### PR TITLE
niv spacemacs: update 40ae5e22 -> 3875f7a2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "40ae5e2293c6edb5aed1c554ec6b825f24db45d8",
-        "sha256": "1ki4h1ygzqv95fvck8dmbw7vlkvxzs0qxp0hgfz0d0gcjpx95mdm",
+        "rev": "3875f7a2fdef2f7373a1f01622dc228b1ed2b534",
+        "sha256": "0x0n8j5f5qwvsc7krm1lq6v0wzmd80cabmncbd1ajgq4yljl1i6s",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/40ae5e2293c6edb5aed1c554ec6b825f24db45d8.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/3875f7a2fdef2f7373a1f01622dc228b1ed2b534.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@40ae5e22...3875f7a2](https://github.com/syl20bnr/spacemacs/compare/40ae5e2293c6edb5aed1c554ec6b825f24db45d8...3875f7a2fdef2f7373a1f01622dc228b1ed2b534)

* [`f3b902a3`](https://github.com/syl20bnr/spacemacs/commit/f3b902a304e1e98eefb60612b76e10e2ff1ebbf7) Fix ahs ts, open prompt
* [`9bb3115b`](https://github.com/syl20bnr/spacemacs/commit/9bb3115bcedf192b52ff2819b02b7844ad84a795) Remove obsolete paragraph from the LSP layer documentation ([syl20bnr/spacemacs⁠#14989](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14989))
* [`8b05eb47`](https://github.com/syl20bnr/spacemacs/commit/8b05eb47c03a015995389fb2953476a38c27b770) Evilify and add follow link (hint) keybinding to org-roam buffer
* [`3875f7a2`](https://github.com/syl20bnr/spacemacs/commit/3875f7a2fdef2f7373a1f01622dc228b1ed2b534) Change show-all keybinding to outline-cycle-buffer in pdf layer
