### PR TITLE
niv powerlevel10k: update a23c4314 -> ed70c90c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "a23c4314a1498c026167d2095d207d418201a98d",
-        "sha256": "1q8k55xl55r5c32m0wvsqx4c9a0dymankyp8pczsdw8wg7krxw63",
+        "rev": "ed70c90c2d6354a38b4528df231ffd599277c548",
+        "sha256": "1m9nlzah08b8385h8p8gngpj7lv2flnxv52lh7fc17x4xdmkgbjz",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/a23c4314a1498c026167d2095d207d418201a98d.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/ed70c90c2d6354a38b4528df231ffd599277c548.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@a23c4314...ed70c90c](https://github.com/romkatv/powerlevel10k/compare/a23c4314a1498c026167d2095d207d418201a98d...ed70c90c2d6354a38b4528df231ffd599277c548)

* [`2e8a8f1d`](https://github.com/romkatv/powerlevel10k/commit/2e8a8f1d6393318e200860fbdc43f23e788ac671) fix a bug that causes VISUAL_IDENTIFIER_COLOR to leak into content
* [`57d0274b`](https://github.com/romkatv/powerlevel10k/commit/57d0274b8892158b8f6fedaf9946e7f3f89d56e9) fix bugs in dir and several other segments when cwd contains control characters
* [`469baa62`](https://github.com/romkatv/powerlevel10k/commit/469baa6221c98a2b3991647adf3e74d653528ed3) url-escape dir properly when POWERLEVEL9K_DIR_HYPERLINK is set
* [`608bd2c8`](https://github.com/romkatv/powerlevel10k/commit/608bd2c88b576627f6f3c9cc4fb5cc94bf51eef6) expand instant prompt faq
* [`09ece960`](https://github.com/romkatv/powerlevel10k/commit/09ece9601f781e582919eb76155cc2a957199e5d) grammar in the instant prompt faq
* [`6692245f`](https://github.com/romkatv/powerlevel10k/commit/6692245f3e0977789669baa6e6bd64fd730a1529) hide all screen recordings under <details> in the hope that #anchors will work properly
* [`356ce68f`](https://github.com/romkatv/powerlevel10k/commit/356ce68f695ead155263687863a4d61a56731358) doc: remove most content from "is it really fast" section
* [`83f773ca`](https://github.com/romkatv/powerlevel10k/commit/83f773caaedf46c6a3fe0adfcee1142ca302cf39) doc: remove most content from "is it fast to load" section
* [`da5a4cdb`](https://github.com/romkatv/powerlevel10k/commit/da5a4cdbec0cf1039ca2614c1912f0778ed16e53) add high-level table of contents at the top and low-level table of contents in each section; remove the full table of contents from the bottom
* [`370535af`](https://github.com/romkatv/powerlevel10k/commit/370535af455f49e6e194c169475774caeaf9414b) explicitly set LC_ALL when starting docker
* [`00dd4ae0`](https://github.com/romkatv/powerlevel10k/commit/00dd4ae009a6b79e886cb8ae1e04889d704ac511) docs: shrink "getting started"
* [`cde05cfa`](https://github.com/romkatv/powerlevel10k/commit/cde05cfa7bf857e5822847e762d1995e624388f5) add a link to romkatv/zsh-bench#instant-prompt (should really copy some of that content over to p10k; maybe later)
* [`2e58e388`](https://github.com/romkatv/powerlevel10k/commit/2e58e3888efe9bc9214803e615f72510fb4b8155) add POWERLEVEL9K_TERM_SHELL_INTEGRATION parameter that enables OSC 133 marks
* [`c9bc2f5a`](https://github.com/romkatv/powerlevel10k/commit/c9bc2f5a329448b4955985fddfb24011ba90b9fa) fix POWERLEVEL9K_TERM_SHELL_INTEGRATION
* [`ed70c90c`](https://github.com/romkatv/powerlevel10k/commit/ed70c90c2d6354a38b4528df231ffd599277c548) fix a bug with URL-escaping for directory links ([romkatv/powerlevel10k⁠#1687](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1687))
