### PR TITLE
niv home-manager: update 0dab8137 -> 5199bc84

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0dab813748b86c5bde5fdfebcbce4bc184c93b32",
-        "sha256": "1lsqn2x7z2jq5r5dwmm2wqnb3h405mbjpjrhg5550ws6x9k09jg3",
+        "rev": "5199bc841aa9ebafc567a1f5c498682650f68973",
+        "sha256": "03m1z2fv6a94pj9513lj6gvzalj21y40wkr02a3yannjka4kp6vy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/0dab813748b86c5bde5fdfebcbce4bc184c93b32.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/5199bc841aa9ebafc567a1f5c498682650f68973.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@0dab8137...5199bc84](https://github.com/nix-community/home-manager/compare/0dab813748b86c5bde5fdfebcbce4bc184c93b32...5199bc841aa9ebafc567a1f5c498682650f68973)

* [`275f3961`](https://github.com/nix-community/home-manager/commit/275f39611dc32243842d5818141278b5676653f2) generic-linux: add system fpaths for zsh
* [`039f786e`](https://github.com/nix-community/home-manager/commit/039f786e609fdb3cfd9c5520ff3791750c3eaebf) fnott: refactor module
* [`208e310e`](https://github.com/nix-community/home-manager/commit/208e310e9409d0d54ae5e19cb52f8d0f3c7f4771) bash: allow unsetting shell options
* [`5199bc84`](https://github.com/nix-community/home-manager/commit/5199bc841aa9ebafc567a1f5c498682650f68973) ci: bump cachix/install-nix-action from 13 to 14
