### PR TITLE
niv spacemacs: update d78d8282 -> a2ab0a02

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "d78d8282f553965d1c6f799179dac13828ca3bc5",
-        "sha256": "0zx1c4nb9slzxvndh9s1larfgbwdv8g2w5qbc26dh06hk3aw7k4r",
+        "rev": "a2ab0a023307c2ecd6b5878f8b503f3601f8fe8f",
+        "sha256": "06kbx9kj9d6x61b21yzswwx27ljsnd4qalf9f7bzwcn1b3zlvzj5",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/d78d8282f553965d1c6f799179dac13828ca3bc5.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/a2ab0a023307c2ecd6b5878f8b503f3601f8fe8f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@d78d8282...a2ab0a02](https://github.com/syl20bnr/spacemacs/compare/d78d8282f553965d1c6f799179dac13828ca3bc5...a2ab0a023307c2ecd6b5878f8b503f3601f8fe8f)

* [`968713e7`](https://github.com/syl20bnr/spacemacs/commit/968713e749be5ec7b388e70e941f098f57c10022) [ci] refactor
* [`f15e95e1`](https://github.com/syl20bnr/spacemacs/commit/f15e95e1f1d9d9be738c403394ee5651756dba87) [ci] Also update built-in on branch push
* [`b992ad29`](https://github.com/syl20bnr/spacemacs/commit/b992ad29bb0f0859db6df30bfac7492c49a8a22c) [bot] "spacemacs_built_in" Tue Jul  6 16:12:28 UTC 2021
* [`daf108cb`](https://github.com/syl20bnr/spacemacs/commit/daf108cb1b035e2e49fad8520ea1b26e6351a234) [ci] fix layers.org gen
* [`04bddbb5`](https://github.com/syl20bnr/spacemacs/commit/04bddbb5b92508c67803c54480e6688be651b52d) [ci] cleanup
* [`7c7843d1`](https://github.com/syl20bnr/spacemacs/commit/7c7843d1219af6ca9c6d85c0dfa557b8ee04c2d4) [ci] fix patching
* [`a082ade2`](https://github.com/syl20bnr/spacemacs/commit/a082ade23b3454c1cab187bf13e9a3bc1d9b9b02) [bot] "documentation_updates" Wed Jul  7 12:41:59 UTC 2021
* [`d818e115`](https://github.com/syl20bnr/spacemacs/commit/d818e1152985d1dc1804a592c8552780056da11a) [bot] "built_in_updates" Wed Jul  7 12:41:15 UTC 2021
* [`1069e37a`](https://github.com/syl20bnr/spacemacs/commit/1069e37a98217f78297c7f825d1132ecfdb5e6da) Fix symbol highlighting
* [`820d9fb9`](https://github.com/syl20bnr/spacemacs/commit/820d9fb9556861ef6354430790f1823762b6e52d) Finish up fixing symbol highlighting
* [`5c75eb4e`](https://github.com/syl20bnr/spacemacs/commit/5c75eb4ea391a424d602dfeb66945e878ce0e23e) Continue fixing and refactoring integration with auto-highlight-symbol
* [`8b832ecb`](https://github.com/syl20bnr/spacemacs/commit/8b832ecb4a8c2276e073555762fdc8e8a5cc963f) [ci] move html export to CircleCI
* [`00599d32`](https://github.com/syl20bnr/spacemacs/commit/00599d325565c22553388fcad06355775a5f79e6) [bot] "built_in_updates" Thu Jul  8 12:30:53 UTC 2021
* [`40d66a72`](https://github.com/syl20bnr/spacemacs/commit/40d66a725ea29bb7fac4824b95dd3a1d76ca5d4c) [ci] cache deps for web export
* [`483cdd1c`](https://github.com/syl20bnr/spacemacs/commit/483cdd1c0d6e2bf12e02fd9b0cec6b585ca482cf) Fix symbol highlight ts, infinite loop
* [`af345fd4`](https://github.com/syl20bnr/spacemacs/commit/af345fd4c16f55ef6cedbfa212ce4452b4894206) [doc] fix links
* [`97ad6bad`](https://github.com/syl20bnr/spacemacs/commit/97ad6bad3ff28bcaff3ba7c4b389326f86228170) [ci] unmask hub push logs
* [`a2ab0a02`](https://github.com/syl20bnr/spacemacs/commit/a2ab0a023307c2ecd6b5878f8b503f3601f8fe8f) [ci] actually unmask the logs
