### PR TITLE
niv nixpkgs: update f91c2cfa -> 564f54eb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f91c2cfab7dbd8b4d74fdd4843cb25f71c41d942",
-        "sha256": "1rxjnf8qmx2n6d1l94b8zmp54d92qmyr9rcp8phvfx9ln9gsdxbd",
+        "rev": "564f54ebd0c28866cd2df84829efec191c90a180",
+        "sha256": "1i17k3kk5wd0435q78wd6pyaam3ig4yyvl2wzy4zbm8ahjdl83j6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f91c2cfab7dbd8b4d74fdd4843cb25f71c41d942.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/564f54ebd0c28866cd2df84829efec191c90a180.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f91c2cfa...564f54eb](https://github.com/nixos/nixpkgs/compare/f91c2cfab7dbd8b4d74fdd4843cb25f71c41d942...564f54ebd0c28866cd2df84829efec191c90a180)

* [`11a5b0b8`](https://github.com/NixOS/nixpkgs/commit/11a5b0b895efcfa4b1ad4ee762caa2e0a0fc3e20) python3Packages.autopep8: 1.5.7 -> 1.6.0
* [`0e9bc9ff`](https://github.com/NixOS/nixpkgs/commit/0e9bc9ffd107c288571af4e3d4a9c2a6b64cf505) dockerTools: Add fakechroot to fakeRootCommands
* [`ddda5f28`](https://github.com/NixOS/nixpkgs/commit/ddda5f28e1f85e0f056996dbf2d2d7fa3718da0f) dockerTools: Keep fakechroot disabled by default
* [`2bf95bbc`](https://github.com/NixOS/nixpkgs/commit/2bf95bbc7c3288708a87e75bc4a826ba0c17f1a5) intel-media-driver: 21.4.2 -> 21.4.3
* [`d1916993`](https://github.com/NixOS/nixpkgs/commit/d1916993471b4e31ba593caf60f828d2edc2c0c2) terminal-typeracer: 2.0.4 -> 2.0.8
* [`3b3494ec`](https://github.com/NixOS/nixpkgs/commit/3b3494eca289a5e902e78f116fdd13c0a862ed52) tev: 1.17 -> 1.19
* [`16e55eac`](https://github.com/NixOS/nixpkgs/commit/16e55eac065d8db933a5b203fbf55f840b6823d4) tev: remove myself as maintainer
* [`9c1fc9a0`](https://github.com/NixOS/nixpkgs/commit/9c1fc9a0180dd5e9cd304f8d62c935513ab6eeb6) aerc: 0.5.2 -> 0.6.0
* [`d6a4500f`](https://github.com/NixOS/nixpkgs/commit/d6a4500f88725c24b82f6f86fb3129ed0561800c) nixos/ddclient: support all special characters in password
* [`67f102d8`](https://github.com/NixOS/nixpkgs/commit/67f102d8d8dee9cd12c082d013081cb296199e1f) nixos/knot: update systemd hardening
* [`893f7af2`](https://github.com/NixOS/nixpkgs/commit/893f7af236bf11fba03ef1c21b381d3ccc5df3f7) nixos/tests/knot: log systemd unit hardening info
* [`146ddee1`](https://github.com/NixOS/nixpkgs/commit/146ddee13b81cd096f0136ebf217947aab114ddc) nixos/tests/knot: add extra cpu core to master
* [`80f86077`](https://github.com/NixOS/nixpkgs/commit/80f8607721e9c211bae9dbcdb7bac584812b7bf6) xdot: needs graphviz in PATH
* [`e906657a`](https://github.com/NixOS/nixpkgs/commit/e906657a50edc800858dac355e32950cb6040616) ocenaudio: 3.10.6 -> 3.11.0
* [`810515f8`](https://github.com/NixOS/nixpkgs/commit/810515f8766eaefd61db358d54849c9d6cd76287) lilo: make sure scripts and manpages are installed properly
* [`1ff7318a`](https://github.com/NixOS/nixpkgs/commit/1ff7318a565cb531b8746bd575f24ceefb6b9ed4) trillian: 1.3.13 -> 1.4.0
* [`4481ef61`](https://github.com/NixOS/nixpkgs/commit/4481ef61e6a571fcbf6ecaa22fe0b5676f9d75f0) qradiolink: 0.8.5-2 -> 0.8.6-2
* [`4752689c`](https://github.com/NixOS/nixpkgs/commit/4752689cfb89d5945612fade8c8ac7430f083a2f) postgresqlPackages.pg_auto_failover: upstream fix for ncurses-6.3
* [`e9917d53`](https://github.com/NixOS/nixpkgs/commit/e9917d53cf17691bea8fc23f70487b3a4bbcdb28) gitlint: 0.16.0 -> 0.17.0
* [`4a0fbcbd`](https://github.com/NixOS/nixpkgs/commit/4a0fbcbd138ae1430df231fe134311a0ac62acf1) liboping: fix format arguments for printf()
* [`6cf2385f`](https://github.com/NixOS/nixpkgs/commit/6cf2385f15986231ad98708aea227a62274f3aff) wireshark: 3.4.9 -> 3.4.10
* [`d09271ab`](https://github.com/NixOS/nixpkgs/commit/d09271ab3517c3ce58de38b57150ecf77f941218) glitter: 1.5.9 -> 1.5.10
* [`8bf6b8fe`](https://github.com/NixOS/nixpkgs/commit/8bf6b8fe27c4a0759ff74bd83cd95067a4740242) python3Packages.pikepdf: 4.0.2 -> 4.1.0
* [`134db1c3`](https://github.com/NixOS/nixpkgs/commit/134db1c397873fb57864ebb9ae45bc55b19b9a0e) sysdig: fix pending upstream inclusion for ncurses-6.3
* [`cee0c4a8`](https://github.com/NixOS/nixpkgs/commit/cee0c4a831bf1cf111071ad1ee3929f290de99e7) python3Packages.ocrmypdf: 12.7.2 -> 13.0.0
* [`1a119b22`](https://github.com/NixOS/nixpkgs/commit/1a119b223c8258ede92ef197b3a8c486b54b4843) vault{,bin}: 1.8.4 -> 1.9.0
* [`60252466`](https://github.com/NixOS/nixpkgs/commit/60252466babdc28e647f6d7fb4544233cadacf33) vault-bin: set dontStrip for darwin
* [`b37d18e7`](https://github.com/NixOS/nixpkgs/commit/b37d18e7316edf92390bd4533f67a9cfd0ad27d8) cosign: 1.3.0 -> 1.3.1
* [`3f996208`](https://github.com/NixOS/nixpkgs/commit/3f9962083619d512b754256ad6dfa8f6a8c3a659) python3Packages.notebook: disable networking tests on darwin
* [`5f8babdd`](https://github.com/NixOS/nixpkgs/commit/5f8babdd259d68ff8052dfc8d650ebdf9cc3bd75) doc beam section: Takle TODO ([nixos/nixpkgs⁠#148624](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/148624))
* [`44b84602`](https://github.com/NixOS/nixpkgs/commit/44b84602c940f4693789501f42f05d007c463031) python3Packages.myfitnesspal: 1.16.4 -> 1.16.5
* [`e97bf4b6`](https://github.com/NixOS/nixpkgs/commit/e97bf4b65308d5c9f7812869f96852243333009f) whitesur-gtk-theme: 2021-10-21 -> 2021-12-04
* [`96e01b7e`](https://github.com/NixOS/nixpkgs/commit/96e01b7e1689d3ee9d2a674a99aa9702e808f5f3) gnomeExtensions: fix ddterm
* [`58ebdc31`](https://github.com/NixOS/nixpkgs/commit/58ebdc31541b3e233178bebf7a25cfad5201bfe6) goimapnotify: remove unused deps.nix
* [`e5c93511`](https://github.com/NixOS/nixpkgs/commit/e5c93511f34613a6c818734d1c21f6a6f51dad36) vault: add vault-postgresql to passthru.tests
* [`d897bd56`](https://github.com/NixOS/nixpkgs/commit/d897bd56af04b0383075bd85d074d6c2be0bc6f3) netbeans: 12.5 -> 12.6
* [`7e1fbeeb`](https://github.com/NixOS/nixpkgs/commit/7e1fbeeb10a27ff85b4a6350288f7cd5f9aa74e5) kubeaudit: init at 0.16.0
* [`62b03e2c`](https://github.com/NixOS/nixpkgs/commit/62b03e2c3967e6c0b618db490fc00e7aea4f4463) cpuid: 20211114 -> 20211129
* [`97fe3d9a`](https://github.com/NixOS/nixpkgs/commit/97fe3d9aa36d6f07324819e6fce1188cd7eeb103) ascii-image-converter: init at 1.11.0
* [`54e0af39`](https://github.com/NixOS/nixpkgs/commit/54e0af392a7e32f3d159210577fa0509f2190d4f) python3Packages.ytmusicapi: 0.19.4 -> 0.19.5
* [`a6197d0f`](https://github.com/NixOS/nixpkgs/commit/a6197d0feb3162a8fa021a7b414d616147484cd5) clickclack: 0.1.1 -> 0.2
* [`53801ef1`](https://github.com/NixOS/nixpkgs/commit/53801ef12226bd519db2c85c5a6a4a5fed951132) qmapshack: 1.16.0 -> 1.16.1
* [`c3a57a62`](https://github.com/NixOS/nixpkgs/commit/c3a57a62856dce4b5dc9154b2a5c6c3ae5f023d1) fnm: 1.27.0 -> 1.28.1 ([nixos/nixpkgs⁠#147798](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/147798))
* [`6af3d13b`](https://github.com/NixOS/nixpkgs/commit/6af3d13bec9b13e8fa8e19594ffbcbe085387bdd) nixos/ddclient: fix permission for ddclient.conf ([nixos/nixpkgs⁠#148179](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/148179))
* [`34103240`](https://github.com/NixOS/nixpkgs/commit/341032407f6371857490da6ced6b88930f335a8a) Revert "neard: fix build"
* [`68dc5484`](https://github.com/NixOS/nixpkgs/commit/68dc5484e9515d0e349677a1347fede62418c67b) nixos/doc/manual/release-notes/rl-2111: add prometheus-smartctl-exporter
* [`b6295037`](https://github.com/NixOS/nixpkgs/commit/b62950371dfa994b4e4b2881d524a3fb8a60c0bf) wezterm: 20210814-124438-54e29167 -> 20211204-082213-a66c61ee9
* [`8592d8f8`](https://github.com/NixOS/nixpkgs/commit/8592d8f8661c9a3de8e37eae51622b9fa1070a4b) senpai: unstable-2021-05-27 -> unstable-2021-11-29
* [`cab6e339`](https://github.com/NixOS/nixpkgs/commit/cab6e3395ad407687e6fd3b9a1b33ef071caa4c9) rdkafka: 1.8.0 -> 1.8.2 ([nixos/nixpkgs⁠#144626](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/144626))
* [`143da123`](https://github.com/NixOS/nixpkgs/commit/143da12376d3522465bcfe2b4333501423c086f2) python39Packages.paste: add six dependency back ([nixos/nixpkgs⁠#148501](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/148501))
* [`5bd4dadb`](https://github.com/NixOS/nixpkgs/commit/5bd4dadb172ab9829c44021d8b599b75bff60422) python3Packages.empy: init at 3.3.4
* [`0ff0d541`](https://github.com/NixOS/nixpkgs/commit/0ff0d54168c3d085243b254ef762524863936f0d) add self to maintainers
* [`72000dce`](https://github.com/NixOS/nixpkgs/commit/72000dced2ec5036ed9eeaa0277f4b1bbf2de4c1) libsForQt5.bismuth: 2.1.0 -> 2.2.0 ([nixos/nixpkgs⁠#148673](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/148673))
* [`36c85e00`](https://github.com/NixOS/nixpkgs/commit/36c85e004838417e59e5ecc81c46afc0e8f2316c) electron_13: 13.6.2 -> 13.6.3
* [`c8eb62f2`](https://github.com/NixOS/nixpkgs/commit/c8eb62f29da84827f695566fe99658b86274eee3) electron_14: 14.2.1 -> 14.2.2
* [`cdb43790`](https://github.com/NixOS/nixpkgs/commit/cdb43790eaa36a848a9fd635bba892b4129bf228) electron_15: 15.3.2 -> 15.3.3
* [`d400ed3e`](https://github.com/NixOS/nixpkgs/commit/d400ed3e66ff0ecf2dd44dbaf2d2feaf55eda3ba) electron_16: 16.0.2 -> 16.0.4
* [`1557d60e`](https://github.com/NixOS/nixpkgs/commit/1557d60eac3db1467b948ce3ada267f2a9493faf) python3Packages.bitlist: 0.6.0 -> 0.6.1
* [`bdda2cca`](https://github.com/NixOS/nixpkgs/commit/bdda2cca74af24138fce810216d1f4c91e6eb13e) autorandr: install zsh completions
* [`138c3b58`](https://github.com/NixOS/nixpkgs/commit/138c3b581627430e5ebd448da20a2ca23523246f) python2Packages.flake8: disable since flake8 v4 dropped Python 2 support
* [`10c725dc`](https://github.com/NixOS/nixpkgs/commit/10c725dc6bc28859870fd7c54d0d6399fcaecd7c) writers.makePythonWriter: drop flake8 checks for Python 2 scripts
* [`582298e5`](https://github.com/NixOS/nixpkgs/commit/582298e598a4853b305d9a1f9282baa4a79279f3) python3Packages.jupytext: 1.13.2 -> 1.13.3
* [`b15bdcab`](https://github.com/NixOS/nixpkgs/commit/b15bdcab9385b8577caa85f2aee42a4d06109407) python3Packages.phonenumbers: 8.12.37 -> 8.12.38
* [`64fbdc20`](https://github.com/NixOS/nixpkgs/commit/64fbdc2099e73b7a905245b1c28207419e0d46ee) git-branchless: 0.3.7 -> 0.3.8
* [`a707ff8c`](https://github.com/NixOS/nixpkgs/commit/a707ff8c99a25ef0c8d6d3cb1980790c9f791915) redo-apenwarr: 0.42c -> 0.42d
* [`8e916a44`](https://github.com/NixOS/nixpkgs/commit/8e916a44611df59428f4ab9fef21e5eda77c1f56) maintainers: add ius
* [`8d0267dc`](https://github.com/NixOS/nixpkgs/commit/8d0267dc8f02e010785d6f90573ea1135b7957e7) treewide: use pname&version instead of name
* [`1a5a9b1e`](https://github.com/NixOS/nixpkgs/commit/1a5a9b1e9d6df53b73ee35f134fcb2c124d2777c) gnome.mutter: fix libdir path
* [`1b9273ff`](https://github.com/NixOS/nixpkgs/commit/1b9273ffa625d5236f46a1c8ac08fd7097ade5b5) checkov: 2.0.626 -> 2.0.628
* [`7a3e80ab`](https://github.com/NixOS/nixpkgs/commit/7a3e80abeea52002b67304d9a44619061487ec91) cloud-hypervisor: 19.0 -> 20.0
* [`05bc708a`](https://github.com/NixOS/nixpkgs/commit/05bc708a7f16e71754810a7d5d2bf3871098d4f2) nixos/collectd: add missing group
* [`2bf5d8d0`](https://github.com/NixOS/nixpkgs/commit/2bf5d8d04f35457f8ff3ac6669d51e7d3ad45d81) zprint: 1.1.2 -> 1.2.0
* [`b716eba4`](https://github.com/NixOS/nixpkgs/commit/b716eba467a7a8472fe964c21e7ee526a2c9f887) libargs: 6.2.6 -> 6.2.7
* [`3cfab137`](https://github.com/NixOS/nixpkgs/commit/3cfab13751c23eeb46d4864780e7a564f39f276b) zfs-prune-snapshots: 1.1.0 -> 1.3.0
* [`ef4173bc`](https://github.com/NixOS/nixpkgs/commit/ef4173bca361bd561cfa92f04196316e251f0803) gnomeExtensions: auto-update
* [`b3035f04`](https://github.com/NixOS/nixpkgs/commit/b3035f0442552e27a94d24267fe906c5a15eed0f) autotiling: 1.5 -> 1.6
* [`2fde20d4`](https://github.com/NixOS/nixpkgs/commit/2fde20d45c5e40c837b89c60a2232eac58da40bd) gnome.gnome-flashback: 3.42.0 → 3.42.1
* [`8bba694a`](https://github.com/NixOS/nixpkgs/commit/8bba694a6aa9b401422f204495a3f25e57765931) wsdd: 0.6.4 -> 0.7.0
* [`62f834b2`](https://github.com/NixOS/nixpkgs/commit/62f834b20caff433ed63b7ea3bcd7bf962504993) barman: 2.15 -> 2.17
* [`43ca0f5e`](https://github.com/NixOS/nixpkgs/commit/43ca0f5e74ab6b179306319cffcc1802558e3337) viewnior: 1.7 -> 1.8
* [`8a88b0c2`](https://github.com/NixOS/nixpkgs/commit/8a88b0c28849a66d6e86756d87432ea30a67e833) act: 0.2.24 -> 0.2.25
* [`32451b55`](https://github.com/NixOS/nixpkgs/commit/32451b55b7926dc1e3b3a637cfd3b653e781b852) air: 1.27.3 -> 1.27.8
* [`4e0f0930`](https://github.com/NixOS/nixpkgs/commit/4e0f0930e9813442fb28a8ac3f164f68079e269a) wasmer: 2.0.0 -> 2.1.0
* [`02ebf2f2`](https://github.com/NixOS/nixpkgs/commit/02ebf2f2bdf174aef8661f2f9154e16870f152d5) afterstep: explicitly disable parallel builds
* [`735d400d`](https://github.com/NixOS/nixpkgs/commit/735d400d0877a28b53444ef9c917544a5861bdd9) cht-sh: unstable-2021-11-13 -> unstable-2021-11-17
* [`406015be`](https://github.com/NixOS/nixpkgs/commit/406015beb873f2c0fcb2a2803c5ad49abe867bb1) xsnow: 3.3.1 -> 3.3.2
* [`7980f52d`](https://github.com/NixOS/nixpkgs/commit/7980f52d0c357338de269ee1b7138f901936942f) yabai: 3.3.4 -> 3.3.10
* [`8437ca7e`](https://github.com/NixOS/nixpkgs/commit/8437ca7e839fe48c1e4daf4c141aeed38302d7b3) python38Packages.meshtastic: 1.2.43 -> 1.2.44
* [`b7b26870`](https://github.com/NixOS/nixpkgs/commit/b7b2687082075c0a07c2e286d1b0d4c342238fc3) amass: 3.15.1 -> 3.15.2
* [`6d1ec447`](https://github.com/NixOS/nixpkgs/commit/6d1ec4479e156344cc4a5dda8cc6be77eb5b8d7f) wike: 1.5.7 -> 1.6.2
* [`7c8bc33e`](https://github.com/NixOS/nixpkgs/commit/7c8bc33ec0a99cc6990784605329c3d7f6c27764) pyperclip: fix license
* [`ee9be8a4`](https://github.com/NixOS/nixpkgs/commit/ee9be8a41665724b1e20a7f7d4df46556aa8520c) mouseinfo: init at 0.1.3
* [`98111a62`](https://github.com/NixOS/nixpkgs/commit/98111a6214fcd5d3bac85cb45e17b2948875642b) pymsgbox: 1.0.6 -> 1.0.9
* [`7ed4633c`](https://github.com/NixOS/nixpkgs/commit/7ed4633ca3ae608b2b0d02de25f670f041b5b830) pygetwindow: init at 0.0.9
* [`11db3d40`](https://github.com/NixOS/nixpkgs/commit/11db3d404a4e4fb426f24dff6fc88af5333d405c) pyrect: init at 0.1.4
* [`e52be73c`](https://github.com/NixOS/nixpkgs/commit/e52be73c2dbd7bf50f44a7e9902dec2f6d257780) pyscreeze: init at 0.1.26
* [`0af9db38`](https://github.com/NixOS/nixpkgs/commit/0af9db3847e55fdb9709c1e2072fd63d3674ac68) pytweening: init at 1.0.4
* [`29990fb8`](https://github.com/NixOS/nixpkgs/commit/29990fb83db4435cfafb45cb4221546f6cc067fb) pyautogui: init at 0.9.53
* [`a3647046`](https://github.com/NixOS/nixpkgs/commit/a3647046fee002a70a5c121101d46535afd640e0) add references for data a few commits behind
* [`eec28b8c`](https://github.com/NixOS/nixpkgs/commit/eec28b8cfd7923a876fb47af8a0459c1a550fd97) pypy3: 7.3.5 -> 7.3.7 ([nixos/nixpkgs⁠#147875](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/147875))
* [`b9811a5a`](https://github.com/NixOS/nixpkgs/commit/b9811a5aeb78ff11f146b60c2c4329a7be8eea81) nginxModules.pam: 1.5.2 -> 1.5.3
* [`f88b90f5`](https://github.com/NixOS/nixpkgs/commit/f88b90f5c329a5a4d49e142315fbcb27986a13b1) facedetect: use Python 3
* [`3a188316`](https://github.com/NixOS/nixpkgs/commit/3a188316e7ba9248ec9ab2bd7d5e632fb22654f4) gaia: Remove
* [`9b867fe9`](https://github.com/NixOS/nixpkgs/commit/9b867fe9075e13b957e3be6ab4a9f03a0ba24f5b) spot: 0.2.0 -> 0.2.2
* [`c3557f2e`](https://github.com/NixOS/nixpkgs/commit/c3557f2e6495722db017b76871c0870c8b95752d) gcc-arm-embedded-{6,7,8}: enable on aarch64-darwin
* [`9c5f93a4`](https://github.com/NixOS/nixpkgs/commit/9c5f93a473ea82b22866dcd22dca46f8d180e556) colmena: init at 0.2.0
* [`c694c35f`](https://github.com/NixOS/nixpkgs/commit/c694c35f9da13e7008b281d757385e6ad525e22a) nixos/*: escape pkgs reference in examples and descriptions
* [`677b3300`](https://github.com/NixOS/nixpkgs/commit/677b33000436a2b5388cb19b0ea8f7b9a30dc9e3) python3Packages.django-rq: 2.5.0 -> 2.5.1
* [`feeea141`](https://github.com/NixOS/nixpkgs/commit/feeea141f536b9daff2e284b28c2b34571aa95fb) xh: 0.14.0 -> 0.14.1
