### PR TITLE
niv spacemacs: update f2afab0c -> 011b1454

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "f2afab0c32c1dfb8e2bfd3d1c4c84c8db5a68c4b",
-        "sha256": "0mlq1iqks51gvdplbiz9jcy09vssxn9m6y4mnfyviig0gr4m74gs",
+        "rev": "011b1454e1dd9bbb1cad425572501ad7506e51bc",
+        "sha256": "13mm76kvrabfhx7fydsnh4yaq8a5jhjz2hlx1jrcq3g3knikyv9b",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/f2afab0c32c1dfb8e2bfd3d1c4c84c8db5a68c4b.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/011b1454e1dd9bbb1cad425572501ad7506e51bc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@f2afab0c...011b1454](https://github.com/syl20bnr/spacemacs/compare/f2afab0c32c1dfb8e2bfd3d1c4c84c8db5a68c4b...011b1454e1dd9bbb1cad425572501ad7506e51bc)

* [`b7e1dee1`](https://github.com/syl20bnr/spacemacs/commit/b7e1dee13f619646d9d419f518f6ba8d835bef41) spacemacs-buffer: Added optional feature to show file icons ([syl20bnr/spacemacs⁠#15332](https://togithub.com/syl20bnr/spacemacs/issues/15332))
* [`13dedf72`](https://github.com/syl20bnr/spacemacs/commit/13dedf72509ea271ca201abd24f3409d88d32f51) spacemacs-buffer: fix bug to show random banner
* [`3deed8f0`](https://github.com/syl20bnr/spacemacs/commit/3deed8f060624ae3085c21d93843235259eaf2ff) compleseus: corrects name of some renamed consul commands ([syl20bnr/spacemacs⁠#15352](https://togithub.com/syl20bnr/spacemacs/issues/15352))
* [`82624811`](https://github.com/syl20bnr/spacemacs/commit/82624811dd83d6df91179010d2a74c39e3af188e) spacemacs-buffer: bug fix and improvement
* [`ee3c558c`](https://github.com/syl20bnr/spacemacs/commit/ee3c558c80bbadfa4c692936ab9502765a4867f8) spacemacs-buffer: fixed a bug on native-comnp
* [`91024552`](https://github.com/syl20bnr/spacemacs/commit/910245527dc2ddcfd676f03bf90f480a541a8c38) spacemacs-evil: use official evil-iedit-state
* [`761e2025`](https://github.com/syl20bnr/spacemacs/commit/761e2025aa37981af99e9eb4964a9de8de7c9023) spacemacs-buffer: fix `pacemacs-buffer||propertize-heading`
* [`4f66e93e`](https://github.com/syl20bnr/spacemacs/commit/4f66e93ed94451dace943a25e3511d64a30c5495) Add 'devdocs' dir to '.gitignore' file. ([syl20bnr/spacemacs⁠#15368](https://togithub.com/syl20bnr/spacemacs/issues/15368))
* [`3cc0f998`](https://github.com/syl20bnr/spacemacs/commit/3cc0f9980080aba3d881aa79f19a0db34eec13a6) [osx] don't set dired-listing-switches ([syl20bnr/spacemacs⁠#15371](https://togithub.com/syl20bnr/spacemacs/issues/15371))
* [`011b1454`](https://github.com/syl20bnr/spacemacs/commit/011b1454e1dd9bbb1cad425572501ad7506e51bc) quickurl: fix typo
