### PR TITLE
niv zsh-you-should-use: update ccc7e7f7 -> 773ae5f4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -240,10 +240,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "ccc7e7f75bd7169758a1c931ea574b96b71aa9a0",
-        "sha256": "12kwwk4gqg00n4xinf8iw30gfjwshjj1vhvmykjk3czxjiw66cl5",
+        "rev": "773ae5f414b296b4100f1ab6668ecffdab795128",
+        "sha256": "1im305039cmfqhp4z0v0fkr7savgx2dvq7qgb5kkcsij7k8p10c3",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/ccc7e7f75bd7169758a1c931ea574b96b71aa9a0.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/773ae5f414b296b4100f1ab6668ecffdab795128.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@ccc7e7f7...773ae5f4](https://github.com/MichaelAquilina/zsh-you-should-use/compare/ccc7e7f75bd7169758a1c931ea574b96b71aa9a0...773ae5f414b296b4100f1ab6668ecffdab795128)

* [`c69d4a5e`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/c69d4a5e61652adc1101ef987f9524fda972228a) "disabling aliases" renamed to "ignoring aliases"
* [`fed8ddd9`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/fed8ddd9c84922b5a7d20c6aafb3e4069f6c7979) Update README.rst
* [`bc98348c`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/bc98348c728dda207d3af3ca6acdc4c2232050c2) Update README.rst
