### PR TITLE
niv nixpkgs-fmt: update d5809df4 -> 1d773768

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/nixpkgs-fmt/",
         "owner": "nix-community",
         "repo": "nixpkgs-fmt",
-        "rev": "d5809df4def9f47421c871101e34b917b76f2118",
-        "sha256": "1f1bg739di1fmgasp105j45x1zbf3walngfv834ns0qw7zabwm2b",
+        "rev": "1d773768ba9941c934f55a8815260cadd27ea9bd",
+        "sha256": "14s7i0q5mqnx4v8k5b8hafs51fw1d4dsr97ip5yq5jygcw2mzk3x",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/d5809df4def9f47421c871101e34b917b76f2118.tar.gz",
+        "url": "https://github.com/nix-community/nixpkgs-fmt/archive/1d773768ba9941c934f55a8815260cadd27ea9bd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs-fmt:
Branch: master
Commits: [nix-community/nixpkgs-fmt@d5809df4...1d773768](https://github.com/nix-community/nixpkgs-fmt/compare/d5809df4def9f47421c871101e34b917b76f2118...1d773768ba9941c934f55a8815260cadd27ea9bd)

* [`1d773768`](https://github.com/nix-community/nixpkgs-fmt/commit/1d773768ba9941c934f55a8815260cadd27ea9bd) flake.lock.nix: work in pure mode
