### PR TITLE
niv spacemacs: update 18ad9759 -> c2a9aaed

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "18ad9759b29a56ba92fe452b62dd545329175b63",
-        "sha256": "0sl02d5l6yxdlb62fwfdj59wqmmcj4irlvszg3gz0lpq0xz9jl82",
+        "rev": "c2a9aaedffdebb511651e0e2299fc0282521ee73",
+        "sha256": "0yxkd24a23bzjpi5653z5zrhhk0w4lj8dw19z9a3x0ycs97a8c5f",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/18ad9759b29a56ba92fe452b62dd545329175b63.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/c2a9aaedffdebb511651e0e2299fc0282521ee73.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@18ad9759...c2a9aaed](https://github.com/syl20bnr/spacemacs/compare/18ad9759b29a56ba92fe452b62dd545329175b63...c2a9aaedffdebb511651e0e2299fc0282521ee73)

* [`bf64c095`](https://github.com/syl20bnr/spacemacs/commit/bf64c09535c5a226ddc8366a75674451120aa04b) [org] Make org buffers work with helm-imenu-in-all-buffers
* [`cb786cc0`](https://github.com/syl20bnr/spacemacs/commit/cb786cc0711e0b23790185ef79012812dcfbe768) [github] clarify Git configuration and authorisation documentation
* [`c2a9aaed`](https://github.com/syl20bnr/spacemacs/commit/c2a9aaedffdebb511651e0e2299fc0282521ee73) [bot] "documentation_updates" Mon Mar 28 11:29:34 UTC 2022 ([syl20bnr/spacemacs⁠#15433](https://togithub.com/syl20bnr/spacemacs/issues/15433))
