### PR TITLE
niv nixpkgs: update c1801065 -> e978e3fd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c1801065f4458ec0a320c074ad48781956eb9093",
-        "sha256": "1rwi1vgkw26wbdd5z2jpkgxc0lbnaxbw34xph1kfg60jw87c0aga",
+        "rev": "e978e3fde980e53fd82f3e27e3aa4bc030af964d",
+        "sha256": "1vxq2b0sp56b3w3yr8ws9rijb4ncalb7aym5bjgal9mrg6hcwrhk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c1801065f4458ec0a320c074ad48781956eb9093.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e978e3fde980e53fd82f3e27e3aa4bc030af964d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c1801065...e978e3fd](https://github.com/nixos/nixpkgs/compare/c1801065f4458ec0a320c074ad48781956eb9093...e978e3fde980e53fd82f3e27e3aa4bc030af964d)

* [`c88d3c37`](https://github.com/NixOS/nixpkgs/commit/c88d3c371add20e91ee2270e6149af5d197c7b66) python3Packages.dash: disable on older Python releases
* [`51d1b081`](https://github.com/NixOS/nixpkgs/commit/51d1b081b5c12d9b9a2b120e37e88ba39b0e9202) texstudio: 4.2.0 -> 4.2.1
* [`48a133a0`](https://github.com/NixOS/nixpkgs/commit/48a133a0667a34a2d54339e674759dc5b6019636) key: add a desktop item
* [`937953f1`](https://github.com/NixOS/nixpkgs/commit/937953f1c46eaa705b28eb8016c1efc78b98c76f) python310Packages.simplisafe-python: 2021.12.2 -> 2022.01.0
* [`0a36a9f6`](https://github.com/NixOS/nixpkgs/commit/0a36a9f6934f5fa184e261923ddb421a2e6ff3e3) linux_zen: 5.15.11-zen1 -> 5.16.3-zen1
* [`55561105`](https://github.com/NixOS/nixpkgs/commit/55561105fa2cf72a8d741114c9e3aa887cdd6502) mysql57: 5.7.27 -> 5.7.37
* [`ea1446f5`](https://github.com/NixOS/nixpkgs/commit/ea1446f5566f65146b2794d494e8bfe5a4ca1291) nomad: drop support for nomad 1.0
* [`e5da53ba`](https://github.com/NixOS/nixpkgs/commit/e5da53ba72361150931f369c5db0bffaf1068071) nextcloud21: 21.0.7 -> 21.0.8
* [`f6038cf1`](https://github.com/NixOS/nixpkgs/commit/f6038cf1eed439b6e18da73746eb25367287ccc3) nextcloud22: 22.2.3 -> 22.2.4
* [`2a7dc81e`](https://github.com/NixOS/nixpkgs/commit/2a7dc81ef48b1204579902ee317dd9538b1fc5b4) python3Packages.asysocks: 0.1.2 -> 0.1.6
* [`7d87529d`](https://github.com/NixOS/nixpkgs/commit/7d87529de990edce3a24f2ac5a86a85b6c3e0bb5) nextcloud23: 23.0.0 -> 23.0.1
* [`d4867eca`](https://github.com/NixOS/nixpkgs/commit/d4867eca678c5a5c44a27aec3f4fe5e8e88128ad) butane: 0.13.1 -> 0.14.0
* [`873ac73f`](https://github.com/NixOS/nixpkgs/commit/873ac73f8659c6e844d090b49a8c9aaa5905e37f) python310Packages.vowpalwabbit: 8.11.0 -> 9.0.0
* [`1043ef65`](https://github.com/NixOS/nixpkgs/commit/1043ef65c040a96d8f67d1ee1af984f88c52c4e7) osm2pgsql: 1.5.1 -> 1.6.0
* [`eb780729`](https://github.com/NixOS/nixpkgs/commit/eb78072935d69921f7c6482ee05d1aebfb378739) chromiumDev: 99.0.4840.0 -> 99.0.4844.11
* [`3c889e14`](https://github.com/NixOS/nixpkgs/commit/3c889e14238fdcf203a91813dabc1c8031de277d) qownnotes: 22.1.10.1 -> 22.1.11
* [`a5b0dd62`](https://github.com/NixOS/nixpkgs/commit/a5b0dd620bb5f08608d06fe40a8dcbbeb8ad571b) nuspell: 5.0.0 -> 5.0.1
* [`3b178976`](https://github.com/NixOS/nixpkgs/commit/3b1789762e64fe84dec5c80d3421b95f4db1bd59) double-conversion: 3.1.5 -> 3.1.6
* [`32d45883`](https://github.com/NixOS/nixpkgs/commit/32d45883a8c34cf9d4e98c14ac601a2c4ecf8313) libf2c: explicitly disable parallel builds
* [`1e414e1b`](https://github.com/NixOS/nixpkgs/commit/1e414e1bd1d6fac6eddee77ecca190e803cbc83a) python310Packages.deezer-python: 5.0.0 -> 5.0.1
* [`4d7d2251`](https://github.com/NixOS/nixpkgs/commit/4d7d225171d0ff92c2b699de6dc3c025dbe3a02f) linux: 4.14.263 -> 4.14.264
* [`291e5ba3`](https://github.com/NixOS/nixpkgs/commit/291e5ba35e1b1b8af08d6f415289171c8052a37b) linux: 4.19.226 -> 4.19.227
* [`be350595`](https://github.com/NixOS/nixpkgs/commit/be3505956a39c3d7396dabcc71a59870866a6768) linux: 4.4.300 -> 4.4.301
* [`dd0e39a9`](https://github.com/NixOS/nixpkgs/commit/dd0e39a900489925f9c272bdc6d74b323816dd95) linux: 4.9.298 -> 4.9.299
* [`e21b404b`](https://github.com/NixOS/nixpkgs/commit/e21b404b64cc5346cd132575951765fb400c5902) linux: 5.10.94 -> 5.10.95
* [`2461a530`](https://github.com/NixOS/nixpkgs/commit/2461a530ff0e6d4430f06f37d9b1f9fabe446dc8) linux: 5.15.17 -> 5.15.18
* [`46708c6a`](https://github.com/NixOS/nixpkgs/commit/46708c6a5b554946b2a55bdfb46976b00a0fdda7) linux: 5.16.3 -> 5.16.4
* [`2c30d76c`](https://github.com/NixOS/nixpkgs/commit/2c30d76cd20a3aad905db5324357933e2da2d59a) linux: 5.4.174 -> 5.4.175
* [`ecc46f19`](https://github.com/NixOS/nixpkgs/commit/ecc46f194cdf3e7184622f10af6d8447c46580a5) python3Packages.arviz: patch requirements.txt and add zarr tests
* [`eaf9d8f5`](https://github.com/NixOS/nixpkgs/commit/eaf9d8f5986a50ce24541d082e31e6e85cca5b9b) labwc: 0.3.0 -> 0.4.0
* [`00478979`](https://github.com/NixOS/nixpkgs/commit/0047897994475e789d3e90b2944f4ee20a8bc1e2) lispPackages: add float-features
* [`5239058d`](https://github.com/NixOS/nixpkgs/commit/5239058d52163f9a1cf6f59a7663601f4db93772) lispPackages: add lisp-binary and quasiquote-2.0
* [`e6d73949`](https://github.com/NixOS/nixpkgs/commit/e6d73949cff6d45522a2c539686c06b0056e13f2) perlPackages.CPAN: 2.28 -> 2.29
* [`bf042a09`](https://github.com/NixOS/nixpkgs/commit/bf042a0978e3f73ad9eff121e2d0058f93cf3b4e) python310Packages.azure-mgmt-compute: 24.0.1 -> 25.0.0
* [`7583e479`](https://github.com/NixOS/nixpkgs/commit/7583e479cb0a76b2efcccfa0e60ea5572f6d5627) _1password: download arm64 binary for aarch64-linux
* [`92eb5bc4`](https://github.com/NixOS/nixpkgs/commit/92eb5bc48e8cccabdfc2bd6e75d5261353ca3578) ethercalc: init at latest master (b19627)
* [`98931e1e`](https://github.com/NixOS/nixpkgs/commit/98931e1ea4c0ad62204b2e8d6003da961e665c49) kube-hunter: 0.6.4 -> 0.6.5
* [`e3d8cc81`](https://github.com/NixOS/nixpkgs/commit/e3d8cc81b37a566d781199dab9d342822393b91f) nixos/nix-daemon: fix config validation with 2.3
* [`86369f49`](https://github.com/NixOS/nixpkgs/commit/86369f498f92344d11e9105eb41746ad4c910b33) gdu: 5.12.1 -> 5.13.0
* [`b7af433f`](https://github.com/NixOS/nixpkgs/commit/b7af433f12e81eb9d4cc78b30ac2bd6144ea4f2c) fd: 8.3.1 -> 8.3.2
* [`4c1d81c9`](https://github.com/NixOS/nixpkgs/commit/4c1d81c91e7265bd8d20c5e4cd26bad41cb9cbdc) Revert "clippy: fix build ([nixos/nixpkgs⁠#152211](https://togithub.com/nixos/nixpkgs/issues/152211))"
* [`d49c2ece`](https://github.com/NixOS/nixpkgs/commit/d49c2ece4a7b4d217db376853db674e7280abb29) t-rex: 0.14.3-beta4 → 0.14.3
* [`66d547de`](https://github.com/NixOS/nixpkgs/commit/66d547dec8d9a18cdd0930866e1c416b8bffa805) garble: 20200107 -> 0.5.1, switch to go_1_17
* [`d9e4b9e3`](https://github.com/NixOS/nixpkgs/commit/d9e4b9e3f5c86b233ed30efb696a7ff5f44bae63) coyim: mark as broken
* [`0ac96d7c`](https://github.com/NixOS/nixpkgs/commit/0ac96d7c5331987c48bb65ba4b2995521c8cf2a8) nixos/gnome: Remove warning for fixed nixos-rebuild switch bug
* [`23881e27`](https://github.com/NixOS/nixpkgs/commit/23881e27efd3521a55effe341a733fa38d1bc59c) ibus-engines.bamboo: switch to go_1_17
* [`e518e07b`](https://github.com/NixOS/nixpkgs/commit/e518e07b0b020173b0cababc92b0373ad34c36ea) python3Packages.policy-sentry: 0.12.0 -> 0.12.1
* [`f1a3e3e2`](https://github.com/NixOS/nixpkgs/commit/f1a3e3e21c9a1c3d7e683a2f0ac5bcce8e90eb1d) virtualbox: set meta.mainProgram
* [`bdd82440`](https://github.com/NixOS/nixpkgs/commit/bdd82440bc65e0dfb3e116a7015a89f0dfafcad7) python3Packages.skodaconnect: 1.1.12 -> 1.1.14
* [`d8bb89b9`](https://github.com/NixOS/nixpkgs/commit/d8bb89b9fff31d6de8b025ee6ee674bbc8909860) make-initrd: fix reproducibility problems with hard links
* [`308a806d`](https://github.com/NixOS/nixpkgs/commit/308a806d9a2e1db571173a0b773d644d1bc732c0) ChowCentaur: init at 1.4.0
* [`81b8c4c2`](https://github.com/NixOS/nixpkgs/commit/81b8c4c267876f640da38f2565ad2b2dabe64809) vivid: 0.7.0 -> 0.8.0 ([nixos/nixpkgs⁠#157312](https://togithub.com/nixos/nixpkgs/issues/157312))
* [`f5e30962`](https://github.com/NixOS/nixpkgs/commit/f5e309621042788250d20992d3267857d0d13eb7) vscode-extensions.pkief.material-icon-theme: 4.11.0 -> 4.12.1
* [`23b616a8`](https://github.com/NixOS/nixpkgs/commit/23b616a82198998289d9b81987d4dd1e9f5780c0) vscode-extensions.esbenp.prettier-vscode: 9.1.0 -> 9.2.0
* [`30d4848f`](https://github.com/NixOS/nixpkgs/commit/30d4848ffc1b6b1768d08d6e5061cab6bcfd7561) vimPlugins.sniprun: init at 1.1.2
* [`42442357`](https://github.com/NixOS/nixpkgs/commit/4244235785b1ddfc0c3bc4b721fc48e02f92998e) vimPlugins.onedark-nvim: etc
* [`7ae2be51`](https://github.com/NixOS/nixpkgs/commit/7ae2be51548c68632bf8973439c311eae317637b) appthreat-depscan: 2.1.0 -> 2.1.2
* [`454006f6`](https://github.com/NixOS/nixpkgs/commit/454006f6fd7c1c8c186d2cfa7de584f427607833) envoy: switch to go_1_17
* [`9690362f`](https://github.com/NixOS/nixpkgs/commit/9690362f6270a66035e050fe1bda63ce0e751bdd) wiki-js: 2.5.272 -> 2.5.274
* [`c4156912`](https://github.com/NixOS/nixpkgs/commit/c4156912399fcaaa21e0afb5def6acbd85194518) go: remove outdated alias throws
* [`69d487b8`](https://github.com/NixOS/nixpkgs/commit/69d487b85f876f39e188302519d1b8eb127df34d) steampipe: 0.12.1 -> 0.12.2
* [`d48d5645`](https://github.com/NixOS/nixpkgs/commit/d48d564569087a53d25721c3739cea5dbaf9770e) steampipe: use proxyVendor to fix darwin/linux vendorSha256 mismatch
* [`9721abad`](https://github.com/NixOS/nixpkgs/commit/9721abadfdb42738ba3591f8b1da06a340b85309) freewheeling: build with fluidsynth ([nixos/nixpkgs⁠#157085](https://togithub.com/nixos/nixpkgs/issues/157085))
* [`b0c0e0d7`](https://github.com/NixOS/nixpkgs/commit/b0c0e0d7eb099a61479b2ca6b390d3b0809a5519) stdenv: introduce withCFlags
* [`47691ae2`](https://github.com/NixOS/nixpkgs/commit/47691ae272fe811dcf53d946eb2756da7c3434cb) pantheon.elementary-music: remove unneeded inputs
* [`0991408d`](https://github.com/NixOS/nixpkgs/commit/0991408d6f048e86189c72bd2a4864f2700c426f) pkgs/pantheon: update meta.license
* [`422471d1`](https://github.com/NixOS/nixpkgs/commit/422471d1b064839879d03dcfa9b8b3530c5be744) pkgs/pantheon: remove unneeded elementary-gtk-theme
* [`151123a5`](https://github.com/NixOS/nixpkgs/commit/151123a54d1eafd7b076f9b28a6ba6624d521b26) weather: use python3
* [`6f391d8b`](https://github.com/NixOS/nixpkgs/commit/6f391d8b567f62c1ba29a7c61267022fad00e50b) python310Packages.upb-lib: 0.4.12 -> 0.5
* [`e1aa7d76`](https://github.com/NixOS/nixpkgs/commit/e1aa7d7609f7be23f973f8221fdd5fb07cca4063) qMasterPassword: 1.2.2 -> git master
* [`1cd734f2`](https://github.com/NixOS/nixpkgs/commit/1cd734f2d3aa1331fbed06729295ab89386a4ae9) pantheon.elementary-photos: remove unneeded inputs
* [`9d8a23f6`](https://github.com/NixOS/nixpkgs/commit/9d8a23f66e4742969483efdea17b5fb9c0182269) nixos/smartctl-exporter: fix typo in rawio capab
* [`3fd6c227`](https://github.com/NixOS/nixpkgs/commit/3fd6c227c6e1cb183adf4e480ba6bb414e511c29) pantheon.elementary-files: remove unneeded inputs
* [`376934f4`](https://github.com/NixOS/nixpkgs/commit/376934f4b7ca6910b243be5fabcf3f4228043725) plausible: 1.4.3 -> 1.4.4 ([nixos/nixpkgs⁠#157335](https://togithub.com/nixos/nixpkgs/issues/157335))
* [`90964d30`](https://github.com/NixOS/nixpkgs/commit/90964d30baf9088d2444dcdf3c2fa6a4c7ad1301) pantheon.switchboard-plug-about: introduces a wallpaper meson flag
* [`5627936d`](https://github.com/NixOS/nixpkgs/commit/5627936df6d4e93b8c9eeaa7c6178f323ad89e53) python310Packages.youtube-search-python: 1.6.1 -> 1.6.2
* [`544586a9`](https://github.com/NixOS/nixpkgs/commit/544586a9b32a29e642c9d971182c21f4dfdf153f) pantheon.granite: drop passthru.updateScript, disable bot update
* [`5161b59f`](https://github.com/NixOS/nixpkgs/commit/5161b59fe09c4296c31532b1e2af1ca6f9e88f2b) wingpanel-indicator-ayatana: add passthru.updateScript
* [`e7746dcc`](https://github.com/NixOS/nixpkgs/commit/e7746dccc12f96f2e5f3a75e46736b267a9c1e2e) dasel: update vendorSha256
* [`cf4b7813`](https://github.com/NixOS/nixpkgs/commit/cf4b7813859fb53339cc7ce2282f8e6e232c5fc0) k0sctl: update vendorSha256
* [`e35f5180`](https://github.com/NixOS/nixpkgs/commit/e35f5180e39538e3493dc2ceb3650bb885fea0d5) k9s: update vendorSha256
* [`844082a3`](https://github.com/NixOS/nixpkgs/commit/844082a3f97446714e153fd32ee72b3be889e6c2) nerdctl: update vendorSha256
* [`cf672068`](https://github.com/NixOS/nixpkgs/commit/cf6720685a324fb58a420ac1ece3867e9dfcb0d9) datree: update vendorSha256
* [`315f2325`](https://github.com/NixOS/nixpkgs/commit/315f2325f11849e12a6ed14596b93d22bfaa47ec) dyff: update vendorSha256
* [`0d3014bc`](https://github.com/NixOS/nixpkgs/commit/0d3014bcc1b95e4d08f789fd89faf5539cb70ec2) naabu: update vendorSha256
* [`efeefb2a`](https://github.com/NixOS/nixpkgs/commit/efeefb2af1469a5d1f0ae7ca8f0dfd9bb87d5cfb) python310Packages.pyexcel-io: 0.6.5 -> 0.6.6
* [`01614440`](https://github.com/NixOS/nixpkgs/commit/01614440cf28f0f5af67dbad21f3d3a591e6760b) exploitdb: 2022-01-26 -> 2022-01-29
* [`dbe084cf`](https://github.com/NixOS/nixpkgs/commit/dbe084cf1c93e9dab571e590a25944501ee172e5) openbabel2: use python3
* [`f9bd7869`](https://github.com/NixOS/nixpkgs/commit/f9bd7869d52a2e0a2fa1bc652d6b9e5c0f55e3a5) python310Packages.pykeyatome: 1.3.1 -> 1.4.1
* [`e084de40`](https://github.com/NixOS/nixpkgs/commit/e084de408ab4b8c37cb55c86b5cd0ca27211d953) python310Packages.aiounifi: 30 -> 31
* [`60b8276d`](https://github.com/NixOS/nixpkgs/commit/60b8276d825b510de3a7bdedee254d352e56b515) pantheon.file-roller-contract: fix version, add passthru.updateScript
* [`60e289a6`](https://github.com/NixOS/nixpkgs/commit/60e289a6d067842b339bc6b1a0b4d59b53796d10) pantheon.gnome-bluetooth-contract: fix version, add passthru.updateScript
* [`1be885d1`](https://github.com/NixOS/nixpkgs/commit/1be885d10757ed5969422348763055636da61eec) pantheon.elementary-calendar: remove unneeded inputs
* [`984466e9`](https://github.com/NixOS/nixpkgs/commit/984466e95769fda8e5e8cc768e2e418b25de611e) python310Packages.python-louvain: 0.15 -> 0.16
* [`cd9779b9`](https://github.com/NixOS/nixpkgs/commit/cd9779b9cbd9651ea282b7922962807574334d13) pantheon.elementary-camera: remove unneeded inputs
* [`d33c0732`](https://github.com/NixOS/nixpkgs/commit/d33c073216f13f3d88a290632ce6f493795e0ea8) pantheon.elementary-code: remove unneeded inputs
* [`83e96efd`](https://github.com/NixOS/nixpkgs/commit/83e96efd141413352d0a40695738a3cfb2897642) pkgs/pantheon: remove unused args
* [`9b89009b`](https://github.com/NixOS/nixpkgs/commit/9b89009bf7532be3cc841c0c1106430ce985fce5) fcitx-engines.libpinyin: 0.5.3 -> 0.5.4
* [`55c79be9`](https://github.com/NixOS/nixpkgs/commit/55c79be9effadcbece00f35aa1b11fd15733bb46) kuma: update vendorSha256
* [`2fe2f500`](https://github.com/NixOS/nixpkgs/commit/2fe2f500d4644319587bda06eceff929852ce527) beats7: update vendorSha256
* [`4b27d4f9`](https://github.com/NixOS/nixpkgs/commit/4b27d4f9f8f5396d0d6688d567568241e8bc34f9) nixos/systemd: only use cryptsetup units if systemd was built with it
* [`6b3a2e6c`](https://github.com/NixOS/nixpkgs/commit/6b3a2e6c3f7a483fcf41b73611cee248d10ae558) nixUnstable: pre20220124 -> pre20220127
* [`a817568b`](https://github.com/NixOS/nixpkgs/commit/a817568b0f88055e064d20279982e6906e14ea3d) nix: fix default value of enableDocumentation
* [`7c895e75`](https://github.com/NixOS/nixpkgs/commit/7c895e75941c9f9950e0367c342e1ffb09f7d8f0) linkerd_edge: 21.10.3 -> 22.1.4
* [`0a16b05e`](https://github.com/NixOS/nixpkgs/commit/0a16b05ea9a12e367cfe96db77429c7daf798481) nixos/nftables: Allow use with iptables ([nixos/nixpkgs⁠#121517](https://togithub.com/nixos/nixpkgs/issues/121517))
* [`81c46ad9`](https://github.com/NixOS/nixpkgs/commit/81c46ad9e83bf1cfa8048302613da942c4c05941) chroma: 0.9.4 -> 0.10.0
* [`282364c5`](https://github.com/NixOS/nixpkgs/commit/282364c50ac7fe7e8a1eafb6b384ae7788cb5cbc) python310Packages.azure-mgmt-iothub: 2.1.0 -> 2.2.0
* [`1110cfeb`](https://github.com/NixOS/nixpkgs/commit/1110cfeb7c8e0d0630a6f9b0e1cd00f1e588be08) oil: 0.9.6 -> 0.9.7
* [`37246842`](https://github.com/NixOS/nixpkgs/commit/372468425f35be282788576d3fc427012579103f) imagemagick: build with potrace
* [`7b2978e9`](https://github.com/NixOS/nixpkgs/commit/7b2978e92b31a71c380c448ada65e25d9af775e6) python310Packages.phonenumbers: 8.12.41 -> 8.12.42
* [`56741fba`](https://github.com/NixOS/nixpkgs/commit/56741fba9452e2f61ba2607c0234b4c571200ce4) wasmtime: use python3
* [`bd8b4741`](https://github.com/NixOS/nixpkgs/commit/bd8b4741a0c491c5baba701dc48397c164038288) ntrack: use python3
* [`e9cdc3fb`](https://github.com/NixOS/nixpkgs/commit/e9cdc3fb36a1de97a2925c692758af33389a138f) cloak: 0.2.0 -> 0.3.0
* [`42ddf4ae`](https://github.com/NixOS/nixpkgs/commit/42ddf4aea4ae4502e8a2d8d1179e360e74e015ef) urlscan: 0.9.8 -> 0.9.9
* [`6ec6ac7f`](https://github.com/NixOS/nixpkgs/commit/6ec6ac7fe1f70eaf610f7beeed5ad7fbc790ddef) kopia: 0.10.0 -> 0.10.2
* [`07df4546`](https://github.com/NixOS/nixpkgs/commit/07df4546ad5a96dd4080fdda276fbe96c2451200) aerc: update vendorSha256
* [`1097381d`](https://github.com/NixOS/nixpkgs/commit/1097381d400990a3c9e4732a1a180e71ace9edcc) hasmail: update vendorSha256
* [`1f2ef555`](https://github.com/NixOS/nixpkgs/commit/1f2ef55547274ac3febd7c86ca12e30f08c5d1da) gmailctl: update vendorSha256
* [`0a9b1548`](https://github.com/NixOS/nixpkgs/commit/0a9b1548668a92e32beb88e0291a6d9987fc299d) nomad-autoscaler: update vendorSha256
* [`8a5ac313`](https://github.com/NixOS/nixpkgs/commit/8a5ac313104b5661623f27976de02d1559ed5f0c) httpx: update vendorSha256
* [`06ced3b3`](https://github.com/NixOS/nixpkgs/commit/06ced3b3578f8e0963792fbff37dce8761a2fc15) gotop: update vendorSha256
* [`e9577ca6`](https://github.com/NixOS/nixpkgs/commit/e9577ca64bb887eea77b0ef26dbb5d97835e25fd) passphrase2pgp: update vendorSha256
* [`b6e20d97`](https://github.com/NixOS/nixpkgs/commit/b6e20d97fac90958029f73270bf9eba6cc3c9b10) livepeer: update vendorSha256
* [`7e1f7068`](https://github.com/NixOS/nixpkgs/commit/7e1f70680d1e77854b968a30f4d7678df3ea7790) hydron: update vendorSha256
* [`c38c0b8d`](https://github.com/NixOS/nixpkgs/commit/c38c0b8daf7bbb97bcfee1d4361a1d798272c548) blockbook: update vendorSha256
* [`586ff1f3`](https://github.com/NixOS/nixpkgs/commit/586ff1f3e971585ad2289c9fc08046ea9171c8ec) croc: update vendorSha256
* [`a86361e2`](https://github.com/NixOS/nixpkgs/commit/a86361e234bb769a96541297dd0eede85c231c2a) croc: disable broken test
* [`4094fcb6`](https://github.com/NixOS/nixpkgs/commit/4094fcb66f551c5eeb56618138149be5adcb5f54) seahub: init at 8.0.8
* [`8d28f104`](https://github.com/NixOS/nixpkgs/commit/8d28f1046bde4a345a4b844a28d9414b5f30fb36) python3Packages.qt5reactor: init at 0.6.3
* [`a13fe11c`](https://github.com/NixOS/nixpkgs/commit/a13fe11c59b84a0e051098c074b89303003fcca8) sasview: 4.2.0 -> 5.0.4
* [`e238c233`](https://github.com/NixOS/nixpkgs/commit/e238c233561d74819781fa41027fb20247271c2f) nomad-autoscaler: fix removeReferencesTo with go_1_17
* [`ae45cea3`](https://github.com/NixOS/nixpkgs/commit/ae45cea36e67f790b9c0a25bdf96e032d3ba0f47) treewide: remove all .upstream files
* [`325d6de9`](https://github.com/NixOS/nixpkgs/commit/325d6de924522ed795ee7fb1e09c2099a8f855b3) editorconfig: remove updatewalker
* [`70ee1155`](https://github.com/NixOS/nixpkgs/commit/70ee115571821c47b2d71c4555ce8456a81cf819) from-quicklisp: move urls-from-page.sh to its directory
* [`012a4cbc`](https://github.com/NixOS/nixpkgs/commit/012a4cbce8e1345e608f9a49043dd8099ceabf37) transmission-rpc: relax version typing_extensions
* [`1ca665dd`](https://github.com/NixOS/nixpkgs/commit/1ca665dd6cd6e84eacb06c80f9ee6e0ea4625f40) wtf: update vendorSha256
* [`d954d92f`](https://github.com/NixOS/nixpkgs/commit/d954d92f300e24a3d77c0c3a73bc42fbf2053628) yq-go: update vendorSha256
* [`d5bde89a`](https://github.com/NixOS/nixpkgs/commit/d5bde89a4b552499d123060e805fa3e451d5262e) zsh-history: update vendorSha256
* [`83a30bb8`](https://github.com/NixOS/nixpkgs/commit/83a30bb85234564911a26057497c32f8688d3c56) topicctl: update vendorSha256
* [`ca165c0f`](https://github.com/NixOS/nixpkgs/commit/ca165c0f7d459cbb7ba75768bb98870837f7f9b4) tz: update vendorSha256
* [`e7433399`](https://github.com/NixOS/nixpkgs/commit/e743339918b904fa784fbcd124fea61941aa50d4) viddy: update vendorSha256
* [`d3850e7e`](https://github.com/NixOS/nixpkgs/commit/d3850e7e18f409b8b79b712fbb3032402914806e) yubikey-agent: update vendorSha256
* [`7ae0bd64`](https://github.com/NixOS/nixpkgs/commit/7ae0bd64dc59cdabfb8ac2a7cb692c2e8d3af832) yubikey-touch-detector: update vendorSha256
* [`fb0d3a28`](https://github.com/NixOS/nixpkgs/commit/fb0d3a28a003c8d4c63f7d35afbc1004ab45f384) vale: update vendorSha256
