### PR TITLE
niv zsh-syntax-highlighting: update e8517244 -> ebef4e55

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "e8517244f7d2ae4f9d979faf94608d6e4a74a73e",
-        "sha256": "1dd1l4g5hkx1pnl1dw4h8ignjhigrvkkcravfkifdl2zf3slyny7",
+        "rev": "ebef4e55691f62e630318d56468e5798367aa81c",
+        "sha256": "0qimb90655hkm64mjqcn48kqq38cbfxlfhs324cbdi9gqpdi6q4b",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/e8517244f7d2ae4f9d979faf94608d6e4a74a73e.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/ebef4e55691f62e630318d56468e5798367aa81c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@e8517244...ebef4e55](https://github.com/zsh-users/zsh-syntax-highlighting/compare/e8517244f7d2ae4f9d979faf94608d6e4a74a73e...ebef4e55691f62e630318d56468e5798367aa81c)

* [`993a07fc`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/993a07fc7f4e077b556192cfc5c3efc29b40fd96) docs: Fix broken link to fish shell
* [`ebef4e55`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/ebef4e55691f62e630318d56468e5798367aa81c) docs: Use SSL for the link to zsh's homepage.
