### PR TITLE
niv home-manager: update b5d738b5 -> da8a78ee

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b5d738b5a3f8c3738433e0aa6482afb4ac635380",
-        "sha256": "07afvwvr9fkrsv5hvv5jjwpphb3s8qw9c2lgh49kil6rd3jczy5h",
+        "rev": "da8a78eec9f7adb57f9e961d1da64805efacff37",
+        "sha256": "1w321r63ij74b5l3mmgb8v3wv0qamz29ps98wrr8q3fpl51b12wi",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/b5d738b5a3f8c3738433e0aa6482afb4ac635380.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/da8a78eec9f7adb57f9e961d1da64805efacff37.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@b5d738b5...da8a78ee](https://github.com/nix-community/home-manager/compare/b5d738b5a3f8c3738433e0aa6482afb4ac635380...da8a78eec9f7adb57f9e961d1da64805efacff37)

* [`91155a98`](https://github.com/nix-community/home-manager/commit/91155a98ed126553deb8696b25556d782d2a5450) htop: add package option ([nix-community/home-manager⁠#2407](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2407))
* [`3e4fedc1`](https://github.com/nix-community/home-manager/commit/3e4fedc1d9c53a0fad0a4e5b63880ab13d1e249d) direnv: make fish enable flag read-only
* [`cfe82d9f`](https://github.com/nix-community/home-manager/commit/cfe82d9f444a1b77f135070f1c1ee63fa061f2fd) gh: support gh as git credential manager for github.com
* [`8278c14f`](https://github.com/nix-community/home-manager/commit/8278c14f5f8725e1b5936d6f54e63d4626aae98c) nixos: replace types.anything with submodule type ([nix-community/home-manager⁠#2396](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2396))
* [`406eeec0`](https://github.com/nix-community/home-manager/commit/406eeec0b98903561767ce7aca311034d298d53e) hexchat: add module
* [`da8a78ee`](https://github.com/nix-community/home-manager/commit/da8a78eec9f7adb57f9e961d1da64805efacff37) hexchat: Replace literalExample with literalExpression ([nix-community/home-manager⁠#2410](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2410))
