### PR TITLE
niv spacemacs: update c3ad2164 -> 6ccbbcc7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "c3ad21645c7e48fec50f6ca29f4ecd831f8023f5",
-        "sha256": "08hlr2rf8r487hvxxm55ry7wggfq3kzywqzfysfphfr7w0cgrf8v",
+        "rev": "6ccbbcc7d9e41205499671611c24a3b8dc709abf",
+        "sha256": "1x2jkq3q2vh5qr4jswb21b76h6br64dwq82j78j6ic3sas6p3w11",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/c3ad21645c7e48fec50f6ca29f4ecd831f8023f5.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/6ccbbcc7d9e41205499671611c24a3b8dc709abf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@c3ad2164...6ccbbcc7](https://github.com/syl20bnr/spacemacs/compare/c3ad21645c7e48fec50f6ca29f4ecd831f8023f5...6ccbbcc7d9e41205499671611c24a3b8dc709abf)

* [`7cb37ee5`](https://github.com/syl20bnr/spacemacs/commit/7cb37ee58e58f4e5c0383fab2956bd8ee3c6b936) markdown: Remove orgtbl
* [`1541eed6`](https://github.com/syl20bnr/spacemacs/commit/1541eed6bdaee3e67fc1f9dacf3f21f8494aab68) fix messed up keybindings in helm-ag-map
* [`84033e16`](https://github.com/syl20bnr/spacemacs/commit/84033e168d53d32220bed2b91df82359fff2c5ba) [clojure] add kaocha-runner as optional package
* [`5b2af049`](https://github.com/syl20bnr/spacemacs/commit/5b2af0498dc9fb33195f9afd185612d29fa58f05) [bot] built_in_updates ([syl20bnr/spacemacs⁠#15272](https://togithub.com/syl20bnr/spacemacs/issues/15272))
* [`abdb818d`](https://github.com/syl20bnr/spacemacs/commit/abdb818d066a1620003d25e20ff58ba292cc5bd1) Revert "[bot] built_in_updates" ([syl20bnr/spacemacs⁠#15273](https://togithub.com/syl20bnr/spacemacs/issues/15273))
* [`19bde126`](https://github.com/syl20bnr/spacemacs/commit/19bde126a5ea19fbf0ad4746bd7e71969383a98f) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15271](https://togithub.com/syl20bnr/spacemacs/issues/15271))
* [`a62b9434`](https://github.com/syl20bnr/spacemacs/commit/a62b94348971f7da90a3e1807e6a39b0faed3d0b) [bot] built_in_updates ([syl20bnr/spacemacs⁠#15274](https://togithub.com/syl20bnr/spacemacs/issues/15274))
* [`719b6437`](https://github.com/syl20bnr/spacemacs/commit/719b64377fd991996f2e4b8ec46b811661f8bca6) fix evil-lisp-state prefixes & improve related functions ([syl20bnr/spacemacs⁠#15258](https://togithub.com/syl20bnr/spacemacs/issues/15258))
* [`ca93e28a`](https://github.com/syl20bnr/spacemacs/commit/ca93e28a9c1e99d3611ccda30a1263e61f0141ad) keyboard-layout: Fixes [syl20bnr/spacemacs⁠#15249](https://togithub.com/syl20bnr/spacemacs/issues/15249) ([syl20bnr/spacemacs⁠#15251](https://togithub.com/syl20bnr/spacemacs/issues/15251))
* [`6ccbbcc7`](https://github.com/syl20bnr/spacemacs/commit/6ccbbcc7d9e41205499671611c24a3b8dc709abf) gnux: fix which-key prefix bug
