### PR TITLE
niv home-manager: update 87e2ec34 -> 1ee1d01d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "87e2ec341bfda373d50ab58529b4bbb0eb9eb9a0",
-        "sha256": "1xjvjibx4qalsv0x4c3wjkig0f8q0ixwm7rlc9q3irr1s2pdp7by",
+        "rev": "1ee1d01daa19b3a6d16b5fb680c31a2bc110ce24",
+        "sha256": "0g45bwiq6dyq74am8kfnzx6ipyjiq967icyy71bcr3c4kfch34pm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/87e2ec341bfda373d50ab58529b4bbb0eb9eb9a0.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/1ee1d01daa19b3a6d16b5fb680c31a2bc110ce24.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@87e2ec34...1ee1d01d](https://github.com/nix-community/home-manager/compare/87e2ec341bfda373d50ab58529b4bbb0eb9eb9a0...1ee1d01daa19b3a6d16b5fb680c31a2bc110ce24)

* [`1ee1d01d`](https://github.com/nix-community/home-manager/commit/1ee1d01daa19b3a6d16b5fb680c31a2bc110ce24) bash: don't unconditionally set HISTFILE variable ([nix-community/home-manager⁠#1621](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1621))
