### PR TITLE
niv spacemacs: update d9ad951c -> 9375d6f5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "d9ad951c86550fbda1e98f5f3e0bc63a4f667305",
-        "sha256": "1ms43j18m16d6c9y18yq5bw3c77qkqlq7ld1ggq6qcn3n2wj2bh7",
+        "rev": "9375d6f54d10b9159ac833ee6eaf43f29b233a9f",
+        "sha256": "06slhhwd3z37ibj6grar6zb1xay2i84m4d1bld07n3x5sl2ll8wr",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/d9ad951c86550fbda1e98f5f3e0bc63a4f667305.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/9375d6f54d10b9159ac833ee6eaf43f29b233a9f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@d9ad951c...9375d6f5](https://github.com/syl20bnr/spacemacs/compare/d9ad951c86550fbda1e98f5f3e0bc63a4f667305...9375d6f54d10b9159ac833ee6eaf43f29b233a9f)

* [`c11e8baa`](https://github.com/syl20bnr/spacemacs/commit/c11e8baa9dd1692f61d849b3887fbd690260c5c2) [ivy-rich] enable ivy-rich-project-root-cache-mode
* [`ec8a2785`](https://github.com/syl20bnr/spacemacs/commit/ec8a278505c52ea00501a7a48ecd23aea8b8cd7a) Fix EAF-layer to make it work with the epc (support Windows)
* [`fae767af`](https://github.com/syl20bnr/spacemacs/commit/fae767afd803847fba53ca3acd4c7e4e06793e01) Change elm-analysis -> elm-analyse
* [`e11fb63f`](https://github.com/syl20bnr/spacemacs/commit/e11fb63f2e359d26a53ff54c96585c9a2e970fab) Built-in files auto-update: Tue Feb 9 14:26:29 UTC 2021
* [`9375d6f5`](https://github.com/syl20bnr/spacemacs/commit/9375d6f54d10b9159ac833ee6eaf43f29b233a9f) Add missing space before defun args parens
