### PR TITLE
niv home-manager: update 0a6227d6 -> 6aa6556b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0a6227d667d1d2bc6a79de24fd12becc523f2e2f",
-        "sha256": "0gwjhr68ds2kyx06xqlfimp5d37b7ny95n0sbhryjnxnhbnmhbpp",
+        "rev": "6aa6556bcab6dc0f6398b4daa8404d788fd7a6a2",
+        "sha256": "1x9fhh2g0n90vp5l0f9g66vxfsfcfy0xbr84qgaahsi2a9qk310j",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/0a6227d667d1d2bc6a79de24fd12becc523f2e2f.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/6aa6556bcab6dc0f6398b4daa8404d788fd7a6a2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@0a6227d6...6aa6556b](https://github.com/nix-community/home-manager/compare/0a6227d667d1d2bc6a79de24fd12becc523f2e2f...6aa6556bcab6dc0f6398b4daa8404d788fd7a6a2)

* [`348b5a5a`](https://github.com/nix-community/home-manager/commit/348b5a5a6945a1b345bf650e50d4c2ad1fe9d9b8) gpg: make homedir configurable
* [`ebbbd4f2`](https://github.com/nix-community/home-manager/commit/ebbbd4f2b50703409543941e7445138dc1e7392e) gpg: fix `homedir` option documentation
* [`6aa6556b`](https://github.com/nix-community/home-manager/commit/6aa6556bcab6dc0f6398b4daa8404d788fd7a6a2) gpg-agent: add GNUPG_HOMEDIR to environment ([nix-community/home-manager⁠#1932](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1932))
