### PR TITLE
niv nixpkgs: update 00f75082 -> 4bc4c7f1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "00f75082753fed6a3b2d2ca9c76035e893408b60",
-        "sha256": "1ql8nwfp7rbwp2pdhhaln1mab0hvqdp4kxx79fd9ycyzp77lls0v",
+        "rev": "4bc4c7f1a0c4df808c3e7f0953dd780f6b8a0dd5",
+        "sha256": "15dmkyd7skkqb1jjzrifbgjdvfz9yzdvgnz4h1wwizfqk6wknwv8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/00f75082753fed6a3b2d2ca9c76035e893408b60.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4bc4c7f1a0c4df808c3e7f0953dd780f6b8a0dd5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@00f75082...4bc4c7f1](https://github.com/nixos/nixpkgs/compare/00f75082753fed6a3b2d2ca9c76035e893408b60...4bc4c7f1a0c4df808c3e7f0953dd780f6b8a0dd5)

* [`c24ba1de`](https://github.com/NixOS/nixpkgs/commit/c24ba1de115f77dd12fe74ee2bb4588b7d154f26) librecad: use mkDerivation instead of mkDerivationWith
* [`24e93afb`](https://github.com/NixOS/nixpkgs/commit/24e93afb05bcf9ddbae1babeef13c0ff34d72f14) qcad: use mkDerivation instead of mkDerivationWith
* [`f6377238`](https://github.com/NixOS/nixpkgs/commit/f63772386b44ac2ca172140424672e6ac0f89739) python3Packages.starlette: 0.16.0 -> 0.17.1
* [`837e61e1`](https://github.com/NixOS/nixpkgs/commit/837e61e16860abd2f16a9a81684c0f94e4bb5c09) eudev: 3.2.10 -> 3.2.11
* [`4aa95890`](https://github.com/NixOS/nixpkgs/commit/4aa95890f32344a58040db10454734a0d21ab02f) python3Packages.fastapi: 0.70.0 -> 0.70.1
* [`34088cbd`](https://github.com/NixOS/nixpkgs/commit/34088cbd5ce03fb90bf47c7a4b51e9b10b8536f7) qcad: 3.26.4.10 -> 3.27.1.0
* [`f9b55947`](https://github.com/NixOS/nixpkgs/commit/f9b559477644ba2471b4a7a5da9777c261080a64) python3Packages.duckdb: fix build
* [`3cd704d8`](https://github.com/NixOS/nixpkgs/commit/3cd704d85fc1abdc8acc477e8e57bc0242bbf06b) wiki-tui: 0.4.2 -> 0.4.3
* [`28546e25`](https://github.com/NixOS/nixpkgs/commit/28546e25c4c72aaa2123c112a08ee71eda13e961) python3Packages.flux-led: 0.27.20 -> 0.27.28
* [`d4c6f7b1`](https://github.com/NixOS/nixpkgs/commit/d4c6f7b1cdf48c236ddd5f606cf3b96db69bd76a) maintainers: add terrorjack
* [`d68c3dce`](https://github.com/NixOS/nixpkgs/commit/d68c3dceb21db923ba525f1ee3b5d8da02f46028) HentaiAtHome: init at 1.6.1
* [`c32c39d6`](https://github.com/NixOS/nixpkgs/commit/c32c39d6f3b1fe6514598fa40ad2cf9ce22c3fb7) terraform-providers.teleport: 7.3.0 -> 8.0.6
* [`b54e5a84`](https://github.com/NixOS/nixpkgs/commit/b54e5a841b2118a51397eefaab2408daaa5e99e5) vampire: 4.5.1 -> 4.6.1
* [`588ef3e2`](https://github.com/NixOS/nixpkgs/commit/588ef3e249059528e87da210aa601d75d7ab645b) fio: 3.28 -> 3.29
* [`ac3a6c1c`](https://github.com/NixOS/nixpkgs/commit/ac3a6c1c36f8193e1ebee25e87ca542df71e5b28) alfaview: 8.33.0 -> 8.34.0
* [`6e721330`](https://github.com/NixOS/nixpkgs/commit/6e7213303bf6e2a9a811d49db96185d830029a02) byacc: 20210808 -> 20211224
* [`a3786f99`](https://github.com/NixOS/nixpkgs/commit/a3786f99a200d8aef8c3ed899bd80c0f65510c66) darktable: 3.6.1 -> 3.8.0
* [`a97f7f70`](https://github.com/NixOS/nixpkgs/commit/a97f7f700e265dd93bf5d251c41f92c08c9e6a75) darktable: run nixpkgs-fmt
* [`ca24e482`](https://github.com/NixOS/nixpkgs/commit/ca24e4820518c57b00f0ecca45cf2e0c615cec82) burpsuite: 2021.10.3 -> 2021.12
* [`7a1f9c89`](https://github.com/NixOS/nixpkgs/commit/7a1f9c890834a7c7776bc0dabc0071ca53e8475b) python3Packages.chex: init at `unstable-2021-12-16` ([nixos/nixpkgs⁠#152969](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152969))
* [`44866de4`](https://github.com/NixOS/nixpkgs/commit/44866de4d11506208d7b0b5e35fe1ffaaa0516a2) python3Packages.jmp: init at unstable-2021-10-03 ([nixos/nixpkgs⁠#152972](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152972))
* [`a68e6c37`](https://github.com/NixOS/nixpkgs/commit/a68e6c37312de76d2230cd84e3d41ed5ea659266) doclifter: 2.19 -> 2.20
* [`08322e6c`](https://github.com/NixOS/nixpkgs/commit/08322e6c6d6d8c1e1767c9cef225f4f32c938bed) python3Packages.dm-tree: refactor to build from sources ([nixos/nixpkgs⁠#152971](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152971))
* [`7f64539e`](https://github.com/NixOS/nixpkgs/commit/7f64539e77ad3cecd6f91e7b9b3dcc75fa2b4604) psi-plus: 1.5.1582 -> 1.5.1596
* [`478037bb`](https://github.com/NixOS/nixpkgs/commit/478037bba546b87966969e5dfd94c7d6579ccac8) oidentd: 2.5.0 -> 3.0.0
* [`7fdb25a2`](https://github.com/NixOS/nixpkgs/commit/7fdb25a24b2bca3af7184ba090e8fcb9317de6df) minizincide: 2.5.3 -> 2.5.5
* [`3f3fee35`](https://github.com/NixOS/nixpkgs/commit/3f3fee35482cf8d1a81c4b92470513b3cc217c6e) pam_krb5: 4.10 -> 4.11
* [`54e83f15`](https://github.com/NixOS/nixpkgs/commit/54e83f150d305208a2088e71fa31132cd1186ec2) elvish: fix building unusable executable
* [`57842398`](https://github.com/NixOS/nixpkgs/commit/57842398c9814f802c8481171ded49b817eb8ae7) libx86emu: 3.1 -> 3.5
* [`6a73381c`](https://github.com/NixOS/nixpkgs/commit/6a73381c3026c019846c8a165bc5b91ed655c775) onedrive: 2.4.13 -> 2.4.14
* [`04ac189b`](https://github.com/NixOS/nixpkgs/commit/04ac189b4d8d89ec5f5903a71cccca3e3dece987) nco: 5.0.3 -> 5.0.4
* [`9268da6b`](https://github.com/NixOS/nixpkgs/commit/9268da6b04068f99db147b26d9078d2ba6c8700e) nixos/i2pd: add module package option
* [`2942abd6`](https://github.com/NixOS/nixpkgs/commit/2942abd63d1c8dcb660014cc4a95e50e80392bea) riemann: 0.3.6 -> 0.3.7
* [`8f24dd16`](https://github.com/NixOS/nixpkgs/commit/8f24dd162f5344fe897f96b2b333c894918ab008) terraform-providers: update-provider scripts
* [`55d89c01`](https://github.com/NixOS/nixpkgs/commit/55d89c011a17d732c364c993b6b8d422cd1238b3) sqlcipher: 4.4.3 -> 4.5.0
* [`3ce6c8e0`](https://github.com/NixOS/nixpkgs/commit/3ce6c8e0de940b4f953a40db399e64adc16b8ffb) sleuthkit: 4.11.0 -> 4.11.1
* [`0b15d116`](https://github.com/NixOS/nixpkgs/commit/0b15d11602d563c258bb8c6dd69602e04d926697) soju: 0.2.2 -> 0.3.0
* [`0fd74961`](https://github.com/NixOS/nixpkgs/commit/0fd74961da9fe2640ad2fbd960c3af08246e6749) uptimed: 0.4.5 -> 0.4.6
* [`9dea419c`](https://github.com/NixOS/nixpkgs/commit/9dea419ccc0cd4bdcab4a9b1cced958e32a1d04d) qtractor: 0.9.23 -> 0.9.24
* [`f274f11b`](https://github.com/NixOS/nixpkgs/commit/f274f11b75093521c3b6b435c062b6365e3cd2c4) embree: 3.13.1 -> 3.13.2
* [`c811f039`](https://github.com/NixOS/nixpkgs/commit/c811f0395ae0f43b66b71b9299ef728422e8114c) python3Packages.pytap2: init at 2.2.0
* [`89f7261c`](https://github.com/NixOS/nixpkgs/commit/89f7261c2366d614d46786030756b3fe1d7cab89) python3Packages.meshtastic: 1.2.48 -> 1.2.50
* [`f91cae30`](https://github.com/NixOS/nixpkgs/commit/f91cae30a797579a7f86b996b754ff1bdf9a23a2) iptsd: 0.4 -> 0.5
* [`80ad6649`](https://github.com/NixOS/nixpkgs/commit/80ad6649f805f38e791d9b3d8e30518d99683e7b) visualvm: 2.1 -> 2.1.1
* [`7895497b`](https://github.com/NixOS/nixpkgs/commit/7895497b11cba5d83817e0413b5c6aec9602cbe3) minisign: 0.9 -> 0.10
* [`86018d74`](https://github.com/NixOS/nixpkgs/commit/86018d741b4134aeced8dec7963901106a05749f) tetrd: init at 1.0.4
* [`f3421fdc`](https://github.com/NixOS/nixpkgs/commit/f3421fdc242a4304b796a60935676ccd9310b47c) python3Packages.sure: pull arch patch to fix build
* [`e16074e8`](https://github.com/NixOS/nixpkgs/commit/e16074e889c8655c8dcfc74c37d28eac3077bf9a) nixos/tetrd: init
* [`299c9bd3`](https://github.com/NixOS/nixpkgs/commit/299c9bd3890549d908a2b0269ae26b14721fd964) urlscan: 0.9.7 -> 0.9.8
* [`35258cbd`](https://github.com/NixOS/nixpkgs/commit/35258cbdc19b60825e09a6f9dfbafada0b437262) python3Packages.pyupgrade: 2.30.1 -> 2.31.0
* [`5dd1000f`](https://github.com/NixOS/nixpkgs/commit/5dd1000f37ef857a976c8680876c3381d27e61ad) wezterm: 20211204-082213-a66c61ee9 -> 20220101-133340-7edc5b5a
* [`e4e06d54`](https://github.com/NixOS/nixpkgs/commit/e4e06d547cbd11b286934bbf77348335e6520abe) colobot: 0.1.12 -> 0.2.0; fixes build
* [`56f64dc0`](https://github.com/NixOS/nixpkgs/commit/56f64dc08bb8b78f22238db7a23aeb6113c88d5a) radsecproxy: 1.9.0 -> 1.9.1
* [`5811fd2f`](https://github.com/NixOS/nixpkgs/commit/5811fd2fdb56d6d06f486650a8402de0e24e47b4) carla: 2.4.0 -> 2.4.1
* [`5851f891`](https://github.com/NixOS/nixpkgs/commit/5851f89195548afb1a311434c095ddfd63c3588d) python3Packages.mypy: unstable-2021-11-14 -> 0.930
* [`c66f86e5`](https://github.com/NixOS/nixpkgs/commit/c66f86e584957fd5a5d162e0fc2d93916a1434ff) range-v3: fix on darwin
* [`29b40b07`](https://github.com/NixOS/nixpkgs/commit/29b40b07db751efbb481a1bba7d695b2170c02b5) fhs-userenv-bubblewrap: allow additional arguments to bwrap
* [`e44cd727`](https://github.com/NixOS/nixpkgs/commit/e44cd727ff7eb876aad36ff9e15a22f5897d2d55) edid-generator: mark as broken on darwin
* [`53109918`](https://github.com/NixOS/nixpkgs/commit/531099180899cbed167490753020cc2fdcd1c4be) dprint: fix darwin build
* [`6236a2d1`](https://github.com/NixOS/nixpkgs/commit/6236a2d111607fa02479fccdb9455af07365396e) python3Packages.restview: 2.9.2 -> 2.9.3
* [`8914f354`](https://github.com/NixOS/nixpkgs/commit/8914f354efd6fdc4f85665dd957a94b90035f6be) python3Packages.python-lsp-server: 1.3.1 -> 1.3.3
* [`057166b5`](https://github.com/NixOS/nixpkgs/commit/057166b50eb1dc254ff3aaef8273f6d37335c47f) miniserve: mark as broken on aarch64-darwin
* [`53c284bd`](https://github.com/NixOS/nixpkgs/commit/53c284bd9e7a99f5e67217b556e13001fb9ad0f0) .github/CODEOWNERS: add go docs
* [`9f0aab98`](https://github.com/NixOS/nixpkgs/commit/9f0aab982763fc90dbdfe88e712cb61227266f0e) doc/go: remove `runVend` from example
* [`fc4b2c2a`](https://github.com/NixOS/nixpkgs/commit/fc4b2c2a50d8394c04c520c4a3e2c6b4e07fd3ed) terraform-providers.google-beta: 3.76.0 -> 4.5.0
* [`3304e7fe`](https://github.com/NixOS/nixpkgs/commit/3304e7fe50a75ad178c8f91ba648219d1e25454f) terraform-providers.oraclepaas: set provider-source-address, vendorSha256
* [`b74afc2f`](https://github.com/NixOS/nixpkgs/commit/b74afc2fc5f2cca6aa96a7d9db516ee0aaf3c0f6) cinnamon.pix: 2.8.0 -> 2.8.4
* [`871184cc`](https://github.com/NixOS/nixpkgs/commit/871184ccd7d1cdcb837a598540adab986048ef48) pdfsam-basic: 4.2.8 -> 4.2.10
* [`2a727981`](https://github.com/NixOS/nixpkgs/commit/2a727981899d6e516982cf1e1669b7c59ae95cb7) nix-direnv: 1.5.0 -> 1.5.1
* [`817d1854`](https://github.com/NixOS/nixpkgs/commit/817d1854e1255e6c521339582c45bcc48864487b) python38Packages.manimpango: 0.4.0 -> 0.4.0.post0
* [`5280e28e`](https://github.com/NixOS/nixpkgs/commit/5280e28e13eda6e98784dbb28e987a436d9a9d5a) terraform-providers: update-provider scripts
* [`505399e6`](https://github.com/NixOS/nixpkgs/commit/505399e63b2ba38ce1ddea2e91d45810f1144dd8) python3Packages.pystray: 0.19.1 -> 0.19.2
* [`df31f75c`](https://github.com/NixOS/nixpkgs/commit/df31f75c1a1f9c476fabf3f496bfc44191f74cee) nushell: 0.41.0 -> 0.42.0
* [`f8694239`](https://github.com/NixOS/nixpkgs/commit/f86942393396368f2db10c843e620990ae9d75ea) Revert "libpulseaudio: fix aarch64-darwin build"
* [`bcbd3725`](https://github.com/NixOS/nixpkgs/commit/bcbd3725d3f5b2ae608506b65d5abc46a2c1a537) python38Packages.requests-cache: 0.8.1 -> 0.9.0
* [`82a3519a`](https://github.com/NixOS/nixpkgs/commit/82a3519a78bb34d64ab252cbb0e2a22bcc438106) unicode-character-database: 13.0.0 -> 14.0.0
* [`caa56925`](https://github.com/NixOS/nixpkgs/commit/caa56925f9f467d3a1b21884643183f3a4aa8b0f) yices: 2.6.2 -> 2.6.4
* [`a50e8e03`](https://github.com/NixOS/nixpkgs/commit/a50e8e034909bb3d6cb3f84bfa5a5f44833c1ae3) maintainers: update noreferences' github
* [`f6875265`](https://github.com/NixOS/nixpkgs/commit/f687526593148b136100f297f316348ce2a583b7) minio: 2021-12-10T23-03-39Z -> 2021-12-27T07-23-18Z
* [`a88c3bbf`](https://github.com/NixOS/nixpkgs/commit/a88c3bbfe1ca298965bca72ae3fdd23b63433e55) kodi: allow using patch with kodi addons
* [`58058239`](https://github.com/NixOS/nixpkgs/commit/58058239d4198f19d8df2d61156b0ca5558ae59e) kodi: workaround for addon path bug in youtube addon
* [`63e9fb04`](https://github.com/NixOS/nixpkgs/commit/63e9fb044878be5d2eace2802739e9b4547d50be) isabelle: Use openjdk17
* [`eb54d82a`](https://github.com/NixOS/nixpkgs/commit/eb54d82aef3ad13e48b812d231a1b2aca91e33ce) mame: 0.238 -> 0.239
* [`824edbe8`](https://github.com/NixOS/nixpkgs/commit/824edbe8ad462620429f8bfe2206dbf63adcf1ee) mkvtoolnix: 63.0.0 -> 64.0.0
* [`99f5cab1`](https://github.com/NixOS/nixpkgs/commit/99f5cab192dfa206aa1d8b489d17d1be2c24bbff) libcaca: 0.99.beta19 -> 0.99.beta20
* [`5f58402c`](https://github.com/NixOS/nixpkgs/commit/5f58402c9462eb6fea52a053e2d21961757932a1) fetchurl: also check certificate when using all zero hash ([nixos/nixpkgs⁠#152608](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152608))
* [`12881275`](https://github.com/NixOS/nixpkgs/commit/128812757bdd3d06a4d8d9d87d26d656def5d644) terraform-providers: remove archived providers ([nixos/nixpkgs⁠#153015](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/153015))
* [`c1d8e77a`](https://github.com/NixOS/nixpkgs/commit/c1d8e77ac2ca4248886632c597debea233700b2b) makeself: 2.4.2 -> 2.4.5
* [`34963f05`](https://github.com/NixOS/nixpkgs/commit/34963f05c527537532fcad7dded2dd7eb031c093) rtrtr: init at 0.1.2
* [`f562adfa`](https://github.com/NixOS/nixpkgs/commit/f562adfab87978c3a24306dd2ddc5e9a7bdd627c) prometheus-openldap-exporter: 2.1.4 -> 2.2.0
* [`697b6d85`](https://github.com/NixOS/nixpkgs/commit/697b6d85aec6b92c359f2ca54bea35f664c3da28) acme-sh: refactor
* [`8cb0ae28`](https://github.com/NixOS/nixpkgs/commit/8cb0ae287c810bb1d37f8ba67a8a978d968a3d94) gitea: 1.15.7 -> 1.15.9
* [`76c1b6c3`](https://github.com/NixOS/nixpkgs/commit/76c1b6c362596480fc21bcccfb933d2ed184f22d) terraform-providers: update providers ([nixos/nixpkgs⁠#153201](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/153201))
* [`64346a86`](https://github.com/NixOS/nixpkgs/commit/64346a8685d366907680c53228e262983f4c0729) ferdi: 5.6.4 -> 5.6.5 ([nixos/nixpkgs⁠#152239](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/152239))
* [`1fc8d58b`](https://github.com/NixOS/nixpkgs/commit/1fc8d58bd910a4d910296db612d631c6c1d826dd) element-{web,desktop}: 1.9.7 -> 1.9.8
* [`008aa8d8`](https://github.com/NixOS/nixpkgs/commit/008aa8d8b7f5ca9f96cd560ffe04d2ff284dd015) acme-sh: 3.0.0 -> 3.0.1
* [`2bf0a986`](https://github.com/NixOS/nixpkgs/commit/2bf0a9864c6c6ebad470af7d9fda5e024a4a8950) micromamba: 0.15.0 -> 0.18.1
* [`aa427377`](https://github.com/NixOS/nixpkgs/commit/aa4273774e819fffc3c6dcf98cda4b4f8a2fb881) libwpe: 1.10.1 -> 1.12.0
* [`e7599f1d`](https://github.com/NixOS/nixpkgs/commit/e7599f1de6af3215e77ea96f423f7746804b05ac) reproc: 14.2.3 -> 14.2.4
* [`5b228580`](https://github.com/NixOS/nixpkgs/commit/5b2285802d12c79c3bbb8456d861dcbc9b14cdfa) smtube: 21.7.0 -> 21.10.0
* [`951a01d2`](https://github.com/NixOS/nixpkgs/commit/951a01d284149371301c8026c5cb9f04839414ca) wmutils-core: 1.5 -> 1.6
* [`64960691`](https://github.com/NixOS/nixpkgs/commit/64960691ca5b9ae4029120445eca1bcfb844df66) sniffglue: 0.13.1 -> 0.14.0
* [`3dffc8ba`](https://github.com/NixOS/nixpkgs/commit/3dffc8babd27471dc7310ca2284644a76da15730) adoptopenjdk-icedtea-web: 1.8.7 -> 1.8.8
* [`cb055cea`](https://github.com/NixOS/nixpkgs/commit/cb055cea999b47e3069facaf968f8dbede63e545) libamqpcpp: 4.3.12 -> 4.3.15
* [`0bff8db6`](https://github.com/NixOS/nixpkgs/commit/0bff8db6bc8101d53d47ffea3c3f7e6851dd6629) kodiPackages.pvr-hdhomerun: 19.0.1 -> 19.0.2
* [`3f07ef8a`](https://github.com/NixOS/nixpkgs/commit/3f07ef8a9f791de5c668a60cad0273df49244f4a) nitter: unstable-2021-07-18 -> unstable-2021-12-31
* [`b704d85c`](https://github.com/NixOS/nixpkgs/commit/b704d85cce2b23eafaf1dc9a8110ab0b351b4f2c) pythonPackages.nix-prefetch-github: 4.0.4 -> 5.0.1
* [`0bf74112`](https://github.com/NixOS/nixpkgs/commit/0bf74112110f225bde9017bd0940226aad1f3155) libpoly: 0.1.10 -> 0.1.11
* [`7e2ca934`](https://github.com/NixOS/nixpkgs/commit/7e2ca934b2b5ff6da8671e1db35e03c59a9df513) kodiPackages.pvr-hts: 19.0.3 -> 19.0.4
* [`7c22f3fc`](https://github.com/NixOS/nixpkgs/commit/7c22f3fcc074e5e0fbff56806210f75d51fbd83b) upterm: 0.6.5 -> 0.6.7
* [`9ae573e5`](https://github.com/NixOS/nixpkgs/commit/9ae573e510aa50c41e08314cd15c87485648fa1c) calibre: 5.33.2 -> 5.34.0
* [`16487556`](https://github.com/NixOS/nixpkgs/commit/164875561859936012fa7421a488870dbdab094a) tqsl: 2.5.7 -> 2.5.9
* [`e1454379`](https://github.com/NixOS/nixpkgs/commit/e1454379a65f7f082087f7052ae415864891ae35) consul-template: 0.27.1 -> 0.27.2
* [`8ab5132f`](https://github.com/NixOS/nixpkgs/commit/8ab5132f7c9bdad5f3e0a9fed40c065538fe64ac) ddcui: 0.1.2 -> 0.2.0
* [`e4992cdd`](https://github.com/NixOS/nixpkgs/commit/e4992cdd655925cfd1d554c73d76567f79edbff7) stacks: 2.59 -> 2.60
* [`369d7bb4`](https://github.com/NixOS/nixpkgs/commit/369d7bb4ca21c311341d288d77fa53f260a6df07) z3: 4.8.12 -> 4.8.14
* [`56e17dc7`](https://github.com/NixOS/nixpkgs/commit/56e17dc786aa7301fbce256bacf542e8a37f0471) spiped: 1.6.1 -> 1.6.2
* [`f9876699`](https://github.com/NixOS/nixpkgs/commit/f98766993dd608a0169b80507263398353fea12b) sg3_utils: 1.46r862 -> 1.47
* [`a10675f4`](https://github.com/NixOS/nixpkgs/commit/a10675f43deb7cc41b69829d6f3290b0506618f6) liblcf, easyrpg-player: 0.6.2 -> 0.7.0
* [`f79b811f`](https://github.com/NixOS/nixpkgs/commit/f79b811f2dd62f5ae46fc460164ebbd865cf9c44) eprover: Add option to enable LFHOL reasoning
* [`c601134a`](https://github.com/NixOS/nixpkgs/commit/c601134af8e58ec26401c8b19e96d1a599fcf90e) isabelle: Use vampire and eprover from nixpkgs
* [`9595114e`](https://github.com/NixOS/nixpkgs/commit/9595114e39dfe04fd63bd5d4439451d273b231a0) kodiPackages.pvr-iptvsimple: 19.0.2 -> 19.0.3
* [`ec150abd`](https://github.com/NixOS/nixpkgs/commit/ec150abd1a5559b835524667ab02e1186a8f947b) Revert "nixos/nginx: disable rejectSSL activation when https is disabled"
* [`968da631`](https://github.com/NixOS/nixpkgs/commit/968da631e6fefa847d90ba8e6b6b2bf9a31700dc) python38Packages.srsly: 2.4.1 -> 2.4.2
* [`21d0a176`](https://github.com/NixOS/nixpkgs/commit/21d0a17694dcdddce94f9f8103cf31f32c687531) gofumpt: 0.1.1 -> 0.2.0
* [`1307805c`](https://github.com/NixOS/nixpkgs/commit/1307805c33f412f18b2e25ae5c4fbdf8713584ab) cutter: 2.0.3 -> 2.0.4
* [`cdb63788`](https://github.com/NixOS/nixpkgs/commit/cdb637881d35b2760875c9679d140ced3668fdd9) checkov: 2.0.701 -> 2.0.702
* [`4bd7cdc0`](https://github.com/NixOS/nixpkgs/commit/4bd7cdc035605807ffc0b8c6ea69a13bf83870b5) aspectj: 1.9.6 -> 1.9.7
* [`db3636de`](https://github.com/NixOS/nixpkgs/commit/db3636de924fd4b1d3ee29072fd2fa9b41b498d1) python38Packages.pynput: 1.7.5 -> 1.7.6
* [`6369dd94`](https://github.com/NixOS/nixpkgs/commit/6369dd9432b46b9941378623021cbdf555737c8e) unzoo: init at 4.4
* [`dceae2ac`](https://github.com/NixOS/nixpkgs/commit/dceae2acce296067780e73e6e79a99c769e8379e) frescobaldi: mark as broken on darwin
* [`9124f3f5`](https://github.com/NixOS/nixpkgs/commit/9124f3f52013fb6f65cb238200f660d9aaf0ff75) fsearch: mark as broken on darwin
* [`8c1644ca`](https://github.com/NixOS/nixpkgs/commit/8c1644ca38dcf0513e267a6734dcc6e4c88dbccc) mubeng: 0.5.2 -> 0.8.0
* [`a2531855`](https://github.com/NixOS/nixpkgs/commit/a2531855aaf857139ec0583eed720f38d6b24261) slic3r: use boost172 ([nixos/nixpkgs⁠#153276](http://r.duckduckgo.com/l/?uddg=https://github.com/nixos/nixpkgs/issues/153276))
