### PR TITLE
niv fast-syntax-highlighting: update 9a5a4a51 -> 585c0899

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "9a5a4a5199e7e480009e10433d0d8c5be91f31d4",
-        "sha256": "16vvmb18qny78sdrild4ksxp4776hlajps5al5b985x7zis7iqjd",
+        "rev": "585c089968caa1c904cbe926ff04a1be9e3d8f42",
+        "sha256": "1lc9mhi25ybkcn0747j3i8y2hrmakv5mxndglf6yfiipxpd05vn7",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/9a5a4a5199e7e480009e10433d0d8c5be91f31d4.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/585c089968caa1c904cbe926ff04a1be9e3d8f42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@9a5a4a51...585c0899](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/9a5a4a5199e7e480009e10433d0d8c5be91f31d4...585c089968caa1c904cbe926ff04a1be9e3d8f42)

* [`c63603f1`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/c63603f1e2e63b28d61a3bef2b08d28e8113e7b4) Suppress exit code when nearcolor is not available
* [`55fedda2`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/55fedda2de7dad38ffe334e4519b0da9dac8d89a) Update url
* [`6c072dc5`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/6c072dc50306e5600a97dfde30c16e90f4ba5cef) Update repo url
* [`1bf99ed4`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/1bf99ed4cdc7fa1fb208f3eba030ca4f3d245152) Replace IRC with gitter.im badge
* [`8fc2b8b9`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/8fc2b8b9a75ffcb3974cd0f8195151a5d2963613) Update TOC
* [`31107990`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/31107990dcbd602a67438f345c717a5a5abb04ec) Change : to true
* [`f4d007e4`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/f4d007e4da34b4a2a36be80b527bd96052fd5aec) Restore compatibility with Zsh v4.3.11 ([zdharma-continuum/fast-syntax-highlighting⁠#7](http://r.duckduckgo.com/l/?uddg=https://github.com/zdharma-continuum/fast-syntax-highlighting/issues/7))
* [`41fe53aa`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/41fe53aa00d5e3578670b00f698ba791d2e2431a) Unit tests via GH Actions
* [`5327d7f9`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/5327d7f9c02c7b4b09bf75c57c71c12dd06f400f) Remove travic CI config
* [`6f36339a`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/6f36339a310c0bbcadae6c2ad96fc362a7707301) Pin zunit, revolver and color.zsh versions
