### PR TITLE
niv powerlevel10k: update 1e7be00e -> 83d80fa3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "1e7be00e04a6e34bdcc7574297413fd6a48be51f",
-        "sha256": "003iv0vc9bng1aq9azby2q0hysz79wa7r6xvg5bsgal9jj7nzbr2",
+        "rev": "83d80fa308f6f8a496205a1ad5cb2ae4c4be55a6",
+        "sha256": "0nq27dwd77ccj1rc9cr1i7pnssqwf1f5zxhps46w47ki2hidnr1d",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/1e7be00e04a6e34bdcc7574297413fd6a48be51f.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/83d80fa308f6f8a496205a1ad5cb2ae4c4be55a6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@1e7be00e...83d80fa3](https://github.com/romkatv/powerlevel10k/compare/1e7be00e04a6e34bdcc7574297413fd6a48be51f...83d80fa308f6f8a496205a1ad5cb2ae4c4be55a6)

* [`f717a91f`](https://github.com/romkatv/powerlevel10k/commit/f717a91f55f4d5dfb89d8828dc5b36fcc45548c2) * Added new module for showing in prompt the active terraform version.
* [`9f989151`](https://github.com/romkatv/powerlevel10k/commit/9f98915167b35bc045090c106b8249f6dadfaf01) * Added new module for showing in prompt the active terraform version.
* [`dae5f7f1`](https://github.com/romkatv/powerlevel10k/commit/dae5f7f1c9ef5116b046f1f9b31a9bdf2154e76b) * Added cache to terraform --version
* [`2c135dd6`](https://github.com/romkatv/powerlevel10k/commit/2c135dd631019a251e073a0f4e86267cf12c50c0) make terraform_version consistent with other *_version segments ([romkatv/powerlevel10k⁠#1487](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1487))
* [`83d80fa3`](https://github.com/romkatv/powerlevel10k/commit/83d80fa308f6f8a496205a1ad5cb2ae4c4be55a6) don't leak 'state' local parameter
