### PR TITLE
niv home-manager: update 07f6c648 -> ddcd4766

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07f6c6481e0cbbcaf3447f43e964baf99465c8e1",
-        "sha256": "0f3r4yjlysglx9a2z0qpinzilv0rhh5kdc3f0d003695yhgay7hm",
+        "rev": "ddcd476603dfd3388b1dc8234fa9d550156a51f5",
+        "sha256": "0amckzfnpldw8hpzgcdp8qqbd91g15dhgaw8mkkb3sghvig0380k",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/07f6c6481e0cbbcaf3447f43e964baf99465c8e1.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/ddcd476603dfd3388b1dc8234fa9d550156a51f5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@07f6c648...ddcd4766](https://github.com/nix-community/home-manager/compare/07f6c6481e0cbbcaf3447f43e964baf99465c8e1...ddcd476603dfd3388b1dc8234fa9d550156a51f5)

* [`b42d987a`](https://github.com/nix-community/home-manager/commit/b42d987ad917edf315bf8d0d6350498d357c5d41) neovim: fall back to plugin name if no pname ([nix-community/home-manager⁠#1864](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1864))
* [`920ea74a`](https://github.com/nix-community/home-manager/commit/920ea74afee92d321a4ff7dc714b165daaad78ec) flake.nix: add nixosModule and darwinModule to outputs ([nix-community/home-manager⁠#1858](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1858))
* [`ffbc3819`](https://github.com/nix-community/home-manager/commit/ffbc3819e4f8aedb0bbd3a12e3dc70e35c0dbcea) prezto: fix environment files being overwritten ([nix-community/home-manager⁠#1863](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1863))
* [`6245dd11`](https://github.com/nix-community/home-manager/commit/6245dd11cf59698aacdf8b153e3e7070abbef36f) chromium: remove 'extensions' option for proprietary Chrome versions ([nix-community/home-manager⁠#1867](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1867))
* [`de1fa8de`](https://github.com/nix-community/home-manager/commit/de1fa8defbdc9b3330858d2686f37af86b29ca6e) docs: fix darwin-rebuild command ([nix-community/home-manager⁠#1869](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1869))
* [`f9b5172d`](https://github.com/nix-community/home-manager/commit/f9b5172d956c79add5f6c8acccea2c7ca7f904c9) jq: Use default upstream values for colors ([nix-community/home-manager⁠#1870](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1870))
* [`f30b62a7`](https://github.com/nix-community/home-manager/commit/f30b62a74d05e055208bea448442b9fc483e9fa5) git: install delta when it's enabled ([nix-community/home-manager⁠#1866](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1866))
* [`ddcd4766`](https://github.com/nix-community/home-manager/commit/ddcd476603dfd3388b1dc8234fa9d550156a51f5) termite: remove use of package alias
