### PR TITLE
niv home-manager: update 0b47ded2 -> b5d738b5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0b47ded208a6ed24f40b9d62379d04fe8dc4f63e",
-        "sha256": "1kzvj43v05adx7szapph3xdyicnpwmawkjrzhhigkqnij1jqibws",
+        "rev": "b5d738b5a3f8c3738433e0aa6482afb4ac635380",
+        "sha256": "07afvwvr9fkrsv5hvv5jjwpphb3s8qw9c2lgh49kil6rd3jczy5h",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/0b47ded208a6ed24f40b9d62379d04fe8dc4f63e.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/b5d738b5a3f8c3738433e0aa6482afb4ac635380.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@0b47ded2...b5d738b5](https://github.com/nix-community/home-manager/compare/0b47ded208a6ed24f40b9d62379d04fe8dc4f63e...b5d738b5a3f8c3738433e0aa6482afb4ac635380)

* [`83f5ce2a`](https://github.com/nix-community/home-manager/commit/83f5ce2aec0f0182fa69bbda30655effaa84c518) mbsync: add missing `literalExample`
* [`a77a01d1`](https://github.com/nix-community/home-manager/commit/a77a01d1f63d510540ad2f82fe9ca686d85dd7a6) docs: bump nmd
* [`468c4611`](https://github.com/nix-community/home-manager/commit/468c4611396f6ca3be5eb54f1c864e34cc19dfe2) lib: add fallback for literalExpression and literalDocBook
* [`bd11e2c5`](https://github.com/nix-community/home-manager/commit/bd11e2c5e67385970e59e55ba7a4c35d1ffaee4d) Replace usage of `literalExample`
* [`b78b5843`](https://github.com/nix-community/home-manager/commit/b78b584368be76cd9a24449f3be2b0a13cf55e3f) tests: fix test.assert.assertions.enable not working
* [`b22004bf`](https://github.com/nix-community/home-manager/commit/b22004bf1f303d68d97928ffbd0b9c76c415362e) rofi: add test case for config with deprecated options
* [`b88c863b`](https://github.com/nix-community/home-manager/commit/b88c863b4068faf43aa4d1bb5c4397a67b64c59c) modules: remove myself from maintainers.nix
* [`223a4a17`](https://github.com/nix-community/home-manager/commit/223a4a17a4087189167f7d3cf2f5af7b526524f9) nixpkgs-disabled: add module
* [`13e00b70`](https://github.com/nix-community/home-manager/commit/13e00b70a42959835190576a80fe9d8ebab062f2) docs: remove $ prompts to make it easier to copy paste
* [`309808af`](https://github.com/nix-community/home-manager/commit/309808afbc2a07e340067f66029a4202b4c4b959) github: disable `strategy.fail-fast`
* [`d244ca12`](https://github.com/nix-community/home-manager/commit/d244ca125f140391c5a8164f576c9cf7ce2f15e1) Dependabot should act on release-21.05, not 20.09
* [`0d110a09`](https://github.com/nix-community/home-manager/commit/0d110a0936e865c208e0188adc43aae42b7989e0) imapnotify: only write onNew* if a value is available
* [`5961c64e`](https://github.com/nix-community/home-manager/commit/5961c64e03bfbd18cbdf2c25960b652b46437704) imapnotify: add `extraConfig` account option
* [`b5d738b5`](https://github.com/nix-community/home-manager/commit/b5d738b5a3f8c3738433e0aa6482afb4ac635380) ci: update install-nix-action to v14.1
