### PR TITLE
niv home-manager: update 8cf13abf -> 462d4a7a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cf13abffc0808b337590a9e382604ab6c2cb3e7",
-        "sha256": "0lcpzavipvzn5779q2857shm7a55g2p2cw55jdzybq14yg3d25gb",
+        "rev": "462d4a7abdfb8cb762584745a480ad01c207570e",
+        "sha256": "0v456cfr1jk8dfn0c9lxzm23sx8f0x9x4n03ls7b1gvs48a2m260",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/8cf13abffc0808b337590a9e382604ab6c2cb3e7.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/462d4a7abdfb8cb762584745a480ad01c207570e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@8cf13abf...462d4a7a](https://github.com/nix-community/home-manager/compare/8cf13abffc0808b337590a9e382604ab6c2cb3e7...462d4a7abdfb8cb762584745a480ad01c207570e)

* [`4d4c1f34`](https://github.com/nix-community/home-manager/commit/4d4c1f343bf16a472827855323a2539f073ff373) Translate using Weblate (German)
* [`eccd7047`](https://github.com/nix-community/home-manager/commit/eccd70475613bfbd19148d7abeef58164a2a2f36) Add translation using Weblate (Portuguese (Brazil))
* [`5e4f439e`](https://github.com/nix-community/home-manager/commit/5e4f439e0cc19941173f037d0556407cac91ed4d) Add translation using Weblate (Portuguese (Brazil))
* [`c4913317`](https://github.com/nix-community/home-manager/commit/c491331718bd41722a2982a5532eb0ff51c3ca28) Translate using Weblate (German)
* [`7eb51065`](https://github.com/nix-community/home-manager/commit/7eb5106548eaab99ebeb21c87f93092de54fe931) docs: fix README flake commands
* [`e8a68de7`](https://github.com/nix-community/home-manager/commit/e8a68de7abb034d39c762c03a3b09ba6304d2fbf) github: copyedit stale bot's messages ([nix-community/home-manager⁠#2658](https://togithub.com/nix-community/home-manager/issues/2658))
* [`32da35f6`](https://github.com/nix-community/home-manager/commit/32da35f65bb68710615eb82053439b89a1ee230d) helix: add module
* [`d469b9bf`](https://github.com/nix-community/home-manager/commit/d469b9bf8a1ca8b596eb86a25b478560fdf3cc2b) watson: add module
* [`54b8b13a`](https://github.com/nix-community/home-manager/commit/54b8b13a9bca973be6803c23ad52de021b9bfee2) timidity: add module
* [`e622c5d8`](https://github.com/nix-community/home-manager/commit/e622c5d83633c16d29c50f8d777dddf2290c0b8c) tint2: add module
* [`c47c350f`](https://github.com/nix-community/home-manager/commit/c47c350f6518ed39c2a16e4fadf9137b6c559ddc) pandoc: add new module
* [`192675b1`](https://github.com/nix-community/home-manager/commit/192675b1496073cc384a5caa566c600e31145d82) docs: fix a few stray periods
* [`462d4a7a`](https://github.com/nix-community/home-manager/commit/462d4a7abdfb8cb762584745a480ad01c207570e) atuin: add fish integration
