### PR TITLE
niv spacemacs: update 198cc3a8 -> 59852a6a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "198cc3a86fb704b9ce1af33e07034fe7d90479dd",
-        "sha256": "01y891gbh7xfxrcs52gkf7zb53n6jx317vcpg951zv63xcsfgmwg",
+        "rev": "59852a6ab52911ac76bb22aa8642ccef48238349",
+        "sha256": "1fmni45czaab38mh3rc0vpwkdjr0h750ibxdrqvfqq9q1ml8n2jp",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/198cc3a86fb704b9ce1af33e07034fe7d90479dd.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/59852a6ab52911ac76bb22aa8642ccef48238349.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@198cc3a8...59852a6a](https://github.com/syl20bnr/spacemacs/compare/198cc3a86fb704b9ce1af33e07034fe7d90479dd...59852a6ab52911ac76bb22aa8642ccef48238349)

* [`671431f6`](https://github.com/syl20bnr/spacemacs/commit/671431f65cf30010a2524cda2b6c7421ffb7f494) [shell-scripts] Add key binding for shfmt-buffer ([syl20bnr/spacemacs⁠#15017](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15017))
* [`80386e84`](https://github.com/syl20bnr/spacemacs/commit/80386e8414f74498314c6ded7d4f34b9e5f24068) Add (optional) ebib support to bibtex layer ([syl20bnr/spacemacs⁠#14876](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14876))
* [`f78c9bed`](https://github.com/syl20bnr/spacemacs/commit/f78c9bed186aa8c48914aa4d300cea93ea38b194) [docs] Fix broken link in ivy README
* [`a9ba3b8f`](https://github.com/syl20bnr/spacemacs/commit/a9ba3b8fe08772194b7c643b3c3bfc96219e9d14) git: restore layout when exiting magit buffer
* [`b1d28708`](https://github.com/syl20bnr/spacemacs/commit/b1d287081f18500cd9644d9a3e1f5951f8e491ce) Fix typo that prevents ivy-rich from being enabled
* [`abb08847`](https://github.com/syl20bnr/spacemacs/commit/abb088474acec666552747f5ccdbf49608ad2ccb) clojure: small change
* [`8b3b647f`](https://github.com/syl20bnr/spacemacs/commit/8b3b647f1ca2dffc4dc3b96cb270ea98bfaf3046) [CI] Use better way to detect changes
* [`a8669415`](https://github.com/syl20bnr/spacemacs/commit/a86694157eaf39ddb332b7258fa09360c558bc07) [CI] Fix committing
* [`59852a6a`](https://github.com/syl20bnr/spacemacs/commit/59852a6ab52911ac76bb22aa8642ccef48238349) [bot] "documentation_updates" Wed Aug 25 22:37:51 UTC 2021
