### PR TITLE
niv nixpkgs: update a8b5aa35 -> e1bc639f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a8b5aa35706c6df84f7700cdeb15a5d538f5d313",
-        "sha256": "1bbc35lgsjsirvkzw3x3hnlw0nfisa4yry39yg5g0n3p42lqb8m7",
+        "rev": "e1bc639fd4c4664484df656a2dd05e7f827543cc",
+        "sha256": "0vf6k0c22fwy40qgpdrb24alh9f9ld82rn48ddywmqhil9xyqj4b",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a8b5aa35706c6df84f7700cdeb15a5d538f5d313.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e1bc639fd4c4664484df656a2dd05e7f827543cc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a8b5aa35...e1bc639f](https://github.com/nixos/nixpkgs/compare/a8b5aa35706c6df84f7700cdeb15a5d538f5d313...e1bc639fd4c4664484df656a2dd05e7f827543cc)

* [`d42e8b35`](https://github.com/NixOS/nixpkgs/commit/d42e8b35d157d4e8ea7112d299aad55554a10ca2) python3Packages.archinfo: 9.0.6790 -> 9.0.6852
* [`ac1adaa1`](https://github.com/NixOS/nixpkgs/commit/ac1adaa1848ceecb9048c2f2b913e208c94fce7c) python3Packages.ailment: 9.0.6790 -> 9.0.6852
* [`8533e7d4`](https://github.com/NixOS/nixpkgs/commit/8533e7d446fccd7d214152d7ded4cc1c3e154501) python3Packages.pyvex: 9.0.6790 -> 9.0.6852
* [`bad41dc4`](https://github.com/NixOS/nixpkgs/commit/bad41dc48e4cab66c37dcab30523edb8f6645b97) python3Packages.claripy: 9.0.6790 -> 9.0.6852
* [`c9f25582`](https://github.com/NixOS/nixpkgs/commit/c9f255825e8c4e9e5a33d8218112fab7214828c0) python3Packages.cle: 9.0.6790 -> 9.0.6852
* [`c150ea08`](https://github.com/NixOS/nixpkgs/commit/c150ea08736b8bbc4ee950fe41fde743b8a40dd4) python3Packages.angr: 9.0.6790 -> 9.0.6852
* [`f728aa66`](https://github.com/NixOS/nixpkgs/commit/f728aa666bde888473c2979f6797ef6bc576f795) python3Packages.angrop: 9.0.6790 -> 9.0.6852
* [`793562da`](https://github.com/NixOS/nixpkgs/commit/793562da349112cb3669386d6e800a1e33a41a6a) git-chglog: 0.9.1 -> 0.14.2 ([nixos/nixpkgs⁠#120097](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120097))
* [`755633ea`](https://github.com/NixOS/nixpkgs/commit/755633ea54894e8f50a038c1e619e509d51bb93f) cryfs: disable tests on Darwin
* [`603707a1`](https://github.com/NixOS/nixpkgs/commit/603707a13707435f130f15bd0265e03fed20734f) nixos/doc/manual: refine extraLayouts, add warnings an test commands
* [`31014c4a`](https://github.com/NixOS/nixpkgs/commit/31014c4a2888cd4f782b0cba246f3b8036d63b30) ocamlPackages.mirage-crypto*: 0.9.2 -> 0.10.0
* [`7c5e7d69`](https://github.com/NixOS/nixpkgs/commit/7c5e7d69eb3a04100047f2b43dc22fd78db2b8a8) python3Packages.survey: 3.4.2 -> 3.4.3
* [`efa5a316`](https://github.com/NixOS/nixpkgs/commit/efa5a31633a93bb3f12b6c0499ad1bbb28766850) wine{Unstable,Staging}: 6.6 -> 6.7
* [`a663a7e1`](https://github.com/NixOS/nixpkgs/commit/a663a7e18cb1b24d664614ef083ee17822bdf61d) pythonPackages.pyturbojpeg: 1.4.2 -> 1.4.3
* [`02c2a942`](https://github.com/NixOS/nixpkgs/commit/02c2a942d9c0cd6e2b992168d15a1dae5806d24c) python3Packages.dask-glm: fix eval
* [`adb13fb8`](https://github.com/NixOS/nixpkgs/commit/adb13fb8a289e02bacfd474252e9c6b72888a225) telegraf: 1.18.0 -> 1.18.1
* [`94d73b52`](https://github.com/NixOS/nixpkgs/commit/94d73b52f2914eed2558c1a155f0c574e76f6c03) python3Packages.panel: 0.11.1 -> 0.11.3
* [`61f2b366`](https://github.com/NixOS/nixpkgs/commit/61f2b36624b039c1ea35e3eba72d094e6bbb1e15) ddcutil: 1.0.1 -> 1.1.0
* [`8fce6f76`](https://github.com/NixOS/nixpkgs/commit/8fce6f76254543f8faf7900590a998d95cbc917f) python3Packages.pyviz-comms: 2.0.1 -> 0.7.6
* [`8aab788d`](https://github.com/NixOS/nixpkgs/commit/8aab788d4a703ee3e0edae7630d94952a2e6cd4f) check_systemd: 2.2.1 -> 2.3.1
* [`bc222c44`](https://github.com/NixOS/nixpkgs/commit/bc222c449ec0129034d49de361e34053587fba21) gdu: remove unused input
* [`a902d994`](https://github.com/NixOS/nixpkgs/commit/a902d99422c6a522ffae7b8ad7711e23c7490d42) llvmPackages_12: Always use the attribute name for pname
* [`e4f8498c`](https://github.com/NixOS/nixpkgs/commit/e4f8498c0bc5add1d704f2c8cc7fd39a48088f0b) llvmPackages_12: Create subdirectories for the last two packages
* [`c534a843`](https://github.com/NixOS/nixpkgs/commit/c534a8434fb470aaf878ac8a398dfd6f68e008e1) nixos-install: fix flake command
* [`5d41312d`](https://github.com/NixOS/nixpkgs/commit/5d41312d3319338ded07f3f63c2ea9691fc29f4d) prs: 0.2.8 -> 0.2.9 ([nixos/nixpkgs⁠#120494](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120494))
* [`754e384f`](https://github.com/NixOS/nixpkgs/commit/754e384fce95b476f8fa7f1c4af12a7985586fc7) pdns-recursor: 4.4.2 -> 4.4.3
* [`a82f2a01`](https://github.com/NixOS/nixpkgs/commit/a82f2a0146f899bdea479d77d285b1473a7d27ef) ungoogled-chromium: 89.0.4389.114 -> 90.0.4430.85
* [`b479a703`](https://github.com/NixOS/nixpkgs/commit/b479a7031e34d71db7827b830da688731441de89) exif: 0.6.21 -> 0.6.22
* [`60b30e4e`](https://github.com/NixOS/nixpkgs/commit/60b30e4ef6beb178af07f36776da878fff7ed596) mkvtoolnix: 55.0.0 -> 56.0.0
* [`eb335f69`](https://github.com/NixOS/nixpkgs/commit/eb335f697eb7fd4e8f10e6d3ec1467a2e7dc0ead) chromium: Warn about and cleanup old chromiumVersionAtLeast conditionals
* [`8495758f`](https://github.com/NixOS/nixpkgs/commit/8495758f16081f05dffc92ca1015d8064218add4) zookeeper: 3.6.2 -> 3.6.3
* [`3f151a56`](https://github.com/NixOS/nixpkgs/commit/3f151a56170b5b7d1cd7580864a2ee9d18bf1c90) vimPlugins: update
* [`fff666d4`](https://github.com/NixOS/nixpkgs/commit/fff666d4f759eeae646fe93acb3dc805fa2f78f7) vimPlugins: resolve github repository redirects
* [`888acb76`](https://github.com/NixOS/nixpkgs/commit/888acb76a758ab7bfc3766b2a00aea2e90af5b8a) vimPlugins.LeaderF: init at 2021-04-02
* [`16f6bc4f`](https://github.com/NixOS/nixpkgs/commit/16f6bc4f01b0034659b4993f0c1d85a4aa5c2b7c) vimPlugins.wildfire-vim: init at 2014-11-16
* [`d1ad812e`](https://github.com/NixOS/nixpkgs/commit/d1ad812ec14bc1f68e9cef3b013219e6c588ca66) vimPlugins.suda-vim: init at 2021-02-20
* [`de69947e`](https://github.com/NixOS/nixpkgs/commit/de69947e83ac5736afff83a25f6eeef28ca0306d) vimPlugins.vim-xtabline: init at 2021-01-31
* [`12ece330`](https://github.com/NixOS/nixpkgs/commit/12ece3309846609807429d414ee630600dced644) vimPlugins.vim-helm: init at 2020-01-02
* [`7b0b4c04`](https://github.com/NixOS/nixpkgs/commit/7b0b4c048a2ef1f719e1e196e6b5786411643a68) vimPlugins.lazygit-nvim: init at 2021-03-25
* [`c1db9914`](https://github.com/NixOS/nixpkgs/commit/c1db991404551371a3aeaeaaac303fca59886386) pythonPackages.hydrus: 434 -> 436
* [`c6e9a834`](https://github.com/NixOS/nixpkgs/commit/c6e9a834b7dfad93d341a676b8c8f61c4b484d1d) python3Packages.homeconnect: init at 0.6.3
* [`24003276`](https://github.com/NixOS/nixpkgs/commit/240032766127394394a23a3fb1d42c8824db1251) home-assistant: update component-packages
* [`766e6987`](https://github.com/NixOS/nixpkgs/commit/766e69873920d62946613570572177edf4abb8b8) home-assistant: enable home_connect tests
* [`53a3fc28`](https://github.com/NixOS/nixpkgs/commit/53a3fc28563c22f78768c3cc479206257183f5f8) ocamlPackages.sedlex_2: 2.2 -> 2.3
* [`ddf567cd`](https://github.com/NixOS/nixpkgs/commit/ddf567cd5a26eefab925ebc2e50d15d61e82257a) nixos/nagios: use the correct option to restart on config change
* [`5577ad58`](https://github.com/NixOS/nixpkgs/commit/5577ad58497481f9736d7dc593884fc821484f14) kubeconform: 0.4.6 -> 0.4.7
* [`7893552a`](https://github.com/NixOS/nixpkgs/commit/7893552afadb4dc5dd81427cd6da673180e53a33) esbuild: 0.11.13 -> 0.11.14
* [`f96a6606`](https://github.com/NixOS/nixpkgs/commit/f96a6606d6c23a598b6a5aa1c08186afec81d990) remote-touchpad: init at 1.0.1
* [`f3a2bf71`](https://github.com/NixOS/nixpkgs/commit/f3a2bf7109ca8f8676de3a3e683ff8ee83132221) git-review: 2.0.0 -> 2.1.0
* [`b7536ac8`](https://github.com/NixOS/nixpkgs/commit/b7536ac80fc0e41ee1bf68d293678fec99cfe99b) dovecot_fts_xapian: 1.4.7 -> 1.4.9
* [`d79d927c`](https://github.com/NixOS/nixpkgs/commit/d79d927cca0ac03067e5727a3d1da60590ad8f17) steamPackages.steam: 1.0.0.69 -> 1.0.0.70
* [`69a4de62`](https://github.com/NixOS/nixpkgs/commit/69a4de62515cb3980fbb5c68120d607a3bbca5c4) steamPackages.steam: use stable archive to avoid 404s
* [`019cf935`](https://github.com/NixOS/nixpkgs/commit/019cf935eb7beb9fe7d1ebfe271a9b03c0d8740a) python3Packages.smhi-pkg: init at 1.0.14
* [`cee05552`](https://github.com/NixOS/nixpkgs/commit/cee055528dcef460c3d5e49eb147d9fd55675d4b) home-assistant: update component-packages
* [`e1054f07`](https://github.com/NixOS/nixpkgs/commit/e1054f07f1c3fae9f8b96cb9d46cf75ddc27216f) home-assistant: enable smhi tests
* [`0b2840ba`](https://github.com/NixOS/nixpkgs/commit/0b2840ba4ed432b5e5a364e0c5bd18cb2535540f) nntp: 6.3.0 -> 6.4.0
* [`9d95ba3d`](https://github.com/NixOS/nixpkgs/commit/9d95ba3dd6aaf60082e040f7762a81fb9cc23c67) actions: add some permission restrictions
* [`47d3e955`](https://github.com/NixOS/nixpkgs/commit/47d3e955fc40c045c3aafee19a9bd82d3d221abe) nixos/mastodon/sandbox: add @⁠privileged and @⁠raw-io to SystemCallFilter
* [`d6ed686e`](https://github.com/NixOS/nixpkgs/commit/d6ed686eb2c121cc5150c742702f908bcb6d9ab7) Add NixOS/Security as a reviewer for .github/workflows
* [`bdb72489`](https://github.com/NixOS/nixpkgs/commit/bdb72489444ab0522f4a143ea53b655a91b1845d) binwalk: 2.2.0 -> 2.3.1
* [`2cc7846a`](https://github.com/NixOS/nixpkgs/commit/2cc7846adf0031a9e8e24a44b677fd4b67996e0a) pdftk: mark unbroken on darwin
* [`ad521d00`](https://github.com/NixOS/nixpkgs/commit/ad521d005b56821c79e98ce65132bca5732ea677) buck: use jdk8
* [`8e93e344`](https://github.com/NixOS/nixpkgs/commit/8e93e344776909de1c486237be6a02c2aac6f7ad) nushell: 0.29.0 -> 0.30.0
* [`3e1c0665`](https://github.com/NixOS/nixpkgs/commit/3e1c06654b94d35f529b061199c7ae5063b0d1b6) airspy: 1.0.9 -> 1.0.10
* [`55e51a81`](https://github.com/NixOS/nixpkgs/commit/55e51a818428f51a37a53eccff6d9ac8874fca4f) qhull: 2016.1 -> 2020.2
* [`a7e5b070`](https://github.com/NixOS/nixpkgs/commit/a7e5b070beba7a11677c1c4050a105aefead2854) androidenv: Allow multiple ndkVersions to be specified
* [`d9b11e53`](https://github.com/NixOS/nixpkgs/commit/d9b11e53b1e30d3d64a96a4156dd67df5c571881) python3Packages.angr: extend pythonImportsCheck
* [`bce7201f`](https://github.com/NixOS/nixpkgs/commit/bce7201f725e0aa867f74185dc0f0e9c7bb8403a) python3Packages.pysmartapp: init at 0.3.3
* [`a0755baf`](https://github.com/NixOS/nixpkgs/commit/a0755baff358228799076e9f97f76ea9c9eb58d5) python3Packages.pysmartthings: init at 0.7.6
* [`55c3640e`](https://github.com/NixOS/nixpkgs/commit/55c3640e8980777087ad9da5c905b4148d14ff84) home-assistant: update component-packages
* [`fe9a9942`](https://github.com/NixOS/nixpkgs/commit/fe9a9942e24e5e45dd2796637275b05b57a283a3) home-assistant: enable smartthings tests
* [`70c96f0e`](https://github.com/NixOS/nixpkgs/commit/70c96f0e02dcfdc559da4bc699c751d9fb1b2dab) babeld: add patch to skip per interface rp_filter setup
* [`e8988f7a`](https://github.com/NixOS/nixpkgs/commit/e8988f7a30ba6e4a55c06673a8b672b75bb25d76) nixos/babeld: run as DynamicUser
* [`ceb26b53`](https://github.com/NixOS/nixpkgs/commit/ceb26b53d817cd60218dc95e00192c20ff0bea54) nixos/tests/babeld: drop forwarding sysctls
* [`4dee1684`](https://github.com/NixOS/nixpkgs/commit/4dee1684ff3a074163c6c8f7e8cdc28895dce77f) himalaya: 0.2.6 -> 0.2.7
* [`3f2857f7`](https://github.com/NixOS/nixpkgs/commit/3f2857f78244798d354519a142b5e9a7fca26e49) qemu: add patches for many CVEs
* [`4f75c6e4`](https://github.com/NixOS/nixpkgs/commit/4f75c6e4386616154914154515d55d53d11e0fe5) drawing: 0.4.13 -> 0.8.0
* [`5b6e08ba`](https://github.com/NixOS/nixpkgs/commit/5b6e08ba57ac384c7206e941448746849cf34a51) gptman: init at 0.8.0
* [`db381efa`](https://github.com/NixOS/nixpkgs/commit/db381efaff433ea8625527adbe574b8d69d1a2ee) avfs: 1.1.3 -> 1.1.4
* [`097467a5`](https://github.com/NixOS/nixpkgs/commit/097467a5046afcf392904b3d42193074394c7479) tflint: 0.27.0 -> 0.28.0
* [`16f68549`](https://github.com/NixOS/nixpkgs/commit/16f68549f2f36420f840811eb9ae604c7393132c) avfs: set license to gpl2Only
* [`45e06725`](https://github.com/NixOS/nixpkgs/commit/45e0672539a7212b0d3205334065b772842b159f) gcsfuse: 0.34.0 -> 0.34.1
* [`4b7ccb34`](https://github.com/NixOS/nixpkgs/commit/4b7ccb341881d1773f250c2a2e3fa6d5cab6d848) stlink: 1.6.0 -> 1.7.0
* [`ab6943a7`](https://github.com/NixOS/nixpkgs/commit/ab6943a745059a8c177d7512c23ab7af58e822d1) macdylibbundler: delete duplicate dylibbundler ([nixos/nixpkgs⁠#119486](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/119486))
* [`e58f896f`](https://github.com/NixOS/nixpkgs/commit/e58f896fffcaf2452f3e8ccb724e733b467d8f96) jellyfin-media-player: 1.4.1 -> 1.5.0
* [`688990ec`](https://github.com/NixOS/nixpkgs/commit/688990ec8914791628704b445dfefe3f6ae93e3d) libchewing: 0.5.1 -> unstable-2020-06-27
* [`4b3592df`](https://github.com/NixOS/nixpkgs/commit/4b3592df70d9ff5c78dbcf50aff4daa645810321) python3Packages.libarcus: 4.8.0 -> 4.9.0
* [`2f7c1489`](https://github.com/NixOS/nixpkgs/commit/2f7c14899e2e66f1826cd7efd7322d2a3956eb93) python3Packages.libsavitar: 4.8.0 -> 4.9.0
* [`8f5cb6ca`](https://github.com/NixOS/nixpkgs/commit/8f5cb6ca60d0a7e0a6314be9f60dbbe48f876867) python3Packages.uranium: 4.7.1 -> 4.9.0
* [`342d9fd8`](https://github.com/NixOS/nixpkgs/commit/342d9fd84f54a38b72f6c18af733c18016f99663) curaengine: 4.8.0 -> 4.9.0
* [`8563f899`](https://github.com/NixOS/nixpkgs/commit/8563f899cb5dc1ca10c663e69da87f37540fd76e) cura: 4.8.0 -> 4.9.0
* [`53657d7d`](https://github.com/NixOS/nixpkgs/commit/53657d7d25e46174aed04af96b112e8f0f71b861) curaPlugins.rawmouse: 1.0.13 -> 1.1.0
* [`d4f48c85`](https://github.com/NixOS/nixpkgs/commit/d4f48c85476b2a7227e587c9a9cfb3b9b41af554) coqPackages.tlc: 20200328 → 20210316
* [`b8ef16dc`](https://github.com/NixOS/nixpkgs/commit/b8ef16dc1e9d07f14be191d020048630079e5235) treefmt: init at 0.1.1 ([nixos/nixpkgs⁠#120521](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120521))
* [`c94c1874`](https://github.com/NixOS/nixpkgs/commit/c94c1874da67916f5cf0f1ef63c3b92a197b3bd3) influxdb: 1.8.4 -> 1.8.5 ([nixos/nixpkgs⁠#120207](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120207))
* [`4a670762`](https://github.com/NixOS/nixpkgs/commit/4a67076273c8c566f90e3f0caadce941106314d9) koka: make sure runtime dependencies are host -> target
* [`b5f7ed7c`](https://github.com/NixOS/nixpkgs/commit/b5f7ed7cc89ec40a79cc1e0e8fdbe738152822fe) ocamlPackages.shared-memory-ring(-lwt): init at 3.1.0
* [`980a2bed`](https://github.com/NixOS/nixpkgs/commit/980a2bed3bdb2801d7aee238decdf62c014b56f4) ocamlPackages.mirage-xen: init at 6.0.0
* [`2fe82391`](https://github.com/NixOS/nixpkgs/commit/2fe8239172c3aeccfd14910638aa74e440516b2a) ocamlPackages.{mirage-net-xen,netchannel}: init at 2.0.0
* [`4f7a6610`](https://github.com/NixOS/nixpkgs/commit/4f7a6610f700bdd1e9dab7b5b3efa125465ae797) ocamlPackages.mirage-bootvar-xen: init at 0.8.0
* [`83452cfd`](https://github.com/NixOS/nixpkgs/commit/83452cfd71cd3ce14750b88f661172f24a92257b) wireshark: 3.4.4 -> 3.4.5
* [`f24b888d`](https://github.com/NixOS/nixpkgs/commit/f24b888dc2efbd1f23bb6b1f46cee5e94c8fdd63) soldat-unstable: 2020-11-26 -> 2021-02-09
* [`c41d97c3`](https://github.com/NixOS/nixpkgs/commit/c41d97c324a187e4a86f414260e034c22db97b92) soldat-unstable: move unstable into version
* [`5f783493`](https://github.com/NixOS/nixpkgs/commit/5f783493a99a41ba2704541a817bfae21d3dd305) soldat-unstable: run hooks for build and install phase
* [`b929d94a`](https://github.com/NixOS/nixpkgs/commit/b929d94a7521d490bd6092e5f9ec34fe4c22b997) python3Packages.python-string-utils: init at 1.0.0
* [`b02d4a38`](https://github.com/NixOS/nixpkgs/commit/b02d4a38d9611ee99fd20aa9fddc6dbfcc555d6c) python3Packages.openshift: init at 0.12.0
* [`024b4917`](https://github.com/NixOS/nixpkgs/commit/024b4917eb9cd8ac094a365e724a7e83ea2584bd) languagetool: 5.2 -> 5.3
* [`093b2f8b`](https://github.com/NixOS/nixpkgs/commit/093b2f8b2608fe6600c1b510088de9418238547e) termsyn: init at 1.8.7
* [`6b9e396a`](https://github.com/NixOS/nixpkgs/commit/6b9e396a071f10119c12f9f8b249d2b17aeb23ce) qalculate-gtk: 3.17.0 -> 3.18.0
* [`9db80bb1`](https://github.com/NixOS/nixpkgs/commit/9db80bb156c3745695df1ebea0887d642f24cb5b) python3Packages.robotframework: 4.0 -> 4.0.1
* [`ed85d8cd`](https://github.com/NixOS/nixpkgs/commit/ed85d8cdfb705f8f1d350bdc6f51e0dfbca2015d) languagetool: add preInstall and postInstall runhooks
* [`468926cb`](https://github.com/NixOS/nixpkgs/commit/468926cba4d5ff826ea0caa408d836636bbeaeef) sigal: 2.1.1 -> 2.2
* [`8e2d3f94`](https://github.com/NixOS/nixpkgs/commit/8e2d3f941e2878e2c666de9c5b131ffb15ff2665) teleport: 5.2.1 -> 6.1.2
* [`df86e6fb`](https://github.com/NixOS/nixpkgs/commit/df86e6fb0e0cd9601fa53b33b886c7e350fd71bb) mpfi: fix download URL
* [`bc1cd4f3`](https://github.com/NixOS/nixpkgs/commit/bc1cd4f3b3d2039e78977f8e2a3c292b15336d6a) python3Packages.pynx584: init at 0.6
* [`5cd12de2`](https://github.com/NixOS/nixpkgs/commit/5cd12de25c44c6f7dad3a1460f5e236074dcc12b) home-assistant: update component-packages
* [`3e1f4139`](https://github.com/NixOS/nixpkgs/commit/3e1f41395b608ce999184b5f0d824211f05b1386) home-assistant: enable nx584 tests
* [`2756b33d`](https://github.com/NixOS/nixpkgs/commit/2756b33d07ced66570bb584b8fe9398ee3179ab8) ftgl: 2.1.3-rc5 -> 2.4.0
* [`963a8cfe`](https://github.com/NixOS/nixpkgs/commit/963a8cfe25b4df70330495b01fa970516cc54b3d) cimg: 2.9.6 -> 2.9.7
* [`3a7af6de`](https://github.com/NixOS/nixpkgs/commit/3a7af6de81eedf4de73b6487e92a88babcb03f6b) dialog: 1.3-2210306 -> 1.3-2210324
* [`738e8eb9`](https://github.com/NixOS/nixpkgs/commit/738e8eb967783b0bda4d3548cd775556d7b5e9c6) python3Packages.robotframework: run the unit tests
* [`8a4abd95`](https://github.com/NixOS/nixpkgs/commit/8a4abd956fff6a5d9cbc2282469478ca88f3fd33) protoc-gen-go-grpc: init at 1.1.0
* [`ddbd4d47`](https://github.com/NixOS/nixpkgs/commit/ddbd4d4749b0fd4d236d2d495e154615d508edd3) simplescreenrecorder: 0.3.11 -> 0.4.3
* [`4b0bde3b`](https://github.com/NixOS/nixpkgs/commit/4b0bde3b42552485f1e4283a950fcdc51ad4cb1c) agi: 1.1.0-dev-20210421 -> 1.1.0-dev-20210423
* [`bc66efc5`](https://github.com/NixOS/nixpkgs/commit/bc66efc5db51b57cafea2ae73c7ec46cf07dd75a) bazelisk: 1.7.5 -> 1.8.0
* [`78459891`](https://github.com/NixOS/nixpkgs/commit/78459891186af7cc32b0257c7abed69b59340ed9) docutils: 0.16 -> 0.17.1
* [`9066cb97`](https://github.com/NixOS/nixpkgs/commit/9066cb97fe27a09423db8e285fe96b875980de53) fme: refactor
* [`e1ad2f5a`](https://github.com/NixOS/nixpkgs/commit/e1ad2f5aa42283e79d33f8c6c8bbc20927fc68fe) sage: remove cypari2 override
* [`11c7219d`](https://github.com/NixOS/nixpkgs/commit/11c7219d4df364da63fa12dd727c6f7b8daf8725) youtube-dl: 2021.04.07 -> 2021.04.26
* [`0080a586`](https://github.com/NixOS/nixpkgs/commit/0080a5869066969e9cd8eebf7fe2f19ded637ff5) vips: 8.10.5 -> 8.10.6
* [`fbf8ee0a`](https://github.com/NixOS/nixpkgs/commit/fbf8ee0a701b3e28ae25c5263e8af2938621ca61) Revert "docutils: 0.16 -> 0.17.1"
* [`1a5230e4`](https://github.com/NixOS/nixpkgs/commit/1a5230e4a9f985e7d71e0197e27af5ff2cedbc66) python3.pkgs.rpmfile: init at 1.0.8
* [`bef69918`](https://github.com/NixOS/nixpkgs/commit/bef6991899476882e7fd3937cbf5322568ee3213) python3.pkgs.cve-bin-tool: init at unstable-2021-04-15
* [`21649174`](https://github.com/NixOS/nixpkgs/commit/216491747960901ad905cb7cef4b4a85552a5558) maintiners: add therealansh
* [`f1df273a`](https://github.com/NixOS/nixpkgs/commit/f1df273a67a2b17f97bc833b76639cda3cdd5d9a) zellij: init at 0.5.1
* [`6be41a35`](https://github.com/NixOS/nixpkgs/commit/6be41a3545c5fe7452039b0d17cfc597e540085f) grub2: Add samueldr as maintainer
* [`789398cf`](https://github.com/NixOS/nixpkgs/commit/789398cfa3f2933d5b9261f7df9d2dd5d1876926) python3Packages.onnx: 1.8.1 -> 1.9.0
* [`ff6eef6c`](https://github.com/NixOS/nixpkgs/commit/ff6eef6cf131f1c75ea620ccff832672b7537b50) python3Packages.onnx: Patch out pytest-runner
* [`a54bc9b6`](https://github.com/NixOS/nixpkgs/commit/a54bc9b671b0ff938075c026180b2ec04b53c8b2) docker: fix systemd unit files ([nixos/nixpkgs⁠#120019](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120019))
* [`eeeaa150`](https://github.com/NixOS/nixpkgs/commit/eeeaa150a833bd69fe7dd8afaa16e3df8357c1fd) ceph: require big-parallel
* [`b1173688`](https://github.com/NixOS/nixpkgs/commit/b1173688a83f7f30f26edf60e9f2ce13ba1187e5) clickhouse: require big-parallel
* [`300d303d`](https://github.com/NixOS/nixpkgs/commit/300d303d258e21bd989a4ff566fec3e06959c86f) aws-sdk-cpp: require big-parallel
* [`0d4abe5d`](https://github.com/NixOS/nixpkgs/commit/0d4abe5d4b63d55f3b93cd744218cf519a9789a0) python3Packages.pytorch: require big-parallel
* [`3429633a`](https://github.com/NixOS/nixpkgs/commit/3429633af36bcedff106c05e3cc1173641ffc32f) qemu: require big-parallel
* [`5907b815`](https://github.com/NixOS/nixpkgs/commit/5907b8151fd8c9e171809779beab6e5b0f6f0036) handlr: 0.6.1 -> 0.6.3
