### PR TITLE
niv spacemacs: update 050221ee -> 33e7f626

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "050221ee35a7dd3f73457a94b192199f57de24b2",
-        "sha256": "0p0ry2lvs961wq3x0ca3y402v2qzkn687624z2k6n9nz9f7i3203",
+        "rev": "33e7f62693baf1a3de87750bf95fd4d6795d190d",
+        "sha256": "1jb98yxcr6iqjrbyb3fx4dgsg9457gkmbn0q19vbiz3a1nnk2h07",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/050221ee35a7dd3f73457a94b192199f57de24b2.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/33e7f62693baf1a3de87750bf95fd4d6795d190d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@050221ee...33e7f626](https://github.com/syl20bnr/spacemacs/compare/050221ee35a7dd3f73457a94b192199f57de24b2...33e7f62693baf1a3de87750bf95fd4d6795d190d)

* [`23367d08`](https://github.com/syl20bnr/spacemacs/commit/23367d08f890873e77fd9a434c9332cf53d5f9df) Add temporary fix for `evil-redirect-digit-argument` error
* [`bdd77bfe`](https://github.com/syl20bnr/spacemacs/commit/bdd77bfed621e8c74182924cd00d8014a6cd9b0f) [version-control] Do not activate git-gutter-mode in pdf-view-mode
* [`33e7f626`](https://github.com/syl20bnr/spacemacs/commit/33e7f62693baf1a3de87750bf95fd4d6795d190d) Fix small typos ([syl20bnr/spacemacs⁠#15188](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15188))
