### PR TITLE
niv powerlevel10k: update c5c91783 -> 543e2d59

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "c5c9178341da88d0d55bad9bb3daa5e90d52411d",
-        "sha256": "1jwxjn8cdx4wvkjhk0pm0lv1vh09qkzw230mlf2hhjykrx1am0bw",
+        "rev": "543e2d59cf107af4e96727aa70d9f1ca93149f14",
+        "sha256": "1ic8wynyrzgw95q0v37k7jd62ipi31nzvmkr98h9iya6h7g1i8iw",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/c5c9178341da88d0d55bad9bb3daa5e90d52411d.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/543e2d59cf107af4e96727aa70d9f1ca93149f14.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@c5c91783...543e2d59](https://github.com/romkatv/powerlevel10k/compare/c5c9178341da88d0d55bad9bb3daa5e90d52411d...543e2d59cf107af4e96727aa70d9f1ca93149f14)

* [`4f3d2ffe`](https://github.com/romkatv/powerlevel10k/commit/4f3d2ffe7251a17aa10e00ed30d55f6fd9d65002) new prompt segment: toolbox (https://github.com/containers/toolbox) [romkatv/powerlevel10k⁠#1560](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1560)
* [`20eb8c64`](https://github.com/romkatv/powerlevel10k/commit/20eb8c64bf2520e20739610acb503c8729867a5e) Squashed 'gitstatus/' changes from edd92f621..cd98a3c28
* [`07455928`](https://github.com/romkatv/powerlevel10k/commit/0745592886e778b50c299ff8a267529848b29407) fix a spello in comments in the generated .p10k.zsh
* [`543e2d59`](https://github.com/romkatv/powerlevel10k/commit/543e2d59cf107af4e96727aa70d9f1ca93149f14) change formatting in the font installation instructions to make it more obvious where each step begins and ends
