### PR TITLE
niv nixpkgs: update 39ef6795 -> 6adca802

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "39ef6795e63674b51330e547d34c69ba42048fa4",
-        "sha256": "1papbf9r2zd072ckmq4494gpsasljq503fv9wrfbq0nn9fikbjwy",
+        "rev": "6adca8026c26d49de0c07a239642c33df58376a8",
+        "sha256": "0ld0isgrc6z7vkgwda8mb3p5m447qp27w10qwq8gvyakj166rrh2",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/39ef6795e63674b51330e547d34c69ba42048fa4.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6adca8026c26d49de0c07a239642c33df58376a8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-fmt": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@39ef6795...6adca802](https://github.com/nixos/nixpkgs/compare/39ef6795e63674b51330e547d34c69ba42048fa4...6adca8026c26d49de0c07a239642c33df58376a8)

* [`218df515`](https://github.com/NixOS/nixpkgs/commit/218df5159cd2c0888afbc2cf6cefd280d007b22b) sconsPackages: expose the python version used with scons
* [`c253ba28`](https://github.com/NixOS/nixpkgs/commit/c253ba2825e94012d75c3bb9196d8139434af918) maintainers: change github username
* [`cd20497c`](https://github.com/NixOS/nixpkgs/commit/cd20497c66d45df7f986c34f9105338df1de7d41) mongodb: pick python version from scons
* [`30281b45`](https://github.com/NixOS/nixpkgs/commit/30281b4529a6a2715cc08b2839361c7bd3d20c4d) intel-media-sdk: 21.2.3 -> 21.3.1
* [`27f4c28c`](https://github.com/NixOS/nixpkgs/commit/27f4c28c74c17586f00e2e3dfcd7b711a823521f) fcft: 2.4.4 -> 2.4.5
* [`340350e5`](https://github.com/NixOS/nixpkgs/commit/340350e5370d54f169890dc5a33434b30d7144e4) libite: 2.2.0 -> 2.4.0
* [`d855d4cc`](https://github.com/NixOS/nixpkgs/commit/d855d4cccc01fcc7e700fcaff5887463c4b2069b) cargo-watch: fix build on darwin
* [`23c54118`](https://github.com/NixOS/nixpkgs/commit/23c541189c0782ad0fb60d26171480012670209d) redmine: 4.2.1 -> 4.2.2
* [`6929f2b2`](https://github.com/NixOS/nixpkgs/commit/6929f2b29b1756871ca00a23e67c4bfa6f8a054e) libpg_query: 13-2.0.5 -> 13-2.0.7
* [`f08a8806`](https://github.com/NixOS/nixpkgs/commit/f08a880657cdd8a036e8958244abfc18d470da05) libqalculate: 3.19.0 -> 3.20.1
* [`442fb19a`](https://github.com/NixOS/nixpkgs/commit/442fb19a1601c9fb483a67811002815ed682945a) yamllint: 1.26.1 -> 1.26.2
* [`80d31ef3`](https://github.com/NixOS/nixpkgs/commit/80d31ef370bbd28d28fda17174d632a2fff55776) zlib-ng: 2.0.2 -> 2.0.5
* [`50fb63e1`](https://github.com/NixOS/nixpkgs/commit/50fb63e197abbb8bad465971ce38ca24926b173e) llvmPackages_git: 2021-07-16 -> 2021-08-03
* [`a6413be9`](https://github.com/NixOS/nixpkgs/commit/a6413be97225d70026740b854f21bcb55d220027) python3Packages.cachelib: 0.2.0 -> 0.3.0
* [`75c43a5f`](https://github.com/NixOS/nixpkgs/commit/75c43a5f8e28f4366f80e59841424ccd90258329) libxlsxwriter: 1.1.1 -> 1.1.3
* [`e0647731`](https://github.com/NixOS/nixpkgs/commit/e06477311ae039345c791cc326a8a1812afec369) lifecycled: 3.1.0 -> 3.2.0
* [`bde1ee18`](https://github.com/NixOS/nixpkgs/commit/bde1ee1865d4660a7279fe2391f0215bc771e735) lightburn: 0.9.23 -> 1.0.00
* [`b2e12b58`](https://github.com/NixOS/nixpkgs/commit/b2e12b58e0c7fc2d9f75c139074254310596dcd6) vips: 8.10.6 -> 8.11.2
* [`452201c4`](https://github.com/NixOS/nixpkgs/commit/452201c4596c4e514b2da8917853449600275b21) klayout: 0.26.10 -> 0.27.3
* [`2b799b5a`](https://github.com/NixOS/nixpkgs/commit/2b799b5a106d09cf461b737b6ee454cba05a61ac) microplane: 0.0.32 -> 0.0.33
* [`e514ea4d`](https://github.com/NixOS/nixpkgs/commit/e514ea4db5362de5b7c9243c4d6230a6fb28768b) mob: 1.4.0 -> 1.8.0
* [`dea2995b`](https://github.com/NixOS/nixpkgs/commit/dea2995b5dddc360a69a884f43b1c3da845d9fb1) mockgen: 1.5.0 -> 1.6.0
* [`a2988584`](https://github.com/NixOS/nixpkgs/commit/a2988584620087d96b33ed7a92a4ec1c19b3a3af) vimPlugins: fix update script indentation
* [`99d5f055`](https://github.com/NixOS/nixpkgs/commit/99d5f055ba7ba135f4a28ebf70a010a61ab8d932) toybox: 0.8.4 -> 0.8.5
* [`46b6e434`](https://github.com/NixOS/nixpkgs/commit/46b6e434b1a80e05ccb112f1fde1f3aa3cddad29) gnome.totem: 3.38.0 -> 3.38.1
* [`af17dca3`](https://github.com/NixOS/nixpkgs/commit/af17dca3e028446d06eb7e59fc5d34f594db4c34) ulauncher: 5.9.0 -> 5.11.0
* [`08ab8dc3`](https://github.com/NixOS/nixpkgs/commit/08ab8dc31deee518cc33758fa8403961293e50b9) marwaita: 10.2 -> 10.3
* [`be5a10a1`](https://github.com/NixOS/nixpkgs/commit/be5a10a11e8d7a2393afd6ce2819d4b0450e7324) cbftp: init at 1173
* [`7467002f`](https://github.com/NixOS/nixpkgs/commit/7467002f21bc4ccdf96c01da916928bd01245820) maxcso: 1.12.0 -> 1.13.0
* [`0b78c106`](https://github.com/NixOS/nixpkgs/commit/0b78c10674ff8ff5f16b092acab7cda22d1923d7) python3Packages.total-connect-client: 0.58 -> 2021.7.1
* [`8371fedb`](https://github.com/NixOS/nixpkgs/commit/8371fedb39d0b2c0aa619f8ab4d5a018f18126f1) vimPlugins: update
* [`0b2ff700`](https://github.com/NixOS/nixpkgs/commit/0b2ff7007ccb0bbbd0b98185c5fb3561cbaed755) vimPlugins.nvim-expand-expr: init at 2021-08-14
* [`b94a55d2`](https://github.com/NixOS/nixpkgs/commit/b94a55d212b1eb16f77d9b9e69aacafb190e279c) vscode: update example to match [nixos/nixpkgs⁠#131589](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131589)
* [`9a62c51f`](https://github.com/NixOS/nixpkgs/commit/9a62c51fdfa2f73d66497a964932afcd6aa96048) Fix import path.
* [`26a8f6ea`](https://github.com/NixOS/nixpkgs/commit/26a8f6eaf46f573c95ccb7ec4e3e4da99cdc351f) pass2csv: init at 0.3.1
* [`6f881778`](https://github.com/NixOS/nixpkgs/commit/6f881778a479388330e9b5bcfd18fe9cdee1a2b2) python38Packages.pytwitchapi: init at 2.3.2
* [`dbe9bf98`](https://github.com/NixOS/nixpkgs/commit/dbe9bf9848d7789b8d89fd2b0a43e3ca91f51357) dockerTools.pullImage: fix for skopeo 1.4.x
* [`5caebbb0`](https://github.com/NixOS/nixpkgs/commit/5caebbb04078470ad573374618f0abcdd0e07066) verilator: 4.202 -> 4.210
* [`f3042857`](https://github.com/NixOS/nixpkgs/commit/f30428571b2ed667676f13469043d3f14ac54b95) rabbitmq: Remove Profpatsch as maintainer
* [`3c426702`](https://github.com/NixOS/nixpkgs/commit/3c42670283df5ee06625c7ab17fa41f622244b22) totem-pl-parser: 3.26.5 -> 3.26.6
* [`b9f4e2aa`](https://github.com/NixOS/nixpkgs/commit/b9f4e2aaf611830df85e9b0093bf80c23dadb93b) webdis: 0.1.15 -> 0.1.16
* [`61885e17`](https://github.com/NixOS/nixpkgs/commit/61885e172b8d83607075ebabd4517a0a7e17da74) mlt: cleanup
* [`757d12a4`](https://github.com/NixOS/nixpkgs/commit/757d12a40cda9a575d0f7e9ad83707fc46090940) python3Packages.howdoi: 2.0.16 -> 2.0.17
* [`914648f9`](https://github.com/NixOS/nixpkgs/commit/914648f99c78fa6ed10f5476159f24d5eddab187) python3Packages.howdoi: enable tests
* [`4591156e`](https://github.com/NixOS/nixpkgs/commit/4591156e7052da0576f5cf70ff64c8bf826eb6eb) homebank: switch to pname + version
* [`da054009`](https://github.com/NixOS/nixpkgs/commit/da0540090507497bac224ca49bf1193845202e74) dolt: format
* [`3023b200`](https://github.com/NixOS/nixpkgs/commit/3023b200a212797e7b2582fb4ec9ab4cb61efc55) khal: 0.10.3 -> 0.10.4
* [`8a4fb6dc`](https://github.com/NixOS/nixpkgs/commit/8a4fb6dc3d45b18381eac4aa1c8d37e8d281fdf9) agenda: 1.1.1 -> 1.1.2
* [`e3701354`](https://github.com/NixOS/nixpkgs/commit/e3701354ff61da42bb5b0cfe8c8ce85f38dfd8bf) urh: 2.9.1 -> 2.9.2
* [`34d15349`](https://github.com/NixOS/nixpkgs/commit/34d1534923f8dfb46245040f56af9cb873e36a05) vimPlugins: update
* [`84407625`](https://github.com/NixOS/nixpkgs/commit/844076256c814a7c5e0dfb28999125398cc6ac8d) vimPlugins.clever-f-vim: init at 2021-07-07
* [`98d8f2e8`](https://github.com/NixOS/nixpkgs/commit/98d8f2e8fed3ef69b4e9adb904a423822ac99407) glances: 3.2.2 -> 3.2.3
* [`000973d1`](https://github.com/NixOS/nixpkgs/commit/000973d1a1fbfed6828a56d9893fb4eeed135e33) audiowaveform: 1.4.2 -> 1.5.1, fix gtest subproject
* [`909558eb`](https://github.com/NixOS/nixpkgs/commit/909558eb27b4fe4e3b42ba40106166d4b472e0e0) libgpgerror: fix cross-compilation
* [`2419ea4a`](https://github.com/NixOS/nixpkgs/commit/2419ea4aff2f4b13fae366b51f1f905ec8ccb1e1) rust: fix build of pam-sys package
* [`2f83defd`](https://github.com/NixOS/nixpkgs/commit/2f83defdc64c529534d481dd4ae6a0f41dce76c6) python38Packages.mautrix: 0.10.2 -> 0.10.3
* [`e6ba34f6`](https://github.com/NixOS/nixpkgs/commit/e6ba34f6e634085a8c7a94eb768e3f74c42e2dd4) lethe: 0.5.1 -> 0.6.0
* [`fb5893ed`](https://github.com/NixOS/nixpkgs/commit/fb5893edbab318119cb38eec8bad0c415ae9304f) catdoc: fix build on darwin
* [`b1618ce0`](https://github.com/NixOS/nixpkgs/commit/b1618ce0c7e3eb4cb72377e6c20b86f40b2643bb) python3Packages.python-box: 5.3.0 -> 5.4.0
* [`deedc9d3`](https://github.com/NixOS/nixpkgs/commit/deedc9d31bba9e2d2c6a97628c1ec5f852209d0e) python3Packages.icmplib: 3.0.0 -> 3.0.1
* [`424ab91f`](https://github.com/NixOS/nixpkgs/commit/424ab91f0cdfe92d6c5509b86d4fb527a520c72c) python3Packages.identify: 2.2.11 -> 2.2.13
* [`a8e5991c`](https://github.com/NixOS/nixpkgs/commit/a8e5991ce3ee80e6aa294feb3a57f1458b76a8bd) python3Packages.pyvicare: 2.5.2 -> 2.6
* [`576f74fb`](https://github.com/NixOS/nixpkgs/commit/576f74fb47191d70953c9809668c1a5bb4f0e6b5) nextpnr: 2021.07.28 -> 2021.08.06
* [`2af9fc4c`](https://github.com/NixOS/nixpkgs/commit/2af9fc4c2aa47a4ecc61e2ca0df5948b575749c5) yosys: 0.9+4221 -> 0.9+4272
* [`f4506e99`](https://github.com/NixOS/nixpkgs/commit/f4506e9946c89b92c0d2c1242ddd50ea7f64e016) python38Packages.gensim: 4.0.0 -> 4.0.1
* [`d0f77d5c`](https://github.com/NixOS/nixpkgs/commit/d0f77d5cccef1178a6e212709ddbe8c4e66ccdfb) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.7.0 -> 0.8.0
* [`d5f4a171`](https://github.com/NixOS/nixpkgs/commit/d5f4a1716e8d088912308ace57007ff31adf2c93) bpb: init at unstable-2018-07-27
* [`b4c9d6eb`](https://github.com/NixOS/nixpkgs/commit/b4c9d6eb31e1b78a0884a2c9749a66487912b0cc) skawarePackages.buildManPages: derivation wrapper for skaware man page ports
* [`be6a19a7`](https://github.com/NixOS/nixpkgs/commit/be6a19a7e66298d4803a913a21ba3a4e0ec31feb) execline-man-pages: init at 2.8.0.1.1
* [`3a9bb707`](https://github.com/NixOS/nixpkgs/commit/3a9bb7078804c53f21eca03de82ce47c6c00143a) s6-man-pages: init at 2.10.0.3.1
* [`840e2d6c`](https://github.com/NixOS/nixpkgs/commit/840e2d6c45569e0e49ab9f7ecbbbf0513b2fc607) s6-networking-man-pages: init at 2.4.1.1.1
* [`bf18158d`](https://github.com/NixOS/nixpkgs/commit/bf18158da7ec1261266da749fa9ecadfaebb2353) unipicker: cleanup
* [`69e4da7a`](https://github.com/NixOS/nixpkgs/commit/69e4da7a6c3f9c868a96186d6732419163959de0) skrooge: 2.24.6 ->2.26.1 ([nixos/nixpkgs⁠#134048](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/134048))
* [`7deb22c0`](https://github.com/NixOS/nixpkgs/commit/7deb22c069c237e31ee446583170e576285d0c7b) treefmt: 0.2.3 -> 0.2.5
* [`035dcc0e`](https://github.com/NixOS/nixpkgs/commit/035dcc0e7ea6a59990fe9bc350115df94aa61564) nixos/nginx: fix typo in listenAdresses
* [`4e6d730d`](https://github.com/NixOS/nixpkgs/commit/4e6d730d5f0b3ca864a6ebacfae4fc0caf86aae5) neo-cowsay: 1.0.1 -> 1.0.3
* [`cbd00ed7`](https://github.com/NixOS/nixpkgs/commit/cbd00ed716a86be238516078cd0863fa67921ab0) nzbget: 21.0 -> 21.1
* [`d7f1a5d6`](https://github.com/NixOS/nixpkgs/commit/d7f1a5d63e7cdcccecf3e0ee268d1a4d38eb02b6) php74Extensions.couchbase: 3.1.2 -> 3.2.0
* [`03976436`](https://github.com/NixOS/nixpkgs/commit/039764362bd23fee07ddce1a6b284e4348a08f41) linux: 4.4.280 -> 4.4.281
* [`9e9933a7`](https://github.com/NixOS/nixpkgs/commit/9e9933a76be27acf86a9a0573f6d5bf794ae5cd8) linux: 4.9.279 -> 4.9.280
* [`f2e78916`](https://github.com/NixOS/nixpkgs/commit/f2e78916b9b72d6e4bb00197f9e79abe1c7b2952) linux: 5.13.10 -> 5.13.11
* [`91a744b1`](https://github.com/NixOS/nixpkgs/commit/91a744b1fdeb0f98f058cff05720ebf2f2fc4c56) odpic: 4.1.0 -> 4.2.1
* [`2a64ca26`](https://github.com/NixOS/nixpkgs/commit/2a64ca263bd4e1a54659ec49a1c574087ea86310) wimboot: 2.6.0 -> 2.7.3
* [`32138825`](https://github.com/NixOS/nixpkgs/commit/32138825dde896f76a89e343e54f84a6c256f5a9) vultr-cli: 2.4.1 -> 2.7.0
* [`56aba815`](https://github.com/NixOS/nixpkgs/commit/56aba815bb409e12f6ef400c6c79cf9fed0d112b) sumneko-lua-language-server: fix tests on aarch64
* [`12a6f2aa`](https://github.com/NixOS/nixpkgs/commit/12a6f2aa592019f82f3f9b29ccfbaa7e2e2cd358) mtools: 4.0.34 -> 4.0.35
* [`8079e994`](https://github.com/NixOS/nixpkgs/commit/8079e99453e6e41bf54043e905e8cd2369b6c906) wezterm: 20210502-154244-3f7122cb -> 20210814-124438-54e29167
* [`039fc793`](https://github.com/NixOS/nixpkgs/commit/039fc793c35f5ea92a13a8a33a6f7edcd7b289f9) vim_configurable: handle python3Dependencies
* [`5fa791f9`](https://github.com/NixOS/nixpkgs/commit/5fa791f953b9444601d7802fc8308b3392afa701) nextdns: 1.11.0 -> 1.35.0
* [`b0e4309d`](https://github.com/NixOS/nixpkgs/commit/b0e4309dd5f723569684372a98d600454fcdbc38) erlang-ls: 0.17.0 -> 0.18.0
* [`340e3b85`](https://github.com/NixOS/nixpkgs/commit/340e3b85dedb289b970e2e7d415a842e60b1d8fb) sumneko-lua-language-server: 2.2.3 -> 2.3.6
* [`a6f7fd64`](https://github.com/NixOS/nixpkgs/commit/a6f7fd64fb40ea07fac87533f57f0a25275c16f1) oneDNN: 2.2.1 -> 2.3.2
* [`daae03bb`](https://github.com/NixOS/nixpkgs/commit/daae03bb4fa8d65486ed9b9b36a9b8f871ddc2a2) onedrive: 2.4.12 -> 2.4.13
* [`16c9ec70`](https://github.com/NixOS/nixpkgs/commit/16c9ec70e3df386e4be10c1915fa90e7d9907656) vimPlugins: update
* [`d2781c50`](https://github.com/NixOS/nixpkgs/commit/d2781c50ff84bf11472636b09a5187641457fa54) vimPlugins.fcitx-vim: init at 2021-08-15
* [`49226e1a`](https://github.com/NixOS/nixpkgs/commit/49226e1ae56881f72df4756226a605634f3d1d40) oneshot: 1.4.1 -> 1.5.0
* [`fbafeb7a`](https://github.com/NixOS/nixpkgs/commit/fbafeb7ad5dd6196fcc5d84264e1706653a62f81) treewide: runCommandNoCC -> runCommand
* [`0d859a07`](https://github.com/NixOS/nixpkgs/commit/0d859a070e1e222ee442f5a3b2fbdf489856761a) yarn2nix-moretea: Generate runCommand instead of -NoCC
* [`a201246b`](https://github.com/NixOS/nixpkgs/commit/a201246bac60c09e51b1659ae61fdbdc242c3269) treewide: runCommandNoCC -> runCommand in generated code
* [`1f20a109`](https://github.com/NixOS/nixpkgs/commit/1f20a1097d364a5d3eba2c15a3b5e10d38c23949) treewide: runCommandNoCCLocal -> runCommandLocal
* [`a13aa64b`](https://github.com/NixOS/nixpkgs/commit/a13aa64bd3318a966fbea471bb1b167a76eec184) build-support/rust: remove unused runCommandNoCC
* [`9feb144c`](https://github.com/NixOS/nixpkgs/commit/9feb144c8cc4f4b71a9c23b2f7fd6b2ea55649e5) runCommandNoCC: deprecate
* [`321045ad`](https://github.com/NixOS/nixpkgs/commit/321045ad35d88939d60c440f7471660532bf2149) listadmin: fix deprecation
* [`d6aafb3b`](https://github.com/NixOS/nixpkgs/commit/d6aafb3be95c156bfdb0992fae27bc3491a8b6e5) nixpkgs-basic-release-checks: Check without aliases
* [`57f3504e`](https://github.com/NixOS/nixpkgs/commit/57f3504e3571bc2d28aabe5b44081eb6cc9c0533) runCommandNoCC: fix ofborg status
* [`5196c780`](https://github.com/NixOS/nixpkgs/commit/5196c7809be4594b914e86bb95a8bc54537b05e8) openfpgaloader: 0.2.6 -> 0.5.0
* [`2c045900`](https://github.com/NixOS/nixpkgs/commit/2c045900b75d5fed44a0a01535f722e02b880416) vimPlugins.plenary-nvim: don't build from luaPackages.plenary-nvim
* [`b80b29c7`](https://github.com/NixOS/nixpkgs/commit/b80b29c7f0bc44f921973c2e1069cece70a13c53) python38Packages.pyfaidx: 0.5.9.5 -> 0.6.1
* [`dcda378e`](https://github.com/NixOS/nixpkgs/commit/dcda378ed9434bf68eb2675e71f696ee18ce9ebc) python38Packages.numcodecs: 0.8.0 -> 0.8.1
* [`505a9449`](https://github.com/NixOS/nixpkgs/commit/505a9449b7c06d3b76abd83432b0ff4159ee7866) osm2pgsql: 1.5.0 -> 1.5.1
* [`3ab8ce12`](https://github.com/NixOS/nixpkgs/commit/3ab8ce12c2db31268f579c11727d9c63cfee2eee) neovide: fix meta.mainProgram
* [`0964eae2`](https://github.com/NixOS/nixpkgs/commit/0964eae237bb7c9a1b49af954b3f9af044f4aa44) sbcl: backport ARM segfault fix for large cores
* [`3b325137`](https://github.com/NixOS/nixpkgs/commit/3b32513767425dd8a81020305a5705760d11224a) acl2: 8.3 -> 8.4
* [`a13f8aa9`](https://github.com/NixOS/nixpkgs/commit/a13f8aa9be146c91c244e25580dd9b6ee369756f) oh-my-git: Add libudev
* [`6adca802`](https://github.com/NixOS/nixpkgs/commit/6adca8026c26d49de0c07a239642c33df58376a8) exa: fix on aarch64-darwin ([nixos/nixpkgs⁠#133660](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133660))
