### PR TITLE
niv nixpkgs: update 7097c8fe -> 1c0a20ef

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7097c8fef12fa818982e8e99aef238e4cd4b2311",
-        "sha256": "1w1134a5bmrmnwbf8b8vs2blyhilf6z7h900yknwa24abhjpgc98",
+        "rev": "1c0a20efcfdb40d7a08078e436baade866f83b0f",
+        "sha256": "1k5f0sg1vvvvgld6llbqskwd0spqaf6wd6zf2b52hqc3clcqryak",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7097c8fef12fa818982e8e99aef238e4cd4b2311.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/1c0a20efcfdb40d7a08078e436baade866f83b0f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7097c8fe...1c0a20ef](https://github.com/nixos/nixpkgs/compare/7097c8fef12fa818982e8e99aef238e4cd4b2311...1c0a20efcfdb40d7a08078e436baade866f83b0f)

* [`642eb3f6`](https://github.com/NixOS/nixpkgs/commit/642eb3f64179dfce0789823d14cbee8f390e329e) goaccess: 1.5.1 -> 1.5.2
* [`b4ba2917`](https://github.com/NixOS/nixpkgs/commit/b4ba29173d06674a764a666c358bfa5d3b1e3983) python3Packages.nunavut: fix build
* [`ac2a0f27`](https://github.com/NixOS/nixpkgs/commit/ac2a0f27573ebf76f3aaa5b16c027f3cf98aa839) python3Packages.ocrmypdf: set version manually
* [`0219679e`](https://github.com/NixOS/nixpkgs/commit/0219679ed0d2325e5c828e1ef16ad4a5c7cfdb2e) mpvScripts.mpv-playlistmanager: unstable-2021-08-17 -> unstable-2021-09-27
* [`dedd0f63`](https://github.com/NixOS/nixpkgs/commit/dedd0f6308443d85d7117bc78698a4761d868ca9) python3Packages.pyserial-asyncio: 0.5 -> 0.6
* [`775c2a23`](https://github.com/NixOS/nixpkgs/commit/775c2a236b9be4f023394b9cef408dfe4e82a620) python3Packages.pyserial-asyncio: add pythonImportsCheck
* [`dbd9ca8d`](https://github.com/NixOS/nixpkgs/commit/dbd9ca8d1b3a02f29f68c2a3c9058e31ab8ed93f) python3Packages.pyturbojpeg: 1.5.4 -> 1.6.1
* [`4766e365`](https://github.com/NixOS/nixpkgs/commit/4766e365d34b7a9925b79f19e5e1bfe691b72294) cni-plugin-flannel: 1.0 -> 1.1
* [`e18f0df4`](https://github.com/NixOS/nixpkgs/commit/e18f0df44bce45e39c3db7e0916b56e215ee273a) sonarr: 3.0.6.1266 -> 3.0.6.1342
* [`a4df6db5`](https://github.com/NixOS/nixpkgs/commit/a4df6db57dd68f7d5dad5dd56aadae57327048d2) rpl: update to 4467bd4 ([nixos/nixpkgs⁠#140161](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140161))
* [`37668736`](https://github.com/NixOS/nixpkgs/commit/376687365050b4cd7fb72151a527c99d135725bc) rpl: remove superfluous let in
* [`175dbdb0`](https://github.com/NixOS/nixpkgs/commit/175dbdb076189b1da5770a2de05e0dd42b1981bf) croc: 9.3.0 -> 9.4.2
* [`98ca06bd`](https://github.com/NixOS/nixpkgs/commit/98ca06bd04c1b96929712087383f2bef189c960c) vimPlugins.markdown-preview-nvim: remove executable check
* [`537d144f`](https://github.com/NixOS/nixpkgs/commit/537d144f64b0da61f3562a7fa756b160179acba8) libdecor: fix cross compile
* [`d5a9d969`](https://github.com/NixOS/nixpkgs/commit/d5a9d96982d15ae5770af5975c52266ca2514ef4) direwolf: fix build
* [`ad7fdc00`](https://github.com/NixOS/nixpkgs/commit/ad7fdc005eaed6a17dab4dcefe3ac2322a269f43) vimPlugins: update
* [`96c0f7e4`](https://github.com/NixOS/nixpkgs/commit/96c0f7e4ddf2104da88ff5a098163b73677d5b2d) rustPackages.rls: Fix 1.55 build on Darwin ([nixos/nixpkgs⁠#140232](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140232))
* [`f017f692`](https://github.com/NixOS/nixpkgs/commit/f017f6926e9e4f80b10288e4059476ed01875db5) maintainers: add @⁠matilde-ametrine
* [`4702df22`](https://github.com/NixOS/nixpkgs/commit/4702df224b9ddd58d93afa51f888faa227d0aa6a) electron_14: 14.0.1 -> 14.1.0
* [`e2a89b0e`](https://github.com/NixOS/nixpkgs/commit/e2a89b0e46a724f59dedc7780e9763a9b4f20b6e) electron_13: 13.4.0 -> 13.5.1
* [`925e11b8`](https://github.com/NixOS/nixpkgs/commit/925e11b83225053f54ee834b649ab85789f035a8) obspy: init at 1.2.2
* [`8ce19c93`](https://github.com/NixOS/nixpkgs/commit/8ce19c9399370cb9c173af1b15bf970004946258) electron_12: 12.1.2 -> 12.2.1
* [`d37df0b6`](https://github.com/NixOS/nixpkgs/commit/d37df0b6756ee7633a05f7a3e2fc94a0ba798fef) vimPlugins.nightfox-nvim: init at 2021-10-01
* [`3a5f9bd5`](https://github.com/NixOS/nixpkgs/commit/3a5f9bd5e5b43fd46b97cb12c42efe2c8f0d9f3c) vivaldi-ffmpeg-codecs: 78.0.3904.70 -> 94.0.4606.50
* [`89032313`](https://github.com/NixOS/nixpkgs/commit/89032313ca28ecc6a30abbc4b64d9dccaf499209) redis: set mainProgram to redis-cli
* [`c0cc04d5`](https://github.com/NixOS/nixpkgs/commit/c0cc04d550929696ce4be92d55b7e2b125c37261) linode-cli: fix escape on updateScript
* [`39f00331`](https://github.com/NixOS/nixpkgs/commit/39f00331dd68f1eca9dfdb68292a94ae03dac1aa) k3s: fix escape on updateScript
* [`bf2a7069`](https://github.com/NixOS/nixpkgs/commit/bf2a70691bbe7572caf94b7cf809ed689edac767) fluxcd: fix escape on updateScript
* [`247bdd7f`](https://github.com/NixOS/nixpkgs/commit/247bdd7f70d94ef4ff51a098c57fa80c919efb9d) python3Packages.marisa-trie: add readme_renderer ([nixos/nixpkgs⁠#140323](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140323))
* [`bbaa9914`](https://github.com/NixOS/nixpkgs/commit/bbaa9914f86f600f9ac2cdf7709e14aea94c2215) python38Packages.awscrt: 0.12.3 -> 0.12.4
* [`b8cb98d6`](https://github.com/NixOS/nixpkgs/commit/b8cb98d6be52b4178e98ec9d264290d308a1c012) nvchecker: 2.4 -> 2.5
* [`afd261cf`](https://github.com/NixOS/nixpkgs/commit/afd261cf930eed5b597f56dd4ef2e4a87c3c64c5) drawterm: unstable-2021-08-02 -> unstable-2021-10-02
* [`2e4938eb`](https://github.com/NixOS/nixpkgs/commit/2e4938eb6a7d594aa3884e903ac40270c5af2258) cfdyndns: fix startAt by setting it to *:0/5 instead of 5 minutes
* [`5e7aab59`](https://github.com/NixOS/nixpkgs/commit/5e7aab598257d7f0cde7c9fe2617c8801e224b9d) lemmy-ui: add static assets folder to out
* [`98ae18fa`](https://github.com/NixOS/nixpkgs/commit/98ae18fa62979ac9837629a39fb18234fcc74772) linux_testing_bcachefs: upstream tarballs rather patchsets
* [`f022b391`](https://github.com/NixOS/nixpkgs/commit/f022b39125e441c4b17d5034f9369c43b0c5ce52) python38Packages.digital-ocean: 1.16.0 -> 1.17.0
* [`358659d6`](https://github.com/NixOS/nixpkgs/commit/358659d668d5740384b165ff38ff721cfe62aeec) yarn: 1.22.11 -> 1.22.15
* [`f05a7c4a`](https://github.com/NixOS/nixpkgs/commit/f05a7c4a4bd18bf285db853139d27a5f2a66ec78) checkmate: 0.4.1 -> 0.4.5
* [`0e686577`](https://github.com/NixOS/nixpkgs/commit/0e686577c1c26cba2b450e0b267ee419f187c5ea) lagrange: 1.6.5 → 1.7.1
* [`dfb2073a`](https://github.com/NixOS/nixpkgs/commit/dfb2073a3e550acef418e5c7698f9412bcdc4a22) python38Packages.idasen: 0.7.1 -> 0.8.0
* [`e75f346a`](https://github.com/NixOS/nixpkgs/commit/e75f346aa309515fa220f6d2124a27f72e245b69) lib: add function escapeXML
* [`8436c0e3`](https://github.com/NixOS/nixpkgs/commit/8436c0e33a6af1db1153064c0e501d7e14fdf6bf) python3Packages.maestral: 1.4.8 -> 1.5.0
* [`820feb8e`](https://github.com/NixOS/nixpkgs/commit/820feb8e8c77e3a5481294cdd85aaf337b52006a) maestral-gui: 1.4.8 -> 1.5.0
* [`a5fc6faf`](https://github.com/NixOS/nixpkgs/commit/a5fc6faf043a65a3a75a6a3ca40add3af0bbffe6) python38Packages.monkeyhex: 1.7.1 -> 1.7.2
* [`1b9dbf40`](https://github.com/NixOS/nixpkgs/commit/1b9dbf407cf8ab3502db9d884288de93d53351dc) beam: mix-release: do not use substituteInPlace on binaries
* [`2b0a7ef8`](https://github.com/NixOS/nixpkgs/commit/2b0a7ef8f2e234470315e89c43765cb2258b2afe) nixos/hqplayerd: do not make manual depend on (unfree) hqplayerd
* [`f6e06020`](https://github.com/NixOS/nixpkgs/commit/f6e0602096d78336dbd218878b5b98aaca005b20) linkerd: add updateScript
* [`0f0ffc5e`](https://github.com/NixOS/nixpkgs/commit/0f0ffc5e867cbd93134c13396174f7cc6ebe10a9) v2ray: 4.42.1 -> 4.43.0
* [`729c2419`](https://github.com/NixOS/nixpkgs/commit/729c241932faee3ef9aeeeca1a861a4bc1aaf96a) maintainers: Update vanilla keys.
* [`15567f5a`](https://github.com/NixOS/nixpkgs/commit/15567f5a16fd512af0eb954451433bef04cec03a) testssl: 3.0.5 -> 3.0.6
* [`bc56346b`](https://github.com/NixOS/nixpkgs/commit/bc56346bcdeec61a13c0b44310b3236a2ef0e440) openssh_hpn/openssh_gssapi: Add CVE-2021-41617
* [`5daa5d3b`](https://github.com/NixOS/nixpkgs/commit/5daa5d3b23590c6a7f5a32e413128b91b9153bd6) python38Packages.pyhomematic: 0.1.74 -> 0.1.75
* [`e4f15f27`](https://github.com/NixOS/nixpkgs/commit/e4f15f27fd51c07843d5027537a474abf1b4687c) mpdevil: add missing libnotify dependency
* [`7ef5416a`](https://github.com/NixOS/nixpkgs/commit/7ef5416aea91f09cb3ab29bae327f62f035ae4e2) taskwarrior: 2.5.3 -> 2.6.0
* [`0d1421c5`](https://github.com/NixOS/nixpkgs/commit/0d1421c5c5fc0c51ec5033c8e8303d4b04e65d5c) exploitdb: 2021-09-30 -> 2021-10-02
* [`770cdc38`](https://github.com/NixOS/nixpkgs/commit/770cdc3897da0f2f183d431d4286dcf6f193ab5b) python38Packages.python-osc: 1.7.7 -> 1.8.0
* [`5895ece3`](https://github.com/NixOS/nixpkgs/commit/5895ece3b943092ce2a73b396bf607a0af39e8ee) mopidy-youtube: 3.2 -> 3.4
* [`c7fc01cd`](https://github.com/NixOS/nixpkgs/commit/c7fc01cd77b4b45ae469f3aac25496384c527861) aerospike: drop blanket -Werror ([nixos/nixpkgs⁠#140306](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140306))
* [`5313fd63`](https://github.com/NixOS/nixpkgs/commit/5313fd63d3ceeadf3afefbe74a193943025400d8) lwan: 0.3 -> 0.4
* [`a446cbaa`](https://github.com/NixOS/nixpkgs/commit/a446cbaaaa4b7888558a88910cec70a722e8e97c) lscolors: 0.7.1 -> 0.8.0
* [`32fb71f2`](https://github.com/NixOS/nixpkgs/commit/32fb71f2d9464452038354ee637ebed6017b8225) python38Packages.sagemaker: 2.59.4 -> 2.59.6
* [`404ece99`](https://github.com/NixOS/nixpkgs/commit/404ece99f21859dd973c4e2693d25c9fa339d836) asciinema: 2.0.2 -> 2.1.0
* [`9a8c64a2`](https://github.com/NixOS/nixpkgs/commit/9a8c64a2f608c305b38137f793afc1e7865a00c3) rslint: init at 0.3.0
* [`ba1029a8`](https://github.com/NixOS/nixpkgs/commit/ba1029a81a9e3e56909fb660c721a7357b4905c8) Submit/fix vega lite ([nixos/nixpkgs⁠#139876](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139876))
* [`d7442dc6`](https://github.com/NixOS/nixpkgs/commit/d7442dc613f8ba6d105b46b845dddbb2fc350b19) ocamlPackages.merlin: 4.1 → 4.3.1
* [`8067021e`](https://github.com/NixOS/nixpkgs/commit/8067021ee7c637cae2d7597f64e7436e803b0b04) chezmoi: 2.1.6 -> 2.3.0
* [`785d49fb`](https://github.com/NixOS/nixpkgs/commit/785d49fb982cc2e9d579f8fffa4f848ea5336679) rewritefs: 2020-02-21 -> 2021-10-03
* [`ebebfb4b`](https://github.com/NixOS/nixpkgs/commit/ebebfb4bf0ec3ef0590021cdf598cb0c110b74d9) gobang: fix darwin build
* [`a0f20138`](https://github.com/NixOS/nixpkgs/commit/a0f20138a4323764ead04e7ffda25dbc15dd81c6) gnomeExtensions.unite: remove manually packaging and use extension overrides
* [`b7cec1d2`](https://github.com/NixOS/nixpkgs/commit/b7cec1d27d7aee0a22d7a8a52a7f0b72b50f832e) selene: init at 0.14.0
* [`fecc5d7b`](https://github.com/NixOS/nixpkgs/commit/fecc5d7bfff23a211278cb1e1fc2a9c2dbfb43ea) treewide: pkgs/**.nix: remove trailing whitespaces
* [`0cb3c776`](https://github.com/NixOS/nixpkgs/commit/0cb3c776cf796c27d535a28b7e0592a05b101e48) pulumi-bin: 3.12.0 -> 3.13.2
* [`6c07b4a3`](https://github.com/NixOS/nixpkgs/commit/6c07b4a3f8d803f78d76d19126f5d0340205327a) python3Packages.rapidfuzz: 1.7.0 -> 1.7.1
* [`5667c1fc`](https://github.com/NixOS/nixpkgs/commit/5667c1fc3f1235e4a55a283d76cfed0ee3cfb04f) libglibutil: Init at 1.0.55
* [`0aeb28e5`](https://github.com/NixOS/nixpkgs/commit/0aeb28e566eddfca126f19cec70eb12bca4771d1) libgbinder: Init at 1.1.12
* [`7f9f26f9`](https://github.com/NixOS/nixpkgs/commit/7f9f26f942f651111cc3472b1fe35a8e3ec1a174) python3Packages.gbinder-python: Init at 1.0.0
* [`6d8cab0b`](https://github.com/NixOS/nixpkgs/commit/6d8cab0b537bf768d044f1789a868261f45803fe) waydroid: Init at 1.1.1
* [`52be208f`](https://github.com/NixOS/nixpkgs/commit/52be208f205b3e4ae40f1ce912c29d9db1273c65) python3Packages.toposort: 1.6 -> 1.7
* [`d5735ae1`](https://github.com/NixOS/nixpkgs/commit/d5735ae18defec17313b82d8002b99ca40dd314e) erigon: 2021.09.02 -> 2021.09.04 ([nixos/nixpkgs⁠#139646](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139646))
* [`27c05093`](https://github.com/NixOS/nixpkgs/commit/27c05093234894f3eb98e05f41ea37073a5cdfe9) webcat: init at unstable-2021-09-06
* [`a21f4b7a`](https://github.com/NixOS/nixpkgs/commit/a21f4b7a76d1984d10cce20ef02076710155a0d4) iosevka: 10.0.0 → 10.3.1
* [`6749fd84`](https://github.com/NixOS/nixpkgs/commit/6749fd84fa6c888ce7618368b1782b666b608e5c) cawbird: add own API key to not run into rate limits
* [`f8333515`](https://github.com/NixOS/nixpkgs/commit/f83335157c800af78709ad6b13925572d15accb7) electron_15: init at 15.1.0
* [`97fe835b`](https://github.com/NixOS/nixpkgs/commit/97fe835b44f6f3fe020db6e9a372a904750cc29f) coqPackages.gappalib: 1.4.5 → 1.5.0
* [`0d7d78f8`](https://github.com/NixOS/nixpkgs/commit/0d7d78f8ff9539fbaf54ef8fc972eb4336893b87) python3Packages.async-upnp-client: 0.22.4 -> 0.22.5
* [`f887d5b3`](https://github.com/NixOS/nixpkgs/commit/f887d5b363b75456d787e2a7e4ca71d2371b22d8) maintainers/maintainers-list: add Matrix IDs
* [`921142e8`](https://github.com/NixOS/nixpkgs/commit/921142e8897b8db93f751149dccc2a577764cacb) python3Packages.pycarwings2: init at 2.11
* [`752336b6`](https://github.com/NixOS/nixpkgs/commit/752336b6e82349db3cf8a9a497101d12fc9ec2f8) home-assistant: update component-packages
* [`c4115245`](https://github.com/NixOS/nixpkgs/commit/c41152455777f877d5488236616890980fe7457c) vimPlugins: update
* [`be01e0f3`](https://github.com/NixOS/nixpkgs/commit/be01e0f3bc8f11fffb4394caeab806350a2536ca) black: Disable failing tests on Darwin ([nixos/nixpkgs⁠#130785](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/130785))
* [`9336af2d`](https://github.com/NixOS/nixpkgs/commit/9336af2d1aa19247c9309227699ba1867b65e38b) fnlfmt: 0.2.1 -> 0.2.2 ([nixos/nixpkgs⁠#140381](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140381))
* [`236d58ae`](https://github.com/NixOS/nixpkgs/commit/236d58aeefd5ad0b80b86ae996906f6dfaaee766) vimPlugins.neuron-nvim: init at 2021-03-20
* [`966763c5`](https://github.com/NixOS/nixpkgs/commit/966763c5b17e46bc1128bd9c4c1a8bde9a762dd2) btop: 1.0.10 -> 1.0.13
* [`7d88d0b0`](https://github.com/NixOS/nixpkgs/commit/7d88d0b040c23684815b2b0e7eb742bcfc3cd88b) clair: 4.2.0 -> 4.3.0
* [`c80fae5b`](https://github.com/NixOS/nixpkgs/commit/c80fae5bbeb9f4bcc0c48a1acd3bc8b4a12d7438) gitlab: 14.2.4 -> 14.3.1
* [`f1f64068`](https://github.com/NixOS/nixpkgs/commit/f1f640684c2e926d187e75f9910bbe04518b35b7) rewritefs: add `unstable` prefix
* [`9e6a39be`](https://github.com/NixOS/nixpkgs/commit/9e6a39be4d465892d32bee6944626415fbd77933) perlPackages.LaTeXML: 0.8.5 -> 0.8.6 ([nixos/nixpkgs⁠#140173](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140173))
* [`e6bdd969`](https://github.com/NixOS/nixpkgs/commit/e6bdd9690ced527fffa7a432ec80135e932907c4) wgpu: init at 0.10.0
* [`0543f2d2`](https://github.com/NixOS/nixpkgs/commit/0543f2d2f62dcc3d5e917f34d3c0526d0548473f) create-amis.sh: make vars overridable from env
* [`1ff82fec`](https://github.com/NixOS/nixpkgs/commit/1ff82fec9a0f48ce29b73113b24d43b83e023813) create-amis.sh: allow uploading private AMIs
* [`407998d1`](https://github.com/NixOS/nixpkgs/commit/407998d15a06a733c330b0a73e1897032c4e6041) create-amis.sh: add support for the ZFS AMIs
* [`2d67b946`](https://github.com/NixOS/nixpkgs/commit/2d67b946b7a065dfae76f77e6da810ac022f99bd) create-amis.sh: use status message
* [`1c0a20ef`](https://github.com/NixOS/nixpkgs/commit/1c0a20efcfdb40d7a08078e436baade866f83b0f) create-amis.sh: fix typo
