### PR TITLE
niv spacemacs: update 2fd3eb3e -> 64fed6f7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "2fd3eb3edbc7c09b825892ce53721120bb999504",
-        "sha256": "00jpk6vhz3r2zbnm0xvqrglgd72m59xj6744r3p2canz0w9kkyhg",
+        "rev": "64fed6f7daba47144b09403a4982f26eb79b8ec6",
+        "sha256": "0f6qyjhc9yff6559w8qz5037q5b1yvbz9zdb7x9dxvrn31qrh7ki",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/2fd3eb3edbc7c09b825892ce53721120bb999504.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/64fed6f7daba47144b09403a4982f26eb79b8ec6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@2fd3eb3e...64fed6f7](https://github.com/syl20bnr/spacemacs/compare/2fd3eb3edbc7c09b825892ce53721120bb999504...64fed6f7daba47144b09403a4982f26eb79b8ec6)

* [`9bde46ee`](https://github.com/syl20bnr/spacemacs/commit/9bde46ee577fd772cb93b513d01fac19b94fcd67) [python] Fix keybinding in README ([syl20bnr/spacemacs⁠#14851](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14851))
* [`4039ad58`](https://github.com/syl20bnr/spacemacs/commit/4039ad5852dc908ecf70408b5e6c3e69c5081a51) [dune] Remove obsolete auto-mode-alist declaration
* [`ab6b165e`](https://github.com/syl20bnr/spacemacs/commit/ab6b165e964ad9b731b1a0b80f3ed419d67694a2) [dotnet] Change bindings to be based on p for project
* [`b0ef47a8`](https://github.com/syl20bnr/spacemacs/commit/b0ef47a885fb43e31230627c7e3ea057f2e4235e) [org] Fix org-habit ([syl20bnr/spacemacs⁠#14838](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14838))
* [`443311c8`](https://github.com/syl20bnr/spacemacs/commit/443311c8f1d7c6ebbe1d10be576a4edc47e03a5a) Small fix: unquote keymap symbols in scheme layer ([syl20bnr/spacemacs⁠#14866](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14866))
* [`cf21402c`](https://github.com/syl20bnr/spacemacs/commit/cf21402c5c82ad9965fa20937010f1a88fbf1191) Revert "Fix which-key entries: gr and gs in dired and magit"
* [`64fed6f7`](https://github.com/syl20bnr/spacemacs/commit/64fed6f7daba47144b09403a4982f26eb79b8ec6) core-dotspacemacs: Fixes typo 
