### PR TITLE
niv nixpkgs-fmt: update a893d437 -> 61cdb8a3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "a893d437317d4a6ea45be0fb65e804482e397b23",
-        "sha256": "1ikf55xv6jgrbhknq6vfmnnbsk4rxi9p25ir2rkagln4ghfl6n83",
+        "rev": "61cdb8a3ed4bdee918c7ef241717c65edef21f65",
+        "sha256": "0q4smnya3nai4liin1g09wlc0nvk176q0j1zdai3wqnfdj76kqwy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/a893d437317d4a6ea45be0fb65e804482e397b23.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/61cdb8a3ed4bdee918c7ef241717c65edef21f65.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@a893d437...61cdb8a3](https://github.com/nix-community/nixpkgs-fmt/compare/a893d437317d4a6ea45be0fb65e804482e397b23...61cdb8a3ed4bdee918c7ef241717c65edef21f65)

* [`327832f9`](https://github.com/nix-community/nixpkgs-fmt/commit/327832f984624b7db0b757c2d27f0322d61a1e4c) fix multiline comment ([nix-community/nixpkgs-fmt⁠#245](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/nixpkgs-fmt/issues/245))
* [`16287c78`](https://github.com/nix-community/nixpkgs-fmt/commit/16287c7873f7e4ae7831a2d72566cb9fdf76ffda) build: replace flake-compat with flake.lock.nix
* [`faa57845`](https://github.com/nix-community/nixpkgs-fmt/commit/faa578450eecae4d74253092daa72244e57a1f95) cargo: fix the rowan dependency
* [`35635d6f`](https://github.com/nix-community/nixpkgs-fmt/commit/35635d6f5c3442c149a12e6d907eaf74715ca80a) nix: replace nixpkgs-mozilla with fenix
* [`9d4eb4b4`](https://github.com/nix-community/nixpkgs-fmt/commit/9d4eb4b4c759297f6c85a675cbcd6dee1f160bba) nix: make the shell buildable
* [`e773b2c9`](https://github.com/nix-community/nixpkgs-fmt/commit/e773b2c955cebfc7475122039e30df4f1e71c3af) README: fix installation ([nix-community/nixpkgs-fmt⁠#246](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/nixpkgs-fmt/issues/246))
* [`6dfed5c2`](https://github.com/nix-community/nixpkgs-fmt/commit/6dfed5c2efae26d6d33d8131a5918ec46fe779be) default.nix: keep back-compat
* [`61cdb8a3`](https://github.com/nix-community/nixpkgs-fmt/commit/61cdb8a3ed4bdee918c7ef241717c65edef21f65) default.nix: composition > inheritance
