### PR TITLE
niv nixpkgs: update 1a7c8399 -> b05815e8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1a7c8399acbbd95b05bfdc6045160c60aa5dcd3e",
-        "sha256": "1addh2j3pipbcwabhglci3ypmfxm7lp1ismzd8g5b5h1780yfdab",
+        "rev": "b05815e88afcf77013655f895e7fb0c8d64e68e3",
+        "sha256": "0zj3ggy7zp04qak177n0lamqy5j4z9spgnsy00mn9pv6ncrz3ihy",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/1a7c8399acbbd95b05bfdc6045160c60aa5dcd3e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/b05815e88afcf77013655f895e7fb0c8d64e68e3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@1a7c8399...b05815e8](https://github.com/nixos/nixpkgs/compare/1a7c8399acbbd95b05bfdc6045160c60aa5dcd3e...b05815e88afcf77013655f895e7fb0c8d64e68e3)

* [`a446131b`](https://github.com/NixOS/nixpkgs/commit/a446131b68580b7fc79e93658d2a5e8e88487500) mkgmap: 4810 -> 4813
* [`801fe645`](https://github.com/NixOS/nixpkgs/commit/801fe64590c1cef718bfb9b51e615d485abf6a5a) megapixels: 1.3.0 -> 1.4.0
* [`1ed375db`](https://github.com/NixOS/nixpkgs/commit/1ed375dba1191fdd40fbfa74ab1c8c213a6263d1) mkgmap-splitter: 642 -> 643
* [`d9dc791f`](https://github.com/NixOS/nixpkgs/commit/d9dc791f7499699c2a9c1ef9b9c86ed7f6c40913) python3Packages.hangups: 0.4.14 -> 0.4.15
* [`0bf39172`](https://github.com/NixOS/nixpkgs/commit/0bf391720bebe4954a0fd76a78458c2c4c7e936d) python3Packages.zulip: 0.8.0 -> 0.8.1
* [`fd50160f`](https://github.com/NixOS/nixpkgs/commit/fd50160f86d4ec38cd489ccda24abf2ef848ec94) python3Packages.scikitimage: fix build in darwin sandbox
* [`1a2019bd`](https://github.com/NixOS/nixpkgs/commit/1a2019bd83de1d5eb0ce3576f1bc31ed0435e408) vimPlugins.coc-ultisnips: init at 1.2.3
* [`3f02caca`](https://github.com/NixOS/nixpkgs/commit/3f02caca7fa3b67cd105da9390c15c6d1e60051f) mpdevil: 1.4.0 -> 1.4.1
* [`89912c3d`](https://github.com/NixOS/nixpkgs/commit/89912c3d0ccc75e1cc95689cd983ed1253629a99) boxfort: mark broken on darwin to match upstream
* [`3067b83e`](https://github.com/NixOS/nixpkgs/commit/3067b83e14704218f8badd9f437a79aa2455d88c) nodejs-17_x: 17.0.1 -> 17.1.0
* [`efa7406c`](https://github.com/NixOS/nixpkgs/commit/efa7406cc79befddc5d731ced046f949fe5068b2) nwg-wrapper: 0.0.2 -> 0.1.0
* [`916603e4`](https://github.com/NixOS/nixpkgs/commit/916603e490ad296a685b4b92d94b90552790bb49) oh-my-zsh: 2021-10-27 -> 2021-11-11
* [`2a6b6b2a`](https://github.com/NixOS/nixpkgs/commit/2a6b6b2a3c1043da60780c448caa7d37ffd4a4a1) osu-lazer: 2021.1105.0 -> 2021.1113.0
* [`e22ed89d`](https://github.com/NixOS/nixpkgs/commit/e22ed89d69368770772c5ac52821460fe9fb8231) pipenv: 2021.5.29 -> 2021.11.9
* [`d5ff6143`](https://github.com/NixOS/nixpkgs/commit/d5ff6143d09a4eafeafaa4101acc0bd06ac7e8b5) proselint: 0.12.0 -> 0.13.0
* [`26ced3aa`](https://github.com/NixOS/nixpkgs/commit/26ced3aa14c9d6a6e700521639a0363a26eb3365) prowlarr: 0.1.1.1030 -> 0.1.2.1060
* [`a84ba490`](https://github.com/NixOS/nixpkgs/commit/a84ba490c457f659300e54e09ab050528d4d1e12) abcmidi: 2021.10.11 -> 2021.10.15
* [`44582a0f`](https://github.com/NixOS/nixpkgs/commit/44582a0f0e9ae4f9b6d553bea80d4a148fed69cf) numberstation: 1.0.0 -> 1.0.1
* [`d7575472`](https://github.com/NixOS/nixpkgs/commit/d7575472f53f94358f505b6bdffc811e29af941d) gitkraken: add darwin support
* [`2ee0687c`](https://github.com/NixOS/nixpkgs/commit/2ee0687c305e29b18c1a3d60186546176bedb97e) pypi-mirror: 4.0.7 -> 4.1.0
* [`c2725457`](https://github.com/NixOS/nixpkgs/commit/c27254571b48e46519f1fa3698000a5fe31faf8d) python38Packages.aiohttp-remotes: 1.0.0 -> 1.1.0
* [`a1ab38df`](https://github.com/NixOS/nixpkgs/commit/a1ab38dfc5cd11f3043dd56a351d7d843cbebb0f) hiredis: 1.0.0 -> 1.0.2
* [`b136a823`](https://github.com/NixOS/nixpkgs/commit/b136a8232111d2d12263c7c96d2f08a7b4361693) buller: 2.87 -> 3.17
* [`566ef06c`](https://github.com/NixOS/nixpkgs/commit/566ef06cf5aba71b850838d2fe9bbd7828475e69) obs-studio: use wrapGAppsHook to add required org.gtk.Settings.ColorChooser schema
* [`90af5cac`](https://github.com/NixOS/nixpkgs/commit/90af5cacfbcf6b3c57a33feb1e19be797b27e7e8) obs-studio: avoid double-wrapping the obs binary
* [`cd1df7d3`](https://github.com/NixOS/nixpkgs/commit/cd1df7d3337bfa1fcc5d6bbb7ac3d4d1d163e00f) host: pull pending upstream inclusion fix for ncurses-6.3
* [`4ee7acde`](https://github.com/NixOS/nixpkgs/commit/4ee7acdef00d255ab1607bbc83ba5171b94c792f) gopass: 1.12.8 → 1.13.0
* [`811fee2d`](https://github.com/NixOS/nixpkgs/commit/811fee2d6401a34bfd7d8c3b35ad9f643bd00b18) nodePackages: update
* [`59e45f44`](https://github.com/NixOS/nixpkgs/commit/59e45f4474a378856e65b794c3aefc040ef9c595) psi-plus: 1.5.1556-2 -> 1.5.1576
* [`4d539648`](https://github.com/NixOS/nixpkgs/commit/4d539648017dc07618eabb3a369226e675efe85e) zinit: zdharma/zinit -> zdharma-continuum/zinit
* [`2812d080`](https://github.com/NixOS/nixpkgs/commit/2812d0802acb7f5d15e3a1096fd7ca6c260551c6) wallutils: 5.9.0 -> 5.10.0
* [`34e9d9b2`](https://github.com/NixOS/nixpkgs/commit/34e9d9b2ecf9d5fbadefcf322b7a69390c0d087d) python38Packages.aws-lambda-builders: 1.8.1 -> 1.9.0
* [`830a13f2`](https://github.com/NixOS/nixpkgs/commit/830a13f2e50461430017c7241d52b9b685375716) wallutils: remove myself as maintainer
* [`d5e0c3ae`](https://github.com/NixOS/nixpkgs/commit/d5e0c3ae0f38d349cc973feaf1b1918a84b35ff9) scdoc: 1.11.1 -> 1.11.2
* [`1a5986ac`](https://github.com/NixOS/nixpkgs/commit/1a5986ac40313daa55b632afdf342f331c8c9893) python38Packages.awscrt: 0.12.5 -> 0.12.6
* [`c5bd5335`](https://github.com/NixOS/nixpkgs/commit/c5bd53355e7b17d8d9891dcb26a940ec999a1749) python38Packages.azure-appconfiguration: 1.2.0 -> 1.3.0
* [`303b5120`](https://github.com/NixOS/nixpkgs/commit/303b5120c0f19b8fd00c266763606391c896d6ab) python38Packages.azure-identity: 1.7.0 -> 1.7.1
* [`082ae9a4`](https://github.com/NixOS/nixpkgs/commit/082ae9a4728bdba8aed217d0d5cb89d104cd2538) python3Packages.minidump: 0.0.20 -> 0.0.21
* [`4594b456`](https://github.com/NixOS/nixpkgs/commit/4594b4562c10dba458efe6a862d1fe04411a9ace) python38Packages.azure-loganalytics: 0.1.0 -> 0.1.1
* [`86dbe45b`](https://github.com/NixOS/nixpkgs/commit/86dbe45bea6098f9b58e672172f890ee04480801) python38Packages.azure-mgmt-eventgrid: 9.0.0 -> 10.0.0
* [`5373aa79`](https://github.com/NixOS/nixpkgs/commit/5373aa7968d2d65a86c462a89a47a7cd2623ccad) python38Packages.azure-mgmt-iotcentral: 4.1.0 -> 9.0.0
* [`c2aeddb9`](https://github.com/NixOS/nixpkgs/commit/c2aeddb9a0c7ec22b7472f30cbeca7b44ff1e23c) python38Packages.azure-mgmt-monitor: 2.0.0 -> 3.0.0
* [`b93a0c71`](https://github.com/NixOS/nixpkgs/commit/b93a0c71f2493880eed74dfc7c4b0e8480947161) python3Packages.praw: 7.4.0 -> 7.5.0
* [`7a6f0c1f`](https://github.com/NixOS/nixpkgs/commit/7a6f0c1f21d4a02ea079ebfe1e6c70ee38ca00f5) python38Packages.azure-mgmt-network: 19.2.0 -> 19.3.0
* [`b9d5df06`](https://github.com/NixOS/nixpkgs/commit/b9d5df0632008f0bafe8fd1f3355b4e4c11d0f3d) python3Packages.aiohttp-remotes: switch to pytestCheckHook
* [`01e481e6`](https://github.com/NixOS/nixpkgs/commit/01e481e621d4c5209a4897dbc258b398bd018706) python38Packages.bracex: 2.2 -> 2.2.1
* [`ff52e0cb`](https://github.com/NixOS/nixpkgs/commit/ff52e0cbc2ae89833527eee2ca7e8bc3ef533da7) python3Packages.flux-led: 0.24.17 -> 0.24.21
* [`9c83343b`](https://github.com/NixOS/nixpkgs/commit/9c83343bb85a4ca71f84213bcd52b1393929e538) scrcpy: 1.19 -> 1.20
* [`f330a765`](https://github.com/NixOS/nixpkgs/commit/f330a765071ebe5e5b4766fd51553bb07944f3ad) python3Packages.greeclimate: 0.12.3 -> 0.12.4
* [`1977eb9d`](https://github.com/NixOS/nixpkgs/commit/1977eb9d6d790349a46a0ae1340c4070a2e1baaa) python38Packages.casbin: 1.9.4 -> 1.9.6
* [`17fdea06`](https://github.com/NixOS/nixpkgs/commit/17fdea06d8f89c4b05faa354f6561f129640e909) diskus: 0.6.0 -> 0.7.0
* [`d234c03d`](https://github.com/NixOS/nixpkgs/commit/d234c03de8e3d1851f8ca285c96847e4d6682403) paper-icon-theme: 2018-06-24 -> unstable-2020-03-12
* [`fbbfc3ed`](https://github.com/NixOS/nixpkgs/commit/fbbfc3edfa4a90743e0f0db179abb242da4c6a4c) paper-icon-theme: replace duplicate files with symlinks
* [`bcdb9e13`](https://github.com/NixOS/nixpkgs/commit/bcdb9e139966e95a95c392536716b17b85afd776) lazygit: 0.30.1 -> 0.31.3
* [`1e16eb5e`](https://github.com/NixOS/nixpkgs/commit/1e16eb5ea6354953ab88bcaed1a6daaab9e4f7f7) python38Packages.coveralls: 3.2.0 -> 3.3.1
* [`9e7cfee0`](https://github.com/NixOS/nixpkgs/commit/9e7cfee02b8fae83b73c3a8b65ca502252b36f7c) vimPlugins: update
* [`6575f966`](https://github.com/NixOS/nixpkgs/commit/6575f966481be606f7d99805ae23c5cbad737e73) vimPlugins.FTerm-nvim: init at 2021-11-13
* [`32b6a2bf`](https://github.com/NixOS/nixpkgs/commit/32b6a2bf6af21a0835ad5654912e8609bf89b96b) vimPlugins.nvim-lint: init at 2021-11-08
* [`e50c9981`](https://github.com/NixOS/nixpkgs/commit/e50c9981d329312fb764b7d58e17488716bf2879) tesseract4: apply patches to fix build on aarch64-darwin
* [`9201d388`](https://github.com/NixOS/nixpkgs/commit/9201d388edc76b87f7d28f4297a25f0f0ce2e2f3) moka-icon-theme: 5.4.0 -> unstable-2019-05-29
* [`58bdfc52`](https://github.com/NixOS/nixpkgs/commit/58bdfc529b30a2e417fcc0edcbc923df23629683) iris: 3.4.0 -> 3.5.0; stdpp: 1.5.0 -> 1.6.0
* [`27bfd797`](https://github.com/NixOS/nixpkgs/commit/27bfd79741808003a7041ef3bbf62472e9ea15ee) moka-icon-theme: replace duplicate files with symlinks
* [`bdaf941e`](https://github.com/NixOS/nixpkgs/commit/bdaf941e39921dc7ef0da9c8263c45943c850eec) haskellPackages.hercules-ci-*: fix eval with haskell.lib.compose
* [`dc768257`](https://github.com/NixOS/nixpkgs/commit/dc7682574256909976b72dd4967946eedfc91fd7) tree: fix build on darwin/others
* [`6a3d7472`](https://github.com/NixOS/nixpkgs/commit/6a3d7472a56cf1b9f996e7bbfcfb1692f21b00a7) python38Packages.fido2: 0.9.2 -> 0.9.3
* [`8010ee3f`](https://github.com/NixOS/nixpkgs/commit/8010ee3ff307381918df203fd154ff002e7012d9) cargo-deps: use fetchCrate
* [`89139c63`](https://github.com/NixOS/nixpkgs/commit/89139c637235f55636445cb3682c0458ed12c5ff) trilium: 0.47.8 -> 0.48.6
* [`5440a389`](https://github.com/NixOS/nixpkgs/commit/5440a389219dfe90f57a780ac5e038c6620fae11) python38Packages.google-cloud-asset: 3.7.0 -> 3.7.1
* [`5e6878cd`](https://github.com/NixOS/nixpkgs/commit/5e6878cdf56016e5733078f1a3418a2702395d4d) python38Packages.google-cloud-automl: 2.5.1 -> 2.5.2
* [`a5e5e2ad`](https://github.com/NixOS/nixpkgs/commit/a5e5e2ad1be5dc125cea72ad4e017b926569c8d8) python38Packages.google-cloud-bigquery-datatransfer: 3.4.0 -> 3.4.1
* [`9467fee4`](https://github.com/NixOS/nixpkgs/commit/9467fee4d444f6080c167fabca5c1766b09e207e) python38Packages.google-cloud-container: 2.10.0 -> 2.10.1
* [`f8448067`](https://github.com/NixOS/nixpkgs/commit/f84480678d6f4ebd95deca201554bec1ce850cfe) makemkv: 1.16.4 -> 1.16.5
* [`cdd3c44b`](https://github.com/NixOS/nixpkgs/commit/cdd3c44bfa6746e47ec3395dd949916f27554b9b) cached-nix-shell: 0.1.4 -> 0.1.5
* [`c59a5b96`](https://github.com/NixOS/nixpkgs/commit/c59a5b968ddde38a4599e1644c9c2f238fc74f16) python38Packages.google-cloud-datacatalog: 3.4.3 -> 3.6.0
* [`ee93a73b`](https://github.com/NixOS/nixpkgs/commit/ee93a73bedd2fbca00c4c7126fcbbdde12faf6e2) python38Packages.google-cloud-dataproc: 3.1.0 -> 3.1.1
* [`f1f3d9f7`](https://github.com/NixOS/nixpkgs/commit/f1f3d9f7f827efb13fc35bdabe29be16fc824e87) mtr: fix JSON output format, add libjansson
* [`0fcdadb8`](https://github.com/NixOS/nixpkgs/commit/0fcdadb80e3067c4ef74b87262bd81e25702db98) python38Packages.google-cloud-datastore: 2.2.0 -> 2.4.0
* [`8b9646c0`](https://github.com/NixOS/nixpkgs/commit/8b9646c0c23836d095e5078a8e8f9faf19dfe933) python38Packages.google-cloud-dlp: 3.3.0 -> 3.3.1
* [`80dacd9f`](https://github.com/NixOS/nixpkgs/commit/80dacd9ffa0729a541935020dce4301e1789f17e) python38Packages.google-cloud-error-reporting: 1.4.0 -> 1.4.1
* [`b36a9512`](https://github.com/NixOS/nixpkgs/commit/b36a9512e71d8b6fc479cecba156f2dea2c9615a) python38Packages.google-cloud-iam: 2.5.0 -> 2.5.1
* [`340160df`](https://github.com/NixOS/nixpkgs/commit/340160df2d58073d868db6468e3a233062887be5) python38Packages.google-cloud-kms: 2.10.0 -> 2.10.1
* [`5e7e5e5d`](https://github.com/NixOS/nixpkgs/commit/5e7e5e5d41cf3f140531d9957ec7c7647bca32d8) ccache: 4.4.2 → 4.5
* [`0f6838b4`](https://github.com/NixOS/nixpkgs/commit/0f6838b42127bd80f0a3fbecbbf15f89438800b1) python38Packages.google-cloud-language: 2.3.0 -> 2.3.1
* [`46c3a0b7`](https://github.com/NixOS/nixpkgs/commit/46c3a0b7be4539a9f1ef71899eff3520fda17a35) python38Packages.google-cloud-logging: 2.6.0 -> 2.7.0
* [`b30aacb9`](https://github.com/NixOS/nixpkgs/commit/b30aacb9b22d75bd8f1ba73d7ca14bd38f10473d) python38Packages.google-cloud-monitoring: 2.6.0 -> 2.7.0
* [`a7044b30`](https://github.com/NixOS/nixpkgs/commit/a7044b306cdef47c90acf9e26d290a7173f1404b) python38Packages.google-cloud-org-policy: 1.2.0 -> 1.2.1
* [`d741f66e`](https://github.com/NixOS/nixpkgs/commit/d741f66ecb8dd5a9660855c27e671db53192442b) python38Packages.google-cloud-os-config: 1.7.0 -> 1.9.0
* [`a881bfed`](https://github.com/NixOS/nixpkgs/commit/a881bfed1249c731ca10ea3dbf24fb5963f7a4f1) python38Packages.google-cloud-pubsub: 2.8.0 -> 2.9.0
* [`69013197`](https://github.com/NixOS/nixpkgs/commit/690131976e9a00f25f3abe8e8b3bc75d694e45d7) python3Packages.casa-formats.io: init at 0.1
* [`0749556d`](https://github.com/NixOS/nixpkgs/commit/0749556dd703da7bd0908be4c98dbf3c4ba490d0) python38Packages.google-cloud-redis: 2.4.0 -> 2.5.0
* [`2b7f7fee`](https://github.com/NixOS/nixpkgs/commit/2b7f7fee7b94563b3516ed62528cebb826d5e693) python3Packages.spectral-cube: 0.5.0 -> 0.6.0
* [`4029da71`](https://github.com/NixOS/nixpkgs/commit/4029da716609b783cddfc0da2fbc2e989a621f60) python38Packages.google-cloud-resource-manager: 1.3.0 -> 1.3.2
* [`8d705305`](https://github.com/NixOS/nixpkgs/commit/8d705305ee185dc77a2c3523d15a23296a2cd422) python38Packages.google-cloud-secret-manager: 2.7.2 -> 2.8.0
* [`f6584583`](https://github.com/NixOS/nixpkgs/commit/f65845839461c5564fcfc273aee217e664d45117) python38Packages.google-cloud-speech: 2.11.0 -> 2.11.1
* [`8c9f6c2b`](https://github.com/NixOS/nixpkgs/commit/8c9f6c2b723cb9c92b1f3b5301841a265d98accc) python38Packages.google-cloud-tasks: 2.7.0 -> 2.7.1
* [`4c7c3f85`](https://github.com/NixOS/nixpkgs/commit/4c7c3f85fbcd9b39052aa46d5df625f58d6816ec) python38Packages.google-cloud-texttospeech: 2.7.0 -> 2.7.1
* [`f4174af6`](https://github.com/NixOS/nixpkgs/commit/f4174af6feb9ef68ff9c30d692a97b2485fb0e30) python38Packages.google-cloud-trace: 1.5.0 -> 1.5.1
* [`145cae01`](https://github.com/NixOS/nixpkgs/commit/145cae01895e1b4d4c562f8d8ecaab1f83473bf6) nvimpager: 0.10 -> 0.10.4
* [`c81411f5`](https://github.com/NixOS/nixpkgs/commit/c81411f58f9cbe20d335e0d20f3bcce76e676371) python38Packages.google-cloud-translate: 3.6.0 -> 3.6.1
* [`73e29858`](https://github.com/NixOS/nixpkgs/commit/73e29858608a5c4fd367b05800f4f4bc9ad168cd) python38Packages.google-cloud-videointelligence: 2.5.0 -> 2.5.1
* [`fe478785`](https://github.com/NixOS/nixpkgs/commit/fe478785a91ef6a78aa75f59e8445facad73303c) python38Packages.google-cloud-vision: 2.6.1 -> 2.6.2
* [`68b7bc8e`](https://github.com/NixOS/nixpkgs/commit/68b7bc8eceeb7516684e307da1e6b03332b09260) python38Packages.google-cloud-websecurityscanner: 1.6.0 -> 1.6.1
* [`488a5a37`](https://github.com/NixOS/nixpkgs/commit/488a5a3787b2b53a991f9554dc9da97951245c77) fuzzel: 1.6.4 -> 1.6.5
* [`1c72fa65`](https://github.com/NixOS/nixpkgs/commit/1c72fa65ed742d9bfa69cf4576b66a4c8aa6abbc) nix-zsh-completions: Lower priority to avoid collisions with nix
* [`8a37d710`](https://github.com/NixOS/nixpkgs/commit/8a37d710fd73e17dde79012a641a85b33dfa98eb) nixos: zsh: Remove hack for zsh-nix-completions on nix 2.4
* [`9a65a60a`](https://github.com/NixOS/nixpkgs/commit/9a65a60a206ad2be649793f987b780b0530ad70c) ArchiSteamFarm: 4.3.1.0 -> 5.1.5.3, use buildDotnetModule ([nixos/nixpkgs⁠#145542](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/145542))
* [`fa0761a7`](https://github.com/NixOS/nixpkgs/commit/fa0761a7c6a31ad1c00cd43f6964829c7513727b) python3Packages.pygame: fix source hash on HFS+ filesystems ([nixos/nixpkgs⁠#145986](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/145986))
* [`b187fab9`](https://github.com/NixOS/nixpkgs/commit/b187fab93e5500d7ba6578f3657b5982e0888d03) tela-icon-theme: remove darwin from platforms ([nixos/nixpkgs⁠#145997](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/145997))
* [`64d7a326`](https://github.com/NixOS/nixpkgs/commit/64d7a3266b6327521cfb563d014c4e26876f4dfa) doc: Fix xref in functions description
* [`520c255e`](https://github.com/NixOS/nixpkgs/commit/520c255e7fc75eda7707b61bb8101022ae91b28e) python38Packages.gin-config: 0.4.0 -> 0.5.0
* [`cbf234b3`](https://github.com/NixOS/nixpkgs/commit/cbf234b34b3471454da96e7f6b5f012647160bc4) python38Packages.gigalixir: 1.2.3 -> 1.2.4
* [`cd7cfb6d`](https://github.com/NixOS/nixpkgs/commit/cd7cfb6def162c75171312cf3565f607a4744399) python38Packages.bandit: 1.7.0 -> 1.7.1
* [`06b3bdbe`](https://github.com/NixOS/nixpkgs/commit/06b3bdbeffde1cbc3ce1818d9543a7bc4e860ab9) python38Packages.ftputil: 5.0.1 -> 5.0.2
* [`ef9ac538`](https://github.com/NixOS/nixpkgs/commit/ef9ac538ebaa6e23cd9dfe95c1d8bd8332351d4a) python38Packages.frozendict: 2.0.6 -> 2.0.7
* [`422c4e19`](https://github.com/NixOS/nixpkgs/commit/422c4e199e1a25902fde646d5a94c14bcaba4aa6) python38Packages.flexmock: 0.10.10 -> 0.11.1
* [`61bb9d5d`](https://github.com/NixOS/nixpkgs/commit/61bb9d5d5d83aa40a1bac3d66fb54601981f4ea1) python3Packages.fritzconnection: 1.7.1 -> 1.7.2
* [`8622d7dc`](https://github.com/NixOS/nixpkgs/commit/8622d7dc11f19dc97cf060e4de25e64768f35f45) fail2ban: Make postInstall delete conditional
* [`e4362cea`](https://github.com/NixOS/nixpkgs/commit/e4362cea6f3c3d8df03ae5e7a2e4f7a5fb8a8422) monosat, python3Packages.monosat: fix for non-x86
* [`df304eeb`](https://github.com/NixOS/nixpkgs/commit/df304eeb8026941efa4cb123d28a12a3a5935b36) glitter: 1.5.4 -> 1.5.5
* [`4f0c8d05`](https://github.com/NixOS/nixpkgs/commit/4f0c8d0512503ff15a0894cf81eb68c536b78aac) nvidia_x11: libPath: add libgbm/libGL libraries ([nixos/nixpkgs⁠#145439](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/145439))
* [`5a3b358b`](https://github.com/NixOS/nixpkgs/commit/5a3b358be5c2f12b56d71e30944160feeaa5ca8c) etcd: 3.3.25 -> 3.3.27
* [`416596bd`](https://github.com/NixOS/nixpkgs/commit/416596bd245db633b2c27ad7a2cfb7bbed6d3e34) etcd_3_4: 3.4.16 -> 3.4.18
* [`b554c3af`](https://github.com/NixOS/nixpkgs/commit/b554c3af7bd0767871d29616614dafc4cf5702d5) etcd_3_4: remove deleteVendor
