### PR TITLE
niv zsh-syntax-highlighting: update ebef4e55 -> 894127b2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "ebef4e55691f62e630318d56468e5798367aa81c",
-        "sha256": "0qimb90655hkm64mjqcn48kqq38cbfxlfhs324cbdi9gqpdi6q4b",
+        "rev": "894127b221ab73847847bf7cf31eeb709bc16dc5",
+        "sha256": "1a3ischgiwqag2caapdh3zmdlsaz57x07zgnk0l3l80g9gxlinib",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/ebef4e55691f62e630318d56468e5798367aa81c.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/894127b221ab73847847bf7cf31eeb709bc16dc5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@ebef4e55...894127b2](https://github.com/zsh-users/zsh-syntax-highlighting/compare/ebef4e55691f62e630318d56468e5798367aa81c...894127b221ab73847847bf7cf31eeb709bc16dc5)

* [`894127b2`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/894127b221ab73847847bf7cf31eeb709bc16dc5) docs,CI: Switch to Libera.Chat
