### PR TITLE
niv nixpkgs: update fd26001e -> 28c3c08b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd26001eadb620de4d08e98121ab71ff99fed066",
-        "sha256": "1dd5lm491skpzlmsqvdwcmqr49il32yd1nly0n52grvjf5kf58na",
+        "rev": "28c3c08b5323d9818ee38f1d3f63af8cd43056fb",
+        "sha256": "0ba5h30ysfi707cwaxg4v2jmr1xb7rnppvwz32lii714qjnqcic9",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/fd26001eadb620de4d08e98121ab71ff99fed066.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/28c3c08b5323d9818ee38f1d3f63af8cd43056fb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@fd26001e...28c3c08b](https://github.com/nixos/nixpkgs/compare/fd26001eadb620de4d08e98121ab71ff99fed066...28c3c08b5323d9818ee38f1d3f63af8cd43056fb)

* [`bb4f70db`](https://github.com/NixOS/nixpkgs/commit/bb4f70db9bc0d34d79d55d8f2d473116aa81cdfa) cascadia-code: 2102.25 -> 2105.24
* [`b45d3f81`](https://github.com/NixOS/nixpkgs/commit/b45d3f813a0acfaf1f7c7c0466136fceddaf7d50) cue: 0.3.2 -> 0.4.0
* [`38cfb84f`](https://github.com/NixOS/nixpkgs/commit/38cfb84ff0cef3e680be150eda5d06ac1b4a1c05) mediatomb/gerbera: Add release note information for 21.03
* [`d1fe6418`](https://github.com/NixOS/nixpkgs/commit/d1fe6418cc9b0a4cea3484671a60249d27abacf1) piston-cli: 1.3.0 -> 1.4.1
* [`cc855b13`](https://github.com/NixOS/nixpkgs/commit/cc855b133100a956d4587079e27c5704cbc8342b) pgsync: 0.6.6 → 0.6.7
* [`39b4c8f9`](https://github.com/NixOS/nixpkgs/commit/39b4c8f9af93f8e72f87cd78df97f948e834ea34) corerad: 0.3.0 -> 0.3.1
* [`f830b000`](https://github.com/NixOS/nixpkgs/commit/f830b000fc8aafd14bf3151178919378584e87c9) maintainers: add mikroskeem
* [`2980b1c4`](https://github.com/NixOS/nixpkgs/commit/2980b1c4f4bbf0e15e709abd769613bcbe83839b) imgcrypt: init at 1.1.1
* [`24507d73`](https://github.com/NixOS/nixpkgs/commit/24507d7346f825d4f513113a52e2921624a8b304) nq: fix tq
* [`5826e902`](https://github.com/NixOS/nixpkgs/commit/5826e9020636c8ba3bc311294ce78b6466fd2b24) dnsname-cni: init at 1.1.1
* [`9868aa60`](https://github.com/NixOS/nixpkgs/commit/9868aa60504d90d76ac86492ce1c7691fd234951) docker: 20.10.2 -> 20.10.6
* [`8baf7189`](https://github.com/NixOS/nixpkgs/commit/8baf7189b0be37c8e19f0d79af869d2ea2479223) docker: drop unused argument, use pname instead of name
* [`beab9f03`](https://github.com/NixOS/nixpkgs/commit/beab9f03224507375434d6223dca824eb0149820) docker: use commit hashes instead of tags, fix containerd sha256
* [`ad256a07`](https://github.com/NixOS/nixpkgs/commit/ad256a077b352cde225844002c087d4a3862e748) docker: bump runc to 1.0-rc95, fixing CVE-2021-30465
* [`c79e3ded`](https://github.com/NixOS/nixpkgs/commit/c79e3ded4b34c848b93db307ffaa8c8dcedf0c2b) gmnisrv: fix security vulnerability
* [`184b4530`](https://github.com/NixOS/nixpkgs/commit/184b453090ea663f98d29cb8a18479e0e9570891) pythonPackages.google-api-python-client: 2.0.2 -> 2.6.0
* [`4758dd48`](https://github.com/NixOS/nixpkgs/commit/4758dd48140070052212e57941dc7dd3ded1c603) patray: Yet another tray pulseaudio frontend
* [`fd2e675e`](https://github.com/NixOS/nixpkgs/commit/fd2e675e7c5205c0c6e3bcdad7f10a2db8fe25d0) diffoscope: 175 -> 176
* [`f451461e`](https://github.com/NixOS/nixpkgs/commit/f451461e9dee2d19e04512ee91b622f1dcb40391) fetchutils: remove DESTDIR, use PREFIX, change owner
* [`53455882`](https://github.com/NixOS/nixpkgs/commit/534558827a48924ebca03da963e8ea292b417195) kops: 1.19.2 -> 1.20.1
* [`07de30ff`](https://github.com/NixOS/nixpkgs/commit/07de30ff81149c3cc02702f7a8cab2c217d44f1e) kops: keep only three latest versions
* [`d6cbf3a7`](https://github.com/NixOS/nixpkgs/commit/d6cbf3a701eaae13d562cc8371f9bc2559e6763a) electron_13: init at 13.0.1
* [`a0426609`](https://github.com/NixOS/nixpkgs/commit/a0426609c8cbf16e8ef1bbae34faa060fec6fe05) electron_12: 12.0.7 -> 12.0.9
* [`505298f8`](https://github.com/NixOS/nixpkgs/commit/505298f812a263244c2189549933c02d810965a7) electron_11: 11.4.6 -> 11.4.7
* [`f8fbfa53`](https://github.com/NixOS/nixpkgs/commit/f8fbfa538bcb8a8c187f4d60946cf8f0dc9dc6a7) electron_10: 10.4.5 -> 10.4.7
* [`42d671a8`](https://github.com/NixOS/nixpkgs/commit/42d671a80d2cf80b25adb3d296dc36df2136c93c) b3sum: 0.3.7 -> 0.3.8
* [`16fc720d`](https://github.com/NixOS/nixpkgs/commit/16fc720da38ac57d5d3a3953b32cb8ba9bf5a28a) python3Packages.pyroon: init at 0.0.37
* [`0aa2c0c6`](https://github.com/NixOS/nixpkgs/commit/0aa2c0c6a3d48f6779942abce5a51885f92b4f62) home-assistant: update component-packages
* [`fe9f49ec`](https://github.com/NixOS/nixpkgs/commit/fe9f49ec5660da02344482970ce9fc8e432e541e) home-assistant: enable roon tests
* [`d86a0722`](https://github.com/NixOS/nixpkgs/commit/d86a0722bea9d526532c5034505ce6951e657650) kind: 0.11.0 -> 0.11.1
* [`d60e79d1`](https://github.com/NixOS/nixpkgs/commit/d60e79d11307aa497a86e2311da5a8be2837e6ae) markdownlint-cli: init at 0.27.1
* [`28ab65b5`](https://github.com/NixOS/nixpkgs/commit/28ab65b5869c6673e359093662a1dfe3aba9b829) tmuxinator: 2.0.2 -> 2.0.3
* [`00a4be22`](https://github.com/NixOS/nixpkgs/commit/00a4be22f7f9d731ccc1f2c5687f29bcbbf41bea) yabridge, yabridgectl: 3.1.0 → 3.2.0 ([nixos/nixpkgs⁠#121715](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/121715))
* [`f159db1d`](https://github.com/NixOS/nixpkgs/commit/f159db1d686d7ab9e76e3646c7f9b231464ac85e) nushell: 0.30.0 -> 0.31.0
* [`976ee287`](https://github.com/NixOS/nixpkgs/commit/976ee287c863520e0fae4518b51d1e254a732bc2) bmake: fix build on darwin
* [`776f1d35`](https://github.com/NixOS/nixpkgs/commit/776f1d3592717521fce13287ca5e8fbbcdedefb6) ugrep: 3.2.2 -> 3.3
* [`8ed2973c`](https://github.com/NixOS/nixpkgs/commit/8ed2973cb1a664d272de9fea25fc31906545cfa7) erlangR24: 24.0 -> 24.0.1
* [`1f6b48be`](https://github.com/NixOS/nixpkgs/commit/1f6b48be7477c7cc6d2de8ab8b5bf15c754eafc6) discourse: 2.6.5 -> 2.7.0
* [`2dec0de3`](https://github.com/NixOS/nixpkgs/commit/2dec0de3c039406950aaa79cbdeb9bfbcae4f87d) nixos/discourse: Add rsync dependency
* [`cb80b679`](https://github.com/NixOS/nixpkgs/commit/cb80b67993d6ba195c3329606aab5fb981d8323c) nixos/discourse: Assert deployed PostgreSQL version
* [`80e86f88`](https://github.com/NixOS/nixpkgs/commit/80e86f8871e3d4e328f5185e98cefa44269fc474) xpra: Add NVENC support
* [`d344dccf`](https://github.com/NixOS/nixpkgs/commit/d344dccf3dc592242f11ef993acb9ecee8d84796) nixos/wireguard: Remove .path systemd unit for privkey. Fixes [nixos/nixpkgs⁠#123203](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123203)
* [`b011e1f8`](https://github.com/NixOS/nixpkgs/commit/b011e1f8104f646f712aa14d2ba5de1bc1366ebe) virt-manager: fix missing cdrtools ([nixos/nixpkgs⁠#124408](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124408))
* [`4d3b47a6`](https://github.com/NixOS/nixpkgs/commit/4d3b47a6146cecc415bdbd9e10959dac3731dd35) linuxPackages_latest: update to 5.12
* [`b7630d55`](https://github.com/NixOS/nixpkgs/commit/b7630d5591d51048155cac4536ff8bedcfaae3b9) rl-2105: mention linux_latest and potential zfs issues
* [`48b6b8b8`](https://github.com/NixOS/nixpkgs/commit/48b6b8b8c663a20fbe7969bed1d6381341106762) cargo-raze: fix darwin ([nixos/nixpkgs⁠#124343](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124343))
* [`e8c8b3a7`](https://github.com/NixOS/nixpkgs/commit/e8c8b3a760ff95ac09a7d5b1f4db872f5d4de20e) rymcast: init at 1.0.6 ([nixos/nixpkgs⁠#123830](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123830))
* [`25bca77c`](https://github.com/NixOS/nixpkgs/commit/25bca77c48ddb0bacdb46e7398d948a348d06119) chaos: init at 0.1.9 ([nixos/nixpkgs⁠#124306](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124306))
* [`724ed08d`](https://github.com/NixOS/nixpkgs/commit/724ed08df02546fea2ab38613d615dd47461528c) nixos/wordpress: regenerate secret keys if misspelled key name is found
* [`d491dd73`](https://github.com/NixOS/nixpkgs/commit/d491dd73134f1adf7916665217093cf4a30ac314) coredns: 1.8.3 -> 1.8.4
* [`91b22b49`](https://github.com/NixOS/nixpkgs/commit/91b22b4917b23e729651a2f59eab07c48d14b90e) fly: 7.3.0 -> 7.3.1
* [`014cc9ce`](https://github.com/NixOS/nixpkgs/commit/014cc9ce0abeb4a78e16e482bef64cd39f7897fa) samba: 4.13.7 -> 4.14.4
* [`fe8fe5ed`](https://github.com/NixOS/nixpkgs/commit/fe8fe5edaa3620215dfac2ef8152f0d46c812c33) dwm: restored config patch interface
* [`4d90a6bc`](https://github.com/NixOS/nixpkgs/commit/4d90a6bcc4ff4b19cd35d45fbda29b5259ec4cc6) dwm: added neonfuz as maintainer
* [`cff04883`](https://github.com/NixOS/nixpkgs/commit/cff04883e8c21fe614dad85a96b3da93909eb8c8) arrow-cpp: 4.0.0 -> 4.0.1
* [`a821e14e`](https://github.com/NixOS/nixpkgs/commit/a821e14e5e8b2b4a71ce2ea4d8d48c7a1455f944) buildkite-agent: 3.29.0 -> 3.30.0 ([nixos/nixpkgs⁠#124837](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124837))
* [`e88d1aed`](https://github.com/NixOS/nixpkgs/commit/e88d1aedfa43d6b7026048ef1510540aef45ca58) python3Packages.evohome-async: 0.3.8 -> 0.3.15
* [`6933d068`](https://github.com/NixOS/nixpkgs/commit/6933d068c5d2fcff398e802f7c4e271bbdab6705) elixir: 1.12.0 -> 1.12.1
* [`52c24e9f`](https://github.com/NixOS/nixpkgs/commit/52c24e9fbef11818445bd7bb460e04e8c0120732) pika-backup: 0.3.1 -> 0.3.2
* [`17f9a15b`](https://github.com/NixOS/nixpkgs/commit/17f9a15b50c43fdc7daded82c2a87aa0013ce0bb) eternal-terminal: 6.1.7 -> 6.1.8
* [`d37dd6c3`](https://github.com/NixOS/nixpkgs/commit/d37dd6c3014c5b6364088841355581bf7e20b5ac) wine{Unstable,Staging}: 6.7 -> 6.8
* [`4c471a73`](https://github.com/NixOS/nixpkgs/commit/4c471a73a05ecad80998a91697be89b7ab1db118) fend: 0.1.14 -> 0.1.16
* [`d5a1bb6a`](https://github.com/NixOS/nixpkgs/commit/d5a1bb6ade9cc0efb289c2f6dba52a5ab9e37404) maintainers: add devins2518
* [`f7589d53`](https://github.com/NixOS/nixpkgs/commit/f7589d53140cdc2076d9720bf62b8d87dbebefb9) python3Packages.watchdog: 2.1.1 -> 2.1.2
* [`c73371e0`](https://github.com/NixOS/nixpkgs/commit/c73371e04b97493a34ac24ca09abc6a726d07697) neovim: fix neovim.override ([nixos/nixpkgs⁠#124785](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124785))
* [`e814269b`](https://github.com/NixOS/nixpkgs/commit/e814269bd2334b7519e37468adac2ef0fab5e00b) yabridge: Fix compatibility with wine 6.8+
* [`0cd06e8b`](https://github.com/NixOS/nixpkgs/commit/0cd06e8b091627dfe2921e3d8a1f26d30d135b7b) wine{Unstable,Staging}: 6.8 -> 6.9
* [`a8fb730e`](https://github.com/NixOS/nixpkgs/commit/a8fb730e04cd7a256ea1e1c3d1d9f21258bddb89) stevenblack-blocklist: init at 3.7.6
* [`ff58fe96`](https://github.com/NixOS/nixpkgs/commit/ff58fe96fdef6caf8100bd6a081fe79640b715c6) maintainers: add rvarago
* [`60f59884`](https://github.com/NixOS/nixpkgs/commit/60f59884e94432fe18e6ac4e2d2dc1a4ca3ec8df) cargo-bitbake: init at 0.3.15
* [`678920b1`](https://github.com/NixOS/nixpkgs/commit/678920b13bed59e76efbc4d8fac34451c86b6c7b) release.nix: add aarch64-darwin as a supportedSystem
* [`af44c17b`](https://github.com/NixOS/nixpkgs/commit/af44c17b5db241c547536ce16341c84dc247c035) welle-io: 2.2 -> 2.3
* [`08532757`](https://github.com/NixOS/nixpkgs/commit/0853275727138c6bb9ade80aa8d2e0f298044f47) mpich: 3.4.1 -> 3.4.2
* [`5a8cd34d`](https://github.com/NixOS/nixpkgs/commit/5a8cd34dba52fc35d25e24f41a17069e2254e609) gotty: 2.0.0-alpha.3 -> 1.2.0
* [`966188ff`](https://github.com/NixOS/nixpkgs/commit/966188ff80f5c4b808f0144c3effd64c5db5b593) openvpn-auth-ldap: 2.0.3+deb6.1 -> 2.0.4
* [`f35c86dc`](https://github.com/NixOS/nixpkgs/commit/f35c86dc1d00187129937bbc28f88cee42aa8991) python3Packages.pyrituals: 0.0.2 -> 0.0.3
* [`793a73a7`](https://github.com/NixOS/nixpkgs/commit/793a73a7684b0931934c70fe3deca720be19ed03) python3Packages.smhi-pkg: 1.0.14 -> 1.0.15
* [`6ee94fc3`](https://github.com/NixOS/nixpkgs/commit/6ee94fc354cb75fe55b7ee6b7cf0ad6d95568264) runelite: 2.0.0 -> 2.1.5
* [`99c80ee7`](https://github.com/NixOS/nixpkgs/commit/99c80ee729b405c575acf4dfdd2033bb8f9b5568) python3Packages.flametree: enable tests
* [`9d75ca70`](https://github.com/NixOS/nixpkgs/commit/9d75ca7054fa5eb7d372295cc79ad88567908a02) python3Packages.pyialarm: 1.5 -> 1.7
* [`b0b823be`](https://github.com/NixOS/nixpkgs/commit/b0b823be50efa168fa386e72e1380cf51412ae49) newsflash: fix build
* [`645446af`](https://github.com/NixOS/nixpkgs/commit/645446afa518ac7ef939bab4393d74d8bf24a7e2) catgirl: 1.7 -> 1.8
* [`364ae134`](https://github.com/NixOS/nixpkgs/commit/364ae13471c3844500befc9d6dda9a38f98142c3) esbuild: 0.12.0 -> 0.12.1
* [`166e67b4`](https://github.com/NixOS/nixpkgs/commit/166e67b4de27a25e56f8abb791e965bfed512496) twine: add top-level entry
* [`6ab535aa`](https://github.com/NixOS/nixpkgs/commit/6ab535aade04127f151570c43922f3472da2c2a7) dua: 2.11.3 -> 2.12.0
* [`e1d59ae8`](https://github.com/NixOS/nixpkgs/commit/e1d59ae8d4c839542607b76218bd9a66ce3f4e20) Revert "podman: add systemd to LD_LIBRARY_PATH for journald log driver"
* [`ada45ac3`](https://github.com/NixOS/nixpkgs/commit/ada45ac3aee664265759611d09443d549250bd70) podman: add systemd to rpath
* [`17887e49`](https://github.com/NixOS/nixpkgs/commit/17887e4967739862ff260b04ea42abae6a6bae85) getdata: add security patch from Debian ([nixos/nixpkgs⁠#124713](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124713))
* [`e00e031c`](https://github.com/NixOS/nixpkgs/commit/e00e031ce1d3907568bee3c7cd92e6a0cbf90b21) gitRepo: 2.14.5 -> 2.15.3 ([nixos/nixpkgs⁠#124904](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124904))
* [`8a8500c2`](https://github.com/NixOS/nixpkgs/commit/8a8500c2adadee055ee1b5200ccd492d7e707933) godot: 3.2.2 -> 3.3.2 ([nixos/nixpkgs⁠#123126](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123126))
* [`33a488c9`](https://github.com/NixOS/nixpkgs/commit/33a488c9afc2a875d9ca60d999b9605b41ec450d) babashka: 0.4.1 -> 0.4.3 ([nixos/nixpkgs⁠#124325](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124325))
* [`91788472`](https://github.com/NixOS/nixpkgs/commit/917884725dbab2f3855da31b46f9342951cafb57) zfsUnstable: 2.1.0-rc5 -> 2.1.0-rc6
* [`df0f92da`](https://github.com/NixOS/nixpkgs/commit/df0f92daeed03f6ffe2a6d8d3ff59393eaad0229) s3rs: init at 0.4.8
* [`c2ac1112`](https://github.com/NixOS/nixpkgs/commit/c2ac1112e51a72c256fcca2d7cf0eaad6a310003) heisenbridge: unstable-2021-05-23 -> unstable-2021-05-29
* [`5619c4f6`](https://github.com/NixOS/nixpkgs/commit/5619c4f67427549c133dbd2094ef6fbb282ae12c) proton-caller: fix version
* [`a8daff8b`](https://github.com/NixOS/nixpkgs/commit/a8daff8b1a95d7a00bd177d682454194713deb6b) gitui: 0.15.0 -> 0.16.0
* [`fe9b5b6b`](https://github.com/NixOS/nixpkgs/commit/fe9b5b6b4ad12cbf61aa0159954f995a6727736b) vieb: use electron_13
* [`fb8b0a38`](https://github.com/NixOS/nixpkgs/commit/fb8b0a38433c8e83a53c1dc0a739c5a7ad64e2fc) nixos/podman: Change podman socket to new podman group
* [`ff4d83a6`](https://github.com/NixOS/nixpkgs/commit/ff4d83a66727ad13da0f51d00db4eda8a8c50590) nixos/podman: Add dockerSocket.enable
* [`52844efc`](https://github.com/NixOS/nixpkgs/commit/52844efcd67028a481a24103d8e93c7ef2bf4f08) nixos/podman: Add generic networkSocket interface
* [`b6570e72`](https://github.com/NixOS/nixpkgs/commit/b6570e723836167640c9b7efc63f327ff17b0755) nixos/podman-network-socket-ghostunnel: init
* [`db31d835`](https://github.com/NixOS/nixpkgs/commit/db31d8354d9c1988968f076c4e01843330162e03) podman: Add iproute2, fixing docker network rm
* [`2eeecef3`](https://github.com/NixOS/nixpkgs/commit/2eeecef3fc70e35b2f4c6d8424e4c726c140e330) nixos/libvirtd: Take ethertypes from iptables-nftables-compat
* [`ba677b14`](https://github.com/NixOS/nixpkgs/commit/ba677b14dd937dc00723dc13dfa2f53c934db392) halide: Fix build
* [`a7cd70f3`](https://github.com/NixOS/nixpkgs/commit/a7cd70f3676d60c64e1c079bbef072bfdd96807c) vimPlugins.gruvbox-flat-nvim: init at 2021-05-28
* [`3f3f5a0d`](https://github.com/NixOS/nixpkgs/commit/3f3f5a0d5df1d6b2ab6ff6ff512aa9b0ee2e74a6) scons: Remove myself as maintainer
* [`964fc7cf`](https://github.com/NixOS/nixpkgs/commit/964fc7cfef94bd598d816979a4ca1a42d9753d23) Update nixos/modules/virtualisation/libvirtd.nix
* [`544db849`](https://github.com/NixOS/nixpkgs/commit/544db849a172f03c7eda038705e303e94bf5a53e) ocamlPackages.uri: 4.0.0 → 4.2.0
* [`41634080`](https://github.com/NixOS/nixpkgs/commit/416340800d1910ced2b02097215d530dfe28074a) python3Packages.pygtfs: init at 0.1.6
* [`a759f21d`](https://github.com/NixOS/nixpkgs/commit/a759f21d3769b1cf774ee15981d6f6e8d6edc4a9) home-assistant: update component-packages
* [`83c102f6`](https://github.com/NixOS/nixpkgs/commit/83c102f66c3ee9252cf012b9a9c85c6f953f7cf3) ocamlPackages.tyxml: 4.4.0 → 4.5.0
* [`d07f52bf`](https://github.com/NixOS/nixpkgs/commit/d07f52bf810beb4c67bcbf012aad78a2c9f3e495) nixos/test-driver: mention the elapsed time when it times out
* [`20db1f28`](https://github.com/NixOS/nixpkgs/commit/20db1f287f07358439390e96fbc4cde20558ee9c) luajit_2_1: 2.1.0-2021-05-22 -> 2.1.0-2021-05-29
* [`b9bf83bc`](https://github.com/NixOS/nixpkgs/commit/b9bf83bc5a7dfe6554c9714e8215e866189d1a4e) luajit_2_0: 2.1.0-2021-05-17 -> 2.1.0-2021-05-29
* [`878103ce`](https://github.com/NixOS/nixpkgs/commit/878103ce553567118aedc30cc23c8377181480cd) nixos/trilium: use boolToString for noBackup
* [`2c7d2ce2`](https://github.com/NixOS/nixpkgs/commit/2c7d2ce295296553451a7839513427f63377e92e) sageWithDoc: fix documentation symlinks
* [`e546f976`](https://github.com/NixOS/nixpkgs/commit/e546f97664601f3828a92f76fa2b2a12d05fb1d5) rpg-cli: unstable-2021-05-27 -> 0.3.0
* [`2d372c1f`](https://github.com/NixOS/nixpkgs/commit/2d372c1f69a382654caa628bd1e1beb986d56625) python3Packages.pytube: 10.8.2 -> 10.8.3
* [`0885a2d4`](https://github.com/NixOS/nixpkgs/commit/0885a2d40fe1e01e80481b3d649ddb1defbe68ef) bunnyfetch: init at unstable-2021-05-24
* [`fbe60d18`](https://github.com/NixOS/nixpkgs/commit/fbe60d186b79349632d1fd0e225f502c96628e0a) neovim: always generate rplugin.vim ([nixos/nixpkgs⁠#124990](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124990))
* [`b72b3c55`](https://github.com/NixOS/nixpkgs/commit/b72b3c557170013601ceffd8c94a40764d34d302) xfitter: remove `hardeningDisable = [ "format" ];`
* [`2c988b61`](https://github.com/NixOS/nixpkgs/commit/2c988b6132f8b5bdaf490efd26f8d027366c7548) plex: 1.23.0.4482-62106842a -> 1.23.1.4602-280ab6053
* [`79c75e54`](https://github.com/NixOS/nixpkgs/commit/79c75e54e57590fabc14ba0b132cea864c140580) vscode-extensions.B4dM4n.vscode-nixpkgs-fmt: init
* [`c383345c`](https://github.com/NixOS/nixpkgs/commit/c383345cc8fa978a71dc07d23acc4cd9eafcc934) erlang: main R23 -> R24
* [`1c979e41`](https://github.com/NixOS/nixpkgs/commit/1c979e4116d132dba334091878ad0bb5cfa966a0) elixir 1_8: set erlang to R23
* [`f5e242b7`](https://github.com/NixOS/nixpkgs/commit/f5e242b7b625bab1e903c2e7c3021e02aea288ac) cl: set erlang to R23
* [`8aee68a9`](https://github.com/NixOS/nixpkgs/commit/8aee68a9f7e87a057c66e00bd445c64f64fe527e) rabbitmq-server: set erlang version
* [`0e705d7a`](https://github.com/NixOS/nixpkgs/commit/0e705d7a255efbc6d5e345985da46f34a4f4afae) relxExe: 3.32.1 -> 4.3.0
* [`2402d70e`](https://github.com/NixOS/nixpkgs/commit/2402d70ef36cb7b09575c7e21bd8ee70ec76d259) relxExe: remove
* [`85d6f6f1`](https://github.com/NixOS/nixpkgs/commit/85d6f6f1f328ad78d963609e4fd5d091291c4bb0) teamspeak_server: 3.13.3 -> 3.13.5 ([nixos/nixpkgs⁠#124601](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124601))
* [`34c6163e`](https://github.com/NixOS/nixpkgs/commit/34c6163ed91a8ab4c0d1160590ccb510fb285a23) mblaze: fix mcom to use file utility. ([nixos/nixpkgs⁠#94881](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/94881))
* [`879e6926`](https://github.com/NixOS/nixpkgs/commit/879e6926ce663313b336974bb28dbaf10967b195) maintainers: add kennyballou
* [`7ff8b88e`](https://github.com/NixOS/nixpkgs/commit/7ff8b88e6ea79db0f4a1314d46997ad37f0704a8) akonadi-calendar-tools: init 20.12.3
* [`af22c928`](https://github.com/NixOS/nixpkgs/commit/af22c928fc87dcdc0396e6efc9fa1909d23603f9) kaccounts-providers: init 20.12.3
* [`28c3c08b`](https://github.com/NixOS/nixpkgs/commit/28c3c08b5323d9818ee38f1d3f63af8cd43056fb) kio-gdrive: init 20.12.3
