### PR TITLE
niv nixpkgs: update a5c2b68d -> c069272a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a5c2b68d8b144343a0aaa4576e2dcfc85f0aa745",
-        "sha256": "080a89gf1r204n016dj0wp2cvz5p638dw6qqdb9avnyj7qdaxvki",
+        "rev": "c069272a4b648cf676a7810108bd2b9a2dbb9d57",
+        "sha256": "00dma7b3nmpjhg9a6djrmwjnbp9lm95vbk6v1wyaylkbjjj7xv6z",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a5c2b68d8b144343a0aaa4576e2dcfc85f0aa745.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c069272a4b648cf676a7810108bd2b9a2dbb9d57.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a5c2b68d...c069272a](https://github.com/nixos/nixpkgs/compare/a5c2b68d8b144343a0aaa4576e2dcfc85f0aa745...c069272a4b648cf676a7810108bd2b9a2dbb9d57)

* [`c5218b52`](https://github.com/NixOS/nixpkgs/commit/c5218b524512fb0cca100a8dcc6b9343ff1761da) rebol/default.nix: remove unused file
* [`64187ae1`](https://github.com/NixOS/nixpkgs/commit/64187ae13f2639f9dbbf68324c55e769e9caa038) haskell-text-icu: remedy a fatal absence of truth in the build
* [`6e156276`](https://github.com/NixOS/nixpkgs/commit/6e1562761b29813b28b66d601875ddbc1d2024a1) configuration-common: cosmetic
* [`c1157b0b`](https://github.com/NixOS/nixpkgs/commit/c1157b0ba5c694755e2e087af7686b6268d548bc) hackage-packages.nix: automatic Haskell package set update
* [`5e401dcd`](https://github.com/NixOS/nixpkgs/commit/5e401dcd2bdb769438ef4902faeea231beeaf67a) alacritty: fix build
* [`48052ca0`](https://github.com/NixOS/nixpkgs/commit/48052ca0dd1939beed30dc8c65f541cfa05704fa) nixos/ksm: remove udev-settle dependency
* [`f7aa0b45`](https://github.com/NixOS/nixpkgs/commit/f7aa0b4575809a31abd5af15abc783a10a16598d) haskell-prettyprinter: disable the freakin' test suite
* [`c801ffd4`](https://github.com/NixOS/nixpkgs/commit/c801ffd4a34da0c0aac452e1cb0dcd925b53e4bb) emacs: Use --with-native-compilation instead of --with-nativecomp
* [`7ee7b5de`](https://github.com/NixOS/nixpkgs/commit/7ee7b5deec517a238a1618202aadbfbc2aadb55b) mdsh: 0.5.0 -> 0.6.0
* [`bdfd5011`](https://github.com/NixOS/nixpkgs/commit/bdfd50116a9022e1188c1e6a4fe5767bbf65f6e6) Revert "mdsh: 0.5.0 -> 0.6.0"
* [`a533bbef`](https://github.com/NixOS/nixpkgs/commit/a533bbef706ce76649aa8b2703007752562b5cd3) haskell-brittany: disable the freakin' test suite
* [`2c9d7ee3`](https://github.com/NixOS/nixpkgs/commit/2c9d7ee3694e0fcc5db9199ce3ff24eeb8cacf4a) R: 4.0.3 -> 4.0.4
* [`1585a04b`](https://github.com/NixOS/nixpkgs/commit/1585a04bcb8deeb63a50c89e89dd0628a4d16077) webwormhole: init at git-2021-01-16 ([nixos/nixpkgs⁠#114269](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114269))
* [`17024be1`](https://github.com/NixOS/nixpkgs/commit/17024be1d1ff96bd58e1b4846b060d417b275744) nixos/tests: add musescore
* [`64f189c8`](https://github.com/NixOS/nixpkgs/commit/64f189c8a04963387ceaa6998214b74815359157) klayout: 0.26.8 -> 0.26.9
* [`4d89f508`](https://github.com/NixOS/nixpkgs/commit/4d89f508815ad015f3bfd972d30cc6e12e33c914) jmol: 14.31.18 -> 14.31.24
* [`c796cc4e`](https://github.com/NixOS/nixpkgs/commit/c796cc4eacedb91feec77e30a2ed79f64a23e08b) opkg: 0.4.3 -> 0.4.4
* [`124e53af`](https://github.com/NixOS/nixpkgs/commit/124e53af2cf0b2f6a25d0c59738e51adf78e9a67) php73Packages.composer2: 2.0.9 -> 2.0.11
* [`a1a6da54`](https://github.com/NixOS/nixpkgs/commit/a1a6da54185ce1c07e7ea0cf6706ef66b3bc29c6) conan: fix build on darwin
* [`36b8a95d`](https://github.com/NixOS/nixpkgs/commit/36b8a95d482a7b13435a506a2300069c0f586475) zsh-fzf-tab: unstable-2021-01-24 -> unstable-2021-02-14
* [`5bbfc16b`](https://github.com/NixOS/nixpkgs/commit/5bbfc16b281d7c6b87ef8b1b56e8b15f8ced47bd) python37Packages.adafruit-platformdetect: 3.1.1 -> 3.2.0
* [`73068649`](https://github.com/NixOS/nixpkgs/commit/7306864977a722ac683f15ae54f99d338c19437b) z3: Add output for Java bindings (*.jar and *.so)
* [`953b7ae2`](https://github.com/NixOS/nixpkgs/commit/953b7ae25575d4ede60d6956b9a1b164fcfdfeb6) python3Packages.slicedimage: switch to pytestCheckHook
* [`4a87fe66`](https://github.com/NixOS/nixpkgs/commit/4a87fe669f318f15d705abb08d67e3574b52718f) python37Packages.censys: 1.1.0 -> 1.1.1
* [`9d9ecfff`](https://github.com/NixOS/nixpkgs/commit/9d9ecfffb9b9fc2a10c0c558dcd869f331094337) python3Packages.pyswitchbot: init at 0.9.1
* [`bbd80791`](https://github.com/NixOS/nixpkgs/commit/bbd80791e00bae7a8c9ce58231957ea7c8abe58e) home-assistant: update component-packages
* [`0dc64d5d`](https://github.com/NixOS/nixpkgs/commit/0dc64d5d7197dead209aff7bffc4ddbf6da2cb31) python: fix full builds by referring to the correct interpreter
* [`4a2934f0`](https://github.com/NixOS/nixpkgs/commit/4a2934f0e687f72a4f234e91ccfe058fee841dbe) python37Packages.libversion: 1.2.1 -> 1.2.2
* [`5ea6b908`](https://github.com/NixOS/nixpkgs/commit/5ea6b9082242eb804def178aaf8408ac4ff6bcb3) adoptopenjdk-bin, zulu, graalvm11-ce: do not wrap jspawnhelper
* [`6ca5b800`](https://github.com/NixOS/nixpkgs/commit/6ca5b8005f26ce1b4c6c6a8d668c410b051bd6c8) nim: 1.4.2 -> 1.4.4
* [`5ad7fb28`](https://github.com/NixOS/nixpkgs/commit/5ad7fb28f6a8732eee23fa33d47fa25444ff3837) treewide/php-packages: Drop pkgs from arguments to packages
* [`e41a34bb`](https://github.com/NixOS/nixpkgs/commit/e41a34bb0260cfd37f2b06fe908b0c17eb66a2da) php.packages.composer: 1.10.15 -> 2.0.11
* [`89dacdd7`](https://github.com/NixOS/nixpkgs/commit/89dacdd7a518c14d3e824d4c6cc0cc93002367f6) php.packages.composer1: init at 1.10.15
* [`ad990d49`](https://github.com/NixOS/nixpkgs/commit/ad990d49aa64dc383ff0a67814b0e7a762e082fd) php.packages.composer2: deinit package since main package is updated
* [`01f1773e`](https://github.com/NixOS/nixpkgs/commit/01f1773e8e12742bd2d51d7fc163b373f0dd3ba3) trezord: don't trigger systemd-udev-settle
* [`6a0b4ab7`](https://github.com/NixOS/nixpkgs/commit/6a0b4ab7bede541a31371d7607a6df968c9a05a0) wpa_supplicant: add CVE-ID for P2P provision discovery proccessing vuln.
* [`0dfc7073`](https://github.com/NixOS/nixpkgs/commit/0dfc707376a9668f4f00d6bb7a85fd22b4b23acf) pulumi-bin: 2.19.2 -> 2.21.2
* [`ab2b32cd`](https://github.com/NixOS/nixpkgs/commit/ab2b32cd1aeb571b860aaf0466d275efdf6f7b19) pulumi-bin: refactor output creation
* [`1c264973`](https://github.com/NixOS/nixpkgs/commit/1c2649737180bb5fd196fb8d3e814977aa3c77d8) ocamlPackages.result: use Dune 2
* [`3f110f98`](https://github.com/NixOS/nixpkgs/commit/3f110f988bc567af01d56838b52d567b49603b91) mdsh: 0.5.0 -> 0.6.0 ([nixos/nixpkgs⁠#114513](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114513))
* [`93c2d520`](https://github.com/NixOS/nixpkgs/commit/93c2d520a59ee78ebde702c2457bc4a24f871bc2) herbstluftwm: 0.9.1 -> 0.9.2
* [`418ba054`](https://github.com/NixOS/nixpkgs/commit/418ba054f547d5c06f972e5501aa7a9f5c84c91a) python3Packages.python-gammu: init at 3.1
* [`1f04109d`](https://github.com/NixOS/nixpkgs/commit/1f04109d2dac99a8e100b441b67fbe7287d06981) home-assistant: update component-packages
* [`8e016023`](https://github.com/NixOS/nixpkgs/commit/8e016023f865b6feb3cff4fac39c5e2315033074) nixos/acpid: clean up the module
* [`adccc8b6`](https://github.com/NixOS/nixpkgs/commit/adccc8b65b9a3f41a5ef2ef59ecf29a85c556fee) chromiumBeta: 89.0.4389.58 -> 89.0.4389.69
* [`5240639a`](https://github.com/NixOS/nixpkgs/commit/5240639ab6bc56824302d32e52753725aa9a963d) chromiumDev: 90.0.4421.5 -> 90.0.4427.5
* [`01fc3a8e`](https://github.com/NixOS/nixpkgs/commit/01fc3a8ea41176c7915cfa9f0f3606793c3811ab) vsh: 0.10.0 -> 0.11.0
* [`37460768`](https://github.com/NixOS/nixpkgs/commit/37460768e229cbaf388b1523b17379b7d397a2f8) nixos/x11: Source .xprofile earlier in xsession-wrapper
* [`ee713d36`](https://github.com/NixOS/nixpkgs/commit/ee713d36bccc0a98b7c46fc4830ab48bc808c421) nixos/x11: Respect XCOMPOSECACHE/XDG_DATA_HOME if set
* [`580cf02c`](https://github.com/NixOS/nixpkgs/commit/580cf02c1967c6338058862fbe3724b57a559a39) nixos/x11: Be more defensive when removing XCOMPOSECACHE
* [`10652db9`](https://github.com/NixOS/nixpkgs/commit/10652db9068d282b7df4a8f49170a1b3f5af642b) ocamlPackages.mmap: use Dune 2
* [`13e7de73`](https://github.com/NixOS/nixpkgs/commit/13e7de73c2b93bccb1d00b44267156f92cc74b33) python37Packages.databricks-cli: 0.14.1 -> 0.14.2
* [`6c351c3d`](https://github.com/NixOS/nixpkgs/commit/6c351c3dbc1713f2d066be427b2127f76e3d4934) python37Packages.azure-mgmt-web: 1.0.0 -> 2.0.0
* [`e31c4b42`](https://github.com/NixOS/nixpkgs/commit/e31c4b42f0c657647857f5e46273d008cd2dfb0e) pythonPackages.json5: init at 0.9.5
* [`d60f67d4`](https://github.com/NixOS/nixpkgs/commit/d60f67d486ff6bcc5a0276d8cd348018ad1ec8b0) python3Packages.graphtage: init at 0.2.5
* [`afc28939`](https://github.com/NixOS/nixpkgs/commit/afc28939f735ca941338c2ea3fefc055be24a70d) python3Packages.graphql-relay: 3.0.0 -> 3.1.0
* [`2af1630a`](https://github.com/NixOS/nixpkgs/commit/2af1630a9b4fb0f394e0c368dec87d13aabf286b) flite: improve cross-compilation support
* [`5cc881d0`](https://github.com/NixOS/nixpkgs/commit/5cc881d0d827b4c3f273b5021a7c0b94c112368f) imagemagick: make 7.0 default
* [`10ba3c20`](https://github.com/NixOS/nixpkgs/commit/10ba3c20a7bdd6021511338b1f01465cfc9b3bee) treewide: replace imagemagick7 with imagemagick
* [`d3cd7c36`](https://github.com/NixOS/nixpkgs/commit/d3cd7c36c3971dfa948faa2e0073614d8fb53150) libdmtx: 0.7.4 -> 0.7.5
* [`9872e4a8`](https://github.com/NixOS/nixpkgs/commit/9872e4a892a5a5554db35536b29001be293277c5) dmtx-utils: 0.7.4 -> 0.7.6
* [`b8f50e15`](https://github.com/NixOS/nixpkgs/commit/b8f50e15fe1001b0f93d68e83c54db2d47a61d17) cataract: use imagemagick6
* [`4b7d9b28`](https://github.com/NixOS/nixpkgs/commit/4b7d9b285528580f704a6e828e0420c84e9494ce) perlPackages.PerlMagick: 6.89-1 -> 7.0.10
* [`e13c16ec`](https://github.com/NixOS/nixpkgs/commit/e13c16ec75f78e98abb2b2163da584122e0d808e) pfstools: use imagemagick6
* [`147359ee`](https://github.com/NixOS/nixpkgs/commit/147359ee16670fd2d22236ac93044c57f181a027) perlPackages.Gtk3ImageView: disable tests
* [`60267c0e`](https://github.com/NixOS/nixpkgs/commit/60267c0ef64a21ac8be1ccb17f15f9774a17e404) rss-glx: use imagemagick6
* [`d2b35b0f`](https://github.com/NixOS/nixpkgs/commit/d2b35b0fc6da5771ebf8c9b5ff6081c18e58de86) php-packages/mongodb: fix evaluation on darwin
* [`253f59e0`](https://github.com/NixOS/nixpkgs/commit/253f59e039977fbe01216908c1456a0223b09358) geos: 3.9.0 -> 3.9.1
* [`cf33ca63`](https://github.com/NixOS/nixpkgs/commit/cf33ca630d2d7409cf4c9d48f47a169d9e22a3b0) python3Packages.shapely: fix build
* [`7ac6fbfe`](https://github.com/NixOS/nixpkgs/commit/7ac6fbfe5ae083da2020b8438ffc4e71c044ae15) imagemagick6: 6.9.11-60 -> 6.9.12-1 ([nixos/nixpkgs⁠#113998](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/113998))
* [`76e68963`](https://github.com/NixOS/nixpkgs/commit/76e6896331db36434fde8fee7a5a880f4a8d4e94) python3Packages.inflect: 5.0.2 -> 5.2.0 ([nixos/nixpkgs⁠#114557](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114557))
* [`83d3f74b`](https://github.com/NixOS/nixpkgs/commit/83d3f74babf8131e0b6254cf8648e100c4d7c3d2) python3Packages.watchdog: fix flaky test on macOS
* [`20dba8a9`](https://github.com/NixOS/nixpkgs/commit/20dba8a982b1d8df57a8efb3a78248e7de5c390b) rst2html5: fix download now that it is a wheel
* [`322e538d`](https://github.com/NixOS/nixpkgs/commit/322e538df89e26cb5753aaf5f40fcc25821f3f4c) libglvnd: Improve the license information ([nixos/nixpkgs⁠#114466](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114466))
* [`d1b0794a`](https://github.com/NixOS/nixpkgs/commit/d1b0794a291d6105aedad9ca2edd3b66537fe31a) python3Packages.pytankerkoenig: init at 0.0.7
* [`a81f23de`](https://github.com/NixOS/nixpkgs/commit/a81f23deb9a56e609d76940bd7a78b3401b3faca) home-assistant: update component-packages
* [`caa23be2`](https://github.com/NixOS/nixpkgs/commit/caa23be256645d6d3c95c0342239ae2f507f7778) ocamlPackages.camomile: use Dune 2
* [`18df480d`](https://github.com/NixOS/nixpkgs/commit/18df480d9bfd445e8cf1c4dbaebfa166a89a638c) gollum: Transfer maintainership to erictapen
* [`5df05c90`](https://github.com/NixOS/nixpkgs/commit/5df05c902cde398e056eb6271d5fe13e418db4c6) gollum: 5.1.2 -> 5.2.1
* [`b4ce0e16`](https://github.com/NixOS/nixpkgs/commit/b4ce0e16d540daeb91271a38f1b1246ccb2aa86c) python3Packages.asteval: 0.9.22 -> 0.9.23
* [`7823d6a4`](https://github.com/NixOS/nixpkgs/commit/7823d6a449dfd5cf598edf88330c3ae34d072d25) resholve: 0.4.2 -> 0.5.0
* [`98fba665`](https://github.com/NixOS/nixpkgs/commit/98fba66557a086e3742434148f191b31ceae7b07) libe-book: fix build after c0b3169d4a48bcd8da29157e1cc2c412873e51d6
* [`0a5e56aa`](https://github.com/NixOS/nixpkgs/commit/0a5e56aa039ba600f5a70c474fe4477105a1f777) libaio: fixup static compilation
* [`42a2ad0f`](https://github.com/NixOS/nixpkgs/commit/42a2ad0f44516b8c74b229442a5196c0ca4ea376) terraform-providers.vultr: 1.5.0 -> 2.1.3 ([nixos/nixpkgs⁠#114593](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114593))
* [`b281937f`](https://github.com/NixOS/nixpkgs/commit/b281937f2111972038bc8db5f9e6e3066ef58936) python3Packages.msldap: 0.3.25 -> 0.3.26
* [`bb310ed0`](https://github.com/NixOS/nixpkgs/commit/bb310ed07c93e3b73d89b6e313e38603ffd4c5fe) python3Packages.winacl: 0.1.0 -> 0.1.1
* [`f6982a7b`](https://github.com/NixOS/nixpkgs/commit/f6982a7bc845433de358a7c53d85618a4fc04bd6) vscode-extensions.gruntfuggly.todo-tree: 0.0.196 -> 0.0.198
* [`df4f3e90`](https://github.com/NixOS/nixpkgs/commit/df4f3e90e221ad3599fbd6fc62729af47902f260) newsflash: 1.2.2 -> 1.3.0
* [`b2629734`](https://github.com/NixOS/nixpkgs/commit/b26297344aa5aa80513a4f4689b159cab5ab73c2) python37Packages.alerta: 8.3.0 -> 8.4.0
* [`60031a1e`](https://github.com/NixOS/nixpkgs/commit/60031a1e954b272ad47872326696e1a1c1422051) gitkraken: 7.5.0 -> 7.5.1
* [`c834c60f`](https://github.com/NixOS/nixpkgs/commit/c834c60ff94482afe047bad5bf6ad571fdc51bfd) turbovnc: init at 2.2.5
* [`33230da5`](https://github.com/NixOS/nixpkgs/commit/33230da5dacd8be7c074dbc01d1e6e5bcf952c7f) cvise: init at 2.1.0 ([nixos/nixpkgs⁠#114197](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114197))
* [`77a087fa`](https://github.com/NixOS/nixpkgs/commit/77a087facc6cbaaa4676e849ccbeb6dbba9d4460) miniserve: 0.10.4 -> 0.11.0
* [`b51b5a10`](https://github.com/NixOS/nixpkgs/commit/b51b5a104b719721cabf0c7018da82e02014cbbd) go_1_14, go_1_15: support colon at start of TZ
* [`11970049`](https://github.com/NixOS/nixpkgs/commit/11970049d16b2628baf8b556e3c8941c561ace1a) python37Packages.databricks-connect: 7.3.8 -> 7.3.9
* [`196b4ead`](https://github.com/NixOS/nixpkgs/commit/196b4ead1d3b064cf3bc94c06ffb790662e1c608) python37Packages.identify: 1.5.14 -> 1.6.1
* [`627f2b5b`](https://github.com/NixOS/nixpkgs/commit/627f2b5b9c80e726a0bb5c536e7995a94ddaa223) adoptopenjdk-icedtea-web: 1.8.5 -> 1.8.6
* [`f361a1a9`](https://github.com/NixOS/nixpkgs/commit/f361a1a90250f8c020032bf0fda1f9ddcfc500d8) argocd: 1.8.5 -> 1.8.6
* [`df3d5609`](https://github.com/NixOS/nixpkgs/commit/df3d5609998e47a98138259816a0db774d901189) nixos/nix-gc: add persistent and randomizeDelaySec options
* [`e8909c77`](https://github.com/NixOS/nixpkgs/commit/e8909c77f6d1386de4fcbc7018991fdb2ef83155) julia-mono 0.022 → 0.034
* [`d0328678`](https://github.com/NixOS/nixpkgs/commit/d0328678e91b1bb89d6a184c63bc3f21f81dbfe2) ocamlPackages.ocaml-migrate-parsetree-2-1: use Dune 2
* [`3e3d0799`](https://github.com/NixOS/nixpkgs/commit/3e3d07997d40b28758ba6058eba56747cddc9555) wpsoffice: update description, homepage
* [`6ff9aeeb`](https://github.com/NixOS/nixpkgs/commit/6ff9aeebc1e3c75a204b1d4438fb620d5674a693) disfetch: 1.14 -> 1.18
* [`02284b87`](https://github.com/NixOS/nixpkgs/commit/02284b8786c4c88a738c3e0704df1a174eb8fed8) doctl: 1.56.0 -> 1.57.0
* [`40e983a5`](https://github.com/NixOS/nixpkgs/commit/40e983a5fff68e77f59e9ce82fb8a85d122930cf) doppler: 3.22.1 -> 3.23.0
* [`af9d9598`](https://github.com/NixOS/nixpkgs/commit/af9d959867c0c885c20ab3e19fc6ea720c312a0e) emplace: 1.1.0 -> 1.2.0
* [`5a0fc991`](https://github.com/NixOS/nixpkgs/commit/5a0fc991018d7015e102ecffd3e142da631e7fdc) python3Packages.pygraphviz: 1.6 -> 1.7 ([nixos/nixpkgs⁠#113040](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/113040))
* [`ccd6cd97`](https://github.com/NixOS/nixpkgs/commit/ccd6cd97c950b4038239a1620e2129280a4507f2) python3Packages.pyvex: 9.0.5739 -> 9.0.5903
* [`ddb855a6`](https://github.com/NixOS/nixpkgs/commit/ddb855a66134dd0a589c4ccfc88fa745f71a7db5) python3Packages.ailment: 9.0.5739 -> 9.0.5903
* [`d6876bc8`](https://github.com/NixOS/nixpkgs/commit/d6876bc87971f3ad66ee1e3e7f773f6f6a2fcb3e) google-cloud-sdk: fix searching for cloud_sql_proxy on the PATH ([nixos/nixpkgs⁠#114488](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114488))
* [`1ff47316`](https://github.com/NixOS/nixpkgs/commit/1ff4731640bc06dc5c0aa4740872a1751ef420b5) gammy: 0.9.63 -> 0.9.64
* [`96a0d6a8`](https://github.com/NixOS/nixpkgs/commit/96a0d6a810eb889f94c07f01314dc02df7287359) qtwebkit: Fix build with icu 68
* [`d3f4aa97`](https://github.com/NixOS/nixpkgs/commit/d3f4aa97a3b0e09ae3e5f2000cd3e397505b67ae) gdu: 4.6.4 -> 4.6.5
* [`a44728d4`](https://github.com/NixOS/nixpkgs/commit/a44728d4590a3f28779a8fa74d9a4f51174a5887) maintainers: add dottedmag
* [`4d678689`](https://github.com/NixOS/nixpkgs/commit/4d6786891290d20fcc824366e01af25621584294) libxcrypt: init at 4.4.18
* [`e5adde15`](https://github.com/NixOS/nixpkgs/commit/e5adde1556e8559527e35d99f939f55f24bbdad3) gerbera: 1.6.4 -> 1.7.0
* [`2d8ef6c5`](https://github.com/NixOS/nixpkgs/commit/2d8ef6c514a99e1445f2e00361c56eeb6fc9392f) ghq: 1.1.6 -> 1.1.7
* [`00529f5b`](https://github.com/NixOS/nixpkgs/commit/00529f5bba7e4adbcd475e320b3b05332a8ed3ad) lf: 20 -> 21
* [`4adcb006`](https://github.com/NixOS/nixpkgs/commit/4adcb0064200facdee1109a0296905717d046b3e) nixos/lxd: cleanup and misc fixes
* [`b9dc818b`](https://github.com/NixOS/nixpkgs/commit/b9dc818bd55ef4314da10d09297d7f51f0d3e6a9) nixos/lxd: make start timeout configurable
* [`657f09e9`](https://github.com/NixOS/nixpkgs/commit/657f09e96fce5f41f76cd29f9baf21956b69b178) gleam: 0.14.0 -> 0.14.1
* [`f35fbf2f`](https://github.com/NixOS/nixpkgs/commit/f35fbf2f793f18f7791aa3f635fad4603d8a0674) jackett: 0.17.311 -> 0.17.598
* [`5a3063ff`](https://github.com/NixOS/nixpkgs/commit/5a3063ff588239946cff2e0a44568c2b33226152) jbang: 0.66.0 -> 0.66.1
* [`44bc58a1`](https://github.com/NixOS/nixpkgs/commit/44bc58a19bd040db0edb34dabc7c5844c5da405d) pythonPackages.fonttools: add myself as maintainer
* [`602464de`](https://github.com/NixOS/nixpkgs/commit/602464de779024ac2ec92c7e979dc71cd8f723f0) agate: 2.5.2 -> 2.5.3
* [`0f0a416d`](https://github.com/NixOS/nixpkgs/commit/0f0a416d7f39261ab42386d458eb47181852853f) pythonPackages.afdko: fix tests for fonttools >= 4.21.0
* [`4dd9084c`](https://github.com/NixOS/nixpkgs/commit/4dd9084ca973847e3dfece0c259599df43456b94) lean: 3.26.0 -> 3.27.0
* [`69ea22c3`](https://github.com/NixOS/nixpkgs/commit/69ea22c3da1a488ec5c7683ba55d146fdb5174d7) gnome-tour: fix build
* [`d44c8cd6`](https://github.com/NixOS/nixpkgs/commit/d44c8cd61f52b8bec1ec6d6994a407d37217f3f6) python3Packages.botocore: 1.20.12 -> 1.20.17
* [`60c62dd5`](https://github.com/NixOS/nixpkgs/commit/60c62dd5f0e43cde3e886214dda23de2e252c0d2) python3Packages.boto3: 1.17.12 -> 1.17.17
* [`058902d1`](https://github.com/NixOS/nixpkgs/commit/058902d18b5b2c156741bbeaa4f96acc0470ed8b) awscli: 1.19.12 -> 1.19.17
* [`7471ce31`](https://github.com/NixOS/nixpkgs/commit/7471ce31fe27ab18a75a72829f1af5a8917ede2f) python3Packages.editdistance: init at 0.5.3
* [`51d4dc26`](https://github.com/NixOS/nixpkgs/commit/51d4dc261922c4cfa1f4c40932264df5650b8d1e) python3Packages.identify: enable tests
* [`fd947e1d`](https://github.com/NixOS/nixpkgs/commit/fd947e1d302ce02240c2f2e0e6d495116c74f672) tecla: support cross-compilation
* [`e8cfc61e`](https://github.com/NixOS/nixpkgs/commit/e8cfc61efa36574823d4194ef0c429708975fb73) pandas: fix scipy coo_matrix test
* [`50885e91`](https://github.com/NixOS/nixpkgs/commit/50885e913f8949a9551d4b3b595b1608ae123383) i3status-rust: 0.14.3 -> 0.14.7
* [`cad6cb7b`](https://github.com/NixOS/nixpkgs/commit/cad6cb7b5aaa184d55719a66a88786008d3468e8) maintainers: update email for metadark
* [`6e3988ae`](https://github.com/NixOS/nixpkgs/commit/6e3988ae064d1999befa786fa21737ee7b6328b9) newsflash: use cargoSetupHook instead of buildRustPackage
* [`21dd525b`](https://github.com/NixOS/nixpkgs/commit/21dd525bc97fb57877df9daffd17669b5fb9513d) python3Packages.python-dotenv: switch to pytestCheckHook
* [`e888cbbd`](https://github.com/NixOS/nixpkgs/commit/e888cbbd8829ce6e9f5631e3ca57a107891abaeb) python3Packages.pydantic: 1.7.3 -> 1.8
* [`540c6fb9`](https://github.com/NixOS/nixpkgs/commit/540c6fb9c4bb8307bade7c119f48f3c0670e0988) git-credential-gopass: remove redundant platforms
* [`71b14fb5`](https://github.com/NixOS/nixpkgs/commit/71b14fb52eb987050ce181b55173ae5352f8aa22) gopass: remove redundant platforms
* [`34bee7e8`](https://github.com/NixOS/nixpkgs/commit/34bee7e8d8fa3cf3ed0e0fb67319121158e52afb) gopass-jsonapi: remove redundant platforms
* [`1b9a5b3f`](https://github.com/NixOS/nixpkgs/commit/1b9a5b3f9f30c0c7c32dff75460f2742b05a9794) bashup-events: satisfy nixpkgs-hammering warnings
* [`9378695d`](https://github.com/NixOS/nixpkgs/commit/9378695d38e46e8d46c1c793127c9601b8c51774) radicle-upstream: 0.1.6 -> 0.1.11
* [`c6898f85`](https://github.com/NixOS/nixpkgs/commit/c6898f85418fd2a895a17fb9a9ba64d2ca1e9803) bazel-kazel: 0.2.0 -> 0.2.1 ([nixos/nixpkgs⁠#114624](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114624))
* [`0aeba64f`](https://github.com/NixOS/nixpkgs/commit/0aeba64fb26e4defa0842a942757144659c6e29f) squashfs: use -no-hardlinks for reproducible squashfs images ([nixos/nixpkgs⁠#114454](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114454))
* [`ac2854a9`](https://github.com/NixOS/nixpkgs/commit/ac2854a9ba886cf687b72ce35916c9d79daac8f3) kubectx: 0.9.2 -> 0.9.3 ([nixos/nixpkgs⁠#114668](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/114668))
* [`4ee567fe`](https://github.com/NixOS/nixpkgs/commit/4ee567fec53d4e23ab2c6197f1979d725f293bc8) python3Packages.elmax: init at 0.1.0
* [`ed95819c`](https://github.com/NixOS/nixpkgs/commit/ed95819c9d42ae9bf4d9fabba60595c251bb54da) flameshot: 0.8.5 -> 0.9.0
* [`ad0e172c`](https://github.com/NixOS/nixpkgs/commit/ad0e172cdc7fd6168e02f91df8223d783bb89139) ircrobots: 0.3.6 -> 0.3.7
* [`c6f991fa`](https://github.com/NixOS/nixpkgs/commit/c6f991fa7e347fe3ae26e0743cee38c9591d78b8) libnbd: init at 1.7.2
* [`1fc22c25`](https://github.com/NixOS/nixpkgs/commit/1fc22c2593ac181f7a9713456556c6abdb91af4d) varnishPackages.dynamic: fix build, use autoreconfHook269
* [`fe99a449`](https://github.com/NixOS/nixpkgs/commit/fe99a449f3668dfbaff6ca49e99d9036ddca56dd) jackett: replace deprecated license name
* [`6ed55034`](https://github.com/NixOS/nixpkgs/commit/6ed55034eec21f50c33afe7b4c4f5c13d49eba72) doc/python: reword sorting gaurentee to be stronger
