### PR TITLE
niv nixpkgs: update 356656f1 -> d263feb6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "356656f14309070dddb51262ff5b51e6d300a17d",
-        "sha256": "0ih142hfbjjkvsikza00k6ipsnn41zsmrzf9masq2xcdjhqr0g9i",
+        "rev": "d263feb6f6392939c4c5e0a2608a450f65417d18",
+        "sha256": "1gdnbsnljld4ha3nqwmgvx9k9yirs03spn4y56x9hjx3gdx7a7f0",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/356656f14309070dddb51262ff5b51e6d300a17d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d263feb6f6392939c4c5e0a2608a450f65417d18.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@356656f1...d263feb6](https://github.com/nixos/nixpkgs/compare/356656f14309070dddb51262ff5b51e6d300a17d...d263feb6f6392939c4c5e0a2608a450f65417d18)

* [`af2d3a99`](https://github.com/NixOS/nixpkgs/commit/af2d3a995828be3bb7b652493ae3be2f14c6833f) tor: 0.4.6.8 -> 0.4.6.9
* [`8bbae8e5`](https://github.com/NixOS/nixpkgs/commit/8bbae8e55873b31faf233cd40cf212b0b8b113c6) unifi: Add NixOS tests
* [`d06fdce8`](https://github.com/NixOS/nixpkgs/commit/d06fdce8958638c8d33437e6d95556d49a9b1e72) vscode: 1.63.1 -> 1.63.2
* [`f3bf177c`](https://github.com/NixOS/nixpkgs/commit/f3bf177c8293a077cc25bc76aa87ab3549e94739) vscodium: 1.63.1 -> 1.63.2
* [`86c501ac`](https://github.com/NixOS/nixpkgs/commit/86c501ac10b999435c5216bd21ef259b98be0e96) python38Packages.casbin: 1.15.1 -> 1.15.2
* [`0cd8847e`](https://github.com/NixOS/nixpkgs/commit/0cd8847e777adaeacf4e879e9481502a4bb23627) dnscontrol: 3.13.0 -> 3.13.1
* [`001c75d5`](https://github.com/NixOS/nixpkgs/commit/001c75d537c959f028229f33803a8c15b142613b) youtube-dl: 2021.06.06 -> 2021.12.17
* [`a958b834`](https://github.com/NixOS/nixpkgs/commit/a958b83425527d881a3ded7eae08b7f44d2ffc6f) smenu: 0.9.18 -> 0.9.19
* [`0f723901`](https://github.com/NixOS/nixpkgs/commit/0f7239019de54a1f7860547ba7f341eeb219ad8f) log4j-sniffer: init at 0.4.0
* [`d62fdbd0`](https://github.com/NixOS/nixpkgs/commit/d62fdbd0be1db6f6bed4bdcaeee6cbb8716f0bf9) checkov: 2.0.668 -> 2.0.672
* [`96c1f0ca`](https://github.com/NixOS/nixpkgs/commit/96c1f0cab49a2d0a6efa98d70364d83a5fb9e53c) gosec: 2.9.3 -> 2.9.5
* [`3017da16`](https://github.com/NixOS/nixpkgs/commit/3017da1633f1974043657361ef1e540fee0337ee) treefmt: 0.2.6 -> 0.3.0 ([nixos/nixpkgs⁠#151110](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/151110))
* [`cef16945`](https://github.com/NixOS/nixpkgs/commit/cef1694515c38c882a3cf23e0cb763495b6d2b95) mednaffe: remove gtk2
* [`4b18165b`](https://github.com/NixOS/nixpkgs/commit/4b18165b53a21ab83179a304d03c7b39301c8de7) SDL_image: use pkg-config
* [`1c93b890`](https://github.com/NixOS/nixpkgs/commit/1c93b890460edb2c0a6e8de063d7024a814c1bc6) SDL_net: use pkg-config
* [`d76192f9`](https://github.com/NixOS/nixpkgs/commit/d76192f94eb101de90bde4c38ae06587e9fde535) SDL_mixer: use pkg-config
* [`34ffda15`](https://github.com/NixOS/nixpkgs/commit/34ffda15ead7fddaa5a39527e534b950761d7d31) tree-sitter: add many new grammars
* [`192fcbd3`](https://github.com/NixOS/nixpkgs/commit/192fcbd32a446dc9899dcf1d9f9b04ff43a3c366) docs: Fix markdown in Rust language section
* [`c55e31a2`](https://github.com/NixOS/nixpkgs/commit/c55e31a2ab88c60979422a45f849f2a4b0097ede) maintainers: add redcodelabs team
* [`f8fa4891`](https://github.com/NixOS/nixpkgs/commit/f8fa489193b5a1df728c2bb22b833b4e8b14b2b5) deno: fix sharedLibrary value usage
* [`b8ea60f4`](https://github.com/NixOS/nixpkgs/commit/b8ea60f47becc7bbaf9dd66f4be132c5cb31fb6e) v2ray-domain-list-community: fix cross compilation
* [`609eb1fa`](https://github.com/NixOS/nixpkgs/commit/609eb1fab9db58ecb9a1405a42bb62ad2115f9cf) pdftk: 3.2.1 -> 3.3.1
* [`b9d1f443`](https://github.com/NixOS/nixpkgs/commit/b9d1f44354bfbde79bcf8b54fa62838de86bfb53) python2Packages.filelock: use correct version
* [`be894db6`](https://github.com/NixOS/nixpkgs/commit/be894db6a8c6e60a6ac7a50d71a14915ad5bf2f1) gtk2: fix cross compilation
* [`f017ea33`](https://github.com/NixOS/nixpkgs/commit/f017ea339c93efc09015286eba510709e8e40dbe) uhttpmock: fix cross compilation
* [`e4ab3d72`](https://github.com/NixOS/nixpkgs/commit/e4ab3d72b814f7d4d66cb578f106e541fd1d8686) python2Packages.virtualenv: disable two failing tests
* [`2e5cfa6d`](https://github.com/NixOS/nixpkgs/commit/2e5cfa6de751cc2e7d75a0fd3060af63cf37a427) python2Packages.platformdirs: init at 2.0.2
* [`4853c2d3`](https://github.com/NixOS/nixpkgs/commit/4853c2d3759bb5d7a894a3457684b71bd8b9c79c) python2.tests.nixenv-virtualenv: fix test
* [`843729d4`](https://github.com/NixOS/nixpkgs/commit/843729d487135871e4b64e959042429d792d7778) luna-icons: 1.7 -> 1.8
* [`a8a7e5af`](https://github.com/NixOS/nixpkgs/commit/a8a7e5af8dd21ac5c233620687040ee7b2d58ebf) conan: 1.40.0 -> 1.43.1
* [`47e354b1`](https://github.com/NixOS/nixpkgs/commit/47e354b1059f4632bd472d7bcc4922bfd8a75e44) mpich: 3.4.2 -> 3.4.3
* [`eedb795f`](https://github.com/NixOS/nixpkgs/commit/eedb795fd2cb4c720529b652791b101dc21a90a5) maintainers: rename enzime to Enzime
* [`9f915836`](https://github.com/NixOS/nixpkgs/commit/9f9158362e6294ab942d134d31e1c19441bf5e05) spotify-tray: init at 1.3.2
* [`38cf64ea`](https://github.com/NixOS/nixpkgs/commit/38cf64eac09cbfc5b7fd818e78499c4ee8644d0d) nodejs-17_x: 17.2.0 -> 17.3.0
* [`c8aed5f9`](https://github.com/NixOS/nixpkgs/commit/c8aed5f960e567a5c48ce1b54bb8c85722fda49d) nim: 1.6.0 -> 1.6.2
* [`0b97e890`](https://github.com/NixOS/nixpkgs/commit/0b97e89049159eb3c74f3824d9dbcec046b6fb7f) doc/python: update buildPythonApplication example
* [`1da3af6b`](https://github.com/NixOS/nixpkgs/commit/1da3af6bec34ad3de941f5ea1e84e72c04f655a6) buildNimPackages: fix configurePhase
* [`a999c2b8`](https://github.com/NixOS/nixpkgs/commit/a999c2b862cde8e168543dc5c942766619d56b4a) dotnet: fix build on darwin
* [`bdc50c70`](https://github.com/NixOS/nixpkgs/commit/bdc50c70bee87d43a92f70f0d491261435278fce) grype: 0.26.1 -> 0.27.3
* [`5b12a5ea`](https://github.com/NixOS/nixpkgs/commit/5b12a5ea1adbbea74f1fbf97a90bd00baff17eb7) beets: 1.5.0 -> 1.6.0
* [`770e2612`](https://github.com/NixOS/nixpkgs/commit/770e26126f988161589eb9f9d66f3aef20504928) aspellDicts: fix cross compilation
* [`bd06f1e3`](https://github.com/NixOS/nixpkgs/commit/bd06f1e3eb93253f9227d5c95274282e085b972e) oh-my-zsh: 2021-12-16 -> 2021-12-18
* [`80a692e2`](https://github.com/NixOS/nixpkgs/commit/80a692e269fc82b0feaa17c1ec00714f4ebf617c) ciao: mark as broken on darwin
* [`438e4b19`](https://github.com/NixOS/nixpkgs/commit/438e4b1910f74ac3545ea625b5f80451ef315bb8) python3Packages.pypandoc: 1.6.4 -> 1.7.0
* [`f10aea24`](https://github.com/NixOS/nixpkgs/commit/f10aea24347a7246a020aa6498ba857de463fd5d) nixos/ssh: Add enableAskPassword
* [`3fb8f402`](https://github.com/NixOS/nixpkgs/commit/3fb8f4025265332dae3e4445e3129c1b765eaaf1) stress-ng: 0.13.03 -> 0.13.08
* [`67f95f15`](https://github.com/NixOS/nixpkgs/commit/67f95f156e181582129e24b1214eaa44d5a8df8b) python3Packages.aiosenz: init at 1.0.0
* [`09b8e7c8`](https://github.com/NixOS/nixpkgs/commit/09b8e7c89bcb9eca85c5d69a3e9961decbe3c232) drawio: 15.8.7 -> 16.0.0
* [`44445a80`](https://github.com/NixOS/nixpkgs/commit/44445a808c57ebeb625f7fdaec5599815ce8ea42) python3Packages.pywizlight: 0.4.15 -> 0.4.16
* [`32f184a1`](https://github.com/NixOS/nixpkgs/commit/32f184a1f0a93124ad92afda3c04d7a26b7afb65) log4j-scan: unstable-2021-12-14 -> unstable-2021-12-18
* [`77b116f0`](https://github.com/NixOS/nixpkgs/commit/77b116f09f5523f45852c63a35ba0b11c130e119) lmp: 1.0 -> 1.1
* [`4d8db814`](https://github.com/NixOS/nixpkgs/commit/4d8db814713da6f960ea0c00ab2be2577b810369) log4j-sniffer: 0.4.0 -> 0.7.0
* [`927b9f17`](https://github.com/NixOS/nixpkgs/commit/927b9f1728d57e7d7b141c871f5717307e703c47) just: 0.10.3 -> 0.10.5
* [`e63a8056`](https://github.com/NixOS/nixpkgs/commit/e63a8056d31e263075d7e05f17b50a9f67adee9f) python3Packages.flux-led: 0.26.11 -> 0.27.7
* [`487bb1b1`](https://github.com/NixOS/nixpkgs/commit/487bb1b1e232015fe4732880389f2fa664f812fc) python3Packages.tensorflow: switched to Nix-provided protobuf. ([nixos/nixpkgs⁠#150887](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/150887))
* [`99d859d4`](https://github.com/NixOS/nixpkgs/commit/99d859d4b59623a988935e7c2264e1b5665a5338) cpustat: 0.02.09 -> 0.02.17
* [`1af5f62c`](https://github.com/NixOS/nixpkgs/commit/1af5f62c1c00fee90fb461c991f1a1491e8aa19e) spacevim: 1.7 -> 1.8
* [`64698756`](https://github.com/NixOS/nixpkgs/commit/64698756087d543f142bd66956f35afc23d11385) gnome.gnome-remote-desktop: 41.1 -> 41.2
* [`5dd8c8cb`](https://github.com/NixOS/nixpkgs/commit/5dd8c8cb1c1867a8a79bf602c978ba3ec8a4f8fc) vimPlugins: update
* [`c9f6025c`](https://github.com/NixOS/nixpkgs/commit/c9f6025c2db5ad087f0ece153828d3c6c843a56c) vimPlugins: resolve github repository redirects
* [`80c4454e`](https://github.com/NixOS/nixpkgs/commit/80c4454e05142134945c292c7c40ef5b8b859377) vimPlugins.nvim-fzf: init at 2021-10-25
* [`fa560a94`](https://github.com/NixOS/nixpkgs/commit/fa560a9423d16eb77e8cafc818160e047a13c67f) vimPlugins.nvim-fzf-commands: init at 2021-05-31
* [`86423ee4`](https://github.com/NixOS/nixpkgs/commit/86423ee4dfb5714dba76983150202a99b1def207) python3Packages.pymavlink: 2.4.17 -> 2.4.19
* [`d14a6ef1`](https://github.com/NixOS/nixpkgs/commit/d14a6ef13e6dba774c90603744d809a3786340e9) mavproxy: 1.8.45 -> 1.8.46
* [`4ec32d1b`](https://github.com/NixOS/nixpkgs/commit/4ec32d1ba344253edb654567df4b0a2794d4fd7e) kodi: move kodi-packages/ to kodi/addons/
* [`42e445f2`](https://github.com/NixOS/nixpkgs/commit/42e445f2571508ddde959e64401edec51e0a8b18) pantheon.wingpanel: 3.0.1 -> 3.0.2
* [`52f2c250`](https://github.com/NixOS/nixpkgs/commit/52f2c2500a62fdf7ea267b91307613031547a9c7) pkgs/pantheon: fix typo
* [`293e2023`](https://github.com/NixOS/nixpkgs/commit/293e20235ea6cf26aa7b870ef8440e2163202697) vsce/CoenraadS.bracket-pair-colorizer-2: 0.2.1 -> 0.2.2
* [`174d6284`](https://github.com/NixOS/nixpkgs/commit/174d628499245d9cd267cd34ba5d51385e975b8c) vsce/eamodio.gitlens: 11.6.0 -> 11.7.0
* [`8610ae60`](https://github.com/NixOS/nixpkgs/commit/8610ae6037af2609d8a620976cbadf9ae1775246) index-fm: fix pname
* [`24111d6a`](https://github.com/NixOS/nixpkgs/commit/24111d6a7a8c8ffb714b797bf7c83f888647bb03) mathematica: 12.3.1 -> 13.0.0 ([nixos/nixpkgs⁠#151213](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/151213))
* [`91c398c7`](https://github.com/NixOS/nixpkgs/commit/91c398c7ab34c609d93d63729150193db89169e0) aaphoto: 0.43.1 -> 0.45
* [`c6c31833`](https://github.com/NixOS/nixpkgs/commit/c6c31833286232b712756da7cae639899e1e34ae) ttyper: 0.3.0 -> 0.4.0
* [`f9c6fd37`](https://github.com/NixOS/nixpkgs/commit/f9c6fd3779468cd31ad1a696d4f9dda2630e5ee9) ttyper: add maintainer max-niederman
* [`0a57633e`](https://github.com/NixOS/nixpkgs/commit/0a57633edb730b4c8ec72decd66c8082fc7cb912) transcribe: 9.00 -> 9.10
* [`917e50c8`](https://github.com/NixOS/nixpkgs/commit/917e50c8f8464050e34beac30d2a4f5272bb110d) python38Packages.mistletoe: 0.7.2 -> 0.8.1
* [`71e0e816`](https://github.com/NixOS/nixpkgs/commit/71e0e816166030feefaf99aa65e14488fac47434) atuin: 0.7.1 -> 0.8.0, install shell completion, add SuperSandro2000 as maintainer
* [`cbfc5072`](https://github.com/NixOS/nixpkgs/commit/cbfc50722fc0dc4e21f08ef1bef0190e3fe78ea0) maintainers: drop phreedom
* [`bcf0c282`](https://github.com/NixOS/nixpkgs/commit/bcf0c28257c9d97dc41008de9b69035433d85852) qmplay2: 21.06.07 -> 21.12.07
* [`04432e8f`](https://github.com/NixOS/nixpkgs/commit/04432e8f11ff51b8252d0946fb426fbd128eeea2) libsForQt5.qtutilities: 6.5.2 -> 6.5.3
* [`57ff8c2e`](https://github.com/NixOS/nixpkgs/commit/57ff8c2e36f66ae9cba4f5dd7254d2a4f733183e) qalculate-gtk: 3.21.0 -> 3.22.0
* [`debe88d9`](https://github.com/NixOS/nixpkgs/commit/debe88d90b6cedccd2c668d29c9a3133707f74a7) wayvnc: 0.4.0 -> 0.4.1
* [`c5070df9`](https://github.com/NixOS/nixpkgs/commit/c5070df97139eed92c8043d3a246ceca64277505) ocamlPackages.iter: 1.2.1 → 1.3
* [`a91a7614`](https://github.com/NixOS/nixpkgs/commit/a91a76146d7f5cbeb9f79458fbdcd90578c39847) waypipe: 0.8.1 -> 0.8.2 ([nixos/nixpkgs⁠#148600](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/148600))
* [`134376e2`](https://github.com/NixOS/nixpkgs/commit/134376e2561c027a9588db76ba300fc4c28dced7) vim: 8.2.3451 -> 8.2.3848
* [`c085a87c`](https://github.com/NixOS/nixpkgs/commit/c085a87cb0aa9bc9f1d180b113e47bedbf1bf11a) cointop: 1.6.8 -> 1.6.10
* [`2e2622dd`](https://github.com/NixOS/nixpkgs/commit/2e2622dd5c8568006bae6bfd2c4ba914d993efbf) duckstation: unstable-2021-10-29 -> 0.pre+date=2021-12-16
* [`34d74ee3`](https://github.com/NixOS/nixpkgs/commit/34d74ee311d377d1f4f1031f5a2cf8b4ee17ae09) python38Packages.ring-doorbell: 0.7.1 -> 0.7.2
* [`9a86a53e`](https://github.com/NixOS/nixpkgs/commit/9a86a53ec5104966717a4963e3f759304120e6c9) emacs: Ignore large file warnings for native compilation
* [`4192dce5`](https://github.com/NixOS/nixpkgs/commit/4192dce5385453340ee6ba0dc664ddbfa99d55b5) melpa2nix: Ignore large file warnings
* [`60420c09`](https://github.com/NixOS/nixpkgs/commit/60420c098abc206f5fbfbf31a13f7b96f073cc16) mgba: 0.9.2 -> 0.9.3
* [`15e4dfff`](https://github.com/NixOS/nixpkgs/commit/15e4dfff8bc18527d5180d976c95feb8680ed797) endgame-singularity: add all licenses
* [`b20024dd`](https://github.com/NixOS/nixpkgs/commit/b20024dd3a2323416642fc13c69a1a772504fe82) elan: set LEAN_CC to stdenv cc
* [`f6cc3760`](https://github.com/NixOS/nixpkgs/commit/f6cc37608d79fb4eadf3883360c10e28e89fbc18) gnuchess: refactor
* [`95655d91`](https://github.com/NixOS/nixpkgs/commit/95655d91523ffbc000d9a98392169a5056dfbd04) rofi-pulse-select: init at 0.2.0
* [`f58b14b0`](https://github.com/NixOS/nixpkgs/commit/f58b14b0ac44e20e40791573329cfd3cc394024a) gnome.gnome-desktop: make deterministic
* [`acb62658`](https://github.com/NixOS/nixpkgs/commit/acb62658663bf60255d0c687da87b928c85fe00f) gnome.gnome-desktop: set gnome_distributor
* [`95238b8a`](https://github.com/NixOS/nixpkgs/commit/95238b8a29a3629da8d84c390319af75dd3ce5e2) appeditor: 1.1.1 -> 1.1.3
