### PR TITLE
niv powerlevel10k: update 0ce9df66 -> edd98053

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0ce9df66d2cffb860a7c48a8d4f3639cf581f908",
-        "sha256": "1cqq6scw3r1bdj5k60q8lhg4d6gciiag9hpdahwhir30160jk84r",
+        "rev": "edd98053cc96a8d2bd50f2b5f18a97fec0a96b26",
+        "sha256": "1ibckwc75p60gm5s4989rhy2xs54fa2v6knjb4zjl55nkixhn1b1",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0ce9df66d2cffb860a7c48a8d4f3639cf581f908.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/edd98053cc96a8d2bd50f2b5f18a97fec0a96b26.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@0ce9df66...edd98053](https://github.com/romkatv/powerlevel10k/compare/0ce9df66d2cffb860a7c48a8d4f3639cf581f908...edd98053cc96a8d2bd50f2b5f18a97fec0a96b26)

* [`ed45177e`](https://github.com/romkatv/powerlevel10k/commit/ed45177e19bbfc4ffe65cc36bdf25e41cb7cf35b) fix nordvpn; it was broken by the latest upstream update ([romkatv/powerlevel10k⁠#1590](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1590))
* [`3e515a75`](https://github.com/romkatv/powerlevel10k/commit/3e515a75d2d197da30a998fa8fd7737430958fba) remove obsolete nordvpn comments
* [`5acedce0`](https://github.com/romkatv/powerlevel10k/commit/5acedce0b04bca7d2e633d15fb4d8c911cb27268) speed up pre-redraw hook
* [`edd98053`](https://github.com/romkatv/powerlevel10k/commit/edd98053cc96a8d2bd50f2b5f18a97fec0a96b26) disable icanon on the tty after printing instant prompt; this way keys like Ctrl-R and Ctrl-D will get through to zle
