### PR TITLE
niv emacs-overlay: update 1e6e66e8 -> 023ce0b1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1e6e66e83b1234963b4b2fdee73c8ebf002292de",
-        "sha256": "12pl550xk88bgpyicw39r9h08zsxljz9f8mbscp3impfc95875aw",
+        "rev": "023ce0b1e29732c6d26a380ad5dc8298c298f99b",
+        "sha256": "0s4n5y3xcnnv1a68a6vdaarnndiimzsjids94qhrfvqq4izihdz8",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/1e6e66e83b1234963b4b2fdee73c8ebf002292de.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/023ce0b1e29732c6d26a380ad5dc8298c298f99b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@1e6e66e8...023ce0b1](https://github.com/nix-community/emacs-overlay/compare/1e6e66e83b1234963b4b2fdee73c8ebf002292de...023ce0b1e29732c6d26a380ad5dc8298c298f99b)

* [`d43b200e`](https://github.com/nix-community/emacs-overlay/commit/d43b200ed5675bf912440975435dd7a7363f9481) Updated repos/melpa
* [`29a7a344`](https://github.com/nix-community/emacs-overlay/commit/29a7a34412e17ada1c2c6271d2ab3d8e0bfefdd8) Updated repos/melpa
* [`d7768391`](https://github.com/nix-community/emacs-overlay/commit/d7768391bccd5200645cc52324f6ff672269bf31) Updated repos/melpa
* [`df459e39`](https://github.com/nix-community/emacs-overlay/commit/df459e39ce667fc1455a1fa05dc107ae624f671a) Updated repos/melpa
* [`b62035a8`](https://github.com/nix-community/emacs-overlay/commit/b62035a82cd6151e655c0f5b2505ab1833f9a198) Updated repos/elpa
* [`8603a233`](https://github.com/nix-community/emacs-overlay/commit/8603a233f2cb5b7ed504f102d4b1fce56b324b36) Updated repos/melpa
* [`d2739b4f`](https://github.com/nix-community/emacs-overlay/commit/d2739b4f1aeae7b7314548a2e1d852ac2fc612a7) Updated repos/melpa
* [`9c0d19aa`](https://github.com/nix-community/emacs-overlay/commit/9c0d19aa7d831263e72552af2b99ec2dbce1a350) Updated repos/melpa
* [`711a3567`](https://github.com/nix-community/emacs-overlay/commit/711a3567a484a750017df905b0063a0ad0ed3434) Updated repos/nongnu
* [`6fdb3c0c`](https://github.com/nix-community/emacs-overlay/commit/6fdb3c0cefe2574073b31b27d2b2f5df9532cd5a) Updated repos/melpa
* [`02d025b9`](https://github.com/nix-community/emacs-overlay/commit/02d025b9371fcc1e95e6e26f64061e39960723f5) Updated repos/elpa
* [`5b6fc7a4`](https://github.com/nix-community/emacs-overlay/commit/5b6fc7a4ef21e8ca787429339476b82165b05f3d) Updated repos/melpa
* [`c4bcf4b6`](https://github.com/nix-community/emacs-overlay/commit/c4bcf4b66394a4472cc251e2350c557dac13d621) Updated repos/melpa
* [`7b43cba1`](https://github.com/nix-community/emacs-overlay/commit/7b43cba136814e022c7515738df0b5adfbb7672c) Updated repos/elpa
* [`2c58c215`](https://github.com/nix-community/emacs-overlay/commit/2c58c215a5ddfa2be00e349ee38545aa0547fcf2) Updated repos/melpa
* [`ea3cc5a1`](https://github.com/nix-community/emacs-overlay/commit/ea3cc5a19dfd32d155b327d61613191f5873a441) Updated repos/elpa
* [`a157cba9`](https://github.com/nix-community/emacs-overlay/commit/a157cba9a5fbdfa9f30aeff0c2ccdcc478e8a316) Updated repos/melpa
* [`a287f3f5`](https://github.com/nix-community/emacs-overlay/commit/a287f3f59cc52cb67b8976c686ebd22619cd2fc6) Updated repos/melpa
* [`2938ceb0`](https://github.com/nix-community/emacs-overlay/commit/2938ceb0577e67871610af592f69d9b04294d22d) Updated repos/melpa
* [`c7789907`](https://github.com/nix-community/emacs-overlay/commit/c77899079ad8142ea3505dbe77fda670308702b4) Updated repos/melpa
* [`2c1878fa`](https://github.com/nix-community/emacs-overlay/commit/2c1878fafc06375cbd923100a753e8ef67eb74a8) Updated repos/nongnu
* [`b225ddeb`](https://github.com/nix-community/emacs-overlay/commit/b225ddeb7bdc17b844ce5f3c33d57d196e972143) Updated repos/melpa
* [`58036d5e`](https://github.com/nix-community/emacs-overlay/commit/58036d5e198e8595e3d9637e0e918aa31ac7dfdf) Updated repos/melpa
* [`78e4e2bd`](https://github.com/nix-community/emacs-overlay/commit/78e4e2bd48d7c0d589135a7baf12c453a14cf97e) Updated repos/elpa
* [`ccb4f7c6`](https://github.com/nix-community/emacs-overlay/commit/ccb4f7c6af0b2dc5c02aec6f28d5cffb199087c4) Updated repos/melpa
* [`24631da8`](https://github.com/nix-community/emacs-overlay/commit/24631da8ead0ac4b193e10b54d6e1052bccc29b6) Updated repos/elpa
* [`d6c1c938`](https://github.com/nix-community/emacs-overlay/commit/d6c1c93815604507fc3a0d5faed445569b1672bb) Updated repos/melpa
* [`023ce0b1`](https://github.com/nix-community/emacs-overlay/commit/023ce0b1e29732c6d26a380ad5dc8298c298f99b) Updated repos/melpa
