### PR TITLE
niv nixpkgs: update dfa93a47 -> c1801065

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dfa93a472533cba8462f8014937afbfa4c0f1b9b",
-        "sha256": "05i4zdmbpzq06cfnhbacy1w9ia8ih8drspp7rp6jrwba7aqww4dv",
+        "rev": "c1801065f4458ec0a320c074ad48781956eb9093",
+        "sha256": "1rwi1vgkw26wbdd5z2jpkgxc0lbnaxbw34xph1kfg60jw87c0aga",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/dfa93a472533cba8462f8014937afbfa4c0f1b9b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c1801065f4458ec0a320c074ad48781956eb9093.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@dfa93a47...c1801065](https://github.com/nixos/nixpkgs/compare/dfa93a472533cba8462f8014937afbfa4c0f1b9b...c1801065f4458ec0a320c074ad48781956eb9093)

* [`112b79f8`](https://github.com/NixOS/nixpkgs/commit/112b79f8eed86338cdd4010d48476ac5fd7bca16) python310Packages.snowflake-connector-python: 2.7.2 -> 2.7.3
* [`d15b4964`](https://github.com/NixOS/nixpkgs/commit/d15b4964bd9346e2d0b9eb4de2947386a9bf9fb3) python310Packages.azure-mgmt-subscription: 2.0.0 -> 3.0.0
* [`5de74e97`](https://github.com/NixOS/nixpkgs/commit/5de74e978d8878704a101ff3d61b32bee6fa428c) mongodb-compass: 1.29.6 -> 1.30.1
* [`7dd52153`](https://github.com/NixOS/nixpkgs/commit/7dd52153d4ff8dc2ec88e722547b5109861a47fa) ddosify: 0.7.1 -> 0.7.2
* [`295a85a6`](https://github.com/NixOS/nixpkgs/commit/295a85a6290d62e92d4fafc353594db666ef7ff8) clojure-lsp: 2021.11.02-15.24.47 -> 2022.01.22-01.31.09
* [`994bd50d`](https://github.com/NixOS/nixpkgs/commit/994bd50deb4b3563cb3039834a790c58761a9e95) rubyPackages: update ([nixos/nixpkgs⁠#155876](https://togithub.com/nixos/nixpkgs/issues/155876))
* [`7f5ea74f`](https://github.com/NixOS/nixpkgs/commit/7f5ea74fc95250438f35c582531b9e466cfa3621) skaffold: 1.35.1 -> 1.35.2
* [`58548a31`](https://github.com/NixOS/nixpkgs/commit/58548a314e25b63a228f6ecff0efdd9cb7d85e13) python39Packages.launchpadlib: 1.10.15.1 -> 1.10.16
* [`ff78d373`](https://github.com/NixOS/nixpkgs/commit/ff78d373f9630382e1049867e3ff48214261bdec) python39Packages.liquidctl: 1.8.0 -> 1.8.1
* [`4e7fdc04`](https://github.com/NixOS/nixpkgs/commit/4e7fdc04c8115b2d797f4af8c69a745301f62317) argocd: 2.2.2 -> 2.2.3
* [`206d3698`](https://github.com/NixOS/nixpkgs/commit/206d369867051e2052c197a4e5f60b981130f347) python39Packages.openai: 0.11.5 -> 0.12.0
* [`fb9297fc`](https://github.com/NixOS/nixpkgs/commit/fb9297fc3a2f70bdc97df0be2b0b3459b1f6da3a) python3Packages.pip: add pip-tools to tests
* [`db3cc2d3`](https://github.com/NixOS/nixpkgs/commit/db3cc2d36ec1b4023abf1e742a69daa0115ff83e) python310Packages.bsblan: 0.4.1 -> 0.5.0
* [`4cf0848f`](https://github.com/NixOS/nixpkgs/commit/4cf0848fc85a05bf46b142d3981f542e2e924034) nixosTests.boot-stage1: fix kernel build with 5.15
* [`f5dfef02`](https://github.com/NixOS/nixpkgs/commit/f5dfef02b93f8e51d393b22c631d21e8a204294a) python310Packages.afsapi: 0.2.0 -> 0.2.1
* [`607c7e95`](https://github.com/NixOS/nixpkgs/commit/607c7e95dc7928165af8ae3ce74e7056f6d428f1) python310Packages.mattermostdriver: 7.3.1 -> 7.3.2
* [`61344186`](https://github.com/NixOS/nixpkgs/commit/613441860fc5bdbb30547d2b5c2514440f86fede) python3Packages.s3transfer: ignore test_compat on darwin ([nixos/nixpkgs⁠#155896](https://togithub.com/nixos/nixpkgs/issues/155896))
* [`7267839e`](https://github.com/NixOS/nixpkgs/commit/7267839e761cca2160233422b86296511591f32c) gprojector: init at 3.0.2 ([nixos/nixpkgs⁠#154932](https://togithub.com/nixos/nixpkgs/issues/154932))
* [`b9e9910c`](https://github.com/NixOS/nixpkgs/commit/b9e9910c012c56d92f2d71ebb7ed22ae24073e4c) Added new vim plugin: Coq nvim ([nixos/nixpkgs⁠#155421](https://togithub.com/nixos/nixpkgs/issues/155421))
* [`5bf92ebb`](https://github.com/NixOS/nixpkgs/commit/5bf92ebbed94040841d7353184fb7d20da5ad063) plocate: add SuperSandro200 to maintainers
* [`0ab07de3`](https://github.com/NixOS/nixpkgs/commit/0ab07de35cb65ec7933849145c625271eb2d082f) python39Packages.easy-thumbnails: 2.8 -> 2.8.1
* [`29dd066a`](https://github.com/NixOS/nixpkgs/commit/29dd066a556a86d608d72e0d14d964a1439fea7a) maintainers: fixed formatting of maintainer entry for jmc-figueira
* [`c24af464`](https://github.com/NixOS/nixpkgs/commit/c24af4642ceeab94936602bf96b8e5c591b79264) sambamba: 0.8.1 -> 0.8.2 ([nixos/nixpkgs⁠#155972](https://togithub.com/nixos/nixpkgs/issues/155972))
* [`1921de36`](https://github.com/NixOS/nixpkgs/commit/1921de36e7e99c3f4eab7702796b12c4c2d370d1) python310Packages.aioapns: 2.0.2 -> 2.1
* [`ef654bec`](https://github.com/NixOS/nixpkgs/commit/ef654bec02f6512cbc118171478aea9b1ca56809) python310Packages.pymsteams: 0.2.0 -> 0.2.1
* [`02d6ae24`](https://github.com/NixOS/nixpkgs/commit/02d6ae24ae4a8a43c6a1346e7dad90707ad8f756) python310Packages.cyclonedx-python-lib: 1.1.0 -> 1.1.1
* [`73486fec`](https://github.com/NixOS/nixpkgs/commit/73486feca0a5c8c8bad8bab91518dc362bdd48a3) python39Packages.influxdb-client: 1.24.0 -> 1.25.0
* [`651242ed`](https://github.com/NixOS/nixpkgs/commit/651242ed728718267b78113fc8e8c82f032e462c) python310Packages.motionblinds: 0.5.8.2 -> 0.5.10
* [`e0801ba6`](https://github.com/NixOS/nixpkgs/commit/e0801ba64b803458644bf26e3e2acdbe7d587895) python39Packages.google-cloud-language: 2.3.1 -> 2.3.2
* [`9f482d8f`](https://github.com/NixOS/nixpkgs/commit/9f482d8f8b90960e35d5db004a54025a1d8ffb1b) python310Packages.gphoto2: 2.3.1 -> 2.3.2
* [`7d70d8f5`](https://github.com/NixOS/nixpkgs/commit/7d70d8f5411bb769a83224d291f5674c5c594460) python3Packages.pydrive2: init at 1.10.0
* [`2984fbf4`](https://github.com/NixOS/nixpkgs/commit/2984fbf4ac79fe766c146ad481a72b9e548ecd86) python39Packages.jc: 1.17.6 -> 1.18.1
* [`e1317cb5`](https://github.com/NixOS/nixpkgs/commit/e1317cb5a170da463a095839dac925fa144d73f8) tile38: init at 1.27.1
* [`899605d9`](https://github.com/NixOS/nixpkgs/commit/899605d9b3c0ef408aea837d3f5e568ce62215d8) maintainers: update sikmir's email
* [`fd196d26`](https://github.com/NixOS/nixpkgs/commit/fd196d26a418751d161823e9ff90ebbd600d9b3f) python310Packages.zigpy: 0.42.0 -> 0.43.0
* [`a59d23e2`](https://github.com/NixOS/nixpkgs/commit/a59d23e2b2ec592382653bcbb11ae0ac98c25cc8) giara: 0.3 -> 1.0
* [`63db2abf`](https://github.com/NixOS/nixpkgs/commit/63db2abf0dad8b1db92985db30328f9b12a1437c) libadwaita: propagate gtk4
* [`5cfcd0b5`](https://github.com/NixOS/nixpkgs/commit/5cfcd0b5b28d3f62c0e6a0a59878613b9f03c4dc) factorio-*: 1.1.50->1.1.53
* [`c59a18ed`](https://github.com/NixOS/nixpkgs/commit/c59a18edec84458805885beaf786aacc69ec5dfc) python310Packages.cocotb-bus: 0.2.0 -> 0.2.1
* [`c43ee47d`](https://github.com/NixOS/nixpkgs/commit/c43ee47d81f2a7129c8c1576bcdb322622f8a700) python3Packages.bsblan: disable on older Python releases
* [`493e1d9b`](https://github.com/NixOS/nixpkgs/commit/493e1d9bc23dc008a2be2849be8bf9b46c525851) python310Packages.aiohomekit: 0.6.10 -> 0.6.11
* [`4f01e47c`](https://github.com/NixOS/nixpkgs/commit/4f01e47c3a9fa1bede8c0558095c526623ed0f7f) vulkan-tools: 1.2.189.1 -> 1.2.198.0
* [`1c1b9186`](https://github.com/NixOS/nixpkgs/commit/1c1b91861a5f66dbd7b3ddb0691de23e4c10827d) ocamlPackages.gtktop: remove at 2.0
* [`e3183d75`](https://github.com/NixOS/nixpkgs/commit/e3183d75e3aac9b0aae7cb4e9d2ebe7f71cc03c9) ocamlPackages.lablgtk: disable glade support
* [`43bbef49`](https://github.com/NixOS/nixpkgs/commit/43bbef4978554a733a987ae307aa658ba34af1d0) ocamlPackages.lablgtk: 2.18.10 → 2.18.12
* [`43a9b2ec`](https://github.com/NixOS/nixpkgs/commit/43a9b2ecc8c419a96999dbfafc538879a285595e) python3Packages.somajo: add pythonImportsCheck
* [`4c5f5d5b`](https://github.com/NixOS/nixpkgs/commit/4c5f5d5b3a6d05b4f88eca5c139311fe16c745df) python3Packages.sagemaker: disable on older Python releases
* [`ccfbc1e9`](https://github.com/NixOS/nixpkgs/commit/ccfbc1e98d700f17507d7b2c1acc5221baab10d2) snowflake: init at 2.0.1
* [`23f87f4b`](https://github.com/NixOS/nixpkgs/commit/23f87f4b69c8ce802af64ad340c8851f7db9f756) onionshare: 2.4 -> 2.5
* [`c78e9334`](https://github.com/NixOS/nixpkgs/commit/c78e9334716a128c0d0c325be69916ad3d74f01b) typos: 1.3.4 -> 1.3.5
* [`543dbb4f`](https://github.com/NixOS/nixpkgs/commit/543dbb4ffb974111511f3f9d6f58fc22abe4da8f) gnomeExtension.pop-shell: 2021-11-30 -> 2022-01-14
* [`5d861604`](https://github.com/NixOS/nixpkgs/commit/5d861604cf8c0967bf9173bae144e385ef5504c7) python3Packages.jsmin: add pythonImportsCheck
* [`8f377752`](https://github.com/NixOS/nixpkgs/commit/8f37775234ea075244384dc5d9407d8f9557024b) alacritty: 0.9.0 -> 0.10.0
* [`ba24545d`](https://github.com/NixOS/nixpkgs/commit/ba24545d7324375e4cc7638a41687d966c41e340) maintainers/team-list: add drupol to php team
* [`f7184176`](https://github.com/NixOS/nixpkgs/commit/f71841764835f3fce502015e3013a8101c380dfa) python3Packages.sqlalchemy-continuum: 1.3.11 -> 1.3.12
* [`10047fc2`](https://github.com/NixOS/nixpkgs/commit/10047fc2b3592585a20c091ac28e5e8e9c078081) python3Packages.ihatemoney: fix build
* [`0439a474`](https://github.com/NixOS/nixpkgs/commit/0439a474bf377c435191a052c0d38df9b3bbc144) imagemagick: 7.1.0-19 -> 7.1.0-20
* [`e54d9608`](https://github.com/NixOS/nixpkgs/commit/e54d96082474cedcb7430cc582639f35aa5dd61e) libxc: 5.1.7 -> 5.2.0
* [`63f93a91`](https://github.com/NixOS/nixpkgs/commit/63f93a91d4340a90516764ba3f2849737d8f12c6) bumblebee: fix source url
* [`5947b9e9`](https://github.com/NixOS/nixpkgs/commit/5947b9e974318a76d942d9edd7ce4ab3078628ad) alacritty: fix build on aarch64
* [`8704f948`](https://github.com/NixOS/nixpkgs/commit/8704f948f1a0453d6ffdde7f5ba1ce70a2bc0d0c) mpich: 3.4.3 -> 4.0
* [`c642e1fc`](https://github.com/NixOS/nixpkgs/commit/c642e1fc5c236650a11f8d3206f36b73b5cbf0c7) maintainers: add gruve-p
* [`c30f25ff`](https://github.com/NixOS/nixpkgs/commit/c30f25ffbb56719a7e03e6639688a1cee5a4a2c7) canon-cups-ufr2: fix library patching; use proot to enable cnsetuputil2 ([nixos/nixpkgs⁠#156090](https://togithub.com/nixos/nixpkgs/issues/156090))
* [`857d2878`](https://github.com/NixOS/nixpkgs/commit/857d2878552a4197b4ba5cd6d54f05e199eaf40f) sdat2img: init at unstable-2021-11-9
* [`3db4201b`](https://github.com/NixOS/nixpkgs/commit/3db4201bc8447282218c7d74b1f17a763820c8f2) mixRelease: allow specifying buildInputs ([nixos/nixpkgs⁠#156288](https://togithub.com/nixos/nixpkgs/issues/156288))
* [`c95e816c`](https://github.com/NixOS/nixpkgs/commit/c95e816c655a1032e25ddcd81d1b4b02f7b69757) nixos/wordpress: Drop old deprecated interface ([nixos/nixpkgs⁠#152674](https://togithub.com/nixos/nixpkgs/issues/152674))
* [`3ab8db0a`](https://github.com/NixOS/nixpkgs/commit/3ab8db0ad04f6f6efae25375ae9577a729d9edc5) mandoc: fix executableCross condition
* [`8499ca25`](https://github.com/NixOS/nixpkgs/commit/8499ca252ab0516c9244eb1150ea6e2e808441ac) mandoc: move executableCross assert into meta.broken
* [`fa74c63b`](https://github.com/NixOS/nixpkgs/commit/fa74c63bdc1065e51486ce3d687db64c2105191d) vlc: optional Wayland support
* [`16305595`](https://github.com/NixOS/nixpkgs/commit/163055958b5c3841009f8eeb288ebcf2a71fbf0e) terragrunt: 0.35.20 -> 0.36.0
* [`5404f234`](https://github.com/NixOS/nixpkgs/commit/5404f23417e41d64f45c95be881fd08d698f9ffd) stellarsolver: 1.8 -> 1.9
* [`6833cd17`](https://github.com/NixOS/nixpkgs/commit/6833cd17bd87f22be92af972e34039154ebe204a) python3Packages.ansimarkup: init at 1.5.0
* [`b876a7e5`](https://github.com/NixOS/nixpkgs/commit/b876a7e5493c399b8a40715ea920d4ef815da229) python3Packages.sigrok: init at 0.5.1
* [`63921adc`](https://github.com/NixOS/nixpkgs/commit/63921adcd4ff10d8c7f2082df31291a1a3bfd5f6) flexget: 3.2.11 -> 3.2.13
* [`deaf36f4`](https://github.com/NixOS/nixpkgs/commit/deaf36f4c68b4d9537d071e821706480d31a12e5) snarkos: init at unstable-2021-01-21 ([nixos/nixpkgs⁠#156209](https://togithub.com/nixos/nixpkgs/issues/156209))
* [`0e4c2ff9`](https://github.com/NixOS/nixpkgs/commit/0e4c2ff9b9fc017425df352d785efcd5d57aa4ee) ocamlPackages.camlpdf: 2.4 → 2.5
* [`8b86f981`](https://github.com/NixOS/nixpkgs/commit/8b86f9816dd46a8b29088ddd91b0a590829f282a) handbrake: convert nixos test to runCommand
* [`3d94cba6`](https://github.com/NixOS/nixpkgs/commit/3d94cba62991fe96e15a4e7da3ca8a188cb459e0) gitlab: 14.6.2 -> 14.6.3 ([nixos/nixpkgs⁠#156296](https://togithub.com/nixos/nixpkgs/issues/156296))
* [`2d42d654`](https://github.com/NixOS/nixpkgs/commit/2d42d654aa482de067d30285d8d5bdce5e32ec62) mautrix-telegram: 0.11.0 -> 0.11.1 ([nixos/nixpkgs⁠#156099](https://togithub.com/nixos/nixpkgs/issues/156099))
* [`9655e2f7`](https://github.com/NixOS/nixpkgs/commit/9655e2f79503bd1b073a6e71a4576765c4cfa1ad) libretro.citra-canary: init at unstable-2022-01-21
* [`f2ed702e`](https://github.com/NixOS/nixpkgs/commit/f2ed702e7eed6c8973e9b93628dd41b38b1615ec) rehex: 0.3.92 -> 0.4.1
* [`75902bb8`](https://github.com/NixOS/nixpkgs/commit/75902bb873391f19a0063f56089b44d6b5d3af76) nodePackages.manta: add completion
* [`c0134288`](https://github.com/NixOS/nixpkgs/commit/c0134288e7a25e95d0ee926aa710118d39cf639a) nodePackages.triton: add completion
* [`290b04c5`](https://github.com/NixOS/nixpkgs/commit/290b04c5a8cfc4fad000364139145b3e9fe6f83b) lzwolf: init at unstable-2022-01-04
* [`ae917ed0`](https://github.com/NixOS/nixpkgs/commit/ae917ed02476a2b98d5019f6abe028a2e7bcd271) xl2tpd: 1.3.16 -> 1.3.17
* [`2e719d1c`](https://github.com/NixOS/nixpkgs/commit/2e719d1cdab9e81750c19425a1f5c7678b5e73ad) sway: 1.6.1 -> 1.7
* [`31e8ff77`](https://github.com/NixOS/nixpkgs/commit/31e8ff776acc7d7e87ecbec4ef9f4504070a7ba7) remake: 4.3+dbg-1.5 -> 4.3+dbg-1.6
* [`bba53f20`](https://github.com/NixOS/nixpkgs/commit/bba53f208055cc7e872025551efcf5a463cfd142) libagent: 0.14.1 -> 0.14.4 ([nixos/nixpkgs⁠#154780](https://togithub.com/nixos/nixpkgs/issues/154780))
* [`1526558d`](https://github.com/NixOS/nixpkgs/commit/1526558d4bf6fe56177be628699b108e528b6d51) xgboost: 1.5.1 -> 1.5.2
* [`8718a35c`](https://github.com/NixOS/nixpkgs/commit/8718a35c5f57f29bbd889677cd898ff458cfec40) gay: refactor python packaging method
* [`02ffdfc6`](https://github.com/NixOS/nixpkgs/commit/02ffdfc68587a68d5e96a3c314f378f438b251eb) stellarsolver: enable on non-linux
* [`0522e55f`](https://github.com/NixOS/nixpkgs/commit/0522e55f996974f1f677617ddc2d9537845907b3) ocamlPackages.ppxlib: 0.23.0 -> 0.24.0 ([nixos/nixpkgs⁠#154901](https://togithub.com/nixos/nixpkgs/issues/154901))
* [`5e822e54`](https://github.com/NixOS/nixpkgs/commit/5e822e54d20ddd4805022cfcf8e813111ce00c27) AusweisApp2: 1.22.2 -> 1.22.3
* [`6c3385ba`](https://github.com/NixOS/nixpkgs/commit/6c3385ba022de3de10f9943825fe3b6698b76f16) python310Packages.youtube-search-python: 1.6.0 -> 1.6.1
* [`177f8cac`](https://github.com/NixOS/nixpkgs/commit/177f8cac9bd9e035027203f37d066e77694040f0) Update pkgs/development/python-modules/ihatemoney/default.nix
* [`667ff184`](https://github.com/NixOS/nixpkgs/commit/667ff184351c3f1a5173030f34f4fddfd1b9776b) Groestlcoin: init at 22.0
* [`fff9730c`](https://github.com/NixOS/nixpkgs/commit/fff9730ce0a324f2a19abb619e3cd8ae866f8912) bazel-buildtools: 4.2.4 -> 4.2.5
* [`5d18ae84`](https://github.com/NixOS/nixpkgs/commit/5d18ae8459855d0a143d2ca0bc7929225b8602b6) .github/CODEOWNERS: add kubernetes
* [`2702a699`](https://github.com/NixOS/nixpkgs/commit/2702a6999f32dbb202147451d5fa55fccd821bf9) kubectl: move alongside kubernetes
* [`745e1ea2`](https://github.com/NixOS/nixpkgs/commit/745e1ea21b7644d20224154a992528beaf7bccb5) maintainers/teams: add kubernetes
* [`c78dba5f`](https://github.com/NixOS/nixpkgs/commit/c78dba5f76837695d75b6f7903cb776b904a2653) kubernetes: use maintainer team
* [`d53ef8b8`](https://github.com/NixOS/nixpkgs/commit/d53ef8b8229336b0f7dcb5b8fbeba217a0bf2033) nixos/locate Add support for plocate ([nixos/nixpkgs⁠#156185](https://togithub.com/nixos/nixpkgs/issues/156185))
* [`27e10a3b`](https://github.com/NixOS/nixpkgs/commit/27e10a3b92e9df8b899dd09b1dafab28f2303ff1) snis: init at 20211017 ([nixos/nixpkgs⁠#142034](https://togithub.com/nixos/nixpkgs/issues/142034))
* [`c1801065`](https://github.com/NixOS/nixpkgs/commit/c1801065f4458ec0a320c074ad48781956eb9093) indicator-sound-switcher: init at 2.3.6 ([nixos/nixpkgs⁠#147413](https://togithub.com/nixos/nixpkgs/issues/147413))
