### PR TITLE
niv nixpkgs: update 58585adb -> 78e94513

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "58585adbcd7fa9889d3d3731fc9c1766317dec77",
-        "sha256": "1w571zyd4vnrkjga1fgr7lbn11097z0arvx0c3xlqvr6vrvshg9l",
+        "rev": "78e94513206616e7f81b0d7c594bf9f7423d1858",
+        "sha256": "1kza6ay1hn42zjk5wricdss8gzlpfinvn80rrg93k9bw2c0jqsfh",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/58585adbcd7fa9889d3d3731fc9c1766317dec77.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/78e94513206616e7f81b0d7c594bf9f7423d1858.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@58585adb...78e94513](https://github.com/nixos/nixpkgs/compare/58585adbcd7fa9889d3d3731fc9c1766317dec77...78e94513206616e7f81b0d7c594bf9f7423d1858)

* [`26d078be`](https://github.com/NixOS/nixpkgs/commit/26d078be2c841c8fcee3bd3ca4b96d753ac5d934) knightos-scas: fix cross-compilation and enable documentation
* [`3f544ff5`](https://github.com/NixOS/nixpkgs/commit/3f544ff584c4a34e626d31b1a1c4005e293704b6) glib: remove build references from cross compiles
* [`e68d2cf1`](https://github.com/NixOS/nixpkgs/commit/e68d2cf1284087f39b1ff55b62f656b0d111f352) help2man: restore nls support on darwin, make nls explicit
* [`e02aeee7`](https://github.com/NixOS/nixpkgs/commit/e02aeee7d07866a80f90de330923a087049237df) maintainers: add tchekda as maintainer
* [`d8604f64`](https://github.com/NixOS/nixpkgs/commit/d8604f64d925c4f2b2224c06626b87b105235f84) maintainers: add cameronfyfe
* [`645c4997`](https://github.com/NixOS/nixpkgs/commit/645c499720e22ba83b68f14db731f4d7f40c7409) ets: init at 0.2.1
* [`9a9a5b40`](https://github.com/NixOS/nixpkgs/commit/9a9a5b4087935b4461694cbedc40764389aeb58f) ets: use installManPage
* [`8d2537a8`](https://github.com/NixOS/nixpkgs/commit/8d2537a820ccf0201f050a3d4f775f2662ca5058) ets: use fetchpatch instead of local patch file
* [`0bc0dc80`](https://github.com/NixOS/nixpkgs/commit/0bc0dc8090e6609838816f43dc7799e32c674434) desktop manager script: start properly
* [`5c2b5c2b`](https://github.com/NixOS/nixpkgs/commit/5c2b5c2b019d507776868bed741cd9a16d6ae3d3) surge-XT: unstable-2021-12-11 -> 1.0.1
* [`63a37b84`](https://github.com/NixOS/nixpkgs/commit/63a37b844cc5e82eb4e963f6fc85b99d2050117f) darwin: deprecate phases
* [`e3f6735b`](https://github.com/NixOS/nixpkgs/commit/e3f6735bca09d12f601c1945eb75339512669142) prometheus-xmpp-alerts: 0.5.1 -> 0.5.3
* [`87c95538`](https://github.com/NixOS/nixpkgs/commit/87c955386cd129d0b810d1864c4043db8408e4b2) s3fs: 1.90 -> 1.91
* [`31d64f74`](https://github.com/NixOS/nixpkgs/commit/31d64f74988c5578c8e5521f2b1c3c9678f27eeb) gurobi: 9.5.0 -> 9.5.1
* [`b3cadfd9`](https://github.com/NixOS/nixpkgs/commit/b3cadfd9e6bf298574f8334f335289e4d0693232) ott: 0.31 -> 0.32
* [`dccb6ebc`](https://github.com/NixOS/nixpkgs/commit/dccb6ebc8816bf3c2c32ea9787c8ae8fd1661fe3) backintime-common: 1.2.1 -> 1.3.2
* [`f0dd951d`](https://github.com/NixOS/nixpkgs/commit/f0dd951db17b18608c2c52447ae8b91f5c725f2f) libsForQt5.signond: 8.60 -> 8.61
* [`31fda203`](https://github.com/NixOS/nixpkgs/commit/31fda20387647ea9d90e4c621b5f101d800205c2) add self to maintainers
* [`93681a52`](https://github.com/NixOS/nixpkgs/commit/93681a52a5bff48ecf434d3225588c1c99c1e853) stdenv: check that all inputs are of an appropriate type
* [`5fe2ade9`](https://github.com/NixOS/nixpkgs/commit/5fe2ade9cada715ebbdd1a7038dc256ea1aa5e05) freetype: add some key reverse dependencies to passthru.tests
* [`688695bd`](https://github.com/NixOS/nixpkgs/commit/688695bde7c85088cccc1419a0f8a273966415eb) imlib2: 1.7.5 -> 1.8.1
* [`33c3d1b4`](https://github.com/NixOS/nixpkgs/commit/33c3d1b4523d15fee70674f81a304a4f16a3acf7) xurls: 2.3.0 -> 2.4.0
* [`235fe92e`](https://github.com/NixOS/nixpkgs/commit/235fe92e4268dfeb681dcb07273b152579592ea4) make-derivation: allow nested lists in buildInputs
* [`078379eb`](https://github.com/NixOS/nixpkgs/commit/078379eb336c73ebe87323732b53ea06e8e700cb) imlib2: add svg and heif support
* [`e628bde7`](https://github.com/NixOS/nixpkgs/commit/e628bde7c1546144e32a1a1486388c798f18e69b) prowlarr: Update dependencies, zlib and dotnet runtime
* [`4cc6fa70`](https://github.com/NixOS/nixpkgs/commit/4cc6fa7005d421865840a315d649951c4206d725) radarr: Update dependencies, zlib and dotnet runtime
* [`f38b4739`](https://github.com/NixOS/nixpkgs/commit/f38b473946022c1feffbbda687c72f7b0adfd406) prometheus-consul-exporter: 0.7.1 -> 0.8.0
* [`1155186a`](https://github.com/NixOS/nixpkgs/commit/1155186a2b72dd8df1d701f40fedf8c84766061a) python3Packages.graphviz: 0.19.1 -> 0.19.2
* [`0931014b`](https://github.com/NixOS/nixpkgs/commit/0931014baf9a4db293f8aa13c86dc7f1c0aa9395) iso-image: slim down UEFI El Torito image
* [`12c1a063`](https://github.com/NixOS/nixpkgs/commit/12c1a063bcf4bac7d6b0a629ace59500cb9d52a4) re2: add some key reverse dependencies to passthru.tests
* [`f77b63b4`](https://github.com/NixOS/nixpkgs/commit/f77b63b46f44a29625b91b0d0a15b8e8d878a350) goku: 0.3.6 -> 0.5.1
* [`61d404a7`](https://github.com/NixOS/nixpkgs/commit/61d404a7933c1c4ef201e9e1bedb519717c11b74) squeekboard: 1.16.0 -> 1.17.0
* [`c4664f6b`](https://github.com/NixOS/nixpkgs/commit/c4664f6bf18c9c8e1bd47f176f3608b4101f4514) microcodeIntel: 20220207 -> 20220419
* [`63029bcf`](https://github.com/NixOS/nixpkgs/commit/63029bcf2e68b38cb02abbc4b10f026cbfc4f237) kreport: switch to python3
* [`813fd5e9`](https://github.com/NixOS/nixpkgs/commit/813fd5e96ddec1d6b25b273cff477ef08a282f3d) swiften: remove python2 dependency
* [`01169764`](https://github.com/NixOS/nixpkgs/commit/01169764651784c15c13415e2b5589e62b4f6f96) kdb: switch to python3
* [`f6999e0c`](https://github.com/NixOS/nixpkgs/commit/f6999e0cc5d3b5b970bfa2fdc52e9c9fbcde2091) sane-backends: fix build on Darwin
* [`e34b2286`](https://github.com/NixOS/nixpkgs/commit/e34b228626cc36ea05455376f5d21c13fd9040cf) pandoc: don't use remove-references-to with haskellPackages.HTTP
* [`127f8ef9`](https://github.com/NixOS/nixpkgs/commit/127f8ef97e4c15ecc34122a3a1aba8c0ad3cbb4b) qpid-cpp: switch to python3
* [`187c58e7`](https://github.com/NixOS/nixpkgs/commit/187c58e74de2407c7d65462923b9e4a9513dbcb0) qcachegrind: drop python profiling support
* [`d9218155`](https://github.com/NixOS/nixpkgs/commit/d9218155d2b3b0ce9d0c7fbc6bcfbf5beec4670c) ghostscript: use system-wide openjpeg
* [`8203e061`](https://github.com/NixOS/nixpkgs/commit/8203e061ec0556b4d4a972b18ba92509cb1ddd04) icu71: init at 71.1
* [`4f55f016`](https://github.com/NixOS/nixpkgs/commit/4f55f016f5fe90aedeaa627f629bc095f4ea2ee0) icu: 70.1 -> 71.1
* [`77a189e0`](https://github.com/NixOS/nixpkgs/commit/77a189e066a839b1c8bb7cb8c125d434d15854ac) systemd: disable EFI stripping
* [`7d81750f`](https://github.com/NixOS/nixpkgs/commit/7d81750f21bff6d599ce4e08c3e13be23b5104b8) python3Packages.flask-restful: update pname
* [`a649d4f0`](https://github.com/NixOS/nixpkgs/commit/a649d4f03832964080ca853695cd74d5fbaafa14) python: use whitespace to split possible existing options
* [`0c219747`](https://github.com/NixOS/nixpkgs/commit/0c2197472daaf4f61b5c09692df5c083f855a0e1) vim: 8.2.4609 -> 8.2.4816
* [`e35682b2`](https://github.com/NixOS/nixpkgs/commit/e35682b207b733ca044caf618b8945f309e1d523) gcc: 11.2.0 -> 11.3.0
* [`890cd18a`](https://github.com/NixOS/nixpkgs/commit/890cd18a55f5dc5bce5eb647c5b8081dc87496f6) python310Packages.pkgconfig: execute tests, adopt
* [`77316244`](https://github.com/NixOS/nixpkgs/commit/773162442af358717b5885b29ea0c0b6f7be1fad) xtreemfs: switch to python3
* [`6694081a`](https://github.com/NixOS/nixpkgs/commit/6694081af04c9cac0f97af88f14cf85599c58518) elfutils: mark as broken when building a static library
* [`15f68580`](https://github.com/NixOS/nixpkgs/commit/15f685808fa7f192cb466d8ff6f607cb338df12b) kbd: fix static build
* [`71ca6660`](https://github.com/NixOS/nixpkgs/commit/71ca66602b1209d784321b59a01a099ce9e97f8a) systemd: mark as broken for static builds
* [`b79ebdec`](https://github.com/NixOS/nixpkgs/commit/b79ebdec9b76a04b4d583929d222e67384a6e444) util-linux: fix static build by disabling systemd support
* [`e4c5ff61`](https://github.com/NixOS/nixpkgs/commit/e4c5ff6156b249f5a6f4017c9b792131352d9759) bluez: add upstream patch for /var/lib/bluetooth
* [`dbf7109d`](https://github.com/NixOS/nixpkgs/commit/dbf7109d7e451a82f61ef47dcf5106b6add9ad50) webrtc-audio-processing: enable powerpc64le
* [`e69c11d0`](https://github.com/NixOS/nixpkgs/commit/e69c11d0dd8f4a1bbce00b7edd686d3b1cc4513d) libopenmpt: 0.6.2 -> 0.6.3
* [`d2275a71`](https://github.com/NixOS/nixpkgs/commit/d2275a71e6bdfb08863d22c4ce9bc3422271eacd) librsvg: 2.54.0 -> 2.54.1
* [`4ff24ba8`](https://github.com/NixOS/nixpkgs/commit/4ff24ba8584e5c46b333864e1e72c117634a9e8a) python3Package.protobuf: 3.19.3 -> 3.19.4
* [`95473329`](https://github.com/NixOS/nixpkgs/commit/954733296484a04ae626929792467f52080ce7c6) python310Packages.curio: ignore flaky test
* [`532ebf6b`](https://github.com/NixOS/nixpkgs/commit/532ebf6b579ebf657a473c371eef7d52e13804a4) wrapGAppsHook: use makeBinaryWrapper
* [`f8cc8ff5`](https://github.com/NixOS/nixpkgs/commit/f8cc8ff5755528d9a73671481ba3d6fb00f4e8d5) makeBinaryWrapper: unset NIX_CFLAGS
* [`1092aa46`](https://github.com/NixOS/nixpkgs/commit/1092aa465699c31e6054c6278c9a496d4febb5de) py-wmi-client: remove
* [`629a7447`](https://github.com/NixOS/nixpkgs/commit/629a74477f7036cec9e186ffab42915a17b7a9dd) libpulseaudio: preserve vapi files
* [`85f5539c`](https://github.com/NixOS/nixpkgs/commit/85f5539c4bed08e58c1ea4d00fdc903e9abb2951) curl: 7.82.0 -> 7.83.0
* [`f8d7adf2`](https://github.com/NixOS/nixpkgs/commit/f8d7adf28432b9f90ae64e305e137088ec8efd57) fluidsynth: fix build on darwin
* [`6f1dbeb3`](https://github.com/NixOS/nixpkgs/commit/6f1dbeb35f4d828dbfc3baf9db5af61812ff42cd) dante: remove hardwired PATH= from redefgen.sh script
* [`e8f4f984`](https://github.com/NixOS/nixpkgs/commit/e8f4f984dfc88792a8348212c603a9816536823f) xow: 0.5 -> unstable-2022-04-24
* [`c60ce4af`](https://github.com/NixOS/nixpkgs/commit/c60ce4afdc13018ab0d7268c6defb2b42f8c93b7) libnotify: 0.7.9 -> 0.7.11
* [`0af63d20`](https://github.com/NixOS/nixpkgs/commit/0af63d20a7435712a785d039ebabafe1a532cd4a) flex-ndax: 0.2-20211111.0 -> 0.2-20220427
* [`eae04234`](https://github.com/NixOS/nixpkgs/commit/eae04234f312738173768a880a7c7acc77fe34c9) 3llo: 0.3.0 -> 1.3.1
* [`910f84bf`](https://github.com/NixOS/nixpkgs/commit/910f84bf9ec3ef574699c85d6b132bacca71dd84) libseccomp: re-enable checkPhase
* [`74d30c2f`](https://github.com/NixOS/nixpkgs/commit/74d30c2fcd3c35ae6984a477247c980e045c6be7) python310Packages.rich: 12.2.0 -> 12.3.0
* [`632043a5`](https://github.com/NixOS/nixpkgs/commit/632043a5bb44d64a57294e15e5f06c1090d57b02) python3Packages.chainer: rm cupy warning
* [`acc0931d`](https://github.com/NixOS/nixpkgs/commit/acc0931de1f5420bbb0c73d1cc816a6e254b1c79) python3Packages: restore warning, but fix tests
* [`ff2aff2a`](https://github.com/NixOS/nixpkgs/commit/ff2aff2a1b6bb665a7e77c5b6de8d6feb4be091e) cldr-annotations: 40.0 -> 41.0
* [`66d16134`](https://github.com/NixOS/nixpkgs/commit/66d16134307f91c58447c7c9f71ae1444025982f) dprint: 0.26.0 -> 0.27.0
* [`bfecfa96`](https://github.com/NixOS/nixpkgs/commit/bfecfa961300d374ce191fd2d1e51bdcb14262e1) zcash: 4.6.0-2 -> 4.7.0
* [`d97e95e8`](https://github.com/NixOS/nixpkgs/commit/d97e95e86298c09bff338c7e9d1778e06792168f) gtk3: support cross-compilation
* [`34cdbb4e`](https://github.com/NixOS/nixpkgs/commit/34cdbb4e731ab34d531a202990879a0587a02b4e) sqlite: 3.38.2 -> 3.38.3
* [`d8891b53`](https://github.com/NixOS/nixpkgs/commit/d8891b5307f43b799a550910eca65bf85c3808e2) python310Packages.setuptools-rust: 1.2.0 -> 1.3.0
* [`2b71de4a`](https://github.com/NixOS/nixpkgs/commit/2b71de4a3dafbac8533469d5f1a5d7fb10758614) pipewire: 0.3.49 -> 0.3.50
* [`37c28808`](https://github.com/NixOS/nixpkgs/commit/37c288082b2108671d551e770f79f2f505fbdb07) pipewire: 0.3.50 -> 0.3.51
* [`04e104bc`](https://github.com/NixOS/nixpkgs/commit/04e104bc018a877dffcdcfac95710197a3d7586f) diffoscope: 210 -> 211
* [`b123419b`](https://github.com/NixOS/nixpkgs/commit/b123419b91b91afce08491861a6dd7069e2ba949) gpt-2-simple: init at 0.8.1
* [`de181bc8`](https://github.com/NixOS/nixpkgs/commit/de181bc8f17f1239772ba4555b7424e4497ae5d0) expat: 2.4.7 -> 2.4.8
* [`a14a3f1e`](https://github.com/NixOS/nixpkgs/commit/a14a3f1e3c66e93b9403d3fd9dd38b099e1574db) python3Packages.limits: enable tests
* [`22f5d327`](https://github.com/NixOS/nixpkgs/commit/22f5d327101dbf13c072761417f460ed413725e8) python39Packages.limits: 2.4.0 -> 2.6.1
* [`1c4be4e2`](https://github.com/NixOS/nixpkgs/commit/1c4be4e27174812a00531521adeb323a414d31ee) python310Packages.limits: remove extra requirements
* [`093a9536`](https://github.com/NixOS/nixpkgs/commit/093a95361bfc1b49823dc99444ddb285a57b2402) libsndfile: 1.0.31 -> 1.1.0
* [`4fefaa54`](https://github.com/NixOS/nixpkgs/commit/4fefaa54aeef6eec90ec58ebfbde99eb074680cb) odp-dpdk: 1.30.1.0_DPDK_19.11 -> 1.35.0.0_DPDK_19.11
* [`13ca8e47`](https://github.com/NixOS/nixpkgs/commit/13ca8e47f045bb54444aec6bc99205d62351d066) python3.pkgs.flask-compress: 1.11 -> 1.12
* [`b9a93b91`](https://github.com/NixOS/nixpkgs/commit/b9a93b91db0cb2a9ad3728bbdcf3e02797844b4a) gdbgui: 0.14.0.2 -> 0.15.0.1
* [`2047e6eb`](https://github.com/NixOS/nixpkgs/commit/2047e6eb7de7669d67ed5a234a2b89fd5da3b955) ghostscript: 9.55.0 -> 9.56.1
* [`5808d9ae`](https://github.com/NixOS/nixpkgs/commit/5808d9aeb801f0dd9581a992701bdf8f150c4c9f) qFlipper: 1.0.1 -> 1.0.2
* [`e19019fe`](https://github.com/NixOS/nixpkgs/commit/e19019fe327a7a9cd8539cfda2381bc2cc59ff75) pythonRelaxDepsHook: init
* [`6e954818`](https://github.com/NixOS/nixpkgs/commit/6e95481822edd16b900bc63416c06eaa98f32a53) archivy: use pythonRelaxDepsHook
* [`4ca1a5fd`](https://github.com/NixOS/nixpkgs/commit/4ca1a5fd256cb3ae44cae0d421926fa1a6155177) python3Packages.testtools: use pythonRelaxDepsHook
* [`29bd2460`](https://github.com/NixOS/nixpkgs/commit/29bd246024a12f79097e3988becd9a98ebe515a7) gitless: use pythonRelaxDepsHook
* [`073ee0e4`](https://github.com/NixOS/nixpkgs/commit/073ee0e4ab0b7d326a58d05fbe7dce8644ce4e6d) umlet: 14.3.0 -> 15.0.0
* [`b3613dd8`](https://github.com/NixOS/nixpkgs/commit/b3613dd8d79940947f649b88e54cda420c7399e1) gtkd: add possibility to use different D compilers
* [`b562fda5`](https://github.com/NixOS/nixpkgs/commit/b562fda57b7b6b97b98d39eaf0c9a776d9fd6a05) mpdris2: 0.8 -> 0.9.1
* [`8a00f0ca`](https://github.com/NixOS/nixpkgs/commit/8a00f0ca38b0c841f5d7a55bca4280bf0b46a96c) cdparanoiaIII: Cleanup
* [`79d9ef8a`](https://github.com/NixOS/nixpkgs/commit/79d9ef8a93be99bca1ee66eb53388e0cfbc3ea68) python3Packages.pycurl: pull fix for curl 7.83.0
* [`f24f2d04`](https://github.com/NixOS/nixpkgs/commit/f24f2d04ee2a4805e29e1071298cea37c11c287d) p2pool: 1.9 -> 2.0
* [`497d46b0`](https://github.com/NixOS/nixpkgs/commit/497d46b0125741a8be64dcf2d1fa340ebf5eba11) php.mkExtension: Format
* [`b2ae4d5a`](https://github.com/NixOS/nixpkgs/commit/b2ae4d5a0ed0578f3bed6424c0ba51fc9dd61a18) php.mkExtension: Run installPhase pre/post hooks
* [`03e31c53`](https://github.com/NixOS/nixpkgs/commit/03e31c533ce0bc568d2aebed5847934d7224c735) php.mkExtension: make source name agnostic
* [`9cdbd720`](https://github.com/NixOS/nixpkgs/commit/9cdbd72004edee9f6b7ed0181996c2104cafb48a) php.extensions.readline: Actually use readline
* [`52a2ace0`](https://github.com/NixOS/nixpkgs/commit/52a2ace065810fa36ae5d9c7b2e8608d1a8711fb) gmime3: 3.2.7 -> 3.2.11
* [`df9ffaf7`](https://github.com/NixOS/nixpkgs/commit/df9ffaf7761e0268c6b8f27044f935a896953dc7) notmuch: skip a test incompatible with newer gmime3
* [`4aa18d92`](https://github.com/NixOS/nixpkgs/commit/4aa18d9249777f24aee61690e6cf7aa1353b69d1) libarchive: disable cpio file-access-time related tests
* [`444e7670`](https://github.com/NixOS/nixpkgs/commit/444e767071083cbebfe6bd11ed33b9ba2ab8e63e) ryujinx: set makeWrapperArgs as an attribute
* [`4d461558`](https://github.com/NixOS/nixpkgs/commit/4d4615583541f1338165dcbc7cfedc66948c7bee) osu-lazer: set dotnetFlags as an attribute
* [`ec9f5dfd`](https://github.com/NixOS/nixpkgs/commit/ec9f5dfd31c1e42a9af1dabeedf0eccd9876e1b1) android-studio: add e2fsprogs dependency
* [`09046b11`](https://github.com/NixOS/nixpkgs/commit/09046b11ceda489ec0dd9751fb8ed2fdff7e380a) Remove whitespace
* [`0081b479`](https://github.com/NixOS/nixpkgs/commit/0081b479c4183c80cf80a28662210a2dd8affd46) gtkmm3: 3.24.5 -> 3.24.6
* [`e63b0f63`](https://github.com/NixOS/nixpkgs/commit/e63b0f634e9f38fe3290660fb37fb6833ed5cf9b) cvs2svn: add man pages
* [`578441d1`](https://github.com/NixOS/nixpkgs/commit/578441d11bb6edd4299ff3a723e31e17250fa477) cvs2svn: add self to maintainers
* [`a7be3b26`](https://github.com/NixOS/nixpkgs/commit/a7be3b2607fef40cb8a9a04ea4ee7753ad8a58e0) openssl_1_1: 1.1.1n -> 1.1.1o
* [`4eba1e11`](https://github.com/NixOS/nixpkgs/commit/4eba1e11bbb9598e2890cfc91283a872c9d367bb) xxe-pe: 9.4.0 -> 10.1.0
* [`207c4030`](https://github.com/NixOS/nixpkgs/commit/207c4030f52ccefe6908b4589b837300bd6debfe) libxml2: 2.9.13 -> 2.9.14
* [`689eed6c`](https://github.com/NixOS/nixpkgs/commit/689eed6ca6be0995d65cf012cf7a0b683ff76102) boundary: 0.7.6 -> 0.8.0
* [`de3945a3`](https://github.com/NixOS/nixpkgs/commit/de3945a340490484befc95f9dd9f9ba854f841d8) cdrkit: support cross compile
* [`194e05f8`](https://github.com/NixOS/nixpkgs/commit/194e05f8afdb268fb3d3618be7865d48b447fdd0) grpc: 1.45.2 -> 1.46.1
* [`3b358749`](https://github.com/NixOS/nixpkgs/commit/3b358749573d20ee196c76cba063542315e8cf94) python39Packages.grpcio-tools: 1.45.2 -> 1.46.1
* [`2a2302e7`](https://github.com/NixOS/nixpkgs/commit/2a2302e7b5f5d5aa60ec0f119b6b79cda631fdaa) python39Packages.grpcio-status: 1.45.2 -> 1.46.1
* [`2bd7ade9`](https://github.com/NixOS/nixpkgs/commit/2bd7ade9310421f06c1476ca852d1c72bf1dc414) python3Packages.matplotlib: 3.5.1 -> 3.5.2
* [`4953c6b5`](https://github.com/NixOS/nixpkgs/commit/4953c6b5e9d28e557457e22139d1c0b232b18b42) google-amber: 2020-09-23 -> 2022-04-21
* [`7c4e34a1`](https://github.com/NixOS/nixpkgs/commit/7c4e34a13bc902b61fb5c2a469baf0e6facd04b2) Re-revert "zimg: 3.0.3 -> 3.0.4"
* [`ca079e30`](https://github.com/NixOS/nixpkgs/commit/ca079e3074549256640126069dcc96a98cbbf3d8) phantomjs2: remove
* [`7b543f03`](https://github.com/NixOS/nixpkgs/commit/7b543f03b4b276280585a886901bd4338ebe599b) termius: 7.39.0 -> 7.40.2
* [`39b9cf31`](https://github.com/NixOS/nixpkgs/commit/39b9cf311be06e50ec79ae022a268acce2b00959) nixos/tests/installer: add bcachefs tests
* [`1b86e9c2`](https://github.com/NixOS/nixpkgs/commit/1b86e9c2086dd35845fb9dc7060fe4628204d46d) bcachefs-tools: add installer tests to passthru.tests
* [`9e24dd01`](https://github.com/NixOS/nixpkgs/commit/9e24dd0149c2a08f155ec486435b0f1779987101) codeblocks: fix builds
* [`2b85d34e`](https://github.com/NixOS/nixpkgs/commit/2b85d34e72e6bae23587acd3e8dcaa8009088cef) python310Packages.bitarray: 2.4.1 -> 2.5.0
* [`c071530c`](https://github.com/NixOS/nixpkgs/commit/c071530ca51013059cb8181d6a34e65fef9702a1) testers.invalidateFetcherByDrvHash: Move from top-level
* [`28f99aad`](https://github.com/NixOS/nixpkgs/commit/28f99aad3180b8da8db1bd2f8bbe98947de867c3) nixos/testing-python.nix: Set meta.mainProgram
* [`7edb4146`](https://github.com/NixOS/nixpkgs/commit/7edb41466086f8cd19fc738e8f9c46b7c64fe182) testers.nixosTest: Move from top-level and improve docs
* [`a52bf037`](https://github.com/NixOS/nixpkgs/commit/a52bf037d8f53684de1ebc9505d8940437e810bf) dpdk: 21.11 -> 22.03
* [`e8ffb6a7`](https://github.com/NixOS/nixpkgs/commit/e8ffb6a727081632781ac1051cf5b192f7cf5cd3) doc/testers: Mention nixosTests in nixosTest doc
* [`ec87e38d`](https://github.com/NixOS/nixpkgs/commit/ec87e38d65d4ea1fa7ab76c7efe70098e36769d0) Revert "gcc: 11.2.0 -> 11.3.0" for aarch64-darwin
* [`e6df8119`](https://github.com/NixOS/nixpkgs/commit/e6df811980c529f2ee5239a848f01709851c0a08) netdata: support cross compile
* [`b99b2783`](https://github.com/NixOS/nixpkgs/commit/b99b2783ec241b209a266091c0f3f07f9ffbb5fa) maintainers: add binsky
* [`57cd07f3`](https://github.com/NixOS/nixpkgs/commit/57cd07f3a9d27d1a63918fe21add060ecde4a29f) treewide: pkgs.systemd -> config.systemd.package
* [`c5e7eff5`](https://github.com/NixOS/nixpkgs/commit/c5e7eff560302b7bf047c5f2a5d4fa184c694fae) wlogout: support cross-compilation
* [`772502c3`](https://github.com/NixOS/nixpkgs/commit/772502c35843f8e8e7610dc63e1b7384f6f5072c) wlogout: disable gtk-layer-shell when cross-compiling
* [`4ff62d90`](https://github.com/NixOS/nixpkgs/commit/4ff62d90ac452024e8fe2c422e7c9f12438abdc4) wlogout: enable strictDeps
* [`cfe0566d`](https://github.com/NixOS/nixpkgs/commit/cfe0566da1f72deb59edb6c9d7ef044961787d68) mercurial: 6.1.1 -> 6.1.2
* [`251ab5f3`](https://github.com/NixOS/nixpkgs/commit/251ab5f3f61e2402833291d28ca6a19ec8839e2a) gnome: fix compilation with gcc 11.3.0
* [`657b6cec`](https://github.com/NixOS/nixpkgs/commit/657b6cecbc1c28b8cbf957edfa7d8d6d89694690) haskellPackages: stackage LTS 19.5 -> LTS 19.6
* [`0a8381fc`](https://github.com/NixOS/nixpkgs/commit/0a8381fc7c2a8faa8728f2835de4a90f1af4cb5b) all-cabal-hashes: 2022-05-01T06:09:30Z -> 2022-05-05T15:07:55Z
* [`c5145d9f`](https://github.com/NixOS/nixpkgs/commit/c5145d9f0dbbb3fa48b479902a4e3bd7ce49c771) haskellPackages: regenerate package set based on current config
* [`3babc11a`](https://github.com/NixOS/nixpkgs/commit/3babc11a0f764fbb8b129476b2d91f485db597ad) meshcentral: 0.9.98 -> 1.0.18
* [`976e6545`](https://github.com/NixOS/nixpkgs/commit/976e65456a25614b4823349be44c24658fce2dce) gcc11: downgrade to 11.2.0 also on x86_64-darwin
* [`7f74141d`](https://github.com/NixOS/nixpkgs/commit/7f74141d97b02e07efb5659762da45773d4cc639) python310Packages.aiobotocore: 2.2.0 -> 2.3.0
* [`4a34dfcb`](https://github.com/NixOS/nixpkgs/commit/4a34dfcbbc9fa1da2148cd2987e14fe73f73a4dc) Add bbenne10 as maintainer to nix-direnv
* [`89028367`](https://github.com/NixOS/nixpkgs/commit/8902836781fd98530e72369de594f8c4e6d40754) nix-direnv: 2.0.1 -> 2.1.0
* [`daace980`](https://github.com/NixOS/nixpkgs/commit/daace980f6936ca0d61452658c5af0994908d2ce) the-foundation: init at 1.4.0
* [`08d33e37`](https://github.com/NixOS/nixpkgs/commit/08d33e379bbe29328f70d46446f9e4ec55632280) sealcurses: init at unstable-2022-04-28
* [`c92b0c5c`](https://github.com/NixOS/nixpkgs/commit/c92b0c5c69aa07a208252847a54b83073a8b59cc) lagrange: 1.12.2 → 1.13.3
* [`4761e503`](https://github.com/NixOS/nixpkgs/commit/4761e5037253e22d47b389ebbb318d355db6bd80) pkgsStatic.perl: fix build
* [`42a4c05d`](https://github.com/NixOS/nixpkgs/commit/42a4c05dd092e379c57eefb174bb1a5fea90b92a) makeBinaryWrapper: add -Wno-overlength-strings
* [`69c7dbb8`](https://github.com/NixOS/nixpkgs/commit/69c7dbb88086b9bd5dce9c314779bed6ac6cb0a9) makeBinaryWrapper: add overlength-strings test
* [`d4aa6506`](https://github.com/NixOS/nixpkgs/commit/d4aa650608fdbf78a9697e272d88f5f6e809744b) makeBinaryWrapper: really unset NIX_CFLAGS
* [`2585fb02`](https://github.com/NixOS/nixpkgs/commit/2585fb0204067ee4fd2a56def8c30b4767215c5e) rubberband: 1.9.0 -> 2.0.2
* [`888c82fb`](https://github.com/NixOS/nixpkgs/commit/888c82fbba7cf3016943d577e91bc0a71ab136bc) Revert "gnome: fix compilation with gcc 11.3.0"
* [`36c879d1`](https://github.com/NixOS/nixpkgs/commit/36c879d18cb3f4e2f6dcdd5e7d646c69138187c1) python3Packages.pandoc-xnos: init at 2.5.0
* [`5466f393`](https://github.com/NixOS/nixpkgs/commit/5466f3931f5041b8cc91cf534c512a97fdaa9fb7) pandoc-eqnos: init at 2.5.0
* [`8fe47199`](https://github.com/NixOS/nixpkgs/commit/8fe47199cca2a83d72eb88101b06b4797bad3347) image_optim: fix wrapper arguments escaping
* [`545a1edd`](https://github.com/NixOS/nixpkgs/commit/545a1eddcdd13b10d6cb2cf391e4a4aff8bffc12) megapixels: fix wrapper arguments escaping
* [`b2a87aef`](https://github.com/NixOS/nixpkgs/commit/b2a87aef369037a69cf95b3c3a11a2047ce32775) chatty: fix wrapper arguments escaping
* [`48e5fbac`](https://github.com/NixOS/nixpkgs/commit/48e5fbac720e6606a6890841bc2c7b064771370f) tremc: fix wrapper arguments escaping
* [`5f3016cd`](https://github.com/NixOS/nixpkgs/commit/5f3016cde8820a383c048d616d971dac2442b31c) jameica: fix wrapper arguments escaping
* [`6d230e4e`](https://github.com/NixOS/nixpkgs/commit/6d230e4e0a09d4ef6954bc56c54a6408de7c0556) soapysdr: fix wrapper arguments escaping
* [`76f93323`](https://github.com/NixOS/nixpkgs/commit/76f93323f278fed174ba646018572040ed756110) qucs-s: fix wrapper arguments escaping
* [`0b941452`](https://github.com/NixOS/nixpkgs/commit/0b9414528838e42803d384816aa7913108ee1d13) vdr: fix wrapper arguments escaping
* [`ed63368d`](https://github.com/NixOS/nixpkgs/commit/ed63368dfe9db50dc42c6cd5c781aba72d8735ae) podman: fix wrapper arguments escaping
* [`2e563123`](https://github.com/NixOS/nixpkgs/commit/2e563123bf6ed58fa85626686a27208a9c96348d) pandoc-fignos: init at 2.4.0
* [`62511c6d`](https://github.com/NixOS/nixpkgs/commit/62511c6de31dd81c2ea07a4cd37e38cb6dee5b29) pandoc-secnos: init at 2.2.2
* [`0a6a3c0b`](https://github.com/NixOS/nixpkgs/commit/0a6a3c0b3375e4d3cdd58c20bc8650b361f81116) pandoc-tablenos: init at 2.3.0
* [`6e0f386a`](https://github.com/NixOS/nixpkgs/commit/6e0f386ae4e04d29db0c31c0e073bf434ae1d587) pythonPackages.limits: hack around versioneer non-reproducibility
* [`b45b15cd`](https://github.com/NixOS/nixpkgs/commit/b45b15cddd1fa636aaf61d58954f3b8981cd794c) metals: 0.11.4 → 0.11.5
* [`ab785b23`](https://github.com/NixOS/nixpkgs/commit/ab785b231b0cd0e83495b92299196c0313436c65) wine{Unstable,Staging}: 7.4 -> 7.5
* [`8752039f`](https://github.com/NixOS/nixpkgs/commit/8752039f03d5544b663403e8ae234fa72e05dd87) wine{Unstable,Staging}: 7.5 -> 7.6
* [`22b127cd`](https://github.com/NixOS/nixpkgs/commit/22b127cd4f8425a04e3715c8eb9031c768d9d007) winetricks: 20210825 -> 20220411
* [`131a5676`](https://github.com/NixOS/nixpkgs/commit/131a5676d10422194cb265062597f235f048792d) wine{Unstable,Staging}: 7.6 -> 7.7
* [`165a8a63`](https://github.com/NixOS/nixpkgs/commit/165a8a6315f2e7ef71352f470be8c60dae508a17) python310Packages.editorconfig: adopt, update homepage, fix checkInputs
* [`94c5433d`](https://github.com/NixOS/nixpkgs/commit/94c5433df267e68ab6c136f1fc742592b3f42714) wolfram-engine: fix wrappers
* [`4206661e`](https://github.com/NixOS/nixpkgs/commit/4206661e5d5273dbbd3f84448176e983fdc29f0f) firefox: Enable crash reporter by default.
* [`e6daff8e`](https://github.com/NixOS/nixpkgs/commit/e6daff8e0797ee0a44c6a55aeb2d3f57d428fd15) python310Packages.py3exiv2: 0.9.3 -> 0.11.0
* [`7e75b3f5`](https://github.com/NixOS/nixpkgs/commit/7e75b3f57113764bc19dc639d04f7dc02ce7f27d) python310Packages.genshi: 0.7.6 -> 0.7.7
* [`881d8649`](https://github.com/NixOS/nixpkgs/commit/881d8649427e0d6333a609a8b0cc9ec4f81d95ce) gnome.atomix: pull upstream fix for -fno-common toolchains
* [`2bebc577`](https://github.com/NixOS/nixpkgs/commit/2bebc577d88eaefeae686d7972d268af65a1051f) python3Packages.PyICU: 2.8.1 -> 2.9
* [`6ca420f7`](https://github.com/NixOS/nixpkgs/commit/6ca420f7970bc686cce3be5debbd4cf16cfb112d) haskellPackages.haskell-language-server: Disable plugin tests on all aarch64 builds
* [`416f2c1a`](https://github.com/NixOS/nixpkgs/commit/416f2c1af6357ad6092d2f2446e227217cad1ebd) wine{Unstable,Staging}: 7.7 -> 7.8
* [`b3e88559`](https://github.com/NixOS/nixpkgs/commit/b3e88559999d7d0332d3415594be1c30edbc0722) make-derivation: allow strings in build input lists
* [`037ec9ab`](https://github.com/NixOS/nixpkgs/commit/037ec9ab0d7fc633ce95660f2a33432d4398654e) musikcube: fix darwin build
* [`ea9be9e2`](https://github.com/NixOS/nixpkgs/commit/ea9be9e24ffdfc2f1cc3973fa784c899b872c0e8) powershell: 7.2.2 -> 7.2.3
* [`c34a8024`](https://github.com/NixOS/nixpkgs/commit/c34a8024bf5f8cae1becf105ad992482cc336e89) gcc12, gfortran12, gnat12: init at 12.1.0
* [`5b42ce1d`](https://github.com/NixOS/nixpkgs/commit/5b42ce1da780a024a8d78846ad1fa0ef408caa5d) imlib2: add explicit svg & heif support-disabling
* [`2032969f`](https://github.com/NixOS/nixpkgs/commit/2032969f0a8b63b3d80596c4ea69856027305709) Initial port of haven-cli
* [`1cf7a75d`](https://github.com/NixOS/nixpkgs/commit/1cf7a75d80118ef89a54718ab9f6218f8459da40) Fix warning about UPNP letter case
* [`80ca2744`](https://github.com/NixOS/nixpkgs/commit/80ca27442bbe9378efd75f537fafa38d38607d2c) python310Packages.py3exiv2: disable on older Python releases
* [`1f4de2c0`](https://github.com/NixOS/nixpkgs/commit/1f4de2c0c901aeb9e32f42995d729e7ff6b35658) python310Packages.py3exiv2: remove whitespace
* [`a0085798`](https://github.com/NixOS/nixpkgs/commit/a00857983edb1e0f4947e567903838047913dd36) Nit, remove trailing whitespace
* [`924ebf65`](https://github.com/NixOS/nixpkgs/commit/924ebf6556118f1ccbc83e5d19e90e5ebde8efb2) curl: add some key reverse-dependencies to passthru.tests
* [`4d2ea62d`](https://github.com/NixOS/nixpkgs/commit/4d2ea62d8211be13575d62c6d1aa3858bf5c90e1) lib/strings/toShellVars: handle derivations as strings
* [`fa020dce`](https://github.com/NixOS/nixpkgs/commit/fa020dce7f61996ef410a1a4b2fa819d8f2360ef) vorta: 0.8.3 -> 0.8.4
* [`863cdf8f`](https://github.com/NixOS/nixpkgs/commit/863cdf8f097c172ed92ccb689c6d52915c2858c3) wrapFirefox: handle binary wrappers
* [`850c9fea`](https://github.com/NixOS/nixpkgs/commit/850c9fea3e9e0f572f80e8eb1df2e325c21cf43d) cdparanoiaIII: Fix Darwin build after [nixos/nixpkgs⁠#171046](https://togithub.com/nixos/nixpkgs/issues/171046)
* [`0bafb3ba`](https://github.com/NixOS/nixpkgs/commit/0bafb3baa7f82797342b787c84e94d6aae70350f) firefox: support JACK and sndio audio backends
* [`6eab3568`](https://github.com/NixOS/nixpkgs/commit/6eab3568fad850e2bfc67264f5ed1077bc1b683d) fheroes2: 0.9.14 -> 0.9.15
* [`985494e6`](https://github.com/NixOS/nixpkgs/commit/985494e6e516ececbc9f3498cc8a547ba90e4b8f) laminar: split documentation into separate output
* [`c88d3ed4`](https://github.com/NixOS/nixpkgs/commit/c88d3ed4bfd21f4ca4820d9815b1ec55f14dd414) ledger: add patch to xdg support
* [`1d5f520d`](https://github.com/NixOS/nixpkgs/commit/1d5f520da8f01d147640e75b8c14ec3263bb7a42) ledger: install bash completion
* [`9d22c5a5`](https://github.com/NixOS/nixpkgs/commit/9d22c5a51a07463869c48dba88013b4bca62e9b7) ledger: add marsam to maintainers
* [`dfd3754f`](https://github.com/NixOS/nixpkgs/commit/dfd3754f612a2e563ada9eaa4554e451040939a1) libreoffice-still: 7.1.8.1 -> 7.2.6.2
* [`3f8c7838`](https://github.com/NixOS/nixpkgs/commit/3f8c7838ad8ab300b3dc0118b824c27894c725d7) python3Packages.zeroconf: 0.38.5 -> 0.38.6
* [`34724f22`](https://github.com/NixOS/nixpkgs/commit/34724f221eedda583e063154799531ea80fb0c3d) ubootQemuRiscv64Smode: Fix build with binutils 2.38
* [`6b6ac53c`](https://github.com/NixOS/nixpkgs/commit/6b6ac53ca52be99ee7e430f10c711fe3c599e3df) python310Packages.py3exiv2: disable tests
* [`fc2445eb`](https://github.com/NixOS/nixpkgs/commit/fc2445eb1068a15af1afe671a242b9d74e4fa335) python310Packages.pytelegrambotapi: 4.5.0 -> 4.5.1
* [`ae48e41a`](https://github.com/NixOS/nixpkgs/commit/ae48e41ad71f44589cab39c3736b38d663356d46) python310Packages.mysql-connector: 8.0.24 -> 8.0.29
* [`218a48c8`](https://github.com/NixOS/nixpkgs/commit/218a48c8491968735af9bb2cd87475206a6310e1) qemu: stabilize USB EHCI
* [`31b1d66b`](https://github.com/NixOS/nixpkgs/commit/31b1d66bfe0a88c424ac93437bc570c4ac99bc9a) powerdevil: drop ddcutil dependency
* [`de396a3c`](https://github.com/NixOS/nixpkgs/commit/de396a3c0a6f6b6c94c1fb188a476cb274b7d351) boost159: fix build on aarch64-darwin
* [`62e689da`](https://github.com/NixOS/nixpkgs/commit/62e689da1287eea56ec571e4d5baa619e401f341) libreoffice-still: apply review comments
* [`28942721`](https://github.com/NixOS/nixpkgs/commit/28942721a1c225278de7c2715c8a45fbfe8202d3) libreoffice-fresh: 7.2.5.2 -> 7.3.3.2
* [`ad48be73`](https://github.com/NixOS/nixpkgs/commit/ad48be73f575f494c8f695b6ff4592ae367857c4) gtkdialog: pull gentoo patch for -fno-common toolchains
* [`44c21a80`](https://github.com/NixOS/nixpkgs/commit/44c21a80ece6818cfed347da38501146ea286768) haskellPackages.cabal2nix-unstable: 2021-10-23 -> 2022-04-27
* [`db502a76`](https://github.com/NixOS/nixpkgs/commit/db502a76f01b10f889a2807dcccc1e2a893461ee) haskellPackages: regenerate package set based on current config
* [`e5ce505f`](https://github.com/NixOS/nixpkgs/commit/e5ce505f1a0a9e95662f3f1b292c6723bea7369f) bottles: 2022.5.2-trento -> 2022.5.2-trento-2
* [`ca428a06`](https://github.com/NixOS/nixpkgs/commit/ca428a0687d60753e23fc0033ef403d13d719444) lua53Packages.lmathx: init at 20150624-1
* [`0b13ca52`](https://github.com/NixOS/nixpkgs/commit/0b13ca520afd8e0877f164aaeabaa7ac0105e8bc) lua53Packages.lmpfrlib: init at 20170112-2
* [`4ff50cc1`](https://github.com/NixOS/nixpkgs/commit/4ff50cc175647afc2e2a5b651540881c40212c9e) rsyslog: 8.2202.0 -> 8.2204.1
* [`d753ffac`](https://github.com/NixOS/nixpkgs/commit/d753ffac205762e8d6a010ae1c01ef66788a8ad2) exoscale-cli: add man pages and completions
* [`0194fb5f`](https://github.com/NixOS/nixpkgs/commit/0194fb5f8497be28ac7b11fdf73cc718199f5ecf) zeroc-ice: mark broken
* [`19663984`](https://github.com/NixOS/nixpkgs/commit/1966398414a1e4fca5342e0ecb2e409dd4c84640) cargo-edit: 0.8.0 -> 0.9.0
* [`bbb9a73d`](https://github.com/NixOS/nixpkgs/commit/bbb9a73d62e71e1a4d6bca7c8426feedb6323f00) python310Packages.ldaptor: adopt, use twisted.extras-require.tls, mark broken
* [`098b5c19`](https://github.com/NixOS/nixpkgs/commit/098b5c191fb09efc3cc4b2e838b878b8261c9e40) python3Packages.pyrogram: 2.0.17 -> 2.0.19
* [`7215264e`](https://github.com/NixOS/nixpkgs/commit/7215264eb3e96d78c6cee677745c6c10e3fe44bb) feedreader: remove
* [`940c886a`](https://github.com/NixOS/nixpkgs/commit/940c886a0b4fa368d51b7a66f3f67e3243c54038) exoscale-cli: add self as maintainer
* [`defb2298`](https://github.com/NixOS/nixpkgs/commit/defb2298de66f6b32ec228a532dc6c8e34733b25) envoy: fix builds for x86_64-linux and aarch64-linux
* [`bf09f6c8`](https://github.com/NixOS/nixpkgs/commit/bf09f6c83afefd3c2dae00eeec0802644ceb7456) fortune: add an option to let user use offensive
* [`d5cdae6c`](https://github.com/NixOS/nixpkgs/commit/d5cdae6c5da043dbf5c58c2b5243cf3c7f7c3e50) fortune: 3.12.0 -> 3.14.0
* [`e1d1b600`](https://github.com/NixOS/nixpkgs/commit/e1d1b600ad0baf94d9aaed17d3e3be66ce4ef93f) python310Packages.txaio: remove unused dependency
* [`544626b1`](https://github.com/NixOS/nixpkgs/commit/544626b11b1bd11feb8bab214595de64a99baa20) python310Packages.zope_event: update homepage
* [`08187ac0`](https://github.com/NixOS/nixpkgs/commit/08187ac06087ef15a320662136f43be9c182a9fd) nongnu-packages 2022-05-08
* [`14dd58e2`](https://github.com/NixOS/nixpkgs/commit/14dd58e25add2c1a5d145c2bb809bc5ff397d22d) melpa-packages 2022-05-08
* [`e7977185`](https://github.com/NixOS/nixpkgs/commit/e79771850ae731c84433e53f86f9bd9eede838d2) elpa-packages 2022-05-08
* [`a7efe866`](https://github.com/NixOS/nixpkgs/commit/a7efe866345bbeb7f27ab7495176e1c557f8b32b) elpa-generated: manual fixup
* [`181dbcf0`](https://github.com/NixOS/nixpkgs/commit/181dbcf0f21b24eeb097960b6c95df8fb9200d17) python3Packages.pytube: 12.0.0 -> 12.1.0
* [`ae9a9ee9`](https://github.com/NixOS/nixpkgs/commit/ae9a9ee9419244c2ba13a8386d4e5844e665ca79) recutils: 1.8 -> 1.9
* [`88639cd7`](https://github.com/NixOS/nixpkgs/commit/88639cd7a93312cfb367e71f673a0fb97eed7ab8) python310Packages.peaqevcore: 0.0.22 -> 0.0.23
* [`2578b89c`](https://github.com/NixOS/nixpkgs/commit/2578b89c84b3cf0f18ea18a9766b0cf10048cb46) python310Packages.pymbolic: 2021.1 -> 2022.1
* [`c3191963`](https://github.com/NixOS/nixpkgs/commit/c31919630b8cd93297e607d13a453563dc67c1da) python310Packages.pycryptodome-test-vectors: 1.0.7 -> 1.0.8
* [`5a1209a1`](https://github.com/NixOS/nixpkgs/commit/5a1209a15aae2757a397916508695b3e05e677c5) boltbrowser: 2.0 -> 2.1
* [`fc060ca6`](https://github.com/NixOS/nixpkgs/commit/fc060ca64781731c7c1cefdee436d1101ae94fdd) chatty: 0.6.3 -> 0.6.4
* [`bb0210e3`](https://github.com/NixOS/nixpkgs/commit/bb0210e327fb5e7023aefb886f8eb7aa153078fb) ena: 2.5.0 -> 2.7.1
* [`35cfe2c2`](https://github.com/NixOS/nixpkgs/commit/35cfe2c29c96d93b4430c59983361c61aaf002ae) nixos/amazon-image: default to 5.15 kernel
* [`be012719`](https://github.com/NixOS/nixpkgs/commit/be0127196301eb6dd388ac2ae61bf47cfa007831) syncthing: 1.19.2 -> 1.20.1
* [`f42f88bd`](https://github.com/NixOS/nixpkgs/commit/f42f88bd15d540a6c46fbdf0cee1994e0e252a9b) rnote: 0.5.0-hotfix-2 -> 0.5.1-hotfix-1
* [`0e8ede9c`](https://github.com/NixOS/nixpkgs/commit/0e8ede9cc4a3660dd23f6c58a2f549b9e3cda118) g15daemon: add -fcommon workaround
* [`b5d30ae3`](https://github.com/NixOS/nixpkgs/commit/b5d30ae3a37ebd1a19afa241b052e0af3748eedc) bazel_0, bazel_0_26, bazel_0_29, bazel_1: remove
* [`cbfb0da7`](https://github.com/NixOS/nixpkgs/commit/cbfb0da7a26bc6ce6e63b262ce5f7949682478cc) python3Packages.httpcore: specify extras-require
* [`1724a34a`](https://github.com/NixOS/nixpkgs/commit/1724a34a0d32a8af8400f46d9254776035636df7) python3Packages.httpx: specify extras-require
* [`a664572f`](https://github.com/NixOS/nixpkgs/commit/a664572fa654fdd4b7a7e39c8c79cc164a93139c) wapiti: update propagatedBuildInputs
* [`e4eba471`](https://github.com/NixOS/nixpkgs/commit/e4eba471d19d2366a17cf36dd96a0e33a2b34807) python3Packages.httpx-socks: specify extras-require
* [`ca767e5e`](https://github.com/NixOS/nixpkgs/commit/ca767e5ea8c59b74a9d19934e54f5691c72a96e0) ntfy-sh: 1.21.2 -> 1.22.0
* [`6c60d3d3`](https://github.com/NixOS/nixpkgs/commit/6c60d3d38ac1512df424ea474dc9e71373b2fe80) gqview: add -fcommon workaround
* [`f4fc992f`](https://github.com/NixOS/nixpkgs/commit/f4fc992f1f8f104660d4204ddb181f0b845ee970) transmission-gtk: fixup build on darwin
* [`a7be18ee`](https://github.com/NixOS/nixpkgs/commit/a7be18ee8528414a7af01674401a173453d0f972) python310Packages.PyChromecast: 12.1.1 -> 12.1.2
* [`3459c405`](https://github.com/NixOS/nixpkgs/commit/3459c4053d0e3e44be463e7dabe03679717ffd78) python310Packages.simplisafe-python: 2022.05.0 -> 2022.05.1
* [`865d79bb`](https://github.com/NixOS/nixpkgs/commit/865d79bb5b5fc04b32222c6029f83e91d64951b5) elmerfem: make elmerfem-9.0 properly
* [`199933ef`](https://github.com/NixOS/nixpkgs/commit/199933efdf5945792f149253256e983f0643cddb) nixos/mandoc: Leave shell argument quoting to nix
* [`4b2e0fe9`](https://github.com/NixOS/nixpkgs/commit/4b2e0fe978cccdc9f6d7f3dc301b8e6c0a1904c2) python310Packages.approvaltests: 5.0.1 -> 5.0.2
* [`0d763720`](https://github.com/NixOS/nixpkgs/commit/0d7637203e9be03281115e1cbabf3884ad33d0ac) libressl: remove weird and old man compression workaround
* [`99bfa8b9`](https://github.com/NixOS/nixpkgs/commit/99bfa8b949565e4f0863e25ed5542e6985c6d0d4) rcshist: init at 1.04
* [`3a71e04f`](https://github.com/NixOS/nixpkgs/commit/3a71e04f36c500df36a1a7374dec9cfd50c27f11) Update pkgs/applications/version-management/rcshist/default.nix
* [`4839ffca`](https://github.com/NixOS/nixpkgs/commit/4839ffca1ff6acfd62fbc83bd0fba94b1b9865da) refind: 0.13.2 -> 0.13.3.1
* [`fa78bd44`](https://github.com/NixOS/nixpkgs/commit/fa78bd440e338cfc2fd54d2e499760ceadf597f8) uxplay: 1.50 -> 1.52
* [`440710cb`](https://github.com/NixOS/nixpkgs/commit/440710cb693b51e7ca76d434d44f6a74b6516d27) haskellPackages.git-annex: update hash
* [`305aabda`](https://github.com/NixOS/nixpkgs/commit/305aabda40e65a8df61c409dae4a61b59e0c4fd7) python310Packages.txaio: remove unused input
* [`f1d34a1a`](https://github.com/NixOS/nixpkgs/commit/f1d34a1a0114ded13721fc327b2b831f4e97cbed) libgtkflow: init at 0.8.0
* [`abf015d9`](https://github.com/NixOS/nixpkgs/commit/abf015d99a5a1878c8287ee005b105cd4b735462) shelf: init at 2.1.1 ([nixos/nixpkgs⁠#154748](https://togithub.com/nixos/nixpkgs/issues/154748))
* [`cb8084f1`](https://github.com/NixOS/nixpkgs/commit/cb8084f11415ef75d824c06b5477289ddfeaefe3) unpackerr: 0.9.9 -> 0.10.0
* [`7fe4f29d`](https://github.com/NixOS/nixpkgs/commit/7fe4f29d680475303a41b71f261eef0ec6fff717) swaylock-effects: 1.6-3 -> unstable-2021-10-21
* [`67d8bc33`](https://github.com/NixOS/nixpkgs/commit/67d8bc339feb6ca29d8213f593f0ad2bac3b90a0) python3.pkgs.moku: init at 2.3
* [`2381aa28`](https://github.com/NixOS/nixpkgs/commit/2381aa28fd1ff0641805b3b8fcc8031a42e2c4e5) scorecard: 4.1.0 -> 4.2.0
* [`ce9122d1`](https://github.com/NixOS/nixpkgs/commit/ce9122d1e824b91ced170b6629202527f51411de) pressureaudio: remove autoreconfHook to fix build for ZHF
* [`4a3ed385`](https://github.com/NixOS/nixpkgs/commit/4a3ed385520d47d29b285344a4786711052000a7) driftctl: 0.28.1 -> 0.29.0
* [`75c90fc7`](https://github.com/NixOS/nixpkgs/commit/75c90fc796f77df28aee12ee612145b07f2f6a5a) python3Packages.falcon: exclude tests
* [`88090385`](https://github.com/NixOS/nixpkgs/commit/8809038568aad423f39156735c222dc7a4dd51a9) conftest: 0.31.0 -> 0.32.0
* [`93cb8037`](https://github.com/NixOS/nixpkgs/commit/93cb80377cd1bc7c55bb91edd69d4f44639d8a84) python310Packages.pymbolic: enable tests
* [`85e59afc`](https://github.com/NixOS/nixpkgs/commit/85e59afc49fc172b60d3320a4a2a9d4f6b5a2919) snazy: 0.4.0 -> 0.9.0
* [`293f3d8e`](https://github.com/NixOS/nixpkgs/commit/293f3d8ec5db5ceda882a71a959ec79194e6b588) python310Packages.argon2-cffi: normalise pname
* [`03ebf37b`](https://github.com/NixOS/nixpkgs/commit/03ebf37be754073601817f78993c178275546013) python310Packages.autobahn: adopt, populate passthru.extras-require
* [`281ebacf`](https://github.com/NixOS/nixpkgs/commit/281ebacfa99e4405af050281d67f8e1da5a3dbee) python310Packages.magic-wormhole-mailbox-server: adopt, fix requirements, run tests with trial
* [`64c7e7e3`](https://github.com/NixOS/nixpkgs/commit/64c7e7e3c59b6ac7e8b26283e9f3e5d9b98b72f1) python310Packages.magic-wormhole-transit-relay: adopt, fix dependencies, run tests with trial
* [`9d976822`](https://github.com/NixOS/nixpkgs/commit/9d976822edfe7935848da53a9d915fac434f1975) python310Packages.magic-wormhole: adopt, fix dependencies, run tests with trial
* [`17b7390b`](https://github.com/NixOS/nixpkgs/commit/17b7390be987fe6e234bcb0a1afc64eaa4bafffb) konstraint: 0.19.0 -> 0.19.1
* [`74542384`](https://github.com/NixOS/nixpkgs/commit/745423848b444fc6dfba67a5189285ef7dbc702e) psensor: add -Wno-error due to increasing compiler strictness
* [`dcb178bf`](https://github.com/NixOS/nixpkgs/commit/dcb178bff97a36d405662b358424e8e4ea02ed6a) whalebird: 4.5.2 -> 4.5.4
* [`ae172a2b`](https://github.com/NixOS/nixpkgs/commit/ae172a2bb4c94da68fb0adfd77d5aacd71c8b930) treewide: nixosTest -> testers.nixosTest
* [`93abb7be`](https://github.com/NixOS/nixpkgs/commit/93abb7bef7a73f0c5fa0453d60c024ca7464f1c5) tests.testers.nixosTest-example: move from tests.nixos-functions.nixosTest-test
* [`b7c84005`](https://github.com/NixOS/nixpkgs/commit/b7c8400546f18686446d825de43feb182e1d22d3) gbl: darwin support
* [`fb3d0256`](https://github.com/NixOS/nixpkgs/commit/fb3d02563a31396dee1b3ada8e610ab3557cee81) crossplane: init at 0.5.7
* [`5f67086a`](https://github.com/NixOS/nixpkgs/commit/5f67086a8a5a8177997eeedc8f08609433961825) python310Packages.exchangelib: 4.7.2 -> 4.7.3
* [`a5e2f0f4`](https://github.com/NixOS/nixpkgs/commit/a5e2f0f4106d623762e07f128805e116e3ba4761) siesta: fix build for gcc/gfortran-10/11
* [`c3bbe1d9`](https://github.com/NixOS/nixpkgs/commit/c3bbe1d9c716936cd446233b41206f461514c526) testers.nixosTest: Remove redundant system.stateVersion = lib.trivial.release;
* [`c5468253`](https://github.com/NixOS/nixpkgs/commit/c54682539bf67ffe4c2bc299d2fb451a335ed70c) os-specific/linux/vmm_clock: mark kernels older than 4.19 as broken
* [`0fc95f66`](https://github.com/NixOS/nixpkgs/commit/0fc95f66fa3a506b9f7ff84eb5b68121cf1aefe5) pcb2gcode: cherry-pick patch from upstream to fix build
* [`d46665e8`](https://github.com/NixOS/nixpkgs/commit/d46665e879a51c307759a776f5ca464985c3197f) ISSUE_TEMPLATE/build_failure.md: create
* [`80cc05f2`](https://github.com/NixOS/nixpkgs/commit/80cc05f26c83ad78945108832f88790e4d23c0ec) alfaview: 8.43.0 -> 8.44.0
* [`52310fb5`](https://github.com/NixOS/nixpkgs/commit/52310fb50cc308d60fd64762bed78fb987b09b9c) thedesk: update electron
* [`0f822a76`](https://github.com/NixOS/nixpkgs/commit/0f822a767f59841bfd1e7ce823830a7af48bd4cc) vial: 0.5 -> 0.5.2
* [`2ba55cd4`](https://github.com/NixOS/nixpkgs/commit/2ba55cd49bc58322db2c6286bfc3135bd2c64a5e) python310Packages.pyskyqremote: 0.3.6 -> 0.3.7
* [`cd75ecd1`](https://github.com/NixOS/nixpkgs/commit/cd75ecd1b7ba4215cae6a0655fa33cf765ee969d) python3Packages.proton-client: change platform to linux
* [`29d3bfce`](https://github.com/NixOS/nixpkgs/commit/29d3bfce16f74ae129a0b4fcf3c2aa2a9a4848b9) python3Packages.protonvpn-nm-lib: change platform to linux
* [`49f66f6d`](https://github.com/NixOS/nixpkgs/commit/49f66f6da8b6982de61c7c48227092c6b29873f3) cargo-feature: 0.6.0 -> 0.7.0
* [`3592c25f`](https://github.com/NixOS/nixpkgs/commit/3592c25fb2917f1946ead3e0391960eccbc7ffef) terragrunt: 0.36.6 -> 0.36.10
* [`e87b171b`](https://github.com/NixOS/nixpkgs/commit/e87b171be6ed6a5e7d9bb31137993e48a0c6a8f7) firejail: Fix opengl support for various apps
* [`ac564365`](https://github.com/NixOS/nixpkgs/commit/ac564365d4e0138712c3eed96b4251b4716e73af) emulationstation: pin boost 1.69
* [`04ba6470`](https://github.com/NixOS/nixpkgs/commit/04ba6470497fcce936f968b7e77c4387a420fe02) communicator: init at 2.1.1
* [`2d1af85d`](https://github.com/NixOS/nixpkgs/commit/2d1af85d4733b886986f8585baa1daf845104a7d) mauikit-nota: init at 2.1.1
* [`cdea50b3`](https://github.com/NixOS/nixpkgs/commit/cdea50b39d7b989f6cce09be65a7be39a32796e2) cue: 0.4.2 -> 0.4.3
* [`a0e539ac`](https://github.com/NixOS/nixpkgs/commit/a0e539ac408b9509723f930151fc900e5b0463ce) vvave: init at 2.1.1
* [`1905c075`](https://github.com/NixOS/nixpkgs/commit/1905c075b014add9485aefb808dcebd362a07d16) raven-reader: init at 1.0.72
* [`9bd212ea`](https://github.com/NixOS/nixpkgs/commit/9bd212eaf0e11b9802dd2e7bea41152cd1d985a0) haskellPackages: update note about dhall in stackage
* [`fcf3fb06`](https://github.com/NixOS/nixpkgs/commit/fcf3fb06ac364d2b9f9d3da498a0171a342dea3b) xvkbd: 3.9 -> 4.1
* [`7f5d5228`](https://github.com/NixOS/nixpkgs/commit/7f5d5228a9f4db3cf58a99858868fce5443878f4) python3Packages.sjcl: init at 0.2.1
* [`3b58c57a`](https://github.com/NixOS/nixpkgs/commit/3b58c57aab6706a902aa048572ff870fe498bf55) gotify-server: 2.1.0 -> 2.1.4 ([nixos/nixpkgs⁠#168910](https://togithub.com/nixos/nixpkgs/issues/168910))
* [`56481a2e`](https://github.com/NixOS/nixpkgs/commit/56481a2ecc842ad2d1915381d9684f33ff74d477) srain: 1.3.2 -> 1.4.0
* [`11a19355`](https://github.com/NixOS/nixpkgs/commit/11a19355818986004fc0496715cb9600863ee7e7) supercollider: fix build with libsndfile >=1.1.0
* [`5fdc74a2`](https://github.com/NixOS/nixpkgs/commit/5fdc74a2ac093c214bfba43c4fb70c3f9951d4e4) roxctl: init at 3.69.1 ([nixos/nixpkgs⁠#168512](https://togithub.com/nixos/nixpkgs/issues/168512))
* [`d346c957`](https://github.com/NixOS/nixpkgs/commit/d346c95784d9f249e9c56478c24dc7cec3dc3798) exaile: add python3 to PATH ([nixos/nixpkgs⁠#169494](https://togithub.com/nixos/nixpkgs/issues/169494))
* [`6592d3fb`](https://github.com/NixOS/nixpkgs/commit/6592d3fbc73c1be639ea2c488204276524f2ab1b) skawarePackages.buildPackage: fix typo in comment
* [`efe6bef3`](https://github.com/NixOS/nixpkgs/commit/efe6bef3b63a58112c0fe3152edb4933ca5d78d9) gnome-inform7: fix cross eval
* [`3fd5f638`](https://github.com/NixOS/nixpkgs/commit/3fd5f63834b67e27c9a16a3a7c8239f21bcd6055) font-awesome: 5.15.3 -> 6.1.1
* [`c19b1b15`](https://github.com/NixOS/nixpkgs/commit/c19b1b15bc65d2e1f16ad1c27051260351520e7e) python3Packages.uharfbuzz: mark as broken on darwin
* [`27424231`](https://github.com/NixOS/nixpkgs/commit/27424231b35c6b0b040afd6e2caf00d7a8887b36) teamviewer: 15.26.4 -> 15.29.4
* [`89412f83`](https://github.com/NixOS/nixpkgs/commit/89412f830e0855fa56ae8d409991b79cbd6b5f73) nuclei: 2.6.9 -> 2.7.0
* [`bff1539d`](https://github.com/NixOS/nixpkgs/commit/bff1539d6308493d959497d3a47373cd4a0ea80b) thiefmd: 0.2.4 -> 0.2.5-stability
* [`c36d585e`](https://github.com/NixOS/nixpkgs/commit/c36d585e14b84f3f046a45b5a36949aa33393f1f) ares: 126 -> 127
* [`145de7cd`](https://github.com/NixOS/nixpkgs/commit/145de7cdc8d8be8ebf9ee31dc8a25300cc7edc23) shellhub-agent: 0.9.1 -> 0.9.2
* [`43cbc7f7`](https://github.com/NixOS/nixpkgs/commit/43cbc7f79f3ab4b76ba615f5fb7dcce00a3d7973) python3Packages.skytemple-files: mark broken on darwin
* [`82720018`](https://github.com/NixOS/nixpkgs/commit/8272001820315b42eb12895f6049c9fa8fbe2770) dosfstools: fix build failure in darwin
* [`d0ecc348`](https://github.com/NixOS/nixpkgs/commit/d0ecc348fbfe4092ce5683cf823c8661019d1c23) cargo-geiger: fix darwin build failures
* [`9ca7db22`](https://github.com/NixOS/nixpkgs/commit/9ca7db22af02d7f80b81318a11a66a881c3d1176) polkadot: 0.9.18 -> 0.9.21
* [`1bd0b4de`](https://github.com/NixOS/nixpkgs/commit/1bd0b4de1f410c2cf09c6027a7db0ac43734184a) goku: fix download url
* [`e93ca388`](https://github.com/NixOS/nixpkgs/commit/e93ca388e81df9a9b9ca5e8b8aedd9909b8eecb0) matrix-recorder: use node14
* [`c073a45c`](https://github.com/NixOS/nixpkgs/commit/c073a45cfa7238efc640a307b8ae3a5678f3a197) python310Packages.elkm1-lib: 1.3.6 -> 2.0.0
* [`136f52d8`](https://github.com/NixOS/nixpkgs/commit/136f52d8969a9369b40549906707da1418753382) python310Packages.meilisearch: 0.18.2 -> 0.18.3
* [`a6c0d101`](https://github.com/NixOS/nixpkgs/commit/a6c0d101679f0344f4284b2d64cfea9c9bfa1daf) python310Packages.nettigo-air-monitor: 1.2.3 -> 1.2.4
* [`6370469c`](https://github.com/NixOS/nixpkgs/commit/6370469cc9495e1efbd32e457992107f33e692e7) python310Packages.scmrepo: 0.0.20 -> 0.0.22
* [`4fc66585`](https://github.com/NixOS/nixpkgs/commit/4fc665856d5a6be6f647fd9d63d9390f48763192) nim: 1.6.4 -> 1.6.6
* [`52a78362`](https://github.com/NixOS/nixpkgs/commit/52a78362ac76d96644ea0057a8544e14ee6667a0) zkar: init at 1.3.0
* [`6f1bb49e`](https://github.com/NixOS/nixpkgs/commit/6f1bb49e5a42ac6154d2a5a0597b8b9a7011a2b6) secp256k1: allow to build on all platforms
* [`470c724f`](https://github.com/NixOS/nixpkgs/commit/470c724f83fa850a1588b89926df86d6f4a0b10f) fwbuilder: add wayland support
* [`2e882e09`](https://github.com/NixOS/nixpkgs/commit/2e882e09033b481a8f4531c30cfab7fc855c3909) hydra-unstable: 2021-08-11 -> 2021-12-17
* [`3c34e350`](https://github.com/NixOS/nixpkgs/commit/3c34e350c930fc1e164627d5ca8daa4dd9f2451a) perlPackages.UUID4Tiny: init at 0.002
* [`cec7fc48`](https://github.com/NixOS/nixpkgs/commit/cec7fc48bb7e7a944fc00ba100018cc1237f6f83) hydra-unstable: 2021-12-17 -> 2022-02-07
* [`a07cc041`](https://github.com/NixOS/nixpkgs/commit/a07cc041090da87693501b86cf8e5bf3529e8ed9) hydra: don't force HYDRA_RELEASE
* [`25cf5ebc`](https://github.com/NixOS/nixpkgs/commit/25cf5ebcd09b155219b11fccff44bd34a61dfb77) teleport: 8.1.3 -> 9.1.2
* [`e3a4076f`](https://github.com/NixOS/nixpkgs/commit/e3a4076faadb2476710f7712e7ad3579f4056441) teleport: add rdpclient
* [`6b8d9125`](https://github.com/NixOS/nixpkgs/commit/6b8d91253d3b921fbdba840af1835d7183f6d7d9) melt: 0.3.0 -> 0.4.0
* [`3ece875b`](https://github.com/NixOS/nixpkgs/commit/3ece875b6007e383428aea745429f3ef8cbe3fff) recutils: disable Clang "format" hardening
* [`12cc1370`](https://github.com/NixOS/nixpkgs/commit/12cc1370a201f8077908c7c6f2598beb8b4bd62e) Revert "glib: remove build references from cross compiles"
* [`3141204b`](https://github.com/NixOS/nixpkgs/commit/3141204b2261ceb8807b7b82dfebe68bf7df3de6) nbench: supply stdenv.glibc.static since Makefile uses -static ([nixos/nixpkgs⁠#172173](https://togithub.com/nixos/nixpkgs/issues/172173))
* [`b86571f4`](https://github.com/NixOS/nixpkgs/commit/b86571f4f550418641efb2cf374595cc96e81b3c) freeradius: remove useless null asserts
* [`0fc6a60e`](https://github.com/NixOS/nixpkgs/commit/0fc6a60ecc20d72d218465831f2882544881d71c) flyctl: fix ldflags date parsing
* [`973a0ee2`](https://github.com/NixOS/nixpkgs/commit/973a0ee2a3cb8c4e0969c98b7cf35d622e7fa729) tachyon: remove nulls
* [`ecc2b14f`](https://github.com/NixOS/nixpkgs/commit/ecc2b14fbc72354b8af3fdfa8359907a2742e49e) libwebp: remove useless nulls
* [`abbb726a`](https://github.com/NixOS/nixpkgs/commit/abbb726a8a4745d7965a9c65325a71c53f427009) lame: remove useless nulls
* [`4bc8d425`](https://github.com/NixOS/nixpkgs/commit/4bc8d425f2c8b1d537293e10e2e8bd9713d9d616) imlib2: add some key reverse-dependencies to passthru.tests
* [`977f14fa`](https://github.com/NixOS/nixpkgs/commit/977f14fab1227bea9f7272cbbbba9f563d102f7a) re2c: add some key reverse dependencies to passthru.tests
* [`33ca5b98`](https://github.com/NixOS/nixpkgs/commit/33ca5b98b4ab4966b1a2923f0fc0a03e2980d6a8) pprof: unstable-2021-09-30 -> unstable-2022-05-09
* [`ed649982`](https://github.com/NixOS/nixpkgs/commit/ed6499826a7f401c536ae6262c52fc636a4f3851) python3Packages.nbclient: 0.6.2 -> 0.6.3
* [`8e3e02b0`](https://github.com/NixOS/nixpkgs/commit/8e3e02b0155ea783ecd2242d3b666e16cb9c1d4e) nghttp2: remove useless nulls and make python3 support build
* [`3c2f3dff`](https://github.com/NixOS/nixpkgs/commit/3c2f3dff8d1c3c9825223496c119479b04011ce9) gloox: remove useless nulls
* [`fe7a2600`](https://github.com/NixOS/nixpkgs/commit/fe7a2600ac35c463b303e3e8c312d704e5ec0ae0) aravis: remove useless nulls
* [`25cdf9bd`](https://github.com/NixOS/nixpkgs/commit/25cdf9bd9eff816a52f97121ffd954f1699bf5f7) libbluray: remove useless nulls
* [`14a95907`](https://github.com/NixOS/nixpkgs/commit/14a95907514a0114fe4c102663a62a320c49108c) deadbeef: remove useless nulls
* [`bab661ab`](https://github.com/NixOS/nixpkgs/commit/bab661ab2b738f9863794220b1f4c2d0166b4be4) profanity: remove useless nulls
* [`5007ea28`](https://github.com/NixOS/nixpkgs/commit/5007ea281de467b1bd95ba7d18cc6088fd8d61e7) gwyddion: remove useless nulls
* [`c07b5cd4`](https://github.com/NixOS/nixpkgs/commit/c07b5cd424651726914877a528f2d8b39dd036fc) mplayer: remove useless nulls
* [`8b10b6b0`](https://github.com/NixOS/nixpkgs/commit/8b10b6b0f5f80915bf8a32aea8536aa8cf089b08) itpp: fix build
* [`49b62442`](https://github.com/NixOS/nixpkgs/commit/49b62442e9222e71bee268d034fce0d67829330f) image_optim: remove useless nulls
* [`51d859cd`](https://github.com/NixOS/nixpkgs/commit/51d859cdab1ef58755bd342d45352fc607f5e59b) gotify-desktop: mark as broken for darwin
* [`d4884bbc`](https://github.com/NixOS/nixpkgs/commit/d4884bbc9ea8ac85b68a05d1c12e1ea1181db3b0) php.extensions: Remove fixes for abandoned PHP versions
* [`8ed605d6`](https://github.com/NixOS/nixpkgs/commit/8ed605d66d8dc051405a44fc0882e69b8ffae391) python3Packages.pydeck: fix build ([nixos/nixpkgs⁠#172055](https://togithub.com/nixos/nixpkgs/issues/172055))
* [`7be4accb`](https://github.com/NixOS/nixpkgs/commit/7be4accb667a31a90247e84f5db38b066366f9a6) python310Packages.aioamqp: 0.14.0 -> 0.15.0
* [`b4c6e5f3`](https://github.com/NixOS/nixpkgs/commit/b4c6e5f34573c22f6eff3fb21c3fdf25a60a1868) php: Remove fixes for abandoned PHP versions
* [`053c592c`](https://github.com/NixOS/nixpkgs/commit/053c592cf204627172540d8c2dd4cf11e770ae27) python310Packages.http-sfv: 0.9.5 -> 0.9.6
* [`faf72ce7`](https://github.com/NixOS/nixpkgs/commit/faf72ce7041e347863763f55272a4da537972be9) python3Packages.prox-tv: ignore known MacOS failure
* [`20eabe33`](https://github.com/NixOS/nixpkgs/commit/20eabe33864104ad9928450e5927ab7835f8f9e8) vtk_9: Fix build
* [`3c296bf7`](https://github.com/NixOS/nixpkgs/commit/3c296bf709e20a73c00b41fd41a680752a3d7698) python310Packages.ecos: 2.0.8 -> 2.0.10
* [`ae40cc00`](https://github.com/NixOS/nixpkgs/commit/ae40cc00325b365b8749a06dd3af5f4f95ff9696) python3Packages.slicer: disable failing tests
* [`7565c2e4`](https://github.com/NixOS/nixpkgs/commit/7565c2e455709e4c4cf78c2bcc81e6ce012c8cc1) apngasm: 3.1.9 -> 3.1.10
* [`a18a0fa2`](https://github.com/NixOS/nixpkgs/commit/a18a0fa29d69ef50f5cfdecda9f7f942aca2ba67) python3Packages.pysabnzbd: init at 1.1.1
* [`33892e97`](https://github.com/NixOS/nixpkgs/commit/33892e97554a4af39dde7f7243468f01c3809219) home-assistant: support sabnzbd component
* [`c9078c52`](https://github.com/NixOS/nixpkgs/commit/c9078c523604f97795a95df979be33a17452fe87) asc: force use of C++11 during build
* [`39688e7f`](https://github.com/NixOS/nixpkgs/commit/39688e7fec0670d6d4fb266ba8c4aee405b2aea1) python3Packages.datapoint: init at 0.9.8
* [`705acec5`](https://github.com/NixOS/nixpkgs/commit/705acec552eb83238e381aee71ac7071ba5ab6b3) home-assistant: support metoffice component
* [`66d86c7f`](https://github.com/NixOS/nixpkgs/commit/66d86c7f3e8c479eea12a5963dbe609c39becf30) cudatext: 1.163.0 -> 1.164.0
* [`a0d4618e`](https://github.com/NixOS/nixpkgs/commit/a0d4618e7f0ad07c308086b627dddcb9cd91f5ad) buildCrystalPackage: enable strictDeps
* [`c609c50a`](https://github.com/NixOS/nixpkgs/commit/c609c50a787fa20e61569b9b352afdc48d88a130) oq: fix strictDeps build
* [`5e3b4a6e`](https://github.com/NixOS/nixpkgs/commit/5e3b4a6eaf83dfb8f4179d1571d6bef72c295372) crystal: enable strictDeps
* [`4d5ac2f6`](https://github.com/NixOS/nixpkgs/commit/4d5ac2f67479fd6b61d08e93bf2f9ea54bc7bc7c) portaudio2014: remove
* [`fb7287e6`](https://github.com/NixOS/nixpkgs/commit/fb7287e6d2d2684520f756639846ee07f6287caa) openmw: enable with glibc fix
* [`f44cf991`](https://github.com/NixOS/nixpkgs/commit/f44cf991c715425e1db6f544a5eec11cc73a1b2a) terraform-providers.cloudamqp: init at 1.15.3
* [`430f6d45`](https://github.com/NixOS/nixpkgs/commit/430f6d45e3487fe745c7774f72f02aa129fcabef) skopeo: 1.7.0 -> 1.8.0
* [`8f91fe6f`](https://github.com/NixOS/nixpkgs/commit/8f91fe6f8260f3236baf785fd01db0b7afe04efa) aws-sam-cli: fix build error due jmespath version
* [`0be721b1`](https://github.com/NixOS/nixpkgs/commit/0be721b12930887fd883260ddb29c80225eaa9f3) terraform-providers: update 2022-05-09
* [`ced69442`](https://github.com/NixOS/nixpkgs/commit/ced69442bca98f4d61189d61d5be13aeedcdaccb) mepo: 0.4.1 -> 0.4.2
* [`9a4ea414`](https://github.com/NixOS/nixpkgs/commit/9a4ea4146e31d172f51591840f7927ccc32dc75f) python3Packages.ipwhl: 1.0.0 -> 1.1.0
* [`d620787d`](https://github.com/NixOS/nixpkgs/commit/d620787dd78e5d3aa612cdb8adbc472dd941a764) fltk: support cross-compilation
* [`06841666`](https://github.com/NixOS/nixpkgs/commit/0684166637e6c9ce87d209d704797f1a9b7e1c3a) haste-server: 72863858338a57d54eb9dee55530e90ebbc22453 -> 68f6fe2b96ad02e21645480448113954bc87e1f5
* [`12e43250`](https://github.com/NixOS/nixpkgs/commit/12e43250db62ccb4fdb8b871b50f61dc7b163f27) curlcpp: drop
* [`fc9d5ea6`](https://github.com/NixOS/nixpkgs/commit/fc9d5ea630a06349a8b49d9c7e68a9f8abf11aab) python310Packages.hvplot: 0.7.3 -> 0.8.0
* [`9d9b4dc6`](https://github.com/NixOS/nixpkgs/commit/9d9b4dc64b366c33ce05b21c4e488e22eca9ece6) envoy: fix sha256 for x86_64-linux
* [`89120cda`](https://github.com/NixOS/nixpkgs/commit/89120cda741c71ca626b383332f8d5e7c31f838a) jitsi-meet: 1.0.6091 -> 1.0.6155
* [`ab456c4d`](https://github.com/NixOS/nixpkgs/commit/ab456c4d4583721157a2e4d48904709e3471ebc7) medusa: pull upstream fix for fno-common toolchains
* [`6eba0380`](https://github.com/NixOS/nixpkgs/commit/6eba03800ef47d9011d39a72a26ad0853fcacb05) spdk: build against old dpdk 21.11
* [`7bd29be2`](https://github.com/NixOS/nixpkgs/commit/7bd29be23bb81d928dc358a6488d96bc2d3e2611) python310Packages.dbf: 0.99.1 -> 0.99.2
* [`69a98c28`](https://github.com/NixOS/nixpkgs/commit/69a98c2869c1d0f5ca429a77168cc2bdf7e0d8ba) python310Packages.stripe: 2.76.0 -> 3.0.0
* [`c95a1d47`](https://github.com/NixOS/nixpkgs/commit/c95a1d47240ca4808186d941b4e08a28a957bb08) cataract: add -fcommon workaround
* [`c08232b7`](https://github.com/NixOS/nixpkgs/commit/c08232b717a221d2b208559a6884e791a5fc791d) directvnc: pull -fno-common fix pending upstream inclusion
* [`b1571265`](https://github.com/NixOS/nixpkgs/commit/b1571265b512febdcc862e8ecf2fb56598648d58) librewolf: move out of firefox directory
* [`f6004cdb`](https://github.com/NixOS/nixpkgs/commit/f6004cdb2ecb5128abb35d8fe75249676e0b1b34) python310Packages.hvplot: disable on older Python releases
* [`3e7a9344`](https://github.com/NixOS/nixpkgs/commit/3e7a93449edda39ce34c09e95ecec2ab2ba6ca1e) cinny: 1.8.2 -> 2.0.0
* [`97ed4e85`](https://github.com/NixOS/nixpkgs/commit/97ed4e85eab62532cb8fc3bc6e2cdc446b2f8bbf) python310Packages.dbf: disable on older Python releases
* [`db30191b`](https://github.com/NixOS/nixpkgs/commit/db30191b78bb3ad82a2edc268a3e372be6aa9887) python3Packages.name-that-hash: init at 1.10
* [`7fde85cb`](https://github.com/NixOS/nixpkgs/commit/7fde85cbe1893c1b0f729063d705786391a1f911) python310Packages.oletools: 0.60 -> 0.60.1
* [`83b7231f`](https://github.com/NixOS/nixpkgs/commit/83b7231f6a4c7fa7c3e31f2a71b42f2d70da6285) clip: init at 2.1.1
* [`d33a05ab`](https://github.com/NixOS/nixpkgs/commit/d33a05ab8962fa5653b0af25b46b2684bb2bf3a0) dovecot: 2.3.18 -> 2.3.19
* [`20020f7c`](https://github.com/NixOS/nixpkgs/commit/20020f7c111c168f7a160e1454fc5ea3bf35486b) dovecot_pigeonhole: 0.5.18 -> 0.5.19
* [`9cf2c679`](https://github.com/NixOS/nixpkgs/commit/9cf2c67910794bf17b28cec21fbb726d9b36fefc) libpulseaudio: fix build on x86_64-darwin
* [`b544d177`](https://github.com/NixOS/nixpkgs/commit/b544d177a26985b5fc1149612bac511f35be6a48) lib.licenses: add DRL-1.0
* [`4a3bbec4`](https://github.com/NixOS/nixpkgs/commit/4a3bbec489c0e076a807ccf6d877662547ea2ad9) python3Packages.prox-tv: ignore unstable test
* [`4fbc3657`](https://github.com/NixOS/nixpkgs/commit/4fbc3657db02f9739f2009fbb924aad2ac93ebf1) python310Packages.aws-lambda-builders: 1.15.0 -> 1.16.0
* [`c0d01f15`](https://github.com/NixOS/nixpkgs/commit/c0d01f15f9274c0314a29b5154ab24ab5ca675a5) pythonPackages.nutils: Mark broken for aarch64
* [`bb55ac97`](https://github.com/NixOS/nixpkgs/commit/bb55ac971a77b7d23d4963eb6ba33652a568d1ef) python310Packages.extractcode: 30.0.0 -> 31.0.0
* [`14d0c3f3`](https://github.com/NixOS/nixpkgs/commit/14d0c3f3a17fda1e1ad7f8ea3cddb2615d095d16) csound: darwin support
* [`0bc70ad4`](https://github.com/NixOS/nixpkgs/commit/0bc70ad43489682489adfcf0678cec700c6d5a20) zeroc-ice: 3.7.6 -> 3.7.7, drop Darwin
* [`b4a61b63`](https://github.com/NixOS/nixpkgs/commit/b4a61b636a21c7e4608ae9003ccb3865176f395c) teams: fix wrapper workaround
* [`b8985bb9`](https://github.com/NixOS/nixpkgs/commit/b8985bb965737ce8d117b7a2c5242aabf0e6062c) teapot: use Museoa as backup
* [`18d7643c`](https://github.com/NixOS/nixpkgs/commit/18d7643c9d19d89658cc820b474201cea9135af6) dgen-sdl: fixup meta.homepage
* [`3d195260`](https://github.com/NixOS/nixpkgs/commit/3d195260adae3ed4436f456a80a563a8844d6aa9) yex-lang: unstable-2021-12-25 -> 0.pre+date=2022-05-10
* [`4029d50b`](https://github.com/NixOS/nixpkgs/commit/4029d50b1e23718b9c6e1b03ded22b552038ae93) maintainers: expand jceb's name ([nixos/nixpkgs⁠#172312](https://togithub.com/nixos/nixpkgs/issues/172312))
* [`70d7d6ee`](https://github.com/NixOS/nixpkgs/commit/70d7d6eefa40a486de4c41ebd5fa4f859151553e) signal-desktop: use non-binary wrapper for wrapGAppsHook
* [`de869f03`](https://github.com/NixOS/nixpkgs/commit/de869f039d591f205e6bf09fd4cc7a55246f1ee2) siesta: fix hardcoded path to rm
* [`8cc63bb7`](https://github.com/NixOS/nixpkgs/commit/8cc63bb7866788e582d05c6209abfb5006805b0c) libast: 0.7.1 -> 0.8
* [`3120f41d`](https://github.com/NixOS/nixpkgs/commit/3120f41ddd58d5a0a466634efdf9b99de1262001) python3Packages.pydyf: fix failing tests
* [`6afb6d40`](https://github.com/NixOS/nixpkgs/commit/6afb6d4032adb78d50bd52cbac9bd33ec6f23c01) fnc: 0.10 -> 0.12
* [`6d06f475`](https://github.com/NixOS/nixpkgs/commit/6d06f47584813ec31e5ad167e3f488fbebaac7a1) brave: use non-binary wrapper for wrapGAppsHook
* [`a6977778`](https://github.com/NixOS/nixpkgs/commit/a6977778089a7f9b31335e5d202cf20798705b6e) discord: use non-binary wrapper for wrapGAppsHook
* [`a2ee3ed3`](https://github.com/NixOS/nixpkgs/commit/a2ee3ed3f284c5b33432fbd55d07a624f01ff8c5) vscode: use non-binary wrapper for wrapGAppsHook
* [`18aee8a1`](https://github.com/NixOS/nixpkgs/commit/18aee8a1ad6a99dbcd5096711b22e4f48e4d8b83) terragrunt: 0.36.10 -> 0.36.11
* [`b0f5004a`](https://github.com/NixOS/nixpkgs/commit/b0f5004a06d1d2e076c571a67a2f35ca28975d4d) wrapFirefox: move back into $out
* [`f3ef6622`](https://github.com/NixOS/nixpkgs/commit/f3ef66220b4224c130cd0c7b860d105c49ea9da8) ocamlPackages.biniou: remove legacy version 1.0.9 for OCaml < 4.02
* [`10bb8b18`](https://github.com/NixOS/nixpkgs/commit/10bb8b1818d309a144b2a0775ce1d0194a433852) ocamlPackages.easy-format: 1.2.0 → 1.3.2
* [`6e6b908a`](https://github.com/NixOS/nixpkgs/commit/6e6b908a9092b4582e63c2c5f01d9b67c22eead5) python310Packages.chiavdf: 1.0.6 -> 1.0.7
* [`7a986c5f`](https://github.com/NixOS/nixpkgs/commit/7a986c5fc1b2f9d81b8e2b4fa043375f9c16f46e) go-mtpfs: unstable-2018-02-09 -> 1.0.0
* [`213335ce`](https://github.com/NixOS/nixpkgs/commit/213335ce593b66ad6452fe48bcfe2112b5a5d8c1) diskrsync: unstable-2019-01-02 -> 1.3.0
* [`bf889b9d`](https://github.com/NixOS/nixpkgs/commit/bf889b9d3decd711ecdbff82680bcef42879a8c4) prometheus-openldap-exporter: 2.2.0 -> 2.2.1
* [`590098bc`](https://github.com/NixOS/nixpkgs/commit/590098bcd7c523e257d00da8cd576d1c5baa52ac) git-codereview: 2020-01-15 -> 1.0.3
* [`cb04e72c`](https://github.com/NixOS/nixpkgs/commit/cb04e72cd8ff039d3fd71cec84521b3556966cfc) jmespath: 0.2.2 -> 0.4.0
* [`7387c69d`](https://github.com/NixOS/nixpkgs/commit/7387c69d8441606758febcbf18bbc7a066bd24ce) goconst: 1.4.0 -> 1.5.1
* [`03e1b376`](https://github.com/NixOS/nixpkgs/commit/03e1b376c61a4a4b77c4f0d27456141bb5e4c3e7) dsp: init at 1.8
* [`f716f305`](https://github.com/NixOS/nixpkgs/commit/f716f305eeb753993c5c07814253bc68f0f4a653) python310Packages.tensorflow-metadata: 1.7.0 -> 1.8.0
* [`155e68e8`](https://github.com/NixOS/nixpkgs/commit/155e68e86ee25235609fa17aa815fec453b1b7cc) libssh2_1_10: remove temp attr
* [`6c3d8d72`](https://github.com/NixOS/nixpkgs/commit/6c3d8d72e907b20967c3f50153ac69fe9fd8b145) all-packages.nix: remove old commented line about xracer
* [`c07919c7`](https://github.com/NixOS/nixpkgs/commit/c07919c76caadd5915cbef41786f595e33cc263b) hydra: fix evaluation with aliases disabled
* [`8bdcffc4`](https://github.com/NixOS/nixpkgs/commit/8bdcffc4fe0b92138ee8ca55a1c690b223beb850) nixos/mbpfan: minor changes
* [`611be96f`](https://github.com/NixOS/nixpkgs/commit/611be96fd91496423cc48718e6d2e795ed2aa073) dotnet: fixed runtime error for dotnet 3.1 after icu update
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
