### PR TITLE
niv spacemacs: update 33e7f626 -> a86cdd35

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "33e7f62693baf1a3de87750bf95fd4d6795d190d",
-        "sha256": "1jb98yxcr6iqjrbyb3fx4dgsg9457gkmbn0q19vbiz3a1nnk2h07",
+        "rev": "a86cdd3506ec30aafdf5a3c16bac81715dc4f875",
+        "sha256": "1mxssy11i27g18k1vmk14dwk2s3yhp62jl76d7n44h572sfv6y1k",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/33e7f62693baf1a3de87750bf95fd4d6795d190d.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/a86cdd3506ec30aafdf5a3c16bac81715dc4f875.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@33e7f626...a86cdd35](https://github.com/syl20bnr/spacemacs/compare/33e7f62693baf1a3de87750bf95fd4d6795d190d...a86cdd3506ec30aafdf5a3c16bac81715dc4f875)

* [`c34cb723`](https://github.com/syl20bnr/spacemacs/commit/c34cb723430ef85794200e58b99db54aeffa1b22) Add documentation for most important org shortcuts ([syl20bnr/spacemacs⁠#15190](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15190))
* [`17b5646e`](https://github.com/syl20bnr/spacemacs/commit/17b5646e77c77563cded4e2ba2bbd4d114426a7a) [bot] "documentation_updates" Tue Nov 30 19:20:17 UTC 2021 ([syl20bnr/spacemacs⁠#15191](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15191))
* [`ab19ea1d`](https://github.com/syl20bnr/spacemacs/commit/ab19ea1de530a3ce4bd1cd58c9e4fcf586bbedad) Coq layer README add optional requirement (auto-completion layer) ([syl20bnr/spacemacs⁠#15195](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15195))
* [`a86cdd35`](https://github.com/syl20bnr/spacemacs/commit/a86cdd3506ec30aafdf5a3c16bac81715dc4f875) [bot] "documentation_updates" Sat Dec  4 16:11:00 UTC 2021 ([syl20bnr/spacemacs⁠#15196](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15196))
