### PR TITLE
niv emacs-overlay: update a162b8f8 -> d32cf218

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a162b8f8420c640d78b7ef3ab9d49197666f309a",
-        "sha256": "09fvjypxivh8l9g3qx6z55dcsfccf7clrv8q54slpxqfifv0dp55",
+        "rev": "d32cf21820f0c14bb4dc7911e4d8d81b891a8f82",
+        "sha256": "045bqf15lxba75lzp95l1xg6ah5cl7p04gkyihsxl3a9j9ngr219",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/a162b8f8420c640d78b7ef3ab9d49197666f309a.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/d32cf21820f0c14bb4dc7911e4d8d81b891a8f82.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@a162b8f8...d32cf218](https://github.com/nix-community/emacs-overlay/compare/a162b8f8420c640d78b7ef3ab9d49197666f309a...d32cf21820f0c14bb4dc7911e4d8d81b891a8f82)

* [`1460b24c`](https://github.com/nix-community/emacs-overlay/commit/1460b24cdce9682f3dd0989f95f7974f3c93bfc9) Updated repos/emacs
* [`ca681435`](https://github.com/nix-community/emacs-overlay/commit/ca681435ecff48905feb643cfa99b1112943289c) Updated repos/melpa
* [`98fde110`](https://github.com/nix-community/emacs-overlay/commit/98fde110b710b4a528d0d38992ad0f95b0b42ebf) Updated repos/elpa
* [`5dddd158`](https://github.com/nix-community/emacs-overlay/commit/5dddd15862f7c1fdf75ba6ad471ec11cc2136744) Updated repos/emacs
* [`96ff9742`](https://github.com/nix-community/emacs-overlay/commit/96ff9742f4c983b8f0dd4ce3e5fc8bd200328021) Updated repos/melpa
* [`8b429d19`](https://github.com/nix-community/emacs-overlay/commit/8b429d1916e221fa94271d0c3da79616e6c69976) Updated repos/elpa
* [`14ac7e08`](https://github.com/nix-community/emacs-overlay/commit/14ac7e083329a2370007461ec446f8bfae173708) Updated repos/emacs
* [`26da73dd`](https://github.com/nix-community/emacs-overlay/commit/26da73dd9129d267f0c8c26b591ab91050c4cdc9) Updated repos/melpa
* [`1cd24591`](https://github.com/nix-community/emacs-overlay/commit/1cd24591055c96113ae1de21aa9cece808e48f81) Updated repos/emacs
* [`af2208c4`](https://github.com/nix-community/emacs-overlay/commit/af2208c42bca9e11703fd4d3853a56213e88cbb8) Updated repos/melpa
* [`278634fc`](https://github.com/nix-community/emacs-overlay/commit/278634fca1386ebeb83c7dff06ff3f601974d7d4) Updated repos/elpa
* [`31e8ddc2`](https://github.com/nix-community/emacs-overlay/commit/31e8ddc2ba06837c5342f43f3c7265be2d577b18) Updated repos/emacs
* [`578eda92`](https://github.com/nix-community/emacs-overlay/commit/578eda92635e270c8b01edfd67aed6a3e8bf7d27) Updated repos/melpa
* [`7ad268f1`](https://github.com/nix-community/emacs-overlay/commit/7ad268f13d72a2e5c357cb83c6def71438217308) Updated repos/melpa
* [`43f90396`](https://github.com/nix-community/emacs-overlay/commit/43f90396e9bdec7fda51a9937a39e8359656aded) Updated repos/emacs
* [`19d35fdb`](https://github.com/nix-community/emacs-overlay/commit/19d35fdbc8f231d548ad907c1a9360b885f35840) Updated repos/melpa
* [`dab08d6d`](https://github.com/nix-community/emacs-overlay/commit/dab08d6d17180e41ea1a184aabf37e1e593e831d) Updated repos/emacs
* [`c86edadc`](https://github.com/nix-community/emacs-overlay/commit/c86edadc97e49bf95122b4cc9785216b0b4a9fea) Updated repos/melpa
* [`656606b7`](https://github.com/nix-community/emacs-overlay/commit/656606b7d41e1680db3a906d58a128d02f8c3da5) Updated repos/emacs
* [`4993cb95`](https://github.com/nix-community/emacs-overlay/commit/4993cb95c8e27e7ba9ca8dc93ffac4fb5af52d66) Updated repos/melpa
* [`0e8c5267`](https://github.com/nix-community/emacs-overlay/commit/0e8c5267921ac19ae104e659870215fec13391a4) Updated repos/emacs
* [`ad46389a`](https://github.com/nix-community/emacs-overlay/commit/ad46389a90ab0cb5a44c9f9a2a258d84aac7a07f) Updated repos/melpa
* [`0addc805`](https://github.com/nix-community/emacs-overlay/commit/0addc805e8310e1d81cfcd66c389c018bf7a6f84) Updated repos/elpa
* [`21758563`](https://github.com/nix-community/emacs-overlay/commit/2175856359ef764b1a126766501cd4c1b72c52bf) Updated repos/emacs
* [`1841bd38`](https://github.com/nix-community/emacs-overlay/commit/1841bd389b6b45d2666abda2f807fdca972172e3) Updated repos/melpa
* [`1f26b59a`](https://github.com/nix-community/emacs-overlay/commit/1f26b59a63261af6bd53b044a7004fe053e75384) Updated repos/emacs
* [`c43afd74`](https://github.com/nix-community/emacs-overlay/commit/c43afd748147e2bf631e5b37f7a68e93a98f89c5) Updated repos/melpa
* [`9fe74460`](https://github.com/nix-community/emacs-overlay/commit/9fe744605c57daaa0d5738ba913c79989cfc92fa) Updated repos/emacs
* [`78e6967b`](https://github.com/nix-community/emacs-overlay/commit/78e6967b1f1aae778daf550ca4af0e193853098d) Updated repos/melpa
* [`aa1974b0`](https://github.com/nix-community/emacs-overlay/commit/aa1974b0537180cb431700c07ff21e17a4ca2613) Updated repos/emacs
* [`13b20a65`](https://github.com/nix-community/emacs-overlay/commit/13b20a65f9f8e865cd9a369bea1b5a0ad48016ba) Updated repos/melpa
* [`19ad0265`](https://github.com/nix-community/emacs-overlay/commit/19ad026508fa766e473ea092091cd4dc3e5735eb) Updated repos/nongnu
* [`5a2b7432`](https://github.com/nix-community/emacs-overlay/commit/5a2b74325992a4595f830affc92d1ffe26ce75ff) Updated repos/emacs
* [`8704d616`](https://github.com/nix-community/emacs-overlay/commit/8704d61679ea1025fa16f612579f80263c96c321) Updated repos/melpa
* [`ad606523`](https://github.com/nix-community/emacs-overlay/commit/ad60652382399b549a91a96fed1b6778fc05b716) Updated repos/emacs
* [`b131cc9c`](https://github.com/nix-community/emacs-overlay/commit/b131cc9cb68d6129a6c40a2d5fa525c75aa61bf8) Updated repos/melpa
* [`4ff628ac`](https://github.com/nix-community/emacs-overlay/commit/4ff628ac30212524e546fb5846bf94b24962b856) Updated repos/emacs
* [`78acfd21`](https://github.com/nix-community/emacs-overlay/commit/78acfd2182b0b119a6815010e99eda589d048889) Updated repos/melpa
* [`713d49d9`](https://github.com/nix-community/emacs-overlay/commit/713d49d994e40ad10d0fbd64b7824179337497a6) Updated repos/emacs
* [`104538c0`](https://github.com/nix-community/emacs-overlay/commit/104538c046d8dc037f09916b5a9d714571429783) Updated repos/melpa
* [`57479e3b`](https://github.com/nix-community/emacs-overlay/commit/57479e3b2f0660c8ae180d292073a06da66d24b8) Updated repos/nongnu
* [`6b473d95`](https://github.com/nix-community/emacs-overlay/commit/6b473d956d494a574fba9622e75a426941abcc84) Updated repos/elpa
* [`f57ac869`](https://github.com/nix-community/emacs-overlay/commit/f57ac86997be66eeb7b710375526d52e24a7c78a) Updated repos/emacs
* [`3ba65e6f`](https://github.com/nix-community/emacs-overlay/commit/3ba65e6ffec27162f6f62b9b6b2944669c26a43e) Updated repos/melpa
* [`a6ff9a59`](https://github.com/nix-community/emacs-overlay/commit/a6ff9a591ce905ea0fa46051410fd7387a89f467) Updated repos/elpa
* [`2e10a6b7`](https://github.com/nix-community/emacs-overlay/commit/2e10a6b7993893e40bf70c190e17d1bd749443ee) Updated repos/emacs
* [`d32cf218`](https://github.com/nix-community/emacs-overlay/commit/d32cf21820f0c14bb4dc7911e4d8d81b891a8f82) Updated repos/melpa
