### PR TITLE
niv zsh-completions: update 1a080869 -> e4090f1b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "1a0808696c5dd6d90ed530e512f3d0a28a7565b8",
-        "sha256": "0lby926k07r4v8f78abxn9b9fbms3hcib0gb52pg9c08gw4m1y9b",
+        "rev": "e4090f1baa4cc0b7adf89c618d6224edaee6a31d",
+        "sha256": "0h83p6qxymr52p6kjirihb5brabxi567p86mq2j5yw5vg82fpf46",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/1a0808696c5dd6d90ed530e512f3d0a28a7565b8.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/e4090f1baa4cc0b7adf89c618d6224edaee6a31d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@1a080869...e4090f1b](https://github.com/zsh-users/zsh-completions/compare/1a0808696c5dd6d90ed530e512f3d0a28a7565b8...e4090f1baa4cc0b7adf89c618d6224edaee6a31d)

* [`c6bce735`](https://github.com/zsh-users/zsh-completions/commit/c6bce7358cdcb979f95018714b8dee81131f240a) Update collect workspaces command
* [`2f54f2b2`](https://github.com/zsh-users/zsh-completions/commit/2f54f2b21287a5753728feba1ae2abcbf9df2aab) Support both older and newer versions
* [`839df669`](https://github.com/zsh-users/zsh-completions/commit/839df669222b7c25b8ffcacbcbd3f01c9154df24) Don't use yarn run --json for newer yarn
* [`790890e2`](https://github.com/zsh-users/zsh-completions/commit/790890e25658f9b5c6ba68264d888a2b191b895e) Fix no node_modules case
