### PR TITLE
niv spacemacs: update 4f7246da -> a80b58c6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "4f7246da07e7eb1e07a26de23a80cd2d89a89a7c",
-        "sha256": "0zqhsizmxgqlmbq8v572lbab90siwfmzy9y0fa74w4d010aw4f70",
+        "rev": "a80b58c635bd381b856dac6307b7e8246527f994",
+        "sha256": "12ca803ynf495m3ng14pwc87bgwbkpsppb2igya0ymynapnx41gk",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/4f7246da07e7eb1e07a26de23a80cd2d89a89a7c.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/a80b58c635bd381b856dac6307b7e8246527f994.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@4f7246da...a80b58c6](https://github.com/syl20bnr/spacemacs/compare/4f7246da07e7eb1e07a26de23a80cd2d89a89a7c...a80b58c635bd381b856dac6307b7e8246527f994)

* [`ae056660`](https://github.com/syl20bnr/spacemacs/commit/ae056660b282b7cecf8760920e45606bd118af44) Remove gist.el since it's unmaintained.
* [`c93b6726`](https://github.com/syl20bnr/spacemacs/commit/c93b6726bcc3a65536fbacc3d738955db9e07a86) LaTeX: Fix broken key binding
* [`6cc5f4ec`](https://github.com/syl20bnr/spacemacs/commit/6cc5f4ec078a9de9e5c6c9de2ec2e92bf87c3db4) [bot] "documentation_updates" Tue Nov  2 20:29:57 UTC 2021
* [`e715fffb`](https://github.com/syl20bnr/spacemacs/commit/e715fffb3cd111bb078162583d368f09f2351b63) [doc] fix incorrect key bindings for buffer functions
* [`f4f8ad8f`](https://github.com/syl20bnr/spacemacs/commit/f4f8ad8fd70f3f1b74b68e1dc04c2e0167863ce9) git: migrate git{attributes,config,ignore}-mode to git-modes
* [`66e509f3`](https://github.com/syl20bnr/spacemacs/commit/66e509f34589f259085e09b70d47128d72bbfdfe) Remove helm-gitignore from git layer.
* [`92979e79`](https://github.com/syl20bnr/spacemacs/commit/92979e7934379ac9a5d55ad072197dc36a10dd0d) fasd layer: fasd & open in a layout ([syl20bnr/spacemacs⁠#15126](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15126))
* [`889f3321`](https://github.com/syl20bnr/spacemacs/commit/889f33216e4c9158f32ee8c5c058079471c17774) helm-find-files-history requires prefix argument
* [`b1fe17d3`](https://github.com/syl20bnr/spacemacs/commit/b1fe17d370d5a3f3b7c8d69b51f7b12b77368418) Open special-mode buffer in motion-state (not evilified)
* [`2dc62081`](https://github.com/syl20bnr/spacemacs/commit/2dc62081741599a714fd6f2a5ff3b0ec2e93e252) [doc] Fix spelling mistake
* [`b926293c`](https://github.com/syl20bnr/spacemacs/commit/b926293c33dc9c605a0c2e0ac0df1bb7da4f6875) [doc] Improve wording
* [`16ae20bc`](https://github.com/syl20bnr/spacemacs/commit/16ae20bcfe64c50129f7c22af5f1e39636f1471e) Update go layer docs since go get is deprecated
* [`7d39d736`](https://github.com/syl20bnr/spacemacs/commit/7d39d7363bcbea91ad6b82f76d080ae0ce37f8d4) python: Update README.org 
* [`22bfc819`](https://github.com/syl20bnr/spacemacs/commit/22bfc8197d5bc3f2e7494ba69cc7da3e087d8a1f) Add zonokai themes to themes-megapack layer
* [`89d34825`](https://github.com/syl20bnr/spacemacs/commit/89d348250392528f5578a1c681ca028bf75b7c86) Add to the docs for compleseus about selecting a completion engine
* [`7ac30392`](https://github.com/syl20bnr/spacemacs/commit/7ac303922eaf04ddb0d9f47877a07f8e97e1059f) [compleseus] Fix some small typos
* [`d5b6df35`](https://github.com/syl20bnr/spacemacs/commit/d5b6df3584cf6196ec373fc62e165fc4fc3f3ba2) Add commands to compleseus layer (locate, yasnippet, search from) ([syl20bnr/spacemacs⁠#15078](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15078))
* [`0dd38667`](https://github.com/syl20bnr/spacemacs/commit/0dd38667dfb7951a617c374aefa8a3a301bd72ae) [compleseus] Fetch consult-yasnippet from melpa
* [`1c0d7be2`](https://github.com/syl20bnr/spacemacs/commit/1c0d7be28b8eaef19f3f8364af9dfd3a986e98e1) [python] Fix broken link
* [`e6bd5cc4`](https://github.com/syl20bnr/spacemacs/commit/e6bd5cc4ac7996fa463dd1482bec597041feedf2) [bot] "documentation_updates" Tue Nov  2 22:01:23 UTC 2021
* [`2dcc0a74`](https://github.com/syl20bnr/spacemacs/commit/2dcc0a747ed70ad3a75bb26bf0003358e57a7530) fix a space issue introduced in [syl20bnr/spacemacs⁠#15098](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15098) in CHANGELOG.develop ([syl20bnr/spacemacs⁠#15135](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15135))
* [`500335a2`](https://github.com/syl20bnr/spacemacs/commit/500335a2c29ec9203054681caff601319aae07dd) fix links
* [`548edefc`](https://github.com/syl20bnr/spacemacs/commit/548edefcce52cf626927c7806c01796cf66b0410) Install org from ELPA instead of Org ELPA
* [`a80b58c6`](https://github.com/syl20bnr/spacemacs/commit/a80b58c635bd381b856dac6307b7e8246527f994) follow-up for [syl20bnr/spacemacs⁠#15135](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15135) with stray leading space in CHANGELOG.develop ([syl20bnr/spacemacs⁠#15142](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15142))
