### PR TITLE
niv nixpkgs: update e978e3fd -> 215002fb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e978e3fde980e53fd82f3e27e3aa4bc030af964d",
-        "sha256": "1vxq2b0sp56b3w3yr8ws9rijb4ncalb7aym5bjgal9mrg6hcwrhk",
+        "rev": "215002fb9f1fdf96fdb73506225044eb6d5da7ca",
+        "sha256": "0a7d3hm06ka5pi9xyl8flfbc3ss7rv5hzqh22i0yc2zks34n1x0x",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e978e3fde980e53fd82f3e27e3aa4bc030af964d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/215002fb9f1fdf96fdb73506225044eb6d5da7ca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e978e3fd...215002fb](https://github.com/nixos/nixpkgs/compare/e978e3fde980e53fd82f3e27e3aa4bc030af964d...215002fb9f1fdf96fdb73506225044eb6d5da7ca)

* [`f327a0de`](https://github.com/NixOS/nixpkgs/commit/f327a0de158cb2778942c8a212d81109b80d2acd) v2ray-domain-list-community: 20220114024213 -> 20220201175515
* [`a9e24deb`](https://github.com/NixOS/nixpkgs/commit/a9e24deb45dd2c7aba309d193e371cf40e904553) {minetestclient,minetestserver}_4: mark as broken on darwin
* [`56109be3`](https://github.com/NixOS/nixpkgs/commit/56109be38bb159fe5dcb0dc7d8878577c69c9389) nixos/qemu-vm: Create option for virtio-keyboard device
* [`02c97600`](https://github.com/NixOS/nixpkgs/commit/02c976001adfc2ccea0d5a0ef511372342b7dab1) flare: 1.12 -> 1.13
* [`deebff0d`](https://github.com/NixOS/nixpkgs/commit/deebff0d5a6637ee7c2e6dffe005c10b44b451fe) phinger-cursors: fix installPhase
* [`598c791f`](https://github.com/NixOS/nixpkgs/commit/598c791f2c79c3a81921722cfe928ebcfd46f125) Revert "hello: 2.10 -> 2.12" ([nixos/nixpkgs⁠#158328](https://togithub.com/nixos/nixpkgs/issues/158328))
* [`2d01ac63`](https://github.com/NixOS/nixpkgs/commit/2d01ac63452eb645a83bf1f43146d8d012ae324f) step-cli: 0.18.0 -> 0.18.1
* [`995df664`](https://github.com/NixOS/nixpkgs/commit/995df664ec2be66d9d2ade4d0ce9aaf8f49620e4) snallygaster: 0.0.11 -> 0.0.12
* [`3304fc1b`](https://github.com/NixOS/nixpkgs/commit/3304fc1bf2d85cc5b4908ab9aa46efb6d1d5b4b5) python3Packages.androidtv: 0.0.60 -> 0.0.63
* [`2f0ea039`](https://github.com/NixOS/nixpkgs/commit/2f0ea039ff4aec1532d021b9483fd36be95de0c3) python3Packages.asyncssh: 2.8.1 -> 2.9.0
* [`04f02145`](https://github.com/NixOS/nixpkgs/commit/04f02145ad43c18af3578741dd812f05a730e5b1) irssi: switch from tarball to git tag
* [`51d95fc7`](https://github.com/NixOS/nixpkgs/commit/51d95fc72a4d73f0864f1db1dcbdea1a1ecfbfd0) irssi_fish: update for changes made to irssi src
* [`3a8c5edf`](https://github.com/NixOS/nixpkgs/commit/3a8c5edf53be8761b53154b96a09e2aff65950f4) python310Packages.flux-led: 0.28.20 -> 0.28.21
* [`8199da62`](https://github.com/NixOS/nixpkgs/commit/8199da62937a867ea04bad956e799d206a21e47b) coqPackages_8_15.dpdgraph: init at 1.0+8.15
* [`35b89cf3`](https://github.com/NixOS/nixpkgs/commit/35b89cf3ebbfdc0f2e3ec2cb4ee37a6df6cca79f) vulnix: 1.10.0 -> 1.10.1
* [`5dac0d97`](https://github.com/NixOS/nixpkgs/commit/5dac0d9723afa9de038853440daf824bf07aba89) haskell-language-server: disable GHC 9.2.1 by default on aarch64
* [`15e36831`](https://github.com/NixOS/nixpkgs/commit/15e36831c2115a4a4a7cd7ed2bf55b68c1c200bf) collectd-data: we only need collectd.src - not collectd.out
* [`0a6388d7`](https://github.com/NixOS/nixpkgs/commit/0a6388d7b6905a944ec5b7708ef72f3de812b467) nginxModules.geoip2: init at 3.3 ([nixos/nixpkgs⁠#157699](https://togithub.com/nixos/nixpkgs/issues/157699))
* [`15780740`](https://github.com/NixOS/nixpkgs/commit/157807406c96b0dd5f7d2ef8c42bdda75882d5f8) ungoogled-chromium: fix build
* [`d3d6dd80`](https://github.com/NixOS/nixpkgs/commit/d3d6dd802c81875ed3117cd5d1d7cdfbcec74153) btcpayserver: 1.3.7 -> 1.4.3
* [`7ccbd82a`](https://github.com/NixOS/nixpkgs/commit/7ccbd82a4263027f3d06da1223c274243093be2e) connman: update homepage
* [`c0e0b449`](https://github.com/NixOS/nixpkgs/commit/c0e0b44964bf23f6c5d7337d2911ec961a3a99d1) cvs2svn: update homepage
* [`bf36f4be`](https://github.com/NixOS/nixpkgs/commit/bf36f4beb4fd5bc6a8d86cfc53f0e47fe09a0ac0) davix: update homepage
* [`d6716e4e`](https://github.com/NixOS/nixpkgs/commit/d6716e4eeee624ba4e6d2a2d4ce657ee6718eb57) dfasma: update homepage
* [`aa2ed524`](https://github.com/NixOS/nixpkgs/commit/aa2ed524fd5f3d119a87d9301d1b018f569d2aa5) dibbler: update homepage
* [`653a4d4a`](https://github.com/NixOS/nixpkgs/commit/653a4d4a98db26236ed1a0d07227efc5f586e982) sourcehut.dispatchsrht: update homepage
* [`a543246d`](https://github.com/NixOS/nixpkgs/commit/a543246db03f5620d0f1ee0d911f0cf33d568bca) docbook-xsl: update homepage
* [`e77cafcf`](https://github.com/NixOS/nixpkgs/commit/e77cafcf6579a42fcb9918221cb3cef4f28127b1) dspam: update homepage
* [`e4779a33`](https://github.com/NixOS/nixpkgs/commit/e4779a33aa71c8baed9a731495d4059ab8bf195f) duti: update homepage
* [`047ecd37`](https://github.com/NixOS/nixpkgs/commit/047ecd37d3149e3d1475c6aeb889997cc364ba51) dvgrab: update homepage
* [`3e5d286c`](https://github.com/NixOS/nixpkgs/commit/3e5d286cc4f4527ba24efd3d6f60c184a5f734c0) eagle7: update homepage
* [`0b564f44`](https://github.com/NixOS/nixpkgs/commit/0b564f445e3929493581a4878f9c663898efc108) easyloggingpp: update homepage
* [`c0743509`](https://github.com/NixOS/nixpkgs/commit/c0743509884888a1d1d32312fe129e7114e7aed3) egoboo: update homepage
* [`3f0fc168`](https://github.com/NixOS/nixpkgs/commit/3f0fc168a2f5caf962f9c47109ad4380c57dfbbb) eid-mw: update homepage
* [`4b8f68cb`](https://github.com/NixOS/nixpkgs/commit/4b8f68cb7663bd5126d904ebdb7d389cdfcd1dd3) encode-sans: update homepage
* [`39539624`](https://github.com/NixOS/nixpkgs/commit/395396244b3814626f2685219f369301ab22629e) ent: update homepage
* [`3bc8ac63`](https://github.com/NixOS/nixpkgs/commit/3bc8ac631cecb9159aec88221fcc71abca1427cd) eresi: update homepage
* [`b1799448`](https://github.com/NixOS/nixpkgs/commit/b1799448aae93e9cdb859ebea219b8049b7eacc3) eterm: update homepage
* [`34903bee`](https://github.com/NixOS/nixpkgs/commit/34903beee0b971b682e92bd0a37b1b1a53ef1db7) evilpixie: update homepage
* [`a6cfd527`](https://github.com/NixOS/nixpkgs/commit/a6cfd52714212f1e65801bada3e2ae3de176672e) fakeroute: update homepage
* [`85208615`](https://github.com/NixOS/nixpkgs/commit/8520861594c80849a12c54cd43ae5e68b696467d) fcgi: update homepage
* [`f0f803bf`](https://github.com/NixOS/nixpkgs/commit/f0f803bf87df4fef449ac92eb39314dcfa57b9d1) fcgiwrap: update homepage
* [`31683fe5`](https://github.com/NixOS/nixpkgs/commit/31683fe55dc96b0f947e155dd2e0d1efcdb6cd81) fdtools: fixe homepage URL
* [`8b4979c7`](https://github.com/NixOS/nixpkgs/commit/8b4979c7505dc5d7f9c7c16ed689a5c55ee55272) flann: update homepage
* [`31f99332`](https://github.com/NixOS/nixpkgs/commit/31f993329eb3c9624eaf0839abaca8cb9abb5063) fomp: update homepage
* [`ad0c4440`](https://github.com/NixOS/nixpkgs/commit/ad0c4440f2177ce93b85825a0ae9377981170246) cm-unicode: update homepage
* [`e7f66bc3`](https://github.com/NixOS/nixpkgs/commit/e7f66bc3148f7f9066247eed021f8306cfeee482) crimson: update homepage
* [`2d90587f`](https://github.com/NixOS/nixpkgs/commit/2d90587fcfec32d57fd19516bfbc93df3a324e63) dejavu-fonts: update homepage
* [`719c702f`](https://github.com/NixOS/nixpkgs/commit/719c702fa11d155b36aebc513ca60071f8fe4713) ipafont: update homepage and source URLs
* [`b61a3fcb`](https://github.com/NixOS/nixpkgs/commit/b61a3fcbea67447cf53396b477b401e20aa69c57) freedink: update homepage
* [`4bf0c67a`](https://github.com/NixOS/nixpkgs/commit/4bf0c67a8e8b4bbe49420abe2f28d6b4c7da00be) glabels: update homepage
* [`77bd0632`](https://github.com/NixOS/nixpkgs/commit/77bd06325725a2c8ab2b008110783783ff058763) gpt2tc: update homepage
* [`d968838c`](https://github.com/NixOS/nixpkgs/commit/d968838c904ba3e04413b69861b398b1af01bdb2) gravit: update homepage and source URLs
* [`d4b72e98`](https://github.com/NixOS/nixpkgs/commit/d4b72e98039f319a5580cf8d3a82e5360e08d67b) greetd: update homepage
* [`9d292907`](https://github.com/NixOS/nixpkgs/commit/9d292907414d11fcb011a1323981136d3ac5ca59) guile-xcb: update homepage and source
* [`8b850916`](https://github.com/NixOS/nixpkgs/commit/8b85091645467e2903f0a23e2bc1046ba5463669) gwenhywfar: update homepage
* [`7d9826eb`](https://github.com/NixOS/nixpkgs/commit/7d9826eb8b5f760ac390e81978901dadc883abf3) gxmessage: update homepage and source URLs
* [`2ddcc2b3`](https://github.com/NixOS/nixpkgs/commit/2ddcc2b369b93796d2e4c85ba58f626eb7b34d11) hisat2: update homepage
* [`42ac817c`](https://github.com/NixOS/nixpkgs/commit/42ac817c5f954cbbe3ff658ddea5e4036ca74bfa) horst: update homepage
* [`a4ca166b`](https://github.com/NixOS/nixpkgs/commit/a4ca166bb67dd28e9d252f9e5346c58ebceb7d6d) hybridreverb2: update homepage
* [`d2ab0390`](https://github.com/NixOS/nixpkgs/commit/d2ab0390f072991160c43ada4875576c8eaa5bc8) hyperledger-fabric: update homepage
* [`0532c0fc`](https://github.com/NixOS/nixpkgs/commit/0532c0fcd8352f0d88b50dcef9e839669894f833) icewm: update homepage
* [`da27e1dd`](https://github.com/NixOS/nixpkgs/commit/da27e1dd8a89dd88d2aa04cf66d7a6bc2a8be6ac) idnkit: update homepage
* [`4e68d69a`](https://github.com/NixOS/nixpkgs/commit/4e68d69af94234cc164880a0fe14b03c2283c9d5) celt: update homepage
* [`83259c68`](https://github.com/NixOS/nixpkgs/commit/83259c68148ffc8dd60643f2ae8ae02944cd52c6) maintainers: add ameer
* [`36b1dedd`](https://github.com/NixOS/nixpkgs/commit/36b1dedddd1b63d83129856ea52f0208f99c672c) firejail: 0.9.66 -> 0.9.68
* [`6f2cabd8`](https://github.com/NixOS/nixpkgs/commit/6f2cabd82c824a18d8b9f0370fa72733bf64b01f) lookatme: init at 2.3.2
* [`cc73f310`](https://github.com/NixOS/nixpkgs/commit/cc73f310fa7c8949c8270e585a24f265c07e1c74) taskwarrior-tui: 0.13.35 -> 0.18.5
* [`85325234`](https://github.com/NixOS/nixpkgs/commit/85325234ee2da4b30297a3ff23ba111cc659cb7e) fakeroot: 1.23 -> 1.27
* [`b796dfa2`](https://github.com/NixOS/nixpkgs/commit/b796dfa2a6f156afa24c7a00644404bc159aa58f) scrot: drop dependency on giblib
* [`0084254a`](https://github.com/NixOS/nixpkgs/commit/0084254ad147fbf4b2ba0e63746449089117cc8a) python3Packages.pysdl2: 0.9.9 -> 0.9.11
* [`09f582a4`](https://github.com/NixOS/nixpkgs/commit/09f582a45be72105bcf780a2dc28ce7199b39eaf) cargo-spellcheck: 0.9.6 -> 0.10.1
* [`12b90a49`](https://github.com/NixOS/nixpkgs/commit/12b90a49fb708bacc883a839db9d449c8c97813e) nongnu-packages 2022-02-06
* [`88a7c0e3`](https://github.com/NixOS/nixpkgs/commit/88a7c0e327772fbac71e5c67d3fbad6b8709d092) melpa-packages 2022-02-06
* [`8b36faa2`](https://github.com/NixOS/nixpkgs/commit/8b36faa20bc86ec9b278c3ca741b94d7fb8b3271) elpa-packages 2022-02-06
* [`eca8a5d6`](https://github.com/NixOS/nixpkgs/commit/eca8a5d6941626d43e05d73635e915a0d3f482ce) pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix: manual fixup
* [`5cf6b248`](https://github.com/NixOS/nixpkgs/commit/5cf6b24884b2ec82a6adc0be73aeb379ce570f1b) python3Packages.xknx: 0.19.1 -> 0.19.2
* [`fb4e2eaa`](https://github.com/NixOS/nixpkgs/commit/fb4e2eaa057aebdce0918bb7ab21a1ef1193df26) python310Packages.dj-email-url: 1.0.4 -> 1.0.5
* [`6bc3ad97`](https://github.com/NixOS/nixpkgs/commit/6bc3ad97a4e50a7f8e134f32ed84ec07c5a1c41e) python3Packages.asysocks: 0.1.6 -> 0.1.7
* [`2680769a`](https://github.com/NixOS/nixpkgs/commit/2680769ae5e3e64dc752850be71aa57c1436ea1c) python3Packages.soco: 0.26.1 -> 0.26.2
* [`1254665d`](https://github.com/NixOS/nixpkgs/commit/1254665d5abed9702390b2f0cfa7b89cc8638b75) python3Packages.pg8000: 1.23.0 -> 1.24.0
* [`c2e6d4ab`](https://github.com/NixOS/nixpkgs/commit/c2e6d4abf0c42f52fce605b89f9888fd0836513c) python3Packages.minikerberos: 0.2.16 -> 0.2.17
* [`c49d149c`](https://github.com/NixOS/nixpkgs/commit/c49d149c82a5e98779c5e1ea18808e77d13ba339) python3Packages.pywizlight: 0.4.16 -> 0.5
* [`df68f3a7`](https://github.com/NixOS/nixpkgs/commit/df68f3a71e458fb6b1c461d4278554acd8e32ec4) scrot: clean up
* [`3302c41f`](https://github.com/NixOS/nixpkgs/commit/3302c41f7f3104042b53393630d0b8577fbb5bd5) haskell-language-server: Disable flaky tests for some plugins
* [`6afd9574`](https://github.com/NixOS/nixpkgs/commit/6afd95743ef045bf5d5a22bc62ce13bdbc6131b3) picom: 8.2 -> 9
* [`4a07f242`](https://github.com/NixOS/nixpkgs/commit/4a07f24237fc3ac627d8bc7b230537c9440f7840) picom-next: unstable-2021-11-19 -> unstable-2022-02-05
* [`c53d2b9c`](https://github.com/NixOS/nixpkgs/commit/c53d2b9c3ee491bfbbf70eaa784c74a7ec046e7d) tauon: 6.7.1 -> 7.0.1
* [`a52aae68`](https://github.com/NixOS/nixpkgs/commit/a52aae6868d4a1d1e5447aa45de6562bfc71b903) tauon: install desktop file and icon
* [`4ec7d050`](https://github.com/NixOS/nixpkgs/commit/4ec7d05099f639e8370ed3506d1a7b17af1ceb6b) google-chrome: passthrough CHROME_WRAPPER environment variable
* [`974f984e`](https://github.com/NixOS/nixpkgs/commit/974f984e56c18b55aca55a6609c69684a6cee330) python3Packages.oscrypto: disable tests on darwin
* [`5facd430`](https://github.com/NixOS/nixpkgs/commit/5facd430d4aedae75f8c4027fa62624225b9e752) slack: aarch64 darwin support and updater
* [`dc28299c`](https://github.com/NixOS/nixpkgs/commit/dc28299c85b35b1ef3a45cb1222dc5fc93a3bad7) irssi: enable parallel building
* [`c7e17313`](https://github.com/NixOS/nixpkgs/commit/c7e17313e155ea544b80ae6ca41988f8fd93718f) python3Packages.intellifire4py: 0.5 -> 0.7.3
* [`6ea5380b`](https://github.com/NixOS/nixpkgs/commit/6ea5380b4eff908f3b2a3eff1dc98f74ff45f1da) mpris-scrobbler: mark as broken on darwin
* [`03c27d12`](https://github.com/NixOS/nixpkgs/commit/03c27d129e48476f0d14943d77efaacf40331f1c) python3Packages.pytradfri: 8.0.1 -> 9.0.0
* [`6308679d`](https://github.com/NixOS/nixpkgs/commit/6308679d28886b8c0d0377b4227a012ca4ca6fdc) ocamlPackages.cairo2: fix build on aarch64-darwin
* [`97f809dc`](https://github.com/NixOS/nixpkgs/commit/97f809dc87f74ef51e4f0482328f7db617db91ef) nixos/ipfs: use ipfs config replace
* [`814b63e9`](https://github.com/NixOS/nixpkgs/commit/814b63e93e2aac4e9f4116735fb290bad4756ed8) treewide: rename name to pname&version
* [`7b937e91`](https://github.com/NixOS/nixpkgs/commit/7b937e9152989c6f6e8c7a44f014cbc84aed640f) rxvt-unicode-emoji: init as variant of rxvt-unicode, with wide glyph (emoji) support
* [`9dcf20f2`](https://github.com/NixOS/nixpkgs/commit/9dcf20f284561d15869f4fb786a58fc8cfde2db7) flutter: 2.8.0 -> 2.10.0
* [`6ad0e10d`](https://github.com/NixOS/nixpkgs/commit/6ad0e10dd350c8ffd1fd35d787f5b5dce95e59f5) coq: add meta.mainProgram
* [`c0217caf`](https://github.com/NixOS/nixpkgs/commit/c0217caf80718e770cb1ec2fc1f9c4bc4c159158) cl-wordle: init at 0.1.2
* [`7ebca5e8`](https://github.com/NixOS/nixpkgs/commit/7ebca5e87ba29e18026e9cfca1c58c66e3c620aa) haskellPackages: mark builds failing on hydra as broken
* [`9334f6f1`](https://github.com/NixOS/nixpkgs/commit/9334f6f1daf88663f4e3d69bb876649abc513dfd) haskellPackages: mark builds failing on hydra as broken
* [`2cddc19d`](https://github.com/NixOS/nixpkgs/commit/2cddc19d39b0ff4d90d511230cd28c28525ab9b1) Revert "python310Packages.oslo-context: 3.4.0 -> 4.0.0"
* [`71f2b10b`](https://github.com/NixOS/nixpkgs/commit/71f2b10b6fba723c33affd1bb9b615b7e1f348df) python39Packages.python-manilaclient: 3.1.0 -> 3.2.0
* [`fd6d3683`](https://github.com/NixOS/nixpkgs/commit/fd6d3683317012d5fdf69df46e3e2d0db841fd51) yq-go: 4.18.1 -> 4.19.1
* [`4469918d`](https://github.com/NixOS/nixpkgs/commit/4469918dffbdbe0d326de7af7df18367802b25ac) dnscontrol: 3.13.1 -> 3.14.0
* [`b8b1f359`](https://github.com/NixOS/nixpkgs/commit/b8b1f35977c0d1a7a205d6aa6b575fd2e00d03f7) python3Packages.plugwise: 0.16.1 -> 0.16.2
* [`98e91ccc`](https://github.com/NixOS/nixpkgs/commit/98e91ccc56ebb9b80026a875aefe90823e211b38) python3Packages.asyncio-dgram: 2.1.1 -> 2.1.2
* [`0764d56e`](https://github.com/NixOS/nixpkgs/commit/0764d56ef309995921bfc9f1bb3b91a4d50bbd22) deis: remove
* [`48b409d8`](https://github.com/NixOS/nixpkgs/commit/48b409d8e2b6339edb655a01ebfee5edd0d948f0) deisctl: remove
* [`cea0fa3f`](https://github.com/NixOS/nixpkgs/commit/cea0fa3f7d1037f9c43c8547fce20d0f2d570566) encryptr: remove
* [`1d5453ca`](https://github.com/NixOS/nixpkgs/commit/1d5453ca8ccbdf2d30749d3c68c2cb92fe94031e) gpgstats: remove
* [`c1ef1d8f`](https://github.com/NixOS/nixpkgs/commit/c1ef1d8f9b1ec61bbdc353b7a5458e9d546a6587) idrisPackages.protobuf: remove
* [`82da8aaa`](https://github.com/NixOS/nixpkgs/commit/82da8aaa53481a202158e357fbfab0c1c4260956) heme: remove
* [`f57aa479`](https://github.com/NixOS/nixpkgs/commit/f57aa4795c2d63d178fe9cf5e664cd655d47ceba) iops: remove
* [`017c4d20`](https://github.com/NixOS/nixpkgs/commit/017c4d207c7f4149f8b631e0f0d6760295d0b8e8) gwtdragdrop: remove
* [`aa2654f9`](https://github.com/NixOS/nixpkgs/commit/aa2654f9dfb2413558e3550978c84bc478b8c912) gwtwidgets: remove
* [`64b39305`](https://github.com/NixOS/nixpkgs/commit/64b39305ae26c269c9afcd17dd1463605878dbfe) prometheus-redis-exporter: 1.34.1 -> 1.35.0
* [`495b80ea`](https://github.com/NixOS/nixpkgs/commit/495b80ea2c2d41e6820cc5c6239a3d7cc43ed84d) wordpress: 5.8.3 -> 5.9
* [`e538c3a5`](https://github.com/NixOS/nixpkgs/commit/e538c3a50f20e23a111d6e27e6e0db7fecafe8a7) rpi-imager: 1.6.2 -> 1.7.1
* [`bb2db452`](https://github.com/NixOS/nixpkgs/commit/bb2db4526ebebbf7c2e6613d7c5de00e98d7c105) python39Packages.gehomesdk: 0.4.22 -> 0.4.23
* [`b6e19348`](https://github.com/NixOS/nixpkgs/commit/b6e193485a42cf1cbeb8b1776130c234df65f6ce) python310Packages.scikit-fmm: 2021.10.29 -> 2022.2.2
* [`6589dec4`](https://github.com/NixOS/nixpkgs/commit/6589dec4588181f795c898055af073a51596b7af) python310Packages.vispy: 0.9.4 -> 0.9.6
* [`963cb6d9`](https://github.com/NixOS/nixpkgs/commit/963cb6d9e53db57f5ea5d82ae58b7ca81a699223) rss-bridge: 2021-04-25 -> 2022-01-20
* [`b950e4af`](https://github.com/NixOS/nixpkgs/commit/b950e4afa22b77f15aae24474a4dfd58985ecd20) sope: 5.5.0 -> 5.5.1
* [`cf55578b`](https://github.com/NixOS/nixpkgs/commit/cf55578b76572dd26a2bbbedcf8def7a73946dbe) libsForQt5.bismuth: 2.2.0 -> 2.3.0
* [`42511893`](https://github.com/NixOS/nixpkgs/commit/4251189327aaaa8733dfce6cd40544531f918c26) lite-xl: 2.0.4 -> 2.0.5
* [`d8014394`](https://github.com/NixOS/nixpkgs/commit/d80143948014db283042a902e26ee18029f2b897) croc: 9.5.0 -> 9.5.1
* [`4d99d069`](https://github.com/NixOS/nixpkgs/commit/4d99d0694d86905646aa38ebd7675ddc05ee6216) vivaldi: 5.0.2497.32-1 -> 5.0.2497.51-1
* [`412a82d0`](https://github.com/NixOS/nixpkgs/commit/412a82d048028681f64d72ec492c13fb60d387ac) python3Packages.garminconnect-ha: add format
* [`915c27b7`](https://github.com/NixOS/nixpkgs/commit/915c27b71b771ae41715198dca801c1eb6088862) python3Packages.garminconnect: rename
* [`08f41c95`](https://github.com/NixOS/nixpkgs/commit/08f41c95f255e01c3dfe46d493b81af04560ed68) python3Packages.garminconnect: 0.1.13 -> 0.1.44
* [`f1c18916`](https://github.com/NixOS/nixpkgs/commit/f1c18916780890496056cf7eb2df7a0097673908) python3Packages.garminconnect-aio: disable on older Python releases
* [`08e32304`](https://github.com/NixOS/nixpkgs/commit/08e32304d7b9a9e974560d63b18d4c3e878029e0) python310Packages.sagemaker: 2.74.0 -> 2.75.0
* [`70791bb1`](https://github.com/NixOS/nixpkgs/commit/70791bb1009114158b9fc658421ac9f61d64d24e) dvdisaster: 0.79.5 -> 0.79.9
* [`66ca0558`](https://github.com/NixOS/nixpkgs/commit/66ca0558df814b421fa1df5a76f4044a98700ef5) afterburn: 5.1.0 -> 5.2.0
* [`743ea6e7`](https://github.com/NixOS/nixpkgs/commit/743ea6e70dc2cfc6cc4d4428e91cd3b5ae4820ac) river: 0.1.2 -> 0.1.3
* [`215002fb`](https://github.com/NixOS/nixpkgs/commit/215002fb9f1fdf96fdb73506225044eb6d5da7ca) terraform-providers: update scripts
