### PR TITLE
niv powerlevel10k: update 8a676a91 -> 123136c0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "8a676a9157d2b0e00e88d06456ac7317f11c0317",
-        "sha256": "0fkfh8j7rd8mkpgz6nsx4v7665d375266shl1aasdad8blgqmf0c",
+        "rev": "123136c0e7566a2a12385f3836e3e92df6b42be1",
+        "sha256": "122rc1znv2dbh4g4y085hw6w992yh7agsfvb3zsrlw7wisfk4h0s",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/8a676a9157d2b0e00e88d06456ac7317f11c0317.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/123136c0e7566a2a12385f3836e3e92df6b42be1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@8a676a91...123136c0](https://github.com/romkatv/powerlevel10k/compare/8a676a9157d2b0e00e88d06456ac7317f11c0317...123136c0e7566a2a12385f3836e3e92df6b42be1)

* [`4b21cd06`](https://github.com/romkatv/powerlevel10k/commit/4b21cd06ffeb5706b017c78b13c2eaf40d7deac1) Squashed 'gitstatus/' changes from b226d8e06..f889c13d1
* [`5fe28f0a`](https://github.com/romkatv/powerlevel10k/commit/5fe28f0a010acd251c25a5bd62dfd8002c37f46c) bug fix: correctly parse kubectl config when current-context has metacharacters ([romkatv/powerlevel10k⁠#1767](https://togithub.com/romkatv/powerlevel10k/issues/1767))
* [`c0a02835`](https://github.com/romkatv/powerlevel10k/commit/c0a028351ff9a611c4061938ebd5ec4cafb900eb) Squashed 'gitstatus/' changes from f889c13d1..6dc0738c0
