### PR TITLE
niv home-manager: update f3be3cda -> 8cf13abf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f3be3cda6a69365f2acecc201b3cd1ee4f6d4614",
-        "sha256": "19ha58d17ng2ab6wvkkibn87w4mkzmv3hfv9akp9dsy2mbiykgvz",
+        "rev": "8cf13abffc0808b337590a9e382604ab6c2cb3e7",
+        "sha256": "0lcpzavipvzn5779q2857shm7a55g2p2cw55jdzybq14yg3d25gb",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f3be3cda6a69365f2acecc201b3cd1ee4f6d4614.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/8cf13abffc0808b337590a9e382604ab6c2cb3e7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f3be3cda...8cf13abf](https://github.com/nix-community/home-manager/compare/f3be3cda6a69365f2acecc201b3cd1ee4f6d4614...8cf13abffc0808b337590a9e382604ab6c2cb3e7)

* [`8a5550ae`](https://github.com/nix-community/home-manager/commit/8a5550aea3e9c07fe7c161e94638a44eec67b6a7) gh: remove git overlay in tests
* [`5a8b29bc`](https://github.com/nix-community/home-manager/commit/5a8b29bc7a97d8080f56d49c851f51cec9ba2e07) tests: disable a few tests due to broken notmuch
* [`204f9808`](https://github.com/nix-community/home-manager/commit/204f9808d3f007f2d4a4f71f96468085f0123371) sagemath: add module
* [`5209ea0d`](https://github.com/nix-community/home-manager/commit/5209ea0d8c77399ec4987590e9738953f15f8d80) skim: use cfg.package in shell integrations
* [`8a431023`](https://github.com/nix-community/home-manager/commit/8a431023c0cfdfc29632e69dd17bf34b8e749b80) Translate using Weblate (Spanish)
* [`d07df8d9`](https://github.com/nix-community/home-manager/commit/d07df8d9a80a4a34ea881bee7860ae437c5d44a5) Translate using Weblate (Spanish)
* [`85f13acb`](https://github.com/nix-community/home-manager/commit/85f13acb811829206eafc438903bbfba39ec5b3a) Translate using Weblate (French)
* [`a5dd5d5f`](https://github.com/nix-community/home-manager/commit/a5dd5d5f197724f3065fd39c59c7ccea3c8dcb8f) docs: clarify stand-alone installation instructions
* [`1477eb15`](https://github.com/nix-community/home-manager/commit/1477eb1555d780470fe5959aa6f60ba8b1fb608f) docs: add link to Matrix room
* [`b2592ae6`](https://github.com/nix-community/home-manager/commit/b2592ae67cab0a6fcd02fccdfe7a0ef80c1a2395) docs: fix typo
* [`46978d20`](https://github.com/nix-community/home-manager/commit/46978d2047a61f6db79826537138b6db8241bd37) docs: add link to contributing chapter in readme
* [`46bba772`](https://github.com/nix-community/home-manager/commit/46bba772f26f89b62811f487d2b0d5357c91bc32) modules/misc/news.nix: fix instructions ([nix-community/home-manager⁠#2643](https://togithub.com/nix-community/home-manager/issues/2643))
* [`986cf41b`](https://github.com/nix-community/home-manager/commit/986cf41b3bf1936b9d06ef0958683f376f1319d9) kitty: Allow package to be configurable ([nix-community/home-manager⁠#2640](https://togithub.com/nix-community/home-manager/issues/2640))
* [`94281669`](https://github.com/nix-community/home-manager/commit/94281669fd1d7c03f1672ef24c2b10a9fc036fc3) Add programs.fish.interactiveShellInit to direnv ([nix-community/home-manager⁠#2614](https://togithub.com/nix-community/home-manager/issues/2614))
* [`f71d41ba`](https://github.com/nix-community/home-manager/commit/f71d41ba360cd49b3647bf91402c7479e859fd2e) kakoune: fix ui options ([nix-community/home-manager⁠#2641](https://togithub.com/nix-community/home-manager/issues/2641))
* [`a69f3e9b`](https://github.com/nix-community/home-manager/commit/a69f3e9b0390f03defb834b15e80c236a537157d) kime: Fix kime systemd service broken ([nix-community/home-manager⁠#2621](https://togithub.com/nix-community/home-manager/issues/2621))
* [`60d2c966`](https://github.com/nix-community/home-manager/commit/60d2c9660be43da4d1ba36f89892b38358039824) rbw: Fix a typo ([nix-community/home-manager⁠#2648](https://togithub.com/nix-community/home-manager/issues/2648))
* [`9bceb829`](https://github.com/nix-community/home-manager/commit/9bceb8292e9a2c84db999cb5817d77fb8d6b83fe) waybar: fix deprecated "modules" setting check ([nix-community/home-manager⁠#2646](https://togithub.com/nix-community/home-manager/issues/2646))
* [`b59752b9`](https://github.com/nix-community/home-manager/commit/b59752b9ffa0511c2dce2ddfb455ce4be2fdf7be) rofi: add finalPackage option ([nix-community/home-manager⁠#2649](https://togithub.com/nix-community/home-manager/issues/2649))
* [`8cf13abf`](https://github.com/nix-community/home-manager/commit/8cf13abffc0808b337590a9e382604ab6c2cb3e7) bspwm: set _JAVA_AWT_WM_NONREPARENTING in xsession.profileExtra ([nix-community/home-manager⁠#2645](https://togithub.com/nix-community/home-manager/issues/2645))
