### PR TITLE
niv spacemacs: update 3875f7a2 -> 198cc3a8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "3875f7a2fdef2f7373a1f01622dc228b1ed2b534",
-        "sha256": "0x0n8j5f5qwvsc7krm1lq6v0wzmd80cabmncbd1ajgq4yljl1i6s",
+        "rev": "198cc3a86fb704b9ce1af33e07034fe7d90479dd",
+        "sha256": "01y891gbh7xfxrcs52gkf7zb53n6jx317vcpg951zv63xcsfgmwg",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/3875f7a2fdef2f7373a1f01622dc228b1ed2b534.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/198cc3a86fb704b9ce1af33e07034fe7d90479dd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@3875f7a2...198cc3a8](https://github.com/syl20bnr/spacemacs/compare/3875f7a2fdef2f7373a1f01622dc228b1ed2b534...198cc3a86fb704b9ce1af33e07034fe7d90479dd)

* [`3a52081c`](https://github.com/syl20bnr/spacemacs/commit/3a52081c23fcc9789ebddcc94e1d79cbc54ea99d) [major-modes] add evil-matchit support for matlab ([syl20bnr/spacemacs⁠#15000](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15000))
* [`fdeb7701`](https://github.com/syl20bnr/spacemacs/commit/fdeb770103c23ba392b04c9d0e2eb4bcdab47ee7) [nixos] Add nixos-format-on-save ([syl20bnr/spacemacs⁠#14982](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14982))
* [`a99b5270`](https://github.com/syl20bnr/spacemacs/commit/a99b5270562f6e689fbaf76c5b10ad2059c61be5) [erlang] add DAP support through erlang_ls-dap ([syl20bnr/spacemacs⁠#14996](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14996))
* [`9745c4e8`](https://github.com/syl20bnr/spacemacs/commit/9745c4e88a048273233c75342a70524a7bb61517) Add purescript formatting support ([syl20bnr/spacemacs⁠#14984](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14984))
* [`090a4c89`](https://github.com/syl20bnr/spacemacs/commit/090a4c89da9359b0baf86874061d0311d1c644b8) [compleseus] Fix junk file function ([syl20bnr/spacemacs⁠#14973](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14973))
* [`6205d29e`](https://github.com/syl20bnr/spacemacs/commit/6205d29e1127a136ad38d57351e7b947ddf39a80) [compleseus] Fix keys ([syl20bnr/spacemacs⁠#14968](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14968))
* [`d9c3dc67`](https://github.com/syl20bnr/spacemacs/commit/d9c3dc678c5fa1cdd22be8daee477a93a84b1b05) Fix evil search prompt on mouse leave ([syl20bnr/spacemacs⁠#15002](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15002))
* [`2f0f7a3f`](https://github.com/syl20bnr/spacemacs/commit/2f0f7a3fe7c1fcda9e9ade1c098d74a5bfed0e7a) Fetch info+ via quelpa wiki recipe
* [`1a9ebf42`](https://github.com/syl20bnr/spacemacs/commit/1a9ebf42df10255bc5ef95194b11c292f4d723c1) Fix file rename target path when buffer name is uniquified
* [`3d6e32e2`](https://github.com/syl20bnr/spacemacs/commit/3d6e32e2a84423b741dd24567bd0408103dc31f4) Fix macOS GUI full screen button wreck caused by GUI setup in early-init.el
* [`8c931b9c`](https://github.com/syl20bnr/spacemacs/commit/8c931b9c8648691c064e72966cb3ffb6308e9731) Evilify special-mode by default
* [`195a2289`](https://github.com/syl20bnr/spacemacs/commit/195a228927e87df61860eb43c4640cb015b11837) [org-roam] Add "r" key to refresh org-roam links list buffer
* [`31222468`](https://github.com/syl20bnr/spacemacs/commit/31222468e6ff090552e807ede21fa97567691ca8) [latex] Doc. TeX engine. Corrects typos, adds on TeX-command-master.
* [`5a9b813c`](https://github.com/syl20bnr/spacemacs/commit/5a9b813c9e55f8ba9ff15943970b026a90efc64f) Add jump to specific manual keybinding (SPC h j)
* [`9f95c95d`](https://github.com/syl20bnr/spacemacs/commit/9f95c95dfcf2d3ebde74fbec9fbf2ec1ea652213) [docs] Update readme, Windows clone path
* [`bb8dd09d`](https://github.com/syl20bnr/spacemacs/commit/bb8dd09d3f84c303628dd54464b425083b5ef80c) [java] improve binding for lsp-java
* [`05f5113b`](https://github.com/syl20bnr/spacemacs/commit/05f5113b7040af6d7001fa4100f8a47fd416ca72) Use built-in get-buffer
* [`f92af998`](https://github.com/syl20bnr/spacemacs/commit/f92af9989a8bf19c29c1b131f9098e06d501f0c5) Add option to enable all-the-icons-ivy-rich to ivy layer
* [`2a0a2612`](https://github.com/syl20bnr/spacemacs/commit/2a0a261263f157d8bbb8b032bab0ec37c0945195) [doc] Change spacemacs links to point to the develop web page
* [`1441dcc0`](https://github.com/syl20bnr/spacemacs/commit/1441dcc0f158f1cb9e6a6a67a986ff0528d72b52) [org-roam] Fix evil org-roam-node-insert spacing ([syl20bnr/spacemacs⁠#15008](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15008))
* [`b1c9ddc4`](https://github.com/syl20bnr/spacemacs/commit/b1c9ddc4525911255388e06a1be5c373816ac443) nim: fix broken indentation
* [`d02fae3c`](https://github.com/syl20bnr/spacemacs/commit/d02fae3c7a7a0fe37916e7c204553711c82ffb9f) Evilify and add cider-repl-history-mode keybindings ([syl20bnr/spacemacs⁠#14842](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14842))
* [`fe147e39`](https://github.com/syl20bnr/spacemacs/commit/fe147e391db71ca44ac5df24493c03a4b221fca7) chinese: add notes on elpa mirrors
* [`198cc3a8`](https://github.com/syl20bnr/spacemacs/commit/198cc3a86fb704b9ce1af33e07034fe7d90479dd) Delete China.png
