### PR TITLE
niv nixpkgs: update 90958cd7 -> 5972cc31

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "90958cd740faaa30b6bce3821502adc74fa801d2",
-        "sha256": "0h6bz6mkgb15553ryff3lksd5x6ycyxiaf2904h0lbqwrkcjq62v",
+        "rev": "5972cc3119a847ef4d5bf65121c5809c70d66972",
+        "sha256": "1scbj28xj488aaqpkn4s3y1g63xawzn9c1rjvkjsan3c3q6yrc6n",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/90958cd740faaa30b6bce3821502adc74fa801d2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5972cc3119a847ef4d5bf65121c5809c70d66972.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@90958cd7...5972cc31](https://github.com/nixos/nixpkgs/compare/90958cd740faaa30b6bce3821502adc74fa801d2...5972cc3119a847ef4d5bf65121c5809c70d66972)

* [`6dcfb308`](https://github.com/NixOS/nixpkgs/commit/6dcfb3083da74a107a0fd5c300f3a84f6087f900) melpa-packages 2021-07-16
* [`e56573a7`](https://github.com/NixOS/nixpkgs/commit/e56573a734fe6eeb38352908aaf846e33e396e85) org-packages 2021-07-16
* [`94bcbeef`](https://github.com/NixOS/nixpkgs/commit/94bcbeef92dd0693eac4886e9fa80d6d9e8aa0ea) ebuild-mode: use ${pname}-${version}
* [`07957d08`](https://github.com/NixOS/nixpkgs/commit/07957d08afb59afefd14cd9da8f716b236f313fe) elpa-packages 2021-07-16
* [`98262bd1`](https://github.com/NixOS/nixpkgs/commit/98262bd121491dc06fb924443dbe5ae577a28942) elpa-packages 2021-07-16
* [`59b2fe6a`](https://github.com/NixOS/nixpkgs/commit/59b2fe6adc8532d1006fbfbeee6754844b85b581) pantheon.elementary-code: 3.4.1 -> 6.0.0
* [`8a9cc8c2`](https://github.com/NixOS/nixpkgs/commit/8a9cc8c2042f832373af94814712a6d90ca07665) pantheon.elementary-terminal: 5.5.2 -> 6.0.0
* [`f3d08d4b`](https://github.com/NixOS/nixpkgs/commit/f3d08d4b9156d92b22c4aca7e0f5171e3da6ebfd) haskellPackages: mark builds failing on hydra as broken
* [`bd8076df`](https://github.com/NixOS/nixpkgs/commit/bd8076df8ae8d857d93f47430df1d400ab7d5964) vscode-extensions: update script consider codium
* [`d3a17ca7`](https://github.com/NixOS/nixpkgs/commit/d3a17ca735eaab64a46a8842304d3e68ad53f12f) vscode-extensions.bradlc.vscode-tailwindcss: 0.6.6 -> 0.6.13
* [`d06e921e`](https://github.com/NixOS/nixpkgs/commit/d06e921ec63cc63bc41bc7d02c3f14cb6eb538d5) vscode-extensions.coenraads.bracket-pair-colorizer-2: 0.2.0 -> 0.2.1
* [`aa15b4f1`](https://github.com/NixOS/nixpkgs/commit/aa15b4f1e3997e754a413aecde345f6d6008feec) vscode-extensions.emmanuelbeziat.vscode-great-icons: 2.1.64 -> 2.1.79
* [`b3b079de`](https://github.com/NixOS/nixpkgs/commit/b3b079de1381dc82a0108bea8044463bb4956b1f) vscode-extensions.esbenp.prettier-vscode: 5.8.0 -> 8.0.1
* [`ae3d297e`](https://github.com/NixOS/nixpkgs/commit/ae3d297e6714e300e9f84bc7b491d44145ad4359) vscode-extensions.jock.svg: 1.4.4 -> 1.4.7
* [`bdd69750`](https://github.com/NixOS/nixpkgs/commit/bdd69750ea0adaea47d304b9ca616fa1c1f30c1f) vscode-extensions.kahole.magit: 0.6.15 -> 0.6.18
* [`c07ff766`](https://github.com/NixOS/nixpkgs/commit/c07ff766f3cfbee793b008bde0f2ffeafd9ae5dd) vscode-extensions.serayuzgur.crates: 0.5.3 -> 0.5.9
* [`ee43e6ba`](https://github.com/NixOS/nixpkgs/commit/ee43e6bac1b4b8d1537bae282db4412b8cdb4694) vscode-extensions.svelte.svelte-vscode: 105.0.0 -> 105.3.0
* [`b84b6477`](https://github.com/NixOS/nixpkgs/commit/b84b6477a54311debede37264182d21b97d208ec) vscode-extensions.timonwong.shellcheck: 0.14.1 -> 0.14.4
* [`60f58c5d`](https://github.com/NixOS/nixpkgs/commit/60f58c5da0ef2179cb0d672f9baf11690829e7fc) vscode-extensions.vscodevim.vim: 1.11.3 -> 1.21.5
* [`6e5f2d2b`](https://github.com/NixOS/nixpkgs/commit/6e5f2d2b0105aea7aa925dd9eaa61d59317fcefe) vscodium: 1.58.1 -> 1.58.2
* [`ff0c051d`](https://github.com/NixOS/nixpkgs/commit/ff0c051daf65555e40a66e9b452568b89d8a5537) cedille: mark broken
* [`29908263`](https://github.com/NixOS/nixpkgs/commit/299082636c5909177456bc7b9a3703e39550d3c2) cedille: set no hydra platforms
* [`43260afe`](https://github.com/NixOS/nixpkgs/commit/43260afeea3f461d28d899585432cdc8019c7138) vimPlugins.null-ls-nvim: init at 2021-07-14
* [`ea2660f8`](https://github.com/NixOS/nixpkgs/commit/ea2660f8d2b14bde09d95fe5ebe6826393b619ab) haskell-updates: make sure the transitive-broken-packges are sorted using LC_ALL=C
* [`19633b7e`](https://github.com/NixOS/nixpkgs/commit/19633b7ea948437b66698322381cbde90394d332) haskellPackages: sort transitive-broken list correctly
* [`3f123794`](https://github.com/NixOS/nixpkgs/commit/3f12379409112b9d8c13ade268e639c0de66123c) pantheon.elementary-mail: unstable-2021-06-21 -> 6.0.0
* [`3d68137c`](https://github.com/NixOS/nixpkgs/commit/3d68137c6e5094ac738745ac41ec980af725590b) pypy: 7.3.3 -> 7.3.5
* [`9fdec687`](https://github.com/NixOS/nixpkgs/commit/9fdec6876ebf668d62559cc35b5d7b2a9b208e3f) release-haskell: disable the x86_64-darwin writers test
* [`b4820bb9`](https://github.com/NixOS/nixpkgs/commit/b4820bb9dc623637c352debdf1c195b99e4fbd0d) nixos/manual: Fix link to contributing guide
* [`bb568917`](https://github.com/NixOS/nixpkgs/commit/bb568917b2c8dfc058d534cc4cc0d1e5588b7664) nixos/bind: add directory config option ([nixos/nixpkgs⁠#129188](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129188))
* [`2bf5cb07`](https://github.com/NixOS/nixpkgs/commit/2bf5cb07cfaf092470886c1af7b4bd0f189562e1) pythonPackages.nix-prefetch-github: 4.0.3 -> 4.0.4
* [`025a67bf`](https://github.com/NixOS/nixpkgs/commit/025a67bf6ce5af89187e3d65fb42d9b7edf549ac) liquidctl: 1.7.0 -> 1.7.1
* [`2489eb5e`](https://github.com/NixOS/nixpkgs/commit/2489eb5e4516aab575ab114b7e0a3e1b5c5daca7) python3Packages.subarulink: 0.3.13 -> 0.3.14
* [`f99094ad`](https://github.com/NixOS/nixpkgs/commit/f99094ad640590145e32df2740df2be502a6eec1) python3Packages.requests-cache: 0.7.0 -> 0.7.1
* [`5f9966e0`](https://github.com/NixOS/nixpkgs/commit/5f9966e03c1910a2db101c54c4e12772b7dc4540) python3Packages.build: 0.3.0 -> 0.5.1
* [`ababd305`](https://github.com/NixOS/nixpkgs/commit/ababd305b30a4d80c33897d86edf1b46373ca0fe) python3Packages.yalexs: 1.1.11 -> 1.1.12
* [`c3ad780c`](https://github.com/NixOS/nixpkgs/commit/c3ad780c664700e4c8446332ed6cb04b245a40c2) python3Packages.skytemple-dtef: 1.1.3 -> 1.1.4
* [`0bcd68b1`](https://github.com/NixOS/nixpkgs/commit/0bcd68b1ef2eda0cbf960f2f5cbfc5bea1fc74b9) python2Packages.convertdate: fix hash
* [`e10404fa`](https://github.com/NixOS/nixpkgs/commit/e10404fa9ca8c22cf5144743f0e531f661897cdd) vscode: 1.58.0 -> 1.58.2
* [`7ab66456`](https://github.com/NixOS/nixpkgs/commit/7ab66456ca15f89d27e79076c4715b0149ae0e7f) wireshark: 3.4.6 -> 3.4.7
* [`3a4e9538`](https://github.com/NixOS/nixpkgs/commit/3a4e9538cd266322baf66b9847947a9d247f3d55) amass: 3.13.2 -> 3.13.3
* [`7f03787b`](https://github.com/NixOS/nixpkgs/commit/7f03787b76cfd8d158a14cdca77bc88e31685d08) choose: 1.3.1 -> 1.3.2
* [`10396abd`](https://github.com/NixOS/nixpkgs/commit/10396abdbc993a3dffeec8d61fe16d4aca5fcaa5) chezmoi: 2.1.0 -> 2.1.1
* [`1c7edc4a`](https://github.com/NixOS/nixpkgs/commit/1c7edc4a71a27692138c4a81d9eace845e1b0630) liquibase: 4.4.0 -> 4.4.1
* [`c8868a9c`](https://github.com/NixOS/nixpkgs/commit/c8868a9c48e5be6ad8445d30a3fe4e2b749f2ea0) grml-zsh-config: 0.18.0 -> 0.19.0
* [`883fbac5`](https://github.com/NixOS/nixpkgs/commit/883fbac5cdbf222609ba727c00a71986e9a407f4) python3Packages.pyvicare: 0.2.5 -> 1.0.0
* [`2dbdca1a`](https://github.com/NixOS/nixpkgs/commit/2dbdca1aa4ce10d3de8e40dcdeed6df6bde4175c) openresty: 1.19.3.1 -> 1.19.3.2
* [`2931283a`](https://github.com/NixOS/nixpkgs/commit/2931283a42b800a10088738261ea422a69499c8e) putty: 0.74 -> 0.75
* [`87707493`](https://github.com/NixOS/nixpkgs/commit/877074932d27d2ef4c25321074a0366f495a41a7) butane: 0.12.1 -> 0.13.0
* [`c5e29c78`](https://github.com/NixOS/nixpkgs/commit/c5e29c786ffa9413a358ed3accf52e22a27f01cb) ungoogled-chromium: 91.0.4472.114 -> 91.0.4472.164
* [`c83fdf9a`](https://github.com/NixOS/nixpkgs/commit/c83fdf9a366f0708f61f398f453f7921b0e67462) ant: 1.10.9 -> 1.10.11
* [`1e1e5364`](https://github.com/NixOS/nixpkgs/commit/1e1e5364883ae78cc15b03c2ff5202bc359e32f2) apacheAnt_1_9: 1.9.15 -> 1.9.16
* [`d268ae1f`](https://github.com/NixOS/nixpkgs/commit/d268ae1f94bce0e22da5f811963a36f9b88de413) exploitdb: update 2021-07-15 -> 2021-07-17
* [`f4902536`](https://github.com/NixOS/nixpkgs/commit/f4902536aa58ef95857a2c55fb650105bb87b442) podman: add darwin wrapper with qemu for podman machine
* [`eaabfeca`](https://github.com/NixOS/nixpkgs/commit/eaabfecab3f9fb9bc5c2bfebf54b993e221be6b2) vulnix: 1.9.6 -> 1.10.0
* [`5206a608`](https://github.com/NixOS/nixpkgs/commit/5206a608e68323d66bb4041bf70fdf1afd06fca6) google-cloud-sdk: 347.0.0 -> 348.0.0
* [`698d433e`](https://github.com/NixOS/nixpkgs/commit/698d433e74a6dcc5d02e1d1f43083ca97433069b) exiv2: fix for darwin by providing libiconv
* [`1d9dfb87`](https://github.com/NixOS/nixpkgs/commit/1d9dfb8747b7e662a6f0436a7172b38e6627ca08) cloudmonkey: 5.3.3 -> 6.1.0
* [`4d052c9b`](https://github.com/NixOS/nixpkgs/commit/4d052c9be8ac10077ed4d8e878c0c8acbf6c7397) linode-cli: 5.5.1 -> 5.5.2
* [`c8e3c1fa`](https://github.com/NixOS/nixpkgs/commit/c8e3c1fa35db9d381ea1fd17e18cf31d96fb2425) python3Packages.pyutil: init at 3.3.0
* [`43685a7a`](https://github.com/NixOS/nixpkgs/commit/43685a7aec7286f026c01887f4c3707816efb4a3) python3Packages.zfec: init at 1.5.5
* [`9ffff041`](https://github.com/NixOS/nixpkgs/commit/9ffff041562b5ef30c55b89b6863043204d7bd4b) blocksat-cli: init at 0.3.2
* [`dfbc9401`](https://github.com/NixOS/nixpkgs/commit/dfbc940137c1b90a2978cba6f4d660516deaf20d) coqPackages.math-classes: 8.12.0 -> 8.13.0
* [`785b67da`](https://github.com/NixOS/nixpkgs/commit/785b67da96e810893e4458adcff0c4429e3cbfd9) julia_16-bin: 1.6.1 -> 1.6.2
* [`c6bd32b0`](https://github.com/NixOS/nixpkgs/commit/c6bd32b06a8053159dd9c0d474a37ebbf7f44af5) wcslib: 7.6 -> 7.7
* [`fb7a4364`](https://github.com/NixOS/nixpkgs/commit/fb7a4364eed25089dab218c811e26bda7ad91b00) python3Packages.mesonpep517: 0.1.9999994 -> 0.2
* [`1c586291`](https://github.com/NixOS/nixpkgs/commit/1c586291425a2e2c5683db88a829dbc419f23e45) python3Packages.editables: init at 0.2
* [`d1d1650e`](https://github.com/NixOS/nixpkgs/commit/d1d1650e19b9c7dad39656ec2b2976ef4e4b0dd1) python3Packages.beniget: 0.3.0 -> 0.4.0
* [`848145ee`](https://github.com/NixOS/nixpkgs/commit/848145ee26c0e50e3cf1558aa94e30986868a4c1) python3Packages.gast: 0.4.0 -> 0.5.0
* [`1d505e49`](https://github.com/NixOS/nixpkgs/commit/1d505e4906259d453d7ae41205e367048c0c7900) python3Packages.pythran: 0.9.8post3 -> 0.9.12
* [`f0eb9656`](https://github.com/NixOS/nixpkgs/commit/f0eb9656a50a04eda18c25a7220ae563aa674907) gopls: 0.6.10 -> 0.7.0
* [`1a65e24a`](https://github.com/NixOS/nixpkgs/commit/1a65e24a8cbb9fbff749819ef305eb9801483a7c) python3Packages.pync: enable for python3 and update checkInputs
* [`e5b5d1b4`](https://github.com/NixOS/nixpkgs/commit/e5b5d1b4c48e4872fb5b7620af32d4b0c888dcb4) python3Packages.adafruit-platformdetect: 3.15.1 -> 3.15.3
* [`ed443e22`](https://github.com/NixOS/nixpkgs/commit/ed443e2213eec6e18886333f29f626bba2d28317) debugedit-unstable: init at e04296ddf / 2021-07-05
* [`36423132`](https://github.com/NixOS/nixpkgs/commit/3642313273e4b2937bae204b3ddaf8163e4f3be3) vimPlugins: update
* [`12b0c115`](https://github.com/NixOS/nixpkgs/commit/12b0c1150bd3b378765022e0ce7410bac3e42b90) vimPlugins.neovim-ayu: init at 2021-07-13
* [`b0f93a01`](https://github.com/NixOS/nixpkgs/commit/b0f93a01336e6cf835e27356c37fced16d6cf408) unar: remove \ from longDescription
* [`ad1e9c3a`](https://github.com/NixOS/nixpkgs/commit/ad1e9c3a275dc30435aebfd05260b78bf02d9d7f) gnumake: remove ? null from inputs
* [`1b9fbd0d`](https://github.com/NixOS/nixpkgs/commit/1b9fbd0d0e07cfba3ed9e69e886a55c15e4a3793) Make namazu package build ([nixos/nixpkgs⁠#129400](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129400))
* [`a80435da`](https://github.com/NixOS/nixpkgs/commit/a80435dac232370e96bc41ae05790ae7ce5deb13) runningx: deprecate phases
* [`0aad66e2`](https://github.com/NixOS/nixpkgs/commit/0aad66e2a269563e5d7426c37119417d4271425b) libgxps: support cross-compilation
* [`865160ea`](https://github.com/NixOS/nixpkgs/commit/865160ea7cc1d52329223b3a1750aa569f28d6d6) vimPlugins: update
* [`2c8298b5`](https://github.com/NixOS/nixpkgs/commit/2c8298b5d92230be8949fc6407ac41b8fff02845) vimPlugins.telescope-fzf-native-nvim: init at 2021-07-06
* [`5a6496b4`](https://github.com/NixOS/nixpkgs/commit/5a6496b41fab1dbc83f3cef41415cfa1dacfceee) clooj: deprecate phases
* [`861e1f1a`](https://github.com/NixOS/nixpkgs/commit/861e1f1a5d6a9874d219b9dc86fe609cbc478e74) scli: 0.6.3 -> 0.6.4
* [`cdf1b40b`](https://github.com/NixOS/nixpkgs/commit/cdf1b40b54fa05418311df47337171ba6f2dcc24) facedetect: deprecate phases
* [`983daf98`](https://github.com/NixOS/nixpkgs/commit/983daf98f7bad12cadeb4253747329669fe13ea7) mdcat: fix wezterm detection through TERM
* [`0222f420`](https://github.com/NixOS/nixpkgs/commit/0222f420c230e718823572c9cf4835b07fdae13a) lvmsync: deprecate phases
* [`64b38a5f`](https://github.com/NixOS/nixpkgs/commit/64b38a5feb9b39ef55cf6a59181bfc3674b5c7be) vimPlugins.telescope-fzf-native-nvim: build binaries
* [`a60a90eb`](https://github.com/NixOS/nixpkgs/commit/a60a90eba3d2e05e78276da38c9bcb4b95f5a2bc) antigen: deprecate phases
* [`d092bf08`](https://github.com/NixOS/nixpkgs/commit/d092bf08fe8a09868ab0a331b7ae72cbfab9b92f) 1password-gui: 8.0.34 - 8.1.1 ([nixos/nixpkgs⁠#130270](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/130270))
* [`cdf9e3a3`](https://github.com/NixOS/nixpkgs/commit/cdf9e3a37b8c289aa0ed56d37799b209ab837a2e) vimPlugins.aerial-nvim: init at 2021-07-17
* [`84abd5c2`](https://github.com/NixOS/nixpkgs/commit/84abd5c20a360a145c70b548d12f232021d39de0) zsh-command-time: deprecate phases
* [`b1121749`](https://github.com/NixOS/nixpkgs/commit/b112174956922fd76d7eb16e4a3716ed79746f77) skk-dicts: deprecate phases
* [`0e5cfdb8`](https://github.com/NixOS/nixpkgs/commit/0e5cfdb8c568f9280e23ee5fae276569b34438b8) Partially revert "various: cleanup of 'inherit version;'"
* [`e023025e`](https://github.com/NixOS/nixpkgs/commit/e023025ee026a9e62a5e754d608572903304550a) various: cleanup of "inherit version;"
* [`d9d7d156`](https://github.com/NixOS/nixpkgs/commit/d9d7d1565e26e03d34bc8a0ec8fce394c1776d10) mnist: deprecate phases
* [`0e4f71d8`](https://github.com/NixOS/nixpkgs/commit/0e4f71d8a8c130f1f49dc1776aed1252a6425a94) sshuttle: format, cleanup, remove extra test dependencies
* [`da37c8eb`](https://github.com/NixOS/nixpkgs/commit/da37c8ebcaf06a785a7e487ce4d61d4325d8944b) wofi-emoji: init at unstable-2021-05-24 ([nixos/nixpkgs⁠#130260](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/130260))
* [`82cb33a0`](https://github.com/NixOS/nixpkgs/commit/82cb33a0ae1a9128141709729b30784e821f0820) treewide: remove meta.version
* [`91e4af79`](https://github.com/NixOS/nixpkgs/commit/91e4af79d05d1d6303edb74aeada834c8dc2103c) thinking-rock: switch to pname + version
* [`efd793b4`](https://github.com/NixOS/nixpkgs/commit/efd793b4848c092a203b3ecffe35d84762877d73) vdr.plugins: switch to pname + version, format
* [`07420707`](https://github.com/NixOS/nixpkgs/commit/07420707949a6d0350f50095dcb1f58cbf013d72) nanopb/test-message-with-{annotations,options}: fix typo
* [`0117861a`](https://github.com/NixOS/nixpkgs/commit/0117861a83328bf7547ea4f7dedd46fabcfd3f54) apulse: switch to pname + version
* [`24f72b61`](https://github.com/NixOS/nixpkgs/commit/24f72b6152bf9f684b90f0461430ba50054352f1) python3Packages.editables: cleanup ([nixos/nixpkgs⁠#130476](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/130476))
* [`87316d77`](https://github.com/NixOS/nixpkgs/commit/87316d778be9234ada273c0892ce9788bd23ab9f) various: cleanup of "inherit version;"
* [`c64bc214`](https://github.com/NixOS/nixpkgs/commit/c64bc214efe713c9ec35db28bd9329e6858c2a4e) mold: mark broken on aarch64
* [`ab65de76`](https://github.com/NixOS/nixpkgs/commit/ab65de76bf3a6d31bc5e98ad6286d1c955c2a607) yandex-disk: 0.1.5.1039 -> 0.1.6.1074 ([nixos/nixpkgs⁠#130450](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/130450))
* [`fa949bad`](https://github.com/NixOS/nixpkgs/commit/fa949bad45df7bf233738ef8505741da8ffe80e9) zsh-autoenv: add unstable to version
* [`290aeb34`](https://github.com/NixOS/nixpkgs/commit/290aeb344f27a40c50b534c43f18484b48b29102) buildLinux: pass buildPackages to linuxManualConfig
* [`aabf5dd5`](https://github.com/NixOS/nixpkgs/commit/aabf5dd5f7a122b33ea601bf5546acf4e2909c81) looking-glass-client: B3 -> B4
* [`d4b8356c`](https://github.com/NixOS/nixpkgs/commit/d4b8356ce2ee17c4abd56588a6f50e4839711d28) pcalc: 20141224 -> 20181202
* [`d015fb1e`](https://github.com/NixOS/nixpkgs/commit/d015fb1edb183823dda5dda29caf21e69c7ca531) lxappearance: add wrapGAppsHook
* [`ac7b8724`](https://github.com/NixOS/nixpkgs/commit/ac7b8724b59974c0d74f2feacc4a2a787a5cf122) nixos/nix-serve: don't run as nogroup
* [`cc56dc07`](https://github.com/NixOS/nixpkgs/commit/cc56dc078d9855e8ba5ba374f75235e9829d5754) nixos/telegraf: don't run as nogroup
* [`43a22358`](https://github.com/NixOS/nixpkgs/commit/43a223586f5fe68f4756afda504355014e43ccf0) deltachat-electron: 1.15.5 -> 1.20.3
* [`c24fa221`](https://github.com/NixOS/nixpkgs/commit/c24fa221abfe606ccfde6d0aa73662385c9d3a77) nixos/telegraf: improve documentation
* [`2953cddf`](https://github.com/NixOS/nixpkgs/commit/2953cddf9aa100fec02d00fafecffa14b75b777a) python38Packages.cherrypy: fix build on darwin
* [`14d59272`](https://github.com/NixOS/nixpkgs/commit/14d592728d25650b487245e8744b4381a63d6a65) smartmontools: add meta.mainProgram
* [`3a7405c1`](https://github.com/NixOS/nixpkgs/commit/3a7405c1beb9d9cfc735c9e3162634e49d526641) nodePackages.autoprefixer: init at 10.3.1
* [`6ec2fcef`](https://github.com/NixOS/nixpkgs/commit/6ec2fcefd296afd0bd6952e11589662b7e9415d0) python3Packages.h2: fix typo (pythonImportCheck -> pythonImportsCheck)
* [`986862fc`](https://github.com/NixOS/nixpkgs/commit/986862fc8f3dfce7c67efd4efe016987d3654534) python3Packages.flask-restx: fix typo (pythonImportCheck -> pythonImportsCheck)
* [`c32d6f8c`](https://github.com/NixOS/nixpkgs/commit/c32d6f8cbdd747be8580052993b67af024cf3316) man-db: add meta.mainProgram
* [`703b9b14`](https://github.com/NixOS/nixpkgs/commit/703b9b144c5b1ed5bc5057c9277c85f00e801d78) nodePackages.postcss-cli: add passthru.tests
* [`cddea297`](https://github.com/NixOS/nixpkgs/commit/cddea297f28ab67d1f2bf0902bfdcc95ec29a8a0) qemu: add patches for CVE-2021-3545 & CVE-2021-3546
* [`1bc6f380`](https://github.com/NixOS/nixpkgs/commit/1bc6f380003de4985ec6c77f86c5743b41773e74) nixos/doc: update EOL of 21.11
* [`23dd37dd`](https://github.com/NixOS/nixpkgs/commit/23dd37dd5ed22cc0ad296698330a9ecd1e26c16c) rustPlatform.importCargoLock: add an assert for old Cargo.locks
* [`e3eace9b`](https://github.com/NixOS/nixpkgs/commit/e3eace9baa10d524173e34cad3d2a31c2413f8cc) linux: 4.14.238 -> 4.14.239
* [`cb978946`](https://github.com/NixOS/nixpkgs/commit/cb978946c1a99c8e6a204d0e45cc7078f331673c) linux: 4.19.196 -> 4.19.197
* [`a2259ae9`](https://github.com/NixOS/nixpkgs/commit/a2259ae9a6a48adc580906a9dcfe653f08aa3a94) linux: 5.10.48 -> 5.10.50
* [`677dcff2`](https://github.com/NixOS/nixpkgs/commit/677dcff2aa039ede045ad751da0a0877238ed2cc) linux: 5.12.15 -> 5.12.17
* [`5d99998e`](https://github.com/NixOS/nixpkgs/commit/5d99998e07ec4f60da6bd0c822356bfecbbbc947) linux: 5.4.130 -> 5.4.132
* [`9e7fd90e`](https://github.com/NixOS/nixpkgs/commit/9e7fd90e153006f1ec5cdd612eb70305c19019db) linux-rt_5_10: 5.10.47-rt45 -> 5.10.47-rt46
* [`73667e11`](https://github.com/NixOS/nixpkgs/commit/73667e11f3b8da2237b4e43816d59151b2f7af50) linux/hardened/patches/4.14: 4.14.238-hardened1 -> 4.14.239-hardened1
* [`888c46fe`](https://github.com/NixOS/nixpkgs/commit/888c46fe62dd87556537da8b04684a63be5cb54e) linux/hardened/patches/4.19: 4.19.196-hardened1 -> 4.19.197-hardened1
* [`b7248370`](https://github.com/NixOS/nixpkgs/commit/b724837096d16e1b64f18228e6ab01ca1dc491ce) linux/hardened/patches/5.10: 5.10.48-hardened1 -> 5.10.50-hardened1
* [`e6ed15ff`](https://github.com/NixOS/nixpkgs/commit/e6ed15ffc466e5bfe32c14a207c8e70abee50dd2) linux/hardened/patches/5.12: 5.12.15-hardened1 -> 5.12.17-hardened1
* [`f011a85f`](https://github.com/NixOS/nixpkgs/commit/f011a85f289507bef66b10759de524d0467821eb) linux/hardened/patches/5.4: 5.4.130-hardened1 -> 5.4.132-hardened1
* [`f123928e`](https://github.com/NixOS/nixpkgs/commit/f123928ec1e660132de15f6b5ff6a2902ad225f6) fs-uae-launcher: init at 3.0.5
* [`b3d80503`](https://github.com/NixOS/nixpkgs/commit/b3d80503cfa3e5b8513d47f91ac1a2025e81141c) du-dust: add meta.mainProgram
* [`dbf4e298`](https://github.com/NixOS/nixpkgs/commit/dbf4e2980d120746def13fb0fd334fc7a867756a) pkgs: add maxeaubrey to maintainers
* [`d5bd34eb`](https://github.com/NixOS/nixpkgs/commit/d5bd34ebf2c2c2b380b76cb86bc68522bc6af4d7) treewide: convert phases that contain ":" to dont* = true ([nixos/nixpkgs⁠#130500](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/130500))
* [`5e8e3b02`](https://github.com/NixOS/nixpkgs/commit/5e8e3b02bfeaa5e9811d5de312ead8b97f7d9150) python3Packages.skytemple-files: 1.2.3 -> 1.2.4
* [`e949f1c7`](https://github.com/NixOS/nixpkgs/commit/e949f1c73ce820d640be4a800a1a537d666c80b3) python3Packages.skytemple-ssb-debugger: 1.2.4 -> 1.2.5
* [`3cabedec`](https://github.com/NixOS/nixpkgs/commit/3cabedec11f9100fe126dbe7d9e49f94e7c66af1) skytemple: 1.2.3 -> 1.2.5
* [`5972cc31`](https://github.com/NixOS/nixpkgs/commit/5972cc3119a847ef4d5bf65121c5809c70d66972) vector: 0.14.0 -> 0.15.0
