### PR TITLE
niv spacemacs: update 6ccbbcc7 -> 175fdcc9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "6ccbbcc7d9e41205499671611c24a3b8dc709abf",
-        "sha256": "1x2jkq3q2vh5qr4jswb21b76h6br64dwq82j78j6ic3sas6p3w11",
+        "rev": "175fdcc967f0fda7ad5bad06bea441256ead0d94",
+        "sha256": "0g0b23c8kvijkqk3d5wanw8q967wmf67ai8bpzlziq1w9p86ym1c",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/6ccbbcc7d9e41205499671611c24a3b8dc709abf.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/175fdcc967f0fda7ad5bad06bea441256ead0d94.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@6ccbbcc7...175fdcc9](https://github.com/syl20bnr/spacemacs/compare/6ccbbcc7d9e41205499671611c24a3b8dc709abf...175fdcc967f0fda7ad5bad06bea441256ead0d94)

* [`c528f614`](https://github.com/syl20bnr/spacemacs/commit/c528f614e8b641eb3e152f1de690b1b8a06066b3) [ci]  Add new files to patch file
* [`cbb3292c`](https://github.com/syl20bnr/spacemacs/commit/cbb3292c436223ad0c6f47a5d5e346ac94a240ef) [ci] track all files
* [`2a668ab9`](https://github.com/syl20bnr/spacemacs/commit/2a668ab90d92421dc5c14bb6440d1bb1a1f99e9a) [ci] Fix problem with bin patches
* [`07081a63`](https://github.com/syl20bnr/spacemacs/commit/07081a63698462d5bf6b3e891e4bf113667876df) FAQ: Added guide on suppressing [syl20bnr/spacemacs⁠#11682](https://togithub.com/syl20bnr/spacemacs/issues/11682)
* [`175fdcc9`](https://github.com/syl20bnr/spacemacs/commit/175fdcc967f0fda7ad5bad06bea441256ead0d94) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15285](https://togithub.com/syl20bnr/spacemacs/issues/15285))
