### PR TITLE
niv zsh-completions: update 6fbf5fc9 -> 55d07cc5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "6fbf5fc9a7033bc47d4c61b2d6b97fe0c74d9c45",
-        "sha256": "1qyp3iblnhxqyadqkmagc53nvndvs9s31751j1gad9v877sbqz72",
+        "rev": "55d07cc57750eb90f8b02be3ddf42c206ecf17b1",
+        "sha256": "0p1zpk55c7wr0j9zj1fc68r52g2vib03hbzp36x4l680k9f357j6",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/6fbf5fc9a7033bc47d4c61b2d6b97fe0c74d9c45.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/55d07cc57750eb90f8b02be3ddf42c206ecf17b1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@6fbf5fc9...55d07cc5](https://github.com/zsh-users/zsh-completions/compare/6fbf5fc9a7033bc47d4c61b2d6b97fe0c74d9c45...55d07cc57750eb90f8b02be3ddf42c206ecf17b1)

* [`e17d4244`](https://github.com/zsh-users/zsh-completions/commit/e17d424462b7a4ed420f809e7fde909f19d98255) Don't complete if here is not git repository
* [`3933b18f`](https://github.com/zsh-users/zsh-completions/commit/3933b18fb32dd81950ec8df34e0c011b909ffaa9) Add install guide with zinit
