### PR TITLE
niv nixpkgs: update ace23e4d -> 58585adb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ace23e4d0bd31154cf5ac6da47d92e12c0b1b79a",
-        "sha256": "0mlpdkv77n92d8m9drd1jhi9h5wzlnfrsgn5rspkabvsgldcyrid",
+        "rev": "58585adbcd7fa9889d3d3731fc9c1766317dec77",
+        "sha256": "1w571zyd4vnrkjga1fgr7lbn11097z0arvx0c3xlqvr6vrvshg9l",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ace23e4d0bd31154cf5ac6da47d92e12c0b1b79a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/58585adbcd7fa9889d3d3731fc9c1766317dec77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ace23e4d...58585adb](https://github.com/nixos/nixpkgs/compare/ace23e4d0bd31154cf5ac6da47d92e12c0b1b79a...58585adbcd7fa9889d3d3731fc9c1766317dec77)

* [`01ede6f1`](https://github.com/NixOS/nixpkgs/commit/01ede6f1baec0ac450832cd80b571425a791f6f3) kdash: init at 0.2.4
* [`89de60a8`](https://github.com/NixOS/nixpkgs/commit/89de60a8ac8de525f6a06acd616a7e1cf7b3741a) standardnotes: fix icon path
* [`16131300`](https://github.com/NixOS/nixpkgs/commit/16131300633776df7392539249af61f73811a93a) p4v: 2020.1.1966006 -> 2021.3.2186916
* [`8aeb2797`](https://github.com/NixOS/nixpkgs/commit/8aeb279701fe867dc728e8dabab0a28a062ace84) yquake2: 8.00 -> 8.01
* [`d0b90bd1`](https://github.com/NixOS/nixpkgs/commit/d0b90bd181c45ac2ec34124b1389ccf90f6a989d) yquake2: migrate from cmake to gnumake
* [`5f63e522`](https://github.com/NixOS/nixpkgs/commit/5f63e522ac18db9c8434a2ec553953b77040f925) protoc-gen-twirp_php: 0.8.0 -> 0.8.1
* [`dcbe74f3`](https://github.com/NixOS/nixpkgs/commit/dcbe74f3d71a4256b1bc9053d762faccfeb9254c) protoc-gen-twirp_php: set version
* [`205971b0`](https://github.com/NixOS/nixpkgs/commit/205971b02cfdfac5980bf7a609cb8115cc37d2f1) gnuplot: 5.4.2 -> 5.4.3
* [`405a7b79`](https://github.com/NixOS/nixpkgs/commit/405a7b79bdb454939a6926098cb148392eec52ce) fluidsynth: 2.2.3 -> 2.2.5
* [`1c403702`](https://github.com/NixOS/nixpkgs/commit/1c4037025f49dd1b8c5fd56382e00b999f2e152a) sysstat: 12.4.4 -> 12.4.5
* [`0a7ff58b`](https://github.com/NixOS/nixpkgs/commit/0a7ff58bef2835d5b7dab0e2d42c6ef499d71833) libvdpau: 1.4 -> 1.5
* [`93d624a4`](https://github.com/NixOS/nixpkgs/commit/93d624a49aa7b616ab6a737b30ae13b4ce073909) doc/builders: fix typos
* [`b5017f53`](https://github.com/NixOS/nixpkgs/commit/b5017f53af93ce8e4e27284fc9d7be6991b02439) linuxKernel.packages.linux_5_16.evdi: 1.10.0 -> 1.10.1
* [`1353d1fb`](https://github.com/NixOS/nixpkgs/commit/1353d1fbdee6bdd1904623326c2f1d2ef13e2a2d) python310Packages.gtts: 2.2.3 -> 2.2.4
* [`f06e9083`](https://github.com/NixOS/nixpkgs/commit/f06e90837263fcf9bf716b4fa2eda7696540f63e) docopt_cpp: patch to support python3 for running tests
* [`13426330`](https://github.com/NixOS/nixpkgs/commit/13426330aa1cbf09ea11197902816edde01dd25e) linuxHeaders: 5.16 -> 5.17
* [`c14456e4`](https://github.com/NixOS/nixpkgs/commit/c14456e41eb4395989095bd5060e4bcda57e9c1c) libsolv: 0.7.21 -> 0.7.22
* [`e6f5eec3`](https://github.com/NixOS/nixpkgs/commit/e6f5eec3f066b4133853b98cb6e17342fd8c52a1) authy: 1.9.0 -> 2.1.0
* [`b9ef500f`](https://github.com/NixOS/nixpkgs/commit/b9ef500f11387852a9d4ed438c666151e8a56986) scli: 0.7.0 -> 0.7.1
* [`f0c470f5`](https://github.com/NixOS/nixpkgs/commit/f0c470f5eb80e484efd694451862ea8a56083b95) oath-toolkit: Rename from oathToolkit to oath-toolkit
* [`18dbdee6`](https://github.com/NixOS/nixpkgs/commit/18dbdee6e19eb1e6b8f29ac64a2bf37bafadcc2b) nodejs: mark versions older than 14 as vulnerable
* [`c6e3cedd`](https://github.com/NixOS/nixpkgs/commit/c6e3ceddd02dfa632b625430d516eca8efe9fb76) liquibase: fix Main -> LiquibaseCommandLine
* [`9d1895cd`](https://github.com/NixOS/nixpkgs/commit/9d1895cd2418f87c8841170a118f005059d7339c) html-xml-utils: 8.3 -> 8.4
* [`64913c64`](https://github.com/NixOS/nixpkgs/commit/64913c64b3cd3aededb42001947232196546dfab) greg: 0.4.7 -> 0.4.8
* [`76591b5b`](https://github.com/NixOS/nixpkgs/commit/76591b5b62275ed19e86353c2c6c91e0267dfc15) psi-plus: 1.5.1615 -> 1.5.1618
* [`aa010a32`](https://github.com/NixOS/nixpkgs/commit/aa010a329dd3393b81c56ff7cd09688ead07f619) openvscode-server: 1.62.3 -> 1.66.0
* [`8655b82d`](https://github.com/NixOS/nixpkgs/commit/8655b82de7507281718f2625a04415295c7fd3ac) sgx-sdk: 2.15.1 -> 2.16
* [`02e6180c`](https://github.com/NixOS/nixpkgs/commit/02e6180ce788ba0a36a2e3ccdc12b6eb6c25c442) sgx-psw: 2.15.1 -> 2.16
* [`f6b17766`](https://github.com/NixOS/nixpkgs/commit/f6b177664893b057c443a2008dd30b0001c4f982) tgt: 1.0.81 -> 1.0.82
* [`25f2da0d`](https://github.com/NixOS/nixpkgs/commit/25f2da0d70d3d102d989497d5f44902eb9203380) scribusUnstable: Fix build with Poppler 22.04
* [`556edebe`](https://github.com/NixOS/nixpkgs/commit/556edebe3cec7ff1f4b131ff8da5478000cdea65) inkscape: Fix build with poppler 22.04
* [`7c952f77`](https://github.com/NixOS/nixpkgs/commit/7c952f772c790085de5fff2206b16720fa1fadd1) poppler: 22.03.0 → 22.04.0
* [`c4f1d21e`](https://github.com/NixOS/nixpkgs/commit/c4f1d21e66188faf5e16e09493e0267588f5b93c) gst_all_1: 1.20.0 -> 1.20.1
* [`a2b02ea6`](https://github.com/NixOS/nixpkgs/commit/a2b02ea64694c35ce4a22eab2e7c005c93c7157c) telegraf: 1.22.0 -> 1.22.1
* [`22419c93`](https://github.com/NixOS/nixpkgs/commit/22419c93cd3a2290a6d53b70201a702847e47275) weechat-otr: Fix build and knownVulnerabilities
* [`1d241a70`](https://github.com/NixOS/nixpkgs/commit/1d241a70b51ae122a30a93dbb619a7679e43b7ae) reflex: 0.2.0 -> 0.3.1
* [`2f99b713`](https://github.com/NixOS/nixpkgs/commit/2f99b71368ce0cb24c1f38a136c24f3de12b34f9) timeular: 3.9.1 -> 4.7.1
* [`e1b29994`](https://github.com/NixOS/nixpkgs/commit/e1b299949eca2ce21bbf5e7a96c739b3d1d66007) codeql: 2.8.2 -> 2.8.5
* [`fc576251`](https://github.com/NixOS/nixpkgs/commit/fc576251524198b6c3e0a91f9e34b048d13f6e01) maintainers: add Anillc
* [`7603cb80`](https://github.com/NixOS/nixpkgs/commit/7603cb807f7cdd248e7f196be59a7b8db2f8950a) telegram-bot-api: init at 5.7
* [`66db6b56`](https://github.com/NixOS/nixpkgs/commit/66db6b56160eb3ef2c13f6bb301046fce932dab1) nomad-pack: 2022-02-11 -> 2022-04-12
* [`58b94a6e`](https://github.com/NixOS/nixpkgs/commit/58b94a6eb0f34f21be50f5c1ab40f5f0d557cc13) android-studio: fixing gui for tiling window managers
* [`d6d12766`](https://github.com/NixOS/nixpkgs/commit/d6d127668df3dd9c52f4aa07ef6d4755aa45ba5d) cmdstan: 2.17.1 -> 2.29.2
* [`d7b3ff6d`](https://github.com/NixOS/nixpkgs/commit/d7b3ff6d566011c47e4b4d4f3c0ad1e0a74831e3) minikube: disable update notifications
* [`5f11f5b0`](https://github.com/NixOS/nixpkgs/commit/5f11f5b0e0349bb9bc04c9d25c282cb4f20cc944) lapack-reference: 3.10.0 -> 3.10.1
* [`7d951466`](https://github.com/NixOS/nixpkgs/commit/7d9514667094595c3263c5dddf85ae737c64caf5) codesearch: 1.0.0 -> 1.2.0
* [`aa977f5b`](https://github.com/NixOS/nixpkgs/commit/aa977f5b7724e24fed379a9a46c4414e08a87ee1) mmake: 1.2.0 -> 1.4.0
* [`259fa13d`](https://github.com/NixOS/nixpkgs/commit/259fa13d53005f073385d280181e6e378da3ed59) treewide: remove nativeBuildInputs that are in stdenv
* [`0a74e0b6`](https://github.com/NixOS/nixpkgs/commit/0a74e0b66e49731b6ac1ba668846aa3f339c2724) libarchive: enable tests
* [`868991db`](https://github.com/NixOS/nixpkgs/commit/868991dbace0c702db3738bdfaea99e90200e244) firefox-devedition-bin-unwrapped: 100.0b6 -> 100.0b7
* [`606333cb`](https://github.com/NixOS/nixpkgs/commit/606333cb1e4480ecd0ef641790cdc202a3f916a0) logseq: 0.6.5 -> 0.6.6
* [`bf990cc3`](https://github.com/NixOS/nixpkgs/commit/bf990cc3cc687f53b70497d282725b3cc77f0347) glibc: unconditionally disable pie
* [`7f01ff78`](https://github.com/NixOS/nixpkgs/commit/7f01ff7822ac74f2e92a6fcc5367c16838038dd4) nixos/prometheus: use pkgs.formats.json.generate to write config file
* [`82060bee`](https://github.com/NixOS/nixpkgs/commit/82060bee0b912334d828a1d2a771fdb55694561e) portfolio: 0.57.1 -> 0.57.2
* [`1ea980a0`](https://github.com/NixOS/nixpkgs/commit/1ea980a082984e535ae8707a764cf74d37df037f) git: 2.35.3 -> 2.36.0
* [`1fc0a5fb`](https://github.com/NixOS/nixpkgs/commit/1fc0a5fbee15c7564eaf49805d158199c83eac56) cht-sh: unstable-2022-04-17 -> unstable-2022-04-18
* [`061d442d`](https://github.com/NixOS/nixpkgs/commit/061d442dce0ecbf929b65176e35d2c1989696544) rust-cbindgen: 0.21.0 -> 0.22.0
* [`4978685d`](https://github.com/NixOS/nixpkgs/commit/4978685d9e585bdb44d6ada8fb5b7814b659fa7e) zookeeper: Expose jre for nixos modules
* [`1637e039`](https://github.com/NixOS/nixpkgs/commit/1637e039d2900e15bc6aae60b7e6af886c0ba991) nixos/zookeeper: Take the same JRE we build zookeeper with
* [`febceef0`](https://github.com/NixOS/nixpkgs/commit/febceef0784aa0826b63af636c58afbcb25ffc60) curl: gate darwin workarounds behind stdenv.isDarwin to make life on linux easier
* [`e91229bf`](https://github.com/NixOS/nixpkgs/commit/e91229bf25f2c21ca0daa5adfe859b211739d475) meson: apply patch fixing exception during cross-compilation
* [`9af0939e`](https://github.com/NixOS/nixpkgs/commit/9af0939eae988eae736a7c2a0d539be4d2d7630a) python3Packages.pybind11: 2.9.1 -> 2.9.2
* [`d80e784f`](https://github.com/NixOS/nixpkgs/commit/d80e784f990ce86c0cd3187f7606a342f2f1948d) libcap_ng: 0.8.2 -> 0.8.3
* [`9f6671a5`](https://github.com/NixOS/nixpkgs/commit/9f6671a51c0c3493760bbdd0d78fa3a4cf2ebfa5) python3Packages.XlsxWriter: 3.0.2 -> 3.0.3
* [`7e3e1ffd`](https://github.com/NixOS/nixpkgs/commit/7e3e1ffd937a14a270c071534b493cc5010deb88) groff: enableParallelBuilding
* [`c7b6852c`](https://github.com/NixOS/nixpkgs/commit/c7b6852cad902a9a247d87d283095aae46cea935) groff: get rid buildtime bash reference and enable strictDeps
* [`c9d0bcba`](https://github.com/NixOS/nixpkgs/commit/c9d0bcbaaaed8233027a15cc781c5aab957891db) man-db: fix cross enable strictDeps
* [`5979a0a0`](https://github.com/NixOS/nixpkgs/commit/5979a0a0726e9d234c7d64416251ca5a7a6e0527) glib: 2.72.0 → 2.72.1
* [`d979ff2d`](https://github.com/NixOS/nixpkgs/commit/d979ff2d4aa24f2b1441c526b91e8d21521c6d31) gst_all_1: 1.20.0 -> 1.20.1
* [`528db197`](https://github.com/NixOS/nixpkgs/commit/528db1977feb45a4b7ea4ea459a87df967a03394) gst_all_1.gst-plugins-bad: enable aptx support
* [`7a2605e0`](https://github.com/NixOS/nixpkgs/commit/7a2605e0f3dc99e02cd577634f792f7a4d229378) pulseaudio: support advanced codecs when enabling bluetooth support
* [`d62bf28b`](https://github.com/NixOS/nixpkgs/commit/d62bf28b76ae3e9c782d7b8b1390b156e9b7daa5) pulseaudio: hide advanced bluetooth codecs behind default-false feature flag
* [`9d06b469`](https://github.com/NixOS/nixpkgs/commit/9d06b469733197b3b254022d6ad9743aa2b57550) dbus: Fix crash when running in nix-shell
* [`de41cba7`](https://github.com/NixOS/nixpkgs/commit/de41cba76ebfe88e1ee3207ebd98a5db7df0c9ad) libinput: 1.20.0 -> 1.20.1
* [`7d677e70`](https://github.com/NixOS/nixpkgs/commit/7d677e7031123caa8a0c3c81440781c287b8e6fe) groff: disable parallel building
* [`7f802c70`](https://github.com/NixOS/nixpkgs/commit/7f802c704651baba3adb2abdd9cc6645c987b9ad) python-wrapper: use makeBinaryWrapper
* [`9ab98ecc`](https://github.com/NixOS/nixpkgs/commit/9ab98eccb36e0f21c691fc15fbb79957aa3d7ce9) libpulseaudio-vanilla: move to aliases
* [`3bf08a77`](https://github.com/NixOS/nixpkgs/commit/3bf08a773198bad751f32e6ab1a156f8bb34815a) doc/release-notes: highlight pulseaudio upgrade with new bluetooth codecs
* [`5a47886f`](https://github.com/NixOS/nixpkgs/commit/5a47886f78abda3ec91888256b2a5d120c7c4b4c) microsoft-edge: 98.0.1108.56 -> 100.0.1185.44
* [`9823f36c`](https://github.com/NixOS/nixpkgs/commit/9823f36c0c2a1e9df83423a48589cead6e2335a4) .editorconfig: allow trailing whitespace for markdown manual files
* [`99efa0e2`](https://github.com/NixOS/nixpkgs/commit/99efa0e292a390f44ba15830c00e2dbc8c217aad) ptex: remove python2 as dependency
* [`8f25cec3`](https://github.com/NixOS/nixpkgs/commit/8f25cec30f97c407d4ea1b7cc588b73de1c506ff) graphviz: 2.49.3 -> 2.50.0
* [`ea5cfaf8`](https://github.com/NixOS/nixpkgs/commit/ea5cfaf8e1123610ac29ef988620d06fca49bc89) libinjection: patch for python3 builds
* [`49efe748`](https://github.com/NixOS/nixpkgs/commit/49efe74808867b6a65c4a70986a4c0313035160e) snack: remove
* [`153b2faf`](https://github.com/NixOS/nixpkgs/commit/153b2fafb01e84c98464035dbf7c8bf908ed1e30) goocanvas2: switch to python3
* [`2165db62`](https://github.com/NixOS/nixpkgs/commit/2165db62ee1ec75f035c55e3e9f44ae84dad0127) rust-cbindgen: 0.22.0 -> 0.23.0
* [`b875cb25`](https://github.com/NixOS/nixpkgs/commit/b875cb256012efa0f944a8fa50bf340bb8043783) rust-cbindgen: adopt
* [`bb6abb6e`](https://github.com/NixOS/nixpkgs/commit/bb6abb6e5b6955625e7d9872bcfe1b399819128e) unit: drop python2 support
* [`0d8a3244`](https://github.com/NixOS/nixpkgs/commit/0d8a3244643cfb8982126c65263294ae9a3f66b1) AusweisApp2: 1.22.4 -> 1.22.5
* [`88e6132f`](https://github.com/NixOS/nixpkgs/commit/88e6132fe804f2245dab8215d65964fa8620102b) at-spi2-core: 2.44.0 -> 2.44.1
* [`5a777566`](https://github.com/NixOS/nixpkgs/commit/5a77756649f7c95268c86dfa6fa96d65bbccd4b1) radicle-upstream: 0.2.12 -> 0.3.0
* [`efe5ba0c`](https://github.com/NixOS/nixpkgs/commit/efe5ba0c4ffe03a100a3a1750983b7d9edbbba8d) jetbrains: update script fixes
* [`6abf6b46`](https://github.com/NixOS/nixpkgs/commit/6abf6b46adfcb11be3dc0187ff07e4ddae8d3e2e) maintainers: adding AnatolyPopov
* [`811f95f0`](https://github.com/NixOS/nixpkgs/commit/811f95f000d9610bd85cca1cf78ae9a069464d87) luaPackages.luaunbound: init at 1.0.0-1
* [`0e630462`](https://github.com/NixOS/nixpkgs/commit/0e630462da8c2e83b6d04eb935353d1e34549c32) nixosTests.prosody: fix test
* [`52248e44`](https://github.com/NixOS/nixpkgs/commit/52248e4466230a6b82ecf182edcdba7bb64f2174) python: enable opt-in parallel build_ext builds for setuptools
* [`5be42ba9`](https://github.com/NixOS/nixpkgs/commit/5be42ba94115f512db062115c6cdd81f0ba091e4) python3Packages.pandas: enable parallel build
* [`e7c481ad`](https://github.com/NixOS/nixpkgs/commit/e7c481adee01b0c382dba4800ba4099c590854ba) python3Packages.pydantic: enable parallel build
* [`3344abcc`](https://github.com/NixOS/nixpkgs/commit/3344abcce60cfa8de68ccb90469d8e342df778e4) ell: 0.49 -> 0.50
* [`4182f29b`](https://github.com/NixOS/nixpkgs/commit/4182f29b415d88e4ef7d03a37beef2bc67f72882) ell: update metadata
* [`49140c79`](https://github.com/NixOS/nixpkgs/commit/49140c798b3c399a42e06170234faa43f1d1c72f) vdrPlugins.fritzbox: 1.5.3 -> 1.5.4
* [`820180c4`](https://github.com/NixOS/nixpkgs/commit/820180c4f01a92dd5692d56ef0bc42d62e211727) maintainers: add deinferno
* [`629fa2f3`](https://github.com/NixOS/nixpkgs/commit/629fa2f3c2ae6e081fc82004ba07c2069123bb34) mesa: 22.0.1 -> 22.0.2
* [`19acc905`](https://github.com/NixOS/nixpkgs/commit/19acc905d095a69dea1dd1bfeaf8b2709d0133bf) pyinfra: 2.0.1 -> 2.0.2
* [`0f1bb1f4`](https://github.com/NixOS/nixpkgs/commit/0f1bb1f41d6e1b2b546f0cf02d1a84bd4a0e2bae) jadx: 1.3.4 -> 1.3.5
* [`1b44874d`](https://github.com/NixOS/nixpkgs/commit/1b44874d7248bb24870d2adbd04dad82742bb1a0) htmlcxx: 0.86 -> 0.87
* [`b0c23289`](https://github.com/NixOS/nixpkgs/commit/b0c232895a678da14daf91c365c8d75fb92e9c71) mapserver: switch to python3
* [`568cb2d6`](https://github.com/NixOS/nixpkgs/commit/568cb2d6abf3e0cdd6607b5e918522aba824c19f) nixos/systemd/nspawn: Add missing nspawn unit options
* [`acca3f4b`](https://github.com/NixOS/nixpkgs/commit/acca3f4b812c75f435ed618dca8adacac83975ac) nixos/plymouth: Add systemd stage 1 support
* [`6031ae21`](https://github.com/NixOS/nixpkgs/commit/6031ae21f6b69b04701e06fbeadf6585c5e3e0cd) fcitx5-rime: add an environment variable for shared data dir passing librime.
* [`3bf6ef26`](https://github.com/NixOS/nixpkgs/commit/3bf6ef26d529fbefdebfbd264683f5c42b6940b7) antimicrox: 3.2.2 -> 3.2.3
* [`0fd723f3`](https://github.com/NixOS/nixpkgs/commit/0fd723f3b4e2af3338207bc39db580bc7be4c286) xpdf: 4.03 -> 4.04
* [`2474c8c8`](https://github.com/NixOS/nixpkgs/commit/2474c8c89a3af7c88a653fc040056d600414307b) nixos/fcitx5: add the setting of RIME_DATA_DIR and options for rime-data
* [`c9a1647a`](https://github.com/NixOS/nixpkgs/commit/c9a1647adeef403328f7b222666648bf8bfa0320) nixos/tailscale: use systemctl restart during activation.
* [`8342425c`](https://github.com/NixOS/nixpkgs/commit/8342425cb01075e5b3571fa272f1fd6f46bf942a) bazel_4, bazel_5: disable sandbox debug
* [`9f5af25c`](https://github.com/NixOS/nixpkgs/commit/9f5af25c4b05a28c87bffa56ba247f14a88867c1) libosmocore: 1.2.0 -> 1.6.0
* [`09a9078f`](https://github.com/NixOS/nixpkgs/commit/09a9078f79aae4ac3df14ffb9d5f5ab39f8e38ee) gnome2.libglade: remove python2-dependent functionality
* [`8ddb45c1`](https://github.com/NixOS/nixpkgs/commit/8ddb45c1d52714d1b4ad916104273329bc923d40) caffe2: remove
* [`0e5763e3`](https://github.com/NixOS/nixpkgs/commit/0e5763e31bd697fcd907dcef8d5ea916937f8286) git: fix failing build on Darwin
* [`6a58a942`](https://github.com/NixOS/nixpkgs/commit/6a58a9425a29a00935579fc588607d0c50b780df) libarchive: disable test_write_disk_hardlink test
* [`8b0e73e7`](https://github.com/NixOS/nixpkgs/commit/8b0e73e70cda02d67119b53e00ce6832b00172f2) john: add gcc11 patch
* [`10fdcd5e`](https://github.com/NixOS/nixpkgs/commit/10fdcd5e47ed0488f0cc806e7c940918b36ad15f) python310Packages.malduck: 4.1.0 -> 4.2.0
* [`db5fd3ba`](https://github.com/NixOS/nixpkgs/commit/db5fd3bad1342bcdaf8fa336819ef6317e71da2a) ffmpeg-normalize: 1.22.9 -> 1.22.10
* [`b6012814`](https://github.com/NixOS/nixpkgs/commit/b6012814b6bb66f9a4b3b43cbe75a97f9d6cdb30) aws-rotate-key: 1.0.6 -> 1.0.8
* [`0a52b5eb`](https://github.com/NixOS/nixpkgs/commit/0a52b5eb1847c56321c22259f8276365ce9c2a46) cli53: 0.8.12 -> 0.8.18
* [`8e20059f`](https://github.com/NixOS/nixpkgs/commit/8e20059ffa99aa2bd06fc2a75bf3d789c072e5dc) python310Packages.scikit-survival: 0.17.1 -> 0.17.2
* [`f3100dd4`](https://github.com/NixOS/nixpkgs/commit/f3100dd4e0072cf641d52ae3dc9da959e5335bf9) sile: Change default interpreter to Lua 5.4
* [`3e5e584c`](https://github.com/NixOS/nixpkgs/commit/3e5e584c1f7589e3525101df32a04fb76b3fe77c) nixos/zookeeper: Update doc with suggested description
* [`b43999be`](https://github.com/NixOS/nixpkgs/commit/b43999bea087e006f92b7011abccb9ba09d1343a) nixos/zookeeper: Remove .passthru as suggested
* [`6b738bce`](https://github.com/NixOS/nixpkgs/commit/6b738bce8091d4fa160fe503e4bf3a0a7ff8d60f) nixos/nscd: Fix lib.literalExample deprecation
* [`1be5ae11`](https://github.com/NixOS/nixpkgs/commit/1be5ae112f4d42c1dfecd9ab555e098edfe4c401) xpf: remove
* [`f5032db4`](https://github.com/NixOS/nixpkgs/commit/f5032db47ea5b561f54abddafe0d667266603fa7) opencc: switch to python3
* [`67b88714`](https://github.com/NixOS/nixpkgs/commit/67b887147fc935ab8587d9b712541dcbf902b48a) nmap: remove graphical support
* [`ee374505`](https://github.com/NixOS/nixpkgs/commit/ee374505e008fe595d93db775d2264fb15e6a7e2) syslogng: switch to python3
* [`9f101952`](https://github.com/NixOS/nixpkgs/commit/9f1019528df10b2b13d003f571df9a239b57bdea) ps_mem: switch to python3
* [`d64b2cc1`](https://github.com/NixOS/nixpkgs/commit/d64b2cc1e9c8f160cfa3c10ed3e9aa8b740173e7) twister: remove
* [`e7c3e490`](https://github.com/NixOS/nixpkgs/commit/e7c3e490511d336b5a3ef23c5e7cd2aa3eb5b521) obs-studio-plugins.obs-gstreamer: 0.2.1 -> 0.3.3
* [`4986504f`](https://github.com/NixOS/nixpkgs/commit/4986504f04680788b6c2904a1acc71135388d0dd) python38Packages.backports-zoneinfo: test data for zoneinfo 2022a
* [`2cfd398b`](https://github.com/NixOS/nixpkgs/commit/2cfd398b57b7c24f995140e78685d415959b07ef) ats2: 0.4.1 -> 0.4.2
* [`3d3ce649`](https://github.com/NixOS/nixpkgs/commit/3d3ce649933ed269fc1a29ff83eec11ae7e3bca0) alda: 2.2.0 -> 2.2.3
* [`b779b46d`](https://github.com/NixOS/nixpkgs/commit/b779b46dd2f032c70aa2cb72a88f597d6c0f0cff) lxd: fix nixos tests on aarch64
* [`ab9d6e8f`](https://github.com/NixOS/nixpkgs/commit/ab9d6e8f9d6944a26d0d3b2baadac45e5b985e27) pdns: 4.6.1 -> 4.6.2
* [`9c7c44c3`](https://github.com/NixOS/nixpkgs/commit/9c7c44c37651e92ddf011ace2c39bb3ec681b4a0) lklug-sinhala: init at 0.6
* [`41876b4f`](https://github.com/NixOS/nixpkgs/commit/41876b4f4622e9d91f4af698465bb73f77ca11e0) sil-padauk: init at 3.003
* [`7c64d883`](https://github.com/NixOS/nixpkgs/commit/7c64d88385068b7746ff8f4708986552e2970252) uthenticode: 1.0.4 -> 1.0.8
* [`637f6305`](https://github.com/NixOS/nixpkgs/commit/637f6305d51f770160bd6db51bfc0337b637392a) nanum: init at 20170925
* [`ae449421`](https://github.com/NixOS/nixpkgs/commit/ae4494212a4ddefae925578939b2cec7aaae1b9e) takao: init at 00303.01
* [`835cbb4e`](https://github.com/NixOS/nixpkgs/commit/835cbb4e6aa10e968ff34bb426c33f8259e1cd3a) python310Packages.aws-lambda-builders: 1.14.0 -> 1.15.0
* [`b531bf47`](https://github.com/NixOS/nixpkgs/commit/b531bf477a4aec9c58cf5b4fd1a7297db4533ce1) wallabag: fix comment with usage instructions
* [`e83884a9`](https://github.com/NixOS/nixpkgs/commit/e83884a9e9ce88e98ea4f35354ffffd1368a4ba1) git-machete: updates to 3.9.0
* [`0c494de2`](https://github.com/NixOS/nixpkgs/commit/0c494de2fd173be1abcf6ce8356221fb16a43a07) airwindows-lv2: init at 1.0
* [`fa018142`](https://github.com/NixOS/nixpkgs/commit/fa01814245e0f6a4dedb720027db87923a404ad3) pgadmin4: 6.7 -> 6.8
* [`cf6b75ad`](https://github.com/NixOS/nixpkgs/commit/cf6b75adb05c0f03fa08ed4efd2f79e763f6effe) pgadmin: fix pgadmin4 command
* [`5cf8ef4b`](https://github.com/NixOS/nixpkgs/commit/5cf8ef4ba41161531fcfaae7e02c2c616d6902a7) pgadmin: add werkzeug override
* [`eff62ac1`](https://github.com/NixOS/nixpkgs/commit/eff62ac1963df80205482aa6d40962f1abdfa832) pgadmin4: make regression test use the same packages
* [`eef222b8`](https://github.com/NixOS/nixpkgs/commit/eef222b8c2f220033fb76aa64cdfd9dcf9d6a3aa) pgadmin4: fix tests
* [`0dd6926b`](https://github.com/NixOS/nixpkgs/commit/0dd6926b29a4510d5e1d7540dd5d6a0fb485e578) pgadmin: revert version string
* [`f764163d`](https://github.com/NixOS/nixpkgs/commit/f764163d458b14a4b94bdeac1d7eadf991887f94) protoc-gen-entgrpc: init 0.2.0
* [`9b641584`](https://github.com/NixOS/nixpkgs/commit/9b641584046b6e0e52775026218e54768c2f50d0) git: disable a test on aarch64-darwin
* [`f18e2de0`](https://github.com/NixOS/nixpkgs/commit/f18e2de0b6a38ca712c07f29032f306ac0f054ff) bashblog: init at unstable-2022-03-26
* [`4cc61c32`](https://github.com/NixOS/nixpkgs/commit/4cc61c3265e4e25034dc999e1234106f96ba5da7) python310Packages.proton-client: enable tests
* [`2d985f3f`](https://github.com/NixOS/nixpkgs/commit/2d985f3fd132e9372147dc37a6c4e39ae31bbc00) vscodium: Add support for aarch64-darwin (M1)
* [`116e42dc`](https://github.com/NixOS/nixpkgs/commit/116e42dc7c9831270fa4bee156296f79343ce1ee) python310Packages.snowflake-sqlalchemy: 1.3.3 -> 1.3.4
* [`26a47abf`](https://github.com/NixOS/nixpkgs/commit/26a47abfcc94d400a3e55d880d048c76c6dbb251) python310Packages.snowflake-connector-python: 2.7.6 -> 2.7.7
* [`709cc706`](https://github.com/NixOS/nixpkgs/commit/709cc7066b631ebc7b97d7213385045985e6e6c9) pgadmin4: pass pythonEnv as variable
* [`0c8e4f4f`](https://github.com/NixOS/nixpkgs/commit/0c8e4f4f19094957758efb1be5ee4b1ebf524b45) pgadmin: minor bugfix in version string
* [`6431e183`](https://github.com/NixOS/nixpkgs/commit/6431e183cd9b67801ed4b6760649e639d2cb2f84) guitarix: fixup build
* [`a3c0afb1`](https://github.com/NixOS/nixpkgs/commit/a3c0afb1e22616b2f9dfab6964966d4ff0e9781c) got: 0.68.1 -> 0.69
* [`3d76f7ec`](https://github.com/NixOS/nixpkgs/commit/3d76f7ec3927f3354bc2df6760e30c2226255d61) input-remapper: unstable-2022-02-09 -> 1.4.2
* [`1c2c2009`](https://github.com/NixOS/nixpkgs/commit/1c2c2009fc66d64d6fd217aa0601c610ed4f230e) python39Packages.fonttools: 4.30.0 -> 4.33.3
* [`30262ff5`](https://github.com/NixOS/nixpkgs/commit/30262ff5978963cdb10d291f5d135e69932bebd6) python39Packages.ufo2ft: 2.26.0 -> 2.27.0
* [`3538ce08`](https://github.com/NixOS/nixpkgs/commit/3538ce088a6f1239040e0ec719ae4c9b060ecb4e) python39Packages.ufoLib2: add setuptoold-csm in nativeBuildInputs
* [`6b93349c`](https://github.com/NixOS/nixpkgs/commit/6b93349c66461046278432bd419d816da3a5f4e5) zulip: 5.9.2 → 5.9.3
* [`93f2fab5`](https://github.com/NixOS/nixpkgs/commit/93f2fab507afe51c8e848c8df26f7c1c9342879f) vivaldi: 5.2.2623.39-1 -> 5.2.2623.41-1
* [`b930a9f7`](https://github.com/NixOS/nixpkgs/commit/b930a9f72b97f69f2a0d704914f91331c8a8ed55) python310Packages.jwcrypto: 1.0 -> 1.2
* [`4901ac20`](https://github.com/NixOS/nixpkgs/commit/4901ac200b9b039c614d0bd9422cb25e35029f5b) pax-utils: 1.3.3 -> 1.3.4
* [`8b4c5b38`](https://github.com/NixOS/nixpkgs/commit/8b4c5b383dd0d223ec40572965915d30cfea2cf2) swtpm: 0.7.2 -> 0.7.3
* [`facadc71`](https://github.com/NixOS/nixpkgs/commit/facadc716ea93903433302c1870794f563b3dd23) rocketchat-desktop: 3.7.8 -> 3.8.5
* [`85f97718`](https://github.com/NixOS/nixpkgs/commit/85f977180abcb7a89bc9cc7c8f325026f3fb4b9e) papermc: 1.18.1r132 -> 1.18.2r313
* [`113ca3c2`](https://github.com/NixOS/nixpkgs/commit/113ca3c22cf9a5afb0577948b85fc523c717ba37) tor: 0.4.6.10 -> 0.4.7.7
* [`6b8b02ce`](https://github.com/NixOS/nixpkgs/commit/6b8b02cef77a7dcd1192cc47ce60fd2e128617a4) python3.pkgs.sphinxHook: new package
* [`3bb2ac5a`](https://github.com/NixOS/nixpkgs/commit/3bb2ac5adfb3f2bceba113f011212aa35b199348) python3.pkgs.beautifulsoup4: build offline html documentation
* [`23d3cd04`](https://github.com/NixOS/nixpkgs/commit/23d3cd040e8f7c3e616ff57b9ce5bd4d28aa9a5a) python3.pkgs.dropbox: build offline html documentation
* [`3eab6412`](https://github.com/NixOS/nixpkgs/commit/3eab641238e55d7d5931c453b9d036cedba148e5) knot-resolver: switch to systemdMinimal
* [`9791289e`](https://github.com/NixOS/nixpkgs/commit/9791289e848f4b48497fbaa955eb49abbdc0f1b1) knot-resolver: enable more tests
* [`813f8b5e`](https://github.com/NixOS/nixpkgs/commit/813f8b5efbc827bf39416120b8a651cc1a2df8c5) haskellPackages: xhtml is not bundled if haddock is disabled
* [`94648ef6`](https://github.com/NixOS/nixpkgs/commit/94648ef64e2673ed44cc60013a40e8ddba83d21e) ventoy-bin: 1.0.72 -> 1.0.74
* [`7532dcd6`](https://github.com/NixOS/nixpkgs/commit/7532dcd683dbdd0d1b32ff069a73bfe4b18c6e16) libmediainfo: 21.09 -> 22.03
* [`f7ad1883`](https://github.com/NixOS/nixpkgs/commit/f7ad1883059b27ec9017438e81aa9ceca875b7a7) mediainfo-gui: 21.09 -> 22.03
* [`0c5dc9c0`](https://github.com/NixOS/nixpkgs/commit/0c5dc9c01ac7b9ed14bb24670fb314332b83503e) brave: 1.37.116 -> 1.38.109 and fix VAAPI/Vulkan
* [`d30dbf38`](https://github.com/NixOS/nixpkgs/commit/d30dbf38b9f416ed756dc2e9a5e6d37865745651) nixos/networkd: reimplement useDHCP in a sensible way
* [`ba4a615d`](https://github.com/NixOS/nixpkgs/commit/ba4a615da9400c3ff8d27b6615013fee5ff69b9e) nixos/tests/networking: add test for global useDHCP
* [`161dd27e`](https://github.com/NixOS/nixpkgs/commit/161dd27ee1ac84a78bda62a603dcb54ae1f8b15f) nixos/tests/networking: test connectivity from both client & router
* [`aa849e14`](https://github.com/NixOS/nixpkgs/commit/aa849e14785930404601747c7ea7b6172d80832d) nixos/network-interfaces-systemd: actually set catchall-iface if `useDHCP = true;`
* [`b08a0685`](https://github.com/NixOS/nixpkgs/commit/b08a06859c615a920b91b05b52b5765ca8368b71) nixos/tests/networking/dhcpDefault: actually use networkd for client
* [`9c186626`](https://github.com/NixOS/nixpkgs/commit/9c186626125999e917027accc297d1c9b24e1fcb) nixos/networkd: allow RouteMetric for IPv6AcceptRA
* [`cff16bc6`](https://github.com/NixOS/nixpkgs/commit/cff16bc62507bc0dfbaa1582ad0931be4da006ad) nixos/doc: add release-note entry for networking.useDHCP change
* [`8e42949a`](https://github.com/NixOS/nixpkgs/commit/8e42949a2421485c34fa56cff3e768af1c91459e) nixos/nixos-generate-config: use networking.useDHCP by default
* [`d9da7087`](https://github.com/NixOS/nixpkgs/commit/d9da7087c03e906ed5cc720a57f18de5329f4007) python310Packages.nftables: init from pkgs.nftables, reduce with lib; usage over enitre file
* [`cecb014d`](https://github.com/NixOS/nixpkgs/commit/cecb014d5daeb8b0c75361ed8ba89d9e84279c8e) networkmanager-applet: rename from networkmanagerapplet
* [`f5e69689`](https://github.com/NixOS/nixpkgs/commit/f5e6968955b4a38ed52674563930245836a808c8) inih: fix version parsing with nix-env
* [`74b17e98`](https://github.com/NixOS/nixpkgs/commit/74b17e98fb5c3922853d463bf5befbbe2736fb2f) fuse-7z-ng: fix repology version parsing
* [`e5e185e5`](https://github.com/NixOS/nixpkgs/commit/e5e185e50a4de6affe753d74e2988a279ba30999) audio-recorder: remove legacy ? null
* [`60c44828`](https://github.com/NixOS/nixpkgs/commit/60c44828720168f1ddf307540ebb3ffad03f2b46) google-chrome: remove legacy ? null
* [`0201c6cf`](https://github.com/NixOS/nixpkgs/commit/0201c6cf46c66a39571071d2b53c52052750d8d6) uni-vga: reduce with lib usage
* [`7bcf1516`](https://github.com/NixOS/nixpkgs/commit/7bcf151685b950a2a5a040f379ca23bfee279865) unityhub: fix nix-env version parsing
* [`5a5699b7`](https://github.com/NixOS/nixpkgs/commit/5a5699b71eca4084da9234c238479bfeee639267) wezterm: build terminfo file without compiling wezterm
* [`3219ff29`](https://github.com/NixOS/nixpkgs/commit/3219ff29a2006af52035d2a0dd4f8d6238963255) python39Packages.fastbencode: init at 0.0.7
* [`205e19ce`](https://github.com/NixOS/nixpkgs/commit/205e19ce38b4ab66216a92780532173df12248f7) breezy: 3.2.1 -> 3.2.2
* [`95fd917f`](https://github.com/NixOS/nixpkgs/commit/95fd917f4ee38d209813495d178ccc16db64cd80) breezy: install completions
* [`5b13c1e6`](https://github.com/NixOS/nixpkgs/commit/5b13c1e65713d1ebd19e8972adfb7ab9a4c2606d) stdenv: use gcc11 for riscv
* [`e6acae67`](https://github.com/NixOS/nixpkgs/commit/e6acae6768384615b898d297ceb67cc9c659c8d7) wiki-js: 2.5.277 -> 2.5.279
* [`8278250a`](https://github.com/NixOS/nixpkgs/commit/8278250ab7bf0f3a6f569935e7d8b69487c49aed) joplin-desktop: 2.7.13 -> 2.7.15
* [`47f0136d`](https://github.com/NixOS/nixpkgs/commit/47f0136dab6586948f563854ce19175eb10d76b4) neomutt: 20220415 -> 20220429
* [`c64751f2`](https://github.com/NixOS/nixpkgs/commit/c64751f2bf1ce5a94313567f4d73bcc007804ac6) open-watcom-v2-unwrapped: unstable-2022-04-24 -> unstable-2022-04-29
* [`b918d3c7`](https://github.com/NixOS/nixpkgs/commit/b918d3c71cef1b3ba8b04efe1d8ce2905dad2141) platformsh: 3.79.0 -> 3.79.1
* [`196c877c`](https://github.com/NixOS/nixpkgs/commit/196c877c8555eb72e52c5a5353a18a710ad00c70) nixos/network-interfaces: remove outdated deprecation information
* [`89ace396`](https://github.com/NixOS/nixpkgs/commit/89ace3967e0fefef19666366d64d315bae9b8f19) nixos/udev: systemd initrd improvements
* [`326b33b7`](https://github.com/NixOS/nixpkgs/commit/326b33b7a5533c23a26bcfe447934773d99ada1c) prusa-slicer: 2.4.1 -> 2.4.2
* [`c25b7497`](https://github.com/NixOS/nixpkgs/commit/c25b74970d2bb272e4616a65485f560602a788cc) runitor: init at 0.9.2
* [`26e02c19`](https://github.com/NixOS/nixpkgs/commit/26e02c1972fb05799289ff25801bcbaa535f72bf) mindustry: propagate more runtime depends
* [`e12eebf5`](https://github.com/NixOS/nixpkgs/commit/e12eebf51a8c864343b43fd6a5c44a853b147f68) aws-c-http: 0.6.10 -> 0.6.15
* [`e35888c2`](https://github.com/NixOS/nixpkgs/commit/e35888c2cf36bee18701f108e36134b4c4b987c5) aws-c-io: 0.10.19 -> 0.11.0
* [`2a08573b`](https://github.com/NixOS/nixpkgs/commit/2a08573b1ecac12293afe33c3869ab97fef9ac93) tracy: 0.8 -> 0.8.1
* [`82fa29a1`](https://github.com/NixOS/nixpkgs/commit/82fa29a1854ef7b60190ea4898cad103e37892eb) aws-c-s3: 0.1.33 -> 0.1.39
* [`beaa1f3d`](https://github.com/NixOS/nixpkgs/commit/beaa1f3d489110607fe3b4a3a83ff11e22990dce) aws-crt-cpp: 0.17.16 -> 0.17.28
* [`b5f7a8ae`](https://github.com/NixOS/nixpkgs/commit/b5f7a8aed3489888ce4b959dcba5dea43570d5d3) s2n-tls: 1.3.6 -> 1.3.12
* [`59e1eb39`](https://github.com/NixOS/nixpkgs/commit/59e1eb39b3736cf22f01ac398ee68ef838208bbd) aws-c-cal: 0.5.14 -> 0.5.17
* [`05021a0f`](https://github.com/NixOS/nixpkgs/commit/05021a0f90682ddc403ae2d441a5cdae07bc2776) aws-c-auth: 0.6.11 -> 0.6.13
* [`3ef14c0d`](https://github.com/NixOS/nixpkgs/commit/3ef14c0d469d715c6181b9c36cfc59bb52fc3c1f) aws-c-common: 0.6.19 -> 0.7.0
* [`35b85a12`](https://github.com/NixOS/nixpkgs/commit/35b85a126d8a23a6b563bb21308a2c067006153e) umockdev: 0.17.8 → 0.17.9
* [`014b59a4`](https://github.com/NixOS/nixpkgs/commit/014b59a4b891ecdec0e162677360d0777dfb5a7a) umockdev: Make library path references absolute
* [`693d4164`](https://github.com/NixOS/nixpkgs/commit/693d4164a00ec78b701e5ec999a8a2ea5653104f) rage: 0.7.1 -> 0.8.0
* [`a609bf9e`](https://github.com/NixOS/nixpkgs/commit/a609bf9e8602e4cf5bd961f33f2c7aca7d5da9f5) ytarchive: 2022-02-16 -> 2022-03-11
* [`36fcd5f0`](https://github.com/NixOS/nixpkgs/commit/36fcd5f0dc31a559d9cda91565c12d8ad66427e6) kodiPackages.inputstreamhelper: 0.5.8+matrix.1 -> 0.5.10+matrix.1
* [`a83edfb8`](https://github.com/NixOS/nixpkgs/commit/a83edfb86b1353acf38f9a69658d157d41124f04) haskellPackages: stackage LTS 19.4 -> LTS 19.5
* [`d36e5507`](https://github.com/NixOS/nixpkgs/commit/d36e5507ffe3cb4a3dfa6872df9b31e5e7c69f6e) all-cabal-hashes: 2022-04-20T23:34:08Z -> 2022-05-01T06:09:30Z
* [`95cb7852`](https://github.com/NixOS/nixpkgs/commit/95cb7852a2b4582489e808b1253275899b94d09b) haskellPackages: regenerate package set based on current config
* [`ce38d266`](https://github.com/NixOS/nixpkgs/commit/ce38d2669c70cde5bc4a130e65bf0d74d604914c) python310Packages.smart-open: 5.2.1 -> 6.0.0
* [`e3f55d56`](https://github.com/NixOS/nixpkgs/commit/e3f55d56f5d21c21baa34460400d26b4b77d06e5) python310Packages.pathy: support later smart-open releases
* [`0e42a3ad`](https://github.com/NixOS/nixpkgs/commit/0e42a3ad3570ed57288eb863f7d825b08e3d2ecf) python39Packages.spacy: 3.2.4 -> 3.3.0
* [`2b27987e`](https://github.com/NixOS/nixpkgs/commit/2b27987edc9cc312be62525111797778527043ca) python310Packages.yte: init at 1.2.2
* [`8b176291`](https://github.com/NixOS/nixpkgs/commit/8b176291d7e33b49be8094588f5aa1206965b88b) snakemake: 6.15.5 -> 7.5.0
* [`fc5fdba4`](https://github.com/NixOS/nixpkgs/commit/fc5fdba4305744bae818a40d8bb0d9d0ecae7ad2) python310Packages.spacy-transformers: adjust inputs
* [`53d9b639`](https://github.com/NixOS/nixpkgs/commit/53d9b6397c151d71ade76609a10e557c88987e2a) bloop: 1.4.13 -> 1.5.0
* [`6273cb33`](https://github.com/NixOS/nixpkgs/commit/6273cb33c02bb62093196368302de1b1b0182c2b) wails: 2.0.0-beta.34 -> 2.0.0-beta.36
* [`4d5a66a1`](https://github.com/NixOS/nixpkgs/commit/4d5a66a1b5a27c53b6d9c4bf356eb3fea4fadab1) haskellPackages.hls-test-utils: remove unneeded patches
* [`096d6e88`](https://github.com/NixOS/nixpkgs/commit/096d6e88cef519f642d7e22eef6ab9a3305de476) python310Packages.sphinxcontrib-spelling: 7.3.2 -> 7.3.3
* [`d4aec931`](https://github.com/NixOS/nixpkgs/commit/d4aec931777eebad8e558b1d11e94aa95c3395b0) fclones: 0.21.0 -> 0.22.0
* [`5d4c4678`](https://github.com/NixOS/nixpkgs/commit/5d4c4678ff1eb15e5148e8ec5161018933287134) haskell.packages.ghc922.hls-fourmolu-plugin: bump assertion from 1.0.2.0 to 1.0.3.0 since jailbreak is still necessary
* [`57db9190`](https://github.com/NixOS/nixpkgs/commit/57db91900ede941ed1def7bc85074c5b2ae309dd) vimix-gtk-themes: 2021-08-17 -> 2022-04-24
* [`c517610e`](https://github.com/NixOS/nixpkgs/commit/c517610eeb50c86ad223fbc10ce746d1bbc2dcfa) swaynotificationcenter: 0.3 -> 0.5
* [`b05132d1`](https://github.com/NixOS/nixpkgs/commit/b05132d12fe0956543ba9f2cd3f34e9e7ae1174c) cmst: add update script
* [`3020f31d`](https://github.com/NixOS/nixpkgs/commit/3020f31d9b66d4eb164d84d8edb5ac6eaa453b61) cmst: 2022.03.13 -> 2020.11.01
* [`54996b86`](https://github.com/NixOS/nixpkgs/commit/54996b86094696c58e9746fbdc39127bddee2cc4) zimg: 3.0.3 -> 3.0.4
* [`cb03b379`](https://github.com/NixOS/nixpkgs/commit/cb03b379274846c8b1be1affcd402a85f30ae4c8) pkgsCross.mingw32.gcc11Stdenv: update mcfgthread patches for gcc-11
* [`e5995b22`](https://github.com/NixOS/nixpkgs/commit/e5995b22353d003cf2c3b32143ff996b14cbbb62) makeInitrdNG: Strip more and remove output
* [`bc53ac77`](https://github.com/NixOS/nixpkgs/commit/bc53ac775324fd16454a0a8e3a3bcf615a4fd8ef) nixos/systemd-shutdown: Remove unneeded binaries
* [`31b23a17`](https://github.com/NixOS/nixpkgs/commit/31b23a1725b81010241dc783a9f46320aa238e3b) nixos/systemd-initrd-simple: Fix test warnings
* [`8379a229`](https://github.com/NixOS/nixpkgs/commit/8379a2291480e388e373a5cb624a25ace4f08f23) mkvtoolnix: 66.0.0 -> 67.0.0
* [`c9f742f7`](https://github.com/NixOS/nixpkgs/commit/c9f742f7bc09672c661a0597f048fa3d5d9f399f) anki -> 2.1.51
* [`9add6bdf`](https://github.com/NixOS/nixpkgs/commit/9add6bdfc8eff26a0ecbd9efbb74f9397dafa89c) nixos/thefuck: fix programs.thefuck.alias for fish
* [`536a78ec`](https://github.com/NixOS/nixpkgs/commit/536a78ecc92688f186d44c8022054ff15de190db) nixos/thefuck: rename variable and move fishInitScript into its own variable
* [`e888c213`](https://github.com/NixOS/nixpkgs/commit/e888c2133fb703d0161a6d7fb45f899289cb9729) lib/strings: convert to string within hasInfix
* [`676ca56f`](https://github.com/NixOS/nixpkgs/commit/676ca56fb32b2f82dfce6a5adc523da8d08d5025) python3Packages.mat2: 0.12.3 -> 0.12.4
* [`5561de6b`](https://github.com/NixOS/nixpkgs/commit/5561de6b331d5f2d3c57dc5ca41807fb0b1e719d) python310Packages.sphinxcontrib-spelling: add pythonImportsCheck
* [`bc97215f`](https://github.com/NixOS/nixpkgs/commit/bc97215ff3ce215971e79e341ec9db3d65f8a43c) pferd: 3.3.1 -> 3.4.0
* [`40cb2223`](https://github.com/NixOS/nixpkgs/commit/40cb2223667542f4f8961ef8517b18de9370beca) python310Packages.sphinxcontrib-spelling: update inputs
* [`14d54882`](https://github.com/NixOS/nixpkgs/commit/14d54882216532cf1eb3c7eee262e6f854aca996) libwebsockets: drop unmaintained older versions
* [`44d939d1`](https://github.com/NixOS/nixpkgs/commit/44d939d1c98e812edd9683dcea548d42b32fbf79) marktext: fix nix-env version parsing
* [`996f6afd`](https://github.com/NixOS/nixpkgs/commit/996f6afd08796bdb6f72d2f782d6c8a3a1fb05ec) pouf: 0.4.1 -> 0.4.3
* [`42830ae1`](https://github.com/NixOS/nixpkgs/commit/42830ae1be22c24c151e4882ae284319cc7bb826) devito: fix sha256 hash that changed
* [`e602c06b`](https://github.com/NixOS/nixpkgs/commit/e602c06be76673aaa1afd57d66be93d91174e276) zigbee2mqtt: 1.25.0 -> 1.25.1
* [`666d3393`](https://github.com/NixOS/nixpkgs/commit/666d33933af0905144b2c53c2030e620b8e0fec0) tibetan-machine: init at 1.901b
* [`777eee14`](https://github.com/NixOS/nixpkgs/commit/777eee14aac4889d591bc85779fcd1a5e8b24783) khmeros: init at 5.0
* [`7058d597`](https://github.com/NixOS/nixpkgs/commit/7058d597ebb5194e86ad3943cd32ac0e69b7bc1d) plexamp: 4.2.0 -> 4.2.1
* [`0fac08c0`](https://github.com/NixOS/nixpkgs/commit/0fac08c0b5abbb8ea44d8aa4c311aae3b5f75d5e) lao: init at 0.0.20060226
* [`5dacb960`](https://github.com/NixOS/nixpkgs/commit/5dacb960165067ab7d04e48edb1b61c1a2ef2b52) python310Packages.Nikola: 8.2.1 -> 8.2.2
* [`f1607201`](https://github.com/NixOS/nixpkgs/commit/f16072011c9f062bb9a0ea40c293aecae4612309) haskellPackages.hls-change-type-signature-plugin: dontCheck
* [`ddd70f2e`](https://github.com/NixOS/nixpkgs/commit/ddd70f2eb8bc00b20aa5a117ed179393b425b769) go-toml: 1.9.4 -> 2.0.0
* [`74dd0e78`](https://github.com/NixOS/nixpkgs/commit/74dd0e78123e9a75cb6858526979f1639985b09f) python310Packages.python-smarttub: 0.0.31 -> 0.0.32
* [`1432f1d4`](https://github.com/NixOS/nixpkgs/commit/1432f1d4c998410f5c3b07d57f66e74578373cad) mustache-go: 1.3.0 -> 1.3.1
* [`a065c798`](https://github.com/NixOS/nixpkgs/commit/a065c79856199033261226eee0f0a6502af8c8a2) terraform-providers: update 2022-05-02
* [`91bbd567`](https://github.com/NixOS/nixpkgs/commit/91bbd5677d62d409eed0d7aade97761c36affe81) nodePackages: use latest node2nix
* [`df82d7c0`](https://github.com/NixOS/nixpkgs/commit/df82d7c0aa38f5bd4a410852a196a3ee7c5f6622) matterircd: 0.25.0 -> 0.25.1
* [`4bc73f44`](https://github.com/NixOS/nixpkgs/commit/4bc73f44e6417806d6ba25a8de60b222b985eb6a) gitea: 1.16.6 -> 1.16.7
* [`7c63f0ab`](https://github.com/NixOS/nixpkgs/commit/7c63f0ab8477433eef621dca468bf43e33a32ca8) gspeech: 0.10.1 -> 0.11.0
* [`a4e70852`](https://github.com/NixOS/nixpkgs/commit/a4e708522768a30cd5120a65c979c87abd525336) stdenv.mkDerivation: Allow overriding of recursive definitions
* [`2afc03a0`](https://github.com/NixOS/nixpkgs/commit/2afc03a084cf736cc76f629a45a720c3c44eb27d) hello: Define a passthru test via new mkDerivation self arg
* [`40ab3b87`](https://github.com/NixOS/nixpkgs/commit/40ab3b8738b4bb10ae849712c6bdc0fdf7564e3e) hello: Use callPackage for test
* [`2f21bc2f`](https://github.com/NixOS/nixpkgs/commit/2f21bc2fdb4349ca89f3c8db9742cdaa15702a52) doc/stdenv/meta: tests -> passthru.tests
* [`6d7efb3a`](https://github.com/NixOS/nixpkgs/commit/6d7efb3a16ddbc58d0c4688cbe8213b337388a0c) stdenv.mkDerivation: Make self more overlay-like; use self.public
* [`41b3688b`](https://github.com/NixOS/nixpkgs/commit/41b3688ba1222b61d19e6f810c9a1867eef69141) make-derivation.nix: Remove unnecessary TODO
* [`d629ba27`](https://github.com/NixOS/nixpkgs/commit/d629ba27d963664282253e6bf32d0f1a38af796a) Use finalAttrs instead of self for mkDerivation "overlay"
* [`1bbb5a14`](https://github.com/NixOS/nixpkgs/commit/1bbb5a14c89427241ec2d7d6c55724332dd59803) doc/using/overrides: Update for overlay style mkDerivation overrideAttrs
* [`37ab5b43`](https://github.com/NixOS/nixpkgs/commit/37ab5b43963f51f939b9c031a0dd824d82b41259) mkDerivation: Add error hint for infinite recursion
* [`2e0bd527`](https://github.com/NixOS/nixpkgs/commit/2e0bd527623626dac4fa9937f94682ecf761af3e) rl-2205: Add entry for overlay-style mkDerivation overriding
* [`ca83dd1a`](https://github.com/NixOS/nixpkgs/commit/ca83dd1ae73a94bee5c67ed21b2f6be41b195f40) stdenv.md: Clarify overrideAttrs sentence
* [`f066ddda`](https://github.com/NixOS/nixpkgs/commit/f066dddaa5cb6aea4429cd9386d4aa6f3963a889) hello: Make pname overridable without breaking src.url
* [`0e00acaf`](https://github.com/NixOS/nixpkgs/commit/0e00acafe9dc8bbd9e6b49d4341b6bf49b6defb8) stdenv.mkDerivation: public -> finalPackage
* [`7b5be1a0`](https://github.com/NixOS/nixpkgs/commit/7b5be1a0f8e8b0298dd71d78ec01de704d151f3b) lib/tests: add tests for hasInfix
* [`a5e15217`](https://github.com/NixOS/nixpkgs/commit/a5e152175d3f3fae591d5798464b8beaf2e55157) python310Packages.pydeps: init at 1.10.17
* [`1ce8edff`](https://github.com/NixOS/nixpkgs/commit/1ce8edff505a33e36ef20eba23369709a6e5be1a) teams: 1.4.00.26453 -> 1.5.00.10453
* [`94d2e55e`](https://github.com/NixOS/nixpkgs/commit/94d2e55ee6f102d7998b65038ad2d3a6dfbdd2c2) wprecon: 1.6.3a -> 2.4.5
* [`d4801769`](https://github.com/NixOS/nixpkgs/commit/d4801769322666d7d10117dad1e61aa3b871d3a3) grype: 0.35.0 -> 0.36.0
* [`69c09eed`](https://github.com/NixOS/nixpkgs/commit/69c09eed58bd9c734a43cf821ec7dae662af6b8c) mqttui: 0.16.1 -> 0.16.2
* [`b892f9dd`](https://github.com/NixOS/nixpkgs/commit/b892f9dd339eeb897c914951c8d5817c7075b728) yle-dl: 20220213 -> 20220425
* [`2f56ba48`](https://github.com/NixOS/nixpkgs/commit/2f56ba48c3be7b8391e4e7d7e661170cd054b771) python310Packages.ansible-doctor: 1.2.4 -> 1.3.0
* [`023a12f0`](https://github.com/NixOS/nixpkgs/commit/023a12f0ad349f999bba6cbd195d3601a6e23a6b) inspircd: 3.12.0 -> 3.13.0
* [`becaf4ac`](https://github.com/NixOS/nixpkgs/commit/becaf4acdf8407c4d33e5f80090600f55599e93a) python3Packages.flask_login: 0.6.0 -> 0.6.1
* [`f2070efc`](https://github.com/NixOS/nixpkgs/commit/f2070efc6b05288e5fd4f0bf6abd351e6bdc6525) slirp4netns: 1.1.12 -> 1.2.0
* [`1cbda904`](https://github.com/NixOS/nixpkgs/commit/1cbda904961bc865c119d693e15120fedef1e8e9) python310Packages.netutils: init at 1.1.0
* [`3bf58300`](https://github.com/NixOS/nixpkgs/commit/3bf58300c2a807746a2ff8a62ef45dfbbc5f20b3) godns: 2.7.5 -> 2.7.6
* [`b1b3f87d`](https://github.com/NixOS/nixpkgs/commit/b1b3f87d63c9ed6f0e22f0ec0670d281a32f10a9) htop: remove with lib over entire file
* [`9f0746f9`](https://github.com/NixOS/nixpkgs/commit/9f0746f997cbbadad1f69ccd97f89430f15daecb) htop: make changelog url better clickable
* [`2bddfc7c`](https://github.com/NixOS/nixpkgs/commit/2bddfc7cd326eae64fc1dfb954ae151b7db15860) python39Packages.pyeapi: fix Python 3.10 support
* [`e5cd0b86`](https://github.com/NixOS/nixpkgs/commit/e5cd0b86b1ff8ddb45eb4438f310c6c2624ab560) python310Packages.pims: 0.5 -> 0.6.0
* [`e93f7b6a`](https://github.com/NixOS/nixpkgs/commit/e93f7b6a894f1ca1c096ee5634b240484d5dc191) gmailctl: unstable-2022-03-24 -> 0.10.2
* [`f5a3980a`](https://github.com/NixOS/nixpkgs/commit/f5a3980a5b24bbffef9b66aba48b1eba6cfa05c8) adreaper: init at 1.1
* [`fdfc491b`](https://github.com/NixOS/nixpkgs/commit/fdfc491ba157b3d80ac59f62e98cb2995c1efac5) haskell.packages.ghc922.ghc-exactprint: 1.4.1 -> 1.5.0
* [`5a5c806c`](https://github.com/NixOS/nixpkgs/commit/5a5c806c9f2e0a42ef7114285d4daaba52ff29e5) haskell.packages.ghc922.hlint: unstable -> 3.4
* [`917be9fa`](https://github.com/NixOS/nixpkgs/commit/917be9fa320d962a5ba75749b62377f73835aa20) asterisk: Create symlinks for each config individually
* [`80ab00ed`](https://github.com/NixOS/nixpkgs/commit/80ab00ed11671f5070942dc11bff092153d3bfd9) haskell.packages.ghc922.haskell-language-server: enable 3 plugins
* [`42b719a3`](https://github.com/NixOS/nixpkgs/commit/42b719a3be121861df8497b4d3de44e631694216) tesseract: fix `fetch-language-hashes`
* [`683c50d8`](https://github.com/NixOS/nixpkgs/commit/683c50d805dcb6037a5b67331cc796dc2d60707b) tesseract: switch to SRI hash format
* [`05325328`](https://github.com/NixOS/nixpkgs/commit/05325328358a960a7308ba37fd1094758059f297) tesseract: use multi-line build inputs format
* [`20693a1e`](https://github.com/NixOS/nixpkgs/commit/20693a1e733dca4cd7e3001d7d7f60bd7237b301) prosody: 0.11.13 -> 0.12.0
* [`788ac72c`](https://github.com/NixOS/nixpkgs/commit/788ac72c7859e27d5800cddb9ee343248f0b3568) nixosTests.prosody: remove explicit timeout_callback error path
* [`23b12701`](https://github.com/NixOS/nixpkgs/commit/23b12701a4b05af2bdb148c928003c74b5dc35f0) prosody: remove ninjatrappeur from maintainers
* [`72698b35`](https://github.com/NixOS/nixpkgs/commit/72698b35cec5ef8c00dd049df7970db4b43cadd1) duckdb: run unit tests
* [`2b88803a`](https://github.com/NixOS/nixpkgs/commit/2b88803ac9d442e8de92950228e9f23c0adc51d2) duckdb: skip kurtosis and skewness tests on aarch64
* [`c05e64b2`](https://github.com/NixOS/nixpkgs/commit/c05e64b281fabb2099537100a46291b14436df50) duckdb: add darwin library path to allow tests to run
* [`da664a14`](https://github.com/NixOS/nixpkgs/commit/da664a14400bcc97cbd7807f1d8132798b840e94) duckdb: concat with space separator explicitly
* [`19e3c148`](https://github.com/NixOS/nixpkgs/commit/19e3c148be8d0a6ccb5d649bf25b335c371d505e) ssh-import-id: add man page
* [`21bf58c7`](https://github.com/NixOS/nixpkgs/commit/21bf58c74a7971776b003a837444652bf755128f) ssh-import-id: add self to maintainers
* [`15122dfd`](https://github.com/NixOS/nixpkgs/commit/15122dfdd9d70e4889bda2820fd05a87eb090cd3) python310Packages.apispec: 5.2.0 -> 5.2.1
* [`8fc246e8`](https://github.com/NixOS/nixpkgs/commit/8fc246e8cf6803d63526eba0baacfa3332ab0e4b) python310Packages.svdtools: 0.1.22 -> 0.1.23
* [`7d2cee00`](https://github.com/NixOS/nixpkgs/commit/7d2cee008b636b2bb754bfbe43f09d8fbc460296) tesseract: add wrapper test
* [`1b38ecfc`](https://github.com/NixOS/nixpkgs/commit/1b38ecfc74e47d49f207d9092571852de834d3e1) tesseract4.tessdata: 4.0.0 -> 4.1.0
* [`92a849e6`](https://github.com/NixOS/nixpkgs/commit/92a849e613e506252d45b6b5483d87377b09ebd7) tesseract5: init at 5.1.0
* [`cd3794a2`](https://github.com/NixOS/nixpkgs/commit/cd3794a21dfc042980a53e3f71380caa9b3dab64) ibus-engines.bamboo: 0.7.0 -> 0.7.7 ([nixos/nixpkgs⁠#167901](https://togithub.com/nixos/nixpkgs/issues/167901))
* [`c0a1035b`](https://github.com/NixOS/nixpkgs/commit/c0a1035b5e73024a4cd57af8edce07a54a2b745f) orchis-theme: 2022-02-18 -> 2022-05-01
* [`6022fd57`](https://github.com/NixOS/nixpkgs/commit/6022fd57b2a98cc7da139c998bcf4fd84029e0b2) htop: add SuperSandro2000 as maintainer
* [`db312071`](https://github.com/NixOS/nixpkgs/commit/db312071f9413048769e23fc9f9117235b00eae2) htop: 3.1.2 -> 3.2.0
* [`5d02b868`](https://github.com/NixOS/nixpkgs/commit/5d02b868881386e126a40526c5073b29f4c54a89) systemd-in-stage1: include firmware in initrd
* [`5a2f238b`](https://github.com/NixOS/nixpkgs/commit/5a2f238b9a55c425488bbcb1676f64e3c3f55942) systemd-boot: use mktemp from coreutils in installer
* [`c91f4f12`](https://github.com/NixOS/nixpkgs/commit/c91f4f127a91f6ccfd87d4c3dca7411bd163329d) maintainers: add numtide team
* [`2e365a07`](https://github.com/NixOS/nixpkgs/commit/2e365a077df2428af1e0a477263c5b7b4eb12158) terraform: maintained by numtide
* [`c398615d`](https://github.com/NixOS/nixpkgs/commit/c398615dae0e74ca48cce4d0cdc9f34ae77745fa) treefmt: maintained by numtide
* [`1864214b`](https://github.com/NixOS/nixpkgs/commit/1864214bd624184085a1bdd5c770b20df4d79488) direnv: maintained by numtide
* [`a71f6bdc`](https://github.com/NixOS/nixpkgs/commit/a71f6bdc7ccfa19b43ab6f530e5be5a67cba7ba1) yubico-piv-tool: 2.0.0 -> 2.2.1
* [`5b3ed6f9`](https://github.com/NixOS/nixpkgs/commit/5b3ed6f9a59e191b2cb6ddd45bd7a05cfccb287d) yubico-piv-tool: add self as maintainer
* [`82da3193`](https://github.com/NixOS/nixpkgs/commit/82da3193fcfc7ffada71d73725436a4d205d2df4) uchiwa: remove
* [`c77dd2c4`](https://github.com/NixOS/nixpkgs/commit/c77dd2c4f1b498273eeb899e53cc24132dd48a35) nixos/tests/gitlab: Add additional test cases ([nixos/nixpkgs⁠#167223](https://togithub.com/nixos/nixpkgs/issues/167223))
* [`9345a203`](https://github.com/NixOS/nixpkgs/commit/9345a203f0f8ea021c9ed1dba7c3ba78a96baeb1) gitlab: 14.9.3 -> 14.10.0 ([nixos/nixpkgs⁠#171129](https://togithub.com/nixos/nixpkgs/issues/171129))
* [`a2192e10`](https://github.com/NixOS/nixpkgs/commit/a2192e10df52feb2117c656c6621afe86dcd0c59) ff2mpv: init at 4.0.0
* [`17d5a572`](https://github.com/NixOS/nixpkgs/commit/17d5a5723d965df7051b4feb5045651b1ab4701f) python310Packages.poetry-dynamic-versioning: 0.14.1 -> 0.15.0
* [`902a2859`](https://github.com/NixOS/nixpkgs/commit/902a2859182b9b17a96b6c7649b8f052450fa84e) python310Packages.fqdn: init at 1.5.1
* [`75f801a8`](https://github.com/NixOS/nixpkgs/commit/75f801a8b1b1b933c754e95250e8b4392e44ddef) python310Packages.poetry-dynamic-versioning: update inputs
* [`4b348d6a`](https://github.com/NixOS/nixpkgs/commit/4b348d6a6faac2c877dbe325088697d20e3e835b) github-runner: Avoid /homeless-shelter bug ([nixos/nixpkgs⁠#170892](https://togithub.com/nixos/nixpkgs/issues/170892))
* [`d9b419dd`](https://github.com/NixOS/nixpkgs/commit/d9b419dd0d5cf1b22365ae635cbd67132465a96a) timetagger: 22.3.1 -> 22.4.2
* [`1c49b812`](https://github.com/NixOS/nixpkgs/commit/1c49b81263858c69b932da05ae63a7767b308e74) config.allowUnfree: define as option
* [`9f473092`](https://github.com/NixOS/nixpkgs/commit/9f473092f84f9d704810146fec2a919bf96e5bf0) config.allowBroken: define as option
* [`17525e5d`](https://github.com/NixOS/nixpkgs/commit/17525e5d37860f996866a8e4a8424f04325d2b43) python310Packages.zeroconf: 0.38.4 -> 0.38.5
* [`1d0ffa45`](https://github.com/NixOS/nixpkgs/commit/1d0ffa450b2025f188d81df73ebbce764c872e25) compile-daemon: 2017-03-08 -> 1.4.0
* [`7c084fde`](https://github.com/NixOS/nixpkgs/commit/7c084fde74f85f1742139eaa366c95ac22f59f52) bionic: fix evaluation on some platforms
* [`380878b5`](https://github.com/NixOS/nixpkgs/commit/380878b5d1f2272e29f404a9736d1cc1e0eb08a1) go-motion: 2018-04-09 -> 1.1.0
* [`1d9929a2`](https://github.com/NixOS/nixpkgs/commit/1d9929a29e5056aa414e42b8e1630540cb34343f) python310Packages.django-taggit: 2.1.0 -> 3.0.0
* [`d5de6ac7`](https://github.com/NixOS/nixpkgs/commit/d5de6ac75e6d19670cdfccc381faf58b66c1efb3) python310Packages.pytest-datafiles: 2.0 -> 2.0.1
* [`88d84fa6`](https://github.com/NixOS/nixpkgs/commit/88d84fa6558c0a6e403138a349ac433fc75a307a) python310Packages.pytest-datafiles: enable tests
* [`39ac55ea`](https://github.com/NixOS/nixpkgs/commit/39ac55ead828149cda3b1c5ccd617dad5521a7d1) python310Packages.gradient: 1.11.0 -> 2.0.3
* [`c0824782`](https://github.com/NixOS/nixpkgs/commit/c08247828f558bdc8e536257bc6e1cc8cc7cabea) python310Packages.pytorch-pfn-extras: 0.5.7 -> 0.5.8
* [`65e57dbb`](https://github.com/NixOS/nixpkgs/commit/65e57dbb528857c8e95e9893ef7d69ba63584774) python310Packages.isoduration: init at 20.11.0
* [`126f2960`](https://github.com/NixOS/nixpkgs/commit/126f2960444150fe43102513cdb7294127d560f5) tup: patch tup to find setuid fusermount
* [`1ca149cc`](https://github.com/NixOS/nixpkgs/commit/1ca149cced09f22beb7d25e50fa1ff23b3e2485e) python310Packages.murmurhash: 1.0.6 -> 1.0.7
* [`50d31845`](https://github.com/NixOS/nixpkgs/commit/50d31845fcc7f03a33128ffb85550fb8de6dff66) python310Packages.monty: 2022.1.19 -> 2022.4.26
* [`a1337c5d`](https://github.com/NixOS/nixpkgs/commit/a1337c5d1ff8f24ac6fb027294dc00a39a917d9f) python310Packages.gensim: 4.1.2 -> 4.2.0
* [`562a1fcd`](https://github.com/NixOS/nixpkgs/commit/562a1fcdc83b98bb2c433627c117c3e4c6bbbb16) perlPackages.POSIXAtFork: init at 0.04
* [`02a4cef8`](https://github.com/NixOS/nixpkgs/commit/02a4cef89caa632fde96f695a3f0be583186ff20) n8n: 0.174.0 → 0.175.0
* [`d515e117`](https://github.com/NixOS/nixpkgs/commit/d515e117997d8634fce0675fce363a8c6c30ccd6) python310Packages.ghp-import: 2.0.2 -> 2.1.0
* [`fe2be5ee`](https://github.com/NixOS/nixpkgs/commit/fe2be5eec29e2761d18d68f60c06232c36de6736) bore-cli: 0.2.3 -> 0.4.0
* [`01048fa3`](https://github.com/NixOS/nixpkgs/commit/01048fa37c386a749bf8315422bf9ba4baeca833) python310Packages.ghp-import: disable on older Python releases
* [`54c357ab`](https://github.com/NixOS/nixpkgs/commit/54c357ab9361b8f8008228628e9d19ecf2062f05) python310Packages.pytelegrambotapi: 4.4.1 -> 4.5.0
* [`073c11c7`](https://github.com/NixOS/nixpkgs/commit/073c11c7d305960a9267cdc8442f331e5bd5db61) kubecfg: 0.22.0 -> 0.26.0 ([nixos/nixpkgs⁠#171259](https://togithub.com/nixos/nixpkgs/issues/171259))
* [`9db41e2c`](https://github.com/NixOS/nixpkgs/commit/9db41e2ceab1ba7d33bab1d13ec6b98da7f6a9ae) python310Packages.jedi-language-server: 0.35.1 -> 0.36.0
* [`cccc4592`](https://github.com/NixOS/nixpkgs/commit/cccc45928a5b9f0bae550151cb9a7e73d5516ecb) python310Packages.commoncode: 30.1.1 -> 30.2.0
* [`6a197290`](https://github.com/NixOS/nixpkgs/commit/6a197290608d7e40d2561b9cd683e17ba47bfab8) wishlist: init at 0.4.0
* [`aff0aeb3`](https://github.com/NixOS/nixpkgs/commit/aff0aeb33dd84ef72dea2b3b1d3556cb25c9d026) python310Packages.zigpy-deconz: 0.15.0 -> 0.16.0
* [`b521c51c`](https://github.com/NixOS/nixpkgs/commit/b521c51c8322c897c0d5cf2168a29ba1e1222d76) python310Packages.zigpy-deconz: disable on older Python releases
* [`9f05fc66`](https://github.com/NixOS/nixpkgs/commit/9f05fc666188c06d5bcc8c1f352d77244ec6f91d) config.allowUnsupportedSystem: define as option
* [`1ce2275c`](https://github.com/NixOS/nixpkgs/commit/1ce2275cf000c8aad3cbd6f86b3e03dfc89dff7c) sigma-cli: 0.4.2 -> 0.4.3
* [`129a6899`](https://github.com/NixOS/nixpkgs/commit/129a6899a000fa3d0fe209d80ced736de85f35d1) pantum-driver: init at 1.1.84
* [`c42af24f`](https://github.com/NixOS/nixpkgs/commit/c42af24f3036e089f79d723314245357626f9a26) signalbackup-tools: 20220425 -> 20220430
* [`a51544b7`](https://github.com/NixOS/nixpkgs/commit/a51544b715b0978dd9063fab77cb9097bf7c5222) teams: fix source hash of 1.5.00.10453 on Darwin
* [`3a8257c7`](https://github.com/NixOS/nixpkgs/commit/3a8257c77be30e8908328f5ce2f5c6e9e01bd381) sigma-cli: add meta.mainProgram
* [`6870929a`](https://github.com/NixOS/nixpkgs/commit/6870929ad1ffa5b78cf613b66e389ce949fc3b95) python310Packages.gensim:disable on older Python releases
* [`2e24a02d`](https://github.com/NixOS/nixpkgs/commit/2e24a02d0f05a92e3611f396329f9d2359a62a68) python310Packages.pims: enable tests
* [`12082b1f`](https://github.com/NixOS/nixpkgs/commit/12082b1f9446284b42160c823060831ab473e01a) python310Packages.gensim: remove whitespace
* [`fc003057`](https://github.com/NixOS/nixpkgs/commit/fc00305708b4806837cb2ceb646a1b488158d87f) pulumi-bin: 3.30.0 -> 3.31.0
* [`3e36af97`](https://github.com/NixOS/nixpkgs/commit/3e36af97686dc67c365a107fe37dbf73b2faa45b) quickemu: fix spice-gtk dependency
* [`e9452b3b`](https://github.com/NixOS/nixpkgs/commit/e9452b3b3ed9b295e1cede48f6549bb28c1d4773) python3Packages.preprocess-cancellation: fix build
* [`a040d8f3`](https://github.com/NixOS/nixpkgs/commit/a040d8f34a07551866e5844de7422b7358ba7e01) python3Packages.pyhiveapi: 0.5.1 -> 0.5.3
* [`2a0b704f`](https://github.com/NixOS/nixpkgs/commit/2a0b704f16f1984e65c661345f267e72014a1d33) python310Packages.pims: ignore DeprecationWarning
* [`69945502`](https://github.com/NixOS/nixpkgs/commit/699455022496a9289ae79634eb3315d4ee14eff4) hjson-go: 3.1.1 -> 3.2.0
* [`fddfaa3b`](https://github.com/NixOS/nixpkgs/commit/fddfaa3b72bd4f13655ac7aba1500c14ba9f0456) firefox: remove unused option
* [`1fddd740`](https://github.com/NixOS/nixpkgs/commit/1fddd7401aa6667dd19780a3d041e9a7ea673c31) htop: remove linux only hint from description
* [`37f3a23a`](https://github.com/NixOS/nixpkgs/commit/37f3a23a029326e42bb59445a059b8a3c70fab1a) fcft: 3.0.1 -> 3.1.1
* [`9f8d8443`](https://github.com/NixOS/nixpkgs/commit/9f8d844340e8026758b56c449f7c3596155cf3e7) foot: 1.11.0 -> 1.12.1
* [`f9ec68bd`](https://github.com/NixOS/nixpkgs/commit/f9ec68bd6dbb1a8b56066330d44b91d64dc850a7) python310Packages.ropper: 1.13.6 -> 1.13.7
* [`733730ef`](https://github.com/NixOS/nixpkgs/commit/733730eff86f0df80aeddaafe729e562d26c1b1b) john: update source to GitHub and homepage url
* [`eeb57890`](https://github.com/NixOS/nixpkgs/commit/eeb57890bb962ef6a9998a5eb6c780016e8d3d3a) python310Packages.pywinrm: 0.4.2 -> 0.4.3
* [`d37aa7fe`](https://github.com/NixOS/nixpkgs/commit/d37aa7fe6a8c4d5743045b2533cc2055b873ff79) python310Packages.pytenable: 1.4.4 -> 1.4.6
* [`d4894355`](https://github.com/NixOS/nixpkgs/commit/d4894355c114e6950d7cb844c0220c91098cf479) vim/update.py: distinguish between vim/neovim plugins
* [`a7ca41f1`](https://github.com/NixOS/nixpkgs/commit/a7ca41f1ff24131c1386a20d5cfa2ce2591b17a1) python310Packages.secretstorage: 3.3.1 -> 3.3.2
* [`494ad978`](https://github.com/NixOS/nixpkgs/commit/494ad97836e36dd6a05fa525323622984e087297) gof5: init at 0.1.4 ([nixos/nixpkgs⁠#169422](https://togithub.com/nixos/nixpkgs/issues/169422))
* [`21f526a7`](https://github.com/NixOS/nixpkgs/commit/21f526a7f33f5c689260ee8e992d954fd7188d3b) vimPlugins: update
* [`1df86fce`](https://github.com/NixOS/nixpkgs/commit/1df86fce588d2229a8bc19ea340e09253c0ad09f) saleae-logic-2: 2.3.50 -> 2.3.51
* [`aeeb5ebd`](https://github.com/NixOS/nixpkgs/commit/aeeb5ebd00adb6e247a4a5774a8a84f24fb1cfb2) firewalld: init at 1.1.1
* [`6c69577b`](https://github.com/NixOS/nixpkgs/commit/6c69577b23bca5431f6849edc9768b7e0d9d4001) colmena: 0.2.2 -> 0.3.0
* [`4427d9cd`](https://github.com/NixOS/nixpkgs/commit/4427d9cd73a3900097d651b0bc1abebc697e94dc) gitbatch: 2019-12-19 -> 0.6.1
* [`738d1454`](https://github.com/NixOS/nixpkgs/commit/738d1454fe71b7392102769a820de8809996b383) gdal_2: fix build ([nixos/nixpkgs⁠#169738](https://togithub.com/nixos/nixpkgs/issues/169738))
* [`2c83b549`](https://github.com/NixOS/nixpkgs/commit/2c83b549280b32353c12b05373fd74829355a593) bottles: 2022.4.28-trento -> 2022.5.2-trento
* [`e4dfaba5`](https://github.com/NixOS/nixpkgs/commit/e4dfaba5068580ab143b0df4e1eac5517164ec35) solc: disable z3 strict version check
* [`114ea5a0`](https://github.com/NixOS/nixpkgs/commit/114ea5a07eb9448ee64ddb20175befa7e778e41b) lisgd: 0.3.3 -> 0.3.4
* [`d770c335`](https://github.com/NixOS/nixpkgs/commit/d770c33587d1ad73b0959c88479439c4aaa1dd90) cvehound: 1.0.4 -> 1.0.9
* [`3caced88`](https://github.com/NixOS/nixpkgs/commit/3caced8853a95b280c1afeb3516348768bffe372) go-junit-report: 2018-06-14 -> 1.0.0
* [`7485e9f1`](https://github.com/NixOS/nixpkgs/commit/7485e9f1d78ae64e42a703f83a12b948e1c5921c) goconvey: 1.6.3 -> 1.7.2
* [`d60e768c`](https://github.com/NixOS/nixpkgs/commit/d60e768cb1560188df672c5d08ef962ba81d96be) redpanda: init at 21.11.15
* [`b2542b5b`](https://github.com/NixOS/nixpkgs/commit/b2542b5b05d1e750e2ade0ae339250ec72640e7d) aws-google-auth: 0.0.37 -> 0.0.38
* [`509a6f1e`](https://github.com/NixOS/nixpkgs/commit/509a6f1ebae10bf3c056ef49961768e5ca5a3406) fnc: unbreak build
* [`5aec68a7`](https://github.com/NixOS/nixpkgs/commit/5aec68a7891d250f020b072a689a19e5f5c2bf1c) prometheus-aws-s3-exporter: 0.4.1 -> 0.5.0
* [`a318ca39`](https://github.com/NixOS/nixpkgs/commit/a318ca39c9cbdf0b1e752f2d87d9bcd8ff230d68) exoscale-cli: 1.52.1 -> 1.54.0
* [`4558d28c`](https://github.com/NixOS/nixpkgs/commit/4558d28cfce57227fd78a7a15120f275c9cf0389) scalafix: 0.9.0 -> 0.10.0, completions, setup-hook instead of jdk ([nixos/nixpkgs⁠#171074](https://togithub.com/nixos/nixpkgs/issues/171074))
* [`24c33ab7`](https://github.com/NixOS/nixpkgs/commit/24c33ab7952544ad355d0677c9eea931b23f371c) metals: 0.11.2 -> 0.11.4 ([nixos/nixpkgs⁠#171127](https://togithub.com/nixos/nixpkgs/issues/171127))
* [`dda33d2b`](https://github.com/NixOS/nixpkgs/commit/dda33d2b2b2c69a0fc04b4abc460248e5b63436b) nixos/doc/manual: Remove trailing white space from 22.05 release notes
* [`064da262`](https://github.com/NixOS/nixpkgs/commit/064da2621ae34c0eb55f2b6229384b5aeed767fc) linux_testing_bcachefs: unstable-2022-04-08 -> unstable-2022-04-25
* [`58d1bd20`](https://github.com/NixOS/nixpkgs/commit/58d1bd206bdfc398694a4a1fa60ada3a838db6db) bcachefs-tools: unstable-2022-04-08 -> unstable-2022-05-02
* [`46241e15`](https://github.com/NixOS/nixpkgs/commit/46241e156c26b6b738e028fec3b5f931e5a7ccf7) nixos/virtualisation.oci-containers: Use podman as the default backend
* [`74fb11c3`](https://github.com/NixOS/nixpkgs/commit/74fb11c3521ed1c61d50d86acff14c3e39c21d20) moonraker: unstable-2022-03-10 -> unstable-2022-04-23
* [`a0ab3450`](https://github.com/NixOS/nixpkgs/commit/a0ab345013c811a3d5841c6f126b7684a96d7e92) freeipmi: support cross compile
* [`35227e5a`](https://github.com/NixOS/nixpkgs/commit/35227e5abb956ae2885306ef4769617ed28427e7) trunk: 0.14.0 -> 0.15.0
* [`53bc699e`](https://github.com/NixOS/nixpkgs/commit/53bc699e2c9bf49d747089f9a56260ab1c163d52) python310Packages.teslajsonpy: 2.1.0 -> 2.2.0
* [`3c79fddd`](https://github.com/NixOS/nixpkgs/commit/3c79fddd9f8ac37aca3bc096853029e509eea870) python310Packages.hahomematic: 1.2.1 -> 1.2.2
* [`6fcda619`](https://github.com/NixOS/nixpkgs/commit/6fcda619244f9e07b7e8dfb3231cddbc18548ee8) python310Packages.youtube-search-python: 1.6.4 -> 1.6.5
* [`76fbad7b`](https://github.com/NixOS/nixpkgs/commit/76fbad7ba64df65c3a36fb71def1215797ed964a) python39Packages.fontmake: init at 3.3.0
* [`a12295c1`](https://github.com/NixOS/nixpkgs/commit/a12295c1f9871d2a690b5aacd48c281865d43e59) pythonPackages39.openstep-plist: init at 0.3.0
* [`ae3522a4`](https://github.com/NixOS/nixpkgs/commit/ae3522a453310117cc6bb1453fef324613da9b63) python39Packages.glyphslib: init at 6.0.4
* [`1eaa0f5a`](https://github.com/NixOS/nixpkgs/commit/1eaa0f5a7bb4d18262810315f871115854f7e4e2) python39Packages.skia-pathops: init at 0.7.9
* [`67947fa1`](https://github.com/NixOS/nixpkgs/commit/67947fa100a003a8bad3313f97f6ea7e86cafdaa) python310Packages.scmrepo: 0.0.19 -> 0.0.20
* [`deb70bd2`](https://github.com/NixOS/nixpkgs/commit/deb70bd200e9dd8e483e05cd8638979c42045edd) ocamlPackages.uuuu: 0.2.0 → 0.3.0
* [`7e315248`](https://github.com/NixOS/nixpkgs/commit/7e315248b73d34ba204ec945b316f46e01e27156) python310Packages.filetype: 1.0.10 -> 1.0.13
* [`12fc9780`](https://github.com/NixOS/nixpkgs/commit/12fc9780aa9d73df78a89f34ed5e381a87ca0277) python310Packages.zeroconf: disable failing test
* [`3c7a994c`](https://github.com/NixOS/nixpkgs/commit/3c7a994c8502af38e3c24b36ec5a77f4a314a7bb) python310Packages.flask-jwt-extended: 4.3.1 -> 4.4.0
* [`5f3b40fd`](https://github.com/NixOS/nixpkgs/commit/5f3b40fdbeb9f46d81d2ffe4fd0b77ad88963cac) python310Packages.signedjson: 1.1.1 -> 1.1.4
* [`6509cea3`](https://github.com/NixOS/nixpkgs/commit/6509cea388297b03ec7a2bc24d5505d47ec887f5) python310Packages.flask-jwt-extended: switch to pytestCheckHook
* [`86a69080`](https://github.com/NixOS/nixpkgs/commit/86a6908045c6a6c613e6a94b447c95846408fde3) coqPackages.metacoq: create package ([nixos/nixpkgs⁠#162639](https://togithub.com/nixos/nixpkgs/issues/162639))
* [`fb5fd132`](https://github.com/NixOS/nixpkgs/commit/fb5fd13212e10b53bda033b24f1fca0860e18990) python310Packages.cert-chain-resolver: add missing input
* [`fa1e8856`](https://github.com/NixOS/nixpkgs/commit/fa1e88569880cf9f875842cdb6f6fe2cf58237a9) gitRepo: 2.24.1 -> 2.25
* [`1d43276e`](https://github.com/NixOS/nixpkgs/commit/1d43276e4e047d581a39f55a815d7b1180a097e1) python310Packages.ansible-later: 2.0.11 -> 2.0.12
* [`eb50502c`](https://github.com/NixOS/nixpkgs/commit/eb50502c5fb000d0d1e5d27fa3c36d7542a213ea) lucenepp: install header files of lucene-contrib
* [`8aa77956`](https://github.com/NixOS/nixpkgs/commit/8aa77956a1a819a0be41a20105015d84e68196cf) python310Packages.bpython: disable failing test
* [`fe8f77c2`](https://github.com/NixOS/nixpkgs/commit/fe8f77c2c086440e8756cba0abf42e7f1b155015) linphone: Cleanup dependencies
* [`251f3244`](https://github.com/NixOS/nixpkgs/commit/251f3244a7a9d6dd93b29926d70fd55181cfd12d) fclones: 0.22.0 -> 0.23.0
* [`2e13dc77`](https://github.com/NixOS/nixpkgs/commit/2e13dc779513e45a972f10099d1a4d4be447399e) python310Packages.glances-api: 0.3.4 -> 0.3.5
* [`a032d2f2`](https://github.com/NixOS/nixpkgs/commit/a032d2f2441105894c64af5c857e92a56536e369) python310Packages.envs: 1.3 -> 1.4
* [`346742d3`](https://github.com/NixOS/nixpkgs/commit/346742d3cb85314f63ee54ca97a7ed971f50cc50) python310Packages.jug: 2.1.1 -> 2.2.0
* [`ebaa5279`](https://github.com/NixOS/nixpkgs/commit/ebaa5279daf393a44b81b74be8a667af12f830ff) python310Packages.pyeapi: fix Python 3.10 support
* [`bbf483c4`](https://github.com/NixOS/nixpkgs/commit/bbf483c46e007036475674a60c5fbd8e5a3e6b32) nixos/release: add podman, oci-containers.podman to tested
* [`82507844`](https://github.com/NixOS/nixpkgs/commit/825078447ac48ed4912e609d671d1f037a1e813c) podman: add oci-containers.podman to passthru.tests
* [`6ac337aa`](https://github.com/NixOS/nixpkgs/commit/6ac337aa06d044cf0a6a8caebb232223d22b402b) python310Packages.namedlist: add patch for collections.abc
* [`56ab4f61`](https://github.com/NixOS/nixpkgs/commit/56ab4f61bc8f9210f76412c615beef64246e50f3) nixos/lxd: improve tests
* [`9ded9f11`](https://github.com/NixOS/nixpkgs/commit/9ded9f11002882d46c7be47527278ae01039c134) harec: init at 0.pre+date=2022-04-26
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
