### PR TITLE
niv home-manager: update 810e5f36 -> 0304f0f5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "810e5f36131c6b6eb1bcc1e3cff23cc604e82887",
-        "sha256": "0s2x9pz7njk3gc1a5mlk00hlkkr4gyrni9i6f7pxbjlkh48gbab5",
+        "rev": "0304f0f58b4c538ff704c58d53a778b062810ec7",
+        "sha256": "0lg23lj5d4jsng92mbzjxzyn0bbkbfjxi16jimvinwjnv4q4a4hc",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/810e5f36131c6b6eb1bcc1e3cff23cc604e82887.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/0304f0f58b4c538ff704c58d53a778b062810ec7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@810e5f36...0304f0f5](https://github.com/nix-community/home-manager/compare/810e5f36131c6b6eb1bcc1e3cff23cc604e82887...0304f0f58b4c538ff704c58d53a778b062810ec7)

* [`2116fe6b`](https://github.com/nix-community/home-manager/commit/2116fe6b50a5118d56f1f443cccf024abee9de40) zsh: move sessionVariables from .zshrc to .zshenv ([nix-community/home-manager⁠#2708](https://togithub.com/nix-community/home-manager/issues/2708))
* [`498c188e`](https://github.com/nix-community/home-manager/commit/498c188e62a879c128aa4210f3e1031a6afe4916) eww: add module
* [`5375afb2`](https://github.com/nix-community/home-manager/commit/5375afb2fbe6043c02f333e93289507caef0ea9f) eww: fix maintainer referencee
* [`30082a62`](https://github.com/nix-community/home-manager/commit/30082a623ac3a88b6649251602c10464570dc011) docs: fix standalone flake setup
* [`c859a526`](https://github.com/nix-community/home-manager/commit/c859a5265ac08db6f5bd750f04e6654cd5b12eab) sway: add tray.target
* [`5b208b42`](https://github.com/nix-community/home-manager/commit/5b208b42b2f2a364735723510bd12899770c9dda) docs: section how to update system
* [`4f4165a8`](https://github.com/nix-community/home-manager/commit/4f4165a8b9108818ab0193bbd1a252106870b2a2) espanso: add module
* [`0232fe1b`](https://github.com/nix-community/home-manager/commit/0232fe1b75e6d7864fd82b5c72f6646f87838fc3) atuin: don't install widget on limited terminals
* [`b3af91d2`](https://github.com/nix-community/home-manager/commit/b3af91d293ef1178ad426306495c7a85ad8b8c9d) tests/nnn: fix tests ([nix-community/home-manager⁠#2746](https://togithub.com/nix-community/home-manager/issues/2746))
* [`69536af2`](https://github.com/nix-community/home-manager/commit/69536af27e86a9fc875d71cb9566ccccf47b5b60) himalaya: fix smtp-starttls option ([nix-community/home-manager⁠#2744](https://togithub.com/nix-community/home-manager/issues/2744))
* [`838d40d6`](https://github.com/nix-community/home-manager/commit/838d40d61a91e3807836545c4b420572ab2d62eb) foot: set OOMPolicy=continue for foot server ([nix-community/home-manager⁠#2749](https://togithub.com/nix-community/home-manager/issues/2749))
* [`0b1745b4`](https://github.com/nix-community/home-manager/commit/0b1745b4ef4c35ec5d554b176539730fcb5ec141) neovim: autogenerate config.lua file sourced to init.vim ([nix-community/home-manager⁠#2716](https://togithub.com/nix-community/home-manager/issues/2716))
* [`1950eb87`](https://github.com/nix-community/home-manager/commit/1950eb878b0290ca2b2f0d85804281b57799c64a) Add translation using Weblate (Italian)
* [`2248ea18`](https://github.com/nix-community/home-manager/commit/2248ea1831611aa5c4926c5ccfa0eb7803af78b3) Add translation using Weblate (Italian)
* [`1faefcde`](https://github.com/nix-community/home-manager/commit/1faefcded37d4d094d086ccf9796de50ca5bc7f7) Translate using Weblate (Russian)
* [`8f7d9255`](https://github.com/nix-community/home-manager/commit/8f7d9255034b12d52242a87f41d2dd8242992083) gitui: add module
* [`650cfe60`](https://github.com/nix-community/home-manager/commit/650cfe60f31f3d27ba869bf7db12ca8ded5f1d74) vscode: fix name of extension in example ([nix-community/home-manager⁠#2759](https://togithub.com/nix-community/home-manager/issues/2759))
* [`662350be`](https://github.com/nix-community/home-manager/commit/662350bee2090edc82b4c162b1415f76b4eee2f3) neovim: remove trace log of vim plugins ([nix-community/home-manager⁠#2756](https://togithub.com/nix-community/home-manager/issues/2756)) ([nix-community/home-manager⁠#2760](https://togithub.com/nix-community/home-manager/issues/2760))
* [`c7a13f76`](https://github.com/nix-community/home-manager/commit/c7a13f76a78bb5c225ca5e08e9a109347d130792) launchd: initial support for LaunchAgents
* [`ccd00e3c`](https://github.com/nix-community/home-manager/commit/ccd00e3c93b89b26ca86749cfe64b371e2dd7910) launchd: fix undefined variable in activation script ([nix-community/home-manager⁠#2763](https://togithub.com/nix-community/home-manager/issues/2763))
* [`1d90b606`](https://github.com/nix-community/home-manager/commit/1d90b6065a0e8713b21cffd7af4f03e31894ae8b) tiny: add module ([nix-community/home-manager⁠#2735](https://togithub.com/nix-community/home-manager/issues/2735))
* [`2499b916`](https://github.com/nix-community/home-manager/commit/2499b916921adde8a694117bc007efdde8bbd918) treewide: apply nixfmt to a few more files
* [`ea85f4b1`](https://github.com/nix-community/home-manager/commit/ea85f4b1fdf3f25cf97dc49f4a9ec4eafda2ea25) launchd: fix multiple agents
* [`e58a7cb1`](https://github.com/nix-community/home-manager/commit/e58a7cb13d5d870550888cdc6fe92154efd9e571) xdg-desktop-entries: adjust to API changes
* [`541874f5`](https://github.com/nix-community/home-manager/commit/541874f55d7c15b4c67329ec0370b245dea322e8) mpd: add basic test case
* [`d119cea3`](https://github.com/nix-community/home-manager/commit/d119cea3763977801ad66330668c1ab4346cb7f7) i3status-rust: change default to newer version ([nix-community/home-manager⁠#2774](https://togithub.com/nix-community/home-manager/issues/2774))
* [`87beebc7`](https://github.com/nix-community/home-manager/commit/87beebc7a2d52dbbf15bbca6099e01d2c719ded3) just: add module
* [`4e685639`](https://github.com/nix-community/home-manager/commit/4e6856397e930228ca887a4fd28a3292395443bf) Translate using Weblate (Polish)
* [`abd221c4`](https://github.com/nix-community/home-manager/commit/abd221c4b38c98293dab38da59a26b14bd4053af) Translate using Weblate (Turkish)
* [`afe96e74`](https://github.com/nix-community/home-manager/commit/afe96e7433c513bf82375d41473c57d1f66b4e68) pubs: add module
* [`e6e19ea5`](https://github.com/nix-community/home-manager/commit/e6e19ea5a8bf77b55ef56e3f48feb82024daabab) ci: bump actions/checkout from 2 to 3
* [`da1f6fab`](https://github.com/nix-community/home-manager/commit/da1f6fab908ef0b348475b29f43381365afdaef7) ci: bump stable version for dependabot
* [`5d4327cf`](https://github.com/nix-community/home-manager/commit/5d4327cff4a5e54be8ca33d7c8a8dce6bdb64b93) irssi: fix syntax error when no channels are specified
* [`da92196a`](https://github.com/nix-community/home-manager/commit/da92196a95c3aeaa6e8336be2864ef02245ad730) mu: allow aliases to be used by mu configuration file
* [`8bdfa41b`](https://github.com/nix-community/home-manager/commit/8bdfa41b4e741ef3c4e684c47b634c697b17b7ba) fusuma: add module
* [`472e67d1`](https://github.com/nix-community/home-manager/commit/472e67d1bb577727e7a8adce8b46431201b18889) himalaya: add support for `account.folders`
* [`8eb7c009`](https://github.com/nix-community/home-manager/commit/8eb7c009f09f1f7b1ec151e5d537104acf42213a) fusuma: avoid unnecessary dependency in test
* [`970b57fd`](https://github.com/nix-community/home-manager/commit/970b57fd3c93f6c76d5cdfb4da23a5b4010b9e8b) autorandr: add filter option ([nix-community/home-manager⁠#2795](https://togithub.com/nix-community/home-manager/issues/2795))
* [`e01facc3`](https://github.com/nix-community/home-manager/commit/e01facc34045cf0026ba61d04e69c61e11f99408) gtk: add cursor theme configuration ([nix-community/home-manager⁠#2481](https://togithub.com/nix-community/home-manager/issues/2481))
* [`a4b0a3fa`](https://github.com/nix-community/home-manager/commit/a4b0a3faa4055521f2a20cfafe26eb85e6954751) xdg: add `XDG_*_HOME` variables to `systemd.user.sessionVariables` ([nix-community/home-manager⁠#2790](https://togithub.com/nix-community/home-manager/issues/2790))
* [`590da80c`](https://github.com/nix-community/home-manager/commit/590da80ceb32edff0bd44b0c3e0fa99eb8173825) neovim/coc: fix loading CoC plugin ([nix-community/home-manager⁠#2801](https://togithub.com/nix-community/home-manager/issues/2801))
* [`32e433d0`](https://github.com/nix-community/home-manager/commit/32e433d07d56202b7ce91dadfd2a313ee90aef21) nix: add structural settings ([nix-community/home-manager⁠#2718](https://togithub.com/nix-community/home-manager/issues/2718))
* [`e2a85ac4`](https://github.com/nix-community/home-manager/commit/e2a85ac43f06859a50d067a029f0a303c4ca5264) bspwm: add alwaysResetDesktops ([nix-community/home-manager⁠#2785](https://togithub.com/nix-community/home-manager/issues/2785))
* [`7cf15b19`](https://github.com/nix-community/home-manager/commit/7cf15b19a931b99f9a918887fc488d577fd07516) vscode: add user tasks ([nix-community/home-manager⁠#2804](https://togithub.com/nix-community/home-manager/issues/2804))
* [`e96fc6d8`](https://github.com/nix-community/home-manager/commit/e96fc6d8f90c96320a9c7e6663b734ab50ec1794) tmux: add notes to existing keybindings ([nix-community/home-manager⁠#2540](https://togithub.com/nix-community/home-manager/issues/2540)) ([nix-community/home-manager⁠#2742](https://togithub.com/nix-community/home-manager/issues/2742))
* [`0fad959d`](https://github.com/nix-community/home-manager/commit/0fad959df8076766d4259c1f76750f892a0cafa1) stalebot: disable auto-closing of issues and pull requests ([nix-community/home-manager⁠#2800](https://togithub.com/nix-community/home-manager/issues/2800))
* [`57476b5d`](https://github.com/nix-community/home-manager/commit/57476b5d286aa9416ed4472d19d37bbd93d30191) xcursor: remove warning and use mkDefault for GTK options ([nix-community/home-manager⁠#2808](https://togithub.com/nix-community/home-manager/issues/2808))
* [`46dc2e5d`](https://github.com/nix-community/home-manager/commit/46dc2e5d9f55164d28705facd0f9a3b4c0d2807a) gtk: fix missing newline in formatted config ([nix-community/home-manager⁠#2809](https://togithub.com/nix-community/home-manager/issues/2809))
* [`835797f3`](https://github.com/nix-community/home-manager/commit/835797f3a4a59459a316ae8d4ab91fa59faf61a4) xsession.pointerCursor: escape special characters in the cursor path ([nix-community/home-manager⁠#2805](https://togithub.com/nix-community/home-manager/issues/2805))
* [`64823066`](https://github.com/nix-community/home-manager/commit/64823066c20073bc60525b5a06364a3714496d31) herbstluftwm, mpd: fix bash version in tests ([nix-community/home-manager⁠#2816](https://togithub.com/nix-community/home-manager/issues/2816))
* [`bbc5e0c1`](https://github.com/nix-community/home-manager/commit/bbc5e0c1e1f511a41618afc028bd93c626ea6dbb) tmux: fix broken vi bindings ([nix-community/home-manager⁠#2817](https://togithub.com/nix-community/home-manager/issues/2817))
* [`80b43606`](https://github.com/nix-community/home-manager/commit/80b4360678fa7890964ba8e40a722985bf8d107e) i3/sway: improve i3.nix to handle options as list like in sway, adjusted functions for less new-lines ([nix-community/home-manager⁠#2314](https://togithub.com/nix-community/home-manager/issues/2314))
* [`48a1584d`](https://github.com/nix-community/home-manager/commit/48a1584d8ba427dd9d74e2b2b842c70a6dd9c4fa) i3-sway: Empty set argument was passed to wrong function ([nix-community/home-manager⁠#2819](https://togithub.com/nix-community/home-manager/issues/2819))
* [`6c730bc0`](https://github.com/nix-community/home-manager/commit/6c730bc0542442e6f20b821c5d03f83e9468573e) Translate using Weblate (German)
* [`0cf9dadf`](https://github.com/nix-community/home-manager/commit/0cf9dadf5bf34314ea5526636b597150e6430032) irssi: use types.lines for extraConfig
* [`e2ebc3a3`](https://github.com/nix-community/home-manager/commit/e2ebc3a3af4d6a942cea2d7d5fe46d56edcecc8b) picom: use types.lines for extraOptions
* [`70c46966`](https://github.com/nix-community/home-manager/commit/70c469661983141d4d83d8180b71c2bb5f66034e) tests: bump nmt
* [`9970d232`](https://github.com/nix-community/home-manager/commit/9970d23218d2215fb7e6e2cb74a3533e2b8863ad) gtk: fix incorrect test assertion
* [`b030278d`](https://github.com/nix-community/home-manager/commit/b030278dc6716bbd6501cfb38456aa95be00f48f) nix: fix attribute path of nix stable
* [`ac940411`](https://github.com/nix-community/home-manager/commit/ac9404115362c901ffe5c5c215f76f74b79d5eda) docs: bump nmd
* [`8afee75d`](https://github.com/nix-community/home-manager/commit/8afee75d0d1cb054cfeddfdc9f7193adc7741c95) dconf: note that system dconf must be enabled
* [`171702dd`](https://github.com/nix-community/home-manager/commit/171702dd88f0ffcc89ad58a653015ac577519bf0) files: avoid cleanup if old home-files is missing
* [`2f58d0a3`](https://github.com/nix-community/home-manager/commit/2f58d0a3de97f4c20efcc6ba00878acfd7b5665d) nix: add support for `nix profile`
* [`b23bb058`](https://github.com/nix-community/home-manager/commit/b23bb05890f4a5f31f4e0d7bc2fe25bc6d4166ac) flake: only support linux + darwin
* [`0520e387`](https://github.com/nix-community/home-manager/commit/0520e387dcc6e6174fd965b27082ede1672ed740) overlay: rename parameters to flake specification
* [`d123fca8`](https://github.com/nix-community/home-manager/commit/d123fca83c9f99b5337679892a2f69cd23005cac) browserpass: add brave support
* [`888eac32`](https://github.com/nix-community/home-manager/commit/888eac32bd657bfe0d024c8770130d80d1c02cd3) home-manager: fix command option
* [`c607ae86`](https://github.com/nix-community/home-manager/commit/c607ae8671d622604630ed3b4bbbc12eb24e791f) Update translation files
* [`80583677`](https://github.com/nix-community/home-manager/commit/80583677e79a683cec24de55f2c80bab1fa0d198) Translate using Weblate (Japanese)
* [`f5a44afa`](https://github.com/nix-community/home-manager/commit/f5a44afa19f8f99af4e1a88c97e2327590cd4217) Translate using Weblate (Turkish)
* [`8db712a6`](https://github.com/nix-community/home-manager/commit/8db712a6a2b5d7f56143a38da14fce85bc0bc97b) types: fix `dagOf` behaviour with `mkIf`
* [`9580f6c4`](https://github.com/nix-community/home-manager/commit/9580f6c42af2535dc7890edb681ead090f5105f2) zellij: add configuration for darwin
* [`cf62e96b`](https://github.com/nix-community/home-manager/commit/cf62e96bf7c72e6a88e0bd43165110f42e44cdb4) Run sudo with -s in the darwin module ([nix-community/home-manager⁠#807](https://togithub.com/nix-community/home-manager/issues/807))
* [`e1fab012`](https://github.com/nix-community/home-manager/commit/e1fab012e872c129099535b5b535fc2347cfa6f4) nix-darwin: sudo --set-home for multiple user activation ([nix-community/home-manager⁠#2857](https://togithub.com/nix-community/home-manager/issues/2857))
* [`38156bd4`](https://github.com/nix-community/home-manager/commit/38156bd4ede9b5b92a7313033e000c1cad767553) doc: Add link to configuration options.html ([nix-community/home-manager⁠#2851](https://togithub.com/nix-community/home-manager/issues/2851))
* [`cfab869f`](https://github.com/nix-community/home-manager/commit/cfab869fcebc56710be6ec3aca76036b25c04a0d) flake: add `packages.<system>.default` ([nix-community/home-manager⁠#2835](https://togithub.com/nix-community/home-manager/issues/2835))
* [`0382c5f7`](https://github.com/nix-community/home-manager/commit/0382c5f75e9b4ffb0cdc75535c3e249019710a02) git: Add option to use difftastic as diff tool ([nix-community/home-manager⁠#2850](https://togithub.com/nix-community/home-manager/issues/2850))
* [`3549f5d0`](https://github.com/nix-community/home-manager/commit/3549f5d0f5aff2aea3d4d2e99f83776a218ab55a) xdg-user-dirs: allow paths and define sessionVariables ([nix-community/home-manager⁠#2757](https://togithub.com/nix-community/home-manager/issues/2757))
* [`a985e711`](https://github.com/nix-community/home-manager/commit/a985e711e88e3aab82c54df39bc4666f98f54937) screen-locker: Add option to configure x screensaver cycle ([nix-community/home-manager⁠#2853](https://togithub.com/nix-community/home-manager/issues/2853))
* [`399a3dfe`](https://github.com/nix-community/home-manager/commit/399a3dfeafa7328f40b99759d94d908185ce72a6) gpg: create homedir with 700 permissions ([nix-community/home-manager⁠#2823](https://togithub.com/nix-community/home-manager/issues/2823))
* [`07b941f0`](https://github.com/nix-community/home-manager/commit/07b941f0c45ac4af6732d96f4cb6142824eee3df) mpd-discord-rpc: init service ([nix-community/home-manager⁠#2728](https://togithub.com/nix-community/home-manager/issues/2728))
* [`66ffa7a0`](https://github.com/nix-community/home-manager/commit/66ffa7a0a6411c7c73a648bd0b426c73e2a14fa0) systemd: fix creation of user service unit files ([nix-community/home-manager⁠#2867](https://togithub.com/nix-community/home-manager/issues/2867))
* [`3604a20b`](https://github.com/nix-community/home-manager/commit/3604a20b67fbf4deb7cc386040adbcf163853446) docs: fix link to rollback instructions
* [`e361373b`](https://github.com/nix-community/home-manager/commit/e361373b5f5003c2806146f97c74f0c9e9d35ef3) taskwarrior: make .taskrc writable ([nix-community/home-manager⁠#2761](https://togithub.com/nix-community/home-manager/issues/2761))
* [`3071ea20`](https://github.com/nix-community/home-manager/commit/3071ea205da9ad7dd1c4094c2076d44f88ba350e) starship: skip one program invocation on each shell init ([nix-community/home-manager⁠#2862](https://togithub.com/nix-community/home-manager/issues/2862))
* [`8a046f36`](https://github.com/nix-community/home-manager/commit/8a046f36ebca680312828e945a4f4928ad503474) Translate using Weblate (Portuguese (Brazil))
* [`47b3719f`](https://github.com/nix-community/home-manager/commit/47b3719f51b020729de0b8f26a7606fb401b5de9) taskwarrior: minor script cleanup
* [`55779b20`](https://github.com/nix-community/home-manager/commit/55779b20cd5a57cae3e1f8508f93fdd7ffdc5826) pandoc: fix test case
* [`f911ebbe`](https://github.com/nix-community/home-manager/commit/f911ebbec927e8e9b582f2e32e2b35f730074cfc) lib.booleans: add yesNo function ([nix-community/home-manager⁠#2818](https://togithub.com/nix-community/home-manager/issues/2818))
* [`e39a9d01`](https://github.com/nix-community/home-manager/commit/e39a9d0103e3b2e42059c986a8c633824b96c193) pylint: add module ([nix-community/home-manager⁠#2729](https://togithub.com/nix-community/home-manager/issues/2729))
* [`7da4e668`](https://github.com/nix-community/home-manager/commit/7da4e6680f814562f070bad01922d6736e54be94) lf: add package option
* [`92f58b67`](https://github.com/nix-community/home-manager/commit/92f58b6728e7c631a7ea0ed68cd21bb29a4876ff) ci: bump cachix/install-nix-action from 16 to 17
* [`d49d68f4`](https://github.com/nix-community/home-manager/commit/d49d68f4196d32c5039cb9e91d730cee894f6f14) home-manager: Fix cross-compiles, fixes [nix-community/home-manager⁠#2675](https://togithub.com/nix-community/home-manager/issues/2675) ([nix-community/home-manager⁠#2893](https://togithub.com/nix-community/home-manager/issues/2893))
* [`7add9ce2`](https://github.com/nix-community/home-manager/commit/7add9ce2e5c517fcc4b25b3ed13e7e28cd325034) picom: remove refreshRate option
* [`a640dddc`](https://github.com/nix-community/home-manager/commit/a640dddc9a176585b7f1a01579f3dcd5bda58b40) waybar: fix command not found when reloading ([nix-community/home-manager⁠#2865](https://togithub.com/nix-community/home-manager/issues/2865))
* [`0586d2d4`](https://github.com/nix-community/home-manager/commit/0586d2d42a7790554842e31efc61c06d1e236280) keychain: set SHELL during initialization ([nix-community/home-manager⁠#2880](https://togithub.com/nix-community/home-manager/issues/2880))
* [`2e473a7b`](https://github.com/nix-community/home-manager/commit/2e473a7b0903709817b1b8cf0ef0cae1defac358) neomutt/signature: unset if disabled ([nix-community/home-manager⁠#2877](https://togithub.com/nix-community/home-manager/issues/2877))
* [`8ab155c6`](https://github.com/nix-community/home-manager/commit/8ab155c61f5821ffda723de88b0009769771d4f2) modules: Export `pkgs` to match NixOS ([nix-community/home-manager⁠#2696](https://togithub.com/nix-community/home-manager/issues/2696))
* [`620ed197`](https://github.com/nix-community/home-manager/commit/620ed197f3624dafa5f42e61d5c043f39b8df366) gpg: fix handling of multiple public keys
* [`c82b8ac5`](https://github.com/nix-community/home-manager/commit/c82b8ac5ad70c17f35eca54e3267e5b0e43fbe6b) sioyek: add module ([nix-community/home-manager⁠#2895](https://togithub.com/nix-community/home-manager/issues/2895))
* [`bb860e3e`](https://github.com/nix-community/home-manager/commit/bb860e3e119ee6d043896544de560cd05096a421) misc: fix nix.conf generation ([nix-community/home-manager⁠#2824](https://togithub.com/nix-community/home-manager/issues/2824))
* [`f47001ce`](https://github.com/nix-community/home-manager/commit/f47001cec9f5c7fa557733db6101d1240aa2f297) xdg-desktop-entries: add 'actions' option, deprecate fileValidation ([nix-community/home-manager⁠#2778](https://togithub.com/nix-community/home-manager/issues/2778))
* [`5ac84ebe`](https://github.com/nix-community/home-manager/commit/5ac84ebeef5d2566ea458b81375cc6eafa19c225) Add lib argument to homeManagerConfiguration ([nix-community/home-manager⁠#2753](https://togithub.com/nix-community/home-manager/issues/2753))
* [`c2726860`](https://github.com/nix-community/home-manager/commit/c2726860a28a2f9331ef8bb4a8505998818bf471) nix-darwin,nixos: convert `modulesPath` to string ([nix-community/home-manager⁠#2714](https://togithub.com/nix-community/home-manager/issues/2714))
* [`742c6cb3`](https://github.com/nix-community/home-manager/commit/742c6cb3e9d866e095c629162fe5faf519adeb26) chromium: add vivaldi
* [`8d38ca88`](https://github.com/nix-community/home-manager/commit/8d38ca886880265d523a66fe3da4d42e92ab0748) xdg-mime-apps: add function `mimeAssociations`
* [`8ec13d33`](https://github.com/nix-community/home-manager/commit/8ec13d33b17f246e03ddfea100b7c3a143255bea) targets.genericLinux: include additional directories in XCURSOR_PATH ([nix-community/home-manager⁠#2902](https://togithub.com/nix-community/home-manager/issues/2902))
* [`93a69d07`](https://github.com/nix-community/home-manager/commit/93a69d07389311ffd6ce1f4d01836bbc2faec644) Simplify function ([nix-community/home-manager⁠#2903](https://togithub.com/nix-community/home-manager/issues/2903))
* [`65a32578`](https://github.com/nix-community/home-manager/commit/65a32578d9b1394bea5c6336721ec392aadc89fb) helix: fix test
* [`6f025b38`](https://github.com/nix-community/home-manager/commit/6f025b38253ae14f38b366c37d8e568a2f8e67b3) i3-sway: only return current user's socket ([nix-community/home-manager⁠#2914](https://togithub.com/nix-community/home-manager/issues/2914))
* [`845aaaf4`](https://github.com/nix-community/home-manager/commit/845aaaf4db2b411d686290fb0c47fc988bca3f14) Translate using Weblate (Persian)
* [`5997c434`](https://github.com/nix-community/home-manager/commit/5997c434580fd3a2d7c5931b2647e07791ddb018) Add translation using Weblate (Persian)
* [`09f3e679`](https://github.com/nix-community/home-manager/commit/09f3e67950823d5abe192e474f1af51914f4cb9a) Translate using Weblate (Italian)
* [`223a73c2`](https://github.com/nix-community/home-manager/commit/223a73c2ba7d358b23666937cb13a59b31df511c) xscreensaver: add xscreensaver to service PATH
* [`778af87a`](https://github.com/nix-community/home-manager/commit/778af87a981eb2bfa3566dff8c3fb510856329ef) i3status-rust: fix formatting
* [`f8b51be7`](https://github.com/nix-community/home-manager/commit/f8b51be7149a0735e87b232d21ae4f852619eac7) neomutt: add support for signature command ([nix-community/home-manager⁠#2899](https://togithub.com/nix-community/home-manager/issues/2899))
* [`df601055`](https://github.com/nix-community/home-manager/commit/df6010551daa826217939641ab805053f0890239) gpg-agent: make shell integrations optional ([nix-community/home-manager⁠#2927](https://togithub.com/nix-community/home-manager/issues/2927))
* [`26858fc0`](https://github.com/nix-community/home-manager/commit/26858fc0dbed71fa0609490fc2f2643e0d175328) tealdeer: add module ([nix-community/home-manager⁠#2928](https://togithub.com/nix-community/home-manager/issues/2928))
* [`d7b97de5`](https://github.com/nix-community/home-manager/commit/d7b97de51a61b51a406f10164a1886f183e220c8) tealdeer: add news entry
* [`5872aad1`](https://github.com/nix-community/home-manager/commit/5872aad1d0f841770db498cba9310d647c4aa376) git: add option to use diff-so-fancy as diff tool
* [`af828536`](https://github.com/nix-community/home-manager/commit/af828536ed7fff012fe9278f67a30be8ee3f5b24) fish: generate fish completions using python 3
* [`0304f0f5`](https://github.com/nix-community/home-manager/commit/0304f0f58b4c538ff704c58d53a778b062810ec7) specialization: add module
