### PR TITLE
niv home-manager: update 5199bc84 -> 371576cd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5199bc841aa9ebafc567a1f5c498682650f68973",
-        "sha256": "03m1z2fv6a94pj9513lj6gvzalj21y40wkr02a3yannjka4kp6vy",
+        "rev": "371576cdc2580ba93a38e28da8ece2129f558815",
+        "sha256": "0vwkmnvc4pggicgzii4gg22pv5whp2aiian0rs80srwzkxl2sz0n",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/5199bc841aa9ebafc567a1f5c498682650f68973.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/371576cdc2580ba93a38e28da8ece2129f558815.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5199bc84...371576cd](https://github.com/nix-community/home-manager/compare/5199bc841aa9ebafc567a1f5c498682650f68973...371576cdc2580ba93a38e28da8ece2129f558815)

* [`2cfea84e`](https://github.com/nix-community/home-manager/commit/2cfea84e6f92e5e9bdd529207b1e9f1ebf3a6d4c) modules: fix list sorting
* [`4b964d2f`](https://github.com/nix-community/home-manager/commit/4b964d2f7baca30655ac0780d3003eeb5a4929f0) bottom: add module
* [`514acaeb`](https://github.com/nix-community/home-manager/commit/514acaebb90dc18ccb577d91faef9089242c9ca0) lieer: change settings to freeform type
* [`562449b5`](https://github.com/nix-community/home-manager/commit/562449b50354ac224adc4265803cba40b931ae7b) files: clarify "Please move the above files" message
* [`371576cd`](https://github.com/nix-community/home-manager/commit/371576cdc2580ba93a38e28da8ece2129f558815) gpg-agent: remove unnecessary IFD
