### PR TITLE
niv nixpkgs: update 609816b0 -> ed3074e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "609816b0cec57b379c4e72abe0869511cf4fd582",
-        "sha256": "0fvi4f1yq7gjm50rs3s9ppknl9c4kj162x8h548j7ayrxw6q39wm",
+        "rev": "ed3074e07b5ef19b7148aa1a73e1a0afa73ed40c",
+        "sha256": "0dz5g1vii2v6r5293akhi681c36kjqynmh2h7xzk6nc705c5h0sy",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/609816b0cec57b379c4e72abe0869511cf4fd582.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ed3074e07b5ef19b7148aa1a73e1a0afa73ed40c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@609816b0...ed3074e0](https://github.com/nixos/nixpkgs/compare/609816b0cec57b379c4e72abe0869511cf4fd582...ed3074e07b5ef19b7148aa1a73e1a0afa73ed40c)

* [`cfb06016`](https://github.com/NixOS/nixpkgs/commit/cfb06016e80ee46b642008d1a6b353127124c022) nixos/availableKernelModules: add cherry hid
* [`146961e8`](https://github.com/NixOS/nixpkgs/commit/146961e814c22e9cbfaaa6a75c278efb90e664f0) nixos/adb: switch to android-tools built from source
* [`e2a8e450`](https://github.com/NixOS/nixpkgs/commit/e2a8e4505f40338345a04ee73a14e4cf14f1cbd2) jupyter: Create jupyter user as system user
* [`52b52c1a`](https://github.com/NixOS/nixpkgs/commit/52b52c1abd9cd0e728fd357bae63c303c2f2049f) emscripten: 2.0.27 -> 3.0.0
* [`f676d119`](https://github.com/NixOS/nixpkgs/commit/f676d1192e3516a6612564b833c97b15c6c4b307) whitebophir: pin to nodejs-14_x to unbreak the build
* [`edd46c86`](https://github.com/NixOS/nixpkgs/commit/edd46c86115dd4ef94ba8b1984cb0b27e251de86) whitebophir: 1.16.0 -> 1.17.0
* [`c74d7847`](https://github.com/NixOS/nixpkgs/commit/c74d784771c9cee62bfd85b302f4568894df291e) network-interfaces: use altered interface name for setting use_tempaddr
* [`3f70d033`](https://github.com/NixOS/nixpkgs/commit/3f70d03369ae6bda65162613d0c6b61c75d5df27) haskell.packages.ghc902.aeson-diff: Fix build by jailbreaking
* [`d9ffac48`](https://github.com/NixOS/nixpkgs/commit/d9ffac48121b92df78cf6d59dba666ad7c222905) haskell.packages.ghc921.aeson-diff: Fix build by jailbreaking
* [`423ad109`](https://github.com/NixOS/nixpkgs/commit/423ad1094e27f953301ea2219c2ab535afcc850c) liberation-circuit: 1.3 -> unstable-2022-01-02
* [`b5489b75`](https://github.com/NixOS/nixpkgs/commit/b5489b75ee41e1e053e08193d3c68046b2cf574f) haskellPackages: Stackage LTS 18.25 -> Stackage Nightly 2022-02-07
* [`19bdc1a4`](https://github.com/NixOS/nixpkgs/commit/19bdc1a4abe1c099a82e18202cc8c142d033e860) all-cabal-hashes: 2022-02-14T17:17:31Z -> 2022-02-17T20:36:23Z
* [`b925f649`](https://github.com/NixOS/nixpkgs/commit/b925f64911b906e2cd50dbc47a9adb5d8e8ad829) haskellPackages.ghc: 8.10.7 -> 9.0.2
* [`32abf399`](https://github.com/NixOS/nixpkgs/commit/32abf39913f5d0dc24055b7b7bf73376815fd592) haskellPackages: match default GHC version 9.0.2 in hackage2nix conf
* [`cd67b4fc`](https://github.com/NixOS/nixpkgs/commit/cd67b4fcbb81d07477746a138d6dbb9d01a81450) haskellPackages: regenerate package set based on current config
* [`7b1e2a22`](https://github.com/NixOS/nixpkgs/commit/7b1e2a2277fabf5a14678892bd5c9d7cce3feb59) haskell.packages.ghc8107: pick correct versions of GHC-specific pkgs
* [`65454750`](https://github.com/NixOS/nixpkgs/commit/65454750ce601c232b78c1c67bec214d8e01bb35) haskellPackages: fix evaluation with stackage nightly 2022-02-17
* [`104c152f`](https://github.com/NixOS/nixpkgs/commit/104c152fd72bafd6a4d2b08c8cfb1dfabc672750) haskellPackages.libyaml-streamly: remove broken flag
* [`4b20fd57`](https://github.com/NixOS/nixpkgs/commit/4b20fd57a9116e006919a9821678dec56ce79c1a) release-haskell.nix: test GHC-specific packages for all package sets
* [`36613295`](https://github.com/NixOS/nixpkgs/commit/36613295ab51b498208b261fabfc6470430398a9) haskellPackages.hw-*: adjust overrides for Stackage Nightly
* [`bf8bd354`](https://github.com/NixOS/nixpkgs/commit/bf8bd354dd2ac363a7ac09b9bd4ffa7335d52b23) haskellPackages.tasty-discover: fix build with tasty-hspec >= 1.2
* [`b80b106e`](https://github.com/NixOS/nixpkgs/commit/b80b106e432cf0744c822db313442a9740b0acce) haskellPackages.vinyl: fix build with aeson 2.0
* [`5c971a17`](https://github.com/NixOS/nixpkgs/commit/5c971a179d9a2494811354817d19da239bacb971) haskellPackages.fgl*: allow newer hspec
* [`e95f451e`](https://github.com/NixOS/nixpkgs/commit/e95f451ea65835805c018cdde69f06f2ee7a2899) haskell.packages.ghc921: fix eval for Stackage Nightly 2022-02-17
* [`600b5f43`](https://github.com/NixOS/nixpkgs/commit/600b5f43f006faf8ee3671d8fe49a533bfea1e39) haskellPackages.linear-base: work around upstream's broken Setup.hs
* [`c0a7ad5c`](https://github.com/NixOS/nixpkgs/commit/c0a7ad5c71ef17efb67302877f4f25c53fa0bbe0) haskellPackages.hslua-module-version: remove broken flag
* [`6f0d0525`](https://github.com/NixOS/nixpkgs/commit/6f0d05253138c71df84c038a65ddabf1b0fa2f66) haskellPackages.singleton-th: remove broken flag
* [`a2b1f8b4`](https://github.com/NixOS/nixpkgs/commit/a2b1f8b47c9a7a33b743daef47251c69d4a6f2e6) haskellPackages.th-lego: remove broken flag
* [`fe3228ed`](https://github.com/NixOS/nixpkgs/commit/fe3228edbdc84bc4d00612841bda42456c1e59dc) haskellPackages.comfort*: remove broken flag
* [`0b193ee9`](https://github.com/NixOS/nixpkgs/commit/0b193ee953c96267fe49cf9455a6c6545e47dc02) haskellPackages.pandoc-lua-marshal: remove broken flag
* [`3f7a1c05`](https://github.com/NixOS/nixpkgs/commit/3f7a1c05f1d2cb9568609aa54576bb926da8e1e2) haskellPackages.acc: remove broken flag
* [`97c9a698`](https://github.com/NixOS/nixpkgs/commit/97c9a698d1fa8015d23ba341edfb6783d686395f) carp: work around new GHC warning breaking the build
* [`d9cbb54b`](https://github.com/NixOS/nixpkgs/commit/d9cbb54b1f412ba8f9304c40abc9c68481c51301) haskellPackages.regex-compat-tdfa: fix build with GHC >= 9.0
* [`3f9aa37a`](https://github.com/NixOS/nixpkgs/commit/3f9aa37aa25877804d57223d8fa5898946370cca) haskellPackages.aws: patch for aeson 2.0 compatibility
* [`b0c61276`](https://github.com/NixOS/nixpkgs/commit/b0c612766821c65eaa9a9f296547acef9a63755e) pandoc: drop obsolete patch
* [`0e233d7a`](https://github.com/NixOS/nixpkgs/commit/0e233d7a632b00a5015514924a81d0b23cdb2d69) haskellPackages.hnix-store-core: allow algebraic-graphs 0.6
* [`35aff43a`](https://github.com/NixOS/nixpkgs/commit/35aff43aba867bf234642a6a019bf927d7b0c0ae) haskellPackages.csv: work around ill conceived Setup.hs
* [`18dc2c6f`](https://github.com/NixOS/nixpkgs/commit/18dc2c6f68246efb272b3411c2060f6eb271df7e) haskellPackages.hledger-lib: drop obsolete patch
* [`a95dcb87`](https://github.com/NixOS/nixpkgs/commit/a95dcb8778b5147e3e04082104721f65e6d77711) haskellPackages.polysemy: drop obsolete patch
* [`92780973`](https://github.com/NixOS/nixpkgs/commit/927809735d0bf7b96071c6b3fc8e5d1108123b5e) haskellPackages.tree-sitter: allow template-haskell 2.17
* [`b68dc536`](https://github.com/NixOS/nixpkgs/commit/b68dc5365f65312edcc16a3de2854d891de8c757) haskellPackages.composite-base: patch for template-haskell 2.17
* [`7e831131`](https://github.com/NixOS/nixpkgs/commit/7e8311311e20dfcb6529f6645551fced269e33e3) haskellPackages.protolude: fix build with GHC 9.0
* [`2dde9a30`](https://github.com/NixOS/nixpkgs/commit/2dde9a3002cd32f1e0c8a1084450ea74be25279c) haskellPackages.HTF: disable test suite incompatible with aeson 2.0
* [`a826da2d`](https://github.com/NixOS/nixpkgs/commit/a826da2d945fbef447d3c56e3ceac412eb3b7b8e) haskellPackages.flat: fix build with GHC 9.0
* [`c90db6bd`](https://github.com/NixOS/nixpkgs/commit/c90db6bd1fe899650452fc0f0a7140ffa5f2893a) haskellPackages.graphviz: allow hspec 2.8.5
* [`a62bfb18`](https://github.com/NixOS/nixpkgs/commit/a62bfb18cc1db491d365cc64f903940ea24b9ccd) haskellPackages: clean up accidentally commited override
* [`97ad10cf`](https://github.com/NixOS/nixpkgs/commit/97ad10cfcc34db25006fc3736bde12a719f432aa) haskellPackages.system-fileio: allow chell >= 0.5
* [`dd0c4562`](https://github.com/NixOS/nixpkgs/commit/dd0c4562f9f049d06df21a49bbdc034ef2d26d6a) haskellPackages.xmonad: use appropriate patch for >= 0.17
* [`4fdc933f`](https://github.com/NixOS/nixpkgs/commit/4fdc933fe5dc766a7e3be1b16367d7f63fa959c5) haskellPackages.heterocephalus: patch for GHC 9.0
* [`b32a80d9`](https://github.com/NixOS/nixpkgs/commit/b32a80d9ecdf28d53c569299207af2722f6edb03) haskellPackages.ShellCheck: drop obsolete patch
* [`e117482c`](https://github.com/NixOS/nixpkgs/commit/e117482cd4e4a282c57474953e83dec2aa3619e2) haskellPackages.Spock-core: patch for GHC 9.0 support
* [`8a54680c`](https://github.com/NixOS/nixpkgs/commit/8a54680cf2d35ea9e0ab1649e574bac4a32b02b2) haskellPackages.Spock: unbreak
* [`46f0cc56`](https://github.com/NixOS/nixpkgs/commit/46f0cc56db6df674a541b601160b9d40b6ee3e31) haskellPackages.haskell-ci: provide ShellCheck 0.7.2 again
* [`bef56cfb`](https://github.com/NixOS/nixpkgs/commit/bef56cfb09ad66113e77b6ea314bc86dd3ad43ae) haskellPackages.filtrable: allow tasty 1.4
* [`38b125a5`](https://github.com/NixOS/nixpkgs/commit/38b125a59dbf77ba77dbbbd737434b1b71448bf7) haskellPackages: Drop a lot of unnecessary overrides
* [`77b623d5`](https://github.com/NixOS/nixpkgs/commit/77b623d5a2b4990e00f0e781beb5a1fb1f7265e7) haskell-language-server: Fix build
* [`99568d7f`](https://github.com/NixOS/nixpkgs/commit/99568d7fe05fb24929280690b96d396ae176dc78) haskell.packages.ghc902.weeder: fix eval
* [`7c8a8301`](https://github.com/NixOS/nixpkgs/commit/7c8a83016e4ee480ca4860fc8635a744a20b9ea8) haskellPackages.futhark-manifest: remove broken flag
* [`a83b0c71`](https://github.com/NixOS/nixpkgs/commit/a83b0c7150e49bb6cbfd95228fd804ae0134aef5) xwayland: 21.4.0 -> 22.1.0
* [`eee13b46`](https://github.com/NixOS/nixpkgs/commit/eee13b46f660fff1baacb6d3fc36b0705fd43406) haskellPackages: drop obsolete attributes
* [`d84b322b`](https://github.com/NixOS/nixpkgs/commit/d84b322b5fdc3089f365db05d7cbc5a337112b1b) haskell.packages.ghc8107.weeder: use weeder 2.2.0
* [`c6775848`](https://github.com/NixOS/nixpkgs/commit/c67758484f85a677c346af2fdbdb5d03e92cd2b5) nixos/factorio: add bind address option
* [`f1c0cd36`](https://github.com/NixOS/nixpkgs/commit/f1c0cd368db7ade149a574e8ae226214645c21ff) maintainers: add zanculmarktum
* [`0f118596`](https://github.com/NixOS/nixpkgs/commit/0f11859679048f3c5183664a6ddba0ba42d0d7fb) maintainers: add kuwii
* [`1574ea27`](https://github.com/NixOS/nixpkgs/commit/1574ea2719e7090594d518070c9b743efc6b6e37) microsoft-edge: init at 98.0.1108.56
* [`05232c1b`](https://github.com/NixOS/nixpkgs/commit/05232c1b7ad6c78424cabda4571336a45410abc3) all-cabal-hashes: 2022-02-17T20:36:23Z -> 2022-02-22T04:07:26Z
* [`29850ac0`](https://github.com/NixOS/nixpkgs/commit/29850ac05ed3685cc357dee501926db9a73eb8c3) haskellPackages: stackage-nightly 2022-02-17 -> 2022-02-19
* [`3f805e76`](https://github.com/NixOS/nixpkgs/commit/3f805e76904ed7b293332b97ca8f23fe3fdb9e93) haskellPackages: regenerate package set based on current config
* [`759631e2`](https://github.com/NixOS/nixpkgs/commit/759631e28b80b6c4f6254781b708c2bf07a4c0cf) haskellPackages.heterocephalus: drop obsolete override
* [`22c75b75`](https://github.com/NixOS/nixpkgs/commit/22c75b75c56da9f4e625e15587aae2efc784ec0d) haskellPackages.xdot: Apply patch bumping upper bound on base
* [`bfc0a60a`](https://github.com/NixOS/nixpkgs/commit/bfc0a60a24f5345f34736228c13c6579d45268f6) haskellPackages.servant-swagger-ui-core: jailbreak to fix the build
* [`6d84e807`](https://github.com/NixOS/nixpkgs/commit/6d84e807412c9c223657053af69fd6a2d608f9b9) gemConfig update for exiv and maxmind
* [`058cbf42`](https://github.com/NixOS/nixpkgs/commit/058cbf42eb309763418d10882ce004cc7215968a) stack: add cdepillabout as maintainer
* [`bac88bf4`](https://github.com/NixOS/nixpkgs/commit/bac88bf4db40ba49a4eafe167d7ab7e2e4c3bd43) haskellPackages.aeson: re-enable tests
* [`48b46658`](https://github.com/NixOS/nixpkgs/commit/48b466586313df6fdf391da51e4006721e1d92f5) haskellPackages.aeson_1_5_6_0: generate this package
* [`6b03b385`](https://github.com/NixOS/nixpkgs/commit/6b03b385a97c0caf27ad84eaa0d183be46e15bbe) haskell.packages.ghc8107.pantry_0_5_2_1: add package
* [`05f768bc`](https://github.com/NixOS/nixpkgs/commit/05f768bc9e61de5852a64b2f51918d5971ee8cd9) stack: switch to building with ghc8107
* [`3c22208d`](https://github.com/NixOS/nixpkgs/commit/3c22208dc9b4f9790d333f40f4736c4d1a101f46) haskellPackages.fakedata: Re-enable test suite
* [`376a511e`](https://github.com/NixOS/nixpkgs/commit/376a511e0997247b8d3a8f46b63a83d6444bf7d2) elmPackages.elm: build using attoparsec 0.13.2.5
* [`fab0d31f`](https://github.com/NixOS/nixpkgs/commit/fab0d31f438483248aafcd1815966d083aee19ab) all-cabal-hashes: 2022-02-22T04:07:26Z -> 2022-02-23T21:28:02Z
* [`e3477598`](https://github.com/NixOS/nixpkgs/commit/e347759873b7a86af3fcb93decd3e962b7a7c697) haskellPackages.xdot: drop now obsolete patch
* [`8b659c90`](https://github.com/NixOS/nixpkgs/commit/8b659c90f5bae0a8eb047a34bd8494c24b51df33) haskellPackages: stackage-nightly 2022-02-19 -> 2022-02-25
* [`95107873`](https://github.com/NixOS/nixpkgs/commit/95107873728a3400e3ff7bd6cec2e7dff3c44d9c) all-cabal-hashes: 2022-02-23T21:28:02Z -> 2022-02-25T10:27:38Z
* [`b4e20523`](https://github.com/NixOS/nixpkgs/commit/b4e20523649a53d9e5ea311eeb050132b0ffe879) haskellPackages: regenerate package set based on current config
* [`1aa02b5c`](https://github.com/NixOS/nixpkgs/commit/1aa02b5c3802100dfba899dc63d143521c761b0d) haskell.packages.ghc8{107,84}.OneTuple: provide hashable
* [`0acc49e2`](https://github.com/NixOS/nixpkgs/commit/0acc49e24dd8b444bd60d877d20157ab0344e544) haskellPackages.cabal-fmt: Fix build with patch
* [`ee745d06`](https://github.com/NixOS/nixpkgs/commit/ee745d06769741cadf26e9731c0b4ae0fccf5185) haskellPackages.ema: Fix build
* [`1c85a665`](https://github.com/NixOS/nixpkgs/commit/1c85a665de2f4e215920a5d8b8dbf24a6bc74443) haskellPackages.dhall-nix: restrict to 1.1.23 for dhall 1.40
* [`925e00c4`](https://github.com/NixOS/nixpkgs/commit/925e00c40c30ccaf2ff80e9532ffda87a1f39c30) haskellPackages: jailbreak glirc-related packages
* [`97107cdb`](https://github.com/NixOS/nixpkgs/commit/97107cdbcfd294713d2ce546ed09ddaa801eb265) nix-output-monitor: 1.0.4.0 -> 1.0.4.2
* [`2833bd5f`](https://github.com/NixOS/nixpkgs/commit/2833bd5f7cc613c5d5acbc0f30cbcbc8bb1981ef) haskellPackages.paths: Jailbreak
* [`69ae736f`](https://github.com/NixOS/nixpkgs/commit/69ae736f009e68da2b9c824fb30d6c5a0451a1d9) haskellPackages.streamly: Fix darwin build
* [`2460c8b1`](https://github.com/NixOS/nixpkgs/commit/2460c8b1a5366846e669cf13100e9c1838a8a5fe) haskell.packages.ghc8107.haskell-language-server: Fix build
* [`028b0da1`](https://github.com/NixOS/nixpkgs/commit/028b0da11b68d72b86ab62d73f8b03d9be1f1343) haskellPackages.reflection: disable test suite on darwin
* [`58d83066`](https://github.com/NixOS/nixpkgs/commit/58d830667a361b525e9915b1c7000857e3f8485c) release-haskell.nix: test static builds with GHC 9.0.2 as well
* [`aa849fe6`](https://github.com/NixOS/nixpkgs/commit/aa849fe602d453bb13ccd9d9fb00c635d469e9bd) release-haskell.nix: generate jobs for native-bignum ghc 9.0.2
* [`41ac9ddd`](https://github.com/NixOS/nixpkgs/commit/41ac9ddde0781a691683027a6d7da9c5b6594cda) haskellPackages.reflection: disable tests for GHC 9.0.2 everywhere
* [`5bd0ba07`](https://github.com/NixOS/nixpkgs/commit/5bd0ba079e137cfb8ce90d6a2af235e67a6048f1) haskellPackages.ema: fix eval
* [`f4828172`](https://github.com/NixOS/nixpkgs/commit/f4828172d782012366fa166c8ce0e9d6e2a6a491) haskellPackages.xmonad-dbus: unbreak
* [`140c56e1`](https://github.com/NixOS/nixpkgs/commit/140c56e116f5260a63af868b4591e1fe239f2852) haskellPackages.colourista: allow hspec 2.8
* [`1566456c`](https://github.com/NixOS/nixpkgs/commit/1566456c1af28743e4124e38931a54d96072596b) haskellPackages.io-streams-haproxy: Disable version checks
* [`d957e12a`](https://github.com/NixOS/nixpkgs/commit/d957e12ae8534200fc58deec585242b6240880ea) haskellPackages.xmlhtml: Disable version checks
* [`4fa49984`](https://github.com/NixOS/nixpkgs/commit/4fa49984b113fd12c564ab792f27d5216020abd7) haskellPackages.map-syntax: Jailbreak to fix build
* [`dcf92bf7`](https://github.com/NixOS/nixpkgs/commit/dcf92bf76e8d9f0f4af8dd5c9f7bb77d48f59067) haskellPackages: stackage-nightly 2022-02-25 -> 2022-02-27
* [`f2ff3e9e`](https://github.com/NixOS/nixpkgs/commit/f2ff3e9ecbc7e0d81179808ecf1595a33040277e) all-cabal-hashes: 2022-02-25T10:27:38Z -> 2022-02-27T02:04:39Z
* [`cb63ca9b`](https://github.com/NixOS/nixpkgs/commit/cb63ca9b2dcc5275a38eb785257eb19ba4277030) haskellPackages: regenerate package set based on current config
* [`f10a7e5a`](https://github.com/NixOS/nixpkgs/commit/f10a7e5a3b15402669a51e1ace056463c0f81eea) haskellPackages.cabal-install: ignore stackage bound
* [`f2253831`](https://github.com/NixOS/nixpkgs/commit/f22538313364b8da8f81fe5ccd5b0b2af31c97f2) haskellPackages.spdx: lift bounds on Cabal and base
* [`833aa519`](https://github.com/NixOS/nixpkgs/commit/833aa51924cc1d817b0cba4da85932eac21e0f0d) lrzip: 0.641 -> 0.650
* [`1ab2463d`](https://github.com/NixOS/nixpkgs/commit/1ab2463d561cfe1778d5b048bcc14b8526dce040) haskellPackages.beam-sqlite: unbreak
* [`94fb4d49`](https://github.com/NixOS/nixpkgs/commit/94fb4d49dfc47d03d5a691202e9e4bf95a5c7b7f) haskellPackages: regenerate package set based on current config
* [`551a6e81`](https://github.com/NixOS/nixpkgs/commit/551a6e81bab72c42f7bb87b00bf82cfa0596459f) haskellPackages: size-based: fix build with template-haskell 2.17
* [`1af73bd4`](https://github.com/NixOS/nixpkgs/commit/1af73bd4127eea72673189181dcbd3e2bfd63545) haskellPackages.snap-core: do jailbreak to allow newer attoparsec
* [`508794ec`](https://github.com/NixOS/nixpkgs/commit/508794ec3a98522b47ed1e4a26e2a7a5578ba5a7) haskellPackages: raise version bounds for binary-strict, remove jailbreak for webify
* [`bffa5bc4`](https://github.com/NixOS/nixpkgs/commit/bffa5bc47d27c83ad6866a3f3b99e43cd854c3c3) haskellPackages.keter: unbreak
* [`a0ed90b3`](https://github.com/NixOS/nixpkgs/commit/a0ed90b345508f7ee7b0a8ed51ceb80183bc3def) haskellPackages.ekg-core: fix build by relaxing bounds
* [`8ecdf545`](https://github.com/NixOS/nixpkgs/commit/8ecdf545a02531a895f1146b12548fe19308e6e3) haskellPackages: stackage-nightly 2022-02-27 -> 2022-03-02
* [`79a75f97`](https://github.com/NixOS/nixpkgs/commit/79a75f971c1183c080584b9bd5ca0ecfd2457c63) all-cabal-hashes: 2022-02-27T02:04:39Z -> 2022-03-02T22:17:55Z
* [`c60b2e16`](https://github.com/NixOS/nixpkgs/commit/c60b2e162393c958ab112c9858d5f66124aa68b3) haskellPackages: regenerate package set based on current config
* [`ee56ce6e`](https://github.com/NixOS/nixpkgs/commit/ee56ce6e56c4683d153167cd79fe8c1ddb81b6fb) haskellPackages.hgeometry: patch for GHC 9.0
* [`6f2d4953`](https://github.com/NixOS/nixpkgs/commit/6f2d495316073b3ea4f0d574dfc47ce5eb246e43) haskellPackages.hls-class-plugin: Disable flaky test.
* [`873e8a60`](https://github.com/NixOS/nixpkgs/commit/873e8a602d3ad4cc43956beeffb13391245c9694) haskellPackages.hls-class-plugin: fix attribute redefinition
* [`66846d1a`](https://github.com/NixOS/nixpkgs/commit/66846d1a84301addb6f6d2c1b6d3a2ad19efd915) haskellPackages: stackage-nightly 2022-03-02 -> 2022-03-03
* [`63d53c31`](https://github.com/NixOS/nixpkgs/commit/63d53c31bb913ec9cd14260a045c25c89045b290) all-cabal-hashes: 2022-03-02T22:17:55Z -> 2022-03-03T10:08:52Z
* [`4eba40e7`](https://github.com/NixOS/nixpkgs/commit/4eba40e7a59bca8ef8d35ecc00ee19a5b985a357) haskellPackages: regenerate package set based on current config
* [`21f7df26`](https://github.com/NixOS/nixpkgs/commit/21f7df26f735cc549e10e04d18a05e1a7da135e7) haskellPackages.foundation: 0.0.27 -> 0.0.28
* [`1943fe6b`](https://github.com/NixOS/nixpkgs/commit/1943fe6bb24631dc884dbd47d33ea5c7019d9857) haskellPackages.git-annex: patch for aeson 2.0 compat
* [`b2c2a925`](https://github.com/NixOS/nixpkgs/commit/b2c2a9252dcc5cb052905794f8e5793113bc080c) intel-media-sdk: 22.2.0 -> 22.2.1
* [`6821948a`](https://github.com/NixOS/nixpkgs/commit/6821948a15675d9479b4dbd9454bef83cb1587ad) xrootd: 5.4.1 -> 5.4.2
* [`e434e215`](https://github.com/NixOS/nixpkgs/commit/e434e215ed3325b26818f0d98a38125743a3db19) perlPackages.DigestSRI: init at 0.02
* [`16fae8b6`](https://github.com/NixOS/nixpkgs/commit/16fae8b675c4c8bac5bf4b030917a0cb1ea1d54b) starlark: init at unstable-2022-02-13
* [`3a60fe39`](https://github.com/NixOS/nixpkgs/commit/3a60fe39c58546498670db3fadad9c4f4d4ed4de) calibre-web: 0.6.16 -> 0.6.17
* [`5a8ee943`](https://github.com/NixOS/nixpkgs/commit/5a8ee94382ecf04c53b75376e532977b363d4d22) haskell.packages.ghc921.basement: fix build
* [`f75f8092`](https://github.com/NixOS/nixpkgs/commit/f75f8092d8808c7c28b887dba0fafd2c10b80031) google-java-format: 1.14.0 -> 1.15.0
* [`71f2c74e`](https://github.com/NixOS/nixpkgs/commit/71f2c74efbad1ec0f5802356e0bc2119cb3121cc) haskellPackages.cryptonite: Disable Argon2 on aarch64-darwin
* [`c269f8e7`](https://github.com/NixOS/nixpkgs/commit/c269f8e79bc8bedce4d69814ff198b9b79cd2ba6) haskellPackages.validation-selective: Jailbreak for selective 0.5
* [`37ed97a9`](https://github.com/NixOS/nixpkgs/commit/37ed97a969ab5a532ae6e971987edadbed619a80) haskellPackages.servant-auth-server: Jailbreak
* [`33f275b4`](https://github.com/NixOS/nixpkgs/commit/33f275b4c21770e29ae515868463a75881e9b1ef) all-cabal-hashes: 2022-03-03T10:08:52Z -> 2022-03-08T11:03:28Z
* [`660e7aaa`](https://github.com/NixOS/nixpkgs/commit/660e7aaa14ed02ffba4ceda415ab14d6586a3692) haskellPackages.hercules-ci-api-agent: adjust override for 0.4.1.1
* [`7a8de8f5`](https://github.com/NixOS/nixpkgs/commit/7a8de8f5d415098270f07bf397c834fecc6cdffb) haskellPackages.patch: Patch to fix build
* [`0dcac295`](https://github.com/NixOS/nixpkgs/commit/0dcac2951ff17fe8090ccac672b80c329d7c80be) haskellPackages.base64: dontCheck
* [`47f837f5`](https://github.com/NixOS/nixpkgs/commit/47f837f5e8bbeacc10d6e656dc1658ba14fd7c9e) haskell.compiler: ghc921 -> ghc922
* [`da80bef7`](https://github.com/NixOS/nixpkgs/commit/da80bef7ba2925f8db33a8c26d26ce7c4172d91d) all-cabal-hashes: 2022-03-08T11:03:28Z -> 2022-03-09T16:42:26Z
* [`dd5bdec6`](https://github.com/NixOS/nixpkgs/commit/dd5bdec6f77151ebd40e40297185b46c0c1366d6) haskellPackages: stackage-nightly 2022-03-03 -> 2022-03-09
* [`fce0a0eb`](https://github.com/NixOS/nixpkgs/commit/fce0a0eb1b14e148f55e1f26a72fd355e729843b) haskellPackages: regenerate package set based on current config
* [`efca299c`](https://github.com/NixOS/nixpkgs/commit/efca299c539577840349de1062c6d50cbc288b20) haskellPackages.{basement,foundation}: drop obsolete overrides
* [`86e22e85`](https://github.com/NixOS/nixpkgs/commit/86e22e8560980064a8dc860e5415c4b121d94c25) haskellPackages.hgeometry: drop obsolete patch
* [`98d263c0`](https://github.com/NixOS/nixpkgs/commit/98d263c0e07f9c5c5f5ccb98f76e1eb8bfc87a69) haskell.packages.ghc922.lzma-conduit: Jailbreak
* [`45127896`](https://github.com/NixOS/nixpkgs/commit/451278963bcdf39c8e43c64f92d601cca659fe28) haskell.packages.ghc922.protolude: Patch
* [`ec2c2731`](https://github.com/NixOS/nixpkgs/commit/ec2c273190317a9a4add52da2cbbb8f830e25938) haskell.packages.ghc922.servant*: Jailbreak and patch
* [`44cb1449`](https://github.com/NixOS/nixpkgs/commit/44cb144942c0486e77333434035b0c11d3a16246) haskell.packages.ghc922.tomland: Jailbreak
* [`c2c0e150`](https://github.com/NixOS/nixpkgs/commit/c2c0e150da6596b3e4a58b62a2094a553fcebb2b) arion: Fix name-setting patch
* [`19f8fcd7`](https://github.com/NixOS/nixpkgs/commit/19f8fcd76692a28dabaf195e30b467d2d72992e2) haskellPackages: stackage-nightly 2022-03-09 -> 2022-03-10
* [`14fd5837`](https://github.com/NixOS/nixpkgs/commit/14fd583715ef7db3b8c3b0aa0ba3e3ed43d6e582) all-cabal-hashes: 2022-03-09T16:42:26Z -> 2022-03-11T16:24:54Z
* [`4eba052b`](https://github.com/NixOS/nixpkgs/commit/4eba052b8d10601c6519faca564cdf6cc95e9ad9) haskellPackages: regenerate package set based on current config
* [`238d2dfa`](https://github.com/NixOS/nixpkgs/commit/238d2dfafc23d78e09b99e908e3b5f496d4163c2) autosuspend: 4.1.0 -> 4.1.1
* [`ea84f6b9`](https://github.com/NixOS/nixpkgs/commit/ea84f6b9e93d44fe586dc2af91fca101ee2dd8b9) tsm-client: 8.1.13.3 -> 8.1.14.0
* [`2ff66af8`](https://github.com/NixOS/nixpkgs/commit/2ff66af811dc4ee5a6903bec3df1454a299903f1) gitit: patch to build with hoauth >= 2.3.0 and pandoc >= 2.17
* [`8f980b43`](https://github.com/NixOS/nixpkgs/commit/8f980b43835b24b15c4ba995932427b6f3daade4) haskell.packages.ghc922.ghc-lib-parser-ex: adjust for hackage update
* [`c8a4385f`](https://github.com/NixOS/nixpkgs/commit/c8a4385f728bda7211bed1f568357389e7157509) haskellPackages.patch: Add patch for ghc 9.0 compat
* [`835c3419`](https://github.com/NixOS/nixpkgs/commit/835c3419d9b98654e13cd5874020f987074fb57b) redis: enable tests
* [`8213bd81`](https://github.com/NixOS/nixpkgs/commit/8213bd819954ee50e740392ed20dfec150eae207) vscode: gtk2 is not a dependency
* [`541064d8`](https://github.com/NixOS/nixpkgs/commit/541064d899ce51d291c0aca27834b740ab21ea4b) sndbus-cpp: init at 1.1.0
* [`0146f135`](https://github.com/NixOS/nixpkgs/commit/0146f135aef4e8d084863a7dea05a43a0887f3df) haskellPackages.mustache: patch for unordered-containers 0.2.17
* [`bb72482c`](https://github.com/NixOS/nixpkgs/commit/bb72482cc3eb6f6604641a246ce26bc8c3dff627) haskell-language-server: Disable more flaky tests
* [`18874353`](https://github.com/NixOS/nixpkgs/commit/188743537d4a306dd8dbe5aa5e9cc2b671215d81) vscode: don't dump all the commands to a file
* [`c13629eb`](https://github.com/NixOS/nixpkgs/commit/c13629eb1265a6c1c0048b81044b2556140de357) haskellPackages.elm2nix: Patch for aeson-2
* [`0eef4333`](https://github.com/NixOS/nixpkgs/commit/0eef43331cca9fa0a38a1b3dd2f0a13bf556541b) haskellPackages.jsaddle: jailbreak
* [`102af71d`](https://github.com/NixOS/nixpkgs/commit/102af71d8c2db79058f568776c29ae2c5a1460d6) haskellPackages.ghcjs-dom: fix package qualified import issue
* [`d3dcfdaf`](https://github.com/NixOS/nixpkgs/commit/d3dcfdaf4cc4f24ead76cd4a6e53ee0701131d14) haskellPackages.jsaddle-dom: Fix build
* [`a17834b4`](https://github.com/NixOS/nixpkgs/commit/a17834b4690e0f86865dd7e3219ec3c13a5494d8) haskellPackages.dependent-sum-aeson-orphans: jailbreak
* [`ab1a3c72`](https://github.com/NixOS/nixpkgs/commit/ab1a3c722494742360de874f87cb3d5ce43de417) haskellPackages.reflex: add patch
* [`4585f07f`](https://github.com/NixOS/nixpkgs/commit/4585f07fced49290a6e5e7a4f917ff6e99922887) haskellPackages.reflex-dom-core: add patches
* [`3cf437e4`](https://github.com/NixOS/nixpkgs/commit/3cf437e4617fdad853616f3c3a50468b92d28037) haskellPackages.shower: jailbreak
* [`1a78adaa`](https://github.com/NixOS/nixpkgs/commit/1a78adaa30fee69e5172efe42579b4065b48067b) haskellPackages.neuron: Fix build
* [`0ba189f2`](https://github.com/NixOS/nixpkgs/commit/0ba189f2d7ba8f6c225fbea2a6b4ba2e037a70b7) haskellPackages.knob: add patch for GHC 9 support
* [`70e6eb9e`](https://github.com/NixOS/nixpkgs/commit/70e6eb9ec8d548b836f8dedbf63d86a6bd737dc3) haskellPackages.stack: Patch for new Cabal
* [`33e1d138`](https://github.com/NixOS/nixpkgs/commit/33e1d138c0eaefc3e5649c7c807c693c1f72cae9) python3Packages.dnspython: fix build on darwin
* [`8b7ca8bd`](https://github.com/NixOS/nixpkgs/commit/8b7ca8bdcb949333c5b64839b660d3d0af68565a) nixos/prometheus-exporters/kea: wait for kea
* [`0da85d3f`](https://github.com/NixOS/nixpkgs/commit/0da85d3f7790ed4acc0fd2ba42d40f8b376d1118) release-haskell.nix: temporarily disable x86_64-darwin
* [`7331a6e2`](https://github.com/NixOS/nixpkgs/commit/7331a6e2f5b55790833cdafd108336b9bf696452) rpcs3: 0.0.21-13327-6c096b72b -> 0.0.21-13352-e58906cb4
* [`4884fcc0`](https://github.com/NixOS/nixpkgs/commit/4884fcc0d2b7581ef670a3cbd71363023a3ee6eb) ghc: enable static RTS
* [`654940f3`](https://github.com/NixOS/nixpkgs/commit/654940f36b5dfa19d87098efca6c4dac44a84eda) haskellPackages.mkDerivation: check haddock availability
* [`4ec13a76`](https://github.com/NixOS/nixpkgs/commit/4ec13a76b0108e4691195b5633b7e5cbd4def2a2) release-haskell.nix: test package that needs -fexternal-dynamic-refs
* [`299bfb16`](https://github.com/NixOS/nixpkgs/commit/299bfb168e74945c9b642d0bf3d5efe370121440) pkgsStatic.{haskellPackages,ghc}: default to BigNum
* [`03402366`](https://github.com/NixOS/nixpkgs/commit/0340236668a81a70f63089f1d6ca2893e980f70a) nixos/matrix-synapse: Fix configFile type
* [`3d45681f`](https://github.com/NixOS/nixpkgs/commit/3d45681f62d15417293feb6bd280b26a2645180b) ddar: remove
* [`99830284`](https://github.com/NixOS/nixpkgs/commit/9983028488e8f893c21676c6f73946dd6aba80bd) disper: remove
* [`ad32e89c`](https://github.com/NixOS/nixpkgs/commit/ad32e89c440f76dfb96c1557ac13c35c18c01fbe) haskellPackages.snap: Fix build
* [`d0fda788`](https://github.com/NixOS/nixpkgs/commit/d0fda788aec3a18350b73ba64bae372f0f51fe14) haskellPackages.shake-bench: Fix build
* [`013afb52`](https://github.com/NixOS/nixpkgs/commit/013afb52c7865aa5169ecc466a5c80c1ef11f3a8) praat: 6.2.09 -> 6.2.10
* [`2a6a5749`](https://github.com/NixOS/nixpkgs/commit/2a6a57498bb33b52eb0bebe925331e3c4c599586) haskellPackages: stackage-nightly 2022-03-10 -> 2022-03-17
* [`6ef31eaf`](https://github.com/NixOS/nixpkgs/commit/6ef31eaf005a77df4167e29224f357ae2365a89a) all-cabal-hashes: 2022-03-11T16:24:54Z -> 2022-03-19T10:17:05Z
* [`44eec005`](https://github.com/NixOS/nixpkgs/commit/44eec0054edee48df3b5ee672cd92b703a05ef12) haskellPackages: regenerate package set based on current config
* [`9e5ac862`](https://github.com/NixOS/nixpkgs/commit/9e5ac8625ea28c58601cfe1053a38b927d32c245) haskellPackages: Fix whitespace lint
* [`fb6dbccb`](https://github.com/NixOS/nixpkgs/commit/fb6dbccbfadaac68d9175a30089795704866c577) joycond: don't use dkms hid-nintendo on kernel 5.16 or newer
* [`5bb4a850`](https://github.com/NixOS/nixpkgs/commit/5bb4a85079ff217f76e982b61ca03b27db7f51d1) haskellPackages.matrix-client: jailbreak
* [`ce4bff54`](https://github.com/NixOS/nixpkgs/commit/ce4bff5467c3b143ca8c854f45593624659ca770) haskellPackages.hinit: jailbreak
* [`5833e429`](https://github.com/NixOS/nixpkgs/commit/5833e429976c8dc95115e011748727fbf744c88e) haskellPackages.snap: Update comment
* [`4e332dd5`](https://github.com/NixOS/nixpkgs/commit/4e332dd5579b29c101e7fc6cec5b30e8f42919b1) haskellPackages.yi-language: disable test suite requiring hspec < 2.8
* [`2812c1a7`](https://github.com/NixOS/nixpkgs/commit/2812c1a74ef312f89b519935fce595591ddfabc4) haskellPackages.mmsyn5: lift too strict base constraint
* [`177255c8`](https://github.com/NixOS/nixpkgs/commit/177255c8aac086b4ea999252a2f042b94e478091) haskellPackages.descriptive: pin aeson < 2.0
* [`6b250818`](https://github.com/NixOS/nixpkgs/commit/6b25081893536afdd18e9a134e8c9418130dc13f) haskellPackages.{alg,category,util}: work around Safe Haskell error
* [`fceb5f98`](https://github.com/NixOS/nixpkgs/commit/fceb5f98a1cfa768a6d2ceb75a1d0279f1453d5e) haskellPackages.jwt: Disable checks
* [`b83cf107`](https://github.com/NixOS/nixpkgs/commit/b83cf10783ef164f468690432a08818ddfb9c5c8) haskellPackages.monad-validate: append patch
* [`ae5d0223`](https://github.com/NixOS/nixpkgs/commit/ae5d022389517d39664b617cb249077ee108784d) thanos: 0.24.0 -> 0.25.1
* [`e3ab27de`](https://github.com/NixOS/nixpkgs/commit/e3ab27de78c0f31e725d80811dcb7cf4c0a2c213) haskellPackages.hadolint: allow deepseq 1.4.5.0
* [`22ced213`](https://github.com/NixOS/nixpkgs/commit/22ced213c00d26d3337815221ee5ab1e38f15bff) maintainers/haskell/update-stackage.sh: make solver configurable
* [`cd0ddefb`](https://github.com/NixOS/nixpkgs/commit/cd0ddefb4382e26c8f8f7bd0acd2c18b2fae94c3) maintainers/haskell/update-stackage.sh: make shellcheck happy
* [`57b1c86e`](https://github.com/NixOS/nixpkgs/commit/57b1c86e746152c7ec0a9660b0eb9a4d18a486f9) maintainers/haskell/update-stackage.sh: always mktemp for tmp files
* [`9b8dfcd9`](https://github.com/NixOS/nixpkgs/commit/9b8dfcd9bf449d0b8dd9a3e788df33340dc909c8) haskellPackages: stackage Nightly 2022-03-17 -> LTS 19.0
* [`7c53f076`](https://github.com/NixOS/nixpkgs/commit/7c53f076efe18d8c2ce33903c4d11589261173b5) all-cabal-hashes: 2022-03-19T10:17:05Z -> 2022-03-20T09:57:59Z
* [`71cfd5ea`](https://github.com/NixOS/nixpkgs/commit/71cfd5ea3efb896748960e1609bc1a75765add15) haskellPackages: regenerate package set based on current config
* [`8656de86`](https://github.com/NixOS/nixpkgs/commit/8656de8646c61a12223109e3d30ae6f322b3f85f) haskell.packages.ghc922.llvm-hs-pure: fix build with bytestring 0.11
* [`0ba3874e`](https://github.com/NixOS/nixpkgs/commit/0ba3874e3a58cdbb7ee91c0bc78f2fa70a98e1d0) nixos/manual: Update copyright years, authors, and copyright
* [`48b01ad7`](https://github.com/NixOS/nixpkgs/commit/48b01ad75f2d59f176ea3665fd6757184c56c3ab) matterhorn: build with aeson 1.5.6.0
* [`acef747b`](https://github.com/NixOS/nixpkgs/commit/acef747bd2a2b218adaf309d1a99cb022164dcc2) gogs: 0.12.5 -> 0.12.6
* [`d2fe726d`](https://github.com/NixOS/nixpkgs/commit/d2fe726d1c5621870b74215995691673e7a13814) haskellPackages.matrix-client: drop jailbreak
* [`fdbc2c45`](https://github.com/NixOS/nixpkgs/commit/fdbc2c45bc067b07061db31be1cd78e04c8d754b) ipfs: 0.12.0 -> 0.12.1
* [`80f8dc82`](https://github.com/NixOS/nixpkgs/commit/80f8dc823b8e285716e50f00a0d904468e76c035) haskellPackages.neuron: pin clay version
* [`4cf31659`](https://github.com/NixOS/nixpkgs/commit/4cf31659f419632f2b7ffc086076c594c52ab1bc) haskellPackages.ghcup: drop maintainership
* [`16f3fbbd`](https://github.com/NixOS/nixpkgs/commit/16f3fbbd6f332daeb36c1c3fa75587ff6d6faf5a) haskellPackages.clay: drop jailbreak
* [`702fa7b5`](https://github.com/NixOS/nixpkgs/commit/702fa7b52ea36cdeadcea29b3fdcd6ffc397b43d) haskellPackages.update-nix-fetchgit: Patch to make compatible with github-rest version in package set
* [`b34575a0`](https://github.com/NixOS/nixpkgs/commit/b34575a0b56dfa147e754d7de8fa56ac2554313f) haskellPackages.update-nix-fetchgit: Document when to remove our patch
* [`3c394e7e`](https://github.com/NixOS/nixpkgs/commit/3c394e7e356278aa9be4713ab550feb3628d9028) fclones: 0.17.1 -> 0.18.1
* [`39a1e04f`](https://github.com/NixOS/nixpkgs/commit/39a1e04f4a9fab42615bcd80a37c7f79a3db4c54) linuxPackages.rtl8821au: 2021-11-05 -> 2022-03-08
* [`267cf195`](https://github.com/NixOS/nixpkgs/commit/267cf195d74304c1c52589f6b0977c6511bf4c58) Assert versions that have 9.2 compatible versions on Hackage
* [`3c105b41`](https://github.com/NixOS/nixpkgs/commit/3c105b417dfa85e4baf6f7b821aa7f3e4c574d44) nvidia-vaapi-driver: mark as high priority for collisions
* [`1cbdce18`](https://github.com/NixOS/nixpkgs/commit/1cbdce18e13baec367f7ef5d09a76011bab8a41d) haskellPackages.large-hashable: 0.1.0.4 -> unstable-2021-11-01
* [`52c98fc3`](https://github.com/NixOS/nixpkgs/commit/52c98fc3e9b593f1b98caeb00864f884e897866f) nixos: systemd: Split unit types into separate module
* [`96cdae60`](https://github.com/NixOS/nixpkgs/commit/96cdae6026120cdcd82f28aa8ad18474fe7043ec) haskellPackages.pipes-aeson: Patch for aeson-2
* [`76be4bd3`](https://github.com/NixOS/nixpkgs/commit/76be4bd38157740144cec1cc30107dfcca9af927) haskellPackages.moto: Patch for GHC 9.0
* [`406981a4`](https://github.com/NixOS/nixpkgs/commit/406981a49a49fc3e134eb4189bf8988525570c28) haskellPackages.moto-postgresql: Patch for MonadFail
* [`7fb5fa68`](https://github.com/NixOS/nixpkgs/commit/7fb5fa680a30edae3a32367d83cc5684c38e0afa) haskellPackages.policeman: drop
* [`6b3818b9`](https://github.com/NixOS/nixpkgs/commit/6b3818b9c07e15ca022533e6d11701fdfcdacf68) haskellPackages.niv: pin aeson < 2.0
* [`53b13c99`](https://github.com/NixOS/nixpkgs/commit/53b13c99955ae68709f17ff227576576d33bf437) haskellPackages.stylish-haskell: pin deps
* [`ff9be3cd`](https://github.com/NixOS/nixpkgs/commit/ff9be3cd21d0c7b7408a9d9dbf26f4a59f0b2f53) haskellPackages.jsaddle-webkit2gtk: add patch
* [`d7b31a50`](https://github.com/NixOS/nixpkgs/commit/d7b31a50c1e843947cfc43ae4ea694388972088b) haskellPackages.reflex-dom: jailbreak
* [`d193ef8a`](https://github.com/NixOS/nixpkgs/commit/d193ef8a57266938b00422144efc04d9dba4d3a9) make-initrd-ng: init
* [`25113740`](https://github.com/NixOS/nixpkgs/commit/25113740a5063483645cab857716a77437cd881e) nixos: systemd-lib: Make generateUnits general with default args
* [`add80ae7`](https://github.com/NixOS/nixpkgs/commit/add80ae7d0324b6cc459e59588c8f2603e30e4f1) all-cabal-hashes: 2022-03-20T09:57:59Z -> 2022-03-22T14:25:11Z
* [`f79f6076`](https://github.com/NixOS/nixpkgs/commit/f79f6076d700a5b54365fdfbcfc039316951ac1e) haskellPackages: regenerate package set based on current config
* [`f8c740b7`](https://github.com/NixOS/nixpkgs/commit/f8c740b781135a7564fa32658c5887e606138e08) haskellPackages.misfortune: apply patch to fix GHC 9 build
* [`fe3d3d57`](https://github.com/NixOS/nixpkgs/commit/fe3d3d5764e3e422ea7979eb68a72080046e35d7) haskellPackages.dice: apply patch to fix GHC 9 build
* [`832c0911`](https://github.com/NixOS/nixpkgs/commit/832c091143013150c41d82ecbd17a680607c68e1) lambdabot: apply patch to fix GHC 9 build
* [`f60832c1`](https://github.com/NixOS/nixpkgs/commit/f60832c17a9bb1b34e1bcb919c6e8e0377b2566c) haskellPackages: move knob patch to configuration-common
* [`9b2781de`](https://github.com/NixOS/nixpkgs/commit/9b2781de35448ad725f3714e31a35612f9c09f53) haskellPackages: fix time-travelling comment
* [`06113f18`](https://github.com/NixOS/nixpkgs/commit/06113f18b48600431a38f7c61dc195edd59e79a8) _1password: 1.12.2 -> 2.0.0
* [`44456a87`](https://github.com/NixOS/nixpkgs/commit/44456a87e8d5facd0ca7a29b79af27aec42981f9) haskellPackages: prune broken.yaml
* [`8b791af7`](https://github.com/NixOS/nixpkgs/commit/8b791af7b14a7797e1bf0b4ca52341a5907eda93) haskellPackages: regenerate package set based on current config
* [`4cb1fc0e`](https://github.com/NixOS/nixpkgs/commit/4cb1fc0e58ecbf0469a05dca8f01372ce7189c9a) argo-rollouts: 1.1.1 -> 1.2.0
* [`2d4ebf12`](https://github.com/NixOS/nixpkgs/commit/2d4ebf1259149ac52c191f461eef4eae6c3671fc) initrd: Optional systemd-based initrd
* [`be10e86c`](https://github.com/NixOS/nixpkgs/commit/be10e86c9587d3207c8d4a850a72ed88124d1aac) systemd-initrd: Partially fix qemu-vm
* [`1abf1541`](https://github.com/NixOS/nixpkgs/commit/1abf15417972cd54eb7013e4a87f6b2de30d8590) systemd-initrd: Add PATH to everything
* [`213de9b1`](https://github.com/NixOS/nixpkgs/commit/213de9b10874370c9f14e41c8551fba701ed8030) systemd-initrd: autoFormat and autoResize in initrd
* [`33656668`](https://github.com/NixOS/nixpkgs/commit/3365666840152b7b1ef2a97f171102575b6d743f) systemd-initrd: Basic test case
* [`98284466`](https://github.com/NixOS/nixpkgs/commit/9828446608cfc3c184ee030fcdf6d2092d22d2fb) systemd-initrd: Fix Environment= and PATH
* [`24313470`](https://github.com/NixOS/nixpkgs/commit/243134704201713c853056f051574d26339e50b6) systemd-initrd: Test autoResize
* [`5bfe2133`](https://github.com/NixOS/nixpkgs/commit/5bfe21331548db28279776debc073b02de71e2e3) Clarify suppressed units description
* [`12200d74`](https://github.com/NixOS/nixpkgs/commit/12200d74572e1551eae857541a31ae25fa9d6bf8) tonelib-metal: init at 1.1.0
* [`33660276`](https://github.com/NixOS/nixpkgs/commit/336602768a96b540c58bb581719875af8d7d9a57) bitwig-studio: 4.2 -> 4.2.1
* [`fa552e76`](https://github.com/NixOS/nixpkgs/commit/fa552e76e681b3b84b9917a09c40201799ded4f0) maintainers/scripts/haskell: add script to find broken maintained packages
* [`213a8085`](https://github.com/NixOS/nixpkgs/commit/213a808539ffd79c21f5cd5625fc1ff98545461c) haskellPackages: mark packages failing on hydra as broken
* [`22091f9a`](https://github.com/NixOS/nixpkgs/commit/22091f9a3933c41d57bffaa990e08bad824e1c50) haskellPackages: regenerate package set based on current config
* [`9a683652`](https://github.com/NixOS/nixpkgs/commit/9a68365233554005b3443b09f249dd212e873d0e) haskellPackages: enable builds for some pkgs needed by top-level pkgs
* [`557e8963`](https://github.com/NixOS/nixpkgs/commit/557e8963e8c7970e280bfbaa9d7e8cae79f98420) maintainers: add rbreslow
* [`a39208dd`](https://github.com/NixOS/nixpkgs/commit/a39208ddded07c3e7921288e94486614eb4ecbb7) haskellPackages: mark more packages as broken or unsupported
* [`bc4631d8`](https://github.com/NixOS/nixpkgs/commit/bc4631d8f0f3f388be3fffb959a893ead997d50a) nixos/syncplay: Add server password support
* [`a4bf7fed`](https://github.com/NixOS/nixpkgs/commit/a4bf7fed594d9133ee9e520a07ac0bc2c723d070) jmol: 14.32.33 -> 14.32.39
* [`484ae5b0`](https://github.com/NixOS/nixpkgs/commit/484ae5b0a134debc48bfcc2c40a05dcd47371385) nixos/doc/rl-22.05: note default GHC update
* [`d1890aee`](https://github.com/NixOS/nixpkgs/commit/d1890aee144a04fcd93d4b0d848917d1e92c0e5d) ocamlPackages.caqti: 1.5.1 -> 1.7.0
* [`b2f458dc`](https://github.com/NixOS/nixpkgs/commit/b2f458dc40243376e7859bcd155d851f3fa068b8) hledger-check-fancyassertions: update source hash for 1.25
* [`76d05dfa`](https://github.com/NixOS/nixpkgs/commit/76d05dfa62d4b3b4db3be3a800d18bee858d1c60) fakeNss: move to toplevel
* [`74bae067`](https://github.com/NixOS/nixpkgs/commit/74bae067487b1292edf5e97962de2bccb014ca15) systemd-initrd: use pkgs.fakeNss, document why we need libnss_files.so
* [`e3083dec`](https://github.com/NixOS/nixpkgs/commit/e3083decc4dea10e34ac08b705ea74808cefa524) systemd-initrd, systemd-lib: drop initrdServiceToUnit
* [`8bb8fcbc`](https://github.com/NixOS/nixpkgs/commit/8bb8fcbc6a7e11dfc9bca59a5f9fa55c57cc8db1) haskellPackages.nvfetcher: jailbreak
* [`38df6e7a`](https://github.com/NixOS/nixpkgs/commit/38df6e7a57de75acd0a8dfb9109ec7dd3984863d) haskellPackages.arch-web: jailbreak
* [`fc91cdb5`](https://github.com/NixOS/nixpkgs/commit/fc91cdb5bcd909f32496c4b69347fb1bd0755a77) nixos/lib/systemd-lib.nix: move comment back down to packages
* [`194c266f`](https://github.com/NixOS/nixpkgs/commit/194c266f9a89db524175ce2803b39093447202ce) haskellPackages: configuration-common.nix add imports at top of file
* [`ecc5b854`](https://github.com/NixOS/nixpkgs/commit/ecc5b8546465ef955bbd9bf3da734fcc690da1d1) postgresql11Packages.pgroonga: 2.3.5 -> 2.3.6
* [`7ab1fd26`](https://github.com/NixOS/nixpkgs/commit/7ab1fd262ffae10c85f4100027872d5954e60797) vimUtils.makeCustomizable: rewrite to include more things
* [`65a6e2cb`](https://github.com/NixOS/nixpkgs/commit/65a6e2cb0df39aafa8d14b1b5e752688d0ba9290) vim_configurable: don't rewrap
* [`0eb92176`](https://github.com/NixOS/nixpkgs/commit/0eb92176bf486dab758ce55c494623f24937e45b) vim_configurable: don't accept arbitrary arguments
* [`e6ff028c`](https://github.com/NixOS/nixpkgs/commit/e6ff028cfa9990336a9ae4ee094c1513d7796d83) vim_configurable: drop patchelf
* [`21e45db6`](https://github.com/NixOS/nixpkgs/commit/21e45db6f1b196678e967b516a0761922bdf5dd7) vim: make customizable
* [`2ec30e4b`](https://github.com/NixOS/nixpkgs/commit/2ec30e4b14e7a32147c62eeb2bf410ab3acb6446) matrix-synapse: 1.55.0 -> 1.55.2
* [`47190314`](https://github.com/NixOS/nixpkgs/commit/47190314dfb7c62cb39e7d831237303b330ac8fb) treewide: replace defunct git://github.com urls with https://
* [`f3bda2f2`](https://github.com/NixOS/nixpkgs/commit/f3bda2f2c0ed785b28d32671b4321f71ccd17c19) docs: replace defunct git://github.com urls with https://
* [`c1f8889b`](https://github.com/NixOS/nixpkgs/commit/c1f8889beb3242322aa972019b417913a54e00a9) haskell.packages.ghc{884,8017}.mysql-simple: provide blaze-textual
* [`f6d7cbb2`](https://github.com/NixOS/nixpkgs/commit/f6d7cbb2470cce467e320ede800ae3d411e88181) haskellPackages.validation: allow lens 5.* in test suite
* [`6af3e616`](https://github.com/NixOS/nixpkgs/commit/6af3e61632c651db2dc1fe55ae48460006eda0ad) nixos/qemu-vm: allow booting VM with the custom kernel
* [`86377397`](https://github.com/NixOS/nixpkgs/commit/863773970cdf5de8ec2bd569d453df43365ae5bb) nixos/oauth2_proxy: add user group
* [`78a439e5`](https://github.com/NixOS/nixpkgs/commit/78a439e5143ddf9e1cb0e485ea05e74f61635b40) rPackages: Disable stackprotector on aarch64-darwin
* [`16f80139`](https://github.com/NixOS/nixpkgs/commit/16f80139f08397a41e6981dccf9f8ae5ff13d1a2) nixos/paperless-ng: fix mail importer
* [`f50e41bf`](https://github.com/NixOS/nixpkgs/commit/f50e41bfd60a7c705086354e020807d0295c3526) rPackages: nloptr requires libiconv
* [`cccc4191`](https://github.com/NixOS/nixpkgs/commit/cccc419102db620bc9877b997aa01a33da2ba8ae) prometheus-redis-exporter: 1.36.0 -> 1.37.0
* [`d1ac8881`](https://github.com/NixOS/nixpkgs/commit/d1ac88811f0235f9ba0834ab1ac970e6f4e7ffc0) nixos/_1password: init
* [`9f7ac926`](https://github.com/NixOS/nixpkgs/commit/9f7ac9269852b12a220a8cc48d1879ddfab0a115) dhall-text: remove at 1.0.18
* [`66996acc`](https://github.com/NixOS/nixpkgs/commit/66996acc2a9afd1b0c34beffc2bab3e8daecbcad) all-cabal-hashes: 2022-03-22T14:25:11Z -> 2022-03-26T03:24:04Z
* [`08458844`](https://github.com/NixOS/nixpkgs/commit/084588444df732a5bb6b0ac87df92b770f3a00c2) haskellPackages: use fetchpatch's `relative` argument
* [`27aed0d1`](https://github.com/NixOS/nixpkgs/commit/27aed0d10bec72ab2cbf24a192e05b431995e746) haskellPackages.mmark: 0.0.7.4 -> 0.0.7.5
* [`ad560b3e`](https://github.com/NixOS/nixpkgs/commit/ad560b3ef4820f505a533953cd23bfc0b3342d90) haskellPackages.knob: remove patch after 0.2
* [`a89197a1`](https://github.com/NixOS/nixpkgs/commit/a89197a11d852870fb174d2c2975c4b4e4b83c1f) checkSSLCert: 2.22.0 -> 2.23.0
* [`4f859973`](https://github.com/NixOS/nixpkgs/commit/4f85997362d9f97fe5282d18956e07cafa44b82c) certigo: 1.15.0 -> 1.15.1
* [`40d6259b`](https://github.com/NixOS/nixpkgs/commit/40d6259bc9fb4a4a74f33971b2c619a7e96c751a) jc: 1.18.5 -> 1.18.6
* [`e6844628`](https://github.com/NixOS/nixpkgs/commit/e68446288efdd86b1930383b2c03c7b93bfb41ee) maintainers: add rgrinberg
* [`da264c50`](https://github.com/NixOS/nixpkgs/commit/da264c508d28719b51f9d680e2e091b20e68d8a2) ablog: init at 0.10.23
* [`45134bb9`](https://github.com/NixOS/nixpkgs/commit/45134bb912698266b3b86da012b30d7c328220a4) libsForQt5.qwt6_1: init at 6.1.6
* [`f405c598`](https://github.com/NixOS/nixpkgs/commit/f405c5987407fda41903c5d6ff311fdad7430ef8) libsForQt5.qwt: 6.1.6 -> 6.2.0
* [`fbc8d491`](https://github.com/NixOS/nixpkgs/commit/fbc8d491eca5b547d8cce39964d8650a40d3f4c6) qwt: remove qwt v5.x derivation
* [`50df7545`](https://github.com/NixOS/nixpkgs/commit/50df75459ee8581be6acf32c82bcfd6a4415e263) libsForQt5.qwt: rename 6.nix to default.nix
* [`47fb5151`](https://github.com/NixOS/nixpkgs/commit/47fb5151cb3f3293363b8b02eef820267da8b8a7) libsForQt5.qwt: cleanup metadata
* [`8ceca9f3`](https://github.com/NixOS/nixpkgs/commit/8ceca9f36b9ca33a55ba857563c9b1e4f7963485) mplus-outline-fonts: init github release
* [`6c5a2b69`](https://github.com/NixOS/nixpkgs/commit/6c5a2b69b459786834d893986a7ecf201ce92138) maintainers: add uakci
* [`e63b736b`](https://github.com/NixOS/nixpkgs/commit/e63b736b1be211c39d38e3419022760c4dc41042) haskellPackages.git-annex: update sha256 for 10.20220322
* [`3388c768`](https://github.com/NixOS/nixpkgs/commit/3388c7684ea8d34a20e96b3f9c4bc0b4c11bb6ca) haskellPackages.mustache: drop upstreamed patch
* [`229609de`](https://github.com/NixOS/nixpkgs/commit/229609de1667dacbc2662b59362c76bf4e468e63) haskellPackages.cabal-install-parsers: provide Cabal 3.6
* [`b4e65fc3`](https://github.com/NixOS/nixpkgs/commit/b4e65fc3d7baa1ffe8dd80320f504bb3c333283a) haskellPackages.geojson: disable test suite failing to compile
* [`b84f1396`](https://github.com/NixOS/nixpkgs/commit/b84f13964d35651fb7bde47ba4b0088f98f8b6e7) gotify-desktop: 1.2.0 -> 1.3.1
* [`f9268040`](https://github.com/NixOS/nixpkgs/commit/f9268040166a01420d396cff7c5fb8b5113a202b) haskellPackages.sbv: provide new solvers for version 8.17
* [`cb1c5dbb`](https://github.com/NixOS/nixpkgs/commit/cb1c5dbb15f1c2f0802007c7ac661d371d00babf) nixos/unifi-video: convert int to string in default command
* [`95a3f6ad`](https://github.com/NixOS/nixpkgs/commit/95a3f6ad266c1a340630bbdb4787e202bf9bd883) nixos/unifi-video: rename openPorts to openFirewall
* [`f23a1c20`](https://github.com/NixOS/nixpkgs/commit/f23a1c20331be05303613768834baebdc7b6240c) gnome-keyring: checkInputs python2 → python3
* [`4ed08031`](https://github.com/NixOS/nixpkgs/commit/4ed08031db4a77a577dc1a8c27310bdb54fa25a4) haskellPackages.mattermost-api: build with aeson 1.5
* [`76a6908a`](https://github.com/NixOS/nixpkgs/commit/76a6908a09c8187215cb28515ed58ad34b04b350) monit: 5.31.0 -> 5.32.0
* [`8b5bf9f2`](https://github.com/NixOS/nixpkgs/commit/8b5bf9f26494c87f9c55a889afb91d2e20fb8cfe) vivaldi: 5.1.2567.66-1 -> 5.1.2567.73-1
* [`1f57d3e7`](https://github.com/NixOS/nixpkgs/commit/1f57d3e7224290eebda23fa1c79718d6b8361574) nix-linter: 0.2.0.3 -> 0.2.0.4
* [`158a2972`](https://github.com/NixOS/nixpkgs/commit/158a2972eb8c54f9a516d5fd314ec207ed305828) nixos/filesystems: Move options into the fs module
* [`452102db`](https://github.com/NixOS/nixpkgs/commit/452102db8fe678aea06eb6904895ec2e4f842c4b) nixos/stage-2-init: Clean up legacy commands
* [`d7e9eb35`](https://github.com/NixOS/nixpkgs/commit/d7e9eb35e20efc5a56a564355e35ac4dbaf5f6d1) nominatim: init at 4.0.1
* [`df698858`](https://github.com/NixOS/nixpkgs/commit/df698858835ebd614d15773267fc4071c8da1139) strace: 5.16 -> 5.17
* [`9f5796be`](https://github.com/NixOS/nixpkgs/commit/9f5796be499b061cee78bd7afb747ae8025a5cab) lib/trivial: actually expose warnIfNot and throwIf
* [`d3fb4568`](https://github.com/NixOS/nixpkgs/commit/d3fb4568b3e963bb3843cb43c1b6e58f122b66b8) monit: don't abuse meta.homepage
* [`c5dead21`](https://github.com/NixOS/nixpkgs/commit/c5dead21cdbfa0e0185cf79d06cf9e40814eef3e) treewide: cleanup old throw aliases
* [`a8ef08b6`](https://github.com/NixOS/nixpkgs/commit/a8ef08b624e780ed150c7a74f81af0876ff0e186) starship: use system libgit2
* [`a3954182`](https://github.com/NixOS/nixpkgs/commit/a3954182ba44ea70d6e6e782e5787884e05d857e) nixos/gnome: change telepathy service from default true to default false
* [`595f7a5a`](https://github.com/NixOS/nixpkgs/commit/595f7a5a766b3dddfd272a1f3482a43098adafe2) python310Packages.nocasedict: 1.0.2 -> 1.0.3
* [`a87f6f9b`](https://github.com/NixOS/nixpkgs/commit/a87f6f9b909134e98ebbc324308f5d3afac08490) eiciel: init at 0.9.13.1
* [`c951914f`](https://github.com/NixOS/nixpkgs/commit/c951914f43c4f7cabcd633a2d6b10ba4f85406a2) stellarium: 0.21.3 -> 0.22.0
* [`ba04eeb1`](https://github.com/NixOS/nixpkgs/commit/ba04eeb1f466cd2a4923ea403f37abf0ee041ace) Revert "poetry: apply toPythonApplication"
* [`b53ee0c6`](https://github.com/NixOS/nixpkgs/commit/b53ee0c6eb7b9b07224477f892b5474222d8d910) bind: add meta.changelog
* [`f17d854d`](https://github.com/NixOS/nixpkgs/commit/f17d854d1eec287dc5018849c3b25ac77e064762) python310Packages.nocaselist: 1.0.4 -> 1.0.5
* [`073206c8`](https://github.com/NixOS/nixpkgs/commit/073206c8e017533f76418ba180db35021a46d6f5) libgpod: reduce propagated libraries, cleanup
* [`a9ab92ee`](https://github.com/NixOS/nixpkgs/commit/a9ab92ee1271b41369a0cc58fa8af5685042b7ed) gtkpod: fix build
* [`8e0f6609`](https://github.com/NixOS/nixpkgs/commit/8e0f6609c3086522314b967218005a7c7fc7b923) libgda: remove `? null` from inputs
* [`9f034e5d`](https://github.com/NixOS/nixpkgs/commit/9f034e5d188ca856c6d84e1dfecefc455da6fd02) libgda: propagate libxml2
* [`069fd78e`](https://github.com/NixOS/nixpkgs/commit/069fd78e321b6a293c2221fd28c269ca2780f355) nheko: 0.9.2 -> 0.9.3
* [`7a9e86f0`](https://github.com/NixOS/nixpkgs/commit/7a9e86f0191cade202861ee47ef989683b8fb1c0) mc: 4.8.27 -> 4.8.28
* [`2b52fed9`](https://github.com/NixOS/nixpkgs/commit/2b52fed9751f66a8228f3df3750a41b6ff31ba04) gnomeExtensions.freon: package automatically
* [`882ecdce`](https://github.com/NixOS/nixpkgs/commit/882ecdce35dc3d9c61bc9f6ef883bfe2d817d878) electrum: 4.1.5 -> 4.2.1
* [`c22627a8`](https://github.com/NixOS/nixpkgs/commit/c22627a866dd32137fb9e717ebd2ce5cafe944ca) vimPlugins: update
* [`9b94bfa1`](https://github.com/NixOS/nixpkgs/commit/9b94bfa1684d55a4aeb54e860a97d91b6f8c7c6e) vimPlugins: resolve github repository redirects
* [`006d42d8`](https://github.com/NixOS/nixpkgs/commit/006d42d8f002ddd2c37744fb2b9154e0783e1e0b) vimPlugins.telescope-ui-select-nvim: init at 2022-03-20
* [`4ad1abf9`](https://github.com/NixOS/nixpkgs/commit/4ad1abf9c4159cfdb63472aeaa4efc5778fd37de) python310Packages.pyinfra: 1.7 -> 1.7.2
* [`a83f15d8`](https://github.com/NixOS/nixpkgs/commit/a83f15d8fb4227318db60162012decaf7a2a1b4b) python310Packages.jupyterlab-lsp: 3.10.0 -> 3.10.1
* [`07c164d3`](https://github.com/NixOS/nixpkgs/commit/07c164d35b10741954fe110510c76efc20b465f5) python310Packages.scikit-fmm: 2022.2.2 -> 2022.3.26
* [`3c245b4e`](https://github.com/NixOS/nixpkgs/commit/3c245b4e49da57dee44ecc3e8164987f1d96c894) spicetify-cli: 2.9.2 -> 2.9.4
* [`91e952f8`](https://github.com/NixOS/nixpkgs/commit/91e952f8861e0171abae80a95dab40a54fd8627d) python39Packages.arviz: 0.11.4 -> 0.12.0
* [`60e62c36`](https://github.com/NixOS/nixpkgs/commit/60e62c36df25e882d73881a627b8cd6816340bee) nixos/unifi-video: clean up indentation and formatting
* [`82761fb6`](https://github.com/NixOS/nixpkgs/commit/82761fb688373e2ca6f08b1f4e718a4f5859eaba) python3Packages.releases: init at 1.6.3
* [`5e7bced9`](https://github.com/NixOS/nixpkgs/commit/5e7bced95e9e0114653435528c1cdb8e03d48491) python3Packages.invocations: init at 2.6.0
* [`68eb7fdd`](https://github.com/NixOS/nixpkgs/commit/68eb7fdd62ac795260ba6d838522750ef5551397) s3-credentials: init at 0.10
* [`ca79392b`](https://github.com/NixOS/nixpkgs/commit/ca79392bbca3b8e8155780e80dae0e94b308c1f9) python39Packages.osc-lib: 2.5.0 -> unstable-2022-03-09
* [`a0968ef3`](https://github.com/NixOS/nixpkgs/commit/a0968ef3b4b65d4c47a4c91e9464503264445837) python310Packages.debugpy: 1.5.1 -> 1.6.0
* [`e3d498d1`](https://github.com/NixOS/nixpkgs/commit/e3d498d19ee7bb185873a626da2a5b3f959effa5) pscale: 0.89.0 -> 0.90.0
* [`f4182075`](https://github.com/NixOS/nixpkgs/commit/f4182075ff292f9c737fa2281f60ea4f514ace89) Update pkgs/development/python-modules/osc-lib/default.nix
* [`a39b29dd`](https://github.com/NixOS/nixpkgs/commit/a39b29dd095327add9a8fbd09ce52f6b9526c7ad) git-branchless: 0.3.9 -> 0.3.10
* [`08b1f113`](https://github.com/NixOS/nixpkgs/commit/08b1f113d9ad681deb392e53ec5742e47d0734fc) python310Packages.types-requests: 2.27.14 -> 2.27.15
* [`30527ee7`](https://github.com/NixOS/nixpkgs/commit/30527ee7e5ebfaf0a82973259ae1791e5e3a8fff) python310Packages.mypy-boto3-builder: 7.4.1 -> 7.5.3
* [`4c0dc16f`](https://github.com/NixOS/nixpkgs/commit/4c0dc16f28692de49919551466caf0c0856c6f83) ircdog: 0.2.1 -> 0.3.0
* [`401a033c`](https://github.com/NixOS/nixpkgs/commit/401a033c6fab4ac564b24d8a466505a72213690f) deltachat-desktop: fix icon
* [`97e58635`](https://github.com/NixOS/nixpkgs/commit/97e586356901b2ea7b6df453caf43b98fae355a3) deltachat-desktop: update react-string-replace to 1.0.0
* [`15f220b0`](https://github.com/NixOS/nixpkgs/commit/15f220b07ced65b6ca8ed862249bf180b5ace9ca) ocamlPackages.buildDunePackage: add support for dune 3
* [`bb559f92`](https://github.com/NixOS/nixpkgs/commit/bb559f92af22bca4f1b58a0fe5b1412fea7e7cca) stog: use dune version 3
* [`ac07d2fa`](https://github.com/NixOS/nixpkgs/commit/ac07d2fa3edf8fb74f34c641b892161a177609df) ocamlPackages.ordering: init at 3.0.3
* [`ab975418`](https://github.com/NixOS/nixpkgs/commit/ab97541807bc7126d577cdc75f46e07a5b052e7b) ocamlPackages.dyn: init at 3.0.3
* [`b19721dc`](https://github.com/NixOS/nixpkgs/commit/b19721dc2a8ceb8d1f46260aad0d5a8783a4b499) ocamlPackages.stdune: init at 3.0.3
* [`7cc59659`](https://github.com/NixOS/nixpkgs/commit/7cc596593c5cae180024b1322f366847ae764bbe) ocamlPackages.dune-private-libs: 2.9.3 → 3.0.3
* [`87c74b81`](https://github.com/NixOS/nixpkgs/commit/87c74b8120980461a9d4ce8f341551ce0fb50728) User manual: document duneVersion
* [`2cc55d8c`](https://github.com/NixOS/nixpkgs/commit/2cc55d8c776ba6881c3bf71a7f4d0b0ba1bcd8f2) tautulli: 2.9.4 -> 2.9.5
* [`70dc29f9`](https://github.com/NixOS/nixpkgs/commit/70dc29f9e8c4bce8d541f997cd7b18e583ed6278) terraform-providers: update 2022-03-28
* [`32ee651e`](https://github.com/NixOS/nixpkgs/commit/32ee651ea94214b8c769b1482b2bf44da533cf7a) python310Packages.sabyenc3: 5.1.3 -> 5.1.5
* [`a107f9de`](https://github.com/NixOS/nixpkgs/commit/a107f9de561054afc111dd9ccf993bd8e38f79aa) ffuf: 1.3.1 -> 1.4.0
* [`db55843a`](https://github.com/NixOS/nixpkgs/commit/db55843a2e7e0d08548f4031dc04f17439c18f9a) python3Packages.mcstatus: 8.0.0 -> 9.0.2
* [`49e412b0`](https://github.com/NixOS/nixpkgs/commit/49e412b04614d8a5f1b4c91a166efdfdecd91cbb) rancher: 2.6.0 -> 2.6.4
* [`06327ff6`](https://github.com/NixOS/nixpkgs/commit/06327ff6d2198a56abe5e15452919f744e364595) python3Packages.elkm1-lib: 1.2.0 -> 1.2.1
* [`478e6f96`](https://github.com/NixOS/nixpkgs/commit/478e6f963e3c22ecbd352dae1101569b2d8e5eea) python3Packages.androidtv: 0.0.65 -> 0.0.66
* [`c5914daa`](https://github.com/NixOS/nixpkgs/commit/c5914daa9f80bef4669909f5d9879c2869c67dad) python3Packages.s3-credentials: add pythonImportsCheck
* [`939ac39e`](https://github.com/NixOS/nixpkgs/commit/939ac39ee49de2a2e747c4d5533b1bb8a95b53c3) python3Packages.asyncmy: 0.2.3 -> 0.2.4
* [`d0b22196`](https://github.com/NixOS/nixpkgs/commit/d0b22196f515b0143d8b5bdf312f2e42e312646d) python3Packages.unicrypto: init at 0.0.2
* [`b0d31a69`](https://github.com/NixOS/nixpkgs/commit/b0d31a697f9bd46d43caf58082cda5d5ea5be8ac) python3Packages.unicrypto: 0.0.2 -> 0.0.5
* [`be917906`](https://github.com/NixOS/nixpkgs/commit/be917906e2e78d9af6bce7f8758d09dc4b517c16) python3Packages.minikerberos: 0.2.18 -> 0.2.20
* [`27d0d8d6`](https://github.com/NixOS/nixpkgs/commit/27d0d8d64b4aa5b12065ec75061666d60bb9cccd) python310Packages.ansible-later: 2.0.6 -> 2.0.8
* [`e2cc03a0`](https://github.com/NixOS/nixpkgs/commit/e2cc03a069d834236dff1fb89eb955a26f15a9ea) python3Packages.subarulink: 0.4.3 -> 0.5.0
* [`9c26dceb`](https://github.com/NixOS/nixpkgs/commit/9c26dceb88f76bf503d474a2593175446f9bcdb4) python3Packages.ansible-later: set version, enable tests
* [`9ee8097b`](https://github.com/NixOS/nixpkgs/commit/9ee8097b31a2f7aed41b7bc1c15d7f3fbee2bc5f) linux: 4.14.273 -> 4.14.274
* [`f77a0e19`](https://github.com/NixOS/nixpkgs/commit/f77a0e19341a9c1b41d0951f30d732de51530221) linux: 4.19.236 -> 4.19.237
* [`61df0a1d`](https://github.com/NixOS/nixpkgs/commit/61df0a1d7dd69a973913fe98efccc6bbdbd206a6) linux: 4.9.308 -> 4.9.309
* [`2abfedc5`](https://github.com/NixOS/nixpkgs/commit/2abfedc54c38442a6660c3a5569bd53c0ed5aa18) linux: 5.10.108 -> 5.10.109
* [`6c6a932a`](https://github.com/NixOS/nixpkgs/commit/6c6a932a9e28ef618fce839d545b6867d533ed40) linux: 5.15.31 -> 5.15.32
* [`aa374b7a`](https://github.com/NixOS/nixpkgs/commit/aa374b7acb3119ec7c83f3d564942549e24c9fc0) linux: 5.16.17 -> 5.16.18
* [`2ddb5604`](https://github.com/NixOS/nixpkgs/commit/2ddb5604db46d2b8e30d49ba5db7c87281afafac) linux: 5.17 -> 5.17.1
* [`566270be`](https://github.com/NixOS/nixpkgs/commit/566270be89071fcc732d20b5d907794b1f13b2e5) linux: 5.4.187 -> 5.4.188
* [`7d1a55bd`](https://github.com/NixOS/nixpkgs/commit/7d1a55bdfb7feca0fdfe9ea7105b5c340f455999) gitlab: 14.8.4 -> 14.9.1 ([nixos/nixpkgs⁠#165309](https://togithub.com/nixos/nixpkgs/issues/165309))
* [`bb18719b`](https://github.com/NixOS/nixpkgs/commit/bb18719b6d305b8395b6d4def57b1a8d452794e7) python310Packages.habanero: 1.0.0 -> 1.2.0
* [`881e60eb`](https://github.com/NixOS/nixpkgs/commit/881e60eb98bac9ccb92f2c9d7ee05aff9afc0f37) linuxPackages.rtl8821ce: fix build for kernel >= 5.17
* [`b83c8aff`](https://github.com/NixOS/nixpkgs/commit/b83c8aff1e21a071ce8a623dbdc76ac148156c08) rar: fix build on darwin
* [`be3b235c`](https://github.com/NixOS/nixpkgs/commit/be3b235cd19e0be790087a6e3f972a847ad44aed) rar: 6.0.2 -> 6.11
* [`3ae9e59e`](https://github.com/NixOS/nixpkgs/commit/3ae9e59e41776520c05836501223671d3586839d) python39Packages.editorconfig: workaround removal of git://
* [`7963f78b`](https://github.com/NixOS/nixpkgs/commit/7963f78ba7c52a85e0db3f3a7748f5f68da4eb49) python3Packages.habanero: add pythonImportsCheck
* [`bea3dc3a`](https://github.com/NixOS/nixpkgs/commit/bea3dc3a4cbdf9e1275604d58a2fa534455152e8) nixui: replace git://github.com with https://
* [`17c8525e`](https://github.com/NixOS/nixpkgs/commit/17c8525e51ac96ef83369a1071d573098cd8e45e) onlykey: replace git://github.com with https://
* [`21120194`](https://github.com/NixOS/nixpkgs/commit/21120194ee6db25b41359ed0eb0eca0e5da855d7) luarocks-packages: replace git://github.com with https://
* [`97f06b5e`](https://github.com/NixOS/nixpkgs/commit/97f06b5e0b3906e6f0141d85dcd5ab3aa2a55816) byzan: switch to working source
* [`cd4a0b88`](https://github.com/NixOS/nixpkgs/commit/cd4a0b8875a03fdbfb2a5f0bc343083ac930777d) python3Packages.pyskyqhub: 0.1.6 -> 0.1.7
* [`7be87f3d`](https://github.com/NixOS/nixpkgs/commit/7be87f3dabfeeb0f8bcacb9b4a5a6040362dc30d) python3Packages.pyskyqhub: 0.1.7 -> 0.1.8
* [`4c766274`](https://github.com/NixOS/nixpkgs/commit/4c766274c5669616be17af6f9cece3112cbae4ee) javaPackages.mavenfod: use mvnParameters in buildPhase
* [`60566767`](https://github.com/NixOS/nixpkgs/commit/60566767704d7eea7273dbc453374d4f7440ebda) dbeaver: use overridden maven in javaPackages.mavenfod
* [`83712ae1`](https://github.com/NixOS/nixpkgs/commit/83712ae183c16f789e605e2c5e1e40dfa5862fbe) python39Packages.google-auth-oauthlib: 0.4.6 -> 0.5.1
* [`8923ef18`](https://github.com/NixOS/nixpkgs/commit/8923ef18cf3d8c1f2e4d61700c5246edb8c8fe0c) python39Packages.tensorflow-tensorboard: relax version constraint
* [`87c0118a`](https://github.com/NixOS/nixpkgs/commit/87c0118ab1873a48f584566daf05ce6d691e8e2b) sshuttle: 1.0.5 -> 1.1.0, add SuperSandro2000 as maintainer
* [`b3de8509`](https://github.com/NixOS/nixpkgs/commit/b3de8509511fecc7276f6b5b393d823ea329cc87) python39Packages.swift: 2.29.0 -> 2.29.1
* [`51631359`](https://github.com/NixOS/nixpkgs/commit/51631359fa1d9a6f229aaac9e0af7beec7742389) yq-go: 4.23.1 -> 4.24.2
* [`6da02123`](https://github.com/NixOS/nixpkgs/commit/6da02123602069ced56d0c733658a4fd509b6964) taffybar: build using GHC 8.10.7
* [`ed6c2f9d`](https://github.com/NixOS/nixpkgs/commit/ed6c2f9d8489c17fecb4011f57280372e70be26c) argocd-autopilot: init at 0.3.0
* [`8aa41aea`](https://github.com/NixOS/nixpkgs/commit/8aa41aeaea77d1ad943abbbbaf0252b1a4cee81c) teleport: fix exec srv command not found ([nixos/nixpkgs⁠#165588](https://togithub.com/nixos/nixpkgs/issues/165588))
* [`de0f59ea`](https://github.com/NixOS/nixpkgs/commit/de0f59ea3782a272b7b76620cfb73d172786aa99) kaf: init at 0.1.44 ([nixos/nixpkgs⁠#164175](https://togithub.com/nixos/nixpkgs/issues/164175))
* [`9c37bef3`](https://github.com/NixOS/nixpkgs/commit/9c37bef37c6f9238de20911a8793d3629581f852) oh-my-zsh: 2022-03-26 -> 2022-03-28
* [`ecbf5ae2`](https://github.com/NixOS/nixpkgs/commit/ecbf5ae27a9ee6e877a20e3abce85c21e4bda9c2) nixosTest: Simplify doc by deprecating syntax sugar
* [`aa0f27ab`](https://github.com/NixOS/nixpkgs/commit/aa0f27abb06ca66a1dc99493ada65e2bbd6000c9) treewide: machine -> nodes.machine
* [`e2461d62`](https://github.com/NixOS/nixpkgs/commit/e2461d62b6c1936b8ab3adcb792ef11693639661) pkgs.tests.nixos-functions: machine -> nodes.machine
* [`b915133b`](https://github.com/NixOS/nixpkgs/commit/b915133bb16aaef8bfe289aeb795baf7f738290f) pipenv: 2022.3.24 -> 2022.3.28
* [`fad08c37`](https://github.com/NixOS/nixpkgs/commit/fad08c37e322ed894e43180c957bcf31702b766a) poco: move openssl to propagatedBuildInputs
* [`c8a5b5aa`](https://github.com/NixOS/nixpkgs/commit/c8a5b5aa89a2f8fa8bbe44f51a0e92c13d0e5d35) vimPlugins: update
* [`996863b0`](https://github.com/NixOS/nixpkgs/commit/996863b07e7c40ab9cb6a0ef664aa49fd0093f47) vimPlugins.coc-tailwindcss: init at 2020-08-19
* [`85f2d57a`](https://github.com/NixOS/nixpkgs/commit/85f2d57a48fc16bf7811a6c64c9ef5b145884020) vimPlugins.coc-svelte: init at 2022-03-14
* [`8c496e61`](https://github.com/NixOS/nixpkgs/commit/8c496e61930d1e83282d919da3a86ce4cff3091b) vimPlugins.vim-svelte: init at 2022-02-17
* [`d999e481`](https://github.com/NixOS/nixpkgs/commit/d999e481028779e10c1556e208604056015f8026) logiops: init at 0.2.3
* [`adf885ca`](https://github.com/NixOS/nixpkgs/commit/adf885ca00c87beded0c4697b5818710d5cd485f) gummy: init at 0.1
* [`e7aa35cc`](https://github.com/NixOS/nixpkgs/commit/e7aa35ccf1d2f864d022da23661c702a1099e050) python310Packages.aiowebostv: 0.1.3 -> 0.2.0
* [`e85e545d`](https://github.com/NixOS/nixpkgs/commit/e85e545dbda8bdf09b32e69545ace49b7bc63c23) powerdns: 4.3.1 -> 4.6.1
* [`fc49bc19`](https://github.com/NixOS/nixpkgs/commit/fc49bc19edd8e9eaea703c795395c2f78354ba80) powerdns: redact configure flags from version output to reduce closure size
* [`fd50b869`](https://github.com/NixOS/nixpkgs/commit/fd50b86920839582243c3ef62e43b32ce7f945e4) flycast: init at 1.2
* [`6e822b50`](https://github.com/NixOS/nixpkgs/commit/6e822b50dfe52a53fb1ca257465691ddffdc659b) reicast: remove
* [`c75a58bb`](https://github.com/NixOS/nixpkgs/commit/c75a58bb927d010f90c66f54999d42e5a93c1f6c) bless: fix build with meson 0.61
* [`ee684089`](https://github.com/NixOS/nixpkgs/commit/ee684089c3509820d6f1fc8938025d091797c3d6) melt: init at 0.2.0 ([nixos/nixpkgs⁠#164439](https://togithub.com/nixos/nixpkgs/issues/164439))
* [`b133ad05`](https://github.com/NixOS/nixpkgs/commit/b133ad055b129b7b7e8e66f883b6120f41f8b584) ydotool: minor fixes ([nixos/nixpkgs⁠#166050](https://togithub.com/nixos/nixpkgs/issues/166050))
* [`37af56dc`](https://github.com/NixOS/nixpkgs/commit/37af56dc3621ca97fae33801b5cac3233dcf2354) ventoy-bin: 1.0.56 -> 1.0.72
* [`af262002`](https://github.com/NixOS/nixpkgs/commit/af26200234b81d2ed83b3937b73099892bcbdea4) gnomeExtensions: add gnome40Extensions to gnomeExtensions
* [`2f2049b1`](https://github.com/NixOS/nixpkgs/commit/2f2049b1fd78bff3395c823baf91da815ddcc116) python310Packages.asyncstdlib: 3.10.3 -> 3.10.4
* [`bcdb2fde`](https://github.com/NixOS/nixpkgs/commit/bcdb2fdee603dd13066f184b0fe6c2b744752428) mate.mate-backgrounds: fix build with meson 0.61
* [`3221d6d4`](https://github.com/NixOS/nixpkgs/commit/3221d6d4188ac63fbb77f9d11aabf6c890a76eeb) rl-2205: fix typo in frrrouting announcement
* [`a8aaeb6e`](https://github.com/NixOS/nixpkgs/commit/a8aaeb6e5379f8b6455fa1072822de0c8099bbbe) clickhouse 21.8.12.29 -> 22.3.2.2
* [`bda82086`](https://github.com/NixOS/nixpkgs/commit/bda820861213579f27b25eec27e80b7e58d9d463) python310Packages.azure-mgmt-cognitiveservices: 13.0.0 -> 13.1.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
