### PR TITLE
niv nixpkgs: update 4826d60b -> 7229e6d6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4826d60ba2724b0e9f56438ae0394424e32efc6a",
-        "sha256": "17idhkwq59rv0mdb6dkvly6f5n2qq767i1bsriij8dv21asnd3x6",
+        "rev": "7229e6d646c90d2097099a825371601f1e8ad381",
+        "sha256": "1jhliwqmax0bl04yx3va0j9qb9kmilk7icgvrd0rxacsk2vsgzxs",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4826d60ba2724b0e9f56438ae0394424e32efc6a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/7229e6d646c90d2097099a825371601f1e8ad381.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4826d60b...7229e6d6](https://github.com/nixos/nixpkgs/compare/4826d60ba2724b0e9f56438ae0394424e32efc6a...7229e6d646c90d2097099a825371601f1e8ad381)

* [`16304106`](https://github.com/NixOS/nixpkgs/commit/16304106ecc6cb7b50d1990075ca4457f50019e2) gifsicle: 1.92 -> 1.93
* [`017aa884`](https://github.com/NixOS/nixpkgs/commit/017aa8847084af88b167e3d21d7691fd625c8126) Remove danieldk as a maintainer for some packages
* [`866c28f5`](https://github.com/NixOS/nixpkgs/commit/866c28f56f8a251122d17072acf3ad7ac58a56a3) python3Packages.cvxpy: 1.1.12 -> 1.1.13
* [`1fd0090f`](https://github.com/NixOS/nixpkgs/commit/1fd0090f14a5423dff8ef24d8440b0008422a64f) python3Packages.curio: 1.4 -> 1.5
* [`c83a5bce`](https://github.com/NixOS/nixpkgs/commit/c83a5bce66b68e4ce4d9dfce3a9a45265418e15b) mercurialFull: add support for experimental in-tree git extension
* [`ff9aaa4e`](https://github.com/NixOS/nixpkgs/commit/ff9aaa4e2e6d98f65a870fe3944dcf8fc54d82cf) python3Packages.crc32c: 2.0.1 -> 2.2.post0
* [`67444f8a`](https://github.com/NixOS/nixpkgs/commit/67444f8a393846b1431cfeb936e83a9f24725e2d) mercurial: fix patch links again
* [`8f901848`](https://github.com/NixOS/nixpkgs/commit/8f901848bf509d3719c1805350194e301523b027) seafile-shared: update source hash
* [`1a4c9851`](https://github.com/NixOS/nixpkgs/commit/1a4c9851c2b79c4d181d9c306476714ce6a217c9) seafile-client: update source hash
* [`b4c419a4`](https://github.com/NixOS/nixpkgs/commit/b4c419a4390177ca98aa6acd8e3c298d99f8841c) libxlsxwriter: 1.0.6 -> 1.0.8
* [`dcf3dec4`](https://github.com/NixOS/nixpkgs/commit/dcf3dec494f34eb4b9f04b78d2eb40686b08d6a4) mercurialFull: add highlight in-tree extension support
* [`40efcce8`](https://github.com/NixOS/nixpkgs/commit/40efcce8702c274cea33dec1e6a46ca78da3a0a2) flyctl: 0.0.227 -> 0.0.228
* [`c0b2241e`](https://github.com/NixOS/nixpkgs/commit/c0b2241e53f3cb4fbea245da960e23a43d9965fc) nixos/top-level: pass lib to specialisations
* [`14da5150`](https://github.com/NixOS/nixpkgs/commit/14da51500d417ab901402fca0aa3c19e03b77e84) python3Packages.python-lsp-jsonrpc: init at 1.0.0
* [`bebb1808`](https://github.com/NixOS/nixpkgs/commit/bebb18083ffa6b89946b76ebe3cb07fa929487c1) python3Packages.python-lsp-server: init at 1.1.0
* [`98dbeb6b`](https://github.com/NixOS/nixpkgs/commit/98dbeb6b790de67b9d8f39968e09836304516fb9) python3Packages.pyls-spyder: fix build
* [`1ec56519`](https://github.com/NixOS/nixpkgs/commit/1ec565191387e1ed6dc5c7a355cdf58a2b56336a) treewide: use pythonPackages.python-dateutil instead of pythonPackages.dateutil
* [`88cb011d`](https://github.com/NixOS/nixpkgs/commit/88cb011dfe8c1cdaeffcf68ca97315507b426cba) pythonPackages.dateutil: move to python-aliases.nix
* [`f32e760b`](https://github.com/NixOS/nixpkgs/commit/f32e760b64560eeb3dd2cd305018c463d12aa1ac) gwyddion: 2.58 -> 2.59
* [`d82c7fe1`](https://github.com/NixOS/nixpkgs/commit/d82c7fe1192af8bb511acc0fab50d4ecd6ae02f0) gops: 0.3.18 -> 0.3.19
* [`4cea628e`](https://github.com/NixOS/nixpkgs/commit/4cea628efbd190a0678a61bd93f87829c0fbcae0) gegl: drop the old 0.2 version, make gegl 0.4 default
* [`d864be81`](https://github.com/NixOS/nixpkgs/commit/d864be81902df1e498f8ccea55a7cd711191513c) global: 6.6.6 -> 6.6.7
* [`698a49a1`](https://github.com/NixOS/nixpkgs/commit/698a49a14cdccbae29f7e3b190ec09eb488279a7) duckdb: 0.2.2 -> 0.2.7
* [`e197447e`](https://github.com/NixOS/nixpkgs/commit/e197447e564aef3dc5650c5a18b3f883c4d10f49) python3Packages.duckdb: minor updates
* [`29464942`](https://github.com/NixOS/nixpkgs/commit/29464942e2b19977e1ffb98d5b807ed131f35df9) Add ToxicFrog to maintainer list
* [`27d101d2`](https://github.com/NixOS/nixpkgs/commit/27d101d2204f7cb07da971dd0cc092c8e636a975) babl: 0.1.86 -> 0.1.88
* [`08a338ef`](https://github.com/NixOS/nixpkgs/commit/08a338ef7edbff127233485f657979d3d7d2481c) pythonPackages.fastimport: requires Python >= 3.5
* [`b7515545`](https://github.com/NixOS/nixpkgs/commit/b7515545b5647ebdef27b52a5d4297b5336c53e7) tdesktop: 2.8.3 -> 2.8.4
* [`b333bf83`](https://github.com/NixOS/nixpkgs/commit/b333bf83d34ba67fb3bb178c73a2967ebba4bc08) egl-wayland: support cross-compilation
* [`0b93eb68`](https://github.com/NixOS/nixpkgs/commit/0b93eb68a2733e5b5ac299cd3753912b0166f3b4) xwayland: support cross-compilation
* [`4c2b069b`](https://github.com/NixOS/nixpkgs/commit/4c2b069b8ffeff2b89eda1fa92358cebf88aa781) wlroots: support cross-compilation
* [`b5b5dbb6`](https://github.com/NixOS/nixpkgs/commit/b5b5dbb62d959e743742e75ef342ff9fca392ada) warzone2100: better fix for absolute bindir
* [`93a665e6`](https://github.com/NixOS/nixpkgs/commit/93a665e66d37d324bd2c761c96a977ea2d1410b6) hugo: 0.84.3 -> 0.84.4
* [`3f2a4497`](https://github.com/NixOS/nixpkgs/commit/3f2a44978b3b782e2ea76e5f4947c87ab2104f4b) darktable: 3.4.1 -> 3.6.0
* [`477ae348`](https://github.com/NixOS/nixpkgs/commit/477ae348caa7fa5e34c646f84ce7e17db5fb47c2) gpxsee: 9.1 -> 9.2
* [`733756cc`](https://github.com/NixOS/nixpkgs/commit/733756ccfc2e333658f77c657a3cd1c64d2ff1eb) tdesktop: Drop the enchant2 and dee dependencies
* [`72894352`](https://github.com/NixOS/nixpkgs/commit/72894352b89a27d883c4c5a687db61fac6843a08) nixos/btrbk: add module and test
* [`8b9d56a1`](https://github.com/NixOS/nixpkgs/commit/8b9d56a19ada3094bb107c558b02f62f7b13ac53) nixos/btrbk: add release notes
* [`c6ba881c`](https://github.com/NixOS/nixpkgs/commit/c6ba881c8d4db240defc00eb6a3705ba3f75a170) btrbk: add nixos test to passthru.tests
* [`d9a1b3c5`](https://github.com/NixOS/nixpkgs/commit/d9a1b3c52c44ca4972b4bc77e84dce0c915b7522) terrascan: 1.7.0 -> 1.8.0
* [`d725de5d`](https://github.com/NixOS/nixpkgs/commit/d725de5d5a8e71c1631fd37d10fca99c7ca4d369) traitor: 0.0.7 -> 0.0.8
* [`cc4d6d48`](https://github.com/NixOS/nixpkgs/commit/cc4d6d48dc2238967b42bbc4d4c6db0556beff47) python3Packages.georss-ign-sismologia-client: 0.3 -> 0.4
* [`f269eaff`](https://github.com/NixOS/nixpkgs/commit/f269eaff232a966c125305fc1ef0962c09b63f5b) infracost: 0.9.1 -> 0.9.2
* [`9598d61c`](https://github.com/NixOS/nixpkgs/commit/9598d61c1f085955625d33c5ffa092c3645257a3) crate2nix: 0.9.0 -> 0.10.0
* [`f93e9e98`](https://github.com/NixOS/nixpkgs/commit/f93e9e98e947630b24362220b1112101a65a2b63) staticjinja: 2.1.0 -> 3.0.1
* [`56722408`](https://github.com/NixOS/nixpkgs/commit/567224081c58b54467af8acd32544504678ddcbe) rebar3-nix: 0.1.0 -> 0.1.1
* [`ed9db4a7`](https://github.com/NixOS/nixpkgs/commit/ed9db4a7f8b69fea1643a964919fca3b6f9d40fc) doc: fix link to kodi-19.0 announcement
* [`ede1785d`](https://github.com/NixOS/nixpkgs/commit/ede1785d110103d43a75c19db7573ad5808bd3b3) doc: point out that nixos-21.05 has gnuradio 3.9
* [`c22c07f5`](https://github.com/NixOS/nixpkgs/commit/c22c07f53024457764d70dc83edb1b0ab5a758c0) katago: 1.9.0 -> 1.9.1
* [`bcd5b096`](https://github.com/NixOS/nixpkgs/commit/bcd5b09634ff12cb426661c125b44984e27ef576) pinnwand: relax token-bucket pin
* [`cdcb439b`](https://github.com/NixOS/nixpkgs/commit/cdcb439bad262467206e2957a4994e440d4af765) mercurial: add withExtensions
* [`65a67517`](https://github.com/NixOS/nixpkgs/commit/65a67517c9cea9768a05e0aacab8530ef4121b5e) tortoisehg: 5.6 -> 5.8
* [`41f850cd`](https://github.com/NixOS/nixpkgs/commit/41f850cdeb134c5e17097c8ecc947ba801aa6a40) python3Packages.bugsnag: 4.0.3 -> 4.1.0
* [`49ac4dfa`](https://github.com/NixOS/nixpkgs/commit/49ac4dfab9c804f6712f71eaffa621a621bf598d) python3Packages.bravado-core: 5.16.1 -> 5.17.0
* [`9b16b5e3`](https://github.com/NixOS/nixpkgs/commit/9b16b5e381aeff13484507ed3ce4db608efb8398) conan: fix build after python3Packages updates
* [`c8dd6cec`](https://github.com/NixOS/nixpkgs/commit/c8dd6cecaaac09171558e45e56fba6bf57aca902) python-language-server: remove myself as maintainer
* [`b84b5172`](https://github.com/NixOS/nixpkgs/commit/b84b5172a945a5a4028f8c91182917417db4678e) blas-reference: 3.8.0 -> 3.10.0
* [`277d1a15`](https://github.com/NixOS/nixpkgs/commit/277d1a156909340a025edf242e8915d570df350b) openttd-grfcodec: init at 6.0.6+git20210310
* [`82c40850`](https://github.com/NixOS/nixpkgs/commit/82c4085089b1ec7e5889bf2e9ef31867f48e8a19) openttd-nml: init at 0.5.3
* [`aed1ed7d`](https://github.com/NixOS/nixpkgs/commit/aed1ed7d04d348921dc2634f36b04dd6856c09a6) amass: 3.11.2 -> 3.13.2
* [`89d78be7`](https://github.com/NixOS/nixpkgs/commit/89d78be7f8d8a6b94dc38a73d695dd7f1f2bf596) lynis: 3.0.4 -> 3.0.5
* [`a50a9bbe`](https://github.com/NixOS/nixpkgs/commit/a50a9bbef78a73f5a29e6d6ebeccde4245174205) tfsec: 0.39.16 -> 0.40.7
* [`e6c88a03`](https://github.com/NixOS/nixpkgs/commit/e6c88a031c43574cb4609fe30310c820ec871930) sn0int: 0.21.1 -> 0.21.2
* [`e4951b57`](https://github.com/NixOS/nixpkgs/commit/e4951b579de021272a33abcbe7bdab69d5cb780b) sslscan: 2.0.9 -> 2.0.10
* [`7b58fcf2`](https://github.com/NixOS/nixpkgs/commit/7b58fcf2a591c0b45b524bcab78ae46f9c53444b) teleport: 6.2.5 -> 6.2.7
* [`74199e11`](https://github.com/NixOS/nixpkgs/commit/74199e111e53c7b5705df277516951103b65724c) stunnel: 5.58 -> 5.59
* [`0216963c`](https://github.com/NixOS/nixpkgs/commit/0216963c9fad4c1307397b6cb8ba706ba4f3f542) python3Packages.aiomusiccast: 0.8.1 -> 0.8.2
* [`d09892f5`](https://github.com/NixOS/nixpkgs/commit/d09892f52149fdd22720facc4e4b196d043c720c) onefetch: 2.9.1 -> 2.10.2
* [`d4cd4061`](https://github.com/NixOS/nixpkgs/commit/d4cd4061d4600d36e5b9c1727c5ba860018420c1) pythonPackages.pillow-simd: revert update to 8.1.2
* [`004febc0`](https://github.com/NixOS/nixpkgs/commit/004febc0cbfce686d53993713fca36b0119ba5fc) subsurface: 5.0.1 -> 5.0.2
* [`2de0ccd9`](https://github.com/NixOS/nixpkgs/commit/2de0ccd9dd7ebff2d59f178905775f0e5e502594) bitwarden: 1.26.4 -> 1.27.0
* [`a0d5f7ea`](https://github.com/NixOS/nixpkgs/commit/a0d5f7eacaa871eefea54a9e8710d129cf865ae5) cargo-release: 0.15.1 -> 0.16.0
* [`6a8335be`](https://github.com/NixOS/nixpkgs/commit/6a8335bea0a5307a87f37da21f582536709f4be6) chezmoi: 2.0.16 -> 2.1.0
* [`5573210d`](https://github.com/NixOS/nixpkgs/commit/5573210d8792c0779b2013873335a144bd98b7ee) nix-doc: 0.3.3 -> 0.5.0
* [`d9a91ae5`](https://github.com/NixOS/nixpkgs/commit/d9a91ae52a4862fdf242a5e058c9311c4089127c) cloud-nuke: 0.2.0 -> 0.3.0
* [`528b0ccf`](https://github.com/NixOS/nixpkgs/commit/528b0ccfd1153bb86a78848366a24b55dfdfbb46) gobgp: 2.28.0 -> 2.29.0
* [`f50ffddc`](https://github.com/NixOS/nixpkgs/commit/f50ffddc9152e8c429ea32b785da821f3bf1139c) gobgpd: 2.28.0 -> 2.29.0
* [`af7a317f`](https://github.com/NixOS/nixpkgs/commit/af7a317f79d07270a5ac036e3d22083f7ff6b2be) kepubify: 3.1.6 -> 4.0.0
* [`c0dd9c3b`](https://github.com/NixOS/nixpkgs/commit/c0dd9c3b3dffb6be8a60f0c92109a5e037f63012) firefox: increase timeout to 86400s (24h)
* [`055dc300`](https://github.com/NixOS/nixpkgs/commit/055dc300ff0de7f901b972cef9483a36c0cbf83e) sd: install man page and shell completions
* [`83e824aa`](https://github.com/NixOS/nixpkgs/commit/83e824aa3c55384435bf557ef099456b30ec93dd) age: 1.0.0-rc.1 -> 1.0.0-rc.3
* [`988daa56`](https://github.com/NixOS/nixpkgs/commit/988daa56af643540cc178b5e1f2afbaa1b931482) kubeconform: 0.4.7 -> 0.4.8
* [`d9eabcd4`](https://github.com/NixOS/nixpkgs/commit/d9eabcd4d9379143e7bd74362724ccffcfbf16f3) python3Packages.libarcus: 4.9.0 -> 4.10.0
* [`53dd8403`](https://github.com/NixOS/nixpkgs/commit/53dd84030fe4b4216055dfeb4fc0d61a6350dd2c) python3Packages.libsavitar: 4.9.0 -> 4.10.0
* [`55bfa330`](https://github.com/NixOS/nixpkgs/commit/55bfa33044c6dbe411ee67d1a1c1aea99078bf7f) python3Packages.pynest2d: 4.8.0 -> 4.10.0
* [`5facfea9`](https://github.com/NixOS/nixpkgs/commit/5facfea9ff6cc788ae0ea8ac38f64e21e493df17) python3Packages.uranium: 4.9.0 -> 4.10.0
* [`84a05811`](https://github.com/NixOS/nixpkgs/commit/84a05811ae853d12d31a17b37dc6bd39bc5981e3) cura: 4.9.0 -> 4.10.0
* [`8f34bdf9`](https://github.com/NixOS/nixpkgs/commit/8f34bdf93a8afc4b6e950189d90b56b4ae0c0076) redo-c: 0.2 -> 0.3
* [`db37a864`](https://github.com/NixOS/nixpkgs/commit/db37a86453abb88c8b35924a9392f31a936597d0) ccls: set resource directory
* [`3325aaac`](https://github.com/NixOS/nixpkgs/commit/3325aaacf0fafb527ae2a7da37f6a132fe15b970) libqalculate: 3.18.0 -> 3.19.0
* [`5fd14f54`](https://github.com/NixOS/nixpkgs/commit/5fd14f54c7bb1cca0a39d37994b5cfb8e7195ca9) qalculate-gtk: 3.18.0 -> 3.19.0
* [`f69522b2`](https://github.com/NixOS/nixpkgs/commit/f69522b22745fcb808835a1f4c25d533bc46943d) clang-tools: fix missing extra tools
* [`d6d304cd`](https://github.com/NixOS/nixpkgs/commit/d6d304cd1246e2a1a302490cc0399ce3efc1681a) erlang: 24.0.2 -> 24.0.3
* [`a3703d72`](https://github.com/NixOS/nixpkgs/commit/a3703d72c57b7a2ef9de99630ab64f0b1dec59a3) cargo-bloat: 0.10.0 -> 0.10.1
* [`e1f7f6df`](https://github.com/NixOS/nixpkgs/commit/e1f7f6df68e3d72d74bfdc4b46a29340a1283c7d) qjournalctl: init at 0.6.3
* [`04f8630f`](https://github.com/NixOS/nixpkgs/commit/04f8630f83949b7d8237ddba0a47d8d6ee41419c) ibus-engines.mozc: 2.23.4206.102 -> 2.26.4423.100
* [`4bc9ad7a`](https://github.com/NixOS/nixpkgs/commit/4bc9ad7a75a9b14b07039a4c4412ecc84f2fc0d7) python3Packages.scp: 0.13.4 -> 0.13.5
* [`228adbbf`](https://github.com/NixOS/nixpkgs/commit/228adbbf7151ba2aad2cc8a4f103001d2bd20107) tcpdump: 4.99.0 -> 4.99.1
* [`26c36ab5`](https://github.com/NixOS/nixpkgs/commit/26c36ab58695188b07eb8539083390886fd7921a) exploitdb: 2021-07-02 -> 2021-07-03
* [`71bfa1cb`](https://github.com/NixOS/nixpkgs/commit/71bfa1cb898c2eae7fbe2e3cc493a86e1a03cbc1) ncdu: 1.15.1 -> 1.16
* [`b95cd0fc`](https://github.com/NixOS/nixpkgs/commit/b95cd0fcd86924ccc0715196ff4bcd44fabb78bf) python-aliases: dtfit, lammps-cython
* [`b07b9e81`](https://github.com/NixOS/nixpkgs/commit/b07b9e81bcf668176662766de1c19170f57bd69f) redo: Set CFLAGS only if not defined
* [`30200ce8`](https://github.com/NixOS/nixpkgs/commit/30200ce8e1ec62c82730e06287de746eda54900c) bmake: 20210420 -> 20210621
* [`32c42d37`](https://github.com/NixOS/nixpkgs/commit/32c42d37ab6d45388fc713fe8312a50eade3d4b3) bmake: test musl build
* [`2019f82e`](https://github.com/NixOS/nixpkgs/commit/2019f82e3ee5764ae2d63a53ef5a44310b7c7f77) bmake: enable ksh test on non musl platforms
* [`45abf2f0`](https://github.com/NixOS/nixpkgs/commit/45abf2f0d0c8077dae322e2b7fa92b3ca1f034aa) nixos/manual: prompt to set root password has changed
* [`5db6b909`](https://github.com/NixOS/nixpkgs/commit/5db6b909cd0e544a5466fb0279d6aeaf202b0cf5) strings.nix: Fix overly monomorphic type signature comments
* [`e2a11c1d`](https://github.com/NixOS/nixpkgs/commit/e2a11c1d3d0d66bf09c5038977ac7e0d7c0ef8cc) koka: 2.1.4 -> 2.1.9
* [`8c44a664`](https://github.com/NixOS/nixpkgs/commit/8c44a664678c22d46e8ce2f91ce96c644a58f036) kea: 1.9.8 -> 1.9.9
