### PR TITLE
niv home-manager: update 65e5b835 -> f3be3cda

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "65e5b835a94b3bca9a1e219e5c43c1bc5fc04598",
-        "sha256": "1xgwl7w0anqm77fhgk9fzf3kzg337lmn6318fzjwh432bnyvzk2y",
+        "rev": "f3be3cda6a69365f2acecc201b3cd1ee4f6d4614",
+        "sha256": "19ha58d17ng2ab6wvkkibn87w4mkzmv3hfv9akp9dsy2mbiykgvz",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/65e5b835a94b3bca9a1e219e5c43c1bc5fc04598.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f3be3cda6a69365f2acecc201b3cd1ee4f6d4614.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@65e5b835...f3be3cda](https://github.com/nix-community/home-manager/compare/65e5b835a94b3bca9a1e219e5c43c1bc5fc04598...f3be3cda6a69365f2acecc201b3cd1ee4f6d4614)

* [`426ab2cf`](https://github.com/nix-community/home-manager/commit/426ab2cf111fca61308bd86fe652e14aa12cc2d2) xdg-desktop-entries: reflect changes in makeDesktopItem API ([nix-community/home-manager⁠#2496](https://togithub.com/nix-community/home-manager/issues/2496))
* [`5fb55d51`](https://github.com/nix-community/home-manager/commit/5fb55d51e2dcdc0dd5f6c82968c3edff00d73b2b) swayidle: fix option documentation
* [`cf0fc744`](https://github.com/nix-community/home-manager/commit/cf0fc744c28eb89f06ff0b9a7b5ed7f98622f62c) Translate using Weblate (Spanish)
* [`a726f7e3`](https://github.com/nix-community/home-manager/commit/a726f7e3e8cec2543e6083f494220e2e0ac9e722) Add translation using Weblate (Spanish)
* [`95823b56`](https://github.com/nix-community/home-manager/commit/95823b5639f054ee8216d194a66dd49f59a7672a) Update translation files
* [`65434ef3`](https://github.com/nix-community/home-manager/commit/65434ef33cd7b32009cd1cb4cc41a54ca26768b8) Translate using Weblate (Swedish)
* [`a2307ff6`](https://github.com/nix-community/home-manager/commit/a2307ff6f32278f8055e5cd2f178974bed69733b) Translate using Weblate (Norwegian Bokmål)
* [`2989c0f6`](https://github.com/nix-community/home-manager/commit/2989c0f6b21acfcba4501e856aac1b984006fbd2) Translate using Weblate (Chinese (Simplified))
* [`a90ddcd6`](https://github.com/nix-community/home-manager/commit/a90ddcd62748e445bbbe01834595eda29dc28db9) skim: add `package` option ([nix-community/home-manager⁠#2619](https://togithub.com/nix-community/home-manager/issues/2619))
* [`05d65514`](https://github.com/nix-community/home-manager/commit/05d655146b1e98bf38c57e2ed2bea0f354e73388) rofi: allow extending themes ([nix-community/home-manager⁠#2571](https://togithub.com/nix-community/home-manager/issues/2571))
* [`f3be3cda`](https://github.com/nix-community/home-manager/commit/f3be3cda6a69365f2acecc201b3cd1ee4f6d4614) services/emacs: add option to set `emacsclient` as the default editor ([nix-community/home-manager⁠#2545](https://togithub.com/nix-community/home-manager/issues/2545))
