### PR TITLE
niv spacemacs: update 64fed6f7 -> d78d8282

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "64fed6f7daba47144b09403a4982f26eb79b8ec6",
-        "sha256": "0f6qyjhc9yff6559w8qz5037q5b1yvbz9zdb7x9dxvrn31qrh7ki",
+        "rev": "d78d8282f553965d1c6f799179dac13828ca3bc5",
+        "sha256": "0zx1c4nb9slzxvndh9s1larfgbwdv8g2w5qbc26dh06hk3aw7k4r",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/64fed6f7daba47144b09403a4982f26eb79b8ec6.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/d78d8282f553965d1c6f799179dac13828ca3bc5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@64fed6f7...d78d8282](https://github.com/syl20bnr/spacemacs/compare/64fed6f7daba47144b09403a4982f26eb79b8ec6...d78d8282f553965d1c6f799179dac13828ca3bc5)

* [`728c0ffb`](https://github.com/syl20bnr/spacemacs/commit/728c0ffb48ddba4e1595283cf2899e4e8e734f2a) [Readme] Fix link ([syl20bnr/spacemacs⁠#14877](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14877))
* [`40ea399d`](https://github.com/syl20bnr/spacemacs/commit/40ea399d8ed0cc91b7ccc5a4dd8b7f710b84f08e) [CI] move built-in auto update to CircleCI
* [`1b662ef9`](https://github.com/syl20bnr/spacemacs/commit/1b662ef95839f98d07b3d681d5bf6c66a0463ec1) [CI] Run core, base and layer tests in the same instance
* [`c59d670d`](https://github.com/syl20bnr/spacemacs/commit/c59d670d50b2d7da5382793e50760ada63647aa3) fix built_in_manifes path
* [`85778b63`](https://github.com/syl20bnr/spacemacs/commit/85778b63837b377fee180e9013d9687f03e008a0) [ci] Fix CircleCI stuff
* [`2189689e`](https://github.com/syl20bnr/spacemacs/commit/2189689eae1b78c3d82cd4cf30160778e88807d4) [ci] move bot init into separate file
* [`b642059a`](https://github.com/syl20bnr/spacemacs/commit/b642059a9be885699d9c93cc405d43c737c97159) [ci] add init script for bot
* [`736b1d98`](https://github.com/syl20bnr/spacemacs/commit/736b1d98ae5782ff6e7eff09ec3d54db5646cabb) [ci] Reorder steps in CircleCI for built-in upd
* [`67ba9ce3`](https://github.com/syl20bnr/spacemacs/commit/67ba9ce3edb5a41348c35c3b8be7fed95f006f55) [ci] Fix hub path
* [`6bd25d2a`](https://github.com/syl20bnr/spacemacs/commit/6bd25d2abcb4f5b348518dec8f0045bea64afbc6) Fix typo
* [`7882913e`](https://github.com/syl20bnr/spacemacs/commit/7882913ee2baae0c1fee62e82faf028212184617) [ci] fix typo
* [`2dafdb09`](https://github.com/syl20bnr/spacemacs/commit/2dafdb090b27366689cfc94b79af2db5b3b43607) [ci] set bot repo via env var
* [`7f743c90`](https://github.com/syl20bnr/spacemacs/commit/7f743c907a0e6377629d04b45765c53799d86df8) Built-in files auto-update: Fri Jul 2 18:04:36 UTC 2021
* [`db2e6d2b`](https://github.com/syl20bnr/spacemacs/commit/db2e6d2be467b1c457848fc873cd8d3fbc4691c0) Built-in files auto-update: Sat Jul 3 00:04:31 UTC 2021
* [`63f5bc7b`](https://github.com/syl20bnr/spacemacs/commit/63f5bc7bb9d351298b860053e6741fb9a50bb564) [ci] clean-up
* [`9159393f`](https://github.com/syl20bnr/spacemacs/commit/9159393f9cd220794719921e7234a437eb269c7a) Fix exit keyword in symbol-highlight TS ([syl20bnr/spacemacs⁠#14890](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14890))
* [`be74dd78`](https://github.com/syl20bnr/spacemacs/commit/be74dd786f9f9b029ba9d8f472e1a18442f44303) Adds function to run default shell in project root, with leader keys `SPC p $` ([syl20bnr/spacemacs⁠#14856](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14856))
* [`aa454708`](https://github.com/syl20bnr/spacemacs/commit/aa4547086da2637d729b8fceb4ab630f7a51ba5f) [CI] Move documentation formatting to CircleCI
* [`18f64862`](https://github.com/syl20bnr/spacemacs/commit/18f648624672d3f7251de73b3bdf6f8ce3277f7d) [doc] Fix exwm README.org
* [`c0899597`](https://github.com/syl20bnr/spacemacs/commit/c089959754f6dc183b35dd9fc06f40f3b4924ccf) [doc] Flatten headlines that are too deep
* [`34f73964`](https://github.com/syl20bnr/spacemacs/commit/34f739649c15fdb602aca3143c5d36bb0e878665) [ci] fix patch name
* [`6f8d6d5b`](https://github.com/syl20bnr/spacemacs/commit/6f8d6d5b3a7c18065afd6a2d45c19c53d848dfe5) [ci] Don't mask push  outputs (CircleCI masks secrets anyway)
* [`88cfc4bc`](https://github.com/syl20bnr/spacemacs/commit/88cfc4bc6790b00d0fa43c9d9dc13ca3412beaac) [ci] fix ws in patches and use git apply
* [`a2e1c2de`](https://github.com/syl20bnr/spacemacs/commit/a2e1c2de2e2d4a439a2b6db9d5120f077ecd1816) [ci] clean-up
* [`284f56a3`](https://github.com/syl20bnr/spacemacs/commit/284f56a3970191c369f8504d63303ba4b3bf0cff) [bot] "spacemacs_fix_org" Mon Jul  5 23:23:52 UTC 2021
* [`d78d8282`](https://github.com/syl20bnr/spacemacs/commit/d78d8282f553965d1c6f799179dac13828ca3bc5) [ci] Handle the case when everything is up to date
