### PR TITLE
niv spacemacs: update e32acdfa -> 18ad9759

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "e32acdfadf6180288d627d39422b43863433fbc0",
-        "sha256": "10v36vp1gk7wmphyk98qasvrf6icy9xg6sg5hy4ll4ag833lh6qf",
+        "rev": "18ad9759b29a56ba92fe452b62dd545329175b63",
+        "sha256": "0sl02d5l6yxdlb62fwfdj59wqmmcj4irlvszg3gz0lpq0xz9jl82",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/e32acdfadf6180288d627d39422b43863433fbc0.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/18ad9759b29a56ba92fe452b62dd545329175b63.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@e32acdfa...18ad9759](https://github.com/syl20bnr/spacemacs/compare/e32acdfadf6180288d627d39422b43863433fbc0...18ad9759b29a56ba92fe452b62dd545329175b63)

* [`d66548fd`](https://github.com/syl20bnr/spacemacs/commit/d66548fd04fdd4c43161e17b1a59831dcddf3f36) [completion] Fix readme markup. ([syl20bnr/spacemacs⁠#15410](https://togithub.com/syl20bnr/spacemacs/issues/15410))
* [`75c30eed`](https://github.com/syl20bnr/spacemacs/commit/75c30eed0d043d1fdd36c170b98456098fd2c0ab) [helm] fix typo in helm-ls-git ([syl20bnr/spacemacs⁠#15411](https://togithub.com/syl20bnr/spacemacs/issues/15411))
* [`18ad9759`](https://github.com/syl20bnr/spacemacs/commit/18ad9759b29a56ba92fe452b62dd545329175b63) [nixos] Fix variable name in README ([syl20bnr/spacemacs⁠#15413](https://togithub.com/syl20bnr/spacemacs/issues/15413))
