### PR TITLE
niv nixpkgs: update 28c3c08b -> dd03217d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "28c3c08b5323d9818ee38f1d3f63af8cd43056fb",
-        "sha256": "0ba5h30ysfi707cwaxg4v2jmr1xb7rnppvwz32lii714qjnqcic9",
+        "rev": "dd03217d4944e2ce7f1991dbeacb482e8d5cc2ff",
+        "sha256": "160hbbmjjv0nf2ycgzaajx2blcfqnc90gg6nwlc0dvigip82z0as",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/28c3c08b5323d9818ee38f1d3f63af8cd43056fb.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/dd03217d4944e2ce7f1991dbeacb482e8d5cc2ff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@28c3c08b...dd03217d](https://github.com/nixos/nixpkgs/compare/28c3c08b5323d9818ee38f1d3f63af8cd43056fb...dd03217d4944e2ce7f1991dbeacb482e8d5cc2ff)

* [`e4a0b101`](https://github.com/NixOS/nixpkgs/commit/e4a0b101904e3d24b60e7f79069a9fe967b54363) wezterm: Add terminfo output ([nixos/nixpkgs⁠#125320](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125320))
* [`25e46dda`](https://github.com/NixOS/nixpkgs/commit/25e46dda3d99050daab3208b00932744dab9a173) openrgb: Fix udev rules with hardcoded /bin/chmod
* [`70d74713`](https://github.com/NixOS/nixpkgs/commit/70d747131fa5b012fbeb38c83ccaec1f6cb68401) python3Packages.georss-nrcan-earthquakes-client: init at 0.2
* [`576c2f55`](https://github.com/NixOS/nixpkgs/commit/576c2f555e5dee3694c484967f92315902882bf4) pull_request_template: fix link to CONTRIBUTING.md
* [`5d223f26`](https://github.com/NixOS/nixpkgs/commit/5d223f2695183df3618a4b3b9b9dea59bdfda253) python3Packages.userpath: 1.5.0 -> 1.6.0
* [`776e8fd6`](https://github.com/NixOS/nixpkgs/commit/776e8fd668560745d20bffc765a94400ef4a523b) haskellPackages.nri-redis: disable tests
* [`fb801bb4`](https://github.com/NixOS/nixpkgs/commit/fb801bb48122567f7367c99fe28ac407069960f7) senpai: init at 2021-05-27 ([nixos/nixpkgs⁠#125794](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125794))
* [`26ac257e`](https://github.com/NixOS/nixpkgs/commit/26ac257e4fecc050f28da30399afdfee83d98836) doc: nix-gitignore to CommonMark
* [`e4d21886`](https://github.com/NixOS/nixpkgs/commit/e4d21886f43a8092331bb229601c3d624d3b1455) haskellPackages.tophat: unbreak
* [`b7749c76`](https://github.com/NixOS/nixpkgs/commit/b7749c76715ba96727f7a12bc2514ddfa6847813) nixos/test-driver: Run commands with error handling
* [`a8685350`](https://github.com/NixOS/nixpkgs/commit/a86853501a339f95765a6763e9c409f374606faa) nixosTests.nginx*: nginxUnstable -> nginxMainline
* [`3d9c3e5c`](https://github.com/NixOS/nixpkgs/commit/3d9c3e5cfd8705b03a175ef40f6eeaa9a16634ff) nixosTests.*: Don't use the `-q` flag with grep when used with curl
* [`f31f0392`](https://github.com/NixOS/nixpkgs/commit/f31f03925c1affabaa5dd8504ca99d03bda51b8d) retroshare: init at 6.6.0
* [`974a30ce`](https://github.com/NixOS/nixpkgs/commit/974a30ce11c7bb268c21b6653fbe39dcce0f5e26) dotnetPackages.FSharpData: 2.2.3 -> 4.1.1
* [`163f88af`](https://github.com/NixOS/nixpkgs/commit/163f88aff8911ee81f2038bc409c2e41d9e35823) matrix-commander: gpl3Only => gpl3Plus & unstable-2021-04-18 -> unstable-2021-05-26 ([nixos/nixpkgs⁠#125700](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125700))
* [`a62c4253`](https://github.com/NixOS/nixpkgs/commit/a62c4253b4788f806abfef27a2c20f845a98e09c) dotnetPackages.YamlDotNet: 11.1.1
* [`22e0fe2f`](https://github.com/NixOS/nixpkgs/commit/22e0fe2f29969e20a3142b6ee2b3a31b4b5e2801) lunar-client: 2.6.0 -> 2.7.3
* [`c78fe7aa`](https://github.com/NixOS/nixpkgs/commit/c78fe7aa78e7f562f6bd4a3f213236640f97448c) python3Packages.subliminal: readd again
* [`ccf8709d`](https://github.com/NixOS/nixpkgs/commit/ccf8709d309958dfb3b9d916aaab635e8da284c0) python3Packages.georss-tfs-incidents-client: init at 0.2
* [`4e0336be`](https://github.com/NixOS/nixpkgs/commit/4e0336be20cd45c1eebbd78aa2763723bea5fb14) python3Packages.georss-wa-dfes-client: init at 0.2
* [`90e409dd`](https://github.com/NixOS/nixpkgs/commit/90e409dd2889bdb9815b2bf6c4abd80d8a150e40) python3Packages.georss-qld-bushfire-alert-client: init at 0.4
* [`7fc09193`](https://github.com/NixOS/nixpkgs/commit/7fc0919351cc9f4c70905728bffbb900c08319c1) python3Packages.georss-ign-sismologia-client: init at 0.2
* [`fcc81afc`](https://github.com/NixOS/nixpkgs/commit/fcc81afcbd3059d4ec1fc1af5d6aeaadf00e766b) python3Packages.georss-ingv-centro-nazionale-terremoti-client: init at 0.4
* [`ed22a2a7`](https://github.com/NixOS/nixpkgs/commit/ed22a2a78dba309b620c36d5fb11d5d4beb87456) ponyc: 0.38.3 -> 0.41.1
* [`157aee00`](https://github.com/NixOS/nixpkgs/commit/157aee00a5b599027f5daa90b699735441ace1c8) nixos/sourcehut: init ([nixos/nixpkgs⁠#113244](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/113244))
* [`e5a5056b`](https://github.com/NixOS/nixpkgs/commit/e5a5056b6461f0696f8c2e53cf7229d12a0a6959) gixy: works on darwin platform too ([nixos/nixpkgs⁠#125713](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125713))
* [`cd7a26eb`](https://github.com/NixOS/nixpkgs/commit/cd7a26eb8c415e63f8333897db19d3b8697c6373) gitAndTools.tig: 2.5.3 -> 2.5.4
* [`2d2c5897`](https://github.com/NixOS/nixpkgs/commit/2d2c58970ad4b04011c23b02be42380e111e4d2e) evcxr: 0.9.0 -> 0.10.0
* [`42df77f7`](https://github.com/NixOS/nixpkgs/commit/42df77f763a313fb7ba38e5b97b755fcf8486f32) gpg-tui: 0.2.0 -> 0.3.0
* [`6e588e5b`](https://github.com/NixOS/nixpkgs/commit/6e588e5b0eb1fab72a479762929a36e927459e1d) nimbo: add shell completions
* [`68f8c1fc`](https://github.com/NixOS/nixpkgs/commit/68f8c1fc66aba287ee42810652df699da46cc4bf) stockfish: 12 -> 13
* [`7c1a2141`](https://github.com/NixOS/nixpkgs/commit/7c1a21412553bfd70d52799bc3f586067e6462cf) torus-trooper: init at 0.22
* [`3a9b42c0`](https://github.com/NixOS/nixpkgs/commit/3a9b42c07e1ee6872b8cdefd75db05a91e8dc83d) tumiki-fighters: init at 0.21
* [`ca6a613f`](https://github.com/NixOS/nixpkgs/commit/ca6a613f7add5e24393c96cfee9dd0849bc97b6a) boops: 1.4.0 -> 1.6.0
* [`35ea60a0`](https://github.com/NixOS/nixpkgs/commit/35ea60a0ff7e1c1a1bc7bc10515ce22c35c88ad8) consul: 1.9.5 -> 1.9.6
* [`8240b5ad`](https://github.com/NixOS/nixpkgs/commit/8240b5ad7f73ebebb0f2d8aea1440882d861b4e9) stochas: 1.3.4 -> 1.3.5
* [`5f8d85a9`](https://github.com/NixOS/nixpkgs/commit/5f8d85a93434e365f52fc858187bdf202d08ce27) cpp-utilities: 5.10.3 -> 5.10.4
* [`754ec218`](https://github.com/NixOS/nixpkgs/commit/754ec218c396d2de5cc493316536c91be2458e90) faust-stk: init at 2.20.2
* [`d3115756`](https://github.com/NixOS/nixpkgs/commit/d3115756194861f48944b6e59d297ef5ef6c413b) faustPhysicalModeling: init at 2.20.2
* [`044053e2`](https://github.com/NixOS/nixpkgs/commit/044053e28c51b0284d1ace43655f8292ad543167) wlrctl: init at 0.2.1
* [`df82caf8`](https://github.com/NixOS/nixpkgs/commit/df82caf8df911674f65cf63f388b7820d410c334) youtube-dl: 2021.05.16 -> 2021.06.06
* [`925ee864`](https://github.com/NixOS/nixpkgs/commit/925ee864feac47905b86fb3313b8afc6c04b3ebf) rss2email test: fix name ([nixos/nixpkgs⁠#125863](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125863))
* [`420000eb`](https://github.com/NixOS/nixpkgs/commit/420000ebc442cb97ced3ea317801290c8b5b2969) f2c: init at 20200916 ([nixos/nixpkgs⁠#125360](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125360))
* [`5e5a3c39`](https://github.com/NixOS/nixpkgs/commit/5e5a3c39edfbb3022c2c8cdffd6f291471437481) nixos/prometheus: add process exporter
* [`5591b8e1`](https://github.com/NixOS/nixpkgs/commit/5591b8e1fc39a05e4a6f792dc54d9085f6ad004c) haskell.packages: let me maintain some more packages
* [`c8e00db1`](https://github.com/NixOS/nixpkgs/commit/c8e00db1f3bbc8389d70af291dfdf9658ec35a7e) go-toml: 1.9.1 -> 1.9.2
* [`8588b80a`](https://github.com/NixOS/nixpkgs/commit/8588b80af49d52033575c774cc57f23ccc43e372) rebar3Relx: add executable to bin dir and remove unnecessary dependency
* [`4b0ea06f`](https://github.com/NixOS/nixpkgs/commit/4b0ea06ff373f0ef27c2f43216c49ff50083c64c) rebar3Relx: only link executables in $out/bin
* [`f614ab78`](https://github.com/NixOS/nixpkgs/commit/f614ab78d8fa15e2e99f45e7feddd600fdf2be1a) mwprocapture: 1.2.4177 -> 1.3.0.4236 ([nixos/nixpkgs⁠#125110](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125110))
* [`c62bf5e4`](https://github.com/NixOS/nixpkgs/commit/c62bf5e4a12a100350fc668e1217e0739a0e9346) remote-touchpad: 1.0.1 -> 1.0.2
* [`763f7e32`](https://github.com/NixOS/nixpkgs/commit/763f7e321c5cdce7a839b39e0b286e2434ca2e4a) sundials: fix download URL and hash ([nixos/nixpkgs⁠#125316](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125316))
* [`e0b91375`](https://github.com/NixOS/nixpkgs/commit/e0b91375bc5eb9495cd11233b1184ffb1a21d2da) box2d: fix hash ([nixos/nixpkgs⁠#125310](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125310))
* [`2854b524`](https://github.com/NixOS/nixpkgs/commit/2854b52437f708cd5d3a1f97207e740c9f7a1f41) rPackages.hdf5r: add missing depedency on pkgs.hdf5 ([nixos/nixpkgs⁠#125549](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125549))
* [`19f80f0d`](https://github.com/NixOS/nixpkgs/commit/19f80f0d327089029796b4482323bba9eb961bc8) veikk-linux-driver-gui: init at 2.0
* [`e977f0f1`](https://github.com/NixOS/nixpkgs/commit/e977f0f112ad2c0212526e84791c178db7830187) ngrok-2: fix aarch64-darwin logic
* [`d32c2470`](https://github.com/NixOS/nixpkgs/commit/d32c2470838e79d01fccf6e7a95b473610b9e1d2) purescript: 0.14.0 -> 0.14.2
* [`8f2ea9a9`](https://github.com/NixOS/nixpkgs/commit/8f2ea9a96189d42a9402b7c726694d831802f1c4) purescript: add changelog
* [`b03b73c8`](https://github.com/NixOS/nixpkgs/commit/b03b73c879884781134c2a28e68dad0de008197f) depotdownloader: init at 2.4.1
* [`38db89df`](https://github.com/NixOS/nixpkgs/commit/38db89df057daae580442c8b39177ad5db6b99ac) verilator: specify lgpl3Only and artistic2 licenses
* [`cd2fea35`](https://github.com/NixOS/nixpkgs/commit/cd2fea35aba8bd4e298037e8d2c40babdf69cec8) lazygit: 0.28.1 -> 0.28.2
* [`5c14e587`](https://github.com/NixOS/nixpkgs/commit/5c14e587c7ebd6f8e02120c41eb7b6e986e03f94) emacsPackages.isearch-plus: init at 2021-01-01
* [`473f1423`](https://github.com/NixOS/nixpkgs/commit/473f1423432dafaad42684b131aedebcd3238178) emacsPackages.isearch-prop: init at 2019-05-01
* [`f135fdad`](https://github.com/NixOS/nixpkgs/commit/f135fdad38ecacf7735aff89f66d78b865890d2b) emacsPackages.git-undo: init at 2019-10-13
* [`0d44260e`](https://github.com/NixOS/nixpkgs/commit/0d44260ebc4fb7c7d384a906608875d5cf9318e7) emacsPackages.youtube-dl: init at 2018-10-12
* [`48b585cb`](https://github.com/NixOS/nixpkgs/commit/48b585cbe4deedb1790303053b614cd5ef68288f) emacsPackages.evil-markdown: init at 2020-06-01
* [`b736e904`](https://github.com/NixOS/nixpkgs/commit/b736e9048b1b833b5d6bfd6959a010f20081c70c) emacsPackages.mu4e-patch: init at 2019-05-09
* [`cf88d436`](https://github.com/NixOS/nixpkgs/commit/cf88d436dc2a511700c955008ab6a0c608351d17) emacsPackages.apheleia: init at 2021-05-23
* [`4a34590e`](https://github.com/NixOS/nixpkgs/commit/4a34590eced7ec7aadf4a64105d7a88125919738) ocamlPackages.cooltt: init at unstable-2021-05-25
* [`943d26cf`](https://github.com/NixOS/nixpkgs/commit/943d26cf3b3aa407c651395141b0a5bbf7043175) linuxPackages_4_4.v4l2loopback: fix build for 4.4 kernels
* [`381dcecd`](https://github.com/NixOS/nixpkgs/commit/381dcecd65e14f1b71b4a2491fe3da0dc8401930) gnome.eog: 40.1 -> 40.2
* [`78952c80`](https://github.com/NixOS/nixpkgs/commit/78952c80b4081383c5159ef5349b220202868c6d) silicon: 0.4.1 -> 0.4.2
* [`47371be9`](https://github.com/NixOS/nixpkgs/commit/47371be95b595923c6c3d2736e2ed339a8457f0c) exploitdb: 2021-06-03 -> 2021-06-05
* [`fb4023f0`](https://github.com/NixOS/nixpkgs/commit/fb4023f046648ce248948ef229e0c23e48718458) erlangR21: 21.3.8.23 -> 21.3.8.24
* [`0fc1a3d0`](https://github.com/NixOS/nixpkgs/commit/0fc1a3d0d89ce06992714c690449c45713af75a6) tor-browser-bundle-bin: 10.0.16 -> 10.0.17
* [`92636c86`](https://github.com/NixOS/nixpkgs/commit/92636c86dae58679a036ea29b39194fb04b431d9) gnome.gnome-maps: 40.1 -> 40.2
* [`4343b60f`](https://github.com/NixOS/nixpkgs/commit/4343b60f9c00ce35027fed2a53a5e6d46212511d) gnome.gnome-boxes: 40.1 -> 40.2
* [`64ab23e7`](https://github.com/NixOS/nixpkgs/commit/64ab23e7a77e0c15ca4b8ccf78caa76b091a025a) gnome.gnome-software: 40.1 -> 40.2
* [`b671334a`](https://github.com/NixOS/nixpkgs/commit/b671334a4fb6994c07de416552b36f6a680c4ee7) gnome.gnome-calendar: 40.1 -> 40.2
* [`1c8c6e2d`](https://github.com/NixOS/nixpkgs/commit/1c8c6e2d9adfdcf2d78460fda45ec9b892765731) evolution-data-server: 3.40.1 -> 3.40.2
* [`d8eb97e3`](https://github.com/NixOS/nixpkgs/commit/d8eb97e3801bde96491535f40483d550b57605b9) epiphany: 40.1 -> 40.2
* [`1b73aa2a`](https://github.com/NixOS/nixpkgs/commit/1b73aa2aea013f23614fe5a5a61621cc6d06c908) tor-browser-bundle: delete unused extensions.nix
* [`fdca90d0`](https://github.com/NixOS/nixpkgs/commit/fdca90d07f654cb54f41659567bed130524cece6) docs: acme: Fix typo
* [`690496c4`](https://github.com/NixOS/nixpkgs/commit/690496c4e545e68482b5c162a03f0a4f97d35373) ocamlPackages.ppx_gen_rec: 1.1.0 -> 2.0.0
* [`b24cc395`](https://github.com/NixOS/nixpkgs/commit/b24cc395ccf892827585d32246b4902bd9379113) maintainers/teams: remove pacien from the matrix team
* [`92f62de6`](https://github.com/NixOS/nixpkgs/commit/92f62de6f1ee9c9e31a8432ad222e79deef2ad87) matrix-appservice-discord: increase test timeout
* [`3b4cace6`](https://github.com/NixOS/nixpkgs/commit/3b4cace64dc19096e6696cfc474fc47b7189e73b) vim-utils: append customRC after plug / pathogen plugins are loaded
* [`bd103151`](https://github.com/NixOS/nixpkgs/commit/bd103151ea885a9802fa25f359f19ed0a0e162ef) haskellPackages.reactive-banana: unbreak
* [`778f07ce`](https://github.com/NixOS/nixpkgs/commit/778f07cea82267a0969c01a0a62239b43d8b2b37) hackage2nix: Mark failing builds broken
* [`ceab4362`](https://github.com/NixOS/nixpkgs/commit/ceab4362b2437a95dc5bc0c8bfe795a849034da9) interception-tools: 0.2.1 -> 0.6.6
* [`1fca83e1`](https://github.com/NixOS/nixpkgs/commit/1fca83e1b6765313e92ef7dc609ae1f50e773766) haskellPakcages.reactive-balsa: disable on darwin
* [`05813f4b`](https://github.com/NixOS/nixpkgs/commit/05813f4bf45718dbcca29f467755fedcc97168e9) hackage2nix: Mark failing builds broken
* [`97d2cfaf`](https://github.com/NixOS/nixpkgs/commit/97d2cfaf810607f590b1b133c4b3d447b9f6f198) adwaita-qt: 1.3.0 -> 1.3.1
* [`bfa89fbf`](https://github.com/NixOS/nixpkgs/commit/bfa89fbfca62837ec0b73ed61e6bad47297845e6) dotnetPackages.FSharpFormatting: 2.9.8 -> 11.2.0
* [`30c602ac`](https://github.com/NixOS/nixpkgs/commit/30c602ac7aa2ba89b5055984ebd69a17cf9e5924) qbittorrent: 4.3.3 -> 4.3.5
* [`ad21be36`](https://github.com/NixOS/nixpkgs/commit/ad21be36ac70180bac5a74eab2a4ee0304862fa2) electron_13: 13.0.1 -> 13.1.0
* [`711c6d57`](https://github.com/NixOS/nixpkgs/commit/711c6d57fb65d9f8086dd0f1ac2d90042fccd462) electron_12: 12.0.9 -> 12.0.10
* [`03bfa298`](https://github.com/NixOS/nixpkgs/commit/03bfa298913e752ff804697ec7f95fdac647b5c3) nixos/tests/test-driver: cleanup "dead" code (USE_SERIAL)
* [`9fcd7d4e`](https://github.com/NixOS/nixpkgs/commit/9fcd7d4e36b8758e121d09aed970133e2f88d3eb) ocamlPackages.fix: 20130611 -> 20201120
* [`5a8372d0`](https://github.com/NixOS/nixpkgs/commit/5a8372d04e5afbca44daed90ff82e0f0003e59b2) lib.systems.parse.kernels: fix typo in comment
* [`4d6a0bb9`](https://github.com/NixOS/nixpkgs/commit/4d6a0bb9667c8083076a96744bdc71643c6febc6) lib.systems.parsed: add "elf" for some NetBSD archs
* [`f2c72bca`](https://github.com/NixOS/nixpkgs/commit/f2c72bca630b13c23aad2addfee3c0dc9b64f29a) netbsd: disable stack protection on i686
* [`39f3777e`](https://github.com/NixOS/nixpkgs/commit/39f3777e923784cbe9af20fe86be0403fe9c8763) ocamlPackages.bisect_ppx: 2.5.0 -> 2.6.1
* [`6d3d57a2`](https://github.com/NixOS/nixpkgs/commit/6d3d57a20d9a6530625733060d152911663fbe7d) ocamlPackages.ocaml-version: 3.0.0 -> 3.1.0
* [`a1c5f4e2`](https://github.com/NixOS/nixpkgs/commit/a1c5f4e2205cff910b849c19ab6218241582d574) graphene: fix nixos test
* [`d83bd16a`](https://github.com/NixOS/nixpkgs/commit/d83bd16a2eab64e3e1b67cd5689807ec844450ba) prometheus-script-exporter: init at 1.2.0
* [`3bcf4e31`](https://github.com/NixOS/nixpkgs/commit/3bcf4e31ef70e2d6ec3fd387c174673aa01ef736) nixos/prometheus: add script exporter
* [`ffb7cfcf`](https://github.com/NixOS/nixpkgs/commit/ffb7cfcfad15e3bff9d05336767e59ee6ee24cb6) pr-tracker: 1.0.0 -> 1.1.0; adopt; add changelog
* [`0998c6a7`](https://github.com/NixOS/nixpkgs/commit/0998c6a73e80ad376f7fc5542ea9412fe477dec2) freshfetch: init at 0.2.0
* [`92c64006`](https://github.com/NixOS/nixpkgs/commit/92c6400651c2fe90aa86bdd728fe7e2f035644cb) nordic: unstable-2021-05-21 -> unstable-2021-06-04
* [`56ca47ff`](https://github.com/NixOS/nixpkgs/commit/56ca47ff3dfd24d45e75d385bac367afe23884db) python3Packages.textacy: 0.10.1 -> 0.11.0
* [`5ee8800b`](https://github.com/NixOS/nixpkgs/commit/5ee8800be0262b74d3815a2c2ea2410464c3b13c) python3Packages.pyupgrade: 2.18.0 -> 2.19.1
* [`e8a9f916`](https://github.com/NixOS/nixpkgs/commit/e8a9f9164c5d4aa08fb1aea3794a47e685f2bedb) vimPlugins: update
* [`df1d134e`](https://github.com/NixOS/nixpkgs/commit/df1d134ee4af581e3228fd332982a7f823f6e9e0) vimPlugins.vim-simpledb: init at 2020-10-02
* [`953be75b`](https://github.com/NixOS/nixpkgs/commit/953be75ba2bdb41e0b72e772e168e7cc27e092bd) vimPlugins.lightline-gruvbox-vim: init at 2018-03-23
* [`a15bd8e0`](https://github.com/NixOS/nixpkgs/commit/a15bd8e006f08202f1c35dc6c0d69a539f372e87) vimPlugins.vim-clap: fix rust build
* [`69c5219c`](https://github.com/NixOS/nixpkgs/commit/69c5219cba9610fd4bc084043144df8e541092a9) python3Packages.adblock: 0.4.0 -> 0.4.4
* [`02e88067`](https://github.com/NixOS/nixpkgs/commit/02e88067f7243ed9283710d15d99c31d1b7ef58e) python3Packages.datadog: 0.40.1 -> 0.41.0
* [`b6a8f9ac`](https://github.com/NixOS/nixpkgs/commit/b6a8f9ac5d0eca5167e9ede1bac5ce7fb62d8f03) python3Packages.google-api-python-client: 2.6.0 -> 2.7.0
* [`7e89fb12`](https://github.com/NixOS/nixpkgs/commit/7e89fb12e4ac75a3db4318e848b35f62bf43bbb3) ec2-amis: add release 21.05
* [`0a776e10`](https://github.com/NixOS/nixpkgs/commit/0a776e108f85d9a8e2f4c2147f6e61cf1880fe6e) vscode-extensions.b4dm4n.vscode-nixpkgs-fmt: add nixpkgs-fmt dependency
* [`5e56caf5`](https://github.com/NixOS/nixpkgs/commit/5e56caf52f876b07b2d04ae36516e54e52f4ba8c) rebar3Relx: strip native binaries
* [`3edda09e`](https://github.com/NixOS/nixpkgs/commit/3edda09ec8d8a0bcc35827f09337dba2b101988a) ngrok-2: 2.3.35 -> 2.3.40 ([nixos/nixpkgs⁠#125949](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/125949))
* [`e41c7bc1`](https://github.com/NixOS/nixpkgs/commit/e41c7bc1f825518993bfd6311e02e3145ceed154) erlang: remove unused setup hook
* [`3bc80f19`](https://github.com/NixOS/nixpkgs/commit/3bc80f19388a8b29b65c91fd4550f51cbc9a3a96) buildMix: switch buildInputs to nativeBuildInputs
* [`357cc8e0`](https://github.com/NixOS/nixpkgs/commit/357cc8e05d1f05c84e778cdd316dce8987396b5f) mix-release: remove rebar dep
* [`8989d2ea`](https://github.com/NixOS/nixpkgs/commit/8989d2eae8aee06ee35b2cbdba74a5e7c366d683) mix-release: remove erlang ref in erts dir
* [`2a87cb7a`](https://github.com/NixOS/nixpkgs/commit/2a87cb7a8b4436bcd85fe0fe9532664386879a67) build-mix buildRebar3: strip out derivation for NIFs
* [`5e9f18c5`](https://github.com/NixOS/nixpkgs/commit/5e9f18c572fa24750a278b80f6ad9ad101f48069) mix-release: remove erlang ref in resulting derivation
* [`e13301fd`](https://github.com/NixOS/nixpkgs/commit/e13301fd5c916ef89d302085c5fdf364a4e5e069) mix-release: do not override fixup to strip binary
* [`2e3e5912`](https://github.com/NixOS/nixpkgs/commit/2e3e591211c1afe4d1b2abc93d537c93f250ce1a) mix-release: add comments
* [`3cbcbfc4`](https://github.com/NixOS/nixpkgs/commit/3cbcbfc4fc5770946bb9fbd91273ca26aa8219d8) powershell: add aarch64 support for Linux
* [`7ef488f8`](https://github.com/NixOS/nixpkgs/commit/7ef488f819e8a631f4f9689f75c3ad168a6ebd1d) python3Packages.pyezviz: 0.1.8.7 -> 0.1.8.9
