### PR TITLE
niv home-manager: update 1375fd4a -> 9b7a90da

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1375fd4a030c27e6c6208b31b8189ca41da01fb0",
-        "sha256": "12pqfnjj15l17vvddwrip58j56vs3rdn6rfv4215lzp9h8f58rpw",
+        "rev": "9b7a90daa17022c428e3b6da36814f5f9a804a35",
+        "sha256": "1r3kxdnqzapkylsnhiw0xz1qdi3mglppnkqmv35j70ilma5j52bp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1375fd4a030c27e6c6208b31b8189ca41da01fb0.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9b7a90daa17022c428e3b6da36814f5f9a804a35.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1375fd4a...9b7a90da](https://github.com/nix-community/home-manager/compare/1375fd4a030c27e6c6208b31b8189ca41da01fb0...9b7a90daa17022c428e3b6da36814f5f9a804a35)

* [`e0f2949c`](https://github.com/nix-community/home-manager/commit/e0f2949c981a636ff1a75bd075e2a614af3bafb1) direnv: add enableFlakes option for enableNixDirenvIntegration ([nix-community/home-manager⁠#2089](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2089))
* [`be0e73a3`](https://github.com/nix-community/home-manager/commit/be0e73a308e9c6f778b7dc710ec6c6fe154b8634) qutebrowser: add quickmark support ([nix-community/home-manager⁠#2059](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2059))
* [`9b39fd7e`](https://github.com/nix-community/home-manager/commit/9b39fd7eb4468781ac0e72c32fc5f86bc9f0f7ea) sxhkd: stop scope before creating ([nix-community/home-manager⁠#2086](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2086))
* [`1e8d0bea`](https://github.com/nix-community/home-manager/commit/1e8d0beae47ab7001d2ae10f738b566f8622d1a2) xresources: load .Xresources in xsession.initExtra
* [`e92f5bb7`](https://github.com/nix-community/home-manager/commit/e92f5bb79e8c72b6afd64d3b6e4614669fcc1518) programs.gnome-terminal: terminal options ([nix-community/home-manager⁠#2042](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2042))
* [`63af2d3e`](https://github.com/nix-community/home-manager/commit/63af2d3e4cac0a84a87b72be0135f5bcec5a9d5d) home-manager: add `home-manager option`
* [`5a19e0ea`](https://github.com/nix-community/home-manager/commit/5a19e0ea9c0da04b9d1e494335f8e743681ce442) home-manager: fix nixos-option evaluation ([nix-community/home-manager⁠#2115](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2115))
* [`6cd92c64`](https://github.com/nix-community/home-manager/commit/6cd92c643aff65a0eaf4e134a1a85cf4545a33ba) sxhkd: minor formatting in test
* [`a01fe9f8`](https://github.com/nix-community/home-manager/commit/a01fe9f81e0364046ff4683307400c5a41c631af) sxhkd: fix service test
* [`3aa479d5`](https://github.com/nix-community/home-manager/commit/3aa479d55101346fffe49235caf39566c4b62732) dunst: make icon_path extensible ([nix-community/home-manager⁠#2097](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2097))
* [`d04e52b0`](https://github.com/nix-community/home-manager/commit/d04e52b0c05afb41139e313dba9b62d1b4878245) terminator: add module ([nix-community/home-manager⁠#2063](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2063))
* [`6d9bff77`](https://github.com/nix-community/home-manager/commit/6d9bff77eda4426b7b9a5e8f0e9b94fe47798582) rsibreak: add package when enabled; fixes [nix-community/home-manager⁠#2092](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2092) ([nix-community/home-manager⁠#2118](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2118))
* [`2f6d5c90`](https://github.com/nix-community/home-manager/commit/2f6d5c90f4497dc3cfc043c0fd1b77272ebaeeaa) fzf: also use custom package for shell integrations ([nix-community/home-manager⁠#2119](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2119))
* [`e70524cd`](https://github.com/nix-community/home-manager/commit/e70524cd2b50682fcb55fc799e7391dc18375903) bspwm: various improvements ([nix-community/home-manager⁠#2095](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2095))
* [`dc1b6b83`](https://github.com/nix-community/home-manager/commit/dc1b6b834987ed5d9f49666bc10765b0f86be6af) bspwm: re-add support for lists as config option values ([nix-community/home-manager⁠#2125](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2125))
* [`a73e6193`](https://github.com/nix-community/home-manager/commit/a73e619377230ff42529fd99843a8dfcb1f6de5c) tests: update nmt
* [`cd11c02c`](https://github.com/nix-community/home-manager/commit/cd11c02c286a996ff55010146baecae4c413634f) command-not-found: update from nixpkgs
* [`04955ca9`](https://github.com/nix-community/home-manager/commit/04955ca970b65c1a5d6f04a888139f30b0a18e38) README: fix outdated description ([nix-community/home-manager⁠#2131](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2131))
* [`762f860c`](https://github.com/nix-community/home-manager/commit/762f860cfb71be9046a97ca4059ddb9a7221f68b) tests: prevent some unnecessary downloads
* [`49864a43`](https://github.com/nix-community/home-manager/commit/49864a4370fcf4114aef839bfb0b81876b6ae8e5) xmonad: document breakage of recompilation ([nix-community/home-manager⁠#2024](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2024))
* [`b42fce7a`](https://github.com/nix-community/home-manager/commit/b42fce7aaae71bbf5160d88b1772cd9167b03d1a) i3,sway: add bar color options for the focused output ([nix-community/home-manager⁠#2135](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2135))
* [`21ac4c49`](https://github.com/nix-community/home-manager/commit/21ac4c499b181b9171770f79105241e235046a7c) xmonad: restrict news entry to Linux
* [`ab0e6c3e`](https://github.com/nix-community/home-manager/commit/ab0e6c3e0e8a301a8426ecf053853ce5984c42e2) tests: bump nmt
* [`7e2b1a42`](https://github.com/nix-community/home-manager/commit/7e2b1a42aaf709bb982dd1dad6f1f3bba290d64d) i18n.inputMethod: add module
* [`0ada50fc`](https://github.com/nix-community/home-manager/commit/0ada50fc9c620f7ad9f7c6ff70bf40514f4400a9) docs: document how to reset the nix-env
* [`8eee5f52`](https://github.com/nix-community/home-manager/commit/8eee5f5272ac21df2f2db4b51eed28820c499930) obs-studio: use wrapobs and the new plugin layout ([nix-community/home-manager⁠#2142](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2142))
* [`8d3b273a`](https://github.com/nix-community/home-manager/commit/8d3b273afef0e6c3d6d6e4239c9c9d79b1ab6ed7) himalaya: add module
* [`f4998f0a`](https://github.com/nix-community/home-manager/commit/f4998f0adccc60a2b463f1892e3eb42b9715a8ee) tests: bump nmt
* [`2aeaf65e`](https://github.com/nix-community/home-manager/commit/2aeaf65e8f9219c1acdb47bcf278983b3170a344) files: assert that target files are unique
* [`a17bc321`](https://github.com/nix-community/home-manager/commit/a17bc3217f0d0a622f2818b2f3ea997f06cd00a4) zsh: add `enableSyntaxHighlighting` option ([nix-community/home-manager⁠#2144](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2144))
* [`dc4337d9`](https://github.com/nix-community/home-manager/commit/dc4337d9fed5b437913e51722fa150b9eae7d91c) xresources: Add path configuration option ([nix-community/home-manager⁠#2141](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2141))
* [`85d67b0a`](https://github.com/nix-community/home-manager/commit/85d67b0a6e3a395bba97805821863dab143e33f8) xsession: Add profilePath configuration option ([nix-community/home-manager⁠#2140](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2140))
* [`9b7a90da`](https://github.com/nix-community/home-manager/commit/9b7a90daa17022c428e3b6da36814f5f9a804a35) files: minor cleanup
