### PR TITLE
niv powerlevel10k: update 9e0ef918 -> 4f143b7b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "9e0ef918db426ba7749e56e9a8ba3308c2f00c60",
-        "sha256": "0rngpv2zqkrml853psi1xrwrrxcxkva2w1h4gx20r0z1ckmgd9sy",
+        "rev": "4f143b7b978e90ac7f36c77d71eaacc29baaec16",
+        "sha256": "1wpn24wdfgch7qn0h5y6sw8dgh5c5hspxx5zkzv37nyzjn5r8j2w",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/9e0ef918db426ba7749e56e9a8ba3308c2f00c60.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/4f143b7b978e90ac7f36c77d71eaacc29baaec16.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@9e0ef918...4f143b7b](https://github.com/romkatv/powerlevel10k/compare/9e0ef918db426ba7749e56e9a8ba3308c2f00c60...4f143b7b978e90ac7f36c77d71eaacc29baaec16)

* [`6c71862c`](https://github.com/romkatv/powerlevel10k/commit/6c71862c5f9824dc92273fbe1d0dd0c37210f2af) don't set OS, DEFAULT_COLOR and DEFAULT_COLOR_INVERTED
* [`5014de05`](https://github.com/romkatv/powerlevel10k/commit/5014de0541201716dc4ee6f544321ac4e3d7431e) Squashed 'gitstatus/' changes from e02d9eed..6eb490ab
* [`d6f8c477`](https://github.com/romkatv/powerlevel10k/commit/d6f8c477617d57363d0e2c28977ef815e5a675a2) survive broken $TMPDIR
* [`bee6e092`](https://github.com/romkatv/powerlevel10k/commit/bee6e09262a6145fc178ddc85c656da4bb83a9a9) Squashed 'gitstatus/' changes from 6eb490ab..b226d8e0
