### PR TITLE
niv mac-zsh-completions: update 3d62a062 -> 303f25c8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": null,
         "owner": "scriptingosx",
         "repo": "mac-zsh-completions",
-        "rev": "3d62a062d3b1860e7f3ec9e93b2fed8ca50bb1df",
-        "sha256": "1v5rw7pqkyyd2xy124kmdzbmgh0adx94kbkwj7afd6vjg5kv9yl6",
+        "rev": "303f25c8b30f3c7351a7bcaaf4b6f01818c3f1ad",
+        "sha256": "0j9npy2xivgr9blcnnig8dzikac9y5j1qsl75b6k4zbcwrd89afk",
         "type": "tarball",
-        "url": "https://github.com/scriptingosx/mac-zsh-completions/archive/3d62a062d3b1860e7f3ec9e93b2fed8ca50bb1df.tar.gz",
+        "url": "https://github.com/scriptingosx/mac-zsh-completions/archive/303f25c8b30f3c7351a7bcaaf4b6f01818c3f1ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for mac-zsh-completions:
Branch: master
Commits: [scriptingosx/mac-zsh-completions@3d62a062...303f25c8](https://github.com/scriptingosx/mac-zsh-completions/compare/3d62a062d3b1860e7f3ec9e93b2fed8ca50bb1df...303f25c8b30f3c7351a7bcaaf4b6f01818c3f1ad)

* [`6d4e0e22`](https://github.com/scriptingosx/mac-zsh-completions/commit/6d4e0e2274a7d9adc63c0f42b744c074e668a751) added gh completion
* [`6c283035`](https://github.com/scriptingosx/mac-zsh-completions/commit/6c283035a2780b1385da968ccb48d9253dd8e520) added project completion
* [`b2853f06`](https://github.com/scriptingosx/mac-zsh-completions/commit/b2853f06f111080c11dec87ee5881591ec6ba6ea) Update _swift
* [`6f6d4372`](https://github.com/scriptingosx/mac-zsh-completions/commit/6f6d437268e91ec765a381454b0d82e59b0098a7) softwareupdate now completes version numbers correctly, dropped ignore option
* [`303f25c8`](https://github.com/scriptingosx/mac-zsh-completions/commit/303f25c8b30f3c7351a7bcaaf4b6f01818c3f1ad) Update _softwareupdate
