### PR TITLE
niv zsh-completions: update 394239d7 -> f52061cd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -144,10 +144,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "394239d7467614ce0bcbf9af73ffcc6fbf0cc5c8",
-        "sha256": "0av7l7g9xqf6yk6ckkl3pwz35b206lxf40hjf9qgcj6i5i31a0ag",
+        "rev": "f52061cd6886250cdeac02cf5a0ad9da44b6efa6",
+        "sha256": "1bjbj242agbvr267pjf70k9pyxbdfjkd23kf8s9s67mlcjlsrjf6",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/394239d7467614ce0bcbf9af73ffcc6fbf0cc5c8.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/f52061cd6886250cdeac02cf5a0ad9da44b6efa6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-history-substring-search": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@394239d7...f52061cd](https://github.com/zsh-users/zsh-completions/compare/394239d7467614ce0bcbf9af73ffcc6fbf0cc5c8...f52061cd6886250cdeac02cf5a0ad9da44b6efa6)

* [`b49f3009`](https://github.com/zsh-users/zsh-completions/commit/b49f3009340e875ae8b0a8cb94697916d47e21cc) xinput: escape colons in device names
