### PR TITLE
niv nixpkgs: update 78e94513 -> d65ee335

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "78e94513206616e7f81b0d7c594bf9f7423d1858",
-        "sha256": "1kza6ay1hn42zjk5wricdss8gzlpfinvn80rrg93k9bw2c0jqsfh",
+        "rev": "d65ee335c862c1b9ed7864c4b6c96b787e1ac166",
+        "sha256": "0iyl8d6snxk3da8kz6v292jgdffdxxv5m0r37m2vz7sc5hgp1kz8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/78e94513206616e7f81b0d7c594bf9f7423d1858.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d65ee335c862c1b9ed7864c4b6c96b787e1ac166.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@78e94513...d65ee335](https://github.com/nixos/nixpkgs/compare/78e94513206616e7f81b0d7c594bf9f7423d1858...d65ee335c862c1b9ed7864c4b6c96b787e1ac166)

* [`e1c47b01`](https://github.com/NixOS/nixpkgs/commit/e1c47b01030714b4aa0992d715475c108417f807) restya-board: further fix for functionality
* [`80a72807`](https://github.com/NixOS/nixpkgs/commit/80a72807e7d32d5176b1734accb867cd43da95c4) restya-board: change password read-in to cat
* [`ca88e5a0`](https://github.com/NixOS/nixpkgs/commit/ca88e5a03aeb0b09ae1e750e39176e7ecd5e66ed) restya-board: require postgresql service only on local database
* [`18d5ed65`](https://github.com/NixOS/nixpkgs/commit/18d5ed658be432ce93f10fd6e3841fe04d354c23) nextcloud: fix logging parameter
* [`1009d6e7`](https://github.com/NixOS/nixpkgs/commit/1009d6e79e7f4ef92d7db27214c55a36f5e22c6f) nixos/wrappers: create a new assert macro that always asserts
* [`2a6a3d2c`](https://github.com/NixOS/nixpkgs/commit/2a6a3d2c47626782f604a1fb4ec506c834efb47a) nixos/wrappers: require argc to be at least one
* [`0cfdfbc6`](https://github.com/NixOS/nixpkgs/commit/0cfdfbc6490a51289c12a3aaaa98de27105fc3fe) kuma: 1.4.1 -> 1.5.0
* [`cbf970e4`](https://github.com/NixOS/nixpkgs/commit/cbf970e4996e95524baa6fae4992e7774bfcec94) prometheus-mysqld-exporter: 0.13.0 -> 0.14.0
* [`e7a656dd`](https://github.com/NixOS/nixpkgs/commit/e7a656ddbe3e1e673562e258d0639b1ce57d8fb8) console-bridge: 1.0.1 -> 1.0.2
* [`368e6d00`](https://github.com/NixOS/nixpkgs/commit/368e6d00f8fa611682acae6c17ec2268d9239795) libdigidocpp: 3.14.7 -> 3.14.8
* [`7b3ac385`](https://github.com/NixOS/nixpkgs/commit/7b3ac385e53101e229122d687fd0021a637407aa) k0sctl: 0.11.4 -> 0.12.6
* [`e70add1c`](https://github.com/NixOS/nixpkgs/commit/e70add1c86e7f45745c7299dd2ae00af9c39775e) tixati: 2.88 -> 2.89
* [`9841a677`](https://github.com/NixOS/nixpkgs/commit/9841a677e6bdde14babd9c487c017351588272bd) argus-clients: 3.0.8.2 -> 3.0.8.3
* [`49df9b76`](https://github.com/NixOS/nixpkgs/commit/49df9b76fe99769c676b7c06e30ab7f52e2da01a) storm: 2.3.0 -> 2.4.0
* [`7e397432`](https://github.com/NixOS/nixpkgs/commit/7e397432743a969b161ac1739b2abc7b37f47625) garble: 0.5.1 -> 0.6.0
* [`0c795a81`](https://github.com/NixOS/nixpkgs/commit/0c795a8127dbed56a0accd5466f6c7ffb80638d7) nixos/wireguard: fix dependencies on network-related targets
* [`cef71b49`](https://github.com/NixOS/nixpkgs/commit/cef71b49d5acefb82258f5e1d1e07459bc89172f) wasabibackend: 1.1.13.0 -> 1.1.13.1
* [`4885b0bc`](https://github.com/NixOS/nixpkgs/commit/4885b0bcf4efacd622f1981325ff1b9c90a979e8) wasabiwallet: 1.1.12.9 -> 1.1.13.1
* [`21552c54`](https://github.com/NixOS/nixpkgs/commit/21552c541f70519a3329d001385bd3f573a8ac77) ocamlPackages.graphql_ppx: 1.2.0 -> 1.2.2
* [`b1c4b96a`](https://github.com/NixOS/nixpkgs/commit/b1c4b96a0848f679452c7cf1856c9dbb946027ea) dbmate: 1.14.0 -> 1.15.0
* [`f8e9e941`](https://github.com/NixOS/nixpkgs/commit/f8e9e941e13ffb54cb43357232fb6318267205b0) tracker-miners: add some gstreamer plugins
* [`41e12309`](https://github.com/NixOS/nixpkgs/commit/41e12309552f11aff87f0bfad971b6633c3ce35d) gnome-music: add gst-libva for m4a
* [`b1cd6100`](https://github.com/NixOS/nixpkgs/commit/b1cd610046753f6fa49c28b4b8c45038a714b2b9) dyff: 1.5.1 -> 1.5.2
* [`aaf2098a`](https://github.com/NixOS/nixpkgs/commit/aaf2098a361e5fd9798fee31c2a7e485720b0ad1) tab: 9.0 -> 9.1
* [`ff6eb929`](https://github.com/NixOS/nixpkgs/commit/ff6eb9293739279c81f1e8e73c058ff6bcd4ed0e) libbsd: 0.11.5 -> 0.11.6
* [`2dd472bd`](https://github.com/NixOS/nixpkgs/commit/2dd472bd9d8f35e9fc45f1f94210529b9023cc79) lndconnect: 0.2.0 -> 0.2.1
* [`573f33f6`](https://github.com/NixOS/nixpkgs/commit/573f33f6853c4026db51f671fc9678023bc89969) yubioath-desktop: 5.0.5 -> 5.1.0
* [`65219bc1`](https://github.com/NixOS/nixpkgs/commit/65219bc169a6d1f691a6df52e1ecc6f550705c6d) assign-lb-ip: 2.3.0 -> 2.3.1
* [`489aafb4`](https://github.com/NixOS/nixpkgs/commit/489aafb436a2dae95e2850a2cfae561151b5e6e9) aws-iam-authenticator: 0.5.6 -> 0.5.7
* [`221dee65`](https://github.com/NixOS/nixpkgs/commit/221dee65480573d890b1e7c7bdb7c0b55d811eeb) bloat: init at unstable-2022-03-31
* [`93d02ccf`](https://github.com/NixOS/nixpkgs/commit/93d02ccfb1669a94fd367debd8b56afef62fa0c9) mpris-scrobbler: 0.4.90 -> 0.4.95
* [`266b01d1`](https://github.com/NixOS/nixpkgs/commit/266b01d1d421844a42571dc9b09ca27c28c211d9) SPIRV-LLVM-Translator: Build and install llvm-spirv tool
* [`155dbcfc`](https://github.com/NixOS/nixpkgs/commit/155dbcfc81ab2cd7242e143958ea890f5e262ed3) libclc: 11.0.1 -> 12.0.1
* [`cb8de952`](https://github.com/NixOS/nixpkgs/commit/cb8de95296a8927708febba78e387ca8ca99faac) datadog-agent: 7.35.0 -> 7.35.1
* [`75c7e048`](https://github.com/NixOS/nixpkgs/commit/75c7e048010a501c20a301ac1cc86bdaa30fad5f) moltenvk: fix Hydra build failures
* [`55d27980`](https://github.com/NixOS/nixpkgs/commit/55d279809c7e4d876e137819d1e6c6d0fe28d66a) wine-packages: fix Hydra build failures on Darwin
* [`749b97bb`](https://github.com/NixOS/nixpkgs/commit/749b97bb2345395e4f7d947c71ac603dbce01d72) bats: improve package w/ new resholve features
* [`a60c1dbb`](https://github.com/NixOS/nixpkgs/commit/a60c1dbb51350c3a7c7ec766c130014d46cdf1eb) bats: move installCheck into passthru.tests
* [`b8d3991c`](https://github.com/NixOS/nixpkgs/commit/b8d3991ce58b2de158649f46061de5753dd8fccc) isso: 0.12.6.1 -> 0.12.6.2
* [`a433cc03`](https://github.com/NixOS/nixpkgs/commit/a433cc0312fbb47edda411f9fbc6fd740911e3a0) python310Packages.ipympl: 0.9.0 -> 0.9.1
* [`c3e9115c`](https://github.com/NixOS/nixpkgs/commit/c3e9115cec5eb4e7e4fac86c85f3e350f355fcf6) air: 1.28.0 -> 1.29.0
* [`5eb9f35c`](https://github.com/NixOS/nixpkgs/commit/5eb9f35c44d30153ff1df2105ed73e148a79a3ee) R: 4.1.3 -> 4.2.0
* [`db5e7f7a`](https://github.com/NixOS/nixpkgs/commit/db5e7f7a928f9504ece7dfccce9f52dc36360fbb) rPackages: CRAN and BioC update
* [`7bec3e60`](https://github.com/NixOS/nixpkgs/commit/7bec3e60efb9203c444bfaf8f35cfb1252ece170)  lib/types: Drop misleading plural from type descriptions [nixos/nixpkgs⁠#170561](https://togithub.com/nixos/nixpkgs/issues/170561)
* [`a7f9bb67`](https://github.com/NixOS/nixpkgs/commit/a7f9bb67da1f4090a50ba0445fdb05f43e233bc7) audit: enable strictDeps
* [`44370b35`](https://github.com/NixOS/nixpkgs/commit/44370b355e5ea046bf3727b9e90db6428e10ea2a) bluez: install gatttool too
* [`c96b21c7`](https://github.com/NixOS/nixpkgs/commit/c96b21c78be0c5f954ac7fc218c5fadb683656dd) libpcap: move dev things to extra output
* [`99dd6e95`](https://github.com/NixOS/nixpkgs/commit/99dd6e952f99e91e9b8526855ebaf790fdbde37c) python3Packages.sqlalchemy: 1.4.35 -> 1.4.36
* [`784ea321`](https://github.com/NixOS/nixpkgs/commit/784ea32182571783f40163739edd00db8ec401ea) gst_all_1.gstreamer: enable strictDeps and fix cross
* [`faef0834`](https://github.com/NixOS/nixpkgs/commit/faef08342601b39b87fc2aa6d90557fba6249a25) libical: enable strictDeps and fix cross
* [`8473cb3a`](https://github.com/NixOS/nixpkgs/commit/8473cb3a2a108c3c089845e8164266943363fc51) gst_all_1.base: fix strictDeps
* [`5e2a1ebd`](https://github.com/NixOS/nixpkgs/commit/5e2a1ebdc4e000bc6e1316ab81c38a87a8ed417a) elfutils: 0.186 -> 0.187
* [`97164719`](https://github.com/NixOS/nixpkgs/commit/97164719dc1e69e722855bee50f2741b1b0e9693) linux_xanmod: 5.15.34 -> 5.15.35
* [`573127a0`](https://github.com/NixOS/nixpkgs/commit/573127a0f20e5046f8b4d8dd5d90b1696219e01e) linux_xanmod_latest: 5.17.2 -> 5.17.4
* [`c2ff9af7`](https://github.com/NixOS/nixpkgs/commit/c2ff9af725a5b4f90d209f7100bb6787ab30dc53) mutagen-compose: init at 0.14.0
* [`bb2c5a36`](https://github.com/NixOS/nixpkgs/commit/bb2c5a3684a5b7240c7104a095077947029319b7) nixosOptionsDoc: Make appendix tag optional
* [`e40d2099`](https://github.com/NixOS/nixpkgs/commit/e40d2099d235f80aa3444b7a76028c0b7725a549) doc: Add Nixpkgs config options reference
* [`9252a7da`](https://github.com/NixOS/nixpkgs/commit/9252a7daa80bf81e76bf826caef8cb6dd08b1325) lib/tests/modules.sh: Fix for singular type descriptions
* [`99786f9a`](https://github.com/NixOS/nixpkgs/commit/99786f9a57a2a9a0ac680550af645dfcdbc7da29) go-modules/packages: Improve `checkFlags` handling
* [`73135fb8`](https://github.com/NixOS/nixpkgs/commit/73135fb85dea9c796207ac1aba95b27c870263d6) nixos/nebula: Always restart
* [`3c746671`](https://github.com/NixOS/nixpkgs/commit/3c7466715aa2ed6be4cc17519ab065bb659f28b5) python3Packages.cachecontrol: enable filecache
* [`de6f14d3`](https://github.com/NixOS/nixpkgs/commit/de6f14d3d855d331c8516d12b7288aa0ddcb27f3) python3Packages.pretend: enable tests
* [`b897629a`](https://github.com/NixOS/nixpkgs/commit/b897629a2c60dd602eaff6b02640d6aeec52e8e4) python3Packages.pip-api: init at 0.0.28
* [`86e49c71`](https://github.com/NixOS/nixpkgs/commit/86e49c7114f4832cc74c59d61eedfa7a9c008a5f) pip-audit: init at 2.0.0
* [`d759e894`](https://github.com/NixOS/nixpkgs/commit/d759e894b2949ca7b8cdf0bb666e6f36d95a4f8f) python310Packages.pip-api: 0.0.28 -> 0.0.29
* [`1d17d14c`](https://github.com/NixOS/nixpkgs/commit/1d17d14cb72c8a3d122827c53f6d30bd9e490314) pip-audit: 2.0.0 -> 2.2.1
* [`59b08b73`](https://github.com/NixOS/nixpkgs/commit/59b08b732acb2280ad5d26efd8e250bf3b30fbe0) Added fleaz to maintainer list
* [`a1068d91`](https://github.com/NixOS/nixpkgs/commit/a1068d919a2fdd71119f8f71f051d7cedd394cd4) r53-ddns: init at 1.0.1
* [`8b250ec5`](https://github.com/NixOS/nixpkgs/commit/8b250ec5af57b8a72b3b35c39d3f0cf12e441eab) nixos/r53-ddns: init
* [`96ed54cf`](https://github.com/NixOS/nixpkgs/commit/96ed54cfce2bedfb4551ea4d33cc2ce507998c9f) lzip: 1.22 -> 1.23, split output
* [`77c177eb`](https://github.com/NixOS/nixpkgs/commit/77c177ebe197a9de3d2a397997d70fa13d12aab4) fribidi: 1.0.11 -> 1.0.12
* [`90157969`](https://github.com/NixOS/nixpkgs/commit/90157969cf10699f9a65077fb709b8935b2612f4) python310Packages.pygments: adopt, enable tests
* [`bad010fa`](https://github.com/NixOS/nixpkgs/commit/bad010fae807f2dbf104c1cdd1c98c1d0e6b7a2d) python310Packages.wcag-contrast-ratio: init at 0.9
* [`bd9f3ec6`](https://github.com/NixOS/nixpkgs/commit/bd9f3ec6644117d80fefe2790bb12ee757ca54c6) python310Packages.pygments: 2.11.2 -> 2.12.0
* [`e4b942ec`](https://github.com/NixOS/nixpkgs/commit/e4b942eccfec761f901a3c7932495cae03ab0809) wg-quick: fix postUp always generated issue
* [`972c7e99`](https://github.com/NixOS/nixpkgs/commit/972c7e99ff692a465509604027d65c28adde3aca) Libsystem: Replace cpio with copyHierarchy
* [`7fb011df`](https://github.com/NixOS/nixpkgs/commit/7fb011df898c703c9435d28633c32b150a6680cd) Libsystem: Update headers.txt
* [`dd1e75a9`](https://github.com/NixOS/nixpkgs/commit/dd1e75a9b2cf03cb097a08de1242fb2d0006bc93) libhandy: support cross-compilation
* [`09159b20`](https://github.com/NixOS/nixpkgs/commit/09159b20889a21dcf5d0c39ffb8328da25ec6552) python3Packages.markdown: 3.3.6 -> 3.3.7
* [`509e2b49`](https://github.com/NixOS/nixpkgs/commit/509e2b499edb97f3dd0ecf1f4b69735dff0b4395) systemd: Remove accidential sysinit re-add
* [`d5beaa1a`](https://github.com/NixOS/nixpkgs/commit/d5beaa1a93ea679bc855ac89197d8cbacb60438d) python310Packages.pkgconfig: fix pkg-config not always being in PATH
* [`7e64123a`](https://github.com/NixOS/nixpkgs/commit/7e64123abd8fb23c5642e969f568b3794d8d9451) docker-credential-helpers: add meta.mainProgram for darwin
* [`ecd8d423`](https://github.com/NixOS/nixpkgs/commit/ecd8d42397d0142b9b54e1e0664acb43c146fe98) nextcloud24: init at 24.0.0
* [`72c388ee`](https://github.com/NixOS/nixpkgs/commit/72c388eed4e12a591833e3c51e419b1af678cee6) rPackages.Rhdf5lib: fix build
* [`5a3e803b`](https://github.com/NixOS/nixpkgs/commit/5a3e803bf3de0e2132e450db86c3197ccc0f02ad) glibc: 2.34-115 -> 2.34-210
* [`9d8bbb54`](https://github.com/NixOS/nixpkgs/commit/9d8bbb544b43a1ba9eac7deab92195a297a17d4d) spirv-llvm-translator: fix duplicate makeFlags merge
* [`f9eaa902`](https://github.com/NixOS/nixpkgs/commit/f9eaa902c0aedf01d476aa7eb2c040c9f9b99387) atk: 2.36.0 → 2.38.0
* [`64853939`](https://github.com/NixOS/nixpkgs/commit/648539391106a7a48abd1d3be45bb0930747984d) pango: 1.50.6 → 1.50.7
* [`92f4d121`](https://github.com/NixOS/nixpkgs/commit/92f4d121a64db24022738fa1812fb7a1b1b1a742) python3.pkgs.pygobject3: 3.42.0 → 3.42.1
* [`11a8c3e4`](https://github.com/NixOS/nixpkgs/commit/11a8c3e409f30099704d74fa349ccde948ec497a) batman-adv: 2022.0 -> 2022.1
* [`0bf838dc`](https://github.com/NixOS/nixpkgs/commit/0bf838dc6eab2a9e3d21d1a7fa758467874005bb) dgsh: mark broken
* [`ea79263e`](https://github.com/NixOS/nixpkgs/commit/ea79263e608224491030a0cdf27b9f11ecff2928) pkgs/shells: enable strictDeps
* [`4f180210`](https://github.com/NixOS/nixpkgs/commit/4f180210a094506ea9fa8f700012b993a7aed334) bash: enable strictDeps
* [`283500ed`](https://github.com/NixOS/nixpkgs/commit/283500ede38216fd0ec331d552ab7bf2198252be) python310Packages.func-timeout: init at 4.3.5
* [`34a388a7`](https://github.com/NixOS/nixpkgs/commit/34a388a7ddf77579a6030c679a8b6cff8549e48c) python310Packages.zipp: adopt, execute tests
* [`0d890670`](https://github.com/NixOS/nixpkgs/commit/0d8906702779ced65a76a38f08d16cbcfac92a1f) latencytop: fix hardcoded path to /bin/mount
* [`42091a7b`](https://github.com/NixOS/nixpkgs/commit/42091a7b8b21f591bf7af5760b55b108348d3712) autoconf213: move 'm4' and 'perl' to nativeBuildInputs (strictDeps = true)
* [`20dad991`](https://github.com/NixOS/nixpkgs/commit/20dad99154f282a4ab6e75348f7c4ed711141af7) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.4.1 -> 1.4.2
* [`e63edadf`](https://github.com/NixOS/nixpkgs/commit/e63edadf368acabccabb6377b4bc2b0eab0eda6c) python3Packages.platformdirs: 2.5.1 -> 2.5.2
* [`7d039927`](https://github.com/NixOS/nixpkgs/commit/7d0399279a6949ad4bddd95a4023ab02dc2286be) gettext: enable strictDeps
* [`6fa9cc41`](https://github.com/NixOS/nixpkgs/commit/6fa9cc41ef209ac6aa3fe6b7e6b302bc2df33349) python3Packages.rich: 12.3.0 -> 12.4.0
* [`194f81ef`](https://github.com/NixOS/nixpkgs/commit/194f81efa1aeac917ca27a1d09d9065d66ad8317) rich-cli: 1.7.0 -> 1.8.0
* [`cb8f9183`](https://github.com/NixOS/nixpkgs/commit/cb8f9183299e3c0a2aad2fa4260707dadb61a631) python310Packages.rich: 12.4.0 -> 12.4.1
* [`d9910fc9`](https://github.com/NixOS/nixpkgs/commit/d9910fc92819cc8290da84bdcddf991dacf06cf6) beets: refactor
* [`874994bc`](https://github.com/NixOS/nixpkgs/commit/874994bcb84119bbdf6588a5d565d36c320d860a) beetsPackages.beets-copyartifacts: use pytest
* [`7a2d33cd`](https://github.com/NixOS/nixpkgs/commit/7a2d33cdf342a8a2858ba267e4b17df2058b006b) beetsPackages.beets-extrafiles: use pytest
* [`c9786cfb`](https://github.com/NixOS/nixpkgs/commit/c9786cfb93a7e898e906f05d595357c37cf53ee5) beets: remove enum34
* [`efbb686d`](https://github.com/NixOS/nixpkgs/commit/efbb686d6a4f695c4248c23f5584112aae954b86) beets: don't use eval in checkPhase
* [`06b03f2e`](https://github.com/NixOS/nixpkgs/commit/06b03f2e6f46b5a1cfd8e866d010042eed8eca4e) beetsPackages: don't prepend names with beets-
* [`98a91948`](https://github.com/NixOS/nixpkgs/commit/98a9194800c6b4834f2b415a0fb7e1a67383d934) beetsPackages: fix input ordering
* [`7169abf5`](https://github.com/NixOS/nixpkgs/commit/7169abf52fedeefe18ff2517a5b6ef7bac93ad15)  python310Packages.babel: 2.9.1 -> 2.10.1  ([nixos/nixpkgs⁠#171867](https://togithub.com/nixos/nixpkgs/issues/171867))
* [`1551b57a`](https://github.com/NixOS/nixpkgs/commit/1551b57a5c66bf10dd282ecf4400da2d1a9af40f) beets: fix absubmit enable condition
* [`4317c931`](https://github.com/NixOS/nixpkgs/commit/4317c93104b4473d2482766fe867f646752dd499) rhash: Correctly set target platform when configuring
* [`1c73a077`](https://github.com/NixOS/nixpkgs/commit/1c73a0773caa843fe16ff6e31eb2fcf7c7362695) doc: clarify what a 'mass rebuild' is
* [`d954878d`](https://github.com/NixOS/nixpkgs/commit/d954878d809103dce1deef350ea476c5175af16d) autoconf: build offline html documentation ([nixos/nixpkgs⁠#172103](https://togithub.com/nixos/nixpkgs/issues/172103))
* [`4729cb69`](https://github.com/NixOS/nixpkgs/commit/4729cb69e35e67bcc0221da00953524d62402a89) SDL2: fix cross-compilation
* [`ae900be6`](https://github.com/NixOS/nixpkgs/commit/ae900be6c48393ba15bf979f49ab4d80ecf81c82) notepad-next: init at 0.5.1
* [`7d5b75b1`](https://github.com/NixOS/nixpkgs/commit/7d5b75b12ab622480ce32ae2e0801edcf23a66d3) SDL2: use wayland-scanner from PATH
* [`6eab1631`](https://github.com/NixOS/nixpkgs/commit/6eab16313f83c13a13fff652622c0e6c5317ea0b) beets: remove usage of ? null
* [`069410f9`](https://github.com/NixOS/nixpkgs/commit/069410f90b306f3b29f74eabbc2863051f3009ec) beets: document pluginOverrides
* [`bb438b6f`](https://github.com/NixOS/nixpkgs/commit/bb438b6f2ca4f1c5d62f4de1bf7e41c87f77dde8) krb5: 1.19.2 -> 1.19.3
* [`4fae05e8`](https://github.com/NixOS/nixpkgs/commit/4fae05e8d646e8b21c02c9642dce7a028c3b1279) sqlite: 3.38.3 -> 3.38.4
* [`ca55f66c`](https://github.com/NixOS/nixpkgs/commit/ca55f66c6d06e3d6d091b60a8e1fad828e710a4d) sqlite: 3.38.4 -> 3.38.5
* [`87ac2775`](https://github.com/NixOS/nixpkgs/commit/87ac2775d8723cdd636d5637502730873da1a7fc) curl: enable tests
* [`32bed4c4`](https://github.com/NixOS/nixpkgs/commit/32bed4c4554220f0ece456d4f3662fc81fafd14b) afpfs-ng: add -fcommon workaround
* [`0abc8ab4`](https://github.com/NixOS/nixpkgs/commit/0abc8ab42fbed14131dc0d1da43411a69838792f) docker-credential-gcr: 2.0.5 -> 2.1.2
* [`7ac2961e`](https://github.com/NixOS/nixpkgs/commit/7ac2961ee3e212ee69ea5176fcc28f17ba354072) terraform-inventory: 0.7-pre -> 0.10
* [`9821a425`](https://github.com/NixOS/nixpkgs/commit/9821a42565dff7adebca3a0c6620ece9b1776812) wireguard-go: 0.0.20210424 -> 0.0.20220316
* [`bbb27f8e`](https://github.com/NixOS/nixpkgs/commit/bbb27f8eb3f11b634c9dce12113407af9a290f78) spidermonkey_91: 91.8.0 -> 91.9.0
* [`f779fff0`](https://github.com/NixOS/nixpkgs/commit/f779fff0bb634fc3893712bf11380444bbf0e7e7) libnotify: 0.7.11 -> 0.7.12
* [`757ee2ed`](https://github.com/NixOS/nixpkgs/commit/757ee2ed93ad2aea8af83240af184c1a28ad0443) dbus: remove useless nulls
* [`72429cd8`](https://github.com/NixOS/nixpkgs/commit/72429cd8ea51ffac7272bb144b36939d4268ac07) microcodeIntel: 20220419 -> 20220510
* [`be4c9c60`](https://github.com/NixOS/nixpkgs/commit/be4c9c60c2e9cd447805b1cd8d0f2493d2e6f323) dbus: 1.12.20 -> 1.14.0
* [`fa7ce6bc`](https://github.com/NixOS/nixpkgs/commit/fa7ce6bc7ffb66c4a0762faa58589a3424749901) nixos/openssh: Add sntrup761x25519-sha512 kexAlgo
* [`ddf809d7`](https://github.com/NixOS/nixpkgs/commit/ddf809d7805edd0b4e5d7e5b2a957844697ff68d) beets-unstable: document limit in pluginOverrides
* [`f4499924`](https://github.com/NixOS/nixpkgs/commit/f4499924a414bebad35725815f589ed223108ef8) goawk: 1.16.0 -> 1.17.1
* [`c2b2a9ce`](https://github.com/NixOS/nixpkgs/commit/c2b2a9ce788f7760bd3148ba9b5c14267f9916e6) python310Packages.werkzeug: 2.1.0 -> 2.1.2
* [`f0e058f1`](https://github.com/NixOS/nixpkgs/commit/f0e058f1e3b74827cb3727f3d44a05709a3d593e) python310Packages.stack-data: disable failing tests
* [`45f50eb9`](https://github.com/NixOS/nixpkgs/commit/45f50eb9ac5cd038c9fc13a4519bd55f20bac2b9) python310Packages.flask: 2.1.1 -> 2.1.2
* [`e960e5c6`](https://github.com/NixOS/nixpkgs/commit/e960e5c643aad0aa94c107ac682733e16d466af1) python310Packages.click: 8.1.2 -> 8.1.3
* [`161b0839`](https://github.com/NixOS/nixpkgs/commit/161b08390f29100f7b5b29e451ce0c195e92a242) python310Packages.werkzeug: add SuperSandro2000 as maintainer
* [`d71354cc`](https://github.com/NixOS/nixpkgs/commit/d71354cca676158526ca07189e7eb98f164cdbff) python310Packages.jinja2: 3.1.1 -> 3.1.2
* [`fa93551f`](https://github.com/NixOS/nixpkgs/commit/fa93551f03f731e7fbad90edd1f22ce6c0935a74) python310Packages.pyparsing: 3.0.7 -> 3.0.9
* [`a2be0bf1`](https://github.com/NixOS/nixpkgs/commit/a2be0bf196bca07e965ea3d6df2cb96d383e2ea7) toxiproxy: 2.1.4 -> 2.4.0
* [`d538cef5`](https://github.com/NixOS/nixpkgs/commit/d538cef5a8d306384af7ed12ad6f55f054a31f50) dbus: enable strictDeps
* [`c5edd992`](https://github.com/NixOS/nixpkgs/commit/c5edd9926d07a1de54d743dbce645778dead7b13) curl: 7.83.0 -> 7.83.1
* [`e304f2f2`](https://github.com/NixOS/nixpkgs/commit/e304f2f2b03cb02f590ceffd874fc00c4add5d9e) maintainers: update oxalica's keys
* [`60e13131`](https://github.com/NixOS/nixpkgs/commit/60e13131b651d6055425bb067c0a03369c38500f) nixos/btrbk: allow instances without timers
* [`085a5256`](https://github.com/NixOS/nixpkgs/commit/085a5256c1133745b4da7bf1348afe45a7f235de) nixos/btrbk: inherit lib functions to simplify use-sites
* [`e3ec2287`](https://github.com/NixOS/nixpkgs/commit/e3ec22876e3b3e58fed5eb9f7dae6a132dd78680) python310Packages.fsspec: 2022.01.0 -> 2022.3.0
* [`49945f07`](https://github.com/NixOS/nixpkgs/commit/49945f07ccfc3dcd36ccb66a5ae37569c80e40e9) installation-cd: add more guest tools to graphical installation base
* [`eeff6c49`](https://github.com/NixOS/nixpkgs/commit/eeff6c493373d3fff11421b55309fab6a1d4ec7d) systemd: fix reproducibility of dbus interface xml
* [`ade93faa`](https://github.com/NixOS/nixpkgs/commit/ade93faa94dd7bcb43b7555d92d6d19ab1dc97a5) python39Packages.sphinx: fix reproducibility ([nixos/nixpkgs⁠#172642](https://togithub.com/nixos/nixpkgs/issues/172642))
* [`d82c0a58`](https://github.com/NixOS/nixpkgs/commit/d82c0a58790d932e99ae625b316a07dfdda4aa93) python310Packages.jsonschema: 4.4.0 -> 4.5.1
* [`bee3e742`](https://github.com/NixOS/nixpkgs/commit/bee3e742effa0932bda95f2134c8846687318a3b) go_1_17: 1.17.9 -> 1.17.10
* [`734d69a3`](https://github.com/NixOS/nixpkgs/commit/734d69a3f07095d676fc211fd0fc3a26ea63c774) kde/gear: 22.04.0 -> 22.04.1
* [`04c57e28`](https://github.com/NixOS/nixpkgs/commit/04c57e28c15a599b32704077b34eecf54ae898c4) Revert "python3Packages.napalm: disable python 3.9 onwards ([nixos/nixpkgs⁠#172643](https://togithub.com/nixos/nixpkgs/issues/172643))"
* [`75eff269`](https://github.com/NixOS/nixpkgs/commit/75eff269f76f6aa01ecc0e08a7958f80846747f2) python310Packages.netmiko: 4.0.0 -> 4.1.0
* [`e4e01fc3`](https://github.com/NixOS/nixpkgs/commit/e4e01fc34f4d0f07d13baf08fb7215151ac5fcdd) kubeseal: 0.17.0 -> 0.17.5
* [`104bc12c`](https://github.com/NixOS/nixpkgs/commit/104bc12c7395f45789ab415e5f8e9bf50c2bfa8e) nomad-pack: 2022-04-12 -> 2022-05-12
* [`75b83f42`](https://github.com/NixOS/nixpkgs/commit/75b83f425e4707408f5f45f9f92a5a3b5c3f4df9) rure: update used dependencies
* [`20a44234`](https://github.com/NixOS/nixpkgs/commit/20a44234da1778d561d20ae6a40a43d09151c386) cdpr: pull patch pending upstream inclusion for -fno-common
* [`4d602688`](https://github.com/NixOS/nixpkgs/commit/4d60268814af2037629d1115eeaff40ec5c8cb1a) mojave-gtk-theme: unstable-2021-12-20 -> 2022-05-12
* [`19d2c6f6`](https://github.com/NixOS/nixpkgs/commit/19d2c6f64d3a8e569d39f7faf44c6102c0974cd5) mojave-gtk-theme: add update script
* [`40840d78`](https://github.com/NixOS/nixpkgs/commit/40840d782048b2769885044afb0d44f4b3bdcb6d) cgminer: add -fcommon workaround
* [`954efdff`](https://github.com/NixOS/nixpkgs/commit/954efdfff3a45afd0aa74b3244a98d73a9162803) curl: disable test 1086 on darwin
* [`a679de55`](https://github.com/NixOS/nixpkgs/commit/a679de55a4d8426c690408da28b471d3347f81dc) chocolateDoom: pull upstream fix for -fno-common toolchains
* [`82a5a605`](https://github.com/NixOS/nixpkgs/commit/82a5a605899ff4b3bf4567c1e3e87eb19a131b16) dirt: pull fix pending upstream inclusion for -fno-common toolchains
* [`93332c27`](https://github.com/NixOS/nixpkgs/commit/93332c27798a61fadf03a12f59980ad9efd5c218) CrystFEL: init at 0.10.1
* [`06da97fc`](https://github.com/NixOS/nixpkgs/commit/06da97fc3a753e0bbebc03ebd63bb1bde2cdda03) lib.types.functionTo: Support type merging
* [`062bc5e7`](https://github.com/NixOS/nixpkgs/commit/062bc5e74a8905d5f1b8573155c558a4d56e55d4) lib.types.functionTo: Add pseudo-attr to generated docs
* [`81a0a8be`](https://github.com/NixOS/nixpkgs/commit/81a0a8be297a88f338ee0fd90c330cd94b4a55bd) lib/tests/modules: Test functionTo submodule merging too
* [`833884de`](https://github.com/NixOS/nixpkgs/commit/833884de60dc28084a3fc7177a4152094f06412a) clamav: 0.103.5 -> 0.103.6
* [`21073940`](https://github.com/NixOS/nixpkgs/commit/210739403a8cfb40f236ea3104dd7096d98193d1) tpmmanager: fix hash
* [`3fc4607b`](https://github.com/NixOS/nixpkgs/commit/3fc4607b5eeff24fe5f1e0d9c53850b4c14f3655) plasma5Packages.kimageformats: enable HEIF/HEIC
* [`aee00ac4`](https://github.com/NixOS/nixpkgs/commit/aee00ac405cbafc234e6b8f0b5e60f9cb5d9914e) jasmin-compiler: 21.0 → 2022.04.0
* [`51986f99`](https://github.com/NixOS/nixpkgs/commit/51986f995e31fb99a5a98469fdee17b86106f760) R: unpin JDK
* [`e77fead6`](https://github.com/NixOS/nixpkgs/commit/e77fead6c7b7a98ea8c474baec81b1e5d5765578) autospotting: unstable-2018-11-17 -> unstable-2022-02-17
* [`41367716`](https://github.com/NixOS/nixpkgs/commit/413677164db94baa1d395b3eef7efae793ea1378) diffoscopeMinimal: move libcaca to bloat to remove graphics libraries from runtime
* [`0c9a754a`](https://github.com/NixOS/nixpkgs/commit/0c9a754a6ccac679c69fc433816a4d8730bd241d) prometheus: fix build when all service discovery plugins are disabled
* [`1d447b0a`](https://github.com/NixOS/nixpkgs/commit/1d447b0a21f1f7c4aec098fb261b3b9ef97fa4b4) dlib: 19.23 -> 19.24
* [`4db7ee21`](https://github.com/NixOS/nixpkgs/commit/4db7ee21d700814e7fd91b0906df84ee8f02a1e4) keepassxc: 2.6.6 -> 2.7.1
* [`482aaa50`](https://github.com/NixOS/nixpkgs/commit/482aaa5029c23c94281cd82c047ddc61b2aeadf9) fx: 22.0.10 → 24.0.0
* [`4a6744b2`](https://github.com/NixOS/nixpkgs/commit/4a6744b2b210d1f04d354aa31a638a172a6d70f0) proxychains-ng: install default config, zsh completion
* [`dac34551`](https://github.com/NixOS/nixpkgs/commit/dac345515807018ee89d46b510073788b4ba7cf4) disk_indicator: unstable-2014-05-19 -> unstable-2018-12-18
* [`4a18eff4`](https://github.com/NixOS/nixpkgs/commit/4a18eff46c5969ae81c80b47ca324fc9e1bbd6b6) tpmmanager: switch to Qt5
* [`59244e07`](https://github.com/NixOS/nixpkgs/commit/59244e07f03795ced73e904d2efdc02b0a7ee8ca) nixos/nextcloud: Add option for max-age HSTS directive
* [`6eb4f210`](https://github.com/NixOS/nixpkgs/commit/6eb4f210a5b7871329f4dda239110fb840fbb1d6) http-parser: fix i686 build
* [`be97f2d5`](https://github.com/NixOS/nixpkgs/commit/be97f2d5c6526fcf9cbdd98a618ae2543ae06487) systemd-journal2gelf: unstable-20200813 -> unstable-2022-02-15
* [`7b71e142`](https://github.com/NixOS/nixpkgs/commit/7b71e1427aa68ca978ea743b2d64bce4678a1117) ua: unstable-2017-02-24 -> unstable-2021-12-18
* [`2262ecdb`](https://github.com/NixOS/nixpkgs/commit/2262ecdb5ef53fed93e4a93a4fafd66937277f0d) all-cabal-hashes: 2022-05-10T13:45:20Z -> 2022-05-14T01:13:33Z
* [`d386160e`](https://github.com/NixOS/nixpkgs/commit/d386160e75b85de0275660496c2d2ab0ea2071ab) haskellPackages: regenerate package set based on current config
* [`ab010f68`](https://github.com/NixOS/nixpkgs/commit/ab010f68fe5442e177ced608b53c31214fcf1fbf) musikcube: Fix Linux build
* [`61e21fee`](https://github.com/NixOS/nixpkgs/commit/61e21feee0816ae838361cd4611fde5f95de4625) prometheus-nginx-exporter: 0.9.0 -> 0.10.0
* [`bba2c44b`](https://github.com/NixOS/nixpkgs/commit/bba2c44b0eca4b4d9dde53481002b012aceb9bc0) oci-image-tool: remove
* [`a4593672`](https://github.com/NixOS/nixpkgs/commit/a45936728a83cca77573b21a4d0cef79b898d689) egoboo: add -fcommon workaround
* [`d45dfee2`](https://github.com/NixOS/nixpkgs/commit/d45dfee2d6b24ac6317cd7ae7f5e688a10657962) eukleides: add -fcommon workaround
* [`cb4dd421`](https://github.com/NixOS/nixpkgs/commit/cb4dd421de39233037b728a85b516ded46ef8f72) devspace: 5.18.4 -> 5.18.5
* [`72ffe3a6`](https://github.com/NixOS/nixpkgs/commit/72ffe3a604d37f8d5581c62870fe0678d9011613) _9pfs: add -fcommon workaround
* [`7a32e42b`](https://github.com/NixOS/nixpkgs/commit/7a32e42b96abe43e814575be9aced505bc86c41e) grub2: separateDebugInfo = true
* [`deaab562`](https://github.com/NixOS/nixpkgs/commit/deaab56289eed7435fd5406ef01faff403c97044) freebayes: add -fcommon workaround
* [`5ce31ec2`](https://github.com/NixOS/nixpkgs/commit/5ce31ec2fda36614a42fe80b0744da78de8a16b7) nix-fallback-paths.nix: Update to 2.8.1
* [`dee976c3`](https://github.com/NixOS/nixpkgs/commit/dee976c3d5309f0632534b10e8562c9be6328f79) icu: Remove redundant compiler overrides
* [`9eb26885`](https://github.com/NixOS/nixpkgs/commit/9eb2688533e2eda865ab9545bf0527186f5ec27a) icu: Remove icu59 and icu65
* [`ea48d036`](https://github.com/NixOS/nixpkgs/commit/ea48d0369edd463d1ed7d5ad16000e38d6711dea) python3Packages.uamqp: re-introduce darwin-fixing patch for x86_64
* [`41ce59dd`](https://github.com/NixOS/nixpkgs/commit/41ce59ddb9f851a2028a4bfa8a7659291f636ba1) pythonPackages.audible: init at 0.8.1
* [`4d5c47da`](https://github.com/NixOS/nixpkgs/commit/4d5c47daeceb3934a26b22d4af2003e2c532e022) audible-cli: init at 0.1.3
* [`4929c804`](https://github.com/NixOS/nixpkgs/commit/4929c80451ec2132a074a6e075a42efd3a2b2ddf) pe-parse: drop `no-sign-conversion` compile flag
* [`1f15388a`](https://github.com/NixOS/nixpkgs/commit/1f15388af162cfabf5f5fb7f4bc2099715ca428b) gnupg1orig: add -fcommon workaround
* [`e098c562`](https://github.com/NixOS/nixpkgs/commit/e098c562b306d2fcb3121e289d03e320930829bd) gpg-mdp: pull patch pending upstream inclusion for -fno-common toolchains
* [`85b0aa8d`](https://github.com/NixOS/nixpkgs/commit/85b0aa8d4d4a1c4c252573ef72440acc6de595d7) grafx2: add -fcommon workaround
* [`128d1385`](https://github.com/NixOS/nixpkgs/commit/128d1385b0b77c8dad4dcb93af6b6cddda9a8ccd) hping: pull patch pending upstream inclusion for -fno-common toolchain support
* [`42caad60`](https://github.com/NixOS/nixpkgs/commit/42caad601b9d6073bbb57d4a6846c5cc3c338dac) rPackages.Rhdf5lib: propagate hdf5 dependency
* [`b10eac1b`](https://github.com/NixOS/nixpkgs/commit/b10eac1b232f2e08f4ccc90aaea1fa4a25523437) Zettlr: 2.2.5 -> 2.2.6
* [`1a634cc0`](https://github.com/NixOS/nixpkgs/commit/1a634cc0577f4bf55b9556ecf8aa721c3ec865e3) treewide: remove unecessary XDG_DATA_DIRS from appimage wrapType2
* [`b431e456`](https://github.com/NixOS/nixpkgs/commit/b431e456607e79f18fea835f2c0850d0aeb937f5) system76-keyboard-configurator: init at 1.0.0
* [`cfb71b45`](https://github.com/NixOS/nixpkgs/commit/cfb71b45a0512f85e870575ed8563a5d118eed19) odoo: add update script
* [`ae72a2d3`](https://github.com/NixOS/nixpkgs/commit/ae72a2d3dd6e1b88bd1ffd7b11ace98e3e209262) odoo: 15.0.20220126 -> 15.0.20220506
* [`87889d80`](https://github.com/NixOS/nixpkgs/commit/87889d80309f2a10ac15dfdbde3a4d4200b86960) odoo: expose tests
* [`eefafb54`](https://github.com/NixOS/nixpkgs/commit/eefafb54ef3fbc0f2bf146e5fdefe75bdc154a69) nixos/upterm: additional hardening
* [`14e2c1e4`](https://github.com/NixOS/nixpkgs/commit/14e2c1e4fb972145bb2d8ed5f60a435fc3319276) nixos/upterm: fix race condition in test
* [`058fae42`](https://github.com/NixOS/nixpkgs/commit/058fae42a9503f5ba27493738d018ff0709c21a0) iftop: add -fcommon workaround
* [`1b8cc529`](https://github.com/NixOS/nixpkgs/commit/1b8cc52931949616df3292a8f4bb3677d99fa9f7) iouyap: add -fcommon workaround
* [`6a836ddf`](https://github.com/NixOS/nixpkgs/commit/6a836ddfa1e388a5724f76e6320c2dbaa2277322) goreplay: 1.1.0 -> 1.3.3
* [`77648937`](https://github.com/NixOS/nixpkgs/commit/77648937b6eba599f7021082b19fafdfb209de03) zabbixctl: unstable-2019-07-06 -> unstable-2021-05-25
* [`fd8983a4`](https://github.com/NixOS/nixpkgs/commit/fd8983a40e68a67a471bf29d2807963ec5960807) uni: init at 2.5.1
* [`6372948d`](https://github.com/NixOS/nixpkgs/commit/6372948d4b936229acfbc6c015058babe981f488) jamin: add -fcommon workaround
* [`2a78dc8e`](https://github.com/NixOS/nixpkgs/commit/2a78dc8e4b47c9ea2de8270e046eec800b13f1cf) wishlist: 0.4.0 -> 0.5.0
* [`0beb34d9`](https://github.com/NixOS/nixpkgs/commit/0beb34d91744c7c2494e5a227f791165792fbdd6) temporal: 1.15.0 -> 1.16.2
* [`50b95670`](https://github.com/NixOS/nixpkgs/commit/50b95670d2922b2f8c30a6c39a8d36fa093314fa) jfsutils: add -fcommon workaround
* [`e58ce952`](https://github.com/NixOS/nixpkgs/commit/e58ce95275ecb4db0b544892f0983309ccc13b3d) kmscube: pull upstream fix for -fno-common toolchains
* [`578e075e`](https://github.com/NixOS/nixpkgs/commit/578e075e1a4e7c457c0032efff958622d18d341c) lcdproc: pull upstream fix for fno-common toolchains
* [`09ab2aba`](https://github.com/NixOS/nixpkgs/commit/09ab2aba13e275eefb4cbb237c54847070006297) lrcalc: 1.2 -> 2.1
* [`e531fc20`](https://github.com/NixOS/nixpkgs/commit/e531fc20cdbd15dfff7169bfa9392a53b0a8e385) python3Packages.lrcalc-python: init at 2.1
* [`10b16ea5`](https://github.com/NixOS/nixpkgs/commit/10b16ea5e7e58c93781dc8f7f78e2f8621498da1) sageWithDoc: make jupyter-sphinx available for docbuild
* [`1ed0bc2b`](https://github.com/NixOS/nixpkgs/commit/1ed0bc2be357a50500ef86f5adf32134f8073a2b) makemkv: install mmccextr
* [`c1809efb`](https://github.com/NixOS/nixpkgs/commit/c1809efb1d6fbcefba0a020b3f05091a64453b24) python*Packages.azure-core: 1.23.1 -> 1.24.0, fix tests
* [`983d2a78`](https://github.com/NixOS/nixpkgs/commit/983d2a78ac916625d6e776ad1a18531c5e0fb334) linux_5_17: add hardened kernel
* [`c4a2a468`](https://github.com/NixOS/nixpkgs/commit/c4a2a468408348237712f003e09be7b0f7588a5e) networkmanager: 1.36.4 → 1.38.0
* [`c750f146`](https://github.com/NixOS/nixpkgs/commit/c750f1466d4ca483f53e2ee00d255a80c25d9abc) python3Packages.embrace: disable check phase on Darwin
* [`58bb9995`](https://github.com/NixOS/nixpkgs/commit/58bb9995a8a9f192d9e94ce842d728e8ab1d8332) haskellPackages.debian: Fix test failures for ghc 9
* [`6088824e`](https://github.com/NixOS/nixpkgs/commit/6088824eee448ea6dfda4084bd66c1326f3d2760) folly: fix build
* [`aa61d406`](https://github.com/NixOS/nixpkgs/commit/aa61d40652db53fae17fd1a3b677e4ab336296c1) python310Packages.napalm: 3.3.1 -> 3.4.1
* [`81cac41c`](https://github.com/NixOS/nixpkgs/commit/81cac41c65083b57013699752aaec74854366acd) python310Packages.geocachingapi: 0.2.1 -> 0.2.2
* [`c952517f`](https://github.com/NixOS/nixpkgs/commit/c952517f974254cd9bcd9367e8337fd861747ef8) python310Packages.pynx584: 0.6 -> 0.7
* [`399a676a`](https://github.com/NixOS/nixpkgs/commit/399a676ada6f42e1623eb038cdebb090b2c12345) gnomeExtensions.vitals: remove workaround
* [`26a87ada`](https://github.com/NixOS/nixpkgs/commit/26a87ada65c74ecab36789aaf5915f55148e1100) sage: 9.5 -> 9.6
* [`27123795`](https://github.com/NixOS/nixpkgs/commit/27123795ad29ab118455069a0af142668025b247) writeCBin: fix formatting
* [`6c0dc6d6`](https://github.com/NixOS/nixpkgs/commit/6c0dc6d621280a2a50ac3544e6f71102f0065ae0) nixos/ddclient: turn verbose off by default
* [`bf8d9545`](https://github.com/NixOS/nixpkgs/commit/bf8d954594690e9dd92df738813ad36f072777a1) kube-router: 1.2.2 -> 1.4.0
* [`b2b2282f`](https://github.com/NixOS/nixpkgs/commit/b2b2282f5d41da0db87d5bcf87aa95b9727260e9) python39Packages.sanic: fix build on darwin
* [`aee07772`](https://github.com/NixOS/nixpkgs/commit/aee07772236445705fde307ba9cfadd419d1c41c) python310Packages.pex: 2.1.87 -> 2.1.88
* [`83ac14f8`](https://github.com/NixOS/nixpkgs/commit/83ac14f820ef075bb1231ee3ec9db4b01505cd10) cinny: 2.0.2 -> 2.0.3
* [`f8e82bab`](https://github.com/NixOS/nixpkgs/commit/f8e82bab5be86899d4d4b00abaf29ee2cd21fad9) haskellPackages: regenerate package set based on current config
* [`be73a962`](https://github.com/NixOS/nixpkgs/commit/be73a96276f9a1cd1f2dfefdb3bc64dff932f434) terraform-providers: update 2022-05-16
* [`204417b2`](https://github.com/NixOS/nixpkgs/commit/204417b2a4de05c3b83ca1b74bb52fa05b886520) restool: fix x86_64-linux build
* [`0c6396c7`](https://github.com/NixOS/nixpkgs/commit/0c6396c7041e27a47469008965347011b0c88914) python310Packages.pyskyqhub: 0.1.8 -> 0.1.9
* [`57affb10`](https://github.com/NixOS/nixpkgs/commit/57affb106a7fb2c23898e5f418d34eb82275c3c5) libreddit: 0.22.6 -> 0.22.7
* [`27e96516`](https://github.com/NixOS/nixpkgs/commit/27e96516f80f38958f628688ad35b538b71de1c9) alfis: 0.7.0 -> 0.7.3
* [`33294cea`](https://github.com/NixOS/nixpkgs/commit/33294cea74a9dad4ecc919d25ecd2437f341e193) git-workspace: 0.9.0 -> 1.0.3
* [`16fc84cd`](https://github.com/NixOS/nixpkgs/commit/16fc84cd4be51376b7517f48d37811eb6ec27471) clamav: 0.103.6 -> 0.105.0
* [`6423fced`](https://github.com/NixOS/nixpkgs/commit/6423fcedb301ebdf02d9e8a8dd2af3dfdcc1455f) nixosTests.keepassxc: Simplify OCR test
* [`85558fff`](https://github.com/NixOS/nixpkgs/commit/85558fff8bcf2811f838c141be5d5ff0e75abb96) clightning: 0.11.0.1 -> 0.11.1
* [`20581e0c`](https://github.com/NixOS/nixpkgs/commit/20581e0cc9350b2bddb2b99543094372f9079ddf) python*Packages.pymdown-extensions: 9.1 -> 9.4
* [`36c7b97e`](https://github.com/NixOS/nixpkgs/commit/36c7b97ebf49d371f87851cff81a960e40df3373) python*Packages.mkdocs-material: 8.2.11 -> 8.2.15
* [`a4a51d9e`](https://github.com/NixOS/nixpkgs/commit/a4a51d9e454fae30f28b01e7d3913791b73bb157) haskellPackages.threadscope: unmark as broken, remove jailbreak
* [`681f4c49`](https://github.com/NixOS/nixpkgs/commit/681f4c49e9ca1b71e3580db619c891c07973fcaa) apache-airflow: mark broken
* [`b50d94a3`](https://github.com/NixOS/nixpkgs/commit/b50d94a3f27ce81ba39068c2450084460c627886) python*Packages.djangorestframework: add missing dependency
* [`a4c0d2b3`](https://github.com/NixOS/nixpkgs/commit/a4c0d2b344721ad37667776ba5388271ca756e01) netbox: fix build, drop overrides, update Django
* [`016facb8`](https://github.com/NixOS/nixpkgs/commit/016facb869ed894692bee9963d580d77b45d146b) hyperkitty: backport patch fixing Python 3.10 support
* [`3458d4cf`](https://github.com/NixOS/nixpkgs/commit/3458d4cf89e2f789197c7e3dbf2e3fd0f052ba1b) installation-cd: remove broken virtualbox module
* [`f6cede3f`](https://github.com/NixOS/nixpkgs/commit/f6cede3f93211d64e63848ca06d805006d86da6a) python310Packages.pycep-parser: 0.3.4 -> 0.3.5
* [`2a1e7026`](https://github.com/NixOS/nixpkgs/commit/2a1e70262867c80f331749c4c9e02670b93364b4) drone: 2.11.1 -> 2.12.0
* [`30f0af5f`](https://github.com/NixOS/nixpkgs/commit/30f0af5f6abb06174325151e9ede005b0305ae87) systemfd: 0.3.0 -> 0.4.0
* [`b43b2856`](https://github.com/NixOS/nixpkgs/commit/b43b28568ff35d9896476bb14a5542ac6f88ba8d) cocoapods: 1.11.0 -> 1.11.3
* [`29bccd95`](https://github.com/NixOS/nixpkgs/commit/29bccd95f778fae365a6af72c326187f0a79e6f8) tilt: 0.26.3 -> 0.30.0 ([nixos/nixpkgs⁠#173252](https://togithub.com/nixos/nixpkgs/issues/173252))
* [`a23fbeb6`](https://github.com/NixOS/nixpkgs/commit/a23fbeb6e8d5c7f35c9feba25da0061ebcf79efe) testers.testVersion: if grep failed then print the output of the command
* [`7ac64fcb`](https://github.com/NixOS/nixpkgs/commit/7ac64fcbae91104edc2d3505302f4b8064e4665d) pjsip: 2.12 -> 2.12.1
* [`3e789af2`](https://github.com/NixOS/nixpkgs/commit/3e789af26cb39c8e25678616c184579532562058) bullet: 3.22b -> 3.23
* [`b5f228c8`](https://github.com/NixOS/nixpkgs/commit/b5f228c836aa88a73f94e89ef830ad9ad427f56d) emscriptenStdenv: fix cache location
* [`0340075c`](https://github.com/NixOS/nixpkgs/commit/0340075cc6a0e2c97e61abc6d0b11a02ede5ddd1) emscriptenPackages.zlib: use emscriptenStdenv
* [`d1e5ca20`](https://github.com/NixOS/nixpkgs/commit/d1e5ca2014084a50807ccc1003711b6be0fb5928) mpc-qt: 2019-06-09 -> 22.02
* [`0f42a04e`](https://github.com/NixOS/nixpkgs/commit/0f42a04eb04fbcfd6df50930a739bb1e67effd2a) nitter: compile markdown
* [`8ef6c2bb`](https://github.com/NixOS/nixpkgs/commit/8ef6c2bbf8e22216610cd6e935f424ccea759db4) nitter: unstable-2022-03-21 -> unstable-2022-05-13
* [`560ca022`](https://github.com/NixOS/nixpkgs/commit/560ca02280cea47c8ad70dd0aeadd667bc55a5c2) nixos/nitter: update example configuration file URL
* [`c4fe785a`](https://github.com/NixOS/nixpkgs/commit/c4fe785aa5a6352445eddab15764c59c56897fbc) logseq: 0.6.8 -> 0.6.9
* [`d32f6e65`](https://github.com/NixOS/nixpkgs/commit/d32f6e65a48b3844d3dabc834f3f973e5377773f) bats: 1.6.0 -> 1.7.0
* [`f52c4ffe`](https://github.com/NixOS/nixpkgs/commit/f52c4ffe0827be01aaee2dbd6802b953e53772b5) cocoapods: fix deprecation about Gemfile
* [`fdf08063`](https://github.com/NixOS/nixpkgs/commit/fdf08063866138def7a5f6615cb71bb505b31ffc) root5: fix build with recent gcc
* [`4c0c8ac7`](https://github.com/NixOS/nixpkgs/commit/4c0c8ac7fe0caca8655e2e75807bac1a4cf0fbe6) rc: fixup build
* [`0659e76d`](https://github.com/NixOS/nixpkgs/commit/0659e76d17ec294b07bd78e6f071ef360b89b73d) ocamlPackages.merlin: 4.4 → 4.5
* [`4f45341b`](https://github.com/NixOS/nixpkgs/commit/4f45341b0d9f2ffb2e45a6561aef595e5e11fcef) n8n: 0.176.0 → 0.177.0
* [`b8135edb`](https://github.com/NixOS/nixpkgs/commit/b8135edb7c65729a21adc70c5dd63c3d20140bcb) bluez-tools: unstable-2016-12-12 -> unstable-2020-10-24
* [`3133e29f`](https://github.com/NixOS/nixpkgs/commit/3133e29fcefe0b619eaa8d951ad21294b3358a03) linux_xanmod: 5.15.35 -> 5.15.40
* [`fe151054`](https://github.com/NixOS/nixpkgs/commit/fe151054ff804eae5e99ee19cb86a024704465f1) linux_xanmod_latest: 5.17.4 -> 5.17.8
* [`336ee6b1`](https://github.com/NixOS/nixpkgs/commit/336ee6b108ec2d004c9bd322220b189d0370b022) xanmod-kernels: make myself a maintainer
* [`bb17d93a`](https://github.com/NixOS/nixpkgs/commit/bb17d93a56ae3bc47255c6f2136f56afee87d231) zoom-us: 5.9.6.2225 -> 5.10.4.2845 on x86_64-linux
* [`5791f1c4`](https://github.com/NixOS/nixpkgs/commit/5791f1c43f97a00ed4c6daf2394e759448620636) zoom-us: Update dependencies
* [`215155b4`](https://github.com/NixOS/nixpkgs/commit/215155b44065e6b2652535f720fa04ac20e8980f) zoom: add dep for udev, fix launching
* [`fa585a07`](https://github.com/NixOS/nixpkgs/commit/fa585a07f65f4ee954758c67db6c75463a6f6560) zoom-us: change wrapper name to fix IPC
* [`810f5b99`](https://github.com/NixOS/nixpkgs/commit/810f5b99a41192a49674b77a9edebb16d1013be9) plex: 1.26.0.5715-8cf78dab3 ->1.26.1.5798-99a4a6ac9
* [`19c42b88`](https://github.com/NixOS/nixpkgs/commit/19c42b883f668d17ac8670c19707c6dd9e7bd28b) trivy: 0.27.1 -> 0.28.0
* [`49f02552`](https://github.com/NixOS/nixpkgs/commit/49f025520c03a77b318c9a5338ec9fdecc69da4c) python310Packages.azure-core: update disabled
* [`a30a3442`](https://github.com/NixOS/nixpkgs/commit/a30a34427c7235706164054394b3a5a628952a96) Revert "libpcap: move dev things to extra output"
* [`cbf36994`](https://github.com/NixOS/nixpkgs/commit/cbf3699448d0c65b7f364fa0396b6b7a8ab04e5c) python310Packages.twentemilieu: 0.6.0 -> 0.6.1
* [`d06d9330`](https://github.com/NixOS/nixpkgs/commit/d06d9330c4a68915705a9dd898e12f664b05019c) python310Packages.django-anymail: 8.5 -> 8.6
* [`6ecb4d7c`](https://github.com/NixOS/nixpkgs/commit/6ecb4d7c4310a223fdfcd2ac7d92d4b72f2a001a) python310Packages.pylsp-mypy: 0.5.7 -> 0.5.8
* [`c0d95d28`](https://github.com/NixOS/nixpkgs/commit/c0d95d280928e3536321ea4abdc89eff2b7e38bb) python3Packages.cheroot: disable failing test on Darwin
* [`9430c997`](https://github.com/NixOS/nixpkgs/commit/9430c997887c4d5da77ce8fc426ba7d40e1b23ef) python3Packages.pywlroots: 0.15.13 -> 0.15.14
* [`2d1048a3`](https://github.com/NixOS/nixpkgs/commit/2d1048a3d1ddbfb1681359ea874438b038acc439) python310Packages.manuel: 1.10.1 -> 1.11.2
* [`df9525d8`](https://github.com/NixOS/nixpkgs/commit/df9525d89ab5a9455ad79a94478c22ed57e55f4d) python3Packages.gcal-sync: 0.7.1 -> 0.8.0
* [`93b45825`](https://github.com/NixOS/nixpkgs/commit/93b45825ddaff290ab9c885c6d2393725a91fbe7) python3.pkgs.ijson: enable yail backend
* [`19c5dc94`](https://github.com/NixOS/nixpkgs/commit/19c5dc94fa86077771111e30c1e2fbce60fdcb9c) python3Packages.pikepdf: 5.1.2 -> 5.1.3
* [`4783e24e`](https://github.com/NixOS/nixpkgs/commit/4783e24e0cffb6dd124f01c85b95be1d703c556e) python310Packages.torchmetrics: 0.8.1 -> 0.8.2
* [`dfc19305`](https://github.com/NixOS/nixpkgs/commit/dfc193057c3e7b414b21c43f860efe8e93228969) python3Packages.ocrmypdf: 13.4.3 -> 13.4.4
* [`72cb3780`](https://github.com/NixOS/nixpkgs/commit/72cb3780a57881aa2fc5e2268380d85de7ea2b4c) python310Packages.dulwich: 0.20.35 -> 0.20.36
* [`d9c2f003`](https://github.com/NixOS/nixpkgs/commit/d9c2f0036d866dd0cdebd2296a9e06c78aeefaed) jameica 2.10.1 -> 2.10.2
* [`f150888d`](https://github.com/NixOS/nixpkgs/commit/f150888da6699b4f6215e9bd25d1074c4e756508) coqPackages.interval: 4.4.0 -> 4.5.1
* [`4a1f7f84`](https://github.com/NixOS/nixpkgs/commit/4a1f7f84724ef242d5ec9faa25081d558c79be08) buildMozillaMach: fix builds with crash reporting disabled
* [`89c3a254`](https://github.com/NixOS/nixpkgs/commit/89c3a254458324999c77eb619ba6ea165bc4f468) gnome3.adwaita-icon-theme: reduce build parallelism
* [`0b02135d`](https://github.com/NixOS/nixpkgs/commit/0b02135d3bdf49f9154f60e7a4c9d54d5e0ee70d) nixosOptionsDoc: refactor
* [`999b8268`](https://github.com/NixOS/nixpkgs/commit/999b8268c87df8eb4f77e47c5f68f42ab06976d3) gitea: 1.16.7 -> 1.16.8
* [`9a1264ca`](https://github.com/NixOS/nixpkgs/commit/9a1264cab0c050355dbf787bd595ee37188d1b33) invidious.lsquic.boringssl: fix gcc11 build
* [`0369625a`](https://github.com/NixOS/nixpkgs/commit/0369625a8225d1734a617f3e39144bc8666c00b3) invidious: use UTC for version in update script
* [`1305a10b`](https://github.com/NixOS/nixpkgs/commit/1305a10b290b7f20e6b228836628bb1313d6890a) invidious: unstable-2022-03-16 -> unstable-2022-05-11
* [`a70d6ad8`](https://github.com/NixOS/nixpkgs/commit/a70d6ad88c8a26c477eaf3ca25be611cf4bc9ceb) terraform-providers: update scripts
* [`be028357`](https://github.com/NixOS/nixpkgs/commit/be028357e3124d2ef2aa2f5286fc717dca922494) terraform-providers.github: 4.25.0-alpha -> 4.24.1
* [`89e46a17`](https://github.com/NixOS/nixpkgs/commit/89e46a1779f55a5f4606516a0ca14cd16c5408cd) terraform-providers.metal: 3.3.0-alpha.3 -> 3.2.2
* [`380b50c0`](https://github.com/NixOS/nixpkgs/commit/380b50c0ade0fa67cfbc3bc94039ad6570d09b33) podofo: 0.9.7 -> 0.9.8
* [`ff691ed9`](https://github.com/NixOS/nixpkgs/commit/ff691ed9ba21528c1b4e034f36a04027e4522c58) nixos/gdm: Fix missing icons
* [`28c3b331`](https://github.com/NixOS/nixpkgs/commit/28c3b33165b32a63693b6577e97246f9e58c7dca) lightwalletd: 0.4.9 -> 0.4.10
* [`669283f0`](https://github.com/NixOS/nixpkgs/commit/669283f06a78741ac640f0700e06794ef7db4cc0) python3Packages.ansible-core: 2.12.5 -> 2.13.0
* [`592a99ec`](https://github.com/NixOS/nixpkgs/commit/592a99ec9ba01612a39799e247ae41ed7b415ba2) mutt: split documentation into separate outputs
* [`dd96e9f5`](https://github.com/NixOS/nixpkgs/commit/dd96e9f5676382ba412d371d03067b300d2b3d54) git-sync: unstable-2021-07-14 -> unstable-2022-03-20
* [`aaa12217`](https://github.com/NixOS/nixpkgs/commit/aaa1221775b090c09f49b985380474f427836a64) python310Packages.types-requests: 2.27.25 -> 2.27.26
* [`0644f259`](https://github.com/NixOS/nixpkgs/commit/0644f25938d8857a6d02022ff5ab6233da99f6ec) pantheon.switchboard-plug-onlineaccounts: 6.4.0 -> 6.5.0
* [`1c78ce70`](https://github.com/NixOS/nixpkgs/commit/1c78ce70fa4811a0a6a074e0fdc2c7f18c7b36fd) xfitter: fix for gfortran10+
* [`cdbb3a70`](https://github.com/NixOS/nixpkgs/commit/cdbb3a70bb4502d36a21039e149e3421212fcec3) python310Packages.herepy: 3.5.7 -> 3.5.8
* [`1a174767`](https://github.com/NixOS/nixpkgs/commit/1a1747677efe715c2143d3f0e82a79a91c144b85) python310Packages.graphtage: 0.2.5 -> 0.2.6
* [`889bb1a1`](https://github.com/NixOS/nixpkgs/commit/889bb1a1aa82d7ec5ddaa0164c3add8be6a9bb10) python3Packages.pandas: remove unused commands
* [`1c802f3b`](https://github.com/NixOS/nixpkgs/commit/1c802f3bfa5324d7915dad3dc2e41234526a2f78) python310Packages.cachelib: 0.6.0 -> 0.7.0
* [`403d5ae1`](https://github.com/NixOS/nixpkgs/commit/403d5ae1a6be960874183c5c824dce5fc7b60e18) j: 902-release-b -> 904-beta-c
* [`ea940467`](https://github.com/NixOS/nixpkgs/commit/ea940467508243aee5b0efd83ecd33abe5372d70) addic7ed-cli: move to top-level
* [`5b7e1045`](https://github.com/NixOS/nixpkgs/commit/5b7e1045c653867d542203099f6ce14ecc9aae06) python310Packages.mt-940: 4.23.0 -> 4.26.0
* [`5da9a690`](https://github.com/NixOS/nixpkgs/commit/5da9a6908336b383b84df9adbe94801ab76ec370) python310Packages.numpy-stl: 2.16.3 -> 2.17.0
* [`3c2e95f4`](https://github.com/NixOS/nixpkgs/commit/3c2e95f4f02f492d93067e21a619e8e3ee2a0dfe) python3Packages.pyrfxtrx: 0.28.0 -> 0.29.0
* [`91a9c5a9`](https://github.com/NixOS/nixpkgs/commit/91a9c5a9beb0028d2d556c2f3cd39f17d8bc8c2f) git-ignore: 1.1.1 -> 1.2.0
* [`c1436e20`](https://github.com/NixOS/nixpkgs/commit/c1436e20bfbd8d3dd62d8ee591cbd25c99d02db7) git-ignore: install shell completions
* [`8eb3f281`](https://github.com/NixOS/nixpkgs/commit/8eb3f281dc1bd1a0599d29eca38e9bd9cfae3590) python310Packages.poetry-dynamic-versioning: 0.16.0 -> 0.17.0
* [`6e8aeecd`](https://github.com/NixOS/nixpkgs/commit/6e8aeecde41f3cef17edb912085dd69511cbf43e) tilt: mark broken on x86_64 Darwin
* [`8e4f7c9d`](https://github.com/NixOS/nixpkgs/commit/8e4f7c9d5168449ef5925f68a25d740de67e121b) python310Packages.fastcore: 1.4.2 -> 1.4.3
* [`f07c969b`](https://github.com/NixOS/nixpkgs/commit/f07c969b8d083c0b3fa57726c961d33c39c5734b) rPackages: CRAN and BioC update
* [`8cd45ee3`](https://github.com/NixOS/nixpkgs/commit/8cd45ee35f1772860dd8e82d9b09e5d96276e82b) sumneko-lua-language-server: 3.2.1 -> 3.2.3
* [`4571db9a`](https://github.com/NixOS/nixpkgs/commit/4571db9a8845176195b00df3028d6b02adde7325) sumneko-lua-language-server: disable cwd support only on x86-darwin
* [`a5f35137`](https://github.com/NixOS/nixpkgs/commit/a5f35137c86d0cc66c57ee5ec67d08c9acdf00b5) nodejs-14_x: 14.19.2 -> 14.19.3
* [`0fb4d8c4`](https://github.com/NixOS/nixpkgs/commit/0fb4d8c4b24a816fda8a184b73dfc18369b75047) nodejs-18_x: 18.1.0 -> 18.2.0
* [`0f2efa91`](https://github.com/NixOS/nixpkgs/commit/0f2efa91a6b70089b92480ba613571e92322f753) nodejs-17_x: drop
* [`55f38ee6`](https://github.com/NixOS/nixpkgs/commit/55f38ee6ab5cd7871a76af156d3874d39b8d2486) python310Packages.hatchling: 0.24.0 -> 0.25.0
* [`9a312725`](https://github.com/NixOS/nixpkgs/commit/9a312725c171304a4692ce73986e7a66cb064ddd) protoc-gen-go-vtproto: 0.2.0 -> 0.3.0
* [`277f39af`](https://github.com/NixOS/nixpkgs/commit/277f39afc9ced4db8120d236017c2f2659e4a35d) gnomeExtensions.dash-to-dock: 71+date=2022-02-23 → 72
* [`7bd68b1d`](https://github.com/NixOS/nixpkgs/commit/7bd68b1df6456c11973ff3ec736e9c70721c5603) link-grammar: 5.10.2 → 5.10.4
* [`434f417e`](https://github.com/NixOS/nixpkgs/commit/434f417e2c9a939b22409788f6d8b172d31d10ce) xdg-dbus-proxy: 0.1.3 → 0.1.4
* [`495d1e94`](https://github.com/NixOS/nixpkgs/commit/495d1e946a196e8df7c95d6d54efaed4f78e0d27) matterbridge: 1.25.0 -> 1.25.1
* [`14661c38`](https://github.com/NixOS/nixpkgs/commit/14661c38b291f10e77d690ecf9f40a5aecadd971) signalbackup-tools: 20220430 -> 20220517
* [`7d85b91e`](https://github.com/NixOS/nixpkgs/commit/7d85b91eba6bafd180965ef94d221474ce41dead) discount: 2.2.7 -> 2.2.7b
* [`365be2ab`](https://github.com/NixOS/nixpkgs/commit/365be2abe0dcecf064a40745c688a11939118b5d) pulseeffects-legacy: drop myself from maintainers
* [`9cdd4e03`](https://github.com/NixOS/nixpkgs/commit/9cdd4e03aecc332128f61bdb26364cebc0be0e7c) python310Packages.pg8000: 1.26.1 -> 1.27.1
* [`45a97a57`](https://github.com/NixOS/nixpkgs/commit/45a97a571bf6ad98a5b31267aed4751672484014) sketchybar: 2.5.0 -> 2.5.2
* [`c4d5cc1e`](https://github.com/NixOS/nixpkgs/commit/c4d5cc1e73c838fbf5734d78f1b55141667b2710) python310Packages.bugsnag: 4.2.0 -> 4.2.1
* [`4b0da188`](https://github.com/NixOS/nixpkgs/commit/4b0da1885ff972d4680ae192fcaec333fdfb862f) ocamlPackages.easy-format: 1.3.2 → 1.3.3
* [`5d483e4d`](https://github.com/NixOS/nixpkgs/commit/5d483e4d3b9b3fdf6c66273f0405a8af3c13cd66) python310Packages.azure-multiapi-storage: 0.8.0 -> 0.9.0
* [`73fe05a5`](https://github.com/NixOS/nixpkgs/commit/73fe05a563411225e9cb9c8170c24196b03e6c1f) nodePackages: add meta.mainProgram to packages with multiple executables
* [`36684377`](https://github.com/NixOS/nixpkgs/commit/36684377024b22c0cab2690623b408077f6db83a) mautrix-whatsapp: 0.3.1 -> 0.4.0
* [`9d4a9f13`](https://github.com/NixOS/nixpkgs/commit/9d4a9f13969c93d30744c23221da0e5229253ff4) mautrix-whatsapp: add myself as a maintainer
* [`3d115ff0`](https://github.com/NixOS/nixpkgs/commit/3d115ff0e981e716074d8b22f21f12491513b4fc) syft: 0.45.1 -> 0.46.1
* [`fb4fc93a`](https://github.com/NixOS/nixpkgs/commit/fb4fc93a3eacab755184924ae7bbb3d1e28e5575) Remove mkDefault
* [`83523b81`](https://github.com/NixOS/nixpkgs/commit/83523b81152536eaa35d409cfe6e0a1da80cef94) konstraint: 0.19.1 -> 0.20.0
* [`d9d59c3e`](https://github.com/NixOS/nixpkgs/commit/d9d59c3ec60f0d834be0aa5fa9910fa6ec9831af) python310Packages.azure-mgmt-recoveryservicesbackup: 4.2.0 -> 5.0.0
* [`47fabead`](https://github.com/NixOS/nixpkgs/commit/47fabead8086049aa278cacc3c6c5d0de84d386b) light: pull upstream fix for -fno-common toolchains
* [`2cdca032`](https://github.com/NixOS/nixpkgs/commit/2cdca0320d8cabc00522f5e7026cfbc3677ca0d0) hubicfuse: pull upstream fix for -fno-common tollchains
* [`fdf74c77`](https://github.com/NixOS/nixpkgs/commit/fdf74c7741465d8d1da7a910cd17d38068c74ff1) maintainers/create-amis.sh: Add more AWS regions
* [`6fd83b70`](https://github.com/NixOS/nixpkgs/commit/6fd83b70a9f8fdecc27f2ac08d876ac21b6121b2) libfpx: pull upstream fix for -fno-common toolchains
* [`cc60c249`](https://github.com/NixOS/nixpkgs/commit/cc60c24909a8b207a0a2dfc18082453ab85c46af) openssl: disable ct feature in static mode ([nixos/nixpkgs⁠#173288](https://togithub.com/nixos/nixpkgs/issues/173288))
* [`e11568dd`](https://github.com/NixOS/nixpkgs/commit/e11568dd9cfccfeb1267199feafea247f444848e) Revert "Merge [nixos/nixpkgs⁠#171177](https://togithub.com/nixos/nixpkgs/issues/171177): go-modules/packages: Improve `checkFlags` handling"
* [`429ab766`](https://github.com/NixOS/nixpkgs/commit/429ab766c3c8576c81212d6208821dfd2e18617c) nerdctl: 0.19.0 -> 0.20.0
* [`83ebd8c5`](https://github.com/NixOS/nixpkgs/commit/83ebd8c52efcc40d070051226a1ddde24b7314dd) libnih: remove
* [`267af27a`](https://github.com/NixOS/nixpkgs/commit/267af27a65aaecf8eb453df89ddc460933765216) mpd: enable NFS support on Darwin
* [`2ab133d4`](https://github.com/NixOS/nixpkgs/commit/2ab133d4884839d3b83e8c314e279777b6d8b269) libprom: add -fcommon workaround
* [`d78f6771`](https://github.com/NixOS/nixpkgs/commit/d78f67717331fbb34a89abf339fab7eb6aecc0b6) liquidwar5: add -fcommon workaround
* [`960e4371`](https://github.com/NixOS/nixpkgs/commit/960e437185ccdd5b0cbe66c496a405bee1223d1e) python310Packages.pg8000: 1.27.1 -> 1.28.0
* [`de3d4f43`](https://github.com/NixOS/nixpkgs/commit/de3d4f4369ba73bf69087f102a9515d141f06b7e) lrs: 7.0 -> 7.2
* [`a44de153`](https://github.com/NixOS/nixpkgs/commit/a44de15349c324c01145e8c22ff38334bcdf138c) vlang: 2022.19 -> 2022.20
* [`3cd44791`](https://github.com/NixOS/nixpkgs/commit/3cd447916cfded86ea7431c6736ae2ea5bc615e7) python310Packages.ansible-compat: 2.0.3 -> 2.0.4
* [`af4488d9`](https://github.com/NixOS/nixpkgs/commit/af4488d9c5588ca8f27cffd22834dca75eb62aaa) witness: 0.1.7 -> 0.1.8
* [`80813d57`](https://github.com/NixOS/nixpkgs/commit/80813d573ac07683ccc9574124719049e30ba985) stripe-cli: 1.8.8 -> 1.8.11
* [`51c86e49`](https://github.com/NixOS/nixpkgs/commit/51c86e49d8212ad2ce1109379eea2800b2cb3a58) opentelemetry-collector-contrib: 0.47.0 -> 0.51.0
* [`ae3e4d22`](https://github.com/NixOS/nixpkgs/commit/ae3e4d2201abb0fec7929095e1a1ae2feef69f01) opentelemetry-collector: 0.47.0 -> 0.51.0
* [`13d03f19`](https://github.com/NixOS/nixpkgs/commit/13d03f19adc18650d2da1784b037abc601cc2257) dump_syms: fix build on darwin
* [`3b4cbaaa`](https://github.com/NixOS/nixpkgs/commit/3b4cbaaa02d6c027870959cb35d2e3ecc85f1497) dune_3: 3.1.1 -> 3.2.0
* [`e2806be7`](https://github.com/NixOS/nixpkgs/commit/e2806be7e9786d9f51dfbf4377b2a49e9f597e5c) python310Packages.bc-python-hcl2: 0.3.39 -> 0.3.40
* [`3cec1627`](https://github.com/NixOS/nixpkgs/commit/3cec1627e2c4336b3e854b0f6f7f83832e256126) checkov: 2.0.1140 -> 2.0.1143
* [`530f1da4`](https://github.com/NixOS/nixpkgs/commit/530f1da4453e5fd4e61562401742f2fc0dafcd0f) driftctl: 0.29.0 -> 0.30.0
* [`998f7e66`](https://github.com/NixOS/nixpkgs/commit/998f7e66b00d2752d133c6079ac3e16291e12b06) python310Packages.cvxpy: 1.2.0 -> 1.2.1
* [`8896e8d3`](https://github.com/NixOS/nixpkgs/commit/8896e8d373ca125d227333e069053821451efa65) imagemagick: 7.1.0-33 -> 7.1.0-34
* [`1f02ea4c`](https://github.com/NixOS/nixpkgs/commit/1f02ea4ccc436d4e0cac1e41d88ecb9ae275774c) cl-wordle: 0.4.0 -> 0.5.0
* [`8c47c1d8`](https://github.com/NixOS/nixpkgs/commit/8c47c1d8f8f4e5a633c96a8b1b8c796dda14e88c) python310Packages.pubnub: 6.3.1 -> 6.3.2
* [`de7fd4e7`](https://github.com/NixOS/nixpkgs/commit/de7fd4e7f02772285d369cc66a7783ec6d7942d7) bottles: 2022.5.2-trento-2 -> 2022.5.14-trento-1
* [`bf3dca0b`](https://github.com/NixOS/nixpkgs/commit/bf3dca0b580f40c4ab4ff24d0f8c7975a910246e) python310Packages.dulwich: 0.20.36 -> 0.20.38
* [`75021339`](https://github.com/NixOS/nixpkgs/commit/75021339971840c0f34b890e368dbfca10173d83) nixos/locate: clarification in warning message ([nixos/nixpkgs⁠#173247](https://togithub.com/nixos/nixpkgs/issues/173247))
* [`42fd630f`](https://github.com/NixOS/nixpkgs/commit/42fd630fe77aad9f882c7a96c720b6ed4c08542f) proxychains: install default config
* [`293b1a9a`](https://github.com/NixOS/nixpkgs/commit/293b1a9afdf325bd44aad9974dbe420366d37a47) python310Packages.humanize: 4.0.0 -> 4.1.0
* [`8c53d653`](https://github.com/NixOS/nixpkgs/commit/8c53d65350e6c176a5ebddec3c2f2917b73b6573) icinga2: 2.13.2 -> 2.13.3
* [`382f515d`](https://github.com/NixOS/nixpkgs/commit/382f515dae52e9b3fa966c17d2dbe919c3b94b2f) icingaweb2-ipl: 0.8.0 -> 0.8.1
* [`8734e42b`](https://github.com/NixOS/nixpkgs/commit/8734e42bf15533fe4f2cde24ea5ee0246024355d) fontforge: remove obsolete comment
* [`4ae5670e`](https://github.com/NixOS/nixpkgs/commit/4ae5670eaa7dce6e82d5e0a5b49a97ac7023ccce) rust-analyzer: 2022-05-02 -> 2022-05-17
* [`3d2fd9ab`](https://github.com/NixOS/nixpkgs/commit/3d2fd9ab51f74e113aa6a5a704676b4fe3854df1) lsh: add -fcommon workaround
* [`3286faa7`](https://github.com/NixOS/nixpkgs/commit/3286faa7e5e4ee65468521cf61d0da654dd2890b) matchbox: pull upstream fix fo -fno-common toolchains
* [`6f0d3c8e`](https://github.com/NixOS/nixpkgs/commit/6f0d3c8ec71dfca5a6bde1d57d85bd48483476ad) drawio: 18.0.4 -> 18.0.6
* [`ab8a7cae`](https://github.com/NixOS/nixpkgs/commit/ab8a7cae2c0eb3be8bf0175f9f53affd193983fa) nixos/nextcloud: remove unneeded `log_level`-param
* [`a52b6401`](https://github.com/NixOS/nixpkgs/commit/a52b64015a8853e0eeebfa534e3860d013a697b9) snakemake: 7.6.2 -> 7.7.0
* [`744ca87e`](https://github.com/NixOS/nixpkgs/commit/744ca87ed01ef0ee02e62c12340c1071351e561f) npins: Init at 0.1.0
* [`73714678`](https://github.com/NixOS/nixpkgs/commit/73714678f13f0e8e5cf043d51afcf23e5c18943b) trying to fix darwin build
* [`5cf446f4`](https://github.com/NixOS/nixpkgs/commit/5cf446f41b400d9a209144b385460766778b787a) ezminc: mark broken
* [`178aaa60`](https://github.com/NixOS/nixpkgs/commit/178aaa60f1d179a4351f7d8f5b5403bc1d756992) rust-analyzer: add tests with neovim
* [`1c8b4ea2`](https://github.com/NixOS/nixpkgs/commit/1c8b4ea2326dea8b203a58952ff26e02068fef91) httm: 0.9.0 -> 0.10.9
* [`cc975df4`](https://github.com/NixOS/nixpkgs/commit/cc975df49c31c220e0c012250cb5dc91e6e19eb6) xml-tooling-c: fix build
* [`8a1e40c9`](https://github.com/NixOS/nixpkgs/commit/8a1e40c96bc21e055383297297267a8cc9443d9f) opensaml-cpp: fix build
* [`c0723eef`](https://github.com/NixOS/nixpkgs/commit/c0723eef37468a1783d3e2fde84e25b3e502f45c) nixos/prometheus: enable checking syntax only
* [`6e632447`](https://github.com/NixOS/nixpkgs/commit/6e63244762f1083bc4fd74a61033dbd485f1a574) shibboleth-sp: fix build
* [`1e2983da`](https://github.com/NixOS/nixpkgs/commit/1e2983dab5a0e1c26c521975cb89085a78781971) libsForQt5.plasmaMobileGear: 21.08 -> 21.12
* [`aebc1240`](https://github.com/NixOS/nixpkgs/commit/aebc1240feca41920ac5c7e4a8aa7441e9804ab8) corrosion: unstable-2021-11-23 -> unstable-2022-01-03
* [`44aeeec3`](https://github.com/NixOS/nixpkgs/commit/44aeeec357409a885f8e5f4656d93b1f6095b5c8) libsForQt5.plasmaMobileGear.plasmatube: init at 21.12
* [`1b0c93d8`](https://github.com/NixOS/nixpkgs/commit/1b0c93d826827fb56e8d280e047885a8d87af624) corrosion: unstable-2022-01-03 -> 0.2.1
* [`a5e825e3`](https://github.com/NixOS/nixpkgs/commit/a5e825e3ba86e60e06461ef403b4ebb114cb389f) libsForQt5.qtmpris: init at 1.0.6
* [`1550635e`](https://github.com/NixOS/nixpkgs/commit/1550635eaaf53ebcf26dd58ed217ce8bedfb6302) libsForQt5.plasmaMobileGear: 21.12 -> 22.04
* [`f586c868`](https://github.com/NixOS/nixpkgs/commit/f586c868d3e1b916c26f1fa57207fa5d35e2435e) python310Packages.hahomematic: 1.3.1 -> 1.4.0
* [`520ca935`](https://github.com/NixOS/nixpkgs/commit/520ca935405c108b02cad79be66f7f842effbdca) python310Packages.marshmallow: 3.13.0 -> 3.15.0
* [`850f5367`](https://github.com/NixOS/nixpkgs/commit/850f53674986d25ad0a680671552176e586e0198) radicale: add optional dependency pytz
* [`ae758a85`](https://github.com/NixOS/nixpkgs/commit/ae758a85d7a0e3f1c37c6434cfe81f41f9575992) nixos/radicale: give access to /dev/urandom
* [`1699720f`](https://github.com/NixOS/nixpkgs/commit/1699720fde716e59fe77f9e99817559be4003d0f) arrow-cpp: Remove redundant compiler override
* [`4bf84c57`](https://github.com/NixOS/nixpkgs/commit/4bf84c57e28bf63d0791b64ec5626c9d9ddeb2e6) haskellPackages.squeal-postgresql: fix build
* [`16ec961d`](https://github.com/NixOS/nixpkgs/commit/16ec961dc0be3f3816c4e97ced8525a954c81515) haskellPackages: fix package pins
* [`5fab4571`](https://github.com/NixOS/nixpkgs/commit/5fab45719eb7a4b536216148addff3e7705f0ac7) haskellPackages.hspec-core: bump version pin
* [`93aa55a2`](https://github.com/NixOS/nixpkgs/commit/93aa55a2997bd70cf5ef376548e0d8180da1a7ab) haskellPackages.hspec-discover: bump version pin
* [`1605472a`](https://github.com/NixOS/nixpkgs/commit/1605472a15e6031fa13a84f35cc9d95a638a237d) btrfs-progs: install Python bindings
* [`b3445aff`](https://github.com/NixOS/nixpkgs/commit/b3445aff661c814a5661413ae12406d4d4130e17) btrfs-progs: remove obsolete _PYTHON_HOST_PLATFORM
* [`a438660f`](https://github.com/NixOS/nixpkgs/commit/a438660fe07be813e6eca27585e62e57c1c135d0) python310Packages.rns: 0.3.5 -> 0.3.6
* [`bbb20d3b`](https://github.com/NixOS/nixpkgs/commit/bbb20d3b9e35356276e9baa49adf3718d0d59893) buildbot: fix dependencies
* [`3b0c84bb`](https://github.com/NixOS/nixpkgs/commit/3b0c84bb7a0ff45d54e404b85a9ce70c92af2f2d) pantheon.elementary-photos: 2.7.4 -> 2.7.5
* [`4ff95784`](https://github.com/NixOS/nixpkgs/commit/4ff9578411c81cf2ac8040579de413a152a12a5e) dockutil 2.0.5 -> 3.0.2 ([nixos/nixpkgs⁠#167488](https://togithub.com/nixos/nixpkgs/issues/167488))
* [`c9b8574c`](https://github.com/NixOS/nixpkgs/commit/c9b8574c3e21e6236ca61f67f8c48814d9555877) haskellPackages.polynomial: Fix build failures for ghc 9
* [`23b890a3`](https://github.com/NixOS/nixpkgs/commit/23b890a3026e6654403822978a5d1268569e0200) haskellPackages: Remove polynomial from the broken list
* [`6e028bd6`](https://github.com/NixOS/nixpkgs/commit/6e028bd63297a2e49305d42d67b7be4c69c59c99) haskellPackages: regenerate package set based on current config
* [`dac52f7d`](https://github.com/NixOS/nixpkgs/commit/dac52f7d71ebff3c5f708c941106ec0a1d5da140) kitty: remove xsel from inputs
* [`d383d27f`](https://github.com/NixOS/nixpkgs/commit/d383d27f29c841da02bca68c4053f6a328be7a94) jl: 0.0.5 -> 0.1.0
* [`1a02999d`](https://github.com/NixOS/nixpkgs/commit/1a02999d5d802d72040bace983c4efe93752bcd0) krane: fix build by updating dependencies
* [`032433e9`](https://github.com/NixOS/nixpkgs/commit/032433e98586be0f8404d8d720d088c9d0bd785b) yt-dlp: 2022.04.08 -> 2022.05.18
* [`74fb021e`](https://github.com/NixOS/nixpkgs/commit/74fb021e95955ca3084d20de6eb977c23722553a) yt-dlp: add marsam to maintainers
* [`6517fa53`](https://github.com/NixOS/nixpkgs/commit/6517fa5378051030e1b8b925ee1f00153498ec9b) aria2: fix completions install
* [`c3427edc`](https://github.com/NixOS/nixpkgs/commit/c3427edcc820e13a088d6dd6403382da4d6c03dd) vale: 2.16.0 -> 2.17.0
* [`6e4887ce`](https://github.com/NixOS/nixpkgs/commit/6e4887ce07549f95e88742712969e6a153dc337c) lab: 0.24.0 -> 0.25.0
* [`87eb72f1`](https://github.com/NixOS/nixpkgs/commit/87eb72f1c3452171a93a760841050c2cdcbb1c7d) dua: 2.17.1 -> 2.17.5
* [`6f23ca82`](https://github.com/NixOS/nixpkgs/commit/6f23ca82bd169d6f169d64e359bb80311a410068) nixos/pantheon: use pantheon.gnome-settings-daemon
* [`0f8888e2`](https://github.com/NixOS/nixpkgs/commit/0f8888e2c18d520cb83e4c07175a88dcc0157d18) python310Packages.elementpath: 2.5.1 -> 2.5.2
* [`b32d017b`](https://github.com/NixOS/nixpkgs/commit/b32d017b60db46e719737a579c1f7362d0c53cef) python3Packages.pyrogram: 2.0.23 -> 2.0.24
* [`99b3c498`](https://github.com/NixOS/nixpkgs/commit/99b3c498a2adfe66434417a817bf5e28e29c9afe) python310Packages.ansible-later: 2.0.12 -> 2.0.13
* [`b93b4f71`](https://github.com/NixOS/nixpkgs/commit/b93b4f71f21e4ff931d669f02cbabe04412d8965) nixos/pantheon: also treat gnome-font-viewer as non-core apps
* [`c601126b`](https://github.com/NixOS/nixpkgs/commit/c601126bc84d5ce74c5f271210c0f3000dc6d5dc) nixos/pantheon: enable power-profiles-daemon
* [`5449a865`](https://github.com/NixOS/nixpkgs/commit/5449a8654895f262a176e251b6fec7ffe10c0a43) pantheon.switchboard-plug-power: 2.6.0 -> 2.7.0
* [`5d6c1f37`](https://github.com/NixOS/nixpkgs/commit/5d6c1f37d4dea8dbfd530cb58edbf46afe716a47) pantheon.elementary-terminal: 6.0.1 -> 6.0.2
* [`cb6efa07`](https://github.com/NixOS/nixpkgs/commit/cb6efa07d009c16ba5a174a7f7d391e2636b2084) pantheon.elementary-capnet-assist: 2.4.1 -> 2.4.2
* [`7541871c`](https://github.com/NixOS/nixpkgs/commit/7541871c1d66e6ed837565391f27de3ce671a269) pantheon.elementary-calendar: 6.1.0 -> 6.1.1
* [`48358d8a`](https://github.com/NixOS/nixpkgs/commit/48358d8a7112ec7419f1fbd51cc7b6b1de306738) pantheon.elementary-settings-daemon: 1.1.0 -> 1.2.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
