### PR TITLE
niv nixpkgs: update c069272a -> 8bad34a0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c069272a4b648cf676a7810108bd2b9a2dbb9d57",
-        "sha256": "00dma7b3nmpjhg9a6djrmwjnbp9lm95vbk6v1wyaylkbjjj7xv6z",
+        "rev": "8bad34a0f1956955f77e43ffb5c531d19678ad1f",
+        "sha256": "0751m7b6yk57pzl2n72pqd86ycd72q5ybxv580zgxqa27hmn7b7g",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c069272a4b648cf676a7810108bd2b9a2dbb9d57.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8bad34a0f1956955f77e43ffb5c531d19678ad1f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c069272a...8bad34a0](https://github.com/nixos/nixpkgs/compare/c069272a4b648cf676a7810108bd2b9a2dbb9d57...8bad34a0f1956955f77e43ffb5c531d19678ad1f)

* [`6c3b5c19`](https://github.com/NixOS/nixpkgs/commit/6c3b5c1942fe539226fad6bea4af9f1b2c275e45) pythonPackages.python_magic: fix build and run tests
* [`f43ae887`](https://github.com/NixOS/nixpkgs/commit/f43ae887d19c6d2156d52532b2691b5ad255f8a7) python3Packages.dask: 2021.01.0 -> 2021.03.0
* [`482e0ac2`](https://github.com/NixOS/nixpkgs/commit/482e0ac25b88e87136e8550a1332e0d13b7b0e1d) python3Packages.ipython: 7.19.0 -> 7.21.0
* [`61b25de9`](https://github.com/NixOS/nixpkgs/commit/61b25de93f5fd95d136096a99cdac30156a6c099) python3Packages.notebook: 6.1.6 -> 6.2.0
* [`cc92e8f8`](https://github.com/NixOS/nixpkgs/commit/cc92e8f8c33e02eeb715fa02884b6d82127b29c7) python3Packages.nbclient: 0.5.2 -> 0.5.3
* [`e3900e3e`](https://github.com/NixOS/nixpkgs/commit/e3900e3e0b0fdbf1e7fd6e92bc845545cb30c01d) python3Packages.ipykernel: 5.2.1 -> 5.5.0
* [`4fde90cf`](https://github.com/NixOS/nixpkgs/commit/4fde90cf8736ef3cb853843e0c2a627874b1c8b6) python3Packages.holoviews: 1.13.5 -> 1.14.2
* [`8c381447`](https://github.com/NixOS/nixpkgs/commit/8c3814471bc08bf32595d8f57c354f2e62478e4d) python3Packages.hvplot: 0.7.0 -> 0.7.1
* [`01b5919d`](https://github.com/NixOS/nixpkgs/commit/01b5919dc89c4e8a6aa35a0130ef73ef0dfa0908) python3Packages.colorcet: remove nbsmoke test dependency
* [`ba9b70bc`](https://github.com/NixOS/nixpkgs/commit/ba9b70bcfd2ea5fbceff3d824cff5339e4f85419) python3Packages.bokeh: 2.2.3 -> 2.3.0
* [`9fa29c0d`](https://github.com/NixOS/nixpkgs/commit/9fa29c0df25cef249645a11c3b9de4dc996bb5e9) python37Packages: no longer recurse into set
* [`6ed2bd99`](https://github.com/NixOS/nixpkgs/commit/6ed2bd99376c7139cdca30a3073c42e720676e9f) home-assistant: disable tests getting stuck on aarch64
* [`2f3eab36`](https://github.com/NixOS/nixpkgs/commit/2f3eab365c2d7dd86f4750caa86a0bb53657c198) nvidia-x11: 460.39 -> 460.56
* [`393d3000`](https://github.com/NixOS/nixpkgs/commit/393d3000557f04763b35a27f2ac96d486922cab9) xfce module: enable notification daemon by default ([nixos/nixpkgs⁠#115130](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115130))
* [`9a18802e`](https://github.com/NixOS/nixpkgs/commit/9a18802edfb9db4d826ec967d7301c6c7460dad9) botan2: 2.17.2 -> 2.17.3
* [`7adf9e90`](https://github.com/NixOS/nixpkgs/commit/7adf9e90559a70473ee5fbcba9ef53d6a5850949) pythonPackages.configshell: 1.1.28 -> 1.1.29
* [`d178471f`](https://github.com/NixOS/nixpkgs/commit/d178471fadd0cb85aa79e19be15144da4efc63a8) targetcli: 2.1.53 -> 2.1.54
* [`9c512f7a`](https://github.com/NixOS/nixpkgs/commit/9c512f7a7651f55b3081418d138deef246a90ee7) smarty3: 3.1.36 -> 3.1.39
* [`6f4b61d2`](https://github.com/NixOS/nixpkgs/commit/6f4b61d2ce39057fc0d9971fa7620cc7d7e7dd3a) awscli2: 2.1.17 -> 2.1.29
* [`99f895fa`](https://github.com/NixOS/nixpkgs/commit/99f895fa2587727c23cacc6eed17752ea28997e5) stunnel: 5.56 -> 5.58
* [`28e538c9`](https://github.com/NixOS/nixpkgs/commit/28e538c9e31caa0a124578b1d37eb4c304e58332) lorri: cleanup, format
* [`80a09a47`](https://github.com/NixOS/nixpkgs/commit/80a09a477fabc28daaea815ec878d966a11030dd) pythonPackages.googleapis_common_protos: remove unused input
* [`2505c4eb`](https://github.com/NixOS/nixpkgs/commit/2505c4ebc2984077ece9ca00c3d96cedb0f476cb) ark: format
* [`5be41d6d`](https://github.com/NixOS/nixpkgs/commit/5be41d6d7d12be583763b5c2716274e2d3e7fff7) kde-frameworks.kguiaddons: format, mark broken below qt 5.14
* [`a54f2438`](https://github.com/NixOS/nixpkgs/commit/a54f2438e47ed4627d9a66724b31e0f66458deac) pythonPackages.shap: mark broken
* [`901206a0`](https://github.com/NixOS/nixpkgs/commit/901206a04e70c99b03a4d96f602a4f39c2780288) pythonPackages.crate: disable failing test on darwin
* [`3353bf7a`](https://github.com/NixOS/nixpkgs/commit/3353bf7a165d5c520d31f2b62f165b605910e512) beets: remove ``? null``; remove ``with lib``
* [`2c19aaab`](https://github.com/NixOS/nixpkgs/commit/2c19aaabd4b851c810b1b36de48bda947e8e0a8f) deltachat-electron: format
* [`bee35c7b`](https://github.com/NixOS/nixpkgs/commit/bee35c7b7c5599e065f7e10b55ca053a81643ef5) tree-sitter: cleanup
* [`975ec901`](https://github.com/NixOS/nixpkgs/commit/975ec901f6498155713aaf6d897fd9b50dce6043) pylode: init at 2.8.6
* [`39b57a4d`](https://github.com/NixOS/nixpkgs/commit/39b57a4d0daa896455be6ccd0df73361335b2484) tor-browser-bundle-bin: 10.0.12 -> 10.0.13
* [`f2ed6d87`](https://github.com/NixOS/nixpkgs/commit/f2ed6d87a40ad55c5b71dd95bbf3287900e42ae9) containerd: 1.4.3 -> 1.4.4
* [`390684da`](https://github.com/NixOS/nixpkgs/commit/390684da02cf154c25355212c86609c335414486) python3Packages.bitlist: init at 0.3.1
* [`60b78b1c`](https://github.com/NixOS/nixpkgs/commit/60b78b1c09951a0732b21cb403d927082081d27f) python3Packages.fe25519: init at 0.2.0
* [`7cdb7324`](https://github.com/NixOS/nixpkgs/commit/7cdb7324494760a016f8772954eef10de71e3b79) python3Packages.ge25519: init at 0.2.0
* [`e83c692f`](https://github.com/NixOS/nixpkgs/commit/e83c692f972cb8b3190f85ed8705f1d2eddc4c53) python3Packages.fountains: init at 0.2.1
* [`10b1c7e5`](https://github.com/NixOS/nixpkgs/commit/10b1c7e54b97ae6053adf7346349d18644d8edfa) python3Packages.parts: init at 1.0.2
* [`4e25873e`](https://github.com/NixOS/nixpkgs/commit/4e25873e92dc07b9d7ce3dfff4974c3bf04046ea) pythonPackages.awkward: 1.0.2 -> 1.1.2
* [`de6283be`](https://github.com/NixOS/nixpkgs/commit/de6283bebfa63c43ef16eee5d66c666a24cfd0ad) gnvim: fix install phase with Rust with custom target
* [`3c9f6c73`](https://github.com/NixOS/nixpkgs/commit/3c9f6c7398beb5d07a1991656482d05fddca3e5e) gtk-layer-shell: 0.5.2 -> 0.6.0
* [`9e3e5276`](https://github.com/NixOS/nixpkgs/commit/9e3e5276fda96d6a58074de24617c31d94e0b80e) gtksourceview4: 4.8.0 -> 4.8.1
* [`53cc1077`](https://github.com/NixOS/nixpkgs/commit/53cc1077518dd753bafa479049a5346b7b591820) babl: 0.1.84 -> 0.1.86
* [`bc23341c`](https://github.com/NixOS/nixpkgs/commit/bc23341c8b4d93f7bdd2cb58edb6e555e549faa3) libdnf: 0.58.0 -> 0.60.0
* [`41d3640e`](https://github.com/NixOS/nixpkgs/commit/41d3640e004e23744d9d01ba09995a9d53ed4963) python3Packages.scramp: 1.2.0 -> 1.2.2
* [`04208d2f`](https://github.com/NixOS/nixpkgs/commit/04208d2ffa148d607164aebcb53ce3037ce40cad) python3Packages.pg8000: 1.17.0 -> 1.18.0
* [`f7625a1d`](https://github.com/NixOS/nixpkgs/commit/f7625a1d7385212eee778d896e8b5c741b1403f9) libabigail: 1.8 -> 1.8.2
* [`f066807b`](https://github.com/NixOS/nixpkgs/commit/f066807b58d8f655c7df0a22611bba41ed84e969) libgxps: 0.3.1 -> 0.3.2
* [`64676e99`](https://github.com/NixOS/nixpkgs/commit/64676e99a6312491a7234417af21607204980235) ibus-engines.bamboo: 0.6.8 -> 0.6.9
* [`3787cf20`](https://github.com/NixOS/nixpkgs/commit/3787cf2075c6b40f77f369f0701a49d97c6c4446) consul: 1.9.3 -> 1.9.4
* [`f754c844`](https://github.com/NixOS/nixpkgs/commit/f754c844d92fe07c1a328de940f55676d2ef3fe1) osinfo-db: 20210202 -> 20210215
* [`ceb1e7d1`](https://github.com/NixOS/nixpkgs/commit/ceb1e7d18a618b9f726b4cc2061c39ad03aed0a5) dsniff: 2.4b1+debian-29 -> 2.4b1+debian-30
* [`8ae8348b`](https://github.com/NixOS/nixpkgs/commit/8ae8348b9dcc0d93a7cb7bbdb16be5fd6fd966f8) gmic: 2.9.5 -> 2.9.6
* [`d59047a7`](https://github.com/NixOS/nixpkgs/commit/d59047a77430fa8705c2fb67795145f657923eff) python3Packages.pypugjs: 5.9.8 -> 5.9.9
* [`62f9a381`](https://github.com/NixOS/nixpkgs/commit/62f9a381a030e188b826bcffeabc3653117bb4b9) fish: 3.1.2 -> 3.2.0
* [`b0128914`](https://github.com/NixOS/nixpkgs/commit/b012891437994a9babcaf98ddf7ffa656cdcfaa9) nixos/fish: adapt completions patch to fish 3.2.0
* [`b0c7213b`](https://github.com/NixOS/nixpkgs/commit/b0c7213bd45a1d81ba797b18f8f861f06a92e82f) fish: fix passthru test
* [`6aa87867`](https://github.com/NixOS/nixpkgs/commit/6aa878679ab9d1d0f5557b95a786b192fcf0f936) fish: execute fish tests
* [`b3c90695`](https://github.com/NixOS/nixpkgs/commit/b3c90695a9a23b893f22903c5b9c22f5ba9af3a8) nomachine-client: 7.0.211 -> 7.2.3
* [`725f331c`](https://github.com/NixOS/nixpkgs/commit/725f331cc8b1d3b762b1adeadf2ee2044f5b69c6) particl-core: 0.19.2.3 -> 0.19.2.5
* [`6303d139`](https://github.com/NixOS/nixpkgs/commit/6303d139fc09122613108f8eb0996441429fe2ea) pythonPackages.cairosvg: 2.5.1 -> 2.5.2
* [`fa2bf8e3`](https://github.com/NixOS/nixpkgs/commit/fa2bf8e38e9ad75f7bfd9953974196fc41980ef7) pythonPackages.celery: add missing requirement
* [`9c43942c`](https://github.com/NixOS/nixpkgs/commit/9c43942caf1e3cb496cf50325bc128d4c0ce740d) mirage: remove unused input
* [`0218a3a1`](https://github.com/NixOS/nixpkgs/commit/0218a3a1d54870440889aa06f5ab8ccf1e0e9a97) pythonPackages.flower: fix broken
* [`a2100d3c`](https://github.com/NixOS/nixpkgs/commit/a2100d3c78121cf723944f97319426c6d4d019b8) python3Packages.defusedxml: 0.6.0 -> 0.7.0
* [`9001fbc4`](https://github.com/NixOS/nixpkgs/commit/9001fbc439737a68d9fdb2dc12e1114bd4c4d906) python3Packages.defusedxml: add meta
* [`fc750b20`](https://github.com/NixOS/nixpkgs/commit/fc750b2000a1cfb31cc4cf2a409f16f243d2f9c0) kubernetes: 1.19.5 -> 1.20.4
* [`7da62867`](https://github.com/NixOS/nixpkgs/commit/7da62867be079bb5f6412fb12a76dbb68f9bad4b) nixos/kubernetes: adapt module and test cases to fit kubernetes v1.20.X as well as coredns v1.7.X
* [`7b5c38e9`](https://github.com/NixOS/nixpkgs/commit/7b5c38e97384257a03ec29e9eec56e2a46a07816) nixos/kubernetes: docker -> containerd
* [`451ffcb2`](https://github.com/NixOS/nixpkgs/commit/451ffcb2ac97c3d110cc88f0a301f4ba0d5b4b1a) pythonPackages.alot: cleanup inputs, fix inputs
* [`473906dc`](https://github.com/NixOS/nixpkgs/commit/473906dc8b895ef6576b054971bf78b923ff2009) hashdeep: simplify platforms
* [`b79b4ab4`](https://github.com/NixOS/nixpkgs/commit/b79b4ab4cb5c57453f82175cbbd41a15b028f0d5) kramdown-rfc2629: 1.2.13 -> 1.3.37
* [`f003d2c9`](https://github.com/NixOS/nixpkgs/commit/f003d2c9cecdb55e720967bc3d13931ef9145fc8) drone-runner-exec: init at unstable-2020-04-19 ([nixos/nixpkgs⁠#115003](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115003))
* [`5a7d2375`](https://github.com/NixOS/nixpkgs/commit/5a7d2375290d7f9be63a71381564196c640ee579) dpt-rp1-py: unstable-2018-10-16 -> 0.1.12
* [`48c2a14f`](https://github.com/NixOS/nixpkgs/commit/48c2a14fe0df35cb1137f975a191a96b7c3c8174) mutt: 2.0.5 -> 2.0.6
* [`6dcd1e4c`](https://github.com/NixOS/nixpkgs/commit/6dcd1e4c6a89921b6610bf6888c2371eedf5f604) lollypop: 1.4.16 -> 1.4.17
* [`52de3976`](https://github.com/NixOS/nixpkgs/commit/52de3976b8a9782f550bc1eb6e3d4d0ab9c89896) doc: replace &lt; with < in Markdown
* [`c408936e`](https://github.com/NixOS/nixpkgs/commit/c408936e23632b2a68a3114be8721df0536b9936) python3Packages.pypykatz: 0.3.15 -> 0.4.2
* [`f956dd3f`](https://github.com/NixOS/nixpkgs/commit/f956dd3ff5bbabbd5515376220255b8da464cc2c) vscx/ms-vsliveshare-vsliveshare: 1.0.2902 -> 1.0.3912
* [`17c4f6fa`](https://github.com/NixOS/nixpkgs/commit/17c4f6fa36b35b3bb92e465dd103bd927c8be8c9) chromium: Make get-commit-message.py more robust
* [`5dc759af`](https://github.com/NixOS/nixpkgs/commit/5dc759afec451ae04750706c5f84c75626de23d2) ocamlPackages.rope: use Dune 2
* [`60785fe4`](https://github.com/NixOS/nixpkgs/commit/60785fe4dbedc4fd2a4a4980c59357a27b57aabf) ocamlPackages.dune: rename into dune_1
* [`a104d2b1`](https://github.com/NixOS/nixpkgs/commit/a104d2b18cf9021e014d06073c45a0c8d2f6bef6) ocamlPackages.dune_1: disable for OCaml ≥ 4.12
* [`df885b71`](https://github.com/NixOS/nixpkgs/commit/df885b718cce7350bd510b2461dcc60e072070eb) zstxtns-utils: use stdenvNoCC
* [`2ef5683c`](https://github.com/NixOS/nixpkgs/commit/2ef5683cd999e1499fedc70c7aa58514c5ae18e8) palemoon: 29.0.1 -> 29.1.0
* [`ffe611ce`](https://github.com/NixOS/nixpkgs/commit/ffe611cec81843e0ef107ab69cc1932ce8cd406e) weechat: 3.0.1 -> 3.1
* [`060efbe3`](https://github.com/NixOS/nixpkgs/commit/060efbe394e1633b8ff6e7aaf23a06cfdc53df1c) cadaver: Fix building with current openssl
* [`3ceb217e`](https://github.com/NixOS/nixpkgs/commit/3ceb217e21fba0dcdaddb21e25f1b3a58b4af074) zz: unstable-2021-01-26 -> unstable-2021-03-07
* [`18750336`](https://github.com/NixOS/nixpkgs/commit/1875033648417e12be76c4bf9b036294500a2c6c) python3Packages.python-telegram-bot: 13.0 -> 13.3 ([nixos/nixpkgs⁠#115287](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115287))
* [`33d7a98f`](https://github.com/NixOS/nixpkgs/commit/33d7a98f9a46123fac6956b2e34e5b74649bea8e) python3Packages.APScheduler: add setuptools
* [`2331c9c8`](https://github.com/NixOS/nixpkgs/commit/2331c9c89b42220a99dc92d487c2e6ba1f215111) maintainers: Add ivankovnatsky
* [`99aa6768`](https://github.com/NixOS/nixpkgs/commit/99aa67688082e9280faa509116be00e8cfb64471) swaykbdd: Init at 1.0
* [`512284ed`](https://github.com/NixOS/nixpkgs/commit/512284ed147abeca5eca8a2875a8de7c0fbca810) msitools: 0.99 -> 0.101
* [`2192b2ab`](https://github.com/NixOS/nixpkgs/commit/2192b2abda68059018b7a4db2750861e2ab217fd) pythonPackages.defusedxml: execute tests
* [`39d56d98`](https://github.com/NixOS/nixpkgs/commit/39d56d9865f41a8035c8ddbe8ef32fce1a6dc2d9) scientifica: 2.1 -> 2.2
* [`288f4a61`](https://github.com/NixOS/nixpkgs/commit/288f4a6173275a6480f7dcbeb6a9bc8aa29ae5e1) dnsviz: init at 0.9.2
* [`155a946c`](https://github.com/NixOS/nixpkgs/commit/155a946c371dc77ae87950be51691da94fce1305) gitAndTools.tig: 2.5.2 -> 2.5.3
* [`49777a74`](https://github.com/NixOS/nixpkgs/commit/49777a74308e79f8cdaab3b44613023dc2c52739) gitea: 1.13.3 -> 1.13.4
* [`a42b2ff7`](https://github.com/NixOS/nixpkgs/commit/a42b2ff76137ded8b2a84884b22628c5dbb58785) python3Packages.fritzconnection: 1.4.1 -> 1.4.2
* [`f43497da`](https://github.com/NixOS/nixpkgs/commit/f43497da9da8e3cce2eb290778918b21a44c7a60) ocamlPackages.asn1-combinators: 0.2.4 -> 0.2.5
* [`40974d10`](https://github.com/NixOS/nixpkgs/commit/40974d10dea75530052dd58ff7da01262c8f5910) gxkb: init at 0.9.0 ([nixos/nixpkgs⁠#115323](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115323))
* [`bdbde521`](https://github.com/NixOS/nixpkgs/commit/bdbde521d79b4755838e6b9dae3cf68119f1d182) pythonPackages: remove inherit pkg-config
* [`d0bc5e0a`](https://github.com/NixOS/nixpkgs/commit/d0bc5e0a8262ffa7eae6c08d535492f4bbd68271) pythonPackages: format some inherits into new line
* [`c34a2136`](https://github.com/NixOS/nixpkgs/commit/c34a2136cfdc61c1d5f7714388a5baa837385216) pythonPackages.dask: format
* [`83f2ece6`](https://github.com/NixOS/nixpkgs/commit/83f2ece67831732f223dcce221e720707dc78555) pythonPackages.dask: add optional extra "complete"
* [`e769eec5`](https://github.com/NixOS/nixpkgs/commit/e769eec5f142b53be442f80bd43ad75208fdf2f1) pythonPackages.datashader: format, dask with extra "complete", switch to pytestCheckHook
* [`92ccd0a0`](https://github.com/NixOS/nixpkgs/commit/92ccd0a06a57f65813da94eb194bf817207be39c) pythonPackages.datashader: 0.11.1 -> 0.12.0
* [`a2a44a90`](https://github.com/NixOS/nixpkgs/commit/a2a44a90deea98243ae4d2cb151ce859395a97e7) pythonPackages.distributed: 2.30.1 -> 2021.3.0
* [`61da73e4`](https://github.com/NixOS/nixpkgs/commit/61da73e444106e481b2e47eebff16ee40d16391e) theme-jade1: 1.11 -> 1.12
* [`8c339023`](https://github.com/NixOS/nixpkgs/commit/8c33902388c30954bb7b4dc345892072056fa92a) mopidy-local: 3.2.0 -> 3.2.1
* [`2b4c7c6c`](https://github.com/NixOS/nixpkgs/commit/2b4c7c6cf3cf7c200a4ad4edc72711a581e6c082) android-udev-rules: 20201003 -> 20210302
* [`e0b6268a`](https://github.com/NixOS/nixpkgs/commit/e0b6268a795ac81df2b4777593f8a8f9cbd4e8fb) python3Packages.phonemizer: update patch to fix tests
* [`05aff5f8`](https://github.com/NixOS/nixpkgs/commit/05aff5f84265cc2640d5a9f3f9e635ed2eab71d2) biboumi: format, remove unused input
* [`2d3effa0`](https://github.com/NixOS/nixpkgs/commit/2d3effa0d046d6ca12b551159c6b314358142680) pythonPackages.cairosvg: 2.5.1 -> 2.5.2
* [`743c6a41`](https://github.com/NixOS/nixpkgs/commit/743c6a4187b9117d500576bc20b0e36650c34cb2) pythonPackages.celery: add missing requirement
* [`af326076`](https://github.com/NixOS/nixpkgs/commit/af3260763009ba50976502594a022d42a8b164b6) php-packages: cleanup
* [`9718302d`](https://github.com/NixOS/nixpkgs/commit/9718302d11cf50b3ff7a9b8114a3fb4157dc660b) arb: format
* [`b7befb35`](https://github.com/NixOS/nixpkgs/commit/b7befb3522f2338c71bf0a51eb9e7c0d24d947f4) palp: format
* [`0207c32e`](https://github.com/NixOS/nixpkgs/commit/0207c32effd1b991cdc6986aae6f25854f0ba15a) giac: remove ? null
* [`089b96e2`](https://github.com/NixOS/nixpkgs/commit/089b96e21799af481bfb51075660652aa0a93a47) csvkit: add pythonImportCheck, mark broken
* [`17badcf5`](https://github.com/NixOS/nixpkgs/commit/17badcf58ad1a05e3a5d3b6eaf9db336bcb6121d) pythonPackages.agate-sql: format, add pythonImportsCheck, mark broken
* [`c878b141`](https://github.com/NixOS/nixpkgs/commit/c878b14107eea569142195b1e330191b3999f30f) zz: remove emojis from description
* [`d5106e90`](https://github.com/NixOS/nixpkgs/commit/d5106e90dac8985a9a3acd33d1f25c24e7162fb4) pythonPackages.dopy: add python importsCheck
