### PR TITLE
niv emacs-overlay: update 3960283c -> 3a0704d6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3960283c022627d29c00dfdcb6b2228396b115b3",
-        "sha256": "00qv7d7jllk68i4nk2ap9kpjlllv7bzd0qvzpnlk6izmzzsncc42",
+        "rev": "3a0704d6ae03c5db954697b6c0873ebc14e324f5",
+        "sha256": "0m443p0lp2pmkgy0a8lizbvy2ia44zpqli422s34hpnqvzxyj2mj",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/3960283c022627d29c00dfdcb6b2228396b115b3.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/3a0704d6ae03c5db954697b6c0873ebc14e324f5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@3960283c...3a0704d6](https://github.com/nix-community/emacs-overlay/compare/3960283c022627d29c00dfdcb6b2228396b115b3...3a0704d6ae03c5db954697b6c0873ebc14e324f5)

* [`262ee11d`](https://github.com/nix-community/emacs-overlay/commit/262ee11dd91eb63f8818666f1fa633dc686b2e14) Updated repos/emacs
* [`b75742a9`](https://github.com/nix-community/emacs-overlay/commit/b75742a99b555312d396b58a3ec749821aed4819) Updated repos/melpa
* [`f5c2505a`](https://github.com/nix-community/emacs-overlay/commit/f5c2505ac8d09edfa9380ab949d29d4ea3c37c9a) Updated repos/nongnu
* [`a738164f`](https://github.com/nix-community/emacs-overlay/commit/a738164f99432b10cf3b9432c1cc8d80d3494196) Updated repos/emacs
* [`7c79ae3f`](https://github.com/nix-community/emacs-overlay/commit/7c79ae3fd29afdcf3267ac1ddfe4daaa8d0a6335) Updated repos/melpa
* [`cec01afb`](https://github.com/nix-community/emacs-overlay/commit/cec01afbb3ee81c380e7ec253d0c03cd699bd41d) Updated repos/elpa
* [`ffab9dd3`](https://github.com/nix-community/emacs-overlay/commit/ffab9dd366b333b391ed94c173f46a147b93016c) Updated repos/emacs
* [`43b4c2b4`](https://github.com/nix-community/emacs-overlay/commit/43b4c2b4eaa3893266661e31bfc87e9915bebeef) Updated repos/melpa
* [`fb4f0f23`](https://github.com/nix-community/emacs-overlay/commit/fb4f0f2346c46d0a892e7fd68cdda88edd4d89ba) Updated repos/emacs
* [`6a432b70`](https://github.com/nix-community/emacs-overlay/commit/6a432b7069783d4f4925a40bc6102d14ceee5c77) Updated repos/melpa
* [`610651ab`](https://github.com/nix-community/emacs-overlay/commit/610651abe8ffc4ca9a1d94e2220f19fd85e78391) Updated repos/elpa
* [`20dab4c6`](https://github.com/nix-community/emacs-overlay/commit/20dab4c60278736c33235143b946db0cc18cef9c) Updated repos/emacs
* [`8309def9`](https://github.com/nix-community/emacs-overlay/commit/8309def99872ead48b2591d7fd7ed198f0b3fb43) Updated repos/melpa
* [`59d714d4`](https://github.com/nix-community/emacs-overlay/commit/59d714d492387132ed6fe650282ee446d97aa31d) Updated repos/elpa
* [`a6e77202`](https://github.com/nix-community/emacs-overlay/commit/a6e77202447fccfcd27c672d4268adbc0a267b13) Updated repos/emacs
* [`1deb4d66`](https://github.com/nix-community/emacs-overlay/commit/1deb4d66be3117dd0d9dbf31fd458035e0f3c4de) Updated repos/melpa
* [`ed26738e`](https://github.com/nix-community/emacs-overlay/commit/ed26738e40ec90822e66a0b3e073b17913509482) Updated repos/emacs
* [`4e0481c7`](https://github.com/nix-community/emacs-overlay/commit/4e0481c777deab3f01cb5a6bdddffd49321ea1a3) Updated repos/melpa
* [`463a98ea`](https://github.com/nix-community/emacs-overlay/commit/463a98ea6a1c137e36a05df81629a3838d2fc1dc) Updated repos/emacs
* [`ad374036`](https://github.com/nix-community/emacs-overlay/commit/ad37403611e633cbe174bb1d40fc4a1b7343c941) Updated repos/melpa
* [`499d6dd4`](https://github.com/nix-community/emacs-overlay/commit/499d6dd4a9f641a90e83486a419961c9e82237ec) Updated repos/elpa
* [`313455c6`](https://github.com/nix-community/emacs-overlay/commit/313455c65b6fab65c228da7c4c03d52092fc298e) Updated repos/emacs
* [`86409cf2`](https://github.com/nix-community/emacs-overlay/commit/86409cf2583798c085f851ae27face6d2067dbb3) Updated repos/melpa
* [`496433d3`](https://github.com/nix-community/emacs-overlay/commit/496433d3a2ab1ae9e7f7d0edbfde96692d1c7efd) Updated repos/emacs
* [`8ac752d1`](https://github.com/nix-community/emacs-overlay/commit/8ac752d1ff06aa4a0be94ca896fd80f6cacd40d1) Updated repos/melpa
* [`e5ab98c5`](https://github.com/nix-community/emacs-overlay/commit/e5ab98c50dc50e09ecd6b1481785ddb5b539455b) Updated repos/elpa
* [`9704ccbb`](https://github.com/nix-community/emacs-overlay/commit/9704ccbbc346b1b7993261e4ba9326a81c96544f) Updated repos/emacs
* [`97727816`](https://github.com/nix-community/emacs-overlay/commit/97727816f744ecc1eb327c28169fae29ac847124) Updated repos/melpa
* [`9bf0039f`](https://github.com/nix-community/emacs-overlay/commit/9bf0039f2976fbc9d4f562c034a388d8b14e64f9) Updated repos/elpa
* [`bec12ee2`](https://github.com/nix-community/emacs-overlay/commit/bec12ee24503fda518f6964bed9f71cdcc2c85a9) Updated repos/emacs
* [`e007354f`](https://github.com/nix-community/emacs-overlay/commit/e007354fcc0f492878d85b85334ab3baa08a273b) Updated repos/melpa
* [`a8d8a64f`](https://github.com/nix-community/emacs-overlay/commit/a8d8a64f1bc367b2366437da55220507a055df8f) Updated repos/emacs
* [`6903c7ef`](https://github.com/nix-community/emacs-overlay/commit/6903c7efd59e14ae3f51a4538efc6ad9fe982355) Updated repos/melpa
* [`ebb4f132`](https://github.com/nix-community/emacs-overlay/commit/ebb4f13297cc67f59ed72faa1402fcd449fa8dce) Updated repos/nongnu
* [`1e70e6df`](https://github.com/nix-community/emacs-overlay/commit/1e70e6dfe07e55ba08c330d320ca8f8582b1faa1) Updated repos/elpa
* [`612c3ed6`](https://github.com/nix-community/emacs-overlay/commit/612c3ed67bfe5cebb1c591d4af10e74f6c976bdc) Updated repos/emacs
* [`551cd0a4`](https://github.com/nix-community/emacs-overlay/commit/551cd0a46e55d7bd0d87e6c34cc8833c5b38a468) Updated repos/melpa
* [`3c01cc16`](https://github.com/nix-community/emacs-overlay/commit/3c01cc1667238149f9ff2aa241808f0ca5acfdaa) Updated repos/elpa
* [`6f41b4aa`](https://github.com/nix-community/emacs-overlay/commit/6f41b4aaf37f166615f4edba872a66c341cfc01f) Updated repos/emacs
* [`d863097f`](https://github.com/nix-community/emacs-overlay/commit/d863097fb813a4fdf856df265714614aebf28aa6) Updated repos/melpa
* [`4c4ab6c5`](https://github.com/nix-community/emacs-overlay/commit/4c4ab6c50af7149404115b6aa9aa8c368f80a0a0) Updated repos/emacs
* [`92f0648d`](https://github.com/nix-community/emacs-overlay/commit/92f0648d4001e7921d77c17f17f23df02697937f) Updated repos/melpa
* [`0faec9d6`](https://github.com/nix-community/emacs-overlay/commit/0faec9d6c06e2b0d28fbd4296969e400446fa729) Updated repos/elpa
* [`ddb2c436`](https://github.com/nix-community/emacs-overlay/commit/ddb2c436452f4436ce061a5411c8c61ad6e6b312) Updated repos/emacs
* [`7cb7c8c5`](https://github.com/nix-community/emacs-overlay/commit/7cb7c8c550ae9e746cbc65bfea7bd005409bf0a4) Updated repos/melpa
* [`2d0a7cd2`](https://github.com/nix-community/emacs-overlay/commit/2d0a7cd2e3d103d56537602f9b0c0157f2d411f7) Updated repos/emacs
* [`ff6f93f4`](https://github.com/nix-community/emacs-overlay/commit/ff6f93f4d156d7e9b48bb9cc986d119775e7df1f) Updated repos/melpa
* [`81a34956`](https://github.com/nix-community/emacs-overlay/commit/81a34956214251feed196a6e68fc7934782d552e) Updated repos/emacs
* [`334ba8c6`](https://github.com/nix-community/emacs-overlay/commit/334ba8c610cf5e41dfe130507030e5587e3551b4) Updated repos/melpa
* [`e47ffb5d`](https://github.com/nix-community/emacs-overlay/commit/e47ffb5d60d8e8271d412945c685dbeac2fca7a4) flake.nix: Add a packages output
* [`2fb72619`](https://github.com/nix-community/emacs-overlay/commit/2fb72619761bb2478715f7a5f64aad619e94da99) Add fallback case when allowAliases is not set
* [`a117f916`](https://github.com/nix-community/emacs-overlay/commit/a117f9162df212752431d09b4ba26f1bf7026287) Updated repos/elpa
* [`bf8765e0`](https://github.com/nix-community/emacs-overlay/commit/bf8765e024d6398cfa703dc0e0d26f94232768a1) Updated repos/emacs
* [`ef308886`](https://github.com/nix-community/emacs-overlay/commit/ef3088863916b0604dbd5c3ba402b7f52c89c53d) Updated repos/melpa
* [`b7cb2919`](https://github.com/nix-community/emacs-overlay/commit/b7cb291928af9a1c69447b56d76e08a7d1271f13) Updated repos/elpa
* [`9beebb6c`](https://github.com/nix-community/emacs-overlay/commit/9beebb6ca0b557de24b3f31d07fbcd0f97994bdd) Updated repos/emacs
* [`3a0704d6`](https://github.com/nix-community/emacs-overlay/commit/3a0704d6ae03c5db954697b6c0873ebc14e324f5) Updated repos/melpa
