### PR TITLE
niv home-manager: update 21952f1c -> e7b1491f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21952f1cab9dcfee92d46448391412701fea4314",
-        "sha256": "0kshxd4fk8aklqbzjdvj6gck84dvjfd7psr1d6vmc10x3ilv342f",
+        "rev": "e7b1491fb8dfb1d2bdb90432312e88d03c8d803d",
+        "sha256": "1y1acyavv7n5pjr3yhpj1glcxs8fk72x38m67c1ppqnr0xq63jjh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/21952f1cab9dcfee92d46448391412701fea4314.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e7b1491fb8dfb1d2bdb90432312e88d03c8d803d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@21952f1c...e7b1491f](https://github.com/nix-community/home-manager/compare/21952f1cab9dcfee92d46448391412701fea4314...e7b1491fb8dfb1d2bdb90432312e88d03c8d803d)

* [`7582090e`](https://github.com/nix-community/home-manager/commit/7582090eb0f64144995d4fb9d5e52343e2c3f64b) kakoune: Fix reference to group in hook config ([nix-community/home-manager⁠#1820](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1820))
* [`0933fb87`](https://github.com/nix-community/home-manager/commit/0933fb876560702db3b74f05e86f77ae615acfe9) Starship: improve zsh terminal check ([nix-community/home-manager⁠#1821](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1821))
* [`e7b1491f`](https://github.com/nix-community/home-manager/commit/e7b1491fb8dfb1d2bdb90432312e88d03c8d803d) pulseeffects: add option to specify package ([nix-community/home-manager⁠#1825](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1825))
