### PR TITLE
niv spacemacs: update b7cbcb5e -> 7d2ff48d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "b7cbcb5ed5741fbe289a99efaed0350812ed85ad",
-        "sha256": "0y05y5rn6z4fkchdfcg536zxwmgvc0isxprq7dyb6aq9r5dxd9w1",
+        "rev": "7d2ff48d77a1591d6ac91a5cb321f9e7371af15d",
+        "sha256": "0c09zymkgp1xml4izwmg4cf61nyp2zracw008h127sxd11h37f1y",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/b7cbcb5ed5741fbe289a99efaed0350812ed85ad.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/7d2ff48d77a1591d6ac91a5cb321f9e7371af15d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@b7cbcb5e...7d2ff48d](https://github.com/syl20bnr/spacemacs/compare/b7cbcb5ed5741fbe289a99efaed0350812ed85ad...7d2ff48d77a1591d6ac91a5cb321f9e7371af15d)

* [`d424c8d1`](https://github.com/syl20bnr/spacemacs/commit/d424c8d1d1d3505268351092c54d15a0a6b31d24) Bind frame keys using spacemacs|spacebind
* [`f8531245`](https://github.com/syl20bnr/spacemacs/commit/f853124578c5e6faa7c169378bbcd7f9335f80c6) Improve editing-style toggles
* [`2e48899d`](https://github.com/syl20bnr/spacemacs/commit/2e48899db743738a2beac100e73ab4b253720c6d) Open home buffer recent files in expected order
* [`4409d39b`](https://github.com/syl20bnr/spacemacs/commit/4409d39bec052b91960c4e8dc4a369d308e24e55) Fixes error if parsing ipython dev version
* [`151d4db8`](https://github.com/syl20bnr/spacemacs/commit/151d4db88438d277caed72d00266ed8b1f74d6c4) Add keybindings for org-roam-alias-add ([syl20bnr/spacemacs⁠#14480](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14480))
* [`15decbc6`](https://github.com/syl20bnr/spacemacs/commit/15decbc67dbee8c6e102bf63c3b2e2746f5a009f) [evilified] Restore evil-surround
* [`b2d89fdc`](https://github.com/syl20bnr/spacemacs/commit/b2d89fdc3ff8ad3808d6c4675fdef886ed51695b) [ess] add keybinding for ess-quit
* [`34aeca5f`](https://github.com/syl20bnr/spacemacs/commit/34aeca5f9874b2c01605e26078b115df000ca4b9) Add note on which jar to use
* [`b5e32b42`](https://github.com/syl20bnr/spacemacs/commit/b5e32b42c0dd46cf1bdb640a5b887a5a7c08e200) FAQ on including _ in words for `*` searches
* [`9b9043bc`](https://github.com/syl20bnr/spacemacs/commit/9b9043bc5cae344eb044b2bb78ed37ebcd4a8448) update cask install instructions in README ([syl20bnr/spacemacs⁠#14452](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14452))
* [`589c16b7`](https://github.com/syl20bnr/spacemacs/commit/589c16b73ac4f3f683d7f700a644359ce4875437) git: adds orgit-forge so org links can be stored from forge topics ([syl20bnr/spacemacs⁠#14450](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14450))
* [`94585331`](https://github.com/syl20bnr/spacemacs/commit/94585331cee24d3226530e1d8bc6640285d5be2a) Replace move-text with drag-stuff
* [`898e5092`](https://github.com/syl20bnr/spacemacs/commit/898e5092733d0ba6e3de0ac4b85e3382f3e52847) [evilified] Add evilified normal keys: yank, navigate
* [`7786e11a`](https://github.com/syl20bnr/spacemacs/commit/7786e11a3592a2a40fcd233433f0b4b08f84fabb) [core] load-env-vars cygwin support ([syl20bnr/spacemacs⁠#14442](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14442))
* [`c7044145`](https://github.com/syl20bnr/spacemacs/commit/c7044145ffe810b54d401cd9e79a2d90971332f6) Add pdf-view-restore to pdf layer
* [`32ead25c`](https://github.com/syl20bnr/spacemacs/commit/32ead25c357a69e9e3605b76c765d4e127699e7f) [lsp] Bind `SPC p E` to `helm-lsp-diagnostics`
* [`c4ed6b5d`](https://github.com/syl20bnr/spacemacs/commit/c4ed6b5d0a8180304a201368f132af4956798850) [pdf] defer loading of pdf-view-restore
* [`13791616`](https://github.com/syl20bnr/spacemacs/commit/13791616c7c93979f6348588e6205c33a6bc731e) [bot] Auto-update ([syl20bnr/spacemacs⁠#14398](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14398))
* [`480efa0f`](https://github.com/syl20bnr/spacemacs/commit/480efa0f3d8c2832d1778a1baebcd3686ec5f448) Remove unused package: move-text
* [`fb41915c`](https://github.com/syl20bnr/spacemacs/commit/fb41915c5b74bbdbc87dc00a157f2e9c842b4273) [org] Add org-appear support ([syl20bnr/spacemacs⁠#14482](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14482))
* [`2fec4a49`](https://github.com/syl20bnr/spacemacs/commit/2fec4a49be9cab54a5b08fc6f4301260088d3eed) [haskell] Add a binding to change the target for the session
* [`de142562`](https://github.com/syl20bnr/spacemacs/commit/de1425628c51ee6e894f0ceeee053557b0ad24d9) Revert "[evilified] Add evilified normal keys: yank, navigate"
* [`07f31743`](https://github.com/syl20bnr/spacemacs/commit/07f31743e71679261162e763580cccbb0a352e54) [evilified] Visual state text objects, exchange point/mark
* [`4bcdc36f`](https://github.com/syl20bnr/spacemacs/commit/4bcdc36f0f53eb8ea0f07e50aba44ef9b873ee67) Add org-wild-notifier to org-layer
* [`7d2ff48d`](https://github.com/syl20bnr/spacemacs/commit/7d2ff48d77a1591d6ac91a5cb321f9e7371af15d) Allow disabling smartparens in dotfile
