### PR TITLE
niv powerlevel10k: update 58f5470c -> af86b530

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "58f5470cd98343581853dafe2a99430c0a6975e5",
-        "sha256": "059bnbd419il4acbalwsdlnxbr8c29cqiw17ch0b8137xqhz4f0s",
+        "rev": "af86b53047ea6d6866dc5dae83eb219e691b9c76",
+        "sha256": "16b82cg57i83ki0vkwsc0pypf6y3w8kr5w02968s4c53av5j0jjb",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/58f5470cd98343581853dafe2a99430c0a6975e5.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/af86b53047ea6d6866dc5dae83eb219e691b9c76.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@58f5470c...af86b530](https://github.com/romkatv/powerlevel10k/compare/58f5470cd98343581853dafe2a99430c0a6975e5...af86b53047ea6d6866dc5dae83eb219e691b9c76)

* [`d3de2e55`](https://github.com/romkatv/powerlevel10k/commit/d3de2e558cc12edc012a868ef11cd0dfb6d03a68) Sets the filter for the current gcloud profile ([romkatv/powerlevel10k⁠#1324](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1324))
* [`eafd78c3`](https://github.com/romkatv/powerlevel10k/commit/eafd78c3e0e19022612508e2ded2c1f035c29a25) respect POWERLEVEL9K_SHORTEN_DIR_LENGTH when POWERLEVEL9K_SHORTEN_STRATEGY=truncate_to_last
* [`af86b530`](https://github.com/romkatv/powerlevel10k/commit/af86b53047ea6d6866dc5dae83eb219e691b9c76) Added urxvt to manual font installation section. ([romkatv/powerlevel10k⁠#1326](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1326))
