### PR TITLE
niv spacemacs: update 120ce695 -> 2fd3eb3e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "120ce6959d10cac04ae27b0a024f879d6d8356bf",
-        "sha256": "1cy02idcalraq2yj7zavlblsc203r1hxjdaz76zkwngmcwvldmi2",
+        "rev": "2fd3eb3edbc7c09b825892ce53721120bb999504",
+        "sha256": "00jpk6vhz3r2zbnm0xvqrglgd72m59xj6744r3p2canz0w9kkyhg",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/120ce6959d10cac04ae27b0a024f879d6d8356bf.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/2fd3eb3edbc7c09b825892ce53721120bb999504.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@120ce695...2fd3eb3e](https://github.com/syl20bnr/spacemacs/compare/120ce6959d10cac04ae27b0a024f879d6d8356bf...2fd3eb3edbc7c09b825892ce53721120bb999504)

* [`af193f76`](https://github.com/syl20bnr/spacemacs/commit/af193f769f52edd611b6cd805630bd4bd025fb0f) [git] Update instructions for global-git-commit-mode
* [`58168158`](https://github.com/syl20bnr/spacemacs/commit/58168158d2d10552770ed62e4e4a84f97fe5aae4) Replace flycheck-perl6 with flycheck-raku ([syl20bnr/spacemacs⁠#14818](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14818))
* [`2fd3eb3e`](https://github.com/syl20bnr/spacemacs/commit/2fd3eb3edbc7c09b825892ce53721120bb999504) [transmission] Add new keybindings ([syl20bnr/spacemacs⁠#14819](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14819))
