### PR TITLE
niv nixpkgs: update 55016232 -> ace23e4d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "550162327f99a99e928739ca4d61a741b17653a2",
-        "sha256": "09lqkp0qhs6acvbhpika7w9ryv8agvp8mdnq8pyqmhwhmnx61yg6",
+        "rev": "ace23e4d0bd31154cf5ac6da47d92e12c0b1b79a",
+        "sha256": "0mlpdkv77n92d8m9drd1jhi9h5wzlnfrsgn5rspkabvsgldcyrid",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/550162327f99a99e928739ca4d61a741b17653a2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ace23e4d0bd31154cf5ac6da47d92e12c0b1b79a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@55016232...ace23e4d](https://github.com/nixos/nixpkgs/compare/550162327f99a99e928739ca4d61a741b17653a2...ace23e4d0bd31154cf5ac6da47d92e12c0b1b79a)

* [`4f624718`](https://github.com/NixOS/nixpkgs/commit/4f62471862d1c1a03939c6588c189aef2eafb0b2) rmfuse: 0.2.1 -> 0.2.3
* [`9b2faeb3`](https://github.com/NixOS/nixpkgs/commit/9b2faeb38e6f4f33f69d356a000cd5aef02a89c9) wpa_supplicant: prevent writing non-writable configuration
* [`00c7a8ee`](https://github.com/NixOS/nixpkgs/commit/00c7a8ee424c2702951e83136577b71a058d618b) caprine-bin: init at 2.55.2
* [`0202ad1e`](https://github.com/NixOS/nixpkgs/commit/0202ad1ef92e385a5445092239ad1f1e1dc2cbf3) jdt-language-server: init at 1.8.0
* [`102eabd1`](https://github.com/NixOS/nixpkgs/commit/102eabd1dfb4a11d9796dc1944752cfca787e23e) jamesdsp: backport fix for PipeWire 0.3.44+
* [`282633be`](https://github.com/NixOS/nixpkgs/commit/282633bed3c2ccb41b6c495bf4aa583e0014b80f) openfst: 1.8.1 -> 1.8.2
* [`89043782`](https://github.com/NixOS/nixpkgs/commit/890437821134149478359b0781bd085ebdace0bb) klipper: unstable-2022-03-11 -> unstable-2022-03-14
* [`8d0b575e`](https://github.com/NixOS/nixpkgs/commit/8d0b575eb4beeb7a0c79cb93be3cb977ba1141ab) facetimehd-calibration: init at 5.1.5769
* [`0d233ebe`](https://github.com/NixOS/nixpkgs/commit/0d233ebed02d41aeef53e1c35b596baa20ce9c31) nixos/facetimehd: add option hardware.facetimehd.withCalibration
* [`c2c95b88`](https://github.com/NixOS/nixpkgs/commit/c2c95b8851528475f742eaaef323771e7adc4f87) libyang: 2.0.112 -> 2.0.164
* [`f49d7e52`](https://github.com/NixOS/nixpkgs/commit/f49d7e521397437659d52a319e69f73ae4cf48c0) jsvc: 1.2.4 -> 1.3.0
* [`7ccb5bdf`](https://github.com/NixOS/nixpkgs/commit/7ccb5bdf4a574a595dbfcb96ab3ae4fad1ce0926) commonsDaemon: 1.2.4 -> 1.3.0
* [`92349ece`](https://github.com/NixOS/nixpkgs/commit/92349ece0f0e0c68df7388066dc24e66a6e22cdf) nixos/galene: systemd unit hardening
* [`b0a6341b`](https://github.com/NixOS/nixpkgs/commit/b0a6341bb7ba2205d1de1c4cd99ac3272b36a16d) joker: 0.18.0 -> 1.0.0
* [`d888261a`](https://github.com/NixOS/nixpkgs/commit/d888261a7d9b47700ca74cca106dfe9c0733a1bd) wlc: 1.12 -> 1.13
* [`264f2008`](https://github.com/NixOS/nixpkgs/commit/264f2008fc8ff3264bd119055aea399c3384b84e) mictray: init at 0.2.5
* [`487eec46`](https://github.com/NixOS/nixpkgs/commit/487eec467f387b38262d1df3ae7e2b2191c573cc) qbittorrent: 4.4.1 -> 4.4.2
* [`b598eae3`](https://github.com/NixOS/nixpkgs/commit/b598eae35a80364534971102f78733d0bc6bc078) doctl: 1.71.1 -> 1.72.0
* [`fa06e9f4`](https://github.com/NixOS/nixpkgs/commit/fa06e9f42fd24832ffaee6ca0ca6a3cf39d28960) graphicsmagick: 1.3.37 -> 1.3.38
* [`ead7f8fb`](https://github.com/NixOS/nixpkgs/commit/ead7f8fb35333edd4337e6b7091422db6a763bfa) nq: 0.4 -> 0.5
* [`b77ad9fe`](https://github.com/NixOS/nixpkgs/commit/b77ad9fe75b9acf29ed43061eb624177fbbac679) rocclr: 5.0.2 -> 5.1.0
* [`f75f84c9`](https://github.com/NixOS/nixpkgs/commit/f75f84c9292a9bd5c0fc9d0baf286d722cd8b24c) rocm-cmake: 5.0.2 -> 5.1.0
* [`4bc1c97e`](https://github.com/NixOS/nixpkgs/commit/4bc1c97e2044defdce956e07920b5b591ec27bde) rocm-comgr: 5.0.2 -> 5.1.0
* [`590e8260`](https://github.com/NixOS/nixpkgs/commit/590e826078b2bbe30bf2468c6448f71b666fe763) rocm-device-libs: 5.0.2 -> 5.1.0
* [`abf11f01`](https://github.com/NixOS/nixpkgs/commit/abf11f01be772ff6193d3d4f34637e9929a4e733) rocm-runtime: 5.0.1 -> 5.1.0
* [`f7be356c`](https://github.com/NixOS/nixpkgs/commit/f7be356ce02439d346655be65a3b285a7206529c) rocm-smi: 5.0.2 -> 5.1.0
* [`e9b2bf17`](https://github.com/NixOS/nixpkgs/commit/e9b2bf17e4d4005d430dd5c254b0d48b516bfdf3) rocm-thunk: 5.0.2 -> 5.1.0
* [`934237e6`](https://github.com/NixOS/nixpkgs/commit/934237e6be8731b561997fe6670c04ecc4bfe44a) weechat-unwrapped: 3.4.1 -> 3.5
* [`9c147307`](https://github.com/NixOS/nixpkgs/commit/9c147307f4cb67c94d942f88ad3c8fea5bcc84c8) imath: 3.1.4 -> 3.1.5
* [`7bb2feb4`](https://github.com/NixOS/nixpkgs/commit/7bb2feb4fca6e5ec42adbf3a0f5b6cb012dcedd3) vscode-extensions.adpyke.codesnap: init 1.3.4
* [`8d94aa06`](https://github.com/NixOS/nixpkgs/commit/8d94aa0660a91692361591560b42a9e260fb5ee7) sollya: 7.0 -> 8.0
* [`1f72f975`](https://github.com/NixOS/nixpkgs/commit/1f72f975349e71525983050a09c62e18cca75ef3) marathonctl: 2017-03-06 -> 0.0.7
* [`614cef92`](https://github.com/NixOS/nixpkgs/commit/614cef9232d0985fa0c833ce13196c0f3d567f6f) redis-plus-plus: init at 1.3.3
* [`46156529`](https://github.com/NixOS/nixpkgs/commit/46156529f2682412b8867f7bc40b32b350a00bd9) tests.pkgs-lib.formats: Allow strings with context in test runner
* [`337c72b5`](https://github.com/NixOS/nixpkgs/commit/337c72b5cde3a034e92cc6c99865869774be7d47) pkgs.formats.javaProperties: Add type coercions
* [`62d781f0`](https://github.com/NixOS/nixpkgs/commit/62d781f09be7bc526e89a6b9bb7ed432dc33df15) tests.pkgs-lib: Fix for darwin
* [`e40b63c1`](https://github.com/NixOS/nixpkgs/commit/e40b63c1da1a8d6134f06242f2f67e97d7a871c0) kompose: 1.21.0 -> 1.26.1
* [`daa65aca`](https://github.com/NixOS/nixpkgs/commit/daa65aca3aaadbb5e67de4ee5d0b73d22c02ab77) gosu: unstable-2017-05-09 -> 1.4
* [`09b7444b`](https://github.com/NixOS/nixpkgs/commit/09b7444b82827acbd89970997ebc11b5e59558e6) dcm2niix: add support for configuring optional compile-time modules
* [`fcd9db43`](https://github.com/NixOS/nixpkgs/commit/fcd9db43682097fe586737bc9a2c1560ca9e312f) fcitx5: move from cldr-emoji-annotation to cldr-annotations
* [`10bb7d69`](https://github.com/NixOS/nixpkgs/commit/10bb7d6911b0feeedf3816ed7f80fa2e4567dfe1) cldr-emoji-annotation: drop
* [`08f0b6cf`](https://github.com/NixOS/nixpkgs/commit/08f0b6cf00b0ee29326b879b4f32e0769d8c1239) helm-docs: 1.7.0 -> 1.8.1
* [`1cd122e7`](https://github.com/NixOS/nixpkgs/commit/1cd122e7b6e404dbda80704774ad1d180f02cde6) pfstools: fix build of pfsglview with newer cmake
* [`f136b6a7`](https://github.com/NixOS/nixpkgs/commit/f136b6a73010431bbd869e9488b84b55464428dd) zoom.us: darwin support
* [`5ba31f02`](https://github.com/NixOS/nixpkgs/commit/5ba31f02b866de9e409bdbb35fdec8dd90a2fb0b) masterpdfeditor: 5.8.33 -> 5.8.46
* [`b7b2c002`](https://github.com/NixOS/nixpkgs/commit/b7b2c002ed6b821d95f93ef3463313fc12175169) moonlight-qt: 3.2.0 -> 4.0.0
* [`45b57ea8`](https://github.com/NixOS/nixpkgs/commit/45b57ea8e3ecd8728247f630e002b33245d8da1c) cider: 1.3.1308 -> 1.4.1.1680
* [`5b44ce33`](https://github.com/NixOS/nixpkgs/commit/5b44ce3367f58f7985ee9dfdc24edde595154f11) The Linux tarball doesn't have a top level directory which is already dealt with in `installPhase`
* [`8fde5025`](https://github.com/NixOS/nixpkgs/commit/8fde5025c30a0e62632b8280630f1e808a41e9eb) phosh: 0.16.0 -> 0.17.0
* [`aef5702d`](https://github.com/NixOS/nixpkgs/commit/aef5702d2bf2b4ed8e56cc42260e586fd5f82285) Don't duplicate `installPhase` on both Darwin platforms.
* [`2d7bf4c4`](https://github.com/NixOS/nixpkgs/commit/2d7bf4c4dbaeb7f020a312b768183a836b4d60ca) kube3d: 5.3.0 -> 5.4.1
* [`793543a1`](https://github.com/NixOS/nixpkgs/commit/793543a19bd9607da579eec0b6885acb78832ca7) xedit: 1.2.2 -> 1.2.3
* [`ad1e2500`](https://github.com/NixOS/nixpkgs/commit/ad1e2500efd0aa49b0dc7427bf69d4879f3b0ff5) pkgs: Add _type = "pkgs"
* [`6fb36a0d`](https://github.com/NixOS/nixpkgs/commit/6fb36a0d47c26b719e391deb7956d8f53b8f3de3) envconsul: 0.7.3 -> 0.12.1
* [`14631945`](https://github.com/NixOS/nixpkgs/commit/14631945b2c3e3dc791dc5bc0f93f5773841debd) faustlive: 2.5.5 -> 2.5.8
* [`b71ff4c6`](https://github.com/NixOS/nixpkgs/commit/b71ff4c656321c2a771b0453a21418ddc0d6d8f2) asterisk: add support for open-source opus codec
* [`3594e28c`](https://github.com/NixOS/nixpkgs/commit/3594e28c87eb14e2ee77ec563d0c4b5f11cf56d1) rocminfo: 5.0.1 -> 5.1.1
* [`9b8e5b52`](https://github.com/NixOS/nixpkgs/commit/9b8e5b524b045e60558b98d074df29bc788d82c9) c14: remove
* [`66801030`](https://github.com/NixOS/nixpkgs/commit/668010302bfb8bf7dc28da69efaca305b3035dcf) grocy: 3.2.0 -> 3.3.0
* [`19ad91fc`](https://github.com/NixOS/nixpkgs/commit/19ad91fcaf7c8242a9793e0304260c1767724239) bitwarden: 1.31.3 -> 1.32.1
* [`dddadac6`](https://github.com/NixOS/nixpkgs/commit/dddadac600be177b35dbffd5ebbe3bc99b86b02c) openafs: Patch for Linux kernel 5.17
* [`14aa201b`](https://github.com/NixOS/nixpkgs/commit/14aa201b658f43546b00153bb2ada7206ba8dd26) lib.modules: Allow making _module.args internal
* [`c190b08b`](https://github.com/NixOS/nixpkgs/commit/c190b08bb7793004a4706e008a7d0f9b2be3df70) lib: add callLocklessFlake
* [`cad8bbe5`](https://github.com/NixOS/nixpkgs/commit/cad8bbe58905a14651a469be78f89cad55ee7c15) lib: init flakes.nix
* [`cc052779`](https://github.com/NixOS/nixpkgs/commit/cc052779fba0d9f0efa5980f42661798598b2ed1) lib/tests: add test for callLocklessFlake
* [`ec59145c`](https://github.com/NixOS/nixpkgs/commit/ec59145c3b8d69bf1e270fdcfa651348880ad8e4) lib/tests: use subflake to test callLocklessFlake
* [`3f128cc0`](https://github.com/NixOS/nixpkgs/commit/3f128cc0247a95cfdcbb34a96c230422706b1715) lib/tests: evaluate value from subflake with callLocklessFlake
* [`e8aee7af`](https://github.com/NixOS/nixpkgs/commit/e8aee7af1a0995db9dd485a2f716afb774411af8) globalprotect-openconnect: 1.3.4 -> 1.4.1
* [`73e52ad7`](https://github.com/NixOS/nixpkgs/commit/73e52ad75aa8794d3d69dc9dfa6d4c01a41d09f8) tor-browser-bundle-bin: Wayland support
* [`169468fe`](https://github.com/NixOS/nixpkgs/commit/169468fe658369a9e05ee65b6dababe808eaff91) maintainers: add lumina team
* [`e132736d`](https://github.com/NixOS/nixpkgs/commit/e132736d0da3549ad33b2dd20041073c36046842) lumina: add maintainers team
* [`c8844868`](https://github.com/NixOS/nixpkgs/commit/c88448684a1b19146e43f68c48757d49ddcf32bb) maintainers: add enlightenment team
* [`8773488c`](https://github.com/NixOS/nixpkgs/commit/8773488cc8bab422fff3f83289bc3b5358f1b7e2) enlightenment: add maintainers team
* [`885dbfc7`](https://github.com/NixOS/nixpkgs/commit/885dbfc7a7f711ac4b763633aaf8cd7ab206b858) mozillavpn: 2.7.1 → 2.8.0
* [`752a0828`](https://github.com/NixOS/nixpkgs/commit/752a0828229d2a6975bfbc7efafb921ee0569788) python310Packages.tern: 2.9.1 -> 2.10.0
* [`4de5a2f7`](https://github.com/NixOS/nixpkgs/commit/4de5a2f79a874ee8c71bde69fe52c48c4fe85896) openai: 0.18.0 -> 0.18.1
* [`78a6caa5`](https://github.com/NixOS/nixpkgs/commit/78a6caa5f808538a0fcae6d02f4eeb3dd2037be0) nixosTests.kexec: better test if we are in a new system
* [`9e8b463c`](https://github.com/NixOS/nixpkgs/commit/9e8b463cce747c63884f911113fd3dd943d04278) nixos: Handle panic_on_fail in systemd stage 1
* [`9ee5d61a`](https://github.com/NixOS/nixpkgs/commit/9ee5d61a16c1a00ae4864a632aba2c297faa81c3) nixos: Installer tests for systemd stage 1
* [`f3f2e55e`](https://github.com/NixOS/nixpkgs/commit/f3f2e55e594f6b1e6bd75d41125fea13d3889896) nixos: Fix channel copying in installer tests with systemd stage 1
* [`ff1fa4fa`](https://github.com/NixOS/nixpkgs/commit/ff1fa4fa22155b4eeff76e281045591908f06db7) lxqt.libfm-qt: 1.0.0 -> 1.1.0
* [`bacb5dd7`](https://github.com/NixOS/nixpkgs/commit/bacb5dd77f32fd0ce3d45794c55f6904c3991c5f) lxqt.libqtxdg: 3.8.0 -> 3.9.0
* [`b20d524d`](https://github.com/NixOS/nixpkgs/commit/b20d524d965f9ddee64ec0237bf93df617fab92e) lxqt.liblxqt: 1.0.0 -> 1.1.0
* [`a6472c56`](https://github.com/NixOS/nixpkgs/commit/a6472c561c7c7bb89afab9da8f80f06cb73cea9d) lxqt.lximage-qt: 1.0.0 -> 1.1.0
* [`bd27a290`](https://github.com/NixOS/nixpkgs/commit/bd27a2909aeb350f73a47c40f0120556659ccc4e) lxqt.lxqt-about: 1.0.0 -> 1.1.0
* [`500b9d5a`](https://github.com/NixOS/nixpkgs/commit/500b9d5a9ffe50622baa2d0a2b7e809d045e7045) lxqt.lxqt-admin: 1.0.0 -> 1.1.0
* [`7c5c5c45`](https://github.com/NixOS/nixpkgs/commit/7c5c5c45e1a96c4bd19c4e54f460305c5cd0dae4) lxqt.lxqt-archiver: 0.5.0 -> 0.6.0
* [`46665c13`](https://github.com/NixOS/nixpkgs/commit/46665c132d4acef2571e814241ec28b6151fee76) lxqt.lxqt-build-tools: 0.10.0 -> 0.11.0
* [`25dde3bf`](https://github.com/NixOS/nixpkgs/commit/25dde3bfc2d4e1a223c6e4b2e683d6f4352c64f3) lxqt.lxqt-config: 1.0.0 -> 1.1.0
* [`01c5066e`](https://github.com/NixOS/nixpkgs/commit/01c5066eb2375a343038983eb83e3b4a351f38da) lxqt.lxqt-globalkeys: 1.0.1 -> 1.1.0
* [`b985c5f7`](https://github.com/NixOS/nixpkgs/commit/b985c5f78ebd1dc3b5ecf1303549d4ae1891dc84) lxqt.lxqt-notificationd: 1.0.0 -> 1.1.0
* [`a4bbf2cf`](https://github.com/NixOS/nixpkgs/commit/a4bbf2cf65e54549bf1529da4e56e06a322bdde6) lxqt.lxqt-openssh-askpass: 1.0.0 -> 1.1.0
* [`79306631`](https://github.com/NixOS/nixpkgs/commit/7930663112744ab0759b137503fcee15f207bff1) lxqt.lxqt-panel: 1.0.0 -> 1.1.0
* [`cb184864`](https://github.com/NixOS/nixpkgs/commit/cb184864142e51327d39b25a9a391e64e2d44a44) lxqt.lxqt-policykit: 1.0.0 -> 1.1.0
* [`9f1751fb`](https://github.com/NixOS/nixpkgs/commit/9f1751fb546d74f44189430f95313ec85f773a48) lxqt.lxqt-powermanagement: 1.0.0 -> 1.1.0
* [`39c00bfd`](https://github.com/NixOS/nixpkgs/commit/39c00bfd00a0cc792acad917736bc394dcae1b90) lxqt.lxqt-qtplugin: 1.0.0 -> 1.1.0
* [`ff44f491`](https://github.com/NixOS/nixpkgs/commit/ff44f4913e4ac385e0542d0fb37c8f07a3627f95) lxqt.lxqt-runner: 1.0.0 -> 1.1.0
* [`4ac8e185`](https://github.com/NixOS/nixpkgs/commit/4ac8e1857e2a9c818100f48863eee71df6747b5d) lxqt.lxqt-session: 1.0.1 -> 1.1.0
* [`b91305d2`](https://github.com/NixOS/nixpkgs/commit/b91305d2a111f5d2e8f38876e319d48dec4e20ad) lxqt.lxqt-sudo: 1.0.0 -> 1.1.0
* [`322ce201`](https://github.com/NixOS/nixpkgs/commit/322ce2015f7ccea35afacc6502e3393a2a0a3e68) lxqt.lxqt-themes: 1.0.0 -> 1.1.0
* [`742a00cb`](https://github.com/NixOS/nixpkgs/commit/742a00cbcc607925015a125e782c3d590a197f08) lxqt.pavucontrol-qt: 1.0.0 -> 1.1.0
* [`439fc5ff`](https://github.com/NixOS/nixpkgs/commit/439fc5ffa717d6e8c0c204a2aaf26b96a63ce40a) lxqt.pcmanfm-qt: 1.0.0 -> 1.1.0
* [`fd8f1024`](https://github.com/NixOS/nixpkgs/commit/fd8f1024d02238677ba8b2095f0b3d28c3dad608) lxqt.qps: 2.4.0 -> 2.5.0
* [`86000d0e`](https://github.com/NixOS/nixpkgs/commit/86000d0e1861cc398602b9a2a3a85b9c526f2ed6) lxqt.qterminal: 1.0.0 -> 1.1.0
* [`0cf20940`](https://github.com/NixOS/nixpkgs/commit/0cf20940db8087cd2ea777ea95af586b048e081a) lxqt.qtermwidget: 1.0.0 -> 1.1.0
* [`6cacd60e`](https://github.com/NixOS/nixpkgs/commit/6cacd60eb9ddb9249300214cc6dac56c658f60f4) lxqt.screengrab: 2.3.0 -> 2.4.0
* [`2aa95b9f`](https://github.com/NixOS/nixpkgs/commit/2aa95b9fecfe4a0ef1e7ee2327ba78178c6301e0) lxqt.xdg-desktop-portal-lxqt: init at 0.2.0
* [`9459a45f`](https://github.com/NixOS/nixpkgs/commit/9459a45f9333ca5b7e2c35101450863dc9aed965) lxqt: remove compton-conf from optional packages
* [`94209587`](https://github.com/NixOS/nixpkgs/commit/94209587a3a35fb678572c2471c4c5c97a3a06c0) lxqt: remove qlipper from optional packages
* [`cea437b2`](https://github.com/NixOS/nixpkgs/commit/cea437b2ca591e51b9922f22adc46edf2443fbe4) lxqt: new default icon theme
* [`b19b12d3`](https://github.com/NixOS/nixpkgs/commit/b19b12d33569c2bccabc1dd2d3046a9937f94c1c) asdf-vm: 0.9.0 -> 0.10.0
* [`66e62534`](https://github.com/NixOS/nixpkgs/commit/66e625348e85eed050ea94b11e49d02ceab4a6bd) python3Packages.skein: fix broken package
* [`28994abc`](https://github.com/NixOS/nixpkgs/commit/28994abc0fd781e94dd1120abb214bb50e1f3bb3) python3Packages.dask-yarn: init at 0.9
* [`8df7dcb2`](https://github.com/NixOS/nixpkgs/commit/8df7dcb2da2f0d5809ee761626c9bd7cf7ec95c0) carla: 2.4.2 -> 2.4.3
* [`a11d4f67`](https://github.com/NixOS/nixpkgs/commit/a11d4f674628c8ed1209529deabcfadadd6217b8) waylandpp: 0.2.9 -> 0.2.10
* [`389d129a`](https://github.com/NixOS/nixpkgs/commit/389d129a3dae25fb1cc868973c5cb25d33ddf9c9) vit: 2.1.0 -> 2.2.0
* [`bb0fbcc7`](https://github.com/NixOS/nixpkgs/commit/bb0fbcc792db4bd001d7caeea43f650aae340a00) vit: needs py3.7 now, drop pytz/tzlocal
* [`e097044b`](https://github.com/NixOS/nixpkgs/commit/e097044b9209742dfd4b23dcb36726d531a44a65) nixos/kexec-boot: auto-detect the right kernel name to support aarch64
* [`9019ce01`](https://github.com/NixOS/nixpkgs/commit/9019ce010601fcd8dff20b1e996a19eccc7b60ec) dcm2niix: add maintainer
* [`d1c3fea7`](https://github.com/NixOS/nixpkgs/commit/d1c3fea7ecbed758168787fe4e4a3157e52bc808) dcm2niix: support usage of suggested Cloudflare zlib
* [`f1ef2bc4`](https://github.com/NixOS/nixpkgs/commit/f1ef2bc428d728aef99f8e775d1cb8bf6dc2a78f) ooniprobe-cli: init at 3.14.2
* [`a94e3cfb`](https://github.com/NixOS/nixpkgs/commit/a94e3cfb0aea5f2c3d6921ce75c5022584225058) termius: 7.37.0 -> 7.39.0
* [`67a2a56d`](https://github.com/NixOS/nixpkgs/commit/67a2a56d57f130d002567a4ecb30d9a84beae652) matrix-synapse-plugins.matrix-synapse-shared-secret-auth: 2.0.1 -> 2.0.2
* [`20804223`](https://github.com/NixOS/nixpkgs/commit/208042232dc2ca71c4e31a70231d5ffe6b08bd94) erlang-ls: 0.24.0 -> 0.29.0
* [`7549a7b0`](https://github.com/NixOS/nixpkgs/commit/7549a7b03abb8a76fad0d142eeb8ddd8d6db1dd6) haskellPackages: stackage LTS 19.3 -> LTS 19.4
* [`af193985`](https://github.com/NixOS/nixpkgs/commit/af193985bed9fc3ffe2651cb7e41d8f1adc41e46) all-cabal-hashes: 2022-04-09T11:23:17Z -> 2022-04-20T23:34:08Z
* [`c659631a`](https://github.com/NixOS/nixpkgs/commit/c659631a924b288238895f56f6f5eaeb5f932997) haskellPackages: regenerate package set based on current config
* [`e3025623`](https://github.com/NixOS/nixpkgs/commit/e3025623e6de3731112d95ae482900df65a7a49d) coc-haxe: init at 0.8.0
* [`135764eb`](https://github.com/NixOS/nixpkgs/commit/135764ebbabbd2d2f935b0ab449b6f5eb3f1deb8) python3Packages.mautrix: 0.14.10 -> 0.16.1
* [`c6b0a0af`](https://github.com/NixOS/nixpkgs/commit/c6b0a0afda99177c957c78e81e88230fc797bc75) mautrix-telegram: 0.11.2 -> 0.11.3
* [`587f5242`](https://github.com/NixOS/nixpkgs/commit/587f52427fe9a323372a0d8b87858576f9cbd8eb) mautrix-signal: 0.2.3 -> 0.3.0
* [`850b784f`](https://github.com/NixOS/nixpkgs/commit/850b784f25d42158d71c3658e2e57d4a7304204e) mautrix-facebook: 0.3.3 → 0.4.0
* [`bd6a8539`](https://github.com/NixOS/nixpkgs/commit/bd6a8539139cd34ec8c1017cd10ddf1a12903f5e) nvfetcher: remove jailbreak that is no longer necessary
* [`6fe53651`](https://github.com/NixOS/nixpkgs/commit/6fe53651df918682280ecac0cec950b055e1facf) haskellPackages.cryptostore: remove override for now-released version
* [`33bf05f4`](https://github.com/NixOS/nixpkgs/commit/33bf05f46a6214eb2ad2d379909ba2192689aef4) openjdk: 11.0.12+7 -> 11.0.15.+10
* [`aca95cc4`](https://github.com/NixOS/nixpkgs/commit/aca95cc45983012212129c8ba824479a7b149ded) openjdk: 17.0.1+12 -> 17.0.3.+7
* [`279270b3`](https://github.com/NixOS/nixpkgs/commit/279270b3914f68c7b58467dcedab723839022101) python3Packages.mautrix: 0.16.1 -> 0.16.3
* [`46bfd333`](https://github.com/NixOS/nixpkgs/commit/46bfd333ea4c3a2c8dc937d8d388ac821002ac35) maintainers: add wyndon
* [`51b0be36`](https://github.com/NixOS/nixpkgs/commit/51b0be3649e4fa7577480e242e9b920e13faf51e) perlPackages.TextMarkdown: apply shortenPerlShebang
* [`260470a1`](https://github.com/NixOS/nixpkgs/commit/260470a1b274548a9ae734da034bc41ee7b6fa31) httm: init at 0.9.0
* [`a5d2d7d4`](https://github.com/NixOS/nixpkgs/commit/a5d2d7d4e8a3504e3ab09827b3a3a98d37e936ca) pythonPackages/treelog: init at 1.0
* [`47def8d3`](https://github.com/NixOS/nixpkgs/commit/47def8d3f074308bc38bcbf74edd4b176f519b7d) pythonPackages/stringly: init at 1.0b2
* [`b4810256`](https://github.com/NixOS/nixpkgs/commit/b481025616b5873f1f15e253d384bce8363de9fe) amberol: init at 0.3.0
* [`0eec6b71`](https://github.com/NixOS/nixpkgs/commit/0eec6b710be7b63eb0f835ce0a50a53643af1920) grafana: 8.4.7 -> 8.5.0
* [`6b694a5f`](https://github.com/NixOS/nixpkgs/commit/6b694a5feecf894d9baad5b60db697133b310cbd) dagger: 0.2.6 -> 0.2.7
* [`d331463a`](https://github.com/NixOS/nixpkgs/commit/d331463a2c7ed1fc9d2fe4b16c94df76a609a8b7) haskell.compiler: fix binary GHCs with store paths containing "xxx"
* [`cb7417c7`](https://github.com/NixOS/nixpkgs/commit/cb7417c74858755ff0d99e35ccb0b3d298380a71) earthly: 0.6.13 -> 0.6.14
* [`06bbe007`](https://github.com/NixOS/nixpkgs/commit/06bbe007b40161dc4585cfdf65e9ab0157c46870) heisenbridge: 1.10.1 -> 1.12.0
* [`fdd05def`](https://github.com/NixOS/nixpkgs/commit/fdd05def592618a8821ab227544317ecebb08c9f) entt: 3.9.0 -> 3.10.0
* [`8f712701`](https://github.com/NixOS/nixpkgs/commit/8f71270112fe61bb01e0f569a1ade67edcfc71fe) dar: 2.7.4 -> 2.7.5
* [`44d586b8`](https://github.com/NixOS/nixpkgs/commit/44d586b8a3517e494ada1d9a52ed2d32c803b497) flat-remix-gtk: 20220330 -> 20220412
* [`c8988e7b`](https://github.com/NixOS/nixpkgs/commit/c8988e7bc34c8ae9938d182bcaef600b1521b6f8) fishPlugins.fzf-fish: 8.2 -> 8.3
* [`aa534e38`](https://github.com/NixOS/nixpkgs/commit/aa534e38696adb411e5c628e8ba1f5ab5fafc03d) obs-vkcapture: init at 1.1.3
* [`797898a4`](https://github.com/NixOS/nixpkgs/commit/797898a45561e69a5830d1f29391f08da53bb6dd) packagekit: fix build with Nix 2.8
* [`63e04ef9`](https://github.com/NixOS/nixpkgs/commit/63e04ef92442e57ae786bcb479dcea3007de5c12) irpf: fixed login bug
* [`55c3e3b0`](https://github.com/NixOS/nixpkgs/commit/55c3e3b030b7628ce1b9cb7593f50bbe0cc78292) lapce: fix build on darwin
* [`27f20550`](https://github.com/NixOS/nixpkgs/commit/27f20550b495fcd95e02b68b36686cc656baed10) binutils-unwrapped-all-targets: fix libctf breakage
* [`89147149`](https://github.com/NixOS/nixpkgs/commit/8914714916d96812cb582425233cfcc1cc17be9f) mavproxy: 1.8.48 -> 1.8.49
* [`1610bf2d`](https://github.com/NixOS/nixpkgs/commit/1610bf2db99f0ad0557a6470e887e708ce25474b) ffmpegthumbnailer: unstable-2021-09-02 -> unstable-2022-02-18
* [`46683073`](https://github.com/NixOS/nixpkgs/commit/46683073edfd22c908355fa3cb0bdcc2670d8667) linux: 4.14.275 -> 4.14.276
* [`e85cc3d4`](https://github.com/NixOS/nixpkgs/commit/e85cc3d40f21c29549b9ca1afcd214ded5cd0504) linux: 4.19.237 -> 4.19.239
* [`1179f982`](https://github.com/NixOS/nixpkgs/commit/1179f98255c7e5f926e9d8415f2236563e89fb08) linux: 4.9.310 -> 4.9.311
* [`b7353ebc`](https://github.com/NixOS/nixpkgs/commit/b7353ebce847b9279f100db1eab0967c2d5fdbce) linux: 5.10.111 -> 5.10.112
* [`55f39cb8`](https://github.com/NixOS/nixpkgs/commit/55f39cb81e12a7de70ea3d7e9409efa242388de0) linux: 5.15.34 -> 5.15.35
* [`8a53f9a7`](https://github.com/NixOS/nixpkgs/commit/8a53f9a72aa12b7dd335082eb8067fda11ce80ac) linux: 5.17.3 -> 5.17.4
* [`b0d8ca58`](https://github.com/NixOS/nixpkgs/commit/b0d8ca58e54242b4c6bffb7aea39de9fbc293c40) linux: 5.4.188 -> 5.4.190
* [`9ab0fece`](https://github.com/NixOS/nixpkgs/commit/9ab0fece50af6a517705ce14e52e25cc9dc85632) linux_latest-libre: 18664 -> 18688
* [`d6b6293c`](https://github.com/NixOS/nixpkgs/commit/d6b6293c900116db7fdf187ee8c6e5ed6c5dfc16) linux-hardened: quickfix to make sure the updater is working again
* [`c1d59aab`](https://github.com/NixOS/nixpkgs/commit/c1d59aabb12e8c5c1758608bc396e25ead4dd65a) linux/hardened/patches/4.14: 4.14.269-hardened1 -> 4.14.276-hardened1
* [`206e53cc`](https://github.com/NixOS/nixpkgs/commit/206e53cc46fb78cf54f1454616b9a2bcc3fe0cf5) linux/hardened/patches/4.19: 4.19.232-hardened1 -> 4.19.239-hardened1
* [`63c0e3bb`](https://github.com/NixOS/nixpkgs/commit/63c0e3bbf7134b788d2a4b971822d5062466f729) linux/hardened/patches/5.10: 5.10.103-hardened1 -> 5.10.112-hardened1
* [`875b52ae`](https://github.com/NixOS/nixpkgs/commit/875b52ae4e37804d5084b8553d1cb9efcb213a1e) linux/hardened/patches/5.15: 5.15.26-hardened1 -> 5.15.35-hardened1
* [`bd45f28b`](https://github.com/NixOS/nixpkgs/commit/bd45f28ba1634df6636c4787e2c6e240b4659dd3) linux/hardened/patches/5.4: 5.4.182-hardened1 -> 5.4.190-hardened1
* [`5580ef0c`](https://github.com/NixOS/nixpkgs/commit/5580ef0c6369d433687a52835dd39c54d658eb43) linux_5_16: drop
* [`804ee6ef`](https://github.com/NixOS/nixpkgs/commit/804ee6ef179bad4911858bbf087125568c16c0dc) texlive: improve reproducibility
* [`b48f2c7e`](https://github.com/NixOS/nixpkgs/commit/b48f2c7ed39820484bb59273b37207596c326023) chntpw: Fix build on macos
* [`e85479a4`](https://github.com/NixOS/nixpkgs/commit/e85479a413c52a84358b43e62560dad9a1c70d93) maintainers: remove ktosiek
* [`0972fd24`](https://github.com/NixOS/nixpkgs/commit/0972fd249445dfc7a8bd26726ee0885a144c01c5) pur: 5.4.2 -> 6.1.0
* [`ddf61329`](https://github.com/NixOS/nixpkgs/commit/ddf613299d6ddde7ec41415919f378df330e0639) linux/hardened/4.14: fix build
* [`90c22150`](https://github.com/NixOS/nixpkgs/commit/90c22150c05dfdadebb89aaafcac656cd44dee9b) linux/hardened/4.19: fix build
* [`c381ab77`](https://github.com/NixOS/nixpkgs/commit/c381ab775ad99dd3b7b673961c8cdc26bcc85727) linux/hardened/5.4: fix build
* [`08d41ae3`](https://github.com/NixOS/nixpkgs/commit/08d41ae317d1f1d7db672776957212e9f3fb2fc6) vapoursynth: R57 -> R58
* [`8f0bd079`](https://github.com/NixOS/nixpkgs/commit/8f0bd079714d50a9b5df10df8fae72e848f40c21) tree-sitter-grammars.tree-sitter-janet-simple: init
* [`4c83c0b0`](https://github.com/NixOS/nixpkgs/commit/4c83c0b02709cc6f864485490f9120e8aef9755b) tree-sitter-grammars.tree-sitter-pgn: init
* [`0ca53cfd`](https://github.com/NixOS/nixpkgs/commit/0ca53cfd87f28f0952d81eee88df6afd9fc6ca65) you-get: 0.4.1555 -> 0.4.1602
* [`ef57e2fb`](https://github.com/NixOS/nixpkgs/commit/ef57e2fb8ddb4f9cf290af15a3aa11f0c52ffb49) common-updater-scripts/list-git-tags: prefer src.meta.homepage
* [`f14a57c9`](https://github.com/NixOS/nixpkgs/commit/f14a57c95b9256b079076d8137eee634e16ba0fa) gitUpdater: update comment for url
* [`be590c34`](https://github.com/NixOS/nixpkgs/commit/be590c34c62ff4c3a65064bf4f620ee1d07722fa) mirakurun: use gitUpdater
* [`122b290d`](https://github.com/NixOS/nixpkgs/commit/122b290dbe9b1365708e5872088fe3e42c79156b) epgstation: use gitUpdater
* [`b70e5055`](https://github.com/NixOS/nixpkgs/commit/b70e50558e5639fc3e09eef25381573d576bad45) paperwork: fix updateScript
* [`59cfe6e3`](https://github.com/NixOS/nixpkgs/commit/59cfe6e376f6b67593acf4d93c0cea240f7ffbd0) rebar3: remove explicit url passed to list-git-tags
* [`388b7857`](https://github.com/NixOS/nixpkgs/commit/388b7857f4e6eb943f816a4fc261c81203672ac7) erlang-ls: remove explicit url passed to list-git-tags
* [`320ce5c6`](https://github.com/NixOS/nixpkgs/commit/320ce5c6d7094e4b3b6ad7739914499d318ec911) elvis-erlang: remove explicit url passed to list-git-tags
* [`75904039`](https://github.com/NixOS/nixpkgs/commit/75904039f260c4d27aa9ed5de67b179ef8b67e14) libsForQt5.mlt: fix attrPath for updateScript
* [`d3befb0c`](https://github.com/NixOS/nixpkgs/commit/d3befb0ccb1986fb9811a8c2894cc61692703b00) texstudio: 4.2.2 -> 4.2.3
* [`7c2fd0ae`](https://github.com/NixOS/nixpkgs/commit/7c2fd0ae5d60e53e25d5b860c0c72838111379b5) stellarium: 0.22.0 -> 0.22.1
* [`224426ba`](https://github.com/NixOS/nixpkgs/commit/224426ba6d4370ede958c127d9b9866a189522f9) lib.types.submoduleWith: Avoid _key collisions after extendModules
* [`3d33f625`](https://github.com/NixOS/nixpkgs/commit/3d33f6253c951c305df971a61f9000076ece588a) redmine: Add update script
* [`72818f95`](https://github.com/NixOS/nixpkgs/commit/72818f956387304cae4b85b6367e565b814cde97) snapper: remove python2 as build dependency
* [`379b9c8b`](https://github.com/NixOS/nixpkgs/commit/379b9c8be30ee14eb8703ec00c7ea5da5337c6b6) lib/meta: add getExe to get the main program of a drv
* [`06187eb3`](https://github.com/NixOS/nixpkgs/commit/06187eb3d209a8526f8e664ef54e2782e325738f) python310Packages.Nikola: 8.2.0 -> 8.2.1
* [`1d24939a`](https://github.com/NixOS/nixpkgs/commit/1d24939a9a16f356923ca9403b2d90fa19da8036) git-machete: 3.8.0 -> 3.9.0
* [`00b2f3d8`](https://github.com/NixOS/nixpkgs/commit/00b2f3d8a733ea8c19ede9a2bddc2508cad8ce00) python310Packages.lightwave2: 0.8.9 -> 0.8.14
* [`6a666dbe`](https://github.com/NixOS/nixpkgs/commit/6a666dbecdabf8de9b792edca8a865bbb04a5d9d) gnome.gnome-maps: 42.0 → 42.1
* [`cc4300ec`](https://github.com/NixOS/nixpkgs/commit/cc4300eccde4ed1c53de3c078cf916190dc79b07) qt5: use 1t5.15 LTS for certain packages
* [`e93ac26f`](https://github.com/NixOS/nixpkgs/commit/e93ac26f47f32d2815ed1ec8333aefe7fcb5413b) libhandy: 1.6.1 -> 1.6.2
* [`592f5036`](https://github.com/NixOS/nixpkgs/commit/592f50365de901aa6007883cd30691e6f0efcf6b) libhandy: fix enableGlade build
* [`0d92d898`](https://github.com/NixOS/nixpkgs/commit/0d92d898ed0baba5195b8dee0d4d45ed8dbb76cf) platformsh: init at v3.78.0
* [`7f9e285f`](https://github.com/NixOS/nixpkgs/commit/7f9e285f5463c697af0fbba6baceb05c0b631851) bat-extras.batman: Add new dependency (util-linux)
* [`98358994`](https://github.com/NixOS/nixpkgs/commit/983589949fb0bb7ac15ec75ebb7fcfc7ee1d7d94) vpnc: enable parallel building
* [`3e8d4d62`](https://github.com/NixOS/nixpkgs/commit/3e8d4d62374cd66b4e8dd000857c09cb830f227b) chromiumDev: Fix the patch phase
* [`160fb93f`](https://github.com/NixOS/nixpkgs/commit/160fb93fdc4155d7e6304f366384ad8afb00db1e) nixos/filesystems: Make most simple filesystems compatible with systemd
* [`acca6999`](https://github.com/NixOS/nixpkgs/commit/acca69992cda719eb71f29f5c8eedf7892127e27) nixos/btrfs: Add systemd stage 1 support
* [`5724dddf`](https://github.com/NixOS/nixpkgs/commit/5724dddf1745ba3908d1e2db54fcdb36ec6f5184) haskellPackages.sensei: mark unbroken, override
* [`4b103773`](https://github.com/NixOS/nixpkgs/commit/4b103773f7f9ba8bdbe07b746e845a26832f04c5) python310Packages.tpm2-pytss: fix build, cleanup, prepare executing tests
* [`a36d4533`](https://github.com/NixOS/nixpkgs/commit/a36d4533767804b0cada4645f4c18cbb811d0b3d) haskellPackages.sensei: add libjared as maintainer
* [`a394a394`](https://github.com/NixOS/nixpkgs/commit/a394a39401236f06e7469323c5ef8a63dcedaa39) slurm: 21.08.6.1 -> 21.08.7.1
* [`84958d12`](https://github.com/NixOS/nixpkgs/commit/84958d12dc99c31eb39fd3db33bbce4085415ce7) speedometer: remove
* [`dc4b2812`](https://github.com/NixOS/nixpkgs/commit/dc4b2812e4c1b24f08349d4fdf23a8d85e0575a4) nixos/stage-1-systemd: Also accept packages as store paths
* [`45494fab`](https://github.com/NixOS/nixpkgs/commit/45494fab688f1e56e951d5046327677676626802) nixos/systemd-stage-1: Get rid of random-seed
* [`76bbb97f`](https://github.com/NixOS/nixpkgs/commit/76bbb97fe5356e88af8344b7a3781d1159a753bd) rdma-core: 39.1 -> 40.0
* [`dd47a9f4`](https://github.com/NixOS/nixpkgs/commit/dd47a9f456e832c6750d0d730bb8b6ee1bb28c71) kde/gear: 21.12.3 -> 22.04.0
* [`aee2d251`](https://github.com/NixOS/nixpkgs/commit/aee2d2511b53cb318c64a598779f653007ba0d3e) skanpage: move into/use kde/gear distribution from 22.04
* [`93b7f867`](https://github.com/NixOS/nixpkgs/commit/93b7f8679bdf8b39f184696b8e0fab11ea4cd80d) kdegraphics-thumbnailers: add mobipocket buildInput
* [`25278f97`](https://github.com/NixOS/nixpkgs/commit/25278f97f4f5592ed1913dc4a84f54b6d9456c3a) kalarmcal: remove package merged to kalarm
* [`18d5c053`](https://github.com/NixOS/nixpkgs/commit/18d5c05315ce4e84bc0d7e040e5cf7561f3d8bfc) kalendar: move into/use kde/gear distribution from 22.04
* [`2e19b676`](https://github.com/NixOS/nixpkgs/commit/2e19b6769576ffd7e7693f81c52e88f87fe02408) kde/gear: adjust some build breakages
* [`e587dcb9`](https://github.com/NixOS/nixpkgs/commit/e587dcb9811bab41a9fdbc87a1d70a3a7684ecba) calligra: build with poppler 22.03 and drop poppler_0_61
* [`5d733315`](https://github.com/NixOS/nixpkgs/commit/5d7333150ada24454555ed30cbf2da1dc72a86bf) digikam: 7.4.0 -> 7.6.0
* [`fa5f7871`](https://github.com/NixOS/nixpkgs/commit/fa5f78712ddf6e4da638646ca4e15d4952f3beba) mimetic: fix compilation failure with new toolchain
* [`69b03815`](https://github.com/NixOS/nixpkgs/commit/69b03815604f684b45372797d14d08a35bb7a1a9) falkon: 3.2.0 -> 22.04.0, kde gear
* [`973b6e60`](https://github.com/NixOS/nixpkgs/commit/973b6e60b712baebb7029421e26969690de37292) rpm-ostree: switch to python3
* [`a5212a77`](https://github.com/NixOS/nixpkgs/commit/a5212a77687aec9b55c0ba22863ff5c9b63a8cd1) haskell.packages.ghc922: use dbus_1_2_24
* [`a01811ab`](https://github.com/NixOS/nixpkgs/commit/a01811ab3b9b08773b53bc3fbfd9feef431a8460) nomad_1_1: 1.1.8 -> 1.1.12
* [`557b9aeb`](https://github.com/NixOS/nixpkgs/commit/557b9aebd6530a6d0547c35ba05e8acf81327495) python310Packages.jupyterlab_server: fix test execution
* [`9d99081d`](https://github.com/NixOS/nixpkgs/commit/9d99081d56337cbcf3b2b1487d59d6fde20a5330) python310Packages.ripser: fix build against c++, use pytestCheckHook
* [`2bc5c67f`](https://github.com/NixOS/nixpkgs/commit/2bc5c67f1c8c92d940b4e2238bfee7eaf5388935) python310Packages.scikit-learn-extra: disable failing test
* [`7d79c0d2`](https://github.com/NixOS/nixpkgs/commit/7d79c0d22a874efe1c39e7e97f722020e8462118) python310Packages.intensity-normalization: mark broken
* [`13961618`](https://github.com/NixOS/nixpkgs/commit/13961618532f97c7770a929fba7563f88a850558) zoxide: 0.8.0 -> 0.8.1
* [`b7ed282b`](https://github.com/NixOS/nixpkgs/commit/b7ed282b365e565cdcb82d923c8a989894cbd601) ibus: remove python2 library option
* [`b8ba0589`](https://github.com/NixOS/nixpkgs/commit/b8ba05895967c7e9d79d313187545c740b1227e2) gremlin-console: 3.5.3 -> 3.6.0
* [`cc17b841`](https://github.com/NixOS/nixpkgs/commit/cc17b8413c6d9dd0039540edf73808a975404f13) shortwave: 2.0.1 -> 3.0.0
* [`abc28679`](https://github.com/NixOS/nixpkgs/commit/abc2867933b2a5f8263f7570877d77be77b1eb7a) apkeep: 0.10.0 -> 0.11.0
* [`18833d2d`](https://github.com/NixOS/nixpkgs/commit/18833d2d94f6c937edea83ead19d7dde8bc4bca6) kotatogram-desktop: fix build with KF5.94
* [`f1527704`](https://github.com/NixOS/nixpkgs/commit/f15277040ca9b9b7f67a92904ec670112657c11d) kotatogram-desktop: merge tg_owt post-patch commands
* [`97913276`](https://github.com/NixOS/nixpkgs/commit/9791327619712bc6d495a6d741b446664730660b) python310Packages.teslajsonpy: 2.0.1 -> 2.0.3
* [`6cab7fb1`](https://github.com/NixOS/nixpkgs/commit/6cab7fb12d3fc59955f396ddc3855999fb94e832) atuin: 0.8.1 -> 0.9.1
* [`16dc611f`](https://github.com/NixOS/nixpkgs/commit/16dc611f05fe455e6451e45b5d42e19682031a07) bazel-remote: 2.3.6 -> 2.3.7
* [`c083780b`](https://github.com/NixOS/nixpkgs/commit/c083780b326ada46cd8a6d6e6d97e353409c8463) gay: fix build
* [`f50b1632`](https://github.com/NixOS/nixpkgs/commit/f50b16321e3b475d7ab03ca1fc8baa4d49eec570) lighthouse: remove
* [`a44a9240`](https://github.com/NixOS/nixpkgs/commit/a44a9240e2bd44cfe5de8a5ff913191bc2b14022) clj-kondo: 2022.04.08 -> 2022.04.23
* [`25d08688`](https://github.com/NixOS/nixpkgs/commit/25d086883cda803ca0399a53ed723c050a088c6c) musikcube: 0.96.10 -> 0.97.0
* [`9af334d8`](https://github.com/NixOS/nixpkgs/commit/9af334d8fcd78bc33590f6b8e3b1ce52d6daf83d) Revert "rmfuse: 0.2.1 -> 0.2.3"
* [`9ea7bd4e`](https://github.com/NixOS/nixpkgs/commit/9ea7bd4e67cc2bc3069b8961914cd80cc55037fa) rmfuse: 0.2.1 -> 0.2.3
* [`b2e2247f`](https://github.com/NixOS/nixpkgs/commit/b2e2247f8bc7d92a08a41eec2f9ca860ff597fba) python310Packages.pytest-snapshot: 0.8.1 -> 0.9.0
* [`00f3b062`](https://github.com/NixOS/nixpkgs/commit/00f3b0622336f4c6ed3492e7347a354563c2c553) libcef: 98.1.21 -> 100.0.24
* [`c98f0a46`](https://github.com/NixOS/nixpkgs/commit/c98f0a46f3cdf70e885cf972d07823202d314b1b) dasel: 1.24.1 -> 1.24.3
* [`90d56bd4`](https://github.com/NixOS/nixpkgs/commit/90d56bd46ddca348d7c711a8fefe4636f0c6c67a) openjpeg: include powerpc64le on doCheck=false list
* [`a5774e76`](https://github.com/NixOS/nixpkgs/commit/a5774e76bb8c3145eac524be62375c937143b80c) terraform-providers: update 2022-04-25
* [`604b9fed`](https://github.com/NixOS/nixpkgs/commit/604b9fed209049e013df8d24c85f491b0f5e06f6) dotnet-sdk: 6.0.201 -> 6.0.202
* [`c40790c7`](https://github.com/NixOS/nixpkgs/commit/c40790c7232625cee78a9770ab21282d270f0825) github-runner: update dependencies
* [`3570e5bf`](https://github.com/NixOS/nixpkgs/commit/3570e5bf40f3c097cbfed67cf185487c7116b8f5) inklecate: update dependencies
* [`6c3e18f7`](https://github.com/NixOS/nixpkgs/commit/6c3e18f759ce234b43f919779ab6bea44f12ace4) omnisharp-roslyn: update dependencies
* [`8a67b740`](https://github.com/NixOS/nixpkgs/commit/8a67b74064ec8e423cfd3d5724774a108befe544) ryujinx: update dependencies
* [`5f441966`](https://github.com/NixOS/nixpkgs/commit/5f4419669239b6fe391130fb1cd0368e9d3626b7) ArchiSteamFarm: update dependencies
* [`46f5fd8c`](https://github.com/NixOS/nixpkgs/commit/46f5fd8cfd8e660796a60e394a98de3df491c926) eksctl: 0.93.0 -> 0.94.0
* [`a97a00fc`](https://github.com/NixOS/nixpkgs/commit/a97a00fcebe2e4186642282b289bcee87a1f0aaf) nginx: fixup build with other than gcc11
* [`58c8e4c8`](https://github.com/NixOS/nixpkgs/commit/58c8e4c8c0a82c1de690226af5eb4153a7c495e6) osu-lazer: fix update.sh script
* [`4dd38e1b`](https://github.com/NixOS/nixpkgs/commit/4dd38e1b456965296ee16d56ea0c6d9ded493ac3) osu-lazer: update dependencies
* [`011f56b2`](https://github.com/NixOS/nixpkgs/commit/011f56b2cb724a8cdc318ee9df28ad1d5bc9b34a) tree-sitter: update grammars
* [`d1402a59`](https://github.com/NixOS/nixpkgs/commit/d1402a59b0477e4f40def3b2d49e6f2c1384de62) docker-slim: 1.37.5 -> 1.37.6
* [`5af0d861`](https://github.com/NixOS/nixpkgs/commit/5af0d861aaee215ee998d71803d64b61cb506696) awslogs: relax jmespath constraint
* [`126d6553`](https://github.com/NixOS/nixpkgs/commit/126d6553b34e4efb555fe4f554394bdaad902905) python310Packages.pg8000: 1.26.0 -> 1.26.1
* [`6ef74142`](https://github.com/NixOS/nixpkgs/commit/6ef74142ebc6451320c3af2e3ae77b871a07a274) archivy: 1.7.1 -> 1.7.2
* [`582a2d76`](https://github.com/NixOS/nixpkgs/commit/582a2d76835681a1d6a6dda245c6fbc7c77b6727) python3Packages.pytest-snapshot: disable on older Python releases
* [`d9eaa9d7`](https://github.com/NixOS/nixpkgs/commit/d9eaa9d70dbcb670d5b2ba1f3d1778b924975dda) evans: 0.10.3 -> 0.10.5
* [`99413d0f`](https://github.com/NixOS/nixpkgs/commit/99413d0f20a9d90db4ec1327553f16564610a86b) cpufetch: 1.01 -> 1.02
* [`6fe8ff98`](https://github.com/NixOS/nixpkgs/commit/6fe8ff983e26ae90bc66253df12ebb441a464af7) python3Packages.apsw: fix tests, add gador as maintainer
* [`85408763`](https://github.com/NixOS/nixpkgs/commit/8540876319735c0891f25c8c7c9d8475159ae8fe) hdhomerun-config-gui: fix install bin path
* [`1f4037d1`](https://github.com/NixOS/nixpkgs/commit/1f4037d13c637d6d807d15f15a4cf62331c90be1) flow: 0.176.2 -> 0.176.3
* [`eabc6334`](https://github.com/NixOS/nixpkgs/commit/eabc63347375c00eb35b88ad9d5833b5c9df96d3) python3Packages.aws-adfs: update substituteInPlace
* [`d11118ec`](https://github.com/NixOS/nixpkgs/commit/d11118ecfbc06f02a93a4ce94aa6b519197e77b0) flyctl: 0.0.320 -> 0.0.323
* [`9ef062f5`](https://github.com/NixOS/nixpkgs/commit/9ef062f508a6784eea87ca07a2abbd319065d47e) open-watcom-v2-unwrapped: unstable-2022-04-23 -> unstable-2022-04-24
* [`48bf204a`](https://github.com/NixOS/nixpkgs/commit/48bf204a58938376d6f6e2136d89878b9afcda7d) gbl: init at 0.3.1
* [`6f3b2327`](https://github.com/NixOS/nixpkgs/commit/6f3b232743b3e4b35d2cb187a48fdbcc49c9f070) frp: 0.41.0 -> 0.42.0
* [`fb838c9d`](https://github.com/NixOS/nixpkgs/commit/fb838c9d1a41fdabe97d128ba1f58f5c1c931425) bingo: 0.5.2 -> 0.6.0
* [`d3ea1663`](https://github.com/NixOS/nixpkgs/commit/d3ea16638bdfa59ef47ffebe438052c08ff91831) python3Packages.ansible-doctor: 1.2.1 -> 1.2.4
* [`8037d235`](https://github.com/NixOS/nixpkgs/commit/8037d235e25607c2b8f8da41a5daf37ef122acb4) bctoolbox: fix cross-compilation
* [`880071b4`](https://github.com/NixOS/nixpkgs/commit/880071b4cffab3c3693685669344334a2315d4e4) python3Packages.ansible-later: 2.0.9 -> 2.0.10
* [`25251762`](https://github.com/NixOS/nixpkgs/commit/25251762f7bdb352b8917f94862329edd9f5c6b4) python3Packages.aiohttp-remotes: set pytest flags
* [`fac3deee`](https://github.com/NixOS/nixpkgs/commit/fac3deeeddfaa7616b4ddac36f6803ec0101180d) python3Packages.aiohttp-swagger: don't use custom client for tests
* [`6f77ffd7`](https://github.com/NixOS/nixpkgs/commit/6f77ffd7f2cb307d746f84db4d0d9708c644628a) browserpass: 3.0.6 -> 3.0.10
* [`01a46a98`](https://github.com/NixOS/nixpkgs/commit/01a46a981727d5c04b21cd841667d0d5f198c787) python3Packages.collections-extended: add missing input
* [`8b62eae0`](https://github.com/NixOS/nixpkgs/commit/8b62eae04069ef0cd821f91759ad11d5ef94261d) evolution-data-server: 3.44.0 -> 3.44.1
* [`1606016e`](https://github.com/NixOS/nixpkgs/commit/1606016efdcc49e3f0636da44b81bc93c318d83f) gnome.nautilus: 42.0 -> 42.1.1
* [`4983d550`](https://github.com/NixOS/nixpkgs/commit/4983d550e4ee5531aced18344a160c41800195e0) gnome.eog: 42.0 -> 42.1
* [`ca3dae7c`](https://github.com/NixOS/nixpkgs/commit/ca3dae7c22aa554460ebf325c2879aaec2536ddb) gnome.gnome-remote-desktop: 42.0 -> 42.1
* [`7c4d42ca`](https://github.com/NixOS/nixpkgs/commit/7c4d42ca7720da83c3d1484c5f1b8fff29032b35) gnome-text-editor: 42.0 -> 42.1
* [`2d928b6c`](https://github.com/NixOS/nixpkgs/commit/2d928b6c61397c48cf3eef5d9cdec4ec4fffa2d0) kabeljau: init at 1.0.1 ([nixos/nixpkgs⁠#168930](https://togithub.com/nixos/nixpkgs/issues/168930))
* [`cad0ef2f`](https://github.com/NixOS/nixpkgs/commit/cad0ef2f059fa9c9a84d4eaa68c161ed2ab02177) libadwaita: 1.1.0 -> 1.1.1
* [`570591c4`](https://github.com/NixOS/nixpkgs/commit/570591c456d32bd5fc6fa284a8a8bcc6e4cfc599) gnome.gvfs: 1.50.0 -> 1.50.1
* [`ef0d40db`](https://github.com/NixOS/nixpkgs/commit/ef0d40db01c1f1a1295fb50dfde42ac2bf10f11b) python3Packages.vivisect: unbreak on python3
* [`94f12251`](https://github.com/NixOS/nixpkgs/commit/94f1225197c156725f8d218416e4471462b71010) calculix: fix build with gfortran 10
* [`5838726c`](https://github.com/NixOS/nixpkgs/commit/5838726cb99855821d1f465d90a2f9aa9d716750) calculix: 2.17 -> 2.19
* [`0d56b692`](https://github.com/NixOS/nixpkgs/commit/0d56b692fa0531c16160f60a64bc3f482a3d98fe) gromacs: 2022 -> 2022.1
* [`773f7905`](https://github.com/NixOS/nixpkgs/commit/773f7905b94e89bf9cd9d9fc606fd61235b5fc16) QtRVSim: 0.9.2 -> 0.9.3
* [`795cd447`](https://github.com/NixOS/nixpkgs/commit/795cd44716f1885febec24a4ecc392baca531184) libechonest: fix build with gcc 11
* [`0e29eb34`](https://github.com/NixOS/nixpkgs/commit/0e29eb34e21d86fb3a1cc39c251f8e768e5be277) Grafana Mimir: init at v2.0.0
* [`c3c33251`](https://github.com/NixOS/nixpkgs/commit/c3c33251e2894d05e3fb7ff3bb7857f543f09055) Grafana Mimir: Add maintainers
* [`b4a661a4`](https://github.com/NixOS/nixpkgs/commit/b4a661a46740e56cedf85a35beffd97050515215) mepo: 0.3 -> 0.4.1
* [`1a9e59ac`](https://github.com/NixOS/nixpkgs/commit/1a9e59acb740170445dc5d7f5c11d72c32d85e3f) clementine: 1.4.0rc1 -> unstable-2022-04-11
* [`a14a51f4`](https://github.com/NixOS/nixpkgs/commit/a14a51f4172b3217aa8342e07168d84fc6fc85f0) devspace: init at 5.18.4
* [`4deb5189`](https://github.com/NixOS/nixpkgs/commit/4deb5189a879593b4871479746d7b9acb4cb0eed) dotter: 0.12.9 -> 0.12.10
* [`19f5cc6e`](https://github.com/NixOS/nixpkgs/commit/19f5cc6ee7bc9b9615a2a8a27cabcb1d906c344c) vscode-extensions.davidanson.vscode-markdownlint: 0.46.0 -> 0.47.0
* [`68e9b54c`](https://github.com/NixOS/nixpkgs/commit/68e9b54c50867735e85a840fadd278eb025fb7bf) vscode-extensions.eamodio.gitlens: 12.0.3 -> 12.0.6
* [`ea81084e`](https://github.com/NixOS/nixpkgs/commit/ea81084e526248555ed43ce86c647fb61e186e80) vscode-extensions.esbenp.prettier-vscode: 9.3.0 -> 9.5.0
* [`5bbdf1dd`](https://github.com/NixOS/nixpkgs/commit/5bbdf1dd3355760b3fb7cf9812695aea480296d1) vscode-extensions.johnpapa.vscode-peacock: 4.0.0 -> 4.0.1
* [`8a31cb6e`](https://github.com/NixOS/nixpkgs/commit/8a31cb6e479f08dad1b2dd4521aab84201c6b4f7) vscode-extensions.ms-azuretools.vscode-docker: 1.20.0 -> 1.22.0
* [`ad3a396e`](https://github.com/NixOS/nixpkgs/commit/ad3a396ee694940f00f7356d41090ccb395672df) vscode-extensions.pkief.material-icon-theme: 4.14.1 -> 4.16.0
* [`2b071e05`](https://github.com/NixOS/nixpkgs/commit/2b071e05f02d0ef4011ca77b50e93fd146be09ba) go-license-detector: 3.1.0 -> 4.3.0
* [`a40607f7`](https://github.com/NixOS/nixpkgs/commit/a40607f7afa163c7ad89715b2aaa76c82e59cd00) cpufetch: update meta.license
* [`babdc25b`](https://github.com/NixOS/nixpkgs/commit/babdc25b1aaa005262b42ae48f04cc4443abcf50) oh-my-zsh: 2022-04-19 -> 2022-04-22 ([nixos/nixpkgs⁠#169921](https://togithub.com/nixos/nixpkgs/issues/169921))
* [`69eeae8d`](https://github.com/NixOS/nixpkgs/commit/69eeae8d53880576b05ac0dcf3a639968f5199a1) goreleaser: 1.8.1 -> 1.8.3
* [`11e8c21c`](https://github.com/NixOS/nixpkgs/commit/11e8c21cae8d5d7fc1bf68dc8d863fb159ffff4e) ibus-engines.table-others: 1.3.12 -> 1.3.13
* [`484a6779`](https://github.com/NixOS/nixpkgs/commit/484a67794d97e1a118730a29cb14bfd22130c859) python310Packages.coqpit: 0.0.15 -> 0.0.16
* [`aa2afa75`](https://github.com/NixOS/nixpkgs/commit/aa2afa75230a74a5406ab4027a4b1a72ebfd6dc7) nix-direnv: 2.0.0 -> 2.0.1
* [`6f34440c`](https://github.com/NixOS/nixpkgs/commit/6f34440ce20a23cfee79632f36e2061bb301d163) python3Packages.ihatemoney: disable failing tests
* [`434d86b2`](https://github.com/NixOS/nixpkgs/commit/434d86b2bc3f58bdf0e6a9f9f25917ce610f8fc7) libixp_hg: hg-2012-12-02 -> unstable-2022-04-04
* [`7ff11b66`](https://github.com/NixOS/nixpkgs/commit/7ff11b66e5d7e048b0fce90216f44c7ee0910071) python3Packages.dropbox: Add sfrijters as maintainer
* [`d5d7d011`](https://github.com/NixOS/nixpkgs/commit/d5d7d01114822ca42a3e558dd41a5e34a49d785d) tree-sitter: revert the parser for nix
* [`4679e06c`](https://github.com/NixOS/nixpkgs/commit/4679e06cfb21c4cc4f89444b52fdb83d8352b8d0) python310Packages.deezer-python: 5.3.0 -> 5.3.1
* [`97f1222d`](https://github.com/NixOS/nixpkgs/commit/97f1222dc764c7e10743fe5e720e6771032545cd) gnome.gnome-music: 42.0 → 42.1
* [`eca073f6`](https://github.com/NixOS/nixpkgs/commit/eca073f6e50b0c3a882559aea71aae975704ad73) azure-cli: pin azure-mgmt-servicelinker
* [`1e59f051`](https://github.com/NixOS/nixpkgs/commit/1e59f05167538c6f87cdc428ce064beede2609c9) python3Packages.pilkit: 2.0 -> unstable-2022-02-17
* [`304d78ce`](https://github.com/NixOS/nixpkgs/commit/304d78cec6b97ffe4734cba3a181c633339bdcc4) n8n: 0.173.1 → 0.174.0
* [`f8e483d8`](https://github.com/NixOS/nixpkgs/commit/f8e483d87a371c6dc26263df37fb1922830c1cb6) python310Packages.amply: 0.1.4 -> 0.1.5
* [`aedd51b0`](https://github.com/NixOS/nixpkgs/commit/aedd51b084df24886ed8222b3b63b322ac1a1fbf) python310Packages.asciimatics: 1.13.0 -> 1.14.0
* [`3ee2e79f`](https://github.com/NixOS/nixpkgs/commit/3ee2e79f5d2084d02b6b79134c1fd3dc404c1976) python310Packages.aioftp: 0.21.0 -> 0.21.2
* [`0a803ad7`](https://github.com/NixOS/nixpkgs/commit/0a803ad7098f3074ef266e607d2fd62e4a354c5a) freerdp: 2.6.1 -> 2.7.0
* [`bbf502a6`](https://github.com/NixOS/nixpkgs/commit/bbf502a6b09fc3d541855900af09513de7344f47) libnftnl: update homepage to https
* [`c80343c3`](https://github.com/NixOS/nixpkgs/commit/c80343c34011532f540771a99c2587a57691a0da) bitcoin: 22.0 -> 23.0
* [`a0a3c850`](https://github.com/NixOS/nixpkgs/commit/a0a3c85083ced9c00eac2ccb072fd3088ead3c6e) ledger-udev-rules: 2019-05-30 -> 2021-09-10
* [`d14db18f`](https://github.com/NixOS/nixpkgs/commit/d14db18fc785c543c0b38aa5425f7a38d9643921) python310Packages.fuse: 1.0.4 -> 1.0.5
* [`319165e4`](https://github.com/NixOS/nixpkgs/commit/319165e4216bd37713d2cee9c6592f760c5b5b34) codepy: init at 2019.1
* [`e0516f24`](https://github.com/NixOS/nixpkgs/commit/e0516f24a9a8db7cd6e0c7dcfc8180b8c113b52e) python3Packages.dropbox: Clean up package and enable more tests
* [`d6d8c43d`](https://github.com/NixOS/nixpkgs/commit/d6d8c43d117281f4e0372d43f4573504001253d4) pythonInterpreters.graalpython37: remove
* [`858dd45f`](https://github.com/NixOS/nixpkgs/commit/858dd45f625c3fe748a8f02bbbb322beacc3a03c) sumneko-lua-language-server: 3.1.0 -> 3.2.1
* [`c6ecf373`](https://github.com/NixOS/nixpkgs/commit/c6ecf3733804e7ff62f92650b45d6f7837c4a40d) swaytools: 0.1.0 -> 0.1.1
* [`49d3cbee`](https://github.com/NixOS/nixpkgs/commit/49d3cbee1836e1f4d4b152c9c7d922f23d278947) omnisharp-roslyn: fix errors related to dlls
* [`df760d5b`](https://github.com/NixOS/nixpkgs/commit/df760d5b58e043507495bf04073ce7e8b1edafbb) Update darwin versions and comment on difference to linux
* [`6ed76cba`](https://github.com/NixOS/nixpkgs/commit/6ed76cba02c579466d67cda632a0954444796112) dry up installPhase with shared runHooks
* [`3a52ece9`](https://github.com/NixOS/nixpkgs/commit/3a52ece9da409dcd9377a5f4b757c29811902f1e) vault-bin: 1.10.0 -> 1.10.1
* [`d8051a6a`](https://github.com/NixOS/nixpkgs/commit/d8051a6a4c20424393bf5c994e70a9c2bbf9ead1) kubernetes-helm: 3.8.1 -> 3.8.2
* [`1d395b2c`](https://github.com/NixOS/nixpkgs/commit/1d395b2c9a82a8bca6f7f67640641c73e833f3d4) python3Packages.seventeentrack: 2022.04.5 -> 2022.04.6
* [`83677514`](https://github.com/NixOS/nixpkgs/commit/83677514e6f9bb827b8c593c154db11e06fcfd4f) .github/CODEOWNERS: add IvarWithoutBones for dotnet
* [`7cee7f98`](https://github.com/NixOS/nixpkgs/commit/7cee7f985e252cb34b72d9d75aab31ce692ed5b0) fwupd: 1.7.6 -> 1.7.7
* [`d7ebbcde`](https://github.com/NixOS/nixpkgs/commit/d7ebbcde879a0b1808e185fb662f20f8ed7b2538) pulumi-bin: 3.29.1 -> 3.30.0
* [`ca47537b`](https://github.com/NixOS/nixpkgs/commit/ca47537b9d4293233783e27180fa7fa6d90e40bd) python3Packages.neo4j-driver: 4.4.2 -> 4.4.3
* [`c62e601a`](https://github.com/NixOS/nixpkgs/commit/c62e601ac83b0870445ae32bee957106e2f50b0e) odpdown: remove
* [`6f5f386a`](https://github.com/NixOS/nixpkgs/commit/6f5f386a6c24d5a5035616e498036bb8163f5719) openrct2: 0.3.5.1 -> 0.4.0
* [`0dc64213`](https://github.com/NixOS/nixpkgs/commit/0dc64213dc7d792ea07deda5da31ad53ec8b40f8) python3Packages.update-dotdee: disable failing test
* [`af7d06ed`](https://github.com/NixOS/nixpkgs/commit/af7d06ed59d9caa1bb03de7c6624d93b2c084cdf) fenics: use normal pytest
* [`cb610be2`](https://github.com/NixOS/nixpkgs/commit/cb610be2a0950efe7688872e1aa3d360abdce5eb) python3Packages.pencompy: init at 0.0.4
* [`b511a75c`](https://github.com/NixOS/nixpkgs/commit/b511a75cb908aea3b157e9b138281f01f49e4745) home-assistant: update component-packages
* [`3e213d5f`](https://github.com/NixOS/nixpkgs/commit/3e213d5f38b8b984b0c4c751cb2c4ccab824701f) python3Packages.hkavr: init at 0.0.5
* [`a2801d43`](https://github.com/NixOS/nixpkgs/commit/a2801d435b5d825e633066a3ee2f8fa84976ce92) home-assistant: update component-packages
* [`3ace2795`](https://github.com/NixOS/nixpkgs/commit/3ace2795b393de60f05b62b177bfa730fd46b4c8) chntpw: Import debian bugfix patches
* [`766646b0`](https://github.com/NixOS/nixpkgs/commit/766646b0f28a39c4e8b593c61211b4db4987d013) python3Packages.pyoppleio: init at 1.0.6
* [`26f5f9c6`](https://github.com/NixOS/nixpkgs/commit/26f5f9c6e32b8149887f60f0d570ac8d5c9b2e2a) home-assistant: update component-packages
* [`f33c02c4`](https://github.com/NixOS/nixpkgs/commit/f33c02c4311d755fd2efb36e1ba0f87b98bb0eb9) ChowPhaser: init at 1.1.1
* [`1bb9bb53`](https://github.com/NixOS/nixpkgs/commit/1bb9bb532397cd44d227f1c3e8eb3dac9fce20da) protoc-gen-doc: 1.5.0 -> 1.5.1
* [`7db78648`](https://github.com/NixOS/nixpkgs/commit/7db7864871845b83af9cc8564a6f1180d2b52542) calibre-web: relax Flask, Flask-Login and lxml requirements
* [`00e66f10`](https://github.com/NixOS/nixpkgs/commit/00e66f10fa1120875201eace3b0a238f7d1b39ca) coq: Rename internal versionAtLeast helper to coqAtLeast
* [`6920d8ca`](https://github.com/NixOS/nixpkgs/commit/6920d8ca42b081c874486ad16fc66f43d8bb8074) treewide: Simplify negated uses of versionAtLeast, versionOlder
* [`370c03a0`](https://github.com/NixOS/nixpkgs/commit/370c03a02ebc62224345472b1eee152072f7fc59) python3Packages.rjpl: init at 0.3.6
* [`6e1e5eac`](https://github.com/NixOS/nixpkgs/commit/6e1e5eaccd3a0984f26b2b678581b49ac5217597) home-assistant: update component-packages
* [`7e66d64e`](https://github.com/NixOS/nixpkgs/commit/7e66d64ed57d3446d5fc33983e86cfa13c717ae9) nut: fix compile error
* [`fece5997`](https://github.com/NixOS/nixpkgs/commit/fece5997c0cd1a18fa8cd1466fa3a49503cef2d4) mockgen: fix tests
* [`163c21d9`](https://github.com/NixOS/nixpkgs/commit/163c21d9bb157ef015f36680d9f9c1d8af8c430f) routinator: 0.11.1 -> 0.11.2
* [`2f39155a`](https://github.com/NixOS/nixpkgs/commit/2f39155ad40b7826fcd7d4d82a3170d4d2d59fe6) python3Packages.dropbox: Update hash for re-release of 11.30.0
* [`50502019`](https://github.com/NixOS/nixpkgs/commit/505020191dcda961d428212e623c52b337faba8a) czkawka: 4.0.0 -> 4.1.0
* [`30e155c5`](https://github.com/NixOS/nixpkgs/commit/30e155c55264c66610db2ac249edf0238673f790) dapr-cli: 1.1.0 -> 1.7.0
* [`092dad1b`](https://github.com/NixOS/nixpkgs/commit/092dad1b2a238e6dfd86bffc54bc3a0e1e2b81ca) python3Packages.pyrogram: 1.4.16 -> 2.0.13
* [`44318a9e`](https://github.com/NixOS/nixpkgs/commit/44318a9e10c42aed4b0aa5468892f29ce20a5bbe) python3Packages.pytest-isort: switch to GitHub as source
* [`23089a1c`](https://github.com/NixOS/nixpkgs/commit/23089a1c18b14bffaa793ed59740eefb2a94dbda) go-protobuf: enable tests
* [`7f4a8f37`](https://github.com/NixOS/nixpkgs/commit/7f4a8f37d4621b27fc0c4eeb3880ecf1cb055371) jitsi-meet-electron: respect NIXOS_OZONE_WL ([nixos/nixpkgs⁠#170304](https://togithub.com/nixos/nixpkgs/issues/170304))
* [`9759288f`](https://github.com/NixOS/nixpkgs/commit/9759288f340754dbe1a33e55343a1931eb807140) hcloud: 1.29.0 -> 1.29.5
* [`6da8554b`](https://github.com/NixOS/nixpkgs/commit/6da8554b2eb85ce06dd86f5549ff54fff2a43d73) nuclei: 2.6.8 -> 2.6.9
* [`6d1396e4`](https://github.com/NixOS/nixpkgs/commit/6d1396e41334c9635e8b80dd3d77f2374d9ad0d8) quickemu: 3.14 -> 3.15
* [`676198fd`](https://github.com/NixOS/nixpkgs/commit/676198fded3bd18516af19e4b9e5e8d0ba82ee5f) python3Packages.weconnect: 0.38.1 -> 0.39.0
* [`06ad766d`](https://github.com/NixOS/nixpkgs/commit/06ad766d4231748b22380309db33d79f1650c212) python3Packages.weconnect-mqtt: 0.32.0 -> 0.33.0
* [`7c1c86a7`](https://github.com/NixOS/nixpkgs/commit/7c1c86a713ff99ce6adc3157e5750f6ad77e16dc) protolock: enable tests
* [`eddb2a15`](https://github.com/NixOS/nixpkgs/commit/eddb2a151f1ed061e6aa2129866305a0a165de26) checkov: 2.0.1077 -> 2.0.1084
* [`8a5f8a4d`](https://github.com/NixOS/nixpkgs/commit/8a5f8a4d8747e446165ee439e07850c68f2ead3f) gortr: enable tests
* [`b2cc79c2`](https://github.com/NixOS/nixpkgs/commit/b2cc79c2a8d13161a6c82dee6ecb8d5c5f040780) gofumpt: enable tests
* [`e05409c5`](https://github.com/NixOS/nixpkgs/commit/e05409c5ce2058f7e1d8c89e2928cbef645085dc) python310Packages.flake8-bugbear: 22.3.23 -> 22.4.25 ([nixos/nixpkgs⁠#170281](https://togithub.com/nixos/nixpkgs/issues/170281))
* [`21458a47`](https://github.com/NixOS/nixpkgs/commit/21458a47a5ddffb1b8051df86b6d09ffea442be5) redmine: 4.2.4 -> 4.2.5
* [`37f9102a`](https://github.com/NixOS/nixpkgs/commit/37f9102a1deb4c14110db47c7f8444bba7b37759) kacst: init at 2.01
* [`ee533442`](https://github.com/NixOS/nixpkgs/commit/ee533442b29f7d84d24bead654b2f7250d9918ed) maintainers: add serge
* [`d59a5a9f`](https://github.com/NixOS/nixpkgs/commit/d59a5a9f1b4e483b885ddfb62dab7bf6fc542254) python310Packages.caldav: 0.8.2 -> 0.9.0
* [`579330cb`](https://github.com/NixOS/nixpkgs/commit/579330cb448161937f620a307983e78ce2ba3842) pouf: init at 0.4.1 ([nixos/nixpkgs⁠#170330](https://togithub.com/nixos/nixpkgs/issues/170330))
* [`c0212333`](https://github.com/NixOS/nixpkgs/commit/c0212333c618ab675bd31424706f9fc0c8351673) python310Packages.mkdocs-material: 8.2.9 -> 8.2.11
* [`293a5455`](https://github.com/NixOS/nixpkgs/commit/293a5455f31039a590cca0b844d134736fedae46) python310Packages.ffcv: fix build ([nixos/nixpkgs⁠#170158](https://togithub.com/nixos/nixpkgs/issues/170158))
* [`4d12f939`](https://github.com/NixOS/nixpkgs/commit/4d12f939d4cd5e7cde66a5a92363d6cb61b7ca9a) cypress: 9.5.4 -> 9.6.0
* [`5c0ff7c3`](https://github.com/NixOS/nixpkgs/commit/5c0ff7c3d993130cdc0e132d0a7a146390618ea2) python310Packages.hahomematic: 1.1.4 -> 1.1.5
* [`bdfa16df`](https://github.com/NixOS/nixpkgs/commit/bdfa16df6c41e54f20f00ef7dc029b358488c76d) ytfzf: 2.2 -> 2.3
* [`d21c94cd`](https://github.com/NixOS/nixpkgs/commit/d21c94cd35ab90d237a768cbce4a1376c339f705) python3Packages.pikepdf: 5.1.1 -> 5.1.2
* [`9e39f6ea`](https://github.com/NixOS/nixpkgs/commit/9e39f6eae2b1aad269142191e858010c18869553) python3Packages.aprslib: 0.7.0 -> 0.7.1
* [`5c63410e`](https://github.com/NixOS/nixpkgs/commit/5c63410e0eb6bb61804abfeabefa7bdcc32153e3) python3Packages.pycoolmasternet-async: 0.1.2 -> 0.1.3
* [`df2e1177`](https://github.com/NixOS/nixpkgs/commit/df2e11770d0797853a5f77ecf48096533091ca65) python310Packages.mypy-boto3-s3: 1.21.34 -> 1.22.0.post1
* [`4fabde08`](https://github.com/NixOS/nixpkgs/commit/4fabde08f941424dc033e6c983af2436123d3cf9) taskflow: init at 3.3.0
* [`463ca4ee`](https://github.com/NixOS/nixpkgs/commit/463ca4ee100b3a2f7ca7afb9ea2b51314ade293b) rapidfuzz-cpp: init at 1.0.1
* [`a4ba2bd9`](https://github.com/NixOS/nixpkgs/commit/a4ba2bd977433708a0be3e2c51b5eabfa2ac9c3d) jarowinkler-cpp: init at 1.0.0
* [`5f5f908c`](https://github.com/NixOS/nixpkgs/commit/5f5f908cdea6565a5c754e2f0e7e9cf8332e323c) python3Packages.rapidfuzz: 2.0.8 -> 2.0.11
* [`5283e2c5`](https://github.com/NixOS/nixpkgs/commit/5283e2c5ed2780b13c438509c44b769a49953bd5) libtmux: avoid passing pkgs as input
* [`73884e5f`](https://github.com/NixOS/nixpkgs/commit/73884e5fb18cd63e89903327729e0f9d874e42fd) libtmux: 0.10.3 -> 0.11.0
* [`7c01ec62`](https://github.com/NixOS/nixpkgs/commit/7c01ec626b2a5cb398b192f639e5b4387ab32570) tmuxp: 1.9.2 -> 1.11.0
* [`492cb7ef`](https://github.com/NixOS/nixpkgs/commit/492cb7efa0c50651590eb3acbed32e446cc3a5ca) libsForQt5.maplibre-gl-native: init at unstable-2022-04-07
* [`84f4037e`](https://github.com/NixOS/nixpkgs/commit/84f4037e741679291d4075a158cf390f70a99e5d) libsForQt5.mapbox-gl-qml: 1.7.7.1 -> 2.0.1
* [`01edd1a4`](https://github.com/NixOS/nixpkgs/commit/01edd1a40921de1053b97d300683e8dea6fbc010) pure-maps: 2.9.2 -> 3.0.0
* [`6885610b`](https://github.com/NixOS/nixpkgs/commit/6885610b2044bd9a5ac1e4fedec199cc2a16ce5d) python310Packages.glcontext: 2.3.5 -> 2.3.6
* [`2866c3f4`](https://github.com/NixOS/nixpkgs/commit/2866c3f4cab5322b17a8c8324fb032ac5ed294fb) upgrade ansible-core to 2.12.5
* [`7859b5e8`](https://github.com/NixOS/nixpkgs/commit/7859b5e8f7671af4c276a98833af40ea45f38090) upgrade ansible collections to 5.6.0
* [`3a27c7fe`](https://github.com/NixOS/nixpkgs/commit/3a27c7fe7083b752bf62bd3936ae7fa80a6f71ff) clucene_core_2: fix cross compile
* [`05a6bcb7`](https://github.com/NixOS/nixpkgs/commit/05a6bcb708967bb6ceff019207c607c253612cf5) python310Packages.pyoppleio: 1.0.6 -> 1.0.7
* [`b491eacf`](https://github.com/NixOS/nixpkgs/commit/b491eacf7fa61cefdf0bfe35fe70ca6e6085ee78) python3Packages.jeepney: 0.7.1 -> 0.8.0
* [`e663518d`](https://github.com/NixOS/nixpkgs/commit/e663518d18e7dedce127edc26888fd997e6c1e73) all-packages.nix: add bootstrapTools to top-level.nix
* [`1f399bac`](https://github.com/NixOS/nixpkgs/commit/1f399bac821f11dda374c86ccded9d199bab9f01) bionic_prebuilt: add x86_64 support
* [`bea03532`](https://github.com/NixOS/nixpkgs/commit/bea03532b9a185ff62ae4540ebf6999eea407747) python3Packages.mkdocs-material: disable on older Python releases
* [`48d473f1`](https://github.com/NixOS/nixpkgs/commit/48d473f1c319157f85a1e22cd1e16e8831c81227) upower: fix cross-compilation support
* [`c7352fbc`](https://github.com/NixOS/nixpkgs/commit/c7352fbc0eba3f2d7d06a429e997cb3a5b53c603) python310Packages.winsspi: 0.0.9 -> 0.0.10
* [`162ea08a`](https://github.com/NixOS/nixpkgs/commit/162ea08aab1a156308a6f35bec867479da5be4b4) python310Packages.pypykatz: 0.5.6 -> 0.5.7
* [`e5b0ba77`](https://github.com/NixOS/nixpkgs/commit/e5b0ba7750d1883f4db96ec80b808a49ac4480a2) redshift_jdbc: init at 2.1.0.3
* [`a7c93695`](https://github.com/NixOS/nixpkgs/commit/a7c93695a5254a0d9fa73c6f9e7628791a9c31a9) liquibase_redshift_extension: init at 4.8.0
* [`3ffe1ccc`](https://github.com/NixOS/nixpkgs/commit/3ffe1ccca03d732f4b5cb435ed4be7cef86a29c2) liquibase: add support for Amazon Redshift
* [`c154c1cd`](https://github.com/NixOS/nixpkgs/commit/c154c1cd79882a70491110a2740af2a3b74b93d6) kompose: use testers.testVersion
* [`fd39a60a`](https://github.com/NixOS/nixpkgs/commit/fd39a60a421e57374f217c277576295fae22a41f) mas: use testers.testVersion
* [`76196d6f`](https://github.com/NixOS/nixpkgs/commit/76196d6f1927e69f18e9229d4b01676721d69ab3) gosu: use testers.testVersion
* [`32e21f38`](https://github.com/NixOS/nixpkgs/commit/32e21f38cda97142b4a6cf76731d46e0c8d32119) comma: use testers.testVersion
* [`2be43f13`](https://github.com/NixOS/nixpkgs/commit/2be43f13935d1e65718f3453d4159bf66c2c4f6f) python3Packages.winsspi: disable on older Python releases
* [`dd4ca36a`](https://github.com/NixOS/nixpkgs/commit/dd4ca36aac752f0b15824b241343d8d7bb0ac006) natscli: 0.0.30 -> 0.0.32
* [`0c922b4e`](https://github.com/NixOS/nixpkgs/commit/0c922b4ea680ff2fa2d7c120c0eaea32694f7eb0) evtest: update sha256 hash
* [`7fadb8fb`](https://github.com/NixOS/nixpkgs/commit/7fadb8fb78260a2025d24b60b632289f608f8680) session-desktop-appimage: 1.7.9 -> 1.8.4
* [`89f390a4`](https://github.com/NixOS/nixpkgs/commit/89f390a40b79bcf2170c4060540a5392c8d1a06a) mmark: 1.3.6 -> 2.2.25
* [`14fca0ca`](https://github.com/NixOS/nixpkgs/commit/14fca0ca6ff878cb3c071fe5c233b5fd5ad8d13b) couchdb3: 3.2.1 -> 3.2.2
* [`0f946e28`](https://github.com/NixOS/nixpkgs/commit/0f946e28754e1da24d373fe9c64b89b51acb3463) ansible: prune old versions; restructure
* [`e6194ec4`](https://github.com/NixOS/nixpkgs/commit/e6194ec45c9f44745c3e1979d4fc535a64d7156e) python310Packages.ansible-later: 2.0.10 -> 2.0.11
* [`7fb99b72`](https://github.com/NixOS/nixpkgs/commit/7fb99b7216002dfbd8bf1b5d5bdf4a829e1a1650) python3Packages.labgrid: add packaging module
* [`198793be`](https://github.com/NixOS/nixpkgs/commit/198793be2dd136b1ee7a67119d7ba4808389c00a) python3Packages.pytest-ansible: mark broken with ansible>=2.10
* [`813330fa`](https://github.com/NixOS/nixpkgs/commit/813330fa92cd8a9e5c8b38fd9f2d020334566e24) kargo: use ansible-core
* [`19b27559`](https://github.com/NixOS/nixpkgs/commit/19b2755900038866fe20888e4503573059816136) python3Packages.ansible-runner: use ansible-core
* [`12c59672`](https://github.com/NixOS/nixpkgs/commit/12c596725d142c64e364c32456eb0d7cd1d39485) python3Packages.ansible-compat: use ansible-core
* [`c1e318d0`](https://github.com/NixOS/nixpkgs/commit/c1e318d0c5d2a065cecb9299fc58f889050f4149) services.gitlab-runner: support runner description
* [`559f41b0`](https://github.com/NixOS/nixpkgs/commit/559f41b0ec701712e506477bfaee6c68c249a1c5) sigal: 2.2 -> 2.3
* [`82fbd081`](https://github.com/NixOS/nixpkgs/commit/82fbd08191e65e8ab21cf37efff9510537454c47) python310Packages.mocket: 3.10.4 -> 3.10.5
* [`11dbf948`](https://github.com/NixOS/nixpkgs/commit/11dbf9489def60f54836d3c8aa436c59d98ae8d9) gbl: use testers.testVersion
* [`3a07bb6a`](https://github.com/NixOS/nixpkgs/commit/3a07bb6ae12e73d6a99551e7ae0d45ff0ee61b03) mysql-shell: remove unused testVersion from args
* [`a4c5a4af`](https://github.com/NixOS/nixpkgs/commit/a4c5a4af3608f1725940db5d4517409a058add32) fclones: 0.20.1 -> 0.21.0
* [`45ec327c`](https://github.com/NixOS/nixpkgs/commit/45ec327c04e358363d2aa4882aa365c703857357) python310Packages.svdtools: 0.1.21 -> 0.1.22
* [`86f05ffd`](https://github.com/NixOS/nixpkgs/commit/86f05ffd7d3dc8f079d2f2390c40ad66ea41eca4) python310Packages.pybullet: 3.2.2 -> 3.2.4
* [`7e2dc25c`](https://github.com/NixOS/nixpkgs/commit/7e2dc25cd1150e63a98d1c1dd83313b8286e487a) python310Packages.boxx: 0.9.11 -> 0.10.0
* [`0872d0d8`](https://github.com/NixOS/nixpkgs/commit/0872d0d82ea419bda0330ffc15121dfee4995285) terraform-providers.buildkite: init at v0.8.0 ([nixos/nixpkgs⁠#170405](https://togithub.com/nixos/nixpkgs/issues/170405))
* [`68322e12`](https://github.com/NixOS/nixpkgs/commit/68322e1297ce606a37622186c85c7b60dd336a1c) coqPackages.mathcomp-word: 1.0 → 1.1
* [`9d15d462`](https://github.com/NixOS/nixpkgs/commit/9d15d4620b0e559020f89c768d38096b22b6e58d) evolution: 3.44.0 -> 3.44.1
* [`debfa672`](https://github.com/NixOS/nixpkgs/commit/debfa6723c4affb080fcf1ce74d166aba5414f50) python3Packages.boxx: disable on older Python releases
* [`77abea3a`](https://github.com/NixOS/nixpkgs/commit/77abea3aae675b3843f312b2dd99abab2565fa4c) trivy: 0.26.0 -> 0.27.0
* [`7fe8c7fd`](https://github.com/NixOS/nixpkgs/commit/7fe8c7fd43743178c7681e87b5cddfef774b85c8) python3Packages.svdtools: remove stale substituteInPlace
* [`786a6094`](https://github.com/NixOS/nixpkgs/commit/786a6094962bae771c9f7f085deefd0a7e157876) ranger: add optional python dependencies ([nixos/nixpkgs⁠#170328](https://togithub.com/nixos/nixpkgs/issues/170328))
* [`eb1bc95c`](https://github.com/NixOS/nixpkgs/commit/eb1bc95c2d886a13e16cc6d0469c7405bd296373) caddy: 2.4.6 -> 2.5.0
* [`ec2c6af0`](https://github.com/NixOS/nixpkgs/commit/ec2c6af0f1a5a09c202ca9436bcdad8d80f86034) wmii: hg-2012-12-09 -> unstable-2022-04-04
* [`ca3c297d`](https://github.com/NixOS/nixpkgs/commit/ca3c297d867f59859ba464c5b818086385b76e8c) simpleitk: move headers to dev output ([nixos/nixpkgs⁠#170165](https://togithub.com/nixos/nixpkgs/issues/170165))
* [`ab968d7d`](https://github.com/NixOS/nixpkgs/commit/ab968d7dd0df4f13d7ff1ae6d4794950a55c63f7) assaultcube: 1.2.0.2 -> 1.3.0.2
* [`32a1b56a`](https://github.com/NixOS/nixpkgs/commit/32a1b56a7435c49650d4461eea854b6bfae3b09f) vapoursynth: reduce with usage
* [`67db991f`](https://github.com/NixOS/nixpkgs/commit/67db991f17d459a81f2e312233c6af0394e45b56) vapoursynth: fix nix search version parsing
* [`6485d949`](https://github.com/NixOS/nixpkgs/commit/6485d94992ca3edb45923e1f910eb64b0d1ab2cb) perlPackages.LexicalSealRequireHints: init at 0.0011
* [`74d938f1`](https://github.com/NixOS/nixpkgs/commit/74d938f11966446d25585821d96551f7f84b086d) hcloud: fix version ldflag
* [`3c0367bc`](https://github.com/NixOS/nixpkgs/commit/3c0367bcc2e5356657fb598254437ba3f1deb690) wp4nix: init at 1.0.0
* [`2158b4f4`](https://github.com/NixOS/nixpkgs/commit/2158b4f411423db94b31ab26b3dba9e883aeb079) philter: remove
* [`02100048`](https://github.com/NixOS/nixpkgs/commit/021000482b9e4e25c468faf160536508dd8a72ab) libviperfx: init at unstable-2018-01-15
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
