### PR TITLE
niv zsh-completions: update c7baec49 -> 322d5f24

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -144,10 +144,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "c7baec49d3e044121f7a37b65a84461ef8dac2de",
-        "sha256": "0a6b6a9pb94kr65dnj6yy1lgj2vp8b61s8zmr8nk52a5pk309sas",
+        "rev": "322d5f24f750646102a00aa09941b0206e744a04",
+        "sha256": "0hl9h43sbq6iwjh1vg97qb3qyyla9swsdlcp4ywjmhvyagxziqhv",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/c7baec49d3e044121f7a37b65a84461ef8dac2de.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/322d5f24f750646102a00aa09941b0206e744a04.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@c7baec49...322d5f24](https://github.com/zsh-users/zsh-completions/compare/c7baec49d3e044121f7a37b65a84461ef8dac2de...322d5f24f750646102a00aa09941b0206e744a04)

* [`d16c8aea`](https://github.com/zsh-users/zsh-completions/commit/d16c8aea5424e77d67143218beb6c04d3c4c7bd9) Add new flags which are introduced at Go 1.16
