### PR TITLE
niv spacemacs: update 5bcedd19 -> 0206197b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "5bcedd19123248bc7a6d80994784062e524ebe05",
-        "sha256": "1n73xi64gljqdqbpgwj42qcxhl5ssva9s9sb7qdgsy8zr5p2g68z",
+        "rev": "0206197b224f67e6a4c65bb850758f4affc9cc84",
+        "sha256": "1fb5wzk1k9f6n15r32qxlvffqn6nnjizmzx5c7s4jbzl0j3s0g01",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/5bcedd19123248bc7a6d80994784062e524ebe05.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/0206197b224f67e6a4c65bb850758f4affc9cc84.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@5bcedd19...0206197b](https://github.com/syl20bnr/spacemacs/compare/5bcedd19123248bc7a6d80994784062e524ebe05...0206197b224f67e6a4c65bb850758f4affc9cc84)

* [`902d2103`](https://github.com/syl20bnr/spacemacs/commit/902d210361c03f3a87cb6bd0cf5c83d06b61aea1) [auto-completion][julia] Revert [syl20bnr/spacemacs⁠#15171](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15171), Proper fix for [syl20bnr/spacemacs⁠#15169](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15169)
* [`8034e471`](https://github.com/syl20bnr/spacemacs/commit/8034e471b5f38dcd5f06ac997ff611932f2c46ea) Fix mouse click behavior in customize buffers (issue [syl20bnr/spacemacs⁠#15211](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15211))
* [`295b86e5`](https://github.com/syl20bnr/spacemacs/commit/295b86e57a74899102aa0f7ef6d55881b7d5568c) [bot] "built_in_updates" Thu Dec 30 17:38:33 UTC 2021 ([syl20bnr/spacemacs⁠#15229](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15229))
* [`eb3ebe2c`](https://github.com/syl20bnr/spacemacs/commit/eb3ebe2c6e15f7a1da4cf170aa2a2eb5f3cb47e5) [compleseus] integration with which-key
* [`d7f9eb63`](https://github.com/syl20bnr/spacemacs/commit/d7f9eb634260597fffa6d93e496640dbeb295cd7) Update minimum supported emacs version to 27.1
* [`088493ab`](https://github.com/syl20bnr/spacemacs/commit/088493ab0ec07fb11694bd2bd3bb62c0364cd932) [languagetool] fix for non standard language code ([syl20bnr/spacemacs⁠#15216](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15216))
* [`c017aa96`](https://github.com/syl20bnr/spacemacs/commit/c017aa961773bc171e54fa60116671363d3fe031) [lsp-latex] Fix warning void variable TeX-view-program-selection
* [`1bd54283`](https://github.com/syl20bnr/spacemacs/commit/1bd5428360bf5a45afe9109e86576b682a39ed62) git-gutter: Remove custom fringe bitmaps
* [`8cbcc9f0`](https://github.com/syl20bnr/spacemacs/commit/8cbcc9f085090d4b4980e4d48a35805c36845068) Fix [syl20bnr/spacemacs⁠#14162](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/14162), python-execute-file not using in virtual environment
* [`1d45278a`](https://github.com/syl20bnr/spacemacs/commit/1d45278a71275cc3e22d136389b6f030d69f50b4) [lsp] add consult-lsp and set lsp-use-upstream-bindings to t
* [`9f92b47c`](https://github.com/syl20bnr/spacemacs/commit/9f92b47ce63c32a074471041f35b9383c3488e3d) Make dotspacemacs config diffs a little smaller...
* [`e2f6aa94`](https://github.com/syl20bnr/spacemacs/commit/e2f6aa94800f1cd5ce80f021bef34df285e35a50) Add basic tree-sitter layer ([syl20bnr/spacemacs⁠#15185](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15185))
* [`4d59149e`](https://github.com/syl20bnr/spacemacs/commit/4d59149eb52f3556db7bb8d5695f446c1592b9d8) [bot] "documentation_updates" Sun Jan  2 06:54:20 UTC 2022
* [`41ea2b21`](https://github.com/syl20bnr/spacemacs/commit/41ea2b2136caf5b9cce8e7690e43881bb6669a86) Update core-themes-support.el ([syl20bnr/spacemacs⁠#15237](http://r.duckduckgo.com/l/?uddg=https://github.com/syl20bnr/spacemacs/issues/15237))
* [`0cbd48f0`](https://github.com/syl20bnr/spacemacs/commit/0cbd48f0a50762ce8c50338a139395333d8d9bc8) [doc] Fix wrong min emacs version and rewrite update instructions
* [`8f597623`](https://github.com/syl20bnr/spacemacs/commit/8f597623789ac942f54a998007f649d65738bbaf) [ci] Deactivate tests for emacs 26.3
* [`faaf87a3`](https://github.com/syl20bnr/spacemacs/commit/faaf87a3757dd03d5009cf080f351e3873ed8ff7) [semantic-web] Fix missing package, ttl-mode
* [`4625745a`](https://github.com/syl20bnr/spacemacs/commit/4625745a8b1faffdb156c168de4b2875b3c30361) Change core-configuration-layer.el to not use obsolete defmethod
* [`0206197b`](https://github.com/syl20bnr/spacemacs/commit/0206197b224f67e6a4c65bb850758f4affc9cc84) [core] less ".el" suffix for support both *.el and *.elc
