### PR TITLE
niv nixpkgs: update 29647c9b -> 5165af00

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29647c9b582338b23577be9f9bddba4295e16111",
-        "sha256": "1ps6yr3dqcz2lb8kb5vsfh2p69vzpgh0v6xhxml7lj0z709m9r4j",
+        "rev": "5165af0033eb17bc9668f21215833aa1eb203f01",
+        "sha256": "0mwsv50v3rzixibmldl484arqv18wvjldqfxijif9h289k0lbvj3",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/29647c9b582338b23577be9f9bddba4295e16111.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5165af0033eb17bc9668f21215833aa1eb203f01.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@29647c9b...5165af00](https://github.com/nixos/nixpkgs/compare/29647c9b582338b23577be9f9bddba4295e16111...5165af0033eb17bc9668f21215833aa1eb203f01)

* [`0616d2a4`](https://github.com/NixOS/nixpkgs/commit/0616d2a4634c0102021a7ff01349d27a1f37b815) blueberry: 1.4.3 -> 1.4.4
* [`f717dcaf`](https://github.com/NixOS/nixpkgs/commit/f717dcafbfa0acb9bd5bd349cf3f314e1cd608b3) avocode: 4.14.3 -> 4.15.0
* [`c805959f`](https://github.com/NixOS/nixpkgs/commit/c805959fbcb0cdcaf45128cf07aaa4d461bae3ee) texlive: drop unused "fetch&unpack" derivations ([nixos/nixpkgs⁠#126982](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/126982))
* [`8b7e73dd`](https://github.com/NixOS/nixpkgs/commit/8b7e73ddb036f6a039050bd1484f5a0e5276e1c0) cbonsai: 1.2.0 -> 1.2.1
* [`233e6c45`](https://github.com/NixOS/nixpkgs/commit/233e6c455bd0a16c9c7b2ffb7f0f3b7ee0640673) cri-o-unwrapped: 1.21.0 -> 1.21.1
* [`8ad7f248`](https://github.com/NixOS/nixpkgs/commit/8ad7f2487eb9525794cc3b5d1ed298ebc97592f0) ocamlPackages.ppxlib: 0.22.0 → 0.22.2
* [`7262a1e0`](https://github.com/NixOS/nixpkgs/commit/7262a1e04640e20db991c115e20f4aaa3cb9bbd3) protoc-gen-go: 1.27.0 -> 1.27.1
* [`9125a1f0`](https://github.com/NixOS/nixpkgs/commit/9125a1f063c0bc3bfcefd2125377123cffc1a0b3) owncloud-client: 2.6.3.14058 -> 2.8.2.4246
* [`007b856b`](https://github.com/NixOS/nixpkgs/commit/007b856b9bfce67b48f4ec75a22b9fad48a42c6a) maintainer-list: update diffumist email
* [`1eb70b95`](https://github.com/NixOS/nixpkgs/commit/1eb70b952cd324e98021e3109b1710837129579b) materia-kde-theme: 20210612 -> 20210624
* [`4dfdf93e`](https://github.com/NixOS/nixpkgs/commit/4dfdf93eaf1f942b9bfdc5a8001baf698329e646) arduino-cli: add zlib to the fhsenv
* [`a7260e81`](https://github.com/NixOS/nixpkgs/commit/a7260e81fc6b722a63641be5923b100ff646c8c8) gnuradio: 3.9.1.0 -> 3.9.2.0
* [`c8d0af7c`](https://github.com/NixOS/nixpkgs/commit/c8d0af7cffae3068326162cbdddcfdad8b97932a) gnuradio3_8: 3.8.3.0 -> 3.8.3.1
* [`64f45f1c`](https://github.com/NixOS/nixpkgs/commit/64f45f1cf6f018c0eeefcf462137e1aee4e494e0) gpg-tui: fix build on Darwin
* [`be766447`](https://github.com/NixOS/nixpkgs/commit/be76644735ad3ef60f2a405fdee79036a5e9a76a) coqPackages.semantics: init
* [`66ca618b`](https://github.com/NixOS/nixpkgs/commit/66ca618b336643e6d593c1dd1bf57ce653c6b5d5) sumo: 1.8.0 -> 1.9.2
* [`6beaa711`](https://github.com/NixOS/nixpkgs/commit/6beaa711035c6fec6842d2f65320e9dc4f3b85c4) maintainers: update mtreca
* [`cca08690`](https://github.com/NixOS/nixpkgs/commit/cca086901537588d4a9e4afabd7f16a5a8ac7300) openmpi: re-enable fortran on aarch64-darwin
* [`fcdcb819`](https://github.com/NixOS/nixpkgs/commit/fcdcb819362836505e059ef1c5cb33c737883400) chromiumDev: Fix build errors due to the older system FFmpeg
* [`e4552975`](https://github.com/NixOS/nixpkgs/commit/e4552975fea1fbb5680d6a4c83765efc79cf5296) intel-gmmlib: 21.1.3 -> 21.2.1
* [`96f9da08`](https://github.com/NixOS/nixpkgs/commit/96f9da0808d33f287a6122ddceb3e991aaca14f7) python3Packages.sonarr: init at 0.3.0
* [`94d8b2dc`](https://github.com/NixOS/nixpkgs/commit/94d8b2dcb219f25d3aaaa426d8c460feaf0860b3) home-assistant: update component-packages.nix
* [`4bb462b8`](https://github.com/NixOS/nixpkgs/commit/4bb462b8f86dd9b7e00aca4b5039812bac3e5540) home-assistant: test sonarr component
* [`67641dc3`](https://github.com/NixOS/nixpkgs/commit/67641dc31a098e7e2a6defcdbceea18d0cf38c3e) exfatprogs: init at 1.1.2
* [`a0fbb879`](https://github.com/NixOS/nixpkgs/commit/a0fbb879d8d858ab9742a72601233c1eacea299e) macchina: 0.8.21 -> 0.9.2
* [`db1ee4e1`](https://github.com/NixOS/nixpkgs/commit/db1ee4e1f80d9be57bcb979ea1546b5c1da66bda) python3Packages.smarthab: init at 0.21
* [`b1d184de`](https://github.com/NixOS/nixpkgs/commit/b1d184deeb5ab300aa864f08b048c0da7d2598dd) home-assistant: update component-packages.nix
* [`f5d90899`](https://github.com/NixOS/nixpkgs/commit/f5d90899d4de88f4b4d881ad6e541dfb56575cba) home-assistant: test smarthab component
* [`485d0fc9`](https://github.com/NixOS/nixpkgs/commit/485d0fc9730a9e1d460e00af1d1becc541e2ad4f) php: expose mkExtension
* [`577baa24`](https://github.com/NixOS/nixpkgs/commit/577baa24a90660fcda9afe2843da7317441150ea) python3Packages.zwave-js-server-python: 0.26.1 -> 0.27.0
* [`89400f1d`](https://github.com/NixOS/nixpkgs/commit/89400f1deca2cbe337e9abcf022e2b2a9683bed1) libint: restrict to x86_64-linux
* [`55562f81`](https://github.com/NixOS/nixpkgs/commit/55562f8122757b163889e8af5f02bcce9007e204) xonotic: fix url
* [`f71e493d`](https://github.com/NixOS/nixpkgs/commit/f71e493dea00c9fc9f585f1cc4ffdbf8c3862876) python3Packages.smart-meter-texas: init at 0.4.3
* [`6d682ef3`](https://github.com/NixOS/nixpkgs/commit/6d682ef306c48a3949688a2f9702d21e894a015f) home-assistant: update component-packages.nix
* [`2e25f443`](https://github.com/NixOS/nixpkgs/commit/2e25f443c9ec15b9f034612709f188777411a884) home-assistant: test smart_meter_texas component
* [`87d1763f`](https://github.com/NixOS/nixpkgs/commit/87d1763f6cd01684ba89dbade4b0ce0cef87c26e) unity3d: update sha1 to sha256
* [`4ec0164a`](https://github.com/NixOS/nixpkgs/commit/4ec0164ab19c7645f42db39597d6e908915b57fd) python3Packages.somfy-mylink-synergy: init at 1.0.6
* [`e3ff8f56`](https://github.com/NixOS/nixpkgs/commit/e3ff8f5658113c09af31d8484fe868447e88c20d) home-assistant: update component-packages.nix
* [`99d3252b`](https://github.com/NixOS/nixpkgs/commit/99d3252b18a7d3e22406182a5a3b12ccb55ab8b9) ocamlPackages.stringext: 1.4.0 -> 1.6.0 ([nixos/nixpkgs⁠#128598](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128598))
* [`b2bbee02`](https://github.com/NixOS/nixpkgs/commit/b2bbee0263ddf0e97b72c10ffad5761cfecbfc5f) home-assistant: test somfy_mylink component
* [`4de7808b`](https://github.com/NixOS/nixpkgs/commit/4de7808be39322923641baab9f99bc9d880f3c5b) matrix-synapse: 1.36.0 -> 1.37.0
* [`9a6cc8c6`](https://github.com/NixOS/nixpkgs/commit/9a6cc8c6a23636c4569175a0581dc78385dc2fbc) fava: 1.18 -> 1.19
* [`d6d0ec6e`](https://github.com/NixOS/nixpkgs/commit/d6d0ec6e670f86d2d267e4c516fa6a85992364f2) python3Packages.env-canada: init at 0.4.0
* [`ee8a5b4b`](https://github.com/NixOS/nixpkgs/commit/ee8a5b4b030095517c85a32ea54c17cf6a48200e) home-assistant: update component-packages
* [`c2908dd0`](https://github.com/NixOS/nixpkgs/commit/c2908dd006e9ded5dfbae38684780f30278bff9d) smooth: 0.9.6 -> 0.9.8
* [`6547c857`](https://github.com/NixOS/nixpkgs/commit/6547c857619515961122cd58719fdd5c392ea653) boca: 1.0.4 -> 1.0.5
* [`f8c38a00`](https://github.com/NixOS/nixpkgs/commit/f8c38a003ef80e8d4a1c29202e38f95eac8b0f8f) freac: 1.1.4 -> 1.1.5
* [`50839b44`](https://github.com/NixOS/nixpkgs/commit/50839b44984e0a0750226509b26a45e014828214) atlassian-confluence: 7.11.0 -> 7.12.2
* [`0ed38b83`](https://github.com/NixOS/nixpkgs/commit/0ed38b838c25670036b42d24e615ff263b370022) irqbalance: 1.7.0 -> 1.8.0
* [`e97c8973`](https://github.com/NixOS/nixpkgs/commit/e97c8973583ecfdf2c179c07c16acadf1a99e6c7) python3Packages.maestral: 1.4.4 -> 1.4.5
* [`a82cae55`](https://github.com/NixOS/nixpkgs/commit/a82cae55d30e2ebc34ffe54cbe7c62a8936b6b29) maestral-gui: 1.4.4 -> 1.4.5
* [`4eace804`](https://github.com/NixOS/nixpkgs/commit/4eace804a5209942e78456be3e2034438f0eef80) python3Packages.hikvision: init at 2.0.4
* [`0f2266fa`](https://github.com/NixOS/nixpkgs/commit/0f2266fa95ea211e8251a37f0a2c00d0a5d1c833) home-assistant: update component-packages
* [`7b54a8b4`](https://github.com/NixOS/nixpkgs/commit/7b54a8b453ed4f5de76e0efa28a3fa2cd0dafb4f) exploitdb: 2021-06-25 -> 2021-06-29
* [`f9326f6c`](https://github.com/NixOS/nixpkgs/commit/f9326f6c4c5f7905cd1d6e0a89b1db612e0a5eb9) cockroachdb: remove myself as maintainer
* [`0877a5a2`](https://github.com/NixOS/nixpkgs/commit/0877a5a2fddff02546dff01a3890450762d168f7) bspwm: remove myself as maintainer
* [`059c8fc4`](https://github.com/NixOS/nixpkgs/commit/059c8fc437ea45c1224760be28e83e49d34b7eb1) mbed-cli: remove myself as maintainer
* [`b24622c3`](https://github.com/NixOS/nixpkgs/commit/b24622c31d8dd07c70add79e87eb0669b96f820f) go-sct: remove myself as maintainer
* [`dfa1e4ca`](https://github.com/NixOS/nixpkgs/commit/dfa1e4ca37d4b9751806506c79e4403fc6f61fcc) SDL: fix wrongly linking to Mesa on Darwin
* [`d7ea598b`](https://github.com/NixOS/nixpkgs/commit/d7ea598b27ccd5b05726a260eebdf4ab80131e4a) gh: 1.11.0 -> 1.12.0
* [`5edaead2`](https://github.com/NixOS/nixpkgs/commit/5edaead2dc639d6ce4d65106c0e667f335e255bc) delta: 0.8.1 -> 0.8.2
* [`b93605da`](https://github.com/NixOS/nixpkgs/commit/b93605da8fa8f803a5d8d8cc59e81ce0d6309291) minikube: 1.20.0 -> 1.21.0
* [`7a14444a`](https://github.com/NixOS/nixpkgs/commit/7a14444ae15f6363e7af446983aa939ecc9bbcb0) python3Packages.hass-nabucasa: 0.43.1 -> 0.44.0
* [`ed632262`](https://github.com/NixOS/nixpkgs/commit/ed6322629865c501a34a3fa9db1f490db577de7e) python3Packages.pyrfxtrx: init at 0.27.0
* [`7d5239da`](https://github.com/NixOS/nixpkgs/commit/7d5239daee27c5420a4e0404b0b289c98f3afc2b) home-assistant: update component-packages.nix
* [`722ea721`](https://github.com/NixOS/nixpkgs/commit/722ea721ab6ce59a784057185efd57eb555b923f) home-assistant: test rfxtrx component
* [`b4bab183`](https://github.com/NixOS/nixpkgs/commit/b4bab183beabc51c7b571a0fc3b76a5d591579d2) tektoncd-cli: 1.19.0 -> 1.19.1
* [`55017c22`](https://github.com/NixOS/nixpkgs/commit/55017c227772afa471c2e75062f1101d54e243f7) deno: 1.11.2 -> 1.11.3
* [`8da86729`](https://github.com/NixOS/nixpkgs/commit/8da867297a6494a6777ad7cbe73a1d69aa9ff392) fishPlugins.pure: 3.4.2 -> 4.1.1
* [`f32b99cb`](https://github.com/NixOS/nixpkgs/commit/f32b99cb31479f7716f1d1476d0c06d70898dbbc) abcmidi: 2021.06.24 -> 2021.06.27
* [`7da8d833`](https://github.com/NixOS/nixpkgs/commit/7da8d833067b9d35c65571c5d9eab8c4fd533a34) python3Packages.requests-pkcs12: 1.9 -> 1.10
* [`d65c0f9f`](https://github.com/NixOS/nixpkgs/commit/d65c0f9f919296f93f6fa4426467fccd4ed601f5) stegseek: 0.5 -> 0.6
* [`8dbcdaca`](https://github.com/NixOS/nixpkgs/commit/8dbcdacaadd103cc12457441f42b8627d835a18d) traitor: 0.0.3 -> 0.0.7
* [`ee9ee764`](https://github.com/NixOS/nixpkgs/commit/ee9ee7646bd882de5db44384e04c39af117348c2) terrascan: 1.6.0 -> 1.7.0
* [`d34cee35`](https://github.com/NixOS/nixpkgs/commit/d34cee35a3ac22ce19376ff94ca3212b2fba5505) sqlfluff: 0.6.0a2 -> 0.6.0
* [`e77f1cb7`](https://github.com/NixOS/nixpkgs/commit/e77f1cb7cdd48593c132e8fb41d07de3af771e46) logseq: 0.2.0 -> 0.2.2
* [`a888795c`](https://github.com/NixOS/nixpkgs/commit/a888795ce7d50d9ca3e0a24a7ff7627b915aa8f6) knockpy: 5.0.0 -> 5.1.0
* [`0b13e8e8`](https://github.com/NixOS/nixpkgs/commit/0b13e8e8907d9c69f78bfa50292dcf0a66f6db41) python3Packages.pubnub: 5.1.3 -> 5.1.4
* [`39a492c9`](https://github.com/NixOS/nixpkgs/commit/39a492c91cb942476647e7c08f6d73093e6cacae) python3Packages.pytenable: 1.3.0 -> 1.3.1
* [`5775580f`](https://github.com/NixOS/nixpkgs/commit/5775580fca61a7301d59a5a572d37a21367c8c2e) smatch: cleanup
* [`53bdcb70`](https://github.com/NixOS/nixpkgs/commit/53bdcb70be02d2e455e4b9a55b8320d56642bc01) python3Packages.adafruit-platformdetect: 3.14.0 -> 3.14.2
* [`b9806191`](https://github.com/NixOS/nixpkgs/commit/b980619182ba8cd7f6d817a1d715b88a13cf1539) python3Packages.adafruit-pureio: 1.1.8 -> 1.1.9
* [`5199ae50`](https://github.com/NixOS/nixpkgs/commit/5199ae50b47180dfa6c9da23bf9e627b002ded9f) natscli: 0.0.22 -> 0.0.24
* [`1a9636f7`](https://github.com/NixOS/nixpkgs/commit/1a9636f784e94bd34a4a20e48dc3de558b3d2973) python3Packages.python-http-client: 3.3.1 -> 3.3.2
* [`2a6fb19a`](https://github.com/NixOS/nixpkgs/commit/2a6fb19a2a59f0d4dac15397945698706c03e18c) python3Packages.asyncstdlib: 3.9.1 -> 3.9.2
* [`6c61f091`](https://github.com/NixOS/nixpkgs/commit/6c61f0919364d694acc07a613059080e350d855d) python3Packages.enturclient: 0.2.1 -> 0.2.2
* [`2ccb0e4b`](https://github.com/NixOS/nixpkgs/commit/2ccb0e4b8677b6afc34c0f41a19c8d8df8cc13fa) nwg-panel: init at 0.3.2
* [`994671a2`](https://github.com/NixOS/nixpkgs/commit/994671a25951a0b1fa7788f47b945408df164628) quakespasm: 0.93.1 -> 0.93.2 ([nixos/nixpkgs⁠#128654](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128654))
* [`9e08ce61`](https://github.com/NixOS/nixpkgs/commit/9e08ce617d9a3b7fa52cd89d3dbd7493023f2bb9) python3Packages.aiosignal: 1.1.1 -> 1.1.2
* [`7e59c197`](https://github.com/NixOS/nixpkgs/commit/7e59c1971572b261fc1a738c2d12ea33bd73bba5) nixos-option: remove if `nix.package` is unstable
* [`6b73bd1f`](https://github.com/NixOS/nixpkgs/commit/6b73bd1fd6a5c7bfee9b885825829302cb04816c) libstatgrab: cleanup
* [`a105c611`](https://github.com/NixOS/nixpkgs/commit/a105c611e6623b439380c1c8084fa40a34620d13) spdx-license-list-data: 3.12 -> 3.13 ([nixos/nixpkgs⁠#128678](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128678))
* [`e266a62d`](https://github.com/NixOS/nixpkgs/commit/e266a62d6d01686527d46ac6956a340e442b9178) xwayland: Fix build options
* [`e885ec30`](https://github.com/NixOS/nixpkgs/commit/e885ec3084ccc755fd1633c3ef45b77d7b00d802) mixxx: 2.2.4 -> 2.3.0
* [`37b1c896`](https://github.com/NixOS/nixpkgs/commit/37b1c8969b95c306efde2b7b8da1e7fb5cd9955f) dnscontrol: 3.9.0 -> 3.10.0
* [`c50de910`](https://github.com/NixOS/nixpkgs/commit/c50de910d13971efb923c7cecf22ddc121aec066) Remove knl as maintainer for oauth2_proxy ([nixos/nixpkgs⁠#128483](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128483))
* [`55469b8f`](https://github.com/NixOS/nixpkgs/commit/55469b8f3bd232f0b132fe0a1454a3e801b190bc) bento: 1.6.0-637 -> 1.6.0-638 ([nixos/nixpkgs⁠#128451](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128451))
* [`4b3cb7c6`](https://github.com/NixOS/nixpkgs/commit/4b3cb7c6eeda6967d9c9e0331912e327d3afea5a) Apply suggestions from code review
* [`172fb6be`](https://github.com/NixOS/nixpkgs/commit/172fb6beb7ac3adb86ab0d28d79b878cfab27d1a) pantheon.notes-up: 2.0.2 -> unstable-2020-12-29 ([nixos/nixpkgs⁠#128316](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128316))
* [`dc8d3549`](https://github.com/NixOS/nixpkgs/commit/dc8d3549d6fe4a2ddba4516be55a1250a229ef57) dnsx: 1.0.4 -> 1.0.5
* [`b7a23097`](https://github.com/NixOS/nixpkgs/commit/b7a2309786b75989fb31816439f7e52a31cc64b3) flashrom: Install udev-rules file
* [`e7de5e16`](https://github.com/NixOS/nixpkgs/commit/e7de5e1653a358283452a1fcb1cc6770f107d1a7) kubernetes-helm: 3.6.1 -> 3.6.2 ([nixos/nixpkgs⁠#128642](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128642))
* [`90f2a9d9`](https://github.com/NixOS/nixpkgs/commit/90f2a9d997753b782102b48320033d2ebc298868) shared-mime-info: fix cross build ([nixos/nixpkgs⁠#128553](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128553))
* [`a3274dca`](https://github.com/NixOS/nixpkgs/commit/a3274dca8852385469d0b89a1661a0e52ccbd0ff) helix: init at 0.3.0 ([nixos/nixpkgs⁠#126208](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/126208))
* [`ef0a4234`](https://github.com/NixOS/nixpkgs/commit/ef0a42347efad85481aa91482e303808bfaca85d) dhall: Use --base-import-url flag for documentation ([nixos/nixpkgs⁠#128588](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128588))
* [`073f4629`](https://github.com/NixOS/nixpkgs/commit/073f462987bfde91ecf90c7cc7b99afe60728e62) nixos/gdm: expand gdm.autoSuspend description
* [`d3bb50e7`](https://github.com/NixOS/nixpkgs/commit/d3bb50e7da2a6ef9745344d251b435e1191fa831) Coq: adapt for upcoming 8.14 ([nixos/nixpkgs⁠#128603](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/128603))
* [`ec00b2d3`](https://github.com/NixOS/nixpkgs/commit/ec00b2d3a2a97f85de61bd49f6296fe142a188a3) flat-remix-gnome: init at 20210623
* [`13a12fe9`](https://github.com/NixOS/nixpkgs/commit/13a12fe9e54a470871031b79508c736293ccb6d9) maintainers: add vanilla
* [`10a8e8fe`](https://github.com/NixOS/nixpkgs/commit/10a8e8fe8b4d674c60ef1b5e5bbdb2cc410fbc8c) python3Packages.portalocker: 1.7.0 -> 2.3.0
* [`95df9607`](https://github.com/NixOS/nixpkgs/commit/95df9607b5915b4e200cc14da20ae7bb9129b14b) python3Packages.msal-extensions: add substituteInPlace for
* [`0d8cbf70`](https://github.com/NixOS/nixpkgs/commit/0d8cbf704cace86734d93d2b49a821e05b1d8bde) azure-cli: replace portalocker version for azure-cli-telemetry
* [`3987b0e4`](https://github.com/NixOS/nixpkgs/commit/3987b0e48124cc0117783ae8f5b8edec501711cb) strip-nondeterminism: file to propagatedBuildInput
* [`e7ba3807`](https://github.com/NixOS/nixpkgs/commit/e7ba38072e664b95d22c2988525dbf462b351e73) python3Packages.python-ipmi: init at 0.5.1
* [`4ff1a6f9`](https://github.com/NixOS/nixpkgs/commit/4ff1a6f91a003c50247990dfa2a335304ca0aabb) esbuild: 0.12.11 -> 0.12.12
* [`9a53c8f4`](https://github.com/NixOS/nixpkgs/commit/9a53c8f4f26c4d653b8f6ea48c7c435385fc97ae) tmuxp: 1.7.2 -> 1.9.2
* [`c9ea6baa`](https://github.com/NixOS/nixpkgs/commit/c9ea6baaf916bbe0b60dd58f94ad7b27935d7cdb) vimPlugins: update
* [`10b8f498`](https://github.com/NixOS/nixpkgs/commit/10b8f498c992195e15a19f16755b0df7a00b46d7) buildah: 1.21.1 -> 1.21.2
* [`7ab005c4`](https://github.com/NixOS/nixpkgs/commit/7ab005c4f3be2696d9eb69189405acd65463c983) skopeo: 1.3.0 -> 1.3.1
* [`c4e97464`](https://github.com/NixOS/nixpkgs/commit/c4e97464060f054045a2838dc5c208d698e74e60) emuflight-configurator: 0.3.5 -> 0.3.6
* [`e8d3c65b`](https://github.com/NixOS/nixpkgs/commit/e8d3c65b361bcdbeb445433660fbdde8c738434e) cargo-tarpaulin: 0.17.0 -> 0.18.0
* [`8cd1066d`](https://github.com/NixOS/nixpkgs/commit/8cd1066dfd4e1443fae2e7bdc5113daa120f1d79) libtpms: 0.8.3 -> 0.8.4
* [`ef892b0a`](https://github.com/NixOS/nixpkgs/commit/ef892b0a9277782c92f71884038d908fc6cdb163) phd2: 2.6.9dev1 -> 2.6.10
* [`44d7d2a4`](https://github.com/NixOS/nixpkgs/commit/44d7d2a49972208ad350ddfdaa9d8fafaa7767e1) libaec: 1.0.4 -> 1.0.5
* [`360c8128`](https://github.com/NixOS/nixpkgs/commit/360c8128bbae300d71ce5440bee2ade3022c0871) gtkwave: 3.3.109 -> 3.3.110
* [`16ab89be`](https://github.com/NixOS/nixpkgs/commit/16ab89bef2b7c6b2e221e29ddd8560521dbb250c) seaweedfs: 2.50 -> 2.56
* [`4ba0ccc5`](https://github.com/NixOS/nixpkgs/commit/4ba0ccc59e4187bde8a01f3480ba6c19743cdb0a) cherrytree: 0.99.37 -> 0.99.38
* [`4e75706a`](https://github.com/NixOS/nixpkgs/commit/4e75706a468a795c2bc67102211b43d41a449df7) rPackages.svglite: Fix nativeBuildInputs
* [`cd3ed54f`](https://github.com/NixOS/nixpkgs/commit/cd3ed54f6ea1c13d45c6772b4752ae6d2ff35997) dwarf-fortress: refactor
* [`e0d776fa`](https://github.com/NixOS/nixpkgs/commit/e0d776fab3fa782f17ca654903b384c8975b504a) python3Packages.netmap: init at 0.7.0.2
* [`5622fd5f`](https://github.com/NixOS/nixpkgs/commit/5622fd5f6c188d12ffff9fd8e92fd58f43d983b0) cinnamon.bulky: 1.4 -> 1.6
* [`801a040d`](https://github.com/NixOS/nixpkgs/commit/801a040deef858799cfcab1c2da52e6a76bb1667) chroma: 0.9.1 -> 0.9.2
* [`b5460f9c`](https://github.com/NixOS/nixpkgs/commit/b5460f9ce2410a731efa8bb9311691b6fe651239) chroma: do version info substitution in postFetch
* [`cb546b29`](https://github.com/NixOS/nixpkgs/commit/cb546b29e05978fc36c9d34e9fc085e68e73b327) python3Packages.pyfritzhome: 0.6.1 -> 0.6.2
