### PR TITLE
niv emacs-overlay: update 8b7323d0 -> 13b55e21

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8b7323d06cc5310f75781ae87dd50840c3b2bfc7",
-        "sha256": "07fxxjskn8ga16kvrnnzawn95ll1m6hgqcpjkxw70nf9q9k87j0g",
+        "rev": "13b55e2157a30257d77d7c4bebbeb318a51dbcb4",
+        "sha256": "1qvjm3yxrak3gx40xm8bvqx4qlppskbhq1y1cjbi1qgzhhib3pkg",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/8b7323d06cc5310f75781ae87dd50840c3b2bfc7.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/13b55e2157a30257d77d7c4bebbeb318a51dbcb4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@8b7323d0...13b55e21](https://github.com/nix-community/emacs-overlay/compare/8b7323d06cc5310f75781ae87dd50840c3b2bfc7...13b55e2157a30257d77d7c4bebbeb318a51dbcb4)

* [`02106c31`](https://github.com/nix-community/emacs-overlay/commit/02106c310ea3454ba77095824cefa993fffa226b) Updated repos/emacs
* [`443a8d48`](https://github.com/nix-community/emacs-overlay/commit/443a8d4881752222d9e1eed515e5f259c6785b6e) Updated repos/melpa
* [`0232272d`](https://github.com/nix-community/emacs-overlay/commit/0232272d4a797fa6b9da942e2a19ed4096950fbd) Use git ls-remote to fetch latest tag
* [`6a263ef2`](https://github.com/nix-community/emacs-overlay/commit/6a263ef2a4acf158f954fc6792ccd18a30062214) Updated repos/emacs
* [`77e2d63a`](https://github.com/nix-community/emacs-overlay/commit/77e2d63a3f5f3a80c40a1d50dedf15c49ccb5fd1) Updated repos/melpa
* [`7884c0a4`](https://github.com/nix-community/emacs-overlay/commit/7884c0a487aab55e53aa4d47ce461bdc94000bcd) Updated repos/emacs
* [`3f368b1b`](https://github.com/nix-community/emacs-overlay/commit/3f368b1be2df5a23a6d944eced1e9612a903feb6) Updated repos/melpa
* [`ff5bdf55`](https://github.com/nix-community/emacs-overlay/commit/ff5bdf55750af896fba04b2b616ef309e44a37d9) Updated repos/emacs
* [`0d179171`](https://github.com/nix-community/emacs-overlay/commit/0d17917116ecef54563eefd12ab8390f24f12d0b) Updated repos/melpa
* [`94df7ad9`](https://github.com/nix-community/emacs-overlay/commit/94df7ad97b2920fcf52d361c8d8e8a1ce5697c81) Updated repos/emacs
* [`46353b3b`](https://github.com/nix-community/emacs-overlay/commit/46353b3bce539bd99eace5584f804320661ec18a) Updated repos/melpa
* [`de8198cd`](https://github.com/nix-community/emacs-overlay/commit/de8198cdb13214ac10e23d31b6bba5421140c8c4) Updated repos/emacs
* [`b06b7dd8`](https://github.com/nix-community/emacs-overlay/commit/b06b7dd842c2c44f8ab3e2a11ebb4ba4a29b93af) Updated repos/melpa
* [`542b9d16`](https://github.com/nix-community/emacs-overlay/commit/542b9d16c8cff71feca5992b4248b09122a89705) Updated repos/emacs
* [`4ddde194`](https://github.com/nix-community/emacs-overlay/commit/4ddde1946df8fd8d209004104eaf459d22f48906) Updated repos/melpa
* [`9b4d6095`](https://github.com/nix-community/emacs-overlay/commit/9b4d609546ee1ad4454f6839afbe190851d1a8f0) Updated repos/emacs
* [`ef13cc8f`](https://github.com/nix-community/emacs-overlay/commit/ef13cc8f02b692832530a3263dd3e9f97d26bebc) Updated repos/melpa
* [`ce5ae7e9`](https://github.com/nix-community/emacs-overlay/commit/ce5ae7e90a5e1dcdabddada5ad0881c9e17c7abe) Updated repos/nongnu
* [`f7218ca3`](https://github.com/nix-community/emacs-overlay/commit/f7218ca3078d089a25a102e40d6e0396ef65d2a0) Updated repos/elpa
* [`869beeb4`](https://github.com/nix-community/emacs-overlay/commit/869beeb448be44361c6d0325b288577e83baa228) Updated repos/emacs
* [`82f83fbd`](https://github.com/nix-community/emacs-overlay/commit/82f83fbd561c08e83faeb4a8c37fb43375d88bd1) Updated repos/melpa
* [`60831444`](https://github.com/nix-community/emacs-overlay/commit/60831444806bef651df193378d7dee8c3309aba7) Updated repos/emacs
* [`9075f801`](https://github.com/nix-community/emacs-overlay/commit/9075f801399bb79217a1f999cb3bf7807c8693b1) Updated repos/melpa
* [`a71784ba`](https://github.com/nix-community/emacs-overlay/commit/a71784bab52f5cd7875140284d469ba8dd938b7c) Updated repos/nongnu
* [`ed18213d`](https://github.com/nix-community/emacs-overlay/commit/ed18213dc094fc3094a9a4b51cca9aaa6b74984c) Updated repos/emacs
* [`27fea646`](https://github.com/nix-community/emacs-overlay/commit/27fea646189ff7572453e1e3a4d1eb9dc5887fb2) Updated repos/melpa
* [`8f24bb97`](https://github.com/nix-community/emacs-overlay/commit/8f24bb97c711fae1b87a202d8c3a70eb40da695e) Updated repos/elpa
* [`507169e0`](https://github.com/nix-community/emacs-overlay/commit/507169e07c3fb4fe032245b4f5b675669b892d07) Updated repos/emacs
* [`d0ef2cfa`](https://github.com/nix-community/emacs-overlay/commit/d0ef2cfa729bab6adacf6461d48a4fb83618c047) Updated repos/melpa
* [`83f5be45`](https://github.com/nix-community/emacs-overlay/commit/83f5be45ef8cc82f02a6d9c9719a2d45e4bda369) Updated repos/elpa
* [`3164129e`](https://github.com/nix-community/emacs-overlay/commit/3164129ed1dfd2fb2ed0c3aa27d508c2e2345d16) Updated repos/emacs
* [`a549ba59`](https://github.com/nix-community/emacs-overlay/commit/a549ba5970311b2de5159bf02f5731a94e6a99d1) Updated repos/melpa
* [`1e654497`](https://github.com/nix-community/emacs-overlay/commit/1e654497fb3e456722d44d209f01e46f9fa5ba18) Change the emacsGcc attribute to emacsNativeComp
* [`bb74d81e`](https://github.com/nix-community/emacs-overlay/commit/bb74d81e6c6e771181b1c85c4adf3fd4118f5afb) Updated repos/emacs
* [`f828e580`](https://github.com/nix-community/emacs-overlay/commit/f828e58050bc3436910c59fb0c0bd5ae20aa48ab) Updated repos/melpa
* [`ba54077d`](https://github.com/nix-community/emacs-overlay/commit/ba54077d5eb8fedfede088ce174a6a0aa5e4dc8b) Updated repos/nongnu
* [`d6dc6eb0`](https://github.com/nix-community/emacs-overlay/commit/d6dc6eb0a2d4cc0cf56f16d190114d015617275b) Updated repos/elpa
* [`20f0569e`](https://github.com/nix-community/emacs-overlay/commit/20f0569e6182475720ef1e01afa62d4c5e6f4d23) Updated repos/emacs
* [`f27a737e`](https://github.com/nix-community/emacs-overlay/commit/f27a737e25c1a37aaa23d2c884c36889896152f3) Updated repos/melpa
* [`4c2cf766`](https://github.com/nix-community/emacs-overlay/commit/4c2cf766910caf44b0c155a50779a66e217eabc7) Updated repos/emacs
* [`3c9addc7`](https://github.com/nix-community/emacs-overlay/commit/3c9addc7c6e5b065058a968f7a699f1ec5133824) Updated repos/melpa
* [`33c6ccbf`](https://github.com/nix-community/emacs-overlay/commit/33c6ccbfdc466ab3137f5e071cdc4478aab2549a) Updated repos/nongnu
* [`0279a5f6`](https://github.com/nix-community/emacs-overlay/commit/0279a5f6a8562b33a2f467ed00b4a321cc1e21b0) Updated repos/emacs
* [`5a666774`](https://github.com/nix-community/emacs-overlay/commit/5a666774b4050d73e9f3c14e8f9eb868f7f7d5a5) Updated repos/melpa
* [`7d6da471`](https://github.com/nix-community/emacs-overlay/commit/7d6da471364bab045f561d891fe97706ae308c47) Updated repos/nongnu
* [`5881b39f`](https://github.com/nix-community/emacs-overlay/commit/5881b39fd6ca1c23f6a36b271b322b6276d0c052) Updated repos/elpa
* [`b6921e72`](https://github.com/nix-community/emacs-overlay/commit/b6921e72b309a542066c89b6f7046719f481f85a) Updated repos/emacs
* [`759b1eb1`](https://github.com/nix-community/emacs-overlay/commit/759b1eb18a5b4afd9b286305032ba73b5bbc8103) Updated repos/melpa
* [`7f2930e4`](https://github.com/nix-community/emacs-overlay/commit/7f2930e4cbdea70e5c62f76911f781ea6c3d9115) Updated repos/melpa
* [`1d1478b3`](https://github.com/nix-community/emacs-overlay/commit/1d1478b3b1f1ac68924705a77bcdc655925cf408) Updated repos/melpa
* [`2bbbf439`](https://github.com/nix-community/emacs-overlay/commit/2bbbf439199d5a3f5aa24bd77ea0c85f3bcc771f) Updated repos/melpa
* [`aad2db28`](https://github.com/nix-community/emacs-overlay/commit/aad2db283f7e56ab29f9025bd57d7c89cd9cd31a) Updated repos/elpa
* [`13b55e21`](https://github.com/nix-community/emacs-overlay/commit/13b55e2157a30257d77d7c4bebbeb318a51dbcb4) Updated repos/melpa
