### PR TITLE
niv home-manager: update 5515ec99 -> ad0fc085

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5515ec99cc1a8df5b8ca2204f752e1501572fa1b",
-        "sha256": "1vrpqlcmzsr7j47zskxpdigdvfbd7pnvcapqv9718drmzxdb48r8",
+        "rev": "ad0fc085c7b954d5813a950cf0db7143e6b049e3",
+        "sha256": "1m5fprdnbl38hfvj65m67nqpajjs3ngz92flx9zfzwpkj8nhvcvf",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/5515ec99cc1a8df5b8ca2204f752e1501572fa1b.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/ad0fc085c7b954d5813a950cf0db7143e6b049e3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5515ec99...ad0fc085](https://github.com/nix-community/home-manager/compare/5515ec99cc1a8df5b8ca2204f752e1501572fa1b...ad0fc085c7b954d5813a950cf0db7143e6b049e3)

* [`a57ef9da`](https://github.com/nix-community/home-manager/commit/a57ef9dad197e3941e9f4bdbbfe5d9213e7d47ed) doc: darwin: user.users.eve -> users.users.eve ([nix-community/home-manager⁠#2258](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2258))
* [`a4a83078`](https://github.com/nix-community/home-manager/commit/a4a83078976025f2dc6aaca35b20880735f7baa3) java: add module
* [`c049a09d`](https://github.com/nix-community/home-manager/commit/c049a09d1aa74e78d84cbb76a84a0218956650a6) easyeffects: add module ([nix-community/home-manager⁠#2182](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2182))
* [`604561ba`](https://github.com/nix-community/home-manager/commit/604561ba9ac45ee30385670b18f15731c541287b) lib.gvariant: escape newlines in strings
* [`3d93e1e8`](https://github.com/nix-community/home-manager/commit/3d93e1e80274fd014cbdae510c0ca3b07bcfc9b6) bat: support list settings and shell escaping
* [`479e26dc`](https://github.com/nix-community/home-manager/commit/479e26dc8c4ee3a24cf7dc61128af17ca9ab6faa) scmpuff: remove test dependency on zsh
* [`d819e074`](https://github.com/nix-community/home-manager/commit/d819e0741a08b18aa290f1d12d8d850ecfc28338) rofi-pass: remove test dependency on rofi
* [`a3d691c0`](https://github.com/nix-community/home-manager/commit/a3d691c05308b43afe264a2165f60948cfd2963e) lib.gvariant: add a few more functions to test case
* [`a965b097`](https://github.com/nix-community/home-manager/commit/a965b097b1e0c3bcf22f39413afd1ec6cc1f5335) lib.gvariant: fix rendering of empty non-string arrays
* [`654d82f8`](https://github.com/nix-community/home-manager/commit/654d82f8884f11804c7b20f9a092807e3bd95de9) syncthing: add more service sandboxing
* [`72f3bc6f`](https://github.com/nix-community/home-manager/commit/72f3bc6fa461a2899a06c87c137c7135e410e387) flameshot: add some service sandboxing
* [`6eb88173`](https://github.com/nix-community/home-manager/commit/6eb88173e969e0b575ff8e09785070e2e9e35d81) htop: remove deprecated options and definitions
* [`7226c2db`](https://github.com/nix-community/home-manager/commit/7226c2db468043e52f0a0ebdfde1b369ed2d6db8) htop: add self as maintainer
* [`e4553546`](https://github.com/nix-community/home-manager/commit/e4553546cce35e8bd33916e194cbcf7c8c648c8a) htop: let htop program use its default settings
* [`447f80f6`](https://github.com/nix-community/home-manager/commit/447f80f67648d956c453aafa873d0026c5563454) htop: verify htoprc contents for example settings test
* [`e60dca7b`](https://github.com/nix-community/home-manager/commit/e60dca7bb3e34817f237f9f97124e64a2afa0455) htop: fix htoprc when fields is not explicitly set
* [`2c3a968f`](https://github.com/nix-community/home-manager/commit/2c3a968f57867bef8ff311d4e993a6e4116b0b1c) htop: make self code owner of tests too
* [`5ed3a41a`](https://github.com/nix-community/home-manager/commit/5ed3a41afa705aa821a69c174e5060024b20c5e2) htop: use dummy package in tests
* [`ad0fc085`](https://github.com/nix-community/home-manager/commit/ad0fc085c7b954d5813a950cf0db7143e6b049e3) git-sync: add module
