### PR TITLE
niv zsh-completions: update 00a7cc22 -> ca484eac

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "00a7cc2200de179d21a5b359c6d670007cf44b08",
-        "sha256": "1li97rzar9cm5wzi9bwj296rq79bbzqj886x4l6lfpbwbnrbqxkg",
+        "rev": "ca484eac407a7a2c35437c93e1c3248512ae2061",
+        "sha256": "0dj34ikd21qpp3w0sipnpc716q0dj4j9mv68avsv4ggfh2xywd86",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/00a7cc2200de179d21a5b359c6d670007cf44b08.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/ca484eac407a7a2c35437c93e1c3248512ae2061.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@00a7cc22...ca484eac](https://github.com/zsh-users/zsh-completions/compare/00a7cc2200de179d21a5b359c6d670007cf44b08...ca484eac407a7a2c35437c93e1c3248512ae2061)

* [`20b3e087`](https://github.com/zsh-users/zsh-completions/commit/20b3e087fdd00582e3ba23a8bc4ba57a1b6843f3) Drop unsupported git protocol from Readme
