### PR TITLE
niv nixpkgs: update bc265bf8 -> 6a201dc7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc265bf81389f1882a19fa24a649c27c4dd070bc",
-        "sha256": "0wqchxiqjd7dw39rnakzw7yih58f7gjb34n8fa4pff6gc4sra0z9",
+        "rev": "6a201dc719648bb5582955480d39dd9b1ffe3d1f",
+        "sha256": "0d9jg7apkxa9gxkc29why1bmhz97wmms465zkaz6500ly3lb39gx",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/bc265bf81389f1882a19fa24a649c27c4dd070bc.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6a201dc719648bb5582955480d39dd9b1ffe3d1f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@bc265bf8...6a201dc7](https://github.com/nixos/nixpkgs/compare/bc265bf81389f1882a19fa24a649c27c4dd070bc...6a201dc719648bb5582955480d39dd9b1ffe3d1f)

* [`b04bfa70`](https://github.com/NixOS/nixpkgs/commit/b04bfa7048310c406621bc9615b9edcd9aa44fe9) endlessh-go: clarify license
* [`9533b97a`](https://github.com/NixOS/nixpkgs/commit/9533b97a8c729b55571fde0c88813bf22e281884) flat-remix-gtk: 20220215 -> 20220310
* [`4c6772e2`](https://github.com/NixOS/nixpkgs/commit/4c6772e2a1152f5c4cede5aeca89d1e3bab8c8a7) nixos/oci-containers: improve description of imageFile
* [`ae5063fc`](https://github.com/NixOS/nixpkgs/commit/ae5063fc07fdf67dab60899a1634395c074eeca9) checkov: 2.0.936 -> 2.0.938
* [`8af3673a`](https://github.com/NixOS/nixpkgs/commit/8af3673aeff80cb2949adf0d8bc52d1c30ee0227) python3Packages.pymediaroom: 0.6.4.1 -> 0.6.5.4
* [`84750aa8`](https://github.com/NixOS/nixpkgs/commit/84750aa8d952dfc840b6432da0bd0561b5c9b09c) python3Packages.zwave-js-server-python: 0.35.1 -> 0.35.2
* [`0f4f3a39`](https://github.com/NixOS/nixpkgs/commit/0f4f3a397f1779555e8266335efab5e1818ad1bc) home-assistant: 2022.3.3 -> 2022.3.4
* [`d32e1010`](https://github.com/NixOS/nixpkgs/commit/d32e10102539c7d73489032b1550d13a97b8275a) python310Packages.persistent: 4.8.0 -> 4.9.0
* [`a599e10c`](https://github.com/NixOS/nixpkgs/commit/a599e10c49259efdda1085ad87360a3d063605dd) lima: 0.8.3 -> 0.9.0
* [`1cc14ccd`](https://github.com/NixOS/nixpkgs/commit/1cc14ccdd49e6c4b4eb904d108707f3c512d1188) natscli: 0.0.29 -> 0.0.30
* [`a5c7dcdf`](https://github.com/NixOS/nixpkgs/commit/a5c7dcdf969fd40819754652c97ef17beb93b009) sdlookup: init at unstable-2022-03-10
* [`db725d89`](https://github.com/NixOS/nixpkgs/commit/db725d892e6f7a90686e9f5b7dddf9f78f0c3a2f) gtk-frdp: unstable-2021-10-01 -> unstable-2021-10-28
* [`898307e8`](https://github.com/NixOS/nixpkgs/commit/898307e862d09213996172f6f3324af9bf740c9e) libdnf: 0.65.0 -> 0.66.0
* [`e86acfa7`](https://github.com/NixOS/nixpkgs/commit/e86acfa7251d7158381fb1de394ccf82c88c178b) python310Packages.awsiotpythonsdk: 1.5.0 -> 1.5.1
* [`c16653f8`](https://github.com/NixOS/nixpkgs/commit/c16653f880dbfe006a6db154ea92a0f052e10b02) sipp: 3.6.0 -> 3.6.1
* [`1037236e`](https://github.com/NixOS/nixpkgs/commit/1037236e65cb903750a37d55a8eb668721bde866) noto-fonts-emoji: fix cross compilation
* [`4f90ac57`](https://github.com/NixOS/nixpkgs/commit/4f90ac5734715f965bdcba8e7a016c2c52eec5b7) lightburn: 1.1.01 -> 1.1.03
* [`26fe586d`](https://github.com/NixOS/nixpkgs/commit/26fe586d53ce14782ea378c51023352581939613) grails: 5.1.2 -> 5.1.3
* [`fa6becdf`](https://github.com/NixOS/nixpkgs/commit/fa6becdfa36069368a1911ff4128b42c7bc574a0) k3s: fix update script
* [`a6103317`](https://github.com/NixOS/nixpkgs/commit/a610331778b6c7160b66f160bb0fc42a3da20a38) gnome.gnome-todo: unstable-2022-02-01 -> unstable-2022-03-11
* [`5294f556`](https://github.com/NixOS/nixpkgs/commit/5294f556395b9d0552f60322a19c1efb41d3b687) slurm: 21.08.5.1 -> 21.08.6.1
* [`3f4faa39`](https://github.com/NixOS/nixpkgs/commit/3f4faa39a0346bb879b33d28af217507b5fa0f20) crow-translate: 2.9.1 → 2.9.2
* [`ee21acc3`](https://github.com/NixOS/nixpkgs/commit/ee21acc36a18112504bf0719c87cda33030cc64a) remmina: Set WITH_VTE=true, so remmina usable as ssh client
* [`5bc6b38e`](https://github.com/NixOS/nixpkgs/commit/5bc6b38ee014b4645dde62a5d18e873a034bedf4) gnunet: 0.15.3 -> 0.16.0
* [`1ac81748`](https://github.com/NixOS/nixpkgs/commit/1ac817481388d2bf53fd3ec13f49e7f118806a40) microdnf: 3.8.0 -> 3.8.1
* [`a521e116`](https://github.com/NixOS/nixpkgs/commit/a521e116c4034e4f6fe25a0eb33f7f25a16a0306) minio-client: 2022-03-03T21-12-24Z -> 2022-03-09T02-08-36Z
* [`a40de4b1`](https://github.com/NixOS/nixpkgs/commit/a40de4b146815c15e3c601625c9f4818c4be44d7) xschem: init at version 3.0.0
* [`5d702c6b`](https://github.com/NixOS/nixpkgs/commit/5d702c6b2344b4bac4a4428c5d424d62c65e39e0) gaw: init at version 20200922
* [`b1f34660`](https://github.com/NixOS/nixpkgs/commit/b1f34660f324290ecd315dcb2d4e308a23194fac) python310Packages.sqlite-utils: 3.25 -> 3.25.1
* [`29d7a27d`](https://github.com/NixOS/nixpkgs/commit/29d7a27d9f34ab48d801b7b5f69e8dbff8018640) opensmt: 2.2.0 -> 2.3.0
* [`f5e999d5`](https://github.com/NixOS/nixpkgs/commit/f5e999d5a05273cd4a7c47eafdf2f4008f20743a) libvirt: cleanup
* [`c451480c`](https://github.com/NixOS/nixpkgs/commit/c451480cb1ffbd08b9f176c80bae787393c12e63) python310Packages.google-cloud-texttospeech: 2.10.2 -> 2.11.0
* [`95de56ba`](https://github.com/NixOS/nixpkgs/commit/95de56ba01159bcb7044cd0f7d48eb04f9ac2d46) fish: 3.3.1 -> 3.4.0
* [`4ad8b43c`](https://github.com/NixOS/nixpkgs/commit/4ad8b43ce2480aa6649e2ec364f5515bd036b796) ruby: 3.1.0 -> 3.1.1
* [`b3a757a2`](https://github.com/NixOS/nixpkgs/commit/b3a757a21a738a3700069ca53c6acc3c564bf1dc) python3Packages.imap-tools: 0.51.1 -> 0.52.0
* [`29beb0e4`](https://github.com/NixOS/nixpkgs/commit/29beb0e46ed72707a768e8c4f2ad3ddb0a6c1cdd) python3Packages.volvooncall: 0.9.2 -> 0.10.0
* [`52cbeeda`](https://github.com/NixOS/nixpkgs/commit/52cbeeda30efb48b473495db9371178ec898108c) signal-desktop: Transfer maintainership
* [`f443859b`](https://github.com/NixOS/nixpkgs/commit/f443859b725bd5054cdc6db51c5ee462d166d717) bubblewrap: 0.5.0 -> 0.6.1
* [`bf783157`](https://github.com/NixOS/nixpkgs/commit/bf7831578d0ac4fe9b3d1339fdb529c7c3c2451a) python3Packages.mat2: only use bubblewrap on Linux
* [`8db28de9`](https://github.com/NixOS/nixpkgs/commit/8db28de91911514e9fe2e03b16128322ba322e62) metadata-cleaner: 2.1.4 -> 2.1.5
* [`7d5e470e`](https://github.com/NixOS/nixpkgs/commit/7d5e470e1fdd564d725f1b8db82fe126efcd649f) chromiumBeta: 100.0.4896.20 -> 100.0.4896.30
* [`7d5373b0`](https://github.com/NixOS/nixpkgs/commit/7d5373b0bab22db3e708fe9dc3cfbdf5d9b0982e) chromiumDev: 101.0.4919.0 -> 101.0.4929.5
* [`1307c79a`](https://github.com/NixOS/nixpkgs/commit/1307c79a1472100901f8dfec52845db660e6adfd) libhdhomerun: 20210624 -> 20220303
* [`06b3a5ac`](https://github.com/NixOS/nixpkgs/commit/06b3a5ac7de61529914f1ca360cac6605b8db4f9) expliot: relax dependency constraints
* [`9ec5ffb4`](https://github.com/NixOS/nixpkgs/commit/9ec5ffb4642e4e10032da4c7001e5d004d7f9728) qrcp: 0.8.5 -> 0.9.0
* [`3abf98e4`](https://github.com/NixOS/nixpkgs/commit/3abf98e46ca54da890eaf0b3059b9ff15a6f35b8) sngrep: 1.4.9 -> 1.4.10
* [`a75d0a2f`](https://github.com/NixOS/nixpkgs/commit/a75d0a2fa6d92bfbed9d073a8cd8570e5bc098c1) virt-manager: disable tests that rely on unfiltered sgio
* [`2837d240`](https://github.com/NixOS/nixpkgs/commit/2837d2401443b05c8243a25ce434ce9e096a67f3) Revert "fish: 3.3.1 -> 3.4.0"
* [`d713f47b`](https://github.com/NixOS/nixpkgs/commit/d713f47b99749f15441d447642169af6535c5258) virt-manager: compile gsettings schemas
* [`c2fba64b`](https://github.com/NixOS/nixpkgs/commit/c2fba64b200cf1476169629e3535f2612b7a1a4f) ytcc: 2.5.4 -> 2.5.5
* [`316b6f84`](https://github.com/NixOS/nixpkgs/commit/316b6f84c22aa022210b7b317a7df02458c266fc) Revert "Merge pull request [nixos/nixpkgs⁠#163714](https://togithub.com/nixos/nixpkgs/issues/163714) from lovesegfault/libvirt-8.1.0"
* [`ee108134`](https://github.com/NixOS/nixpkgs/commit/ee1081340409aebb6b58806ee6ea82477d1b3831) logseq: 0.6.1 -> 0.6.3 ([nixos/nixpkgs⁠#163754](https://togithub.com/nixos/nixpkgs/issues/163754))
* [`9506646f`](https://github.com/NixOS/nixpkgs/commit/9506646f14d351239b73020f3094b15e3f38d7b7) sockperf: 3.7 -> 3.8
* [`1a051750`](https://github.com/NixOS/nixpkgs/commit/1a0517507818f0ca726f8daf3708e732e8511ccd) sops: 3.7.1 -> 3.7.2
* [`5497a927`](https://github.com/NixOS/nixpkgs/commit/5497a9278617bcad5151fcb0f628fb7c5dcd1f65) jetbrains: add support for Apple M1
* [`b6a95da0`](https://github.com/NixOS/nixpkgs/commit/b6a95da0934e9675a072f388f76c5c37addafff1) firecracker: fix aarch64 sha
* [`cfb40928`](https://github.com/NixOS/nixpkgs/commit/cfb40928716ba1228661c21fc1a50198a86ceda9) open-vm-tools: 11.3.5 -> 12.0.0 ([nixos/nixpkgs⁠#163685](https://togithub.com/nixos/nixpkgs/issues/163685))
* [`82ad78ca`](https://github.com/NixOS/nixpkgs/commit/82ad78ca03090322893953cb6bfa267a3715f15a) flintlock: init at 0.1.0-alpha.9 ([nixos/nixpkgs⁠#163625](https://togithub.com/nixos/nixpkgs/issues/163625))
* [`cb75063b`](https://github.com/NixOS/nixpkgs/commit/cb75063bccb562b289a90c91ddf350151d69b3a7) v2ray-geoip: 202203020509 -> 202203100039
* [`fa403382`](https://github.com/NixOS/nixpkgs/commit/fa40338259e5a43cab1d87527e86e885e77a016b) python310Packages.parts: 1.2.2 -> 1.3.0
* [`d09489e5`](https://github.com/NixOS/nixpkgs/commit/d09489e5f18b20022da9f4ff97f002d03edfb742) QtRvSim: init at 0.9.1 ([nixos/nixpkgs⁠#163128](https://togithub.com/nixos/nixpkgs/issues/163128))
* [`2b6cb189`](https://github.com/NixOS/nixpkgs/commit/2b6cb18901b97bb019741d533207d4bec7518ffe) x11docker: 7.1.1 -> 7.1.3
* [`5f95fee8`](https://github.com/NixOS/nixpkgs/commit/5f95fee80eff6b224af62488d5610a8f8c88c3bb) python310Packages.pudb: 2022.1 -> 2022.1.1
* [`729ef324`](https://github.com/NixOS/nixpkgs/commit/729ef3246afc4d65121fbffce5ff187a0bbd8062) zellij: 0.25.0 -> 0.26.0
* [`c409ce5e`](https://github.com/NixOS/nixpkgs/commit/c409ce5eb8e7a74f3b3d9fb42468fe67334d997f) python310Packages.pyathena: 2.5.0 -> 2.5.1
* [`e46bfadd`](https://github.com/NixOS/nixpkgs/commit/e46bfadd6d089d4d3c830f4779172dca0b92a0ac) signal-desktop: 5.34.0 -> 5.35.0
* [`65f9112d`](https://github.com/NixOS/nixpkgs/commit/65f9112d6b22b9fb38d77a20ec2d1387d7cfc92e) nixos/pantheon: enable xdg desktop integration
* [`52bc9658`](https://github.com/NixOS/nixpkgs/commit/52bc965878cbf9ba32f0b940af5f42cab87ef96f) docker-compose_2: 2.3.0 -> 2.3.3
* [`71b07eaa`](https://github.com/NixOS/nixpkgs/commit/71b07eaac3552d41c92a604059840e3c5589a657) freedroidrpg: add upstream fix for -fno-common toolchains
* [`4fd04a19`](https://github.com/NixOS/nixpkgs/commit/4fd04a19f1dcd6d1ee21a5b99a79747611bd3dd8) Revert "deno: 1.19.1 -> 1.19.3"
* [`78e4513c`](https://github.com/NixOS/nixpkgs/commit/78e4513c3d03dc21ba47284a99cd92a94ec86348) python3Packages.pudb: disable on older Python releeases
* [`bc72629e`](https://github.com/NixOS/nixpkgs/commit/bc72629eee81ce75520f835dbb09257ad3be65b9) python3Packages.pudb: remove duplicate input
* [`d52b9375`](https://github.com/NixOS/nixpkgs/commit/d52b93750e524b4f5c4233094b767f7630e6e11f) gitleaks: 8.3.0 -> 8.4.0
* [`aeb5eeff`](https://github.com/NixOS/nixpkgs/commit/aeb5eeff087d2294f20db4cae4e612f984c29425) elpa: 2021.11.001 -> 2021.11.002
* [`27e32bbf`](https://github.com/NixOS/nixpkgs/commit/27e32bbfde6c0c27c78859b23943e79b84e3c860) nixos/systembus-notify: add support for system services notifying users
* [`895090bf`](https://github.com/NixOS/nixpkgs/commit/895090bf89cd1a9cd7bc3ea7edd3bd2a0ae9d88f) nixos/earlyoom: use the newly introduced systembus-notify option
* [`80b9bfdf`](https://github.com/NixOS/nixpkgs/commit/80b9bfdfb1f72dc7067e355fbc89cb68ea0be118) nixos/captive-browser: add to menu bar
* [`90d9b7c8`](https://github.com/NixOS/nixpkgs/commit/90d9b7c8dc770611f744aa6fad2e1f32a167e807) llvmPackages: Fix the update script
* [`f0c2e464`](https://github.com/NixOS/nixpkgs/commit/f0c2e464685a4e638f088d4b18e57a32a7014239) llvmPackages_14: 14.0.0-rc2 -> 14.0.0-rc4
* [`884b3784`](https://github.com/NixOS/nixpkgs/commit/884b37844e88dfc45d31cd2661576e7e17338348) nix-output-monitor: 1.1.1.0 -> 1.1.2.0
* [`3f259031`](https://github.com/NixOS/nixpkgs/commit/3f25903151bb8db613fe93a20dba79c63b0ddb4b) nixos/nixpkgs/doc: fix typo in the signature of attrsets.zipAttrs
* [`d12186a6`](https://github.com/NixOS/nixpkgs/commit/d12186a6017e7fddaa0e97db90c4924485aca92c) nixos/tomcat: configure default group and fix broken default package reference
* [`158211b6`](https://github.com/NixOS/nixpkgs/commit/158211b6a1b78966a8291eaad9c48f6ddec43b68) squeezelite: 1.9.6.1196 -> 1.9.9.1401
* [`d853dc52`](https://github.com/NixOS/nixpkgs/commit/d853dc52d87692619412a074846144262d6a48b3) nixos/squeezelite: add support for PulseAudio version
* [`f332895c`](https://github.com/NixOS/nixpkgs/commit/f332895cd18bdc2f0020039068d95dd1d3bfa84e) python310Packages.types-requests: 2.27.11 -> 2.27.12
* [`99dacc15`](https://github.com/NixOS/nixpkgs/commit/99dacc15d301f9e3f6d4576e8b16a72ebd47bfbc) python310Packages.types-urllib3: 1.26.10 -> 1.26.11
* [`86fafe5f`](https://github.com/NixOS/nixpkgs/commit/86fafe5f5026651ae5139f4880f177b350c8ec83) nixos/tomcat: add basic test case using the example app
* [`529b09a7`](https://github.com/NixOS/nixpkgs/commit/529b09a729d06c3a18ce16526992d4e693257734) sdboot-builder: fix crash in exception handling
* [`164c966f`](https://github.com/NixOS/nixpkgs/commit/164c966f4b47dbcf661b511a8a5205dacfb48eec) python310Packages.unidiff: 0.7.0 -> 0.7.3
* [`18670375`](https://github.com/NixOS/nixpkgs/commit/18670375d09cfa4ec4c1b9b44bcd4204947e4890) qtox: 1.17.5 -> 1.17.6
* [`79c1b6b9`](https://github.com/NixOS/nixpkgs/commit/79c1b6b96d2a6a543348dd4fdec77275dff179d8) python310Packages.wled: 0.13.0 -> 0.13.1
* [`46c9fe7d`](https://github.com/NixOS/nixpkgs/commit/46c9fe7d0873a3952a97840a076685e253f92874) pythonPackages.allure_behave: init at 2.9.45
* [`cf2e8652`](https://github.com/NixOS/nixpkgs/commit/cf2e8652bcca9ed133e62e7d4f796660f466d623) wllvm: 1.2.8 -> 1.3.1 ([nixos/nixpkgs⁠#163879](https://togithub.com/nixos/nixpkgs/issues/163879))
* [`a6aceda1`](https://github.com/NixOS/nixpkgs/commit/a6aceda140cd6846fb9cf0338dcfeeb539c5dd31) php.packages.phive: init at 0.15.0
* [`a45244eb`](https://github.com/NixOS/nixpkgs/commit/a45244eb8e952e0c3ae20cc30737a5faabaf410d) mediaelch: 2.8.14 -> 2.8.16
* [`d0e0d14a`](https://github.com/NixOS/nixpkgs/commit/d0e0d14a1953d7eeadb05c15d0e010583b41f3be) nncp: 8.7.1 -> 8.7.2
* [`7db19e78`](https://github.com/NixOS/nixpkgs/commit/7db19e78ff8a87ff316fa8f8b1724101740ac78a) sigil: 1.9.1 -> 1.9.2
* [`b77494ba`](https://github.com/NixOS/nixpkgs/commit/b77494badb8995a024b72afccc597fffac6bc041) nixos/jellyfin: Disable PrivateDevices from hardening to allow GPU endpoints to be accessed
* [`40195e1c`](https://github.com/NixOS/nixpkgs/commit/40195e1c4e85d6eb1fc4fc14e424e16e4a89de7e) php.packages: Add missing hooks.
* [`cdf8fde6`](https://github.com/NixOS/nixpkgs/commit/cdf8fde65753dd453894cf3e31eebf8a077d22b3) nix-eval-jobs: 0.0.3 -> 0.0.4
* [`540de854`](https://github.com/NixOS/nixpkgs/commit/540de8542d60c31aad9198a95d0e799474fe927a) python310Packages.aio-geojson-client: 0.16 -> 0.17
* [`953de209`](https://github.com/NixOS/nixpkgs/commit/953de2094635feba95fc2a64d5b4bf10d8b0f1f6) pkgs/build-support/fetchurl/mirrors.nix: reoder
* [`2d88a59d`](https://github.com/NixOS/nixpkgs/commit/2d88a59de11f1c16fbb31829307b6c3e560839da) pkgs/build-support/fetchurl/mirrors.nix: add TCSH mirrors
* [`7b212f90`](https://github.com/NixOS/nixpkgs/commit/7b212f90e72fa665171ac591eb1cf2a7ef6166fa) tcsh: use tcsh mirrors
* [`201d1632`](https://github.com/NixOS/nixpkgs/commit/201d1632e71707929b3341b0a52e53acfcc454d9) ocamlPackages.spacetime_lib: disable for OCaml ≥ 4.12
* [`804d792c`](https://github.com/NixOS/nixpkgs/commit/804d792c44c4b7bef74cb79146c8f220b5d17959) ocamlPackages.owee: 0.3 → 0.4
* [`4d10c11d`](https://github.com/NixOS/nixpkgs/commit/4d10c11d98b14070bac36c6cd1360a2f16083c0d) ocamlPackages.ocamlfuse: 2.7.1_cvs6 -> 2.7.1_cvs7
* [`b5359c44`](https://github.com/NixOS/nixpkgs/commit/b5359c444e881e36864c658bbcfc61259544c023) buildDunePackage: use dune_2 by default
* [`961581fb`](https://github.com/NixOS/nixpkgs/commit/961581fba4f2d09eb6109678db1fa7e03628c82b) nixUnstable: 2.7pre20220221 -> 2.8pre20220311
* [`9d13bf5b`](https://github.com/NixOS/nixpkgs/commit/9d13bf5b1caedcee62cd7bb7fa71a61f0ba87403) ocaml-ng.ocamlPackages_4_14.ocaml: init at 4.14.0-β1
* [`ad826d3b`](https://github.com/NixOS/nixpkgs/commit/ad826d3b93b9f2d069beeb3c259d192146309ec3) vte: respect the global systemdSupport flag
* [`c32a688f`](https://github.com/NixOS/nixpkgs/commit/c32a688f82fbc01f489eeeb078621f7301e1e740) terraform-providers: refactor scripts
* [`f2ebc057`](https://github.com/NixOS/nixpkgs/commit/f2ebc057eeddfe8bb207fdadc8d78ae1976d43ee) mpv: add javascriptSupport option
* [`a33e2735`](https://github.com/NixOS/nixpkgs/commit/a33e2735a17005ccbe12e67d3e1f8fb384380d97) terraform-providers: update 2022-03-14
