### PR TITLE
niv home-manager: update 462d4a7a -> 95d39e13

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "462d4a7abdfb8cb762584745a480ad01c207570e",
-        "sha256": "0v456cfr1jk8dfn0c9lxzm23sx8f0x9x4n03ls7b1gvs48a2m260",
+        "rev": "95d39e13a4a7a818c87f2701b59820d3ac0e674c",
+        "sha256": "19aqfh76b5gp3l09vxmczivx4vz2vwi86ny8crs5nihrsyhn08dp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/462d4a7abdfb8cb762584745a480ad01c207570e.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/95d39e13a4a7a818c87f2701b59820d3ac0e674c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@462d4a7a...95d39e13](https://github.com/nix-community/home-manager/compare/462d4a7abdfb8cb762584745a480ad01c207570e...95d39e13a4a7a818c87f2701b59820d3ac0e674c)

* [`f206f94a`](https://github.com/nix-community/home-manager/commit/f206f94ac50fdfa5c73e28c6999094cd4c82d477) tests: re-enable commented tests
* [`990ca662`](https://github.com/nix-community/home-manager/commit/990ca662c4b92636053ea399f5fb80702830522c) unison: fix option example
* [`93b52ce0`](https://github.com/nix-community/home-manager/commit/93b52ce0bde1d44d2133d89045d1f5ae17f39e45) chromium: add commandLineArgs option
* [`cbc17601`](https://github.com/nix-community/home-manager/commit/cbc176010b83361af5eec4b28af78d9fd69a6383) kodi: add module
* [`86248a2d`](https://github.com/nix-community/home-manager/commit/86248a2d5ca027af2ce605defbb505c4f6706fe1) syncthing: add option `extraOptions`
* [`24ed6e6d`](https://github.com/nix-community/home-manager/commit/24ed6e6d4d8df7045b1fe38dedc3db179321eaa3) syncthing: add `cfg` variable for convenience
* [`8d3fe136`](https://github.com/nix-community/home-manager/commit/8d3fe1366b8b6c4748a847d1e3b41a73269caaee) neovim: support different configuration languages ([nix-community/home-manager⁠#2637](https://togithub.com/nix-community/home-manager/issues/2637))
* [`aa6261bb`](https://github.com/nix-community/home-manager/commit/aa6261bb96b8e19805d6b7ea764929f015a0ac09) nix: add module ([nix-community/home-manager⁠#2623](https://togithub.com/nix-community/home-manager/issues/2623))
* [`4e92ec84`](https://github.com/nix-community/home-manager/commit/4e92ec84f93a293042a64c3ed56ac8aee62fb6e1) ion: Add module ([nix-community/home-manager⁠#2625](https://togithub.com/nix-community/home-manager/issues/2625))
* [`fb939d1a`](https://github.com/nix-community/home-manager/commit/fb939d1acf2d677d4404452f072bb0fe3ae4417d) docs: note how to get status of activation service
* [`418ae217`](https://github.com/nix-community/home-manager/commit/418ae217ddf31e02649d07e58da05110840a7962) home-manager.autoUpgrade: add module
* [`acf824c9`](https://github.com/nix-community/home-manager/commit/acf824c9ed70f623b424c2ca41d0f6821014c67c) sbt: trim output of password command
* [`95d39e13`](https://github.com/nix-community/home-manager/commit/95d39e13a4a7a818c87f2701b59820d3ac0e674c) bash: use shellDryRun to check scripts
