### PR TITLE
niv nixpkgs: update ed3074e0 -> 00aa5372

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ed3074e07b5ef19b7148aa1a73e1a0afa73ed40c",
-        "sha256": "0dz5g1vii2v6r5293akhi681c36kjqynmh2h7xzk6nc705c5h0sy",
+        "rev": "00aa5372094568f4634c94b72fa8f1a9eec34f72",
+        "sha256": "11km38p6vqpk83nhxhw097qbxhcnkw3xv0sp96yl178i599zjr4v",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ed3074e07b5ef19b7148aa1a73e1a0afa73ed40c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/00aa5372094568f4634c94b72fa8f1a9eec34f72.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ed3074e0...00aa5372](https://github.com/nixos/nixpkgs/compare/ed3074e07b5ef19b7148aa1a73e1a0afa73ed40c...00aa5372094568f4634c94b72fa8f1a9eec34f72)

* [`a62c5f34`](https://github.com/NixOS/nixpkgs/commit/a62c5f34356fcbbec9b02f54ed655d06cc9634c2) nixos/mailman: use separate virtualHosts
* [`b3823a35`](https://github.com/NixOS/nixpkgs/commit/b3823a35e5579e5d1a051f6011bc86ea0e754b50) qtwayland: declare proper `app_id` for wrapped executables
* [`4f209920`](https://github.com/NixOS/nixpkgs/commit/4f209920e3af0e402de40f164c1e5a53e8a3d4e7) bugdom: init at 1.3.1
* [`831dbf4e`](https://github.com/NixOS/nixpkgs/commit/831dbf4e0a8ce8d1b4d2830ead35461aba4a72ac) nixos/virtualisation/azure-common: add auto resize of os disk
* [`60b5f837`](https://github.com/NixOS/nixpkgs/commit/60b5f837cac1c5a7f3fac221bf50191bbfac01f6) mysql80: fix build on Darwin
* [`4e199a91`](https://github.com/NixOS/nixpkgs/commit/4e199a91dc49659ea3ecd7f8e174d6ade2a1d717) mesa.drivers: Convert hard links to symlinks
* [`be85a554`](https://github.com/NixOS/nixpkgs/commit/be85a5548509d267cdeae8a13a02e019c3dbcfac) valgrind: Search NIX_DEBUG_INFO_DIRS for debug info
* [`4bb77929`](https://github.com/NixOS/nixpkgs/commit/4bb779294e0cf7e45eea52c93c8ad97a6cf9a549) libpsl: Add glibc.debug for valgrind tests
* [`d6525567`](https://github.com/NixOS/nixpkgs/commit/d65255675854b4d2bd367549a423988bf8ddc5e5) separateDebugInfo: Use --strip-unneeded
* [`21babd5d`](https://github.com/NixOS/nixpkgs/commit/21babd5d529aae112c473ad438d93686a0df2149) linux: enable ISO9660_FS module
* [`81380e5b`](https://github.com/NixOS/nixpkgs/commit/81380e5b4ac56057cfc741dc07e1280fdf5ae774) grpc: 1.43.0 -> 1.44.0
* [`a93a11df`](https://github.com/NixOS/nixpkgs/commit/a93a11df1d5c53376b1d5d66063d6fe42ac88660) python3Packages.grpcio-status: 1.43.0 -> 1.44.0
* [`4d3651ca`](https://github.com/NixOS/nixpkgs/commit/4d3651ca292d2b641356f3c0282ecae45680f8c6) python3Packages.grpcio-tools: 1.43.0 -> 1.44.0
* [`eba4cbbd`](https://github.com/NixOS/nixpkgs/commit/eba4cbbde174f48ce985fb85491ffb5f86df940a) libnetfilter_conntrack: 1.0.8 -> 1.0.9
* [`f1f9d37e`](https://github.com/NixOS/nixpkgs/commit/f1f9d37ec4a673c05c1db4341c6637a3d5df97f2) libusb1: 1.0.24 -> 1.0.25
* [`b7da6c7d`](https://github.com/NixOS/nixpkgs/commit/b7da6c7da765bb07fbcd3366d29d89c56cf25e97) stdenv, dep-licenses.sh: do not skip handling of other exit traps
* [`6799a918`](https://github.com/NixOS/nixpkgs/commit/6799a9184336146467eb71298d6b18ba7f45e0dc) Revert "prosody: work around makeWrapper bug"
* [`6a08fcb5`](https://github.com/NixOS/nixpkgs/commit/6a08fcb524804d14cbbc527d417d81b658e4209c) python3Packages.scmrepo: 0.0.7 -> 0.0.8
* [`f94dfc5b`](https://github.com/NixOS/nixpkgs/commit/f94dfc5b40ab5ced42a13fa79ecc915935e7b182) aspell: Build with ncurses
* [`a5eb7d85`](https://github.com/NixOS/nixpkgs/commit/a5eb7d85c83ba9e965daa8eca1fd420d835c7cfb) wxwidgets: remove unused asserts
* [`ee2f1269`](https://github.com/NixOS/nixpkgs/commit/ee2f1269d0734cafb182dc90e2848e138855e698) wxwidgets: remove darwin from inputs
* [`368ad4df`](https://github.com/NixOS/nixpkgs/commit/368ad4df2ea6900656287072d32fe9f0d22d9ec5) wxwidgets: resolve easy let ins
* [`db949f02`](https://github.com/NixOS/nixpkgs/commit/db949f020acda8460616f81ac85ed6fd130c1fe9) gmpxx: remove appendToName to have a consistent package name for repology
* [`b14ec1a9`](https://github.com/NixOS/nixpkgs/commit/b14ec1a927b82b7792d0b1244be4a68110eb400f) libusb1: fix build on darwin
* [`c01851e3`](https://github.com/NixOS/nixpkgs/commit/c01851e31c3f25a1debb130517b0a06c9bc8c772) ghostscriptX: remove appendToName to have a consistent package name for repology
* [`f24f73b5`](https://github.com/NixOS/nixpkgs/commit/f24f73b562140d8af7299b6dfc5a976c9f8af0cc) kde-frameworks: rename name to pname
* [`0269c10d`](https://github.com/NixOS/nixpkgs/commit/0269c10d747b3d95847d4afc19e84701c9ff0fab) openssh: 8.8p1 -> 8.9p1
* [`1cf552b7`](https://github.com/NixOS/nixpkgs/commit/1cf552b7db2dd9aeda460b3ab8553a21605c2f39) isl: rename name to pname&version
* [`92074a45`](https://github.com/NixOS/nixpkgs/commit/92074a45f308a1c42de2c57233471bfd7cc6189c) darwin.apple_sdk.frameworks.IOSurface: use Libsystem instead of xpc ([nixos/nixpkgs⁠#161561](https://togithub.com/nixos/nixpkgs/issues/161561))
* [`215b0774`](https://github.com/NixOS/nixpkgs/commit/215b0774d134c824ace91865d8a37c8f7839e7d8) libappindicator: rename name to pname&version
* [`c7d1c416`](https://github.com/NixOS/nixpkgs/commit/c7d1c41680c7d0c1ddea0098205a469e06175e95) flac: 1.3.3 -> 1.3.4
* [`4fe96a6b`](https://github.com/NixOS/nixpkgs/commit/4fe96a6b168fbd2165ee4962503f487ac188695c) Test curses dependency
* [`e693994c`](https://github.com/NixOS/nixpkgs/commit/e693994cc8704b5fe9d9ca294c369811f9ccff58) patchelf: 0.14.3 -> 0.14.5
* [`c5e32a90`](https://github.com/NixOS/nixpkgs/commit/c5e32a90f8df3f1f890fde6c3800ce67673b3ab5) sqlite: 3.37.2 -> 3.38.0
* [`1bcbec67`](https://github.com/NixOS/nixpkgs/commit/1bcbec677a6925ce415841f3a50ffc48915e4363) cyrus_sasl: 2.1.27 -> 2.1.28
* [`7cc08a32`](https://github.com/NixOS/nixpkgs/commit/7cc08a32e1b043abe26fdf306c228fd5413095d7) cyrus_sasl: set up passthru tests
* [`b69be3d8`](https://github.com/NixOS/nixpkgs/commit/b69be3d855d33ea41d8a240ba0784a130cc98cd8) avahi: rename name to pname
* [`041dcd46`](https://github.com/NixOS/nixpkgs/commit/041dcd46a5de60165e43912ffdad4a32e65808ab) krb5: rename name to pname&version
* [`daef4faf`](https://github.com/NixOS/nixpkgs/commit/daef4faf187913c17b5bd74fee9d54a570fb79ec) python3Packages.uvloop: fix tests on Darwin
* [`9427d3e0`](https://github.com/NixOS/nixpkgs/commit/9427d3e060a90e359fd5473cc6b2f8f9a102a3bc) ijs: rename name to pname&version
* [`4322a397`](https://github.com/NixOS/nixpkgs/commit/4322a397635c4a9cb5b4c14fcee973ffd4f01b27) apparmor: 3.0.3 -> 3.0.4
* [`68cf28ce`](https://github.com/NixOS/nixpkgs/commit/68cf28cec7f7984609db006912fc104c00eef6d9) apparmor: clean-up python path
* [`dc93e103`](https://github.com/NixOS/nixpkgs/commit/dc93e10397b6efadefe58fe0a74925595d273d75) rust: 1.58.1 -> 1.59.0
* [`5db064da`](https://github.com/NixOS/nixpkgs/commit/5db064dafb15a5d369d3ff09679514d8d18b23a0) libva: 2.13.0 -> 2.14.0
* [`f4b7ce72`](https://github.com/NixOS/nixpkgs/commit/f4b7ce72bf10d4af61e6ac6b240cf341f5d28e37) libva-utils: 2.13.0 -> 2.14.0
* [`dcd0f1c6`](https://github.com/NixOS/nixpkgs/commit/dcd0f1c61725ec45bc5774df5a71a24f6efca8ef) modemmanager: 1.18.4 -> 1.18.6
* [`5100787c`](https://github.com/NixOS/nixpkgs/commit/5100787ca284f6749807b33225ab0489d2ba14d6) spaceship-prompt: 3.16.3 -> 3.16.4
* [`59f6ea24`](https://github.com/NixOS/nixpkgs/commit/59f6ea24c994d40443c66cc4fe643d8e1c453a94) bubblewrap: 0.5.0 -> 0.6.0
* [`155d3794`](https://github.com/NixOS/nixpkgs/commit/155d379451b1d84be804ef2babda55e0ebfcc5a6) flyway: 7.13.0 -> 8.5.1
* [`5f4816c0`](https://github.com/NixOS/nixpkgs/commit/5f4816c06a7ff35468cf194c42b5ccc1d1568556) python310Packages.phonenumbers: 8.12.43 -> 8.12.44
* [`a5c3d34c`](https://github.com/NixOS/nixpkgs/commit/a5c3d34c636a11e3b1d4940d9b80283c7de289ac) fastlane: 2.171.0 -> 2.204.3
* [`534cb85e`](https://github.com/NixOS/nixpkgs/commit/534cb85ea247e4299f56520320f9954cf2cd1c14) fdroidserver: 2.0.3 -> 2.1
* [`4b331bea`](https://github.com/NixOS/nixpkgs/commit/4b331bea5bcab8c35d3f42ad6fbe5931eaf12dc9) libngspice: 34 -> 36
* [`8f548c84`](https://github.com/NixOS/nixpkgs/commit/8f548c8401d5ec0c4700b03eb2119975b07c76ec) python3Packages.requests: remove unneded trustme dependency
* [`97acaf6d`](https://github.com/NixOS/nixpkgs/commit/97acaf6d65e869abf7dc9e6825aef4c0e7b98432) glibc: 2.33-108 -> 2.34-115
* [`7459a402`](https://github.com/NixOS/nixpkgs/commit/7459a4021cb33d71598f0cbf8c798f9168638d3f) stdenv-bootstrap: force using new libc from stage2
* [`7bc32b3e`](https://github.com/NixOS/nixpkgs/commit/7bc32b3e5cc623a7b4b0fad900db26258592b9e6) glibc: symlink `libpthread.so -> libpthread.so.0` (same for `-lrt`) for backwards compatibility
* [`49028fb1`](https://github.com/NixOS/nixpkgs/commit/49028fb110ffb19e5326879d7ec6245ebd0315d2) findutils: fix build w/glibc-2.34
* [`9fe34ccf`](https://github.com/NixOS/nixpkgs/commit/9fe34ccfbe8e80f6c0c5b2df3625e0e44d2ed070) glibc: also create backwards-compat symlinks for libdl and libutil
* [`f363b7c5`](https://github.com/NixOS/nixpkgs/commit/f363b7c5dfc50b3b3051c333678d22fd318fa89d) boost1{69,70,72}: fix build w/glibc-2.34
* [`1b8aa881`](https://github.com/NixOS/nixpkgs/commit/1b8aa881ea438df01fa112d4d4c8f11ef0bbef26) glibc: revert `/bin/bash` usage
* [`2357e828`](https://github.com/NixOS/nixpkgs/commit/2357e828f5dc9fca7dc9df0e62f210c79f948649) gdb: fix build w/glibc-2.34
* [`3aa6c49a`](https://github.com/NixOS/nixpkgs/commit/3aa6c49ab4a6b094ab6f125303b674bb99985f35) libressl: fix build w/glibc-2.34
* [`8631ba18`](https://github.com/NixOS/nixpkgs/commit/8631ba18eee7fe48dc17244fa8b6425b3d84201e) fuse: fix build w/glibc-2.34
* [`486f248c`](https://github.com/NixOS/nixpkgs/commit/486f248ce46043cd4c76e60012c83a14f310784e) catch: fix build w/glibc-2.34
* [`f81f59df`](https://github.com/NixOS/nixpkgs/commit/f81f59dfce012b9835980e2865e1c107fca009c8) autofs: fix build w/glibc-2.34
* [`b9078e58`](https://github.com/NixOS/nixpkgs/commit/b9078e581b20e613dfd3a36a262d2da31c74ce81) qt515.qtwebengine: fix build w/glibc-2.34
* [`0caf7e5f`](https://github.com/NixOS/nixpkgs/commit/0caf7e5f0c53b2a3c7320e376eda97e1b29baa68) qt514.qtwebengine: fix build w/glibc-2.34
* [`96418eb0`](https://github.com/NixOS/nixpkgs/commit/96418eb0e78ccce10d8c9e07457fa0c754cb04e8) rcs: fix build w/glibc-2.34
* [`48d71357`](https://github.com/NixOS/nixpkgs/commit/48d713574293092544bd7deae2cef1e789f478e1) emacs: fix build w/glibc-2.34
* [`1470227e`](https://github.com/NixOS/nixpkgs/commit/1470227ef41c4b101c77f3f1969d3978678215df) postfix: fix build w/glibc-2.34
* [`917b7e5f`](https://github.com/NixOS/nixpkgs/commit/917b7e5fd2e29346040dc95a39cae17f92eae0dc) ocaml: fix build w/glibc-2.34
* [`8e16dcc4`](https://github.com/NixOS/nixpkgs/commit/8e16dcc4aa268de14fdaa0fac4acf7c7a11df903) openjdk11: fix build w/glibc-2.34
* [`f97b9951`](https://github.com/NixOS/nixpkgs/commit/f97b9951865b659bd0ee3ae6662676ad0efafa4b) texinfo: fix build w/glibc-2.34
* [`bcf8aeff`](https://github.com/NixOS/nixpkgs/commit/bcf8aeff3c7fbf92d576f89dad6a21913f7eb37a) ocaml 4.10/4.11: fix build w/glibc-2.34
* [`f8a7d99e`](https://github.com/NixOS/nixpkgs/commit/f8a7d99e54e0a7cc0a41e89c74e04015aafdc369) spdlog: 1.8.5 -> 1.9.2, fix build w/glibc-2.34
* [`49a7ee96`](https://github.com/NixOS/nixpkgs/commit/49a7ee9604b6c4c0a7389baa293b9f57a331ed9c) seasocks: fix build w/glibc-2.34
* [`c2050675`](https://github.com/NixOS/nixpkgs/commit/c2050675d6c7f9d2a7aaaa3d3d00c7b4f22753cc) leatherman: fix build w/glibc-2.34
* [`b770794c`](https://github.com/NixOS/nixpkgs/commit/b770794ce34ad8d1f03a24954123d4c41487286c) eternal-terminal: fix build w/glibc-2.34
* [`c905ab58`](https://github.com/NixOS/nixpkgs/commit/c905ab58a2fe60e0a34b3c1ed13b28b573267da3) trenchbroom: fix build w/glibc-2.34
* [`7c578161`](https://github.com/NixOS/nixpkgs/commit/7c5781615febc475d9b33ae07d2cdf634b50a783) trafficserver: fix build w/glibc-2.34
* [`d4593d4d`](https://github.com/NixOS/nixpkgs/commit/d4593d4dafa3dab28acb76eb0256081077fcc15d) pdfslicer: fix build w/glibc-2.34
* [`a3f4ff59`](https://github.com/NixOS/nixpkgs/commit/a3f4ff59ae365e1f10b5fa36dd802eb7d7b326f6) openmw: mark as broken
* [`dbe99a01`](https://github.com/NixOS/nixpkgs/commit/dbe99a0172e9316cf5f3a9c6a3935efeecb1b1fc) ntp: fix build w/glibc-2.34
* [`f8fc20df`](https://github.com/NixOS/nixpkgs/commit/f8fc20df2b7bdae96c8b8abfae13f70437cc80bd) breakpad: fix build w/glibc-2.34
* [`65f5fdb8`](https://github.com/NixOS/nixpkgs/commit/65f5fdb81823a4875e8c714211ef117d3ededadf) arangodb*: fix build w/glibc-2.34
* [`84635a6e`](https://github.com/NixOS/nixpkgs/commit/84635a6e17a8907b1f28d3efb9d3b98ea61cbe66) apitrace: fix build w/glibc-2.34
* [`40fc0090`](https://github.com/NixOS/nixpkgs/commit/40fc0090fc5442d8dd67423284282548625618a6) aspcud: fix build w/glibc-2.34
* [`0bdcc484`](https://github.com/NixOS/nixpkgs/commit/0bdcc484855b74fc50f2f821e81ee9518550a4cb) conky: fix build w/glibc-2.34
* [`29e14f8a`](https://github.com/NixOS/nixpkgs/commit/29e14f8a72530d059a1eed65ab2c772cc91e76be) polyml*: fix build w/glibc-2.34
* [`da905d4c`](https://github.com/NixOS/nixpkgs/commit/da905d4cf918e28f924bab99c6f2a4012d55410d) nixos/stage-1: fix `modprobe` in initial ramdisk on systems w/glibc-2.34
* [`51886505`](https://github.com/NixOS/nixpkgs/commit/518865059a1818895575c9f82e7677d94f958957) libowfat: mark as broken
* [`5f56cd54`](https://github.com/NixOS/nixpkgs/commit/5f56cd54061d9d79aa387ad1df677cfac7eaf55f) tiscamera: fix build w/glibc-2.34
* [`18d915e4`](https://github.com/NixOS/nixpkgs/commit/18d915e48e2ff34a525eac03ab0dba82ef89eceb) ursadb: fix build w/glibc-2.34
* [`89caa8e5`](https://github.com/NixOS/nixpkgs/commit/89caa8e552328b8a28d0133ed5931927eb671ddc) libfive: mark as broken
* [`fe58c181`](https://github.com/NixOS/nixpkgs/commit/fe58c181d3573e35da55bf43c3827d2e7627c8af) libspf2: fix build w/glibc-2.34
* [`6b98a5e5`](https://github.com/NixOS/nixpkgs/commit/6b98a5e51256e8b9d7a5c30f93a8d4178554013f) nethack-qt: fix build w/glibc-2.34
* [`748faeb6`](https://github.com/NixOS/nixpkgs/commit/748faeb623035c1360eeb6dc4b05abf5defd721c) glibc: don't hide symbol `__nss_files_fopen`
* [`1046c86c`](https://github.com/NixOS/nixpkgs/commit/1046c86c9986ca7239b00a6ef1396aae0961ba90) libosmscout: fix build w/glibc-2.34
* [`c0f49544`](https://github.com/NixOS/nixpkgs/commit/c0f49544d4952b1c63180fbb3dd5af2611a1b6c6) maude: fix build w/glibc-2.34
* [`4427e547`](https://github.com/NixOS/nixpkgs/commit/4427e547ca418bac7cc2a6b4c5d144a4a2fac126) jetbrains.jdk: fix build w/glibc-2.34
* [`81e0c947`](https://github.com/NixOS/nixpkgs/commit/81e0c947ecbf88e89f75bed560b07ae2fdc006a5) xnee: fix build w/glibc-2.34
* [`7605d492`](https://github.com/NixOS/nixpkgs/commit/7605d492a772670ebe621a9d0a8f7e34dcf79300) qt512.qtwebengine: fix build w/glibc-2.34
* [`f3193097`](https://github.com/NixOS/nixpkgs/commit/f31930977deea1c0c49b8a72234a0a7a7864aa35) djmount: fix build w/glibc-2.34
* [`52bba1de`](https://github.com/NixOS/nixpkgs/commit/52bba1de8ae33329d9e5937f0585c56179160938) clingcon: fix build w/glibc-2.34
* [`322c4908`](https://github.com/NixOS/nixpkgs/commit/322c490803f242fef658f37f4ddf71b97e2e05fd) mustache-hpp: fix build w/glibc-2.34
* [`a2ac7c60`](https://github.com/NixOS/nixpkgs/commit/a2ac7c607b965aa2296421bfd801f1c74f09fd9a) recastnavigation: fix build w/glibc-2.34
* [`5f9c36c0`](https://github.com/NixOS/nixpkgs/commit/5f9c36c07f0f82d5488f7264651e32dd4c6b0e0a) spdlog_0: fix build w/glibc-2.34
* [`8ba95b68`](https://github.com/NixOS/nixpkgs/commit/8ba95b68554d35faa422dec4a8bb201510e6686b) symengine: fix build w/glibc-2.34
* [`6a977757`](https://github.com/NixOS/nixpkgs/commit/6a977757e284b76468c7973f094eb99aa20b9251) zeroc-ice: fix build w/glibc-2.34
* [`e10ea960`](https://github.com/NixOS/nixpkgs/commit/e10ea9608a46565bd4d8d0a692647f9ce43b1de5) gcc{7,9,10}: apply patches for asan w/glibc-2.34
* [`64f9c923`](https://github.com/NixOS/nixpkgs/commit/64f9c9236150cdf03ffacf2c5fcf0055fea1f428) soci: fix build w/glibc-2.34
* [`da55ba2a`](https://github.com/NixOS/nixpkgs/commit/da55ba2a06e02e200daa3433ea84d0f9874eff4e) sfizz: fix build w/glibc-2.34, actually enable tests
* [`9a9fff59`](https://github.com/NixOS/nixpkgs/commit/9a9fff59b28d06cd3f22397c778fcbacf46ccc22) quvi*: mark as broken
* [`357dd9ed`](https://github.com/NixOS/nixpkgs/commit/357dd9ed5f5d956e97080996bcf0ed6fdf5b3257) zeroc-ice-36: remove, unmaintained
* [`2db6c7e8`](https://github.com/NixOS/nixpkgs/commit/2db6c7e893ffcfa79e94fb3f6d70666c36e26043) jumanpp: fix build w/glibc-2.34
* [`b43a3567`](https://github.com/NixOS/nixpkgs/commit/b43a3567eca70579e2a34e5fba3fda6154ea142f) cpp-hocon: fix build w/glibc-2.34
* [`6320b724`](https://github.com/NixOS/nixpkgs/commit/6320b7240f75d11b5a96bc03372a839c53427433) cataclysm-dda: fix build w/glibc-2.34
* [`25172c97`](https://github.com/NixOS/nixpkgs/commit/25172c97d03c3035869c8a1a753232b0b5017cd1) securefs: fix build w/glibc-2.34
* [`11597d11`](https://github.com/NixOS/nixpkgs/commit/11597d116244611940d3366db7c85f7181a32ae3) sfxr-qt: fix build w/glibc-2.34
* [`e9187abf`](https://github.com/NixOS/nixpkgs/commit/e9187abff193a6689621acb00c3ee31c954bf793) gdb: remove `--disable-sim` fix
* [`69af73d4`](https://github.com/NixOS/nixpkgs/commit/69af73d4b05fcb2cdd35e9f82ba881718172a920) texinfo: review fixes
* [`238d634e`](https://github.com/NixOS/nixpkgs/commit/238d634e4b7cbe58c9d9fbc155ffcf19f25f2b12) ocaml: enable parallel building
* [`e110983e`](https://github.com/NixOS/nixpkgs/commit/e110983ed3c6bb301b9a4266e400e0e1b2ef58dd) glibc: add empty libpthread.a
* [`1077a6e0`](https://github.com/NixOS/nixpkgs/commit/1077a6e040b445bf3d0854a667a1c03f33aa5c60) nixos/stage-1: typo fixes
* [`91fa7657`](https://github.com/NixOS/nixpkgs/commit/91fa7657d180942da624520231754706940f23f4) stdenv: revert gcc hack
* [`41eb407d`](https://github.com/NixOS/nixpkgs/commit/41eb407d2c77046ed0cc8c4beb246be25728ffb2) Revert "jetbrains.jdk: fix build w/glibc-2.34"
* [`82580b15`](https://github.com/NixOS/nixpkgs/commit/82580b15188e994aff429220d1634b3fc6ad357f) cataclysm-dda: fix eval
* [`9239261d`](https://github.com/NixOS/nixpkgs/commit/9239261de14a81237e1cc74dfa1b0b09adb09e05) python3Packages.dnspython: fix tests
* [`b83b3490`](https://github.com/NixOS/nixpkgs/commit/b83b3490495f0a086597416e0766b6d5729e3c54) treewide: rename name to pname&version
* [`42236ccc`](https://github.com/NixOS/nixpkgs/commit/42236cccf4c8ac05e74ce57022bd24f59adfc597) wtype: 0.3 -> 0.4
* [`c330b2ac`](https://github.com/NixOS/nixpkgs/commit/c330b2ac0ab84b29f898d7e5f13e9fe039919a39) coursier: 2.1.0-M1 -> 2.1.0-M5
* [`32c30ae4`](https://github.com/NixOS/nixpkgs/commit/32c30ae43c475fdf2c2c60c6441821945ab3a88f) pkgs/stdenv/linux/default.nix: restore dropped gcc-wrapper
* [`98084125`](https://github.com/NixOS/nixpkgs/commit/9808412565795c8d2e560a4abefe4003dc45cc3f) libical: 3.0.11 -> 3.0.14
* [`d14fe018`](https://github.com/NixOS/nixpkgs/commit/d14fe018fcf9502dfa20fde84d45d8845e1441f4) libsecret: clean up
* [`d56a0b9d`](https://github.com/NixOS/nixpkgs/commit/d56a0b9d728ac92383a135760f8daa5bed1c9bdb) libsecret: 0.20.4 → 0.20.5
* [`821703c0`](https://github.com/NixOS/nixpkgs/commit/821703c0d20f28592ccb40d43246cdcfa644679d) libsecret: fix tests
* [`e2b96417`](https://github.com/NixOS/nixpkgs/commit/e2b9641729c32d3cc37ecd16ca82a0e43161fb10) perl: rename name to pname
* [`4261fff2`](https://github.com/NixOS/nixpkgs/commit/4261fff202d5758bac695d2523798e0fb5477ab0) libcbor: 0.8.0 -> 0.9.0, libfido2: 1.9.0 -> 1.10.0 ([nixos/nixpkgs⁠#157553](https://togithub.com/nixos/nixpkgs/issues/157553))
* [`d6af5366`](https://github.com/NixOS/nixpkgs/commit/d6af5366a5ea9c041ac637914c8df08f711c9888) seaweedfs: 2.90 -> 2.91
* [`b9ed8525`](https://github.com/NixOS/nixpkgs/commit/b9ed8525d90f648e5954d052b0ab38052963e4f6) python3Packages.httplib2: disable failing test on darwin
* [`d5cd8efa`](https://github.com/NixOS/nixpkgs/commit/d5cd8efaca6d2a04a35696ddc2f38a7a374e54d3) mesa.drivers: improve readability
* [`f5f9b6af`](https://github.com/NixOS/nixpkgs/commit/f5f9b6af9d207974075ce3963a6f17739beb3726) mesa.drivers: nit, more info in a comment
* [`ae747bc0`](https://github.com/NixOS/nixpkgs/commit/ae747bc0072f8e3eb2d17da131cd9134208a1142) rubygems: rename name to pname
* [`03d38f77`](https://github.com/NixOS/nixpkgs/commit/03d38f77498c155c5439dbf596409a7f9ff2c0e0) azure-storage-azcopy: 10.13.0 -> 10.14.0
* [`32c25e92`](https://github.com/NixOS/nixpkgs/commit/32c25e929866400c09d79a8cc92f6f4eb1b653fb) checkstyle: 9.3 -> 10.0
* [`12341ef5`](https://github.com/NixOS/nixpkgs/commit/12341ef5350a115d8899216d1ecb362c0ab9170d) codeql: 2.8.1 -> 2.8.2
* [`de0ff652`](https://github.com/NixOS/nixpkgs/commit/de0ff65232aaa38b61a0e07f120173b7d1c793c2) cwltool: 3.1.20220221074232 -> 3.1.20220224085855
* [`cba041c3`](https://github.com/NixOS/nixpkgs/commit/cba041c35d4817f83892e6a49c52fe34dde494d7) gitSVN,gitMinimal: remove appendToName to have a consistent package n… ([nixos/nixpkgs⁠#161390](https://togithub.com/nixos/nixpkgs/issues/161390))
* [`5545fb36`](https://github.com/NixOS/nixpkgs/commit/5545fb36d2eac17f3301dedce60e58ba8bf29a06) cargo: rename name to pname
* [`6381ee34`](https://github.com/NixOS/nixpkgs/commit/6381ee34b5a84a3935194de62e97d5ac22dc3a6f) rust: rename name to pname
* [`68e29163`](https://github.com/NixOS/nixpkgs/commit/68e29163aa51cf96f63a00015500fdcf722e573d) pebble: 2.3.0 -> 2.3.1
* [`a9dc51bd`](https://github.com/NixOS/nixpkgs/commit/a9dc51bd26ce5c667807b35ce96c39790bf8ef75) python3Packages.respx: 0.19.1 -> 0.19.2
* [`103f0186`](https://github.com/NixOS/nixpkgs/commit/103f0186e15a0485a9cd612b710e17e91e561e31) ocaml: rename name to pname
* [`322a608a`](https://github.com/NixOS/nixpkgs/commit/322a608a5e71dfcaf74cb66dd0cb2689947b68c0) mutt-ics: add new package
* [`72c95f28`](https://github.com/NixOS/nixpkgs/commit/72c95f2878c59ca359670376e393044238ef6258) php.extensions.datadog_trace: init at 0.70.0
* [`e3360ea4`](https://github.com/NixOS/nixpkgs/commit/e3360ea46cf66371a241621ddf7a1dabfcb1f842) libjpeg: 2.1.2 -> 2.1.3
* [`18c72c22`](https://github.com/NixOS/nixpkgs/commit/18c72c223a65a6bbe26f974f04976a279dce01e4) nftables: 1.0.1 -> 1.0.2
* [`dd3d4171`](https://github.com/NixOS/nixpkgs/commit/dd3d4171471b8bbd58550ca412c66dc54771fedf) python3Packages.pybind11: build in parallel
* [`abfcc2e0`](https://github.com/NixOS/nixpkgs/commit/abfcc2e0ffa1546d73f8df4373838f3c1275b392) mozillavpn: init at 2.7.1
* [`0de0c604`](https://github.com/NixOS/nixpkgs/commit/0de0c6049ca8d44e90e0cbbd774b235eb62eae83) opaline: 0.3.2 -> 0.3.3
* [`1e655654`](https://github.com/NixOS/nixpkgs/commit/1e6556547236cfcd7cf61f10f0f859637bd96c44) step-ca: 0.18.1 -> 0.18.2
* [`bcad3669`](https://github.com/NixOS/nixpkgs/commit/bcad3669e8b2b32bdaeace0618f02393121a41bf) util-linuxMinimal: remove appendToName to have a consistent package name for repology
* [`5c09870c`](https://github.com/NixOS/nixpkgs/commit/5c09870c0244bbcf47a84f379e05bf10c7aa3f0d) python3Packages.setuptools: 57.2.0 -> 60.8.2
* [`3411fecd`](https://github.com/NixOS/nixpkgs/commit/3411fecdd5afe7642aa2015e974881725159204d) python3Packages.parse-type: 0.5.6 -> 0.6.0
* [`31507976`](https://github.com/NixOS/nixpkgs/commit/31507976bc879492830004338dd847c8bacb0378) python3Packages.readme_renderer: disable tests that rely on old distutils behaviour
* [`20b0221e`](https://github.com/NixOS/nixpkgs/commit/20b0221ec3e97cfce9778df834c7311d34239522) python3Packages.pybind11: disable tests that parse setuptools output
* [`f1738923`](https://github.com/NixOS/nixpkgs/commit/f1738923eb0949cd8b14fea258347a770d9d85a4) python3Packages.async-lru: fix tests
* [`e26fba6f`](https://github.com/NixOS/nixpkgs/commit/e26fba6f34dcf90b715416c67fbdd008d83593ef) python3Packages.bitcoin-price-api: drop
* [`aaf81c37`](https://github.com/NixOS/nixpkgs/commit/aaf81c378c85b62e1836fec88e3bfb0b4c72f00e) python3Packages.django-widget-tweaks: fix build and update tests
* [`a98f94fc`](https://github.com/NixOS/nixpkgs/commit/a98f94fcf3bc4b096d666211b39798e6cae9ff0c) python3Packages.hypothesmith: patch lark requirement
* [`bef19b75`](https://github.com/NixOS/nixpkgs/commit/bef19b759f000cd0b2c83665f621cc54c4430188) python3Packages.hypothesmith: configure parallel build
* [`83c88278`](https://github.com/NixOS/nixpkgs/commit/83c88278c3c845d7183c3280ce975a6d36f375eb) isso: fix check phase
* [`3ee71049`](https://github.com/NixOS/nixpkgs/commit/3ee7104971a9b0f62a4ab118e6158846cf93c106) python3Packages.portalocker: disable setuptools sensitive test
* [`42dea375`](https://github.com/NixOS/nixpkgs/commit/42dea375bc96ab86fd0f6799d6169ae3800773ac) python3Packages.keepalive: mark brokenk for setuptools>=58
* [`4ecb548a`](https://github.com/NixOS/nixpkgs/commit/4ecb548a6b737755ee50bb234432d89b90c6b0e7) python3Packages.parameterizedtestcase: mark brokenk for setuptools>=58
* [`4cc256f2`](https://github.com/NixOS/nixpkgs/commit/4cc256f221c0c346ecd56333e8c36fd32b23369b) azure-cli: fix build
* [`4b2b144d`](https://github.com/NixOS/nixpkgs/commit/4b2b144dfe8dc1c925ed76fbe0446cb5efa61e71) python3Packages.nose-cover3: drop
* [`73726ba8`](https://github.com/NixOS/nixpkgs/commit/73726ba87d5651f8cc318deceb6225bde35c5944) python3Packages.setuptools: add patch for bundled distutils c++ support
* [`01667337`](https://github.com/NixOS/nixpkgs/commit/01667337f1a397fab9ac234eac1f975d37d482f4) release-python.nix: add buildcatrust to tested set
* [`3bb7f98d`](https://github.com/NixOS/nixpkgs/commit/3bb7f98d2b267326fe2111587170176167ef4d74) python3Packages.rich: 11.0.0 -> 11.2.0
* [`12c1e476`](https://github.com/NixOS/nixpkgs/commit/12c1e476814ad4497c24998b1b64914b76aa712e) datadog-agent: 7.33.1 -> 7.34.0
* [`ee885d43`](https://github.com/NixOS/nixpkgs/commit/ee885d43f704c686733311385788816156041ee7) es: 0.9.1 -> 0.9.2
* [`056b2ab4`](https://github.com/NixOS/nixpkgs/commit/056b2ab46bf391cb923c24da90356db6988605ec) jump: 0.40.0 -> 0.41.0
* [`187f86a2`](https://github.com/NixOS/nixpkgs/commit/187f86a227ad9afadb21f2b13057a6ff47cf1ff1) obs-studio: 27.2.1 -> 27.2.2
* [`c90cc201`](https://github.com/NixOS/nixpkgs/commit/c90cc201b3a51a4d7230ea319ce9a2c8ae38195d) git: install contrib git hooks
* [`71f1f488`](https://github.com/NixOS/nixpkgs/commit/71f1f4884b5e40ae6647fa7f0f1890554ad6aa7d) openssl: stop static binaries referencing libs
* [`7bd35b61`](https://github.com/NixOS/nixpkgs/commit/7bd35b61fe880ae282b7a332431b740f20406c3c) go_1_17: 1.17.7 -> 1.17.8
* [`8b5a7940`](https://github.com/NixOS/nixpkgs/commit/8b5a7940b0cd1f6f232933099f12f383c3b3c32a) go: Bunch of fixes when using excludedPackages and other bits
* [`64ca0894`](https://github.com/NixOS/nixpkgs/commit/64ca089436377e1359636c22e19fdd56f0d889ff) go: Avoid setting excludedPackages for package already being excluded by default
* [`10d3e3a0`](https://github.com/NixOS/nixpkgs/commit/10d3e3a0f41fd682011e572ab92edf1edda1138e) go: convert alternating regex string to list of packages to exclude
* [`dc17b7f7`](https://github.com/NixOS/nixpkgs/commit/dc17b7f725b597d1efb7609195b93d90694a6c8f) python3Packages.oauthlib: 3.1.1 -> 3.2.0
* [`5f82cdc8`](https://github.com/NixOS/nixpkgs/commit/5f82cdc853aaf809534dcdf85bfe0c1ad1135c12) python3Packages.weconnect: 0.37.0 -> 0.37.1
* [`e7d4a05b`](https://github.com/NixOS/nixpkgs/commit/e7d4a05b2d20c07c32d68867b6cb1941eac5eb72) python3Packages.weconnect-mqtt: 0.30.0 -> 0.30.1
* [`a52c0134`](https://github.com/NixOS/nixpkgs/commit/a52c01340d6fca30d3204c8ac57ccc60b46a4655) splat: init at 1.4.2
* [`52ad014f`](https://github.com/NixOS/nixpkgs/commit/52ad014fe640b2743d6c87e5fa8120b24ed2c210) postfixadmin: 3.3.10 -> 3.3.11
* [`6fb7d8e6`](https://github.com/NixOS/nixpkgs/commit/6fb7d8e67593549838da839f7435156f1fd81f31) tmux-mem-cpu-load: 3.5.1 -> 3.6.0
* [`6d8efcd7`](https://github.com/NixOS/nixpkgs/commit/6d8efcd75a5144cefc10bba222dcd3a341b527e9) pmacct: 1.7.6 -> 1.7.7
* [`f62dfc83`](https://github.com/NixOS/nixpkgs/commit/f62dfc83ae3d253b45bbabe58b40caaf2bec179e) yad: 10.1 -> 11.0
* [`62860b31`](https://github.com/NixOS/nixpkgs/commit/62860b31ef9060340c480831b7f735b963dcfcbf) Revert "darwin.apple_sdk.frameworks.IOSurface: use Libsystem instead of xpc ([nixos/nixpkgs⁠#161561](https://togithub.com/nixos/nixpkgs/issues/161561))"
* [`48a00730`](https://github.com/NixOS/nixpkgs/commit/48a007306b4bc19af90142e28b7da1e9330f782a) expat: 2.4.6 -> 2.4.7
* [`c18eab5a`](https://github.com/NixOS/nixpkgs/commit/c18eab5a31b3e37254780877e4ca6eabda0a0e3b) Revert "python3Packages.xmltodict: disable incompatible expat tests"
* [`331797fd`](https://github.com/NixOS/nixpkgs/commit/331797fdc9c842342047a822bc3ab0b29827b1ad) python3Packages.weconnect: 0.37.1 -> 0.37.2
* [`b85cdb44`](https://github.com/NixOS/nixpkgs/commit/b85cdb44a83225624a81a19f0bd619930911235c) python3Packages.weconnect-mqtt: 0.30.1 -> 0.30.2
* [`bfc349fc`](https://github.com/NixOS/nixpkgs/commit/bfc349fcb7032a3cb137aae185ff213a22add6a9) python3Packages.XlsxWriter: 1.2.9 -> 3.0.2
* [`999f1ed5`](https://github.com/NixOS/nixpkgs/commit/999f1ed5b5aa059de96bf060c66b1443cbdb326f) ethtool: 5.15 -> 5.16
* [`3cef6eff`](https://github.com/NixOS/nixpkgs/commit/3cef6effe981d7dd2896320da6f0bf7e94a7fd9c) python3Packages.xmltodict: use pytest over nosetests
* [`28b3e0a8`](https://github.com/NixOS/nixpkgs/commit/28b3e0a8a0cb69043cc0971a8eec25f93ac9f19f) cmake: 3.22.2 -> 3.22.3
* [`0423158e`](https://github.com/NixOS/nixpkgs/commit/0423158e106ec4a838f0d8f956faecfacf4396f3) systemd: reformat code with nixpkgs-fmt
* [`3869ce78`](https://github.com/NixOS/nixpkgs/commit/3869ce784e80445cc6037999b087e7ca61ebf60f) systemd: 249.7 -> 250.3
* [`3ceeae83`](https://github.com/NixOS/nixpkgs/commit/3ceeae830d42e7857981d11ad251c4f39e2fdd4b) systemdMinimal: don't set {libfido2,p11-kit,libgcrypt} to null
* [`0c852e1f`](https://github.com/NixOS/nixpkgs/commit/0c852e1fa6318bfc43b138832e6d42e40ed054e6) systemd: remove unused lvm2 input
* [`e6280a63`](https://github.com/NixOS/nixpkgs/commit/e6280a639759ff6343a9d63e83c0466f17281a68) systemd: introduce withTests flag
* [`d67caf3c`](https://github.com/NixOS/nixpkgs/commit/d67caf3c894ed5424ba73b6d39db2eddf25bc128) nixos/timesyncd: initialize clock file with current time
* [`49267a99`](https://github.com/NixOS/nixpkgs/commit/49267a99d248c1666cae2621f311b25bccf9d7ac) systemd: add the release timestamp into the build
* [`f592c5a7`](https://github.com/NixOS/nixpkgs/commit/f592c5a7c484ab50f2be569c9a3c5c984b9e2a15) systemd: do not patch test files
* [`f5c243d6`](https://github.com/NixOS/nixpkgs/commit/f5c243d6c291671d256ec12a4c6805e9cb049565) systemd: drop -Defi-ld=gold
* [`d88dc978`](https://github.com/NixOS/nixpkgs/commit/d88dc978f65b99b9cf44f851f773803631a47678) expat: add python3Packages.xmltodict to passthru.tests
* [`479b1cb5`](https://github.com/NixOS/nixpkgs/commit/479b1cb510b13fe5a89e5aa228b2df60d8c464ed) systemd: fix a whole bunch of typos
* [`47ac2574`](https://github.com/NixOS/nixpkgs/commit/47ac25743c28f26a2eb1871183670dca45599560) anybadge: 1.8.0 -> 1.9.0
* [`b400ae82`](https://github.com/NixOS/nixpkgs/commit/b400ae822bdbcebede1e3736a79cf354d84caaae) regbot: 0.3.10 -> 0.4.0
* [`a0bfc8e7`](https://github.com/NixOS/nixpkgs/commit/a0bfc8e7c1f2a138ea0453bb0502277e042afc06) systemd: update patchShebangs comment
* [`d5480e41`](https://github.com/NixOS/nixpkgs/commit/d5480e41a41b3a4337f44864b897e6e3dfbb53b2) wob: 0.12 -> 0.13
* [`7af50258`](https://github.com/NixOS/nixpkgs/commit/7af502587d506d208ff10818624d4c188a5168d9) swaysome: init at 1.1.2
* [`35727684`](https://github.com/NixOS/nixpkgs/commit/35727684c8b4ed73af10ee404759c58e5a630454) gnome2: rename name to pname&version
* [`0067dbbf`](https://github.com/NixOS/nixpkgs/commit/0067dbbf632610eb1e9253d7ce8f5e79e82ad0b9) kde/gear: 21.12.2 -> 21.12.3
* [`dc130318`](https://github.com/NixOS/nixpkgs/commit/dc1303185f809382dc075d23e881f71b0794b826) kmod: add dev and lib outputs
* [`8d820a4d`](https://github.com/NixOS/nixpkgs/commit/8d820a4daaa76afeff040bf812894d4afe9478b8) openconnect: enable p11kit on linux
* [`9d53c38f`](https://github.com/NixOS/nixpkgs/commit/9d53c38f615d9e683e88a1899fd6ffc368bf4be8) adoptopenjdk-bin: rename name to pname&version
* [`94a6a281`](https://github.com/NixOS/nixpkgs/commit/94a6a281933485c668b95f95eba87dbafdb983d3) docbook_xml_dtd,docbook_xml_ebnf_dtd,xhtml1: replace name with pname&version
* [`191f62fe`](https://github.com/NixOS/nixpkgs/commit/191f62fe307fbd72a35ea3a0e612a9b2c33cdbce) libuv: 1.43.0 -> 1.44.0
* [`7513cd2f`](https://github.com/NixOS/nixpkgs/commit/7513cd2f5a286751e06ff00d10ee632fe615f180) patchelfUnstable: 2021-11-16 -> 2022-02-21
* [`32dbdc43`](https://github.com/NixOS/nixpkgs/commit/32dbdc4388bf10e6939da4e5877dfbb93d0cdda8) nghttp2: 1.43.0 -> 1.47.0
* [`d9518537`](https://github.com/NixOS/nixpkgs/commit/d951853737e07b7277d676126ad73aba98ffd55b) govers: switch to fetchFromGitHub
* [`3fae68b3`](https://github.com/NixOS/nixpkgs/commit/3fae68b30cfc27a7df5beaf9aaa7cb654edd8403) build-support/writeTextFile: fix for names with spaces
* [`267f618d`](https://github.com/NixOS/nixpkgs/commit/267f618da56d8ef12c3ada98d08c032549afadc2) build-support/makeDesktopItem: remove workaround, fix quoting
* [`7e3c5032`](https://github.com/NixOS/nixpkgs/commit/7e3c503257490763fac7ceacbd33e551a0811e37) build-support/writeTextFile: add test for weird file names
* [`aac2283c`](https://github.com/NixOS/nixpkgs/commit/aac2283c26f138ad43727aac9673fbe9b3d69dff) libinput: 1.19.3 → 1.20.0
* [`fb079c31`](https://github.com/NixOS/nixpkgs/commit/fb079c3110d95867be383415e9ac41fd1520ab6f) linux.configfile: fix alts containing "/m"
* [`f8be98b2`](https://github.com/NixOS/nixpkgs/commit/f8be98b2cb58149b8f9789123743392b354d51a2) cryptsetup: separate binaries from libraries
* [`69da642a`](https://github.com/NixOS/nixpkgs/commit/69da642a5a9bb433138ba1b13c8d56fb5bb6ec05) fontforge: 20201107 -> 20220308
* [`46baf627`](https://github.com/NixOS/nixpkgs/commit/46baf627e21a3199b56e7fef95963a9c47b06042) avahi: patch segfault on resolving .local addresses
* [`e073f65d`](https://github.com/NixOS/nixpkgs/commit/e073f65d682b04a1e2394dd333cf71dbe5235df5) gitlab-pages: 1.51.0 -> 1.54.0
* [`8f1cf1ea`](https://github.com/NixOS/nixpkgs/commit/8f1cf1ea0be9c62ef5a83e6ed16ddb7dcdbb06a5) doxygen: 1.8.20 -> 1.9.3
* [`6e2dd672`](https://github.com/NixOS/nixpkgs/commit/6e2dd6725c23c6d46f8e1d48e7decbf9d558c684) gtk3: 3.24.31 → 3.24.33
* [`b5fde728`](https://github.com/NixOS/nixpkgs/commit/b5fde728eee1569e408db9d832f5fdaa262dce64) meson: 0.60.3 -> 0.61.2
* [`7a9b09b2`](https://github.com/NixOS/nixpkgs/commit/7a9b09b2a5ee8895833823669223d886fd0d3f64) http-parser: fix build on armv7l-linux
* [`f476db5b`](https://github.com/NixOS/nixpkgs/commit/f476db5bddfeaec35a84c967fa27cf9367198716) libva1: 1.7.3 -> 1.8.3, update homepage, add SuperSandro2000 as maintainer
* [`c329f549`](https://github.com/NixOS/nixpkgs/commit/c329f549eb0745abc9a836c10a15e13bc05915a1) libva: add SuperSandro2000 as maintainer, add - before minimal
* [`9e1ee884`](https://github.com/NixOS/nixpkgs/commit/9e1ee884e99428cee274892b802792b264bdb184) libva-utils: add SuperSandro2000 as maintainer
* [`f8ca3a90`](https://github.com/NixOS/nixpkgs/commit/f8ca3a9099629c3fc81deb11b1a7fd95e1bb6dce) liva{,-utils}: remove primos from maintainers
* [`c30918d4`](https://github.com/NixOS/nixpkgs/commit/c30918d419f5b4b60f8d5b965f600c05bec63761) nixos/networkd: add support for more WireGuard options (introduced in systemd v250)
* [`47932961`](https://github.com/NixOS/nixpkgs/commit/479329611e570447e679f6d6922028ab5935ad2f) polkit: fix build with meson 0.61
* [`7c19019c`](https://github.com/NixOS/nixpkgs/commit/7c19019c1bbae0b3202246edd4379bb1c6a7a105) libuv: 1.44.0 -> 1.44.1
* [`f63d93bc`](https://github.com/NixOS/nixpkgs/commit/f63d93bc3d0ad73b24b2cf9c0ee0381161071395) pam_ussh: init at unstable-20210615
* [`18530155`](https://github.com/NixOS/nixpkgs/commit/1853015550a78acbc3e9d090d174120796c4b784) nixos/pam: add support for pam-ussh
* [`5ecb4b78`](https://github.com/NixOS/nixpkgs/commit/5ecb4b787410c435fc7cf139357c7e54ff313d4c) python3Packages.pip: 21.3.1 -> 22.0.3
* [`ac90f423`](https://github.com/NixOS/nixpkgs/commit/ac90f4238934a643f1858855223a59c525c97828) python3Packages.pytest: 6.2.5 -> 7.0.1
* [`423785bd`](https://github.com/NixOS/nixpkgs/commit/423785bd843171f45ccab98168d09ad2d69d434d) python3Packages.pytest-subtests: 0.6.0 -> 0.7.0
* [`3855b2d0`](https://github.com/NixOS/nixpkgs/commit/3855b2d0c3b6a6e9f1be95233e2582ad1acda6ad) python3Packages.adblock: 0.5.1 -> 0.5.2
* [`7b34bb2e`](https://github.com/NixOS/nixpkgs/commit/7b34bb2ed8deacade7490ec3a4c525c8ecd47453) python3Packages.aioftp: 0.20.0 -> 0.20.1
* [`e878a91a`](https://github.com/NixOS/nixpkgs/commit/e878a91a1396587e3b272bc2ac6b1610ed14556f) python3Packages.alembic: 1.7.5 -> 1.7.6
* [`bb06db91`](https://github.com/NixOS/nixpkgs/commit/bb06db91731e78eaf5a299ab017b87db262d635f) python3Packages.ansi2html: 1.6.0 -> 1.7.0
* [`37435d23`](https://github.com/NixOS/nixpkgs/commit/37435d23acdf8fdd8d0126161845f2816d918746) python3Packages.ansible-lint: 5.3.2 -> 5.4.0
* [`638c332a`](https://github.com/NixOS/nixpkgs/commit/638c332a31581f7fc80bd11f6182e77e5a4e1f1e) python3Packages.ansi: 0.2.0 -> 0.3.6
* [`30bda34f`](https://github.com/NixOS/nixpkgs/commit/30bda34f740cc8c31a55e7f41574d3ccffbd70ae) python3Packages.apache-airflow: 2.2.3 -> 2.2.4
* [`53e7b4a5`](https://github.com/NixOS/nixpkgs/commit/53e7b4a5dfd218240db21c6c828f0dacd40aa1a9) python3Packages.apache-beam: 2.35.0 -> 2.36.0
* [`f170668a`](https://github.com/NixOS/nixpkgs/commit/f170668a7b71cc44658cbbdb97cf7e2445f67b19) python3Packages.approvaltests: 3.6.0 -> 4.0.0
* [`31c778cd`](https://github.com/NixOS/nixpkgs/commit/31c778cd96aa553183cc5a57dd74bbc23bb778c2) python3Packages.arrow: 1.2.1 -> 1.2.2
* [`31e8a8f4`](https://github.com/NixOS/nixpkgs/commit/31e8a8f4e435dd1385d184c63485b70a3207e60a) python3Packages.asdf: 2.8.3 -> 2.10.1
* [`117eb5bf`](https://github.com/NixOS/nixpkgs/commit/117eb5bfbfa13cf5d0046facf6aff3e533f16285) python3Packages.astropy: 5.0 -> 5.0.1
* [`cc53855a`](https://github.com/NixOS/nixpkgs/commit/cc53855a7c41296f019aafa75634fd3303e17d74) python3Packages.authcaptureproxy: 1.1.1 -> 1.1.3
* [`d9b506dc`](https://github.com/NixOS/nixpkgs/commit/d9b506dc82e368d91c328bdb1aa0872c8e4da53a) python3Packages.autobahn: 21.11.1 -> 22.2.2
* [`94d80a18`](https://github.com/NixOS/nixpkgs/commit/94d80a1820440b716a2340f1fd126bb108bec69d) python3Packages.aws-adfs: 1.24.5 -> 2.0.1
* [`4467434c`](https://github.com/NixOS/nixpkgs/commit/4467434cc62bfd5b447ad7f15e3fa9dc2a4f6410) python3Packages.azure-common: 1.1.27 -> 1.1.28
* [`40bd4fef`](https://github.com/NixOS/nixpkgs/commit/40bd4fef12b8186ba6a5c86080f3f10d32beac34) python3Packages.azure-core: 1.21.1 -> 1.22.1
* [`7927d4aa`](https://github.com/NixOS/nixpkgs/commit/7927d4aad281cf0fac0c959c4be0b5180d89329f) python3Packages.azure-mgmt-apimanagement: 2.1.0 -> 3.0.0
* [`95bf8353`](https://github.com/NixOS/nixpkgs/commit/95bf8353503a74424354bb7cef1471c418d4b548) python3Packages.azure-mgmt-trafficmanager: 0.51.0 -> 1.0.0
* [`8b86ab5a`](https://github.com/NixOS/nixpkgs/commit/8b86ab5af270aca60f3ea59b136b2d1b24e74909) python3Packages.azure-servicebus: 7.5.0 -> 7.6.0
* [`ab5c2658`](https://github.com/NixOS/nixpkgs/commit/ab5c26589bbf547c4c682a980985fb821ddb19b7) python3Packages.basemap: 1.3.0 -> 1.3.2
* [`c3366d5f`](https://github.com/NixOS/nixpkgs/commit/c3366d5fe2ae11ea16c60c4abd990ab7eb447f2c) python3Packages.bip_utils: 2.1.0 -> 2.2.1
* [`f264180b`](https://github.com/NixOS/nixpkgs/commit/f264180b63832508a365e118cfae36c7fc5937b7) python3Packages.bitbox02: 5.3.0 -> 6.0.0
* [`da98bb07`](https://github.com/NixOS/nixpkgs/commit/da98bb072499a062498b6b80b91b0b03e1868e6d) python3Packages.bjoern: 3.1.0 -> 3.2.1
* [`6fb9a658`](https://github.com/NixOS/nixpkgs/commit/6fb9a658b7ba00abbca702878ec170e7e454410f) python3Packages.blessed: 1.19.0 -> 1.19.1
* [`04f4ee8d`](https://github.com/NixOS/nixpkgs/commit/04f4ee8d2ba8aa7b309e3f5abfad7bc411ddad44) python3Packages.boto3: 1.20.35 -> 1.21.11
* [`97c0dba4`](https://github.com/NixOS/nixpkgs/commit/97c0dba4a9987e90314f18650986e7e74546827c) python3Packages.botocore: 1.23.35 -> 1.24.11
* [`e9f5119e`](https://github.com/NixOS/nixpkgs/commit/e9f5119edc6d0dd760c0706d2e9230632399677c) python3Packages.Bottleneck: 1.3.2 -> 1.3.4
* [`23e9464e`](https://github.com/NixOS/nixpkgs/commit/23e9464e048dcfb73f23059209e6a3666f9a5d36) python3Packages.boxx: 0.9.9 -> 0.9.10
* [`27723998`](https://github.com/NixOS/nixpkgs/commit/277239983248ea302c0ba6e2b694796160a83039) python3Packages.bsblan: 0.5.0 -> 0.5.5
* [`95d73d3c`](https://github.com/NixOS/nixpkgs/commit/95d73d3c80b33674469f8e498544aa329d23a171) python3Packages.cbor2: 5.4.2 -> 5.4.2.post1
* [`dbb9df56`](https://github.com/NixOS/nixpkgs/commit/dbb9df56e2994cae1796874fb8449d0ead01ff0c) python3Packages.certbot: 1.22.0 -> 1.24.0
* [`b8943d12`](https://github.com/NixOS/nixpkgs/commit/b8943d1285a638f6ad9de1bd0d742358a316c5d2) python3Packages.chart-studio: 5.5.0 -> 5.6.0
* [`8a175bd2`](https://github.com/NixOS/nixpkgs/commit/8a175bd2fa09b9660212c585c5be5fe790699255) python3Packages.click: 8.0.3 -> 8.0.4
* [`2f5994c3`](https://github.com/NixOS/nixpkgs/commit/2f5994c353f09f8eb24aa004650709b4c8c3ebc0) python3Packages.cma: 3.1.0 -> 3.2.1
* [`a521505b`](https://github.com/NixOS/nixpkgs/commit/a521505b0a7825e2141b7de6dbeb245bb36c04d1) python3Packages.cmd2: 2.3.3 -> 2.4.0
* [`2084747e`](https://github.com/NixOS/nixpkgs/commit/2084747e898755df99eabae32f8b2ea7182c5575) python3Packages.collections-extended: 2.0.0 -> 2.0.2
* [`14f366ec`](https://github.com/NixOS/nixpkgs/commit/14f366ecaf4013b650b9f6a01a252cd9c33cea8f) python3Packages.construct: 2.10.67 -> 2.10.68
* [`ea86d0ba`](https://github.com/NixOS/nixpkgs/commit/ea86d0ba5dcec9bc1795866dd59722ebc376707f) python3Packages.convertdate: 2.3.2 -> 2.4.0
* [`99e7b03c`](https://github.com/NixOS/nixpkgs/commit/99e7b03c0a613b76ddd940ae3052edf16376cc9b) python3Packages.coverage: 6.2 -> 6.3.2
* [`5ac0c989`](https://github.com/NixOS/nixpkgs/commit/5ac0c98987d33873d3d5b44912239dafb71617cb) python3Packages.cssselect2: 0.4.1 -> 0.5.0
* [`994f13b2`](https://github.com/NixOS/nixpkgs/commit/994f13b2d3cf74290e87786768e63b4c8b89e374) python3Packages.cx_Freeze: 6.9 -> 6.10
* [`9cc7502d`](https://github.com/NixOS/nixpkgs/commit/9cc7502db1f7285bf79b338b3e16ebbfb070d618) python3Packages.cyclonedx-python-lib: 1.3.0 -> 2.0.0
* [`79c45e08`](https://github.com/NixOS/nixpkgs/commit/79c45e08d74bd9a50c03165973d285225c1635c7) python3Packages.datasets: 1.17.0 -> 1.18.3
* [`54a6971a`](https://github.com/NixOS/nixpkgs/commit/54a6971a65e68c59e38d13640a8f27de03553e23) python3Packages.detect-secrets: 1.1.0 -> 1.2.0
* [`8bd3a132`](https://github.com/NixOS/nixpkgs/commit/8bd3a132596d02af26952da1f61437a9e41b5160) python3Packages.distributed: 2022.2.0 -> 2022.2.1
* [`4618c4bb`](https://github.com/NixOS/nixpkgs/commit/4618c4bb0ff1f9605e674fa628bf6716ae200416) python3Packages.distro: 1.6.0 -> 1.7.0
* [`4d7b531a`](https://github.com/NixOS/nixpkgs/commit/4d7b531a45d0c60f221e43796e4892c499833776) python3Packages.django-contrib-comments: 2.1.0 -> 2.2.0
* [`75c288db`](https://github.com/NixOS/nixpkgs/commit/75c288dbb5c8b3e9378c81a46535a162776a23da) python3Packages.django-reversion: 4.0.2 -> 5.0.0
* [`8571b071`](https://github.com/NixOS/nixpkgs/commit/8571b07158a7368485a73651feaaff81c0cce143) python3Packages.dm-haiku: 0.0.5 -> 0.0.6
* [`0e590ca9`](https://github.com/NixOS/nixpkgs/commit/0e590ca9aa4819ee7c0ac87f3d99ab540ee3a68e) python3Packages.dynalite-devices: 0.1.46 -> 0.46
* [`4a95953e`](https://github.com/NixOS/nixpkgs/commit/4a95953e6d38565a12a742365e616912cf90c110) python3Packages.EasyProcess: 0.3 -> 1.1
* [`c1158905`](https://github.com/NixOS/nixpkgs/commit/c1158905e7e7b02bf20d4129803f479568fec32c) python3Packages.einops: 0.3.2 -> 0.4.0
* [`5d714738`](https://github.com/NixOS/nixpkgs/commit/5d7147381c933088386692dd796870188c814ad3) python3Packages.elegy: 0.8.4 -> 0.8.5
* [`4915afac`](https://github.com/NixOS/nixpkgs/commit/4915afac14d2417bd7fb335e347f326f6b0881dd) python3Packages.entrypoints: 0.3 -> 0.4
* [`8ed0cf2b`](https://github.com/NixOS/nixpkgs/commit/8ed0cf2b0c0a5e56f325a3d4ad95642c89c8c406) python3Packages.faker: 11.3.0 -> 13.3.0
* [`06e32056`](https://github.com/NixOS/nixpkgs/commit/06e320562bbc1fe90ab9ac17058e01fc51c9df9b) python3Packages.fasteners: 0.16.3 -> 0.17.3
* [`3719c915`](https://github.com/NixOS/nixpkgs/commit/3719c915e61ddd9d132434e0e1eb8e36597e93a8) python3Packages.filelock: 3.4.2 -> 3.6.0
* [`df218fdd`](https://github.com/NixOS/nixpkgs/commit/df218fdd3ee7dcb1217f047a3572d38d67c8da54) python3Packages.Flask-Compress: 1.10.1 -> 1.11
* [`aa12d780`](https://github.com/NixOS/nixpkgs/commit/aa12d780f24f24e03afe92a91469ceb2cb0102ce) python3Packages.Flask: 2.0.2 -> 2.0.3
* [`eddb45ed`](https://github.com/NixOS/nixpkgs/commit/eddb45ed251be89df005a809ebd5fcea8d69c61b) python3Packages.flask-security-too: 4.1.2 -> 4.1.3
* [`09782d68`](https://github.com/NixOS/nixpkgs/commit/09782d6886ad771a46e84bd69fa1b52c0badc096) python3Packages.fonttools: 4.29.0 -> 4.29.1
* [`def52864`](https://github.com/NixOS/nixpkgs/commit/def5286419df75006861f7727c4ca3119930b0d4) python3Packages.fs: 2.4.14 -> 2.4.15
* [`a4a0cc2b`](https://github.com/NixOS/nixpkgs/commit/a4a0cc2b4d0a8fd11fa97a172d193c190a492bbb) python3Packages.ftfy: 6.0.3 -> 6.1.1
* [`c967d88f`](https://github.com/NixOS/nixpkgs/commit/c967d88ffc0a68fbd3dce4b5b8ba1709fe893522) python3Packages.Genshi: 0.7.5 -> 0.7.6
* [`8f9fca51`](https://github.com/NixOS/nixpkgs/commit/8f9fca514a6b92bc122fe42b825d996e02fe07fa) python3Packages.gidgethub: 5.0.1 -> 5.1.0
* [`a5483739`](https://github.com/NixOS/nixpkgs/commit/a5483739f5d78bec75d5a7e248eb89714c591709) python3Packages.github3.py: 3.0.0 -> 3.2.0
* [`222b9d54`](https://github.com/NixOS/nixpkgs/commit/222b9d54d41cedc8ffde75a41db1add8217d7a3b) python3Packages.google-api-python-client: 2.35.0 -> 2.39.0
* [`6775f282`](https://github.com/NixOS/nixpkgs/commit/6775f2827e994a99522fa83a002e0436b3a0075f) python3Packages.googleapis-common-protos: 1.54.0 -> 1.55.0
* [`abce52df`](https://github.com/NixOS/nixpkgs/commit/abce52df801f257eee064b0890d9b9f02da89420) python3Packages.google-auth-oauthlib: 0.4.6 -> 0.5.0
* [`c68f5afe`](https://github.com/NixOS/nixpkgs/commit/c68f5afe368a3b7efbb1a0a3dfe22725b35a6561) python3Packages.graphql-relay: 3.1.0 -> 3.1.5
* [`cb8e95eb`](https://github.com/NixOS/nixpkgs/commit/cb8e95eb51bcd6de31e00ed300b9d6f6cc5a30c4) python3Packages.graspologic: 0.3.1 -> 1.0.0
* [`410c585a`](https://github.com/NixOS/nixpkgs/commit/410c585a4c6fc8e8def3f29bae59831a5edf8271) python3Packages.gssapi: 1.7.2 -> 1.7.3
* [`c59e2d37`](https://github.com/NixOS/nixpkgs/commit/c59e2d3789c0a6f5ae04705c7f6e941a6a66ed7e) python3Packages.gym: 0.21.0 -> 0.22.0
* [`e70fd31a`](https://github.com/NixOS/nixpkgs/commit/e70fd31a5b0a717d30bc47c9257ca04a5bc3efa7) python3Packages.h11: 0.12.0 -> 0.13.0
* [`4d81db20`](https://github.com/NixOS/nixpkgs/commit/4d81db205db97ff99e5da97880a94529072bf968) python3Packages.hass-nabucasa: 0.52.0 -> 0.54.0
* [`def84cb7`](https://github.com/NixOS/nixpkgs/commit/def84cb7d39044dd1968bc60edf3a5aff2680bf1) python3Packages.hatasmota: 0.3.1 -> 0.4.0
* [`4b03937b`](https://github.com/NixOS/nixpkgs/commit/4b03937bae7e804b57e38d87255e12f3f7893bf5) python3Packages.hg-git: 0.10.3 -> 0.10.4
* [`a6118e13`](https://github.com/NixOS/nixpkgs/commit/a6118e1395378828c7600a00c6ada76d195af385) python3Packages.hmmlearn: 0.2.6 -> 0.2.7
* [`deda5e4c`](https://github.com/NixOS/nixpkgs/commit/deda5e4c21f120587321ddd5b987b4179b5fbd0d) python3Packages.socksio: init at 1.0.0
* [`ab248891`](https://github.com/NixOS/nixpkgs/commit/ab248891031daec7f7faeb1b32abc3acbd4df4a3) python3Packages.httpcore: 0.14.4 -> 0.14.7
* [`c89fdaa8`](https://github.com/NixOS/nixpkgs/commit/c89fdaa8655f921ec632867861ab7d78dde71f3b) python3Packages.httptools: 0.3.0 -> 0.4.0
* [`f5289383`](https://github.com/NixOS/nixpkgs/commit/f5289383d6187034062104db6656a2e20938d33e) python3Packages.httpx: 0.21.3 -> 0.22.0
* [`f4dafacf`](https://github.com/NixOS/nixpkgs/commit/f4dafacf992a7a0f96e36cfd09b9b20a24cab8bf) python3Packages.huggingface-hub: 0.1.2 -> 0.4.0
* [`684e9075`](https://github.com/NixOS/nixpkgs/commit/684e9075ee19cd3e9ef1fdf9316e1fc8b4870ff1) python3Packages.humanize: 3.13.1 -> 4.0.0
* [`40cac59f`](https://github.com/NixOS/nixpkgs/commit/40cac59f12f162e3652ffb675d438962070a6c54) python3Packages.hypothesis: 6.35.0 -> 6.38.0
* [`ceb3e974`](https://github.com/NixOS/nixpkgs/commit/ceb3e9742217881c53631b1768f8b67b1c32c1c0) python3Packages.hyppo: 0.2.2 -> 0.3.2
* [`8cae1582`](https://github.com/NixOS/nixpkgs/commit/8cae15829d38548fa1716aa8e52278b624905a13) python3Packages.imageio: 2.14.1 -> 2.16.1
* [`06cae9aa`](https://github.com/NixOS/nixpkgs/commit/06cae9aa956d76e6e775eb62a4065fd9ec785070) python3Packages.importlib-metadata: 4.11.0 -> 4.11.2
* [`e31838f0`](https://github.com/NixOS/nixpkgs/commit/e31838f0e38a8893753cd23fe14b6f63f43d57bd) python3Packages.intbitset: 2.4.1 -> 3.0.0
* [`7758d354`](https://github.com/NixOS/nixpkgs/commit/7758d354c00b4495ef682ae383d3976f108f688b) python3Packages.intensity-normalization: 2.1.4 -> 2.2.0
* [`5d4a480e`](https://github.com/NixOS/nixpkgs/commit/5d4a480e6aecbe0ce06aaac50eb395424861868a) python3Packages.ipykernel: 6.7.0 -> 6.9.1
* [`2f978e27`](https://github.com/NixOS/nixpkgs/commit/2f978e2731083bc78e42b35b2ee135d1f0f2f15f) python3Packages.ipympl: 0.8.7 -> 0.8.8
* [`c161e7b4`](https://github.com/NixOS/nixpkgs/commit/c161e7b47d1e9dc12588dcb5f7040c5b1d6b5b56) python3Packages.ipython: 8.0.1 -> 8.1.0
* [`a07a7208`](https://github.com/NixOS/nixpkgs/commit/a07a720813299d99805a1cdc4116263abb9b6929) python3Packages.itsdangerous: 2.0.1 -> 2.1.0
* [`c09d0be8`](https://github.com/NixOS/nixpkgs/commit/c09d0be8aac754a85371ca57ac2a8aa103f87af1) python3Packages.jaraco.itertools: 6.0.3 -> 6.2.1
* [`12eeeaa9`](https://github.com/NixOS/nixpkgs/commit/12eeeaa9614b9cc2364fc093f981b650a6472c6f) python3Packages.jaraco.text: 3.6.0 -> 3.7.0
* [`4e3dc53b`](https://github.com/NixOS/nixpkgs/commit/4e3dc53bff0e3c9e5b509172481cdf50c423e3fd) python3Packages.jsondiff: 1.3.0 -> 1.3.1
* [`12c94304`](https://github.com/NixOS/nixpkgs/commit/12c9430438dbbe71f96aee803cc6f03f82a874fb) python3Packages.jsonpickle: 2.0.0 -> 2.1.0
* [`677ef90a`](https://github.com/NixOS/nixpkgs/commit/677ef90a34123baed15c543ee0909d0aaf39d234) python3Packages.jupyter_client: 7.1.0 -> 7.1.2
* [`6add5863`](https://github.com/NixOS/nixpkgs/commit/6add586341153c6a8fc8c33f8dbe1321e97c0795) python3Packages.jupyter_core: 4.9.1 -> 4.9.2
* [`4cede2b0`](https://github.com/NixOS/nixpkgs/commit/4cede2b0393d45a1d6e41cf6dbbc91aa51aafad0) python3Packages.jupyterlab-git: 0.34.1 -> 0.34.2
* [`b42b2c63`](https://github.com/NixOS/nixpkgs/commit/b42b2c63846f27b2014b23952c1cc6114bdcf925) python3Packages.keras: 2.7.0 -> 2.8.0
* [`1a93d016`](https://github.com/NixOS/nixpkgs/commit/1a93d01619d19178d76c144f8f54949e57960196) python3Packages.labelbox: 3.11.1 -> 3.15.0
* [`d47d87f9`](https://github.com/NixOS/nixpkgs/commit/d47d87f9f9ad81bafb61e45605d22a08295fb6aa) python3Packages.lektor: 3.3.1 -> 3.3.2
* [`7ed8ac06`](https://github.com/NixOS/nixpkgs/commit/7ed8ac06d1aae3ae78303342b4271b6ff6d968cd) python3Packages.levenshtein: 0.17.0 -> 0.18.1
* [`ff86d0fe`](https://github.com/NixOS/nixpkgs/commit/ff86d0fed55fec87533fffc5e6d7096fdeb7e8b6) python3Packages.libcst: 0.3.23 -> 0.4.1
* [`aadf6d7e`](https://github.com/NixOS/nixpkgs/commit/aadf6d7ea09769827cbc238ed6c258813711c864) python3Packages.libevdev: 0.9 -> 0.10
* [`0036e692`](https://github.com/NixOS/nixpkgs/commit/0036e6929572a84f8bd93c0cc8ed38cb06f3bf06) python3Packages.limits: 2.2.0 -> 2.3.3
* [`6a0eefa7`](https://github.com/NixOS/nixpkgs/commit/6a0eefa743a6a52fe38cf6a5bc02d9169fa82bfb) python3Packages.lxml: 4.7.1 -> 4.8.0
* [`a253b0d2`](https://github.com/NixOS/nixpkgs/commit/a253b0d20a13ad28646cfdbfd1783d38b22f9bbb) python3Packages.python-lz4: 3.1.12 -> 4.0.0
* [`d07d9cae`](https://github.com/NixOS/nixpkgs/commit/d07d9cae26f20ea7ae985bd549e48695567feefd) python3Packages.magicgui: 0.3.0 -> 0.3.7
* [`b5bc9180`](https://github.com/NixOS/nixpkgs/commit/b5bc91804315742f173781655e34ee39a43af6bf) python3Packages.manticore: 0.3.6 -> 0.3.7
* [`805d0a2c`](https://github.com/NixOS/nixpkgs/commit/805d0a2c99d0c28f5ec8c9a61077e01bdaf65432) python3Packages.markupsafe: 2.0.1 -> 2.1.0
* [`794822a1`](https://github.com/NixOS/nixpkgs/commit/794822a191b9f48b9955fec06833197559356d0d) python3Packages.meshio: 5.2.2 -> 5.3.2
* [`ca2577b8`](https://github.com/NixOS/nixpkgs/commit/ca2577b8fa49483f293b65ffece002ab6f624d28) python3Packages.Mezzanine: 5.1.0 -> 5.1.3
* [`36cd8367`](https://github.com/NixOS/nixpkgs/commit/36cd8367b973c34fd3e6f022dab812e359a5070c) python3Packages.minio: 7.1.2 -> 7.1.4
* [`8441eba1`](https://github.com/NixOS/nixpkgs/commit/8441eba18ff0e2316d2d25cf66e32525d682ea62) python3Packages.mlflow: 1.23.1 -> 1.24.0
* [`4de81a0b`](https://github.com/NixOS/nixpkgs/commit/4de81a0b283bd184f8ec333ed7b3ff88861c4a16) python3Packages.mongoengine: 0.23.1 -> 0.24.0
* [`8c84c405`](https://github.com/NixOS/nixpkgs/commit/8c84c40502e09508ecbda266653128e7cee6ef53) python3Packages.moonraker-api: 2.0.4 -> 2.0.5
* [`02b065dc`](https://github.com/NixOS/nixpkgs/commit/02b065dcdc2bb6e82be4bbf09f6040e181b7bda8) python3Packages.moto: 3.0.2 -> 3.0.5
* [`9e7a04d5`](https://github.com/NixOS/nixpkgs/commit/9e7a04d528fbda4ee472864059f56d3e7d42759b) python3Packages.msal-extensions: 0.3.1 -> 1.0.0
* [`25a12606`](https://github.com/NixOS/nixpkgs/commit/25a12606cb6d9b20618c98db55bcbf7a6a0cc6bd) python3Packages.multidict: 5.2.0 -> 6.0.2
* [`2f6d2ddd`](https://github.com/NixOS/nixpkgs/commit/2f6d2ddd8fe028ca9c75c459989a32fec5bee971) python3Packages.napari: 0.4.12 -> 0.4.14
* [`5149a984`](https://github.com/NixOS/nixpkgs/commit/5149a984728494deafe6980223abd14d156af8ba) python3Packages.nbclient: 0.5.10 -> 0.5.11
* [`2d2285e9`](https://github.com/NixOS/nixpkgs/commit/2d2285e9415f440e09b718f6ccb2ba378a86e897) python3Packages.nbconvert: 6.4.0 -> 6.4.2
* [`5823c672`](https://github.com/NixOS/nixpkgs/commit/5823c6720ea43ff732850052d8cc2de81cadefda) python3Packages.net2grid: 3.0.0 -> 4.0.0
* [`018a61d4`](https://github.com/NixOS/nixpkgs/commit/018a61d48cb3bde374e5ec81b1b7d07f66b10152) python3Packages.networkx: 2.6.3 -> 2.7
* [`49ff3d9e`](https://github.com/NixOS/nixpkgs/commit/49ff3d9ed6e77cea11419420e65423f54aac3916) python3Packages.nilearn: 0.8.1 -> 0.9.0
* [`1b084308`](https://github.com/NixOS/nixpkgs/commit/1b084308a570ea8737a4b76c1607e6dbfb8819f7) python3Packages.notebook: 6.4.7 -> 6.4.8
* [`1c64dd01`](https://github.com/NixOS/nixpkgs/commit/1c64dd01ef2b6ce467e5a14e2fff93b8bf20d3b5) python3Packages.numba: 0.55.0 -> 0.55.1
* [`d78bad22`](https://github.com/NixOS/nixpkgs/commit/d78bad227728cc22cfab005a5ec6330596e6daaf) python3Packages.numpy: 1.21.5 -> 1.22.2
* [`6b0f91ba`](https://github.com/NixOS/nixpkgs/commit/6b0f91baf92c5964f28e8fd5784a8be6aef3fde7) python3Packages.numpydoc: 1.1.0 -> 1.2
* [`955e58dd`](https://github.com/NixOS/nixpkgs/commit/955e58dd9f930da369cc972afbb1a2b55c526414) python3Packages.nunavut: 1.6.2 -> 1.7.3
* [`a507224c`](https://github.com/NixOS/nixpkgs/commit/a507224cdbd6f75213602c705f327ad6945122f0) python3Packages.oci: 2.56.0 -> 2.59.0
* [`f232fd33`](https://github.com/NixOS/nixpkgs/commit/f232fd3335b0ab46f21fd560dc21ffea037d8876) python3Packages.onnx: 1.10.2 -> 1.11.0
* [`dae4b932`](https://github.com/NixOS/nixpkgs/commit/dae4b932963452278db6ce5e57fa347c401ef147) python3Packages.openapi-schema-validator: 0.2.0 -> 0.2.3
* [`15c952bf`](https://github.com/NixOS/nixpkgs/commit/15c952bf44bc0007038be7c545d246e38ca4cb1f) python3Packages.openapi-spec-validator: 0.3.1 -> 0.4.0
* [`c4950045`](https://github.com/NixOS/nixpkgs/commit/c49500456e82c1b1aae53fa4b0154bae2fee5bf4) python3Packages.openshift: 0.12.1 -> 0.13.1
* [`64af180d`](https://github.com/NixOS/nixpkgs/commit/64af180db041d6c8f73cefbdda02a79515e2e45f) python3Packages.ordered-set: 4.0.2 -> 4.1.0
* [`37893429`](https://github.com/NixOS/nixpkgs/commit/378934298fea9b899b62caa558fcc6fc901a3f5f) python3Packages.oslo.context: 3.4.0 -> 4.1.0
* [`398be2e2`](https://github.com/NixOS/nixpkgs/commit/398be2e2b2c28f2edc949e61ad896ef8726a90ae) python3Packages.packageurl-python: 0.9.8.1 -> 0.9.9
* [`491416d9`](https://github.com/NixOS/nixpkgs/commit/491416d9ccc95c266d04df603ca11262fd7fe8ab) python3Packages.pandas: 1.3.5 -> 1.4.1
* [`02ccb75c`](https://github.com/NixOS/nixpkgs/commit/02ccb75c1e6000d42326637a0d05b9ba51e417b6) python3Packages.pathlib2: 2.3.6 -> 2.3.7.post1
* [`8776195b`](https://github.com/NixOS/nixpkgs/commit/8776195b6805f70c4989d38a1745cd2a45d02b0e) python3Packages.pdm-pep517: 0.10.2 -> 0.11.2
* [`bab54430`](https://github.com/NixOS/nixpkgs/commit/bab54430c86c7540a4b362b403575a713fd15fd6) python3Packages.peewee: 3.14.8 -> 3.14.9
* [`9d17779c`](https://github.com/NixOS/nixpkgs/commit/9d17779cca47296d554a995868e04f444357f9a7) python3Packages.pelican: 4.7.1 -> 4.7.2
* [`a6b1a677`](https://github.com/NixOS/nixpkgs/commit/a6b1a677f7d64b907a58a6a0194ab906d12f5b7a) python3Packages.perfplot: 0.9.13 -> 0.10.1
* [`2c4b54a3`](https://github.com/NixOS/nixpkgs/commit/2c4b54a395dd9343f6bcd09193895187a86166e6) python3Packages.pgspecial: 1.13.0 -> 1.13.1
* [`560b3c25`](https://github.com/NixOS/nixpkgs/commit/560b3c2526403661d4e221c6b9e6f5e2bd9b22e1) python3Packages.phonenumbers: 8.12.43 -> 8.12.44
* [`9b3f008c`](https://github.com/NixOS/nixpkgs/commit/9b3f008c56d244a9cf0a6b4ac5252b2f3dd0e4db) python3Packages.platformdirs: 2.5.0 -> 2.5.1
* [`5f760356`](https://github.com/NixOS/nixpkgs/commit/5f7603563905574ef0526f5b07b808499e4c8bf0) python3Packages.plotly: 5.5.0 -> 5.6.0
* [`90e8a1db`](https://github.com/NixOS/nixpkgs/commit/90e8a1dbb4635fca4a0074e3a954c43a996f0824) python3Packages.poetry-core: 1.0.7 -> 1.0.8
* [`951f98af`](https://github.com/NixOS/nixpkgs/commit/951f98afacc94aac828ab36143eacdd1a51d33e3) python3Packages.pooch: 1.5.2 -> 1.6.0
* [`788e15b1`](https://github.com/NixOS/nixpkgs/commit/788e15b1b7f39429258017ca6ff4697b60552ce1) python3Packages.prettytable: 3.0.0 -> 3.1.1
* [`3f7d2dca`](https://github.com/NixOS/nixpkgs/commit/3f7d2dcad22e5f7b7fc2c16b8921e1811a5faa05) python3Packages.prometheus-client: 0.12.0 -> 0.13.1
* [`3d1859d3`](https://github.com/NixOS/nixpkgs/commit/3d1859d3327f514f9f2025842ad68d3f92ff423b) python3Packages.prompt-toolkit: 3.0.24 -> 3.0.28
* [`548b9695`](https://github.com/NixOS/nixpkgs/commit/548b96952740a5b5a73d90618b88edc226273905) python3Packages.proto-plus: 1.19.8 -> 1.20.3
* [`edd52ecf`](https://github.com/NixOS/nixpkgs/commit/edd52ecf80afa0cadb682e42e951c2d416118089) python3Packages.proxy-py: 2.3.1 -> 2.4.0
* [`02bdb74a`](https://github.com/NixOS/nixpkgs/commit/02bdb74a28d3eb5f97d480e3ac2983e79e3907f1) python3Packages.pycognito: 2022.01.0 -> 2022.02.1
* [`48632114`](https://github.com/NixOS/nixpkgs/commit/48632114037964b1681096a68f5fb626687c42eb) python3Packages.pyee: 8.2.2 -> 9.0.4
* [`e2629a6b`](https://github.com/NixOS/nixpkgs/commit/e2629a6b5baf849224006331ae66f45ebe71ca59) python3Packages.pyfaidx: 0.6.3.1 -> 0.6.4
* [`0423be59`](https://github.com/NixOS/nixpkgs/commit/0423be59a348df72dc626582b2f3dab9c675bcb8) python3Packages.pyfakefs: 4.5.4 -> 4.5.5
* [`592082ab`](https://github.com/NixOS/nixpkgs/commit/592082ab33638c2892b8fa0e6789b7a7312495aa) python3Packages.pygit2: 1.8.0 -> 1.9.0
* [`e7fa6ec2`](https://github.com/NixOS/nixpkgs/commit/e7fa6ec2f0e69f7faf38275ded173724281c3118) python3Packages.PyICU: 2.8 -> 2.8.1
* [`fd1dd8c9`](https://github.com/NixOS/nixpkgs/commit/fd1dd8c9c04ea5a8cc6f3a99913c7f4c9762f5cc) python3Packages.pylint-django: 2.5.0 -> 2.5.2
* [`2e1380f3`](https://github.com/NixOS/nixpkgs/commit/2e1380f3ec22af6ae6847ee60820d560aa325ef5) python3Packages.pymemcache: 3.5.0 -> 3.5.1
* [`27488a3e`](https://github.com/NixOS/nixpkgs/commit/27488a3ed53026bc64e97689f19335d6171465c4) python3Packages.pyomo: 5.7.3 -> 6.3.0
* [`cb705d19`](https://github.com/NixOS/nixpkgs/commit/cb705d19a513ffa6c09b6effdc1dfdd1f15325df) python3Packages.pyopengl: 3.1.5 -> 3.1.6
* [`a2541751`](https://github.com/NixOS/nixpkgs/commit/a25417511c6ba19805571af1ee574965e7623cdf) python3Packages.pyparsing: 3.0.6 -> 3.0.7
* [`5d481bd1`](https://github.com/NixOS/nixpkgs/commit/5d481bd1703bb1ee90322c9213d2304d1bb381c4) python3Packages.pypdf3: 1.0.5 -> 1.0.6
* [`b323e99e`](https://github.com/NixOS/nixpkgs/commit/b323e99ecf8b6d4f501cc2cd2767a5152e6dc4b9) python3Packages.pyperf: 2.3.0 -> 2.3.1
* [`6340108b`](https://github.com/NixOS/nixpkgs/commit/6340108b4e43fbd47b06d22c899efc7d153ebbd2) python3Packages.pyrsistent: 0.18.0 -> 0.18.1
* [`5ba76cab`](https://github.com/NixOS/nixpkgs/commit/5ba76cabd20ad8a109c03446987b051c861bc9cc) python3Packages.pyspark: 3.2.0 -> 3.2.1
* [`71886c3c`](https://github.com/NixOS/nixpkgs/commit/71886c3c01862035c6824bfd39577b8348931dde) python3Packages.pyspnego: 0.3.1 -> 0.5.0
* [`b54c57fb`](https://github.com/NixOS/nixpkgs/commit/b54c57fbfabb2c6652a56dac8702a3ddc84e24b7) python3Packages.pytesseract: 0.3.8 -> 0.3.9
* [`995ae2eb`](https://github.com/NixOS/nixpkgs/commit/995ae2eb80ecfd7aed997ad9307cf68159f16fb8) python3Packages.pytest-asyncio: 0.18.0 -> 0.18.1
* [`85a0475d`](https://github.com/NixOS/nixpkgs/commit/85a0475df3392f8e9197f5590a443ab4dc473fa8) python3Packages.pytest-httpx: 0.17.3 -> 0.20.0
* [`cb918724`](https://github.com/NixOS/nixpkgs/commit/cb91872481465374ef03e170fa81c74998b75911) python3Packages.pytest-isort: 2.0.0 -> 3.0.0
* [`8a2e1e42`](https://github.com/NixOS/nixpkgs/commit/8a2e1e42409208f36d1ec0821d0805c25532c6e1) python3Packages.pytest-mpl: 0.13 -> 0.14.0
* [`c7687801`](https://github.com/NixOS/nixpkgs/commit/c7687801b9e2fb68700e7f71e8d07b6eedf17d3a) python3Packages.pytest-mypy: 0.8.1 -> 0.9.1
* [`a0e0dcb9`](https://github.com/NixOS/nixpkgs/commit/a0e0dcb91b90a00703773e911d8bd070f4242de5) python3Packages.pytest-regressions: 2.3.0 -> 2.3.1
* [`2a2cc076`](https://github.com/NixOS/nixpkgs/commit/2a2cc0763c4405279c1c592dbf94d46124bd3b12) python3Packages.pytest-runner: 5.3.1 -> 6.0.0
* [`d8b5604f`](https://github.com/NixOS/nixpkgs/commit/d8b5604f1a4ecc9ef7e1ec240946afe4cc5d51b4) python3Packages.pytest-socket: 0.5.0 -> 0.5.1
* [`f1ca8aca`](https://github.com/NixOS/nixpkgs/commit/f1ca8acad6ab31ba697ebceb04323050a7abc9c9) python3Packages.pytest-testmon: 1.2.2 -> 1.3.0
* [`0476f56d`](https://github.com/NixOS/nixpkgs/commit/0476f56d7c555dc4a3e015398b7c08e8a06cd94c) python3Packages.pytest-timeout: 2.0.2 -> 2.1.0
* [`c51ab22a`](https://github.com/NixOS/nixpkgs/commit/c51ab22a29edb8e77544be8ce3ba48f4d835d8a4) python3Packages.python3-saml: 1.12.0 -> 1.14.0
* [`87c097da`](https://github.com/NixOS/nixpkgs/commit/87c097da10f2decb43464882cdd9040d030f0da3) python3Packages.python-cinderclient: 8.2.0 -> 8.3.0
* [`eb2fdeab`](https://github.com/NixOS/nixpkgs/commit/eb2fdeaba0cf16811ec577d6bfe18c9d72d2862f) python3Packages.python-dbusmock: 0.25.0 -> 0.26.1
* [`788c5e57`](https://github.com/NixOS/nixpkgs/commit/788c5e57dc7998e1573cb165e95508519e9f942f) python3Packages.python-glanceclient: 3.5.0 -> 3.6.0
* [`00154ce2`](https://github.com/NixOS/nixpkgs/commit/00154ce2689a5affe0320c49e8b300cf9113447e) python3Packages.python-heatclient: 2.5.0 -> 2.5.1
* [`50d5d5f7`](https://github.com/NixOS/nixpkgs/commit/50d5d5f72784e3eb1ddbcb7538598ed32fccc408) python3Packages.python-ironicclient: 4.10.0 -> 4.11.0
* [`4a07d368`](https://github.com/NixOS/nixpkgs/commit/4a07d3682ebef37a90b420b1072687f955e077e5) python3Packages.python-manilaclient: 3.2.0 -> 3.3.0
* [`340b69d7`](https://github.com/NixOS/nixpkgs/commit/340b69d7d27685a05ae3566c69edb87760c3aec1) python3Packages.python-novaclient: 17.6.0 -> 17.7.0
* [`43607344`](https://github.com/NixOS/nixpkgs/commit/43607344a5ccfb7830b4b47451e24e12e0bbb871) python3Packages.python-slugify: 6.1.0 -> 6.1.1
* [`a7765b82`](https://github.com/NixOS/nixpkgs/commit/a7765b82c9fc0b2084d119a97aaaf77915d37cbe) python3Packages.python-snappy: 0.6.0 -> 0.6.1
* [`d70008b2`](https://github.com/NixOS/nixpkgs/commit/d70008b22cec9cc8f3d0f89902a5b50a71f52c3a) python3Packages.python-swiftclient: 3.13.0 -> 3.13.1
* [`6e76be08`](https://github.com/NixOS/nixpkgs/commit/6e76be083c8c76d67689c25b4efebdfb6e731533) python3Packages.pytools: 2021.2.9 -> 2022.1
* [`a5c9b0ac`](https://github.com/NixOS/nixpkgs/commit/a5c9b0ac748c8941be9e9a08dfe10fe238bef6fd) python3Packages.pytorch-lightning: 1.5.8 -> 1.5.10
* [`c51a4787`](https://github.com/NixOS/nixpkgs/commit/c51a47878a4d8de28b0e1693dae8227c942ef156) python3Packages.pytorch-metric-learning: 1.1.0 -> 1.2.0
* [`abb7ae70`](https://github.com/NixOS/nixpkgs/commit/abb7ae702f1984daab9091167a32d35392ffd143) python3Packages.pytorch-pfn-extras: 0.5.6 -> 0.5.7
* [`f1e696d1`](https://github.com/NixOS/nixpkgs/commit/f1e696d17163048dc57fa1900b61e12ea2744355) python3Packages.pyudev: 0.22.0 -> 0.23.2
* [`a5d2d8ff`](https://github.com/NixOS/nixpkgs/commit/a5d2d8ff0fb070c6341c1c6b43e56b7761401e68) python3Packages.pywbem: 1.4.0 -> 1.4.1
* [`bc476c77`](https://github.com/NixOS/nixpkgs/commit/bc476c77bb9d9264970178159484d716b899492d) python3Packages.pywebview: 3.5 -> 3.6.1
* [`9e307c9e`](https://github.com/NixOS/nixpkgs/commit/9e307c9e47f30b6fd23ed6e46651f0bad63e5d80) python3Packages.qiling: 1.4.1 -> 1.4.2
* [`5a34905a`](https://github.com/NixOS/nixpkgs/commit/5a34905a74a7f1b743935e937d6d506e16415c53) python3Packages.qiskit-machine-learning: 0.3.0 -> 0.3.1
* [`5cae5b27`](https://github.com/NixOS/nixpkgs/commit/5cae5b274ad91b658fd3862d74f6daff6a26bb78) python3Packages.QtPy: 2.0.0 -> 2.0.1
* [`2d9e3ed9`](https://github.com/NixOS/nixpkgs/commit/2d9e3ed9f862230467a4fd5e4121cfc4a4ae2fed) python3Packages.rasterio: 1.2.6 -> 1.2.10
* [`18c0af63`](https://github.com/NixOS/nixpkgs/commit/18c0af6354c1a1a8b4e7013a12d1a1adef6c6bd0) python3Packages.redis: 4.1.0 -> 4.1.4
* [`12578139`](https://github.com/NixOS/nixpkgs/commit/12578139a64924cd8892662b21f6c9b9b8128555) python3Packages.regex: 2022.1.18 -> 2022.3.2
* [`4d7f7a9f`](https://github.com/NixOS/nixpkgs/commit/4d7f7a9fc9b045aa814b9c3583b9947caf5b3944) python3Packages.reportlab: 3.6.5 -> 3.6.8
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
