### PR TITLE
niv fast-syntax-highlighting: update ef8ba84c -> 9469bd0e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "ef8ba84c3a76c768f49a0bdd2a620b2f53c2478a",
-        "sha256": "058s55r8gq1giwnb2si8k38nvd0qy8jlhd9zhvsxyl0mvi7wk9ar",
+        "rev": "9469bd0e7ed65eb30e38085409b96ad6643752c5",
+        "sha256": "1r9v8ij2lvjf7jx4p97l53lhy7dpbcdrmiq6w31s5p32wx24cblh",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/ef8ba84c3a76c768f49a0bdd2a620b2f53c2478a.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/9469bd0e7ed65eb30e38085409b96ad6643752c5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@ef8ba84c...9469bd0e](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/ef8ba84c3a76c768f49a0bdd2a620b2f53c2478a...9469bd0e7ed65eb30e38085409b96ad6643752c5)

* [`9469bd0e`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/9469bd0e7ed65eb30e38085409b96ad6643752c5) maint: add linting Github action workflow ([zdharma-continuum/fast-syntax-highlighting⁠#29](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/29))
