### PR TITLE
niv powerlevel10k: update 683a4852 -> 3d994b03

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "683a485232d75978a79199a305c4fc4843772a77",
-        "sha256": "0swggp7f6vbzc70bbfiihj3f8z7j16jrcnk76nypzpxvn8sc48w1",
+        "rev": "3d994b033b934b6f5d4e021b6e0b4155bf13542b",
+        "sha256": "0n3y42jcbyp7b3aayyq1san3p31vb07bn8z3d81w48w4mkh1qd9r",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/683a485232d75978a79199a305c4fc4843772a77.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/3d994b033b934b6f5d4e021b6e0b4155bf13542b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@683a4852...3d994b03](https://github.com/romkatv/powerlevel10k/compare/683a485232d75978a79199a305c4fc4843772a77...3d994b033b934b6f5d4e021b6e0b4155bf13542b)

* [`6fae3a16`](https://github.com/romkatv/powerlevel10k/commit/6fae3a169b470ba84ef7f643451e1cac4be58d77) add toolbox segment to the docs ([romkatv/powerlevel10k⁠#1713](https://togithub.com/romkatv/powerlevel10k/issues/1713))
* [`fdbde52c`](https://github.com/romkatv/powerlevel10k/commit/fdbde52c201569afc53229412fea11aae87d6bc8) docs: sort the table of segments
* [`69909a7a`](https://github.com/romkatv/powerlevel10k/commit/69909a7a1f64a91c947417c4bbd8669c6edd5049) Add xterm to font configuration section
* [`b8ddcd4c`](https://github.com/romkatv/powerlevel10k/commit/b8ddcd4c17c650c49087b6993383e865206b7212) docs: clean up font instructions for xterm and copy them to README.md
* [`161f4c1f`](https://github.com/romkatv/powerlevel10k/commit/161f4c1f0475b9370697d31b180e6b097c297ddf) respect VIRTUAL_ENV_PROMPT if its value is different from the default ([romkatv/powerlevel10k⁠#1718](https://togithub.com/romkatv/powerlevel10k/issues/1718))
* [`0f8a77d4`](https://github.com/romkatv/powerlevel10k/commit/0f8a77d47df744038d7d841b7321b55b6b2db638) increase the minimum required zsh version from 5.1 to 5.3 ([romkatv/powerlevel10k⁠#1722](https://togithub.com/romkatv/powerlevel10k/issues/1722))
* [`3d994b03`](https://github.com/romkatv/powerlevel10k/commit/3d994b033b934b6f5d4e021b6e0b4155bf13542b) work around bugs in WSL where it reports more swap being used than the total available ([romkatv/powerlevel10k⁠#1724](https://togithub.com/romkatv/powerlevel10k/issues/1724))
