### PR TITLE
niv nixpkgs: update 975fd299 -> f2e899e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "975fd299713554077b983e76fda8cd135c957506",
-        "sha256": "188fycpc8r2hajlsdnx358vbyir4qpg8w2zi6929rmc87z33k7yk",
+        "rev": "f2e899e01a02e10ae0affd879bd445aa57eb05a8",
+        "sha256": "1g3s4a9r6lx25w32jclnqkr9s27335m6zknmakc8f93hzjnihan4",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/975fd299713554077b983e76fda8cd135c957506.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f2e899e01a02e10ae0affd879bd445aa57eb05a8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@975fd299...f2e899e0](https://github.com/nixos/nixpkgs/compare/975fd299713554077b983e76fda8cd135c957506...f2e899e01a02e10ae0affd879bd445aa57eb05a8)

* [`a70ed465`](https://github.com/NixOS/nixpkgs/commit/a70ed465bc5cb5f6da10a2e260045cd19233c756) minio: 2021-04-22T15-44-28Z -> 2021-05-11T23-27-41Z
* [`f070de25`](https://github.com/NixOS/nixpkgs/commit/f070de253cf7bf071f313a8a1a0222d2adaee59f) Revert "hwdata: 0.344 -> 0.347"
* [`28f2476f`](https://github.com/NixOS/nixpkgs/commit/28f2476fe41fcab6cae85d73a05d6032edd756b0) arc-theme: 20210127 -> 20210412, switch to meson
* [`a542827c`](https://github.com/NixOS/nixpkgs/commit/a542827c9bb9f90fad6d1c9b5bab7eec24db824c) nixos/sway: Update the module documentation
* [`e7115b7d`](https://github.com/NixOS/nixpkgs/commit/e7115b7da455e2bf8214b43621a1a3d7d91e3cc5) python3Packages.flask-appbuilder: unbreak
* [`f8a8ac23`](https://github.com/NixOS/nixpkgs/commit/f8a8ac2331053fe553b53f0862ed80af570b137b) cairomm_1_16: fix darwin build ([nixos/nixpkgs⁠#123020](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123020))
* [`e957b3c5`](https://github.com/NixOS/nixpkgs/commit/e957b3c5b82091898add49fd886f4c6e41538410) evcxr: fix darwin build
* [`2594e822`](https://github.com/NixOS/nixpkgs/commit/2594e822160ce5f2ae0295a06a89ce1d090875c5) ethabi: fix darwin build
* [`830ebf14`](https://github.com/NixOS/nixpkgs/commit/830ebf14b2f07086e909077521a5033973e4892d) kbdd: unstable-2017-01-30 -> unstable-2021-04-26 ([nixos/nixpkgs⁠#122768](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122768))
* [`3b856174`](https://github.com/NixOS/nixpkgs/commit/3b856174c3568276dee6cd88e550212aaca15b32) gitoxide: fix darwin build
* [`59ceb192`](https://github.com/NixOS/nixpkgs/commit/59ceb1926aac428b203ba9b384cf058fc24a2c85) arc_unpacker: fix build
* [`21108101`](https://github.com/NixOS/nixpkgs/commit/21108101a5051e8733a379d2091dd938c6920ab2) arc_unpacker: add missing hooks and clear up license
* [`5548ff17`](https://github.com/NixOS/nixpkgs/commit/5548ff174ca661d6585f8838a9d1c72003daf603) getxbook: fix clang build
* [`878eec12`](https://github.com/NixOS/nixpkgs/commit/878eec12e53e69de3ba639f344deada28baf386b) theme-jade1: 1.12 -> 1.13
* [`c4c147cd`](https://github.com/NixOS/nixpkgs/commit/c4c147cd15ae61313a134cf9de311bece0555c26) gonic: Fix build error
* [`8f64c5d9`](https://github.com/NixOS/nixpkgs/commit/8f64c5d9fcce5981b8ea2a861566e382ddbc9731) ffmpeg_4: fix build error on darwin
* [`d5d750fa`](https://github.com/NixOS/nixpkgs/commit/d5d750fa540b2a9d9a8354d7652faf7aacbd7511) vdr: 2.4.6 -> 2.4.7
* [`5b31dece`](https://github.com/NixOS/nixpkgs/commit/5b31dece4dd545cb49701a08551f76eca00608ec) marwaita: 9.1 -> 9.2.1
* [`d3b00c99`](https://github.com/NixOS/nixpkgs/commit/d3b00c99a92e554ea74380b61ef4ee2f12adc88a) python-language-server: 2020-06-19 -> 2020-10-08
* [`d68e0569`](https://github.com/NixOS/nixpkgs/commit/d68e0569a0b5be705f11922f6144b334e3905c13) python-language-server: cleanup deps, add missing phase hooks
* [`f00d022e`](https://github.com/NixOS/nixpkgs/commit/f00d022ebff7eee9115c433d9fc8f9f2ef588fb0) git-workspace: fix darwin build
* [`8ceb0380`](https://github.com/NixOS/nixpkgs/commit/8ceb0380a252d91ba6ba8ce90befbdf5c99c7bd2) cxxopts: fix darwin build
* [`1dde95b7`](https://github.com/NixOS/nixpkgs/commit/1dde95b786497c3b4e410ef276565ba6e660568d) alembic: 1.8.0 -> 1.8.1
* [`4a9b0f0e`](https://github.com/NixOS/nixpkgs/commit/4a9b0f0eb450d7bef5db5c05c2086b24aaecf05c) arduino-cli: 0.12.1 -> 0.18.1 ; fix darwin build
* [`61d8677d`](https://github.com/NixOS/nixpkgs/commit/61d8677ddfadc5bd6f039eadd4071c9990e6818b) corectrl: 1.1.2 -> 1.1.3
* [`db8a884d`](https://github.com/NixOS/nixpkgs/commit/db8a884d4b7948ee2b03db702722d8b2879f592b) fancy-motd: init at unstable-2021-05-15
* [`6e7fac36`](https://github.com/NixOS/nixpkgs/commit/6e7fac368f9c0f4558e32fa41c406a674d722fbe) solaar: 1.0.2 -> 1.0.5
* [`0633aea3`](https://github.com/NixOS/nixpkgs/commit/0633aea3d5470fce7d5321236560ee4cf102f435) ltunify: unstable-20180330 -> 0.3
* [`33a2d3a8`](https://github.com/NixOS/nixpkgs/commit/33a2d3a8178b4e05efa90cda0b67c65c10f45d8a) logitech-udev-rules: truly minor permission fix
* [`8749ba11`](https://github.com/NixOS/nixpkgs/commit/8749ba1165c5cece22badf21a599793c23d46d91) findomain: 4.2.0 -> 4.2.1
* [`201e1a4f`](https://github.com/NixOS/nixpkgs/commit/201e1a4fb870c8b904c078f3e22790b0d873adc3) vdr: Update license
* [`0a099aa6`](https://github.com/NixOS/nixpkgs/commit/0a099aa6c522fb169825877c747a72d584192f69) fatrace: 0.16.2 -> 0.16.3
* [`0a5ec972`](https://github.com/NixOS/nixpkgs/commit/0a5ec9728b296d78fafe28e0d56ecde1b331771f) doctl: 1.60.0 -> 1.61.0
* [`fd793047`](https://github.com/NixOS/nixpkgs/commit/fd7930476909f3b53b15c6b37c570a09901fd946) lefthook: 0.7.4 -> 0.7.5
* [`2558acf8`](https://github.com/NixOS/nixpkgs/commit/2558acf87072f09181dfff7bf0ce47828e2490ec) pulseview: fix build error
* [`4539a5b8`](https://github.com/NixOS/nixpkgs/commit/4539a5b8be350016b4cc8af67aab6baba88005f4) ace: 7.0.1 -> 7.0.2
* [`9528bf9f`](https://github.com/NixOS/nixpkgs/commit/9528bf9fd93b97d49c69098e773779f7ab1b70c2) bowtie2: 2.4.2 -> 2.4.3
* [`b6595ab6`](https://github.com/NixOS/nixpkgs/commit/b6595ab614a2ea69305c35cf6d11bc8694b9289e) pistol: 0.2.0 -> 0.2.1
* [`37434d70`](https://github.com/NixOS/nixpkgs/commit/37434d704bb16b9097fff5bb3ed5826e7230bea0) lime: 4.5.1 -> 4.5.14
* [`3d18edda`](https://github.com/NixOS/nixpkgs/commit/3d18eddae244c9a88fc5d8dfe2e90a29d412bb0f) pulseview: fix patch hash
* [`c4ff610b`](https://github.com/NixOS/nixpkgs/commit/c4ff610b31f5c08af749bc2e4fe5d10d43bdce8c) mbtileserver: 0.6.1 → 0.7.0
* [`3e43d42f`](https://github.com/NixOS/nixpkgs/commit/3e43d42f87388db13783701993e96f115501cd27) ffmpeg_4: only apply the patch on darwin
* [`11ac26ba`](https://github.com/NixOS/nixpkgs/commit/11ac26ba22948f0a076afa811eb33d0223e7c586) bctoolbox: 4.5.7 -> 4.5.15
* [`f2c015d3`](https://github.com/NixOS/nixpkgs/commit/f2c015d33d1b36070c64b726662db42c6c87b7be) python3Packages.awkward: 1.2.2 -> 1.2.3
* [`1e6a687f`](https://github.com/NixOS/nixpkgs/commit/1e6a687fd0dc633a156933ad876ed1e843220f0b) linux_lqx: 5.11.20 -> 5.11.21
* [`9018f5eb`](https://github.com/NixOS/nixpkgs/commit/9018f5eb0148cc500e786906d8109e2cafe30878) dasher: enableParallelBuilding = true
* [`d460acab`](https://github.com/NixOS/nixpkgs/commit/d460acab056d8351d1a6a659f249022fc44fc565) pika-backup: 0.2.3 -> 0.3.0
* [`02b121bf`](https://github.com/NixOS/nixpkgs/commit/02b121bf85433d7501ee99a44e6a558998091f84) minio: fix license change
* [`acec233f`](https://github.com/NixOS/nixpkgs/commit/acec233fcdca924e87e669ef548f7d0c24bd3ede) minio: set version variables with ldflags
* [`4c0441c0`](https://github.com/NixOS/nixpkgs/commit/4c0441c0b14250955bf4325c7299fa7640ceb30d) plasma-applet-volumewin7mixer: v25 -> v26
* [`3fbdcefe`](https://github.com/NixOS/nixpkgs/commit/3fbdcefe1d133f9a1d8a870bbd79eacb6ca6dc05) minio: 2021-05-11T23-27-41Z -> 2021-05-16T05-32-34Z
* [`7a1fbc38`](https://github.com/NixOS/nixpkgs/commit/7a1fbc38a4b538450ac0d42aec8a3e513b4d723e) hdhomerun-config-gui: 20200907 -> 20210224
* [`4ef47f32`](https://github.com/NixOS/nixpkgs/commit/4ef47f32d7a16b62682460e4330ac2863ef05712) eukleides: use $CC instead of hardcoded gcc
* [`f1d61e1b`](https://github.com/NixOS/nixpkgs/commit/f1d61e1b4bc38ff1b2434fc94884b28476c62436) imagemagick6: 6.9.12.8 -> 6.9.12-12
* [`a5092257`](https://github.com/NixOS/nixpkgs/commit/a5092257c4420c8ee026392f6e41764307163b8f) top-level: refactor for editorconfig-checker all-packages
* [`eb8890f3`](https://github.com/NixOS/nixpkgs/commit/eb8890f3bb59ecfb50e52250ec8ba2adb46d4e5e) jpeg-archive: fix darwin build
* [`601ceec2`](https://github.com/NixOS/nixpkgs/commit/601ceec28d443255f76c48499ec2c446d135a712) nixos-rebuild: Don’t reset the experimental features
* [`16ccf819`](https://github.com/NixOS/nixpkgs/commit/16ccf81982f27b609173f7f630f5a47d775b6c12) cardboard: 0.0.0-unstable=2021-01-21 -> 0.0.0+unstable=2021-05-10
* [`ec7ed128`](https://github.com/NixOS/nixpkgs/commit/ec7ed128a1ba4008b73d85d772312c09370ff609) stilo-themes: 3.36-3 -> 3.38-1
* [`2b7ed5de`](https://github.com/NixOS/nixpkgs/commit/2b7ed5deef3bee1a112d294204be1b3d21283693) trafficserver: remove joaquinito2051 as maintainer
* [`fe298804`](https://github.com/NixOS/nixpkgs/commit/fe29880472b296ff472f9c20772786e371533bce) cargo-c,rav1e: Remove myself as maintainer
* [`bc9098d6`](https://github.com/NixOS/nixpkgs/commit/bc9098d60d47b797d1943b98b16ac29437a37823) river: remove branwright1 as maintainer ([nixos/nixpkgs⁠#123266](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123266))
* [`da04ea77`](https://github.com/NixOS/nixpkgs/commit/da04ea775ea4823320b0e0349b20ad69b8743f6f) vimPlugins.lsp_signature-nvim: init at 2021-05-07
* [`805825cc`](https://github.com/NixOS/nixpkgs/commit/805825cc524058526e3a5b9d1583ba317319fe2a) pythonPackages.pyqt4: 4.12 -> 4.12.3
* [`de9e2ce4`](https://github.com/NixOS/nixpkgs/commit/de9e2ce42d7834cdc361cc8139ffb9b76643768d) yubikey-manager-qt: 1.1.5 -> 1.2.2 ([nixos/nixpkgs⁠#123118](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123118))
* [`bf7b9406`](https://github.com/NixOS/nixpkgs/commit/bf7b94061d734791254215c30d557400a55b879a) esbuild: 0.11.19 -> 0.11.23
* [`cf1db581`](https://github.com/NixOS/nixpkgs/commit/cf1db5812d09ca681eb51423315eae1a587908c9) osu-lazer: 2021.502.0 -> 2021.515.0
* [`7051dd78`](https://github.com/NixOS/nixpkgs/commit/7051dd78ff0790dd0d627d7fdc2648cfc3c3f13a) kdeltachat: unstable-2021-05-03 -> unstable-2021-05-16
* [`74b74b05`](https://github.com/NixOS/nixpkgs/commit/74b74b05550f258e9055b824eff49b15637dd917) river: add fortuneteller2k as maintainer ([nixos/nixpkgs⁠#123271](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123271))
* [`dfb2d52a`](https://github.com/NixOS/nixpkgs/commit/dfb2d52a78ef79157f8aad5c4deae18373cf52cb) angelscript: Make Darwin-compatible
* [`08ab7e10`](https://github.com/NixOS/nixpkgs/commit/08ab7e10f3b5bfa0a87df22f764179ccebf21707) go_2-dev: 2021-03-22 -> 2021-04-13
* [`2142f885`](https://github.com/NixOS/nixpkgs/commit/2142f885261a690a17a9e208b4cff270c6e3386a) nixos/containerd: sanitize StateDirectory and RuntimeDirectory
* [`7e310dd8`](https://github.com/NixOS/nixpkgs/commit/7e310dd8e82cbbaae9132756d7da9bf85ad10ab3) nixos/containerd: StartLimit* options must be in the unit-section
* [`0b95e8cb`](https://github.com/NixOS/nixpkgs/commit/0b95e8cbfaf1b00809cb713d8dfb76bdc2861102) conmon: 2.0.27 -> 2.0.28
* [`7f56f380`](https://github.com/NixOS/nixpkgs/commit/7f56f38051938bbfe9f16546ae830df15cc61ac6) wiiuse: Make Darwin-compatible
* [`f2a29c1e`](https://github.com/NixOS/nixpkgs/commit/f2a29c1ee93b9f0ab9077704f5e1699b964b1978) superTuxKart: Make Darwin-compatible
* [`81ffbb80`](https://github.com/NixOS/nixpkgs/commit/81ffbb808ac4dc8c8258285d9a7a0d7e8b76514f) zotero: 5.0.96 -> 5.0.96.2
* [`06741b34`](https://github.com/NixOS/nixpkgs/commit/06741b34d8d7a2805e07d23b6f201b8f1a6e63a7) hashcat: 6.1.1 -> 6.2.1 ([nixos/nixpkgs⁠#123256](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123256))
* [`1e85864c`](https://github.com/NixOS/nixpkgs/commit/1e85864c6f7afe8ba44ee0cde0ad29f9ab80c137) youtube-dl: 2021.04.26 -> 2021.05.16
* [`a5d04b89`](https://github.com/NixOS/nixpkgs/commit/a5d04b89fd5238f0e38ef87de4678e378761d67b) azure-cli: fix build
* [`24507013`](https://github.com/NixOS/nixpkgs/commit/245070134f670feab40696464ae63d733645befc) plantuml-server: 1.2020.14 -> 1.2021.6
* [`454df730`](https://github.com/NixOS/nixpkgs/commit/454df730b638d051e157b61950b328b389451589) gping: fix darwin build
* [`de658376`](https://github.com/NixOS/nixpkgs/commit/de658376785cf7120957f8adeeb70855ef405e6b) gptman: fix darwin build
* [`523572c9`](https://github.com/NixOS/nixpkgs/commit/523572c9f396f85ff2cdd02852e8e2f6d7b690f0) s3ql: 3.3.2 -> 3.7.2
* [`82f66a40`](https://github.com/NixOS/nixpkgs/commit/82f66a4050c1e2a3278b10d0594ef3cdcc16c2a6) handlr: fix darwin build
* [`40c346de`](https://github.com/NixOS/nixpkgs/commit/40c346de466d83a25d7750686c5b96ddfc6476c5) heimdall-gui: fix darwin build
* [`9716355b`](https://github.com/NixOS/nixpkgs/commit/9716355b45f47fc3069cc9c5dbedc50fdc4793cc) inform6: fix darwin build
* [`a5bff380`](https://github.com/NixOS/nixpkgs/commit/a5bff380e60bcb56ed69407e7e27b45385061007) krapslog: fix darwin build
* [`dc2efe76`](https://github.com/NixOS/nixpkgs/commit/dc2efe7680a1bb45dac415a5918acb744ef92a0e) libacr38u: fix darwin build
* [`2412b97e`](https://github.com/NixOS/nixpkgs/commit/2412b97e181b31338839122762fd7b41e10d74fe) nfstrace: fix build error
* [`195ee1e1`](https://github.com/NixOS/nixpkgs/commit/195ee1e14b6356f81f53505dc8a03875fc369df0) python3Packages.hsluv: init at 5.0.2
* [`ba2cac52`](https://github.com/NixOS/nixpkgs/commit/ba2cac52bdfbc8dd661104f94b68e56a16a941fb) python3Packages.Nikola: fix build
* [`a58b3274`](https://github.com/NixOS/nixpkgs/commit/a58b32743baedbf6cad6ce7ec4e7c99d69a414a6) vimPlugins.indent-blankline-nvim-lua: init at 2021-04-28
* [`2b467919`](https://github.com/NixOS/nixpkgs/commit/2b467919c1d53270a3a14431683b78ebb922b830) python3Packages.pyupgrade: 2.12.0 -> 2.16.0
* [`abd6f000`](https://github.com/NixOS/nixpkgs/commit/abd6f00001710347d56e14e1928876c166e2c9df) python3Packages.torchvision-bin: init at 0.9.1
* [`64bb7a00`](https://github.com/NixOS/nixpkgs/commit/64bb7a00ba2a71662017401aaf61684284b7c5e2) vimPlugins: update
* [`b0129813`](https://github.com/NixOS/nixpkgs/commit/b0129813017a9045db26b94e508d74bb502221b3) vimPlugins.todo-comments-nvim: init at 2021-05-16
* [`87399659`](https://github.com/NixOS/nixpkgs/commit/873996595cc920b561e27823e53f5eae240917d8) acl2: fix darwin build
* [`fb637b89`](https://github.com/NixOS/nixpkgs/commit/fb637b899a9b6ccb1cb47e5916a7c94b686c554a) python3Packages.behave: disable tests
* [`4db951e4`](https://github.com/NixOS/nixpkgs/commit/4db951e4e17cc36795adbfec1c930d1342c263e2) atinout: fix darwin build
* [`ce0cabb4`](https://github.com/NixOS/nixpkgs/commit/ce0cabb49d5bd4f4afca3ec040888f3bd65bb42a) numberstation: init at 0.4.0 ([nixos/nixpkgs⁠#122190](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122190))
* [`8c63ac78`](https://github.com/NixOS/nixpkgs/commit/8c63ac789359e1a0a7199229809bdd0673752805) vimPlugins: generate an overlay
* [`0a9e9c09`](https://github.com/NixOS/nixpkgs/commit/0a9e9c09659dff66f40829d5161b8b71931dbeee) pkgs/misc/vim-plugins/update.py: add logging
* [`1372b429`](https://github.com/NixOS/nixpkgs/commit/1372b429cca63f5e63ba4d942944730475cea336) cataclysm-dda-git: 2019-11-22 -> 2020-12-09
* [`f269c570`](https://github.com/NixOS/nixpkgs/commit/f269c57097d4b2b56556d5393d8248659dc40fc3) vimPlugins: update
* [`42bb7e9e`](https://github.com/NixOS/nixpkgs/commit/42bb7e9e4ceb2c2afe03f9725da4a7566c18c5d6) clpm: fix darwin build ([nixos/nixpkgs⁠#123029](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123029))
* [`f867062e`](https://github.com/NixOS/nixpkgs/commit/f867062ef9e2b862f397d7a38f4899667a7be2d3) erlangR21: 21.3.8.22 -> 21.3.8.23
* [`a2f3a639`](https://github.com/NixOS/nixpkgs/commit/a2f3a63953b6fc0812cca363accbc5d4176f1f02) restore buildMix and its bootstrapper ([nixos/nixpkgs⁠#122374](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122374))
* [`ea6d3aa1`](https://github.com/NixOS/nixpkgs/commit/ea6d3aa18f516a703128ac4967c4782100993031) cargo-flash: 0.8.0 -> 0.10.1 ; fix darwin build ([nixos/nixpkgs⁠#123210](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123210))
* [`7bd65d54`](https://github.com/NixOS/nixpkgs/commit/7bd65d54f772589bf321e25b605166bf626cc131) treewide: remove nand0p as maintainer
* [`ba0da8a0`](https://github.com/NixOS/nixpkgs/commit/ba0da8a076e94ff1119cd46fe58d12c54f9e978b) virtualbox: 6.1.18 -> 6.1.22
* [`ee2cf163`](https://github.com/NixOS/nixpkgs/commit/ee2cf16385eee10ea27bbc2b57cadfe036027a1e) ferdi: Update license to asl20
* [`6e80cf82`](https://github.com/NixOS/nixpkgs/commit/6e80cf82383951a22ef78ba1daafbce9825eb33f) meme: rename to meme-image-generator, unstable-2020-05-28 -> 1.0.1 ([nixos/nixpkgs⁠#120079](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/120079))
* [`51166f90`](https://github.com/NixOS/nixpkgs/commit/51166f90c694785975c2b0f48a20dd35663bb1fa) nixos/nginx: add option to change proxy timeouts
* [`3ed9ed81`](https://github.com/NixOS/nixpkgs/commit/3ed9ed81abed7191ec6f77550778f7f8e580e187) gerbera: 1.8.0 -> 1.8.1
* [`fd899bd0`](https://github.com/NixOS/nixpkgs/commit/fd899bd0804be2473fc29a436e5464b13b4004b4) kodi: update git tag
* [`814d9bac`](https://github.com/NixOS/nixpkgs/commit/814d9bac114dfa89321954767db376d7f2ec053f) erlang-ls: add erlang to buildInputs
* [`644fbb4b`](https://github.com/NixOS/nixpkgs/commit/644fbb4b8c2d18c6873257f3bd6a968ce5918027) vimPlugins.vim-easyescape: init at 2020-11-22
* [`79d252d2`](https://github.com/NixOS/nixpkgs/commit/79d252d26c492e9c64258be41fe2e110fa7a7679) vimPlugins.edge: init at 2021-05-08
* [`22437644`](https://github.com/NixOS/nixpkgs/commit/22437644f997050b4077fe52d5bf8e41434f26e6) home-assistant: disable failing test in mobile app component
* [`aba7bc98`](https://github.com/NixOS/nixpkgs/commit/aba7bc983f9f487ea64a5d47bd1c2a33fdf65c11) openvino: move unzip to nativeBuildInputs
* [`682578af`](https://github.com/NixOS/nixpkgs/commit/682578af423e08953f38990b6cc7a9a4cff07c71) openjdk: move unzip to nativeBuildInputs
* [`75c67d6b`](https://github.com/NixOS/nixpkgs/commit/75c67d6be96c5a511b78282d0ef711bc7deacf59) torchat: use fetchFromGitHub
* [`c5a669d3`](https://github.com/NixOS/nixpkgs/commit/c5a669d3f7c9b9695f6e19f5b035a30a33576b1f) treewide: remove unzip where not needed
* [`65f7d4a1`](https://github.com/NixOS/nixpkgs/commit/65f7d4a1622189774aceea342acff6d3ab6faa57) apprise: 0.9.1 -> 0.9.3
* [`66201e2c`](https://github.com/NixOS/nixpkgs/commit/66201e2c1de3b385f79286c956a15f5b6d227126) cntk: fix build
* [`85c40fb0`](https://github.com/NixOS/nixpkgs/commit/85c40fb0f85b89eb273e2cc47124200877782967) chezmoi: 2.0.11 -> 2.0.12
* [`18b051fd`](https://github.com/NixOS/nixpkgs/commit/18b051fde589b77fabff5cbb984aa3a5769bf357) scite: 4.0.5 -> 5.0.2
* [`20467ad0`](https://github.com/NixOS/nixpkgs/commit/20467ad058ade328d95aac43307dc1eceedfa56b) findomain: 4.2.1 -> 4.3.0
* [`e906410c`](https://github.com/NixOS/nixpkgs/commit/e906410c9a6a8bcbad3ef8beeea963bad24afc0b) solc: remove 0.7 release
* [`74e27e22`](https://github.com/NixOS/nixpkgs/commit/74e27e2236429cdf5c35eb0ff9b489aaab52b6c3) slade-git: 3.1.2 -> 3.2.0
* [`28b48756`](https://github.com/NixOS/nixpkgs/commit/28b48756d5d2da3bb659f11a4eb0b1231a47d1af) hetzner-kube: fix darwin build
* [`371d80c4`](https://github.com/NixOS/nixpkgs/commit/371d80c468a3cf7343cab49b780d5e08d40f6b37) libical: fix darwin build
* [`04aa238c`](https://github.com/NixOS/nixpkgs/commit/04aa238c1a700680f19ecbaaae5e3012352b5342) gnucap: broken on darwin
* [`329ec3d1`](https://github.com/NixOS/nixpkgs/commit/329ec3d17cd8392a3e01e5ac35dbbe114a719e5c) influxdb2: 2.0.2 -> 2.0.6
* [`f37710e9`](https://github.com/NixOS/nixpkgs/commit/f37710e94ed4381f5a85a1e47fbc35c002c12303) influxdb2: fix darwin build
* [`76417690`](https://github.com/NixOS/nixpkgs/commit/76417690557857f31f6909acb9b928d6f1f0e9de) nixos/fancontrol: back to running as root
* [`eec3738f`](https://github.com/NixOS/nixpkgs/commit/eec3738f4c033b38b4ddd542f796418955258116) hsetroot: fix darwin build
* [`f2dd3eac`](https://github.com/NixOS/nixpkgs/commit/f2dd3eac0e7b7d7b98c53895a162f28971e4e3bb) rebar3-nix: init at 0.1.0
* [`34ea3cd9`](https://github.com/NixOS/nixpkgs/commit/34ea3cd906ae88e36561aa83f28bf9600745cbdb) rebar3: add updateScript
* [`9541ad60`](https://github.com/NixOS/nixpkgs/commit/9541ad60e1f3e560bae0fe348266aa6642f9b412) gitkraken: 7.5.5 -> 7.6.0
* [`b5f84d83`](https://github.com/NixOS/nixpkgs/commit/b5f84d830b514435c5e37928ffce0300b8170d88) doc: Add anchors to dhall sections
* [`354e005d`](https://github.com/NixOS/nixpkgs/commit/354e005d6c7a910fd009b90360545fed8ddba4a2) nixos/dconf: fix d-bus activation
* [`915abd3f`](https://github.com/NixOS/nixpkgs/commit/915abd3f08a06e02e06c2e6769749db4c9c38df4) coqPackages.aac-tactics: init
* [`8ff27c0c`](https://github.com/NixOS/nixpkgs/commit/8ff27c0c094ca9d69f92f731116fb00476d1439d) coqPackages.relation-algebra: init
* [`f2e899e0`](https://github.com/NixOS/nixpkgs/commit/f2e899e01a02e10ae0affd879bd445aa57eb05a8) nextdns: 1.10.1 -> 1.11.0
