### PR TITLE
niv spacemacs: update a2ab0a02 -> 4bcd16d6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "a2ab0a023307c2ecd6b5878f8b503f3601f8fe8f",
-        "sha256": "06kbx9kj9d6x61b21yzswwx27ljsnd4qalf9f7bzwcn1b3zlvzj5",
+        "rev": "4bcd16d6a04202d6e7e71d1fed747b179080789d",
+        "sha256": "0m1nar0xwc61rdy67wp30hc292xb7bkd5p8lzwy1qd30sd9ilkqr",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/a2ab0a023307c2ecd6b5878f8b503f3601f8fe8f.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/4bcd16d6a04202d6e7e71d1fed747b179080789d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@a2ab0a02...4bcd16d6](https://github.com/syl20bnr/spacemacs/compare/a2ab0a023307c2ecd6b5878f8b503f3601f8fe8f...4bcd16d6a04202d6e7e71d1fed747b179080789d)

* [`964faf49`](https://github.com/syl20bnr/spacemacs/commit/964faf49b1b627dca4d8ab811eb6220d185fc911) [doc] Start documenting CI
* [`5b3786f5`](https://github.com/syl20bnr/spacemacs/commit/5b3786f520e8c1bbacdae7c31fe79bf8eba3eb96) [bot] "documentation_updates" Wed Jul 14 17:35:44 UTC 2021
* [`ba8074b6`](https://github.com/syl20bnr/spacemacs/commit/ba8074b604f33cfa760e9d476c8f5afa84868eb8) Fix symbol highlight ts counter
* [`28a79cd9`](https://github.com/syl20bnr/spacemacs/commit/28a79cd9600d8c2a96aa92c99a7ca8c5cb48ddea) Keep working on CI docs
* [`24b2ba86`](https://github.com/syl20bnr/spacemacs/commit/24b2ba86f5f70f2c073a793e3808b0888311a91a) [bot] "documentation_updates" Mon Jul 19 00:33:01 UTC 2021
* [`67bb23bc`](https://github.com/syl20bnr/spacemacs/commit/67bb23bc25a2672e71a76edaa2fec0108139d1c3) [docs] More on CI
* [`b7e08eeb`](https://github.com/syl20bnr/spacemacs/commit/b7e08eebcf54a6bc8fdc62ca1ec8311d6ad7e61e) [docs] CI documentation.
* [`4bcd16d6`](https://github.com/syl20bnr/spacemacs/commit/4bcd16d6a04202d6e7e71d1fed747b179080789d) [bot] "documentation_updates" Mon Jul 19 10:05:03 UTC 2021
