### PR TITLE
niv home-manager: update 55030c83 -> 82d6ba70

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "55030c83024bf2d10ff86f3874b91794b9d32722",
-        "sha256": "1akp4ka25a462pg2n2lzadcznq4njllij3h6yansg8r6jfi3b5cw",
+        "rev": "82d6ba7003fcf51e9a5b71ab1923e18d5c00fd6f",
+        "sha256": "0pnvp525jlrx0dnwcaxh7b85nzd3lkkl3w3dz6mghm1vk6l692a7",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/55030c83024bf2d10ff86f3874b91794b9d32722.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/82d6ba7003fcf51e9a5b71ab1923e18d5c00fd6f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@55030c83...82d6ba70](https://github.com/nix-community/home-manager/compare/55030c83024bf2d10ff86f3874b91794b9d32722...82d6ba7003fcf51e9a5b71ab1923e18d5c00fd6f)

* [`da923602`](https://github.com/nix-community/home-manager/commit/da923602089501142855bbb3c276fbc36513eefb) polybar: allow config to be more nix-like ([nix-community/home-manager⁠#1430](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1430))
* [`2b7a7307`](https://github.com/nix-community/home-manager/commit/2b7a73071a2810726edf39b8e57d47b5e3844b9e) targets/darwin: copy fonts to ~/Library/Fonts/HomeManager ([nix-community/home-manager⁠#1817](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1817))
* [`eb3a0342`](https://github.com/nix-community/home-manager/commit/eb3a0342a89b705d8de83c024e5bd6e4805016f1) gpg: allow for duplicate keys in config ([nix-community/home-manager⁠#1814](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1814))
* [`82d6ba70`](https://github.com/nix-community/home-manager/commit/82d6ba7003fcf51e9a5b71ab1923e18d5c00fd6f) nixos,darwin: add sharedModules and extraSpecialArgs options ([nix-community/home-manager⁠#1793](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1793))
