### PR TITLE
niv powerlevel10k: update b55ad16b -> 48ff2e80

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "b55ad16bdf747e7ff6a3c821d92ed942d4e3be7c",
-        "sha256": "1qgxdjxw5878iknxaf5fdnxm9d9mphfdsfl8prdpak6pgqj6kphx",
+        "rev": "48ff2e8065cf6c78ab303863ca46b91113eb0ddd",
+        "sha256": "0dg92i4sv6d20jgabwlz2p1yp6c47ys4715jv2l27bb4lnk8qa21",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/b55ad16bdf747e7ff6a3c821d92ed942d4e3be7c.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/48ff2e8065cf6c78ab303863ca46b91113eb0ddd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@b55ad16b...48ff2e80](https://github.com/romkatv/powerlevel10k/compare/b55ad16bdf747e7ff6a3c821d92ed942d4e3be7c...48ff2e8065cf6c78ab303863ca46b91113eb0ddd)

* [`cd865da1`](https://github.com/romkatv/powerlevel10k/commit/cd865da150cab138dda586f76d6a02f3a943d629) expand c-escapes in kubectl ([romkatv/powerlevel10k⁠#1361](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1361))
* [`607befe8`](https://github.com/romkatv/powerlevel10k/commit/607befe822e52b180fcb28bba01b273d3206bb84) bump version ([romkatv/powerlevel10k⁠#1361](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1361))
* [`836332f5`](https://github.com/romkatv/powerlevel10k/commit/836332f578a5802012b5f9f947285d2a8456c747) Font instructions for Asbrú Connection Manager ([romkatv/powerlevel10k⁠#1362](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1362))
* [`48ff2e80`](https://github.com/romkatv/powerlevel10k/commit/48ff2e8065cf6c78ab303863ca46b91113eb0ddd) fix style in font instructions
