### PR TITLE
niv home-manager: update 7c2ae0bd -> 69536af2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06",
-        "sha256": "017b3v16zas9914d7pbqva1fg3bdi7wrqrlks5pbymrr2ypb3v64",
+        "rev": "69536af27e86a9fc875d71cb9566ccccf47b5b60",
+        "sha256": "1p16rnz1q023xmky6ckdiyaz939i562sv58n8237r2yj0g2bdazi",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/69536af27e86a9fc875d71cb9566ccccf47b5b60.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@7c2ae0bd...69536af2](https://github.com/nix-community/home-manager/compare/7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06...69536af27e86a9fc875d71cb9566ccccf47b5b60)

* [`03b74951`](https://github.com/nix-community/home-manager/commit/03b7495183e86e3d71852975697dcb7ac8779811) docs: fix typo and clarify
* [`23a9f912`](https://github.com/nix-community/home-manager/commit/23a9f9127c3975fd3c25869c55a6014ee2aefaeb) home-manager: add more pass-through options
* [`50204cea`](https://github.com/nix-community/home-manager/commit/50204cea940ffe8aa479c255e84ba1f633084a13) completion.*: add flake-related arguments
* [`a3c18a60`](https://github.com/nix-community/home-manager/commit/a3c18a60d598157f34d7774956c05fb975838994) neovim: add `extraLuaPackages` to neovim, fixes [nix-community/home-manager⁠#1964](https://togithub.com/nix-community/home-manager/issues/1964). ([nix-community/home-manager⁠#2617](https://togithub.com/nix-community/home-manager/issues/2617))
* [`2a7e2472`](https://github.com/nix-community/home-manager/commit/2a7e247202b6bfc158af47eac7bec8f460a3f72e) Translate using Weblate (Russian)
* [`810e5f36`](https://github.com/nix-community/home-manager/commit/810e5f36131c6b6eb1bcc1e3cff23cc604e82887) zellij: add module
* [`2116fe6b`](https://github.com/nix-community/home-manager/commit/2116fe6b50a5118d56f1f443cccf024abee9de40) zsh: move sessionVariables from .zshrc to .zshenv ([nix-community/home-manager⁠#2708](https://togithub.com/nix-community/home-manager/issues/2708))
* [`498c188e`](https://github.com/nix-community/home-manager/commit/498c188e62a879c128aa4210f3e1031a6afe4916) eww: add module
* [`5375afb2`](https://github.com/nix-community/home-manager/commit/5375afb2fbe6043c02f333e93289507caef0ea9f) eww: fix maintainer referencee
* [`30082a62`](https://github.com/nix-community/home-manager/commit/30082a623ac3a88b6649251602c10464570dc011) docs: fix standalone flake setup
* [`c859a526`](https://github.com/nix-community/home-manager/commit/c859a5265ac08db6f5bd750f04e6654cd5b12eab) sway: add tray.target
* [`5b208b42`](https://github.com/nix-community/home-manager/commit/5b208b42b2f2a364735723510bd12899770c9dda) docs: section how to update system
* [`4f4165a8`](https://github.com/nix-community/home-manager/commit/4f4165a8b9108818ab0193bbd1a252106870b2a2) espanso: add module
* [`0232fe1b`](https://github.com/nix-community/home-manager/commit/0232fe1b75e6d7864fd82b5c72f6646f87838fc3) atuin: don't install widget on limited terminals
* [`b3af91d2`](https://github.com/nix-community/home-manager/commit/b3af91d293ef1178ad426306495c7a85ad8b8c9d) tests/nnn: fix tests ([nix-community/home-manager⁠#2746](https://togithub.com/nix-community/home-manager/issues/2746))
* [`69536af2`](https://github.com/nix-community/home-manager/commit/69536af27e86a9fc875d71cb9566ccccf47b5b60) himalaya: fix smtp-starttls option ([nix-community/home-manager⁠#2744](https://togithub.com/nix-community/home-manager/issues/2744))
