### PR TITLE
niv spacemacs: update 6d8101c2 -> b7cbcb5e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "6d8101c20e600c9498398d3a1c412ab5e68f86f4",
-        "sha256": "1whwiphy9k65xshksl3zswgp7arkm8r010wmyv2zwig3c80nfv2r",
+        "rev": "b7cbcb5ed5741fbe289a99efaed0350812ed85ad",
+        "sha256": "0y05y5rn6z4fkchdfcg536zxwmgvc0isxprq7dyb6aq9r5dxd9w1",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/6d8101c20e600c9498398d3a1c412ab5e68f86f4.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/b7cbcb5ed5741fbe289a99efaed0350812ed85ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@6d8101c2...b7cbcb5e](https://github.com/syl20bnr/spacemacs/compare/6d8101c20e600c9498398d3a1c412ab5e68f86f4...b7cbcb5ed5741fbe289a99efaed0350812ed85ad)

* [`a8aa24af`](https://github.com/syl20bnr/spacemacs/commit/a8aa24af45675aa3148ff828bda53233b501e0a6) [autohotkey] Work-around for prog-mode-hook
* [`0a0d623c`](https://github.com/syl20bnr/spacemacs/commit/0a0d623c19b10f2207a016f33363611eab3add4c) [autohotkey] Enable auto-completion
* [`91f92d82`](https://github.com/syl20bnr/spacemacs/commit/91f92d82fe22ace0dcba2365270d1e4117d2d15b) Fix purpose and magit: max-lisp-eval-depth
* [`b24fccdb`](https://github.com/syl20bnr/spacemacs/commit/b24fccdbff0276a38cefd1249c92a32b48deac8f) Update call to purpose-x-magit-multi-on
* [`de55a45d`](https://github.com/syl20bnr/spacemacs/commit/de55a45dbd46516cf17846f669f80a41f77c4ab4) [parinfer] Switch implementation to parinfer-rust-mode
* [`b7cbcb5e`](https://github.com/syl20bnr/spacemacs/commit/b7cbcb5ed5741fbe289a99efaed0350812ed85ad) [parinfer] Fix: Wrong number of arguments: setq, 5
