### PR TITLE
niv spacemacs: update c2a9aaed -> d79b12e7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "c2a9aaedffdebb511651e0e2299fc0282521ee73",
-        "sha256": "0yxkd24a23bzjpi5653z5zrhhk0w4lj8dw19z9a3x0ycs97a8c5f",
+        "rev": "d79b12e7b4634f1212c4f5aaad756851335aa008",
+        "sha256": "1nh25aa0nvaiaiwrqi20hmq9q3c414dc5v0wahd5khya53hyv9di",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/c2a9aaedffdebb511651e0e2299fc0282521ee73.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/d79b12e7b4634f1212c4f5aaad756851335aa008.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@c2a9aaed...d79b12e7](https://github.com/syl20bnr/spacemacs/compare/c2a9aaedffdebb511651e0e2299fc0282521ee73...d79b12e7b4634f1212c4f5aaad756851335aa008)

* [`2202597e`](https://github.com/syl20bnr/spacemacs/commit/2202597ee3b459b047556414f8f85466f3f4fe7f) notmuch: Fix company based address completion ([syl20bnr/spacemacs⁠#15392](https://togithub.com/syl20bnr/spacemacs/issues/15392))
* [`97af6fa9`](https://github.com/syl20bnr/spacemacs/commit/97af6fa9f843832d3795e9b3fc174dac57de08bb) [neotree] Add zz, zt, zb bindings
* [`d3d50f58`](https://github.com/syl20bnr/spacemacs/commit/d3d50f580bce1fcf4ff09e055cf0c4786cf2d4b0) [spacemacs-editing] initialize `undo-tree-history-directory-alist`
* [`38c03449`](https://github.com/syl20bnr/spacemacs/commit/38c034494d54e33a4ab3f7e3fa46de2668387575) [core] Make startup not fail when home buffer is customised
* [`587f584e`](https://github.com/syl20bnr/spacemacs/commit/587f584ebc17bb8a2d262bde0bcb026ebe749808) [lsp] Change default source of bindings back to spacemacs
* [`6774f37f`](https://github.com/syl20bnr/spacemacs/commit/6774f37fc1c542fab664f1b65931e52a4991d71a) Fix [syl20bnr/spacemacs⁠#15306](https://togithub.com/syl20bnr/spacemacs/issues/15306). Reflect eaf layer keybinding logic to upstream changes.
* [`d79b12e7`](https://github.com/syl20bnr/spacemacs/commit/d79b12e7b4634f1212c4f5aaad756851335aa008) Replace alist helm sources with proper helm sources ([syl20bnr/spacemacs⁠#15364](https://togithub.com/syl20bnr/spacemacs/issues/15364))
