### PR TITLE
niv emacs-overlay: update 023ce0b1 -> a162b8f8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "023ce0b1e29732c6d26a380ad5dc8298c298f99b",
-        "sha256": "0s4n5y3xcnnv1a68a6vdaarnndiimzsjids94qhrfvqq4izihdz8",
+        "rev": "a162b8f8420c640d78b7ef3ab9d49197666f309a",
+        "sha256": "09fvjypxivh8l9g3qx6z55dcsfccf7clrv8q54slpxqfifv0dp55",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/023ce0b1e29732c6d26a380ad5dc8298c298f99b.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/a162b8f8420c640d78b7ef3ab9d49197666f309a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@023ce0b1...a162b8f8](https://github.com/nix-community/emacs-overlay/compare/023ce0b1e29732c6d26a380ad5dc8298c298f99b...a162b8f8420c640d78b7ef3ab9d49197666f309a)

* [`cb7373b0`](https://github.com/nix-community/emacs-overlay/commit/cb7373b0475e5b8fa6315433b719d2ddb3d02027) rename emacPackagesNgGen to emacsPackagesFor
* [`dc9da411`](https://github.com/nix-community/emacs-overlay/commit/dc9da411e35c896dd57acd7a1a20bc0c3f85d811) rename old alias "emacsPackagesNg" to "emacsPackages"
* [`6d9fd817`](https://github.com/nix-community/emacs-overlay/commit/6d9fd817e8f2606df8a5afc138b840c9dc7184f3) Updated repos/melpa
* [`c9cc3ca3`](https://github.com/nix-community/emacs-overlay/commit/c9cc3ca3cb0d7137ae82a77edd38d5819139db7c) Updated repos/emacs
* [`c8b35e15`](https://github.com/nix-community/emacs-overlay/commit/c8b35e15514632cc242875f0c8f23beffde3b9f2) Updated repos/melpa
* [`2ae488bd`](https://github.com/nix-community/emacs-overlay/commit/2ae488bd969f0e8302a655117adfd3820df7110b) Updated repos/elpa
* [`c3d2e8da`](https://github.com/nix-community/emacs-overlay/commit/c3d2e8da65a3290858d1c94c7f47b3e1b7d81a42) Updated repos/emacs
* [`41b030ae`](https://github.com/nix-community/emacs-overlay/commit/41b030aed1fe36edb73cf80e3215acdaef394fe3) Updated repos/melpa
* [`a7333c3b`](https://github.com/nix-community/emacs-overlay/commit/a7333c3b26f715f7cf226aed82ab4add85a2ddd5) Updated repos/emacs
* [`71a57f5f`](https://github.com/nix-community/emacs-overlay/commit/71a57f5f916b6b80eb64f8f4a1e1c46ee857639b) Updated repos/melpa
* [`27e4cb7f`](https://github.com/nix-community/emacs-overlay/commit/27e4cb7f90a5e7b4d4c59cfdd87024aef992c0de) Updated repos/emacs
* [`f5921747`](https://github.com/nix-community/emacs-overlay/commit/f592174794d3bc90df3b83671541dae2642c23ff) Updated repos/melpa
* [`273d9f8d`](https://github.com/nix-community/emacs-overlay/commit/273d9f8d2c8a89dbae82a04d581ea7dcf3b847b0) Updated repos/elpa
* [`7ec5b333`](https://github.com/nix-community/emacs-overlay/commit/7ec5b333d3c534fe18a23db0dc0958a4dbf738ef) Updated repos/emacs
* [`c0f04f62`](https://github.com/nix-community/emacs-overlay/commit/c0f04f623ea142862dfc02bbda18a0685bb42e39) Updated repos/melpa
* [`f54b5753`](https://github.com/nix-community/emacs-overlay/commit/f54b5753720af298f5d9c9543dd0f07d32983e66) Updated repos/melpa
* [`a8ebde25`](https://github.com/nix-community/emacs-overlay/commit/a8ebde25f295b1b9904e61976ea7c464c981d467) Updated repos/nongnu
* [`13b62a60`](https://github.com/nix-community/emacs-overlay/commit/13b62a606d60f3093b403e3f73a12290e043fdbd) Updated repos/emacs
* [`b5166130`](https://github.com/nix-community/emacs-overlay/commit/b5166130a4b97a9f07e8d94e5c86cc30a467570c) Updated repos/melpa
* [`136ad542`](https://github.com/nix-community/emacs-overlay/commit/136ad542eb46f06e55fe03616455bccabd41c80f) Updated repos/elpa
* [`f9da699f`](https://github.com/nix-community/emacs-overlay/commit/f9da699f14c266876d046e5f057ce27214be2bbd) Updated repos/emacs
* [`357854a2`](https://github.com/nix-community/emacs-overlay/commit/357854a2d9c95c0212cf385a3ab9612fd272fba9) Updated repos/exwm
* [`c5e33a70`](https://github.com/nix-community/emacs-overlay/commit/c5e33a703a354af02481e2affc1f5155b867cc94) Updated repos/melpa
* [`17ca81a8`](https://github.com/nix-community/emacs-overlay/commit/17ca81a89cd97ee44c8ffd605e7a59158b676706) Updated repos/emacs
* [`7cf52c48`](https://github.com/nix-community/emacs-overlay/commit/7cf52c48e5130cdffedc60ab588e90ce3eea4417) Updated repos/melpa
* [`5fe70a14`](https://github.com/nix-community/emacs-overlay/commit/5fe70a1438ca56f39a0c011bfb4d28c167a37f50) Updated repos/elpa
* [`6f36a65e`](https://github.com/nix-community/emacs-overlay/commit/6f36a65e31517b682a6f229006da2c179fdcc935) Updated repos/emacs
* [`290037a1`](https://github.com/nix-community/emacs-overlay/commit/290037a17d773073bd4237f92732f850c7b9a160) Updated repos/melpa
* [`025dfffa`](https://github.com/nix-community/emacs-overlay/commit/025dfffacfcfdeacf1c260ccf5415bdb77510ddd) Updated repos/elpa
* [`91440215`](https://github.com/nix-community/emacs-overlay/commit/91440215ef3fcacf6da2c18cf4611223dac69043) Updated repos/emacs
* [`8c3bfcbd`](https://github.com/nix-community/emacs-overlay/commit/8c3bfcbd7076d60c8988bbffcca2403676367acf) Updated repos/melpa
* [`38615649`](https://github.com/nix-community/emacs-overlay/commit/38615649d290050b765a571773dcc1ed4cb0d657) Updated repos/emacs
* [`adf05412`](https://github.com/nix-community/emacs-overlay/commit/adf05412cca0a492c2465ac5de719954834c449e) Updated repos/melpa
* [`e857df98`](https://github.com/nix-community/emacs-overlay/commit/e857df9805b9cfbcb0220c6755f1ace70ce3238f) Updated repos/emacs
* [`c8935bf5`](https://github.com/nix-community/emacs-overlay/commit/c8935bf513b963a10b35ad0e5370b063d09127ea) Updated repos/melpa
* [`edfee102`](https://github.com/nix-community/emacs-overlay/commit/edfee102d855ad0dcbf59ed0980e4bc5f53d2597) Updated repos/emacs
* [`38176a2c`](https://github.com/nix-community/emacs-overlay/commit/38176a2cc6c208a1b3c04fcfc1cd0c5a4b1b2379) Updated repos/melpa
* [`b4ad3c27`](https://github.com/nix-community/emacs-overlay/commit/b4ad3c273fd87bb49deb1d1e06110328edb4c3a7) Updated repos/emacs
* [`50325b2b`](https://github.com/nix-community/emacs-overlay/commit/50325b2b5aacadf03abc9c6d81083601a8d9d99e) Updated repos/melpa
* [`c8d5830b`](https://github.com/nix-community/emacs-overlay/commit/c8d5830b14db96c231fb02d39cc394c915ab2a0a) Updated repos/elpa
* [`bd6a61aa`](https://github.com/nix-community/emacs-overlay/commit/bd6a61aa567fee1d667a01e6c5856fa28dd4b67f) Updated repos/emacs
* [`fdafbede`](https://github.com/nix-community/emacs-overlay/commit/fdafbede17265f56e3df5382442a8c41069e0994) Updated repos/melpa
* [`7a5bed24`](https://github.com/nix-community/emacs-overlay/commit/7a5bed243912859fb465701d041422344b492287) Updated repos/emacs
* [`681dd447`](https://github.com/nix-community/emacs-overlay/commit/681dd44788dabb4723c9f0f93b1aed8759ad7152) Updated repos/melpa
* [`30fb1b5c`](https://github.com/nix-community/emacs-overlay/commit/30fb1b5cd8218c4fe92c69489e4c7c4ff5b4facd) Updated repos/emacs
* [`cb5bae9a`](https://github.com/nix-community/emacs-overlay/commit/cb5bae9a90139ea872ce8ba5c3efd5d619e85975) Updated repos/melpa
* [`c0719fd6`](https://github.com/nix-community/emacs-overlay/commit/c0719fd6934c30af83d961ddf6d0f3bea0909237) Updated repos/melpa
* [`a279ff3b`](https://github.com/nix-community/emacs-overlay/commit/a279ff3b5762e62cf5af2418dcdf24bfccf0c5ae) Updated repos/elpa
* [`a162b8f8`](https://github.com/nix-community/emacs-overlay/commit/a162b8f8420c640d78b7ef3ab9d49197666f309a) Updated repos/melpa
