### PR TITLE
niv home-manager: update 23769994 -> f9e45390

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "23769994e8f7b212d9a257799173b120ed87736b",
-        "sha256": "13vw6dwnva6922ayzj0b0gpwgzz14202llv37pr8w8qfrrg83xxk",
+        "rev": "f9e45390deced72bc7cc0b75d3a922aa10a33e08",
+        "sha256": "14z5d9rlqcp35d4lg7wlvkqzydkhc8qvpjlf0bnn9gkng5wia2w9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/23769994e8f7b212d9a257799173b120ed87736b.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f9e45390deced72bc7cc0b75d3a922aa10a33e08.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@23769994...f9e45390](https://github.com/nix-community/home-manager/compare/23769994e8f7b212d9a257799173b120ed87736b...f9e45390deced72bc7cc0b75d3a922aa10a33e08)

* [`77188bcd`](https://github.com/nix-community/home-manager/commit/77188bcd6e2c6c7a99253b36f08ed7b65f2901d2) services/kanshi: add module example ([nix-community/home-manager⁠#2008](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2008))
* [`01ec2aae`](https://github.com/nix-community/home-manager/commit/01ec2aaefeeed45764841cf42e1de56e01209e66) systemd: revert systemd-environment-generator usage for environment variables ([nix-community/home-manager⁠#2001](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2001))
* [`6a471f1b`](https://github.com/nix-community/home-manager/commit/6a471f1b1111408d541caf04e64650813bfb22ac) i3,sway: add option for default workspace ([nix-community/home-manager⁠#2002](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2002))
* [`b0688a63`](https://github.com/nix-community/home-manager/commit/b0688a631b63d6a37425f528c1cf1c4ceea9edd5) i3status-rust: fix bars.block example ([nix-community/home-manager⁠#2016](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2016))
* [`794d08a1`](https://github.com/nix-community/home-manager/commit/794d08a1d8647d04d32a16c25944671436f38db2) home-environment: generate checked activation script
* [`e9b7d12e`](https://github.com/nix-community/home-manager/commit/e9b7d12e06dd353334de98e0cbd9cd8e19d7d510) bash: generate files using writeShellScript
* [`adbabcd0`](https://github.com/nix-community/home-manager/commit/adbabcd0a04cdb78c8599ca33d115ee0320b3455) gtk: fix gtk2-basic-config test
* [`f9e45390`](https://github.com/nix-community/home-manager/commit/f9e45390deced72bc7cc0b75d3a922aa10a33e08) scmpuff: use pkgs.scmpuff
