### PR TITLE
niv niv: update 65a61b14 -> 5830a4dd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e",
-        "sha256": "17mirpsx5wyw262fpsd6n6m47jcgw8k2bwcp1iwdnrlzy4dhcgqh",
+        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
+        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@65a61b14...5830a4dd](https://github.com/nmattia/niv/compare/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e...5830a4dd348d77e39a0f3c4c762ff2663b602d4c)

* [`19545d39`](https://github.com/nmattia/niv/commit/19545d3926c658ad91d819e630f2e93188f22f8e) Bump nixpkgs
* [`0ff60d5b`](https://github.com/nmattia/niv/commit/0ff60d5b094a27d3c384a493b14533dec1ae5d3c) Ad extra-experimental-features
* [`a751be07`](https://github.com/nmattia/niv/commit/a751be07758fe1e4a596ce248e62836f00fb6526) Workaround nix-shell silliness
* [`5830a4dd`](https://github.com/nmattia/niv/commit/5830a4dd348d77e39a0f3c4c762ff2663b602d4c) Fix nix.conf
