### PR TITLE
niv nixpkgs: update da01cce1 -> 7097c8fe

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da01cce16d9c8ef64b19d89d58839cb53718f2e3",
-        "sha256": "0n77b4dvjz5zwk6lwydzs1p82xvypcnymnbhwd1lcjgyzl2wbs1i",
+        "rev": "7097c8fef12fa818982e8e99aef238e4cd4b2311",
+        "sha256": "1w1134a5bmrmnwbf8b8vs2blyhilf6z7h900yknwa24abhjpgc98",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/da01cce16d9c8ef64b19d89d58839cb53718f2e3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/7097c8fef12fa818982e8e99aef238e4cd4b2311.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@da01cce1...7097c8fe](https://github.com/nixos/nixpkgs/compare/da01cce16d9c8ef64b19d89d58839cb53718f2e3...7097c8fef12fa818982e8e99aef238e4cd4b2311)

* [`c3875017`](https://github.com/NixOS/nixpkgs/commit/c38750173d82346cfcc0c427c1dead5d691d611d) python3Packages.aiowatttime: init at 0.1.1
* [`f1ae15c4`](https://github.com/NixOS/nixpkgs/commit/f1ae15c4e7e5c58a8cafa0927ee9da19f76b4a4c) python3Packages.iotawattpy: init at 0.1.0
* [`eba807d5`](https://github.com/NixOS/nixpkgs/commit/eba807d5949801334cf4742423e8a7d5eb161d26) chromiumDev: 95.0.4638.17 -> 96.0.4651.0
* [`28580344`](https://github.com/NixOS/nixpkgs/commit/28580344231bd73178a888430a36852292547e99) python3Packages.p1monitor: init at 1.0.0
* [`2d4c7f67`](https://github.com/NixOS/nixpkgs/commit/2d4c7f67cc404b2163c067bdbe738da9ea08bb27) home-assistant: update component-packages
* [`7704e229`](https://github.com/NixOS/nixpkgs/commit/7704e2298404057d0a89a5c1ee04cc20c134b0b7) home-assistant: enable p1_monitor tests
* [`b7d6c648`](https://github.com/NixOS/nixpkgs/commit/b7d6c64871a68f76979015b7434233d84370686e) gotestsum: fix package name in ldflags
* [`98fe3260`](https://github.com/NixOS/nixpkgs/commit/98fe3260c624d94726aec9ff7f7c4f2f456ceea1) nixos/gnome: Fix broken .gnome-shell-wrapped wrapper
* [`aec24826`](https://github.com/NixOS/nixpkgs/commit/aec248263991541bebfb781376543d26d6c79d7f) supertag: fix build caused by outdated lexical-core
* [`5a566e3e`](https://github.com/NixOS/nixpkgs/commit/5a566e3e7762bdc5ca5f6296f3d72e61dbd597ba) firefox-beta-bin: 90.0b6 -> 93.0b9
* [`8eeb28ff`](https://github.com/NixOS/nixpkgs/commit/8eeb28ffc3cb5265d080626faa76c6e600c32d33) firefox-devedition-bin: 90.0b6 -> 93.0b9
* [`28d8ad0b`](https://github.com/NixOS/nixpkgs/commit/28d8ad0be1a42ac439f4bfe84df1c1eac4c83506) firefox-bin: Don't reference gnome in expression
* [`e456e9b1`](https://github.com/NixOS/nixpkgs/commit/e456e9b1ae467c8f83b923dbd2fea337dfe9ff3c) sigtool: 0.1.0 -> 0.1.2
* [`804e2edf`](https://github.com/NixOS/nixpkgs/commit/804e2edff596e667d287556cfd3a701bad1648b3) flutter: 2.2.1 -> 2.5.1
* [`5b2139ea`](https://github.com/NixOS/nixpkgs/commit/5b2139eadc55f9cbc09e19d6654132928992565b) python38Packages.filetype: 1.0.7 -> 1.0.8
* [`1bac76f0`](https://github.com/NixOS/nixpkgs/commit/1bac76f06fbdcb5d0ea0e18e9dae359c942825da) racket: unbreak on darwin
* [`54974715`](https://github.com/NixOS/nixpkgs/commit/5497471572f8a8c4e0ca1b44bfd4de854023b85d) python38Packages.deemix: 3.5.1 -> 3.5.3
* [`29ba0603`](https://github.com/NixOS/nixpkgs/commit/29ba06034e1f9d17f260240a24020beb5ddddaad) python38Packages.fountains: 1.0.0 -> 1.1.0
* [`df02d2b1`](https://github.com/NixOS/nixpkgs/commit/df02d2b17570f569c50e9e5fd340697d0272cd8c) python38Packages.goalzero: 0.1.59 -> 0.2.0
* [`d800b42d`](https://github.com/NixOS/nixpkgs/commit/d800b42dec422dcf09f908f2065ef310e5fb38b4) udunits: meta.platforms = lib.platforms.all
* [`7a08ed05`](https://github.com/NixOS/nixpkgs/commit/7a08ed05f64a4ce14dfcf7c8a4f8db507a5d07a4) python3Packages.marshmallow-dataclass: init at 8.5.3
* [`f6ce10aa`](https://github.com/NixOS/nixpkgs/commit/f6ce10aac7c645f637997412c193eaea323499a9) python3Packages.renault-api: init at 0.1.4
* [`9aa02e78`](https://github.com/NixOS/nixpkgs/commit/9aa02e78e14a0ff1994574c50377184abf7237ab) home-assistant: update component-packages
* [`b9317c9e`](https://github.com/NixOS/nixpkgs/commit/b9317c9ed1c9261e3fbde8d16fac60ec665b02e5) home-assistant: enable renault tests
* [`9d6fbb6b`](https://github.com/NixOS/nixpkgs/commit/9d6fbb6b2cb036c8206e3bfb18aafc13493f286a) python3Packages.pysdcp: init at 1
* [`c4fc5f5d`](https://github.com/NixOS/nixpkgs/commit/c4fc5f5dda7a87317e7d9856c30a2e4f4c3f19cf) home-assistant: update component-packages
* [`ccb5c228`](https://github.com/NixOS/nixpkgs/commit/ccb5c2285b2f8110ae469ac23e2cad63f761ed95) perlPackages.ConvertASN1: 0.27 -> 0.33
* [`ed04c57d`](https://github.com/NixOS/nixpkgs/commit/ed04c57df977cca53b702dac7268774a2560e2b4) python3Packages.eternalegypt: init at 0.0.13
* [`e96405f6`](https://github.com/NixOS/nixpkgs/commit/e96405f686b7a4e1341c25f82c1300354819e0c4) home-assistant: update component-packages
* [`3d650ad7`](https://github.com/NixOS/nixpkgs/commit/3d650ad7d17f49b9b5f8ae64c3463d410d6b0b43) home-assistant: update component-packages
* [`2fb9f65c`](https://github.com/NixOS/nixpkgs/commit/2fb9f65c0a1c9d6624b5c0a237b3eaa9d14b8dcd) comby: nixpkgs-fmt
* [`75f3b984`](https://github.com/NixOS/nixpkgs/commit/75f3b98431f89c0313a75447fec3e85419a85bee) python3Packages.aiopvapi: init at 1.6.14
* [`86690c93`](https://github.com/NixOS/nixpkgs/commit/86690c930c571860717de155162326e2a5afde1b) home-assistant: update component-packages
* [`fc43bfa5`](https://github.com/NixOS/nixpkgs/commit/fc43bfa5f452fd19e246a14fdab0ac0ce86d0ed4) home-assistant: enable hunterdouglas_powerview tests
* [`29efb76a`](https://github.com/NixOS/nixpkgs/commit/29efb76ab6480426ce8c1f7bd8e341f0249a61cc) google-chrome: add pipewire dependency
* [`ea678f70`](https://github.com/NixOS/nixpkgs/commit/ea678f709fd3c39bd044a62df5e141dcefb98ed3) python38Packages.phonenumbers: 8.12.32 -> 8.12.33
* [`d66e4eea`](https://github.com/NixOS/nixpkgs/commit/d66e4eea8550cc10d2f579b4e821639d44deae01) ungoogled-chromium: 94.0.4606.54 -> 94.0.4606.61
* [`54051ba4`](https://github.com/NixOS/nixpkgs/commit/54051ba41855a1bbbe8ebe4d6f87386604fb6df9) comby: 1.5.1 -> 1.7.0
* [`88cdb0a3`](https://github.com/NixOS/nixpkgs/commit/88cdb0a3c041ab6a401c6776de548e72bb332e22) wifite2: add pixiewps dependency
* [`48c21d8c`](https://github.com/NixOS/nixpkgs/commit/48c21d8c273dbe5427e22545073b58adc4fba930) python38Packages.ytmusicapi: 0.19.2 -> 0.19.3
* [`d047d336`](https://github.com/NixOS/nixpkgs/commit/d047d336d60433a07c8e0de2dee45cfad8ceecef) prisma-engines: [nixos/nixpkgs⁠#135934](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135934) follow-up corrections
* [`47557e29`](https://github.com/NixOS/nixpkgs/commit/47557e2984cac84711bf3aad6213dade0907116f) nodesPackages.prisma: [nixos/nixpkgs⁠#135934](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/135934) follow-up corrections
* [`3bc4a574`](https://github.com/NixOS/nixpkgs/commit/3bc4a574dbb1674cf99eda99bb4af364c9c8472a) prisma: add pimeys as maintainer
* [`8bc030eb`](https://github.com/NixOS/nixpkgs/commit/8bc030eb13ea2fd611e446042340e9f19aa218e4) llvmPackages_13: 13.0.0-rc3 -> 13.0.0-rc4
* [`847bfb3d`](https://github.com/NixOS/nixpkgs/commit/847bfb3df34b42daca5203c4828af57a46538d8f) tdesktop: 3.1.0 -> 3.1.1
* [`b6678803`](https://github.com/NixOS/nixpkgs/commit/b6678803d1cb8baabb87939ff31735755ec08885) navi: 2.16.0 -> 2.17.0
* [`d038da0a`](https://github.com/NixOS/nixpkgs/commit/d038da0ab4cf98699af1b5821172ce19a96c27fa) python3Packages.flipr-api: init at 1.4.1
* [`b5802f42`](https://github.com/NixOS/nixpkgs/commit/b5802f427f0d7ad351d6e789fa4deb62f5838c62) home-assistant: update component-packages
* [`ec54e608`](https://github.com/NixOS/nixpkgs/commit/ec54e6081866b22bead1f4951c6af05b027724e9) home-assistant: enable flipr tests
* [`faef9593`](https://github.com/NixOS/nixpkgs/commit/faef95930b1b52b93d8c98cdf5032fdcbfb93a3f) meilisearch: add meta
* [`0f9a1d70`](https://github.com/NixOS/nixpkgs/commit/0f9a1d70fad4af54a0d411b306427823476dcced) meilisearch: add docs
* [`5f7019ed`](https://github.com/NixOS/nixpkgs/commit/5f7019ed8a8ad8af7a4db18a12fe2fb8955a647a) prisma: 2.30.2 -> 3.1.1
* [`5ff1057e`](https://github.com/NixOS/nixpkgs/commit/5ff1057ec4134d76481d9761ebed76d1cb1d3452) python3Packages.types-requests: 2.25.8 -> 2.25.9
* [`de68426d`](https://github.com/NixOS/nixpkgs/commit/de68426db81f8061923b283118d5d7f6582b3c29) ocamlPackages.labltk: add version 8.06.11 for OCaml 4.13
* [`f9756aa1`](https://github.com/NixOS/nixpkgs/commit/f9756aa1d9ad47c73198bebca8ef473f15305fca) nomad_1_0: 1.0.10 -> 1.0.11
* [`0593b0a4`](https://github.com/NixOS/nixpkgs/commit/0593b0a4de51bfdbc3e2e8be368ee9012381afad) nomad_1_1: 1.1.4 -> 1.1.5
* [`048af0cd`](https://github.com/NixOS/nixpkgs/commit/048af0cd5ff53c31eff561b25b9b558e62f82817) python3Packages.niluclient: init at 0.1.2
* [`539b9b26`](https://github.com/NixOS/nixpkgs/commit/539b9b26aa702e5114595ecb58ae36ebde6ee62b) home-assistant: update component-packages
* [`b5f27628`](https://github.com/NixOS/nixpkgs/commit/b5f27628e4ad2dc3d84ee41af6251b8ad5174880) greybird: 3.22.14 -> 3.22.15
* [`780415ce`](https://github.com/NixOS/nixpkgs/commit/780415ce5d5bf3df6e361178206cd1185c56c4b9) cargo-llvm-lines: 0.4.11 -> 0.4.12
* [`e95a50a6`](https://github.com/NixOS/nixpkgs/commit/e95a50a64b4061ab2cb0572ac493f841e7b65b14) nixos/networkd: add ActivationPolicy option
* [`10a0b29d`](https://github.com/NixOS/nixpkgs/commit/10a0b29d211e8228cef9bf32b10623c8d1756291) apfsprogs: unstable-2021-05-07 -> unstable-2021-08-24
* [`69cb5e3d`](https://github.com/NixOS/nixpkgs/commit/69cb5e3dc6bfd0ae2eb4d0eb9b8c2810d798cc05) nixos/owncast: release notes
* [`99b632b2`](https://github.com/NixOS/nixpkgs/commit/99b632b2208b69911f3ca48cc0f5fb095e2d2314) python38Packages.yt-dlp: 2021.9.2 -> 2021.9.25
* [`5ad2ce9d`](https://github.com/NixOS/nixpkgs/commit/5ad2ce9dca210123762cb1dbb6f5c81c31c25f0d) vsce/asvetliakov.vscode-neovim: init at 0.0.82
* [`3194ce02`](https://github.com/NixOS/nixpkgs/commit/3194ce025c746acdc5460a7a7d4fff298ba6a3e5) cpio: add two subsequent upstream patches
* [`c3330fa7`](https://github.com/NixOS/nixpkgs/commit/c3330fa752d2fa06d6f8ad68d535152fb9d1d778) cpio: clean up the nix expression
* [`cf4d5a3a`](https://github.com/NixOS/nixpkgs/commit/cf4d5a3a319c699381878d75e608263f672a116c) libsForQt5.mauikit: 2.0.1 -> 2.0.2
* [`fd08bea7`](https://github.com/NixOS/nixpkgs/commit/fd08bea7f7740b265abae6bbccaa4a87be0fbcd9) libsForQt5.mauikit-filebrowsing: 2.0.1 -> 2.0.2
* [`cda1e497`](https://github.com/NixOS/nixpkgs/commit/cda1e49784034826eb04a67cfe6fff5e226cc609) foreman: add more platform support
* [`646cb17c`](https://github.com/NixOS/nixpkgs/commit/646cb17cdb142128e3d90c7e718da57ef355136d) feh: 3.7.1 -> 3.7.2
* [`63eb37d2`](https://github.com/NixOS/nixpkgs/commit/63eb37d2cade10d66a5c00f8da5e98adf7ed3b54) rizin: 0.2.1 -> 0.3.0
* [`1ae69f0d`](https://github.com/NixOS/nixpkgs/commit/1ae69f0dce7db8ea0494aacd2e302b5158ed0ec5) cutter: 2.0.2 -> 2.0.3
* [`fce1ac0d`](https://github.com/NixOS/nixpkgs/commit/fce1ac0d62b496d11f5dd4700524f92c2b844905) sqlfluff: 0.6.5 -> 0.6.6
* [`6e20be97`](https://github.com/NixOS/nixpkgs/commit/6e20be978b1aea35bfb1da4ef39200d72a9a74ed) chatterino2: 2.3.0 -> 2.3.4
* [`5a0c59bb`](https://github.com/NixOS/nixpkgs/commit/5a0c59bb4dd90bb6103822daaa30bf2fbc70da67) python3Packages.xml2rfc: 3.9.1 -> 3.10.0
* [`e6cc081a`](https://github.com/NixOS/nixpkgs/commit/e6cc081a42c3f2dfe7fa363da6408fbc359648e5) github-backup: 0.40.0 -> 0.40.1
* [`d3e59373`](https://github.com/NixOS/nixpkgs/commit/d3e59373610389ff65ff025231c70695362b09dc) python3Packages.imdbpy: remove patch
* [`450c0ab5`](https://github.com/NixOS/nixpkgs/commit/450c0ab5e7686b8a595024a91a9b5a29d2209765) ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0-rc2 → 4.13.0
* [`bd077a5b`](https://github.com/NixOS/nixpkgs/commit/bd077a5b4204d1ec60067329a7065c8d85baea26) python3Packages.pyezviz: 0.1.9.3 -> 0.1.9.4
* [`fb972569`](https://github.com/NixOS/nixpkgs/commit/fb9725692f7b765617a800bdc92d9b4cc37f69d0) python3Packages.asynccmd: init at 0.2.4
* [`5c8bd5a5`](https://github.com/NixOS/nixpkgs/commit/5c8bd5a5ef26da8a555e64c5e4e93efbf75c3b93)  python3Packages.streamlabswater: init at 0.3.2
* [`4d7751ad`](https://github.com/NixOS/nixpkgs/commit/4d7751adb6ed5a7bec4a9930ff5f714cad48a995) home-assistant: update component-packages
* [`9c0e8584`](https://github.com/NixOS/nixpkgs/commit/9c0e8584e9fd1ed8e1faa5e09097916f7e387730) home-assistant: update component-packages
* [`c9ebf4ed`](https://github.com/NixOS/nixpkgs/commit/c9ebf4ed8001e51fdbf976862a2f04d9d580f9b9) home-assistant: enable spc tests
* [`d472c9d8`](https://github.com/NixOS/nixpkgs/commit/d472c9d87c6fea330660c2bc079e0e6b607e4c40) python3Packages.pyspcwebgw: init at 0.5.0
* [`be3bc77e`](https://github.com/NixOS/nixpkgs/commit/be3bc77e3175f055e634ca1375d7cbdb60facfad) libnatpmp: make files in $out/lib executable
* [`5fdb0a6c`](https://github.com/NixOS/nixpkgs/commit/5fdb0a6cafff7c41107fdd80e306b47a1bc54718) joshuto: 0.9.0 -> 0.9.1
* [`7a038d04`](https://github.com/NixOS/nixpkgs/commit/7a038d04c64c81470e8691e19ee371a4d1aac178) pantheon.gala: fix session crash when taking screenshots with mutter 3.38
* [`f40924a4`](https://github.com/NixOS/nixpkgs/commit/f40924a499b405becc41b9c869f64ef0ac5b4b5b) vscode: apply postPatch on linux only
* [`54cecf8b`](https://github.com/NixOS/nixpkgs/commit/54cecf8bdee6f4eeb9a9a3b4917ceebe51e8b18d) tailscale: 1.14.3 -> 1.14.4
* [`383b3b36`](https://github.com/NixOS/nixpkgs/commit/383b3b36d06bddd730acbb466f66af5b7bee913a) mop: fix build on bash-5
* [`bd0ea729`](https://github.com/NixOS/nixpkgs/commit/bd0ea72925ec64f0613240894313ad778871e477) python38Packages.casbin: 1.8.1 -> 1.9.0
* [`f59bceb7`](https://github.com/NixOS/nixpkgs/commit/f59bceb7f785f50ba7c3dd0e8e0b9ea20143a71c) vsce/kamikillerto.vscode-colorize: init at 0.11.1
* [`f1a8d087`](https://github.com/NixOS/nixpkgs/commit/f1a8d087eb59b4513b37873c4b96bf7d63ec41b1) cargo-feature: 0.5.2 -> 0.5.3
* [`8d77e899`](https://github.com/NixOS/nixpkgs/commit/8d77e899e89f8828b211ee66265aa177ad038eca) sasquatch: drop blanket -Werror (fix gcc-11 build) ([nixos/nixpkgs⁠#139350](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139350))
* [`d032f60c`](https://github.com/NixOS/nixpkgs/commit/d032f60c37ebdae3afd9a24212497ec8725ee4fb) ghcjs: Enable on darwin ([nixos/nixpkgs⁠#139067](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139067))
* [`628f61fe`](https://github.com/NixOS/nixpkgs/commit/628f61fe1a5830787ae359aa61be877858c36100) python38Packages.deezer-py: 1.2.3 -> 1.2.4
* [`ecd33477`](https://github.com/NixOS/nixpkgs/commit/ecd334772cdf2a57bab4d88ec6f761e2ba38e420) python38Packages.emoji: 1.5.0 -> 1.5.2
* [`5fa508d9`](https://github.com/NixOS/nixpkgs/commit/5fa508d98fe3de78fe8e882ce703ea9ee7144468) python38Packages.fe25519: 0.2.0 -> 0.3.0
* [`33d3f1d8`](https://github.com/NixOS/nixpkgs/commit/33d3f1d8207a411d5b343c74e409cab3a2608788) python38Packages.fountains: 1.1.0 -> 1.1.1
* [`2eb62bb9`](https://github.com/NixOS/nixpkgs/commit/2eb62bb92e78402557b9f7fe38561f1154ad1aee) tfsec: 0.58.9 -> 0.58.10
* [`4e276096`](https://github.com/NixOS/nixpkgs/commit/4e27609642ce2a57539c103ca9a995ad761d53aa) exploitdb: 2021-09-22 -> 2021-09-25
* [`aef78fae`](https://github.com/NixOS/nixpkgs/commit/aef78fae439df7663e4e2268fc8230d5bedebb63) python3Packages.mypy-boto3-builder: 4.14.1 -> 4.22.1
* [`293c04c6`](https://github.com/NixOS/nixpkgs/commit/293c04c6a9898847f6c22d9bd4bc83e8f3434b8d) python3Packages.mypy-boto3-builder: 4.22.1 -> 5.4.0
* [`d859c439`](https://github.com/NixOS/nixpkgs/commit/d859c439d20da9341d826768f0a830550fbf46d0) python3Packages.pytibber: 0.19.1 -> 0.20.0
* [`20706e94`](https://github.com/NixOS/nixpkgs/commit/20706e94085b79340cbdd28abcb9f5f4da9883f1) python3Packages.pytibber: update description
* [`9e1a79a0`](https://github.com/NixOS/nixpkgs/commit/9e1a79a05f7067aaa2763c6e2a142c012b1b47a4) libarchive-qt 2.0.4 -> 2.0.6
* [`fe6701ec`](https://github.com/NixOS/nixpkgs/commit/fe6701ec3ab3ede6f53d6f014fe1db80b83d0fa7) packer: 1.7.4 -> 1.7.5
* [`61da8692`](https://github.com/NixOS/nixpkgs/commit/61da86928406435694525d7b9553f6ee2703fd77) apostrophe: 2.4 -> 2.5
* [`e7d24168`](https://github.com/NixOS/nixpkgs/commit/e7d2416831020fe4b894fd6db202d2beb66d569f) ytcc: 2.3.0 -> 2.4.1
* [`7c86d105`](https://github.com/NixOS/nixpkgs/commit/7c86d10590ccc5330fed0866fe937faf3e36f7a3) texinfo6_8: init at 6.8 (without switching default)
* [`8bf6ca43`](https://github.com/NixOS/nixpkgs/commit/8bf6ca43cbaef0de2bfa031f9c8f6dc2bff8001f) python38Packages.pytelegrambotapi: 4.0.0 -> 4.1.0
* [`9b5dd003`](https://github.com/NixOS/nixpkgs/commit/9b5dd00333775ca9be0d9ac67cc00755708ec494) wsdd: 0.6.2 -> 0.6.4
* [`6ae909d1`](https://github.com/NixOS/nixpkgs/commit/6ae909d1839c2d40dcb05f596add39eccde1b690) vnote: 2.10 -> 3.7.0
* [`c43789e7`](https://github.com/NixOS/nixpkgs/commit/c43789e7bb3768e0a084e4bf79366212d4a69f4b) julia_16-bin: 1.6.2 -> 1.6.3
* [`cb28af90`](https://github.com/NixOS/nixpkgs/commit/cb28af904528e23f3c345821210a5a2d4c7e0370) matcha-gtk-theme: 2021-08-23 -> 2021-09-24
* [`9eb60cdf`](https://github.com/NixOS/nixpkgs/commit/9eb60cdf4e2755c06298ad0404afaf3aa4de07b2) emacs.pkgs.bqn-mode: 2021-09-15 -> 2021-09-26
* [`0f77179b`](https://github.com/NixOS/nixpkgs/commit/0f77179bcfa2e821d98889423d1f8a18e22952ee) quilt: wrap all required inputs
* [`89da7764`](https://github.com/NixOS/nixpkgs/commit/89da7764efd809a2238a5d6e2788e8e523df7444) quilt: add smancill as maintainer
* [`1ec1836d`](https://github.com/NixOS/nixpkgs/commit/1ec1836dfeee36a4616e5a34b5e19fd28669a88e) vimPlugins.inkpot: init at 2013-02-10
* [`ca4e61d5`](https://github.com/NixOS/nixpkgs/commit/ca4e61d58607c65691f32c31e4add106b27dfd2b) yarn2nix: run `nix-prefetch-git` with `--fetch-submodules`
* [`aa4c5bb7`](https://github.com/NixOS/nixpkgs/commit/aa4c5bb7cf0eb2210bad93483a26a8bb155cd814) hedgedoc: fix build by re-running `yarn2nix`
* [`cf28ad7e`](https://github.com/NixOS/nixpkgs/commit/cf28ad7e6f7cd14e489c5326a54117827f7cf89d) python3Packages.python3-application: refactor
* [`b20e68e6`](https://github.com/NixOS/nixpkgs/commit/b20e68e6230cb137b0fc23b38423465fbd4ba82a) trebleshot: remove
* [`a3fa65e4`](https://github.com/NixOS/nixpkgs/commit/a3fa65e48f0cb03e83f8eb16f31fa2cfec0ab606) linuxKernel.kernels.linux_xanmod: 5.14.7 -> 5.14.8
* [`5bd537cc`](https://github.com/NixOS/nixpkgs/commit/5bd537ccef03f3010e7709b170d6368cde45927e) fclones: 0.15.0 -> 0.16.0
* [`f339e9af`](https://github.com/NixOS/nixpkgs/commit/f339e9af4205498f7e003beb799d21dad5a43b33) sumneko-lua-language-server: set meta.mainProgram
