### PR TITLE
niv home-manager: update 781d25b3 -> ea5591d2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "781d25b315def05cd7ede3765226c54216f0b1fe",
-        "sha256": "14cbfsslf1qbgkif3hrgn6x5rxa9h6b61jh4jmjbfi6mbnxvn8r9",
+        "rev": "ea5591d225c379d7b0ad594ab901bec498aefe91",
+        "sha256": "0rz74wb909ym3n5zj0c0nz32kdxrh4jg1yaxic3jk7m3pqvyrr44",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/781d25b315def05cd7ede3765226c54216f0b1fe.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/ea5591d225c379d7b0ad594ab901bec498aefe91.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@781d25b3...ea5591d2](https://github.com/nix-community/home-manager/compare/781d25b315def05cd7ede3765226c54216f0b1fe...ea5591d225c379d7b0ad594ab901bec498aefe91)

* [`78ff6b85`](https://github.com/nix-community/home-manager/commit/78ff6b851cec07b1ce0ac0af60c6744280ca42e8) gpg-agent: fix and enable tests
* [`736581f1`](https://github.com/nix-community/home-manager/commit/736581f113c90e8805d04899f422880d51fa9d2d) gpg-agent: rewrite hash algo in Nix to avoid IFD
* [`829e89a1`](https://github.com/nix-community/home-manager/commit/829e89a16f4f96428d1b94e68d4c06107b5491c0) less: store 'lesskey' under XDG_CONFIG_HOME
* [`c7592b74`](https://github.com/nix-community/home-manager/commit/c7592b747b332eded1a1728e87abbc6e66b934f4) treewide: prefer XDG variables over dot directories
* [`fa73c316`](https://github.com/nix-community/home-manager/commit/fa73c3167eca42fee081df64ad47319be37d999b) sqls: add module
* [`6fe3b539`](https://github.com/nix-community/home-manager/commit/6fe3b539e057feadbf94e845412f4b438260690b) navi: add module
* [`0ebed30a`](https://github.com/nix-community/home-manager/commit/0ebed30a10617bd48dd1bd0ce8697aab1b42d933) gromit-mpx: add module
* [`543484d2`](https://github.com/nix-community/home-manager/commit/543484d298abaab9c6ec5cfc1f8a772791e086ec) navi: don't install widget on limited terminals
* [`3d46c011`](https://github.com/nix-community/home-manager/commit/3d46c011d2cc2c9ca24d9b803e9daf156d9429ea) opensnitch-ui: add module
* [`9bcad200`](https://github.com/nix-community/home-manager/commit/9bcad2001386a086acda24ae973c230c7b06513f) home-manager: add basic i18n support
* [`0422d1f8`](https://github.com/nix-community/home-manager/commit/0422d1f87fa82d5e7cdd31b308211b6be2183571) Add translation using Weblate (Norwegian Bokmål)
* [`1fad70e9`](https://github.com/nix-community/home-manager/commit/1fad70e995ce6c7447135bfc8b44153553be0666) Add translation using Weblate (Norwegian Bokmål)
* [`2ff170d9`](https://github.com/nix-community/home-manager/commit/2ff170d91c5506402930ac13f541c3caaa700f7c) Translate using Weblate (Swedish)
* [`0c6180c7`](https://github.com/nix-community/home-manager/commit/0c6180c714e9ed0c67bcac2ca1638e57d1a28e44) Translate using Weblate (Norwegian Bokmål)
* [`ea5591d2`](https://github.com/nix-community/home-manager/commit/ea5591d225c379d7b0ad594ab901bec498aefe91) Translate using Weblate (Norwegian Bokmål)
