### PR TITLE
niv spacemacs: update 651a7a9f -> 5bcedd19

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "651a7a9f11b6095c77ac29ed05659185d7490830",
-        "sha256": "1a75ph9ad3fl4gs64bdfmyc2q8p23bzl48m07agrnicp0iiqbrma",
+        "rev": "5bcedd19123248bc7a6d80994784062e524ebe05",
+        "sha256": "1n73xi64gljqdqbpgwj42qcxhl5ssva9s9sb7qdgsy8zr5p2g68z",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/651a7a9f11b6095c77ac29ed05659185d7490830.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/5bcedd19123248bc7a6d80994784062e524ebe05.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@651a7a9f...5bcedd19](https://github.com/syl20bnr/spacemacs/compare/651a7a9f11b6095c77ac29ed05659185d7490830...5bcedd19123248bc7a6d80994784062e524ebe05)

* [`387d1654`](https://github.com/syl20bnr/spacemacs/commit/387d16545573517524a60dbebf0c6e71be58eab6) Replace use of `parent-mode-list` in `spacemacs-visual/funcs.el` ([syl20bnr/spacemacs⁠#15209](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15209))
* [`58ca8bd8`](https://github.com/syl20bnr/spacemacs/commit/58ca8bd87949994e36b18bd28d53bd4dbd7e628c) Fix package update for emacs versions < 26.2 (issue [syl20bnr/spacemacs⁠#15212](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15212)) ([syl20bnr/spacemacs⁠#15215](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15215))
* [`5bcedd19`](https://github.com/syl20bnr/spacemacs/commit/5bcedd19123248bc7a6d80994784062e524ebe05) [bot] built_in_updates ([syl20bnr/spacemacs⁠#15210](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15210))
