### PR TITLE
niv powerlevel10k: update 3920940e -> 6d545d5d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "3920940ea84f6fba767cbed3fe6ba0653411c706",
-        "sha256": "1hsi3zhzrwj1s7wkdhnhb21i9zwxj111ajmflvnz4h9zswgqigyk",
+        "rev": "6d545d5dd06bd85bbfda5cc8fd7938aee4b79d55",
+        "sha256": "15birkmgbs6ffmxmrkkgy3j3sw0k2qni6wg074ddsz944g421vr2",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/3920940ea84f6fba767cbed3fe6ba0653411c706.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/6d545d5dd06bd85bbfda5cc8fd7938aee4b79d55.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@3920940e...6d545d5d](https://github.com/romkatv/powerlevel10k/compare/3920940ea84f6fba767cbed3fe6ba0653411c706...6d545d5dd06bd85bbfda5cc8fd7938aee4b79d55)

* [`6d545d5d`](https://github.com/romkatv/powerlevel10k/commit/6d545d5dd06bd85bbfda5cc8fd7938aee4b79d55) Fix [romkatv/powerlevel10k⁠#1286](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1286) ([romkatv/powerlevel10k⁠#1288](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1288))
