### PR TITLE
niv spacemacs: update c6c17748 -> 6f5de5cc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "c6c17748f649236e5c4afab6a0cabb97f0806bf9",
-        "sha256": "0qm7ld88ap2m75rwamgd5yqhz2hqkbxpasqz6fp5l6128z91csv1",
+        "rev": "6f5de5cc4f0616da33948a8b662cf8e81a9aacea",
+        "sha256": "0n8hf2djrv0fnlxdrn2qmcs1g0j7h29mhkw8hj187rxcl3s5rldz",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/c6c17748f649236e5c4afab6a0cabb97f0806bf9.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/6f5de5cc4f0616da33948a8b662cf8e81a9aacea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@c6c17748...6f5de5cc](https://github.com/syl20bnr/spacemacs/compare/c6c17748f649236e5c4afab6a0cabb97f0806bf9...6f5de5cc4f0616da33948a8b662cf8e81a9aacea)

* [`2218a5e2`](https://github.com/syl20bnr/spacemacs/commit/2218a5e2861d183938fb7a7c30627799f79ae9f3) common-lisp: Fix typo ([syl20bnr/spacemacs⁠#15507](https://togithub.com/syl20bnr/spacemacs/issues/15507))
* [`11f45d52`](https://github.com/syl20bnr/spacemacs/commit/11f45d529fe4294ca2082ac7e740994a83192047) [bot] "built_in_updates" Wed May 11 06:35:02 UTC 2022 ([syl20bnr/spacemacs⁠#15508](https://togithub.com/syl20bnr/spacemacs/issues/15508))
* [`895deed5`](https://github.com/syl20bnr/spacemacs/commit/895deed51a03b4f64a5395d05b6d95539ac5e745) Add support for code-cells in python layer
* [`6bdf6094`](https://github.com/syl20bnr/spacemacs/commit/6bdf609421f4cd2665ace9bf544b952955144484) [git] key bindings to edit magit forge topics
* [`26547221`](https://github.com/syl20bnr/spacemacs/commit/265472214e01ecb58c0203023a51f125b99e9510) add org-roam-ui to replace org-roam-server ([syl20bnr/spacemacs⁠#15504](https://togithub.com/syl20bnr/spacemacs/issues/15504))
* [`f70110dd`](https://github.com/syl20bnr/spacemacs/commit/f70110dd776484d6921442bf0ed5acd4eb81e640) [version-control] Load smerge-mode when entering smerge-transient-state
* [`83d68753`](https://github.com/syl20bnr/spacemacs/commit/83d687534cc7df538a4fb4680650790f21bffef5) tidy read syntax for anonymous functions
* [`0d5247f2`](https://github.com/syl20bnr/spacemacs/commit/0d5247f231b2c67e62270365e31a08bfd413a66b) Only bind TAB when evil setting allows it ([syl20bnr/spacemacs⁠#15473](https://togithub.com/syl20bnr/spacemacs/issues/15473))
* [`06f790d4`](https://github.com/syl20bnr/spacemacs/commit/06f790d4cf8a0a7b5f60aec6d30f57a8bc1d814e) [latex] add, configure, and document evil-tex package
* [`805d9e8c`](https://github.com/syl20bnr/spacemacs/commit/805d9e8cd6d8d8338cd6778a4ab868a1a4e8ecdc) When enabled make sure we load org-roam-protocol
* [`5609868f`](https://github.com/syl20bnr/spacemacs/commit/5609868f27b688db2f7fac54fa1be456fe436d9e) Add doom-tokyo-night to the theme-support alist. ([syl20bnr/spacemacs⁠#15453](https://togithub.com/syl20bnr/spacemacs/issues/15453))
* [`a69aba73`](https://github.com/syl20bnr/spacemacs/commit/a69aba732a8bbeeaac42e4208948f59d0ce6aae2) Fix function quote warning ([syl20bnr/spacemacs⁠#15446](https://togithub.com/syl20bnr/spacemacs/issues/15446))
* [`dd1e077c`](https://github.com/syl20bnr/spacemacs/commit/dd1e077c5d13c2e0a1eabcd7259b104c879d4226) [core] enable lexical binding for all
* [`50c8651b`](https://github.com/syl20bnr/spacemacs/commit/50c8651b7da2b0d9be100b9fadd749b12c2384a1) [bot] "documentation_updates" Wed May 11 17:49:13 UTC 2022
* [`1fde8719`](https://github.com/syl20bnr/spacemacs/commit/1fde8719e988843adcee809960c09b94d6bb06d1) python: Fix broken link
* [`88e5d10d`](https://github.com/syl20bnr/spacemacs/commit/88e5d10d2bcf67729388f54e96070ab8b94ae0d1) Add rails api to search engines
* [`24640fca`](https://github.com/syl20bnr/spacemacs/commit/24640fca75b96a97c852e32f41559bbe02b4fb8d) Add layer `translate` for doing translation jobs
* [`f54cc055`](https://github.com/syl20bnr/spacemacs/commit/f54cc055b18ac39c7816ae2ecc31a3cc7c1e6e17) s/org-roam-enable-protocol/org-enable-roam-protocol
* [`10913cae`](https://github.com/syl20bnr/spacemacs/commit/10913caeb0acfe96c6fbe1f07c6cebdb64444a44) [bot] "documentation_updates" Fri May 13 16:52:02 UTC 2022
* [`6f5de5cc`](https://github.com/syl20bnr/spacemacs/commit/6f5de5cc4f0616da33948a8b662cf8e81a9aacea) [doc] Remove install instructions for old master
