### PR TITLE
niv spacemacs: update 9375d6f5 -> af0d0e72

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "9375d6f54d10b9159ac833ee6eaf43f29b233a9f",
-        "sha256": "06slhhwd3z37ibj6grar6zb1xay2i84m4d1bld07n3x5sl2ll8wr",
+        "rev": "af0d0e72763c6b441087dfdb96b65020c3c43650",
+        "sha256": "0kl98m2jnpjqb5yigapdrv2qwjzvcs8f43ixks078zyh8lg3cj39",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/9375d6f54d10b9159ac833ee6eaf43f29b233a9f.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/af0d0e72763c6b441087dfdb96b65020c3c43650.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@9375d6f5...af0d0e72](https://github.com/syl20bnr/spacemacs/compare/9375d6f54d10b9159ac833ee6eaf43f29b233a9f...af0d0e72763c6b441087dfdb96b65020c3c43650)

* [`7238eb03`](https://github.com/syl20bnr/spacemacs/commit/7238eb03e8dae65bac0a3664637c0700eb93642a) Better .elc cleanup
* [`3acf188b`](https://github.com/syl20bnr/spacemacs/commit/3acf188bad47cab05eefaba1943a748c74015af9) [keyboard-layout] Fix colemak-hneio next/prev line in magit
* [`3bb13db8`](https://github.com/syl20bnr/spacemacs/commit/3bb13db85704f08e602a4c6b7d2dff76aec54025) Fix home buffer ace links
* [`91d5bfba`](https://github.com/syl20bnr/spacemacs/commit/91d5bfbadcfaea7b764e44d5102977a4e0f03921) Add eval to comment elisp-mode function
* [`901082b9`](https://github.com/syl20bnr/spacemacs/commit/901082b914773a14c3e6e49a3fe3270596e88683) [fsharp] Declare package eglot-fsharp
* [`a747c1ea`](https://github.com/syl20bnr/spacemacs/commit/a747c1eadd39cd4921007d898f9a666f31896432) Improve better-dafault docs about possible bindings shadowed
* [`b93bdbd4`](https://github.com/syl20bnr/spacemacs/commit/b93bdbd4ad75566dc44f47698212b2ad30f3cd4e) Handle when evil-set-undo-system is missing
* [`ca0fe33c`](https://github.com/syl20bnr/spacemacs/commit/ca0fe33c8d417ab1cfba86a1f76bed1d1ad72c70) [lua] more lsp backends for lua
* [`fc2aa260`](https://github.com/syl20bnr/spacemacs/commit/fc2aa2601c8b23c4f53ebd27dd96eaca06dab9b2) [lua] Revise layer and fix LSP integration
* [`8f934f13`](https://github.com/syl20bnr/spacemacs/commit/8f934f138dd8a9755c026d3e4dde5d5cc22a0044) [lua] Fix unbound var error during layer load
* [`228097a1`](https://github.com/syl20bnr/spacemacs/commit/228097a19ef2e1ab601d9cef19b07c10f9fbff32) Built-in files auto-update: Sat Feb 13 22:24:06 UTC 2021
* [`44add11c`](https://github.com/syl20bnr/spacemacs/commit/44add11c7a80dcb64ed84ef2ff76aaae519e3055) Add auto hide tabs feature to tabs layer
* [`7eaa0722`](https://github.com/syl20bnr/spacemacs/commit/7eaa0722340db4f06813fc11b5c813f68248399b) documentation formatting: Sat Feb 13 22:58:15 UTC 2021
* [`af0d0e72`](https://github.com/syl20bnr/spacemacs/commit/af0d0e72763c6b441087dfdb96b65020c3c43650) [purpose] Fix undefined magit-display-buffer-function during startup
