### PR TITLE
niv emacs-overlay: update dddc2903 -> 5f10d6cf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dddc29038a06a29b92d07cb21490b228329ae9ac",
-        "sha256": "0qsq3lmwx33djz3dyq78iwi42b7ja36jaway0v472nzkk23h1zyd",
+        "rev": "5f10d6cf7c37ddf97df61bd25bb68e124b094014",
+        "sha256": "1lwspl4v0xj8skbx8zmlym56vim3j597rc9avlbrngy8zlckrddy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/dddc29038a06a29b92d07cb21490b228329ae9ac.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/5f10d6cf7c37ddf97df61bd25bb68e124b094014.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@dddc2903...5f10d6cf](https://github.com/nix-community/emacs-overlay/compare/dddc29038a06a29b92d07cb21490b228329ae9ac...5f10d6cf7c37ddf97df61bd25bb68e124b094014)

* [`d50b93fe`](https://github.com/nix-community/emacs-overlay/commit/d50b93fe889f6261d879cc28613d1010060eea61) Updated repos/emacs
* [`3fc50646`](https://github.com/nix-community/emacs-overlay/commit/3fc50646405f0362b0abb28cc0928a951db82c5f) Updated repos/melpa
* [`dcbb707a`](https://github.com/nix-community/emacs-overlay/commit/dcbb707a85372909622b094eb193c4fb7a83a3a1) Updated repos/nongnu
* [`114df1a7`](https://github.com/nix-community/emacs-overlay/commit/114df1a77d5c35e0fbf87b6286b48206e15c5174) Updated repos/elpa
* [`4b055fca`](https://github.com/nix-community/emacs-overlay/commit/4b055fcaf5c599c529da13b974fce868481813e8) Updated repos/emacs
* [`a5b353b0`](https://github.com/nix-community/emacs-overlay/commit/a5b353b0382987239f9d4b44c4cc8db3248ee0d5) Updated repos/melpa
* [`fa2f0962`](https://github.com/nix-community/emacs-overlay/commit/fa2f096282a3e8043e147faeac4323f2b0f33153) Updated repos/nongnu
* [`3133c11a`](https://github.com/nix-community/emacs-overlay/commit/3133c11a05ad2a52cf760d6b185d816194d36f9a) Updated repos/emacs
* [`a18eb3f2`](https://github.com/nix-community/emacs-overlay/commit/a18eb3f2dd7f21b70f2d1afd1c0486d8dbcce1b3) Updated repos/melpa
* [`5a11a565`](https://github.com/nix-community/emacs-overlay/commit/5a11a565eeda78e787a200f3bc423e3a199829f6) Updated repos/elpa
* [`c3b4f0e4`](https://github.com/nix-community/emacs-overlay/commit/c3b4f0e49ba0f0d9ccd1249215727c0e566f719c) Updated repos/emacs
* [`679fceda`](https://github.com/nix-community/emacs-overlay/commit/679fcedab06892651d3173c2f504dcf40b4ef939) Updated repos/melpa
* [`ee294048`](https://github.com/nix-community/emacs-overlay/commit/ee29404870b13dba20fc3b519ad4af533c2c0051) Updated repos/emacs
* [`de5c8261`](https://github.com/nix-community/emacs-overlay/commit/de5c826149bcfbaa5f0ce985bb184c9bc7f11e46) Updated repos/melpa
* [`cfe32794`](https://github.com/nix-community/emacs-overlay/commit/cfe3279462f76eaf2365aef288fee406c32b8557) Updated repos/emacs
* [`4681a0c9`](https://github.com/nix-community/emacs-overlay/commit/4681a0c9dcbcc70fb2befe2d3d56a5277fbac7f7) Updated repos/melpa
* [`2fb5bc67`](https://github.com/nix-community/emacs-overlay/commit/2fb5bc67b5527c64c8ebade96ac7ea3373bfaa5e) Updated repos/emacs
* [`1a2a9c2b`](https://github.com/nix-community/emacs-overlay/commit/1a2a9c2b0e788c985092cf32290d9de31c1330f4) Updated repos/melpa
* [`f33f24c9`](https://github.com/nix-community/emacs-overlay/commit/f33f24c9ed9bc3ec97707f7e78c5229455cc1f8c) Updated repos/emacs
* [`bfc024a3`](https://github.com/nix-community/emacs-overlay/commit/bfc024a3aed6a909bb07521c3d46d89f3fd68c6d) Updated repos/melpa
* [`62087127`](https://github.com/nix-community/emacs-overlay/commit/6208712709671ce25b931433f8b81e2e30346f73) Updated repos/nongnu
* [`1c9b88ea`](https://github.com/nix-community/emacs-overlay/commit/1c9b88ea285ccf17d62b8f2037e034aa871c2b88) Updated repos/emacs
* [`f2b5fc68`](https://github.com/nix-community/emacs-overlay/commit/f2b5fc6846d69051b7a7b174f7a96aa57b195f6e) Updated repos/melpa
* [`0f4b8090`](https://github.com/nix-community/emacs-overlay/commit/0f4b809001bb5e951bf46d2f50c8c608682aede2) Updated repos/emacs
* [`c04830e9`](https://github.com/nix-community/emacs-overlay/commit/c04830e91ab27bb98f66d936f36137275804a6e3) Updated repos/melpa
* [`f02d6cdd`](https://github.com/nix-community/emacs-overlay/commit/f02d6cdd0ba5e1e2a6778886ef741cc81a2006e3) Updated repos/emacs
* [`ecbf3cd2`](https://github.com/nix-community/emacs-overlay/commit/ecbf3cd2be71e3da5427b50ef71fdb6d548a977c) Updated repos/melpa
* [`4f50148c`](https://github.com/nix-community/emacs-overlay/commit/4f50148cfe66a58cf13e1e95d15f290e13dc1c66) Updated repos/emacs
* [`f251c3e4`](https://github.com/nix-community/emacs-overlay/commit/f251c3e4bcca34feb1b3d178843ae30a024da3a9) Updated repos/melpa
* [`11ad86a8`](https://github.com/nix-community/emacs-overlay/commit/11ad86a8eb4dc3ba6b8256ad76ef6ab5acc663d1) Updated repos/elpa
* [`480968ad`](https://github.com/nix-community/emacs-overlay/commit/480968ad51a0bbee9c8ea3628bc475390273666d) Updated repos/emacs
* [`d969a968`](https://github.com/nix-community/emacs-overlay/commit/d969a968ee668d3ed646e056710c13f2efb9073a) Updated repos/melpa
* [`af371091`](https://github.com/nix-community/emacs-overlay/commit/af371091b8aeea7946c68f6e215d4604381aac47) Updated repos/elpa
* [`7c922784`](https://github.com/nix-community/emacs-overlay/commit/7c9227843b57077ad44f4d8dd25b775e964eca14) Updated repos/emacs
* [`30010fdf`](https://github.com/nix-community/emacs-overlay/commit/30010fdfc3905e552bc8942afae06ed69b5d2211) Updated repos/melpa
* [`fd5baf06`](https://github.com/nix-community/emacs-overlay/commit/fd5baf065e1af4cbb9d40eba66971d31f61d6bd1) Updated repos/nongnu
* [`042cfa90`](https://github.com/nix-community/emacs-overlay/commit/042cfa90b8257e5d751a797384eb671e6852d3c1) Updated repos/emacs
* [`99235a10`](https://github.com/nix-community/emacs-overlay/commit/99235a10c3b3ddd0b3e5fef006c394a4ffba3c37) Updated repos/melpa
* [`6dadf0d6`](https://github.com/nix-community/emacs-overlay/commit/6dadf0d6dd983d4fcb5c688e98340e1441a0a74d) Updated repos/elpa
* [`996f7b25`](https://github.com/nix-community/emacs-overlay/commit/996f7b25fa056a219f426b4c7d1bdc81c7eec257) Updated repos/melpa
* [`00102e5b`](https://github.com/nix-community/emacs-overlay/commit/00102e5b1d751e5c7d65c11249e68ed036ca6cea) Updated repos/emacs
* [`e25c1f33`](https://github.com/nix-community/emacs-overlay/commit/e25c1f33790a1101a8e0003cf99abcac6e4ca333) Updated repos/melpa
* [`5c4f6711`](https://github.com/nix-community/emacs-overlay/commit/5c4f6711ad4163c308d9a338e0611ddd75af13b4) Updated repos/emacs
* [`cd6fbfa2`](https://github.com/nix-community/emacs-overlay/commit/cd6fbfa22bfd96967231515843fbdef3bda7966f) Updated repos/melpa
* [`a6e7f651`](https://github.com/nix-community/emacs-overlay/commit/a6e7f65111cf9f85b15ec93b23372b933349af61) Updated repos/emacs
* [`dcd7a7f6`](https://github.com/nix-community/emacs-overlay/commit/dcd7a7f69126b99d4498a10a3c74e820ec91a167) Updated repos/melpa
* [`0c65a75d`](https://github.com/nix-community/emacs-overlay/commit/0c65a75d5c3526dcd11735defb1ecea16ec7da5c) Updated repos/elpa
* [`ef90d640`](https://github.com/nix-community/emacs-overlay/commit/ef90d640ebe7a8fc06a3be7ea68c514b966ebce6) Updated repos/emacs
* [`5f10d6cf`](https://github.com/nix-community/emacs-overlay/commit/5f10d6cf7c37ddf97df61bd25bb68e124b094014) Updated repos/melpa
