### PR TITLE
niv spacemacs: update 011b1454 -> f5489758

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "011b1454e1dd9bbb1cad425572501ad7506e51bc",
-        "sha256": "13mm76kvrabfhx7fydsnh4yaq8a5jhjz2hlx1jrcq3g3knikyv9b",
+        "rev": "f5489758417a7d75d0319b5c9f537d93f106a773",
+        "sha256": "03jcjs0z8z20s34x04anl6x8g8pwz4bknzkz10p1zzljq1fn7qyl",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/011b1454e1dd9bbb1cad425572501ad7506e51bc.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/f5489758417a7d75d0319b5c9f537d93f106a773.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@011b1454...f5489758](https://github.com/syl20bnr/spacemacs/compare/011b1454e1dd9bbb1cad425572501ad7506e51bc...f5489758417a7d75d0319b5c9f537d93f106a773)

* [`e9adfe91`](https://github.com/syl20bnr/spacemacs/commit/e9adfe912229ceae3d3715dfdfbba96130a3f561) [scala] add keybinding for running `Test / compile` in SBT ([syl20bnr/spacemacs⁠#15372](https://togithub.com/syl20bnr/spacemacs/issues/15372))
* [`8587ab6d`](https://github.com/syl20bnr/spacemacs/commit/8587ab6df07a1796584c7d129ef399f6be681350) fix: do not setenv PAGER in shell layer ([syl20bnr/spacemacs⁠#15369](https://togithub.com/syl20bnr/spacemacs/issues/15369))
* [`9f1155a9`](https://github.com/syl20bnr/spacemacs/commit/9f1155a998e9a540a92a678dad22c599bd225547) [bot] "documentation_updates" Tue Feb 22 16:39:44 UTC 2022 ([syl20bnr/spacemacs⁠#15373](https://togithub.com/syl20bnr/spacemacs/issues/15373))
* [`b316ee93`](https://github.com/syl20bnr/spacemacs/commit/b316ee936f5b1bb3a3f69626e19244d64072e9b4) reinstate cfgl-layer docstring fix ([syl20bnr/spacemacs⁠#15376](https://togithub.com/syl20bnr/spacemacs/issues/15376))
* [`a027f34a`](https://github.com/syl20bnr/spacemacs/commit/a027f34a949d4ceb6303465a23520f19872124a3) spacemacs-navigation: golden-ratio fix for SPC w TAB. ([syl20bnr/spacemacs⁠#15374](https://togithub.com/syl20bnr/spacemacs/issues/15374))
* [`f5489758`](https://github.com/syl20bnr/spacemacs/commit/f5489758417a7d75d0319b5c9f537d93f106a773) Use org-agenda-files correctly in insert-recent-files ([syl20bnr/spacemacs⁠#15367](https://togithub.com/syl20bnr/spacemacs/issues/15367))
