### PR TITLE
niv spacemacs: update a86cdd35 -> 651a7a9f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "a86cdd3506ec30aafdf5a3c16bac81715dc4f875",
-        "sha256": "1mxssy11i27g18k1vmk14dwk2s3yhp62jl76d7n44h572sfv6y1k",
+        "rev": "651a7a9f11b6095c77ac29ed05659185d7490830",
+        "sha256": "1a75ph9ad3fl4gs64bdfmyc2q8p23bzl48m07agrnicp0iiqbrma",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/a86cdd3506ec30aafdf5a3c16bac81715dc4f875.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/651a7a9f11b6095c77ac29ed05659185d7490830.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@a86cdd35...651a7a9f](https://github.com/syl20bnr/spacemacs/compare/a86cdd3506ec30aafdf5a3c16bac81715dc4f875...651a7a9f11b6095c77ac29ed05659185d7490830)

* [`d3071ae3`](https://github.com/syl20bnr/spacemacs/commit/d3071ae37bbd3a527e3ad429d6f0e8f9bfd8c980) Improve temporary fix for evil-redirect-digit-argument
* [`8b895fe2`](https://github.com/syl20bnr/spacemacs/commit/8b895fe2907fb7c50bc82aae1215f0b0aecfec55) Fix [syl20bnr/spacemacs⁠#15186](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15186), broken package update due to commit cac0105
* [`3883d1b1`](https://github.com/syl20bnr/spacemacs/commit/3883d1b195518dea243a57a7c950f7cb08be4a4f) Add pdf occur follow mode spacemacs binding
* [`651a7a9f`](https://github.com/syl20bnr/spacemacs/commit/651a7a9f11b6095c77ac29ed05659185d7490830) Fix [syl20bnr/spacemacs⁠#15198](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15198): Apply ansi-colors to compilation-mode derived modes
