### PR TITLE
niv zsh-completions: update 6db5ddc6 -> 3d394eba

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "6db5ddc6559ad8f66ca22a29365b34ad8d573884",
-        "sha256": "0q87xxw6dv55djxf55f0lh3cm4lpmza3sg848b5nz0hfd383raxq",
+        "rev": "3d394ebaa14f50a8498ab29b3a3d07cb82dee1e5",
+        "sha256": "0cdy9z622ss2f3ps7z64q8x0n1vfmbm4x1xyafsr6bz5s3wbhx24",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/6db5ddc6559ad8f66ca22a29365b34ad8d573884.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/3d394ebaa14f50a8498ab29b3a3d07cb82dee1e5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@6db5ddc6...3d394eba](https://github.com/zsh-users/zsh-completions/compare/6db5ddc6559ad8f66ca22a29365b34ad8d573884...3d394ebaa14f50a8498ab29b3a3d07cb82dee1e5)

* [`ac3e08c9`](https://github.com/zsh-users/zsh-completions/commit/ac3e08c9d486c46afcb9305b90a4684183392a5f) Update node.js options
