### PR TITLE
niv nixpkgs: update 0a5da457 -> afb9a57a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0a5da457e98508fb20465723e5d1f34bd02bb5e1",
-        "sha256": "1xbswg6q7ynp4zlb34inb0fj3r29n9h7926s90sdxrxwc37d539h",
+        "rev": "afb9a57ae3c0cc5c7ba0689935727faca223f011",
+        "sha256": "1scpxwlzn4is8b5jlch9q88ccaqwa9q16nlr9pbmiivm0if2n97v",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/0a5da457e98508fb20465723e5d1f34bd02bb5e1.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/afb9a57ae3c0cc5c7ba0689935727faca223f011.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@0a5da457...afb9a57a](https://github.com/nixos/nixpkgs/compare/0a5da457e98508fb20465723e5d1f34bd02bb5e1...afb9a57ae3c0cc5c7ba0689935727faca223f011)

* [`0b1ce653`](https://github.com/NixOS/nixpkgs/commit/0b1ce6538e47b7c9a3b8060d49efa28eeb2f5371) wxsqlite3: 4.7.3 -> 4.7.6
* [`fdaa640d`](https://github.com/NixOS/nixpkgs/commit/fdaa640dae0fea8fe2f1bc975209e03a74f45e78) aeon: 0.13.0.0 -> 0.14.1.0
* [`9ba3f626`](https://github.com/NixOS/nixpkgs/commit/9ba3f626ce57e756fa38ec56e422a4b6d8113516) curaengine: 4.10.0 -> 4.12.1
* [`bcc76291`](https://github.com/NixOS/nixpkgs/commit/bcc762910853359e247453b351cb07938e2e654b) python3Packages.rokuecp: 0.14.0 -> 0.14.1
* [`0560db58`](https://github.com/NixOS/nixpkgs/commit/0560db5867293eaabcd1be0bf85e80aa66e26d56) radare2: 5.6.0 -> 5.6.2
* [`3cefc454`](https://github.com/NixOS/nixpkgs/commit/3cefc45430a85a36b9eaa48e1edcad0ef786a337) python3Packages.intellifire4py: 0.9.8 -> 0.9.9
* [`8e544d10`](https://github.com/NixOS/nixpkgs/commit/8e544d1043a43da193719633888bb4229a3b7ed4) python3Packages.python-miio: 0.5.9.2 -> 0.5.10
* [`1176525f`](https://github.com/NixOS/nixpkgs/commit/1176525f8788e95b34c1e6e3ebbe8537472d705a) treewide: remove obsolete kernel version checks
* [`834d1f7c`](https://github.com/NixOS/nixpkgs/commit/834d1f7c20c8b2cc78a98d5b7e46f75db3d5cacb) python3Packages.total-connect-client: 2022.2 -> 2022.2.1
* [`a3bee014`](https://github.com/NixOS/nixpkgs/commit/a3bee014bec85b15149bacf115475ad3e0a12ebf) python3Packages.advantage-air: 0.3.0 -> 0.3.1
* [`9741903d`](https://github.com/NixOS/nixpkgs/commit/9741903d62e0794211be4b10fc6ee1c94bb1873a) evemu: 2.6.0 -> 2.7.0
* [`649e456f`](https://github.com/NixOS/nixpkgs/commit/649e456f2083858e80efcda31e7d40883e580efa) natscli: 0.0.28 -> 0.0.29
* [`41fc14e3`](https://github.com/NixOS/nixpkgs/commit/41fc14e3ed8d18effca9c52e75b10f96e00e6c44) exodus: 21.10.25 -> 21.12.3
* [`286ecff9`](https://github.com/NixOS/nixpkgs/commit/286ecff9e09f6dd9f339f7e62d2b834fd5ad5868) getdp: 3.3.0 -> 3.4.0
* [`451c27fb`](https://github.com/NixOS/nixpkgs/commit/451c27fb70610188d44e9f24b2fd89b390eb4e96) shfmt: 3.4.2 -> 3.4.3
* [`f7fbd4b2`](https://github.com/NixOS/nixpkgs/commit/f7fbd4b21c919ed5e10ae883bed51a3077c67793) gdu: 5.13.1 -> 5.13.2
* [`9fb8a292`](https://github.com/NixOS/nixpkgs/commit/9fb8a2923b6692cce543ab138fe202daa41afbb3) cinnamon.xapps: 2.2.5 -> 2.2.8
* [`c9effadc`](https://github.com/NixOS/nixpkgs/commit/c9effadcfccc7e0b6fe28da124c2c82f89abf216) cinnamon.xviewer: 3.2.2 -> 3.2.4
* [`8388c525`](https://github.com/NixOS/nixpkgs/commit/8388c525c3c09715e09357b5547c128f931a7cf3) vpnc: don't produce non-free binaries by default
* [`6f056e58`](https://github.com/NixOS/nixpkgs/commit/6f056e58f44d5e80a887720c95c38c3dd2774f6a) python3Packages.slack-sdk: 3.15.0 -> 3.15.1
* [`46b7d93c`](https://github.com/NixOS/nixpkgs/commit/46b7d93c947782d49698fe67ec9ae397eb9d670d) python3Packages.hahomematic: 0.34.2 -> 0.35.0
* [`1d1db20c`](https://github.com/NixOS/nixpkgs/commit/1d1db20c0448796b7bc6a0fd838f966a14478db2) python3Packages.aiogithubapi: 22.2.0 -> 22.2.2
* [`bec0ed75`](https://github.com/NixOS/nixpkgs/commit/bec0ed753eda9e3a2d4f5dd7fabcdccd18c85cbd) galene: 0.3.5 -> 0.4.4
* [`b195c2c4`](https://github.com/NixOS/nixpkgs/commit/b195c2c47f8d7c863ccc97a26a2eebe8a16b7cbd) vieb: 6.1.0 -> 6.2.0
* [`60102b9a`](https://github.com/NixOS/nixpkgs/commit/60102b9a13eed9911e0e660eb0df55fc375f63b9) kconf: 1.10.1 -> 1.11.0
* [`482a0f3b`](https://github.com/NixOS/nixpkgs/commit/482a0f3bb65b3adcf9b674c93819bc9654732027) python3Packages.awesomeversion: 22.1.0 -> 22.2.0
* [`157b6703`](https://github.com/NixOS/nixpkgs/commit/157b6703ea5710491deed981bb85d0d5404db7f8) stork: 1.3.0 -> 1.4.0
* [`8ed0f686`](https://github.com/NixOS/nixpkgs/commit/8ed0f686cd4b7d437369539b0476ae9806b13892) xed-editor: 3.0.2 -> 3.2.2
* [`4ec68358`](https://github.com/NixOS/nixpkgs/commit/4ec683588426cf97d67158448e61119b5be56d23) sbt-extras: 2021-10-21 -> 2021-11-08
* [`508adb01`](https://github.com/NixOS/nixpkgs/commit/508adb0115232c18498465da455a9dd91f308143) passerine: 0.9.2 → 0.9.3
* [`b9d731d2`](https://github.com/NixOS/nixpkgs/commit/b9d731d22e1e180ebefdcfb7c4f55a866dd28599) plexamp: 4.0.0 -> 4.0.1
* [`baa56436`](https://github.com/NixOS/nixpkgs/commit/baa564361fce476b18f848ac99aea421d9281d49) containerd: add maintainer
* [`a15635a6`](https://github.com/NixOS/nixpkgs/commit/a15635a6b3e2ab6c729b5812eb8ecbfdcb6027ba) jless: add maintainer
* [`3004ee49`](https://github.com/NixOS/nixpkgs/commit/3004ee49b289c4fab047729fbf902e6b232da432) gdu: add maintainer
* [`6095fd0c`](https://github.com/NixOS/nixpkgs/commit/6095fd0c63c548f89b37ddd31b78b883029a9321) pueue: 1.0.6 -> 2.0.0
* [`223f5872`](https://github.com/NixOS/nixpkgs/commit/223f5872f8e391ec7e4c8e3b17d879c58542ed22) skeema: init at 1.7.0
* [`d2e125d1`](https://github.com/NixOS/nixpkgs/commit/d2e125d11949c314d823bcc897ce8cc6d99a611f) rocksdb: 6.28.2 -> 6.29.3
* [`103c44d0`](https://github.com/NixOS/nixpkgs/commit/103c44d03569918d7219aef3b71df416e218194e) python3Packages.imap-tools: 0.50.2 -> 0.51.0
* [`617e0845`](https://github.com/NixOS/nixpkgs/commit/617e0845c715e9eef316af0a8e1028de9233893a) xrootd: init at 5.4.0 ([nixos/nixpkgs⁠#160102](https://togithub.com/nixos/nixpkgs/issues/160102))
* [`da95597f`](https://github.com/NixOS/nixpkgs/commit/da95597fe8823153a1fc5e6465e464b893b44852) shiori: 1.5.0 -> 1.5.1
* [`50411a70`](https://github.com/NixOS/nixpkgs/commit/50411a706bc42dc01404f87a3d82abd86d4d83ab) tiled: 1.8.1 -> 1.8.2
* [`8b25c418`](https://github.com/NixOS/nixpkgs/commit/8b25c418bc62d1c5e06bf29752940b396e327872) tilt: 0.25.0 -> 0.25.1
* [`3ca65662`](https://github.com/NixOS/nixpkgs/commit/3ca6566259091946d621862d8f110d085be4a4fe) python310Packages.symengine: 0.8.1 -> 0.9.0
* [`03200cc4`](https://github.com/NixOS/nixpkgs/commit/03200cc4c40889f4ad515b3d5fbc606484e30d60) buildNimPackages: by default use Nim's platforms
* [`a5497466`](https://github.com/NixOS/nixpkgs/commit/a54974664d30444dd9fa253710667f8c92ad9439) python310Packages.aioazuredevops: 1.3.5 -> 1.4.3
* [`8ec5134f`](https://github.com/NixOS/nixpkgs/commit/8ec5134f0e21f096a0f044854713ba05cea768ea) werf: 1.2.67 -> 1.2.69
* [`857da052`](https://github.com/NixOS/nixpkgs/commit/857da052ee430649b643cb1cbd99212aaa5c1b1d) autorestic: 1.5.2 -> 1.5.5
* [`5a51b208`](https://github.com/NixOS/nixpkgs/commit/5a51b208691b854765a1eb97039e5fea5560bddb) python310Packages.protego: 0.2.0 -> 0.2.1
* [`187d0055`](https://github.com/NixOS/nixpkgs/commit/187d0055d666833c3585d969bfe87c534a4eac8f) python310Packages.tinydb: 4.6.1 -> 4.7.0
* [`0bb30259`](https://github.com/NixOS/nixpkgs/commit/0bb30259bab2bb27b593d3cbc429c8fe0a944dc0) python310Packages.aws-lambda-builders: 1.11.0 -> 1.12.0
* [`f4bbb877`](https://github.com/NixOS/nixpkgs/commit/f4bbb877aa915a1708b26e356dc6ef309d315eb9) python310Packages.python-rapidjson: 1.5 -> 1.6
* [`b030dbef`](https://github.com/NixOS/nixpkgs/commit/b030dbef0366548c4c1f497671f397d7077f3a46) scli: 0.6.6 -> 0.7.0
* [`9c001696`](https://github.com/NixOS/nixpkgs/commit/9c0016965665b9041012c5d2b728aeb9e72e5428) sqlite-utils: 3.23 -> 3.24
* [`3082e064`](https://github.com/NixOS/nixpkgs/commit/3082e064fe3c9008ca559cfd7b7ecba4fffcfec5) pycritty: 0.3.5 -> 0.4.0
* [`f04b77b0`](https://github.com/NixOS/nixpkgs/commit/f04b77b015ca4cbd0c0638c4ee9581697a0f7dcd) dolt: 0.36.2 -> 0.37.0
* [`f1f722f2`](https://github.com/NixOS/nixpkgs/commit/f1f722f2220203fcb77d279cb590a7e9d8414752) bitwarden: 1.31.2 -> 1.31.3
* [`16764012`](https://github.com/NixOS/nixpkgs/commit/16764012f7a84f86b11bda0676c6efedab1b3f6c) mutt: 2.2.0 -> 2.2.1
* [`04f07d1d`](https://github.com/NixOS/nixpkgs/commit/04f07d1d284d05c1bcf282e3377030e221f0abc4) girara: 0.3.6 -> 0.3.7
* [`08b16191`](https://github.com/NixOS/nixpkgs/commit/08b16191a93d10bdbec0e56e4a90f709e653d5a5) datree: 0.15.5 -> 0.15.16
* [`32a2f83b`](https://github.com/NixOS/nixpkgs/commit/32a2f83b65f5f51e819be4fd9157edc5a0f5c660) python310Packages.azure-mgmt-recoveryservicesbackup: 4.1.0 -> 4.1.1
* [`59b1fab5`](https://github.com/NixOS/nixpkgs/commit/59b1fab58026b08ad7c0103ab6b53ca067af41f6) libguestfs: 1.44.1 → 1.46.2
* [`c6859b76`](https://github.com/NixOS/nixpkgs/commit/c6859b76947766a63ea86410014966d8eb1d3f20) python310Packages.coqpit: 0.0.14 -> 0.0.15
* [`b1cd9254`](https://github.com/NixOS/nixpkgs/commit/b1cd9254849b3a1a81d225f4a3025e1a53a7a481) php74: 7.4.27 -> 7.4.28
* [`60dfe5bd`](https://github.com/NixOS/nixpkgs/commit/60dfe5bd6c173fe3e59273983b97b0a745b96f72) php80: 8.0.14 -> 8.0.16
* [`96983152`](https://github.com/NixOS/nixpkgs/commit/96983152e7b0576dc0d0887a0e5610cffc8fd28e) php81: 8.1.2 -> 8.1.3
* [`c8c847b8`](https://github.com/NixOS/nixpkgs/commit/c8c847b8e848714f0848479c8d11e2d2d48ffcb2) squirrel-sql: 4.2.0 -> 4.3.0
* [`09033167`](https://github.com/NixOS/nixpkgs/commit/09033167ee998599b1234bc94f456942e2edc4a8) gnome-bluetooth: fix transposition error
* [`0a5fe820`](https://github.com/NixOS/nixpkgs/commit/0a5fe8205a90fd6f53de10852fcaee01b209dcf0) python310Packages.jsonrpclib-pelix: 0.4.3.1 -> 0.4.3.2
* [`f55d6277`](https://github.com/NixOS/nixpkgs/commit/f55d6277524dfb3bffcb71ebb17ad5c6340f3308) python310Packages.pyoctoprintapi: 0.1.7 -> 0.1.8
* [`ef828225`](https://github.com/NixOS/nixpkgs/commit/ef828225247a472b41dca0e2e7e8120407d0290d) python3Packages.enlighten: disable failing test
* [`4593c25b`](https://github.com/NixOS/nixpkgs/commit/4593c25b4ab6eb9f19e4bb856d56529dc99a0ab0) swtpm: 0.7.0 -> 0.7.1
* [`93609b6a`](https://github.com/NixOS/nixpkgs/commit/93609b6af5e30470c9df3c9345b999d27f46bb4b) swtpm: add nixosTests.systemd-cryptenroll to passthru.tests
* [`156e0e2b`](https://github.com/NixOS/nixpkgs/commit/156e0e2b071c8de44155ab56830192a6586edc87) rsyslog: 8.2112.0 -> 8.2202.0
* [`e7597bcb`](https://github.com/NixOS/nixpkgs/commit/e7597bcb5a5f8324a4997dfdd2d6b43bc8aa85dd) postgresql11Packages.repmgr: 5.3.0 -> 5.3.1
* [`a8121ca8`](https://github.com/NixOS/nixpkgs/commit/a8121ca80e04d22d98504fdddd90e342fdda7387) mastodon: apply upstream patch for CVE-2022-0432
* [`7fa2a723`](https://github.com/NixOS/nixpkgs/commit/7fa2a7232d1105501e498d0846828c3b82ab4c4b) coqPackages.LibHyps: init at 2.0.4.1
* [`d0bb08b5`](https://github.com/NixOS/nixpkgs/commit/d0bb08b5cce184e1f9837eeede8c6e2227bb2379) coqPackages.hydra-battles: 0.5 -> 0.6
* [`8208c3ee`](https://github.com/NixOS/nixpkgs/commit/8208c3eec8622becc0806c998146161a82a715ec) coqPackages.addition-chains: 0.5 -> 0.6
* [`450eab2c`](https://github.com/NixOS/nixpkgs/commit/450eab2ca784ba51384cb34e146a1be2b88bf144) coqPackages_8_14.gaia-hydras: 0.5 -> 0.6
* [`8c023415`](https://github.com/NixOS/nixpkgs/commit/8c023415b9696df1361d338fea00ee4cce7af73a) python3Packages.newversion: init at 1.8.2
* [`712344f0`](https://github.com/NixOS/nixpkgs/commit/712344f0f925b7c312969086050b9f44a720cbb0)  python310Packages.mypy-boto3-builder: 6.3.2 -> 7.1.2
* [`7d6dc250`](https://github.com/NixOS/nixpkgs/commit/7d6dc250f6da66baa338f360b94d0f03f4bca9bb) nimPackages.jsonschema: use buildNimPackage
* [`ed39a3ff`](https://github.com/NixOS/nixpkgs/commit/ed39a3ffba221a2a98d510d6f04bdb8658e01f2b) nimlsp: 0.3.2 -> 0.4.0
* [`4994cd3f`](https://github.com/NixOS/nixpkgs/commit/4994cd3f8ed1778d8bf77ee39f75ec435006f25a) tuntox: init at 0.0.10
* [`96deebbd`](https://github.com/NixOS/nixpkgs/commit/96deebbd3485a0d071eb350a184b49668f84f340) tribler: 7.10.0 -> 7.11.0
* [`23360348`](https://github.com/NixOS/nixpkgs/commit/233603486790b6ab0b2bac3e88b0751c2066d613) remmina: 1.4.23 -> 1.4.24
* [`75a46778`](https://github.com/NixOS/nixpkgs/commit/75a4677819589cb610199143e113f86e495404ca) jackett: 0.20.576 -> 0.20.596
* [`da6d0ab6`](https://github.com/NixOS/nixpkgs/commit/da6d0ab616a45d318e9d92d99d7a5b6ee9dc8bda) alephone-infinity: 20210408 -> 20220115
* [`5cd89f91`](https://github.com/NixOS/nixpkgs/commit/5cd89f9173c313c85d17c00cb9393b638b664710) python3Packages.dsinternals: init at 1.2.4
* [`8b118258`](https://github.com/NixOS/nixpkgs/commit/8b1182587217019753d6bedc7df766ee641b802f) certipy: unstable-2021-11-08 -> 2.0
* [`9b84a53c`](https://github.com/NixOS/nixpkgs/commit/9b84a53ce8ef9bef0b6d1374d281dcabced4c17b) Adjust ehmry maintainership
* [`22fc52a4`](https://github.com/NixOS/nixpkgs/commit/22fc52a4b11be91ec8791c3e4427c4823d776d7c) bird2: 2.0.8 -> 2.0.9
* [`4710213b`](https://github.com/NixOS/nixpkgs/commit/4710213b36635f0364f53a7e3cd63832abc28b94) lagrange: 1.10.5 -> 1.10.6
* [`6b14b4fb`](https://github.com/NixOS/nixpkgs/commit/6b14b4fb30a94559a3e4e4dac7c83bb15e11e494) libliftoff: 0.1.0 -> 0.2.0
* [`8c6ba1fe`](https://github.com/NixOS/nixpkgs/commit/8c6ba1fe12deea33701028240426284b9343deb4) svgbob: 0.6.3 -> 0.6.4
* [`74a17478`](https://github.com/NixOS/nixpkgs/commit/74a1747887fa611d31294311dff076aa35071755) svgbob: 0.6.4 -> 0.6.5
* [`79f76cd8`](https://github.com/NixOS/nixpkgs/commit/79f76cd8df535587074f74916fa853097025f4a7) fish: fix cross compile
* [`76007afe`](https://github.com/NixOS/nixpkgs/commit/76007afe26b20830bb307ebdf70444ce98023024) yate: 6.1.0-1 -> 6.4.0-1
* [`2d28e648`](https://github.com/NixOS/nixpkgs/commit/2d28e64868296e361202352645c297385be3c15c) yq-go: 4.20.1 -> 4.20.2
* [`be840f03`](https://github.com/NixOS/nixpkgs/commit/be840f035a8a7a2af5d725c15155db8871221a3a) exploitdb: 2022-02-17 -> 2022-02-19
* [`8b7f1265`](https://github.com/NixOS/nixpkgs/commit/8b7f1265c2213ed6dbd92f84670f7ab0c539d435) mdbook-graphviz: 0.1.3 -> 0.1.4
* [`f9cdab72`](https://github.com/NixOS/nixpkgs/commit/f9cdab729d89429f48ea91c333c65fa9f7f3bfc7) readline5, readline62: drop
* [`bd76a1ed`](https://github.com/NixOS/nixpkgs/commit/bd76a1edbc5d1681cfd8efbfbfc090aaf362f238) phantomjs: drop
* [`dae6f96a`](https://github.com/NixOS/nixpkgs/commit/dae6f96a4178bfe3d4bd8782d553ac9e487abc3c) haskellPackages.git-annex: Add shellPath for the git-annex-shell.
* [`23881812`](https://github.com/NixOS/nixpkgs/commit/23881812cffcd8f0b51d4f3e640438cd40dc017f) python3Packages.pywlroots: 0.15.8 -> 0.15.9
* [`3efa108f`](https://github.com/NixOS/nixpkgs/commit/3efa108f6eaaf2109ec5e83b139a74743fa1d4d2) checkov: 2.0.873 -> 2.0.875
* [`6a3c746e`](https://github.com/NixOS/nixpkgs/commit/6a3c746e3bca67bc3f589493d364c8970c7162b8) python3Packages.aiohttp-wsgi: 0.9.1 -> 0.10.0
* [`064a1d87`](https://github.com/NixOS/nixpkgs/commit/064a1d87c339abb68d62dc7e5840da481e8ef9dc) python3Packages.georss-wa-dfes-client: 0.3 -> 0.4
* [`4d237532`](https://github.com/NixOS/nixpkgs/commit/4d2375326ea15abadb7cbd1b2be3a494da7deb67) python3Packages.georss-qld-bushfire-alert-client: 0.5 -> 0.6
* [`aa418a01`](https://github.com/NixOS/nixpkgs/commit/aa418a0101119facbbfab2072ca3f3ba7e6bfb1f) python3Packages.pyskyqremote: 0.3.1 -> 0.3.2
* [`5ab8c97a`](https://github.com/NixOS/nixpkgs/commit/5ab8c97a90c3579a47b3cf4ef24f0e16f014d86e) python3Packages.rki-covid-parser: 1.3.1 -> 1.3.2
* [`d9d37eea`](https://github.com/NixOS/nixpkgs/commit/d9d37eea316a06f1b7b6451a33eb7aa51e7a7253) esphome: 2022.2.3 -> 2022.2.4
* [`d81f048e`](https://github.com/NixOS/nixpkgs/commit/d81f048ef4ce360ba2d11d3d7c94398be134b380) jless: 0.7.1 -> 0.7.2
* [`13f55bab`](https://github.com/NixOS/nixpkgs/commit/13f55bab1b1c68a0c7c6b63872ddb9aa57438068) ioztat: init at 1.1.0
* [`fa7af736`](https://github.com/NixOS/nixpkgs/commit/fa7af73685366d1da6d248679bf2b9ce7007692e) alejandra: 0.3.0 -> 0.3.1
* [`3fc658e0`](https://github.com/NixOS/nixpkgs/commit/3fc658e07ea08105349c3823905ba204ab92e5e1) python3Packages.bimmer-connected: 0.8.10 -> 0.8.11
* [`4ffd1c3a`](https://github.com/NixOS/nixpkgs/commit/4ffd1c3aa242171a3314b92559cc4e4a05c8f4f7) esphome: fix esp32 build
