### PR TITLE
niv home-manager: update 1ca6293c -> 7c2ae0bd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ca6293c8fb1dbe13c48fe518440c288256cd562",
-        "sha256": "12la18ih9nrh9172jjb32vbn8my5x0kfgn534v7181bbvcxcbqsn",
+        "rev": "7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06",
+        "sha256": "017b3v16zas9914d7pbqva1fg3bdi7wrqrlks5pbymrr2ypb3v64",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1ca6293c8fb1dbe13c48fe518440c288256cd562.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1ca6293c...7c2ae0bd](https://github.com/nix-community/home-manager/compare/1ca6293c8fb1dbe13c48fe518440c288256cd562...7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06)

* [`e2aa1f59`](https://github.com/nix-community/home-manager/commit/e2aa1f598674aa9c06f28f5db60b89f37f1e961b) kitty: add option `theme` ([nix-community/home-manager⁠#2710](https://togithub.com/nix-community/home-manager/issues/2710))
* [`85bbc6cc`](https://github.com/nix-community/home-manager/commit/85bbc6cc12071c840cf3998e5d8f757fd00c1542) docs: move Nix Flakes documentation to manual
* [`6d9d9294`](https://github.com/nix-community/home-manager/commit/6d9d9294d09b5e88df65f8c6651efb8a4d7d2476) notmuch: fix database creation when using hooks
* [`a2363ceb`](https://github.com/nix-community/home-manager/commit/a2363ceb1d4f8ee17d23e9b00d7d2930f76cddde) Translate using Weblate (Japanese)
* [`e448c3c1`](https://github.com/nix-community/home-manager/commit/e448c3c1232065eb225bdd7d31a805610233a73d) Add translation using Weblate (Japanese)
* [`ec5c5ae9`](https://github.com/nix-community/home-manager/commit/ec5c5ae9a8069f1479d2f1ae093dadfca7c25399) Translate using Weblate (Japanese)
* [`68cf4bef`](https://github.com/nix-community/home-manager/commit/68cf4bef2e5fecdcc2546f182f659517cc8700fb) Translate using Weblate (Japanese)
* [`b784f588`](https://github.com/nix-community/home-manager/commit/b784f588eed7ad260e588717b57c27662ce23a42) Translate using Weblate (Japanese)
* [`be7f132a`](https://github.com/nix-community/home-manager/commit/be7f132a125aea7922dae1814d04e6de8710fc83) Add translation using Weblate (Turkish)
* [`37f0a161`](https://github.com/nix-community/home-manager/commit/37f0a161a03d32ea10c0e1402339b23b1df6bfaf) Add translation using Weblate (Turkish)
* [`54c2cf7f`](https://github.com/nix-community/home-manager/commit/54c2cf7fb8183f88aec179e7efe54deed93d27fa) Translate using Weblate (Japanese)
* [`ae95406f`](https://github.com/nix-community/home-manager/commit/ae95406f86c3d2b023822b0487df71673ce35092) Translate using Weblate (Turkish)
* [`4160629a`](https://github.com/nix-community/home-manager/commit/4160629af7b66066726ba948660645b0a17c87b3) Translate using Weblate (Turkish)
* [`7c2ae0bd`](https://github.com/nix-community/home-manager/commit/7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06) faq: explain how to let HM manage shell profiles
