### PR TITLE
niv nixpkgs: update 4cd977e6 -> a5c2b68d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4cd977e60d611130312b888077f99bc9d2b9f851",
-        "sha256": "1xj94c4yizazzla9b0z57ph82d21h0rl28gswbl6849napb8k9k6",
+        "rev": "a5c2b68d8b144343a0aaa4576e2dcfc85f0aa745",
+        "sha256": "080a89gf1r204n016dj0wp2cvz5p638dw6qqdb9avnyj7qdaxvki",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4cd977e60d611130312b888077f99bc9d2b9f851.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a5c2b68d8b144343a0aaa4576e2dcfc85f0aa745.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4cd977e6...a5c2b68d](https://github.com/nixos/nixpkgs/compare/4cd977e60d611130312b888077f99bc9d2b9f851...a5c2b68d8b144343a0aaa4576e2dcfc85f0aa745)

* [`90cca972`](https://github.com/NixOS/nixpkgs/commit/90cca972971ff6d52d51d34c5ad3edc406b1d1d9) python3Packages.pypcap: fix build on Python 3.9
* [`5e19a1f4`](https://github.com/NixOS/nixpkgs/commit/5e19a1f495a323dd9763d9534c22337461350e59) python39Packages.numpy-stl: 2.13.0 -> 2.15.1
* [`23d566de`](https://github.com/NixOS/nixpkgs/commit/23d566def262f0f18801ecc6ad23429a9d64635a) python3Packages.aqualogic: 2.3 -> 2.5
* [`b76056ae`](https://github.com/NixOS/nixpkgs/commit/b76056aebcdddf7e68170a57314c4c6afd599d49) spacevim: fix [nixos/nixpkgs⁠#110407](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/110407)
* [`1c5c1840`](https://github.com/NixOS/nixpkgs/commit/1c5c18407966dd9b22f459c69a7fb225a4b85306) pythonInterpreters.pypy36_prebuilt: Add missing lib argument
* [`d08ec2f1`](https://github.com/NixOS/nixpkgs/commit/d08ec2f1956b8b630e5f2026ebb4c5ed06e24e81) pythonInterpreters.pypy36_prebuilt: Set pythonOnBuildForHost
* [`f80ef849`](https://github.com/NixOS/nixpkgs/commit/f80ef8496037ac9a77f58ba711af78dfbf45970f) python3Packages.numba: add setuptools dependency
* [`37fbc86e`](https://github.com/NixOS/nixpkgs/commit/37fbc86e353a0b7f322c65a85d1e3a9fcddb99da) python3Packages.numba: clean up dependencies
* [`62a94d2c`](https://github.com/NixOS/nixpkgs/commit/62a94d2c40c8b3dc333fcd2b7a4c0018373379a1) python3Packages.numba: use pythonImportsCheck
* [`df790a96`](https://github.com/NixOS/nixpkgs/commit/df790a9626787df163dfc378cb49d8fb3f552226) netdata: remove unused imports, fix suggestions
* [`f49a63ec`](https://github.com/NixOS/nixpkgs/commit/f49a63ece6ddf9aba40a91b62df29c6069379997) metasploit: 6.0.30 -> 6.0.31
* [`98d32996`](https://github.com/NixOS/nixpkgs/commit/98d3299612eeb865d93dc95f25c6c2828e561729) dolphinEmuMaster: 5.0-13178 -> 5.0-13603
* [`7e2baa21`](https://github.com/NixOS/nixpkgs/commit/7e2baa21b58edddead00db1bb2118d50948bed93) garble: pin to go1.15
* [`c62662c9`](https://github.com/NixOS/nixpkgs/commit/c62662c962ef4e5aa392896c611cf5e1ce683f68) garble: fix aarch64 build
* [`c4550b2b`](https://github.com/NixOS/nixpkgs/commit/c4550b2b8dbb3592ec4d3f2841bd3e473714d786) python3Packages.xknx: 0.16.3 -> 0.17.0
* [`e76c0691`](https://github.com/NixOS/nixpkgs/commit/e76c069163465dcf8ac599f073914345b77e172d) python37Packages.google-cloud-bigquery: 2.8.0 -> 2.9.0
* [`f3918b4b`](https://github.com/NixOS/nixpkgs/commit/f3918b4bc39b95915c2dac471f16b11a2b891e28) nixos/pipewire: only enable media-session if pipewire is enabled
* [`7e771d4d`](https://github.com/NixOS/nixpkgs/commit/7e771d4d3353e99459eec6db3fccf471499ab95e) python3Packages.pyalmond: init at 0.0.3
* [`214163c8`](https://github.com/NixOS/nixpkgs/commit/214163c8b60d147655c5e5fd39a6e78be7b0f4b4) home-assistant: update component-packages
* [`712bd27c`](https://github.com/NixOS/nixpkgs/commit/712bd27c139a8d5b3e25638ac65d7c7513676e4c) python3Packages.pymitv: init at 1.4.3
* [`71a1f1d8`](https://github.com/NixOS/nixpkgs/commit/71a1f1d8d9de20396a5ad8088606a92a063f4a23) home-assistant: update component-packages
* [`39f824d1`](https://github.com/NixOS/nixpkgs/commit/39f824d1d627682df2ba5552124f3d51e98036a3) krapslog: init at 0.1.2
* [`db100ec8`](https://github.com/NixOS/nixpkgs/commit/db100ec834f2d00ad7babff90bfb734e949ec949) python3Packages.python-twitch-client: init at 0.7.1
* [`a73ab65d`](https://github.com/NixOS/nixpkgs/commit/a73ab65d0a68439e8ff6d76acdf579b09e43185d) home-assistant: update component-packages
* [`b0d4b68b`](https://github.com/NixOS/nixpkgs/commit/b0d4b68b44b6730ef3e2bcc3d4575b66e2e38d95) maintainers: add _414owen
* [`ed08ba41`](https://github.com/NixOS/nixpkgs/commit/ed08ba414e2a324ae24b33fc379a6f4c10c412f7) cen64: init at unstable-2020-02-20
* [`4c02c662`](https://github.com/NixOS/nixpkgs/commit/4c02c66275eb6653da51479719affdfd17286ab1) python3Packages.tuyaha: init at 0.0.10
* [`e81a4a4f`](https://github.com/NixOS/nixpkgs/commit/e81a4a4f9fcbf9f6778c0f766f198bbec5a1ac5e) home-assistant: update component-packages
* [`e735b861`](https://github.com/NixOS/nixpkgs/commit/e735b86183b5051eae2492fcf944b45c67d5d9c3) ma1sd: 2.1.1 -> 2.4.0 ([nixos/nixpkgs⁠#113720](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/113720))
* [`e1eb2c16`](https://github.com/NixOS/nixpkgs/commit/e1eb2c16b99d83d69fd9a8d8e73fb1f385189c51) fairymax: enable clang/darwin build ([nixos/nixpkgs⁠#113728](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/113728))
* [`7273115c`](https://github.com/NixOS/nixpkgs/commit/7273115cc1e2a321f59fd034221f31543ec810cf) python3Packages.wiffi: init at 1.0.1
* [`81fdd231`](https://github.com/NixOS/nixpkgs/commit/81fdd23144164be072c4d5bb8d6d666abc146752) home-assistant: update component-packages
* [`e2abd532`](https://github.com/NixOS/nixpkgs/commit/e2abd532869a1a0efb25bf6ee16ec0352e3cce7e) python3Packages.pyvolumio: init 0.1.3
* [`3d7db73a`](https://github.com/NixOS/nixpkgs/commit/3d7db73a37368e445dee8d4358f9b88f2cb0aea1) home-assistant: update component-packages
* [`6ef71992`](https://github.com/NixOS/nixpkgs/commit/6ef71992224875abfce549e3ac711f6916a15947) pythonPackages.launchpadlib: fix tests by using pytestCheckHook, update license
* [`def77586`](https://github.com/NixOS/nixpkgs/commit/def775866f61cdee1dcbbf2b2715c7314e69149c) python3Packages.yalesmartalarmclient: init at 0.3.1
* [`3b100e6d`](https://github.com/NixOS/nixpkgs/commit/3b100e6db13e472223805a539f62899c10735323) home-assistant: update component-packages
* [`1aee3385`](https://github.com/NixOS/nixpkgs/commit/1aee338519982431256d49c25d28a4c16b144a13) xandikos: 0.2.3 -> 0.2.5
* [`d292f827`](https://github.com/NixOS/nixpkgs/commit/d292f8272647b596ab275b9d3d0037e366e88ea8) python3Packages.tahoma-api: init at 0.0.17
* [`c175f68a`](https://github.com/NixOS/nixpkgs/commit/c175f68a175768c6b9fa8f15e421e1e9e2e6deab) home-assistant: update component-packages
* [`6d771e53`](https://github.com/NixOS/nixpkgs/commit/6d771e5330157de230a8431577edb20a8733112b) python37Packages.breathe: 4.26.1 -> 4.27.0
* [`c14eb379`](https://github.com/NixOS/nixpkgs/commit/c14eb379f8af2c447e4a98eba95a822cebf8e93b) python37Packages.google-cloud-container: 2.3.0 -> 2.3.1
* [`92bc0f7b`](https://github.com/NixOS/nixpkgs/commit/92bc0f7bc61baf88e40a6c846f9ce352407f49a2) spacevim: best practices
* [`ce981a9d`](https://github.com/NixOS/nixpkgs/commit/ce981a9ddd6d57522d2645eebf0c3a774ec6412e) python3Packages.ratelimit: init at 2.2.1
* [`7522c4a1`](https://github.com/NixOS/nixpkgs/commit/7522c4a1a1d772463cb6a3c8fa75d921b5a08289) python3Packages.pyflume: init at 0.6.2
* [`412690ab`](https://github.com/NixOS/nixpkgs/commit/412690ab43fac88704b50838b6d97f21ca4965fb) home-assistant: update component-packages
* [`4b1655f4`](https://github.com/NixOS/nixpkgs/commit/4b1655f47e3b0d9bc6b2fdc7e240e40a4b9d5072) sumneko-lua-language-server: 1.11.2 -> 1.16.0
* [`5363f171`](https://github.com/NixOS/nixpkgs/commit/5363f1714b632a87fdbb7f160ee2a90e77f2db36) mesa: fix missing timespec_get on aarch64-darwin
* [`312bc73b`](https://github.com/NixOS/nixpkgs/commit/312bc73b22db3a889b7fafa5c8c0bdd52c269840) geant4: 10.7.0 -> 10.7.1
* [`02028810`](https://github.com/NixOS/nixpkgs/commit/020288102a3c635ba2b456ba428de036c85da302) gomuks: 0.2.2 -> 0.2.3
* [`25cf4b00`](https://github.com/NixOS/nixpkgs/commit/25cf4b000971538581457d2a9ca5b3e99819f5d1) pipewire: 0.3.21 -> 0.3.22
* [`06e8cbf8`](https://github.com/NixOS/nixpkgs/commit/06e8cbf83f895d73c7d3084e18d361771ab4c886) cargo-deny: 0.8.5 -> 0.8.7
* [`2210eb35`](https://github.com/NixOS/nixpkgs/commit/2210eb352bca997658dd3d7221ec6f3f7b8db457) gtk*: remove myself from meta.maintainers
* [`f3074fb6`](https://github.com/NixOS/nixpkgs/commit/f3074fb6378c6da21f35d33befc58ac1101a3a4b) cointop: 1.6.0 -> 1.6.2
* [`ceeccb2c`](https://github.com/NixOS/nixpkgs/commit/ceeccb2ce2cc57162d892e34b22019e8c0c61003) dnscontrol: 3.6.0 -> 3.7.0
* [`2b5a8787`](https://github.com/NixOS/nixpkgs/commit/2b5a8787b386b8c0145f1473d778e5c231c7be8e) emplace: 1.0.0 -> 1.1.0
* [`6e31c709`](https://github.com/NixOS/nixpkgs/commit/6e31c70928175249b37935f583edc2eb356044b1) reddsaver: 0.3.0 -> 0.3.1
* [`2f199f0c`](https://github.com/NixOS/nixpkgs/commit/2f199f0c96bdeaad7b6cc21855ac765b06c1d7f0) termbox: 1.1.2 -> 1.1.4
* [`0f9a5212`](https://github.com/NixOS/nixpkgs/commit/0f9a5212f5b92c315f9289d5fdf7752c90423d26) gdu: 4.6.2 -> 4.6.3
* [`2f8425c8`](https://github.com/NixOS/nixpkgs/commit/2f8425c8677a08be1a5903e20134f8b9e886db72) git-cola: 3.8 -> 3.9
* [`da26156b`](https://github.com/NixOS/nixpkgs/commit/da26156bdf868181fbbce89b8a9e15266dd6598f) gleam: 0.13.2 -> 0.14.0
* [`f8048224`](https://github.com/NixOS/nixpkgs/commit/f80482241b584c688ee5610ada7b116fa2184b02) hugo: 0.80.0 -> 0.81.0
* [`dd54d778`](https://github.com/NixOS/nixpkgs/commit/dd54d77845d405ce4982b14fb51e8d14cd0d70ef) libgcrypt: disable asm on aarch64-darwin
* [`1173ecf6`](https://github.com/NixOS/nixpkgs/commit/1173ecf67374d140d19be1485818d85daba9979e) ipfs: 0.7.0 -> 0.8.0
* [`497ff776`](https://github.com/NixOS/nixpkgs/commit/497ff776a6a388c7c842ade7b94cd14270b6d7b7) mmtc: 0.2.12 -> 0.2.13
* [`7e711976`](https://github.com/NixOS/nixpkgs/commit/7e711976bfbe93807dcd60dae81dca0fdc176a15) tre-command: 0.3.3 -> 0.3.4
* [`882d0f06`](https://github.com/NixOS/nixpkgs/commit/882d0f06592ee1bcf80ff0edea78ee6af765d89f) cargo-limit: 0.0.5 -> 0.0.6
* [`f2d739f6`](https://github.com/NixOS/nixpkgs/commit/f2d739f6f3a821a1b308f7d8d210d2dc10ac0f4f) shellhub-agent: 0.5.1 -> 0.5.2
* [`39383a84`](https://github.com/NixOS/nixpkgs/commit/39383a8494c5a1f754899667e7e6058c0c9ff105) nixos/rngd: Remove module entirely, leave an explaination
* [`c8dcbfc0`](https://github.com/NixOS/nixpkgs/commit/c8dcbfc0478796ae7fd592eafa72ba90bba1656d) nixos/swap: Remove dependency on rngd (module removed)
* [`d7c15d0e`](https://github.com/NixOS/nixpkgs/commit/d7c15d0eece59a3cf779ac9fa871c7f88f27cf9d) nixos/hyperv-guest: rngd was removed, no need to disable it
* [`16b6c4b2`](https://github.com/NixOS/nixpkgs/commit/16b6c4b2d7b0bb5e64492daf4e9adc185bbcf48d) nixos/manual/virtualbox-guest: Remove mentions of rngd
* [`e85117b0`](https://github.com/NixOS/nixpkgs/commit/e85117b024d7576ca2f0d2f6e73ad8b9ee3116f2) minio: 2021-02-14T04-01-33Z -> 2021-02-19T04-38-02Z
* [`ba701c3c`](https://github.com/NixOS/nixpkgs/commit/ba701c3cc5b6a451ff995a0f018e7368754c6aa2) minio-client: 2021-02-14T04-28-06Z -> 2021-02-19T05-34-40Z
* [`8395f80f`](https://github.com/NixOS/nixpkgs/commit/8395f80fc4ad8eba6c5d803fabf2c9cb3f85119a) mockgen: 1.4.4 -> 1.5.0
* [`f428bb03`](https://github.com/NixOS/nixpkgs/commit/f428bb03f2dd4e74fd748fa33d436d8738280586) nix-output-monitor: 0.1.0.2 -> 1.0.0.0
* [`c24258b0`](https://github.com/NixOS/nixpkgs/commit/c24258b0006dfa31f20a61de30097bf0e3702a3f) osu-lazer: 2021.212.0 -> 2021.220.0
* [`83de5aa3`](https://github.com/NixOS/nixpkgs/commit/83de5aa31a9bf73d85f57fdb223c6f4b0562955c) kustomize-sops: init at 2.4.0
* [`ae012d70`](https://github.com/NixOS/nixpkgs/commit/ae012d706d798d3f647e0c6eb852080c74d3ef73) nix-output-monitor: 1.0.0.0 -> 1.0.1.0
* [`c28a79a6`](https://github.com/NixOS/nixpkgs/commit/c28a79a649447fc1101485ee931f76302f8ec9b6) sd-local: 1.0.21 -> 1.0.23
* [`b62c3665`](https://github.com/NixOS/nixpkgs/commit/b62c3665766f99208fa1d3e4c61b41fefa11a6c2) enigma: stdenv.lib -> lib
* [`514987f4`](https://github.com/NixOS/nixpkgs/commit/514987f46f8d05668083cdfaa92a2d84e842ac46) shipyard: 0.1.18 -> 0.2.1
* [`27d72106`](https://github.com/NixOS/nixpkgs/commit/27d72106cc73d20bb5c6261f528c46d72ff49d9f) enigma: xdg_utils -> xdg-utils
* [`0ea8d5c0`](https://github.com/NixOS/nixpkgs/commit/0ea8d5c004fb742907d1b656b3c3c45451d517f7) terrascan: 1.3.2 -> 1.3.3
* [`92d319d5`](https://github.com/NixOS/nixpkgs/commit/92d319d5d549b8f621042caa3ba6624d5210d2fd) doc/stdenv/platform-notes: convert to markdown
* [`a6912010`](https://github.com/NixOS/nixpkgs/commit/a6912010d272e2c1309ba39f5104025a70fbbc02) yq-go: 4.5.0 -> 4.6.0
* [`2e73ee0c`](https://github.com/NixOS/nixpkgs/commit/2e73ee0c4fdf1ac5a3e88d10327abafba7df4279) bdf2psf: 1.200 -> 1.201
* [`95a9e43a`](https://github.com/NixOS/nixpkgs/commit/95a9e43a3d2c3fa2ddc978996325490d102fc6c4) swappy: 1.3.0 -> 1.3.1
* [`193bf09e`](https://github.com/NixOS/nixpkgs/commit/193bf09ef740e6573d1f4e5ca37d4a3c83ea3b66) traefik: update test to use virtualisation.oci-containers
* [`cdb97ba5`](https://github.com/NixOS/nixpkgs/commit/cdb97ba52397fc059f47758d4dc8311fe044f44f) ocamlPackages.ocamlmod: disable tests if ounit is not available
* [`8625e975`](https://github.com/NixOS/nixpkgs/commit/8625e975bd503ba53c2afa6ed24df6b497f629d2) powerline-go: update meta
* [`55130258`](https://github.com/NixOS/nixpkgs/commit/5513025855ea6fd5dc8d48572eca5c03d4723682) swappy: add wrapGappsHook
* [`85b236e5`](https://github.com/NixOS/nixpkgs/commit/85b236e54a446ea136ca539c7bb3b36591e4cc08) bdf2psf: fix license, run pre/post hooks
* [`f32bd9e7`](https://github.com/NixOS/nixpkgs/commit/f32bd9e70e60391b4554ccb397cec8cbd0c3671e) plex: 1.21.3.4046-3c1c83ba4 -> 1.21.4.4054-bab510e86
* [`c7917e58`](https://github.com/NixOS/nixpkgs/commit/c7917e58bdfa8149ae45188e290ffc5cfa0f3f13) consul-template: 0.25.1 -> 0.25.2
* [`27a35cba`](https://github.com/NixOS/nixpkgs/commit/27a35cba249fa599893c3cce6991616adc382a93) taskwarrior-tui: 0.9.10 -> 0.9.15
* [`3c888202`](https://github.com/NixOS/nixpkgs/commit/3c88820235fdd63f10d87eb120bd16fb2c7f7a96) rl-2105: rngd
* [`e3d3643f`](https://github.com/NixOS/nixpkgs/commit/e3d3643f1b26db3bb9892d7b6e433889ce8c5e60) nixos/release-notes/rl-2105.xml: fix typo
* [`3be4cfb7`](https://github.com/NixOS/nixpkgs/commit/3be4cfb7de112339429c34de50510cdee3cbb722) treewide: minor cleanup of packages maintained by siraben
* [`4f1e0c7e`](https://github.com/NixOS/nixpkgs/commit/4f1e0c7ec06b7c4a0bcacbce38127212ca94ae6b) mysqltuner: add password list to output
* [`230d58d3`](https://github.com/NixOS/nixpkgs/commit/230d58d30f804d23a9f11bc38ddc14f455cc1b17) smartmontools: update drivedb to r5171
* [`b3444319`](https://github.com/NixOS/nixpkgs/commit/b3444319462423b2e4753e904842c2b1f29ca0ec) maintainers: rename charvp to chvp
* [`b5171593`](https://github.com/NixOS/nixpkgs/commit/b5171593b3edefdfaa8ca0b8d7fad71d1006538e) gomuks: fix license information
* [`5d461c5e`](https://github.com/NixOS/nixpkgs/commit/5d461c5ea3e865d390e3fd44741cff812d025ab2) beancount: add myself to maintainers
* [`86248156`](https://github.com/NixOS/nixpkgs/commit/862481560c3c9e5c4a7101cfb5b4dfb21c6c01a6) nixos/dnscrypt-proxy2: reallow @⁠sync syscalls
* [`9c42db00`](https://github.com/NixOS/nixpkgs/commit/9c42db00dc17e12fed525829ec58bf5690e4eae6) maintainers: add sbruder
* [`2f96b9a7`](https://github.com/NixOS/nixpkgs/commit/2f96b9a7b4c083edf79374ceb9d61b5816648276) ocamlPackages.qcheck*: 0.16 -> 0.17
* [`1ee875ce`](https://github.com/NixOS/nixpkgs/commit/1ee875ce6840c5e7ea22e2229dcb741bbf4fa00d) nix-output-monitor: 1.0.1.0 -> 1.0.1.1
* [`3ba6124d`](https://github.com/NixOS/nixpkgs/commit/3ba6124df7b595501560659da841e22b516547a6) darkhttpd: 1.12 -> 1.13
* [`c373e6dd`](https://github.com/NixOS/nixpkgs/commit/c373e6ddb267a10319c90d1de8540379c7c365af) vapoursynth: add withPlugins interface
* [`b6f3c4d0`](https://github.com/NixOS/nixpkgs/commit/b6f3c4d0753f0f42a0b4c44c5b1f5d7ddeb06d5e) vapoursynth-editor: allow adding plugins without rebuilding
* [`c2eadf21`](https://github.com/NixOS/nixpkgs/commit/c2eadf214830b025efc33120351c1f0c167deabe) jwt-cli: 3.3.0 -> 4.0.0
* [`a4d916ac`](https://github.com/NixOS/nixpkgs/commit/a4d916ace393939e42d66cb2b187d33202bec49b) nushell: 0.27.0 -> 0.27.1
* [`e81a4170`](https://github.com/NixOS/nixpkgs/commit/e81a4170bd0b7d07c56dec3744eceaca5aa0f31f) python3.pkgs.jabberbot: remove
* [`66db640e`](https://github.com/NixOS/nixpkgs/commit/66db640ed8b44773f6120f636af8d79ab41ee0e7) llvm-mode: Init (verison inherited from llvm)
* [`9d21f1df`](https://github.com/NixOS/nixpkgs/commit/9d21f1dfabe0d9be680c1b923c42155f482df30d) nixos/plymouth: Add label plugin and a font to the initrd
* [`095f8cec`](https://github.com/NixOS/nixpkgs/commit/095f8cec5a64553b72873c38d1d5211172f95c29) nixpkgs-fmt: 1.0.0 -> 1.1.0
* [`f77c15ca`](https://github.com/NixOS/nixpkgs/commit/f77c15ca31563e87b4eaf7372476f87c3dec72b2) beancount: set gpl2 -> gpl2Only
* [`ef811f2d`](https://github.com/NixOS/nixpkgs/commit/ef811f2d08fc6c3bbd0e392ed1c359a4567e08f8) boto3: Format
* [`31688e5c`](https://github.com/NixOS/nixpkgs/commit/31688e5ce9a8a812a95c4ebbc0c2a09cd77ca21e) taskwarrior-tui: 0.9.15 -> 0.10.4
* [`3669ac9a`](https://github.com/NixOS/nixpkgs/commit/3669ac9a89a2784d5b7646fac25db09ecea2080d) ipset: 7.10 -> 7.11
* [`a106eec5`](https://github.com/NixOS/nixpkgs/commit/a106eec57f8468e048b1ac48b907c7b4d4e6ec7d) nodePackages: update
* [`19596401`](https://github.com/NixOS/nixpkgs/commit/19596401c464e70d28fc6055828615e86f3d0e19) coc-pyright: init at 1.1.113
* [`bb9d2a8c`](https://github.com/NixOS/nixpkgs/commit/bb9d2a8cad5500996b5a3218175f743691055972) nodePackages.coc-clangd: init at 0.9.0
* [`ced9972b`](https://github.com/NixOS/nixpkgs/commit/ced9972b3e8b641c09885a8fe5d8d99ae0a6226c) nodePackages.coc-cmake: init at 0.1.1
* [`067ed4b6`](https://github.com/NixOS/nixpkgs/commit/067ed4b6102bb84e5fea8bb1df6d2145df88837b) nodePackages.coc-texlab: init at 2.3.0
* [`b5930103`](https://github.com/NixOS/nixpkgs/commit/b59301034873f132dd6971099446f2ceb3b060ae) pythonPackages.protobuf3-to-dict: Init at 0.1.5
* [`c10da052`](https://github.com/NixOS/nixpkgs/commit/c10da052fc764b534d6d0b9ef28abe2f84b239b3) pythonPackages.smdebug-rulesconfig: Init at 1.0.1
* [`6d408889`](https://github.com/NixOS/nixpkgs/commit/6d408889f092213fcb1a460cf2b31be1c134a3e4) pythonPackages.sagemaker: Init at 2.24.5
* [`340eff8b`](https://github.com/NixOS/nixpkgs/commit/340eff8b0dc08a8d40d6ab7060b75f4cc75e689d) Update pkgs/development/python-modules/protobuf3-to-dict/default.nix
* [`6b81e73c`](https://github.com/NixOS/nixpkgs/commit/6b81e73c4b5dc2a13bd82700149fcdcef79d2976) Update pkgs/development/python-modules/sagemaker/default.nix
* [`90120d70`](https://github.com/NixOS/nixpkgs/commit/90120d702ccb3b76bf56dbf375894c810b8feb9f) youtube-dl: 2021.02.10 -> 2021.02.22
* [`6bfaed9b`](https://github.com/NixOS/nixpkgs/commit/6bfaed9b2c691a93933ce3bc4a9f3c41c45becf2) installer: fixup sd-card folder move from [nixos/nixpkgs⁠#110827](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/110827)
* [`ff27c8e0`](https://github.com/NixOS/nixpkgs/commit/ff27c8e0ad7ce3cbeb3cf983c5f46c13f1d741a4) last: 1178 -> 1179
* [`41c93481`](https://github.com/NixOS/nixpkgs/commit/41c93481cc0b5215ee43a0e8612a14cefa031ca2) telegraf: 1.17.2 -> 1.17.3
* [`6900641c`](https://github.com/NixOS/nixpkgs/commit/6900641ceca54cbf230ea0b7d7442346efc80cd8) Revert "pipewire: 0.3.21 -> 0.3.22"
* [`3ae8bebc`](https://github.com/NixOS/nixpkgs/commit/3ae8bebc9e86b46bcbffc726891aa92a67b0aa29) Update pkgs/tools/nix/nixpkgs-fmt/default.nix
* [`50847e0b`](https://github.com/NixOS/nixpkgs/commit/50847e0b174a879ca09dbf31bb8cc4729b82327c) wargus: init at 2.4.3
* [`4dfe07da`](https://github.com/NixOS/nixpkgs/commit/4dfe07dadac24ae00881b6ab808d8f3627340511) libsigcxx: specify that lgpl21 is lgpl21Plus
