### PR TITLE
niv home-manager: update ea5591d2 -> aef97988

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ea5591d225c379d7b0ad594ab901bec498aefe91",
-        "sha256": "0rz74wb909ym3n5zj0c0nz32kdxrh4jg1yaxic3jk7m3pqvyrr44",
+        "rev": "aef97988dac0541747de8bcc85c7e27726eea4af",
+        "sha256": "15id5prqlbg7jqhhjna4901rjib6vkfm0fmavvmdbnmf988gkc4m",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/ea5591d225c379d7b0ad594ab901bec498aefe91.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/aef97988dac0541747de8bcc85c7e27726eea4af.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@ea5591d2...aef97988](https://github.com/nix-community/home-manager/compare/ea5591d225c379d7b0ad594ab901bec498aefe91...aef97988dac0541747de8bcc85c7e27726eea4af)

* [`9b70b229`](https://github.com/nix-community/home-manager/commit/9b70b22948960011a0bbc725d5bef80beecf0505) Add translation using Weblate (French)
* [`c1677de3`](https://github.com/nix-community/home-manager/commit/c1677de31a53972a21201d56d4a792461b0c8e73) Add translation using Weblate (French)
* [`3d9eb1ce`](https://github.com/nix-community/home-manager/commit/3d9eb1cecd3f2d9f96c60bf9f78899fe54291e9f) home-manager: support i18n of install script
* [`c61fc1c2`](https://github.com/nix-community/home-manager/commit/c61fc1c288bd1fdf96261ba5574a12cf8f9be70b) xmonad: add support for v0.17.0 ([nix-community/home-manager⁠#2522](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2522))
* [`42ba7b63`](https://github.com/nix-community/home-manager/commit/42ba7b630437ab04b9d97b0745194cd913481051) sway: add 'xwayland disable' to sway config if disabled ([nix-community/home-manager⁠#2568](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2568))
* [`f97e921c`](https://github.com/nix-community/home-manager/commit/f97e921c94dd7382787311ee115b58873fbabb4e) Translate using Weblate (French)
* [`1acbc5ad`](https://github.com/nix-community/home-manager/commit/1acbc5ad8bfb4fb3de331a79ae0000b3f2a61d1c) Translate using Weblate (Swedish)
* [`fd7c5e93`](https://github.com/nix-community/home-manager/commit/fd7c5e93460bd2f5869674ff7aff0d6d1767db2c) Translate using Weblate (French)
* [`4108989d`](https://github.com/nix-community/home-manager/commit/4108989d191bde2506868dc02fab893a3219bd94) Translate using Weblate (French)
* [`78aa7cce`](https://github.com/nix-community/home-manager/commit/78aa7cceffe2a48d05694d3ddf7a323d554d9be0) gpg: allow specifying trust levels by name
* [`d8f9dcfb`](https://github.com/nix-community/home-manager/commit/d8f9dcfbd34bace6da54462f2ea08e0f19e21378) pam: add yubico option
* [`25e5a900`](https://github.com/nix-community/home-manager/commit/25e5a900deab645c088ea52d37a5a44c43a639db) Update translation files
* [`6c6f934f`](https://github.com/nix-community/home-manager/commit/6c6f934f0ba77dbcaefa84c106cab505f1e5bc58) gitlab-ci: build HTML manual in a simpler way
* [`8b44e819`](https://github.com/nix-community/home-manager/commit/8b44e81978a2bef60c83ecc0199ab2523310214a) Translate using Weblate (Swedish)
* [`3db60367`](https://github.com/nix-community/home-manager/commit/3db603677509eb0b8c396a3234b1d4b70d023894) waybar: allow using attrs for settings ([nix-community/home-manager⁠#2547](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2547))
* [`679e07e3`](https://github.com/nix-community/home-manager/commit/679e07e32ed079a1d88ec88cd0d30db67a963a2d) Translate using Weblate (French)
* [`aef97988`](https://github.com/nix-community/home-manager/commit/aef97988dac0541747de8bcc85c7e27726eea4af) docs: add release note about translation support
