### PR TITLE
niv powerlevel10k: update a3494a52 -> f217e4a3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "a3494a52d7c01fbc28e7ab12b7af347860aa62a7",
-        "sha256": "1ipza9jb3qk7lnwav4hlyily2lhlv3pqq2pp490i22jammj6p5l1",
+        "rev": "f217e4a39a284f6db7be7a4cfde8647085f97865",
+        "sha256": "0an3h0g252mhj91qq51prxh1y10f0gvlq6srmrbn6l2n7axlc85g",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/a3494a52d7c01fbc28e7ab12b7af347860aa62a7.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/f217e4a39a284f6db7be7a4cfde8647085f97865.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@a3494a52...f217e4a3](https://github.com/romkatv/powerlevel10k/compare/a3494a52d7c01fbc28e7ab12b7af347860aa62a7...f217e4a39a284f6db7be7a4cfde8647085f97865)

* [`c5972064`](https://github.com/romkatv/powerlevel10k/commit/c59720647a328c9dfdd96702ee22d4217c0974ed) fix asdf, was broken by 1ad8e5759ecd41619746a775d9bc9d2902c5c90e ([romkatv/powerlevel10k⁠#1409](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1409))
* [`35acee11`](https://github.com/romkatv/powerlevel10k/commit/35acee119d2d18aa4630a63f36cb5b447bd17637) Fix icon padding for VCS bookmark icon ([romkatv/powerlevel10k⁠#1414](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1414)) ([romkatv/powerlevel10k⁠#1415](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1415))
* [`aa4d3663`](https://github.com/romkatv/powerlevel10k/commit/aa4d36634132b6c510207e6cdbc6d1aceaf7ddbd) Add region support for aws element
* [`c7ad00b5`](https://github.com/romkatv/powerlevel10k/commit/c7ad00b5a5ec92c9b6edf8051502f42659f820b5) add P9K_AWS_PROFILE and P9K_AWS_REGION and use it in default configs
* [`d87d557b`](https://github.com/romkatv/powerlevel10k/commit/d87d557b0f99a526f71fd8c3831842c70fab8cb7) Correct name of Windows Terminal in README ([romkatv/powerlevel10k⁠#1424](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1424))
* [`77fa0e6d`](https://github.com/romkatv/powerlevel10k/commit/77fa0e6dcc56d71590967714f9e76bbf2c9ecc17) clarify that Windows Terminal is the one from Microsoft
* [`ba83466e`](https://github.com/romkatv/powerlevel10k/commit/ba83466e1da75d9260ebbb145215d9c46d6eadf6) Squashed 'gitstatus/' changes from 6d00edd0..113f1f69
