### PR TITLE
niv home-manager: update e72e241d -> 57a7e5e2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e72e241d7a602559285205820cfd708282a4197a",
-        "sha256": "05za9s44qlwpbyvm5z600wy85nk328vxg4cj68vc6nzsz91n5m9d",
+        "rev": "57a7e5e2c53de58215fdac1910470bef36dd30cd",
+        "sha256": "0cgjai6l1j73h6mwgndcyha7wy6am2vwd25274lffzqzrs0n1ac9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e72e241d7a602559285205820cfd708282a4197a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/57a7e5e2c53de58215fdac1910470bef36dd30cd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e72e241d...57a7e5e2](https://github.com/nix-community/home-manager/compare/e72e241d7a602559285205820cfd708282a4197a...57a7e5e2c53de58215fdac1910470bef36dd30cd)

* [`ddee030d`](https://github.com/nix-community/home-manager/commit/ddee030dc7b298f24e86e0e6ec9cc9117e7069be) gpg: export GPG_TTY for fish ([nix-community/home-manager⁠#1846](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1846))
* [`69e26933`](https://github.com/nix-community/home-manager/commit/69e2693342f78be18126665c2c3adc28f8d66a4b) home-manager: respect NO_COLOR environment variable
* [`39e49918`](https://github.com/nix-community/home-manager/commit/39e49918562f28cfce01fbaf3ddeecbb52ea5416) git: Add configured SSL certificate for SMTP ([nix-community/home-manager⁠#1833](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1833))
* [`0e2dc4be`](https://github.com/nix-community/home-manager/commit/0e2dc4be3006ef8354d782d34301f9a09946cfc2) qt: add qt.style option ([nix-community/home-manager⁠#1839](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1839))
* [`73559e0d`](https://github.com/nix-community/home-manager/commit/73559e0dbcd1701e7db0d4e118893784a44df234) qutebrowser: add option to load autoconfig ([nix-community/home-manager⁠#1842](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1842))
* [`abc9d96d`](https://github.com/nix-community/home-manager/commit/abc9d96d19e2c8a7f3a32b74894dc16ba4c25df0) waybar: fix slow service stop ([nix-community/home-manager⁠#1852](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1852))
* [`5fbb33cf`](https://github.com/nix-community/home-manager/commit/5fbb33cff5a722b267a561b3559d1e4c3b5ec156) targets/genericLinux: set TERMINFO_DIRS ([nix-community/home-manager⁠#1819](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1819))
* [`57a7e5e2`](https://github.com/nix-community/home-manager/commit/57a7e5e2c53de58215fdac1910470bef36dd30cd) docs: document qt.style and programs.rofi.theme changes ([nix-community/home-manager⁠#1849](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1849))
