### PR TITLE
niv zsh-completions: update bffff37c -> 20f3cd5f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "bffff37c3e1d40239e2fd55a8e9755d211e8f982",
-        "sha256": "10c1ajlnsk29qkdr4a3s0d6qgg5hpdz06bw9d8w5nw8hy9bzdxsh",
+        "rev": "20f3cd5f5d3e6ef7deb343b11c084e1fb2f5a3f2",
+        "sha256": "04q9nrvvx2gzcymakaygcklqh0w33pwf3x5jd42pbqici505gqbz",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/bffff37c3e1d40239e2fd55a8e9755d211e8f982.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/20f3cd5f5d3e6ef7deb343b11c084e1fb2f5a3f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@bffff37c...20f3cd5f](https://github.com/zsh-users/zsh-completions/compare/bffff37c3e1d40239e2fd55a8e9755d211e8f982...20f3cd5f5d3e6ef7deb343b11c084e1fb2f5a3f2)

* [`1b1b0c7c`](https://github.com/zsh-users/zsh-completions/commit/1b1b0c7c8fb34926733e2292acd11cfef2b58ae7) Fix script completion which contains colons
