### PR TITLE
niv nixpkgs: update 6a7bafcb -> dfa93a47

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6a7bafcb0fd068716ca6659e59d197044c41a9a7",
-        "sha256": "1639fypvn9qnaq42a9m1byv7jbxhhlidhnr6v31l3hvijzny90bn",
+        "rev": "dfa93a472533cba8462f8014937afbfa4c0f1b9b",
+        "sha256": "05i4zdmbpzq06cfnhbacy1w9ia8ih8drspp7rp6jrwba7aqww4dv",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/6a7bafcb0fd068716ca6659e59d197044c41a9a7.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/dfa93a472533cba8462f8014937afbfa4c0f1b9b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@6a7bafcb...dfa93a47](https://github.com/nixos/nixpkgs/compare/6a7bafcb0fd068716ca6659e59d197044c41a9a7...dfa93a472533cba8462f8014937afbfa4c0f1b9b)

* [`f3516813`](https://github.com/NixOS/nixpkgs/commit/f3516813d829ac711d044da9aac8aecc7f628c46) thermald: disable network access
* [`2cb556b6`](https://github.com/NixOS/nixpkgs/commit/2cb556b6105da17706f7d29859c4b881684ba466) argocd: 2.2.1 -> 2.2.2 ([nixos/nixpkgs⁠#154369](https://togithub.com/nixos/nixpkgs/issues/154369))
* [`9b394d9d`](https://github.com/NixOS/nixpkgs/commit/9b394d9dbff1223393052b3b7f789a64f0a6d9d4) fceux: 2.5.0 -> 2.6.0
* [`23e1f0d0`](https://github.com/NixOS/nixpkgs/commit/23e1f0d0131bc82208db0784b4c85e0b750af74c) python310Packages.tatsu: Fix the build
* [`be7e5971`](https://github.com/NixOS/nixpkgs/commit/be7e5971739da2cf4928b63c44f4071a21217780) lightly-qt: init at 0.4.1
* [`b0d472b8`](https://github.com/NixOS/nixpkgs/commit/b0d472b8e7403ef9fcb9cecd7ab7b596b0324e72) Fix styling
* [`3db46978`](https://github.com/NixOS/nixpkgs/commit/3db469781ad1de6f667d55b9f4cb88db127b5b77) Update pkgs/data/themes/lightly-qt/default.nix
* [`57c9949a`](https://github.com/NixOS/nixpkgs/commit/57c9949a64a32681d5305a3f3f103c2e9422c192) license: gpl2Plus
* [`610b8b22`](https://github.com/NixOS/nixpkgs/commit/610b8b2210428080020d00ec0e083fb54fedaf1f) Cleanup: Factor out lib for metadata
* [`b241f314`](https://github.com/NixOS/nixpkgs/commit/b241f3143a4f14e1bda901c4132cdd69443152b8) diffoscope: 197 -> 200
* [`12098119`](https://github.com/NixOS/nixpkgs/commit/12098119d9ab25a467eaa85dc26901b63d188696) python2Packages.pyyaml: init at 5.4.1.1
* [`51077332`](https://github.com/NixOS/nixpkgs/commit/510773323bcc8eaa57f965791f0bac57cb862c96) nsync: apply suggestions from code review
* [`bb888535`](https://github.com/NixOS/nixpkgs/commit/bb8885351616ccab0f399614d2365a2a0ac71583) skawarePackages: fix llvm build
* [`b648a474`](https://github.com/NixOS/nixpkgs/commit/b648a4742effbfbf9da7196f016fa5d68ff9c356) skawarePackages.buildPackage: reformat with nixpkgs-fmt
* [`0c7342b6`](https://github.com/NixOS/nixpkgs/commit/0c7342b6e730ddbf6ba9a1bd596d8f8cab9356f2) horizon-eda: 2.1.0 -> 2.2.0
* [`4a94071f`](https://github.com/NixOS/nixpkgs/commit/4a94071fb3e4fddc8b98dc13104ac720eceb728c) mkgmap: 4836 -> 4855
* [`1794554a`](https://github.com/NixOS/nixpkgs/commit/1794554a9aa7dccc6a1b42b50402cb88c10c1d7d) gnuradio: 3.9 -> 3.10
* [`31f069f7`](https://github.com/NixOS/nixpkgs/commit/31f069f779ee739fba946ccc58521ebb57646b19) dictu: 0.22.0 -> 0.23.0
* [`d5dae656`](https://github.com/NixOS/nixpkgs/commit/d5dae6569ea9952f1ae4e727946d93a71c507821) webdis: 0.1.16 -> 0.1.19
* [`dbda4fc2`](https://github.com/NixOS/nixpkgs/commit/dbda4fc20c937282e9965fe56995d6e935632529) gnuradio.pkgs.grnet: disable for GR 3.10
* [`d21fa199`](https://github.com/NixOS/nixpkgs/commit/d21fa199ae37ef9e6e8cb672b08902c2818884d2) gnuradio.pkgs: Remove redundent null attributes
* [`08232177`](https://github.com/NixOS/nixpkgs/commit/0823217739d553efdd8b98ea25e72c9dec25ff95) gnuradio3_8.pkgs.osmosdr: 0.2.2 -> 0.2.3
* [`ca74d2fa`](https://github.com/NixOS/nixpkgs/commit/ca74d2faaae268caa975e4a648b574297d4e4719) nats-server: 2.6.3 -> 2.7.0
* [`1e4664e1`](https://github.com/NixOS/nixpkgs/commit/1e4664e1a0f78ef487cf0d7432a118e6f9a069cf) betaflight-configurator: 10.7.1 -> 10.7.2
* [`89ddab6c`](https://github.com/NixOS/nixpkgs/commit/89ddab6c82ec3fa7f0ef28fbbfc4493aaea82b0f) cloudflared: 2021.12.3 -> 2022.1.2
* [`d8062c34`](https://github.com/NixOS/nixpkgs/commit/d8062c345d08c7c3545bf11141faad5eeb2caf66) colima: 0.3.1 -> 0.3.2
* [`1bc66cb8`](https://github.com/NixOS/nixpkgs/commit/1bc66cb8423de33846e3c88e083a2a008fd182e3) nerdctl: 0.15.0 -> 0.16.0
* [`3ee20629`](https://github.com/NixOS/nixpkgs/commit/3ee206291a20b2d18e651c77bf161ef42108901f) linux: enable BPF_UNPRIV_DEFAULT_OFF between 5.10 and 5.15
* [`9dcc01f0`](https://github.com/NixOS/nixpkgs/commit/9dcc01f0f5d62fbb6fb75cb89c01b139baa03f97) python38Packages.scikits-odes: 2.6.2 -> 2.6.3
* [`f4ef2647`](https://github.com/NixOS/nixpkgs/commit/f4ef264724d836112ec906f516a89b0193c3f546) polymc: init at 1.0.4
* [`155f3153`](https://github.com/NixOS/nixpkgs/commit/155f315319cac7136db5f048b4341b34a370ae18) multimc: document replacement
* [`6cb5b31d`](https://github.com/NixOS/nixpkgs/commit/6cb5b31dc4a3e37309696f127adb740fa4c2d86a) home-assistant: prune overrides
* [`6054fb82`](https://github.com/NixOS/nixpkgs/commit/6054fb82d5e5351d6432f57bd66de64723fe53ba) python3Packages.rpi-bad-power: init at 0.1.0
* [`c2ab1f23`](https://github.com/NixOS/nixpkgs/commit/c2ab1f2380063a923c34ddc344a23dcd87ba939a) python38Packages.cx_Freeze: 6.8.4 -> 6.9
* [`cca85c7c`](https://github.com/NixOS/nixpkgs/commit/cca85c7c3d1e4708b89a92d5bd11200aa2d6675a) tailscale: 1.18.2 -> 1.20.1
* [`61265ec0`](https://github.com/NixOS/nixpkgs/commit/61265ec0b4176678aa776d901ace3d5191728b65) home-assistant: outsource component tests
* [`1f71224f`](https://github.com/NixOS/nixpkgs/commit/1f71224fe86605ef4cd23ed327b3da7882dad382) nixos/modules/rename: Sort alphabetically
* [`4a065e56`](https://github.com/NixOS/nixpkgs/commit/4a065e569ba568ec708100bf20a49d0521ebe02c) solo2-cli: init at 0.1.1
* [`6c67bfc9`](https://github.com/NixOS/nixpkgs/commit/6c67bfc98618b2ac2cb68e12fed394bdbb285494) cde-gtk-theme: drop
* [`802f80b5`](https://github.com/NixOS/nixpkgs/commit/802f80b50c60bedc8bcb0ebb02cf39c91bff7622) pyrex, pyrex096, pyrex095: drop
* [`33df2ffa`](https://github.com/NixOS/nixpkgs/commit/33df2ffa0a5e666f9fd9a2a836b2ff4f96224e6d) blink: drop
* [`78bc359e`](https://github.com/NixOS/nixpkgs/commit/78bc359e037c846b566d49e2a7fd829c94a8a58a) python2Packages.cjson: drop
* [`dda538b1`](https://github.com/NixOS/nixpkgs/commit/dda538b172517b4c2344fdbcacf1aca2635a2826) renpy: drop
* [`5d0261b4`](https://github.com/NixOS/nixpkgs/commit/5d0261b438867a1af13cc8c1b22228e6991d59c1) curaByDagoma: drop
* [`4a1da0be`](https://github.com/NixOS/nixpkgs/commit/4a1da0bed973596414962755ac6cafc0479550c6) neap: drop
* [`608cde3b`](https://github.com/NixOS/nixpkgs/commit/608cde3bd4485d8e0337dc9495ed3909459a052a) metamorphose2: drop
* [`369db3b2`](https://github.com/NixOS/nixpkgs/commit/369db3b2f321c8fe263084dd876dfb3a330b36cf) mailpile, nixos/mailpile: drop
* [`492e5e07`](https://github.com/NixOS/nixpkgs/commit/492e5e07c9f2d622e776fcc2887ecded5edf0a43) lumpy: drop
* [`878c9204`](https://github.com/NixOS/nixpkgs/commit/878c920437255850408c8f9777ace404d362a630) gdal: use python3
* [`33610bfe`](https://github.com/NixOS/nixpkgs/commit/33610bfeca7469cf4cb698ec8208849357de8e7e) gitinspector: drop
* [`6bcbf84f`](https://github.com/NixOS/nixpkgs/commit/6bcbf84fb188ce60d06510bfcb282e19fdad02d8) git-crecord: 20161216.0 -> 20201025.0
* [`b8594d2b`](https://github.com/NixOS/nixpkgs/commit/b8594d2b00755fe4d740b5e5be54815653d81638) opae: use python3
* [`88b69dbc`](https://github.com/NixOS/nixpkgs/commit/88b69dbcbc5ae086ea93d8ba9eba059c0cde5ec9) quickder: use python3
* [`9cdd711a`](https://github.com/NixOS/nixpkgs/commit/9cdd711a66b7d383ed61adfa7c37b570ee46a5b3) systemtap: use python3
* [`fa0e52a9`](https://github.com/NixOS/nixpkgs/commit/fa0e52a9182b799f1fa9475d80210951bc199722) vigra: use python3
* [`308e8396`](https://github.com/NixOS/nixpkgs/commit/308e8396b73947dca793085a0377c32d1b477dfe) ino: drop
* [`0a29b6bc`](https://github.com/NixOS/nixpkgs/commit/0a29b6bcd1f87fae4dcc2d200b25b88501802e7e) getmail: drop
* [`03ddc5b2`](https://github.com/NixOS/nixpkgs/commit/03ddc5b29511cbedeff6fe49951ad6ed80b36c65) mididings: drop
* [`3c0752db`](https://github.com/NixOS/nixpkgs/commit/3c0752dbe0b6bf8b700725bcd4ef1bb66538bd38) displaycal: drop
* [`8afa8e93`](https://github.com/NixOS/nixpkgs/commit/8afa8e93b4e76b603a532514d9e6df9d7c1c8ce4) python3Packages.rasterio: drop gdal_2 pin
* [`554616d5`](https://github.com/NixOS/nixpkgs/commit/554616d5eda58b55702a63846b234d561540e4ec) python3Packages.fiona: drop gdal_2 pin
* [`29f997ef`](https://github.com/NixOS/nixpkgs/commit/29f997efd8392db6ed39360ac223a20d80432548) python3Packages.hangups: 0.4.15 -> 0.4.17
* [`867b8e21`](https://github.com/NixOS/nixpkgs/commit/867b8e2188cbe46cee7385b11750dde16f805570) minecraft-server: package major versions
* [`63c488bf`](https://github.com/NixOS/nixpkgs/commit/63c488bf3b2bca92d6a564ba42a4a25e63be48a1) minecraft-server: add jyooru as maintainer
* [`e0843a80`](https://github.com/NixOS/nixpkgs/commit/e0843a80e2a77888866d10482372894ad051ec8a) minecraft-server: fix using latest jre for all minecraft server versions
* [`b254d2b1`](https://github.com/NixOS/nixpkgs/commit/b254d2b1fefa96aed7f832ba5f1ab792ff50b8c4) minecraftServers: init - move all minecraft-server versions into minecraftServers
* [`d5744cff`](https://github.com/NixOS/nixpkgs/commit/d5744cffdc9f77b79b58ff175c6611a3ae4e11ef) abcmidi: 2021.12.12 -> 2022.01.13
* [`cef5f8db`](https://github.com/NixOS/nixpkgs/commit/cef5f8dba6ba9175bd40ba71b4b60e0f0b2eaf5f) notion-app-enhanced: 2.0.16-5 -> 2.0.18-1
* [`e24c1567`](https://github.com/NixOS/nixpkgs/commit/e24c1567a6ebcbfc37b5fedcca695593ac37be5c) i3lock-blur: mark as broken on darwin
* [`3c7e78cc`](https://github.com/NixOS/nixpkgs/commit/3c7e78cc6ab73ca9b0dbcb376122befa59098300) keycloak service: ordering for CLI script
* [`827267a2`](https://github.com/NixOS/nixpkgs/commit/827267a27f300a8fe503986da2570bc3b9252e69) keycloak service: update HTTPS configuration
* [`a42abe27`](https://github.com/NixOS/nixpkgs/commit/a42abe27c0b58749f1c563fc77305d145c739746) keycloak service: use 'attrsOf anything' for extraConfig
* [`3cef3028`](https://github.com/NixOS/nixpkgs/commit/3cef3028c2a691a781ceeddf5f2ae640f7a04b5e) python3Packages.drf-jwt: 1.19.1 -> 1.19.2
* [`1b5158c4`](https://github.com/NixOS/nixpkgs/commit/1b5158c4bc0d5e13b715e9d11ea100e9c4e77018) python3Packages.greeclimate: 1.0.1 -> 1.0.2
* [`d83a1a48`](https://github.com/NixOS/nixpkgs/commit/d83a1a4846112195f9a1fca4fd1c042e8b70b7cc) python3Packages.pikepdf: 4.3.0 -> 4.3.1
* [`1f858b31`](https://github.com/NixOS/nixpkgs/commit/1f858b31c6e67cbfd327996142b0279ae3604be4) python3Packages.pyhiveapi: 0.4.3 -> 0.4.6
* [`ec01395f`](https://github.com/NixOS/nixpkgs/commit/ec01395f811a1987f4210383cbdaba2569edac46) python3Packages.sentry-sdk: 1.5.1 -> 1.5.2
* [`134fa81d`](https://github.com/NixOS/nixpkgs/commit/134fa81d6dd39a07fa5d00aa9029bbf25f71bf58) python3Packages.pywayland: 0.4.7 -> 0.4.8
* [`6a0de2a2`](https://github.com/NixOS/nixpkgs/commit/6a0de2a2f2b4cf0f9bd963ab70e277c65dd03d29) python3Packages.mlflow: Fix broken package
* [`84f70eef`](https://github.com/NixOS/nixpkgs/commit/84f70eefd1c4f90e892164afa39931a9fc5ba8db) keycloak service: add themes support
* [`97a0cf62`](https://github.com/NixOS/nixpkgs/commit/97a0cf62f098d21a31c4dc03294e4919e88c225f) keycloak service: allow to set empty frontend URL
* [`5ec497a2`](https://github.com/NixOS/nixpkgs/commit/5ec497a248608c2d4bdf340c76057ce3779bb589) python38Packages.pytelegrambotapi: 4.2.1 -> 4.3.0
* [`c4777aeb`](https://github.com/NixOS/nixpkgs/commit/c4777aeb997da3583f8c72b0939ed653d3fd30cb) python38Packages.sagemaker: 2.70.0 -> 2.72.2
* [`2f99db6b`](https://github.com/NixOS/nixpkgs/commit/2f99db6b3e6f8364c6edff70622ec48b501cc52d) python38Packages.pyatv: 0.9.7 -> 0.9.8
* [`209326c6`](https://github.com/NixOS/nixpkgs/commit/209326c600b2031deb0b7465a2a5b2a3d3debc44) pythonPackages.python-miio: 0.5.9.1 -> 0.5.9.2
* [`08e95726`](https://github.com/NixOS/nixpkgs/commit/08e9572677967f0245b6defd3f3d97c6d7f44d89) python38Packages.pybotvac: 0.0.22 -> 0.0.23
* [`9cf1c7c4`](https://github.com/NixOS/nixpkgs/commit/9cf1c7c4a7b67d1aa750e21f8c88ddc21d34f858) python38Packages.transformers: 4.12.5 -> 4.15.0
* [`0a780fe3`](https://github.com/NixOS/nixpkgs/commit/0a780fe392341e84fa20ca1b2b0e079c54659bc7) python38Packages.irc: 19.0.1 -> 20.0.0
* [`7c1d6cfb`](https://github.com/NixOS/nixpkgs/commit/7c1d6cfb95373af83148c57551650179ae2ae17e) gnuradio3_7: remove
* [`8c946f4b`](https://github.com/NixOS/nixpkgs/commit/8c946f4baa56ca966c26aea7bea1f161e82e274f) python38Packages.sopel: 7.1.6 -> 7.1.7
* [`979e54b0`](https://github.com/NixOS/nixpkgs/commit/979e54b0ea0d10844afbc7424dda179ee92ae349) doit: 0.33.1 -> 0.34.0
* [`629605c2`](https://github.com/NixOS/nixpkgs/commit/629605c2ac3418672d2a9985d5d20172f1797c83) python3Packages.bimmer-connected: 0.8.7 -> 0.8.10
* [`f92cb93d`](https://github.com/NixOS/nixpkgs/commit/f92cb93d5fda54149f63a8ea704f84baf5d3a058) python3Packages.meshtastic: 1.2.54 -> 1.2.56
* [`226586e5`](https://github.com/NixOS/nixpkgs/commit/226586e56943aacb314c1fe78ff048f58e529c8d) python3Packages.mitogen: 0.3.0 -> 0.3.2
* [`bbf10ee6`](https://github.com/NixOS/nixpkgs/commit/bbf10ee6a8946a3308bae6a14dda29119ca1cc78) krita: 5.0.0 -> 5.0.2
* [`2027fb60`](https://github.com/NixOS/nixpkgs/commit/2027fb600d891379c53c4762463e65d040359682) alot: application instead of python library
* [`ae18d68b`](https://github.com/NixOS/nixpkgs/commit/ae18d68b6b117528e6cd72325ead36b48562d43f) python2.pkgs: move expressions into python2-modules/ folder
* [`ea222b17`](https://github.com/NixOS/nixpkgs/commit/ea222b17d1af9fe42f21741f4c818774ba78efaf) python-modules: remove unused secretstorage/2.nix
* [`470fdb30`](https://github.com/NixOS/nixpkgs/commit/470fdb307a9ae2c9b309c1e55d97a2c05ef01b8e) python36Packages.ipython: remove
* [`4bf9e61a`](https://github.com/NixOS/nixpkgs/commit/4bf9e61a76ba26a8b61b3fafebfd8d8e5f9613f4) python3Packages.pytest_5: remove
* [`d63c752b`](https://github.com/NixOS/nixpkgs/commit/d63c752b0062861fc0c45adc9db0e1379b353a88) python3Packages.graph-tool: rename file
* [`6652fefd`](https://github.com/NixOS/nixpkgs/commit/6652fefdabef78b468eb75cc40e15704cc324d7c) timeline: use newer wxPython
* [`f0996f2d`](https://github.com/NixOS/nixpkgs/commit/f0996f2d22216c9468205b1ae207d89bfa48fd8e) python3Packages.pyrogram: 1.3.1 -> 1.3.5
* [`d5026c33`](https://github.com/NixOS/nixpkgs/commit/d5026c33182093d2984c348df541d8b912bdd7d6) python3Packages.aiogithubapi: 21.11.0 -> 22.1.0
* [`fb9ce2d9`](https://github.com/NixOS/nixpkgs/commit/fb9ce2d9f25b5d61e04f7e78a6666869e5f6c6bc) python3Packages.sense-energy: 0.9.3 -> 0.9.4
* [`8eb05125`](https://github.com/NixOS/nixpkgs/commit/8eb05125ef93f013198b0047699515bb38cd1b80) python3Packages.nexia: 0.9.12 -> 0.9.13
* [`71523a4e`](https://github.com/NixOS/nixpkgs/commit/71523a4e7e999976259650d72a831fd26e026557) python3Packages.teslajsonpy: 1.4.2 -> 1.5.0
* [`0d2fa1e0`](https://github.com/NixOS/nixpkgs/commit/0d2fa1e0d6dddd4fe1b50218d404413696404555) python3Packages.wtforms: 2.3.3 -> 3.0.1
* [`a8affa91`](https://github.com/NixOS/nixpkgs/commit/a8affa912c883c59f7052779a2440c796715ced8) chromium: Backport important fixes for Wayland
* [`65b77d8a`](https://github.com/NixOS/nixpkgs/commit/65b77d8aaa1b79185ff02505ad00d980bd5218fd) lsd: 0.20.1 -> 0.21.0
* [`2a1ff6dd`](https://github.com/NixOS/nixpkgs/commit/2a1ff6dd5140f3e7eae4446547ab53470ca6bad1) python3Packages.python-kasa: 0.4.0 -> 0.4.1
* [`438b4fd0`](https://github.com/NixOS/nixpkgs/commit/438b4fd0e32c3fe746505ad80b5612468e2121d8) opentracker: mark linux only
* [`1ed395aa`](https://github.com/NixOS/nixpkgs/commit/1ed395aaaf6115a4e2a74c388ec2ecc2b8b2971c) pinta: 2.0.1 -> 2.0.2
* [`81712905`](https://github.com/NixOS/nixpkgs/commit/81712905af5b544af318ca97714b70e25a4b676f) python3Packages.identify: 2.4.3 -> 2.4.4
* [`b755af85`](https://github.com/NixOS/nixpkgs/commit/b755af85fc17d0962934019db35488fb6b56dbb1) yex-lang: init at unstable-2021-12-25
* [`baf11b26`](https://github.com/NixOS/nixpkgs/commit/baf11b26b230974157e0e5507411661393fd47bc) mold: set enableParallelBuilding = true
* [`66370f4f`](https://github.com/NixOS/nixpkgs/commit/66370f4f12a3cd5bb66c3c9a070a77b5c2cbe9ab) cubiomes-viewer: init at 1.12.1
* [`34950c73`](https://github.com/NixOS/nixpkgs/commit/34950c73596cd2a8369d929cd5dd412a5ca308e0) sinit: refactor
* [`7b38dfca`](https://github.com/NixOS/nixpkgs/commit/7b38dfca529f783003b6a07ac238abe5ab029e2c) python3Packages.pony: 0.7.14 -> 0.7.15rc1
* [`21046086`](https://github.com/NixOS/nixpkgs/commit/2104608642f3be6671ace4d6d9b29837cbf4ad2b) nixos/borgbackup: allow empty archive base name
* [`c0da379c`](https://github.com/NixOS/nixpkgs/commit/c0da379c1c8219ef667ea969115b1e24ed273bfc) firefox_decrypt: init at unstable-2021-12-29
* [`6a7da24a`](https://github.com/NixOS/nixpkgs/commit/6a7da24a485051fb3286bc778b93533b7c015bfa) kodi.packages.typing_extensions: init at 3.7.4.3
* [`a1ed2b84`](https://github.com/NixOS/nixpkgs/commit/a1ed2b8400f043effcaeeebb6c1a2065c8e09372) kodi.packages.arrow: init at 1.0.3.1
* [`e58344d0`](https://github.com/NixOS/nixpkgs/commit/e58344d08e761cba6c6c6620fd8939d112aba5d3) kodi.packages.trakt-py: init at 4.4.0
* [`4b775ed5`](https://github.com/NixOS/nixpkgs/commit/4b775ed53fb40936cdbc83db185e24aedd5b98ef) kodi.packages.trakt: init at 3.5.0
* [`72f9a086`](https://github.com/NixOS/nixpkgs/commit/72f9a08648a27096b9a176a12b1e09573244adb6) PageEdit: init at 1.7.0 ([nixos/nixpkgs⁠#153403](https://togithub.com/nixos/nixpkgs/issues/153403))
* [`90af6344`](https://github.com/NixOS/nixpkgs/commit/90af6344ab0c62ff654ed4c64ad87e53a382e439) apache-jena: refactor, apache-jena-fuseki: refactor
* [`03bfd9f5`](https://github.com/NixOS/nixpkgs/commit/03bfd9f53e4fa2f82b88296ff029fb03968a6e73) barcode: pull upstream fix for -fno-common toolchains
* [`cf3c3da4`](https://github.com/NixOS/nixpkgs/commit/cf3c3da4699f018c8907a224b14bbea2bbf1a493) vimPlugins.vim-markdown-composer: update cargoSha256
* [`c875cdce`](https://github.com/NixOS/nixpkgs/commit/c875cdce3fbc4264734c919d7cdd4aa65e6ac6d9) lemmy: 0.14.0 -> 0.15.1 ([nixos/nixpkgs⁠#155236](https://togithub.com/nixos/nixpkgs/issues/155236))
* [`1ab07956`](https://github.com/NixOS/nixpkgs/commit/1ab0795642b66a1d6f0cee1f64a88759fce8691d) python3Packages.cozy: remove ([nixos/nixpkgs⁠#154903](https://togithub.com/nixos/nixpkgs/issues/154903))
* [`74168b1f`](https://github.com/NixOS/nixpkgs/commit/74168b1feaf84b6ed4573e5adce7472b13791d8e) yex-lang: minor adjustements ([nixos/nixpkgs⁠#155229](https://togithub.com/nixos/nixpkgs/issues/155229))
* [`f60b7917`](https://github.com/NixOS/nixpkgs/commit/f60b7917bfa2ea1c5bebf720dcadfa5e3ced8a18) n2048: refactor
* [`bbfca6b6`](https://github.com/NixOS/nixpkgs/commit/bbfca6b6b9f6f79994c4fb82bd13629b4ba759cc) nixos/prosody-filer: remove usage of literalExample
* [`cf12e0e7`](https://github.com/NixOS/nixpkgs/commit/cf12e0e7ed02b91b202e68d15f045b6982f22d71) nixos/thelounge: add test
* [`3a82e3cc`](https://github.com/NixOS/nixpkgs/commit/3a82e3cc939998e3bf604c55b93474689a724cab) nodePackages.thelounge: add winter to maintainers
* [`78abd4df`](https://github.com/NixOS/nixpkgs/commit/78abd4df66a1f9c2ff41060266747f31c9cfc5bd) pinta: add translations, use msbuild to install files
* [`649a7d75`](https://github.com/NixOS/nixpkgs/commit/649a7d75b4668a8d1a709a9d47d526953c627331) polkit: disable gtkdoc when cross compiling
* [`d18d62d4`](https://github.com/NixOS/nixpkgs/commit/d18d62d487a523376369559fa7425f67c958da8b) gqrx: 2.15.2 → 2.15.4
* [`d3bc05b0`](https://github.com/NixOS/nixpkgs/commit/d3bc05b0f90a447787d5ef57f7f66478b4ac2ed0) add cfhammill (me) to the maintainers list
* [`fd51177e`](https://github.com/NixOS/nixpkgs/commit/fd51177e5c91ac86220f2f4a11fcc99f0bb9a6a3) rstudio-server, rstudioServerWrapper: init at rstudio.version (1.4.1717)
* [`0fe01530`](https://github.com/NixOS/nixpkgs/commit/0fe01530034762c50c5b379e3852a8cb53901b0d) nixos/rstudio-server: init
* [`43047ec1`](https://github.com/NixOS/nixpkgs/commit/43047ec128536b0324dccfef13d593aab3ce3778) nixos/rstudio-server: add to 22.05 release notes
* [`a0b38130`](https://github.com/NixOS/nixpkgs/commit/a0b3813092d6645ee5248f6c931ebd15e92e7293) lighttpd: 1.4.59 -> 1.4.63
* [`ecfda6ef`](https://github.com/NixOS/nixpkgs/commit/ecfda6ef7cb5d663af536b9f6ad406d3b4302bf5) lighttpd: add patch for CVE-2022-22707
* [`d952e9aa`](https://github.com/NixOS/nixpkgs/commit/d952e9aa46c974dd35802cd71b903b98282dc8fc) python310Packages.tempest: use stable patch URL
* [`52edbfc4`](https://github.com/NixOS/nixpkgs/commit/52edbfc42712fbfe15e8620a9a2d0c663aef4b7a) pulumi: use gh for versions and parallelize pulumi API downloads ([nixos/nixpkgs⁠#154880](https://togithub.com/nixos/nixpkgs/issues/154880))
* [`a9581967`](https://github.com/NixOS/nixpkgs/commit/a9581967f798032ab04cc3d951b3c430271bb794) opentabletdriver: v0.5.3.3 -> v0.6.0.2
