### PR TITLE
niv spacemacs: update a80b58c6 -> 1a4912e5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "a80b58c635bd381b856dac6307b7e8246527f994",
-        "sha256": "12ca803ynf495m3ng14pwc87bgwbkpsppb2igya0ymynapnx41gk",
+        "rev": "1a4912e51fdc012ba571c670e8c8e8c5eb4695d1",
+        "sha256": "1hiwxpkpsmk5fxz9byi67169slqsnqhl6qq5nnzn1k65lw3sqsqv",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/a80b58c635bd381b856dac6307b7e8246527f994.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/1a4912e51fdc012ba571c670e8c8e8c5eb4695d1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@a80b58c6...1a4912e5](https://github.com/syl20bnr/spacemacs/compare/a80b58c635bd381b856dac6307b7e8246527f994...1a4912e51fdc012ba571c670e8c8e8c5eb4695d1)

* [`c0fd5c96`](https://github.com/syl20bnr/spacemacs/commit/c0fd5c960116940776b14e7fd796d14dc765877e) [doc] clean up
* [`1638bbf3`](https://github.com/syl20bnr/spacemacs/commit/1638bbf39d6c7b4dd93f3d3cadca9d5a63893c6c) Fix typo doftile->dotfile ([syl20bnr/spacemacs⁠#15147](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15147))
* [`a911c9fe`](https://github.com/syl20bnr/spacemacs/commit/a911c9fe4d29b83cdecde110ccc3ddaafd1b3b43) [bot] "documentation_updates" Tue Nov  9 23:59:04 UTC 2021
* [`76841d87`](https://github.com/syl20bnr/spacemacs/commit/76841d87fcdfe2c427b4afadbbb2fd8432f1ed13) [compleseus] tuned completion-style and added support for M-:
* [`cac01055`](https://github.com/syl20bnr/spacemacs/commit/cac0105553bf3c924a5247f45ecf91a114ddd46f) Add option to select packages for update
* [`707124fd`](https://github.com/syl20bnr/spacemacs/commit/707124fd3a4177e2e9bc1b1cb2ad448ab6ccfcc1) [compleseus] Fix orderless integration
* [`3185902f`](https://github.com/syl20bnr/spacemacs/commit/3185902f781499559a98454ddc2752b901b81f79) Add Svelte layer
* [`f5541e87`](https://github.com/syl20bnr/spacemacs/commit/f5541e876abef22610bae71ecb7381697a97aae0) [svelte] Revise layer
* [`759e7610`](https://github.com/syl20bnr/spacemacs/commit/759e7610996f5949dffe7bb80adadfdc5af37fa9) [bot] "documentation_updates" Sat Nov 13 09:20:02 UTC 2021
* [`51611b6e`](https://github.com/syl20bnr/spacemacs/commit/51611b6e307c9a1c1627c18fbaa03022de07a8ac) Fix autocompletion in elisp and text mode
* [`0f7c2e3c`](https://github.com/syl20bnr/spacemacs/commit/0f7c2e3cab37ec4d5c1d31564ad02946fe6f5d83) Adds example on how to set an alert style for org notifications
* [`c9917ea5`](https://github.com/syl20bnr/spacemacs/commit/c9917ea54101a7c706c95fb495f77aa89735e4bf) [ci] fix html export
* [`47fdbced`](https://github.com/syl20bnr/spacemacs/commit/47fdbced8b5f3456bf5baa316580938e0674cd2c) [bot] "documentation_updates" Sun Nov 14 17:38:06 UTC 2021
* [`2dded311`](https://github.com/syl20bnr/spacemacs/commit/2dded3117a289b12d0f940d081dc4774f811e924) [ci] pre-create the missing dir
* [`089ca143`](https://github.com/syl20bnr/spacemacs/commit/089ca1433159de1d7ab6c5bce7c8a6d6ae4bf495) [ci] Actually fix html export
* [`1a4912e5`](https://github.com/syl20bnr/spacemacs/commit/1a4912e51fdc012ba571c670e8c8e8c5eb4695d1) [ci] better error handling in html export
