### PR TITLE
niv nixpkgs: update da7b746c -> 1a7c8399

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da7b746c54c38b6d8c2f7bc1628231c2581a9b53",
-        "sha256": "05bvq3893lvnd84wgswnfmgq81v7fwrjl2bcwvxrz42qd1s8hxqd",
+        "rev": "1a7c8399acbbd95b05bfdc6045160c60aa5dcd3e",
+        "sha256": "1addh2j3pipbcwabhglci3ypmfxm7lp1ismzd8g5b5h1780yfdab",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/da7b746c54c38b6d8c2f7bc1628231c2581a9b53.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/1a7c8399acbbd95b05bfdc6045160c60aa5dcd3e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@da7b746c...1a7c8399](https://github.com/nixos/nixpkgs/compare/da7b746c54c38b6d8c2f7bc1628231c2581a9b53...1a7c8399acbbd95b05bfdc6045160c60aa5dcd3e)

* [`e978251c`](https://github.com/NixOS/nixpkgs/commit/e978251cfb8dd231851349c1a154fd054fb8bed7) cpyparsing: 2.4.5.0.1.2 → 2.4.7.1.0.0
* [`54ee0fad`](https://github.com/NixOS/nixpkgs/commit/54ee0fad2eff900f417de96686a7ad760c82175d) coconut: 1.5.0 → 1.6.0
* [`57225d51`](https://github.com/NixOS/nixpkgs/commit/57225d51a6afecc991e761d7614ddfc93f39c035) statix: 0.3.6 -> 0.4.0
* [`1dfe0be7`](https://github.com/NixOS/nixpkgs/commit/1dfe0be750cb81f38381e994885296cf0bfb5be0) pipr: 0.0.15 -> 0.0.16; fixes build
* [`90bac670`](https://github.com/NixOS/nixpkgs/commit/90bac670c0ef7b474841c2f929a2e0d63059e8a0) nixos/pam: pam_mkhomedir umask to 0077
* [`943f15d4`](https://github.com/NixOS/nixpkgs/commit/943f15d4b76e13c19ac08a298bc12f7b6f14b931) nixos/mastodon: add new sandboxing options
* [`700ea62f`](https://github.com/NixOS/nixpkgs/commit/700ea62f549e00fbe531c387e68b99b08378f172) nixos/mastodon: remove duplicates SystemCallFilters
* [`91e510ae`](https://github.com/NixOS/nixpkgs/commit/91e510ae220e3287ccfc868ef63b8e952f76d3ae) nixos/mastodon: add '@⁠ipc' SystemCallFilter
* [`a71576b0`](https://github.com/NixOS/nixpkgs/commit/a71576b07b59a86a27555ab8a3dff901b10d8b6c) nixos/mastodon/streaming: add '@⁠memlock' SystemCallFilter
* [`7deb5247`](https://github.com/NixOS/nixpkgs/commit/7deb5247a5da4f468a0abe464275f6c913c5f33f) nixos/ddclient: fix privs when loading password
* [`cdd38551`](https://github.com/NixOS/nixpkgs/commit/cdd385510a69ada4a0c6b3e2348ad6aa4b88344e) nixos/ddclient: customizable package option
* [`392a7a3d`](https://github.com/NixOS/nixpkgs/commit/392a7a3d7ebc07fc2950459bbf72a2837caa1157) python39Packages.ansible-runner: 2.0.2 -> 2.0.3
* [`26e1daaa`](https://github.com/NixOS/nixpkgs/commit/26e1daaa43876c082d64f4ab9941602b99b5c14f) treewide: eliminate stdenv.lib usage
* [`f3ee1060`](https://github.com/NixOS/nixpkgs/commit/f3ee1060747b49902533568bf1ba2ecd4127fc76) kubebuilder: 3.1.0 -> 3.2.0
* [`87d250e6`](https://github.com/NixOS/nixpkgs/commit/87d250e6554161db681fef23ff92cbe5879b0092) cpuid: 20201006 -> 20211031
* [`41dbc0a9`](https://github.com/NixOS/nixpkgs/commit/41dbc0a9954d852ef1d33ec5c79d64fe3cc84b8c) chromiumBeta: 96.0.4664.27 -> 96.0.4664.35
* [`00460bd6`](https://github.com/NixOS/nixpkgs/commit/00460bd6e2c89f3b76dcb42032194e6eed0616d2) chromiumDev: 97.0.4682.3 -> 97.0.4688.2
* [`abe8a309`](https://github.com/NixOS/nixpkgs/commit/abe8a309121a7839f5126d405e5edbf18294e685) libopenshot: 0.2.5 -> 0.2.7
* [`cdddc286`](https://github.com/NixOS/nixpkgs/commit/cdddc286a269502fef895c4f455b27e33765a738) libopenshot-audio: 0.2.0 -> 0.2.2
* [`4d5d3449`](https://github.com/NixOS/nixpkgs/commit/4d5d34495fd08345f2064c875224b48a684f89e9) openshot: refactor
* [`32cfea71`](https://github.com/NixOS/nixpkgs/commit/32cfea717df430248c7230c40572dfa9bfd69b0d) python3Packages.flower: disable failing tests
* [`ff69cda0`](https://github.com/NixOS/nixpkgs/commit/ff69cda0bc2ad2fbe79e0e863439ed7e283b09b5) python3Packages.systembridge: 2.2.0 -> 2.2.1
* [`65b2b7e0`](https://github.com/NixOS/nixpkgs/commit/65b2b7e02a4edd91c0eebef52d70200765d44e11) python3Packages.pygls: 0.11.2 → 0.11.3
* [`ed83ff9b`](https://github.com/NixOS/nixpkgs/commit/ed83ff9bccf795ba9ce5e885b950ee86d39c68af) signal-desktop: 5.22.0 -> 5.23.0
* [`46180e40`](https://github.com/NixOS/nixpkgs/commit/46180e407e520aa1959ad50128e7be2657c610b9) nixos/xmrig: init
* [`caeefb8b`](https://github.com/NixOS/nixpkgs/commit/caeefb8bd128c7928fdbd2b66b905776b47112f5) ansifilter: fix non-determinism in gzipped manpages with s/gzip/gzip -n/
* [`0390fcfd`](https://github.com/NixOS/nixpkgs/commit/0390fcfd059dd76e2fe2939892888e121c21e65a) jconvolver: init at 1.1.0 ([nixos/nixpkgs⁠#143520](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/143520))
* [`f7a4abe5`](https://github.com/NixOS/nixpkgs/commit/f7a4abe5c0594cfa60e6dc6bfef446fdbf2c7b17) tagutil: fix build
* [`2fa9bf4b`](https://github.com/NixOS/nixpkgs/commit/2fa9bf4b8b13adcadb9c06529ff46ccff7c255a9) yandex-browser: set meta.broken
* [`541fe07b`](https://github.com/NixOS/nixpkgs/commit/541fe07bb117d8fc9e8c8c8eb6e480c48d1af9bb) python3Packages.pip-tools: use pytestCheckHook, disable failing test, cleanup
* [`7aa9186a`](https://github.com/NixOS/nixpkgs/commit/7aa9186ae4cd67983db5d0cc14bd79748d8f216b) linuxPackages.rr-zen_workaround: mark x86_64-only
* [`17f391e0`](https://github.com/NixOS/nixpkgs/commit/17f391e05a97c611d2892602a6054917eda89283) linuxPackages.kvmfr: set minimum kernel version
* [`b21b1b7c`](https://github.com/NixOS/nixpkgs/commit/b21b1b7c6471fe610e5815e11b4e9d3d0822b778) linuxPackages.ddcci: mark broken on Linux 5.15
* [`768c8ca1`](https://github.com/NixOS/nixpkgs/commit/768c8ca1625a423d926285a83a3ab7a9f1903dc9) linuxPackages.ena: mark broken on Linux 5.15
* [`a32d9211`](https://github.com/NixOS/nixpkgs/commit/a32d921183c0088c979438dd29b132e9c6245ac5) linuxPackages.evdi: mark broken on Linux 5.15
* [`bb2b3da3`](https://github.com/NixOS/nixpkgs/commit/bb2b3da36d2a39446417fc05aaadbde5fc68fa3e) linuxPackages.openafs: mark broken on Linux 5.15
* [`4e7392e7`](https://github.com/NixOS/nixpkgs/commit/4e7392e76ba23d1bc7ac4f1fac9fe058ff4dfc10) linuxPackages.openafs_1_9: mark broken on Linux 5.15
* [`163e90cd`](https://github.com/NixOS/nixpkgs/commit/163e90cdd75446cbef621598b999fff3e5aa2d88) linuxPackages.rtl8188eus-aircrack: mark broken on Linux 5.15
* [`3683cca6`](https://github.com/NixOS/nixpkgs/commit/3683cca605e147a6ea5b9b654c7a9f0dc4a8fc06) linuxPackages.rtl8812au: mark broken on Linux 5.15
* [`6ce4879b`](https://github.com/NixOS/nixpkgs/commit/6ce4879bfb702d159e7d886acc1b5bdeb68cf3fd) linuxPackages.rtl88xxau-aircrack: mark broken on Linux 5.15
* [`c3cf40e5`](https://github.com/NixOS/nixpkgs/commit/c3cf40e50e78eb570826860d8bf4c17bf948d625) linuxPackages.xmm7360-pci: set minimum kernel version
* [`e9d384fd`](https://github.com/NixOS/nixpkgs/commit/e9d384fd6283260a3abac2a4287c37ea70c8f978) osu-lazer: 2021.1028.0 -> 2021.1105.0
* [`50417ddb`](https://github.com/NixOS/nixpkgs/commit/50417ddb87f8dbe992f08fdd9ad9be26ebad0098) opendungeons: 0.7.1 -> unstable-2021-11-06
* [`787b6127`](https://github.com/NixOS/nixpkgs/commit/787b6127d24e6006feaedc216181a235af993af4) pythonPackages.watermark: init at 2.2.0
* [`ef0ac43d`](https://github.com/NixOS/nixpkgs/commit/ef0ac43dee7ac5443d8f587f09fdc80f393e5596) pythonPackages.watermark: init at 2.2.0
* [`999d3972`](https://github.com/NixOS/nixpkgs/commit/999d3972591f87515379ff511aead07cd8f7f751) linuxPackages.rtl8814au: 2021-05-18 -> 2021-10-25
* [`8cc3c4ff`](https://github.com/NixOS/nixpkgs/commit/8cc3c4ff6e623fab80291e35791c9ce6b2232fef) linuxPackages.rtl8821au: 2021-05-18 -> 2021-11-05
* [`44729a30`](https://github.com/NixOS/nixpkgs/commit/44729a305e55ddbf66c6bbdc670cc8b1cd01b513) linuxPackages.rtl8821cu: 2021-05-19 -> 2021-10-21
* [`525c565b`](https://github.com/NixOS/nixpkgs/commit/525c565baeec06bbd200fd7cb555f7c6f15a13b4) linuxPackages.rtl8192eu: 4.4.1.20210403 -> 4.4.1.20211023
* [`4b5e873e`](https://github.com/NixOS/nixpkgs/commit/4b5e873e6ea165c751c8103f1f03040360c60f3b) linuxPackages.rtl88x2bu: 2021-05-18 -> 2021-11-04
* [`69d066da`](https://github.com/NixOS/nixpkgs/commit/69d066da7063b8b8b8526daa412f313e94da79e9) linux: 4.19.215 -> 4.19.216
* [`154f16fc`](https://github.com/NixOS/nixpkgs/commit/154f16fc533e1cdd732b83ba6f546d3bda47ecfe) linux: 5.10.77 -> 5.10.78
* [`ded9d6fd`](https://github.com/NixOS/nixpkgs/commit/ded9d6fd05ad4d6f6d890054b5335abe4f976f64) linux: 5.14.16 -> 5.14.17
* [`235c88c0`](https://github.com/NixOS/nixpkgs/commit/235c88c09416bc32e97c77766701f25dece0e737) linux: 5.15 -> 5.15.1
* [`0be2bcf9`](https://github.com/NixOS/nixpkgs/commit/0be2bcf9288ce0648e03e0dd3ac196cd381b28b8) linux: 5.4.157 -> 5.4.158
* [`bf3aff8e`](https://github.com/NixOS/nixpkgs/commit/bf3aff8eb0b9db1ff43139dc7e08cbc1d539eea6) newsflash: 1.4.3 -> 1.5.1
* [`c756d168`](https://github.com/NixOS/nixpkgs/commit/c756d168dc6883244358ccf7b09404c29d69ed8c) pgcli: disable failing tests
* [`a5293373`](https://github.com/NixOS/nixpkgs/commit/a529337334ec8b4a5331c9ae8e481582f8c74423) dropbox: Fix missing icon from the desktop item
* [`c0814cef`](https://github.com/NixOS/nixpkgs/commit/c0814cef0bcdc20c082ff90f031f46611c0abd99) python3.pkgs.dropbox: use source from git, since it contains documentation
* [`d64f7a76`](https://github.com/NixOS/nixpkgs/commit/d64f7a76fb53a98f9f699f9d1c6b36053c486b6f) nixos/tests.plasma5: Fix after [nixos/nixpkgs⁠#142747](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142747)
* [`27717439`](https://github.com/NixOS/nixpkgs/commit/277174396634aff9e48fb254f38fba86a77f4206) cemu: add link-time-compile-gen, build with gcc9stdenv
* [`065281ad`](https://github.com/NixOS/nixpkgs/commit/065281add0016f2c1e6fa340ae78823fba9124c7) cemu: mark as broken on darwin
* [`ef89ee9b`](https://github.com/NixOS/nixpkgs/commit/ef89ee9b71aaa8597198e5dd4b90b46051569459) fheroes2: 0.9.8 -> 0.9.9
* [`6b83b457`](https://github.com/NixOS/nixpkgs/commit/6b83b457d25cf670f83df84b2e3c9244a61eda68) entangle: Add missing zstd dependency
* [`9af25ef3`](https://github.com/NixOS/nixpkgs/commit/9af25ef30bb15cca4996943af31909007432f9e7) smemstat: pull pending upstream inclusion fix for ncurses-6.3
* [`6f9c9425`](https://github.com/NixOS/nixpkgs/commit/6f9c942585613f3dd4e7662ae906d20911d9b49a) couchdb3: 3.2.0 -> 3.2.1
* [`8f6392ce`](https://github.com/NixOS/nixpkgs/commit/8f6392cec9ab0392a2c959796e6c18b8823cbc33) dhall-grafana: Fix Prelude dependency. ([nixos/nixpkgs⁠#144915](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/144915))
* [`ff0d921b`](https://github.com/NixOS/nixpkgs/commit/ff0d921b21da7e7e210874bbb18a007428d2571d) kde-gear: 21.08.2 -> 21.08.3
* [`7be1b371`](https://github.com/NixOS/nixpkgs/commit/7be1b371026529af5fe16f5ea5ab3c50eb2f0b06) python3Packages.aioshelly: 1.0.3 -> 1.0.4
* [`f1b83980`](https://github.com/NixOS/nixpkgs/commit/f1b83980d37567eeed64dcb5a7a1fd2d4a84e1ba) python3Packages.fastecdsa: migrate to disabledTestPaths
* [`ca38dd2a`](https://github.com/NixOS/nixpkgs/commit/ca38dd2a47b11a44f9961c90b17e9faaec1a6a98) python3Packages.solo-python: 0.0.30 -> 0.0.31
* [`84b960ca`](https://github.com/NixOS/nixpkgs/commit/84b960ca01dfbf6e40148698f8cdc999d6615804) metal-cli: Fix build
* [`ef8eb42d`](https://github.com/NixOS/nixpkgs/commit/ef8eb42db58c2bc0d270054ed16567b51ab92c20) msmtp: 1.8.18 -> 1.8.19
* [`68ca39a7`](https://github.com/NixOS/nixpkgs/commit/68ca39a775a637f289c63248b64443ef7342f6ad) winetricks: remove wine dependency
* [`182a36bc`](https://github.com/NixOS/nixpkgs/commit/182a36bc33e399a7f3e607cfe6e3d4d990ed1651) spidermonkey: drop unused patches
* [`5f12f89a`](https://github.com/NixOS/nixpkgs/commit/5f12f89a6ff32543ad7661c788f93cd9ffbd2010) spidermonkey_68: 68.10.0 -> 68.12.0
* [`59b832d5`](https://github.com/NixOS/nixpkgs/commit/59b832d51a016675256f5d828f563d8be9b2ce3f) spidermonkey_91: init at 91.3.0
* [`c207be65`](https://github.com/NixOS/nixpkgs/commit/c207be6591e45e844f193f147c1f3447af054eba) handbrake: 1.3.3 -> 1.4.2 ([nixos/nixpkgs⁠#143654](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/143654))
* [`ba3bf3b9`](https://github.com/NixOS/nixpkgs/commit/ba3bf3b9f69eb3a3e0281bb40b45532b74822f1e) racket: 8.2 -> 8.3
* [`81e952e8`](https://github.com/NixOS/nixpkgs/commit/81e952e8a49d936f0612e98e0234eaf4dd192f02) cspell: init at 5.12.6 ([nixos/nixpkgs⁠#144954](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/144954))
* [`06a3d5fe`](https://github.com/NixOS/nixpkgs/commit/06a3d5fe54aaa98752105717aecf6af3cc7aa64e) wiki-tui: 0.4.1 -> 0.4.2
* [`4dcf909d`](https://github.com/NixOS/nixpkgs/commit/4dcf909d0437df6dc606a9117a8c00f30c70270b) pngout: 20150319 -> 20200115
* [`2ef3df9e`](https://github.com/NixOS/nixpkgs/commit/2ef3df9e93621b672c274cd739f6e6c251616fc4) notmuch: 0.34 -> 0.34.1
* [`f55376e8`](https://github.com/NixOS/nixpkgs/commit/f55376e8753e36ce1bb629273743fdfa349c0972) tiny: 0.9.0 -> 0.10.0
* [`960eb082`](https://github.com/NixOS/nixpkgs/commit/960eb082f1013536268bbb3bf7ff0969dc6c631b) pcsxr: build with newer ffmpeg
* [`1777da08`](https://github.com/NixOS/nixpkgs/commit/1777da08a3edef2f6afd9f248dab77a71ed0dd6c) gnash: build with newer ffmpeg
* [`1d177d5a`](https://github.com/NixOS/nixpkgs/commit/1d177d5a70ad0f52a70f68196e69369bf73c8256) stepmania: build with newer ffmpeg
* [`4c6d0451`](https://github.com/NixOS/nixpkgs/commit/4c6d0451b2dd909f1f3f6eab8403cc34b1870670) ffmpeg_2{,_8}: remove
* [`7e0f6ddd`](https://github.com/NixOS/nixpkgs/commit/7e0f6ddda2a4e52effc40306aacb3a7672fa45c4) python3Packages.hbmqtt: drop
* [`40c83d1e`](https://github.com/NixOS/nixpkgs/commit/40c83d1e0a0708a16c0c917d231082f6352b38fe) virtualbox: Add option to build vboxwebsrv tool
* [`db34ebb5`](https://github.com/NixOS/nixpkgs/commit/db34ebb557cd299b0389ef999bc670f05727e820) loki: 2.3.0 -> 2.4.0
* [`f3e1b319`](https://github.com/NixOS/nixpkgs/commit/f3e1b3194b09e604abba94c811e90321020263d9) python3Packages.slackclient: disable broken tests on darwin
* [`024f518e`](https://github.com/NixOS/nixpkgs/commit/024f518e65ffbe64f0f044b194ad15ec2e973788) yarn: 1.22.15 -> 1.22.17 ([nixos/nixpkgs⁠#144974](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/144974))
* [`6661cb08`](https://github.com/NixOS/nixpkgs/commit/6661cb0887876cc2d3a96adf832ce20a114fbc96) kakoune: 2021.10.28 -> 2021.11.08
* [`d1a8806e`](https://github.com/NixOS/nixpkgs/commit/d1a8806e3910ed32d1d702c21b9375297292305e) nixos/mastodon: allow '@⁠resources' filter to mastodon-web service
* [`db20747d`](https://github.com/NixOS/nixpkgs/commit/db20747d364aad0f3e474873152155295ec3aa4a) rpsamd: 3.0 -> 3.1
* [`dc5e6713`](https://github.com/NixOS/nixpkgs/commit/dc5e6713e4f63fdf69174e99725498ca8fc247d1) rspamd: add lewo as maintainer
* [`056d880f`](https://github.com/NixOS/nixpkgs/commit/056d880f90dc1e1a89ea5f349b6408337397650d) helmfile: Stop prefixing PATH with kubernetes-helm
* [`beed35c4`](https://github.com/NixOS/nixpkgs/commit/beed35c41747f033f64cc1d7def4220837140271) StormLib: init at 9.22
* [`573849ce`](https://github.com/NixOS/nixpkgs/commit/573849ce89f5fc5b18a8979d4496f09ac031880c) smpq: init at 1.6
* [`565d6329`](https://github.com/NixOS/nixpkgs/commit/565d63295200f44948f384e0523336c511b60fb6) devilutionx: 1.2.1 -> 1.3.0
* [`102fe107`](https://github.com/NixOS/nixpkgs/commit/102fe107456266547063657deb02c11550454cf2) devilutionx: include patch to compile with system SDL2_image
* [`afdd9ddb`](https://github.com/NixOS/nixpkgs/commit/afdd9ddbfa130f93d5861c2ca4635f735cf0c9db) fscryptctl-experimental: remove the package
* [`5c72b636`](https://github.com/NixOS/nixpkgs/commit/5c72b63690eaed2f5aa10f8cad3df0b43cd267a4) fscryptctl: Fix meta.changelog
* [`b52ab3b7`](https://github.com/NixOS/nixpkgs/commit/b52ab3b712cc44b5eb88557ad2ca206dcd10af20) pkgs/applications: rename name to pname&version part 2
* [`7d64d4b1`](https://github.com/NixOS/nixpkgs/commit/7d64d4b197ec74e66532cce8dbf6a440e9a22ebc) factorio{,demo,headless}: 1.1.42 -> 1.1.46
* [`a2149a2e`](https://github.com/NixOS/nixpkgs/commit/a2149a2ee2134efcbc398e6129f65903dd466f9b) lima: 0.7.2 -> 0.7.3
* [`8d197bff`](https://github.com/NixOS/nixpkgs/commit/8d197bffd80e21f34c3f52379d93a565444ea189) nixos/proxmox-image: init ([nixos/nixpkgs⁠#144013](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/144013))
* [`416369dc`](https://github.com/NixOS/nixpkgs/commit/416369dc847fafaffb57758c00eb5ac9cb009705) samba: fix ceph library path
* [`8fc318ae`](https://github.com/NixOS/nixpkgs/commit/8fc318aebeee655dbf7edf81120d66f79272cf90) exploitdb: 2021-11-05 -> 2021-11-06
* [`eca55443`](https://github.com/NixOS/nixpkgs/commit/eca554435e6acdc412825f2fb0683ccd423ea6bb) cloog: enable parallel building, explicitly disable parallel testing
* [`cfb91f81`](https://github.com/NixOS/nixpkgs/commit/cfb91f812b79cdf923f63e2cbb6dd5f09c03122c) python3Packages.commoncode: disable test_searchable_paths on darwin
* [`ea5437f8`](https://github.com/NixOS/nixpkgs/commit/ea5437f80c60bb7a8c5ca258dd443aa96c5e763f) arrow-cpp: add GCS feature flag ([nixos/nixpkgs⁠#144610](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/144610))
* [`6d6fe244`](https://github.com/NixOS/nixpkgs/commit/6d6fe2447e8766c3e6efbdedf32a54446809b888) zydis: fix upgrade
* [`b0088eb8`](https://github.com/NixOS/nixpkgs/commit/b0088eb87347b6f1799d25355a657c586c3eb24b) python3Packages.pyemby: 1.7 -> 1.8
* [`de696e21`](https://github.com/NixOS/nixpkgs/commit/de696e213f12a995e4ed6fe11291a6793db73781) vimPlugins: update
* [`155c4ad5`](https://github.com/NixOS/nixpkgs/commit/155c4ad5ab5c5ef7f1da4fe012fae21bb97a25a8) vimPlugins.stabilize-nvim: init at 2021-11-07
* [`b142bd35`](https://github.com/NixOS/nixpkgs/commit/b142bd35d508ce0cfb0abc9814ebb1cc07704d4f) nixos/neovim: fix withRuby, add with{Python3,NodeJs}
* [`18ed048c`](https://github.com/NixOS/nixpkgs/commit/18ed048c7b27e288a6c9ba894790a7e67ed5080d) build-support/rust: Organize
* [`8f499b97`](https://github.com/NixOS/nixpkgs/commit/8f499b97ad9c9d7fad6423fa4d334db11a860494) firefox: 94.0 -> 94.0.1
* [`f06cec95`](https://github.com/NixOS/nixpkgs/commit/f06cec9564a2fc6b85d92398551a0c059fc4db86) spdlog: 1.8.5 -> 1.9.2
* [`b4fab0a9`](https://github.com/NixOS/nixpkgs/commit/b4fab0a98b28ee09102aeac511a967be6253572e) treewide: remove fmt from buildInputs where spdlog is used
* [`fbdf7823`](https://github.com/NixOS/nixpkgs/commit/fbdf78236a346f57f716fb66ed62e1993260c9e5) pkgs/applications: rename name to pname&version part 1 ([nixos/nixpkgs⁠#144949](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/144949))
* [`c39ad5be`](https://github.com/NixOS/nixpkgs/commit/c39ad5be5eb81c4cc0edf7fbb756d4f2d5a7f095) numberstation: 0.5.0 -> 1.0.0
* [`ea33beda`](https://github.com/NixOS/nixpkgs/commit/ea33beda928094fc7d5709fdcb110a99773914a0) kopia: 0.9.4 -> 0.9.5
* [`e24463bc`](https://github.com/NixOS/nixpkgs/commit/e24463bcc92ccd58584fbfda8c2dd661b7858450) nvidia-x11: Add update comment
* [`772069c2`](https://github.com/NixOS/nixpkgs/commit/772069c287600817e9ec64ab5e459b57a847b2f6) handbrake: mark broken on darwin < 10.13
