### PR TITLE
niv zsh-completions: update a1a11caf -> 536bd1d3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "a1a11caf4fae822a684c00d3c0687d8bed5ceb77",
-        "sha256": "01w2nxin5hbmclsznyz911chx2nc6msbcl3wib2ffsrpansg4n9r",
+        "rev": "536bd1d3d4480e99c2d0532f488eb547d073a66d",
+        "sha256": "0a9s25bvpq2klrsfzmz8jsbj8q480qviyfjb6hp2hk404vg3fss8",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/a1a11caf4fae822a684c00d3c0687d8bed5ceb77.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/536bd1d3d4480e99c2d0532f488eb547d073a66d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@a1a11caf...536bd1d3](https://github.com/zsh-users/zsh-completions/compare/a1a11caf4fae822a684c00d3c0687d8bed5ceb77...536bd1d3d4480e99c2d0532f488eb547d073a66d)

* [`b5de3d53`](https://github.com/zsh-users/zsh-completions/commit/b5de3d53e0b8066ddea38c5f32b34ddd4c265a60) knife: sync with oh-my-zsh
* [`da42a24a`](https://github.com/zsh-users/zsh-completions/commit/da42a24a07888ddf252e5ea9a869598ae135c626) knife: backport [zsh-users/zsh-completions⁠#531](http://r.duckduckgo.com/l/?uddg=https://github.com/zsh-users/zsh-completions/issues/531) and [zsh-users/zsh-completions⁠#131](http://r.duckduckgo.com/l/?uddg=https://github.com/zsh-users/zsh-completions/issues/131)
* [`392487b0`](https://github.com/zsh-users/zsh-completions/commit/392487b0fad01ba621b07ba11bd3f54ec32b1f55) knife: improve code quality
* [`1f5e5ff4`](https://github.com/zsh-users/zsh-completions/commit/1f5e5ff4715885b1e97f801fcf274e6868c7be59) knife: improve completion for Chef Vault commands
