### PR TITLE
niv zsh-completions: update d4511c23 -> 394239d7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -144,10 +144,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "d4511c23659381b56dec8be8c8553b7ff3dc5fd8",
-        "sha256": "1y8wkmhgkkyfz91y1f8crh6cg912n87gmcchc8xhnwji11n1mqrq",
+        "rev": "394239d7467614ce0bcbf9af73ffcc6fbf0cc5c8",
+        "sha256": "0av7l7g9xqf6yk6ckkl3pwz35b206lxf40hjf9qgcj6i5i31a0ag",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/d4511c23659381b56dec8be8c8553b7ff3dc5fd8.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/394239d7467614ce0bcbf9af73ffcc6fbf0cc5c8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@d4511c23...394239d7](https://github.com/zsh-users/zsh-completions/compare/d4511c23659381b56dec8be8c8553b7ff3dc5fd8...394239d7467614ce0bcbf9af73ffcc6fbf0cc5c8)

* [`8ed1a90b`](https://github.com/zsh-users/zsh-completions/commit/8ed1a90bdec9f5e0bee0150e71ae41af214bf299) Completion for openvpn3.
* [`00b5130b`](https://github.com/zsh-users/zsh-completions/commit/00b5130b26c99bade79dc18b2370423513f33b2e) Globals are bad! keep var's local, nice and cozzy.
* [`ae82a1ef`](https://github.com/zsh-users/zsh-completions/commit/ae82a1efae66117d371f47bf0aaf2b5c9264b4e1) Lowercase variables.
