### PR TITLE
niv emacs-overlay: update d32cf218 -> 8b7323d0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d32cf21820f0c14bb4dc7911e4d8d81b891a8f82",
-        "sha256": "045bqf15lxba75lzp95l1xg6ah5cl7p04gkyihsxl3a9j9ngr219",
+        "rev": "8b7323d06cc5310f75781ae87dd50840c3b2bfc7",
+        "sha256": "07fxxjskn8ga16kvrnnzawn95ll1m6hgqcpjkxw70nf9q9k87j0g",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/d32cf21820f0c14bb4dc7911e4d8d81b891a8f82.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/8b7323d06cc5310f75781ae87dd50840c3b2bfc7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@d32cf218...8b7323d0](https://github.com/nix-community/emacs-overlay/compare/d32cf21820f0c14bb4dc7911e4d8d81b891a8f82...8b7323d06cc5310f75781ae87dd50840c3b2bfc7)

* [`e02a399f`](https://github.com/nix-community/emacs-overlay/commit/e02a399fcbfea751d8e6f95b50f9117884804ae5) Updated repos/emacs
* [`6bad1a2d`](https://github.com/nix-community/emacs-overlay/commit/6bad1a2d7ef2fdb822e2374b2c5bdb37d8edda2d) Updated repos/melpa
* [`6edaa7aa`](https://github.com/nix-community/emacs-overlay/commit/6edaa7aab38970d1ab8e339b9d747e88ac760db5) Updated repos/elpa
* [`05b1a658`](https://github.com/nix-community/emacs-overlay/commit/05b1a65892afbdd4a6ea1bb8988ffc70bd2474f8) Updated repos/emacs
* [`5032b19f`](https://github.com/nix-community/emacs-overlay/commit/5032b19f82312fdf5d572df24f8700afb433ee13) Updated repos/melpa
* [`6a689f3f`](https://github.com/nix-community/emacs-overlay/commit/6a689f3f39314a4684c516f44413632a03a527e6) Updated repos/elpa
* [`1d9bfaf2`](https://github.com/nix-community/emacs-overlay/commit/1d9bfaf2236e23629b224935c49ede0e1ed8e8d0) Updated repos/emacs
* [`b51e1bbc`](https://github.com/nix-community/emacs-overlay/commit/b51e1bbca6109b7750d71b5f01f0fb20dde02217) Updated repos/melpa
* [`1ad4e2ec`](https://github.com/nix-community/emacs-overlay/commit/1ad4e2ec756edcee5fcb9f51f55caa779c39caf6) Updated repos/emacs
* [`e8bcf0dd`](https://github.com/nix-community/emacs-overlay/commit/e8bcf0ddb6fe849c8eead988eaf837b68e6019a7) Updated repos/melpa
* [`97747122`](https://github.com/nix-community/emacs-overlay/commit/9774712262c71def7b070a992cf7b1a913795276) Updated repos/emacs
* [`7f24256e`](https://github.com/nix-community/emacs-overlay/commit/7f24256e2e5423ad21b1953977fa102aa3401dfb) Updated repos/melpa
* [`9f8b9f9b`](https://github.com/nix-community/emacs-overlay/commit/9f8b9f9be73759c8ba81360b59511f53db43eee7) Updated repos/emacs
* [`29e4e335`](https://github.com/nix-community/emacs-overlay/commit/29e4e335d817c3b1cb643d62f7c0a72e41745bd1) Updated repos/melpa
* [`808ba014`](https://github.com/nix-community/emacs-overlay/commit/808ba014efae50bb769102aa7124e3061a2f1abe) Updated repos/emacs
* [`e5b8a928`](https://github.com/nix-community/emacs-overlay/commit/e5b8a928990a7cb1a852cd613e1a571fcc96ac06) Updated repos/melpa
* [`577f4cad`](https://github.com/nix-community/emacs-overlay/commit/577f4cad3c4d27e4b934c847f91fca328851e0af) Updated repos/emacs
* [`25df8845`](https://github.com/nix-community/emacs-overlay/commit/25df8845f053e0f6062808e537b23934b102a0f7) Updated repos/melpa
* [`1747f282`](https://github.com/nix-community/emacs-overlay/commit/1747f2824758d15cba4d530e752cca405f33e6df) Updated repos/elpa
* [`916be686`](https://github.com/nix-community/emacs-overlay/commit/916be6860d87c774f90321f820d7ac1a4d93b7d8) Updated repos/emacs
* [`c8f8659a`](https://github.com/nix-community/emacs-overlay/commit/c8f8659aba293cd7cf484c691afecde833af7dbb) Updated repos/melpa
* [`5b7e2d97`](https://github.com/nix-community/emacs-overlay/commit/5b7e2d97b8139f3d3eda49aa57944503176f132b) Updated repos/nongnu
* [`60432b8a`](https://github.com/nix-community/emacs-overlay/commit/60432b8a7dabadda524429d9f16ed9bdb9fc793e) Updated repos/emacs
* [`cfda90a9`](https://github.com/nix-community/emacs-overlay/commit/cfda90a920588fa76dd2a1a33c1c8e1a19b05df2) Updated repos/melpa
* [`2264d27f`](https://github.com/nix-community/emacs-overlay/commit/2264d27fe9048a982411fda879ed638119f5cbbc) Updated repos/nongnu
* [`3f88c9a5`](https://github.com/nix-community/emacs-overlay/commit/3f88c9a5afc859098cbc55116290d7379abe41fb) Updated repos/elpa
* [`82e4a171`](https://github.com/nix-community/emacs-overlay/commit/82e4a17195cbbca669a3746a0397ea25ddc7b75c) Updated repos/emacs
* [`64d16bb1`](https://github.com/nix-community/emacs-overlay/commit/64d16bb1dcef3f9b7a52b38cf54d87a792651968) Updated repos/melpa
* [`17abda15`](https://github.com/nix-community/emacs-overlay/commit/17abda15a37092bffd2516e6a5b3ccc5bfa20637) Updated repos/elpa
* [`ccbf3d88`](https://github.com/nix-community/emacs-overlay/commit/ccbf3d882799458460c731f40b0ab311f6c189bf) Updated repos/emacs
* [`90788aa6`](https://github.com/nix-community/emacs-overlay/commit/90788aa6c10ed3d29d101caeb1aa7570d1252848) Updated repos/melpa
* [`ede128d6`](https://github.com/nix-community/emacs-overlay/commit/ede128d6fad8342cb837761a274e8224e76a833d) Updated repos/nongnu
* [`b88358a5`](https://github.com/nix-community/emacs-overlay/commit/b88358a51ab31c62b8ddedec56f7706bc1dcc546) Updated repos/emacs
* [`08b7c825`](https://github.com/nix-community/emacs-overlay/commit/08b7c82597147158c5be42322f2dc77bb48fccdb) Updated repos/melpa
* [`06c6fa4f`](https://github.com/nix-community/emacs-overlay/commit/06c6fa4f24b90673d80a23e10e20f74577285241) Updated repos/nongnu
* [`4b96e4f1`](https://github.com/nix-community/emacs-overlay/commit/4b96e4f17cce7ec5319e0987f0595f76425bc025) Updated repos/elpa
* [`4a128aff`](https://github.com/nix-community/emacs-overlay/commit/4a128aff2349006582335b835831519bf4413ed0) Updated repos/emacs
* [`c4289e3d`](https://github.com/nix-community/emacs-overlay/commit/c4289e3dc3f221e5f2ad3a949644d969cba4bad4) Updated repos/melpa
* [`2bb4de25`](https://github.com/nix-community/emacs-overlay/commit/2bb4de25946bc4d5f3a3daa546a3362b2a07516f) Updated repos/emacs
* [`ae3d3f1a`](https://github.com/nix-community/emacs-overlay/commit/ae3d3f1a0008651650cd58af19eb6afaf6f33acd) Updated repos/melpa
* [`d38909da`](https://github.com/nix-community/emacs-overlay/commit/d38909da1dd30b900e5e23f2a4eb2f1421a4df55) Updated repos/emacs
* [`16262a84`](https://github.com/nix-community/emacs-overlay/commit/16262a84ef07fb0e8cfc592b65d786b086840065) Updated repos/melpa
* [`321a8e05`](https://github.com/nix-community/emacs-overlay/commit/321a8e051c481c8817976fdee9d16b0e8e29be0e) Updated repos/emacs
* [`1c46ded4`](https://github.com/nix-community/emacs-overlay/commit/1c46ded4e0f663d12f9ad2da1d5e1e9bdec9d01e) Updated repos/melpa
* [`d0381ae9`](https://github.com/nix-community/emacs-overlay/commit/d0381ae9f79f2a305b6003d0de15b431312c051a) Update fromElisp
* [`93f09511`](https://github.com/nix-community/emacs-overlay/commit/93f0951183e07baf9de5c64e9455bf5f8b337f0a) Updated repos/elpa
* [`255a351b`](https://github.com/nix-community/emacs-overlay/commit/255a351bbcda1a3da398cc20492b6ab49beca7b9) Updated repos/emacs
* [`fca0818d`](https://github.com/nix-community/emacs-overlay/commit/fca0818d762b8d7655aa8879dc731c01f726adda) Updated repos/melpa
* [`4392b4c2`](https://github.com/nix-community/emacs-overlay/commit/4392b4c2b738c2447b796be2e27bb00d97aa0522) Updated repos/nongnu
* [`2c10c167`](https://github.com/nix-community/emacs-overlay/commit/2c10c1679ef6c0dd190226c105450cf604f44c01) Updated repos/emacs
* [`599d8fa4`](https://github.com/nix-community/emacs-overlay/commit/599d8fa4c786917f1921f60c5bcbe517cfebbd7d) Updated repos/melpa
* [`e0f4bc33`](https://github.com/nix-community/emacs-overlay/commit/e0f4bc33ca1776c1103d15a63f022e29486d9455) Updated repos/nongnu
* [`962da39f`](https://github.com/nix-community/emacs-overlay/commit/962da39f402df54c5c2157f0d00a44fddaa1d391) Updated repos/emacs
* [`d570feea`](https://github.com/nix-community/emacs-overlay/commit/d570feea6d181b095b26a34acb2e4ef095ecf69b) Updated repos/melpa
* [`46c403ca`](https://github.com/nix-community/emacs-overlay/commit/46c403ca02391c74dfcd9502ac97869e5a497757) Updated repos/emacs
* [`1d39ce7e`](https://github.com/nix-community/emacs-overlay/commit/1d39ce7ea737cca619d10f95fb0b44029a4860f8) Updated repos/melpa
* [`8b7323d0`](https://github.com/nix-community/emacs-overlay/commit/8b7323d06cc5310f75781ae87dd50840c3b2bfc7) Updated repos/nongnu
