### PR TITLE
niv nixpkgs: update 5f019422 -> 33afbbd4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f0194220f2402b06f7f79bba6351895facb5acb",
-        "sha256": "0h2j0ivbp3b84d38h8s06s2yvnwqy80f4i1a75jd11m45m804n3s",
+        "rev": "33afbbd4afe427d0bcac3354382c33c0a358a06a",
+        "sha256": "1fvfpmav599vv8x46grj2qh14irbzcwach178dyqqh7bxz91cvyj",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5f0194220f2402b06f7f79bba6351895facb5acb.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/33afbbd4afe427d0bcac3354382c33c0a358a06a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5f019422...33afbbd4](https://github.com/nixos/nixpkgs/compare/5f0194220f2402b06f7f79bba6351895facb5acb...33afbbd4afe427d0bcac3354382c33c0a358a06a)

* [`090e4a21`](https://github.com/NixOS/nixpkgs/commit/090e4a21a5734077c2246a4c2cbd94dc201b9cef) piping-server-rust: init at 0.9.1
* [`e2db47a6`](https://github.com/NixOS/nixpkgs/commit/e2db47a66f20ef8c8ca7f3202a416c977d6799db) anewer: init at 0.1.6
* [`de0f40c8`](https://github.com/NixOS/nixpkgs/commit/de0f40c837232761068bba96adf0da20abe13f3d) python3Packages.jupyter-server-mathjax: init at 0.2.3
* [`2fa6e756`](https://github.com/NixOS/nixpkgs/commit/2fa6e756ed0aa186c74854b73605bf48e5067c3d) python3Packages.nbdime: fix build, add missing dependency
* [`f9e0bae4`](https://github.com/NixOS/nixpkgs/commit/f9e0bae4857f6d3aeb8a9ecb35de3e1668132d23) jrnl: 2.8 -> 2.8.3
* [`bf657a09`](https://github.com/NixOS/nixpkgs/commit/bf657a0996d8faca4c3a88dbd00205ee7475e4e1) flink: 1.13.2 -> 1.14.0
* [`7db7784f`](https://github.com/NixOS/nixpkgs/commit/7db7784f5176fa1e9f94d16b01689f823441d58e) anewer: fix license
* [`ced0efcf`](https://github.com/NixOS/nixpkgs/commit/ced0efcfd1e19a66c0e816aee3df65ee6a7b7024) slides: 0.5.0 -> 0.6.1
* [`c28e9c4c`](https://github.com/NixOS/nixpkgs/commit/c28e9c4c50d50c289af6c6b018735b44167018bd) factorio: 1.1.39 -> 1.1.42
* [`47c38dc2`](https://github.com/NixOS/nixpkgs/commit/47c38dc25f0f1223ac79eff052d8f7af94844b2a) sdrangel: 6.16.3 → 6.17.1
* [`52f22edb`](https://github.com/NixOS/nixpkgs/commit/52f22edb9cdd2beb1ec37c80913c5fab1f73dd47) wine-staging: Move staging patches to prePatch
* [`56d0b5cd`](https://github.com/NixOS/nixpkgs/commit/56d0b5cd6a61da42cca5be52b216bad9d1ff2b59) nixos/mosquitto: rewrite the module
* [`c47fcb70`](https://github.com/NixOS/nixpkgs/commit/c47fcb70c6885d6df869934280ebeb715ca7e6fd) nixos/mosquitto: rewrite the test
* [`1fa5e13f`](https://github.com/NixOS/nixpkgs/commit/1fa5e13f30c60890b01475d7945a17ca5721a5f2) nixos/borgbackup: allow dump scripts as stdin inputs
* [`1fb77e82`](https://github.com/NixOS/nixpkgs/commit/1fb77e822b87b0ca729c007e63166c7d2d38e947) discourse: Fix the public directory path reported by Discourse
* [`5c2879d8`](https://github.com/NixOS/nixpkgs/commit/5c2879d8854ec35f5bd79807b27d1fcc4d9e51bf) python3Packages.restfly: 1.4.2 -> 1.4.3
* [`2070d83f`](https://github.com/NixOS/nixpkgs/commit/2070d83f07e77278ddf8da3b90fc5c6f471df273) python39Packages.pdfminer: add symlinks without .py extension
* [`5be11d92`](https://github.com/NixOS/nixpkgs/commit/5be11d92d3caff849d74bf006385b1887c5f531e) python3Packages.yara-python: 4.1.2 -> 4.1.3
* [`6fdc3e6a`](https://github.com/NixOS/nixpkgs/commit/6fdc3e6a7c04865b59f7c3e28d4eb16818cb7da2) oggvideotools: init at 0.9.1
* [`bc4417cd`](https://github.com/NixOS/nixpkgs/commit/bc4417cdca640090bc55e9b7b9b7e7f72c92d764) enjarify: init at 1.0.3
* [`c6172d38`](https://github.com/NixOS/nixpkgs/commit/c6172d382cdab1beb686a43875616a747f59643f) procyon: init at 0.6-prerelease
* [`aa3eb13c`](https://github.com/NixOS/nixpkgs/commit/aa3eb13c9f2886f47ad04b97fde5660481d68aaa) xmlbeans: init at 5.0.2-20211014
* [`3da71c4e`](https://github.com/NixOS/nixpkgs/commit/3da71c4e9a50890903ef767af99de51a88e71df4) diffoscope: enable all available tools
* [`78778173`](https://github.com/NixOS/nixpkgs/commit/787781730098773a1a6e9c1d0e25e63383fcf111) python3Packages.hole: 0.5.1 -> 0.6.0
* [`90da4105`](https://github.com/NixOS/nixpkgs/commit/90da4105ce057be396e73a7c0ddae88d6262e286) pgmetrics: 1.11.0 -> 1.12.0
* [`2de2502f`](https://github.com/NixOS/nixpkgs/commit/2de2502fc084450d490a5179b240294a2f12a73e) haskellPackages: mark builds failing on hydra as broken
* [`36cee8e9`](https://github.com/NixOS/nixpkgs/commit/36cee8e9e59e7990a014a7c16a4e45d498856332) rqbit: init at 2.0.0
* [`4b63a6da`](https://github.com/NixOS/nixpkgs/commit/4b63a6dacc25d5eead0466ecf56e67136656257d) purescript: 0.14.4 -> 0.14.5
* [`db287c38`](https://github.com/NixOS/nixpkgs/commit/db287c380df20eeef6626f14f760eb0f6e091dfc) git-lfs: 2.13.3 -> 3.0.1
* [`73acbabd`](https://github.com/NixOS/nixpkgs/commit/73acbabd328169113533250ecd6960fc9ee5d3c9) postgresqlPackages.plpgsql_check: 2.0.2 -> 2.0.5
* [`382e7832`](https://github.com/NixOS/nixpkgs/commit/382e7832e5fb7644ccee66f4742fd9b7b3daafba) resvg: 0.18.0 -> 0.19.0
* [`b964c5da`](https://github.com/NixOS/nixpkgs/commit/b964c5da83ec234b01cfbba0280a3d6079cd4883) mtxclient: fix compilation with olm-3.2.6
* [`273200e3`](https://github.com/NixOS/nixpkgs/commit/273200e3a2ae63e8c6d566c9f13e836368cfe9a8) dino: remove mic92 as maintainer
* [`596e0d1f`](https://github.com/NixOS/nixpkgs/commit/596e0d1ff18ceb2925427a62e8e6656d46bde4ae) gdu: 5.8.1 -> 5.9.0
* [`8cde0d3f`](https://github.com/NixOS/nixpkgs/commit/8cde0d3fef5264d0bfdf42697432cd33d9632a94) python3Packages.ismartgate: 4.0.3 -> 4.0.4
* [`43b33a0a`](https://github.com/NixOS/nixpkgs/commit/43b33a0aeb14e74bfd12f1ea5d22ca0708e01f42) sacc: 1.03 -> 1.04
* [`f71d3ea5`](https://github.com/NixOS/nixpkgs/commit/f71d3ea520cdc91c3fa61c8b37bdd5f7e762c45f) pantheon.elementary-photos: fix build with vala 0.54
* [`4e1740b9`](https://github.com/NixOS/nixpkgs/commit/4e1740b9deada68469741f5b802dda26553dd799) pantheon.wingpanel-indicator-sound: fix build with vala 0.54
* [`15702a7b`](https://github.com/NixOS/nixpkgs/commit/15702a7b9ac30711b9fbb40abb8dd0135eb57db6) pantheon.elementary-gtk-theme: 6.0.0 -> 6.1.0
* [`4b1f166f`](https://github.com/NixOS/nixpkgs/commit/4b1f166fbfac5622b88ccbe546f0ea2117832929) postman: 9.0.5 -> 9.1.1
* [`87304645`](https://github.com/NixOS/nixpkgs/commit/87304645b876629a056d4e4b3043b99d125a054d) Add missing clang_13 alias
* [`aa37d894`](https://github.com/NixOS/nixpkgs/commit/aa37d8940547dd706734431d7ae0da128b9de6a7) python3Packages.piccata: enable tests
* [`2d0ff634`](https://github.com/NixOS/nixpkgs/commit/2d0ff634f1f2c52622d3371231fb47dcbcb2189d) python3Packages.pyspinel: unstable-2020-06-19 -> unstable-2021-08-19
* [`7d3bb392`](https://github.com/NixOS/nixpkgs/commit/7d3bb3928df85fcfb44933c555d9722780c802f9) python3Packages.pc-ble-driver-py: 0.15.0 -> 0.16.1
* [`8d559672`](https://github.com/NixOS/nixpkgs/commit/8d559672bedd54034b711dedb7f3fd19b41ce88d) nixos/grafana: fix systemd unit
* [`9eae13d6`](https://github.com/NixOS/nixpkgs/commit/9eae13d6c212b5a6dac976eaa53897673ed5eda6) fluxcd: 0.18.3 -> 0.19.1
* [`05b40133`](https://github.com/NixOS/nixpkgs/commit/05b40133c57dd61fdf8dfd9d13138012aa7e63c1) nrfutil: 6.1 -> 6.1.3
* [`daf3ce27`](https://github.com/NixOS/nixpkgs/commit/daf3ce27e3a3707034a80df0ccab58001bd06489) git-branchless: 0.3.6 -> 0.3.7
* [`3e84134a`](https://github.com/NixOS/nixpkgs/commit/3e84134af426cd1d1a06452b6f09ccb949212844) curaLulzbot: remove
* [`744fa21b`](https://github.com/NixOS/nixpkgs/commit/744fa21b712b14a06726c85324429160fc4fdaf6) python3Packages.teslajsonpy: 1.2.0 -> 1.2.1
* [`560b50d7`](https://github.com/NixOS/nixpkgs/commit/560b50d744b39bb84f10d8a2ecedda9d45f602ef) keyscope: 1.0.1 -> 1.1.0
* [`49a5b293`](https://github.com/NixOS/nixpkgs/commit/49a5b293b940446e00837c424753f17314571395) prefetch-yarn-deps: add nix dependency ([nixos/nixpkgs⁠#142664](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142664))
* [`747f040e`](https://github.com/NixOS/nixpkgs/commit/747f040edc2e66c187774b25e46c89e20dee8ef7) kopia: 0.9.3 -> 0.9.4
* [`6e38d720`](https://github.com/NixOS/nixpkgs/commit/6e38d72020a218a3a2ef0a38be55c9a4e15255d1) slides: 0.6.1 -> 0.6.2
* [`5aa76018`](https://github.com/NixOS/nixpkgs/commit/5aa760189355bbc1b9b72ef2925b46e252748016) vopono: 0.8.6 -> 0.8.7
* [`dbb0d2e3`](https://github.com/NixOS/nixpkgs/commit/dbb0d2e3ab9685945b444822ff5872b17753f1d3) maintainers: add wentasah
* [`12aa2031`](https://github.com/NixOS/nixpkgs/commit/12aa20319323106838f45a2efb715af9b98137f0) libtraceevent: init at 1.4.0
* [`b068cd2e`](https://github.com/NixOS/nixpkgs/commit/b068cd2e1479a9ff4e3567e11edbf06b2e1ea6c5) libtracefs: init at 1.2.5
* [`3d249d1d`](https://github.com/NixOS/nixpkgs/commit/3d249d1d49c6eb35d14f812ee40a6cbb6b8aa7b3) trace-cmd: 2.9.1 -> 2.9.5
* [`393fc1f7`](https://github.com/NixOS/nixpkgs/commit/393fc1f7ee8204aa335e57e4b8bea9dccf24d4ee) kernelshark: 1.2 -> 2.0.2
* [`e7cb19c1`](https://github.com/NixOS/nixpkgs/commit/e7cb19c1a7f5440fd5a10b7d4b454a221496e0a5) fntsample: init at 5.4
* [`38b81820`](https://github.com/NixOS/nixpkgs/commit/38b81820eeef14344b9e805d91c5c9f8c854b5db) yt-dlp: 2021.10.10 -> 2021.10.22
* [`59fd7781`](https://github.com/NixOS/nixpkgs/commit/59fd77818604a13e073b51f248709ecdc6540ada) glusterfs: 9.3 -> 9.4
* [`ad57da7e`](https://github.com/NixOS/nixpkgs/commit/ad57da7e1e41d27fb63d1108d86ebed48781ad1f) wine{Unstable,Staging}: 6.19 -> 6.20
* [`d53ea8fb`](https://github.com/NixOS/nixpkgs/commit/d53ea8fbaa37eff0c227ea068df89dcb3116e502) vimPlugins: update
* [`d22c0e56`](https://github.com/NixOS/nixpkgs/commit/d22c0e561bd3509db9900807a65f0728f45644fc) vimPlugins.vim-reasonml: init at 2020-07-16
* [`d75dca05`](https://github.com/NixOS/nixpkgs/commit/d75dca05f86d3441f6a3880fbb63875502c70ad6) gnome-disk-utility: set meta.mainProgram to "gnome-disks"
* [`6aa730f4`](https://github.com/NixOS/nixpkgs/commit/6aa730f48925c53927f5949c8cce63de860473fc) maintainers: add lucasew
* [`23960334`](https://github.com/NixOS/nixpkgs/commit/23960334d7e3635908345cb407c62c680aeb0bd1) taskwarrior: 2.6.0 -> 2.6.1
* [`ff38b05b`](https://github.com/NixOS/nixpkgs/commit/ff38b05b49eafe39e83a9f4ec1d07326ada8b82e) release-notes: Include note on Cawbird API key change
* [`e3fa8645`](https://github.com/NixOS/nixpkgs/commit/e3fa86456d4f0594e1920aa564799fbef96b54af) home-assistant: pin aioesphomeapi at 9.1.5
* [`713a69a1`](https://github.com/NixOS/nixpkgs/commit/713a69a199c62a14dec2e86df1619282065247db) treewide: rename perlPackages.libintl_perl -> perlPackages.libintl-perl
* [`a37334b1`](https://github.com/NixOS/nixpkgs/commit/a37334b1ddb367e728267fe1e24a18d8920d6f36) lima: 0.7.1 -> 0.7.2
* [`872080e3`](https://github.com/NixOS/nixpkgs/commit/872080e31c44d8581d96e6260276203b44456e14) kotlin-native: init at 1.5.31
* [`b30e56bd`](https://github.com/NixOS/nixpkgs/commit/b30e56bddfc27846f8338ea7a0748bb8069e19b5) gssdp: 1.2.3 → 1.4.0.1
* [`d08875a4`](https://github.com/NixOS/nixpkgs/commit/d08875a433b47f8d1360568054f7c751ce88c9b7) soupault: 3.1.0 -> 3.2.0
* [`4a225de2`](https://github.com/NixOS/nixpkgs/commit/4a225de252a81ab6fba0e4462ea3a86111f6b0c2) fclones: 0.16.1 -> 0.17.0
* [`910e1eab`](https://github.com/NixOS/nixpkgs/commit/910e1eab7161b60f8e18e2df984e115c0b28fa33) flameshot: fix desktop Exec path and autostart directory location
* [`df6e8bbd`](https://github.com/NixOS/nixpkgs/commit/df6e8bbd4241385da76d9dc66f15b0da2ca7497f) python3Packages.venstarcolortouch: 0.14 -> 0.15
* [`d49f6144`](https://github.com/NixOS/nixpkgs/commit/d49f61442e52fd2a077c29315d009948f5340683) python3Packages.mypy-boto3-s3: 1.19.1 -> 1.19.2
* [`b3157a9e`](https://github.com/NixOS/nixpkgs/commit/b3157a9ea5c52d79c01d1ae02f839141b17f4689) notmuch: 0.33.2 -> 0.34
* [`ddef047f`](https://github.com/NixOS/nixpkgs/commit/ddef047f0970805b6887eb83e78c3fc569962800) python3Packages.bidict: 0.21.3 -> 0.21.4
* [`b475247b`](https://github.com/NixOS/nixpkgs/commit/b475247b852aa3cb010443546d9ffd7bef3f46c6) ocamlPackages.lambdasoup: 0.7.2 → 0.7.3
* [`350f01dc`](https://github.com/NixOS/nixpkgs/commit/350f01dc8a9d40bea30c938a090e136696df3b85) python3Packages.aioymaps: 1.2.0 -> 1.2.1
* [`b54d520a`](https://github.com/NixOS/nixpkgs/commit/b54d520ae51f198c6dab295f8e618b366de2e463) yuzu-{ea,mainline}: {1874,679} -> {2156,788}
* [`dc0769c6`](https://github.com/NixOS/nixpkgs/commit/dc0769c63c65118eb39720d17604d22c7787887d) nixos/bookstack: fix error message output ([nixos/nixpkgs⁠#142729](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142729))
* [`18de1eba`](https://github.com/NixOS/nixpkgs/commit/18de1eba7f12e99aa63f593457295a551834af33) gnome-desktop-testing: unstable-2019-12-11 → 2021.1
* [`6ef96ead`](https://github.com/NixOS/nixpkgs/commit/6ef96ead9a47a0b5ca67a425c90367b85d439c73) gnome.gnome-applets: 3.40.0 → 3.42.0
* [`3d9cb399`](https://github.com/NixOS/nixpkgs/commit/3d9cb399a65cd0d36a70b9d4187d4a7ad342e8d0) gnome.gnome-clocks: 40.0 → 41.0
* [`e8696979`](https://github.com/NixOS/nixpkgs/commit/e869697963f0df2ca366e43ee6653facb6d153a0) xplr: 0.14.7 -> 0.15.2
* [`ae56abbb`](https://github.com/NixOS/nixpkgs/commit/ae56abbb470bc50cb13e92b5d50664894ad33e9f) gnome.gnome-panel: 3.40.0 → 3.42.0
* [`d2ea3914`](https://github.com/NixOS/nixpkgs/commit/d2ea39144c458b99e7e998b81d9df89b04ba68f3) gnome.metacity: 3.40.0 → 3.42.0
* [`522e29d0`](https://github.com/NixOS/nixpkgs/commit/522e29d09e587985db1ad0da8a3e8abb14a0c8ef) shotwell.updateScript: fix version policy
* [`453edd71`](https://github.com/NixOS/nixpkgs/commit/453edd71bfc0a7f56ad6e8969d80945ad1cc3c23) vte: 0.64.2 → 0.66.0
* [`e4fafc01`](https://github.com/NixOS/nixpkgs/commit/e4fafc019a48703f6f2c8fb023c42071bd8e6264) cryptpad: 4.9.0 -> 4.11.0
* [`43df6327`](https://github.com/NixOS/nixpkgs/commit/43df632797318143ac12fa7e7a5892ee382f2a6a) dendrite: 0.4.1 -> 0.5.0
* [`7cfe1ab7`](https://github.com/NixOS/nixpkgs/commit/7cfe1ab75b0996cf87457b9bb50ae66d4dea4a8b) b2sum: switch to fetchFromGitHub
* [`11031d1c`](https://github.com/NixOS/nixpkgs/commit/11031d1c0c716fe6927af41a048511884d453f81) daemonize: switch to fetchFromGitHub
* [`ac3c391f`](https://github.com/NixOS/nixpkgs/commit/ac3c391fa344472191e0bb7c0ac616975ae27a1a) symlinks: switch to fetchFromGitHub
* [`ed565347`](https://github.com/NixOS/nixpkgs/commit/ed5653470c9391c089a9e376eb1f81f554ba8a3a) cconv: switch to fetchFromGitHub
* [`4b951f0a`](https://github.com/NixOS/nixpkgs/commit/4b951f0a6fbd656a546f69e2ced3a58eeade8868) qshowdiff: switch to fetchFromGitHub
* [`4ff280ef`](https://github.com/NixOS/nixpkgs/commit/4ff280efd727d34de76607740655b55f00cb24a0) odpdown: switch to fetchFromGitHub
* [`1ed5606d`](https://github.com/NixOS/nixpkgs/commit/1ed5606d8a65c45f9f24229202be6c60c019c01f) nixos/test-runner: Fix thread cleanup
* [`43265387`](https://github.com/NixOS/nixpkgs/commit/432653874ca68c7f6579a1d758e92741753c0252) bgs: switch to fetchFromGitHub
* [`54ecf6b4`](https://github.com/NixOS/nixpkgs/commit/54ecf6b486e8829f9cc15fef8da47a540f08166c) wmutils-core: switch to fetchFromGitHub
* [`a58c4b60`](https://github.com/NixOS/nixpkgs/commit/a58c4b60caf41c8990fd034b4994c68dfc7ff15c) xinput_calibrator: switch to fetchFromGitHub
* [`767f2007`](https://github.com/NixOS/nixpkgs/commit/767f2007ffd8babe23c5514aefcfbceca6594e38) gssdp-tools: re-add as separate derivation
* [`529f7dd5`](https://github.com/NixOS/nixpkgs/commit/529f7dd5da3436a032aad17a9f9ae3297bb1ec38) gupnp-av: 0.12.11 → 0.14.0
* [`df76d9f7`](https://github.com/NixOS/nixpkgs/commit/df76d9f7a4f0ecec360bacafe68ff872dc8f9ae2) gupnp: 1.2.4 → 1.4.0
* [`2e6cb043`](https://github.com/NixOS/nixpkgs/commit/2e6cb043da269ac041ab3f49ac960003f7b9dd8b) gupnp-dlna: 0.10.5 → 0.12.0
* [`d7ec4b30`](https://github.com/NixOS/nixpkgs/commit/d7ec4b30f792c6c3acd97c38606a99c04d1827ad) gupnp-tools: 0.10.0 → 0.10.1
* [`90d5815b`](https://github.com/NixOS/nixpkgs/commit/90d5815b1c979683203de47184a4471146d9b105) dleyna-core: 0.6.0 → 0.7.0
* [`1b809034`](https://github.com/NixOS/nixpkgs/commit/1b809034d0f0cf297f220020666ab2659f45e51c) dleyna-connector-dbus: 0.3.0 → 0.4.1
* [`3eeb9e70`](https://github.com/NixOS/nixpkgs/commit/3eeb9e70d06c2153f467e500bb4f9296c38333fc) dleyna-renderer: 0.6.0 → 0.7.1
* [`00ba9c33`](https://github.com/NixOS/nixpkgs/commit/00ba9c33985dd9f426879fc48e68317861c6c898) dleyna-server: 0.6.0 → 0.7.1
* [`a43ed763`](https://github.com/NixOS/nixpkgs/commit/a43ed763a640291960314ec73622a85e5cfcd095) bees: 0.6.5 -> 0.7
* [`17547192`](https://github.com/NixOS/nixpkgs/commit/17547192a49bc12c37f79113f8e0be9a46f1e38f) webkitgtk: 2.34.0 → 2.34.1
* [`ed8e11e6`](https://github.com/NixOS/nixpkgs/commit/ed8e11e6a55f2cfed7fa8f683f974527adf65129) python3Packages.hwi: make compatible with libusb1 2.x
* [`ef9b6b9c`](https://github.com/NixOS/nixpkgs/commit/ef9b6b9cd0c63313651b3f905b8abe26967b5006) ring-daemon: remove
* [`3efb07b9`](https://github.com/NixOS/nixpkgs/commit/3efb07b9cca50661c84e9242d70ed2eb571da43c) quickemu: init at 2.2.6
* [`3b9284cf`](https://github.com/NixOS/nixpkgs/commit/3b9284cf2c4d4ba93aec138f3421ff03dcc04682) maintainers: add fedx-sudo
* [`cd2b95a4`](https://github.com/NixOS/nixpkgs/commit/cd2b95a439283b593179129c8e9868bc56b0be2c) icesl: 2.1.10 -> 2.4.1 ([nixos/nixpkgs⁠#142739](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142739))
* [`d1542854`](https://github.com/NixOS/nixpkgs/commit/d1542854f66cd4c38be0abbf7f80e5d02ca26e0c) vscode: quote variables ([nixos/nixpkgs⁠#142735](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142735))
* [`5274c92d`](https://github.com/NixOS/nixpkgs/commit/5274c92d723e80c90ff5de9c2b4e0c178d3bc62f) urbackup-client: init at 2.4.11 ([nixos/nixpkgs⁠#140504](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/140504))
* [`c7788a8f`](https://github.com/NixOS/nixpkgs/commit/c7788a8fecb1c719e2665a513e54cda847eb1239) barman: 2.12 -> 2.15 ([nixos/nixpkgs⁠#142098](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142098))
* [`763293b0`](https://github.com/NixOS/nixpkgs/commit/763293b0d922366fbaab5250e943bd8690d20ca0) altair-graphql-client: 4.0.2 -> 4.1.0 ([nixos/nixpkgs⁠#142753](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142753))
* [`278c53b8`](https://github.com/NixOS/nixpkgs/commit/278c53b884dddef077dc29b2a6adcbf85de06524) unison-ucm: M2g -> M2j ([nixos/nixpkgs⁠#142751](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142751))
* [`0c2f2c74`](https://github.com/NixOS/nixpkgs/commit/0c2f2c746fdeb0e6168d42cab335231e2d21d0e6) intel-gmmlib: 21.3.1 -> 21.3.2
* [`69b10769`](https://github.com/NixOS/nixpkgs/commit/69b1076982f636c73feabd3deb3bceed8b64a6f0) duckstation: 2021-10-01 -> 2021-10-19 ([nixos/nixpkgs⁠#142741](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142741))
* [`6c7a6bf8`](https://github.com/NixOS/nixpkgs/commit/6c7a6bf895f86eb2ef263a42b0ef99ff6482098c) jami: init 20211005.2.251ac7d
* [`86d572c8`](https://github.com/NixOS/nixpkgs/commit/86d572c86a58b96b70b0f82c49278d6339c7500c) mpd: 0.22.11 -> 0.23.2, activate pipewire
* [`3c3998ee`](https://github.com/NixOS/nixpkgs/commit/3c3998ee91f35705241f1f4df892a62a3bf92af5) pythonPackages.powerlineMemSegment: kebab-case
