### PR TITLE
niv spacemacs: update 37c8669d -> 5ef4960d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "37c8669d3604b9f2e8de378cca9836019a95360a",
-        "sha256": "0qixjqv4qwv9hymm0zl0l5hv1qy5yvzrmlqjzqqby3c3sycy16hk",
+        "rev": "5ef4960d46fcfb333f59ee32ad19471ee177d64f",
+        "sha256": "12d0v1c776vh9capwv01jbjrjnmsiirkgs1b0ipj7mi74n1n59mx",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/37c8669d3604b9f2e8de378cca9836019a95360a.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/5ef4960d46fcfb333f59ee32ad19471ee177d64f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@37c8669d...5ef4960d](https://github.com/syl20bnr/spacemacs/compare/37c8669d3604b9f2e8de378cca9836019a95360a...5ef4960d46fcfb333f59ee32ad19471ee177d64f)

* [`2515f141`](https://github.com/syl20bnr/spacemacs/commit/2515f141b69ce9fdb75ed27c4088fab3557df86b) [+intl/chinese] fix warning for quote lambda function ([syl20bnr/spacemacs⁠#14786](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14786))
* [`a47b4a46`](https://github.com/syl20bnr/spacemacs/commit/a47b4a4672c342928bd0a7d5231f669166b57c81) [pdf] Update pdf-layer documentation ([syl20bnr/spacemacs⁠#14791](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14791)) ([syl20bnr/spacemacs⁠#14792](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14792))
* [`5ef4960d`](https://github.com/syl20bnr/spacemacs/commit/5ef4960d46fcfb333f59ee32ad19471ee177d64f) [bot] Auto-update ([syl20bnr/spacemacs⁠#14793](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14793))
