### PR TITLE
niv nixpkgs: update 564f54eb -> 356656f1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "564f54ebd0c28866cd2df84829efec191c90a180",
-        "sha256": "1i17k3kk5wd0435q78wd6pyaam3ig4yyvl2wzy4zbm8ahjdl83j6",
+        "rev": "356656f14309070dddb51262ff5b51e6d300a17d",
+        "sha256": "0ih142hfbjjkvsikza00k6ipsnn41zsmrzf9masq2xcdjhqr0g9i",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/564f54ebd0c28866cd2df84829efec191c90a180.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/356656f14309070dddb51262ff5b51e6d300a17d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@564f54eb...356656f1](https://github.com/nixos/nixpkgs/compare/564f54ebd0c28866cd2df84829efec191c90a180...356656f14309070dddb51262ff5b51e6d300a17d)

* [`f1c4bec4`](https://github.com/NixOS/nixpkgs/commit/f1c4bec46a86d44d5756aba816de09de81c0dc41) papermc: 1.17.1r97 -> 1.17.1r399 ([nixos/nixpkgs⁠#149989](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/149989))
* [`fcf6840e`](https://github.com/NixOS/nixpkgs/commit/fcf6840eb146583c6ec6e890cd28be64673e58c5) closurecompiler: 20210808 -> 20211107
* [`f9610aca`](https://github.com/NixOS/nixpkgs/commit/f9610acae1d04179f178fe57d6f2cc758d75101f) drogon: 1.7.3 -> 1.7.4
* [`04152bb8`](https://github.com/NixOS/nixpkgs/commit/04152bb85c11e7f4586c3085683ff573a2a04b48) flexget: 3.2.1 -> 3.2.4
* [`f5e44065`](https://github.com/NixOS/nixpkgs/commit/f5e4406520339193af23dede6760ff150ed6f4e5) python3Packages.imap-tools: 0.50.1 -> 0.50.2
* [`5e4feb3c`](https://github.com/NixOS/nixpkgs/commit/5e4feb3c2da78853c87f29d97e34096facf5a10d) python3Packages.django-sites: run tests
* [`c9dcdafd`](https://github.com/NixOS/nixpkgs/commit/c9dcdafd1aeed9917b54b8a32dcca32eb2cf2d16) python3Packages.ocrmypdf: remove meta.platforms
* [`2deb8c0f`](https://github.com/NixOS/nixpkgs/commit/2deb8c0fc588aa0ceaff8110f08363dc9415d64c) nixos/postgresql: improve docs on how to upgrade
* [`32e77004`](https://github.com/NixOS/nixpkgs/commit/32e770042e8c1ba70d89d9190f30405b26208f26) python38Packages.gspread: 4.0.1 -> 5.0.0
* [`7b3fb295`](https://github.com/NixOS/nixpkgs/commit/7b3fb295ca60aa958ecc2e85ec1e72413ec6384c) python3Packages.simple-rest-client: 1.1.1 -> 1.1.2
* [`624ecbbc`](https://github.com/NixOS/nixpkgs/commit/624ecbbcaa6d25d8bc05a61e3ec9d5a3b43fb837) python3Packages.spur: init at 0.3.22
* [`d2b5486a`](https://github.com/NixOS/nixpkgs/commit/d2b5486ae949b9092b4f56c93d694cbea09c05a6) python3Packages.stickytape: init at 0.2.1
* [`e116afd1`](https://github.com/NixOS/nixpkgs/commit/e116afd102645a305064b186b285e22098f21c68) inql: init at 4.0.5
* [`d2ab0b15`](https://github.com/NixOS/nixpkgs/commit/d2ab0b151454957394079142b70d001fad183938) python3Packages.pikepdf: 4.1.0 -> 4.2.0
* [`fe403426`](https://github.com/NixOS/nixpkgs/commit/fe403426d069603f675999244c47774558443faa) python38Packages.sphinxcontrib-seqdiag: 2.0.0 -> 3.0.0
* [`2b1ef081`](https://github.com/NixOS/nixpkgs/commit/2b1ef081e7aaa70cc567ad1dd8a54f73ac3dbb7a) libabigail: correct license
* [`05823d0e`](https://github.com/NixOS/nixpkgs/commit/05823d0ed742dbafc7d0714729542e8d333cd58e) python38Packages.sphinxcontrib-spelling: 7.2.1 -> 7.3.0
* [`1531ab2f`](https://github.com/NixOS/nixpkgs/commit/1531ab2fccccf202ad31696a66fe88ce98b9c09a) python38Packages.grappelli_safe: 0.5.2 -> 1.0.0
* [`c9554e9e`](https://github.com/NixOS/nixpkgs/commit/c9554e9ef62148ffed9fa8a56fdca1a9bbefd8cb) python38Packages.Kajiki: 0.8.3 -> 0.9.0
* [`dded26d1`](https://github.com/NixOS/nixpkgs/commit/dded26d1fadfffa2561f6ab97899bf7682f1f06f) python38Packages.pytest-annotate: 1.0.3 -> 1.0.4
* [`94809fac`](https://github.com/NixOS/nixpkgs/commit/94809fac3082749c19194139f3b5aae9b96687a9) whitebox-tools: 1.4.0 -> 2.0.0
* [`975b7ed6`](https://github.com/NixOS/nixpkgs/commit/975b7ed60bf04614350c3af682be3b46dd7a0290) python38Packages.azure-mgmt-datafactory: 2.0.0 -> 2.1.0
* [`3cefa1b7`](https://github.com/NixOS/nixpkgs/commit/3cefa1b7659094f410f01a247652cf2ebe63f4dd) python38Packages.sphinxcontrib-blockdiag: 2.0.0 -> 3.0.0
* [`bb826909`](https://github.com/NixOS/nixpkgs/commit/bb82690935acce293a4a3440878549d42d6a188f) python38Packages.mockito: 1.2.2 -> 1.3.0
* [`32bbd13b`](https://github.com/NixOS/nixpkgs/commit/32bbd13b0a8f9ebd08572695505dc4dd89b121f0) python38Packages.precis-i18n: 1.0.2 -> 1.0.3
* [`c5d9ec0d`](https://github.com/NixOS/nixpkgs/commit/c5d9ec0dd1d08be8f1830df2608a64355235e5c8) python38Packages.schema: 0.7.4 -> 0.7.5
* [`269390af`](https://github.com/NixOS/nixpkgs/commit/269390af5cb9869a2bbd74fdbfbb076835c35f4d) maestral: 1.5.1 -> 1.5.2
* [`e92e1f01`](https://github.com/NixOS/nixpkgs/commit/e92e1f017e09420134217fa41a89bd44602c85ac) jenkins-job-builder: 3.10.0 -> 3.11.0
* [`7480245e`](https://github.com/NixOS/nixpkgs/commit/7480245e02414e7d9da15555bb0aec512805ee54) python38Packages.snowflake-connector-python: 2.6.2 -> 2.7.0
* [`f572eb6f`](https://github.com/NixOS/nixpkgs/commit/f572eb6f8676eff79968f71e93a7b7e6d1271337) python38Packages.ipyvue: 1.6.1 -> 1.7.0
* [`3fe9b97d`](https://github.com/NixOS/nixpkgs/commit/3fe9b97ddfd93bef87c8e9384a583897bc3842a4) python38Packages.ldap: 3.3.1 -> 3.4.0
* [`1e178abc`](https://github.com/NixOS/nixpkgs/commit/1e178abc9465d8af896666a9a7e170229dc1a1b2) python3Packages.vt-py: 0.9.0 -> 0.11.0
* [`e7048a6c`](https://github.com/NixOS/nixpkgs/commit/e7048a6c2b586845f8130b8005b18ccb753310a8) python38Packages.colorcet: 2.0.6 -> 3.0.0
* [`be4883e2`](https://github.com/NixOS/nixpkgs/commit/be4883e2181a7f9e1513be091ea573f9f2411c81) zap: 2.11.0 -> 2.11.1
* [`9cd228f3`](https://github.com/NixOS/nixpkgs/commit/9cd228f3e3d5d5db25ec65cf53b71339d594a34a) libreoffice-still: 7.1.7.2 -> 7.1.8.1
* [`9c36e9cb`](https://github.com/NixOS/nixpkgs/commit/9c36e9cb9a7aceaed14c1ccd4d2d009a267665a7) libreoffice-fresh: 7.2.3.2 -> 7.2.4.1
* [`b2aa4f1f`](https://github.com/NixOS/nixpkgs/commit/b2aa4f1f251a8747485cfd0168c5ca3ee47a0fee) esphome: 2021.11.4 -> 2021.12.0
* [`1bc07165`](https://github.com/NixOS/nixpkgs/commit/1bc0716555ef9184117a61c4d0d133f0b6c85464) qt515.qtwebkit: fix build on darwin
* [`cf504b23`](https://github.com/NixOS/nixpkgs/commit/cf504b2330061b05b7e449de74b02fcf0f5fe078) nixos/nitter: remove syslog.target from service ([nixos/nixpkgs⁠#150224](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/150224))
* [`fe44db82`](https://github.com/NixOS/nixpkgs/commit/fe44db8271d87ddf2747d145373c0b9f04188b77) openafsServer: remove dependency on syslog.target ([nixos/nixpkgs⁠#150294](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/150294))
* [`bb976f4e`](https://github.com/NixOS/nixpkgs/commit/bb976f4e86c91deb124d7267cc02b76e7b8f75b8) haskell.packages.ghcjs.vector: Fix evaluation failure ([nixos/nixpkgs⁠#150002](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/150002))
* [`cbe39436`](https://github.com/NixOS/nixpkgs/commit/cbe394366af7866e02c97dda951f47df6a65c906) callaudiod: 0.1.0 -> 0.1.1
* [`822e58e6`](https://github.com/NixOS/nixpkgs/commit/822e58e607878ac15ee4919d19016701e06804a7) dupeguru: set platforms to unix
* [`77f65a82`](https://github.com/NixOS/nixpkgs/commit/77f65a82fe8b5cbe5e220f06bc4a0f24e69021fe) gitui: 0.18.0 -> 0.19.0
* [`e6217908`](https://github.com/NixOS/nixpkgs/commit/e6217908a39e5d61366141913798d9fa59974bf6) nixos/glusterfs: remove syslog.target from services
* [`50a74117`](https://github.com/NixOS/nixpkgs/commit/50a74117b6acc19e09b1ddafd32ed0f196be5fed) cargo-cache: 0.6.3 -> 0.7.0
* [`90185d9f`](https://github.com/NixOS/nixpkgs/commit/90185d9f22a8ebb2de75d366016d08c4c8387a0c) wad: migrate to new Python app style
* [`f075c1c9`](https://github.com/NixOS/nixpkgs/commit/f075c1c97036d64592c1c26c1b20ae26854a67de) auto-multiple-choice: 1.5.1 -> 1.5.2
* [`0fe8586f`](https://github.com/NixOS/nixpkgs/commit/0fe8586f433bf411cbcd2a4997ac23b05d8b9776) glusterfs: 9.4 -> 10.0
* [`5a6e995a`](https://github.com/NixOS/nixpkgs/commit/5a6e995a46ccb5e16c3c7ddba700c8d753b8ae41) nordzy-cursor-theme: init at 0.1.0
* [`445638d3`](https://github.com/NixOS/nixpkgs/commit/445638d3ecdc239e62d78cfee776a01753d03e11) gdu: 5.12.0 -> 5.12.1
* [`6fab6f56`](https://github.com/NixOS/nixpkgs/commit/6fab6f5665ffcd9afe70178dd7ea4ec0167bdb7f) dnsrecon: 0.10.1 -> 1.0.0
* [`20371fd1`](https://github.com/NixOS/nixpkgs/commit/20371fd18ce6f212ba921570ebe2a9b3d014e273) dnsrecon: 0.10.1 -> 1.0.0
* [`48feb21a`](https://github.com/NixOS/nixpkgs/commit/48feb21a3c2118c7eea3c28169c9a7349b556e74) unifi6: 6.5.53 -> 6.5.54
* [`cda7cc96`](https://github.com/NixOS/nixpkgs/commit/cda7cc96039ce70b3bf1896f08c1b5a5a422a92b) armadillo: 10.6.2 -> 10.7.4
* [`7ce8a2e3`](https://github.com/NixOS/nixpkgs/commit/7ce8a2e375a9882ef1c83a48763a57c9f0203cac) bgpq4: 1.2 -> 1.4
* [`6e7c7e6b`](https://github.com/NixOS/nixpkgs/commit/6e7c7e6b77565679451c3c4d5a65d1d466f2b8ac) argo: 3.1.1 -> 3.2.4
* [`23df95ff`](https://github.com/NixOS/nixpkgs/commit/23df95ff327c4f3bd4a2d4fd93f61d3fca870fc1) bibutils: 6.10 -> 7.2
* [`c0751190`](https://github.com/NixOS/nixpkgs/commit/c075119091be7f0985aab3c91887b1404130158b) ajour: 1.3.1 -> 1.3.2
* [`b835bec4`](https://github.com/NixOS/nixpkgs/commit/b835bec4d74f47d802031cb129cd0abe6c5f95cc) minecraft-server: 1.18 -> 1.18.1 ([nixos/nixpkgs⁠#149982](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/149982))
* [`ba32d993`](https://github.com/NixOS/nixpkgs/commit/ba32d993811bab54480f342394937be4f0cb32b6) release: add cargo and go as unstable blockers for x86_64-{darwin,linux}
* [`3aa43592`](https://github.com/NixOS/nixpkgs/commit/3aa4359254a62742ae9858bf25a4a51add4a3004) pantheon.appcenter: re-add patch for disable packagekit backend
* [`1eef9ae2`](https://github.com/NixOS/nixpkgs/commit/1eef9ae2d1274e97097b0ab38a18a6748cb87a20) Revert "nixos/pantheon: cleanup FAQ section"
* [`c65f6852`](https://github.com/NixOS/nixpkgs/commit/c65f6852e4f5b28e12406b1876956763ef1eb8cd) Revert "nixos/pantheon: mention latest appcenter changes in manual"
* [`212182ed`](https://github.com/NixOS/nixpkgs/commit/212182edf594a3374b89a117e4893db95a6a6723) python38Packages.deezer-python: 4.2.0 -> 4.2.1
* [`688235fb`](https://github.com/NixOS/nixpkgs/commit/688235fb07757c7b17e2f58f069f3055351ccebd) batsignal: 1.2.0 -> 1.3.1
* [`31fd8829`](https://github.com/NixOS/nixpkgs/commit/31fd88293b0b04d75f3872907d686d737bb376af) xsnow: 3.3.2 -> 3.3.6
* [`e06f742b`](https://github.com/NixOS/nixpkgs/commit/e06f742bebd4e125bc6f2426cc5b2c51a2b7b42a) cinnamon.xviewer: 3.2.1 -> 3.2.2
* [`1c55acf8`](https://github.com/NixOS/nixpkgs/commit/1c55acf8cd116c0121dc2b7bba8cf246e07509d2) mod-arpeggiator-lv2: init at unstable-2021-11-09
* [`4da1c56c`](https://github.com/NixOS/nixpkgs/commit/4da1c56ce2b4b5efc03df1e7ed49d25d1364be26) wike: 1.6.2 -> 1.6.3
* [`f3b234be`](https://github.com/NixOS/nixpkgs/commit/f3b234be9db3442a2e0e591d94b99daae0d359ec) vmpk: 0.8.4 -> 0.8.5
* [`82c83835`](https://github.com/NixOS/nixpkgs/commit/82c838356d86ee7305ddfdad3a7f3ca96c3fac2d) skaffold: update sha256
* [`6e6c3c5c`](https://github.com/NixOS/nixpkgs/commit/6e6c3c5c92eb3a76f8e9f166fa9f0861cc7aa743) skaffold: add myself as maintainer
* [`f552127e`](https://github.com/NixOS/nixpkgs/commit/f552127eb37b00c58b5271f3e0c16d9c2fa12b85) python38Packages.casbin: 1.13.0 -> 1.15.0
* [`e992604b`](https://github.com/NixOS/nixpkgs/commit/e992604bf0b4afb4c3e8ccad04d6ea69bba49681) nixos/unifi: Apply log4j2 mitigation
* [`c4dbe8fe`](https://github.com/NixOS/nixpkgs/commit/c4dbe8fe65a04a282585811665caec1361e5fe51) colima: init at 0.2.2
* [`91c6a972`](https://github.com/NixOS/nixpkgs/commit/91c6a97243711446471fc8a576cb9d21f516641f) kubernetes: disable rbac tests
* [`65e47459`](https://github.com/NixOS/nixpkgs/commit/65e4745989cc29314caec1548cf7a0923991f39b) Surge-XT: unstable-2021-11-07 -> unstable-2021-12-11
* [`ad9c4bcf`](https://github.com/NixOS/nixpkgs/commit/ad9c4bcf5286c3bcf220afd7fde96b6e4f40ef01) zrythm: don't strip
* [`a8aaaf5f`](https://github.com/NixOS/nixpkgs/commit/a8aaaf5f62caf70376f4bacd9f55f1722b209279) tint2: 17.0.1 -> 17.0.2
* [`3c8f6c54`](https://github.com/NixOS/nixpkgs/commit/3c8f6c5407aab5b872892f24fdf82ef8076b2ec5) grafana: 8.3.1 -> 8.3.2, fix CVE-2021-43813, CVE-2021-43815
* [`150a6f41`](https://github.com/NixOS/nixpkgs/commit/150a6f4117487e15f67b4a2c62d046d09651446f) syncthing: 1.18.4 -> 1.18.5
* [`4c764d4d`](https://github.com/NixOS/nixpkgs/commit/4c764d4dbf217e48b2eaf54da4ec62c558f6cfd5) shattered-pixel-dungeon: 1.0.0 -> 1.1.0
* [`66352e3e`](https://github.com/NixOS/nixpkgs/commit/66352e3ee4b02927a57b708c32b8314b9df0d948) chromium: Install vk_swiftshader_icd.json
* [`5e4b6df5`](https://github.com/NixOS/nixpkgs/commit/5e4b6df585a90f0661e953ae7583022b06ab8a24) python3Packages.ssdeep: enable tests
* [`74210c7b`](https://github.com/NixOS/nixpkgs/commit/74210c7b48dee7c34d0a998f60ce6e5e99423db8) pythonPackages.pytmx: 3.30 -> 3.31
* [`75af1116`](https://github.com/NixOS/nixpkgs/commit/75af1116153e589b931280303e6098deaaf9c9e9) terragrunt: 0.35.13 -> 0.35.14
* [`0acfd0c1`](https://github.com/NixOS/nixpkgs/commit/0acfd0c1e179c1fa276fd931bdd22f207e7d5a48) ugrep: 3.3.10 -> 3.3.12
* [`a065cc03`](https://github.com/NixOS/nixpkgs/commit/a065cc0359071b0d4a5f92b37bb956682294ed1d) tixati: 2.86 -> 2.87
* [`7810e5eb`](https://github.com/NixOS/nixpkgs/commit/7810e5eb0ce067706234cc280f4576232a109e6f) astromenace: 1.3.2 -> 1.4.1
* [`6871e40b`](https://github.com/NixOS/nixpkgs/commit/6871e40bbb769389645411d237cbbd791ab33e0e) texstudio: 4.1.1 -> 4.1.2
* [`60a72578`](https://github.com/NixOS/nixpkgs/commit/60a72578ff96e6a7c5166f62aadab08af389f04c) ocrmypdf: 13.1.0 -> 13.1.1
* [`480fbd70`](https://github.com/NixOS/nixpkgs/commit/480fbd70487fb0e92480b53f9904300e03726ccd) elmPackages.elm-git-install: init at 0.1.3
* [`005aa180`](https://github.com/NixOS/nixpkgs/commit/005aa1807cc2fb575ce42edac3884b1728e93110) python38Packages.lupupy: 0.0.22 -> 0.0.24
* [`38da06c6`](https://github.com/NixOS/nixpkgs/commit/38da06c69f821af50323d54b28d342cc3eb42891) arrow-cpp: fix sandboxed build on darwin
* [`6d797036`](https://github.com/NixOS/nixpkgs/commit/6d7970362f9d73ae5f477ba3c6e7f5a4873d87e6) python3Packages.aioambient: 2021.10.1 -> 2021.12.0
* [`632c8b42`](https://github.com/NixOS/nixpkgs/commit/632c8b42c45bb6f8ab87d2db5672c23abd018d4c) python3Packages.aioymaps: 1.2.1 -> 1.2.2
* [`ecc5da77`](https://github.com/NixOS/nixpkgs/commit/ecc5da7743983b7fbb41d8cee0c9c99823940f11) python3Packages.buienradar: 1.0.4 -> 1.05
* [`41b6fc71`](https://github.com/NixOS/nixpkgs/commit/41b6fc7176526eaaf85189c2e1c85831a2a90f79) python3Packages.google-nest-sdm: 0.4.0 -> 0.4.5
* [`68aa7a80`](https://github.com/NixOS/nixpkgs/commit/68aa7a8081899bfc461a26b3d9ca1a29a5cedfcd) python3Packages.hatasmota: 0.3.0 -> 0.3.1
* [`875e6c15`](https://github.com/NixOS/nixpkgs/commit/875e6c15b8401ffadd5baffe2f00831a6e9da459) python3Packages.py17track: 3.3.0 -> 2021.12.2
* [`62b6d864`](https://github.com/NixOS/nixpkgs/commit/62b6d864d207d7b3192a37457672dc9d5292cfee) python3Packages.pydexcom: 0.2.0 -> 0.2.1
* [`897c0c6e`](https://github.com/NixOS/nixpkgs/commit/897c0c6ec032de94b0631fd00c31bc0f9de51ff2) python3Packages.pyefergy: 0.1.4 -> 0.1.5
* [`b11d09f7`](https://github.com/NixOS/nixpkgs/commit/b11d09f79352c8c1b27131461668e09a3c8d60ec) python3Packages.simplisafe-python: 2021.11.2 -> 2021.12.1
* [`a7760fb1`](https://github.com/NixOS/nixpkgs/commit/a7760fb114cadc27299adce9c7f9b04e76e304ed) python3Packages.twentemilieu: 0.3.0 -> 0.5.0
* [`957538cd`](https://github.com/NixOS/nixpkgs/commit/957538cd9dd163c068b984bb15704daaf8217290) python3Packages.wled: 0.8.0 -> 0.10.2
* [`f21a477c`](https://github.com/NixOS/nixpkgs/commit/f21a477c7b380f113200ce5ceaebc3e8dfe727e7) python3Packages.zigpy: 0.41.0 -> 0.42.0
* [`c9e02713`](https://github.com/NixOS/nixpkgs/commit/c9e0271369f228d66f574997e77bfd13910e229e) python3Packages.zha-quirks: 0.0.63 -> 0.0.65
* [`fd19df26`](https://github.com/NixOS/nixpkgs/commit/fd19df269d61b897dc42cbbe9495cfa1bdd6fe09) home-assistant: 2021.11.4 -> 2021.12.0
* [`510d7ec6`](https://github.com/NixOS/nixpkgs/commit/510d7ec6d71c176c26dc393e8f38af6843a343ec) python3Packages.velbus-aio: fetch submodules
* [`4cc23f2b`](https://github.com/NixOS/nixpkgs/commit/4cc23f2b1e1b9ae443d257129001caebca464d2f) why3.withProvers: add dontUnpack
* [`9ec8e461`](https://github.com/NixOS/nixpkgs/commit/9ec8e461418c18766a6abdfb2345ef22a10d1e09) coqPackages.serapi: init at 8.14.0+0.14.0 for Coq 8.14 & OCaml < 4.12 ([nixos/nixpkgs⁠#148775](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/148775))
* [`760a55ab`](https://github.com/NixOS/nixpkgs/commit/760a55ab931022795396e37985718e2c08107b22) python38Packages.plaid-python: 8.7.0 -> 8.8.0
* [`bf2ed226`](https://github.com/NixOS/nixpkgs/commit/bf2ed226735fc51634d9b3b147deb62e6a8e31a6) gnome.gnome-calendar: 41.1 -> 41.2
* [`b27d0da9`](https://github.com/NixOS/nixpkgs/commit/b27d0da9d87ed6bc65a4c677e8cb9f4ebd410234) python3Packages.pyoctoprintapi: init at 0.1.7
* [`11802670`](https://github.com/NixOS/nixpkgs/commit/1180267064d2a7c098d53438a58c6155fb121226) home-assistant: update component-packages
* [`1445fca5`](https://github.com/NixOS/nixpkgs/commit/1445fca5d67e63c4a1ba116de42d1693e04e7ccb) home-assistant: test octoprint component
* [`8fda3f69`](https://github.com/NixOS/nixpkgs/commit/8fda3f6989d73729ad6a92fe59573a0b5dd9b55b) jackline: use default version of OCaml
* [`79ab6a83`](https://github.com/NixOS/nixpkgs/commit/79ab6a83828ecee660e362e6c97384ff0489f9b2) signald: incorporate log4j update for CVE-2021-44228
* [`03d3ea77`](https://github.com/NixOS/nixpkgs/commit/03d3ea77984738f095b8867f4ae7354616b0fa17) imgui: init at 1.85
* [`08724263`](https://github.com/NixOS/nixpkgs/commit/087242632bdbc056934555b8c62ac3ace1a34c64) python3Packages.ml-collections: init at 0.1.0
* [`7aa85933`](https://github.com/NixOS/nixpkgs/commit/7aa859336967273d230ffc8ef8a6978088f4b8aa) python3Packages.mizani: init at 0.7.3
* [`c473cc87`](https://github.com/NixOS/nixpkgs/commit/c473cc8714710179df205b153f4e9fa007107ff9) python3Packages.dm-tree: init at 0.1.6
