### PR TITLE
niv spacemacs: update 7d2ff48d -> 3fe675d5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "7d2ff48d77a1591d6ac91a5cb321f9e7371af15d",
-        "sha256": "0c09zymkgp1xml4izwmg4cf61nyp2zracw008h127sxd11h37f1y",
+        "rev": "3fe675d588889c2afa5bd0494d2497b626250495",
+        "sha256": "05mxfj764f3h4pnz5d0fnwk66j2d5sdin52h3d55g11ihg94m8sm",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/7d2ff48d77a1591d6ac91a5cb321f9e7371af15d.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/3fe675d588889c2afa5bd0494d2497b626250495.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@7d2ff48d...3fe675d5](https://github.com/syl20bnr/spacemacs/compare/7d2ff48d77a1591d6ac91a5cb321f9e7371af15d...3fe675d588889c2afa5bd0494d2497b626250495)

* [`60185809`](https://github.com/syl20bnr/spacemacs/commit/6018580958211a80870d09ee632766a248801ec4) Make layers activate/deactivate the right version of smartparens
* [`cd254057`](https://github.com/syl20bnr/spacemacs/commit/cd254057813460c00607af31184c2a388c7013e5) Make smartparens toggles activate/deactivate the right modes
* [`9ff20047`](https://github.com/syl20bnr/spacemacs/commit/9ff2004706eadf18cf63b7367b7f9836c28de13f) Avoid special handling of smartparens in lisp layers
* [`8f854da6`](https://github.com/syl20bnr/spacemacs/commit/8f854da6498aae72b43b087a2f3c50f6c297c1ee) Make auto-completion activate/deactivate smartparens properly
* [`780a96cf`](https://github.com/syl20bnr/spacemacs/commit/780a96cfacb4236f825773406b5cc703ba486d9a) [org] Fix unsupported fuzzy link in docs
* [`0f2df272`](https://github.com/syl20bnr/spacemacs/commit/0f2df2727d2896261c17ee31a44e34a888e79c81) Validate .spacemacs variables.
* [`4a4557c3`](https://github.com/syl20bnr/spacemacs/commit/4a4557c3c80ccf59bcc2671e09bfee862d694363) [ci] Update built_in_manifest, add frame and zoom packages
* [`b86c619c`](https://github.com/syl20bnr/spacemacs/commit/b86c619cb6264acd14c2cfabacf516f9b9c753b5) Built-in files auto-update: Thu Mar 18 14:37:56 UTC 2021
* [`8c43115a`](https://github.com/syl20bnr/spacemacs/commit/8c43115a63ab477656e610b3b3732548ace672d7) Ensure required arguments of macro spacemacs|define-custom-layout
* [`bbf05073`](https://github.com/syl20bnr/spacemacs/commit/bbf050734af0a3c2e2d5360a2ade735f581c5eb9) Don't show customize link in doc-strings of uncustomizable  variables.
* [`369cf751`](https://github.com/syl20bnr/spacemacs/commit/369cf7519f0bdf90d9e4285d4114b0cd42a49a33) Improve spacemacs|defc doc-string
* [`da00174c`](https://github.com/syl20bnr/spacemacs/commit/da00174c11739e38a663eca71f456d41bdf961af) Fix SPC h SPC, void smartparens-mode
* [`b71e5fdb`](https://github.com/syl20bnr/spacemacs/commit/b71e5fdb179d7fdba92f80ce07aedbfb70339411) Enhance shell-default-position validation spec
* [`8f1b6b1e`](https://github.com/syl20bnr/spacemacs/commit/8f1b6b1e0471dbe1c5e5ea552b3690a50edd5e33) Prefer downloading org-appear from melpa
* [`454e729e`](https://github.com/syl20bnr/spacemacs/commit/454e729ef08e0da7da391f82d8f0bc0183a8605f) In SPC h d P, print :toggle expression using Elisp syntax
* [`9e4845b9`](https://github.com/syl20bnr/spacemacs/commit/9e4845b9139083b2741954ec0b9820c3157d5911) Hide drag stuff modeline indicator
* [`d6eb0f9f`](https://github.com/syl20bnr/spacemacs/commit/d6eb0f9fe66a6e1fe8ad0464157bbdd80c1a2e4a) rust: Improved LSP Rust server switch functionality
* [`4e241385`](https://github.com/syl20bnr/spacemacs/commit/4e2413856de309ef37f61cd45435abdea098910e) [org] add keybinding for org-copy-tree as with org-cut-tree
* [`e702cbac`](https://github.com/syl20bnr/spacemacs/commit/e702cbac4ee74b198df598d78a91f9b7845ba88b) Add to docs, replacing a layer package with a local version
* [`6136f0b1`](https://github.com/syl20bnr/spacemacs/commit/6136f0b118e18843292ea65b6edff9b988b37308) rcirc: replace local pkg rcirc-late-fix with github one
* [`b89391e4`](https://github.com/syl20bnr/spacemacs/commit/b89391e4c87258ae67d6413e362262041b18cbb2) vim-empty-lines: replaced local `vim-empty-lines-mode` with melpa one
* [`6e0f6501`](https://github.com/syl20bnr/spacemacs/commit/6e0f6501017552ad6213d3ab0328db39c7158faa) python: replaced local package `pylookup` with the one on github
* [`e0a94825`](https://github.com/syl20bnr/spacemacs/commit/e0a94825fe1555257422f4c548480afdaaab6ec4) [python] Fix broken fetcher declaration for pylookup
* [`eda04edb`](https://github.com/syl20bnr/spacemacs/commit/eda04edbe70472ac709793fafc0c3ee2184064f6) spacemacs-defaults: replace local pkg help-fns+ with github one
* [`a1415442`](https://github.com/syl20bnr/spacemacs/commit/a14154422fbb91a5914f5bb7eb34cdd72f18d442) [spacemacs-defaults] Fix broken URL in help-fns+ fetcher recipe
* [`ee384531`](https://github.com/syl20bnr/spacemacs/commit/ee3845315a1b6f409cd1b2fe069eeaeacc5832de) spacemacs-navigation: replace local package info+ with github one
* [`60741722`](https://github.com/syl20bnr/spacemacs/commit/6074172207933699e43bf98ff3092bc6cac40ba7) [spacemacs-navigation] Fix wrong url in recipe declaration
* [`fb16fa95`](https://github.com/syl20bnr/spacemacs/commit/fb16fa95cbe32dcb7ca530392f5552fc9410ebf2) python: replaced local package `nose` with `syl20bnr/nose.el`
* [`a9d5c5ed`](https://github.com/syl20bnr/spacemacs/commit/a9d5c5ed25a7b2d617673688732fd9a60c0fea9c) [python] Fix invalid recipe declaration for nose.el
* [`f5d12159`](https://github.com/syl20bnr/spacemacs/commit/f5d121599bd84bd5718a871a691467c609efa4bd) Fix void variable `mu4e-view-mode-map`
* [`8bcc4205`](https://github.com/syl20bnr/spacemacs/commit/8bcc42059b9990a383aef440d48a20cc6a08f07a) Revert "spacemacs-navigation: replace local package info+ with github one"
* [`f0b60976`](https://github.com/syl20bnr/spacemacs/commit/f0b60976d22c5baff69839f66863619f98932d87) Revert "spacemacs-defaults: replace local pkg help-fns+ with github one"
* [`70f475d7`](https://github.com/syl20bnr/spacemacs/commit/70f475d78200d4779824118e19b081bc23ccc1b6) Fix .spacemacs validation choices
* [`3f455278`](https://github.com/syl20bnr/spacemacs/commit/3f455278139c3c809661ab5f74f77a8db5822148) Update doc-string for dotspacemacs-frame-title-format
* [`1fcef834`](https://github.com/syl20bnr/spacemacs/commit/1fcef83467f1b99b248f3ecf848f06d57ce35ae7) Minibuffer bind C-n C-p to <next>/<previous>-line-or-history-element
* [`a8d3d998`](https://github.com/syl20bnr/spacemacs/commit/a8d3d99894571d3b3c790770267aea87e8016147) Add Edebug Eval List key bindings
* [`170e4a98`](https://github.com/syl20bnr/spacemacs/commit/170e4a985268a0c02ab3cb21eaa4a775cfb5c242) Add keybind to reload Rust-Analyzer workspace
* [`93f16c6a`](https://github.com/syl20bnr/spacemacs/commit/93f16c6a02620db530a206102e974eed22e3d0d0) [factor] Only reload fuel mode if factor root path has changed.
* [`0ccea3c4`](https://github.com/syl20bnr/spacemacs/commit/0ccea3c43696be11649a8e159e608434443918c4) Update to default behaviour
* [`86ea9871`](https://github.com/syl20bnr/spacemacs/commit/86ea9871cbe9bac91a1ec59ed86848635e613962) [scala] Make changed default behaviour more clear in docs
* [`5fac9a26`](https://github.com/syl20bnr/spacemacs/commit/5fac9a26c60f0227fd366035d93056e03fbe9e3d) Provide a switch to auto run mu4e at emacs startup
* [`bfb3cdad`](https://github.com/syl20bnr/spacemacs/commit/bfb3cdad8a42dddf3cade7b8312578fa08b51986) documentation formatting: Sat Mar 20 21:07:12 UTC 2021
* [`3e156ec7`](https://github.com/syl20bnr/spacemacs/commit/3e156ec76377ade0392c004b32fafe82ff3da5e6) fixup! Validate .spacemacs variables.
* [`5830e72b`](https://github.com/syl20bnr/spacemacs/commit/5830e72b601126b9ae787c5a3c43b097e89040a7) fixup! Validate .spacemacs variables.
* [`3d1b8865`](https://github.com/syl20bnr/spacemacs/commit/3d1b8865d96dc7e1e01780ee144936d076a24785) [core] Fix value validation for `dotspacemacs-editing-style`
* [`0ed84490`](https://github.com/syl20bnr/spacemacs/commit/0ed84490d55e47422f83e9cfbbb7d5d8179af6bd) [scala] Fix typos
* [`3243172a`](https://github.com/syl20bnr/spacemacs/commit/3243172af1dc419561312d502f76b0e300eac762) [core] Fix another typo
* [`6d40ee8e`](https://github.com/syl20bnr/spacemacs/commit/6d40ee8e1047e0d5e4ba509418527c53e1e60365) Revert "python: replaced local package `pylookup` with the one on github"
* [`d16a8c3a`](https://github.com/syl20bnr/spacemacs/commit/d16a8c3a7c698be49d521580ee573945e8c15b52) [auto-completion] Remove standard transformers
* [`13a5d5c9`](https://github.com/syl20bnr/spacemacs/commit/13a5d5c95ff7709451b2e6515601f3616bbbf74e) [shell] Make vterm support C-o in evil insert state again
* [`7a2eb1be`](https://github.com/syl20bnr/spacemacs/commit/7a2eb1be70775762461f3600c348d5e9f681d9c7) [home] Add multi-digit numbers to the startup lists
* [`3fe675d5`](https://github.com/syl20bnr/spacemacs/commit/3fe675d588889c2afa5bd0494d2497b626250495) [auto-completion] Fix obsolete: helm-c-yas-space-match-any-greedy
