### PR TITLE
niv nixpkgs-fmt: update 148ec478 -> 3efa82f9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "148ec47877499e3d671f6366f9eed812db181b40",
-        "sha256": "0dqirvn8pq6ssxjlf6rkqcsx6ndasws93lz2v9f9s01k9ny8x8mq",
+        "rev": "3efa82f9bf2868177b63d771862bd74ad8b54a85",
+        "sha256": "0cvlicjczhdraj5sdwdxrhw4jszjka5msg8mv5fdg9p2garcpkgn",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/148ec47877499e3d671f6366f9eed812db181b40.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/3efa82f9bf2868177b63d771862bd74ad8b54a85.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@148ec478...3efa82f9](https://github.com/nix-community/nixpkgs-fmt/compare/148ec47877499e3d671f6366f9eed812db181b40...3efa82f9bf2868177b63d771862bd74ad8b54a85)

* [`9b8863a4`](https://github.com/nix-community/nixpkgs-fmt/commit/9b8863a4e3d46dd37280d86201e5f75d0be4aa17) Remove indentation for lambda function in top level
* [`0ba03e7f`](https://github.com/nix-community/nixpkgs-fmt/commit/0ba03e7f464251cdc98555ba92e189ef63f4c288) Bump cachix/cachix-action from v8 to v9
* [`ee6c6645`](https://github.com/nix-community/nixpkgs-fmt/commit/ee6c6645f203077472454f20acfb2388ec077c3f) Bump cachix/install-nix-action from v12 to v13
* [`5d909589`](https://github.com/nix-community/nixpkgs-fmt/commit/5d909589e0ad434c2e6c34cdb3dd6e60b1c4e6ed) fix ordering error in CI
* [`3efa82f9`](https://github.com/nix-community/nixpkgs-fmt/commit/3efa82f9bf2868177b63d771862bd74ad8b54a85) Bump cachix/cachix-action from v9 to v10 ([nix-community/nixpkgs-fmt⁠#240](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/nixpkgs-fmt/issues/240))
