### PR TITLE
niv home-manager: update 371576cd -> cb09a968

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "371576cdc2580ba93a38e28da8ece2129f558815",
-        "sha256": "0vwkmnvc4pggicgzii4gg22pv5whp2aiian0rs80srwzkxl2sz0n",
+        "rev": "cb09a968e9b4ab12a8f203f454a1fba372a9fd71",
+        "sha256": "0nva46aix2wjab4b7prxf4c540fajj8a4xjm3b33a1r0jqaq0z52",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/371576cdc2580ba93a38e28da8ece2129f558815.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/cb09a968e9b4ab12a8f203f454a1fba372a9fd71.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@371576cd...cb09a968](https://github.com/nix-community/home-manager/compare/371576cdc2580ba93a38e28da8ece2129f558815...cb09a968e9b4ab12a8f203f454a1fba372a9fd71)

* [`7cb118c9`](https://github.com/nix-community/home-manager/commit/7cb118c9d232e36f8508686535dec8596c8c48a8) xdg: coerce XDG base directories settings to strings
* [`4320399a`](https://github.com/nix-community/home-manager/commit/4320399a3e5f3afb8a867324901a559f23be8178) flake: add docs to packages output
* [`821299e9`](https://github.com/nix-community/home-manager/commit/821299e90e6e11b5db5dc258b2d85d3b01e95857) sbt: run passwordCommand without trailing newline
* [`58aa667e`](https://github.com/nix-community/home-manager/commit/58aa667e28ca4a6a2159b1f3258ef5d494d5ecb6) starship: initialize using command in profile
* [`eee80756`](https://github.com/nix-community/home-manager/commit/eee807560b4c2c7cdda00913056429d85a090eeb) dbus: improve recommended NixOS configuration
* [`b0651cc2`](https://github.com/nix-community/home-manager/commit/b0651cc2173427857b172604f85da6afe69e1d41) nixos: import existing environment during activation
* [`cb09a968`](https://github.com/nix-community/home-manager/commit/cb09a968e9b4ab12a8f203f454a1fba372a9fd71) tests: add option `test.stubs`
