### PR TITLE
niv zsh-autosuggestions: update ae315ded -> a411ef3e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -144,10 +144,10 @@
         "homepage": null,
         "owner": "zsh-users",
         "repo": "zsh-autosuggestions",
-        "rev": "ae315ded4dba10685dbbafbfa2ff3c1aefeb490d",
-        "sha256": "0h52p2waggzfshvy1wvhj4hf06fmzd44bv6j18k3l9rcx6aixzn6",
+        "rev": "a411ef3e0992d4839f0732ebeb9823024afaaaa8",
+        "sha256": "1g3pij5qn2j7v7jjac2a63lxd97mcsgw6xq6k5p7835q9fjiid98",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/ae315ded4dba10685dbbafbfa2ff3c1aefeb490d.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/a411ef3e0992d4839f0732ebeb9823024afaaaa8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-completions": {


### PR DESCRIPTION
## Changelog for zsh-autosuggestions:
Branch: master
Commits: [zsh-users/zsh-autosuggestions@ae315ded...a411ef3e](https://github.com/zsh-users/zsh-autosuggestions/compare/ae315ded4dba10685dbbafbfa2ff3c1aefeb490d...a411ef3e0992d4839f0732ebeb9823024afaaaa8)

* [`f90d0407`](https://github.com/zsh-users/zsh-autosuggestions/commit/f90d040784fa67d7bc5e9aca5bdd6517db0bc40e) cleanup: Use more idiomatic method of checking if var is set
* [`7682c138`](https://github.com/zsh-users/zsh-autosuggestions/commit/7682c13860597ce09e672faeae7d3429d5460dcc) cleanup: Pull built-in widget actions into global variable
* [`c114bd22`](https://github.com/zsh-users/zsh-autosuggestions/commit/c114bd2298dcb8a4d30f2c9c61393bf2bd1186dd) Be more specific about the built-in widgets we want to avoid wrapping
* [`19e375bb`](https://github.com/zsh-users/zsh-autosuggestions/commit/19e375bbc81d32aed85596dc73ccfe46aae7bbd5) cleanup: Consolidate `autoload`s
* [`6c634c1e`](https://github.com/zsh-users/zsh-autosuggestions/commit/6c634c1e35cd6093ad01bb6002f63aa5c0f6a3b6) Enable async mode by default in newer versions of zsh
* [`a83c7cf9`](https://github.com/zsh-users/zsh-autosuggestions/commit/a83c7cf9d6a23175079fe28d986e54634e32e0c2) Add links to documentation on zsh glob patterns to the readme
* [`e715ffb1`](https://github.com/zsh-users/zsh-autosuggestions/commit/e715ffb1ae48b04a30a83c3556194d7d5e83daa4) Rewrite `with_history` test helper to be more robust
* [`05f22fa8`](https://github.com/zsh-users/zsh-autosuggestions/commit/05f22fa8a32634534afc2efbefd4458632d5569f) Fix flaky special char specs by not using `with_history` twice per test
* [`e0b96e1b`](https://github.com/zsh-users/zsh-autosuggestions/commit/e0b96e1bd6810a1303a0869658916974a6674187) fix a bug in partial acceptance of suggestions
* [`9ad305c9`](https://github.com/zsh-users/zsh-autosuggestions/commit/9ad305c906bf3e227236e890fd51423c2a689ab3) Update INSTALL.md
* [`bb18c4f6`](https://github.com/zsh-users/zsh-autosuggestions/commit/bb18c4f677b95c2a324ca848fa6c3b9ed1515415) Update INSTALL.md
* [`590c1cd8`](https://github.com/zsh-users/zsh-autosuggestions/commit/590c1cd84ca0157bf41fdd8ad87313125644ea5f) Disable ^C async workaround for zsh version 5.8 and later
* [`89c600c8`](https://github.com/zsh-users/zsh-autosuggestions/commit/89c600c873a7e64b075c916850e80bfd62f81de9) Support new zsh version: 5.8
* [`3ecc53df`](https://github.com/zsh-users/zsh-autosuggestions/commit/3ecc53dfe29442ecc4bcb7f3af6c3a263407ab7c) Update license copyright year
* [`74ba3739`](https://github.com/zsh-users/zsh-autosuggestions/commit/74ba3739bb1d202d7fe4e309e2e907df228b4325) Update changelog for v0.7.0 release
* [`fcca8755`](https://github.com/zsh-users/zsh-autosuggestions/commit/fcca87555fe5c0c93c5ba865505a7e5d7a1a95cb) v0.7.0
