### PR TITLE
niv nixpkgs: update 72757a3b -> 55016232

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "72757a3b302fae930da3378d43fee5eb48528ca9",
-        "sha256": "0zyl4jligpafs30awi6mwkrv2ivcrncwqkmfsabkwm6n5df5snr6",
+        "rev": "550162327f99a99e928739ca4d61a741b17653a2",
+        "sha256": "09lqkp0qhs6acvbhpika7w9ryv8agvp8mdnq8pyqmhwhmnx61yg6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/72757a3b302fae930da3378d43fee5eb48528ca9.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/550162327f99a99e928739ca4d61a741b17653a2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@72757a3b...55016232](https://github.com/nixos/nixpkgs/compare/72757a3b302fae930da3378d43fee5eb48528ca9...550162327f99a99e928739ca4d61a741b17653a2)

* [`57e5fe76`](https://github.com/NixOS/nixpkgs/commit/57e5fe76081be0904a5b62bddaecadb3a911124a) docs: modules/prometheus: finish exporter setup
* [`32f41fbe`](https://github.com/NixOS/nixpkgs/commit/32f41fbef26aa7be03c89d3eab31a45d8b21acc1) nvidia_x11_vulkan_beta: 455.46.04 -> 470.62.13
* [`e357ea6b`](https://github.com/NixOS/nixpkgs/commit/e357ea6b01b509a48f1e67643ff74c1d8d4e8a08) wpa_supplicant: fix withDbus=false build
* [`ae4dae29`](https://github.com/NixOS/nixpkgs/commit/ae4dae2909aad127686306ce140f6551db6cf9c3) libraw: 0.20.2 -> unstable-2021-12-03
* [`2bc097e4`](https://github.com/NixOS/nixpkgs/commit/2bc097e409da9e62d3c3f9e3bd3b938c303fa867) freeimage: unstable-2020-07-04 -> unstable-2021-11-01
* [`686e1352`](https://github.com/NixOS/nixpkgs/commit/686e1352f725d3bd7808cd66f2d8923db17ac9c0) libraw_0_20: init at 0.20.2
* [`0d579123`](https://github.com/NixOS/nixpkgs/commit/0d5791236431766fa70ceca0e1df17ac8087ed13) wvkbd: init at 0.7
* [`57a136f6`](https://github.com/NixOS/nixpkgs/commit/57a136f61db6cb15e1ce39fe77b599df26453ab7) sasutils: init at 0.3.12
* [`6fced8a9`](https://github.com/NixOS/nixpkgs/commit/6fced8a9239a39d7e631b94fe6ecb1232d15be1e) synth: 0.6.4 -> 0.6.5-r1
* [`bd3968f0`](https://github.com/NixOS/nixpkgs/commit/bd3968f0e0ea7766403c740654074578714053e7) mautrix-signal: 0.2.2 -> 0.2.3
* [`9bba5944`](https://github.com/NixOS/nixpkgs/commit/9bba594437ff872a8be05379106c656a5e7ebbcb) Dart: Add support for aarch64-darwin
* [`6cf706b5`](https://github.com/NixOS/nixpkgs/commit/6cf706b5bd507b00e7513717bd9abf5722bdac19) erlang-ls: 0.23.1 -> 0.24.0
* [`c4cfcc55`](https://github.com/NixOS/nixpkgs/commit/c4cfcc559fc8dd65ba838aa49524ae9f46ac0fc8) wireless-regdb: 2021.08.28 -> 2022.02.18
* [`7988f94c`](https://github.com/NixOS/nixpkgs/commit/7988f94cd32d2ed7aceccfa24849a963768e9daf) mpv-scripts: init autocrop, autodeint
* [`8bbfaea1`](https://github.com/NixOS/nixpkgs/commit/8bbfaea1c130f5c5b96b94e8e7266a31aed3f7c3) ocamlPackages.ctypes: 0.18.0 -> 0.20.0
* [`7d7f18b0`](https://github.com/NixOS/nixpkgs/commit/7d7f18b0a08eec84d452a86a2a0eda6fc068e5d5) faudio: 21.10 -> 22.02
* [`06ffff70`](https://github.com/NixOS/nixpkgs/commit/06ffff70bbd852e4476d01f0c59b199ce445c2c2) gerbera: 1.9.2 -> 1.10.0
* [`9013352e`](https://github.com/NixOS/nixpkgs/commit/9013352e3f1941f6ee4430baaa69b0b0927adb15) nixos/taskserver: port helper-tool to Python 3
* [`0091e319`](https://github.com/NixOS/nixpkgs/commit/0091e3198a81cfc5cd867f676f3711a63979b938) nixos/taskserver: do not open firewall port implicitly
* [`a9d32d78`](https://github.com/NixOS/nixpkgs/commit/a9d32d78895273c80a04e3219a7b82f95f1a8501) roundcubePlugins.persistent_login: 5.2.0 -> 5.3.0
* [`54f2cde9`](https://github.com/NixOS/nixpkgs/commit/54f2cde947c5c9262979646d6fa3b69ed6152d98) pipewire-media-session: changed options to take defaults from JSON
* [`9f30caf8`](https://github.com/NixOS/nixpkgs/commit/9f30caf8b9ad6b91a71b6f49bd753cffeb506c1c) helio-workstation: 3.8 -> 3.9
* [`b4979639`](https://github.com/NixOS/nixpkgs/commit/b4979639740b721c0b2dae5c189b874fddb0cbe6) unciv: 3.19.12 -> 3.19.14
* [`33a51ae8`](https://github.com/NixOS/nixpkgs/commit/33a51ae8b0e27b38c340e5d4db0b053973c99c69) copyq: 6.0.1 -> 6.1.0
* [`af092267`](https://github.com/NixOS/nixpkgs/commit/af092267a80cab87c7b8e59c8f98ea7efaca4148) jitsi-meet: 1.0.5818 -> 1.0.5913
* [`1b9add6f`](https://github.com/NixOS/nixpkgs/commit/1b9add6f695cfcbeb3b25d0a5d962a0ea003bacf) maigret: 0.4.1 -> 0.4.2
* [`999a964d`](https://github.com/NixOS/nixpkgs/commit/999a964d09fb888c7aac32fdd23900e33003c228) bakelite: unstable-2021-10-19 -> unstable-2022-02-12
* [`b237d327`](https://github.com/NixOS/nixpkgs/commit/b237d3275da4f2809ef1827e9d935fd12ae88c56) bakelite: extend platforms
* [`00e8ecb9`](https://github.com/NixOS/nixpkgs/commit/00e8ecb90b00b2b762aed7982022a5cc321ddd67) bzflag: 2.4.22 -> 2.4.24
* [`e55eb3d3`](https://github.com/NixOS/nixpkgs/commit/e55eb3d376c05d2bc902506aa0c42c8eb8c06bcb) mas: 1.8.2 -> 1.8.6
* [`75669c90`](https://github.com/NixOS/nixpkgs/commit/75669c90abd1713a1e570d2774b116e4c072b4a5) gimpPlugins.bimp: init at 2.6
* [`80f0cf33`](https://github.com/NixOS/nixpkgs/commit/80f0cf33d8a922b021e366015e09f00d31c4b339) signify: 30 -> 31
* [`142dab5c`](https://github.com/NixOS/nixpkgs/commit/142dab5c73090f9445458b75e64ce4183554b53e) scryer-prolog: v0.8.127 -> v0.9.0
* [`75648090`](https://github.com/NixOS/nixpkgs/commit/7564809000aea811d68e8197e4304c7bb4e73f59) libinput-gestures: 2.39 -> 2.72
* [`54bf7c3c`](https://github.com/NixOS/nixpkgs/commit/54bf7c3c5b2f6c466e7e7c93d0b19babab19085c) bluejeans-gui: 2.26.0.136 -> 2.27.0.130
* [`1d79ffcb`](https://github.com/NixOS/nixpkgs/commit/1d79ffcb6814bc93bc790517187ccfdab43eaa21) tests/peertube: update redis usage
* [`6af7f6eb`](https://github.com/NixOS/nixpkgs/commit/6af7f6eb783ddf103561aa4c4e2e68abe01336ab) tests/step-ca: give name, fix acme usage
* [`ff15d086`](https://github.com/NixOS/nixpkgs/commit/ff15d08681f22613392f7d9cba700c2fa6eb5641) fluidd: 1.17.1 -> 1.17.2
* [`51f78ade`](https://github.com/NixOS/nixpkgs/commit/51f78ade780e2cd94d3fa2fb855aa02742bc7664) nixos/jira: set home for jira user
* [`d3aa7c14`](https://github.com/NixOS/nixpkgs/commit/d3aa7c14039471d52b2d36266008502d78c0e179) python310Packages.flask-talisman: 0.8.1 -> 1.0.0
* [`e3ccf7d4`](https://github.com/NixOS/nixpkgs/commit/e3ccf7d41b717d3439eb25cf1bc096645dd6e013) libxcrypt: 4.4.18 -> 4.4.28
* [`a8d7ac1b`](https://github.com/NixOS/nixpkgs/commit/a8d7ac1b11b095563018c2855cc4289f763beb34) make-darwin-bundle: Use actual bin output
* [`4c14b9a7`](https://github.com/NixOS/nixpkgs/commit/4c14b9a77817527e5c2a8b1d0d3f56ffd3dec08f) make-darwin-bundle: Escape outputBin for Nix '' string
* [`783eaf99`](https://github.com/NixOS/nixpkgs/commit/783eaf99809201a1e9cd70a4cfd89568b1830d42) make-darwin-bundle: Prefer long lines to splitting
* [`e7e3e939`](https://github.com/NixOS/nixpkgs/commit/e7e3e939a8e9d71e9ec32bc7f3165a311c0a3821) pjsip: add patch for CVE-2022-24764
* [`8fd85d69`](https://github.com/NixOS/nixpkgs/commit/8fd85d69403565ed6bc23ca0290918821e205f19) verilator: 4.218 -> 4.220
* [`cc02c4aa`](https://github.com/NixOS/nixpkgs/commit/cc02c4aabfcee2b4e73c2ed32375de4305c87afb) minizinc: 2.6.1 -> 2.6.2
* [`13b5309a`](https://github.com/NixOS/nixpkgs/commit/13b5309a020fe66a62d8c06823611fc176a5bc42) highlight: 4.1 -> 4.2
* [`903c9c09`](https://github.com/NixOS/nixpkgs/commit/903c9c09328a1bc654523280c4f7304fd3d1848c) mob: 2.6.0 -> 3.0.0
* [`3a9fb1ab`](https://github.com/NixOS/nixpkgs/commit/3a9fb1ab8db27ae20baddeede8a4eccd1e705551) Fix SUNDIALS for macOS M1
* [`13c6b4ae`](https://github.com/NixOS/nixpkgs/commit/13c6b4aee5153904b4a158e2f481cc74bf593f87) nixos/tests/nar-serve: Fix after nix version bump
* [`3e1e1955`](https://github.com/NixOS/nixpkgs/commit/3e1e19557c3ab18213932042d8256a65879c28dc) sarasa-gothic: 0.36.1 -> 0.36.2
* [`7212c1ac`](https://github.com/NixOS/nixpkgs/commit/7212c1acd99de059242333a411df2f8e468b7d2b) ddnet: 15.9.1 -> 16.0
* [`6967ed62`](https://github.com/NixOS/nixpkgs/commit/6967ed62127aea6fbb768631c052c458b85477db) megasync: 4.6.3.0 -> 4.6.5.0
* [`99f387e4`](https://github.com/NixOS/nixpkgs/commit/99f387e462b16d38069168750e5dfbfa1211df55) desktopToDarwinBundle: Fixup Exec
* [`b52a9621`](https://github.com/NixOS/nixpkgs/commit/b52a9621412ab6b2b12885f3875a7a956d4ab46a) desktopToDarwinBundle: Complete field code removal
* [`7ef15c96`](https://github.com/NixOS/nixpkgs/commit/7ef15c96dc6180295d46efb0a0a4f1dd5b0b687a) desktopToDarwinBundle: Add X-macOS-Exec and log editing Exec
* [`6fabd819`](https://github.com/NixOS/nixpkgs/commit/6fabd819a05d748d657421ebdda301e2763d5f3b) ddnet: 16.0 -> 16.0.1
* [`c3c57914`](https://github.com/NixOS/nixpkgs/commit/c3c57914b3f32d632d805e285b492ce2785bdd7d) python310Packages.pytest-check: 1.0.4 -> 1.0.5
* [`30e8e0a9`](https://github.com/NixOS/nixpkgs/commit/30e8e0a9a3b11e06f0aed76e25ae5fdd73f833de) desktopToDarwinBundle: Change empty directory test
* [`4a749a89`](https://github.com/NixOS/nixpkgs/commit/4a749a89c453551e107567cdf5d80165383b537f) desktopToDarwinBundle: Implement %k Exec field code
* [`4dc94e14`](https://github.com/NixOS/nixpkgs/commit/4dc94e1489fd7045e4b898996cecfbf28ed87ab3) desktopToDarwinBundle: Implement %c Exec field code
* [`196f989a`](https://github.com/NixOS/nixpkgs/commit/196f989ae88a13210720cb08d53a57c5c05481a0) desktopToDarwinBundle: Implement %i Exec field code
* [`67303b06`](https://github.com/NixOS/nixpkgs/commit/67303b06c0a20f3dfa11a390ffd35e4762a7c179) python3.pkgs.ihatemoney: fix build with flask-talisman 1
* [`f31d9457`](https://github.com/NixOS/nixpkgs/commit/f31d9457551315abad6174c08646e39e09f8db70) desktopToDarwinBundle: Implement %f and %u Exec field codes
* [`261b7365`](https://github.com/NixOS/nixpkgs/commit/261b73652131421cd562873191060b02b56db1fe) desktopToDarwinBundle: Implement %F and %U Exec field codes
* [`334b30c4`](https://github.com/NixOS/nixpkgs/commit/334b30c464d95bcedd473014aa83c7d68ece641f) nixos/github-runner: systemd service hardening
* [`70f50a9d`](https://github.com/NixOS/nixpkgs/commit/70f50a9dfbbde9bdec0a91cccf347039009b8448) ddnet: 16.0.1 -> 16.0.2
* [`4565febb`](https://github.com/NixOS/nixpkgs/commit/4565febba8250c2e830e932279be21915fcab8cf) quake3e: 2020-04-04 -> 2022-04-01-dev
* [`821a184f`](https://github.com/NixOS/nixpkgs/commit/821a184fa99f9ef10ced1c215fd77444fa9cb8d0) nixos/bird: reloadIfChanged -> reloadTriggers
* [`08efd19b`](https://github.com/NixOS/nixpkgs/commit/08efd19bd34798c47f558b2c2c31034b64458250) stm32flash: 0.6 -> 0.7
* [`06430639`](https://github.com/NixOS/nixpkgs/commit/06430639a7fa0b5577120e669c1cec4352dcc32c) realvnc-vnc-viewer: 6.21.1109 -> 6.22.207
* [`05d75288`](https://github.com/NixOS/nixpkgs/commit/05d752888ee2c2351ba104df893b8bc8abcafb1e) github-runner: guard support for Node.js 12
* [`104d8c8f`](https://github.com/NixOS/nixpkgs/commit/104d8c8f80cf0527f4e384e67ea6564d22a44e4e) ddnet: 16.0.2 -> 16.0.3
* [`8ece9248`](https://github.com/NixOS/nixpkgs/commit/8ece92480755ab3d372290522b95502633863007) jellyfin-web: switch nodejs-12_x to nodejs-14_x
* [`fb2fa1b5`](https://github.com/NixOS/nixpkgs/commit/fb2fa1b50fe32e4d4f4e251b5892598f38f40a71) nixos/postfix: pull setup into its own unit
* [`3326297c`](https://github.com/NixOS/nixpkgs/commit/3326297c8e93c895f7bac7a84729216515383a84) ethtool: 5.16 -> 5.17
* [`2ce4c3c8`](https://github.com/NixOS/nixpkgs/commit/2ce4c3c8ec5268ee45f9a66c5cc9e6a6239af8f0) hunspellDicts: fix cross compilation
* [`89f15314`](https://github.com/NixOS/nixpkgs/commit/89f15314013af00739b3eb394d064989e43f8e4b) icingaweb2: 2.10.0 -> 2.10.1
* [`cb720edb`](https://github.com/NixOS/nixpkgs/commit/cb720edb7dd3529787bdd2945e5da9402c3bca08) kodi: More robust handling of kodi webserver assets
* [`b11775bf`](https://github.com/NixOS/nixpkgs/commit/b11775bf57886e7e473060146dff5990a483c585) python310Packages.google-cloud-bigtable: 2.8.0 -> 2.8.1
* [`26caa23a`](https://github.com/NixOS/nixpkgs/commit/26caa23ad34e0dd4dc1c1acdcef58f35e028e7d8) obs-studio: 27.2.1 -> 27.2.4
* [`de775772`](https://github.com/NixOS/nixpkgs/commit/de77577258abb51482da78f301d5d45e7b8c1cec) vimPlugins.vim-search-pulse: init at 2017-01-05
* [`e5e8f993`](https://github.com/NixOS/nixpkgs/commit/e5e8f993a26580fd44c21758cf6e5126fcec49d9) owncloud-client: 2.10.0.6519 -> 2.10.1.7187
* [`eb286631`](https://github.com/NixOS/nixpkgs/commit/eb286631b4cec28424fb4056735a79cdb36eec59) haskell.compiler: check targetPlatform for Cabal Paths module patch
* [`49d14610`](https://github.com/NixOS/nixpkgs/commit/49d146101a2a131a86d1a257cb3a3753d8637773) haskell: don't lose packageOverrides for native-bignum
* [`df2b17ce`](https://github.com/NixOS/nixpkgs/commit/df2b17ce3fa74e4c9aeb276a22e0946e06aff878) musl: 1.2.2 -> 1.2.3
* [`c16208e4`](https://github.com/NixOS/nixpkgs/commit/c16208e4a313bb4aea74bef5c21c1e6514d623cf) haskellPackages: unbreak bloodhound
* [`be0e373e`](https://github.com/NixOS/nixpkgs/commit/be0e373e8555173bd24c9c8c44ab23184e4e661a) python310Packages.glfw: 2.5.1 -> 2.5.3
* [`7a13b86d`](https://github.com/NixOS/nixpkgs/commit/7a13b86dbd88871124a9af6654b5eaef00a19f82) androidStudioPackages.stable: 2021.1.1.21 -> 2021.1.1.23
* [`61069589`](https://github.com/NixOS/nixpkgs/commit/61069589c24fc7f7bd09f8599b1699a1c8830ee6) androidStudioPackages.beta: 2021.2.1.8 -> 2021.2.1.11
* [`fb909729`](https://github.com/NixOS/nixpkgs/commit/fb90972987eb0ddb1914e4d7e8ac77186cbda444) androidStudioPackages.{canary,dev}: 2021.3.1.1 -> 2021.3.1.7
* [`5a2e2471`](https://github.com/NixOS/nixpkgs/commit/5a2e2471e8163da8e6f2c1dfd50ef9063199c08b) haskellPackages: stackage LTS 19.2 -> LTS 19.3
* [`ef0a727e`](https://github.com/NixOS/nixpkgs/commit/ef0a727ee53eb626b067a9bc7a5d3a46800e29d6) all-cabal-hashes: 2022-04-06T22:24:53Z -> 2022-04-09T11:23:17Z
* [`d14e0c0d`](https://github.com/NixOS/nixpkgs/commit/d14e0c0dfb46ff5ffe21ed1d247b4d1f58b67b39) haskellPackages: regenerate package set based on current config
* [`bd2a384c`](https://github.com/NixOS/nixpkgs/commit/bd2a384c40c4176c279502c46c2ac411f8c31cbd) thanos: 0.25.1 -> 0.25.2
* [`7aac84db`](https://github.com/NixOS/nixpkgs/commit/7aac84dbeacaf2bb7f508563db6e81f5195078fe) graphene: 1.10.6 -> 1.10.8
* [`81afd541`](https://github.com/NixOS/nixpkgs/commit/81afd541f99a6d1c9aea2ddbad642f8df0db1c18) lib/systems/inspect.nix: add isPower64
* [`302574ee`](https://github.com/NixOS/nixpkgs/commit/302574ee511a5fc476564b054ced2621168c0e86) gomplate: 3.9.0 -> 3.10.0
* [`b3886428`](https://github.com/NixOS/nixpkgs/commit/b3886428c1beb2c8eb7909b066e12e35a5f40294) haskellPackages.hercules-ci-cnix-expr: Fix test
* [`fde2e98a`](https://github.com/NixOS/nixpkgs/commit/fde2e98a0116ddba74569d11f281cd87fbdf13ab) haskell.compiler.ghcjs: fix build with aeson 2.0
* [`bfc55bad`](https://github.com/NixOS/nixpkgs/commit/bfc55bad14c3d2f53465280434a51acd5a3223d1) xanmod-kernels: add STABLE and EDGE variants
* [`96c7dbbc`](https://github.com/NixOS/nixpkgs/commit/96c7dbbcd5af15d012e857808fdf6d3c63c133dc) linux_xanmod: 5.15.30 -> 5.15.31
* [`dd22fa7e`](https://github.com/NixOS/nixpkgs/commit/dd22fa7ecd82753b2bbfb8ed1dd1b42552c20d9e) linux_xanmod: 5.15.31 -> 5.15.32
* [`3280363b`](https://github.com/NixOS/nixpkgs/commit/3280363b2f9e85aaedd179f6b30e0c28281ef863) linux_xanmod_latest: 5.17.0 -> 5.17.1
* [`77e6d152`](https://github.com/NixOS/nixpkgs/commit/77e6d15276effcebfdb10c87a3d5b7bcce413e63) linux_xanmod_latest: 5.17.1 -> 5.17.2
* [`7e318349`](https://github.com/NixOS/nixpkgs/commit/7e31834981199670f3f3d8e920ede864aaab095c) linux_xanmod: 5.15.32 -> 5.15.33
* [`7ad0327b`](https://github.com/NixOS/nixpkgs/commit/7ad0327b599c653cd8eecdae6dcb1eb2ceccc29e) release-haskell.nix: build boot ghcjs on Hydra
* [`6675a161`](https://github.com/NixOS/nixpkgs/commit/6675a16146bb25c5728d340fa40e989fe24eedb9) rPackages: CRAN and BioC update
* [`4db0aaa9`](https://github.com/NixOS/nixpkgs/commit/4db0aaa94da44b18477f37548c944d0452b9b75c) confluent-platform: 7.0.1 -> 7.1.0
* [`5a7db167`](https://github.com/NixOS/nixpkgs/commit/5a7db167c91da7e093d8f0d56278dfc7e4daa297) melody: 0.13.9 -> 0.13.10
* [`8c6b13b2`](https://github.com/NixOS/nixpkgs/commit/8c6b13b23435f9a4b4647d41d5d94e28209dfc40) dalfox: 2.7.1 -> 2.7.4
* [`14f36b6f`](https://github.com/NixOS/nixpkgs/commit/14f36b6f87d5f4c2f00d846d82743b4f68323d11) Update hash + add myself as maintainer
* [`2f444f12`](https://github.com/NixOS/nixpkgs/commit/2f444f12c8c6dceba20db54b4afe33192a929a7d) runescape-launcher: use package from archive.org
* [`abe8ff56`](https://github.com/NixOS/nixpkgs/commit/abe8ff56e274d80a82b51d022875123ffaa3ebc8) update remote package hash
* [`fe847a48`](https://github.com/NixOS/nixpkgs/commit/fe847a48c9747b41afc195999c097ad0870b019d) python310Packages.twill: 3.0.1 -> 3.0.2
* [`69b65787`](https://github.com/NixOS/nixpkgs/commit/69b65787e8060b2e20c77d38d307dfd52d09af17) moc: build on darwin
* [`7ff4a7e6`](https://github.com/NixOS/nixpkgs/commit/7ff4a7e624c91fab45555117d8adbdda8a781362) python310Packages.twill: disable on older Python releases
* [`8adfdcb7`](https://github.com/NixOS/nixpkgs/commit/8adfdcb746706201b38556dcaea85e50012e41b9) rare: 1.8.8 -> 1.8.9
* [`fbe7b754`](https://github.com/NixOS/nixpkgs/commit/fbe7b754e53909d20e6d7256e8c2b62e857339df) execline: 2.8.2.0 -> 2.8.3.0
* [`1be5cae5`](https://github.com/NixOS/nixpkgs/commit/1be5cae549b0f8a85915062450808ce58939bac1) haskell: remove override of integer-gmp
* [`1cab5cba`](https://github.com/NixOS/nixpkgs/commit/1cab5cbae44f4666e1e85153e6b2f6ac0a1621fd) python310Packages.fastcore: 1.4.1 -> 1.4.2
* [`bb6afd70`](https://github.com/NixOS/nixpkgs/commit/bb6afd70079c1de67bcb0f29e9754451741443e6) haskellPackages.gi-adwaita: mark as broken
* [`82ab7c37`](https://github.com/NixOS/nixpkgs/commit/82ab7c3799f9b6d8fb064510de7577bf9e913805) gotestsum: 1.7.0 -> 1.8.0
* [`ab12eef0`](https://github.com/NixOS/nixpkgs/commit/ab12eef0fbfbd1ab07be0c0c63dceeabe4b84f49) haskellPackages.cryptostore: disable flaky test suite
* [`3689c012`](https://github.com/NixOS/nixpkgs/commit/3689c012135801d5fb48dae93b0731a1ebb389c0) cypress: 9.5.3 -> 9.5.4
* [`ce8dab1b`](https://github.com/NixOS/nixpkgs/commit/ce8dab1b441e7d0b147c6338e2e874f04418fa50) luajit: 2.0.5-2021-10-02, 2.1.0-2021-10-27 -> 2.0.5-2022-03-13, 2.1.0-2022-04-05
* [`86ee754c`](https://github.com/NixOS/nixpkgs/commit/86ee754c4f5cc76ac6bea9066f00d48edc247a5b) wlr-randr: add wayland-scanner to nativeBuildInputs
* [`eca4a008`](https://github.com/NixOS/nixpkgs/commit/eca4a0087f6406c08915313dae8fcf6a57450e29) CODEOWNERS: Add layus for autoPatchelfHook
* [`1e1c29aa`](https://github.com/NixOS/nixpkgs/commit/1e1c29aa78ae20dc4be3540b35d58ef51a5de2f2) alfis: 0.6.11 -> 0.7.0
* [`76168cb0`](https://github.com/NixOS/nixpkgs/commit/76168cb09670a03ae62a7150b2f910ef4756b093) haskell.packages.ghc8107.haskell-language-server: enable hlint plugin
* [`82b4dabe`](https://github.com/NixOS/nixpkgs/commit/82b4dabe8f9f54df50514db0375dd466c1a1fb6c) haskell.packages.ghc8107.haskell-language-server: enable fourmolu plugin
* [`3fa9ae18`](https://github.com/NixOS/nixpkgs/commit/3fa9ae18a01b7a87e245000bb0c25d0d011a66b9) haskell.packages.ghc884.haskell-language-server: enable hlint and fourmolu plugins
* [`0d0feaa4`](https://github.com/NixOS/nixpkgs/commit/0d0feaa4fc281c6d79b7a8afb97237676a623d44) gcc{4..10}: add aarch64-darwin to badPlatforms
* [`7fd6cea2`](https://github.com/NixOS/nixpkgs/commit/7fd6cea253a27d3c0660a4c21774c9697a655661) make-initrd: fix reproducibility problems
* [`6b123967`](https://github.com/NixOS/nixpkgs/commit/6b123967ff0e7cfbe959ccfd51da9ac6429709d7) qbe: unstable-2022-03-17 -> unstable-2022-04-11
* [`e98748a8`](https://github.com/NixOS/nixpkgs/commit/e98748a87bde3976ba818084710cf849383ffa9b) faircamp: unstable-2022-01-19 -> unstable-2022-03-20
* [`5889b22f`](https://github.com/NixOS/nixpkgs/commit/5889b22fe3d9359bae89435b0b0893577d4a7c2f) pinegrow: fix download link
* [`739daae8`](https://github.com/NixOS/nixpkgs/commit/739daae8ca008a82f7a23d2f0634e74fb3932709) fclones: 0.19.0 -> 0.20.0
* [`15805756`](https://github.com/NixOS/nixpkgs/commit/158057568ac621241c71f292544680d17ed0186c) fclones: 0.20.0 -> 0.20.1
* [`f5b1bd16`](https://github.com/NixOS/nixpkgs/commit/f5b1bd166aac6c8d3a2e85eaa8dffa3f3504dce0) wimlib: Fix build on darwin.
* [`efc55a81`](https://github.com/NixOS/nixpkgs/commit/efc55a817333b4cb179293983a07211c806d8406) skate: 0.1.4 -> 0.2.0
* [`b26d2b79`](https://github.com/NixOS/nixpkgs/commit/b26d2b7998d83b4555bad7d1e0e85f0890b76900) gnome-shell-extension-impatience: unstable-2019-09-23 -> unstable-2022-03-26
* [`4b7d1951`](https://github.com/NixOS/nixpkgs/commit/4b7d1951772841e7fce13e84cea1988ccd0db170) maintainers: Add `neilmayhew`
* [`4f7de016`](https://github.com/NixOS/nixpkgs/commit/4f7de0169b89eda49f8aae7a307c9064753b04e0) bottles: 2022.4.14-trento -> 2022.4.14-trento-1
* [`65927972`](https://github.com/NixOS/nixpkgs/commit/6592797222ea9b4c91b642b31322c57e9f8a2ca5) hydrus: 480 -> 481
* [`6d377ae0`](https://github.com/NixOS/nixpkgs/commit/6d377ae0a926121234584f9c743993710325381d) mold: 1.1.1 -> 1.2.0
* [`564acf70`](https://github.com/NixOS/nixpkgs/commit/564acf704bcb9d4dc4fc213b547bedc8fcfc68a2) python3Packages.ocrmypdf: 13.4.2 -> 13.4.3
* [`b7d2914b`](https://github.com/NixOS/nixpkgs/commit/b7d2914baa8ea7e1df2d884b4c90e0e62f325b0b) python3Packages.iso8601: build with poetry
* [`632e170e`](https://github.com/NixOS/nixpkgs/commit/632e170e3f1bb45410b744042a5d26974fda6978) herbstluftwm: 0.9.3 -> 0.9.4
* [`5c09c15d`](https://github.com/NixOS/nixpkgs/commit/5c09c15d92012cd1436b3a9564fbeee0115fd7e7) python310Packages.casbin: 1.15.4 -> 1.15.5
* [`63a979fb`](https://github.com/NixOS/nixpkgs/commit/63a979fb64c0d25c3189f668e5a5c3e44fd2ae6a) imgcrypt: 1.1.1 -> 1.1.4
* [`9d295d7c`](https://github.com/NixOS/nixpkgs/commit/9d295d7ca4cdb04092e371fe81c02796f7e2e806) xfce.xfce4-panel: 4.16.3 -> 4.16.4
* [`e77e09c5`](https://github.com/NixOS/nixpkgs/commit/e77e09c5d2d863d5b0500d08ee6afae7895da723) postgresqlTestHook: init
* [`53881039`](https://github.com/NixOS/nixpkgs/commit/5388103926de037277e80b48cf7e0221bbb56cbe) haskellPackages.pg-client: Enable tests
* [`ebf1ce19`](https://github.com/NixOS/nixpkgs/commit/ebf1ce192388b5588e1a206579d9678a93fad65e) nixos/doc/rl-2205: Add `postgresqlTestHook`
* [`b4b53283`](https://github.com/NixOS/nixpkgs/commit/b4b53283896327360ecf4bcc5ae8c87212ca3ed0) haskellPackages.esqueleto: Enable tests
* [`f60768b6`](https://github.com/NixOS/nixpkgs/commit/f60768b6cda4e48c1905649868592c7b080fa355) haskellPackages.persistent-postgresql: Enable tests
* [`c29cca1e`](https://github.com/NixOS/nixpkgs/commit/c29cca1eef4e16dab6354a96076396362a9a016f) xfce.xfce4-eyes-plugin: 4.5.1 -> 4.6.0
* [`77f15bc6`](https://github.com/NixOS/nixpkgs/commit/77f15bc69feebcea77d4d075b8302d99871b12ab) xfce.xfce4-terminal: 0.8.10 -> 1.0.1
* [`6951ba02`](https://github.com/NixOS/nixpkgs/commit/6951ba02f4c7cef6cd38825ae8fc5f51be05205d) nginxStable: add patch for CVE-2021-3618
* [`c1f27518`](https://github.com/NixOS/nixpkgs/commit/c1f27518045e6e61b74ad8e9a039221ae1ae8438) haskellPackages.cryptostore: 0.2.1.0 -> 0.2.2.0
* [`9ac0f3c9`](https://github.com/NixOS/nixpkgs/commit/9ac0f3c915afe9753be47679af49b7c2020e8f85) iproute2: 5.14.0 -> 5.17.0
* [`30a00c29`](https://github.com/NixOS/nixpkgs/commit/30a00c29c4b0be54cee6f8bcfb2fdde583454407) nixos/systemd: Properly shut down the system
* [`3396c96e`](https://github.com/NixOS/nixpkgs/commit/3396c96e4b884f9d3cba6ad37da30e83a7c52e60) nixos/stage-1-init: Set host id for ZFS
* [`9749d34a`](https://github.com/NixOS/nixpkgs/commit/9749d34ac03650c712848a1fc2188e496e87c3f0) octave-kernel: 0.32.0 -> 0.34.2
* [`81f9e288`](https://github.com/NixOS/nixpkgs/commit/81f9e288444b9c01c5cef2bf1e9173adf6a25f5a) root5: fix for glibc
* [`2acbc3d8`](https://github.com/NixOS/nixpkgs/commit/2acbc3d8525706135513397ca139b8290a90f5ad) qpwgraph: 0.2.2 -> 0.2.5
* [`47586fec`](https://github.com/NixOS/nixpkgs/commit/47586fec7e92d30480411d323a88a92ff3477070) SDL_audiolib: init at unstable-2022-04-17
* [`a67950f2`](https://github.com/NixOS/nixpkgs/commit/a67950f20b97a293b2fefeecc349c6b785321e4b) fetchurl: passthru url
* [`cc4c0bb4`](https://github.com/NixOS/nixpkgs/commit/cc4c0bb4c6368db95555c4d7705359fcf472399e) python310Packages.kiss-headers: 2.3.0 -> 2.3.1
* [`c9464f47`](https://github.com/NixOS/nixpkgs/commit/c9464f4716ea18614ba8952e73bf75fbd3c15818) pyinfra: 2.0 -> 2.0.1
* [`75349302`](https://github.com/NixOS/nixpkgs/commit/753493028426ff4d79389caf404b3aa03f2200da) osdlyrics: init at 0.5.10
* [`eb86e75c`](https://github.com/NixOS/nixpkgs/commit/eb86e75c1677203668a49045e87a350d40bc7e55) rekor-cli, rekor-server: 0.5.0 -> 0.6.0
* [`0b371422`](https://github.com/NixOS/nixpkgs/commit/0b371422d82d83bd4fd0d5f493e91ffcff86f9f7) gnomeExtensions: auto-update
* [`0a60a12f`](https://github.com/NixOS/nixpkgs/commit/0a60a12fae59593332fa6883d2d4b1e51c48c2bd) nixos/amdgpu-pro: Add support for systemd stage 1
* [`d45c1652`](https://github.com/NixOS/nixpkgs/commit/d45c165216b77630dca2d71433bc39d689c15d87) irpf: 2022-1.0 -> 2022-1.3
* [`165b5324`](https://github.com/NixOS/nixpkgs/commit/165b53247f08a36441bb47043daeb45fa0cda5cf) minify: 2.10.0 -> 2.11.1
* [`9481fdcd`](https://github.com/NixOS/nixpkgs/commit/9481fdcdfc9fbf45244bf93eec16ba5a1a9ae6e7) flyctl: 0.0.316 -> 0.0.320
* [`f77479ec`](https://github.com/NixOS/nixpkgs/commit/f77479eca5dfc3e3f3eb1172aced128b1681e894) python3Packages.imap-tools: 0.52.0 -> 0.54.0
* [`62f67382`](https://github.com/NixOS/nixpkgs/commit/62f673823937d2ee5e8491c643b53360c7d212d2) linux_xanmod: 5.15.33 -> 5.15.34
* [`6f6daf3a`](https://github.com/NixOS/nixpkgs/commit/6f6daf3a6a5be74b70ba2bd270ff19824824c3a5) man-db: add support for zstd
* [`fe7fb4b8`](https://github.com/NixOS/nixpkgs/commit/fe7fb4b87fe1d3160b1dcb9ec70c2371ac2665a2) man-db: use autoreconfHook;
* [`2030ed94`](https://github.com/NixOS/nixpkgs/commit/2030ed94c557918af94f3ff3769fbba2c4c0d854) Update pkgs/tools/misc/man-db/default.nix
* [`9135ad09`](https://github.com/NixOS/nixpkgs/commit/9135ad098d535fd4252fd0ce8d2432509ef96af2) man-db: fix after rebase
* [`9a724bde`](https://github.com/NixOS/nixpkgs/commit/9a724bde60b2e61cea1e892861e042780d4e9f39) tpm2-abrmd: 2.3.3 -> 2.4.1
* [`9ca25256`](https://github.com/NixOS/nixpkgs/commit/9ca25256765a992cea8120f0e020854cb83197c8) Add exi as maintainer for qpwgraph
* [`779cca1b`](https://github.com/NixOS/nixpkgs/commit/779cca1bd152b2d25ff8bbfcafcc30d1aad7fa6e) tpm2-tss: fix version detection
* [`966aab32`](https://github.com/NixOS/nixpkgs/commit/966aab323cc3be2071ab4c5e4eafe347aa5a9820) python3Packages.zulip: 0.8.1 -> 0.8.2
* [`bb26a5de`](https://github.com/NixOS/nixpkgs/commit/bb26a5de13964683d50e5a2ff27448c071e9dc48) python3Packages.wallbox: 0.4.6 -> 0.4.8
* [`3d4f536d`](https://github.com/NixOS/nixpkgs/commit/3d4f536dd483dd892fa1f89e6bd61005d750e88a) python3Packages.nextcord: 2.0.0a9 -> 2.0.0a10
* [`c9aacf1f`](https://github.com/NixOS/nixpkgs/commit/c9aacf1f8b807f19195bc5b24f01460db69581a3) haskellPackages: mark builds failing on hydra as broken
* [`d07bed56`](https://github.com/NixOS/nixpkgs/commit/d07bed56c90af2744d9403c2298e3ee0690efb38) python3Packages.pyrogram: 1.4.12 -> 1.4.16
* [`e1bbc6ca`](https://github.com/NixOS/nixpkgs/commit/e1bbc6ca9cf832d10acda995fba0be4ab559374d) gitleaks: 8.6.1 -> 8.7.0
* [`ff4656d8`](https://github.com/NixOS/nixpkgs/commit/ff4656d89bb2b4fb8643585da5a54f1a3a2d4af1) python3Packages.lightwave2: 0.8.1 -> 0.8.4
* [`4cd90c2e`](https://github.com/NixOS/nixpkgs/commit/4cd90c2e2bf6e08767ee455bacf96ce957876fa5) argagg: init at 0.4.6
* [`73481d9e`](https://github.com/NixOS/nixpkgs/commit/73481d9e3823fa07605f0c6db1ad309362aa2818) python310Packages.pytelegrambotapi: 4.4.0 -> 4.4.1
* [`a8bc4ffb`](https://github.com/NixOS/nixpkgs/commit/a8bc4ffbf19e7097e12eae9252e0abecea0dada9) cgreen: Fix some uses of /usr/bin
* [`5d6f12db`](https://github.com/NixOS/nixpkgs/commit/5d6f12dbcf73178606f949fb5064742b49f2a4a0) alan: init at 3.0beta8
* [`b0de2214`](https://github.com/NixOS/nixpkgs/commit/b0de2214e5d190982c6fe845d31c47dd8e0b3d6f) alan_2: init at 2.8.7
* [`fa34deb7`](https://github.com/NixOS/nixpkgs/commit/fa34deb77c1a4102068c86e8c4926eab90d1f1c3) checkov: 2.0.1065 -> 2.0.1067
* [`6f56cbc0`](https://github.com/NixOS/nixpkgs/commit/6f56cbc0caedab6454218e4514f16a985aaff28c) edid-decode: unstable-2018-12-06 -> unstable-2022-04-06
* [`77877c09`](https://github.com/NixOS/nixpkgs/commit/77877c0916306f875894b6f9b3bd7b80455eca2a) python3Packages.umap-learn: 0.5.2 -> 0.5.3
* [`2034eb4a`](https://github.com/NixOS/nixpkgs/commit/2034eb4a273e4864c2157b540e45cd3ae57c9244) F2: init at 1.8.0
* [`bdfa8c5b`](https://github.com/NixOS/nixpkgs/commit/bdfa8c5bdfe4057a822845fd7b758b865d02e6ff) mysql-shell: init at 8.0.28
* [`b5f6673f`](https://github.com/NixOS/nixpkgs/commit/b5f6673f097681d3287a842fccf3198518bbf17d) pdfstudio: 2021.1.2 -> 2021.1.3
* [`538a5a28`](https://github.com/NixOS/nixpkgs/commit/538a5a28b75a3ae6a52f073eba727a81135ec76d) fetchgit: allow passing thru meta
* [`0cd55983`](https://github.com/NixOS/nixpkgs/commit/0cd55983086d188c0f59e4a4f3132e29ea32823e) emulators: reorder all-packages.nix
* [`af8c5237`](https://github.com/NixOS/nixpkgs/commit/af8c5237d86073a60f19adc679cf617f1f9342fe) ares: move to bsnes/ subdir
* [`a6035820`](https://github.com/NixOS/nixpkgs/commit/a6035820148b2e645166422d26596ef6bffcec1a) bsnes-hd: move to bsnes/ subdir
* [`d575f864`](https://github.com/NixOS/nixpkgs/commit/d575f86479128f03983ef38f32d4e0856669c4a1) higan: move to bsnes/ subdir
* [`355b60dd`](https://github.com/NixOS/nixpkgs/commit/355b60dd6c7852586cbae98f86f8d28007b234fb) ffmpeg-normalize: 1.22.8 -> 1.22.9
* [`6d21daa4`](https://github.com/NixOS/nixpkgs/commit/6d21daa43e7459db7aee4fec22fb209e3047d3ae) evince: 42.1 -> 42.2
* [`35ea9f1a`](https://github.com/NixOS/nixpkgs/commit/35ea9f1a6fc3cef6d1c1ddefdc8a608ffab75b6c) lbreakout2: move to lgames/ subdir
* [`fd1492cd`](https://github.com/NixOS/nixpkgs/commit/fd1492cdf74ef459f67e8c9c9edd50f7b8d5c880) ltris: move to lgames/ subdir
* [`edc25332`](https://github.com/NixOS/nixpkgs/commit/edc25332f47bafc510ffe4aa14a0e495d4afb190) ltris: 1.0.19 -> 1.2.4
* [`be137a24`](https://github.com/NixOS/nixpkgs/commit/be137a244683bb1b273f4b666d45cc000cd8656d) python310Packages.svg-path: 5.1 -> 6.0
* [`3a4fbddd`](https://github.com/NixOS/nixpkgs/commit/3a4fbddd1d68cb3a4a289771639fe7f4f7190352) chatty: 0.6.1 -> 0.6.3
* [`980b1ba3`](https://github.com/NixOS/nixpkgs/commit/980b1ba32b978d30eaf115c62f9d90d1cf075c3c) josm: 18387 → 18427
* [`fad2f335`](https://github.com/NixOS/nixpkgs/commit/fad2f3353c1916b45e2d6936cf8ebf30bbd95b9c) terraform-providers: update 2022-04-18
* [`88c57c4c`](https://github.com/NixOS/nixpkgs/commit/88c57c4c4a6e8afced78c231525ad867499661ba) python310Packages.pg8000: 1.24.2 -> 1.25.0
* [`b3e86b6b`](https://github.com/NixOS/nixpkgs/commit/b3e86b6bcbbe0f36b1d9c075ea3cab642ce02242) hqplayerd: use fc35 rpm
* [`9233d335`](https://github.com/NixOS/nixpkgs/commit/9233d3357911600683263a64cf346e84d5ac07c5) pkgs-lib.formats: fix tomlkit output
* [`eb57cadc`](https://github.com/NixOS/nixpkgs/commit/eb57cadcaa6fdfd865e8c1f6bdaeda0031589b27) open-watcom-v2-unwrapped: unstable-2022-03-14 -> unstable-2022-04-18
* [`a77406f1`](https://github.com/NixOS/nixpkgs/commit/a77406f1f203da1c423adb25ea48fea634a206ef) tdesktop: fix build with kwayland 5.94
* [`51f68dfd`](https://github.com/NixOS/nixpkgs/commit/51f68dfddc839f9d62d5a7cee5f933d422c7a83f) sile: 0.12.4 → 0.12.5
* [`ead2f36c`](https://github.com/NixOS/nixpkgs/commit/ead2f36c5eeaed411a57e390c1ab90b56d61e19e) python310Packages.approvaltests: 5.0.0 -> 5.0.1
* [`99fed858`](https://github.com/NixOS/nixpkgs/commit/99fed858bbb77490a70a3e33713b66b4ccae1b03) doc/hooks/index.xml: Fix typo and terminology
* [`154d9a8d`](https://github.com/NixOS/nixpkgs/commit/154d9a8d8ad9a95c6a1e9d78569f7957bfcedf09) maintainers: add lilyinstarlight
* [`09f63fb4`](https://github.com/NixOS/nixpkgs/commit/09f63fb46c65db37881d32afeb2913a6ce41b9b6) supercollider: change maintainer to lilyinstarlight
* [`089f8b10`](https://github.com/NixOS/nixpkgs/commit/089f8b107ba9b3810905e54a6efaffbed0e4e38f) supercollider: add plugin support
* [`59175401`](https://github.com/NixOS/nixpkgs/commit/591754016f8733a6d860982faddbaeb5650882fd) supercolliderPlugins.sc3-plugins: init at 3.11.1
* [`2b7ebac3`](https://github.com/NixOS/nixpkgs/commit/2b7ebac344bc92a6ef43bd543eb104ac08610819) supercollider: add sc3-plugins test
* [`73c7bab2`](https://github.com/NixOS/nixpkgs/commit/73c7bab23a5768c2f862a2cc4842a77da9ca9976) python310Packages.azure-mgmt-containerservice: 18.0.0 -> 19.0.0
* [`1acc9752`](https://github.com/NixOS/nixpkgs/commit/1acc9752da3892280bfe16388e4dc337c8a432aa) python310Packages.azure-mgmt-datafactory: 2.3.0 -> 2.4.0
* [`1bea49d3`](https://github.com/NixOS/nixpkgs/commit/1bea49d3bf339a708dc8724a9f2ebd3047e212b5) nixos/stage-1-systemd: Add LUKS w/ password support
* [`28c7721a`](https://github.com/NixOS/nixpkgs/commit/28c7721aa3caaeb84742250a911d951a7d817688) nixos/stage-1-systemd: Add a test for LUKS keyfiles
* [`a9e951eb`](https://github.com/NixOS/nixpkgs/commit/a9e951eb88c93d92af0720046a36a91a06b84162) jsonb_deep_sum: init at unstable-2021-12-24
* [`a62be8ad`](https://github.com/NixOS/nixpkgs/commit/a62be8ad084783d5cf87980c260c81069fc2e4af) batman-adv: 2021.4 -> 2022.0
* [`eb862d7d`](https://github.com/NixOS/nixpkgs/commit/eb862d7d4fbabb4fd05524963a8f7830e5044fbc) python310Packages.enaml: 0.14.1 -> 0.15.0
* [`8407ddd1`](https://github.com/NixOS/nixpkgs/commit/8407ddd125e10a44d84f8efb60173e7e08221e93) python310Packages.commoncode: 30.0.0 -> 30.1.1
* [`01872023`](https://github.com/NixOS/nixpkgs/commit/018720239cb4fdc026dd16921ece5fec58855c0c) irpf: update description
* [`73a22ba3`](https://github.com/NixOS/nixpkgs/commit/73a22ba300583b1e5247bac9778d7653d21e6ad3) ocamlPackages.coin: 0.1.3 → 0.1.4
* [`f5ab0f0e`](https://github.com/NixOS/nixpkgs/commit/f5ab0f0e9363f4204dfa23015fff043712f43e8f) protonvpn-gui: 1.7.0 -> 1.8.0
* [`0bcf4a81`](https://github.com/NixOS/nixpkgs/commit/0bcf4a81c8886b57356e99b0f094e821fd0a06ab) ocamlPackages.bjack: init at 0.1.6
* [`fd0b0605`](https://github.com/NixOS/nixpkgs/commit/fd0b06056033fd45dd40edd71173afdd082fc692) ocamlPackages.gen_js_api: init at 1.0.9
* [`9bb17e40`](https://github.com/NixOS/nixpkgs/commit/9bb17e40624d0b584eda52f9155c3a9433fb5c41) ping: add throw
* [`ee672c82`](https://github.com/NixOS/nixpkgs/commit/ee672c823ed46d8eec1354e6570e699954e01993) ocamlPackages.samplerate: init at 0.1.6
* [`df6fa847`](https://github.com/NixOS/nixpkgs/commit/df6fa84709e3c7413df2dd9ef162b6e5167557a6) nixos/nscd: fix manual build
* [`6a14836a`](https://github.com/NixOS/nixpkgs/commit/6a14836a53cb70a9c5ed26cff9d953fedd11c2ed) ocamlPackages.xmlplaylist: init at 0.1.5
* [`0a44fe4d`](https://github.com/NixOS/nixpkgs/commit/0a44fe4daed4a63a959ebaee7b7f902eb48a6320) ocamlPackages.lastfm: init at 0.3.3
* [`11bbb28f`](https://github.com/NixOS/nixpkgs/commit/11bbb28f8a6906f3402549af1c4bd24061f06ada) nixos/kmscon: Add fonts option
* [`0c7af2f4`](https://github.com/NixOS/nixpkgs/commit/0c7af2f43d9e9450026f57c59226be934763ee97) ocamlPackages.ladspa: init at 0.2.2
* [`2d1cfba3`](https://github.com/NixOS/nixpkgs/commit/2d1cfba3490ef02b5d5e40540289b171e54dab0a) ocamlPackages.dssi: init at 0.1.5
* [`0d1c745d`](https://github.com/NixOS/nixpkgs/commit/0d1c745d7a7bd3af335a512f71b009916d9793bf) conan: pin distro==1.5.0 to fix build
* [`1a99b8ed`](https://github.com/NixOS/nixpkgs/commit/1a99b8ed14d329de3b9acb7e42fc033f0f731c2f) conan: 1.43.1 -> 1.47.0
* [`1f6537a1`](https://github.com/NixOS/nixpkgs/commit/1f6537a15dc5c1095d3b2b761b3c0621fcd53ae1) python310Packages.findpython: 0.1.4 -> 0.1.5
* [`9e0568f7`](https://github.com/NixOS/nixpkgs/commit/9e0568f78101f5d3cc03ec5987f130ddd16460cd) python3Packages.pytelegrambotapi: add pythonImportsCheck
* [`ec129be2`](https://github.com/NixOS/nixpkgs/commit/ec129be253486b4e7df1bcade24c8b1c0fe3f731) python3Packages.azure-mgmt-datafactory: disable on older Python releases
* [`2e5cf118`](https://github.com/NixOS/nixpkgs/commit/2e5cf118420ef77f7e2a7380429a034bdfd5a978) cuneiform: fix build with gcc 11
* [`54979403`](https://github.com/NixOS/nixpkgs/commit/54979403b99d476dcd2d025af254aafda81c4b7a) linuxPackages.virtualboxGuestAdditions: xserverABI
* [`c52e644a`](https://github.com/NixOS/nixpkgs/commit/c52e644aeaec6e036e79b34e231275f3c8090913) oh-my-zsh: 2022-04-13 -> 2022-04-14 ([nixos/nixpkgs⁠#168756](https://togithub.com/nixos/nixpkgs/issues/168756))
* [`506050b5`](https://github.com/NixOS/nixpkgs/commit/506050b57f7e781c37c442ffbdb5cd4697be4a03) emacs: prepare webp support for versions >=29.1
* [`056fd0af`](https://github.com/NixOS/nixpkgs/commit/056fd0af5e405b3525c9e11c08a56017b99a5ec0) pathvector: init at 5.11.1
* [`460d8a60`](https://github.com/NixOS/nixpkgs/commit/460d8a60d24d805c052b01e3bbeba169331e0726) amass: 3.19.1 -> 3.19.2
* [`46464911`](https://github.com/NixOS/nixpkgs/commit/46464911756ced488d10404769e2bb45434765ac) nixos/nbd: fix nbd-server config section ordering
* [`c07da190`](https://github.com/NixOS/nixpkgs/commit/c07da190f5a14307222016bed70170efacdf9043) libsForQt5.liblastfm: fixup build with gcc 11
* [`90edec05`](https://github.com/NixOS/nixpkgs/commit/90edec053b58e1dafb2c76c59604bb5c87fade40) gringo: fixup build with gcc 11
* [`d219cdcd`](https://github.com/NixOS/nixpkgs/commit/d219cdcd8f785faa52632358151de08ad01b3e0c) uasm: 2.53 -> 2.55
* [`6a5b8390`](https://github.com/NixOS/nixpkgs/commit/6a5b8390695068823f80131be4801297d963880e) usbrelay: init at 0.9
* [`8d81114a`](https://github.com/NixOS/nixpkgs/commit/8d81114a3768284574cbb4d2828dacfd9bde7d6b) _7zz: build with useUasm in more platforms
* [`7382d8d8`](https://github.com/NixOS/nixpkgs/commit/7382d8d8568d5dd52948800a1056703381661f99) google-cloud-cpp: fix build by overriding abseil-cpp cxxStandard
* [`904432fd`](https://github.com/NixOS/nixpkgs/commit/904432fdba1adf1c7203c281cad4e6861a9dafa2) virt-manager: fix setuptools-61 breaking change
* [`1dfcf7d2`](https://github.com/NixOS/nixpkgs/commit/1dfcf7d2e7515d5856d7756c39e7fe9c0a9e5484) libsForQt5.liblastfm: revert addition of flags on darwin
* [`619c43a5`](https://github.com/NixOS/nixpkgs/commit/619c43a56e6fd2a768ef0d50d11cede5f6036581) python3Packages.add-trailing-comma: 2.2.1 -> 2.2.3
* [`654e1d7f`](https://github.com/NixOS/nixpkgs/commit/654e1d7f6325608e07beb60a1c3d2b023dccfa38) veracrypt: 1.24-Update7 -> 1.25.9
* [`ba645ea1`](https://github.com/NixOS/nixpkgs/commit/ba645ea156ff1a20341e0d8d529ed1833b24e1a1) python3Packages.svg-path: disable on older Python releases
* [`78d682f2`](https://github.com/NixOS/nixpkgs/commit/78d682f23efabf5ba7bf33326205151c5a63ae2e) ocamlPackages.frontc: 3.4.1 -> 4.1.0
* [`3a510ac1`](https://github.com/NixOS/nixpkgs/commit/3a510ac1ce5a81f11bba878be16e6fe6816d7586) ocamlPackages.bap: 2.2.0 -> 2.4.0
* [`2e4ce509`](https://github.com/NixOS/nixpkgs/commit/2e4ce50912e2f8c3236b9e96bc2c7a4b236fe20a) ocamlPackages.bap: use default version of llvm
* [`35d05542`](https://github.com/NixOS/nixpkgs/commit/35d055425a831c2caa200b2de54cf17a9894b89c) dune_3: 3.0.3 -> 3.1.0
* [`ee122a33`](https://github.com/NixOS/nixpkgs/commit/ee122a33378d60a1699463733bd7fdb60fd389cb) ocamlPackages.ffmpeg: 1.1.0 -> 1.1.3
* [`ce602086`](https://github.com/NixOS/nixpkgs/commit/ce602086b5994df8496516e4e74b6eb0fc282ee8) uasm: fix compilation on darwin
* [`b2d35019`](https://github.com/NixOS/nixpkgs/commit/b2d35019c024fed6d0e3f8fa604492bbf58b3d5e) _7zz: cross-compilation fixes
* [`e277cf18`](https://github.com/NixOS/nixpkgs/commit/e277cf18e20f40b69a8a54af183b8218a7daa74a) uasm: add testVersion
* [`21a40059`](https://github.com/NixOS/nixpkgs/commit/21a40059dd8dd97d90941150854432b39f0445c0) _7zz: useUasm only in x86 platforms
* [`f0846b14`](https://github.com/NixOS/nixpkgs/commit/f0846b148399f9c8b064f0e9135420410e720b91) ablog: 0.10.23 -> 0.10.24
* [`99199524`](https://github.com/NixOS/nixpkgs/commit/9919952421f39d20eb28e0bbeaf7206d6950bf6c) bada-bib: 0.6.1 -> 0.6.2
* [`38070f95`](https://github.com/NixOS/nixpkgs/commit/38070f95d96b1a7525648b9053d6aa5f5930d1ce) python310Packages.pywayland: 0.4.11 -> 0.4.12
* [`f99d89f7`](https://github.com/NixOS/nixpkgs/commit/f99d89f77df84e8869c38c959c9db3d77aee3da9) python3Packages.tensorflow-bin: 2.7.0 -> 2.8.0
* [`107284ee`](https://github.com/NixOS/nixpkgs/commit/107284eec440a1c3be532cd5ecfc202269c4aa41) clojure-lsp: 2022.03.31-20.00.20 -> 2022.04.18-00.59.32
* [`9d0e77b3`](https://github.com/NixOS/nixpkgs/commit/9d0e77b38e0f8f82b9d26bf9044ff843184155aa) python310Packages.vispy: 0.9.6 -> 0.10.0
* [`64240018`](https://github.com/NixOS/nixpkgs/commit/64240018e04560c49288daf043f113d5c0b67829) header-file-mode: init at version unstable-2022-04-19
* [`984e8f83`](https://github.com/NixOS/nixpkgs/commit/984e8f83269ddff9d0e15aec13eb16538b64e47d) python310Packages.pex: 2.1.79 -> 2.1.80
* [`49f40370`](https://github.com/NixOS/nixpkgs/commit/49f403701c12b3232e8c3d987c884541b4c5a05c) gensio: 2.3.6 -> 2.3.7
* [`e76dad1a`](https://github.com/NixOS/nixpkgs/commit/e76dad1a77ed5bf5cc5253d0ed9a842a1c135e7f) git-review: 2.2.0 -> 2.3.0
* [`d9fa620b`](https://github.com/NixOS/nixpkgs/commit/d9fa620b828bf252bcb0d3fcc1d3de3e3d72bf3f) python310Packages.pynetbox: 6.6.1 -> 6.6.2
* [`5164f505`](https://github.com/NixOS/nixpkgs/commit/5164f50539a2feef2eea1708b504181c4b53558a) python310Packages.stripe: 2.72.0 -> 2.73.0
* [`57998352`](https://github.com/NixOS/nixpkgs/commit/579983525cea451e5e5ab25934fd38bedfd58c15) gnumeric: 1.12.51 -> 1.12.52
* [`0b3247ed`](https://github.com/NixOS/nixpkgs/commit/0b3247ed0681a979c2b1108aed7b8414287f2810) python310Packages.bitstruct: 8.13.0 -> 8.14.0
* [`10ce5761`](https://github.com/NixOS/nixpkgs/commit/10ce57613612bdfc460471b5300d48c8ca4e4598) goffice: 0.10.51 -> 0.10.52
* [`e6acd435`](https://github.com/NixOS/nixpkgs/commit/e6acd435ca2d41fa581c59d6ab90bf67a3f230ca) radicale: 3.1.5 -> 3.1.6
* [`d71cc5bb`](https://github.com/NixOS/nixpkgs/commit/d71cc5bbadc09e344950e65763e1eb2ed55df1c1) header-file-mode: fix build
* [`1344d5fe`](https://github.com/NixOS/nixpkgs/commit/1344d5fe60419a91b580338199d37666f3c33fed) cudaPackages_11_{4,5,6}.cudatoolkit: gcc10 -> gcc11
* [`92a001fa`](https://github.com/NixOS/nixpkgs/commit/92a001fa1c230f3fc8a810790738a66b35855397) python3Packages.jaxlib: pin cudaPackages to 11.6
* [`7dca9989`](https://github.com/NixOS/nixpkgs/commit/7dca99892388bb0b0fd21bd4033a5c0c0a6fb208) python310Packages.pykeyatome: 1.4.1 -> 1.5.1
* [`d5b64650`](https://github.com/NixOS/nixpkgs/commit/d5b646502d9d980968ccd40ebb018d1f307713b1) lutris-unwrapped: 0.5.10 -> 0.5.10.1
* [`7c5e8f44`](https://github.com/NixOS/nixpkgs/commit/7c5e8f44a9fc9bd12c5fc321fad9c7676007e578) python3Packages.bitstruct: add pythonImportsCheck
* [`772ac30e`](https://github.com/NixOS/nixpkgs/commit/772ac30ee8cd49f285d4ccd4eb469d3c2050e1d5) python310Packages.awscrt: 0.13.8 -> 0.13.9
* [`d98ccca9`](https://github.com/NixOS/nixpkgs/commit/d98ccca9b5f62bc6270427ac840a6896f32f2650) python3Packages.aiodiscover: 1.4.8 -> 1.4.9
* [`cfb5ca06`](https://github.com/NixOS/nixpkgs/commit/cfb5ca06dbd5896a5acfe9666efae1b989a68222) python3Packages.meteofrance-api: adjust pytz constraint
* [`9b8dbb2e`](https://github.com/NixOS/nixpkgs/commit/9b8dbb2eaf695d6bf7c543627ec6bb837e52b057) checkov: 2.0.1067 -> 2.0.1068
* [`c10c8912`](https://github.com/NixOS/nixpkgs/commit/c10c8912eed56322bbe5e2124e53d0361d2017cb) strawberry: Add gst-libav dependency
* [`c0cc9045`](https://github.com/NixOS/nixpkgs/commit/c0cc9045e2b312629ad39abeb41890bb7501fdaf) python3Packages.schema-salad: disable failing test
* [`b993d978`](https://github.com/NixOS/nixpkgs/commit/b993d978bf88d006e5c62aecfb917d07fce345c6) opensnitch-ui: 1.5.0 -> 1.5.1
* [`58d503fe`](https://github.com/NixOS/nixpkgs/commit/58d503fe3cb5f0928f2189f79dea6836bef8dd2f) python3Packages.html-sanitizer: disable failing test
* [`4b77f8de`](https://github.com/NixOS/nixpkgs/commit/4b77f8de8c2396b0a8893c08acfc25c1fa089487) python3Packages.pyee: add missing dependency
* [`b05096d0`](https://github.com/NixOS/nixpkgs/commit/b05096d0d9f696095cde73297a9f3812f1baa380) python3Packages.webthing: disable on older Python releases
* [`430c5697`](https://github.com/NixOS/nixpkgs/commit/430c56976febb06ab26d839ca45b7c52d46d74f5) cloud-hypervisor: 22.1 -> 23.0
* [`b2b02f30`](https://github.com/NixOS/nixpkgs/commit/b2b02f3026e2e44760d933af10525154c4799bae) ocamlPackages.rebez: init unstable-2019-06-20
* [`1b1aa470`](https://github.com/NixOS/nixpkgs/commit/1b1aa47052432c3be2c36e2e4e3265695ecc60cf) python310Packages.pg8000: 1.25.0 -> 1.26.0
* [`42973eb2`](https://github.com/NixOS/nixpkgs/commit/42973eb2be01df0faf6c2456024f37f7d26c1dca) python3Packages.pywlroots: 0.15.12 -> 0.15.13
* [`0c15d80f`](https://github.com/NixOS/nixpkgs/commit/0c15d80f6b77da0cb5b2181a670be9912e7361a2) kratos: upgrade 0.8.3-alpha.1.pre.0 -> 0.9.0-alpha.3
* [`a8d61ae5`](https://github.com/NixOS/nixpkgs/commit/a8d61ae53092520faba23759d90b8e42f32fbb17) Revert "rcs: fix build w/glibc-2.34"
* [`b7642726`](https://github.com/NixOS/nixpkgs/commit/b7642726f98375eb8f9bdda4cabd7d82376144d7) unigine-valley: add desktop icon and change libGL to libglvnd
* [`0edfd89d`](https://github.com/NixOS/nixpkgs/commit/0edfd89d6e24064d2b0fd0853b8e19c42906dc1b) nixos/tools: add copySystemConfiguration to configuration file template
* [`47165382`](https://github.com/NixOS/nixpkgs/commit/471653824c1d2bf42f107c3f7942ba0d72aa7951) pkgsMusl.haskell.compiler.ghc884: bootstrap using normal binary ghc
* [`d0988711`](https://github.com/NixOS/nixpkgs/commit/d09887119f7269177e8bac0244b66ff00943594e) 1password-gui-beta: add at 8.7.0-49
* [`c6950658`](https://github.com/NixOS/nixpkgs/commit/c6950658dac54fe754969181dfa209fd61ce289e) python3Packages.pyppeteer: 0.2.6 -> 1.0.2
* [`55742089`](https://github.com/NixOS/nixpkgs/commit/557420891daa30aab3b21799b46cbf813a6f2fcb) python310Packages.asdf: 2.11.0 -> 2.11.1
* [`655d3780`](https://github.com/NixOS/nixpkgs/commit/655d3780780713d16a9a5471def745b45aa94c20) python3Packages.fastapi: 0.75.1 -> 0.75.2
* [`55022cbe`](https://github.com/NixOS/nixpkgs/commit/55022cbea741f9a17dc08f18da0bbb33023e64ea) python3Packages.ormar: update substituteInPlace
* [`26e607f0`](https://github.com/NixOS/nixpkgs/commit/26e607f03587e12e45107a9cadc728e08fa3028d) python3Packages.mypy-boto3-s3: 1.21.27.post1 -> 1.21.34
* [`8be47229`](https://github.com/NixOS/nixpkgs/commit/8be4722999db6571c4f2a531c55e2395da13771c) python310Packages.azure-keyvault-keys: 4.5.0 -> 4.5.1
* [`0cb205e3`](https://github.com/NixOS/nixpkgs/commit/0cb205e35513d8d9a0e5b5cf8a25886ad9d724f4) xorg.xf86videointel: 2019-12-09 -> 2021-01-15
* [`6a5bf9d6`](https://github.com/NixOS/nixpkgs/commit/6a5bf9d6863cafb83131a20f11bec5842e9d5ea7) miniserve: add manpage
* [`1a53c295`](https://github.com/NixOS/nixpkgs/commit/1a53c295bfaad2871b339c4253428c0620ea99dc) python3Packages.webssh: disable failing test
* [`09b8f108`](https://github.com/NixOS/nixpkgs/commit/09b8f108023349a7c414ddcfb5d0b4703ad06c4c) miniserve: 0.19.3 -> 0.19.4
* [`627cc295`](https://github.com/NixOS/nixpkgs/commit/627cc295bb3ecaf5114808956e76a986f4d5bcb3) qownnotes: 22.3.4 -> 22.4.1
* [`87438184`](https://github.com/NixOS/nixpkgs/commit/874381847b1063b811c4631244a77356335d04ce) gnumeric: mark aarch64-darwin as broken
* [`905fad4c`](https://github.com/NixOS/nixpkgs/commit/905fad4c4b5c80b9d802d1780d56418c55be60ab) darktable: add glib-networking dependency
* [`635d8882`](https://github.com/NixOS/nixpkgs/commit/635d888296f777bca841a95a02f99e2c5b9eb396) python3Packages.pywlroots: disable on older Python releases
* [`f0c565c1`](https://github.com/NixOS/nixpkgs/commit/f0c565c1278153236f93b53d744beef618653778) comma: 1.1.0 -> 1.2.3
* [`4cb9b04b`](https://github.com/NixOS/nixpkgs/commit/4cb9b04b1a3abc441b5839360f2ca982fb395d32) n8n: 0.172.0 → 0.173.0
* [`b8c192b9`](https://github.com/NixOS/nixpkgs/commit/b8c192b98e13d09be3789e527f1f2358d46666f5) linuxPackages.virtualboxGuestAdditions: xserverABI cleanup
* [`b0933bda`](https://github.com/NixOS/nixpkgs/commit/b0933bdae7c3e5bac3fff2ab4b004e9780d00baf) python3Packages.pywebview: 3.6.1 -> 3.6.3
* [`a3c257c3`](https://github.com/NixOS/nixpkgs/commit/a3c257c38fbfb0158c988c8c1790e8d593009181) python: panel: 0.12.7 -> 0.13.0
* [`437f2c74`](https://github.com/NixOS/nixpkgs/commit/437f2c747b223a87de7a0a4aecf4ec9a9515a221) python3Packages.pytest-mpl: fix build
* [`815299d4`](https://github.com/NixOS/nixpkgs/commit/815299d47872889093b428aff730eec84c93e95e) cantoolz: disable failing test
* [`0e17b364`](https://github.com/NixOS/nixpkgs/commit/0e17b3643ce87c23541395a46f7e42229c7e00fd) heroic: 2.2.1 -> 2.2.6
* [`2d1b9c06`](https://github.com/NixOS/nixpkgs/commit/2d1b9c0632dbbbf2d150bb0de027cbbd2ea9400d) tdlib: 1.8.1 -> 1.8.3
* [`7b6f2b6c`](https://github.com/NixOS/nixpkgs/commit/7b6f2b6c8a093766d6e3276ab7537b3dd231acf9) python3Packages.graphene: fix graphql-core==3.2.0 compat
* [`7dcfa05a`](https://github.com/NixOS/nixpkgs/commit/7dcfa05ac8d87dfba8885c2e6b7bee4286291f9c) oh-my-zsh: 2022-04-14 -> 2022-04-18 ([nixos/nixpkgs⁠#169289](https://togithub.com/nixos/nixpkgs/issues/169289))
* [`4230a224`](https://github.com/NixOS/nixpkgs/commit/4230a224535362d11f1bdb7f2ac39562ee71caba) signal-desktop: 5.38.0 -> 5.39.0
* [`a6bc9e05`](https://github.com/NixOS/nixpkgs/commit/a6bc9e05cf44900c7eca2846935530c98f1c1b62) matrix-synapse: 1.56.0 -> 1.57.0
* [`de3f5c22`](https://github.com/NixOS/nixpkgs/commit/de3f5c22703ba82c6c59cb94ae3af15a2239b01f) python310Packages.txtorcon: fix test execution, cleanup
* [`56c72fce`](https://github.com/NixOS/nixpkgs/commit/56c72fce7d2190ac2bbb5da2a7a3b51c0e57c4fe) spago: get working by using aeson-1.5.6.0
* [`beee56ee`](https://github.com/NixOS/nixpkgs/commit/beee56eeefc4a3ac3cf87cd29491c9a62e6abbea) python310Packages.findpython: 0.1.5 -> 0.1.6
* [`fc5bf744`](https://github.com/NixOS/nixpkgs/commit/fc5bf74480f52f243b4c9b80fd4be2b95f060079) mle: fix on darwin
* [`9568a7af`](https://github.com/NixOS/nixpkgs/commit/9568a7afef30d78eb422bf2a78c972d90c9f51b9) binutils: fix cross compilation from darwin
* [`2eeed290`](https://github.com/NixOS/nixpkgs/commit/2eeed2904aba82cc5af46e9925dcdb2a3121242d) python3Packages.aiotractive: 0.5.3 -> 0.5.4
* [`021fad38`](https://github.com/NixOS/nixpkgs/commit/021fad3832c5b234be31c31e5f69394745e0a2d3) python3Packages.graphene-django: unstable-2021-06-11 -> unstable-2022-03-03
* [`896c716d`](https://github.com/NixOS/nixpkgs/commit/896c716d1b8fa7b39ed1c96f4ae9ec3f3e957a37) netbox: 3.1.10 -> 3.2.1
* [`e8f99f7f`](https://github.com/NixOS/nixpkgs/commit/e8f99f7fd686936a48e0a212ab489ea73090ee67) scala-cli: 0.1.3 -> 0.1.4
* [`30f1776d`](https://github.com/NixOS/nixpkgs/commit/30f1776d29a0beb52e0c8e78e30f3d72a644fe24) ledger-live-desktop: 2.40.2 -> 2.40.4
* [`e1212c4c`](https://github.com/NixOS/nixpkgs/commit/e1212c4c2812e92d1c7cbed63eb0e417de89a430) pigeon: unstable -> 1.1.0 ([nixos/nixpkgs⁠#169123](https://togithub.com/nixos/nixpkgs/issues/169123))
* [`4d5ce1c2`](https://github.com/NixOS/nixpkgs/commit/4d5ce1c2b6fc48b15a9e84439f5970b41d221fe6) maintainers: add melias122
* [`d89adda6`](https://github.com/NixOS/nixpkgs/commit/d89adda6ea57e61f2ea8d1c0dc50a57d3587742f) libdvbcsa: init at 1.1.0
* [`2085f10e`](https://github.com/NixOS/nixpkgs/commit/2085f10ea4f88acfb0c02e40700438b3d6158511) nix-template: 0.2.0 -> 0.3.0 ([nixos/nixpkgs⁠#169282](https://togithub.com/nixos/nixpkgs/issues/169282))
* [`047473aa`](https://github.com/NixOS/nixpkgs/commit/047473aa32471086d42177c3b70c573ea1b748db) nixos/nextcloud: Support create database locally
* [`d924de58`](https://github.com/NixOS/nixpkgs/commit/d924de58be179e38ce352171055c2832c3ca4d97) cudaPackages.cudnn: migrate to redist cuda, fix missing zlib ([nixos/nixpkgs⁠#168748](https://togithub.com/nixos/nixpkgs/issues/168748))
* [`e56192d8`](https://github.com/NixOS/nixpkgs/commit/e56192d840768a1e7cc9d66ea0e533d728fbc55b) cudaPackages: recurse
* [`0f316e55`](https://github.com/NixOS/nixpkgs/commit/0f316e5553561774a795f6ec69949ab70bd93a8f) emacsWrapper: fix mishandling of empty package list
* [`7c55d1d1`](https://github.com/NixOS/nixpkgs/commit/7c55d1d1646db5645d7e82613506fdaf7853d423) gpu-burn: fix build
* [`aa2a3960`](https://github.com/NixOS/nixpkgs/commit/aa2a396048f3dfc42dc17bc99ef68ce7cc9c40d7) graalvmXX-ce: refactor
* [`834faa24`](https://github.com/NixOS/nixpkgs/commit/834faa24b416c549c2b6da70024f7a9b13d8a835) coqPackages.Verdi: 20210524 → 20211026
* [`cc12a292`](https://github.com/NixOS/nixpkgs/commit/cc12a2922114ec184b4ab5f33a695ce689b6065f) librealsenseWithCuda: fix build
* [`4cbce553`](https://github.com/NixOS/nixpkgs/commit/4cbce55388652ebb2b394fa4ad91209bcfb76fd9) python3Packages.cupy: fix build
* [`551b703f`](https://github.com/NixOS/nixpkgs/commit/551b703fd1df586f68282ca4fa7735b2c9945a16) python3Packages.pyvesync: 2.0.1 -> 2.0.2
* [`c9c6d2a1`](https://github.com/NixOS/nixpkgs/commit/c9c6d2a18ac4f114030e669ae95f9f00f43a1f77) talosctl: 1.0.2 -> 1.0.3
* [`85020dcb`](https://github.com/NixOS/nixpkgs/commit/85020dcbda5ec9697e0906cb8e011006fd8573e2) qtmultimedia: restrict libpulseaudio to linux
* [`bf796813`](https://github.com/NixOS/nixpkgs/commit/bf7968139acdb2b7b80f4f7f7f546c8df1c39a2b) chromium: Fix Wayland screen sharing
* [`23689c5f`](https://github.com/NixOS/nixpkgs/commit/23689c5f21e84ae02d6e1c4d465fe773609f82e9) pulumi-bin: 3.28.0 -> 3.29.1
* [`088112c8`](https://github.com/NixOS/nixpkgs/commit/088112c89714e6daf490cb3877773e83c6fbdea2) acpilight: set mainProgram = "xbacklight"
* [`f394cc6c`](https://github.com/NixOS/nixpkgs/commit/f394cc6c547f1162dac673f0fba11eca75022a98) aws-sdk-cpp: 1.9.150 → 1.9.238
* [`a6b4d66b`](https://github.com/NixOS/nixpkgs/commit/a6b4d66b773cf040ce5a0980aa11e4457df44548) python3Packages.python-vagrant: use pyproject format
* [`fe21e62b`](https://github.com/NixOS/nixpkgs/commit/fe21e62b9a7d6962e734f4ad51e8720230bb6090) python3Packages.kaldi-active-grammar: propagate six
* [`b3b47962`](https://github.com/NixOS/nixpkgs/commit/b3b47962f04d7fa8448bd5748eb0532c6f4fd876) python3Packages.flask-seasurf: 0.3.0 -> 1.1.1
* [`98e82ea0`](https://github.com/NixOS/nixpkgs/commit/98e82ea091d4e08870cc2c8b24d398ccdf186b49) python3Packages.flask-bcrypt: 0.7.1 -> 1.0.1
* [`3c1742cc`](https://github.com/NixOS/nixpkgs/commit/3c1742cc089399ce64e80564d293e7c2b6461786) Revert "python3Packages.gym: 0.21.0 -> 0.22.0"
* [`683e87e2`](https://github.com/NixOS/nixpkgs/commit/683e87e2ebb23bc873b7f6bbd3a4419341d06181) moltenvk: 1.1.8 -> 1.1.9
* [`1ac3bb0c`](https://github.com/NixOS/nixpkgs/commit/1ac3bb0c7d1220db270477dc4300365c0d073691) python3Packages.kbcstorage: rename from sapi-python-client; fix build
* [`f9c5259b`](https://github.com/NixOS/nixpkgs/commit/f9c5259b71c83173fb20bfc93cfaa9eb343aa12b) python3Packages.sendgrid: propagate six
* [`f2d98aed`](https://github.com/NixOS/nixpkgs/commit/f2d98aedb13d662eb3cc273e06f96a3195467b3d) python3Packags.geoalchemy2: disable test that depend on pgsql instance
* [`67884e4e`](https://github.com/NixOS/nixpkgs/commit/67884e4e9a1e057bcdd049879848d98d734cd03d) python3Packages.pyfaidx: disable failing tests
* [`16e78118`](https://github.com/NixOS/nixpkgs/commit/16e781187a61a84a5ff90ff9769ebf1acd28f31d) cfripper: 1.8.0 -> 1.9.0
* [`d8eb5fd7`](https://github.com/NixOS/nixpkgs/commit/d8eb5fd7a4e7c9e86012ea4f84b3c138b6534fec) python3Packages.flask-admin: disable test that fails with werkzeug>=2.1.0
* [`d09ee141`](https://github.com/NixOS/nixpkgs/commit/d09ee141f077cc5ad42acff11a094bad8336c09b) python3Packages.radio_beam: propagate numpy, scipy, six
* [`522afed5`](https://github.com/NixOS/nixpkgs/commit/522afed5a67e6944135359bc4621633058b5adcc) cudatext: 1.161.0 -> 1.162.0
* [`be73d666`](https://github.com/NixOS/nixpkgs/commit/be73d666287ccf7ab7e6c1fed477ef47f078cd05) Create a GAMES/LGAMES tag
* [`3469e707`](https://github.com/NixOS/nixpkgs/commit/3469e707e19f73027230e654dd80a8ae21f407f5) python310Packages.pycfmodel: 0.19.0 -> 0.19.1
* [`6efbfd12`](https://github.com/NixOS/nixpkgs/commit/6efbfd12e7a595833f6c26d350ed89bcb41bbb68) inkscape: add pyserial
* [`74ccb557`](https://github.com/NixOS/nixpkgs/commit/74ccb557e2210285ec870d7f5d7b83cf1267c0d1) python310Packages.pex: 2.1.80 -> 2.1.81
* [`cc3a4082`](https://github.com/NixOS/nixpkgs/commit/cc3a4082acb899ce4a6125052a8091183c270bbd) khronos: 3.6.6 -> 3.7.0
* [`2272244c`](https://github.com/NixOS/nixpkgs/commit/2272244c04d264272cd36d0e848620a15e61c0ae) notejot: 3.4.9 -> 3.5.1
* [`a4512530`](https://github.com/NixOS/nixpkgs/commit/a4512530fe35a0a2fa2e1322e13b332adefe4b13) gnome.simple-scan: 42.0 → 42.1
* [`efd13315`](https://github.com/NixOS/nixpkgs/commit/efd13315f77c6313f71feced31fef6fa972e0964) ocamlPackages.brisk-reconciler: init unstable-2020-12-02
* [`4389bfe8`](https://github.com/NixOS/nixpkgs/commit/4389bfe8f033695ae32bee8aed7d8b0d0d646411) gspell: 1.9.1 -> 1.10.0
* [`cd8f1c2f`](https://github.com/NixOS/nixpkgs/commit/cd8f1c2f111880de24e577599edbcb139eec3571) rcs: cleanup remove unecessary input
* [`d386719c`](https://github.com/NixOS/nixpkgs/commit/d386719c7e6ffc5baa14ec5bdf1f1d3350b3da81) python3Packages.python-miio: update decorator
* [`6e06f630`](https://github.com/NixOS/nixpkgs/commit/6e06f630400ad9e4c364862efab1ba1c9561c954) python3Packages.readme_renderer: 34.0 -> 35.0
* [`2e52d5c8`](https://github.com/NixOS/nixpkgs/commit/2e52d5c892e03a9f9d61d2479b10c908d9bdec39) naproche: 0.1.0.0 -> 2022-04-19
* [`ab0788c8`](https://github.com/NixOS/nixpkgs/commit/ab0788c8f5c2109de29b3be5858fc32a9332a36d) ocamlPackages.flex: init unstable-2020-09-12
* [`dca08f64`](https://github.com/NixOS/nixpkgs/commit/dca08f645d6632449f5a5a1e329296a87033503f) naproche: add to release-haskell.nix
* [`30943ab9`](https://github.com/NixOS/nixpkgs/commit/30943ab97bb29bfd55c3972dddddb9cd26bf5591) unifont: 14.0.02 -> 14.0.03
* [`3540cc8d`](https://github.com/NixOS/nixpkgs/commit/3540cc8d16870c2a39f4254152e9be1cb2214473) ocamlPackages.hacl-star-raw: fix aarch64-darwin
* [`27245956`](https://github.com/NixOS/nixpkgs/commit/27245956af1f03ceb5be370c8218e2bbdd6c32ea) trash-cli: 0.21.10.24 -> 0.22.4.16
* [`aa305e50`](https://github.com/NixOS/nixpkgs/commit/aa305e509322a6cefa4660402689b45bbc292f30) python3Packages.sentry-sdk: disable tests
* [`7383ec70`](https://github.com/NixOS/nixpkgs/commit/7383ec7045c66d11cf48dad2afee8d6920e568aa) python3Packages.setupmeta: add missing input
* [`1e03b381`](https://github.com/NixOS/nixpkgs/commit/1e03b381e7af7e167cace24b0fc72754e794e40c) python310Packages.aiohomekit: 0.7.16 -> 0.7.17
* [`9aa4c5db`](https://github.com/NixOS/nixpkgs/commit/9aa4c5dbfc806b2f71ad351fc79d5d0312e0caa4) isabelle: Make closer to upstream
* [`a7e62c21`](https://github.com/NixOS/nixpkgs/commit/a7e62c21c1fbb36588e06dadd252f3fced6dbda2) ocamlPackages.pure-splitmix: init at 0.3
* [`4162f7d2`](https://github.com/NixOS/nixpkgs/commit/4162f7d27984ae92c3bbd803f6af323934ca22dc) python3Packages.xdis: 6.0.3 -> unstable-2022-04-13
* [`45e8dc9a`](https://github.com/NixOS/nixpkgs/commit/45e8dc9a14d19f9fe067ea5f82a71755cdcfc5b7) python310Packages.apprise: 0.9.7 -> 0.9.8
* [`5a27ee3e`](https://github.com/NixOS/nixpkgs/commit/5a27ee3e7ce84e79198889cb19536c01f963c4e3) dragonfly: 0.32.0 -> 0.35.0
* [`e7e330d1`](https://github.com/NixOS/nixpkgs/commit/e7e330d112783de9976c4c299a20e04b691b2c25) python3Packages.kaldi-active-grammar: add note about updating dragonfly
* [`a61732d4`](https://github.com/NixOS/nixpkgs/commit/a61732d482a3df79be24dc8152d4b41624c2697c) conftest: 0.30.0 -> 0.31.0
* [`05554d6c`](https://github.com/NixOS/nixpkgs/commit/05554d6c575286d2fd80405222774d8415c995cb) ft2-clone: 1.52 -> 1.54
* [`1f285a90`](https://github.com/NixOS/nixpkgs/commit/1f285a9046b70ba8289f84ce842b0aff2cb8b161) pt2-clone: 1.43 -> 1.46
* [`5799e258`](https://github.com/NixOS/nixpkgs/commit/5799e2580d4516c616bbf478090098ea1d6a6903) franz: 5.6.1 -> 5.9.2
* [`8059cfce`](https://github.com/NixOS/nixpkgs/commit/8059cfcecb9d71cd6bbdcf77366bc36ae4ceca56) python3Packages.flask-security-too: 4.1.3 -> 4.1.4
* [`7de75144`](https://github.com/NixOS/nixpkgs/commit/7de75144a7c8fa4f28a91d6ca68dd2d31949926a) python3Packages.shtab: 1.5.3 -> 1.5.4
* [`5d5fe2be`](https://github.com/NixOS/nixpkgs/commit/5d5fe2be203a122e668f183e61e83ede43ff04b7) python310Packages.cyclonedx-python-lib: 2.2.0 -> 2.3.0
* [`52a744b7`](https://github.com/NixOS/nixpkgs/commit/52a744b7f89a9add978bc1d6cc5d92352580eca4) testers.testEqualDerivation: move from build-support/test-equal-derivation.nix
* [`572131c6`](https://github.com/NixOS/nixpkgs/commit/572131c6a945069dba5a12a0354df8254224a458) nixos/mailman: ensure Postfix is started after Mailman
* [`20684d72`](https://github.com/NixOS/nixpkgs/commit/20684d72b7d84b7e20b3eae7a2d325806b379dc7) maintainers: update ashley
* [`39396a4b`](https://github.com/NixOS/nixpkgs/commit/39396a4bbbd295aeba13b97ea4934833c5a4274d) python310Packages.faraday-plugins: 1.6.2 -> 1.6.3
* [`a49e4933`](https://github.com/NixOS/nixpkgs/commit/a49e4933767acaafebda4c94ac629c2cfdc48f4b) python3Packages.httpx-ntlm: relax dependency constraints
* [`6b70d7a4`](https://github.com/NixOS/nixpkgs/commit/6b70d7a4f0e31409b928609a909f9767634f07f0) addlicense: init at 1.0.0
* [`581998a7`](https://github.com/NixOS/nixpkgs/commit/581998a73e648a93978570e70017939acb3a6f8a) python39Packages.pytest-testmon: fix build
* [`92555464`](https://github.com/NixOS/nixpkgs/commit/925554648196d96644fcdebc8aa2818bbe5761b0) richgo: enable tests
* [`88e0bd61`](https://github.com/NixOS/nixpkgs/commit/88e0bd61198f79a50d2e03cd07d6b48a8e8e9445) yafetch: unstable-2021-07-18 -> unstable-2022-04-20
* [`9d733f3d`](https://github.com/NixOS/nixpkgs/commit/9d733f3d4975fb3c516a2bf2bf1bc6f50781a553) qemu: 6.2.0 -> 7.0.0
* [`325a5254`](https://github.com/NixOS/nixpkgs/commit/325a525467f6200eae76a1406b1684d02536c8e4) nixos/consul: allow ipv6-only
* [`6bd609ac`](https://github.com/NixOS/nixpkgs/commit/6bd609ac0eed972c46a3e0624e65570e18d8c016) vimPlugins: update
* [`36b6d377`](https://github.com/NixOS/nixpkgs/commit/36b6d377c06b9fb5589cabe4b7f26784bb3ab21b) fluxcd: 0.28.5 -> 0.29.1
* [`9a6c54e2`](https://github.com/NixOS/nixpkgs/commit/9a6c54e28b821469e9268525be08c6eee245628f) terraform.mkProvider: include rev in src
* [`e148dfe8`](https://github.com/NixOS/nixpkgs/commit/e148dfe8b866064124677c32a4f0dab7ab7a41b0) metal-cli: 0.7.3 -> 0.7.4
* [`e551794b`](https://github.com/NixOS/nixpkgs/commit/e551794bfe83c9140bfb94e6ac843e58a7b77718) sccache: Fix sccache compilation on aarch64-linux platform
* [`2696f4c6`](https://github.com/NixOS/nixpkgs/commit/2696f4c69688d6c31fb8363fdf556e06047eb068) terraform: 1.1.8 -> 1.1.9 ([nixos/nixpkgs⁠#169452](https://togithub.com/nixos/nixpkgs/issues/169452))
* [`3924c086`](https://github.com/NixOS/nixpkgs/commit/3924c086f64c71bdacf6d104f8b0010dd18a8760) python310Packages.pixcat: init at 0.1.4 ([nixos/nixpkgs⁠#162556](https://togithub.com/nixos/nixpkgs/issues/162556))
* [`b2613561`](https://github.com/NixOS/nixpkgs/commit/b261356146d0834c6e2146f04018c081fa3985aa) awscli2: 2.4.23 -> 2.5.6 ([nixos/nixpkgs⁠#169441](https://togithub.com/nixos/nixpkgs/issues/169441))
* [`20206d6e`](https://github.com/NixOS/nixpkgs/commit/20206d6e58d46bc6b03dd5b55c66cb82daa8dda0) oh-my-zsh: 2022-04-18 -> 2022-04-19 ([nixos/nixpkgs⁠#169408](https://togithub.com/nixos/nixpkgs/issues/169408))
* [`6a9aafbf`](https://github.com/NixOS/nixpkgs/commit/6a9aafbf3bc051b2fdbd91c35f2153ba9dc27398) pigz: use github as a source
* [`f5dcf2fa`](https://github.com/NixOS/nixpkgs/commit/f5dcf2fa818a9012f560144fbb11a11984aab77a) python3Packages.dm-tree: fix gcc11 build due to abseil-cpp version mismatch
* [`576b229f`](https://github.com/NixOS/nixpkgs/commit/576b229fccc55a8e410725da7aaf7f7f5a4e803d) debian-goodies: init at 0.87
* [`db4a2977`](https://github.com/NixOS/nixpkgs/commit/db4a2977daef7e13f442d923a2f813c033ea7ecb) devilutionx: 1.3.0 -> 1.4.0
* [`582a42ec`](https://github.com/NixOS/nixpkgs/commit/582a42ece7e2a86d5b076addd5f18a6379fd326a) lvm2: fix static compilation
* [`67ae929d`](https://github.com/NixOS/nixpkgs/commit/67ae929deb3b3c5102848485dbb3f48e5ff27278) mesa: disable withValgrind if valgrind-light is marked as broken
* [`4202e1bf`](https://github.com/NixOS/nixpkgs/commit/4202e1bf0b212fdb738de028d226d595a0c227be) consul: 1.11.5 -> 1.12.0
* [`d002c9f5`](https://github.com/NixOS/nixpkgs/commit/d002c9f58f2e63cb2548ee6649d9deb310788818) bottles: remove custom updater
* [`b587fa28`](https://github.com/NixOS/nixpkgs/commit/b587fa2897da0a53939d5994ee8a6f30c498e0c0) bottles: move patching from preConfigure into postPatch
* [`5a9a3c22`](https://github.com/NixOS/nixpkgs/commit/5a9a3c221fe19535d6da88e8aec65bd4605503a5) home-assistant: 2022.4.5 -> 2022.4.6
* [`df873bb8`](https://github.com/NixOS/nixpkgs/commit/df873bb84f6212a30c25eaee662095d615a35ae0) awscli2: use python-dateutil directly
* [`67e9ab56`](https://github.com/NixOS/nixpkgs/commit/67e9ab5612efbbd4274d6330034280fb14c4b6c5) nushell: 0.60.0 -> 0.61.0
* [`e8f3e829`](https://github.com/NixOS/nixpkgs/commit/e8f3e829a750794f42634f4975062177e7c5466f) cudaPackages: 11_5 -> 11_6, recover from gcc10->gcc11
* [`b1eef8c0`](https://github.com/NixOS/nixpkgs/commit/b1eef8c0f0d3ca1263590a16a36b1d1832b5d4f1) ocamlPackages.toml: 6.0.0 -> 7.0.0 ([nixos/nixpkgs⁠#165676](https://togithub.com/nixos/nixpkgs/issues/165676))
* [`d5239ed8`](https://github.com/NixOS/nixpkgs/commit/d5239ed8d0e6197e1123e0e61b99f58f4a0e584b) cudaPackages: undo the cudaPackages_11_3 fallback
* [`11ff7da6`](https://github.com/NixOS/nixpkgs/commit/11ff7da635524eab596982a22cc715a5ac8b9429) nccl: 2.7.8-1 -> 2.12.10-1
* [`49974bd3`](https://github.com/NixOS/nixpkgs/commit/49974bd39777bfc84199319b346170b072ecabf3) python3Packages.seventeentrack: init at 2022.04.4
* [`1613460b`](https://github.com/NixOS/nixpkgs/commit/1613460b35e8fcbc326557bee54215c1e06c31d3) siege: 4.1.2 -> 4.1.3
* [`3d707f09`](https://github.com/NixOS/nixpkgs/commit/3d707f0920755102083f1d34287f1f9d06d00d96) python3Packages.eagle100: init at 0.1.0
* [`1a1ce8f8`](https://github.com/NixOS/nixpkgs/commit/1a1ce8f8c74712871a8737e653aa9246e43efa3f) python3Packages.aioqsw: init at 0.0.5
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
