### PR TITLE
niv zsh-completions: update ca484eac -> 7a72511f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "ca484eac407a7a2c35437c93e1c3248512ae2061",
-        "sha256": "0dj34ikd21qpp3w0sipnpc716q0dj4j9mv68avsv4ggfh2xywd86",
+        "rev": "7a72511f7b3793b1a985c73364fffd1d8ad63931",
+        "sha256": "0b7i4iy0dx2r7lc3pmpnyibvs5ja0h91jrvh8vi8100v5l30075z",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/ca484eac407a7a2c35437c93e1c3248512ae2061.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/7a72511f7b3793b1a985c73364fffd1d8ad63931.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@ca484eac...7a72511f](https://github.com/zsh-users/zsh-completions/compare/ca484eac407a7a2c35437c93e1c3248512ae2061...7a72511f7b3793b1a985c73364fffd1d8ad63931)

* [`19b03c3b`](https://github.com/zsh-users/zsh-completions/commit/19b03c3b2d8040e84458a1f0289627fa9578c19e) Added add, binstubs, clean, doctor, remove commands to bundler completions
