### PR TITLE
niv zsh-completions: update 20f3cd5f -> 546fa7e5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "20f3cd5f5d3e6ef7deb343b11c084e1fb2f5a3f2",
-        "sha256": "04q9nrvvx2gzcymakaygcklqh0w33pwf3x5jd42pbqici505gqbz",
+        "rev": "546fa7e5bbadafedc1a965456ed9c18a309643a0",
+        "sha256": "0a57v0d5ljvxdzv65w4dy89r0zmrkagbglg32vzwzlsab3qby8g7",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/20f3cd5f5d3e6ef7deb343b11c084e1fb2f5a3f2.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/546fa7e5bbadafedc1a965456ed9c18a309643a0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@20f3cd5f...546fa7e5](https://github.com/zsh-users/zsh-completions/compare/20f3cd5f5d3e6ef7deb343b11c084e1fb2f5a3f2...546fa7e5bbadafedc1a965456ed9c18a309643a0)

* [`97093dda`](https://github.com/zsh-users/zsh-completions/commit/97093ddac66ede23e0f4c5b4046ecbd390ebc10e) git-flow: Adding description to be picked up.
