### PR TITLE
niv home-manager: update 2a4ab0d8 -> aa36e2d6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a4ab0d891a59fd3a0fc09e9805aad5a8f82dfac",
-        "sha256": "1szil3m4k2mrpmqimy5ykgba9ls4j7iai0q817r29wnyh3py5m58",
+        "rev": "aa36e2d6b481a54b95fbddbecb76076e0f38eb89",
+        "sha256": "1avdicccxkpndq7r15jazjjl070ynp88qnd6f7kc2x1aavhakkly",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/2a4ab0d891a59fd3a0fc09e9805aad5a8f82dfac.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/aa36e2d6b481a54b95fbddbecb76076e0f38eb89.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@2a4ab0d8...aa36e2d6](https://github.com/nix-community/home-manager/compare/2a4ab0d891a59fd3a0fc09e9805aad5a8f82dfac...aa36e2d6b481a54b95fbddbecb76076e0f38eb89)

* [`cb227dc6`](https://github.com/nix-community/home-manager/commit/cb227dc6c29eb4f768d04958f4fe6d9d3d4aba46) foot: add foot binaries to user service's path ([nix-community/home-manager⁠#2061](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2061))
* [`b9176246`](https://github.com/nix-community/home-manager/commit/b91762467001fe5d0dee6e3b4562ce0a32be3c95) i3status-rust: replace deprecated format keys ([nix-community/home-manager⁠#2062](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2062))
* [`d6bbd02e`](https://github.com/nix-community/home-manager/commit/d6bbd02e95556b285abb610eba923f528462f860) htop: fix preserving the order of meters ([nix-community/home-manager⁠#2065](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2065))
* [`30102ea9`](https://github.com/nix-community/home-manager/commit/30102ea9e5cbf8a3d696f7604610740ecb6b5953) xdg-desktop-entries: add module ([nix-community/home-manager⁠#1450](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1450))
* [`95da56b7`](https://github.com/nix-community/home-manager/commit/95da56b783e4ccc8ded71137e4add780b239dd46) i3,sway: workspace output assignment ([nix-community/home-manager⁠#2003](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2003))
* [`c7e79b53`](https://github.com/nix-community/home-manager/commit/c7e79b53376bc5110c6cdfcc0f5f7705932b8b37) programs.neovim: dont wrap init.vim ([nix-community/home-manager⁠#2058](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2058))
* [`d3cdabb5`](https://github.com/nix-community/home-manager/commit/d3cdabb5c9fb3dc57b3a0c02ca5fa92719970a30) Replace references to pkgs.gnome3 by pkgs.gnome
* [`c12d53dd`](https://github.com/nix-community/home-manager/commit/c12d53dd7cdcc5de9b7a41b31c3edf80fc1f2fc8) texlive: "Texlive" -> "TeX Live"
* [`45f9cb06`](https://github.com/nix-community/home-manager/commit/45f9cb06a9152ca367edc3e7eaa5449338885167) texlive: add `packageSet` option
* [`5c1415d6`](https://github.com/nix-community/home-manager/commit/5c1415d67f11f89e6182cefeca5519c504ed769d) docs: mark 21.05 as stable version
* [`19d95258`](https://github.com/nix-community/home-manager/commit/19d95258ac63ff8c5d920a136d4780ad07affee5) docs: set current version to 21.11
* [`e4c55ed4`](https://github.com/nix-community/home-manager/commit/e4c55ed4e6b319534c1f0213ce61252fe5ee5def) Revert "foot: add foot binaries to user service's path ([nix-community/home-manager⁠#2061](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2061))"
* [`dba802c1`](https://github.com/nix-community/home-manager/commit/dba802c1d958c49e74f865e00473db9ad6e1b268) dunst: add the whole package to home.packages ([nix-community/home-manager⁠#2079](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2079))
* [`5eb199e9`](https://github.com/nix-community/home-manager/commit/5eb199e9371b59e97186d83dc4a44477a7c79e43) home-manager: pass on `--debug` option ([nix-community/home-manager⁠#2049](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2049))
* [`e9ed9c2e`](https://github.com/nix-community/home-manager/commit/e9ed9c2e111b9990eca96242f9beddce2ce3fd94) etesync-dav: fix typo ([nix-community/home-manager⁠#2067](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2067))
* [`ac82c036`](https://github.com/nix-community/home-manager/commit/ac82c036d8dafa4ed55b0cf1a870493fbf6931a4) services/emacs: Update systemd definitions, drop Emacs 26 support
* [`5060262b`](https://github.com/nix-community/home-manager/commit/5060262b79a74dd7b35d6a5c2c3fd02bae1ccecc) services/emacs: Prevent deletion of socket file
* [`7591c804`](https://github.com/nix-community/home-manager/commit/7591c8041d290d4bb99679e9fed2d8061a8f0435) rbw: add module ([nix-community/home-manager⁠#1998](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1998))
* [`afb5fd96`](https://github.com/nix-community/home-manager/commit/afb5fd962cdd122b70a7c0f3ad78c8ec6a75766b) irssi: add ssl_cert option for servers ([nix-community/home-manager⁠#2043](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2043))
* [`3ffe2a4c`](https://github.com/nix-community/home-manager/commit/3ffe2a4cdf5896081edb2b661fa27316309dc624) programs.senpai: add module ([nix-community/home-manager⁠#2076](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2076))
* [`9424f31f`](https://github.com/nix-community/home-manager/commit/9424f31f86e2fee2e64834e1430ecd31c88da923) piston-cli: add module ([nix-community/home-manager⁠#2052](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2052))
* [`f74dc9c7`](https://github.com/nix-community/home-manager/commit/f74dc9c70bc05c87bf2ebb9a5e60665a87753ce5) xidlehook: add module ([nix-community/home-manager⁠#1761](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1761))
* [`06a98ba0`](https://github.com/nix-community/home-manager/commit/06a98ba0fd25f0eb6294f4272d32d389156db806) pantalaimon: add module ([nix-community/home-manager⁠#2056](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2056))
* [`aa36e2d6`](https://github.com/nix-community/home-manager/commit/aa36e2d6b481a54b95fbddbecb76076e0f38eb89) xsession.pointerCursor: .icons file for AwesomeWM ([nix-community/home-manager⁠#2084](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2084))
