### PR TITLE
niv nixpkgs-fmt: update 61cdb8a3 -> d5809df4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "61cdb8a3ed4bdee918c7ef241717c65edef21f65",
-        "sha256": "0q4smnya3nai4liin1g09wlc0nvk176q0j1zdai3wqnfdj76kqwy",
+        "rev": "d5809df4def9f47421c871101e34b917b76f2118",
+        "sha256": "1f1bg739di1fmgasp105j45x1zbf3walngfv834ns0qw7zabwm2b",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/61cdb8a3ed4bdee918c7ef241717c65edef21f65.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/d5809df4def9f47421c871101e34b917b76f2118.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@61cdb8a3...d5809df4](https://github.com/nix-community/nixpkgs-fmt/compare/61cdb8a3ed4bdee918c7ef241717c65edef21f65...d5809df4def9f47421c871101e34b917b76f2118)

* [`a911dd80`](https://github.com/nix-community/nixpkgs-fmt/commit/a911dd8003e2637ea351fc6a123312b58863e86a) add single space after variable declaration
* [`ebbc84a0`](https://github.com/nix-community/nixpkgs-fmt/commit/ebbc84a0e5f74749a2bf4f964cf0af9b835bf597) change NODE_LET_IN behavior to fix idempotent issue.
