### PR TITLE
niv zsh-completions: update cb4b721a -> 901a787b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -156,10 +156,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "cb4b721ada6cb2fa01c97cc3a04aeca4d7aae6bc",
-        "sha256": "036pqh4b8lvdjac3iqvj0giq4c857fw6ngfq4c9ng0rksm4g2dfn",
+        "rev": "901a787b2d514e417d019f676fcc3adfa1929eb1",
+        "sha256": "03yqimb4xp5lswsl1gvrqpxmsn1q4hsdkc802x5iq5iy0k47nli3",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/cb4b721ada6cb2fa01c97cc3a04aeca4d7aae6bc.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/901a787b2d514e417d019f676fcc3adfa1929eb1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@cb4b721a...901a787b](https://github.com/zsh-users/zsh-completions/compare/cb4b721ada6cb2fa01c97cc3a04aeca4d7aae6bc...901a787b2d514e417d019f676fcc3adfa1929eb1)

* [`b65eb5d6`](https://github.com/zsh-users/zsh-completions/commit/b65eb5d64e74a07b92f64398209d389322ec38d4) added completions for opus-tools (opusenc, opusdec & opusinfo)
