### PR TITLE
niv nixpkgs: update 00aa5372 -> 72757a3b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "00aa5372094568f4634c94b72fa8f1a9eec34f72",
-        "sha256": "11km38p6vqpk83nhxhw097qbxhcnkw3xv0sp96yl178i599zjr4v",
+        "rev": "72757a3b302fae930da3378d43fee5eb48528ca9",
+        "sha256": "0zyl4jligpafs30awi6mwkrv2ivcrncwqkmfsabkwm6n5df5snr6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/00aa5372094568f4634c94b72fa8f1a9eec34f72.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/72757a3b302fae930da3378d43fee5eb48528ca9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@00aa5372...72757a3b](https://github.com/nixos/nixpkgs/compare/00aa5372094568f4634c94b72fa8f1a9eec34f72...72757a3b302fae930da3378d43fee5eb48528ca9)

* [`5610ff5b`](https://github.com/NixOS/nixpkgs/commit/5610ff5ba1cb55ccbf07b377e992614f8ae21a1d) Improved error message on disabling NSS modules when disabling nscd
* [`8dda9e74`](https://github.com/NixOS/nixpkgs/commit/8dda9e74d50bdda66607587b0cf077767ebbb20f) programs.chromium fix policies for brave
* [`de7e9374`](https://github.com/NixOS/nixpkgs/commit/de7e93748181f071d4689c319bfa1dc41573ad65) Removing trailing whitespace
* [`98aa1c7e`](https://github.com/NixOS/nixpkgs/commit/98aa1c7e30c035120cfa16030005515f6614eecc) Update nixos/modules/programs/chromium.nix
* [`f640192a`](https://github.com/NixOS/nixpkgs/commit/f640192affefddaa16e1ac88b936462a7678e205) zfp: init at 0.5.5
* [`01ec4349`](https://github.com/NixOS/nixpkgs/commit/01ec4349f20157dd3bbcc1f3a540eb051c47be50) docs: Make coding conventions use pname/version
* [`6063283b`](https://github.com/NixOS/nixpkgs/commit/6063283be1ffdd5334569929a3e7e9df03508011) groonga: 11.0.9 -> 11.1.0
* [`0181cd96`](https://github.com/NixOS/nixpkgs/commit/0181cd9654ad3cc56277907af942fcff095957fa) cadvisor: 0.38.7 -> 0.40.0
* [`9746d129`](https://github.com/NixOS/nixpkgs/commit/9746d129bc8f909a2939391cb696f15cac93034d) p4.src: fix sha256
* [`12d22cda`](https://github.com/NixOS/nixpkgs/commit/12d22cda2d89951af900e21b4d1a8c2bdcdda260) libxcvt: init at 0.1.1
* [`d334cee5`](https://github.com/NixOS/nixpkgs/commit/d334cee58242aaa7a01c1ebaafc54e8fecdbf9c1) generate-expr-from-tarballs.pl: support git commit as version
* [`6a9fc444`](https://github.com/NixOS/nixpkgs/commit/6a9fc4441581e787ce8aec724a100a17817133a2) xorg.xf86videoati: 19.1.0 -> 5eba006e4129e8015b822f9e1d2f1e613e252cda
* [`982aabff`](https://github.com/NixOS/nixpkgs/commit/982aabffb59a4aa75363bb3d316decfe9f82a8dd) xorg.xf86videonouveau: 1.0.17 -> 3ee7cbca8f9144a3bb5be7f71ce70558f548d268
* [`33123525`](https://github.com/NixOS/nixpkgs/commit/3312352596a2c5c6bf6775ee2f90c4eca0e39223) xorg.xorgserver: 1.20.13 -> 21.1.3
* [`01a76b15`](https://github.com/NixOS/nixpkgs/commit/01a76b159a6ab07710492064ae658b9c0a6658ac) python310Packages.nilearn: 0.8.1 -> 0.9.0
* [`e5c53450`](https://github.com/NixOS/nixpkgs/commit/e5c534504ad33bca46d883d9ca8e54179269c7cb) python310Packages.pytest-regressions: 2.3.0 -> 2.3.1
* [`c0e4e9a3`](https://github.com/NixOS/nixpkgs/commit/c0e4e9a3771b1f5a64e9b4eb56d8d55f5b73e89f) python310Packages.datasets: 1.17.0 -> 1.18.3
* [`fe5ca118`](https://github.com/NixOS/nixpkgs/commit/fe5ca118bf107c61f2843c09bd3d5437bbd57257) fop: 2.6 -> 2.7
* [`72b4ebc1`](https://github.com/NixOS/nixpkgs/commit/72b4ebc187eb19e285b79c1c76d95b9a1d6732e3) libunistring: 0.9.10 -> 1.0
* [`ba8ec9d6`](https://github.com/NixOS/nixpkgs/commit/ba8ec9d6d22697ccfce290f6e1ba5bb0f7371c4b) maintainers: viraptor
* [`d2ae11af`](https://github.com/NixOS/nixpkgs/commit/d2ae11afb7b2348d3c847e73f7d1e5a2e70bcbc6) rbspy: init at 0.10.0
* [`624eaca9`](https://github.com/NixOS/nixpkgs/commit/624eaca9b994ed39e0028127b086ab8ce76a5056) wireguard: remove dependency on wireguard-go
* [`0df4a592`](https://github.com/NixOS/nixpkgs/commit/0df4a5922d3fa548ff41a8e11d36c64ab8d21a18) aerc: 0.7.1 -> 0.8.2
* [`4257b3c0`](https://github.com/NixOS/nixpkgs/commit/4257b3c056882e60298367ce3ecdf2a803c7ef08) prometheus-bird-exporter: 1.4.0 -> 1.4.1
* [`369bc63a`](https://github.com/NixOS/nixpkgs/commit/369bc63ae7327833830469fc137562fba636b95e) maintainers: add grnnja
* [`b6c7526d`](https://github.com/NixOS/nixpkgs/commit/b6c7526d3a950a206868fc611730ff3f4e498b71) jflap: init at 7.1
* [`29199091`](https://github.com/NixOS/nixpkgs/commit/29199091c685ec6d924331ed0d10f90b52ffc589) odin2: int at unstable-2022-02-23
* [`b7334992`](https://github.com/NixOS/nixpkgs/commit/b7334992e5ee5a73838013093a9a04766f1a1379) rbspy: 0.10.0 -> 0.11.1
* [`94adf261`](https://github.com/NixOS/nixpkgs/commit/94adf26120fe1b0c13927839594f0962df6c52c7) gojq: init at 0.12.7
* [`d6026416`](https://github.com/NixOS/nixpkgs/commit/d6026416f496c3352aea5e7a14f6cf5407d414a6) roundcubePlugins.carddav: v3.0.3 -> v4.3.0
* [`1748887f`](https://github.com/NixOS/nixpkgs/commit/1748887ff2353a16806a46dc27fb603981a047d5) llvmPackages/libllvm: move static archives to dev output
* [`f346d282`](https://github.com/NixOS/nixpkgs/commit/f346d2829e03776ae8a425645c3dbc008f0f33ae) git-series: 0.9.1 -> unstable-2019-10-15
* [`62f5a23f`](https://github.com/NixOS/nixpkgs/commit/62f5a23f66838f6055acee8666d3649209c20b02) brave: enable native wayland support with NIXOS_OZONE_WL
* [`16e667e3`](https://github.com/NixOS/nixpkgs/commit/16e667e3495488b8f1e514d850b0b3fba0be84a1) python310Packages.flask-security-too: 4.1.2 -> 4.1.3
* [`d8fe2323`](https://github.com/NixOS/nixpkgs/commit/d8fe23231a627f82305b483693d0e7967bbe8621) mbpfan: 2.2.1 -> 2.3.0
* [`442ced61`](https://github.com/NixOS/nixpkgs/commit/442ced61547e4a6942166ee81df3f800ff66f786) haste-server: init at 3dcc43578b99dbafac35dece9d774ff2af39e8d0
* [`a1cbf8cf`](https://github.com/NixOS/nixpkgs/commit/a1cbf8cfffc04a4cb493fa4f1c296668119ac4ca) nixos/haste-server: add
* [`d8bae875`](https://github.com/NixOS/nixpkgs/commit/d8bae875e07d7dc43bf1bf9087bdf10f076793a0) nixosTests.haste-server: init
* [`9bc43e3b`](https://github.com/NixOS/nixpkgs/commit/9bc43e3bada7016012f6d6d13debf71a884492b0) celluloid: 0.22 -> 0.23
* [`c4e6f834`](https://github.com/NixOS/nixpkgs/commit/c4e6f834d4175c61330aa0e06468eddec6a6bdb6) prometheus-process-exporter: 0.7.5 -> 0.7.10
* [`b1e73fa2`](https://github.com/NixOS/nixpkgs/commit/b1e73fa2e086f1033a33d93524ae2a1781d12b95) nixos/wrap-gapps-hook: don't add data directories of icon dependencies into XDG_DATA_DIRS
* [`22208a7a`](https://github.com/NixOS/nixpkgs/commit/22208a7a6eb86caf92cae5ed5b7ea0b05b0386c7) rich-cli: init at 1.5.1
* [`a6a82383`](https://github.com/NixOS/nixpkgs/commit/a6a823834b2588ae3d63ea60597f2f43b4a62bf2) wpa_supplicant: rename withDbus to dbusSupport
* [`5bb6a807`](https://github.com/NixOS/nixpkgs/commit/5bb6a807cc1814dd7c751cc0c71b0b484bbb456d) soju: 0.3.0 -> 0.4.0
* [`aeb3ae50`](https://github.com/NixOS/nixpkgs/commit/aeb3ae5008cb75134f90031d6ca9b973a2ba150d) ruby: separate rails express patches and source location
* [`fa6f87a8`](https://github.com/NixOS/nixpkgs/commit/fa6f87a8aefa8c9d00b69b8de96fed2f869f8cbb) ruby: fix default value of RUBY_REVISION when building from git
* [`96348950`](https://github.com/NixOS/nixpkgs/commit/9634895022ef33cc4b02c8b483771050c68750ce) ruby: fix build with bundled gems
* [`6e859afe`](https://github.com/NixOS/nixpkgs/commit/6e859afe34879a29b9389aa47f1fb022fc0f4f98) ruby: always build from the tarball, drop support for git builds
* [`dcc886f8`](https://github.com/NixOS/nixpkgs/commit/dcc886f88911b99465b3fca288640ed537e9800b) python3Packages.dnspython: 2.2.0 -> 2.2.1
* [`c8527aab`](https://github.com/NixOS/nixpkgs/commit/c8527aab06212b15819aeddc394afe72e9a744ab) perl: 5.34.0 -> 5.34.1
* [`d25a1e4e`](https://github.com/NixOS/nixpkgs/commit/d25a1e4e0febee463529d40b8c5b2112c6f059fc) perl.perl-cross: 393821c7 -> 1.3.7
* [`2cf99c99`](https://github.com/NixOS/nixpkgs/commit/2cf99c997decee01ebf6e21d3081c15c3e3835d4) perldevel: 5.35.4 -> 5.35.9
* [`e9d2785e`](https://github.com/NixOS/nixpkgs/commit/e9d2785e6b2bccfeb5b23d1eb3c474d0877861ec) cppy: 1.1.0 -> 1.2.0
* [`802c818d`](https://github.com/NixOS/nixpkgs/commit/802c818d3f3aaa14c0442d44d340de4e1f107559) doc/gnome: update accordingly to wrapGAppsHook change
* [`9df2c375`](https://github.com/NixOS/nixpkgs/commit/9df2c375542e729d8d3692c34227a0e1623ea706) powershell: 7.2.1 -> 7.2.2
* [`af6b0743`](https://github.com/NixOS/nixpkgs/commit/af6b07431daea3c12348bfaf7a91bb5a7d453186) libguestfs: 1.46.2 -> 1.48.0
* [`84bbe973`](https://github.com/NixOS/nixpkgs/commit/84bbe973cc066b4007af8e65248f37db06b7e52a) maven: 3.8.4 -> 3.8.5
* [`d055eda6`](https://github.com/NixOS/nixpkgs/commit/d055eda636d265fe01e420be966f97293210ec49) mavproxy: 1.8.46 -> 1.8.48
* [`b5639fc9`](https://github.com/NixOS/nixpkgs/commit/b5639fc91bf5a4858f0f0a3db867d7fb9df790e2) liquid-dsp: 20170307 -> 1.4.0
* [`f054fb8e`](https://github.com/NixOS/nixpkgs/commit/f054fb8e8b999555860cbdc5f0f8325b5ac13bb9) moodle: 3.11.5 -> 3.11.6
* [`4d3b9839`](https://github.com/NixOS/nixpkgs/commit/4d3b9839a4cb61c8145e95017acc0ca9ffe99284) libopenmpt: 0.5.11 -> 0.6.2, refactor
* [`10479e4f`](https://github.com/NixOS/nixpkgs/commit/10479e4f51ff182651ccff4a71b2a94ab93816c0) makeWrapper: add `--chdir`
* [`f8e08ed2`](https://github.com/NixOS/nixpkgs/commit/f8e08ed20e65e1a20032b937158d6022c0f35300) liquibase: 4.8.0 -> 4.9.0
* [`d1009de6`](https://github.com/NixOS/nixpkgs/commit/d1009de69837eddf285f89c68c89a26375d0e76a) mackerel-agent: 0.72.8 -> 0.72.9
* [`0f488afa`](https://github.com/NixOS/nixpkgs/commit/0f488afad28f057ce3caf771b21f379d1dcd00bb) build-fhs-userenv-bubblewrap: symlink share directory when there's no need to merge
* [`9160044f`](https://github.com/NixOS/nixpkgs/commit/9160044f5f05d0a4ac46f1260beb8604c15ed4fa) treewide/makeWrapper: replace `--run cd` with `--chdir`
* [`13d37eab`](https://github.com/NixOS/nixpkgs/commit/13d37eab6cdd8c4803cac5866a7aba9a7ad4bcde) nodejs: fix cross compilation
* [`48034046`](https://github.com/NixOS/nixpkgs/commit/48034046bf6271d44f7dea4c1ba97196b3b105a7) autoPatchelfHook: Make Linux-exclusive
* [`cf73b899`](https://github.com/NixOS/nixpkgs/commit/cf73b899c025582f6003e7efb693404b68d0f1d5) python39Packages.asgiref: 3.4.1 -> 3.5.0, add SuperSandro2000 as maintainer
* [`42ac9a88`](https://github.com/NixOS/nixpkgs/commit/42ac9a88a057e1af48a1be2755e1c0df99918df7) python39Packages.blinker: run tests with nose like upstream, add SuperSandro2000 as maintainer
* [`facde176`](https://github.com/NixOS/nixpkgs/commit/facde176d232ccf6aef9dcf10e76db5acf3a7e45) python39Packages.cryptography-vectors: add pythonImportsCheck
* [`85b84125`](https://github.com/NixOS/nixpkgs/commit/85b84125e1f9ae5c4c56851fa38ebcac17025218) python39Packages.cryptography: add SuperSandro2000 as maintainer
* [`ece9e820`](https://github.com/NixOS/nixpkgs/commit/ece9e8200f3cb85921d8d63289389c0d7dd33ac0) python39Packages.cryptography: remove darwin from inputs
* [`de6171a4`](https://github.com/NixOS/nixpkgs/commit/de6171a4414d1103855a6b1bced6daca11429443) python39Packages.cryptography: switch to pytestCheckHook
* [`2c7290a1`](https://github.com/NixOS/nixpkgs/commit/2c7290a1891be6c52b8a2c168b0ca185a2eab100) python39Packages.cryptography: remove depedencies which have no mentions in code
* [`37a6c262`](https://github.com/NixOS/nixpkgs/commit/37a6c262f318789a8803c11a60a835a4255720b2) python39Packages.cryptography: format
* [`a217922f`](https://github.com/NixOS/nixpkgs/commit/a217922f79689295097644e51581f4f9aeefa000) python39Packages.hpack: run tests, add SuperSandro2000 as maintainer
* [`3a4718d7`](https://github.com/NixOS/nixpkgs/commit/3a4718d7b7bfd2616f276cdf1943e55e505a95dc) python39Packages.hyperframe: add pythonImportsCheck, update homepage, add SuperSandro2000 as maintainer
* [`458b2925`](https://github.com/NixOS/nixpkgs/commit/458b29255f22a4f32e0c10ddba63e595d11a9f5a) python39Packages.pyasn1: add pythonImportsCheck, fix license, update homepage, add SuperSandro2000 as maintainer
* [`a923e194`](https://github.com/NixOS/nixpkgs/commit/a923e194a3f21ed8a31367c96530a06756ed993e) python39Packages.pyopenssl: cleanup dependencies
* [`ea829cff`](https://github.com/NixOS/nixpkgs/commit/ea829cff7569de8704cf46b861f317b64a6ba354) python39Packages.tornado: enable tests, add SuperSandro2000 as maintainer
* [`8cdcda6c`](https://github.com/NixOS/nixpkgs/commit/8cdcda6c9760e2e6a1a5aa14585645b3d200c0ae) audit: fix build for linux-headers-5.17
* [`ff53fd63`](https://github.com/NixOS/nixpkgs/commit/ff53fd63f8664223bf3fa8235cf2ce5a83232225) python39Packages.wsproto: switch to pytestCheckHook, remove python 3.6 support, add SuperSandro2000 as maintainer
* [`a06d3ff2`](https://github.com/NixOS/nixpkgs/commit/a06d3ff281ceeb053116f77f7dd93dcdfd1f1814) python39Packages.pyparsing: 3.0.6 -> 3.0.7, switch to pytestCheckHook
* [`be07e4c1`](https://github.com/NixOS/nixpkgs/commit/be07e4c1e21a6a93a6d33d624c709232fe95f1f2) python39Packages.h11: disable on pythons older than 3.6, add SuperSandro2000 as maintainer
* [`8d862c57`](https://github.com/NixOS/nixpkgs/commit/8d862c57024792a67ce6a07bafb16e0bb611fef9) python3Packages.asgiref: update supported Python releases
* [`a2c4c7f7`](https://github.com/NixOS/nixpkgs/commit/a2c4c7f7a8faa1c794536cfebf78f2d5428fb21a) python39Packages.requests: remove no longer required patch
* [`977534ec`](https://github.com/NixOS/nixpkgs/commit/977534ec0a093dba8ff22fb3c2f4a68939a90807) python39Packages.setuptools-rust: 1.1.2 -> 1.2.0
* [`4cc71fa9`](https://github.com/NixOS/nixpkgs/commit/4cc71fa97dab015d8dbee99c441b13ccca7a4b90) python39Packages.cryptography: 36.0.0 -> 36.0.2
* [`698af35a`](https://github.com/NixOS/nixpkgs/commit/698af35a8ec2e6ba89d2e0398e6a8524a1e2954e) cppy: enable tests, add pythonImportsCheck
* [`1be45287`](https://github.com/NixOS/nixpkgs/commit/1be45287bdedb40f3d070733dc5975f64341c9c9) python3Packages.regex: 2022.3.2 -> 2022.3.15
* [`d4ec9dd5`](https://github.com/NixOS/nixpkgs/commit/d4ec9dd553e5ba2277f3aea2c5e54d23023b2544) python3Packages.pycep-parser: 0.3.2 -> 0.3.3
* [`e1d32f94`](https://github.com/NixOS/nixpkgs/commit/e1d32f9407117fbaf30a042df80048c883469d8f) python3Packages.responses: 0.18.0 -> 0.20.0
* [`d2f26874`](https://github.com/NixOS/nixpkgs/commit/d2f268745a44dfd0ff23b5a00a75c1e13279bc3d) treewide: autoPatchelfHook only on Linux
* [`835b162c`](https://github.com/NixOS/nixpkgs/commit/835b162caee2713d19e28117f6f292a6f03185d5) fixDarwinDylibNames: Make Darwin-exclusive
* [`b07c5b82`](https://github.com/NixOS/nixpkgs/commit/b07c5b829aa1f44cc314b13fd7d9072560cba605) treewide: fixDarwinDylibNames only on Darwin
* [`6d5605af`](https://github.com/NixOS/nixpkgs/commit/6d5605afcd80d491dcaa95b62d6e97be315ea17b) freepats: replace name with pname&version
* [`e6ab13f0`](https://github.com/NixOS/nixpkgs/commit/e6ab13f00595572b49139ec0a06c5eddade28376) dns-root-data: replace name with pname&version
* [`b5cad4d4`](https://github.com/NixOS/nixpkgs/commit/b5cad4d4a4055d9aa3c19660122ff5541de9706f) stdenv/setup.sh: make sure $sourceRoot has +x before cd-ing
* [`1454f5c0`](https://github.com/NixOS/nixpkgs/commit/1454f5c0cd109ba99d424c165533896735db30ad) man: 2.10.1 -> 2.10.2
* [`52f8cf58`](https://github.com/NixOS/nixpkgs/commit/52f8cf58a4504e5e219faebffa51033e400e3aec) linux.stdenv: gcc_10 → gcc_11
* [`5267c0e2`](https://github.com/NixOS/nixpkgs/commit/5267c0e20ed4e83e1128bc3d118f08201da588a0) exempi: pin boots/gccStdenv versions due to compilation errors with more recent stdenv
* [`04afc69a`](https://github.com/NixOS/nixpkgs/commit/04afc69a29c3de7fee5ea4e1a34b2064f758a539) discourse: 2.9.0.beta1 -> 2.9.0.beta3
* [`9b891e6f`](https://github.com/NixOS/nixpkgs/commit/9b891e6f64a7f8275954597d717543dedc3e64d7) discourse.plugins: Update all plugins to their latest versions
* [`068c5a0c`](https://github.com/NixOS/nixpkgs/commit/068c5a0c80097af8b419e26297fc4bef48344a54) nixos/discourse: Update redis server settings...
* [`d46598d4`](https://github.com/NixOS/nixpkgs/commit/d46598d4f4dbba8eaa5d56786db65bad17010332) discourse-mail-receiver: Add update_mail_receiver to update.py
* [`cdbe5e98`](https://github.com/NixOS/nixpkgs/commit/cdbe5e98e07c40bfbf671dd6b43e443d07155267) pmdk: 1.9.2 → 1.11.1
* [`c24ffe3d`](https://github.com/NixOS/nixpkgs/commit/c24ffe3d5243f0cb77a783af9a2870b61bd364a8) rlottie: add upstream gcc11 patch
* [`9464bf0a`](https://github.com/NixOS/nixpkgs/commit/9464bf0ad62355cecc709244863e401b15b21812) glm: `-no-strict-aliasing` due to upstream bug
* [`7481d515`](https://github.com/NixOS/nixpkgs/commit/7481d51589c7a30cc7cc5818dd7281d560b8c4e4) glog: disable parallel checking due to errors
* [`a084137f`](https://github.com/NixOS/nixpkgs/commit/a084137fac5ae52743957b9b93204b803fda6cd6) zlib: add patches to fix CVE-2018-25032
* [`57c57397`](https://github.com/NixOS/nixpkgs/commit/57c573971d6ed49902cbf2aea0afee13636d4f25) python3Packages.zopfli: 0.2.0 -> 0.2.1
* [`7d3d72e1`](https://github.com/NixOS/nixpkgs/commit/7d3d72e1f498029b14b4d5600811d8f959af220e) python3Packages.fontparts: 0.10.3 -> 0.10.4
* [`5694e725`](https://github.com/NixOS/nixpkgs/commit/5694e725958f23db99f8e8f2e26b0e4ff27439e6) python3Packages.psautohint: 2.3.1 -> 2.4.0
* [`90b04047`](https://github.com/NixOS/nixpkgs/commit/90b04047ce2dca0d8aa0539634a85b2cb394c073) python3Packages.fonttools: 4.29.1 -> 4.30.0
* [`54a0c4b9`](https://github.com/NixOS/nixpkgs/commit/54a0c4b92371a5d1a03f8a6d30fee719a4b990c2) python3Packages.afdko: 3.7.1 -> 3.8.0
* [`6dbebf08`](https://github.com/NixOS/nixpkgs/commit/6dbebf08c8b56765ad239f31490f738a16cc2a22) bluez: 5.63 -> 5.64
* [`95d7a7bb`](https://github.com/NixOS/nixpkgs/commit/95d7a7bbf1dfb56b701c46d169866aab751d7116) pythonPackages.cryptography*: remove primeos from maintainers
* [`a8b0e20b`](https://github.com/NixOS/nixpkgs/commit/a8b0e20bc368555042e6a57346cb4c466bec20cd) python39Packages.twisted: don't overwrite patchPhase, fix path to tests, update homepage ...
* [`8c59d68a`](https://github.com/NixOS/nixpkgs/commit/8c59d68a940da3d51e73cab2cf69f0537856d0d0) python39Packages.sortedcontainers: enable tests, replace SuperSandro2000 as maintainer
* [`4df569c6`](https://github.com/NixOS/nixpkgs/commit/4df569c641a8f5c91793c1aafd0855679bbfb0d6) python3Packages.freezegun: 1.1.0 -> 1.2.1
* [`748dfdd1`](https://github.com/NixOS/nixpkgs/commit/748dfdd1f58ee07395fbfd6689a360e3dd6dda5b) libtiff: add patches for multiple CVEs
* [`c3c04449`](https://github.com/NixOS/nixpkgs/commit/c3c0444949ed44a718c20d49acf4a115c406b03a) findutils: move {locate,updatedb} to a separate $locate output
* [`261aa482`](https://github.com/NixOS/nixpkgs/commit/261aa4822120be88547e90d653efd9fbbc74c535) hwloc: 2.7.0 -> 2.7.1
* [`b7dcb6e2`](https://github.com/NixOS/nixpkgs/commit/b7dcb6e2c70d9e2ed06a17d0ba728f156943c080) e2fsprogs: build fuse2fs and add output for fuse2fs
* [`84064299`](https://github.com/NixOS/nixpkgs/commit/84064299e160d46f7a9b8a887fc74198e834e375) libevdev: 1.12.0 -> 1.12.1
* [`930993f5`](https://github.com/NixOS/nixpkgs/commit/930993f510e103091a1a36a68e108b51cabffc90) python3Packages.pycep-parser: remove old patch
* [`958ca1d1`](https://github.com/NixOS/nixpkgs/commit/958ca1d1dd77e4cdb6de5d2042f06f2d218f6e6d) python39Packages.cppy: fix version number, update disabled
* [`1da1c07d`](https://github.com/NixOS/nixpkgs/commit/1da1c07d03d9c960167f425bde49440e89d9eeb2) python39Packages.kiwisolver: 1.3.2 -> 1.4.0
* [`4345b27d`](https://github.com/NixOS/nixpkgs/commit/4345b27dedf55e09e4afa085df1c6504072d279e) git: enable debug info
* [`8df79497`](https://github.com/NixOS/nixpkgs/commit/8df7949791250b580220eb266e72e77211bedad9) pythonPackages.cryptography-vectors: make internal to cryptography
* [`0b1a35a7`](https://github.com/NixOS/nixpkgs/commit/0b1a35a7882d6424e7fbb4000ee740e6006dbdcd) rust-cbindgen: 0.20.0 -> 0.21.0
* [`745dd2d1`](https://github.com/NixOS/nixpkgs/commit/745dd2d18bdcbf1a8f175174b523e20341bbe579) xprintidle: init at 0.2.4
* [`ffb8c40a`](https://github.com/NixOS/nixpkgs/commit/ffb8c40ad7638ade21f71015c26b448c0033d7e5) intel-media-driver: 22.2.2 -> 22.3.0
* [`303eaed4`](https://github.com/NixOS/nixpkgs/commit/303eaed49fc3859b7a987120ea528d0a47fdf5b1) flit, flit-core: update homepage
* [`3073f621`](https://github.com/NixOS/nixpkgs/commit/3073f621c1194a044915059db8c96289715ea804) python39Packages.flit: sync maintainers with flit-core
* [`71fba1fb`](https://github.com/NixOS/nixpkgs/commit/71fba1fb0b662677effd89ec7ec86b0ef954fb8c) vim: 8.2.4350 -> 8.2.4609
* [`52165eef`](https://github.com/NixOS/nixpkgs/commit/52165eefbeb355c327fbe9f1678b560ec8d38e6b) python3Packages.requests-oauthlib: rename
* [`d9ddafc4`](https://github.com/NixOS/nixpkgs/commit/d9ddafc4c956b2ed7641cf633c97f517c6e3c5a4) python3Packages.msrest: switch to pytestCheckHook and clean-up
* [`0ffe93b4`](https://github.com/NixOS/nixpkgs/commit/0ffe93b4087a46489e0865aefe00131855b80803) python3Packages.apprise: update input name
* [`26b86fa1`](https://github.com/NixOS/nixpkgs/commit/26b86fa1f85c4ac68ec172a182b6bfc5dc9a441e) seahhub: rename requests-oauthlib
* [`ecd0dd8d`](https://github.com/NixOS/nixpkgs/commit/ecd0dd8d1b60cbafd960cf35103853d9967c3173) python3Packages.asana: 0.10.3 -> 0.10.9
* [`539043cf`](https://github.com/NixOS/nixpkgs/commit/539043cfa8c61c74d75e6640e2cffbdf34c130b5) python3Packages.twitterapi: rename requests-oauthlib
* [`52f97ffa`](https://github.com/NixOS/nixpkgs/commit/52f97ffab2bb2c67402728ddaff3bf0431f1a63a) python3Packages.python-twitter: rename requests-oauthlib
* [`76c7d5fc`](https://github.com/NixOS/nixpkgs/commit/76c7d5fcdd9c874b79cb89c959ad704357e6ad46) python3Packages.tweepy: rename requests-oauthlib
* [`34c92824`](https://github.com/NixOS/nixpkgs/commit/34c928243bb6cbc5c1cddf5ec728e99fdb39f198) python3Packages.pynello: rename requests-oauthlib
* [`7a147fe4`](https://github.com/NixOS/nixpkgs/commit/7a147fe459a88d4160fc4c3f721179fbb60e95f8) python3Packages.ondilo: rename requests-oauthlib
* [`a95f4be8`](https://github.com/NixOS/nixpkgs/commit/a95f4be804cf02e56a33ca10e3e84441f3bef5fb) python3Packages.tellduslive: rename requests-oauthlib
* [`31e92b26`](https://github.com/NixOS/nixpkgs/commit/31e92b268f43c992127ef46af8f286d3cef70a6e) python3Packages.pymfy: rename requests-oauthlib
* [`3fe06336`](https://github.com/NixOS/nixpkgs/commit/3fe0633692ea84b98ff6db3ff8e295cac7c26228) python3Packages.pyvicare: rename requests-oauthlib
* [`2699c585`](https://github.com/NixOS/nixpkgs/commit/2699c585d63502e9cb560363eb0430fcb319d80f) python3Packages.pysmappee: rename requests-oauthlib
* [`34a776c8`](https://github.com/NixOS/nixpkgs/commit/34a776c8efc858645cf4bb3d575bc4cbd4d28d84) python3Packages.pybotvac: rename requests-oauthlib
* [`1e69a845`](https://github.com/NixOS/nixpkgs/commit/1e69a845f9366b3b4719e4305ea3d2aeebbe6c3d) python3Packages.pysnow: switch to pytestCheckHook
* [`9493af17`](https://github.com/NixOS/nixpkgs/commit/9493af17585f90722394c9241ff4177779b64a9b) python3Packages.pyatmo: rename requests-oauthlib
* [`bb7af999`](https://github.com/NixOS/nixpkgs/commit/bb7af999e824c055188cb8cdf19aca6026af421a) python3Packages.ring-doorbell: rename requests-oauthlib
* [`f31dd24f`](https://github.com/NixOS/nixpkgs/commit/f31dd24fac9dee04f980c5fa96b31bc3117b694b) python3Packages.fitbit: clean-up and rename requests-oauthlib
* [`4618d624`](https://github.com/NixOS/nixpkgs/commit/4618d624cfa7f16634dc5587981bce50b72003ee) python3Packages.python-google-nest: rename requests-oauthlib
* [`1f613307`](https://github.com/NixOS/nixpkgs/commit/1f613307b97ecbbf1551dbda80842a7867260212) python3Packages.google-nest-sdm: rename requests-oauthlib
* [`b1407304`](https://github.com/NixOS/nixpkgs/commit/b140730436b21519a22cb77bce13fc67605b2309) python3Packages.flickrapi: enable tests and rename requests-oauthlib
* [`2d800e45`](https://github.com/NixOS/nixpkgs/commit/2d800e458d8b804d34518c462df1a881d826b1d3) python3Packages.exchangelib: rename requests-oauthlib
* [`549a8ae8`](https://github.com/NixOS/nixpkgs/commit/549a8ae8eaf37ee3a2049523a44613159fc431f7) python3Packages.atlassian-python-api: rename requests-oauthlib
* [`a1262591`](https://github.com/NixOS/nixpkgs/commit/a1262591fd07525a722275f85fbcfddba0c741da) python3Packages.google-auth-oauthlib: rename requests-oauthlib
* [`90d27e59`](https://github.com/NixOS/nixpkgs/commit/90d27e59ffad0964ae328c1f042615aa5f60d0d7) python3Packages.google-auth-oauthlib: update hash
* [`2685758b`](https://github.com/NixOS/nixpkgs/commit/2685758bd26f69bf3bdd64c5e6db89ef41acd3fc) python3Packages.mwoauth: rename requests-oauthlib
* [`247a5b0d`](https://github.com/NixOS/nixpkgs/commit/247a5b0d18ae197edac8e930534686de3cb2df67) python3Packages.django-allauth: rename requests-oauthlib
* [`0a34a966`](https://github.com/NixOS/nixpkgs/commit/0a34a9669802ae7f050286fc1cbee0b5d37e2b20) python3Packages.jira: rename requests-oauthlib
* [`efb1c809`](https://github.com/NixOS/nixpkgs/commit/efb1c8096e7dc58bd645cc845061d548244a548a) python3Packages.kubernetes: rename requests-oauthlib
* [`276e2f27`](https://github.com/NixOS/nixpkgs/commit/276e2f27132cde0b89eb6ff6fa078d32760abd26) python3Packages.mwclient: switch to pytestCheckHook
* [`6f18cda2`](https://github.com/NixOS/nixpkgs/commit/6f18cda23cc67b47f846b96ce94c27ef1eac8af6) python3Packages.lmnotify: rename requests-oauthlib
* [`e85edf7c`](https://github.com/NixOS/nixpkgs/commit/e85edf7c83fa6eae0ad1a34dc2254ca86fc30624) python3Packages.mezzanine: rename requests-oauthlib
* [`8e1f03ee`](https://github.com/NixOS/nixpkgs/commit/8e1f03ee6f6676d442daed1f7ef218bb7cac1283) python3Packages.vdirsyncer: rename requests-oauthlib
* [`135299a1`](https://github.com/NixOS/nixpkgs/commit/135299a1f4cb677c26ff0c1bd44c3e1addf12a5c) beets: rename requests-oauthlib
* [`f91f32ac`](https://github.com/NixOS/nixpkgs/commit/f91f32ac2a36288180f039edeb4269bc4eb2f64a) gphotos-sync: rename requests-oauthlib
* [`c58c2a31`](https://github.com/NixOS/nixpkgs/commit/c58c2a312b6d60a8c554e96e51971a19960f6aa2) python3Packages.pleroma-bot: rename requests-oauthlib
* [`73fd7713`](https://github.com/NixOS/nixpkgs/commit/73fd7713328422fa01730c5bdf66f785bf1fc44d) python3Packages.homeconnect: rename requests-oauthlib
* [`41a2d7a1`](https://github.com/NixOS/nixpkgs/commit/41a2d7a1c3a825a02eb81fbf4d38d2e8407804b0) python3Packages.weconnect: 0.37.0 -> 0.38.1
* [`6f80b29a`](https://github.com/NixOS/nixpkgs/commit/6f80b29a883cae97ea87d6ffe306e2e87aedcff5) python3Packages.weconnect-mqtt: 0.30.2 -> 0.32.0
* [`e30f0f31`](https://github.com/NixOS/nixpkgs/commit/e30f0f31e8def38a28e8af20ebac0ed607ba2563) coreutils: add debug output
* [`36aa3f6a`](https://github.com/NixOS/nixpkgs/commit/36aa3f6a09ad59869baeff3909385db9b2307e07) binutils: 2.35.1 -> 2.37
* [`7bac80fe`](https://github.com/NixOS/nixpkgs/commit/7bac80fef8d153147de38fbd5586255d836ce980) stdenv: fix binutils' bootstrap
* [`f8885d9d`](https://github.com/NixOS/nixpkgs/commit/f8885d9d0742deab59d0dfda28dbbf12bf0ecedc) libbfd: fix binutils components patch
* [`ce91080d`](https://github.com/NixOS/nixpkgs/commit/ce91080db260c76537c59d887ef48a98c27c9d5c) binutils: add patch for ld file descriptor explosion
* [`cc83bad8`](https://github.com/NixOS/nixpkgs/commit/cc83bad887fec116d435e1d9e977883afc54dd55) afterstep: binutils 2.37 fix
* [`492a6023`](https://github.com/NixOS/nixpkgs/commit/492a60230cbebee424ce8d70c20d4f5012791dfa) cdesktopenv: binutils 2.37 fix
* [`561781c4`](https://github.com/NixOS/nixpkgs/commit/561781c4d7d00ed57de1f6c3918bf59d7db3856d) nx-libs: binutils 2.37 fix
* [`c748ef4d`](https://github.com/NixOS/nixpkgs/commit/c748ef4d1b6a3f9e9e370a0ff0f6ade7ec0e2ecc) binutils: format input attrs
* [`8e5d2ead`](https://github.com/NixOS/nixpkgs/commit/8e5d2ead61539c6998ca55def4c29ff2e8bac600) binutils: rename gold to enableGold
* [`008ce661`](https://github.com/NixOS/nixpkgs/commit/008ce6610abdeb4c8e42d2cad8f7e91f1fd193c5) binutils: join srcs in an attrset
* [`34368867`](https://github.com/NixOS/nixpkgs/commit/3436886724af7c160ea541859bd72208c7f8c417) binutils: format and order patches section
* [`c4913fb2`](https://github.com/NixOS/nixpkgs/commit/c4913fb289ba18a7474cc232fd84b5ae17a39125) binutils: inherit {build,host,target}Platform to avoid repeating ourselves
* [`e06d51d4`](https://github.com/NixOS/nixpkgs/commit/e06d51d4c04a55e9b671d7417e83c50a7576d521) binutils: add tags to comments where relevant
* [`a3accfbe`](https://github.com/NixOS/nixpkgs/commit/a3accfbea9c4cd68227fda6690556b7a7dd701c3) binutils: inline reuseLibs
* [`8f7c9816`](https://github.com/NixOS/nixpkgs/commit/8f7c9816aaf7cc4347c3aa1cec916f20d2622fc7) binutils: sort configureFlags
* [`737fe071`](https://github.com/NixOS/nixpkgs/commit/737fe071363c5f5c809279effb4dea27c5644d77) binutils: take some suggestion from nixpkgs-fmt
* [`29e61371`](https://github.com/NixOS/nixpkgs/commit/29e61371a70a747f284516c6e277a6e6f9ebddb9) binutils: add lovesegfault as a maintainer
* [`ca02ea1e`](https://github.com/NixOS/nixpkgs/commit/ca02ea1e2641487f9c7fe8002569a99856a96304) binutils: 2.37 -> 2.38
* [`3de6fbcf`](https://github.com/NixOS/nixpkgs/commit/3de6fbcfa277d12abde12814943b41f56f219898) libbfd: update build-components-separately.patch for 2.38
* [`aa9448db`](https://github.com/NixOS/nixpkgs/commit/aa9448db2abf5fea1086eb43f1d7bedf5a23b85b) binutils: move src hack out of srcs attrset
* [`022e81d7`](https://github.com/NixOS/nixpkgs/commit/022e81d7f12deb2d58d967e309603c5028cea982) binutils: revert libtool changes that break darwin
* [`c9810944`](https://github.com/NixOS/nixpkgs/commit/c9810944803485ade690d89b12527e330f2fa1b8) binutils: only autoconf on Darwin
* [`51f16633`](https://github.com/NixOS/nixpkgs/commit/51f1663342257f21635563a9cb83091e4bab58fe) wcslib: 7.7 -> 7.9
* [`43f3c510`](https://github.com/NixOS/nixpkgs/commit/43f3c510fc42ed0f187a493d1d0266493817a8ab) python3Packages.black: 22.1.0 -> 22.3.0
* [`655789a7`](https://github.com/NixOS/nixpkgs/commit/655789a7f47bdc973158a976eaecf2f05e4c8ebb) aws-c-sdkutils: 0.1.1 -> 0.1.2
* [`c987121a`](https://github.com/NixOS/nixpkgs/commit/c987121acf5c87436a0b05ca75cd70bf38c452ca) glib: Add support for GNOME Console
* [`ca0b2cdd`](https://github.com/NixOS/nixpkgs/commit/ca0b2cdd6774635150fedcca009fee8a18df1dcb) glib: add support for Pantheon’s terminal emulator
* [`0dc98240`](https://github.com/NixOS/nixpkgs/commit/0dc9824089477730157091e6eff4b593f0a81889) python39Packages.flit: 3.6.0 -> 3.7.1
* [`e3430389`](https://github.com/NixOS/nixpkgs/commit/e34303895eb37abae89ab583908ab47036d19859) python39Packages.flit: switch to pytestCheckHook
* [`2f027dff`](https://github.com/NixOS/nixpkgs/commit/2f027dff0b5fcd646cd8c96bc2f473f0cd8f0993) python: remove ncurses flag
* [`e61ba68a`](https://github.com/NixOS/nixpkgs/commit/e61ba68a0e4695f25415c0a6837740b4667e8a37) gsettings-desktop-schemas: clear out broken dark background URL
* [`ef9896e7`](https://github.com/NixOS/nixpkgs/commit/ef9896e71791d695c98097690a3f1e0ba4c9fdd5) gsettings-desktop-schemas: Improve comments
* [`e9cfdc6b`](https://github.com/NixOS/nixpkgs/commit/e9cfdc6b77fefd77ed04a7eb3e3e0796dfca270c) libunwind: fix for aarch64 and non-4K pages ([nixos/nixpkgs⁠#166006](https://togithub.com/nixos/nixpkgs/issues/166006))
* [`462d460d`](https://github.com/NixOS/nixpkgs/commit/462d460daecac7aa59be779a9e5491157edaee3f) libgcrypt: 1.9.4 -> 1.10.1
* [`c270defa`](https://github.com/NixOS/nixpkgs/commit/c270defab79e46b4c98039b09ab6209d1a69ffb3) python39Packages.pycurl: disable failing tests, add SuperSandro2000 as maintainer
* [`64208378`](https://github.com/NixOS/nixpkgs/commit/64208378a8c3964fb709b3c776124197592de906) python39Packages.packaging: add tests, remove unused six
* [`27d065db`](https://github.com/NixOS/nixpkgs/commit/27d065dbf294e56c0284a6f8333638515c7a178b) python39Packages.kiwisolver: 1.4.0 -> 1.4.2
* [`c46c3a55`](https://github.com/NixOS/nixpkgs/commit/c46c3a55d9a7814467a93f2404e0cc5b2fdf9ca2) sqlite: 3.38.1 -> 3.38.2
* [`70149720`](https://github.com/NixOS/nixpkgs/commit/701497206bd894670a258cb6cf412bf7d32c1b07) python3Packages.kiwisolver: disable on older Python releases
* [`06e3b4f7`](https://github.com/NixOS/nixpkgs/commit/06e3b4f7a0c92457eae07431b2f09964dd872c08) geos39: init at 3.9.2
* [`65e92f70`](https://github.com/NixOS/nixpkgs/commit/65e92f70284f282801beb16bdebd74e4eedadfce) geos: 3.9.1 -> 3.10.2
* [`6a3cd2f6`](https://github.com/NixOS/nixpkgs/commit/6a3cd2f6d718c27aa5dc28917a007633386dd574) geos: add willcohen to maintainers
* [`46aaabd7`](https://github.com/NixOS/nixpkgs/commit/46aaabd7dca78e8726f32c9b6aae903b56d2f292) python310Packages.sphinxext-opengraph: 0.6.2 -> 0.6.3
* [`c8eda85f`](https://github.com/NixOS/nixpkgs/commit/c8eda85fb642d586d43d84f1daf2beb29162eb91) mesa: 21.3.8 -> 22.0.1
* [`3ddd9479`](https://github.com/NixOS/nixpkgs/commit/3ddd9479c9fb102ea36a5b5f8be6153d1c2908ed) mesa: Fix cross-compilation
* [`f5880404`](https://github.com/NixOS/nixpkgs/commit/f588040472b3c0cacd7987aafe2626c7dc65bde4) powerdns: fix 32-bit builds against glibc
* [`6efbd34e`](https://github.com/NixOS/nixpkgs/commit/6efbd34eed5d0d04625a54ea004251ad50fa2792) libepoxy: 1.5.9 -> 1.5.10
* [`cfae6723`](https://github.com/NixOS/nixpkgs/commit/cfae672307ea843fa62de47f891bfba902328a88) SDL2: build kmsdrm video driver on Linux
* [`aeef08c9`](https://github.com/NixOS/nixpkgs/commit/aeef08c9f996b0e50babedd18d2632fb3c603949) joystickwake: autostart
* [`2366f055`](https://github.com/NixOS/nixpkgs/commit/2366f0554e32e4424e45a4bdbd12515b2db13ead) go-containerregistry: 0.6.0 -> 0.8.0
* [`74e85f3b`](https://github.com/NixOS/nixpkgs/commit/74e85f3b68752e3b607f548c34eac7aefc4194ef) infracost: 0.9.20 -> 0.9.21
* [`e9c6db64`](https://github.com/NixOS/nixpkgs/commit/e9c6db642f54427036d878043a39197e5bea3cda) firebird: 3.0.8 -> 3.0.9
* [`fe27fc6b`](https://github.com/NixOS/nixpkgs/commit/fe27fc6ba71d45cb7cb72265b29765f865e9f7b0) python3Packages.social-auth-core: fix eval
* [`49427555`](https://github.com/NixOS/nixpkgs/commit/494275558aca30b0afcc7967d700e658c6b2b10a) libotr: Fix build of tests/regression/client/client.c
* [`fb245f54`](https://github.com/NixOS/nixpkgs/commit/fb245f546a122d65a107f7fdeff9e44501964279) rasdaemon: 0.6.7 -> 0.6.8
* [`075c5eb8`](https://github.com/NixOS/nixpkgs/commit/075c5eb8d39f63a3fd9bcd903d7a19fe22a35224) llvmPackages_14.clang: include clang-tools-extra in src for use
* [`219ca584`](https://github.com/NixOS/nixpkgs/commit/219ca5845235c7481e48096e32b34aac78630d79) gitUpdater: add explicit url parameter to specify a git tree for tags
* [`a106b77b`](https://github.com/NixOS/nixpkgs/commit/a106b77b34b759c5789c1ded077e31dfaf8a2d46) freetype: 2.11.1 -> 2.12.0
* [`fccd8f51`](https://github.com/NixOS/nixpkgs/commit/fccd8f5131e598f88a20d425f679988d7d4dd6f2) azuredatastudio: 1.33.1 -> 1.35.1
* [`5fa538ed`](https://github.com/NixOS/nixpkgs/commit/5fa538ed8815e0c941de7859c0cfc7d9bf8f6e35) bloop: fix hashes for the v1.4.13
* [`1e2a288f`](https://github.com/NixOS/nixpkgs/commit/1e2a288f0e84b7064020554cd89415932b458c1b) stdenv: print the time the phase took if it was longer than 30s
* [`2f1ea003`](https://github.com/NixOS/nixpkgs/commit/2f1ea003ad7890033339de148146746b32c49c4a) re2: 2022-02-01 -> 2022-04-01
* [`1c02d425`](https://github.com/NixOS/nixpkgs/commit/1c02d4252dd7eaa31c4fb15a903916b2dfb0414c) cryptomator: 1.6.7 -> 1.6.8
* [`f9b9a473`](https://github.com/NixOS/nixpkgs/commit/f9b9a473c6120dec27f73c059c753d0b4f8e7270) bloop: add output hash for Darwin (thanks to @⁠kubukoz)
* [`ba46176d`](https://github.com/NixOS/nixpkgs/commit/ba46176d4e10a3786819e4cd580475f592421add) enigma: 1.30-alpha -> 1.30
* [`e839c8e0`](https://github.com/NixOS/nixpkgs/commit/e839c8e0cb4ab2ae08f9719692943ae00669152a) pulseaudio: 14.2 -> 15.0, switch to meson, enable tests
* [`470a4b15`](https://github.com/NixOS/nixpkgs/commit/470a4b15e17bb057117febe3bb48776c861ef1b1) pulseaudio-hsphfpd: drop
* [`0d90bcf1`](https://github.com/NixOS/nixpkgs/commit/0d90bcf1ef13c3cc56998b16585f9fbebb269aff) pulseaudio-modules-bt: drop
* [`a3ce1b0a`](https://github.com/NixOS/nixpkgs/commit/a3ce1b0a9c4a9ce2488f51ab7c4bd591fbff5958) sioyek: init at 1.1.0
* [`4a2a7b74`](https://github.com/NixOS/nixpkgs/commit/4a2a7b74f05ccbc8e003490a776858f1c4c3caf1) Add myself to maintainers list
* [`44f241f6`](https://github.com/NixOS/nixpkgs/commit/44f241f69aab2caff34cedd8d42b9d610bba44eb) nss: split into nss_latest and nss_esr
* [`9109742c`](https://github.com/NixOS/nixpkgs/commit/9109742c6b21b5223540797147d9dfbeb89be16f) nss: add maintainers
* [`f3d301ab`](https://github.com/NixOS/nixpkgs/commit/f3d301ab8196d0f6f290a68f2348201bc7ac0670) thunderbird{-bin}|firefox|librewolf: use nss_latest for regular releases
* [`faee35ce`](https://github.com/NixOS/nixpkgs/commit/faee35ce35eca08e3a18e10d8583fe54de222fea) nss_latest: 3.76 -> 3.76.1
* [`eb9c616c`](https://github.com/NixOS/nixpkgs/commit/eb9c616c79596c9ff43ec9e7ced46c4739a16047) nss_latest: 3.76.1 -> 3.77
* [`8e773802`](https://github.com/NixOS/nixpkgs/commit/8e773802506eb620d90921497d7ce2bcf62ad149) cacert: 3.74 -> 3.77
* [`973e3f8b`](https://github.com/NixOS/nixpkgs/commit/973e3f8b9c29bd661245989f517fd1d74d6af8db) electrum-grs: 4.1.5 -> 4.2.0
* [`6f92fcbc`](https://github.com/NixOS/nixpkgs/commit/6f92fcbcbe6383f6aa354d91cd0cb675eb968555) nss: add esr and latest change release-notes entry
* [`232c7bd1`](https://github.com/NixOS/nixpkgs/commit/232c7bd19551561c4c41a2b5442a94abca63d593) beekeeper-studio: 3.1.0 -> 3.3.8
* [`6b7bd8d0`](https://github.com/NixOS/nixpkgs/commit/6b7bd8d06e627979dbf2c7b199f2e0437349ba4c) powerdns: fix typo
* [`5f5a0687`](https://github.com/NixOS/nixpkgs/commit/5f5a06877ff40bb176e0db2b181084ce7359cbd3) CloudCompare: unstable-2021-10-14 -> 2.12.0, add plugins
* [`d1adf502`](https://github.com/NixOS/nixpkgs/commit/d1adf502779a07dfc602d12e40116249b3dabb00) perl: use pkgs.zlib instead of bundled zlib
* [`3a86b88e`](https://github.com/NixOS/nixpkgs/commit/3a86b88ef1996b6f85d41c02a3b4af5985dc200d) nixos/gitea: Prevent secrets from being exposed at ExecStart time
* [`72f22c9e`](https://github.com/NixOS/nixpkgs/commit/72f22c9e3e9c38b7b219c56d6b3650f2045debb6) go: remove unnecessary `patch` input
* [`3f73270a`](https://github.com/NixOS/nixpkgs/commit/3f73270a62a45376d8f3adb32af69b2116701a77) quick-lint-js: 2.3.0 -> 2.3.1
* [`f9180933`](https://github.com/NixOS/nixpkgs/commit/f9180933cae3dea5546b6954c66da7b77e04ff4c) grpc: override abseil to use same std=c++14 version
* [`39cda6be`](https://github.com/NixOS/nixpkgs/commit/39cda6be9908275bd5daee82818a675547833c3e) jsoncpp: enable static and USING_SECURE_MEMORY
* [`a167391b`](https://github.com/NixOS/nixpkgs/commit/a167391bc80c48f31d17712d0fdbb32f8854f7ca) lightning-loop: 0.17.0-beta -> 0.18.0-beta
* [`cb246b3a`](https://github.com/NixOS/nixpkgs/commit/cb246b3a1df15c4dc0d303b48208450ed65b58b7) ghc_filesystem: 1.5.6 -> 1.5.12
* [`951c0139`](https://github.com/NixOS/nixpkgs/commit/951c01396e976c6374d994d0bf57794246668c9a) asmfmt: 1.2.3 -> 1.3.2
* [`cb79cf47`](https://github.com/NixOS/nixpkgs/commit/cb79cf47f7624a46acbd964c207bdb4375a56bf7) gscan2pdf: 2.12.5 -> 2.12.6
* [`06d1798a`](https://github.com/NixOS/nixpkgs/commit/06d1798a8f7211197d686928ee824e1118d94156) ocenaudio: 3.11.7 -> 3.11.10
* [`e7c301df`](https://github.com/NixOS/nixpkgs/commit/e7c301df52edcf6043ebd56b0da8db94be621d96) nixos/mailman: remove obsolete setting
* [`737cd109`](https://github.com/NixOS/nixpkgs/commit/737cd109e7bf295be12f41dea75708930e36b8ae) otpclient: 2.4.9.1 -> 2.5.1
* [`66a0358a`](https://github.com/NixOS/nixpkgs/commit/66a0358a15337d99e89e31d6c20081b7b74854de) nixos-rebuild: document cross compilation subtlety
* [`c3428419`](https://github.com/NixOS/nixpkgs/commit/c3428419e05c8e3ef2b722b82b2f7065a6d46441) nixos/switch-to-configuration: Provider better error message in cross-compiling situations
* [`7ba18124`](https://github.com/NixOS/nixpkgs/commit/7ba181240d8e394b3504735b615a1cdfe6d4e2e5) debianutils:  4.11.2 -> 5.7
* [`e69fd090`](https://github.com/NixOS/nixpkgs/commit/e69fd09023ba0b4f8961906f7e96a92953af2996) keyutils: inline patch to improve reproducibility
* [`067b774e`](https://github.com/NixOS/nixpkgs/commit/067b774e7c998b93ce678c964a4886c81dad0747) thunderbird-bin: 91.7.0 -> 91.8.0
* [`f091c0e8`](https://github.com/NixOS/nixpkgs/commit/f091c0e80dd2b8b4323fec041068c77b1a5c48f2) zlib: fix cross-compilation not producing shared libraries
* [`e251a4e6`](https://github.com/NixOS/nixpkgs/commit/e251a4e67fe849104c63a94102fdd2772f3ef8a1) protoc-gen-twirp: 8.1.1 -> 8.1.2
* [`a4314873`](https://github.com/NixOS/nixpkgs/commit/a43148735774e2af98ef04520b8dd890b3685ad3) rustracer: 2.1.48 -> 2.2.1
* [`8305aa29`](https://github.com/NixOS/nixpkgs/commit/8305aa29c2a48b80cc6dfaf087bc80cf98ed84d4) binutils: apply debian's patch if isMips64n64
* [`efcf757b`](https://github.com/NixOS/nixpkgs/commit/efcf757b645494653d7fe8bc443111dd98e730fc) matrix-appservice-slack: 1.10.0 -> 1.11.0
* [`4b38deb3`](https://github.com/NixOS/nixpkgs/commit/4b38deb3aa21317a2f9711fd428a76cdbeb0a63c) steampipe: enable tests
* [`a4fbb92b`](https://github.com/NixOS/nixpkgs/commit/a4fbb92be0995a7c20eff607959f0d1971047729) qt515: update KDE patches
* [`dc7f2592`](https://github.com/NixOS/nixpkgs/commit/dc7f25926ecb7ad64ac5539b10137b552329f1b5) qtModule: allow shared patches
* [`40b789cf`](https://github.com/NixOS/nixpkgs/commit/40b789cfbb872d0d4d8994b8f8daeef9064b9049) qtbase: build with libdrm
* [`35e673dd`](https://github.com/NixOS/nixpkgs/commit/35e673dda2df38f8d9977065e4fdf8e532c681aa) qtwayland: include app_id patch in module definition
* [`1d3e73f7`](https://github.com/NixOS/nixpkgs/commit/1d3e73f73a8d02e9bea8746c8872f4f0cc050bcf) gopass: enable tests
* [`79a5b548`](https://github.com/NixOS/nixpkgs/commit/79a5b548cc48770c062a6a60503628017ea0855e) Revert "nss_latest: 3.76.1 -> 3.77"
* [`ffa3fa9d`](https://github.com/NixOS/nixpkgs/commit/ffa3fa9d763c4cd53b742395fd485fb229a79457) vmware-horizon-client: 2111 -> 2203
* [`9b310e61`](https://github.com/NixOS/nixpkgs/commit/9b310e61b4585ff719dbe2c37bc641b65e46a927) gcc10: fix cross-compilation from aarch64-darwin host
* [`08f4d64b`](https://github.com/NixOS/nixpkgs/commit/08f4d64b70951c0a3e6bd490b7a180b8e2d073af) linode-cli: 5.17.2 -> 5.17.2
* [`b68eb22b`](https://github.com/NixOS/nixpkgs/commit/b68eb22b90e3b42f10e93d0289747147ac530bf8) xjadeo: 0.8.10 -> 0.8.11
* [`d36e0267`](https://github.com/NixOS/nixpkgs/commit/d36e02678bbcf55dfe745e19363e3dd494d13408) hydrus: 479 -> 480
* [`5fd49e35`](https://github.com/NixOS/nixpkgs/commit/5fd49e35ccc4061f37ce3c65a7a0312584044768) atlantis: 0.16.1 -> 0.19.2
* [`7d80a830`](https://github.com/NixOS/nixpkgs/commit/7d80a83005c95aff02839dd822b79e72ba7d2673) arkade: 0.8.20 -> 0.8.22
* [`35e363bf`](https://github.com/NixOS/nixpkgs/commit/35e363bf128debbc45e9e6cf91bf847e054ecf01) cloud-sql-proxy: 1.29.0 -> 1.30.0
* [`e4ebc8c2`](https://github.com/NixOS/nixpkgs/commit/e4ebc8c200adacb7cc07fb6efc93aeae7084191a) powerline-go: enable tests
* [`3ed4e07a`](https://github.com/NixOS/nixpkgs/commit/3ed4e07a52697dd12396ee7f8621d9485eef3d32) protobuf2_5: remove
* [`a02786a2`](https://github.com/NixOS/nixpkgs/commit/a02786a2e81127e111f346151d403434d90c8006) ntfy-sh: 1.19.0 -> 1.20.0
* [`7f1bde2c`](https://github.com/NixOS/nixpkgs/commit/7f1bde2ca0ad2563a390bb0d00f14d71b4d175ca) kopia: 0.10.6 -> 0.10.7
* [`141443e0`](https://github.com/NixOS/nixpkgs/commit/141443e02b5c7038a5247563ed08c520e0063299) obfs4: enable tests
* [`b3dfff28`](https://github.com/NixOS/nixpkgs/commit/b3dfff282b114daf304aa4c97a2532cd9b6b8ca3) openstack-image: minor cleanups
* [`e9f01548`](https://github.com/NixOS/nixpkgs/commit/e9f015480c0573736cc87b5a90588a0b92a507d3) openstack-image: make it easy to disable copying the channel to improve iteration time
* [`b8fe7923`](https://github.com/NixOS/nixpkgs/commit/b8fe792394757f415c71c6cf20de10899c2388b1) openstack-image-zfs: init
* [`80b00ef0`](https://github.com/NixOS/nixpkgs/commit/80b00ef02a8efc958e2a16a7264c147e2a8ffbf4) openstack-options: init
* [`e5a7d077`](https://github.com/NixOS/nixpkgs/commit/e5a7d077c1a1d6a91e40634e9fd4841a91b4bb1f) openstack-config: support a ZFS root with /boot perhaps coming from an ESP
* [`14304bfe`](https://github.com/NixOS/nixpkgs/commit/14304bfe40d8fa90f6a371cd6445a3ec7d09e0e9) openstack-config: setup serial access on ttyS0
* [`a8f41adb`](https://github.com/NixOS/nixpkgs/commit/a8f41adbb753f1a94cfd9086f09b177cf11a7a4b) amazon-image: use make-multi-disk-zfs-image
* [`d4c502a9`](https://github.com/NixOS/nixpkgs/commit/d4c502a94a03a66da48870f30588dc7d601c50f8) openstack-metadata-fetcher: don't fail if any specific wget's fail
* [`1c0b76b5`](https://github.com/NixOS/nixpkgs/commit/1c0b76b5c447ff0879ae5e57fa8af0cb5639bdd8) openstack-image-zfs: don't support vpc type, default to qcow2
* [`0a086bf7`](https://github.com/NixOS/nixpkgs/commit/0a086bf7bf88d617f0cb126f8119e9e57b77af45) openstack-config: enable tty1
* [`9e3dab7d`](https://github.com/NixOS/nixpkgs/commit/9e3dab7d2e2f7e08baa65dfec78e27343608bdbd) openstack-image-zfs: build a single-image ZFS root
* [`b4c495ae`](https://github.com/NixOS/nixpkgs/commit/b4c495aeffb610cffd08e0000817f02742365dec) openstack-image-zfs: make the generated configuration.nix valid
* [`8a5bdce5`](https://github.com/NixOS/nixpkgs/commit/8a5bdce5665e24c1656aab2235ac9bd556316adf) make-single-disk-zfs-image: init
* [`d3aff5fa`](https://github.com/NixOS/nixpkgs/commit/d3aff5fa3cb1ecd9d339e3801373ec3cca0057e4) openstack-config: make the expandOnBoot option default to `all`
* [`d99f3013`](https://github.com/NixOS/nixpkgs/commit/d99f30137492749eb011f01b5fcd3c29fd411825) openstack-config: note the image metadata needed to boot a uefi image
* [`555bc533`](https://github.com/NixOS/nixpkgs/commit/555bc5335bf8dcec8e0562ca1bedc96efdc8fc80) openstack-image-zfs: start copying the channel now that we've mostly got the expressions down
* [`acc99abf`](https://github.com/NixOS/nixpkgs/commit/acc99abf6a4a25ec0796cbcb7a9faf487e56cea8) python3Packages.twisted: Patch HTTP request smuggling issue
* [`d2b22578`](https://github.com/NixOS/nixpkgs/commit/d2b225789c9caae1b502478d054e30651532b2e4) gnomeExtensions: refactor update script
* [`ab27371e`](https://github.com/NixOS/nixpkgs/commit/ab27371e2f98ee4681b248d6243b255a4f39347f) impl: 1.0.0 -> 1.1.0
* [`3eb6b5fc`](https://github.com/NixOS/nixpkgs/commit/3eb6b5fc73f8b4db1c2d64fced5ebe4203b129c1) glfw: 3.3.6 -> 3.3.7
* [`c6adc829`](https://github.com/NixOS/nixpkgs/commit/c6adc82943759bbe38759bba3284267045f2bb21) charm: 0.10.3 -> 0.11.0
* [`c4d4de89`](https://github.com/NixOS/nixpkgs/commit/c4d4de89ddac3e11f4c0e4b3c9f6bd074796cbb3) gzip: 1.11 -> 1.12
* [`83f2427b`](https://github.com/NixOS/nixpkgs/commit/83f2427bc17c4aee2953ce634c68b6f212bd5a2a) go_2: remove
* [`6edc4b20`](https://github.com/NixOS/nixpkgs/commit/6edc4b20c75519176892559aaedb61d1d88404a1) hyper: 3.2.0 -> 3.2.1
* [`bb2018c0`](https://github.com/NixOS/nixpkgs/commit/bb2018c026d71d8b026c7f02e57762fe4877068a) python3Packages.jax: 0.3.4 -> 0.3.5
* [`745790d3`](https://github.com/NixOS/nixpkgs/commit/745790d3c1285ab3eb486cb3c66e16c2ebf37c70) python3Packages.pylama: 8.3.7 -> 8.3.8
* [`bcd08bb6`](https://github.com/NixOS/nixpkgs/commit/bcd08bb618dc599f157490db01c3d9caf7984fd3) python3Packages.tzlocal: 4.1 -> 4.2
* [`45bb9217`](https://github.com/NixOS/nixpkgs/commit/45bb9217a5026695f10c35e168dbb1102055dc19) ktlint: 0.45.1 -> 0.45.2
* [`e3d9b211`](https://github.com/NixOS/nixpkgs/commit/e3d9b2115958472d51298d1653f90f993acd3eba) zlib: fix cross-compilation not producing shared libraries
* [`c03c50a1`](https://github.com/NixOS/nixpkgs/commit/c03c50a109d6bf53884a7c88d50785f599ae2518) libavif: 0.9.3 -> 0.10.0
* [`2f84501a`](https://github.com/NixOS/nixpkgs/commit/2f84501ac0717e01569260fb4321376a960de055) libwacom: 2.1.0 -> 2.2.0
* [`771a209a`](https://github.com/NixOS/nixpkgs/commit/771a209a5c37fcceb08b5001381ddf692b45d1ca) zsh-prezto: unstable-2021-11-16 → unstable-2022-04-05
* [`9e63303b`](https://github.com/NixOS/nixpkgs/commit/9e63303ba22697e143835960771e461350499389) symfony-cli: Rename `symfony-cli` in `symfony`.
* [`4cfdd982`](https://github.com/NixOS/nixpkgs/commit/4cfdd9826530bfc380b67cf3409fd9ae91bd3b66) openssh: 8.9p1 -> 9.0p1
* [`5c048110`](https://github.com/NixOS/nixpkgs/commit/5c0481109c0d7fe2a19dfbdb6bd18f94b1c21a35) Update pkgs/applications/misc/sioyek/default.nix
* [`6d49a350`](https://github.com/NixOS/nixpkgs/commit/6d49a35080775c27cd4280ab8363790f9c9cd2bd) rust: 1.59.0 -> 1.60.0
* [`3d883a5d`](https://github.com/NixOS/nixpkgs/commit/3d883a5d9be8dd3b0111d2756746fec7d4bf0066) fixes
* [`703cea5f`](https://github.com/NixOS/nixpkgs/commit/703cea5f4765bca358cb5cbc48fc61e82151ab7d) deno: 1.19.1 -> 1.20.5
* [`4dd78c63`](https://github.com/NixOS/nixpkgs/commit/4dd78c63a17c6fa816eca53222a7d0d25aa1f4b3) starboard: 0.14.1 -> 0.15.3
* [`dbc24add`](https://github.com/NixOS/nixpkgs/commit/dbc24adde7f6631c1f17804cd32487c47075d3ba) claws-mail: add keyword_warner-plugin
* [`61751885`](https://github.com/NixOS/nixpkgs/commit/6175188591f13d8bbcfab928acb5958b0504f59d) nixos/shellhub-agent: reformat code using nixpkgs-fmt
* [`a93c334f`](https://github.com/NixOS/nixpkgs/commit/a93c334ff01a31f4acd267e6a0ddce1144afa829) libsoup_3: 3.0.5 -> 3.0.6
* [`f70bf64e`](https://github.com/NixOS/nixpkgs/commit/f70bf64e75bfb273f7e56d2c0f694d0283006f1c) glog: 0.5.0 -> 0.6.0
* [`588663ae`](https://github.com/NixOS/nixpkgs/commit/588663ae7998ea9c1af83f278142361ddaf8f420) tpm2-tss: 3.0.3 -> 3.2.0
* [`ddcc7c67`](https://github.com/NixOS/nixpkgs/commit/ddcc7c67d280eb0ea76a9079c49c9f70c6cc2e4f) go: Apply package exclusion equally
* [`462b1e44`](https://github.com/NixOS/nixpkgs/commit/462b1e4473d3d322a8ddc3a335ebc8959e645ce8) mongodb: add 4.4
* [`1be42266`](https://github.com/NixOS/nixpkgs/commit/1be4226669a58a64db6118c5d257ceaee02589cd) mongodb: add 5.0
* [`7a246abc`](https://github.com/NixOS/nixpkgs/commit/7a246abcf1181d86c7ca1babf2b9623f351a4eec) mongodb: 4.4.10 -> 4.4.13
* [`dc724666`](https://github.com/NixOS/nixpkgs/commit/dc72466610d35382d15a8595c81be6cd8aedc97f) mongodb: 4.2.17 -> 4.2.19
* [`92402c90`](https://github.com/NixOS/nixpkgs/commit/92402c908ff53ee426f112a5fc13928105668f9d) mongodb: 5.0.5 -> 5.0.7
* [`b71479ac`](https://github.com/NixOS/nixpkgs/commit/b71479ac8d8c154186f675ce363a527c2e1877d0) openai: 0.16.0 -> 0.18.0
* [`d018a536`](https://github.com/NixOS/nixpkgs/commit/d018a53664cb57abf14af63320b2bacf131c2428) trilium: 0.50.2 -> 0.50.3
* [`0fad2b34`](https://github.com/NixOS/nixpkgs/commit/0fad2b34c4e1454ce83ec1486725771273c7c0dc) Patch curl certificate CN verification
* [`0c401715`](https://github.com/NixOS/nixpkgs/commit/0c4017153957120c0953a355ee5eb39d5bf8acec) python3Packages.rns: init at 0.3.4
* [`bed3a732`](https://github.com/NixOS/nixpkgs/commit/bed3a732cb086389793d959633b6df2dbd641abe) python3Packages.lxmf: init at 0.1.4
* [`5d89f265`](https://github.com/NixOS/nixpkgs/commit/5d89f265661a113235d30bd16bb8e87e0126d108) python3Packages.nomadnet: init at 0.1.7
* [`5e334e32`](https://github.com/NixOS/nixpkgs/commit/5e334e3296d9e317c778787cc4ef757cd364455d) cudatext: 1.160.0 -> 1.160.2
* [`cdef7bcb`](https://github.com/NixOS/nixpkgs/commit/cdef7bcb5b5f13fc8d21bb26330631b69b9962bc) nixos/qemu-vm: sanitize generated environment variable name
* [`4c1dfa7b`](https://github.com/NixOS/nixpkgs/commit/4c1dfa7b27b1944607c51b543b43dc36256c9fbb) pypy2Packages.nose, pypy37Packages.nose: fix build by not trying to use 2to3
* [`9de6fad1`](https://github.com/NixOS/nixpkgs/commit/9de6fad194b06f0ab17f975f1be1f97eac90aab4) fheroes2: 0.9.13 -> 0.9.14
* [`ca0a463f`](https://github.com/NixOS/nixpkgs/commit/ca0a463f7414a1b32a4c272d9cf22ab45518dbfc) python3Packages.pysigma: 0.4.5 -> 0.5.0
* [`3760e94f`](https://github.com/NixOS/nixpkgs/commit/3760e94ffa50e5bab21edbb93a384d682101f72e) python3Packages.django-hijack: 2.1.10 -> 3.2.0
* [`33b61afd`](https://github.com/NixOS/nixpkgs/commit/33b61afdd9c092c118b860f8e87dfeb814b05e0d) python39Packages.django-hijack-admin: mark as broken
* [`7a6e4879`](https://github.com/NixOS/nixpkgs/commit/7a6e487964192a1dde99ca51ba7b6f7297ea30d2) telepresence2: 2.4.10 -> 2.5.4
* [`d8b3d0fe`](https://github.com/NixOS/nixpkgs/commit/d8b3d0fe46a2a26f8e8aa246e77326a7836b2b98) python3Packages.apache-beam: 2.36.0 -> 2.37.0
* [`6a548352`](https://github.com/NixOS/nixpkgs/commit/6a54835299e726268805d458fcaf0bebc9754a50) mindustry: Set ALSA_PLUGIN_DIR environment variable
* [`44604a6a`](https://github.com/NixOS/nixpkgs/commit/44604a6a165f661c82f46ede9273ad7d18f7605e) grpc: 1.44.0 -> 1.45.2
* [`dce286b6`](https://github.com/NixOS/nixpkgs/commit/dce286b69a299b718c1f5121d5f35ca2657a5f0a) nix-direnv: 1.6.1 -> 2.0.0
* [`710afcdb`](https://github.com/NixOS/nixpkgs/commit/710afcdb4ff2f06573b450e320f808b5478c5b5d) swayr: 0.16.0 -> 0.16.1
* [`9ec60f81`](https://github.com/NixOS/nixpkgs/commit/9ec60f810df8c4b6e0851e00f4a4d86be3340e69) python3Packages.servefile: init at 0.5.3
* [`a62471fc`](https://github.com/NixOS/nixpkgs/commit/a62471fc65888bb0ba7b6d8b79352a560cb1629f) nixos/shellhub-agent: use mkEnableOption to simplify code
* [`60158bfc`](https://github.com/NixOS/nixpkgs/commit/60158bfc22a50d90919ee647b3a36e4f5f255428) nixos/shellhub-agent: use new configuration variables
* [`67296533`](https://github.com/NixOS/nixpkgs/commit/6729653309e636401ea880acffa17866f18f320d) nixos/shellhub-agent: allow setting the keepAliveInterval
* [`68c4492a`](https://github.com/NixOS/nixpkgs/commit/68c4492a0323fb0867a2f1c70bd4ca583ee6e891) plexamp: 4.1.0 -> 4.2.0
* [`03771f6d`](https://github.com/NixOS/nixpkgs/commit/03771f6d87321907b7c87dd5ecc096c2c09676fc) python310Packages.testing-common-database: patch collections.Callable for python 3.10 support
* [`6951c5b6`](https://github.com/NixOS/nixpkgs/commit/6951c5b6d990fb381fd030864bdd4bef1b8ece6b) python310Packages.asn1crypto: 1.4.0 -> 1.5.1
* [`5382623d`](https://github.com/NixOS/nixpkgs/commit/5382623d7f035fb65e84d4712ab357b18ff00d88) vivaldi-widevine: 4.10.2391.0 -> 4.10.2449.0
* [`c6bd4c4a`](https://github.com/NixOS/nixpkgs/commit/c6bd4c4ad1dc2387841e6a7a51dc333a507fd3d9) wabt: 1.0.27 -> 1.0.28
* [`77b11e49`](https://github.com/NixOS/nixpkgs/commit/77b11e49fe84794c09236af27dbc0c73a4d4c836) python310Packages.tablib: 3.2.0 -> 3.2.1
* [`6ab633a0`](https://github.com/NixOS/nixpkgs/commit/6ab633a0c8f412a7ae2a022d2b05707659592125) gcc: 10 -> 11 on x86-64_darwin
* [`39050c8c`](https://github.com/NixOS/nixpkgs/commit/39050c8c66cd6dac8a39d20ef2bc902f12fef924) wordpress: 5.9.2 -> 5.9.3
* [`a20e363e`](https://github.com/NixOS/nixpkgs/commit/a20e363e6b9b00f2adc170883b7204436b449ddf) glibc: Fix segfault in getpwuid when stat fails ([nixos/nixpkgs⁠#167932](https://togithub.com/nixos/nixpkgs/issues/167932))
* [`1c5ef46b`](https://github.com/NixOS/nixpkgs/commit/1c5ef46be7e24e471f0963822807846e9ef4e0ef) x42-plugins: 20220107 -> 20220327
* [`f1e1a11a`](https://github.com/NixOS/nixpkgs/commit/f1e1a11ae3e28b4da4bd253e8c9d857a01fb987c) pyinfra: 1.7.2 -> 2.0
* [`15d17344`](https://github.com/NixOS/nixpkgs/commit/15d1734496e8216083c80dea813653a717f6f20f) libtiff: add patches for multiple CVEs
* [`836d4062`](https://github.com/NixOS/nixpkgs/commit/836d4062517b8c44e6cd506c52f8f205040dd3e6) perl: use pkgs.zlib instead of bundled zlib
* [`25b43e17`](https://github.com/NixOS/nixpkgs/commit/25b43e170f32c4fbbc45a434f5a677aec3a8d3a8) python39Packages.twisted: don't overwrite patchPhase, ...
* [`2459b662`](https://github.com/NixOS/nixpkgs/commit/2459b6628f9f2f598e3354a173df245d821a26b8) sqlite: 3.38.1 -> 3.38.2
* [`07eeff90`](https://github.com/NixOS/nixpkgs/commit/07eeff90551918756ba75586497e02f9dd50f61f) Merge [nixos/nixpkgs⁠#167852](https://togithub.com/nixos/nixpkgs/issues/167852): openssh: 8.9p1 -> 9.0p1
* [`97431475`](https://github.com/NixOS/nixpkgs/commit/974314755e5afa6a0d38fdbdfe109814e9b521d2) glibc: Fix segfault in getpwuid when stat fails ([nixos/nixpkgs⁠#167932](https://togithub.com/nixos/nixpkgs/issues/167932))
* [`0342af6d`](https://github.com/NixOS/nixpkgs/commit/0342af6d1655bb8cd3fd8438ba2f9e82823230ad) appgate-sdp: 5.5.3 -> 5.5.4
* [`f0c8e6bf`](https://github.com/NixOS/nixpkgs/commit/f0c8e6bf7f2b6856f9a85e85b3f216e2036b3ad7) patch paths
* [`1c828908`](https://github.com/NixOS/nixpkgs/commit/1c828908a57564c3b0fdf680527bddc05a20d5ae) bump version
* [`e420804e`](https://github.com/NixOS/nixpkgs/commit/e420804ed7e2328806a672edfdf44e1d7bb4a240) remove whitespace
* [`5a90f2ab`](https://github.com/NixOS/nixpkgs/commit/5a90f2abf72c72124c0b76bec2ebbd1de654d1c9) linux_zen: 5.17.0-zen1 -> 5.17.2-zen3
* [`5d64003e`](https://github.com/NixOS/nixpkgs/commit/5d64003e017ca3734249e01f422c49e0e18f272c) difftastic: 0.25.0 -> 0.26.0
* [`cc067725`](https://github.com/NixOS/nixpkgs/commit/cc067725453ea09bf6437896513be1692f352b98) gnuradio: 3.10.1.1 -> 3.10.2.0
* [`2b745e7a`](https://github.com/NixOS/nixpkgs/commit/2b745e7ae8f96ecbd6bd8185530a651d4cf003da) gnuradio3_9: 3.9.5.0 -> 3.9.6.0
* [`32f42705`](https://github.com/NixOS/nixpkgs/commit/32f42705ff7070bb32dcc3c4fecddd444a795344) Revert "python39Packages.pycurl: disable failing tests"
* [`a2f91d18`](https://github.com/NixOS/nixpkgs/commit/a2f91d1831e0da7c9e673c960d136fbe1e6297a0) wafHook: export PKGCONFIG if needed
* [`a13f4f6c`](https://github.com/NixOS/nixpkgs/commit/a13f4f6c1cfaa02531abf37f18029ebe0a136e96) jackaudio: remove unneeded PKGCONFIG variable
* [`65940487`](https://github.com/NixOS/nixpkgs/commit/65940487937d053d303b2127d755f7c071b4b622) lv2: support cross-compilation
* [`70e88b8c`](https://github.com/NixOS/nixpkgs/commit/70e88b8cb2973db94980783f3c95cc713568a1ba) sratom: support cross-compilation
* [`76015b85`](https://github.com/NixOS/nixpkgs/commit/76015b8597fb1b52b49e37ca600a0a8f51b6aa20) lilv: support cross-compilation
* [`f1521ea5`](https://github.com/NixOS/nixpkgs/commit/f1521ea573e6a52f6d360b01e446428b957839f5) flycast: 1.2 -> 1.3
* [`8c4bc7f6`](https://github.com/NixOS/nixpkgs/commit/8c4bc7f62c912d7828568492b8715a3006133907) nixos/shellhub-agent: allow setting the preferredHostname
* [`bd3b046a`](https://github.com/NixOS/nixpkgs/commit/bd3b046ac85758208b362e0b4234fb0466cd5cbd) nixos/shellhub-agent: use mkPackageOption to simplify code
* [`d7a0f56c`](https://github.com/NixOS/nixpkgs/commit/d7a0f56c6a2a19c9e6a61716ce5315412b61c2f6) nixos/shellhub-agent: avoid code duplication for environment
* [`fcb69a85`](https://github.com/NixOS/nixpkgs/commit/fcb69a858359f7b7fe453c06697f6e4200a4d2d4) nixos/shellhub-agent: use package internally, avoiding it in PATH
* [`83c9b748`](https://github.com/NixOS/nixpkgs/commit/83c9b7483430d7e361d0c7676a8cc31008f400c3) nifi: init at 1.16.0
* [`d706301b`](https://github.com/NixOS/nixpkgs/commit/d706301b0cb45bb7451a3bfb685b3bf2795baa8f) nixos/nifi: init service
* [`07962ac6`](https://github.com/NixOS/nixpkgs/commit/07962ac6f132a12e133c1a057ddb2507d96386d2) nixos/nifi: add release notes
* [`63ef6aeb`](https://github.com/NixOS/nixpkgs/commit/63ef6aebef14c23276532a3abdff01fc14b618ee) nixos/tests: add nifi test
* [`12f66be9`](https://github.com/NixOS/nixpkgs/commit/12f66be9deb220ea6439aa41605ddfee91a0e4dc) libsForQt5.qca-qt5: 2.3.1 -> 2.3.4
* [`2eb82298`](https://github.com/NixOS/nixpkgs/commit/2eb82298de3bfb1052106b482904743e5e474c4e) argocd-autopilot: 0.3.1 -> 0.3.2
* [`7abd2214`](https://github.com/NixOS/nixpkgs/commit/7abd221433749f27b67a9ed31c4d92521c8c86cb) fio: 3.29 -> 3.30
* [`a4dbe5c1`](https://github.com/NixOS/nixpkgs/commit/a4dbe5c10c38173612985c9ca98c9a04d22a0401) lvm2: fix blkdeactive
* [`f44598b8`](https://github.com/NixOS/nixpkgs/commit/f44598b8e0b5970239e791e3f3f1c93722f57986) Revert "python39Packages.pycurl: disable failing tests"
* [`f1f1c062`](https://github.com/NixOS/nixpkgs/commit/f1f1c062e7448049004342266a709e983977b72f) feroxbuster: 2.6.2 -> 2.6.4
* [`9cd12eec`](https://github.com/NixOS/nixpkgs/commit/9cd12eecb5087e058c6509642525dae9968a16bb) python3Packages.pytibber: 0.22.1 -> 0.22.3
* [`e0617066`](https://github.com/NixOS/nixpkgs/commit/e0617066bc4d85a326f3c46a2ae9d11f205a0d7a) werf: 1.2.78 -> 1.2.87
* [`0c0e9ceb`](https://github.com/NixOS/nixpkgs/commit/0c0e9ceb8ac8faefe1d4dfdad23abc6dec541719) Add sir4ur0n to maintainers
* [`c5b017c5`](https://github.com/NixOS/nixpkgs/commit/c5b017c5d40589f1fbc87fcaaed5960a45f2ff78) f1viewer: 2.6.2 -> 2.7.0
* [`8603836e`](https://github.com/NixOS/nixpkgs/commit/8603836e479be00f6a4d6e0c42d7c529ca747a74) hugo: 0.92.2 -> 0.96.0
* [`92559b73`](https://github.com/NixOS/nixpkgs/commit/92559b7330a56778dde383225bae47e225de4861) chromium: get-commit-message.py: Support releases with 1 security fix
* [`dbf02e3a`](https://github.com/NixOS/nixpkgs/commit/dbf02e3a52d3e37759328e2c90b38ee8ba95b2f2) chromiumDev: 102.0.4972.0 -> 102.0.4987.0
* [`52458a29`](https://github.com/NixOS/nixpkgs/commit/52458a29bd1be652f72c7980b6d33f2b15f09099) gfortran: default to same gcc version as stdenv
* [`8a17c5db`](https://github.com/NixOS/nixpkgs/commit/8a17c5dba612fdc4d5445d83156e3975ec57ca93) gnomeExtensions.arcmenu: 27 -> 30
* [`28e936ba`](https://github.com/NixOS/nixpkgs/commit/28e936ba64c015caa1ce1be21ea7c790898ce336) nixos/xserver: add excludePackages option
* [`05d01163`](https://github.com/NixOS/nixpkgs/commit/05d0116368067c29b1866606618839591a182d02) acr: init at 2.0.0
* [`5980cad6`](https://github.com/NixOS/nixpkgs/commit/5980cad677a8d86220f70057a4f2a5b3fe056993) python310Packages.sumo: 2.2.5 -> 2.3.0
* [`60dc89be`](https://github.com/NixOS/nixpkgs/commit/60dc89be41bce80a086872492510a2312f920657) alejandra: 1.1.0 -> 1.2.0
* [`a7fc2f63`](https://github.com/NixOS/nixpkgs/commit/a7fc2f6392be849f811c0a3f29f559311dc695df) autoPatchelfHook: more precise dependency ignorance
* [`3d558785`](https://github.com/NixOS/nixpkgs/commit/3d558785a1c5a173b5d23e606ed998610582ef7e) openvino: autoPatchelfIgnoreMissingDeps is now a list
* [`3a84954a`](https://github.com/NixOS/nixpkgs/commit/3a84954a8983e6bb23d9ce2710df3fe393dd89d7) alttpr-opentracker: autoPatchelfIgnoreMissingDeps is now a list
* [`a2c44cba`](https://github.com/NixOS/nixpkgs/commit/a2c44cba88f13909fdf39c5678bd96962144d705) discordchatexporter-cli: 2.33.2 -> 2.34
* [`4093d69e`](https://github.com/NixOS/nixpkgs/commit/4093d69e477c08788e9f09c7368650ec9da1d6a8) dsq: 0.12.0 -> 0.13.0
* [`8f07a30e`](https://github.com/NixOS/nixpkgs/commit/8f07a30e7df58088f6b7837904ad97a47952bcbe) astc-encoder: 3.5 -> 3.6
* [`e2e68e29`](https://github.com/NixOS/nixpkgs/commit/e2e68e29f9647a19a0c62809f1bc259f1a6d0ddf) libsForQt5.bismuth: 3.0.0 -> 3.1.0
* [`5d5700b9`](https://github.com/NixOS/nixpkgs/commit/5d5700b985af93dc05550827fe3d96712914d2cc) azure-storage-azcopy: 10.14.0 -> 10.14.1
* [`d4071bd1`](https://github.com/NixOS/nixpkgs/commit/d4071bd1fcd27d62f7cd1eafe026511008aebc0c) python310Packages.env-canada: 0.5.22 -> 0.5.23
* [`cc90d526`](https://github.com/NixOS/nixpkgs/commit/cc90d526933904f7fe8e39236a98b31154dcc581) terraform-providers: update 2022-04-11
* [`aa58c159`](https://github.com/NixOS/nixpkgs/commit/aa58c15998c62722e8a77b5f1eaa47af76f38d5f) checkip: 0.19.0 -> 0.24.5
* [`79de6016`](https://github.com/NixOS/nixpkgs/commit/79de601673f4bdc04c370033e2c693987088d1f9) checkstyle: 10.0 -> 10.1
* [`0caca7c4`](https://github.com/NixOS/nixpkgs/commit/0caca7c40f4c44f065d7bd4156d0ada550ce77e0) chezmoi: 2.15.0 -> 2.15.1
* [`4ac8a78c`](https://github.com/NixOS/nixpkgs/commit/4ac8a78cbb9a03caba9675ad474cd55e6eba2168) netcdf: disable tests on aarch64-darwin
* [`e321a614`](https://github.com/NixOS/nixpkgs/commit/e321a614e2707dbec7fa7d876d9d869d426a45ef) bullet: 3.22a -> 3.22b
* [`8505845d`](https://github.com/NixOS/nixpkgs/commit/8505845d24e6976a0f653c1ae490c21f6653845b) cmctl: 1.7.2 -> 1.8.0
* [`fa4f79ef`](https://github.com/NixOS/nixpkgs/commit/fa4f79ef636870ef01b1d12ee0645ab9d1b99413) abcmidi: 2022.02.21 -> 2022.03.20
* [`6bfb28f9`](https://github.com/NixOS/nixpkgs/commit/6bfb28f90db9e022491f05fc9f6c6457d5468b38) unixODBCDrivers.redshift: init at 1.4.49.1000
* [`b0f5cd41`](https://github.com/NixOS/nixpkgs/commit/b0f5cd418c74471d80f03da1de5dd5e5b749a82a) datadog-agent: 7.34.0 -> 7.35.0
* [`e37855ba`](https://github.com/NixOS/nixpkgs/commit/e37855ba15f544eded14129d1759f789c69069ed) dnsproxy: 0.42.0 -> 0.42.1
* [`17867e6f`](https://github.com/NixOS/nixpkgs/commit/17867e6fbccdfc8f8200490785e0151da61067b9) lapce: 0.0.10 -> 0.0.12
* [`e5ca3bbc`](https://github.com/NixOS/nixpkgs/commit/e5ca3bbc0a2116528f2a58c2bffb8bbb151aa1cf) unigine-tropics: init at 1.3
* [`a59b03b3`](https://github.com/NixOS/nixpkgs/commit/a59b03b38a8139dbc70ddf4198e018253ca0ecf9) ejson2env: 2.0.2 -> 2.0.4
* [`adc727d6`](https://github.com/NixOS/nixpkgs/commit/adc727d6f8367a1e84326007d2ef1a724575252e) python310Packages.editables: 0.2 -> 0.3
* [`68a880ec`](https://github.com/NixOS/nixpkgs/commit/68a880ecb172c3f94acdc344da2124ca5e44eea0) difftastic: 0.26.0 -> 0.26.3
* [`af0e1375`](https://github.com/NixOS/nixpkgs/commit/af0e1375e412cd1dd063443ddf99ade6a661fe62) faustPhysicalModeling: 2.37.3 -> 2.40.0
* [`7fbeeb53`](https://github.com/NixOS/nixpkgs/commit/7fbeeb5382b061cc384b0ba763fdf8926ea8ee00) fennel: 1.0.0 -> 1.1.0
* [`7f67b9d3`](https://github.com/NixOS/nixpkgs/commit/7f67b9d301d443383f961e4597eec41a3e32850a) fits-cloudctl: 0.10.12 -> 0.10.13
* [`a82378a7`](https://github.com/NixOS/nixpkgs/commit/a82378a76a28e0da67572cda4dc1f04eed0af9d9) pcmsolver: fix glibc >= 2.34 compatibility
* [`2c1e6217`](https://github.com/NixOS/nixpkgs/commit/2c1e621741d74d88b8983cfb186713f6b5925c43) pcmsolver: replace python2 by python3 as build dependency
* [`91d2fd21`](https://github.com/NixOS/nixpkgs/commit/91d2fd21bdfe747e7c4112921efb571c75b70159) flow: 0.174.1 -> 0.175.1
* [`0fc32505`](https://github.com/NixOS/nixpkgs/commit/0fc325059423e2e38fda7373ea3448a30fca1484) wezterm: 20220319-142410-0fcdea07 -> 20220408-101518-b908e2dd
* [`d49d06ee`](https://github.com/NixOS/nixpkgs/commit/d49d06eecd9472b6835100a3e5bf54e173808fc0) flyctl: 0.0.314 -> 0.0.316
* [`2055f853`](https://github.com/NixOS/nixpkgs/commit/2055f85304933814a367e816d010d769d6c4cb16) wolfram-engine: init at 13.0.1
* [`55a070a6`](https://github.com/NixOS/nixpkgs/commit/55a070a61664412398e561d2fdac7ace618c44d6) wolfram-for-jupyter-kernel: init at 0.9.2
* [`3cc26915`](https://github.com/NixOS/nixpkgs/commit/3cc26915217f1bdf93bb883f504c05f72b182e4a) python310Packages.sphinxcontrib-bibtex: 2.4.1 -> 2.4.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
