### PR TITLE
niv home-manager: update 9029fd2b -> 61ca2fc1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9029fd2b9de2147480efab55f351343f4fed73b9",
-        "sha256": "1jnn3xxnx6k3sa3ws78zhv7lq83713y580qvgqd54spz9c9x5iiz",
+        "rev": "61ca2fc1c00a275b8bd61582b23195d60fe0fa40",
+        "sha256": "10pnnpikq9yikvkzfsap172wsi2h207camv1n5myr8f22qmw1vgm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9029fd2b9de2147480efab55f351343f4fed73b9.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/61ca2fc1c00a275b8bd61582b23195d60fe0fa40.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9029fd2b...61ca2fc1](https://github.com/nix-community/home-manager/compare/9029fd2b9de2147480efab55f351343f4fed73b9...61ca2fc1c00a275b8bd61582b23195d60fe0fa40)

* [`2cf19d1d`](https://github.com/nix-community/home-manager/commit/2cf19d1d9871fc6fc590440dac9ea673d97b6737) neomutt: configurable package ([nix-community/home-manager⁠#2294](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2294))
* [`84d54402`](https://github.com/nix-community/home-manager/commit/84d54402a5dcd5f5561f1273db0781d8e96df229) format: update nixpkgs revision in format script ([nix-community/home-manager⁠#2283](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2283))
* [`521a03d8`](https://github.com/nix-community/home-manager/commit/521a03d8bffe28745bcd4638bfdbc144a2e72065) fnott: add module
* [`f637e145`](https://github.com/nix-community/home-manager/commit/f637e145d758ab183d3dba096c9312eae8bc0c7c) docs/manual: describes -> describe
* [`33db7cc6`](https://github.com/nix-community/home-manager/commit/33db7cc6a66d1c1cb77c23ae8e18cefd0425a0c8) kitty: add environment and darwinLaunchOptions options ([nix-community/home-manager⁠#2280](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2280))
* [`61ca2fc1`](https://github.com/nix-community/home-manager/commit/61ca2fc1c00a275b8bd61582b23195d60fe0fa40) mcfly: switch to init command ([nix-community/home-manager⁠#2301](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2301))
