### PR TITLE
niv home-manager: update da8a78ee -> 21590d40

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da8a78eec9f7adb57f9e961d1da64805efacff37",
-        "sha256": "1w321r63ij74b5l3mmgb8v3wv0qamz29ps98wrr8q3fpl51b12wi",
+        "rev": "21590d40c1575ff77c96bbb0c7b151cfa788e100",
+        "sha256": "1frn5zzn4fr4pmxahlj68a8p254sh9k6kn6qpk9p79zkc5hc0ksh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/da8a78eec9f7adb57f9e961d1da64805efacff37.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/21590d40c1575ff77c96bbb0c7b151cfa788e100.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@da8a78ee...21590d40](https://github.com/nix-community/home-manager/compare/da8a78eec9f7adb57f9e961d1da64805efacff37...21590d40c1575ff77c96bbb0c7b151cfa788e100)

* [`46a69810`](https://github.com/nix-community/home-manager/commit/46a69810cb95d2e7286089830dc535d6719eaa6f) fnott: remove global properties generation
* [`9282dbc1`](https://github.com/nix-community/home-manager/commit/9282dbc1fa69eee22086920d24fec7588bd5c160) fish: remove `promptInit` in favor of `interactiveShellInit` ([nix-community/home-manager⁠#2231](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2231))
* [`158bc593`](https://github.com/nix-community/home-manager/commit/158bc593983ef26daeb9cc73fd659f64b4d1998a) vscode: allow argument for keybind to any json value ([nix-community/home-manager⁠#2418](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2418))
* [`cf4866d2`](https://github.com/nix-community/home-manager/commit/cf4866d2187399117d3aed47a58e6f8ef58e5afd) powerline-go: fix regression introduced by [nix-community/home-manager⁠#2231](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2231) ([nix-community/home-manager⁠#2421](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2421))
* [`bc0acdad`](https://github.com/nix-community/home-manager/commit/bc0acdad8c001843d4e22cfa20a6ce84b462ab19) modules/modules.nix: pkgs.system -> pkgs.stdenv.hostPlatform.system ([nix-community/home-manager⁠#2419](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2419))
* [`bb725558`](https://github.com/nix-community/home-manager/commit/bb72555852c0dc397ca65ba21c6317cada7e3058) files: quote cmp file arguments
* [`7e30aec2`](https://github.com/nix-community/home-manager/commit/7e30aec28236cbfeddd932c94b801adcc718e6c6) hexchat: simplify theme example
* [`0f724418`](https://github.com/nix-community/home-manager/commit/0f7244182114ce4f131ffc9ed2f23aebf290cf15) bspwm: stub test dependency
* [`78afc2fa`](https://github.com/nix-community/home-manager/commit/78afc2fa741a93df3c73cedd26f09ee77465dc71) git: stub test dependency on msmtp
* [`e28a720c`](https://github.com/nix-community/home-manager/commit/e28a720ce942bbb87240885e20408a3f32218556) irssi: fix test directory name
* [`134c5ccd`](https://github.com/nix-community/home-manager/commit/134c5ccdd356607da86f8b422fddf5e585793d93) mbsync: stub test dependency
* [`71902bc9`](https://github.com/nix-community/home-manager/commit/71902bc913ccc36baa9ac18dd9b84117a34a36b0) home-manager: fix command line option for nix build
* [`3ccddfc4`](https://github.com/nix-community/home-manager/commit/3ccddfc48dde625044f243049a4830a7104d9095) lib: remove top-level `with lib`
* [`abe12a4b`](https://github.com/nix-community/home-manager/commit/abe12a4bad8efd3b270b1026dbd581adf165dae3) Makefile: add test-install target
* [`e3775568`](https://github.com/nix-community/home-manager/commit/e3775568184899969115114e72031d226c188934) home-manager: remove top-level `with pkgs.lib`
* [`34327e06`](https://github.com/nix-community/home-manager/commit/34327e067f95dc86d4caa570ca2282168e8375c4) tmux: format using nixfmt
* [`275f955d`](https://github.com/nix-community/home-manager/commit/275f955db979e069fbe7a1fd7cfcb5ec030a2096) irssi: format using nixfmt
* [`7523252f`](https://github.com/nix-community/home-manager/commit/7523252f97bff5d39de47fb2b112f2039d1218a3) htop: fix order or header_columns setting ([nix-community/home-manager⁠#2435](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2435))
* [`2e1a5b53`](https://github.com/nix-community/home-manager/commit/2e1a5b53ec2bec28d92db5acb416ad60e6760926) xsession: don't reset the inherited keyboard options
* [`21590d40`](https://github.com/nix-community/home-manager/commit/21590d40c1575ff77c96bbb0c7b151cfa788e100) home-environment: document escaping of home.sessionPath
