### PR TITLE
niv powerlevel10k: update af86b530 -> b55ad16b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "af86b53047ea6d6866dc5dae83eb219e691b9c76",
-        "sha256": "16b82cg57i83ki0vkwsc0pypf6y3w8kr5w02968s4c53av5j0jjb",
+        "rev": "b55ad16bdf747e7ff6a3c821d92ed942d4e3be7c",
+        "sha256": "1qgxdjxw5878iknxaf5fdnxm9d9mphfdsfl8prdpak6pgqj6kphx",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/af86b53047ea6d6866dc5dae83eb219e691b9c76.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/b55ad16bdf747e7ff6a3c821d92ed942d4e3be7c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@af86b530...b55ad16b](https://github.com/romkatv/powerlevel10k/compare/af86b53047ea6d6866dc5dae83eb219e691b9c76...b55ad16bdf747e7ff6a3c821d92ed942d4e3be7c)

* [`4d15cf97`](https://github.com/romkatv/powerlevel10k/commit/4d15cf977eb82ec127fd7ddfab281194765748e2) Get active gcloud profile using `list` command ([romkatv/powerlevel10k⁠#1331](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1331))
* [`8b2aab74`](https://github.com/romkatv/powerlevel10k/commit/8b2aab74d446d631ff6e85ceb7ab827a38932650) Add CPU load threshold setting ([romkatv/powerlevel10k⁠#1340](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1340))
* [`8dc91004`](https://github.com/romkatv/powerlevel10k/commit/8dc91004cb0a46898856bfac5fa66b1019824408) Fix gcloud CLI ([romkatv/powerlevel10k⁠#1342](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1342))
* [`30bd9461`](https://github.com/romkatv/powerlevel10k/commit/30bd9461b3f013bc4c529de0a123db89a92a87c7) replace POWERLEVEL9K_LOAD_THRESHOLD with POWERLEVEL9K_LOAD_{WARNING,CRITICAL}_PCT ([romkatv/powerlevel10k⁠#1340](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1340))
* [`b55ad16b`](https://github.com/romkatv/powerlevel10k/commit/b55ad16bdf747e7ff6a3c821d92ed942d4e3be7c) bug fix: segments whose state contains numbers could not be hidden ([romkatv/powerlevel10k⁠#1353](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1353))
