### PR TITLE
niv spacemacs: update b3e67aaf -> dc85616d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "b3e67aafe2451ca91e2d310d29879616e10981d0",
-        "sha256": "1i07q98n065phvklg8mmhgvsq74gn03rdm32jassg2pjj43diqmb",
+        "rev": "dc85616df542fd8d2b3739f26a29b66af6fab91e",
+        "sha256": "09vpvpz6m2iiyzj1zdrng1fakl6x17a9fs1bx5rdhlnn9152lydb",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/b3e67aafe2451ca91e2d310d29879616e10981d0.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/dc85616df542fd8d2b3739f26a29b66af6fab91e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@b3e67aaf...dc85616d](https://github.com/syl20bnr/spacemacs/compare/b3e67aafe2451ca91e2d310d29879616e10981d0...dc85616df542fd8d2b3739f26a29b66af6fab91e)

* [`abc028e2`](https://github.com/syl20bnr/spacemacs/commit/abc028e24eea06d967d8c077c483dffc29f93f61) [zig] Fix setup backend hook ([syl20bnr/spacemacs⁠#15483](https://togithub.com/syl20bnr/spacemacs/issues/15483))
* [`dc85616d`](https://github.com/syl20bnr/spacemacs/commit/dc85616df542fd8d2b3739f26a29b66af6fab91e) Add key binding for revert-buffer in process-menu-mode ([syl20bnr/spacemacs⁠#15403](https://togithub.com/syl20bnr/spacemacs/issues/15403))
