### PR TITLE
niv spacemacs: update df092402 -> cecc4ef8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "df092402291d82da582c986b24051c64f080f9a3",
-        "sha256": "14600bc1knd8k2q3vglr5983sm9rgjmm6400x23zhw1a5hf0ylah",
+        "rev": "cecc4ef887f02a8c5f497110da8aafe4e87852e8",
+        "sha256": "0lxsys6g30cqjvwn065c3413q3618c4ris37sz2qnli9q2yxbs8m",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/df092402291d82da582c986b24051c64f080f9a3.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/cecc4ef887f02a8c5f497110da8aafe4e87852e8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@df092402...cecc4ef8](https://github.com/syl20bnr/spacemacs/compare/df092402291d82da582c986b24051c64f080f9a3...cecc4ef887f02a8c5f497110da8aafe4e87852e8)

* [`b6aed092`](https://github.com/syl20bnr/spacemacs/commit/b6aed092cf1de8992522d69c8158a20df880a84e) [evil-cleverparens] `evil-cp-change' should move the point
* [`9ecce823`](https://github.com/syl20bnr/spacemacs/commit/9ecce8231a16fcca5a2e6c3d3f43bec306bfc93e) fix variable name in lsp doc
* [`aa1051e1`](https://github.com/syl20bnr/spacemacs/commit/aa1051e1c85ccd5ab783491d684a0336d7ddddf7) Move lsp-ui back to be enabled by default
* [`cecc4ef8`](https://github.com/syl20bnr/spacemacs/commit/cecc4ef887f02a8c5f497110da8aafe4e87852e8) [markdown] Make sure not to throw when git-commit-mode is not bound
