### PR TITLE
niv nixpkgs: update d65ee335 -> d8994d48

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d65ee335c862c1b9ed7864c4b6c96b787e1ac166",
-        "sha256": "0iyl8d6snxk3da8kz6v292jgdffdxxv5m0r37m2vz7sc5hgp1kz8",
+        "rev": "d8994d48bad6232b4987e3184bb850ef446d791a",
+        "sha256": "1kyhb33wx8mgnp4dq83axz00hywwimhkh44md5rv66ygisb2q8x9",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d65ee335c862c1b9ed7864c4b6c96b787e1ac166.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d8994d48bad6232b4987e3184bb850ef446d791a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d65ee335...d8994d48](https://github.com/nixos/nixpkgs/compare/d65ee335c862c1b9ed7864c4b6c96b787e1ac166...d8994d48bad6232b4987e3184bb850ef446d791a)

* [`9a94139d`](https://github.com/NixOS/nixpkgs/commit/9a94139d343aad265457d65632e6f70be306616f) cfs-zen-tweaks: init at 1.2.0
* [`04d31258`](https://github.com/NixOS/nixpkgs/commit/04d312589cc8a4daf74b565583379a873147247e) nixos/cfs-zen-tweaks: init
* [`f2c71138`](https://github.com/NixOS/nixpkgs/commit/f2c7113872928266d4ffa327795b2e6bf569076b) pgmodeler: 0.9.3 -> 0.9.4
* [`44454a17`](https://github.com/NixOS/nixpkgs/commit/44454a17b42dfeb50fe010975a60e6e13155594c) jruby: 9.3.3.0 -> 9.3.4.0
* [`47be0b37`](https://github.com/NixOS/nixpkgs/commit/47be0b370a9e4860eab2b91ea7ad022c33fda2bf) black-hole-solver: 1.10.1 -> 1.12.0
* [`7661ce7c`](https://github.com/NixOS/nixpkgs/commit/7661ce7cfbe3477f7accc87fda59303489ff923f) clifm: 1.4 -> 1.5.1
* [`10a3c1b9`](https://github.com/NixOS/nixpkgs/commit/10a3c1b93d844588acedfb32672e20861d9befd8) grml-zsh-config: 0.19.1 -> 0.19.2
* [`9a8b7640`](https://github.com/NixOS/nixpkgs/commit/9a8b7640e010b901fb528cf62cf0bc79e0912ae2) nixos/doc/types: note submodules’ default’s behaviour
* [`8e68f3fc`](https://github.com/NixOS/nixpkgs/commit/8e68f3fcfc9eb2a00aae46bfb7f6f27a87f920f0) nixos/doc: build manual
* [`9fc01af1`](https://github.com/NixOS/nixpkgs/commit/9fc01af1cc8f9ffe40bf87b96cbafd1810856ea7) nixos/users-group: Add 'homeMode' option.
* [`72037880`](https://github.com/NixOS/nixpkgs/commit/72037880688ff9c6f4188a5746c3ab5ce7215628) lib/generators: withRecursion: don't break attr-sets with special attrs
* [`3473aa29`](https://github.com/NixOS/nixpkgs/commit/3473aa295b88d6cabab33f774cc6af6fb759acae) nextpnr: 2022.01.03 -> 0.3
* [`cdbda2a8`](https://github.com/NixOS/nixpkgs/commit/cdbda2a8c2954a66f2ca000af48cc52d40ab68fa) valgrind: 3.18.1 -> 3.19.0
* [`2118173c`](https://github.com/NixOS/nixpkgs/commit/2118173ca4ac0276c261f4c04eb10a2cbafb7ba8) .github/stale bot: stop commenting
* [`4b7a8ae9`](https://github.com/NixOS/nixpkgs/commit/4b7a8ae94753d8cb3f11103bbc60144b9edc47b3) treewide: refactor curlWithGnuTls into all-packages.nix
* [`89a0dd24`](https://github.com/NixOS/nixpkgs/commit/89a0dd24143b3f604451ad2f31c27faf3e274b88) wrapCCWith: structured argument for wrapper flags
* [`ff802de6`](https://github.com/NixOS/nixpkgs/commit/ff802de61e44ab70363d245c251ec2b427def6b5) llvm-14: use nixSupport arguments with wrapCCWith
* [`96a8c0ac`](https://github.com/NixOS/nixpkgs/commit/96a8c0ac23c1aca2c6542c85b95ed29b444f4597) nixos/postgresql: use postgres 14 for 22.05
* [`e6491be4`](https://github.com/NixOS/nixpkgs/commit/e6491be4e39a7dcd1337ba50cccc00a59c8f44aa) gdb: 11.2 -> 12.1
* [`cd1d65cf`](https://github.com/NixOS/nixpkgs/commit/cd1d65cfc1cf96049488ee2139b5e73563109c84) gdb: fix w/musl, touchup postPatch expr
* [`30b459c3`](https://github.com/NixOS/nixpkgs/commit/30b459c377d104767b9daf119d735f486dc17d4e) dotty: rename to scala_3
* [`7655d19f`](https://github.com/NixOS/nixpkgs/commit/7655d19fc2235edbc583183218b9ba8a2eff481d) directx-shader-compiler: 1.6.2106 -> 1.6.2112
* [`91e4fa27`](https://github.com/NixOS/nixpkgs/commit/91e4fa278e3095285fc5cb56681a4aff076ca805) haskell-modules/generic-builder.nix: use mktemp instead of TMPDIR
* [`bf64063f`](https://github.com/NixOS/nixpkgs/commit/bf64063fc306010857fccbf84a584544351a4621) libqrtr-glib: only enable gtk-doc when not cross-compiling
* [`4447d407`](https://github.com/NixOS/nixpkgs/commit/4447d4071bc69e2e18aef96aa14fc0ec835fd5cd) mingw-w64: 9.0.0 -> 10.0.0
* [`504d38ae`](https://github.com/NixOS/nixpkgs/commit/504d38ae7ba872dbf3b9972d33c94912e56807ed) cross: Allow Windows toolchains to use ucrt as libc.
* [`4b503b2a`](https://github.com/NixOS/nixpkgs/commit/4b503b2a58fd7776a497b1c0109f5de1eb76fdb4) cc-wrapper: clang doesn't support -fPIC on Windows
* [`a73b59a1`](https://github.com/NixOS/nixpkgs/commit/a73b59a157f149369283eda571b61f7990e6afa3) llvm-bintools: Include aliases for windres and dlltool on Windows
* [`133513b0`](https://github.com/NixOS/nixpkgs/commit/133513b065682076fe83c00458daaedeadb73a65) python3Packages.dash: add test dependency
* [`b00016d9`](https://github.com/NixOS/nixpkgs/commit/b00016d9d92187f9fb39d4890e44be3f1f2a21f0) bintools-wrapper: Remove LDEMULATION setting.
* [`dee9af93`](https://github.com/NixOS/nixpkgs/commit/dee9af932383801ccd5bbb5f48109a556c1b632c) bintools: Add isXXX flags to check linker type
* [`4c0d5f80`](https://github.com/NixOS/nixpkgs/commit/4c0d5f80fcdef2024f73c584f7450a6f37ced8cd) bintools-wrapper: Don't pass -z to lld targeting Windows
* [`078a0770`](https://github.com/NixOS/nixpkgs/commit/078a07708a6add846447272f0797fbde778a0522) libunwind: Fix build against compiler-rt-using clang
* [`5ca96b94`](https://github.com/NixOS/nixpkgs/commit/5ca96b948c7acc307b9b0d7d6ff5f60c77763d8e) libcxxabi: Fix build against compiler-rt-using clang
* [`b7b9b737`](https://github.com/NixOS/nixpkgs/commit/b7b9b73760c421ccf7323ab6827dec3c31bef344) libcxx/libcxxabi: Fix build on Windows with lld
* [`5c0654f2`](https://github.com/NixOS/nixpkgs/commit/5c0654f26211aa9e8a0f6783de3e89c5ca1d2724) cross: Add mingwW64-llvm cross-system.
* [`15aa32e0`](https://github.com/NixOS/nixpkgs/commit/15aa32e082124e37587b5fb250598a7019694500) llvm-bintools: passthru targetPrefix.
* [`d68a532d`](https://github.com/NixOS/nixpkgs/commit/d68a532d1be6b5ef579e3b950d01d85b8bcdfd85) Set a default machine type when using lld targeting Windows.
* [`98a853c3`](https://github.com/NixOS/nixpkgs/commit/98a853c37d90d4b0696deb6a5f3a47a877f48568) Add msys2 libtool patch for mingw + clang + compiler-rt
* [`f4d58300`](https://github.com/NixOS/nixpkgs/commit/f4d583000192d0e8759ebaac60ec6b32488117ea) libffi: autoreconf on Windows for libtool fix
* [`b08eed0c`](https://github.com/NixOS/nixpkgs/commit/b08eed0cbc92b3bca1347f4534f1059b42e06de4) libffi: Fix build for Windows with lld
* [`f28101d2`](https://github.com/NixOS/nixpkgs/commit/f28101d2a421da8b9836a9e339dc8b27353f60d3) gmp: autoreconf on Windows for libtool fixes.
* [`5e8a8573`](https://github.com/NixOS/nixpkgs/commit/5e8a857310a580d6f7a3d56ec99295792143d496) ncurses: Fix building against ucrt
* [`ece10a71`](https://github.com/NixOS/nixpkgs/commit/ece10a711f5a2c406d8907c66c99c61f776c2ac1) ghcHEAD: Fix Windows cross-compilation with lld.
* [`4d2237c8`](https://github.com/NixOS/nixpkgs/commit/4d2237c841d5e670e9ac994be432db04f09fd537) lib.foldAttrs: Clarify example
* [`596b3663`](https://github.com/NixOS/nixpkgs/commit/596b3663a53de13a7f56d0b052c094214fbad49d) pkgs/top-level/config.nix: Add warnUndeclaredOptions
* [`9020f1cf`](https://github.com/NixOS/nixpkgs/commit/9020f1cf3e4abf3dc62f6661f6808bd59ccd2976) nixpkgs.config: Also warn for unused defs if warnUndeclaredOptions
* [`8f5c4204`](https://github.com/NixOS/nixpkgs/commit/8f5c420450bd431c09d92d009fff5bf0e024c12a) haskellPackages.mkDerivation: show test outputs as they happen
* [`62002644`](https://github.com/NixOS/nixpkgs/commit/62002644d8ac176f469ff184f58eb9ad57cb3cdf) androidStudioPackages.stable: 2021.1.1.23 -> 2021.2.1.14
* [`c6026cb9`](https://github.com/NixOS/nixpkgs/commit/c6026cb9c7ec85a6b0658bd153a1405a372ab717) ndroidStudioPackages.canary: 2021.3.1.7 -> 2021.3.1.9
* [`f615c754`](https://github.com/NixOS/nixpkgs/commit/f615c7545b71ad5a2ca5b5fae5881a9008432e24) androidStudioPackages: add myself as maintainer
* [`0d6bcb51`](https://github.com/NixOS/nixpkgs/commit/0d6bcb513bf2f2fe92ff8b2fae75da95007a03e3) makeBinaryWrapper: move into its own folder
* [`62245943`](https://github.com/NixOS/nixpkgs/commit/62245943aa12a06cc976ca94c632d70049316415) makeWrapper,makeBinaryWrapper: introduce explicitly named functions
* [`81b9c712`](https://github.com/NixOS/nixpkgs/commit/81b9c712cec8b0edf772c3ffb113e39867bfc86c) wrapGAppsHook: rename argument to makeWrapper
* [`8b79ef2c`](https://github.com/NixOS/nixpkgs/commit/8b79ef2cb6ac286ae3489bcc5a3e6bd546dac67f) makeBinaryWrapper: remove cc from deps
* [`2ae69114`](https://github.com/NixOS/nixpkgs/commit/2ae69114a11c6a80a58abc6984fde8851ee8fe40) makeWrapper: implement --inherit-argv0
* [`4c8fe91f`](https://github.com/NixOS/nixpkgs/commit/4c8fe91fb0bb87c8fe9edff91bb7f447ec56752e) go-camo: init at 2.4.0
* [`88369997`](https://github.com/NixOS/nixpkgs/commit/88369997e1db7e1819b7b940fc2740f188d6608d) makeBinaryWrapper: add extractCmd
* [`c6a44147`](https://github.com/NixOS/nixpkgs/commit/c6a4414766547f32ba4b70261c42db3578ddafff) postgresqlPackages.pg_safeupdate: 1.2 -> 1.4
* [`5a19730b`](https://github.com/NixOS/nixpkgs/commit/5a19730b5d346134bd7e8bc64185d5d430790cd3) postgresql_10: 10.20 -> 10.21
* [`74707e7b`](https://github.com/NixOS/nixpkgs/commit/74707e7b120750c9ca2668b3c3abd1bc5a787722) postgresql_11: 11.15 -> 11.16
* [`9d599ca1`](https://github.com/NixOS/nixpkgs/commit/9d599ca124c568db7e348ba5ff6bbd12559a4e03) postgresql_12: 12.10 -> 12.11
* [`84e86fc9`](https://github.com/NixOS/nixpkgs/commit/84e86fc9ee92e7214e07e685ff87312b5a66da15) postgresql_13: 13.6 -> 13.7
* [`242c4aaf`](https://github.com/NixOS/nixpkgs/commit/242c4aaf39096a2ed9e7022adbf51ccee102fd80) postgresql_14: 14.2 -> 14.3
* [`3c77d361`](https://github.com/NixOS/nixpkgs/commit/3c77d361b5e8e8d9173282538067cce6bcc3cc29) makeShellWrapper: add explicitly named attribute
* [`4b0f59af`](https://github.com/NixOS/nixpkgs/commit/4b0f59afccb060fd7bfd9b107a21bd8a0fdac775) binutils: add upstream patch to fix issue with parallel use of dlltool
* [`3e385d9a`](https://github.com/NixOS/nixpkgs/commit/3e385d9a8262fedc647f59aebc5464d7a9212c1a) makeBinaryWrapper: add comment
* [`51b24b0b`](https://github.com/NixOS/nixpkgs/commit/51b24b0bf08f3b7d99de00140229294cac8429fb) openxray: 822-december-preview -> 1144-december-2021-rc1
* [`8e857780`](https://github.com/NixOS/nixpkgs/commit/8e8577806de026f1cb7d012ae0c95a3496f84925) gtk: fix missing immodules.cache
* [`e8e144a2`](https://github.com/NixOS/nixpkgs/commit/e8e144a22a313a4618c6384d13ef55d8c8cfba3c) srb2: init at 2.2.8
* [`a93a197f`](https://github.com/NixOS/nixpkgs/commit/a93a197fc986de833553c23ddded5a6202268956) srb2kart: init at 1.3.0
* [`8085bbe6`](https://github.com/NixOS/nixpkgs/commit/8085bbe67be3c031716f263045242921101ebaed) srb2: 2.2.8 -> 2.2.10
* [`be29f457`](https://github.com/NixOS/nixpkgs/commit/be29f4575e6ba2f0610180ab765f1b767578968e) rustc: expose correct llvmPackages for cross compile
* [`f6c57619`](https://github.com/NixOS/nixpkgs/commit/f6c57619358d51e71a5298503c84e1c1ce4f9f12) firefox-unwrapped: fix cross compilation
* [`ce5a25ef`](https://github.com/NixOS/nixpkgs/commit/ce5a25ef1abf1bdc4cb14835f6bc2e0a2bf574f2) flutter.dart: 2.16.1 -> 2.16.2
* [`4abc8088`](https://github.com/NixOS/nixpkgs/commit/4abc8088b7c4c6c7d87a9b65ed10461bcdd85266) e2fsprogs: patch for CVE-2022-1304
* [`5d15a099`](https://github.com/NixOS/nixpkgs/commit/5d15a099b94be16ee619053ed6bcbddefd561a19) gtk4: patch fixing g-c-c crashes
* [`20c371f9`](https://github.com/NixOS/nixpkgs/commit/20c371f91e48412ca219c1c7b5249da4ead329bc) gtk3: 3.24.33 -> 3.24.33-2022-03-11
* [`6595bdb3`](https://github.com/NixOS/nixpkgs/commit/6595bdb30e564c8ad97c12333130791509cf0f14) awesome: pull upstream fix for -fno-common toolchains
* [`311aa6d0`](https://github.com/NixOS/nixpkgs/commit/311aa6d05d57fe1e94d16509b8eff43dbd6dbc7d) nixos/users-group: Update description of 'homeMode' option.
* [`f74dcd2f`](https://github.com/NixOS/nixpkgs/commit/f74dcd2f28054f3151ff3815a1bc51f5f9a19c53) foma: 0.9.18alpha -> 0.10.0alpha
* [`5f137cf5`](https://github.com/NixOS/nixpkgs/commit/5f137cf5b70cae5b4bb2185b6439a020b1d47e63) apacheHttpdPackages.mod_tile: pull upstream fix for -fno-common
* [`9ccccc3e`](https://github.com/NixOS/nixpkgs/commit/9ccccc3e255948be13079138d09b3b21da1a5e23) edk2: fix cross compilation
* [`110c6e6c`](https://github.com/NixOS/nixpkgs/commit/110c6e6c966be817640bb7723e7d74dcdc614e44) nixos/libvirtd: allow to provide both x86 and aarch64 ovmf
* [`0b3eecc5`](https://github.com/NixOS/nixpkgs/commit/0b3eecc56f119d2307da27ffc081af4a714b8c0a) gerbv: pull fix pending upstream inclusion for -fno-common toolchains
* [`3ab2cf22`](https://github.com/NixOS/nixpkgs/commit/3ab2cf227936d71d8f22eedd4242610515b31c36) lxqt.libqtxdg: 3.9.0 -> 3.9.1
* [`6a693179`](https://github.com/NixOS/nixpkgs/commit/6a693179007f5b432559cd06859d7e1fd3488b55) lxqt.qtxdg-tools: init at 3.9.1
* [`1c884fb5`](https://github.com/NixOS/nixpkgs/commit/1c884fb5bd1ceae9e73220a8edb92c968142e223) lxqt.lxqt-session: 1.1.0 -> 1.1.1
* [`2145dbc4`](https://github.com/NixOS/nixpkgs/commit/2145dbc4fcd3c512bb7ec6e0826fa3d2d2e80c4c) nixos/mosquitto: add missing listener option bind_interface
* [`c1115d37`](https://github.com/NixOS/nixpkgs/commit/c1115d37ffd4f947dd110c1bfc8f1593eaa07928) nixos/mosquitto: fix attribute path display in assertions
* [`687decaa`](https://github.com/NixOS/nixpkgs/commit/687decaa2d29d6bfe6a70ae528b2cbde59b6438d) flasm: pull patch pending upstream inclusion for -fno-common toolchains
* [`1838712a`](https://github.com/NixOS/nixpkgs/commit/1838712a15df62f354993d68187225b8f70cc5dc) i3lock-blur: pull patch pending upstream inclusion for -fno-common toolchain support
* [`e9b13758`](https://github.com/NixOS/nixpkgs/commit/e9b1375878a798850457c7c86af2795451b489b1) nixos/hedgedoc: fix and add config options
* [`96467f28`](https://github.com/NixOS/nixpkgs/commit/96467f286f85f0d937ec3c4e8c02c5d84a8358e8) sigi: 3.3.0 -> 3.4.0
* [`4ec57fea`](https://github.com/NixOS/nixpkgs/commit/4ec57fea9c4f9b951293ff3ee28200e143d0e71c) python3Packages.dpcontracts: init at master
* [`d5cf6ab1`](https://github.com/NixOS/nixpkgs/commit/d5cf6ab1b15a7c461d2000bbfdf250f120f19b40) pandas: fix darwin build
* [`408492b2`](https://github.com/NixOS/nixpkgs/commit/408492b2346c2fd2675884792e614b9faa7f25d2) python310Packages.python-mimeparse: execute tests
* [`1dfba65a`](https://github.com/NixOS/nixpkgs/commit/1dfba65a22007636bebc7f1d60d833c8649a318c) nlohmann_json: 3.10.2 -> 3.10.5
* [`1cd33517`](https://github.com/NixOS/nixpkgs/commit/1cd3351798562b83b9087d4dc936ae01d1f5be29) opentx: 2.3.14 -> 2.3.15
* [`d62f3acd`](https://github.com/NixOS/nixpkgs/commit/d62f3acd4dfbe051a81281d1b1b86f99992ae578) photoflare: 1.6.7.1 -> 1.6.10
* [`4f0b07f7`](https://github.com/NixOS/nixpkgs/commit/4f0b07f7704521ed4e050002bb8cd977fab447d0) guile-json: 4.7.0 -> 4.7.1
* [`1d36aafa`](https://github.com/NixOS/nixpkgs/commit/1d36aafa55bec318896fe9661943e1b081f06217) guile-json: allow on all platforms
* [`aa6a14f3`](https://github.com/NixOS/nixpkgs/commit/aa6a14f350a5c8e8b0ea55d948dae465612d4116) oh-my-git: fix ingame editor missing perl
* [`cbcc746f`](https://github.com/NixOS/nixpkgs/commit/cbcc746f8f521849687d225c4a3f85b2beb24168) nixos/systemd: Package only built component units
* [`6107bbf5`](https://github.com/NixOS/nixpkgs/commit/6107bbf55393e58d0da7841c25a55a923dc16949) buildDotnetModule: change default dotnet SDK and runtime to version 6
* [`6b3e1485`](https://github.com/NixOS/nixpkgs/commit/6b3e1485b4b0307eedbbf3fa175d8719706bae14) alttpr-opentracker: update for dotnet 6
* [`c48a73bb`](https://github.com/NixOS/nixpkgs/commit/c48a73bb50d7c079440a8b875c1577bd4b806c63) depotdownloader: update for dotnet 6
* [`402cfbf7`](https://github.com/NixOS/nixpkgs/commit/402cfbf73cb96de37a5f26d0ffb141403a7ba1c9) formula: update for dotnet 6
* [`578589e1`](https://github.com/NixOS/nixpkgs/commit/578589e1dadb6358ff015746844acf297c07c9e1) treewide: remove unneeded dotnet SDK version pins
* [`0c86c19d`](https://github.com/NixOS/nixpkgs/commit/0c86c19d2269069e1825cf7546f7307060a87393) lhapdf: 6.4.0 -> 6.5.1
* [`e7d67d85`](https://github.com/NixOS/nixpkgs/commit/e7d67d857632b609b4cf33b9a213d2af224f47db) python3Packages.lhapdf: fix for python 3.10+
* [`92f4c6ed`](https://github.com/NixOS/nixpkgs/commit/92f4c6ed823ce10c484daa6582a908c5ae9ad61b) lua: fix on darwin by using makeBinaryWrapper ([nixos/nixpkgs⁠#172749](https://togithub.com/nixos/nixpkgs/issues/172749))
* [`ad241745`](https://github.com/NixOS/nixpkgs/commit/ad241745c3d72d13f7c2f2a273fb93a4f181830d) mangohud: 0.6.5 -> 0.6.7-1
* [`cf608e1b`](https://github.com/NixOS/nixpkgs/commit/cf608e1b5d5657a61d6678bdec809e30edb278ee) bootstrap-studio: init at 6.0.1
* [`84c3b4f9`](https://github.com/NixOS/nixpkgs/commit/84c3b4f9859770fd411f19a654a8b515dce55ce6) maintainers: update khushraj
* [`4720f3ac`](https://github.com/NixOS/nixpkgs/commit/4720f3ac737e7db54f487f89be4479bc6da659fc) postgresqlPackages.wal2json: init at 2.4
* [`f8d8fd75`](https://github.com/NixOS/nixpkgs/commit/f8d8fd75291431103c91ba683dfe80cd0445c3e4) kitty-themes: 2022-02-03 -> 2022-05-04
* [`695b93b0`](https://github.com/NixOS/nixpkgs/commit/695b93b0795da031baeb0d46319d7b5710d40842) python310Packages.pg8000: 1.28.0 -> 1.28.2
* [`c911240e`](https://github.com/NixOS/nixpkgs/commit/c911240e9cc2a7c12c985bd32700b9657b5698a9) Revert "Add mingwW64-llvm cross-system."
* [`39ef6322`](https://github.com/NixOS/nixpkgs/commit/39ef6322b5b9dcddaee2a1caf7b07c09747784a2) openldap: 2.4.58 -> 2.6.2
* [`1d24e9ae`](https://github.com/NixOS/nixpkgs/commit/1d24e9ae37c3a71d91a624bc28a2e25c54c35a2f) openldap: update maintainers
* [`0ce4fec7`](https://github.com/NixOS/nixpkgs/commit/0ce4fec78597d266f0d56fbc02586d8f694d0fc3) mysql: 8.0.28 -> 8.0.29
* [`9e44ffc0`](https://github.com/NixOS/nixpkgs/commit/9e44ffc04300e0191e3c8f5a601a96e808eaf67b) nixos/gnupg: default to a reasonable pinentry program on headless systems
* [`588d62e2`](https://github.com/NixOS/nixpkgs/commit/588d62e2d410716769d08358e7fe20b537bd626b) mcfm: fix gcc-flavored lhapdf for darwin
* [`c2261bce`](https://github.com/NixOS/nixpkgs/commit/c2261bce535eb7e8887c8134a0d4f5c499eac8a6) python310Packages.pg8000: 1.28.2 -> 1.28.3
* [`885144b2`](https://github.com/NixOS/nixpkgs/commit/885144b2d05342f5d3c5aebc68259ef59a7724e3) python310Packages.django-allauth: 0.47.0 -> 0.50.0, adopt
* [`1568b6c5`](https://github.com/NixOS/nixpkgs/commit/1568b6c5fd8491e76d71deb316e094ed20cf5225) python310Packages.django-guardian: normalise attr, add pythonImportsCheck, adopt
* [`11820f11`](https://github.com/NixOS/nixpkgs/commit/11820f11df27d0cb8dcfb68913f3a020f8be3e81) python310Packages.django-rest-auth: adopt, prepare to run tests
* [`11eb2d29`](https://github.com/NixOS/nixpkgs/commit/11eb2d295de1121432b35f8d2d9ede458ccdd677) yandex-disk: 0.1.6.1074 → 0.1.6.1080
* [`efe825af`](https://github.com/NixOS/nixpkgs/commit/efe825af166cd36293934e0eb184871ce9c359be) python310Packages.djangorestframework: 3.12.4 -> 3.13.1, enable tests, adopt
* [`3d060814`](https://github.com/NixOS/nixpkgs/commit/3d060814cb7cd516d2846f1662ebd36a8e583fae) python310Packages.unittest-xml-reporting: enable tests, adopt
* [`4aeabf14`](https://github.com/NixOS/nixpkgs/commit/4aeabf1492a11a717fcdfc803f99d911070a27c0) python310Packages.drf-spectacular-sidecar: init at 2022.5.1
* [`358b2ca0`](https://github.com/NixOS/nixpkgs/commit/358b2ca070037d63ef9cf8b74761a14e05a07741) python310Packages.ansible-lint: 6.0.2 -> 6.1.0
* [`b4c69d74`](https://github.com/NixOS/nixpkgs/commit/b4c69d74eb4bde1def09f7e4da314b864962ed53) python3Packages.pulumi: init at 3.25.1
* [`3510fba9`](https://github.com/NixOS/nixpkgs/commit/3510fba9b0b754525dad2be0c1c2e586d5326c71) python3Packages.pulumi-aws: init at 4.38.0
* [`c1aec215`](https://github.com/NixOS/nixpkgs/commit/c1aec2157fe753de9f057fc7f940f2fbb6c31e3a) libsForQt5.qtstyleplugin-kvantum: 1.0.1 -> 1.0.2
* [`6238d2fe`](https://github.com/NixOS/nixpkgs/commit/6238d2fe76bb2dcdc0af05ab6eacf9ac15d4a7ec) libsForQt5.qtstyleplugin-kvantum: add update script
* [`dae4350d`](https://github.com/NixOS/nixpkgs/commit/dae4350d25883f99aafdba66bb2e96a4163f91d8) shotwell: fix video thumbnails
* [`4dd8c921`](https://github.com/NixOS/nixpkgs/commit/4dd8c9218ef90e46d9bf825f0b6199e8f8da53f7) citra: rename to citra-nightly, init citra-canary
* [`885d4e04`](https://github.com/NixOS/nixpkgs/commit/885d4e047b807719996a0c497b63ab6d77eba439) nixos/openldap: use upstream unit defaults
* [`ac7627e6`](https://github.com/NixOS/nixpkgs/commit/ac7627e62dac6b1cfe608b646dacf180a21a218f) gtk4: Fix incorrect merge
* [`20c4aa10`](https://github.com/NixOS/nixpkgs/commit/20c4aa10543dac09ab3a9d04eef75253a3ab7a35) mimalloc: 2.0.5 -> 2.0.6
* [`0e1c9977`](https://github.com/NixOS/nixpkgs/commit/0e1c9977e9325f4dec21c46a80badf3b525aed48) tbb: pull fix pending upstream inclusion for gcc-13 support
* [`98e84e3c`](https://github.com/NixOS/nixpkgs/commit/98e84e3c93689b093d1bc21e3d98d9035dfea622) dirb: add -fcommon workaround
* [`b56e64b9`](https://github.com/NixOS/nixpkgs/commit/b56e64b99bf90f1d2c9c5fad7b021dc5f505e9f8) ddnet 16.0.3 -> 16.1
* [`298b76da`](https://github.com/NixOS/nixpkgs/commit/298b76dabccf848a50a823ab10f66bd3ba42725a) djmount: add -fcommon workaround
* [`2fd6e6e2`](https://github.com/NixOS/nixpkgs/commit/2fd6e6e264d033fa32582c32c717590f8f614541) nginx: take care not to pull in module sources as runtime deps
* [`84fad7bf`](https://github.com/NixOS/nixpkgs/commit/84fad7bf602a98707f489180f39dce128e3c8bc8) dspam: add -fcommon workaround
* [`4ff0469d`](https://github.com/NixOS/nixpkgs/commit/4ff0469dacd53fef66e6d714467f7ace70844228) perlPackages.DBMDeep: init at 2.0016
* [`e75dad1f`](https://github.com/NixOS/nixpkgs/commit/e75dad1fe3ec0787df1012236a0c149994393e72) perlPackages.NumberPhone: init at 3.8004
* [`d0362198`](https://github.com/NixOS/nixpkgs/commit/d0362198f0351b25069738e4db1acd7998b350ef) pgadmin4: 6.8 -> 6.9
* [`99601311`](https://github.com/NixOS/nixpkgs/commit/99601311778a4905246df568213ab57916be613d) python3Packages.pyschemes: init at master
* [`55c1e633`](https://github.com/NixOS/nixpkgs/commit/55c1e633aa3e73a010fdf9ff5132ba1c6f61544c) python3Packages.vaa: init at 0.2.1
* [`e763e37b`](https://github.com/NixOS/nixpkgs/commit/e763e37b49ab6c8481335e42d4f9957ef0842637) python3Packages.deal-sover: init at 0.1.0
* [`db7e12a2`](https://github.com/NixOS/nixpkgs/commit/db7e12a2b2d006ecd5807e530622b97917b817dc) python3Packages.deal: init at 4.23.3
* [`0a9f6d1d`](https://github.com/NixOS/nixpkgs/commit/0a9f6d1d9c7db38317db2d9a2cd2a1ef06edacfa) bird-lg: init at 2022-05-09
* [`0f63bd3b`](https://github.com/NixOS/nixpkgs/commit/0f63bd3ba84c300db46b384287b066c4c98ca3f4)  nixos/bird-lg: init
* [`17ce82cf`](https://github.com/NixOS/nixpkgs/commit/17ce82cf813ac83c0a3f7f45f6687b03a243186d) python3Packages.icontract: init at 2.6.1
* [`7c0dd3ff`](https://github.com/NixOS/nixpkgs/commit/7c0dd3ff5bbe908bb1bbd86ef864625f6f47afee) trivy: mark x86_64-darwin broken
* [`ba010e36`](https://github.com/NixOS/nixpkgs/commit/ba010e3688be68c8d82668a3b924972b8b81f7a8) haskellPackages: stackage LTS 19.6 -> LTS 19.7
* [`341d31a3`](https://github.com/NixOS/nixpkgs/commit/341d31a36ff78d240029bee53dd364e6c6788aaa) all-cabal-hashes: 2022-05-14T01:13:33Z -> 2022-05-20T19:45:02Z
* [`1b8c4d4f`](https://github.com/NixOS/nixpkgs/commit/1b8c4d4fd4810116b7ca75c09f24d3bd9a0d7824) haskellPackages: regenerate package set based on current config
* [`9b6f7450`](https://github.com/NixOS/nixpkgs/commit/9b6f7450b2b0f2d46b7ae6321e1a3ce88f0fd1a0) haskellPackages: fix eval errors
* [`7bbe4df4`](https://github.com/NixOS/nixpkgs/commit/7bbe4df45ad7beac2fd662125b51770e2830e689) haskellPackages.friendly: jailbreak for ghc-9.0.2/optparse-applicative 0.16
* [`6895219b`](https://github.com/NixOS/nixpkgs/commit/6895219b618c25e6db5d258105626d95ece4819f) python310Packages.requirements-detector: 0.7 -> 1.0.3
* [`9d1932e3`](https://github.com/NixOS/nixpkgs/commit/9d1932e38b4047daa8bd5f2e57c524f622315f9e) prospector: relax requirements-detector constraint
* [`80367c8d`](https://github.com/NixOS/nixpkgs/commit/80367c8db877e65ba7727c834fae8ce078295f0d) nixos/nextcloud: Remove confusing comment
* [`b92533e7`](https://github.com/NixOS/nixpkgs/commit/b92533e71ac471cc341555ba188c796b3baec5e1) kube-router: remove checkFlags
* [`fe1c235a`](https://github.com/NixOS/nixpkgs/commit/fe1c235af983cb58dcfa6c684d4afd8222112142) goconvey: tweak test flags
* [`39e0af7b`](https://github.com/NixOS/nixpkgs/commit/39e0af7b7eb420719ef11a82c75881ca4a709f16) prometheus-mysqld-exporter: tweak test flags
* [`1acac48b`](https://github.com/NixOS/nixpkgs/commit/1acac48b6d2a445f00144fc582691e1ce0669fe2) cloud-sql-proxy: tweak test flags
* [`aeb353f7`](https://github.com/NixOS/nixpkgs/commit/aeb353f7a0b4c19de85f821c90360d9954239799) docker-credential-gcr: tweak tests
* [`dad03081`](https://github.com/NixOS/nixpkgs/commit/dad03081b1dc5b1127a5bfb248cd1f9d5af29e7d) temporal: disable tests
* [`3c627fc5`](https://github.com/NixOS/nixpkgs/commit/3c627fc5d37c8c77d33bf097131ee4c0f3c53230) cni-flannel-plugin: 1.0.0 -> 1.1.0
* [`be02f1b1`](https://github.com/NixOS/nixpkgs/commit/be02f1b12adee732695d975251ef6fdc675fc9bf) foremost: add -fcommon workaround
* [`4fc2a315`](https://github.com/NixOS/nixpkgs/commit/4fc2a31536f4ee18b0540abc4435cbcc5dc9baed) glabels: pull fix pending upstream inclusion for -fno-common toolchain support
* [`eb0590ec`](https://github.com/NixOS/nixpkgs/commit/eb0590ec3dfd6f0c2f35e936e3b3ac4367e771a5) kssd: pull upstream fix for -fno-common tollchains
* [`a2a2be0c`](https://github.com/NixOS/nixpkgs/commit/a2a2be0ca75d97e8cf108c51edc666a47c50a0e9) haskellPackages.spago: pin bower-json
* [`6f7f5bc8`](https://github.com/NixOS/nixpkgs/commit/6f7f5bc8235a37214d92fb817a95d31af5f1e052) lastpass-cli: fix build for -fno-common toolchains
* [`47c1c35f`](https://github.com/NixOS/nixpkgs/commit/47c1c35f7e762d38a2afa24180d1e207441997b1) haskellPackages.genric-arbitrary: remove obsolete patch
* [`9da0f836`](https://github.com/NixOS/nixpkgs/commit/9da0f836bf96e52ca73c48bd34ebc60ba552b34c) haskellPackages.size-based: remove obsolete patch
* [`96f9a159`](https://github.com/NixOS/nixpkgs/commit/96f9a15947f19e1ab77428da404f3a00253c0d20) ocenaudio: 3.11.10 -> 3.11.11
* [`32e45a5c`](https://github.com/NixOS/nixpkgs/commit/32e45a5c9f246488e90c6e2b7e852b78162a2d54) nixos/tests/os-prober: fix
* [`dcf4c8e7`](https://github.com/NixOS/nixpkgs/commit/dcf4c8e7b947b23355590bde46cb605428d68490) apko: init at 0.3.3
* [`e2917e01`](https://github.com/NixOS/nixpkgs/commit/e2917e019bd88d87581e381516fe9e6cb67bac91) tracee: init at 0.7.0
* [`c68803fe`](https://github.com/NixOS/nixpkgs/commit/c68803fe317ae500bf3c64d635ac24b50d7b21e8) tracee: add manual nixosTest for integration testing
* [`e373b1a7`](https://github.com/NixOS/nixpkgs/commit/e373b1a746317dc089e3dc16e06d5994746cfa78) vimPlugins.diffview-nvim: add plenary as dependency
* [`a2d4d474`](https://github.com/NixOS/nixpkgs/commit/a2d4d474c21a9543192e9c9eb56e67885e73a137) vimPlugins.nvim-biscuits: init at 2021-11-12
* [`d7bfa0dc`](https://github.com/NixOS/nixpkgs/commit/d7bfa0dcc49491c7683a84e7edbf24b1c3bddcc6) vim/update.py: mark some plugins as neovim ones
* [`6a065534`](https://github.com/NixOS/nixpkgs/commit/6a065534bb3f17b536308168b4621edff504b0d7) colima: embed version and git revision
* [`63d81ddf`](https://github.com/NixOS/nixpkgs/commit/63d81ddf9f45b727fc3cf0f2d5ae8bbdc3fc8ad3) pkgsi686Linux.gdb: fix formatting for 32-bit systems
* [`4c559160`](https://github.com/NixOS/nixpkgs/commit/4c5591606cf09d33ef8420d16f9b45f6aa572c6a) sparrow: init at 1.6.4
* [`1ba9dfbd`](https://github.com/NixOS/nixpkgs/commit/1ba9dfbd974616ecf9735742fab179de64065f15) buildMozillaMach: add support for MLS
* [`0750e47a`](https://github.com/NixOS/nixpkgs/commit/0750e47a4d3a7c6a09d1c67348477148847eb87b) buildMozillaMach: Clean up Google API key configuration
* [`125b803e`](https://github.com/NixOS/nixpkgs/commit/125b803e446851520a1a866cb6a657b493973673) gecode_6: add patch fixing clang build
* [`fde16aef`](https://github.com/NixOS/nixpkgs/commit/fde16aefa7561bbc34d4e9f75581075bd69570d6) qgroundcontrol: 4.2.0 -> 4.2.1
* [`9f8beb12`](https://github.com/NixOS/nixpkgs/commit/9f8beb12368a52871b0ae76e63b2aa30fbb59ed9) pantheon.elementary-music: 5.1.1 -> 7.0.0
* [`543b1c5f`](https://github.com/NixOS/nixpkgs/commit/543b1c5fa69e97f4c001e04998268f6ea4992763) python310Packages.shortuuid: 1.0.8 -> 1.0.9
* [`ecb166b3`](https://github.com/NixOS/nixpkgs/commit/ecb166b3e3890504af0828bfd2e03edd6f720971) nginx: simplify the postInstall phase
* [`e3694948`](https://github.com/NixOS/nixpkgs/commit/e369494848e5b87597f687a1034b7309718fcfbe) python310Packages.shortuuid: add pythonImportsCheck
* [`8d08c7b8`](https://github.com/NixOS/nixpkgs/commit/8d08c7b83edabefc833763910c9a9af354e16511) lincity: add -fcommon workaround
* [`1b11f2b6`](https://github.com/NixOS/nixpkgs/commit/1b11f2b6ac6625912ba1ccf71eb9d913fbbc5eae) lockdep: add -fcommon workaround
* [`c882821d`](https://github.com/NixOS/nixpkgs/commit/c882821dd40179ede4e2b01696ea77f08b2d6e13) mkcl: pull upstream fix for -fno-common toolchains
* [`7d56d31d`](https://github.com/NixOS/nixpkgs/commit/7d56d31d822967dbd9d082889d2666cf81f1426c) moarvm: add patch fixing build of bundled mimalloc on darwin
* [`30aeecfc`](https://github.com/NixOS/nixpkgs/commit/30aeecfc6f52ca3485b12d7353a94a61fc7fee4d) wine: enable parallel build again
* [`6e17b694`](https://github.com/NixOS/nixpkgs/commit/6e17b6945c7224b73f21ec0f390120ba3432978d) scantailor-advanced: fix build with qt5.15 by switching to a maintained fork
* [`2d97db78`](https://github.com/NixOS/nixpkgs/commit/2d97db78736a4b60f4c6ab39350fa07fedc8ab3c) buildMozillaMach: set geo.provider.network.url for new profiles.
* [`94a5ae4f`](https://github.com/NixOS/nixpkgs/commit/94a5ae4f9100d3480e490b556ff89cf17c9e5490) mni_autoreg: pull upstream workaround for -fno-common toolchains
* [`9f4060c5`](https://github.com/NixOS/nixpkgs/commit/9f4060c55289472edcd6a47b92cb3dc98380cbd8) Revert "lua: fix on darwin by using makeBinaryWrapper ([nixos/nixpkgs⁠#172749](https://togithub.com/nixos/nixpkgs/issues/172749))"
* [`1dace77d`](https://github.com/NixOS/nixpkgs/commit/1dace77da58628bf29655c033b939daf3670546a) mpc123: add -fcommon workaround
* [`a35a5689`](https://github.com/NixOS/nixpkgs/commit/a35a56895415dc46b514ba30d9445f1800d9f72b) mpg321: add -fcommon workaround
* [`bf1aabe3`](https://github.com/NixOS/nixpkgs/commit/bf1aabe3c1b1ca19e8c2f1ef60338b3b4683a77e) nixosTests.custom-ca: fix meta evaluation
* [`1e42f67d`](https://github.com/NixOS/nixpkgs/commit/1e42f67d82d82bb095721f05d3f70ae95502a3a6) mupen64plus: pull upstream fix for -fno-common toolchains
* [`73ae512f`](https://github.com/NixOS/nixpkgs/commit/73ae512f2d58a2e28970eade45d266b4332d9950) session-desktop-appimage: 1.8.4 -> 1.8.6
* [`6206aff2`](https://github.com/NixOS/nixpkgs/commit/6206aff28a396a99b4a5248498ddc4cbe457d423) maintainers: add mdarocha as maintainer
* [`1458666f`](https://github.com/NixOS/nixpkgs/commit/1458666fa17c93e6ac4e2da22d0d25ed2b113f25) dotnet-sdk: 6.0.202 -> 6.0.300
* [`2454cb06`](https://github.com/NixOS/nixpkgs/commit/2454cb06ecf388f2fec28ba762434ba1fce0150c) omnisharp-roslyn: update dependencies
* [`737bce9b`](https://github.com/NixOS/nixpkgs/commit/737bce9b594d184a53179e0f0fcd1df4739cd96c) github-runner: update dependencies
* [`4b6af00b`](https://github.com/NixOS/nixpkgs/commit/4b6af00b8dc0c75be7cf7ab4550dc88148669cfb) python3Packages.ldap: fix linking with openldap 2.5+
* [`f7933e9f`](https://github.com/NixOS/nixpkgs/commit/f7933e9fac9274cf4bacf7b2163a1df9108712c2) pt2-clone: 1.46 -> 1.49
* [`10f1d293`](https://github.com/NixOS/nixpkgs/commit/10f1d293c4a754785140358717c414b1847c3028) session-desktop-appimage: wayland support
* [`6cd8386d`](https://github.com/NixOS/nixpkgs/commit/6cd8386d1d66834188b625cb820a506071150fe2) nuweb: add -fcommon workaround
* [`7414d60e`](https://github.com/NixOS/nixpkgs/commit/7414d60e52ae06525e5605e202fabae213dd8afd) probe-run: 0.3.2 -> 0.3.3
* [`5c26b9f3`](https://github.com/NixOS/nixpkgs/commit/5c26b9f376209360db32b2c1fcff259ac00ea56b) oonf-olsrd2: add -fcommon workaround
* [`7520e84e`](https://github.com/NixOS/nixpkgs/commit/7520e84ec2830fe889b538a00415ae7a0ce2452e) openbgpd: add -fcommon workaround
* [`6322d6be`](https://github.com/NixOS/nixpkgs/commit/6322d6be3ae19dfa1474ef2dbc5968487d03c92e) cifs-utils: 6.14 -> 6.15
* [`5e8e5553`](https://github.com/NixOS/nixpkgs/commit/5e8e5553ad721c93b415e5c62d3780bb969f2a85) opencorsairlink: pull upstream fix for -fno-common toolchains
* [`b12c35dc`](https://github.com/NixOS/nixpkgs/commit/b12c35dcf6a26359f552e7f2085e1c761b16e4b8) orangefs: pull upstream fix for -fno-common toolchains
* [`75b764a8`](https://github.com/NixOS/nixpkgs/commit/75b764a8c08e1ba2c4087eab1832945a41a5cd4e) ossec: add -fcommon workaround
* [`5a6a31e5`](https://github.com/NixOS/nixpkgs/commit/5a6a31e54ddaf59aa8e1c5e7e9b02623d4881c34) fetchzip: extraPostFetch -> postFetch && tests
* [`5a61d189`](https://github.com/NixOS/nixpkgs/commit/5a61d189974198bcf61b494f11aabb65a77cb03e) ocamlPackages.cmdliner_1_1: init at 1.1.1
* [`29750d36`](https://github.com/NixOS/nixpkgs/commit/29750d369c0a6bbce1b4f57b4a6f63da06a31390) ocamlformat: 0.20.1 -> 0.21.0
* [`bcbbbea8`](https://github.com/NixOS/nixpkgs/commit/bcbbbea82e5a0618f3a11126fea7210bb9af1031) ocamlPackages.cmdliner_1_0: Update license
* [`8cba3775`](https://github.com/NixOS/nixpkgs/commit/8cba3775d82fe224b7b379a1913369d49ffedc44) paml: add -fcommon workaround
* [`1572de8d`](https://github.com/NixOS/nixpkgs/commit/1572de8d203cbddeab81e4f005db55eb81276693) pcsxr: add -fcommon workaround
* [`1cc6f08c`](https://github.com/NixOS/nixpkgs/commit/1cc6f08cdd8ebb37e33473e81893b4f480eabe16) makeBinaryWrapper: fix codesign on aarch64-darwin
* [`e381b640`](https://github.com/NixOS/nixpkgs/commit/e381b64026110f81fd0777bba61619feeb2a0508) python3Packages.pytile: does not depend on pylint
* [`efd3568e`](https://github.com/NixOS/nixpkgs/commit/efd3568e0269a2d816c81dbca79170b8a4b694ce) python3Packages.lektor: does not depend on pytest-pylint
* [`b048539a`](https://github.com/NixOS/nixpkgs/commit/b048539afb23542dd33768604c5935a60a7926ba) python3Packages.pamqp: run tests
* [`1b815c86`](https://github.com/NixOS/nixpkgs/commit/1b815c86c1fd62732c342d5901c9a7b2c0c99579) home-assistant: don't run pylint tests
* [`55b15504`](https://github.com/NixOS/nixpkgs/commit/55b15504732af1856b2ac0c54f7fd413a9eb5ffa) praat: fix cross-compilation
* [`1191cec7`](https://github.com/NixOS/nixpkgs/commit/1191cec77b19fbf93bc4dace8fd2eb9f6c7447c5) python310Packages.ssh-mitm: 2.0.2 -> 2.0.3
* [`86b4f37f`](https://github.com/NixOS/nixpkgs/commit/86b4f37fcadb442cb33a3ad863768f3f47414830) checkov: 2.0.1147 -> 2.0.1153
* [`eb8c029c`](https://github.com/NixOS/nixpkgs/commit/eb8c029c9c7c61c4ea3c7b1ee0b6d45b1ad9e282) python310Packages.beautifultable: 1.0.1 -> 1.1.0
* [`7c00f54a`](https://github.com/NixOS/nixpkgs/commit/7c00f54ab65b4b1984b11513ba62c5d051c7757c) python310Packages.beautifultable: disable on older Python releases
* [`2c54c060`](https://github.com/NixOS/nixpkgs/commit/2c54c0602d739b684b5b8dbf9496cdd4de5b226a) lingua-franca: 0.1.0 -> 0.2.0
* [`04dccdf5`](https://github.com/NixOS/nixpkgs/commit/04dccdf5f5af38db0af8f720416a01157cc77f9a) pandoc: Add bash completions
* [`b6750072`](https://github.com/NixOS/nixpkgs/commit/b67500724f05d5ee4c05eaa9c1a068e21d8bbfe3) nixosTests.mysql-backup: fix
* [`e5caa559`](https://github.com/NixOS/nixpkgs/commit/e5caa559c41a0b23c0fcdf16bcdf9f84c5c7e83f) mesa: Add support for building the Zink driver
* [`5baa20d7`](https://github.com/NixOS/nixpkgs/commit/5baa20d7c8bd2b04ac30316d4c8ee4d8f4db3ad6) qt6: init at 6.3.0
* [`33775ec9`](https://github.com/NixOS/nixpkgs/commit/33775ec9a2173a08e46edf9f46c9febadbf743e8) tdesktop: 3.6.0 -> 3.7.3
* [`4a029b24`](https://github.com/NixOS/nixpkgs/commit/4a029b247717729d0bdced11e3d4ce0ff096ace3) golangci-lint: 1.45.2 -> 1.46.2
* [`93fe6c89`](https://github.com/NixOS/nixpkgs/commit/93fe6c89c87ceb1aed4454d5dbd227f13bf5e281) isync: set mainProgram
* [`aab6863d`](https://github.com/NixOS/nixpkgs/commit/aab6863dde3bfb47a0fe161d1c2efcf5a50791c8) python310Packages.pywemo: 0.8.0 -> 0.8.1
* [`fa49483a`](https://github.com/NixOS/nixpkgs/commit/fa49483a26958fc12a71368d51c5f84fb6327493) python310Packages.keyring: 23.5.0 -> 23.5.1
* [`c67d1d87`](https://github.com/NixOS/nixpkgs/commit/c67d1d875264e43a1ddf2d29e2152d335cca8c58) terraform-providers: update 2022-05-23
* [`af99bbf4`](https://github.com/NixOS/nixpkgs/commit/af99bbf45100f6179bd1158d3bfb804259e7ee19) moltenvk: fix broken ICD definition
* [`71ceba17`](https://github.com/NixOS/nixpkgs/commit/71ceba177ffd922c82191560c7878ac587f06253) moltenvk: provide MoltenVK-specific headers
* [`5603dff9`](https://github.com/NixOS/nixpkgs/commit/5603dff93c56f0dcc7f3ad2367ac60c0b8f721f8) vulkan-tools: enable support for Darwin
* [`5463b86d`](https://github.com/NixOS/nixpkgs/commit/5463b86d03d456c1d2496a09c6e9f82c9bd66c87) nixos/users: Fix typo
* [`be2ceef4`](https://github.com/NixOS/nixpkgs/commit/be2ceef4f126ffb083b37bc3830f31f8c4a433e7) openldap: fix cross-compilation
* [`572ff94f`](https://github.com/NixOS/nixpkgs/commit/572ff94f55b8dc9ee230212df72c2d40beefc73e) nixos/users-group: make homeMode respect is_dry and create home directly with right permissions
* [`ba114c44`](https://github.com/NixOS/nixpkgs/commit/ba114c44650d42f10cec28080c1de96866342b65) box64: init at 0.1.8
* [`ad81f8db`](https://github.com/NixOS/nixpkgs/commit/ad81f8dbeff52b2746c1859a879e09e3c7f4c02c) ocamlPackages.faraday: 0.7.2 -> 0.8.1
* [`26e7906a`](https://github.com/NixOS/nixpkgs/commit/26e7906a969db1b2e44ca9125b985ca38c039597) ocamlPackages.hacl_x25519: 0.2.0 -> 0.2.2
* [`3d162497`](https://github.com/NixOS/nixpkgs/commit/3d162497370cae2a8dd62eb644a81d6630b0cf71) python3Packages.mkdocs-drawio-exporter: init at 0.8.0
* [`d17f9fbc`](https://github.com/NixOS/nixpkgs/commit/d17f9fbc86c9aae6a11cb1c693a9d1477c22699a) maintainers: init snpschaaf
* [`56dd7b9b`](https://github.com/NixOS/nixpkgs/commit/56dd7b9b1c5534fb653e4fee2c0b9e7543084ddb) mons: migrate to resholve.mkDerivation
* [`7af228f1`](https://github.com/NixOS/nixpkgs/commit/7af228f1b68adfaab5c8d9c68d64cbdde7b2cf67) activate-linux: init at unstable-2022-05-22
* [`4ddea71b`](https://github.com/NixOS/nixpkgs/commit/4ddea71bbd7ea3586520598b9b6c2b3789fd2405) Re-Revert "lua: fix on darwin by using makeBinaryWrapper ([nixos/nixpkgs⁠#172749](https://togithub.com/nixos/nixpkgs/issues/172749))"
* [`fa2393f0`](https://github.com/NixOS/nixpkgs/commit/fa2393f03111219bf855ca325ac486ad971103bc) pulumi: update updater
* [`2cc4bf94`](https://github.com/NixOS/nixpkgs/commit/2cc4bf9427221753e1147b71b352a5a2c23a1ad6) nixos/plymouth: Fix non-systemd initrd boot
* [`fa7ae887`](https://github.com/NixOS/nixpkgs/commit/fa7ae8876f0b6bd05262a6be12ccd1fc551ed25d) linux_latest: 5.17.9 -> 5.18
* [`6a9e61bd`](https://github.com/NixOS/nixpkgs/commit/6a9e61bde1a0b115d0533f41cf4e466eca87593a) maintainers: add dukc
* [`e4650d6d`](https://github.com/NixOS/nixpkgs/commit/e4650d6d6ca9e4146b969e9af899fefbf5b45f77) dmd: made derivation compile when overriding version to 2.084.1, 2.087.1 or 2.088.1.
* [`6c822e25`](https://github.com/NixOS/nixpkgs/commit/6c822e25b66f78d5051d101d366c81b663946b72) vim: 8.2.4816 -> 8.2.4874
* [`2e4c67b5`](https://github.com/NixOS/nixpkgs/commit/2e4c67b555e0a8261f797b804c28c1063e675833) vim: 8.2.4874 -> 8.2.4975
* [`b5d942b8`](https://github.com/NixOS/nixpkgs/commit/b5d942b84f961a3dda3d2d418dfffe5d27c3dea1) gnome.seahorse: 41.0 → 42.0
* [`275b2f85`](https://github.com/NixOS/nixpkgs/commit/275b2f85ec3844ea0f949e5ca8e2e85c5b9a287d) orca: 42.0 → 42.1
* [`2f87de7b`](https://github.com/NixOS/nixpkgs/commit/2f87de7b08a1de5b8f9c501b03c81bcc1e4d9a7e) shotwell: 0.30.15 → 0.30.16
* [`e337e4ea`](https://github.com/NixOS/nixpkgs/commit/e337e4ea5f5563fa3a0d916482ffdcf56e500e57) evince: 42.2 → 42.3
* [`9925507b`](https://github.com/NixOS/nixpkgs/commit/9925507b45d51c36065d40529bba9d3d751f18b6) gupnp-tools: 0.10.2 → 0.10.3
* [`e3e91f0c`](https://github.com/NixOS/nixpkgs/commit/e3e91f0c33757126568adba98a3844d1f86bcdbc) seahorse: fix missing icons
* [`c5bfda47`](https://github.com/NixOS/nixpkgs/commit/c5bfda47e760cd9b091d2c7d9d09db16c470f7fc) linuxPackages.zenpower: 0.1.13 -> unstable-2022-04-13
* [`0795cb72`](https://github.com/NixOS/nixpkgs/commit/0795cb72d313d15c1721bbd633fbf550961dc77e) linuxPackages.zenpower: clarify license
* [`062d21ee`](https://github.com/NixOS/nixpkgs/commit/062d21eeadd6e9f6ba9ca8a2370f2823c2d66fb6) linuxPackages.nvidiabl: use a better homepage
* [`f60bb297`](https://github.com/NixOS/nixpkgs/commit/f60bb297340f473b25e8613ace6660f0d26d6912) pantheon-tweaks: 1.0.3 -> 1.0.4
* [`7b5bd9f7`](https://github.com/NixOS/nixpkgs/commit/7b5bd9f71926d2a8c85ddaa3f78b872f71d2ac57) linuxPackages.apfs: add patch for Linux 5.18
* [`168b9264`](https://github.com/NixOS/nixpkgs/commit/168b926435628cb06c4a8cb0f3e6f69f141529f1) lib.systems: remove supported, replace with flakeExposed
* [`6436bdeb`](https://github.com/NixOS/nixpkgs/commit/6436bdeb7f4f74264c17a92457e1ebc8ca6fbe43) gcc: add langD support to gcc 10
* [`2481fd2d`](https://github.com/NixOS/nixpkgs/commit/2481fd2d8360c93718473f6a8a6e95e02b212040) python310Packages.types-setuptools: 57.4.14 -> 57.4.15
* [`b5917a7f`](https://github.com/NixOS/nixpkgs/commit/b5917a7ff46c7d45a7b99570248553277cbc62b5) maintainers: add GaetanLepage
* [`22e0c737`](https://github.com/NixOS/nixpkgs/commit/22e0c737ad4807c0eee671dc3f020812606e5187) mprocs: init at 0.2.2
* [`b3caa2f1`](https://github.com/NixOS/nixpkgs/commit/b3caa2f1fed4526fa0d6744c353f3c7678d4bb40) treewide: extraPostFetch -> postFetch
* [`fbf5610b`](https://github.com/NixOS/nixpkgs/commit/fbf5610b033f0a52212262b3a977037ec2745f82) polymc: 1.2.2 -> 1.3.0
* [`cb4e7fd9`](https://github.com/NixOS/nixpkgs/commit/cb4e7fd9bc53b75f8aeaa00b7486b15a3557c790) gdc: nicer eval failure from versions >= 12
* [`03e3c23e`](https://github.com/NixOS/nixpkgs/commit/03e3c23e69d2e96ccae54a6a22b7dfc1bdd4881c) python310Packages.xmlschema: 1.11.0 -> 1.11.1
* [`bcbdfeb4`](https://github.com/NixOS/nixpkgs/commit/bcbdfeb41567254db75cf4aeb10301213757e959) ArchiSteamFarm: update dependencies, fixes to updater.sh
* [`5258230d`](https://github.com/NixOS/nixpkgs/commit/5258230d4eb662c4802f9cf186db6730e324e907) inklecate: update dependencies
* [`5241fbb0`](https://github.com/NixOS/nixpkgs/commit/5241fbb00cc9cb2513042e87521a959b85a3ad34) ryujinx: update dependencies, update updater.sh script
* [`851211ea`](https://github.com/NixOS/nixpkgs/commit/851211ea7269ac794c307bc1034cbd5d53ccec83) osu-lazer: update dependencies
* [`82541f40`](https://github.com/NixOS/nixpkgs/commit/82541f40f4a0b6fae2289b14b4082ff8fdd271c0) xivlauncher: update dependencies
* [`3df920c6`](https://github.com/NixOS/nixpkgs/commit/3df920c6747421c06bfddb7c08f9165c3f4970dd) linuxPackages.it87: switch upstream to Frank Crawford
* [`b2e67a34`](https://github.com/NixOS/nixpkgs/commit/b2e67a347710f3549b8f5cbdf801af17edab8134) linuxPackages.it87: clarify license
* [`843fba6a`](https://github.com/NixOS/nixpkgs/commit/843fba6a7cb5a58a26ce1e1affa6d914314a3187) httm: 0.10.9 -> 0.10.10
* [`36fbecf1`](https://github.com/NixOS/nixpkgs/commit/36fbecf10917959e538a81512684510d1efe94b0) github-runner: 2.291.1 -> 2.292.0
* [`6891c924`](https://github.com/NixOS/nixpkgs/commit/6891c924ca6e3e4b9855006250a0d8d5ae7720cf) flexget: 3.3.11 -> 3.3.12
* [`fd044175`](https://github.com/NixOS/nixpkgs/commit/fd044175314798d06d142089cd98c6d32e5d35d2) python39Packages.manticore: relax crytic-compile constraint
* [`00004be6`](https://github.com/NixOS/nixpkgs/commit/00004be60ea161a1a30f3b32d33cb3d43cd88d32) python310Packages.mlflow: 1.25.1 -> 1.26.0
* [`6f14f38b`](https://github.com/NixOS/nixpkgs/commit/6f14f38b278a213ab5d2135bac1af4d142f53ff2) python310Packages.xmlschema: update disable
* [`f3f0b600`](https://github.com/NixOS/nixpkgs/commit/f3f0b60006cc992856061a16d9dc5bcf4ab20cfa) nixos/nextcloud: use PHP 8 avoiding broken 2FA app
* [`92413909`](https://github.com/NixOS/nixpkgs/commit/924139096a8064b4959c7e314c19293459741b37) honggfuzz: Use LLVM 12
* [`aa608e45`](https://github.com/NixOS/nixpkgs/commit/aa608e458c7f9eac3a9fdf7c546a7cf82fc4ffd3) s3bro: remove use_2to3
* [`74457ff9`](https://github.com/NixOS/nixpkgs/commit/74457ff923fd62c874967560948396ff975f338a) syft: 0.46.1 -> 0.46.2
* [`c1c36819`](https://github.com/NixOS/nixpkgs/commit/c1c368194ef4eeaccb38508e11e57b491b62f9a3) release-notes: Fix the first lines for 22.05
* [`e6fcf830`](https://github.com/NixOS/nixpkgs/commit/e6fcf830d87545daa60e906e128cfbf8fe440dc8) cargo-audit: 0.16.0 -> 0.17.0
* [`c376e5b5`](https://github.com/NixOS/nixpkgs/commit/c376e5b58959e6b517464fd11ad37f5f7da6a1dc) snazy: 0.9.0 -> 0.10.0
* [`51d86fb7`](https://github.com/NixOS/nixpkgs/commit/51d86fb7cf45878b53dbc0ae79265a9595a06f81) scorecard: 4.2.0 -> 4.3.0
* [`94d38b83`](https://github.com/NixOS/nixpkgs/commit/94d38b8321805c569be447573004205a93b942ac) dolphin-emu-beta: 5.0-16101 -> 5.0-16380
* [`e728029b`](https://github.com/NixOS/nixpkgs/commit/e728029b3070c170a87273ccc873b18e492fcc93) workflows: Replace 21.05 with 22.05
* [`bfdfe12c`](https://github.com/NixOS/nixpkgs/commit/bfdfe12c788d7474b88e7a7790b88b1c0f8e01b5) 22.11 is Raccoon
* [`ffe324d8`](https://github.com/NixOS/nixpkgs/commit/ffe324d8bd63cb03f8cfaaa8f4de61efb4bb6ec3) waybar: 0.9.12 -> 0.9.13
* [`681e2d00`](https://github.com/NixOS/nixpkgs/commit/681e2d00834325c293831d07b4db74d927dfd683) python3Packages.pykrakenapi: 0.3.0 -> 0.3.1
* [`953b5d19`](https://github.com/NixOS/nixpkgs/commit/953b5d19bca4d4ddfaef5625cca277c47b39f5e7) manual: Fix the 22.11 changelog
* [`ef51af12`](https://github.com/NixOS/nixpkgs/commit/ef51af120350d4a9c54decf9c3c3c49807ecc9e4) python310Packages.hahomematic: 1.4.0 -> 1.5.0
* [`9b25d1aa`](https://github.com/NixOS/nixpkgs/commit/9b25d1aa7bc605ec40d74875f748c79f36350b56) python310Packages.sepaxml: 2.4.1 -> 2.5.0
* [`fe836f35`](https://github.com/NixOS/nixpkgs/commit/fe836f35644a152c5a38d09e162694fec9755b6b) lib/systems/parse: don't consider mode switching CPUs compatible
* [`acb06370`](https://github.com/NixOS/nixpkgs/commit/acb063701a6a209a514bbdefacc9bce22332ef60) lib.systems.elaborate: expose canExecute predicate over isCompatible
* [`41485e73`](https://github.com/NixOS/nixpkgs/commit/41485e7337baca768dc542c553a9d66030df7b33) stdenv.mkDerivation: be less strict about check execution for cross
* [`c6cbef9a`](https://github.com/NixOS/nixpkgs/commit/c6cbef9aece79e7dc2957368eceed0840c386638) libffi: disable tests if linked statically
* [`1f8bae43`](https://github.com/NixOS/nixpkgs/commit/1f8bae43e49e3147028cd42b8e789454bede2975) nixos/doc/rl-2211.section.md: changes w.r.t. cross check execution
* [`82c434b3`](https://github.com/NixOS/nixpkgs/commit/82c434b3ded704e249374e96e6819760735a76fa) lib.systems: inform isCompatible users about removal
* [`ff2a8c60`](https://github.com/NixOS/nixpkgs/commit/ff2a8c6083870e6ffe68bf1d5e705cd6e21ec77a) saleae-logic-2: 2.3.52 -> 2.3.53
* [`6db12559`](https://github.com/NixOS/nixpkgs/commit/6db12559ee51eca9ed9d1478beae451fca6a2876) python310Packages.django-guardian: add me as Maintainer
* [`a7de2cdc`](https://github.com/NixOS/nixpkgs/commit/a7de2cdcacc3daaa0cd141bcacb7a440733c0fc3) python3Packages.pyzbar: fix for darwin
* [`c5eedd1a`](https://github.com/NixOS/nixpkgs/commit/c5eedd1ae5eac86c6fd6db736e8410759e6c5168) linuxPackages.gcadapter-oc-kmod: 1.4 -> unstable-2021-12-11
* [`b4e4982e`](https://github.com/NixOS/nixpkgs/commit/b4e4982e6ce36281159e2256a936f302bda1eb5c) emacsPackages.melpaBuild: Update package-build, avoid monkey-patch
* [`e9be5fe4`](https://github.com/NixOS/nixpkgs/commit/e9be5fe419c945d0473b60f4072028e3160d0a8a) linux-doc: init
* [`fc4dc5ef`](https://github.com/NixOS/nixpkgs/commit/fc4dc5ef8c7f89e6de57ed1be7060a91dafe6a2a) systeroid: init at 0.1.1
* [`87e0baba`](https://github.com/NixOS/nixpkgs/commit/87e0baba2d3725299019b066ec849312fd29e463) gnuclad: enable on darwin
* [`75cfbd6b`](https://github.com/NixOS/nixpkgs/commit/75cfbd6bb0f660bcc984e400e911877795d12f00) python310Packages.broadlink: 0.18.1 -> 0.18.2
* [`2f4da397`](https://github.com/NixOS/nixpkgs/commit/2f4da397f07581a7e13cc0b6ddc363e1a4fddc9c) python3Packages.aspy-refactor-imports: fix url and darwin test failure
* [`366420b0`](https://github.com/NixOS/nixpkgs/commit/366420b0d29b2adae8008031cf9f18594d6a9532) hercules-ci-agent: Work around missing file from sdist
* [`36ea50ff`](https://github.com/NixOS/nixpkgs/commit/36ea50ffe5e9882185874823405882157c45b5e8) python39Packages.manticore: mark as broken on darwin
* [`da56374a`](https://github.com/NixOS/nixpkgs/commit/da56374a496b8a77ff7425030f2005fdddae26a3) wallabag: 2.4.3 -> 2.5.0
* [`36b612e9`](https://github.com/NixOS/nixpkgs/commit/36b612e90ebc992c79a20c8d39e36619239f4a32) _3proxy: fix cross-compilation
* [`bd500347`](https://github.com/NixOS/nixpkgs/commit/bd500347811507ff614b209d422301ef6e27dbe0) gnomeExtensions: auto-update
* [`6d80baff`](https://github.com/NixOS/nixpkgs/commit/6d80baff6d0bf2b95d77f9b3f02612ed9b6a06f5) librseq: 0.1.0pre70 -> 0.1.0pre71
* [`bbfdf8f1`](https://github.com/NixOS/nixpkgs/commit/bbfdf8f138c557f92d48192342e219194adf7e18) perlPackages.NumberPhone: rm TestMore dependency
* [`e4dad6d6`](https://github.com/NixOS/nixpkgs/commit/e4dad6d60692955f6496ba37c90bbbb51023f40f) xfce.xfce4-terminal: 1.0.3 -> 1.0.4
* [`5dfdf69e`](https://github.com/NixOS/nixpkgs/commit/5dfdf69ee25da2ad0544d8739991fcdc2e94a424) quick-lint-js: 2.4.0 -> 2.5.0
* [`cbbd0f77`](https://github.com/NixOS/nixpkgs/commit/cbbd0f77eae0702d02dbbf6f0d45ad34844c6c4a) cutemaze: 1.3.0 -> 1.3.1
* [`76d8cf06`](https://github.com/NixOS/nixpkgs/commit/76d8cf069b9ed9be6f53e4dcfe2637e76022fafb) conmon: 2.1.0 -> 2.1.1
* [`620b891f`](https://github.com/NixOS/nixpkgs/commit/620b891fd43b775c61c95ce031fb2a644cf8dd93) vscode-extensions.ionide.ionide-fsharp: 6.0.1 -> 6.0.4
* [`699ae2d2`](https://github.com/NixOS/nixpkgs/commit/699ae2d202ba5b2741885fa4c439380da97eedf2) terraform: 1.2.0 -> 1.2.1
* [`60be290e`](https://github.com/NixOS/nixpkgs/commit/60be290e1f3e198ae04713aa10684b9d8e17b9d2) python310Packages.google-cloud-logging: 3.0.0 -> 3.1.1
* [`7e72954c`](https://github.com/NixOS/nixpkgs/commit/7e72954cad8010abc743a44b72a969a36f5bf3c4) pantheon.elementary-mail: 6.4.0 -> 7.0.0
* [`7d48c204`](https://github.com/NixOS/nixpkgs/commit/7d48c204efd169837a75c752d8c13515388c2a1b) pantheon.gala: save/restore easing on workspace switch
* [`e112247f`](https://github.com/NixOS/nixpkgs/commit/e112247f93dae1f5d69d41d413a407b089416cb1) gnome-feeds: use readability-lxml
* [`4dcada79`](https://github.com/NixOS/nixpkgs/commit/4dcada7989b3cc47f4f6c8c688854d093a24bd43) qutebrowser: use readability-lxml
* [`26e554d7`](https://github.com/NixOS/nixpkgs/commit/26e554d7a4258e78ecf053a5ba4678ab3224f158) python3Packages.pyreadability: make alias of readability-lxml
* [`2c5a0e07`](https://github.com/NixOS/nixpkgs/commit/2c5a0e07a97193816f4306261bf2ed3908eaf9ce) python3Packages.readability-lxml: run tests
* [`37fa3c37`](https://github.com/NixOS/nixpkgs/commit/37fa3c37322f7660dc3555f00c52272b422bc0f8) python310Packages.stripe: 3.1.0 -> 3.2.0
* [`ca320378`](https://github.com/NixOS/nixpkgs/commit/ca32037807fb686859938ef01c1d31f596ab27ea) onlykey-cli: 1.2.5 -> 1.2.9
* [`9ba84fb7`](https://github.com/NixOS/nixpkgs/commit/9ba84fb7f78b342888bcc7d8f155cce842f3388b) onlykey-agent: 1.1.11 -> 1.1.13
* [`0094dccd`](https://github.com/NixOS/nixpkgs/commit/0094dccde866df787d16ddd4b53d83e3978ee694) onlykey: 5.3.3 -> 5.3.4
* [`a8a0313b`](https://github.com/NixOS/nixpkgs/commit/a8a0313b98e4fd10503513a00afdf749773630fa) archivy: simplify expression
* [`9ce5e322`](https://github.com/NixOS/nixpkgs/commit/9ce5e3220a0eac911821de3c353dbc6b8253780d) python3Packages.wtforms: normalize pname
* [`eef4bbd8`](https://github.com/NixOS/nixpkgs/commit/eef4bbd82f4c2fe108dc68f90a7c5871c768f0f7) stdenv: fix evaluation of platform emulator
* [`c88d7fb8`](https://github.com/NixOS/nixpkgs/commit/c88d7fb8592a87f231c4ce6fb8f9761159b6b581) python3Packages.flask-wtf: 1.0.0 -> 1.0.1
* [`a16d56e7`](https://github.com/NixOS/nixpkgs/commit/a16d56e7b4067315a65cc5f7a5e9886fc21e4e6e) seatd: 0.6.4 -> 0.7.0
* [`98bf174d`](https://github.com/NixOS/nixpkgs/commit/98bf174d522e4e17993654df564ddeb1dd30ce89) etesync-dav: pin dependency versions
* [`2d425e97`](https://github.com/NixOS/nixpkgs/commit/2d425e97e07f550d78089f5136d3bfa0027d02ad) archivy: 1.7.2 -> 1.7.3
* [`43b8ad27`](https://github.com/NixOS/nixpkgs/commit/43b8ad27aa0a39dc7882c526e7b8ce18933b5cdf) ncftp: add -fcommon workaround
* [`ff6ad139`](https://github.com/NixOS/nixpkgs/commit/ff6ad139da51b16ebc8bdb4f55c1a2e69f6fa237) python310Packages.policyuniverse: 1.5.0.20220426 -> 1.5.0.20220523
* [`9d8cfc22`](https://github.com/NixOS/nixpkgs/commit/9d8cfc22c36a802e3f57e8873103c5c769c4c6cb) adtool: mark broken
* [`0cfd23c3`](https://github.com/NixOS/nixpkgs/commit/0cfd23c34ee05322c0ccad06dc4e91365c65ef70) python310Packages.pip-tools: 6.6.1 -> 6.6.2
* [`e9fc987d`](https://github.com/NixOS/nixpkgs/commit/e9fc987d8d669391c9786890e442c9b49e0110d6) dask-xgboost: remove
* [`ad13d56c`](https://github.com/NixOS/nixpkgs/commit/ad13d56c999ba3d3b8c796b756b1c8b6127d1e85) duplicity: S3 backups fail with "boto" not being found.
* [`39f208db`](https://github.com/NixOS/nixpkgs/commit/39f208db81e5b36134e77ce60bf345cf9fa3f7b3) python310Packages.boxx: 0.10.0 -> 0.10.1
* [`17520867`](https://github.com/NixOS/nixpkgs/commit/17520867b018f0b4df63d85dc5b7ecb141ba9868) python310Packages.policyuniverse: add format
* [`acf69be9`](https://github.com/NixOS/nixpkgs/commit/acf69be9516bf81faaf251e280449ed9854c2106) python310Packages.google-cloud-logging: disable on older Python releases
* [`6d3a164c`](https://github.com/NixOS/nixpkgs/commit/6d3a164c742ed0f333fcbed512733343a708ee58) python310Packages.pip-tools: update disable
* [`5c801dd6`](https://github.com/NixOS/nixpkgs/commit/5c801dd6019f063af18a4729b756956c8f0cc35c) tor-browser-bundle-bin: 11.0.11 -> 11.0.13
* [`c888cdbc`](https://github.com/NixOS/nixpkgs/commit/c888cdbccae9326e0dc8504a57bf6aac1c4886f7) dolphin-emu-beta: mark as compatible with aarch64
* [`ad9a297f`](https://github.com/NixOS/nixpkgs/commit/ad9a297ff4b7a0065c42c13553cc669f0b121f0c) nix-plugins: 8.0.0 -> 9.0.0
* [`9dc13fb9`](https://github.com/NixOS/nixpkgs/commit/9dc13fb95359fa78d5ad7580d1e52d87cbf11f4d) python310Packages.policyuniverse: fix typo
* [`d2b57ba3`](https://github.com/NixOS/nixpkgs/commit/d2b57ba3453efb90b67ad882e4058aa8fc0f2936) terrascan: 1.15.0 -> 1.15.1
* [`c60d5f08`](https://github.com/NixOS/nixpkgs/commit/c60d5f08da0ee25b9ad5c9da5b1f978d51847b98) python310Packages.build: 0.7.0 -> 0.8.0
* [`96ba323a`](https://github.com/NixOS/nixpkgs/commit/96ba323a968d5f37b651a0f7442d971358653c82) kubescape: 2.0.152 -> 2.0.155
* [`a434418b`](https://github.com/NixOS/nixpkgs/commit/a434418bbe767329258f0c1da2c23ca5e00b1d48) cri-tools: 1.23.0 -> 1.24.1
* [`237b5838`](https://github.com/NixOS/nixpkgs/commit/237b5838d3b34b8a48dc6b65f7abd6538e26ec12) asterisk: update updateScript to include python deps
* [`06eee309`](https://github.com/NixOS/nixpkgs/commit/06eee30956e6bb2d3dae379e6c0905fcf7e0f2b1) postgresqlPackages.timescaledb: 2.6.1 -> 2.7.0
* [`3798f3c1`](https://github.com/NixOS/nixpkgs/commit/3798f3c16813373b434169d787f871b6276df507) kops: 1.23.1 -> 1.23.2 ([nixos/nixpkgs⁠#174165](https://togithub.com/nixos/nixpkgs/issues/174165))
* [`5d62b7f7`](https://github.com/NixOS/nixpkgs/commit/5d62b7f79fc2f2d83259584cc76d5dbf819c7ee2) asterisk: 16.25.1 -> 16.26.1, 18.11.1 -> 18.12.1, 19.3.1 -> 19.4.1
* [`c78acaec`](https://github.com/NixOS/nixpkgs/commit/c78acaecb415cc75b7a796ad76b2ccfc76517d92) gh: 2.10.1 -> 2.11.0
* [`208a03de`](https://github.com/NixOS/nixpkgs/commit/208a03de9303819907556e3ac0866a449af9dcbe) vivaldi-widevine: switch to fetchzip
* [`d08975af`](https://github.com/NixOS/nixpkgs/commit/d08975af50a36af940f3e2c92b8c9fa640f34a74) octoprint: 1.8.0 -> 1.8.1
* [`f0089877`](https://github.com/NixOS/nixpkgs/commit/f0089877040aa2d97814b9a3f261737115769dd4) e2fsprogs: apply patch unconditionally
* [`402e5fe4`](https://github.com/NixOS/nixpkgs/commit/402e5fe40d1184154e6ace4d2743fe53e7e83842) element-{web,desktop}: 1.10.12 -> 1.10.13
* [`1b27e162`](https://github.com/NixOS/nixpkgs/commit/1b27e162e537681b318b4610d0bffb2a74c47b70) zoom-us: 5.10.4.2845 -> 5.10.6.3192 on x86_64-linux
* [`b37e4c01`](https://github.com/NixOS/nixpkgs/commit/b37e4c01b13e01f6a2ec87c55f5255e1efa03fdf) ocamlPackages.linenoise: 1.3.0 -> 1.3.1
* [`6dcbf260`](https://github.com/NixOS/nixpkgs/commit/6dcbf260ccefe07fb4559faf8a3bcfd8154252a2) swaynotificationcenter: 0.5 -> 0.6.1
* [`4da5aea7`](https://github.com/NixOS/nixpkgs/commit/4da5aea7a370dd3334197c6a48da72016fa7baa8) maintainers: add ibizaman
* [`fb17a97f`](https://github.com/NixOS/nixpkgs/commit/fb17a97f1728cb59e24e4a88f641ee7208ba3ac0) nxt-python: init at 3.0.1
* [`1e447d78`](https://github.com/NixOS/nixpkgs/commit/1e447d78982c086d88509564d3176291746bc34b) pkgsStatic.python3: fix build
* [`4b8488f7`](https://github.com/NixOS/nixpkgs/commit/4b8488f72ac9f6cd964c83c2b1a9d273dc645b5b) ber-metaocaml: make useX11 be a parameter rather than a let-binding
* [`2d6c4410`](https://github.com/NixOS/nixpkgs/commit/2d6c4410424e75048144b147cb3e6ad51432fd82) gnome.gnome-keyring: 40.0 → 42.1
* [`0997b7fc`](https://github.com/NixOS/nixpkgs/commit/0997b7fc2997ba913604f2df6f11c054212c4452) python310Packages.django-polymorphic: 2.1.2 -> 3.1, adopt, normalise attr
* [`2e207b95`](https://github.com/NixOS/nixpkgs/commit/2e207b95a1a0fb101e007e7b371321e633210e79) python310Packages.ansible-lint: 6.1.0 -> 6.2.1
* [`2f5bb0bd`](https://github.com/NixOS/nixpkgs/commit/2f5bb0bddf74a9494d24765118b079abc64811ef) python310Packages.plugwise: 0.18.4 -> 0.18.5
* [`3bc476c9`](https://github.com/NixOS/nixpkgs/commit/3bc476c9b5c21e01ecb96db82a01f7d9ab0b8478) python310Packages.hahomematic: 1.5.0 -> 1.5.2
* [`fccb4573`](https://github.com/NixOS/nixpkgs/commit/fccb457303ed5ebd0ba39785667312f1ed634fb6) python310Packages.hahomematic: 1.5.2 -> 1.5.3
* [`a77280ef`](https://github.com/NixOS/nixpkgs/commit/a77280ef85ba5af5bfbac0c1fb5000988d7b8943) netdata: go.d.plugin: 0.31.0 -> 0.32.3
* [`2ab4d2f3`](https://github.com/NixOS/nixpkgs/commit/2ab4d2f39e05ff5250bcdcbd97f41ec81b4d320b) netdata: 1.33.1 -> 1.34.1
* [`7aae279a`](https://github.com/NixOS/nixpkgs/commit/7aae279ad9aacbf09293912939c2ba5795033f60) unstableGitUpdater: fix updating fetchzip-based sources
* [`4479dda8`](https://github.com/NixOS/nixpkgs/commit/4479dda83e9872bd59fad38ccc2f44aea8d1c4c5) python310Packages.pyduke-energy: 1.0.0 -> 1.0.1
* [`a8d44428`](https://github.com/NixOS/nixpkgs/commit/a8d44428398e3e7e8655f62505e839c68bb24b41) uutils-coreutils: 0.0.13 -> 0.0.14
* [`868e5192`](https://github.com/NixOS/nixpkgs/commit/868e5192385b8aab48a1e1c842e4317f912bc0ad) php: Upgrade from PHP 8.0 to 8.1 as default PHP
* [`7acf1bd7`](https://github.com/NixOS/nixpkgs/commit/7acf1bd7159d26fce2ae81ea2aafa7457156499d) python310Packages.qiskit-aer: disable failing test
* [`7397e96f`](https://github.com/NixOS/nixpkgs/commit/7397e96f1e14203ecb39fd1b25b391b26bb8b25d) unison-ucm: M2j -> M2l
* [`60a4fda9`](https://github.com/NixOS/nixpkgs/commit/60a4fda91d6cf27fc1b3774eef13259378571169) python3Packages.types-redis: init at 4.2.5
* [`b79667a2`](https://github.com/NixOS/nixpkgs/commit/b79667a20dfbb937311aec77123213387679f765) nixos-generators: 1.5.0 -> 1.6.0
* [`0bee571d`](https://github.com/NixOS/nixpkgs/commit/0bee571d1b420a885617dcef9a97e44fb60eedb0) python39Packages.tensorly: disable failing test
* [`886d8b7e`](https://github.com/NixOS/nixpkgs/commit/886d8b7ecfc600fc57047898ed3b1fceef39b613) xfce: convert old aliases to throws, and remove old throws
* [`bf30415f`](https://github.com/NixOS/nixpkgs/commit/bf30415f27ee6b0e4262782e675a5c7d428388ac) python310Packages.sumtypes: 0.1a5 -> 0.1a6
* [`183bd9e9`](https://github.com/NixOS/nixpkgs/commit/183bd9e940c1ca6373b9cf7c730ba9088959aed9) dump_syms: unstable-2022-05-05 -> 1.0.0
* [`f21a131f`](https://github.com/NixOS/nixpkgs/commit/f21a131f8925b97b6740474b52b8573cd7fd9341) checkov: 2.0.1153 -> 2.0.1160
* [`b95fefe3`](https://github.com/NixOS/nixpkgs/commit/b95fefe36051c02cf182a997668b9183ffbe87d9) python310Packages.tokenizers: unstable-2021-08-13 -> 0.12.1
* [`8075e7a1`](https://github.com/NixOS/nixpkgs/commit/8075e7a172633e5de88a07c76fc4665e4d0add8c) stockfish: 14.1 -> 15
* [`511491b5`](https://github.com/NixOS/nixpkgs/commit/511491b547ea8612cfd8b8431551e0ef92853edf) vimPlugins.vim-markdown-composer: fix executing
* [`79c564d9`](https://github.com/NixOS/nixpkgs/commit/79c564d9fa7869226b8463b0825eeb73ca17e517) modem-manager-gui: fix segfault on launch
* [`8c00b0e2`](https://github.com/NixOS/nixpkgs/commit/8c00b0e250e2555786ddad720dc393e822f7e5a4) gh: 2.11.0 -> 2.11.1
* [`76014d39`](https://github.com/NixOS/nixpkgs/commit/76014d394e728224c651e4fa66ad13224f4cd324) python310Packages.pyhocon: disable failing tests
* [`465a7f1e`](https://github.com/NixOS/nixpkgs/commit/465a7f1ef101d4241f5416ef9968ec3f4de5d53a) python310Packages.librouteros: 3.2.0 -> 3.2.1
* [`5d2ed3de`](https://github.com/NixOS/nixpkgs/commit/5d2ed3de044f783fc4f52e329e962eb1c982b033) python310Packages.pynetgear: 0.10.1 -> 0.10.2
* [`efec13e5`](https://github.com/NixOS/nixpkgs/commit/efec13e55019e029eaa995cfb10f443b625e0133) powerdns-admin: fix build
* [`73aa9f07`](https://github.com/NixOS/nixpkgs/commit/73aa9f07ee612cd8ab1f55dc9743a5015e8bd3b0) python310Packages.tokenizers: add Security for darwin
* [`0cb780d9`](https://github.com/NixOS/nixpkgs/commit/0cb780d900438e3d5030e92e4b4627e24800506b) python310Packages.archinfo: 9.2.4 -> 9.2.5
* [`2c0b4624`](https://github.com/NixOS/nixpkgs/commit/2c0b4624a0e9c6ace093452c4f7ffbf450a0ac40) python310Packages.ailment: 9.2.4 -> 9.2.5
* [`c4f9745f`](https://github.com/NixOS/nixpkgs/commit/c4f9745f39ff8e0e3baab2a87feafe663f6d0e09) python310Packages.pyvex: 9.2.4 -> 9.2.5
* [`4c0e9d32`](https://github.com/NixOS/nixpkgs/commit/4c0e9d324613012c44c0a53839bd523f2fd7e332) python310Packages.claripy: 9.2.4 -> 9.2.5
* [`829a56d6`](https://github.com/NixOS/nixpkgs/commit/829a56d63c57483b36063ee748fd134b95563f22) python310Packages.cle: 9.2.4 -> 9.2.5
* [`04352ee9`](https://github.com/NixOS/nixpkgs/commit/04352ee92fd71b1adcd9aec4670a781a6ceaf3f3) python310Packages.angr: 9.2.4 -> 9.2.5
* [`e4f65282`](https://github.com/NixOS/nixpkgs/commit/e4f65282482cf338102da7f408bfc034e1c90a7b) python310Packages.angrop: 9.2.4 -> 9.2.5
* [`e48814a2`](https://github.com/NixOS/nixpkgs/commit/e48814a245e08d8af5441d27a78b63701c1ba7ec) chromium: 101.0.4951.64 -> 102.0.5005.61
* [`c1781162`](https://github.com/NixOS/nixpkgs/commit/c17811628972327357e717988c85aeff0a1e95de) lincity: mark broken on darwin
* [`ba943bd9`](https://github.com/NixOS/nixpkgs/commit/ba943bd907beb63a845e4320a37c540094a8453a) chromiumBeta: 102.0.5005.49 -> 102.0.5005.61
* [`f52ca60f`](https://github.com/NixOS/nixpkgs/commit/f52ca60fd6340871203689de97c909a3e0e760b1) chromiumDev: 103.0.5056.0 -> 103.0.5060.13
* [`daacd37d`](https://github.com/NixOS/nixpkgs/commit/daacd37d6211b4ef7c7580bc0dfbbfb00c8d9896) chrysalis: 0.8.6 -> 0.9.4
* [`3cf64d71`](https://github.com/NixOS/nixpkgs/commit/3cf64d717af61c66d5a05b56a85dcb3f0c87dd8b) holdingnuts: remove
* [`a661cfe9`](https://github.com/NixOS/nixpkgs/commit/a661cfe9c2d9e945c5c90515390dc177f47f13c5) oprofile: remove withGUI
* [`02eba7e7`](https://github.com/NixOS/nixpkgs/commit/02eba7e7c59a6c962c24ee2d91d2243bbca86d42) python3Packages.panasonic-viera: init at 0.4.0
* [`cd19b704`](https://github.com/NixOS/nixpkgs/commit/cd19b704d1f088a7205ac8c40202698d4975984b) home-assistant: support panasonic_viera component
* [`876f70ea`](https://github.com/NixOS/nixpkgs/commit/876f70ea41fa3658db144e23a6316985fabed8dc) python3Packages.siobrultech-protocols: init at 0.5.0
* [`718a35f6`](https://github.com/NixOS/nixpkgs/commit/718a35f65adff8e5239b32852bd602a8a35ba15d) python3Packages.greeneye-monitor: init at 3.0.3
* [`56a06e50`](https://github.com/NixOS/nixpkgs/commit/56a06e501a50eba4691cb74dfe4c66c029656e51) home-assistant: support greeneye_monitor component
* [`4b67eb76`](https://github.com/NixOS/nixpkgs/commit/4b67eb7610d063ce7e332bd4eafe32f082e98f0c) home-assistant: don't test hassfest
* [`ee880b7f`](https://github.com/NixOS/nixpkgs/commit/ee880b7fe13d32aede183562e634c4f77deb3ff9) bloat: unstable-2022-03-31 -> unstable-2022-05-10
* [`85efde9b`](https://github.com/NixOS/nixpkgs/commit/85efde9b7ef554c956b83a6603e8abf61ecc4f5d) arkade: 0.8.23 -> 0.8.24
* [`cbf736eb`](https://github.com/NixOS/nixpkgs/commit/cbf736eb3906fd1d4c3efba40d3846140a616b9b) CODEOWNERS: remove expipiplus1 from haskell
* [`65bd6b2f`](https://github.com/NixOS/nixpkgs/commit/65bd6b2faa640314cdbee5c04a86f7b5bc1f484a) ani-cli: 2.1 -> 2.2
* [`ed8f89cc`](https://github.com/NixOS/nixpkgs/commit/ed8f89cc125ed521cc71852c516b10f2f215c63f) asciigraph: 0.5.3 -> 0.5.5
* [`68dfbe06`](https://github.com/NixOS/nixpkgs/commit/68dfbe0683f3738f06062be4dcef7736d081670d) shfmt: 3.5.0 -> 3.5.1
* [`00a7a7f2`](https://github.com/NixOS/nixpkgs/commit/00a7a7f26bb06725832ac09d9b1e2991075bf2f5) boundary: 0.8.0 -> 0.8.1
* [`3688fe70`](https://github.com/NixOS/nixpkgs/commit/3688fe70f4ddece54a8a468fa90209066675f0e0) qt6: remove all references to aliases
* [`becc3bd5`](https://github.com/NixOS/nixpkgs/commit/becc3bd5cba478aea91d42102a9839365797fc4a) plexRaw: 1.26.1.5798-99a4a6ac9 -> 1.26.2.5797-5bd057d2b
* [`cce84b57`](https://github.com/NixOS/nixpkgs/commit/cce84b571dc59beffe26e5cb75ca0477d6959aa4) starship: 1.6.3 -> 1.7.1
* [`52ef678c`](https://github.com/NixOS/nixpkgs/commit/52ef678cae9f62b7d709daf0f961d615f5b7d3a6) cfripper: 1.9.0 -> 1.10.0
* [`4ccd3c97`](https://github.com/NixOS/nixpkgs/commit/4ccd3c9704707725ae4ef86f4333bb5e608ddfb2) actionlint: 1.6.12 -> 1.6.13
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
