### PR TITLE
niv spacemacs: update 3fe675d5 -> eaf2e932

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "3fe675d588889c2afa5bd0494d2497b626250495",
-        "sha256": "05mxfj764f3h4pnz5d0fnwk66j2d5sdin52h3d55g11ihg94m8sm",
+        "rev": "eaf2e932e6aca3fe5a53715089f9566d9dacffe4",
+        "sha256": "1xag2bjaxmakwdz4pb764hnjximhp20yzc2ybdzqdjq3a5ljm83n",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/3fe675d588889c2afa5bd0494d2497b626250495.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/eaf2e932e6aca3fe5a53715089f9566d9dacffe4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@3fe675d5...eaf2e932](https://github.com/syl20bnr/spacemacs/compare/3fe675d588889c2afa5bd0494d2497b626250495...eaf2e932e6aca3fe5a53715089f9566d9dacffe4)

* [`bc51b6a5`](https://github.com/syl20bnr/spacemacs/commit/bc51b6a5eab58883ad51fcdd12c8cdfbdb74170d) Fix lambda quoting warning
* [`679040fb`](https://github.com/syl20bnr/spacemacs/commit/679040fbfa1927b912f814a70944cf27d1fb9035) [colors] Remove duplicate function
* [`a6d13ebc`](https://github.com/syl20bnr/spacemacs/commit/a6d13ebc583913e2a1436f4f01d76a69b65979c4) Update ISSUE_TEMPLATE
* [`d55a9e2e`](https://github.com/syl20bnr/spacemacs/commit/d55a9e2e677cbf8d08c895ec6ffce5ab63332eb8) Update header for year 2021
* [`3f727e54`](https://github.com/syl20bnr/spacemacs/commit/3f727e54a635de8010535e127c404f0a926caf9d) Add LICENSE file
* [`2c22bb96`](https://github.com/syl20bnr/spacemacs/commit/2c22bb96a054376124345ca1cc505b02f3c8a480) Add GPLv3 logo to README
* [`97cd83e1`](https://github.com/syl20bnr/spacemacs/commit/97cd83e169a7d3a5633bfebe561b0084a5ed6c1a) Apply GPLv3 terms explicitly to all elisp files
* [`9a66c256`](https://github.com/syl20bnr/spacemacs/commit/9a66c2566e980c18708ca4b93def54cb70b65994) [home] Add Licensing button
* [`532ad256`](https://github.com/syl20bnr/spacemacs/commit/532ad2567cba1d57d09e102c385315e7cfa829ec) [home] Add GPLv3 badge in footer
* [`92c15655`](https://github.com/syl20bnr/spacemacs/commit/92c1565507ba389ecc45d79e173d5efd06659ed3) [home] Fix alignement and footer regression cased by 9a66c2566
* [`60a07043`](https://github.com/syl20bnr/spacemacs/commit/60a070433f4fc8fa78ea5f05ddb0fc9d23d2098a) [home] Add "Proudly free software" to footer
* [`314c1312`](https://github.com/syl20bnr/spacemacs/commit/314c13120981cd1878f4fe926615819035feb299) Built-in files auto-update: Fri Mar 26 03:33:18 UTC 2021
* [`aa0c0301`](https://github.com/syl20bnr/spacemacs/commit/aa0c0301e2dc5751690518372ec4c0329f60420f) [home] Add link to free software definition
* [`aabd3bca`](https://github.com/syl20bnr/spacemacs/commit/aabd3bcac32cafb931afb6e1777f7bc08ee92c50) Fix expected type of: dotspacemacs-which-key-delay
* [`eaf2e932`](https://github.com/syl20bnr/spacemacs/commit/eaf2e932e6aca3fe5a53715089f9566d9dacffe4) Fix typo: connst -> const
