### PR TITLE
niv spacemacs: update 060f5585 -> 37c8669d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "060f558530c9fce1aa7ac4751ede5c94387f3b09",
-        "sha256": "11bvwwc2x48bjj0sw2xm3ayh9mihqcn2796p0jl1l4wjwrhpac0w",
+        "rev": "37c8669d3604b9f2e8de378cca9836019a95360a",
+        "sha256": "0qixjqv4qwv9hymm0zl0l5hv1qy5yvzrmlqjzqqby3c3sycy16hk",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/060f558530c9fce1aa7ac4751ede5c94387f3b09.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/37c8669d3604b9f2e8de378cca9836019a95360a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@060f5585...37c8669d](https://github.com/syl20bnr/spacemacs/compare/060f558530c9fce1aa7ac4751ede5c94387f3b09...37c8669d3604b9f2e8de378cca9836019a95360a)

* [`346b7a8a`](https://github.com/syl20bnr/spacemacs/commit/346b7a8a12cce618c450deef866cdf48dd941e27) [json] Fix functions optionally working on regions
* [`76133f86`](https://github.com/syl20bnr/spacemacs/commit/76133f86f728c64023b37c58f8e0550c2134367e) [csv] Make tsv-mode inherit csv-mode's leader key bindings ([syl20bnr/spacemacs⁠#14763](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14763))
* [`104ce943`](https://github.com/syl20bnr/spacemacs/commit/104ce94389561f22a6e82069e04d582b6ff83065) [json] Fix "void variable" in init-json-navigator
* [`f8301056`](https://github.com/syl20bnr/spacemacs/commit/f8301056c964fd49a9dfb39151b30c0fd876d2e3) Update python layer to use pylsp (new maintained fork of pyls) ([syl20bnr/spacemacs⁠#14772](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14772))
* [`5c214e51`](https://github.com/syl20bnr/spacemacs/commit/5c214e51605c03a094e655c302bb36ddccda55bb) documentation formatting: Thu May 13 22:33:42 UTC 2021 ([syl20bnr/spacemacs⁠#14773](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14773))
* [`2c661ab4`](https://github.com/syl20bnr/spacemacs/commit/2c661ab49d5affd1762f12fe7517aee2c897902a) Ensure hjkl bindings are respected during company search/filter ([syl20bnr/spacemacs⁠#14768](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14768))
* [`80e2fd42`](https://github.com/syl20bnr/spacemacs/commit/80e2fd42797dda3559a53ab201261ba326fd29a9) [python] Add instruction to install pyls-memestra
* [`fef9ba9e`](https://github.com/syl20bnr/spacemacs/commit/fef9ba9e183083486e0098ef8511731ebae81274) [exwm] Remove manual XF86 keybindings ([syl20bnr/spacemacs⁠#14770](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14770))
* [`8e3ab24c`](https://github.com/syl20bnr/spacemacs/commit/8e3ab24c36285614973688e09e3cb6da8f53b403) fixup! [syl20bnr/spacemacs⁠#14770](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14770)
* [`bcfd7a3f`](https://github.com/syl20bnr/spacemacs/commit/bcfd7a3fe8d1b549737577edbce0ce86cc851762) [home] Show notes preview, with full note button
* [`639160ed`](https://github.com/syl20bnr/spacemacs/commit/639160ed9535c934b4dc425a45a7115f2777f009) Evilify xref--xref-buffer-mode
* [`6d20f923`](https://github.com/syl20bnr/spacemacs/commit/6d20f923bc31c1fc3e7d98000725f529a4ea6115) Not using "call-interactively" result in error
* [`54cb40b9`](https://github.com/syl20bnr/spacemacs/commit/54cb40b9cada3fd30a29414e12a2b1389131eaa5) [helm] Add `S-RET` keybinding for helm modes to open in other window
* [`846a5c7c`](https://github.com/syl20bnr/spacemacs/commit/846a5c7c4d13aefe13ca131df90d124fee53c64e) [home] Fix full release note cursor position
* [`917ebbc4`](https://github.com/syl20bnr/spacemacs/commit/917ebbc4cbe4179e6ebc0a3f12ee545137be0662) [version-control] Show bound but unlisted VCS TS key: d
* [`a5d05c8f`](https://github.com/syl20bnr/spacemacs/commit/a5d05c8fac12dc373ce1f2fb8ebde56663d89247) [default] Do not take y as yes for prompts by default
* [`f51731bf`](https://github.com/syl20bnr/spacemacs/commit/f51731bf98284d52967a1054635ed514e34de0dc) [default] Fix the condition for dotspacemacs-use-SPC-as-y
* [`37c8669d`](https://github.com/syl20bnr/spacemacs/commit/37c8669d3604b9f2e8de378cca9836019a95360a) [parinfer] Allow to disable auto-installation
