### PR TITLE
niv nixpkgs: update 8f27e517 -> f082ab00

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f27e517a23a808289b79a6c954945ea6c8efc94",
-        "sha256": "1dqs5f5dlhzxmk1ffnfskvim0h2i1047997hnj5q357qykdag9wp",
+        "rev": "f082ab00bd29de3bea7faa1a9654fc45151f86a2",
+        "sha256": "0zm07jp4s6axsirnz9l46yf3fzah2xplkm575ding4l04fkgfyr2",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/8f27e517a23a808289b79a6c954945ea6c8efc94.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f082ab00bd29de3bea7faa1a9654fc45151f86a2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@8f27e517...f082ab00](https://github.com/nixos/nixpkgs/compare/8f27e517a23a808289b79a6c954945ea6c8efc94...f082ab00bd29de3bea7faa1a9654fc45151f86a2)

* [`93edf35c`](https://github.com/NixOS/nixpkgs/commit/93edf35cc57d6aeedf452ace674c457269d8fb8e) python38Packages.itemadapter: 0.3.0 -> 0.4.0
* [`ff220d3b`](https://github.com/NixOS/nixpkgs/commit/ff220d3b3f96fb3920946af8521494f19415e90f) maintainers: add nerdypepper
* [`2fe44209`](https://github.com/NixOS/nixpkgs/commit/2fe4420941201068b6d2ee63d94b654bb276ac9b) ocamlPackages.ocaml-print-intf: init at 1.2.0
* [`755b77f8`](https://github.com/NixOS/nixpkgs/commit/755b77f858a81a5e6c7250a5ac3f18c6c68a6dbe) soupault: init at 3.1.0
* [`1f7711f0`](https://github.com/NixOS/nixpkgs/commit/1f7711f0dd9d0a1163b5758038cafd324b274e81) python3Packages.anybadge: init at 1.7.0
* [`9c65427b`](https://github.com/NixOS/nixpkgs/commit/9c65427ba76882de80063d836b81f87a2f26650f) gdal: 3.2.2 -> 3.3.1 ([nixos/nixpkgs⁠#132852](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/132852))
* [`d890b9b6`](https://github.com/NixOS/nixpkgs/commit/d890b9b6179199bf021ed0b3c1dbe0310b623992) kube-capacity: 0.6.0 -> 0.6.1
* [`6e3451a6`](https://github.com/NixOS/nixpkgs/commit/6e3451a6a8219ded3f124fc1a7d9e63cdc70d28e) mu: 1.6.4 -> 1.6.5
* [`e4591b39`](https://github.com/NixOS/nixpkgs/commit/e4591b39178324c7881239904bb45b99ee3536c2) mu: add chvp as maintainer
* [`6f8fe2e5`](https://github.com/NixOS/nixpkgs/commit/6f8fe2e58b7ff1a6e5e2ed36dbaf76d3a576aae1) mob: 1.9.0 -> 1.10.0
* [`d945e55f`](https://github.com/NixOS/nixpkgs/commit/d945e55ffc55f2f3800239b7d1933fb338b05e5e) miniserve: 0.14.0 -> 0.15.0
* [`a241fee9`](https://github.com/NixOS/nixpkgs/commit/a241fee93a04633269a715f568e3a1015b29c674) python38Packages.wurlitzer: 2.1.1 -> 3.0.2
* [`bae65a3c`](https://github.com/NixOS/nixpkgs/commit/bae65a3c06ae03c17edc91be35bfbf067d27ed23) nixos/mautrix-telegram: loosen umask to keep `config.json` writable
* [`38927fac`](https://github.com/NixOS/nixpkgs/commit/38927fac53a02f233f294265e48cc2bcbd7b2667) ocamlPackages.callipyge: init at 0.2
* [`dd37bf5d`](https://github.com/NixOS/nixpkgs/commit/dd37bf5d75fd1fbfc7e71d46c9db926909198eef) ocamlPackages.chacha: init at 1.0.0
* [`843eebbd`](https://github.com/NixOS/nixpkgs/commit/843eebbd8e0a951e5c2c3f1cd2e17a39f6c08701) ocamlPackages.noise: init at 0.2.0
* [`61ea3fe6`](https://github.com/NixOS/nixpkgs/commit/61ea3fe636a7ceaf0356e2b78a41f6587a46bf4d) ocamlPackages.rfc7748: init at 1.0
* [`6ba20fa0`](https://github.com/NixOS/nixpkgs/commit/6ba20fa087be388c286bf439a69b95abafdbaa9c) ocamlPackages.pp: init at 1.1.2
* [`c765c1d6`](https://github.com/NixOS/nixpkgs/commit/c765c1d6955d9a450a005712906215ee3c0d2f25) ocamlPackages.ocaml-lsp: 1.5.0 -> 1.7.0
* [`bc2cd871`](https://github.com/NixOS/nixpkgs/commit/bc2cd8712855d57df39a271d4e2fc32c19a9ad03) esbuild: 0.12.22 -> 0.12.23
* [`a0eae3b8`](https://github.com/NixOS/nixpkgs/commit/a0eae3b8777f1d0d9e865a50fec1728bf279b009) headscale: 0.7.0 -> 0.7.1
* [`9f01f3f2`](https://github.com/NixOS/nixpkgs/commit/9f01f3f2670a085420d0da4c8c39e5f0580e4945) intel-gmmlib: 21.2.1 -> 21.2.2
* [`33567bd3`](https://github.com/NixOS/nixpkgs/commit/33567bd3b329560b424c526f419539273f25b48f) ssh-audit: 2.4.0 -> 2.5.0
* [`b49afb3f`](https://github.com/NixOS/nixpkgs/commit/b49afb3fe6096f6b2047dba6730c6f6b6d4c3473) signal-desktop: 5.14.0 -> 5.15.0
* [`f2e2b9d9`](https://github.com/NixOS/nixpkgs/commit/f2e2b9d98870706936613cad32ad5ee7228600f6) electron_13: 13.2.0 -> 13.2.2
* [`0e6f0724`](https://github.com/NixOS/nixpkgs/commit/0e6f0724c6dae128fa1e7ffcf34a8b4bc9e51aa6) electron_12: 12.0.16 -> 12.0.17
* [`032baedc`](https://github.com/NixOS/nixpkgs/commit/032baedc9777520ffdeaeac5bc3c378deef275f1) electron_11: 11.4.11 -> 11.4.12
* [`8a2c51a1`](https://github.com/NixOS/nixpkgs/commit/8a2c51a15fe0ee831880490f2e3245d9dcef830f) python3Packages.simplisafe-python: 11.0.4 -> 11.0.5
* [`af5ec6d6`](https://github.com/NixOS/nixpkgs/commit/af5ec6d616ab4d9af17becf8a1079fb8576c6bf4) wireshark: 3.4.7 -> 3.4.8
* [`3dd17ae2`](https://github.com/NixOS/nixpkgs/commit/3dd17ae22f17fb2f5f3bcf99437fe899d727beac) gitlab: Enable puma's systemd notify support
* [`8ad3441f`](https://github.com/NixOS/nixpkgs/commit/8ad3441f2d1c50f02f4d1326502a64d8f2bd5fb8) exodus: fix the desktop file patch
* [`b4804fdf`](https://github.com/NixOS/nixpkgs/commit/b4804fdffe268d4051b3cf6999a7ff18ca6c5b7c) python38Packages.mautrix: 0.10.4 -> 0.10.5
* [`54197b57`](https://github.com/NixOS/nixpkgs/commit/54197b57b26aae15ec1add88f16ebe51a5e7daf2) python38Packages.msal: 1.13.0 -> 1.14.0
* [`467e3a7a`](https://github.com/NixOS/nixpkgs/commit/467e3a7a8758b533147912c2b790ec5de93b4500) linux: 4.14.244 -> 4.14.245
* [`500a91bf`](https://github.com/NixOS/nixpkgs/commit/500a91bf685c9c00b2d89634d800c84a395f6f4f) linux: 4.19.204 -> 4.19.205
* [`770b3058`](https://github.com/NixOS/nixpkgs/commit/770b3058744d01afe5582dc4c9a84f8d1471ceab) linux: 4.4.281 -> 4.4.282
* [`12ea01ba`](https://github.com/NixOS/nixpkgs/commit/12ea01bac9d989f7ac60bfbba1ffb099ccfb8362) linux: 4.9.280 -> 4.9.281
* [`6c457d29`](https://github.com/NixOS/nixpkgs/commit/6c457d29b8865344e07e2383b6fc1f3d31f27085) linux: 5.10.60 -> 5.10.61
* [`198f0a0f`](https://github.com/NixOS/nixpkgs/commit/198f0a0f30e56992692e44a07f1817703120da69) linux: 5.13.12 -> 5.13.13
* [`aeb198d7`](https://github.com/NixOS/nixpkgs/commit/aeb198d7ced73f236637322b6cd2894c5c902b26) linux: 5.4.142 -> 5.4.143
* [`cc93163a`](https://github.com/NixOS/nixpkgs/commit/cc93163a9543c97e7f2775bbee3fb1a719d944a0) linux-rt_5_10: 5.10.56-rt49 -> 5.10.59-rt52
* [`ea89b8bc`](https://github.com/NixOS/nixpkgs/commit/ea89b8bc1f8a046edd5475471ba0ae8845adbf95) linux_latest-libre: 18239 -> 18260
* [`fec4358b`](https://github.com/NixOS/nixpkgs/commit/fec4358b1ee9c19d0b6b4dc5df63eb81cb8d5af7) linux/hardened/patches/4.14: 4.14.244-hardened1 -> 4.14.245-hardened1
* [`3e58b971`](https://github.com/NixOS/nixpkgs/commit/3e58b9716e563221fa66c1c17a16dd40adaca6a1) linux/hardened/patches/4.19: 4.19.204-hardened1 -> 4.19.205-hardened1
* [`21140759`](https://github.com/NixOS/nixpkgs/commit/2114075986ac3653d5a83e1c693b84d7197e7176) linux/hardened/patches/5.10: 5.10.60-hardened1 -> 5.10.61-hardened1
* [`2c9124ef`](https://github.com/NixOS/nixpkgs/commit/2c9124efdba6769a0fa1285f046f7cb2d4e92c7c) linux/hardened/patches/5.13: init at 5.13.13-hardened1
* [`4d8a8abb`](https://github.com/NixOS/nixpkgs/commit/4d8a8abb33a5872c009246f86e3d8cbbdd8a9801) linux/hardened/patches/5.4: 5.4.142-hardened1 -> 5.4.143-hardened1
* [`d90b2fc2`](https://github.com/NixOS/nixpkgs/commit/d90b2fc264e4238eac6b8f2fe1e62c9f0759445e) linux-hardened: Fix update script
* [`c97d75e8`](https://github.com/NixOS/nixpkgs/commit/c97d75e8e520a817dced6d5c569402315065b8ef) openipmi: fix collectd assertion
* [`6bb97886`](https://github.com/NixOS/nixpkgs/commit/6bb97886ad705096346e189952cb5d20e9b23ee8) llvmPackages_git: 2021-08-03 -> 2021-08-13
* [`eaeb4fe0`](https://github.com/NixOS/nixpkgs/commit/eaeb4fe04ee5a5ffae4f7dc03d3f072d59d80337) nixos/nextcloud: remove invalid `--database-table-prefix` option
* [`33a4dae9`](https://github.com/NixOS/nixpkgs/commit/33a4dae995e39360da9b70024da3e1267318ff84) chromiumBeta: 93.0.4577.58 -> 94.0.4606.20
* [`04fa5e85`](https://github.com/NixOS/nixpkgs/commit/04fa5e852a0c467cfa29dce74500705ed5d21e0c) chromiumDev: 94.0.4606.20 -> 95.0.4621.4
* [`a8ec48a4`](https://github.com/NixOS/nixpkgs/commit/a8ec48a4c7d330ce57b5d0de3ad23876aa16369e) musescore: fix JACK output ([nixos/nixpkgs⁠#135740](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135740))
* [`73164006`](https://github.com/NixOS/nixpkgs/commit/73164006951cea087c822e02760d9a1473216110) python38Packages.scikit-hep-testdata: 0.4.6 -> 0.4.7
* [`1cb0ebd2`](https://github.com/NixOS/nixpkgs/commit/1cb0ebd2e25fa7160c204812f7ac47877c5190e5) c2ffi: unstable-2021-04-15 -> unstable-2021-06-15
* [`176705c2`](https://github.com/NixOS/nixpkgs/commit/176705c2953c17d6f7c703745d926c053e59e9f1) vintagestory: init at 1.15.5
* [`3da886bf`](https://github.com/NixOS/nixpkgs/commit/3da886bf41981dcb541a0d98761cd69c0860cf92) treewide: remove ma27 from the maintainer-list of a few packages
* [`ff2e5a6d`](https://github.com/NixOS/nixpkgs/commit/ff2e5a6d3cdb6b0bad0fdf62477cef910e0d4aac) dutree: fix darwin build
* [`1a9ec741`](https://github.com/NixOS/nixpkgs/commit/1a9ec74169199eab3442808e2727aabc47c65af1) diffoscope: 181 -> 182
* [`3ef54d20`](https://github.com/NixOS/nixpkgs/commit/3ef54d2032dda4e3c7c1cd26f4456d11fe6d129f) terminal-colors: init at 3.0.1
* [`861350f6`](https://github.com/NixOS/nixpkgs/commit/861350f65bebd7ad8b15fc6dfe5c0d3137ff04a6) discord-canary: 0.0.126 -> 0.0.128
* [`08b86004`](https://github.com/NixOS/nixpkgs/commit/08b86004a2b671a4e51d8d4b8f4cb6c54ada23b9) mucommander: unbreak on darwin
* [`999f55ee`](https://github.com/NixOS/nixpkgs/commit/999f55ee01390f5d455662e48067de68ab6260bb) bear: unbreak on aarch64-darwin
* [`5a4d7fc3`](https://github.com/NixOS/nixpkgs/commit/5a4d7fc3fb7a6a470a2b7aee521f087096a958d5) sudo: 1.9.7 -> 1.9.7p2
* [`7e3bf56a`](https://github.com/NixOS/nixpkgs/commit/7e3bf56a0887d158841b8c09e90357462f9bca3e) vault: 1.8.1 -> 1.8.2
* [`bac15390`](https://github.com/NixOS/nixpkgs/commit/bac15390f5dbe8072b7acc77329e68a9fdfb5758) llvmPackages_13: 13.0.0-rc1 -> 13.0.0-rc2
* [`f34c35c6`](https://github.com/NixOS/nixpkgs/commit/f34c35c6dc5f5cae9a86bc22920dc69440bda229) cloudlist: init at 0.0.1
* [`6642509b`](https://github.com/NixOS/nixpkgs/commit/6642509bac4ca9d85f9c6a9fe0f41379e2dbc24b) stm32flash: 0.5 -> 0.6
* [`601751a7`](https://github.com/NixOS/nixpkgs/commit/601751a7b6d9620207878e2cd9ede3034ed533a1) yq-go: 4.12.0 -> 4.12.1
* [`7f59b0a9`](https://github.com/NixOS/nixpkgs/commit/7f59b0a98cbd0598fe6cf8eb838e29e2d95093d3) gdu: 5.6.0 -> 5.6.2
* [`0a7137a2`](https://github.com/NixOS/nixpkgs/commit/0a7137a2dfe05ba080381fb8e4f311b43c534a01) yt-dlp: use PyPI tarball
* [`081d39ee`](https://github.com/NixOS/nixpkgs/commit/081d39eee2a7a497069512857cc200384515cc5e) ncspot: 0.8.1 -> 0.8.2
* [`1d9b5a62`](https://github.com/NixOS/nixpkgs/commit/1d9b5a62e01fad75e5473aea3d86c506ba6c59ba) elvish: 0.16.1 -> 0.16.3
* [`7a9526d4`](https://github.com/NixOS/nixpkgs/commit/7a9526d433c35e515b7692904f51a3e733842374) sentry-cli: fix build on Darwin
* [`a54208d9`](https://github.com/NixOS/nixpkgs/commit/a54208d9afe8496b77f31e1f7d7b11ae9775f46f) gopass: 1.12.7 -> 1.12.8
* [`c0c88243`](https://github.com/NixOS/nixpkgs/commit/c0c88243ee64e4fd5bbedf3c79f411f0b942880c) gnome.simple-scan: 40.0 -> 40.1
* [`4ca57d82`](https://github.com/NixOS/nixpkgs/commit/4ca57d8219b4ffca43a5b0f1ed2e957cc7c03dc9) scid-vs-pc: 4.21 -> 4.22
* [`174868d4`](https://github.com/NixOS/nixpkgs/commit/174868d4fa8452c0dc7ebcaf5548376351fa280a) openssl: 1.1.1k -> 1.1.1l
* [`e2e44d9b`](https://github.com/NixOS/nixpkgs/commit/e2e44d9b5c6bf84b89d2f5bb7145e95923aa43f4) bear: fix on x86_64-darwin
* [`ff3aa121`](https://github.com/NixOS/nixpkgs/commit/ff3aa121fdcb16c29374a924714f03e32f56181d) simgear: 2020.3.8 -> 2020.3.11
* [`b0daf8fb`](https://github.com/NixOS/nixpkgs/commit/b0daf8fb06497da6b3bc0259d4d93617fe81bdfe) remarshal: use toPythonApplication ([nixos/nixpkgs⁠#135897](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135897))
* [`f58cfd33`](https://github.com/NixOS/nixpkgs/commit/f58cfd33c2e6ba5ccc5fd53ce5f53ee19c73faae) python38Packages.aiolifx: 0.6.9 -> 0.6.10
* [`9bd880fa`](https://github.com/NixOS/nixpkgs/commit/9bd880fa7258900cb13bc60b60e441189846bf0f) linux_xanmod: 5.13.12 -> 5.13.13
* [`f8f60445`](https://github.com/NixOS/nixpkgs/commit/f8f60445d97a3d510192559fe03fbd2190fed4ca) cloudflared: 2021.8.3 -> 2021.8.6
* [`4f9e77d1`](https://github.com/NixOS/nixpkgs/commit/4f9e77d17cfb4fb9f93bdc7db92763771c3ededb) dnsproxy: 0.39.2 -> 0.39.4
* [`b2b0115e`](https://github.com/NixOS/nixpkgs/commit/b2b0115e70003e0070a50a1e0217a43c7e081588) Revert "openssl: 1.1.1k -> 1.1.1l" ([nixos/nixpkgs⁠#135999](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135999))
* [`f108efaa`](https://github.com/NixOS/nixpkgs/commit/f108efaa01d5fd6b7c984c46f7e82aa0fa67b4a6) python38Packages.internetarchive: 2.0.3 -> 2.1.0
* [`ac0b44b1`](https://github.com/NixOS/nixpkgs/commit/ac0b44b1eea909a45e332aa3ed266dea0bd0a125) dcmtk: support darwin platform ([nixos/nixpkgs⁠#136005](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/136005))
* [`86632bc0`](https://github.com/NixOS/nixpkgs/commit/86632bc0eae73f3023b2fdd5d1f45f3749246e4f) python38Packages.django-haystack: 3.0 -> 3.1.1
* [`b8c5c06a`](https://github.com/NixOS/nixpkgs/commit/b8c5c06aab9e84ba9304b2016428a1d4df4dc512) snakemake: 6.6.1 -> 6.7.0
* [`8d9814b4`](https://github.com/NixOS/nixpkgs/commit/8d9814b4d082a42b33dcdd46deeed46ba98379e0) python3Packages.tldextract: 3.1.0 -> 3.1.1
* [`4e04f84a`](https://github.com/NixOS/nixpkgs/commit/4e04f84aacea7760d97a244a03c999d379081875) tfsec: 0.58.4 -> 0.58.5
* [`f43829a1`](https://github.com/NixOS/nixpkgs/commit/f43829a1d809722340157dbe8f1e7fd6be48070e) nix-prefetch-git: provide fallback for $TMPDIR
* [`2d2d5ce3`](https://github.com/NixOS/nixpkgs/commit/2d2d5ce304316663a5de645b4d76f8ae816337af) nix-prefetch-git: add git-lfs dependency
* [`9bd51f0d`](https://github.com/NixOS/nixpkgs/commit/9bd51f0db9773c2ccec9964a25c2af4745888875) nix-prefetch-git: add fetchLFS flag to the JSON output
* [`cc11b48a`](https://github.com/NixOS/nixpkgs/commit/cc11b48a1e904ac200542f92a06f2158b73e6317) exploitdb: 2021-08-24 -> 2021-08-28
* [`c7cccc55`](https://github.com/NixOS/nixpkgs/commit/c7cccc55fe2fb39761ce6427294a102af865971a) python38Packages.ntc-templates: 2.2.2 -> 2.3.0
* [`21482724`](https://github.com/NixOS/nixpkgs/commit/21482724329dc52a307a3808a9ef5265a6e7b29e) nixos/paperless-ng: fix web file upload
* [`07c31956`](https://github.com/NixOS/nixpkgs/commit/07c3195664eaf0d927965ef75e850bcdb0b550db) libguestfs: 1.40.2 -> 1.44.1
* [`9c442fa9`](https://github.com/NixOS/nixpkgs/commit/9c442fa9014640a0dcc771635db6cc93f6c8f0f2) libguestfs: enable strictDeps
* [`3e9661ce`](https://github.com/NixOS/nixpkgs/commit/3e9661ce7f0622411169b7551b3617feec72a687) libguestfs: change license to gpl2Plus and lgpl21Plus
* [`236fd9c9`](https://github.com/NixOS/nixpkgs/commit/236fd9c90262fcbdcbedb9ee580a0473c79315c7) darwin.signingUtils: move signDarwinBinariesIn from fixupOutputHooks to postFixupHooks
* [`e0b89aff`](https://github.com/NixOS/nixpkgs/commit/e0b89affa04465a31c8564b49518a2eaad95573f) haskellPackages: fix ghc build on aarch64-darwin
* [`420ae3f0`](https://github.com/NixOS/nixpkgs/commit/420ae3f0410b836e922bced1e9f1808be07c6727) racket: 8.1 -> 8.2
* [`33359f51`](https://github.com/NixOS/nixpkgs/commit/33359f518b3e9254889fdbebca3be5509541f140) esbuild: 0.12.23 -> 0.12.24
* [`2784f1bd`](https://github.com/NixOS/nixpkgs/commit/2784f1bd6908b37ed0d686778f347e63692c0f84) pkgsMusl.python*: disable LTO
* [`93462299`](https://github.com/NixOS/nixpkgs/commit/934622990298da37d08e89f62094e4c747cb1037) inferno: init at 0.10.6
* [`3d245b3a`](https://github.com/NixOS/nixpkgs/commit/3d245b3a377b0a91f1be6f819b77cc04cbf24a7d) Revert "Revert "openssl: 1.1.1k -> 1.1.1l" ([nixos/nixpkgs⁠#135999](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135999))"
* [`ca20a96b`](https://github.com/NixOS/nixpkgs/commit/ca20a96b5ff3318eb136c93b44d4996e2a88fb61) treewide: concatStrings (intersperse ...) -> concatStringsSep ...
* [`e2551a69`](https://github.com/NixOS/nixpkgs/commit/e2551a696b32560164388d9e6b4a5b828cd25575) charge-lnd: 0.2.2 -> 0.2.3
* [`4fecb8b2`](https://github.com/NixOS/nixpkgs/commit/4fecb8b2d0c31caf963a35b4525b4a884adecec9) nixos/airsonic: make path to war file and jre configurable ([nixos/nixpkgs⁠#135709](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135709))
* [`b6ea4c47`](https://github.com/NixOS/nixpkgs/commit/b6ea4c478b163cda1dfefc420cb2cb51d74ed2dc) deltachat-cursed: 0.2.0 -> 0.3.0
* [`a544b2b3`](https://github.com/NixOS/nixpkgs/commit/a544b2b3782b4b30d626ed0d7870d4339808257a) electron_13: 13.2.2 -> 13.2.3
* [`f3840694`](https://github.com/NixOS/nixpkgs/commit/f3840694a6673dfbe964427b4d77fd028c7e982c) electron_12: 12.0.17 -> 12.0.18
* [`680c2e60`](https://github.com/NixOS/nixpkgs/commit/680c2e60c9cf5d0bbeb81a31cfec2ca0c77b903a) llvm/update-git.py: Automatically commit the changes
* [`00e380f1`](https://github.com/NixOS/nixpkgs/commit/00e380f1be5f393b7ea8ec9848d89284dd5254ce) llvmPackages/update.sh: Support LLVM 13+
* [`186315de`](https://github.com/NixOS/nixpkgs/commit/186315def77d62b53ad6ccdf57ec9593edbe8bc3) chromium: Move the version helper functions into default.nix
* [`ea4364b2`](https://github.com/NixOS/nixpkgs/commit/ea4364b2f7d3d92e200b1b5b7b831e2be8f1b896) kdeltachat: unstable-2021-08-02 -> unstable-2021-08-28
* [`22a588bc`](https://github.com/NixOS/nixpkgs/commit/22a588bca25e6dd6f9edf41041ac22509f7c696b) python38Packages.portalocker: 2.3.1 -> 2.3.2
* [`ad4883cb`](https://github.com/NixOS/nixpkgs/commit/ad4883cb96307bcf5094cbbae761411743ebb8a4) gnucash: Add patch that fixes enableDebugging gnucash
* [`1025f271`](https://github.com/NixOS/nixpkgs/commit/1025f271896570f8110368dfddb64fc26b7cbfb3) python38Packages.vyper: 0.2.15 -> 0.2.16
* [`9e8fcb01`](https://github.com/NixOS/nixpkgs/commit/9e8fcb0184170a97b4d0a933783bd7c83aff2ab2) nixos/fonts: fixup dd38ae1f
* [`b991f1e4`](https://github.com/NixOS/nixpkgs/commit/b991f1e4483a2356b351d97dcaafe7bfc9822331) syncthing: add autoAcceptFolders to devices config
* [`972a3654`](https://github.com/NixOS/nixpkgs/commit/972a3654888f23f67caefa817889a0033d88a755) syncthing: add extraFlags option that adjust service
* [`66fb8494`](https://github.com/NixOS/nixpkgs/commit/66fb849432beb8cae0c150445496803424f34402) proxychains: revert commit e6b5d5401e42346a0a2190a
* [`224cbafe`](https://github.com/NixOS/nixpkgs/commit/224cbafe165f096f825097663677117d8c245628) merkaartor: 0.18.4 → 0.19.0
* [`8d8a28b4`](https://github.com/NixOS/nixpkgs/commit/8d8a28b47b7c41aeb4ad01a2bd8b7d26986c3512) goimapnotify: 2.0 -> 2.3.2
* [`f7286acd`](https://github.com/NixOS/nixpkgs/commit/f7286acdae6382fc868c7764943ac9b1c4799090) linuxPackages.tuxedo-keyboard: 3.0.7 -> 3.0.8
* [`2e6d5630`](https://github.com/NixOS/nixpkgs/commit/2e6d563067c620d42c9d63911a637793698273eb) linuxPackages.tuxedo-keyboard: expose all kernel modules
* [`e5ad4c72`](https://github.com/NixOS/nixpkgs/commit/e5ad4c72a48cd0f3a81d2a78ad8d02930e75b7ae) iperf: 3.9 -> 3.10.1 ([nixos/nixpkgs⁠#136027](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/136027))
* [`4a67110b`](https://github.com/NixOS/nixpkgs/commit/4a67110bee8c006e94c3f4243963da7edeebe4a8) silver-searcher: add meta.mainProgram
* [`c33c7c3d`](https://github.com/NixOS/nixpkgs/commit/c33c7c3d5fa99fb13d39fd9af265b38a161abaf1) clang_11: Fix RISC-V builds for compiler-rt. ([nixos/nixpkgs⁠#135718](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135718))
* [`4d83b252`](https://github.com/NixOS/nixpkgs/commit/4d83b2529c19f5f01866721688e4eb850827bb6b) vector: 0.15.2 -> 0.16.0
* [`fc87d9a0`](https://github.com/NixOS/nixpkgs/commit/fc87d9a067dfb13739388afd4318241c96e66b6a) vector: 0.16.0 -> 0.16.1
* [`f082ab00`](https://github.com/NixOS/nixpkgs/commit/f082ab00bd29de3bea7faa1a9654fc45151f86a2) vector: disable flaky tests
