### PR TITLE
niv powerlevel10k: update 3091ffbd -> a23c4314

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "3091ffbd8657a0d4df645a7336700a242af855f7",
-        "sha256": "1ipvgv8yp4dns90d43nh6p5cacslivswz5vdhdxqrd1i9sfs3zh6",
+        "rev": "a23c4314a1498c026167d2095d207d418201a98d",
+        "sha256": "1q8k55xl55r5c32m0wvsqx4c9a0dymankyp8pczsdw8wg7krxw63",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/3091ffbd8657a0d4df645a7336700a242af855f7.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/a23c4314a1498c026167d2095d207d418201a98d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@3091ffbd...a23c4314](https://github.com/romkatv/powerlevel10k/compare/3091ffbd8657a0d4df645a7336700a242af855f7...a23c4314a1498c026167d2095d207d418201a98d)

* [`45430764`](https://github.com/romkatv/powerlevel10k/commit/4543076483f4c98c3b03d61d1e6f0313b8fbd21c) when using tmux, write unwrapped OSC 133 in addition to wrapped; the new integrated tmux uses them when resizing
* [`a23c4314`](https://github.com/romkatv/powerlevel10k/commit/a23c4314a1498c026167d2095d207d418201a98d) doc: update "horrific mess when resizing terminal window" section
