### PR TITLE
niv niv: update 52749409 -> 65a61b14

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "527494090f7075ed5e3aa15ef7093846e5e25d52",
-        "sha256": "1hahf0i0iix1iyzaaq5a7rbgyfm3xjcfl69lm1b5mas1p8vdimih",
+        "rev": "65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e",
+        "sha256": "17mirpsx5wyw262fpsd6n6m47jcgw8k2bwcp1iwdnrlzy4dhcgqh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/527494090f7075ed5e3aa15ef7093846e5e25d52.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@52749409...65a61b14](https://github.com/nmattia/niv/compare/527494090f7075ed5e3aa15ef7093846e5e25d52...65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e)

* [`e9e31a72`](https://github.com/nmattia/niv/commit/e9e31a7248e0728ab67a5a911b7ef704b1e399c4) foo: stdenv.lib -> lib
* [`e0ca65c8`](https://github.com/nmattia/niv/commit/e0ca65c81a2d7a4d82a189f1e23a48d59ad42070) examples: stdenv.lib -> lib
* [`65a61b14`](https://github.com/nmattia/niv/commit/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e) Update documentation
