### PR TITLE
niv home-manager: update 827636c6 -> 9ffb2060

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "827636c619ce0d8178ddc08ab86ee92b50f2e5b4",
-        "sha256": "0imqxlj40fabg7iifqqa5d91is842124qpflb8l36xpcjgfs4q4p",
+        "rev": "9ffb206050bab47122eac18ea7cb289849f8d128",
+        "sha256": "0rlcp23ask8v8rwpaclbgxzb633ap1wp92anwkr9s84sl9zzfq96",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/827636c619ce0d8178ddc08ab86ee92b50f2e5b4.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9ffb206050bab47122eac18ea7cb289849f8d128.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@827636c6...9ffb2060](https://github.com/nix-community/home-manager/compare/827636c619ce0d8178ddc08ab86ee92b50f2e5b4...9ffb206050bab47122eac18ea7cb289849f8d128)

* [`b4e3f069`](https://github.com/nix-community/home-manager/commit/b4e3f069f1e9c774c3f9d21215c38a1ab910c3a9) pass-secret-service: add module ([nix-community/home-manager⁠#1898](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1898))
* [`d4278212`](https://github.com/nix-community/home-manager/commit/d4278212b54b6f653786162a9869e111d071e154) pass-secret-service: fix systemd unit install option ([nix-community/home-manager⁠#1959](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1959))
* [`865e4048`](https://github.com/nix-community/home-manager/commit/865e404826a802b38de33e5465cea510f8eca15a) poweralertd: add module ([nix-community/home-manager⁠#1951](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1951))
* [`d437baa4`](https://github.com/nix-community/home-manager/commit/d437baa41ca9e8e544fe8969310141816d1e8611) gnupg/gpg-agent: gnupg package is configurable ([nix-community/home-manager⁠#1949](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1949))
* [`18ad12d5`](https://github.com/nix-community/home-manager/commit/18ad12d52b8cebbb57013865eec2be5125de050a) programs.ssh: Use nullable types for optional forward attrs ([nix-community/home-manager⁠#1946](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1946))
* [`c0ba8c52`](https://github.com/nix-community/home-manager/commit/c0ba8c526d2dba4863ee9ed1c5d4c47cae40f0e4) gpg: can configure scdaemon.conf ([nix-community/home-manager⁠#1960](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1960))
* [`a513fbc3`](https://github.com/nix-community/home-manager/commit/a513fbc395d135d214b30462018262ed346ff755) qutebrowser: fix config location on darwin ([nix-community/home-manager⁠#1925](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1925))
* [`a759143a`](https://github.com/nix-community/home-manager/commit/a759143ae130e68b8c0ce867c28b3e006f9920e0) mpris-proxy: add module ([nix-community/home-manager⁠#1832](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1832))
* [`19ebab97`](https://github.com/nix-community/home-manager/commit/19ebab97e818256bf4d751c119a1e189d6d0f075) i3, sway: extract border functionality to common function ([nix-community/home-manager⁠#1947](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1947))
* [`b706d101`](https://github.com/nix-community/home-manager/commit/b706d101ebb1630383a8abfa2ca566d77dbcd641) format: remove exception for afew module ([nix-community/home-manager⁠#1955](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1955))
* [`2d421b30`](https://github.com/nix-community/home-manager/commit/2d421b30ad6efc96b7deb653ea8fcc4d570a75f5) format: removed exceptions already formatted files ([nix-community/home-manager⁠#1954](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1954))
* [`4edc2091`](https://github.com/nix-community/home-manager/commit/4edc2091e092f6182d9d947d9f6e124c6a93b604) github: configure probot/stale
* [`4727b054`](https://github.com/nix-community/home-manager/commit/4727b0543d8fa43c364e0d962f59242455a6d638) pbgopy: add missing options
* [`5ae7817d`](https://github.com/nix-community/home-manager/commit/5ae7817dc534fd5440d7c726af26fc3a0503dffb) kitty: use dummy package in test
* [`55ef8d3a`](https://github.com/nix-community/home-manager/commit/55ef8d3a109918e7eca4d8dcbcf1824a0e23c284) format: remove exception for keybase and kbfs modules
* [`137a584e`](https://github.com/nix-community/home-manager/commit/137a584e22e13a8d0d82102dedaca17f36110a94) topgrade: add module ([nix-community/home-manager⁠#1924](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1924))
* [`d57c59e7`](https://github.com/nix-community/home-manager/commit/d57c59e7cb4beba06825c042df35cc1f707bb41a) home-environment: extra message on nix-env error
* [`5e6f0979`](https://github.com/nix-community/home-manager/commit/5e6f09795c799e5ca1f1712489ecb2a8b76e0268) gtk2: allow configuration of gtkrc file
* [`2eed1380`](https://github.com/nix-community/home-manager/commit/2eed1380266cf6d0f48a90ba24131fc8f65a4f61) barrier: add module
* [`614a5b55`](https://github.com/nix-community/home-manager/commit/614a5b55bf46673c174dd3775e7fb1d6f9e14dfa) lazygit: add module ([nix-community/home-manager⁠#1930](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1930))
* [`19fc0917`](https://github.com/nix-community/home-manager/commit/19fc0917c0510f2191e4b6024a7d4d6190fabbf8) waybar: fix systemd service
* [`5709b5f9`](https://github.com/nix-community/home-manager/commit/5709b5f9536354a5cfdf80f31d82abcd4432edb6) zsh: add history.ignorePatterns option ([nix-community/home-manager⁠#1933](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1933))
* [`2f857761`](https://github.com/nix-community/home-manager/commit/2f857761d0506d3c4c51455aafb1df5180ad7e34) ncspot: add module ([nix-community/home-manager⁠#1939](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1939))
* [`ca7868dc`](https://github.com/nix-community/home-manager/commit/ca7868dc2977e2bdb4b1c909768c686d4ec0a412) fzf: option for tmux usage in shell integration ([nix-community/home-manager⁠#1926](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1926))
* [`cdc774f3`](https://github.com/nix-community/home-manager/commit/cdc774f3371ecf74434a486f4d264474aada27a1) lieer-service: add path to notmuch config ([nix-community/home-manager⁠#1704](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1704))
* [`225bf275`](https://github.com/nix-community/home-manager/commit/225bf275ba8ea3f23728685c12b902dedcd3a666) neomutt: make folder change when sourcing account optional
* [`e0ee5068`](https://github.com/nix-community/home-manager/commit/e0ee5068ddefd49728484c18fa032de05be440bf) neovim: drop python2 support ([nix-community/home-manager⁠#1978](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1978))
* [`9ffb2060`](https://github.com/nix-community/home-manager/commit/9ffb206050bab47122eac18ea7cb289849f8d128) i3, sway: replace fonts with submodule ([nix-community/home-manager⁠#1950](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1950))
