### PR TITLE
niv nixpkgs: update 7c932296 -> 06bad855

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c932296e05b32e5414140d69aac75a039d0a7f0",
-        "sha256": "1m5mznplajgv6bzag0p16kb2ya5i4n2qkwj65p4nlj4waalbcpjj",
+        "rev": "06bad85574280676fec907234bcb58281058c0d2",
+        "sha256": "0knixl7c6s83003rnsriykh13bk0wvc372nr46ryfp7542agy5ql",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7c932296e05b32e5414140d69aac75a039d0a7f0.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/06bad85574280676fec907234bcb58281058c0d2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7c932296...06bad855](https://github.com/nixos/nixpkgs/compare/7c932296e05b32e5414140d69aac75a039d0a7f0...06bad85574280676fec907234bcb58281058c0d2)

* [`ecc1a0ff`](https://github.com/NixOS/nixpkgs/commit/ecc1a0ff708d9916fa279b4f1fb931825ed7cd99) pythonPackages.splinter: fix build
* [`cca6c852`](https://github.com/NixOS/nixpkgs/commit/cca6c852312a1e4ef17e626dc3f0f8e52bf38bc1) httpx: 1.0.3 -> 1.0.4
* [`9501203d`](https://github.com/NixOS/nixpkgs/commit/9501203dc10b7604ca2c084728859620a5d9dcec) pythia: 8.303 -> 8.304
* [`558b4bcf`](https://github.com/NixOS/nixpkgs/commit/558b4bcf16c27dd460049ce2d1dbf6a30487f01f) imgproxy: 2.16.2 -> 2.16.3
* [`eff2b5d2`](https://github.com/NixOS/nixpkgs/commit/eff2b5d29f9818d977af5710df9d2ee4e27a9573) jbang: 0.69.2 -> 0.70.0
* [`6ed757b4`](https://github.com/NixOS/nixpkgs/commit/6ed757b460731d10200e7d90a6266e5b6dc7048b) lazygit: 0.26.1 -> 0.27.3
* [`723a8da8`](https://github.com/NixOS/nixpkgs/commit/723a8da830f1a4826437421161dd4fc75cd61fb8) libqalculate: 3.17.0 -> 3.18.0
* [`c69e6e52`](https://github.com/NixOS/nixpkgs/commit/c69e6e52e8e9be2ae5f2de85c9698e030ca2d70a) python3Packages.pytest-subprocess: init at 1.0.1
* [`aff13753`](https://github.com/NixOS/nixpkgs/commit/aff13753d4ee49d32d22d3dc37846ef4c2918070) spotdl: 3.5.0 -> 3.5.1
* [`6b577f46`](https://github.com/NixOS/nixpkgs/commit/6b577f46b4d0f612321eb5ab6e410a95f0074c4a) nixos/spacecookie: use nix style strings for description
* [`8abd77c8`](https://github.com/NixOS/nixpkgs/commit/8abd77c8118c10702d7226379649a2e63d922d5c) nixos/tests/spacecookie: refactor
* [`58be28d7`](https://github.com/NixOS/nixpkgs/commit/58be28d7ce5b559c1547d437743ec7890b43eff5) nixos/spacecookie: add package option
* [`d1f57cba`](https://github.com/NixOS/nixpkgs/commit/d1f57cbaf02be1ea3434563446c417ef98748568) nixos/spacecookie: add openFirewall option
* [`b74821f3`](https://github.com/NixOS/nixpkgs/commit/b74821f31b468d8a302b07e528bcce16c24e4b06) nixos/spacecookie: add address option customizing listen address
* [`76583ee8`](https://github.com/NixOS/nixpkgs/commit/76583ee81a1a2d1c8f467fd0c509bc7b4b79f17c) nixos/spacecookie: convert into settings-style freeform configuration
* [`d51edbe1`](https://github.com/NixOS/nixpkgs/commit/d51edbe17e978ec041917e81b8bfd94414bebf0c) nixos/spacecookie: reflect changes for spacecookie 1.0.0.0
* [`9c989f2f`](https://github.com/NixOS/nixpkgs/commit/9c989f2fd9471ec27c5b420fce6b8f2769fb70a6) spacecookie: add top-level attribute for haskellPackages.spacecookie
* [`773cfbf0`](https://github.com/NixOS/nixpkgs/commit/773cfbf027f2937dacedf69ce82d488e48f7a056) qownnotes: 21.3.2 -> 21.4.0
* [`2d42fde8`](https://github.com/NixOS/nixpkgs/commit/2d42fde8159b513283a8d3413a2288fa7ddc6a33) osm2pgsql: 1.4.1 -> 1.4.2
* [`3314db5a`](https://github.com/NixOS/nixpkgs/commit/3314db5a56144637ddb45480d52cc05e3b72f390) cdogs-sdl: init at 0.11.0 ([nixos/nixpkgs⁠#118949](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118949))
* [`e0e9ab3b`](https://github.com/NixOS/nixpkgs/commit/e0e9ab3b623f92d3ee050fcd4f7d664651b575ab) minio: 2021-03-26T00-00-41Z -> 2021-04-06T23-11-00Z
* [`ea4b7bdc`](https://github.com/NixOS/nixpkgs/commit/ea4b7bdc57c57cadcfb7034376c26525be4ae8cb) obsidian: 0.11.9 -> 0.11.13
* [`bcb7d810`](https://github.com/NixOS/nixpkgs/commit/bcb7d810cf8ce5132cf5d6af8bf07eca921cb02b) python3Packages.pydanfossair: init at 0.1.0
* [`5bfab71c`](https://github.com/NixOS/nixpkgs/commit/5bfab71cd80ed080e11c15daed6a45a55471aca8) home-assistant: update component-packages
* [`7a5b175c`](https://github.com/NixOS/nixpkgs/commit/7a5b175c597554132805d8e3bf7bb64914c0519d) oneDNN: 2.1.3 -> 2.2.1
* [`822c94a5`](https://github.com/NixOS/nixpkgs/commit/822c94a5576b033a861b4a8c0b77a8a2815b958e) openfpgaloader: 0.2.5 -> 0.2.6
* [`5ac1f455`](https://github.com/NixOS/nixpkgs/commit/5ac1f45541638836da28322f7b61cbfb9f3eb38d) octant: 0.18.0 -> 0.19.0
* [`2f1131cf`](https://github.com/NixOS/nixpkgs/commit/2f1131cff7ccff5fc2e7a29358984d200940215e) cc-wrapper: match useGccForLibs conditional order
* [`6378cdeb`](https://github.com/NixOS/nixpkgs/commit/6378cdebada6296cd3207ecf18372649881880fc) syncthing: 1.14.0 -> 1.15.1
* [`124aa021`](https://github.com/NixOS/nixpkgs/commit/124aa0218585de217fd6ae9a7dfb5a0699fafe36) python3Packages.expects: init at 0.9.0
* [`926d6ab2`](https://github.com/NixOS/nixpkgs/commit/926d6ab20daa901c1c13ac9e57ee1580aa444b1c) python3Packages.aiosyncthing: init at 0.5.1
* [`37b3deb7`](https://github.com/NixOS/nixpkgs/commit/37b3deb758e88bc1a695cc3abe7fc82ea3c1fb4c) imgproxy: fix build on Darwin
* [`fec6f0b1`](https://github.com/NixOS/nixpkgs/commit/fec6f0b152da41b439bf8197ad870399af820f87) python3Packages.aioemonitor: init at 1.0.5
* [`fb327d72`](https://github.com/NixOS/nixpkgs/commit/fb327d72dfdf5aa4984a1748c8bb5051287a198c) python3Packages.pyclimacell: init at 0.18.0
* [`7ff4a1eb`](https://github.com/NixOS/nixpkgs/commit/7ff4a1eb7969c6003d004c8d2d736db2eaf6265b) home-assistant: update component-packages
* [`b79e96e2`](https://github.com/NixOS/nixpkgs/commit/b79e96e2ed95ed789376da20624470201e2cdaba) gnomeExtensions.unite: 48 -> 49
* [`b9e77788`](https://github.com/NixOS/nixpkgs/commit/b9e777887721eff8391b848c1fe034a661ba3531) linux_xanmod: 5.11.12 -> 5.11.13
* [`83838f72`](https://github.com/NixOS/nixpkgs/commit/83838f72332968d7694a89386c5159ee2788a6d8) maintainers: add chivay
* [`e5b6e6f2`](https://github.com/NixOS/nixpkgs/commit/e5b6e6f2897ba9bb95d1c753b16ad687c581615e) hfinger: init at 0.2.0
* [`0b78980d`](https://github.com/NixOS/nixpkgs/commit/0b78980d678deeef61f76f50fbd395daba2f4467) python3Packages.pyenvisalink: init at 4.1
* [`2ea8e240`](https://github.com/NixOS/nixpkgs/commit/2ea8e240ff2abe079d2d31e764db7dbb9ef0d193) home-assistant: update component-packages
* [`8edca5ad`](https://github.com/NixOS/nixpkgs/commit/8edca5ad7943d4ea4f61be5c22cacb1fa8d10acd) motif: 2.3.6 -> 2.3.8; clarify license; adopt
* [`a3251fb2`](https://github.com/NixOS/nixpkgs/commit/a3251fb2e0ade5c4d83d41108cbabc6c79f2bd7e) motif: fix format-security
* [`d45fc07b`](https://github.com/NixOS/nixpkgs/commit/d45fc07bc29c1a3d0e1eac61666d020c5b0e3a47) nixos/postfix: add services.postfix.canonical opt
* [`f9cc3264`](https://github.com/NixOS/nixpkgs/commit/f9cc32641f0ff6c7692c6cbe5cd51351da84daeb) git-review: 1.28.0 -> 2.0.0
* [`ec2e4b2d`](https://github.com/NixOS/nixpkgs/commit/ec2e4b2d74b6a691e5ae42ece559462dc75cf51d) bazel-buildtools: 3.5.0 -> 4.0.1
* [`6b4de5af`](https://github.com/NixOS/nixpkgs/commit/6b4de5afecd074a96f1c459acc12ad5e5ef6d540) air: 1.15.1 -> 1.25
* [`76444805`](https://github.com/NixOS/nixpkgs/commit/764448055551a4c664a1b0e2cecfc61731b32c5d) python3Packages.snitun: disable failing test on darwin ([nixos/nixpkgs⁠#119009](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119009))
* [`cf25944d`](https://github.com/NixOS/nixpkgs/commit/cf25944d02f2c1703e278115bdaad4dced26d950) clpm: use sbcl 2.0.9 when building
* [`da55ee48`](https://github.com/NixOS/nixpkgs/commit/da55ee488f735b1ea2cbaa3a85b770a7e3b3daff) tcpdump: 4.9.3 -> 4.99.0
* [`1b662aa1`](https://github.com/NixOS/nixpkgs/commit/1b662aa1fa7ccfba441008bcccacaacebe5929c8) xfig: 3.2.8 -> 3.2.8a
* [`920ffc27`](https://github.com/NixOS/nixpkgs/commit/920ffc27cb1a6a4596cfeb65f95a88b6549c813d) fig2dev: 3.2.8 -> 3.2.8a
* [`0062afc0`](https://github.com/NixOS/nixpkgs/commit/0062afc0506491c2989a17eadf7239b5a7b38338) ocamlPackages.printbox: 0.4 → 0.5
* [`c7557da3`](https://github.com/NixOS/nixpkgs/commit/c7557da36ce9d9a031e19d10c0e3aae489ab4c80) python3Packages.wakeonlan: 2.0.0 -> 2.0.1
* [`5d775bb2`](https://github.com/NixOS/nixpkgs/commit/5d775bb2b0130ee099065a1cfcf8494ec4c89f14) chromiumBeta: Fix the build ([nixos/nixpkgs⁠#119087](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119087))
* [`9430cc2d`](https://github.com/NixOS/nixpkgs/commit/9430cc2da074f26f2267465b2146f8aa518c6f55) github-commenter: 0.8.0 -> 0.9.0
* [`2ae947c4`](https://github.com/NixOS/nixpkgs/commit/2ae947c401ece12823ef26f86af68c4e60e84939) octant-desktop: 0.18.0 -> 0.19.0
* [`144cf600`](https://github.com/NixOS/nixpkgs/commit/144cf60076c172dee4de29fa7b2cc70528609d20) python3Packages.hass-nabucasa: 0.42.0 -> 0.43.0
* [`c1f31aaf`](https://github.com/NixOS/nixpkgs/commit/c1f31aaf22d75dd6e2b1cfa3d82bcce8b9ad5d00) python3Packages.pycognito: 0.1.5 -> 2021.03.1
* [`687e55bf`](https://github.com/NixOS/nixpkgs/commit/687e55bfc0a29dd64cbe24c868350f6013e2f648) ifcopenshell: 0.6.0b0 -> 210410
* [`441f0c89`](https://github.com/NixOS/nixpkgs/commit/441f0c894aae2846190724828054e4bad9284579) mdevd: init at 0.1.3.0
* [`2df1ab33`](https://github.com/NixOS/nixpkgs/commit/2df1ab3378de8ff01086189f3ef1d8fb405a4990) python3Packages.twilio: 6.51.1 -> 6.56.0
* [`2140791f`](https://github.com/NixOS/nixpkgs/commit/2140791f9b2be837880a4e8cd03378f835cc94be) ocamlPackages.janeStreet{,_0_9_0}: join the ocamlPackages fix point, allowing overriding to work as expected ([nixos/nixpkgs⁠#113696](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/113696))
* [`fac3725e`](https://github.com/NixOS/nixpkgs/commit/fac3725e5bc5d960f79b9baf57cc1bf05ea0fd73) pythonPackages.karton-core: init at 4.2.0
* [`1dee5f43`](https://github.com/NixOS/nixpkgs/commit/1dee5f4388280a6e71f7d442a93d737c80c915c6) python3Packages.transformers: fix build
* [`9e9527b1`](https://github.com/NixOS/nixpkgs/commit/9e9527b1b4bc632f89039be243fdd285a153cb21) python3Packages.poetry: 1.1.4 -> 1.1.5
* [`89fb8850`](https://github.com/NixOS/nixpkgs/commit/89fb8850e0f0aa87c440442a6ac19fbc8439b550) librsync: 2.3.1 -> 2.3.2
* [`7dbe49ed`](https://github.com/NixOS/nixpkgs/commit/7dbe49ed1ad660ad36c35b56069ee98eb16f8955) rizin: 0.1.2 -> 0.2.0
* [`f381fecf`](https://github.com/NixOS/nixpkgs/commit/f381fecfd5b73509c67990ccfefbdabd8b87f748) cutter: 2.0.0 -> 2.0.1
* [`c17a2151`](https://github.com/NixOS/nixpkgs/commit/c17a2151bbddf9f73ec322b7b319d8246c6487da) python3Packages.pyemby: init at 1.7
* [`d7e919c6`](https://github.com/NixOS/nixpkgs/commit/d7e919c60ff5e1a6b9b483e28e8a656f6a04c1c2) home-assistant: update component-packages
* [`45ad2b29`](https://github.com/NixOS/nixpkgs/commit/45ad2b290f06732b137d5a7371ce5032357efa57) anki-bin: 2.1.40 -> 2.1.43
* [`7875699b`](https://github.com/NixOS/nixpkgs/commit/7875699b7edbc35be7700290e673cc3f082606dc) python3Packages.pythonegardia: init at 1.0.40
* [`5cae921f`](https://github.com/NixOS/nixpkgs/commit/5cae921f1e3bd51fce199be7c729ac43e9baac79) home-assistant: update component-packages
* [`b729d408`](https://github.com/NixOS/nixpkgs/commit/b729d4080a0b9108800a314e48921ea49a29c1ce) ocamlPackages.ocp-indent: use Dune 2
* [`9396e1b2`](https://github.com/NixOS/nixpkgs/commit/9396e1b2f0d927e222e50c8dae0ce567e15c34f7) pdfcpu: 0.3.9 -> 0.3.11
* [`76019785`](https://github.com/NixOS/nixpkgs/commit/76019785f6ca319f97b39084f7a39534e41cc69b) python3Packages.aiolip: init at 1.1.4
* [`d93a7946`](https://github.com/NixOS/nixpkgs/commit/d93a794679e8068093bc9f3f3739c2f32c40a849) python3Packages.pylutron-caseta: init at 0.9.0
* [`f66278d0`](https://github.com/NixOS/nixpkgs/commit/f66278d07467bfe9eb7b45e9c501454434464b6d) home-assistant: update component-packages
* [`24079ff7`](https://github.com/NixOS/nixpkgs/commit/24079ff7e8e36c6519ce03ec20a8f6bd5001888a) home-assistant: enable lutron_caseta tests
* [`a9dc1be6`](https://github.com/NixOS/nixpkgs/commit/a9dc1be62f02910641f165b7fd54f6f3522c6e7e) python3Packages.nexia: init at 0.9.6
* [`d83386c8`](https://github.com/NixOS/nixpkgs/commit/d83386c85ff41f3bccfcd2ceeb01b3d064561cf3) python3Packages.python-telegram-bot: 13.3 -> 13.4.1
* [`12b2b8ba`](https://github.com/NixOS/nixpkgs/commit/12b2b8ba2b83e573b4acd7a52f149550888264a2) promscale: 0.2.1 -> 0.3.0
* [`48d9b452`](https://github.com/NixOS/nixpkgs/commit/48d9b4524a17ce1b06d2d3cbc8c60fb892e0cfa5) python3Packages.pyeconet: init at 0.1.13
* [`14c2dd37`](https://github.com/NixOS/nixpkgs/commit/14c2dd372b10eeacf31326bf5a1a2d52b40e259c) home-assistant: update component-packages
* [`ca7c3c73`](https://github.com/NixOS/nixpkgs/commit/ca7c3c7377c20d8c8f39a28bd3c1039def511e3c) home-assistant: enable econet tests
* [`eba83c89`](https://github.com/NixOS/nixpkgs/commit/eba83c89474bde0ea3433e8e5f54b2c7e0bbc2de) fava: update maintainers
* [`12518ff6`](https://github.com/NixOS/nixpkgs/commit/12518ff683a46858bbe06aaf5fef4b88b4ea9e15) rink: 0.5.1 -> 0.6.0
* [`dec72fd1`](https://github.com/NixOS/nixpkgs/commit/dec72fd10e73f55d5498466632634cc2a424a9cf) pulumi-bin: 2.23.2 -> 2.24.1
* [`e1760f89`](https://github.com/NixOS/nixpkgs/commit/e1760f89be271833d2000d7397351a3ff6527073) polkadot: fix invalid cargoSha256
* [`caf96de6`](https://github.com/NixOS/nixpkgs/commit/caf96de667310ec968d85e97502d8fe3529890bd) aws-workspaces: 3.1.3.925 -> 3.1.5.1105
* [`33ac5ff0`](https://github.com/NixOS/nixpkgs/commit/33ac5ff09b354507a965b0fdfaadb69745f86b23) rtsp-simple-server: 0.15.3 -> 0.15.4
* [`efc1197d`](https://github.com/NixOS/nixpkgs/commit/efc1197dd6a74e1c7db7cb6bdc13e0bb7737f765) python3Packages.karton-classifier: init at 1.0.0
* [`be0b5f26`](https://github.com/NixOS/nixpkgs/commit/be0b5f26b18ff2882b252ac851e8f5f358b963cf) medfile: use hdf5 1.10
* [`b3fe6407`](https://github.com/NixOS/nixpkgs/commit/b3fe64070ffc79c5c523ab56a645f7be0034ae92) python3Packages.sleepyq: init at 0.8.1
* [`9f1ef12b`](https://github.com/NixOS/nixpkgs/commit/9f1ef12b1a7629ccbb9a9e55ce1dd380a154dbe7) home-assistant: update component-packages
* [`b2f82162`](https://github.com/NixOS/nixpkgs/commit/b2f8216254ada81994d6a30cc28521fc48b9249e) vimPlugins: update
* [`4ad68316`](https://github.com/NixOS/nixpkgs/commit/4ad683167124e1e28b6ec2e0584072e05374f2f7) vimPlugins.vim-markdown-toc: init at 2021-03-02
* [`423c23c7`](https://github.com/NixOS/nixpkgs/commit/423c23c7a3df161e0ace5dbd344391049ebfb049) home-assistant: enable sleepiq tests
* [`d4e758c5`](https://github.com/NixOS/nixpkgs/commit/d4e758c5ac02126e30abcb8a2c72cde18f661a8e) rust-analyzer: 2021-03-22 -> 2021-04-05
* [`33a3715a`](https://github.com/NixOS/nixpkgs/commit/33a3715a5ec07443ed6fef3afd369edc5074b115) medfile: use HDF5 1.12
* [`f82b01c0`](https://github.com/NixOS/nixpkgs/commit/f82b01c0d91740a10d68e80d60491477270cca49) lagrange: 1.3.0 → 1.3.2
* [`6efb930e`](https://github.com/NixOS/nixpkgs/commit/6efb930e1844da28cac7d6059a65969f41190d8a) rust-analyzer: merge version specific fields into generic derivation
* [`501284ea`](https://github.com/NixOS/nixpkgs/commit/501284ea42d909ecd5bd8e0ca82482a2fc6afb61) rust-analyzer: rename nix file
* [`4227c6c9`](https://github.com/NixOS/nixpkgs/commit/4227c6c9d8a6449755dad1aef54cf9337378e8bf) irssi: 1.2.2 -> 1.2.3
* [`26f66129`](https://github.com/NixOS/nixpkgs/commit/26f66129f8a2f63fe51f8ba1b547de9e6db8a425) ccache: 4.2 -> 4.2.1
* [`dbeee740`](https://github.com/NixOS/nixpkgs/commit/dbeee740859bac94f1c6719aee718a5e854de9ff) ccache: enable test.modules on Darwin
* [`32d7db5e`](https://github.com/NixOS/nixpkgs/commit/32d7db5e70b05bd1c1de052a8649f2447154a744) maintainers: add wunderbrick
* [`ddb3399c`](https://github.com/NixOS/nixpkgs/commit/ddb3399c3ab9f8c2ad9cdfbbf33287e7dde90fa2) juniper: init at 2.3.0
* [`620137af`](https://github.com/NixOS/nixpkgs/commit/620137afca9f6ef103cf80b06bb2efb1dbcf6c4d) cudatext: 1.129.3 → 1.131.0
* [`03a196c2`](https://github.com/NixOS/nixpkgs/commit/03a196c26ae898cc8c8fb739e435c86b1c88173e) libsForQt5.fcitx5-qt: 5.0.2 -> 5.0.4
* [`e2395721`](https://github.com/NixOS/nixpkgs/commit/e23957211c0b32019db8ef9d0aaa808340e9857f) fcitx5-lua: 5.0.3 -> 5.0.4
* [`2a3ff386`](https://github.com/NixOS/nixpkgs/commit/2a3ff386807b5f642b5e05599149c1409461597b) r2mod_cli: use bashInteractive as interpreter
* [`0b897f7c`](https://github.com/NixOS/nixpkgs/commit/0b897f7cd5ef898d889d77acc20b3d4da02cdea3) python3Packages.discordpy: 1.7.0 -> 1.7.1
* [`77a2fadc`](https://github.com/NixOS/nixpkgs/commit/77a2fadc4be28274a63d8fbf85f7abe780b18a54) kooha: init at 1.1.1
* [`e4149e6e`](https://github.com/NixOS/nixpkgs/commit/e4149e6e0b41b19df487438c039d248cf4941f41) rink: specify license
* [`33ca41c6`](https://github.com/NixOS/nixpkgs/commit/33ca41c63ecf9fae1b3a2930fe2419d8bf4dff65) aws-c-common: 0.5.2 -> 0.5.4 ([nixos/nixpkgs⁠#119187](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119187))
* [`d8c6dda7`](https://github.com/NixOS/nixpkgs/commit/d8c6dda74bd187e645848ad7ec981def6ba30a41) chez-matchable: typo fix in the description value
* [`7dd22ac8`](https://github.com/NixOS/nixpkgs/commit/7dd22ac8bdd19ff95be6ae1cf0327550e469d83f) home-assistant: pin pyruckus==0.12 and enable ruckus_unleashed tests
* [`320bbf0b`](https://github.com/NixOS/nixpkgs/commit/320bbf0be453c1fe42bd50d4d900ad398c23acbb) r2mod_cli: 1.0.6 -> 1.0.7
* [`a1bc838a`](https://github.com/NixOS/nixpkgs/commit/a1bc838a5ef8aee5e3107ff7b8ed3720a6a7385b) blender: install with python3Packages.requests, fixes [nixos/nixpkgs⁠#97250](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/97250) ([nixos/nixpkgs⁠#118987](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118987))
* [`06bad855`](https://github.com/NixOS/nixpkgs/commit/06bad85574280676fec907234bcb58281058c0d2) distrho: 2020-07-14 -> 2021-03-15 ([nixos/nixpkgs⁠#118928](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118928))
