### PR TITLE
niv powerlevel10k: update 32e76e77 -> e362b697

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "32e76e772173f1d2856ee4002f21607523221ce7",
-        "sha256": "03krpp3zxpvr8zfgpcj2gmxfgxf0jlxg1ic929i229v6q6qw5isd",
+        "rev": "e362b697355c99d164217c62b051a441b9bcd8f2",
+        "sha256": "1h9qwyiklvbhypd76m6z0r9x6jypn4v9hbchjyrkgzcsic7slpgf",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/32e76e772173f1d2856ee4002f21607523221ce7.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/e362b697355c99d164217c62b051a441b9bcd8f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@32e76e77...e362b697](https://github.com/romkatv/powerlevel10k/compare/32e76e772173f1d2856ee4002f21607523221ce7...e362b697355c99d164217c62b051a441b9bcd8f2)

* [`20b87731`](https://github.com/romkatv/powerlevel10k/commit/20b87731de26638f40dce1bfc89f5b5a207e090f) add availability to display or not Terraform version
* [`6aeb13b0`](https://github.com/romkatv/powerlevel10k/commit/6aeb13b08aab0b35f0c9b0212f1c0cba89eaa5d3) add terraform_version segment to the list of available segments
* [`e7629449`](https://github.com/romkatv/powerlevel10k/commit/e7629449c62918ccb0ce1bee1fec12226f38a7f2) spello
* [`5669c12c`](https://github.com/romkatv/powerlevel10k/commit/5669c12c6659e888de9d0093f95a8fc91d0dba8d) Revert "add availability to display or not Terraform version"
* [`25e5f598`](https://github.com/romkatv/powerlevel10k/commit/25e5f5985f0b977461c0d14663a910363684014e) spello
* [`80ec734a`](https://github.com/romkatv/powerlevel10k/commit/80ec734a953d930838ea6839923c97c3da880a0d) Squashed 'gitstatus/' changes from 845f492f..2ecd9907
* [`277ff8b4`](https://github.com/romkatv/powerlevel10k/commit/277ff8b414a595902981b95199d0ffbc4498f808) Add support for AWS_REGION with fallback to AWS_DEFAULT_REGION ([romkatv/powerlevel10k⁠#1544](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1544))
* [`379b97e4`](https://github.com/romkatv/powerlevel10k/commit/379b97e4e71cf311ebe1dfa11b2e0432c678a43d) Fix after [romkatv/powerlevel10k⁠#1544](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1544) ([romkatv/powerlevel10k⁠#1547](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1547))
* [`0a1946b9`](https://github.com/romkatv/powerlevel10k/commit/0a1946b9651c037a1266ce88cadf8f30fe8d1cac) bug fix: display the intended battery icon when using legacy configs ([romkatv/powerlevel10k⁠#1530](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1530))
* [`10ad57cc`](https://github.com/romkatv/powerlevel10k/commit/10ad57cc6b73b9ed51474edbd5235e6b5f2fd16b) Squashed 'gitstatus/' changes from 2ecd9907..edd92f62
