### PR TITLE
niv zsh-syntax-highlighting: update 6e0e9501 -> 1a9264bc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "6e0e950154a4c6983d9e077ed052298ad9126144",
-        "sha256": "09bkg1a7qs6kvnq17jnw5cbcjhz9sk259mv0d5mklqaifd0hms4v",
+        "rev": "1a9264bc661b3d52756916bf9ec3f41687d64db2",
+        "sha256": "119srhx1cy4bgj3v8lh5ydcgx70xvhc9kmj6mmgmdrrcc4an02xz",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/6e0e950154a4c6983d9e077ed052298ad9126144.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/1a9264bc661b3d52756916bf9ec3f41687d64db2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@6e0e9501...1a9264bc](https://github.com/zsh-users/zsh-syntax-highlighting/compare/6e0e950154a4c6983d9e077ed052298ad9126144...1a9264bc661b3d52756916bf9ec3f41687d64db2)

* [`f6a22fa8`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/f6a22fa842e0e6af00df2e9c21c8de6c4614d6fc) docs: Change highlighters' URL indexes from numbers to labels
* [`1a9264bc`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/1a9264bc661b3d52756916bf9ec3f41687d64db2) docs: Add `regexp` to the list of built-in highlighters
