### PR TITLE
niv home-manager: update 57a7e5e2 -> 040ea28e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "57a7e5e2c53de58215fdac1910470bef36dd30cd",
-        "sha256": "0cgjai6l1j73h6mwgndcyha7wy6am2vwd25274lffzqzrs0n1ac9",
+        "rev": "040ea28e448a93d24540b7cf2eda4b25300c5ab1",
+        "sha256": "0llviiyi3crf3giq95d1xa6zjvrf6rndjr36r4mqcyh6qk903v7r",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/57a7e5e2c53de58215fdac1910470bef36dd30cd.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/040ea28e448a93d24540b7cf2eda4b25300c5ab1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@57a7e5e2...040ea28e](https://github.com/nix-community/home-manager/compare/57a7e5e2c53de58215fdac1910470bef36dd30cd...040ea28e448a93d24540b7cf2eda4b25300c5ab1)

* [`040ea28e`](https://github.com/nix-community/home-manager/commit/040ea28e448a93d24540b7cf2eda4b25300c5ab1) offlineimap: Strip newlines from offlineimap passwordcommand ([nix-community/home-manager⁠#1853](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1853))
