### PR TITLE
niv home-manager: update 69536af2 -> afe96e74

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "69536af27e86a9fc875d71cb9566ccccf47b5b60",
-        "sha256": "1p16rnz1q023xmky6ckdiyaz939i562sv58n8237r2yj0g2bdazi",
+        "rev": "afe96e7433c513bf82375d41473c57d1f66b4e68",
+        "sha256": "0z6ak8mwx2n5fwqvygjlmxg20xmx6c6ffda219y3agf8gz22lfjq",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/69536af27e86a9fc875d71cb9566ccccf47b5b60.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/afe96e7433c513bf82375d41473c57d1f66b4e68.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@69536af2...afe96e74](https://github.com/nix-community/home-manager/compare/69536af27e86a9fc875d71cb9566ccccf47b5b60...afe96e7433c513bf82375d41473c57d1f66b4e68)

* [`838d40d6`](https://github.com/nix-community/home-manager/commit/838d40d61a91e3807836545c4b420572ab2d62eb) foot: set OOMPolicy=continue for foot server ([nix-community/home-manager⁠#2749](https://togithub.com/nix-community/home-manager/issues/2749))
* [`0b1745b4`](https://github.com/nix-community/home-manager/commit/0b1745b4ef4c35ec5d554b176539730fcb5ec141) neovim: autogenerate config.lua file sourced to init.vim ([nix-community/home-manager⁠#2716](https://togithub.com/nix-community/home-manager/issues/2716))
* [`1950eb87`](https://github.com/nix-community/home-manager/commit/1950eb878b0290ca2b2f0d85804281b57799c64a) Add translation using Weblate (Italian)
* [`2248ea18`](https://github.com/nix-community/home-manager/commit/2248ea1831611aa5c4926c5ccfa0eb7803af78b3) Add translation using Weblate (Italian)
* [`1faefcde`](https://github.com/nix-community/home-manager/commit/1faefcded37d4d094d086ccf9796de50ca5bc7f7) Translate using Weblate (Russian)
* [`8f7d9255`](https://github.com/nix-community/home-manager/commit/8f7d9255034b12d52242a87f41d2dd8242992083) gitui: add module
* [`650cfe60`](https://github.com/nix-community/home-manager/commit/650cfe60f31f3d27ba869bf7db12ca8ded5f1d74) vscode: fix name of extension in example ([nix-community/home-manager⁠#2759](https://togithub.com/nix-community/home-manager/issues/2759))
* [`662350be`](https://github.com/nix-community/home-manager/commit/662350bee2090edc82b4c162b1415f76b4eee2f3) neovim: remove trace log of vim plugins ([nix-community/home-manager⁠#2756](https://togithub.com/nix-community/home-manager/issues/2756)) ([nix-community/home-manager⁠#2760](https://togithub.com/nix-community/home-manager/issues/2760))
* [`c7a13f76`](https://github.com/nix-community/home-manager/commit/c7a13f76a78bb5c225ca5e08e9a109347d130792) launchd: initial support for LaunchAgents
* [`ccd00e3c`](https://github.com/nix-community/home-manager/commit/ccd00e3c93b89b26ca86749cfe64b371e2dd7910) launchd: fix undefined variable in activation script ([nix-community/home-manager⁠#2763](https://togithub.com/nix-community/home-manager/issues/2763))
* [`1d90b606`](https://github.com/nix-community/home-manager/commit/1d90b6065a0e8713b21cffd7af4f03e31894ae8b) tiny: add module ([nix-community/home-manager⁠#2735](https://togithub.com/nix-community/home-manager/issues/2735))
* [`2499b916`](https://github.com/nix-community/home-manager/commit/2499b916921adde8a694117bc007efdde8bbd918) treewide: apply nixfmt to a few more files
* [`ea85f4b1`](https://github.com/nix-community/home-manager/commit/ea85f4b1fdf3f25cf97dc49f4a9ec4eafda2ea25) launchd: fix multiple agents
* [`e58a7cb1`](https://github.com/nix-community/home-manager/commit/e58a7cb13d5d870550888cdc6fe92154efd9e571) xdg-desktop-entries: adjust to API changes
* [`541874f5`](https://github.com/nix-community/home-manager/commit/541874f55d7c15b4c67329ec0370b245dea322e8) mpd: add basic test case
* [`d119cea3`](https://github.com/nix-community/home-manager/commit/d119cea3763977801ad66330668c1ab4346cb7f7) i3status-rust: change default to newer version ([nix-community/home-manager⁠#2774](https://togithub.com/nix-community/home-manager/issues/2774))
* [`87beebc7`](https://github.com/nix-community/home-manager/commit/87beebc7a2d52dbbf15bbca6099e01d2c719ded3) just: add module
* [`4e685639`](https://github.com/nix-community/home-manager/commit/4e6856397e930228ca887a4fd28a3292395443bf) Translate using Weblate (Polish)
* [`abd221c4`](https://github.com/nix-community/home-manager/commit/abd221c4b38c98293dab38da59a26b14bd4053af) Translate using Weblate (Turkish)
* [`afe96e74`](https://github.com/nix-community/home-manager/commit/afe96e7433c513bf82375d41473c57d1f66b4e68) pubs: add module
