### PR TITLE
niv spacemacs: update eec5ba65 -> a862d1ac

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "eec5ba657799668acef88bedc7dfadf5f13a1082",
-        "sha256": "0bgh1sp0jwyfrc94msky2vg25zrxma301v20i4bgvlf8xmn7lrr8",
+        "rev": "a862d1ac5f76fca79dffdc2f12e901e98645eb68",
+        "sha256": "0952kmka9jvcj89wp8rzfb7s2sk9n3g8l5gjd5dm9jzggzrw51q8",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/eec5ba657799668acef88bedc7dfadf5f13a1082.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/a862d1ac5f76fca79dffdc2f12e901e98645eb68.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@eec5ba65...a862d1ac](https://github.com/syl20bnr/spacemacs/compare/eec5ba657799668acef88bedc7dfadf5f13a1082...a862d1ac5f76fca79dffdc2f12e901e98645eb68)

* [`ee6d410f`](https://github.com/syl20bnr/spacemacs/commit/ee6d410f11d59d7b106cf3116816c0e0f031265c) [CI]rebase PRs on develop push
* [`eb38394f`](https://github.com/syl20bnr/spacemacs/commit/eb38394fd8d6b455f472a1fe6d0c488e71ccd24a) [CI]try fixing rebase workflow
* [`ee63894a`](https://github.com/syl20bnr/spacemacs/commit/ee63894aeb5c36e26923e23cb463e2f911e0d010) [CI]try fixing rebase workflow X2
* [`3371a822`](https://github.com/syl20bnr/spacemacs/commit/3371a8220c8e48503dc6dd4e2d6ac532ba9946ad) [CI]use comment based PR rebase
* [`07970be5`](https://github.com/syl20bnr/spacemacs/commit/07970be51d6db5f6e4237d57d88097bd9ae06e42) docs: fix ‘gzip-for-windows’ link error
* [`d77e76e9`](https://github.com/syl20bnr/spacemacs/commit/d77e76e9f7098fdf80175e05acf28f4cde24d6dc) Add support for the org-roam-server package
* [`5fd1976e`](https://github.com/syl20bnr/spacemacs/commit/5fd1976e05ef85e9b2474be92ada40e5d96fa758) [org] Fix startup and document key bindings
* [`383237ef`](https://github.com/syl20bnr/spacemacs/commit/383237ef295a07356deb79812952c9440c1d438b) Built-in files auto-update: Thu Apr 8 18:27:04 UTC 2021
* [`57f6a2d9`](https://github.com/syl20bnr/spacemacs/commit/57f6a2d94df362264a14bd690ed0161376f74104) [finance] Enable flycheck when syntax-checking-enable-by-default
* [`4836a256`](https://github.com/syl20bnr/spacemacs/commit/4836a2569b3c8b959420201c9d2613e03317ef54) bootstrap: new :spacediminish keyword to use-package
* [`38f582d7`](https://github.com/syl20bnr/spacemacs/commit/38f582d785627fe996141d15aa54cdba2c3167a4) [bootstrap] Fix depreciation warning for pcase `t case
* [`e817e0fa`](https://github.com/syl20bnr/spacemacs/commit/e817e0faae35769b906285630a6880f51b3ef09b) [Python layer] Add links to the LSP implementations ([syl20bnr/spacemacs⁠#14562](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14562))
* [`e6e58c54`](https://github.com/syl20bnr/spacemacs/commit/e6e58c54d6b64a5524ac40e3419e4f5a22421643) [defaults] Add SPC f e I to open Emacs early-init.el file
* [`910f68b5`](https://github.com/syl20bnr/spacemacs/commit/910f68b59e30ee9c52ef4feaa9e35f4a8d9d69d8) [defaults] Document new keybindings
* [`9c7e4bd5`](https://github.com/syl20bnr/spacemacs/commit/9c7e4bd5f1478f36e524c41764b614199d366cd1) [init] Disable GUI elements in early-init as well ([syl20bnr/spacemacs⁠#14559](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14559))
* [`d012d2d9`](https://github.com/syl20bnr/spacemacs/commit/d012d2d95f1ac354aae223de5db94bc1ff822312) [dotfile] New var: dotspacemacs-startup-buffer-multi-digit-delay
* [`dfb4c1c4`](https://github.com/syl20bnr/spacemacs/commit/dfb4c1c4cb007cc17b2a8fbe59032621bb267b53) git: Added `magit-todos`, improved docs, etc.
* [`9eac85fb`](https://github.com/syl20bnr/spacemacs/commit/9eac85fb6c46a978c4218d9796e8f21fb23f6257) [git] Add `magit-todo` to `evil-collection` configured packages
* [`948d15a2`](https://github.com/syl20bnr/spacemacs/commit/948d15a272f8fdd3da383b3332888aaaa460ac57) Search Engine layer: Add Debian & Ubuntu package search.
* [`01a84d9f`](https://github.com/syl20bnr/spacemacs/commit/01a84d9fe8023d688af6d015e4fdb1bc50da9935) [defaults] Improve scrolling with mouse wheel
* [`811001a4`](https://github.com/syl20bnr/spacemacs/commit/811001a48c755d5e6ae7ed58d9afae2cca4a429e) [defaults] Show scroll bar when using the mouse wheel
* [`4dc1d764`](https://github.com/syl20bnr/spacemacs/commit/4dc1d7640a98b9a776d853729356344f0832a4be) [defaults] Add dotspacemacs-scroll-bar-while-scrolling
* [`291cf9d6`](https://github.com/syl20bnr/spacemacs/commit/291cf9d671cac5516cc50a214910e6a0855f848a) CONTRIBUTING.org, Fix typos, etc.
* [`d2b73999`](https://github.com/syl20bnr/spacemacs/commit/d2b7399958967c6d0ebe929b2cc2718df5c01b1b) Fix bug in `spacemacs//python-setup-backend ()`
* [`ef1ad4ec`](https://github.com/syl20bnr/spacemacs/commit/ef1ad4ecee2644b8bf9ed6c4e2440e8d3878a8ca) Check package updates from Spacemacs home buffer
* [`95a703b6`](https://github.com/syl20bnr/spacemacs/commit/95a703b68494b88dc56e62cc529b2ae5c0c931b9) documentation formatting: Fri Apr 9 11:56:19 UTC 2021
* [`0570e141`](https://github.com/syl20bnr/spacemacs/commit/0570e14144b8f1461ab77ce6ef9c9545f4505345) Add docs agenda usage recommendations ([syl20bnr/spacemacs⁠#14587](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14587))
* [`49d1eaed`](https://github.com/syl20bnr/spacemacs/commit/49d1eaed50130c032cacabf4fdc4c9be0ea962c1) rust and lsp: better integration of lsp-rust-analyzer-reload-workspace
* [`96008496`](https://github.com/syl20bnr/spacemacs/commit/96008496d601e8517b52f139f43c66c4097767c7) windows-scripts: replaced dos.el with bat-mode, added bmx-mode
* [`dc07cdbd`](https://github.com/syl20bnr/spacemacs/commit/dc07cdbdc3d8b15a6b4d3b320c4442102e951fe4) [windows-scripts] Add missing keybinding to docs
* [`6bafc726`](https://github.com/syl20bnr/spacemacs/commit/6bafc72697881f308a892f9ee36c68e57b7db294) Enhance +lang/zig layer
* [`8c937e9a`](https://github.com/syl20bnr/spacemacs/commit/8c937e9a716f86a0f74d0aef38ccf47385341dce) [zig] Fix some smaller issues in the docs
* [`be6f8202`](https://github.com/syl20bnr/spacemacs/commit/be6f820256fa3753069a89c928df6dfe6bba9f3e) Add missing GPLv3 headers to various files
* [`41393004`](https://github.com/syl20bnr/spacemacs/commit/41393004881109d014dc2166c7110545ece9c32e) [zig] Adjust backend variables to match new style
* [`d301a88d`](https://github.com/syl20bnr/spacemacs/commit/d301a88df0ca22d16ed3ffbf4adfab7a69534071) [java] only download meghanada package if needed
* [`e54affd5`](https://github.com/syl20bnr/spacemacs/commit/e54affd5a70e5524adaca5f48e3c0ede2d126d5f) [java] Add back support for emacs 25.1
* [`5bd1603b`](https://github.com/syl20bnr/spacemacs/commit/5bd1603b652cef4e696f7c0375e8c059c0fc0ece) [Fix] `dotspacemacs/test-dotfile` complains error on new custom vars
* [`66d774cd`](https://github.com/syl20bnr/spacemacs/commit/66d774cd67258bb08ca7207a09deb9fedad5640e) [java] Fix not existing function
* [`bebf5c4a`](https://github.com/syl20bnr/spacemacs/commit/bebf5c4a0741bd28620717659165d5c83691b22a) Use the standard elpa gpg homedir
* [`a4eadc97`](https://github.com/syl20bnr/spacemacs/commit/a4eadc97fecaa4f7c5776d24c8ec55379fbc876e) rename {,c-}c++-enable-organize-includes-on-save
* [`85d0aa2b`](https://github.com/syl20bnr/spacemacs/commit/85d0aa2b18c07ef46c51e78fa266077c04f846e0) [c-c++] Provide an alias for `c++-enable-organize-includes-on-save`
* [`f136f465`](https://github.com/syl20bnr/spacemacs/commit/f136f465abf599f6869b178e9338c72053444aec) core: revise core-jump
* [`9cb5a3f6`](https://github.com/syl20bnr/spacemacs/commit/9cb5a3f67bc98a21219c80465759938f402d132e) [core] Remove some typos in doc of new jump handlers
* [`a862d1ac`](https://github.com/syl20bnr/spacemacs/commit/a862d1ac5f76fca79dffdc2f12e901e98645eb68) [CI] remove stale label when issue updated
