### PR TITLE
niv emacs-overlay: update 13b55e21 -> 4356a064

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "13b55e2157a30257d77d7c4bebbeb318a51dbcb4",
-        "sha256": "1qvjm3yxrak3gx40xm8bvqx4qlppskbhq1y1cjbi1qgzhhib3pkg",
+        "rev": "4356a0643b98868883425711daa02dde1290b2ed",
+        "sha256": "08vljl2v1nba6cr3fjmibqnh679sc1inf6sy5ayjh2j35bxi2sk0",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/13b55e2157a30257d77d7c4bebbeb318a51dbcb4.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/4356a0643b98868883425711daa02dde1290b2ed.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@13b55e21...4356a064](https://github.com/nix-community/emacs-overlay/compare/13b55e2157a30257d77d7c4bebbeb318a51dbcb4...4356a0643b98868883425711daa02dde1290b2ed)

* [`24a75cb7`](https://github.com/nix-community/emacs-overlay/commit/24a75cb77b9f7204a265528ff2d154d2299d907a) Updated repos/melpa
* [`aef2a37f`](https://github.com/nix-community/emacs-overlay/commit/aef2a37fd64133f1177ed7bc6e4d139285b20bd6) Updated repos/melpa
* [`9677fba2`](https://github.com/nix-community/emacs-overlay/commit/9677fba279a16c9cda5efdaeb36d5ecae8d7502c) Updated repos/elpa
* [`5c7ecd9b`](https://github.com/nix-community/emacs-overlay/commit/5c7ecd9b6d6101b3263f4b0f8b7fec32756a1bbd) Updated repos/melpa
* [`5cbd3109`](https://github.com/nix-community/emacs-overlay/commit/5cbd3109afa89d840de09a54c0a46f6fa911bc6a) Updated repos/melpa
* [`39c9e60e`](https://github.com/nix-community/emacs-overlay/commit/39c9e60e08523c735e1efbdeeaea8452d4cd752a) Updated repos/emacs
* [`9fad13bf`](https://github.com/nix-community/emacs-overlay/commit/9fad13bfded278742a088d73bdb9e2a63efb1c29) Updated repos/melpa
* [`03367406`](https://github.com/nix-community/emacs-overlay/commit/033674066a99e691b52bb95de6fe991375081bfb) Updated repos/emacs
* [`601c017b`](https://github.com/nix-community/emacs-overlay/commit/601c017b2a4c7f9bf2d41a174753d3aa3bd8d796) Updated repos/melpa
* [`5899fae0`](https://github.com/nix-community/emacs-overlay/commit/5899fae0b3e4b3279991c32978a5a95f09ee16df) Updated repos/emacs
* [`34d35051`](https://github.com/nix-community/emacs-overlay/commit/34d35051f15a98eddc78378e31ebbf9a82fc1f47) Updated repos/melpa
* [`2278ae89`](https://github.com/nix-community/emacs-overlay/commit/2278ae89ea9c5d53aaec906e445687fd4e7507dd) Updated repos/elpa
* [`e814608a`](https://github.com/nix-community/emacs-overlay/commit/e814608af7a945b88b5415bf5de67726313c1048) Updated repos/emacs
* [`fef4e2e4`](https://github.com/nix-community/emacs-overlay/commit/fef4e2e46ee8e42b68571cabc0bd73998e0d078f) Updated repos/melpa
* [`1acccbf5`](https://github.com/nix-community/emacs-overlay/commit/1acccbf55d50ee0de421c5493e5afc2b3f1c5113) Updated repos/elpa
* [`1dca5c58`](https://github.com/nix-community/emacs-overlay/commit/1dca5c58d98e9beaac1e97a063ef53d07425b5b3) Updated repos/emacs
* [`f4835cdd`](https://github.com/nix-community/emacs-overlay/commit/f4835cdd39c5e36ee0da62fb2fa8d8ef75f68f5f) Updated repos/melpa
* [`90e40240`](https://github.com/nix-community/emacs-overlay/commit/90e40240fd34d870611ff8bb8fe650ab32b027c8) Updated repos/emacs
* [`aa750ab9`](https://github.com/nix-community/emacs-overlay/commit/aa750ab92fa4bc1699b23c23e4a908a2e7dcfeae) Updated repos/melpa
* [`07fc9c91`](https://github.com/nix-community/emacs-overlay/commit/07fc9c91d82fde75c08b8fca08c4f619dce85edd) Updated repos/elpa
* [`e6379ffc`](https://github.com/nix-community/emacs-overlay/commit/e6379ffc7fb1bff68b130aaecd0e5bceb184890e) Updated repos/emacs
* [`cc4fef53`](https://github.com/nix-community/emacs-overlay/commit/cc4fef537668493d714431645d9b46f1d14c7b1c) Updated repos/melpa
* [`b55b1394`](https://github.com/nix-community/emacs-overlay/commit/b55b1394b9a3ab3b222457f5bf3bef73bac9c19b) Updated repos/elpa
* [`5d191602`](https://github.com/nix-community/emacs-overlay/commit/5d191602729d796fb69c9192a68f6d9521f81538) Updated repos/emacs
* [`46041a07`](https://github.com/nix-community/emacs-overlay/commit/46041a0711e643c8911845878fa4604dc8669a66) Updated repos/melpa
* [`b94c0a54`](https://github.com/nix-community/emacs-overlay/commit/b94c0a54c6c5241f6696b2130ba3e0352ee35c8e) Updated repos/emacs
* [`9e103bfa`](https://github.com/nix-community/emacs-overlay/commit/9e103bfabd3e1adbfc4e5aab8d12b8fe70d78885) Updated repos/melpa
* [`8f21be10`](https://github.com/nix-community/emacs-overlay/commit/8f21be102a5ddd9c0d513797e62f1c669a474a9d) Replace IRC channel reference with Matrix room
* [`d697ae95`](https://github.com/nix-community/emacs-overlay/commit/d697ae9569368e65ef134ea7102b35cea3757f5c) Updated repos/emacs
* [`49322ef5`](https://github.com/nix-community/emacs-overlay/commit/49322ef5264e7a8f443092268c10acd6f05cbed6) Updated repos/melpa
* [`b50be562`](https://github.com/nix-community/emacs-overlay/commit/b50be56283fe96da500980a49297096890535d3e) Add emacsGitNativeComp attribute
* [`498364dc`](https://github.com/nix-community/emacs-overlay/commit/498364dcdf6b99ce3abfd6bbe373fa3cacc3aab7) Rename emacsPgtkGcc to emacsPgtkNativeComp
* [`21841fc9`](https://github.com/nix-community/emacs-overlay/commit/21841fc99e6fbabde8c6e085adc05ce4c51a92ef) Updated repos/emacs
* [`6216f7c7`](https://github.com/nix-community/emacs-overlay/commit/6216f7c7e05c5f7d579dc898219207a8509be910) Updated repos/melpa
* [`3244c107`](https://github.com/nix-community/emacs-overlay/commit/3244c1074365557dddd81439dd2f538cd68457dc) Updated repos/emacs
* [`d50f841d`](https://github.com/nix-community/emacs-overlay/commit/d50f841db7b856d79fcfc1a71582dfb5ee1a5830) Updated repos/melpa
* [`ab593083`](https://github.com/nix-community/emacs-overlay/commit/ab593083f34d2bafe091554072c5bedecbcee190) Updated repos/emacs
* [`b77f4943`](https://github.com/nix-community/emacs-overlay/commit/b77f494343f4000b0002b9c50b8e300bb271f8bc) Updated repos/melpa
* [`afc2cd55`](https://github.com/nix-community/emacs-overlay/commit/afc2cd555fd03240c06750a7448a80135623977f) Updated repos/emacs
* [`ce0571f9`](https://github.com/nix-community/emacs-overlay/commit/ce0571f95210dc4c00a3affb4128012947f9a250) Updated repos/melpa
* [`6934f443`](https://github.com/nix-community/emacs-overlay/commit/6934f4439906df868d9aaa4f3e7dc1e538b1517a) Updated repos/emacs
* [`5daf2e7e`](https://github.com/nix-community/emacs-overlay/commit/5daf2e7e8dc77c029c2436ae32d7aa869acce648) Updated repos/melpa
* [`83621efb`](https://github.com/nix-community/emacs-overlay/commit/83621efbc81fab136d8097807163ef215d3a6e6b) Updated repos/elpa
* [`891f6534`](https://github.com/nix-community/emacs-overlay/commit/891f6534049c593b5ffbad6cb752063ec9246fdc) Updated repos/emacs
* [`0ab31957`](https://github.com/nix-community/emacs-overlay/commit/0ab31957afc748f9d618e197dff88a8be1989600) Updated repos/melpa
* [`751cdcc4`](https://github.com/nix-community/emacs-overlay/commit/751cdcc4beca04321ab17a1b8f3a9938b104d222) Updated repos/emacs
* [`4356a064`](https://github.com/nix-community/emacs-overlay/commit/4356a0643b98868883425711daa02dde1290b2ed) Updated repos/melpa
