### PR TITLE
niv zsh-completions: update 3fb84ee9 -> 6fbf5fc9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "3fb84ee9cc290adb38ac02c629f7fc026acfd2ff",
-        "sha256": "03hlwq9213cgmp8bcr28ajhj0x6ibm2gmn5ih688rf72nszs70sb",
+        "rev": "6fbf5fc9a7033bc47d4c61b2d6b97fe0c74d9c45",
+        "sha256": "1qyp3iblnhxqyadqkmagc53nvndvs9s31751j1gad9v877sbqz72",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/3fb84ee9cc290adb38ac02c629f7fc026acfd2ff.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/6fbf5fc9a7033bc47d4c61b2d6b97fe0c74d9c45.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@3fb84ee9...6fbf5fc9](https://github.com/zsh-users/zsh-completions/compare/3fb84ee9cc290adb38ac02c629f7fc026acfd2ff...6fbf5fc9a7033bc47d4c61b2d6b97fe0c74d9c45)

* [`83d9ea92`](https://github.com/zsh-users/zsh-completions/commit/83d9ea92186cf5420899039a1746eba3deec832b) Remove cheat completions
* [`b34650ea`](https://github.com/zsh-users/zsh-completions/commit/b34650ea31c61ab02d093d85049e638fe17bfbf5) fix presets
* [`ff6031a8`](https://github.com/zsh-users/zsh-completions/commit/ff6031a8ea549ca8deff1f163a43388cce936160) re-write to use python, hopefully this is portable enough, tested with python 3.6.5 anf 2.7.18
* [`d9e81e08`](https://github.com/zsh-users/zsh-completions/commit/d9e81e08f20cddb37377b8f8af0c4da706b7e829) Rewrite JSON parsing code in Perl for portability
