### PR TITLE
niv zsh-syntax-highlighting: update 205bc7ea -> e8517244

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "205bc7ea199cfd4cded51d465baad63b3d7f3aad",
-        "sha256": "1n80s6h746k3an2i9bpmkfci6dd8kf0n6b3z39f11imzn1c0q9pg",
+        "rev": "e8517244f7d2ae4f9d979faf94608d6e4a74a73e",
+        "sha256": "1dd1l4g5hkx1pnl1dw4h8ignjhigrvkkcravfkifdl2zf3slyny7",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/205bc7ea199cfd4cded51d465baad63b3d7f3aad.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/e8517244f7d2ae4f9d979faf94608d6e4a74a73e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@205bc7ea...e8517244](https://github.com/zsh-users/zsh-syntax-highlighting/compare/205bc7ea199cfd4cded51d465baad63b3d7f3aad...e8517244f7d2ae4f9d979faf94608d6e4a74a73e)

* [`e8517244`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/e8517244f7d2ae4f9d979faf94608d6e4a74a73e) main: Allow for "]" in shell aliases
