### PR TITLE
niv powerlevel10k: update f217e4a3 -> b9c62ca0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "f217e4a39a284f6db7be7a4cfde8647085f97865",
-        "sha256": "0an3h0g252mhj91qq51prxh1y10f0gvlq6srmrbn6l2n7axlc85g",
+        "rev": "b9c62ca02827c828fb544033950232e5426930ad",
+        "sha256": "1ysx7jg8gr9ya3r6zijxb2v0ziylwj9mwr162q5qiyxa7ckqsd9s",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/f217e4a39a284f6db7be7a4cfde8647085f97865.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/b9c62ca02827c828fb544033950232e5426930ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@f217e4a3...b9c62ca0](https://github.com/romkatv/powerlevel10k/compare/f217e4a39a284f6db7be7a4cfde8647085f97865...b9c62ca02827c828fb544033950232e5426930ad)

* [`b9c62ca0`](https://github.com/romkatv/powerlevel10k/commit/b9c62ca02827c828fb544033950232e5426930ad) cleanup
