### PR TITLE
niv nixpkgs: update d0dc38c1 -> 975fd299

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0dc38c19ff3e23c9fbad48939dbd1ba18267924",
-        "sha256": "1qbcxjdy0p9f2q3hzhds2y1d2vy0pb11v24l12gcxh3g9h61szck",
+        "rev": "975fd299713554077b983e76fda8cd135c957506",
+        "sha256": "188fycpc8r2hajlsdnx358vbyir4qpg8w2zi6929rmc87z33k7yk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d0dc38c19ff3e23c9fbad48939dbd1ba18267924.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/975fd299713554077b983e76fda8cd135c957506.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d0dc38c1...975fd299](https://github.com/nixos/nixpkgs/compare/d0dc38c19ff3e23c9fbad48939dbd1ba18267924...975fd299713554077b983e76fda8cd135c957506)

* [`f6987986`](https://github.com/NixOS/nixpkgs/commit/f6987986d3249ed8358e78ec569fbc0b838d103a) python3Packages.pillow-simd: 7.0.0.post3 -> 8.1.2
* [`13f0da71`](https://github.com/NixOS/nixpkgs/commit/13f0da71e613fab9303af5af60c67d4fc5a60051) python3Packages.myjwt: 1.4.0 -> 1.5.0
* [`34305cc1`](https://github.com/NixOS/nixpkgs/commit/34305cc1a0ff707f050243a31e2616f9376e07b2) python3Packages.pomegranate: 0.11.2 -> 0.13.5
* [`b690ceff`](https://github.com/NixOS/nixpkgs/commit/b690ceff5dd2ce5b34d37209f883e575e77b7ec8) superTuxKart: Fix aarch64-linux build
* [`eacd24ae`](https://github.com/NixOS/nixpkgs/commit/eacd24aed23b09a101a1ca98594ec7b6d704eb76) python3Packages.pykerberos: 1.2.1 -> 1.2.3.dev0
* [`5624aa9f`](https://github.com/NixOS/nixpkgs/commit/5624aa9f812aeccc6b70de9812a28df28996545a) nixos/sudo: add option execWheelOnly
* [`8268e64d`](https://github.com/NixOS/nixpkgs/commit/8268e64d0e791ee88feaa6cae43cf68b0755aef8) python3Packages.hg-evolve: 10.3.0 -> 10.3.1
* [`41e2941f`](https://github.com/NixOS/nixpkgs/commit/41e2941fc29de4e6fe158d17e7ae6228adbb67a5) python3Packages.mlrose: fix build
* [`78c97f07`](https://github.com/NixOS/nixpkgs/commit/78c97f07c8b912373b2cb957e6478b0d80ca3bf6) python39Packages.blist: fix build
* [`e2d99fac`](https://github.com/NixOS/nixpkgs/commit/e2d99fac687a353ef866e4c644f954595a4c43bd) kubecfg: 0.19.0 -> 0.19.1
* [`13193df2`](https://github.com/NixOS/nixpkgs/commit/13193df29d3095ed8c383751d81439da67eed2ba) helmfile: 0.138.7 -> 0.139.0
* [`ace0555d`](https://github.com/NixOS/nixpkgs/commit/ace0555d7223143e5c63428ea795c158bd309685) fluxcd: 0.13.2 -> 0.13.3
* [`ae33267b`](https://github.com/NixOS/nixpkgs/commit/ae33267babb36b68dd839989c913d4c7e4250af8) python3Packages.backports-zoneinfo: init at 0.2.1
* [`283a7fe8`](https://github.com/NixOS/nixpkgs/commit/283a7fe85c001dfa4cb36659f04d6f91f1359079) python3Packages.exchangelib: fix build
* [`d19e4cc5`](https://github.com/NixOS/nixpkgs/commit/d19e4cc55a3329546a7ebee860e5da77105ae702) kooha: 1.1.2 -> 1.1.3
* [`3e8440cb`](https://github.com/NixOS/nixpkgs/commit/3e8440cb2691d12dfe9458f96ca65a4aae5db460) bazelisk: 1.8.0 -> 1.8.1
* [`f36a22c6`](https://github.com/NixOS/nixpkgs/commit/f36a22c6b335e29a22f8fa9d0c2cf5ff2a39c230) gh-ost: 1.1.0 -> 1.1.1
* [`4d85ba7d`](https://github.com/NixOS/nixpkgs/commit/4d85ba7d911f1c65badf24911565bcc30a4345bf) acme-sh: 2.8.8 -> 2.8.9
* [`e8a58e8a`](https://github.com/NixOS/nixpkgs/commit/e8a58e8a909bd14e90e95e614e95f5b7f453c934) doppler: 3.24.3 -> 3.24.4
* [`bf003c46`](https://github.com/NixOS/nixpkgs/commit/bf003c4670c6c4059c6f4f873518a4819368f19d) linuxPackages.bcc: 0.19.0 -> 0.20.0
* [`9cb8e1ea`](https://github.com/NixOS/nixpkgs/commit/9cb8e1ea069dcf86a930690dd9c9640eab815dfa) jenkins: 2.277.3 -> 2.277.4
* [`d32199f0`](https://github.com/NixOS/nixpkgs/commit/d32199f0a6b46cf481b0ebd569588ca0dc94ab0c) certbot: 1.14.0 -> 1.15.0
* [`aff091d3`](https://github.com/NixOS/nixpkgs/commit/aff091d3dadf476837b6f7a843013d2f718b2806) libmodulemd: 2.12.0 -> 2.12.1
* [`c13ae19f`](https://github.com/NixOS/nixpkgs/commit/c13ae19fadf2fe009952a9a9c0fc91b5e0921e86) droidcam: 1.7.2 -> 1.7.3
* [`77079fba`](https://github.com/NixOS/nixpkgs/commit/77079fba2cddf642af7b1e5e981fe90afa5611e8) flyctl: 0.0.211 -> 0.0.212
* [`177dc3e8`](https://github.com/NixOS/nixpkgs/commit/177dc3e8452cf7b78e0771d431f994977fd4e35d) global: 6.6.5 -> 6.6.6
* [`b88ed9cb`](https://github.com/NixOS/nixpkgs/commit/b88ed9cbe7b38c54424c50240e071e97ebddb314) corectrl: 1.1.1 -> 1.1.2
* [`1370970c`](https://github.com/NixOS/nixpkgs/commit/1370970ca81e72188faedd50b448379247c2efaf) python3Packages.wordfeq: 2.3.2 -> 2.5
* [`e7e6c1e3`](https://github.com/NixOS/nixpkgs/commit/e7e6c1e37e6185a75bfdb4facbf1df8139d058f3) python3Packages.dask-image: 0.5.0 -> 0.6.0
* [`4053d2e4`](https://github.com/NixOS/nixpkgs/commit/4053d2e481ab68558445540ac1b6a8ba97101349) containerd: 1.4.4 -> 1.5.0
* [`99f9c7c4`](https://github.com/NixOS/nixpkgs/commit/99f9c7c4d35629bd67eb4806c0c863c5c9cdb471) python3Packages.Markups: fix tests by providing PyYAML
* [`49c8421f`](https://github.com/NixOS/nixpkgs/commit/49c8421f10faa416c690246b4f9db6ac50300de8) python38Packages.autopep8: 1.5.6 -> 1.5.7
* [`f0521b24`](https://github.com/NixOS/nixpkgs/commit/f0521b2416d8c9615d76bbc1bd0a44cefedc2998) codeql: 2.5.2 -> 2.5.3
* [`7f1a670e`](https://github.com/NixOS/nixpkgs/commit/7f1a670e79e746c1388c038ecf4bbc0a6a13c2db) findomain: 4.0.1 -> 4.1.0
* [`6a0d9e52`](https://github.com/NixOS/nixpkgs/commit/6a0d9e5242ea97fd0ae6e1294df2a6414a0a0d39) haskellPackages.paramtree: disable flaky test suite
* [`e7296ab9`](https://github.com/NixOS/nixpkgs/commit/e7296ab998deda5c525f1d9516e2b9ac733b4195) python3Packages.pygmt: fix build
* [`66de11da`](https://github.com/NixOS/nixpkgs/commit/66de11da71cf3de9a748eb30cad667e6147b4c41) maintainers/scripts/haskell/regenerate-hackage-packages.sh: Small improvents and encoding workaround
* [`3e3f1c02`](https://github.com/NixOS/nixpkgs/commit/3e3f1c02f24b4ba8d582bb0fb9ef256fa3293fd0) haskellPackages.gi-gtk-declarative-app-simple: loosen haskell-gi version bound
* [`3a9d159e`](https://github.com/NixOS/nixpkgs/commit/3a9d159ed1b41ca18523b2c95c7edb3845c1b411) libsForQt5.fcitx5-qt: 5.0.4 -> 5.0.6
* [`d52c2692`](https://github.com/NixOS/nixpkgs/commit/d52c2692e974360fc5064173e28428fe72ac7386) haskellPackages.language-docker: unbreak
* [`f170298c`](https://github.com/NixOS/nixpkgs/commit/f170298c9aa07cbd08af414ea16723af3122cb9e) top-level/release.nix: fix evaluation of jobset
* [`ce420d97`](https://github.com/NixOS/nixpkgs/commit/ce420d97923d68c9b43b0e18f7d15837d4a32f58) libwpe: 1.8.0 -> 1.10.0
* [`014d7ce3`](https://github.com/NixOS/nixpkgs/commit/014d7ce37799b66040b3d170920a448d31910922) liquibase: 4.3.2 -> 4.3.4
* [`2502b7cb`](https://github.com/NixOS/nixpkgs/commit/2502b7cb916d7c10aa4ca528c162a59a4e98462d) libsolv: 0.7.17 -> 0.7.19
* [`df68856b`](https://github.com/NixOS/nixpkgs/commit/df68856b084ef38094e530223acfc74e21bd8159) python3Packages.pyflume: fix build
* [`b4640b3c`](https://github.com/NixOS/nixpkgs/commit/b4640b3cfc63aeff89147123b2e93a112402e7b0) python3Packages.pyaftership: fix build
* [`83fe0340`](https://github.com/NixOS/nixpkgs/commit/83fe0340fd81f1810e6ffcb314770e6659f2d032) python3Packages.ipympl: fix build
* [`dd7741f2`](https://github.com/NixOS/nixpkgs/commit/dd7741f26e0140f53a3baf68b380aae701844434) python3Packages.hyppo: fix build
* [`db770a84`](https://github.com/NixOS/nixpkgs/commit/db770a84f11b5322f4d688a3b3dfe111283ecd92) lilypond: 2.22.0 -> 2.22.1
* [`da98a2da`](https://github.com/NixOS/nixpkgs/commit/da98a2dac872e13820385b9da53adbb7960f5151) python3Packages.crate: fix build
* [`cb2604ae`](https://github.com/NixOS/nixpkgs/commit/cb2604ae1a4f306f679d5d6e8c82713653b7d880) klibc: 2.0.8 -> 2.0.9
* [`cba2ac27`](https://github.com/NixOS/nixpkgs/commit/cba2ac27050f288b807204bc57abac3f4fc7763e) python3Packages.localzone: 0.9.7 -> 0.9.8
* [`5ab09faa`](https://github.com/NixOS/nixpkgs/commit/5ab09faafb5ba9875ce86ae99caa92f1194880d1) gretl: 2021a -> 2021b
* [`ed09e90e`](https://github.com/NixOS/nixpkgs/commit/ed09e90e95f2feddb72bd1cd1bbe038c7637fd6e) matio: 1.5.20 -> 1.5.21
* [`9a153cb2`](https://github.com/NixOS/nixpkgs/commit/9a153cb2800e9c38378dff01be930380b0a8488a) eventstat: 0.04.11 -> 0.04.12
* [`7c4e0e3a`](https://github.com/NixOS/nixpkgs/commit/7c4e0e3a90e099e0e171ba98440cdc59b60ac5c1) activemq: 5.16.1 -> 5.16.2
* [`d76e167b`](https://github.com/NixOS/nixpkgs/commit/d76e167bd5a5c4a28fe12effe406749e5734092a) kronosnet: 1.20 -> 1.21
* [`c362a28f`](https://github.com/NixOS/nixpkgs/commit/c362a28fcf2621fd3b6d6a96c821e9af9d123e21) nixos/testing: Switch from black to pyflakes
* [`71087b2b`](https://github.com/NixOS/nixpkgs/commit/71087b2bc4e3d78a44c8d562be63fc91c0acbefa) nixos/testing-python.nix: Expose driver
* [`56d96371`](https://github.com/NixOS/nixpkgs/commit/56d9637119ef4f05be20887ed09b2a2b760e6dae) nixos/testing: Set up scope for testScript linter
* [`06b070ff`](https://github.com/NixOS/nixpkgs/commit/06b070ffe7f4f24a2a92c22b0696517b247cd862) nixosTests.acme: lint
* [`b9e7fb14`](https://github.com/NixOS/nixpkgs/commit/b9e7fb14e2ea9a7047e719f65aa1b465ec472829) nixos/tests/nfs: lint
* [`774aba10`](https://github.com/NixOS/nixpkgs/commit/774aba102a842c60c635fdc583ba871cf1dea8cf) nixosTests.chromium: lint
* [`fc76a44d`](https://github.com/NixOS/nixpkgs/commit/fc76a44d0f9cc43a496b0bb4afb5b628b8fb250e) nixosTests.containers-custom-pkgs: lint
* [`b4b5dcb6`](https://github.com/NixOS/nixpkgs/commit/b4b5dcb66947cf195fd05978cae0eb9d3a708199) nixosTests.containers-imperative: lint
* [`b782440a`](https://github.com/NixOS/nixpkgs/commit/b782440a62879f1ea9cfe3b9be4475de924c9a51) nixosTests.custom-ca: lint
* [`62a518b9`](https://github.com/NixOS/nixpkgs/commit/62a518b904a235709b30293a08caffa202b7cbb2) nixos/tests/yggdrasil: Fix linting error
* [`c066cc3c`](https://github.com/NixOS/nixpkgs/commit/c066cc3c0b1f7f3c4b7e11ef330ce0980440273a) nixos/tests/networking: Fix str literal comparison
* [`e157ad41`](https://github.com/NixOS/nixpkgs/commit/e157ad41cb2df25b21a2d648f519caa0dc6dc712) nixos/tests/printing: Remove unused 'sys' import
* [`6c0ec527`](https://github.com/NixOS/nixpkgs/commit/6c0ec527b98de827e4dcb868498409b8e2cee1f3) nixos/tests/shadow: Fix linting errors
* [`6ad2e412`](https://github.com/NixOS/nixpkgs/commit/6ad2e41269db0d68aaf92440ad44d354e9608ff0) nixos/testing: lint jellyfin test
* [`74bff4e6`](https://github.com/NixOS/nixpkgs/commit/74bff4e6678a90934a37ab7d912c480fd313a588) nixos/tests/unbound: Remove unused 'json' import
* [`54bc6963`](https://github.com/NixOS/nixpkgs/commit/54bc69637bf2a891977dc87418e4c8cd1f71ce6f) nixos/test/virtualbox: Fix linting errors
* [`bf8c4855`](https://github.com/NixOS/nixpkgs/commit/bf8c4855e06d46ea54cc4f00f3ee5b01b82c80d2) libmaxminddb: 1.5.2 -> 1.6.0
* [`0e0a10ce`](https://github.com/NixOS/nixpkgs/commit/0e0a10ceb69bbfe17fcafb6d29cbad2e5f49485f) python3Packages.pylint-django: 2.4.2 -> 2.4.3
* [`9a414c14`](https://github.com/NixOS/nixpkgs/commit/9a414c148874c67c087712d1ed6827d0ad210356) libjwt: 1.12.1 -> 1.13.1
* [`74d8b78a`](https://github.com/NixOS/nixpkgs/commit/74d8b78a24be1f896cec07bb2ba0e1dbc840c34a) haskellPackages.tomland: Fix build
* [`518269b7`](https://github.com/NixOS/nixpkgs/commit/518269b7cb80dab7a1f39fa8513978d186832236) hydroxide: 0.2.17 -> 0.2.18
* [`54933eee`](https://github.com/NixOS/nixpkgs/commit/54933eeef03eabff730507f6393335e196f7563f) ibus-engines.m17n: 1.4.4 -> 1.4.5
* [`078e0b6f`](https://github.com/NixOS/nixpkgs/commit/078e0b6f935de243dc6bf62be94355263d1a5550) fcitx-engines.anthy: 0.2.3 -> 0.2.4
* [`b8cf4172`](https://github.com/NixOS/nixpkgs/commit/b8cf4172f234746445f24240fbe04634eb867997) gallery-dl: 1.17.1 -> 1.17.3
* [`5d9dc70c`](https://github.com/NixOS/nixpkgs/commit/5d9dc70c2fc0e2bbf8375b1ef5c22df5606682ea) pony-corral: 0.4.1 -> 0.5.0
* [`b1d725d4`](https://github.com/NixOS/nixpkgs/commit/b1d725d4d930f9e4f4f99fdd910682f2321d161c) gcsfuse: 0.34.1 -> 0.35.0
* [`796208b8`](https://github.com/NixOS/nixpkgs/commit/796208b8fc7f97b36f3160c7ffed9b43f74cec55) debootstrap: 1.0.123 -> 1.0.124
* [`577c3a55`](https://github.com/NixOS/nixpkgs/commit/577c3a55780d98923b8f09f7f0d42791d0db01d4) heimer: 2.4.0 -> 2.5.0
* [`7d1f79eb`](https://github.com/NixOS/nixpkgs/commit/7d1f79ebe021ba853df8dc3355629ad3d5513d34) bazarr: 0.9.4 -> 0.9.5
* [`b8016c6a`](https://github.com/NixOS/nixpkgs/commit/b8016c6aa6b552b98b0bd9e37d73ccc4cd3dc53a) istioctl: 1.9.3 -> 1.9.4
* [`6d7d4664`](https://github.com/NixOS/nixpkgs/commit/6d7d4664231919a4058e5943416c2a30b792f338) cargo-fuzz: 0.10.0 -> 0.10.1
* [`5fbb4944`](https://github.com/NixOS/nixpkgs/commit/5fbb4944bc5c8eb84c0fe62b908ad4d5fd749594) apt-cacher-ng: 3.6.1 -> 3.6.3
* [`c6dbb82d`](https://github.com/NixOS/nixpkgs/commit/c6dbb82d8c0cc39f40267974d81ae61de64d8ca0) gmic: 2.9.6 -> 2.9.7
* [`6f09f253`](https://github.com/NixOS/nixpkgs/commit/6f09f253f52f67cedb6eb0f7c1406c09d7a2b3f7) birdfont: 2.29.1 -> 2.29.4
* [`68155982`](https://github.com/NixOS/nixpkgs/commit/68155982fad9a5b478a28eed6de4bf7bfef00e50) kustomize-sops: 2.5.2 -> 2.5.5
* [`8c868f47`](https://github.com/NixOS/nixpkgs/commit/8c868f47a8934ccfa27d5ac3103297d344506b68) Revert "nixos/tests/docker-tools*: remove useless formatter"
* [`69090bce`](https://github.com/NixOS/nixpkgs/commit/69090bce703261ff57b694668aa6269b467da492) sickgear: 0.23.15 -> 0.23.16
* [`a8926057`](https://github.com/NixOS/nixpkgs/commit/a8926057f051da54f543751c577a3434298f658b) bacula: 11.0.1 -> 11.0.2
* [`36c5cea0`](https://github.com/NixOS/nixpkgs/commit/36c5cea0f6af3c86af3933da4c74e038a7b63569) bzrtp: 4.5.1 -> 4.5.10
* [`75c4fc1c`](https://github.com/NixOS/nixpkgs/commit/75c4fc1c8bf1c4c453c2b7279d70dc058d0b60ba) nixos/testing-python.nix: Move makeWrapper to nativeBuildInputs
* [`dfa9e91b`](https://github.com/NixOS/nixpkgs/commit/dfa9e91b11b0e4a1e12fe7c3fcffbdd945f365aa) python3Packages.pulsectl: 21.3.4 -> 21.5.0
* [`33603146`](https://github.com/NixOS/nixpkgs/commit/3360314646ce5c354057e848cb35f67bf6e3a586) rtl8812au: 5.6.4.2 -> 5.9.3.2
* [`918cf983`](https://github.com/NixOS/nixpkgs/commit/918cf983fb2022d260058991d28af0a8a8509c97) rtl8812au: remove unsupported kernels
* [`77ff20bd`](https://github.com/NixOS/nixpkgs/commit/77ff20bdbaba71224cff0fb6c11c20ef48839605) python3Packages.csvw: 1.10.2 -> 1.11.0
* [`2c143443`](https://github.com/NixOS/nixpkgs/commit/2c143443f7c5c17e57a0723a2bf0e84a74f8778a) libpoly: 0.1.8 -> 0.1.9
* [`ac3277d0`](https://github.com/NixOS/nixpkgs/commit/ac3277d04c3c51431b046a2690db626c50335cfd) libdigidocpp: 3.14.5 -> 3.14.6
* [`ba80e48d`](https://github.com/NixOS/nixpkgs/commit/ba80e48da5d545f6a0d607f3dc829fd01faf2d03) gerbera: 1.7.0 -> 1.8.0
* [`769c3430`](https://github.com/NixOS/nixpkgs/commit/769c34306ffb6b1c3f3cac6e08b5f4728b268bb2) jftui: 0.4.0 -> 0.5.0
* [`2d41db9d`](https://github.com/NixOS/nixpkgs/commit/2d41db9d71902b098351ecc38715303f16414374) helmsman: 3.6.6 -> 3.6.7
* [`cbd1cc10`](https://github.com/NixOS/nixpkgs/commit/cbd1cc10cd4872d9ecd3a8a064edc8ffe0cd2acd) kubernetes: 1.20.5 -> 1.21.0
* [`548bd841`](https://github.com/NixOS/nixpkgs/commit/548bd84185d2e1c62448edb76565f8467642b955) fstrm: 0.6.0 -> 0.6.1
* [`e11130d6`](https://github.com/NixOS/nixpkgs/commit/e11130d6fcf980785a6f2c78932743c6c71b2aef) ergo: 4.0.8 -> 4.0.9
* [`99e84920`](https://github.com/NixOS/nixpkgs/commit/99e8492074e21c27a7c522c57bf4c684d4a280df) belle-sip: 4.5.1 -> 4.5.3
* [`c6f9eceb`](https://github.com/NixOS/nixpkgs/commit/c6f9eceb3dd6518cd0b82fddf74a1d177eb976c3) clash: 1.5.0 -> 1.6.0
* [`cbaa4db0`](https://github.com/NixOS/nixpkgs/commit/cbaa4db0ad3a355687611939425a6faf5dd94278) chroma: update sha256
* [`d8458c45`](https://github.com/NixOS/nixpkgs/commit/d8458c456413e7df48ce5b1033d3f81288e75169) flavours: add missing libiconv dependency on darwin
* [`8647f157`](https://github.com/NixOS/nixpkgs/commit/8647f1570fdaa6081db373fb73511643254b8d91) pqiv: use ffmpeg4
* [`54f592da`](https://github.com/NixOS/nixpkgs/commit/54f592da6a0955b4628ef70e16581a930b60db16) croc: 9.1.1 -> 9.1.2
* [`174735e1`](https://github.com/NixOS/nixpkgs/commit/174735e1399d03631bf641dbbd694995cb776264) bitwig-studio: Move away from from ffmpeg_3
* [`a1bd1932`](https://github.com/NixOS/nixpkgs/commit/a1bd19325ee1d87d0dbc454b4f37265083fd846f) czkawka: 3.0.0 -> 3.1.0
* [`7c58a1e2`](https://github.com/NixOS/nixpkgs/commit/7c58a1e244ef39f96aa6906594d35c8079a99bc5) python3Packages.mcstatus: 5.1.4 -> 5.2.0
* [`7f428e89`](https://github.com/NixOS/nixpkgs/commit/7f428e89d7a86e54d5d91cdb79509ca4ce47a618) python3Packages.uvloop: disable problematic test on aarch64
* [`9b80b832`](https://github.com/NixOS/nixpkgs/commit/9b80b8324c837feef5a88930a8b734d30c1f9a95) python3Packages.pytest-ordering: mark as broken
* [`b1f796ea`](https://github.com/NixOS/nixpkgs/commit/b1f796eabe317d441626e616ed96d23eed1432af) rebar3: 3.14.4 -> 3.15.1
* [`1578d8d3`](https://github.com/NixOS/nixpkgs/commit/1578d8d3f8ca1f07f6d6a3dd4d478f502d56356e) flexget: 3.1.116 -> 3.1.121
* [`c8cc491b`](https://github.com/NixOS/nixpkgs/commit/c8cc491b7ec29d83a2f8d07dbffcbef604a13e81) dragonfly-reverb: 3.2.1 -> 3.2.5 ([nixos/nixpkgs⁠#118939](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118939))
* [`506646e4`](https://github.com/NixOS/nixpkgs/commit/506646e48bd1fe5be08742d1942062b53aba6f93) nixos/tests/unit-php: require one of users.users.name.{isSystemUser,isNormalUser}
* [`bedbf2c8`](https://github.com/NixOS/nixpkgs/commit/bedbf2c81c2e8cf29cc11df4b3b7eaeae326c119) fselect: 0.7.4 -> 0.7.5
* [`7c46cfbc`](https://github.com/NixOS/nixpkgs/commit/7c46cfbc026db51374b9f02a6b9dcc342fc60a2c) qtwebkit: fix linux build with glib 2.68 ([nixos/nixpkgs⁠#122259](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122259))
* [`b26b54f0`](https://github.com/NixOS/nixpkgs/commit/b26b54f056330010b23e0df2057ec5c1ee6e13fb) mamba: 1.8 -> 2.2 ([nixos/nixpkgs⁠#122193](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122193))
* [`b4833b34`](https://github.com/NixOS/nixpkgs/commit/b4833b346c78b4308e574b6134aa03b21dda268f) gleam: 0.15.0 -> 0.15.1
* [`c405fdec`](https://github.com/NixOS/nixpkgs/commit/c405fdecc7b3db9ba2a43fa303eed9e36a4e88f2) himalaya: 0.3.1 -> 0.3.2
* [`438b60f3`](https://github.com/NixOS/nixpkgs/commit/438b60f3f72725aceecf0e1a3eab0b02d56101c6) openrazer: 3.0.0 -> 3.0.1, mark broken for kernels < 4.19
* [`16a600d2`](https://github.com/NixOS/nixpkgs/commit/16a600d29e03751e0a025bfc212f0621778013ab) tuir: unbreak adding six dependency
* [`0f4d3902`](https://github.com/NixOS/nixpkgs/commit/0f4d3902abeebcc5379b81e4218f32ca5c2478d9) palemoon: Remove MOZ_PKG_SPECIAL, add AV1 configure flag
* [`d3ed0f50`](https://github.com/NixOS/nixpkgs/commit/d3ed0f5028bf29c1ccee82bb815deaf40d337a51) ghostwriter: 2.0.0-rc5 -> 2.0.0 ([nixos/nixpkgs⁠#122268](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122268))
* [`fb8b1191`](https://github.com/NixOS/nixpkgs/commit/fb8b11917e12d52287de10c52506ba2376123188) visidata: 2.2.1 -> 2.4
* [`c0a998de`](https://github.com/NixOS/nixpkgs/commit/c0a998de58a89ed92a4657871d0b9e24f38fd92a) python3Packages.pyexcel-xls: unbreak
* [`ca365f69`](https://github.com/NixOS/nixpkgs/commit/ca365f6946d6349a5e2fb70ceaff126772169691) monotone: 1.1 -> 1.1-unstable-2021-05-01 to move from insecure botan 1
* [`d5bec773`](https://github.com/NixOS/nixpkgs/commit/d5bec77379672caf60e18af5d0d432336465de6c) python3Packages.pyjwt: cleanup
* [`bd50f699`](https://github.com/NixOS/nixpkgs/commit/bd50f69946bcd2dbcea5e9b06407200915d490e4) python3Packages.pyjwt: 2.0.1 -> 2.1.0
* [`d10aedae`](https://github.com/NixOS/nixpkgs/commit/d10aedaea55cc5fb8add384cc60bcb212e1136ed) python3Packages.msal: 1.10.0 -> 1.11.0
* [`b4170925`](https://github.com/NixOS/nixpkgs/commit/b4170925efd3c5081db50f6266e14fc1479049d2) python3Packages.mwoauth: fix build
* [`2789f04f`](https://github.com/NixOS/nixpkgs/commit/2789f04fbe068d501313b52d7c18d869b7b61c65) python3Packages.pyflume: fix build
* [`28b5164f`](https://github.com/NixOS/nixpkgs/commit/28b5164fca6135cb545ad9fd3baa04f193b7f20a) python3Packages.snowflake-connector-python: 2.4.1 -> 2.4.3
* [`cc9e009e`](https://github.com/NixOS/nixpkgs/commit/cc9e009e79b9e0abdb671b911a610cbba34e4e24) python3Packages.oauthenticator: 0.13.0 -> 14.0.0
* [`8eed0e20`](https://github.com/NixOS/nixpkgs/commit/8eed0e209537f00195855c8eef0dabf9ed99154f) bottom: add meta.mainProgram
* [`524ff402`](https://github.com/NixOS/nixpkgs/commit/524ff402913da2b718fd96d5f2f3c7aa3bd93581) nixosTests.systemd-networkd: remove wireguard kernel module
* [`7c4f7614`](https://github.com/NixOS/nixpkgs/commit/7c4f7614b4d29840ae696f9a6fde906e3bcd1957) esphome: 1.17.1 -> 1.17.2
* [`5b29b74b`](https://github.com/NixOS/nixpkgs/commit/5b29b74b71743fc97a9c8f79827e563b820278ec) python3Packages.privacyidea: fix eval with python3
* [`3f8e2f06`](https://github.com/NixOS/nixpkgs/commit/3f8e2f06d27615d3e37d2f7b58573b9fbea11c9e) ffsend: 0.2.71 -> 0.2.72
* [`67e49dbb`](https://github.com/NixOS/nixpkgs/commit/67e49dbbb7edc1db8a07db9854aba39ae437b074) python2Packages.privacyidea-ldap-proxy: fix python2 build
* [`0f4f1ae3`](https://github.com/NixOS/nixpkgs/commit/0f4f1ae3f219f8f2eef6df4d28a1a7ea4dc2613e) linux_lqx: 5.11.18 -> 5.11.19
* [`52c27c3b`](https://github.com/NixOS/nixpkgs/commit/52c27c3b7dddf21979d86a504fa1d2ad13d0fd6b) squeezelite: use ffmpeg 4 ([nixos/nixpkgs⁠#122336](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122336))
* [`e0e62c88`](https://github.com/NixOS/nixpkgs/commit/e0e62c8804375ad7f1a1d7f1239256c30fff52e9) git-repo: 2.13.1 -> 2.14.5
* [`a9cbc58b`](https://github.com/NixOS/nixpkgs/commit/a9cbc58b398315d7950bc687d2d255f66df468bc) plano-theme: 3.36-2 -> 3.38-1
* [`2bc02574`](https://github.com/NixOS/nixpkgs/commit/2bc025749943c6d25cf11f29fdb9987cc230c050) i3status-rust: 0.14.7 -> 0.20.0
* [`f1b9f802`](https://github.com/NixOS/nixpkgs/commit/f1b9f8023d11155bf72f56aafaa6009f51284942) linux: 4.14.231 -> 4.14.232
* [`df61f804`](https://github.com/NixOS/nixpkgs/commit/df61f804fb8670879ff0b51cb9f4fb900b5df52a) linux: 4.19.188 -> 4.19.190
* [`662c0201`](https://github.com/NixOS/nixpkgs/commit/662c0201a531c1cb0637d164f16328976a087f17) linux: 4.4.267 -> 4.4.268
* [`94ce8621`](https://github.com/NixOS/nixpkgs/commit/94ce86210197f75a8bcab9ff04f273f43ce1910f) linux: 4.9.267 -> 4.9.268
* [`2161af8d`](https://github.com/NixOS/nixpkgs/commit/2161af8d3c5f57279598395ace47bd8e3994f06b) linux: 5.10.32 -> 5.10.35
* [`d96c775d`](https://github.com/NixOS/nixpkgs/commit/d96c775d1af7b397099e8469f138908370db7f89) linux: 5.11.16 -> 5.11.19
* [`08bc0909`](https://github.com/NixOS/nixpkgs/commit/08bc09092cefd363fdeab147885a80a847d1c9bf) linux: 5.4.114 -> 5.4.117
* [`0426acd2`](https://github.com/NixOS/nixpkgs/commit/0426acd2e4ad2ca7c70149373f97bf62efb9f6ea) linux-rt_5_10: 5.10.30-rt37 -> 5.10.30-rt38
* [`c580bc9a`](https://github.com/NixOS/nixpkgs/commit/c580bc9a255686433e0b79788194012f0d365003) linux-rt_5_4: 5.4.109-rt56 -> 5.4.115-rt57
* [`301a17cd`](https://github.com/NixOS/nixpkgs/commit/301a17cdcf0d39c0eff45d54f329246f891aad4c) linux_latest-libre: 17990 -> 18063
* [`98eb12bc`](https://github.com/NixOS/nixpkgs/commit/98eb12bcae5ba91521ba28bfa67d096c25a4faf9) linux/hardened/patches/4.14: 4.14.231-hardened1 -> 4.14.232-hardened1
* [`a2a89d85`](https://github.com/NixOS/nixpkgs/commit/a2a89d85d06be38bcbdc61e602fbe71585ca2729) linux/hardened/patches/4.19: 4.19.188-hardened1 -> 4.19.190-hardened1
* [`2e32ce5e`](https://github.com/NixOS/nixpkgs/commit/2e32ce5eddbfaec313d3edda8d1e987efd9287c1) linux/hardened/patches/5.10: 5.10.32-hardened1 -> 5.10.35-hardened1
* [`5b5ecae6`](https://github.com/NixOS/nixpkgs/commit/5b5ecae63d28db71a69979bbe0e7f0dc31725116) linux/hardened/patches/5.11: 5.11.16-hardened1 -> 5.11.19-hardened1
* [`c1569cc8`](https://github.com/NixOS/nixpkgs/commit/c1569cc8ad30f6ff4c3635f13a25ebeb3fdda32a) linux/hardened/patches/5.4: 5.4.114-hardened1 -> 5.4.117-hardened1
* [`852b4e90`](https://github.com/NixOS/nixpkgs/commit/852b4e9018d554e1bbea4d69251b9629ff0d43b6) createrepo_c: 0.11.1 -> 0.17.1
* [`046bc37d`](https://github.com/NixOS/nixpkgs/commit/046bc37d1c85a520c66a8ef0f9cfc118a2af3609) humblewx: init at 0.2.2
* [`e9e72ab4`](https://github.com/NixOS/nixpkgs/commit/e9e72ab47a8aeef5ef2dcc04df43a6bd7fe1805f) pysvg-py3: init at 0.2.2-post3
* [`8dc6fccf`](https://github.com/NixOS/nixpkgs/commit/8dc6fccf325b59dcd46051e7bcb86d646794abf7) timeline: init at 2.4.0
* [`1dec938c`](https://github.com/NixOS/nixpkgs/commit/1dec938c7d5ed4ea483cf08e26eb36f09ee77566) glfw: 3.3.3 -> 3.3.4
* [`51ade7bf`](https://github.com/NixOS/nixpkgs/commit/51ade7bf461a7f4d1c82e01a4fb01618b2250abf) maintainers: add noreferences
* [`ab22d96d`](https://github.com/NixOS/nixpkgs/commit/ab22d96d1dd97a2c7b8ec51398906a02bb6885d2) maintainers: add alex-eyre
* [`cefc7af0`](https://github.com/NixOS/nixpkgs/commit/cefc7af063c3c354dc241adc569facaf506bb792) nimbo: init at 0.2.4
* [`c8f5ce18`](https://github.com/NixOS/nixpkgs/commit/c8f5ce18fadf55c04bf0cbffff2ab404edad05f1) assaultcube licensing: mark unfree
* [`73e62029`](https://github.com/NixOS/nixpkgs/commit/73e62029b98e8849e4db37c0e24bcc8be88d608b) feh: 3.6.3 -> 3.7 ([nixos/nixpkgs⁠#122375](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122375))
* [`418a37d9`](https://github.com/NixOS/nixpkgs/commit/418a37d99c155841e0df7893d48d28040b6120ab) coq2html: 20170720 -> 1.2
* [`a4b05310`](https://github.com/NixOS/nixpkgs/commit/a4b05310c2602e70b75b59c9189b8fd414c99bef) dua: 2.11.2 -> 2.11.3
* [`c8156c23`](https://github.com/NixOS/nixpkgs/commit/c8156c23867e2487e1e299f32b14de04041eadbe) cargo-binutils: format with nixpkgs-fmt
* [`56dc147d`](https://github.com/NixOS/nixpkgs/commit/56dc147d26aaa874e6618742169c5f71cd061267) cargo-binutils: add longDescription
