### PR TITLE
niv home-manager: update 9de77227 -> 781d25b3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9de77227d7780518cfeaee5a917970247f3ecc56",
-        "sha256": "0d9mddbndy6f7q3vmfmc563ncbi407l2v1i4f9ydqlm334qzfqb9",
+        "rev": "781d25b315def05cd7ede3765226c54216f0b1fe",
+        "sha256": "14cbfsslf1qbgkif3hrgn6x5rxa9h6b61jh4jmjbfi6mbnxvn8r9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9de77227d7780518cfeaee5a917970247f3ecc56.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/781d25b315def05cd7ede3765226c54216f0b1fe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9de77227...781d25b3](https://github.com/nix-community/home-manager/compare/9de77227d7780518cfeaee5a917970247f3ecc56...781d25b315def05cd7ede3765226c54216f0b1fe)

* [`7c320a53`](https://github.com/nix-community/home-manager/commit/7c320a53254609d9814280a34e312b7f00fd160b) waybar: make module a freeform module, remove warnings
* [`f23073f1`](https://github.com/nix-community/home-manager/commit/f23073f1daa769a28a12ac587eea487aa8afb196) less: allow customization
* [`de54d513`](https://github.com/nix-community/home-manager/commit/de54d513c74bf8f4f3a58954b80b5f690639fe72) firefox: create user.js when only bookmarks are specified in config (issue [nix-community/home-manager⁠#2492](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2492)) ([nix-community/home-manager⁠#2521](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2521))
* [`0d585828`](https://github.com/nix-community/home-manager/commit/0d585828877a2a840d7ba7e87731080394408392) darwin: keep the options for the "defaults" system up-to-date
* [`fbb80207`](https://github.com/nix-community/home-manager/commit/fbb80207f3840785e2918143ebe709f26372f91d) darwin: add midchildan to maintainers
* [`f46972e4`](https://github.com/nix-community/home-manager/commit/f46972e46676886423b8336c30bd0f1027fa87af) powerline-go: add support for -modules-right
* [`290a188d`](https://github.com/nix-community/home-manager/commit/290a188dad547df8b1069bf14cb21f9aa276413d) docs: change stable from 21.05 to 21.11
* [`1aaa1a03`](https://github.com/nix-community/home-manager/commit/1aaa1a033bae6c53773ad4374756ac72ba25b729) docs: add note about Waybar modules
* [`781d25b3`](https://github.com/nix-community/home-manager/commit/781d25b315def05cd7ede3765226c54216f0b1fe) Replace pkgs.hostPlatform by pkgs.stdenv.hostPlatform
