### PR TITLE
niv zsh-syntax-highlighting: update c10808ad -> 56b44334

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -228,10 +228,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "c10808ad5f3ace0696f900b9c543172bc1f8e27c",
-        "sha256": "0mn7nlsayh6l7vkyg62l78wzi63slh5q5g432yy36vl3xh9kvjin",
+        "rev": "56b44334617aa719e8e01bb5e00d3e176114a036",
+        "sha256": "1xpn0rgvw50m5x6c9pa58a0kz5jz50jp8f33yddnm8jszzhas9nk",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/c10808ad5f3ace0696f900b9c543172bc1f8e27c.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/56b44334617aa719e8e01bb5e00d3e176114a036.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@c10808ad...56b44334](https://github.com/zsh-users/zsh-syntax-highlighting/compare/c10808ad5f3ace0696f900b9c543172bc1f8e27c...56b44334617aa719e8e01bb5e00d3e176114a036)

* [`0ddb1a8d`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/0ddb1a8d51205d53ea283e9fdd5135eb4039fec8) driver: Bump the in-development is-at-least checks so they return false on zsh 5.8.1, released yesterday.
* [`56b44334`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/56b44334617aa719e8e01bb5e00d3e176114a036) CI += zsh 5.8.1
