### PR TITLE
niv home-manager: update 82d6ba70 -> 21952f1c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "82d6ba7003fcf51e9a5b71ab1923e18d5c00fd6f",
-        "sha256": "0pnvp525jlrx0dnwcaxh7b85nzd3lkkl3w3dz6mghm1vk6l692a7",
+        "rev": "21952f1cab9dcfee92d46448391412701fea4314",
+        "sha256": "0kshxd4fk8aklqbzjdvj6gck84dvjfd7psr1d6vmc10x3ilv342f",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/82d6ba7003fcf51e9a5b71ab1923e18d5c00fd6f.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/21952f1cab9dcfee92d46448391412701fea4314.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@82d6ba70...21952f1c](https://github.com/nix-community/home-manager/compare/82d6ba7003fcf51e9a5b71ab1923e18d5c00fd6f...21952f1cab9dcfee92d46448391412701fea4314)

* [`aa9affb5`](https://github.com/nix-community/home-manager/commit/aa9affb53f2fd6232b1d06e761331b34c22b62d2) nix-darwin: remove trailing whitespace
* [`029767ca`](https://github.com/nix-community/home-manager/commit/029767ca63fe33d9dd002093fc065ea8fde565ab) docs: use working link for "DocBook rocks!"
* [`21952f1c`](https://github.com/nix-community/home-manager/commit/21952f1cab9dcfee92d46448391412701fea4314) fzf: remove non-working historyWidgetCommand option ([nix-community/home-manager⁠#1818](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1818))
