### PR TITLE
niv zsh-syntax-highlighting: update c5ce0014 -> caa749d0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -228,10 +228,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "c5ce0014677a0f69a10b676b6038ad127f40c6b1",
-        "sha256": "000ksv6bb4qkdzp6fdgz8z126pwin6ywib5d6cfwqa2w27xqm9sj",
+        "rev": "caa749d030d22168445c4cb97befd406d2828db0",
+        "sha256": "17ck9lm8j6bv9fhag827kxrbwdwbhhss0sw7p1yz7nhpknj6apv1",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/c5ce0014677a0f69a10b676b6038ad127f40c6b1.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/caa749d030d22168445c4cb97befd406d2828db0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@c5ce0014...caa749d0](https://github.com/zsh-users/zsh-syntax-highlighting/compare/c5ce0014677a0f69a10b676b6038ad127f40c6b1...caa749d030d22168445c4cb97befd406d2828db0)

* [`caa749d0`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/caa749d030d22168445c4cb97befd406d2828db0) main: Housekeep $precommand_options.  Add -v to tabbed(1).
