### PR TITLE
niv nixpkgs: update e8d42483 -> 2a22c805

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8d424833ebbd90977106ea1c4cafa30ffc2571a",
-        "sha256": "046cvj5jy83l4ns7lrs99cpigzwx2zfd1jaaaf0fzyrhhfmam3jc",
+        "rev": "2a22c805af02ec92b679c52b2c6c0cf8a838f015",
+        "sha256": "029gwcvywcbq12j80y004dyhc9vmsl7n8mkh4whanf60avcqf9gp",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e8d424833ebbd90977106ea1c4cafa30ffc2571a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/2a22c805af02ec92b679c52b2c6c0cf8a838f015.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e8d42483...2a22c805](https://github.com/nixos/nixpkgs/compare/e8d424833ebbd90977106ea1c4cafa30ffc2571a...2a22c805af02ec92b679c52b2c6c0cf8a838f015)

* [`c8ff5bc6`](https://github.com/NixOS/nixpkgs/commit/c8ff5bc6f74a2960fab5ae417cd2bb055eab1002) coqPackages.category-theory: v20210730, for Coq versions 8.10-8.13
* [`f4491a0f`](https://github.com/NixOS/nixpkgs/commit/f4491a0f38b0d8b591c7e35adcf19bc552664a52) archiver: add meta.mainProgram
* [`f5b0f06a`](https://github.com/NixOS/nixpkgs/commit/f5b0f06a5da43e7ff72a4b4a01c13a89fc67912b) yabasic: 2.89.1 -> 2.90.1
* [`95f1154f`](https://github.com/NixOS/nixpkgs/commit/95f1154f993bc788bad7df1feed1b98c7e7381cb) coqPackages.interval: 4.1.1 -> 4.3.0 ([nixos/nixpkgs⁠#131818](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131818))
* [`99cea37c`](https://github.com/NixOS/nixpkgs/commit/99cea37cd52b2ef72e75c220c5378f5f02034584) tfsec: 0.52.1 -> 0.55.0
* [`80956269`](https://github.com/NixOS/nixpkgs/commit/809562692ce929a2014ba35034975a295030211c) python3Packages.praw: 7.3.0 -> 7.4.0
* [`088b985a`](https://github.com/NixOS/nixpkgs/commit/088b985a714d46d7fa09191173450120e42747d7) erlang: 24.0.4 -> 24.0.5
* [`66b3e4a7`](https://github.com/NixOS/nixpkgs/commit/66b3e4a71f2d487b7bdee020e8431d657d835a24) maintainers: add yayayayaka
* [`2cb01075`](https://github.com/NixOS/nixpkgs/commit/2cb0107550a9c40664cf423931ff8adeb3b1000f) arch-install-scripts: init at 24
* [`cf3dcef3`](https://github.com/NixOS/nixpkgs/commit/cf3dcef38b69f7c02847ab35b38b03be4a81010e) cargo-release: 0.16.0 -> 0.16.2
* [`d55bba14`](https://github.com/NixOS/nixpkgs/commit/d55bba14daa28dc4df9014a1f2774cab998b82a4) wrangler: 1.18.0 -> 1.19.0
* [`e721776c`](https://github.com/NixOS/nixpkgs/commit/e721776cbbaeedf7d7da434fba5845f2d81685b4) Revert "notmuch: skip T568-lib-thread"
* [`3b3ef3b8`](https://github.com/NixOS/nixpkgs/commit/3b3ef3b8653eaddeb4e61fad0e4880dbd921894f) bibletime: 3.0 -> 3.0.1
* [`15eec211`](https://github.com/NixOS/nixpkgs/commit/15eec2111fc06cca2b0abd7b3de1b6922fabf21e) notmuch: 0.32.1 -> 0.32.2; clarify license
* [`c5b20238`](https://github.com/NixOS/nixpkgs/commit/c5b20238a32a4de07a787a138dff31fa315452b3) cargo-watch: 7.8.1 -> 8.0.0
* [`7d0285d1`](https://github.com/NixOS/nixpkgs/commit/7d0285d139bac124364e59687771cf523d01329c) crawl: 0.26.1 -> 0.27.0
* [`6eef84d6`](https://github.com/NixOS/nixpkgs/commit/6eef84d697b1e07c85892241e53c746a9ecc6bf5) mu: 1.6.0 -> 1.6.1
* [`682442d0`](https://github.com/NixOS/nixpkgs/commit/682442d027e2d00085f71e46cf7e78322598d301) tdesktop: 2.8.11 -> 2.9.0 ([nixos/nixpkgs⁠#132195](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/132195))
* [`a2e60292`](https://github.com/NixOS/nixpkgs/commit/a2e6029290a87bdfdca4c1f0af6a267263e09c5b) docker-buildx: 0.6.0 -> 0.6.1
* [`ce28b01e`](https://github.com/NixOS/nixpkgs/commit/ce28b01ea34c346d697348b6082c90c0b9613ede) maintainers/haskell/package-list: Only read one line from password-cmd
* [`3209d25f`](https://github.com/NixOS/nixpkgs/commit/3209d25fd2355dbb68bf231ee1c1b3b442d42e86) viber: add 'QML2_IMPORT_PATH' to the wrap
* [`75524662`](https://github.com/NixOS/nixpkgs/commit/75524662af31ac0f513edafddcba8d32f6ccfb98) hugo: 0.86.0 -> 0.86.1
* [`501ec4cf`](https://github.com/NixOS/nixpkgs/commit/501ec4cf5d9eb49ded40fe05ec33ad01f6fcffc1) hydroxide: 0.2.19 -> 0.2.20
* [`45547332`](https://github.com/NixOS/nixpkgs/commit/45547332afaa948ec9a47ced6f393762779dcd2d) python3Packages.pytesseract: 0.3.7 -> 0.3.8
* [`2bace832`](https://github.com/NixOS/nixpkgs/commit/2bace832c4fc2b28215fd10b4664e9ba536c56d1) buildbot: 3.2.0 -> 3.3.0
* [`293ff939`](https://github.com/NixOS/nixpkgs/commit/293ff939461b5b7fd0eca0d057645d4db4acbe12) keycloak: 14.0.0 -> 15.0.0
* [`9b0a99f6`](https://github.com/NixOS/nixpkgs/commit/9b0a99f64c9e61b6176238d9c3eabdcfa61723db) nixos-rebuild: print run-*-vm location with bootloader ([nixos/nixpkgs⁠#130385](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/130385))
* [`256af6b7`](https://github.com/NixOS/nixpkgs/commit/256af6b7422e99e7dba850718c0618905375c617) nixos/tt-rss: fix eval
* [`e17c7def`](https://github.com/NixOS/nixpkgs/commit/e17c7def698a6efede9fc09e7d6f70e4c467f25c) diffoscope: fix build, 178 -> 179
* [`b826d722`](https://github.com/NixOS/nixpkgs/commit/b826d7228a3102903fb9baec353b514114c5246c) python3Packages.pysma: 0.6.4 -> 0.6.5
* [`738f92f2`](https://github.com/NixOS/nixpkgs/commit/738f92f2baf8652c5c81d43067acba801c6ee89b) epson-escpr2: 1.1.34 -> 1.1.38
* [`2f949916`](https://github.com/NixOS/nixpkgs/commit/2f94991628ea21ff82227c79aac8a57582c9576d) treewide: fix redirected URLs
* [`cbcee79d`](https://github.com/NixOS/nixpkgs/commit/cbcee79dad077676c1521a39995eacd3f83f58d4) kazam: switch to a maintained fork
* [`8921779f`](https://github.com/NixOS/nixpkgs/commit/8921779f0af1422ea1d7cf23d47f8d688b21d193) mtools: 4.0.33 -> 4.0.34
* [`01c5b018`](https://github.com/NixOS/nixpkgs/commit/01c5b01858ff6870ec138c5fefdfaa13e9f6725e) udocker: 1.1.3 -> 1.3.1 and make usable
* [`d0556404`](https://github.com/NixOS/nixpkgs/commit/d0556404f6d437aab5527e05854b119b5f14c61d) pony-corral: 0.5.1 -> 0.5.3
* [`598266b3`](https://github.com/NixOS/nixpkgs/commit/598266b34c7c6cccd26f8c65c16d9397932153d7) calibre: 5.17.0 -> 5.24.0
* [`6dac1b7a`](https://github.com/NixOS/nixpkgs/commit/6dac1b7a09564d1d362c8fc9cfed0a6264e85a72) coqPackages.VST: build and install more modules from floyd/
* [`10cd1a54`](https://github.com/NixOS/nixpkgs/commit/10cd1a5497a906f951591a3bfa0a56649ecf9ed9) python3Packages.sentry-sdk: 1.3.0 -> 1.3.1
* [`47177fcf`](https://github.com/NixOS/nixpkgs/commit/47177fcf4eb86928e69bf3cfd1890f97f405edf0) python3Packages.pg8000: 1.20.0 -> 1.21.0
* [`e5cf1f11`](https://github.com/NixOS/nixpkgs/commit/e5cf1f11c21c3cc31521021fa069dc169b51f919) python3Packages.phonenumbers: 8.12.26 -> 8.12.28
* [`6e9195f6`](https://github.com/NixOS/nixpkgs/commit/6e9195f6687d05d4225521a34d1702dd9c0a4444) linux_zen: 5.13.5 -> 5.13.7
* [`a895c83b`](https://github.com/NixOS/nixpkgs/commit/a895c83b03ec053665f82599e97e35411b7c62f9) python3Packages.pipdate: 0.5.2 -> 0.5.5
* [`ab21b704`](https://github.com/NixOS/nixpkgs/commit/ab21b704130458c4fc5e5e840cf1e7ac2094f93e) python3Packages.plexapi: 4.6.1 -> 4.7.0
* [`eb6202d5`](https://github.com/NixOS/nixpkgs/commit/eb6202d5e7ea1ec3f761cadc61f9dbfa24aeb6b1) python3Packages.neo: 0.9.0 -> 0.10.0
* [`604d0dd0`](https://github.com/NixOS/nixpkgs/commit/604d0dd0d68daf696a9ba5494b63500e9db36874) linux_zen: actually enable patchset
* [`f85d58f9`](https://github.com/NixOS/nixpkgs/commit/f85d58f97845131e9959f5915bd9ec3ecdd0a743) python3Packages.nbxmpp: 2.0.2 -> 2.0.3
* [`83d432ea`](https://github.com/NixOS/nixpkgs/commit/83d432ea5aac1bc5a9a8bd2778b3abb093da139d) python3Packages.nbxmpp: enable tests
* [`5ba63366`](https://github.com/NixOS/nixpkgs/commit/5ba6336647cb7d015a2463df1dd822a06518fa4b) rst2html5: 1.10.6 -> 2.0
* [`a7dbb322`](https://github.com/NixOS/nixpkgs/commit/a7dbb32253ed33b1c8fba5eb0ad10025cbe3f7f8) findutils: remove upstreamed patch
* [`ce2d6c8e`](https://github.com/NixOS/nixpkgs/commit/ce2d6c8e978a686435acdba4929b8c34e99989e6) zchunk: 1.1.11 -> 1.1.16
* [`e8b00e9e`](https://github.com/NixOS/nixpkgs/commit/e8b00e9eebf7d6138a767107758920bb98b47a22) mavproxy: 1.8.39 -> 1.8.40
* [`c9e991bd`](https://github.com/NixOS/nixpkgs/commit/c9e991bd649c231e673bef17dd8820b71fb90f64) mpvScripts.simple-mpv-webui: 1.0.0 -> 2.1.0
* [`71394c34`](https://github.com/NixOS/nixpkgs/commit/71394c34478e5e53a8839980481e3eaea39254cd) erlang-ls: skip tests on darwin
* [`bf3fd5a7`](https://github.com/NixOS/nixpkgs/commit/bf3fd5a7db0af881356e2433ef3dce82619329f4) gensio: 2.2.7 -> 2.2.8
* [`da663a95`](https://github.com/NixOS/nixpkgs/commit/da663a953bb3345288acc0f890173ae3e5b34880) ghostunnel: 1.5.3 -> 1.6.0
* [`9a6d7eab`](https://github.com/NixOS/nixpkgs/commit/9a6d7eab73b9642eaea666e04bd9c18460511c40) ghostunnel: Add passthru.tests.podman
* [`2730f105`](https://github.com/NixOS/nixpkgs/commit/2730f105acd2aa4f866b45e33caf4c619558ef7d) arcan: 0.6.1pre1+unstable=2021-07-10 -> 0.6.1pre1+unstable=2021-07-30
* [`bf0cd1ce`](https://github.com/NixOS/nixpkgs/commit/bf0cd1ce16321de4823ede4fd7e6ac4c03a74d82) libcanberra/libcanberra-gtk2: fix build on darwin
* [`db915d4c`](https://github.com/NixOS/nixpkgs/commit/db915d4cca276cddb5957bc97a4072a6e25a5d72) yambar: 1.6.1 -> 1.6.2
* [`72d43569`](https://github.com/NixOS/nixpkgs/commit/72d43569121a8e3053e717a20dabb1ec550b40d0) enlightenment: add wayland support
* [`75b4fccf`](https://github.com/NixOS/nixpkgs/commit/75b4fccfa4dde18a2761f5e3eb2b7a19baa32faf) ecl: make sure boehmgc is available to gcc/linker
* [`d4d9dd61`](https://github.com/NixOS/nixpkgs/commit/d4d9dd61a192f98f88d86f62d3b5484fec0f2e17) dwarf-fortress-packages.twbt: Fix twbt version to match tfhack version.
* [`4f0545c3`](https://github.com/NixOS/nixpkgs/commit/4f0545c3d44ca09cbaa6295e17370abfadbf2d56) vial: 0.4 -> 0.4.1
* [`092851dd`](https://github.com/NixOS/nixpkgs/commit/092851ddeb92a08d674c03af7078ca14beec4240) vial: gpl2Only -> gpl2Plus
* [`ad5c19a7`](https://github.com/NixOS/nixpkgs/commit/ad5c19a72808ef82b9299f1b516fdc6e22b0d277) zulip: 5.8.0 → 5.8.1
* [`6395aaba`](https://github.com/NixOS/nixpkgs/commit/6395aaba171b8be4d0c67f6e843051b834ccf0f0) darwin.apple_sdk.frameworks.AVFoundation: Add missing dependencies
* [`9ab9a811`](https://github.com/NixOS/nixpkgs/commit/9ab9a8118c821ec22ce36eb26a4f69814c4a5d0a) libgme: fix build on apple silicon
* [`6decab67`](https://github.com/NixOS/nixpkgs/commit/6decab67c64131058021370653286d3e99e774bd) stella: 6.5.2 -> 6.5.3
* [`bbf384f4`](https://github.com/NixOS/nixpkgs/commit/bbf384f4cd71bf3646e7058719436c0996761e16) tcsh: 6.22.03 -> 6.22.04
* [`556fd077`](https://github.com/NixOS/nixpkgs/commit/556fd07764fcdd5320c1c173c0275e64c16c6226) qmplay2: 20.12.16 -> 21.06.07
* [`35a3cbc7`](https://github.com/NixOS/nixpkgs/commit/35a3cbc754eb21cae5eb5f96d6e9ef0cc983d856) openmsx: 16.0 -> 17.0
* [`b12ba366`](https://github.com/NixOS/nixpkgs/commit/b12ba3668482b49bb275dad733da30becafbd9ff) mgba: 0.9.0 -> 0.9.2
* [`1437fd4a`](https://github.com/NixOS/nixpkgs/commit/1437fd4a855f19f2b9686f9864bd22e356c02171) dialog: 1.3-20210324 -> 1.3-20210621
* [`555c3afa`](https://github.com/NixOS/nixpkgs/commit/555c3afaf2b17af6ad06ae82b545ca06e252bcd1) chromium: Restructure gnFlags
* [`6e4c660f`](https://github.com/NixOS/nixpkgs/commit/6e4c660f49644bd2860b5149a2bb52f36d526712) eksctl: 0.58.0 -> 0.59.0
* [`7c312a6c`](https://github.com/NixOS/nixpkgs/commit/7c312a6cf9be35d7bde0e0c92fa21e4658f7e030) tahoe-lafs: 1.13.0 -> 2021-07-09
* [`a5d97564`](https://github.com/NixOS/nixpkgs/commit/a5d975648da42e79dc4da422939d0fc588b23765) python3Packages.dufte: 0.2.12 -> 0.2.27
* [`5b683507`](https://github.com/NixOS/nixpkgs/commit/5b683507ec4be2d17540df047614b5fa692ee24e) python3Packages.perfplot: 0.9.5 -> 0.9.6
* [`85a09cf3`](https://github.com/NixOS/nixpkgs/commit/85a09cf3a3edbdef5cd71856d424b3ce16b5978a) pulseaudio: fix build on aarch64-darwin
* [`bc3416a2`](https://github.com/NixOS/nixpkgs/commit/bc3416a2dddd3c7a2a3182373c392292ed8e22b6) squashfsTools: patch a channel-blocking bug
* [`2808286a`](https://github.com/NixOS/nixpkgs/commit/2808286add3e873db6e16e01b7062d3811d61afb) squashfsTools: add NixOS cdrom boot as passthru test
* [`abdd33ed`](https://github.com/NixOS/nixpkgs/commit/abdd33edea66b9668c3b2d941d3cda2f6cb40730) python3Packages.pyfma: fix build
* [`976fbe0f`](https://github.com/NixOS/nixpkgs/commit/976fbe0f1354485c326fbb85632eaa017f385299) python3Packages.dipy: 1.3.0 -> 1.4.1
* [`1005c971`](https://github.com/NixOS/nixpkgs/commit/1005c971f5198f050d7be5a7c270fe6b869f2efe) gdu: 5.3.0 -> 5.5.0
* [`63764584`](https://github.com/NixOS/nixpkgs/commit/6376458424433ced446cbb9045641cb23c9b832d) sane: Add support for the unfree Fujitsu ScanSnap drivers
* [`12bbb0fd`](https://github.com/NixOS/nixpkgs/commit/12bbb0fd7bd2d88ee232cf505b917f3873be0f4f) nixos/syncthing: fix curl not retrying on network errors
* [`ac793548`](https://github.com/NixOS/nixpkgs/commit/ac7935480a8b786d267b20e5b84fdee842c954d0) broot: add dywedir to maintainers
* [`cd3cb8a9`](https://github.com/NixOS/nixpkgs/commit/cd3cb8a9e40b366462cb2edd86410b9aee18f1aa) broot: 1.6.0 -> 1.6.2
* [`173a37e7`](https://github.com/NixOS/nixpkgs/commit/173a37e7b5bb79566ca91876820235a88acea03d) lib.systems.doubles: re-sort
* [`3669b12f`](https://github.com/NixOS/nixpkgs/commit/3669b12f35aa4cce673191e061349e70bb3d4ddd) lib.systems: add m68k-netbsd support
* [`88a326a9`](https://github.com/NixOS/nixpkgs/commit/88a326a9268b66c7182c669ad5066b2d10b6ead3) tt-rss-plugin-auth-ldap: fix compat with latest tt-rss
* [`2682531c`](https://github.com/NixOS/nixpkgs/commit/2682531c67cefc5110adfa546bfdc66e6374e91f) chromium: Drop two gn overrides that are not required anymore
* [`0307a8af`](https://github.com/NixOS/nixpkgs/commit/0307a8af6ce903e217377d053d1157f816aa06fe) pkgs/top-level/release.nix: build pkgsLLVM.stdenv as part of trunk
* [`9fc2cddf`](https://github.com/NixOS/nixpkgs/commit/9fc2cddf24ad1819f17174cbae47789294ea6dc4) 1password: 1.9.1 -> 1.11.2 ([nixos/nixpkgs⁠#131497](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131497))
* [`f22a7ae1`](https://github.com/NixOS/nixpkgs/commit/f22a7ae1a8efe6c322de04b86adcf0b6c5ea5646) soapui: 5.5.0 -> 5.6.0 ([nixos/nixpkgs⁠#131307](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131307))
* [`2c79ed45`](https://github.com/NixOS/nixpkgs/commit/2c79ed45859a07565a49212a262bfd1f29e1546d) vimPlugins.onedark-nvim: Add lush-nvim dependency ([nixos/nixpkgs⁠#131987](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131987))
* [`b5fab536`](https://github.com/NixOS/nixpkgs/commit/b5fab53628e8f080bae24ea1396f72d9d21e1f9b) nixos/virtualbox-image: cast baseImageFreeSpace into str
* [`ecae25c3`](https://github.com/NixOS/nixpkgs/commit/ecae25c3ef137d972e909eb0e85960d90481789e) nixos/nix-daemon: fix registry flake type
* [`6dd36f95`](https://github.com/NixOS/nixpkgs/commit/6dd36f95f22836d6f5a1eb0b286a14f433413e2f) linux_xanmod: 5.13.6 -> 5.13.7
* [`6ef24596`](https://github.com/NixOS/nixpkgs/commit/6ef245969667210bac50e214f79a0cb84f825341) rdma-core: 35.0 -> 36.0
* [`5a7d7dc1`](https://github.com/NixOS/nixpkgs/commit/5a7d7dc19f774e66f83c7e214007107c7d89da2d) nixos/display-managers: update set-session for new "SessionType" property
