### PR TITLE
niv spacemacs: update af0d0e72 -> e4452f9a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "af0d0e72763c6b441087dfdb96b65020c3c43650",
-        "sha256": "0kl98m2jnpjqb5yigapdrv2qwjzvcs8f43ixks078zyh8lg3cj39",
+        "rev": "e4452f9a855d452aa3969ba8a5268f27ba936b06",
+        "sha256": "0kxz0r8rgmkrnfifg2f0iz158ypm9nw34i7l2wbvjrmhm1miwdvj",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/af0d0e72763c6b441087dfdb96b65020c3c43650.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/e4452f9a855d452aa3969ba8a5268f27ba936b06.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@af0d0e72...e4452f9a](https://github.com/syl20bnr/spacemacs/compare/af0d0e72763c6b441087dfdb96b65020c3c43650...e4452f9a855d452aa3969ba8a5268f27ba936b06)

* [`3f7e69e0`](https://github.com/syl20bnr/spacemacs/commit/3f7e69e0b1b0af776f18091707603cc2687de4de) [git][doc] Update magit bindings link
* [`b6aa0e65`](https://github.com/syl20bnr/spacemacs/commit/b6aa0e651fa4ef9eeca1af776af36f72589d97c4) [git] Remove unused evil-magit function
* [`e4452f9a`](https://github.com/syl20bnr/spacemacs/commit/e4452f9a855d452aa3969ba8a5268f27ba936b06) [ess] Set DISPLAY in R buffer only if not set already
