### PR TITLE
niv powerlevel10k: update 717573d8 -> 0c862a13

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "717573d845944c32e8a42059d21052e72972b4f2",
-        "sha256": "0ysp23b3bxqh3mhszhgmgzxkqkjnbqlshp382pajwfl49hw5hfqr",
+        "rev": "0c862a130710b351e34720fcbc90684239bd9d6c",
+        "sha256": "05zivrwglbs4xr1fy2157jyx2hqyjzw5spazx0swp8l3b57z38gz",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/717573d845944c32e8a42059d21052e72972b4f2.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/0c862a130710b351e34720fcbc90684239bd9d6c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@717573d8...0c862a13](https://github.com/romkatv/powerlevel10k/compare/717573d845944c32e8a42059d21052e72972b4f2...0c862a130710b351e34720fcbc90684239bd9d6c)

* [`606d4a85`](https://github.com/romkatv/powerlevel10k/commit/606d4a85a9b8f4a29d5e9b1bce31f22fe6f7fb30) readme: update git commands for ahead/behind arrows
* [`67f494cf`](https://github.com/romkatv/powerlevel10k/commit/67f494cf54372af576296407f02f862ae0a057bc) docs: cross-link two faq entries
* [`515422c7`](https://github.com/romkatv/powerlevel10k/commit/515422c727539c39caf1f46eb8823c1454fd7fb6) fix a bug that can cause instant prompt to be duplicated in z4h
* [`c003c253`](https://github.com/romkatv/powerlevel10k/commit/c003c253e8f4b3afde76d09c95691f77178b7cc8) respect POWERLEVEL9K_INSTANT_PROMPT_COMMAND_LINES if it is explicitly set even when using z4h
* [`f1ff6804`](https://github.com/romkatv/powerlevel10k/commit/f1ff6804871d47381b9bd398a60f4c77174fd1d3) Squashed 'gitstatus/' changes from 260a5f4b..76182238
* [`0c862a13`](https://github.com/romkatv/powerlevel10k/commit/0c862a130710b351e34720fcbc90684239bd9d6c) add zwc make target
