### PR TITLE
niv home-manager: update c4c761ba -> 9de77227

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c4c761ba554bc674b0d5a89eb7e9f7a488a8859d",
-        "sha256": "06ndnrcxhpngkzlqhiy3phas245al7macwpjb3jfrfar87xa9k93",
+        "rev": "9de77227d7780518cfeaee5a917970247f3ecc56",
+        "sha256": "0d9mddbndy6f7q3vmfmc563ncbi407l2v1i4f9ydqlm334qzfqb9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c4c761ba554bc674b0d5a89eb7e9f7a488a8859d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9de77227d7780518cfeaee5a917970247f3ecc56.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c4c761ba...9de77227](https://github.com/nix-community/home-manager/compare/c4c761ba554bc674b0d5a89eb7e9f7a488a8859d...9de77227d7780518cfeaee5a917970247f3ecc56)

* [`df931a59`](https://github.com/nix-community/home-manager/commit/df931a59a5864d6ff0c5d83598135816f8593647) taskwarrior: change config file location and use relative theme paths ([nix-community/home-manager⁠#2455](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2455))
* [`60937069`](https://github.com/nix-community/home-manager/commit/609370699f2dc90988f8a6881837c5092484e9c0) home-manager: do not build news when using flake ([nix-community/home-manager⁠#2501](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2501))
* [`e28185a2`](https://github.com/nix-community/home-manager/commit/e28185a2c062e7d77fd2a71678a75ce7a2eeb6fe) vscode: avoid unnecessary IFD ([nix-community/home-manager⁠#2506](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2506))
* [`81fc0c6f`](https://github.com/nix-community/home-manager/commit/81fc0c6fbfb2a94ee406fac824090e07aaf618de) tests: disable Nixpkgs release check
* [`18461b5d`](https://github.com/nix-community/home-manager/commit/18461b5dda5341828d66e5acce6ac2c08ba1be34) firefox: fix tests
* [`c27c8f49`](https://github.com/nix-community/home-manager/commit/c27c8f49c0bccaff91f5f637ad727d440b769997) taskwarrior: clean up news entry
* [`dc2a4e41`](https://github.com/nix-community/home-manager/commit/dc2a4e4146d1626bc6a916cb57c9e12be2399ca3) Switch to 21.11 as stable release
* [`2889ee23`](https://github.com/nix-community/home-manager/commit/2889ee23630d3e54bd20d0b6b45361b67533edc0) mpv: temporarily disable tests
* [`579f2e8b`](https://github.com/nix-community/home-manager/commit/579f2e8bebb954a103a96b905c27b10f15ef38c7) Switch to 22.05 as current development release
* [`ea1794a7`](https://github.com/nix-community/home-manager/commit/ea1794a798d60ac10b0354b811aea6fe652914a3) gpg: support declarative trust and public keys
* [`a28cf79a`](https://github.com/nix-community/home-manager/commit/a28cf79a78040b4e6d8d50a39760a296d5e95dd6) ci: bump cachix/install-nix-action from 15 to 16
* [`3ec7f6fb`](https://github.com/nix-community/home-manager/commit/3ec7f6fb43ff77cff429aba1a2541d28cc44d37c) rofi: fix theme definition in configuration for 1.7.0+ ([nix-community/home-manager⁠#2513](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2513))
* [`9de77227`](https://github.com/nix-community/home-manager/commit/9de77227d7780518cfeaee5a917970247f3ecc56) home-manager: fix home-manager build error ([nix-community/home-manager⁠#2514](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2514))
