### PR TITLE
niv nixpkgs-fmt: update fb30f69d -> 426699dd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "fb30f69dc42710937331045c3ca43c1c4c9123d0",
-        "sha256": "00x1qygk11x6v7mnybwkg3mvsq7p3mwwaxln7ww649hqq7b6cqd1",
+        "rev": "426699dd825dddc2950a0afab76b4ca33e2b5b8b",
+        "sha256": "08byzcwrhk726r0s41ll9ik0znslq0pxadhwxc11yzv491qnl2pa",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/fb30f69dc42710937331045c3ca43c1c4c9123d0.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/426699dd825dddc2950a0afab76b4ca33e2b5b8b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@fb30f69d...426699dd](https://github.com/nix-community/nixpkgs-fmt/compare/fb30f69dc42710937331045c3ca43c1c4c9123d0...426699dd825dddc2950a0afab76b4ca33e2b5b8b)

* [`da654024`](https://github.com/nix-community/nixpkgs-fmt/commit/da654024ede59fc29c43d3afacb2ed633bfb2247) deploy.sh: build wasm before deploying
* [`eed55a2d`](https://github.com/nix-community/nixpkgs-fmt/commit/eed55a2db908bb34bf3dfe9f0c859ec40a78fb8d) fixup! deploy.sh: build wasm before deploying
* [`5bf2c11c`](https://github.com/nix-community/nixpkgs-fmt/commit/5bf2c11c13f7e9305d39ca9434157971f58c6053) Update rnix + rowan
* [`718e3a5e`](https://github.com/nix-community/nixpkgs-fmt/commit/718e3a5e9abb653d735c54c84f072fcb58dde159) Bump rust version in nix
* [`c4a5030e`](https://github.com/nix-community/nixpkgs-fmt/commit/c4a5030e42a0231be53aa1865c6d5d2efd93b34c) Fix tests
