### PR TITLE
niv spacemacs: update 42dbd1d3 -> 120ce695

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "42dbd1d3597fb11f697fc80902472cbac836fe02",
-        "sha256": "1rdxy7j9qrraa7wbsfp9hn09j6fr2zhj4ajbp926im1mw36rawa5",
+        "rev": "120ce6959d10cac04ae27b0a024f879d6d8356bf",
+        "sha256": "1cy02idcalraq2yj7zavlblsc203r1hxjdaz76zkwngmcwvldmi2",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/42dbd1d3597fb11f697fc80902472cbac836fe02.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/120ce6959d10cac04ae27b0a024f879d6d8356bf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@42dbd1d3...120ce695](https://github.com/syl20bnr/spacemacs/compare/42dbd1d3597fb11f697fc80902472cbac836fe02...120ce6959d10cac04ae27b0a024f879d6d8356bf)

* [`4ef66493`](https://github.com/syl20bnr/spacemacs/commit/4ef664934b61de5c86c0573b87ad49cd7b8c339d) [ci] Add PAT to rebase GH action workflow
* [`f5a777b8`](https://github.com/syl20bnr/spacemacs/commit/f5a777b86165b06bdfeec7340e32992820f7cee5) [CI] Test disabled DockerCI autobuild
* [`1ce4a7fd`](https://github.com/syl20bnr/spacemacs/commit/1ce4a7fd66a4f19c8b9008798d526a754b213f94) [CI] Test disabled TravisCI webhook
* [`96304721`](https://github.com/syl20bnr/spacemacs/commit/9630472187ce24d5e595099130aa2f22ff8e6df0) racket: Function-quote company-mode-hook function ([syl20bnr/spacemacs⁠#14824](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14824))
* [`8c8fc646`](https://github.com/syl20bnr/spacemacs/commit/8c8fc6463ca873d66616144884d1108b42efc4b5) Use local copy of old devdocs for emacs < 27.1 ([syl20bnr/spacemacs⁠#14823](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14823))
* [`eda7e193`](https://github.com/syl20bnr/spacemacs/commit/eda7e193701742c58857e556b60db9bff6896916) Don't fail hard when trying to delete a non-existing package ([syl20bnr/spacemacs⁠#14821](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14821))
* [`5cd56a46`](https://github.com/syl20bnr/spacemacs/commit/5cd56a466848f1fb99e109ea055212a15ccb8d74) Only load evil-collection in vim or hybrid mode ([syl20bnr/spacemacs⁠#14825](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14825))
* [`53027df2`](https://github.com/syl20bnr/spacemacs/commit/53027df26a2fa2a788e0558cb5dbc78c92d7dbf0) exwm: fix missing kwarg
* [`1d07f56a`](https://github.com/syl20bnr/spacemacs/commit/1d07f56aedc9729f48522417df211355ff6a48a5) fixup [syl20bnr/spacemacs⁠#14715](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14715) ([syl20bnr/spacemacs⁠#14826](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14826))
* [`d262103b`](https://github.com/syl20bnr/spacemacs/commit/d262103b5ef202c29057d0b7244b746f5952162d) fixup! fixup! [syl20bnr/spacemacs⁠#14715](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14715)
* [`95b683c0`](https://github.com/syl20bnr/spacemacs/commit/95b683c0a5e20b338f45920c1031db46e7b017c9) Fixed bugs and refactor in new EXWM layer 
* [`f0cadad3`](https://github.com/syl20bnr/spacemacs/commit/f0cadad38f1671dfde4d6b8851661d694a07fc09) fixup fixup fixup [syl20bnr/spacemacs⁠#14715](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14715) ([syl20bnr/spacemacs⁠#14827](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14827))
* [`51142a23`](https://github.com/syl20bnr/spacemacs/commit/51142a23ada2d801360c82b111698998ee835d0b) [doc] Fix broken link ([syl20bnr/spacemacs⁠#14828](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14828))
* [`70ec2270`](https://github.com/syl20bnr/spacemacs/commit/70ec22703a67380de34f6d268bc8d6dfedfc9682) [nix] Add key binding for nix-format-buffer
* [`12c4d510`](https://github.com/syl20bnr/spacemacs/commit/12c4d510ff5a817956645a29bde25922608f595a) Update php dap debugging doc to cover xdebug v3 and docker debug host issues.
* [`500e5834`](https://github.com/syl20bnr/spacemacs/commit/500e58341cfdac69071096506c684e1cd04d5b6a) Defer loading of lsp servers up to when the buffer is visible
* [`120ce695`](https://github.com/syl20bnr/spacemacs/commit/120ce6959d10cac04ae27b0a024f879d6d8356bf) Fix some typos ([syl20bnr/spacemacs⁠#14832](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14832))
