### PR TITLE
niv home-manager: update cb09a968 -> 88f9b333

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cb09a968e9b4ab12a8f203f454a1fba372a9fd71",
-        "sha256": "0nva46aix2wjab4b7prxf4c540fajj8a4xjm3b33a1r0jqaq0z52",
+        "rev": "88f9b333845d3d905463368efed5eabe304d75c2",
+        "sha256": "1dp65ai73vyk8rfrkjfhclklgrdkk76661mb87y3z7wha3wq67ds",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/cb09a968e9b4ab12a8f203f454a1fba372a9fd71.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/88f9b333845d3d905463368efed5eabe304d75c2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@cb09a968...88f9b333](https://github.com/nix-community/home-manager/compare/cb09a968e9b4ab12a8f203f454a1fba372a9fd71...88f9b333845d3d905463368efed5eabe304d75c2)

* [`959217e5`](https://github.com/nix-community/home-manager/commit/959217e51dbd07d0de6dcbddfbfcb4f2efdc0c1e) astroid: fix maildir paths ([nix-community/home-manager⁠#2350](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2350))
* [`52e84a04`](https://github.com/nix-community/home-manager/commit/52e84a040e2db9a78267a7e30576cfb472d15fa4) xsettingsd: make configurable through module
* [`66d9dbfa`](https://github.com/nix-community/home-manager/commit/66d9dbfa36f59748e06bb30cd98b3f4ad76cd482) Makefile: init ([nix-community/home-manager⁠#2351](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2351))
* [`ad05443e`](https://github.com/nix-community/home-manager/commit/ad05443e04648dca047e43090856ef9de79fbe25) kitty: add onChange configuration reload
* [`8f1d8c2e`](https://github.com/nix-community/home-manager/commit/8f1d8c2ef1202d0523cb5c3acd91fad0db5cea77) mako: add onChange configuration reload
* [`d5151186`](https://github.com/nix-community/home-manager/commit/d5151186aca3d706be73b02f47cff574cb91c641) waybar: add onChange configuration reload
* [`0f3dfc94`](https://github.com/nix-community/home-manager/commit/0f3dfc94ef9f70cdb800e0cf8e22ec9d3a0a3c70) services.emacs: add option `extraOptions`
* [`f15cd0f0`](https://github.com/nix-community/home-manager/commit/f15cd0f08750a9346c0434b9767031ef86a0a62f) gtk: add final newline to bookmarks to avoid conflicts
* [`095f3e32`](https://github.com/nix-community/home-manager/commit/095f3e32ae8de2e0828e548d88e553069025cec1) kanshi: allow multiple exec statements per profile
* [`e0a87d75`](https://github.com/nix-community/home-manager/commit/e0a87d75e9083569f73efc47b58c0e3fa4f99382) firefox: add bookmarks support
* [`179ce0aa`](https://github.com/nix-community/home-manager/commit/179ce0aacf11a84a840d4ddc94c3b09ac7b0eb6c) fontconfig: use a prettier "real directory" hack
* [`099cbcf1`](https://github.com/nix-community/home-manager/commit/099cbcf13e8219f07b493980a66fe64df0e32d09) nixos: add modulesPath to specialArgs
* [`81ec2aed`](https://github.com/nix-community/home-manager/commit/81ec2aed8a2438553c6689061eeb45a40883ec24) kitty: make onChange Linux only
* [`9b04ff5e`](https://github.com/nix-community/home-manager/commit/9b04ff5e3be0ff25256bafce5d95b40313f882eb) fish: remove superfluous config guard
* [`88f9b333`](https://github.com/nix-community/home-manager/commit/88f9b333845d3d905463368efed5eabe304d75c2) docs: update session variables suggestion for Fish
