### PR TITLE
niv powerlevel10k: update 123136c0 -> f07d7bae

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "123136c0e7566a2a12385f3836e3e92df6b42be1",
-        "sha256": "122rc1znv2dbh4g4y085hw6w992yh7agsfvb3zsrlw7wisfk4h0s",
+        "rev": "f07d7baea36010bfa74708844d404517ea6ac473",
+        "sha256": "0208437mx12rnqwdmw3r9n5w6n8zq1h3y7h1nm8yr92acnxq8rz5",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/123136c0e7566a2a12385f3836e3e92df6b42be1.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/f07d7baea36010bfa74708844d404517ea6ac473.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prezto": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@123136c0...f07d7bae](https://github.com/romkatv/powerlevel10k/compare/123136c0e7566a2a12385f3836e3e92df6b42be1...f07d7baea36010bfa74708844d404517ea6ac473)

* [`b898d1de`](https://github.com/romkatv/powerlevel10k/commit/b898d1de150c1dd26da2d0b0376ae7b517b9665f) feature: added perlbrew
* [`40a5cdfa`](https://github.com/romkatv/powerlevel10k/commit/40a5cdfa6cf20af0133f888be095198ea49d41a1) chore: forgot to add global variables to main
* [`f07d7bae`](https://github.com/romkatv/powerlevel10k/commit/f07d7baea36010bfa74708844d404517ea6ac473) minor cleanup around perlbrew
