### PR TITLE
niv home-manager: update ad0fc085 -> 9029fd2b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ad0fc085c7b954d5813a950cf0db7143e6b049e3",
-        "sha256": "1m5fprdnbl38hfvj65m67nqpajjs3ngz92flx9zfzwpkj8nhvcvf",
+        "rev": "9029fd2b9de2147480efab55f351343f4fed73b9",
+        "sha256": "1jnn3xxnx6k3sa3ws78zhv7lq83713y580qvgqd54spz9c9x5iiz",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/ad0fc085c7b954d5813a950cf0db7143e6b049e3.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9029fd2b9de2147480efab55f351343f4fed73b9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@ad0fc085...9029fd2b](https://github.com/nix-community/home-manager/compare/ad0fc085c7b954d5813a950cf0db7143e6b049e3...9029fd2b9de2147480efab55f351343f4fed73b9)

* [`7ef3db37`](https://github.com/nix-community/home-manager/commit/7ef3db3730d7bddad471372ed823c770634933a7) docs: rename "doc" directory to "docs"
* [`8d68dbd1`](https://github.com/nix-community/home-manager/commit/8d68dbd144f2bcb9d0c89f7e978f1fd55cb281fb) doc: Add an example for a git includes section ([nix-community/home-manager⁠#2275](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2275))
* [`5569770d`](https://github.com/nix-community/home-manager/commit/5569770d1ef66cfacea2c7d116c156fabfb5310b) files: move dry run logic out of onChange hooks
* [`d11afee9`](https://github.com/nix-community/home-manager/commit/d11afee9735a1f9fba2358885fdd86318e214ccb) home-manager: allow remote builders for nix-build ([nix-community/home-manager⁠#2268](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2268))
* [`72394f6d`](https://github.com/nix-community/home-manager/commit/72394f6d6b1cee26021c3e319fa249122ad33d82) fluidsynth: add sound service option
* [`ec260995`](https://github.com/nix-community/home-manager/commit/ec260995e25a38be212b4ba807de2b763fee996d) xsession: set default value of windowManager.command to handle display manager parameter ([nix-community/home-manager⁠#2123](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2123))
* [`a5c609b4`](https://github.com/nix-community/home-manager/commit/a5c609b4b1cd4e1381ac8ea1b7d5b0792ebde0a3) sway: workspaceLayout: `stacked` -> `stacking` ([nix-community/home-manager⁠#2272](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2272))
* [`49a03303`](https://github.com/nix-community/home-manager/commit/49a03303e120e06935151801cbfd70a209cf5371) fish: provide different examples
* [`1a6df903`](https://github.com/nix-community/home-manager/commit/1a6df903e320eb848c02a343141a11afefe4a73f) home-manager: add command line argument `--impure`
* [`bf6b8513`](https://github.com/nix-community/home-manager/commit/bf6b85136b47ab1a76df4a90ea4850871147494a) neomutt: Allow named mailboxes ([nix-community/home-manager⁠#2212](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2212))
* [`4367119c`](https://github.com/nix-community/home-manager/commit/4367119ca3e295513a71eafe839296410a73dbf0) local gpg-agent acting as ssh-agent should yield ([nix-community/home-manager⁠#667](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/667)) ([nix-community/home-manager⁠#2253](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2253))
* [`c5b30691`](https://github.com/nix-community/home-manager/commit/c5b3069145806965ff2bf3807cf273a5a36dc23c) i3/sway: allow empty criterias using a value of 'true' ([nix-community/home-manager⁠#2277](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2277))
* [`f6d1cad6`](https://github.com/nix-community/home-manager/commit/f6d1cad6ba228b81bf7045f1124aa99dfdcf3daa) [nixos] Fix race condition with user units ([nix-community/home-manager⁠#2286](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2286))
* [`9029fd2b`](https://github.com/nix-community/home-manager/commit/9029fd2b9de2147480efab55f351343f4fed73b9) service/window-manager/awesome: replace not existing package ([nix-community/home-manager⁠#2293](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2293))
