### PR TITLE
niv home-manager: update 9b7a90da -> 97d183e2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b7a90daa17022c428e3b6da36814f5f9a804a35",
-        "sha256": "1r3kxdnqzapkylsnhiw0xz1qdi3mglppnkqmv35j70ilma5j52bp",
+        "rev": "97d183e2e466808f5d7cd1c838815bedd88f37fe",
+        "sha256": "1h24illqvxymyjxr4bym11g3bgwd5ni7dhniisq829phbq11xbl6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9b7a90daa17022c428e3b6da36814f5f9a804a35.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/97d183e2e466808f5d7cd1c838815bedd88f37fe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9b7a90da...97d183e2](https://github.com/nix-community/home-manager/compare/9b7a90daa17022c428e3b6da36814f5f9a804a35...97d183e2e466808f5d7cd1c838815bedd88f37fe)

* [`5b08b33e`](https://github.com/nix-community/home-manager/commit/5b08b33e8fcd4737edca0f187e47033b1b206114) rofi: add "plugins" option ([nix-community/home-manager⁠#2117](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2117))
* [`3f6cb409`](https://github.com/nix-community/home-manager/commit/3f6cb409cadf38e71d73f43af52ce27b6ee70214) xmobar: add module ([nix-community/home-manager⁠#2120](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2120))
* [`9ad0024d`](https://github.com/nix-community/home-manager/commit/9ad0024d4d292c628d4c9a50c2347f23418d7000) rbw: use pientry.binaryPath when available ([nix-community/home-manager⁠#2153](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2153))
* [`7df6656b`](https://github.com/nix-community/home-manager/commit/7df6656b113ce0d39c8b7d30915cafe046e1d64e) foot: revert always create config file ([nix-community/home-manager⁠#2091](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2091)) ([nix-community/home-manager⁠#2157](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2157))
* [`ac319fd3`](https://github.com/nix-community/home-manager/commit/ac319fd3149b23a3ad8ee24cb2def6e67acf194c) home-environment: add Nixpkgs release version check
* [`97d183e2`](https://github.com/nix-community/home-manager/commit/97d183e2e466808f5d7cd1c838815bedd88f37fe) devilspie2: add module ([nix-community/home-manager⁠#1477](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/1477))
