### PR TITLE
niv spacemacs: update 63056ecb -> 5c88c3b0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "63056ecb50f93808781b97feab1c3225d35c7aa1",
-        "sha256": "038rfnyd404bzv83h5l0fbp3mn9c6qpn4h2liyf5baqc8wsmzg7x",
+        "rev": "5c88c3b089c132997bf9f571a0207d93739efef1",
+        "sha256": "0axmrbl0w016p4fc962i4bk318l4sk4fn7v4wli0fz0zj0zns4nz",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/63056ecb50f93808781b97feab1c3225d35c7aa1.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/5c88c3b089c132997bf9f571a0207d93739efef1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@63056ecb...5c88c3b0](https://github.com/syl20bnr/spacemacs/compare/63056ecb50f93808781b97feab1c3225d35c7aa1...5c88c3b089c132997bf9f571a0207d93739efef1)

* [`5b3bb908`](https://github.com/syl20bnr/spacemacs/commit/5b3bb908a1bc31938c3eaa45da43c7b94bc90115) LaTeX: Remove duplicate latex-refresh-preview ([syl20bnr/spacemacs⁠#15091](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15091))
* [`5c88c3b0`](https://github.com/syl20bnr/spacemacs/commit/5c88c3b089c132997bf9f571a0207d93739efef1) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15071](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15071))
