### PR TITLE
niv powerlevel10k: update b9c62ca0 -> 717573d8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "b9c62ca02827c828fb544033950232e5426930ad",
-        "sha256": "1ysx7jg8gr9ya3r6zijxb2v0ziylwj9mwr162q5qiyxa7ckqsd9s",
+        "rev": "717573d845944c32e8a42059d21052e72972b4f2",
+        "sha256": "0ysp23b3bxqh3mhszhgmgzxkqkjnbqlshp382pajwfl49hw5hfqr",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/b9c62ca02827c828fb544033950232e5426930ad.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/717573d845944c32e8a42059d21052e72972b4f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@b9c62ca0...717573d8](https://github.com/romkatv/powerlevel10k/compare/b9c62ca02827c828fb544033950232e5426930ad...717573d845944c32e8a42059d21052e72972b4f2)

* [`4ba3c010`](https://github.com/romkatv/powerlevel10k/commit/4ba3c010f6fa66dcf7d785251c80c416454b6e90) display "wip" in git status if the latest commit's summary contains "wip" or "WIP" ([romkatv/powerlevel10k⁠#1425](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1425))
* [`96f3ca17`](https://github.com/romkatv/powerlevel10k/commit/96f3ca173331c5dba505d2ef5106cb0d605ec3be) Squashed 'gitstatus/' changes from 113f1f69..96b520b2
* [`038de6f7`](https://github.com/romkatv/powerlevel10k/commit/038de6f78b21171615d0b4628471e71efe10d77e) Squashed 'gitstatus/' changes from 96b520b2..260a5f4b
* [`4e4c1492`](https://github.com/romkatv/powerlevel10k/commit/4e4c14927fe45a8280b60c547a864175f2e92ac2) update windows terminal font instructions to accound for the fact that they've changed the default settings.json ([romkatv/powerlevel10k⁠#1443](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1443))
* [`a49f90d3`](https://github.com/romkatv/powerlevel10k/commit/a49f90d3ba7e8f89ab69c2ba846b81cd6f784dc0) cleanup
* [`717573d8`](https://github.com/romkatv/powerlevel10k/commit/717573d845944c32e8a42059d21052e72972b4f2) presume that `node --version` may depend on package.json ([romkatv/powerlevel10k⁠#1388](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1388))
