### PR TITLE
niv nixpkgs: update da01cce1 -> 6b740f44

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da01cce16d9c8ef64b19d89d58839cb53718f2e3",
-        "sha256": "0n77b4dvjz5zwk6lwydzs1p82xvypcnymnbhwd1lcjgyzl2wbs1i",
+        "rev": "6b740f441f205f4b5e8695e4809fabee9afd8a8b",
+        "sha256": "1m9y7vcyrim3069lfrsni255lcs36vb5zlx6y12z9ckgz2pmnw5j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/da01cce16d9c8ef64b19d89d58839cb53718f2e3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6b740f441f205f4b5e8695e4809fabee9afd8a8b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@da01cce1...6b740f44](https://github.com/nixos/nixpkgs/compare/da01cce16d9c8ef64b19d89d58839cb53718f2e3...6b740f441f205f4b5e8695e4809fabee9afd8a8b)

* [`3ef60d4e`](https://github.com/NixOS/nixpkgs/commit/3ef60d4ee42c84be5baf71a2eb0f7deb4fe4a6b9) fcitx5: 5.0.8 -> 5.0.9
* [`5d5170c5`](https://github.com/NixOS/nixpkgs/commit/5d5170c5d7719fb9e85012cdda03e6dde8ec30ad) fcitx5-rime: 5.0.6 -> 5.0.7
* [`365413e2`](https://github.com/NixOS/nixpkgs/commit/365413e22fc68bb7e7695f29b21dd3fd7d3bf3f4) catcli: 0.7.2 -> 0.7.3
* [`db9d0731`](https://github.com/NixOS/nixpkgs/commit/db9d0731bae95d689b992cc5fb17c3e856f523a4) getmail6: 6.18.3 -> 6.18.4
* [`564e2a51`](https://github.com/NixOS/nixpkgs/commit/564e2a51876c8062727222e58ddb0fbd96289b1e) leo-editor: add meta.mainProgram
* [`e6654828`](https://github.com/NixOS/nixpkgs/commit/e6654828b8be4e89cd1ef01424aca412b009d87a) bashdb: 4.4-1.0.0 -> 5.0-1.1.2, fix build with bash 5.1
* [`bb7692db`](https://github.com/NixOS/nixpkgs/commit/bb7692db80c2fb76d349b188e72f56e3e911451c) ocamlPackages.gen: disable tests with OCaml < 4.08
* [`801b070c`](https://github.com/NixOS/nixpkgs/commit/801b070c408b49d7ee8b0c82378eafde26fcb9d0) ocamlPackages.stringext: disable tests with OCaml < 4.08
* [`5f16f0a9`](https://github.com/NixOS/nixpkgs/commit/5f16f0a9cf2b5b5249382e19b8e2206dbfb9fd12) ocamlPackages.batteries: disable tests with OCaml < 4.08
* [`049ca38a`](https://github.com/NixOS/nixpkgs/commit/049ca38a0c84f7c41467b006712340fd52f00043) ocamlPackages.containers: disable tests with OCaml < 4.08
* [`09f33fd8`](https://github.com/NixOS/nixpkgs/commit/09f33fd8aa06f5b5522cb50b309ee548fc3df4fe) ocamlPackages.stdint: disable tests with OCaml < 4.08
* [`6f85b0fa`](https://github.com/NixOS/nixpkgs/commit/6f85b0fa7b3b190152acb168ec2624697621891b) ocamlPackages.syslog-message: disable tests with OCaml < 4.08
* [`c5a5f7b1`](https://github.com/NixOS/nixpkgs/commit/c5a5f7b13df1191656974122d8a1a8b090fd810f) ocamlPackages.lru: disable tests with OCaml < 4.08
* [`8c32eb1a`](https://github.com/NixOS/nixpkgs/commit/8c32eb1a99963124c9a1203c690bddad796b7d8e) ocamlPackages.psq: disable tests with OCaml < 4.08
* [`f548ac9c`](https://github.com/NixOS/nixpkgs/commit/f548ac9c6cac47d36d9ed8c999b83c561b97f34d) ocamlPackages.iter: disable tests with OCaml < 4.08
* [`b99e43a9`](https://github.com/NixOS/nixpkgs/commit/b99e43a96eb85dc845f9e47afe71dbbaf1560ba7) ocamlPackages.reason-native.qcheck-rely: mark as broken
* [`f9c7333b`](https://github.com/NixOS/nixpkgs/commit/f9c7333bce5312e88795fb1f22b6191b93f45b07) ocamlPackages.qcheck: 0.17 → 0.18
* [`e50975e8`](https://github.com/NixOS/nixpkgs/commit/e50975e89d4405b0a7a82738207d8e7768fcd2dc) vsce/zxh404.vscode-proto3: init at 0.5.4
* [`cc49c13a`](https://github.com/NixOS/nixpkgs/commit/cc49c13a6bad964951093705128ab6c40c202066) nixos/postfix: Fix virtual alias manpage section
* [`8170f821`](https://github.com/NixOS/nixpkgs/commit/8170f8214059f822ab753515884455a34b42a971) jc: 1.16.2 -> 1.17.0
* [`baa04706`](https://github.com/NixOS/nixpkgs/commit/baa04706d7ac4b8c0d6c6d0eab41158176c25d36) lighttpd: add build options for new auth methods
* [`8a585fd5`](https://github.com/NixOS/nixpkgs/commit/8a585fd5c59bebb04434e2b7d0bfac1123b0a919) nixos/lighttpd: support new authentication modules
* [`5655e71e`](https://github.com/NixOS/nixpkgs/commit/5655e71eeeb7c47908ac92b3ff2f6c5073a30d76) lighttpd: remove null defaults for input packages
* [`042eebd8`](https://github.com/NixOS/nixpkgs/commit/042eebd8d91c16fbe44186bbf33b478c9edb780b) qgis: fix build with PROJ 8
* [`7e6325ef`](https://github.com/NixOS/nixpkgs/commit/7e6325efd413bd72df9b9a89af9669f843120b11) python3Packages.geopandas: fix tests
* [`98c8fc6f`](https://github.com/NixOS/nixpkgs/commit/98c8fc6fd01749b3aa7f28516ebfdefaab079cab) gplates: 2.2.0 -> 2.3.0
* [`7d38eec7`](https://github.com/NixOS/nixpkgs/commit/7d38eec7c55730af4e74049f2f7e6cb122ddff2c) qlandkartegt: use proj_7
* [`d08244d5`](https://github.com/NixOS/nixpkgs/commit/d08244d50ea6696a9fdf297fa2d81a30072ca039) sydbox: init at 2.2.0
* [`b24780c6`](https://github.com/NixOS/nixpkgs/commit/b24780c6b427c26ac24d745bf75111a6ea9f0138) vikunja-api: 0.18.0 -> 1.18.1
* [`7b03c7ee`](https://github.com/NixOS/nixpkgs/commit/7b03c7ee60844ecab58d45bd06e2c5f2f8336e64) vikunja-frontend: 0.18.0 -> 0.18.1
* [`7e0456bd`](https://github.com/NixOS/nixpkgs/commit/7e0456bd14aa8439e1b97f84c0ee35831e50a897) python3Packages.elkm1-lib: init at 1.0.0
* [`0945839a`](https://github.com/NixOS/nixpkgs/commit/0945839a586dfb72b3b069a7fb144f528cc23a84) home-assistant: update component-packages
* [`1363e03f`](https://github.com/NixOS/nixpkgs/commit/1363e03f345b0c23aa9b0e543cc6d589503d3b82) home-assistant: enable elkm1 tests
* [`194eb792`](https://github.com/NixOS/nixpkgs/commit/194eb792885f676df6098ae97692192e0a3abbf2) python3Packages.lupupy: init at 0.0.21
* [`541fd993`](https://github.com/NixOS/nixpkgs/commit/541fd9936db69116a94fb3dbe9eff5bd00c4460f) home-assistant: update component-packages
* [`a649cbca`](https://github.com/NixOS/nixpkgs/commit/a649cbca0948c39c43c63b790c75b5b6e4db1564) resholvePackage: extract util functions
* [`67ec4fa4`](https://github.com/NixOS/nixpkgs/commit/67ec4fa479b82a264ee647785df261f0f12b7f05) resholve: fix review nits from [nixos/nixpkgs⁠#138080](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/138080)
* [`b5833091`](https://github.com/NixOS/nixpkgs/commit/b5833091d4d24e7a742df703a4b02acfe8f4ecb1) resholve: 0.6.0 -> 0.6.1, add resholveScript* fns
* [`6568f18e`](https://github.com/NixOS/nixpkgs/commit/6568f18ea3a3b32f53cbcd2db90915128edd21d3) resholve: 0.6.1 -> 0.6.2
* [`679b29d3`](https://github.com/NixOS/nixpkgs/commit/679b29d33d8fc2609cbc6789512075b9af918dd3) resholve: 0.6.2 -> 0.6.3, fix readme
* [`8b2cd3a7`](https://github.com/NixOS/nixpkgs/commit/8b2cd3a79af041687d60c475c4462a25c60bf351) resholve: 0.6.3 -> 0.6.4
* [`407ff075`](https://github.com/NixOS/nixpkgs/commit/407ff07598afac2754d83923aff1b9e4f5e5d66a) resholve: 0.6.4 -> 0.6.5
* [`1dd78cbd`](https://github.com/NixOS/nixpkgs/commit/1dd78cbd74e8b85354d8902ead8090ae3f69d170) resholve: 0.6.5 -> 0.6.6, respect buildInputs
* [`56c47107`](https://github.com/NixOS/nixpkgs/commit/56c4710770540700f2b02e2a94a692cc5a4541dd) python3Packages.ge25519: 0.2.0 -> 1.0.0
* [`77187783`](https://github.com/NixOS/nixpkgs/commit/77187783c4544c8c455e29fd5da1b3af6402ef9a) python3Packages.fe25519: 0.3.0 -> 1.0.0
* [`97034cfa`](https://github.com/NixOS/nixpkgs/commit/97034cfa1c3b455f1114fea8d302925014dd4bd8) discourse.plugins.discourse-github: Update
* [`b1aa7efd`](https://github.com/NixOS/nixpkgs/commit/b1aa7efd36d1e8c9df8f97602038b98533f84cf9) discourse.plugins.discourse-math: Update
* [`fd084acb`](https://github.com/NixOS/nixpkgs/commit/fd084acb95f3e80a80405924e44002e2e4f6dd0e) discourse.plugins.discourse-solved: Update
* [`957eaf82`](https://github.com/NixOS/nixpkgs/commit/957eaf8237a44f6849716739d35057b7ceaba84c) discourse.plugins.discourse-spoiler-alert: Update
* [`e4ed6b59`](https://github.com/NixOS/nixpkgs/commit/e4ed6b5929d56328e79ad8792568790f6c077251) discourse.plugins.discourse-yearly-review: Update
* [`ed8c4e01`](https://github.com/NixOS/nixpkgs/commit/ed8c4e01d985d115f8821106318afc65fc7eaf5f) discourse: Enable jhead, which is no longer marked vulnerable
* [`f9067c45`](https://github.com/NixOS/nixpkgs/commit/f9067c45f1bab132bbdb3070148490ae6c2358fa) rPackages: update package set
* [`85f963ca`](https://github.com/NixOS/nixpkgs/commit/85f963cacadee53e90b9e5b4881a6c6443a7f109) rPackages.s2: add missing buildInput
* [`3f726202`](https://github.com/NixOS/nixpkgs/commit/3f72620275f1b58bf66fa6e99b10d365a8f136f7) rPackages.ArrayExpressHTS: add missing buildInputs
* [`353fea87`](https://github.com/NixOS/nixpkgs/commit/353fea8792f9362cf8c379eb85e38121ab4fb3dd) rPackages.bbl: add missing gsl dependency
* [`6df27f31`](https://github.com/NixOS/nixpkgs/commit/6df27f31095e4f1f7362a86dd3712b884a5c86ec) rPackages.writexl: add zlib dependency
* [`fcd7af4a`](https://github.com/NixOS/nixpkgs/commit/fcd7af4a53b8c3e4d27150a9b0ce799e94768865) rPackages.qpdf: fix build
* [`d17b0978`](https://github.com/NixOS/nixpkgs/commit/d17b097899f1b1f17652d03a6b2ba2081a351774) rPackages.ggbio: fix build
* [`ff6652c1`](https://github.com/NixOS/nixpkgs/commit/ff6652c17c3f0dfd0a7940495a585996bbeb564f) rPackages.vcfR: fix build
* [`e1c79634`](https://github.com/NixOS/nixpkgs/commit/e1c796341a265f864b77118bdf40a20bc01bafaa) rPackages.bio3d: fix build
* [`1af3c328`](https://github.com/NixOS/nixpkgs/commit/1af3c32897666703384e747eda198666514f94de) rPackages.sodium: fix build
* [`17ffaf2a`](https://github.com/NixOS/nixpkgs/commit/17ffaf2a07c561ebb4703ffc78d62c503b8af643) rPackages.arrangements: fix build
* [`2bed59ab`](https://github.com/NixOS/nixpkgs/commit/2bed59ab862d4df7dac67b5be6c69534fabf67c4) rPackages.loon: fix build
* [`c60aa79a`](https://github.com/NixOS/nixpkgs/commit/c60aa79a646473fe20b528cb0c2b1b344a8181ef) rPackages.spp: fix build
* [`ff0b840c`](https://github.com/NixOS/nixpkgs/commit/ff0b840c6ca7a1294952e403377cafb71f191a00) rPackages.Rbowtie: fix build
* [`a0802ef5`](https://github.com/NixOS/nixpkgs/commit/a0802ef5a596926c270656f72383b35cbea9da9f) rPackages.gaston: fix build
* [`5ed5a62c`](https://github.com/NixOS/nixpkgs/commit/5ed5a62cae89677f5870202f137dc7b0f01a9999) rPackages.Rhtslib: passthrough libcurl to dependents correctly
* [`831fa2f7`](https://github.com/NixOS/nixpkgs/commit/831fa2f7b97c840e80f76a97f99dbcced3b5f4c8) rPackages.csaw: fix build
* [`320235ce`](https://github.com/NixOS/nixpkgs/commit/320235ce214d1078eb98cccabc1c2287a66b4680) vimUtils.packDir: expose packDir function
* [`a72cf113`](https://github.com/NixOS/nixpkgs/commit/a72cf113d8d6f8dbdb5ef8037702b2c31d90111f) Update pkgs/applications/audio/spot/default.nix
* [`8278a467`](https://github.com/NixOS/nixpkgs/commit/8278a4679be8088c5353ffac78de2687b21d6d3b) luaPackages.luv: 1.30.0-0 -> 1.42.0-0
* [`66afaccb`](https://github.com/NixOS/nixpkgs/commit/66afaccb81c8db8294bbd8d5476c96bfaf33570f) luaPackages: update
* [`7005f1e6`](https://github.com/NixOS/nixpkgs/commit/7005f1e6e25968de72e67a93fc8116bc8263dffb) neovim: 0.5.0 -> 0.5.1
* [`39f0cfdd`](https://github.com/NixOS/nixpkgs/commit/39f0cfdd12119d991225c6ab2d7e4483d67cf0a3) vimPlugins.deoplete-emoji: Drop plugin
* [`1cbb0fea`](https://github.com/NixOS/nixpkgs/commit/1cbb0feae596544af67bec58c8282de9e31d807b) erlang: fix nix-env version confusion
* [`bf33c0e6`](https://github.com/NixOS/nixpkgs/commit/bf33c0e62e24d95edd7808ff6c19409212da1f96) skawarePackages: Fall 2021 release
* [`843dca38`](https://github.com/NixOS/nixpkgs/commit/843dca38b836801f153d43669d2f95852d6aa637) fdtools: pin to older skalibs version
* [`457ff383`](https://github.com/NixOS/nixpkgs/commit/457ff3835c48d091fe0ba9e16dc8381703469c09) doc: fix misspelling ([nixos/nixpkgs⁠#139623](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139623))
* [`df3b026c`](https://github.com/NixOS/nixpkgs/commit/df3b026cc90dd0e92b305ff02896c44c31801d68) hck: 0.6.5 -> 0.6.6
* [`39d038d1`](https://github.com/NixOS/nixpkgs/commit/39d038d14d05c9095808b3230980d64181d9a096) Fix metrics job
* [`7f5d66c5`](https://github.com/NixOS/nixpkgs/commit/7f5d66c5ba3cb720cd7ab7685e24f672658164c0) Revert "nixpkgs-unstable channel: don't depend on the metrics job"
* [`a954cb10`](https://github.com/NixOS/nixpkgs/commit/a954cb109d7560e79ff3149240f360747f02a685) ocr-a: init at 1.0
* [`3fc12275`](https://github.com/NixOS/nixpkgs/commit/3fc12275e6029b4622051ede24c45f0e4168aeea) pkgsStatic.capnproto: fix build
* [`860b938b`](https://github.com/NixOS/nixpkgs/commit/860b938bbf27d6b44d0ea60ec5a0ff1320072291) capnproto: fix cross
* [`bf12e3f2`](https://github.com/NixOS/nixpkgs/commit/bf12e3f2a3ad2a937955661a2d169e2c9fc25188) weechatScripts.zncplayback: init at 0.2.1
* [`05bdbc55`](https://github.com/NixOS/nixpkgs/commit/05bdbc55ffb15fbbf92a487664f1d4421542cb90) plasma5Packages: add missing homepages and descriptions
* [`e9bd47e6`](https://github.com/NixOS/nixpkgs/commit/e9bd47e681ae711b522674953e2e17d657adfc99) pkgsi686Linux.pkgsStatic.libgpgerror: fix build
* [`f5f386d2`](https://github.com/NixOS/nixpkgs/commit/f5f386d297f8ba8e5527c78de2f11b12daded6f6) nixos/syncoid: Delegate permissions to parent dataset if target is missing
* [`90c22863`](https://github.com/NixOS/nixpkgs/commit/90c2286300df73ccec96e7d04a809eaebd105be5) zcash: 4.4.1 -> 4.5.0
* [`1e05c4ea`](https://github.com/NixOS/nixpkgs/commit/1e05c4eae9ec704b7057dcec87cf5007d6a081ac) linux/hardened/patches/4.14: 4.14.247-hardened1 -> 4.14.248-hardened1
* [`9e78068b`](https://github.com/NixOS/nixpkgs/commit/9e78068b041dfebbac36958d6745bc3ef2415d5d) linux/hardened/patches/4.19: 4.19.207-hardened1 -> 4.19.208-hardened1
* [`c4ea02fc`](https://github.com/NixOS/nixpkgs/commit/c4ea02fc5c468ebd06f9575eb764ad4d08c8fdd6) linux/hardened/patches/5.10: 5.10.68-hardened1 -> 5.10.69-hardened1
* [`05ed561f`](https://github.com/NixOS/nixpkgs/commit/05ed561fb6de4fce668d5c5d1c2c7ae18ab8aff5) linux/hardened/patches/5.14: 5.14.7-hardened1 -> 5.14.8-hardened1
* [`a92a208a`](https://github.com/NixOS/nixpkgs/commit/a92a208a9d8eaba19a5d985f567387adea455687) linux/hardened/patches/5.4: 5.4.148-hardened1 -> 5.4.149-hardened1
* [`ba6a2ecc`](https://github.com/NixOS/nixpkgs/commit/ba6a2ecc641312e31983405491b8b4233f2b0b98) wine: only embed mono & gecko installers in winePackages.full
* [`abc36451`](https://github.com/NixOS/nixpkgs/commit/abc36451d78d4c36a57a3acc7ce2f08e40789e72) lua: create a folder for hooks
* [`54d2bd8d`](https://github.com/NixOS/nixpkgs/commit/54d2bd8df5dedfcb710c6f092d798a259066cbaf) chrysalis: 0.8.4 -> 0.8.5
* [`2174c771`](https://github.com/NixOS/nixpkgs/commit/2174c7715f2b122d3b3f55c084cab7355e7bd725) ardour_5: remove package
* [`aed860f8`](https://github.com/NixOS/nixpkgs/commit/aed860f87662825abdad405b0b5008013e42d042) nixos/zoneminder: not using zoneminder any longer
* [`35dbdedf`](https://github.com/NixOS/nixpkgs/commit/35dbdedf6337ffe6a003990697b114bea728b11a) vala: not using vala
* [`35cad8da`](https://github.com/NixOS/nixpkgs/commit/35cad8da44b44a174798e19d03b81bd995ac5de0) heroku: remove peterhoeg as maintainer
* [`dc72e18d`](https://github.com/NixOS/nixpkgs/commit/dc72e18d5f34b3605ae9d7996984eaab239ef460) quaternion: 0.0.9.5-beta2 -> 0.0.95
* [`50e10fe0`](https://github.com/NixOS/nixpkgs/commit/50e10fe084d4d095e6ff533302d6e4e6ddc75780) viddy: init at 0.3.1
* [`5cf2600f`](https://github.com/NixOS/nixpkgs/commit/5cf2600ff265a31ef7c13efb37eb12606590b80b) python38Packages.google-cloud-kms: 2.6.0 -> 2.6.1
* [`7db32410`](https://github.com/NixOS/nixpkgs/commit/7db32410760ccdbbb43283dbc0371542c7dada09) ocamlPackages.ocsigen-toolkit: 2.12.2 → 3.0.1
* [`c636fcf4`](https://github.com/NixOS/nixpkgs/commit/c636fcf47fcdee88f4685c9ebcc4579875518b4c) python38Packages.google-cloud-redis: 2.2.2 -> 2.2.3
* [`2c138410`](https://github.com/NixOS/nixpkgs/commit/2c13841060b5fc1927231191d60c9df4f17a6d0a) python38Packages.google-cloud-trace: 1.3.2 -> 1.3.3
* [`33987745`](https://github.com/NixOS/nixpkgs/commit/33987745849749c2f4f8117882433f4e470c6cbf) python38Packages.google-cloud-vision: 2.4.2 -> 2.4.3
* [`6e75f7c8`](https://github.com/NixOS/nixpkgs/commit/6e75f7c8627f90b90c59d69d9db7f640fb75c3e7) linuxPackages.system76: 1.0.9 -> 1.0.12
* [`382d842d`](https://github.com/NixOS/nixpkgs/commit/382d842d217c7063ed6e64deff93d85311b2ba4e) linuxPackages.system76-acpi: 1.0.1 -> 1.0.2
* [`81e81903`](https://github.com/NixOS/nixpkgs/commit/81e81903d824f5d46025f34f08135d1eef80bc31) python38Packages.google-cloud-appengine-logging: 0.1.4 -> 0.1.5
* [`52ceb66f`](https://github.com/NixOS/nixpkgs/commit/52ceb66f21c8c85bb88076f5f8f64176ffa10b80) python38Packages.google-cloud-asset: 3.5.0 -> 3.6.0
* [`69ed54bf`](https://github.com/NixOS/nixpkgs/commit/69ed54bf9a94c5b9b3762cf2c3865e97a5c335cb) python38Packages.google-cloud-asset: 3.5.0 -> 3.6.0
* [`7a045776`](https://github.com/NixOS/nixpkgs/commit/7a045776215dab56dee7d2487e16cf53cd00add8) python38Packages.google-cloud-bigquery-logging: 0.2.1 -> 0.2.2
* [`41159766`](https://github.com/NixOS/nixpkgs/commit/41159766fc98c4f050a85ce6f8ccb0975c0b5bbf) python38Packages.google-cloud-monitoring: 2.5.0 -> 2.5.1
* [`9f2d83fd`](https://github.com/NixOS/nixpkgs/commit/9f2d83fd261ef9174e236d650052edcd12b32e1a) python38Packages.google-cloud-datacatalog: 3.4.1 -> 3.4.2
* [`4e1c790f`](https://github.com/NixOS/nixpkgs/commit/4e1c790fbc2fb583da483736638e2787d1f71bd2) python38Packages.google-cloud-texttospeech: 2.5.2 -> 2.5.3
* [`abe608c4`](https://github.com/NixOS/nixpkgs/commit/abe608c4405f0b38df78244ca9799a4fee1c7a3f) python38Packages.google-cloud-error-reporting: 1.2.2 -> 1.2.3
* [`fd8c892b`](https://github.com/NixOS/nixpkgs/commit/fd8c892b438ea700b2aad1663d152ff023e57027) python38Packages.google-cloud-securitycenter: 1.5.0 -> 1.5.1
* [`31efca77`](https://github.com/NixOS/nixpkgs/commit/31efca77d1cb114f713d777d4c09bb1037a81fba) git-remote-hg: unstable-2020-06-12 -> 1.0.2.1
* [`ff2be416`](https://github.com/NixOS/nixpkgs/commit/ff2be4167b0c3ad3765550d2d32eec8824d4d876) python38Packages.google-cloud-org-policy: 1.0.1 -> 1.0.2
* [`742f90c4`](https://github.com/NixOS/nixpkgs/commit/742f90c464284b7ccebac3ca50d3c9409e9f55c9) python38Packages.google-cloud-videointelligence: 2.3.2 -> 2.3.3
* [`7b666d26`](https://github.com/NixOS/nixpkgs/commit/7b666d266877502092e73d85f41797540f30e473) python38Packages.google-cloud-iam-logging: 0.1.2 -> 0.1.3
* [`547f1386`](https://github.com/NixOS/nixpkgs/commit/547f1386d3372ee0a1688634984bed1459d133e9) release-cross.nix: test cross compilation to x86_64-netbsd
* [`47972275`](https://github.com/NixOS/nixpkgs/commit/47972275ef53c60878b87a3b007a2995299d30af) python38Packages.google-cloud-monitoring: 2.5.0 -> 2.5.1
* [`6edc2500`](https://github.com/NixOS/nixpkgs/commit/6edc25002f8a4ddd532837381e53280c18f2ef8b) python38Packages.google-cloud-org-policy: 1.0.1 -> 1.0.2
* [`c76eb10d`](https://github.com/NixOS/nixpkgs/commit/c76eb10d993de743150e86c631b79b282730954d) python38Packages.google-cloud-redis: 2.2.2 -> 2.2.3
* [`d0a430f9`](https://github.com/NixOS/nixpkgs/commit/d0a430f90a51c5246552f550d973d735cf07202e) python38Packages.google-cloud-securitycenter: 1.5.0 -> 1.5.1
* [`c21ba4f7`](https://github.com/NixOS/nixpkgs/commit/c21ba4f7bb4a3d621eb1d187e6b5e816bb85380c) linux: fix cross-build dependencies
* [`349f17c7`](https://github.com/NixOS/nixpkgs/commit/349f17c7bd11b3c809fed46cc018409a825e145e) python38Packages.google-cloud-error-reporting: 1.2.2 -> 1.2.3
* [`eafd84da`](https://github.com/NixOS/nixpkgs/commit/eafd84daba871f7bd3bc2be910414dd020a3a9d4) python38Packages.google-cloud-texttospeech: 2.5.2 -> 2.5.3
* [`52d27921`](https://github.com/NixOS/nixpkgs/commit/52d2792162eb53f1e6f9f107dc2a167e1afb82ad) btop: 1.0.5 -> 1.0.9
* [`0f58eabc`](https://github.com/NixOS/nixpkgs/commit/0f58eabc1f69da0d362f1c73a00f8034d7aebc22) python38Packages.google-cloud-trace: 1.3.2 -> 1.3.3
* [`52117f9b`](https://github.com/NixOS/nixpkgs/commit/52117f9bf5a4fad222c1fd53885f64315d4b4f30) python38Packages.google-cloud-websecurityscanner: 1.4.1 -> 1.4.2
* [`b5873a97`](https://github.com/NixOS/nixpkgs/commit/b5873a97ecf39ade633e9062bc2487f30874178a) python38Packages.google-cloud-videointelligence: 2.3.2 -> 2.3.3
* [`a1048fcc`](https://github.com/NixOS/nixpkgs/commit/a1048fcc30d7cbb9fbe16d3e5794f24952b9f913) python38Packages.google-cloud-vision: 2.4.2 -> 2.4.3
* [`fb794d24`](https://github.com/NixOS/nixpkgs/commit/fb794d24c809a2010d96bf687c27ae7c9dff87d8) python38Packages.intensity-normalization: 2.0.1 -> 2.0.2
* [`afe7bbe0`](https://github.com/NixOS/nixpkgs/commit/afe7bbe071a8c4a8baa3f66b3e4530bf63ea43f6) esphome: 2021.9.1 -> 2021.9.2
* [`387bdb87`](https://github.com/NixOS/nixpkgs/commit/387bdb87512bd344bcf0f7ec53db575ff60815b5) tfsec: 0.58.10 -> 0.58.11
* [`e964f487`](https://github.com/NixOS/nixpkgs/commit/e964f487f69288c00a964de681957f20c227cd63) python38Packages.sentry-sdk: 1.4.1 -> 1.4.2
* [`11aadc46`](https://github.com/NixOS/nixpkgs/commit/11aadc4658f20a1228cecf29722ad4f865155c1b) python38Packages.jupyterlab: 3.1.13 -> 3.1.14
* [`fbdf7d22`](https://github.com/NixOS/nixpkgs/commit/fbdf7d2206786aada8716552e6966f699b3d4653) stellarium: 0.21.1 -> 0.21.2
* [`be499cf8`](https://github.com/NixOS/nixpkgs/commit/be499cf85eec9a067141cd7e64cdaa979cf7fcfc) vimPlugins.crates-nvim: fix branch name
* [`daa817d2`](https://github.com/NixOS/nixpkgs/commit/daa817d23ab35e4b5e3f3e9841d462f051ce51d3) vimPlugins: update
* [`fd7d5824`](https://github.com/NixOS/nixpkgs/commit/fd7d5824556ec20ddc2a42da05cb14dadb09508c) vimPlugins.nvim-code-action-menu: init at 2021-09-28
* [`b1adc893`](https://github.com/NixOS/nixpkgs/commit/b1adc89386998dae3c7ee05126ec881709e82d02) spot: 0.1.14 -> 0.2.0 ([nixos/nixpkgs⁠#137435](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137435))
* [`b1a7f33b`](https://github.com/NixOS/nixpkgs/commit/b1a7f33b3927eede727144d1761c0afe61676706) firefox-bin: fix license
* [`5282622c`](https://github.com/NixOS/nixpkgs/commit/5282622cf542bf05e7892f256410402847f75276) home-assistant: relax voluptuous constraint
* [`2cbdd8d8`](https://github.com/NixOS/nixpkgs/commit/2cbdd8d88670e8cba97d4b07e7af1b581c19162c) aminal: remove ([nixos/nixpkgs⁠#139747](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139747))
* [`bbd54564`](https://github.com/NixOS/nixpkgs/commit/bbd545646b762f09b2d986074c796c3e7de97801) polkadot: 0.9.9-1 -> 0.9.10 ([nixos/nixpkgs⁠#139660](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139660))
* [`62eff259`](https://github.com/NixOS/nixpkgs/commit/62eff2592ca6324546ed8745f440f4959307dc27) python38Packages.pulp: 2.5.0 -> 2.5.1 ([nixos/nixpkgs⁠#139760](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139760))
* [`6b740f44`](https://github.com/NixOS/nixpkgs/commit/6b740f441f205f4b5e8695e4809fabee9afd8a8b) lm_sensors: fix for cross compilation ([nixos/nixpkgs⁠#139577](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139577))
