### PR TITLE
niv nixpkgs: update 6adca802 -> 8f27e517

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6adca8026c26d49de0c07a239642c33df58376a8",
-        "sha256": "0ld0isgrc6z7vkgwda8mb3p5m447qp27w10qwq8gvyakj166rrh2",
+        "rev": "8f27e517a23a808289b79a6c954945ea6c8efc94",
+        "sha256": "1dqs5f5dlhzxmk1ffnfskvim0h2i1047997hnj5q357qykdag9wp",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/6adca8026c26d49de0c07a239642c33df58376a8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8f27e517a23a808289b79a6c954945ea6c8efc94.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@6adca802...8f27e517](https://github.com/nixos/nixpkgs/compare/6adca8026c26d49de0c07a239642c33df58376a8...8f27e517a23a808289b79a6c954945ea6c8efc94)

* [`77506e4f`](https://github.com/NixOS/nixpkgs/commit/77506e4f258f1922148986a73a713006318e9fe9) bettercap: 2.31.1 -> 2.32.0 ([nixos/nixpkgs⁠#135101](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135101))
* [`90b0a733`](https://github.com/NixOS/nixpkgs/commit/90b0a7336b2b45e64666abaa9eb91273f1a89feb) yq-go: 4.11.2 -> 4.12.0
* [`7c784439`](https://github.com/NixOS/nixpkgs/commit/7c784439a265f7d9cd32be35ed7d7363b626e3eb) development/{arduino/compilers/interpreters}: replace name with pname&version
* [`82050f0a`](https://github.com/NixOS/nixpkgs/commit/82050f0a137ba800d1bad1cb4126820bd4ad49d1) disfetch: 2.12 -> 2.13
* [`c8e34419`](https://github.com/NixOS/nixpkgs/commit/c8e344196154514112c938f2814e809b1ca82da1) nixos/fluidd: init fluidd service at 1.16.2
* [`556a8fd8`](https://github.com/NixOS/nixpkgs/commit/556a8fd85b10eb7cb0e9582768dfbec0373c7c9b) vips: 8.11.2 -> 8.11.3
* [`c8289bce`](https://github.com/NixOS/nixpkgs/commit/c8289bceb3363aa48114757bc32d00545d5e58cf) python38Packages.google-cloud-pubsub: 2.7.0 -> 2.7.1
* [`58078da4`](https://github.com/NixOS/nixpkgs/commit/58078da425264785882e120edd5b28f6a9b92ea6) python3Packages.yamale: 3.0.4 -> 3.0.8
* [`18973329`](https://github.com/NixOS/nixpkgs/commit/18973329335238bd5aa5b23da73f57494cf408a6) timescaledb-tune: 0.11.0 -> 0.11.2
* [`a1307749`](https://github.com/NixOS/nixpkgs/commit/a1307749a12474b7e4dfb1be63d2b238cdd0d613) hakrawler: 20201224-e39a514 -> 2.0
* [`2ea7eb9c`](https://github.com/NixOS/nixpkgs/commit/2ea7eb9c976f71ad4b1c5d58bbd55c0deb692b3f) flow: 0.157.0 -> 0.158.0
* [`87669a6b`](https://github.com/NixOS/nixpkgs/commit/87669a6b89e63026d3229dbf3295d5fb49f07687) tor: 0.4.6.6 -> 0.4.6.7
* [`942d78d9`](https://github.com/NixOS/nixpkgs/commit/942d78d9cdac3826059cbf351932cd5bcf1c315f) nixos/rspamd: Avoid empty postfix service
* [`c091b809`](https://github.com/NixOS/nixpkgs/commit/c091b809cac3f099d01c9d01d6031c8b180d4d9d) haskellPackages.hasura-ekg-core: unbreak by adding overrides
* [`d72da408`](https://github.com/NixOS/nixpkgs/commit/d72da4088431070c917a13bea2ac0b31f06a4afa) hasura-graphql-engine: add lassulus as maintainer for all dependencies
* [`92d00ac3`](https://github.com/NixOS/nixpkgs/commit/92d00ac35278a4050e260144145244044b04ab27) gocryptfs: 2.0.1 -> 2.1
* [`f3df98d8`](https://github.com/NixOS/nixpkgs/commit/f3df98d8f3b9504c430a1d494950bb47383b386b) goreleaser: 0.174.2 -> 0.175.0
* [`e7c7ccaf`](https://github.com/NixOS/nixpkgs/commit/e7c7ccaf6d2d1455e1aa291252ec91c52c700c0a) unit: 1.24.0 -> 1.25.0
* [`6a38e6ee`](https://github.com/NixOS/nixpkgs/commit/6a38e6ee93981409ecfae49d227db32e50987b71) grype: 0.15.0 -> 0.16.0
* [`9a8850ae`](https://github.com/NixOS/nixpkgs/commit/9a8850aea97840dca1cc1087447ed89dbfe183dc) dhallToNix: Permit inputs referring to derivations ([nixos/nixpkgs⁠#134459](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/134459))
* [`23209f0e`](https://github.com/NixOS/nixpkgs/commit/23209f0e301ba4412c0cb69aea34c4d774994c70) tiled: 1.7.0 -> 1.7.2
* [`acdc88d1`](https://github.com/NixOS/nixpkgs/commit/acdc88d158a40504594e7621c3b1e62e86cd172c) esbuild: 0.12.20 -> 0.12.22
* [`cba087a8`](https://github.com/NixOS/nixpkgs/commit/cba087a88e62cd63264da986a617b6e27dcd3465) icinga2: 2.13.0 -> 2.13.1
* [`39d2d3a2`](https://github.com/NixOS/nixpkgs/commit/39d2d3a288c491aeb13629536c437851b78f63d6) zeroc-ice-36: fix
* [`9608f26a`](https://github.com/NixOS/nixpkgs/commit/9608f26acff129d07ebe881e5c15b2684d074b7f) zeroc-ice: 3.6.3 -> 3.6.5, 3.7.2 -> 3.7.6
* [`679c67ce`](https://github.com/NixOS/nixpkgs/commit/679c67ced8e8872ad0b6fe2ded6328b8973a1e73) zeroc-ice: share meta definition and clarify license
* [`9d71711a`](https://github.com/NixOS/nixpkgs/commit/9d71711aec86ea6434c22bee80c02506bfe2d305) lib: export strings/escapeRegex
* [`b6266dce`](https://github.com/NixOS/nixpkgs/commit/b6266dce644ea6ed47445b36c88e5cf23a6e7fb8) zeroc-ice: enable tests
* [`a2ce8223`](https://github.com/NixOS/nixpkgs/commit/a2ce82238290589a2a9ab267bc0ef5030c4bce9c) git-filter-repo: 2.32.0 -> 2.33.0
* [`fbab8e42`](https://github.com/NixOS/nixpkgs/commit/fbab8e429d28519f50f25efb30fe05c43bf575a2) talloc: 2.3.2 -> 2.3.3
* [`883d2b64`](https://github.com/NixOS/nixpkgs/commit/883d2b64b1a0fd62d8f8285e8b513f87a00742b9) lazygit: 0.28.2 -> 0.29
* [`ba5c69bf`](https://github.com/NixOS/nixpkgs/commit/ba5c69bf04101c215362050acf0a4028ca19e4c8) terraformer: 0.8.11 -> 0.8.15
* [`94321faf`](https://github.com/NixOS/nixpkgs/commit/94321faf13ed6f3f258511a35a874a390a9cf28f) flexget: 3.1.133 -> 3.1.135
* [`d74f249f`](https://github.com/NixOS/nixpkgs/commit/d74f249f7677d43756cd34ccb960205856cd4e17) python39Packages.unidiff: fetch from PyPI
* [`efe3840e`](https://github.com/NixOS/nixpkgs/commit/efe3840e362ee77366b9c196fb01ea17593c4bdb) macchina: 0.9.2 -> 1.0.0
* [`9e62ee7a`](https://github.com/NixOS/nixpkgs/commit/9e62ee7a191ba2b267965b24d1168687ba52d41d) python38Packages.pytest-testmon: 1.1.1 -> 1.1.2
* [`d3806e19`](https://github.com/NixOS/nixpkgs/commit/d3806e192712c66f2ce38cbae98644ee3e71d4ec) python38Packages.ntc-templates: 2.2.0 -> 2.2.2
* [`0a26bf41`](https://github.com/NixOS/nixpkgs/commit/0a26bf415f6e84cf208d1601efd765b15bd8b5d1) mob: 1.8.0 -> 1.9.0
* [`e49e3d75`](https://github.com/NixOS/nixpkgs/commit/e49e3d750e44a10f1b925ac3c1bd48a085d61741) sqlfluff: 0.6.3 -> 0.6.4
* [`0d5e3692`](https://github.com/NixOS/nixpkgs/commit/0d5e3692b192bdb706c52f4581813d1969c72fd3) python3Packages.yamale: switch to pytestCheckHook
* [`6f401698`](https://github.com/NixOS/nixpkgs/commit/6f401698f439c150f53e0a62df1ab2f6410fc1b4) ticker: 4.2.0 -> 4.2.1
* [`2ae7ba44`](https://github.com/NixOS/nixpkgs/commit/2ae7ba4434f060b56cf64ed02c8eabce6103f4c0) mlkit: build on darwin
* [`02c58cc5`](https://github.com/NixOS/nixpkgs/commit/02c58cc5c8b4feb66f261604d94665f32f64e7d6) notejot: 3.1.0 -> 3.1.1
* [`792e5170`](https://github.com/NixOS/nixpkgs/commit/792e517070bb0ba395aaef0de9f9e71e396d1604) nixos/httpd: add none option to logFormat
* [`76ab9029`](https://github.com/NixOS/nixpkgs/commit/76ab90294e4014a3a1e887f1099fc1f674385b94) ungoogled-chromium: 92.0.4515.131 -> 92.0.4515.159
* [`06e13c0c`](https://github.com/NixOS/nixpkgs/commit/06e13c0c88cceb0647ec6b977eb68c169f9eed29) bee: buildFlags -> ldflags
* [`d97118d2`](https://github.com/NixOS/nixpkgs/commit/d97118d2082407a0b10df627f6d055a58fde748c) pond: buildFlags -> tags
* [`e5096a50`](https://github.com/NixOS/nixpkgs/commit/e5096a5041e12cf673390d50bb7fd532f674e755) containerd: move version/revision into buildPhase
* [`d951a8a0`](https://github.com/NixOS/nixpkgs/commit/d951a8a0af83ec8ee295f1bc0b7b69eab2b2f807) teleconsole: remove unnecessary buildFlags
* [`842ae284`](https://github.com/NixOS/nixpkgs/commit/842ae28456de36ccce86bb8348dcb134b5aad27a) pond: mark as broken on aarch64
* [`257c768e`](https://github.com/NixOS/nixpkgs/commit/257c768efa0287f80cac43faffdcdca179751573) ucx: 1.10.1 -> 1.11.0
* [`232b2f89`](https://github.com/NixOS/nixpkgs/commit/232b2f89238bbdefc2ade1a718136dd3f46c3492) brook: 20200201 -> 20210701
* [`193c893e`](https://github.com/NixOS/nixpkgs/commit/193c893efdd5aec34bd70ed6b7dc5ea14ce30db6) mail-notification: remove
* [`f45f451f`](https://github.com/NixOS/nixpkgs/commit/f45f451fb9aa3bddfc04bf567dd6c5b01c09ce69) i3status-rust: 0.20.3 -> 0.20.4
* [`3760bcfd`](https://github.com/NixOS/nixpkgs/commit/3760bcfd589b4dbe86ec634e4908ebd0126f4c0c) opensmt: 2.0.1 -> 2.1.0
* [`4fdfea5f`](https://github.com/NixOS/nixpkgs/commit/4fdfea5fcc1af256d2057a8eda1a29f494f23bf6) betterlockscreen: 4.0.1 -> 4.0.3
* [`fe473b56`](https://github.com/NixOS/nixpkgs/commit/fe473b56444e352b55acc6294f8d890c65daf917) cloud-init: add licenses
* [`76b3e354`](https://github.com/NixOS/nixpkgs/commit/76b3e3540b164fb0cf8d0381c6961071bd2dc7b3) pwgen: update meta
* [`515a6fbe`](https://github.com/NixOS/nixpkgs/commit/515a6fbe79cf705afb61fd599f64e40b39165023) elvish: 0.15.0 -> 0.16.1
* [`5b4b1cbf`](https://github.com/NixOS/nixpkgs/commit/5b4b1cbfc41d0354645059b10df547a82905eb1e) python3Packages.markdown2: 2.4.0 -> 2.4.1
* [`6ee7f338`](https://github.com/NixOS/nixpkgs/commit/6ee7f3383386f56ede19eace321e431b22a3af3a) yarn2nix: replace simple mkDerivation with runCommandLocal
* [`8c2fa7b5`](https://github.com/NixOS/nixpkgs/commit/8c2fa7b5aeb1d6b287422fb8c01229f98f48618d) poedit: 2.4.3 -> 3.0
* [`15b41363`](https://github.com/NixOS/nixpkgs/commit/15b41363c201e0ea5e56db8fd99fa73814452a8e) gitea: 1.14.6 -> 1.15.0
* [`cce78314`](https://github.com/NixOS/nixpkgs/commit/cce7831490628d270f69e9431b4795aca6b0f814) python38Packages.transmission-rpc: 3.2.6 -> 3.2.7
* [`237e85d5`](https://github.com/NixOS/nixpkgs/commit/237e85d5aa9150162548680ae930b2a4489d5a2a) python3Packages.transmission-rpc: update homepage
* [`1fd619a3`](https://github.com/NixOS/nixpkgs/commit/1fd619a368a0d678d6b2217a582c3c82a7a2f65b) python3Packages.immutables: 0.15 -> 0.16
* [`8ed936a1`](https://github.com/NixOS/nixpkgs/commit/8ed936a10b734e9ceb5b762a273d3c1bddabdf54) ptcollab: 0.4.1 -> 0.4.2
* [`960ddb6f`](https://github.com/NixOS/nixpkgs/commit/960ddb6f8f2404cc25b625c4429f49ec0ccef168) cadical: 1.3.0 -> 1.4.1
* [`54c1ca1c`](https://github.com/NixOS/nixpkgs/commit/54c1ca1cb4f7058b9458f94ce6c74d57176d6845) python38Packages.pycdio: 2.1.0 -> 2.1.1
* [`aa0992cc`](https://github.com/NixOS/nixpkgs/commit/aa0992ccc7df329912ba1a5a2accf8236494928d) python38Packages.pytest-sanic: 1.7.1 -> 1.8.1
* [`9a6323d1`](https://github.com/NixOS/nixpkgs/commit/9a6323d16ab54b585de21e56eb608674c6cf979d) reviewdog: 0.12.0 -> 0.13.0
* [`6ea03e77`](https://github.com/NixOS/nixpkgs/commit/6ea03e770a9e907ef35df977b0e55c19589d3ea6) python3Packages.bleach: 3.3.1 -> 4.0.0
* [`a6a68eeb`](https://github.com/NixOS/nixpkgs/commit/a6a68eeb2dc9b02b0cfc1b3e6bb879b1096cc544) gnome.tali: 40.1 -> 40.2
* [`0e94271c`](https://github.com/NixOS/nixpkgs/commit/0e94271c4b8358cf51c20d597f78c58eb1d44a1c) python3Packages.memory-allocator: init at 0.1.0
* [`b565d30c`](https://github.com/NixOS/nixpkgs/commit/b565d30c478517db18fdafb03bd3c1b8bfb07a75) maxima: 5.44.0 -> 5.45.0
* [`9be26479`](https://github.com/NixOS/nixpkgs/commit/9be264795c3840701b0bd94bd114678c2fc8b904) pynac: import segfault fix
* [`46c3703e`](https://github.com/NixOS/nixpkgs/commit/46c3703ec1fe45767a8781e290ed874704d5d18e) sage: 9.3 -> 9.4
* [`113be0cf`](https://github.com/NixOS/nixpkgs/commit/113be0cf0aaea8be25eb531141bdac5e55bbe51e) vimPlugins: update
* [`69fa6bfb`](https://github.com/NixOS/nixpkgs/commit/69fa6bfb8ada0e5f18b5d7f4d7d3c6d0dfbfbe12) vimPlugins: resolve github repository redirects
* [`494002a3`](https://github.com/NixOS/nixpkgs/commit/494002a3af07498bb95de764acf44b7c783f82ce) vimPlugins.nvim-gps: init at 2021-08-22
* [`53bf8857`](https://github.com/NixOS/nixpkgs/commit/53bf88577babb43b99e26029b9361389b06fcb8a) shadowenv: 2.0.3 -> 2.0.4
* [`9fee9590`](https://github.com/NixOS/nixpkgs/commit/9fee9590d459deef78c1da6612c39cf2783870e2) a52dec: fix homepage
* [`69590666`](https://github.com/NixOS/nixpkgs/commit/695906668364af6e6e51872545b1e6b2bf22deff) alure: fix homepage
* [`b113d0c2`](https://github.com/NixOS/nixpkgs/commit/b113d0c2039ab55212638dcd1a6d0de44ce321f6) ansible: fix https url
* [`e6d52673`](https://github.com/NixOS/nixpkgs/commit/e6d5267332e2206d6fb2866d7d9b91bfe41f2748) arandr: fix homepage
* [`aeb86aec`](https://github.com/NixOS/nixpkgs/commit/aeb86aecd4dae9561f9c4d9dcef42b1dcb98c8a2) argocd: fix homepage
* [`237f52b5`](https://github.com/NixOS/nixpkgs/commit/237f52b5026c9fc5e619186897952a9205eb482b) b43: fix homepage
* [`7dfbfb64`](https://github.com/NixOS/nixpkgs/commit/7dfbfb648328a4fba6c64bc02b2dce59dd02e59d) banner: fix homepage
* [`11e5c3ac`](https://github.com/NixOS/nixpkgs/commit/11e5c3ac4b3faa338a581dd54e49a1e34f625d17) bowtie: fix homepage
* [`5bc63f63`](https://github.com/NixOS/nixpkgs/commit/5bc63f63ff7ad26452d23d5b49d2d296222b9fa4) boolstuff: fix homepage
* [`324c07a8`](https://github.com/NixOS/nixpkgs/commit/324c07a825d973bdad196602f6a77e4f68fb9397) bomber: fix homepage
* [`c581e3e1`](https://github.com/NixOS/nixpkgs/commit/c581e3e1371daee265b8622bcc72861aaa7d56d0) betterdiscord-installer: fix homepage
* [`e78c1891`](https://github.com/NixOS/nixpkgs/commit/e78c1891d0eab40d91b2951a22811f92e3fb6fa7) beets: fix homepage
* [`a864b59e`](https://github.com/NixOS/nixpkgs/commit/a864b59ef1a807586f2bccbca46ac1478d04138c) coqPackage.topology: 8.12.0 -> 9.0.0
* [`6d65cb85`](https://github.com/NixOS/nixpkgs/commit/6d65cb8569122295b0f71af100ef8337d7543e32) bitsnbots: drop
* [`671f047c`](https://github.com/NixOS/nixpkgs/commit/671f047c7c1a066e60c4b415a7425873a2e74c08) bcat: remove
* [`9e774593`](https://github.com/NixOS/nixpkgs/commit/9e774593da30a86c1f6af9f46ad2a75d6956e445) bgpdump: 1.6.0 -> 1.6.2
* [`8a653e7c`](https://github.com/NixOS/nixpkgs/commit/8a653e7cf8094fc306ba95a2df311ad3523f8a22) apg: 2.3.0b -> unstable-2015-01-29
* [`a1876c14`](https://github.com/NixOS/nixpkgs/commit/a1876c1437d52dc9f92c4edd83ca48d75a884452) xmrig-mo: 6.14.1-mo1 -> 6.14.1-mo2
* [`0e56ec33`](https://github.com/NixOS/nixpkgs/commit/0e56ec33573216eef456335a50eda7841a00016f) mdk: fix url
* [`26f0cea4`](https://github.com/NixOS/nixpkgs/commit/26f0cea47133404bbe21a3751ae76bdb75e7127f) socat2pre: remove
* [`7f6cb5a2`](https://github.com/NixOS/nixpkgs/commit/7f6cb5a22675f9b0d8217d44ffad252e1714b473) eagle: put the desktop icon where it can be found
* [`58cff035`](https://github.com/NixOS/nixpkgs/commit/58cff03579b48e8d4c0e3a7726ef6a78998b8e99) vips: Add optional dependencies; update to python3
* [`aae58e15`](https://github.com/NixOS/nixpkgs/commit/aae58e15fe2d3834122b1d92b06c3fd8a76a8228) nip2: Fix location of builtins by setting VIPSHOME
* [`0317f616`](https://github.com/NixOS/nixpkgs/commit/0317f61692194ab8731e49368d8358dac101cfcb) nip2: Use nativeBuildInputs as needed
* [`32be1b3c`](https://github.com/NixOS/nixpkgs/commit/32be1b3cbdb6ae93f28ac9a3dc8eb44a92681b32) helix: 0.4.0 -> 0.4.1
* [`60198f1e`](https://github.com/NixOS/nixpkgs/commit/60198f1ebf8e8003395e77e5bff2d7d34ee775ec) python38Packages.txtorcon: 20.0.0 -> 21.1.0
* [`60c8c645`](https://github.com/NixOS/nixpkgs/commit/60c8c645953f78efba191c0a02afa00448f9dfe0) nixos/dovecot: Switch systemd service type to notify
* [`1d3760da`](https://github.com/NixOS/nixpkgs/commit/1d3760dacb2e416c998afeefbb43e8fb68613de4) cointop: 1.6.5 -> 1.6.6
* [`1a5be74d`](https://github.com/NixOS/nixpkgs/commit/1a5be74ddddcbef25314f3162ab00c7c4ff7116d) python3Packages.memory-allocator: add pythonImportsCheck
* [`64de340d`](https://github.com/NixOS/nixpkgs/commit/64de340d726ccd74bbaa1b27fcee2b0efcbd99f6) filtron: init at 0.2.0
* [`3f70ecd6`](https://github.com/NixOS/nixpkgs/commit/3f70ecd60f519851318752cf54dd61dfdf54df2c) rubyPackages: update
* [`73ff5250`](https://github.com/NixOS/nixpkgs/commit/73ff5250eaaf85a130068bc48e62c52b317c4dd7) pythonPackages.datasette-template-sql: init at 1.0.2 ([nixos/nixpkgs⁠#129072](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/129072))
* [`7d356361`](https://github.com/NixOS/nixpkgs/commit/7d35636126b357069125852570ed1755af9d784a) vale: 2.10.4 -> 2.10.5
* [`45108e3f`](https://github.com/NixOS/nixpkgs/commit/45108e3f4849bbd2fb769e9c1e1964bf73a5daac) bat: 0.18.2 -> 0.18.3
* [`905174cb`](https://github.com/NixOS/nixpkgs/commit/905174cb9167f80484586fba72d75156123f23cf) git-delete-merged-branches: 6.0.5 -> 6.3.0
* [`4c9338c8`](https://github.com/NixOS/nixpkgs/commit/4c9338c8dc57bb12eb41706ca1d3e234c330c39b) grpc: 1.39.0 -> 1.39.1
* [`4ce1122a`](https://github.com/NixOS/nixpkgs/commit/4ce1122a3e8867bd26e583a25b2e2f996703a63b) thrift: Move from Python 2 to Python 3
* [`1975b07d`](https://github.com/NixOS/nixpkgs/commit/1975b07db3700a7ca503eda9fa077205fc5a981a) maintainers: add exarkun
* [`e41b0b50`](https://github.com/NixOS/nixpkgs/commit/e41b0b50b0e507c21d226195a557f131f699e583) pythonPackages.txtorcon: run tests with trial and disable for <py3.5
* [`f3ddf4fd`](https://github.com/NixOS/nixpkgs/commit/f3ddf4fd715c9bf9316caf58def2a5de2a4907db) pythonPackages.tubes: init at 0.2.0
* [`804a2a35`](https://github.com/NixOS/nixpkgs/commit/804a2a35de5afea8100bb3f962cbf8b561f91e40) pythonPackages.klein: 17.10.0 -> 21.8.0
* [`c0635782`](https://github.com/NixOS/nixpkgs/commit/c06357825bd099f028d1ca3761929f1522f82b47) pythonPackages.twisted: 20.3.0 -> 21.7.0
* [`3e3938a6`](https://github.com/NixOS/nixpkgs/commit/3e3938a6650ef1963074fe88598d5ee59978ccd5) python3Packages.python-lsp-server: make some dependencies optional
* [`5a6906b0`](https://github.com/NixOS/nixpkgs/commit/5a6906b0e7cd93e426b054f06ca4ca0ad4f8c24a) grpc-tools: 1.10.0 -> 1.11.2
* [`0dabddc5`](https://github.com/NixOS/nixpkgs/commit/0dabddc50ea28fcbe040672014194a2ed4429da4) usql: 0.9.2 -> 0.9.3
* [`f3706ab2`](https://github.com/NixOS/nixpkgs/commit/f3706ab27f99b2ffdaeb6dd03ee6e2f26511c6db) nodejs-16_x: 16.6.2 -> 16.7.0
* [`a55b345f`](https://github.com/NixOS/nixpkgs/commit/a55b345fa6b245d682f0b7ef51977e8874251be0) theme-obsidian2: 2.18 -> 2.19
* [`5f67fc8e`](https://github.com/NixOS/nixpkgs/commit/5f67fc8e69be101c4c39ce3dded953ae3f3b8cb4) openipmi: init at 2.0.31
* [`cb88fc70`](https://github.com/NixOS/nixpkgs/commit/cb88fc7036ddf2100c8dd55dec0c09b57fffc9ce) texmaker: 5.1.0 -> 5.1.1
* [`02ac43e5`](https://github.com/NixOS/nixpkgs/commit/02ac43e5ed8839d3e2e1be175b74c0d0baddfcd7) terracognita: 0.7.1 -> 0.7.2
* [`31dd75c7`](https://github.com/NixOS/nixpkgs/commit/31dd75c7e724b0960a5d4706970e47bdf61d0f9a) commitlint: init at 13.1.0
* [`cb7d80dc`](https://github.com/NixOS/nixpkgs/commit/cb7d80dcaf926a38e80044c29a8210e69f27bb80) buildGo{Module,Package}: warn if buildFlags is used
* [`a313d290`](https://github.com/NixOS/nixpkgs/commit/a313d2907daa27aff4e8d973e20eb652c9b804ce) hyprspace: 0.1.5 -> 0.1.6
* [`06bc3335`](https://github.com/NixOS/nixpkgs/commit/06bc3335d6debc11ffc003fc5d5d2dfa44fcf1b5) polkadot: 0.9.9 -> 0.9.9-1 ([nixos/nixpkgs⁠#135226](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135226))
* [`5d8e6ff9`](https://github.com/NixOS/nixpkgs/commit/5d8e6ff9560ffb221da3819dd23d4c42fc64bb1f) meh: 2015-04-11 -> 2018-10-22 ([nixos/nixpkgs⁠#135299](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135299))
* [`8f27e517`](https://github.com/NixOS/nixpkgs/commit/8f27e517a23a808289b79a6c954945ea6c8efc94) rabbitmq-server: 3.9.3 -> 3.9.4
