### PR TITLE
niv home-manager: update 88f9b333 -> 0b47ded2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "88f9b333845d3d905463368efed5eabe304d75c2",
-        "sha256": "1dp65ai73vyk8rfrkjfhclklgrdkk76661mb87y3z7wha3wq67ds",
+        "rev": "0b47ded208a6ed24f40b9d62379d04fe8dc4f63e",
+        "sha256": "1kzvj43v05adx7szapph3xdyicnpwmawkjrzhhigkqnij1jqibws",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/88f9b333845d3d905463368efed5eabe304d75c2.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/0b47ded208a6ed24f40b9d62379d04fe8dc4f63e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@88f9b333...0b47ded2](https://github.com/nix-community/home-manager/compare/88f9b333845d3d905463368efed5eabe304d75c2...0b47ded208a6ed24f40b9d62379d04fe8dc4f63e)

* [`e4df31dc`](https://github.com/nix-community/home-manager/commit/e4df31dceaedc4b9abd18f7c8616d58987e790c8) screen-locker: Make xautolock optional, reorganize options ([nix-community/home-manager⁠#2343](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2343))
* [`1719495b`](https://github.com/nix-community/home-manager/commit/1719495bdfd5dc1e142aacc43e12a8c08584c856) screen-locker: make news entry conditional
* [`af2007bb`](https://github.com/nix-community/home-manager/commit/af2007bb7772c6f17f4924639f2eb8a321d74fb4) atuin: add module
* [`80d23ee0`](https://github.com/nix-community/home-manager/commit/80d23ee06cff0d0bef20b9327566f7de2498f4cb) fzf: do shell initialization a bit earlier
* [`592da767`](https://github.com/nix-community/home-manager/commit/592da767bd46a206a1a8200a48b829a59a06b969) nnn: init ([nix-community/home-manager⁠#2368](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2368))
* [`c100bd0c`](https://github.com/nix-community/home-manager/commit/c100bd0c4b0d90df863205ece373a4b4988455dd) Makefile: improvements ([nix-community/home-manager⁠#2374](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2374))
* [`8bbade4b`](https://github.com/nix-community/home-manager/commit/8bbade4b01c316119e6b163fa9af6ee246cc989a) fontconfig: only remove directory if it exists
* [`85440668`](https://github.com/nix-community/home-manager/commit/854406680b30f9e64276e89938cdada141ec13d4) vim: add option to specify pkgs.vim_configurable ([nix-community/home-manager⁠#2307](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2307))
* [`60ebc273`](https://github.com/nix-community/home-manager/commit/60ebc273c92edae796931649e83bf753e72b3ef4) nix-darwin,nixos: add osConfig module argument ([nix-community/home-manager⁠#2302](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2302))
* [`d9fe208f`](https://github.com/nix-community/home-manager/commit/d9fe208f3ccd7047a29eb31fd0cd3191c4445323) z-lua: Add shell aliases to fish ([nix-community/home-manager⁠#2376](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2376))
* [`fd2f7460`](https://github.com/nix-community/home-manager/commit/fd2f746016e3d99bdc3c86736d30f2ca7594929a) nix-darwin: add modulesPath to specialArgs ([nix-community/home-manager⁠#2375](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2375))
* [`82c92a18`](https://github.com/nix-community/home-manager/commit/82c92a18baaa5bd2546b02f006fb0d5dbf4fcfa4) gh: use structural settings ([nix-community/home-manager⁠#2339](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2339))
* [`32285d8f`](https://github.com/nix-community/home-manager/commit/32285d8fe64138a41f1caed23d94f28529ea4eb4) rofi: remove options removed from upstream in v1.7.0
* [`0b47ded2`](https://github.com/nix-community/home-manager/commit/0b47ded208a6ed24f40b9d62379d04fe8dc4f63e) flameshot: add settings option
