### PR TITLE
niv zsh-syntax-highlighting: update 56b44334 -> c5ce0014

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -228,10 +228,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "56b44334617aa719e8e01bb5e00d3e176114a036",
-        "sha256": "1xpn0rgvw50m5x6c9pa58a0kz5jz50jp8f33yddnm8jszzhas9nk",
+        "rev": "c5ce0014677a0f69a10b676b6038ad127f40c6b1",
+        "sha256": "000ksv6bb4qkdzp6fdgz8z126pwin6ywib5d6cfwqa2w27xqm9sj",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/56b44334617aa719e8e01bb5e00d3e176114a036.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/c5ce0014677a0f69a10b676b6038ad127f40c6b1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@56b44334...c5ce0014](https://github.com/zsh-users/zsh-syntax-highlighting/compare/56b44334617aa719e8e01bb5e00d3e176114a036...c5ce0014677a0f69a10b676b6038ad127f40c6b1)

* [`caeca0bf`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/caeca0bf6b4dd26026df884e32ca3915f0e1b780) docs: regexp: Document the platform dependency
* [`643717cc`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/643717ccafb35a1b56a1407c852275406467b6f0) changelog: Update zsh version numbers
* [`2cd73fcb`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/2cd73fcbde1b47f0952027c0674c32b9f1756a59) *: Update sourceforge links
* [`5459ebcc`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/5459ebcc4e788e1db514d95a0bf81adb6f19ea74) main: precommand_options += grc
* [`c5ce0014`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/c5ce0014677a0f69a10b676b6038ad127f40c6b1) main: Deconfuse $EDITOR
