### PR TITLE
niv home-manager: update 97d183e2 -> 775cb20b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "97d183e2e466808f5d7cd1c838815bedd88f37fe",
-        "sha256": "1h24illqvxymyjxr4bym11g3bgwd5ni7dhniisq829phbq11xbl6",
+        "rev": "775cb20bd4af7781fbf336fb201df02ee3d544bb",
+        "sha256": "0lnjkli210yrwa39n77n4kvbzplrxw0bljgvrsyskfsmzb4h31xy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/97d183e2e466808f5d7cd1c838815bedd88f37fe.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/775cb20bd4af7781fbf336fb201df02ee3d544bb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@97d183e2...775cb20b](https://github.com/nix-community/home-manager/compare/97d183e2e466808f5d7cd1c838815bedd88f37fe...775cb20bd4af7781fbf336fb201df02ee3d544bb)

* [`06ee8ec8`](https://github.com/nix-community/home-manager/commit/06ee8ec8dfc4554c374052cd7b7083765748af99) xmobar: use dummy package in test
* [`d7d7bbbf`](https://github.com/nix-community/home-manager/commit/d7d7bbbf20b17444d8843b47df727d16d84b840d) home-manager: use nixos-option from pkgs
* [`2c9fe368`](https://github.com/nix-community/home-manager/commit/2c9fe368c1b5d79d504e3111ebaa97e90192fbb4) Revert "home-manager: use nixos-option from pkgs"
* [`ae636c09`](https://github.com/nix-community/home-manager/commit/ae636c09f452f351d3983a6aac101de20db18b44) Revert "Revert "home-manager: use nixos-option from pkgs""
* [`9ed7a73a`](https://github.com/nix-community/home-manager/commit/9ed7a73ae23f0d905bd098c6ce71c50289d37928) home-manager: fix nixos-option fallback
* [`3ab254af`](https://github.com/nix-community/home-manager/commit/3ab254aff4ea57c4c879a0410f1b3ceadca15b7a) qutebrowser: add onChange ipc reloading
* [`4971b9ca`](https://github.com/nix-community/home-manager/commit/4971b9cad07dfe247f7d970b6823540f767df249) setxkbmap: reset options before setting new ones ([nix-community/home-manager⁠#2160](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2160))
* [`9e3c4029`](https://github.com/nix-community/home-manager/commit/9e3c4029720504d93db1ad3b1fabebfeb95ae82f) brave: fix config dir path ([nix-community/home-manager⁠#2173](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2173))
* [`775cb20b`](https://github.com/nix-community/home-manager/commit/775cb20bd4af7781fbf336fb201df02ee3d544bb) sm64ex: add module
