### PR TITLE
niv nixpkgs: update 63a9f162 -> 342c7e72

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63a9f162355ec84c423690869a97848d73409fb8",
-        "sha256": "0k2xynqmnmr9l1d36lg4f5akvrhjs7vp474px5d22pr4pyjpka51",
+        "rev": "342c7e724eb7fb1f60da3eaf082cfe6ea0df1e8f",
+        "sha256": "169y41f0qmy32cc55rmlfrj74j2az5dsinn8am4ibn7n83qn57hk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/63a9f162355ec84c423690869a97848d73409fb8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/342c7e724eb7fb1f60da3eaf082cfe6ea0df1e8f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@63a9f162...342c7e72](https://github.com/nixos/nixpkgs/compare/63a9f162355ec84c423690869a97848d73409fb8...342c7e724eb7fb1f60da3eaf082cfe6ea0df1e8f)

* [`ef3912b3`](https://github.com/NixOS/nixpkgs/commit/ef3912b34c27e25b2a6c6c9f77a695d12bb4ae35) python3Packages.packageurl-python: init at 0.9.4
* [`9716c448`](https://github.com/NixOS/nixpkgs/commit/9716c4487e38a9dba488b93543f0a39b92762b44) python3Packages.pytest-dependency: Fix build with pytest ≥ 6.2.0
* [`ac1d24c9`](https://github.com/NixOS/nixpkgs/commit/ac1d24c91176805a561116fbc5be249e96180717) jetbrains: updates ([nixos/nixpkgs⁠#116595](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/116595))
* [`970f8cae`](https://github.com/NixOS/nixpkgs/commit/970f8caef444a856a852179efd5852aaea8082d6) python3Packages.glances-api: 0.2.0 -> 0.2.1
* [`8bd88d96`](https://github.com/NixOS/nixpkgs/commit/8bd88d96cced71033a26cb8f4ab8bf123977376e) python3Packages.volkszaehler: 0.2.1 -> 0.2.2
* [`f3ed3bbd`](https://github.com/NixOS/nixpkgs/commit/f3ed3bbd3649f41aeef474a1b80f646cc42033dd) python3Packages.python-opendata-transport: 0.2.1 -> 0.2.2
* [`3fc0f7ab`](https://github.com/NixOS/nixpkgs/commit/3fc0f7abcda1ae78a6d6df1add5cf01cd9c595f2) rsbep: 0.1.0 -> 0.2.0
* [`10434a04`](https://github.com/NixOS/nixpkgs/commit/10434a0466664c82787beb4f966d144e6d5cd16c) python3Packages.netdata: 0.2.0 -> 0.2.1
* [`729a67a3`](https://github.com/NixOS/nixpkgs/commit/729a67a3c216f93e5b4973bdcd758645b009ef39) python3Packages.opensensemap-api: 0.1.5 -> 0.1.6
* [`b3287e86`](https://github.com/NixOS/nixpkgs/commit/b3287e8650fb60f56a426819220a3f288732e4ea) findomain: specify license
* [`bbcb9126`](https://github.com/NixOS/nixpkgs/commit/bbcb91266661c367111127bc7cd4dbc00a11e7bb) assh: set version
* [`6d92b004`](https://github.com/NixOS/nixpkgs/commit/6d92b004ceca0c45055be7c1d1d8721ea0d60055) python3Packages.simplisafe-python: init at 9.6.9
* [`8e0d487e`](https://github.com/NixOS/nixpkgs/commit/8e0d487ed00657b18162009b186e363e76ca208e) home-assistant: update component-packages
* [`8ba0c688`](https://github.com/NixOS/nixpkgs/commit/8ba0c68815b293a7c749d58576fca34a1211d9e7) home-assistant: enable simplisafe tests
* [`13f2a8f9`](https://github.com/NixOS/nixpkgs/commit/13f2a8f99170479eaffdd5049c9970e04e06bfbd) python3Packages.aionotion: init at 3.0.1
* [`6022ca6e`](https://github.com/NixOS/nixpkgs/commit/6022ca6e0b6a67ab1b38258ce7cd018d9d2f7e01) home-assistant: update component-packages
* [`b9375be5`](https://github.com/NixOS/nixpkgs/commit/b9375be57e70a1c266d30580108f41b671f63911) home-assistant: enable notion tests
* [`4bd8ad43`](https://github.com/NixOS/nixpkgs/commit/4bd8ad4380479abc38567967c3b4bf33fac76fb5) qtstyleplugins: fix gtk2 background
* [`0b018a7a`](https://github.com/NixOS/nixpkgs/commit/0b018a7a6571866bbe7695684b18c741a3eff29d) emacs.pkgs.elpa-packages: 2021-03-21
* [`78556a8f`](https://github.com/NixOS/nixpkgs/commit/78556a8f234ebba89d6db5e77824b07753c8f9b8) emacs.pkgs.org-packages: 2021-03-21
* [`3017b247`](https://github.com/NixOS/nixpkgs/commit/3017b247c5ee97449ced8a04fc832775e51f63a3) emacs.pkgs.melpa-packages: 2021-03-21
* [`8efca926`](https://github.com/NixOS/nixpkgs/commit/8efca926314ac3634fd306a1fd06e2d07fa270ba) surface-control: 0.3.1-1 -> 0.3.1-2
* [`bf4a3c20`](https://github.com/NixOS/nixpkgs/commit/bf4a3c208e54c909e2e86497854a3be0304abb89) logseq: init at 0.0.13
* [`594ebb5a`](https://github.com/NixOS/nixpkgs/commit/594ebb5ade85702f6d7a1c9e2cd7bfa1c22a344a) maintainers: add weihua
* [`10422678`](https://github.com/NixOS/nixpkgs/commit/10422678bc95785677ff787a41926514221de93b) python3.pkgs.django-cacheops: init at 5.1 ([nixos/nixpkgs⁠#115916](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115916))
* [`efb1815d`](https://github.com/NixOS/nixpkgs/commit/efb1815d1bcac7de4f32d5849558f6472aa4f683) zen-kernels: 5.11.1 -> 5.11.5 ([nixos/nixpkgs⁠#115920](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115920))
* [`4ce3e862`](https://github.com/NixOS/nixpkgs/commit/4ce3e862ceb8af52f7dca9f28b97db101b5c8ae8) librecad: 2.2.0-rc1 -> 2.2.0-rc2
* [`ef5d88f0`](https://github.com/NixOS/nixpkgs/commit/ef5d88f0819f259d0e7ef9bb5d1f7804bd25ce91) past-time: init at 0.2.1
* [`46fe4032`](https://github.com/NixOS/nixpkgs/commit/46fe40324a39f950b7e25dfb2259cb287fe2a87f) home-assistant: enable iaqualink tests
* [`2fbcbe20`](https://github.com/NixOS/nixpkgs/commit/2fbcbe203b977d4441edc15d799ea965c9816d32) notcurses: 2.1.5 -> 2.2.2
* [`83222170`](https://github.com/NixOS/nixpkgs/commit/832221706d7384e34dc094b5465c1a230d9b457b) trunk: init at 0.10.0
* [`e979d9f5`](https://github.com/NixOS/nixpkgs/commit/e979d9f55dc5c03b64374490267699dd15ce3223) unciv: 3.13.7-patch2 -> 3.13.8
* [`2720de62`](https://github.com/NixOS/nixpkgs/commit/2720de622b88ef06f1c26dd9cc0b30f2a5d82462) python3Packages.mplfinance: init at 0.12.7a7 ([nixos/nixpkgs⁠#116728](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/116728))
* [`46318ab4`](https://github.com/NixOS/nixpkgs/commit/46318ab4df63b5d68d377ed00c050ad30a06c00f) vivaldi: 3.6.2165.36-1 -> 3.7.2218.45-1
* [`cce9a296`](https://github.com/NixOS/nixpkgs/commit/cce9a296bd8856190e8bee8218809c09ca1d49c0) .github/workflows/labels.yml: label PRs
* [`13e762e9`](https://github.com/NixOS/nixpkgs/commit/13e762e940885436a750cff0975fdea045442c9c) .github/labeler.yml: update paths and sort
* [`b40a3018`](https://github.com/NixOS/nixpkgs/commit/b40a3018e7e776321015a2a3508a077a74d10916) demjson: add top level entry
* [`623eda1a`](https://github.com/NixOS/nixpkgs/commit/623eda1ac2cc8f644eacd318f770c77eea786292) j2cli: add top level entry
* [`3cbaf6d7`](https://github.com/NixOS/nixpkgs/commit/3cbaf6d73d7eb4582690182e17f54dd4c956f54f) hjson: add top level entry
* [`e020ff5d`](https://github.com/NixOS/nixpkgs/commit/e020ff5db69b7a4e404f41c50f094e2f914bc66f) beancount: 2.3.3 -> 2.3.4
* [`7cdf1862`](https://github.com/NixOS/nixpkgs/commit/7cdf18620323b135233c2c1eeee3973f06960f78) discover: add missing dependencies
* [`615e63c4`](https://github.com/NixOS/nixpkgs/commit/615e63c43235a4c007e8ef7837192ccec0d1fb97) sddm-kcm: add missing dependencies
* [`e3e8b48c`](https://github.com/NixOS/nixpkgs/commit/e3e8b48ca6fe4b87fd8b3f234d4aa5f79cf37f90) spidermonkey_60: drop
* [`cfce5158`](https://github.com/NixOS/nixpkgs/commit/cfce5158023892d30a18d57ba006fba05aa73055) home-assistant: pin iaqualink at 0.3.4
* [`3a1268fa`](https://github.com/NixOS/nixpkgs/commit/3a1268fa04720bcf3dbaf4b1ccc37bdf80c6866e) python38Packages.casbin: 0.18.4 -> 0.19.1
* [`2ace9b68`](https://github.com/NixOS/nixpkgs/commit/2ace9b682dc6eec92728127495958a128090cfd1) python38Packages.django-simple-captcha: 0.5.13 -> 0.5.14
* [`27f1e2b7`](https://github.com/NixOS/nixpkgs/commit/27f1e2b7b12f8813cb32919c660cd11319cd8822) python38Packages.avro-python3: 1.10.1 -> 1.10.2
* [`9c0b4459`](https://github.com/NixOS/nixpkgs/commit/9c0b4459a51ae728816d332cfb4c8f9a7a2da55b) python38Packages.azure-mgmt-marketplaceordering: 1.0.0 -> 1.1.0
* [`434768ad`](https://github.com/NixOS/nixpkgs/commit/434768ad6435a927d92fd40ecae93a7d086c6b67) gnome-podcasts: don't mark as broken
* [`bbecd2a7`](https://github.com/NixOS/nixpkgs/commit/bbecd2a7a1660e28ef98f4b1d73df3013a809871) fractal: don't mark as broken
* [`b3172906`](https://github.com/NixOS/nixpkgs/commit/b3172906a7edad73199acddd8e738a2715345c16) apfs-fuse: 2019-07-23 -> 2020-09-28 ([nixos/nixpkgs⁠#112937](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/112937))
* [`c9699e50`](https://github.com/NixOS/nixpkgs/commit/c9699e502db91545d73ad028c22f97449b0fef4a) gallery-dl: 1.17.0 -> 1.17.1
* [`e87ec307`](https://github.com/NixOS/nixpkgs/commit/e87ec30710345ca9de8b8587b615fee4e68e7875) python38Packages.bayespy: 0.5.21 -> 0.5.22
* [`99a25148`](https://github.com/NixOS/nixpkgs/commit/99a25148e8db244ab3e2f7865789c5237a46b29c) rocksdb: 6.15.5 -> 6.17.3
* [`9105a6aa`](https://github.com/NixOS/nixpkgs/commit/9105a6aab8491bef5e5aab1543061858034d3322) jackett: 0.17.668 -> 0.17.699
* [`32b5606e`](https://github.com/NixOS/nixpkgs/commit/32b5606e9e634bfa13d434ee157439d88f320507) pt2-clone: 1.28 -> 1.29
* [`e3307308`](https://github.com/NixOS/nixpkgs/commit/e3307308fa8de6b93055917a7dddb92e6d76df1d) python38Packages.jupyter_console: 6.2.0 -> 6.3.0
* [`e468ecbf`](https://github.com/NixOS/nixpkgs/commit/e468ecbf8a016b8301279f286e13a79b880e4259) go-org: init at 1.4.0
* [`9832a6fa`](https://github.com/NixOS/nixpkgs/commit/9832a6fa5fa815c807a5bc1edfb9ae4963c196a7) miniserve: 0.11.0 -> 0.12.0
* [`87b5c574`](https://github.com/NixOS/nixpkgs/commit/87b5c5748082ff0b11949d64e7aa3eb5e8e9a3a2) mimalloc: 1.6.7 -> 2.0.0
* [`fa6c8b65`](https://github.com/NixOS/nixpkgs/commit/fa6c8b656b72dfa97d7a5aa9892569fd6eb64dfc) macfuse-stubs: init at 4.0.4
* [`3a4c9d4b`](https://github.com/NixOS/nixpkgs/commit/3a4c9d4b62213c7932ceb811c3278313ae099037) llfuse: fix darwin build
* [`6cdd3438`](https://github.com/NixOS/nixpkgs/commit/6cdd34382a04c3af313beda0091781270513d781) libquotient: 0.6.5 -> 0.6.6
* [`870b0dd8`](https://github.com/NixOS/nixpkgs/commit/870b0dd84d0826a7f3cacde5389c39cd0c947738) noweb: add useIcon boolean arg
* [`fc345a51`](https://github.com/NixOS/nixpkgs/commit/fc345a51dd818e06cafe7f265976b83ff2a61142) munin: 2.0.65 -> 2.0.66
* [`9a00d766`](https://github.com/NixOS/nixpkgs/commit/9a00d76624abfccb763be63f29f9b3398adfd20b) python3Packages.PyChromecast: 8.1.0 -> 9.1.1
* [`b8a4d564`](https://github.com/NixOS/nixpkgs/commit/b8a4d564f0c9b5f7cefd3287c01f2c4a6b191da9) python3Packages.aioresponses: 0.7.1 -> 0.7.2
* [`4b902164`](https://github.com/NixOS/nixpkgs/commit/4b9021644ca2f127ea4b17fdc4cba58eeb573132) python3Packages.aioresponses: update test part
* [`05aa0823`](https://github.com/NixOS/nixpkgs/commit/05aa0823a89f5c986523297149b2376974448377) python3Packages.asdf: 2.7.1 -> 2.7.3
* [`1519f8f9`](https://github.com/NixOS/nixpkgs/commit/1519f8f976f39b4527d81ba9edc26ae31550498f) python3Packages.asdf: switch to pytestCheckHook
* [`c20cd183`](https://github.com/NixOS/nixpkgs/commit/c20cd1834f675153f87bb8544053b4069688f0c8) sane-backends: 1.0.30 -> 1.0.32
* [`bab28cf3`](https://github.com/NixOS/nixpkgs/commit/bab28cf36c8b414f87491e9f926bbc7cd59faf3d) automaticcomponenttoolkit: init at 1.6.0
* [`1a5ccd13`](https://github.com/NixOS/nixpkgs/commit/1a5ccd133975c33f6ef65dd762eb854aef8bea06) lib3mf: 2.0.0 -> 2.1.1
* [`4660c8c1`](https://github.com/NixOS/nixpkgs/commit/4660c8c1531106f3dd5f46565e3014038c457f8e) maintainers: add maxeaubrey to the gnome team
* [`520689c0`](https://github.com/NixOS/nixpkgs/commit/520689c01eaa6de474b83f29d186236a6c5ff358) libsForQt5.qwt: 6.1.5 -> 6.1.6
* [`8c4b85db`](https://github.com/NixOS/nixpkgs/commit/8c4b85dbca14379ab56f7ff83199de7a8968e57b) vimPlugins: update
* [`85d8cdd8`](https://github.com/NixOS/nixpkgs/commit/85d8cdd866f15c315c554e3cde63c0597fcd12b7) vimPlugins.nginx-vim: init at 2021-02-25
* [`302103b7`](https://github.com/NixOS/nixpkgs/commit/302103b7149f8ce494be5a5d7664b9eb87510c03) balanceofsatoshis: init at 8.0.2
* [`d1cac719`](https://github.com/NixOS/nixpkgs/commit/d1cac719480b485c971897e6a3724717ba664067) python3Packages.influxdb: disable failing test
* [`827f213f`](https://github.com/NixOS/nixpkgs/commit/827f213fb29c346c8977cc70c3adc164e349ae10) flashfocus: don't use python3Packages.callPackage ([nixos/nixpkgs⁠#117027](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117027))
* [`42f157fd`](https://github.com/NixOS/nixpkgs/commit/42f157fd07d870ef0cacd1f5c6a0ba4d6eaecf05) mapbox-gl-native: use upstream version, unvendor rapidjson, and move to libsForQt5
* [`cccebb6f`](https://github.com/NixOS/nixpkgs/commit/cccebb6f372d2fdf5110e3db5cf9fb459fe9fda4) mapbox-gl-qml: 1.7.5 -> 1.7.6 and move to libsForQt5
* [`7a0533d4`](https://github.com/NixOS/nixpkgs/commit/7a0533d43802698f69547a68358b41a4bfc79941) bs-platform: remove myself from maintainers
* [`fc0f84cf`](https://github.com/NixOS/nixpkgs/commit/fc0f84cfe1f75a6b94a2377d079a0dc27f95e50b) teler: set version
* [`669cfc19`](https://github.com/NixOS/nixpkgs/commit/669cfc195fe46dc6b89ac7ad2c6f403c7457c0f9) ocaml-lsp, lsp, jsonrpc: allow overriding the source globally
* [`e36737f7`](https://github.com/NixOS/nixpkgs/commit/e36737f7bdae26341a75e420dc9df2a625b93b26) semantik: Init at 1.2.5 ([nixos/nixpkgs⁠#95818](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/95818))
* [`ac295b38`](https://github.com/NixOS/nixpkgs/commit/ac295b38f1c99ccd2e15c20f0e1da4df3dd6e383) vimPlugins: update
* [`fac96abe`](https://github.com/NixOS/nixpkgs/commit/fac96abe50c7a115f1a43c6752f1ad752f784d2d) vimPlugins.rspec-vim: init at 2020-08-20
* [`5427f2a8`](https://github.com/NixOS/nixpkgs/commit/5427f2a847ff8abb0465d51849b70134a7ba6686) tre-command: 0.3.4 -> 0.3.5
* [`898232ad`](https://github.com/NixOS/nixpkgs/commit/898232add704e8b8566636e28ba7565dfd242ac7) epkowa: update iscan-data 1.39.1-2 -> 1.39.2-1
* [`c37afee5`](https://github.com/NixOS/nixpkgs/commit/c37afee5550afc1a9935e42a859529dbb294d11d) sqlmap: 1.4.12 -> 1.5.3
* [`f7ac029a`](https://github.com/NixOS/nixpkgs/commit/f7ac029a1dec02245c057f967a324b7e3eecd5fb) rofi: Add option to symlink dmenu ([nixos/nixpkgs⁠#107146](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/107146))
* [`c78e0e37`](https://github.com/NixOS/nixpkgs/commit/c78e0e376c7175cfc00ed38684e1b4d9b54acaf6) plasma-systemmonitor: init at 5.21.1
* [`ed9ddeb1`](https://github.com/NixOS/nixpkgs/commit/ed9ddeb1426f4198abed10bbbe41a033a8b22f3e) vulkan-validation-layers: fix bug related to XDG_DATA_DIRS ([nixos/nixpkgs⁠#106085](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/106085))
* [`6fe6c35a`](https://github.com/NixOS/nixpkgs/commit/6fe6c35a9660a18cdf93b99f141a5b9a0eb06be5) kodi.packages.buildKodiAddon, kodi.packages.buildKodiBinaryAddon: include runHook preInstall and postInstall
* [`d9b776a3`](https://github.com/NixOS/nixpkgs/commit/d9b776a3a26a8a55dd1b531e331670dc6be15bc9) kodi.packages.jellyfin: init at 0.7.1
* [`ef2ac476`](https://github.com/NixOS/nixpkgs/commit/ef2ac47659e70aa5b94fc128ee273bfd52df79d7) python38Packages.avro: 1.10.1 -> 1.10.2
* [`e3e54e60`](https://github.com/NixOS/nixpkgs/commit/e3e54e6001d8c032daf8dc9b970fa509df0550a8) kodi.packages.netflix: add inputstream-adaptive dependency
* [`13bee29b`](https://github.com/NixOS/nixpkgs/commit/13bee29b9b7e8dc04e6212ceb2704530d38c86a9) restic: allow prune without backup
