### PR TITLE
niv nixpkgs: update f2e899e0 -> fd26001e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f2e899e01a02e10ae0affd879bd445aa57eb05a8",
-        "sha256": "1g3s4a9r6lx25w32jclnqkr9s27335m6zknmakc8f93hzjnihan4",
+        "rev": "fd26001eadb620de4d08e98121ab71ff99fed066",
+        "sha256": "1dd5lm491skpzlmsqvdwcmqr49il32yd1nly0n52grvjf5kf58na",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f2e899e01a02e10ae0affd879bd445aa57eb05a8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/fd26001eadb620de4d08e98121ab71ff99fed066.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f2e899e0...fd26001e](https://github.com/nixos/nixpkgs/compare/f2e899e01a02e10ae0affd879bd445aa57eb05a8...fd26001eadb620de4d08e98121ab71ff99fed066)

* [`6a4ef962`](https://github.com/NixOS/nixpkgs/commit/6a4ef962d352284696260986b9add804fdf42d8e) signal-desktop: 5.2.0 -> 5.2.1
* [`72f225ca`](https://github.com/NixOS/nixpkgs/commit/72f225cad421242e7ac3767647c0239d22c6c755) git-aggregator: init at 1.8.1
* [`17baa1a9`](https://github.com/NixOS/nixpkgs/commit/17baa1a9be1f79f384bc8591cf30847bea5067b6) pythonPackages.pykeepass: 4.0.0 -> 4.0.1
* [`e1a8e856`](https://github.com/NixOS/nixpkgs/commit/e1a8e856316f3498176923ace906591a0e420845) nixos/atop: Wait for conditions
* [`9cb76c21`](https://github.com/NixOS/nixpkgs/commit/9cb76c21ee134b23e72b09d0043e94ab89f83338) nixos/atop: Add defaultText for types.package options
* [`3abe7e12`](https://github.com/NixOS/nixpkgs/commit/3abe7e12e23fc4f3c4cd3ed4e2e74eb2159b7898) eksctl: 0.48.0 -> 0.51.0
* [`e54c43f8`](https://github.com/NixOS/nixpkgs/commit/e54c43f8f159eaca24332057a255dc34322b1618) vimPlugins: update
* [`dcc83cd0`](https://github.com/NixOS/nixpkgs/commit/dcc83cd07ac254b2e2944abba730ed4c345d5983) vimPlugins.telescope-dap-nvim: init at 2021-03-26
* [`757de5a4`](https://github.com/NixOS/nixpkgs/commit/757de5a432a93251355a95e483f304902221bb68) vimPlugins.scrollbar-nvim: init at 2020-09-28
* [`0eb12af2`](https://github.com/NixOS/nixpkgs/commit/0eb12af27942bde9032498750c9a0edf6929db22) vimPlugins.nvim-dap-ui: init at 2021-05-21
* [`8c2a60ad`](https://github.com/NixOS/nixpkgs/commit/8c2a60ad5af4fe07b7f426be4694f52791a031cc) vimPlugins.pears-nvim: init at 2021-05-21
* [`9b0fca29`](https://github.com/NixOS/nixpkgs/commit/9b0fca29f9d11cd1ef2b57e575e3bca7fea39dde) vimPlugins.nvim-treesitter-pyfold: init at 2021-05-20
* [`fdaf66b6`](https://github.com/NixOS/nixpkgs/commit/fdaf66b6f0198bd91b7ec014665f7975446ec681) vimPlugins.hiPairs: init at 2020-12-10
* [`1941e7c9`](https://github.com/NixOS/nixpkgs/commit/1941e7c9968d013464eae80256a75377a67885f7) vimPlugins.conflict-marker-vim: init at 2020-09-23
* [`3147a710`](https://github.com/NixOS/nixpkgs/commit/3147a7104d15d978515caad171e38ad8c5fae61b) xpra: 4.1.3 -> 4.2
* [`32fdb916`](https://github.com/NixOS/nixpkgs/commit/32fdb916a12536517412171baa893b573940f8b9) libcgroup: 0.41 -> 0.42.2
* [`4509181d`](https://github.com/NixOS/nixpkgs/commit/4509181d6c3eeafd6c4f032926f0a6d01a011f93) cereal: add patch for CVE-2020-11105 ([nixos/nixpkgs⁠#121574](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121574))
* [`7a28fcef`](https://github.com/NixOS/nixpkgs/commit/7a28fcef8458cd732008f7b42d535d1465d30096) python3Packages.jupyter_server: disable failing tests on darwin
* [`eb01e519`](https://github.com/NixOS/nixpkgs/commit/eb01e5193860a51e5d581345a993a4214e842690) ldgallery: fix darwin build
* [`3ddabfb9`](https://github.com/NixOS/nixpkgs/commit/3ddabfb9c353acb02a743e0df3cab6975e308886) influxdb: 1.8.5 -> 1.8.6 ([nixos/nixpkgs⁠#123973](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123973))
* [`f2996998`](https://github.com/NixOS/nixpkgs/commit/f29969988d2744435e820bf0df36919ac9980dbc) eid-mw: 4.4.27 -> 5.0.21 ([nixos/nixpkgs⁠#122247](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/122247))
* [`20f59577`](https://github.com/NixOS/nixpkgs/commit/20f595774df8527d8fbb88d0dd456745254a625c) cmakeWithQt4Gui: add a throw-alias
* [`f7d9b201`](https://github.com/NixOS/nixpkgs/commit/f7d9b2016cd4bd81e08cffafd53985c2454fa399) lemonbar-xft: 2016-02-17 -> 2020-09-10, cleanup
* [`741f33da`](https://github.com/NixOS/nixpkgs/commit/741f33da138f6013f53c02385cb81f2d92bfe6f9) xh: 0.9.2 -> 0.10.0
* [`6187a1f5`](https://github.com/NixOS/nixpkgs/commit/6187a1f53b75621e605d99e170fbeb5e1561902f) Update pkgs/misc/vim-plugins/generated.nix
* [`cd4780fa`](https://github.com/NixOS/nixpkgs/commit/cd4780fab4fd0652cc55109cca5a8e9e893f603d) maintainers: rename metadark -> kira-bruneau ([nixos/nixpkgs⁠#124035](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124035))
* [`dc50511a`](https://github.com/NixOS/nixpkgs/commit/dc50511ad1a311a9ad4193636b335ccec4d4d2d2) i3-gaps: use pname and version, fetchFromGitHub, cleanup
* [`31aab8c9`](https://github.com/NixOS/nixpkgs/commit/31aab8c980225348e154b77c0d1f591f78523f2e) cairomm_1_16: 1.16.0 -> 1.16.1
* [`fc4f549d`](https://github.com/NixOS/nixpkgs/commit/fc4f549d394b27e9ebbb5139711300d4ba586b57) abseil-cpp: 20200923.3 -> 20210324.1
* [`a6d48f9c`](https://github.com/NixOS/nixpkgs/commit/a6d48f9c2a8ad80a576221b7e49e0d2933fb1e75) or-tools: 8.1 -> 9.0
* [`5fe63fc3`](https://github.com/NixOS/nixpkgs/commit/5fe63fc3fbf66fbe3eb0d5448e79c140380ad206) rippled: fix hashes
* [`7c1d8636`](https://github.com/NixOS/nixpkgs/commit/7c1d8636dd990e4763659cc1a7b5134c2a4637b8) st: support cross-compilation ([nixos/nixpkgs⁠#123722](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123722))
* [`0331c3ec`](https://github.com/NixOS/nixpkgs/commit/0331c3ecf479d03583c5caef857ede429d828806) lemonbar: use fetchFromGithub, cleanup
* [`7c6c48ab`](https://github.com/NixOS/nixpkgs/commit/7c6c48ab9c078fdcb59616cc037e2df293e51db5) gitlab-runner: fix wrong hash ([nixos/nixpkgs⁠#124033](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124033))
* [`c6bf23a1`](https://github.com/NixOS/nixpkgs/commit/c6bf23a12ea93a8d21daa7e3406f46379d6241d3) glibmm_2_68: 2.68.0 -> 2.68.1
* [`8fb12dea`](https://github.com/NixOS/nixpkgs/commit/8fb12deae506eba756fde843ccb084a02fb3018c) gnome.quadrapassel: 3.38.1 → 40.1
* [`c912d30f`](https://github.com/NixOS/nixpkgs/commit/c912d30f6505fa3ceb0a1a1cd28f66086a386101) gnome.tali: 40.0 → 40.1
* [`fc8eefe2`](https://github.com/NixOS/nixpkgs/commit/fc8eefe2fee759434282d6311aca59b17fc63f41) shattered-pixel-dungeon: 0.9.2 -> 0.9.2b
* [`388a1962`](https://github.com/NixOS/nixpkgs/commit/388a1962470e1e48e60ff2905f94dd5860897113) pythonPackages.vdf: 3.3 → 3.4
* [`119a3e6a`](https://github.com/NixOS/nixpkgs/commit/119a3e6a351d71da38bead931d73355a368eca5d) bunyan-rs: init at 0.1.2
* [`1241d9fa`](https://github.com/NixOS/nixpkgs/commit/1241d9fae3451b824506277174b6053a379f4db7) arpack: fix libblas.dylib's path on darwin
* [`73df171f`](https://github.com/NixOS/nixpkgs/commit/73df171f26f426d1e2201e04ad0a7fa556eca17b) igraph: fix libblas.dylib's path on darwin
* [`2d959454`](https://github.com/NixOS/nixpkgs/commit/2d9594542048490cf2206386f85a03e49420bf52) sublime3: remove updateScript
* [`79e67544`](https://github.com/NixOS/nixpkgs/commit/79e675444caf7b491b2c0d25277b046d3f6d8e04) nixos/matrix-synapse: protect created files
* [`217b14cb`](https://github.com/NixOS/nixpkgs/commit/217b14cb2fd722a779fe9787c6f781ffcda9cdc0) python3Packages.token-bucket: init at 0.2.0
* [`2d9558b3`](https://github.com/NixOS/nixpkgs/commit/2d9558b33be02257e5b13876efb5203a679485b2) pinnwand: 1.2.3 -> 1.3.0
* [`6a3d82e4`](https://github.com/NixOS/nixpkgs/commit/6a3d82e43367808f67e17b67764f9ba0dec0fd1d) sublime4: init at 4107
* [`c47425a2`](https://github.com/NixOS/nixpkgs/commit/c47425a230522a96650d8c4f41d6483253018742) sambamba: fix darwin build
* [`18e4425e`](https://github.com/NixOS/nixpkgs/commit/18e4425e23f85a7ecf56a3e7083664ef97ef74fa) reproxy: fix darwin build
* [`9201ef97`](https://github.com/NixOS/nixpkgs/commit/9201ef9749a86a3fd92cfadae1c33c184b46cbe1) texlab: 3.0.0 → 3.0.1 ([nixos/nixpkgs⁠#124053](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124053))
* [`25570942`](https://github.com/NixOS/nixpkgs/commit/255709420269fcd57392824ee43f2b0638f3de5d) nyxt: v2_pre-release-7 -> 2.0.0 ([nixos/nixpkgs⁠#124024](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124024))
* [`8664c2c7`](https://github.com/NixOS/nixpkgs/commit/8664c2c7431a04d1ef88000a12c8498847521892) nixos/cinnamon: add polkit_gnome to fix [nixos/nixpkgs⁠#124062](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124062)
* [`eca2b053`](https://github.com/NixOS/nixpkgs/commit/eca2b053544e92ba07ae31a6178c19a54c210a64) nixos/cinnamon: add cinnamon-translations to systemPackages
* [`425ac82c`](https://github.com/NixOS/nixpkgs/commit/425ac82c146758f9508b660f9892007099133e99) cinnamon.cinnamon-common: use cinnamon-translations
* [`eac85651`](https://github.com/NixOS/nixpkgs/commit/eac85651a3a44c5de3c024bc098fec2991903cd8) cinnamon.cinnamon-control-center: use cinnamon-translations
* [`77c27b67`](https://github.com/NixOS/nixpkgs/commit/77c27b6715531a3fc34fbcff3b340c55c0fd93f2) cinnamon.cinnamon-session: use cinnamon-translations
* [`4a365124`](https://github.com/NixOS/nixpkgs/commit/4a3651243121222a8729c0b8be40fd23f37766de) cinnamon.cinnamon-settings-daemon: use cinnamon-translations
* [`56dbdba0`](https://github.com/NixOS/nixpkgs/commit/56dbdba0cc9e0a7f33417837246484a1815091ce) cinnamon.nemo: use cinnamon-translations
* [`0197f1dc`](https://github.com/NixOS/nixpkgs/commit/0197f1dc4198e79efed554a901d9fdf81551abb8) pythonPackages: Add aliases :tada:
* [`d6ff646b`](https://github.com/NixOS/nixpkgs/commit/d6ff646b3f44b046326d9108546e033c16dac8d3) pythonPackages.smart_open: rename to smart-open
* [`939c4c1c`](https://github.com/NixOS/nixpkgs/commit/939c4c1cbd7f2626ce8f571d32334578d38cf95c) python-packages: add aliases for google_api_python_client, googleapis_common_protos
* [`024243ba`](https://github.com/NixOS/nixpkgs/commit/024243bac4612c62ef5be676818ed2465edae27f) php74.extensions.iconv: fix error signalling
* [`ea5726ae`](https://github.com/NixOS/nixpkgs/commit/ea5726aefeb5731ff3705b33ddbc86cded976ae3) lite: fix build error
* [`4cbb2040`](https://github.com/NixOS/nixpkgs/commit/4cbb20402a88abee9a68b53a8786df5af87b4101) qtwebengine: only set -webengine-webrtc-pipewire with qt >= 5.15
* [`5b511ca6`](https://github.com/NixOS/nixpkgs/commit/5b511ca6f33ac0a5b0eda435e05aa4465d1ee79c) python3Packages.pyvex: fix build for darwin
* [`59e5ff4b`](https://github.com/NixOS/nixpkgs/commit/59e5ff4b29a8091135938d2145df9a7b2ed3c11e) nixos/botamusique: init
* [`d210ed99`](https://github.com/NixOS/nixpkgs/commit/d210ed99c4461c4d11f7a2a02a4da2cfe41616af) nixos/tests/botamusique: init
* [`f79c1d1c`](https://github.com/NixOS/nixpkgs/commit/f79c1d1c3e85a97bc2aa45dcd3ab626011d954fb) botamusique: add passthru test
* [`f05a2c22`](https://github.com/NixOS/nixpkgs/commit/f05a2c22cf7688177bf100667e5dc971a7876be3) botamusique: unstable-2021-03-13 -> unstable-2021-05-19
* [`bafd6631`](https://github.com/NixOS/nixpkgs/commit/bafd6631da895959976d1a5771f639a22c4b80e1) python3Packages.pymumble: 1.6 -> 1.6.1
* [`bd441a13`](https://github.com/NixOS/nixpkgs/commit/bd441a13398166bbebcb788ff6191a4e3af770c6) liblinphone: 4.5.15 -> 4.5.17
* [`31601a59`](https://github.com/NixOS/nixpkgs/commit/31601a5977f7bf765ea4b6e3fc99ac10f5e9be4a) python3Packages.aiohomekit: 0.2.61 -> 0.2.62
* [`1693374d`](https://github.com/NixOS/nixpkgs/commit/1693374dbdc6b71052c7f40c097fa328b2b3f8a8) synergy: 1.11.1 -> 1.13.1.41 ([nixos/nixpkgs⁠#123359](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123359))
* [`740c34ac`](https://github.com/NixOS/nixpkgs/commit/740c34ac9fd4e53640d15afb07c35452792987fc) qvge: 0.6.2 → 0.6.3
* [`b5251f59`](https://github.com/NixOS/nixpkgs/commit/b5251f59ad5ea5b3ccea02f6cf1f0a870a19245b) libavif: 0.9.0 -> 0.9.1
* [`ff1ded3e`](https://github.com/NixOS/nixpkgs/commit/ff1ded3e2047268a55d3443459cda01cf9242e45) 21.11 is Porcupine!
* [`6c148519`](https://github.com/NixOS/nixpkgs/commit/6c14851943fe55da9df88a502d1e1fe2271d9666) nixos/doc: add md-to-db.sh, convert "Building Your Own NixOS CD" to CommonMark
* [`a67febac`](https://github.com/NixOS/nixpkgs/commit/a67febac45f8b9798a138b2fd59bd921c148bf17) CODEOWNERS: add ryantm to /nixos/doc
* [`75014679`](https://github.com/NixOS/nixpkgs/commit/7501467903faa3de62f6a45d5ee2fda35154b8a2) nixos/doc: convert "Contributing to this manual" to CommonMark
* [`6543c613`](https://github.com/NixOS/nixpkgs/commit/6543c61311c0397775253dd3d7f1f41154fc6189) nixos/doc: add 21.11 release notes stub
* [`2b993783`](https://github.com/NixOS/nixpkgs/commit/2b993783de9f51afb102e39128cbaf48ed15cb27) lynis: 3.0.3 -> 3.0.4
* [`f93f0e72`](https://github.com/NixOS/nixpkgs/commit/f93f0e72e9ef423ed591951030f08cafd209e637) iso-image: Force gfxmode
* [`15eaed07`](https://github.com/NixOS/nixpkgs/commit/15eaed0718515db3f2fa7d4ed71676e6069d3fb5) iso-image: change date on all files
* [`c9bb054d`](https://github.com/NixOS/nixpkgs/commit/c9bb054dd68964b0eb9a38c51bdf824bfb212fc7) iso-image: unqualified root → ($root)
* [`20b023b5`](https://github.com/NixOS/nixpkgs/commit/20b023b5ea63a6513a4dce7f162736a00bce5cc8) iso-image: Improve disk detection
* [`351187d8`](https://github.com/NixOS/nixpkgs/commit/351187d8482a1fe2d7bb957f7b99c3a13ce68db4) octave.buildEnv: Handle better no packages situation
* [`4e8c4218`](https://github.com/NixOS/nixpkgs/commit/4e8c42184f98731fbb564ade4184a4fdffe0f348) bemenu: 0.6.0 -> 0.6.1
* [`38c36d61`](https://github.com/NixOS/nixpkgs/commit/38c36d61a3bc6d18df424c95985110a23e07077a) bettercap: 2.31.0 -> 2.31.1
* [`1f5baa4b`](https://github.com/NixOS/nixpkgs/commit/1f5baa4bf866b7443a1d0e3df7ed0dcf52ad64ca) erlang: 23.3.4 -> 23.3.4.1
* [`bf2d30dc`](https://github.com/NixOS/nixpkgs/commit/bf2d30dced0ecabce814f9eff826f881d700a2a8) hottext: init at 1.3
* [`38931d97`](https://github.com/NixOS/nixpkgs/commit/38931d97836428d9496835e848f50d3fa5df2214) lynis: specify license
* [`1801c4f7`](https://github.com/NixOS/nixpkgs/commit/1801c4f7f02b20fb412a78f10d1f2c04998b7886) gdu: 4.11.2 -> 5.0.0
* [`d8c0615b`](https://github.com/NixOS/nixpkgs/commit/d8c0615b4fcaa6211721fe9690778b495c62ac0f) terrascan: 1.5.1 -> 1.6.0
* [`0d1b1416`](https://github.com/NixOS/nixpkgs/commit/0d1b14161acc0c79b0712ea4f4c476684bfa41a3) redis: 6.2.1 -> 6.2.3
* [`cd8ba9f1`](https://github.com/NixOS/nixpkgs/commit/cd8ba9f1750ea1797956ed2eea515d170c87a07d) trash-cli: 0.21.5.11 -> 0.21.5.22
* [`f2a4f72b`](https://github.com/NixOS/nixpkgs/commit/f2a4f72ba3c666d1fe109806b949a1a9d8cdf133) README: point to Matrix
* [`499952f4`](https://github.com/NixOS/nixpkgs/commit/499952f44ed3667162b577770ff01fe0ff4d891a) README: just IRC, not "other channels"
* [`d317ed3d`](https://github.com/NixOS/nixpkgs/commit/d317ed3d477e1e1e4ad90eb6ed89f4d1d7a8db3f) flood: set 'meta.mainProgram'
* [`9a6abff3`](https://github.com/NixOS/nixpkgs/commit/9a6abff3de84f080d7c38b347025e3e83f120c0b) xplr: 0.9.1 -> 0.10.1
* [`19c3849b`](https://github.com/NixOS/nixpkgs/commit/19c3849b71e68a630fa1d651bb2972a5383f9faf) caffeine-ng: set 'meta.mainProgram'
* [`4b8a57d8`](https://github.com/NixOS/nixpkgs/commit/4b8a57d891af9423a195e5d6ea430b8419a946ac) betterlockscreen: 3.1.0 -> 3.1.1
* [`555afaa9`](https://github.com/NixOS/nixpkgs/commit/555afaa94e60f0dae5572174a5f4af2ee715eb14) neovide: Fix build caused by llvm multi output
* [`05aa6885`](https://github.com/NixOS/nixpkgs/commit/05aa68850cc55bad5a1829f0bd3995c82a8029db) libgudev: support cross-compilation by disabling introspection and vala
* [`3f1b917d`](https://github.com/NixOS/nixpkgs/commit/3f1b917deae4efd529c7d923013f36982c93d52b) netbeans: 12.3 -> 12.4 ([nixos/nixpkgs⁠#124084](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124084))
* [`02c595eb`](https://github.com/NixOS/nixpkgs/commit/02c595ebdb4f9767c8efc1718a1e886aba728822) Prefer `pname` and `version` in `mkDerivation`s instead of `name` ([nixos/nixpkgs⁠#123438](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123438))
* [`9fad0cbd`](https://github.com/NixOS/nixpkgs/commit/9fad0cbd5bb2e14186c46abe873898860f2f4639) heisenbridge: init at unstable-2021-05-23 ([nixos/nixpkgs⁠#123846](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123846))
* [`3a3543ed`](https://github.com/NixOS/nixpkgs/commit/3a3543edd4b83489f11bff872a3b5ed0618d3b67) vscode: fix symlink to executable ([nixos/nixpkgs⁠#123811](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123811))
* [`72317155`](https://github.com/NixOS/nixpkgs/commit/723171555fb1145b61dea18624e62f4a042a782b) otfcc: enable aarch64-darwin build
* [`caa041c4`](https://github.com/NixOS/nixpkgs/commit/caa041c44ba2ecd600719411359097792c2744e1) GNUnet: optional Postgres support
* [`0e1ad621`](https://github.com/NixOS/nixpkgs/commit/0e1ad6217ac920fffea1b4d6335fedc045c14cde) taler-exchange, taler-merchant: init at 0.8.1, 0.8.0
* [`459fbe19`](https://github.com/NixOS/nixpkgs/commit/459fbe19317baabd332f9000c1f0eb1a2a6bac99) nushell: enable aarch64-darwin build
* [`53951c0c`](https://github.com/NixOS/nixpkgs/commit/53951c0c1444e500585205e8b2510270b2ad188f) phpExtensions.dom: fix build
* [`509b00e9`](https://github.com/NixOS/nixpkgs/commit/509b00e9af5cc1edfa3aed02295f078bfceff9a5) chmlib: enable aarch64-darwin build
* [`dc3dea22`](https://github.com/NixOS/nixpkgs/commit/dc3dea22be2efd25517be358bb6bce64c670d318) doc/submitting-changes: should -> must
* [`a528f2a4`](https://github.com/NixOS/nixpkgs/commit/a528f2a48d39cc5f316e9ef84020ee24f555649b) metasploit: set mainProgram
* [`2d98c76a`](https://github.com/NixOS/nixpkgs/commit/2d98c76a380c6f003daef2362e9a0af65200aeb4) maintainers: add stelcodes
* [`eacbb570`](https://github.com/NixOS/nixpkgs/commit/eacbb570cd0e6f6eb43437022b5bf4fa8dbc2b7b) init zprint at 1.1.2
* [`aa86fdcf`](https://github.com/NixOS/nixpkgs/commit/aa86fdcf85ad282be0478711343c5a77fa4f5ce2) elixir: default to 1.12; init 1.12
* [`a6cfe320`](https://github.com/NixOS/nixpkgs/commit/a6cfe3208965fafc2492a8eeb4409cb4567efea6) elixir: add deprecation schedule docs
* [`58a66f01`](https://github.com/NixOS/nixpkgs/commit/58a66f016038dc111babf009da1d968c3e09bd60) elixir: nixpkgs-fmt
* [`79118eb6`](https://github.com/NixOS/nixpkgs/commit/79118eb65772e43bf9bbe6228066621c93a129a6) elixir: format: group inherit
* [`7e26b2a4`](https://github.com/NixOS/nixpkgs/commit/7e26b2a45583c3804d92e0f31d3b13db1c887d78) elixir: remove unused setup hook
* [`131700c1`](https://github.com/NixOS/nixpkgs/commit/131700c100d36e6affd35921d5896c77f3a0f565) prometheus-pihole-exporter: init at 0.0.11
* [`07245189`](https://github.com/NixOS/nixpkgs/commit/07245189195cd69badd57cba7c109cf99985a0d6) nixos/prometheus: init pihole-exporter
* [`541ff510`](https://github.com/NixOS/nixpkgs/commit/541ff510da58cab359658cf76177920819e45bdf) top-level: sort prometheus exporter
