### PR TITLE
niv powerlevel10k: update b3b0efb6 -> c5c91783

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "b3b0efb69f5b7817490aa9163ca44b40699b2bcc",
-        "sha256": "1gd616x10dzzbimk414mipwvdnk3lnb9v4y055dkjimdr22w9zyw",
+        "rev": "c5c9178341da88d0d55bad9bb3daa5e90d52411d",
+        "sha256": "1jwxjn8cdx4wvkjhk0pm0lv1vh09qkzw230mlf2hhjykrx1am0bw",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/b3b0efb69f5b7817490aa9163ca44b40699b2bcc.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/c5c9178341da88d0d55bad9bb3daa5e90d52411d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@b3b0efb6...c5c91783](https://github.com/romkatv/powerlevel10k/compare/b3b0efb69f5b7817490aa9163ca44b40699b2bcc...c5c9178341da88d0d55bad9bb3daa5e90d52411d)

* [`2c7241c4`](https://github.com/romkatv/powerlevel10k/commit/2c7241c43de9aa200498e1cd55cf4926de31ffe4) add an extra step to the uninstallation instructions to delete cache files ([romkatv/powerlevel10k⁠#1561](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1561))
* [`b5f4d27c`](https://github.com/romkatv/powerlevel10k/commit/b5f4d27c745a5e678900a6872cd4ef4c0788367a) add a screenshot of vscode font settings
* [`c2c31719`](https://github.com/romkatv/powerlevel10k/commit/c2c3171927639b4da22972cbab817c08954d8d67) extra verbose instructions for vscode font changes
* [`c5c91783`](https://github.com/romkatv/powerlevel10k/commit/c5c9178341da88d0d55bad9bb3daa5e90d52411d) update a link to visual-studio-code-font-settings.jpg (now with annotations)
