### PR TITLE
niv nixpkgs: update 9783ef30 -> bc265bf8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9783ef308da620a48a9849d977dd1dfdf7f9ba45",
-        "sha256": "1v96lrhsjq76xxmn7bv1vkqb5nbg6qnm03bqqx02cz6bmvgbzwyy",
+        "rev": "bc265bf81389f1882a19fa24a649c27c4dd070bc",
+        "sha256": "0wqchxiqjd7dw39rnakzw7yih58f7gjb34n8fa4pff6gc4sra0z9",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/9783ef308da620a48a9849d977dd1dfdf7f9ba45.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/bc265bf81389f1882a19fa24a649c27c4dd070bc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@9783ef30...bc265bf8](https://github.com/nixos/nixpkgs/compare/9783ef308da620a48a9849d977dd1dfdf7f9ba45...bc265bf81389f1882a19fa24a649c27c4dd070bc)

* [`b2f3e416`](https://github.com/NixOS/nixpkgs/commit/b2f3e4165e8861ddc78cc427a73708bae87154a5) firefox-esr: 91.6.0esr -> 91.6.1esr
* [`9c465fc4`](https://github.com/NixOS/nixpkgs/commit/9c465fc4e6ea70d493d9f6d0442dcb3cf5fefd10) nixos/tests/home-assistant: drop mqtt tests
* [`a253e17d`](https://github.com/NixOS/nixpkgs/commit/a253e17d4a8e29b3c1933c7e2db882cfc1c679b5) home-assistant: 2022.3.0 -> 2022.3.1
* [`1a07b3f0`](https://github.com/NixOS/nixpkgs/commit/1a07b3f05b7e76945273c48744d0492578d56d17) babashka: 0.7.6 -> 0.7.7
* [`149d6826`](https://github.com/NixOS/nixpkgs/commit/149d68268dc698fb1689f1336aa4c38e38616c63) root: fix ROOTConfig.cmake.in patching
* [`5218aba1`](https://github.com/NixOS/nixpkgs/commit/5218aba1326a1df48238cbde28b000f98b209a11) lilypond: 2.22.1 -> 2.22.2
* [`c2fc98a4`](https://github.com/NixOS/nixpkgs/commit/c2fc98a4aa14fbea8d4318094eafad889a3f86a9) distrobox: init at 1.2.13
* [`0278ee6c`](https://github.com/NixOS/nixpkgs/commit/0278ee6c4fcca381ef9873ea0fb25af315de63d1) clj-kondo: 2022.02.09 -> 2022.03.04
* [`d753ad72`](https://github.com/NixOS/nixpkgs/commit/d753ad72af63f59311f1206c92fb911a3f2707d0) earthly: 0.6.9 -> 0.6.10
* [`3c745c05`](https://github.com/NixOS/nixpkgs/commit/3c745c05fb1d0979af3c6db7dc8c12d35c7e41e0) python310Packages.pyrogram: 1.4.7 -> 1.4.8
* [`27f61e4b`](https://github.com/NixOS/nixpkgs/commit/27f61e4b3e8438087b70549ba6d4f15e9a317f20) ent-go: 0.10.0 -> 0.10.1
* [`e3a60c19`](https://github.com/NixOS/nixpkgs/commit/e3a60c19f8918c72d8fb556b52216ec8e90d6fb5) yarn2nix: support new yarn workspace json
* [`d6db766b`](https://github.com/NixOS/nixpkgs/commit/d6db766b87f89e2a07f48cc6b1aae58ceec318f4) python310Packages.fastapi: 0.74.1 -> 0.75.0
* [`181d3f75`](https://github.com/NixOS/nixpkgs/commit/181d3f75f9517e4e0cf0f80f83ef49e25fc81836) geant4.data: fix evaluation
* [`915b971e`](https://github.com/NixOS/nixpkgs/commit/915b971efada6c85bae43f3b00dec4426a94f9ad) jackett: 0.20.660 -> 0.20.663
* [`ff597533`](https://github.com/NixOS/nixpkgs/commit/ff5975338afddaac7219ed5b7994ba01718ca3af) chromium: fix download due to typo
* [`85e428b8`](https://github.com/NixOS/nixpkgs/commit/85e428b8e4b8fccafffa3a54a245fc58d4c14784) python3Packages.reolink: 0053 -> 0.60
* [`015c16f8`](https://github.com/NixOS/nixpkgs/commit/015c16f87e503c87cf08d6c4ca9fe8327ba35847) python3Packages.ffmpeg-python: disable failing test on Python 3.10
* [`e7b5e62d`](https://github.com/NixOS/nixpkgs/commit/e7b5e62d0a01f94c5b1376775a0f8943da7f1417) aliyun-cli: 3.0.109 -> 3.0.110 ([nixos/nixpkgs⁠#162833](https://togithub.com/nixos/nixpkgs/issues/162833))
* [`d88bb647`](https://github.com/NixOS/nixpkgs/commit/d88bb647c149cdb624cbfa9d3130e5cc01a2ddaf) ccache: fix download hash
* [`1bdeae35`](https://github.com/NixOS/nixpkgs/commit/1bdeae3546415664370cb81a816c1d73bcfb89c5) lfs: 2.2.0 -> 2.4.0
* [`eb8c10a8`](https://github.com/NixOS/nixpkgs/commit/eb8c10a816370c3145a7812d0d7a4d826ff9d561) python310Packages.fastavro: 1.4.9 -> 1.4.10
* [`a8c080b0`](https://github.com/NixOS/nixpkgs/commit/a8c080b0b9a6d580859a28539df1b48fb2fa39ca) schildichat: 1.10.3-sc.0.test.1 -> 1.10.4-sc.1 ([nixos/nixpkgs⁠#162131](https://togithub.com/nixos/nixpkgs/issues/162131))
* [`1f9e0b76`](https://github.com/NixOS/nixpkgs/commit/1f9e0b76d09a6b68a7f9b8ff6c7cc8285fead30c) wego: unstable-2019-02-11 -> 2.1
* [`8556aadd`](https://github.com/NixOS/nixpkgs/commit/8556aaddccb07dbf23cee24e17a5b5099e2ce45b) batsignal: 1.3.4 -> 1.3.5
* [`6458e082`](https://github.com/NixOS/nixpkgs/commit/6458e0829f4467c0b80d13519e8ae73bc9680640) libwbxml: 0.11.7 -> 0.11.8
* [`0e352390`](https://github.com/NixOS/nixpkgs/commit/0e352390e217c587a97ba2fed240e2e145a12f20) sickgear: 0.25.26 -> 0.25.28
* [`a70ed538`](https://github.com/NixOS/nixpkgs/commit/a70ed538918e7fe09d4720961693b8e145ac06a6) dovecot_fts_xapian: 1.5.2 -> 1.5.4
* [`8a95d9fe`](https://github.com/NixOS/nixpkgs/commit/8a95d9fede1dd191228af37b8a75d706b88fa481) nixos/flatpak: enable polkit
* [`9ae8234e`](https://github.com/NixOS/nixpkgs/commit/9ae8234e8ff0f6c079389fca7e01937461e657fa) clipster: 2.0.2 -> 2.1.1
* [`9b87a779`](https://github.com/NixOS/nixpkgs/commit/9b87a77964aa66189cfa6d80deca0864674832c9) platformio: 5.2.4 -> 5.2.5
* [`f386c42a`](https://github.com/NixOS/nixpkgs/commit/f386c42a48397d232869e03f123e2bb5f8bfd3d8) nixos/doc: improve wording in "Options Types" and "Option Declarations"
* [`1354f51b`](https://github.com/NixOS/nixpkgs/commit/1354f51bdb2d314449058375a9485118f9af744d) whois: 5.5.11 -> 5.5.12
* [`c914eeea`](https://github.com/NixOS/nixpkgs/commit/c914eeeaa73e60807af679846be48bf6ce825b5d) vscode-extensions.james-yu.latex-workshop: 8.2.0 -> 8.23.0
* [`84eccc04`](https://github.com/NixOS/nixpkgs/commit/84eccc04487d653cc09e3fcc8ed0bca3bff86d2d) vscode-extensions.eamodio.gitlens: 11.7.0 -> 12.0.1
* [`386d5b3e`](https://github.com/NixOS/nixpkgs/commit/386d5b3ee80d092f10a94218feaba10a0c5cd9e8) vscode-extensions.github.vscode-pull-request-github: 0.35.2022010609 -> 0.37.2022030309
* [`00347883`](https://github.com/NixOS/nixpkgs/commit/003478830b47b0099c7ebfeb0061f71af7a8814e) oil-buku: improved syntax
* [`cb760417`](https://github.com/NixOS/nixpkgs/commit/cb76041783eb5cb40d1ec376cdadabced6ab45be) diffoscope: 205 -> 207
* [`63955110`](https://github.com/NixOS/nixpkgs/commit/639551108422e7386cfe4f232b9537c87c09468f) sniffglue: 0.14.0 -> 0.15.0
* [`ca43e4a4`](https://github.com/NixOS/nixpkgs/commit/ca43e4a438662e5ce3ba46d1e0f1d67dfb4c0fe7) hyperfine: 1.12.0 -> 1.13.0
* [`f7e9fa8d`](https://github.com/NixOS/nixpkgs/commit/f7e9fa8dc6eca6b48458d80902b97d4f6aff0fd3) nix-output-monitor: 1.0.4.0 -> 1.0.5.0
* [`b4e2df2e`](https://github.com/NixOS/nixpkgs/commit/b4e2df2e10616396ecdbacecc52d5c7bc92e8efd) remove networkmanager098 ([nixos/nixpkgs⁠#162904](https://togithub.com/nixos/nixpkgs/issues/162904))
* [`feba0915`](https://github.com/NixOS/nixpkgs/commit/feba091524d02d52bde79842f814a00b39b15db7) werf: 1.2.72 -> 1.2.73
* [`16fbf265`](https://github.com/NixOS/nixpkgs/commit/16fbf26530163d2244e2cdc2d4d1a12fe022ba0c) ungoogled-chromium: 98.0.4758.102 -> 99.0.4844.51
* [`b0439f0b`](https://github.com/NixOS/nixpkgs/commit/b0439f0bd269e99d597b7e0a5788b7be40780a6d) streamlink: 3.1.1 -> 3.2.0
* [`a7ae3eff`](https://github.com/NixOS/nixpkgs/commit/a7ae3eff03f8f3750a9e1109b9eae55b411370d4) intel-gmmlib: 22.0.2 -> 22.0.3
* [`73fd38fe`](https://github.com/NixOS/nixpkgs/commit/73fd38fe67cd4a0e5ae2db933b3251a2c35aa29f) biodiff: init at 1.0.1
* [`bc6b0979`](https://github.com/NixOS/nixpkgs/commit/bc6b09791edb89e22e175d1b57d7834999922db1) rauc: 1.5.1 -> 1.6
* [`a173e92e`](https://github.com/NixOS/nixpkgs/commit/a173e92ee458878651356b9bcfb1e2b5145f76af) igrep: 0.1.2 -> 0.2.0
* [`14f14eb6`](https://github.com/NixOS/nixpkgs/commit/14f14eb6ad99ed3c03a2a70c9f148e6952556403) glitter: 1.5.14 -> 1.5.15
* [`0d510c9f`](https://github.com/NixOS/nixpkgs/commit/0d510c9fb60cb3eba0434d360568a3535c58f152) bacon: 2.0.0 -> 2.0.1
* [`14eb3ead`](https://github.com/NixOS/nixpkgs/commit/14eb3ead59416dfff950d593986932114d739d3c) btop: 1.2.4 -> 1.2.5
* [`6aec94c8`](https://github.com/NixOS/nixpkgs/commit/6aec94c801cb361224b1d3d49cd3678e72131d5c) calamares: 3.2.51 -> 3.2.53
* [`f90d177a`](https://github.com/NixOS/nixpkgs/commit/f90d177a981aebcbd0d54e95f1879788f1610717) python310Packages.lupa: 1.10 -> 1.13
* [`8bf052a6`](https://github.com/NixOS/nixpkgs/commit/8bf052a607094d8219f621774a571b7ce255aa0d) kdiff3: 1.9.4 -> 1.9.5
* [`7516b203`](https://github.com/NixOS/nixpkgs/commit/7516b203d78689df0553bf8604d89e07a8272b05) yandex-browser: 21.6.2.817-1 -> 22.1.3.856-1
* [`2b0c964e`](https://github.com/NixOS/nixpkgs/commit/2b0c964e4b0e366bd7f54fd01de9871e6b8328a2) github-desktop: 2.9.6 -> 2.9.9
* [`df44cea4`](https://github.com/NixOS/nixpkgs/commit/df44cea4feac401bd5528ff249ba39fd9b146382) ddgr: 1.9 -> 2.0
* [`a8f6e92f`](https://github.com/NixOS/nixpkgs/commit/a8f6e92fdd6fd69823311368767c10b37fc62ed7) earlyoom: 1.6.2 -> 1.7
* [`a810619d`](https://github.com/NixOS/nixpkgs/commit/a810619d4fe6f5d251695a9ba9f4040fa4e1c266) foxotron: 2021-08-13 -> 2022-03-05
* [`4b059031`](https://github.com/NixOS/nixpkgs/commit/4b059031e3663a19f94dfc267e1571cbd3bf39f5) mkgmap: 4896 -> 4897
* [`e08090e4`](https://github.com/NixOS/nixpkgs/commit/e08090e479e89ca04ebacb5b54b12aa1570b6b22) thunderbird-bin: 91.6.1 -> 91.6.2
* [`93aeade5`](https://github.com/NixOS/nixpkgs/commit/93aeade5567ef3f4fd8ec60700046a67a6573e7b) thunderbird: 91.6.1 -> 91.6.2
* [`f3288c60`](https://github.com/NixOS/nixpkgs/commit/f3288c60f0139f5be8295db73802a6718934aab8) marvin: 22.3.0 -> 22.7.0
* [`afced370`](https://github.com/NixOS/nixpkgs/commit/afced370a66d7fd78ee868c2a74760cf0b579fb6) python310Packages.deezer-py: 1.3.6 -> 1.3.7
* [`64cb3a02`](https://github.com/NixOS/nixpkgs/commit/64cb3a021bc454c638458349c286aa3a8cbd0456) tiny: make dbus, openssl, and notifications each optional
* [`05a656ac`](https://github.com/NixOS/nixpkgs/commit/05a656acf1fcd924f2bdf8b86182b69aae89b01c) checkov: 2.0.913 -> 2.0.918
* [`047ac8cc`](https://github.com/NixOS/nixpkgs/commit/047ac8cca2b01ea1030740baab5a6d4bdc46e64b) csound: 6.16.2 -> 6.17.0
* [`6ede6183`](https://github.com/NixOS/nixpkgs/commit/6ede6183296771d62110d73a55cdada0bf6fc14a) python3Packages.pydroid-ipcam: 2021-06-01 -> 1.3.1
* [`c7a7acb0`](https://github.com/NixOS/nixpkgs/commit/c7a7acb034f090a315d79f05475327919a501cfd) sway: respect systemdSupport and dbusSupport ([nixos/nixpkgs⁠#160972](https://togithub.com/nixos/nixpkgs/issues/160972))
* [`64373d18`](https://github.com/NixOS/nixpkgs/commit/64373d18f9a91f6759a7443cc593a71e470ef020) mtools: 4.0.37 -> 4.0.38
* [`a3dc42f2`](https://github.com/NixOS/nixpkgs/commit/a3dc42f2954dada879992af53aba9985986a67d0) python3Packages.intellifire4py: 0.9.10 -> 1.0.0
* [`1122130c`](https://github.com/NixOS/nixpkgs/commit/1122130c6f5b1bd388334ba02f06383ab4ceffa6) ungoogled-chromium: inherit upstream's build flags
* [`6e73c0de`](https://github.com/NixOS/nixpkgs/commit/6e73c0de7d336e0420710b27e20720e9b1990c21) cozy-drive: 3.30.1 -> 3.32.0
* [`afb3e019`](https://github.com/NixOS/nixpkgs/commit/afb3e01958af208fb96b19930d48984b29f27008) grails: 4.1.0.M1 -> 5.1.2
* [`9fbd32c5`](https://github.com/NixOS/nixpkgs/commit/9fbd32c5733641d4a109a5a9ce8f12100bd6b240) ocamlPackages.ocaml-lsp: 1.9.1 -> 1.10.3
* [`5ea04680`](https://github.com/NixOS/nixpkgs/commit/5ea0468032ffeb12f80cf049cf2439f20cf53347) nncp: 8.6.0 -> 8.7.0
* [`8cf26309`](https://github.com/NixOS/nixpkgs/commit/8cf2630925453666cbdafe3c150ae0f42bc7c632) tshark: alias to wireshark-cli
* [`d0a7cf78`](https://github.com/NixOS/nixpkgs/commit/d0a7cf788e75b10080d53e7985606e4f5dce41ec) python3Packages.canonicaljson: 1.5.0 -> 1.6.0
* [`82c4fff8`](https://github.com/NixOS/nixpkgs/commit/82c4fff8d4120ae7da99512b0698cd1f135719c4) ghorg: 1.7.8 -> 1.7.10
* [`599cd39e`](https://github.com/NixOS/nixpkgs/commit/599cd39ec13f60e45ba7cbe445a7e0842060bf3b) openboard: fix build
* [`238c01ad`](https://github.com/NixOS/nixpkgs/commit/238c01ad213ff2583b63a7a47565d3b40ccc52af) vscode-extensions.viktorqvarfordt.vscode-pitch-black-theme: 1.2.4 -> 1.3.0
* [`2eaf09cf`](https://github.com/NixOS/nixpkgs/commit/2eaf09cf6ba1c52010f5c59b20009b5009b9ae1a) pulumictl: init at 0.0.29
* [`ccc067fd`](https://github.com/NixOS/nixpkgs/commit/ccc067fd9f0b375366429e84ae782296d14528ed) ioztat: 1.1.0 -> 2.0.1
* [`0e16ba47`](https://github.com/NixOS/nixpkgs/commit/0e16ba47b7cd89ca1f50054421a16ea6857c6c64) tinyssh: 20220222 -> 20220305
* [`b06d4704`](https://github.com/NixOS/nixpkgs/commit/b06d47040891abbbdcfed25e0ede03cc083cb47b) python3Packages.asyncsleepiq: 1.1.0 -> 1.1.2
* [`2bf8c1ab`](https://github.com/NixOS/nixpkgs/commit/2bf8c1ab87ae711c8fb76ac4c301996f5791eb19) python310Packages.scikit-survival: 0.17.0 -> 0.17.1
* [`7fc1df1d`](https://github.com/NixOS/nixpkgs/commit/7fc1df1d362b9d61ad12d3bd508b0a7279a19076) python310Packages.pymavlink: 2.4.20 -> 2.4.27
* [`31324964`](https://github.com/NixOS/nixpkgs/commit/313249641dc39eacb583770b040a7820d5c3c6af) python3Packages.google-nest-sdm: 1.7.1 -> 1.8.0
* [`7d0dde3b`](https://github.com/NixOS/nixpkgs/commit/7d0dde3b3ab3d6d2a945ae2ceb3b6255d7933724) signal-desktop: 5.33.0 -> 5.34.0
* [`c3b01a2e`](https://github.com/NixOS/nixpkgs/commit/c3b01a2e24f63aa80db90028650b40080c8df4aa) python3Packages.herepy: 3.5.6 -> 3.5.7
* [`afc04e8a`](https://github.com/NixOS/nixpkgs/commit/afc04e8a051873d82acafc1e7c1eead6f563a8e4) fn-cli: 0.6.14 -> 0.6.15
* [`b58fb10f`](https://github.com/NixOS/nixpkgs/commit/b58fb10fbfd5be339bc3d1856fddbde64becffd4) python3Packages.aiohomekit: 0.7.15 -> 0.7.16
* [`69a285ff`](https://github.com/NixOS/nixpkgs/commit/69a285ff55d4ce8b90f2f889bdd366a28106a322) home-assistant: 2022.3.1 -> 2022.3.2
