### PR TITLE
niv zsh-completions: update aa98bc59 -> f0c85691

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -156,10 +156,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "aa98bc593fee3fbdaf1acedc42a142f3c4134079",
-        "sha256": "11q3f3nm0b13xhim5r3h2vpf76g97w811f30kl0a3w5i57jkc5vq",
+        "rev": "f0c856912cd5a74041978d6b02e22b6d3db69924",
+        "sha256": "029b8lb7ma7qz0wjn009nwhwm3kb2qprfgzn1zkazsh2gk056gbn",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/aa98bc593fee3fbdaf1acedc42a142f3c4134079.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/f0c856912cd5a74041978d6b02e22b6d3db69924.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@aa98bc59...f0c85691](https://github.com/zsh-users/zsh-completions/compare/aa98bc593fee3fbdaf1acedc42a142f3c4134079...f0c856912cd5a74041978d6b02e22b6d3db69924)

* [`b152a490`](https://github.com/zsh-users/zsh-completions/commit/b152a4901fc1314ef24ba5bc2ad1f6f5e824f9e7) Autocomplete files for mix run
* [`24834255`](https://github.com/zsh-users/zsh-completions/commit/24834255e973c997f9357651d8054b9f78b1317b) Remove deprecated `-$` option
* [`cec34820`](https://github.com/zsh-users/zsh-completions/commit/cec348209c22fb84610fd2d48fc43b4e32055b05) Add table of contents
