### PR TITLE
niv home-manager: update cc60c22c -> 0a6227d6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cc60c22c69e6967b732d02f072a9f1e30454e4f6",
-        "sha256": "191w8ps6m8kf2fxdbmcsa75j5bbirrvgb2cavrj69dkhsll9czh7",
+        "rev": "0a6227d667d1d2bc6a79de24fd12becc523f2e2f",
+        "sha256": "0gwjhr68ds2kyx06xqlfimp5d37b7ny95n0sbhryjnxnhbnmhbpp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/cc60c22c69e6967b732d02f072a9f1e30454e4f6.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/0a6227d667d1d2bc6a79de24fd12becc523f2e2f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@cc60c22c...0a6227d6](https://github.com/nix-community/home-manager/compare/cc60c22c69e6967b732d02f072a9f1e30454e4f6...0a6227d667d1d2bc6a79de24fd12becc523f2e2f)

* [`33edf558`](https://github.com/nix-community/home-manager/commit/33edf558a0735a86f322fe121d910d14ecbcdc97) lib/types/fontType:  Add size attribute ([nix-community/home-manager⁠#1848](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1848))
* [`e5a260a5`](https://github.com/nix-community/home-manager/commit/e5a260a569960ff26fca6dbf3e6a99c733e40211) xmonad: use compiled configuration when config is not null ([nix-community/home-manager⁠#1893](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1893))
* [`3a16ebdf`](https://github.com/nix-community/home-manager/commit/3a16ebdf726a7ba5abb073bb069fbe8344826e88) home-manager: Add --flake option to home-manager ([nix-community/home-manager⁠#1856](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1856))
* [`7fcfd9b5`](https://github.com/nix-community/home-manager/commit/7fcfd9b565a470ccd43cd826d650931d660777fe) home-manager: format `home-manager/default.nix`
* [`4fd4066d`](https://github.com/nix-community/home-manager/commit/4fd4066d2fd408046c9d049afaea2e8221dad6a2) ci: bump cachix/install-nix-action from v12 to v13
* [`c12897e8`](https://github.com/nix-community/home-manager/commit/c12897e8e1b3ac7a48e343de6af29376c5f0a10e) ci: bump cachix/cachix-action from v8 to v10
* [`be56b6f2`](https://github.com/nix-community/home-manager/commit/be56b6f2c5df6a4da8c91d4a3174f77d66c35533) neomutt: Add encryptByDefault support ([nix-community/home-manager⁠#1882](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1882))
* [`56f5f41e`](https://github.com/nix-community/home-manager/commit/56f5f41ed42f7d476a7c79fa8ec71f5605487abf) README: typo fix ([nix-community/home-manager⁠#1912](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1912))
* [`17a10287`](https://github.com/nix-community/home-manager/commit/17a10287d2c306cca1a4f9689af7ada9cb37a39e) gtk: use font.size option in dconf ([nix-community/home-manager⁠#1920](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1920))
* [`f567ea82`](https://github.com/nix-community/home-manager/commit/f567ea8228e0ce718871d7346e444dd15ad702e5) msmtp: add extraAccounts option
* [`91418d3e`](https://github.com/nix-community/home-manager/commit/91418d3e57e96dc9f520931401c653becd33b4a4) programs.neomutt: Make manual configuration take precedence over generated settings ([nix-community/home-manager⁠#1896](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1896))
* [`5c5d5622`](https://github.com/nix-community/home-manager/commit/5c5d562266ddeba10e6995d11800502f7a10eec0) sway: add config.seat
* [`18930aaf`](https://github.com/nix-community/home-manager/commit/18930aaf75eea3380ff38ceae96a81fbcfaa2914) sway: add sumnerevans as maintainer
* [`f7159a0f`](https://github.com/nix-community/home-manager/commit/f7159a0f7655106ecec68c838bebbed0b39a2215) newsboat: use $XDG_CONFIG_HOME/newsboat
* [`073710d7`](https://github.com/nix-community/home-manager/commit/073710d7f29a7469cc5146e46cf5c6aa76b335a3) newsboat: add sumnerevans as maintainer
* [`7cf69a3b`](https://github.com/nix-community/home-manager/commit/7cf69a3b8db6cdd451f83bfe1a6de3a07a6a295f) exa: add module
* [`0a6227d6`](https://github.com/nix-community/home-manager/commit/0a6227d667d1d2bc6a79de24fd12becc523f2e2f) flake.nix: Add packages and defaultPackages outputs ([nix-community/home-manager⁠#1913](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1913))
