### PR TITLE
niv spacemacs: update cf82ac2e -> 721765dc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "cf82ac2ed38c3bb7a46899802f35eb23d4818746",
-        "sha256": "1xh9psf6xxfgvv6s6sx86rml3f72y6il3f87wgpyd19lxg15rs32",
+        "rev": "721765dccb94fc89a51c4d3e4730e311fe70821d",
+        "sha256": "0zz5wva5163h5wrfiw6wwlmgmdk08fbb6pqzc7pq0jg0hm7jsnw9",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/cf82ac2ed38c3bb7a46899802f35eb23d4818746.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/721765dccb94fc89a51c4d3e4730e311fe70821d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@cf82ac2e...721765dc](https://github.com/syl20bnr/spacemacs/compare/cf82ac2ed38c3bb7a46899802f35eb23d4818746...721765dccb94fc89a51c4d3e4730e311fe70821d)

* [`54e3cc57`](https://github.com/syl20bnr/spacemacs/commit/54e3cc572f0cbbeb9f1523a5a10442e1c97d13b3) [ivy] extend highlight for selection in emacs 27
* [`2efe665b`](https://github.com/syl20bnr/spacemacs/commit/2efe665bce71ad6b45b97d912aabc7f51e126f2c) [java] New keybindings for lsp-java
* [`e8976832`](https://github.com/syl20bnr/spacemacs/commit/e8976832f80f46a329582964a798e84550490855) Restore SPC gfd for magit-diff, set SPC gfm for magit-file-dispatch
* [`fe0af4f7`](https://github.com/syl20bnr/spacemacs/commit/fe0af4f74bebb6f0f09ebdcd5876efe53b0cffb6) mu4e: require mu4e for mu4e-org-link-support
* [`c6ffe996`](https://github.com/syl20bnr/spacemacs/commit/c6ffe996b62f93f59df42a11f28dbf4b03f6bf49) [editing] Added string-edit package to editing layer
* [`c3b40ce1`](https://github.com/syl20bnr/spacemacs/commit/c3b40ce13b48ff6a5a4c5119bb5f5205d06dcc80) [editing] Add missing documentation and make string-edit lazy load
* [`8181bc9c`](https://github.com/syl20bnr/spacemacs/commit/8181bc9cf23982dc8abbe97d02eeafbcf0d2fd21) [editing] Make string-edit confirm/abort align to conventions
* [`69f21eaa`](https://github.com/syl20bnr/spacemacs/commit/69f21eaaa04bfdf40db58a571bbe65f41b626dda) [org][org-brain] Add SPC menu (vim or hybrid style)
* [`40c42e6a`](https://github.com/syl20bnr/spacemacs/commit/40c42e6af5a1aa99621d6c1d2fe8090232e809b4) Support system-type 'cygwin
* [`721765dc`](https://github.com/syl20bnr/spacemacs/commit/721765dccb94fc89a51c4d3e4730e311fe70821d) Update eaf-layer
