### PR TITLE
niv nixpkgs-fmt: update 851b39bf -> 148ec478

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "851b39bffdd86d8852372100bfe4bfc46bc0e346",
-        "sha256": "1c5kis36cmq14x2lpizn7lrhkdxnjxmwmrnqzdb6lxpnaqmmr5q6",
+        "rev": "148ec47877499e3d671f6366f9eed812db181b40",
+        "sha256": "0dqirvn8pq6ssxjlf6rkqcsx6ndasws93lz2v9f9s01k9ny8x8mq",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/851b39bffdd86d8852372100bfe4bfc46bc0e346.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/148ec47877499e3d671f6366f9eed812db181b40.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@851b39bf...148ec478](https://github.com/nix-community/nixpkgs-fmt/compare/851b39bffdd86d8852372100bfe4bfc46bc0e346...148ec47877499e3d671f6366f9eed812db181b40)

* [`b273bb4b`](https://github.com/nix-community/nixpkgs-fmt/commit/b273bb4b869fd8d1fa6dfc14f9f745441c298c40) flake: use `lib` instead of `stdenv.lib`
* [`c3cdab17`](https://github.com/nix-community/nixpkgs-fmt/commit/c3cdab17f197edeb26ab2112dae4b7421f9b1a70) add format rule for NODE_OR_DEFAULT, adding nixpkgs repo test, and remove walk_non_whitespace function
* [`b6213b0c`](https://github.com/nix-community/nixpkgs-fmt/commit/b6213b0c3ccdef2a75275a6f75063ea5a5374d5c) ci: use the nix-community cache
* [`148ec478`](https://github.com/nix-community/nixpkgs-fmt/commit/148ec47877499e3d671f6366f9eed812db181b40) Release v1.2.0
