### PR TITLE
niv nixpkgs: update 09454d0f -> f91c2cfa

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b",
-        "sha256": "1sl10xjy91kx3i2al76kgk85q8mlxaw23dnnrfyswx2pjsiqln6p",
+        "rev": "f91c2cfab7dbd8b4d74fdd4843cb25f71c41d942",
+        "sha256": "1rxjnf8qmx2n6d1l94b8zmp54d92qmyr9rcp8phvfx9ln9gsdxbd",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f91c2cfab7dbd8b4d74fdd4843cb25f71c41d942.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@09454d0f...f91c2cfa](https://github.com/nixos/nixpkgs/compare/09454d0f4a23f79d884de9d6ff0d3dfe5ea1e97b...f91c2cfab7dbd8b4d74fdd4843cb25f71c41d942)

* [`9327db35`](https://github.com/NixOS/nixpkgs/commit/9327db355462f78f7c85fe8d40851ebea8266c2f) python3Packages.tensorflowWithCuda: upgrade cuda to recommended 11.2 to fix runtime warning
* [`621f57ba`](https://github.com/NixOS/nixpkgs/commit/621f57ba6fa1efbb1785430c5919235ed67d3972) skopeo: 1.5.1 -> 1.5.2
* [`d07a9427`](https://github.com/NixOS/nixpkgs/commit/d07a9427f4303fda1a5229611391fc401e99d182) python3Packages.wiffi: 1.0.1 -> 1.1.0
* [`65f8d1a0`](https://github.com/NixOS/nixpkgs/commit/65f8d1a0590e8b2a983c3cff332f7049ef533658) tfsec: 0.60.1 -> 0.61.0
* [`ab211d13`](https://github.com/NixOS/nixpkgs/commit/ab211d1343bf083c21b8929098187fd865ee3409) python3Packages.frigidaire: 0.17 -> 0.18.3
* [`85585e9d`](https://github.com/NixOS/nixpkgs/commit/85585e9d13c9e729ecb453b26bc2426aaab17aed) python3Packages.potentials: add missing dependencies
* [`7287bf05`](https://github.com/NixOS/nixpkgs/commit/7287bf05aa441bba567cb2a98dc1987f2b8e79e0) openmpi: 4.1.1 -> 4.1.2
* [`6116670d`](https://github.com/NixOS/nixpkgs/commit/6116670dcb9b7d57a30acc29fe81774066af253b) fd: 8.2.1 -> 8.3.0
* [`51ab665a`](https://github.com/NixOS/nixpkgs/commit/51ab665ad7d29ace29dd1b3702fa2a44d48e4e56) zydis: 3.2.0 -> 3.2.1
* [`bf730c8e`](https://github.com/NixOS/nixpkgs/commit/bf730c8e2f53e3dcd40e6a19f105cd16594832e5) tsung: use Python 3
* [`e71b01a8`](https://github.com/NixOS/nixpkgs/commit/e71b01a8fc34a2c3e3b67d354cb991c4ee9095cb) python3Packages.py17track: relax async_timeout constraint
* [`f6d5c5fe`](https://github.com/NixOS/nixpkgs/commit/f6d5c5fe01bf57a9ac82946bdd9250b6cab1e136) shfmt: 3.4.0 -> 3.4.1
* [`d08d54ce`](https://github.com/NixOS/nixpkgs/commit/d08d54ced891825f0f42845c4d5bbffc3281f66a) python3Packages.pep8-naming: add patch to fix tests
* [`82e26e09`](https://github.com/NixOS/nixpkgs/commit/82e26e0974a5541d3592cc446ee2d300c0291791) python3Packages.pylint-django: disable failing tests
* [`8959f7b2`](https://github.com/NixOS/nixpkgs/commit/8959f7b2110972fce5f5025517399f7297dad040) python3Packages.flake8-polyfill: disable failing tests
* [`ee74e654`](https://github.com/NixOS/nixpkgs/commit/ee74e6547d318cea196eefe497cf78fb6339ca8e) electron_16: 16.0.1 -> 16.0.2
* [`0dd351d4`](https://github.com/NixOS/nixpkgs/commit/0dd351d423a56e796e2ed758364f112c39c896de) trezor-suite: 21.10.2 -> 21.11.2
* [`70307e16`](https://github.com/NixOS/nixpkgs/commit/70307e16745959c52fc6889ae546f1e4887e16ee) lima: 0.7.3 -> 0.7.4
* [`479cf400`](https://github.com/NixOS/nixpkgs/commit/479cf4005bed53098cf41bcee840e33fd06538b1) nodePackages.gramma: init at 1.6.0
* [`595543a3`](https://github.com/NixOS/nixpkgs/commit/595543a3149b64a809da8fb4fdabbd6800d29ad4) tests: Verify /etc/pam.d/chfn file contents
* [`32f21eef`](https://github.com/NixOS/nixpkgs/commit/32f21eefab39537224743b664a03800d0c566ba7) git-review: 2.1.0 → 2.2.0
* [`7944324d`](https://github.com/NixOS/nixpkgs/commit/7944324d80d50bdfa7649598db6a06f0620cd9bb) programmer-calculator: 2.1 -> 2.2
* [`f9da65f6`](https://github.com/NixOS/nixpkgs/commit/f9da65f6703b982c2c4710804186431fb1b147e7) python39Packages.guessit: 3.3.1 -> 3.4.3
* [`abcbdc61`](https://github.com/NixOS/nixpkgs/commit/abcbdc61e4c1e8f418d9225708fdd7beb9ad2343) gallery-dl: 1.19.2 -> 1.19.3
* [`836866f9`](https://github.com/NixOS/nixpkgs/commit/836866f9f4b70fdfb56177b9eae01e8746b07bff) flexget: 3.1.153 -> 3.2.1
* [`92cc9524`](https://github.com/NixOS/nixpkgs/commit/92cc9524c0f0255d660fd2b4f6f982a6192a8b55) recursive: 1.082 -> 1.084
* [`ab8482e1`](https://github.com/NixOS/nixpkgs/commit/ab8482e19356669c5b989a2241cacbb3fb797792) fstar: 2021.10.16 -> 2021.11.27
* [`14e055c4`](https://github.com/NixOS/nixpkgs/commit/14e055c454689084a352f9a5b07f2e41f23541e7) wtf: 0.39.2 -> 0.40.0
* [`006f1f79`](https://github.com/NixOS/nixpkgs/commit/006f1f795d4c612ebe7db7f11d1c92f9467e0b8d) sudo-font: 0.60 -> 0.61
* [`84730c9f`](https://github.com/NixOS/nixpkgs/commit/84730c9f5de7a14ff0a951541e4ec84233df393b) janus-gateway: fix build
* [`ed3cfc8a`](https://github.com/NixOS/nixpkgs/commit/ed3cfc8abe467110ded21593f8695ebb3e392087) invidious/lsquic: fix build
* [`f104c143`](https://github.com/NixOS/nixpkgs/commit/f104c1434bb9458da9b49c0c9a7066c8e3d967c3) tinyscheme: add aarch64-darwin to badplatforms
* [`7ae23b2f`](https://github.com/NixOS/nixpkgs/commit/7ae23b2ffc159bcc295c62ba89c89a1db94d39cc) gdu: 5.10.1 -> 5.11.0
* [`6d808dfb`](https://github.com/NixOS/nixpkgs/commit/6d808dfbaec8d1ad324a6fbc650cb43aa4b134ff) python3Packages.aiopulse: 0.4.2 -> 0.4.3
* [`6daa24a1`](https://github.com/NixOS/nixpkgs/commit/6daa24a1c7059e7a940e164320419ca1fea82315) python3Packages.fpyutils: 2.0.1 -> 2.1.0
* [`90be2bed`](https://github.com/NixOS/nixpkgs/commit/90be2bed3905b147f0ac8822c20ecd75c34ce570) metasploit: 6.1.15 -> 6.1.16
* [`4982ca6e`](https://github.com/NixOS/nixpkgs/commit/4982ca6e67ee2083589e5cafb45cb0efa173d955) tut: 0.0.36 -> 0.0.41
* [`d5d4aa22`](https://github.com/NixOS/nixpkgs/commit/d5d4aa223705a26ad600dfe9c0702c33346182c0) python3Packages.boschshcpy: 0.2.23 -> 0.2.24
* [`b8fceba8`](https://github.com/NixOS/nixpkgs/commit/b8fceba81305d0cf3a36e8fbc91e34f363ee8c60) python3Packages.md-toc: relax fpyutils constraint
* [`73b3f81d`](https://github.com/NixOS/nixpkgs/commit/73b3f81d96f266d4acab6bf96a77e5f68558d1cf) zydis: add myself as maintainer
* [`c249f14b`](https://github.com/NixOS/nixpkgs/commit/c249f14bf8249246eacf342225996903acf5e1ef) wireshark: add wrapGAppsHook fixing open/save GUI
* [`17b8b5a4`](https://github.com/NixOS/nixpkgs/commit/17b8b5a4dc5a49d83d508cb66c6ac2f0bb9fa39b) haskell.compiler.*: pass runtime dependencies via configure script
* [`d20dc696`](https://github.com/NixOS/nixpkgs/commit/d20dc696648e8c389150fb104043cf21b1c75bd8) residualvm: remove
* [`33c8bc71`](https://github.com/NixOS/nixpkgs/commit/33c8bc71868a04e0ce91ab5f7bbba85f8fef9bae) polylith: 0.2.12-alpha -> 0.2.13-alpha
* [`de31473c`](https://github.com/NixOS/nixpkgs/commit/de31473c422e4ae7d2386319ba3e1d3039546d48) losslessaudiochecker: init at 2.0.5
* [`1cfecb63`](https://github.com/NixOS/nixpkgs/commit/1cfecb636b14a88174d914cd0522b78ff3bf9f82) Revert "Merge pull request [nixos/nixpkgs⁠#141192](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/141192) from helsinki-systems/feat/improved-socket-handling2"
* [`a38fd4fa`](https://github.com/NixOS/nixpkgs/commit/a38fd4faef054319c5903601e6a4e5f0032236b3) exploitdb: 2021-11-25 -> 2021-11-27
* [`b6d26384`](https://github.com/NixOS/nixpkgs/commit/b6d263844900415858e796382b473e3633cb9eaa) appgate-sdp: 5.4.2 -> 5.5.0
* [`a697c03e`](https://github.com/NixOS/nixpkgs/commit/a697c03e850600b95ba4a2518a9c609069a82974) cudatext: 1.148.0 → 1.150.0
* [`a84f06bb`](https://github.com/NixOS/nixpkgs/commit/a84f06bba158e141dbf9207ce3da32e6171522d2) python3Packages.flux-led: 0.24.25 -> 0.25.0
* [`609ab2cd`](https://github.com/NixOS/nixpkgs/commit/609ab2cdc478bf1147cf90ba49b2c20108342139) btop: 1.1.0 -> 1.1.2
* [`3b2e6e72`](https://github.com/NixOS/nixpkgs/commit/3b2e6e72faff6255230b17991eb545824b00630f) tests: Move all PAM tests into a separate directory
* [`dcb941f3`](https://github.com/NixOS/nixpkgs/commit/dcb941f3ede938c01b82ea6be4aa148eb479a413) security/pam: Document test location
* [`f622890f`](https://github.com/NixOS/nixpkgs/commit/f622890f9b8b1fd0b00e7381171c39ee882cfa6d) xonsh: 0.10.1 -> 0.11.0
* [`66236eeb`](https://github.com/NixOS/nixpkgs/commit/66236eeb4bb0c8ef1b61e4ffe2d829acbbd2ffaf) flam3: 3.1.1 -> 3.1.1+date=2018-04-12
* [`fc66ea69`](https://github.com/NixOS/nixpkgs/commit/fc66ea690a8eb88734af58cd1c533935dc9ec4f4) aaphoto: init at 0.43.1
* [`9440449a`](https://github.com/NixOS/nixpkgs/commit/9440449acbf32742850395c22345efe2e69ee322) aaphoto: set meta.broken to true in Darwin
* [`909df3fa`](https://github.com/NixOS/nixpkgs/commit/909df3fa25f094fbf81b4780e018e7bf86f201e0) delta: 0.10.1 -> 0.10.2
* [`8fb36866`](https://github.com/NixOS/nixpkgs/commit/8fb36866b8be4ebad0c160845774008a1d3f851d) octopus: 11.2 -> 11.3
* [`58f88a56`](https://github.com/NixOS/nixpkgs/commit/58f88a56c26ecb405d4332b0f0bc5ea96363b639) anytype: 0.21.1 -> 0.21.9
* [`4a48b34e`](https://github.com/NixOS/nixpkgs/commit/4a48b34ead2b9ecde64fb3d3421cc78f4a601793) python3Packages.jupyterhub-systemdspawner: install check-kernel.bash
* [`ade2d34d`](https://github.com/NixOS/nixpkgs/commit/ade2d34d4f965abd6acfa54dc10ee00a057a703b) pdns-recursor: 4.5.6 -> 4.5.7
* [`f07f124d`](https://github.com/NixOS/nixpkgs/commit/f07f124d3a1bf6e441a899410b65aa1b09902905) jing-trang: 20151127 -> 20181222
* [`1561c366`](https://github.com/NixOS/nixpkgs/commit/1561c366ab92246fc7f4e2e6b48b394e944c8703) libAfterImage: fix binutils-2.36 compatibility ([nixos/nixpkgs⁠#147617](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/147617))
* [`8d4f2c38`](https://github.com/NixOS/nixpkgs/commit/8d4f2c38168d8822584c255a4cccb5946aa85205) streamlink: 3.0.1 -> 3.0.3
* [`b3572654`](https://github.com/NixOS/nixpkgs/commit/b35726542e8cf68512e87fbd23eb22778f977f22) docbookrx: fix build
* [`ef62ecac`](https://github.com/NixOS/nixpkgs/commit/ef62ecac5f9d21990a97ed96e5f909e8efce60f8) mame: 0.237 -> 0.238
* [`40fb87f5`](https://github.com/NixOS/nixpkgs/commit/40fb87f5ca84fb7d5299041a9aa632410108f6e7) nixos/doc: Add note about big updates regarding hydrus to release notes
* [`0fff6b89`](https://github.com/NixOS/nixpkgs/commit/0fff6b89eac2a9bcf743dfaca7f0ee956a683be5) hydrus: 462 -> 463
* [`b930e3fe`](https://github.com/NixOS/nixpkgs/commit/b930e3fe52657cb58ebbf4fcb91030151fbd4f14) btrfs-snap: init at 1.7.3
* [`c192da17`](https://github.com/NixOS/nixpkgs/commit/c192da17cc4d87460664d72c1a845647d4b6e46b) nixUnstable: 2.5pre20211007 -> 2.5pre20211126
* [`95312f56`](https://github.com/NixOS/nixpkgs/commit/95312f56b5846503c5629b87df413f386b46a2ef) umap-learn: fix build
* [`182c8be4`](https://github.com/NixOS/nixpkgs/commit/182c8be43317221676de695fa76dd680e4bc7ee9) slicer: fix build
* [`51694b0a`](https://github.com/NixOS/nixpkgs/commit/51694b0af4e811dabac490b98eba588b06585cdd) root5: binutils 2.37 fix
* [`17c11a63`](https://github.com/NixOS/nixpkgs/commit/17c11a63a79c35bce93a7e263c05d14c8f460194) mkvtoolnix: 62.0.0 -> 63.0.0
* [`a537690d`](https://github.com/NixOS/nixpkgs/commit/a537690d30d5ace874fe9838c12ec82f28fc4473) Revert "wireshark: add wrapGAppsHook fixing open/save GUI"
* [`8874d307`](https://github.com/NixOS/nixpkgs/commit/8874d30775f0b1a5c6d58423f2ec36d20154c58f) dero: remove package ([nixos/nixpkgs⁠#147656](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/147656))
* [`0050284d`](https://github.com/NixOS/nixpkgs/commit/0050284daabd584054773f3a23f8b6254264e998) mbuffer: 20210328 -> 20211018
* [`9d80a436`](https://github.com/NixOS/nixpkgs/commit/9d80a43612af5e1a50bfab734aac0e5a88ad8e60) julia_16-bin: 1.6.3 -> 1.6.4
* [`97a3b2af`](https://github.com/NixOS/nixpkgs/commit/97a3b2af1dc0a781f6a5886b536628d374c65c4b) monero: rename to monero-cli
* [`27e1ecfd`](https://github.com/NixOS/nixpkgs/commit/27e1ecfde52607e9f4968d36bee22ac5a77427ed) cpufetch: 1.00 -> 1.01
* [`9a005535`](https://github.com/NixOS/nixpkgs/commit/9a005535faf25b19c46689f1d14111e1750d9fab) hwinfo: 21.76 -> 21.78
* [`8b88a195`](https://github.com/NixOS/nixpkgs/commit/8b88a195712f2a861e58cc8ccd9119d231b60bbd) getdata: 0.10.0 -> 0.11.0
* [`840af81e`](https://github.com/NixOS/nixpkgs/commit/840af81e55f4936be6cc3b58c7010ca1cd164745) storm: 2.2.0 -> 2.3.0
* [`b1005e8b`](https://github.com/NixOS/nixpkgs/commit/b1005e8b3d0fa1b95fc624b078b5db65b22ff0c9) pantheon.switchboard: remove clutter-gtk from buildInputs
* [`c0966f85`](https://github.com/NixOS/nixpkgs/commit/c0966f8571c17fceb93aef059ddbf321e5b0fefd) pantheon.elementary-code: remove zeitgeist from buildInputs
* [`5cfe3c4e`](https://github.com/NixOS/nixpkgs/commit/5cfe3c4e82118dd732ffb23c469b128ed8ee3283) gromacs: fix double precission build on aarch64
* [`3076b3d0`](https://github.com/NixOS/nixpkgs/commit/3076b3d087344ce250ec3f3ae0c554416357dd01) hashcat: 6.2.4 -> 6.2.5
* [`b1494f81`](https://github.com/NixOS/nixpkgs/commit/b1494f8182aa635a909fec930a3dc8c700ea89c9) cherrytree: 0.99.42 -> 0.99.43
* [`c80cb3ca`](https://github.com/NixOS/nixpkgs/commit/c80cb3ca818a47cdedbf0b75c8b5b6d9b9ff03a7) lispPackages: add cl-shellwords
* [`9991cd36`](https://github.com/NixOS/nixpkgs/commit/9991cd362517e23115796c124fbefe9f09f9ecbf) python3Packages.flux-led: 0.25.0 -> 0.25.1
* [`a59add84`](https://github.com/NixOS/nixpkgs/commit/a59add846d7785ec13622c7856bc5e4f0d521866) python3Packages.crownstone-sse: 2.0.2 -> 2.0.3
* [`5a76214c`](https://github.com/NixOS/nixpkgs/commit/5a76214c5d2277a28fe15a18f3e95cf89fcd03e8) ocamlPackages.reactivedata: fix src hash
* [`8f1a52ac`](https://github.com/NixOS/nixpkgs/commit/8f1a52ac33fb9a441713261c35cecab7b5331512) haskell.compiler.*: disable useLLVM also for SPARC and PowerPC
* [`079827e8`](https://github.com/NixOS/nixpkgs/commit/079827e8c3cc5f0c1624edc105d17da258ae5f0d) todoist: 0.15.0 -> 0.16.0
* [`b9f6ee2e`](https://github.com/NixOS/nixpkgs/commit/b9f6ee2e2f1cde415b610619e154d6b452583460) pijul: 1.0.0-alpha.55 → 1.0.0-alpha.56
* [`1e3b8e3f`](https://github.com/NixOS/nixpkgs/commit/1e3b8e3fd835832864d8038d9d6bb906372a764e) python3Packages.pywal: use $TMPDIR in tests
* [`f6053b7c`](https://github.com/NixOS/nixpkgs/commit/f6053b7c826d4927e1d9460027b15281b8211d79) verifpal: 0.26.0 -> 0.26.1 ([nixos/nixpkgs⁠#143282](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/143282))
* [`6f05bc37`](https://github.com/NixOS/nixpkgs/commit/6f05bc3791cd7d27cdc376548df4ce05d9a4ce6d) libretro.pcsx2: init at unstable-2021-11-27
* [`7ff536ed`](https://github.com/NixOS/nixpkgs/commit/7ff536edd6a8fff222889229dce7d2673f0ab463) libretro: remove "-DCMAKE_BUILD_TYPE=Release"
* [`5c589d83`](https://github.com/NixOS/nixpkgs/commit/5c589d83edadc493b0c99a663f1433cf9c8f2b80) libretro: fix core platforms
* [`37af67a8`](https://github.com/NixOS/nixpkgs/commit/37af67a84a6210c65ce7e61efcad9bf96e3dbc50) rdma-core: 37.1 -> 38.0
* [`32067bb1`](https://github.com/NixOS/nixpkgs/commit/32067bb1597fdbf762a4b55c81e7788a5c2149cd) neard: fix build
* [`d18a44ab`](https://github.com/NixOS/nixpkgs/commit/d18a44ab6dff396fd3cdd439406933c3369cb2eb) ttyper: 0.3.0 -> 0.3.1
* [`d26a0b8d`](https://github.com/NixOS/nixpkgs/commit/d26a0b8d9f520fc3d8c19fcb6efb877587270024) cargo-sort: 1.0.5 -> 1.0.6
* [`cda6d383`](https://github.com/NixOS/nixpkgs/commit/cda6d383462cce9e5d6f1848480c3322c4dff92b) statix: 0.4.0 -> 0.4.1
* [`1c8513df`](https://github.com/NixOS/nixpkgs/commit/1c8513dfe4af5220d7a6d3c259471b502d2be84e) difftastic: 0.11.0 -> 0.12.0
* [`81fb8b76`](https://github.com/NixOS/nixpkgs/commit/81fb8b76317c509098fbcccf4f7ca086603f2201) pipe-rename: 1.4.0 -> 1.4.1
* [`0a9dd29c`](https://github.com/NixOS/nixpkgs/commit/0a9dd29c98c6dd720bfb9e5e6d8a3b551fc71d94) netatalk: fix build
* [`fdc128b1`](https://github.com/NixOS/nixpkgs/commit/fdc128b146fcc7a9c4f3bc50f1cf511abe184152) iterm2: 3.4.13 -> 3.4.14
* [`4aa2320e`](https://github.com/NixOS/nixpkgs/commit/4aa2320ec14b185e0a601b108c3d970f6bba22c8) vorta: 0.7.8 -> 0.8.2
* [`3eb5d85b`](https://github.com/NixOS/nixpkgs/commit/3eb5d85beb8f126def8dbf7b35035826bd7dd58f) .github/workflows/periodic-merge: configure 21.11 release
* [`e1486fee`](https://github.com/NixOS/nixpkgs/commit/e1486feead37cacbc9726fba9c20c4fbc28b2b37) maintainers: winterqt -> winter
