### PR TITLE
niv nixpkgs: update 781674e7 -> 6a7bafcb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "781674e726d95057eb0751cca4dd3e2aa2a4f533",
-        "sha256": "12r62iwq6pvvqqrycd5gbyns6fj5072768mj89d5lhhi34dl8wb7",
+        "rev": "6a7bafcb0fd068716ca6659e59d197044c41a9a7",
+        "sha256": "1639fypvn9qnaq42a9m1byv7jbxhhlidhnr6v31l3hvijzny90bn",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/781674e726d95057eb0751cca4dd3e2aa2a4f533.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6a7bafcb0fd068716ca6659e59d197044c41a9a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@781674e7...6a7bafcb](https://github.com/nixos/nixpkgs/compare/781674e726d95057eb0751cca4dd3e2aa2a4f533...6a7bafcb0fd068716ca6659e59d197044c41a9a7)

* [`e8522472`](https://github.com/NixOS/nixpkgs/commit/e852247238a8271972a1669704e2dd82b31ad75b) python38Packages.python-ironicclient: 4.9.0 -> 4.10.0
* [`bb551205`](https://github.com/NixOS/nixpkgs/commit/bb551205bbd247230a027a47ab095ca015544119) python38Packages.jupyterlab_server: 2.10.2 -> 2.10.3
* [`41688346`](https://github.com/NixOS/nixpkgs/commit/416883461db4d3b8d451155dd6b6886da876f16e) mercurialFull: skip an unstable experimental test
* [`be9e2cf9`](https://github.com/NixOS/nixpkgs/commit/be9e2cf9cc2b39f25d1388ce6827b9b5870a34d7) python38Packages.python-keystoneclient: 4.3.0 -> 4.4.0
* [`2dae7387`](https://github.com/NixOS/nixpkgs/commit/2dae738752d1f19f862626bf38ead9ed4ff77fb4) libcryptui: fix build with latest gnupg
* [`8fc9b26b`](https://github.com/NixOS/nixpkgs/commit/8fc9b26bc36ce17045439d0a64ed8f6ba36f0dfc) notmuch: 0.34.1 → 0.34.2
* [`eed857b5`](https://github.com/NixOS/nixpkgs/commit/eed857b539fd78ffcaf74d52543c17b568a2a4ad) python3.pkgs.panflute: 2.1.0 → 2.1.3
* [`37e9987f`](https://github.com/NixOS/nixpkgs/commit/37e9987fb94f3e52f23d284fe07b4a5b7c844e06) swiften: use system expat
* [`ec90decc`](https://github.com/NixOS/nixpkgs/commit/ec90decc7d175814f673803682b41d66f891f7b2) swiften: fix build
* [`419cf5cd`](https://github.com/NixOS/nixpkgs/commit/419cf5cd4f1409d0b92a9d5ef956ec2e4970e406) swiften: format the expression
* [`17577f6b`](https://github.com/NixOS/nixpkgs/commit/17577f6b54d71875b6c14edb31dbd474282d663e) pkgsStatic.libredirect: print error message why it won't work
* [`c555a4e3`](https://github.com/NixOS/nixpkgs/commit/c555a4e329904552a92947e125d9bc9d9a17c59e) testEqualDerivation: init
* [`0edf0fd2`](https://github.com/NixOS/nixpkgs/commit/0edf0fd22074c2ee178b194203643c19f9fb66d0) hello: Test independence of environment.noXlibs
* [`573edbf4`](https://github.com/NixOS/nixpkgs/commit/573edbf405c369e9d9c8860b8b4abe7d87d1cb3d) swiften: use dependencies from nix
* [`345370b2`](https://github.com/NixOS/nixpkgs/commit/345370b21cdba29aab36f53ae101543ead01f748) swiften: another build fix attempt
* [`3045dd2a`](https://github.com/NixOS/nixpkgs/commit/3045dd2aef0d801a1f79e940b7d2a004bcc75cd3) nfpm: 2.11.2 -> 2.11.3
* [`12cc34ce`](https://github.com/NixOS/nixpkgs/commit/12cc34ce2dd2f8d5973b91ca0c6c16d98f335fd6) yosys: Add yosys-symbiflow-plugins
* [`9d3ba92d`](https://github.com/NixOS/nixpkgs/commit/9d3ba92d635aaf728423488205b04f15e8953887) nixos/documentation: fix docs cross build
* [`9ef985aa`](https://github.com/NixOS/nixpkgs/commit/9ef985aa84f1c2b1da55a8a3ab341182c79c34eb) phoronix-test-suite: 10.6.1 -> 10.8.0
* [`b2645131`](https://github.com/NixOS/nixpkgs/commit/b26451314a196a4e4d3afbc886c7df57001a5c31) python3.pkgs.weasyprint: 53.4 → 54.0
* [`76034fee`](https://github.com/NixOS/nixpkgs/commit/76034fee72c735a6419477f9e968284fa44e6b1e) jetbrains.goland: Fix debugging
* [`e898681c`](https://github.com/NixOS/nixpkgs/commit/e898681ce1f119ae3b7208c6950a9db16ff3cae1) flexget: 3.2.7 -> 3.2.8
* [`d69abfe5`](https://github.com/NixOS/nixpkgs/commit/d69abfe510c77fa4cd01346e155c8a6e0e6de920) mercurial: move tests to passthru.tests
* [`840d7881`](https://github.com/NixOS/nixpkgs/commit/840d7881a60826eed652958d2edebf45f541cf26) icewm: 2.6.0 → 2.9.4
* [`9d7399d9`](https://github.com/NixOS/nixpkgs/commit/9d7399d998dc8328b3960c4c5704280dcdd45cfc) bat: 0.18.3 -> 0.19.0
* [`13c7faa8`](https://github.com/NixOS/nixpkgs/commit/13c7faa86538bb62904fe8e60dbadcc2455fc0f3) duf: 0.6.2 -> 0.7.0
* [`d990513e`](https://github.com/NixOS/nixpkgs/commit/d990513e494758bdad6d67cde33bbb7f28d36b6a) calibre: fix build on staging-next due to missing setuptools
* [`c1b06381`](https://github.com/NixOS/nixpkgs/commit/c1b06381d8a742d9a6214018399b56f443d0717e) nongnu-packages 2022-01-08
* [`fbc1fd22`](https://github.com/NixOS/nixpkgs/commit/fbc1fd224a7bc460ed0f02b8e4180209ff1bec55) python38Packages.geoalchemy2: 0.10.1 -> 0.10.2
* [`ceb262a9`](https://github.com/NixOS/nixpkgs/commit/ceb262a9231afc472db047222ef3d7538911b1c9) python38Packages.types-pytz: 2021.3.3 -> 2021.3.4
* [`33f86c6a`](https://github.com/NixOS/nixpkgs/commit/33f86c6aa79383ba909b3e98eff17a49f21402fe) python38Packages.types-setuptools: 57.4.5 -> 57.4.6
* [`51494bfe`](https://github.com/NixOS/nixpkgs/commit/51494bfecb7af9b2407a74362ae724bd2feafd69) python38Packages.cornice: 6.0.0 -> 6.0.1
* [`1cdee8ee`](https://github.com/NixOS/nixpkgs/commit/1cdee8eec0935c763dd8f4320eabfa53fa3cf97f) python38Packages.lightgbm: 3.3.1 -> 3.3.2
* [`cf62e9c0`](https://github.com/NixOS/nixpkgs/commit/cf62e9c07a29453468ede8917ecb3800392ee3a3) python3Packages.typesystem: 0.2.4 -> 0.4.1
* [`6f99ebff`](https://github.com/NixOS/nixpkgs/commit/6f99ebff740502d13becd18f1c12d0b47f2e1ecd) python3Packages.orm: 0.1.5 -> 0.3.1
* [`81e1292b`](https://github.com/NixOS/nixpkgs/commit/81e1292bb39c8fd6d5ecf16b80ebc80c2cc61316) python38Packages.enamlx: 0.5.0 -> 0.6.0
* [`427d3d15`](https://github.com/NixOS/nixpkgs/commit/427d3d15d4f5b5aa5c02ffc79b7277714ebb5e9f) python3Packages.mdformat: 0.7.11 -> 0.7.12
* [`d8c384e6`](https://github.com/NixOS/nixpkgs/commit/d8c384e6b81598689e0e96b341f1b149a88a2ddc) python38Packages.pyrogram: 1.2.0 -> 1.3.0
* [`6a1109ad`](https://github.com/NixOS/nixpkgs/commit/6a1109adfa4b81627c967e1aa791e816a49e12de) vimPlugins.parinfer-rust at init
* [`89d61280`](https://github.com/NixOS/nixpkgs/commit/89d612804d0cdfb4c8280070a6ad4acae09f734c) python38Packages.jdatetime: 3.7.0 -> 3.8.0
* [`6015cd8e`](https://github.com/NixOS/nixpkgs/commit/6015cd8ea8d4030655a1379aad6628555cdf8455) python38Packages.pudb: 2021.2.2 -> 2022.1
* [`2fbf860e`](https://github.com/NixOS/nixpkgs/commit/2fbf860e58b9aed749db94e92591b41ed163aea6) python38Packages.types-futures: 3.3.1 -> 3.3.2
* [`41d2ab40`](https://github.com/NixOS/nixpkgs/commit/41d2ab408517d45f1edeb45649045a0e3ea109bb) python38Packages.bitarray: 2.3.4 -> 2.3.5
* [`17113a7b`](https://github.com/NixOS/nixpkgs/commit/17113a7b699b243514c1e9dabae81abdc9963d71) python3Packages.fastjsonschema: 2.15.1 -> 2.15.2
* [`a404e491`](https://github.com/NixOS/nixpkgs/commit/a404e49124416564236169ac67c2c87bc4945b8d) python3Packages.typical: 2.7.9 -> 2.8.0
* [`0a0c1140`](https://github.com/NixOS/nixpkgs/commit/0a0c1140dc3ca394e29033d059d7c18fd4bdfd7d) melpa-packages 2022-01-08
* [`9c51fce6`](https://github.com/NixOS/nixpkgs/commit/9c51fce6a92a73517cedc58969239ddc726faf60) timg: 1.4.2 -> 1.4.3
* [`69dadbcd`](https://github.com/NixOS/nixpkgs/commit/69dadbcd8bc98f9ab27cbf985059c8511946dafc) elpa-packages 2022-01-08
* [`46223d06`](https://github.com/NixOS/nixpkgs/commit/46223d06c63b9bdf979a714cec4ba7c45d098946) elpa-generated.nix: manual fixup of duplicate shell-command-plus
* [`0a19fe83`](https://github.com/NixOS/nixpkgs/commit/0a19fe8310099fe1857e1be505df7db97da9d035) uriparser: 0.9.5 -> 0.9.5 (security, fixes [nixos/nixpkgs⁠#153777](https://togithub.com/nixos/nixpkgs/issues/153777)) ([nixos/nixpkgs⁠#154033](https://togithub.com/nixos/nixpkgs/issues/154033))
* [`fd39255c`](https://github.com/NixOS/nixpkgs/commit/fd39255c33390ef35d656596053ce05c8b22656f) vscode-extensions: update installed extensions
* [`0610155a`](https://github.com/NixOS/nixpkgs/commit/0610155a9ba59dda22679bd69f12841730e5188e) qrcodegen: mark as broken on Darwin
* [`72f8b239`](https://github.com/NixOS/nixpkgs/commit/72f8b239059c4019bcebd6f58ca07dedea546c89) notcurses: 2.4.9 -> 3.0.3
* [`34b6ed85`](https://github.com/NixOS/nixpkgs/commit/34b6ed85730156d554ed2adaf4656f6c302050ce) emacsPackages.apheleia: 1.1.2+unstable=2021-10-03 -> 1.2
* [`ce9d3bee`](https://github.com/NixOS/nixpkgs/commit/ce9d3bee88fd01fc4f8e8ec911a1778f6479091c) emacsPackages.tramp: 2.5.1 -> 2.5.2
* [`6ee417ac`](https://github.com/NixOS/nixpkgs/commit/6ee417ace669ff6f051d00797046dc11c694cbc7) emacsPackages.bqn-mode: 0.pre+date=2021-12-03 -> 0.pre+date=2022-01-07
* [`39ce4ddd`](https://github.com/NixOS/nixpkgs/commit/39ce4ddd85bad02d48c7c0588d50ee03af6a8ef9) nixos/prometheus: fix usage of bearer_token
* [`b575e8c2`](https://github.com/NixOS/nixpkgs/commit/b575e8c297302fb1429649f62609ffb4fbf7dc41) emacsPackages.tramp: remove
* [`30b3b39f`](https://github.com/NixOS/nixpkgs/commit/30b3b39f72e7c61844df3dc1fe793d7805aae646) org-generated.nix: remove
* [`5f8f72c1`](https://github.com/NixOS/nixpkgs/commit/5f8f72c10c43514a4e9093efb9029cf3f8a9ec00) klee: init at 2.2
* [`e0a7e674`](https://github.com/NixOS/nixpkgs/commit/e0a7e674584196fb64d2d43e7f1f91a10737b492) python3Packages.pydevccu: 0.0.9 -> 0.1.0
* [`cf141804`](https://github.com/NixOS/nixpkgs/commit/cf141804e3d7540600aa7cf5fe534a7819ac3947) python3Packages.hahomematic: 0.15.0 -> 0.15.2
* [`8ee96596`](https://github.com/NixOS/nixpkgs/commit/8ee965960239255c696d950f302b040a22524092) python3Packages.hahomematic: 0.15.2 -> 0.16.0
* [`d3bf3e01`](https://github.com/NixOS/nixpkgs/commit/d3bf3e012e2a3a506ea1272bc43d5e566206b3b4) libgtop: add dev output
* [`0b0fcb01`](https://github.com/NixOS/nixpkgs/commit/0b0fcb01c70ee40618fde848d87779e4444a46b9) libvncserver: add dev output
* [`7f725209`](https://github.com/NixOS/nixpkgs/commit/7f7252093ffdd080d0e3f3faa7a4a9ccda51e616) emacs.pkgs.melpa*: Fix version numbers with negative numbers
* [`234f0a25`](https://github.com/NixOS/nixpkgs/commit/234f0a25b71e392a7c2ea544f65d648826bcc560) python38Packages.schema-salad: 8.2.20211222191353 -> 8.2.20220103095339
* [`52658fb0`](https://github.com/NixOS/nixpkgs/commit/52658fb09090ef5958037130ed865dd841b822a3) python38Packages.azure-mgmt-compute: 23.1.0 -> 24.0.0
* [`c3037644`](https://github.com/NixOS/nixpkgs/commit/c3037644d7c4b08c81f62c45b77a9c88b25736fd) azure-cli: fix pinning for azure-mgmt-compute
* [`701f1c4c`](https://github.com/NixOS/nixpkgs/commit/701f1c4c55be8ac28bf8fd5acf9d3bb6f047248b) gnome.gnome-shell: switch to non-full asciidoc
* [`ff0ee5bf`](https://github.com/NixOS/nixpkgs/commit/ff0ee5bf85841c0e4af0d739c490495830b50ea2) octoprint: ignore pyyaml version constraint
* [`874acbb2`](https://github.com/NixOS/nixpkgs/commit/874acbb235945ffb1fbced580cde0394bcada466) python3Packages.dulwich: 0.20.27 -> 0.20.30
* [`c60fa622`](https://github.com/NixOS/nixpkgs/commit/c60fa62269269bc553af574dd0dbed36f8b19ad7) python3Packages.natsort: 7.2.0 -> 8.0.2
* [`8c161f6a`](https://github.com/NixOS/nixpkgs/commit/8c161f6a62852e7e36b3dbb2ca3168e07a3e5ec8) emacs.pkgs.melpa*: Fix version number checks if number is zero
* [`b9c6bff4`](https://github.com/NixOS/nixpkgs/commit/b9c6bff4f07ea912a8be8af1a0a3bb043626f75c) nextinspace: 1.0.6 -> 2.0.3
* [`e4255a2a`](https://github.com/NixOS/nixpkgs/commit/e4255a2ad0ccb08bd0ac20ac0bdbd6c6654c68bf) CODEOWNERS: subscribe to few pkgs, modules and tests
* [`708a15bc`](https://github.com/NixOS/nixpkgs/commit/708a15bc2b7ef7411117ad4f0ec34ef43340f2b9) python3Packages.readme_renderer: relax cmarkgfm constraint
* [`f5e0f293`](https://github.com/NixOS/nixpkgs/commit/f5e0f2932e9a4f05bc267fbbf9c554e237cb91ba) sshd: disable trigger limit for systemd socket
* [`051f0406`](https://github.com/NixOS/nixpkgs/commit/051f0406cb3c6c28e19f57c8d1ae51c0a458baf9) aws-crt-cpp: add dev output
* [`e2441863`](https://github.com/NixOS/nixpkgs/commit/e2441863d447d25757ccb1586d352380d8a95042) gnome-photos: remove adwaita-icon-theme dependency
* [`52f2f6cf`](https://github.com/NixOS/nixpkgs/commit/52f2f6cf4be9eb88711644282e5e706cfa03cc69) cryptopp: be graceful when removing static lib, fixing cross compilation
* [`f0225e37`](https://github.com/NixOS/nixpkgs/commit/f0225e376fede135d36f91893b8af26d0e33232e) vala_0_48: 0.48.20 → 0.48.21
* [`3ace1a91`](https://github.com/NixOS/nixpkgs/commit/3ace1a91eca77224ebf79a36699f6389cca831b5) speechd: 0.10.2 → 0.11.1
* [`b0a4fa52`](https://github.com/NixOS/nixpkgs/commit/b0a4fa5273467246d0e86033c5712978237eb953) speechd: clean up
* [`67e5298b`](https://github.com/NixOS/nixpkgs/commit/67e5298bfb49471dc4e43a35f4bc97186a120f26) speechd: Fix espeak-mbrola voice check
* [`29d7307a`](https://github.com/NixOS/nixpkgs/commit/29d7307a05f3467a51b559dae6e2025afa446127) abootimg: fix cross compilation and set strictDeps
* [`bc547213`](https://github.com/NixOS/nixpkgs/commit/bc547213ebc45895e1a1a38f8d395a7f57882aa3) astrolog: fix cross compilation
* [`51f93cb7`](https://github.com/NixOS/nixpkgs/commit/51f93cb778f95937daabb80b1d47f244e9537343) roc-toolkit: fix cross compilation
* [`c9f08ace`](https://github.com/NixOS/nixpkgs/commit/c9f08ace52ee152e0dd75bc071e4159c0bcc7cc2) zpaq: cleanup and fix cross compilation
* [`4d70e2dc`](https://github.com/NixOS/nixpkgs/commit/4d70e2dca4457e22753aba5ba118a59e1d5535fe) vala_0_52: 0.52.8 → 0.52.9
* [`a2aee625`](https://github.com/NixOS/nixpkgs/commit/a2aee6257316f779c06d24d3badd6cc304747f32) zpaqd: fix cross compilation
* [`752ae866`](https://github.com/NixOS/nixpkgs/commit/752ae8660562b7a037d7c49bcf95465028a35005) python38Packages.python-telegram-bot: 13.8.1 -> 13.9
* [`cb6adff3`](https://github.com/NixOS/nixpkgs/commit/cb6adff3ba6f9a347dcc2d7afbade1e25fee0a7b) python3Packages.img2pdf: run tests ([nixos/nixpkgs⁠#152365](https://togithub.com/nixos/nixpkgs/issues/152365))
* [`509a9f5f`](https://github.com/NixOS/nixpkgs/commit/509a9f5f14775e761afa8b06e3b752929232b0ab) asdf: fix cross compilation and set strictDeps
* [`745b35fa`](https://github.com/NixOS/nixpkgs/commit/745b35facdba2c3b96171ab74267bef3dc4cbd35) python38Packages.cocotb: 1.6.0 -> 1.6.1
* [`d5e4ceac`](https://github.com/NixOS/nixpkgs/commit/d5e4ceac727c4b28a139c7707e5e5cc8eaf74a35) touchegg: 2.0.12 -> 2.0.13
* [`48271361`](https://github.com/NixOS/nixpkgs/commit/482713610577999076af1d3ce4f981cd2b71c2fd) python38Packages.trimesh: 3.9.41 -> 3.9.42
* [`6675c8e9`](https://github.com/NixOS/nixpkgs/commit/6675c8e96d401881c60f3add3c5703319fc645f4) tailscale: remove old xversion tag
* [`35a91860`](https://github.com/NixOS/nixpkgs/commit/35a9186075f70b58fa0095b49446dc86c46eefec) python38Packages.goodwe: 0.2.11 -> 0.2.12
* [`f2c5970a`](https://github.com/NixOS/nixpkgs/commit/f2c5970a7654c8fed9ba13f70071c29161d80c7c) users-groups service: add autoSubUidGidRange option
* [`e1e4e1c2`](https://github.com/NixOS/nixpkgs/commit/e1e4e1c2cb82cdd1afeca2ba45214afeb4b4bdf6) postgresqlPackages.tds_fdw: 2.0.2 -> unstable-2021-12-14
* [`0ecf7d41`](https://github.com/NixOS/nixpkgs/commit/0ecf7d414811f831060cf55707c374d54fbb1dec) pam_pgsql: 0.7.3.2 -> unstable-2020-05-05
* [`db0a716d`](https://github.com/NixOS/nixpkgs/commit/db0a716d2bd8b59a12d5606616dad3fd3f6088be) python38Packages.types-toml: 0.10.2 -> 0.10.3
* [`ff5850f5`](https://github.com/NixOS/nixpkgs/commit/ff5850f5d759294a6c44f093190044733b47044d) python38Packages.deezer-py: 1.3.5 -> 1.3.6
* [`f0ed9541`](https://github.com/NixOS/nixpkgs/commit/f0ed9541586dbc2209501b9cdce876c703336e88) amdvlk: fix repo hash for v2021.Q4.3
* [`37bb0ba9`](https://github.com/NixOS/nixpkgs/commit/37bb0ba9f41a2825bb9821d20cf7c72c76344565) python38Packages.pyradios: 0.0.22 -> 1.0.1
* [`87c9cbde`](https://github.com/NixOS/nixpkgs/commit/87c9cbdea4f3ecd035fd172f862fcb4dca1d6de9) python3Packages.pyradios: update meta
* [`a0785fd0`](https://github.com/NixOS/nixpkgs/commit/a0785fd0c73c626fae92bea7fac81d46e926905d) python38Packages.pycocotools: 2.0.3 -> 2.0.4
* [`2febc7dd`](https://github.com/NixOS/nixpkgs/commit/2febc7dd79653114eae54e27c9be215fe53b7ce5) nixos/ddclient: don't store config world-readable
* [`d45abd5f`](https://github.com/NixOS/nixpkgs/commit/d45abd5fc9c22a09638f3ad487738e0da4a7900d) python38Packages.mocket: 3.10.2 -> 3.10.3
* [`41710117`](https://github.com/NixOS/nixpkgs/commit/417101172d118da24deb027aad999be8013f2e7d) tautulli: add some missing files and update licence
* [`72af5962`](https://github.com/NixOS/nixpkgs/commit/72af5962468ca956cf6f9778545aa4a11e05b78e) tautulli: 2.8.0 -> 2.8.1
* [`51967ca7`](https://github.com/NixOS/nixpkgs/commit/51967ca77a23215df766a4cf72a56ac219e49d2a) nixos/ddclient: better default for nsupdate
* [`71930ab2`](https://github.com/NixOS/nixpkgs/commit/71930ab2f4cd152d83c976e18be17e24acccad31) yash: init at 2.52
* [`9648b4f6`](https://github.com/NixOS/nixpkgs/commit/9648b4f6a3c13d19b6c6ebba0bedfe327a4b3e59) maintainers: add qbit
* [`08e6b802`](https://github.com/NixOS/nixpkgs/commit/08e6b80248e25d2d32d22c00a2f17e5b626b95d8) rime-data: 0.38.20210628 -> 0.38.20211002
* [`1ed1e00d`](https://github.com/NixOS/nixpkgs/commit/1ed1e00d2be929740f214f8053316bd0e4d64d2f) commit-formatter: init at 0.2.1
* [`b61827f6`](https://github.com/NixOS/nixpkgs/commit/b61827f61d6a8abc0279be50d84ba4309539a39c) gns3-{gui,server}: 2.2.28 -> 2.2.29
* [`fdc80b46`](https://github.com/NixOS/nixpkgs/commit/fdc80b46b27eb7cef9b06a7196c516961a9ce7e1) python3Packages.pycocotools: drop maintainership
* [`f32e876f`](https://github.com/NixOS/nixpkgs/commit/f32e876f36da2c6626a456ad16a2ade5fa762358) python3.pkgs.tensorboardx: re-enable disabled test
* [`19be0891`](https://github.com/NixOS/nixpkgs/commit/19be0891069a116ea6eff5d3a1aa87ad2a1b39bc) tensorboardx: fix tests
* [`2af27e44`](https://github.com/NixOS/nixpkgs/commit/2af27e443f3ee0a242ea9513d8c872aadab63346) alsa-ucm-conf: 1.2.5.1 -> 1.2.6.3
* [`f89427f9`](https://github.com/NixOS/nixpkgs/commit/f89427f939ae8c834f85e741c680cee25bcc4d3a) tagtime: init at 2018-09-02
* [`91d02282`](https://github.com/NixOS/nixpkgs/commit/91d0228224279e10bb74be6656b0820a93d8ab37) gallery-dl: 1.19.3 -> 1.20.1
* [`1f78e4c1`](https://github.com/NixOS/nixpkgs/commit/1f78e4c10173a03ac41b9121b88b690546dd2f7a) protontricks: 1.6.2 → 1.7.0
* [`4cb152fc`](https://github.com/NixOS/nixpkgs/commit/4cb152fceaf8d3a93227b6965325fc81a689951c) Update pkgs/applications/editors/jetbrains/default.nix
* [`fe20f479`](https://github.com/NixOS/nixpkgs/commit/fe20f479e9a6bee55d47ad450ec81b07200a8168) nixos/thelounge: add plugins option
* [`e5e46f1a`](https://github.com/NixOS/nixpkgs/commit/e5e46f1add3362d9b35f4a82ed95716c9d115e99) nodePackages: add The Lounge plugins
* [`0028d75b`](https://github.com/NixOS/nixpkgs/commit/0028d75b1c912e4bcbae870e40ee8fd553f32a17) nixos/thelounge: add winter to maintainers
* [`91b1b02d`](https://github.com/NixOS/nixpkgs/commit/91b1b02d527fc08066c60a0c918c427e13b88cd7) Refactor all-packages.nix
* [`bd2aeade`](https://github.com/NixOS/nixpkgs/commit/bd2aeade45130a03710553066e416ef8d9ebedee) etcd_3_5: init at 3.5.1
* [`d7054157`](https://github.com/NixOS/nixpkgs/commit/d7054157281a569a662de9fa7f9cdfe96a083186) python38Packages.tgcrypto: 1.2.2 -> 1.2.3
* [`df7f6e9e`](https://github.com/NixOS/nixpkgs/commit/df7f6e9ecaabaedb0bdfc4a713f7c1fcc7f51cd6) terraform: switch to go_1_17
* [`addbaf25`](https://github.com/NixOS/nixpkgs/commit/addbaf25a16c9edd48d426c2fc07ef8abdd8cc8d) terraform-providers: updates, switch go_1_17
* [`ec9217de`](https://github.com/NixOS/nixpkgs/commit/ec9217de49b5e4ecb33f4683e8d3898727e0927f) python310Packages.meross-iot: 0.4.4.1 -> 0.4.4.2
* [`a0af8785`](https://github.com/NixOS/nixpkgs/commit/a0af8785fce91d5877792cb9ae2a39955437a1e2) python3Packages.flux-led: 0.27.43 -> 0.27.44
* [`9e97ef79`](https://github.com/NixOS/nixpkgs/commit/9e97ef794a8f22e96e1d8ec3d80f0cf14e27fad4) lib/qemu-common: Add serial device name for RISC-V
