### PR TITLE
niv nixpkgs: update 1c0a20ef -> ed1605e9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c0a20efcfdb40d7a08078e436baade866f83b0f",
-        "sha256": "1k5f0sg1vvvvgld6llbqskwd0spqaf6wd6zf2b52hqc3clcqryak",
+        "rev": "ed1605e9661d6ded35b00250d8014dd833accbf0",
+        "sha256": "06flzihhkfh6rlwkjh4dksprdzqhzzffgl3v1f648db99pb2jgqh",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/1c0a20efcfdb40d7a08078e436baade866f83b0f.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ed1605e9661d6ded35b00250d8014dd833accbf0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@1c0a20ef...ed1605e9](https://github.com/nixos/nixpkgs/compare/1c0a20efcfdb40d7a08078e436baade866f83b0f...ed1605e9661d6ded35b00250d8014dd833accbf0)

* [`6b97150c`](https://github.com/NixOS/nixpkgs/commit/6b97150cda5b61bf5fee0f7385ec16dcb93654e1) python3Packages.hap-python: 4.1.0 -> 4.3.0
* [`5a2ecde0`](https://github.com/NixOS/nixpkgs/commit/5a2ecde0daa038cda090fef88d32e3a110c21e6f) gitea: 1.15.3 -> 1.15.4
* [`d406bca7`](https://github.com/NixOS/nixpkgs/commit/d406bca7461e94cb3c9544e7ccfb3c3bba6df1d2) chromium: 94.0.4606.71 -> 94.0.4606.81
* [`a15be1c5`](https://github.com/NixOS/nixpkgs/commit/a15be1c5f65b15d75a4e30a82340ed34d538e449) chromiumBeta: 95.0.4638.32 -> 95.0.4638.40
* [`38392881`](https://github.com/NixOS/nixpkgs/commit/383928815fd9fc828b7bb43c1f3edeeb50ab08e4) ungoogled-chromium: 94.0.4606.71 -> 94.0.4606.81
* [`757d3b91`](https://github.com/NixOS/nixpkgs/commit/757d3b91a6cac8a3668bd003aa62c041022432f1) plexamp: update hash due to silent release
* [`e59dd593`](https://github.com/NixOS/nixpkgs/commit/e59dd593c8ed9271c3f568a9972ed0a697731ca9) python3Packages.smbus2: init at 0.4.1
* [`c8fff86c`](https://github.com/NixOS/nixpkgs/commit/c8fff86cd6dc7ddb3e8e804a9f3aff149191b72c) python3Packages.djangorestframework-simplejwt: add setuptools-scm
* [`55ed9b77`](https://github.com/NixOS/nixpkgs/commit/55ed9b77357ba2c7042af32b8c8e58293fd2ec06) _3270font: 2.3.0 -> 2.3.1
* [`27ce3b12`](https://github.com/NixOS/nixpkgs/commit/27ce3b12b3d600155732eb014c02ca3dde180a24) home-assistant: 2021.10.0 -> 2021.10.1
* [`c1cf3662`](https://github.com/NixOS/nixpkgs/commit/c1cf3662a1488840420f25ebb95c0fdeb20f3b4e) python3Packages.python-didl-lite: 1.2.6 -> 1.3.0
* [`4a7a5d17`](https://github.com/NixOS/nixpkgs/commit/4a7a5d175ab5419fb170bb46dea2b2409e271c7b) python3Packages.async-upnp-client: 0.22.5 -> 0.22.8
* [`a1d3f8f4`](https://github.com/NixOS/nixpkgs/commit/a1d3f8f48e56cc4de2417a576ee9f82f8a2f4758) home-assistant: 2021.10.1 -> 2021.10.2
* [`5f79b7a1`](https://github.com/NixOS/nixpkgs/commit/5f79b7a15b4658caa415e63f3d4e84b4b58f9991) mdbook-katex: init @ 0.2.10
* [`06e0a8e4`](https://github.com/NixOS/nixpkgs/commit/06e0a8e43a18bcbda088b54c4b931cad842ef76d) time-ghc-modules: init at 1.0.0 ([nixos/nixpkgs⁠#140847](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140847))
* [`508d862d`](https://github.com/NixOS/nixpkgs/commit/508d862dc72a4c2a1cb06700ab28ac319961e925) python39Packages.scrapy: 2.5.0 -> 2.5.1
* [`a6c34ff3`](https://github.com/NixOS/nixpkgs/commit/a6c34ff3633924f0aa1b91cc0eaa4559986e6633) linux: cleanup zlib conditional dependency
* [`d02c87a3`](https://github.com/NixOS/nixpkgs/commit/d02c87a392cd964af20243e072b186f9efd90572) vscodium: 1.60.2 -> 1.61.0
* [`85bd79c7`](https://github.com/NixOS/nixpkgs/commit/85bd79c702e524761512d2a8a4a1730b4b85786e) actionlint: 1.6.4 -> 1.6.5
* [`2a42dff3`](https://github.com/NixOS/nixpkgs/commit/2a42dff30ef818486fe317e66ba748a1424ef552) mtm: 1.2.0 -> 1.2.1
* [`42f543b2`](https://github.com/NixOS/nixpkgs/commit/42f543b2173b3772c1f156feb6075acc805a5c0d) hurl: install manpages
* [`e19b6535`](https://github.com/NixOS/nixpkgs/commit/e19b6535d1c7a2edc499f9b392bbb0560c6bc9f9) keepalived: 2.2.2 -> 2.2.4
* [`e8a12492`](https://github.com/NixOS/nixpkgs/commit/e8a12492fcc0c776a08ceafca93eb4a58564aca6) tdesktop: 3.1.8 -> 3.1.9
* [`4715a08d`](https://github.com/NixOS/nixpkgs/commit/4715a08d0872425a73e3a185e9699bc3e4080212) python38Packages.mautrix: 0.10.9 -> 0.10.10
* [`a720b733`](https://github.com/NixOS/nixpkgs/commit/a720b7331f0febb6721c9ea641f59c290a4e2394) python38Packages.flask-jwt-extended: 4.3.0 -> 4.3.1
* [`83d2927d`](https://github.com/NixOS/nixpkgs/commit/83d2927d1e1dcaee7e07e89b00a58aa63e84494f) python3Packages.colorlog: 6.4.1 -> 6.5.0
* [`e84f3ad7`](https://github.com/NixOS/nixpkgs/commit/e84f3ad76cf962c1621140528492200a5ed80c1f) terrascan: 1.10.0 -> 1.11.0
* [`d43c27b9`](https://github.com/NixOS/nixpkgs/commit/d43c27b96be926d4b7d96dae62661f9c3b59271e) python3Packages.guppy3: 3.1.1 -> 3.1.2
* [`4c9f6db4`](https://github.com/NixOS/nixpkgs/commit/4c9f6db483bcea854306e297b1426f07c035793f) python3Packages.proxmoxer: 1.1.1 -> 1.2.0
* [`edf8f5d0`](https://github.com/NixOS/nixpkgs/commit/edf8f5d054d878adba911c8fdb26ecba19ae4db4) p7zip: fix determinism of compressed manpages
* [`1d90007b`](https://github.com/NixOS/nixpkgs/commit/1d90007b1dd97a6b361c848a92ff2cb317f58865) eksctl: 0.68.0 -> 0.69.0
* [`65fe62e0`](https://github.com/NixOS/nixpkgs/commit/65fe62e0205e941d3be226ff5dee3aae00c00c08) python3Packages.commoncode: 21.8.31 -> 30.0.0
* [`467e36f5`](https://github.com/NixOS/nixpkgs/commit/467e36f5da2fc8c9cb481d7ce28a8b3725b051b1) guitarix: move from Python 2 to Python 3
* [`16677081`](https://github.com/NixOS/nixpkgs/commit/166770817df5f260b1ace224eafece4209507239) python3Packages.extractcode: disable failing test
* [`291d63f8`](https://github.com/NixOS/nixpkgs/commit/291d63f8884b6716525debd7d114aa39f03ad252) python3Packages.pygmars: init at 0.7.0
* [`6423dc78`](https://github.com/NixOS/nixpkgs/commit/6423dc7828e57abceebcbfdd707b1463a937fc37) python3Packages.spdx-tools: 0.6.1 -> 0.7.0a3
* [`4521bf49`](https://github.com/NixOS/nixpkgs/commit/4521bf49d19efe245e02ec923296155eb8ae75b9) python3Packages.parameter-expansion-patched: init at 0.2.1b4
* [`54caa413`](https://github.com/NixOS/nixpkgs/commit/54caa4135aa584aead70ce80f169eb5980ddfed9) python3Packages.debian-inspector: 21.5.25 -> 30.0.0
* [`570e2536`](https://github.com/NixOS/nixpkgs/commit/570e2536e8cf525b54f2cc32f61a702c4885edbf) python3Packages.license-expression: 1.2 -> 21.6.14
* [`e531a5a7`](https://github.com/NixOS/nixpkgs/commit/e531a5a7120816144b6e653d6fc186d64f6b9fd9) python3Packages.scancode-toolkit: 21.8.4 -> 30.1.0
* [`99805ce1`](https://github.com/NixOS/nixpkgs/commit/99805ce16739d1eb4d46bd9ccd1218a626b7c9f3) nginxModules.upload: init at 2.3.0
* [`e0f5245a`](https://github.com/NixOS/nixpkgs/commit/e0f5245ab30f87ba4d357f8b3d32d6ed027a8f0f) electron_15: 15.1.1 -> 15.1.2
* [`9b46db90`](https://github.com/NixOS/nixpkgs/commit/9b46db90ffb313e3d738be406d77c9ad0717ec84) electron_14: 14.1.0 -> 14.1.1
* [`903dc5bf`](https://github.com/NixOS/nixpkgs/commit/903dc5bf924c87a466e93ed37001f9c1a6afbbd5) git: darwin: disable flaky tests
* [`139ecccc`](https://github.com/NixOS/nixpkgs/commit/139ecccc84091cb1ee605cc77e221fd643517caa) home-assistant: disable tado test that needs network access
* [`82c0181d`](https://github.com/NixOS/nixpkgs/commit/82c0181dfb3dc951156097752d5a876754db3591) python38Packages.mypy-boto3-s3: 1.18.57 -> 1.18.58
* [`ed666b44`](https://github.com/NixOS/nixpkgs/commit/ed666b443daaaa4ea5a226606b4272c4b5286ff0) k0sctl: 0.10.3 -> 0.10.4
* [`38314527`](https://github.com/NixOS/nixpkgs/commit/383145270fe9640fe07f9806845acf1b7849be3e) exploitdb: 2021-10-06 -> 2021-10-09
* [`2cfc72c4`](https://github.com/NixOS/nixpkgs/commit/2cfc72c44a31a02642fee0d9d9f9ad673168beef) apache-airflow: 2.1.2 -> 2.1.4
* [`463c567b`](https://github.com/NixOS/nixpkgs/commit/463c567becb387c462a7de387c20fcc567487e5c) cozydrive: fix maintainers
* [`07f71d21`](https://github.com/NixOS/nixpkgs/commit/07f71d21995f0707758370bbaf850bfa509321a5) python38Packages.pymavlink: 2.4.16 -> 2.4.17
* [`d66a5122`](https://github.com/NixOS/nixpkgs/commit/d66a5122227d4610efe7846babcc58a4b20064b9) libjaylink: Init at 0.2.0
* [`34c98d24`](https://github.com/NixOS/nixpkgs/commit/34c98d248ea162a5d7aa8e78a623e20cc3b700cf) fetchmail: 6.4.21 -> 6.4.22
* [`52c95adb`](https://github.com/NixOS/nixpkgs/commit/52c95adb9315ed032235f8959f8cf8704a8b1583) geany: 1.37.1 -> 1.38
* [`314a4950`](https://github.com/NixOS/nixpkgs/commit/314a49503af315c25a5fefb0eb3d088bd610ff32) libsForQt5.dxflib: 3.17.0 -> 3.26.4
* [`981d5317`](https://github.com/NixOS/nixpkgs/commit/981d5317b9722c33a0926929fb589d61c866f6a1) gitlint: 0.15.1 -> 0.16.0
* [`cff7863c`](https://github.com/NixOS/nixpkgs/commit/cff7863c34b759810a73b6db0e91b032b338ccf8) coreboot-toolchain: Use git repository as source
* [`864f96cd`](https://github.com/NixOS/nixpkgs/commit/864f96cd7fd732b9339494b2890ebe0685b43a7f) libredirect: handle mkdir(2) + mkdirat(2)
* [`9044534a`](https://github.com/NixOS/nixpkgs/commit/9044534a8dd73df87ef35e604d7212f876988b02) elan: 1.0.7 -> 1.1.0
* [`882ed22e`](https://github.com/NixOS/nixpkgs/commit/882ed22e5cfcc5863777058799e329896ba607ad) cbqn: 0.pre+unstable=2021-10-05 -> 0.pre+unstable=2021-10-09
* [`b62cda1a`](https://github.com/NixOS/nixpkgs/commit/b62cda1af2659128ee8162154e879a7dc67d0127) phpPackages.composer: 2.1.8 -> 2.1.9
* [`3ea6c9e4`](https://github.com/NixOS/nixpkgs/commit/3ea6c9e48a40e80fb58fe33c64bc35d41bbd5a13) python3Packages.pyswitchbot: 0.11.0 -> 0.12.0
* [`1ab3b970`](https://github.com/NixOS/nixpkgs/commit/1ab3b9704ed71906abbce1de03c9a9caad8b4dd3) depotdownloader: 2.4.1 -> 2.4.5
* [`8a6c987c`](https://github.com/NixOS/nixpkgs/commit/8a6c987c2bb9b532eba3d9ee930f2b56c4763371) python3Packages.youless-api: 0.13 -> 0.14
* [`4dc0be75`](https://github.com/NixOS/nixpkgs/commit/4dc0be7557d54872961a33334659e1fccdb70f53) python3Packages.greeclimate: 0.11.8 -> 0.11.9
* [`28383a92`](https://github.com/NixOS/nixpkgs/commit/28383a922e5660ce184fbfdd6b50913360d32182) coreboot-toolchain: Introduce script for generating sources file
* [`35a26a5b`](https://github.com/NixOS/nixpkgs/commit/35a26a5b210eb0ac5656f21adee96281339a1b36) chromiumDev: 96.0.4655.0 -> 96.0.4662.6
* [`60b4a5ea`](https://github.com/NixOS/nixpkgs/commit/60b4a5ea82b2551717bcc16a10245fea25980a7b) vscode-extensions.vadimcn.vscode-lldb: 1.6.7 -> 1.6.8
* [`6c6670d9`](https://github.com/NixOS/nixpkgs/commit/6c6670d9c458e4421e58cc99d6ac55f669a59ac1) lima: 0.6.4 -> 0.7.1
* [`bc482d83`](https://github.com/NixOS/nixpkgs/commit/bc482d83e6e5ead1922081c5eba4124c6e533532) python3Packages.limiter: init at 0.1.2
* [`12623a3e`](https://github.com/NixOS/nixpkgs/commit/12623a3e2933491a25c867943456e3f53d3702c4) python3Packages.spyse-python: init at 2.2.3
* [`5608c26f`](https://github.com/NixOS/nixpkgs/commit/5608c26f72125b4b14d8a74e37fd34afaf3b616c) python3Packages.furo: 2021.9.22 -> 2021.10.9
* [`0b2b0331`](https://github.com/NixOS/nixpkgs/commit/0b2b0331f0de0fba15d3eb813032250e634bfedb) coreboot-toolchain: Use sources.nix generated by update.sh
* [`fbb2cfd0`](https://github.com/NixOS/nixpkgs/commit/fbb2cfd0bb72cd18d523b2b99807c76a3f7d57c4) crabz: init at 0.7.2
* [`f731f82c`](https://github.com/NixOS/nixpkgs/commit/f731f82c975169c259c3a8ee436e0994de4c7237) suckit: init at 0.1.2
* [`e7a771e4`](https://github.com/NixOS/nixpkgs/commit/e7a771e4cf25fa3a34e5f721cb0b2b8cae9e9c43) cloudflared: 2021.9.1 -> 2021.9.2
* [`5a0e5409`](https://github.com/NixOS/nixpkgs/commit/5a0e54095aad3643f5e9a7c995b1ccfef848f295) pipes-rs: 1.4.4 -> 1.4.5
* [`9ab6478c`](https://github.com/NixOS/nixpkgs/commit/9ab6478cae969f486ea9a83b6bf24c8d351be40c) python38Packages.django-dynamic-preferences: 1.10.1 -> 1.11.0
* [`d9594771`](https://github.com/NixOS/nixpkgs/commit/d959477134a3e765696bc197ccb678ec97ffd3de) python3Packages.labgrid: remove disabled tests
* [`80d0a6d4`](https://github.com/NixOS/nixpkgs/commit/80d0a6d4438f96750d7ea5a8ae4712854f5858ce) python38Packages.deezer-python: 2.4.0 -> 3.1.0
* [`c2059441`](https://github.com/NixOS/nixpkgs/commit/c205944161d39753a1968aae010060e373a16336) lilypond-with-fonts: fix lilypond not finding its libraries
* [`b7e7d35c`](https://github.com/NixOS/nixpkgs/commit/b7e7d35cccea936bc41d9f2602bda3effee97b0a) yarn2nix: workaround for NixOS/nix[nixos/nixpkgs⁠#5128](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/5128)
* [`397a555b`](https://github.com/NixOS/nixpkgs/commit/397a555b699bb1ce0488bc8f2bdbfc30db3ebc86) python38Packages.nunavut: 1.4.2 -> 1.5.0
* [`861c36e3`](https://github.com/NixOS/nixpkgs/commit/861c36e309f8d5d6df0e0e5d9e08ad807d428757) python38Packages.teslajsonpy: 0.21.0 -> 1.0.0
* [`eb0588f4`](https://github.com/NixOS/nixpkgs/commit/eb0588f4b7cbeafbde17475a3b47536025c53978) nix-eval-jobs: init at 0.0.1
* [`9a8404ee`](https://github.com/NixOS/nixpkgs/commit/9a8404ee692868f23fdce93df34843bf4e758d40) python3Packages.teslajsonpy: add new dependency
* [`69fec99e`](https://github.com/NixOS/nixpkgs/commit/69fec99e6702dc90262deaeaed326d4e03e6f8d6) python38Packages.pytelegrambotapi: 4.1.0 -> 4.1.1
* [`fc6631d3`](https://github.com/NixOS/nixpkgs/commit/fc6631d3e728df4b6f321d53aa258bbd48c31325) xorg.xev: 1.2.3 -> 1.2.4
* [`dabafc8a`](https://github.com/NixOS/nixpkgs/commit/dabafc8ac748ce035d8e8c9e9072fb57f8a51235) mopidy-youtube: enable tests
* [`ccc287f6`](https://github.com/NixOS/nixpkgs/commit/ccc287f6d9d0039a88eef8d4634856d5f35f2cac) terraform-providers.openstack: 1.28.0 -> 1.43.1 ([nixos/nixpkgs⁠#139753](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139753))
* [`7938ea67`](https://github.com/NixOS/nixpkgs/commit/7938ea67a717e69d00edab8c2cb6f04c9c469aaf) nixos/doc/md-to-db.sh: handle path to nixpkgs with spaces
* [`3ce2e89d`](https://github.com/NixOS/nixpkgs/commit/3ce2e89dec81b09b7b927e469fd401c272ad5aa4) mpd: 0.22.10 -> 0.22.11
* [`2b06bd2b`](https://github.com/NixOS/nixpkgs/commit/2b06bd2b8aacc25bac08b1a22cc578337db1822d) python38Packages.pglast: 3.5 -> 3.6
* [`454d9f74`](https://github.com/NixOS/nixpkgs/commit/454d9f74104b41adb871f11911dab9e8e960de1a) neovide: unstable-2021-08-08 -> unstable-2021-10-09
* [`acc4cf0d`](https://github.com/NixOS/nixpkgs/commit/acc4cf0d34595e07c488ae8b817b6255b5cb74df) python38Packages.pg8000: 1.21.2 -> 1.21.3
* [`c21d56e6`](https://github.com/NixOS/nixpkgs/commit/c21d56e6dbf23d1ac755fe7d88ab97f25ccb1c23) python38Packages.pikepdf: 3.1.1 -> 3.2.0
* [`11e5bc64`](https://github.com/NixOS/nixpkgs/commit/11e5bc6438b7bdbbf2caf889dc7bd20cbd29185d) marwaita: 10.3 -> 11.1
* [`d002e84b`](https://github.com/NixOS/nixpkgs/commit/d002e84bab94fbdca4a8d2f981225868a24f3a36) perlPackages.LaTeXML: backport downgrade to medium security of File::Temp ([nixos/nixpkgs⁠#141182](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141182))
* [`a3660c86`](https://github.com/NixOS/nixpkgs/commit/a3660c86de2803e4d3281947d616ccf404add2ea) kubescape: 1.0.88 -> 1.0.109
* [`0efe135d`](https://github.com/NixOS/nixpkgs/commit/0efe135d99311b3daa4e081e278d460200cc4105) scorecard: 2.2.8 -> 3.0.1
* [`51529190`](https://github.com/NixOS/nixpkgs/commit/515291906eb9fe138f3a52856537157c4f541a1c) nbxplorer: 2.2.5 -> 2.2.11
* [`965caf6b`](https://github.com/NixOS/nixpkgs/commit/965caf6b999db180b0d9b11380243d68ab3613ad) btcpayserver: 1.2.3 -> 1.2.4
* [`0e1dba38`](https://github.com/NixOS/nixpkgs/commit/0e1dba3824894c308d6200be0e121a71944bf2ab) maintainers: add jdreaver
* [`6b9f8629`](https://github.com/NixOS/nixpkgs/commit/6b9f8629d2a612bd8a9425542fe2ed1cb214f775) synth: init at 0.5.6
* [`7d9d6c82`](https://github.com/NixOS/nixpkgs/commit/7d9d6c825f990ef389dd538513a73677ec84ab56) python38Packages.tasklib: 2.4.0 -> 2.4.3
* [`47e66ec1`](https://github.com/NixOS/nixpkgs/commit/47e66ec1d0ef9598d1572cf7a3056aa71db325fa) mapcidr: init at 0.0.8 ([nixos/nixpkgs⁠#141102](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141102))
* [`9aae7137`](https://github.com/NixOS/nixpkgs/commit/9aae71379d4e07a7ab4be4c8cfcae5e63252fe95) nixos/wakeonlan: add note to rename.nix
* [`43bbea93`](https://github.com/NixOS/nixpkgs/commit/43bbea938785d4228d87e4a443ea82f5ead9bcec) lfs: init at 1.0.0 ([nixos/nixpkgs⁠#141178](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141178))
* [`1c9afc5a`](https://github.com/NixOS/nixpkgs/commit/1c9afc5a883065552190b7bae6ae04b6abfe0312) releaseTools.debBuild: fix invocation
* [`e3126455`](https://github.com/NixOS/nixpkgs/commit/e312645535f1edab0e5ed7356fba009a8a4b7359) cloudfoundry-cli: 7.3.0 -> 8.0.0
* [`4172adde`](https://github.com/NixOS/nixpkgs/commit/4172adde122752268ce9c415723a5f41edb26e68) clickhouse: fix non-x86 build ([nixos/nixpkgs⁠#141009](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141009))
* [`f52699bc`](https://github.com/NixOS/nixpkgs/commit/f52699bc713545e32b5aaa1290e03c4ebf0d4110) python3Packages.pytest-rerunfailures: 10.1 → 10.2 ([nixos/nixpkgs⁠#141166](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141166))
* [`58269d48`](https://github.com/NixOS/nixpkgs/commit/58269d4875b357fba7a34608bbe5691eecf30fb4) yt-dlp: 2021.9.25 -> 2021.10.10
* [`34f77f42`](https://github.com/NixOS/nixpkgs/commit/34f77f423c0d86a5b0928f1fc5f7550374fffedf) jackett: 0.18.582 -> 0.18.925
* [`acb7f9b0`](https://github.com/NixOS/nixpkgs/commit/acb7f9b0ce4f19cbc2104fc560b6503ae24867af) hackrf: 2018.01.1 -> 2021.03.1
* [`fb79f910`](https://github.com/NixOS/nixpkgs/commit/fb79f910b79c70a4bbbf7a19873f8a95b6732df2) mininet: 2.3.0d6 -> 2.3.0
* [`4228bbe0`](https://github.com/NixOS/nixpkgs/commit/4228bbe0b2a7318878a3cd49e808866472413262) prowlarr: init at 0.1.1.978
* [`3d79c925`](https://github.com/NixOS/nixpkgs/commit/3d79c9250aadebe59dcdf43352d9128ddbff675c) nixos/prowlarr: init
* [`11ce4818`](https://github.com/NixOS/nixpkgs/commit/11ce48184547625a2a02a0902839481336c6134d) nixos/tests/prowlarr: init
* [`4c7e1a10`](https://github.com/NixOS/nixpkgs/commit/4c7e1a10b4b6b580c63662423288633990b87f89) yarn2nix: fix "rev is not defined" ([nixos/nixpkgs⁠#141207](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141207))
* [`8755e7aa`](https://github.com/NixOS/nixpkgs/commit/8755e7aa4984540ac60c8f361dddeb7163aad7f0) gnused,gnused_422: set meta.mainProgram
* [`9bf9e342`](https://github.com/NixOS/nixpkgs/commit/9bf9e3423be57473c70bf588ffd2711663d7d02c) cdk-go: set meta.mainProgram
