### PR TITLE
niv home-manager: update ddcd4766 -> cbf06670

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ddcd476603dfd3388b1dc8234fa9d550156a51f5",
-        "sha256": "0amckzfnpldw8hpzgcdp8qqbd91g15dhgaw8mkkb3sghvig0380k",
+        "rev": "cbf0667037e6ca16fcc38818b2aa1391de702c6a",
+        "sha256": "14s01yhwkb8p1kwlmiaky7ygnb14mivskczsxypsxdp10q8r3y9h",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/ddcd476603dfd3388b1dc8234fa9d550156a51f5.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/cbf0667037e6ca16fcc38818b2aa1391de702c6a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@ddcd4766...cbf06670](https://github.com/nix-community/home-manager/compare/ddcd476603dfd3388b1dc8234fa9d550156a51f5...cbf0667037e6ca16fcc38818b2aa1391de702c6a)

* [`fedfd430`](https://github.com/nix-community/home-manager/commit/fedfd430f96695997b3eaf8d7e82ca79406afa23) nixos/nix-darwin: switch sharedModules type to anything with custom check ([nix-community/home-manager⁠#1880](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1880))
* [`7b30fc99`](https://github.com/nix-community/home-manager/commit/7b30fc99227e6c7c331a01a9fb87599e4cd8cee1) dunst: update documentation on settings ([nix-community/home-manager⁠#1881](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1881))
* [`c1761366`](https://github.com/nix-community/home-manager/commit/c1761366b522595ff0dda47d7ba79d5242ecb31e) xmonad: add libFiles option and build type compilation
* [`cbf06670`](https://github.com/nix-community/home-manager/commit/cbf0667037e6ca16fcc38818b2aa1391de702c6a) programs.neomutt: Fix eval error when primary account not enabled ([nix-community/home-manager⁠#1873](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1873))
