### PR TITLE
niv zsh-completions: update 901a787b -> 773ead6e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -156,10 +156,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "901a787b2d514e417d019f676fcc3adfa1929eb1",
-        "sha256": "03yqimb4xp5lswsl1gvrqpxmsn1q4hsdkc802x5iq5iy0k47nli3",
+        "rev": "773ead6ea7b579106624851404d4f651acd5e042",
+        "sha256": "123jj1nzfrsr69y6qq4hw26mxc034pbp8bqlpiw78qv7q08mayl2",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/901a787b2d514e417d019f676fcc3adfa1929eb1.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/773ead6ea7b579106624851404d4f651acd5e042.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@901a787b...773ead6e](https://github.com/zsh-users/zsh-completions/compare/901a787b2d514e417d019f676fcc3adfa1929eb1...773ead6ea7b579106624851404d4f651acd5e042)

* [`d930094f`](https://github.com/zsh-users/zsh-completions/commit/d930094f84449a79e4173826aff8889ff8af11f2) fixed issues raised in the review
* [`57ba534a`](https://github.com/zsh-users/zsh-completions/commit/57ba534a6a1e53940fc052525c9ae4c07b820f9c) added appropriate opts for _arguments
* [`fea56d1a`](https://github.com/zsh-users/zsh-completions/commit/fea56d1a7b3764feab32bcaaddcfb805bd2d6aa2) Add zsh license header
* [`78fb97c2`](https://github.com/zsh-users/zsh-completions/commit/78fb97c24db7a81e2408206600d93477562637c3) changed "(%)" to "(percent)" in optarg descriptions
* [`67ced04c`](https://github.com/zsh-users/zsh-completions/commit/67ced04c7f6abb61bd790e4db0b78b77a2cde227) completions for lilypond
