### PR TITLE
niv powerlevel10k: update 48ff2e80 -> 8d1daa4e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "48ff2e8065cf6c78ab303863ca46b91113eb0ddd",
-        "sha256": "0dg92i4sv6d20jgabwlz2p1yp6c47ys4715jv2l27bb4lnk8qa21",
+        "rev": "8d1daa4e6340b1689bf951730489bc64c52220c7",
+        "sha256": "0bm0dd4lb9kwv3xl6lk0wyb0fqq83gs8kl9111qs5ybavwcxlnnr",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/48ff2e8065cf6c78ab303863ca46b91113eb0ddd.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/8d1daa4e6340b1689bf951730489bc64c52220c7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@48ff2e80...8d1daa4e](https://github.com/romkatv/powerlevel10k/compare/48ff2e8065cf6c78ab303863ca46b91113eb0ddd...8d1daa4e6340b1689bf951730489bc64c52220c7)

* [`b69bb45a`](https://github.com/romkatv/powerlevel10k/commit/b69bb45ab1f3171b88e192a121c86016dc02cd6e) disable colors in the output of taskwarrior ([romkatv/powerlevel10k⁠#1365](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1365))
* [`8d1daa4e`](https://github.com/romkatv/powerlevel10k/commit/8d1daa4e6340b1689bf951730489bc64c52220c7) disable colors in the output of taskwarrior; this time for real ([romkatv/powerlevel10k⁠#1365](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1365))
