### PR TITLE
niv zsh-syntax-highlighting: update 1a9264bc -> c7caf57c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -228,10 +228,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "1a9264bc661b3d52756916bf9ec3f41687d64db2",
-        "sha256": "119srhx1cy4bgj3v8lh5ydcgx70xvhc9kmj6mmgmdrrcc4an02xz",
+        "rev": "c7caf57ca805abd54f11f756fda6395dd4187f8a",
+        "sha256": "0cvz071fz67wf8kjavizyq6adm206945byqlv9ib59c96yl8zsri",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/1a9264bc661b3d52756916bf9ec3f41687d64db2.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/c7caf57ca805abd54f11f756fda6395dd4187f8a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@1a9264bc...c7caf57c](https://github.com/zsh-users/zsh-syntax-highlighting/compare/1a9264bc661b3d52756916bf9ec3f41687d64db2...c7caf57ca805abd54f11f756fda6395dd4187f8a)

* [`c7caf57c`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/c7caf57ca805abd54f11f756fda6395dd4187f8a) check KEYS_QUEUED_COUNT and PENDING to skip parsing when pasting
