### PR TITLE
niv home-manager: update 90493027 -> 2a4ab0d8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "90493027e33ba9eb3f50dc1da365d0e4ca31bf14",
-        "sha256": "0jnxpc1ywnccri1d3m7hqrmxzifi65dk1zyh9xdlbx1fjm4x6xr5",
+        "rev": "2a4ab0d891a59fd3a0fc09e9805aad5a8f82dfac",
+        "sha256": "1szil3m4k2mrpmqimy5ykgba9ls4j7iai0q817r29wnyh3py5m58",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/90493027e33ba9eb3f50dc1da365d0e4ca31bf14.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/2a4ab0d891a59fd3a0fc09e9805aad5a8f82dfac.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@90493027...2a4ab0d8](https://github.com/nix-community/home-manager/compare/90493027e33ba9eb3f50dc1da365d0e4ca31bf14...2a4ab0d891a59fd3a0fc09e9805aad5a8f82dfac)

* [`b840707a`](https://github.com/nix-community/home-manager/commit/b840707a87f6a35a5c24ea6edf8846741d924616) firefox: Always create profile directories
* [`ddf35436`](https://github.com/nix-community/home-manager/commit/ddf35436b7104e456ef22af48452e13ee5f0eb78) nextcloud-client: add startInBackground option ([nix-community/home-manager⁠#2038](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2038))
* [`0e6c61a4`](https://github.com/nix-community/home-manager/commit/0e6c61a44092e98ba1d75b41f4f947843dc7814d) programs.neovim: Set customRC for new nixpkgs ([nix-community/home-manager⁠#2039](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2039))
* [`3591cd2b`](https://github.com/nix-community/home-manager/commit/3591cd2b3bbb1b4c7033bc2b5dc3d142bc3f9074) docs: switch IRC to OFTC
* [`ab64dc32`](https://github.com/nix-community/home-manager/commit/ab64dc32493996c24607eab2cae6663466ddfb8a) docs: make OFTC upper case
* [`07ad6a4f`](https://github.com/nix-community/home-manager/commit/07ad6a4f76d9402ae8af1507b4158b52aa59fcea) files: fix use of onChange with directory source
* [`d2aaeac4`](https://github.com/nix-community/home-manager/commit/d2aaeac42c563cf8cf76ee3b90d9585dadbb91e0) files: remove assertion on recursive onChange
* [`0e329cee`](https://github.com/nix-community/home-manager/commit/0e329cee4c17fa0b7df32233513b9cb2236d382b) jq: add `package` option
* [`5573c10e`](https://github.com/nix-community/home-manager/commit/5573c10ea4564268967da659dbcf230185fb4226) docs: update issue template
* [`9e253a8c`](https://github.com/nix-community/home-manager/commit/9e253a8c3065f08ec94d24363221d1988c27a273) docs: minor additional issue template update
* [`2a4ab0d8`](https://github.com/nix-community/home-manager/commit/2a4ab0d891a59fd3a0fc09e9805aad5a8f82dfac) programs.neovim: fix tests + swap extraConfig and pluginconfig ([nix-community/home-manager⁠#2053](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2053))
