### PR TITLE
niv nixpkgs: update 76bd9531 -> 7c932296

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "76bd95316205e1eaf472b04fceef654f0e7639a1",
-        "sha256": "1nixk3xp5aw220ppdj90mmif825qsr20ajgh2izgmbp4khxrwj94",
+        "rev": "7c932296e05b32e5414140d69aac75a039d0a7f0",
+        "sha256": "1m5mznplajgv6bzag0p16kb2ya5i4n2qkwj65p4nlj4waalbcpjj",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/76bd95316205e1eaf472b04fceef654f0e7639a1.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/7c932296e05b32e5414140d69aac75a039d0a7f0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@76bd9531...7c932296](https://github.com/nixos/nixpkgs/compare/76bd95316205e1eaf472b04fceef654f0e7639a1...7c932296e05b32e5414140d69aac75a039d0a7f0)

* [`155f034b`](https://github.com/NixOS/nixpkgs/commit/155f034b62890f8e80a338208a41774870dbd94f) freecad: reenable spacenav support
* [`295acf04`](https://github.com/NixOS/nixpkgs/commit/295acf0460aae74bb9ebd999f639348a2f3c13bb) nixos/spacenavd: start as system service
* [`83dbaf67`](https://github.com/NixOS/nixpkgs/commit/83dbaf67a99624ceaba75d4fc8a22d691f577828) spnavcfg: init at 0.3.1
* [`ab336074`](https://github.com/NixOS/nixpkgs/commit/ab336074fdcc195a8216713bb16a7083ba3fccd8) blender: enable spacenav support
* [`9508fcff`](https://github.com/NixOS/nixpkgs/commit/9508fcff310fa0ec66d9e035b8d13f9eff141044) openscad: enable spacenav support
* [`ec07a395`](https://github.com/NixOS/nixpkgs/commit/ec07a39536f987308ad3e93bbb18274e11c6834c) bitwig-studio: fix hash
* [`594399e5`](https://github.com/NixOS/nixpkgs/commit/594399e51a94884a82f3c482c9ab7a044d956c3f) python3Packages.certbot: 1.12.0 -> 1.13.0
* [`d869ed77`](https://github.com/NixOS/nixpkgs/commit/d869ed778e9a4164746fb927fbb905b8fd10b523) python3Packages.acme: remove mock from propagatedBuildInputs
* [`b9c178aa`](https://github.com/NixOS/nixpkgs/commit/b9c178aa6d899eaa35b919295816d7d5b3c6cdc2) simp_le: add mock to checkInputs
* [`d80e1d24`](https://github.com/NixOS/nixpkgs/commit/d80e1d2473ab2ff1176de2268a4dea5a4000f111) duf: 0.6.0 -> 0.6.2
* [`91317794`](https://github.com/NixOS/nixpkgs/commit/9131779490b81e6c81af178a7c367357b05a6dcb) vmware-horizon-client: use pkgs.cairo instead of bundled version
* [`6444c442`](https://github.com/NixOS/nixpkgs/commit/6444c4420cd1b95b7d88368d2d160355d7bc4acb) rss2email: 3.12.1 -> 3.13 ([nixos/nixpkgs⁠#118371](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118371))
* [`ada287e3`](https://github.com/NixOS/nixpkgs/commit/ada287e34bb334f4dd82cb9466e60fb694d4e813) kodi.packages.netflix: 1.14.1 -> 1.15.0
* [`226a0ef4`](https://github.com/NixOS/nixpkgs/commit/226a0ef401e43740730ea71bbf22b7ae69fef9cd) kodi.packages.inputstream-adaptive: 2.6.7 -> 2.6.8
* [`142418d9`](https://github.com/NixOS/nixpkgs/commit/142418d94118ea7431f9d8ea4116f3be1845adfd) acousticbrainz-client: init at 0.1 ([nixos/nixpkgs⁠#115780](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/115780))
* [`dd2f61d2`](https://github.com/NixOS/nixpkgs/commit/dd2f61d22dc77bfd30a0c6d3ab8687c72f438653) .github/workflows/manual-*.yml: update cachix / install-nix actions
* [`3bbb11e0`](https://github.com/NixOS/nixpkgs/commit/3bbb11e0e577d82cddfc0bb10d56deab9c3764ce) clickclack: init at 0.1.1
* [`340194a7`](https://github.com/NixOS/nixpkgs/commit/340194a7b0d5972000ed7a4c9f3689873a861764) python3Packages.aiorpcx: 0.18.4 -> 0.18.7
* [`de89b66b`](https://github.com/NixOS/nixpkgs/commit/de89b66ba78d5b5dcf7c06384df2ee8f97c1da44) electrum: 4.0.9 -> 4.1.1
* [`76f9ddf4`](https://github.com/NixOS/nixpkgs/commit/76f9ddf4700d1132a2ad604185b1af4885e18b5a) libfyaml: enable tests
* [`eae0b8fb`](https://github.com/NixOS/nixpkgs/commit/eae0b8fbfb9b2e4c348b33ca030eb79b3c30ee62) blender: 2.91.0 -> 2.92.0
* [`f9bd8b1b`](https://github.com/NixOS/nixpkgs/commit/f9bd8b1b7bda019a823e93a0ecb719e15ac620cb) nixos/home-assistant: use overridePythonAttrs
* [`8442c216`](https://github.com/NixOS/nixpkgs/commit/8442c216af8ce966796d3096e5ef21b1f20887fb) nixos/shiori: fix SystemCallFilter after libseccomp update ([nixos/nixpkgs⁠#108160](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/108160))
* [`dcbcfae5`](https://github.com/NixOS/nixpkgs/commit/dcbcfae56e81ede914e94599fa5690112fb69ba5) ytfzf: 1.1.1 -> 1.1.2 ([nixos/nixpkgs⁠#118393](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118393))
* [`68a1f6f3`](https://github.com/NixOS/nixpkgs/commit/68a1f6f391a2b67e0b93cdb7f70c29bded15dd84) foot: fix PGO build with clang
* [`6c1566fa`](https://github.com/NixOS/nixpkgs/commit/6c1566fab75e6eafce4aeb41536c7e0468b1e690) foot: remove usage of stdenv.cc.cc.pname
* [`4a16f2ec`](https://github.com/NixOS/nixpkgs/commit/4a16f2ec94643dfa24f0ad0737d9bcebcf8fd464) foot: add tests checking the clang compilation to the package
* [`d6a67759`](https://github.com/NixOS/nixpkgs/commit/d6a67759e7743bb80a0bc66c860a7f51a902816d) foot: 1.7.0 -> 1.7.1
* [`216ce448`](https://github.com/NixOS/nixpkgs/commit/216ce4486f1b955e0cf65823c610cf01fdac1179) thrift-0_10: mark as insecure
* [`3d2bd75f`](https://github.com/NixOS/nixpkgs/commit/3d2bd75fc2b433a6b4d2b6126f06a9009c8f3af7) thrift: mark as insecure
* [`6242f38c`](https://github.com/NixOS/nixpkgs/commit/6242f38c3058f5a9136b357d0fa0598c18bd5cae) gnuradio: enable gr-vocoder
* [`02221219`](https://github.com/NixOS/nixpkgs/commit/0222121978a40ce4fee946402681e40b863919d1) python3Packages.zeroconf: 0.28.8 -> 0.29.0
* [`e29f991f`](https://github.com/NixOS/nixpkgs/commit/e29f991f1f37a3c7b4342e3b14cd1c89806be300) python3Packages.python-miio: allow later zeroconf releases
* [`876deb41`](https://github.com/NixOS/nixpkgs/commit/876deb41036d1618fbcc005a537afc718a53c1a6) expliot: 0.9.6 -> 0.9.7
* [`de5d734e`](https://github.com/NixOS/nixpkgs/commit/de5d734e0cdefc9241f9c687538e5bdeda0e52d6) python3Packages.pynetdicom: 1.5.5 -> 1.5.6
* [`43f47196`](https://github.com/NixOS/nixpkgs/commit/43f471964941c180ce3f1e69845da498be18d4ca) Revert "zigbee2mqtt: 1.16.2 -> 1.18.2"
* [`1a037df4`](https://github.com/NixOS/nixpkgs/commit/1a037df4d2079f4fed65d72888bb10658de823a9) python3Packages.aioshelly: 0.6.1 -> 0.6.2
* [`b465c2e3`](https://github.com/NixOS/nixpkgs/commit/b465c2e3fdda16be380eea13117ac6f1c36cadf9) python3Packages.axis: 43 -> 44
* [`f86e033b`](https://github.com/NixOS/nixpkgs/commit/f86e033b86844e2729f264396973583d13137fe4) home-assistant: enable axis tests
* [`64678850`](https://github.com/NixOS/nixpkgs/commit/64678850c9cbf4244d571e39ecc6c0ff66dc4624) blender: make darwin patch apply again
* [`a1579f70`](https://github.com/NixOS/nixpkgs/commit/a1579f7076b76e36386fbce11c4d014a1195d3be) betterdiscordctl: 1.7.0 -> 1.7.1
* [`5e8ff7b3`](https://github.com/NixOS/nixpkgs/commit/5e8ff7b3b9ab850131654bb80873fd7b4e134615) pythonPackages.pyturbojpeg: init at 1.4.1
* [`7a3f21c1`](https://github.com/NixOS/nixpkgs/commit/7a3f21c1e453a57b5bbd5135bac2bfce7dc37d87) linux: don't compress by ZSTD on 32-bit
* [`f822651e`](https://github.com/NixOS/nixpkgs/commit/f822651e70d83a87c38b0f2367086b0d7cdb4b33) tree-sitter: Add aarch64 support
* [`24ad481a`](https://github.com/NixOS/nixpkgs/commit/24ad481a61a44e7aa06089324d3a4b7c426c82c4) bluespec: unstable-2021.02.14 -> 2021.03.29
* [`36392596`](https://github.com/NixOS/nixpkgs/commit/363925961ec29e23a52905d068d02912dfc38a42) gdal_1_11: remove old and unused version
* [`54dcdfb5`](https://github.com/NixOS/nixpkgs/commit/54dcdfb59b1d4b427796bba4d518b791bb5d427a) gdal_2: keep using pythn 2
* [`58579c64`](https://github.com/NixOS/nixpkgs/commit/58579c642a52e3c968070c21869b7fb03407c005) gede: use python3
* [`76b3f90f`](https://github.com/NixOS/nixpkgs/commit/76b3f90f5c4ec8289bdd858a2f5c8d52ed250331) gemrb: stay with python2
* [`09b2a0c0`](https://github.com/NixOS/nixpkgs/commit/09b2a0c0afbe659d48ac82bac6c0ca0692a9e07b) gen-oauth-safe: use python3
* [`e5f9db31`](https://github.com/NixOS/nixpkgs/commit/e5f9db31352ccd43e607ee8c68d5bfb74c075ef8) git-bz: stay with python2
* [`ea7d049f`](https://github.com/NixOS/nixpkgs/commit/ea7d049f51dab6f001bbd887c4a9f65ed36e5107) git-crecord: stay with python2
* [`ee258981`](https://github.com/NixOS/nixpkgs/commit/ee258981bff4542f1a5b916dc0f36a0616ccf9ad) ginac: use python3
* [`5c8e424b`](https://github.com/NixOS/nixpkgs/commit/5c8e424b84546ff47a26b2ecd93d56b4da78e6b7) gitstats: stay with python2
* [`34c23dbb`](https://github.com/NixOS/nixpkgs/commit/34c23dbb42601fd502d9f04f9fd854df0adfddca) global: use python3
* [`c85a6400`](https://github.com/NixOS/nixpkgs/commit/c85a64002c62623c41886964182d4f71d1a009f1) gnubg: use python3
* [`c817f644`](https://github.com/NixOS/nixpkgs/commit/c817f6442f1266c015be30a58791671a7f8c449a) gnuk: stay with python2
* [`233f08a8`](https://github.com/NixOS/nixpkgs/commit/233f08a87cb884023324779667b6687a4159db2a) gnuradioPackages: use same python for all packages
* [`ff06baf3`](https://github.com/NixOS/nixpkgs/commit/ff06baf396f5a2c090361561c84736ad9df0fc5b) grabserial: use python3
* [`45229e44`](https://github.com/NixOS/nixpkgs/commit/45229e4410c26af3106f189b4ebeb8843af3bbcc) grib-api: python is optional
* [`e9e4ca6b`](https://github.com/NixOS/nixpkgs/commit/e9e4ca6b4ae439a730f0419abd3d6945959383b2) libnl: python is optional
* [`a06641c0`](https://github.com/NixOS/nixpkgs/commit/a06641c08f5a105fb2a837e5be5d221e7d4d8218) gtimelog: use python3
* [`34adf2b6`](https://github.com/NixOS/nixpkgs/commit/34adf2b617ecf92234363567ad7575588a55ebcd) gtklick: stay with python2
* [`d8ed6258`](https://github.com/NixOS/nixpkgs/commit/d8ed6258b46399d41f0877fa16f9740e43ea53a0) gup: use python3
* [`7368564f`](https://github.com/NixOS/nixpkgs/commit/7368564f99e34b91a673274d8de0362cccc3f592) gurobi: stay with python2
* [`fe538efe`](https://github.com/NixOS/nixpkgs/commit/fe538efe61b1dc4eaea00d79a19a93fe21ead654) hash-slinger: stay with python2
* [`ba6f1213`](https://github.com/NixOS/nixpkgs/commit/ba6f1213f092aee58455a6f57f14cbf1257963dc) libreswan: use python3
* [`ae202269`](https://github.com/NixOS/nixpkgs/commit/ae202269faf37871b7a80abd1f238d0e5dcdaf25) hexio: stay with python2
* [`28647e4f`](https://github.com/NixOS/nixpkgs/commit/28647e4ff2115478dc7c7a2dfd82bd502bb865fb) honcho: use python3
* [`fa9d5aa4`](https://github.com/NixOS/nixpkgs/commit/fa9d5aa4aacd628d8f368ddfebcb6d105c7dc1b5) httpstat: use python3
* [`5bba64ad`](https://github.com/NixOS/nixpkgs/commit/5bba64adac3157ba85cc0dd686fcab25fc54277e) i3minator: use python3
* [`5984dd57`](https://github.com/NixOS/nixpkgs/commit/5984dd57d527555844599bafe8a4307716a19568) ibus-mozc: remove unused python parameter
* [`ecb85b08`](https://github.com/NixOS/nixpkgs/commit/ecb85b0865a73da55a803b352464b75599c6c143) icdiff: use python3
* [`8fccb64a`](https://github.com/NixOS/nixpkgs/commit/8fccb64af1be556f436d86262c844d3276ecff6b) hpx: use python3
* [`48816612`](https://github.com/NixOS/nixpkgs/commit/488166124e2ddbf3cc8e5727b6d70cfb9e9a072b) raul: use python3
* [`9a75e2f9`](https://github.com/NixOS/nixpkgs/commit/9a75e2f9fd14b769ae65bee5cde1fbd935593813) suil: use python3
* [`2a286fa3`](https://github.com/NixOS/nixpkgs/commit/2a286fa36061456b00c3acfe402e8e9dc2e2435c) ingen: use python3
* [`cd7593f8`](https://github.com/NixOS/nixpkgs/commit/cd7593f81590578d0a10725306aaea127f325141) innoextract: drop python as dep
* [`714961a4`](https://github.com/NixOS/nixpkgs/commit/714961a4943f2c99e1b50de88789fb365f794401) irker: use python3
* [`9fc74756`](https://github.com/NixOS/nixpkgs/commit/9fc74756bb093cd2accb0a120df70761afbaa12c) jalv: use python3
* [`0ca017da`](https://github.com/NixOS/nixpkgs/commit/0ca017dadc4ea9e355303986b77964faae0aa51f) jetbrains.pycharm-community: propagate python3
* [`8527e634`](https://github.com/NixOS/nixpkgs/commit/8527e634c36e1e1a3857331d8548db80358eca7f) intel-graphics-compiler: use python3
* [`32cf3252`](https://github.com/NixOS/nixpkgs/commit/32cf3252d1c2d6cc6b3ce555d02da71ad18f5e8d) ingen: fixup callPackage
* [`9029840d`](https://github.com/NixOS/nixpkgs/commit/9029840dc84f3108c57a49bb72d69db1073abfd1) jscoverage: use python3
* [`f812cdd3`](https://github.com/NixOS/nixpkgs/commit/f812cdd3b87394210dab147272f7fa46c19adcfa) kconfig-frontends: use python3
* [`732addbb`](https://github.com/NixOS/nixpkgs/commit/732addbb8186ff79be8e9fd29c6d8e84268a59dd) kcov: use python3
* [`1b213f32`](https://github.com/NixOS/nixpkgs/commit/1b213f321cdbfcf868b96fd9959c24207ce1b66a) kippo: remove broken package
* [`f9778bb1`](https://github.com/NixOS/nixpkgs/commit/f9778bb1dc050c32ba1bf48ff100860f30511fb3) klayout: use python3
* [`6809a2d5`](https://github.com/NixOS/nixpkgs/commit/6809a2d5a95a7321e3ec1386fa1881873cab40a2) kmsxx: python is optional
* [`90198ed9`](https://github.com/NixOS/nixpkgs/commit/90198ed989b23ca4f38e7f1c47e00f9b720fc772) kmsxx: mark broken
* [`3502d57d`](https://github.com/NixOS/nixpkgs/commit/3502d57d7a48098bafcafe9645c338b32b06a2bb) ksh: use python3
* [`12585844`](https://github.com/NixOS/nixpkgs/commit/12585844a372fd12b3e744ce1f330fad9e7a49e0) lastfmsubmitd: use python2
* [`7865ac10`](https://github.com/NixOS/nixpkgs/commit/7865ac104676c59892f64be2b413227a7d0572ec) lean2: stay with python2
* [`993f3e4b`](https://github.com/NixOS/nixpkgs/commit/993f3e4b4e0daf717d541ee388a26a7dc1fddc72) libcint: use python3
* [`b89e2d2e`](https://github.com/NixOS/nixpkgs/commit/b89e2d2ed0b375b4dbe04204aff0aa8be2db572a) libclc: use python3
* [`7686edc5`](https://github.com/NixOS/nixpkgs/commit/7686edc5ae72d9bfdd70b79f51cc76e2e0b7025b) libiio: call with python3
* [`cca1d52b`](https://github.com/NixOS/nixpkgs/commit/cca1d52bbc5cb8af0042cae80027cdde413be126) libinjection: stay with python2
* [`e8cd2296`](https://github.com/NixOS/nixpkgs/commit/e8cd2296ca4113a8c47f75f7ea7f87da0d297f3f) mbedtls: use python3
* [`b1f6fed0`](https://github.com/NixOS/nixpkgs/commit/b1f6fed005a2a85b407d09c8bd3f0c4b2f405f58) libplist: python is optional
* [`bba77d5b`](https://github.com/NixOS/nixpkgs/commit/bba77d5b4348d2e1a9d1da728e1dbbf01e198e10) liblinphone: use python3
* [`24d008a9`](https://github.com/NixOS/nixpkgs/commit/24d008a9f4764c99699cd26744c2ada3212bdc51) mediastreamer: use python3
* [`d20a05e9`](https://github.com/NixOS/nixpkgs/commit/d20a05e9630bce28b77d8f6733ef9b78c00c85d8) libpoly: use python3
* [`939a00f0`](https://github.com/NixOS/nixpkgs/commit/939a00f04b5493965d1eb6d7d741278137f6b2b6) libredwg: python is optional
* [`a1352be6`](https://github.com/NixOS/nixpkgs/commit/a1352be6c003e85f7b32f30c5c1fb6a786dbfe96) plasma5Packages.discover: use python3
* [`9645c0b3`](https://github.com/NixOS/nixpkgs/commit/9645c0b3fac3fe309a643ac6ec051681711e20c5) kapidox: use python3, fix build
* [`8654e483`](https://github.com/NixOS/nixpkgs/commit/8654e4836c3637309d53e73c96d612a66e59024d) kcachegrind: use python3
* [`eca71656`](https://github.com/NixOS/nixpkgs/commit/eca7165648d8d45d05fe2518b408363ba60d00f5) kdebugsettings: use python3
* [`eed84b9b`](https://github.com/NixOS/nixpkgs/commit/eed84b9b6584557b83c0e753baca6b3c044c09b9) minuet: use python3
* [`6a5049cb`](https://github.com/NixOS/nixpkgs/commit/6a5049cb30bdd12ec227a9cad9b9b2e3fafebe77) gdal_1_11: add alias
* [`5a28fc17`](https://github.com/NixOS/nixpkgs/commit/5a28fc174a00b8c21eb70700cd3561eb6cafb50d) python3Packages.httpsig: fix build
* [`a04f64cd`](https://github.com/NixOS/nixpkgs/commit/a04f64cd5ea5c02115fde330daca53bd76647fac) python3Packages.pynetdicom: disable failing tests
* [`63d6d99f`](https://github.com/NixOS/nixpkgs/commit/63d6d99f6dd59e500b208ccbc0f96a0dd04b7712) cmake-format: Fix missing dependency ([nixos/nixpkgs⁠#118388](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118388))
* [`dd9862ba`](https://github.com/NixOS/nixpkgs/commit/dd9862ba9831195f58421a7ff23388c92cd5a8e5) jack2Full: deprecate alias
* [`990f2778`](https://github.com/NixOS/nixpkgs/commit/990f2778f573a452a6abe07378fb8b75c91d65fc) home-assistant: update component-packages.nix
* [`a8c0dbda`](https://github.com/NixOS/nixpkgs/commit/a8c0dbdab9f446b6264aba18a645c47f84b839cf) home-assistant: test homekit component
* [`55abe2a9`](https://github.com/NixOS/nixpkgs/commit/55abe2a96371563c21c6fbaa1d5c453b513d7763) home-assistant: update component-packages.nix
* [`b94f2dfd`](https://github.com/NixOS/nixpkgs/commit/b94f2dfd168bb4607f2ca8661f9ab609e0b91a86) home-assistant: test freebox component
* [`ebe4e81a`](https://github.com/NixOS/nixpkgs/commit/ebe4e81a71eb9fb0636617a35ceb74ed95c7f494) libzen: 0.4.38 -> 0.4.39
* [`e4c1ca9b`](https://github.com/NixOS/nixpkgs/commit/e4c1ca9b7ca921543ccdfcdaee38f168861e851a) exa: unstable-2021-01-14 -> 0.10.0
* [`9531c4ad`](https://github.com/NixOS/nixpkgs/commit/9531c4adefd7fca359acee9e90f58bfe182dae4b) v2ray: 4.36.2 -> 4.37.0
* [`0d12b459`](https://github.com/NixOS/nixpkgs/commit/0d12b459918a2b686cb8d6c80bcc9fcef458ab83) mediainfo-gui: 20.09 -> 21.03
* [`bfeba88b`](https://github.com/NixOS/nixpkgs/commit/bfeba88bb3a4e626cd91d200169ef20235badfeb) libmediainfo: 20.09 -> 21.03
* [`8b0b632f`](https://github.com/NixOS/nixpkgs/commit/8b0b632f881d43bfbba69dd5cdeb46cc6bd55437) metasploit: 6.0.37 -> 6.0.38
* [`8d0b81ca`](https://github.com/NixOS/nixpkgs/commit/8d0b81ca5d15669cf91ce8da7fe9167dc33ab0c5) python3Packages.aqualogic: 2.5 -> 2.6
* [`525420ef`](https://github.com/NixOS/nixpkgs/commit/525420ef36e5de7ccb4ae97aa1e5d477410196aa) gnuradio3_8: 3.8.2.0 -> 3.8.3.0
* [`d8645cfe`](https://github.com/NixOS/nixpkgs/commit/d8645cfe6f5b21523b18e2ff72bf568fc40c93c8) papirus-icon-theme: 20210302 -> 20210401
* [`07700e51`](https://github.com/NixOS/nixpkgs/commit/07700e51dc3c9671b878eadb835a242c8ad65953) gnuradio: remove volk cmake flags mistakenly added
* [`1845f7a0`](https://github.com/NixOS/nixpkgs/commit/1845f7a077ee8aef9c33b031a4ed7fcf7e2958bf) home-assistant: set platforms to linux
* [`a054e8b9`](https://github.com/NixOS/nixpkgs/commit/a054e8b903692994bc75b00dcc5dbcd7c3fae057) thrift: 0.13.0 -> 0.14.1
* [`9378fdf8`](https://github.com/NixOS/nixpkgs/commit/9378fdf87e0626e8c63a90a378c38444ff54808b) iproute: deprecate alias
* [`dcb501f9`](https://github.com/NixOS/nixpkgs/commit/dcb501f99325920c7f9df536b738f863c12a165e) kerberos: deprecate alias
* [`62733b37`](https://github.com/NixOS/nixpkgs/commit/62733b37b4a866cabafe1fc8bb7415240126eb0b) mysql: deprecate alias
* [`8e1db896`](https://github.com/NixOS/nixpkgs/commit/8e1db896a39cbcae79924534a6e383c58f5db7f9) all-packages: format to make readable
* [`33a395f1`](https://github.com/NixOS/nixpkgs/commit/33a395f1957ed8da558f8a145c2e06a428779eb0) yacc: deprecate alias
* [`d24e2d1b`](https://github.com/NixOS/nixpkgs/commit/d24e2d1b0ba77da1ea5b91fcf6cf869d42880dc5) gmock: deprecate alias
* [`06021016`](https://github.com/NixOS/nixpkgs/commit/06021016f15ce33886fe3f7ee49d512a83ff2369) tflint: 0.25.0 -> 0.26.0
* [`db5a1567`](https://github.com/NixOS/nixpkgs/commit/db5a15676cfa0b072d271e76fe1c7825907a833a) nixos/nginx: set "recommended" proxy timeouts to 60s
* [`673d561c`](https://github.com/NixOS/nixpkgs/commit/673d561cd26888679a46ac0fe986ed2150aa1bce) shellharden: init at 4.1.2
* [`f4593abd`](https://github.com/NixOS/nixpkgs/commit/f4593abda0dae0e4b0e42cbceb1681f29b82a479) deno: 1.8.2 -> 1.8.3
* [`68e901c6`](https://github.com/NixOS/nixpkgs/commit/68e901c68446539165b19b227f51f7fc2b3655f9) pythonPackages.zopfli: 0.1.7 -> 0.1.8
* [`d2076566`](https://github.com/NixOS/nixpkgs/commit/d2076566908a3eb90f0b6ee58050527ac5f10ae8) duplicity: reduce closure size
* [`d9a164a4`](https://github.com/NixOS/nixpkgs/commit/d9a164a401ae1d44d7ccf42026d62405cfc009f0) python3Packages.discordpy: 1.6.0 -> 1.7.0
* [`144a8769`](https://github.com/NixOS/nixpkgs/commit/144a8769a92d60a87210bbf24501a7d48ffc6d9f) apple-music-electron: fix desktop file exec path
* [`67f3319f`](https://github.com/NixOS/nixpkgs/commit/67f3319fb7ebd3284561246b3f2943b8db31d45f) wpa_supplicant: Enable bgscan 'learn' module
* [`9a3bd785`](https://github.com/NixOS/nixpkgs/commit/9a3bd785356ab763985fd62bad7643d1d6a3e6f4) cargo-make: 0.32.15 -> 0.32.16
* [`0ae5e0e7`](https://github.com/NixOS/nixpkgs/commit/0ae5e0e7841b325255b1a130bf3751c781bd6a63) chezmoi: 2.0.7 -> 2.0.8
* [`0194b6a9`](https://github.com/NixOS/nixpkgs/commit/0194b6a9d337e17e1664302d2ef8c0244a0c1790) coordgenlibs: 2.0.0 -> 2.0.2
* [`3453b89f`](https://github.com/NixOS/nixpkgs/commit/3453b89f4bba270e2d82f6248b09b9595bb47f4b) lzma: deprecate alias
* [`f9bcee4e`](https://github.com/NixOS/nixpkgs/commit/f9bcee4ed5409c8a2e76e7f2d9a5e46611d2e20e) darwin.text_cmds: Fix editor check
* [`adfad6c5`](https://github.com/NixOS/nixpkgs/commit/adfad6c5b88a2d720bb8baf944573a4626a3f8c5) crlfuzz: 1.4.0 -> 1.4.1
* [`a528b5b7`](https://github.com/NixOS/nixpkgs/commit/a528b5b7e926a87fa5a6bb12e0eab3ecd925acf7) python3Packages.minio: add certifi
* [`7ad342bc`](https://github.com/NixOS/nixpkgs/commit/7ad342bc0d5bc6ffc0d21cfd2cf514786d10d9ea) python3Packages.fiona: add missing dependency
* [`ca120f61`](https://github.com/NixOS/nixpkgs/commit/ca120f6144a6406c78c2adc075399d1cb34c57b7) fselect: 0.7.3 -> 0.7.4
* [`96d742f7`](https://github.com/NixOS/nixpkgs/commit/96d742f7f180d4ad0ec6e76d95c54cd32f770743) python3Packages.pysmappee: 0.2.17 -> 0.2.18
* [`667da299`](https://github.com/NixOS/nixpkgs/commit/667da2996258b4f5c1fc98f2b1d3cba441a1618b) gnuradio3_8: remove fetchpatch from inputs (not used)
* [`9551b11d`](https://github.com/NixOS/nixpkgs/commit/9551b11d4f67c5ca5b52deaf2b6123956c42789c) home-assistant: enable smappee tests
* [`f78d635e`](https://github.com/NixOS/nixpkgs/commit/f78d635e4c03f21c18da3fd714aa55f84850474a) python3Packages.python-smarttub: 0.0.19 -> 0.0.21
* [`2c76567a`](https://github.com/NixOS/nixpkgs/commit/2c76567af391a2d0fa5a5b6909285a54368e7156) prometheus-domain-exporter: init at 1.10.0
* [`6840746f`](https://github.com/NixOS/nixpkgs/commit/6840746f2d155f564030a7270924eadda6b5aa52) nixos/prometheus-domain-exporter: init
* [`8479a427`](https://github.com/NixOS/nixpkgs/commit/8479a427cd92378e4fb665a950875153e6c7260c) devolutionx: 1.0.1 -> unstable-2020-10-20
* [`ac6d98db`](https://github.com/NixOS/nixpkgs/commit/ac6d98dbdcd5536f6ed6f68987280ff99d64813d) dash: move confusing comment
* [`f4ac75a5`](https://github.com/NixOS/nixpkgs/commit/f4ac75a56dcf0fdf045c04722ef6dcff7b12c2ee) dash: add libedit support
* [`101cc902`](https://github.com/NixOS/nixpkgs/commit/101cc9024b05f1ed80c7111da86825ff72ae4fa3) dash: enable parallel building
* [`5fa10aa3`](https://github.com/NixOS/nixpkgs/commit/5fa10aa313f16e2afedefc58806d1c0a40ed08df) cloud-hypervisor: 0.8.0 -> 0.14.1
* [`bb7da110`](https://github.com/NixOS/nixpkgs/commit/bb7da110d16c6bcf89ddb69f9c7e5aa72e1e3be2) vector: format with nixpkgs-fmt
* [`d434251d`](https://github.com/NixOS/nixpkgs/commit/d434251d1c71139085cd051e49d14fcebbfe8d47) vector: remove deprecated --no-topology
* [`1ccf0988`](https://github.com/NixOS/nixpkgs/commit/1ccf09884bc469a36bc89dfd098cb7196bdfff34) python3Packages.gsd: 1.9.3 -> 2.4.1
* [`97bb239d`](https://github.com/NixOS/nixpkgs/commit/97bb239d9d2a53565883f81b73f61cbaa419f459) recoll: drop assert on hostPlatform.system
* [`7ffdeb35`](https://github.com/NixOS/nixpkgs/commit/7ffdeb358b946250ac848b7257880bab615a2cc7) tellico: 3.3.3 -> 3.4
