### PR TITLE
niv zsh-syntax-highlighting: update 894127b2 -> 0e1bb144

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "894127b221ab73847847bf7cf31eeb709bc16dc5",
-        "sha256": "1a3ischgiwqag2caapdh3zmdlsaz57x07zgnk0l3l80g9gxlinib",
+        "rev": "0e1bb14452e3fc66dcc81531212e1061e02c1a61",
+        "sha256": "09ncmyqlk9a3h470z0wgbkrznb5zyc9dj96011wm89rdxc1irxk2",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/894127b221ab73847847bf7cf31eeb709bc16dc5.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/0e1bb14452e3fc66dcc81531212e1061e02c1a61.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@894127b2...0e1bb144](https://github.com/zsh-users/zsh-syntax-highlighting/compare/894127b221ab73847847bf7cf31eeb709bc16dc5...0e1bb14452e3fc66dcc81531212e1061e02c1a61)

* [`0e1bb144`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/0e1bb14452e3fc66dcc81531212e1061e02c1a61) main: precommands += proxychains
