### PR TITLE
niv nixpkgs: update afb9a57a -> 9783ef30

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "afb9a57ae3c0cc5c7ba0689935727faca223f011",
-        "sha256": "1scpxwlzn4is8b5jlch9q88ccaqwa9q16nlr9pbmiivm0if2n97v",
+        "rev": "9783ef308da620a48a9849d977dd1dfdf7f9ba45",
+        "sha256": "1v96lrhsjq76xxmn7bv1vkqb5nbg6qnm03bqqx02cz6bmvgbzwyy",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/afb9a57ae3c0cc5c7ba0689935727faca223f011.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9783ef308da620a48a9849d977dd1dfdf7f9ba45.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@afb9a57a...9783ef30](https://github.com/nixos/nixpkgs/compare/afb9a57ae3c0cc5c7ba0689935727faca223f011...9783ef308da620a48a9849d977dd1dfdf7f9ba45)

* [`a06b41a0`](https://github.com/NixOS/nixpkgs/commit/a06b41a02fb9b810dff1716f9d7235362482de59) python3Packages.google-cloud-bigtable: disable on older Python releases
* [`b8d80588`](https://github.com/NixOS/nixpkgs/commit/b8d80588aa51e038f16e12faa558ba2238251ba5) python3Packages.google-cloud-translate: disable on older Python releases
* [`37a19c55`](https://github.com/NixOS/nixpkgs/commit/37a19c55df912a111d10f4b78367ad906db031b0) chromium: Suffix instead of prefix ${xdg-utils}/bin to $PATH
* [`0dda2d38`](https://github.com/NixOS/nixpkgs/commit/0dda2d3888eb8726dcdd891f34cbc64db8d1c85a) pgadmin4: init at 6.3
* [`69ec03d1`](https://github.com/NixOS/nixpkgs/commit/69ec03d112f9ca80f12ae5e744c5d3cc5e262724) pgadmin3: move
* [`46bb6a78`](https://github.com/NixOS/nixpkgs/commit/46bb6a78dbcf293dc651b8bcb02f16e6d78b24ae) haskellPackages.callCabal2nix: Use stdenvNoCC
* [`b4524d8e`](https://github.com/NixOS/nixpkgs/commit/b4524d8eda7fae5fc81e83286a402a37526220eb) haskellPackages.haskellSrc2nix: stdenvNoCC.mkDerivation -> runCommand
* [`3bcb49ab`](https://github.com/NixOS/nixpkgs/commit/3bcb49aba45e58d8eedeca0f8804fb329cdcad23) ocamlPackages.pycaml: remove at 0.82-14
* [`0afa5a14`](https://github.com/NixOS/nixpkgs/commit/0afa5a144439f544c195ce796e91a2b5d7bce2d7) pgadmin4: 6.3 -> 6.5
* [`0d09c4cc`](https://github.com/NixOS/nixpkgs/commit/0d09c4cc6fe9b86abb2e859a6283e572dd531ce8) qownnotes: 22.2.7 -> 22.2.9
* [`3cbd5a6d`](https://github.com/NixOS/nixpkgs/commit/3cbd5a6deb68511189d19bfbf51b925b34830035) pgadmin4: expose setup.py as pgadmin4-setup
* [`ae2f179c`](https://github.com/NixOS/nixpkgs/commit/ae2f179c9b27f6d4c40e46a07b1d748ba53f3b33) tests/pgadmin4-standalone: add
* [`56471498`](https://github.com/NixOS/nixpkgs/commit/56471498943c97a8bf7b81f4a5a2bfa5420c0f16) accountsservice: 0.6.55 → 22.07.5
* [`7614caf3`](https://github.com/NixOS/nixpkgs/commit/7614caf32979bda5133735504c819bd58f244e7b) accountsservice: clean up
* [`9adfe4a6`](https://github.com/NixOS/nixpkgs/commit/9adfe4a6ac8173d3e08348e96733f8dc6d096713) accountsservice: Fix setting profile picture in GNOME Settings
* [`42a5831e`](https://github.com/NixOS/nixpkgs/commit/42a5831e6235f815546411c48106381f2b2d1a8a) nixos/pgadmin: init
* [`03fbc3ea`](https://github.com/NixOS/nixpkgs/commit/03fbc3ea99fa1b5379a68019cf81267bcd403db2) release-notes: mention pgadmin
* [`e0df172c`](https://github.com/NixOS/nixpkgs/commit/e0df172ce2111052f20dd180fc91cc0e9bbdfc0f) gitlab: 14.7.3 -> 14.7.4 ([nixos/nixpkgs⁠#161948](https://togithub.com/nixos/nixpkgs/issues/161948))
* [`41fbd969`](https://github.com/NixOS/nixpkgs/commit/41fbd969da4a668125042781c6eb41f58f53feb1) python310Packages.ormar: 0.10.24 -> 0.10.25
* [`c790751a`](https://github.com/NixOS/nixpkgs/commit/c790751a59657d98cbfa9cf003688ccf3851ced8) gegl: 0.4.34 → 0.4.36
* [`8a1af228`](https://github.com/NixOS/nixpkgs/commit/8a1af22836abb4718e9e6c0598af3bf3e82a38de) python310Packages.google-cloud-dataproc: 3.2.0 -> 3.3.0
* [`0c8d2aa9`](https://github.com/NixOS/nixpkgs/commit/0c8d2aa94d06f552d215638347725fc4a119b403) rofi: fix cross compilation
* [`4497d352`](https://github.com/NixOS/nixpkgs/commit/4497d3522e8ec59a160e2e9d0ba7853d97fe3ca9) dockle: 0.4.4 -> 0.4.5
* [`61d2bc0c`](https://github.com/NixOS/nixpkgs/commit/61d2bc0cfe14ca32d420766b83ad0a839a3503c1) gnome-tour: 40.0 -> 40.1
* [`dd9760d9`](https://github.com/NixOS/nixpkgs/commit/dd9760d9f7e5b13d2323781cf468d5fe90d1794c) purescript: 0.14.5 -> 0.14.6
* [`9c61cdfb`](https://github.com/NixOS/nixpkgs/commit/9c61cdfb85f87abbe25e47d4005407a34179a88a) gnome.gpaste: 3.42.5 -> 3.42.6
* [`ce25f6f2`](https://github.com/NixOS/nixpkgs/commit/ce25f6f2db789d8374d0fa5a737cd6f3ab09d813) argo: fix cross compilation
* [`6fede792`](https://github.com/NixOS/nixpkgs/commit/6fede79227a872f860d3ba8ee95d08459c4a0509) unrar: 6.1.4 -> 6.1.5
* [`8d87ec8d`](https://github.com/NixOS/nixpkgs/commit/8d87ec8d17a4a7f4c8d88816de4d4e6063a98077) shadowsocks-rust: 1.13.3 -> 1.13.5
* [`f17c99c1`](https://github.com/NixOS/nixpkgs/commit/f17c99c166c064b6fcf597ff681ced509810f779) fend: 0.1.28 -> 0.1.29
* [`74b76b9e`](https://github.com/NixOS/nixpkgs/commit/74b76b9e042887aa38ebbbb4a5cd2f2d6327d380) python310Packages.azure-mgmt-batch: 16.0.0 -> 16.1.0
* [`b97b9c37`](https://github.com/NixOS/nixpkgs/commit/b97b9c376c093ca3a582a4477e6e61a40a9fc6d5) tor-browser-bundle-bin: add tor.calyxinstitute.org mirror
* [`24cbda98`](https://github.com/NixOS/nixpkgs/commit/24cbda98f321bad884e3e464ec0ef965d4a91777) fetchzip: remove need for overrideAttrs
* [`35c1b68c`](https://github.com/NixOS/nixpkgs/commit/35c1b68c8640f2a22ee925c903bfc29d5c125259) lfs: 2.1.0 -> 2.1.1
* [`0b77e65f`](https://github.com/NixOS/nixpkgs/commit/0b77e65fa61c5b20b973b42952f0051f8cacdf43) html-xml-utils: 8.2 -> 8.3
* [`464bb0bb`](https://github.com/NixOS/nixpkgs/commit/464bb0bb59a27f311441429fa99167de3f300ae8) evolution-ews: 3.42.3 -> 3.42.4
* [`c9fa0313`](https://github.com/NixOS/nixpkgs/commit/c9fa03136ad26fab9c5d4d62c57fc26e2d5dc9e5) or-tools: disable parallel-building
* [`1827d631`](https://github.com/NixOS/nixpkgs/commit/1827d6315a8a6862e9bb40f1bc554045efd95065) uncrustify: 0.72.0 -> 0.74.0
* [`2bdadac1`](https://github.com/NixOS/nixpkgs/commit/2bdadac12312a5078fea298b94d5ac1d50337e2d) python310Packages.ibm-cloud-sdk-core: 3.14.0 -> 3.15.0
* [`6431bebc`](https://github.com/NixOS/nixpkgs/commit/6431bebc93b6ce35f98d9c6d1b09975126a391d8) mesa: Limit the devDoesNotDependOnLLVM test to Linux
* [`d4096ffd`](https://github.com/NixOS/nixpkgs/commit/d4096ffd0a36e5600906cad6deca864a0c9b01db) mpd-discord-rpc: 1.4.0 -> 1.4.1
* [`05b2b4e3`](https://github.com/NixOS/nixpkgs/commit/05b2b4e3cbfa23926cb30ffab16d2f2409a1b6c0) chromiumBeta: 99.0.4844.35 -> 99.0.4844.45
* [`154e13a5`](https://github.com/NixOS/nixpkgs/commit/154e13a556984f1aa2f88b6c866a8370cf21af1a) chromiumDev: 100.0.4892.0 -> 100.0.4896.12
* [`cc0b1fdd`](https://github.com/NixOS/nixpkgs/commit/cc0b1fddcdd9a55005d18ecee6fc30eabc89d156) python3Packages.mlflow: 1.22.0 -> 1.23.1
* [`f2943856`](https://github.com/NixOS/nixpkgs/commit/f29438562f9693f724e022e1fe0196ad983bdf6f) nextcloud-client: add xdg-utils
* [`b438b68c`](https://github.com/NixOS/nixpkgs/commit/b438b68cb495e48f104e4f87ac28ef52c6e7b3cd) python3Packages.zcs: patch to fix the test
* [`c267e9ce`](https://github.com/NixOS/nixpkgs/commit/c267e9ce37dd2f2f9975ab83c538a624f1fede50) mumble,murmur: 1.3.4 -> 1.4.231
* [`005a18f6`](https://github.com/NixOS/nixpkgs/commit/005a18f6bda9376fe8f92b324db4ac05cd5387de) hepmc3: 3.2.4 -> 3.2.5
* [`953c9a5d`](https://github.com/NixOS/nixpkgs/commit/953c9a5d6e162ee35455f13b77d2c4d279356223) coreboot-toolchain: 4.15 -> 4.16
* [`0dadec45`](https://github.com/NixOS/nixpkgs/commit/0dadec45d805c31a0cff3d1ea4e0a3e9a357edfe) logrotate/systemd: add 'minsize = 1M' to wtmp/btmp rotation
* [`e517d280`](https://github.com/NixOS/nixpkgs/commit/e517d280c01521b15795c9b493fc1e7c911fd3bd) libtraceevent: 1.5.0 -> 1.5.1
* [`d1418cce`](https://github.com/NixOS/nixpkgs/commit/d1418cce93da4c3fb5d2a419ada82d20f77e24c5) velero: 1.7.1 -> 1.8.0
* [`fe73c827`](https://github.com/NixOS/nixpkgs/commit/fe73c8276aaeea3f05c6d8090bbc34a592ad77a6) libtracefs: 1.2.5 -> 1.3.0
* [`e0819e3c`](https://github.com/NixOS/nixpkgs/commit/e0819e3c508fea4e4c7903684ecd66ce58a31c02) jool: 4.1.6 -> 4.1.7
* [`6fa9f8b5`](https://github.com/NixOS/nixpkgs/commit/6fa9f8b56410b8dc9e3d22b102fd256264a4f94f) plexamp: 4.0.2 -> 4.0.3
* [`06e5302e`](https://github.com/NixOS/nixpkgs/commit/06e5302eb5ede88379355afc88d12305f8890d8d) apktool: 2.6.0 -> 2.6.1
* [`9d3a2508`](https://github.com/NixOS/nixpkgs/commit/9d3a2508162e770ee90c5fbf17d743ce50986831) bazarr: 1.0.2 -> 1.0.3
* [`23380df7`](https://github.com/NixOS/nixpkgs/commit/23380df7de6a417630aa181e7e5bb60fa475d45d) randtype: mark as broken on darwin
* [`dc23e694`](https://github.com/NixOS/nixpkgs/commit/dc23e69491c746083210618e7b55dd1afb010621) python3Packages.tensorflow: 2.7.0 -> 2.7.1 ([nixos/nixpkgs⁠#161589](https://togithub.com/nixos/nixpkgs/issues/161589))
* [`9e609e9d`](https://github.com/NixOS/nixpkgs/commit/9e609e9d81c0156163e1d0985f5858597fcf79e2) rtsp-simple-server: 0.17.8 -> 0.17.17
* [`6e1e1ddf`](https://github.com/NixOS/nixpkgs/commit/6e1e1ddf070a703c51f77ffa7aa176c339dc055a) python3Packages.ipython: disable clipboard test on darwin (targeting master)
* [`867bbad5`](https://github.com/NixOS/nixpkgs/commit/867bbad5c295ec1959bb15e6ffa87b4875f840dd) gdown: 4.3.1 -> 4.4.0
* [`17df62a9`](https://github.com/NixOS/nixpkgs/commit/17df62a9373741f490aacb817c0341704dd5a830) shiori: fix NixOS test ([nixos/nixpkgs⁠#161969](https://togithub.com/nixos/nixpkgs/issues/161969))
* [`eec72b56`](https://github.com/NixOS/nixpkgs/commit/eec72b56d773d0e808d8c95c72290a7f16f12962) cataclysm-dda: enable parallel building ([nixos/nixpkgs⁠#161957](https://togithub.com/nixos/nixpkgs/issues/161957))
* [`78ec9971`](https://github.com/NixOS/nixpkgs/commit/78ec9971a49bc005082d8cb100b484f1d096b42b) bat: 0.19.0 -> 0.20.0
* [`33a22b33`](https://github.com/NixOS/nixpkgs/commit/33a22b332a8743acdc01505b238de9f882657a77) python310Packages.motionblinds: 0.5.13 -> 0.6.0
* [`6e389e63`](https://github.com/NixOS/nixpkgs/commit/6e389e63678fe13660bcc9f708649e64eae6bb05) nixos/bird: run service as non-root user, add test for reload
* [`9f064b9d`](https://github.com/NixOS/nixpkgs/commit/9f064b9d541652f8b92fa70b786525b0eacac9d5) lfs: 2.1.1 -> 2.2.0
* [`d118f55e`](https://github.com/NixOS/nixpkgs/commit/d118f55e2310b29fdb037d900e062705edcb27dd) php74Packages.composer: 2.2.6 -> 2.2.7
* [`aa23e9cd`](https://github.com/NixOS/nixpkgs/commit/aa23e9cdb4fbe367a7aceee96a00d5865fafeb50) minio-client: 2022-02-23T03-15-59Z -> 2022-02-26T03-58-31Z
* [`0f43432b`](https://github.com/NixOS/nixpkgs/commit/0f43432b55212b0abf58095b18c000e15d1608e0) php74Extensions.mongodb: 1.12.0 -> 1.12.1
* [`bd61b913`](https://github.com/NixOS/nixpkgs/commit/bd61b9139fac3cd637a91a00b80ec79aeec228a7) mob: 2.3.0 -> 2.5.0
* [`5668e630`](https://github.com/NixOS/nixpkgs/commit/5668e6309f97e4a35e60bbb21f5d442ac92cb588) python310Packages.rpyc: 5.0.1 -> 5.1.0
* [`9a07db13`](https://github.com/NixOS/nixpkgs/commit/9a07db13ca03d93362edb6e6a7ab22813f6f6ba8) nfpm: 2.13.0 -> 2.14.0
* [`8e97a58b`](https://github.com/NixOS/nixpkgs/commit/8e97a58b5665f9f4eabe7602ac06de16b031a41a) okapi: 1.3.0 -> 1.4.0
* [`64ba26f7`](https://github.com/NixOS/nixpkgs/commit/64ba26f745354ace38e955ca0554b0825c901ce3) purescript: 0.14.6 -> 0.14.7
* [`19185e8c`](https://github.com/NixOS/nixpkgs/commit/19185e8ca9f2176242bd7910cbd35e6e7fdd545c) du-dust: 0.7.5 -> 0.8.0
* [`98b8385e`](https://github.com/NixOS/nixpkgs/commit/98b8385e20ee82adce7d2b7d72374efa44226665) oven-media-engine: 0.13.0 -> 0.13.1
* [`f04b4d06`](https://github.com/NixOS/nixpkgs/commit/f04b4d064033a7adfb4d1c1838192e63c6239165) calibre: 5.34.0 -> 5.37.0
* [`e1214d5d`](https://github.com/NixOS/nixpkgs/commit/e1214d5d8a959d78b0607d54d9b165b27f68bd54) python310Packages.samsungtvws: 1.7.0 -> 2.0.0
* [`c596cb7c`](https://github.com/NixOS/nixpkgs/commit/c596cb7cb25a60a94f7dc21601497c7fb7fb5f7c) omnisharp-roslyn: support Darwin
* [`faae760e`](https://github.com/NixOS/nixpkgs/commit/faae760e98c9a17d9604d2b66b8a15a13071f94e) llvmPackages_git.llvm: Drop llvm-config-link-static.patch ([nixos/nixpkgs⁠#162101](https://togithub.com/nixos/nixpkgs/issues/162101))
* [`e2ba45f5`](https://github.com/NixOS/nixpkgs/commit/e2ba45f5abc7332b07d57d9cb17ea9da3b3a8887) llvmPackages_14: Copy the files from llvmPackages_git
* [`d61e45b6`](https://github.com/NixOS/nixpkgs/commit/d61e45b686bba959ae361425a47a881a43a56fad) llvmPackages_14: init at 2022-01-07
* [`c06351b0`](https://github.com/NixOS/nixpkgs/commit/c06351b06e94305f152b53aaa1eb9eb52cdfbda3) opentabletdriver: v0.6.0.2 -> v0.6.0.3
* [`fbb2eb81`](https://github.com/NixOS/nixpkgs/commit/fbb2eb81f87e113a10c11050b90f25c875f665ea) texlab: 3.3.1 -> 3.3.2
* [`45cd41de`](https://github.com/NixOS/nixpkgs/commit/45cd41de23593be4ab1da45546b883ef14f3e596) llvmPackages_{git,14}: Replace tabs in lld/default.nix
* [`a9defb71`](https://github.com/NixOS/nixpkgs/commit/a9defb71ed07cc53cc47b9a9da8cf0767b437014) python39Packages.fontparts: 0.10.2 -> 0.10.3
* [`cd1c866d`](https://github.com/NixOS/nixpkgs/commit/cd1c866d87f943c266a315c2cb0bd34a5acd12dd) readability-lxml: init at 0.8.1
* [`ea7ff89d`](https://github.com/NixOS/nixpkgs/commit/ea7ff89d2cc3790ba087a17d14d807bd04881f8a) archivy: 1.6.1 -> 1.7.1
* [`169ba823`](https://github.com/NixOS/nixpkgs/commit/169ba823d9379e6adec8ff703adb43be5b4e4659) cmark-gfm: fix includes
* [`339463b0`](https://github.com/NixOS/nixpkgs/commit/339463b00d7b42c2bd09086386edb4cfd06beb4c) python310Packages.python-izone: 1.2.4 -> 1.2.7
* [`22ce0cf3`](https://github.com/NixOS/nixpkgs/commit/22ce0cf3649ca70d026c227d4116ba48d75a894c) texworks: 0.6.6 -> 0.6.7
* [`2448f4dd`](https://github.com/NixOS/nixpkgs/commit/2448f4dd455119cfd272bc6618cbd2db38a86bc7) qgis: 3.22.3 -> 3.24.0
* [`9f27578b`](https://github.com/NixOS/nixpkgs/commit/9f27578b401813f9355ca3c789e10df872541d7d) qgis-ltr: 3.16.16 -> 3.22.4
* [`e18d2801`](https://github.com/NixOS/nixpkgs/commit/e18d2801ad5b50bc82e4a42dd083d9795d75966a) qgis: add willcohen to maintainers
* [`b2ffb9fc`](https://github.com/NixOS/nixpkgs/commit/b2ffb9fc96c3b2c1f16112a750da03c82b789760) qgis-ltr: add willcohen to maintainers
* [`b3bb79b6`](https://github.com/NixOS/nixpkgs/commit/b3bb79b6b1747755846a3c974b6ca0e865bb05ff) aquosctl: init at unstable-2014-04-06
* [`27e7b4d9`](https://github.com/NixOS/nixpkgs/commit/27e7b4d9c754e6595e3c5033b691cadd40b999bf) steam: add dotnet support
* [`0685f53c`](https://github.com/NixOS/nixpkgs/commit/0685f53c66ec580e560cbc04f468bbb3f6d7d5a1) python310Packages.hg-evolve: 10.4.1 -> 10.5.0
* [`323837f7`](https://github.com/NixOS/nixpkgs/commit/323837f7db75d84672a9d5a2368905b132ef91cf) llvmPackages_14: 2022-01-07 -> 14.0.0-rc1
* [`74cb03c8`](https://github.com/NixOS/nixpkgs/commit/74cb03c8efd046bde52a915e0403a65b89aea727) python3Packages.weconnect: 0.36.4 -> 0.37.0
* [`899f4107`](https://github.com/NixOS/nixpkgs/commit/899f4107a4ceff0a32b71c648a74970837d0e6ad) python3Packages.weconnect-mqtt: 0.29.1 -> 0.30.0
* [`507ab175`](https://github.com/NixOS/nixpkgs/commit/507ab175316c6b1d4510b696182b1af6148aa7ca) python3Packages.celery: add nixosTests.sourcehut as passthru test
* [`11189a2c`](https://github.com/NixOS/nixpkgs/commit/11189a2cd4224efa55f1402630dba47908178311) vimPlugins.vim-CtrlXA: init at 2021-08-09
* [`d91c40a3`](https://github.com/NixOS/nixpkgs/commit/d91c40a3cd423124518a6f7c4a3b7d7b192cf5f8) vscode-extensions.llvm-vs-code-extensions.vscode-clangd: 0.1.13 -> 0.1.15
* [`0e734b2f`](https://github.com/NixOS/nixpkgs/commit/0e734b2fe223b3e9dd3cad878ed41738fb6017a3) python310Packages.django-dynamic-preferences: 1.11.0 -> 1.12.0
* [`1300b351`](https://github.com/NixOS/nixpkgs/commit/1300b351a73d9a4792bf7eae9bf8048e46abcd24) vscode-extensions.redhat.java: 1.2.0 -> 1.3.0
* [`f006f108`](https://github.com/NixOS/nixpkgs/commit/f006f108ab66d49d4755819213be80bd2f9c0d3b) python310Packages.APScheduler: 3.8.1 -> 3.9.0.post1
* [`a0abe63e`](https://github.com/NixOS/nixpkgs/commit/a0abe63e440a320323251895d2f6de61e0893d57) python310Packages.aiogithubapi: 22.2.3 -> 22.2.4
* [`881a1092`](https://github.com/NixOS/nixpkgs/commit/881a10922712ae4dbb784d5240728222ea176bf3) Revert "Revert "linuxPackages: bump default 5.10 -> 5.15""
* [`177281ad`](https://github.com/NixOS/nixpkgs/commit/177281ad00b6e5f1b3ba9acced399e2bc7d37340) nixos/amazon-image: use 5_10 kernel and add assert
* [`836c6353`](https://github.com/NixOS/nixpkgs/commit/836c6353cc33fd43e3c956040e77d050a4e6e727) linux_5_15: mark as broken on i686
* [`fa52a102`](https://github.com/NixOS/nixpkgs/commit/fa52a102be121ea203f4fb4a1fcb403426c0fee5) linuxPackages: use 5_10 kernel on i686
* [`56828530`](https://github.com/NixOS/nixpkgs/commit/56828530275888e4d79ee64f8ff772bdbfe34637) nixos/release: disable nfs3.simple
* [`f79572f9`](https://github.com/NixOS/nixpkgs/commit/f79572f92ff4fa7024aad4c50494318fdb331fe4) k3s: update script fixed
* [`820d3be4`](https://github.com/NixOS/nixpkgs/commit/820d3be48821a91469aa25536c3596de48ab7d6d) k3s: add superherointj to maintainers
* [`a1df6e1b`](https://github.com/NixOS/nixpkgs/commit/a1df6e1ba3e0a26fcc7923d3555ea97d698e36dd) python310Packages.pyamg: 4.2.1 -> 4.2.2
* [`0a800749`](https://github.com/NixOS/nixpkgs/commit/0a8007498f9dba0d5feb191d16317ffa85a9e698) bash: use default PATH in FHS environments
