### PR TITLE
niv powerlevel10k: update a9f208c8 -> 3380f750

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "a9f208c8fc509b9c591169dd9758c48ad4325f76",
-        "sha256": "1jkddpmdmp274wkx407dwyi78dhraqq6vdxh15m13yraq1cy17jw",
+        "rev": "3380f7503e7dc252163d5b30475335ed67f58a98",
+        "sha256": "1dwrn7qaxg3qhijrrjzia0c4z9q278niy6p71q1x3h2px3dpwmf2",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/a9f208c8fc509b9c591169dd9758c48ad4325f76.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/3380f7503e7dc252163d5b30475335ed67f58a98.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@a9f208c8...3380f750](https://github.com/romkatv/powerlevel10k/compare/a9f208c8fc509b9c591169dd9758c48ad4325f76...3380f7503e7dc252163d5b30475335ed67f58a98)

* [`e181bc06`](https://github.com/romkatv/powerlevel10k/commit/e181bc0653ae15ba5730a65b253d499bf22a31bf) Squashed 'gitstatus/' changes from e26996460..f1cf61b24
