### PR TITLE
niv nixpkgs: update b05815e8 -> 09454d0f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b05815e88afcf77013655f895e7fb0c8d64e68e3",
-        "sha256": "0zj3ggy7zp04qak177n0lamqy5j4z9spgnsy00mn9pv6ncrz3ihy",
+        "rev": "09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b",
+        "sha256": "1sl10xjy91kx3i2al76kgk85q8mlxaw23dnnrfyswx2pjsiqln6p",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/b05815e88afcf77013655f895e7fb0c8d64e68e3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@b05815e8...09454d0f](https://github.com/nixos/nixpkgs/compare/b05815e88afcf77013655f895e7fb0c8d64e68e3...09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b)

* [`241c1452`](https://github.com/NixOS/nixpkgs/commit/241c145226ce031543c4580acfa7feef993d7463) chromiumDev: 97.0.4692.20 -> 98.0.4710.4
* [`48e70f34`](https://github.com/NixOS/nixpkgs/commit/48e70f34bf47d0651b0e1b718507b1e368e8c079) python3Packages.py-nightscout: init at 1.3.2
* [`23b94ff0`](https://github.com/NixOS/nixpkgs/commit/23b94ff04dd6535f75647f9bd3a10cde02f3e99d) home-assistant: update component-packages
* [`72da520e`](https://github.com/NixOS/nixpkgs/commit/72da520e40dd0c767ebe0e689f396191de25effe) home-assistant: enable nightscout tests
* [`67c0df93`](https://github.com/NixOS/nixpkgs/commit/67c0df93ead69f20418853fdbd1356671e869ed6) gimp: fix build on darwin
* [`be2bc44d`](https://github.com/NixOS/nixpkgs/commit/be2bc44d0e12d0fbb5f89fe410fa6c3baa64ef3c) Partially revert "chromiumDev: 97.0.4692.20 -> 98.0.4710.4"
* [`3c20fe4f`](https://github.com/NixOS/nixpkgs/commit/3c20fe4ffc93096dc389cd93c2f59a8c6d161e4f) signal-desktop: 5.23.1 -> 5.24.0
* [`717bac8a`](https://github.com/NixOS/nixpkgs/commit/717bac8a4d88852d8a71e5ea91fc13064da9c0a0) makemkv: add libcurl to runtimeDependencies
* [`454a8706`](https://github.com/NixOS/nixpkgs/commit/454a8706ca6aadb820890a0b8126d307a89d85c6) pythonPackages.dogpile-core: remove
* [`30632db5`](https://github.com/NixOS/nixpkgs/commit/30632db50a85e51088d3465ae77315b1215b76d7) f3d: 1.1.0 -> 1.1.1
* [`e2ab6321`](https://github.com/NixOS/nixpkgs/commit/e2ab6321ed156e0bc9479c118c80db691bff935a) vmTools: set msize to 128KiB
* [`d1277658`](https://github.com/NixOS/nixpkgs/commit/d127765898cf783e083e277a9abae4f909263956) wine{Unstable,Staging}: 6.20 -> 6.21
* [`ec24bab9`](https://github.com/NixOS/nixpkgs/commit/ec24bab90eac4c100aa5eeef77dec10dc391158b) hmmer: restrict platforms to x86_64
* [`e19fe85e`](https://github.com/NixOS/nixpkgs/commit/e19fe85e84db636ab12a86f11571370825872360) python3Packages.envisage: disable tests of broken optional feature
* [`42a83770`](https://github.com/NixOS/nixpkgs/commit/42a83770be09b3ac21b18da6d03c95c8a3398ecd) python3Packages.envisage: format default.nix
* [`ff7045f0`](https://github.com/NixOS/nixpkgs/commit/ff7045f01839bb299311bcb463e732f4f52888b3) vscode-extensions.haskell.haskell: 1.6.1 -> 1.7.1 ([nixos/nixpkgs⁠#146528](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/146528))
* [`74cb0717`](https://github.com/NixOS/nixpkgs/commit/74cb07175b8788ad33dcc622aca8769828b925d1) qvge: enable on darwin
* [`fedc3db7`](https://github.com/NixOS/nixpkgs/commit/fedc3db7ba5a6f29f2518db4c01fcda87ef0c487) qvge: don't use libsForQt5.mkDerivation
* [`00a52ef6`](https://github.com/NixOS/nixpkgs/commit/00a52ef677eb7098c42c6deb81d11bf9e5740e20) R: manually fix things after patches got applied
* [`9387303e`](https://github.com/NixOS/nixpkgs/commit/9387303e393e4da1e4f38caa51fc6f77a74e2edc) broot: 1.7.1 -> 1.7.3
* [`471183f2`](https://github.com/NixOS/nixpkgs/commit/471183f245c3dd85221f5821d570d4fb84c52d5a) nixos/tests/hibernate: set memorySize to 2G
* [`24cfd348`](https://github.com/NixOS/nixpkgs/commit/24cfd348b1b2cadc81080f72ed7aad55730c2a82) python3Packages.aiovlc: init at 0.1.0
* [`2bfbd302`](https://github.com/NixOS/nixpkgs/commit/2bfbd302b229dacbb16e868a1f77623b53beb4c3) home-assistant: update component-packages
* [`96d27b27`](https://github.com/NixOS/nixpkgs/commit/96d27b27c5d50e08b44adf5a2bd81f8dcf5200c6) home-assistant: enable vlc_telnet tests
* [`0ca14515`](https://github.com/NixOS/nixpkgs/commit/0ca14515c6ed3c4f80afd80b315cf7bcf559200a) testVersion: name runCommand after package.name
* [`110930ee`](https://github.com/NixOS/nixpkgs/commit/110930ee32c8572cedd46eebeb26e643e1e4c179) maintainers: add genofire (me)
* [`39d1d189`](https://github.com/NixOS/nixpkgs/commit/39d1d1893bbdb4af6119efd65331980ed7aa86f6) gotify-desktop: add maintainer genofire (me)
* [`b054a859`](https://github.com/NixOS/nixpkgs/commit/b054a8594a1f5136e4ae7aa5f4e76bea95d7aab9) chromium: update.py: Download files from the main repository
* [`70e9780f`](https://github.com/NixOS/nixpkgs/commit/70e9780f978a80fd5f9d041ad3172b2525f788f7) wine{Unstable,Staging}: 6.21 -> 6.22
* [`a94464d5`](https://github.com/NixOS/nixpkgs/commit/a94464d58554aa02dc144431fcface13829cd039) intel-gmmlib: 21.3.2 -> 21.3.3
* [`a88446e3`](https://github.com/NixOS/nixpkgs/commit/a88446e324ce48d244a9e2866325b00ab0729b11) zynaddsubfx: fix aarch64-linux build
* [`a66592d7`](https://github.com/NixOS/nixpkgs/commit/a66592d763bff6da755495e18d1f1dc68508c44e) gimpPlugins.fourier: fix build on clang
* [`60c52309`](https://github.com/NixOS/nixpkgs/commit/60c52309689d7a9260035b66e7a7f29f2b92880e) nixosTests.installer: increase the VM memory
* [`09b01aa4`](https://github.com/NixOS/nixpkgs/commit/09b01aa435a5214376d71a787717c07bed60ed4c) vector: 0.17.3 -> 0.18.0 ([nixos/nixpkgs⁠#146523](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/146523))
* [`8886aa29`](https://github.com/NixOS/nixpkgs/commit/8886aa29fa0c359964d8644ab572509921725263) oil: 0.9.3 -> 0.9.4
* [`1ee4cb8d`](https://github.com/NixOS/nixpkgs/commit/1ee4cb8d9341d52d36e0fb954f69e7669d1f8e8c) sage: patch test so that new pari warning doesn't cause failures ([nixos/nixpkgs⁠#4](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/4))
* [`d1c3a49f`](https://github.com/NixOS/nixpkgs/commit/d1c3a49fdd110aee082467af8e9ae8213613971e) vmTools: set msize to 16KiB temporarily
* [`31b38fd9`](https://github.com/NixOS/nixpkgs/commit/31b38fd938038c63e0623dba0d6a7eccc7bd39ed) cdpr: fix build on darwin
* [`e12d98f2`](https://github.com/NixOS/nixpkgs/commit/e12d98f2db31dd2245be168254c566a99ac88432) super-slicer-latest: renamed from super-slicer-staging
* [`08b402b7`](https://github.com/NixOS/nixpkgs/commit/08b402b70e3d84d089f3de7221423790afd6a06a) libretro: enableParalellBuilding, except for older MAMEs
* [`a907da6e`](https://github.com/NixOS/nixpkgs/commit/a907da6e638c8654bface8a4f5aeec2776668c8c) libasyncns: fix build for darwin
* [`2077956e`](https://github.com/NixOS/nixpkgs/commit/2077956e7813fcc57f45d07a4b46715d0cd592ce) nixos/network-interfaces: add a warning for underscores in hostname
* [`15f425ae`](https://github.com/NixOS/nixpkgs/commit/15f425ae9c25aacea6dfd3754e9a0f7e803524ac) python3Packages.libasyncns: fix build for darwin
* [`34a7ce11`](https://github.com/NixOS/nixpkgs/commit/34a7ce11562b146b57bf68083f322c370a06c1b1) python3Packages.libasyncns: add pythonImportsCheck
* [`42133e84`](https://github.com/NixOS/nixpkgs/commit/42133e84517a8aef0de2788160055494284a0447) python3Packages.python-crontab: skip test test_03_usage
* [`8afc4e54`](https://github.com/NixOS/nixpkgs/commit/8afc4e543663ca0a6a4f496262cd05233737e732) pythonPackages.termplotlib: fix build
* [`24aacf38`](https://github.com/NixOS/nixpkgs/commit/24aacf38082fac4de98d4bc2275ae3db38d273aa) nilfs-utils: fix hardcoded paths
* [`e9de71cc`](https://github.com/NixOS/nixpkgs/commit/e9de71cc5d0f6755987c93705cf21e69197540bb) darwin: stop using gccStdenv when stdenv works fine
* [`2175b157`](https://github.com/NixOS/nixpkgs/commit/2175b157acf1fd338021bc162ec7c4d6d7f90306) treewide: refactor isi686 && isx86_64 -> isx86
* [`3a98364c`](https://github.com/NixOS/nixpkgs/commit/3a98364c4b8741ca40e0af5597f44e6e12e9922b) purenix: add to top-level packages
* [`255c2849`](https://github.com/NixOS/nixpkgs/commit/255c2849248e331d7f0e56a041b80e0014a19177) czkawka: 0.3.2 -> 0.3.3 ([nixos/nixpkgs⁠#146757](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/146757))
* [`c2409db9`](https://github.com/NixOS/nixpkgs/commit/c2409db926de4b7435e14e8366e8d08b0f69fd12) firefox: remove unnecessary make flags and LD_FLAGS
* [`8d4bef71`](https://github.com/NixOS/nixpkgs/commit/8d4bef7124cfab618d25113ef22d0852b0e33387) firefox: enable separated debug symbols
* [`a343380d`](https://github.com/NixOS/nixpkgs/commit/a343380d9dca9305951fe4eca8b58745b4bb3f97) firefox: enable cross-language LTO
* [`8a2be272`](https://github.com/NixOS/nixpkgs/commit/8a2be27251d9a36c7cbdb684d97c07e481d2c5f4) firefox: disable jemalloc by default to fix crash
* [`fe15c4fd`](https://github.com/NixOS/nixpkgs/commit/fe15c4fd239b0c355119aaa6e99c7af93986170f) kopia: 0.9.5 -> 0.9.6
* [`6ba916f5`](https://github.com/NixOS/nixpkgs/commit/6ba916f5ad7c5634cf2692a996938c644ec72a85) python3Packages.qcs-api-client: 0.19.0 -> 0.20.0
* [`4afcb8d1`](https://github.com/NixOS/nixpkgs/commit/4afcb8d1e8f4bcb24834dffae50ab6d502a73cb2) python3Packages.pyvesync: 1.4.1 -> 1.4.2
* [`32478d22`](https://github.com/NixOS/nixpkgs/commit/32478d226dc47c9984464f57c4c3062421789e14) python3Packages.env-canada: 0.5.16 -> 0.5.17
* [`4f53f0d9`](https://github.com/NixOS/nixpkgs/commit/4f53f0d9c5cc73d8a6f6d941e357b630b0460355) python3Packages.pyopenuv: 2021.10.0 -> 2021.11.0
* [`b1b274bb`](https://github.com/NixOS/nixpkgs/commit/b1b274bb9f54efe4e1cff5c964f6af94538e93eb) python3Packages.pyiqvia: 2021.10.0 -> 2021.11.0
* [`34802d57`](https://github.com/NixOS/nixpkgs/commit/34802d57bdc640b240bbd231a58d5429d00f4aba) python3Packages.aiopvpc: 2.2.2 -> 2.2.4
* [`ff6d13cd`](https://github.com/NixOS/nixpkgs/commit/ff6d13cdad94b08d5ddb7765c34310716f5b6422) rippled: 1.7.0 -> 1.7.3
* [`130ef76c`](https://github.com/NixOS/nixpkgs/commit/130ef76ca7a286dbd8fa0aba50e592299357f96b) python3Packages.uamqp: 1.4.1 -> 1.4.3
* [`0ecb09b2`](https://github.com/NixOS/nixpkgs/commit/0ecb09b2a3c8edade3aa186ad907b6e0468bc107) python3Packages.azure-eventhub: 5.6.0 -> 5.6.1
* [`f1e8640c`](https://github.com/NixOS/nixpkgs/commit/f1e8640c5482f39b90864eadedab20c3f4b075c6) libisl: Make derivations generic, add 0.24 ([nixos/nixpkgs⁠#146693](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/146693))
* [`6f2adb82`](https://github.com/NixOS/nixpkgs/commit/6f2adb82875db4346a7a4400422f2e609f991eb8) python3Packages.azure-servicebus: 7.3.3 -> 7.4.0
* [`28aae759`](https://github.com/NixOS/nixpkgs/commit/28aae75929bb2a04a3e789052cb8128c91dfc6bf) python3Packages.casbin: 1.9.7 -> 1.11.1
* [`ea6fb1e2`](https://github.com/NixOS/nixpkgs/commit/ea6fb1e297fcee773e3cf3c8a833c2964e3564e1) gwtdragdrop: remove builder.sh
* [`512fadbc`](https://github.com/NixOS/nixpkgs/commit/512fadbc6410660737da7a4977445005e6bdb151) gwtwidgets: remove builder.sh
* [`92322a1a`](https://github.com/NixOS/nixpkgs/commit/92322a1a6570cd153769a868d82d7afc87c6d69d) invoice2data: 0.2.93 -> 0.3.6
* [`82ccc7f1`](https://github.com/NixOS/nixpkgs/commit/82ccc7f17b5f70c36568918c386992fa4706faff) libgphoto2: fix cross
* [`858f0e8e`](https://github.com/NixOS/nixpkgs/commit/858f0e8ed9ac9b00d03feccb5fb564bf6b75e27a) python3.pkgs.keyutils: fix cross
* [`f508ae88`](https://github.com/NixOS/nixpkgs/commit/f508ae889415b51263ea1c20b6b4c0e0ecbfc0bd) mirrors: add kernel.org mirrors where appropriate
* [`46c3452a`](https://github.com/NixOS/nixpkgs/commit/46c3452a16a030c20cf2f842ee3820cf6bebd0a3) python3Packages.pyahocorasick: fix build on Hydra (x86_64-darwin)
* [`09a54b14`](https://github.com/NixOS/nixpkgs/commit/09a54b14cd1abb87c7f9e5357cd0030f9d8aefda) fluent-bit: fix build on darwin
* [`996f991b`](https://github.com/NixOS/nixpkgs/commit/996f991b5deed60fc613e2d62b414c96335127d8) icingaweb2-ipl: 0.6.1 -> 0.7.0
* [`05bbe40f`](https://github.com/NixOS/nixpkgs/commit/05bbe40f68313e08486151d014dc99e037924c56) cingaweb2: 2.9.3 -> 2.9.4
* [`ccfc3b0f`](https://github.com/NixOS/nixpkgs/commit/ccfc3b0f411c67e5afb4e93c00b1da9519cfe788) checkov: 2.0.591 -> 2.0.594
* [`fb93af82`](https://github.com/NixOS/nixpkgs/commit/fb93af82cc08df7b0641e26b524bd8e7b814087a) cernlib: binutils 2.37 fix
* [`54ece050`](https://github.com/NixOS/nixpkgs/commit/54ece050b8ff6ce12a665832b2c83bfd925ce8a3) nixos/qemu-vm: default memorySize 384 -> 1024
* [`194310ce`](https://github.com/NixOS/nixpkgs/commit/194310ce7c48962be2ebf662e0cf1752db135bd8) _2048-in-terminal: 2017-11-29 -> 2021-09-12
* [`4459b353`](https://github.com/NixOS/nixpkgs/commit/4459b35304dfb86626778a1118a485a2be2d73ed) mpv: set meta.mainProgram
* [`a99b6112`](https://github.com/NixOS/nixpkgs/commit/a99b61127e8e370b49dc872fc40b6a7aa9120c4f) arj: fix build on darwin
* [`625150b2`](https://github.com/NixOS/nixpkgs/commit/625150b22d9cb55a3d0ad9b0e0a9d953093f5745) reproxy: 0.9.0 → 0.11.0
* [`7640f6e6`](https://github.com/NixOS/nixpkgs/commit/7640f6e678cec99f4a5bf22015ba0651581e352e) callaudiod: support cross-compilation, enable strictDeps
* [`0c593779`](https://github.com/NixOS/nixpkgs/commit/0c59377977dd7b11e9752cf6ac873d0d70137e11) python3Packages.sense-energy: 0.9.2 -> 0.9.3
* [`339974e1`](https://github.com/NixOS/nixpkgs/commit/339974e1a868527b88928de5784f1ee95f284853) libite: set platforms to linux + netbsd
* [`849e45fe`](https://github.com/NixOS/nixpkgs/commit/849e45fe7ae4d426deba3bfde6df7416b43f7fc5) python3Packages.oath: 1.4.3 -> 1.4.4
* [`cde18dcb`](https://github.com/NixOS/nixpkgs/commit/cde18dcb924b80cc2c01a27133f0fc035827a4ac) python3Packages.oath: switch to pytestCheckHook
* [`279ef8ed`](https://github.com/NixOS/nixpkgs/commit/279ef8ed7eea250a1727c0c4a56f01aad786882c) libtsm: set platforms to linux only
* [`0241bd3d`](https://github.com/NixOS/nixpkgs/commit/0241bd3d64f9fc757514b0d4c5b43ef8fc0c5e82) libqb: fix build on darwin
* [`bb898727`](https://github.com/NixOS/nixpkgs/commit/bb898727ec1a11be1d8544602a8a0331850a205a) hdr-plus: fix build on darwin
* [`c4ecae1b`](https://github.com/NixOS/nixpkgs/commit/c4ecae1bd4743d0f33e86188be8d029356bffbe1) jami-*: 20211005.2.251ac7d -> 20211104.2.e80361d
* [`8996f6a2`](https://github.com/NixOS/nixpkgs/commit/8996f6a2bca508f1d31dd6f7ceaa17f68ccd6f68) ctl: fix build on darwin
* [`87ae243d`](https://github.com/NixOS/nixpkgs/commit/87ae243d2e51263865e6a94778928c66f08bd254) picom-next: unstable-2021-10-31 -> unstable-2021-11-19
* [`5beb83e0`](https://github.com/NixOS/nixpkgs/commit/5beb83e061f9ebb0392cd681d29c6bf495b92d22) tor-browser-bundle-bin: enable pulseaudio by default
* [`b8d69b12`](https://github.com/NixOS/nixpkgs/commit/b8d69b120d8ef5e8f0d44c67b3d594de435456eb) mame: 0.226 -> 0.237
* [`984f0f29`](https://github.com/NixOS/nixpkgs/commit/984f0f29fdcbd7845655ce41ee9a97f2359c5c9a) maintainers: add shikanime
* [`e156e78d`](https://github.com/NixOS/nixpkgs/commit/e156e78d4b78c3f31ad032f77b84464771b7fca4) droopy: Fix Python 3.9 compatiblity ([nixos/nixpkgs⁠#145702](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/145702))
* [`2a997524`](https://github.com/NixOS/nixpkgs/commit/2a99752451956fb7cd2a323c3e16fd4f4e499521) nordic: unstable-2021-08-13 -> unstable-2021-11-19
* [`ef9bcf24`](https://github.com/NixOS/nixpkgs/commit/ef9bcf24ca2ee5c6d348b1b95c3a8d59aba33490) bitcoin-knots: 0.20.0.knots20200614 -> 22.0.knots20211108
* [`783dbd1b`](https://github.com/NixOS/nixpkgs/commit/783dbd1ba87c1f5e8624c140f0c7d1f0f0cdc182) bitcoin: fix tests on darwin by using en_US.UTF-8 instead of C.UTF-8
* [`427941d7`](https://github.com/NixOS/nixpkgs/commit/427941d7377ff2762305f36479fb4365ad2abe68) nixos/clickhouse: add package option
* [`faadbddc`](https://github.com/NixOS/nixpkgs/commit/faadbddcd7af99f908c9111c6612e90dae1c201e) clickhouse: Add passthru.tests
* [`0eddc870`](https://github.com/NixOS/nixpkgs/commit/0eddc8707d102af771defea92efaaf50a20f875a) grafana: 8.2.4 -> 8.2.5
* [`de5ed818`](https://github.com/NixOS/nixpkgs/commit/de5ed8189b421190e407c83626f3e06802324604) qmk-dotty-dict: add longDescription
* [`d3a670eb`](https://github.com/NixOS/nixpkgs/commit/d3a670eb7ebbdbd5728a6adcfe451aaea271b57f) qmk: cosmetic cleanups
* [`fdd35e77`](https://github.com/NixOS/nixpkgs/commit/fdd35e7715c556b995e8615f73efd2f166cdfe16) vdr-vaapidevice: Fix libva-x11
* [`03e8e584`](https://github.com/NixOS/nixpkgs/commit/03e8e5848be209ddffa968ebe9de4dafb76bbf4e) nixos/tests/installer: increase memorySize to 3G
* [`68f226ae`](https://github.com/NixOS/nixpkgs/commit/68f226aedb66f1be56ea48d929cd356fb4aa6904) jwt-cli: 4.0.0 -> 5.0.0
* [`87d20e35`](https://github.com/NixOS/nixpkgs/commit/87d20e352ff27c4a0fed11d30f437495baa13c1a) cernlib: fix for gfortran10
* [`5421e153`](https://github.com/NixOS/nixpkgs/commit/5421e153c1cd2b84f5f97d88b0ce33df679eb681) ddosify: 0.5.1 -> 0.6.0
* [`9c8ce83e`](https://github.com/NixOS/nixpkgs/commit/9c8ce83ecb898f68dc72934af404b3da971a9f91) python3Packages.cozy: rename dependency python-igraph -> igraph
* [`7e037d3b`](https://github.com/NixOS/nixpkgs/commit/7e037d3b386d72a75d753ffd8e18af57cae4bf36) python3Packages.cozy: format default.nix
* [`652d17ec`](https://github.com/NixOS/nixpkgs/commit/652d17ec7823e81baaebf07abf2939f10919740d) discord: remove double systemd dependency
* [`36a37f7a`](https://github.com/NixOS/nixpkgs/commit/36a37f7a8f4498b33788729aed10b13b8d6ceb47) rtaudio: 5.1.0 -> 5.2.0
* [`82a8f891`](https://github.com/NixOS/nixpkgs/commit/82a8f891ed2a63f95ef5c86be298ac95ae3beedd) dendrite: 0.5.0 -> 0.5.1
* [`09454d0f`](https://github.com/NixOS/nixpkgs/commit/09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b) parquet-tools: init at 0.2.9 ([nixos/nixpkgs⁠#142562](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142562))
