### PR TITLE
niv zsh-history-substring-search: update 0f80b8eb -> 4abed97b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -168,10 +168,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-history-substring-search",
-        "rev": "0f80b8eb3368b46e5e573c1d91ae69eb095db3fb",
-        "sha256": "0y8va5kc2ram38hbk2cibkk64ffrabfv1sh4xm7pjspsba9n5p1y",
+        "rev": "4abed97b6e67eb5590b39bcd59080aa23192f25d",
+        "sha256": "0s8xdddb6zppc5lj28w44nl4n45wg9ic8x3b5pm1139cv038yj7j",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/0f80b8eb3368b46e5e573c1d91ae69eb095db3fb.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/4abed97b6e67eb5590b39bcd59080aa23192f25d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for zsh-history-substring-search:
Branch: master
Commits: [zsh-users/zsh-history-substring-search@0f80b8eb...4abed97b](https://github.com/zsh-users/zsh-history-substring-search/compare/0f80b8eb3368b46e5e573c1d91ae69eb095db3fb...4abed97b6e67eb5590b39bcd59080aa23192f25d)

* [`3f8e85f3`](https://github.com/zsh-users/zsh-history-substring-search/commit/3f8e85f3f8d676f2156849755b29a24cc82ac28a) Support anchoring the substring to search for
* [`f48193bc`](https://github.com/zsh-users/zsh-history-substring-search/commit/f48193bcd9d7bb4845c1502be5edbdc214f8c2e4) Declare HISTORY_SUBSTRING_SEARCH_ANCHORED global
* [`56dc8c2e`](https://github.com/zsh-users/zsh-history-substring-search/commit/56dc8c2ec4a7492706b4b3b19e4cd44240501c4b) Update README.md
* [`4f2f17cc`](https://github.com/zsh-users/zsh-history-substring-search/commit/4f2f17cc46f21924cad9f3ca5019d7909c94d066) add HISTORY_SUBSTRING_SEARCH_PREFIX ([zsh-users/zsh-history-substring-search⁠#112](http://r.duckduckgo.com/l/?uddg=https://github.com/zsh-users/zsh-history-substring-search/issues/112),[zsh-users/zsh-history-substring-search⁠#115](http://r.duckduckgo.com/l/?uddg=https://github.com/zsh-users/zsh-history-substring-search/issues/115))
* [`4ee70abb`](https://github.com/zsh-users/zsh-history-substring-search/commit/4ee70abb6f96012bd561c93b75fe764229e24734) Don't overwrite config with default values
