### PR TITLE
niv powerlevel10k: update 0c862a13 -> 4bcc5195

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0c862a130710b351e34720fcbc90684239bd9d6c",
-        "sha256": "05zivrwglbs4xr1fy2157jyx2hqyjzw5spazx0swp8l3b57z38gz",
+        "rev": "4bcc51954714ce89bcb11a2f07e26f9188cb542b",
+        "sha256": "0r5z5nqxm9yhgnd70114mwpdq2js4ga5664a9mnkwi92c5j50g4x",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0c862a130710b351e34720fcbc90684239bd9d6c.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/4bcc51954714ce89bcb11a2f07e26f9188cb542b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@0c862a13...4bcc5195](https://github.com/romkatv/powerlevel10k/compare/0c862a130710b351e34720fcbc90684239bd9d6c...4bcc51954714ce89bcb11a2f07e26f9188cb542b)

* [`fd7313a5`](https://github.com/romkatv/powerlevel10k/commit/fd7313a5e7bf2d781ca27edc5e10c00798862e69) replace @{u} with @{upstream} in the docs (it's the same thing but clearer)
* [`3213e2e1`](https://github.com/romkatv/powerlevel10k/commit/3213e2e17f1695c88959e3b74e3302d628520382) docs: grammar
* [`7759063b`](https://github.com/romkatv/powerlevel10k/commit/7759063b7485ca0701fc8ba1961d0e53568ddd59) Squashed 'gitstatus/' changes from 76182238..68bf9e0d
* [`63a00966`](https://github.com/romkatv/powerlevel10k/commit/63a009669a7ed6aa6040f0af008adfb62829188c) Squashed 'gitstatus/' changes from 68bf9e0d..4b4226ca
* [`077abf95`](https://github.com/romkatv/powerlevel10k/commit/077abf95e0a3c6325a6cdd9761cab75b2f5468c6) Squashed 'gitstatus/' changes from 4b4226ca..0440e38b
* [`4bcc5195`](https://github.com/romkatv/powerlevel10k/commit/4bcc51954714ce89bcb11a2f07e26f9188cb542b) add 'minify' make target
