### PR TITLE
niv powerlevel10k: update e362b697 -> b3b0efb6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "e362b697355c99d164217c62b051a441b9bcd8f2",
-        "sha256": "1h9qwyiklvbhypd76m6z0r9x6jypn4v9hbchjyrkgzcsic7slpgf",
+        "rev": "b3b0efb69f5b7817490aa9163ca44b40699b2bcc",
+        "sha256": "1gd616x10dzzbimk414mipwvdnk3lnb9v4y055dkjimdr22w9zyw",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/e362b697355c99d164217c62b051a441b9bcd8f2.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/b3b0efb69f5b7817490aa9163ca44b40699b2bcc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@e362b697...b3b0efb6](https://github.com/romkatv/powerlevel10k/compare/e362b697355c99d164217c62b051a441b9bcd8f2...b3b0efb69f5b7817490aa9163ca44b40699b2bcc)

* [`b3b0efb6`](https://github.com/romkatv/powerlevel10k/commit/b3b0efb69f5b7817490aa9163ca44b40699b2bcc) work around bugs in terminals and window managers by essentially disabling prompt_sp (but keeping prompt_cr) in instant prompt for new TTYs
