### PR TITLE
niv spacemacs: update 59852a6a -> a3b40d23

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "59852a6ab52911ac76bb22aa8642ccef48238349",
-        "sha256": "1fmni45czaab38mh3rc0vpwkdjr0h750ibxdrqvfqq9q1ml8n2jp",
+        "rev": "a3b40d231857747b6e7b00d4c75cd6531e8e3b5f",
+        "sha256": "17klg8hy4n43hs8zd9j2bjmvkxpgpzx7l15b8bpnfpvbq0y4cbrl",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/59852a6ab52911ac76bb22aa8642ccef48238349.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/a3b40d231857747b6e7b00d4c75cd6531e8e3b5f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@59852a6a...a3b40d23](https://github.com/syl20bnr/spacemacs/compare/59852a6ab52911ac76bb22aa8642ccef48238349...a3b40d231857747b6e7b00d4c75cd6531e8e3b5f)

* [`797360a4`](https://github.com/syl20bnr/spacemacs/commit/797360a419ff7d856a6d2a22c677fb8501a7f07d) lsp: add call hierarchy binding ([syl20bnr/spacemacs⁠#15021](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15021))
* [`ed12b111`](https://github.com/syl20bnr/spacemacs/commit/ed12b1118f1e6b3813dfc2a98536f2316524d0d4) ocaml: Allow new OPAM command-line syntax ([syl20bnr/spacemacs⁠#15011](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15011))
* [`3bf2b481`](https://github.com/syl20bnr/spacemacs/commit/3bf2b481a88917cce9faf56f3bf0028e7c3f5e62) [c-c++]: Fix keybinding for organizing includes ([syl20bnr/spacemacs⁠#15029](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15029))
* [`696cfd47`](https://github.com/syl20bnr/spacemacs/commit/696cfd47c110a4dafd447440312841dd93451321) Revert "Fix evil search prompt on mouse leave ([syl20bnr/spacemacs⁠#15002](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15002))"
* [`0ad0e7d3`](https://github.com/syl20bnr/spacemacs/commit/0ad0e7d32873a0851a1dbb6699d8dbcdc300e5fd) c-c++ layer : Added doxygen support and keybindings via gendoxy
* [`4e306e10`](https://github.com/syl20bnr/spacemacs/commit/4e306e10649cf1068674b1fc847117142ee9130c) Make golden-ratio global mode and ediff mode coexist harmoniously ([syl20bnr/spacemacs⁠#15031](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15031))
* [`073fe39b`](https://github.com/syl20bnr/spacemacs/commit/073fe39b3866b1e28fabda5c816c34fa24cba659) latex layer add auto configure pdf-tools and open in split window
* [`b66e60ca`](https://github.com/syl20bnr/spacemacs/commit/b66e60cabb29c07f8d713d1646ccadbd46e4f03e) [latex] Provide more robust version of latex-setup-pdf-tools
* [`ec19d6ac`](https://github.com/syl20bnr/spacemacs/commit/ec19d6ac98664283e6979b2fda3e80b3aec94d22) Fix link
* [`848ae483`](https://github.com/syl20bnr/spacemacs/commit/848ae483730bcfb6f0669c0e80dff5bec2150c2b) Fix another link
* [`f73d6ea9`](https://github.com/syl20bnr/spacemacs/commit/f73d6ea9c7ba6ab9cbdac7a7f1ebd8898f56f568) Add reddit layer
* [`aebb5229`](https://github.com/syl20bnr/spacemacs/commit/aebb522922064c4b8ae157e270c5a35827f7e01c) [reddit] Fix small typos in docs and add dependency to org layer
* [`4ebd512d`](https://github.com/syl20bnr/spacemacs/commit/4ebd512d140f5743ec731ab5147330ccf0e626c4) c-c++: Package cpp-auto-include can be fetched from Melpa ([syl20bnr/spacemacs⁠#15037](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15037))
* [`a3b40d23`](https://github.com/syl20bnr/spacemacs/commit/a3b40d231857747b6e7b00d4c75cd6531e8e3b5f) [bot] "documentation_updates" Sun Sep  5 06:17:34 UTC 2021 ([syl20bnr/spacemacs⁠#15035](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15035))
