### PR TITLE
niv spacemacs: update df15f8cc -> eeee3a1f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "df15f8cc159b9fe4380144355af077935e7770b7",
-        "sha256": "18k04wji7681bp6b28g015yf71pndl5g0vyxrkb33mg9vsimfyjn",
+        "rev": "eeee3a1fa0c2fc70be7b62d95aac49a1c6b3ba22",
+        "sha256": "0bx3xf89nscrl5axgpnsmpnwi1c2dxppkj63dm7aq4g9s0sv5rwz",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/df15f8cc159b9fe4380144355af077935e7770b7.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/eeee3a1fa0c2fc70be7b62d95aac49a1c6b3ba22.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@df15f8cc...eeee3a1f](https://github.com/syl20bnr/spacemacs/compare/df15f8cc159b9fe4380144355af077935e7770b7...eeee3a1fa0c2fc70be7b62d95aac49a1c6b3ba22)

* [`a6fc48db`](https://github.com/syl20bnr/spacemacs/commit/a6fc48dba42d3981b4d1b6f8771f9ba5a6738db7) bug fix - eslint not available for typescript-tsx-mode ([syl20bnr/spacemacs⁠#14685](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14685))
* [`70be2c03`](https://github.com/syl20bnr/spacemacs/commit/70be2c03d8bb926e700071a9df46cced0797cd38) Added asciidoc support. ([syl20bnr/spacemacs⁠#14689](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14689))
* [`7e031962`](https://github.com/syl20bnr/spacemacs/commit/7e031962808463c9af859b3c51381afa76d9a06f) [ocaml] Fix for merlin package split ([syl20bnr/spacemacs⁠#14691](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14691))
* [`433f6729`](https://github.com/syl20bnr/spacemacs/commit/433f6729e7c4fc562b5f48a62bcd0bb87ccc1173) [ocaml] Fix typo ([syl20bnr/spacemacs⁠#14692](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14692))
* [`ec2c511c`](https://github.com/syl20bnr/spacemacs/commit/ec2c511c6fd15169315697a5e854a1f42dd483ff) Add support for org-roam-protocol ([syl20bnr/spacemacs⁠#14687](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14687))
* [`e290b100`](https://github.com/syl20bnr/spacemacs/commit/e290b1006072cd2ee4578b1c4e2c737c78c1675e) Replace function aliases with their real names ([syl20bnr/spacemacs⁠#14688](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14688))
* [`7ef15a56`](https://github.com/syl20bnr/spacemacs/commit/7ef15a561a1a1f00574d30f46dd564c6d648ebfd) Fix issues with EXWM layer ([syl20bnr/spacemacs⁠#14693](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14693))
* [`870b2c9e`](https://github.com/syl20bnr/spacemacs/commit/870b2c9e5dc3765c80440d2118e26b2bbffb5ec0) dart: Fix local vars
* [`983ace00`](https://github.com/syl20bnr/spacemacs/commit/983ace0097427e3e972b04174f7bb67507b59e3e) elixir: Fix file local vars
* [`c8b914c8`](https://github.com/syl20bnr/spacemacs/commit/c8b914c8de7a844f2aebbba465e8569751bad479) erlang: Fix local vars
* [`7f0f93d7`](https://github.com/syl20bnr/spacemacs/commit/7f0f93d765697fef993fb83f28c446eed9844542) fix exwm readme
* [`982a3db0`](https://github.com/syl20bnr/spacemacs/commit/982a3db01fe07e0bcf12318688d1f7c908d8a202) [doc]fix the rest of exwm readme hls
* [`eddf1dc4`](https://github.com/syl20bnr/spacemacs/commit/eddf1dc46058d69e394ecf3aa0ca1e06bc0182e4) documentation formatting: Fri Apr 23 14:03:32 UTC 2021
* [`e0a6363b`](https://github.com/syl20bnr/spacemacs/commit/e0a6363ba90f7a1672142fa633c5921a6ee2b8c1) Built-in files auto-update: Fri Apr 23 14:02:04 UTC 2021
* [`d72e5129`](https://github.com/syl20bnr/spacemacs/commit/d72e5129930f0f96805da96b95ca4166e02f80ae) Use timeclock-mode-line-display in default bindings ([syl20bnr/spacemacs⁠#14713](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14713))
* [`557fc0ef`](https://github.com/syl20bnr/spacemacs/commit/557fc0efab0f7e459882149b90a23b11fb28ac7d) Scheme layer, add REPL keybindings ([syl20bnr/spacemacs⁠#14708](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14708))
* [`3dbe66dd`](https://github.com/syl20bnr/spacemacs/commit/3dbe66dda768fe3d14bfa9619dc01972e11747e5) documentation formatting: Mon Apr 26 13:46:02 UTC 2021 ([syl20bnr/spacemacs⁠#14718](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14718))
* [`6b135c5a`](https://github.com/syl20bnr/spacemacs/commit/6b135c5a69f05c7f5608c86dc8ecdea4bf555b7d) [scheme] Fix geiser company backends
* [`374fc28c`](https://github.com/syl20bnr/spacemacs/commit/374fc28c76ac72fcc3740b6e10026919f20461e0) Fix clone workspace
* [`635c326c`](https://github.com/syl20bnr/spacemacs/commit/635c326c0abee03fbc3d335482ec4578be3602be) fixed asciidoc export
* [`eeee3a1f`](https://github.com/syl20bnr/spacemacs/commit/eeee3a1fa0c2fc70be7b62d95aac49a1c6b3ba22) [core] Fix 'append nesting in transient-state-format-hint macro ([syl20bnr/spacemacs⁠#14698](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14698))
