### PR TITLE
niv nixpkgs: update 7229e6d6 -> 90958cd7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7229e6d646c90d2097099a825371601f1e8ad381",
-        "sha256": "1jhliwqmax0bl04yx3va0j9qb9kmilk7icgvrd0rxacsk2vsgzxs",
+        "rev": "90958cd740faaa30b6bce3821502adc74fa801d2",
+        "sha256": "0h6bz6mkgb15553ryff3lksd5x6ycyxiaf2904h0lbqwrkcjq62v",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7229e6d646c90d2097099a825371601f1e8ad381.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/90958cd740faaa30b6bce3821502adc74fa801d2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7229e6d6...90958cd7](https://github.com/nixos/nixpkgs/compare/7229e6d646c90d2097099a825371601f1e8ad381...90958cd740faaa30b6bce3821502adc74fa801d2)

* [`f9645002`](https://github.com/NixOS/nixpkgs/commit/f9645002a2d8615fd608bfdef4f924481dca391e) nixos/tests/chromium: Fix the test for M92+
* [`7d766fb4`](https://github.com/NixOS/nixpkgs/commit/7d766fb47894d93bdfa5ab966c374a36bb796d37) imgproxy: 2.16.5 -> 2.16.6
* [`fb933406`](https://github.com/NixOS/nixpkgs/commit/fb93340613a4cd475ad2d8271c807174695ff4e9) metasploit: 6.0.51 -> 6.0.52
* [`256993cc`](https://github.com/NixOS/nixpkgs/commit/256993cc59a387f930e8bcebcfe5e67df161b431) gitlint: override requirements
* [`021bc5b9`](https://github.com/NixOS/nixpkgs/commit/021bc5b92920d4675e88228b3dfe41d525c42432) kube3d: 4.4.6 -> 4.4.7
* [`5c4d869a`](https://github.com/NixOS/nixpkgs/commit/5c4d869adaa6a25aac00fac2cb222f33799b0617) engauge-digitizer: init at 12.1
* [`3e75e57e`](https://github.com/NixOS/nixpkgs/commit/3e75e57eb4730b0b7bb3ec9c8e9b551ea554ace7) elfkickers: 3.1a -> 3.2 ([nixos/nixpkgs⁠#124178](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/124178))
* [`c70e4a60`](https://github.com/NixOS/nixpkgs/commit/c70e4a6089da1c86bbb091eac01d22c7450aaa75) python3Packages.pyfronius: 0.5.2 -> 0.5.3
* [`c85f7779`](https://github.com/NixOS/nixpkgs/commit/c85f77790b8a00d0a670a8b5264ef3b12f5428c9) squeekboard: 1.13.0 -> 1.14.0
* [`ed4cbb7b`](https://github.com/NixOS/nixpkgs/commit/ed4cbb7b5929408f623a80548b4539dadcf30c06) ocamlPackages.uecc: init at 0.3
* [`4acf681b`](https://github.com/NixOS/nixpkgs/commit/4acf681ba8cbcbb948339b75bf1d68dec1c27fd8) tfsec: 0.41.0 -> 0.45.3
* [`f0bdb5bd`](https://github.com/NixOS/nixpkgs/commit/f0bdb5bd89e8f7482f2779b60bdc46e719dde76c) watson: fix build problem with click 8
* [`32b9c9a1`](https://github.com/NixOS/nixpkgs/commit/32b9c9a1890a7a6329a12e69a816e9254f431006) EmptyEpsilon: 2021.03.31 -> 2021.06.23 ([nixos/nixpkgs⁠#129739](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129739))
* [`761efb95`](https://github.com/NixOS/nixpkgs/commit/761efb95134beca3a4481c7a3490f84c20c8d4ac) cgal_5: 5.2.2 -> 5.3
* [`76135659`](https://github.com/NixOS/nixpkgs/commit/76135659eeaa1b66e17db1b4aa3503ceaa5b098d) egl-wayland: 1.1.6 -> 1.1.7
* [`3956639b`](https://github.com/NixOS/nixpkgs/commit/3956639b58a4fee3debe975a38ab91642c960f07) xwayland: 21.1.1 -> 21.1.2
* [`47c6bd0c`](https://github.com/NixOS/nixpkgs/commit/47c6bd0c85e054a8f857df899cfd7944b46b3ee7) corkscrew: name -> pname
* [`93a66b3d`](https://github.com/NixOS/nixpkgs/commit/93a66b3d52aeb25af2a8e1cd0d5d6dbd921a58a4) mangohud: 0.6.4 -> 0.6.5
* [`84eb0781`](https://github.com/NixOS/nixpkgs/commit/84eb0781aa54d647e6daca87e4c8e22fc5cbb957) lemmy: init 0.11.2 ([nixos/nixpkgs⁠#129723](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129723))
* [`4b0dcec6`](https://github.com/NixOS/nixpkgs/commit/4b0dcec686f5917036a33acd606188e043b2b303) unciv : 3.13.12-patch -> 3.15.9
* [`ff1b1874`](https://github.com/NixOS/nixpkgs/commit/ff1b1874f8ff974a79f7f353c33d38738335d7ab) tecnoballz: init at 0.93.1
* [`0851d84f`](https://github.com/NixOS/nixpkgs/commit/0851d84fed3d63481f4f8554003bec5b30ba8673) powermanga: init at 0.93.1
* [`4364b96e`](https://github.com/NixOS/nixpkgs/commit/4364b96eb6595740628c1f0ea4d1d6232ea14b87) flexget: 3.1.127 -> 3.1.131
* [`59daf217`](https://github.com/NixOS/nixpkgs/commit/59daf2171fb9e0055cb8549e42cea3ee462ff165) vimPlugins: update
* [`4096fe61`](https://github.com/NixOS/nixpkgs/commit/4096fe61a2e2a05b78f967f35ce32ba05facf935) vimPlugins.onedark-nvim: init at 2021-06-18
* [`2cf81aa3`](https://github.com/NixOS/nixpkgs/commit/2cf81aa35895895f717a0c230a53042e343fa703) tabnine: 3.3.115 -> 3.5.15
* [`c4212c8b`](https://github.com/NixOS/nixpkgs/commit/c4212c8bf6ac7a25d7e011257de7128fc491a4e9) tabnine: add lovesegfault as maintainer
* [`760e7e14`](https://github.com/NixOS/nixpkgs/commit/760e7e14b3f8c10c6fc1ee15606fedd22e19f685) nix-doc: Fix lint: the license is LGPL3+
* [`befa5eaf`](https://github.com/NixOS/nixpkgs/commit/befa5eafd309d313878eb8c912d3fb2377ad3711) tabnine: add runHook to installPhase
* [`f1313a80`](https://github.com/NixOS/nixpkgs/commit/f1313a80c9463616ac749025d1a4726a134506ce) visidata: 2.4 -> 2.5
* [`8afe239f`](https://github.com/NixOS/nixpkgs/commit/8afe239fb42e6d00226632d009b21b843e4d422f) malt: init at 1.2.1
* [`59bad37f`](https://github.com/NixOS/nixpkgs/commit/59bad37f4f5054addbaeefa1df3770f4eac47633) pythonPackages.BTrees: remove patch for file that doesn't exist
* [`b12a239a`](https://github.com/NixOS/nixpkgs/commit/b12a239a8e153135fdf884020067edcfbd4911f4) python3Packages.iso3166: 0.8 -> 1.0.1
* [`97192751`](https://github.com/NixOS/nixpkgs/commit/97192751d7f159dea39a6b6706943c7440991c32) maintainers: add nkje
* [`bcc71e31`](https://github.com/NixOS/nixpkgs/commit/bcc71e31b177891b1dd9fd4adf1827194d17f24d) breezy: 3.2.0 -> 3.2.1
* [`23ab1a2d`](https://github.com/NixOS/nixpkgs/commit/23ab1a2d920948b37a3922a13365785725e57463) python3Packages.gym: 0.18.1 -> 0.18.3
* [`95726968`](https://github.com/NixOS/nixpkgs/commit/95726968d92a53f9f2836defe19378ef4f48773c) pythonPackages.pypandoc: 1.5.0 -> 1.6.3
* [`ed97a5f1`](https://github.com/NixOS/nixpkgs/commit/ed97a5f158ee3c8d48604a32713c3d905c67bdd3) python3Packages.geographiclib: 1.50 -> 1.52
* [`a0005de2`](https://github.com/NixOS/nixpkgs/commit/a0005de253a11840fa7eeb76493535053bb49024) python3Packages.geographiclib: enable tests
* [`c921b5f5`](https://github.com/NixOS/nixpkgs/commit/c921b5f52632acc72f30b2582f9e387a97795fba) psi-plus: 1.5.1520 -> 1.5.1549
* [`e54730b0`](https://github.com/NixOS/nixpkgs/commit/e54730b0b863e2b872bc89a7a058bd453fc98764) gprolog: 1.4.5 -> 1.5.0
* [`84c41885`](https://github.com/NixOS/nixpkgs/commit/84c4188584460d145a981a339524f9ce9cdeb360) headscale: init at 0.2.2
* [`8a76eaa3`](https://github.com/NixOS/nixpkgs/commit/8a76eaa305fe177770855564e99e6490e04c4582) python3Packages.cachelib: 0.1.1 -> 0.2.0
* [`956caf75`](https://github.com/NixOS/nixpkgs/commit/956caf75d0660f59e779687ecffe47c8e72d7275) python3Packages.cachelib: enable tests
* [`8b7f8e2e`](https://github.com/NixOS/nixpkgs/commit/8b7f8e2e6970f21d9f180887b91c979b41450fe8) ip2unix: 2.1.3 -> 2.1.4
* [`4492c776`](https://github.com/NixOS/nixpkgs/commit/4492c776eb4245cbe10e025197304a01239881e5) maintainers: add unclechu
* [`d1f2cd1b`](https://github.com/NixOS/nixpkgs/commit/d1f2cd1b02fa43e44f1676321a1692f7a43444d3) psi-plus: add unclechu to the maintainers list
* [`6edf7503`](https://github.com/NixOS/nixpkgs/commit/6edf7503f309d61bdf86a3c70a0c3954e01c5586) code-server: 3.8.0 -> 3.9.0 ([nixos/nixpkgs⁠#118317](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/118317))
* [`1e753f52`](https://github.com/NixOS/nixpkgs/commit/1e753f52bd4877f3967a4e9c21c26e22fb51dfe9) pythonPackages.poetry: 1.1.6 -> 1.1.7
* [`41490c2b`](https://github.com/NixOS/nixpkgs/commit/41490c2bfb8879a8fe3be143cd67a9295019f8d2) gruut-ipa: init at 0.9.2
* [`0548185f`](https://github.com/NixOS/nixpkgs/commit/0548185f5b1c20c6d2ebb2fe1e266a36c0c81366) python3Packages.python-crfsuite: init at 0.9.7
* [`b95b77bb`](https://github.com/NixOS/nixpkgs/commit/b95b77bb98e79b4d2ea6801c1804e0cbea7df098) gruut: init at 1.2.2
* [`aa7a0964`](https://github.com/NixOS/nixpkgs/commit/aa7a09646bc1297d9096d2d3a3e514538fc7a9f4) tts: 0.0.15.1 -> 0.1.2
* [`cc2e8155`](https://github.com/NixOS/nixpkgs/commit/cc2e81557164339b0be93261614be3aa7ceda89e) matcha-gtk-theme: 2021-06-24 -> 2021-07-08
* [`5528f117`](https://github.com/NixOS/nixpkgs/commit/5528f1170c1a276903eabc7533020eccc9d2cd4c) saxonb_8_8, saxon: Fix jre incompatibility
* [`634e6bb3`](https://github.com/NixOS/nixpkgs/commit/634e6bb36a8c3bf3b9a742f29159651416a1cdc1) leftwm: set rpath in all executables
* [`8c52061b`](https://github.com/NixOS/nixpkgs/commit/8c52061b1fce2036b70836e5dcdfcf4b702dd405) nixos/tests/chromium: Refactor launching the browser process
* [`c33015a0`](https://github.com/NixOS/nixpkgs/commit/c33015a0c94777261ef054a3d7dacd53e744ceea) nixos/tests/chromium: Print the content of chrome://{sandbox,gpu}
* [`796214bc`](https://github.com/NixOS/nixpkgs/commit/796214bca6faadeb821479e2f841b6f3ae53a380) python-language-server: 2020-10-08 -> 2021-05-20
* [`0d9673b3`](https://github.com/NixOS/nixpkgs/commit/0d9673b318a55510cf7143a8e657447cac91f829) gdu: 5.1.1 -> 5.2.0
* [`08de64d6`](https://github.com/NixOS/nixpkgs/commit/08de64d6aa11749c417e40d50b3c893d22c7f5d9) moonlight: 3.1.1 -> 3.1.4
* [`ecb2db7d`](https://github.com/NixOS/nixpkgs/commit/ecb2db7d7e3aac716d65d14f03ac2f95bacb81e5) pythonPackages.bleak: 0.12.0 -> 0.12.1
* [`4d881f91`](https://github.com/NixOS/nixpkgs/commit/4d881f91494fed25350ec77239a7d06ff08fa91a) linuxptp: 3.1 -> 3.1.1
* [`1b89efa8`](https://github.com/NixOS/nixpkgs/commit/1b89efa8104f3445353066e9da4bc8c24715b30a) charge-lnd: 0.1.3 -> 0.2.1
* [`8534667f`](https://github.com/NixOS/nixpkgs/commit/8534667f0fe478b76e1b2eb52a636bcec83b407b) python3Packages.aiosmb: 0.2.48 -> 0.2.49
* [`aa82a79c`](https://github.com/NixOS/nixpkgs/commit/aa82a79c8ae8e8f49d570af7014f91ade2489220) doctl: 1.61.0 -> 1.62.0
* [`6f85ca43`](https://github.com/NixOS/nixpkgs/commit/6f85ca4366ba70ece65858bcce450b3d3145ebe0) thunderbird: improve integration by depending on xdg-utils
* [`c05bef5b`](https://github.com/NixOS/nixpkgs/commit/c05bef5bc56325032f4602a9d5025551653bcc5c) glances: 3.2.0 -> 3.2.1
* [`2208f09e`](https://github.com/NixOS/nixpkgs/commit/2208f09ec24d8b2770369b3cdbeb76cd019a681f) python3Packages.pyupgrade: 2.19.1 -> 2.20.0
* [`b5188025`](https://github.com/NixOS/nixpkgs/commit/b5188025c12fe8313407373c41f960d69b31ac5c) maintainers: add dgliwka
* [`8544200f`](https://github.com/NixOS/nixpkgs/commit/8544200f467f01ac7acbf313c1a4918c3f60e9e7) pythonPackages.hypercorn: init at 0.11.2
* [`ea8ac0b8`](https://github.com/NixOS/nixpkgs/commit/ea8ac0b87d0efc28a10cd0560b0e7241c5747fcf) python3Packages.identify: 2.2.10 -> 2.2.11
* [`26f64b25`](https://github.com/NixOS/nixpkgs/commit/26f64b251cbac73569e2f5cf83b27f1b0f1fe011) python3Packages.nexia: 0.9.8 -> 0.9.9
* [`43ab29e0`](https://github.com/NixOS/nixpkgs/commit/43ab29e013cba522dc8bfb8e70f15b972bb7bfb8) cinnamon.nemo: 5.0.0 -> 5.0.3
* [`c2354121`](https://github.com/NixOS/nixpkgs/commit/c2354121d5f278ae72ea9b47306fa88ac86579de) exploitdb: 2021-07-09 -> 2021-07-10
* [`b18a3d05`](https://github.com/NixOS/nixpkgs/commit/b18a3d0583f1c262845dd30761922fa5761693ca) papermc: 1.16.5r771 -> 1.17.1r97
* [`51e3fe53`](https://github.com/NixOS/nixpkgs/commit/51e3fe53462eb72aa038f2b47735acea8b1fcae2) neovim: set meta in the unwrapped version
* [`61521251`](https://github.com/NixOS/nixpkgs/commit/6152125110db596320d919df0b4b8bbbd912b089) python3Packages.python-registry: 1.3.1 -> 1.4
* [`336494e1`](https://github.com/NixOS/nixpkgs/commit/336494e19f4110a9024f994a5628743f77fbade2) nixos/prometheus: add password_file option to scrapeConfig's basic_auth ([nixos/nixpkgs⁠#123252](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/123252))
* [`e0eb4293`](https://github.com/NixOS/nixpkgs/commit/e0eb4293ea53e2d791c14b4258cecafdbfb32a94) zoom-us: 5.6.22045.0607 -> 5.7.26030.0627
* [`5ec8029d`](https://github.com/NixOS/nixpkgs/commit/5ec8029d370d5c874961baf7d8fbf5eb8f01298b) terraform-providers.kubernetes-alpha: 0.3.3 -> 0.5.0 ([nixos/nixpkgs⁠#129666](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129666))
* [`dafb3dfc`](https://github.com/NixOS/nixpkgs/commit/dafb3dfc483a1e12017ac9ddf88907d009b3edec) kops: default to 1.21.0, drop 1.18 ([nixos/nixpkgs⁠#129472](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129472))
* [`3c28724d`](https://github.com/NixOS/nixpkgs/commit/3c28724df9bea95f2922b7c25812577b692d3a3a) cudatext: 1.133.5 → 1.137.2
* [`66618844`](https://github.com/NixOS/nixpkgs/commit/66618844e3a20743d2b15590aaa370f5bb3fca6f) bluez: 5.59 -> 5.60
* [`a5d2a209`](https://github.com/NixOS/nixpkgs/commit/a5d2a209452edbeb426428af50c983dd8259da91) urlscan: 0.9.5 -> 0.9.6
* [`231a31be`](https://github.com/NixOS/nixpkgs/commit/231a31be87f8718885331fdf13a9ef235c402bb2) nixos-option: add backwards compatibility layer
* [`1701a3ef`](https://github.com/NixOS/nixpkgs/commit/1701a3efc109102531a4ef153bde5e1c78b00841) wpscan: 6.1.3.2 -> 6.1.4
* [`4e500e95`](https://github.com/NixOS/nixpkgs/commit/4e500e95c0a557e0bcd5e66bbb9be844d1c814f2) python3Packages.scp: 0.13.5 -> 0.13.6
* [`420cc96e`](https://github.com/NixOS/nixpkgs/commit/420cc96e3908f67802d502c26773746234dcf7f3) grafana-agent: 0.15.0 -> 0.16.1
* [`08ed6214`](https://github.com/NixOS/nixpkgs/commit/08ed62143f16e807288572e8f75d331c3cba13ce) slides: 0.4.0 -> 0.4.1
* [`d47d4971`](https://github.com/NixOS/nixpkgs/commit/d47d49711d8c87abb8d1cd08113c76a7a4d714ea) vscode: 1.57.1 -> 1.58.0
* [`da1dde42`](https://github.com/NixOS/nixpkgs/commit/da1dde42fb89bb63f6af04b2b63111e8595a69f4) gitui: 0.16.1 -> 0.16.2
* [`50c201f1`](https://github.com/NixOS/nixpkgs/commit/50c201f1aa8488527cbbaadedcd3a49ca832b064) platformio: fix build by pinning dependencies
* [`4dbe056e`](https://github.com/NixOS/nixpkgs/commit/4dbe056ea24da745afa3163dd859ea71ef0e6bc5) esphome: disable two failing tests
* [`63b62fbf`](https://github.com/NixOS/nixpkgs/commit/63b62fbf25b13abdb5d0e461375b70fa040e8ce9) termius: unbreak
* [`5ce96d5b`](https://github.com/NixOS/nixpkgs/commit/5ce96d5b9975a68d7e3429bd3e02dcb40471cce5) curlie: 1.6.0 -> 1.6.2
* [`75b8e218`](https://github.com/NixOS/nixpkgs/commit/75b8e2180aa2a0ee2e47464bef1202511f670dd5) oracle-instantclient: format with nixpkgs-fmt
* [`f82fa045`](https://github.com/NixOS/nixpkgs/commit/f82fa0458c51fa62f52faeb956113aa20636f4de) oracle-instantclient: add tools
* [`1864951a`](https://github.com/NixOS/nixpkgs/commit/1864951ac54a24769f67ac1a8aee07babd3e26ba) hepmc3: 3.2.3 -> 3.2.4
* [`1dec71e5`](https://github.com/NixOS/nixpkgs/commit/1dec71e52a2e71974d01a525f82a34f7c83869cd) ubootRockPro64: Fix boot hanging
* [`30ada3e6`](https://github.com/NixOS/nixpkgs/commit/30ada3e6aff2ea1731358d511d5e124d64650b6c) spidermonkey_68: fix cross
* [`1ec09ca6`](https://github.com/NixOS/nixpkgs/commit/1ec09ca60a4a28e1006e69f7bd316e8317466943) nodePackages: fix generate.sh failing on path with space
* [`8f66191e`](https://github.com/NixOS/nixpkgs/commit/8f66191e321bef3869fe902889eee84531f9daca) diylc: 4.17.0 -> 4.18.0
* [`1325f262`](https://github.com/NixOS/nixpkgs/commit/1325f2626df9a14384fdb0d5f7db5f9c3180e725) perlPackages.ImageExifTool: 12.16 -> 12.29
* [`520c2971`](https://github.com/NixOS/nixpkgs/commit/520c2971d1da6936c706138bdbe6b339f888d1c7) blender: 2.93.0 -> 2.93.1
* [`0a745f1e`](https://github.com/NixOS/nixpkgs/commit/0a745f1ef72c5bc120dbe49a2f1d156512110427) pythonPackages.awkward: 1.3.0 -> 1.4.0
* [`45bed6d9`](https://github.com/NixOS/nixpkgs/commit/45bed6d99f7b8ef9130e0bf60d1768be37e685f2) snakemake: 6.5.0 -> 6.5.3
* [`aec737ee`](https://github.com/NixOS/nixpkgs/commit/aec737eec562450433219bf7602aecfa8bfb4eb6) python3Packages.advantage-air: 0.2.2 -> 0.2.5
* [`2be79bc3`](https://github.com/NixOS/nixpkgs/commit/2be79bc371d03028508209d3fb3942833eaf2a24) pythonPackages.mat2: fix exiftool testing error
* [`93d219c8`](https://github.com/NixOS/nixpkgs/commit/93d219c8b640f987f5c4d4218ab75811e7bb5497) fennel: init at 0.9.2
* [`74812d63`](https://github.com/NixOS/nixpkgs/commit/74812d638601ce1e7d6f94f6621829ef3f3ba96a) python3Packages.aiojobs: 0.2.2 -> 0.3.0
* [`c8c7b1c2`](https://github.com/NixOS/nixpkgs/commit/c8c7b1c22e20e9ffe31052185f5e93d343129fe1) python3Packages.asgi-csrf: 0.8 -> 0.9
* [`c772d750`](https://github.com/NixOS/nixpkgs/commit/c772d7503d2e8b8c919a068b78a2c3bca52f17a8) p7zip: update owner info
* [`64bf0aa0`](https://github.com/NixOS/nixpkgs/commit/64bf0aa0239cb94ededa5ec98e155b081b28d574) neo4j-desktop: 1.4.5 -> 1.4.7 ([nixos/nixpkgs⁠#129948](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129948))
* [`b15ff3e9`](https://github.com/NixOS/nixpkgs/commit/b15ff3e91ebc2510410ed605bfb0f1dcdf230611) cobalt: fix darwin build ([nixos/nixpkgs⁠#129758](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129758))
* [`d6da9bb1`](https://github.com/NixOS/nixpkgs/commit/d6da9bb14bd50cfd7869a0ef66f6e698166ba16d) volatility: Make the screenshot tool work ([nixos/nixpkgs⁠#129772](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129772))
* [`8c6d56dd`](https://github.com/NixOS/nixpkgs/commit/8c6d56dddbfd3f6a6361924cd13730138e9a707b) infracost: improvements
* [`997d98b8`](https://github.com/NixOS/nixpkgs/commit/997d98b86fe10816df25b305222ef6d5025ad07e) lilo: init at 24.2
* [`275b7dea`](https://github.com/NixOS/nixpkgs/commit/275b7deadaaf189d14ded9431241e11d39d6c304) pastel: 0.8.0 -> 0.8.1
* [`ce770aca`](https://github.com/NixOS/nixpkgs/commit/ce770aca6836c178fb64e7923f5117ce823f4d77) stylua: 0.9.3 -> 0.10.0
* [`91eea548`](https://github.com/NixOS/nixpkgs/commit/91eea5481c7c889a0817125a30bea7e85adcc27d) tea: use fetchFromGitea instead of fetchgit
* [`c8fefce4`](https://github.com/NixOS/nixpkgs/commit/c8fefce416a60927f5d7d54c268a240c793b64c4) dhcp: was relicensed from ISC to MPL2.0 in 2018
* [`1fb2e392`](https://github.com/NixOS/nixpkgs/commit/1fb2e3920466b6f7569ba3fc264ce67ba68fa779) cod: unstable-2020-09-10 -> 0.1.0 ([nixos/nixpkgs⁠#129951](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129951))
* [`7f882823`](https://github.com/NixOS/nixpkgs/commit/7f8828230fa180acb82517f73d7f903378c1d707) vscode: Add arm64-darwin support
* [`e398cfb1`](https://github.com/NixOS/nixpkgs/commit/e398cfb1219cdbdd58ef6ba713c5459b5730d7f8) pure-prompt: 1.16.0 -> 1.17.0
* [`32900181`](https://github.com/NixOS/nixpkgs/commit/32900181cb1100b5fd88760a598084a42bc8bfdd) vimPlugins: update
* [`dd2293c1`](https://github.com/NixOS/nixpkgs/commit/dd2293c14628239313ed48684f735539acdf6d86) vimPlugins.lsp-rooter-nvim: init at 2021-05-25
* [`00ab017f`](https://github.com/NixOS/nixpkgs/commit/00ab017fec960b30abb90c4dfcd53815d38fc72a) easyeffects: re-add plugins ([nixos/nixpkgs⁠#129968](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129968))
* [`eb5fb129`](https://github.com/NixOS/nixpkgs/commit/eb5fb1290bae61dc948b73876cd74511f37f973f) vscode: add aarch64-darwin to update script
* [`39331740`](https://github.com/NixOS/nixpkgs/commit/39331740f8127a427941a8daf1d32a7cad0e253f) prometheus-lnd-exporter: unstable-2020-12-04 -> unstable-2021-03-26
* [`eab071ae`](https://github.com/NixOS/nixpkgs/commit/eab071ae545169528bd9769000fb40287ccb2b08) nixos/prometheus-lnd-exporter: fix test
* [`ea49e9dc`](https://github.com/NixOS/nixpkgs/commit/ea49e9dc0197466aa6efb81a3e94999a08c620e6) maintainers/teams: remove mmilata from jitsi
* [`44fa7674`](https://github.com/NixOS/nixpkgs/commit/44fa76748e61b7f027ba771384a15bac3ae346b5) vimPlugins.feline-nvim: init at 2021-07-11
* [`ddfe4569`](https://github.com/NixOS/nixpkgs/commit/ddfe45698313e731529203a69fcdd6709d1010be) cod: cleanup
* [`81650628`](https://github.com/NixOS/nixpkgs/commit/816506281dc5c696c924557c367bb245afbb3b44) open-vm-tools: add aarch64-linux to platforms ([nixos/nixpkgs⁠#129981](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129981))
