### PR TITLE
niv spacemacs: update 0206197b -> c3ad2164

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "0206197b224f67e6a4c65bb850758f4affc9cc84",
-        "sha256": "1fb5wzk1k9f6n15r32qxlvffqn6nnjizmzx5c7s4jbzl0j3s0g01",
+        "rev": "c3ad21645c7e48fec50f6ca29f4ecd831f8023f5",
+        "sha256": "08hlr2rf8r487hvxxm55ry7wggfq3kzywqzfysfphfr7w0cgrf8v",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/0206197b224f67e6a4c65bb850758f4affc9cc84.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/c3ad21645c7e48fec50f6ca29f4ecd831f8023f5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@0206197b...c3ad2164](https://github.com/syl20bnr/spacemacs/compare/0206197b224f67e6a4c65bb850758f4affc9cc84...c3ad21645c7e48fec50f6ca29f4ecd831f8023f5)

* [`a843146f`](https://github.com/syl20bnr/spacemacs/commit/a843146f17d4cb92b44e16f566d8b79aa0ea47c0) Update README.md
* [`d63e172b`](https://github.com/syl20bnr/spacemacs/commit/d63e172bde5b2b3cb8ddb676f6db1e6df4b31fbb) Revert "[org-roam] Fix evil org-roam-node-insert spacing" ([syl20bnr/spacemacs⁠#15244](https://togithub.com/syl20bnr/spacemacs/issues/15244))
* [`bbd40f11`](https://github.com/syl20bnr/spacemacs/commit/bbd40f113fe396a2109086db0529751c3e9d0846) Add C-o and C-i keybindings to evil-evilified-state-map (and remove from pdf-view-mode-map) 
* [`2f061d26`](https://github.com/syl20bnr/spacemacs/commit/2f061d26ae68b3a7fea1cc728726be34e9ba3faa) Fix keybindings in ivy-occur-grep-mode
* [`8856bc43`](https://github.com/syl20bnr/spacemacs/commit/8856bc431679fb057c834a33364033c3b6a7c63e) themes-megapack: Update obsolete package
* [`e9648b80`](https://github.com/syl20bnr/spacemacs/commit/e9648b809a527597702d63f0d14989de9a1614c4) [tree-sitter] Rename variables to match conventions
* [`f85b5610`](https://github.com/syl20bnr/spacemacs/commit/f85b561085f55c773c46b4bc5149cfdf268cfc50) [bot] "documentation_updates" Sat Jan  8 12:02:19 UTC 2022 ([syl20bnr/spacemacs⁠#15254](https://togithub.com/syl20bnr/spacemacs/issues/15254))
* [`94a68116`](https://github.com/syl20bnr/spacemacs/commit/94a6811682d68b3afdea164c86debb76d5cb6bed) Fix [syl20bnr/spacemacs⁠#15198](https://togithub.com/syl20bnr/spacemacs/issues/15198) predicate to check if major-mode is compilation-mode or derived. ([syl20bnr/spacemacs⁠#15253](https://togithub.com/syl20bnr/spacemacs/issues/15253))
* [`964f4c5a`](https://github.com/syl20bnr/spacemacs/commit/964f4c5af3615b648a7707a39b82b7ef02dc4807) [core] Set version to 0.999 and report rolling release schedule
* [`a4e5615f`](https://github.com/syl20bnr/spacemacs/commit/a4e5615f664c87277691b2272977f0dfa9c98b37) [core] Rename next master release to show depreciation message
* [`f60aec52`](https://github.com/syl20bnr/spacemacs/commit/f60aec52a5d473535a015549b6d3b3f516812ef3) [core] Make rolling release message more clear
* [`8226efa6`](https://github.com/syl20bnr/spacemacs/commit/8226efa633d896aad7f7cd1fa1979bdae131f5e0) help/helpful: Set tab-width to 8, better integration w/ Ivy ([syl20bnr/spacemacs⁠#15243](https://togithub.com/syl20bnr/spacemacs/issues/15243))
* [`c3ad2164`](https://github.com/syl20bnr/spacemacs/commit/c3ad21645c7e48fec50f6ca29f4ecd831f8023f5) [bot] built_in_updates ([syl20bnr/spacemacs⁠#15261](https://togithub.com/syl20bnr/spacemacs/issues/15261))
