### PR TITLE
niv nixpkgs: update 6a201dc7 -> e73b01f9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6a201dc719648bb5582955480d39dd9b1ffe3d1f",
-        "sha256": "0d9jg7apkxa9gxkc29why1bmhz97wmms465zkaz6500ly3lb39gx",
+        "rev": "e73b01f93a6ca0b689865861bc79b25d49961ae2",
+        "sha256": "0i60v0d504as68bxcscjwqa213n91wgb1zj9bsv3zkqq3s0a4j4h",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/6a201dc719648bb5582955480d39dd9b1ffe3d1f.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e73b01f93a6ca0b689865861bc79b25d49961ae2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@6a201dc7...e73b01f9](https://github.com/nixos/nixpkgs/compare/6a201dc719648bb5582955480d39dd9b1ffe3d1f...e73b01f93a6ca0b689865861bc79b25d49961ae2)

* [`970d249d`](https://github.com/NixOS/nixpkgs/commit/970d249d39ccac356c705e6e4db6318ffe93dd42) invidious: unstable-2021-11-08 -> unstable-2021-11-13
* [`5f3b85f6`](https://github.com/NixOS/nixpkgs/commit/5f3b85f618339de8cb69819e5c9354479265d970) kernel: Enable IPoIB Connected Mode
* [`3768a914`](https://github.com/NixOS/nixpkgs/commit/3768a9142dc02aba9b37ebfe10a974d3f0345308) lime: 5.0.0 -> 5.0.53
* [`172673cf`](https://github.com/NixOS/nixpkgs/commit/172673cf676ea7abe6ee7f4394892e449455fa17) aws-checksums: 0.1.11 -> 0.1.12
* [`ccdaaa07`](https://github.com/NixOS/nixpkgs/commit/ccdaaa0788e0ca0134ad1a43ee8e91dd5068a624) tzdata: fix for darwin sandbox
* [`11d686de`](https://github.com/NixOS/nixpkgs/commit/11d686de1202a3a1ba5e98f949db165e9740d6e1) rubyPackages.ruby-libvirt: remove patch
* [`b9064648`](https://github.com/NixOS/nixpkgs/commit/b906464824bde6fc5e13db1f18066c4de68d25b1) boost177: fix on platforms without atomics
* [`840a527f`](https://github.com/NixOS/nixpkgs/commit/840a527f72c67b86d1a3fcc8c66ef19aa6f4839b) exiv2: enable BMFF support
* [`37467208`](https://github.com/NixOS/nixpkgs/commit/374672081ec00f11588233333eca78fc0cef4026) libclc: fix libclc.pc file
* [`6ffb6114`](https://github.com/NixOS/nixpkgs/commit/6ffb6114dc6d1e30b774529b4db98265c09793af) gnu-config: make scripts executable
* [`946f5dd9`](https://github.com/NixOS/nixpkgs/commit/946f5dd980bde493da19312a290c7d9ef3ac32bb) flex: backwards-compatible executable alias `lex`
* [`4c7208b4`](https://github.com/NixOS/nixpkgs/commit/4c7208b46ede553fb3f4926e977e628313cf5157) gdb: 11.1 -> 11.2
* [`8ae82554`](https://github.com/NixOS/nixpkgs/commit/8ae82554c915e8d1f0af53c4588e65e01d76f97d) nixos/tests/wine: fix gecko check and diskSize type
* [`8aae7afa`](https://github.com/NixOS/nixpkgs/commit/8aae7afa3ea0244722202b99c9e6813da462362d) linux: enable FF for many gamepads
* [`98d32545`](https://github.com/NixOS/nixpkgs/commit/98d32545dcc680dfd90797ac4f3e4ed0f0b9db27) weechat: 3.3 -> 3.4
* [`106c28df`](https://github.com/NixOS/nixpkgs/commit/106c28df5492f352c9ee2780de954f5aa9d5b172) python3Packages.regex: 2021.11.10 -> 2022.1.18
* [`652deba3`](https://github.com/NixOS/nixpkgs/commit/652deba33e1c9d68fe1802c1c06d274328ac351c) readline: add symlink to update-patch-set script
* [`8fc93336`](https://github.com/NixOS/nixpkgs/commit/8fc933368c25cacd030ec667b2ff33f2c601ce5d) readline: 8.1p0 -> 8.1p2
* [`830435cc`](https://github.com/NixOS/nixpkgs/commit/830435ccc39f9ee6c816bf63c2c4eac455437203) bash: 5.1p12 -> 5.1p16
* [`49a0059a`](https://github.com/NixOS/nixpkgs/commit/49a0059a59a950c9261325fad14a2f905f53036d) python3: unset  MACOSX_DEPLOYMENT_TARGET
* [`c7c3187d`](https://github.com/NixOS/nixpkgs/commit/c7c3187d9897b304c85542130ece7bacc44906a9) python3: don't patch out -Wl,-stack_size,1000000
* [`68d828f6`](https://github.com/NixOS/nixpkgs/commit/68d828f64ca8cde5dbe85c55ca6563f92482cd4e) python3: don't hardcode -msse2 on darwin
* [`f67b8ea7`](https://github.com/NixOS/nixpkgs/commit/f67b8ea731208e14953d068ed6f506f83a049e3a) audit: Fix python bindings
* [`de76433f`](https://github.com/NixOS/nixpkgs/commit/de76433f5407a7661c5534e4d98a96794e35ceac) nss: 3.74 -> 3.75
* [`d08be771`](https://github.com/NixOS/nixpkgs/commit/d08be77171b356a9cdf57af9bba2d96290dbfc8c) audit: use python3
* [`f4d36431`](https://github.com/NixOS/nixpkgs/commit/f4d364314bc064cbeb9ca8a36855bcd37848e453) wxGTK31: 3.1.4 -> 3.1.5
* [`4bcf0dcf`](https://github.com/NixOS/nixpkgs/commit/4bcf0dcf8d5de980e021697a35682d15c5090796) wxwidgets: rename files
* [`cd5a0133`](https://github.com/NixOS/nixpkgs/commit/cd5a0133f76779d5273e8fce3695b501bcd286ec) wxGTK30: fix compat2* flags
* [`a66d9c85`](https://github.com/NixOS/nixpkgs/commit/a66d9c85c98fa11cf6eaa3ea6af279d1473d1a96) go: Fix the build in non-root sandboxes
* [`f02dc538`](https://github.com/NixOS/nixpkgs/commit/f02dc538002d6a0d7724c318e41447ceeec9d4e7) glibc: 2.33-108 -> 2.33-117
* [`7b9fd5d1`](https://github.com/NixOS/nixpkgs/commit/7b9fd5d1c9802131ca0a01ff08a3ff64379d2df4) rewrite autoPatchelfHook in python ([nixos/nixpkgs⁠#149731](https://togithub.com/nixos/nixpkgs/issues/149731))
* [`1a8754ca`](https://github.com/NixOS/nixpkgs/commit/1a8754caf8eb8831b904daaf34b2ee737053b383) llvmPackages_13: 13.0.0 -> 13.0.1
* [`81b7e7c9`](https://github.com/NixOS/nixpkgs/commit/81b7e7c98ed8afc87294fa4d0138ad28354169fd) python3Packages.responses: 0.17.0 -> 0.18.0
* [`ae6bb2fc`](https://github.com/NixOS/nixpkgs/commit/ae6bb2fcf8166424b36308e8ac4e696dac6147b9) treesitter grammars: on darwin should use .so suffix
* [`773aea72`](https://github.com/NixOS/nixpkgs/commit/773aea727a3c8a91881c4883190f785184f1d3f2) libxkbcommon: 1.3.1 -> 1.4.0
* [`f48c4bb7`](https://github.com/NixOS/nixpkgs/commit/f48c4bb72d1d2e4e045b0583e6e9e92a7eea1a02) cups: 2.4.0 -> 2.4.1
* [`0f049646`](https://github.com/NixOS/nixpkgs/commit/0f049646e6584cc8580a0b1e13390e0d06a86639) libtiff: add patch for CVE-2022-22844
* [`18b9acd0`](https://github.com/NixOS/nixpkgs/commit/18b9acd0b4abd20ba5b483da7275153cfcc3fa16) gdbm: 1.20 -> 1.23
* [`c4232bf2`](https://github.com/NixOS/nixpkgs/commit/c4232bf2b79418b5c5bd373c3c7f9015d790f332) findutils: 4.8.0 -> 4.9.0
* [`93f9305e`](https://github.com/NixOS/nixpkgs/commit/93f9305e25b8124f42892317d83ba46c078cce9f) pythonPackages.cchardet: fix build on non-x86_64
* [`34afacfd`](https://github.com/NixOS/nixpkgs/commit/34afacfd7833cf7ab2dc7f7213d4fc73d0bc23d8) pythonPackages.cchardet: fix build on non-x86_64
* [`c3a1495f`](https://github.com/NixOS/nixpkgs/commit/c3a1495f4a62f674c5072583f9d90e3b6fbb5afd) ctags: rename name to pname&version
* [`7bcb373a`](https://github.com/NixOS/nixpkgs/commit/7bcb373a99a745916e93e483573717c87377fbf5) SDL2: 2.0.14 -> 2.0.20
* [`acc1ac45`](https://github.com/NixOS/nixpkgs/commit/acc1ac45358bef847a3697a223417bd2626814a8) SDL2: fix formatting
* [`d0a84bf1`](https://github.com/NixOS/nixpkgs/commit/d0a84bf142896aa5bccec1f27e48f79e27eb3c54) bluez: 5.62 -> 5.63
* [`ec1715bc`](https://github.com/NixOS/nixpkgs/commit/ec1715bc12e9d292dfe0ae06f4611db396d61de7) python3Packages.pillow: 9.0.0 -> 9.0.1
* [`ce867061`](https://github.com/NixOS/nixpkgs/commit/ce8670619da99c5077a8f12b164e0982b9a7d956) lvm2: 2.03.14 -> 2.03.15
* [`83f57484`](https://github.com/NixOS/nixpkgs/commit/83f574842fdc4dc2c3500fe2b90261d47a4fbb59) python39Packages.pyopenssl: add meta, adopt to myself
* [`5cb3a4b4`](https://github.com/NixOS/nixpkgs/commit/5cb3a4b465d49f9efb8af282ec705a82c372a365) python39Packages.pyopenssl: adopt pytestCheckHook, unify and streamline disabled tests
* [`cc6b51db`](https://github.com/NixOS/nixpkgs/commit/cc6b51db8626fc54c68ff38fa5872b8d8f22285d) python39Packages.pyopenssl: 21.0.0 -> 22.0.0
* [`18aadd72`](https://github.com/NixOS/nixpkgs/commit/18aadd72b9b1591a75f9759557ce435e7b245d65) python39Packages.eventlet: disable failing test with pyopenssl 22.0.0
* [`db3df880`](https://github.com/NixOS/nixpkgs/commit/db3df8802cb7da16bb736657ff9556ed359cc649) qt515: Update KDE Qt 5.15 patches
* [`6f0ae5f6`](https://github.com/NixOS/nixpkgs/commit/6f0ae5f6f3872472040df55120176714d8b6b009) qt515 qtwayland: update to latest KDE patch
* [`f730b8fa`](https://github.com/NixOS/nixpkgs/commit/f730b8fa3676f783148dfc178bf2fd2dadca0afe) qt515: Update KDE Qt 5.15 patches
* [`a4e8f00d`](https://github.com/NixOS/nixpkgs/commit/a4e8f00de11e0328a5add48f7d0dd98da72f34c8) qt515: Update KDE Qt 5.15 patches (20220205)
* [`adb82085`](https://github.com/NixOS/nixpkgs/commit/adb8208581a3a1d6a362b9f018cc46f34cb336cd) qt515: Update KDE Qt 5.15 patches (20220208)
* [`daca656e`](https://github.com/NixOS/nixpkgs/commit/daca656e1626a0b2009167e38bbe1556ac793c18) python3Packages.pyyaml: fix pname
* [`5c499400`](https://github.com/NixOS/nixpkgs/commit/5c499400ff5b14d2e12f3dda555c7eb494232a14) python39Packages.iniconfig: fix version number, update homepage
* [`e986a2e0`](https://github.com/NixOS/nixpkgs/commit/e986a2e0c2162941e12c9a32485a67f651a6c0d2) gd: enable AVIF support ([nixos/nixpkgs⁠#158698](https://togithub.com/nixos/nixpkgs/issues/158698))
* [`c99eb31d`](https://github.com/NixOS/nixpkgs/commit/c99eb31d1d5b373ea5aa0b3a08dbd5ca4c25470a) python3Packages.pytest-asyncio: 0.17.2 -> 0.18.0
* [`d5310bc0`](https://github.com/NixOS/nixpkgs/commit/d5310bc00a9f6e74168491f7d3af1c35825d7417) python3Packages.async_generator: use pytestCheckHook
* [`f1cd446b`](https://github.com/NixOS/nixpkgs/commit/f1cd446bcf45b917f0e81e72737c44a7295dadf6) python3Packages.aiosignal: ignore DeprecationWarning
* [`c4bd8a39`](https://github.com/NixOS/nixpkgs/commit/c4bd8a390abc5a1689884ad1a01f77496476253a) python3Packages.pytest-mock: 3.6.1 -> 3.7.0
* [`e06dae59`](https://github.com/NixOS/nixpkgs/commit/e06dae598a5b88b99fa0334f0e09cf41eeb1fdbf) python3Packages.pytest-aiohttp: 0.3.0 -> 1.0.3
* [`6838e32a`](https://github.com/NixOS/nixpkgs/commit/6838e32af555c2798a91a43da6f04459ac35cdd1) python3Packages.snitun: 0.30.0 -> 0.31.0
* [`26ad54af`](https://github.com/NixOS/nixpkgs/commit/26ad54afcf3e62a25076ba31434fd8b407c006c8) python3Packages.pytestCheckHook_6_1: drop
* [`6ebc9d20`](https://github.com/NixOS/nixpkgs/commit/6ebc9d2001eda0771c00223f42ed255783fc5c54) python3Packages.pytest_6: make alias
* [`d23a35c6`](https://github.com/NixOS/nixpkgs/commit/d23a35c63098f61d37145ebe257f58ac843d3189) python3Packages.pytest_6_1: drop
* [`8d3528e2`](https://github.com/NixOS/nixpkgs/commit/8d3528e2afd8938810c9d3d985b80a0937bfe816) python3Packages.django: 2 -> 3
* [`66b6f5f8`](https://github.com/NixOS/nixpkgs/commit/66b6f5f860f015bdb8b458a2b74bbc5bc45e5a83) python3Packages.django_2: fix pname
* [`8b4354e8`](https://github.com/NixOS/nixpkgs/commit/8b4354e860c87415b731af4f7fda2ed4204fb904) python3Packages.django_3: fix pname
* [`8b36aaf0`](https://github.com/NixOS/nixpkgs/commit/8b36aaf032a1532f5a162fa0f808e1f9e9257ba9) ncurses: rename name to pname&version
* [`1eb584fc`](https://github.com/NixOS/nixpkgs/commit/1eb584fc1521a352a6ff39c3605b218c6db1881f) speex: patch zero division vector in wave header parser
* [`584a8b35`](https://github.com/NixOS/nixpkgs/commit/584a8b351471c44ba5535adabf6c440b474698bb) autoconf213: fix nativeBuildInputs
* [`53372dfe`](https://github.com/NixOS/nixpkgs/commit/53372dfea7a12785ee78c938bad0875b2bb29462) libgee: 0.20.4 -> 0.20.5
* [`9fb4cb7b`](https://github.com/NixOS/nixpkgs/commit/9fb4cb7bd48dfbf47bf8a7b5a8c003bdfe0ab4b2) python3Packages.pycryptodomex: 3.12.0 -> 3.14.1
* [`ed62196c`](https://github.com/NixOS/nixpkgs/commit/ed62196c1cdb2aeade2f164971077324056adc21) python3Packages.pycryptodome: 3.12.0 -> 3.14.1
* [`18b73d48`](https://github.com/NixOS/nixpkgs/commit/18b73d48ddd782bbd2c5a56a06fd6a48b89d66f5) btrfs-progs: 5.16 -> 5.16.1
* [`f50fac79`](https://github.com/NixOS/nixpkgs/commit/f50fac793596489ea57323914d62db109fb09866) autoconf213: remove xz from inputs
* [`c176f83b`](https://github.com/NixOS/nixpkgs/commit/c176f83b13930ef5511a995cfc04edf86a25d3fe) ed: 1.17 -> 1.18
* [`7c5a72ae`](https://github.com/NixOS/nixpkgs/commit/7c5a72ae2ec908b395ff5f21acedbfba15230904) blas/lapack-ilp64: expose blas/lapack with ILP64 interface by default
* [`39210e89`](https://github.com/NixOS/nixpkgs/commit/39210e89c2ba8dbcedd62f04c83458f0b555f9bc) lapack,blas: allow for more flexible use of ILP64 interface
* [`f176a5b3`](https://github.com/NixOS/nixpkgs/commit/f176a5b3ac117bc77fd8d2dadf52098a223551d3) lapack-reference: allow building with ILP64 interface
* [`b15bd66e`](https://github.com/NixOS/nixpkgs/commit/b15bd66e5a57a17ef0c327fb601305079d89e327) amd-libflame: add dummy blas64 input for compatibility with wrapper
* [`5815ed06`](https://github.com/NixOS/nixpkgs/commit/5815ed0676da1924c5b89c8a56b0725a4d8c3f7f) blas-reference: use cmake and allow for ILP64 builds
* [`0a1f86cc`](https://github.com/NixOS/nixpkgs/commit/0a1f86cc87c3ddf4e14baeb4c8333dce33950e9c) blas-references: add markuskowa as maintainer
* [`daccd0e2`](https://github.com/NixOS/nixpkgs/commit/daccd0e29918a01115587ed08929488347fec7ff) lapack-reference: add markuskowa as maintainer
* [`e1c98c11`](https://github.com/NixOS/nixpkgs/commit/e1c98c11127ff10a7f06676d29894d6979c06718) amd-blis: add markuskowa as maintainer
* [`f415aae9`](https://github.com/NixOS/nixpkgs/commit/f415aae96554cf83379fdd7fd4c9152822f9b977) nixpkgs/doc: update overlay/lapack section
* [`3c9b6d19`](https://github.com/NixOS/nixpkgs/commit/3c9b6d192317ace7df01d45115d9ae6764a5b8b8) python3Packages.importlib-metadata: 4.10.1 -> 4.11.0
* [`dd4675f6`](https://github.com/NixOS/nixpkgs/commit/dd4675f674ea1bb6858bae402bd516b03c2dedf2) python3Packages.moto: disable aarch64 network test
* [`fb3637ef`](https://github.com/NixOS/nixpkgs/commit/fb3637ef1de60f2a73ba994d32e3dbb205301520) postgresql_10: 10.19 -> 10.20
* [`726aad37`](https://github.com/NixOS/nixpkgs/commit/726aad379677e22f0a8158109a15b411e04dcd4b) postgresql_11: 11.14 -> 11.15
* [`c6b58fec`](https://github.com/NixOS/nixpkgs/commit/c6b58fecd0815c0f79d086c28e0ecd2e6f85d874) postgresql_12: 12.9 -> 12.10
* [`42722790`](https://github.com/NixOS/nixpkgs/commit/42722790c828180c1b5afe874ee66a052232d462) postgresql_13: 13.5 -> 13.6
* [`4cc1cb36`](https://github.com/NixOS/nixpkgs/commit/4cc1cb36467c51f69dc20a20e9b64b554851e5e3) postgresql_14: 14.1 -> 14.2
* [`23d91da8`](https://github.com/NixOS/nixpkgs/commit/23d91da833454408d553a4866aa7b808ddb12979) harfbuzz: 3.2.0 -> 3.3.2
* [`183147a0`](https://github.com/NixOS/nixpkgs/commit/183147a037b68c656e5e568f4d7f00e994068e0f) makeWrapper: Don't glob in prefix/suffix
* [`6bcaa9da`](https://github.com/NixOS/nixpkgs/commit/6bcaa9da83a6a05ce3ce253d3a637a03f456cc8d) libnfs: 4.0.0 -> 5.0.1
* [`a375ff13`](https://github.com/NixOS/nixpkgs/commit/a375ff1332d41bf3aba9d173055cfe3e9d2c3077) man: 2.9.4 -> 2.10.1
* [`eb9e336f`](https://github.com/NixOS/nixpkgs/commit/eb9e336fbdcf1f5f9c97e53a8a467970e075016c) python3Packages.platformdirs: 2.4.1 -> 2.5.0
* [`4c7c1975`](https://github.com/NixOS/nixpkgs/commit/4c7c1975b6bae77549f7c3564fa0c09d074d90dd) python3Packages.ipython: disable clipboard test on darwin
* [`99b46757`](https://github.com/NixOS/nixpkgs/commit/99b46757ccb7a2504cbf8877dac9cefe5b167bdb) gnupg: 2.3.3 -> 2.3.4
* [`b9597a91`](https://github.com/NixOS/nixpkgs/commit/b9597a916ab87dd1ac3d5ca3666714bcc07cd12f) gnupg: remove patch for darwin warnings
* [`2cbb397a`](https://github.com/NixOS/nixpkgs/commit/2cbb397acf58a32d8b75f6caf1878d4fae409742) neon: 0.31.2 -> 0.32.2
* [`5e94b6a1`](https://github.com/NixOS/nixpkgs/commit/5e94b6a1db6779684426f4ac484c33ddeb795211) gnupg: remove unneeded SOURCE_DATE_EPOCH patch
* [`8c6becd9`](https://github.com/NixOS/nixpkgs/commit/8c6becd90467e6decc16fa33a7e3424bbaa01164) gnupg: fix default keyserver patch
* [`ba724316`](https://github.com/NixOS/nixpkgs/commit/ba724316cbbc780279df25e775f4a19dcdf71c0b) python3Packages.jedi: reduce test dependencies
* [`90c2dc3a`](https://github.com/NixOS/nixpkgs/commit/90c2dc3aba36176ff2db4ea33f9bb305359a407c) openh264: 2.1.1 -> 2.2.0
* [`25e585cc`](https://github.com/NixOS/nixpkgs/commit/25e585cc77770629e59a08f8358d63c986f0060d) libsigsegv: 2.13 -> 2.14
* [`db629045`](https://github.com/NixOS/nixpkgs/commit/db629045cd701dfa1e0b04f2158cac97b2ff1e2a) lcms2: 2.12 -> 2.13.1
* [`240ceadd`](https://github.com/NixOS/nixpkgs/commit/240ceaddb9dacdb6e463e1f9ffb437fe9545cfe0) libarchive: 3.5.2 -> 3.6.0
* [`a7cf36f8`](https://github.com/NixOS/nixpkgs/commit/a7cf36f84118aa503e09a1b188f6cbba63dd4cd6) vim: 8.2.4227 -> 8.2.4350
* [`0098ccb8`](https://github.com/NixOS/nixpkgs/commit/0098ccb8f8251cc8b277eddfbd9c270b3adde52c) rocm-device-libs: 4.5.2 -> 5.0.0
* [`05fdc9cc`](https://github.com/NixOS/nixpkgs/commit/05fdc9cce0dc59e62a8951460f7d00e1550d7e8e) gpgme: 1.16.0 -> 1.17.0
* [`6542bd23`](https://github.com/NixOS/nixpkgs/commit/6542bd231250e2aef7e9a5a5963a3092c41b6c2e) kde/frameworks: 5.90 -> 5.91
* [`d27ab140`](https://github.com/NixOS/nixpkgs/commit/d27ab140ca78e6beb4974a0d612d73db4c706f81) kchmviewer: init at 8.0
* [`2fe19fe2`](https://github.com/NixOS/nixpkgs/commit/2fe19fe24a225c33c4011ee9dbc0b4310b798134) llvmPackages_13.clang: add nostdlibinc flag
* [`ae734c34`](https://github.com/NixOS/nixpkgs/commit/ae734c34f66c87cf4d35eee42bdf0706538861ec) python3Packages.charset-normalizer: 2.0.10 -> 2.0.12
* [`05d293c2`](https://github.com/NixOS/nixpkgs/commit/05d293c2bf55a94622ece5ca196187cd622f5941) util-linux: 2.37.3 -> 2.37.4
* [`b07a1f4c`](https://github.com/NixOS/nixpkgs/commit/b07a1f4c60e45acbd1c362035dd730e48a0bc64e) kde/kdesu: Fix patch to work with new kde framework
* [`b72f4a4a`](https://github.com/NixOS/nixpkgs/commit/b72f4a4a2ad01104f39f151bca77b15f55b5c461) libpng: rename name to pname&version ([nixos/nixpkgs⁠#160047](https://togithub.com/nixos/nixpkgs/issues/160047))
* [`d7d7c67c`](https://github.com/NixOS/nixpkgs/commit/d7d7c67c89a57ccaf3e6bbe763aa7516372fd162) libpsm2: 11.2.203 -> 11.2.206
* [`4df3d430`](https://github.com/NixOS/nixpkgs/commit/4df3d430e5afd191b91c6a3c9133b6458b0c67ae) pango: 1.50.3 -> 1.50.4
* [`273a460b`](https://github.com/NixOS/nixpkgs/commit/273a460b8b3222646aa564a52d198ba5c94e6b91) python3Packages.black: 21.12b0 -> 22.1.0
* [`c6d57ed1`](https://github.com/NixOS/nixpkgs/commit/c6d57ed150d1741758a4d76e3d3febcdd12ade67) python3Packages.frozenlist: 1.2.0 -> 1.3.0
* [`70c9f1b2`](https://github.com/NixOS/nixpkgs/commit/70c9f1b2ada231640d52e184d4e16d3e1b70ff28) python3Packages.semantic-version: 2.8.5 -> 2.9.0
* [`5f3dfcf7`](https://github.com/NixOS/nixpkgs/commit/5f3dfcf71e88cb365eef64da462c3c3498d6b3a7) python3Packages.semantic-version: enable tests
* [`04c5b5ad`](https://github.com/NixOS/nixpkgs/commit/04c5b5ad9772c9ebc7247726bcdf5b5835d3e634) nettle: rename name to pname&version
* [`7d6a74d1`](https://github.com/NixOS/nixpkgs/commit/7d6a74d11c91730b1a54df31dbbc4d9c3aa09854) tk: rename name to pname&version
* [`b076bd35`](https://github.com/NixOS/nixpkgs/commit/b076bd352af965edd101c3c3c1a9a8cb7c3437e1) libwacom: 1.99.1 -> 2.0.0
* [`aa9df425`](https://github.com/NixOS/nixpkgs/commit/aa9df42506746e0818c80fa18f02406056a47e7d) glib: 2.70.2 -> 2.70.3
* [`baee63f5`](https://github.com/NixOS/nixpkgs/commit/baee63f5e1af6d6a16fc0d3bd993673ecc689e00) SDL2: add pipewire & libdecor support
* [`6407cb37`](https://github.com/NixOS/nixpkgs/commit/6407cb37d98a3287d9e65c343746ce062f916eb0) libqmi: 1.30.2 -> 1.30.4
* [`d38a799f`](https://github.com/NixOS/nixpkgs/commit/d38a799ff87df362556061fedaae1a5beec9aad7) kde/plasma5: 5.23.5 -> 5.24.0
* [`5e80366c`](https://github.com/NixOS/nixpkgs/commit/5e80366cb26ae97f88920ca3fea1d1ae32fbf7cb) plasma-wayland-protocols: 1.5.0 -> 1.6.0
* [`217b65f6`](https://github.com/NixOS/nixpkgs/commit/217b65f690ccdde04b9849b897b3fafecb3430f3) kde/plasma5: adjust patches to 5.24
* [`febc317d`](https://github.com/NixOS/nixpkgs/commit/febc317da58544dddf9d7d7cfcfeb8414bb8aba4) help2man: 1.48.5 -> 1.49.1
* [`54806020`](https://github.com/NixOS/nixpkgs/commit/54806020fa4f85a73d5580d5c3d1faaca1785286) libxslt: Fix use-after-free in xsltApplyTemplates
* [`cee6a92b`](https://github.com/NixOS/nixpkgs/commit/cee6a92b215acba7300af1e1690a24622b1f65b0) mesa: 21.3.5 -> 21.3.6
* [`39bbf55f`](https://github.com/NixOS/nixpkgs/commit/39bbf55f4f8314f3003414a94c152b3c5afbc2c1) rocminfo: 4.5.2 -> 5.0.1
* [`0b16f920`](https://github.com/NixOS/nixpkgs/commit/0b16f9206933bd76f1147be45878267f7764ec88) libaom: 3.2.0 -> 3.3.0
* [`9c5d593b`](https://github.com/NixOS/nixpkgs/commit/9c5d593baaa4026cff67b7753b4150bf4a86cd6d) vala: 0.54.6 -> 0.54.7
* [`cfe1e451`](https://github.com/NixOS/nixpkgs/commit/cfe1e45137a3150f6de8d8d8908133227f94718b) libbsd: 0.11.3 -> 0.11.5
* [`08a80b7b`](https://github.com/NixOS/nixpkgs/commit/08a80b7b009feb1334dfb764ab25641ecda3f1dd) polkit: Patch unauthenticated file descriptor leak
* [`8bb64ffa`](https://github.com/NixOS/nixpkgs/commit/8bb64ffa11af7889dd3a289f6f975c5b99dc09f9) furnace: init at 0.5.6
* [`bc3994e1`](https://github.com/NixOS/nixpkgs/commit/bc3994e14a8315be05b78ecf01ad69a79797ddb8) prosody: 0.11.12 -> 0.11.13
* [`7629826b`](https://github.com/NixOS/nixpkgs/commit/7629826b0307980765c50d4f661399d236cb6c26) nixos/tests/prosody: return prosody-mysql test
* [`3e18e6e7`](https://github.com/NixOS/nixpkgs/commit/3e18e6e7a881a734ed2d4e2e24d144a62091b2c4) libdrm: 2.4.109 -> 2.4.110
* [`046300ef`](https://github.com/NixOS/nixpkgs/commit/046300ef593fa2909ff2190b1b238283a6e02a7b) python39Packages.ruamel-yaml: 0.17.20 -> 0.17.21
* [`b79405c6`](https://github.com/NixOS/nixpkgs/commit/b79405c627010f429b95879b7ef9650f139b198b) python39Packages.typed-ast: 1.5.1 -> 1.5.2
* [`62b1a577`](https://github.com/NixOS/nixpkgs/commit/62b1a57752816207137e3f7f8c1167c80eb08965) expat: 2.4.4 -> 2.4.5 (security)
* [`7cbe22df`](https://github.com/NixOS/nixpkgs/commit/7cbe22df7593a16a4b49b6973d1e5b41c39ea748) python3Packages.check-manifest: cleanup
* [`1d58c6b0`](https://github.com/NixOS/nixpkgs/commit/1d58c6b05696610faa79d19d5a1ca3a08c572ed0) xdg-dbus-proxy: 0.1.2 -> 0.1.3
* [`84c2d95c`](https://github.com/NixOS/nixpkgs/commit/84c2d95cf8a6cc862ee7d97403d001d66120af18) libwnck: 40.0 -> 40.1
* [`ff2862eb`](https://github.com/NixOS/nixpkgs/commit/ff2862eb7ae11fd1574a3147bfec8288e0a2c879) librsvg: 2.52.5 -> 2.52.6
* [`1340607f`](https://github.com/NixOS/nixpkgs/commit/1340607f3dd6ba1b3c3888c3375e6837e353c2bd) gpgme: add patch for Python 3.10 support
* [`32125edc`](https://github.com/NixOS/nixpkgs/commit/32125edc9826d5524f87ca8b2c5bd4848aa2b7a8) python39Packages.pbr: 5.8.0 -> 5.8.1
* [`8706d948`](https://github.com/NixOS/nixpkgs/commit/8706d94802ec151d0c74d8d6d3e0675c39e4662f) gpgme: fix python 3.10 support, try 2
* [`649ebfbe`](https://github.com/NixOS/nixpkgs/commit/649ebfbed65189d7d62e4f2fe0e491552308a6f1) cc-wrapper: change cflags order from cc/crt1/libc to crt1/libc/cc
* [`c13e6e30`](https://github.com/NixOS/nixpkgs/commit/c13e6e30d729ff4b70b8445458ec72fc5ab79b13) rocm-runtime: 4.5.2 -> 5.0.1
* [`08bd5cbf`](https://github.com/NixOS/nixpkgs/commit/08bd5cbf9c3171698f61081b85e254b52dbaa092) expat: 2.4.5 -> 2.4.6
* [`7e1f7b8e`](https://github.com/NixOS/nixpkgs/commit/7e1f7b8e1fc882dd560aca61d1d9d489cff4202f) python3Packages.aiohttp: fix tests on Darwin
* [`dfab9e35`](https://github.com/NixOS/nixpkgs/commit/dfab9e35c612076d411728df24b67f852faa8024) libv4l: 1.20.0 -> 1.22.1
* [`8ca7bb10`](https://github.com/NixOS/nixpkgs/commit/8ca7bb10a8980d2b9a11a4a1d68347bbbc6c2314) libxml2: Format the expression
* [`ce668865`](https://github.com/NixOS/nixpkgs/commit/ce668865b942d3d4c10da051751dcc2551a6cbab) libxml2: switch to gnome mirrors
* [`33ee72f4`](https://github.com/NixOS/nixpkgs/commit/33ee72f4b130eaee659a931db32c4bdeacee66d0) libxml2: Add myself as a maintainer
* [`8570316d`](https://github.com/NixOS/nixpkgs/commit/8570316d3d22546fb79f951863a7741f908c9f95) libxml2: do not disable working test
* [`9c57fa9f`](https://github.com/NixOS/nixpkgs/commit/9c57fa9fc1de613bcc03ac1676ae1792942a0f9b) libxml2: use autoreconfHook
* [`65ca2a4b`](https://github.com/NixOS/nixpkgs/commit/65ca2a4bbbaea67c734e225432b5464af697726c) libxml2: More cleanups
* [`7eb38d55`](https://github.com/NixOS/nixpkgs/commit/7eb38d554c91b691aa3cedc80acec4e28950eb63) libxml2: fix configure flags
* [`cb8aaea8`](https://github.com/NixOS/nixpkgs/commit/cb8aaea8fd5fac6410bfc4fab1ea76f6f2c6118f) libxml2: 2.9.12 → 2.9.13
* [`7b83c90d`](https://github.com/NixOS/nixpkgs/commit/7b83c90d91a73de6e569e35ce92d276ca0d729a7) libxslt: Format the expression
* [`1614783d`](https://github.com/NixOS/nixpkgs/commit/1614783d59f2304401fc797a21121f611429521b) libxslt: switch to gnome mirrors
* [`15328411`](https://github.com/NixOS/nixpkgs/commit/1532841149b6f0a0a936c178b6784e8c94f2ac72) libxslt: Add myself as a maintainer
* [`2982bcbc`](https://github.com/NixOS/nixpkgs/commit/2982bcbcbc87e51a3d59e24004912968e9cf6b7f) libxslt: 1.1.34 → 1.1.35
* [`251c50fb`](https://github.com/NixOS/nixpkgs/commit/251c50fb72fe051afe3a073ed5fe85c0f4d2e44b) openblas: 0.3.19 -> 0.3.20
* [`3b3a934e`](https://github.com/NixOS/nixpkgs/commit/3b3a934ed8654f2bf0c4156d1d771d94e39dee3e) argon2_cffi: add missing non-native bindings dep
* [`7d6abd19`](https://github.com/NixOS/nixpkgs/commit/7d6abd197c1b5853d3fe57ef2202b8092f340d66) libtiff: add patches for CVE-2022-0561 & CVE-2022-0562
* [`b936d17f`](https://github.com/NixOS/nixpkgs/commit/b936d17f834f6f68234a14e57b17e597fd8c7e13) python3Packages.stack-data: 0.1.0 -> 0.2.0
* [`586b8976`](https://github.com/NixOS/nixpkgs/commit/586b897693ecc4166c0c0802963516a2ca37961c) sage: update test expectations for stack_data 0.2.0
* [`04a1e436`](https://github.com/NixOS/nixpkgs/commit/04a1e43685e3e3aad93b7fc6589a3d2577213cfc) pypy27_prebuilt: 7.3.6 -> 7.3.8
* [`fd9c3674`](https://github.com/NixOS/nixpkgs/commit/fd9c3674b94e68a8f2039472d21f6762d9387d4b) pypy27_prebuilt: remove unneeded openssl_1_0_2 dependency
* [`e2fd70f5`](https://github.com/NixOS/nixpkgs/commit/e2fd70f59927c95b53147a32c551b801e38257bd) libxslt: use autoreconfHook
* [`ba2687fc`](https://github.com/NixOS/nixpkgs/commit/ba2687fcfbbfa66af3fcad30a0eadbbf01b14586) libtiff: standardize the patch URLs
* [`f57be3c7`](https://github.com/NixOS/nixpkgs/commit/f57be3c72ace01f5c0c5412e7de43d2b0ed47f12) linux: restrict option JOYSTICK_PSXPAD_SPI_FF
* [`043f2055`](https://github.com/NixOS/nixpkgs/commit/043f2055b45b82b4a789567b4b2ae6478ee05f46) libvirt: fix build with latest libxslt
* [`5f7a91e4`](https://github.com/NixOS/nixpkgs/commit/5f7a91e49ba6aca334be410e94f1153aa177e5ff) gramps: disable strictDeps
* [`a95e947c`](https://github.com/NixOS/nixpkgs/commit/a95e947c816db6a13a2a2099df9471d30850547d) protonvpn-gui: activate strictDeps
* [`42890734`](https://github.com/NixOS/nixpkgs/commit/42890734c3e0da2e7e1f0b6b04743b004772afee) mesa: 21.3.6 -> 21.3.7
* [`e8c323aa`](https://github.com/NixOS/nixpkgs/commit/e8c323aa3973d97b3a5cd0c5928f31777ded4efd) lbry: 0.52.4 -> 0.52.5
* [`0451c289`](https://github.com/NixOS/nixpkgs/commit/0451c289d3011dd1ad1f97f6157c8937ba4f620e) python3Packages.xmltodict: disable incompatible expat tests
* [`4db2ee62`](https://github.com/NixOS/nixpkgs/commit/4db2ee62787f0d5f339dd25e7db43a7f79ece09c) fixup patches reference on wxwidgets
* [`690e3f30`](https://github.com/NixOS/nixpkgs/commit/690e3f304e531f51096f281e7d990980b3ec27d3) freetube: fix icon
* [`403faa7f`](https://github.com/NixOS/nixpkgs/commit/403faa7fd0f41a506d706bd1e963dc4898e07c0a) Revert "python3Packages.ipython: disable clipboard test on darwin (targeting master)"
* [`5cee9c9e`](https://github.com/NixOS/nixpkgs/commit/5cee9c9ef2f6b640c7dd48d7f68e87e2d24478c1) prometheus-dmarc-exporter: init at 0.5.1
* [`cafa5b40`](https://github.com/NixOS/nixpkgs/commit/cafa5b400c48be75300b3e1ec28ddeead9f6f392) prometheus-dmarc-exporter: add meta
* [`b2d803ca`](https://github.com/NixOS/nixpkgs/commit/b2d803ca57ef06b3f681db109d7f6069b2eb9bc1) nixos/treewide: Add last missing option types
* [`0c766a10`](https://github.com/NixOS/nixpkgs/commit/0c766a100e416611807a184ee35a0edbd11b15a4) lib/options: Throw error for options without a type
* [`3b25e846`](https://github.com/NixOS/nixpkgs/commit/3b25e846f2fac1134a553b76328c1656250f967e) btrbk: 0.32.0 -> 0.32.1
* [`2b71e685`](https://github.com/NixOS/nixpkgs/commit/2b71e6850398f368ebaf7e2914fd9d1d832252ca) naproche: init at 0.1.0.0
* [`c1ef185b`](https://github.com/NixOS/nixpkgs/commit/c1ef185bdb88b148428fba00260afd23f8fc11ef) isabelle: Use naproche from nixpkgs
* [`04ee1b89`](https://github.com/NixOS/nixpkgs/commit/04ee1b8975c1c3e8eb13783a75baa59e85f44704) phd2: 2.6.10 -> 2.6.11
* [`45295517`](https://github.com/NixOS/nixpkgs/commit/45295517b92e2c17af34cfab740163ad57687a0e) shipyard: 0.3.47 -> 0.3.48
* [`3e7e6ab8`](https://github.com/NixOS/nixpkgs/commit/3e7e6ab84a5a4facdbeea8941af9df471d66c839) buildFHSUserEnv{Chroot,Bubblewrap}: link gsettings-schemas to the FHS location
* [`4330797d`](https://github.com/NixOS/nixpkgs/commit/4330797dfb095d59f57bb65f04d4054a53089892) appimage: add gsettings-desktop-schemas, hicolor-icon-theme to the fhs
* [`d030e210`](https://github.com/NixOS/nixpkgs/commit/d030e2109fd491e32cb48df54d100aa608551298) lib.modules: Let module declare options directly in bare submodule
* [`58a8a48e`](https://github.com/NixOS/nixpkgs/commit/58a8a48e9d14cf397181d1223eabeb001f499049) lib.types.submodule: Remove redundant isSubmodule attr
* [`0c09eb34`](https://github.com/NixOS/nixpkgs/commit/0c09eb343dfa186c0fbf2bb6cbc36e7a8f369ea5) lib.modules: Refactor option scanning slightly
* [`81f342d1`](https://github.com/NixOS/nixpkgs/commit/81f342d1f3a6bab4a57e195ce99a153b82b1ef86) lib.modules: Explain why options can only be merged into submodules
* [`11537c9c`](https://github.com/NixOS/nixpkgs/commit/11537c9c0239dc4ae52477faa78a4a0a7bdf206c) lib.modules: Improve option-is-prefix error message
* [`8baea8b8`](https://github.com/NixOS/nixpkgs/commit/8baea8b82cc80c6a2843045d5b554f7f65acbc4f) lib.modules: Make option injection work when shorthandOnlyDefinesConfig
* [`6b077c47`](https://github.com/NixOS/nixpkgs/commit/6b077c47ff14cb9a4a8f5cb8986fa83ff626c732) lib.modules: Remove redundant fixupOptionType in option injection
* [`28aeae21`](https://github.com/NixOS/nixpkgs/commit/28aeae21269a69ae9721c9c8f9194877799ead69) lib.modules: Default shorthandOnlyDefinesConfig to true when null
* [`20506699`](https://github.com/NixOS/nixpkgs/commit/20506699226b0dac5d423c6f6249f3cb15565169) lib.modules: Inline a private function
* [`9db967d7`](https://github.com/NixOS/nixpkgs/commit/9db967d700ce88a0d624d37ea06eb20af0e77425) rPackages.chebpol: fix fftw linking
* [`7f9a18fe`](https://github.com/NixOS/nixpkgs/commit/7f9a18fe0743bd1bdcd92eff1c35c4b96ffa6445) flyctl: 0.0.301 -> 0.0.302
* [`5f69cf07`](https://github.com/NixOS/nixpkgs/commit/5f69cf07020e24da5d8a6057a2f865e50a02a527) timeline: 2.4.0 -> 2.6.0
* [`12f9b166`](https://github.com/NixOS/nixpkgs/commit/12f9b166d738fd13c4da483bf3c0d27776b82a2e) mautrix-telegram: 0.11.1 -> 0.11.2
* [`67481d8e`](https://github.com/NixOS/nixpkgs/commit/67481d8e56c273b8aaa03ba50ee9d3d1b41b30fb) python3Packages.django-picklefield: disable tests
* [`afdcf374`](https://github.com/NixOS/nixpkgs/commit/afdcf37462af9e06d92869548f2ab6876cb5df8e) paperless-ng: remove django-picklefield override
* [`012bfb64`](https://github.com/NixOS/nixpkgs/commit/012bfb6439899fe0dc6095c2a58fcdf43cce747a) protolock: 0.15.2 -> 0.16.0
* [`a255d7f4`](https://github.com/NixOS/nixpkgs/commit/a255d7f44530dc456cfadf2d5b52cf9081dc68de) stellarsolver: 1.9 -> 2.0
* [`29933974`](https://github.com/NixOS/nixpkgs/commit/29933974535c473ba43f2dd1f4febcbcc4705bdd) belr: 5.0.55 -> 5.1.3
* [`96d0feb1`](https://github.com/NixOS/nixpkgs/commit/96d0feb1ecfec80eb2b8a897272714a86a7dd125) owncast: 0.0.10 -> 0.0.11
* [`2c374da1`](https://github.com/NixOS/nixpkgs/commit/2c374da14da078a74572379d3ca104b5c5ec4198) qbec: 0.15.1 -> 0.15.2
* [`92071669`](https://github.com/NixOS/nixpkgs/commit/92071669a43fc2238904df9eb24de50d4de08bf0) mmv: 2.1 -> 2.3
* [`5e2074dd`](https://github.com/NixOS/nixpkgs/commit/5e2074dddbd342feaaf93d9647d770b613b48f39) vscode-extensions.kddejong.vscode-cfn-lint: init at 0.21.0
* [`0b05331c`](https://github.com/NixOS/nixpkgs/commit/0b05331cb344b865f4bde3cfac92ac5e8fcd9157) libarchive-qt: 2.0.6 -> 2.0.7
* [`df751f54`](https://github.com/NixOS/nixpkgs/commit/df751f5488857fa458ac404d9959bc8b193a1a65) dictu: 0.23.0 -> 0.24.0
* [`db082904`](https://github.com/NixOS/nixpkgs/commit/db08290453ae0eb7622648435bf7af187929b153) Revert "lib.modules: Remove redundant fixupOptionType in option injection"
* [`e162ed8a`](https://github.com/NixOS/nixpkgs/commit/e162ed8a142d6ff53b7d03018bfd95a3a044bd06) lib/modules.nix: Move comment to the actual legacy code
* [`c90844ae`](https://github.com/NixOS/nixpkgs/commit/c90844aeb97c0d57f3dbb5774f56cddbf5b2a16d) lib/tests/modules: Add test case for duplicate option error file location
* [`c4b38702`](https://github.com/NixOS/nixpkgs/commit/c4b38702e59ea156924d3297e3f7ec80f7f816cb) lib/modules.nix: Add comment about internal shorthand null value
* [`1d76c5b6`](https://github.com/NixOS/nixpkgs/commit/1d76c5b6696e4202852310c84d3c35675ebc9113) wget: 1.21.2 -> 1.21.3
* [`05c12ee7`](https://github.com/NixOS/nixpkgs/commit/05c12ee78cf5c9a7a01fcdb841825db4b6a771d9) spark: init 3.2.1 and test on aarch64-linux
* [`ef18b4f8`](https://github.com/NixOS/nixpkgs/commit/ef18b4f863409a4deac34bfb2fb787fc2796b508) discordchatexporter-cli: 2.32 -> 2.33.2
* [`7e5b346b`](https://github.com/NixOS/nixpkgs/commit/7e5b346bd4fc80063d743e076b705e40c2387482) firefox: 97.0.2 -> 98.0
* [`0342d39a`](https://github.com/NixOS/nixpkgs/commit/0342d39a7d69c4ea7ef15dd65b2939d2a8e776ab) menyoki: 1.5.6 -> 1.6.0
* [`b087f754`](https://github.com/NixOS/nixpkgs/commit/b087f7545878262faa6362b2abc751b733543f77) joshuto: 0.9.2 -> 0.9.3
* [`07d35fb4`](https://github.com/NixOS/nixpkgs/commit/07d35fb44472ebb7afa36731a94dffcb741c3a53) lpcnetfreedv: enable all platforms
* [`e7e86ceb`](https://github.com/NixOS/nixpkgs/commit/e7e86ceb19c8eae6c065122052d6ab79f8aafd57) freedv: specify platforms
* [`7ed07996`](https://github.com/NixOS/nixpkgs/commit/7ed0799682736cd4631195937dcce2bd52ce3c23) freedv: permit selection of audio backend
* [`6efa931c`](https://github.com/NixOS/nixpkgs/commit/6efa931c518e8fdc725527e465bceb0b8fb60a4a) nixos/hadoop: fix mkenableoption text
* [`dd5f004b`](https://github.com/NixOS/nixpkgs/commit/dd5f004b06a16e7c291bd159f792b718b7fce0b3) nixos/hadoop: refactor HDFS options
* [`2b78cfdb`](https://github.com/NixOS/nixpkgs/commit/2b78cfdb097dfb68bcfcae532de303475ae1a030) pacemaker: init at 2.1.2
* [`68c44db7`](https://github.com/NixOS/nixpkgs/commit/68c44db781e3372f3370ced39a52b42dd8f5f059) corosync: configure with --enable-systemd
* [`a60ab35d`](https://github.com/NixOS/nixpkgs/commit/a60ab35dd653b0969c014ced93396d212f1c460c) nixos: init corosync, pacemaker modules
* [`6285a2ea`](https://github.com/NixOS/nixpkgs/commit/6285a2ea52102ec59809303eb20414937592fdd2) ferdi: 5.7.0 -> 5.8.0
* [`b734bd12`](https://github.com/NixOS/nixpkgs/commit/b734bd12e5d2a9e29bb7e7a3ca097a7cb8d416c3) libgbinder: 1.1.16 -> 1.1.19
* [`70c1e849`](https://github.com/NixOS/nixpkgs/commit/70c1e849c0b5741e07e7d8d0d418764e2fdb4e24) nixos/tests/pacemaker: init
* [`3c7e3a32`](https://github.com/NixOS/nixpkgs/commit/3c7e3a328ca8d537af1327e2b14db85e22a5b0eb) openrussian-cli: refactor to use lua.withPackages instead of luaPackages
* [`39f3eb30`](https://github.com/NixOS/nixpkgs/commit/39f3eb30048e6af67044985a5de80eefd88bd1fc) NixOS/auto-upgrade: offer the possibility to define a reboot window during which the system may be automatically rebooted
* [`b9c5e1e8`](https://github.com/NixOS/nixpkgs/commit/b9c5e1e81adc66ffd12cf0afd5b061317a80c790) peertube: 4.1.0 -> 4.1.1
* [`a822d0c0`](https://github.com/NixOS/nixpkgs/commit/a822d0c0756c085cb18b889bfcd39838e14b6fa1) nixos/tests/peertube: add check peertube cli
* [`246794d5`](https://github.com/NixOS/nixpkgs/commit/246794d5c48de67ede26c3ca9bc122a56f097877) spark: bring version naming in line with hadoop
* [`3739a781`](https://github.com/NixOS/nixpkgs/commit/3739a7819dea81d1cfc4cf44c1dba86993514b1c) R: 4.1.2 -> 4.1.3
* [`ee1ff079`](https://github.com/NixOS/nixpkgs/commit/ee1ff0797b6f16e5a6fe7caf2ec50907c6de99d2) spark: update release notes for 22.05
* [`f67c61e0`](https://github.com/NixOS/nixpkgs/commit/f67c61e0d507ed352e33be64d0d02b9d6be0488b) rPackages: CRAN and BioC update
* [`f764458e`](https://github.com/NixOS/nixpkgs/commit/f764458ed23dc8eae5dc5d53aa14e289818cb282) siril: 0.99.10.1 -> 1.0.0
* [`79141f2c`](https://github.com/NixOS/nixpkgs/commit/79141f2ce4453ab2e6720e4308af31751f0b6eeb) syslogng: 3.35.1 -> 3.36.1
* [`12371a51`](https://github.com/NixOS/nixpkgs/commit/12371a51e647a00b90fe250837f056642125c095) lib/systems: add mips64el definitions
* [`3cf83187`](https://github.com/NixOS/nixpkgs/commit/3cf831874e1dd5a804f4c86910c5129096e8a708) Update pkgs/top-level/stage.nix
* [`5b63b25d`](https://github.com/NixOS/nixpkgs/commit/5b63b25d68d0fbf64f14179b81f68d863b5c88ae) s/makeStaticParsedPlatform/makeMuslParsedPlatform/g
* [`8a1235f7`](https://github.com/NixOS/nixpkgs/commit/8a1235f77511d8ca34c8bc74d7933de2faaef48c) https://github.com/NixOS/nixpkgs/pull/161158#pullrequestreview-903824138
* [`e748e1fd`](https://github.com/NixOS/nixpkgs/commit/e748e1fd18617319e9f46eaca7e68c0621c5f356) https://github.com/NixOS/nixpkgs/pull/161158#pullrequestreview-903824553
* [`998fd408`](https://github.com/NixOS/nixpkgs/commit/998fd408e0675e71c7abe600b4dc6a5c29845634) remove float = "hard" from mips entries
* [`ed4fa55f`](https://github.com/NixOS/nixpkgs/commit/ed4fa55fc3d152b924d6c23bb97856f64729a11c) comment: explain why gnuabi64 has a rustc.config but gnuabin32 does not.
* [`6de935a0`](https://github.com/NixOS/nixpkgs/commit/6de935a0126efde78feefbbe3bddfaa6be2bda6a) This commit adds only comments to platforms.nix.
* [`ff69b8c2`](https://github.com/NixOS/nixpkgs/commit/ff69b8c2bf81f848979f18a47f18941979c5eaf2) Ericson2314's suggestion here: https://github.com/NixOS/nixpkgs/pull/161158#discussion_r822295406
* [`5660c5f8`](https://github.com/NixOS/nixpkgs/commit/5660c5f8b4a5f716f4fd1fdfee11088af4139688) jetty 9.4.45.v20220203 -> 11.0.8
* [`4ea5398d`](https://github.com/NixOS/nixpkgs/commit/4ea5398d20cf110b84800e91f30a3dfce96c1b4e) plantuml-server 1.2021.12 -> 1.2022.2
* [`f6cf1ced`](https://github.com/NixOS/nixpkgs/commit/f6cf1ced335869002697efa8f18cb77493a38e56) nixos/hadoop: refactor HDFS configs
* [`0f97c9ae`](https://github.com/NixOS/nixpkgs/commit/0f97c9ae82bae1d445b14483864d784e1245204e) nixos/hadoop: disable openFirewall by default
* [`c82d4891`](https://github.com/NixOS/nixpkgs/commit/c82d48913f581a5c878e9f31075c23563f92b9a3) nixos/hadoop: add HADOOP_CONF_DIR to env
* [`799dc66c`](https://github.com/NixOS/nixpkgs/commit/799dc66cf1ea36b2dea0893734ace5606cb63433) hadoop: add passthrough tests
* [`cc19b949`](https://github.com/NixOS/nixpkgs/commit/cc19b949af25b9d4db80a62fd445ff1987cc8241) hadoop: Add Java 8 support for Hadoop 3.2
* [`2130653a`](https://github.com/NixOS/nixpkgs/commit/2130653ae2b9e3e090127055cebf3ed09f2724e8) hadoop: Add support for linux container executor in versions < 3.3
* [`8aeb60f0`](https://github.com/NixOS/nixpkgs/commit/8aeb60f034d7581245bdcb3f26e5bc3078dfe0ea) nixos/hadoop: use FairScheduler by default
* [`d39056d1`](https://github.com/NixOS/nixpkgs/commit/d39056d165c9dc480284f3bd1e63b6213f0e518d) nixos/hadoop: fix tests for hadoop 2 and 3.2
* [`716b0dfa`](https://github.com/NixOS/nixpkgs/commit/716b0dfaaf12afe83ff54b793dc52c022ab62155) nixos/hadoop: add gateway role
* [`bef71d7c`](https://github.com/NixOS/nixpkgs/commit/bef71d7c530aeecdcfb66290e6c0b4948d1fb223) nixos/hadoop: use CGroups to enforce container limits by default
* [`e1017adb`](https://github.com/NixOS/nixpkgs/commit/e1017adb328da98e7942ec08354dd686653370a4) nixos/hadoop: add module options for commonly used service configs
* [`a7827ecf`](https://github.com/NixOS/nixpkgs/commit/a7827ecfae20a31d47aad8d1798460886936b002) nixos/hadoop: add release notes
* [`42391303`](https://github.com/NixOS/nixpkgs/commit/423913035a300abcfb52c2efe321c31262ab1f2e) maintainers: add brianmcgee
* [`dd510b90`](https://github.com/NixOS/nixpkgs/commit/dd510b9053e38ac176cdc3fdd042d82cb4ff088e) nixos/mate: allow remove any added package
* [`ee7e17b5`](https://github.com/NixOS/nixpkgs/commit/ee7e17b5403b6a3cb1be0cc3f599b9f0ea3988f8) devilutionx: fix invalid icon filename references
* [`e975c565`](https://github.com/NixOS/nixpkgs/commit/e975c5650174f472bad14e946cdb34e5e1ea6874) nodejs: Fix setup-hook addNodePath quoting
* [`97981156`](https://github.com/NixOS/nixpkgs/commit/97981156f131bf3de99db144a9d1f9d83e1384c1) shellharden: 4.1.3 -> 4.2.0
* [`59752718`](https://github.com/NixOS/nixpkgs/commit/5975271884736446379000cf697779d8f107b1db) brave: 1.36.111 -> 1.36.112
* [`62e9ba74`](https://github.com/NixOS/nixpkgs/commit/62e9ba7410a34ce5fd3616d41260f959e9b38c6b) aws-vault: 6.5.0 -> 6.6.0
* [`dfd24496`](https://github.com/NixOS/nixpkgs/commit/dfd24496571ad338de9b65f3c8e84c2570e2fdea) dolphin-emu-beta: 5.0-15993 -> 5.0-16101
* [`2878227a`](https://github.com/NixOS/nixpkgs/commit/2878227a12ec3b06c9d52b5f66dc94a940fd847b) chezmoi: 2.13.1 -> 2.14.0
* [`138471e0`](https://github.com/NixOS/nixpkgs/commit/138471e084aff615eabfa879a9fad772492bf92a) coredns: 1.9.0 -> 1.9.1
* [`88a7e31b`](https://github.com/NixOS/nixpkgs/commit/88a7e31b7a26fc9d9f825816f482f0f44ba7c431) difftastic: 0.19.0 -> 0.22.0
* [`e3daaada`](https://github.com/NixOS/nixpkgs/commit/e3daaada3f170d8ded772cf85173672278083bfe) klipper: unstable-2022-02-07 -> unstable-2022-03-11
* [`d4694d12`](https://github.com/NixOS/nixpkgs/commit/d4694d127fcedc6c077f96ebe7d9c2b21ab0f81e) exoscale-cli: 1.51.1 -> 1.51.2
* [`a6bbbcbb`](https://github.com/NixOS/nixpkgs/commit/a6bbbcbbbe077db595960efd72a9f8f3f9412a15) frp: 0.39.1 -> 0.40.0
* [`e7a43e0a`](https://github.com/NixOS/nixpkgs/commit/e7a43e0a63b4d306591cf4ecab53a81a59ab0cf2) gogs: 0.12.4 -> 0.12.5
* [`05881337`](https://github.com/NixOS/nixpkgs/commit/058813373b3a19c4e9b719135eeaed0f49e8739a) python3Packages.pysigma: init at 0.3.2
* [`403a124f`](https://github.com/NixOS/nixpkgs/commit/403a124f4d2a6e18e245bfb576d3c31ddb776ecf) python3Packages.pysigma-backend-splunk: init at 0.1.1
* [`fd50e124`](https://github.com/NixOS/nixpkgs/commit/fd50e124044c6305d23654b3081b9657d5cff8de) python3Packages.pysigma-pipeline-sysmon: init at 0.1.1
* [`a5615d44`](https://github.com/NixOS/nixpkgs/commit/a5615d445e24762dbafb467adedb0c51ca3b48d1) python3Packages.pysigma-pipeline-crowdstrike: init at 0.1.3
* [`d697ee65`](https://github.com/NixOS/nixpkgs/commit/d697ee65ebec9c26250bc1e272ee61b8cffb650d) invidious: add update script
* [`2e0fce98`](https://github.com/NixOS/nixpkgs/commit/2e0fce9838a21f5e070ac5ac70c8ba10940202ae) sigma-cli: init at 0.3.0
* [`a81cd19c`](https://github.com/NixOS/nixpkgs/commit/a81cd19ce74ce254118dab0b6ff7f8b702bfae44) python3Packages.pyroute2-core: 0.6.7 -> 0.6.8
* [`a169f424`](https://github.com/NixOS/nixpkgs/commit/a169f42499c8f55b53408941ed00935d30cbcdc1) python3Packages.pyroute2-ethtool: 0.6.7 -> 0.6.8
* [`c5784a1d`](https://github.com/NixOS/nixpkgs/commit/c5784a1da0506838cdbdba1b8f6c367339030837) python3Packages.pyroute2-ipdb: 0.6.7 -> 0.6.8
* [`fb0c6bd3`](https://github.com/NixOS/nixpkgs/commit/fb0c6bd3b1442010dc3368d87a9471c98a89f970) python3Packages.pyroute2-ndb: 0.6.7 -> 0.6.8
* [`07aa5ce5`](https://github.com/NixOS/nixpkgs/commit/07aa5ce5516b57f5c8d3c3888bcb28d921baae71) python3Packages.pyroute2-nftables: 0.6.7 -> 0.6.8
* [`f9c2a258`](https://github.com/NixOS/nixpkgs/commit/f9c2a258e48c115a5ee9939d32f3e2a76d52cad4) python3Packages.pyroute2-nslink: 0.6.7 -> 0.6.8
* [`7c417b7d`](https://github.com/NixOS/nixpkgs/commit/7c417b7d70e4db29ce5cceb78d73ba1c941da94e) python3Packages.pyroute2-protocols: 0.6.7 -> 0.6.8
* [`02d16c88`](https://github.com/NixOS/nixpkgs/commit/02d16c88293811a32ec9ca0a83fa5339a7b8719b) python3Packages.pyroute2: 0.6.7 -> 0.6.8
* [`3f7b755f`](https://github.com/NixOS/nixpkgs/commit/3f7b755f52a25522fcbad7efd5fca726c17eed97) python3Packages.pyroute2-ipset: 0.6.7 -> 0.6.8
* [`1515e9d0`](https://github.com/NixOS/nixpkgs/commit/1515e9d0924ec063c171791c4fb4d067b6021049) istioctl: 1.13.1 -> 1.13.2
* [`2e553c83`](https://github.com/NixOS/nixpkgs/commit/2e553c830743283c8a462792e0de1462a5b42f0f) libtpms: 0.9.2 -> 0.9.3
* [`8a6726bf`](https://github.com/NixOS/nixpkgs/commit/8a6726bf177b09e58865519686ea0fbaeb37670e) litestream: 0.3.7 -> 0.3.8
* [`175e2992`](https://github.com/NixOS/nixpkgs/commit/175e29928197ca533de7aafe081494ebf567dafb) opendht: 2.3.2 -> 2.3.5
* [`924aec9d`](https://github.com/NixOS/nixpkgs/commit/924aec9de61310a5e4c9f4010d2a071395af068d) janus-gateway: 0.11.8 -> 1.0.0
* [`df9f9dda`](https://github.com/NixOS/nixpkgs/commit/df9f9dda6322736effeb71a765c271ccb28f000d) operator-sdk: 1.18.0 -> 1.18.1
* [`4e5c3ba3`](https://github.com/NixOS/nixpkgs/commit/4e5c3ba35e4847712d5eb9f41191b0a8ef18ee96) orcania: 2.2.1 -> 2.2.2
* [`cca8f150`](https://github.com/NixOS/nixpkgs/commit/cca8f150df59dfbb812022958e9698e17f0f28f8) nats-server: 2.7.2 -> 2.7.4
* [`cb10f1ec`](https://github.com/NixOS/nixpkgs/commit/cb10f1ecd8c9e26961baa203936d9818882d3cb8) nats-streaming-server: 0.23.0 -> 0.24.0
* [`9fad223a`](https://github.com/NixOS/nixpkgs/commit/9fad223ad1d5ab3810e17cdb9323fe49f478f51c) matrix-synapse: fix release notes and doc for [nixos/nixpkgs⁠#158605](https://togithub.com/nixos/nixpkgs/issues/158605) changes
* [`6e1c043f`](https://github.com/NixOS/nixpkgs/commit/6e1c043ffaf8f3f856570651418951363e5b91b2) sabnzbd: 3.5.1 -> 3.5.2
* [`69b06bce`](https://github.com/NixOS/nixpkgs/commit/69b06bceab724b706790ecc9673d20917abe102e) python311: 3.11.0a4 -> 3.11.0a6
* [`38154206`](https://github.com/NixOS/nixpkgs/commit/38154206beefc7d883a61ece0669dc6eed51e31b) steampipe: 0.12.2 -> 0.13.0
* [`51561427`](https://github.com/NixOS/nixpkgs/commit/5156142740211d0be56658c36edb27d3c39a00c2) stylua: 0.12.4 -> 0.12.5
* [`7a5c6cac`](https://github.com/NixOS/nixpkgs/commit/7a5c6cace5e3eaa7984ce6042697bd963e1ea912) syft: 0.41.1 -> 0.41.4
* [`a2d1be59`](https://github.com/NixOS/nixpkgs/commit/a2d1be594789d2c2d62bea6503edbee8648a1b19) symfony-cli: 5.4.1 -> 5.4.2
* [`39f7bd4d`](https://github.com/NixOS/nixpkgs/commit/39f7bd4d6957c9a45a86b86c7389eec5de0ae03c) udisks2: correct patch
* [`c9a6adc8`](https://github.com/NixOS/nixpkgs/commit/c9a6adc80367efb0b3e18c7a9d2d54b5542e9095) tfswitch: 0.13.1201 -> 0.13.1218
* [`c0bd9a8b`](https://github.com/NixOS/nixpkgs/commit/c0bd9a8b4618955a13e6c8ee7cab36cc3f9f50ca) udisks2: Add freedesktop team to maintainers
* [`55b4ea6e`](https://github.com/NixOS/nixpkgs/commit/55b4ea6e5b7650d952422c2d25fb219fea828190) tgswitch: 0.5.382 -> 0.5.389
* [`8affa68a`](https://github.com/NixOS/nixpkgs/commit/8affa68af925c815c50140900bd7030a259b8133) tilt: 0.25.2 -> 0.25.3
* [`e40ae516`](https://github.com/NixOS/nixpkgs/commit/e40ae5169f410f59fbb535e8cae94f9d5b0a01fc) tinyssh: 20220305 -> 20220311
* [`ae54adf8`](https://github.com/NixOS/nixpkgs/commit/ae54adf8ff94faf6ce8be85a70a43f5188628342) treesheets: 1.0.1 → unstable-2022-03-12
* [`993e8e31`](https://github.com/NixOS/nixpkgs/commit/993e8e313d906a6aff071e64c48feb0b7b7ba388) treesheets: Switch to GTK 3
* [`2c8a5ccb`](https://github.com/NixOS/nixpkgs/commit/2c8a5ccb917843f209235ea1ac59795b56b12378) typos: 1.4.1 -> 1.5.0
* [`6b362588`](https://github.com/NixOS/nixpkgs/commit/6b36258807f98742e34a4b2f9d32d3564f179af1) vendir: 0.24.0 -> 0.26.0
* [`34774452`](https://github.com/NixOS/nixpkgs/commit/34774452aa83da548f239faa9ddb41c7075f686f) python310Packages.pex: 2.1.69 -> 2.1.71
* [`2da9a539`](https://github.com/NixOS/nixpkgs/commit/2da9a53905b0b561f84c5c5a4e7c00399ff24b9f) waybar: 0.9.10 -> 0.9.12
* [`658496e9`](https://github.com/NixOS/nixpkgs/commit/658496e9bd938c3028db9cc6a2b76f11885869b7) werf: 1.2.73 -> 1.2.74
* [`4876a423`](https://github.com/NixOS/nixpkgs/commit/4876a4235846107cf0f9e8fe032489980b6175bc) cliphist: 0.3.0 -> 0.3.1
* [`abed904c`](https://github.com/NixOS/nixpkgs/commit/abed904c9af4076ae37f7337fcc58620d6144a09) evans: 0.10.2 -> 0.10.3
* [`70465ede`](https://github.com/NixOS/nixpkgs/commit/70465ede405f5df34cdf92ca4816e09fe5442768) iperf: 3.10.1 -> 3.11
* [`4573df4d`](https://github.com/NixOS/nixpkgs/commit/4573df4de163a97ea59c12848f72237ab4b3adc3) fn-cli: 0.6.15 -> 0.6.17
* [`f07266ad`](https://github.com/NixOS/nixpkgs/commit/f07266ad8b142d089ddf719722adfac3ded0b377) goreleaser: 1.6.1 -> 1.6.3
* [`c6dba0da`](https://github.com/NixOS/nixpkgs/commit/c6dba0daf4a9e7febf6dc02f92d835d7df2a8b22) hilbish: 1.0.2 -> 1.0.4
* [`75546e20`](https://github.com/NixOS/nixpkgs/commit/75546e200809c5a08fd0ac8f4e980987152f94b6) qbe: unstable-2021-12-05 -> unstable-2022-03-11
* [`01e69e91`](https://github.com/NixOS/nixpkgs/commit/01e69e9113354820690ac02512ab693edd034edd) rocclr: 4.5.2 -> 5.0.2
* [`f0a3f862`](https://github.com/NixOS/nixpkgs/commit/f0a3f8627ebfe6029b66abb44fdcfe6c73309388) rocm-smi: 4.5.2 -> 5.0.0
* [`70ce1775`](https://github.com/NixOS/nixpkgs/commit/70ce1775f328de1552abd0be8538022850670e20) rocm-thunk: 4.5.2 -> 5.0.2
* [`6d61669d`](https://github.com/NixOS/nixpkgs/commit/6d61669d69c9e4724eff3d8d32fef40d2399cff6) jmol: 14.32.30 -> 14.32.33
* [`c3142193`](https://github.com/NixOS/nixpkgs/commit/c31421937897d65277c40b952b4577dce5f986cd) tdesktop: 3.5.2 -> 3.6.0
* [`65eed885`](https://github.com/NixOS/nixpkgs/commit/65eed885d636e74eb3349b3aacee5e945a99f092) klavaro: 3.11 -> 3.13, espeak support
* [`04b83746`](https://github.com/NixOS/nixpkgs/commit/04b8374667c8b6718e1879eb44e7487d23e57666) kn: 1.3.0 -> 1.3.1
* [`4e9b08b9`](https://github.com/NixOS/nixpkgs/commit/4e9b08b9139d169ec3eccc7497c7e503f3dad093) piping-server-rust: 0.12.0 -> 0.12.1
* [`a77d5752`](https://github.com/NixOS/nixpkgs/commit/a77d575286a806cfcf0f69c73d5908a1ddb483f6) vala-lint: unstable-2021-12-28 -> unstable-2022-02-16
* [`756ee236`](https://github.com/NixOS/nixpkgs/commit/756ee236e197d15c54f3ae65c0496e345f58dcfd) xterm: 371 -> 372
* [`5240cbc0`](https://github.com/NixOS/nixpkgs/commit/5240cbc0d816d12b5bb56789489e4e90ae751172) sage: adapt tachyon interface for 0.99.3
* [`32fe2acf`](https://github.com/NixOS/nixpkgs/commit/32fe2acfab585422569bc73e4d06d51bd5e855da) babashka: 0.7.7 -> 0.7.8
* [`66790289`](https://github.com/NixOS/nixpkgs/commit/667902897a706e24a0e4a780a83a140cd039fb10) pkgs/build-support/fetchurl/mirrors.nix: add IBiblioPubLinux
* [`65268fe9`](https://github.com/NixOS/nixpkgs/commit/65268fe99a36f32a7c11eda40a9a18156a5c7436) .github/workflows: update cachix cache comment
* [`1d41af9b`](https://github.com/NixOS/nixpkgs/commit/1d41af9bc9f51783f5010d6d57a67908322bf3fc) .github/workflows/basic-eval.yml: add cachix cache
* [`11e41ae4`](https://github.com/NixOS/nixpkgs/commit/11e41ae4b2f51dfa4ccb93143d26f2e2aa62aa1a) evince: 41.3 -> 41.4
* [`95077158`](https://github.com/NixOS/nixpkgs/commit/95077158aadd83015f59c018f64c14c7655fdb81) nixos/fonts: Remove ancient bitmap fonts from defaultXFonts
* [`5ac5bed4`](https://github.com/NixOS/nixpkgs/commit/5ac5bed4b4b029324ffbe6228be5f6db96005779) nixos/fonts: Document removal of ancient bitmap fonts from default config
* [`5cd57cc7`](https://github.com/NixOS/nixpkgs/commit/5cd57cc7c0238c176d342d8122080179b7573d52) llvmPackages: update wasm to 12
* [`47ca51cb`](https://github.com/NixOS/nixpkgs/commit/47ca51cba9d997be0be4b93f9757d3a04a1a8b79) wasilibc: 20190712 -> unstable-2021-09-23
* [`15304776`](https://github.com/NixOS/nixpkgs/commit/1530477650768f41bfac6439043e5d1ec2c0bd4f) firefox: enable RLBox sandboxing
* [`38f7252d`](https://github.com/NixOS/nixpkgs/commit/38f7252d3472bc887af3bca7eba4c85686048678) btrfs-progs: depends on udev, not systemd
* [`2e480dc1`](https://github.com/NixOS/nixpkgs/commit/2e480dc1626b6eac6ea8c5eac23094ffe568b18f) unison: 2.51.5 -> 2.52.0
* [`7f25d6e0`](https://github.com/NixOS/nixpkgs/commit/7f25d6e079104fb574b4b505218709c06bfb3229) firefox-esr-91-unwrapped: 91.7.0esr -> 91.7.1esr
* [`df636302`](https://github.com/NixOS/nixpkgs/commit/df6363024abd6029372eeee7795133147c86a8eb) lxd: 4.23 -> 4.24
* [`8996c57c`](https://github.com/NixOS/nixpkgs/commit/8996c57c202f42e0b08a7936f03ac885710a4a8d) t1lib: ibiblioPubLinux mirror
* [`ae55f080`](https://github.com/NixOS/nixpkgs/commit/ae55f08023e44aebffd9d184ecf8e0d29537de32) bsdgames: ibiblioPubLinux mirror
* [`197cb047`](https://github.com/NixOS/nixpkgs/commit/197cb04778e894452f9b52503be85e0ba22ff8cb) forktty: ibiblioPubLinux mirror
* [`f3e1e370`](https://github.com/NixOS/nixpkgs/commit/f3e1e37041b33d658c1d606658c7b74caaad0333) bsd-fingerd: ibiblioPubLinux mirror
* [`de6c0f0f`](https://github.com/NixOS/nixpkgs/commit/de6c0f0ff7cd6e0a9337a4ac20b76a9108f1b25d) bsd-finger: ibiblioPubLinux mirror
* [`638efbf7`](https://github.com/NixOS/nixpkgs/commit/638efbf778c49ec60e636d2c9d35d459a3dfe0df) wakelan: ibiblioPubLinux mirror
* [`b988e9a1`](https://github.com/NixOS/nixpkgs/commit/b988e9a1f9aab982c5adc95143df37417b82a951) pkgs/build-support/fetchurl/mirrors.nix: remove metalab
* [`9bdd2f85`](https://github.com/NixOS/nixpkgs/commit/9bdd2f852cdcaadd65ba38876c3379e10a967290) nixos/switch-to-configuration: fix installBootLoader escaping
* [`46ce9946`](https://github.com/NixOS/nixpkgs/commit/46ce994651bbc78c2bdd248baaceb00f4cedb9cb) amber-secret: 0.1.2 -> 0.1.3
* [`95d69d32`](https://github.com/NixOS/nixpkgs/commit/95d69d32d9236943da3abf62d3dd2b2274770f88) rPackages.RNifti: use nixpkgs zlib
* [`e599d1ce`](https://github.com/NixOS/nixpkgs/commit/e599d1ce9840aa2f98afb128d3cf2ab2b41f992b) rPackages.qqconf: add missing FFTW and pkg-config dependencies
* [`976a5bc9`](https://github.com/NixOS/nixpkgs/commit/976a5bc9fffaad437069df4d06edf0315f7a020f) nix-du: 0.4.1 -> 0.5.0
* [`09c7cf2f`](https://github.com/NixOS/nixpkgs/commit/09c7cf2f4ecc1665b58002bb9683ba00fbc559cd) klavaro: patch to fix invalid free
* [`606eab00`](https://github.com/NixOS/nixpkgs/commit/606eab00d04f298a98a8c9e468b1cd19d7faec48) klavaro: patch to use non-deprecated names for icons
* [`9ae6eefd`](https://github.com/NixOS/nixpkgs/commit/9ae6eefd057ea84a50446ee5f5359a2d73c16d0d) virt-manager: fix filtered tests
* [`1b71d746`](https://github.com/NixOS/nixpkgs/commit/1b71d746a3386a80b17da3955cd7a6639fd41c25) opera: 84.0.4316.21 -> 84.0.4316.31
* [`5c4e343b`](https://github.com/NixOS/nixpkgs/commit/5c4e343b4fd798cae56507c6f88832ff415be0a0) cmst: 2022.01.05 -> 2022.03.13
* [`b11029f2`](https://github.com/NixOS/nixpkgs/commit/b11029f2406422188e0dea35c494a851ab9d302b) lmodern: 2.004.5 -> 2.005
* [`c51d465e`](https://github.com/NixOS/nixpkgs/commit/c51d465e8b36c48f50a55303ab5bca532757faeb) dnsx: 1.0.9 -> 1.1.0
* [`9c951ed8`](https://github.com/NixOS/nixpkgs/commit/9c951ed83e24f8f00ef9a73c5673091938104732) open-watcom-v2-unwrapped: unstable-2022-02-22 -> unstable-2022-03-14
* [`aef8fe5c`](https://github.com/NixOS/nixpkgs/commit/aef8fe5c6885b229950bbdd467ff6dfe58443a33) himalaya: 0.5.8 → 0.5.9
* [`63ecdee9`](https://github.com/NixOS/nixpkgs/commit/63ecdee96b5c436c2f53c32f213803ada42bb7ba) python310Packages.graphql-subscription-manager: 0.5.1 -> 0.5.4
* [`bc6f110f`](https://github.com/NixOS/nixpkgs/commit/bc6f110f01638803b57e0f88c8e68936c9317f47) python310Packages.pyisy: 3.0.3 -> 3.0.5
* [`075de1bb`](https://github.com/NixOS/nixpkgs/commit/075de1bb2d7b41a26399ec84d48fae1dacb70121) libvirt: refactor
* [`f1636eb9`](https://github.com/NixOS/nixpkgs/commit/f1636eb9679784c5eef9e5d0931ed12125029aaf) git-cliff: 0.6.0 -> 0.6.1
* [`36ad6084`](https://github.com/NixOS/nixpkgs/commit/36ad60841c59828f58c36d208d1150bac4bc67f7) python3Packages.meilisearch: init at 0.18.0
* [`a8c87a52`](https://github.com/NixOS/nixpkgs/commit/a8c87a52d28497677fd6117acdc690d4466450a8) checkov: 2.0.938 -> 2.0.941
* [`fe92f71e`](https://github.com/NixOS/nixpkgs/commit/fe92f71efa486f512cd2be5e1bbcd86cd06d8c86) python3Packages.pyupgrade: 2.31.0 -> 2.31.1
* [`a7114d85`](https://github.com/NixOS/nixpkgs/commit/a7114d859d79891a3a1dc443a35c60051fddd7e4) libreddit: 0.21.7 -> 0.22.1
* [`e73e9e94`](https://github.com/NixOS/nixpkgs/commit/e73e9e9420009ed37d3c46f847e2e8d2b2853b99) python310Packages.amcrest: 1.9.4 -> 1.9.7
* [`41ca5932`](https://github.com/NixOS/nixpkgs/commit/41ca5932b3996e4dd49ae5cf578cc71d0ffd2915) onedrive: 2.4.15 -> 2.4.16
* [`4f646210`](https://github.com/NixOS/nixpkgs/commit/4f646210564cab1507655922b433268b8fac5bc7) linux_testing_bcachefs: unstable-2022-01-12 -> unstable-2022-03-09
* [`db181acb`](https://github.com/NixOS/nixpkgs/commit/db181acbf8fec9bcf23551202279947799da6e2c) bcachefs-tools: unstable-2022-01-12 -> unstable-2022-03-09
* [`5a8602a8`](https://github.com/NixOS/nixpkgs/commit/5a8602a87bbbd48a6e05083d07afda56a80d90dc) bcachefs-tools: enable parallel building
* [`4ee9b84e`](https://github.com/NixOS/nixpkgs/commit/4ee9b84ec5e0367f24fd144d778490d093471d7d) nixos/bcachefs: re-enable encryption in test
* [`2f1f631e`](https://github.com/NixOS/nixpkgs/commit/2f1f631eaa1cc39ae889fffb3a7911a5de7b502c) pantheon.elementary-mail: fix build with vala 0.56
* [`3b01bd62`](https://github.com/NixOS/nixpkgs/commit/3b01bd6249cf90bfd7048003e8f2f9e98371c00d) bcachefs: update maintainers
* [`c9f623a9`](https://github.com/NixOS/nixpkgs/commit/c9f623a970cdea3e897e1ceec59854b72a2a1742) nix-index: 0.1.2 -> unstable-2022-03-07
* [`cfa288b4`](https://github.com/NixOS/nixpkgs/commit/cfa288b486ba814569da385041235b1d794be5c2) kubemq-community: init at 2.2.12
* [`abd21698`](https://github.com/NixOS/nixpkgs/commit/abd21698cc07cf64b91d327da1aa565a84e77c5d) ocrmypdf: 13.4.0 -> 13.4.1
* [`e65da5e7`](https://github.com/NixOS/nixpkgs/commit/e65da5e795e6fe3425c6211e05c4901478b9b789) kubemqctl: init at 3.5.1
* [`a6d04257`](https://github.com/NixOS/nixpkgs/commit/a6d04257b728bb5138f138d4662c537ebecf2487) php74Packages.phpstan: 1.4.8 -> 1.4.9
* [`5979627e`](https://github.com/NixOS/nixpkgs/commit/5979627e321fba01a01796ff5403b98be31c9140) pt2-clone: 1.41 -> 1.42
* [`19da5f1e`](https://github.com/NixOS/nixpkgs/commit/19da5f1e688adad6fb5997b7bbe7c112096e1dc5) kustomize-sops: 3.0.1 -> 3.0.2
* [`7919dd26`](https://github.com/NixOS/nixpkgs/commit/7919dd265510a9d7221c84003a8325ec2f7d9517) rocm-opencl-runtime: 4.5.2 -> 5.0.2
* [`35a3108f`](https://github.com/NixOS/nixpkgs/commit/35a3108fae664a917b90c7415c346ac31527dc2e) rocm-cmake: 4.5.2 -> 5.0.2
* [`de8f18cf`](https://github.com/NixOS/nixpkgs/commit/de8f18cfc653a51b4913f5f6d45ed734442a926b) rocm-device-libs: 5.0.0 -> 5.0.2
* [`6bf34a0c`](https://github.com/NixOS/nixpkgs/commit/6bf34a0cfe325964ae0ba01e4c53b8ea00ef0df2) rocm-smi: 5.0.0 -> 5.0.2
* [`58760ac1`](https://github.com/NixOS/nixpkgs/commit/58760ac1a412a71d5783255e792d1c0fb610bb31) postgresql11Packages.pgroonga: 2.3.4 -> 2.3.5
* [`24b4b027`](https://github.com/NixOS/nixpkgs/commit/24b4b027dfea9d60a7c0bcbb772cbf11c3804adc) mirage-im: add missing dependency
* [`1a268c42`](https://github.com/NixOS/nixpkgs/commit/1a268c42c8b0550f70da78c136171799481b0d97) flannel: 0.16.3 -> 0.17.0
* [`21eeb396`](https://github.com/NixOS/nixpkgs/commit/21eeb396dea9f77c9737e0347e8dda1bbc74c1b1) pantheon.elementary-photos: fix build with vala 0.56
* [`2b2ac312`](https://github.com/NixOS/nixpkgs/commit/2b2ac31248b169b8435f7ada019c549d4aedc8b4) qemu: remove 9p O_NOATIME patch
* [`e6974d06`](https://github.com/NixOS/nixpkgs/commit/e6974d060268a52325a11e88f49dff8ec13cc54e) nix-plugins: pin to nix 2.5, not yet compat with 2.6
* [`a608df0e`](https://github.com/NixOS/nixpkgs/commit/a608df0ecb6ddcbc1177b76d0304511862d46590) nix-doc: pin to nix 2.5, not yet compat with 2.6
* [`6bf33369`](https://github.com/NixOS/nixpkgs/commit/6bf333697510da981f3c641b38c0fdbf97c4b252) apacheHttpd: 2.4.52 -> 2.4.53
* [`94790aa6`](https://github.com/NixOS/nixpkgs/commit/94790aa6df84d9d823de46ed0e1d7ac5fbcb2139) home-assistant: update pytest-aiohttp and related overrides
* [`c7fe08ce`](https://github.com/NixOS/nixpkgs/commit/c7fe08cea2652bad4cf4f460ac1eb1e8b346802e) cloud-hypervisor: 22.0 -> 22.1
* [`5dd15bb5`](https://github.com/NixOS/nixpkgs/commit/5dd15bb54cb9e8eebc285b9a7c871051ec1e8baf) klavaro: another icon fix per PR feedback
* [`873b0ad2`](https://github.com/NixOS/nixpkgs/commit/873b0ad28a460e02078eed803752d50533bf16c0) icon-library: 0.0.8 -> 0.0.11
* [`6d48ecf2`](https://github.com/NixOS/nixpkgs/commit/6d48ecf2dd3c250df86fd40b8c107e698969fbe2) eos-installer: init at 4.0.3
* [`b0a871a3`](https://github.com/NixOS/nixpkgs/commit/b0a871a3ec5449a7f77b75f1abfbfe5bde650719) zsh: 5.8 -> 5.8.1
* [`e1b23b90`](https://github.com/NixOS/nixpkgs/commit/e1b23b90ceba1a63c0da41d7ff25328f5f42b731) xsnow: 3.3.6 -> 3.4.4
* [`eaa21176`](https://github.com/NixOS/nixpkgs/commit/eaa21176e27fc081baa4acfa902143ebafedac5c) tkrev: tkcvs 8.2.1 -> tkrev 9.4.1
* [`864f1413`](https://github.com/NixOS/nixpkgs/commit/864f1413b0142a3ce26306d1a92bf42ddb7056e7) tuxguitar: 1.5.4 -> 1.5.5
* [`d319a2b7`](https://github.com/NixOS/nixpkgs/commit/d319a2b798dc7dcfff966809a94fea4af2475a15) tuxpaint: 0.9.24 -> 0.9.27; clarify license
* [`3d0e5c12`](https://github.com/NixOS/nixpkgs/commit/3d0e5c122777bdf62a9811c442c44f7f61a85d27) tuxpaint: stamps: 2014-08-23 -> 2021-11-25
* [`674223e6`](https://github.com/NixOS/nixpkgs/commit/674223e6483b9e0b6c3e230492ceacd8957b9256) tuxpaint: enable parallel building
* [`8df0f8bc`](https://github.com/NixOS/nixpkgs/commit/8df0f8bcef282ce2749390001d51111b01398a26) sbt-extras: 2021-11-08 -> 2022-02-01
* [`024abf92`](https://github.com/NixOS/nixpkgs/commit/024abf923b256921e47143237f7d73c1e3846911) wiki-js: 2.5.274 -> 2.5.276
* [`05d738af`](https://github.com/NixOS/nixpkgs/commit/05d738afe863baab18132f76e5eff34aaa13b299) python3Packages.parts: disable on older Python releases
* [`2a03d6f2`](https://github.com/NixOS/nixpkgs/commit/2a03d6f2bfe052f33aa3be42d403a6f6de2a5f60) python3Packages.bitlist: 0.6.2 -> 0.7.0
* [`5405a862`](https://github.com/NixOS/nixpkgs/commit/5405a8625ef051b276c1cec151edff2cf111d30c) python3Packages.fountains: 1.2.0 -> 1.3.0
* [`8d23c0f0`](https://github.com/NixOS/nixpkgs/commit/8d23c0f0f3a67b9fd5a9089f6798729d409ffc1c) python3Packages.fe25519: 1.1.0 -> 1.2.0
* [`7170d555`](https://github.com/NixOS/nixpkgs/commit/7170d555c12237211c7fe2493f8884ae96d5176a) python3Packages.ge25519: 1.1.0 -> 1.2.0
* [`35dc184a`](https://github.com/NixOS/nixpkgs/commit/35dc184ac5c45c83924da4b465e4fba7320c67ed) python3Packages.pyftdi: 0.53.3 -> 0.54.0
* [`aee602ac`](https://github.com/NixOS/nixpkgs/commit/aee602ac0ee907c7b7d0a15c815b29d098a0bbd7) airshipper: 0.6.0 -> 0.7.0
* [`899f1131`](https://github.com/NixOS/nixpkgs/commit/899f1131d406ee4881b8e3962b14f06e2219cb87) irpf: init at 2022-1.0
* [`e2d6f416`](https://github.com/NixOS/nixpkgs/commit/e2d6f416d5f5cad2fd53cb16b542aee4ba970727) mercurial: add patch to fix the libc buffer type for aarch64-linux
* [`f78b6046`](https://github.com/NixOS/nixpkgs/commit/f78b6046caf57d12697e2002599785a47597ef6b) Adding toastal as a himalaya maintainer
* [`198f6c58`](https://github.com/NixOS/nixpkgs/commit/198f6c583e3c1645177072e3aa35dccb4d419130) steam: re-expose LD_LIBRARY_PATH
* [`ec2d8f62`](https://github.com/NixOS/nixpkgs/commit/ec2d8f622d4ed20fecfe4380637747603ecd98aa) python310Packages.chart-studio: 5.5.0 -> 5.6.0
* [`ede76de8`](https://github.com/NixOS/nixpkgs/commit/ede76de87d082edc629958eefb292020cb621f6d) python310Packages.libcloud: 3.4.1 -> 3.5.0
* [`19bcfe05`](https://github.com/NixOS/nixpkgs/commit/19bcfe05f3c1c0e121d953934fd953dabc21aa64) python3Packages.rencode: switch to fetchFromGitHub
* [`15eda19c`](https://github.com/NixOS/nixpkgs/commit/15eda19c8eafb567c47eba9a725a6691e734196c) python3Packages.rencode: 1.0.3 -> 1.0.6
* [`d9098887`](https://github.com/NixOS/nixpkgs/commit/d909888703a4fa120cda19ca87acfdeae7c8e5d9) python310Packages.channels-redis: 3.3.1 -> 3.4.0
* [`f48caeca`](https://github.com/NixOS/nixpkgs/commit/f48caecaf35fa87c9cbd7bc7a8d0e105961215b1) vscode-extensions.eamodio.gitlens: 12.0.1 -> 12.0.3
* [`2730e56e`](https://github.com/NixOS/nixpkgs/commit/2730e56ed814bb49f2c5ec9623c8e0951654ca58) vscode-extensions.esbenp.prettier-vscode: 9.2.0 -> 9.3.0
* [`28a9b174`](https://github.com/NixOS/nixpkgs/commit/28a9b174130cfb102d9119d52bdc440d46e93bbe) vscode-extensions.formulahendry.auto-close-tag: 0.5.13 -> 0.5.14
* [`809af29d`](https://github.com/NixOS/nixpkgs/commit/809af29d7b3a7f376f5e480c2d07259962f4d63f) vscode-extensions.formulahendry.auto-rename-tag: 0.1.9 -> 0.1.10
* [`2bf666ca`](https://github.com/NixOS/nixpkgs/commit/2bf666caafeeb2203f25be9df7799a9d4d3bba63) vscode-extensions.jock.svg: 1.4.15 -> 1.4.17
* [`4f2a47bc`](https://github.com/NixOS/nixpkgs/commit/4f2a47bc5e27315e72ce41411829d98692371157) vscode-extensions.ms-azuretools.vscode-docker: 1.19.0 -> 1.20.0
* [`58d61dab`](https://github.com/NixOS/nixpkgs/commit/58d61dab7b84ee6b0477cfeacdcf4336ddc47822) vscode-extensions.redhat.java: 1.3.0 -> 1.4.0
* [`631534d9`](https://github.com/NixOS/nixpkgs/commit/631534d97df2e9cfeb8caa7aecb084807008af5d) vscode-extensions.redhat.vscode-yaml: 1.3.0 -> 1.5.1
* [`f2bdaba3`](https://github.com/NixOS/nixpkgs/commit/f2bdaba3fdcd3045edce4d43e0bf5e7571d6c64b) vscode-extensions.pkief.material-icon-theme: 4.12.1 -> 4.14.1
* [`0b29a7d6`](https://github.com/NixOS/nixpkgs/commit/0b29a7d688bb322ea35573eea5c0eef5705abc31) ocamlPackages.utop: 2.8.0 → 2.9.0
* [`e2c5abdd`](https://github.com/NixOS/nixpkgs/commit/e2c5abdd5d5a58bd48de0c2e32fa287d5c0fcbf5) python3Packages.vt-py: 0.13.1 -> 0.13.2
* [`c0e90b7c`](https://github.com/NixOS/nixpkgs/commit/c0e90b7c546896708d7359bd4f92a9cc4015c5a4) python310Packages.dash: 2.2.0 -> 2.3.0
* [`552cfc00`](https://github.com/NixOS/nixpkgs/commit/552cfc008a9a07690f5f07c5f9002d717b71f537) firefox: 98.0 -> 98.0.1
* [`bf2d8ef5`](https://github.com/NixOS/nixpkgs/commit/bf2d8ef5500643a40f62c4fc2fee1313e4dce188) fingerd_bsd: "merge" with finger_bsd
* [`0562c75f`](https://github.com/NixOS/nixpkgs/commit/0562c75f4a8aa2f1c6ccc7ebfcfc338a0443ee34) rename+alias finger_bsd to bsd-finger
* [`fb3ef16f`](https://github.com/NixOS/nixpkgs/commit/fb3ef16f527767c7e61c06c1209344f72a9236b6) gnome-obfuscate: init at 0.0.4
* [`b93c5724`](https://github.com/NixOS/nixpkgs/commit/b93c5724fc6cebcda6ee57982c3311adf90c9623) python310Packages.tatsu: 5.7.3 -> 5.8.0
* [`3e497e31`](https://github.com/NixOS/nixpkgs/commit/3e497e315e97df5d0f57b7fcd9068c252dea07d6) weechat: 3.4 -> 3.4.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
