### PR TITLE
niv nixpkgs: update 29647c9b -> 4826d60b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29647c9b582338b23577be9f9bddba4295e16111",
-        "sha256": "1ps6yr3dqcz2lb8kb5vsfh2p69vzpgh0v6xhxml7lj0z709m9r4j",
+        "rev": "4826d60ba2724b0e9f56438ae0394424e32efc6a",
+        "sha256": "17idhkwq59rv0mdb6dkvly6f5n2qq767i1bsriij8dv21asnd3x6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/29647c9b582338b23577be9f9bddba4295e16111.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4826d60ba2724b0e9f56438ae0394424e32efc6a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@29647c9b...4826d60b](https://github.com/nixos/nixpkgs/compare/29647c9b582338b23577be9f9bddba4295e16111...4826d60ba2724b0e9f56438ae0394424e32efc6a)

* [`3f667821`](https://github.com/NixOS/nixpkgs/commit/3f667821252ee6baaa38868c9fea95136ffe91b0) pythonPackages.pyqtwebengine: disable python 2 support
* [`38034013`](https://github.com/NixOS/nixpkgs/commit/38034013e3832460860e6ea63dc074797a954c92) pythonPackages.pyqt-builder: add eduardosm as maintainer
* [`d6e728ef`](https://github.com/NixOS/nixpkgs/commit/d6e728efc21a8658353d87542957a8b1a1caf05a) pythonPackages.qscintilla-qt5: add pythonImportsCheck and disable Python 2 support
* [`a1539652`](https://github.com/NixOS/nixpkgs/commit/a1539652494ac9484c1982c6cfe7ed93280dcd0f) pythonPackages.pyqt5: fix license and homepage
* [`f5888e72`](https://github.com/NixOS/nixpkgs/commit/f5888e7277f35efd47a5f3d93a3e8fc4126a277d) pythonPackages.sip{,_4}: update homepage
* [`42d9ba90`](https://github.com/NixOS/nixpkgs/commit/42d9ba907ceae0d90e08cf52fdcc9b16208b81ae) hplip_3_18_5: remove
* [`a3e96e61`](https://github.com/NixOS/nixpkgs/commit/a3e96e616f3b5bd2d1c79de046420a9b847bfcfb) pythonPackages.pyqt5: remove Python 2 support
* [`3b606629`](https://github.com/NixOS/nixpkgs/commit/3b6066299d7cf89ebef7027e9d9e974cb24fd3e2) pythonPackages.qscintilla-qt5: do not use `with pythonPackages;`
* [`0da8789e`](https://github.com/NixOS/nixpkgs/commit/0da8789e736d16fa42e0913aed3a5c835bab3630) slides: 0.2.0 -> 0.3.0
* [`52457525`](https://github.com/NixOS/nixpkgs/commit/52457525adde1b9a80bffd57139b28e7402477b8) veusz: fix PyQt5 sip path and use sip 4
* [`015fa4e5`](https://github.com/NixOS/nixpkgs/commit/015fa4e53e0ff069abbea93ccecc9c84571311fd) python3Packages.pyqt5: use python callPackage instead of qt5 callPackage
* [`373e9efc`](https://github.com/NixOS/nixpkgs/commit/373e9efc264eeedec22f65a26acf6e8997266b52) mpd: 0.22.8 -> 0.22.9
* [`a3fd8234`](https://github.com/NixOS/nixpkgs/commit/a3fd8234b887cdc8bf007ea47fef57899e8a8b31) freetube: 0.13.1 -> 0.13.2
* [`a397294e`](https://github.com/NixOS/nixpkgs/commit/a397294e06392168819be2b3bbd8d09d880cd0bb) vimPlugins: update
* [`8ca4f6c8`](https://github.com/NixOS/nixpkgs/commit/8ca4f6c8520f1c1025c94bc27571b76c38151398) vimPlugins.neorg: init at 2021-06-26
* [`14ec3c0a`](https://github.com/NixOS/nixpkgs/commit/14ec3c0a82dc8e08effa12ae5a56cd63be036b1f) gemrb: vlc is only needed on mac
* [`189a6ba9`](https://github.com/NixOS/nixpkgs/commit/189a6ba91d81962f017651af3d5ffca5a37fcae5) rpg-cli: 0.4.1 -> 0.5.0
* [`773bdf69`](https://github.com/NixOS/nixpkgs/commit/773bdf699871fdc590c0ff94b464f19149264f79) why3: 1.3.3 → 1.4.0
* [`d6053472`](https://github.com/NixOS/nixpkgs/commit/d60534722e90a367a5c849fb7ecc294f08c75755) why3: use GTK3
* [`4c31c211`](https://github.com/NixOS/nixpkgs/commit/4c31c2113f5535f96d97ad9fb0b639f11128ae39) pythonPackages.pystray: 0.17.3 -> 0.17.4
* [`0a977cf1`](https://github.com/NixOS/nixpkgs/commit/0a977cf125a86b5580de6e05bfeaa07aa54c4a78) nixos/duplicity: fix typo in subcommand
* [`9a9def4b`](https://github.com/NixOS/nixpkgs/commit/9a9def4bf5739552a1ed3dc2ea81fcec5d31f6ac) python3Packages.aiohomekit: 0.2.67 -> 0.3.0
* [`e73b32f1`](https://github.com/NixOS/nixpkgs/commit/e73b32f1c51d8fd343eb68656d5c82d7384dd690) vlang: 0.1.21 -> weekly.2021.25
* [`3524f5a4`](https://github.com/NixOS/nixpkgs/commit/3524f5a4c9a8b4695628046d7e8348bca5bb198b) python3Packages.adblock: 0.4.4 -> 0.5.0
* [`22ea812b`](https://github.com/NixOS/nixpkgs/commit/22ea812bffbccb200d587be4ce7ed29978d98910) ghostwriter: 2.0.1 -> 2.0.2
* [`4ba70da8`](https://github.com/NixOS/nixpkgs/commit/4ba70da807359ed01d662763a96c7b442762e5ef) ghostwriter: add run-time dependencies to PATH
* [`8ee5356a`](https://github.com/NixOS/nixpkgs/commit/8ee5356aa98e80d96183d374dc8affb8e754015a) python3Packages.total-connect-client: init at 0.58
* [`57bb3d7e`](https://github.com/NixOS/nixpkgs/commit/57bb3d7e7aad3d6f9f1b6b35a7e949b4c037d80a) home-assistant: update component-packages.nix
* [`1d473cf5`](https://github.com/NixOS/nixpkgs/commit/1d473cf59377e961260b8dbab5e1b7bca9b2f66d) home-assistant: test totalconnect component
* [`8e4c6b84`](https://github.com/NixOS/nixpkgs/commit/8e4c6b845965440850eaec79db7086e5d9e350fd) nushell: 0.32.0 -> 0.33.0
* [`4502e7e4`](https://github.com/NixOS/nixpkgs/commit/4502e7e46f9eb800014e436ad0e5a5ec695a5dc6) spotify-tui: 0.23.0 -> 0.24.0
* [`9ecc9078`](https://github.com/NixOS/nixpkgs/commit/9ecc9078cd921bf81ec8f31814c95fe5447b0b23) ombi: 4.0.1345 -> 4.0.1430
* [`90925dbf`](https://github.com/NixOS/nixpkgs/commit/90925dbf68d686645fcc71dd33411af7bdf328e0) linuxPackages.veikk-linux-driver: mark broken for kernels older than 4.19
* [`988677d7`](https://github.com/NixOS/nixpkgs/commit/988677d741d60787471474e4b77d6c9e34b4e037) python3Packages.upcloud-api: init at 2.0.0
* [`e33db522`](https://github.com/NixOS/nixpkgs/commit/e33db52206a359737f3479fa51d0be5306a4816d) home-assistant: update component-packages.nix
* [`59245deb`](https://github.com/NixOS/nixpkgs/commit/59245deb146837de15f9b1e71335973cbc8d5449) home-assistant: test upcloud component
* [`a4459504`](https://github.com/NixOS/nixpkgs/commit/a4459504c81d5ed2f889be8c74f92404a9927548) python3Packages.aiomodernforms: init at 0.1.7
* [`3f4d568c`](https://github.com/NixOS/nixpkgs/commit/3f4d568ccf41afc6f20435aaea2b884cb15f38b8) python3Packages.synologydsm-api: init at 1.0.2
* [`3a9eeac3`](https://github.com/NixOS/nixpkgs/commit/3a9eeac3c173f017199e045e1c6219ad72e93823) home-assistant: update component-packages.nix
* [`654ca524`](https://github.com/NixOS/nixpkgs/commit/654ca524212865bc7f68a3c769b1857d86bb85d7) home-assistant: test synology_dsm component
* [`cb6b93e2`](https://github.com/NixOS/nixpkgs/commit/cb6b93e29963405ce41d3fd3734ffe31f9c0c8c4) python3Packages.python-juicenet: init at 1.0.2
* [`968e0987`](https://github.com/NixOS/nixpkgs/commit/968e0987d7e9dc7edac4d49eb9118e19fbd054e4) home-assistant: update component-packages.nix
* [`c82cb95a`](https://github.com/NixOS/nixpkgs/commit/c82cb95a02ed74ba3105a318d13e48acf86f8a5a) home-assistant: test juicenet component
* [`177164ba`](https://github.com/NixOS/nixpkgs/commit/177164baa71e98b60964151eea36785e2e567ada) jitsi-meet-electron: 2.8.6 -> 2.8.7 ([nixos/nixpkgs⁠#128259](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128259))
* [`f45ccc53`](https://github.com/NixOS/nixpkgs/commit/f45ccc532b3667a9784ec83f355a32d48ca589a1) fastd: 21 -> 22 ([nixos/nixpkgs⁠#128301](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128301))
* [`5ea390f6`](https://github.com/NixOS/nixpkgs/commit/5ea390f6c05a51b23a5f9c169ec66d151d2658bd) fancy-motd: unstable-2021-05-26 -> unstable-2021-06-27
* [`a608decd`](https://github.com/NixOS/nixpkgs/commit/a608decddccf6f413293188438ad4cae0b28876f) python3Packages.forecast-solar: init at 1.3.1
* [`a9d36bc6`](https://github.com/NixOS/nixpkgs/commit/a9d36bc6feafed0928703c93fd4cfdd23d27ddcb) libsForQt5.mauikit: only supports Qt>=5.15
* [`dc87cf52`](https://github.com/NixOS/nixpkgs/commit/dc87cf529880ec6ddbc4ac3011928fc28ef2ff58) tdesktop: 2.8.0 -> 2.8.1
* [`bbd9f938`](https://github.com/NixOS/nixpkgs/commit/bbd9f938d44658b7f0d2b8b95ddceb36b330da33) tdesktop: Finalize the update script
* [`4a9f048d`](https://github.com/NixOS/nixpkgs/commit/4a9f048d8964307172e8f8be51d08b84a4fcccad) mangohud: 0.6.3 → 0.6.4
* [`34131ae7`](https://github.com/NixOS/nixpkgs/commit/34131ae72823d9ba24fbd8ca71b0f674ce5ee622) stevenblack-blocklist: 3.7.9 -> 3.7.10
* [`ada25b1a`](https://github.com/NixOS/nixpkgs/commit/ada25b1a983557c690d42b8d7de153b989f55bad) bear: 3.0.12 -> 3.0.13
* [`e1dc1d6c`](https://github.com/NixOS/nixpkgs/commit/e1dc1d6c33441f933c2094d949c613aaf108a603) python3Packages.aiomodernforms: 0.1.7 -> 0.1.8
* [`3b9daa68`](https://github.com/NixOS/nixpkgs/commit/3b9daa68280f6b207291636db49e7872a7ab7f5b) python3Packages.pyrituals: 0.0.3 -> 0.0.4
* [`df7bc169`](https://github.com/NixOS/nixpkgs/commit/df7bc169742461f7aa7744bebc4881f5f3b76432) ceph-csi: init at 3.3.1 ([nixos/nixpkgs⁠#123472](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123472))
* [`15fe4be1`](https://github.com/NixOS/nixpkgs/commit/15fe4be12b1e79d7ecfb07ee29e58a16a19f0ad3) pycritty: init at 0.3.5 ([nixos/nixpkgs⁠#128166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128166))
* [`d67d3710`](https://github.com/NixOS/nixpkgs/commit/d67d37104aa041e0d13643f9060a175eac5e4201) i3status-rust: 0.20.1 -> 0.20.2
* [`efe2e4e8`](https://github.com/NixOS/nixpkgs/commit/efe2e4e8c2da7ef263adcd9eaf8c1c920f6f36f1) pan: fix build and format
* [`fb81b076`](https://github.com/NixOS/nixpkgs/commit/fb81b076729e0675df8475ad340e7e275c1e8769) python3Packages.pypdf3: init at 1.0.5
* [`62bdc511`](https://github.com/NixOS/nixpkgs/commit/62bdc5114a08040f2e03bac9f0c6a38f343ce29e) calibre-web: 0.6.11 -> 0.6.12
* [`a06aeca3`](https://github.com/NixOS/nixpkgs/commit/a06aeca3bbefe5ea08604387eeeba68e64650acd) libint: init at 2.6.0 ([nixos/nixpkgs⁠#128083](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128083))
* [`edba9765`](https://github.com/NixOS/nixpkgs/commit/edba976506ba7dca308e7b01b554676b263534f6) wpa_supplicant: allow disabling pcsclite dependency ([nixos/nixpkgs⁠#128182](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128182))
* [`e1d6051d`](https://github.com/NixOS/nixpkgs/commit/e1d6051d81835079f0e37e1d5fc5f029f32df512) imagej: reformat expression
* [`25d22238`](https://github.com/NixOS/nixpkgs/commit/25d2223859d27063c8f7d7baa68568a63801bcad) ytmdl: 2021.05.26 -> 2021.06.26 ([nixos/nixpkgs⁠#128256](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128256))
* [`34eb39f1`](https://github.com/NixOS/nixpkgs/commit/34eb39f141bc925cdde2ea56d74b7ea82534dd46) obs-move-transition: 2.3.0 -> 2.4.3 ([nixos/nixpkgs⁠#128270](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128270))
* [`ecb5cd97`](https://github.com/NixOS/nixpkgs/commit/ecb5cd972ff1cb5a40cb15c6d177fa81e9003713) unison: patch 2.51.3
* [`07500621`](https://github.com/NixOS/nixpkgs/commit/0750062126633db814ead9298902e845102ab1ba) imagej: Add desktop item and icon
* [`796ae067`](https://github.com/NixOS/nixpkgs/commit/796ae067c4b6348e900c1384ef3759dc90fef01c) imagej: 150 -> 153
* [`9216c9f1`](https://github.com/NixOS/nixpkgs/commit/9216c9f195dd24501072ae59e61db3961433b74b) gupnp: 1.2.4 -> 1.2.7
* [`6b0a1dfd`](https://github.com/NixOS/nixpkgs/commit/6b0a1dfd4ce13e4f336fec0e7488986fc080edb5) epson-escpr2: 1.1.25 -> 1.1.34
* [`664d835d`](https://github.com/NixOS/nixpkgs/commit/664d835d7ecbe173fe11d8089575a14c60f6f9ee) ginkgo: 1.16.3 -> 1.16.4
* [`29b2c507`](https://github.com/NixOS/nixpkgs/commit/29b2c507b8489c60fe0e2bdd4d445e1547bed069) goreleaser: 0.168.0 -> 0.172.0
* [`d4ae1277`](https://github.com/NixOS/nixpkgs/commit/d4ae12779a74f05b58b4f4432e10ac040331689a) gpg-tui: 0.6.0 -> 0.6.1
* [`b16dbf99`](https://github.com/NixOS/nixpkgs/commit/b16dbf99b6dca94a4c5468fee649e04de51017d3) hyprspace: 0.1.4 -> 0.1.5
* [`dcbc0954`](https://github.com/NixOS/nixpkgs/commit/dcbc095441cda3325c81d98673542f0704000a49) home-assistant: requires setuptools
* [`572c9219`](https://github.com/NixOS/nixpkgs/commit/572c9219ad1f4ecffa2ff0459f2e0b1355c78dc5) wio:0.0.0+unstable=2021-06-01 -> 0.0.0+unstable=2021-06-27
* [`74281b9f`](https://github.com/NixOS/nixpkgs/commit/74281b9faa2f5cf64f43573b04e7a30fdf559a80) globalprotect-vpn: add missing 'mkIf cfg.enable'
* [`31487e43`](https://github.com/NixOS/nixpkgs/commit/31487e434b317195d22e2e9b4810a46285df0782) bochs: refactor and prepare it for next release
* [`110a85fd`](https://github.com/NixOS/nixpkgs/commit/110a85fd367e6e0d2443a403863548247abe1be4) distrobuilder: 2019_10_07 -> 1.2
* [`83c72771`](https://github.com/NixOS/nixpkgs/commit/83c727719024f6d0a0e88dd30041a55f8702c6a3) python3Packages.lmnotify: init at 0.0.4
* [`23e3724a`](https://github.com/NixOS/nixpkgs/commit/23e3724a11f9e1119d717fde53e4f3ac8a42e5ca) home-assistant: update component-packages.nix
* [`875e4abc`](https://github.com/NixOS/nixpkgs/commit/875e4abc7dd81a90837c31e7df1b2ead161c8b5d) vsce/asciidoctor.asciidoctor-vscode: init at 2.8.9
* [`e13f126c`](https://github.com/NixOS/nixpkgs/commit/e13f126c4be4068b216845d19e4852f7799c067e) python3Packages.geopandas: 0.8.1 → 0.9.0
* [`5b2824b9`](https://github.com/NixOS/nixpkgs/commit/5b2824b9e2534a9aa4c8cc8f32f3322ea757640b) matomo: 4.2.1 -> 4.3.1
* [`3f50543e`](https://github.com/NixOS/nixpkgs/commit/3f50543e347c074f2834c0a899d3b1fbd626375f) neovide: enable wayland usage without xwayland
* [`5550614a`](https://github.com/NixOS/nixpkgs/commit/5550614aba16a6cab98f3b97f88302db4201cf2a) python3Packages.pytibber: 0.17.1 -> 0.18.0
* [`4f3bc6aa`](https://github.com/NixOS/nixpkgs/commit/4f3bc6aa7f333627e86d52dbef6d9686ca296b35) ocamlPackages.utop: 2.7.0 → 2.8.0
* [`5ca20c29`](https://github.com/NixOS/nixpkgs/commit/5ca20c29fa5c7311e0467a6783229474febb0685) wireless-regdb: 2020.04.29 -> 2021.04.21
* [`e8905779`](https://github.com/NixOS/nixpkgs/commit/e89057790aeb3fc3792a33afd6256ed820692e93) nix-direnv: 1.2.6 -> 1.4.0
* [`9fdc5e10`](https://github.com/NixOS/nixpkgs/commit/9fdc5e10eea0b7f36d7712ae64a943787a807e00) smlnj: fix x86_64-darwin build
* [`4a4fc6c9`](https://github.com/NixOS/nixpkgs/commit/4a4fc6c9c91b895f39c0b402426751f2174b43d9) smlnjBootstrap: move dependents over to regular smlnj
* [`1c450db3`](https://github.com/NixOS/nixpkgs/commit/1c450db3cca4a3aa1f00bf2c454dc7e17b21f661) yq: fix build
* [`2b41f19f`](https://github.com/NixOS/nixpkgs/commit/2b41f19f791abc139695a9fe8c4c0015eae36f5a) volk: 2.4.1 -> 2.5.0
* [`124bbaf3`](https://github.com/NixOS/nixpkgs/commit/124bbaf311076d6e6b79bc2093fa4726a388cc16) lsp-plugins: 1.1.26 -> 1.1.30 ([nixos/nixpkgs⁠#128330](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128330))
* [`c15d6f57`](https://github.com/NixOS/nixpkgs/commit/c15d6f570cefd259976b0ffa66cc835393c7a089) python3Packages.lmnotify: update description
* [`5698f711`](https://github.com/NixOS/nixpkgs/commit/5698f71177f280b549693d237d7c70f77c9a1f77) python3Packages.pysyncthru: init at 0.7.3
* [`45c5ead5`](https://github.com/NixOS/nixpkgs/commit/45c5ead53c38ad358d05992aa0edc7a1a150609a) home-assistant: update component-packages.nix
* [`49d03473`](https://github.com/NixOS/nixpkgs/commit/49d0347312af5e1cdccac6f9fa13c6db35fb09ff) home-assistant: test syncthru component
* [`a3d04338`](https://github.com/NixOS/nixpkgs/commit/a3d043387fa335a6a723dc31188e99c5230ce0c2) nixos/tests/home-assistant: don't test package
* [`4502f74f`](https://github.com/NixOS/nixpkgs/commit/4502f74f29e4daaaae5fc61a52818b3bc6f86b94) chuck: 1.4.0.1 -> 1.4.1.0
* [`ee8bdde2`](https://github.com/NixOS/nixpkgs/commit/ee8bdde2cea283e4ca01736d07626852fda7d3bc) emacs.pkgs.ebuild-mode: init at 1.52
* [`78df2079`](https://github.com/NixOS/nixpkgs/commit/78df2079fce786a020a2d8fb9a07ea7241ee2a11) python3Packages.starline: init at 0.1.5
* [`831807d6`](https://github.com/NixOS/nixpkgs/commit/831807d65ac46e71372fd1c2bc8161b4fff13d93) home-assistant: update component-packages.nix
* [`0e6f2e22`](https://github.com/NixOS/nixpkgs/commit/0e6f2e2201a78f663f4cb159ebf79f03c61c778b) home-assistant: test starline component
* [`568ca861`](https://github.com/NixOS/nixpkgs/commit/568ca86168da1cb778c4a1adec2f3f781f87d037) dpdk: make myself maintainer
* [`24da5909`](https://github.com/NixOS/nixpkgs/commit/24da590943a28b20bfd9c3dbae3210068c5bc817) python3Packages.srpenergy: init at 1.3.2
* [`12fd96ae`](https://github.com/NixOS/nixpkgs/commit/12fd96ae06482d8da6601cc2b41ae7a4d3bfae32) home-assistant: update component-packages.nix
* [`6b21275e`](https://github.com/NixOS/nixpkgs/commit/6b21275e586453b19c0dd2cb68aa9b31c9a80bde) home-assistant: test srp_energy component
* [`25eb4871`](https://github.com/NixOS/nixpkgs/commit/25eb4871dedaffd054b97c099cf436d2992850c8) polkadot: 0.9.6 -> 0.9.7
* [`254a1f32`](https://github.com/NixOS/nixpkgs/commit/254a1f32a6a4664b7a6072c9f7419f1802b3a5a5) libsForQt5.kimageformats: fix build after libavif update
* [`7286fc29`](https://github.com/NixOS/nixpkgs/commit/7286fc29c544f66126c955d4374a53684e4a6c37) qutebrowser: 2.2.3 -> 2.3.0
* [`98336c22`](https://github.com/NixOS/nixpkgs/commit/98336c223b7778053bf8136c2f269ce4dfec29f5) pkgs-lib: allow paths in TOML, YAML and JSON
* [`3a30f526`](https://github.com/NixOS/nixpkgs/commit/3a30f526761528bc7b4dd609709e71b643a929ba) nixos/nginx: fix typo
* [`aee94b09`](https://github.com/NixOS/nixpkgs/commit/aee94b0981182417b5e2b07f07e5ff18e3cf4a70) scream: 3.6 -> 3.7
* [`3bccd612`](https://github.com/NixOS/nixpkgs/commit/3bccd612d343ebffb24e4ba62bc83164d7dc6457) openring: unstable-2021-04-03 -> unstable-2021-06-28
* [`6edeec2b`](https://github.com/NixOS/nixpkgs/commit/6edeec2b73dd744b4eda7ef8247a427bec9068e5) python3Packages.trezor: patch for updated dep
* [`3864c36b`](https://github.com/NixOS/nixpkgs/commit/3864c36b790f253e5109f833a788ece7e2dfbaa4) tdesktop: 2.8.1 -> 2.8.3
* [`367a53a8`](https://github.com/NixOS/nixpkgs/commit/367a53a82b0a3ffe6c1ea4261c22764129994669) linux_5_13: init at 5.13
* [`2ced8f24`](https://github.com/NixOS/nixpkgs/commit/2ced8f24554648c6a8b1bb27a9cc087600c3644b) checkstyle: 8.43 -> 8.44
* [`a8c0b777`](https://github.com/NixOS/nixpkgs/commit/a8c0b77793f90283b9e652504de63f8086d98c14) volk: remove unused argument
* [`6fe65621`](https://github.com/NixOS/nixpkgs/commit/6fe65621771fa409c1ad0cbd61b138eb384a5a4e) go-minimock: 3.0.8 -> 3.0.9
* [`b3beccf6`](https://github.com/NixOS/nixpkgs/commit/b3beccf6798936bac20c687e81c58f5c7efc04db) kodiPackages.inputstream-adaptive: 2.6.16 -> 2.6.17
* [`3b77eb17`](https://github.com/NixOS/nixpkgs/commit/3b77eb173434e366b26b5e95975f4556e80ce9d4) fluent-bit: 1.7.6 -> 1.7.9
* [`87f2fe53`](https://github.com/NixOS/nixpkgs/commit/87f2fe53663c0fc6c6d6eee6f0d773b50ecd3020) fuzzel: 1.5.4 -> 1.6.0
* [`886c38ab`](https://github.com/NixOS/nixpkgs/commit/886c38abb8dc139652169a11044a0f61f0afa69e) gophernotes: 0.7.2 -> 0.7.3
* [`f1413d34`](https://github.com/NixOS/nixpkgs/commit/f1413d34e9fb60d5f93ae737ed5c41365e59e441) cargo-flash: 0.10.1 -> 0.11.0
* [`a54553ef`](https://github.com/NixOS/nixpkgs/commit/a54553eff6527994bd6efab15f9023aa28066135) volk: fix darwin build
* [`d71d7ece`](https://github.com/NixOS/nixpkgs/commit/d71d7ecef16788f717ba5d1ae739fb8915648205) tinc_pre: 1.1pre17 -> 1.1pre18
* [`2b0ad115`](https://github.com/NixOS/nixpkgs/commit/2b0ad115b2133a005d8353378df216955db26d12) esbuild: 0.12.9 -> 0.12.11
* [`7f07b70d`](https://github.com/NixOS/nixpkgs/commit/7f07b70d08e19322c2b982be8e37746419e26add) Revert "writers: Allow string paths"
* [`b9317c2a`](https://github.com/NixOS/nixpkgs/commit/b9317c2afe0dc44e7243327d25c6799d6c553d0d) python3Packages.hstspreload: 2021.6.21 -> 2021.6.28
* [`56d11e14`](https://github.com/NixOS/nixpkgs/commit/56d11e1467123fb1cd6212418aa2703520415524) gupnp: revert [nixos/nixpkgs⁠#128448](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128448) ([nixos/nixpkgs⁠#128543](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128543))
* [`5dcfdb5b`](https://github.com/NixOS/nixpkgs/commit/5dcfdb5bd679fb3773ca4f7b56a9918a0072fb46) restique: init at unstable-2021-05-03
* [`0dccbe27`](https://github.com/NixOS/nixpkgs/commit/0dccbe2729efbaee995605bff8de3c83ca61860f) nixos/tests/kernel-generic: fix evaluation
* [`0432fe10`](https://github.com/NixOS/nixpkgs/commit/0432fe1034f8780170157e86b0383f68cb4e2c5e) hugo: 0.84.1 -> 0.84.2
* [`447e75a2`](https://github.com/NixOS/nixpkgs/commit/447e75a24c310f6175091955f8ec1886b7cdcdca) imgproxy: 2.16.4 -> 2.16.5
* [`40db7836`](https://github.com/NixOS/nixpkgs/commit/40db7836fe09eadd3cfcf9127011b10ffd0e4f95) k9s: 0.24.10 -> 0.24.11
* [`6b06737e`](https://github.com/NixOS/nixpkgs/commit/6b06737e5a01aab9bb655cc69370e4e30da1b2fe) katago: 1.8.2 -> 1.9.0
* [`13034ba7`](https://github.com/NixOS/nixpkgs/commit/13034ba77aa98f28c804d0b1638d9bab96d3e768) mimalloc: 2.0.0 -> 2.0.2
* [`58e6fa61`](https://github.com/NixOS/nixpkgs/commit/58e6fa615a9e7fe7a6f6ae7f8c705dabeab292ae) mimalloc: make use of MI_INSTALL_TOPLEVEL
* [`89400633`](https://github.com/NixOS/nixpkgs/commit/89400633b973709eeb1276e1008bb181e39b5b50) mimalloc: revert doCheck enable
* [`2820afa6`](https://github.com/NixOS/nixpkgs/commit/2820afa6f6da3317fb0a17827768d5cf9eb3e756) gxemul: 0.6.2 -> 0.7.0
* [`16fbc036`](https://github.com/NixOS/nixpkgs/commit/16fbc036ef46d950c450c64071fad5e97f29435d) snort: 2.9.16.1 -> 2.9.18 ([nixos/nixpkgs⁠#128580](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128580))
* [`0616d2a4`](https://github.com/NixOS/nixpkgs/commit/0616d2a4634c0102021a7ff01349d27a1f37b815) blueberry: 1.4.3 -> 1.4.4
* [`f717dcaf`](https://github.com/NixOS/nixpkgs/commit/f717dcafbfa0acb9bd5bd349cf3f314e1cd608b3) avocode: 4.14.3 -> 4.15.0
* [`c805959f`](https://github.com/NixOS/nixpkgs/commit/c805959fbcb0cdcaf45128cf07aaa4d461bae3ee) texlive: drop unused "fetch&unpack" derivations ([nixos/nixpkgs⁠#126982](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/126982))
* [`8b7e73dd`](https://github.com/NixOS/nixpkgs/commit/8b7e73ddb036f6a039050bd1484f5a0e5276e1c0) cbonsai: 1.2.0 -> 1.2.1
* [`8ad7f248`](https://github.com/NixOS/nixpkgs/commit/8ad7f2487eb9525794cc3b5d1ed298ebc97592f0) ocamlPackages.ppxlib: 0.22.0 → 0.22.2
