### PR TITLE
niv spacemacs: update dc85616d -> c6c17748

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "dc85616df542fd8d2b3739f26a29b66af6fab91e",
-        "sha256": "09vpvpz6m2iiyzj1zdrng1fakl6x17a9fs1bx5rdhlnn9152lydb",
+        "rev": "c6c17748f649236e5c4afab6a0cabb97f0806bf9",
+        "sha256": "0qm7ld88ap2m75rwamgd5yqhz2hqkbxpasqz6fp5l6128z91csv1",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/dc85616df542fd8d2b3739f26a29b66af6fab91e.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/c6c17748f649236e5c4afab6a0cabb97f0806bf9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@dc85616d...c6c17748](https://github.com/syl20bnr/spacemacs/compare/dc85616df542fd8d2b3739f26a29b66af6fab91e...c6c17748f649236e5c4afab6a0cabb97f0806bf9)

* [`056c7264`](https://github.com/syl20bnr/spacemacs/commit/056c7264ad1e95a1aa9b20c61ad667844a35f062) [spacemacs-bootstrap] Fix :pre-bindings evaluation in evilified-state-evilify-map ([syl20bnr/spacemacs⁠#15490](https://togithub.com/syl20bnr/spacemacs/issues/15490))
* [`9b6083b3`](https://github.com/syl20bnr/spacemacs/commit/9b6083b32d4de500c8728541dd09e196f2e464b6) Fix NPM package to install for JSON lsp ([syl20bnr/spacemacs⁠#15492](https://togithub.com/syl20bnr/spacemacs/issues/15492))
* [`c37d5056`](https://github.com/syl20bnr/spacemacs/commit/c37d50562569c7dd654e495d8b5fc7dd312ab2ac) Prefix obsolete aliases with "cl-" namespace. ([syl20bnr/spacemacs⁠#15494](https://togithub.com/syl20bnr/spacemacs/issues/15494))
* [`c6c17748`](https://github.com/syl20bnr/spacemacs/commit/c6c17748f649236e5c4afab6a0cabb97f0806bf9) [bot] "built_in_updates" Mon May  2 04:11:44 UTC 2022 ([syl20bnr/spacemacs⁠#15495](https://togithub.com/syl20bnr/spacemacs/issues/15495))
