### PR TITLE
niv nixpkgs: update 215002fb -> 0a5da457

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "215002fb9f1fdf96fdb73506225044eb6d5da7ca",
-        "sha256": "0a7d3hm06ka5pi9xyl8flfbc3ss7rv5hzqh22i0yc2zks34n1x0x",
+        "rev": "0a5da457e98508fb20465723e5d1f34bd02bb5e1",
+        "sha256": "1xbswg6q7ynp4zlb34inb0fj3r29n9h7926s90sdxrxwc37d539h",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/215002fb9f1fdf96fdb73506225044eb6d5da7ca.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/0a5da457e98508fb20465723e5d1f34bd02bb5e1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@215002fb...0a5da457](https://github.com/nixos/nixpkgs/compare/215002fb9f1fdf96fdb73506225044eb6d5da7ca...0a5da457e98508fb20465723e5d1f34bd02bb5e1)

* [`30869efa`](https://github.com/NixOS/nixpkgs/commit/30869efa4fcf1120d84330dd48f48f1bc51f3c26) dotenv-linter: 3.1.1 -> 3.2.0
* [`49d1366f`](https://github.com/NixOS/nixpkgs/commit/49d1366f43564848787104ecbe38b995da71d73c) flannel: 0.16.1 -> 0.16.3
* [`d9979c18`](https://github.com/NixOS/nixpkgs/commit/d9979c182c3596e7c120e4a8d3d0e270e1c8cac2) sentry-native: 0.4.14 -> 0.4.15
* [`5c38d3cd`](https://github.com/NixOS/nixpkgs/commit/5c38d3cd07970ab907d3e5c8eb297c9b9e6bf59d) dbmate: 1.13.0 -> 1.14.0
* [`353338bf`](https://github.com/NixOS/nixpkgs/commit/353338bfb046a04f64f3dd268276e6cacaf24c33) coredns: 1.8.6 -> 1.9.0
* [`80cc9a02`](https://github.com/NixOS/nixpkgs/commit/80cc9a02bde6887f37729f2896c34f3a28ef24a4) python310Packages.databricks-connect: 9.1.8 -> 9.1.9
* [`bdc257a4`](https://github.com/NixOS/nixpkgs/commit/bdc257a47c49de65b115215172677403060606f6) dcw-gmt: 2.0.2 -> 2.1.0
* [`f53437ff`](https://github.com/NixOS/nixpkgs/commit/f53437fff4a3281ed568033c839f6272e245a9d5) direvent: 5.2 -> 5.3
* [`d49f63a4`](https://github.com/NixOS/nixpkgs/commit/d49f63a464f40086599c64a421ce6d48c25c5401) chaos: 0.1.9 -> 0.2.0
* [`38d0462b`](https://github.com/NixOS/nixpkgs/commit/38d0462bb26ce3c3721a6ee5f4cc48adfb89072c) python310Packages.pex: 2.1.62 -> 2.1.65
* [`16ac86db`](https://github.com/NixOS/nixpkgs/commit/16ac86db99002c25c90346c54e2368f9717c6061) ccid: 1.4.36 -> 1.5.0
* [`7d8026b7`](https://github.com/NixOS/nixpkgs/commit/7d8026b72a926a360b3eec1bfccc9b96ed1c3168) duckdb: 0.3.1 -> 0.3.2
* [`ad205764`](https://github.com/NixOS/nixpkgs/commit/ad205764e8083bab292b8dfce3c0eb974a771db9) byacc: 20211224 -> 20220128
* [`19d0256e`](https://github.com/NixOS/nixpkgs/commit/19d0256e61a7b209410cc05984d3cc4c2c44e67b) checkSSLCert: 2.19.0 -> 2.20.0
* [`396db0e1`](https://github.com/NixOS/nixpkgs/commit/396db0e1146cf9f8608829be71be3da6ccc1e930) clightd: 5.5 -> 5.6
* [`d9eef99d`](https://github.com/NixOS/nixpkgs/commit/d9eef99ddd8a4ebd035e59547b0c6c0ed76b9116) cilium-cli: 0.9.3 -> 0.10.2
* [`488122be`](https://github.com/NixOS/nixpkgs/commit/488122be9f8f2cb3ef97b190cd23019989e7bc97) bitwig-studio: 4.1.2 -> 4.1.6
* [`db898160`](https://github.com/NixOS/nixpkgs/commit/db8981606c02e1aafd1810edfcadfbbe3347d7fa) dt-schema: 2021.10 -> 2022.1
* [`8b7773a3`](https://github.com/NixOS/nixpkgs/commit/8b7773a343be6e625482d8ce1c1aa9c0b329868e) domoticz: 2021.1 -> 2022.1
* [`92cf8c24`](https://github.com/NixOS/nixpkgs/commit/92cf8c24b4769210ecaa4ac4498ca36435c99d4c) cups-filters: 1.28.10 -> 1.28.11
* [`36fe673c`](https://github.com/NixOS/nixpkgs/commit/36fe673cbdd68b8ef3a9efc9411306125db6c1ba) bzrtp: 5.0.55 -> 5.1.0
* [`d31255bb`](https://github.com/NixOS/nixpkgs/commit/d31255bbc5c63c5e30663bd24c71de29c3fd5e2b) chessx: 1.5.6 -> 1.5.7
* [`68ea939b`](https://github.com/NixOS/nixpkgs/commit/68ea939b35cbb17544c259c3b5877a8aa6ba75d7) skaffold: 1.35.2 -> 1.36.0
* [`6d6c6680`](https://github.com/NixOS/nixpkgs/commit/6d6c668043e47ff7588f81969f0f64c5ecac0618) cloud-sql-proxy: 1.28.0 -> 1.28.1
* [`28f04545`](https://github.com/NixOS/nixpkgs/commit/28f045457e72a2ed87f26377f2b498f39f851e82) cflow: 1.6 -> 1.7
* [`f37c5d40`](https://github.com/NixOS/nixpkgs/commit/f37c5d405f4e15041a76b3dcd35f64fd358f084d) boofuzz: 0.4.0 -> 0.4.1
* [`c78ff3d9`](https://github.com/NixOS/nixpkgs/commit/c78ff3d9454c19109b87d0fae598556eac285a56) aws-vault: 6.4.0 -> 6.5.0
* [`f8270628`](https://github.com/NixOS/nixpkgs/commit/f8270628702fea0e1d352f504bc75d2ebaf84476) b3sum: 1.3.0 -> 1.3.1
* [`77851adc`](https://github.com/NixOS/nixpkgs/commit/77851adcd86bf2cf895a0ac22673be53185a3313) aescrypt: 3.14 -> 3.16
* [`4bc77d37`](https://github.com/NixOS/nixpkgs/commit/4bc77d37bccafb7977966caef2d4bb3926d2641e) postgresql11Packages.plpgsql_check: 2.1.0 -> 2.1.2
* [`df066e9f`](https://github.com/NixOS/nixpkgs/commit/df066e9f060449372ad0edd3941d47b132c32f59) prometheus-bird-exporter: 1.2.6 -> 1.4.0
* [`2897904f`](https://github.com/NixOS/nixpkgs/commit/2897904fc5f60cdedba9253b1449f849035a2c45) atlassian-jira: 8.20.1 -> 8.21.0
* [`850b12b9`](https://github.com/NixOS/nixpkgs/commit/850b12b9d6b03bcf0fb9cc0eb1648116c7377e7c) air: 1.27.9 -> 1.27.10
* [`44d82e22`](https://github.com/NixOS/nixpkgs/commit/44d82e22114e8f78b36ab9b0765f05cc2d90b365) argo: 3.2.6 -> 3.2.8
* [`10bc3991`](https://github.com/NixOS/nixpkgs/commit/10bc3991c28410f2e31c1e08d1e0d6f8ef8e1948) argocd: 2.2.3 -> 2.2.5
* [`3f24923b`](https://github.com/NixOS/nixpkgs/commit/3f24923ba5cf5a75900cf1487c3ac335ea287819) argocd: update gitCommit
* [`4c3ec647`](https://github.com/NixOS/nixpkgs/commit/4c3ec647645939fa5662ac8f90d32c03c5b27c08) jitsi-meet: 1.0.5675 -> 1.0.5818
* [`2220d355`](https://github.com/NixOS/nixpkgs/commit/2220d35562e7269fb36bcb4a3634e6626c38309b) bada-bib: 0.3.0 -> 0.4.1
* [`3b28856f`](https://github.com/NixOS/nixpkgs/commit/3b28856f08aad1b7a222e9ccfdc79a7f3e32883e) aws-nuke: 2.16.0 -> 2.17.0
* [`8184cdaf`](https://github.com/NixOS/nixpkgs/commit/8184cdaf46cd936279f832d37fbb74c5f328dedd) tailscale: 1.20.3 -> 1.20.4
* [`4d99f83f`](https://github.com/NixOS/nixpkgs/commit/4d99f83f1f6e9fbdaeb489bfe32ea90442ef55fc) jibri: 8.0-114-g20e233e -> 8.0-93-g51fe7a2
* [`4ea58428`](https://github.com/NixOS/nixpkgs/commit/4ea58428a9353565e16574fefca05f4193fd2874) gitRepo: 2.20 -> 2.21
* [`2762b480`](https://github.com/NixOS/nixpkgs/commit/2762b480f9da1ac20b0deebbd42ac38f2de3299e) python310Packages.pyopencl: 2021.2.11 -> 2022.1
* [`0025dce4`](https://github.com/NixOS/nixpkgs/commit/0025dce444f2f8fdfff6c6ca6b9cc9cb06f6688e) zanshin: 21.12.1 -> 21.12.2
* [`dc1c4360`](https://github.com/NixOS/nixpkgs/commit/dc1c43605143227a2c12f712d9cfe0ff12a04146) python310Packages.treq: 22.1.0 -> 22.2.0
* [`1e33ab33`](https://github.com/NixOS/nixpkgs/commit/1e33ab339591ea5b21f15760488fe1f1ec3855d3) spotdl: 3.9.2 -> 3.9.3
* [`a50206c7`](https://github.com/NixOS/nixpkgs/commit/a50206c71f9d261f32260d78bf5ae321d915a3ea) python310Packages.cachelib: 0.5.0 -> 0.6.0
* [`585db988`](https://github.com/NixOS/nixpkgs/commit/585db9884671f3dd859c1d486ea89c410b4b54a9) mkgmap: 4855 -> 4895
* [`9b0c8a9d`](https://github.com/NixOS/nixpkgs/commit/9b0c8a9d06c2228110853eea7e6805e0a5a9d469) dpic: 2021.01.01 -> 2021.11.01
* [`1c7afde3`](https://github.com/NixOS/nixpkgs/commit/1c7afde31c4d1e9c53934ce14cda9678d6419d31) python310Packages.mypy-boto3-s3: 1.20.35.post1 -> 1.20.49
* [`1738bb6d`](https://github.com/NixOS/nixpkgs/commit/1738bb6d5dbe0b84c457cd4997d3984f6feb53c3) spaceship-prompt: 3.15.0 -> 3.16.2
* [`5a3e7f68`](https://github.com/NixOS/nixpkgs/commit/5a3e7f68b8d796e96b73045ec4543af795f81bf5) gtkmm4: 4.4.0 -> 4.6.0
* [`245712db`](https://github.com/NixOS/nixpkgs/commit/245712db48dbbb432256d49a4da174c8400cd10b) ddcui: 0.2.0 -> 0.2.1
* [`8b41152e`](https://github.com/NixOS/nixpkgs/commit/8b41152e66f7142604e9800072e6d5a8c1fdec92) dprint: 0.19.2 -> 0.22.0
* [`37b3d101`](https://github.com/NixOS/nixpkgs/commit/37b3d10157b7ee5468c1de9b38b74b8df6dbd033) kak-lsp: 11.1.0 -> 12.0.1
* [`549e0ca3`](https://github.com/NixOS/nixpkgs/commit/549e0ca34e71dbaa307adfcad7e57d69b1c73edb) spago: 0.20.5 -> 0.20.7
* [`8ddadffb`](https://github.com/NixOS/nixpkgs/commit/8ddadffbd068de20d044ecc1fc8d468b48a75712) srain: 1.3.1 -> 1.3.2
* [`654781cb`](https://github.com/NixOS/nixpkgs/commit/654781cb74ee31ecb9c915767bb01cf46048d4cc) python310Packages.phonopy: 2.12.0 -> 2.13.1
* [`22e325f7`](https://github.com/NixOS/nixpkgs/commit/22e325f795c65345b773dc2c658e91eebb1f8805) sshportal: 1.18.5 -> 1.19.3
* [`440151e3`](https://github.com/NixOS/nixpkgs/commit/440151e3459d3df37063e3055e52f44e4b354b76) python310Packages.heatzypy: 2.0.2 -> 2.0.4
* [`32a7f9da`](https://github.com/NixOS/nixpkgs/commit/32a7f9da13f463a2d51d1909095815d657619dea) prometheus-statsd-exporter: 0.20.2 -> 0.22.2
* [`b673f46b`](https://github.com/NixOS/nixpkgs/commit/b673f46bce871172e9038d9e86789e69a017c983) stilo-themes: 3.38-1 -> 4.0
* [`de68f80a`](https://github.com/NixOS/nixpkgs/commit/de68f80a9a76fb79c29d1eceb168c02bea69c914) stripe-cli: 1.7.11 -> 1.7.12
* [`c3d43d2f`](https://github.com/NixOS/nixpkgs/commit/c3d43d2fab38f33e230b27c091078f2894f2420f) mutt: 2.1.5 -> 2.2.0
* [`ddab7df5`](https://github.com/NixOS/nixpkgs/commit/ddab7df5818da1ab0679b45c93ddcdd20bb1d548) svlint: 0.4.18 -> 0.5.1
* [`9884dc9e`](https://github.com/NixOS/nixpkgs/commit/9884dc9e42ac7df24800cce16a4d175f4b890004) qownnotes: 22.2.2 -> 22.2.4
* [`137e383b`](https://github.com/NixOS/nixpkgs/commit/137e383b55a9b1301f12abd8636964966c6e7f08) python310Packages.protego: 0.1.16 -> 0.2.0
* [`e1cdf09d`](https://github.com/NixOS/nixpkgs/commit/e1cdf09dc77a55556392011dc26a8760493c25d6) symfony-cli: 5.3.3 -> 5.3.4
* [`a395bc3e`](https://github.com/NixOS/nixpkgs/commit/a395bc3e59c95b21360ddb1dc48209ff634e16c2) ocamlPackages.luv: 0.5.10 -> 0.5.11
* [`cc9a711f`](https://github.com/NixOS/nixpkgs/commit/cc9a711f5aac346d1b52738759b9100e7f3d92ec) python3Packages.weconnect: 0.36.3 -> 0.36.4
* [`4f181963`](https://github.com/NixOS/nixpkgs/commit/4f1819638390f42d57c9ca4dbf16fd265b379e7a) python3Packages.weconnect-mqtt: 0.29.0 -> 0.29.1
* [`a668f0e2`](https://github.com/NixOS/nixpkgs/commit/a668f0e26f40ad3f765826cf11c1d73e0fb4edf5) python310Packages.packageurl-python: 0.9.7 -> 0.9.8.1
* [`4eb39a02`](https://github.com/NixOS/nixpkgs/commit/4eb39a02da0671817a2619f0b5c269738af83da2) tiled: 1.8.0 -> 1.8.1
* [`c27ec6b5`](https://github.com/NixOS/nixpkgs/commit/c27ec6b5aea117c073293ed4894485a6b91a3fb8) python3Packages.aioswitcher: 2.0.7 -> 2.0.8
* [`c867f79a`](https://github.com/NixOS/nixpkgs/commit/c867f79aed521bc4e610f8ca2e852004ca044f44) tilt: 0.24.1 -> 0.25.0
* [`b7229541`](https://github.com/NixOS/nixpkgs/commit/b7229541c621ee57d05a47b736c4d6ae2a187b3f) tiv: 1.1.0 -> 1.1.1
* [`4dc53079`](https://github.com/NixOS/nixpkgs/commit/4dc53079b33c51f2c9b2dd25f6d349c6b73a957c) traefik-certs-dumper: 2.7.4 -> 2.8.1
* [`91a7fe07`](https://github.com/NixOS/nixpkgs/commit/91a7fe0783686189a031a7961a829bbb20d3ba5d) python310Packages.pypinyin: 0.45.0 -> 0.46.0
* [`3507b350`](https://github.com/NixOS/nixpkgs/commit/3507b350065e6e25e769a153f8a0b16c694f472e) wine{Unstable,Staging}: 7.1 -> 7.2
* [`1e96e20e`](https://github.com/NixOS/nixpkgs/commit/1e96e20eb871480ef5d2f8cec6ec0fb2a8018bf8) python39Packages.ignite: 0.4.7 -> 0.4.8
* [`423dd394`](https://github.com/NixOS/nixpkgs/commit/423dd394153f467497fc8d80a48ce5f8a00aeb85) python310Packages.pydal: 20220114.1 -> 20220213.2
* [`54679d94`](https://github.com/NixOS/nixpkgs/commit/54679d94a3e7046759fd960d7be8be2810aaaaae) tt-rss-theme-feedly: 2.8.2 -> 2.9.1
* [`ca4c2693`](https://github.com/NixOS/nixpkgs/commit/ca4c2693bc77540b487c36181a585b532a86e9f3) tytools: 0.9.3 -> 0.9.7
* [`92f6a18c`](https://github.com/NixOS/nixpkgs/commit/92f6a18c9f0f1c45d89a068906ea37b0aed63e15) unciv: 3.15.9 -> 3.19.7
* [`54f8f15c`](https://github.com/NixOS/nixpkgs/commit/54f8f15c3f387c7563b4039e9deebf1dfca8bc01) python310Packages.google-cloud-container: 2.10.1 -> 2.10.3
* [`3848550b`](https://github.com/NixOS/nixpkgs/commit/3848550bc3a6a35baeb5c5b9623156c0034844d2) zsh-autocomplete: 21.09.22 -> 22.01.21
* [`3c2ff723`](https://github.com/NixOS/nixpkgs/commit/3c2ff723de9fe44ea98dc7630d80caa0af7d96aa) n8n: 0.162.0 -> 0.163.0
* [`1555480a`](https://github.com/NixOS/nixpkgs/commit/1555480a4a66661d35f87a41706a438552305fc1) v2ray-geoip: 202202030030 -> 202202100032
* [`e99a955d`](https://github.com/NixOS/nixpkgs/commit/e99a955d2d310b63f253173699f638484cc8c3e3) lbry: 0.52.0 -> 0.52.2
* [`cb8b6ea4`](https://github.com/NixOS/nixpkgs/commit/cb8b6ea473ef18a6b2768d3da19048c3d1cd19d3) wakatime: 1.18.7 -> 1.35.4
* [`08a3f8b1`](https://github.com/NixOS/nixpkgs/commit/08a3f8b13d7c837f42b6f92f6373533be658b767) vazir-fonts: 22.1.0 -> 30.1.0
* [`a573c1f7`](https://github.com/NixOS/nixpkgs/commit/a573c1f7f02b92af2fc68516e06c6147b2b6a7b4) your-editor: 1303 -> 1400
* [`8ea199eb`](https://github.com/NixOS/nixpkgs/commit/8ea199eb8c11bd389c8ab41bdf555e1d41620d34) postman: 9.7.1 -> 9.13.0
* [`d44cff05`](https://github.com/NixOS/nixpkgs/commit/d44cff052953418fdc97d723cd29d6c952f6e2e7) ytt: 0.36.0 -> 0.39.0
* [`488019c4`](https://github.com/NixOS/nixpkgs/commit/488019c4e652b080bd94476dd84377118e9ddf63) z-lua: 1.8.13 -> 1.8.14
* [`f975ee02`](https://github.com/NixOS/nixpkgs/commit/f975ee023359aa524389b9d4e7029d7b0cce1bad) tts: pin librosa at 0.8.1
* [`cd356ef8`](https://github.com/NixOS/nixpkgs/commit/cd356ef87219151145eac938880d8e2355e09758) terraform-providers.bitbucket: reintroduce ([nixos/nixpkgs⁠#159374](https://togithub.com/nixos/nixpkgs/issues/159374))
* [`23576387`](https://github.com/NixOS/nixpkgs/commit/235763873c4a674336f426e709735fb0944aa654) php74Packages.php-cs-fixer: 3.4.0 -> 3.6.0
* [`c3475bc0`](https://github.com/NixOS/nixpkgs/commit/c3475bc0b93b3a4ef4e694af036136f3cddcb928) apt-offline: unstable-2022-02-06 -> 1.8.4
* [`56ff38a1`](https://github.com/NixOS/nixpkgs/commit/56ff38a1695659cac5bb532c96c865fccafe9d8f) qsstv: 9.4.4 -> 9.5.8
* [`c2bbdf4e`](https://github.com/NixOS/nixpkgs/commit/c2bbdf4e67249032f6aed3a1fa86dc633c960d93) bitwarden: 1.31.1 -> 1.31.2
* [`c22dfd85`](https://github.com/NixOS/nixpkgs/commit/c22dfd85d2d7b34f6b6a9d489873421f386542bb) btop: 1.2.1 -> 1.2.2
* [`5fd5c866`](https://github.com/NixOS/nixpkgs/commit/5fd5c86643bc0bed90e9df87b95bd98df716fe3d) tcpreplay: 4.4.0 -> 4.4.1
* [`de8a7645`](https://github.com/NixOS/nixpkgs/commit/de8a764559cf56bbedd16fa443ca1756c964946f) yamale: 4.0.2 -> 4.0.3
* [`8102e35e`](https://github.com/NixOS/nixpkgs/commit/8102e35ed5bb178c78f72ff376df8c4a8b94adba) python310Packages.sense-energy: 0.10.0 -> 0.10.1
* [`1cb2d4c1`](https://github.com/NixOS/nixpkgs/commit/1cb2d4c19f5948e10041c8af77f4c439cfc53445) alejandra: unstable-2022-02-10 -> unstable 2022-02-12
* [`8bd4ebee`](https://github.com/NixOS/nixpkgs/commit/8bd4ebee3289ad387903d38828bd6f12edbc7210) vscode-extensions.kamadorueda.alejandra: init at 1.0.0
* [`a69e3a8f`](https://github.com/NixOS/nixpkgs/commit/a69e3a8fa9128c1af54bf7653b531eabacbb5f8c) python310Packages.canopen: 1.2.1 -> 2.0.0
* [`79953e76`](https://github.com/NixOS/nixpkgs/commit/79953e76a02233bd5c723e91eec29fe108fe86f3) python3Packages.canopen: limit to later Python releases
* [`68b71c54`](https://github.com/NixOS/nixpkgs/commit/68b71c5485246035504711d72147d5782135e2a5) python310Packages.jupytext: 1.13.6 -> 1.13.7
* [`48fb9875`](https://github.com/NixOS/nixpkgs/commit/48fb9875ca27f14d0ec79376fe955f1c83d17dcd) log4j-sniffer: 1.6.0 -> 1.8.0
* [`116facd4`](https://github.com/NixOS/nixpkgs/commit/116facd4b47a9406c34125f0abe74035133e0637) masterpdfeditor: 5.8.20 -> 5.8.33
* [`0cca3ab3`](https://github.com/NixOS/nixpkgs/commit/0cca3ab3f62b0876dea84a0b416a64815105e3a0) mrtg: 2.17.8 -> 2.17.10
* [`864919a9`](https://github.com/NixOS/nixpkgs/commit/864919a9b958fe47385db6dadf994887a4de0265) mackerel-agent: 0.72.3 -> 0.72.7
* [`f56f0a68`](https://github.com/NixOS/nixpkgs/commit/f56f0a68c634d83cbc1a7223495fa123c439f1f3) tartube: 2.3.332 -> 2.3.367
* [`640b3cb1`](https://github.com/NixOS/nixpkgs/commit/640b3cb122f0418391ba89616ba3ca6aa7e5b5de) mtdutils: 2.1.3 -> 2.1.4
* [`4c62413a`](https://github.com/NixOS/nixpkgs/commit/4c62413a4906ef3b2808d7f29f7f2e4db5c08b58) monit: 5.29.0 -> 5.30.0
* [`738944fd`](https://github.com/NixOS/nixpkgs/commit/738944fd5fbd643b66e51960539f4eda640b044b) mongodb-tools: 100.5.1 -> 100.5.2
* [`838c1a01`](https://github.com/NixOS/nixpkgs/commit/838c1a01a5c44c5c62e027d8948c59599552dafb) macchina: 6.0.5 -> 6.0.6
* [`fff5d485`](https://github.com/NixOS/nixpkgs/commit/fff5d485eee4e126e745e75abac0cb85eabbe020) lagrange: 1.10.4 -> 1.10.5
* [`a0167e41`](https://github.com/NixOS/nixpkgs/commit/a0167e41e373123270a88ce1509c7ffef3cea0f6) python3Packages.matrix-nio: 0.18.7 -> 0.19.0
* [`b0b9b924`](https://github.com/NixOS/nixpkgs/commit/b0b9b9241c6e3690580334fba43fd8d3f9c4b22d) pantalaimon: 0.10.2 -> 0.10.4
* [`b80f5c61`](https://github.com/NixOS/nixpkgs/commit/b80f5c61045dcddbebab370fd030b540a0d17809) mixxx: 2.3.1 -> 2.3.2
* [`2fedc3c8`](https://github.com/NixOS/nixpkgs/commit/2fedc3c89d77954ad8b2f427486d37b561a82fde) dolt: 0.36.1 -> 0.36.2
* [`bb2997cc`](https://github.com/NixOS/nixpkgs/commit/bb2997cc01ea60ade4ae9e55462755e8d833da10) fend: 0.1.27 -> 0.1.28
* [`20c318ac`](https://github.com/NixOS/nixpkgs/commit/20c318ac029efb8be74148b9f45dbb5ea1c1c2b1) flyctl: 0.0.296 -> 0.0.297
* [`5f0b0394`](https://github.com/NixOS/nixpkgs/commit/5f0b0394f6a9c6434db2ce0550f6cb5cda953c54) git-cliff: 0.5.0 -> 0.6.0
* [`dca9dd52`](https://github.com/NixOS/nixpkgs/commit/dca9dd52b8041bebec09b0b803737e67b27b025a) enpass: remove trailing whitespace
* [`7436b064`](https://github.com/NixOS/nixpkgs/commit/7436b064a1c3d7eba773fe1f28c59f580373d58a) .editorconfig: remove enpass
* [`4f2e712c`](https://github.com/NixOS/nixpkgs/commit/4f2e712cde7adee025369d7bb81da653837ced79) arkade: remove unnecessary platforms
* [`bbd7dde0`](https://github.com/NixOS/nixpkgs/commit/bbd7dde0bdd881b416cb1d5d065f555c6984cf4c) faas-cli: remove unnecessary platforms
* [`08d62da6`](https://github.com/NixOS/nixpkgs/commit/08d62da627bac2121b81f8fa8021d0f73516064c) shadowsocks-rust: 1.13.0 -> 1.13.2
* [`07895c78`](https://github.com/NixOS/nixpkgs/commit/07895c78f7b45ac146616367c9dc3dd0c1888502) k3sup: init at 0.11.3
* [`0be64167`](https://github.com/NixOS/nixpkgs/commit/0be64167a1a2096e273689e0e0f0751a9515cdfd) .editorconfig: remove emscripten
* [`86d37cc2`](https://github.com/NixOS/nixpkgs/commit/86d37cc221d19e04c3698933f2764a5464ffee7c) samim-fonts: 3.1.0 -> 4.0.4
* [`5a07a32f`](https://github.com/NixOS/nixpkgs/commit/5a07a32f30cb7154324ba09dc21fc7ee41ce6afe) imagemagick: 7.1.0-23 -> 7.1.0-24
* [`ac88670f`](https://github.com/NixOS/nixpkgs/commit/ac88670f82e6fc81acdf9473531faf4eaad1633a) hexchat: 2.16.0 -> 2.16.1
* [`d3ebd7d5`](https://github.com/NixOS/nixpkgs/commit/d3ebd7d5256ef6fcffd2c68f64921a124e45056e) signal-desktop: 5.30.0 -> 5.31.1
* [`6e2acad5`](https://github.com/NixOS/nixpkgs/commit/6e2acad5cb32167d054971e2658f7073dfc61d21) resvg: 0.20.0 -> 0.21.0
* [`76e13d32`](https://github.com/NixOS/nixpkgs/commit/76e13d32a6e51502b6f379547eca921343713054) jackett: 0.20.546 -> 0.20.562
* [`3066715a`](https://github.com/NixOS/nixpkgs/commit/3066715a5afc55b5e39c636cccf71f40e987e7dd) python3Packages.pi1wire: init at 0.2.0
* [`0dba363d`](https://github.com/NixOS/nixpkgs/commit/0dba363dd04d53788aec58fb8ab60025dc6e6fbb) python3Packages.pyownet: init at 0.10.0.post1
* [`a1f6f53d`](https://github.com/NixOS/nixpkgs/commit/a1f6f53dfc52f1597810da16a07af9b305404f97) home-assistant: support onewire component
* [`6a74f625`](https://github.com/NixOS/nixpkgs/commit/6a74f6251d1bb70f78d14006161e7be272fee522) racket: add ncurses dependency
* [`8a5a31ec`](https://github.com/NixOS/nixpkgs/commit/8a5a31ec0b1054d3cafacb13ab05efc0a74961cc) .github/CODEOWNERS: add rust docs
