### PR TITLE
niv nixpkgs: update dd03217d -> 29647c9b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dd03217d4944e2ce7f1991dbeacb482e8d5cc2ff",
-        "sha256": "160hbbmjjv0nf2ycgzaajx2blcfqnc90gg6nwlc0dvigip82z0as",
+        "rev": "29647c9b582338b23577be9f9bddba4295e16111",
+        "sha256": "1ps6yr3dqcz2lb8kb5vsfh2p69vzpgh0v6xhxml7lj0z709m9r4j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/dd03217d4944e2ce7f1991dbeacb482e8d5cc2ff.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/29647c9b582338b23577be9f9bddba4295e16111.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@dd03217d...29647c9b](https://github.com/nixos/nixpkgs/compare/dd03217d4944e2ce7f1991dbeacb482e8d5cc2ff...29647c9b582338b23577be9f9bddba4295e16111)

* [`903a4579`](https://github.com/NixOS/nixpkgs/commit/903a45791a8d7b45b57062377bea86f9cf4f31d0) home-assistant: enable venstar tests
* [`5a819352`](https://github.com/NixOS/nixpkgs/commit/5a819352ad668f08fc06b8aa558c5878fa1ec78c) python3Packages.bravia-tv: 1.0.8 -> 1.0.11
* [`11531689`](https://github.com/NixOS/nixpkgs/commit/11531689279217163f89c6d50240e7b04599547b) python3Packages.gios: init at 1.0.1
* [`4ae94a79`](https://github.com/NixOS/nixpkgs/commit/4ae94a79614f2ac0a07839833ffe852783c15d77) home-assistant: update component-packages
* [`d497487a`](https://github.com/NixOS/nixpkgs/commit/d497487acae762382790e7be7b50b8fa877bede8) home-assistant: enable gios tests
* [`5f16f26d`](https://github.com/NixOS/nixpkgs/commit/5f16f26d93eaae3dd9edad893284eab1432f7539) python3Packages.growattserver: init at 1.0.1
* [`b2c343ef`](https://github.com/NixOS/nixpkgs/commit/b2c343ef6fdb75c4c31af7e3e984a758a08eb26f) home-assistant: update component-packages
* [`d94868a4`](https://github.com/NixOS/nixpkgs/commit/d94868a441b219ecfc7b53af71d85f31148b6c53) home-assistant: enable growatt_server tests
* [`438fadd2`](https://github.com/NixOS/nixpkgs/commit/438fadd2ea780669ac361778b25c2bc53b91ce09) python3Packages.ismartgate: init at 4.0.1
* [`26eecaaf`](https://github.com/NixOS/nixpkgs/commit/26eecaaf05235d392607af74aad78a0491e109fd) python3Packages.boschshcpy: init at 0.2.18
* [`8aff25d2`](https://github.com/NixOS/nixpkgs/commit/8aff25d21de76fd3f8b1403e907c41df82eb32c9) python3Packages.aiohomekit: 0.2.62 -> 0.2.66
* [`5113edee`](https://github.com/NixOS/nixpkgs/commit/5113edee2343130ba96c101a9389e3bbde027c73) python3Packages.hap-python: 3.4.1 -> 3.5.0
* [`bb9615fc`](https://github.com/NixOS/nixpkgs/commit/bb9615fce46dccfc62776d0deb86a9a79a9023ac) python3Packages.aiohue: 2.3.1 -> 2.5.0
* [`00b19611`](https://github.com/NixOS/nixpkgs/commit/00b196112253c4da4eb45a39139b4784f4e2e294) python3Packages.openhomedevice: 1.0.0 -> 2.0.1
* [`eac23670`](https://github.com/NixOS/nixpkgs/commit/eac2367067aca1438388a8cbdaa419edff3565ea) python3Packages.garages-amsterdam: 2.1.0 -> 2.1.1
* [`55218443`](https://github.com/NixOS/nixpkgs/commit/552184431bcc3b93dccc64a44f35af9518c002ad) python3Packages.pyatmo: 4.2.3 -> 5.0.1
* [`5684cd0c`](https://github.com/NixOS/nixpkgs/commit/5684cd0c64cf2624408fdb3c7b4581061823036e) python3Packages.pydroid-ipcam: unstable-2021-04-16 -> unstable-2021-06-01
* [`dfa53e1a`](https://github.com/NixOS/nixpkgs/commit/dfa53e1aff5f1cbf427d76b7d628e9a4ce9d1010) python3Packages.python-smarttub: 0.0.24 -> 0.0.25
* [`d3708244`](https://github.com/NixOS/nixpkgs/commit/d370824442bfcd0f9192b67e774d7b3fc291bf7f) home-assistant: 2021.5.5 -> 2021.6.0
* [`82ea022b`](https://github.com/NixOS/nixpkgs/commit/82ea022b008738af0fd9c6aad6e29ac4822a7b0b) python3Packages.aiohomekit: 0.2.66 -> 0.2.67
* [`e6a895c7`](https://github.com/NixOS/nixpkgs/commit/e6a895c79284ef199c3f71baa00f8b3892102f37) python3Packages.zwave-js-server-python: 0.26.0 -> 0.26.1
* [`7ef89797`](https://github.com/NixOS/nixpkgs/commit/7ef89797af0b66dee63637f3b42ae4e4dd5df271) home-assistant: 2021.6.0 -> 2021.6.1
* [`4432b29e`](https://github.com/NixOS/nixpkgs/commit/4432b29e91c47f6511563e89bb3a8cb81ca2b812) python3Packages.xknx: 0.18.3 -> 0.18.4
* [`04015a0a`](https://github.com/NixOS/nixpkgs/commit/04015a0a41a289f7cbb74367c908884702da9cd2) python3Packages.aiolyric: 1.0.6 -> 1.0.7
* [`38dd3a24`](https://github.com/NixOS/nixpkgs/commit/38dd3a24f3286e034b1585f0cc503d9b636b3040) home-assistant: 2021.6.1 -> 2021.6.2
* [`097499bf`](https://github.com/NixOS/nixpkgs/commit/097499bfeb2a1d0434b0bb90b40616e1a176588d) python3Packages.aiorecollect: 1.0.4 -> 1.0.5
* [`85998d1b`](https://github.com/NixOS/nixpkgs/commit/85998d1b02f88cb529f7c07e5485c8e5bdf39265) home-assistant: 2021.6.2 -> 2021.6.3
* [`558cb984`](https://github.com/NixOS/nixpkgs/commit/558cb984de748cdf86f08c8bf5d410390d2503ec) chromiumBeta: 92.0.4515.40 -> 92.0.4515.51
* [`f8a97bf9`](https://github.com/NixOS/nixpkgs/commit/f8a97bf9d8adf56204a57b945257873cf490e523) python3Packages.systembridge: add websockets dependency
* [`feeffee0`](https://github.com/NixOS/nixpkgs/commit/feeffee08103edc1920a00273278eb1f70ea50d5) urxvt-font-size: 2015-05-22 -> 1.3
* [`fa4172e4`](https://github.com/NixOS/nixpkgs/commit/fa4172e4161a2550ed652fc8ef5d826b06effc36) python3Packages.python-igraph: 0.9.4 -> 0.9.5
* [`40f58ac5`](https://github.com/NixOS/nixpkgs/commit/40f58ac5ab142be87cee54a761c96e38fae92a99) maintainers: add ncfavier
* [`c5a63ebf`](https://github.com/NixOS/nixpkgs/commit/c5a63ebf394ecc7c81c0c7e1a88508721958355a) tectonic: 0.4.1 -> 0.5.2
* [`706ce9e2`](https://github.com/NixOS/nixpkgs/commit/706ce9e2308ac370088abb09cf63b20cce2b07cf) nixos/synergy: add encryption support
* [`606bf6dc`](https://github.com/NixOS/nixpkgs/commit/606bf6dc17b6cdc5217a27d9bc703bc0f43f8c58) doc/functions/generators: convert to CommonMark
* [`d5555852`](https://github.com/NixOS/nixpkgs/commit/d555585281829ba4eb007d0b83bae6cb721c5886) zsh-autosuggestions: 0.6.4 -> 0.7.0
* [`8f3bf74e`](https://github.com/NixOS/nixpkgs/commit/8f3bf74e1c1689e8c04f83a2c4cf58b38c17ab33) bosh-cli: init at 6.4.3
* [`07864c64`](https://github.com/NixOS/nixpkgs/commit/07864c64aa106b6f9223973e1e6187828c684ebb) nginxQuic: 12f18e0bca09 -> 1fec68e322d0
* [`44055b45`](https://github.com/NixOS/nixpkgs/commit/44055b455747c850bc3d2bcf5d87d068349efa6e) nixos/manual: update documentation on Qt themes
* [`99f12af6`](https://github.com/NixOS/nixpkgs/commit/99f12af681ebd3369a72580cccddc317841765c5) imagemagick: 6.9.12-12 -> 6.9.12-14
* [`ad502ab5`](https://github.com/NixOS/nixpkgs/commit/ad502ab5c59a49eaf0c92f90201dffd4255a005a) nixos/sourcehut: automatically build and import qemu image for docker
* [`ea5956a2`](https://github.com/NixOS/nixpkgs/commit/ea5956a2ed03bcd34b6d269cbb6613db47d9a957) nixos-rebuild: remove repair, never used
* [`0e8e7968`](https://github.com/NixOS/nixpkgs/commit/0e8e7968d1528ed4df50d6b86e0079ba94ccaf63) nixos-rebuild: prevent masking return value with declaration
* [`07da819b`](https://github.com/NixOS/nixpkgs/commit/07da819bcff7dccac8407698b5144decba81b571) nixos-rebuild: prevent wordsplitting
* [`d6a829e7`](https://github.com/NixOS/nixpkgs/commit/d6a829e7b703cb0453685e6490edfaf9c3d84b67) nixos-rebuild: remove unused variable: remotePATH
* [`971eb043`](https://github.com/NixOS/nixpkgs/commit/971eb043411eef0d6d3010cf9673a6a88fe101eb) nixos-rebuild: fix extraBuildFlags usage with flakes
* [`389f628c`](https://github.com/NixOS/nixpkgs/commit/389f628c08eea2c2301a7eaca22c4f0a90d15072) knot-resolver: skip tests on aarch64-darwin (for now)
* [`81e6e2fd`](https://github.com/NixOS/nixpkgs/commit/81e6e2fdd0eca1ba16dea353ca6dd543448d3500) xfce.thunar: depends on pcre
* [`ff424e99`](https://github.com/NixOS/nixpkgs/commit/ff424e99361df3e88a953da0ca31c7e50378511b) python3Packages.boschshcpy: 0.2.18 -> 0.2.19
* [`e8f08487`](https://github.com/NixOS/nixpkgs/commit/e8f08487b15a473feced964150d3eabd8fdb2942) metasploit: 6.0.47 -> 6.0.48
* [`529db88e`](https://github.com/NixOS/nixpkgs/commit/529db88e931feb6dc2bda558e0568b1b48ab7599) google-cloud-sdk: 343.0.0 -> 344.0.0
* [`8cb2d7a0`](https://github.com/NixOS/nixpkgs/commit/8cb2d7a0950a4b5ddc0e7581b74548d2cbe0d458) python3Packages.pyflic: init at 2.0.3
* [`199a1453`](https://github.com/NixOS/nixpkgs/commit/199a1453ed529f770c96f45a4b2b1a99d05c32a0) python3packages.meteoalertapi: init at 0.1.8
* [`ccfde9b5`](https://github.com/NixOS/nixpkgs/commit/ccfde9b5412e45d29c18a043495ba5d87c93f08d) home-assistant: update component-packages
* [`84c97f7b`](https://github.com/NixOS/nixpkgs/commit/84c97f7b27cf5a68f3e82f3fa602e6dcf95a37b7) python3Packages.meteoalertapi: 0.1.8 -> 0.2.0
* [`21ed7a97`](https://github.com/NixOS/nixpkgs/commit/21ed7a970c7d8da87acc6629c6c71cd40589cac4) vimPlugins.vim-bracketed-paste: init at 2018-05-22
* [`4e5d5bfc`](https://github.com/NixOS/nixpkgs/commit/4e5d5bfc323e7ccb39f57ab915c6c4c14650e070) python3Packages.xknx: 0.18.4 -> 0.18.5
* [`eeb25520`](https://github.com/NixOS/nixpkgs/commit/eeb255207df56b2b28745eb53b33e50bb87c3021) zfsUnstable: 2.1.0-rc6 -> 2.1.0-rc7
* [`71ffc07f`](https://github.com/NixOS/nixpkgs/commit/71ffc07f4e3f56301e6b7737667d4a9cc3202a4a) haskellPackages.cabal2nix-unstable: 2021-06-10 -> 2021-06-12
* [`c0d39d26`](https://github.com/NixOS/nixpkgs/commit/c0d39d26a511ddeb794319d7cfa758c3d96f570f) haskell.packages.ghc901.retry: dont build test suite
* [`c3173699`](https://github.com/NixOS/nixpkgs/commit/c3173699c74b0f68ceb6afee77f258a7e98cbc01) ammonite: 2.3.8 -> 2.4.0
* [`88fc8922`](https://github.com/NixOS/nixpkgs/commit/88fc8922a4908fab2752ea312b40123de8627a51)  mas: 1.8.1 -> 1.8.2
* [`b06a0d40`](https://github.com/NixOS/nixpkgs/commit/b06a0d409e8e7b4f56b9661b0cc5538180b80289) linuxPackages.lttng-modules: 2.10.5 -> 2.12.6
* [`24f34c1b`](https://github.com/NixOS/nixpkgs/commit/24f34c1b90aabda177e156f51242e2df543cf57a) box2d: enable on darwin
* [`2c8871a7`](https://github.com/NixOS/nixpkgs/commit/2c8871a7dbc9db0753fdea004ef264ed249d9791) vscode: 1.56.2 -> 1.57.0
* [`c9ddfed1`](https://github.com/NixOS/nixpkgs/commit/c9ddfed1707f3e830a8a1fe3bdec69057e464f61) tflint: 0.29.0 -> 0.29.1
* [`74c602f2`](https://github.com/NixOS/nixpkgs/commit/74c602f2115904a9d3facfe6d84beda4926e7f30) scheme-bytestructures: init at 1.0.7
* [`0dd23e26`](https://github.com/NixOS/nixpkgs/commit/0dd23e26108575c48c46ba994b6a4aaa92904b60) guile-git: init at 0.3.0
* [`4f6518d8`](https://github.com/NixOS/nixpkgs/commit/4f6518d8ff00ba2cff2947130194e639298250c7) Fix GPLv3Plus license
* [`720c66eb`](https://github.com/NixOS/nixpkgs/commit/720c66eb6189722c1fe80d6b49c2acceefb7f93e) plex-media-player: 2.58.0.1076 -> 2.58.1
* [`c63d4270`](https://github.com/NixOS/nixpkgs/commit/c63d4270feed5eb6c578fe2d9398d3f6f2f96811) linuxPackages.rtl8188eus-aircrack: init at unstable-2021-05-04
* [`741277f5`](https://github.com/NixOS/nixpkgs/commit/741277f5b8d85119dd9f4cc41cdf340b7e8f42c2) vscode-extensions.vadimcn.vscode-lldb: 1.6.1 -> 1.6.3
* [`a5f462e7`](https://github.com/NixOS/nixpkgs/commit/a5f462e79169777a0706312214f473984f7b5648) mindforger: remove use of deprecated QtWebFrame
* [`0887d7a7`](https://github.com/NixOS/nixpkgs/commit/0887d7a7476bef520d35ff6321303bfee7ea5965) ocaml-ng.ocamlPackages_4_13.ocaml: init at 4.13.0-α1
* [`b94e1977`](https://github.com/NixOS/nixpkgs/commit/b94e1977e0c89060d3ba63bbfa6372e0f0d231b3) attr: only supported on Linux
* [`7c85cd4e`](https://github.com/NixOS/nixpkgs/commit/7c85cd4e4be9056a22eaf1bac21e1fff77848650) python3Packages.nsapi: init at 3.0.5
* [`d4652e5a`](https://github.com/NixOS/nixpkgs/commit/d4652e5ac4a7da4aac86218f562de9db8fccc375) home-assistant: update component-packages
* [`69e25514`](https://github.com/NixOS/nixpkgs/commit/69e2551485e674d84ad0e46528825ee83768b10b) home-assistant: update component-packages
* [`61543790`](https://github.com/NixOS/nixpkgs/commit/61543790d3e2b33b8b936b5baa24b86e7a67fb6d) python3Packages.pymeteoclimatic: init at 0.0.6
* [`505f2702`](https://github.com/NixOS/nixpkgs/commit/505f270294caedc9fa07ae76cf2a77b6bce6c769) home-assistant: update component-packages
* [`41fa8557`](https://github.com/NixOS/nixpkgs/commit/41fa85575784f84378bb996a6ecf8a29f28c34e3) home-assistant: enable meteoclimatic tests
* [`2d641a29`](https://github.com/NixOS/nixpkgs/commit/2d641a29abeee4ab098e404b25b359b6f00aada6) nixUnstable: fix cross by disabling documentation
* [`be976cdd`](https://github.com/NixOS/nixpkgs/commit/be976cdda9fcb41402be7ba1d09166e094e5e0f5) materialize: 0.7.1 -> 0.8.0
* [`39bc7363`](https://github.com/NixOS/nixpkgs/commit/39bc7363820157000a389e078808a1d553b9bf6b) nixos/console: allow console.font to be a path
* [`3952d191`](https://github.com/NixOS/nixpkgs/commit/3952d191751df8313e0ba0e17ea4818ded20e027) ungoogled-chromium: 91.0.4472.77 -> 91.0.4472.101
* [`280afb7d`](https://github.com/NixOS/nixpkgs/commit/280afb7d4c03400771ca20f03abab75bc81ce796) wineUnstable: 6.9 -> 6.10
* [`bbfe4e6a`](https://github.com/NixOS/nixpkgs/commit/bbfe4e6a5ef92be765cd6dc4d6aabc54af935704) ocamlPackages.arp: 2.3.1 -> 2.3.2
* [`dc5593c2`](https://github.com/NixOS/nixpkgs/commit/dc5593c2986f2ea6f3babda46d4dfbbcc6686a68) python3Packages.georss-client: 0.13 -> 0.14
* [`9e2b8f07`](https://github.com/NixOS/nixpkgs/commit/9e2b8f07adc6ef70125cdd26d8447a3cff3d7a59) python3Packages.georss-generic-client: 0.4 -> 0.6
* [`0f6a466b`](https://github.com/NixOS/nixpkgs/commit/0f6a466b0cfc49bd312e358fa114d726fd11587e) python3Packages.typed-ast: 1.4.1 -> 1.4.3
* [`9052ddec`](https://github.com/NixOS/nixpkgs/commit/9052ddec409723e297f5de93f9f83e0dee35ba1e) kitty: 0.20.3 -> 0.21.0
* [`af9015c2`](https://github.com/NixOS/nixpkgs/commit/af9015c2aa2795c95fa0dc1743aafeaf0ceafbbe) mindforger: don't use qt5.mkDerivation
* [`48f22f43`](https://github.com/NixOS/nixpkgs/commit/48f22f432d5c7b328ba6cea01a1b5d640563c4da) mindforger: install app on darwin
* [`061b8331`](https://github.com/NixOS/nixpkgs/commit/061b83317da2dcbb937fe9fb76076731b4bc1563) ocamlPackages.index: 1.3.0 -> 1.3.1
* [`047fe2fe`](https://github.com/NixOS/nixpkgs/commit/047fe2fe23a902c777e10ba37534b8a1b7072a1e) emptyFile, emptyDirectory: init
* [`d4859112`](https://github.com/NixOS/nixpkgs/commit/d48591123f4d5936ef6c9fd5d963ce3b1925d4c4) nixos/apache-httpd: Use pkgs.emptyDirectory
* [`c38c5dba`](https://github.com/NixOS/nixpkgs/commit/c38c5dba10e5a239a4d297c64f4c0a5fd2d5e1b9) tests.trivial: Add emptyFile, emptyDirectory to samples
* [`36a4ae8c`](https://github.com/NixOS/nixpkgs/commit/36a4ae8c05f4c8cd6b83bea0374d9bf98f301c11) liblangtag: enable on darwin
* [`a6ff43ca`](https://github.com/NixOS/nixpkgs/commit/a6ff43caa80bc73a639d218c22c5b3605d50d2cc) home-assistant: 2021.6.3 -> 2021.6.4
* [`401e5cf6`](https://github.com/NixOS/nixpkgs/commit/401e5cf6fca7fe461d88af581e707f5300f020d5) bombadillo: Remove empty vendor dependency
* [`fa88e963`](https://github.com/NixOS/nixpkgs/commit/fa88e96379ea461253fe91dc5b009f9910469a92) kubectl-example: Remove empty vendor dependency
* [`4acb93c1`](https://github.com/NixOS/nixpkgs/commit/4acb93c132d1aa767a378927a34f3dd7b0501e88) gjo: Remove empty vendor dependency
* [`c5a98fd7`](https://github.com/NixOS/nixpkgs/commit/c5a98fd73cb3d1bcd59b47e2e4799f870fa9c78f) wineStable: 6.0 -> 6.0.1
* [`327ac769`](https://github.com/NixOS/nixpkgs/commit/327ac769dd734f51c774c99d9a26b8c13e6aefb3) python3Packages.python-igraph: 0.9.5 -> 0.9.6
* [`38c4256a`](https://github.com/NixOS/nixpkgs/commit/38c4256a9635d37ed297e43ade8e6f5ef42893d1) haskellPackages.gtk2hs-buildtools: attempt to fix build on aarch64
* [`1dc8d8f0`](https://github.com/NixOS/nixpkgs/commit/1dc8d8f0c443df7c477dd44c3c914085d8c40347) vscode-extensions.vadimcn.vscode-lldb: 1.6.3 -> 1.6.4
* [`7b92c7f7`](https://github.com/NixOS/nixpkgs/commit/7b92c7f79583c908952423935b75d51d0616149a) haskellPackages.hackage-db: Reactivate hydra job
* [`37c8bfc0`](https://github.com/NixOS/nixpkgs/commit/37c8bfc077f6c160dc186f042c78843e2469a708) haskellPackages.cabal2nix-unstable: Bump for alsa-lib alias
* [`6eaf494a`](https://github.com/NixOS/nixpkgs/commit/6eaf494a8369d72d0f9d1e0deaec30764f8acdf4) haskellPackages: mark builds failing on hydra as broken
* [`0c8e2c2a`](https://github.com/NixOS/nixpkgs/commit/0c8e2c2a11570b5cdcca7282135fe9944410dd00) haskellPackages.mptcp-pm: Disable on darwin to fix eval error
* [`682649cb`](https://github.com/NixOS/nixpkgs/commit/682649cbc05124b8c7a6a3da5364da59ad778258) ripgrep: 12.1.1 -> 13.0.0
* [`e1d5e9da`](https://github.com/NixOS/nixpkgs/commit/e1d5e9da32aeed8fa8107f1a2e8d19ad0e707db5) polylith: init at 0.1.0-alpha9
* [`0d2276ec`](https://github.com/NixOS/nixpkgs/commit/0d2276ec343e8965c023eecc1780d3521276047f) dpdk-kmods: init at 2021-04-21
* [`26744cb5`](https://github.com/NixOS/nixpkgs/commit/26744cb512676fc7b2be0dc7b0c881a6df879245) transgui: fix transgui build on aarch64
* [`e9c55912`](https://github.com/NixOS/nixpkgs/commit/e9c55912021adffb70185df5911540fdd47c7322) pythonPackages: move all throws to python-aliases.nix
* [`a421a74b`](https://github.com/NixOS/nixpkgs/commit/a421a74be31c36ff85829e70a6621ab59fb98a18) tt-rss-plugin-tumblr-gdpr: remove
* [`222dcb8e`](https://github.com/NixOS/nixpkgs/commit/222dcb8ed714244637450ccbf504c957ce427718) google-re2: init at 0.1.20210601 ([nixos/nixpkgs⁠#99938](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/99938))
* [`4988b9bd`](https://github.com/NixOS/nixpkgs/commit/4988b9bda18b0ba4373e15edb71d8538b39fd2c4) authenticator: mark as broken
* [`10f85360`](https://github.com/NixOS/nixpkgs/commit/10f85360c6df79697e32da02ca390113d3004745) maintainers: remove jD91mZM2
* [`baf91ea7`](https://github.com/NixOS/nixpkgs/commit/baf91ea7d9ffab6d1f95395b7c2f724a2e349698) pythonPackages: set mainProgram to pname by default
* [`6650cbfd`](https://github.com/NixOS/nixpkgs/commit/6650cbfd5fe80ed02b388c3396ec1ab1cca84bf9) python3Packages.pytenable: 1.2.8 -> 1.3.0
* [`d6cd94b6`](https://github.com/NixOS/nixpkgs/commit/d6cd94b6b708a3d8d18b8e3b3f1cc83b6f827655) python3Packages.minidump: 0.0.17 -> 0.0.18
* [`29aaf536`](https://github.com/NixOS/nixpkgs/commit/29aaf536bc3e7fdf2f8ca12d236bc05f3eb238af) firefox-beta-bin: 85.0b6 -> 90.0b6
* [`fdca1450`](https://github.com/NixOS/nixpkgs/commit/fdca145086cb64a9a8ec56fb78c56613073f26d2) firefox-devedition-bin: 85.0b6 -> 90.0b6
* [`22ae7ede`](https://github.com/NixOS/nixpkgs/commit/22ae7ededae09201595440fec9809d34261b5767) goofys: init at unstable-2021-03-26
* [`e0b13fe9`](https://github.com/NixOS/nixpkgs/commit/e0b13fe95b22dcf97b048ac1775ad06ef1cfad51) sauerbraten: set mainProgram to sauerbraten_client
* [`52d50b05`](https://github.com/NixOS/nixpkgs/commit/52d50b0585908fbb1a49eb7c5b44f85c71e4d1be) pass-import: 3.1 -> 3.2
* [`c64e4d25`](https://github.com/NixOS/nixpkgs/commit/c64e4d25f76d68e7300df95525f015fd279a7e58) efont-unicode: init at 0.4.2
* [`722e5ccf`](https://github.com/NixOS/nixpkgs/commit/722e5ccfea7f42e11cfb10e92d444da1a9c9fc26) prometheus-node-exporter: fix version info ([nixos/nixpkgs⁠#126580](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/126580))
* [`72fd6f9c`](https://github.com/NixOS/nixpkgs/commit/72fd6f9ca7bbe087566fea304e54ec9455169ed1) mg: 6.8.1 -> 6.9 ([nixos/nixpkgs⁠#126694](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/126694))
* [`cf69e3dc`](https://github.com/NixOS/nixpkgs/commit/cf69e3dc605b2d213989c4e339459ed3ad3575e8) Update pkgs/applications/misc/variety/default.nix
* [`16763ef0`](https://github.com/NixOS/nixpkgs/commit/16763ef031f9edc7f9bc5158a8f5e8dc318bce08) ocamlPackages.magic-mime: 1.0.0 -> 1.1.3
* [`181d7643`](https://github.com/NixOS/nixpkgs/commit/181d764372eb1735cc7daad95445e5e7064c08c4) hyprspace: init at 0.1.2
* [`79f7b965`](https://github.com/NixOS/nixpkgs/commit/79f7b9652fff02c8b0a3bec383b56ff6251f5eab) pdns-recursor: 2.5.1 -> 2.5.2
* [`09866589`](https://github.com/NixOS/nixpkgs/commit/098665898d52d2e296bb5e96737233d146a174ef) weechat: 3.1 -> 3.2
* [`07a8f0c9`](https://github.com/NixOS/nixpkgs/commit/07a8f0c95f0c0b55d23b607b8914a66876ce0ce9) pdns-recursor: fix ambiguous license
* [`bfde742b`](https://github.com/NixOS/nixpkgs/commit/bfde742b86160ac27362eeb39cbbdba1b2e1c832) ocamlPackages.parmap: 1.2 -> 1.2.3
* [`b1f74dd4`](https://github.com/NixOS/nixpkgs/commit/b1f74dd413772d0155608be02c3b720a3b83f742) iosevka: 5.0.2 -> 7.0.4, iosevka-bin: 5.0.5 -> 7.0.4  ([nixos/nixpkgs⁠#126664](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/126664))
* [`a88ad636`](https://github.com/NixOS/nixpkgs/commit/a88ad63642bcf793ffb3a0527f3e222bcedb3f8d) ocamlPackages.fileutils: 0.5.3 -> 0.6.3
* [`a3e6044f`](https://github.com/NixOS/nixpkgs/commit/a3e6044fa663ab77b3a34dc002b314b588f53250) ncurses: fix build on NetBSD
* [`ea67c657`](https://github.com/NixOS/nixpkgs/commit/ea67c657ccc81c84d380522dec694852d8684e0f) ocamlPackages.sha: 1.13 -> 1.14
* [`0d02b47d`](https://github.com/NixOS/nixpkgs/commit/0d02b47ddd479eabb84109054e2a71a8faaf7c5b) llvmPackages_git: 12.0.0 -> 2021-05-17
* [`8e06a395`](https://github.com/NixOS/nixpkgs/commit/8e06a39574aeb6500ad233e3b529e0e43fb80788) clang-tools: fix clangd
* [`0516afb2`](https://github.com/NixOS/nixpkgs/commit/0516afb2675151bd020980826bba831c9f2fb064) starspace: build with gzip support
* [`18664a31`](https://github.com/NixOS/nixpkgs/commit/18664a319a888c7cf52ca784d6e71721cfa2a39d) pferd: 3.0.1 -> 3.1.0
* [`363140fd`](https://github.com/NixOS/nixpkgs/commit/363140fd276b96f0022125c5636ad0ca2b7c5771) micropython: 1.13 -> 1.15
* [`596e9eac`](https://github.com/NixOS/nixpkgs/commit/596e9eac8e60fa974375d6212ed4ca5b7328df60) xfce.ristretto: 0.10.0 -> 0.11.0
* [`a6a82884`](https://github.com/NixOS/nixpkgs/commit/a6a82884a552cabe4f704a0f6d06810c818b34d1) python3Packages.black: 21.5b1 -> 21.6b0
* [`547fb093`](https://github.com/NixOS/nixpkgs/commit/547fb093c3a2542a650c06b4515075870f41350d) imagemagick6: 6.9.12-14 -> 6.9.12-15
* [`54f77325`](https://github.com/NixOS/nixpkgs/commit/54f77325e7ce7d86157e08c084c15cb68e7823c4) imv: install .desktop file
* [`2732a344`](https://github.com/NixOS/nixpkgs/commit/2732a344bbad05bd8245561760c44b688869b487) imv: remove unused fontconfig argument
* [`945c0214`](https://github.com/NixOS/nixpkgs/commit/945c021476da4f8bf0a1845d5c5bee9f9f4d1451) imv: clarify license
* [`da30dd8e`](https://github.com/NixOS/nixpkgs/commit/da30dd8e8fcd841a552395b8605b49cba63bcfd9) python3Packages.aprslib: init at 0.6.47
* [`67d1807e`](https://github.com/NixOS/nixpkgs/commit/67d1807ea99e5aad0a063d150fbbaebdf52eec1e) home-assistant: update component-packages.nix
* [`29647c9b`](https://github.com/NixOS/nixpkgs/commit/29647c9b582338b23577be9f9bddba4295e16111) home-assistant: test aprs component
