### PR TITLE
niv zsh-syntax-highlighting: update 0e1bb144 -> f0e6a8ef

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "0e1bb14452e3fc66dcc81531212e1061e02c1a61",
-        "sha256": "09ncmyqlk9a3h470z0wgbkrznb5zyc9dj96011wm89rdxc1irxk2",
+        "rev": "f0e6a8ef5c90ff3e1e9516df666e36e02d0f362d",
+        "sha256": "1imcxz5fxhmkjjbrqikk01zh07kjal7nrgfwf2q2dprsiasy7jv3",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/0e1bb14452e3fc66dcc81531212e1061e02c1a61.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/f0e6a8ef5c90ff3e1e9516df666e36e02d0f362d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@0e1bb144...f0e6a8ef](https://github.com/zsh-users/zsh-syntax-highlighting/compare/0e1bb14452e3fc66dcc81531212e1061e02c1a61...f0e6a8ef5c90ff3e1e9516df666e36e02d0f362d)

* [`f0e6a8ef`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/f0e6a8ef5c90ff3e1e9516df666e36e02d0f362d) main: Honor shwordsplit when expanding parameters
