### PR TITLE
niv powerlevel10k: update 6441a01d -> ed0bd294

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "6441a01dd361c2b8aee7f95801fb896fc35f066b",
-        "sha256": "143nw31h0dlsfjsy4pjc2isifb2isdr60gd437m3y2h90mbq4jha",
+        "rev": "ed0bd29416af583b22e6e7b03f9f6d449c4522ca",
+        "sha256": "00vpx89jn6d0m4555adx7cal2rfwkf8agm6q1l0jn7lxhsp7zfnr",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/6441a01dd361c2b8aee7f95801fb896fc35f066b.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/ed0bd29416af583b22e6e7b03f9f6d449c4522ca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@6441a01d...ed0bd294](https://github.com/romkatv/powerlevel10k/compare/6441a01dd361c2b8aee7f95801fb896fc35f066b...ed0bd29416af583b22e6e7b03f9f6d449c4522ca)

* [`1af63854`](https://github.com/romkatv/powerlevel10k/commit/1af638543631f2e7db64829c7412ed007047fa81) Squashed 'gitstatus/' changes from cd98a3c2..eaf43011
