### PR TITLE
niv niv: update 9cb7ef33 -> 5912c378

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "9cb7ef336bb71fd1ca84fc7f2dff15ef4b033f2a",
-        "sha256": "1ajyqr8zka1zlb25jx1v4xys3zqmdy3prbm1vxlid6ah27a8qnzh",
+        "rev": "5912c378c2f87e911f1bc7236202f69581406c9d",
+        "sha256": "1jhs562k3pk0xgwyf0m1h2bck4rivv9f3aznz8dslgby9g5mdnda",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9cb7ef336bb71fd1ca84fc7f2dff15ef4b033f2a.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/5912c378c2f87e911f1bc7236202f69581406c9d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@9cb7ef33...5912c378](https://github.com/nmattia/niv/compare/9cb7ef336bb71fd1ca84fc7f2dff15ef4b033f2a...5912c378c2f87e911f1bc7236202f69581406c9d)

* [`78828970`](https://github.com/nmattia/niv/commit/788289706e903c5a4dbc24a968e92b01fb859f99) fix: formatting error in sources.nix
* [`768210ef`](https://github.com/nmattia/niv/commit/768210efbe89d1e84048c38658f185f6d9c1461d) Remove custom github actions
* [`b8202cb2`](https://github.com/nmattia/niv/commit/b8202cb275ad5a6afc44db24cf482e8f557aaacd) fix: use the same nix path as scripts
* [`5912c378`](https://github.com/nmattia/niv/commit/5912c378c2f87e911f1bc7236202f69581406c9d) Fix GitHub Actions badge.
