### PR TITLE
niv home-manager: update 61ca2fc1 -> 0dab8137

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61ca2fc1c00a275b8bd61582b23195d60fe0fa40",
-        "sha256": "10pnnpikq9yikvkzfsap172wsi2h207camv1n5myr8f22qmw1vgm",
+        "rev": "0dab813748b86c5bde5fdfebcbce4bc184c93b32",
+        "sha256": "1lsqn2x7z2jq5r5dwmm2wqnb3h405mbjpjrhg5550ws6x9k09jg3",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/61ca2fc1c00a275b8bd61582b23195d60fe0fa40.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/0dab813748b86c5bde5fdfebcbce4bc184c93b32.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@61ca2fc1...0dab8137](https://github.com/nix-community/home-manager/compare/61ca2fc1c00a275b8bd61582b23195d60fe0fa40...0dab813748b86c5bde5fdfebcbce4bc184c93b32)

* [`21a2ff44`](https://github.com/nix-community/home-manager/commit/21a2ff449620a9cb91802f9d1a9157b2ae8c6b39) broot: expose modal option ([nix-community/home-manager⁠#2300](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2300))
* [`bd747c5a`](https://github.com/nix-community/home-manager/commit/bd747c5a53e6f0df368066788be26e9934620bcb) nixos: add timeout to hm-activate service
* [`2952168e`](https://github.com/nix-community/home-manager/commit/2952168ed59aa369a560563de2e00eab19f42d1b) docs: update session-vars info about fish shell
* [`5e46262c`](https://github.com/nix-community/home-manager/commit/5e46262cb1fa888f6f46a675cc2806a23ba9625c) betterlockscreen: add module ([nix-community/home-manager⁠#2292](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2292))
* [`0dab8137`](https://github.com/nix-community/home-manager/commit/0dab813748b86c5bde5fdfebcbce4bc184c93b32) betterlockscreen: limit to platform linux
