### PR TITLE
niv nixpkgs: update 06bad855 -> a8b5aa35

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "06bad85574280676fec907234bcb58281058c0d2",
-        "sha256": "0knixl7c6s83003rnsriykh13bk0wvc372nr46ryfp7542agy5ql",
+        "rev": "a8b5aa35706c6df84f7700cdeb15a5d538f5d313",
+        "sha256": "1bbc35lgsjsirvkzw3x3hnlw0nfisa4yry39yg5g0n3p42lqb8m7",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/06bad85574280676fec907234bcb58281058c0d2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a8b5aa35706c6df84f7700cdeb15a5d538f5d313.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@06bad855...a8b5aa35](https://github.com/nixos/nixpkgs/compare/06bad85574280676fec907234bcb58281058c0d2...a8b5aa35706c6df84f7700cdeb15a5d538f5d313)

* [`f9a79837`](https://github.com/NixOS/nixpkgs/commit/f9a798375983332b8ebdabf1dd872a092e2e0f22) vscode-extensions.gruntfuggly.todo-tree: 0.0.209 -> 0.0.211
* [`2e6b1f57`](https://github.com/NixOS/nixpkgs/commit/2e6b1f573f013d8a87c35031c598eabd33efd7a5) pythonPackages.tqdm: Fix build on i686 architecture ([nixos/nixpkgs⁠#119608](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119608))
* [`9ad3ceae`](https://github.com/NixOS/nixpkgs/commit/9ad3ceaea4a6c3ab4bc2660850fb2583b3ac5d0b) gnomeExtensions.unite: 49 -> 50
* [`f16b7094`](https://github.com/NixOS/nixpkgs/commit/f16b70941f3ea6215056387036cce02a8d9b6b29) hackage-packages.nix: automatic Haskell package set update
* [`55f76ad8`](https://github.com/NixOS/nixpkgs/commit/55f76ad8fdf8cf787bb99e73754f25fd2efe5f8d) terragrunt: 0.28.22 -> 0.28.24
* [`850d6414`](https://github.com/NixOS/nixpkgs/commit/850d64142ea52145e2c37faeb7370ea544f13ce2) consul: 1.9.4 -> 1.9.5
* [`4c71d57c`](https://github.com/NixOS/nixpkgs/commit/4c71d57c99495ea405b29bf3fa7ed8f73d3d26cf) haskellPackages.haskell-language-server: Fix more deps to stay compat with 1.0.0
* [`b77c77de`](https://github.com/NixOS/nixpkgs/commit/b77c77debbc6d0f7ce96196748ebd647d0fae5db) kupfer: 319 -> 321
* [`4f3907fc`](https://github.com/NixOS/nixpkgs/commit/4f3907fc0f84a39aebd8e48ef1dd2fb85efa84b5) cryptomator: 1.5.13 -> 1.5.14
* [`4130abfe`](https://github.com/NixOS/nixpkgs/commit/4130abfe1295836a5971caa5a92434f8459e52df) neofetch: wrap with pciutils
* [`dba0cfb2`](https://github.com/NixOS/nixpkgs/commit/dba0cfb2d9bf4d0b0db113e896c094e3d1fefd34) yubioath-desktop: 5.0.4 -> 5.0.5
* [`7dc5c0f1`](https://github.com/NixOS/nixpkgs/commit/7dc5c0f1e1d9fd973f880e966f1bfdaf6f68a169) bluejeans: 2.19.0 -> 2.21.3 ([nixos/nixpkgs⁠#119599](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119599))
* [`ecfd3d4c`](https://github.com/NixOS/nixpkgs/commit/ecfd3d4c53476885ea3de59b82ccc17a660024b9) nixos/services/matrix-synapse: fix eval errors in manual example
* [`93ad4bae`](https://github.com/NixOS/nixpkgs/commit/93ad4bae790f77239a6e6344eeb506af3aceb97d) mindustry: mark as broken
* [`591ef853`](https://github.com/NixOS/nixpkgs/commit/591ef853c741213c6f81d7b2935e64afac00701b) haskellPackages.lzma-static: unbreak
* [`d5a4dec5`](https://github.com/NixOS/nixpkgs/commit/d5a4dec5d28729d25756345c9fe9c38b4139c340) agate: fix cargoSha256 change
* [`12d590ba`](https://github.com/NixOS/nixpkgs/commit/12d590ba3d51ac13830ccc942f997490def549ec) kakounePlugins: Add pandoc.kak
* [`8416de54`](https://github.com/NixOS/nixpkgs/commit/8416de54751561be6ac14e9555047dcf1d47ddc7) kakounePlugins: update
* [`087f1e1d`](https://github.com/NixOS/nixpkgs/commit/087f1e1daf12b873c568292cfc3cf50fa0683f65) pikchr: init at unstable-2021-04-07 ([nixos/nixpkgs⁠#119006](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119006))
* [`e8635f55`](https://github.com/NixOS/nixpkgs/commit/e8635f55b48ced909f679d9c28f0201de234d4a9) home-assistant: 2021.4.4 -> 2021.4.5
* [`1a11337c`](https://github.com/NixOS/nixpkgs/commit/1a11337ccf2b071e166ec2f22a79edeb68494e5c) python3Packages.pycomfoconnect: drop unused pytestCheckHook input
* [`c9bee598`](https://github.com/NixOS/nixpkgs/commit/c9bee598311d3d3c5d897a65f843f7341671ba1b) haskellPackages.reflex*: Fix various dependencies
* [`c1535b26`](https://github.com/NixOS/nixpkgs/commit/c1535b26ef6fd0cc04958698c7fbcd82aa460d15) hackage2nix: update list of broken packages to fix evaluation errors
* [`b70a9c2f`](https://github.com/NixOS/nixpkgs/commit/b70a9c2fc7723724059b2a820657e868a844821d) hackage-packages.nix: automatic Haskell package set update
* [`5476e46e`](https://github.com/NixOS/nixpkgs/commit/5476e46eb6565605a12df0add5705233757f7956) linux_xanmod: 5.11.14 -> 5.11.15
* [`0d8e3490`](https://github.com/NixOS/nixpkgs/commit/0d8e34906c87fad89ede376e5f1fe2e4c5150f82) dasel: 1.14.0 -> 1.14.1
* [`a5aa71ee`](https://github.com/NixOS/nixpkgs/commit/a5aa71ee47347ec7dc6dff24c3aebe9c84a875db) tremor-rs: 0.10.1 -> 0.11.0
* [`f739f523`](https://github.com/NixOS/nixpkgs/commit/f739f523d5556f46162e29e776ac0a5115a8c1a4) kodi: remove old file that was missed during cleanup
* [`12a520fc`](https://github.com/NixOS/nixpkgs/commit/12a520fc53a9dd197600ca4d118774249d92eb36) kodi.packages.buildKodiBinaryAddon: add extraNativeBuildInputs
* [`797aaf99`](https://github.com/NixOS/nixpkgs/commit/797aaf997eeb323eab6966977f7d9eb5175ad421) kodi.packages.inputstream-adaptive: 2.6.8 -> 2.6.13
* [`928113b2`](https://github.com/NixOS/nixpkgs/commit/928113b28d68ad381475564bbe19653db415aea1) kodi.packages.inputstream-ffmpegdirect: 1.19.4 -> 1.21.1
* [`66be5560`](https://github.com/NixOS/nixpkgs/commit/66be5560298f6c7ae9799202d891d967daa74b25) foxotron: init at 2021-03-12
* [`b1c71eb2`](https://github.com/NixOS/nixpkgs/commit/b1c71eb215b7833afc074da11924af5b3a425815) openethereum: 3.2.3 -> 3.2.4
* [`e288f5b7`](https://github.com/NixOS/nixpkgs/commit/e288f5b7c9c03a0c166ace33396e09535a24e82a) conftest: 0.23.0 -> 0.24.0
* [`fbffc54a`](https://github.com/NixOS/nixpkgs/commit/fbffc54ac81497653cdcaddabfd446b7292b7eee) profanity: Enable clipboard support
* [`b623794a`](https://github.com/NixOS/nixpkgs/commit/b623794aba1915e0dfa1d7731f28d59967ae6c9d) dmd: mark unbroken ([nixos/nixpkgs⁠#119647](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119647))
* [`1766f309`](https://github.com/NixOS/nixpkgs/commit/1766f30971795e524eac5138bfa53c676ffaedad) yubioath-desktop: fix icon
* [`dfb0999f`](https://github.com/NixOS/nixpkgs/commit/dfb0999f7355c9caa40eee45b87bfc9071e09fdc) yubikey-agent: fix systemd unit
* [`0f1e2242`](https://github.com/NixOS/nixpkgs/commit/0f1e22421ee476f79edd948c7d83dd38750f4233) go_1_16: 1.16.2 -> 1.16.3
* [`ab16ad87`](https://github.com/NixOS/nixpkgs/commit/ab16ad87649b6ea845be46fa7df7e9466ed4e05d) coq_8_13: 8.13.1 → 8.13.2
* [`a350ad30`](https://github.com/NixOS/nixpkgs/commit/a350ad306aa8ee0a9d4fc28c533cad4e4c5493f5) ostree: fix TLS errors
* [`f3186411`](https://github.com/NixOS/nixpkgs/commit/f31864112f27d7a168f285b3147307649e68cca6) libcaca: refactor
* [`12268047`](https://github.com/NixOS/nixpkgs/commit/12268047412f56657c4366c82471333c9783bfd7) stretchly: 1.5.0 -> 1.6.0
* [`c95c2212`](https://github.com/NixOS/nixpkgs/commit/c95c22129fc597e509d1377befbb59fe7c316728) vscode-extensons.github.github-vscode-theme: 3.0.0 -> 4.0.2
* [`0139874d`](https://github.com/NixOS/nixpkgs/commit/0139874db9bca4be6f54c52f2da40e8ac7c5237b) nixos/nginx: add upstreams examples ([nixos/nixpkgs⁠#118447](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118447))
* [`0aa8f9e5`](https://github.com/NixOS/nixpkgs/commit/0aa8f9e52068b03e3dca9944007dc159f6820a1e) kodi{-wayland,-gbm}: use LTS jdk11 ([nixos/nixpkgs⁠#119611](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119611))
* [`f7cb740d`](https://github.com/NixOS/nixpkgs/commit/f7cb740de8df969ae4cecd21684b822823830093) ntp: set platforms to unix ([nixos/nixpkgs⁠#119644](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119644))
* [`2c54f585`](https://github.com/NixOS/nixpkgs/commit/2c54f585e029d9eabb7431c8c60ee99371ca042f) kodi.packages.youtube: init at 6.8.10+matrix.1
* [`70c52ffd`](https://github.com/NixOS/nixpkgs/commit/70c52ffdf11ff1af1b20fddb3367b9b7228d5056) kodi.packages.pvr-iptvsimple: 7.5.1 -> 7.6.1
* [`78fe17af`](https://github.com/NixOS/nixpkgs/commit/78fe17af458bce8b48b7f6bcd4a9abb19e129e95) kodi.packages.pvr-hts: 8.2.4 -> 8.3.0
* [`1d9f6193`](https://github.com/NixOS/nixpkgs/commit/1d9f619311e9fa28a63ce0b65ae93a9273709114) nixos/home-assistant: warn about `overridePythonAttrs` in package option
* [`cc104324`](https://github.com/NixOS/nixpkgs/commit/cc10432418239080ea1348de857d9bfa75a44619) mailman: add myself as a maintainer all around
* [`9aa8ae99`](https://github.com/NixOS/nixpkgs/commit/9aa8ae999ad1562e15e3aa2066549e0a0cf7ac3e) llvmPackages_12.llvm: fix building on older CPUs
* [`af2b2fe3`](https://github.com/NixOS/nixpkgs/commit/af2b2fe34a5cadd8907ebd348789bccddaf3e9de) with-shell: 2016-08-20 -> 2018-03-20
* [`de1907ef`](https://github.com/NixOS/nixpkgs/commit/de1907ef124482459e982d5185dd3aa4b0faacd3) watchexec: 1.15.0 -> 1.15.1
* [`fc604e07`](https://github.com/NixOS/nixpkgs/commit/fc604e07399900696e30f321bdf9fc8a930d0cfe) flexget: 3.1.106 -> 3.1.110
* [`dabbf9d4`](https://github.com/NixOS/nixpkgs/commit/dabbf9d447340a1624b9a200e783773d9a253ac2) shadowsocks-rust: 1.10.5 -> 1.10.7
* [`03e50cf1`](https://github.com/NixOS/nixpkgs/commit/03e50cf1392623f410a5e8847500d78ec8a5ef5d) mailspring: 1.9.0 -> 1.9.1
* [`67c4ab77`](https://github.com/NixOS/nixpkgs/commit/67c4ab77be9daaca447c14ec5c3fdcb62f581ad0) podman: 3.1.0 -> 3.1.1
* [`6ab8cd7a`](https://github.com/NixOS/nixpkgs/commit/6ab8cd7a22bbfa084966e42f349c043886f2d147) shfm: init at 0.4.2
* [`2a441ee4`](https://github.com/NixOS/nixpkgs/commit/2a441ee408ea9cc784cf0d28c0f55c9be06b7c9e) bat-extras: 20200515-dev -> 2021.04.06
* [`932a4ce6`](https://github.com/NixOS/nixpkgs/commit/932a4ce6be42efa80601c5ab9879871ccb2d1781) tmpmail: init at master
* [`0c86640c`](https://github.com/NixOS/nixpkgs/commit/0c86640c688d3fb85de39a2bc27cacb80d4425a0) maintainers: add legendofmiracles
* [`cf8ebdc9`](https://github.com/NixOS/nixpkgs/commit/cf8ebdc9c6587f3f5df254041607cc776c8b7c5e) ja2-stracciatella 0.16.1 -> 0.17.0
* [`7050620e`](https://github.com/NixOS/nixpkgs/commit/7050620e332eaf117dca4fd8130ae16a8f942b60) jhead: 3.04 -> 3.06.0.1
* [`38c68e1d`](https://github.com/NixOS/nixpkgs/commit/38c68e1da330625c1c1074c70f42ecc2d62cf6ed) spice-protocol: 0.14.1 -> 0.14.3
* [`c6cc128f`](https://github.com/NixOS/nixpkgs/commit/c6cc128f30ccf2a5570aa9efce57ac015e65341e) python3Packages.py: fix homepage link
* [`2918f537`](https://github.com/NixOS/nixpkgs/commit/2918f537ea5ee682ddf4a71dba76543dc8f0545f) haskellPackages.reflex-dom: Remove obsolete override do fix build
* [`63eda681`](https://github.com/NixOS/nixpkgs/commit/63eda681e9f1f516dcf441a13f6a0990509c371e) mtools: 4.0.26 -> 4.0.27
* [`de2a86c9`](https://github.com/NixOS/nixpkgs/commit/de2a86c9bc2118cd427df97afdda48697d64c0a0) rubyPackages.rails: 6.1.0 -> 6.1.3.1
* [`b660a15b`](https://github.com/NixOS/nixpkgs/commit/b660a15ba8845592942589f4d5d215134d8bd7b2) subversion_1_10: 1.10.6 -> 1.10.7
* [`ec6d5ef4`](https://github.com/NixOS/nixpkgs/commit/ec6d5ef4f087369326cbbf34df8e24e170cc55c6) libtransmission: init at 3.00 ([nixos/nixpkgs⁠#118998](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118998))
* [`6c961ddd`](https://github.com/NixOS/nixpkgs/commit/6c961dddd13b195c7425d33637551f21576f310d) nixos/nullmailer: set isSystemUser
* [`0c7e1669`](https://github.com/NixOS/nixpkgs/commit/0c7e16694807f7aa23f0d176501259c549f7d1ee) tdrop: unstable-2020-05-14 -> 0.4.0
* [`28de4ac6`](https://github.com/NixOS/nixpkgs/commit/28de4ac62a9839145f3564ce0f24c15301a010c9) treewide: make AppRun substitutions constistent
* [`8db89752`](https://github.com/NixOS/nixpkgs/commit/8db8975228581cb80f2b7581fd445afa4aab43f9) ocamlPackages.ezxmlm: 1.0.2 → 1.1.0
* [`65bb97ee`](https://github.com/NixOS/nixpkgs/commit/65bb97ee72bf9d0b19f5ee2895389cc0ced441b5) sdcc: 4.0.0 -> 4.1.0
* [`6e655ee3`](https://github.com/NixOS/nixpkgs/commit/6e655ee33e103b88b965f81e586c6683d6decfb1) runwayml: drop in favor of runwayml webapp
* [`532f6a2c`](https://github.com/NixOS/nixpkgs/commit/532f6a2c700c3f139a525fe8ed962db8e6b30680) haruna: 0.6.1 -> 0.6.2
* [`c2834fd6`](https://github.com/NixOS/nixpkgs/commit/c2834fd6dd1cf3a8e8eaf90b5d865e0911a92b45) awstats: 7.7.0 -> 7.8.0
* [`7a07dc0a`](https://github.com/NixOS/nixpkgs/commit/7a07dc0a07bd98f97d83453cec2bb0bf448d6f77) libmodsecurity: 3.0.3 -> 3.0.4
* [`2814a535`](https://github.com/NixOS/nixpkgs/commit/2814a535ec35e1d73248f913303f803ada4386ef) yabridge, yabridgectl: 3.0.2 -> 3.1.0
* [`29bb1925`](https://github.com/NixOS/nixpkgs/commit/29bb19258a90a5e1f13791788b4b601d8f87e82c) treewide: use https for github URIs
* [`4e3361e2`](https://github.com/NixOS/nixpkgs/commit/4e3361e2a785179339d389f9da2a13188a776db2) pythonPackages.awkward: 1.1.2 -> 1.2.2
* [`bc7f4759`](https://github.com/NixOS/nixpkgs/commit/bc7f4759ec1f577fe84222b6111f344def3e7af5) bicpl: unstable-2017-09-10 -> unstable-2020-10-15
* [`03518371`](https://github.com/NixOS/nixpkgs/commit/03518371afe250c2c78186393296e6bf49ff0494) oobicpl: unstable-2016-03-02 -> unstable-2020-08-12
* [`62806df6`](https://github.com/NixOS/nixpkgs/commit/62806df678933ec105fd699076db93b9557b43e4) mikutter: 4.0.0 -> 4.1.4 ([nixos/nixpkgs⁠#119454](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119454))
* [`05987f95`](https://github.com/NixOS/nixpkgs/commit/05987f952f86f94c5c7201a0c0e251098a6758ab) nx2elf: init at unstable-2020-05-26 ([nixos/nixpkgs⁠#119493](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119493))
* [`97368d37`](https://github.com/NixOS/nixpkgs/commit/97368d3738f63f6928a31774a015f4945cb9e408) tor: 0.4.5.6 -> 0.4.5.7
* [`43aeba0d`](https://github.com/NixOS/nixpkgs/commit/43aeba0d1b3f1804ee71d46b57a761b925355218) macchina: init at 0.6.9
* [`280e6d1b`](https://github.com/NixOS/nixpkgs/commit/280e6d1b110aebe24186930d6c530069991fd9a6) grim: 1.3.1 -> 1.3.2
* [`918f81e3`](https://github.com/NixOS/nixpkgs/commit/918f81e35833d6d18e75cb355a09d4006002490b) slurp: 1.3.1 -> 1.3.2
* [`e839e96d`](https://github.com/NixOS/nixpkgs/commit/e839e96dabadd1d8bd36ff84d347e58b19ec0c9a) python3Packages.pur: init at 5.4.0
* [`3ff497aa`](https://github.com/NixOS/nixpkgs/commit/3ff497aaab9870fdbefbd6f5016843d93c255fe5) ptcollab: 0.3.5.1 -> 0.4.0
* [`34598678`](https://github.com/NixOS/nixpkgs/commit/345986786907f12ca3838b1918c1fff34585bccc) ytfzf: 1.1.3 -> 1.1.4
* [`e58ec080`](https://github.com/NixOS/nixpkgs/commit/e58ec08048c6d5aadf14957be80e413862ed9e34) go-task: 3.3.0 -> 3.4.1
* [`b2f2d04f`](https://github.com/NixOS/nixpkgs/commit/b2f2d04f01b3de3abad0dd9bc48ad7a3ee32bbc6) rnix-hashes: fix tests, add me as maintainer ([nixos/nixpkgs⁠#119749](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119749))
* [`5594aa42`](https://github.com/NixOS/nixpkgs/commit/5594aa424c471c9cbff9f628916acd1742860002) elpi: 1.13.0 -> 1.13.1
* [`9400e49d`](https://github.com/NixOS/nixpkgs/commit/9400e49ddf9a2b2f0c514ebc573edef730d80c90) coq-elpi: 1.9.5 -> 1.9.7
* [`5feab34f`](https://github.com/NixOS/nixpkgs/commit/5feab34f2e174847d20b5cee304fdcb3402b8494) coq-elpi: 1.8.2 -> 1.8.3
* [`38cef0ba`](https://github.com/NixOS/nixpkgs/commit/38cef0ba3b4c215cf1d4d03d137c66d948bdf1be) coq-elpi: 1.6.2 -> 1.6.3
* [`63fca8b6`](https://github.com/NixOS/nixpkgs/commit/63fca8b610c01a3382ea190989f886d3e2c99015) vimPlugins.LanguageClient-neovim: 0.1.160 → 0.1.161
* [`831e64ba`](https://github.com/NixOS/nixpkgs/commit/831e64bad4616a5be3281537c431087be2d372f8) Drop maintainership for some packages
* [`73fdc55b`](https://github.com/NixOS/nixpkgs/commit/73fdc55b4fccd8f06e5cef6b6ecc10cbfc399e97) sdcc: clarify license
* [`c6df94ce`](https://github.com/NixOS/nixpkgs/commit/c6df94ce561456492babc7628042fdc1c5fa0d5a) sdcc: use nativeBuildInputs
* [`64852c57`](https://github.com/NixOS/nixpkgs/commit/64852c57cc50d4f324e21580a57abd4f0af9e1d3) veracrypt: correct license
* [`908b4c61`](https://github.com/NixOS/nixpkgs/commit/908b4c61b963cac62e0789aa8180e97a1ed22f0c) kramdown-rfc2629: 1.4.1 -> 1.4.2
* [`faab9ed6`](https://github.com/NixOS/nixpkgs/commit/faab9ed66b27a1c191cf8cd5135a167ec2100191) miniserve: 0.13.0 -> 0.14.0
* [`dc282fc3`](https://github.com/NixOS/nixpkgs/commit/dc282fc3f3c1f0454ebd7120d9e5ac38f8e0b609) nixos/dnsdist: dndist.conf -> dnsdist.conf
* [`1c038b1c`](https://github.com/NixOS/nixpkgs/commit/1c038b1c5abf834400a95154384e9a0f6c8f1a88) traitor: init at 0.0.3
* [`536a23ec`](https://github.com/NixOS/nixpkgs/commit/536a23ec82a142c505483585307a725ce5d1165c) ffuf: 1.2.1 -> 1.3.0
* [`d8a6f559`](https://github.com/NixOS/nixpkgs/commit/d8a6f55942aba0467a7f50003d5549a1e2c819bb) netbsd: add myself as maintainer
* [`784cdd33`](https://github.com/NixOS/nixpkgs/commit/784cdd33b04bd722dd691b192b8c51ffe212e9f6) lxqt.liblxqt: use absolute path with pkexec
* [`e8b81fe0`](https://github.com/NixOS/nixpkgs/commit/e8b81fe04da54e2bd55c6ecdd0b6804a8845a4ca) redis: add withSystemd argument
* [`56a4d985`](https://github.com/NixOS/nixpkgs/commit/56a4d9857a269a3df89cb9b5ea99917e83850620) losslesscut-bin: init at 3.33.1 ([nixos/nixpkgs⁠#108512](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/108512))
* [`d0a243c4`](https://github.com/NixOS/nixpkgs/commit/d0a243c4babf502463293f289361f82359ff00c8) luaPackages.lua-resty-openidc: 1.7.2-1 -> 1.7.4-1
* [`60c97bac`](https://github.com/NixOS/nixpkgs/commit/60c97bacb67a8ea83b0cb1e8e6a976907efc1d7b) screenkey: 1.2 -> 1.4
* [`43445e94`](https://github.com/NixOS/nixpkgs/commit/43445e942295e3056abd0f557bd4b324bf76e27d) libpcap: fix build on NetBSD
* [`f4803076`](https://github.com/NixOS/nixpkgs/commit/f48030761f9299c1aae1d97581db2d2256f7923a) react-static: init at 7.5.3
* [`f85086f6`](https://github.com/NixOS/nixpkgs/commit/f85086f6c35e3939a3159caf4820efaec392fe55) nixos/tests/packagekit: fix test machine evaluation
* [`bcb8079a`](https://github.com/NixOS/nixpkgs/commit/bcb8079a93322d4fec98d6f0ba7fc433610e5bc1) spin: enable darwin support ([nixos/nixpkgs⁠#119809](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119809))
* [`da680110`](https://github.com/NixOS/nixpkgs/commit/da680110643876b460b767ae983b9a7eb8291c13) sumneko-lua-language-server: 1.16.0 -> 1.20.2
* [`5752d0b1`](https://github.com/NixOS/nixpkgs/commit/5752d0b1c14a57fbda0a37e4c9b9777ca9499dba) searx: 0.18.0 -> 1.0.0
* [`acfb7cb3`](https://github.com/NixOS/nixpkgs/commit/acfb7cb31a9adb2f146d95b8af2aae72ba421e0d) hydrogen: set license to gpl2Only
* [`cb605fc8`](https://github.com/NixOS/nixpkgs/commit/cb605fc83a3649bd335c1ac06652bbb0b0817d88) foot: 1.7.1 -> 1.7.2
* [`b66295b8`](https://github.com/NixOS/nixpkgs/commit/b66295b80a423953a02d1d8d23613c2a6f6ba9ea) python3Packages.pytest-subprocess: 1.0.1 -> 1.1.0
* [`722abdd9`](https://github.com/NixOS/nixpkgs/commit/722abdd9632bace23977a1e84a7f5b8ba6a1fb06) kissfft: 131 -> 131.1.0
* [`1a2c0d22`](https://github.com/NixOS/nixpkgs/commit/1a2c0d22135a64ceedcbac8dd615f219e37202be) ocamlPackages.x509: 0.11.2 -> 0.12.0
* [`d9d0223b`](https://github.com/NixOS/nixpkgs/commit/d9d0223b863869a8c9a92a57797d220bffe2c893) dbeaver: 21.0.2 -> 21.0.3
* [`b9e4b02b`](https://github.com/NixOS/nixpkgs/commit/b9e4b02b388bba1be475b16fa2681c85799fbb66) zrepl: 0.3.1 -> 0.4.0
* [`1e0bf533`](https://github.com/NixOS/nixpkgs/commit/1e0bf533d0cbf7ba018d3cfcd8cdacf9a0cbf954) portfolio: 0.51.2 -> 0.52.0
* [`286c1918`](https://github.com/NixOS/nixpkgs/commit/286c1918da72abd71149f9e036e41661ebee4f8d) xorg.xf86inputlibinput: 1.0.0 -> 1.0.1
* [`d0d77ec0`](https://github.com/NixOS/nixpkgs/commit/d0d77ec032d31fb22076325b018b60bbe0dc8177) nixos/tests/searx: fix for 1.0 update
* [`9162925d`](https://github.com/NixOS/nixpkgs/commit/9162925dc4e26867404a4875286cbfdbcc3d2756) netbeans: Enable antialiasing for texts in NetBeans IDE ([nixos/nixpkgs⁠#119817](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119817))
* [`ea3622dc`](https://github.com/NixOS/nixpkgs/commit/ea3622dcc8ed05fd2dd94a0634c28b1f3f9ebc52) passphrase2pgp: 1.1.0 -> 1.2.0 ([nixos/nixpkgs⁠#119748](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119748))
