### PR TITLE
niv home-manager: update 63d5d28d -> d8dd2a09

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "63d5d28db6068e58c24afa4089f13941500d5fe8",
-        "sha256": "034ai3n9mg518y7k200q14cizymki93929013kbv36ilrdsnx7rl",
+        "rev": "d8dd2a09b0a9c2c12d733f5d1eb3fa39bbe215b8",
+        "sha256": "1x33x5gddg9syfj8nh8nlakaz6s3l6mh4avdkwzaw1w4c3j3kgq9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/63d5d28db6068e58c24afa4089f13941500d5fe8.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d8dd2a09b0a9c2c12d733f5d1eb3fa39bbe215b8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@63d5d28d...d8dd2a09](https://github.com/nix-community/home-manager/compare/63d5d28db6068e58c24afa4089f13941500d5fe8...d8dd2a09b0a9c2c12d733f5d1eb3fa39bbe215b8)

* [`46a750f9`](https://github.com/nix-community/home-manager/commit/46a750f94f39de12a1153da1949e6f4cfa9f0854) home-manager: use 21.05 as next version
* [`d4202875`](https://github.com/nix-community/home-manager/commit/d4202875831a2d1b9dd3002d89b8c794af9e5a43) vscode: add `args` option to keybindings
* [`fc87ac92`](https://github.com/nix-community/home-manager/commit/fc87ac92afe8df28850196d7ab5a1242cbef5dba) neovim: suffix path with extraPackages ([nix-community/home-manager⁠#1756](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1756))
* [`6dfa9ef8`](https://github.com/nix-community/home-manager/commit/6dfa9ef85cf4e23ec42f34c9e988baaf793617a1) mbsync: add subFolders option ([nix-community/home-manager⁠#1760](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1760))
* [`dd6ee694`](https://github.com/nix-community/home-manager/commit/dd6ee694dfe0417214f80764e10866f56d766110) redshift/gammastep: use ini file
* [`bdee1be7`](https://github.com/nix-community/home-manager/commit/bdee1be7b36e49cbfd1407ab4a243e994b27a601) Revert "redshift/gammastep: use ini file"
* [`ef4370be`](https://github.com/nix-community/home-manager/commit/ef4370bedc9e196aa4ca8192c6ceaf34dca589ee) tests: allow testing assertions
* [`d8dd2a09`](https://github.com/nix-community/home-manager/commit/d8dd2a09b0a9c2c12d733f5d1eb3fa39bbe215b8) redshift/gammastep: use ini file
