### PR TITLE
niv emacs-overlay: update 3a0704d6 -> dddc2903

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3a0704d6ae03c5db954697b6c0873ebc14e324f5",
-        "sha256": "0m443p0lp2pmkgy0a8lizbvy2ia44zpqli422s34hpnqvzxyj2mj",
+        "rev": "dddc29038a06a29b92d07cb21490b228329ae9ac",
+        "sha256": "0qsq3lmwx33djz3dyq78iwi42b7ja36jaway0v472nzkk23h1zyd",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/3a0704d6ae03c5db954697b6c0873ebc14e324f5.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/dddc29038a06a29b92d07cb21490b228329ae9ac.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@3a0704d6...dddc2903](https://github.com/nix-community/emacs-overlay/compare/3a0704d6ae03c5db954697b6c0873ebc14e324f5...dddc29038a06a29b92d07cb21490b228329ae9ac)

* [`a803ac7b`](https://github.com/nix-community/emacs-overlay/commit/a803ac7b1feafd1d4ead5d027524ff5cb8a3242b) Updated repos/emacs
* [`0646f7ce`](https://github.com/nix-community/emacs-overlay/commit/0646f7ce8d90faadd752ea8037ed4d3c82b7576e) Updated repos/melpa
* [`e90288a8`](https://github.com/nix-community/emacs-overlay/commit/e90288a89120372b34b90437f3052bcd429a2168) Updated repos/emacs
* [`61b4451c`](https://github.com/nix-community/emacs-overlay/commit/61b4451c26c4759923d0794aab96e86366de0769) Updated repos/melpa
* [`e467eb92`](https://github.com/nix-community/emacs-overlay/commit/e467eb927eda9a66638d4dabeceabf9e73767c20) Updated repos/elpa
* [`258a069a`](https://github.com/nix-community/emacs-overlay/commit/258a069a285100ca653d6eae9529a992c86ec1ac) Updated repos/emacs
* [`4daa399a`](https://github.com/nix-community/emacs-overlay/commit/4daa399a9895ce76441f696be993c339d4096341) Updated repos/melpa
* [`e2c944b2`](https://github.com/nix-community/emacs-overlay/commit/e2c944b28b964730ed98dc83a28d9c07dcde3063) Updated repos/emacs
* [`681b5512`](https://github.com/nix-community/emacs-overlay/commit/681b5512f5bc6ae454cf3a8c224c72d368981d12) Updated repos/melpa
* [`4b5f224a`](https://github.com/nix-community/emacs-overlay/commit/4b5f224ab39fe69ba6a867d71c990a6549d2d865) Updated repos/emacs
* [`e79f6d3c`](https://github.com/nix-community/emacs-overlay/commit/e79f6d3ce935898960d865faea9e9fa88ba1b26b) Updated repos/melpa
* [`304d3e84`](https://github.com/nix-community/emacs-overlay/commit/304d3e84b36dc8c91a92b62c7de220c1b384b4fc) Updated repos/elpa
* [`963bfcfe`](https://github.com/nix-community/emacs-overlay/commit/963bfcfecaa5deefe98d3d146f37abbad0f10d4d) Updated repos/emacs
* [`e6ec42b6`](https://github.com/nix-community/emacs-overlay/commit/e6ec42b61a1a151d1f7adec951138597448007e6) Updated repos/melpa
* [`bb509f85`](https://github.com/nix-community/emacs-overlay/commit/bb509f857b8591fd4c02152df045111780a09d58) Updated repos/emacs
* [`4757eb63`](https://github.com/nix-community/emacs-overlay/commit/4757eb63bcf809b5e1c014e7849cad5a49d9dc82) Updated repos/melpa
* [`74a7ddd5`](https://github.com/nix-community/emacs-overlay/commit/74a7ddd5200db4689adc89efd5d9251e7df2d401) Updated repos/elpa
* [`85e5eaaa`](https://github.com/nix-community/emacs-overlay/commit/85e5eaaa19fe411f3496798e03c601662c7afe8e) Updated repos/emacs
* [`b324b27d`](https://github.com/nix-community/emacs-overlay/commit/b324b27d58fe93add90d80e081c39d452ae1cb98) Updated repos/melpa
* [`8834bf71`](https://github.com/nix-community/emacs-overlay/commit/8834bf71c86ae28f122f3a8f99ec04636c91a9fc) Updated repos/elpa
* [`3c4249ac`](https://github.com/nix-community/emacs-overlay/commit/3c4249ac362e46e63facba47835a9dae930d687c) Updated repos/emacs
* [`9c90a10f`](https://github.com/nix-community/emacs-overlay/commit/9c90a10f7c5d4e99392090820460c1fa7486ae2c) Updated repos/melpa
* [`7456759c`](https://github.com/nix-community/emacs-overlay/commit/7456759c0fe5f1a8da6b62218055b01f8cd9b85b) Updated repos/emacs
* [`672ed963`](https://github.com/nix-community/emacs-overlay/commit/672ed963c05977c629f0ec7521b4d347968cd201) Updated repos/melpa
* [`20c5cfea`](https://github.com/nix-community/emacs-overlay/commit/20c5cfea4b55734fe6e1b2213574c4ca56f04dc6) Updated repos/elpa
* [`5fc2cae6`](https://github.com/nix-community/emacs-overlay/commit/5fc2cae6b4f1dca76cb006f53739e2d1a54e8199) Updated repos/emacs
* [`b4fb024e`](https://github.com/nix-community/emacs-overlay/commit/b4fb024e32ceec9f65310fec4ac670d054d92477) Updated repos/melpa
* [`f5978012`](https://github.com/nix-community/emacs-overlay/commit/f5978012b29fc163beb6d4ee6f6038f96bbde9f3) Updated repos/elpa
* [`b051d91d`](https://github.com/nix-community/emacs-overlay/commit/b051d91d33fdb486c38006f1a1c31b9b8d58cb18) Updated repos/emacs
* [`20f9d4b1`](https://github.com/nix-community/emacs-overlay/commit/20f9d4b117c972756c4b1fcd6e11af02a45ec493) Updated repos/melpa
* [`845c483d`](https://github.com/nix-community/emacs-overlay/commit/845c483d7370633883ed9f1ac28691be308f0202) Updated repos/emacs
* [`7965b47c`](https://github.com/nix-community/emacs-overlay/commit/7965b47c428473943a49873385f5b168baeb7357) Updated repos/melpa
* [`0a26e7bd`](https://github.com/nix-community/emacs-overlay/commit/0a26e7bdc34ab239f8d4965ea193df5e37e2acd9) Updated repos/elpa
* [`555028d2`](https://github.com/nix-community/emacs-overlay/commit/555028d2439767e0637d326f44400095a0cf12c9) Updated repos/melpa
* [`387fc33e`](https://github.com/nix-community/emacs-overlay/commit/387fc33e0569b3fa2252ca543413b391ddd51663) Updated repos/elpa
* [`6a61ab56`](https://github.com/nix-community/emacs-overlay/commit/6a61ab567c4a827819e53fd0e6716f6f2f77739d) Updated repos/melpa
* [`11fff15d`](https://github.com/nix-community/emacs-overlay/commit/11fff15d94a72b93604f28e7858bd00055ee9991) Updated repos/emacs
* [`9f831bb5`](https://github.com/nix-community/emacs-overlay/commit/9f831bb5ac5ae54420defefba76ef7741e6264b5) Updated repos/melpa
* [`972925e3`](https://github.com/nix-community/emacs-overlay/commit/972925e3f1b6724eaf6a896f1ae9390d205fcaae) Updated repos/nongnu
* [`8019a5ac`](https://github.com/nix-community/emacs-overlay/commit/8019a5ac24f31e3ab3c74a49bc743e11532199fe) Updated repos/emacs
* [`48b5d664`](https://github.com/nix-community/emacs-overlay/commit/48b5d664638c851932d656c20447a632f0b58912) Updated repos/melpa
* [`271efe39`](https://github.com/nix-community/emacs-overlay/commit/271efe39a945e622c1629c54db1063ee6be20ef8) Updated repos/melpa
* [`6e6e81c7`](https://github.com/nix-community/emacs-overlay/commit/6e6e81c7150cb19595fad48ebe6844b2f9e99876) Updated repos/emacs
* [`e9f4792a`](https://github.com/nix-community/emacs-overlay/commit/e9f4792aa79bccedb34b3fc04d1a36f1848b7b57) Updated repos/melpa
* [`37265b87`](https://github.com/nix-community/emacs-overlay/commit/37265b87aa5f02c589a0147346de05d25c87a3db) Updated repos/emacs
* [`513a50db`](https://github.com/nix-community/emacs-overlay/commit/513a50dbc4589f33abca1f8d1084496fbb70a08e) Updated repos/melpa
* [`8d5d3a0b`](https://github.com/nix-community/emacs-overlay/commit/8d5d3a0b2d135cd0104cf76c45abea3d82da5b57) Updated repos/elpa
* [`e0f32326`](https://github.com/nix-community/emacs-overlay/commit/e0f32326057be3592ffc045ac2de670403aa28d7) Updated repos/emacs
* [`dddc2903`](https://github.com/nix-community/emacs-overlay/commit/dddc29038a06a29b92d07cb21490b228329ae9ac) Updated repos/melpa
