### PR TITLE
niv spacemacs: update ed19c94a -> e32acdfa

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "ed19c94a1edeb9a02e0c7f93367e0fc134949f73",
-        "sha256": "1fcx7dk869p67s5i4r1xd5q115l0ddhqzjjsvn9g1aqdzhlkhj5w",
+        "rev": "e32acdfadf6180288d627d39422b43863433fbc0",
+        "sha256": "10v36vp1gk7wmphyk98qasvrf6icy9xg6sg5hy4ll4ag833lh6qf",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/ed19c94a1edeb9a02e0c7f93367e0fc134949f73.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/e32acdfadf6180288d627d39422b43863433fbc0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@ed19c94a...e32acdfa](https://github.com/syl20bnr/spacemacs/compare/ed19c94a1edeb9a02e0c7f93367e0fc134949f73...e32acdfadf6180288d627d39422b43863433fbc0)

* [`82cb081d`](https://github.com/syl20bnr/spacemacs/commit/82cb081d846c0ce6ad1207253f84606598a201b1) README: Added a Discord Channel
* [`d751c09f`](https://github.com/syl20bnr/spacemacs/commit/d751c09fab66392163e25c8ebb0659214e769f44) [git] document configuration of Magit Forge and Git identity ([syl20bnr/spacemacs⁠#15388](https://togithub.com/syl20bnr/spacemacs/issues/15388))
* [`e32acdfa`](https://github.com/syl20bnr/spacemacs/commit/e32acdfadf6180288d627d39422b43863433fbc0) [bot] "documentation_updates" Fri Mar 11 06:55:25 UTC 2022 ([syl20bnr/spacemacs⁠#15402](https://togithub.com/syl20bnr/spacemacs/issues/15402))
