### PR TITLE
niv spacemacs: update e15dbdc0 -> 060f5585

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "e15dbdc03694ecdb66c9152d8a3d236325d99d72",
-        "sha256": "1m2nl2z8kmsad9l6wwh5aidkafqi7cjxbv3k7bhj2np9yw7cxyf0",
+        "rev": "060f558530c9fce1aa7ac4751ede5c94387f3b09",
+        "sha256": "11bvwwc2x48bjj0sw2xm3ayh9mihqcn2796p0jl1l4wjwrhpac0w",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/e15dbdc03694ecdb66c9152d8a3d236325d99d72.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/060f558530c9fce1aa7ac4751ede5c94387f3b09.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@e15dbdc0...060f5585](https://github.com/syl20bnr/spacemacs/compare/e15dbdc03694ecdb66c9152d8a3d236325d99d72...060f558530c9fce1aa7ac4751ede5c94387f3b09)

* [`efbf4c5f`](https://github.com/syl20bnr/spacemacs/commit/efbf4c5fb581e8c921525ca96ec814bc4a00b6df) set initial evil state of ccls-tree-mode to be emacs
* [`4fc78bdc`](https://github.com/syl20bnr/spacemacs/commit/4fc78bdc023c2889078c7fa53331bf6c0b86f6c3) add a feature to save file as a new file and open it in a new buffer
* [`1169eb37`](https://github.com/syl20bnr/spacemacs/commit/1169eb3709e596c2abead14986842366cec70839) [spacemacs-defaults] Move new function to correct file
* [`5c48a35b`](https://github.com/syl20bnr/spacemacs/commit/5c48a35bc892e53e5f73b4781c60424f6cc09801) fixup! [syl20bnr/spacemacs⁠#982](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/982)e25
* [`d2e9730a`](https://github.com/syl20bnr/spacemacs/commit/d2e9730acb2c20626cb1f9f78e07431b334008cf) Update pyls install command to use quotes ([syl20bnr/spacemacs⁠#14741](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14741))
* [`72807f3e`](https://github.com/syl20bnr/spacemacs/commit/72807f3ef2c37c17e5426fb2e1b67bc2e8c249cb) [vim] add evil-better-jumper layer
* [`0ffe1606`](https://github.com/syl20bnr/spacemacs/commit/0ffe16066f1fcf01c3da5c58007998ffbc4cc8f7) [vim] Disable unused functions in evil-better-jumper layer
* [`f213b8cf`](https://github.com/syl20bnr/spacemacs/commit/f213b8cf20deb4ec9c9d2b267b9c5210555a5f9a) Revert "[spacemacs-defaults] Move new function to correct file"
* [`c1c18b7e`](https://github.com/syl20bnr/spacemacs/commit/c1c18b7eedc9bc6ee07618f064e8eb8d9ef58337) Revert "add a feature to save file as a new file and open it in a new buffer"
* [`a26121db`](https://github.com/syl20bnr/spacemacs/commit/a26121db4f60d49dd0ccb0bcf4a4fc538a11bc67) documentation formatting: Thu May 6 20:14:11 UTC 2021
* [`c4a1caae`](https://github.com/syl20bnr/spacemacs/commit/c4a1caae176d19a9d1e33b126604475baa3041eb) [core] Add :timeout/:idle for spacemacs|define-transient-state ([syl20bnr/spacemacs⁠#14742](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14742))
* [`64902865`](https://github.com/syl20bnr/spacemacs/commit/649028658a8c870339d0a5c2587f08c945607efb) Add 'image-dired' directory to .gitignore. ([syl20bnr/spacemacs⁠#14748](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14748))
* [`5b5bd915`](https://github.com/syl20bnr/spacemacs/commit/5b5bd915c203a876a9ccb3f45baa911221ebcec9) [home] New var dotspacemacs-show-startup-list-numbers
* [`6e578cbb`](https://github.com/syl20bnr/spacemacs/commit/6e578cbb346d369e1ac42b62e69e68fa833fc440) [home] Add button: Close note
* [`8ede09f8`](https://github.com/syl20bnr/spacemacs/commit/8ede09f87596365aee710ee70fadc51c77eab873) Small fix to eaf-layer refactor
* [`5ba65203`](https://github.com/syl20bnr/spacemacs/commit/5ba6520389919b1e7475b09f52c736169ca8a5a6) Revert "[keyboard-layout] Fix colemak-hneio next/prev line in magit"
* [`947763ee`](https://github.com/syl20bnr/spacemacs/commit/947763eeaadb3888656a4c9f19cb77dbe708aca5) [evil-better-jumper] Update layer documentation ([syl20bnr/spacemacs⁠#14744](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14744))
* [`91460598`](https://github.com/syl20bnr/spacemacs/commit/914605989ff44e95e00d119abb305ba0348be9c1) [home] Only jump to visible nr lines
* [`8adebd97`](https://github.com/syl20bnr/spacemacs/commit/8adebd9757e6d1444553b50623165671d9e2dde1) [core] remove jump-to-reference from core-jump
* [`72127a49`](https://github.com/syl20bnr/spacemacs/commit/72127a49cbab36d7b8a91c45f3e6858b00c1aa02) Replace counsel-M-x command in eaf-layer
* [`61f6480e`](https://github.com/syl20bnr/spacemacs/commit/61f6480ef89af497143bec4727126d0e3841cb58) documentation formatting: Sun May 9 19:09:25 UTC 2021
* [`ad8acf6d`](https://github.com/syl20bnr/spacemacs/commit/ad8acf6d51a44971aab7c9f4da3468dd9252f2b1) [latex] Add missing binding for 'org-ref-insert-cite-key with lsp
* [`e9b4131d`](https://github.com/syl20bnr/spacemacs/commit/e9b4131d1886f69a6b8a483f87d7de2a60e0ac59) [auto-complete] Removed the last traces of transformer integration
* [`060f5585`](https://github.com/syl20bnr/spacemacs/commit/060f558530c9fce1aa7ac4751ede5c94387f3b09) [json] Avoid changing default evil state for tabulated-list-modes
