### PR TITLE
niv spacemacs: update d3661501 -> f2afab0c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "d366150139c2c3fa8b743f502efccd542e7a6f3a",
-        "sha256": "1v6jplrzlybhxlkwvz034lw5pnz348ic02ma9yyyb37rllhi9sji",
+        "rev": "f2afab0c32c1dfb8e2bfd3d1c4c84c8db5a68c4b",
+        "sha256": "0mlq1iqks51gvdplbiz9jcy09vssxn9m6y4mnfyviig0gr4m74gs",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/d366150139c2c3fa8b743f502efccd542e7a6f3a.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/f2afab0c32c1dfb8e2bfd3d1c4c84c8db5a68c4b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@d3661501...f2afab0c](https://github.com/syl20bnr/spacemacs/compare/d366150139c2c3fa8b743f502efccd542e7a6f3a...f2afab0c32c1dfb8e2bfd3d1c4c84c8db5a68c4b)

* [`22d168a0`](https://github.com/syl20bnr/spacemacs/commit/22d168a05461d0744a472bb0b795b014ea890160) Fix consult-buffer error ([syl20bnr/spacemacs⁠#15327](https://togithub.com/syl20bnr/spacemacs/issues/15327))
* [`031f7e16`](https://github.com/syl20bnr/spacemacs/commit/031f7e16664f2379c5d84307ccf30ed48826a216) Fix the use of consult--source-project-file ([syl20bnr/spacemacs⁠#15328](https://togithub.com/syl20bnr/spacemacs/issues/15328))
* [`d33a1a8f`](https://github.com/syl20bnr/spacemacs/commit/d33a1a8fcc11f68195f70af437b84c6c522a3a3a) spacemacs-defaults: Added prompt to save a buffer ([syl20bnr/spacemacs⁠#15297](https://togithub.com/syl20bnr/spacemacs/issues/15297))
* [`696b1565`](https://github.com/syl20bnr/spacemacs/commit/696b15652fe27ce6cfd6cc0da63df3c498a0d5ee) Revert "spacemacs-defaults: Added prompt to save a buffer ([syl20bnr/spacemacs⁠#15297](https://togithub.com/syl20bnr/spacemacs/issues/15297))" ([syl20bnr/spacemacs⁠#15330](https://togithub.com/syl20bnr/spacemacs/issues/15330))
* [`9e30cf9b`](https://github.com/syl20bnr/spacemacs/commit/9e30cf9b3989797072de8b83f39f2fd08fe80c79) Fix ⌘-s shortcut in macOS ([syl20bnr/spacemacs⁠#15329](https://togithub.com/syl20bnr/spacemacs/issues/15329))
* [`8bfc1566`](https://github.com/syl20bnr/spacemacs/commit/8bfc1566ecebc780c8cf23d6a3a5a1ac08c6d6da) fixup! help/helpful: Set tab-width to 8, better integration w/ Ivy ([syl20bnr/spacemacs⁠#15243](https://togithub.com/syl20bnr/spacemacs/issues/15243))
* [`a50aa7d2`](https://github.com/syl20bnr/spacemacs/commit/a50aa7d225dc7784e416a6594bb9edb2fb821547) spacemacs-buffer: lock it in read-only
* [`efdfecbf`](https://github.com/syl20bnr/spacemacs/commit/efdfecbf8f72d3de4a410f9d653f8b91e569063c) spacemacs-buffer: allow 'kp-*' keys for jump to number ([syl20bnr/spacemacs⁠#15308](https://togithub.com/syl20bnr/spacemacs/issues/15308))
* [`e24e1e4b`](https://github.com/syl20bnr/spacemacs/commit/e24e1e4b5725d9eb940263f7427cc1a06376560f) spacemacs-defaults: Prompt to save a buffer for certain operations ([syl20bnr/spacemacs⁠#15331](https://togithub.com/syl20bnr/spacemacs/issues/15331))
* [`ebd06038`](https://github.com/syl20bnr/spacemacs/commit/ebd0603885bf2d71115ec3803d7acb774afcba66) eww: cleaned up ([syl20bnr/spacemacs⁠#15321](https://togithub.com/syl20bnr/spacemacs/issues/15321))
* [`8863a34b`](https://github.com/syl20bnr/spacemacs/commit/8863a34b56ab42769b02fdf1a650ab4bda5e112b) [bot] built_in_updates ([syl20bnr/spacemacs⁠#15336](https://togithub.com/syl20bnr/spacemacs/issues/15336))
* [`34e14fb6`](https://github.com/syl20bnr/spacemacs/commit/34e14fb68158bfe3099e829d0373a552f257e450) [org] add support for transclusion ([syl20bnr/spacemacs⁠#15333](https://togithub.com/syl20bnr/spacemacs/issues/15333))
* [`a7d91f1b`](https://github.com/syl20bnr/spacemacs/commit/a7d91f1b4f74ede127fc1d896ef5f2e44c8b74f4) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15337](https://togithub.com/syl20bnr/spacemacs/issues/15337))
* [`77ba076f`](https://github.com/syl20bnr/spacemacs/commit/77ba076f697d270b011586944004ce8dfb6f61a4) spacemacs-editing-visual: rework ([syl20bnr/spacemacs⁠#15322](https://togithub.com/syl20bnr/spacemacs/issues/15322))
* [`9deb58d1`](https://github.com/syl20bnr/spacemacs/commit/9deb58d16a24d9a23980d79647129fbc6d8bad61) [elisp] add elisp-def ([syl20bnr/spacemacs⁠#15315](https://togithub.com/syl20bnr/spacemacs/issues/15315))
* [`44fbaa3d`](https://github.com/syl20bnr/spacemacs/commit/44fbaa3d106df84c0c7ca22751acd9c2d195239d) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15338](https://togithub.com/syl20bnr/spacemacs/issues/15338))
* [`023ba524`](https://github.com/syl20bnr/spacemacs/commit/023ba524f4304708ba22c0a25cf11ccef8a6ea12) [tree-sitter] add option to seletively disable tree sitter hl mode ([syl20bnr/spacemacs⁠#15317](https://togithub.com/syl20bnr/spacemacs/issues/15317))
* [`60e512a4`](https://github.com/syl20bnr/spacemacs/commit/60e512a48b886b27764188d44610374890017874) [iedit] use fork ([syl20bnr/spacemacs⁠#15318](https://togithub.com/syl20bnr/spacemacs/issues/15318))
* [`4d0529d3`](https://github.com/syl20bnr/spacemacs/commit/4d0529d3e77ccb1bb441e1e2c21b56018fc53edb) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15339](https://togithub.com/syl20bnr/spacemacs/issues/15339))
* [`adf9da37`](https://github.com/syl20bnr/spacemacs/commit/adf9da378bca8e0a2947a40a185b53c1c7099efd) [auto-completion] add company-posframe ([syl20bnr/spacemacs⁠#15320](https://togithub.com/syl20bnr/spacemacs/issues/15320))
* [`179bb38e`](https://github.com/syl20bnr/spacemacs/commit/179bb38ebc0a10c9b33ffb8949b6e170564b7016) fix: progn typo in org-transclusion :init ([syl20bnr/spacemacs⁠#15340](https://togithub.com/syl20bnr/spacemacs/issues/15340))
* [`ea020911`](https://github.com/syl20bnr/spacemacs/commit/ea020911f880e36fc53106fefc3df100f4f857b6) Add basic LSP support to NixOS layer ([syl20bnr/spacemacs⁠#15342](https://togithub.com/syl20bnr/spacemacs/issues/15342))
* [`6fc9faee`](https://github.com/syl20bnr/spacemacs/commit/6fc9faee851e27568f7410c4ffa63b010d997026) [bot] "documentation_updates" Sun Feb 13 20:45:13 UTC 2022 ([syl20bnr/spacemacs⁠#15343](https://togithub.com/syl20bnr/spacemacs/issues/15343))
* [`fe23d524`](https://github.com/syl20bnr/spacemacs/commit/fe23d52414646cbeb5637ad09902e8e97cc4bb7d) fixup! fixup! help/helpful: Set tab-width to 8, better integration w/Ivy ([syl20bnr/spacemacs⁠#15243](https://togithub.com/syl20bnr/spacemacs/issues/15243))
* [`ec8c87df`](https://github.com/syl20bnr/spacemacs/commit/ec8c87df2722cfbd867aaa9156a197a820347839) spacemacs-purpose: Improved README.org ([syl20bnr/spacemacs⁠#15346](https://togithub.com/syl20bnr/spacemacs/issues/15346))
* [`30e32ea4`](https://github.com/syl20bnr/spacemacs/commit/30e32ea41f5a638a20bba09ff76ff375b2cf5080) fixup! [auto-completion] add company-posframe
* [`25674b77`](https://github.com/syl20bnr/spacemacs/commit/25674b7768126a43913eceb8a781891a8491bc20) Fix tab key functionality in pdf outline mode ([syl20bnr/spacemacs⁠#15345](https://togithub.com/syl20bnr/spacemacs/issues/15345))
* [`3429bcf0`](https://github.com/syl20bnr/spacemacs/commit/3429bcf056e6593a43cb0fa01204182e99315bae) fixed typos postframe to posframe
* [`0bdddfc1`](https://github.com/syl20bnr/spacemacs/commit/0bdddfc165a11b5fb2d319bc028b327744186ed5) tabs: fix a typo
* [`db15a2d5`](https://github.com/syl20bnr/spacemacs/commit/db15a2d5a0e6e776f18a9d6a3998475421fa5408) core-jump: fixed a typo
* [`f2afab0c`](https://github.com/syl20bnr/spacemacs/commit/f2afab0c32c1dfb8e2bfd3d1c4c84c8db5a68c4b) fixup! core-jump: fixed a typo
