### PR TITLE
niv zsh-completions: update 3d394eba -> 00a7cc22

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "3d394ebaa14f50a8498ab29b3a3d07cb82dee1e5",
-        "sha256": "0cdy9z622ss2f3ps7z64q8x0n1vfmbm4x1xyafsr6bz5s3wbhx24",
+        "rev": "00a7cc2200de179d21a5b359c6d670007cf44b08",
+        "sha256": "1li97rzar9cm5wzi9bwj296rq79bbzqj886x4l6lfpbwbnrbqxkg",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/3d394ebaa14f50a8498ab29b3a3d07cb82dee1e5.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/00a7cc2200de179d21a5b359c6d670007cf44b08.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@3d394eba...00a7cc22](https://github.com/zsh-users/zsh-completions/compare/3d394ebaa14f50a8498ab29b3a3d07cb82dee1e5...00a7cc2200de179d21a5b359c6d670007cf44b08)

* [`03731671`](https://github.com/zsh-users/zsh-completions/commit/03731671e3067f2b73c95062d3144af2477c4d26) Update node-v18
