### PR TITLE
niv nixpkgs: update d8994d48 -> e4cb4bdb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8994d48bad6232b4987e3184bb850ef446d791a",
-        "sha256": "1kyhb33wx8mgnp4dq83axz00hywwimhkh44md5rv66ygisb2q8x9",
+        "rev": "e4cb4bdb05605d691ca31b54703f2866197944ef",
+        "sha256": "0qmqcisls40qp8va6bj9pamprslrwwwlwdq0bcsq41bgk6nki8dz",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d8994d48bad6232b4987e3184bb850ef446d791a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e4cb4bdb05605d691ca31b54703f2866197944ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d8994d48...e4cb4bdb](https://github.com/nixos/nixpkgs/compare/d8994d48bad6232b4987e3184bb850ef446d791a...e4cb4bdb05605d691ca31b54703f2866197944ef)

* [`d68f731b`](https://github.com/NixOS/nixpkgs/commit/d68f731ba246add4c4e456d829eb19136e65290e) nixos/libreddit: systemd unit hardening
* [`f04ef2a2`](https://github.com/NixOS/nixpkgs/commit/f04ef2a25b292144ba7856c96b2a96fee99639dc) nixos/libreddit: do not test an error
* [`29bcdaad`](https://github.com/NixOS/nixpkgs/commit/29bcdaade355680132add66fc676ca86e2aaf88d) nixos/libreddit: remove redirect option
* [`42f6c2c7`](https://github.com/NixOS/nixpkgs/commit/42f6c2c7ed3e5c9b27c7f05415ba0d22913fa3bd) python: fix enableOptimizations with clang
* [`680b1632`](https://github.com/NixOS/nixpkgs/commit/680b1632a609d5e7f128c445a382486ca106800a) python3Packages.sfepy: 2021.4 -> 2022.1
* [`3b07ade2`](https://github.com/NixOS/nixpkgs/commit/3b07ade247bebbfad3d36162a1693ab994776a82) wasm-bindgen-cli: 0.2.79 -> 0.2.80
* [`8b5d305e`](https://github.com/NixOS/nixpkgs/commit/8b5d305e7c09f107fcfe85eacc209e4e9c729012) olm: 3.2.10 -> 3.2.11
* [`d78bf759`](https://github.com/NixOS/nixpkgs/commit/d78bf7598ac0da8d58a55b11e6f3d25f05786217) chatterino2: 2.3.4 -> 2.3.5
* [`fba8a1de`](https://github.com/NixOS/nixpkgs/commit/fba8a1de003db2e403d3c1d26069e87921777c0f) appimageTools.defaultFhsEnvArgs: Drop GConf
* [`e48ca2fa`](https://github.com/NixOS/nixpkgs/commit/e48ca2fa569b92ba3e196bf0b015bb5e342cc508) androidenv: document update procedure
* [`928d976a`](https://github.com/NixOS/nixpkgs/commit/928d976aa59dd45fc68bfb933e27c3453cddfe23) androidenv: regenerate repo.json
* [`1df30613`](https://github.com/NixOS/nixpkgs/commit/1df306132b89d5d5ad9895a47efc3f76963963fc) platform-tools: allow aarch64-darwin
* [`f9e2c544`](https://github.com/NixOS/nixpkgs/commit/f9e2c5443cf6072546b7d9ee7231dcc829a01d7f) prusa-slicer: use patched wxWidgets
* [`24aedd7f`](https://github.com/NixOS/nixpkgs/commit/24aedd7fb9784729605068f0123e7068ebb0daa9) pcre2: 10.39 -> 10.40
* [`235c1c17`](https://github.com/NixOS/nixpkgs/commit/235c1c17662bca229537a560b79bd33b5fd3131b) qtbase: use -pthread instead of -lpthread
* [`47473d4a`](https://github.com/NixOS/nixpkgs/commit/47473d4ad993b28f7cf1b03d95335cc79795ff53) python310Packages.vulcan-api: 2.0.3 -> 2.1.1
* [`d6b756de`](https://github.com/NixOS/nixpkgs/commit/d6b756dec558672fca372b1e261ed0e813c1091d) jabcode: unstable-2020-05-13 -> unstable-2021-02-16
* [`c047171d`](https://github.com/NixOS/nixpkgs/commit/c047171df6b1790d0a8776099cfe55059c8ac4e2) python39Packages.nbclient.passthru.tests.check: fix tests
* [`bff64d8e`](https://github.com/NixOS/nixpkgs/commit/bff64d8e02fa1685b6cfbbd9e2b980f36ffd60f6) libmt32emu: 2.5.3 -> 2.6.3
* [`f7db111f`](https://github.com/NixOS/nixpkgs/commit/f7db111ff081c69c77e64b1750a1bfcc63cb4b99) gkraken: 1.1.6 -> 1.2.0
* [`883cb64a`](https://github.com/NixOS/nixpkgs/commit/883cb64ae9d9c266bae6e19d740428505a997a66) mt32emu-qt: 1.9.0 -> 1.10.2
* [`f88302aa`](https://github.com/NixOS/nixpkgs/commit/f88302aa1c0bc6f41cf2391605112c2c31a84290) mt32emu-smf2wav: 1.7.0 -> 1.8.2
* [`be09e321`](https://github.com/NixOS/nixpkgs/commit/be09e32117d51bae9f05951fbd69c3c530aa03ad) ncurses: 6.3 -> 6.3-p20220507
* [`73ec0bf7`](https://github.com/NixOS/nixpkgs/commit/73ec0bf71fc15c01ae408e826e6c014ab2f0cf0e) vala: default to vala_0_56
* [`caa832cb`](https://github.com/NixOS/nixpkgs/commit/caa832cbc6a48cc6ea4a9cc4c390fbb62002d4a9) teamviewer: set outputs to reduce runtime closure
* [`4165ae53`](https://github.com/NixOS/nixpkgs/commit/4165ae53920a84ba14ce675d138592432e0a3a74) pygtk: set outputs to reduce runtime closure
* [`179dd402`](https://github.com/NixOS/nixpkgs/commit/179dd402cbb2772cb8b80de3c58b21efb23ba030) yoda: 1.9.4 -> 1.9.5
* [`d2144c1e`](https://github.com/NixOS/nixpkgs/commit/d2144c1e0cce513807d15979eb9844386cd16ccc) rivet: 3.1.5 -> 3.1.6
* [`94ca2255`](https://github.com/NixOS/nixpkgs/commit/94ca225532c90c2f83785eaf62c2ce8b54511061) python310Packages.ujson: 5.1.0 -> 5.2.0
* [`304eb995`](https://github.com/NixOS/nixpkgs/commit/304eb995a7a4936c113ccd5a2300c9db0bcf77ff) python310Packages.incremental: adopt, add tests, fix dependencies
* [`6596ccf4`](https://github.com/NixOS/nixpkgs/commit/6596ccf4471abc8c746190a34a2da6d6c0658c63) python310Packages.automat: adopt, run tests
* [`76291b33`](https://github.com/NixOS/nixpkgs/commit/76291b332b2de570acad407c0e01babdabda0b00) python310Packages.twisted: adopt, run tests
* [`06737d28`](https://github.com/NixOS/nixpkgs/commit/06737d2879bd33a65540ebd69431e457e92fe075) python3Packages.twisted: add some key reverse dependencies to passthru.tests
* [`5ec3ebf9`](https://github.com/NixOS/nixpkgs/commit/5ec3ebf9bc9a5b2f184bfdddc265c50bd73d7c65) python3Packages.twisted: use extras-require
* [`49810cec`](https://github.com/NixOS/nixpkgs/commit/49810cec5da9c15d3afc7f6a3f2e8ab477a4e0d7) mjolnir: 1.4.1 -> 1.4.2
* [`050e0aa6`](https://github.com/NixOS/nixpkgs/commit/050e0aa6de82ca773bb763ad5715f38202ae3a22) nixos/tests/mjolnir: set enable_registration_without_verification for matrix-synapse
* [`be201078`](https://github.com/NixOS/nixpkgs/commit/be2010780908cc80c73c7d66edf4c95dc3ffbddf) kde/frameworks: 5.93 -> 5.94
* [`a2e8dd2e`](https://github.com/NixOS/nixpkgs/commit/a2e8dd2e74787b08908d9548484d3204dcbbaa43) kapidox: fix build with python packages
* [`efb845f4`](https://github.com/NixOS/nixpkgs/commit/efb845f4a731b1498e85fd62f2e8d2911c129675) plasma-wayland-protocols: 1.6.0 -> 1.7.0
* [`27b6da01`](https://github.com/NixOS/nixpkgs/commit/27b6da01b3d5c245e7e09df04ac02ca106a629a8) kf5/kguiaddons: add plasma-wayland-protocols to buildInputs
* [`4b6301d6`](https://github.com/NixOS/nixpkgs/commit/4b6301d6564cde7509895a222e2eea8fe347029c) loki-lib: compile with c++11
* [`2fce4539`](https://github.com/NixOS/nixpkgs/commit/2fce45391a91a898d0183149ad602a0db397fea2) semantik: fix for new kf5
* [`d7ee690a`](https://github.com/NixOS/nixpkgs/commit/d7ee690ae7f94ba35562ab96a5caf70356d66695) ksmoothdock: 6.2 -> 6.3
* [`e13ec872`](https://github.com/NixOS/nixpkgs/commit/e13ec87217c949d0aea368fafb2808578e2ced05) nixos/grafana: add Azure AD OAuth options
* [`8d8b43cb`](https://github.com/NixOS/nixpkgs/commit/8d8b43cb3c5069e6a90b011e3882dd27a91e63bb) libtiff: add patches for CVE-2022-1354 & CVE-2022-1355
* [`ea8f7e7b`](https://github.com/NixOS/nixpkgs/commit/ea8f7e7bbdea64e693fc09f0a68d55d5a260020f) nixos/grafana: add serveFromSubPath option
* [`298e2ce3`](https://github.com/NixOS/nixpkgs/commit/298e2ce302c3d4eeacaca4bf4d0437253a8cafbc) nixos/grafana: add disableLoginForm option
* [`44c5652c`](https://github.com/NixOS/nixpkgs/commit/44c5652c191901a25a63740c43a6ec0f45ec1959) mesa: 22.0.2 -> 22.0.3
* [`d97482f6`](https://github.com/NixOS/nixpkgs/commit/d97482f6c6a1f4e2a4bfe523d6767f218f56abd4) git: 2.36.0 -> 2.36.1
* [`5185a359`](https://github.com/NixOS/nixpkgs/commit/5185a359c25e8f821cd87877d56f1cc831705159) python310Packages.django: add pythonImportsCheck, little code cleanup
* [`939cdf5d`](https://github.com/NixOS/nixpkgs/commit/939cdf5d46adee9dfadc8dc7634f4edc1c9e68f0) python310Packages.nexia: 0.9.13 -> 1.0.0
* [`0b1340f5`](https://github.com/NixOS/nixpkgs/commit/0b1340f57b09e6cf290f0fe45509665aea14b5b3) nixos/peertube: use redis.servers
* [`f4129f97`](https://github.com/NixOS/nixpkgs/commit/f4129f97aacb73f5cda3659a1167bfdbc2720b6b) python3Packages.msgraph-core: init at 0.2.2
* [`da7ccf3f`](https://github.com/NixOS/nixpkgs/commit/da7ccf3f63311da228604389a30d8e4ac151d99c) python3Packages.parsedmarc: 7.0.1 -> 8.2.0
* [`8abf3eaa`](https://github.com/NixOS/nixpkgs/commit/8abf3eaa38c1b6e5159a7a114f819499404f2622) Revert "libfreeaptx: avoid rebuilding on Linux for now"
* [`aac2235e`](https://github.com/NixOS/nixpkgs/commit/aac2235e79c449667b357e83c1b0b934ca299799) valgrind: fix build error for aarch64+Musl
* [`5a057726`](https://github.com/NixOS/nixpkgs/commit/5a0577265e7c644603a42da0fe7f907b199d57e4) nixos/tests/ihatemoney: fix test
* [`39a77086`](https://github.com/NixOS/nixpkgs/commit/39a77086e1c50bc602c803df43b0e72e0f4fe1bb) kf5/kapidox: apply suggestions from code review
* [`5e2009d8`](https://github.com/NixOS/nixpkgs/commit/5e2009d8942ca408016085cf2aceb9e6b0b24d05) systemd: fix build platform shebang reference
* [`09d7db1e`](https://github.com/NixOS/nixpkgs/commit/09d7db1e99f190b4d747c882a00f651cf61cc2ea) python310Packages.nexia: 1.0.0 -> 1.0.1
* [`98ce308a`](https://github.com/NixOS/nixpkgs/commit/98ce308ab5fbd33701490cc28a1331dfae1de2bc) python3Packages.pandas: skip test_rolling_var_numerical_issues
* [`8fdfe10b`](https://github.com/NixOS/nixpkgs/commit/8fdfe10bcffab56ab95d7e092acd9d8b9157e65c) lean2: 2017-07-22 -> 2018-10-01, unbreak
* [`be366766`](https://github.com/NixOS/nixpkgs/commit/be366766f67a6f964a9ac06bb980968ccac63a8d) mlmmj: add -fcommon workaround
* [`81666cca`](https://github.com/NixOS/nixpkgs/commit/81666cca21d1ded667eced1f00ea78478e007021) mmh: unstable-2019-09-08 -> unstable-2020-08-21
* [`e0ecf697`](https://github.com/NixOS/nixpkgs/commit/e0ecf69705bcffd8cb57b955f5f5e651b0e57c76) iana-etc: 20211124 -> 20220520
* [`62e002d1`](https://github.com/NixOS/nixpkgs/commit/62e002d1cd8e46a2a635116ea895fb7df83553db) bison: explicitly set strictDeps
* [`b0dce7f7`](https://github.com/NixOS/nixpkgs/commit/b0dce7f79b7c0efaffbdecbc0a576481ce608932) texinfo: enable strictDeps and use libintl instead of gettext optional
* [`39b85d1c`](https://github.com/NixOS/nixpkgs/commit/39b85d1c2a85c91d5d14235cd5aeb8a3a3fae5e1) trivial-builders.nix: add TODO
* [`f002ffed`](https://github.com/NixOS/nixpkgs/commit/f002ffed9ab96ed074aba0f20c54e813e604fc4e) treewide: enable strictDeps in bootstrap packages
* [`6b46fa89`](https://github.com/NixOS/nixpkgs/commit/6b46fa896e5a92795894ff191e96c4fe51d99b87) python3Minimal: enable strictDeps
* [`0f9ee45a`](https://github.com/NixOS/nixpkgs/commit/0f9ee45a6d9cb043ca29f84fcb977c3f15cc005d) glibc: enable strictDeps
* [`761ecd10`](https://github.com/NixOS/nixpkgs/commit/761ecd1061f27c429bd06b11e16f85d2b0db8a6e) python39: 3.9.12 -> 3.9.13
* [`55c8e272`](https://github.com/NixOS/nixpkgs/commit/55c8e2729042bfab9b91bc01b14a504cbf2702e2) rust: 1.60.0 -> 1.61.0 ([nixos/nixpkgs⁠#173631](https://togithub.com/nixos/nixpkgs/issues/173631))
* [`a4774b5b`](https://github.com/NixOS/nixpkgs/commit/a4774b5b1b6ee17908c456727eb22d3508c8fe84) netperf: pull patch pending upstream inclusion for -fno-common toolchain support
* [`4647a8f7`](https://github.com/NixOS/nixpkgs/commit/4647a8f70a8c48258babcf4e8bc4117a85d2d6d3) rkdeveloptool-pine64: init at unstable-2021-09-04
* [`3f1dc48e`](https://github.com/NixOS/nixpkgs/commit/3f1dc48efea0a3a6608263c79485a91686629d28) python3Packages.sqlalchemy-utils: run tests
* [`97a855ca`](https://github.com/NixOS/nixpkgs/commit/97a855ca0ec6509b6da8fed8232b97094ce97e97) nixos/nvidia: only apply workarounds for finegrained when needed
* [`d5a9c1dd`](https://github.com/NixOS/nixpkgs/commit/d5a9c1dd08dab74d5d76b5ceb3079ab91e1778c6) nixos/nvidia: remove a useless option
* [`a452e0e2`](https://github.com/NixOS/nixpkgs/commit/a452e0e2642bf961d03eaa5ce6b2ee8a9725ecee) hypnotix: init at 2.6
* [`386ccee2`](https://github.com/NixOS/nixpkgs/commit/386ccee2fb2df8f671584cb73ec1eb2b7114fdaa) ntfy-sh: 1.22.0 -> 1.23.0
* [`b1737502`](https://github.com/NixOS/nixpkgs/commit/b1737502131b02a52b475a0ee084b758e2989388) kmod: build devdoc
* [`305b8d47`](https://github.com/NixOS/nixpkgs/commit/305b8d473edfe2ba52bc2deddb89013d38609dc3) unibilium: 20190811 → 2.1.1, fix cross-compilation
* [`2654e44f`](https://github.com/NixOS/nixpkgs/commit/2654e44f04965a82cc4d37eb1343b268364c13fa) swaysome: 1.1.4 -> 1.1.5
* [`3bb9f758`](https://github.com/NixOS/nixpkgs/commit/3bb9f75827ee59f914dca0b0357a05259ec59354) maintainers: add minion3665
* [`36a11674`](https://github.com/NixOS/nixpkgs/commit/36a116742ded785300809dfa25a7dba18e54f443) krita: 5.0.2 -> 5.0.6
* [`08280046`](https://github.com/NixOS/nixpkgs/commit/0828004641db1dc111f7d14004a7101626980e30) openrazer-daemon,linuxPackages.openrazer,python3.pkgs.openrazer: 3.1.0 -> 3.3.0
* [`2cdd54c2`](https://github.com/NixOS/nixpkgs/commit/2cdd54c279b563fac6b658b35c214ab1936d7109) linuxPackages.openrazer: enable parallel building
* [`c9e173fe`](https://github.com/NixOS/nixpkgs/commit/c9e173fe09e33545ba936a0ee681df5200bae8f1) bzip3: init at 1.1.3
* [`43b7c961`](https://github.com/NixOS/nixpkgs/commit/43b7c9611ca823741d702f6e00059185bb3e856e) Revert "xorg.xorgserver: 1.20.13 -> 21.1.3"
* [`1e65cb9c`](https://github.com/NixOS/nixpkgs/commit/1e65cb9c88999f725385425a562de9dcadf41397) xorg.xorgserver: 1.20.13 -> 1.20.14
* [`2c1040a3`](https://github.com/NixOS/nixpkgs/commit/2c1040a31543c0dd59a73c4ad0cc057e520048b2) SDL2: 2.0.20 -> 2.0.22
* [`3c211fb5`](https://github.com/NixOS/nixpkgs/commit/3c211fb5915a5984639e4ed61824c2aa2234bec6) glibc: apply pending PR29162 to unbreak gnat6
* [`f862ced0`](https://github.com/NixOS/nixpkgs/commit/f862ced024e8c033df755010b4cce3d718b99b79) lvm2: 2.03.15 -> 2.03.16
* [`fc3790f9`](https://github.com/NixOS/nixpkgs/commit/fc3790f9952d21da3f3696ec2e3f03081704842a) mozillavpn: 2.8.0 → 2.8.3
* [`9608aebc`](https://github.com/NixOS/nixpkgs/commit/9608aebcca8fa8f0424547f6e41c75fd9e0320fe) libtermkey: fix cross-compilation
* [`81e1166b`](https://github.com/NixOS/nixpkgs/commit/81e1166bffbe792d303dac9a84fe751dc53b8d64) themechanger: 0.10.2 -> 0.11.0
* [`ec44e2cc`](https://github.com/NixOS/nixpkgs/commit/ec44e2cc3923b85ea5a53155e6d79ef6ff65e064) dbeaver: 22.0.2 -> 22.0.5
* [`446d2cb0`](https://github.com/NixOS/nixpkgs/commit/446d2cb0216dc02c37f6f4eb815a5c1754594a44) nixos/nvidia: add hardware.nvidia.forceFullCompositionPipeline
* [`70f0cf5d`](https://github.com/NixOS/nixpkgs/commit/70f0cf5d00a5fc05e160ba827b55bddcca357f0b) maintainers/team-list: add LumiGuide team
* [`0924b186`](https://github.com/NixOS/nixpkgs/commit/0924b1863c479691a22fc449e6e92c005e2e056e) picoscope, openrazer, it87, esptool: move maintainership to LumiGuide
* [`9c3e9279`](https://github.com/NixOS/nixpkgs/commit/9c3e9279495ba48e37e999ee0d3cc3731d6f0b6c) manim: remove to be replaced by ManimCE
* [`2e4a7c0e`](https://github.com/NixOS/nixpkgs/commit/2e4a7c0ec50dae5c9524dcf697e7741296a0755c) python3Packages.rich: 12.4.1 -> 12.4.4
* [`8206643d`](https://github.com/NixOS/nixpkgs/commit/8206643d416e0ef95c883bb10a3be22005c37e23) bikeshed: 3.4.3 -> 3.5.2
* [`6a925882`](https://github.com/NixOS/nixpkgs/commit/6a925882648ca00b141ece4b95d66fe3f4afd0f9) ccache: 4.6 -> 4.6.1
* [`4568934e`](https://github.com/NixOS/nixpkgs/commit/4568934e9565c4599ffc94a3d2dd31d440656592) logseq: 0.6.9 -> 0.7.0
* [`3431c84b`](https://github.com/NixOS/nixpkgs/commit/3431c84b5d179efd7c830039d2fb2b88cd5ae3c0) pypi-mirror: 4.2.0 -> 5.0.1
* [`bde885a1`](https://github.com/NixOS/nixpkgs/commit/bde885a181ebec6096505c77e66f6516889313c1) graphviz: 2.50.0 -> 3.0.0
* [`7b447b51`](https://github.com/NixOS/nixpkgs/commit/7b447b51515244a5f7d00f20e7cc801950835220) graphviz: add reverse deps to passthru.tests
* [`1d44ac17`](https://github.com/NixOS/nixpkgs/commit/1d44ac176ce6de74ac912a5b043e948a87a6d2f5) treewide: add enableParallelBuilding's to bootstrap packages so hashes stay the same
* [`cf44b6fb`](https://github.com/NixOS/nixpkgs/commit/cf44b6fb791453461505a00cf7ee56d0d9b5b4bc) cppcheck: 2.7.5 -> 2.8
* [`235f1299`](https://github.com/NixOS/nixpkgs/commit/235f1299d3ad42a13d2fcc060fda95d6f8ecff54) tree-sitter: Remove the Swift grammar
* [`a8916599`](https://github.com/NixOS/nixpkgs/commit/a891659902512a66d7faf4c424c8c360de304720) coreutils: 9.0 -> 9.1
* [`026cf7ac`](https://github.com/NixOS/nixpkgs/commit/026cf7ac48c0a4e08a53b9284130a6ee33b76e3e) lirc: adapt to linux-headers-5.18
* [`19dd9236`](https://github.com/NixOS/nixpkgs/commit/19dd92369e27197002e8c0b03ff3538dfd843276) zsh: 5.8.1 -> 5.9 && add artturin to maintainers
* [`c3cc53d4`](https://github.com/NixOS/nixpkgs/commit/c3cc53d4b6a4c5a568686888f4d9dba033567399) freetype: 2.12.0 -> 2.12.1
* [`354abfaa`](https://github.com/NixOS/nixpkgs/commit/354abfaaa297272455046a7522913edf7e3296d7) sundials: 5.7.0 -> 6.2.0
* [`e8a89451`](https://github.com/NixOS/nixpkgs/commit/e8a8945108156e3382562cb257fea26e9ac585ec) librsvg: 2.54.1 -> 2.54.3
* [`5de817cd`](https://github.com/NixOS/nixpkgs/commit/5de817cd3f09823f8639920149767c8b5b17e05e) coreutils: NixOS.org -> nixos.org
* [`a9468b99`](https://github.com/NixOS/nixpkgs/commit/a9468b99ef2d776131cd98032f31738a8de4c560) coreutils: Get rid of the optionalAttrs
* [`a7be0f27`](https://github.com/NixOS/nixpkgs/commit/a7be0f278d4379a30ae1d3be8578368274fae12d) nspr: 4.33 -> 4.34
* [`e71288ff`](https://github.com/NixOS/nixpkgs/commit/e71288ffe58925c60dc13122c437b5739211eedc) nspr: add hexa to maintainers
* [`b3fa0c3f`](https://github.com/NixOS/nixpkgs/commit/b3fa0c3f864a1ea0dfe4c7dd72a7e38e1cbd4d76) mesa: 22.0.3 -> 22.0.4
* [`95531068`](https://github.com/NixOS/nixpkgs/commit/955310683206739931c2106ac661a670181be364) nixos/stage-1: Ensure correct ZFS mount options
* [`de77849a`](https://github.com/NixOS/nixpkgs/commit/de77849ad689101c4a7af14a9d02c9906d2b0b13) nixos/stage-1: Account for hardcoded executable paths
* [`4b045c70`](https://github.com/NixOS/nixpkgs/commit/4b045c70664617180c776d3d301fb7563572e66f) nixos/stage-1: Remove redundant symlink check
* [`d33e52b2`](https://github.com/NixOS/nixpkgs/commit/d33e52b2539c5b36a5a876df9006a7145efd42ea) nixos/stage-1: Fix library path in libraries also
* [`9eb704b6`](https://github.com/NixOS/nixpkgs/commit/9eb704b65a43047d136218b98e6f01fc20a6e83c) nixos/stage-1: Zap no longer needed LD_LIBRARY_PATH
* [`1a16b511`](https://github.com/NixOS/nixpkgs/commit/1a16b5113edd1391847f22331a92e9ab1324aa50) python3Packages.bite-parser: init at 0.1.1
* [`e2860780`](https://github.com/NixOS/nixpkgs/commit/e28607802d925d57fb8fb2fd0cf0917dabb0840d) python3Packages.more-properties: init at 1.1.1
* [`2c942c0e`](https://github.com/NixOS/nixpkgs/commit/2c942c0eaf570cdf946c4568b2ed45b29007c2e2) python3Packages.dataclasses-serialization: init at 1.3.1
* [`74625634`](https://github.com/NixOS/nixpkgs/commit/746256345f12f2278632217fa9ec13d6de8dd9b4) python3Packages.docformatter: init at 1.4
* [`ce47cf42`](https://github.com/NixOS/nixpkgs/commit/ce47cf422bb9f54e0906c23d65fe96b711ec886c) python310Packages.ujson: 5.2.0 -> 5.3.0
* [`fa4ab568`](https://github.com/NixOS/nixpkgs/commit/fa4ab568a6ee556a235c91d60f6d22bb7d5973fa) python310Packages.zha-quirks: 0.0.73 -> 0.0.74
* [`bb3d32f7`](https://github.com/NixOS/nixpkgs/commit/bb3d32f71606ae093ecca42162476a5bed4a6e6a) python310Packages.zwave-js-server-python: 0.36.1 -> 0.37.0
* [`d88f9f6a`](https://github.com/NixOS/nixpkgs/commit/d88f9f6a3be6833c0bf0925c6521f02ee64a7d20) python3Packages.more-properties: init at 1.1.1
* [`446c6b36`](https://github.com/NixOS/nixpkgs/commit/446c6b36abef308050d286ee8cd046ddc11c6e5a) buildkite-agent: 3.35.2 -> 3.36.1
* [`442076da`](https://github.com/NixOS/nixpkgs/commit/442076dadf234e8f2e6337a02b18736b6e3bb46b) gpgme: 1.17.0 -> 1.17.1
* [`646e214e`](https://github.com/NixOS/nixpkgs/commit/646e214e114a0965d1b38313de5d221f55f0f787) nixos: remove effect-less nixpgks.initialSystem
* [`c762acd8`](https://github.com/NixOS/nixpkgs/commit/c762acd8f138d0d40e7843d132c117809556c5f1) mavproxy: 1.8.49 -> 1.8.50
* [`8cb2a61d`](https://github.com/NixOS/nixpkgs/commit/8cb2a61de4e819e0584a955cea7768569649bb78) nixos/tests/mjolnir: fix registration test
* [`c590c23f`](https://github.com/NixOS/nixpkgs/commit/c590c23f495a04ede004b9f0cfbc48a07765afce) cups: 2.4.1 -> 2.4.2
* [`3de68001`](https://github.com/NixOS/nixpkgs/commit/3de6800173403ce2ebf8f13e0a424bfd8d3abdb6) rsync: 3.2.3 -> 3.2.4
* [`0b74602d`](https://github.com/NixOS/nixpkgs/commit/0b74602d7aa3fe7bd4cdb68b2a1bd6a485b142d0) fplll: 5.4.1 -> 5.4.2
* [`19e4234f`](https://github.com/NixOS/nixpkgs/commit/19e4234f4cb2ac70d9e8edfb99603ea65ba362ab) nixos/tests/meilisearch: fix curl invocation
* [`9d2c8ba7`](https://github.com/NixOS/nixpkgs/commit/9d2c8ba7e91aeaa398fa952f6ac6045f137a4674) nixos/tests/gitolite: fix test timeout
* [`8395d7a4`](https://github.com/NixOS/nixpkgs/commit/8395d7a4d390dad584ebc3f31c14c67f71e9c591) libreoffice: add update-script for darwin
* [`9f80b6d8`](https://github.com/NixOS/nixpkgs/commit/9f80b6d8fe87eccd39e7018512de6998c2765551) libreoffice: refactor and document version reset workaround
* [`ed52a449`](https://github.com/NixOS/nixpkgs/commit/ed52a4493459ee51f9e8d0bf31b707b5a8598693) libreoffice: general darwin improvements
* [`ccfd4255`](https://github.com/NixOS/nixpkgs/commit/ccfd4255bb77f3769345e6e1799eb2f00168e05a) libreoffice: 7.2.5 -> 7.3.3
* [`d679ccc9`](https://github.com/NixOS/nixpkgs/commit/d679ccc970b7847a3bf216a1456c99ec5a52f774) libreoffice: apply suggestions from code review
* [`2fb0615a`](https://github.com/NixOS/nixpkgs/commit/2fb0615a66d2d7bd4745aeec995645e7cb01411b) libreoffice: add integration test and use `lib.fakeSha256`
* [`d4dd3f5f`](https://github.com/NixOS/nixpkgs/commit/d4dd3f5f7e2f1df1e57f933504f942404e8eca9c) libreoffice: move darwin to separate libreoffice-darwin package
* [`b9a5485a`](https://github.com/NixOS/nixpkgs/commit/b9a5485aa5ebe0547de52f04603831d74f00e1f8) Revert "libreoffice: move darwin to separate libreoffice-darwin package"
* [`8315cf27`](https://github.com/NixOS/nixpkgs/commit/8315cf274bf02124dbdea8106d6cd7ccefbd9484) libreoffice: add darwin to meta platforms and extract to common.nix
* [`106bfcaf`](https://github.com/NixOS/nixpkgs/commit/106bfcaf8a916650f01df5498020e273905c2172) nixos/openconnect: add autoStart option
* [`56ce01ec`](https://github.com/NixOS/nixpkgs/commit/56ce01eca397ece27f5073f7eee3e637e90b4d2a) libreoffice: pass explicit file to update-source-version function and
* [`e9128a34`](https://github.com/NixOS/nixpkgs/commit/e9128a3436da0cd89608092db9a10430b06b667f) qt6.wrapQtAppsHook: remove dependencies: qtbase qtwayland
* [`b818b6c6`](https://github.com/NixOS/nixpkgs/commit/b818b6c696d0c5c173c5154705f586cc5c384060) tdesktop: add dependency: qtwayland
* [`784a6333`](https://github.com/NixOS/nixpkgs/commit/784a63333c2fdbf0c11aa7beac1455c8fd0392ca) cutemaze: add dependencies: qtbase qtwayland
* [`47f8dbee`](https://github.com/NixOS/nixpkgs/commit/47f8dbee96d9b0a94137cac3d83238764ed9475b) go_1_18: fix pkgsCross.raspberryPi.pkgsBuildHost.go_1_18 ([nixos/nixpkgs⁠#174612](https://togithub.com/nixos/nixpkgs/issues/174612))
* [`1478ffdd`](https://github.com/NixOS/nixpkgs/commit/1478ffddf2b0cc4ed862e82cf94d9c2996f1d0b4) gpgme: add passthru.tests
* [`435c0b50`](https://github.com/NixOS/nixpkgs/commit/435c0b508eee99fcc8da20aa3fcf510f6072a770) gtk3: 3.24.33-2022-03-11 → 3.24.34
* [`8229c0ea`](https://github.com/NixOS/nixpkgs/commit/8229c0ea67ef71a59e6f4c61f284eed02fc2c495) python310Packages.types-dateutil: 2.8.16 -> 2.8.17
* [`cd52b647`](https://github.com/NixOS/nixpkgs/commit/cd52b647b6685aa15dba0e391f1f700e0122cd0a) python310Packages.types-dateutil: update pname
* [`ab6f2a32`](https://github.com/NixOS/nixpkgs/commit/ab6f2a32361b1f693167c5d4d2b304898d84c335) gmailctl: 0.10.2 -> 0.10.3
* [`d2aa5ff6`](https://github.com/NixOS/nixpkgs/commit/d2aa5ff6e7c17887fabb08aebca40f45d60b7cea) infnoise: unstable-2019-08-12 -> 0.3.2
* [`6c4bfe58`](https://github.com/NixOS/nixpkgs/commit/6c4bfe583c0bb74ff62e29bce3818654242667ad) nixos/infnoise: init
* [`31cb3f99`](https://github.com/NixOS/nixpkgs/commit/31cb3f9908a31e6c3ba88b38c675f533fc0d5aae) infnoise: Add patch to fix build on aarch64-linux
* [`d7432b81`](https://github.com/NixOS/nixpkgs/commit/d7432b815d0e08634d0a5e4f56f42fc18cbd38e9) infnoise: Also build and install tools
* [`39478cbe`](https://github.com/NixOS/nixpkgs/commit/39478cbeffb2a9044112a070db46652d5efbffaf) leocad: 21.03 -> 21.06
* [`ec4c76e0`](https://github.com/NixOS/nixpkgs/commit/ec4c76e0a8c66fbea095589f91640553c07eb86f) curtail: init at 1.3.0
* [`f3911059`](https://github.com/NixOS/nixpkgs/commit/f39110594e93a776e29f57b775c6388c15396ffd) werf: 1.2.99 -> 1.2.107
* [`91473f20`](https://github.com/NixOS/nixpkgs/commit/91473f20c477cf19ca49e04d125a8692ac882d52) ejson: 1.2.1 -> 1.3.3
* [`d5926bcc`](https://github.com/NixOS/nixpkgs/commit/d5926bccbe946c85c74ac787b0a9ff7bbb132a77) python3.pkgs.psycopg2: build offline documentation
* [`fa093cff`](https://github.com/NixOS/nixpkgs/commit/fa093cff8161af642783faa747a13ea0bb29e347) koreader: 2022.03.01 -> 2022.05.01
* [`1bdc32f9`](https://github.com/NixOS/nixpkgs/commit/1bdc32f97002440304c620ef6f1dadc49ab9a6b1) ocaml-ng.ocamlPackages_4_00_1.ocaml, ocaml-ng.ocamlPackages_4_08.ocaml: add -fcommon workaround
* [`7d4af5de`](https://github.com/NixOS/nixpkgs/commit/7d4af5de4090988370a5c027b463608f187511af) blueprint-compiler: init at 0.1.0
* [`fe949d64`](https://github.com/NixOS/nixpkgs/commit/fe949d64ef417ec254fea7d2ae022b1f78f4ad1e) libreoffice: rename libreoffice -> libreoffice-bin
* [`58631ab7`](https://github.com/NixOS/nixpkgs/commit/58631ab7d1b0f0bc89783f184e76a5887a97a73c) petrifoo: pull patch pending upstream inclusion for -fno-common toolchain support
* [`df38903e`](https://github.com/NixOS/nixpkgs/commit/df38903e7985d5aff55f9111bac5fa6e4a0a65c7) Add @⁠PedroHLC to maintainer-list
* [`1e5b8da0`](https://github.com/NixOS/nixpkgs/commit/1e5b8da09de9dcb6ee56744d86a31de247fbe829) airgeddon: init at 11.01
* [`7327069e`](https://github.com/NixOS/nixpkgs/commit/7327069eccb47fb947e2a80d8b93ea8a8c8c0553) pflask: pull fix pending upstream inclusion for -fno-common support
* [`09c911a4`](https://github.com/NixOS/nixpkgs/commit/09c911a42a35a99b56efffbe044cc5213924d38e) colima: 0.3.4 -> 0.4.2
* [`36ad5b9b`](https://github.com/NixOS/nixpkgs/commit/36ad5b9b963c37917f65ae00bb3ea603cea95970) buildRustPackage: add missing attr to remove
* [`68b6a3d7`](https://github.com/NixOS/nixpkgs/commit/68b6a3d71b2d541c211063417563c2bfdec0fa1b) python310Packages.ocrmypdf: 13.4.5 -> 13.4.6
* [`2dfcfcc1`](https://github.com/NixOS/nixpkgs/commit/2dfcfcc1a9070c4c246b8a5047aada2a52599494) pgpool: 4.0.6 -> 4.3.2
* [`9ca1379b`](https://github.com/NixOS/nixpkgs/commit/9ca1379bdf44774f236219abc38c72dbfdc6534b) fetchCargoTarball: allow adding nativeBuildInputs
* [`7d735f01`](https://github.com/NixOS/nixpkgs/commit/7d735f01a4046fed90a2d14ecfceeb40fc18b88c) nushell: use cargo-edit instead of a patch to add pkg-config feature
* [`90099ac5`](https://github.com/NixOS/nixpkgs/commit/90099ac5fa24cd9f4003c4def847c3559352dc8e) haskell.compiler: ghc922 -> ghc923
* [`7c94d5fd`](https://github.com/NixOS/nixpkgs/commit/7c94d5fd8caa223bba15c52b4363581d781d1f24) plasma5Packages.khelpcenter: fix not finding man pages
* [`264e99b9`](https://github.com/NixOS/nixpkgs/commit/264e99b951d060d587026636e7825b04beb99df9) pommed_light: pull fix pending upstream inclusion for -fno-common toolchains
* [`77a11bce`](https://github.com/NixOS/nixpkgs/commit/77a11bce4f27356c27fdb183140e49932b24067a) pharo-spur64, pharo-cog32: add -fcommon workaround
* [`07c26c77`](https://github.com/NixOS/nixpkgs/commit/07c26c77dc7ea2b354b31ce2c01e4681dada9bbe) purple-xmpp-http-upload: unstable-2017-12-31 -> unstable-2021-11-04
* [`a6558445`](https://github.com/NixOS/nixpkgs/commit/a6558445617e2b5924d02ed2d4414ce31060e18f) magic-wormhole-rs: 0.3.0 -> 0.5.0
* [`327af2f9`](https://github.com/NixOS/nixpkgs/commit/327af2f90f9f89d6a4f031f124fdd732247956f9) liblouis: fix darwin build with patch
* [`965c6422`](https://github.com/NixOS/nixpkgs/commit/965c6422fcc8fd77cf8dddccf7ab3cc1498d7adb) kid3: remove unused automoc4 input
* [`06f3bb21`](https://github.com/NixOS/nixpkgs/commit/06f3bb21cde622fb6ffe08e85253ea3a18a81ef1) universal-ctags: 5.9.20220220.0 -> 5.9.20220529.0
* [`58fabf55`](https://github.com/NixOS/nixpkgs/commit/58fabf558bf98a6436674ba75aaaa2b98684c78d) universal-ctags: set meta.mainProgram
* [`f242b107`](https://github.com/NixOS/nixpkgs/commit/f242b1079a281e656188ea6264520b006097861b) python310Packages.smart-meter-texas: 0.5.0 -> 0.5.1
* [`bbfed347`](https://github.com/NixOS/nixpkgs/commit/bbfed3477dee0855983bc05c19e2cb7015328f42) taisei: 1.3.1 -> 1.3.2
* [`d70af2c3`](https://github.com/NixOS/nixpkgs/commit/d70af2c3b685e0e487a00e151f4c8345b28cbeef) git-lfs1: remove
* [`5f45f1cd`](https://github.com/NixOS/nixpkgs/commit/5f45f1cd289f0219642ae0f43f55996fdb6e246d) argocd: 2.3.3 -> 2.3.4
* [`0287ef10`](https://github.com/NixOS/nixpkgs/commit/0287ef1019a15356ad2a6d20fe1e566d2c9a3795) flat-remix-gnome: update 20220510 -> 20220524
* [`ad5f9ad8`](https://github.com/NixOS/nixpkgs/commit/ad5f9ad8927605e224317b210a1ae0f7d91fb30f) sasquatch: add -fcommon workaround
* [`1b6b3673`](https://github.com/NixOS/nixpkgs/commit/1b6b36735453f3a38bb6765b60a033cf10637dbd) shallot: add -fcommon workaround
* [`d2ef6333`](https://github.com/NixOS/nixpkgs/commit/d2ef633388ebdef6da2cc294dddcd73f7bb270a4) sil: add -fcommon workaround
* [`d07a56dd`](https://github.com/NixOS/nixpkgs/commit/d07a56ddd340b48febf85a1d2885fff5f4d3a967) silver-searcher: add -fcommon workaround
* [`8fb4658b`](https://github.com/NixOS/nixpkgs/commit/8fb4658bc243275ade4cb7d73ff76142d1b9b516) cinny: 2.0.3 -> 2.0.4
* [`62a65320`](https://github.com/NixOS/nixpkgs/commit/62a65320aedaa9327c261bca6676ba3eb7fcf254) siproxd: 0.8.2 -> 0.8.3
* [`260e65d3`](https://github.com/NixOS/nixpkgs/commit/260e65d33714ca918a86e8b3ced35436b3ac8973) sipsak: add -fcommon workaround
* [`6b0031db`](https://github.com/NixOS/nixpkgs/commit/6b0031dbbe3439fa4a7cc59d024db71998aa4275) super: add -fcommon workaround
* [`2f60be03`](https://github.com/NixOS/nixpkgs/commit/2f60be03bb019bd927f56a336afd80b6a32b950b) svaba: add -fcommon workaround
* [`7d92eea1`](https://github.com/NixOS/nixpkgs/commit/7d92eea1c93cf64f11adf4329215f3f5f27e06de) svnfs: add -fcommon workaround
* [`5f70accc`](https://github.com/NixOS/nixpkgs/commit/5f70accc9d9f9815e47ed823c0cbac766a3489a1) python3.pkgs.coqui-trainer: 0.0.5 -> 0.0.11
* [`f273458b`](https://github.com/NixOS/nixpkgs/commit/f273458b656b79dd24e4ae7b538edbfa75127a5a) tts: 0.6.1 -> 0.6.2
* [`859aa7da`](https://github.com/NixOS/nixpkgs/commit/859aa7da131edfd6cad7fe8edd4495b171a50afc) CHOWTapeModel: mark broken on aarch64
* [`70c66de1`](https://github.com/NixOS/nixpkgs/commit/70c66de145339a8c9ba02989644627041888bd69) adwaita-qt: mark broken on Darwin since it doesn't build with qt514
* [`b465f1a9`](https://github.com/NixOS/nixpkgs/commit/b465f1a92f9019c2fc8cd26eb10804659848860c) alttpr-opentracker: only enable on x86_64-linux
* [`5e1adaca`](https://github.com/NixOS/nixpkgs/commit/5e1adacaf03c8fc954a754cbf464a2c3c84bf59b) aspino: mark broken for x86_64 Darwin
* [`22318422`](https://github.com/NixOS/nixpkgs/commit/223184228cbc3ffcdfbe14489083fd654c51bd88) awless: mark broken for aarch64-linux
* [`5d8ec2ad`](https://github.com/NixOS/nixpkgs/commit/5d8ec2adc190abdd8463b41ec776bdbd1b4fd6d9) bakelite: only supports linux
* [`ce7a6471`](https://github.com/NixOS/nixpkgs/commit/ce7a64713eb631c08e7d403893023fb87be95abd) binwalk: mark broken on x86_64-darwin
* [`8152b170`](https://github.com/NixOS/nixpkgs/commit/8152b170e21f004d589e856e0cc74ad03b5fafe7) bigloo: mark broken on x86_64 Darwin
* [`53d8d816`](https://github.com/NixOS/nixpkgs/commit/53d8d816565a373f5f5e2173b299e0f370e91175) blender: mark broken on x86_64-darwin
* [`90869787`](https://github.com/NixOS/nixpkgs/commit/90869787c58d67703b8941ac397403874bc8a70c) boinc: mark broken for aarch64
* [`1f88f6a2`](https://github.com/NixOS/nixpkgs/commit/1f88f6a2c0868302a555534bd53d00461161087d) boofuzz: mark broken on x86_64-darwin
* [`d898e268`](https://github.com/NixOS/nixpkgs/commit/d898e26892f24587f7a14218870ff9f72bd92b2d) bsnes-hd: mark broken on x86_64-darwin
* [`bc286911`](https://github.com/NixOS/nixpkgs/commit/bc286911d8d4089cf72fb5f615709af5012de84e) bullet-roboschool: mark broken on x86_64-darwin
* [`c3fa68c9`](https://github.com/NixOS/nixpkgs/commit/c3fa68c928c67a4d7d2627638577b79ad548d79c) bupstash: mark broken on x86_64-darwin
* [`dd6e61fa`](https://github.com/NixOS/nixpkgs/commit/dd6e61fa5408b15ace9e1856ea55ac0e66693c78) cardinal: mark broken on darwin
* [`ed759930`](https://github.com/NixOS/nixpkgs/commit/ed7599305f0c9977a6f578a443ef94765952ee6b) cargo-deb: mark broken on x86_64-darwin
* [`2542b4d6`](https://github.com/NixOS/nixpkgs/commit/2542b4d60ef5e45a1f232593bdc2b8d08c503e74) cargo-modules: mark broken on x86_64-darwin
* [`941458e0`](https://github.com/NixOS/nixpkgs/commit/941458e0b95044596693fafa3eefdc3d07398a1d) cataclysm-dda-git: mark broken on x86_64-darwin
* [`6d9a3374`](https://github.com/NixOS/nixpkgs/commit/6d9a33741eecbf01e5ddaa080abb53108bcbb8f6) ccl: mark broken on x86_64-darwin
* [`cd3c2561`](https://github.com/NixOS/nixpkgs/commit/cd3c25616d603598d32430e30ae676f93959f6bd) treewide: pkgs/tools: mark broken for darwin
* [`f97a7e63`](https://github.com/NixOS/nixpkgs/commit/f97a7e634f55390fade545892c70ecf05e59aaea) treewide: pkgs/games: mark broken for darwin
* [`37c633f7`](https://github.com/NixOS/nixpkgs/commit/37c633f7ae518456af1f3064bd5c386e2de92c37) treewide: pkgs/applications: mark broken for darwin
* [`a99736e3`](https://github.com/NixOS/nixpkgs/commit/a99736e399c68db364485f127ae86e7ce3970f75) nixos/test-driver: add option to add extra python packages to test code
* [`8858bf00`](https://github.com/NixOS/nixpkgs/commit/8858bf009e8ed2545205686945e64f0406dede9d) nixos/test-driver: add test for extraPythonPackages
* [`2a750c30`](https://github.com/NixOS/nixpkgs/commit/2a750c302669a59a13d8a2a6fa038cbc6e6cb134) nixos/manual: Add docs on extra python packages in tests
* [`48210371`](https://github.com/NixOS/nixpkgs/commit/48210371c10926e3b23eba7dd639f899e2f668a6) drawio: 18.0.6 -> 18.1.3
* [`28f9043a`](https://github.com/NixOS/nixpkgs/commit/28f9043aa92e3d1d127b18d21a7c6984eebcdf93) pkgs/tests/config.nix: Make test future proof
* [`8187ce44`](https://github.com/NixOS/nixpkgs/commit/8187ce441044170ba8f6970e71e369a695095d0b) wails: 2.0.0-beta.36 -> 2.0.0-beta.37
* [`1461002c`](https://github.com/NixOS/nixpkgs/commit/1461002cc8c044dc466b810ed345f5bb66f75734) powershell: add maintainer script getHashes
* [`4eec7ea7`](https://github.com/NixOS/nixpkgs/commit/4eec7ea781247aa0adc02764be7d6df7da954d40) python3Packages.poster3: remove
* [`f06f4663`](https://github.com/NixOS/nixpkgs/commit/f06f4663d207a28f8823ee79f4acf74d42881b55) python310Packages.wsgiproxy2: 0.4.2 -> 0.5.1
* [`cf21f982`](https://github.com/NixOS/nixpkgs/commit/cf21f982175d4b9b775c36014841759542680e48) openmpi: 4.1.3 -> 4.1.4
* [`e5d35ef2`](https://github.com/NixOS/nixpkgs/commit/e5d35ef23f6325793fd0b68a04ccee7aba0d4e63) python3Packages.webapp2: remove
* [`74a0e97c`](https://github.com/NixOS/nixpkgs/commit/74a0e97cd4a2f8a237f4fb3156c9cb83cf2879f3) doc: document pythonRelaxDepsHook
* [`c2755427`](https://github.com/NixOS/nixpkgs/commit/c2755427d67bbcdf0e05609d52e8674d1ea0c1e9) python3Packages.mapbox-earcut: init at 2.2.2
* [`6ab6d7f9`](https://github.com/NixOS/nixpkgs/commit/6ab6d7f9f66ec353c03610fc40d49f88d84084ec) python3Packages.cloup: init at 0.14.0
* [`d37086b4`](https://github.com/NixOS/nixpkgs/commit/d37086b4bf4612d0658f1a4786a4bd37bdbe378a) python3Packages.isosurfaces: init at 0.1.0
* [`00bcf672`](https://github.com/NixOS/nixpkgs/commit/00bcf6729290ce4d155e057beb3c1f264ad09228) python3Packages.srt: init at 3.5.2
* [`81c384a4`](https://github.com/NixOS/nixpkgs/commit/81c384a4c02f59134566d555b3776aaefb1216ed) manim: init at 0.15.2
* [`654856e8`](https://github.com/NixOS/nixpkgs/commit/654856e8dffe7188217ed089211e2f37c6c58be6) xplr: 0.17.6 -> 0.18.0
* [`57ad98d9`](https://github.com/NixOS/nixpkgs/commit/57ad98d9bf35ee8bb0cdc9da081ea6153f37d3d3) python310Packages.wfuzz: disable on unsupported Python releases
* [`a5c1d43a`](https://github.com/NixOS/nixpkgs/commit/a5c1d43a31d6eb4a2f0a463b2cc9349a9ce20da3) qogir-theme: 2022-04-29 -> 2022-05-29
* [`8d325054`](https://github.com/NixOS/nixpkgs/commit/8d325054afc010a34980cb7938926653ab8bb60c) slurm: 21.08.8.2 -> 22.05.0.1
* [`b6020f42`](https://github.com/NixOS/nixpkgs/commit/b6020f42a5bb67b3bcd3628a85c03b194a0d4c00) nixos/slurm: update systemd service for slurmd
* [`05a1cba1`](https://github.com/NixOS/nixpkgs/commit/05a1cba10bbaa866572a86b1cdfa743acd21e024) qt6.qtwebengine: fix LibraryExecutablesPath
* [`c36fce40`](https://github.com/NixOS/nixpkgs/commit/c36fce4046a292644c97ea4f672bd2d71e1647ab) vimPlugins: update
* [`0e024a31`](https://github.com/NixOS/nixpkgs/commit/0e024a3126485af4a3b2633886b096b2443eb9a2) haskellPackages: stackage LTS 19.7 -> LTS 19.8
* [`8f4dd98a`](https://github.com/NixOS/nixpkgs/commit/8f4dd98a47378d7c86deafb00df25f08e92c1c94) all-cabal-hashes: 2022-05-20T19:45:02Z -> 2022-05-29T17:05:02Z
* [`d4323047`](https://github.com/NixOS/nixpkgs/commit/d4323047f48bacefdd9e8943f675107da2df4854) haskellPackages: regenerate package set based on current config
* [`849d47a9`](https://github.com/NixOS/nixpkgs/commit/849d47a9280e059bf6a6f8762431f04d4c12f02b) ghc: use CXX=c++, not CXX=cxx
* [`1c2971c8`](https://github.com/NixOS/nixpkgs/commit/1c2971c8a4a02744bd0a34d24c3998235c53a2d1) haskellPackages: use 9.2.3 releases for ghc-lib* packages
* [`cfb1a6cc`](https://github.com/NixOS/nixpkgs/commit/cfb1a6cc8f6348b4e078d18f427fbf36bb75b883) haskell.packages.ghc923.th-desugar: reflect 1.13 -> 1.13.1 update
* [`eb68aa71`](https://github.com/NixOS/nixpkgs/commit/eb68aa7177fdda688398061a4efeebb84310fafa) pico-sdk: 1.3.0 -> 1.3.1
* [`b2eb98a0`](https://github.com/NixOS/nixpkgs/commit/b2eb98a0401f49f529eb9aebab1009b6e6b3a477) vimPlugins.nord-vim: fix the remote's main branch name
* [`2a5d767e`](https://github.com/NixOS/nixpkgs/commit/2a5d767efb0f7fdcd8acb46454ac543b86796a7f) vimPlugins.markdown-preview-nvim: update fix-node-paths.patch
* [`833d7f8a`](https://github.com/NixOS/nixpkgs/commit/833d7f8aed3396bb6c56f561a475898558f16113) vimPlugins.markdown-preview-nvim: add a missing node depedency
* [`e18ca9a9`](https://github.com/NixOS/nixpkgs/commit/e18ca9a9108d1ab5a080139cd4657e29722a1299) pulseaudio: fix !bluetoothSupport build
* [`f598554c`](https://github.com/NixOS/nixpkgs/commit/f598554c7344a45bde1ed3207aad83c3131a3a9d) pridefetch: init at 1.0.0
* [`e0ea4b52`](https://github.com/NixOS/nixpkgs/commit/e0ea4b52f03465863a0000595404d67cabfcbbd2) mopidy-spotify-tunigo: remove
* [`eaf436cc`](https://github.com/NixOS/nixpkgs/commit/eaf436cc25922ac7dac74d2e93dd190ce9dc4313) mopidy-spotify: remove
* [`645f612c`](https://github.com/NixOS/nixpkgs/commit/645f612c40776d895048a9575792fe456a22bb42) python3Packages.pyspotify: remove
* [`70c42db5`](https://github.com/NixOS/nixpkgs/commit/70c42db535fea306ff1586d29b840857b7fc7fd5) clementineUnfree: remove
* [`1f402eec`](https://github.com/NixOS/nixpkgs/commit/1f402eec780bbbbe720cc46de98f02adc5770d92) libspotify: remove
* [`8485bfc9`](https://github.com/NixOS/nixpkgs/commit/8485bfc9bf50a11e410a6834334d44280cc644ac) arm-trusted-firmware: unfree only if hdcp.bin used; otherwise delete it
* [`fb57eed4`](https://github.com/NixOS/nixpkgs/commit/fb57eed4b5fe5b12ee17ff0c536b4e70b6816a66) python38Packages.pdf2image: fix providing `poppler_utils` dependency
* [`670cb210`](https://github.com/NixOS/nixpkgs/commit/670cb2103a4d41705ce33ceff39c1636073d9dce) qbittorrent: Wrap once, python is optional
* [`125a626d`](https://github.com/NixOS/nixpkgs/commit/125a626d54ca08ab5560b6bb489b480bf0b61cd9) python310Packages.packaging: add disabled
* [`582268d2`](https://github.com/NixOS/nixpkgs/commit/582268d27b76f86c2959033c12bf298258e4a9e4) python310Packages.maxminddb: remove ipaddress usage, update homepage
* [`67832a5f`](https://github.com/NixOS/nixpkgs/commit/67832a5f0f24bdd6316b7a90a92cfd7a0953e077) svd2rust: 0.21.0 -> 0.24.0
* [`e18c7884`](https://github.com/NixOS/nixpkgs/commit/e18c7884b1b3fb924f839e4e31a5d5784f74fa9e) python310Packages.service-identity: remove ipaddress
* [`c2aba563`](https://github.com/NixOS/nixpkgs/commit/c2aba5631008e10d0e990d222743e52fcf5bbe35) python310Packages.types-cryptography: remove because types have been upstreamed
* [`bcb0f60b`](https://github.com/NixOS/nixpkgs/commit/bcb0f60b31bc2da22acddb79b267bda1d312d3b4) python310Packages.types-paramiko: remove because unused
* [`42725bb3`](https://github.com/NixOS/nixpkgs/commit/42725bb36e38f1f606be23134c9b03bd5ba352e6) python310Packages.txtorcon: update dependencies
* [`3f2838e5`](https://github.com/NixOS/nixpkgs/commit/3f2838e5f5a0dec2180b32e12e5a6b24b0f08d5b) python310Packages.swagger-spec-validator: switch to pytestCheckHook, add imports check
* [`92e26f14`](https://github.com/NixOS/nixpkgs/commit/92e26f1491da11f667001446ed86731258eb434f) python310Packages.mail-parser: remove ipaddress usage
* [`8a12230b`](https://github.com/NixOS/nixpkgs/commit/8a12230be6fb3a5176786cdd5aa7cba042690ba3) python310Packages.geoip2: add missing dependency, description
* [`a2c2795e`](https://github.com/NixOS/nixpkgs/commit/a2c2795e1c4d13f56457e40ced52561f07b6e29f) xpra: remove ipaddress
* [`9a5fde83`](https://github.com/NixOS/nixpkgs/commit/9a5fde8383182ae7c0f32df427081b2b2288a32b) azure-cli: remove backport ipaddress
* [`c9a2b12d`](https://github.com/NixOS/nixpkgs/commit/c9a2b12db5b59997702e04e888ee0252faed2f0e) duplicity: remove backport ipaddress, remove always false condition
* [`b134a283`](https://github.com/NixOS/nixpkgs/commit/b134a28381d140eb2f43928cef2022199ae8c1d7) dd-agent: remove backport ipaddress
* [`d060e634`](https://github.com/NixOS/nixpkgs/commit/d060e634e8d5b43725d6ec8acda066e33bf3bed9) virt-manager: remove with over entire scope, do manually patching in postPatch, remove backport ipaddress
* [`8d7b3a18`](https://github.com/NixOS/nixpkgs/commit/8d7b3a1878e67362826cb4f30d681206a7ffe4ef) python310Packages.flask-restful: remove condition from patch
* [`c9d0d43d`](https://github.com/NixOS/nixpkgs/commit/c9d0d43db0bbbef15c5d74f704484b5dd82db195) python310Packages.codespell: remove pytest-cov
* [`0dbe01aa`](https://github.com/NixOS/nixpkgs/commit/0dbe01aa771e19a5428710d0d7c2d5729b240de2) python310Packages.celery: remove stale postPatch
* [`1593316a`](https://github.com/NixOS/nixpkgs/commit/1593316a21521b24b3f5035e796a1ced78699941) gajim: 1.4.1 → 1.4.2
* [`029b7b9b`](https://github.com/NixOS/nixpkgs/commit/029b7b9b9964e2296d2bd01b38734f07484cbe8a) python310Packages.pynetgear: 0.10.2 -> 0.10.3
* [`e037da1c`](https://github.com/NixOS/nixpkgs/commit/e037da1ccaab9a29f1884aa7b5ddcefb7acf348c) python310Packages.hahomematic: 1.5.4 -> 1.6.1
* [`4ca3b0d4`](https://github.com/NixOS/nixpkgs/commit/4ca3b0d40ba4c0d79ccc0c1869af84cd71ce7c4e) truecrack: add -fcommon workaround
* [`a59257a7`](https://github.com/NixOS/nixpkgs/commit/a59257a7710340d9e583ef484249e75098dbd489) typespeed: add -fcommon workaround
* [`1322160a`](https://github.com/NixOS/nixpkgs/commit/1322160a35210abd9d6ec1d25cf6bca9e3c550f5) ucarp: add -fcommon workaround
* [`c3337a71`](https://github.com/NixOS/nixpkgs/commit/c3337a717ed1b237481ed86fb2fc996e489750a7) vimPlugins: update
* [`eee2bff9`](https://github.com/NixOS/nixpkgs/commit/eee2bff922477148607cb5861dee8ebae0ae778e) python310Packages.structlog: remove unused depedency, little cleanup
* [`b885589e`](https://github.com/NixOS/nixpkgs/commit/b885589e7d5934a430ebfe8a4361d3c5e5459682) python310Packages.kubernetes: 20.13.0 -> 23.6.0
* [`7997ad6d`](https://github.com/NixOS/nixpkgs/commit/7997ad6d34032282d83e94a5ece19c2d621fff80) python310Packages.fake_factory: drop
* [`c4c4babb`](https://github.com/NixOS/nixpkgs/commit/c4c4babb5533a8e4a5a4c1543d59cf9380e08fd0) python310Packages.mail-parser: remove unused input
* [`39b60ae0`](https://github.com/NixOS/nixpkgs/commit/39b60ae0b8474ecfaa87d52c36b392b04bb03191) python310Packages.pglast: 3.10 -> 3.11
* [`b32b506a`](https://github.com/NixOS/nixpkgs/commit/b32b506ad0b4a99a7675fb8dea3af209d052875a) python310Packages.gpsoauth: cleanup dependencies
* [`095219c3`](https://github.com/NixOS/nixpkgs/commit/095219c30c6ab46b496b9abdc218b24b3a35804a) natscli: 0.0.32 -> 0.0.33
* [`412ec27c`](https://github.com/NixOS/nixpkgs/commit/412ec27c1688e282b18453e7ae15a8628a740aa9) python310Packages.pysaml2: add missing dependency on setuptools
* [`d02116e3`](https://github.com/NixOS/nixpkgs/commit/d02116e31944b63058b592b1025fe090eea6c95f) python3Packages.transformers: fix pytorch reference
* [`cbe5dca3`](https://github.com/NixOS/nixpkgs/commit/cbe5dca334ec05e593d9018df3a087ffaa0ac03a) libreddit: 0.22.7 -> 0.22.9
* [`5523be73`](https://github.com/NixOS/nixpkgs/commit/5523be73f4913ff62e54a859b4e2359e57229b51) python310Packages.brother: 1.2.2 -> 1.2.3
* [`8bb4fac4`](https://github.com/NixOS/nixpkgs/commit/8bb4fac4053aa311b836c1243f817f5cd506e01d) terraform-providers: update scripts
* [`049be08d`](https://github.com/NixOS/nixpkgs/commit/049be08db3addfd5bdf7361e057b7198b0327e33) terraform-providers: update 2022-05-30
* [`30d5e606`](https://github.com/NixOS/nixpkgs/commit/30d5e6068af96b31ca729d83f52c238f4082be1a) python310Packages.elasticsearch-dsl: remove ipaddress dependency
* [`4dc5ea52`](https://github.com/NixOS/nixpkgs/commit/4dc5ea5202a17db17953551a88966cc3e85256c4) python310Packages.sphinxcontrib-spelling: 7.4.0 -> 7.4.1
* [`c68d9334`](https://github.com/NixOS/nixpkgs/commit/c68d9334815057d61e379a0adc9019e594867d84) python310Packages.flask-httpauth: 4.6.0 -> 4.7.0
* [`c78821e0`](https://github.com/NixOS/nixpkgs/commit/c78821e0fd85bfda2622cfd9a187358ea03a09e5) python310Packages.wordcloud: switch to pytestCheckHook
* [`f6facfe5`](https://github.com/NixOS/nixpkgs/commit/f6facfe59d1e6f891d456a93ac34ae60d7ab2813) python310Packages.pims: 0.6.0 -> 0.6.1
* [`b445957a`](https://github.com/NixOS/nixpkgs/commit/b445957a81a773efa1f4e1722c0510e97c2475e2) pls: 4.0.3 -> 5.0.0
* [`90a74154`](https://github.com/NixOS/nixpkgs/commit/90a741547ea72c14f7eb26f1e72604b7c3a66e21) geomyidae: init at 0.50.1
* [`1c6360e3`](https://github.com/NixOS/nixpkgs/commit/1c6360e3330165b0223af760014141c4769acfba) python310Packages.whodap: disable on older Python releases
* [`4b3a039b`](https://github.com/NixOS/nixpkgs/commit/4b3a039b60dc3626b201fa39d1955e1feb08a9b2) gh-cal: fix pkg-config
* [`0ec13035`](https://github.com/NixOS/nixpkgs/commit/0ec13035f6f28b5ce089cb5a682750cab6a7dd9f) python310Packages.pynisher: add pythonImportsCheck
* [`bc555806`](https://github.com/NixOS/nixpkgs/commit/bc555806c0259333ae64efe622d2d76d527974f8) ntfy-sh: 1.23.0 -> 1.24.0
* [`da9162f6`](https://github.com/NixOS/nixpkgs/commit/da9162f667e5833b885edae3631299c0e7005d2b) add mechanism for handling meta.sourceProvenance attributes
* [`9d078482`](https://github.com/NixOS/nixpkgs/commit/9d0784829a1dabe24b186c976502a6642f99997c) add initial meta.sourceProvenance documentation
* [`81bc106e`](https://github.com/NixOS/nixpkgs/commit/81bc106e080e56e2c85466ea7d4ecf38bc99149c) meta.sourceProvenance documentation: clarify it is unaffected by changes to meta.license
* [`095eb915`](https://github.com/NixOS/nixpkgs/commit/095eb9153381d240e2ba3e05716b3ce7fda85080) meta.sourceProvenance: disallow string values
* [`7906ea6d`](https://github.com/NixOS/nixpkgs/commit/7906ea6d9d938c7f4221c305cfbcc9f8ba63804a) allowNonSourcePredicate: use example of categorical permissivity
* [`5bb9bf47`](https://github.com/NixOS/nixpkgs/commit/5bb9bf47740bb98bf6c2c404a086d7ed6a5c595d) meta.sourceProvenance: inline hasSourceProvenance
* [`ae0df5d3`](https://github.com/NixOS/nixpkgs/commit/ae0df5d38afdb0be90973ddd42b1c9b1059464fd) lib.sourceTypes: simplify implementation
* [`567e6513`](https://github.com/NixOS/nixpkgs/commit/567e65136f35ec6a2028c677282267e80d7636ec) paperless-ngx: 1.6.0 -> 1.7.1
* [`138a9422`](https://github.com/NixOS/nixpkgs/commit/138a94228d1019889b437ff7d30c9450078468f8) paperless-ngx: add maintainers
* [`bb8a7949`](https://github.com/NixOS/nixpkgs/commit/bb8a794957c5646a61cad5d401e7903b69b4c773) tile38: 1.27.1 → 1.28.0
* [`f630ac5f`](https://github.com/NixOS/nixpkgs/commit/f630ac5f2d9bd20623e9fe51797a98cf59b12a6d) deadbeef-statusnotifier-plugin: fix libdbusmenu dependency
* [`e0115c36`](https://github.com/NixOS/nixpkgs/commit/e0115c36ece8889fbd97c31113c19de07869af62) hydra_unstable: passthru pinned nix
* [`146a2545`](https://github.com/NixOS/nixpkgs/commit/146a2545a0e399a7190e6e62612fa3043f996b4a) gparted: enable parallel building
* [`6540a117`](https://github.com/NixOS/nixpkgs/commit/6540a11768861c99a8b9f94c1aaf0ad27e1a7142) haskellPackages.composite-{base,aeson}: drop obsolete overrides
* [`1a20dbc0`](https://github.com/NixOS/nixpkgs/commit/1a20dbc0861e4378975960b7ccfe3d49218965eb) bpftrace: Rename *.8 to *.bt.8 to avoid bcc conflicts
* [`475b2f12`](https://github.com/NixOS/nixpkgs/commit/475b2f1244020e51e6521f208d55072fdc95a272) partitionmanager: Wrap once
* [`5157246a`](https://github.com/NixOS/nixpkgs/commit/5157246aa4fdcbef7796ef9914c3a7e630c838ef) nixos/vmware-guest: Remove the video driver
* [`14ef375c`](https://github.com/NixOS/nixpkgs/commit/14ef375cf036a7f8e3ed610f21ed5a591371d747) nginxStable: 1.20.2 -> 1.22.0
* [`893214cd`](https://github.com/NixOS/nixpkgs/commit/893214cd0e6d15a2dbadfa5cc680e7ba18e4d1c0) nginxMainline: 1.21.6 -> 1.22.0
* [`b4849523`](https://github.com/NixOS/nixpkgs/commit/b4849523302484e7cd365a2765f2e8894ace39fe) nginx(Stable|Mainline|Quic): use pcre2
* [`c26e3354`](https://github.com/NixOS/nixpkgs/commit/c26e3354a7e8f5233f2a8d3755edbe4262193dae) nginxQuic: update
* [`30186896`](https://github.com/NixOS/nixpkgs/commit/30186896ee517990e51c5256b589c0224c971670) nixos/nginx: fix SystemCallFilter for openresty
* [`b1aa4a7f`](https://github.com/NixOS/nixpkgs/commit/b1aa4a7f2564156aaa256514f3498758bcbab7da) Fix typo in compareLists docstring
* [`daef7d85`](https://github.com/NixOS/nixpkgs/commit/daef7d854ff6b19c5cd7cd03df2169e4881bdd01) ansible-later: add to all packages
* [`d1b430ec`](https://github.com/NixOS/nixpkgs/commit/d1b430ec3fb1f244566cbdcb55b7515704528321) gnome.mutter: 42.1 -> 42.2
* [`cd21d432`](https://github.com/NixOS/nixpkgs/commit/cd21d43206f6fe58cdee3366a3cf171e69782976) gnome.gnome-shell: 42.1 -> 42.2
* [`3ece45bc`](https://github.com/NixOS/nixpkgs/commit/3ece45bc72edf425232867c377a52e3c59bd1bb0) gnome.gnome-remote-desktop: 42.1.1 -> 42.2
* [`bd78e1ac`](https://github.com/NixOS/nixpkgs/commit/bd78e1ac1efd7a68b969dc308ce22381bf7a9135) sway-launcher-desktop: 1.5.4 -> 1.6.0
* [`0b45cae8`](https://github.com/NixOS/nixpkgs/commit/0b45cae8a35412e461c13c5037dcdc99c06b7451) treewide: pkgs/development/compilers: mark broken for darwin
* [`13e0d337`](https://github.com/NixOS/nixpkgs/commit/13e0d337037b3f59eccbbdf3bc1fe7b1e55c93fd) treewide: pkgs/development/tools: mark broken for darwin
* [`65db3b17`](https://github.com/NixOS/nixpkgs/commit/65db3b17a8a4ba70c371767e7c484f70203080f2) treewide: pkgs/development/python-modules: mark broken for darwin
* [`7d58a302`](https://github.com/NixOS/nixpkgs/commit/7d58a30286490b7cf7486093d615195fc7695520) treewide: pkgs/development/libraries: mark broken for darwin
* [`c3d7a0ef`](https://github.com/NixOS/nixpkgs/commit/c3d7a0ef4ffbfd2045228e0643a1d03e81b14c4f) gnome.gnome-shell-extensions: 42.1 -> 42.2
* [`03bc5717`](https://github.com/NixOS/nixpkgs/commit/03bc5717445bbccda21d10eeecb6ded4c12d08fe) treewide: pkgs/development: mark broken for darwin
* [`edde4da4`](https://github.com/NixOS/nixpkgs/commit/edde4da42e7e00fd07dc84d7d6cc34d26ebbb1fd) pqrs: mark broken
* [`da846421`](https://github.com/NixOS/nixpkgs/commit/da846421fc1ee9257871f65998358e23b923113d) libresprite: mark broken on darwin
* [`117ee3af`](https://github.com/NixOS/nixpkgs/commit/117ee3af2ac60518c7ecb80e08b0a058542f598b) blender: mark broken on all darwins
* [`c312ae98`](https://github.com/NixOS/nixpkgs/commit/c312ae98a15aef70ba7eedbbd66c31fb8d705759) tippecanoe: mark broken on darwin as well
* [`a0dd8198`](https://github.com/NixOS/nixpkgs/commit/a0dd8198cd898a00f036e37b89be1843ab3a1943) speedcrunch: mark broken on darwin
* [`879d2782`](https://github.com/NixOS/nixpkgs/commit/879d278253424b2e63f8b1b7269a244d4e14aa9f) treewide: pkgs/servers: mark broken for darwin
* [`033d5579`](https://github.com/NixOS/nixpkgs/commit/033d5579c2e965a35b4d7b41249d809c844906d2) treewide: pkgs/servers/sql: mark 2 psql extension broken
* [`7a685488`](https://github.com/NixOS/nixpkgs/commit/7a685488229770b53fffaf81e1aec561a9476130) treewide: pkgs/desktops: mark broken for darwin
* [`82ccbc08`](https://github.com/NixOS/nixpkgs/commit/82ccbc08de7bc6fce46b633eb1db1fd6890a3d91) luaPackages.luxio: mark broken for darwin
* [`010f6ee3`](https://github.com/NixOS/nixpkgs/commit/010f6ee30de634c51d0c7337762dee61cb8427ea) treewide: mark broken for darwin
* [`43370114`](https://github.com/NixOS/nixpkgs/commit/433701147a8a4766edd51114d186a54e19fc13cc) treewide: pkgs/applications: mark broken for aarch64-linux
* [`11ee22d7`](https://github.com/NixOS/nixpkgs/commit/11ee22d797016be02743a9973fe09e0362bcb91b) treewide: pkgs/development: mark broken for aarch64-linux
* [`cd19a0e7`](https://github.com/NixOS/nixpkgs/commit/cd19a0e7b415de52e67b248fecf1ca566f16fa10) swift: mark broken
* [`7da0ca2e`](https://github.com/NixOS/nixpkgs/commit/7da0ca2e252799366176081186935682e8b3603a) mps: mark broken
* [`afbb0f6f`](https://github.com/NixOS/nixpkgs/commit/afbb0f6ff4a6df918d1f0dc37dd2d4b97cf2881e) treewide: pkgs/development/python-modules: mark broken for aarch64-linux
* [`26243136`](https://github.com/NixOS/nixpkgs/commit/26243136fe7559eb139d0bc6bda5d8a1ad737a3a) robomachine: mark broken
* [`90ce1f86`](https://github.com/NixOS/nixpkgs/commit/90ce1f86b9bec2f468fd82316d12b1f9d24397d7) cri-tools: 1.24.1 -> 1.24.2
* [`908245b5`](https://github.com/NixOS/nixpkgs/commit/908245b5532e4fcfedc8e6f15abc330ad5942506) v2ray: 4.44.0 -> 4.45.0
* [`369710ef`](https://github.com/NixOS/nixpkgs/commit/369710eff7adc37189c2f55300ee1ffde1bf797d) python310Packages.azure-mgmt-datafactory: 2.5.0 -> 2.6.0
* [`ac0907f3`](https://github.com/NixOS/nixpkgs/commit/ac0907f326256b29d4d06d2d749d353b945294f4) release-alternatives.nix: fix eval
* [`7badab08`](https://github.com/NixOS/nixpkgs/commit/7badab08b5789bd6c357704b43d1e4612abafd2d) haskellPackages.tasty-discover: drop obsolete overrides
* [`437c8e65`](https://github.com/NixOS/nixpkgs/commit/437c8e6554911095f0557d524e9d2ffe1c26e33a) bullet: 3.23 -> 3.24
* [`06f08e97`](https://github.com/NixOS/nixpkgs/commit/06f08e974977cf2a5a5ce17e5ac9bb7e44ef23bb) automoc4: remove
* [`cd0956e5`](https://github.com/NixOS/nixpkgs/commit/cd0956e5d80ea83f9b92745bfa14d4c5a5cdde98) libportal/libqalculate: Unbreak
* [`0e287081`](https://github.com/NixOS/nixpkgs/commit/0e287081aba179a61eed086836cb05d1b71e26ac) python310Packages.robotframework: 5.0 -> 5.0.1
* [`631fb48f`](https://github.com/NixOS/nixpkgs/commit/631fb48f815488d1d5bda411364799ed3c5e10c5) add jali-clarke to maintainers list
* [`d29cd82b`](https://github.com/NixOS/nixpkgs/commit/d29cd82bfb406e700b655bc4fafd661d2aa039f9) elmPackages.elm-pages: init at 2.1.11
* [`4bd0fe1e`](https://github.com/NixOS/nixpkgs/commit/4bd0fe1e310c28b13672d75c26ce3a6735dd3bc8) cloudflared: 2022.5.1 -> 2022.5.2
* [`7a54d237`](https://github.com/NixOS/nixpkgs/commit/7a54d237e0c459faa7d9f328c7e99c6efb9bff41) snakemake: 7.7.0 -> 7.8.0 ([nixos/nixpkgs⁠#174592](https://togithub.com/nixos/nixpkgs/issues/174592))
* [`b5c01026`](https://github.com/NixOS/nixpkgs/commit/b5c0102678e1e23275b9149bed4ecd70a0f13d35) python310Packages.caldav: 0.9.0 -> 0.9.1
* [`342f0879`](https://github.com/NixOS/nixpkgs/commit/342f0879ca53094ed56fc6a03c20fe000dba4f96) n8n: 0.177.0 → 0.179.0
* [`4c23cbcc`](https://github.com/NixOS/nixpkgs/commit/4c23cbcc15034e043ab522815af020254c2472da) libreoffice: add impure functions comment
* [`9253fc4a`](https://github.com/NixOS/nixpkgs/commit/9253fc4a56a6c3c0eef4de0664fc3abb4223557e) btcpayserver: 1.5.3 -> 1.5.4
* [`b67d16e7`](https://github.com/NixOS/nixpkgs/commit/b67d16e7adec9649dfc2418322eeaad5951afd71) i3-rounded: init at 4.20.1 ([nixos/nixpkgs⁠#174215](https://togithub.com/nixos/nixpkgs/issues/174215))
* [`15ba69d1`](https://github.com/NixOS/nixpkgs/commit/15ba69d1b7966100083f80743a571f3b7c3f20d7) python310Packages.elementpath: 2.5.2 -> 2.5.3
* [`963e1c79`](https://github.com/NixOS/nixpkgs/commit/963e1c79dcd3ada2ecb302edc6ea15634531881b) nixVersions.unstable: pre20220512 -> pre20220530
* [`80d6f179`](https://github.com/NixOS/nixpkgs/commit/80d6f179b9672dea9b0ac05444a26dbfffdf3c55) procs: unbreak on aarch64-darwin
* [`643be073`](https://github.com/NixOS/nixpkgs/commit/643be073a36dc71d3e45af0960b8f5c24c9c76dc) python3Packages.fpylll: 0.5.6 -> 0.5.7
* [`567b83eb`](https://github.com/NixOS/nixpkgs/commit/567b83ebbd9961717a83233970209918b6430867) scala-cli: add updater
* [`bab6e292`](https://github.com/NixOS/nixpkgs/commit/bab6e2925668d59aada968fec93930d26dbbfec0) scala-cli: 0.1.5 -> 0.1.6
* [`1980cec0`](https://github.com/NixOS/nixpkgs/commit/1980cec089c745cd3c67b7f0772b2c3feb2c9e42) python310Packages.pyramid_chameleon: fix compatibility with pyramid 2
* [`9c813249`](https://github.com/NixOS/nixpkgs/commit/9c8132494fbfb6c5cf09767b18d703103d067a17) virtualbox: 6.1.30 -> 6.1.34
* [`cbaacfb8`](https://github.com/NixOS/nixpkgs/commit/cbaacfb8dfa2ddadfb152fa8ef163b40db9041af) Release 22.05
* [`bec4b99b`](https://github.com/NixOS/nixpkgs/commit/bec4b99baad961400eb64a00a78211debe1e091a) python310Packages.huggingface-hub: 0.6.0 -> 0.7.0
* [`09118d3d`](https://github.com/NixOS/nixpkgs/commit/09118d3debc74c8b8a2b262ae72900c2f3ca7214) python310Packages.ua-parser: remove unused pyyaml, add pythonImportsCheck
* [`e47fff26`](https://github.com/NixOS/nixpkgs/commit/e47fff26cc89000efc72fb66aabda84b75218657) deltachat-desktop: 1.28.2 -> 1.30.0
* [`63cbdf67`](https://github.com/NixOS/nixpkgs/commit/63cbdf67ae20521d26e34aae181bc1eea3ec8588) fix font fallout from extraPostFetch -> postFetch ([nixos/nixpkgs⁠#175381](https://togithub.com/nixos/nixpkgs/issues/175381))
* [`7c495114`](https://github.com/NixOS/nixpkgs/commit/7c495114745a1bd9eaa9d2af67c2d76c6e105fa8) python310Packages.authheaders: remove backport ipaddress ([nixos/nixpkgs⁠#175415](https://togithub.com/nixos/nixpkgs/issues/175415))
* [`8143329f`](https://github.com/NixOS/nixpkgs/commit/8143329fc8bfa862c377e9aba9af44cc701ef6a8) maintainers: add polarmutex
* [`18d53f80`](https://github.com/NixOS/nixpkgs/commit/18d53f807ea456d19609ef4e14a48738d8945d75) docker-compose_2: 2.5.1 -> 2.6.0
* [`5b314280`](https://github.com/NixOS/nixpkgs/commit/5b314280b05938086854ca178e023ca44bdb52b5) magic-wormhole-rs: Add alias `wormhole-rs`
* [`51b506f8`](https://github.com/NixOS/nixpkgs/commit/51b506f8de4bdd2122bd2b6e7166245a2e72f0da) python3.pkgs.pyfuse3: fix broken mark
* [`62089e3e`](https://github.com/NixOS/nixpkgs/commit/62089e3ecaa332367dbb0e077533df83ffee719e) checkov: 2.0.1174 -> 2.0.1175
* [`8e113240`](https://github.com/NixOS/nixpkgs/commit/8e113240bbf7e5b630cde79b0fe27f8ed97131e7) libnatspec: fix build on darwin
* [`01202165`](https://github.com/NixOS/nixpkgs/commit/012021659f68cfdb982b54e463eb456fc8767926) libnatspec: unmark broken on darwin
* [`6f7557f8`](https://github.com/NixOS/nixpkgs/commit/6f7557f8c6f2727a0398786c1100a9c232bf2f5d) python3Packages.uamqp: use openssl on darwin-aarch64
* [`c9098ff0`](https://github.com/NixOS/nixpkgs/commit/c9098ff0bb3f08ada15b0b2a47095a34488e0ef0) python310Packages.pyramid_jinja2: disable failing tests
* [`951488b1`](https://github.com/NixOS/nixpkgs/commit/951488b16707a23f0e2a8573337277ee7b7fc876) ansible-lint: 6.2.1 -> 6.2.2
* [`66ff8747`](https://github.com/NixOS/nixpkgs/commit/66ff8747b81d2f024c7a36d55859c004c4095616) python310Packages.pysnmplib: 5.0.15 -> 5.0.16
* [`ab76f322`](https://github.com/NixOS/nixpkgs/commit/ab76f3220da5b6cfdf39f16683ec4be53299fc79) xedit: fix build on darwin
* [`4c885335`](https://github.com/NixOS/nixpkgs/commit/4c8853358de627904f31d98db6f2dfb5db4e789c) python310Packages.nettigo-air-monitor: 1.2.4 -> 1.3.0
* [`d8219583`](https://github.com/NixOS/nixpkgs/commit/d821958373bddedc25d8100abcbf4118580fa5a9) python310Packages.nettigo-air-monitor: remove postPatch
* [`e9ad7e5f`](https://github.com/NixOS/nixpkgs/commit/e9ad7e5feca8a185cb28363b9e33d9fbe7ba6624) python310Packages.huggingface-hub: disable on older Python releases
* [`113003f1`](https://github.com/NixOS/nixpkgs/commit/113003f1a279840ca055ecb84bd5a6a642f9483c) python310Packages.huum: init at 0.5.0
* [`07517967`](https://github.com/NixOS/nixpkgs/commit/07517967de14d16de525f0fa11a2962fb2557466) python310Packages.verboselogs: switch to pytestCheckHook
* [`b787f238`](https://github.com/NixOS/nixpkgs/commit/b787f238f4d091a083cb3600db81f763fa27c8c5) python310Packages.webtest-aiohttp: remove superflouses inputs
* [`71c7efa3`](https://github.com/NixOS/nixpkgs/commit/71c7efa3877218ea3cd6ed07f95e804dd10d7daf) python3Packages.celery: skip hydra-failing tests on darwin
* [`67dffc30`](https://github.com/NixOS/nixpkgs/commit/67dffc3000fb931058e39a2967a4d66d3cc05af4) python3Packages.celery: unmark as broken
* [`2cae94e5`](https://github.com/NixOS/nixpkgs/commit/2cae94e56a24599777e70e4d878acf9c52c2a834) ncdc: 1.22.1 -> 1.23
* [`76a10f36`](https://github.com/NixOS/nixpkgs/commit/76a10f36450fba0f8eff5e936cf80af810d00b73) httm: 0.10.12 -> 0.10.15
* [`cea2a516`](https://github.com/NixOS/nixpkgs/commit/cea2a516382e9ca7f9b0b31618fd14db9d773302) python310Packages.pyhiveapi: 0.5.3 -> 0.5.4
* [`bd1d3d24`](https://github.com/NixOS/nixpkgs/commit/bd1d3d243a48bb58d21dcd4a244b986b32b3a662) imagemagick: 7.1.0-35 -> 7.1.0-36
* [`d10af529`](https://github.com/NixOS/nixpkgs/commit/d10af5290b676a957e2c34098e77636cf14b90a1) cfripper: 1.10.0 -> 1.11.0
* [`79772f20`](https://github.com/NixOS/nixpkgs/commit/79772f20c52d66c310d60cc16770e998c3f04c8f) beancount-language-server: refactor -> 1.1.1
* [`aaf94758`](https://github.com/NixOS/nixpkgs/commit/aaf94758f3634888312b0ec5e3dd7bbd59543a88) python310Packages.hatasmota: 0.5.0 -> 0.5.1
* [`7064d75b`](https://github.com/NixOS/nixpkgs/commit/7064d75b711a866e159b46bcd17d97d2f557b118) python310Packages.hahomematic: 1.6.1 -> 1.6.2
* [`6abc75c9`](https://github.com/NixOS/nixpkgs/commit/6abc75c9400201c7b9eb14680d1eaf634f961434) python310Packages.pex: 2.1.90 -> 2.1.91
* [`09350ff7`](https://github.com/NixOS/nixpkgs/commit/09350ff7d4243e81fcab99cdd5f2c696075de42e) nixos/atop: Convert log format to fix service start
* [`161315c4`](https://github.com/NixOS/nixpkgs/commit/161315c4de69fde33c330afcaa6ec69a965232df) gtk3: fixup build on *-darwin
* [`e70ebbd0`](https://github.com/NixOS/nixpkgs/commit/e70ebbd0bfa1e9245d70b7ab80739e53ecdcc233) gnome.gnome-software: 42.1 -> 42.2
* [`cfaec958`](https://github.com/NixOS/nixpkgs/commit/cfaec958cc81014eae1b8f35827c7c46b4c74207) README: 21.11 -> 22.05
* [`32e26d26`](https://github.com/NixOS/nixpkgs/commit/32e26d2627154a54f42334dc31bf5338dc7a97ff) release-notes: fix typo
* [`376897ce`](https://github.com/NixOS/nixpkgs/commit/376897ced34becbfce58950225360c28e0a3ecf0) astral: init at 5.7.1
* [`83505670`](https://github.com/NixOS/nixpkgs/commit/835056702eb6e1fdf36f34e3cb4acf9e53ea17cd) python310Packages.regenmaschine: 2022.05.0 -> 2022.05.1
* [`97bdb3c6`](https://github.com/NixOS/nixpkgs/commit/97bdb3c6450c58d16eeb93f4cf24500ddbe2f75c) nearcore: 1.26.0 -> 1.26.1
* [`4729707e`](https://github.com/NixOS/nixpkgs/commit/4729707e40d212f9b794c9ca49e34c1efdc01429) nix-doc: 0.5.3->0.5.4 to support nix 2.9.0
* [`2bc4dcde`](https://github.com/NixOS/nixpkgs/commit/2bc4dcde870ebc37c784c13067ae0579153be8ba) moz-phab: add missing 'pip' runtime dependency
* [`b654502b`](https://github.com/NixOS/nixpkgs/commit/b654502b2bb0026cdfd4d9cecdd5656745866c84) terraform-providers: also include name in error messages
* [`84065e32`](https://github.com/NixOS/nixpkgs/commit/84065e32ba502d521d8a750b05f68bf37198350b) python310Packages.sunpy: 3.1.6 -> 4.0.0
* [`5db40e76`](https://github.com/NixOS/nixpkgs/commit/5db40e768d1447624235b27d7176726550eb353f) dpdk-kmods.src: use HTTPS URL
* [`423a7514`](https://github.com/NixOS/nixpkgs/commit/423a751465e74c9bfffb6649bd9d8adb800154e2) haskellPackages.git-annex: adjust sha256 for 10.20220525
* [`9075eec2`](https://github.com/NixOS/nixpkgs/commit/9075eec2a76c7d4d963a023f1b715bbc681d22c9) mkgmap: 4902 -> 4904
* [`5944112a`](https://github.com/NixOS/nixpkgs/commit/5944112af71a2bb444e7f66d44ecb9c7ccd99e83) haskell.packages.ghc902.weeder: pin to < 2.4
* [`2c746066`](https://github.com/NixOS/nixpkgs/commit/2c746066649266eec0ce529f2091e09e905ece94) .github/PULL_REQUEST_TEMPLATE.md: 21.11 -> 22.05
* [`c356e724`](https://github.com/NixOS/nixpkgs/commit/c356e7246f8b1a65b8edbe1c57e9f895caabeab5) gtk4: 4.6.4 -> 4.6.5
* [`156532fd`](https://github.com/NixOS/nixpkgs/commit/156532fdc0ff066af6b0ad442bdda2649077bd90) Move geospatial servers into its own folder
* [`d27cc392`](https://github.com/NixOS/nixpkgs/commit/d27cc392f04381074e5c71a2d5356442b1610cac) ocamlPackages.resto:  0.6.1 -> 0.7
* [`a9ce8f1e`](https://github.com/NixOS/nixpkgs/commit/a9ce8f1ef222c4b03773e5931176189cb59daa8b) ocamlPackages.json-data-encoding: 0.10 -> 0.11
* [`36049542`](https://github.com/NixOS/nixpkgs/commit/36049542b81b97c1d93131cd986856967719f365) gnome.gnome-boxes: 42.0.1 -> 42.1
* [`eef2c762`](https://github.com/NixOS/nixpkgs/commit/eef2c762ce19c8cf7172b319a7f4cd5555b5f289) makeBinaryWrapper: fix cross-compilation and add test
* [`2d0b5636`](https://github.com/NixOS/nixpkgs/commit/2d0b56360fc7a702f0c4fac5f202389a569f58c5) glirc: unbreak via downgrade to 2.38
* [`a3859b79`](https://github.com/NixOS/nixpkgs/commit/a3859b796fea622e4173fa18500842e70b74f2af) python310Packages.pyfuse3: cythonize before building
* [`43337d4f`](https://github.com/NixOS/nixpkgs/commit/43337d4f93da9348d744112fa351e110986e3113) borgbackup: need either pyfuse3 or llfuse
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
