### PR TITLE
niv nixpkgs: update 10bd2ab8 -> da01cce1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10bd2ab8fd18e779d8067f0644cf87c2a7f445c2",
-        "sha256": "1ckgr8iba6a759v3lkd7zcf56z1iyl90mkvcb6yd38gz5y3h078w",
+        "rev": "da01cce16d9c8ef64b19d89d58839cb53718f2e3",
+        "sha256": "0n77b4dvjz5zwk6lwydzs1p82xvypcnymnbhwd1lcjgyzl2wbs1i",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/10bd2ab8fd18e779d8067f0644cf87c2a7f445c2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/da01cce16d9c8ef64b19d89d58839cb53718f2e3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@10bd2ab8...da01cce1](https://github.com/nixos/nixpkgs/compare/10bd2ab8fd18e779d8067f0644cf87c2a7f445c2...da01cce16d9c8ef64b19d89d58839cb53718f2e3)

* [`e654bff6`](https://github.com/NixOS/nixpkgs/commit/e654bff699efca52d212d56e60536260ca52c528) pantheon.wingpanel-indicator-network: 2.2.4 -> 2.3.0
* [`66f99d3b`](https://github.com/NixOS/nixpkgs/commit/66f99d3b61a5b852ec0b729df55cd687be417c91) pantheon.wingpanel-indicator-nightlight: 2.0.4 -> 2.1.0
* [`13d1f3a0`](https://github.com/NixOS/nixpkgs/commit/13d1f3a08fa213445aed7e405c654435ca45a69c) pantheon.wingpanel-indicator-notifications: 2.1.4 -> 6.0.0
* [`243f51d3`](https://github.com/NixOS/nixpkgs/commit/243f51d34a0815e08ce0c4e522977294e835d3ac) pantheon.wingpanel-indicator-power: 2.2.0 -> 6.1.0
* [`aeeed28b`](https://github.com/NixOS/nixpkgs/commit/aeeed28b6e1b80a3b841d921c7c58c1f08b22a22) pantheon.wingpanel-indicator-session: unstable-2020-09-13 -> 2.3.0
* [`798cc01d`](https://github.com/NixOS/nixpkgs/commit/798cc01d0c0834c2a2c3b923ff07917edb5703da) pantheon.wingpanel-indicator-sound: 2.1.6 -> 6.0.0
* [`634488aa`](https://github.com/NixOS/nixpkgs/commit/634488aa608c863fa54eaaa232024856bc3463dd) gnome.mutter338: 3.34.6 -> 3.38.6
* [`75473c2d`](https://github.com/NixOS/nixpkgs/commit/75473c2d7002b08e53d437f6f88c8975721834e2) gnome.gnome-settings-daemon338: init at 3.38.2
* [`ceedbf92`](https://github.com/NixOS/nixpkgs/commit/ceedbf92c095f2d1943b966f0816a5e85bd82b9a) pantheon.gala: 3.3.2 -> 6.0.1
* [`79737143`](https://github.com/NixOS/nixpkgs/commit/7973714304f012f5ad3a991c2cdec0a8a9d6e7ac) pantheon.elementary-dpms-helper: drop package
* [`834e7ea0`](https://github.com/NixOS/nixpkgs/commit/834e7ea022758eeb86115d4ac9b2af65dd0ba8de) pantheon.elementary-gtk-theme: 5.4.2 -> 6.0.0
* [`0b44eae0`](https://github.com/NixOS/nixpkgs/commit/0b44eae0ab4c96e18693287fcfc543176e09e5c7) pantheon.elementary-wallpapers: 5.5.0 -> 6.0.0
* [`f7103f89`](https://github.com/NixOS/nixpkgs/commit/f7103f89272d760e3f22d969dd0b46da4388b933) pantheon.elementary-greeter: 5.0.4 -> 6.0.0
* [`03a059f6`](https://github.com/NixOS/nixpkgs/commit/03a059f60744020ad5cf593f8855c8ebf6932a7a) pantheon.elementary-default-settings: 5.1.2 -> 6.0.1
* [`990ba078`](https://github.com/NixOS/nixpkgs/commit/990ba0785541a7a67c069a1fdbb7be7d1101090a) pantheon.elementary-session-settings: unstable-2020-07-06 -> 6.0.0
* [`891f943c`](https://github.com/NixOS/nixpkgs/commit/891f943c126815f858294ad12e2c876b259e6a74) pantheon.elementary-onboarding: 1.2.1 -> 6.0.0
* [`88b3b9d8`](https://github.com/NixOS/nixpkgs/commit/88b3b9d84756245147a4f20d22816195c7b484c1) pantheon.elementary-shortcut-overlay: 1.1.2 -> 1.2.0
* [`a3b7f0cd`](https://github.com/NixOS/nixpkgs/commit/a3b7f0cd349ded83bc548b3970aaf88601dde91d) pantheon.contractor: 0.3.4 -> 0.3.5
* [`c7b59807`](https://github.com/NixOS/nixpkgs/commit/c7b5980740d0192d220d7547bd8a96e300b43ce4) pantheon.elementary-capnet-assist: 2.2.5 -> 2.3.0
* [`4f1ecaf4`](https://github.com/NixOS/nixpkgs/commit/4f1ecaf481e4c5bf8e3fa5990e07037a13c2283d) pantheon.elementary-notifications: unstable-2020-03-31 -> 6.0.0
* [`df45f3fc`](https://github.com/NixOS/nixpkgs/commit/df45f3fc469a876f5f33f508c65ffba975f30638) pantheon.pantheon-agent-geoclue2: 1.0.4 -> 1.0.5
* [`2a11a3f6`](https://github.com/NixOS/nixpkgs/commit/2a11a3f6845e3b884049988406469b8ae4fd3b67) pantheon.pantheon-agent-polkit: 1.0.3 -> 1.0.4
* [`25070d7d`](https://github.com/NixOS/nixpkgs/commit/25070d7d69bd503c27a565e2970922ef12b14861) pantheon.sideload: 1.1.1 -> 6.0.1
* [`a13fd377`](https://github.com/NixOS/nixpkgs/commit/a13fd37777bc051dd71944e04d8de7b7649dc02b) pantheon.elementary-dock: unstable-2020-06-11 -> unstable-2021-07-16
* [`e9facd8a`](https://github.com/NixOS/nixpkgs/commit/e9facd8a4617897f4dc772b01459aed5d8610e9a) pantheon.elementary-music: 5.1.0 -> 5.1.1
* [`1558d9c1`](https://github.com/NixOS/nixpkgs/commit/1558d9c17ba53652cb779298c9bde9e00a7c754c) pantheon.elementary-settings-daemon: reinit at 1.0.0
* [`a94ae9d2`](https://github.com/NixOS/nixpkgs/commit/a94ae9d223b2cb6430f96940404ab56805b71535) pantheon.elementary-gsettings-desktop-schemas: fix build
* [`9a630f47`](https://github.com/NixOS/nixpkgs/commit/9a630f47d8dcb543a11f273e5a37c2861497ff33) pantheon.elementary-camera: 1.0.6 -> 6.0.0
* [`3da8bb4e`](https://github.com/NixOS/nixpkgs/commit/3da8bb4e3a8836ca53396f52ac92998992a476e2) pantheon.elementary-tasks: init at 6.0.3
* [`91073bc8`](https://github.com/NixOS/nixpkgs/commit/91073bc810e1606a116b96c4f59c57ad7c2777f0) pantheon.elementary-screenshot: 1.7.1 -> 6.0.0
* [`2cc74a21`](https://github.com/NixOS/nixpkgs/commit/2cc74a2106038356daee39062bb8b1cf0c55d488) pantheon.elementary-calendar: 5.1.1 -> 6.0.1
* [`de73ad25`](https://github.com/NixOS/nixpkgs/commit/de73ad2567a4f445ea46b30b51ab86aa191e92e3) pantheon.elementary-files: 4.5.0 -> 6.0.2
* [`55236341`](https://github.com/NixOS/nixpkgs/commit/5523634193c79ccb3861e517cea5c7f31ed41397) pantheon.elementary-mail: 6.0.0 -> 6.1.1
* [`e56ee9ba`](https://github.com/NixOS/nixpkgs/commit/e56ee9ba6602c7fdf30648b4b170a06c4ad436a0) pantheon.elementary-feedback: 6.0.0 -> 6.1.0
* [`bdce39c9`](https://github.com/NixOS/nixpkgs/commit/bdce39c9f274d0849e0a99220e163ec07515325d) pantheon.appcenter: 3.6.0 -> 3.7.1
* [`8808680e`](https://github.com/NixOS/nixpkgs/commit/8808680e7a212bf80fc057c5766cd0de0dc3b03c) pantheon.elementary-videos: fix translations
* [`7627e552`](https://github.com/NixOS/nixpkgs/commit/7627e5523cca23fd0c33a4741ff1b4899cb31ae9) pantheon.elementary-terminal: fix translations
* [`f7b26fbe`](https://github.com/NixOS/nixpkgs/commit/f7b26fbe9aa7df40264a2da754bee74d62ed5b4d) pantheon.elementary-code: fix translations
* [`2c3dec3e`](https://github.com/NixOS/nixpkgs/commit/2c3dec3e2d55e382ada8dd37ce0993f877836f46) pantheon.elementary-photos: fix translations
* [`1258bfcc`](https://github.com/NixOS/nixpkgs/commit/1258bfcc496b138e638e71d624d8ed036d4f9049) pantheon.elementary-calculator: 1.6.2 -> 1.7.0
* [`5bab4543`](https://github.com/NixOS/nixpkgs/commit/5bab454300db3b4f495b986587179835aad70d2a) pantheon.granite: 6.1.0 -> 6.1.1
* [`72b2f5ab`](https://github.com/NixOS/nixpkgs/commit/72b2f5ab093f7fcae0e464c965317d5ce65eaa10) touchegg: 1.1.1 -> 2.0.11
* [`dc5ea090`](https://github.com/NixOS/nixpkgs/commit/dc5ea0908da8359383c96bfa5f8c23fd5b8308d1) pantheon.touchegg: init
* [`fee747f5`](https://github.com/NixOS/nixpkgs/commit/fee747f5c5dc1db64c7a2805507387a85bd1c842) pantheon.epiphany: init
* [`2478c8bf`](https://github.com/NixOS/nixpkgs/commit/2478c8bf01cbb85ce15d32f01af053a00fd9ed82) nixos/touchegg: init
* [`0366acbc`](https://github.com/NixOS/nixpkgs/commit/0366acbcd54e2e27d3a96c4cadd8aaf2f2ce12bf) nixos/pantheon: add inter and open-dyslexic as preinstalled font
* [`760f7e57`](https://github.com/NixOS/nixpkgs/commit/760f7e57e42d92f39d2b59794716e508472ec762) nixos/pantheon: install elementary-mail by default
* [`3f3502ca`](https://github.com/NixOS/nixpkgs/commit/3f3502ca9340246a9c00ada9ccb21bf0b7be1ab3) nixos/pantheon: update excludePackages example in docs
* [`a66bcfe9`](https://github.com/NixOS/nixpkgs/commit/a66bcfe997af79d7697ae72044890e1f2ce7db73) nixos/pantheon: fix test command for wingpanel
* [`b420199b`](https://github.com/NixOS/nixpkgs/commit/b420199b87a0572291b9bc25c36953b2b33fb246) nixos/pantheon: enable fwupd by default
* [`15818140`](https://github.com/NixOS/nixpkgs/commit/158181403aee2bc9bc93137802f335c172f3d16d) nixos/pantheon: enable touchegg by default
* [`dc19457a`](https://github.com/NixOS/nixpkgs/commit/dc19457a80ba0c7c871d832f60dbf7c3cfbff2a1) nixos/pantheon: remove lightlocker
* [`49988059`](https://github.com/NixOS/nixpkgs/commit/49988059476e53a3d1cf4c41f4186f3cb2396d04) nixos/pantheon: prefer pantheon.epiphany
* [`1b16dbeb`](https://github.com/NixOS/nixpkgs/commit/1b16dbeb557c0016d070687a296f0afe37b540b9) nixos/rl-2111: mention pantheon 6 upgrade and touchegg module
* [`fd010f6b`](https://github.com/NixOS/nixpkgs/commit/fd010f6ba6c46f29d0606d1abce268c92d639c94) autorestic: init at 1.2.0
* [`a1ac5195`](https://github.com/NixOS/nixpkgs/commit/a1ac5195b2e8536d1d35ded33d33c3f5730a086a) pleroma: 2.4.0 -> 2.4.1
* [`6cf8b27f`](https://github.com/NixOS/nixpkgs/commit/6cf8b27fd669eb19b63d4d25acc1b08460c0dd71) nixos/rdnssd: define group; fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`a654d779`](https://github.com/NixOS/nixpkgs/commit/a654d779fe57f8bcbf711353d2caa11423495506) nixos/ripple-data-api: define group
* [`feeca7dd`](https://github.com/NixOS/nixpkgs/commit/feeca7dd55f4e793487238311261ba45baf97684) nixos/rippled: define group, fix eval after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`d09ab775`](https://github.com/NixOS/nixpkgs/commit/d09ab77588852a9d30e7f85f85d5266f50f59f78) nixos/shout: define group, fix eval after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`fd04a872`](https://github.com/NixOS/nixpkgs/commit/fd04a872bcc94c8eba9a34328d593e1d9d62f250) nixos/toxvpn: define group, fix eval after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`23d14d89`](https://github.com/NixOS/nixpkgs/commit/23d14d89b8678944f8f8211f6366bba3d54f930c) nixos/tvheadend: define group, fix eval after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`8ba5f811`](https://github.com/NixOS/nixpkgs/commit/8ba5f8115c6a21d98213f08716aae2f386443c26) nixos/zope2: define group
* [`663b56ef`](https://github.com/NixOS/nixpkgs/commit/663b56eff099eaa2b0efa4ec5b2a2d6cc1ed09a0) procdump: 1.1.1 -> 1.2
* [`ab5e9ceb`](https://github.com/NixOS/nixpkgs/commit/ab5e9cebcd1b1a18412f25518407421e20114034) monitor: 0.8.1 -> 0.9.5
* [`1b01b72d`](https://github.com/NixOS/nixpkgs/commit/1b01b72d85d78a4f586a35a141d062939682e897) maintainers: add iagoq
* [`88b4ba21`](https://github.com/NixOS/nixpkgs/commit/88b4ba2169994650aabdd7591a6bfd70fb187690) nixos/unifi: define group, fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`615db90f`](https://github.com/NixOS/nixpkgs/commit/615db90f3db73ebe5bef1bab3f1fca90a6cbe521) nixos/openntpd, nixos/ntp: define group, fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`8c2e6705`](https://github.com/NixOS/nixpkgs/commit/8c2e6705b38182cbe1f2fb1e460e7b7d26d75b46) nixos/gpsd: define group, fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`3e9520f4`](https://github.com/NixOS/nixpkgs/commit/3e9520f414e438b5f4911838713e34d11268163f) nixos/cgminer: fix type of services.cgminer.config option
* [`ca2db671`](https://github.com/NixOS/nixpkgs/commit/ca2db671badf066911a3805bf00e5c3adce66909) nixos/cgminer: define group, fix eval after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`9e94e48b`](https://github.com/NixOS/nixpkgs/commit/9e94e48b9487281bebd37a8f2696f7b6f88240fb) nixos/gammu-smsd: define group, fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`cd2b24c3`](https://github.com/NixOS/nixpkgs/commit/cd2b24c3060bbe5173a746b34da3c61799c5e8d7) nixos/heapster: define group, fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`fa3664a1`](https://github.com/NixOS/nixpkgs/commit/fa3664a176b36d731b5673d5674a8b81229acce1) nixos/logcheck: define group, fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`af5ba65b`](https://github.com/NixOS/nixpkgs/commit/af5ba65b9f4b9fee755fb6701400b7d61d1804e3) nixos/nntp-proxy: define group, fix after [nixos/nixpkgs⁠#133166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/133166)
* [`fe296b79`](https://github.com/NixOS/nixpkgs/commit/fe296b79b4c803fec51410a987a11f077715a845) materialize: 0.8.3 -> 0.9.4
* [`647a5f63`](https://github.com/NixOS/nixpkgs/commit/647a5f636b225ed996966d5c38763c43f6f40e8a) pyradio: moved package folder
* [`dde5b46c`](https://github.com/NixOS/nixpkgs/commit/dde5b46c5abd66198e56149157e591ae9d729707) pantheon-tweaks: init at 1.0.1
* [`0dcac759`](https://github.com/NixOS/nixpkgs/commit/0dcac759f29b5bd983f2bda424c081aa71b04875) nixos/dokuwiki: Add support for Caddy web server
* [`a0bbb9e7`](https://github.com/NixOS/nixpkgs/commit/a0bbb9e7667e10862e14056ae446a47b3c95aac7) zfsUnstable: correct sha256
* [`f126efd8`](https://github.com/NixOS/nixpkgs/commit/f126efd820273736a7910777641e4ed5563ba091) nixos/pantheon-tweaks: init
* [`10842338`](https://github.com/NixOS/nixpkgs/commit/108423388944d94a080fc5f04f213777f78f11b1) atftp: 0.7.4 -> 0.7.5
* [`70da1764`](https://github.com/NixOS/nixpkgs/commit/70da17646624c7d24daacc644c3c870a938b2f94) atftp: enable tests
* [`0fd8cc39`](https://github.com/NixOS/nixpkgs/commit/0fd8cc390806ef15ded043e729816faa277120af) treewide: switch from pantheon.maintainers to lib.teams.pantheon
* [`a92dd171`](https://github.com/NixOS/nixpkgs/commit/a92dd171bae2db6eeff74a3d31fa99e47e793359) catatonit: 0.1.5 -> 0.1.6
* [`bb198385`](https://github.com/NixOS/nixpkgs/commit/bb19838557dbd643b685ef395dc93632db59718f) tilt: 0.22.8 -> 0.22.9
* [`d7b1157b`](https://github.com/NixOS/nixpkgs/commit/d7b1157b9bf0956397d8fbcced3fe2370db36e21) vscode-extensions.haskell.haskell: 1.10 -> 1.61
* [`ffb2d26c`](https://github.com/NixOS/nixpkgs/commit/ffb2d26c36b83a5a1070018fb54625f86167858d) vscode-extensions.justusadam.language-haskell: 3.2.1 -> 3.40
* [`a34f7dbb`](https://github.com/NixOS/nixpkgs/commit/a34f7dbb73831240702c1f60ca24e6f856622575) chromiumDev: fix build
* [`ef448795`](https://github.com/NixOS/nixpkgs/commit/ef448795997dd7bde63cdb1a50413e3f0f855af6) phoronix-test-suite: run missing hooks: preInstall, postInstall
* [`8b749d81`](https://github.com/NixOS/nixpkgs/commit/8b749d8134347a814cd023f18c5b0bc327e1d1da) vimPlugins.vim-clap: fix cargoSha256
* [`77adbb9c`](https://github.com/NixOS/nixpkgs/commit/77adbb9ce7e9f3585102d23614e7c3a596d83b71) maintainers/scripts/haskell/hydra-report: Add traffic light
* [`13ccdc4e`](https://github.com/NixOS/nixpkgs/commit/13ccdc4e710c5a80a5b2a2ec704d0d796b0b8504) vendir: 0.22.0 -> 0.23.0
* [`cb8b9f47`](https://github.com/NixOS/nixpkgs/commit/cb8b9f47f59ec6015a022eb332f147c2a904a59a) conftest: 0.27.0 -> 0.28.0
* [`b098f6ff`](https://github.com/NixOS/nixpkgs/commit/b098f6ff0dd77083617be628f26fbd78bdd598c0) memorymapping: constrain to darwin (fails on linux) ([nixos/nixpkgs⁠#138404](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/138404))
* [`b6d51777`](https://github.com/NixOS/nixpkgs/commit/b6d517774cb41b6ba685223b6f7adf941b0ca26f) mnamer: 2.5.3 -> 2.5.4
* [`f54d2792`](https://github.com/NixOS/nixpkgs/commit/f54d2792e0bbfcd31900fd4a22cdd977d5bafad8) apache-jena: 3.7.0 -> 4.2.0
* [`a53e02e3`](https://github.com/NixOS/nixpkgs/commit/a53e02e3ec3fa770e9449924c45fe99bc10a1cda) apache-jena-fuseki: 3.13.1 -> 4.2.0
* [`501cb25e`](https://github.com/NixOS/nixpkgs/commit/501cb25ed8c5dbf37dfd4c61365d5f18f12dc0ae) chia: 1.2.6 -> 1.2.7
* [`14791e1d`](https://github.com/NixOS/nixpkgs/commit/14791e1debe62e94fb2e8b8c8782b085c27f0d9a) gnugrep: add meta.mainProgram
* [`5ad7db7e`](https://github.com/NixOS/nixpkgs/commit/5ad7db7ed87e03e3fbd818f05f34010ebe9636db) openssh: add meta.mainProgram
* [`9d529893`](https://github.com/NixOS/nixpkgs/commit/9d5298933afb1ed0dcada1eed9314e470458b7f8) zfs: add meta.mainProgram
* [`ed55c1a4`](https://github.com/NixOS/nixpkgs/commit/ed55c1a44435d36eb4e35da67d0f1faa6e423f04) mmv-go: 0.1.3 -> 0.1.4
* [`19bd423f`](https://github.com/NixOS/nixpkgs/commit/19bd423fadd91b900899959038cf7f6471434dcd) tree-sitter-clojure: init
* [`88b8df5c`](https://github.com/NixOS/nixpkgs/commit/88b8df5c21b7a081a58751466da5b1b248cae68d) linuxPackages.bcc: fix build
* [`5d087332`](https://github.com/NixOS/nixpkgs/commit/5d087332634f434165c25cc06068f782638d740d) tree-sitter-dart: init
* [`b7fb2794`](https://github.com/NixOS/nixpkgs/commit/b7fb2794c4d45653027c4b2e3fb4f23dd8914112) tree-sitter-elisp: init
* [`527933a7`](https://github.com/NixOS/nixpkgs/commit/527933a7d87a712f3b1568cb69db5e3f01494f57) tree-sitter-rst: init
* [`bebdf982`](https://github.com/NixOS/nixpkgs/commit/bebdf9820cfc6da1bc1061c479440d65756e81ff) tree-sitter-vim: init
* [`e2600d44`](https://github.com/NixOS/nixpkgs/commit/e2600d4430f60f31b38c6164b6241b5ba742836a) tree-sitter-zig: switch to a maintained version
* [`1623e435`](https://github.com/NixOS/nixpkgs/commit/1623e435dd72ee71b33f2b9b7f70de3b1a0350db) tree-sitter: update grammars
* [`aa0b3b20`](https://github.com/NixOS/nixpkgs/commit/aa0b3b200df99315e55bea3357151705e11025cb) vimPlugins: update
* [`e98e088d`](https://github.com/NixOS/nixpkgs/commit/e98e088d4af3c41bf1a79d7135a360a0120f55d2) kubernetes: 1.22.1 -> 1.22.2
* [`3389aab8`](https://github.com/NixOS/nixpkgs/commit/3389aab889719081e240ce169ec5bc0d5ccd60d0) haskell.compiler.ghcjs: mark hydraPlatforms as none because output is too large
* [`52187777`](https://github.com/NixOS/nixpkgs/commit/5218777714a09597ae3c35c94ee2096425266f1c) gitoxide: 0.7.0 -> 0.8.4
* [`cdd4d1ce`](https://github.com/NixOS/nixpkgs/commit/cdd4d1ceec76d727118ccec610832b7ba3e51de0) vector: disable flaky test
* [`50010c72`](https://github.com/NixOS/nixpkgs/commit/50010c72c637f8442d30ba9a0702eded422bad00) python3Packages.pyopenuv: 2.2.0 -> 2.2.1
* [`54bff886`](https://github.com/NixOS/nixpkgs/commit/54bff88644a6bfa52030d4356e07d4836b249201) python3Packages.PyChromecast: 9.2.0 -> 9.2.1
* [`37cc6984`](https://github.com/NixOS/nixpkgs/commit/37cc698435f4546ba4ed7be972b1144bbc180816) python3Packages.pykodi: 0.2.5 -> 0.2.6
* [`f573a1b2`](https://github.com/NixOS/nixpkgs/commit/f573a1b2c435ee4e62edf9c24050e8674dfeafcf) python3Packages.plexapi: 4.7.0 -> 4.7.1
* [`cba7d5d9`](https://github.com/NixOS/nixpkgs/commit/cba7d5d90e53094255b36816a04764a9803b4858) python3Packages.aioswitcher: 2.0.5 -> 2.0.6
* [`4bb46590`](https://github.com/NixOS/nixpkgs/commit/4bb46590541798103eef60c7cbd3d1fb24e327eb) home-assistant: 2021.9.6 -> 2021.9.7
* [`f13c1d94`](https://github.com/NixOS/nixpkgs/commit/f13c1d948a41d338127284670576c144c6656258) cargo-spellcheck: init at 0.8.13
* [`556dcbe5`](https://github.com/NixOS/nixpkgs/commit/556dcbe51db6d9e7452bf211baf5e731554a0258) python3Packages.orjson: init at 3.6.3 ([nixos/nixpkgs⁠#137969](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137969))
* [`5ece1469`](https://github.com/NixOS/nixpkgs/commit/5ece1469136092a3509283c6d4942af2714fbca0) deltachat-desktop: 1.21.0 -> 1.21.1
* [`e67bd161`](https://github.com/NixOS/nixpkgs/commit/e67bd161e0203b625fdf157b64dfd1730967a368) cicero-tui: 0.2.2 -> 0.3.0
* [`12c65922`](https://github.com/NixOS/nixpkgs/commit/12c6592208ce632106b76c975789c617552547e6) adguardhome: 0.105.2 -> 0.106.3
* [`06a91dda`](https://github.com/NixOS/nixpkgs/commit/06a91dda9cae112c32177f64df4ebfc01be934e3) octoprint.python.pkgs.ender3v2tempfix: init at unstable-2021-04-27
* [`70a61f29`](https://github.com/NixOS/nixpkgs/commit/70a61f2921440a913e57d99f53fd5a7fbbe2e5dd) awscli2: 2.2.30 -> 2.2.39
* [`2e44a72b`](https://github.com/NixOS/nixpkgs/commit/2e44a72b8f3cd35318af1b167994f78ca259e119) github-backup: 0.39.0 -> 0.40.0
* [`948ef8a6`](https://github.com/NixOS/nixpkgs/commit/948ef8a6c5fd2c71a5e45aecd5cc997740e91024) idris2: 0.4.0 -> 0.5.0
* [`6b84305e`](https://github.com/NixOS/nixpkgs/commit/6b84305e5cc0efe58ae3af0ba939c4f414b34305) python37Packages.py-air-control-exporter: 0.3.0 -> 0.3.1
* [`64f5d681`](https://github.com/NixOS/nixpkgs/commit/64f5d681d95ba708afef378f86c5112798cc9039) nixos/physlock: fix broken wrapper
* [`defe183d`](https://github.com/NixOS/nixpkgs/commit/defe183dad2ab2b419314515326bdab93d35306a) firejail: Remove symlink check patch
* [`4ec3a295`](https://github.com/NixOS/nixpkgs/commit/4ec3a29566d01b3a0ee80303a83d417c3de8ca33) maddy: remove maintainer ([nixos/nixpkgs⁠#138508](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/138508))
* [`0bdde7ec`](https://github.com/NixOS/nixpkgs/commit/0bdde7ecdf02f55d71792069c401fa270cf3e58c) haproxy: 2.3.13 -> 2.3.14
* [`f8b837c8`](https://github.com/NixOS/nixpkgs/commit/f8b837c808490644bc7de35108a2212c22c8b262) ungoogled-chromium: 92.0.4515.159 -> 93.0.4577.82
* [`3133899c`](https://github.com/NixOS/nixpkgs/commit/3133899cbc6a72d3a6282b46cbec465506fc2cd7) tailscale: 1.14.0 -> 1.14.3
* [`2448e9eb`](https://github.com/NixOS/nixpkgs/commit/2448e9eb11b313c3d30626e72c4aabba83cfd69e) python38Packages.scikit-hep-testdata: 0.4.7 -> 0.4.8
* [`242ab4de`](https://github.com/NixOS/nixpkgs/commit/242ab4debd0eca13d579d824c2d993e5ee5f0cda) haskell-language-server: Disable several plugin checks on arm
* [`ca679942`](https://github.com/NixOS/nixpkgs/commit/ca67994224c253ac2c305392f8e58b3be78fea49) dua: 2.14.6 -> 2.14.7
* [`7e399b70`](https://github.com/NixOS/nixpkgs/commit/7e399b70a70cd8ff6e15af37813edf9726d4a26b) exploitdb: 2021-09-17 -> 2021-09-18
* [`88cddfbf`](https://github.com/NixOS/nixpkgs/commit/88cddfbfb5accf02f357a42835f5e7d26ca6db82) gocryptfs: support fstab mount
* [`cb916713`](https://github.com/NixOS/nixpkgs/commit/cb9167139eda6d4c3143d2ba1e7cf848a0a9718d) vmware-guest: Use vmware-vmblock-fuse for drag-and-drop synchronization ([nixos/nixpkgs⁠#131278](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/131278))
* [`139c8fe7`](https://github.com/NixOS/nixpkgs/commit/139c8fe7055ee1788a3f2657525d41bf00cff6aa) elmPackages.*: auto upgrade
* [`cdea486e`](https://github.com/NixOS/nixpkgs/commit/cdea486e7a79995cb029ce61bbec8715572fba4d) cargo-diet: init at 1.2.2
* [`d0dde619`](https://github.com/NixOS/nixpkgs/commit/d0dde6199f29417aa48423644db5b259ab8dc95e) hck: 0.6.3 -> 0.6.4
* [`248eeddc`](https://github.com/NixOS/nixpkgs/commit/248eeddcddf680b5e92c5da149db1ce7e980a2c5) wget: 1.21.1 -> 1.21.2
* [`1e7edcb2`](https://github.com/NixOS/nixpkgs/commit/1e7edcb21f13bfb959cf7fd0d41d52fdb9931164) cawbird: 1.4.1 -> 1.4.2
* [`73414b57`](https://github.com/NixOS/nixpkgs/commit/73414b570ad5a0e49fbe51236a3e0108710ef927) libdnf: switch back to default stdenv.
* [`b06ffb4b`](https://github.com/NixOS/nixpkgs/commit/b06ffb4b454286d71ad646fc7032942d2625f589) doc/rust: add missing fetchfromGitHub to derivation example
* [`cab1a84f`](https://github.com/NixOS/nixpkgs/commit/cab1a84f28cf61d6a5c4a167afb5e712ca8d88c7) cargo-llvm-lines: init at 0.4.11
* [`bdac6826`](https://github.com/NixOS/nixpkgs/commit/bdac6826b78c183ff2dd18e8db0b2825a60fd586) seatd: 0.5.0 -> 0.6.2
* [`f0bc4d95`](https://github.com/NixOS/nixpkgs/commit/f0bc4d95b81e9b08fcdfbd96c5c6311190f2dbfe) pkgsStatic.toybox: fix build
* [`1ae90c51`](https://github.com/NixOS/nixpkgs/commit/1ae90c51183f3b7ac192018c17b696ef2ceedcb3) dhallPackages: Remove `dhall-packages` ([nixos/nixpkgs⁠#138487](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/138487))
* [`9bc67194`](https://github.com/NixOS/nixpkgs/commit/9bc67194e06875f888bedc3bae1d1062b7a4faec) weechat: 3.2.1 -> 3.3
* [`f5c3ef77`](https://github.com/NixOS/nixpkgs/commit/f5c3ef776243bfcbb8a00494fa6d2aa6fe7af8a2) python38Packages.gensim: 4.1.1 -> 4.1.2
* [`aeee80f1`](https://github.com/NixOS/nixpkgs/commit/aeee80f10e1861eea15d64b3848cfb3cb343767a) python38Packages.databricks-connect: 8.1.12 -> 8.1.13
* [`c0423f63`](https://github.com/NixOS/nixpkgs/commit/c0423f6304aa5aec46aa3eb55b8937b4932dcf03) python38Packages.emoji: 1.4.2 -> 1.5.0
* [`abbbc072`](https://github.com/NixOS/nixpkgs/commit/abbbc072b1353d8c8dbc58a6d8f3fdf83a48fa03) cargo-tally: init at 1.0.0
* [`0adf50ee`](https://github.com/NixOS/nixpkgs/commit/0adf50eefec9fb0122682a178659d6e2593f8e89) haskellPackages: mark builds failing on hydra as broken
* [`c9845d4d`](https://github.com/NixOS/nixpkgs/commit/c9845d4d32fa4fe2b7e7c439b25b68df5dcfc005) cargo-dephell: init at 0.5.1
