### PR TITLE
niv nixpkgs-fmt: update 426699dd -> 3ef5622f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "426699dd825dddc2950a0afab76b4ca33e2b5b8b",
-        "sha256": "08byzcwrhk726r0s41ll9ik0znslq0pxadhwxc11yzv491qnl2pa",
+        "rev": "3ef5622f1cd70f4bb6af553893306a77a12d367b",
+        "sha256": "1fb2mm1y2qb3imc48g2ad3rdbjlj326cggrc4hvdc0fb41vxinpp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/426699dd825dddc2950a0afab76b4ca33e2b5b8b.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/3ef5622f1cd70f4bb6af553893306a77a12d367b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@426699dd...3ef5622f](https://github.com/nix-community/nixpkgs-fmt/compare/426699dd825dddc2950a0afab76b4ca33e2b5b8b...3ef5622f1cd70f4bb6af553893306a77a12d367b)

* [`3ef5622f`](https://github.com/nix-community/nixpkgs-fmt/commit/3ef5622f1cd70f4bb6af553893306a77a12d367b) Release v1.1.0
