### PR TITLE
niv home-manager: update aa36e2d6 -> 1375fd4a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aa36e2d6b481a54b95fbddbecb76076e0f38eb89",
-        "sha256": "1avdicccxkpndq7r15jazjjl070ynp88qnd6f7kc2x1aavhakkly",
+        "rev": "1375fd4a030c27e6c6208b31b8189ca41da01fb0",
+        "sha256": "12pqfnjj15l17vvddwrip58j56vs3rdn6rfv4215lzp9h8f58rpw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/aa36e2d6b481a54b95fbddbecb76076e0f38eb89.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/1375fd4a030c27e6c6208b31b8189ca41da01fb0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@aa36e2d6...1375fd4a](https://github.com/nix-community/home-manager/compare/aa36e2d6b481a54b95fbddbecb76076e0f38eb89...1375fd4a030c27e6c6208b31b8189ca41da01fb0)

* [`42847469`](https://github.com/nix-community/home-manager/commit/42847469b3f65a363dc52b66be09d0ac4edcc55c) zsh: add `completionInit` option ([nix-community/home-manager⁠#2046](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2046))
* [`666eee4f`](https://github.com/nix-community/home-manager/commit/666eee4f72979b0ebbd2e065a3846d7a8a16895c) programs.foot: Always create config file ([nix-community/home-manager⁠#2091](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2091))
* [`fb50102d`](https://github.com/nix-community/home-manager/commit/fb50102daf904c4ced33374816f9ee2cfde24c01) mangohud: add module
* [`25bf3d79`](https://github.com/nix-community/home-manager/commit/25bf3d79531ce45fd36866205bf07a24bb3be2b9) password-store: add environment variables to xsession.importedVariables ([nix-community/home-manager⁠#2103](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2103))
* [`4ed6705b`](https://github.com/nix-community/home-manager/commit/4ed6705b0fa52c93c9131c6cd37cfdc0155d6b33) nixos: set stopIfChanged to false ([nix-community/home-manager⁠#2105](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2105))
* [`c982c19f`](https://github.com/nix-community/home-manager/commit/c982c19f53b35a93463f7b028edb5b862d0243a5) files: properly escape shell arguments
* [`b6613a85`](https://github.com/nix-community/home-manager/commit/b6613a854495ce320dd655a5070010664a09c475) systemd: bring more in line with upstream
* [`1375fd4a`](https://github.com/nix-community/home-manager/commit/1375fd4a030c27e6c6208b31b8189ca41da01fb0) systemd: add `automounts` option
