### PR TITLE
niv zsh-async: update 0f3b27b9 -> a61239dd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -132,10 +132,10 @@
         "homepage": null,
         "owner": "mafredri",
         "repo": "zsh-async",
-        "rev": "0f3b27b9ce3a1566d4393a6191b859ecb29b55b9",
-        "sha256": "0cmlhv70vqm5rng7g841hq2adcjc1vqn61jyrhxjvri7ima1kvx1",
+        "rev": "a61239dd55028eec173374883809f439c93d292b",
+        "sha256": "1knvz6091a2isify9zq24a7nvh15zgsacqmlv1dx3ppc8jxl0cgc",
         "type": "tarball",
-        "url": "https://github.com/mafredri/zsh-async/archive/0f3b27b9ce3a1566d4393a6191b859ecb29b55b9.tar.gz",
+        "url": "https://github.com/mafredri/zsh-async/archive/a61239dd55028eec173374883809f439c93d292b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-autosuggestions": {


### PR DESCRIPTION
## Changelog for zsh-async:
Branch: master
Commits: [mafredri/zsh-async@0f3b27b9...a61239dd](https://github.com/mafredri/zsh-async/compare/0f3b27b9ce3a1566d4393a6191b859ecb29b55b9...a61239dd55028eec173374883809f439c93d292b)

* [`a61239dd`](https://github.com/mafredri/zsh-async/commit/a61239dd55028eec173374883809f439c93d292b) Clarify functions for jobs must be defined when worker is started ([mafredri/zsh-async⁠#53](http://r.duckduckgo.com/l/?uddg=https://github.com/mafredri/zsh-async/issues/53))
