### PR TITLE
niv nixpkgs: update f082ab00 -> 87c6a8a7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f082ab00bd29de3bea7faa1a9654fc45151f86a2",
-        "sha256": "0zm07jp4s6axsirnz9l46yf3fzah2xplkm575ding4l04fkgfyr2",
+        "rev": "87c6a8a7066117f547f05fcc678db4119059bbd9",
+        "sha256": "0zijk00zlad3q9yylzd77ipmxlz1l0j02yna75hn0jkcj0rplm9l",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f082ab00bd29de3bea7faa1a9654fc45151f86a2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/87c6a8a7066117f547f05fcc678db4119059bbd9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f082ab00...87c6a8a7](https://github.com/nixos/nixpkgs/compare/f082ab00bd29de3bea7faa1a9654fc45151f86a2...87c6a8a7066117f547f05fcc678db4119059bbd9)

* [`d68d6477`](https://github.com/NixOS/nixpkgs/commit/d68d6477c2ceb855059612b48b650998ee8ca764) release-notes: add nats service
* [`af9f38c2`](https://github.com/NixOS/nixpkgs/commit/af9f38c205fbcd0959169771bf65b77cc1264f81) zsh: fix TZ= completion
* [`94c4410f`](https://github.com/NixOS/nixpkgs/commit/94c4410f7c82c19deeea9ffbefbf76fcd8dfc2dc) libint: make enableFMA default dependent of hostPlatform flags
* [`cfb993f7`](https://github.com/NixOS/nixpkgs/commit/cfb993f75586757293e884b8403c1ea7ca507dd3) inferno: 0.10.6 -> 0.10.7
* [`98a3230a`](https://github.com/NixOS/nixpkgs/commit/98a3230afa0ba04863c783f19e6eed389af1f338) remove a mention of #node.section.md
* [`850286cb`](https://github.com/NixOS/nixpkgs/commit/850286cb9a3d010fdbbe7280721b649e2078998c) buildbot: fix withPlugins
* [`742750cc`](https://github.com/NixOS/nixpkgs/commit/742750ccfd0582cd73af272d9dd3a011fb2d6f42) linuxPackages.ddcci-driver: 0.3.3 -> 0.4.1
* [`ee94d2f3`](https://github.com/NixOS/nixpkgs/commit/ee94d2f39218a7b97f9421525f0f9c47ada8af4f) bear: 3.0.13 -> 3.0.14
* [`5d852fef`](https://github.com/NixOS/nixpkgs/commit/5d852fef63156b965f302de98d30949258d7af23) haskellPackages: mark builds failing on hydra as broken
* [`446de3a2`](https://github.com/NixOS/nixpkgs/commit/446de3a2f3a3d04a0a16de059abee7ce4614501b) emacs.pkgs.ebuild-mode: 1.52 -> 1.53
* [`3677d4bc`](https://github.com/NixOS/nixpkgs/commit/3677d4bc22eddac35e5a19080ec09ab387a76528) kexec-tools: rename from kexectools to match the project name
* [`c418c4f8`](https://github.com/NixOS/nixpkgs/commit/c418c4f8c6d4fc35c6381e5da430e2b17f2c3145) mercurial: 5.8 -> 5.9.1
* [`ed471ccf`](https://github.com/NixOS/nixpkgs/commit/ed471ccf22e3bc11de7f67f7ba89c948d20003f0) tortoisehg: 5.8 -> 5.9
* [`3da1c959`](https://github.com/NixOS/nixpkgs/commit/3da1c959408f90cb9299d383e5e48a6b2cf13cb3) fftw: add optional AVX/FMA optmization flags
* [`3da2e9c3`](https://github.com/NixOS/nixpkgs/commit/3da2e9c34bf575e2449ae21626ed1a4ab351a3ce) shadowenv: 2.0.4 -> 2.0.5
* [`fe182538`](https://github.com/NixOS/nixpkgs/commit/fe1825384743f35e7caddb1b596b6de499e22925) dockfmt: init at 0.3.3
* [`1ef95334`](https://github.com/NixOS/nixpkgs/commit/1ef95334b7b494f0e2c5e5991a4c12cd93677222) dockfmt: add version information
* [`b41f640f`](https://github.com/NixOS/nixpkgs/commit/b41f640fb7665c20be4afba3072a3adfadc33c4e) corerad: 0.3.3 -> 0.3.4
* [`51df9074`](https://github.com/NixOS/nixpkgs/commit/51df9074f00d449bad44c08d81847a06c6d9ec97) terraform_1_0: 1.0.5 -> 1.0.6
* [`a7532641`](https://github.com/NixOS/nixpkgs/commit/a75326417df32c0354e3244a9461700d214eab82) vscode,vscodium: fix moving files to the trash
* [`a53cae02`](https://github.com/NixOS/nixpkgs/commit/a53cae021ab54d9bcbdadffb98a063ef36ef3858) android-studio: 2020.3.1.23 → 2020.3.1.24
* [`ca899bfe`](https://github.com/NixOS/nixpkgs/commit/ca899bfe66b54b6a982f8ddfb960786564e581e6) hck: 0.5.4 -> 0.6.1
* [`ad44de1d`](https://github.com/NixOS/nixpkgs/commit/ad44de1d945aab770833134d74d801b05e2208a8) linux: 4.14.245 -> 4.14.246
* [`9c8dbd4a`](https://github.com/NixOS/nixpkgs/commit/9c8dbd4a1ea5b32c9ef63d97665064c7f1bea3cc) linux: 4.19.205 -> 4.19.206
* [`5ed23535`](https://github.com/NixOS/nixpkgs/commit/5ed235352a04bc73adf172cfd91d9c5a1c27db67) linux: 4.4.282 -> 4.4.283
* [`c57b2db4`](https://github.com/NixOS/nixpkgs/commit/c57b2db48bd112e329a56d1c55596e0805be707c) linux: 4.9.281 -> 4.9.282
* [`f57a2e0b`](https://github.com/NixOS/nixpkgs/commit/f57a2e0bed20c180aca22dae884c3965d70cb13f) linux: 5.10.61 -> 5.10.62
* [`ba3f560d`](https://github.com/NixOS/nixpkgs/commit/ba3f560dc5a0cf5824c39b4eee23d2978a882622) linux: 5.13.13 -> 5.13.14
* [`116141a1`](https://github.com/NixOS/nixpkgs/commit/116141a18868ec3e520423cd69c8fab31442d95a) linux: 5.14 -> 5.14.1
* [`32211147`](https://github.com/NixOS/nixpkgs/commit/32211147489cd3126fb46b21306310fb3d4e1594) linux: 5.4.143 -> 5.4.144
* [`979c0b77`](https://github.com/NixOS/nixpkgs/commit/979c0b77abaf3866b1d32a3cb68906fd01946840) linux-rt_5_4: 5.4.138-rt62 -> 5.4.143-rt63
* [`395d2eff`](https://github.com/NixOS/nixpkgs/commit/395d2eff174438c631592f95b8b32182fab416e2) linux_latest-libre: 18268 -> 18298
* [`cfd5c585`](https://github.com/NixOS/nixpkgs/commit/cfd5c58596a5d38459f0c4245598c21fc63282dc) vimPlugins.crates-nvim: init at 2021-09-03
* [`439c6eb7`](https://github.com/NixOS/nixpkgs/commit/439c6eb770c50277b977e70a8600868c9af705e1) scilla: 20210118 -> 1.1.1
* [`4ad4ae68`](https://github.com/NixOS/nixpkgs/commit/4ad4ae68c427ef8458be34051b4e545eb752811c) salt: 3003.2 -> 3003.3
* [`dbb78328`](https://github.com/NixOS/nixpkgs/commit/dbb78328cff22b32ca401d86d3fb3fe51ff4353c) dalfox: init at 2.4.9
* [`12571055`](https://github.com/NixOS/nixpkgs/commit/12571055cfb2fb32b096d786b9766a76e9f7e93f) gotestwaf: init at 0.3.1
* [`7cfd9fcd`](https://github.com/NixOS/nixpkgs/commit/7cfd9fcd8f61a6c01591988ccb8f884736cd4719) credential-detector: init at 1.7.0
* [`5ca02655`](https://github.com/NixOS/nixpkgs/commit/5ca02655057bb568f09b3aed4acee44e3f805291) libredirect: Add missing phase hooks
* [`0afbd6c8`](https://github.com/NixOS/nixpkgs/commit/0afbd6c86a29160386e5386332b65ba707a25340) libredirect: Enable debug symbols
* [`4961547d`](https://github.com/NixOS/nixpkgs/commit/4961547d05376023fdc7a4664aba4d933d43e7b5) libredirect: Fix redirects not working for subprocesses
* [`e3e971fc`](https://github.com/NixOS/nixpkgs/commit/e3e971fc75054c387e708d23e57d21fbbdc1bbbb) metabigor: init at 1.9
* [`08fee95d`](https://github.com/NixOS/nixpkgs/commit/08fee95dce40525555d902f740da05d2b53091e5) heisenbridge: 1.0.0 -> 1.0.1
* [`bb13c55e`](https://github.com/NixOS/nixpkgs/commit/bb13c55e6c93214e309673fa36540f6b0f9d0e7a) vimPackages: rename nathunsmitty/nvim-ale-diagnostic@main to nathanmsmith/nvim-ale-diagnostic@main
* [`651d7cdc`](https://github.com/NixOS/nixpkgs/commit/651d7cdc19cec611b759a20ed6384017c75a6653) factorio-experimental: 1.1.38 -> 1.1.39
* [`5661f7db`](https://github.com/NixOS/nixpkgs/commit/5661f7dbeeee708a401d2524ddb40374dda4c6a7) llvmPackages_13.compiler-rt: Mark as broken on Aarch64
* [`c5130a62`](https://github.com/NixOS/nixpkgs/commit/c5130a6205c9b89d31b7140f6478fdc9014e06ea) signal-desktop: 5.15.0 -> 5.16.0
* [`062af857`](https://github.com/NixOS/nixpkgs/commit/062af857e33197c550979dc97ca8a7e1ca6242d7) python38Packages.azure-mgmt-compute: 22.1.0 -> 23.0.0
* [`4fe1ffec`](https://github.com/NixOS/nixpkgs/commit/4fe1ffec45d8798b1b92011e28a62a0646ae94d0) python38Packages.dogpile_cache: 1.1.3 -> 1.1.4
* [`c615ff0a`](https://github.com/NixOS/nixpkgs/commit/c615ff0a8ce147db37fdaa7622d85dc7c1cec253) python38Packages.google-re2: 0.2.20210801 -> 0.2.20210901
* [`af0c4eb5`](https://github.com/NixOS/nixpkgs/commit/af0c4eb5eab666bd4c130eb4fc305f5ddf6acd12) python38Packages.elementpath: 2.2.3 -> 2.3.0
* [`cb8e60d3`](https://github.com/NixOS/nixpkgs/commit/cb8e60d31c2f9a9231dc01da25908245616ed62d) python38Packages.mwparserfromhell: 0.6.2 -> 0.6.3
* [`585fe114`](https://github.com/NixOS/nixpkgs/commit/585fe1146f1a6715ddb83b73e6212d3653feec88) python38Packages.cucumber-tag-expressions: 3.0.1 -> 4.0.0
* [`adbd7680`](https://github.com/NixOS/nixpkgs/commit/adbd7680a43ae5e324c01f2655e269e71f979a10) python38Packages.pyacoustid: 1.2.1 -> 1.2.2
* [`dcd65ace`](https://github.com/NixOS/nixpkgs/commit/dcd65ace3c6cbb48511ebc25de5df31cb8483b6a) python38Packages.elasticsearch: 7.14.0 -> 7.14.1
* [`fc5196c2`](https://github.com/NixOS/nixpkgs/commit/fc5196c2f089e1483429aecd8dff56387a444e6b) libredirect: add subprocess test
* [`2a5f23d0`](https://github.com/NixOS/nixpkgs/commit/2a5f23d0e5e4bba82267027d1c6246f05ced7b3b) python38Packages.mechanize: 0.4.5 -> 0.4.6
* [`717cbf8e`](https://github.com/NixOS/nixpkgs/commit/717cbf8e7dcd14d97125cc1176d43c5dabc5c933) python38Packages.eventlet: 0.31.1 -> 0.32.0
* [`9dea9867`](https://github.com/NixOS/nixpkgs/commit/9dea98679d45d22c85ff2fc5d190ebbe5b03d6bc) python38Packages.google-cloud-datacatalog: 3.4.0 -> 3.4.1
* [`1fa84e3e`](https://github.com/NixOS/nixpkgs/commit/1fa84e3e027e8a830f129b58439db7c037530d75) vimPlugins: split doc generation into a hook
* [`c0d30989`](https://github.com/NixOS/nixpkgs/commit/c0d3098932cd51cd55ef9b7bd7e3c8bf6d1aa17f) erlangR24: 24.0.5 -> 24.0.6
* [`57d17c2a`](https://github.com/NixOS/nixpkgs/commit/57d17c2abe0b109a69b1efdfda726204a7eab818) gokart: init at 0.2.0
* [`6c4ac973`](https://github.com/NixOS/nixpkgs/commit/6c4ac973a3d3f8bcc31daf114061a8afdc35bfd9) nmap-formatter: init at 0.2.1
* [`1e548583`](https://github.com/NixOS/nixpkgs/commit/1e548583afc8623702daab75ad447f383b32717f) wrangler: 0.19.1 -> 0.19.2
* [`af406de8`](https://github.com/NixOS/nixpkgs/commit/af406de8b10d378e7bdd955fb3197de6a7fcf525) python38Packages.transitions: 0.8.8 -> 0.8.9
* [`702d1834`](https://github.com/NixOS/nixpkgs/commit/702d1834218e483ab630a3414a47f3a537f94182) lemmy: 0.11.2 -> 0.11.3
* [`3a77817e`](https://github.com/NixOS/nixpkgs/commit/3a77817ee97720d1fe6d780d2ed5fad49b0d5435) gitea: 1.15.0 -> 1.15.2
* [`9232fbdc`](https://github.com/NixOS/nixpkgs/commit/9232fbdc5d6a66c95fd6a2623f06f73513da1ae4) vim-plugins: update
* [`3c836e9a`](https://github.com/NixOS/nixpkgs/commit/3c836e9a822cdfbc7352f918c9bb8a5dbfe8eb5b) python3Packages.markdown-it-py: use pythonImportsCheck instead of pytestImportsCheck
* [`3584ad8d`](https://github.com/NixOS/nixpkgs/commit/3584ad8d5754b74185be2c43c6eb24ea4db90fd8) meilisearch: 0.9.0 -> 0.21.1
* [`0e8d59e3`](https://github.com/NixOS/nixpkgs/commit/0e8d59e3cbb11d1157761890e993d0725483be9d) default-crate-overrides: nixpkgs-fmt
* [`0585c981`](https://github.com/NixOS/nixpkgs/commit/0585c981f11a7bfcef79f386000a8219e819e169) build-rust-crate: nixpkgs-fmt
* [`c9f0c6f1`](https://github.com/NixOS/nixpkgs/commit/c9f0c6f115f4369b5047c3c3086518294541d0bf) build-rust-crate: add global libiconv darwin buildInputs
* [`0f1a3661`](https://github.com/NixOS/nixpkgs/commit/0f1a3661f12b23e066b73909a07e36b60e824893) meilisearch: add wrapper derivation for renaming
* [`d431839a`](https://github.com/NixOS/nixpkgs/commit/d431839ab4494499714f2b6f001413fe380607eb) lima: 0.6.1 -> 0.6.2
* [`8cc6f5fd`](https://github.com/NixOS/nixpkgs/commit/8cc6f5fdd8565fec6f8280675b8565d121de6774) exploitdb: 2021-09-01 -> 2021-09-03
* [`da0626ca`](https://github.com/NixOS/nixpkgs/commit/da0626cad7513b0d2fb603107051edd8a4dc377f) sad: init at 0.4.14
* [`41f7f653`](https://github.com/NixOS/nixpkgs/commit/41f7f6539c912f3280e536bcc18c38d8cc8a46f3) python38Packages.ledgerblue: 0.1.35 -> 0.1.37
* [`cb335144`](https://github.com/NixOS/nixpkgs/commit/cb335144651db48c36eeedf30c497e514482b11e) python38Packages.eth-hash: 0.3.1 -> 0.3.2
* [`81ba8bbd`](https://github.com/NixOS/nixpkgs/commit/81ba8bbd675bc7bd296863a99185843b604e5335) python38Packages.mailmanclient: 3.3.2 -> 3.3.3
* [`a442e572`](https://github.com/NixOS/nixpkgs/commit/a442e572cbc1edf6a53e6684edfd43e1840c35e9) intel-media-driver: 21.3.2 -> 21.3.3
* [`40eae2c9`](https://github.com/NixOS/nixpkgs/commit/40eae2c9159a06bcbdcbd9482b7f66a87dafb6bf) python3Packages.aiolifx: 0.6.10 -> 0.7.0
* [`9cf254c4`](https://github.com/NixOS/nixpkgs/commit/9cf254c40c6fbc559d8ff5007d74c7384b476610) procs: fix completions installation
* [`e0f90f86`](https://github.com/NixOS/nixpkgs/commit/e0f90f86e9e73668efd7c71fe473db4c318d6798) procs: add changelog to meta
* [`5f84dad7`](https://github.com/NixOS/nixpkgs/commit/5f84dad75d24322ffe361a635e76839eee4aaa1f) kak-lsp: 10.0.0 -> 11.0.0
* [`90982af6`](https://github.com/NixOS/nixpkgs/commit/90982af6a14f75b148f98ac6cc09c569b14c0b61) rust-analyzer: 2021-08-23 -> 2021-08-30
* [`dc2ad494`](https://github.com/NixOS/nixpkgs/commit/dc2ad49441526afbbe5942878e9d1fa372f793ad) python3Packages.anyascii: 0.2.0 -> 0.3.0
* [`d68ca993`](https://github.com/NixOS/nixpkgs/commit/d68ca99316080e6d17a1851752b30ebb22f87395) vscode-extensions.viktorqvarfordt.vscode-pitch-black-theme: init at 1.2.4
* [`7c0b350d`](https://github.com/NixOS/nixpkgs/commit/7c0b350d943312fffa10090b5884a2bf5e9d3902) gitleaks: 7.5.0 -> 7.6.0
* [`e01a8047`](https://github.com/NixOS/nixpkgs/commit/e01a8047d532b65d77ef4fdac8620670f1ddd411) python3Packages.surepy: 0.7.0 -> 0.7.1
* [`4fef4315`](https://github.com/NixOS/nixpkgs/commit/4fef4315e8ea3f56b69880298bab7bb7d212b3be) bundler-audit: 0.8.0 → 0.9.0.1
* [`4ebe496b`](https://github.com/NixOS/nixpkgs/commit/4ebe496bad646a9e99f79250f885d7144fe39230) trellis: 2021.07.06 -> 2021-09-01
* [`dd63f999`](https://github.com/NixOS/nixpkgs/commit/dd63f999bd90c678d8ccf1faf3b1ddb3abf3a157) treewide: remove dummy file
* [`5e6a41c4`](https://github.com/NixOS/nixpkgs/commit/5e6a41c43c5153313612197798c9a673ae4a32ab) weechat: 3.2 -> 3.2.1
* [`f04979d6`](https://github.com/NixOS/nixpkgs/commit/f04979d632fde0a200126a0de134550d9bcbb4bc) notejot: 3.1.1 -> 3.1.2
* [`a7bf9ea8`](https://github.com/NixOS/nixpkgs/commit/a7bf9ea8b5e773d9b4f49a7c28d63f636f07e181) grafana: support darwin
* [`d28c708b`](https://github.com/NixOS/nixpkgs/commit/d28c708bc75425eccff806ca975c2d309c00dd18) vimPlugins: rename tami5/sql.lua to tami5/sqlite.lua
* [`da375dee`](https://github.com/NixOS/nixpkgs/commit/da375deef35659edd5fcda57c56334cdd1e66746) vimPlugins: add chr4/sslsecure.vim
* [`eb5dcf81`](https://github.com/NixOS/nixpkgs/commit/eb5dcf8115bde2110620bbe77b161a6bddd49803) vimPlugins: add edkolev/tmuxline.vim
* [`de0b857f`](https://github.com/NixOS/nixpkgs/commit/de0b857f8a9f26e380ed67800db18693e2a0f50b) vimPlugins: add junegunn/vim-emoji
* [`0efb0a67`](https://github.com/NixOS/nixpkgs/commit/0efb0a67f869650673477045e85dc5b3d6447ccd) vimPlugins: add neoclide/jsonc.vim
* [`61f72ef0`](https://github.com/NixOS/nixpkgs/commit/61f72ef0294d347b6e62663d0dca77e2078b3114) vimPlugins: add RobertAudi/securemodelines
* [`f7ebeacf`](https://github.com/NixOS/nixpkgs/commit/f7ebeacf4ab01477b94369685f3785fde983c2ac) vimPlugins: add vim-python/python-syntax
* [`d7b70ffc`](https://github.com/NixOS/nixpkgs/commit/d7b70ffc4d636a7592efd2529f1e5d96f89eb9ea) vim-plugins: add wincent/terminus
* [`287383c6`](https://github.com/NixOS/nixpkgs/commit/287383c61e51b1e11f933550e4a9acfe9d3477c5) emacs.pkgs.bqn-mode: init at unstable-2021-09-04
* [`4a4294d7`](https://github.com/NixOS/nixpkgs/commit/4a4294d74be2c6fdc2041275762a8a1dc7216a0b) vim-plugins.direnv.vim: fix directory for substitution
* [`c879a416`](https://github.com/NixOS/nixpkgs/commit/c879a416bbcf94f2895bc80ec970f8dd2b4f3cf8) super-slicer: 2.3.56.5 -> 2.3.56.8
* [`2837f7a6`](https://github.com/NixOS/nixpkgs/commit/2837f7a6944432c7e38365681859635dd81288dc) python3Packages.deprecated: remove unused tox dependency
* [`96f5319a`](https://github.com/NixOS/nixpkgs/commit/96f5319abb2195c877453696c6a906c0b29df3d3) hck: 0.6.1 -> 0.6.2
* [`2d1908ac`](https://github.com/NixOS/nixpkgs/commit/2d1908ac0b1c32cfa2e793212b9f10d0f7be75ea) xplr: 0.14.5 -> 0.14.7
* [`1b4038bd`](https://github.com/NixOS/nixpkgs/commit/1b4038bddfac009f0eccf516e4874219bfc331d2) linux_zen: 5.13.13-zen1 -> 5.14.1-zen1
* [`d5327b6d`](https://github.com/NixOS/nixpkgs/commit/d5327b6de285eaff4d525daa8203467c990f61db) reddsaver: 0.3.3 -> 0.4.0
* [`4a49353e`](https://github.com/NixOS/nixpkgs/commit/4a49353e9b2bd896c13c826a70dc49686363cb74) rdfind: 1.4.1 -> 1.5.0
* [`e507ca59`](https://github.com/NixOS/nixpkgs/commit/e507ca593330a24f0de49cdeb60d4074e5bb3ab9) timetable: drop package
* [`c32fa3f1`](https://github.com/NixOS/nixpkgs/commit/c32fa3f108532b19b6482078dc10b99f752001f2) intel-gmmlib: add x686-linux to meta.platforms ([nixos/nixpkgs⁠#136738](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/136738))
* [`219d3e43`](https://github.com/NixOS/nixpkgs/commit/219d3e437e55741d7d8e2ce1265ba48b0e05afd0) sasquatch: support cross-compilation
* [`b2480d25`](https://github.com/NixOS/nixpkgs/commit/b2480d258065a34a4d8ee50f3e5e53b4cea8ed9a) qownnotes: 21.7.4 -> 21.8.12 ([nixos/nixpkgs⁠#135941](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135941))
* [`434b9bde`](https://github.com/NixOS/nixpkgs/commit/434b9bde936866887c7fa9f9fa7c080d56e352eb) rdfind: clarify license
* [`29cd399d`](https://github.com/NixOS/nixpkgs/commit/29cd399d805c66510c097fe1f79c142c9ddc504d) python3Packages.python-nomad: add pythonImportsCheck
* [`b85d9176`](https://github.com/NixOS/nixpkgs/commit/b85d91762a73624ce283528d7201a5e0785dd5e6) cramfsprogs: support cross-compilation
* [`4dd783a1`](https://github.com/NixOS/nixpkgs/commit/4dd783a187f71a6735867820233cd50e62f610b3) pax-utils: clarify license
* [`d705ef65`](https://github.com/NixOS/nixpkgs/commit/d705ef6521cfc764d9028d0ab8f51618c37ec69a) sstp: clarify license
* [`420797fe`](https://github.com/NixOS/nixpkgs/commit/420797fe78cef3c38e724492a32230020f37ce42) sstp: rename phase
* [`01920016`](https://github.com/NixOS/nixpkgs/commit/019200160c257bf5cd4880d2501e03c9868ed89b) python3Packages.numpy-stl: use pytestCheckHook
* [`7559cd66`](https://github.com/NixOS/nixpkgs/commit/7559cd66012025da118062d3c8b32dbfc4a9d41e) bamf: 0.5.4 -> 0.5.5
* [`51c4e675`](https://github.com/NixOS/nixpkgs/commit/51c4e675e293a172ad8d3a84ef99497067841601) google-cloud-sdk: add meta.mainProgram ([nixos/nixpkgs⁠#136713](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/136713))
* [`ca6cb24b`](https://github.com/NixOS/nixpkgs/commit/ca6cb24b966832c851c01754e069edfe7bccaa77) foot: 1.8.2 -> 1.9.0
* [`9f98d0df`](https://github.com/NixOS/nixpkgs/commit/9f98d0df442edd8c34898536b57e265ea3969d04) zellij: 0.15.0 -> 0.16.0
* [`39688bfb`](https://github.com/NixOS/nixpkgs/commit/39688bfb41799c5e836128b3126e966ab3585c6c) knot-dns: upstream patch that should fix aarch64-darwin
* [`e0fbad9a`](https://github.com/NixOS/nixpkgs/commit/e0fbad9a66714bcace29ff34e65573e9d6a0bec0) vikunja-frontend: 0.17.0 -> 0.18.0
* [`732316e9`](https://github.com/NixOS/nixpkgs/commit/732316e9c571d17eb039bfecfc3604738bba33ad) vikunja-api: 0.17.1 -> 0.18.0
* [`8666c95a`](https://github.com/NixOS/nixpkgs/commit/8666c95a0e66f91ba3d67d0d31e1c04c2c12035f) grafana: add meta.mainProgram
* [`f1312d51`](https://github.com/NixOS/nixpkgs/commit/f1312d514d0d5d4c2254fb7f8a9a4388a6cd1145) git-cliff: init at 0.2.6
* [`d44b6ae6`](https://github.com/NixOS/nixpkgs/commit/d44b6ae6cb4d262b7281896df6f79fba04b67837) modules/programs/bash: Fix ShellCheck warnings
* [`d8ef13fc`](https://github.com/NixOS/nixpkgs/commit/d8ef13fc13974b1406fd8aa9afd683f91c522052) modules/programs/command-not-found: Fix ShellCheck warnings
* [`85763b63`](https://github.com/NixOS/nixpkgs/commit/85763b63cc24286b11e93ea118dc4195ad511a76) caddy: 2.4.4 -> 2.4.5
* [`5e47a07e`](https://github.com/NixOS/nixpkgs/commit/5e47a07e9f2d7ed999f2c7943b0896f5f7321ca3) pkgs/tracy: fix on Darwin
* [`87c6a8a7`](https://github.com/NixOS/nixpkgs/commit/87c6a8a7066117f547f05fcc678db4119059bbd9) envsubst: drive-by cleanup
