### PR TITLE
niv niv: update 5912c378 -> df49d53b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5912c378c2f87e911f1bc7236202f69581406c9d",
-        "sha256": "1jhs562k3pk0xgwyf0m1h2bck4rivv9f3aznz8dslgby9g5mdnda",
+        "rev": "df49d53b71ad5b6b5847b32e5254924d60703c46",
+        "sha256": "1j5p8mi1wi3pdcq0lfb881p97i232si07nb605dl92cjwnira88c",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5912c378c2f87e911f1bc7236202f69581406c9d.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/df49d53b71ad5b6b5847b32e5254924d60703c46.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@5912c378...df49d53b](https://github.com/nmattia/niv/compare/5912c378c2f87e911f1bc7236202f69581406c9d...df49d53b71ad5b6b5847b32e5254924d60703c46)

* [`9d09779a`](https://github.com/nmattia/niv/commit/9d09779ad1f3ee5fc29cc3ae849268e15fe83c84) Work with (only) aeson 2.
* [`533d1ba9`](https://github.com/nmattia/niv/commit/533d1ba912944c7d5d4e5d058aef5d57732bdb4e) Fix Nix setup to use aeson 2.
* [`81192ec5`](https://github.com/nmattia/niv/commit/81192ec5536b745944a3d4668bd1d748c704c17f) Fix formatting.
* [`2998a663`](https://github.com/nmattia/niv/commit/2998a663d03ef9521585f67cf8fdfa8dac348462) Make tests work with newest Nix.
* [`df49d53b`](https://github.com/nmattia/niv/commit/df49d53b71ad5b6b5847b32e5254924d60703c46) Release 0.2.20
