### PR TITLE
niv nixpkgs-fmt: update 3ef5622f -> 851b39bf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "3ef5622f1cd70f4bb6af553893306a77a12d367b",
-        "sha256": "1fb2mm1y2qb3imc48g2ad3rdbjlj326cggrc4hvdc0fb41vxinpp",
+        "rev": "851b39bffdd86d8852372100bfe4bfc46bc0e346",
+        "sha256": "1c5kis36cmq14x2lpizn7lrhkdxnjxmwmrnqzdb6lxpnaqmmr5q6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/3ef5622f1cd70f4bb6af553893306a77a12d367b.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/851b39bffdd86d8852372100bfe4bfc46bc0e346.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@3ef5622f...851b39bf](https://github.com/nix-community/nixpkgs-fmt/compare/3ef5622f1cd70f4bb6af553893306a77a12d367b...851b39bffdd86d8852372100bfe4bfc46bc0e346)

* [`ac2557a3`](https://github.com/nix-community/nixpkgs-fmt/commit/ac2557a3f21ead390510388a841319f7a0a09297) update vscode's setting.json
* [`d549bfd8`](https://github.com/nix-community/nixpkgs-fmt/commit/d549bfd8dedbe97b47575e395ac2d228fcacd26c) refactor block comment formatting
* [`90be3a6b`](https://github.com/nix-community/nixpkgs-fmt/commit/90be3a6b931c1083572a1fb090b28f6ea5de7e60) add and fix new test_date to match the new block comment formatting
