### PR TITLE
niv spacemacs: update eeee3a1f -> e15dbdc0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "eeee3a1fa0c2fc70be7b62d95aac49a1c6b3ba22",
-        "sha256": "0bx3xf89nscrl5axgpnsmpnwi1c2dxppkj63dm7aq4g9s0sv5rwz",
+        "rev": "e15dbdc03694ecdb66c9152d8a3d236325d99d72",
+        "sha256": "1m2nl2z8kmsad9l6wwh5aidkafqi7cjxbv3k7bhj2np9yw7cxyf0",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/eeee3a1fa0c2fc70be7b62d95aac49a1c6b3ba22.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/e15dbdc03694ecdb66c9152d8a3d236325d99d72.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@eeee3a1f...e15dbdc0](https://github.com/syl20bnr/spacemacs/compare/eeee3a1fa0c2fc70be7b62d95aac49a1c6b3ba22...e15dbdc03694ecdb66c9152d8a3d236325d99d72)

* [`982e2515`](https://github.com/syl20bnr/spacemacs/commit/982e2515a39fbaddf53cef2e583d748ca9eb4e9a) [keyboard-layout] replace `evil-magit` by `evil-collection-magit`
* [`bc272036`](https://github.com/syl20bnr/spacemacs/commit/bc27203615268ad192e917565585f55b3e61b2e6) Removed legacy codes for emacs-version < 25.1 ([syl20bnr/spacemacs⁠#14497](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14497))
* [`117f4b73`](https://github.com/syl20bnr/spacemacs/commit/117f4b73ab37f0e68f254308db84bf102b9c711b) squash! Removed legacy codes for emacs-version < 25.1 ([syl20bnr/spacemacs⁠#14497](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14497))
* [`d24249b7`](https://github.com/syl20bnr/spacemacs/commit/d24249b7597a30f759703ca99ed04bb65b4f026a) [erlang] fix run-prog-mode-hooks function call ([syl20bnr/spacemacs⁠#14725](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14725))
* [`2182be94`](https://github.com/syl20bnr/spacemacs/commit/2182be9440dc2f862c4248b43bb7c74a30e9c308) [documentation]: Improved core-load-paths and core-versions ([syl20bnr/spacemacs⁠#14707](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14707))
* [`4e5a7233`](https://github.com/syl20bnr/spacemacs/commit/4e5a7233b07778417d33f6cd898096b1ae33bf38) SpacemacsOS: provide new layer variables for systray and autostart ([syl20bnr/spacemacs⁠#14714](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14714))
* [`29fa26af`](https://github.com/syl20bnr/spacemacs/commit/29fa26af9870f99cfa99de02cc7bd966b3e04a68) Add workspace action messages and open home buffer ([syl20bnr/spacemacs⁠#14709](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14709))
* [`4f8ac8fc`](https://github.com/syl20bnr/spacemacs/commit/4f8ac8fc39fc3773a8dd029ee2e6c65f53354a1d) Improve quick-start guide
* [`e5be31bb`](https://github.com/syl20bnr/spacemacs/commit/e5be31bb8541e420c5fae666980287753f3c90e0) Bumped minimum emacs version to 26.1
* [`1136a616`](https://github.com/syl20bnr/spacemacs/commit/1136a61645715432b00bbc0a6f8723bbd21d4863) [ocaml] Fix variable name to make ocamlformat properly working on save
* [`220536fd`](https://github.com/syl20bnr/spacemacs/commit/220536fd3905b1a03bdd1266a97b4e5f8c25ad5d) [org] sane default strategies for enforcing `TODO` dependencies
* [`a2dc0c18`](https://github.com/syl20bnr/spacemacs/commit/a2dc0c18e034cc2c91ecc94880832c32726e27ce) Built-in files auto-update: Mon May 3 19:32:32 UTC 2021
* [`27f1519a`](https://github.com/syl20bnr/spacemacs/commit/27f1519a5a950d128a9dc88d8cd8db27816990a7) [lsp] add option to bind commands to lsp-command-map
* [`99231d3a`](https://github.com/syl20bnr/spacemacs/commit/99231d3a703bb35e3216fe5cee0bc547aaca26c7) [lsp] Fix some smaller issues in documentation
* [`bf8cb19c`](https://github.com/syl20bnr/spacemacs/commit/bf8cb19cca193dc3a8956b077bcf7b0778e66093) documentation formatting: Mon May 3 20:22:58 UTC 2021
* [`fdda1bd2`](https://github.com/syl20bnr/spacemacs/commit/fdda1bd2819179ed2a8be2d99e476e21637493ef) [lsp] Fix missing [ in documentation
* [`c6945815`](https://github.com/syl20bnr/spacemacs/commit/c69458150f351e104a32c4ce830b7e5190bce9fc) documentation formatting: Mon May 3 22:15:02 UTC 2021
* [`e15dbdc0`](https://github.com/syl20bnr/spacemacs/commit/e15dbdc03694ecdb66c9152d8a3d236325d99d72) [ocaml] Fix name of layer variable in defvar ([syl20bnr/spacemacs⁠#14736](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14736))
