### PR TITLE
niv emacs-overlay: update 0985a6df -> 1e6e66e8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0985a6dfa8918641e7c0bc7d86254c46bc103d2a",
-        "sha256": "0c5l0zz4nw1nsfwbbc5m0m794flbg5j95mhp1cg1sa6drkimzyb3",
+        "rev": "1e6e66e83b1234963b4b2fdee73c8ebf002292de",
+        "sha256": "12pl550xk88bgpyicw39r9h08zsxljz9f8mbscp3impfc95875aw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/0985a6dfa8918641e7c0bc7d86254c46bc103d2a.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/1e6e66e83b1234963b4b2fdee73c8ebf002292de.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@0985a6df...1e6e66e8](https://github.com/nix-community/emacs-overlay/compare/0985a6dfa8918641e7c0bc7d86254c46bc103d2a...1e6e66e83b1234963b4b2fdee73c8ebf002292de)

* [`1e6e66e8`](https://github.com/nix-community/emacs-overlay/commit/1e6e66e83b1234963b4b2fdee73c8ebf002292de) Updated repos/melpa
