### PR TITLE
niv spacemacs: update 5c88c3b0 -> 4f7246da

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "5c88c3b089c132997bf9f571a0207d93739efef1",
-        "sha256": "0axmrbl0w016p4fc962i4bk318l4sk4fn7v4wli0fz0zj0zns4nz",
+        "rev": "4f7246da07e7eb1e07a26de23a80cd2d89a89a7c",
+        "sha256": "0zqhsizmxgqlmbq8v572lbab90siwfmzy9y0fa74w4d010aw4f70",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/5c88c3b089c132997bf9f571a0207d93739efef1.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/4f7246da07e7eb1e07a26de23a80cd2d89a89a7c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@5c88c3b0...4f7246da](https://github.com/syl20bnr/spacemacs/compare/5c88c3b089c132997bf9f571a0207d93739efef1...4f7246da07e7eb1e07a26de23a80cd2d89a89a7c)

* [`f320524a`](https://github.com/syl20bnr/spacemacs/commit/f320524a552c6bee90704db8932a9f2479147c92) Fetch info+ from GitHub
* [`256a4c03`](https://github.com/syl20bnr/spacemacs/commit/256a4c03845fb9b789be1d8bc57e1de07a726647) Update Bibtex Layer README ([syl20bnr/spacemacs⁠#15115](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15115))
* [`0e1d124a`](https://github.com/syl20bnr/spacemacs/commit/0e1d124a8fe599c98a48a93a7bf6c846064917a7) [CI] Drop old html pub cache.
* [`0701a4a5`](https://github.com/syl20bnr/spacemacs/commit/0701a4a56fd6ec7bd28d35d2e2cf92e597b28a34) [bot] "documentation_updates" Sat Oct 23 14:32:06 UTC 2021
* [`191c7ac9`](https://github.com/syl20bnr/spacemacs/commit/191c7ac95422c72528948e0b058ae6b0d3cde84d) [CI] Use spacemacs-base for html export
* [`6e512b80`](https://github.com/syl20bnr/spacemacs/commit/6e512b80e19b40fa1162efdfa9b493199c4a4fe4) [compleseus] Cleanup fetcher now that vertico-repeat is on elpa
* [`15824133`](https://github.com/syl20bnr/spacemacs/commit/1582413370b6769e0fb156ac1d0ee54740a9cce2) [ci] Disable org-mode hooks while exporting html
* [`337c1108`](https://github.com/syl20bnr/spacemacs/commit/337c1108b9c5935a8e0a7419519a3257b4eff8cc) require org-indent for space-doc
* [`4f7246da`](https://github.com/syl20bnr/spacemacs/commit/4f7246da07e7eb1e07a26de23a80cd2d89a89a7c) use fetcher url for vertico-repeat package
