### PR TITLE
niv nixpkgs: update ed1605e9 -> 5f019422

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ed1605e9661d6ded35b00250d8014dd833accbf0",
-        "sha256": "06flzihhkfh6rlwkjh4dksprdzqhzzffgl3v1f648db99pb2jgqh",
+        "rev": "5f0194220f2402b06f7f79bba6351895facb5acb",
+        "sha256": "0h2j0ivbp3b84d38h8s06s2yvnwqy80f4i1a75jd11m45m804n3s",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ed1605e9661d6ded35b00250d8014dd833accbf0.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5f0194220f2402b06f7f79bba6351895facb5acb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ed1605e9...5f019422](https://github.com/nixos/nixpkgs/compare/ed1605e9661d6ded35b00250d8014dd833accbf0...5f0194220f2402b06f7f79bba6351895facb5acb)

* [`a8498f08`](https://github.com/NixOS/nixpkgs/commit/a8498f08bf29c129d91978aaedf60877f0047553) linux-libre: unbreak
* [`dfbd20a1`](https://github.com/NixOS/nixpkgs/commit/dfbd20a16e7e488765e8df2dda1f2411858d7c52) ttyper: 0.2.5 -> 0.3.0
* [`400b6f42`](https://github.com/NixOS/nixpkgs/commit/400b6f42e7b4ec6a9c5306ee114d11956e2087be) aphleia: 0.pre+unstable=2021-08-08 -> 1.1.2+unstable=2021-10-03
* [`9c6c5787`](https://github.com/NixOS/nixpkgs/commit/9c6c5787f6b76a081f7a46c3584c4a18fc5a8610) exploitdb: 2021-10-13 -> 2021-10-15
* [`8e38ff69`](https://github.com/NixOS/nixpkgs/commit/8e38ff698e41dd8c37f98e495c7857f9777da3c4) notejot: 3.1.5 -> 3.2.0
* [`805b4e10`](https://github.com/NixOS/nixpkgs/commit/805b4e109b077ac14cd6b0c62213c09a627d5c3a) khronos: 3.5.9 -> 3.6.0
* [`0b92261d`](https://github.com/NixOS/nixpkgs/commit/0b92261d6a9dc256418e3dc0cde67b52b560a686) OVMF: add TPM2 support flags
* [`7cd65916`](https://github.com/NixOS/nixpkgs/commit/7cd65916e94257b79ad521482ae25b32016e3896) texlab: 3.2.0 → 3.3.0
* [`07c44a2d`](https://github.com/NixOS/nixpkgs/commit/07c44a2d31e3becd566b6380d1873852262f11a2) Revert "Merge pull request [nixos/nixpkgs⁠#141782](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141782) from fufexan/tlp"
* [`5c16ebad`](https://github.com/NixOS/nixpkgs/commit/5c16ebad93bf4fa481855797d4edc0efff0ae31d) pgformatter: 5.0 -> 5.1
* [`92daf01d`](https://github.com/NixOS/nixpkgs/commit/92daf01de69c4679f09cdcfd9e276c45d2cce8d3) tlp: 1.3.1 -> 1.4.0
* [`a6f7fdfe`](https://github.com/NixOS/nixpkgs/commit/a6f7fdfe0875287fa6b25b009f71a8497cdaedc4) vale: 2.10.6 -> 2.11.2
* [`5f0d9180`](https://github.com/NixOS/nixpkgs/commit/5f0d9180ac7656c3ad6a40939ad2258f7cd9de0c) tectonic: 0.7.0 -> 0.8.0
* [`3ee5dff7`](https://github.com/NixOS/nixpkgs/commit/3ee5dff79e6feb748597c8aaabe9ec47c389ff83) tflint: 0.32.1 -> 0.33.0
* [`4b26811c`](https://github.com/NixOS/nixpkgs/commit/4b26811cdd7568e7ad331186f82009e60c882eb9) coqPackages.gaia: mark as compatible with Coq 8.14
* [`3c6e3c74`](https://github.com/NixOS/nixpkgs/commit/3c6e3c742fbbc28a9ee6bb4840d9f88957c75d42) coqPackages.mathcomp-zify: 1.0.0+1.12+8.13 -> 1.1.0+1.12+8.13
* [`8960e6bc`](https://github.com/NixOS/nixpkgs/commit/8960e6bc7457cc1850ff8013750ca7c19c8a8797) python38Packages.miniaudio: 1.44 -> 1.45
* [`96e03882`](https://github.com/NixOS/nixpkgs/commit/96e038820c4bde374bf484886b695f169292dc2f) julius: 1.6.0 -> 1.7.0
* [`29c8e91c`](https://github.com/NixOS/nixpkgs/commit/29c8e91c5dc5fcd510e00ebf0611481458b4d31d) macdylibbundler: 20180825 -> 1.0.0
* [`d4c2c9c9`](https://github.com/NixOS/nixpkgs/commit/d4c2c9c960e34117e76614f7e927905b54ed589a) vouch-proxy: 0.34.1 -> 0.35.1
* [`b0ed9c83`](https://github.com/NixOS/nixpkgs/commit/b0ed9c8372686a513c947c204956e7a28e7e7147) tracker: patch failing test due to float comparison
* [`ce036aad`](https://github.com/NixOS/nixpkgs/commit/ce036aad8e7f3ae46d2e60dd04a877896fc1083a) python3Packages.braceexpand: init at 0.1.7
* [`24fceb4a`](https://github.com/NixOS/nixpkgs/commit/24fceb4a931e60ef5d66e8b6545727664841703e) svdtools: init at 0.1.20
* [`218ea9f2`](https://github.com/NixOS/nixpkgs/commit/218ea9f22366a1040fe371847dd369133192707e) flexget: 3.1.138 -> 3.1.139
* [`4df3bf48`](https://github.com/NixOS/nixpkgs/commit/4df3bf48ad3103129907ca09a338815443c66cdd) python38Packages.pytwitchapi: 2.4.2 -> 2.5.0
* [`42db6197`](https://github.com/NixOS/nixpkgs/commit/42db619720dc144f495d409a7b1ebd1f1550a382) python38Packages.progressbar2: 3.54.0 -> 3.55.0
* [`de8d0982`](https://github.com/NixOS/nixpkgs/commit/de8d09829e32e7531df7f16f7e97f67efe4ea1f9) python38Packages.robotframework: 4.1.1 -> 4.1.2
* [`23d28a5c`](https://github.com/NixOS/nixpkgs/commit/23d28a5caa740007029a99f97fbf4e6391359f47) python38Packages.ibm-cloud-sdk-core: 3.11.3 -> 3.12.0
* [`1daab6c7`](https://github.com/NixOS/nixpkgs/commit/1daab6c7339f072293e9d77e80c7d558870a848a) python38Packages.pynput: 1.7.3 -> 1.7.4
* [`08c5aa32`](https://github.com/NixOS/nixpkgs/commit/08c5aa32e4ca73ae614912db0557c8839e727bef) vlc: remove live555 dependency on 32-bit ARM ([nixos/nixpkgs⁠#141215](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141215))
* [`2dc8282f`](https://github.com/NixOS/nixpkgs/commit/2dc8282f91728ca66ab6fa21504da0e7000b2c57) python38Packages.python-rapidjson: 1.4 -> 1.5
* [`980d3e1e`](https://github.com/NixOS/nixpkgs/commit/980d3e1e68171e3ec99d514b695bca95f7ae4931) python38Packages.pyvmomi: 7.0.2 -> 7.0.3
* [`8c5e07ca`](https://github.com/NixOS/nixpkgs/commit/8c5e07ca9d491a8bee1e6b343679891ac574d09e) python38Packages.hg-evolve: 10.3.3 -> 10.4.0
* [`682e7efa`](https://github.com/NixOS/nixpkgs/commit/682e7efafc3aff5f4436ed8d8b4b4cacea94b976) python38Packages.intensity-normalization: 2.0.3 -> 2.1.0
* [`1416be78`](https://github.com/NixOS/nixpkgs/commit/1416be7893f77ba2de36c5624103d8bdc93f830d) python38Packages.pymetar: 1.3 -> 1.4
* [`05d9c4e3`](https://github.com/NixOS/nixpkgs/commit/05d9c4e3b61e4b805439e14f42aba7adbb5ab12c) python38Packages.mypy-boto3-s3: 1.18.60 -> 1.18.62
* [`aa6cb73f`](https://github.com/NixOS/nixpkgs/commit/aa6cb73f5e4bf621fc8114bb7f067064cad8e4e8) python38Packages.env-canada: 0.5.13 -> 0.5.14
* [`3faf5493`](https://github.com/NixOS/nixpkgs/commit/3faf54932cefd69d4e34e62ad614192249766962) gitRepo: 2.17.1 -> 2.17.2
* [`0be1a95e`](https://github.com/NixOS/nixpkgs/commit/0be1a95e5ad32c153a9ccd48675a420b5f01d4dc) python38Packages.strictyaml: 1.4.4 -> 1.5.0
* [`c267b390`](https://github.com/NixOS/nixpkgs/commit/c267b3908156ceff4e6b8fcb48ed566ffc2ae619) python38Packages.azure-identity: 1.6.1 -> 1.7.0
* [`0fa14d32`](https://github.com/NixOS/nixpkgs/commit/0fa14d32ec13ffcaaa78a1c888ac01a951cea0a2) python38Packages.awkward: 1.5.0 -> 1.5.1
* [`78d3d137`](https://github.com/NixOS/nixpkgs/commit/78d3d137ea1c6f6602e4103fdb072ba73ec0aa54) python38Packages.django_modelcluster: 5.1 -> 5.2
* [`8b475f18`](https://github.com/NixOS/nixpkgs/commit/8b475f1880036a49911ced43beaf13438a75b5e8) python38Packages.pynndescent: 0.5.4 -> 0.5.5
* [`1ec3f619`](https://github.com/NixOS/nixpkgs/commit/1ec3f619742053018b2c59dc3733369b236bd603) python38Packages.sagemaker: 2.60.0 -> 2.63.0
* [`8bcfa5ed`](https://github.com/NixOS/nixpkgs/commit/8bcfa5edfb242928a51e9449ac326be85703614f) python38Packages.django-storages: 1.12 -> 1.12.1
* [`ccfd9f50`](https://github.com/NixOS/nixpkgs/commit/ccfd9f50d487cc101adb31cb4031f590027031cd) python38Packages.annexremote: 1.4.5 -> 1.6.0
* [`c49cde62`](https://github.com/NixOS/nixpkgs/commit/c49cde62f00c0f1d114c38b9e6f26ffb05293573) python38Packages.types-protobuf: 3.17.5 -> 3.18.0
* [`9eff77bc`](https://github.com/NixOS/nixpkgs/commit/9eff77bc60f65287e65fa1a8aff533cd8fe4d867) python38Packages.limnoria: 2021.07.21 -> 2021.10.9
* [`b7765fee`](https://github.com/NixOS/nixpkgs/commit/b7765fee5130598f3be0214021a35ef3935296a4) python38Packages.nltk: 3.6.4 -> 3.6.5
* [`a89b31ac`](https://github.com/NixOS/nixpkgs/commit/a89b31ac1c846ceaf9d7bd7476a8f4f7c3d4aac3) python38Packages.azure-mgmt-datafactory: 1.1.0 -> 2.0.0
* [`c2572160`](https://github.com/NixOS/nixpkgs/commit/c25721601dbe5c0d2c2436204ba1f391f71ffa20) python38Packages.stripe: 2.60.0 -> 2.61.0
* [`fa17503c`](https://github.com/NixOS/nixpkgs/commit/fa17503ced275e068d68a20fb174bd54fa4a1498) python38Packages.lightgbm: 3.2.1 -> 3.3.0
* [`fb11d51e`](https://github.com/NixOS/nixpkgs/commit/fb11d51e280da7e81b34d78879171edbc4305769) hubstaff: 1.6.2-b5029032 -> 1.6.2-328c666b
* [`03ab641a`](https://github.com/NixOS/nixpkgs/commit/03ab641a3a728344145bfc8860ef882bcb242449) python38Packages.mockupdb: 1.8.0 -> 1.8.1
* [`5d1532c5`](https://github.com/NixOS/nixpkgs/commit/5d1532c5aa434a0903953003a891e61302d8ac57) python38Packages.pulsectl: 21.9.1 -> 21.10.4
* [`33bc6f87`](https://github.com/NixOS/nixpkgs/commit/33bc6f87068d4bbc843881b6581d8a07e4a424aa) docker-compose2: init at 2.0.1 ([nixos/nixpkgs⁠#141366](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141366))
* [`6e58a09e`](https://github.com/NixOS/nixpkgs/commit/6e58a09e52a1fa8be4efc9fe201a6bccf3d5b75d) python38Packages.inifile: 0.3 -> 0.4.1
* [`b47182ff`](https://github.com/NixOS/nixpkgs/commit/b47182ff8cb7bbc9402813823784bdaa4628b2ed) python38Packages.google-cloud-iam-logging: 0.1.3 -> 0.2.0
* [`afa3174c`](https://github.com/NixOS/nixpkgs/commit/afa3174c73e1ee43e4b6e41b0862c9f30bc0d315) python38Packages.nunavut: 1.5.0 -> 1.5.1
* [`55d4dc8f`](https://github.com/NixOS/nixpkgs/commit/55d4dc8f3eaf7e0bd7d929ed6dba30e30646b19b) python38Packages.gsd: 2.4.2 -> 2.5.0
* [`319f7d2a`](https://github.com/NixOS/nixpkgs/commit/319f7d2aa45eff6e5220750fd6b68ab62a1c4010) python38Packages.azure-mgmt-compute: 23.0.0 -> 23.1.0
* [`5ca1a1a2`](https://github.com/NixOS/nixpkgs/commit/5ca1a1a2c167f2543cd1349512d8f3afb34ef1ce) python38Packages.cucumber-tag-expressions: 4.0.2 -> 4.1.0
* [`c8e9d945`](https://github.com/NixOS/nixpkgs/commit/c8e9d945428669c4de5d3889bd9ae9e9f5943368) python38Packages.keepkey: 6.7.0 -> 7.2.1
* [`e8b8dd13`](https://github.com/NixOS/nixpkgs/commit/e8b8dd13e0d867f8753f89946dbc4bc614000368) jitsi-meet-prosody: 1.0.5307 -> 1.0.5415
* [`3f9e478d`](https://github.com/NixOS/nixpkgs/commit/3f9e478db130170829d5b9143c1e653e662f3847) jitsi-videobridge: 2.1-551-g2ad6eb0b -> 2.1-570-gb802be83
* [`0eae36de`](https://github.com/NixOS/nixpkgs/commit/0eae36de63a1021b4ab48b35281655530d4339ea) battop: remove
* [`0ad041e5`](https://github.com/NixOS/nixpkgs/commit/0ad041e5bcf5358ba100f806e2e925ef5c7be7bf) ocamlPackages.color: init at 0.2.0
* [`18d24771`](https://github.com/NixOS/nixpkgs/commit/18d24771da3a19113122ba961b4b206613883f60) flitter: init at unstable-2020-10-05
* [`1ea63956`](https://github.com/NixOS/nixpkgs/commit/1ea6395610212ea8c54bd39560eebc0f33d7a76c) ms-python.python: fix [nixos/nixpkgs⁠#139813](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/139813) and [nixos/nixpkgs⁠#137314](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/137314) (lttng-ust and libstdc++ errors) ([nixos/nixpkgs⁠#140564](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140564))
* [`3fe3c640`](https://github.com/NixOS/nixpkgs/commit/3fe3c640e827bb282bbf336db6b607fac2621499) jitsi-meet: 1.0.5307 -> 1.0.5415
* [`16c505e8`](https://github.com/NixOS/nixpkgs/commit/16c505e87e4724a4488c5a1a96316374c6dc3ab3) metals: 0.10.6 → 0.10.7
* [`3c6a46cf`](https://github.com/NixOS/nixpkgs/commit/3c6a46cfc970ac21cd1b3ce2a1394075a3af969a) osu-lazer: 2021.1006.1 -> 2021.1016.0
* [`e8499098`](https://github.com/NixOS/nixpkgs/commit/e849909813eddce351baa0429a98299da80c77e6) alpine: 2.24 → 2.25
* [`16ffcc8f`](https://github.com/NixOS/nixpkgs/commit/16ffcc8f547182986c39c8becc8853ea1e02c301) qcoro: init at 0.3.0
* [`1d93a080`](https://github.com/NixOS/nixpkgs/commit/1d93a080a6ad6cffb2b7ac38b8e86dd46937a543) lua: add conditional to use linux-readline as the plat on 5.4+
* [`5c93a778`](https://github.com/NixOS/nixpkgs/commit/5c93a7780a5f9e47f534e7c726a65b72f4b9d2ce) Revert "luarocks: 3.2.1 -> 3.7.0"
* [`397b6492`](https://github.com/NixOS/nixpkgs/commit/397b6492832866fb4d4d7e4ea837376acc14512d) luaPackages.luarocks-3_7: init so that the reverted update can be accessed if desired
* [`9889c07e`](https://github.com/NixOS/nixpkgs/commit/9889c07eb3c6919eb1f71fbbd871e5166aa71ec4) ddnet: init at 15.5.4
* [`765142f3`](https://github.com/NixOS/nixpkgs/commit/765142f3154a81130d4ebc89e3a8aaf005ad020c) python3Packages.frozenlist: 1.1.1 -> 1.2.0
* [`b0581c26`](https://github.com/NixOS/nixpkgs/commit/b0581c2699cf4f4fb7da2098385372739d4d8955) chromiumDev: Fix the build
* [`78d619d9`](https://github.com/NixOS/nixpkgs/commit/78d619d9d5a0c9413bcf217e7b9cf3982541ad10) dapl, dapl-native: fix
* [`cb8fcfa3`](https://github.com/NixOS/nixpkgs/commit/cb8fcfa3e65b169cd94709fff54dd4ea55d24db7) highlight: fix cross-platform build
* [`20441457`](https://github.com/NixOS/nixpkgs/commit/20441457d94a1344a86aa236814fa456feec72eb) sqlfluff: 0.6.8 -> 0.7.0
* [`9b3ef21b`](https://github.com/NixOS/nixpkgs/commit/9b3ef21bff420b87aa00418dbe1037ed5f5fd322) signal-desktop: 5.19.0 -> 5.20.0
* [`f33e326e`](https://github.com/NixOS/nixpkgs/commit/f33e326e4029d2455d1a2a040d6e04696b0b0ff1) highlight: make manpage compression reproducible
* [`0773baf0`](https://github.com/NixOS/nixpkgs/commit/0773baf0beb83f986b1b98a0eede495a3c8a750f) python38Packages.aiosignal: 1.1.2 -> 1.2.0
* [`85d1b34f`](https://github.com/NixOS/nixpkgs/commit/85d1b34f320e500b14a1699fc035faac2749cf33) linuxPackages.nvidia_x11_beta: 470.42.01 -> 495.29.05
* [`d3e92322`](https://github.com/NixOS/nixpkgs/commit/d3e9232242f5276a385a2b03837651da54422e30) vimPlugins: update
* [`a21416e5`](https://github.com/NixOS/nixpkgs/commit/a21416e5a92704eb6270f20dfb596c94f7f48e49) vimPlugins.nvim-lsp-ts-utils: init at 2021-10-03
* [`a2004d37`](https://github.com/NixOS/nixpkgs/commit/a2004d37a3c2ef4380097a8a8e28632ec395ec78) lmms: build using fluidsynth 2.x
* [`d7b844ef`](https://github.com/NixOS/nixpkgs/commit/d7b844ef82c159b30ba3b5fd7a2299cc748997b8) bubblewrap: 0.4.1 -> 0.5.0
* [`20c78da4`](https://github.com/NixOS/nixpkgs/commit/20c78da41fd1185b521487b0296a8d014a3e0401) kubernetes-helmPlugins.helm-git: init at 0.10.0
* [`56c31c1b`](https://github.com/NixOS/nixpkgs/commit/56c31c1b13242a4013203e180411b3744ca3984a) trellis: Revert removal of CMAKE_INSTALL_DATADIR
* [`eebfe719`](https://github.com/NixOS/nixpkgs/commit/eebfe7199d9e543acea19de4af15a91ab7774e7c) trellis: Added installCheckPhase that ensures database is available and updated maintainers
* [`504fff7a`](https://github.com/NixOS/nixpkgs/commit/504fff7a3b6e2b33ab1664e8671fbe89d6fb9ceb) dapl: 0.2.0+unstable=2021-06-30 -> 0.2.0+date=2021-10-16
* [`84e726be`](https://github.com/NixOS/nixpkgs/commit/84e726be4724435fc8531d698a379199d5c9eff6) dbqn: 0.pre+unstable=2021-10-05 -> 0.pre+date=2021-10-08
* [`5213ac95`](https://github.com/NixOS/nixpkgs/commit/5213ac95cce079b20252afc35fdd89981b321987) tidy-viewer: init at 0.0.21
* [`f29ea2d1`](https://github.com/NixOS/nixpkgs/commit/f29ea2d15d833494f7e97e0231b03ca70a8e7db4) nixos/networking: add foo-over-udp endpoint support
* [`c1f51554`](https://github.com/NixOS/nixpkgs/commit/c1f515547109a7e1845120449676ba6aa9a78fe9) nixos/networking: support FOU encapsulation for sits
* [`4973ffc8`](https://github.com/NixOS/nixpkgs/commit/4973ffc800e9ca08e36772332c23505e51cd31a8) zettlr: 1.8.9 -> 2.0.0
* [`7f8d276a`](https://github.com/NixOS/nixpkgs/commit/7f8d276a8a2be2b698cf1c0e30505b5ea0c99027) kn: init at 0.26.0 ([nixos/nixpkgs⁠#141928](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141928))
* [`6e8bde44`](https://github.com/NixOS/nixpkgs/commit/6e8bde44448205b05a769f75624584343961204f) python38Packages.mypy-boto3-s3: 1.18.62 -> 1.18.63
* [`d883b616`](https://github.com/NixOS/nixpkgs/commit/d883b616ef0e4ce5fcabf7152aa58264e3c47cb6) jetbrains: update
* [`ac6f34a6`](https://github.com/NixOS/nixpkgs/commit/ac6f34a6698d6079a46dd1dc88e8b52d40134b8f) pantheon.evince: init
* [`ce7479ef`](https://github.com/NixOS/nixpkgs/commit/ce7479ef91037dbe08540d8148cd2fdd509f4abd) nixos/evince: add option for specify package
* [`cae29344`](https://github.com/NixOS/nixpkgs/commit/cae293443bbbf07c05912c8ee1f6a6facfbde5bc) nixos/pantheon: prefer pantheon.evince
* [`609928f5`](https://github.com/NixOS/nixpkgs/commit/609928f5a1599b029a12dbf748b01d23ccada5a1) pantheon.epiphany: rename patches
* [`acb119c1`](https://github.com/NixOS/nixpkgs/commit/acb119c16e9eb23ff1d8da2eea8695017c72a29c) python38Packages.pulsectl: 21.10.4 -> 21.10.5
* [`cb1b8eb4`](https://github.com/NixOS/nixpkgs/commit/cb1b8eb419fb474e181d206366447c9f729dd0c2) exploitdb: 2021-10-15 -> 2021-10-16
* [`eefdd9ff`](https://github.com/NixOS/nixpkgs/commit/eefdd9ffb29fad8e650ef8f063d8e4eab4e1e3c2) zfs: strip debug symbols
* [`d80b0c01`](https://github.com/NixOS/nixpkgs/commit/d80b0c01711f840aa703a3c923f7d941cded15b9) gnudatalanguage: Init at 1.0.0
* [`79ffee21`](https://github.com/NixOS/nixpkgs/commit/79ffee21c5395c9e71b1a7456f5ee60942177d44) python3Packages.pyintesishome: 1.8.0 -> 1.8.1
* [`280e7b93`](https://github.com/NixOS/nixpkgs/commit/280e7b93bef612f74cb5110e3afad4f90818c717) unbound: enable more features
* [`1995c1ce`](https://github.com/NixOS/nixpkgs/commit/1995c1ce4b60d0507318e05121f0af5a77adb7ba) python3Packages.asyncssh: disable TestSKAuthCTAP2 tests
* [`e6cd387e`](https://github.com/NixOS/nixpkgs/commit/e6cd387e0510f6093fec3739706d9d92dd93256c) python3Packages.browser-cookie3: add pythonImportsCheck
* [`3b93c7a3`](https://github.com/NixOS/nixpkgs/commit/3b93c7a39e0ae4b54a243cdacbdc83587111c0f7) aml: 0.2.0 -> 0.2.1
* [`5f7e675c`](https://github.com/NixOS/nixpkgs/commit/5f7e675c455d17564eff46911cee4b602c1b5e63) nixos/libvirtd: add qemuOvmfPackage option
* [`c0f60149`](https://github.com/NixOS/nixpkgs/commit/c0f60149708fb9bb8014fcc8b03fc25ea10f9b27) ocamlPackages.ocaml-freestanding: 0.6.4 → 0.6.5
* [`156e94c2`](https://github.com/NixOS/nixpkgs/commit/156e94c2c5a152fa17a8a526731d8717229bd43a) python38Packages.bond-api: 0.1.13 -> 0.1.14
* [`71fa2b05`](https://github.com/NixOS/nixpkgs/commit/71fa2b05f61b9caaab2bb571aa2200c72801fafb) rstudio: fix source revision reference
* [`76842da5`](https://github.com/NixOS/nixpkgs/commit/76842da57921359a7f87c991d72462c7381f31d4) auto-cpufreq: 1.6.9 -> 1.7.0
* [`b3d58113`](https://github.com/NixOS/nixpkgs/commit/b3d5811308cbd38006332c7c33f44aa6f1848375) tnat64: 0.05 -> 0.06
* [`9763f0b8`](https://github.com/NixOS/nixpkgs/commit/9763f0b83f95fd4e562c9298c7c321dff2ded901) clapper: add missing deps
* [`9a534569`](https://github.com/NixOS/nixpkgs/commit/9a5345698dc85bb4076116e0e9fea29898cc8946) tinycc: fix pkgsStatic.tinycc (musl)
* [`8d52479b`](https://github.com/NixOS/nixpkgs/commit/8d52479bc7843cff0f291dc31da8af4f965e755d) nixos/libvirtd: Add configuration option for swtpm
* [`802aa647`](https://github.com/NixOS/nixpkgs/commit/802aa64773c246c2db157f5072401a64bf9ab519) catcli: 0.7.3 -> 0.7.4
* [`f2ee2ca4`](https://github.com/NixOS/nixpkgs/commit/f2ee2ca4cef1507e950090f32e299ba7b9d8b135) vimPlugins: update
* [`222ae15d`](https://github.com/NixOS/nixpkgs/commit/222ae15d55ff4b90c7dc2ae0ef417655d8cfaf00) vimPlugins.better-escape-nvim: init at 2021-10-09
* [`1ba118f4`](https://github.com/NixOS/nixpkgs/commit/1ba118f40ae227ac7545f547d0996e5000d9cd66) vimPlugins.comment-nvim: init at 2021-10-17
* [`f13b08e9`](https://github.com/NixOS/nixpkgs/commit/f13b08e900c283b657a5626f059ae11ef674457b) pdns-recursor: 4.5.4 -> 4.5.6
* [`826f620f`](https://github.com/NixOS/nixpkgs/commit/826f620ffe4c8202bcbf45ebe72533e5620ae567) vimPlugins.telescope-cheat-nvim: init at 2021-09-24
* [`67ef64c5`](https://github.com/NixOS/nixpkgs/commit/67ef64c5cfb32382b17d02d46151bd9e504a44dd) llvm: bump min version for musl to 11+
* [`216d735f`](https://github.com/NixOS/nixpkgs/commit/216d735fad15c1a8b29bc6f2b8b763cded2aa2aa) rates: init at 0.5.0
* [`c10d30c4`](https://github.com/NixOS/nixpkgs/commit/c10d30c4347bc3d6e7e85c77582931fed9e5058d) randomx: 1.1.8 -> 1.1.9
* [`8eeae532`](https://github.com/NixOS/nixpkgs/commit/8eeae5320e741d55ec1b891853fa48419e3a5a26) tinycc: simplify specifying cc/ar
* [`cf8610c7`](https://github.com/NixOS/nixpkgs/commit/cf8610c7b5e70008c4903b3cf5e3279c1e8e45e8) pythonPackages.libusb1: 1.9.3 -> 2.0.1
* [`675c3b3d`](https://github.com/NixOS/nixpkgs/commit/675c3b3d02b1c6f9750e8221fe5322245321b29c) meli: alpha-0.7.1 -> alpha-0.7.2
* [`3c3fc76c`](https://github.com/NixOS/nixpkgs/commit/3c3fc76c13538ccc2134ec48dcda5b04a7c23cba) flatpak: 1.10.2 -> 1.12.2
* [`5f019422`](https://github.com/NixOS/nixpkgs/commit/5f0194220f2402b06f7f79bba6351895facb5acb) cloud-hypervisor: 18.0 -> 19.0
