### PR TITLE
niv spacemacs: update 1a4912e5 -> 050221ee

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "1a4912e51fdc012ba571c670e8c8e8c5eb4695d1",
-        "sha256": "1hiwxpkpsmk5fxz9byi67169slqsnqhl6qq5nnzn1k65lw3sqsqv",
+        "rev": "050221ee35a7dd3f73457a94b192199f57de24b2",
+        "sha256": "0p0ry2lvs961wq3x0ca3y402v2qzkn687624z2k6n9nz9f7i3203",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/1a4912e51fdc012ba571c670e8c8e8c5eb4695d1.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/050221ee35a7dd3f73457a94b192199f57de24b2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@1a4912e5...050221ee](https://github.com/syl20bnr/spacemacs/compare/1a4912e51fdc012ba571c670e8c8e8c5eb4695d1...050221ee35a7dd3f73457a94b192199f57de24b2)

* [`415f3675`](https://github.com/syl20bnr/spacemacs/commit/415f367589be8f41b0610b3890d3d1f6a16c0383) [scala] Shortcut keys for common/standard SBT commands
* [`dafae5f1`](https://github.com/syl20bnr/spacemacs/commit/dafae5f136a6056c87ad0dbe4355cfad43c148d3) [compleseus] improve ([syl20bnr/spacemacs⁠#15165](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15165))
* [`1c48cc5a`](https://github.com/syl20bnr/spacemacs/commit/1c48cc5a5a90de6e3f272025de177938bc877f59) [ivy] add mark unmark bindings
* [`f61a7cd4`](https://github.com/syl20bnr/spacemacs/commit/f61a7cd453648299468992ed3f4a04a38d3eaf7f) Add a keybinding for lsp-treemacs-type-hierarchy ([syl20bnr/spacemacs⁠#15163](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15163))
* [`f06fb38a`](https://github.com/syl20bnr/spacemacs/commit/f06fb38a8ff0ad4ded208751ddac6667cf07ca60) [bot] "documentation_updates" Thu Nov 18 05:35:20 UTC 2021
* [`dee70b84`](https://github.com/syl20bnr/spacemacs/commit/dee70b8486ec8e11a3a620f7da359da79efe56b2) Fix forge evil keybinds ([syl20bnr/spacemacs⁠#15167](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15167))
* [`b108f8b3`](https://github.com/syl20bnr/spacemacs/commit/b108f8b3195a537b234ba65d196b29abc3ec552c) Add binding for markdown-table-align
* [`f2755533`](https://github.com/syl20bnr/spacemacs/commit/f2755533deef68cb2fb2a2d40e6a5ab6ede13204) Fix [syl20bnr/spacemacs⁠#15169](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15169), snippets not loading correctly
* [`050221ee`](https://github.com/syl20bnr/spacemacs/commit/050221ee35a7dd3f73457a94b192199f57de24b2) [gnus] Fix wrong evilified macro
