### PR TITLE
niv spacemacs: update 175fdcc9 -> 0ba8aa19

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "175fdcc967f0fda7ad5bad06bea441256ead0d94",
-        "sha256": "0g0b23c8kvijkqk3d5wanw8q967wmf67ai8bpzlziq1w9p86ym1c",
+        "rev": "0ba8aa194a71345542617a2b39439226923448e7",
+        "sha256": "0rzw7mjkj33bk6c21xkmqgyy12zcfmma90dcx0pamhxxb1gcxl9v",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/175fdcc967f0fda7ad5bad06bea441256ead0d94.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/0ba8aa194a71345542617a2b39439226923448e7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@175fdcc9...0ba8aa19](https://github.com/syl20bnr/spacemacs/compare/175fdcc967f0fda7ad5bad06bea441256ead0d94...0ba8aa194a71345542617a2b39439226923448e7)

* [`4bc45f70`](https://github.com/syl20bnr/spacemacs/commit/4bc45f70a189403c5a5b0740de0d5ee17aa520cc) [org] integrate org-appear with evil when triggering manually ([syl20bnr/spacemacs⁠#15284](https://togithub.com/syl20bnr/spacemacs/issues/15284))
* [`44ed2f84`](https://github.com/syl20bnr/spacemacs/commit/44ed2f84a1548b8ad23a468723c8daf0e8084f0a) org: add binding for org-paste-subtree ([syl20bnr/spacemacs⁠#15289](https://togithub.com/syl20bnr/spacemacs/issues/15289))
* [`a158bbff`](https://github.com/syl20bnr/spacemacs/commit/a158bbffd23ff214fdb76a9914af9f2675e0b3b0) FAQ: complete information on system package
* [`ddf44ab9`](https://github.com/syl20bnr/spacemacs/commit/ddf44ab93f2b112d9496643f55eca7e4b616ed0a) org: fix [syl20bnr/spacemacs⁠#15290](https://togithub.com/syl20bnr/spacemacs/issues/15290) ([syl20bnr/spacemacs⁠#15291](https://togithub.com/syl20bnr/spacemacs/issues/15291))
* [`4743c01f`](https://github.com/syl20bnr/spacemacs/commit/4743c01fa93894a121973ed7e2babeac610a1905) [bot] "built_in_updates" Sat Jan 29 01:35:00 UTC 2022 ([syl20bnr/spacemacs⁠#15292](https://togithub.com/syl20bnr/spacemacs/issues/15292))
* [`45264868`](https://github.com/syl20bnr/spacemacs/commit/4526486893fd63f308c6b57bb8598ae9eabdc7a4) updated README.md
* [`42dc30e3`](https://github.com/syl20bnr/spacemacs/commit/42dc30e33cc71029daf766831e4b2e42b846d893) core-spacemacs: fix daemon font size ([syl20bnr/spacemacs⁠#15295](https://togithub.com/syl20bnr/spacemacs/issues/15295))
* [`d2b56640`](https://github.com/syl20bnr/spacemacs/commit/d2b566406a0d23c414e4d7742fded9c13b48794b) rust: respect `lsp-use-upstream-bindings`
* [`6d42d05b`](https://github.com/syl20bnr/spacemacs/commit/6d42d05bda6b33ce9d8d91e75ab90fa784bc2503) [bot] "built_in_updates" Mon Jan 31 04:15:41 UTC 2022 ([syl20bnr/spacemacs⁠#15301](https://togithub.com/syl20bnr/spacemacs/issues/15301))
* [`a10d2fd8`](https://github.com/syl20bnr/spacemacs/commit/a10d2fd84558c76f0ba681cb55856a813dbea507) Add journalctl-mode to systemd layer ([syl20bnr/spacemacs⁠#15288](https://togithub.com/syl20bnr/spacemacs/issues/15288))
* [`0ba8aa19`](https://github.com/syl20bnr/spacemacs/commit/0ba8aa194a71345542617a2b39439226923448e7) [bot] "documentation_updates" Mon Jan 31 21:49:47 UTC 2022 ([syl20bnr/spacemacs⁠#15303](https://togithub.com/syl20bnr/spacemacs/issues/15303))
