### PR TITLE
niv zsh-completions: update 773ead6e -> 9dfd5c66

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -156,10 +156,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "773ead6ea7b579106624851404d4f651acd5e042",
-        "sha256": "123jj1nzfrsr69y6qq4hw26mxc034pbp8bqlpiw78qv7q08mayl2",
+        "rev": "9dfd5c667072a9aef13a237fe3c3cc857ca9917f",
+        "sha256": "1l3lqbl17yjaf1kcs58rkv7mz7rq89bgww427ykkip2fb55zbyn3",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/773ead6ea7b579106624851404d4f651acd5e042.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/9dfd5c667072a9aef13a237fe3c3cc857ca9917f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@773ead6e...9dfd5c66](https://github.com/zsh-users/zsh-completions/compare/773ead6ea7b579106624851404d4f651acd5e042...9dfd5c667072a9aef13a237fe3c3cc857ca9917f)

* [`5922465d`](https://github.com/zsh-users/zsh-completions/commit/5922465d53e4a751e93877dcc557c036837af536) _mssh: Handle error cases more gracefully
* [`876e972f`](https://github.com/zsh-users/zsh-completions/commit/876e972fe0b7fd999f01d2af1e0a984d3c1bbcc3) fix license
* [`c4b8c833`](https://github.com/zsh-users/zsh-completions/commit/c4b8c833150031a53773b98f08d1aef4d4219c41) gist -u or gist --update will auto-complete user gists
