### PR TITLE
niv powerlevel10k: update ed0bd294 -> d281e595

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "ed0bd29416af583b22e6e7b03f9f6d449c4522ca",
-        "sha256": "00vpx89jn6d0m4555adx7cal2rfwkf8agm6q1l0jn7lxhsp7zfnr",
+        "rev": "d281e595b3ddf2f5ccefb0cd7bfa475222566186",
+        "sha256": "1875mjaanyzsifmrs580wxcn1x94mjl1d4jddmkv62im71wa1086",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/ed0bd29416af583b22e6e7b03f9f6d449c4522ca.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/d281e595b3ddf2f5ccefb0cd7bfa475222566186.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@ed0bd294...d281e595](https://github.com/romkatv/powerlevel10k/compare/ed0bd29416af583b22e6e7b03f9f6d449c4522ca...d281e595b3ddf2f5ccefb0cd7bfa475222566186)

* [`b4615f5e`](https://github.com/romkatv/powerlevel10k/commit/b4615f5e008c496791c1ea37981ee18f15d464ed) add _p9k__raw_msg for direnv notifications in zsh4humans
* [`faddef4a`](https://github.com/romkatv/powerlevel10k/commit/faddef4a226f8b07eebe059389a1ddd756eba4a9) add faq entries about enabling direnv and exporting GPG_TTY ([romkatv/powerlevel10k⁠#702](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/702))
* [`99edd12e`](https://github.com/romkatv/powerlevel10k/commit/99edd12e00b8c1a38635a28eb33d6454c1ba09b2) grammar
* [`85e31542`](https://github.com/romkatv/powerlevel10k/commit/85e31542dd8cf902afd564846adfef7c8187350d) wizard: underline paths instead of bolding in the success message
* [`dce00cdb`](https://github.com/romkatv/powerlevel10k/commit/dce00cdb5daaa8a519df234a7012ba3257b644d4) docs: typo
* [`a55955c5`](https://github.com/romkatv/powerlevel10k/commit/a55955c5cfb360c6088fd0141c6157533f3e1481) enable bracketed paste when printing instant prompt
* [`e2447322`](https://github.com/romkatv/powerlevel10k/commit/e2447322e0be4eddb84196f05952f91fa3c6f37e) Squashed 'gitstatus/' changes from eaf430112..e26996460
