### PR TITLE
niv spacemacs: update d79b12e7 -> 434e2648

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "d79b12e7b4634f1212c4f5aaad756851335aa008",
-        "sha256": "1nh25aa0nvaiaiwrqi20hmq9q3c414dc5v0wahd5khya53hyv9di",
+        "rev": "434e26486cfd2cd0db8c51f6e0d4e7b029187657",
+        "sha256": "0y5ir3ipqz530yzf1yx1m0j5jhdighgix2k1dd5snpppdv95ympb",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/d79b12e7b4634f1212c4f5aaad756851335aa008.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/434e26486cfd2cd0db8c51f6e0d4e7b029187657.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@d79b12e7...434e2648](https://github.com/syl20bnr/spacemacs/compare/d79b12e7b4634f1212c4f5aaad756851335aa008...434e26486cfd2cd0db8c51f6e0d4e7b029187657)

* [`5c065028`](https://github.com/syl20bnr/spacemacs/commit/5c0650282fe09f852ecd4109bf2a6bc9cb5a950b) core-jump: fix incorrect lookup of :async ([syl20bnr/spacemacs⁠#15449](https://togithub.com/syl20bnr/spacemacs/issues/15449))
* [`9dd28c03`](https://github.com/syl20bnr/spacemacs/commit/9dd28c031688eb74c8d4a3233239f29250c5f7fb) disable evil-surround in magit-status buffers ([syl20bnr/spacemacs⁠#15462](https://togithub.com/syl20bnr/spacemacs/issues/15462))
* [`434e2648`](https://github.com/syl20bnr/spacemacs/commit/434e26486cfd2cd0db8c51f6e0d4e7b029187657) Remove disabled code and FIXME: resolved. ([syl20bnr/spacemacs⁠#15464](https://togithub.com/syl20bnr/spacemacs/issues/15464))
