### PR TITLE
niv spacemacs: update 663cfc5b -> 845cdcab

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "663cfc5ba7826dd20d18fe5c1f8fb09338284955",
-        "sha256": "16qnz7nvp712gph1wwgznpk1bia4rggq3flr89ps0b26b95yhcww",
+        "rev": "845cdcaba82e44a4715f56d15d608627d8c006ec",
+        "sha256": "1pih28yn5p10cbql6ahmsjrs5zcvgyx8i0i70jgxv7ahn59b5nmg",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/663cfc5ba7826dd20d18fe5c1f8fb09338284955.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/845cdcaba82e44a4715f56d15d608627d8c006ec.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@663cfc5b...845cdcab](https://github.com/syl20bnr/spacemacs/compare/663cfc5ba7826dd20d18fe5c1f8fb09338284955...845cdcaba82e44a4715f56d15d608627d8c006ec)

* [`6a5b2292`](https://github.com/syl20bnr/spacemacs/commit/6a5b2292565c8e5776c2049d24d02b949c0f0283) Add simple workaround to ebib kill buffer issue ([syl20bnr/spacemacs⁠#15048](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15048))
* [`cabe650f`](https://github.com/syl20bnr/spacemacs/commit/cabe650f008b07f240d3a220960e2c84c5ea9918) Extend spacemacs/copy-file command with extra actions ([syl20bnr/spacemacs⁠#14754](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14754))
* [`08fa117a`](https://github.com/syl20bnr/spacemacs/commit/08fa117afafdf53a5b915ec7711119b864960bbb) Update keybinding
* [`c8c20bec`](https://github.com/syl20bnr/spacemacs/commit/c8c20becf6b1159791896e7a853f1ee32ad62a1f) Fix and update PR [syl20bnr/spacemacs⁠#14992](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14992): update eaf layer
* [`2de0a10a`](https://github.com/syl20bnr/spacemacs/commit/2de0a10ae0bde7a88934109410092d0665c8a803) Add documentation about evilifying 'special-mode buffers' (+fix eww)
* [`b4db1415`](https://github.com/syl20bnr/spacemacs/commit/b4db1415317066bfeac15c19ba17589b3e2c826a) [bot] "documentation_updates" Fri Sep 17 18:59:01 UTC 2021
* [`9803b60d`](https://github.com/syl20bnr/spacemacs/commit/9803b60d644d1e79aab92a47cc90ffab3df2f2f7) Fix (activate) company-emoji completion
* [`845cdcab`](https://github.com/syl20bnr/spacemacs/commit/845cdcaba82e44a4715f56d15d608627d8c006ec) [bot] "documentation_updates" Fri Sep 17 19:24:14 UTC 2021
