### PR TITLE
niv powerlevel10k: update 74ff02a8 -> 5c7ad753

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "74ff02a819c5b83b8022c973ce100e41104a41cf",
-        "sha256": "1sy8h2wvj0br1fj97crcvw6a9k4gx4vvh082l26kzv75y9069qzg",
+        "rev": "5c7ad753a2addf016532283978c4b72653670275",
+        "sha256": "148wp38vxa2fcffm1n6zcgj9mydffsrzmknr9f9l1sjwn6by0kvw",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/74ff02a819c5b83b8022c973ce100e41104a41cf.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/5c7ad753a2addf016532283978c4b72653670275.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@74ff02a8...5c7ad753](https://github.com/romkatv/powerlevel10k/compare/74ff02a819c5b83b8022c973ce100e41104a41cf...5c7ad753a2addf016532283978c4b72653670275)

* [`cf9a1fd0`](https://github.com/romkatv/powerlevel10k/commit/cf9a1fd02de7c23de102abbf6406ceaabf252a83) suppress `nounset` error if `DIRENV_DIR` isn’t defined (fix [romkatv/powerlevel10k⁠#1876](https://togithub.com/romkatv/powerlevel10k/issues/1876))
* [`a3f6859a`](https://github.com/romkatv/powerlevel10k/commit/a3f6859a8d263973f840f2ae12c0c1f9821cdea8) cleanup
* [`5c7ad753`](https://github.com/romkatv/powerlevel10k/commit/5c7ad753a2addf016532283978c4b72653670275) add installation instructions for alpine; related: [romkatv/powerlevel10k⁠#1828](https://togithub.com/romkatv/powerlevel10k/issues/1828)
