### PR TITLE
niv spacemacs: update 5ef4960d -> 42dbd1d3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "5ef4960d46fcfb333f59ee32ad19471ee177d64f",
-        "sha256": "12d0v1c776vh9capwv01jbjrjnmsiirkgs1b0ipj7mi74n1n59mx",
+        "rev": "42dbd1d3597fb11f697fc80902472cbac836fe02",
+        "sha256": "1rdxy7j9qrraa7wbsfp9hn09j6fr2zhj4ajbp926im1mw36rawa5",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/5ef4960d46fcfb333f59ee32ad19471ee177d64f.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/42dbd1d3597fb11f697fc80902472cbac836fe02.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@5ef4960d...42dbd1d3](https://github.com/syl20bnr/spacemacs/compare/5ef4960d46fcfb333f59ee32ad19471ee177d64f...42dbd1d3597fb11f697fc80902472cbac836fe02)

* [`41f8430c`](https://github.com/syl20bnr/spacemacs/commit/41f8430c1f82c241b655d201c955cc69b40c0e45) Evilify geiser-doc-mode-map and add keybindings in scheme layer ([syl20bnr/spacemacs⁠#14758](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14758))
* [`b51c359d`](https://github.com/syl20bnr/spacemacs/commit/b51c359d897191ce1328ab84011b4cc605b349b3) Group lisp state key bindings ([syl20bnr/spacemacs⁠#14790](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14790))
* [`15b9e0fd`](https://github.com/syl20bnr/spacemacs/commit/15b9e0fd8a5bf5347bd32432af4a18c156d5cb55) Add bindings for opening eaf applications
* [`3b45182e`](https://github.com/syl20bnr/spacemacs/commit/3b45182e45fb9ac454c5a9a2666fa838e3d6393d) [eaf] Add docs for new keybindings
* [`89844fe4`](https://github.com/syl20bnr/spacemacs/commit/89844fe411b8e91098fc0b625ac7717a12813bd8) Add custom-file to recentf-exclude list
* [`af86a142`](https://github.com/syl20bnr/spacemacs/commit/af86a142ebeff3bfa0c5cb41d47455af3cd68eab) [spacemacs-default] Replace "unless null" with "when"
* [`bc616321`](https://github.com/syl20bnr/spacemacs/commit/bc6163216c6ec5cc4da9dd7856d6c9de1700a51b) [lsp] add keybindings for lsp-ivy/helm-lsp when use upstream bindings
* [`3e93f56e`](https://github.com/syl20bnr/spacemacs/commit/3e93f56e58bf303f9e400bbefd2c59e568772164) [docker] simplify keybings for docker.el
* [`b29ed9b5`](https://github.com/syl20bnr/spacemacs/commit/b29ed9b59821e83fa065b766bcc1069d8cff8479) [docker] Register "q" to close the current window for docker modes
* [`83659793`](https://github.com/syl20bnr/spacemacs/commit/8365979326d7da9459268671fc73fb57b48e7d0e) [perforce] Add p4-shelve and p4-unshelve commands with keybindings
* [`d9132f8b`](https://github.com/syl20bnr/spacemacs/commit/d9132f8bc07b6eec9565614e8904a3fed7e80949) spacedminish: fixed bug
* [`63197014`](https://github.com/syl20bnr/spacemacs/commit/63197014cc3c9f4bcd64be112543c859eec629d9) use org and org-contrib packages rather than org-plus-contrib
* [`5e26865e`](https://github.com/syl20bnr/spacemacs/commit/5e26865ef955af7dfcac9e10091592825c50ba8b) [org] Fix installation from nongnu elpa and double ownership of org
* [`627940d6`](https://github.com/syl20bnr/spacemacs/commit/627940d6d7a2eecb1642f653269efcc662aef151) `(format (concat go-run-command)` modification
* [`e708f8dc`](https://github.com/syl20bnr/spacemacs/commit/e708f8dcaaf56bf20ac2cdd261848451ab8cad0c) [go] Remove obsolete format statement and fix go-run-args passing
* [`358d60b6`](https://github.com/syl20bnr/spacemacs/commit/358d60b67633c7fd9e990fb7bc79893f1bb9583f) [markdown] Add binding for inserting common tables
* [`b96ace13`](https://github.com/syl20bnr/spacemacs/commit/b96ace13137a6b407440b70317cacc6139377f8e) [markdown] Remove obsolete orgtbl-mode cleanup
* [`c74b0f8b`](https://github.com/syl20bnr/spacemacs/commit/c74b0f8bc0989c0e3f15a679bfc373a9d504cce4) [org] Remove unit tests for non existing function
* [`4acdf773`](https://github.com/syl20bnr/spacemacs/commit/4acdf7733ef2791fc4e4e49ab8403240e0ced60c) Fix one diminish pattern in a list in :spacediminish ([syl20bnr/spacemacs⁠#14810](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14810))
* [`27fa8f8f`](https://github.com/syl20bnr/spacemacs/commit/27fa8f8f7d989ae9db5ebaf62cd76dc3e1055dc4) Fix key binding in README in layers/tools/transmission ([syl20bnr/spacemacs⁠#14814](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14814))
* [`42dbd1d3`](https://github.com/syl20bnr/spacemacs/commit/42dbd1d3597fb11f697fc80902472cbac836fe02) swap 'so' and 'such' in the 999 banner ([syl20bnr/spacemacs⁠#14815](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14815))
