### PR TITLE
niv powerlevel10k: update 83d80fa3 -> 8f798f98

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "83d80fa308f6f8a496205a1ad5cb2ae4c4be55a6",
-        "sha256": "0nq27dwd77ccj1rc9cr1i7pnssqwf1f5zxhps46w47ki2hidnr1d",
+        "rev": "8f798f986a02eb27c4ef25229976443fa2a66809",
+        "sha256": "1lv6s39sbm61yq4rn3vai7a4kizgsl7gq6qk90z7m77dhpql6ryg",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/83d80fa308f6f8a496205a1ad5cb2ae4c4be55a6.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/8f798f986a02eb27c4ef25229976443fa2a66809.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@83d80fa3...8f798f98](https://github.com/romkatv/powerlevel10k/compare/83d80fa308f6f8a496205a1ad5cb2ae4c4be55a6...8f798f986a02eb27c4ef25229976443fa2a66809)

* [`70ae5810`](https://github.com/romkatv/powerlevel10k/commit/70ae5810d81f941a93e2077a2aa080f341deb96e) Squashed 'gitstatus/' changes from 0440e38b..1edd9e62
* [`5e1c1cae`](https://github.com/romkatv/powerlevel10k/commit/5e1c1caeb1ac178a3460bf209f56bdf9ced2b9ff) doc: spello
* [`c23f3c3c`](https://github.com/romkatv/powerlevel10k/commit/c23f3c3c1074041a572b32b49820b00797f36ca5) README: Windows Terminal "default"->"defaults" key ([romkatv/powerlevel10k⁠#1499](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1499))
* [`e3c85290`](https://github.com/romkatv/powerlevel10k/commit/e3c8529052bb8c73fdde48a28ed9f6a8b4a4408b) doc: typo
* [`799c22f6`](https://github.com/romkatv/powerlevel10k/commit/799c22f63b93e9d1ab8f01473bf9ebd2e9750f43) Squashed 'gitstatus/' changes from 1edd9e62..845f492f
