### PR TITLE
niv home-manager: update 7f976da0 -> 5515ec99

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7f976da06840c268cc291a021bab7532b923713c",
-        "sha256": "06ip8hxjm8mvwrjzrsp9l8zzj74rr2sy6x009pfyz5w6030axdpr",
+        "rev": "5515ec99cc1a8df5b8ca2204f752e1501572fa1b",
+        "sha256": "1vrpqlcmzsr7j47zskxpdigdvfbd7pnvcapqv9718drmzxdb48r8",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/7f976da06840c268cc291a021bab7532b923713c.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/5515ec99cc1a8df5b8ca2204f752e1501572fa1b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@7f976da0...5515ec99](https://github.com/nix-community/home-manager/compare/7f976da06840c268cc291a021bab7532b923713c...5515ec99cc1a8df5b8ca2204f752e1501572fa1b)

* [`ab6517d3`](https://github.com/nix-community/home-manager/commit/ab6517d34a6f73dee356b601f363d10d71a46656) powerline-go: add fish integration
* [`d4907971`](https://github.com/nix-community/home-manager/commit/d490797179a02167e7617da367916bd6a4722e0d) nix-index: use dummy fish package in tests
* [`29ea3737`](https://github.com/nix-community/home-manager/commit/29ea37374dd50cf2033b9e1e52d32a63100d5051) fish: use dummy fish package in tests
* [`b0d76969`](https://github.com/nix-community/home-manager/commit/b0d769691cc379c9ab91d3acec5d14e75c02c02b) emacs: add extraConfig option
* [`59be1f49`](https://github.com/nix-community/home-manager/commit/59be1f4983ee3689de3172716a6c7e95a6a37bb7) dunst: add option to read alternative configuration file ([nix-community/home-manager⁠#2113](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2113))
* [`2c4234cb`](https://github.com/nix-community/home-manager/commit/2c4234cb79684646657f9cfcd4075c3122845670) notify-osd: init ([nix-community/home-manager⁠#2240](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2240))
* [`5515ec99`](https://github.com/nix-community/home-manager/commit/5515ec99cc1a8df5b8ca2204f752e1501572fa1b) email: allow null certificatesFile
