### PR TITLE
niv home-manager: update 1ee1d01d -> 55030c83

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ee1d01daa19b3a6d16b5fb680c31a2bc110ce24",
-        "sha256": "0g45bwiq6dyq74am8kfnzx6ipyjiq967icyy71bcr3c4kfch34pm",
+        "rev": "55030c83024bf2d10ff86f3874b91794b9d32722",
+        "sha256": "1akp4ka25a462pg2n2lzadcznq4njllij3h6yansg8r6jfi3b5cw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1ee1d01daa19b3a6d16b5fb680c31a2bc110ce24.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/55030c83024bf2d10ff86f3874b91794b9d32722.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1ee1d01d...55030c83](https://github.com/nix-community/home-manager/compare/1ee1d01daa19b3a6d16b5fb680c31a2bc110ce24...55030c83024bf2d10ff86f3874b91794b9d32722)

* [`2e795f3e`](https://github.com/nix-community/home-manager/commit/2e795f3efd6265e3d538d4ee78bba773e1044340) redshift/gammastep: fix deprecated options warning ([nix-community/home-manager⁠#1804](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1804))
* [`55030c83`](https://github.com/nix-community/home-manager/commit/55030c83024bf2d10ff86f3874b91794b9d32722) neovim: deprecate programs.neovim.configure ([nix-community/home-manager⁠#1810](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1810))
