### PR TITLE
niv home-manager: update cbf06670 -> cc60c22c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cbf0667037e6ca16fcc38818b2aa1391de702c6a",
-        "sha256": "14s01yhwkb8p1kwlmiaky7ygnb14mivskczsxypsxdp10q8r3y9h",
+        "rev": "cc60c22c69e6967b732d02f072a9f1e30454e4f6",
+        "sha256": "191w8ps6m8kf2fxdbmcsa75j5bbirrvgb2cavrj69dkhsll9czh7",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/cbf0667037e6ca16fcc38818b2aa1391de702c6a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/cc60c22c69e6967b732d02f072a9f1e30454e4f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@cbf06670...cc60c22c](https://github.com/nix-community/home-manager/compare/cbf0667037e6ca16fcc38818b2aa1391de702c6a...cc60c22c69e6967b732d02f072a9f1e30454e4f6)

* [`90223cf3`](https://github.com/nix-community/home-manager/commit/90223cf3eb33863dff50fc240a5728ebdf249303) home-manager: allow overriding pkgs with --arg(str) ([nix-community/home-manager⁠#1889](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1889))
* [`447ed0fb`](https://github.com/nix-community/home-manager/commit/447ed0fbcb5be449e977d8c094e52e2172f600d2) bash: improve initialisation ([nix-community/home-manager⁠#1850](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1850))
* [`ad04237d`](https://github.com/nix-community/home-manager/commit/ad04237d5142f53dcba258942b78e2d2bbf210c8) dircolors: apply extraConfig after settings ([nix-community/home-manager⁠#1890](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1890))
* [`6e3d93d7`](https://github.com/nix-community/home-manager/commit/6e3d93d7ccf0ec0f5faebc6a6a550a1299ca0d39) xdg-user-dirs: add createDirectories option
* [`25a6a6d2`](https://github.com/nix-community/home-manager/commit/25a6a6d2984e70c9a07c8f8a69ebe24e6c700abf) neomutt: support list in binds.map ([nix-community/home-manager⁠#1885](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1885))
* [`cc60c22c`](https://github.com/nix-community/home-manager/commit/cc60c22c69e6967b732d02f072a9f1e30454e4f6) programs.git: make signing key id be optional ([nix-community/home-manager⁠#1886](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1886))
