### PR TITLE
niv powerlevel10k: update 7a72acf5 -> 0ce9df66

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "7a72acf5635cfc09aa544bfb70e13ad46faa432b",
-        "sha256": "18qy4jz30hw2wm8scjsa6lb67ikchnsm94hhgl19whkqsqx6vi21",
+        "rev": "0ce9df66d2cffb860a7c48a8d4f3639cf581f908",
+        "sha256": "1cqq6scw3r1bdj5k60q8lhg4d6gciiag9hpdahwhir30160jk84r",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/7a72acf5635cfc09aa544bfb70e13ad46faa432b.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/0ce9df66d2cffb860a7c48a8d4f3639cf581f908.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@7a72acf5...0ce9df66](https://github.com/romkatv/powerlevel10k/compare/7a72acf5635cfc09aa544bfb70e13ad46faa432b...0ce9df66d2cffb860a7c48a8d4f3639cf581f908)

* [`0ce9df66`](https://github.com/romkatv/powerlevel10k/commit/0ce9df66d2cffb860a7c48a8d4f3639cf581f908) Add RHEL to the OS Icon lists ([romkatv/powerlevel10k⁠#1581](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1581))
