### PR TITLE
niv powerlevel10k: update 9c034101 -> a3494a52

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "9c034101fe3cec1e2edb8e07c32a3e6dba9afaee",
-        "sha256": "1sr7sdqyschslmdi7q7rhn2g04fc3kghavpbgc0r67brvkdv05m4",
+        "rev": "a3494a52d7c01fbc28e7ab12b7af347860aa62a7",
+        "sha256": "1ipza9jb3qk7lnwav4hlyily2lhlv3pqq2pp490i22jammj6p5l1",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/9c034101fe3cec1e2edb8e07c32a3e6dba9afaee.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/a3494a52d7c01fbc28e7ab12b7af347860aa62a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@9c034101...a3494a52](https://github.com/romkatv/powerlevel10k/compare/9c034101fe3cec1e2edb8e07c32a3e6dba9afaee...a3494a52d7c01fbc28e7ab12b7af347860aa62a7)

* [`0ab7e1cc`](https://github.com/romkatv/powerlevel10k/commit/0ab7e1ccfd91ecdc3a3ad2efcc8704d589d1ff54) when resolving `python --version`, handle pyenv shims specially ([romkatv/powerlevel10k⁠#1378](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1378))
* [`4d2346da`](https://github.com/romkatv/powerlevel10k/commit/4d2346da0ae352235bfafc7cc8774ce60da7e70b) set P9K_PYENV_PYTHON_VERSION correctly when dealing with multiple pyenv versions ([romkatv/powerlevel10k⁠#1376](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1376))
* [`1ad8e575`](https://github.com/romkatv/powerlevel10k/commit/1ad8e5759ecd41619746a775d9bc9d2902c5c90e) when searching for files in ancestor directories, do match in $HOME ([romkatv/powerlevel10k⁠#1376](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1376))
* [`69d36509`](https://github.com/romkatv/powerlevel10k/commit/69d3650958ce03d666f433792444290b7b2ffe5d) hide python version in pyenv in lean/classic/rainbow if the rest of the content starts with it ([romkatv/powerlevel10k⁠#1376](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1376))
* [`f774df6c`](https://github.com/romkatv/powerlevel10k/commit/f774df6c76c3cf98d7740a00ef63d36e5a5cc0a7) pyenv: skip lines that start with "#" ([romkatv/powerlevel10k⁠#1376](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1376))
* [`a3494a52`](https://github.com/romkatv/powerlevel10k/commit/a3494a52d7c01fbc28e7ab12b7af347860aa62a7) don't leak 'token' local variable in parser ([romkatv/powerlevel10k⁠#1407](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1407))
