### PR TITLE
niv spacemacs: update b5ae2fc3 -> 69027b8e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "b5ae2fc3b211f03a475d3115e90183f7dbce1981",
-        "sha256": "17p141n7fz3njsdw52cryqj7iawlhn0wsbfidjx1qmwjslw9nvbl",
+        "rev": "69027b8eec1c09c867c9951908f73b26213eec31",
+        "sha256": "0j121sxqpabqmyphdqpgr6aaac2c3yx7z0rpmxmim592mmcf7dc6",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/b5ae2fc3b211f03a475d3115e90183f7dbce1981.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/69027b8eec1c09c867c9951908f73b26213eec31.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@b5ae2fc3...69027b8e](https://github.com/syl20bnr/spacemacs/compare/b5ae2fc3b211f03a475d3115e90183f7dbce1981...69027b8eec1c09c867c9951908f73b26213eec31)

* [`5c3c14b1`](https://github.com/syl20bnr/spacemacs/commit/5c3c14b1090f30befc7bee410fd7202908d90767) [ci] Update Emacs version (elisp tests)
* [`350953e0`](https://github.com/syl20bnr/spacemacs/commit/350953e093e90a1f688d525e90305f06c39a5508) [doc] remove lexical binding from export script
* [`06f85fb2`](https://github.com/syl20bnr/spacemacs/commit/06f85fb201b2b34acd7b269e61c441dc5917f7cb) [bot] "built_in_updates" Tue May 24 11:51:51 UTC 2022
* [`756e204d`](https://github.com/syl20bnr/spacemacs/commit/756e204d250507ad7137ecbcd2ab4feaedf68b63) [layers+misc/ietf] fix auto-mode-alias for ietf
* [`f4b04bcf`](https://github.com/syl20bnr/spacemacs/commit/f4b04bcf228b9e9a6eb1e19a9f1f78b429e347ad)  Add obsoletion notification evilified-state-evilify
* [`e9f09cde`](https://github.com/syl20bnr/spacemacs/commit/e9f09cde482bf3da239bbcb34999b4e404356d06) Enable racer only when it is selected as a backend
* [`712aa318`](https://github.com/syl20bnr/spacemacs/commit/712aa3187024158e9f284af925ec41ea0a46d293) [Rust] Move package loading conditions to package list
* [`9d7646f0`](https://github.com/syl20bnr/spacemacs/commit/9d7646f0f4293c618779fde90087140db506078d) [scala] add keybinding for running `It / compile` in SBT
* [`2325fc52`](https://github.com/syl20bnr/spacemacs/commit/2325fc521fbbc9a33d7e5f7dd6471141a20f3f1b) Fix: variable is void: emoji-cheat-sheet-plus-buffer-mode warning
* [`39b9def6`](https://github.com/syl20bnr/spacemacs/commit/39b9def6d5ef4988ca2862d5198dee611452dfb7) Fix variable is void warnings at startup
* [`54c6cce3`](https://github.com/syl20bnr/spacemacs/commit/54c6cce3706eddc9d591fcd23931b98fa362e0e6) [bot] "documentation_updates" Sun May 29 13:05:22 UTC 2022
* [`04143bd9`](https://github.com/syl20bnr/spacemacs/commit/04143bd937994079768875d8ede857c5da96f7da) [bot] "built_in_updates" Sun May 29 13:05:01 UTC 2022
* [`96360701`](https://github.com/syl20bnr/spacemacs/commit/96360701cc610f894bf0b63bf917e3c36e038d08) [evil] fix missing spacemacs-default-map in evil-lisp-state.
* [`b8f471dc`](https://github.com/syl20bnr/spacemacs/commit/b8f471dc1ca0fa87d48dd1060ab75fd220da1e2e) [core] new recipe :fetcher local
* [`c0948b3e`](https://github.com/syl20bnr/spacemacs/commit/c0948b3e04890dd699d579a469e506c85b78a3e5) [defaults] Fix toggle line numbers to respect dotspacemacs-line-numbers.
* [`69027b8e`](https://github.com/syl20bnr/spacemacs/commit/69027b8eec1c09c867c9951908f73b26213eec31) [latex] Replace auctex-latexmk with a fixed fork
