### PR TITLE
niv spacemacs: update a3b40d23 -> 663cfc5b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "a3b40d231857747b6e7b00d4c75cd6531e8e3b5f",
-        "sha256": "17klg8hy4n43hs8zd9j2bjmvkxpgpzx7l15b8bpnfpvbq0y4cbrl",
+        "rev": "663cfc5ba7826dd20d18fe5c1f8fb09338284955",
+        "sha256": "16qnz7nvp712gph1wwgznpk1bia4rggq3flr89ps0b26b95yhcww",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/a3b40d231857747b6e7b00d4c75cd6531e8e3b5f.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/663cfc5ba7826dd20d18fe5c1f8fb09338284955.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@a3b40d23...663cfc5b](https://github.com/syl20bnr/spacemacs/compare/a3b40d231857747b6e7b00d4c75cd6531e8e3b5f...663cfc5ba7826dd20d18fe5c1f8fb09338284955)

* [`1e79c362`](https://github.com/syl20bnr/spacemacs/commit/1e79c362668079fa8916826d0a415d5bf9f18c8e) README: fix macOS prerequisites regarding grep ([syl20bnr/spacemacs⁠#15038](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15038))
* [`6b9ec10c`](https://github.com/syl20bnr/spacemacs/commit/6b9ec10c74cf20e156d2f8b60d0ddad76391f204) Implement inspector package to emacs-lisp layer see [syl20bnr/spacemacs⁠#15039](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15039)
* [`2fc428d5`](https://github.com/syl20bnr/spacemacs/commit/2fc428d5279224e0586acc7a9a7ead3e0b360975) [elisp] Fix small typo in README
* [`785035cc`](https://github.com/syl20bnr/spacemacs/commit/785035cc285c5b30405953d0d32a693e5b36e95f) Warn user they are reading develop docs ([syl20bnr/spacemacs⁠#14136](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14136))
* [`8e5b4c7e`](https://github.com/syl20bnr/spacemacs/commit/8e5b4c7ec30d60da06577910fa184106f3cd0d3b) [core] Reformat core-documentation.el
* [`f928c32e`](https://github.com/syl20bnr/spacemacs/commit/f928c32eecd5689be299dff179809917bbcba062) vc: use smerge-vc-next-conflict instead of smerge-next
* [`e5a180e7`](https://github.com/syl20bnr/spacemacs/commit/e5a180e78d4b3bbd9685193588ea41ca97c256d0) [vc] Make smerge ts use emacs version specific functions
* [`b5aea561`](https://github.com/syl20bnr/spacemacs/commit/b5aea5610e1923bdf69b3432a1dccc4a2e816f74) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15042](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15042))
* [`acea3324`](https://github.com/syl20bnr/spacemacs/commit/acea332435d1d9cab8be43f649919fa52b35069f) Move known temporary files of LSP into `spacemacs-cache-directory`.
* [`e67caf84`](https://github.com/syl20bnr/spacemacs/commit/e67caf84868351f5cb5429ef4f22283ecde31f06) [lsp] Revise lsp layer's create temp files in cache folder feature
* [`b5d3cf96`](https://github.com/syl20bnr/spacemacs/commit/b5d3cf96784ba80d05c32701284052d3c4389ab8) Add .leex support for the html layer
* [`42868141`](https://github.com/syl20bnr/spacemacs/commit/42868141dad2fe973649bd43a658f03a2f23e2c6) [lsp] Fix void variable error during startup
* [`3c7956ce`](https://github.com/syl20bnr/spacemacs/commit/3c7956ced7363b205a233250c2743b339726dfd2) [html] Make leex support optional
* [`5ce60dfd`](https://github.com/syl20bnr/spacemacs/commit/5ce60dfdf76331c1600cf7a6710467e739c437b7) Add djvu layer
* [`7f43d9cf`](https://github.com/syl20bnr/spacemacs/commit/7f43d9cf6d508285e5ed3df0a4ce24180ac78465) [djvu] Fix docs and prefixes
* [`0cc5a554`](https://github.com/syl20bnr/spacemacs/commit/0cc5a554af78f5812920787405e07f49427d0101) Add lobsters layer
* [`16f976c7`](https://github.com/syl20bnr/spacemacs/commit/16f976c713a461c4ebf6983097fcb9e1c87a0857) [lobsters] Revise package.el
* [`17b59348`](https://github.com/syl20bnr/spacemacs/commit/17b59348f781d8d18d96fff288b1ed4b6331279d) Add hackernews layer
* [`39da3fc4`](https://github.com/syl20bnr/spacemacs/commit/39da3fc4a0b72247046ed3d24ca816ee439a0b61) [hackernews] Revise layer
* [`069fa875`](https://github.com/syl20bnr/spacemacs/commit/069fa87583456dbcf8d3b4c2e414b98ef51e8787) Add streamlink layer
* [`d9fde24a`](https://github.com/syl20bnr/spacemacs/commit/d9fde24ae186e593ea9572fc7313b6f5e30be50e) [streamlink] Revise layer
* [`06cfd272`](https://github.com/syl20bnr/spacemacs/commit/06cfd27276f1e376b4f7eb20d80d1c83ef9dfb27) Add twitch layer
* [`471b6939`](https://github.com/syl20bnr/spacemacs/commit/471b6939c8c5235fafd87382ab5ebb1353a8d54a) [twitch] Revise layer
* [`7f00715b`](https://github.com/syl20bnr/spacemacs/commit/7f00715b143df8381973931428f07735d8da99f1) [docs] fix link
* [`663cfc5b`](https://github.com/syl20bnr/spacemacs/commit/663cfc5ba7826dd20d18fe5c1f8fb09338284955) [bot] "documentation_updates" Sat Sep 11 22:58:39 UTC 2021
