### PR TITLE
niv spacemacs: update 431dfd5a -> 40ae5e22

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "431dfd5ad99df934df290eedfda9257192148c04",
-        "sha256": "14r5hqa3gp6iwh66svx5a6qsmik6blzxw16nlq304q6av9lpadg0",
+        "rev": "40ae5e2293c6edb5aed1c554ec6b825f24db45d8",
+        "sha256": "1ki4h1ygzqv95fvck8dmbw7vlkvxzs0qxp0hgfz0d0gcjpx95mdm",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/431dfd5ad99df934df290eedfda9257192148c04.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/40ae5e2293c6edb5aed1c554ec6b825f24db45d8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@431dfd5a...40ae5e22](https://github.com/syl20bnr/spacemacs/compare/431dfd5ad99df934df290eedfda9257192148c04...40ae5e2293c6edb5aed1c554ec6b825f24db45d8)

* [`44affc4d`](https://github.com/syl20bnr/spacemacs/commit/44affc4d2b9ec654bb67909e7de58f4eede73b89) Rename commands for org-roam v2 compatibility
* [`3b8bb7f5`](https://github.com/syl20bnr/spacemacs/commit/3b8bb7f5b7305a04438d609036461f3ddbe1e6cd) [docs] Update org-roam key bindings
* [`99e74fbd`](https://github.com/syl20bnr/spacemacs/commit/99e74fbd0ec0d6a000bf24cc7f162304d09e55a9) Fix typos in .spacemacs.template
* [`5cadadc3`](https://github.com/syl20bnr/spacemacs/commit/5cadadc3eac25aaf6fda623dc1efbf2ad48b6b99) [bot] "built_in_updates" Wed Jul 28 13:12:20 UTC 2021
* [`81eb8260`](https://github.com/syl20bnr/spacemacs/commit/81eb82603c091ebd2432832f780a7ec314e3cae8) [bot] "documentation_updates" Wed Jul 28 13:13:07 UTC 2021
* [`c5248ac4`](https://github.com/syl20bnr/spacemacs/commit/c5248ac4653276080d4005f6d406a02f67f2b534) fix issue [syl20bnr/spacemacs⁠#14919](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14919) (force-init-spacemacs-env fails)
* [`579edd5d`](https://github.com/syl20bnr/spacemacs/commit/579edd5debb1f03eac61f59e405237d012047da4) fixed a small typo in the ivy docu
* [`ee2fc1ef`](https://github.com/syl20bnr/spacemacs/commit/ee2fc1efc044194f70268acfe8c6c2f16e2edfcc) plantuml layer supports .puml extension
* [`dce3f1d7`](https://github.com/syl20bnr/spacemacs/commit/dce3f1d7225f7f56c0de5f47f909cb0b5adcbbfc) [ivy] add open in other window for ivy-xref
* [`15ec5c57`](https://github.com/syl20bnr/spacemacs/commit/15ec5c57e9edb71b440563f9df39ca865860380c) Evilify image-dired-thumbnail/display-image-mode-(map)s
* [`295e4271`](https://github.com/syl20bnr/spacemacs/commit/295e4271efc2e597fa153e07da13f3d2fdbb77ba) Fix wrong buffer name after file rename
* [`b2a18301`](https://github.com/syl20bnr/spacemacs/commit/b2a18301faf7944aa8976082dd826d388da08936) [defaults] Disable line numbers with `SPC t n n`
* [`65121ddd`](https://github.com/syl20bnr/spacemacs/commit/65121ddd307b689027e2122832d762334657f1c9) Improve spacemacs/default-pop-shell docstring
* [`236eb943`](https://github.com/syl20bnr/spacemacs/commit/236eb94320748e6232317c1bd10a92c35008966d) Fix google-translate functionality
* [`168e68e2`](https://github.com/syl20bnr/spacemacs/commit/168e68e2d5513803b544fbdba147bb1a1a0595a6) [bot] "documentation_updates" Sat Jul 31 14:26:32 UTC 2021
* [`ac1087ea`](https://github.com/syl20bnr/spacemacs/commit/ac1087ea4e3479980ffa0531f25fafb77868b53e) [ci] refactoring
* [`e2aff2c9`](https://github.com/syl20bnr/spacemacs/commit/e2aff2c915bd28663bacd122c457cd5e01148345) use new breakpoint() for more Python versions
* [`50f4fe18`](https://github.com/syl20bnr/spacemacs/commit/50f4fe183f5b9b71081a797f0f7955fa335e54e7) [compleseus] add consult-line-multi
* [`7b5b69fd`](https://github.com/syl20bnr/spacemacs/commit/7b5b69fda5c889cb2edf732e2d93cffd03bbdb98) [compleseus] Fix indentation
* [`cc8f3a3a`](https://github.com/syl20bnr/spacemacs/commit/cc8f3a3a32377c90533b9f5ef0b2cc5e98641122) Add python-send-shell-with-output command
* [`9e361eed`](https://github.com/syl20bnr/spacemacs/commit/9e361eedc204d62e1a0a9ec9a68a18ff9ffcc550) [shell-scripts] Add shell-scripts-format-on-save
* [`0f71054d`](https://github.com/syl20bnr/spacemacs/commit/0f71054dcce0025d815c72166cfa8088b9767d49) [shell-scripts] Add format-on-save docs to README.org
* [`40ae5e22`](https://github.com/syl20bnr/spacemacs/commit/40ae5e2293c6edb5aed1c554ec6b825f24db45d8) Add bindings for scrolling the message pane in tree-view
