### PR TITLE
niv home-manager: update f9e45390 -> 90493027

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9e45390deced72bc7cc0b75d3a922aa10a33e08",
-        "sha256": "14z5d9rlqcp35d4lg7wlvkqzydkhc8qvpjlf0bnn9gkng5wia2w9",
+        "rev": "90493027e33ba9eb3f50dc1da365d0e4ca31bf14",
+        "sha256": "0jnxpc1ywnccri1d3m7hqrmxzifi65dk1zyh9xdlbx1fjm4x6xr5",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f9e45390deced72bc7cc0b75d3a922aa10a33e08.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/90493027e33ba9eb3f50dc1da365d0e4ca31bf14.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f9e45390...90493027](https://github.com/nix-community/home-manager/compare/f9e45390deced72bc7cc0b75d3a922aa10a33e08...90493027e33ba9eb3f50dc1da365d0e4ca31bf14)

* [`3612ca58`](https://github.com/nix-community/home-manager/commit/3612ca58e8d592e58762da9ea650f82b9c7c05d9) syncthing: make syncthing tray package configurable ([nix-community/home-manager⁠#1257](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1257))
* [`73ecbd37`](https://github.com/nix-community/home-manager/commit/73ecbd37223e04321a32c5c34e4f01111fdc3674) Revert "status-notifier-watcher: introduce unit start delay"
* [`ff616b27`](https://github.com/nix-community/home-manager/commit/ff616b273426b528ae15f1b042863a4828dc1d88) foot: add module
* [`91450f23`](https://github.com/nix-community/home-manager/commit/91450f23ce658bd529ed6d79b599f0766fc3b71c) htop: replace individual option with 'settings' ([nix-community/home-manager⁠#1844](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1844))
* [`cced902d`](https://github.com/nix-community/home-manager/commit/cced902ddab06e94eeefee932c158dbbc248b52b) gpg: document lists are converted to duplicate keys ([nix-community/home-manager⁠#2025](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2025))
* [`b449cb77`](https://github.com/nix-community/home-manager/commit/b449cb77b19be059f2a3cf9e7e26d3f68cea56a8) firefox: deprecate 'enableGnomeExtensions'
* [`3d18912f`](https://github.com/nix-community/home-manager/commit/3d18912f5ae7c98bd5249411d98cdf3b28fe1f09) htop: fix deprecation warnings ([nix-community/home-manager⁠#2026](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2026))
* [`82ab1ad4`](https://github.com/nix-community/home-manager/commit/82ab1ad46746cd05e992c02d4636177e1b55ce1f) syncthing: fix news link ([nix-community/home-manager⁠#2032](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2032))
* [`4f70f49c`](https://github.com/nix-community/home-manager/commit/4f70f49cec34cb22b9be9f42cd0dd68ef816a797) Add systemd target `tray.target` ([nix-community/home-manager⁠#2027](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2027))
* [`64607f58`](https://github.com/nix-community/home-manager/commit/64607f58b75741470284c698f82f0199fcecdfa7) isync/mbsync: replace master/slave with far/near ([nix-community/home-manager⁠#1776](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1776))
* [`90493027`](https://github.com/nix-community/home-manager/commit/90493027e33ba9eb3f50dc1da365d0e4ca31bf14) mbsync: fix news entry
