### PR TITLE
niv spacemacs: update cecc4ef8 -> cf82ac2e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "cecc4ef887f02a8c5f497110da8aafe4e87852e8",
-        "sha256": "0lxsys6g30cqjvwn065c3413q3618c4ris37sz2qnli9q2yxbs8m",
+        "rev": "cf82ac2ed38c3bb7a46899802f35eb23d4818746",
+        "sha256": "1xh9psf6xxfgvv6s6sx86rml3f72y6il3f87wgpyd19lxg15rs32",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/cecc4ef887f02a8c5f497110da8aafe4e87852e8.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/cf82ac2ed38c3bb7a46899802f35eb23d4818746.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@cecc4ef8...cf82ac2e](https://github.com/syl20bnr/spacemacs/compare/cecc4ef887f02a8c5f497110da8aafe4e87852e8...cf82ac2ed38c3bb7a46899802f35eb23d4818746)

* [`23af0c54`](https://github.com/syl20bnr/spacemacs/commit/23af0c540a17860b40799ade8f588ba4c078ceb9) [markdown] remove duplicating code which already exists in "markdown-mode"
* [`1f1ed2a9`](https://github.com/syl20bnr/spacemacs/commit/1f1ed2a976fbe57b47dc149f2804fcc0f1afc444) Add typescript-format keybinding in typescript-tsx-mode
* [`98176b13`](https://github.com/syl20bnr/spacemacs/commit/98176b130c4bfed2bd88a29fc60eceb920ec51dd) [typescript] Cleanup bindings to avoid duplicate code
* [`722fa45e`](https://github.com/syl20bnr/spacemacs/commit/722fa45ea13412d1edc68a454ec3ab5dfd272669) [core-env] [syl20bnr/spacemacs⁠#14348](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14348) ignore env "DISPLAY" for .spacemacs.env
* [`6111b279`](https://github.com/syl20bnr/spacemacs/commit/6111b2794506f366f997711911c92bb7505e9874) [languagetool] Fix missing autoload on `langtool-correct-buffer`
* [`e3434e86`](https://github.com/syl20bnr/spacemacs/commit/e3434e8635e6c13efd2702d5be2532e3c1faf18f) source-control: Change SPC gfd to magit-file-dispatch
* [`319626d1`](https://github.com/syl20bnr/spacemacs/commit/319626d1ad8d43b51e1652d10039d3b0b0e6efe7) Bind s to the dired-quick-sort hydra
* [`b3992c61`](https://github.com/syl20bnr/spacemacs/commit/b3992c61ef196fd884916239c7e8dfe81fb00288) [lsp] Bind lsp specific toggles from `SPC m T` to `SPC m T l`
* [`37008c07`](https://github.com/syl20bnr/spacemacs/commit/37008c07c4e9b5d28ffc7bf3b4d986d5b45728a6) [typescript] Restore format bindings for `typescript-tsx-mode`
* [`67287fae`](https://github.com/syl20bnr/spacemacs/commit/67287faeedba47554a24cb804df3991509d3ad86) [doc][spacemacs-editing] Add urls to supported packages
* [`cf82ac2e`](https://github.com/syl20bnr/spacemacs/commit/cf82ac2ed38c3bb7a46899802f35eb23d4818746) [org] Make org layer activate org-roam-global-minor-mode
