### PR TITLE
niv powerlevel10k: update 3380f750 -> 3091ffbd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "3380f7503e7dc252163d5b30475335ed67f58a98",
-        "sha256": "1dwrn7qaxg3qhijrrjzia0c4z9q278niy6p71q1x3h2px3dpwmf2",
+        "rev": "3091ffbd8657a0d4df645a7336700a242af855f7",
+        "sha256": "1ipvgv8yp4dns90d43nh6p5cacslivswz5vdhdxqrd1i9sfs3zh6",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/3380f7503e7dc252163d5b30475335ed67f58a98.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/3091ffbd8657a0d4df645a7336700a242af855f7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@3380f750...3091ffbd](https://github.com/romkatv/powerlevel10k/compare/3380f7503e7dc252163d5b30475335ed67f58a98...3091ffbd8657a0d4df645a7336700a242af855f7)

* [`abc5df44`](https://github.com/romkatv/powerlevel10k/commit/abc5df446d28b64a7c792b867da6d0357a675e39) attempt to fix asdf when some files have windows line endings ([romkatv/powerlevel10k⁠#1653](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1653))
* [`fde8bf62`](https://github.com/romkatv/powerlevel10k/commit/fde8bf62d451c621fb1bc05f9564140ffdc1672a) fix prefix-based formatting of numbers that are slightly below the boundary ([romkatv/powerlevel10k⁠#1664](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1664))
* [`3091ffbd`](https://github.com/romkatv/powerlevel10k/commit/3091ffbd8657a0d4df645a7336700a242af855f7) bust caches
