### PR TITLE
niv spacemacs: update e4452f9a -> df092402

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "e4452f9a855d452aa3969ba8a5268f27ba936b06",
-        "sha256": "0kxz0r8rgmkrnfifg2f0iz158ypm9nw34i7l2wbvjrmhm1miwdvj",
+        "rev": "df092402291d82da582c986b24051c64f080f9a3",
+        "sha256": "14600bc1knd8k2q3vglr5983sm9rgjmm6400x23zhw1a5hf0ylah",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/e4452f9a855d452aa3969ba8a5268f27ba936b06.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/df092402291d82da582c986b24051c64f080f9a3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@e4452f9a...df092402](https://github.com/syl20bnr/spacemacs/compare/e4452f9a855d452aa3969ba8a5268f27ba936b06...df092402291d82da582c986b24051c64f080f9a3)

* [`7e38f2e6`](https://github.com/syl20bnr/spacemacs/commit/7e38f2e64e1c5cc74966cdbccf6b4adc2f89fc44) Disable evil collection unimpaired bindings
* [`0220101c`](https://github.com/syl20bnr/spacemacs/commit/0220101c7f277b2f83336afe5a81684139bf2431) [markdown] fix warning message for [syl20bnr/spacemacs⁠#14387](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14387)
* [`f4999e82`](https://github.com/syl20bnr/spacemacs/commit/f4999e8242eacef3e8bfe834507de3f03ce4f508) Restore evil-visual-state-map on edebug exit
* [`699be3fe`](https://github.com/syl20bnr/spacemacs/commit/699be3fe283aba0b0ce67cfc9b27babaa7bd0221) [editing] add binding for multi-line
* [`e5620ddf`](https://github.com/syl20bnr/spacemacs/commit/e5620ddfbf8745e87cd9f822dd6fdd7f8e7f17ba) Reverted `ESS: Fixes syl20bnr[syl20bnr/spacemacs⁠#13282](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/13282)`
* [`1d0cd56c`](https://github.com/syl20bnr/spacemacs/commit/1d0cd56c1704d74ffcc3c0c1e5b42d87c01e68f8) Revert to default value of helm-swoop-speed-or-color
* [`599a9bb2`](https://github.com/syl20bnr/spacemacs/commit/599a9bb278b231f5d6b860ddbb1c382498364c95) [helm] avoid duplicates in `helm-M-x' history
* [`df092402`](https://github.com/syl20bnr/spacemacs/commit/df092402291d82da582c986b24051c64f080f9a3) [lsp] Do not include lsp-ui by default
