### PR TITLE
niv powerlevel10k: update ed70c90c -> 73546881

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "ed70c90c2d6354a38b4528df231ffd599277c548",
-        "sha256": "1m9nlzah08b8385h8p8gngpj7lv2flnxv52lh7fc17x4xdmkgbjz",
+        "rev": "73546881235dae77f9f93e7525d63b4c1f486397",
+        "sha256": "11jdchqrmp4nb35if081f8s218n42xs4zfgfckvdlckrl9lsa047",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/ed70c90c2d6354a38b4528df231ffd599277c548.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/73546881235dae77f9f93e7525d63b4c1f486397.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@ed70c90c...73546881](https://github.com/romkatv/powerlevel10k/compare/ed70c90c2d6354a38b4528df231ffd599277c548...73546881235dae77f9f93e7525d63b4c1f486397)

* [`0d6202c0`](https://github.com/romkatv/powerlevel10k/commit/0d6202c07749e18c9f90fc331cb21e538ccb9f60) add puTTY to the install section including not about a bug in versions prior to 0.75
* [`ab321a2a`](https://github.com/romkatv/powerlevel10k/commit/ab321a2a03388272cbf00fb6eda52e1cee87a02c) docs: clean up puTTY font instructions
* [`ced77880`](https://github.com/romkatv/powerlevel10k/commit/ced77880120dc8073f5781fc7994942ff5ebbfae) docs: fix indentation
* [`dd3dcfaf`](https://github.com/romkatv/powerlevel10k/commit/dd3dcfaf51d2f12ea208c0c96b2f039c0435ec00) make `toolbox` segment work with distrobox ([romkatv/powerlevel10k⁠#1696](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1696))
* [`73546881`](https://github.com/romkatv/powerlevel10k/commit/73546881235dae77f9f93e7525d63b4c1f486397) fix cwd handling when the current dir is '/foo\bar' ([romkatv/powerlevel10k⁠#1697](http://r.duckduckgo.com/l/?uddg=https://github.com/romkatv/powerlevel10k/issues/1697))
