### PR TITLE
niv home-manager: update aef97988 -> 0b197562

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aef97988dac0541747de8bcc85c7e27726eea4af",
-        "sha256": "15id5prqlbg7jqhhjna4901rjib6vkfm0fmavvmdbnmf988gkc4m",
+        "rev": "0b197562ab7bf114dd5f6716f41d4b5be6ccd357",
+        "sha256": "0b1xp5l0xgfsy1qy7w79i3q6y79w3jx39wxlr23ckc8ccia5d5qp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/aef97988dac0541747de8bcc85c7e27726eea4af.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/0b197562ab7bf114dd5f6716f41d4b5be6ccd357.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@aef97988...0b197562](https://github.com/nix-community/home-manager/compare/aef97988dac0541747de8bcc85c7e27726eea4af...0b197562ab7bf114dd5f6716f41d4b5be6ccd357)

* [`7ec50b1f`](https://github.com/nix-community/home-manager/commit/7ec50b1f77e62c79f07ed200853c07894195f544) gtk: add support for GTK4 configuration
* [`02426bb5`](https://github.com/nix-community/home-manager/commit/02426bb52fb5f9b5f21711baf8e046baea8870e8) systembus-notify: add module
* [`1b03a8ab`](https://github.com/nix-community/home-manager/commit/1b03a8ab7af9385b70b7d7c319c4a31a58c5cfa5) direnv: add troubleshooting to fish integration
* [`3b9c625b`](https://github.com/nix-community/home-manager/commit/3b9c625b6446b4f68fc8c5d737bb7b4a40a363be) xsession: add xplugd service to accompany setxkbmap ([nix-community/home-manager⁠#2450](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2450))
* [`f15b151c`](https://github.com/nix-community/home-manager/commit/f15b151ca1c4aea23515c241051d71f1b5cf97c8) waybar: configurable systemd WantedBy target ([nix-community/home-manager⁠#2524](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2524))
* [`0fd86c66`](https://github.com/nix-community/home-manager/commit/0fd86c66fec6e11526a018060b73f96efc31f95f) Translate using Weblate (Russian)
* [`76c50cec`](https://github.com/nix-community/home-manager/commit/76c50cecf866403d0da21b471a774648f78b066b) Add translation using Weblate (Russian)
* [`3b5ebdef`](https://github.com/nix-community/home-manager/commit/3b5ebdefd8705ca177855ffaee89fbee1a3017f9) Translate using Weblate (Russian)
* [`48f2b381`](https://github.com/nix-community/home-manager/commit/48f2b381dd397ec88040d3354ac9c036739ba139) dconf: remove gnidorah from maintainers/CODEOWNERS ([nix-community/home-manager⁠#2586](http://r.duckduckgo.com/l/?uddg=https://github.com/nix-community/home-manager/issues/2586))
* [`0b197562`](https://github.com/nix-community/home-manager/commit/0b197562ab7bf114dd5f6716f41d4b5be6ccd357) treewide: use `remove` when possible
