### PR TITLE
niv nixpkgs-fmt: update 3efa82f9 -> a893d437

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "3efa82f9bf2868177b63d771862bd74ad8b54a85",
-        "sha256": "0cvlicjczhdraj5sdwdxrhw4jszjka5msg8mv5fdg9p2garcpkgn",
+        "rev": "a893d437317d4a6ea45be0fb65e804482e397b23",
+        "sha256": "1ikf55xv6jgrbhknq6vfmnnbsk4rxi9p25ir2rkagln4ghfl6n83",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/3efa82f9bf2868177b63d771862bd74ad8b54a85.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/a893d437317d4a6ea45be0fb65e804482e397b23.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@3efa82f9...a893d437](https://github.com/nix-community/nixpkgs-fmt/compare/3efa82f9bf2868177b63d771862bd74ad8b54a85...a893d437317d4a6ea45be0fb65e804482e397b23)

* [`a893d437`](https://github.com/nix-community/nixpkgs-fmt/commit/a893d437317d4a6ea45be0fb65e804482e397b23) fix CLI option output-format ([nix-community/nixpkgs-fmt⁠#242](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/nixpkgs-fmt/issues/242))
