### PR TITLE
niv fast-syntax-highlighting: update 585c0899 -> ef8ba84c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "585c089968caa1c904cbe926ff04a1be9e3d8f42",
-        "sha256": "1lc9mhi25ybkcn0747j3i8y2hrmakv5mxndglf6yfiipxpd05vn7",
+        "rev": "ef8ba84c3a76c768f49a0bdd2a620b2f53c2478a",
+        "sha256": "058s55r8gq1giwnb2si8k38nvd0qy8jlhd9zhvsxyl0mvi7wk9ar",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/585c089968caa1c904cbe926ff04a1be9e3d8f42.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/ef8ba84c3a76c768f49a0bdd2a620b2f53c2478a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@585c0899...ef8ba84c](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/585c089968caa1c904cbe926ff04a1be9e3d8f42...ef8ba84c3a76c768f49a0bdd2a620b2f53c2478a)

* [`8064150e`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/8064150eee8ff8f7c13883f1d642e43985480880) -ssh.sh: don't expand $userdirs for user matching
* [`c8771e43`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/c8771e436de2980d19accabdd4f79b70dbf9e230) docs(`README.md`): correct link pointing to chromas directory ([zdharma-continuum/fast-syntax-highlighting⁠#19](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/19))
* [`ef8ba84c`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/ef8ba84c3a76c768f49a0bdd2a620b2f53c2478a) fix: correct highlighting logic for hex color codes (e.g., `#fff` & `#ffffff`) ([zdharma-continuum/fast-syntax-highlighting⁠#18](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/18))
