### PR TITLE
niv home-manager: update 2917ef23 -> a7c5b00d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2917ef23b398a22ee33fb34b5766b28728228ab1",
-        "sha256": "09whf7ai8ppcj931r82wyahgfhrk32r54arbi3lpwz4w38d2x5mm",
+        "rev": "a7c5b00d44f65efd1e8ace2c02243f179e72283a",
+        "sha256": "17hziylq4nbg95cm30kmwhwhw8xvabka48xgviidvw4wxli3wc0k",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/2917ef23b398a22ee33fb34b5766b28728228ab1.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a7c5b00d44f65efd1e8ace2c02243f179e72283a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@2917ef23...a7c5b00d](https://github.com/nix-community/home-manager/compare/2917ef23b398a22ee33fb34b5766b28728228ab1...a7c5b00d44f65efd1e8ace2c02243f179e72283a)

* [`1e5c8e9b`](https://github.com/nix-community/home-manager/commit/1e5c8e9bff00d0844bc3d25d1a98eab5633e600b) direnv.nix-direnv: remove enableFlakes ([nix-community/home-manager⁠#2458](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2458))
* [`be1ad305`](https://github.com/nix-community/home-manager/commit/be1ad30503024129477956289ea5e51593d3a445) Remove remaining `allowSubstitutes = false`
* [`39c5c739`](https://github.com/nix-community/home-manager/commit/39c5c7397ed27aa4146a63cb1a27c0a4d4030224) docs: improve description of extraSpecialArgs
* [`520adafc`](https://github.com/nix-community/home-manager/commit/520adafcb993bf382e9c3e20742c9b4f998330bf) docs: add example how to use flakes on non-NixOS
* [`f7a37ad0`](https://github.com/nix-community/home-manager/commit/f7a37ad0b6a3ed256a3d9d36fd78918989427244) email: add fastmail.com email flavor ([nix-community/home-manager⁠#2457](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2457))
* [`426830a1`](https://github.com/nix-community/home-manager/commit/426830a174ca032f62225ea968fdb19f2b24ab0d) home-manager: minor reorder of generated `home.nix`
* [`0f5d9311`](https://github.com/nix-community/home-manager/commit/0f5d93119c1e87f6ea44b5a8f4db17f3ff9d5e81) docs: move usage section to chapter in manual
* [`accfbdf2`](https://github.com/nix-community/home-manager/commit/accfbdf215dbf39eac2fbae67b574dac0be83d51) docs: add license section in readme
* [`3f12ce5f`](https://github.com/nix-community/home-manager/commit/3f12ce5f7df69dfb8e12b02e88979b9d7770c663) home-manager: forward --no-write-lock-file ([nix-community/home-manager⁠#2471](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2471))
* [`cbcb2976`](https://github.com/nix-community/home-manager/commit/cbcb2976b69a4054a8cb2a4c26101ca337191999) ci: bump cachix/install-nix-action from 14 to 15
* [`e785e679`](https://github.com/nix-community/home-manager/commit/e785e6797786d4c08a74039a2b4afd4c8d90ba21) docs: make text more specific about Nix 2.4 support
* [`c855cdde`](https://github.com/nix-community/home-manager/commit/c855cdde20f3d00c421aeae59546d22430ba86ae) docs: make README refer to installation chapter
* [`2dcd9eb0`](https://github.com/nix-community/home-manager/commit/2dcd9eb021bab3ac51995099aec16b7354851c9c) docs: minor rewording in usage documentation
* [`a7c5b00d`](https://github.com/nix-community/home-manager/commit/a7c5b00d44f65efd1e8ace2c02243f179e72283a) polybar: use recursive config type ([nix-community/home-manager⁠#2235](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2235))
