### PR TITLE
niv nixpkgs: update e73b01f9 -> 609816b0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e73b01f93a6ca0b689865861bc79b25d49961ae2",
-        "sha256": "0i60v0d504as68bxcscjwqa213n91wgb1zj9bsv3zkqq3s0a4j4h",
+        "rev": "609816b0cec57b379c4e72abe0869511cf4fd582",
+        "sha256": "0fvi4f1yq7gjm50rs3s9ppknl9c4kj162x8h548j7ayrxw6q39wm",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e73b01f93a6ca0b689865861bc79b25d49961ae2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/609816b0cec57b379c4e72abe0869511cf4fd582.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e73b01f9...609816b0](https://github.com/nixos/nixpkgs/compare/e73b01f93a6ca0b689865861bc79b25d49961ae2...609816b0cec57b379c4e72abe0869511cf4fd582)

* [`50df42f0`](https://github.com/NixOS/nixpkgs/commit/50df42f0f314ca423ee299b8dc866fc3b189799b) nixos/samba: Add a wants=network-online.target to the target.
* [`5106a2f7`](https://github.com/NixOS/nixpkgs/commit/5106a2f74fd0fcf8f0ed6b4d9fef2eb0a2281f68) javaPackages.mavenfod: init
* [`a61cf209`](https://github.com/NixOS/nixpkgs/commit/a61cf20944911e20b91fa69b84749e52e72eefd6) dbeaver: use javaPackages.mavenfod
* [`d8110b0e`](https://github.com/NixOS/nixpkgs/commit/d8110b0e75cd576adb82f4eb4946ddb8f90c578f) keycloak: add keycloak.plugins
* [`74801dd0`](https://github.com/NixOS/nixpkgs/commit/74801dd0ea01ba714071cc80922a379c0019262b) keycloak.plugins.scim-for-keycloak: init at kc-15-b2
* [`891f2053`](https://github.com/NixOS/nixpkgs/commit/891f2053a019c5fa834988e59c9639b4b47545c5) nixos/keycloak: add plugins option
* [`985afdbb`](https://github.com/NixOS/nixpkgs/commit/985afdbb33cf546191307a2df7191ef9f470baf4) keycloak.plugins.keycloak-discord: init at 0.3.1
* [`bd33583c`](https://github.com/NixOS/nixpkgs/commit/bd33583c88f0859768dbf84186128ffc597864f5) nixosTests.keycloak: add discord plugin to test
* [`8e317c16`](https://github.com/NixOS/nixpkgs/commit/8e317c16309c7fe6f30213e705f3cecdbd2275eb) javaPackages.mavenfod: make maven parameters configurable
* [`41dd1d4d`](https://github.com/NixOS/nixpkgs/commit/41dd1d4d8b0a8b6dc2a7d71ab28adb0db111bf97) nixos/autorandr: refactor
* [`125a347a`](https://github.com/NixOS/nixpkgs/commit/125a347ae193e43a4e7f67ee4a5df198ef0040b4) nvidia: Fix AMD APU for Prime Sync
* [`a21c84bc`](https://github.com/NixOS/nixpkgs/commit/a21c84bc753dbb330dfbf8fa15ce414c658714dc) python3Packages.nilearn: reduce test suite significantly
* [`a4ec6f67`](https://github.com/NixOS/nixpkgs/commit/a4ec6f67c41348bc68b0c0d3f78259e8bf8044f6) python3Packages.mopidy-youtube: 3.4 -> 3.5
* [`cdf5bfff`](https://github.com/NixOS/nixpkgs/commit/cdf5bfff4bd756b522391970823c96493107eae3) libarchive: add some reverse dependencies to passthru.tests
* [`e6fe53cc`](https://github.com/NixOS/nixpkgs/commit/e6fe53cc808ef5e394274eb14ea8242e3ad02fc4) harfbuzz: add some reverse dependencies to passthru.tests
* [`6f17ba55`](https://github.com/NixOS/nixpkgs/commit/6f17ba558f6605c7f65c3cc6cea7e3975f3f78c7) nodePackages.thelounge-{plugin-closepms, theme-flat-blue, theme-flat-dark}: add override
* [`c95a170a`](https://github.com/NixOS/nixpkgs/commit/c95a170ac282da27c1b215996051d353de90cf90) air: 1.27.10 -> 1.28.0
* [`6749cba6`](https://github.com/NixOS/nixpkgs/commit/6749cba6997353d3f6f30a455b1e3f29dbe4074c) kauth: make polkit dependency optional
* [`b2e2e7c6`](https://github.com/NixOS/nixpkgs/commit/b2e2e7c6363988bfee822ab0ff4f1ca76a8962fc) synaesthesia: init at 2.4
* [`e2566775`](https://github.com/NixOS/nixpkgs/commit/e2566775c76ae2e98617941c2555b439bc15de6d) micro: add test with expect
* [`93c58365`](https://github.com/NixOS/nixpkgs/commit/93c58365386a20b82378df1d8ec441677c128874) libtiff: add some reverse dependencies to passthru.tests
* [`c4016f91`](https://github.com/NixOS/nixpkgs/commit/c4016f91299486254ad544e3c10b4e7c4efac26b) minio: 2022-02-24T22-12-01Z -> 2022-02-26T02-54-46Z
* [`bbbab2a2`](https://github.com/NixOS/nixpkgs/commit/bbbab2a249086b3c8877a76787b879ca3492a7d6) python310Packages.mlflow: 1.23.1 -> 1.24.0
* [`cbb5ddf9`](https://github.com/NixOS/nixpkgs/commit/cbb5ddf9912a84242801aeb7782cfc43ba958e4b) spotify-unwrapped: 1.1.77.643.g3c4c6fc6 -> 1.1.80.699.gc3dac750
* [`192646e4`](https://github.com/NixOS/nixpkgs/commit/192646e4417c1ececb7039d01e9e531c036fc8c1) tree-sitter-hcl: init
* [`515ec057`](https://github.com/NixOS/nixpkgs/commit/515ec05766edca0fae9d360268a13fd7684a37dc) python310Packages.iminuit: 2.9.0 -> 2.10.0
* [`17b4223d`](https://github.com/NixOS/nixpkgs/commit/17b4223d210a71c65d3bbfc576ec8eaf9dba2250) gnome-solanum: init at 3.0.1
* [`64022316`](https://github.com/NixOS/nixpkgs/commit/6402231607610a1f80b6aaaf4c6d5c89c3db0bf2) fragments: 1.5 -> 2.0.2
* [`54410abf`](https://github.com/NixOS/nixpkgs/commit/54410abf5db94d7e6a0decf145445dbf880af64b) SQUASH_BEFORE_MERGE: apply @⁠Artturin's recommendation https://github.com/NixOS/nixpkgs/pull/160972#r820163675
* [`2962e2a2`](https://github.com/NixOS/nixpkgs/commit/2962e2a2be56c2662b85a888586b5e9569b992e5) python310Packages.gphoto2: 2.3.2 -> 2.3.3
* [`70d3697f`](https://github.com/NixOS/nixpkgs/commit/70d3697f8c913b25e4632cb483834031c25fd1a1) nixos/resolvconf: allow disabling
* [`54c98ebd`](https://github.com/NixOS/nixpkgs/commit/54c98ebd268cd28370499269dd3eb15b94a8a585) filebot: 4.9.5 -> 4.9.6
* [`a2859168`](https://github.com/NixOS/nixpkgs/commit/a28591680be7ff4daa6cc97d33239a5357a8630a) nixos/prometheus/exporters/varnish: improve some defaults
* [`5d304d00`](https://github.com/NixOS/nixpkgs/commit/5d304d0098d8f5857103b5674a37f2ba86692ed7) ciao: 1.20.0 -> 1.21.0-m1
* [`6ebf051c`](https://github.com/NixOS/nixpkgs/commit/6ebf051cc036b0b864e43e532bf434895a7dae38) maintainers/scripts/remove-old-aliases.py: ignore lines which have 'preserve, reason:' in them
* [`2f80a58b`](https://github.com/NixOS/nixpkgs/commit/2f80a58bdd2f724cb0a373febf47e81c2f2495ee) faircamp: init at unstable-2022-01-19
* [`b7eaf0ff`](https://github.com/NixOS/nixpkgs/commit/b7eaf0ff3dc3249b43c9ef5ec9a33db0d671074b) python310Packages.cvxopt: 1.2.7 -> 1.3.0
* [`7377ea57`](https://github.com/NixOS/nixpkgs/commit/7377ea57ff104ba49b2b0b2b838a8c7bfbc55cea) lib: Add mkRenamedOptionModuleWith
* [`646e8880`](https://github.com/NixOS/nixpkgs/commit/646e88801113aaa9e2d255853d7de04066440b36) nixos/nix-daemon: Stop warning about nix.settings
* [`3e39e243`](https://github.com/NixOS/nixpkgs/commit/3e39e243db681acf8c0aeeeb8d6a9b27b0f02240) doc/reviewing-contributions: Recommend mkRenamedOptionModuleWith
* [`11d74c38`](https://github.com/NixOS/nixpkgs/commit/11d74c38718574b3cdb46999ce6399b0acbd560e) nixos/rl-2205: Add mkRenamedOptionModuleWith
* [`ca8fa3bb`](https://github.com/NixOS/nixpkgs/commit/ca8fa3bb6e2c924ffcf18843268df37c7871308d) rl-2205.section.xml: Regenerate
* [`e2369cb9`](https://github.com/NixOS/nixpkgs/commit/e2369cb9c90b92a465aeb40d62f2abd467c91543) dxvk: refactor to better support Darwin and Linux
* [`f29e152b`](https://github.com/NixOS/nixpkgs/commit/f29e152b7e23c163b904a942af33875d87effc12) dxvk: support version-specific MoltenVK patches
* [`519572c4`](https://github.com/NixOS/nixpkgs/commit/519572c4f26d2d17d4e1c29b091e3f9571be2554) vivaldi: fix update script for ffmpeg
* [`997fa335`](https://github.com/NixOS/nixpkgs/commit/997fa335c372056667502a2d877b326fecb79850) warzone2100: 4.2.6 -> 4.2.7
* [`9c8eda7f`](https://github.com/NixOS/nixpkgs/commit/9c8eda7f38c071c725c86627d1dce78ea5334c7a) llvmPackages_rocm.llvm: don't build shared libs
* [`77135ce7`](https://github.com/NixOS/nixpkgs/commit/77135ce76320db6a32037a3470b939123552e691) obsidian: Add obsidian:// scheme handler
* [`43c49dc7`](https://github.com/NixOS/nixpkgs/commit/43c49dc7b42b10d87a9982e001ee329f9b033fc2) cypress: 9.4.1 -> 9.5.1
* [`e96d73ed`](https://github.com/NixOS/nixpkgs/commit/e96d73eda10f503903f923f932d3a071c769ebfe) bacula: 11.0.5 -> 11.0.6
* [`3a87b878`](https://github.com/NixOS/nixpkgs/commit/3a87b878ffb04daedea88b06316d340b21399a66) mmctl: 6.3.3 -> 6.4.2
* [`8dc6d0d0`](https://github.com/NixOS/nixpkgs/commit/8dc6d0d0ac8c1818d9da723acfbc5422a04ce755) sonic-pi: 3.2.2 -> 3.3.1
* [`6bda8f8d`](https://github.com/NixOS/nixpkgs/commit/6bda8f8d5c8ae28db2057b190e16cb494b76b033) polymc: 1.0.6 -> 1.1.0
* [`1f377138`](https://github.com/NixOS/nixpkgs/commit/1f3771382a1f7c8ee2006eae3e438175f90ef94c) pythonPackages.boto: Enable Python 3.9
* [`b4ce56da`](https://github.com/NixOS/nixpkgs/commit/b4ce56dafc90e85f6c12bf84d476bbc86dd1f1e8) pythonPackages.boto: enable test
* [`045b8199`](https://github.com/NixOS/nixpkgs/commit/045b819959208f55e85a5f58b2dd082eff4cfbfa) nixos/graylog: fix group creation
* [`498e4973`](https://github.com/NixOS/nixpkgs/commit/498e4973b34a3bcb981685a22564fcf6970b0310) bottles: added autoupdate
* [`d37f9937`](https://github.com/NixOS/nixpkgs/commit/d37f993770f503fbbdf3b28e8ba96a10292f2a41) bottles: 2022.2.28-trento-1 -> 2022.3.14-trento-3
* [`cf9d0351`](https://github.com/NixOS/nixpkgs/commit/cf9d03519cfc8f02331dad87059a98792dff1294) python310Packages.pycurl: 7.45.0 -> 7.45.1
* [`2dfbdb27`](https://github.com/NixOS/nixpkgs/commit/2dfbdb27d5ff8c66dad3d1344a5ce71273a6aaf4) codesearch: switch to fetchFromGitHub
* [`87530053`](https://github.com/NixOS/nixpkgs/commit/87530053481bc6634926d0a3a695abdb9d0b3bca) das_watchdog: switch to fetchFromGitHub
* [`646f5c73`](https://github.com/NixOS/nixpkgs/commit/646f5c7302be74328be85f50c5d94ce0d5fa1bf8) tpm-luks: switch to fetchFromGitHub
* [`b60ee6e4`](https://github.com/NixOS/nixpkgs/commit/b60ee6e462d4ec9f33690eca4e62e61164a32aa0) waitron: switch to fetchFromGitHub
* [`e822bf4e`](https://github.com/NixOS/nixpkgs/commit/e822bf4e6b671a9e735f913808aa50c9c0c09cd0) ua: switch to fetchFromGitHub
* [`7b4607f8`](https://github.com/NixOS/nixpkgs/commit/7b4607f83fd9ff54d34d40d18171d0f274b025b4) s3gof3r: switch to fetchFromGitHub
* [`c3d260d8`](https://github.com/NixOS/nixpkgs/commit/c3d260d8d8f1b5d603f473aac87641beb3948b96) bud: switch to fetchFromGitHub
* [`96aad972`](https://github.com/NixOS/nixpkgs/commit/96aad972429b88065aee364c78425677571fa2ac) go-upower-notify: switch to fetchFromGitHub
* [`a92360c7`](https://github.com/NixOS/nixpkgs/commit/a92360c7a613a5f1e2b4c3ef362320efc3bf0362) sdl-jstest: switch to fetchFromGitHub
* [`6128e151`](https://github.com/NixOS/nixpkgs/commit/6128e1515cbefe80e0c836c83ae299f1c66bd1bb) i3cat: switch to fetchFromGitHub
* [`c0e4a932`](https://github.com/NixOS/nixpkgs/commit/c0e4a932cdf7a9f8d346c8fbb5ab309ead239beb) trustedGrub: switch to fetchFromGitHub
* [`2653975e`](https://github.com/NixOS/nixpkgs/commit/2653975e7174c7e9191446d6383e030f1394db6e) gosu: switch to fetchFromGitHub
* [`8e9dcca2`](https://github.com/NixOS/nixpkgs/commit/8e9dcca200a1082fea263e89b481c1d0eab2a4fb) gawp: switch to fetchFromGitHub
* [`0aed0348`](https://github.com/NixOS/nixpkgs/commit/0aed0348efb2f0594fb877faa61f3ced27677f21) azure-vhd-utils: switch to fetchFromGitHub
* [`6ffdc42c`](https://github.com/NixOS/nixpkgs/commit/6ffdc42cd06ea0165ed6c9634ea04dbee18e30a9) go-mtpfs: switch to fetchFromGitHub
* [`27db42fb`](https://github.com/NixOS/nixpkgs/commit/27db42fb3e06004f16f30d92dd3b70dd2ddda631) vobsub2srt: switch to fetchFromGitHub
* [`1441aa2f`](https://github.com/NixOS/nixpkgs/commit/1441aa2f6ab94a3d32947b7975d5efb621b43543) gvolicon: switch to fetchFromGitHub
* [`de5c01cd`](https://github.com/NixOS/nixpkgs/commit/de5c01cdd32332319b9c7100fb7c6b04c4fc28b3) bash-my-aws: switch to fetchFromGitHub
* [`2ef96d71`](https://github.com/NixOS/nixpkgs/commit/2ef96d712bfa76ca4d03d9027cffe703b910da14) morty: switch to fetchFromGitHub
* [`85f87b2c`](https://github.com/NixOS/nixpkgs/commit/85f87b2c7e8e188cb42a964431d266012cc96527) scylladb: switch to fetchFromGitHub
* [`984f4a8c`](https://github.com/NixOS/nixpkgs/commit/984f4a8c575f344bcb9a88ca3649a3947a40df98) ps3netsrv: switch to fetchFromGitHub
* [`45740c7e`](https://github.com/NixOS/nixpkgs/commit/45740c7e89bc75d401f4423c5ca9d062348b02a3) lightdm-enso-os-greeter: switch to fetchFromGitHub
* [`fb8a6c02`](https://github.com/NixOS/nixpkgs/commit/fb8a6c02bcb202c1558896d116e0d0dfa73acebb) rippled: switch to fetchFromGitHub
* [`cfc95ec9`](https://github.com/NixOS/nixpkgs/commit/cfc95ec96f3453605cc7d9fa616d75c5256dd2c0) brickd: switch to fetchFromGitHub
* [`8af8ab0f`](https://github.com/NixOS/nixpkgs/commit/8af8ab0f0ea77ba560e4c1e5732848f3e3b4d59d) usermount: switch to fetchFromGitHub
* [`2cfd9d25`](https://github.com/NixOS/nixpkgs/commit/2cfd9d259329c99f6dfdf68508561087ab7fd577) lightum: switch to fetchFromGitHub
* [`c3857b31`](https://github.com/NixOS/nixpkgs/commit/c3857b318e080f642b9cd6bc247598f3090a3d5d) rt5677-firmware: switch to fetchFromGitHub
* [`e5c1b1f1`](https://github.com/NixOS/nixpkgs/commit/e5c1b1f17eb3764112a13592b8a10576e2974ab6) xtrlock-pam: switch to fetchFromGitHub
* [`8322c182`](https://github.com/NixOS/nixpkgs/commit/8322c182fa52f2c53454c8aacf14dfac55f256e7) alock: switch to fetchFromGitHub
* [`82134852`](https://github.com/NixOS/nixpkgs/commit/821348523f1a9fa42d595b7134dbbdad1c582fdf) ws: switch to fetchFromGitHub
* [`2c02eb4a`](https://github.com/NixOS/nixpkgs/commit/2c02eb4aa93d4d2be385299ebea3fb58195660cf) rtags: switch to fetchFromGitHub
* [`c087e36f`](https://github.com/NixOS/nixpkgs/commit/c087e36fdda02037c873114ab9d743407923b58b) ycmd: switch to fetchFromGitHub
* [`b4e01326`](https://github.com/NixOS/nixpkgs/commit/b4e01326d7b81ee3a4e9b7339848743b4458e99e) Literate: switch to fetchFromGitHub
* [`ae6e3ae0`](https://github.com/NixOS/nixpkgs/commit/ae6e3ae0e2508df7812a2a2e2c79a7f75bf2cb64) jd: switch to fetchFromGitHub
* [`9aeb5a8d`](https://github.com/NixOS/nixpkgs/commit/9aeb5a8d01c5272af88eaf3dac8be6e5cece899c) haskellPackages.dconf2nix: switch to fetchFromGitHub
* [`b6ea3447`](https://github.com/NixOS/nixpkgs/commit/b6ea3447c8237f4a3e7aa7432882b45368cc92fc) gotags: switch to fetchFromGitHub
* [`ba616952`](https://github.com/NixOS/nixpkgs/commit/ba61695222b5170245cdecdc922f296c636a881e) go-repo-root: switch to fetchFromGitHub
* [`79a4f024`](https://github.com/NixOS/nixpkgs/commit/79a4f02481e94ddc3c659ee6d6ed9564400a8e46) svg2tikz: switch to fetchFromGitHub
* [`9d349d6a`](https://github.com/NixOS/nixpkgs/commit/9d349d6a482cbaad82d51399bc3b223f55c9e01c) python3-scikits.samplerate: switch to fetchFromGitHub
* [`97b38058`](https://github.com/NixOS/nixpkgs/commit/97b380587f3e4416a15e0537714c207d6a7e57d3) python3Packages.mutag: switch to fetchFromGitHub
* [`fca3e2ac`](https://github.com/NixOS/nixpkgs/commit/fca3e2ac936829c5a7213188db442b7f9dc63c9c) python3Packages.editorconfig: switch to fetchFromGitHub
* [`f31c35ab`](https://github.com/NixOS/nixpkgs/commit/f31c35ab3d5f861b3fe5be987064ab338502ba1d) python3.pkgs.twisted: 21.7.0 -> 22.2.0
* [`662414d8`](https://github.com/NixOS/nixpkgs/commit/662414d8a838f5aa8eb3c71b7f94b0b64f6cc373) insomnia: 2021.7.2 -> 2022.1.1
* [`47157bf5`](https://github.com/NixOS/nixpkgs/commit/47157bf539df081f13a828e213de91b67f52516e) frugal: 3.14.15 -> 3.15.0
* [`58e32427`](https://github.com/NixOS/nixpkgs/commit/58e32427d813439a08fef4008151bfba1e244ba1) libnatpmp: fix dyld path on darwin
* [`c234b179`](https://github.com/NixOS/nixpkgs/commit/c234b17951d0f957128be071aae119e44347bdeb) xfce.xfce4-screenshooter: 1.9.9 -> 1.9.10
* [`e31ccc84`](https://github.com/NixOS/nixpkgs/commit/e31ccc845fae25fe31711d4bd91b05759e228349) lxqt.obconf-qt: 0.16.1 -> 0.16.2
* [`d2c297a6`](https://github.com/NixOS/nixpkgs/commit/d2c297a6a5c108b07c4d16e5b426f4a84b783b83) phpExtensions.memcached: switch to fetchFromGitHub
* [`dfff76aa`](https://github.com/NixOS/nixpkgs/commit/dfff76aa14d6c1a5f90ad7ab7374ac1b8110ea21) haskellPackages.hercules-ci-optparse-applicative: switch to fetchFromGitHub
* [`7bbf666c`](https://github.com/NixOS/nixpkgs/commit/7bbf666c9ff9b19fbd50720d8bbc421bd3615be8) hydraAntLogger: switch to fetchFromGitHub
* [`339ccbe9`](https://github.com/NixOS/nixpkgs/commit/339ccbe93376df53ead60c810cb05fef830493a9) lispPackages.quicklisp: switch to fetchFromGitHub
* [`28ff2255`](https://github.com/NixOS/nixpkgs/commit/28ff2255a41c8d13129fa3942ecd0c8f77d3811e) pixie: switch to fetchFromGitHub
* [`9feb246f`](https://github.com/NixOS/nixpkgs/commit/9feb246fb84bf7239e8e1de388a4edbd45ebc644) ceptre: switch to fetchFromGitHub
* [`aaa85855`](https://github.com/NixOS/nixpkgs/commit/aaa85855ca3e4be34bd61a3c06ca0d4898a2a89a) bossa: switch to fetchFromGitHub
* [`fe193e7d`](https://github.com/NixOS/nixpkgs/commit/fe193e7dd25b366c57647e4b0edc7ac6498d6545) opendylan: switch to fetchFromGitHub
* [`7c71e843`](https://github.com/NixOS/nixpkgs/commit/7c71e8438cdadbbbb8437c0bc501f6f4c3ec3a1e) nim: switch to fetchFromGitHub
* [`98a951c5`](https://github.com/NixOS/nixpkgs/commit/98a951c50952598b6eedcf291c8f8d88fadd0943) klee: build with klee-uclibc
* [`ddf78f13`](https://github.com/NixOS/nixpkgs/commit/ddf78f131265b2921bc01f1870e179abf042843b) dar: 2.7.3 -> 2.7.4
* [`9991e13d`](https://github.com/NixOS/nixpkgs/commit/9991e13d86b0dbc7edf165bb66ccbd4c8b45e6b5) maintainers: add lockejan
* [`6475ad4e`](https://github.com/NixOS/nixpkgs/commit/6475ad4ea8b47849b0d54cc89856ccf45964ed07) libthreadar: 1.3.5 -> 1.4.0
* [`de62c2c1`](https://github.com/NixOS/nixpkgs/commit/de62c2c1f498c62b502c97c99e85aa285446ed52) furnace: 0.5.6 -> 0.5.8
* [`31440798`](https://github.com/NixOS/nixpkgs/commit/314407980e3f45d6138ce258fd76bca878d3b680) gopass: 1.13.1 → 1.14.0
* [`3a46b6e1`](https://github.com/NixOS/nixpkgs/commit/3a46b6e1c48f1b6fcef49cdebf6f30663077a09b) librewolf: 97.0.2-1 -> 98.0-1
* [`fccbe209`](https://github.com/NixOS/nixpkgs/commit/fccbe209cb2cc4cc893f3fd30f759be411986d21) stellarsolver: 2.0 -> 2.2
* [`013d4cc0`](https://github.com/NixOS/nixpkgs/commit/013d4cc072f4963e5784a700cc415103d12f303b) aldor: switch to fetchFromGitHub
* [`5e756617`](https://github.com/NixOS/nixpkgs/commit/5e7566170835cbf7572f2265008e475a9907ee9c) chez-srfi: switch to fetchFromGitHub
* [`e5346e0f`](https://github.com/NixOS/nixpkgs/commit/e5346e0f294567a41e001ddf24a8c28c900e74ac) chez-scmutils: switch to fetchFromGitHub
* [`aaccd199`](https://github.com/NixOS/nixpkgs/commit/aaccd19948ebeecb3107fb098fafcd20ce8eaa9b) chez-mit: switch to fetchFromGitHub
* [`84fe8734`](https://github.com/NixOS/nixpkgs/commit/84fe8734f63afb08d70a41f43f4d1100c81d6492) rictydiminished-with-firacode: switch to fetchFromGitHub
* [`b5d13100`](https://github.com/NixOS/nixpkgs/commit/b5d1310056382d31c30e8fbbb4fc0efc822f85fe) btops: switch to fetchFromGitHub
* [`ba4c657b`](https://github.com/NixOS/nixpkgs/commit/ba4c657bdac39a935ee2e8e3625b4a81dcec3951) spike: switch to fetchFromGitHub
* [`f8684d34`](https://github.com/NixOS/nixpkgs/commit/f8684d34e99bdaf3d6c01d05dfb236a19dd10eb7) cntk: switch to fetchFromGitHub
* [`ee2a1e3a`](https://github.com/NixOS/nixpkgs/commit/ee2a1e3a1986536d97a35c0ae163bcf914921b22) mmex: switch to fetchFromGitHub
* [`27af6126`](https://github.com/NixOS/nixpkgs/commit/27af61265b8fcfbd156360a93eed1417ab943ef3) communi: switch to fetchFromGitHub
* [`afb9c153`](https://github.com/NixOS/nixpkgs/commit/afb9c15341303b7d28d9326b90bddff6c1182643) git-annex-remote-b2: switch to fetchFromGitHub
* [`bf316c83`](https://github.com/NixOS/nixpkgs/commit/bf316c83076005b15bf6c1b5ce7e161dc05eb430) tensor: switch to fetchFromGitHub
* [`b5bbff0e`](https://github.com/NixOS/nixpkgs/commit/b5bbff0e029015f46a04050b4a96ed63cbaa6402) schildichat-web: switch to fetchFromGitHub
* [`7288417b`](https://github.com/NixOS/nixpkgs/commit/7288417b83740407dc9e1be7cbcdf9261a146490) schildichat-desktop: switch to fetchFromGitHub
* [`4c7f9afd`](https://github.com/NixOS/nixpkgs/commit/4c7f9afd31da9d2d2c5a8a57e9012397ab2c2e8c) pond: switch to fetchFromGitHub
* [`de81be0d`](https://github.com/NixOS/nixpkgs/commit/de81be0d53205c142e201d84a912c6f5d3c3edd1) telegram-purple: switch to fetchFromGitHub
* [`084cd8cb`](https://github.com/NixOS/nixpkgs/commit/084cd8cb090ad6f15b9dbb3858ee54ae18cfeba6) pidgin-mra: switch to fetchFromGitHub
* [`bfccc7c3`](https://github.com/NixOS/nixpkgs/commit/bfccc7c38c007c8f96d64dc2a837dc770fd81c71) matrixcli: switch to fetchFromGitHub
* [`3a1e0156`](https://github.com/NixOS/nixpkgs/commit/3a1e015627474c8f1da6a5c83577cd3e293a7475) tpmmanager: switch to fetchFromGitHub
* [`45c1cc21`](https://github.com/NixOS/nixpkgs/commit/45c1cc217556a056bb91c8680e262d997008df22) nix-tour: switch to fetchFromGitHub
* [`e7149994`](https://github.com/NixOS/nixpkgs/commit/e71499940349f49696cb193454b9853ed999ed09) mop: switch to fetchFromGitHub
* [`a336bbef`](https://github.com/NixOS/nixpkgs/commit/a336bbef76146d1e617e0005981e12da0e28bcba) lightdm-enso-os-greeter: switch to fetchFromGitHub
* [`d1d06e33`](https://github.com/NixOS/nixpkgs/commit/d1d06e33c6487a4866bcb861a3cadeec76585a52) emacs27Packages: switch to fetchFromGitHub
* [`1e395cf2`](https://github.com/NixOS/nixpkgs/commit/1e395cf2e81f14f528eac0e9fd871b5ea4d6b668) php80: 8.0.16 -> 8.0.17
* [`e97d5884`](https://github.com/NixOS/nixpkgs/commit/e97d5884238a483c8c62c4aabdf8f68d2dadb734) nix-info: add BUILD_ID information
* [`e1432a6f`](https://github.com/NixOS/nixpkgs/commit/e1432a6f48360ef4a132dbb792a45f5a17808e8b) yuzu-{ea,mainline}: {2432,882} -> {2557,953}
* [`73449ea7`](https://github.com/NixOS/nixpkgs/commit/73449ea799ec13e91349a4a4dae758e03e6c51aa) inav-configurator: 3.0.2 -> 4.1.0
* [`3420dba8`](https://github.com/NixOS/nixpkgs/commit/3420dba80a0b36c70b3ed62a605fe6b1172f8304) nixos: systemd: move systemd-nspawn to systemd/nspawn
* [`0c94a512`](https://github.com/NixOS/nixpkgs/commit/0c94a512dd974232b0a4de637f8df5d707055e75) nixos: systemd: avoid using "with systemdUtils.lib"
* [`5b55eb42`](https://github.com/NixOS/nixpkgs/commit/5b55eb42f1b14fdab2a09669fa27d44f492eb7e4) tree-sitter: add extraGrammars attribute
* [`6db78a17`](https://github.com/NixOS/nixpkgs/commit/6db78a1751cc0d629c51a315b6fafc9d15ea543d) crcpp: 1.1.0.0 -> 1.2.0.0
* [`c647002a`](https://github.com/NixOS/nixpkgs/commit/c647002a9449ea9bcc8327087386cd9b89a43c3b) nixos: systemd: split off logind into separate module
* [`e2cb8903`](https://github.com/NixOS/nixpkgs/commit/e2cb8903da7d36a4fbb6edd97b672e66e08a0339) nixos: systemd-logind: use cfg shorthand
* [`fee1e24b`](https://github.com/NixOS/nixpkgs/commit/fee1e24b3bf15c2ff6ac88658323c2815f697a5b) nixos: systemd: split off journald into separate module
* [`7adc8eca`](https://github.com/NixOS/nixpkgs/commit/7adc8ecac39b65c5499578c79aab62a3f14c5625) nixos: systemd-journald: use cfg shorthand
* [`ccfcb78a`](https://github.com/NixOS/nixpkgs/commit/ccfcb78a5096e613b9d0767d3c3e77616c3e06f5) nixos: systemd: split off coredump into separate module
* [`cae8ef12`](https://github.com/NixOS/nixpkgs/commit/cae8ef12320a45e5c630b43c9e1e62279d9a5992) nixos: systemd-coredump: use cfg shorthand
* [`022b4209`](https://github.com/NixOS/nixpkgs/commit/022b4209a398b0648e4d5e2bead42ad9662ad764) nixos: systemd: split off systemd-user into separate module
* [`b6d50528`](https://github.com/NixOS/nixpkgs/commit/b6d50528dd0af3ddbcd333402473589f3897d278) nixos: systemd-user: use cfg shorthand
* [`0e665d18`](https://github.com/NixOS/nixpkgs/commit/0e665d181500da4836a1d3ab64464e5ff1e3574a) nixos: systemd-user: allow additional upstream user units
* [`38d043de`](https://github.com/NixOS/nixpkgs/commit/38d043de9c5459e4797749822c0e2a590cc0bee5) nixos: systemd: split off systemd-tmpfiles into separate module
* [`753b9117`](https://github.com/NixOS/nixpkgs/commit/753b91170858ece27a1680ce3264d37f4034b51f) nixos: systemd-tmpfiles: use cfg shorthand
* [`79a23456`](https://github.com/NixOS/nixpkgs/commit/79a234567c01399c5f1ae1d0b60ac84d12075b3b) nixos/testing: restrict arguments to makeTest
* [`ca8c877f`](https://github.com/NixOS/nixpkgs/commit/ca8c877f8cd1f9b84e8aa57741aa5cd60a3a2ba3) nixos/tests: fix some evaluation errors
* [`96698efe`](https://github.com/NixOS/nixpkgs/commit/96698efe0cd9e0ffe38d95e043acafa926fa5e0d) lib/modules: Finally remove deprecated types.optionSet
* [`286c04bc`](https://github.com/NixOS/nixpkgs/commit/286c04bcbf54ed52e3de28a6a033a4be61e16a01) python3Packages.cleo: 0.8.1 -> 1.0.0a4
* [`16ce18ba`](https://github.com/NixOS/nixpkgs/commit/16ce18bab3f25056216f8fd7f8f26fc0f11d381f) librtprocess: 0.11.0 -> 0.12.0
* [`a5911f15`](https://github.com/NixOS/nixpkgs/commit/a5911f15973f01567d104dd2944b58bea9830322) php81: 8.1.3 -> 8.1.4
* [`7c26be24`](https://github.com/NixOS/nixpkgs/commit/7c26be24f3aa61bd35f4258c2c85f93e1be5bd24) astc-encoder: 3.4 -> 3.5
* [`2ac52753`](https://github.com/NixOS/nixpkgs/commit/2ac527530e3d3b9e335d511a6fe2736ceffe90c1) nixosTests.keepassxc: Add regression test for [nixos/nixpkgs⁠#163482](https://togithub.com/nixos/nixpkgs/issues/163482)
* [`53f22375`](https://github.com/NixOS/nixpkgs/commit/53f2237575786090f9d6a3e432d2afd489606aa1) keepassxc: Add wrapGAppsHook. Fixes [nixos/nixpkgs⁠#163482](https://togithub.com/nixos/nixpkgs/issues/163482).
* [`0e373bb4`](https://github.com/NixOS/nixpkgs/commit/0e373bb46aa6fe4f2f274c3ccb70a97097d74b4a) capnproto: use upstream patch to fix w/musl
* [`5e801d82`](https://github.com/NixOS/nixpkgs/commit/5e801d82ddbd2c39dcd8d5bf96d1f897a3b1c3c6) lunar-client: 2.9.3 -> 2.10.0
* [`7b32b8b6`](https://github.com/NixOS/nixpkgs/commit/7b32b8b66f80c10e7d509d62051dfd64470b3ebb) Remove ancient mkOption tests
* [`00487b5a`](https://github.com/NixOS/nixpkgs/commit/00487b5a87cff8c0970a64a040377949ffa11b1a) nixos/nixos-generate-config: resolve abspath to root
* [`611b8c44`](https://github.com/NixOS/nixpkgs/commit/611b8c4472db0bde066b97960ccfe4671ffb89fb) nixos/nixos-generate-config: fix specifying --root /mnt --dir adir
* [`fb71b0ac`](https://github.com/NixOS/nixpkgs/commit/fb71b0acab701c547a66541962a17167596f46b8) autorestic: 1.5.7 -> 1.5.8
* [`8f57dc38`](https://github.com/NixOS/nixpkgs/commit/8f57dc38d93d9a6b8a792e7cd963af676a1de252) fixup! nixos/testing: restrict arguments to makeTest
* [`66759cea`](https://github.com/NixOS/nixpkgs/commit/66759cea7dcd78219b4738b556de2cf416c6c61c) nixos: systemd-user: expand on additionalUpstreamUserUnits description
* [`6514bb46`](https://github.com/NixOS/nixpkgs/commit/6514bb46201fca7ea0a35828c98f711d952be878) nixos: systemd-user: make additionalUpstreamUserUnits internal
* [`72faca43`](https://github.com/NixOS/nixpkgs/commit/72faca439d72f654808a0f6b49ffe3c059a7b55b) CODEOWNERS: add @⁠NixOS/systemd for systemd files
* [`fa9ee43d`](https://github.com/NixOS/nixpkgs/commit/fa9ee43d7f17a3087f10065a9a07269313239231) python3Packages.dunamai: init at 1.10.0
* [`76cfedbe`](https://github.com/NixOS/nixpkgs/commit/76cfedbe2800a5e86a3dc60f55fb762671043a94) linux: 5.10.106 -> 5.10.107
* [`32f1dca6`](https://github.com/NixOS/nixpkgs/commit/32f1dca656e0485f960d9c1a3ce27f2feffd644c) linux: 5.15.29 -> 5.15.30
* [`e5f91ad1`](https://github.com/NixOS/nixpkgs/commit/e5f91ad13411b39100e46f709a5a5c3e3d5de60f) linux: 5.16.15 -> 5.16.16
* [`7c8a33bb`](https://github.com/NixOS/nixpkgs/commit/7c8a33bbcf533b797f223a5f557b65357a802b0d) linux: 5.4.185 -> 5.4.186
* [`2d1b42d2`](https://github.com/NixOS/nixpkgs/commit/2d1b42d21680f392cd85146fb82f4e6b1b113139) linux-rt_5_10: 5.10.104-rt63 -> 5.10.106-rt64
* [`4aeb9ea1`](https://github.com/NixOS/nixpkgs/commit/4aeb9ea1078724a3322749751df2340328c1f7ac) ryujinx: 1.1.76 -> 1.1.77
* [`7fae930a`](https://github.com/NixOS/nixpkgs/commit/7fae930a37a06fe08d4f85d6f41b04b37ed05cd0) lib/trivial: add warnIfNot and throwIf
* [`733068d2`](https://github.com/NixOS/nixpkgs/commit/733068d254fbe76a39f1c0c80252e7be4bf85a32) varnish: 7.0.2 -> 7.1.0
* [`e5527761`](https://github.com/NixOS/nixpkgs/commit/e552776181643872ae3a8330bd44959bad94561a) trezor-suite: 22.1.1 -> 22.3.2
* [`609623c3`](https://github.com/NixOS/nixpkgs/commit/609623c346811eab0f6031d188fa833659026ae3) libvirt: Fix a segfault when undefining a domain
* [`69544f20`](https://github.com/NixOS/nixpkgs/commit/69544f204da8d897f3ca8505eefc9a965143117f) protoc-gen-go-grpc: 1.1.0 -> 1.2.0
* [`649b74f4`](https://github.com/NixOS/nixpkgs/commit/649b74f4558fc50d67ab826aee15e9815a504f03) skaffold: 1.36.0 -> 1.37.0
* [`87b147a1`](https://github.com/NixOS/nixpkgs/commit/87b147a1f135acc687764cbb86df7e76b3909aa4) python310Packages.awscrt: 0.13.5 -> 0.13.6
* [`34c841ab`](https://github.com/NixOS/nixpkgs/commit/34c841ab46ce260ab6d75bdf74d0f27db5d3ca15) python3Packages.myfitnesspal: add toPythonApplication
* [`9bffd90a`](https://github.com/NixOS/nixpkgs/commit/9bffd90af89201264cf02a6e2bf03692750725c3) tor-browser-bundle-bin: 11.0.7 -> 11.0.9
* [`5c00fe6b`](https://github.com/NixOS/nixpkgs/commit/5c00fe6b1bfba588f4e9c7fdcc9de8c3b7b191f7) nixos/switchTest: Also test the os-release parser
* [`bdcd5588`](https://github.com/NixOS/nixpkgs/commit/bdcd55881231b43e3e72393aace962ce32ae9909) nixos/switch-to-configuration: Get rid of all postfixes and unlesses
* [`23ea9965`](https://github.com/NixOS/nixpkgs/commit/23ea9965bbe51ec506518fd5084a8648b78aa32c) nixos/switch-to-configuration: Enforce consistent quoting
* [`67f84b4b`](https://github.com/NixOS/nixpkgs/commit/67f84b4b87d3a1df5fc0f23e7fe5db52b5ac030b) nixos/switch-to-configuration: Snake-case all subroutines and add comments
* [`9c494b57`](https://github.com/NixOS/nixpkgs/commit/9c494b57732076fd01ba7a1c8ac0f228285c43c9) nixos/switch-to-configuration: Snake-case all variables
* [`85874efc`](https://github.com/NixOS/nixpkgs/commit/85874efcb01fe6266c78761900b2c526cf929cd3) nixos/switch-to-configuration: Make perlcritic happy
* [`2473cce8`](https://github.com/NixOS/nixpkgs/commit/2473cce829b30a35655baf1501e392337549a179) nixos/switchTest: Also test boot/switch actions
* [`a605bd75`](https://github.com/NixOS/nixpkgs/commit/a605bd758cfdd811d2b81b2f52fc9a52b26ed89f) flyctl: 0.0.302 -> 0.0.306
* [`fd654d3c`](https://github.com/NixOS/nixpkgs/commit/fd654d3c3e2ccea298685af77ee15fcb7d555958) vivaldi: 5.1.2567.49-1 -> 5.1.2567.66-1
* [`41a25e00`](https://github.com/NixOS/nixpkgs/commit/41a25e008803c19c13cb67423ad3070be4051b71) vivaldi-ffmepg-codecs: 97.0.4692.56 -> 97.0.4692.71
* [`ca6c166c`](https://github.com/NixOS/nixpkgs/commit/ca6c166c0b981d6f57f5ee31d3c1b9ed2c0fbbf2) guile-ssh: 0.15.0 -> 0.15.1
* [`eebff747`](https://github.com/NixOS/nixpkgs/commit/eebff7472936aecb1231632c73e2d5d43c2ad315) mitmproxy: 7.0.4 -> 8.0.0
* [`fc6f267e`](https://github.com/NixOS/nixpkgs/commit/fc6f267e5d3b9c42163aac81e28e8613195576ec) kicad: 6.0.2 -> 6.0.4
* [`89ed2ce3`](https://github.com/NixOS/nixpkgs/commit/89ed2ce3e8e21d3cb70edde3ce726a747e26b3e0) gcr: pull upstream fix for meson-0.60
* [`73e92f61`](https://github.com/NixOS/nixpkgs/commit/73e92f61bf5cc4ddc01e79680b4dc802eea548e8) CODEOWNERS: add members of NixOS/systemd as well
* [`92af44e0`](https://github.com/NixOS/nixpkgs/commit/92af44e04df36947d844b1f49bf14443d378e9db) nixos: systemd: remove unhelpful comments in additionalUpstreamSystemUnits
* [`7505d917`](https://github.com/NixOS/nixpkgs/commit/7505d91783e4544551f84ac12ffe61032750eb4e) maintainers: add freax13
* [`dfb7d36e`](https://github.com/NixOS/nixpkgs/commit/dfb7d36e7aeaf101a9d6c5c9717ee5ae97eb1a2f) kicad-unstable: 2022-01-13 -> 2022-03-19
* [`70f65b1b`](https://github.com/NixOS/nixpkgs/commit/70f65b1ba802a4f2cd3177df839421de4c560628) gnomeExtensions: auto-update
* [`b8229f28`](https://github.com/NixOS/nixpkgs/commit/b8229f288c7eabe6014849d5828d54d03f3a14a6) gnomeExtensions: add GNOME 42 extensions
* [`e6157516`](https://github.com/NixOS/nixpkgs/commit/e6157516711d016c04529e58d6171380f348b4ba) bottles: added `gnutls` to `extraLibraries` to enable encryption support
* [`da583d8a`](https://github.com/NixOS/nixpkgs/commit/da583d8a670620406d46202f2f337e7b166c6dcf) displaylink: 5.5.0-beta-59.118 -> 5.5.0-59.151
* [`142a76c4`](https://github.com/NixOS/nixpkgs/commit/142a76c4125ffe4853525ff304190b797403bc8a) kstars: 3.5.7 -> 3.5.8
* [`9f7e505d`](https://github.com/NixOS/nixpkgs/commit/9f7e505dd7de32cd33b6d8cc905edfd6d4971c1a) nix: make Perl bindings use matching Nix version
* [`2cd15bbb`](https://github.com/NixOS/nixpkgs/commit/2cd15bbbedba8fb1ae2b008331aefe6804d4075c) gef: init at 2022.01
* [`2593530f`](https://github.com/NixOS/nixpkgs/commit/2593530f3f1233c2d12604a7a560113b729e87f0) minio-certgen: 1.1.0 -> 1.2.0
* [`0cf8a815`](https://github.com/NixOS/nixpkgs/commit/0cf8a8155bbb8937a93d400a018d5ea279a5b553) sfxr-qt: 1.4.0 -> 1.5.0
* [`8ec528fe`](https://github.com/NixOS/nixpkgs/commit/8ec528feefa7793ac4363ab200a7ddd6fc9c3bc6) collapseos-cvm: init at 20220316
* [`6d6dfc8f`](https://github.com/NixOS/nixpkgs/commit/6d6dfc8fdf04b7b187128cea480aa467c80a2a08) micropad: init at 3.30.6
* [`b97947bb`](https://github.com/NixOS/nixpkgs/commit/b97947bb898577cc6e04139e1b0f319d641b5d52) python3Packages.flake8-bugbear: 22.1.11 -> 22.3.20
* [`233408b8`](https://github.com/NixOS/nixpkgs/commit/233408b810cbef3862e5647124e3d298f32b6187) cudatoolkit_11: cudatoolkit_11_4 → cudatoolkit_11_6
* [`d386210a`](https://github.com/NixOS/nixpkgs/commit/d386210a918155d448e56c0a412fa5180d2a253f) python3Packages.slixmpp: 1.8.0.1 -> 1.8.1
* [`97016266`](https://github.com/NixOS/nixpkgs/commit/97016266055cf6a174e4fe26c6951020ff8db141) linuxPackages.rtl8192eu: 4.4.1.20211023 -> 4.4.1.20220313
* [`23b44464`](https://github.com/NixOS/nixpkgs/commit/23b44464be3648f0a0a00111db85163d8c57dec6) emacspeak: Use bundled espeak server instead of espeak-ng
* [`a982f69f`](https://github.com/NixOS/nixpkgs/commit/a982f69fa884be70ac3223f6919867e7d4e00596) linuxPackages.rtl8821cu: 2021-10-21 -> 2022-03-08
* [`e6a8a1c1`](https://github.com/NixOS/nixpkgs/commit/e6a8a1c1b39c214ac610184866cef007debf2a85) linuxPackages.rtl88xxau-aircrack: 307d69 -> 37e27f
* [`994137ba`](https://github.com/NixOS/nixpkgs/commit/994137ba12858aa4fa576a31e8a60cd15feee994) python3Packages.mitmproxy: re-enable tests on darwin
* [`d5bf6bac`](https://github.com/NixOS/nixpkgs/commit/d5bf6bac5c0e51624eb26d38621718759df32eac) buildFHSUserEnv{Chroot,Bubblewrap}: fix handling of glib schema
* [`3518ed19`](https://github.com/NixOS/nixpkgs/commit/3518ed19a50a12472dd9077d226eef221bd6abeb) plexamp: 4.0.3 -> 4.1.0
* [`3132fcfe`](https://github.com/NixOS/nixpkgs/commit/3132fcfec3f648091d651c5f86af0dfd804a6397) linux: Enable BPF_UNPRIV_DEFAULT_OFF in 5.15
* [`ddf002c0`](https://github.com/NixOS/nixpkgs/commit/ddf002c0ac03024d317bf1149290aacfe967a4e6) mmdoc: init at 0.9.1
* [`5e06fb88`](https://github.com/NixOS/nixpkgs/commit/5e06fb8879749aa0dfe3fe636aa4824ef8021b72) argocd: 2.2.5 -> 2.3.1
* [`4d0bdd1a`](https://github.com/NixOS/nixpkgs/commit/4d0bdd1a5b70502b1ada2d3240eacf602831bd04) cameradar: 5.0.1 -> 5.0.2
* [`6bbf0863`](https://github.com/NixOS/nixpkgs/commit/6bbf08637bf348caa8e1d2073883cc4d00abc74c) ocamlPackages.markup: 1.0.0 -> 1.0.2
* [`2c2d0b93`](https://github.com/NixOS/nixpkgs/commit/2c2d0b9379c03a68348cb6a7f7f8c94401c753ea) goreleaser: 1.6.3 -> 1.7.0
* [`cb6528f5`](https://github.com/NixOS/nixpkgs/commit/cb6528f5c23cfac57cfd854bcdc4482d07026684) cglm: 0.8.4 -> 0.8.5
* [`fe66cc0d`](https://github.com/NixOS/nixpkgs/commit/fe66cc0d813e67c592f2adceab0955522735cdfc) ocamlPackages.eqaf: 0.7 -> 0.8
* [`0241bed8`](https://github.com/NixOS/nixpkgs/commit/0241bed8f71e684c1476e52487854814c30608a4) dbeaver: 22.0.0 -> 22.0.1
* [`aba19ebf`](https://github.com/NixOS/nixpkgs/commit/aba19ebf98ec6d5ab8536fd3f9d6a220818d2554) python310Packages.youtube-search-python: 1.6.2 -> 1.6.3
* [`2bf2a759`](https://github.com/NixOS/nixpkgs/commit/2bf2a759dbe50d3a40687b34c89b821701ba2086) ocamlPackages.ocamlbuild: 0.14.0 -> 0.14.1
* [`57fefcdf`](https://github.com/NixOS/nixpkgs/commit/57fefcdf60c4b8d021db89c4d9920ad5541451ff) terraform-providers: update 2022-03-21
* [`d36edbd8`](https://github.com/NixOS/nixpkgs/commit/d36edbd8438791052be763a6592aae0c5017472b) python310Packages.pyrogram: 1.4.8 -> 1.4.9
* [`fbac0f4a`](https://github.com/NixOS/nixpkgs/commit/fbac0f4a6d367974be3a8ee015fd403a679a3402) ocamlPackages.asn1-combinators: 0.2.5 -> 0.2.6
* [`f8dfc09c`](https://github.com/NixOS/nixpkgs/commit/f8dfc09c35c5d2a0516892f99c56904d4caba01f) perlPackages.DevelPatchPerl: 2.04 -> 2.08
* [`4f7b4fd2`](https://github.com/NixOS/nixpkgs/commit/4f7b4fd2befdd1720df618ecd6f53e75e05c41b6) ocamlPackages.ocplib-endian: 1.1 -> 1.2
* [`c5e9132f`](https://github.com/NixOS/nixpkgs/commit/c5e9132fbb2089e7b1d4fb5acde6ec272c8019c3) whitesur-icon-theme: 20211108 -> 20220318
* [`75501aff`](https://github.com/NixOS/nixpkgs/commit/75501aff5a660e09fe1328dc8f6b8900fb6c71d3) linuxPackages.lttng-modules: 2.13.1 -> 2.13.2
* [`5037da0d`](https://github.com/NixOS/nixpkgs/commit/5037da0d294d72bdecee7087525e10d552ceda10) ocamlPackages.magic-mime: 1.1.3 -> 1.2.0
* [`fbc9c00e`](https://github.com/NixOS/nixpkgs/commit/fbc9c00e4f5e3fe07b90c95346c8c236d34ca5ed) clash: 1.6.0 -> 1.10.0
* [`a88c8d13`](https://github.com/NixOS/nixpkgs/commit/a88c8d132a905393aefd344718fde02b5e4722c4) python3Packages.youtube-search-python: add format
* [`92a720cb`](https://github.com/NixOS/nixpkgs/commit/92a720cbacbdbbdf4be68eb1d0c2f2b83b226406) ci: add warning to actions with writeable GITHUB_TOKEN
* [`56d2144d`](https://github.com/NixOS/nixpkgs/commit/56d2144d032c0eb2d0793f0131b9cb775ad5e3e0) ocamlPackages.duration: 0.1.3 -> 0.2.0
* [`f10e4f9c`](https://github.com/NixOS/nixpkgs/commit/f10e4f9cdf61aa7ef0a4fe41bf9ec943884961b5) himalaya: 0.5.9 -> 0.5.10
* [`184a2dde`](https://github.com/NixOS/nixpkgs/commit/184a2dde39ae6cc2d938ca8918885cf6321cc968) ocamlPackages.bos: 0.2.0 -> 0.2.1
* [`0e882f0d`](https://github.com/NixOS/nixpkgs/commit/0e882f0d2bdc054aede0e552daa4fa384d24a873) sonobuoy: 0.56.2 -> 0.56.3
* [`6d6543e2`](https://github.com/NixOS/nixpkgs/commit/6d6543e27e90d7e8e3b59cc7f53c7baae30763ac) ungoogled-chromium: 99.0.4844.74 -> 99.0.4844.82
* [`9d0ca608`](https://github.com/NixOS/nixpkgs/commit/9d0ca6083158b5b1d0a1a98549fbd1bf1eac888f) ocamlPackages.psmt2-frontend: 0.3.1 -> 0.4.0
* [`a30cb0ea`](https://github.com/NixOS/nixpkgs/commit/a30cb0ea42f0bb26d20937bf76ffe020aa5b8812) ocamlPackages.gapi_ocaml: 0.4.1 -> 0.4.2
* [`784336e4`](https://github.com/NixOS/nixpkgs/commit/784336e4afab15e15d2ef0fb4b31c8ba8df65469) sky: init at 2.1.7801
* [`1ee6a7ed`](https://github.com/NixOS/nixpkgs/commit/1ee6a7edf163cb07923c6f0d59ac94eab02ede73) php74Extensions.blackfire: 1.74.0 -> 1.75.0
* [`9c8a7b7c`](https://github.com/NixOS/nixpkgs/commit/9c8a7b7c773e5886b3c7ac36dd5c9e21989eb29e) ocamlPackages.bigarray-compat: 1.0.0 -> 1.1.0
* [`3b7e8f9f`](https://github.com/NixOS/nixpkgs/commit/3b7e8f9f7f3723964203a88f4e7d84b0588f23c4) zammad: 5.0.1 -> 5.1.0
* [`86c168a0`](https://github.com/NixOS/nixpkgs/commit/86c168a034b5c70de61dbc54e66d99ec691ac6c3) python310Packages.simplisafe-python: 2022.02.1 -> 2022.03.0
* [`a98ea7e6`](https://github.com/NixOS/nixpkgs/commit/a98ea7e6f8743863aa51385c942ad482ea598707) nix-ld: init at 1.0.0 + nixos module
* [`35eb6cf7`](https://github.com/NixOS/nixpkgs/commit/35eb6cf7119d2ec27d6fe417c266a0152738d36b) nix-ld: mention in changelog
* [`d79779a1`](https://github.com/NixOS/nixpkgs/commit/d79779a1f4512bed1308ede93ada64d2cd450a82) koreader: 2022.02 -> 2022.03
* [`af9f4446`](https://github.com/NixOS/nixpkgs/commit/af9f444698174177e5576a7fa50cd17622915d32) jadx: 1.3.3 -> 1.3.4
* [`397b8257`](https://github.com/NixOS/nixpkgs/commit/397b8257a0f926c518a01dd20d2911945a649743) nixos: systemd-user: fix additionalUpstreamUserUnits description
* [`04efb0c2`](https://github.com/NixOS/nixpkgs/commit/04efb0c252886f790234e001a0babf5fea1c3c76) mastodon: build nodejs modules with fetchYarnDeps
* [`b043c9d5`](https://github.com/NixOS/nixpkgs/commit/b043c9d5f6eb35c345b84271f8bb08baea9f1e98) bcompare: 4.4.0.25886 -> 4.4.2.26348
* [`858e03cf`](https://github.com/NixOS/nixpkgs/commit/858e03cf1f6ccae0c04840bf50120396a6d254b2) golly-beta: remove
* [`bf3e826d`](https://github.com/NixOS/nixpkgs/commit/bf3e826d7c254331be91cbcc6f719b3b3a953fbc) python310Packages.types-protobuf: 3.19.12 -> 3.19.14
* [`52221374`](https://github.com/NixOS/nixpkgs/commit/52221374e5b4f8d2922090b0ff26e390d4016b0b) yuview: init at 2.12.1
* [`eec46660`](https://github.com/NixOS/nixpkgs/commit/eec466609bbd6ec1471bcc861236d0cdcae2e3ff) python3Packages.aioairzone: 0.1.0 -> 0.1.2
* [`7a40437b`](https://github.com/NixOS/nixpkgs/commit/7a40437bddfaedeb4d0300afbc1bb2cbf9081290) write-darwin-bundle: Invert squircle logic
* [`21fe5d3b`](https://github.com/NixOS/nixpkgs/commit/21fe5d3b8b86b16aaf2b7768c99f78a5fa5f0f96) desktopToDarwinBundle: Drop 48x48 size
* [`c3d974e4`](https://github.com/NixOS/nixpkgs/commit/c3d974e44181603e73ec541568c0e8b102cecd0e) desktopToDarwinBundle: Simplify double negation
* [`08a2b83c`](https://github.com/NixOS/nixpkgs/commit/08a2b83c9630fb191022dda93d62cc1c0f9e5aa4) desktopToDarwinBundle: Include TOC in generated ICNS file
* [`6aa5c537`](https://github.com/NixOS/nixpkgs/commit/6aa5c537483e9cc9cbd66ac28fef8800ba306f97) desktopToDarwinBundle: Fall back to scaling available
* [`69af0d17`](https://github.com/NixOS/nixpkgs/commit/69af0d17174ee60f75e6e9f4d74c2152f4e7968e) linuxPackages.virtualboxGuestAdditions: mark broken on Linux 5.17
* [`6d43305b`](https://github.com/NixOS/nixpkgs/commit/6d43305b8987fea18a0c2fe7a5625acd63a57278) linuxPackages.r8168: mark broken on Linux 5.17
* [`fe6c2190`](https://github.com/NixOS/nixpkgs/commit/fe6c2190e8f9d75212104cdf95f84b45b6e33748) linuxPackages.rtl8189es: mark broken on Linux 5.17
* [`2f9822b6`](https://github.com/NixOS/nixpkgs/commit/2f9822b6593444ad55c255068e0f11f673fcd346) linuxPackages.rtl8821ce: mark broken on Linux 5.17
* [`3a06e285`](https://github.com/NixOS/nixpkgs/commit/3a06e285c9ec97a32c8f3fc93cc6dfe0c902f8ed) linuxPackages.openafs: mark broken on Linux 5.17
* [`9eb20012`](https://github.com/NixOS/nixpkgs/commit/9eb200121764dfa8a57acd906dfccf60d760e2fc) mupdf: Patch out which
* [`a149e9b2`](https://github.com/NixOS/nixpkgs/commit/a149e9b220990da7fd97689742597324dcedba71) mupdf: Unbreak build on Darwin
* [`04fc58f3`](https://github.com/NixOS/nixpkgs/commit/04fc58f31d38e2dd5ab556c8b57b08a7dc46ab58) capnproto: regenerate patch with more clear commit message
* [`1eb627c4`](https://github.com/NixOS/nixpkgs/commit/1eb627c4cf62f50b647d2bf287d1ea97e326539f) lib.mkRenamedOptionModuleWith: Remove warnWhenRead
* [`af02076c`](https://github.com/NixOS/nixpkgs/commit/af02076c5bf57c111a789dc7123d7eae5f138b49) driftctl: 0.23.2 -> 0.24.0
* [`aa9a6a22`](https://github.com/NixOS/nixpkgs/commit/aa9a6a22d0729466071d532f1bfc803b4cba1c92) python310Packages.xmlschema: 1.9.2 -> 1.10.0
* [`6aefdafb`](https://github.com/NixOS/nixpkgs/commit/6aefdafbed9309f301d4605519f80b9498b98016) crosvm: 81.12871.0.0-rc1 -> 99.14468.0.0-rc1
* [`43421bc3`](https://github.com/NixOS/nixpkgs/commit/43421bc305cb7602054c0c34f551af835443a3bf) nwipe: 0.32 -> 0.33
* [`e7d335fa`](https://github.com/NixOS/nixpkgs/commit/e7d335fa8b0c4ba46104b0d885bc276365495af1) mupdf: Don't build X11 binaries by default on Darwin
* [`5c4f57cc`](https://github.com/NixOS/nixpkgs/commit/5c4f57cc5720ca7c4a500d6dc672208fe191564a) mupdf: Add Darwin application
* [`23a67050`](https://github.com/NixOS/nixpkgs/commit/23a6705050c85c1479e578d1e0362ad1d1dd028c) steam: do not install mesa drivers
* [`898eba25`](https://github.com/NixOS/nixpkgs/commit/898eba25d20ca336bc41514ecb68d0027d9c4a7c) patroni: 2.0.2 -> 2.1.3
* [`b4c266b8`](https://github.com/NixOS/nixpkgs/commit/b4c266b8e5ebc4b17b9313923fd57d08f1f3f7ed) electron-cash: 4.2.5 -> 4.2.7
* [`66f1f073`](https://github.com/NixOS/nixpkgs/commit/66f1f073c203a39db09fa4c5aaa37c78bd61348b) mupdf: Add patches
* [`1c078c4d`](https://github.com/NixOS/nixpkgs/commit/1c078c4da01cb728c22390caa105415fa73c1522) brook: 20220404 -> 20220406
* [`c16d9b98`](https://github.com/NixOS/nixpkgs/commit/c16d9b98ec63a7715ae1e95bbe28d8dd04f4c3a0) php74Packages.php-cs-fixer: 3.7.0 -> 3.8.0
* [`131ecf27`](https://github.com/NixOS/nixpkgs/commit/131ecf27a6d8d9e836d295b3544f1249f8ad295a) maintainers: add @⁠jmgilman
* [`6c2b7519`](https://github.com/NixOS/nixpkgs/commit/6c2b7519332b6f0e7ed854a46517a4450d5b40f0) youtube-dl: update youtube.com download throttling patch
* [`0341e3d5`](https://github.com/NixOS/nixpkgs/commit/0341e3d535bd0856bd664bfcaa8f16824535d8ba) lwan: indicate jemalloc should be used, or it won't be
* [`5ca30687`](https://github.com/NixOS/nixpkgs/commit/5ca306875ca5e432f074603846826d742c12bd71) lwan: no jemalloc w/musl
* [`16b5d56a`](https://github.com/NixOS/nixpkgs/commit/16b5d56a0839edb621f7e938c84d7008277579f7) headscale: 0.14.0 -> 0.15.0
* [`e225f918`](https://github.com/NixOS/nixpkgs/commit/e225f918838536afbdba7e599ec26e03540e881e) lwan: fix build w/musl, disable PIE
* [`021d10cd`](https://github.com/NixOS/nixpkgs/commit/021d10cde0abcb88a55cfa5d90af581e97104cd0) added fetchFromGitea to docs
* [`fd1b7310`](https://github.com/NixOS/nixpkgs/commit/fd1b7310ab492906b2cb5321102cc677dd469440) pyradio: 0.8.9.15 -> 0.8.9.16
* [`e40e7f5b`](https://github.com/NixOS/nixpkgs/commit/e40e7f5bab09f9cd32f8016a930b8b074d031b0b) prometheus-blackbox-exporter: 0.19.0 -> 0.20.0
* [`b22dba38`](https://github.com/NixOS/nixpkgs/commit/b22dba3859f719d0ac89a49d0db7d5b37fae28e1) qmplay2: 21.12.24 -> 22.03.19
* [`17a43eef`](https://github.com/NixOS/nixpkgs/commit/17a43eefb8c67195e8839da3ddaee448eec2369f) ocamlPackages.ca-certs: 0.2.1 -> 0.2.2
* [`47363ef0`](https://github.com/NixOS/nixpkgs/commit/47363ef04f20560adabc13dddf1bea28afe33dd8) gdb: fix w/musl ([nixos/nixpkgs⁠#164766](https://togithub.com/nixos/nixpkgs/issues/164766))
* [`9d2055cd`](https://github.com/NixOS/nixpkgs/commit/9d2055cd99728f9740fbad99bbd2e2121e6d3262) rslint: 0.3.1 -> 0.3.2
* [`af3e1dae`](https://github.com/NixOS/nixpkgs/commit/af3e1dae6afdb5e398734d28ceafb13b71078115) vnc2flv: remove
* [`7d4c1dad`](https://github.com/NixOS/nixpkgs/commit/7d4c1daddf958b0416ce5a74d92a98f8147ae2e5) desync: 0.9.0 -> 0.9.2
* [`55d462ee`](https://github.com/NixOS/nixpkgs/commit/55d462eea9a0073ab384a085c84ad24300801188) miller: 5.10.3 -> 6.2.0
* [`214be243`](https://github.com/NixOS/nixpkgs/commit/214be243c9c4d2ac1ff1dafeb2a58745186c28ce) polkadot: 0.9.17 -> 0.9.18
* [`4be32826`](https://github.com/NixOS/nixpkgs/commit/4be3282668a9f5f896c9bdf7aeaa5f82090b033a) python3Packages.qtpy: 2.0.0 -> 2.0.1
* [`c3dfe39b`](https://github.com/NixOS/nixpkgs/commit/c3dfe39b617774d14dea3da209c29ce0257fb3c8) psi-plus: 1.5.1600 -> 1.5.1615
* [`c26740fb`](https://github.com/NixOS/nixpkgs/commit/c26740fbcd30e19e81cd5daab14f5ccd14d4a115) openai: 0.15.0 -> 0.16.0
* [`9d237afe`](https://github.com/NixOS/nixpkgs/commit/9d237afebb9363882a30505ed81bbbb8a7090cf6) openai: add python3Packages.wandb dependency
* [`24a68dba`](https://github.com/NixOS/nixpkgs/commit/24a68dba7cbdacc215412195fe0e18b5280cdf98) sqlcheck: 1.2 -> 1.3
* [`26f77209`](https://github.com/NixOS/nixpkgs/commit/26f77209002ddf6f10dd44f5a968b85e0b27c203) Revert "openai: add python3Packages.wandb dependency"
* [`c4527f5b`](https://github.com/NixOS/nixpkgs/commit/c4527f5bd82b93b15e21936c7d00350332baa228) firefox-beta-bin-unwrapped: 98.0b5 -> 99.0b6
* [`42784b3d`](https://github.com/NixOS/nixpkgs/commit/42784b3d20026475933bca01e0cd0f5b6e6c25b8) CODEOWNERS: only include NixOS/systemd and Kloenk
* [`ff37bc39`](https://github.com/NixOS/nixpkgs/commit/ff37bc3937954483d1c269b3c5996fda5b58bb98) firefox-devedition-bin-unwrapped: 98.0b5 -> 99.0b6
* [`56c88689`](https://github.com/NixOS/nixpkgs/commit/56c88689085598c7cbafd4e64c916ca63538dbf6) t-rec: 0.6.0 -> 0.7.3
* [`17eff63e`](https://github.com/NixOS/nixpkgs/commit/17eff63ea4e0f0577a3ee8f6af209a171418b42e) siege: 4.1.1 -> 4.1.2
* [`5c105f92`](https://github.com/NixOS/nixpkgs/commit/5c105f9208ef86b1d64a859d2cfc2804a7ea3082) docs: document Javascript package updates in nixpkgs
* [`85c14e9c`](https://github.com/NixOS/nixpkgs/commit/85c14e9c0f0c12a8c0eb34c899700ecd4270a717) vscode-extensions.matklad.rust-analyzer: 0.2.834 -> 0.2.975
* [`b073d7c1`](https://github.com/NixOS/nixpkgs/commit/b073d7c10c0f33382eaa37d41982ad4bd4c89edb) chromium: 99.0.4844.74 -> 99.0.4844.82
* [`94411d03`](https://github.com/NixOS/nixpkgs/commit/94411d03cc9daa35e7d07724eb7c23c6b0fbd557) wl-color-picker: init at 1.3
* [`3512f5b7`](https://github.com/NixOS/nixpkgs/commit/3512f5b7075c11a3ac24b03b58b45b334a7d2f1b) mailman-web: fix django version check removal
* [`6beb1f8e`](https://github.com/NixOS/nixpkgs/commit/6beb1f8e11f67082a5a11ac538a68d19656f7589) taskwarrior-tui: 0.20.1 -> 0.21.0
* [`c1301304`](https://github.com/NixOS/nixpkgs/commit/c13013049eb1b9f2faed3d41740ccdfa049b9be2) bitbucket-cli: remove
* [`569af342`](https://github.com/NixOS/nixpkgs/commit/569af342ec4b7767f2cd9afc52bd62e252586d98) omnisharp-roslyn: 1.38.0 -> 1.38.1 ([nixos/nixpkgs⁠#164761](https://togithub.com/nixos/nixpkgs/issues/164761))
* [`c1bc8de9`](https://github.com/NixOS/nixpkgs/commit/c1bc8de9e3f174853df69acdc2fa594d34d5417c) nixos-rebuild: Reexec when using flakes
* [`c2789917`](https://github.com/NixOS/nixpkgs/commit/c2789917a6cbbed245a1ab7a517fd919bac112bc) friture: 0.48 -> 0.49 ([nixos/nixpkgs⁠#164475](https://togithub.com/nixos/nixpkgs/issues/164475))
* [`d11083e4`](https://github.com/NixOS/nixpkgs/commit/d11083e401e9ffe792616b4a4cee076b706db6c8) plex: 1.25.6.5577-c8bd13540 -> 1.25.7.5604-980a13e02
* [`10d595ef`](https://github.com/NixOS/nixpkgs/commit/10d595efc191189951aa65a7d854b241e50a2a5b) tpmmanager: fetch tag
* [`cae5a42b`](https://github.com/NixOS/nixpkgs/commit/cae5a42bab00ea822de109dc2d28350d0fbaa225) webbrowser: drop
* [`838f644e`](https://github.com/NixOS/nixpkgs/commit/838f644e91cc422f84608c207e7c2b010493f41c) tree-sitter: update grammars
* [`181d2faf`](https://github.com/NixOS/nixpkgs/commit/181d2fafb54f2ea1be91ace8706bfb6e7c1d4b51) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.3.2 -> 1.4.1
* [`4434f534`](https://github.com/NixOS/nixpkgs/commit/4434f53415dd6aa12e133b1bb50c1b2d660fdec4) nix-output-monitor: 1.1.2.1 -> 1.1.3.0
* [`58ae1175`](https://github.com/NixOS/nixpkgs/commit/58ae11758e853ac307b4cd1032d2f0436a77bc50) linux_latest: 5.16.14 -> 5.17
* [`cf7556ee`](https://github.com/NixOS/nixpkgs/commit/cf7556eea5a1477c87dbb4caf90cb896ec4d6ee8) ccsymbols: init at 2020-04-19
* [`90e83147`](https://github.com/NixOS/nixpkgs/commit/90e831473c469efbc7414db16f7baffdbb538bfc) alda: 2.0.6 -> 2.2.0
* [`eb8b70c0`](https://github.com/NixOS/nixpkgs/commit/eb8b70c020e6693b29634660fa173d7f14f882eb) nixos: Make config.nix.enable pass test
* [`6a0b24b2`](https://github.com/NixOS/nixpkgs/commit/6a0b24b27675d03a7f24c124e6c145076104e869) lib: applyIfFunction -> applyModuleArgsIfFunction
* [`84274cbc`](https://github.com/NixOS/nixpkgs/commit/84274cbc95b370bf8e38430453b48b7017671a8a) lib: Add toFunction
* [`db6e76f5`](https://github.com/NixOS/nixpkgs/commit/db6e76f5246fa843c21bded326e1d0bd363f40ce) nixosTest: Fix invocation
* [`b2d3baa3`](https://github.com/NixOS/nixpkgs/commit/b2d3baa3cf5d8650401d0e4b0d27284e084a1e52) tests.nixos-functions.nixosTest-test: Test callPackage-like behavior
* [`7b01ce8d`](https://github.com/NixOS/nixpkgs/commit/7b01ce8d9c55c3051a3ff3e7750d2c4f6d35daef) minio: 2022-02-26T02-54-46Z -> 2022-03-17T06-34-49Z
* [`92de7613`](https://github.com/NixOS/nixpkgs/commit/92de761336322b9751069cc85d37b00d8bba3609) fend: 0.1.29 -> 1.0.1
* [`a06e3103`](https://github.com/NixOS/nixpkgs/commit/a06e3103b2924ba3939880a38f8724a6b46fec28) fend: fix darwin build by supplying Security framework
* [`a8f938c1`](https://github.com/NixOS/nixpkgs/commit/a8f938c15c84df4bef8e920fac71cd876188fa9e) 1password-gui: 8.5.0 -> 8.6.0
* [`467c3cc4`](https://github.com/NixOS/nixpkgs/commit/467c3cc4cd9ddf546945deb7d6b515f42293adfe) keycloak-discord: fix installPhase
* [`6bf2168e`](https://github.com/NixOS/nixpkgs/commit/6bf2168e2b9be5731e49037bcbbfc7944934e720) scim-for-keycloak: fix mvnHash
* [`3d9818b9`](https://github.com/NixOS/nixpkgs/commit/3d9818b9c79690c972469ab1a318c74cf1d89f3c) Revert "Merge pull request [nixos/nixpkgs⁠#164677](https://togithub.com/nixos/nixpkgs/issues/164677) from lovesegfault/update-cleo"
* [`44cbf461`](https://github.com/NixOS/nixpkgs/commit/44cbf46178e4e91a56cb061b5430ba9c6529e027) python310Packages.pysigma-pipeline-sysmon: 0.1.2 -> 0.1.3
* [`50c32e18`](https://github.com/NixOS/nixpkgs/commit/50c32e180649a98b013f78741b083a996deb848b) amass: 3.17.1 -> 3.18.2
* [`86e74a4b`](https://github.com/NixOS/nixpkgs/commit/86e74a4b9746220dad3d03452aae58c014c61cfa) wp-cli: ensure arguments are sent to wp-cli and not php
* [`6fc40c85`](https://github.com/NixOS/nixpkgs/commit/6fc40c85c4709c70eb57c23701977f1bf94992a1) goldberg-emu: init at 0.2.5
* [`e473e8c2`](https://github.com/NixOS/nixpkgs/commit/e473e8c210d773f27d658cd50cc080ffa5d4e0e0) python310Packages.meshtastic: 1.2.92 -> 1.2.93
* [`8171e0a2`](https://github.com/NixOS/nixpkgs/commit/8171e0a24ebc714937752b1fb74c8f758dd3ab3e) magic-vlsi: 8.3.109 -> 8.3.277
* [`8eb25b61`](https://github.com/NixOS/nixpkgs/commit/8eb25b61d187d7a70bc8e865d70e6c184090a41a) python310Packages.pytest-cases: 3.6.10 -> 3.6.11
* [`812c6acd`](https://github.com/NixOS/nixpkgs/commit/812c6acdfcf323633a95c8015599ffa1dad1886d) buf: 1.1.0 -> 1.1.1
* [`3c8312df`](https://github.com/NixOS/nixpkgs/commit/3c8312dfef1de740c3fd5d6c54d85991faa7ad6f) clojure: 1.10.3.1087 -> 1.10.3.1093
* [`2d4de47b`](https://github.com/NixOS/nixpkgs/commit/2d4de47b3eb617fd5c9f55eda419cae7d0d23ffb) calamares: 3.2.53 -> 3.2.54
* [`3901b149`](https://github.com/NixOS/nixpkgs/commit/3901b14926e1119b2dc46ca3349ca8783a1d0977) munin: switch to python3
* [`a5fddb93`](https://github.com/NixOS/nixpkgs/commit/a5fddb932438dd2f4d65b7bc07dc637751bd84d6) python310Packages.hahomematic: 0.38.2 -> 0.38.4
* [`1ed1d764`](https://github.com/NixOS/nixpkgs/commit/1ed1d764f6c6fbf353fb6a4cd1257230df860ec4) python310Packages.manimpango: 0.4.0.post2 -> 0.4.1
* [`ce32401e`](https://github.com/NixOS/nixpkgs/commit/ce32401ea16e47c8b95b32a2cd45e791a39544ec) tonelib-gfx: 4.7.0 -> 4.7.5
* [`ca835c58`](https://github.com/NixOS/nixpkgs/commit/ca835c58ed2f595a0e1c2161d39b1093d18400ef) tonelib-jam: 4.7.0 -> 4.7.5
* [`0077def6`](https://github.com/NixOS/nixpkgs/commit/0077def6bfec8e0ad22614dc5a1750ca68406f64) maintainers: add BarinovMaxim
* [`d7666997`](https://github.com/NixOS/nixpkgs/commit/d766699779eb86f42b67f1efe5e8d3d2b68e7159) dnsproxy: 0.41.4 -> 0.42.0
* [`a6fd2c46`](https://github.com/NixOS/nixpkgs/commit/a6fd2c461803a50732b6cced19a893804b736211) docker-buildx: 0.8.0 -> 0.8.1
* [`f8f8bc58`](https://github.com/NixOS/nixpkgs/commit/f8f8bc585299fb6670709c4bde671d09d51edc34) docker-slim: 1.37.4 -> 1.37.5
* [`6823f42f`](https://github.com/NixOS/nixpkgs/commit/6823f42f0e9dca19042ab8e96e17225a43cad77b) python310Packages.blinkpy: 0.18.0 -> 0.19.0
* [`0e89355d`](https://github.com/NixOS/nixpkgs/commit/0e89355d0226f299e72cc2253f288bc84d4dd5b7) yandex-browser: 22.1.3.856-1 -> 22.1.3.907-1
* [`c5a6e4a0`](https://github.com/NixOS/nixpkgs/commit/c5a6e4a0fcf5437bc8150c6aae5bf216a9dc622d) bundler: 2.3.6 -> 2.3.9
* [`4a05d363`](https://github.com/NixOS/nixpkgs/commit/4a05d3635613305e34b4e7104764f6dfda18f65a) gitleaks: 8.4.0 -> 8.5.0
* [`054e5b57`](https://github.com/NixOS/nixpkgs/commit/054e5b573bf8629b6fdd8fa1a231ed4648167851) python310Packages.ibm-watson: 5.3.1 -> 6.0.0
* [`51f26666`](https://github.com/NixOS/nixpkgs/commit/51f266661a8a3edc9c172844758e90ae3098bc8a) gofumpt: 0.3.0 -> 0.3.1
* [`038daf71`](https://github.com/NixOS/nixpkgs/commit/038daf71080d535c7e06505c373abec02d74f8b4) gore: 0.5.3 -> 0.5.4
* [`77d8cc83`](https://github.com/NixOS/nixpkgs/commit/77d8cc83dec3e0cce385512bf7db134e9e5389bd) gosec: 2.10.0 -> 2.11.0
* [`0b4b7817`](https://github.com/NixOS/nixpkgs/commit/0b4b78170b2b617b34602175fe9ffb6c7b55b75e) ocamlPackages.enumerate: remove at 111.08.00 (broken with OCaml ≥ 4.02)
* [`308a442f`](https://github.com/NixOS/nixpkgs/commit/308a442f17dd179e352b99db2e9f96e9d3dbcf02) keybase-gui: 5.9.0 → 5.9.3
* [`67a5c031`](https://github.com/NixOS/nixpkgs/commit/67a5c0315730d318ac2a7930810d1240591dc8b0) Revert "palemoon: 29.4.4 -> 30.0.0"
* [`4bbef818`](https://github.com/NixOS/nixpkgs/commit/4bbef818cc1672649caeb2de2985694a7c8edcd4) python3Packages.pyroute2-core: 0.6.8 -> 0.6.9
* [`2a58e670`](https://github.com/NixOS/nixpkgs/commit/2a58e67076c7e0baa536b2853e5432a351667a30) python3Packages.pyroute2-ethtool: 0.6.8 -> 0.6.9
* [`b3131e3c`](https://github.com/NixOS/nixpkgs/commit/b3131e3c7ce92e1ae9c4a12c91c499e89a28e85e) python3Packages.pyroute2-ipdb: 0.6.8 -> 0.6.9
* [`52342467`](https://github.com/NixOS/nixpkgs/commit/52342467719176f5b1c11a88d27e224dd125184d) python3Packages.pyroute2-ndb: 0.6.8 -> 0.6.9
* [`b67d3a0b`](https://github.com/NixOS/nixpkgs/commit/b67d3a0b2cf68f2410e44056d54950e6ad9edd6f) python3Packages.pyroute2-nftables: 0.6.8 -> 0.6.9
* [`f913df13`](https://github.com/NixOS/nixpkgs/commit/f913df13113bbea204a112389a2420b4224f9985) python3Packages.pyroute2-nslink: 0.6.8 -> 0.6.9
* [`74563451`](https://github.com/NixOS/nixpkgs/commit/7456345105782a8dbbe6344b7de1fbe00569bf32) python3Packages.pyroute2-protocols: 0.6.8 -> 0.6.9
* [`6ec5aaf2`](https://github.com/NixOS/nixpkgs/commit/6ec5aaf241dba4954b64789a98b102a50e059e10) python3Packages.pyroute2: 0.6.8 -> 0.6.9
* [`8588c4ac`](https://github.com/NixOS/nixpkgs/commit/8588c4ac1cb2fe0dafd5aebe01f5b1dd7b5d5c2a) python3Packages.pyroute2-ipset: 0.6.8 -> 0.6.9
* [`dfc489e5`](https://github.com/NixOS/nixpkgs/commit/dfc489e510404daf56c5e212a01b09b689d8c95d) pulumi: 3.25.1 -> 3.26.1
* [`283acd12`](https://github.com/NixOS/nixpkgs/commit/283acd12292c8905de453cd4971a340a76e9690f) python3Packages.manimpango: disable on older Python releases
* [`cefc1fc1`](https://github.com/NixOS/nixpkgs/commit/cefc1fc120c8d93fa952fb7224f6afbf99ff9ca9) imgproxy: 3.3.2 -> 3.3.3
* [`24781cfa`](https://github.com/NixOS/nixpkgs/commit/24781cfa0df812ebf1d7c1bd617b49b22e3d57e8) tfsec: 1.2.1 -> 1.13.0
* [`f89439a3`](https://github.com/NixOS/nixpkgs/commit/f89439a30168093ff3cea3d0f87e1956e68eef2b) python310Packages.python-kasa: 0.4.1 -> 0.4.2
* [`bf6c9407`](https://github.com/NixOS/nixpkgs/commit/bf6c94077672a36acd39d2fc53bf0054d1f5e907) python3Packages.pyskyqhub: 0.1.4 -> 0.1.6
* [`f4876014`](https://github.com/NixOS/nixpkgs/commit/f487601491e7ca58870fa0494bb06e701c2a5803) python3Packages.pysigma: 0.4.1 -> 0.4.2
* [`8757379f`](https://github.com/NixOS/nixpkgs/commit/8757379f78c40e119119a815269a8c8fea7c25c3) python3Packages.pysigma-backend-splunk: 0.1.2 -> 0.2.0
* [`006f552a`](https://github.com/NixOS/nixpkgs/commit/006f552af4a93768f9ab487623cf909b127b8229) python3Packages.pyvesync: 1.4.3 -> 2.0.0
* [`b17235e1`](https://github.com/NixOS/nixpkgs/commit/b17235e1e3c9b204f25ccc3a1d28517be61b9fee) mjolnir: 1.3.2 -> 1.4.1
* [`87909ae9`](https://github.com/NixOS/nixpkgs/commit/87909ae9c3499b4a504516524b472fd12cc22c4f) ko: 0.11.1 -> 0.11.2
* [`1dbc26d9`](https://github.com/NixOS/nixpkgs/commit/1dbc26d995026ed943f939800a36abe8e1c3140c) nixos/pipewire: unbreak mixed Pulse/Pipewire setups
* [`2f619d7f`](https://github.com/NixOS/nixpkgs/commit/2f619d7f05e854ba30abd485cd6ba13abc425e12) ocamlPackages.comparelib: remove at 113.00.00
* [`5dbd4b2b`](https://github.com/NixOS/nixpkgs/commit/5dbd4b2b27e24eaed6a79603875493b15b999d4b) ocamlPackages.ocamlscript: 2.0.3 → 3.0.0
* [`ae67ae39`](https://github.com/NixOS/nixpkgs/commit/ae67ae39f8dfca34f6414e3d5d0a579ee14c93c1) juju: 2.9.26 -> 2.9.27
* [`a1a64729`](https://github.com/NixOS/nixpkgs/commit/a1a6472993e44c44c437f6b5004e53289bc8399c) vimPlugins: update
* [`28d840de`](https://github.com/NixOS/nixpkgs/commit/28d840de0e505231122f0a72854a73a45360bde3) grype: 0.34.3 -> 0.34.4
* [`c132d20e`](https://github.com/NixOS/nixpkgs/commit/c132d20ef1f1c0aaf426167f276670c4ef281cce) ktlint: 0.45.0 -> 0.45.1
* [`8a6b3eb5`](https://github.com/NixOS/nixpkgs/commit/8a6b3eb598a3867d0d24461d485bb5c1720c336b) python310Packages.asyncsleepiq: 1.1.2 -> 1.2.0
* [`5e6a9599`](https://github.com/NixOS/nixpkgs/commit/5e6a95991e16ffc7a3d7e57ca8bd69de1f69c5e8) terragrunt: 0.36.2 -> 0.36.6
* [`6175651c`](https://github.com/NixOS/nixpkgs/commit/6175651c4294954b0e7eadd34725de779ff10c7c) python310Packages.azure-mgmt-cdn: 11.0.0 -> 12.0.0
* [`41d45d67`](https://github.com/NixOS/nixpkgs/commit/41d45d674a3460b4984c6e3917f7cf231d0ec386) nixos/ipfs: add systemd hardening
* [`c4016b5b`](https://github.com/NixOS/nixpkgs/commit/c4016b5b8ce20cbf01785fc017f7e37ad925b59c) session-desktop-appimage: 1.7.7 -> 1.7.9
* [`934dd07d`](https://github.com/NixOS/nixpkgs/commit/934dd07de9d14c44fb9fa040e231b6b5ce28865e) sigma-cli: 0.3.2 -> 0.3.3
* [`fa3fed2a`](https://github.com/NixOS/nixpkgs/commit/fa3fed2a3ebde4d8aa22ff1a7200515449b14513) libqb: 2.0.4 -> 2.0.5
* [`cb040db7`](https://github.com/NixOS/nixpkgs/commit/cb040db7ab06db02e9e6544b574ec232c61eceeb) pkgsStatic.gcc: fix build
* [`da450f6b`](https://github.com/NixOS/nixpkgs/commit/da450f6b1d4614ae6d060fa75e99eb5906f18b8d) treewide: clean up obsolete version checks
* [`b2a46c27`](https://github.com/NixOS/nixpkgs/commit/b2a46c270544fc6a2987264fbd92fe724b3b1f2e) python310Packages.catalogue: 2.0.6 -> 2.0.7
* [`11901d89`](https://github.com/NixOS/nixpkgs/commit/11901d89c45423ec6787a37001203f3905fe06d9) dmtcp: 2021-03-01 -> 2022-02-28
* [`6340db62`](https://github.com/NixOS/nixpkgs/commit/6340db62495590ec33b05867cd4654123e70010f) libreoffice-qt: kf5 header files have moved into a subdir
* [`37102b6b`](https://github.com/NixOS/nixpkgs/commit/37102b6bffa5e5efbb021c39f1271cf5c396a6a2) bookworm: 1.1.2 -> unstable-2022-01-09
* [`3031d330`](https://github.com/NixOS/nixpkgs/commit/3031d3308d0a249ed99ed31a9973447a1feab26a) python3Packages.dataclasses-json: 0.5.6 -> 0.5.7
* [`c7b7ad77`](https://github.com/NixOS/nixpkgs/commit/c7b7ad77985e941081dc635d39b5debb0c3155dd) libudev-zero: 1.0.0 -> 1.0.1
* [`052632fd`](https://github.com/NixOS/nixpkgs/commit/052632fd15550d83fe98ed599c8504eaad67f0b5) nixos/iwd: workaround for race condition where wlan device disappears
* [`5b1c414b`](https://github.com/NixOS/nixpkgs/commit/5b1c414be6941eebcf9a63b644f091a6bac2d5dc) python39Packages.sentry-sdk: 1.5.6 -> 1.5.8
* [`9496786b`](https://github.com/NixOS/nixpkgs/commit/9496786b36c435d3424f9f27215d87c75e14ed6e) cfn-nag: init at 0.8.9
* [`084268aa`](https://github.com/NixOS/nixpkgs/commit/084268aab1fdf1e4bbf732acb2c1ab7ae71c159a) python310Packages.pyglet: 1.5.22 -> 1.5.23
* [`6d766ae8`](https://github.com/NixOS/nixpkgs/commit/6d766ae8b7961fb0ca64639d5318dd29cccc3748) nixos/test-driver: deduplicate VLANs
* [`55381a3c`](https://github.com/NixOS/nixpkgs/commit/55381a3ce18de3bc60f38990b5f3c7ddef5e6075) abuild: 3.7.0 -> 3.9.0
* [`8ae47900`](https://github.com/NixOS/nixpkgs/commit/8ae47900166db91ce816bfa769ce930910bb2b5e) nuclei: 2.6.3 -> 2.6.5
* [`216b4f18`](https://github.com/NixOS/nixpkgs/commit/216b4f181379ad704b6102eef4ad36b4a18b2d30) ocenaudio: 3.11.5 -> 3.11.7
* [`b4c2ffaf`](https://github.com/NixOS/nixpkgs/commit/b4c2ffaffa600ffce2121e21f65641ec92955781)  nixos/wg-quick: add autostart option to interfaces ([nixos/nixpkgs⁠#162219](https://togithub.com/nixos/nixpkgs/issues/162219))
* [`deab83e1`](https://github.com/NixOS/nixpkgs/commit/deab83e11674f1cfbc9d5e5626d12ed9344d8091) cgit-pink: init at 1.3.0
* [`788b69df`](https://github.com/NixOS/nixpkgs/commit/788b69dfe731adca6fece863d151792af0f7fa0a) python310Packages.docplex: 2.22.213 -> 2.23.222
* [`168bdc3c`](https://github.com/NixOS/nixpkgs/commit/168bdc3c7d124a0b638c4648df5fa252d384f44b) u9fs: fix man page location
* [`fd02a092`](https://github.com/NixOS/nixpkgs/commit/fd02a092d28cfc9179dd43b5296d2a1e003def38) u9fs: use install(1) for copying files
* [`9ff032c2`](https://github.com/NixOS/nixpkgs/commit/9ff032c2918ada79edf6598220ae4a9ff43a3462) simgrid: 3.30 -> 3.31
* [`086c5106`](https://github.com/NixOS/nixpkgs/commit/086c5106d1bc351caac49e8a40bb99b16182823c) u9fs: unstable-2020-11-21 -> unstable-2021-25
* [`4ceb138f`](https://github.com/NixOS/nixpkgs/commit/4ceb138f4b77e6ad5e15c372a895981d285bd5a8) haskellPackages.HaskellNet-SSL: mark unbroken
* [`cb4c1ec8`](https://github.com/NixOS/nixpkgs/commit/cb4c1ec8aa633d64dcfca8b15ebc70addc892189) remind: 03.04.01 -> 03.04.02
* [`699c3005`](https://github.com/NixOS/nixpkgs/commit/699c30056b6f278077fe21aad3d7f7336a7cc783) gitlab-runner: 14.8.2 -> 14.9.0
* [`de096b7c`](https://github.com/NixOS/nixpkgs/commit/de096b7c8331acfea75f4d97717e25a1cd03c721) isso: 0.12.5 -> 0.12.6.1
* [`23b9ad34`](https://github.com/NixOS/nixpkgs/commit/23b9ad346a30b89b4e080b0a062700a305a99851) exploitdb: 2022-03-15 -> 2022-03-22
* [`1a889c09`](https://github.com/NixOS/nixpkgs/commit/1a889c097be3e0778983de446173d822be5c0634) ucx: 1.12.0 -> 1.12.1
* [`c60647f5`](https://github.com/NixOS/nixpkgs/commit/c60647f50bf00af087e411a2891ce132883d6b1c) pr-tracker: 1.1.0 -> 1.2.0
* [`bb82344c`](https://github.com/NixOS/nixpkgs/commit/bb82344ca6925b1b4e4a7de9465016ba40904fc3) python3Packages.zipstream-ng: init at 1.3.4
* [`9e533703`](https://github.com/NixOS/nixpkgs/commit/9e53370359f669ccad1f3ed569dae57fd39ac600) matrix-synapse: 1.54.0 -> 1.55.0
* [`a68d71c7`](https://github.com/NixOS/nixpkgs/commit/a68d71c775bed051dec17028ff85c63beebeaa6f) fq: 0.0.4 -> 0.0.6
* [`be37c9a4`](https://github.com/NixOS/nixpkgs/commit/be37c9a4e1466e9e1610c83ab201279a31325f50) graphite-gtk-theme: add update script
* [`5af555af`](https://github.com/NixOS/nixpkgs/commit/5af555af48164cf4d0b8326468c7d5a499b00e4f) graphite-gtk-theme: unstable-2022-02-04 -> 2022-03-22
* [`de4a69b2`](https://github.com/NixOS/nixpkgs/commit/de4a69b2de1f157989fb1780d89d8db004169bd1) nixos/tests/avahi: Fix running background command
* [`d6f50a5c`](https://github.com/NixOS/nixpkgs/commit/d6f50a5c8ec3ed386531011027a56908829f7124) keycloak: fix a missing newline when using plugins
* [`826febf7`](https://github.com/NixOS/nixpkgs/commit/826febf74f022d51ec6c539b05259e9eb2611df9) qgis-ltr: 3.22.4 -> 3.22.5
* [`fd620c8d`](https://github.com/NixOS/nixpkgs/commit/fd620c8da1ac24f3dc4366a01d9570e87ffac16e) qgis: 3.24.0 -> 3.24.1
* [`488869f6`](https://github.com/NixOS/nixpkgs/commit/488869f602eea53e3fe08c89bdb655811877cde0) nixos-rebuild: support --quiet, --print-build-logs
* [`d3a855b9`](https://github.com/NixOS/nixpkgs/commit/d3a855b9b000ced9f5f8ffed8d4eb957a6c5a4ce) stunnel: 5.62 -> 5.63
* [`c7172046`](https://github.com/NixOS/nixpkgs/commit/c7172046c7aa28bce8ce3f024d74518669cedfbe) nixos-rebuild: add meta & add Profpatsch as maintainer
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
