### PR TITLE
niv powerlevel10k: update d28e84ca -> 58f5470c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "d28e84ca7061c43c49c91059d15b49bc5859a3a7",
-        "sha256": "1i4saf5k3kmsz36wdyg03lhfa910fb0iabxmf9rayaxd59f0z10p",
+        "rev": "58f5470cd98343581853dafe2a99430c0a6975e5",
+        "sha256": "059bnbd419il4acbalwsdlnxbr8c29cqiw17ch0b8137xqhz4f0s",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/d28e84ca7061c43c49c91059d15b49bc5859a3a7.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/58f5470cd98343581853dafe2a99430c0a6975e5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@d28e84ca...58f5470c](https://github.com/romkatv/powerlevel10k/compare/d28e84ca7061c43c49c91059d15b49bc5859a3a7...58f5470cd98343581853dafe2a99430c0a6975e5)

* [`7d786b9c`](https://github.com/romkatv/powerlevel10k/commit/7d786b9c50913028eec0463c5cca00796633997f) remove all CR from prompt ([romkatv/powerlevel10k⁠#1304](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1304) and [romkatv/powerlevel10k⁠#1305](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1305))
* [`58f5470c`](https://github.com/romkatv/powerlevel10k/commit/58f5470cd98343581853dafe2a99430c0a6975e5) Add font configuration instructions for WezTerm ([romkatv/powerlevel10k⁠#1313](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1313))
