### PR TITLE
niv home-manager: update 6aa6556b -> 827636c6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6aa6556bcab6dc0f6398b4daa8404d788fd7a6a2",
-        "sha256": "1x9fhh2g0n90vp5l0f9g66vxfsfcfy0xbr84qgaahsi2a9qk310j",
+        "rev": "827636c619ce0d8178ddc08ab86ee92b50f2e5b4",
+        "sha256": "0imqxlj40fabg7iifqqa5d91is842124qpflb8l36xpcjgfs4q4p",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/6aa6556bcab6dc0f6398b4daa8404d788fd7a6a2.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/827636c619ce0d8178ddc08ab86ee92b50f2e5b4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@6aa6556b...827636c6](https://github.com/nix-community/home-manager/compare/6aa6556bcab6dc0f6398b4daa8404d788fd7a6a2...827636c619ce0d8178ddc08ab86ee92b50f2e5b4)

* [`1e7e8ac7`](https://github.com/nix-community/home-manager/commit/1e7e8ac75d8a8b4da3f3ed44a97ddeb94512a20a) pet: Add support for tags in snippets ([nix-community/home-manager⁠#1883](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1883))
* [`0c236e13`](https://github.com/nix-community/home-manager/commit/0c236e13bc6b07a138a7a31fa408a73202cff28c) flake: add extraModules option, inherit nixpkgs config and overlays in homeManagerConfiguration ([nix-community/home-manager⁠#1767](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1767))
* [`db00b39a`](https://github.com/nix-community/home-manager/commit/db00b39a9abec04245486a01b236b8d9734c9ad0) termite: add option to enable VTE integration ([nix-community/home-manager⁠#1917](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1917))
* [`26fa84eb`](https://github.com/nix-community/home-manager/commit/26fa84ebce364aef3c3e041b7c01d4cb84db192d) scmpuff: init ([nix-community/home-manager⁠#1921](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1921))
* [`e00dd0d7`](https://github.com/nix-community/home-manager/commit/e00dd0d7d2565a9d79c3826b088bef039624382e) programs.tmux: use xdg config path ([nix-community/home-manager⁠#1928](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1928))
* [`839645ca`](https://github.com/nix-community/home-manager/commit/839645caf35b7004d3422fbdba6db1d762a410d0) programs.neovim: fix failing test ([nix-community/home-manager⁠#1943](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1943))
* [`c2c26120`](https://github.com/nix-community/home-manager/commit/c2c26120d7e76b2ab9a2f6584c8d6223fbd1123a) scmpuff: fix formatting
* [`827636c6`](https://github.com/nix-community/home-manager/commit/827636c619ce0d8178ddc08ab86ee92b50f2e5b4) dunst: add service package option ([nix-community/home-manager⁠#1944](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1944))
