### PR TITLE
niv home-manager: update d8dd2a09 -> 87e2ec34

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d8dd2a09b0a9c2c12d733f5d1eb3fa39bbe215b8",
-        "sha256": "1x33x5gddg9syfj8nh8nlakaz6s3l6mh4avdkwzaw1w4c3j3kgq9",
+        "rev": "87e2ec341bfda373d50ab58529b4bbb0eb9eb9a0",
+        "sha256": "1xjvjibx4qalsv0x4c3wjkig0f8q0ixwm7rlc9q3irr1s2pdp7by",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d8dd2a09b0a9c2c12d733f5d1eb3fa39bbe215b8.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/87e2ec341bfda373d50ab58529b4bbb0eb9eb9a0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d8dd2a09...87e2ec34](https://github.com/nix-community/home-manager/compare/d8dd2a09b0a9c2c12d733f5d1eb3fa39bbe215b8...87e2ec341bfda373d50ab58529b4bbb0eb9eb9a0)

* [`88e05a54`](https://github.com/nix-community/home-manager/commit/88e05a5472d1eb95088d68e8a8e0083e67cd2d87) obs-studio: Allow package to be configurable ([nix-community/home-manager⁠#1787](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1787))
* [`b220d5c4`](https://github.com/nix-community/home-manager/commit/b220d5c4461173ed734ef354cfb976b937155691) prezto: fix [nix-community/home-manager⁠#1773](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1773) ([nix-community/home-manager⁠#1778](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1778))
* [`e6f2687a`](https://github.com/nix-community/home-manager/commit/e6f2687a838dd6079b65fc2cd67760c590b4bc91) firefox: drop enableAdobeFlash option ([nix-community/home-manager⁠#1791](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1791))
* [`87e2ec34`](https://github.com/nix-community/home-manager/commit/87e2ec341bfda373d50ab58529b4bbb0eb9eb9a0) rofi: support top-level clauses in rasi ([nix-community/home-manager⁠#1788](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1788))
