### PR TITLE
niv nixpkgs: update 2a22c805 -> 39ef6795

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2a22c805af02ec92b679c52b2c6c0cf8a838f015",
-        "sha256": "029gwcvywcbq12j80y004dyhc9vmsl7n8mkh4whanf60avcqf9gp",
+        "rev": "39ef6795e63674b51330e547d34c69ba42048fa4",
+        "sha256": "1papbf9r2zd072ckmq4494gpsasljq503fv9wrfbq0nn9fikbjwy",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/2a22c805af02ec92b679c52b2c6c0cf8a838f015.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/39ef6795e63674b51330e547d34c69ba42048fa4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@2a22c805...39ef6795](https://github.com/nixos/nixpkgs/compare/2a22c805af02ec92b679c52b2c6c0cf8a838f015...39ef6795e63674b51330e547d34c69ba42048fa4)

* [`1531e34b`](https://github.com/NixOS/nixpkgs/commit/1531e34bdfd607b7e2f7d990cd5be8c3d2461a3f) fuzzel: refactor dependencies
* [`609eb35c`](https://github.com/NixOS/nixpkgs/commit/609eb35c3264fed87474af4b1034f1347d8f57e7) fuzzel: add polykernel to maintainers list
* [`107b43ae`](https://github.com/NixOS/nixpkgs/commit/107b43ae9688360dcfeb3dd28b98fc55e8bdf9ba) yder: format, cleanup
* [`42b315fa`](https://github.com/NixOS/nixpkgs/commit/42b315fa7931f141bcc2885e535dcc76784dd27d) grafana-loki: 2.2.1 -> 2.3.0 ([nixos/nixpkgs⁠#133011](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133011))
* [`82076fcd`](https://github.com/NixOS/nixpkgs/commit/82076fcde4f878e74a6a9e341526c9f796dee522) yambar: refactor derivation and split backends as separate packages
* [`99d8d553`](https://github.com/NixOS/nixpkgs/commit/99d8d553da44fb065f9cb8bb54e2e93b85417fab) nixos/gitea: init/migrate db in startup script
* [`0f70b1bc`](https://github.com/NixOS/nixpkgs/commit/0f70b1bc9e51f00c6e2e8b56f6b1cfda53f80ae3) vscode-extensions.matklad.rust-analyzer: nixpkgs-fmt
* [`bc520477`](https://github.com/NixOS/nixpkgs/commit/bc520477f49c0a5a7ba6014a7126da05dbcb2fef) yambar: document breaking changes
* [`a687f1ae`](https://github.com/NixOS/nixpkgs/commit/a687f1aef482c602da86f84133465d2b4e07e60b) vscode-extensions.matklad.rust-analyzer: fix server path
* [`826e592c`](https://github.com/NixOS/nixpkgs/commit/826e592c2c1f57c974f76b285bff43cd7c48cc67) flow: cleanup, format
* [`240cf37b`](https://github.com/NixOS/nixpkgs/commit/240cf37b505554ba7466993b7b11682ad2dcec74) python39Packages.awslambdaric: move depedency patching to right phase
* [`90832a03`](https://github.com/NixOS/nixpkgs/commit/90832a038710a2d925626a4f5230f5ccbead89c5) python39Packages.xml-marshaller: add pythonImportsCheck
* [`23615cdd`](https://github.com/NixOS/nixpkgs/commit/23615cdd9e1a794f7824a925e493be951da3ca85) python3Packages.threadpoolctl: 2.1.0 -> 2.2.0
* [`90fcd8e7`](https://github.com/NixOS/nixpkgs/commit/90fcd8e7a948601a7a9c9d5b752aa40bfb5fbec1) vistafonts-cht: init
* [`3a3f8263`](https://github.com/NixOS/nixpkgs/commit/3a3f82631fa60bece8a7d499eee29e522c770fd8) kmsxx: 2020-08-04 -> 2021-07-26 unbreak
* [`0429b202`](https://github.com/NixOS/nixpkgs/commit/0429b202a32022f1626b08f00aaca9d3c31c03a6) python3Packages.ignite: 0.4.5 -> 0.4.6
* [`79031751`](https://github.com/NixOS/nixpkgs/commit/79031751b9586a9b74c773d06148f82904a45c57) python3Packages.pynvml: 8.0.4 -> 11.0.0
* [`3015c82e`](https://github.com/NixOS/nixpkgs/commit/3015c82ecad73712579db990c2878980db72b1dd) etcher: fix desktop file
* [`9ec3ed91`](https://github.com/NixOS/nixpkgs/commit/9ec3ed91b88835db42d14b0df69e6d1a2a105349) mdbook: 0.4.10 -> 0.4.12
* [`03c5948c`](https://github.com/NixOS/nixpkgs/commit/03c5948c1223b96a664c8c6731e28d637ccfb82d) AusweisApp2: 1.22.1 -> 1.22.2
* [`dfd825e2`](https://github.com/NixOS/nixpkgs/commit/dfd825e2e21e6a500db36dabb53ae53895079fe8) boops: 1.6.0 -> 1.6.4
* [`59b6ec82`](https://github.com/NixOS/nixpkgs/commit/59b6ec82f38ddacd1150d48f96b449c6626f9e79) cherrytree: 0.99.39 -> 0.99.40
* [`e1012bc6`](https://github.com/NixOS/nixpkgs/commit/e1012bc6f1ed0a9ad7b99d9fa9d7f8187e8530a2) yarn: 1.22.10 -> 1.22.11
* [`23cedc30`](https://github.com/NixOS/nixpkgs/commit/23cedc3088a628e1f5454cab6864f9b1a059e1ba) circleci-cli: 0.1.15149 -> 0.1.15663
* [`90d14641`](https://github.com/NixOS/nixpkgs/commit/90d14641289b1d18c9919bef32afd84472231efc) cloudflared: 2021.7.4 -> 2021.8.1
* [`891a21cd`](https://github.com/NixOS/nixpkgs/commit/891a21cddeb3f165c4639b53dea43e3b80a409b0) maintainers: add ereslibre
* [`a613b9c7`](https://github.com/NixOS/nixpkgs/commit/a613b9c7a5a1edbe43008c65288cfeff11d9fea3) czkawka: 3.1.0 -> 3.2.0
* [`9ccb5859`](https://github.com/NixOS/nixpkgs/commit/9ccb5859fba07e105931c9527f059ada0ca6fdea) dnsproxy: 0.39.1 -> 0.39.2
* [`a57ddffc`](https://github.com/NixOS/nixpkgs/commit/a57ddffcab06048086a38c082dc0400c9acb1446) dolt: 0.24.1 -> 0.27.2
* [`cc3a5e1e`](https://github.com/NixOS/nixpkgs/commit/cc3a5e1e45c15221431cb1a16ce84bef1fb1eaee) pantheon.granite: propagate dependencies
* [`fbaa499c`](https://github.com/NixOS/nixpkgs/commit/fbaa499c62958e5576ec81a04b7e233c15333b30) cozy: 0.7.2 -> 1.0.3
* [`3d59c44d`](https://github.com/NixOS/nixpkgs/commit/3d59c44dfda83b00b57f047e35cd67fe2b37ea2c) nix-simple-deploy: 0.1.1 -> 0.2.1 ([nixos/nixpkgs⁠#133104](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133104))
* [`802e5faf`](https://github.com/NixOS/nixpkgs/commit/802e5fafc6a6cb69344d97a53afbe75d37da9ed5) eggdrop: 1.8.4 -> 1.9.1
* [`0f572158`](https://github.com/NixOS/nixpkgs/commit/0f572158bb08182b1400bab92a14a49a3b9dd11d) rtv: drop package ([nixos/nixpkgs⁠#133085](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133085))
* [`d89f7ca8`](https://github.com/NixOS/nixpkgs/commit/d89f7ca8de29e2300b6fd8b4784d0f1653cbd3d9) elogind: 246.9.2 -> 246.10
* [`ea1d43b1`](https://github.com/NixOS/nixpkgs/commit/ea1d43b12f9f6009371d60e315abca1bb0df3fef) cl-wrapper-script: deprecate phases
* [`dc44b90b`](https://github.com/NixOS/nixpkgs/commit/dc44b90bbcb6eedb1a5eae9b279f407b23f70f03) entt: 3.8.0 -> 3.8.1
* [`f8634b5d`](https://github.com/NixOS/nixpkgs/commit/f8634b5d952787f395def53353c51a01329e80f3) lagrange: 1.5.2 → 1.6.2
* [`02130271`](https://github.com/NixOS/nixpkgs/commit/021302710e17054502ae55c127b08c33d05a6448) epubcheck: 4.2.4 -> 4.2.6
* [`d111adc1`](https://github.com/NixOS/nixpkgs/commit/d111adc10fa59c16f252475155c134c1359b6528) dqlite: 1.8.0 -> 1.9.0
* [`7956e6e8`](https://github.com/NixOS/nixpkgs/commit/7956e6e8721ca91fe03afb88fbc9396713f73fee) zola: 2021-07-14 -> 0.14.0
* [`98533894`](https://github.com/NixOS/nixpkgs/commit/98533894909de2dfaf956339935e3380e31e9e30) rocksdb: 6.17.3 -> 6.23.2
* [`b2ca1b97`](https://github.com/NixOS/nixpkgs/commit/b2ca1b97cef97dc73605fdf5b54a2bb15725c5c0) raft-canonical: 0.10.1 -> 0.11.2
* [`023f0daa`](https://github.com/NixOS/nixpkgs/commit/023f0daa24ff2fada579570029038c170c382e67) esbuild: 0.12.18 -> 0.12.19
* [`861697b8`](https://github.com/NixOS/nixpkgs/commit/861697b840e27934b6d6989500dfaaea01a30101) lxd: 4.16 -> 4.17
* [`56c9d57d`](https://github.com/NixOS/nixpkgs/commit/56c9d57d58dd31653b7c5d5d084a5d641395a449) lxd: add marsam to maintainers
* [`6a04d273`](https://github.com/NixOS/nixpkgs/commit/6a04d273d660f2170686adf6103da1de0b5f500b) vscode-extensions/rust-analyzer: pin rollup dep to avoid regression.
* [`0ed79602`](https://github.com/NixOS/nixpkgs/commit/0ed7960274b3740b5741414f95322fcbc67a6dc1) reg: init at 0.16.1
* [`b8fbf8ac`](https://github.com/NixOS/nixpkgs/commit/b8fbf8acac6f54704e92ad5f4cb8675b0eb21933) fission: 1.13.1 -> 1.14.1
* [`d4d144e9`](https://github.com/NixOS/nixpkgs/commit/d4d144e98fc34c2331169595e5148972e19fdb11) wifite2: 2.5.5 -> 2.5.7
* [`9c086360`](https://github.com/NixOS/nixpkgs/commit/9c086360f5037061424a16da9e75965daa82c8ec) tflint: 0.30.0 -> 0.31.0
* [`09339da8`](https://github.com/NixOS/nixpkgs/commit/09339da83209e8b953ea3a7b829883aef4a7da68) frp: 0.36.1 -> 0.37.1
* [`76901019`](https://github.com/NixOS/nixpkgs/commit/7690101953af3be73576f7550427a7924a7afad4) nodePackages.degit: init at 2.8.4
* [`7a0c6cdd`](https://github.com/NixOS/nixpkgs/commit/7a0c6cdd396521b2d0207bd97bf7b119fbd8e3ea) nixos/miniflux: systemd unit hardening ([nixos/nixpkgs⁠#133123](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133123))
* [`3cd9a760`](https://github.com/NixOS/nixpkgs/commit/3cd9a760929c43e79c280f643c7ad7f355c8f3bd) go-containerregistry: make the package easier to find
* [`dbae6eea`](https://github.com/NixOS/nixpkgs/commit/dbae6eea00f5044e561493cc51ec60a9e5a3d8c8) ghq: 1.1.7 -> 1.2.1
* [`8090305b`](https://github.com/NixOS/nixpkgs/commit/8090305b6496795ac8d3875e45733b00e00b4882) spamassassin: 3.4.5 -> 3.4.6
* [`faab2fda`](https://github.com/NixOS/nixpkgs/commit/faab2fda34ba8fbc4f0ce93be47388fd17df9eb9) top-level/all-packages.nix: Remove self
* [`361fef52`](https://github.com/NixOS/nixpkgs/commit/361fef520190a28a0434274b3f13525138179453) fwts: cleanup
* [`326a0a95`](https://github.com/NixOS/nixpkgs/commit/326a0a958da327ecc6b82acaae7482ac2e0bc430) gpg-tui: 0.7.3 -> 0.7.4
* [`1f714c82`](https://github.com/NixOS/nixpkgs/commit/1f714c8205bb816dc71962ab97a771236f8f4218) grc: 1.12 -> 1.13
* [`e783c89a`](https://github.com/NixOS/nixpkgs/commit/e783c89ad978c438058c603b7bbb4d6aaf3daf28) hcloud: 1.21.0 -> 1.26.1
* [`d104afea`](https://github.com/NixOS/nixpkgs/commit/d104afea069eb762f35085075c04a176f9c03c6f) headscale: 0.5.1 -> 0.5.2
* [`9898f7e0`](https://github.com/NixOS/nixpkgs/commit/9898f7e0728d45cf9cd60d340e023683b7b6472d) nixos/nitter: systemd unit hardening
* [`2e8e8f2c`](https://github.com/NixOS/nixpkgs/commit/2e8e8f2c92a76535fa0d44611a20b97ee6b75927) nixos/nitter: test with CAP_NET_BIND_SERVICE
* [`88b7302b`](https://github.com/NixOS/nixpkgs/commit/88b7302b9019a1ef08224961a862e9b6547b3b91) nitter: add test to passthru.tests
* [`3e37e1d9`](https://github.com/NixOS/nixpkgs/commit/3e37e1d98096a50e2063e4ecefbab17aaaaf4c06) llvmPackages_git.clang: fix linker invocation with LLVMgold plugin
* [`3731e2d9`](https://github.com/NixOS/nixpkgs/commit/3731e2d9b1b180a27487d89204e9e538a9983348) llvmPackages_git.compiler-rt: fix build on darwin
* [`cab7daf2`](https://github.com/NixOS/nixpkgs/commit/cab7daf2c1443041753abf0d22830148a77694b1) llvmPackages_git.lldb: fix python lldb library
* [`9b10cb2c`](https://github.com/NixOS/nixpkgs/commit/9b10cb2cba5862194b043fd925acb69e5bf5b652) llvmPackages_git.lldb: python into lib & wrap binary
* [`d49cdfed`](https://github.com/NixOS/nixpkgs/commit/d49cdfed55863792c970f584e9ee370351ec8f71) pkgsi686Linux.llvmPackages_git.compiler-rt: fix build
* [`84f00bc6`](https://github.com/NixOS/nixpkgs/commit/84f00bc630eb954576871fe108a4ef568c2ce524) helvum: 0.2.1 -> 0.3.0
* [`cdba9b4f`](https://github.com/NixOS/nixpkgs/commit/cdba9b4fca8aa87829e8b77cb0a2eb90ea906da1) influxdb: 1.8.6 -> 1.8.9
* [`85209382`](https://github.com/NixOS/nixpkgs/commit/85209382c1c4c9553e7d4fcb90cfa97c122545b2) nginx: allow overriding SSL trusted certificates when using ACME
* [`87255d1f`](https://github.com/NixOS/nixpkgs/commit/87255d1fe7f767cc628a5811449ff88aea24c71a) jackett: 0.18.459 -> 0.18.531
* [`ba4fcbb3`](https://github.com/NixOS/nixpkgs/commit/ba4fcbb33f2a0880ea5f87ef2f2cee19670bb15d) foot: refactor derivation
* [`765d5c71`](https://github.com/NixOS/nixpkgs/commit/765d5c71e4d113d17d5bfb712a58683298b369f5) keycloak: 15.0.0 -> 15.0.1
* [`ceea8b2b`](https://github.com/NixOS/nixpkgs/commit/ceea8b2b35e46e8eddb766ea10cd30439dffe0f7) fcft: refactor derivation
* [`14200c55`](https://github.com/NixOS/nixpkgs/commit/14200c55aa93e20bd099b9817232ef74c35e1f38) stylua: 0.10.0 -> 0.10.1
* [`13be07b2`](https://github.com/NixOS/nixpkgs/commit/13be07b251b8fd64aabd39f97362f10dd0eb0b7a) tiny: 0.8.0 -> 0.9.0
* [`9bbb2391`](https://github.com/NixOS/nixpkgs/commit/9bbb2391e5ee8cf17fd99b63b93f1ee79441586b) orchis-theme: 2021-06-09 -> 2021-06-25
* [`ccd598cf`](https://github.com/NixOS/nixpkgs/commit/ccd598cfd654794e5d66c0175786e5f9d7eb9f68) tllist: refactor derivation
* [`792abce1`](https://github.com/NixOS/nixpkgs/commit/792abce19438e0d900c0b8e1002d70322c9a3ed1) python3.pkgs.flufl_lock: 5.0.5 -> 5.1
* [`12a866df`](https://github.com/NixOS/nixpkgs/commit/12a866dfd952c0907337448c7cce7b5e7d58d5a3) wbg: unstable-2020-08-01 -> 1.0.2
* [`c1186b57`](https://github.com/NixOS/nixpkgs/commit/c1186b572f73ce45b2d60ce97ada6a25713d659a) maintainers: xwvvvvwx -> d-xo
* [`dfc20639`](https://github.com/NixOS/nixpkgs/commit/dfc206394e271d02c7150cf4bc249ca5677f7906) ocamlPackages.ocsigen_server: 2.18.0 → 4.0.1
* [`1cffbf61`](https://github.com/NixOS/nixpkgs/commit/1cffbf616835878b6d982297346050c5c29b3eff) python3Packages.nad-receiver: 0.2.0 -> 0.3.0
* [`c0d7ec43`](https://github.com/NixOS/nixpkgs/commit/c0d7ec431db8af0dfc474617e417895ddc4b4447) python3Packages.pymata-express: 1.20 -> 1.21
* [`3b12f3c3`](https://github.com/NixOS/nixpkgs/commit/3b12f3c3cf1fbb82246b7408e049ce84aa387f17) python3Packages.solax: 0.2.6 -> 0.2.7
* [`8c656947`](https://github.com/NixOS/nixpkgs/commit/8c656947dcc908ea269b9df3dff3b6d83468d59a) python3Packages.subarulink: 0.3.14 -> 0.3.15
* [`717538e9`](https://github.com/NixOS/nixpkgs/commit/717538e9082a42d97dce9f53740045a73865b18e) python3Packages.torchvision: added cudaSupport option ([nixos/nixpkgs⁠#132917](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/132917))
* [`a1a34f71`](https://github.com/NixOS/nixpkgs/commit/a1a34f71dc47eea6fc4b282907c496cd9f505c2f) fastnlo_toolkit: refactor to not define rev as environment variable
* [`d3997e04`](https://github.com/NixOS/nixpkgs/commit/d3997e04fee19429d5c5697f8463c902342a1a7e) python3Packages.ha-philipsjs: 2.7.4 -> 2.7.5
* [`da045464`](https://github.com/NixOS/nixpkgs/commit/da045464c49de77b0406e07bfc78d608646c84df) lynis: 3.0.5 -> 3.0.6
* [`865e06fa`](https://github.com/NixOS/nixpkgs/commit/865e06fa211706dde4917ac4652accbe6456b7ee) python3Packages.pynetbox: 6.1.2 -> 6.1.3
* [`e19b326e`](https://github.com/NixOS/nixpkgs/commit/e19b326e1cde4de0110a3ffe831cb633ea5fba97) dprint: 0.15.0 -> 0.15.1
* [`9e9a7327`](https://github.com/NixOS/nixpkgs/commit/9e9a7327d1ecf4cca60f3362c1b0f1220708bbda) argyllcms: 2.1.2 -> 2.2.0
* [`9437d2ca`](https://github.com/NixOS/nixpkgs/commit/9437d2ca411c1857f324de3a02ca72ef6e344979) python3Packages.gremlinpython: 3.4.10 -> 3.5.1
* [`8ab578e4`](https://github.com/NixOS/nixpkgs/commit/8ab578e496796accddeeceb48b966983cc90cd09) unicorn: 1.0.2 -> 1.0.3
* [`090a1588`](https://github.com/NixOS/nixpkgs/commit/090a15887460d208e5f382a89d4ae5fd1de5ffd5) linux_xanmod: 5.13.8 -> 5.13.9
* [`7907d803`](https://github.com/NixOS/nixpkgs/commit/7907d803799bbf712fec4fd7ec55afead06dbeae) intel-graphics-compiler: deprecate phases and replace it with runCommandLocal
* [`816b3dec`](https://github.com/NixOS/nixpkgs/commit/816b3decda2cc331ff2f8ef0cbfe39fbdb2882af) tabnine: 3.5.15 -> 3.5.37
* [`b00dd3ac`](https://github.com/NixOS/nixpkgs/commit/b00dd3ac1f53eebfd9c8291ce1fa10b559b04a04) nixos/tests/prometheus-exporters/kea: drop enable option
* [`32313424`](https://github.com/NixOS/nixpkgs/commit/323134240a18ecd771df0d3258d71949c6de932a) gama: 2.12 -> 2.14
* [`d63e4e23`](https://github.com/NixOS/nixpkgs/commit/d63e4e2367bd53089d51673236289468b0256daa) aws-sdk-cpp: fix cross-OS crosscompilation ([nixos/nixpkgs⁠#133182](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133182))
