### PR TITLE
niv powerlevel10k: update d281e595 -> 6520323f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "d281e595b3ddf2f5ccefb0cd7bfa475222566186",
-        "sha256": "1875mjaanyzsifmrs580wxcn1x94mjl1d4jddmkv62im71wa1086",
+        "rev": "6520323fdbc02190528ff3ded57361088d53cdfb",
+        "sha256": "18m760l5y8qm9w2lpqsxvihkyryamrjd51xi4p6hlv9g7mzh3794",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/d281e595b3ddf2f5ccefb0cd7bfa475222566186.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/6520323fdbc02190528ff3ded57361088d53cdfb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@d281e595...6520323f](https://github.com/romkatv/powerlevel10k/compare/d281e595b3ddf2f5ccefb0cd7bfa475222566186...6520323fdbc02190528ff3ded57361088d53cdfb)

* [`6520323f`](https://github.com/romkatv/powerlevel10k/commit/6520323fdbc02190528ff3ded57361088d53cdfb) Delete duplicate word "using using"
