### PR TITLE
niv nixpkgs: update e1bc639f -> d0dc38c1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e1bc639fd4c4664484df656a2dd05e7f827543cc",
-        "sha256": "0vf6k0c22fwy40qgpdrb24alh9f9ld82rn48ddywmqhil9xyqj4b",
+        "rev": "d0dc38c19ff3e23c9fbad48939dbd1ba18267924",
+        "sha256": "1qbcxjdy0p9f2q3hzhds2y1d2vy0pb11v24l12gcxh3g9h61szck",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e1bc639fd4c4664484df656a2dd05e7f827543cc.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d0dc38c19ff3e23c9fbad48939dbd1ba18267924.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e1bc639f...d0dc38c1](https://github.com/nixos/nixpkgs/compare/e1bc639fd4c4664484df656a2dd05e7f827543cc...d0dc38c19ff3e23c9fbad48939dbd1ba18267924)

* [`e20a75ec`](https://github.com/NixOS/nixpkgs/commit/e20a75ec7412252daff68950126efc8ad8ff6d8d) hackage2nix: update list of broken packages
* [`f5704c86`](https://github.com/NixOS/nixpkgs/commit/f5704c862d3150f6703a48674fb924177b5073a0) xsimd: init at 7.5.0
* [`2d9f3e32`](https://github.com/NixOS/nixpkgs/commit/2d9f3e32d9bd43b05c284aa5815463cbd790c0e7) arrow-cpp: 3.0.0 -> 4.0.0
* [`e3185a56`](https://github.com/NixOS/nixpkgs/commit/e3185a56b5416b9d1b24fd161895565860fc11c8) hackage-packages.nix: automatic Haskell package set update
* [`2b61d9ea`](https://github.com/NixOS/nixpkgs/commit/2b61d9ea01dd69eeb5f113b906e24d0cb2252367) nixos/zigbee2mqtt: create migration path from config to settings
* [`62de527d`](https://github.com/NixOS/nixpkgs/commit/62de527dc32563e65556669037f5ce81943091bf) nixos/zigbee2mqtt: start maintaing the module
* [`8a3ef679`](https://github.com/NixOS/nixpkgs/commit/8a3ef679253778c39dc2e487d8afe35a9fe7f8ee) kcov: 36 -> 38 ([nixos/nixpkgs⁠#121160](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121160))
* [`37656dc2`](https://github.com/NixOS/nixpkgs/commit/37656dc20816c27df282605ee8d2adff2563d0f0) git-annex: update sha256 hash for the new version
* [`248a57d6`](https://github.com/NixOS/nixpkgs/commit/248a57d61a68fe08d9bbaa639ae3c6ea3a1bc57c) nixos/adguardhome: init ([nixos/nixpkgs⁠#120568](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120568))
* [`b522e483`](https://github.com/NixOS/nixpkgs/commit/b522e483b9b2e2d2867620bda4c79728f05db57a) kcov: add metadata and passthru.tests ([nixos/nixpkgs⁠#121308](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121308))
* [`fef20991`](https://github.com/NixOS/nixpkgs/commit/fef20991e894dea59f4522b272e57124227492ec) macchina: 0.6.9 -> 0.7.2
* [`02c3bd21`](https://github.com/NixOS/nixpkgs/commit/02c3bd218740e38f1b0f2a2573464903e3873757) nixos/gitea: set umask for secret creation
* [`33f9d305`](https://github.com/NixOS/nixpkgs/commit/33f9d30558ef7635cd0aeb983edfde7c8c090639) rclone: 1.55.0 -> 1.55.1 ([nixos/nixpkgs⁠#121297](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121297))
* [`9465ce4e`](https://github.com/NixOS/nixpkgs/commit/9465ce4e10ab833546afd7c521bb0bb98c1d775e) rtl88xxau-aircrack: fc0194 -> c0ce81
* [`d25741e7`](https://github.com/NixOS/nixpkgs/commit/d25741e70740256cb180c32eee99a968640b5b67) logcheck: 1.3.22 -> 1.3.23
* [`b6b5fe55`](https://github.com/NixOS/nixpkgs/commit/b6b5fe550d41b4b1c84b50d0cd4d799b10563905) all-cabal-hashes: update to Hackage at 2021-04-30T19:36:25Z
* [`ac1ce993`](https://github.com/NixOS/nixpkgs/commit/ac1ce993bedd4c9c5be73e367dfab9ded7eff76a) vagrant: 2.2.15 -> 2.2.16
* [`6d365578`](https://github.com/NixOS/nixpkgs/commit/6d365578bfbac27e1e52422aa7a22e68fb447938) aegisub: ffmpeg_3 -> ffmpeg
* [`27525f6c`](https://github.com/NixOS/nixpkgs/commit/27525f6c4d2d7851657243f59441b5e7b7855e46) kid3: ffmpeg_3 -> ffmpeg
* [`41c71047`](https://github.com/NixOS/nixpkgs/commit/41c71047c0b10ae62553b91f272a2e8531d18062) mgba: ffmpeg_3 -> ffmpeg
* [`5495d6d2`](https://github.com/NixOS/nixpkgs/commit/5495d6d2b2a4508bcaf65f7f3470d82d38bf8031) ppsspp: ffmpeg_3 -> ffmpeg
* [`5eefe24c`](https://github.com/NixOS/nixpkgs/commit/5eefe24c94d451b93b75a2ea89232737777e7d9e) wxSVG: ffmpeg_3 -> ffmpeg
* [`b13d36b9`](https://github.com/NixOS/nixpkgs/commit/b13d36b973d52157555e7c0be17e023819ddd600) xineLib -> xine-lib
* [`8518bfea`](https://github.com/NixOS/nixpkgs/commit/8518bfeae1c3e0d0b5512fd39c5f74c95ea9ee56) xineUI -> xine-ui
* [`f223a67c`](https://github.com/NixOS/nixpkgs/commit/f223a67c651a366d382b00a8392010ce92dbd5e8) xine-lib: ffmpeg_3 -> ffmpeg
* [`bc5a164c`](https://github.com/NixOS/nixpkgs/commit/bc5a164ccfe9e1353e8d93639b299e7c386cb82e) xine-ui: xineLib -> xine-lib
* [`06dadfa1`](https://github.com/NixOS/nixpkgs/commit/06dadfa1a1f7fa08f50b2a9f4c67f8eb4cb7da84) xineliboutput: xineLib -> xine-lib
* [`e44606ff`](https://github.com/NixOS/nixpkgs/commit/e44606ff470b29af631f33bdd4a5b63abf34bd1c) dvdstyler: xineUI -> xine-ui
* [`df26e9a5`](https://github.com/NixOS/nixpkgs/commit/df26e9a55dc22931bbad3ff81df03597059a1e35) eaglemode: xineLib -> xine-lib
* [`72dacfd3`](https://github.com/NixOS/nixpkgs/commit/72dacfd325b2e5bb7ec042403459e6458e8fa63b) quodlibet: xineLib -> xine-lib
* [`307c0e2a`](https://github.com/NixOS/nixpkgs/commit/307c0e2a3be2df853ea1d6b413553d56b5bc35ab) maddy: 0.4.3 -> 0.4.4
* [`640253ce`](https://github.com/NixOS/nixpkgs/commit/640253ce2e7e9803908149a0ef2ffe574095930c) nix-output-monitor: 1.0.3.0 -> 1.0.3.1
* [`490fa1e8`](https://github.com/NixOS/nixpkgs/commit/490fa1e891fde1aa41474c4c6e29369d9da63097) steamPackages.steam-runtime: 0.20201203.1 -> 0.20210317.0
* [`eae41465`](https://github.com/NixOS/nixpkgs/commit/eae41465ad65893723249e72b1af854c599bac45) lldpd: 1.0.8 -> 1.0.10
* [`7cc0cf90`](https://github.com/NixOS/nixpkgs/commit/7cc0cf9077122f47fb6d90fd6a412b714618193b) logcheck: update license to gpl2Plus
* [`cd5f229e`](https://github.com/NixOS/nixpkgs/commit/cd5f229e4f1da480b876946938147a025de104a2) logcheck: fix license
* [`bd722f11`](https://github.com/NixOS/nixpkgs/commit/bd722f1105462dab55246d179711e917b72477d4) haunt: enable tests and verify that the binary works
* [`855b2b96`](https://github.com/NixOS/nixpkgs/commit/855b2b96bbcc004ca9a016ccb7e89a5ba87af510) broot: 1.3.0 -> 1.3.1
* [`bd64a622`](https://github.com/NixOS/nixpkgs/commit/bd64a6221f18a24c79b879c0441f4420f0f2d47e) broot: remove unused argument
* [`2e0ddf4c`](https://github.com/NixOS/nixpkgs/commit/2e0ddf4c669fd40d0002c8ade5f70e5a07bc89a6) buildkit: 0.8.2 -> 0.8.3
* [`a5c7cd57`](https://github.com/NixOS/nixpkgs/commit/a5c7cd5779954d345035ef152e99a82bd7691d6b) haunt: fix Guile load paths
* [`36a44c4e`](https://github.com/NixOS/nixpkgs/commit/36a44c4e8d07bee733ea1e9fe336854164ba13f4) credhub-cli: fix build under go1.15
* [`bef4bda8`](https://github.com/NixOS/nixpkgs/commit/bef4bda8dd1655ec76849059c5dbd7c5de6eaebe) sd-image: Add option to control sd image expansion on boot.
* [`87c3b7e7`](https://github.com/NixOS/nixpkgs/commit/87c3b7e767b18492fa8b3641b9c5d14dd2f38a8c) amazonImage: make statically sized again
* [`0c73f4e9`](https://github.com/NixOS/nixpkgs/commit/0c73f4e985f0339ce0fec02e73f55149c4862261) cargo-rr: init at 0.1.3
* [`733d682c`](https://github.com/NixOS/nixpkgs/commit/733d682cc3ed32c4b6325b8acffefa32a58ddb70) nixos/release: add amazonImageAutomaticSize
* [`168f7a1d`](https://github.com/NixOS/nixpkgs/commit/168f7a1dcf06b9d5c2fd6aa79359a97f84996f8e) malcontent: 0.10.0 -> 0.10.1
* [`e1a8c80e`](https://github.com/NixOS/nixpkgs/commit/e1a8c80e92b2424b9aed0f423ffd8741673a9bc7) river: refactor
* [`aad3e1bf`](https://github.com/NixOS/nixpkgs/commit/aad3e1bf6f7c876a715f8b120cfd2e6bb10eefec) lxc: 4.0.7 -> 4.0.8
* [`d4fc6ca4`](https://github.com/NixOS/nixpkgs/commit/d4fc6ca4ff1046c60ceef1193095228b5767837b) gopass: 1.12.5 -> 1.12.6
* [`b65e2101`](https://github.com/NixOS/nixpkgs/commit/b65e2101b7f7c13cd60f61adb400e6e82b05cbe2) krankerl: 0.13.0 -> 0.13.1
* [`fcc82301`](https://github.com/NixOS/nixpkgs/commit/fcc8230147ae36f183b27e32230e61ac532cc030) bombono: update ffmpeg, fix iso generation
* [`38865991`](https://github.com/NixOS/nixpkgs/commit/388659919a6f64e5dfb8d95701ff802b77f4156c) cargo-limit: 0.0.7 -> 0.0.8
* [`3b07746b`](https://github.com/NixOS/nixpkgs/commit/3b07746b0a362092f90248948270ddbae7a2fb2d) shellhub-agent: 0.6.0 -> 0.6.4
* [`f3e28831`](https://github.com/NixOS/nixpkgs/commit/f3e288316790c92df0eb43510fe8420bd3900836) feedbackd: Add udev rules to output
* [`3086335f`](https://github.com/NixOS/nixpkgs/commit/3086335f04b5bf7875508f84af6080b51c413065) nixos/feedbackd: init
* [`31a32eee`](https://github.com/NixOS/nixpkgs/commit/31a32eeed3f11fca7475cd5f9746081033856132) nixos/phosh: init
* [`f722f8d5`](https://github.com/NixOS/nixpkgs/commit/f722f8d518a6b5048219eacbd2e4bf26bb48c300) postgresql_jdbc: 42.2.5 -> 42.2.20
* [`2ec00820`](https://github.com/NixOS/nixpkgs/commit/2ec00820e6ae1079f4facc362a03a3a2a16c2712) cgal_5: 5.2 -> 5.2.1
* [`ada3e19b`](https://github.com/NixOS/nixpkgs/commit/ada3e19b7a20424381a75e109ced34e59054e1d7) prs: 0.2.10 -> 0.2.11 ([nixos/nixpkgs⁠#121314](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121314))
* [`c49a518f`](https://github.com/NixOS/nixpkgs/commit/c49a518f9f9b175a8689f48e253fa4bc0c1fb401) qemu: 5.2.0 -> 6.0.0; adopt; broaden platforms
* [`2bf2252d`](https://github.com/NixOS/nixpkgs/commit/2bf2252d6a61f55a1ba5375968b8b3788ede0c93) libsForQt5.libopenshot: tidy up nixpkgs-hammering comments
* [`3b18aacd`](https://github.com/NixOS/nixpkgs/commit/3b18aacd1f8b434294bcd74581615f91db0b6ad5) facter: 3.14.16 -> 3.14.17
* [`d77daaf1`](https://github.com/NixOS/nixpkgs/commit/d77daaf10b6a5cd8b756646974ba3da93fc3ce5f) virt-manager: 3.1.0 -> 3.2.0 ([nixos/nixpkgs⁠#120279](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120279))
* [`8c70a1a9`](https://github.com/NixOS/nixpkgs/commit/8c70a1a989bb9f4bdce93cd6ab632d00fa6c15a1) lib: fix documented type of fixedWidthString ([nixos/nixpkgs⁠#121396](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121396))
* [`ddf04685`](https://github.com/NixOS/nixpkgs/commit/ddf04685068c605ecaf4d080957932aa09db21cf) google-drive-ocamlfuse: 0.7.22 -> 0.7.26
* [`8776e9a6`](https://github.com/NixOS/nixpkgs/commit/8776e9a6eda236607a956b3c984663e68a691487) Revert "river: refactor"
* [`d05202ea`](https://github.com/NixOS/nixpkgs/commit/d05202ea7c026640c18c9d058aa24a0469e7930d) Revert "firefox-esr: use latest Rust"
* [`64042dc2`](https://github.com/NixOS/nixpkgs/commit/64042dc2c6c075fa4b537729afa7ed84e1e6e35e) kime: 2.5.2 -> 2.5.3
* [`291fd0ee`](https://github.com/NixOS/nixpkgs/commit/291fd0ee7ee672ce68dcc3397c877ce5960a3d98) doppler: 3.24.1 -> 3.24.3
* [`b63002b2`](https://github.com/NixOS/nixpkgs/commit/b63002b223e3bbb7be97563e857539ea1d562956) papirus-icon-theme: 20210401 -> 20210501
* [`33e86762`](https://github.com/NixOS/nixpkgs/commit/33e867620eb1e27d44a35fb57944ce8a5bccfdab) nixos/mosquitto: harden systemd unit
* [`a2d1d16a`](https://github.com/NixOS/nixpkgs/commit/a2d1d16af82b7133547353568c5af33bbfcdca28) nixos/mosquitto: Migrate away from bind_address/port config keys
* [`af688cc0`](https://github.com/NixOS/nixpkgs/commit/af688cc00e301cfe90a905a6a7e2c32b34988b22) python3.pkgs.cloudsmith-api: init at 0.54.15
* [`0d55d38b`](https://github.com/NixOS/nixpkgs/commit/0d55d38b4148a4f40b7d00361c87e368e1ca1dbf) python3.pkgs.click-spinner: init at 0.1.10
* [`d26d7713`](https://github.com/NixOS/nixpkgs/commit/d26d7713819ae913b575a45defd094fb7ee8e30a) python3.pkgs.click-configfile: init at 0.2.3
* [`1818ef17`](https://github.com/NixOS/nixpkgs/commit/1818ef1785936f7f7df9a7489c80dcfac9856e7f) cloudsmith-cli: init at 0.26.0
* [`049efb91`](https://github.com/NixOS/nixpkgs/commit/049efb917104b2476b4aaf13fa1a5b7444621baf) xen: fix build with GCC 10
* [`c02b4629`](https://github.com/NixOS/nixpkgs/commit/c02b4629530fbf61398720fdadd6f746df9bd36d) charliecloud: remove unused python3Packages argument
* [`039101ad`](https://github.com/NixOS/nixpkgs/commit/039101ad945b1b3b90a3e6a592f6200770518a42) libtorch-bin: 1.8.0 -> 1.8.1
* [`30397763`](https://github.com/NixOS/nixpkgs/commit/303977634c10e495cdb4855ffe00fc02ac9801c8) libtorch-bin: fix false CUDA dependency in passthru test
* [`42268373`](https://github.com/NixOS/nixpkgs/commit/4226837368068600e6afd11b5cbc6d586c7b5fa9) python3Packages.python-language-server: disable when python>=3.9
* [`e6cc77ea`](https://github.com/NixOS/nixpkgs/commit/e6cc77ea8d16f47282eb5c5f14b8bb10b5c48640) starship: 0.52.1 -> 0.53.0
* [`92041277`](https://github.com/NixOS/nixpkgs/commit/92041277ce6a379a50d9ada8680aa5ed8d1bc118) ophis: fix build
* [`38499a3b`](https://github.com/NixOS/nixpkgs/commit/38499a3b086fa47f87410a754e4d8efc7a0fcae6) j: 901f -> 902b
* [`38033cd9`](https://github.com/NixOS/nixpkgs/commit/38033cd97147467834a3555e4b9cda5a59e489f0) neofetch: set meta.mainProgram
* [`510fc9cd`](https://github.com/NixOS/nixpkgs/commit/510fc9cd8f97f6c7fc04f0346089a87b1000f71f) jetbrains: update
* [`a4cd2553`](https://github.com/NixOS/nixpkgs/commit/a4cd25533dd14d63f0a486352c6f2c0b0fbfac37) bitcoin: 0.21.0 -> 0.21.1
* [`4df002c4`](https://github.com/NixOS/nixpkgs/commit/4df002c43283952f4ffc434153b3d5efa3024fa8) grub2_efi: fix cross-compilation
* [`7326c917`](https://github.com/NixOS/nixpkgs/commit/7326c917e4152df8e7c95e3045c663ede73a87b4) lxcfs: 4.0.7 -> 4.0.8
* [`6866364f`](https://github.com/NixOS/nixpkgs/commit/6866364f837cee54ee9dc86218dea80b752186b4) firefox-bin: rpath pipewire
* [`37030075`](https://github.com/NixOS/nixpkgs/commit/370300758a9d8ee92d5d90659371f75f9448c83d) netcdfcxx4: 4.3.0 -> 4.3.1
* [`56858c2b`](https://github.com/NixOS/nixpkgs/commit/56858c2b92bcd038aa5718fa6e0ad72e7c8c9bb9) netcdfcxx4: use fetchzip
* [`dfe5071b`](https://github.com/NixOS/nixpkgs/commit/dfe5071b8233700daf163ade1792f8e62b45902b) netcdfcxx4: fix linking on Darwin
* [`147a5cda`](https://github.com/NixOS/nixpkgs/commit/147a5cda7299be628f34a336c5f2ade1c8b725b2) netcdfcxx4: switch to CMake
* [`99f8bc3e`](https://github.com/NixOS/nixpkgs/commit/99f8bc3e0303bd58ed823937ad5e76791b5cb2f0) sumorobot-manager: 0.9.0 -> 1.0.0
* [`ebf37172`](https://github.com/NixOS/nixpkgs/commit/ebf371726d47a0cd434ba2b6a8ec606f97efed83) sumorobot-manager: fix compilation
* [`57454d5d`](https://github.com/NixOS/nixpkgs/commit/57454d5d19d187a72c6d6c6c7302bd9e49f02442) cypress: add updateScript
* [`04ca6340`](https://github.com/NixOS/nixpkgs/commit/04ca6340bd0668af243a5ac7cb56f20350cedcfd) miniscript: init at unstable-2020-11-04
* [`1d00429e`](https://github.com/NixOS/nixpkgs/commit/1d00429e59300942c7c74d69c18a91be1f9ca66b) ideamaker: mark as broken
* [`de536ac4`](https://github.com/NixOS/nixpkgs/commit/de536ac410ed16664dca0f076348e8b03344f0d9) all-packages: remove quazip_qt4
* [`da1a0f5c`](https://github.com/NixOS/nixpkgs/commit/da1a0f5ce4c626e42712cfba7ae7befd11572541) libsForQt5.quazip: 0.9.1 -> 1.1
* [`eb5588f9`](https://github.com/NixOS/nixpkgs/commit/eb5588f9147a0035e14b05c9b3ff2181dae539fa) nomacs: support quazip 1.x
* [`59ecd516`](https://github.com/NixOS/nixpkgs/commit/59ecd5167a7ecbd199c05c8db463b040e78f14e1) qmapshack: support Quazip 1.x
* [`c116c5f8`](https://github.com/NixOS/nixpkgs/commit/c116c5f89ff8d8825505f1b6c40856c0c717c6f8) zoxide: 0.6.0 -> 0.7.0
* [`ab92ec63`](https://github.com/NixOS/nixpkgs/commit/ab92ec63d29361d8632d89d318d915d974f40c54) zoxide: install manpages
* [`beca3d2c`](https://github.com/NixOS/nixpkgs/commit/beca3d2c0b1a953dfdcbef78cdcf3ec27cd7e8ee) openboard: build with quazip 1.x
* [`ad5f2512`](https://github.com/NixOS/nixpkgs/commit/ad5f25123091545fbd5026f4008fddbfa22a6a0a) dcm2niix: 1.0.20200331 -> 1.0.20201102
* [`2fa2d15a`](https://github.com/NixOS/nixpkgs/commit/2fa2d15a7d8702846dbf8dc86c714ef35001b9a9) knightos-mkrom : 1.0.3 -> 1.0.4
* [`a54ed361`](https://github.com/NixOS/nixpkgs/commit/a54ed3611b4adf72425b4976c93da5b0a2df825d) knightos-scas: 0.5.3 -> 0.5.5
* [`c5769985`](https://github.com/NixOS/nixpkgs/commit/c576998594b4b8790f291d17fa92d499d1dc5d42) nim: 1.4.4 -> 1.4.6
* [`4dfcc530`](https://github.com/NixOS/nixpkgs/commit/4dfcc530cdd2d0f046f5503839bd117edd7efa79) quirc: 2016-08-16 -> 2020-04-06
* [`26d52437`](https://github.com/NixOS/nixpkgs/commit/26d524374faffbc81844a7869ebb05a7ef3e6b19) monero: 0.17.1.9 -> 0.17.2.0
* [`3227f676`](https://github.com/NixOS/nixpkgs/commit/3227f676cb168b9310b0f386e37ad706c1f84b8c) monero-gui: 0.17.1.9 -> 0.17.2.1
* [`8309374a`](https://github.com/NixOS/nixpkgs/commit/8309374a78fd201cb4c352f5c2cd087d400df6a5) ogre: Added SDL2 as dependency
* [`884cf295`](https://github.com/NixOS/nixpkgs/commit/884cf29501c424ee68d1f2791edd1ed4ef2a9361) dcm2niix: 1.0.20201102 -> 1.0.20210317
* [`cf39deb8`](https://github.com/NixOS/nixpkgs/commit/cf39deb8a32d2b154e1d36c317cc4a163d448836) python38Packages.flask-restx: 0.2.0 -> 0.3.0 ([nixos/nixpkgs⁠#121465](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121465))
* [`4da5de00`](https://github.com/NixOS/nixpkgs/commit/4da5de00a546f7820d33a3b11deb02c20816130a) flexget: 3.1.110 -> 3.1.116 ([nixos/nixpkgs⁠#121464](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121464))
* [`637c7391`](https://github.com/NixOS/nixpkgs/commit/637c7391adf6e221a882b5ea98d8ba9666436e49) xplr: 0.5.10 -> 0.5.12 ([nixos/nixpkgs⁠#121473](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121473))
* [`8a92cdd9`](https://github.com/NixOS/nixpkgs/commit/8a92cdd9f5b83af9ea6c44c0ec3f8622d12364b9) teamspeak_client: fix for quazip 1.x
* [`9a943b4b`](https://github.com/NixOS/nixpkgs/commit/9a943b4b4213888382d88c1d69d8dacffa936867) maintainers: add vojta001
* [`8c045003`](https://github.com/NixOS/nixpkgs/commit/8c04500313344dba9a3113425eea85c6b01e9d32) thonny: 3.3.3 -> 3.3.6
* [`8b882a58`](https://github.com/NixOS/nixpkgs/commit/8b882a58420cd72ea150802c778b29f260cdb136) librespot: 0.1.3 -> 0.1.6
* [`aacbc738`](https://github.com/NixOS/nixpkgs/commit/aacbc7385c5757a20b9b3ec172e58e7bc1039257) pythonPackages.pynmea2: 1.17.0 -> 1.18.0 ([nixos/nixpkgs⁠#121484](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121484))
* [`d196216e`](https://github.com/NixOS/nixpkgs/commit/d196216e11ef2a2ac37184814f08aa7c9f8d1281) man-pages-posix: use version format as repology
* [`bc33b23c`](https://github.com/NixOS/nixpkgs/commit/bc33b23cd057f13060e69cc65157b233d7be7fc0) ppx_deriving_cmdliner: init at 0.6.0
* [`12714a47`](https://github.com/NixOS/nixpkgs/commit/12714a4726a0444cdc3515eb6f4dd71e46b4f43d) python3Packages.pywizlight: 0.4.6 -> 0.4.7
* [`33682a80`](https://github.com/NixOS/nixpkgs/commit/33682a80a10a67866849325e5d2bbc9866a66689) maintainers: add daneads
* [`9e94b036`](https://github.com/NixOS/nixpkgs/commit/9e94b036a1b4deb45bece418a2eeac28b10f447e) pcloud: fix runtime dependencies ([nixos/nixpkgs⁠#121495](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121495))
* [`86ec321e`](https://github.com/NixOS/nixpkgs/commit/86ec321e63754f6aa129ce9519b77e64d2178071) link-grammar: 5.8.1 -> 5.9.1
* [`75468c39`](https://github.com/NixOS/nixpkgs/commit/75468c3907a7cda848f2ee48bdf5c1322a73f4b1) mopidy-podcast: init at 3.0.0
* [`e3763e47`](https://github.com/NixOS/nixpkgs/commit/e3763e4799d074411c7a6a20d7a7c3d51d876147) piston-cli: 1.2.2 -> 1.3.0 ([nixos/nixpkgs⁠#121448](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121448))
* [`1b10b0d5`](https://github.com/NixOS/nixpkgs/commit/1b10b0d57979cc289c69301d754838a1c8562f43) kernel: clarify license
* [`8142fd65`](https://github.com/NixOS/nixpkgs/commit/8142fd653fe425760afa82f468451c95768aeb1f) tela-icon-theme: format slightly differently
* [`13cadfac`](https://github.com/NixOS/nixpkgs/commit/13cadfac151df84dc61b1062b2ec648b0ca29af6) zoom-us: fix overriding source
* [`501956b9`](https://github.com/NixOS/nixpkgs/commit/501956b985e6be807fa2208dd587022c22973784) glances: 3.1.6.2 -> 3.1.7
* [`6f55db13`](https://github.com/NixOS/nixpkgs/commit/6f55db13eb745068766ac34f843590d39701735e) tela-icon-theme: skip patchelf and symlink rewrite steps
* [`a494e0ce`](https://github.com/NixOS/nixpkgs/commit/a494e0ce56bb476ecea69c85ccdf1f6a5ccc6a92) tela-icon-theme: switch to gpl3Only
* [`134c68a4`](https://github.com/NixOS/nixpkgs/commit/134c68a411fb8b52cf761ee799d5b242c9b87e18) tela-icon-theme: use stdenvNoCC
* [`6c022654`](https://github.com/NixOS/nixpkgs/commit/6c022654f6925c94fc11294fa6e11a9f5d148697) python3Packages.csvw: 1.10.1 -> 1.10.2
* [`73a0b6c8`](https://github.com/NixOS/nixpkgs/commit/73a0b6c8262314a1d5d5bf3a68b634a85ab07e98) buildFHSUserEnvBubblewrap: add dieWithParent option, and /etc/nix
* [`9bd292c9`](https://github.com/NixOS/nixpkgs/commit/9bd292c9291abf6ca53980f9316d55c83d5753b4) vscod{e,ium}: Add fhs passthru
* [`a060b84b`](https://github.com/NixOS/nixpkgs/commit/a060b84b3276420abffe2ac4699d4fef66905aad) vscod{e,ium}-fhs: add top-level aliases, add description
* [`f5e695bf`](https://github.com/NixOS/nixpkgs/commit/f5e695bf3ac63a5a3b2d2cf4f2427e232534915a) kubelogin-oidc: 1.23.0 -> 1.23.1 ([nixos/nixpkgs⁠#121440](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121440))
* [`d942d447`](https://github.com/NixOS/nixpkgs/commit/d942d4473d1165cf9d8a1171bbad154f77239ba0) neovim, neovimUtils, neovim-qt: drop python2 support
* [`8b0515eb`](https://github.com/NixOS/nixpkgs/commit/8b0515eb9ae070855d670c4638ef7618a7fb3418) pngquant: 2.12.5 -> 2.14.1 ([nixos/nixpkgs⁠#121470](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121470))
* [`7d09d7f5`](https://github.com/NixOS/nixpkgs/commit/7d09d7f5713dac972ce9d72624d20635899c876d) nixos/home-assistant: harden systemd service
* [`8ab7fc11`](https://github.com/NixOS/nixpkgs/commit/8ab7fc11076373fee3e5cc842176e6fb8c5705b3) nixos/tests/home-assistant: test capability passing
* [`1dbb60f5`](https://github.com/NixOS/nixpkgs/commit/1dbb60f562f73cfa46d2e5ef21f9d2a98ecba565) nixos/tests/home-assistant: update maintainership to home-assistant team
* [`f41349d3`](https://github.com/NixOS/nixpkgs/commit/f41349d30d5e1cc72c8041616ecb8c36d56f3682) nixos/home-assistant: Restart systemd unit on restart service
* [`280c8cf5`](https://github.com/NixOS/nixpkgs/commit/280c8cf540342414661b89158c707fb9ef74a91e) py3c: fix build with darwin ([nixos/nixpkgs⁠#121447](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121447))
* [`11bb46fd`](https://github.com/NixOS/nixpkgs/commit/11bb46fdc63db2f00c7f458f871d2015e1f4fe6e) clanlib: init at 4.1.0
* [`d5a0b50f`](https://github.com/NixOS/nixpkgs/commit/d5a0b50f2653f9792f62138edbff70c789f233ab) methane: init at 2.0.1
