### PR TITLE
niv powerlevel10k: update 73546881 -> 683a4852

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "73546881235dae77f9f93e7525d63b4c1f486397",
-        "sha256": "11jdchqrmp4nb35if081f8s218n42xs4zfgfckvdlckrl9lsa047",
+        "rev": "683a485232d75978a79199a305c4fc4843772a77",
+        "sha256": "0swggp7f6vbzc70bbfiihj3f8z7j16jrcnk76nypzpxvn8sc48w1",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/73546881235dae77f9f93e7525d63b4c1f486397.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/683a485232d75978a79199a305c4fc4843772a77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@73546881...683a4852](https://github.com/romkatv/powerlevel10k/compare/73546881235dae77f9f93e7525d63b4c1f486397...683a485232d75978a79199a305c4fc4843772a77)

* [`3d3b24c4`](https://github.com/romkatv/powerlevel10k/commit/3d3b24c419a3b35b632e96fe9de34641e06f8521) work around bugs in WSL where it /proc/pid/cwd reports an alias drive
* [`c8160f29`](https://github.com/romkatv/powerlevel10k/commit/c8160f29543a2f57ae7149103deefa029fd4e861) Squashed 'gitstatus/' changes from f1cf61b24..e02d9eedd
* [`67ac98d5`](https://github.com/romkatv/powerlevel10k/commit/67ac98d515c2d8c7a85345aa2e3597df364c2f16) doc: kitty v0.24.0 has been released (the first version with shell integration)
* [`66c0181f`](https://github.com/romkatv/powerlevel10k/commit/66c0181f765185d20386174cad19d7ecee0b97a1) doc: s/Kitty/kitty/
* [`fba50d96`](https://github.com/romkatv/powerlevel10k/commit/fba50d967184c6b5be15a94c0c960b7f0811585b) Added gsutil as is the main "other command" in GCP
* [`e1c52e08`](https://github.com/romkatv/powerlevel10k/commit/e1c52e08d43652a513379f7bac7c57664c895d43) add an icon for amazon linux ([romkatv/powerlevel10k⁠#1706](https://togithub.com/romkatv/powerlevel10k/issues/1706))
* [`683a4852`](https://github.com/romkatv/powerlevel10k/commit/683a485232d75978a79199a305c4fc4843772a77) remove duplicate the
