### PR TITLE
niv home-manager: update 040ea28e -> 07f6c648

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "040ea28e448a93d24540b7cf2eda4b25300c5ab1",
-        "sha256": "0llviiyi3crf3giq95d1xa6zjvrf6rndjr36r4mqcyh6qk903v7r",
+        "rev": "07f6c6481e0cbbcaf3447f43e964baf99465c8e1",
+        "sha256": "0f3r4yjlysglx9a2z0qpinzilv0rhh5kdc3f0d003695yhgay7hm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/040ea28e448a93d24540b7cf2eda4b25300c5ab1.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/07f6c6481e0cbbcaf3447f43e964baf99465c8e1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@040ea28e...07f6c648](https://github.com/nix-community/home-manager/compare/040ea28e448a93d24540b7cf2eda4b25300c5ab1...07f6c6481e0cbbcaf3447f43e964baf99465c8e1)

* [`a4e14669`](https://github.com/nix-community/home-manager/commit/a4e146693edb4fe24f448a008ec984184542df34) starship: use formats.toml to generate configuration
* [`19c7d4e2`](https://github.com/nix-community/home-manager/commit/19c7d4e29f4e696c77e6305041d29c55d379f464) nushell: use formats.toml to generate configuration
* [`42bb5535`](https://github.com/nix-community/home-manager/commit/42bb553544420942415257fb2d3938698b27d72d) broot: use formats.toml to generate configuration
* [`1ee1835a`](https://github.com/nix-community/home-manager/commit/1ee1835a3ee303bb694dbe06b4e85b1dc0a03b91) lsd: add support for config file
* [`07f6c648`](https://github.com/nix-community/home-manager/commit/07f6c6481e0cbbcaf3447f43e964baf99465c8e1) lsd: use explicit path for aliases
