### PR TITLE
niv nixpkgs: update 342c7e72 -> 76bd9531

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "342c7e724eb7fb1f60da3eaf082cfe6ea0df1e8f",
-        "sha256": "169y41f0qmy32cc55rmlfrj74j2az5dsinn8am4ibn7n83qn57hk",
+        "rev": "76bd95316205e1eaf472b04fceef654f0e7639a1",
+        "sha256": "1nixk3xp5aw220ppdj90mmif825qsr20ajgh2izgmbp4khxrwj94",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/342c7e724eb7fb1f60da3eaf082cfe6ea0df1e8f.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/76bd95316205e1eaf472b04fceef654f0e7639a1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@342c7e72...76bd9531](https://github.com/nixos/nixpkgs/compare/342c7e724eb7fb1f60da3eaf082cfe6ea0df1e8f...76bd95316205e1eaf472b04fceef654f0e7639a1)

* [`c9dcff24`](https://github.com/NixOS/nixpkgs/commit/c9dcff241e69398a9a7046a55cf0605b3e12f461) linux: 4.4.262 -> 4.4.263
* [`57ea233d`](https://github.com/NixOS/nixpkgs/commit/57ea233d162916dc384f5c84ae231951eda5a0e2) linux: 4.9.262 -> 4.9.263
* [`9ce0fb81`](https://github.com/NixOS/nixpkgs/commit/9ce0fb815c88e6028f3ce9a2c45cc02fc075e913) linux: 5.11.8 -> 5.11.9
* [`1c7273cc`](https://github.com/NixOS/nixpkgs/commit/1c7273cc1759bd55fb8d2dc023730813dfda0cec) linux: 5.4.107 -> 5.4.108
* [`6765e61e`](https://github.com/NixOS/nixpkgs/commit/6765e61ed4d59a982da6df7fa52bcd246cbb125b) linux: 5.10.25 -> 5.10.26
* [`435366bd`](https://github.com/NixOS/nixpkgs/commit/435366bdd38b96b03fb07f0400b983eadd92819f) linux/hardened/patches/4.14: 4.14.226-hardened1 -> 4.14.227-hardened1
* [`98d48280`](https://github.com/NixOS/nixpkgs/commit/98d48280b796f8838300051713257c78f7c582e3) linux/hardened/patches/4.19: 4.19.182-hardened1 -> 4.19.183-hardened1
* [`03664646`](https://github.com/NixOS/nixpkgs/commit/036646460b4729e3e5293ef4e992fe320c29cebb) linux/hardened/patches/5.11: 5.11.8-hardened1 -> 5.11.9-hardened1
* [`6052a427`](https://github.com/NixOS/nixpkgs/commit/6052a427a1f7ef3c174454fb822f265e03dfc4fe) linux/hardened/patches/5.4: 5.4.107-hardened1 -> 5.4.108-hardened1
* [`6042f10c`](https://github.com/NixOS/nixpkgs/commit/6042f10cbe046197b14ad8db99ebe2f0277ad4a8) labeller: Add kernel subfolder
* [`4f173f61`](https://github.com/NixOS/nixpkgs/commit/4f173f616d3e8900a711f33dd62a8290791da8f8) zgrab2: init at 20210327-17a5257
* [`d90adf06`](https://github.com/NixOS/nixpkgs/commit/d90adf06081c91712d3cb55cea33e6d16413bacc) python38Packages.bitarray: 1.8.0 -> 1.8.1
* [`d696e4b8`](https://github.com/NixOS/nixpkgs/commit/d696e4b875d25821a12abc43f50cc62905abe4fe) add pname into python-modules/mxnet ([nixos/nixpkgs⁠#117101](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117101))
* [`6d41c7e4`](https://github.com/NixOS/nixpkgs/commit/6d41c7e4d50bb952b6d47815805430fd57affa1f) openrazer: 2.9.0 -> 3.0.0
* [`90caa400`](https://github.com/NixOS/nixpkgs/commit/90caa40006fe2599013c4e6ab0ccb4943fd205e9) yed: 3.20.1 -> 3.21.1
* [`e157c846`](https://github.com/NixOS/nixpkgs/commit/e157c846ce22bed9daf4b3ce6a35794f344a6053) agate: 2.5.3 -> 3.0.0
* [`30050ab2`](https://github.com/NixOS/nixpkgs/commit/30050ab2fcb59bbf61be50cbb4ee43bc169b4d45) nixUnstable: pre20210317_8a5203d -> pre20210326_dd77f71
* [`d63909f0`](https://github.com/NixOS/nixpkgs/commit/d63909f04581849863f04217882296764fae2caf) Update Org Mode Emacs packages
* [`4a488a0b`](https://github.com/NixOS/nixpkgs/commit/4a488a0bf6840beb7fc70c4612ce7a4586e2077a) Update ELPA packages
* [`fba4e73b`](https://github.com/NixOS/nixpkgs/commit/fba4e73b009bff18e8e0287140722dbdea2a2579) Manual fix: remove duplicated shell-command-plus expression
* [`190a6f04`](https://github.com/NixOS/nixpkgs/commit/190a6f04b6cdf95b50170282e5d1518a1ee883e2) calc: 2.12.9.0 -> 2.12.9.1
* [`47121663`](https://github.com/NixOS/nixpkgs/commit/471216639a5edcffbcca22e5bcd66ac1ae4e0e98) cargo-udeps: 0.1.19 -> 0.1.20
* [`886d4352`](https://github.com/NixOS/nixpkgs/commit/886d4352127b61f6bab91ec62658b1d745d4fc50) chezmoi: 2.0.3 -> 2.0.4
* [`4d1b488f`](https://github.com/NixOS/nixpkgs/commit/4d1b488f2f23531b306c1b81757ae8519502c13e) codeql: 2.4.6 -> 2.5.0
* [`f250e5b8`](https://github.com/NixOS/nixpkgs/commit/f250e5b8987cbfc7ec3d58638e08eefa9f4b0a83) coordgenlibs: 1.4.2 -> 2.0.0
* [`7da3df8e`](https://github.com/NixOS/nixpkgs/commit/7da3df8e9aac6c8f82c4e554f91301d176e4a93e) Update Emacs MELPA expressions
* [`cd7b4b64`](https://github.com/NixOS/nixpkgs/commit/cd7b4b64b189e218d3abd25aa5f6329f72a2a213) croc: 8.6.11 -> 8.6.12
* [`9e4b635d`](https://github.com/NixOS/nixpkgs/commit/9e4b635dee8bd5379250d54f24cb007be2f2db18) arpack: 3.7.0 -> 3.8.0
* [`5ebacbf4`](https://github.com/NixOS/nixpkgs/commit/5ebacbf4740c4d0e790ccd8974076b88a5d0123a) python39Packages.ldap: unbreak ([nixos/nixpkgs⁠#117614](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117614))
* [`194d26f9`](https://github.com/NixOS/nixpkgs/commit/194d26f9790326af74ee3b44ed139f25c067165a) fishnet: 2.2.5 -> 2.2.6
* [`38b9434c`](https://github.com/NixOS/nixpkgs/commit/38b9434ce9609cdfb9119ccd7dcb6e10d9f133f0) gdu: 4.8.1 -> 4.9.0
* [`415788b8`](https://github.com/NixOS/nixpkgs/commit/415788b8d33a8f4e08ee951fb955aba2a0b377c3) git-extras: 6.1.0 -> 6.2.0
* [`f5dc5512`](https://github.com/NixOS/nixpkgs/commit/f5dc55128cf9e61bcb9af314d068b1c07029ce11) golangci-lint: 1.38.0 -> 1.39.0
* [`b177e5ed`](https://github.com/NixOS/nixpkgs/commit/b177e5ed999be37c4f298e4ee24f39ad00c4f232) git-lfs: 2.13.2 -> 2.13.3
* [`ce6eb617`](https://github.com/NixOS/nixpkgs/commit/ce6eb6175887d7232ad5f02e686bdbe7ce5dfc01) pythonPackages.pynmea2: 1.16.0 -> 1.17.0
* [`3aba63ab`](https://github.com/NixOS/nixpkgs/commit/3aba63ab29e4ed073c689e7e9995ca682d133173) qt5.qtwebengine: 5.15.2 -> 5.15.3-a059e740
* [`c7e4fdef`](https://github.com/NixOS/nixpkgs/commit/c7e4fdef1839d3f69e3f21101fcfb25495857350) pythonPackages.pyqtwebengine: 5.15.2 -> 5.15.4
* [`b710cdf8`](https://github.com/NixOS/nixpkgs/commit/b710cdf80a6af25e719ba5349134b61454807027) qutebrowser: 2.0.2 -> 2.1.0
* [`d3ebe834`](https://github.com/NixOS/nixpkgs/commit/d3ebe834086aeef0d0978177ba6dfbd1e3b4c133) qutebrowser: add pynacl for qute-keepassxc
* [`b858559f`](https://github.com/NixOS/nixpkgs/commit/b858559f86436b54d49bd34ae19b40f48d7e8d59) goreleaser: 0.160.0 -> 0.161.1
* [`87e44b86`](https://github.com/NixOS/nixpkgs/commit/87e44b865fdd8bf63dda53ec9c8fe5a4730b65a0) grype: 0.8.0 -> 0.9.0
* [`75f531b3`](https://github.com/NixOS/nixpkgs/commit/75f531b3fc6f902c6b60c70405a1102a635760b3) webkitgtk: 2.30.5 -> 2.30.6
* [`b2eb2c8b`](https://github.com/NixOS/nixpkgs/commit/b2eb2c8b4f422bee0f5f5a07cd705fadf1cbbc32) Revert "ocamlPackages.tcpip: 6.0.0 -> 6.1.0"
* [`588da550`](https://github.com/NixOS/nixpkgs/commit/588da550f76715a92e927a70fc193da55c5eb159) grype: set version
* [`b7e18a3c`](https://github.com/NixOS/nixpkgs/commit/b7e18a3c4f2aad3bc130063219fd8ae4f73fdff4) k9s: 0.24.3 -> 0.24.5
* [`46caf260`](https://github.com/NixOS/nixpkgs/commit/46caf2601c813e219119c6d0a67760044741ac03) rpm: 4.16.1.2 -> 4.16.1.3
* [`d1599260`](https://github.com/NixOS/nixpkgs/commit/d1599260b358d75b2c999bb368208c561bbe5c2d) bitwig-studio: 3.3.3 -> 3.3.6
* [`f12df7e1`](https://github.com/NixOS/nixpkgs/commit/f12df7e1005438d9f89fb89a1e4714dadeb6a6c1) lazydocker: 0.10 -> 0.12
* [`60b85e6b`](https://github.com/NixOS/nixpkgs/commit/60b85e6b95488488d3b233800ce02f77706970bb) python3Packages.tldextract: enable tests ([nixos/nixpkgs⁠#117787](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117787))
* [`f4be46f9`](https://github.com/NixOS/nixpkgs/commit/f4be46f9be1351e9c58399bcbdfa2573695a79bb) lightburn: 0.9.21 -> 0.9.22
* [`29d77c57`](https://github.com/NixOS/nixpkgs/commit/29d77c57edefc8412eb9abb23985d9371d409c76) dot-merlin-reader: 3.4.2 -> 4.1
* [`ef645041`](https://github.com/NixOS/nixpkgs/commit/ef6450411f1c924463508a6b01e36801784042f3) ocamlPackages_4_{11,12}: merlin: 3.4.2 -> 4.1
* [`f615c233`](https://github.com/NixOS/nixpkgs/commit/f615c23325e13a54ba18cdfabd1eaf7ace0b0741) bashate: init at 2.0.0 ([nixos/nixpkgs⁠#117469](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117469))
* [`35d8e068`](https://github.com/NixOS/nixpkgs/commit/35d8e068f895b5e0a39e9ab8b0f76b9469ddee9d) zile: 2.6.0.90 -> 2.6.1
* [`48e14cf9`](https://github.com/NixOS/nixpkgs/commit/48e14cf92afdfd8b29c6ae7c1f689151a580feb2) cosign: init at 0.1.0
* [`50850a2e`](https://github.com/NixOS/nixpkgs/commit/50850a2e3acbb03d48db387c72fb2490d99b5526) spamassassin: 3.4.4 -> 3.4.5
* [`604e1b2d`](https://github.com/NixOS/nixpkgs/commit/604e1b2d5098407985ba0e58dba1fb16514387a9) deltachat-electron: 1.15.3 -> 1.15.5
* [`306c4657`](https://github.com/NixOS/nixpkgs/commit/306c46577303b1da62dc799a61816c988779e03c) python2Packages.pygments: add patch for CVE-2021-27291
* [`8292b073`](https://github.com/NixOS/nixpkgs/commit/8292b0739ad642b7fb54cb317a0dcd400a58ae4a) hwi: 2.0.0 -> 2.0.1
* [`3725e9ce`](https://github.com/NixOS/nixpkgs/commit/3725e9cee3ca99a4a8de520f142439d47e2e5420) photoflare: 1.6.7 -> 1.6.7.1
* [`4ee2a19b`](https://github.com/NixOS/nixpkgs/commit/4ee2a19bb621a10ebe8fc05ad8a9ed4ba7c497af) vistafonts-chs: fix build
* [`c91cafb6`](https://github.com/NixOS/nixpkgs/commit/c91cafb66a15ca31f98f68705cdc9e05ace9cb33) _20kly: 1.4 -> 1.5.0
* [`11b13209`](https://github.com/NixOS/nixpkgs/commit/11b13209f3acc09f5e0743ecfaf4d34ae47d254f) gitkraken: 7.5.2 -> 7.5.3
* [`dc90f0c0`](https://github.com/NixOS/nixpkgs/commit/dc90f0c0b2c8ec4a3d84e68e3389fd6a43ef3f85) inter-ui: [duplicate] remove inter-ui
* [`426a64fa`](https://github.com/NixOS/nixpkgs/commit/426a64fafd818eac518a59a2abcb5661b581f170) gnomeExtensions.appindicator: 35 -> 36
* [`a2bc84a4`](https://github.com/NixOS/nixpkgs/commit/a2bc84a4a2ed11b21be3f4d7d8bc586ef2f52369) remove from package list
* [`0c39926e`](https://github.com/NixOS/nixpkgs/commit/0c39926e7ee56c1da33e70e0be156cc739881bf3) tabnine: 3.2.64 -> 3.3.101
* [`cb231de7`](https://github.com/NixOS/nixpkgs/commit/cb231de72bae23b42cba47ac4540eafb801b0a60) miniserve: 0.12.0 -> 0.12.1
* [`6493604b`](https://github.com/NixOS/nixpkgs/commit/6493604b1eebed72fb0cf9a58be7a37f9a52ed12) add alias
* [`f3f1e160`](https://github.com/NixOS/nixpkgs/commit/f3f1e1602777c7fb25101faf35279e13bf9fa9b6) wiki-js: use `installPhase` & get rid of `buildCommand`
* [`47cc45ad`](https://github.com/NixOS/nixpkgs/commit/47cc45ad77ed0c771ab48764594f99e32f22c145) wiki-js: 2.5.191 -> 2.5.197
* [`ffe04082`](https://github.com/NixOS/nixpkgs/commit/ffe0408224d1d2474313340ebd024f296fdb898c) maintainers: add russell
* [`6db0ff62`](https://github.com/NixOS/nixpkgs/commit/6db0ff627b94a7f0e0f4d734cbdd70301cf40969) vendir: init at 0.17.0
* [`144a997c`](https://github.com/NixOS/nixpkgs/commit/144a997c8e58c996330c1bf4cb78430f3e18a498) lib: fix commitIdFromGitRepo ([nixos/nixpkgs⁠#117752](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117752))
* [`eaff5544`](https://github.com/NixOS/nixpkgs/commit/eaff554484ffe06665192ef28b343700d7c9c965) python3Packages.dulwich: 0.20.20 -> 0.20.21
* [`14d136c0`](https://github.com/NixOS/nixpkgs/commit/14d136c0a7830560cb8c6253f1eb885a5d838803) tor-browser-bundle-bin: 10.0.13 -> 10.0.14
* [`3a2b68fd`](https://github.com/NixOS/nixpkgs/commit/3a2b68fd5faf7b25a604eeabe17e339d3d92c47e) sipvicious: 0.3.2 -> 0.3.3
* [`a3f74559`](https://github.com/NixOS/nixpkgs/commit/a3f74559cf4307b251ca76649b4f6c4528391bff) llvmPackages_6.llvm-manpages: unbreak
* [`4cab1eb3`](https://github.com/NixOS/nixpkgs/commit/4cab1eb3bc578a094da6a65d59144d7fd3e11044) swego: 0.93 -> 0.94
* [`f01d07ec`](https://github.com/NixOS/nixpkgs/commit/f01d07ec0bf39d43b78bb0f07705dda847e24e01) wineUnstable: 6.3 -> 6.4
* [`3b90e8f9`](https://github.com/NixOS/nixpkgs/commit/3b90e8f9dee571d586d90aafb7ba82737fac95aa) wineUnstable: enable cross building for unstable/staging by default
* [`a09b170f`](https://github.com/NixOS/nixpkgs/commit/a09b170ffa4d554c81b754cad4c4bbecfda56e1d) teler: 1.1.1 -> 1.2.1
* [`e4f2c68b`](https://github.com/NixOS/nixpkgs/commit/e4f2c68b2878df7de8d0248bd8f9dbdea8c2d7a9) tfsec: 0.39.10 -> 0.39.14
* [`f94168c9`](https://github.com/NixOS/nixpkgs/commit/f94168c983a19956bc76eb0ccaa618a36f476761) factorio: 1.1.27 -> 1.1.30
* [`ce3c1f86`](https://github.com/NixOS/nixpkgs/commit/ce3c1f86510399fe22f9694852dfcd95339954d0) monado: 0.4.1 -> 21.0.0 ([nixos/nixpkgs⁠#117811](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117811))
* [`53aac393`](https://github.com/NixOS/nixpkgs/commit/53aac393e8b7c8059f7d71f8e4a3a2a3fdc973d1) yq-go: 4.6.2 -> 4.6.3
* [`a856cce9`](https://github.com/NixOS/nixpkgs/commit/a856cce9ab000c61a0cb9ec1020f2967dd2afed2) libsForQt5.ffmpegthumbs: ffmpeg_3 -> ffmpeg_4 ([nixos/nixpkgs⁠#117859](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117859))
* [`dca6abeb`](https://github.com/NixOS/nixpkgs/commit/dca6abeb4db3f021653760b3bffe446ec93beffb) ecasound: unbreak
* [`26f1d7a3`](https://github.com/NixOS/nixpkgs/commit/26f1d7a3f6e965438ce6f0cf2320a69f5d55e401) gopass: 1.12.4 -> 1.12.5
* [`1dfe6902`](https://github.com/NixOS/nixpkgs/commit/1dfe690209af14a91b32dbf2f379ca02d050e1a1) egl-wayland: 1.1.4 -> 1.1.6, fix pkg-config file ([nixos/nixpkgs⁠#111541](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/111541))
* [`8ba11d00`](https://github.com/NixOS/nixpkgs/commit/8ba11d0068085d6d6854a9b975b6b97ae6f01445) jellyfin-mpv-shim: 1.10.2 -> 1.10.3
* [`8dadf387`](https://github.com/NixOS/nixpkgs/commit/8dadf3873fc653115f1f5273dc1312bedfbe8cd4) tor-browser-bundle-bin: make overrideAttrs work
* [`2749351a`](https://github.com/NixOS/nixpkgs/commit/2749351acd828a1fbddf8cb6efd1a9cb33d22e0f) gremlin-console: 3.4.8 -> 3.4.10
* [`d0ee6127`](https://github.com/NixOS/nixpkgs/commit/d0ee6127dca2c1e27d447203a76b06f97dbb99d9) tor-browser-bundle-bin: 10.0.14 -> 10.0.15
* [`96df21a8`](https://github.com/NixOS/nixpkgs/commit/96df21a88ebf6fa80f2919a3512e08cdd6eb4317) abcmidi: 2021.03.10 -> 2021.03.27
* [`c7aef6de`](https://github.com/NixOS/nixpkgs/commit/c7aef6dedb29392ef2aad8fe70fa9745597c84ea) metrics: drop requiredSystemFeatures; /cc [nixos/nixpkgs⁠#76776](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/76776)
* [`414d17a1`](https://github.com/NixOS/nixpkgs/commit/414d17a17baf5316622fedafa6aa8694f1d62af8) hugo: add man pages and shell completions
* [`6a2a2d65`](https://github.com/NixOS/nixpkgs/commit/6a2a2d6503f450941bd471d9933e55c35e80625e) julia: use system blas only when not darwin
* [`72850d84`](https://github.com/NixOS/nixpkgs/commit/72850d84f874968f543614dd23d2b8c11a0d457b) radarr: change sed separator in update script
* [`22de3c19`](https://github.com/NixOS/nixpkgs/commit/22de3c19e765088f8dfd243e9bbd95330d7d8a10) graylog: improve JRE handling
* [`1331b90c`](https://github.com/NixOS/nixpkgs/commit/1331b90c9b6a6a0ffc42ea7ddd540bfbf49b13b0) lispPackages.quicklisp: 2019-02-16 -> 2021-02-13, dist info 2020-10-16 -> 2021-02-28
* [`e96cae7e`](https://github.com/NixOS/nixpkgs/commit/e96cae7e3c201cb2003a63ef1bd9c1c9fc4093fe) quicklisp-to-nix: ban serapeum/docs due to weird issues
* [`fad53e29`](https://github.com/NixOS/nixpkgs/commit/fad53e29615e9cac2b00c455a5c21b8efdeaacf7) quicklispPackages: regenerate
* [`09b9030e`](https://github.com/NixOS/nixpkgs/commit/09b9030ebb069804ddc64a018068b5e59f34fe92) pycoin: expose cli via top-level entry
* [`850862ff`](https://github.com/NixOS/nixpkgs/commit/850862ffac96a25457d6d105b18d243a4b9af307) lispPackages: pass lib explicitly
* [`b4d085cb`](https://github.com/NixOS/nixpkgs/commit/b4d085cb9aaa1ab8edd371518416e6d9da36f580) sbcl: init 2.1.2, default 2.0.8 -> 2.1.2
* [`f3c739f4`](https://github.com/NixOS/nixpkgs/commit/f3c739f4792eff0fca12c637c3017f431272665e) pidgin: add checks (see parent commit, too)
* [`cf86741d`](https://github.com/NixOS/nixpkgs/commit/cf86741d99f60588773e188fe8d0550c7d9a5c20) ocamlPackages.ocaml-version: use Dune 2
* [`85b6efff`](https://github.com/NixOS/nixpkgs/commit/85b6efff7cac3d455228b0207266431ba9e05570) quicklispPackages: improve non-SBCL support
* [`3f6be2ae`](https://github.com/NixOS/nixpkgs/commit/3f6be2ae8f42a935ddb14fe6d0529fcc0c360826) quicklispPackages: give names to all somewhat-working versions
* [`debbd843`](https://github.com/NixOS/nixpkgs/commit/debbd843330393dbf9f1abdccf20255cf33712bf) zabbix.agent2: init at 5.0.5
* [`d6fd7c66`](https://github.com/NixOS/nixpkgs/commit/d6fd7c661365638c576c2885068b459c67684e7b) nixos/zabbixAgent: add a few minor tweaks to make configuration file compatible with both zabbix agent 1 and 2
* [`80a1336b`](https://github.com/NixOS/nixpkgs/commit/80a1336bb9e958564b26e2b6e43fe22004cb4a4e) nixos/filesystems: always write mount options for swap devices
* [`0be7adbc`](https://github.com/NixOS/nixpkgs/commit/0be7adbc6c885a3a63529d75888cfd89d5dae381) fly: remove writeText
* [`1e5e8f49`](https://github.com/NixOS/nixpkgs/commit/1e5e8f49d6f4accf3856e551a856256b37fc3f06) waypipe: 0.7.2 -> 0.8.0 ([nixos/nixpkgs⁠#117879](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117879))
* [`45cea672`](https://github.com/NixOS/nixpkgs/commit/45cea67242b7cae37afa572fae35db6e12ea6809) gitAndTools.git-bug: 0.7.1 -> 0.7.2
* [`78e741c6`](https://github.com/NixOS/nixpkgs/commit/78e741c65ffe629fab8385558eb6b73d63a3b2f8) calibre: add cchardet library
* [`56f308bb`](https://github.com/NixOS/nixpkgs/commit/56f308bb2f5ec2f872491a945b4cb911c66f2fee) nixos/kresd: trivial cleanup
* [`4ae1fa61`](https://github.com/NixOS/nixpkgs/commit/4ae1fa61ad66c0cb5e08549c9f4ae300ee956b25) Revert "nixos/dysnomia nixos/disnix: Drop modules"
* [`13b367df`](https://github.com/NixOS/nixpkgs/commit/13b367df5f3a03fb258462e410816a7fed3989e8) nixos/dysnomia: configure systemd unit path
* [`b8258843`](https://github.com/NixOS/nixpkgs/commit/b8258843d4d78e14c08e610a202c7c331a8f0f44) nixos/misc/ids: reclaim uid for disnix
* [`43846a58`](https://github.com/NixOS/nixpkgs/commit/43846a58345c72bff79b2e06c74a1d2d790c7363) ocamlPackages.wtf8: use Dune 2
* [`f0c01da4`](https://github.com/NixOS/nixpkgs/commit/f0c01da4928fe46a5201193c12d23f74f3c0e9dc) svtplay-dl: 3.0 -> 3.3
* [`768bbabf`](https://github.com/NixOS/nixpkgs/commit/768bbabf0ce9a92778a4b09da2ea373367955203) ocamlPackages.cpuid: use Dune 2
* [`83f0eb53`](https://github.com/NixOS/nixpkgs/commit/83f0eb535c7433773f0b83200185e3332252bf43) python3Packages.labmath: init at 1.2.0 ([nixos/nixpkgs⁠#117882](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/117882))
* [`4fc2ef2c`](https://github.com/NixOS/nixpkgs/commit/4fc2ef2c5ec65a5c77150e5348cae1dd4ee96cb2) stellarium: 0.20.4 -> 0.21.0
* [`55416750`](https://github.com/NixOS/nixpkgs/commit/55416750f815227dec3b8e633f67de2789f061fd) dlib: 19.21 -> 19.22
* [`950085c3`](https://github.com/NixOS/nixpkgs/commit/950085c3dd81e31353d92529757b6bdcf0ee26ea) urjtag: 2019.12 -> 2021.03
* [`76bd9531`](https://github.com/NixOS/nixpkgs/commit/76bd95316205e1eaf472b04fceef654f0e7639a1) bedops: init 2.4.39
