### PR TITLE
niv spacemacs: update 4bcd16d6 -> 431dfd5a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "4bcd16d6a04202d6e7e71d1fed747b179080789d",
-        "sha256": "0m1nar0xwc61rdy67wp30hc292xb7bkd5p8lzwy1qd30sd9ilkqr",
+        "rev": "431dfd5ad99df934df290eedfda9257192148c04",
+        "sha256": "14r5hqa3gp6iwh66svx5a6qsmik6blzxw16nlq304q6av9lpadg0",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/4bcd16d6a04202d6e7e71d1fed747b179080789d.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/431dfd5ad99df934df290eedfda9257192148c04.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@4bcd16d6...431dfd5a](https://github.com/syl20bnr/spacemacs/compare/4bcd16d6a04202d6e7e71d1fed747b179080789d...431dfd5ad99df934df290eedfda9257192148c04)

* [`7d156b10`](https://github.com/syl20bnr/spacemacs/commit/7d156b1002ab53c7463916b0d156391fb0863261) [doc] finish documenting CI
* [`77f0124a`](https://github.com/syl20bnr/spacemacs/commit/77f0124a45fd8600435e298e81275418bb84bb49) [doc] Remove TODOs
* [`47f35072`](https://github.com/syl20bnr/spacemacs/commit/47f350726054319d07118ec3c8318523fe24f3a9) [bot] "documentation_updates" Thu Jul 22 06:21:02 UTC 2021
* [`eeb363f6`](https://github.com/syl20bnr/spacemacs/commit/eeb363f6e4f8c0d7895f15ef59aae4a759852538) Add flag to enable org-brain support making it optional
* [`48d1f536`](https://github.com/syl20bnr/spacemacs/commit/48d1f536308974c61c5087f0aa2e97268bac520e) Fix evil-matchit % jump in web mode ([syl20bnr/spacemacs⁠#14940](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14940))
* [`d5dffa98`](https://github.com/syl20bnr/spacemacs/commit/d5dffa988d56fd1372b1333e7f00ada9fa5f55df) [docs] cleanup
* [`d4b50741`](https://github.com/syl20bnr/spacemacs/commit/d4b50741809e50951ab52f13e2f0b68c866f6e82) [docs] fix link issue
* [`6121a580`](https://github.com/syl20bnr/spacemacs/commit/6121a5807bc1387dd02683f4ea4a90623b866b2e) [compleseus] new completion layer consult embark orderless selectrum/vertico
* [`fa514c6a`](https://github.com/syl20bnr/spacemacs/commit/fa514c6ace3279d77090465f2fa0dfe28859e1de) Update changelog
* [`431dfd5a`](https://github.com/syl20bnr/spacemacs/commit/431dfd5ad99df934df290eedfda9257192148c04) [docs] Update completion layer install notes
