### PR TITLE
niv emacs-overlay: update 5f10d6cf -> 563a7a4b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5f10d6cf7c37ddf97df61bd25bb68e124b094014",
-        "sha256": "1lwspl4v0xj8skbx8zmlym56vim3j597rc9avlbrngy8zlckrddy",
+        "rev": "563a7a4b38efb5c99ef4638bfa8064136c05b19f",
+        "sha256": "0wrdjl0v6hm5lpkrjfahh232782d1fydr583j24ypv0khw3a25h7",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/5f10d6cf7c37ddf97df61bd25bb68e124b094014.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/563a7a4b38efb5c99ef4638bfa8064136c05b19f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@5f10d6cf...563a7a4b](https://github.com/nix-community/emacs-overlay/compare/5f10d6cf7c37ddf97df61bd25bb68e124b094014...563a7a4b38efb5c99ef4638bfa8064136c05b19f)

* [`0a9aa03c`](https://github.com/nix-community/emacs-overlay/commit/0a9aa03cd359bf58d079a1670e083c4ce33d3a15) Updated repos/emacs
* [`5eca6eb3`](https://github.com/nix-community/emacs-overlay/commit/5eca6eb3f6bad6b8121c5f73a3ce403b3cb2be51) Updated repos/melpa
* [`30daebac`](https://github.com/nix-community/emacs-overlay/commit/30daebac5920dd01f4fc426f10fe619c290e32c7) Updated repos/emacs
* [`2a6e56c7`](https://github.com/nix-community/emacs-overlay/commit/2a6e56c7e3a30b98677447748084a2e5926af982) Updated repos/melpa
* [`571a6570`](https://github.com/nix-community/emacs-overlay/commit/571a657028abd0696e3f60c42f3693741ff880fd) Updated repos/emacs
* [`2a9b6c91`](https://github.com/nix-community/emacs-overlay/commit/2a9b6c9109e73e7c2c3b5de32577a1365926524c) Updated repos/melpa
* [`22e40098`](https://github.com/nix-community/emacs-overlay/commit/22e40098093f7b1b393f879a47fd618d99c78356) Updated repos/emacs
* [`d17a84f5`](https://github.com/nix-community/emacs-overlay/commit/d17a84f55aa4964afe0acfe09f96aa525b5292a4) Updated repos/melpa
* [`157f8649`](https://github.com/nix-community/emacs-overlay/commit/157f8649d4fee3fd092421d20bdd24f6c0f35f04) Updated repos/melpa
* [`4ffbd5cb`](https://github.com/nix-community/emacs-overlay/commit/4ffbd5cb12653c1827cd56b440a6fb93f5d27ebe) Updated repos/elpa
* [`eb802040`](https://github.com/nix-community/emacs-overlay/commit/eb80204023dcbe807634ce3b42e678abb6cb2da9) Updated repos/emacs
* [`6945be48`](https://github.com/nix-community/emacs-overlay/commit/6945be48fc2c2592de4876c0bc8cfdc8c5227cb3) Updated repos/melpa
* [`fc4e57e8`](https://github.com/nix-community/emacs-overlay/commit/fc4e57e8b7c15623e7af30027c8768300bc9a9f3) Updated repos/emacs
* [`586db93d`](https://github.com/nix-community/emacs-overlay/commit/586db93d221cd9ab53db661e9403f9f63c8d897d) Updated repos/melpa
* [`e285a37c`](https://github.com/nix-community/emacs-overlay/commit/e285a37cd7dc3c610087002ee5cb90d858d66c41) Updated repos/elpa
* [`7a5353c3`](https://github.com/nix-community/emacs-overlay/commit/7a5353c3d27749912df89d1083e9b675f70accb4) Updated repos/melpa
* [`4f155fb0`](https://github.com/nix-community/emacs-overlay/commit/4f155fb01e84fa47ae31df5fcc213c1a4fcfb8ab) Updated repos/elpa
* [`2db72f29`](https://github.com/nix-community/emacs-overlay/commit/2db72f298775895f836a6a29e22e2568b6d72e44) Updated repos/emacs
* [`acc4b3f7`](https://github.com/nix-community/emacs-overlay/commit/acc4b3f78f3d210215a9cf96c8e5cef068b53b6b) Updated repos/melpa
* [`8c890940`](https://github.com/nix-community/emacs-overlay/commit/8c8909403cb279cc7e15a81ae99bfef41245b53c) Updated repos/elpa
* [`cde43f4e`](https://github.com/nix-community/emacs-overlay/commit/cde43f4ee533961653a974ddebb2d0dc4ae3462c) Updated repos/emacs
* [`3380f53d`](https://github.com/nix-community/emacs-overlay/commit/3380f53d06f484a87c5dd0317bc081dbc9f5f13d) Updated repos/melpa
* [`e556be8e`](https://github.com/nix-community/emacs-overlay/commit/e556be8ee42f6c11bc223ffc4d1743f36472d011) Updated repos/emacs
* [`b4e68af3`](https://github.com/nix-community/emacs-overlay/commit/b4e68af357c86148dad55b0a40049c63df7271b4) Updated repos/melpa
* [`b9bf95db`](https://github.com/nix-community/emacs-overlay/commit/b9bf95db7427b39d40f65e5a0ee0d2a9bd9abd60) Updated repos/emacs
* [`ff629e75`](https://github.com/nix-community/emacs-overlay/commit/ff629e757452d010b7c91fdd2597aeca370bcf68) Updated repos/melpa
* [`4aad6817`](https://github.com/nix-community/emacs-overlay/commit/4aad6817784435c9125d91a7e0070a799fc3a57e) Updated repos/emacs
* [`e3994fc8`](https://github.com/nix-community/emacs-overlay/commit/e3994fc8b0cf4a1dc1080e697a09d33d9faa5e39) Updated repos/melpa
* [`5c914d54`](https://github.com/nix-community/emacs-overlay/commit/5c914d54634f928cc07b3e7529b6b44d392ccb83) Updated repos/elpa
* [`14a95b9c`](https://github.com/nix-community/emacs-overlay/commit/14a95b9c920768b53d07d7e648723229c016e831) Updated repos/emacs
* [`5c1b9b2d`](https://github.com/nix-community/emacs-overlay/commit/5c1b9b2d7bca01ff7f50a0de435d796bf42c2081) Updated repos/melpa
* [`8a11b61b`](https://github.com/nix-community/emacs-overlay/commit/8a11b61b5374597070488b59389990a98c7f66e0) Updated repos/emacs
* [`8c19a841`](https://github.com/nix-community/emacs-overlay/commit/8c19a841dbf438c1001fdd869612ea79e00404c0) Updated repos/melpa
* [`5a1d3e07`](https://github.com/nix-community/emacs-overlay/commit/5a1d3e0732f21e2b7d568e30d5d8870beed9c13b) Updated repos/elpa
* [`4eef0800`](https://github.com/nix-community/emacs-overlay/commit/4eef0800ba7ab577e1e130b9dc7377e73bad0e5c) Updated repos/emacs
* [`8d1ee06d`](https://github.com/nix-community/emacs-overlay/commit/8d1ee06daa51522db5efd5308d85106197f6ffb0) Updated repos/melpa
* [`1ec5fb4c`](https://github.com/nix-community/emacs-overlay/commit/1ec5fb4c67714e99c1870d5e5d6e71c22507133d) Updated repos/elpa
* [`77a1abdc`](https://github.com/nix-community/emacs-overlay/commit/77a1abdc1c6c9a471c6c1d72d48079063db80db9) Updated repos/emacs
* [`140928a8`](https://github.com/nix-community/emacs-overlay/commit/140928a84b535f0566f9fc881de29012e7e9331c) Updated repos/melpa
* [`259b9760`](https://github.com/nix-community/emacs-overlay/commit/259b9760b24d99a45e08a562c4fc98191091ac12) Updated repos/emacs
* [`59765312`](https://github.com/nix-community/emacs-overlay/commit/597653124da17fe0837f58e038cd683a4abfb50f) Updated repos/melpa
* [`8b4487f6`](https://github.com/nix-community/emacs-overlay/commit/8b4487f62c9cf20eb44c2dcdc0b96b99cdef804c) Updated repos/emacs
* [`97caa1df`](https://github.com/nix-community/emacs-overlay/commit/97caa1df840ca614698e3e286a0a27916306234e) Updated repos/melpa
* [`522ef925`](https://github.com/nix-community/emacs-overlay/commit/522ef9258453a65f582305feafcb67d0e42d55bd) Updated repos/elpa
* [`a2d01390`](https://github.com/nix-community/emacs-overlay/commit/a2d01390ff15a060785f7a8eea440b9e2fae7ee3) Updated repos/emacs
* [`563a7a4b`](https://github.com/nix-community/emacs-overlay/commit/563a7a4b38efb5c99ef4638bfa8064136c05b19f) Updated repos/melpa
