### PR TITLE
niv home-manager: update 9ffb2060 -> 23769994

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ffb206050bab47122eac18ea7cb289849f8d128",
-        "sha256": "0rlcp23ask8v8rwpaclbgxzb633ap1wp92anwkr9s84sl9zzfq96",
+        "rev": "23769994e8f7b212d9a257799173b120ed87736b",
+        "sha256": "13vw6dwnva6922ayzj0b0gpwgzz14202llv37pr8w8qfrrg83xxk",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9ffb206050bab47122eac18ea7cb289849f8d128.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/23769994e8f7b212d9a257799173b120ed87736b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9ffb2060...23769994](https://github.com/nix-community/home-manager/compare/9ffb206050bab47122eac18ea7cb289849f8d128...23769994e8f7b212d9a257799173b120ed87736b)

* [`64c5228c`](https://github.com/nix-community/home-manager/commit/64c5228c0828fff0c94c1d42f7225115c299ae08) i3, sway: description and example for font options ([nix-community/home-manager⁠#1980](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1980))
* [`90dd375e`](https://github.com/nix-community/home-manager/commit/90dd375eba16e11949d4a4a7538554dc8e9ceb8f) zsh: break configuration dependency in documentation
* [`f298705a`](https://github.com/nix-community/home-manager/commit/f298705ae4c8994aba25296e1ee151a2d4e560c5) i3,sway: break documentation dependency on configuration
* [`30355f8e`](https://github.com/nix-community/home-manager/commit/30355f8ee677fded3ac34d28cd59a0e682549f98) etesync-dav: add module
* [`86944b0f`](https://github.com/nix-community/home-manager/commit/86944b0fb15f89bc1173efabbce556260a410154) docs: remove requirement about capitalization
* [`ff959fd4`](https://github.com/nix-community/home-manager/commit/ff959fd49a53869588679ebb0435728c15fb9564) sxhkd: fix environment ([nix-community/home-manager⁠#1892](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1892))
* [`b2dec35b`](https://github.com/nix-community/home-manager/commit/b2dec35b86e8488831734ff7936589d710b47420) Fix eval errors when i3 or sway null configs are null ([nix-community/home-manager⁠#1989](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1989))
* [`4896c500`](https://github.com/nix-community/home-manager/commit/4896c500742a2a2e86e71018e17e617c5ffc74c6) msmtp: add note about account commands in extraConfig
* [`e42e147b`](https://github.com/nix-community/home-manager/commit/e42e147b581bbe36be651ba3f9e74715f10a4eff) Remove some usage of config.lib.dag
* [`15a2953c`](https://github.com/nix-community/home-manager/commit/15a2953c814efd5280f121d802c510d26ca15726) powerline-go: avoid dependency in tests
* [`7d765d8f`](https://github.com/nix-community/home-manager/commit/7d765d8f46b479abe69b6da324e6bb6444be5cfd) firefox: do not override other attributes in 'cfg' ([nix-community/home-manager⁠#1988](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1988))
* [`3b799f6e`](https://github.com/nix-community/home-manager/commit/3b799f6ea42f850316ae4741ff323dc74ce09467) nix-index: add module ([nix-community/home-manager⁠#1984](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1984))
* [`23769994`](https://github.com/nix-community/home-manager/commit/23769994e8f7b212d9a257799173b120ed87736b) xdg.systemDirs: init module ([nix-community/home-manager⁠#1797](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1797))
