### PR TITLE
niv zsh-completions: update 6fe9995f -> c7baec49

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -144,10 +144,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "6fe9995fd953d042bb3704610f421b270ceb2319",
-        "sha256": "1w67da22mvrixbjciyq9hy58bk6nm9q7yg27vbgm5gcszbxh6g5b",
+        "rev": "c7baec49d3e044121f7a37b65a84461ef8dac2de",
+        "sha256": "0a6b6a9pb94kr65dnj6yy1lgj2vp8b61s8zmr8nk52a5pk309sas",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/6fe9995fd953d042bb3704610f421b270ceb2319.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/c7baec49d3e044121f7a37b65a84461ef8dac2de.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@6fe9995f...c7baec49](https://github.com/zsh-users/zsh-completions/compare/6fe9995fd953d042bb3704610f421b270ceb2319...c7baec49d3e044121f7a37b65a84461ef8dac2de)

* [`37a9a485`](https://github.com/zsh-users/zsh-completions/commit/37a9a485eea1fbe7695a78d736b808912a61cc1c) update nano to version 5.4
