### PR TITLE
niv zsh-syntax-highlighting: update f0e6a8ef -> dffe3045

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "f0e6a8ef5c90ff3e1e9516df666e36e02d0f362d",
-        "sha256": "1imcxz5fxhmkjjbrqikk01zh07kjal7nrgfwf2q2dprsiasy7jv3",
+        "rev": "dffe304567c86f06bf1be0fce200077504e79783",
+        "sha256": "0dwgcfbi5390idvldnf54a2jg2r1dagc1rk7b9v3lqdawgm9qvnw",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/f0e6a8ef5c90ff3e1e9516df666e36e02d0f362d.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/dffe304567c86f06bf1be0fce200077504e79783.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@f0e6a8ef...dffe3045](https://github.com/zsh-users/zsh-syntax-highlighting/compare/f0e6a8ef5c90ff3e1e9516df666e36e02d0f362d...dffe304567c86f06bf1be0fce200077504e79783)

* [`dffe3045`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/dffe304567c86f06bf1be0fce200077504e79783) CI: Pull image from the GitHub container registry
