### PR TITLE
niv home-manager: update a7c5b00d -> c4c761ba

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7c5b00d44f65efd1e8ace2c02243f179e72283a",
-        "sha256": "17hziylq4nbg95cm30kmwhwhw8xvabka48xgviidvw4wxli3wc0k",
+        "rev": "c4c761ba554bc674b0d5a89eb7e9f7a488a8859d",
+        "sha256": "06ndnrcxhpngkzlqhiy3phas245al7macwpjb3jfrfar87xa9k93",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a7c5b00d44f65efd1e8ace2c02243f179e72283a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c4c761ba554bc674b0d5a89eb7e9f7a488a8859d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a7c5b00d...c4c761ba](https://github.com/nix-community/home-manager/compare/a7c5b00d44f65efd1e8ace2c02243f179e72283a...c4c761ba554bc674b0d5a89eb7e9f7a488a8859d)

* [`05a31160`](https://github.com/nix-community/home-manager/commit/05a31160913d2ae91b7e71d5ced12416d2049d24) offlineimap: Fix for OfflineIMAP 8 ([nix-community/home-manager⁠#2479](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2479))
* [`42915b78`](https://github.com/nix-community/home-manager/commit/42915b78af4a6c9e07a3ae412ff3a494a1fc98d5) lieer: use configured package in service ([nix-community/home-manager⁠#2480](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2480))
* [`5559ef00`](https://github.com/nix-community/home-manager/commit/5559ef002306dde0093f3d329725259cada9ed41) ssh: add includes option ([nix-community/home-manager⁠#2453](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2453))
* [`d85bf67c`](https://github.com/nix-community/home-manager/commit/d85bf67c48f5c64ca39d3d48375e742e16933f4f) pet: fix settings format issue
* [`2452979e`](https://github.com/nix-community/home-manager/commit/2452979efe92128b03e3c27567267066c2825fab) docs: bump nmd
* [`398c0b36`](https://github.com/nix-community/home-manager/commit/398c0b36a3d8f7285db938468f46e82cf1a3d746) home-manager: properly forward exit codes
* [`8230decb`](https://github.com/nix-community/home-manager/commit/8230decb3f0cb3408607accc93e5d0951ebf3963) home-environment: make `home.profileDirectory` public
* [`8a16d62e`](https://github.com/nix-community/home-manager/commit/8a16d62e953a3bd16f1c5c9538bb9099c52de1e6) flameshot: extend module with package-option
* [`a19f40d3`](https://github.com/nix-community/home-manager/commit/a19f40d39dfedb9158c29566169f49c6b80a8865) firefox: fix test case
* [`c82bc787`](https://github.com/nix-community/home-manager/commit/c82bc787b8990c89f2f7d57df652ce2424129b92) xdg: fix typo and add test
* [`1abd311e`](https://github.com/nix-community/home-manager/commit/1abd311eef125e7b64dff723f198d15e5aca2dd4) fnott: add polykernel as maintainer
* [`15ae861e`](https://github.com/nix-community/home-manager/commit/15ae861e1bfad90e0d14106551544e9e07cbcb10) swaynag: add module
* [`c2aa8314`](https://github.com/nix-community/home-manager/commit/c2aa831491cb8ca1481bdf13a8ff3dd6b1ecc830) systemd: do not install systemd files when user is root ([nix-community/home-manager⁠#2454](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2454))
* [`c4c761ba`](https://github.com/nix-community/home-manager/commit/c4c761ba554bc674b0d5a89eb7e9f7a488a8859d) add flake attribute apps to make it easier to run ([nix-community/home-manager⁠#2442](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2442))
