### PR TITLE
niv home-manager: update 21590d40 -> 2917ef23

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21590d40c1575ff77c96bbb0c7b151cfa788e100",
-        "sha256": "1frn5zzn4fr4pmxahlj68a8p254sh9k6kn6qpk9p79zkc5hc0ksh",
+        "rev": "2917ef23b398a22ee33fb34b5766b28728228ab1",
+        "sha256": "09whf7ai8ppcj931r82wyahgfhrk32r54arbi3lpwz4w38d2x5mm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/21590d40c1575ff77c96bbb0c7b151cfa788e100.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/2917ef23b398a22ee33fb34b5766b28728228ab1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@21590d40...2917ef23](https://github.com/nix-community/home-manager/compare/21590d40c1575ff77c96bbb0c7b151cfa788e100...2917ef23b398a22ee33fb34b5766b28728228ab1)

* [`288faaa5`](https://github.com/nix-community/home-manager/commit/288faaa5a65e72e37e6027024829b15c8bb69286) programs.zsh.zplug: add zplugHome option
* [`70c5b268`](https://github.com/nix-community/home-manager/commit/70c5b268e10025c70823767f4fb49e240b40151d) xdg: add option 'xdg.stateHome' ([nix-community/home-manager⁠#2439](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2439))
* [`f6f013f7`](https://github.com/nix-community/home-manager/commit/f6f013f7642437b0b613aec17f331fe5700fcb35) home: shell agnostic aliases ([nix-community/home-manager⁠#2347](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2347))
* [`7f416c9e`](https://github.com/nix-community/home-manager/commit/7f416c9e2f3b72b514ff8f39f7ef789de442fb80) home: use literalExpression
* [`c678162e`](https://github.com/nix-community/home-manager/commit/c678162e208bf3342471accf8024d67fe563ea79) ci: error out if code contains `literalExample`
* [`2917ef23`](https://github.com/nix-community/home-manager/commit/2917ef23b398a22ee33fb34b5766b28728228ab1) kakoune: clean up tests
