### PR TITLE
niv nixpkgs: update 5972cc31 -> e8d42483

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5972cc3119a847ef4d5bf65121c5809c70d66972",
-        "sha256": "1scbj28xj488aaqpkn4s3y1g63xawzn9c1rjvkjsan3c3q6yrc6n",
+        "rev": "e8d424833ebbd90977106ea1c4cafa30ffc2571a",
+        "sha256": "046cvj5jy83l4ns7lrs99cpigzwx2zfd1jaaaf0fzyrhhfmam3jc",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5972cc3119a847ef4d5bf65121c5809c70d66972.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e8d424833ebbd90977106ea1c4cafa30ffc2571a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5972cc31...e8d42483](https://github.com/nixos/nixpkgs/compare/5972cc3119a847ef4d5bf65121c5809c70d66972...e8d424833ebbd90977106ea1c4cafa30ffc2571a)

* [`49853b27`](https://github.com/NixOS/nixpkgs/commit/49853b2757740397bb3ff47b12630cda372c8664) ocamlPackages.irmin*: 2.7.1 -> 2.7.2
* [`8eff4493`](https://github.com/NixOS/nixpkgs/commit/8eff44934a0a370fc4ee92e852cfc01f60009c3b) xournalpp: 1.0.20 → 1.1.0
* [`d67b0386`](https://github.com/NixOS/nixpkgs/commit/d67b0386c3e4e56bcaa785c93f942b2a1500bee7) nnn: 4.1.1 → 4.2
* [`71ec1f87`](https://github.com/NixOS/nixpkgs/commit/71ec1f87a9c149e8c6eefe2add62e60cf69e5897) vimPlugins: update
* [`19458a7a`](https://github.com/NixOS/nixpkgs/commit/19458a7a0156c2cf7718aec83b5504cfb45bd556) vimPlugins.lualine-lsp-progress: init at 2021-07-10
* [`6e557e45`](https://github.com/NixOS/nixpkgs/commit/6e557e45c12ffc829fda6f48af80723cb967013f) goverlay: 0.5.1 → 0.6
* [`8e8f611d`](https://github.com/NixOS/nixpkgs/commit/8e8f611d6f8d13a2f2187d345cecdb97bc9b7ba9) dtc: disable checks for darwin
* [`bc7bddb0`](https://github.com/NixOS/nixpkgs/commit/bc7bddb0dfc43b535551415a1ac038ce0da677fb) snixembed: init at 0.3.1
* [`861f36d8`](https://github.com/NixOS/nixpkgs/commit/861f36d871ce0354b0e26ee02d2fbda54a787062) pythonPackages.fastparquet: 0.6.3 -> 0.7.0
* [`0204024d`](https://github.com/NixOS/nixpkgs/commit/0204024d1b135eee8adf80a9047a13351137b6c1) earthly: 0.5.18 -> 0.5.20
* [`ec037850`](https://github.com/NixOS/nixpkgs/commit/ec03785094c8d114dac9bdfd96922d8892b4d91d) earthly: update license to bsl11
* [`fd828ac4`](https://github.com/NixOS/nixpkgs/commit/fd828ac4f5d413c80f24e927d9608788b47b7603) s9fes: cleanup
* [`16af37bf`](https://github.com/NixOS/nixpkgs/commit/16af37bfca2228c988283c4103492d9617f6b281) pythonPackages.debugpy: 1.3.0 → 1.4.0
* [`3786773d`](https://github.com/NixOS/nixpkgs/commit/3786773dff5a1b2500ca5b13122a87f2097b34f3) pythonPackages.debugpy: 1.4.0 → 1.4.1
* [`7d24d06c`](https://github.com/NixOS/nixpkgs/commit/7d24d06c71d3abd72c25caaea86305aa46d44a08) nixos/postgresql: use postgres 13 for 21.11 ([nixos/nixpkgs⁠#131018](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131018))
* [`5c8561f1`](https://github.com/NixOS/nixpkgs/commit/5c8561f11aac6250d787b35ba71f80ac1ab80a5c) openmodelica: 1.9.3 -> 1.17.0 with lots of changes
* [`b98b88fa`](https://github.com/NixOS/nixpkgs/commit/b98b88fa49b405cfd75bfb95020867b1e0cb3958) drogon: cleanup
* [`3d3b3712`](https://github.com/NixOS/nixpkgs/commit/3d3b37129968e8ac697e893f4627c66b15bddf78) ocamlPackages.ca-certs-nss: 3.64.0.1 -> 3.66
* [`dde2fa86`](https://github.com/NixOS/nixpkgs/commit/dde2fa8611cb03cf311d0f1f4f527f7f0f13529d) josm: 17919 → 18004
* [`1fa65a88`](https://github.com/NixOS/nixpkgs/commit/1fa65a8865c3b6cb326d88b4d395a5fb27934ae2) pdfchain: init at 0.4.4.2
* [`79953c4b`](https://github.com/NixOS/nixpkgs/commit/79953c4bc323ec2cf698a1c73b50dc4827d4dd14) python3Packages.channels: enable  tests
* [`a9d2bdba`](https://github.com/NixOS/nixpkgs/commit/a9d2bdbae3529ab5c2e8cf4aff80fb59f289b26d) aseprite.skia: cleanup, switch to pname + version, add meta
* [`8fff6a92`](https://github.com/NixOS/nixpkgs/commit/8fff6a92d739ded122e595d5a9ff9ffa827b3046) Update pkgs/misc/vscode-extensions/default.nix
* [`4683bca7`](https://github.com/NixOS/nixpkgs/commit/4683bca7df8bfec9bf1292ada5bae062532f57c5) pythonPackages.pylzma: init at 0.5.0
* [`17e77e14`](https://github.com/NixOS/nixpkgs/commit/17e77e142252c67e776cf2869de2cbaa82e23378) python3Packages.flower: 0.9.7 -> 1.0.0
* [`97be046b`](https://github.com/NixOS/nixpkgs/commit/97be046b0e014aafca7edf7e3352d7730a66f7a9) hydrus: Add pylzma as dependency
* [`c8516c8c`](https://github.com/NixOS/nixpkgs/commit/c8516c8ce5bf2992bb1deef514af8292d77528e7) hydrus: correct dependencies, simply external programs
* [`eb07e28d`](https://github.com/NixOS/nixpkgs/commit/eb07e28d0f220021465e1a70253cc70672cca53c) swftools: unmark as broken
* [`46146630`](https://github.com/NixOS/nixpkgs/commit/461466306ef3cef014c8ca4899879a77993b6f7d) octaveFull: set QT_MAC_WANTS_LAYER=1 on Darwin
* [`2b8523fd`](https://github.com/NixOS/nixpkgs/commit/2b8523fd7e4252455e3596b93a990a7ea6f76ef5) portaudio: remove unsupported compiler flag
* [`02258ab8`](https://github.com/NixOS/nixpkgs/commit/02258ab8c1ecfcaf01606e3c24b24318b43ca911) apache-airflow: remove unused input
* [`c2bb089b`](https://github.com/NixOS/nixpkgs/commit/c2bb089b1808db178ed685cc37ec100da1181243) python3Packages.influxdb-client: 1.18.0 -> 1.19.0
* [`621eadca`](https://github.com/NixOS/nixpkgs/commit/621eadcaa61c9bf12b3add8ec40798ffc710ee29) apksigner: init
* [`9adcb3a2`](https://github.com/NixOS/nixpkgs/commit/9adcb3a2ab32d642355340bcf10108c8a3c69d05) apksigcopier: use apksigner
* [`c3778dc4`](https://github.com/NixOS/nixpkgs/commit/c3778dc4d8285b3f01e9efd0a2f5ead6c699a3da) fdroidserver: use apksigner
* [`407c9d44`](https://github.com/NixOS/nixpkgs/commit/407c9d4437751a0f4c74235da4d331dac66d1ecd) diffoscope: use top-level apksigner
* [`2346ec88`](https://github.com/NixOS/nixpkgs/commit/2346ec8883c8bfca53ea7a7a1b0441a4a0562225) fail2ban: 0.11.1 -> 0.11.2
* [`18563876`](https://github.com/NixOS/nixpkgs/commit/1856387636e71d579dfe2a5f67c6220db4e500b3) hikari: 2.3.1 -> 2.3.2, cleanup
* [`24509ea3`](https://github.com/NixOS/nixpkgs/commit/24509ea30344d4624427f6c1116c70a4c3ee0a90) riemann: remove phases
* [`edc01d05`](https://github.com/NixOS/nixpkgs/commit/edc01d05a925369f518b0f3cef6f3689e561011e) lrzsz: add patch for CVE-2018-10195
* [`5a597210`](https://github.com/NixOS/nixpkgs/commit/5a5972100ada9af71612f9bd21167bce5d5e6991) prometheus-jmx-httpserver: deprecate phases
* [`96ea4f52`](https://github.com/NixOS/nixpkgs/commit/96ea4f525250020d623ad941c9166a77a7b6f649) pythonPackages.ignite: ignore failing tests, fix hash
* [`15b29ec3`](https://github.com/NixOS/nixpkgs/commit/15b29ec38ceeaae1a4e13f7a8be2c767937ba2a4) subsonic: remove phases
* [`5939a44a`](https://github.com/NixOS/nixpkgs/commit/5939a44ad0f50eea2e5211915ffed54789599465) jboss: remove phases
* [`2a202658`](https://github.com/NixOS/nixpkgs/commit/2a2026580ffbd13eec8b16b5d30da76c6b449c81) mastodon-update-script: remove phases
* [`0bbc4bcd`](https://github.com/NixOS/nixpkgs/commit/0bbc4bcdba97eb25852bd168808701894129c03b) atlassian-crowd: remove phases
* [`395890ba`](https://github.com/NixOS/nixpkgs/commit/395890ba6a0b07f3d6eae11cb5d99cd20478316d) framac: 23.0 -> 23.1 ([nixos/nixpkgs⁠#131252](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131252))
* [`df9d5f8f`](https://github.com/NixOS/nixpkgs/commit/df9d5f8fe5bacaec418e2489bd34b95d14e64a6e) minecraft-server: deprecate phases
* [`0271807d`](https://github.com/NixOS/nixpkgs/commit/0271807d6fb34509e78ed66a8c972dd851b996cd) btar: fix build with librsync 1.x
* [`7368fa12`](https://github.com/NixOS/nixpkgs/commit/7368fa12c4c6b05027b367293b92b6a8f310d08e) btar: clean up
* [`648aacb6`](https://github.com/NixOS/nixpkgs/commit/648aacb65dc8e4203a52b843652430b3d582dfdb) librsync_0_9: drop
* [`4183793b`](https://github.com/NixOS/nixpkgs/commit/4183793b492eb4fe8a0562c69075529a4e3c1ad8) tcl2048: deprecate phases
* [`5496ed32`](https://github.com/NixOS/nixpkgs/commit/5496ed328af1af672a166a8c409066f490c05117) fail2ban: cleanup
* [`4a7e4dd6`](https://github.com/NixOS/nixpkgs/commit/4a7e4dd6452146f537e008eac32ea796e41f4bd7) scalafix: deprecate phases and use pname&version
* [`6098b5b2`](https://github.com/NixOS/nixpkgs/commit/6098b5b2c80592bee58eb1ef1d47a7393a0c07a0) thrust: remove phases
* [`1c33f2af`](https://github.com/NixOS/nixpkgs/commit/1c33f2afcfd7ae9f9c503ad28ae62cd41f72ec4a) ronn: deprecate phases
* [`38f2a714`](https://github.com/NixOS/nixpkgs/commit/38f2a71410a34da37ae8599e003e192cd0ff80bf) postiats-utilities: remove phases
* [`987902c4`](https://github.com/NixOS/nixpkgs/commit/987902c43446fbcf614193a965d81946b0861aaf) lemon: deprecate phases
* [`f61fe3ec`](https://github.com/NixOS/nixpkgs/commit/f61fe3ec6b3741d95e968ffb2394419bd8ddc598) python3Packages.jc: 1.14.4 -> 1.16.0
* [`0f1204bd`](https://github.com/NixOS/nixpkgs/commit/0f1204bd2be0ca1ea60b70d6d1eb7a11077f6986) Initial implementation of s390 cross-compile
* [`c9ea3151`](https://github.com/NixOS/nixpkgs/commit/c9ea31512ce0e2642827e41ce096f1f05f7edc62) csfml: 2.5 -> 2.5.1
* [`e7ddc0ff`](https://github.com/NixOS/nixpkgs/commit/e7ddc0ff6a34b22777afca389ae28af40964c662) dbmate: 1.12.0 -> 1.12.1
* [`1730d167`](https://github.com/NixOS/nixpkgs/commit/1730d167ec5a997554da787e40f49d4d05ca699a) libcouchbase: 3.1.3 -> 3.1.4
* [`3a284fbd`](https://github.com/NixOS/nixpkgs/commit/3a284fbde0a7abe4e4b05f1aad31df6a66f5e8b8) corehunt: init at 4.2.0
* [`b400b6f9`](https://github.com/NixOS/nixpkgs/commit/b400b6f91d0cc62a29f79e3dd8494cf93a7412ca) iterm2: 3.3.9 -> 3.4.0 ([nixos/nixpkgs⁠#131314](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131314))
* [`a57ca294`](https://github.com/NixOS/nixpkgs/commit/a57ca29433890e526835c8d40594a96caeadeca2) python3Packages.graphviz: 0.16 -> 0.17
* [`ebe051fc`](https://github.com/NixOS/nixpkgs/commit/ebe051fca136c3d2621cf00715576249c5c1fe90) python3Packages.imap-tools: 0.42.0 -> 0.44.0
* [`003d8abd`](https://github.com/NixOS/nixpkgs/commit/003d8abd3016fd7fea2af90a0c85171a6fa21b03) evans: 0.9.3 -> 0.10.0
* [`434508d7`](https://github.com/NixOS/nixpkgs/commit/434508d7016ead992bfe71198e7e44086451af38) python3Packages.asysocks: 0.1.1 -> 0.1.2
* [`c563421f`](https://github.com/NixOS/nixpkgs/commit/c563421ff7ca3f937af5ff2ebfeb0ca681fd61d8) tfsec: 0.51.2 -> 0.51.4
* [`1566e187`](https://github.com/NixOS/nixpkgs/commit/1566e187da34c20b945d70ea626beb2e9d6d3554) androidStudioPackages.{canary,dev}: 2021.1.1.3 -> 2021.1.1.4
* [`65ae9a16`](https://github.com/NixOS/nixpkgs/commit/65ae9a162b1a9399c3f0e24c42184bd776f2dbd9) androidStudioPackages.beta: 2020.3.1.20 -> 2020.3.1.21
* [`6d762622`](https://github.com/NixOS/nixpkgs/commit/6d76262230cafc19f5f12406af5bd29525183d36) blackshades: 1.1.1 -> 1.3.1
* [`c2461f0d`](https://github.com/NixOS/nixpkgs/commit/c2461f0d67efbd642d647e827c8f234f15386fa1) zoom-us: 5.7.26030.0627 -> 5.7.28852.0718
* [`b17d7516`](https://github.com/NixOS/nixpkgs/commit/b17d7516f2b9dcfd22b9e2064167e82d54ae15d7) apache-directory-studio: 2.0.0-M15 -> 2.0.0-M17
* [`327eaa42`](https://github.com/NixOS/nixpkgs/commit/327eaa4292ce7f0b3eedd4ce49869961b04086fa) moarvm: 2021.06 -> 2021.07
* [`100411d5`](https://github.com/NixOS/nixpkgs/commit/100411d53fcc25e7f1ca19375f2ad77a4e06c210) nqp: 2021.06 -> 2021.07
* [`662dbb47`](https://github.com/NixOS/nixpkgs/commit/662dbb477f2a0169357c8a98d5b100230d6ff3f8) rakudo: 2021.06 -> 2021.07
* [`8c72d9ad`](https://github.com/NixOS/nixpkgs/commit/8c72d9ad8df85b33f6a76b5826f44f6ae90f4760) zef: 0.11.5 -> 0.11.9
* [`51d83077`](https://github.com/NixOS/nixpkgs/commit/51d83077ffbca115265b04853e244179713c6518) google-chrome: avoid crash under some situations
* [`463148c5`](https://github.com/NixOS/nixpkgs/commit/463148c57a99b4cc6b46b197ff4fd6a28273e97a) cimg: 2.9.7 -> 2.9.8
* [`b9c9d93e`](https://github.com/NixOS/nixpkgs/commit/b9c9d93e517c7e2457125ccac384127139426ffb) _389-ds-base: 2.0.6 -> 2.0.7
* [`b59fd45b`](https://github.com/NixOS/nixpkgs/commit/b59fd45b12dac8b3326797b5195f20e425d7d2ff) clight: 4.5 -> 4.6
* [`10012bac`](https://github.com/NixOS/nixpkgs/commit/10012bacc60a7116cfe16a2fe4df9fe28751d870) carla: 2.3.0 -> 2.3.1
* [`2e9d0ede`](https://github.com/NixOS/nixpkgs/commit/2e9d0ededcdba4e06ccc26aaf6c40a41228cde15) evolution-data-server: 3.40.2 -> 3.40.3
* [`9d28b44f`](https://github.com/NixOS/nixpkgs/commit/9d28b44f60f254fb0c254ab9447cc6e6b71733c1) bzrtp: 4.5.10 -> 5.0.0
* [`72517fee`](https://github.com/NixOS/nixpkgs/commit/72517fee4dc42a522e3c57863e4be6c0138b82e9) juju: 2.9.5 -> 2.9.7
* [`e050c689`](https://github.com/NixOS/nixpkgs/commit/e050c6890ad49c176e68db086d395b538ff8f5df) hubstaff: 1.5.19-9e79d1da -> 1.6.0-02e625d8
* [`d0834047`](https://github.com/NixOS/nixpkgs/commit/d0834047e99a8d132ee5e5a6c77a91cfa6e96f96) fuzzel: 1.6.0 -> 1.6.1
* [`b08a4740`](https://github.com/NixOS/nixpkgs/commit/b08a47402dea3d8bb8b444a57aa00676d6e8eab8) mackerel-agent: 0.71.2 -> 0.72.1
* [`e84a1189`](https://github.com/NixOS/nixpkgs/commit/e84a1189f509e7a9835a061503d2197a6778f9cc) doppler: 3.25.0 -> 3.26.0
* [`f1561b7f`](https://github.com/NixOS/nixpkgs/commit/f1561b7f4dfa78288ef470724377f94a7e56efe3) glances: 3.2.1 -> 3.2.2
* [`d3483140`](https://github.com/NixOS/nixpkgs/commit/d3483140b2808fe68323b29f432e40fe80d54df6) erlangR23: 23.3.4.4 -> 23.3.4.5
* [`f5e367d9`](https://github.com/NixOS/nixpkgs/commit/f5e367d987791b5060f5cc71923901a29d56cc5a) gnome.gnome-sudoku: 40.1 -> 40.2
* [`7b3c0545`](https://github.com/NixOS/nixpkgs/commit/7b3c0545149cb5c67611945d6022b61047439d61) nixos/tests/chromium: Check the version and that it's an official build
* [`4ec2b246`](https://github.com/NixOS/nixpkgs/commit/4ec2b24603e6eb4a48272678c75d2518de4e2191) nixos/tests/chromium: Drop the workaround for Chrome GPU crashes
* [`f6c5598f`](https://github.com/NixOS/nixpkgs/commit/f6c5598f54ebe442debef526b6baf9fdbeb4d1da) tdesktop: Cleanup/refactor
* [`8ebf75b3`](https://github.com/NixOS/nixpkgs/commit/8ebf75b3c7ab95e42fa080503945dd056332c3ee) build(deps): bump cachix/cachix-action from 9 to 10
* [`10594c9a`](https://github.com/NixOS/nixpkgs/commit/10594c9a96ac5e23f05040ea1e0789d631fdcd1f) Revert "chromiumBeta: Temporarily build on Hydra"
* [`9ac31885`](https://github.com/NixOS/nixpkgs/commit/9ac31885527059cfc150343e576216e712408d1b) chromium: Merge the installPhase command strings
* [`c7d4d354`](https://github.com/NixOS/nixpkgs/commit/c7d4d354edc091bd32294ef18e1ffe1ce012ddc6) markets: init at 0.5.2
* [`05b7d715`](https://github.com/NixOS/nixpkgs/commit/05b7d71544e3a06b51d32e62febc2dab93b95d1b) CODEOWNERS: remove ryantm from /nixos/doc
* [`d0c2a472`](https://github.com/NixOS/nixpkgs/commit/d0c2a472d826372c4cf94f491a7cadb0ac6ba3bc) arb: 2.19.0 -> 2.20.0
* [`4036c82d`](https://github.com/NixOS/nixpkgs/commit/4036c82da82da2c7218e315871690fec19d467ec) flint: 2.7.1 -> 2.8.0
* [`beb353c7`](https://github.com/NixOS/nixpkgs/commit/beb353c7765ad6ea632acccb26f0d63c8c12d06b) imagemagick6: 6.9.12-17 -> 6.9.12-19
* [`8c59a77a`](https://github.com/NixOS/nixpkgs/commit/8c59a77a04339beaced44b293db579c9aaa16aa0) phpPackages.composer: 2.1.3 -> 2.1.5
* [`4cf4f3c4`](https://github.com/NixOS/nixpkgs/commit/4cf4f3c454ed5f6c54afdfdf0cad23f8badabd0d) Revert "ocamlPackages.letsencrypt: 0.2.5 -> 0.3.0"
* [`e7312503`](https://github.com/NixOS/nixpkgs/commit/e731250332709eed4384c1176cc176eb217fc55f) ocamlPackages.tcpip: 6.1.0 -> 6.2.0
* [`f027f8e3`](https://github.com/NixOS/nixpkgs/commit/f027f8e38d926ffc925f4b9a7b1aa09cf2451ebc) ocamlPackages.x509: 0.13.0 -> 0.14.0
* [`2f9cf506`](https://github.com/NixOS/nixpkgs/commit/2f9cf506dd12c86a322ace5ae74b4eafee172cc2) build(deps): bump zeebe-io/backport-action ([nixos/nixpkgs⁠#131466](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131466))
* [`76a1e7c5`](https://github.com/NixOS/nixpkgs/commit/76a1e7c5e3c6568c540969634a73b7e25cb030be) cloud-init: fix build
* [`94ac68c8`](https://github.com/NixOS/nixpkgs/commit/94ac68c879f4b172ade9cd7fabca1b9ed85bcdd1) eduke32: 20200907 -> 20210722
* [`c7452dde`](https://github.com/NixOS/nixpkgs/commit/c7452ddec18aeaf3c9afa48c32733bbf8a50d42b) python3Packages.pyvicare: 1.0.0 -> 1.1
* [`ae13f7cc`](https://github.com/NixOS/nixpkgs/commit/ae13f7ccc5c5c3627d0c87964ac147b4ce5e3ee4) flexget: 3.1.131 -> 3.1.133
* [`6be2cb76`](https://github.com/NixOS/nixpkgs/commit/6be2cb762e9a12e9e1086682cd3f86aa35858207) warzone2100: 4.1.0 -> 4.1.1
* [`11863820`](https://github.com/NixOS/nixpkgs/commit/11863820b2c4e10917e65c6c1f73cd3891ce97be) ic-keysmith: init at 1.6.0
* [`85f3a06c`](https://github.com/NixOS/nixpkgs/commit/85f3a06c9f132fb7344bced48c3e49e28268b19b) quill-qr: init at 0.1.0
* [`351b7d24`](https://github.com/NixOS/nixpkgs/commit/351b7d24e2974169fecf14b1cdc1dde0664819ff) logisim: create desktop entry ([nixos/nixpkgs⁠#131450](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131450))
* [`0834491c`](https://github.com/NixOS/nixpkgs/commit/0834491cb742c7a8b95b90e5754b6e7d01cb55ca) flint: cleanup
* [`5b8a0fae`](https://github.com/NixOS/nixpkgs/commit/5b8a0fae655bff27590bacbcce261ae38754a514) fldigi: format
* [`8dee9de4`](https://github.com/NixOS/nixpkgs/commit/8dee9de4781564940cfa8145c7a0f409041ef646) multimon-ng: fix for darwin ([nixos/nixpkgs⁠#131522](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131522))
* [`5dede290`](https://github.com/NixOS/nixpkgs/commit/5dede290891ed8c44d68fe5a279cdc47bc976916) wrangler: 1.16.1 -> 1.18.0
* [`e8d42483`](https://github.com/NixOS/nixpkgs/commit/e8d424833ebbd90977106ea1c4cafa30ffc2571a) dua: 2.14.2 -> 2.14.3
