### PR TITLE
niv emacs-overlay: update 4356a064 -> 3960283c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4356a0643b98868883425711daa02dde1290b2ed",
-        "sha256": "08vljl2v1nba6cr3fjmibqnh679sc1inf6sy5ayjh2j35bxi2sk0",
+        "rev": "3960283c022627d29c00dfdcb6b2228396b115b3",
+        "sha256": "00qv7d7jllk68i4nk2ap9kpjlllv7bzd0qvzpnlk6izmzzsncc42",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/4356a0643b98868883425711daa02dde1290b2ed.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/3960283c022627d29c00dfdcb6b2228396b115b3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@4356a064...3960283c](https://github.com/nix-community/emacs-overlay/compare/4356a0643b98868883425711daa02dde1290b2ed...3960283c022627d29c00dfdcb6b2228396b115b3)

* [`d9dd20a8`](https://github.com/nix-community/emacs-overlay/commit/d9dd20a85eba5188e927e10316bafbf362048b6a) Updated repos/emacs
* [`53327a35`](https://github.com/nix-community/emacs-overlay/commit/53327a35225b6876329fe8334cb56555d90a916d) Updated repos/melpa
* [`5f258dfd`](https://github.com/nix-community/emacs-overlay/commit/5f258dfdab8e58abe2e44b78a3ccf262041f7b74) Updated repos/nongnu
* [`1ed15a5d`](https://github.com/nix-community/emacs-overlay/commit/1ed15a5d4f31f75b180aaa71dc273b8940b1a163) Updated repos/emacs
* [`cff805af`](https://github.com/nix-community/emacs-overlay/commit/cff805afbd9b5115a781df553b21e479e772aa61) Updated repos/melpa
* [`3a52bb5a`](https://github.com/nix-community/emacs-overlay/commit/3a52bb5a2fc443fcb3ca3ff80a79c2498a7ad934) Updated repos/emacs
* [`c96b4e69`](https://github.com/nix-community/emacs-overlay/commit/c96b4e694a1307d805b20fc9d7ddd0fcc0c8619b) Updated repos/melpa
* [`d98d19e7`](https://github.com/nix-community/emacs-overlay/commit/d98d19e77aad6451b3fb6a584b82b675d1a107c4) Updated repos/emacs
* [`21e9d952`](https://github.com/nix-community/emacs-overlay/commit/21e9d952151321735b0e379728f8bf163da606a6) Updated repos/melpa
* [`618322f6`](https://github.com/nix-community/emacs-overlay/commit/618322f63deff3ba260bcf3f5a8daa7995e8ddb6) Updated repos/emacs
* [`5ce36b9d`](https://github.com/nix-community/emacs-overlay/commit/5ce36b9d3180f647a585c7c3aaaf39ed6cae4f3c) Updated repos/melpa
* [`42344d3a`](https://github.com/nix-community/emacs-overlay/commit/42344d3a2a461bb974c8ccf82a7416c2f4e42c5c) Updated repos/elpa
* [`31953af1`](https://github.com/nix-community/emacs-overlay/commit/31953af15a3e762102dbcfdeac0d997fb3fda814) Updated repos/emacs
* [`754f0951`](https://github.com/nix-community/emacs-overlay/commit/754f0951f87e644297f1366a29031dbf84ff83b6) Updated repos/melpa
* [`f590816f`](https://github.com/nix-community/emacs-overlay/commit/f590816f135d299b60472f196ee703153c955b79) Updated repos/emacs
* [`12a28f7f`](https://github.com/nix-community/emacs-overlay/commit/12a28f7f05867d4ea80b26158523600354aaf6a6) Updated repos/melpa
* [`6b919b7e`](https://github.com/nix-community/emacs-overlay/commit/6b919b7e7bc19a99c905bc4e9f22a7bcb7241fb1) Updated repos/elpa
* [`f080ed8f`](https://github.com/nix-community/emacs-overlay/commit/f080ed8f7276adf800670830296baba85ec6bbce) Updated repos/emacs
* [`391a03f3`](https://github.com/nix-community/emacs-overlay/commit/391a03f37369bb2857ebbc996c37e7855181b0f5) Updated repos/melpa
* [`65b0b30b`](https://github.com/nix-community/emacs-overlay/commit/65b0b30b4d2696aca880b9de2d0826cbff9d41de) Updated repos/elpa
* [`865fbed5`](https://github.com/nix-community/emacs-overlay/commit/865fbed591a90625b1b9c82c5e4a80d3257f6e0c) Updated repos/emacs
* [`ae922968`](https://github.com/nix-community/emacs-overlay/commit/ae922968e1277e6526ffd76ab69e4c07dafae4c4) Updated repos/melpa
* [`2d7a5e16`](https://github.com/nix-community/emacs-overlay/commit/2d7a5e16c6af228c7f83977e19b7fe4050dc62a1) Updated repos/nongnu
* [`5be88e3e`](https://github.com/nix-community/emacs-overlay/commit/5be88e3e944747cdce0e103f78196d55343bcaf8) Updated repos/emacs
* [`c7205991`](https://github.com/nix-community/emacs-overlay/commit/c7205991cfb365c4774b75335f2f9e8c1c3c706e) Updated repos/melpa
* [`c83081ea`](https://github.com/nix-community/emacs-overlay/commit/c83081eadb65d402d3d50f00f775d2ebe3fcd2f4) Updated repos/elpa
* [`396859c3`](https://github.com/nix-community/emacs-overlay/commit/396859c3418604113e95610d20fa26f282ef3a8b) Updated repos/emacs
* [`82abb862`](https://github.com/nix-community/emacs-overlay/commit/82abb862fec2c3f48d8f3690d22f27fc25f48478) Updated repos/melpa
* [`02d18088`](https://github.com/nix-community/emacs-overlay/commit/02d18088a9a46ea1374aaf14e4a3b22331dd9a05) Updated repos/emacs
* [`4e2effae`](https://github.com/nix-community/emacs-overlay/commit/4e2effae68761f6456940367f1f47f361ad38466) Updated repos/melpa
* [`50b110d3`](https://github.com/nix-community/emacs-overlay/commit/50b110d31cb274fecad0a85771fcfd0f3878930c) Updated repos/nongnu
* [`a2f4b8f8`](https://github.com/nix-community/emacs-overlay/commit/a2f4b8f8b4c3288d89d2d2d8f5eb6803d27a57c8) Updated repos/emacs
* [`8ac1c89a`](https://github.com/nix-community/emacs-overlay/commit/8ac1c89acb7fd39c8094d0cb81cb3323bc3eb3dc) Updated repos/melpa
* [`f2992b32`](https://github.com/nix-community/emacs-overlay/commit/f2992b32f79cb42c8f98f1fc4f367483b2efe856) Updated repos/elpa
* [`bd3e1c34`](https://github.com/nix-community/emacs-overlay/commit/bd3e1c34f3d8bd5983da216d7ec81b024c7f81db) Updated repos/emacs
* [`18c78b2f`](https://github.com/nix-community/emacs-overlay/commit/18c78b2f18183cb06ebb5b9acba88bd197640ca8) Updated repos/melpa
* [`6c0b522a`](https://github.com/nix-community/emacs-overlay/commit/6c0b522a92b9f6f8d255b7db714716fd51732ecc) Updated repos/emacs
* [`fa49b15c`](https://github.com/nix-community/emacs-overlay/commit/fa49b15c8282a8aecdbe388cd69da232618821bf) Updated repos/melpa
* [`0937ebf2`](https://github.com/nix-community/emacs-overlay/commit/0937ebf25918895f01e558d17e382c312c1c21b9) Updated repos/emacs
* [`003dd113`](https://github.com/nix-community/emacs-overlay/commit/003dd113bbf93ec0d61804cd5bba142576248e69) Updated repos/melpa
* [`87916f94`](https://github.com/nix-community/emacs-overlay/commit/87916f94475e546dc77bd35a80857d19140b45d6) Updated repos/emacs
* [`cb750f32`](https://github.com/nix-community/emacs-overlay/commit/cb750f32b7408ea737e3e44fbf9538671f4fe52a) Updated repos/melpa
* [`9ca1054c`](https://github.com/nix-community/emacs-overlay/commit/9ca1054ca90d52dbe6a1ac508ba2cd008d23cd4b) Updated repos/elpa
* [`1fe251bc`](https://github.com/nix-community/emacs-overlay/commit/1fe251bc9db5fef88619c7bb770371639a83c9dd) Updated repos/emacs
* [`d79b2f60`](https://github.com/nix-community/emacs-overlay/commit/d79b2f60888043be3e27d33a33f93ff792bf0376) Updated repos/melpa
* [`015c8c2c`](https://github.com/nix-community/emacs-overlay/commit/015c8c2cfd4f62d7f317e777ebaef0df39e7a748) Updated repos/nongnu
* [`6822a164`](https://github.com/nix-community/emacs-overlay/commit/6822a16488e1dd2855948eb158226e6542c9fb80) Updated repos/emacs
* [`2191e967`](https://github.com/nix-community/emacs-overlay/commit/2191e9676590a1220683cceabaf9bf07da145a0c) Updated repos/melpa
* [`81c5ad21`](https://github.com/nix-community/emacs-overlay/commit/81c5ad211db3c23250153baae4dc96b83d462a2e) Updated repos/elpa
* [`1aff3046`](https://github.com/nix-community/emacs-overlay/commit/1aff30465c374eaaf041a03926211628e0d94c23) Updated repos/emacs
* [`2ab399a9`](https://github.com/nix-community/emacs-overlay/commit/2ab399a94a96281508ff7fcbe522b9d00b8dc304) Updated repos/melpa
* [`6fc3c2c1`](https://github.com/nix-community/emacs-overlay/commit/6fc3c2c1b2461278ba883b22e77984422bf16913) Updated repos/elpa
* [`f79465b8`](https://github.com/nix-community/emacs-overlay/commit/f79465b83c390f8ac8440e7185f94affe0b68810) Updated repos/emacs
* [`8b1c5750`](https://github.com/nix-community/emacs-overlay/commit/8b1c57506cdf2d75f7bcc948b226a3beeb544f3a) Updated repos/melpa
* [`3960283c`](https://github.com/nix-community/emacs-overlay/commit/3960283c022627d29c00dfdcb6b2228396b115b3) Updated repos/nongnu
