### PR TITLE
niv spacemacs: update a862d1ac -> df15f8cc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "a862d1ac5f76fca79dffdc2f12e901e98645eb68",
-        "sha256": "0952kmka9jvcj89wp8rzfb7s2sk9n3g8l5gjd5dm9jzggzrw51q8",
+        "rev": "df15f8cc159b9fe4380144355af077935e7770b7",
+        "sha256": "18k04wji7681bp6b28g015yf71pndl5g0vyxrkb33mg9vsimfyjn",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/a862d1ac5f76fca79dffdc2f12e901e98645eb68.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/df15f8cc159b9fe4380144355af077935e7770b7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@a862d1ac...df15f8cc](https://github.com/syl20bnr/spacemacs/compare/a862d1ac5f76fca79dffdc2f12e901e98645eb68...df15f8cc159b9fe4380144355af077935e7770b7)

* [`4262e01f`](https://github.com/syl20bnr/spacemacs/commit/4262e01f1172d9d9190805a2c2e5bb63d2035af4) [doc] Fix links
* [`278a27d5`](https://github.com/syl20bnr/spacemacs/commit/278a27d5b093766ab359caa75ebd0044c26eb73c) Make TravisCI happy.
* [`aae6c119`](https://github.com/syl20bnr/spacemacs/commit/aae6c119570022968720c70ce78e8060628d35b1) fix rest of doc links
* [`f8d62d91`](https://github.com/syl20bnr/spacemacs/commit/f8d62d91f8ac05e0b3bc9489889d1788cf4155ba) Update CI badges
* [`9da9e3ff`](https://github.com/syl20bnr/spacemacs/commit/9da9e3ff01d7071a894acc34e31d8c9a6dc983fe) Align badges
* [`32da4286`](https://github.com/syl20bnr/spacemacs/commit/32da42863e3109bf5df33503515f8a52ca1d8524) [c-c++] Fix "Wrong number of arguments" on Emacs 28
* [`2713ec87`](https://github.com/syl20bnr/spacemacs/commit/2713ec8789f7b245325846f4233f581459f29a72) Fix [syl20bnr/spacemacs⁠#14641](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14641)
* [`d4458571`](https://github.com/syl20bnr/spacemacs/commit/d44585717880de268c91131a6c8399baa1367a20) [gtags] improve
* [`693a0110`](https://github.com/syl20bnr/spacemacs/commit/693a0110ff48eb94add5b5e8b0d26ea1b34eb929) Fix call to deleted method in latex layer
* [`83455689`](https://github.com/syl20bnr/spacemacs/commit/8345568971ce4d882a58826fcee0dcb05946710d) Fix scheme layer support for scheme implementations
* [`b3c78297`](https://github.com/syl20bnr/spacemacs/commit/b3c78297fbdd070b397722ab1a7970bf9d2f400a) Add describe evil ex-command functionality
* [`b5fb7d53`](https://github.com/syl20bnr/spacemacs/commit/b5fb7d5376de236d31811cb1b1b6d05cf090bfab) [base] Fix void spacemacs-evil-collection-allowed-list
* [`95280d15`](https://github.com/syl20bnr/spacemacs/commit/95280d15a8612b1edd519d1f0e9472cfd8fa7e27) [dired] Add ivy command and replace evil collection key
* [`26390c15`](https://github.com/syl20bnr/spacemacs/commit/26390c155c121b6d78b01aae6b73c27052ae4653) Search Engine layer: Allow customization of Amazon site TLD.
* [`44710247`](https://github.com/syl20bnr/spacemacs/commit/44710247211273b21a5131d232ac07df3e146e3f) [bot] Auto-update ([syl20bnr/spacemacs⁠#14648](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14648))
* [`3f795aeb`](https://github.com/syl20bnr/spacemacs/commit/3f795aebdbece1dac7108e873dfc96b8bf506aed) [parinfer] Remove path hack and obsolete layer specific hooks
* [`59ecf6a1`](https://github.com/syl20bnr/spacemacs/commit/59ecf6a119c3d397aabfdbdbac7022d831db2a3b) fixup! windows-scripts: replaced dos.el with bat-mode, added bmx-mode
* [`347ac504`](https://github.com/syl20bnr/spacemacs/commit/347ac504d87653a6ec356ff801321038d8cd2b5c) [helpful] Make layer alias standard describe-functions
* [`313f975a`](https://github.com/syl20bnr/spacemacs/commit/313f975a2fb4c19c4d5edf81f5ce9769fd6d2027) Add eww layer
* [`f5ae7206`](https://github.com/syl20bnr/spacemacs/commit/f5ae72064587a26949b1fc1edac599cb48af23c5) [eww] Specific changes from `dalanicolai/eww-layer`
* [`bc713b19`](https://github.com/syl20bnr/spacemacs/commit/bc713b194381234366aa2fe5b4246eb9958c46bc) [eww] Fix some smaller issues in the new layer
* [`2b921493`](https://github.com/syl20bnr/spacemacs/commit/2b9214938673b5a9f9d5fef1d284088fe6aa11ec) Fix ewww docs
* [`9257aab1`](https://github.com/syl20bnr/spacemacs/commit/9257aab154ba91617768aeb45cd52b81d08c1889) documentation formatting: Sat Apr 17 07:08:57 UTC 2021
* [`c0525bed`](https://github.com/syl20bnr/spacemacs/commit/c0525bed816ad507b28fdc21733153ad10d0ca08) [eww] Change bindings to match its given category
* [`c83a9e76`](https://github.com/syl20bnr/spacemacs/commit/c83a9e76b35e3d3a4c07d88a85297dc5dad88929) groovy: Fix local vars
* [`8814329a`](https://github.com/syl20bnr/spacemacs/commit/8814329a115ec813b2da9a55ff3f29270a5b5e18) [groovy] Replace defvar with spacemacs|defc
* [`539c7849`](https://github.com/syl20bnr/spacemacs/commit/539c7849d5661a02727424cad738d213a0e5aea4) [core] Avoid setting safe-local-variable to nil in spacemacs|defc
* [`bd3a7fb0`](https://github.com/syl20bnr/spacemacs/commit/bd3a7fb0b519e042e4d555ac835c35beec245c71) go: Fix local variables
* [`b3bf5c1f`](https://github.com/syl20bnr/spacemacs/commit/b3bf5c1fb4e002c2de89d2cb6360f151b5355146) [groovy] Fix wrong customization type
* [`247d0592`](https://github.com/syl20bnr/spacemacs/commit/247d059289792513963f6aa481f488f8909ef435) [go] Switch layer variables to defcustoms
* [`4a1f0ae4`](https://github.com/syl20bnr/spacemacs/commit/4a1f0ae49f61eb56457dd48bceb2bec10b7e669b) [python] Fix directory specific python-backend
* [`175840bc`](https://github.com/syl20bnr/spacemacs/commit/175840bc6e326069495d806e3c49dd839fe7170c) react: fix file auto detection ([syl20bnr/spacemacs⁠#14680](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14680))
* [`3bbc7a7d`](https://github.com/syl20bnr/spacemacs/commit/3bbc7a7d408f67ad78590fae7831ae14cd5c1896) core-customization: improved SAFE variable handling ([syl20bnr/spacemacs⁠#14679](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14679))
* [`623c75d7`](https://github.com/syl20bnr/spacemacs/commit/623c75d7d9dcfc207f6ec634e854b85ddf8b8f3f) Fix: update eaf layer
* [`866c362d`](https://github.com/syl20bnr/spacemacs/commit/866c362d06f123af77b93be482c3a6c6013643eb) configure racket-describe-mode keybindings
* [`056eb6b9`](https://github.com/syl20bnr/spacemacs/commit/056eb6b91b1afa8459af715bb32e6c1a3fff97b3) [defaults] add qickrun
* [`b4cf0043`](https://github.com/syl20bnr/spacemacs/commit/b4cf004319c9e0a73609382f7417e4191edd00fb) [visual][popwin] add keybiding to resume last popwin buffer
* [`6a8dcd01`](https://github.com/syl20bnr/spacemacs/commit/6a8dcd014ea1f58952dfaa9fa02b485c5dee97d8) [visual][popwin] Adjust variable naming to match conventions
* [`235aa8d4`](https://github.com/syl20bnr/spacemacs/commit/235aa8d44e1eaa23c00bd3fdd6c550be9fcab87d) [new layer] nav-flash
* [`a664569a`](https://github.com/syl20bnr/spacemacs/commit/a664569a4879b24973111871f92c6c566b6503b9) Add Emacs Window Manager (EXWM) Layer AKA SpacemacsOS ([syl20bnr/spacemacs⁠#3321](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/3321))
* [`2e02ac0a`](https://github.com/syl20bnr/spacemacs/commit/2e02ac0a31a9f5225aefbf52d0d11e188b8cd733) [exwm] Adjust layer README to match current standards
* [`df15f8cc`](https://github.com/syl20bnr/spacemacs/commit/df15f8cc159b9fe4380144355af077935e7770b7) documentation formatting: Mon Apr 19 20:28:58 UTC 2021
