### PR TITLE
niv emacs-overlay: update 563a7a4b -> 5ea4edff

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "563a7a4b38efb5c99ef4638bfa8064136c05b19f",
-        "sha256": "0wrdjl0v6hm5lpkrjfahh232782d1fydr583j24ypv0khw3a25h7",
+        "rev": "5ea4edff63d066fae8e89d32f1e9a4ee0dcf056d",
+        "sha256": "1d53sm1j9vpa79mvzlpgyl1jhldk95vmf81jc2d0777d64hss0mp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/563a7a4b38efb5c99ef4638bfa8064136c05b19f.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/5ea4edff63d066fae8e89d32f1e9a4ee0dcf056d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@563a7a4b...5ea4edff](https://github.com/nix-community/emacs-overlay/compare/563a7a4b38efb5c99ef4638bfa8064136c05b19f...5ea4edff63d066fae8e89d32f1e9a4ee0dcf056d)

* [`d941b948`](https://github.com/nix-community/emacs-overlay/commit/d941b94818f29f84c6e1dc36657d900896a2b27b) Updated repos/emacs
* [`00cbfa09`](https://github.com/nix-community/emacs-overlay/commit/00cbfa093fc1a9769271f0a9ea019b1ccc569482) Updated repos/melpa
* [`1d258683`](https://github.com/nix-community/emacs-overlay/commit/1d2586833f2f614b8275d46887e0207117d089bc) Updated repos/elpa
* [`4841619d`](https://github.com/nix-community/emacs-overlay/commit/4841619d55dae7c65ec0267cde843989bb7c1d3d) Updated repos/emacs
* [`fa3548ca`](https://github.com/nix-community/emacs-overlay/commit/fa3548ca8f9205cef2c41c9e8bc8cb4f1a879cbf) Updated repos/melpa
* [`216a7fd9`](https://github.com/nix-community/emacs-overlay/commit/216a7fd975234182dda23884dcaa028c5c751358) Updated repos/emacs
* [`9d06bcfc`](https://github.com/nix-community/emacs-overlay/commit/9d06bcfc5b5d351ede146d77db7dfdff724d4196) Updated repos/melpa
* [`75985d73`](https://github.com/nix-community/emacs-overlay/commit/75985d7381f20ee392c2a990d0ca8b19ea622118) Updated repos/emacs
* [`0b120cc8`](https://github.com/nix-community/emacs-overlay/commit/0b120cc825715d594fa30a180924618ab2f54137) Updated repos/melpa
* [`4e10b8e5`](https://github.com/nix-community/emacs-overlay/commit/4e10b8e5a7045ab29751eb65b4c0b4b80c6f0192) Updated repos/emacs
* [`11d059ab`](https://github.com/nix-community/emacs-overlay/commit/11d059ab7ebadb20ca1c6b1ae77266608def2b50) Updated repos/melpa
* [`7881a45a`](https://github.com/nix-community/emacs-overlay/commit/7881a45a1e1e8ee724c7c0a1bc82e0f2fc3fda29) Updated repos/elpa
* [`f0ecd0d4`](https://github.com/nix-community/emacs-overlay/commit/f0ecd0d4efcf81bb86b323d74745416acd237018) Updated repos/emacs
* [`274db48d`](https://github.com/nix-community/emacs-overlay/commit/274db48d3a88a44d742c2543afc8e3f4e6be9189) Updated repos/melpa
* [`3871f48d`](https://github.com/nix-community/emacs-overlay/commit/3871f48d0bd5221303ff7bd1c43e0ea1bfb526f1) Updated repos/emacs
* [`489651e2`](https://github.com/nix-community/emacs-overlay/commit/489651e2927fdf356b68123ed6f8c7910bfa7f7d) Updated repos/melpa
* [`6659a771`](https://github.com/nix-community/emacs-overlay/commit/6659a77128ac18df4faf72f810203f0777ad8b05) Updated repos/emacs
* [`2d0205dd`](https://github.com/nix-community/emacs-overlay/commit/2d0205ddd7003ac495d992e70459d8dd4bd14e38) Updated repos/melpa
* [`0a5e60b2`](https://github.com/nix-community/emacs-overlay/commit/0a5e60b2af8df1ec1feec31d5e6892d91f2d12a7) Updated repos/elpa
* [`e3d285d6`](https://github.com/nix-community/emacs-overlay/commit/e3d285d6d0d451e6acc33cdde6a4e850622b7b4e) Updated repos/melpa
* [`7303e566`](https://github.com/nix-community/emacs-overlay/commit/7303e566d4056132a2dd6ba469b66f5e17ec5b78) Updated repos/emacs
* [`04c8cbe9`](https://github.com/nix-community/emacs-overlay/commit/04c8cbe99335bb903b76e72752e6840286e2c03a) Updated repos/melpa
* [`e46be45e`](https://github.com/nix-community/emacs-overlay/commit/e46be45e91c29bef96da432e6c926505f719ed57) Updated repos/elpa
* [`d6d818b5`](https://github.com/nix-community/emacs-overlay/commit/d6d818b57d5c28b8a283ff4082e32a33a5ba74ec) Updated repos/emacs
* [`06da4715`](https://github.com/nix-community/emacs-overlay/commit/06da47152be5f7d8186d2602ced50109ad77e519) Updated repos/melpa
* [`ea85a2ee`](https://github.com/nix-community/emacs-overlay/commit/ea85a2ee1bb33050c6b4de89f261851fe385ea56) Updated repos/elpa
* [`f9247c01`](https://github.com/nix-community/emacs-overlay/commit/f9247c01f8ce9a06501635d7b8987a7e0c75cbe6) Updated repos/emacs
* [`b20daaf9`](https://github.com/nix-community/emacs-overlay/commit/b20daaf964c777c2ceb6f2f81dfe6c468682e8b2) Updated repos/melpa
* [`2659ae85`](https://github.com/nix-community/emacs-overlay/commit/2659ae85ef09d230569fd2d1a024fd24df49c330) Updated repos/emacs
* [`ed487066`](https://github.com/nix-community/emacs-overlay/commit/ed4870665719c3d37c5947fc425f8a45716b4ea8) Updated repos/melpa
* [`44270347`](https://github.com/nix-community/emacs-overlay/commit/442703473f34303e6e3d14d520858cc95796711a) Updated repos/emacs
* [`ea1b9cee`](https://github.com/nix-community/emacs-overlay/commit/ea1b9ceee2778d1691fb8e5b47e05310440e3ce9) Updated repos/melpa
* [`8fa0b679`](https://github.com/nix-community/emacs-overlay/commit/8fa0b679fafd73c0b8033d9b7890297d418c0431) Updated repos/emacs
* [`20e5d45d`](https://github.com/nix-community/emacs-overlay/commit/20e5d45de6962e07829eb8bf1c9420856d53b669) Updated repos/melpa
* [`b1eb7f04`](https://github.com/nix-community/emacs-overlay/commit/b1eb7f047259b765071640946fca7d63ad5c5b52) Updated repos/emacs
* [`92244ab0`](https://github.com/nix-community/emacs-overlay/commit/92244ab0b93bed8e207f8ccb6b2e08557a84594c) Updated repos/melpa
* [`9ca90084`](https://github.com/nix-community/emacs-overlay/commit/9ca900846dff793a440e4c8560a986bfccf9edd0) Updated repos/emacs
* [`468341ff`](https://github.com/nix-community/emacs-overlay/commit/468341ff2164834767efbd5e0f55f942342deaab) Updated repos/melpa
* [`afeed80f`](https://github.com/nix-community/emacs-overlay/commit/afeed80f089065aa3d8b7cdf2c03fcd2deba7922) Updated repos/elpa
* [`c879d99d`](https://github.com/nix-community/emacs-overlay/commit/c879d99d8a3558cb8c7b772f0ed178a0b849ec20) Updated repos/emacs
* [`d41b2e83`](https://github.com/nix-community/emacs-overlay/commit/d41b2e83e72307a69cf7413085158bc9192e3d4b) Updated repos/melpa
* [`6633d502`](https://github.com/nix-community/emacs-overlay/commit/6633d5026ef829daa5cb095d43cb64bccd6efc06) Updated repos/emacs
* [`bc9fa090`](https://github.com/nix-community/emacs-overlay/commit/bc9fa0906efbf7f767837682483136b1e4a0bf4d) Updated repos/melpa
* [`2c38b9d2`](https://github.com/nix-community/emacs-overlay/commit/2c38b9d2884b84af04ce1797717e3a2a8fc534d0) Updated repos/elpa
* [`d2c63d0d`](https://github.com/nix-community/emacs-overlay/commit/d2c63d0da557561016474a1586f83dfc6ce1408c) Updated repos/emacs
* [`e9fe5549`](https://github.com/nix-community/emacs-overlay/commit/e9fe554910fabf301ebf244aa2f9e5f2d5f69c4b) Updated repos/melpa
* [`9e1f1c1e`](https://github.com/nix-community/emacs-overlay/commit/9e1f1c1ec4395e11a2639939d1299350dfe651d5) Updated repos/emacs
* [`5ea4edff`](https://github.com/nix-community/emacs-overlay/commit/5ea4edff63d066fae8e89d32f1e9a4ee0dcf056d) Updated repos/melpa
