### PR TITLE
niv home-manager: update f45c7000 -> e72e241d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f45c7000d544f17e5499e2ae6b505b5f705c5d61",
-        "sha256": "0ipskyf8whx8hnmdfgq57d5jqfdnw6nrw8l57s870ng832p83pls",
+        "rev": "e72e241d7a602559285205820cfd708282a4197a",
+        "sha256": "05za9s44qlwpbyvm5z600wy85nk328vxg4cj68vc6nzsz91n5m9d",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f45c7000d544f17e5499e2ae6b505b5f705c5d61.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e72e241d7a602559285205820cfd708282a4197a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f45c7000...e72e241d](https://github.com/nix-community/home-manager/compare/f45c7000d544f17e5499e2ae6b505b5f705c5d61...e72e241d7a602559285205820cfd708282a4197a)

* [`9068ff29`](https://github.com/nix-community/home-manager/commit/9068ff292c8627bb09cf44e508ace2a352fe4e2f) offlineimap: precompile get_settings.py
* [`e72e241d`](https://github.com/nix-community/home-manager/commit/e72e241d7a602559285205820cfd708282a4197a) getmail: fix configuration mailboxes generation ([nix-community/home-manager⁠#1719](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1719))
