### PR TITLE
niv home-manager: update 775cb20b -> fa483b82

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "775cb20bd4af7781fbf336fb201df02ee3d544bb",
-        "sha256": "0lnjkli210yrwa39n77n4kvbzplrxw0bljgvrsyskfsmzb4h31xy",
+        "rev": "fa483b82ab35c670de12a022d7c57237c3b31008",
+        "sha256": "0dm07gp5ajl6cp7650406zj3m185qmjzrhywrrl0ammy8blna7ka",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/775cb20bd4af7781fbf336fb201df02ee3d544bb.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/fa483b82ab35c670de12a022d7c57237c3b31008.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@775cb20b...fa483b82](https://github.com/nix-community/home-manager/compare/775cb20bd4af7781fbf336fb201df02ee3d544bb...fa483b82ab35c670de12a022d7c57237c3b31008)

* [`f56a087c`](https://github.com/nix-community/home-manager/commit/f56a087cbc702e1f5e20cb7ae4dded64fac1db52) sway: add propagate --to-code for modes ([nix-community/home-manager⁠#2176](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2176))
* [`c476cc61`](https://github.com/nix-community/home-manager/commit/c476cc61b2dd8c7f868b213b7757b565bdf2bb7d) xsettingsd: add service module
* [`1617e56c`](https://github.com/nix-community/home-manager/commit/1617e56c2feda7e92494f62f083b603768a25cba) firefox: fix tests
* [`5f433eb1`](https://github.com/nix-community/home-manager/commit/5f433eb164832fc507c3e1ba2a798f8c00578316) Move platform check into modules
* [`82b06103`](https://github.com/nix-community/home-manager/commit/82b06103ae3e33eaa8d0806c839131d68d58ddd9) home-manager: add fish completion
* [`41903a14`](https://github.com/nix-community/home-manager/commit/41903a14b03614bc22d9726b854f54e1e1839c9e) Remove a few format exceptions
* [`2b75633b`](https://github.com/nix-community/home-manager/commit/2b75633b2c470e1249d46fe5d9ee848e3f7ab4e7) meta: github: update issue template
* [`d7e08969`](https://github.com/nix-community/home-manager/commit/d7e089699aedb67f79d2fa70bfdc39ea25ad5ea6) syncthing: restrict service slightly
* [`fa483b82`](https://github.com/nix-community/home-manager/commit/fa483b82ab35c670de12a022d7c57237c3b31008) xcape: run xcape after setxkbmap ([nix-community/home-manager⁠#2198](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2198)) ([nix-community/home-manager⁠#2199](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2199))
