### PR TITLE
niv powerlevel10k: update 0b026542 -> 406e6aa9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0b026542699ca0f2de7c5354fe0ff1184e63a3f3",
-        "sha256": "1cvsh3lsalx7d472aciblv8c7dvvf12css21jq796ny2dxnii5pw",
+        "rev": "406e6aa9e46429872c211d0c37517238ce9da3db",
+        "sha256": "0dz0cfgdzrspyc48ncn9pvw3i591bwcrk5ymyx3a6yxkmp2qzj99",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0b026542699ca0f2de7c5354fe0ff1184e63a3f3.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/406e6aa9e46429872c211d0c37517238ce9da3db.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@0b026542...406e6aa9](https://github.com/romkatv/powerlevel10k/compare/0b026542699ca0f2de7c5354fe0ff1184e63a3f3...406e6aa9e46429872c211d0c37517238ce9da3db)

* [`ff531e5f`](https://github.com/romkatv/powerlevel10k/commit/ff531e5f2cfcb8994daf7a11d6de086c57becdb2) Added missing segments to README.
* [`d0305881`](https://github.com/romkatv/powerlevel10k/commit/d03058819df3aa74fe9f6c639935ce18d27a2703) Revert "Added missing segments to README." because of auto-formatting.
* [`406e6aa9`](https://github.com/romkatv/powerlevel10k/commit/406e6aa9e46429872c211d0c37517238ce9da3db) Added missing segments to README without auto-formatting.
