### PR TITLE
niv powerlevel10k: update 8d1daa4e -> 9c034101

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "8d1daa4e6340b1689bf951730489bc64c52220c7",
-        "sha256": "0bm0dd4lb9kwv3xl6lk0wyb0fqq83gs8kl9111qs5ybavwcxlnnr",
+        "rev": "9c034101fe3cec1e2edb8e07c32a3e6dba9afaee",
+        "sha256": "1sr7sdqyschslmdi7q7rhn2g04fc3kghavpbgc0r67brvkdv05m4",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/8d1daa4e6340b1689bf951730489bc64c52220c7.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/9c034101fe3cec1e2edb8e07c32a3e6dba9afaee.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@8d1daa4e...9c034101](https://github.com/romkatv/powerlevel10k/compare/8d1daa4e6340b1689bf951730489bc64c52220c7...9c034101fe3cec1e2edb8e07c32a3e6dba9afaee)

* [`f9246461`](https://github.com/romkatv/powerlevel10k/commit/f924646194e95c9ef0423d0e6c10cf41cc7bf6b1) add P9K_IP_{RX,TX}_BYTES_DELTA to the list of parameters available within POWERLEVEL9K_IP_CONTENT_EXPANSION ([romkatv/powerlevel10k⁠#1392](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1392))
* [`9c034101`](https://github.com/romkatv/powerlevel10k/commit/9c034101fe3cec1e2edb8e07c32a3e6dba9afaee) Add xplr segment ([romkatv/powerlevel10k⁠#1396](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1396))
