### PR TITLE
niv powerlevel10k: update 543e2d59 -> 7a72acf5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "543e2d59cf107af4e96727aa70d9f1ca93149f14",
-        "sha256": "1ic8wynyrzgw95q0v37k7jd62ipi31nzvmkr98h9iya6h7g1i8iw",
+        "rev": "7a72acf5635cfc09aa544bfb70e13ad46faa432b",
+        "sha256": "18qy4jz30hw2wm8scjsa6lb67ikchnsm94hhgl19whkqsqx6vi21",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/543e2d59cf107af4e96727aa70d9f1ca93149f14.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/7a72acf5635cfc09aa544bfb70e13ad46faa432b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@543e2d59...7a72acf5](https://github.com/romkatv/powerlevel10k/compare/543e2d59cf107af4e96727aa70d9f1ca93149f14...7a72acf5635cfc09aa544bfb70e13ad46faa432b)

* [`0122a638`](https://github.com/romkatv/powerlevel10k/commit/0122a63834183f32568942338454a83830e21d0b) Add instructions to manually set font on Yakuake
* [`7a72acf5`](https://github.com/romkatv/powerlevel10k/commit/7a72acf5635cfc09aa544bfb70e13ad46faa432b) clean up font instructions for yakuake
