### PR TITLE
niv zsh-completions: update 546fa7e5 -> 298020e4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "546fa7e5bbadafedc1a965456ed9c18a309643a0",
-        "sha256": "0a57v0d5ljvxdzv65w4dy89r0zmrkagbglg32vzwzlsab3qby8g7",
+        "rev": "298020e4e310f0dac5ee1475694a46cff19eccb6",
+        "sha256": "0dps1mlmigm8vkgpavqrdzp61ksps5r7mnjgqxr795ljqr2gysjn",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/546fa7e5bbadafedc1a965456ed9c18a309643a0.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/298020e4e310f0dac5ee1475694a46cff19eccb6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@546fa7e5...298020e4](https://github.com/zsh-users/zsh-completions/compare/546fa7e5bbadafedc1a965456ed9c18a309643a0...298020e4e310f0dac5ee1475694a46cff19eccb6)

* [`f20a81f8`](https://github.com/zsh-users/zsh-completions/commit/f20a81f8130c3373078906fa395771bcd188d5d4) Add (unCamelised) vboxmanage for Linux
* [`c83b6a50`](https://github.com/zsh-users/zsh-completions/commit/c83b6a505b7e1d0a0b5e76c4f93c2177d91a44d9) Add function to list natnetworks
* [`b3469afc`](https://github.com/zsh-users/zsh-completions/commit/b3469afc2434fdd02d40ed1caea2ea17eada87a5) Add initial support for natnetwork subcommand
* [`2c3b218d`](https://github.com/zsh-users/zsh-completions/commit/2c3b218d2491da941c86d00df7ee7e0b6130fcd2) Add list natnets and natnetwork option
* [`40616705`](https://github.com/zsh-users/zsh-completions/commit/406167058b5eb0495e75c5579e5be665cf211557) Add additional PostgreSQL completions for 13+ and reorganize
