### PR TITLE
niv spacemacs: update 6f5de5cc -> b5ae2fc3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "6f5de5cc4f0616da33948a8b662cf8e81a9aacea",
-        "sha256": "0n8hf2djrv0fnlxdrn2qmcs1g0j7h29mhkw8hj187rxcl3s5rldz",
+        "rev": "b5ae2fc3b211f03a475d3115e90183f7dbce1981",
+        "sha256": "17p141n7fz3njsdw52cryqj7iawlhn0wsbfidjx1qmwjslw9nvbl",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/6f5de5cc4f0616da33948a8b662cf8e81a9aacea.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/b5ae2fc3b211f03a475d3115e90183f7dbce1981.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@6f5de5cc...b5ae2fc3](https://github.com/syl20bnr/spacemacs/compare/6f5de5cc4f0616da33948a8b662cf8e81a9aacea...b5ae2fc3b211f03a475d3115e90183f7dbce1981)

* [`7834b2b7`](https://github.com/syl20bnr/spacemacs/commit/7834b2b7e189f20a12263ff0355f1d4312d356c1) update org-superstar-mode docs
* [`35bfa860`](https://github.com/syl20bnr/spacemacs/commit/35bfa8601a351b38c1c4d82b835c16b7f94de307) [layout] consittent buffer list ([syl20bnr/spacemacs⁠#15520](https://togithub.com/syl20bnr/spacemacs/issues/15520))
* [`85e14e55`](https://github.com/syl20bnr/spacemacs/commit/85e14e55199405809abf4fce4ad20e8f35bc5ac6) [compleseus] update
* [`15a174c1`](https://github.com/syl20bnr/spacemacs/commit/15a174c17b8aca744b59c2882306554686c83ba9) core-jump: reworked
* [`d7bcc5c7`](https://github.com/syl20bnr/spacemacs/commit/d7bcc5c71699d879ceaec238ce37d0c724998bf2) [bot] "built_in_updates" Sat May 21 09:40:03 UTC 2022
* [`b5ae2fc3`](https://github.com/syl20bnr/spacemacs/commit/b5ae2fc3b211f03a475d3115e90183f7dbce1981) Refactor core-load-paths to an in-lined form
