### PR TITLE
niv nixpkgs: update 87c6a8a7 -> 10bd2ab8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "87c6a8a7066117f547f05fcc678db4119059bbd9",
-        "sha256": "0zijk00zlad3q9yylzd77ipmxlz1l0j02yna75hn0jkcj0rplm9l",
+        "rev": "10bd2ab8fd18e779d8067f0644cf87c2a7f445c2",
+        "sha256": "1ckgr8iba6a759v3lkd7zcf56z1iyl90mkvcb6yd38gz5y3h078w",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/87c6a8a7066117f547f05fcc678db4119059bbd9.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/10bd2ab8fd18e779d8067f0644cf87c2a7f445c2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@87c6a8a7...10bd2ab8](https://github.com/nixos/nixpkgs/compare/87c6a8a7066117f547f05fcc678db4119059bbd9...10bd2ab8fd18e779d8067f0644cf87c2a7f445c2)

* [`8ac8c33d`](https://github.com/NixOS/nixpkgs/commit/8ac8c33df1723d2384136416248017f5a65e294b) mitmproxy: 6.0.2 -> 7.0.2
* [`3dde4fd3`](https://github.com/NixOS/nixpkgs/commit/3dde4fd38bc51ccf8fc486bb58678007b4e6ee1a) textplots: init at 0.8.0
* [`62cc1f90`](https://github.com/NixOS/nixpkgs/commit/62cc1f90e554a370ddb08b5c8c7bcec619665602) cni-plugin-flannel: init at 20210910 ([nixos/nixpkgs⁠#137412](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137412))
* [`7a9f5d69`](https://github.com/NixOS/nixpkgs/commit/7a9f5d69c88efbf907bbffacaa21fbf159d23284) ncdns: 2020-11-22 -> 2021-07-18
* [`f74154a4`](https://github.com/NixOS/nixpkgs/commit/f74154a4b99e6f0d3e9b381d8f008aa9fe61963d) sc-controller: switch to python3 fork
* [`781766e3`](https://github.com/NixOS/nixpkgs/commit/781766e30cb5726d5558773be3ec70305becb91d) treewide: yank wicd as it is abandoned
* [`d126476d`](https://github.com/NixOS/nixpkgs/commit/d126476d4060d997bfb440d2fa3756eca3feeefa) grpc: add patch to revert alias to abseil mutex
* [`6285fa7f`](https://github.com/NixOS/nixpkgs/commit/6285fa7f9ddf1e76f1b8ca78a55486d2c1f91448) vtk_9: 9.0.1 -> 9.0.3
* [`56f823dd`](https://github.com/NixOS/nixpkgs/commit/56f823dd5c596ef6374f99a22ca63168ff6f6fb9) vimPlugins: shorten rtpPath
* [`82d8e2f0`](https://github.com/NixOS/nixpkgs/commit/82d8e2f0b4f59290b6dd5c7910bde5dc62b54ae6) datadog-integrations-core: git-2018-09-18 -> 7.30.1
* [`f98ae8d5`](https://github.com/NixOS/nixpkgs/commit/f98ae8d59e27205b198631bbce7dc6fda619e9eb) datadog-process-agent: 6.11.1 -> 7.30.2
* [`818cabf5`](https://github.com/NixOS/nixpkgs/commit/818cabf53bc327d43fefe5552261cce6c70b931d) datadog-agent: Don't use invoke during build.
* [`e131d6bf`](https://github.com/NixOS/nixpkgs/commit/e131d6bf5136b72eb4f2019dcedb64a80214c0ee) datadog-agent: Add release note entry.
* [`cdae1d60`](https://github.com/NixOS/nixpkgs/commit/cdae1d60d15491a9fbac877ddff67dfe6d6f1b84) datadog-agent: Add process to default integrations.
* [`a51ee771`](https://github.com/NixOS/nixpkgs/commit/a51ee771bed2449b0afe0f562844da3a5a4330bf) nixos/datadog-agent: Update process collection binary.
* [`b1c57920`](https://github.com/NixOS/nixpkgs/commit/b1c57920f52548fd3069461759883bc2a9cac003) nixos/datadog-agent: Note breaking changes in release notes.
* [`607e3893`](https://github.com/NixOS/nixpkgs/commit/607e389393328623c7c6bb745569550db7346a78) megapixels: 1.2.0 -> 1.3.0
* [`e9c921a3`](https://github.com/NixOS/nixpkgs/commit/e9c921a301f76e4708d6361e5278651244791e35) mudlet: remove unneeded LUA_CPATH
* [`823d0d83`](https://github.com/NixOS/nixpkgs/commit/823d0d835ce789726d8df681c6ba286f04d8998c) vis: simplify thanks to lua update
* [`03806dfe`](https://github.com/NixOS/nixpkgs/commit/03806dfee73c18ce4d55542af46e7af8816a673b) awesome: use a luaEnv
* [`f6cc04fd`](https://github.com/NixOS/nixpkgs/commit/f6cc04fd6576b2c9d1f4cc4d31a2fd0e66a7f99f) astromenace: add meta.mainProgram
* [`2464f7ae`](https://github.com/NixOS/nixpkgs/commit/2464f7ae0a31f002e6b7d5dd96ae09ea9c25553c) mavproxy: 1.8.41 -> 1.8.42
* [`2ce4d216`](https://github.com/NixOS/nixpkgs/commit/2ce4d21663113020195f1d953e360213954645b3) go_1_16: 1.16.7 -> 1.16.8
* [`0b6d33c2`](https://github.com/NixOS/nixpkgs/commit/0b6d33c2ed177be6d937e3043ac77252007a77b1) prosody: simplify lua aspects
* [`88842910`](https://github.com/NixOS/nixpkgs/commit/88842910b52c146bc5ef9c78eed34e5e570ef76c) lua: introduced a lua lib
* [`496b8abf`](https://github.com/NixOS/nixpkgs/commit/496b8abf789b891f5355ea2265416e5121855308) Apply suggestions from code review
* [`b9797768`](https://github.com/NixOS/nixpkgs/commit/b97977681eec4233bcc0428ccdd93a038f810ebf) lua: add LUA_PATH changes to release notes
* [`623aa314`](https://github.com/NixOS/nixpkgs/commit/623aa314dd27f186bf3edc2e02445c359ade9604) bochs: Enable VT-x/VMX emulation
* [`7fb52b13`](https://github.com/NixOS/nixpkgs/commit/7fb52b1325a383b7bd83aa2552f6d9d57106d241) nixos: nixos/doc/manual/installation/installing.xml to CommonMark
* [`72dd18cc`](https://github.com/NixOS/nixpkgs/commit/72dd18cc55f5097d3a0ae808125dc74155891e72) python38Packages.scp: 0.13.6 -> 0.14.0
* [`a8bd9dcd`](https://github.com/NixOS/nixpkgs/commit/a8bd9dcd7c0d2fbbfdedf89a4359959793f15e25) cni-plugin-flannel: move to flannel directory
* [`07109dd4`](https://github.com/NixOS/nixpkgs/commit/07109dd495bd3e8b6ef39d737d93b7e721b06ff3) nixos/kubernetes: add cni-plugin-flannel to kubelet.cni.packages
* [`022c300d`](https://github.com/NixOS/nixpkgs/commit/022c300df10d5e90ea9738441fd3d978b80596e5) quill: 0.2.4 -> 0.2.5
* [`117a1b97`](https://github.com/NixOS/nixpkgs/commit/117a1b97458ba5c43b4c0187ef2fdfa1e8b21ed2) klipper: unstable-2021-07-15 -> unstable-2021-09-03
* [`9e90a400`](https://github.com/NixOS/nixpkgs/commit/9e90a400a576da61e7a75d5cf1159e478a68ef04) lib.generators.toGitINI: don't traverse derivations
* [`f882fbce`](https://github.com/NixOS/nixpkgs/commit/f882fbcee0b076fd6f964643af9d5ae690c610c7) lib.generators.toINI: serialize derivations to string
* [`11fa1732`](https://github.com/NixOS/nixpkgs/commit/11fa1732bb87a4fab407db02737a3d640eb508cf) kodiPackages.inputstreamhelper: 0.5.5+matrix.1 -> 0.5.8+matrix.1
* [`d0eca54c`](https://github.com/NixOS/nixpkgs/commit/d0eca54c81370cdb9bd7e8c68fb9ba2f002f5b21) kodiPackages.youtube: 6.8.14+matrix.1 -> 6.8.17+matrix.1
* [`80ab542a`](https://github.com/NixOS/nixpkgs/commit/80ab542af868455cda81718e134d726dc8348e76) steam: fix steamwebhelper
* [`be5e48ac`](https://github.com/NixOS/nixpkgs/commit/be5e48ac7e40ba2223d77301941b88315717df03) libnma: 1.8.30 -> 1.8.32
* [`0fc38b1e`](https://github.com/NixOS/nixpkgs/commit/0fc38b1eb2aa6e3c5d2d60135e280e4d3f6d87ca) libsigcxx30: 3.0.6 -> 3.0.7
* [`03d20cbc`](https://github.com/NixOS/nixpkgs/commit/03d20cbced6d28aa299c280d42147af434b19ad7) matrix-synapse-plugins.matrix-synapse-ldap3: 0.1.4 -> 0.1.5
* [`f095deec`](https://github.com/NixOS/nixpkgs/commit/f095deec649195d6f37378da4d8461dd0955bdf9) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 0.1.17 -> 0.1.19
* [`65fb0203`](https://github.com/NixOS/nixpkgs/commit/65fb0203850fe824763f545e72dfef420a08295c) mm-common: 1.0.2 -> 1.0.3
* [`72d984d2`](https://github.com/NixOS/nixpkgs/commit/72d984d20e28666214349fa197712dc951d4314c) moonraker: unstable-2021-07-18 -> unstable-2021-09-04
* [`6bc05449`](https://github.com/NixOS/nixpkgs/commit/6bc0544998096343b8b4917c22295894bfb35d80) nextcloud-news-updater: 10.0.1 -> 11.0.0
* [`365a8fb5`](https://github.com/NixOS/nixpkgs/commit/365a8fb5f9316271b5499702fbe49eadc81f0b8c) nncp: 7.6.0 -> 7.7.0
* [`252edd9d`](https://github.com/NixOS/nixpkgs/commit/252edd9d164240b6e40f978e830216d20857856f) obsidian: 0.12.12 -> 0.12.15
* [`6d1ece38`](https://github.com/NixOS/nixpkgs/commit/6d1ece3818fb70aa64856d9d24bb39b5546fed67) octant: 0.23.0 -> 0.24.0
* [`a7b1e14a`](https://github.com/NixOS/nixpkgs/commit/a7b1e14af9f7d57a9773549d6902d7e119340014) wine{Unstable,Staging}: 6.16 -> 6.17
* [`151fd8a6`](https://github.com/NixOS/nixpkgs/commit/151fd8a64cf66473b0007f204d7a2fc4a9e804a2) maintainers: add x3ro
* [`f6211582`](https://github.com/NixOS/nixpkgs/commit/f6211582a16c535700178921200247bc59b4e81e) linux-router: init at 0.6.2
* [`6fb71e46`](https://github.com/NixOS/nixpkgs/commit/6fb71e46ca0b38e3d8a1bcc37f795fef8c4b8873) sysdig: fix linking against libabseil
* [`fba1e377`](https://github.com/NixOS/nixpkgs/commit/fba1e37757b55c2ebdb5ff9066377af51e6c1d1c) python3Packages.mutf8: 1.0.4 -> 1.0.5
* [`e2e065ab`](https://github.com/NixOS/nixpkgs/commit/e2e065ab538889f5de2c190786a418f54cffefff) nuclei: 2.5.0 -> 2.5.1
* [`75eaccdc`](https://github.com/NixOS/nixpkgs/commit/75eaccdcbc79f908902638bbea4aef33ebdad712) wiki-js: 2.5.201 -> 2.5.214
* [`036c82cc`](https://github.com/NixOS/nixpkgs/commit/036c82cca19779ba4ff7abf085226d606e085a12) libvirt: fix tarball hash
* [`15fdbbe4`](https://github.com/NixOS/nixpkgs/commit/15fdbbe4e9742fe81fdabc6867f34480983e2cb9) python38Packages.relatorio: 0.9.3 -> 0.10.0
* [`fd9a52c4`](https://github.com/NixOS/nixpkgs/commit/fd9a52c466e03a19f8d88a607ea122d7376a28d8) unpackerr: 0.9.7 -> 0.9.8
* [`8112bb92`](https://github.com/NixOS/nixpkgs/commit/8112bb92f9df718eaa077ec77109eecc60240a72) eduke32: implement proper macOS support
* [`acdec49e`](https://github.com/NixOS/nixpkgs/commit/acdec49e965b9556bcb89e0ce3fec844a2cff469) eduke32: 20210722 -> 20210910
* [`c5513615`](https://github.com/NixOS/nixpkgs/commit/c5513615310ed4a24e7d7ec1722ea6893eae4d9f) blocksat-cli: 0.3.2 -> 0.4.0
* [`71348196`](https://github.com/NixOS/nixpkgs/commit/71348196a0aa2ca74487c7f8e24a02aad5ae42ab) linux: 5.10.63 -> 5.10.64
* [`f0878c65`](https://github.com/NixOS/nixpkgs/commit/f0878c65eb8824957a2eabb863cefac5b09df3b3) linux: 5.13.15 -> 5.13.16
* [`b81ac243`](https://github.com/NixOS/nixpkgs/commit/b81ac24356c60e63c7daccedf278c500f1ca5179) linux: 5.14.2 -> 5.14.3
* [`be590b86`](https://github.com/NixOS/nixpkgs/commit/be590b86e26f9144e7c2719650c57772bb797ed9) linux: 5.4.144 -> 5.4.145
* [`5698fc0d`](https://github.com/NixOS/nixpkgs/commit/5698fc0dfc669166371b07a12ed6908696b2776c) linux-rt_5_4: 5.4.143-rt63 -> 5.4.143-rt64
* [`e4a49641`](https://github.com/NixOS/nixpkgs/commit/e4a49641ae4e0a06062c973891ed54fddf3b9e04) openems: fix eval
* [`1dc56f1d`](https://github.com/NixOS/nixpkgs/commit/1dc56f1dc81ac409acab530266f8101c3e078dca) quakespasm: add SDL2 support; add Darwin support
* [`1d8bdf53`](https://github.com/NixOS/nixpkgs/commit/1d8bdf5389d49ba7216dd20bb7245ebb5208329d) stuntman: init at 1.2.16
* [`d279bf97`](https://github.com/NixOS/nixpkgs/commit/d279bf976744ba6a48144909a7214ddaef6c9cd0) taskopen: modernize
* [`688b9b65`](https://github.com/NixOS/nixpkgs/commit/688b9b65cb95a7d0bd65d09acfbe249f95a8a024) hubble: init at 0.8.2
* [`6ab20337`](https://github.com/NixOS/nixpkgs/commit/6ab2033765f409f0c65511c86bbc6e20d9bbca4e) quakespasm: 0.93.2 -> 0.94.1
* [`f460ae5a`](https://github.com/NixOS/nixpkgs/commit/f460ae5aaa2f08efaff6f43a5e88b4b546427b8e) notejot: 3.1.2 -> 3.1.5
* [`1cee7f6c`](https://github.com/NixOS/nixpkgs/commit/1cee7f6cf43612e1ee72d41201366c48275b5b8c) v2ray: 4.41.1 -> 4.42.1
* [`2b022a97`](https://github.com/NixOS/nixpkgs/commit/2b022a979ab40832bf35442fe5a5e5466e97619e) zsh-fzf-tab: Support darwin platform ([nixos/nixpkgs⁠#137514](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137514))
* [`b0403854`](https://github.com/NixOS/nixpkgs/commit/b04038541242bdbe0891fc42a7b215cd02519f48) flynt: init at 0.66 ([nixos/nixpkgs⁠#137177](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137177))
* [`7f22c185`](https://github.com/NixOS/nixpkgs/commit/7f22c1851fd1baa3b9149f3b6202f6350324e943) gnuplot: Allow compiling with libcaca ([nixos/nixpkgs⁠#137523](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137523))
* [`a51701e3`](https://github.com/NixOS/nixpkgs/commit/a51701e3f318377ad743d97e0a9b53d9b8ba45b0) android-backup-extractor: init at 20210909062443-4c55371 ([nixos/nixpkgs⁠#137516](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137516))
* [`06a94f6d`](https://github.com/NixOS/nixpkgs/commit/06a94f6d6317bc6ff2e712e643b1050e26a1c89d) python38Packages.pex: 2.1.48 -> 2.1.49
* [`e3cf7c1a`](https://github.com/NixOS/nixpkgs/commit/e3cf7c1a909ca3e572401ea615203eccbbfa6fdb) gnuk: switch to python3
* [`9ef79a5f`](https://github.com/NixOS/nixpkgs/commit/9ef79a5f128518f3cf0c46439816daa0c4634587) gmailctl: 0.8.0 -> 0.9.0
* [`119c9e1f`](https://github.com/NixOS/nixpkgs/commit/119c9e1f700c05cb98451db2359e08cf87cdd5e5) nixos/rabbitmq: clean-up after f091420c1d194ad398142959266f18493da1ff83
* [`a88557ec`](https://github.com/NixOS/nixpkgs/commit/a88557ec5f52ee5270978899e4a7e887f49861fc) gitstatus: 1.5.2 -> 1.5.3
* [`12259ba1`](https://github.com/NixOS/nixpkgs/commit/12259ba1b4e948e3b441d32064912c6ea727fb8e) yambar: 1.6.2 -> 1.7.0
* [`d94bd5c5`](https://github.com/NixOS/nixpkgs/commit/d94bd5c599fb225591786a45fb89b081a1189d85) svtplay-dl: 4.2 -> 4.3
* [`6f2ce2a6`](https://github.com/NixOS/nixpkgs/commit/6f2ce2a65e33ca00c5cb7f32b7ee871b05d66735) treewide: remove danieldk as maintainer from a set of packages
* [`ba1b9152`](https://github.com/NixOS/nixpkgs/commit/ba1b9152c367785618c05f5a8aa04be540e89d35) python38Packages.numcodecs: 0.9.0 -> 0.9.1
* [`ff8e690f`](https://github.com/NixOS/nixpkgs/commit/ff8e690f97e80382b2d13676e45e9ca395c3c75d) python39Packages.setuptools-rust: adopt
* [`7ed75bfa`](https://github.com/NixOS/nixpkgs/commit/7ed75bfa955eb309287f97b0a928acfe803f4863) clojure-lsp: 2021.07.12-12.30.59 -> 2021.09.04-17.11.44
* [`1c490409`](https://github.com/NixOS/nixpkgs/commit/1c4904092b2d824256ebba20cc9b7ba9c941e18a) neovim.tests: test vim-plug too
* [`354b1864`](https://github.com/NixOS/nixpkgs/commit/354b1864025c8f70c976ade3f3af99f792d7bd08) vimUtils.vimGenDocHook: dont copy the folder (again)
* [`55130d56`](https://github.com/NixOS/nixpkgs/commit/55130d56aa950cda73f61f51686703507e21ffe5) watson: use packageOverrides
* [`4b0699e5`](https://github.com/NixOS/nixpkgs/commit/4b0699e5d034890388c3a42ee871c788b3427a53) linux_xanmod: 5.13.13 -> 5.14.3
* [`271b6edb`](https://github.com/NixOS/nixpkgs/commit/271b6edba253bba11f331de5c00ec72d84877c62) corrscope: Fix ffmpeg package to ffmpeg-full
* [`d5540fa1`](https://github.com/NixOS/nixpkgs/commit/d5540fa18f9bc7e914e9b48d462c5cddfc7fb013) telfhash: unstable-2021-01-29 -> 0.9.8 ([nixos/nixpkgs⁠#137305](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137305))
* [`21ca66be`](https://github.com/NixOS/nixpkgs/commit/21ca66bef063c4da0bf74ec3c148ebf1508aaaf3) gvm-libs: 21.4.1 -> 21.4.2
* [`06971f97`](https://github.com/NixOS/nixpkgs/commit/06971f9777d3355b8942459babe59a7be6a64a3b) libnbd: 1.9.3 -> 1.9.5
* [`c1fe8aea`](https://github.com/NixOS/nixpkgs/commit/c1fe8aea8f501d88f459d9cdeb5d3f42757776c8) signal-cli: 0.8.5 -> 0.9.0
* [`0d557fce`](https://github.com/NixOS/nixpkgs/commit/0d557fce7db59364995ddb9b372d3961ccb90b5e) venta: 2020-08-20 -> 0.6
* [`130479b1`](https://github.com/NixOS/nixpkgs/commit/130479b12c57cabcf9f0a982340aea00bb418fac) vimPlugins: update
* [`55afd072`](https://github.com/NixOS/nixpkgs/commit/55afd0721b3b77597bcf789949f8a275dccff4aa) vimPlugins.cmp-latex-symbols: init at 2021-09-10
* [`baf7b4c0`](https://github.com/NixOS/nixpkgs/commit/baf7b4c03835206ef18899390790f1807c17cafe) vimPlugins.cmp-spell: init at 2021-08-28
* [`b81849da`](https://github.com/NixOS/nixpkgs/commit/b81849da3ae8afa360fbef50c37175eb56b5efb7) vimPlugins.cmp-treesitter: init at 2021-09-11
* [`10f63bef`](https://github.com/NixOS/nixpkgs/commit/10f63bef0c2ceaeb9717d4702ba72f32fe5b1cd5) vimPlugins.orgmode-nvim: init at 2021-09-10
* [`2444c114`](https://github.com/NixOS/nixpkgs/commit/2444c11431a37e04de025b63f6a12bdd05d2f4c1) nixos/kernel: add 5.14 to kernel test-suite
* [`7f08f7de`](https://github.com/NixOS/nixpkgs/commit/7f08f7de7bb370772d366fab451cfb5dafc8b3f0) whitesur-icon-theme: 20210520 -> 20210826
* [`2f73bd77`](https://github.com/NixOS/nixpkgs/commit/2f73bd77ed034e1a565920a1d52fb585a6ec7aa2) vimPlugins.sqlite-lua: fix postPatch substituting nonexistent file
* [`88a8d1df`](https://github.com/NixOS/nixpkgs/commit/88a8d1df0a0bfc33e537f570c7f8f787a594a410) openshot-qt: 2.6.0 -> 2.6.1
* [`c07ae7fe`](https://github.com/NixOS/nixpkgs/commit/c07ae7fe519331f184a18413b3aa946db9f67023) opentabletdriver: 0.5.3.2 -> 0.5.3.3
* [`81439e71`](https://github.com/NixOS/nixpkgs/commit/81439e7178f7a545dd6d1b6ff3427ca986d1c89c) php74Extensions.blackfire: 1.53.0 -> 1.66.0
* [`5e44271c`](https://github.com/NixOS/nixpkgs/commit/5e44271c07b359c082cfa1d8ad572f88b28c50b7) bottom: 0.6.3 -> 0.6.4
* [`86b4033b`](https://github.com/NixOS/nixpkgs/commit/86b4033b23d2cd892d11982ceb6337c5c3a9b362) gnome.gnome-initial-setup: 40.3 -> 40.4
