### PR TITLE
niv spacemacs: update 7276970c -> d9ad951c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "7276970c914af32f7e3d3f45e654eaa2e04bf81e",
-        "sha256": "0ca8x25kgjyn6wsjk60lhmvx0ac2kc3zfqqczkipccs4qq0hz40a",
+        "rev": "d9ad951c86550fbda1e98f5f3e0bc63a4f667305",
+        "sha256": "1ms43j18m16d6c9y18yq5bw3c77qkqlq7ld1ggq6qcn3n2wj2bh7",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/7276970c914af32f7e3d3f45e654eaa2e04bf81e.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/d9ad951c86550fbda1e98f5f3e0bc63a4f667305.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@7276970c...d9ad951c](https://github.com/syl20bnr/spacemacs/compare/7276970c914af32f7e3d3f45e654eaa2e04bf81e...d9ad951c86550fbda1e98f5f3e0bc63a4f667305)

* [`b18c87c8`](https://github.com/syl20bnr/spacemacs/commit/b18c87c832bc51599f2ec7d102c419b41b44f4e6) [javascript] add npm-mode ([syl20bnr/spacemacs⁠#14347](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14347))
* [`3a02c12c`](https://github.com/syl20bnr/spacemacs/commit/3a02c12ca7855fa070bbd27368f2dbde0ee09d5a) Add org-contacts to org layer
* [`23414485`](https://github.com/syl20bnr/spacemacs/commit/234144853110990d8e4e33aba805609ad89961fd) [org] Revise org-contacts support
* [`b82f505f`](https://github.com/syl20bnr/spacemacs/commit/b82f505fbafcfa13a6df8c691f4ccf1e361408c8) [org] Try to fix eval errors caused by org-contacts-support
* [`ddb0d02c`](https://github.com/syl20bnr/spacemacs/commit/ddb0d02c51231236b1bf037d01c4e3c4f8056b18) Also run `treemacs-load-theme` on `dired-mode-hook`
* [`60ad8194`](https://github.com/syl20bnr/spacemacs/commit/60ad8194d779c7dc81dba0d875c3d558ade2cf5f) Refactor spacemacs/rename-current-buffer-file
* [`5b9612f5`](https://github.com/syl20bnr/spacemacs/commit/5b9612f57e7f3e44402ddc19912d95328120ee01) Add Emacs Application Framework (EAF) layer
* [`85e62347`](https://github.com/syl20bnr/spacemacs/commit/85e6234708456f7e3ed99c94c28081942e56ad9d) Restore docs in private folder
* [`10a8803d`](https://github.com/syl20bnr/spacemacs/commit/10a8803d609d8161fa02804bf61e66d021cd64cb) Restore .gitignore
* [`884dc44a`](https://github.com/syl20bnr/spacemacs/commit/884dc44a483dde0aa26b0714ead2c1ff57fbedfc) [eaf] Revise the new layer
* [`ae65f3ce`](https://github.com/syl20bnr/spacemacs/commit/ae65f3cedd7328b7f346f01e4597979671d67f5a) Fix [syl20bnr/spacemacs⁠#14213](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14213) remove dash and ht from core libs
* [`ea58a797`](https://github.com/syl20bnr/spacemacs/commit/ea58a7971510ba92d4d517ce71c404c579beb564) Built-in files auto-update: Sun Feb 7 20:27:36 UTC 2021
* [`dfd55324`](https://github.com/syl20bnr/spacemacs/commit/dfd55324295748c2d733e2a1c585fa4bea4d3f75) Add search-from ivy action to fasd layer
* [`1d84447e`](https://github.com/syl20bnr/spacemacs/commit/1d84447e6814b5dfc9408b5442654efbbf022d2a) [fasd] Revise layer
* [`d264d046`](https://github.com/syl20bnr/spacemacs/commit/d264d04698af3c0ef43af9f8c67f875d3740434a) [org] Manually load org-contacts during agenda config
* [`3c1526fc`](https://github.com/syl20bnr/spacemacs/commit/3c1526fcd4074cc44031526ea3415158ac9447a6) Fix doc org-contacts
* [`68444f54`](https://github.com/syl20bnr/spacemacs/commit/68444f54875f57d651b3e46b0d9ebf97e5c3acf2) documentation formatting: Sun Feb 7 21:35:33 UTC 2021
* [`d9ad951c`](https://github.com/syl20bnr/spacemacs/commit/d9ad951c86550fbda1e98f5f3e0bc63a4f667305) documentation formatting: Sun Feb 7 22:30:25 UTC 2021
