### PR TITLE
niv spacemacs: update f5bd49cc -> 63056ecb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "f5bd49cc8e99ec5ec63f3581200c350d55a20c5b",
-        "sha256": "0w0jycdgqf3na0g5cwayysjsjzxdamvmzy68m11082k98yjnnazy",
+        "rev": "63056ecb50f93808781b97feab1c3225d35c7aa1",
+        "sha256": "038rfnyd404bzv83h5l0fbp3mn9c6qpn4h2liyf5baqc8wsmzg7x",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/f5bd49cc8e99ec5ec63f3581200c350d55a20c5b.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/63056ecb50f93808781b97feab1c3225d35c7aa1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@f5bd49cc...63056ecb](https://github.com/syl20bnr/spacemacs/compare/f5bd49cc8e99ec5ec63f3581200c350d55a20c5b...63056ecb50f93808781b97feab1c3225d35c7aa1)

* [`d5cee221`](https://github.com/syl20bnr/spacemacs/commit/d5cee221169e2247b042d314e89e0a26223a3479) [python] Make ipython version detection more robust
* [`071b48ba`](https://github.com/syl20bnr/spacemacs/commit/071b48ba3255c0b8139313b3fd6e658b002fd2f0) Add pydoc to python layer for better python doc functionality
* [`250e103c`](https://github.com/syl20bnr/spacemacs/commit/250e103cab63401ba5e4d08414fce3f1985759ed) [bot] "built_in_updates" Wed Sep 29 19:18:45 UTC 2021
* [`d7a0492a`](https://github.com/syl20bnr/spacemacs/commit/d7a0492ac739d88039e1ab09abf4691af0f33a9e) [python] Remove comments and fix new commands
* [`151ca61d`](https://github.com/syl20bnr/spacemacs/commit/151ca61df5dcdbef5ad4f1f4887bfc5152dc805e) [version-control] Switch default version control diff tool to git-gutter
* [`497c7670`](https://github.com/syl20bnr/spacemacs/commit/497c7670361cfafa7247fe484038f052feb9e137) [core] Support packing elisp to *.elc and *.el.gz files
* [`03ab15ed`](https://github.com/syl20bnr/spacemacs/commit/03ab15ed36d265cb48c05d572638e21bc7508e26) [ivy] counsel search commands use spacemacs--ivy-file-actions
* [`44078aae`](https://github.com/syl20bnr/spacemacs/commit/44078aaebcebaed391eeacda555a0f96e88917fd) [ivy] Fix new src block in docs
* [`b0029167`](https://github.com/syl20bnr/spacemacs/commit/b0029167154d579c08c238afbb2275a8cd4a0a4d) Added COPYRIGHT file
* [`63056ecb`](https://github.com/syl20bnr/spacemacs/commit/63056ecb50f93808781b97feab1c3225d35c7aa1) [doc] use org-mode  example block for example
