### PR TITLE
niv nixpkgs: update 8bad34a0 -> 63a9f162

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bad34a0f1956955f77e43ffb5c531d19678ad1f",
-        "sha256": "0751m7b6yk57pzl2n72pqd86ycd72q5ybxv580zgxqa27hmn7b7g",
+        "rev": "63a9f162355ec84c423690869a97848d73409fb8",
+        "sha256": "0k2xynqmnmr9l1d36lg4f5akvrhjs7vp474px5d22pr4pyjpka51",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/8bad34a0f1956955f77e43ffb5c531d19678ad1f.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/63a9f162355ec84c423690869a97848d73409fb8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@8bad34a0...63a9f162](https://github.com/nixos/nixpkgs/compare/8bad34a0f1956955f77e43ffb5c531d19678ad1f...63a9f162355ec84c423690869a97848d73409fb8)

* [`24133ead`](https://github.com/NixOS/nixpkgs/commit/24133ead28dc4ece7ba016bc8f7624db0478e977) nixos/mautrix-telegram: substitute secrets in config file at runtime ([nixos/nixpkgs⁠#112966](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/112966))
* [`1c6fd902`](https://github.com/NixOS/nixpkgs/commit/1c6fd902f405c548928ac91cb85c41b87960c260) sd-local: 1.0.24 -> 1.0.26
* [`005fc548`](https://github.com/NixOS/nixpkgs/commit/005fc54819ffca08d834daeafeb9eb859a64f4f6) seaweedfs: 2.29 -> 2.31
* [`f6e73103`](https://github.com/NixOS/nixpkgs/commit/f6e7310387bc6b751ce9c18ae5fe3fd09314985b) shipyard: 0.2.9 -> 0.2.15
* [`5f41ef7d`](https://github.com/NixOS/nixpkgs/commit/5f41ef7d78fd33cf56b67c111e99051d30117675) singularity: 3.7.1 -> 3.7.2
* [`22b61e52`](https://github.com/NixOS/nixpkgs/commit/22b61e52634160847a19e63b65265219f9a806d6) nixos/prometheus/exporters: fix eval if only `openFirewall = true;` is set
* [`00286f1b`](https://github.com/NixOS/nixpkgs/commit/00286f1b1bd5009b5b52772e53646111ad934a22) libhandy: 1.0.3 -> 1.2.0
* [`17566354`](https://github.com/NixOS/nixpkgs/commit/175663548cbec68251a6be77d7e6dbc5b9545eaf) reiser4progs: 2.0.1 -> 2.0.4
* [`6a4c7b35`](https://github.com/NixOS/nixpkgs/commit/6a4c7b35e86d7f0bc159590886e170fbdcf754b4) rosegarden: 20.06 -> 20.12
* [`94942626`](https://github.com/NixOS/nixpkgs/commit/9494262663e2bf23b7d50afc92cd7f67654685b8) svxlink: 19.09.1 -> 19.09.2
* [`ac49f2ff`](https://github.com/NixOS/nixpkgs/commit/ac49f2ff8194717385f52fc54fc92035a407fe4e) libisoburn: 1.5.2 -> 1.5.4
* [`b417a8ac`](https://github.com/NixOS/nixpkgs/commit/b417a8aca34cef137446aaf3dd3a633329fbbc77) libofx: 0.10.0 -> 0.10.1
* [`148b1387`](https://github.com/NixOS/nixpkgs/commit/148b1387e1ba0e378a07c532be48dfcd46dbbd9f) libdigidocpp: 3.14.4 -> 3.14.5
* [`1de17296`](https://github.com/NixOS/nixpkgs/commit/1de17296c6bfb17b74155eb914b34484b57d98d8) lightdm-mini-greeter: 0.5.0 -> 0.5.1
* [`99286f26`](https://github.com/NixOS/nixpkgs/commit/99286f264050fd2697b253eb1f3a90b0b1d8ecb9) liblinear: 2.42 -> 2.43
* [`805e9c5f`](https://github.com/NixOS/nixpkgs/commit/805e9c5f691629bfe19e52350ffc6f18ce200131) ibus-engines.anthy: 1.5.11 -> 1.5.12
* [`305267aa`](https://github.com/NixOS/nixpkgs/commit/305267aacb0c2b0e2345cb87dff689e7d8aa300b) python37Packages.convertdate: 2.3.0 -> 2.3.1
* [`ddd71dd0`](https://github.com/NixOS/nixpkgs/commit/ddd71dd0c9a6d87f947050b35f2361c799d24b83) ibus-engines.table: 1.12.3 -> 1.12.4
* [`2edf46ca`](https://github.com/NixOS/nixpkgs/commit/2edf46ca6a0cfc7277ef4109d2dcd3df824ae96f) pypy3.pkgs.cryptography: fix build
* [`8eb02477`](https://github.com/NixOS/nixpkgs/commit/8eb024773c61bbee28a019e035bddec710e645b7) teler: 1.0.3 -> 1.1.0
* [`dae85031`](https://github.com/NixOS/nixpkgs/commit/dae8503172f9376e175284facee24cf3d2fe6b41) terraform-ls: 0.14.0 -> 0.15.0
* [`e38bea23`](https://github.com/NixOS/nixpkgs/commit/e38bea23358bd4082b56bec648b578810e6763ac) terragrunt: 0.28.9 -> 0.28.11
* [`eb1a98b1`](https://github.com/NixOS/nixpkgs/commit/eb1a98b142d20e13d502f23e5d5b71b920f4c750) terrascan: 1.3.3 -> 1.4.0
* [`c02bf972`](https://github.com/NixOS/nixpkgs/commit/c02bf9722717d8f140caa7dc7e3b907bf3e4e39a) tfsec: 0.39.5 -> 0.39.6
* [`0175c11e`](https://github.com/NixOS/nixpkgs/commit/0175c11e65f424af03dbdbb96b443aa686706921) jasper: re-enable expression
* [`509377bb`](https://github.com/NixOS/nixpkgs/commit/509377bb432b911cededfc0486dc8c35358d3e0c) traefik: 2.4.6 -> 2.4.7
* [`10042ddf`](https://github.com/NixOS/nixpkgs/commit/10042ddfd7159323f5ea2ced54d55e5136a7a00e) unciv: 3.12.14 -> 3.13.7-patch2
* [`8ef19ab8`](https://github.com/NixOS/nixpkgs/commit/8ef19ab88d6886f0ef2c6b2a2302c82fcfedcabb) wrangler: 1.13.0 -> 1.15.0
* [`0e3fb2ae`](https://github.com/NixOS/nixpkgs/commit/0e3fb2ae42ade19ad5a034aee8f5573dabe1b80a) fzf: 0.25.1 -> 0.26.0
* [`650ee258`](https://github.com/NixOS/nixpkgs/commit/650ee258fde069a1ac3544cdce89029e9f91d5c5) gnuradio3_{7,8}: Use external volk
* [`fb024f50`](https://github.com/NixOS/nixpkgs/commit/fb024f50e5557e42b4bb8249d0298c244ff8082d) gnuradio: 3.8 -> 3.9
* [`c30a9fd9`](https://github.com/NixOS/nixpkgs/commit/c30a9fd9460edbc8a0f3e8b91dca05e4a13d25ad) renderizer: 2.0.9 -> 2.0.12
* [`09481d06`](https://github.com/NixOS/nixpkgs/commit/09481d065e653b7e228e36af1190002cd4ab46dc) syncthingtray: 1.1.2 -> 1.1.3
* [`e27a6e16`](https://github.com/NixOS/nixpkgs/commit/e27a6e16cf4bc3e2573ce1521193413539f4bea4) deadd-notification-center: 1.7.3 -> 2021-03-10
* [`02fa7b8e`](https://github.com/NixOS/nixpkgs/commit/02fa7b8edfed004aaf9f03b9071e00142ddf3b59) deadd-notification-center: use make to install and fix issues with service files
* [`3d15fa8a`](https://github.com/NixOS/nixpkgs/commit/3d15fa8ae656d797c750c459a7e79b288fe58e7e) jasper: init at 2.0.26
* [`3f109f6f`](https://github.com/NixOS/nixpkgs/commit/3f109f6f275016eb3d93a59be134302f5a27f1ea) zulip-term: 0.5.2 -> 0.6.0
* [`6a813afe`](https://github.com/NixOS/nixpkgs/commit/6a813afe61a7db864f6bbf916c1eb1d20afe950c) vscode-extensions.hashicorp.terraform: 2.8.1 -> 2.8.2
* [`68f45df6`](https://github.com/NixOS/nixpkgs/commit/68f45df6beb3b156e533bdcf89a3ba1c8c92f750) vscode-extensions.gruntfuggly.todo-tree: 0.0.201 -> 0.0.204
* [`c47eacf4`](https://github.com/NixOS/nixpkgs/commit/c47eacf4ccb524030bc9e4ea2f6aa15165952a82) python3Packages.hass-nabucasa: 0.41.0 -> 0.42.0
* [`b67d1971`](https://github.com/NixOS/nixpkgs/commit/b67d19710c66af8e03ac9ef3325a742afb7d6945) kgx: init at unstable-2021-03-13
* [`dcbfa026`](https://github.com/NixOS/nixpkgs/commit/dcbfa026a3145c18332ee6db89d9cf4c4ee05073) python3Packages.convertdate: 2.3.1 -> 2.3.2
* [`be6d79d8`](https://github.com/NixOS/nixpkgs/commit/be6d79d83f07f053a2f986c983cd34b4ef9fdc07) folks: Fix tests with e-d-s linked with libphonenumber support
* [`4e701b58`](https://github.com/NixOS/nixpkgs/commit/4e701b586ada7abbdce1a7add69cd7f9437b56b7) python3Packages.xknx: 0.17.1 -> 0.17.2
* [`c826ae5b`](https://github.com/NixOS/nixpkgs/commit/c826ae5b14b14f2e459dbb8d300a3c02aa42ee9e) broadlink-cli: 0.16.0 -> 0.17.0
* [`89ca7d44`](https://github.com/NixOS/nixpkgs/commit/89ca7d44c022625d09ccbf5b827f22db97f8512e) python3Packages.adguardhome: 0.4.2 -> 0.5.0
* [`4693291f`](https://github.com/NixOS/nixpkgs/commit/4693291f625999111b181759fc56ffe3d51499f7) gupnp-igd: 0.2.5 -> 1.2.0
* [`921d0269`](https://github.com/NixOS/nixpkgs/commit/921d0269cc2b918f5e20a3f0bf5887280a28d1e6) doc: Port stdenv/meta to Markdown
* [`da4f4431`](https://github.com/NixOS/nixpkgs/commit/da4f44311b7353b2bff1221f6e9684fa45fd39a4) uutils-coreutils: install symlinks again by converting to stdenv.mkDerivation which executes make,
* [`53830ca0`](https://github.com/NixOS/nixpkgs/commit/53830ca04cc58dfbe8536dad266ffb23c3d2f3f4) doc: Port stdenv/multiple-output to Markdown
* [`f854ee87`](https://github.com/NixOS/nixpkgs/commit/f854ee87f088b04f7e0b49c9d3d898a575867b11) doc: Port stdenv to Markdown
* [`e70d4b62`](https://github.com/NixOS/nixpkgs/commit/e70d4b62b6041a0e1749e91dbb3ff4fdd30f32a6) expliot: init at 0.9.6
* [`6596d10f`](https://github.com/NixOS/nixpkgs/commit/6596d10f1d37f5d24b2dfe75931983d3b63d0500) _3mux: 1.0.1 -> 1.1.0
* [`52426825`](https://github.com/NixOS/nixpkgs/commit/524268252d468095e38415684824e52b554f10d4) glow: 1.3.0 -> 1.4.0
* [`eb362f9a`](https://github.com/NixOS/nixpkgs/commit/eb362f9af966f04f74ee839f85562008a487eaf9) gnome3.hitori: 3.38.0 -> 3.38.1
* [`621f19d8`](https://github.com/NixOS/nixpkgs/commit/621f19d89c8af11b52bb50513558071ab7b7d139) calc: 2.12.8.2 -> 2.12.9.0
* [`b94530c5`](https://github.com/NixOS/nixpkgs/commit/b94530c576691c09ebd60b801a55aa8a59aa16a3) armadillo: 10.2.2 -> 10.3.0
* [`1a85b648`](https://github.com/NixOS/nixpkgs/commit/1a85b648af451f797f6c0866e1ed4d598659fbab) ticker: 3.1.9 -> 4.0.3
* [`88e379a2`](https://github.com/NixOS/nixpkgs/commit/88e379a2abbd985ae214f676d9535d11f9509736) tickrs: 0.14.1 -> 0.14.2
* [`d0cc6585`](https://github.com/NixOS/nixpkgs/commit/d0cc6585ee6cec9555a907025dcffb3faa3cdab0) orchis: 2021-01-22 -> 2021-02-28
* [`98c753c6`](https://github.com/NixOS/nixpkgs/commit/98c753c6626de8618016919df273bb1362329764) mark: 5.2.1 -> 5.2.2
* [`aa7d353c`](https://github.com/NixOS/nixpkgs/commit/aa7d353c75d8d67324fcd3364b07d877f31a0ac2) obsidian: 0.11.3 -> 0.11.5
* [`e9022849`](https://github.com/NixOS/nixpkgs/commit/e9022849e657c0f17b3fcd00167c0cdd0c6970cf) gofumpt: 0.1.0 -> 0.1.1
* [`43d381f9`](https://github.com/NixOS/nixpkgs/commit/43d381f918e8b9de2607d0a8a6db2747b961f9fd) progress: 0.15 -> 0.16
* [`d8a96e2f`](https://github.com/NixOS/nixpkgs/commit/d8a96e2f8f4fb578e70c005e3ecea763c73cff83) glab: 1.15.0 -> 1.16.0
* [`7dd7da52`](https://github.com/NixOS/nixpkgs/commit/7dd7da52014b280ffe6a67d3a49e7f20a0222c23) pspg: 4.3.0 -> 4.3.1
* [`243ddc22`](https://github.com/NixOS/nixpkgs/commit/243ddc22bf35670a716ff252ac7f3281b855f7e5) pentobi: 18.4 -> 18.5
* [`cac752ac`](https://github.com/NixOS/nixpkgs/commit/cac752acb21fce5e0575ded2734e63ad715176cc) osu-lazer: 2021.226.0 -> 2021.312.0
* [`bc1069bc`](https://github.com/NixOS/nixpkgs/commit/bc1069bcbdc22c092efd77dd6e8aa4739b7471a2) riscv-pk: riscv-pk-0.1pre438_e5846a2 -> 1.0.0
* [`44c21068`](https://github.com/NixOS/nixpkgs/commit/44c21068aeab776bb4ead395e3b8bef437977d98) spike: fix build
* [`85ad7501`](https://github.com/NixOS/nixpkgs/commit/85ad7501ec97903a3daa459c18141179234fb17e) nixos/tests/spike: Fix assertion
* [`29bf7e2b`](https://github.com/NixOS/nixpkgs/commit/29bf7e2b89110dfaa0821a432228cdea316cc793) jmol: 14.31.32 -> 14.31.34
* [`dd58f3ad`](https://github.com/NixOS/nixpkgs/commit/dd58f3ad13cec8c90d43e051e8cf5a1f50176889) firefox-bin: add pciutils to libPath
* [`8d301a28`](https://github.com/NixOS/nixpkgs/commit/8d301a28ad1e0d38e42adfed3b650b633ef64d0d) boundary: 0.1.7 -> 0.1.8
* [`6a99841c`](https://github.com/NixOS/nixpkgs/commit/6a99841c113d0d7baf3849087d2670f8f6bc4bed) go_1_15: 1.15.8 -> 1.15.10
* [`eecacdf3`](https://github.com/NixOS/nixpkgs/commit/eecacdf3d8d58ccc689b7194d33a5ba53a7bdd79) go_1_16: 1.16 -> 1.16.2
* [`0a5ef270`](https://github.com/NixOS/nixpkgs/commit/0a5ef27091b9a26c79a4b1d6679b0ca2891ce3a2) insomnia: 2020.5.2 -> 2021.1.0
* [`b40f1a81`](https://github.com/NixOS/nixpkgs/commit/b40f1a81189d7f88b4754c7f719e621e97139881) nats-streaming-server: 0.21.0 -> 0.21.1
* [`d908f40e`](https://github.com/NixOS/nixpkgs/commit/d908f40e8baee520953f9cfb91ae4476a02430c4) imgproxy: 2.16.0 -> 2.16.2
* [`9e6742b8`](https://github.com/NixOS/nixpkgs/commit/9e6742b8477a28966def4ed469e95ce184b08f2c) catcli: 0.6.1 -> 0.6.2
* [`8676e8fe`](https://github.com/NixOS/nixpkgs/commit/8676e8fe71f29065d3429898cda5f9b9c96e58f4) units: 2.19 -> 2.21
* [`ccf321f3`](https://github.com/NixOS/nixpkgs/commit/ccf321f37ab02c055cf474c59e7bffa6988cb813) worker: 4.5.0 -> 4.7.0
* [`2265051d`](https://github.com/NixOS/nixpkgs/commit/2265051d99e0e630255ead26f8ec091ee4a55ba9) snooze: 0.4 -> 0.5
* [`727471ee`](https://github.com/NixOS/nixpkgs/commit/727471ee5155982e0099925bc27ef8380b32d091) qstopmotion: 2.4.1 -> 2.5.2
* [`e56ce5e7`](https://github.com/NixOS/nixpkgs/commit/e56ce5e794cb41f7e6dd5e5e37558e9a7952163e) elpa-packages 2021-03-13
* [`49888798`](https://github.com/NixOS/nixpkgs/commit/49888798876c012cff86dd16d356395b66cd98ae) emacs.pkgs.org-packages: 2021-03-14
* [`2475b551`](https://github.com/NixOS/nixpkgs/commit/2475b551f27a67b747f47ee7d3147a4c9678bc22) emacs.pkgs.melpa-packages: 2021-03-14
* [`bd5c89a5`](https://github.com/NixOS/nixpkgs/commit/bd5c89a5e4840407e32cab7d70be59ed24d83b4a) python3Packages.incomfort-client: init at 0.4.5
* [`d4b5a9a6`](https://github.com/NixOS/nixpkgs/commit/d4b5a9a6075a0eeb0b81ac66f3694c818a8417fd) home-assistant: update component-packages
* [`87f4d7a0`](https://github.com/NixOS/nixpkgs/commit/87f4d7a07a076e4c879c213da3df7cfa62630cdc) nixos/printing: simplify filterGutenprint function
* [`e53f145c`](https://github.com/NixOS/nixpkgs/commit/e53f145c5c591ea5c7e6a3c57b2d743632d9ec0b) canon-cups-ufr2: small refactor
* [`3329093c`](https://github.com/NixOS/nixpkgs/commit/3329093c6aca716761a3d91089d49e5cbb873d77) Remove repeating words from doc
* [`03c98972`](https://github.com/NixOS/nixpkgs/commit/03c98972ccb194111a2a21e34822cedabbec12fa) cups-brother-hll2340dw: remove unreferenced top-level argument
* [`4c117adb`](https://github.com/NixOS/nixpkgs/commit/4c117adb7602ec5a06a4260f0c7b1694dfe82664) networkmanagerapplet: 1.18.0 -> 1.20.0
* [`151cc36b`](https://github.com/NixOS/nixpkgs/commit/151cc36b9511f33685d03fb7d831cc3a9825e0da) networkmanagerapplet: licence, drop unused args
* [`5bf3230f`](https://github.com/NixOS/nixpkgs/commit/5bf3230f6b26baa313a5300ad000e5c6a98db257) firmwareLinuxNonfree: fix fetching from git ([nixos/nixpkgs⁠#116306](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/116306))
* [`f7574a5c`](https://github.com/NixOS/nixpkgs/commit/f7574a5c8fefd86b50def1827eadb9b8cb266ffd) pika-backup: init at 0.2.1 ([nixos/nixpkgs⁠#115573](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115573))
* [`a79bb1c7`](https://github.com/NixOS/nixpkgs/commit/a79bb1c72b19495c593afb7b0da544101057802b) mkgmap: 4604 -> 4608
* [`03bc13f6`](https://github.com/NixOS/nixpkgs/commit/03bc13f68ccde33c6b6f6e3b49c55d20ac80b27c) python3Packages.adafruit-platformdetect: 3.3.0 -> 3.4.0
* [`2cbd01d2`](https://github.com/NixOS/nixpkgs/commit/2cbd01d244a6a5ad17fbedc981de77c610d5426c) newsflash: 1.3.0 -> 1.4.0
* [`92630146`](https://github.com/NixOS/nixpkgs/commit/92630146e1311152b2c6c1edde0361d80a6210a6) libxmlb: 0.2.1 -> 0.3.0
* [`d86882dd`](https://github.com/NixOS/nixpkgs/commit/d86882dd0f192dee1be08487e7b8647acf7518d9) nss: 3.60 -> 3.61
* [`16f10846`](https://github.com/NixOS/nixpkgs/commit/16f108467be3c9ed4db832256f4278ee0d49dd4b) rust-cbindgen: 0.15.0 -> 0.17.0
* [`a6136848`](https://github.com/NixOS/nixpkgs/commit/a613684873dbc71adde460f5ecbdabef28886515) firefox: 85.0.2 -> 86.0
* [`e73210fd`](https://github.com/NixOS/nixpkgs/commit/e73210fd67c3f81067c6120b8d03ce6b8466310a) nss: 3.61 -> 3.62
* [`a390e929`](https://github.com/NixOS/nixpkgs/commit/a390e92928384846eeabdca162d88f0917cf0072) firefox: 86.0 -> 86.0.1
* [`ddf18211`](https://github.com/NixOS/nixpkgs/commit/ddf18211121f8e03d3f626a7c8452f1edd92bdc6) tla-toolbox: 1.7.0 -> 1.7.1
* [`d516b27a`](https://github.com/NixOS/nixpkgs/commit/d516b27a1cfaa2c72cad68692acb17f094f7a04f) rmfuse: 0.1.1 -> 0.2.1
* [`e1ac66bd`](https://github.com/NixOS/nixpkgs/commit/e1ac66bd970b2a1d4a54d69a0a10a66a8db52f0c) s3backer: 1.5.4 -> 1.6.1
* [`7c14c1a8`](https://github.com/NixOS/nixpkgs/commit/7c14c1a8d0bdc2e773b30c04b01b435dd40cd211) pcb: 4.2.2 -> 4.3.0
* [`deefae97`](https://github.com/NixOS/nixpkgs/commit/deefae9708ca1446b65367ab99d6b72b84a3ca5a) luna-icons: 1.0 -> 1.1
* [`abb6266d`](https://github.com/NixOS/nixpkgs/commit/abb6266dbc7e305312431c99fd98310c13422be6) zcash: 4.1.1 -> 4.3.0 ([nixos/nixpkgs⁠#115463](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115463))
* [`7163929c`](https://github.com/NixOS/nixpkgs/commit/7163929ceece23d17f5198e35c0c2c6cff1bc625) doodle: 0.7.1 -> 0.7.2
* [`68b97478`](https://github.com/NixOS/nixpkgs/commit/68b974785c29c7e12498a281ef08260122606159) python3Packages.labgrid: 0.3.1 -> 0.3.2 ([nixos/nixpkgs⁠#116288](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/116288))
* [`bed86681`](https://github.com/NixOS/nixpkgs/commit/bed86681367c1f57324249db181d142e2efc1f0b) kubecfg: 0.17.0 -> 0.18.0 ([nixos/nixpkgs⁠#116150](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/116150))
* [`3210e915`](https://github.com/NixOS/nixpkgs/commit/3210e9158f2888c487eade7ec221c6a65cde1675) imagemagick6: 6.9.12-1 -> 6.9.12-3
* [`c528ddd2`](https://github.com/NixOS/nixpkgs/commit/c528ddd2da8ebe1c441f4ebde6ff5757673127d0) imagemagick6: add erictapen as maintainer
* [`e4988898`](https://github.com/NixOS/nixpkgs/commit/e49888983dbc597942bddfe6311ce15c7c277585) steam: xlibs -> xorg
* [`63eb38c8`](https://github.com/NixOS/nixpkgs/commit/63eb38c8e3499c64d5662cb091ad333d942ca9c3) prime-server: 0.6.7 -> 0.7.0
* [`6340e3af`](https://github.com/NixOS/nixpkgs/commit/6340e3af68023fcaef6ec1adb081164d1bd6258c) libebml: 1.4.1 -> 1.4.2
* [`ad4daeef`](https://github.com/NixOS/nixpkgs/commit/ad4daeefbd7f007862b950ccc75687bf91f991a3) libmatroska: 1.6.2 -> 1.6.3
* [`9235d126`](https://github.com/NixOS/nixpkgs/commit/9235d126cc377991479a81baac041040aef06d3c) mkvtoolnix: 53.0.0 -> 55.0.0
* [`0af0c5c8`](https://github.com/NixOS/nixpkgs/commit/0af0c5c8e79609c06a5532ab2a58d2f7c55e3c9a) osinfo-db: 20210215 -> 20210312
* [`4c0404ea`](https://github.com/NixOS/nixpkgs/commit/4c0404ea17314c82a6420f7cf4d9d1c9c658a1d7) python38Packages.bitarray: 1.7.0 -> 1.7.1
* [`ca4406f3`](https://github.com/NixOS/nixpkgs/commit/ca4406f30f741b3cbb728b3fc64a3413c1b790c1) python3Packages.evohome-async: init at 0.3.8
* [`46d8354a`](https://github.com/NixOS/nixpkgs/commit/46d8354af1a0866c9ec613b6056e3334c8821217) home-assistant: update component-packages
* [`b8f974d8`](https://github.com/NixOS/nixpkgs/commit/b8f974d8a75ccf9b3234c2904afa7af461531ca2) smplayer: 20.6.0 -> 21.1.0
* [`b78770a1`](https://github.com/NixOS/nixpkgs/commit/b78770a1ee898a105f55fab5ed78446dfd82a7c9) renderdoc: 1.11 -> 1.12
* [`d5930430`](https://github.com/NixOS/nixpkgs/commit/d59304307ec68c77ee010688130ffe8d1a5081d3) python3Packages.azure-core: 1.10.0 -> 1.12.0
* [`f4e050e0`](https://github.com/NixOS/nixpkgs/commit/f4e050e01f82923d6b84d576d276f8c5d4fa8ea0) python3Packages.azure-eventgrid: 1.3.0 -> 2.0.0
* [`f6a6ee6b`](https://github.com/NixOS/nixpkgs/commit/f6a6ee6b477e76217f1146361b3f5da213813623) python3Packages.azure-mgmt-applicationinsights: 0.3.0 -> 1.0.0
* [`95b8b0d2`](https://github.com/NixOS/nixpkgs/commit/95b8b0d25683a5048f7625496de0d53150e715c6) python3Packages.azure-mgmt-compute: 18.1.0 -> 19.0.0
* [`fe74a7c7`](https://github.com/NixOS/nixpkgs/commit/fe74a7c71b080a99e96ca12fd6175aaa73fa68c6) python3Packages.azure-mgmt-kusto: 0.10.0 -> 1.0.0
* [`51462cec`](https://github.com/NixOS/nixpkgs/commit/51462cec1f71aa844c4af74a44434179c07a036c) python3Packages.azure-storage-blob: 12.7.1 -> 12.8.0
* [`1591e296`](https://github.com/NixOS/nixpkgs/commit/1591e296e77a8a3c7710a71227681d22fbb7ae24) python3Packages.msal: 1.8.0 -> 1.10.0
* [`4d711898`](https://github.com/NixOS/nixpkgs/commit/4d711898ef5d7971b7fbf06bf706a88231b4acc5) python3Packages.msrest: 0.6.19 -> 0.6.21
* [`3595db38`](https://github.com/NixOS/nixpkgs/commit/3595db38cd6b48fb10880f25ee31b79070a995f6) python3Packages.azure-multiapi-storage: 0.4.1 -> 0.6.0
* [`b32c4fc4`](https://github.com/NixOS/nixpkgs/commit/b32c4fc4573adcb3b60375e225d652a5231bd7f0) azure-cli: 2.18.0 -> 2.20.0
* [`2146f32a`](https://github.com/NixOS/nixpkgs/commit/2146f32a18520b4ce8fd18f45955669e08254856) python3Packages.azure*: remove unused imports
* [`6a36b730`](https://github.com/NixOS/nixpkgs/commit/6a36b730ae553ea237c049585a445d5bb8dd48bf) solc: 0.7.4 -> 0.8.2
* [`cbce4e76`](https://github.com/NixOS/nixpkgs/commit/cbce4e76d3e9b43b6987841deaa960ce197f846a) solc: make linux only
