### PR TITLE
niv nixpkgs: update d263feb6 -> 6f41cce0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d263feb6f6392939c4c5e0a2608a450f65417d18",
-        "sha256": "1gdnbsnljld4ha3nqwmgvx9k9yirs03spn4y56x9hjx3gdx7a7f0",
+        "rev": "6f41cce03bf41991b60620522aac081f41815747",
+        "sha256": "1y0awxm26a8il9x4z0r8kd5pwsl7rlmnlgfra4q7bymbkdkvyb8z",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d263feb6f6392939c4c5e0a2608a450f65417d18.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6f41cce03bf41991b60620522aac081f41815747.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d263feb6...6f41cce0](https://github.com/nixos/nixpkgs/compare/d263feb6f6392939c4c5e0a2608a450f65417d18...6f41cce03bf41991b60620522aac081f41815747)

* [`e2aa58cc`](https://github.com/NixOS/nixpkgs/commit/e2aa58ccec39faca77640220b7bf7e34cd981db8) kodiPackages.pvr-hdhomerun: 19.0.0 -> 19.0.1
* [`b3a2f0c0`](https://github.com/NixOS/nixpkgs/commit/b3a2f0c0360bb0b3740682657082a7bf20e018f0) jmeter: 5.4.2 -> 5.4.3
* [`c86ac438`](https://github.com/NixOS/nixpkgs/commit/c86ac438420b299fff1e407e92c7bdbd7a834953) kodiPackages.inputstream-adaptive: 19.0.0 -> 19.0.1
* [`5f882c77`](https://github.com/NixOS/nixpkgs/commit/5f882c77a279d86b88056db6fc3c0b48857228bd) tmpmail: 1.1.4 -> 1.1.9
* [`d63606d7`](https://github.com/NixOS/nixpkgs/commit/d63606d759a352bc9a6dfc1fb02f9cdb1f0c8b37) poetry2nix: 1.21.0 -> 1.22.0
* [`c71583df`](https://github.com/NixOS/nixpkgs/commit/c71583df955933b7b3e77ffa9a24d4f2fc8cbe9c) python38Packages.xmlschema: 1.9.1 -> 1.9.2
* [`77116ca8`](https://github.com/NixOS/nixpkgs/commit/77116ca8398d2651c02d0483c9bd26bde0e3a747) tgt: update meta.homepage
* [`10bca262`](https://github.com/NixOS/nixpkgs/commit/10bca26212cffe4f569df58e94e348349b8a5017) deadpixi-sam-unstable: 2017-10-27 -> 2020-07-14
* [`d5bdb7d3`](https://github.com/NixOS/nixpkgs/commit/d5bdb7d39d057d2f96672073d506a7b102be43c9) root: fix installation of bin/rootcint and bin/genreflex
* [`42ecaa0c`](https://github.com/NixOS/nixpkgs/commit/42ecaa0ca44c780b2aca2d6a8369be52174e66df) wsjtx: 2.5.2 -> 2.5.3
* [`cd36651b`](https://github.com/NixOS/nixpkgs/commit/cd36651b1570e0acb120f56c8162d90cc05381a1) zoxide: 0.7.9 -> 0.8.0
* [`fedde5d2`](https://github.com/NixOS/nixpkgs/commit/fedde5d24f4e749a62d3bebcb86e0bb71ce92c64) woeusb-ng: init at 0.2.10
* [`80ea4b1c`](https://github.com/NixOS/nixpkgs/commit/80ea4b1c87e59ad20a38c8369949d5562c1ab13d) python38Packages.databricks-connect: 9.1.4 -> 9.1.5
* [`6fcc9f24`](https://github.com/NixOS/nixpkgs/commit/6fcc9f249f38178ca29cd719dba9b2e62af41c89) ocamlPackages.ocaml-migrate-parsetree-2: 2.2.0 → 2.3.0
* [`40545515`](https://github.com/NixOS/nixpkgs/commit/40545515e54a475e70cc62ee960db7506900c538) vala-language-server: 0.48.3 → 0.48.4
* [`7ecb4299`](https://github.com/NixOS/nixpkgs/commit/7ecb4299a7e6ea4d94215c4403981a4ebcf48f7c) checkov: 2.0.690 -> 2.0.692
* [`89625909`](https://github.com/NixOS/nixpkgs/commit/896259096ea404446d719ea7a07a050b0672ca72) nicotine-plus: Fix crash when opening file dialog, closes [nixos/nixpkgs⁠#142014](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/142014)
* [`e159658b`](https://github.com/NixOS/nixpkgs/commit/e159658bf5e7437d005fee8bb2c4831101809bec) nicotine-plus: 3.1.1 -> 3.2.0
* [`388b7ecf`](https://github.com/NixOS/nixpkgs/commit/388b7ecfa0e71efa3d87695e19aedda502baa29d) monotone: ping boost_170 to fix build
* [`60375da6`](https://github.com/NixOS/nixpkgs/commit/60375da6f7f5aab0227befe186c19f5c9b18a913) python38Packages.snowflake-connector-python: 2.7.1 -> 2.7.2
* [`f3139957`](https://github.com/NixOS/nixpkgs/commit/f3139957682adc2d5ecfc2c40053e51be6b884fb) tflint: 0.34.0 -> 0.34.1
* [`c3131d5c`](https://github.com/NixOS/nixpkgs/commit/c3131d5c325c892aa900a5c3485a9f63b3acaa97) qemu: disable debug info on aarch64-linux
* [`6c011c17`](https://github.com/NixOS/nixpkgs/commit/6c011c17a084c526505c31f86bb29d3049e9a25e) electron_14: 14.2.2 -> 14.2.3
* [`760cec73`](https://github.com/NixOS/nixpkgs/commit/760cec731e4bf7e7aa0479bca11f4d3b95ee1543) electron_15: 15.3.3 -> 15.3.4
* [`f3a39a33`](https://github.com/NixOS/nixpkgs/commit/f3a39a335f125ea95f89e0d08005a8cf15b53fa7) electron_16: 16.0.4 -> 16.0.5
* [`cfcbe0d1`](https://github.com/NixOS/nixpkgs/commit/cfcbe0d16dae599fd9bff1a621c95242b2b34471) sogo: 5.3.0 -> 5.4.0
* [`630ac9b7`](https://github.com/NixOS/nixpkgs/commit/630ac9b73caf88078e17c1b28f9701c1b2ccd241) haskellPackages.ema: reflect maintainer configuration update
* [`755fb7d1`](https://github.com/NixOS/nixpkgs/commit/755fb7d17ee438ed8efb73eb7265aa0a9aea81fa) haskellPackages.haskell-postgis: skip ordering dependent test case
* [`4821b61a`](https://github.com/NixOS/nixpkgs/commit/4821b61a701bfeda777a0372ea7a9fac4aea71d1) haskellPackages.json-to-haskell: skip ordering dependent tests
* [`71e3d4db`](https://github.com/NixOS/nixpkgs/commit/71e3d4dbb1e6369c5378c7ee370162d3690d79fc) haskellPackages.aeson-deriving: disable ordering dependent tests
* [`2725f265`](https://github.com/NixOS/nixpkgs/commit/2725f265741df09256a246c9bd46cf59f75ab813) haskellPackages.morpheus-graphql-core: skip ordering dependent tests
* [`ecb3268d`](https://github.com/NixOS/nixpkgs/commit/ecb3268d04045cd06d9a9389e1cba2fa2d598931) haskellPackages.dropbox: skip ordering dependent tests
* [`b51b7162`](https://github.com/NixOS/nixpkgs/commit/b51b7162b18bb069a19dcb79bf39251b4295689f) haskellPackages.hschema-aeson: skip ordering dependent tests
* [`64a14527`](https://github.com/NixOS/nixpkgs/commit/64a14527a9099ce7ea3b1cc743bc66a06d1bd596) haskellPackages.xmlbf: skip ordering dependent tests
* [`f4b07c35`](https://github.com/NixOS/nixpkgs/commit/f4b07c3549194df4885e4c5254e84d11d10ad685) haskellPackages.aeson-quick: skip ordering dependent tests
* [`73d9158d`](https://github.com/NixOS/nixpkgs/commit/73d9158d70fc895504c8b99e9bb79378cf19ca6e) haskellPackages.hpack-dhall: disable tests due to outdated test data
* [`bcf8a276`](https://github.com/NixOS/nixpkgs/commit/bcf8a276d5d346444a8182381721a2b9c936d146) haskellPackages.polysemy-plugin: unbreak
* [`803aea3d`](https://github.com/NixOS/nixpkgs/commit/803aea3d3c36d0bc601ca13e9cbc084d63c6a1fa) haskellPackages.polysemy-{resume,conc,mocks}: downgrade to unbreak
* [`b07e9851`](https://github.com/NixOS/nixpkgs/commit/b07e9851b7b3ab0f4c36c8f4867223522dc20c00) haskellPackages.memory-cd: work around compilation failure in tests
* [`a808b2d9`](https://github.com/NixOS/nixpkgs/commit/a808b2d9320fbd270aa720646272c53f59d92bfc) haskellPackages.sdp: disable library profiling breaking the build
* [`f9b337d1`](https://github.com/NixOS/nixpkgs/commit/f9b337d15ef8ef58d3b36f29dfbec6a2afaa0fd6) haskellPackages.minio-hs: disable ordering dependent test case
* [`729053d2`](https://github.com/NixOS/nixpkgs/commit/729053d2e8e8f819ee7e5be08a60c01b5469e168) vala-lint: unstable-2021-02-17 -> unstable-2021-11-18
* [`ac7bba60`](https://github.com/NixOS/nixpkgs/commit/ac7bba60a20c176353d87cae3d661c57a29880f1) flow: 0.166.1 → 0.168.0
* [`b072f7ec`](https://github.com/NixOS/nixpkgs/commit/b072f7ec195ca2da515bb487d7e4b1deb9ca40b9) gegl: 0.4.32 → 0.4.34
* [`e6c3e3d3`](https://github.com/NixOS/nixpkgs/commit/e6c3e3d3948cdea2c816d280c7caca88330b4d38) gimp: 2.10.28 → 2.10.30
* [`806797df`](https://github.com/NixOS/nixpkgs/commit/806797df248e47f3a130abe3ea1ebb141b3b923b) gitty: 0.3.0 -> 0.5.0
* [`5df2206a`](https://github.com/NixOS/nixpkgs/commit/5df2206a4d2d9c3e42233d7b2ff7f7b476ec7fb3) sof-firmware: 1.9.3 -> 2.0
* [`2d18e3a3`](https://github.com/NixOS/nixpkgs/commit/2d18e3a33daf50b3eb1fb6e9405f72ca8be502ba) roon-server: 1.8-850 -> 1.8-880
* [`a88d846b`](https://github.com/NixOS/nixpkgs/commit/a88d846b91dc3c75b825187998debd8e08c7794b) nixos/acme: Remove selfsignedDeps from finished targets
* [`87403a0b`](https://github.com/NixOS/nixpkgs/commit/87403a0b078d62245de7d619f2b71d2a0c78675a) nixos/acme: Add a human readable error on run failure
* [`a7f00013`](https://github.com/NixOS/nixpkgs/commit/a7f00013280416ce889d841e675526b8cb96a0ee) nixos/acme: Check for revoked certificates
* [`377c6bce`](https://github.com/NixOS/nixpkgs/commit/377c6bcefce8e8ccd471892a1b24621d5a909457) nixos/acme: Add defaults and inheritDefaults option
* [`795469df`](https://github.com/NixOS/nixpkgs/commit/795469df589a3e1a595f556c8e817ce158922bd7) roon-server: explicitly set dontConfigure/Build
* [`07c15833`](https://github.com/NixOS/nixpkgs/commit/07c15833093b9db5dacb3829afda03d7c71cc077) nixos/acme: Update release notes
* [`8d01b086`](https://github.com/NixOS/nixpkgs/commit/8d01b0862d3d52d72539cff65a405c09d864f82f) nixos/acme: Update documentation
* [`41fb8d71`](https://github.com/NixOS/nixpkgs/commit/41fb8d71ab5d92118eec5f056d3ce7e8f370a652) nixos/acme: Add useRoot option
* [`2dcc3daa`](https://github.com/NixOS/nixpkgs/commit/2dcc3daadf3718b3b0216d4cfbaab9040a9beffd) nixos/acme: Clean up default handling
* [`65f1b8c6`](https://github.com/NixOS/nixpkgs/commit/65f1b8c6ae2f2cf6a13d77b98b42eba31eef0424) nixos/acme: Add test for lego's built-in web server
* [`a456d83e`](https://github.com/NixOS/nixpkgs/commit/a456d83ee7c9fd45f3e1e74ae12780205b09823b) prusa-slicer: 2.3.3 -> 2.4.0
* [`7e9eb10b`](https://github.com/NixOS/nixpkgs/commit/7e9eb10b798a264bafd57989828deb4084c8b750) maintainers: add broke
* [`12469b7e`](https://github.com/NixOS/nixpkgs/commit/12469b7ed01f61c7cfd0d38aa58ca16d069e7028) vpn-slice: 0.16 -> 0.16.1
* [`c0d24bd6`](https://github.com/NixOS/nixpkgs/commit/c0d24bd6e28ade62d134810ef57cbec5f1926a6e) domoticz: mark as broken on darwin
* [`27ab5f06`](https://github.com/NixOS/nixpkgs/commit/27ab5f06e43ffcdd1e2b4e3a5e9f29401497ea0c) Update homepage to https ([nixos/nixpkgs⁠#152264](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152264))
* [`9b31b5bd`](https://github.com/NixOS/nixpkgs/commit/9b31b5bde6fb86fe8d8a43b70959cebe18cb3798) python38Packages.schema-salad: 8.2.20211116214159 -> 8.2.20211222191353
* [`cc690c83`](https://github.com/NixOS/nixpkgs/commit/cc690c83f43c155e4046c5bc3b4b8cd6eb7d08b4) elmerfem: 8.4 -> 9.0
* [`47081b25`](https://github.com/NixOS/nixpkgs/commit/47081b2553840c4ba45a66b8948cd65ea6f18bd9) yoda: 1.9.3 -> 1.9.4
* [`98077c64`](https://github.com/NixOS/nixpkgs/commit/98077c6486fdd1c912c93c03a106c42b2c3c8eab) ptcollab: 0.5.0.1 -> 0.5.0.3
* [`02c725db`](https://github.com/NixOS/nixpkgs/commit/02c725db8508f1305eb44214f3e914a721a496ff) maintainers: add cirno-999
* [`917a3fac`](https://github.com/NixOS/nixpkgs/commit/917a3facd90bf006eee4bb06e836f3704bc3c7ab) hover: 0.46.6 -> 0.47.0
* [`4a819373`](https://github.com/NixOS/nixpkgs/commit/4a81937388d5da2b92bab96168b199921a0e086e) Chowtapemodel: unstable-2020-12-12 -> 2.10.0
* [`b7f92030`](https://github.com/NixOS/nixpkgs/commit/b7f9203059f3a26d7dd8918cb59d48f748bc479b) kicad.updateScript: account for the bad 6.9.9 tag
* [`78f07691`](https://github.com/NixOS/nixpkgs/commit/78f07691832d9912d59f29c002a176585b67f569) kicad: 5.1.12 -> 6.0.0
* [`818894d6`](https://github.com/NixOS/nixpkgs/commit/818894d6a5bbe548db0d681945c430142511377b) kicad-unstable: 6.0.0-rc1 -> 2021-12-23
* [`b3f0da10`](https://github.com/NixOS/nixpkgs/commit/b3f0da107ea4ed4951afe3fe6ae2b18c2b5d7ec0) kicad: remove the separate i18n stuff
* [`f7da08bb`](https://github.com/NixOS/nixpkgs/commit/f7da08bb193e9d0ae9e12319ba2941fa61f5d9c8) kicad.updateScript: full shellcheck
* [`e54357a7`](https://github.com/NixOS/nixpkgs/commit/e54357a7d28ba3a69b0e13d5164815281bce0cc9) kicad: KICAD_SPICE build option defaults to ON
* [`83e6fe55`](https://github.com/NixOS/nixpkgs/commit/83e6fe5557aa296f1d40c06458a28a2d7c99dbc1) kicad: remove unused options
* [`46cd06eb`](https://github.com/NixOS/nixpkgs/commit/46cd06eb9d2763c0b7adaa362e2d03a945b2645f) nixos/acme: Add test for caddy
* [`5d2fefe6`](https://github.com/NixOS/nixpkgs/commit/5d2fefe6e57bbd043a4f948a93611b05fda6dfd4) leveldb: reenable RTTI in build
* [`c033826f`](https://github.com/NixOS/nixpkgs/commit/c033826f3960ee40cb33f09ec3d1c414ab582939) torrent7z: init at 1.3
* [`e22939cc`](https://github.com/NixOS/nixpkgs/commit/e22939cc8072a603e55b82272db97bbcc2cfe063) haskellPackages.nix-thunk: Document patches
* [`26a59d42`](https://github.com/NixOS/nixpkgs/commit/26a59d42422e22b16c6f65268e79a9349dbbe2c3) octavePackages.gsl: Mark broken on Darwin
* [`183a8e98`](https://github.com/NixOS/nixpkgs/commit/183a8e9846727092e2c8ed5f1f54cdcf989e63e7) octavePackages.level-set: Mark broken on Darwin
* [`af8c2038`](https://github.com/NixOS/nixpkgs/commit/af8c2038fd499676f2c819acf6f08aa36e7aae33) octavePackages.ocl: Mark broken on Darwin
* [`b1738683`](https://github.com/NixOS/nixpkgs/commit/b17386836df954570a4f385c77fb99fed386e889) octavePackages.strings: Mark broken on Darwin
* [`fe5e896f`](https://github.com/NixOS/nixpkgs/commit/fe5e896f470d120834ae4d9abb643486c71f45cb) octavePackages.tisean: Mark broken on Darwin
* [`a1dc23c1`](https://github.com/NixOS/nixpkgs/commit/a1dc23c17fe5254fe2aa15f63ee313a8e733f2e2) octavePackages.video: Mark broken on Darwin
* [`ffb546a1`](https://github.com/NixOS/nixpkgs/commit/ffb546a115479035e1a430ffc6afe6582642fded) python3Packages.yamlfix: 0.7.2 -> 0.8.0
* [`d8591505`](https://github.com/NixOS/nixpkgs/commit/d859150533d7ecca750d2798fed9c01793271482) ammonite: 2.4.1 -> 2.5.0
* [`cb2fee8e`](https://github.com/NixOS/nixpkgs/commit/cb2fee8ed3a1315cf8d467153c76318f962dc023) echidna: 1.7.2 -> 1.7.3
* [`2d7fc66c`](https://github.com/NixOS/nixpkgs/commit/2d7fc66c79d7543ada565c96a3c6ad2b15c6b350) nixos/gvfs: fix libmtp udev package path
* [`cf5a79f8`](https://github.com/NixOS/nixpkgs/commit/cf5a79f89ca3f064e0b9338c46780d370b16a511) python3Packages.caldav: 0.8.0 -> 0.8.2
* [`c8ae7e83`](https://github.com/NixOS/nixpkgs/commit/c8ae7e83350464ec218cc4a1a0f63788b14eeeaf) calendar-cli: 0.12.0 -> 0.13.0
* [`a06f2818`](https://github.com/NixOS/nixpkgs/commit/a06f28189a0e246729d21983af25ea981b62362e) radicale: 3.0.6 -> 3.1.0
* [`2c526159`](https://github.com/NixOS/nixpkgs/commit/2c526159cf348026233b67f239f9d80f6131d3b9) imagemagick: 7.1.0-17 -> 7.1.0-19
* [`e3b5c713`](https://github.com/NixOS/nixpkgs/commit/e3b5c71323d5c11f0c7cb2a196921e39e917aed2) ghostwriter: 2.1.0 -> 2.1.1
* [`1a16e310`](https://github.com/NixOS/nixpkgs/commit/1a16e310958c77506c9adfc50b8d739036271d06) python3Packages.tzlocal: disable test_assert_tz_offset test on darwin
* [`3415b50a`](https://github.com/NixOS/nixpkgs/commit/3415b50ab631ef6e665e0e74237e101e933346de) aocd: pythonPackages → python3Packages
* [`e36c946f`](https://github.com/NixOS/nixpkgs/commit/e36c946fb3516e95264e047386bd29b5908dae3c) crowdin-cli: 3.7.2 -> 3.7.4
* [`56751653`](https://github.com/NixOS/nixpkgs/commit/56751653a94e4340c07fcffe5483907dbcb08fcd) poetry2nix: 1.22.0 -> 1.23.0
* [`6faa7ad3`](https://github.com/NixOS/nixpkgs/commit/6faa7ad3fc2fe556324c225bd704fef3a7fb2003) nixos/kea: fixes for the systemd units
* [`343de1eb`](https://github.com/NixOS/nixpkgs/commit/343de1eb120a74d7084591f72257d06520c5125b) dalfox: 2.6.1 -> 2.7.0
* [`2753f7c8`](https://github.com/NixOS/nixpkgs/commit/2753f7c8e1727d0c4068353d01f742aeccf87b59) kicad: disable tests
* [`ab886f79`](https://github.com/NixOS/nixpkgs/commit/ab886f7939ce9c046bfda3975419d05b771ba790) mcfly: 0.5.10 -> 0.5.11
* [`3fdeef8a`](https://github.com/NixOS/nixpkgs/commit/3fdeef8a7ee81787a099cfb57bd91f24c5ec587d) emacs: Add withXinput2 argument
* [`aecc901b`](https://github.com/NixOS/nixpkgs/commit/aecc901b4ba9f36aeb3572f8ac110e7bc57d8079) nixos/hydra: Removing self as maintainer
* [`bc0c1f45`](https://github.com/NixOS/nixpkgs/commit/bc0c1f4597490e88b273f018b2c921a2e6744224) haskellPackages.sdp*: disable library profiling
* [`96b5f414`](https://github.com/NixOS/nixpkgs/commit/96b5f414fe6e7fe539c37af2bf0b74b6ae038e86) haskellPackages.morpheus-graphql: disable ordering dependent test
* [`f3a3ddb8`](https://github.com/NixOS/nixpkgs/commit/f3a3ddb87b1c6f9a36e0bef25e4e84560ed596fe) haskellPackages.http-api-data-qq: disable network dependent test
* [`7ef0a91a`](https://github.com/NixOS/nixpkgs/commit/7ef0a91a4d6d1e7162857eecc7faea5fa65095fd) haskellPackages: mark builds failing on hydra as broken
* [`f427295e`](https://github.com/NixOS/nixpkgs/commit/f427295e61b3d878b2dd9d30cb8d24df312ae9da) python3Packages.pypandoc: 1.7.0 -> 1.7.2
* [`0b55af0d`](https://github.com/NixOS/nixpkgs/commit/0b55af0decfba13e484c859e57dfd102841529f0) openai: 0.11.4 -> 0.11.5
* [`1d3a2290`](https://github.com/NixOS/nixpkgs/commit/1d3a229018b3ec2adbc57401bce16ea32f696660) python38Packages.jupyterlab: 3.2.4 -> 3.2.5
* [`e5daa25d`](https://github.com/NixOS/nixpkgs/commit/e5daa25d079dae2af4d819e1259e6c98b0b5efcd) python3Packages.flux-led: 0.27.13 -> 0.27.17
* [`fdae0317`](https://github.com/NixOS/nixpkgs/commit/fdae0317e1045dcc9a82d8f6f16261203d702b7b) python38Packages.pycarwings2: 2.12 -> 2.13
* [`51335e58`](https://github.com/NixOS/nixpkgs/commit/51335e586b0e46c1d069c9d57ecd7b4fe981c960) deep-translator: 1.5.5 -> 1.6.0
* [`8cd81712`](https://github.com/NixOS/nixpkgs/commit/8cd81712b4100f400dd8801c2a83aeaf726a4b95) vim-plugins.kanagawa-nvim at init
* [`fa272718`](https://github.com/NixOS/nixpkgs/commit/fa272718c8ad7486672e1542dd5da495c5e6f3a1) vscode-extensions.matklad.rust-analyzer: fix [nixos/nixpkgs⁠#152285](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152285) on aarch64-darwin
* [`f3cf953b`](https://github.com/NixOS/nixpkgs/commit/f3cf953bbab8f9fd1e809dd6bf9439b683c36f4e) python38Packages.django_compressor: 2.4.1 -> 3.1
* [`9a98b3a7`](https://github.com/NixOS/nixpkgs/commit/9a98b3a7094019637fd6eaf451a310f3614b72e4) python38Packages.phonenumbers: 8.12.39 -> 8.12.40
* [`cb8f8644`](https://github.com/NixOS/nixpkgs/commit/cb8f864487100698fd9ab50d618f6c3d5425b117) python3Packages.nitransforms: init at 21.0.0
* [`aa450b60`](https://github.com/NixOS/nixpkgs/commit/aa450b6094d54995223e6885acf603b07f648985) python38Packages.panel: 0.12.5 -> 0.12.6
* [`0a38568f`](https://github.com/NixOS/nixpkgs/commit/0a38568ff75771a852c98aeefe7115ed5582d7eb) perl5Packages.DBIxClass: fix build ([nixos/nixpkgs⁠#152207](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152207))
* [`dcbd0c94`](https://github.com/NixOS/nixpkgs/commit/dcbd0c941b0963e98bb63ac2d155978eee295c21) mopidy-jellyfin: init at 1.0.2
* [`4d6b67b9`](https://github.com/NixOS/nixpkgs/commit/4d6b67b9685bc2232e08ecd65a1633cbdedef4f5) citra: add build options
* [`9027a59f`](https://github.com/NixOS/nixpkgs/commit/9027a59f7a8b776377c2020bd1444fc9c6ac3627) influxdb2 service: don't use dynamic user
