### PR TITLE
niv powerlevel10k: update f07d7bae -> 65599411

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "f07d7baea36010bfa74708844d404517ea6ac473",
-        "sha256": "0208437mx12rnqwdmw3r9n5w6n8zq1h3y7h1nm8yr92acnxq8rz5",
+        "rev": "65599411ec83505a091f68489617316dec355510",
+        "sha256": "0sjnfxmykygqps9am7kx6hylqy6mln120sm212y5qmhxdgni5v4h",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/f07d7baea36010bfa74708844d404517ea6ac473.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/65599411ec83505a091f68489617316dec355510.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@f07d7bae...65599411](https://github.com/romkatv/powerlevel10k/compare/f07d7baea36010bfa74708844d404517ea6ac473...65599411ec83505a091f68489617316dec355510)

* [`e13283ec`](https://github.com/romkatv/powerlevel10k/commit/e13283ec7dd02d97363303d97d7d36f7521a1344) bug fix: strip escape sequences in instant prompt output less aggressively
* [`65599411`](https://github.com/romkatv/powerlevel10k/commit/65599411ec83505a091f68489617316dec355510) ignore garbage printed by vscode
