### PR TITLE
niv home-manager: update f6f6990f -> 7f976da0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f6f6990fc811454cb3082ba3662b711488fd0554",
-        "sha256": "04dycwy18f1d2x8n3blpq7f3yl006naqpy4mkmwbgzifj86ajsc7",
+        "rev": "7f976da06840c268cc291a021bab7532b923713c",
+        "sha256": "06ip8hxjm8mvwrjzrsp9l8zzj74rr2sy6x009pfyz5w6030axdpr",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f6f6990fc811454cb3082ba3662b711488fd0554.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/7f976da06840c268cc291a021bab7532b923713c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f6f6990f...7f976da0](https://github.com/nix-community/home-manager/compare/f6f6990fc811454cb3082ba3662b711488fd0554...7f976da06840c268cc291a021bab7532b923713c)

* [`47ad3655`](https://github.com/nix-community/home-manager/commit/47ad3655ec804ce250f391567ea57e7eb1bbbdf7) programs.neovim: expose generatedConfigViml ([nix-community/home-manager⁠#2213](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2213))
* [`ae8cb242`](https://github.com/nix-community/home-manager/commit/ae8cb242f2e450c525274732af58b3050399f5bd) home-environment: use `declare -gr` in activation init
* [`e08c6965`](https://github.com/nix-community/home-manager/commit/e08c696524dcbd761a42160f3f288ee620527f66) volnoti: fix package option namespace ([nix-community/home-manager⁠#2227](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2227))
* [`2272fc31`](https://github.com/nix-community/home-manager/commit/2272fc312d5dc477e70816d94e550d08729b307b) doc: darwin: need to specify a system user ([nix-community/home-manager⁠#2220](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2220))
* [`5f6364fc`](https://github.com/nix-community/home-manager/commit/5f6364fc28065d6b26423512e14207ce0bffb27a) home-manager: add `--no-out-link` command line option
* [`7c19bcb8`](https://github.com/nix-community/home-manager/commit/7c19bcb822a351cbcdda245710a6e17d296f0647) nixos: remove indirection via activate-${username}
* [`7f976da0`](https://github.com/nix-community/home-manager/commit/7f976da06840c268cc291a021bab7532b923713c) files: ignore conflict when files are identical
