### PR TITLE
niv home-manager: update e7b1491f -> f45c7000

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e7b1491fb8dfb1d2bdb90432312e88d03c8d803d",
-        "sha256": "1y1acyavv7n5pjr3yhpj1glcxs8fk72x38m67c1ppqnr0xq63jjh",
+        "rev": "f45c7000d544f17e5499e2ae6b505b5f705c5d61",
+        "sha256": "0ipskyf8whx8hnmdfgq57d5jqfdnw6nrw8l57s870ng832p83pls",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e7b1491fb8dfb1d2bdb90432312e88d03c8d803d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f45c7000d544f17e5499e2ae6b505b5f705c5d61.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e7b1491f...f45c7000](https://github.com/nix-community/home-manager/compare/e7b1491fb8dfb1d2bdb90432312e88d03c8d803d...f45c7000d544f17e5499e2ae6b505b5f705c5d61)

* [`fb9bf032`](https://github.com/nix-community/home-manager/commit/fb9bf032fb2e68456f8653a15909038f87700a93) alot: set primary email first ([nix-community/home-manager⁠#1826](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1826))
* [`3327cbe1`](https://github.com/nix-community/home-manager/commit/3327cbe1f9d355fbeb5ee204908ab1013c18f685) gh: fix protocol setting ([nix-community/home-manager⁠#1831](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1831))
* [`aa479b01`](https://github.com/nix-community/home-manager/commit/aa479b0124393e0a828f97cfa75a418b4c6c20f8) git: rely on msmtp for smtp if msmtp is enabled ([nix-community/home-manager⁠#1829](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1829))
* [`f45c7000`](https://github.com/nix-community/home-manager/commit/f45c7000d544f17e5499e2ae6b505b5f705c5d61) git: correct value of envelopeSender for msmtp ([nix-community/home-manager⁠#1838](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1838))
