### PR TITLE
niv spacemacs: update 69027b8e -> 85edf6a5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "69027b8eec1c09c867c9951908f73b26213eec31",
-        "sha256": "0j121sxqpabqmyphdqpgr6aaac2c3yx7z0rpmxmim592mmcf7dc6",
+        "rev": "85edf6a578c81f12537ac0b1d8b98324625e4275",
+        "sha256": "1amr4b8iz56z7xqknm8lh92v5h72alx26l32862vzifg4vr1d0p2",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/69027b8eec1c09c867c9951908f73b26213eec31.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/85edf6a578c81f12537ac0b1d8b98324625e4275.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@69027b8e...85edf6a5](https://github.com/syl20bnr/spacemacs/compare/69027b8eec1c09c867c9951908f73b26213eec31...85edf6a578c81f12537ac0b1d8b98324625e4275)

* [`11277c51`](https://github.com/syl20bnr/spacemacs/commit/11277c517c0370d834b2d96f2576aff4831af49d) [Rust] fix dap mode toggle logic
* [`3afb0889`](https://github.com/syl20bnr/spacemacs/commit/3afb088940eb0a51f0105625fb4c74ca4e789f9f) [javascript] Use js2-mode with .cjs files
* [`1228c574`](https://github.com/syl20bnr/spacemacs/commit/1228c57444f5d8da5d6077c3597a58d55f244750) removing consult-completing-read-multiple in compleseus
* [`771bb6c4`](https://github.com/syl20bnr/spacemacs/commit/771bb6c43adb91daae86bb320f1d2f6e3e494c2a) [Chinese] refactor the input with last pyim ([syl20bnr/spacemacs⁠#15563](https://togithub.com/syl20bnr/spacemacs/issues/15563))
* [`1bb3ebf1`](https://github.com/syl20bnr/spacemacs/commit/1bb3ebf10f4202a475133d380bb79e0d2e89df85) [bot] "built_in_updates" Thu Jun  2 13:08:50 UTC 2022
* [`6fd11650`](https://github.com/syl20bnr/spacemacs/commit/6fd1165060762fa9de5a7da1b9721400fb2871e5) Add fountain layer, a screenwriting file format
* [`00f9ab19`](https://github.com/syl20bnr/spacemacs/commit/00f9ab19ac8642d3256ea9b278e7d165a897c622) chore: update copyright headers to 2022
* [`3ba43e29`](https://github.com/syl20bnr/spacemacs/commit/3ba43e29165fb17d39baab528d63a63e907fa81a) [bot] "documentation_updates" Fri Jun  3 15:18:32 UTC 2022
* [`3087f5cf`](https://github.com/syl20bnr/spacemacs/commit/3087f5cf58bcb405298f084155bc40b7d79eb972) [fountain] Fix tag declaration
* [`51686e5f`](https://github.com/syl20bnr/spacemacs/commit/51686e5f1206d57a86d9d33a62ed02c9aa9c7e8b) [bot] "documentation_updates" Sat Jun  4 08:12:41 UTC 2022
* [`a485b5a8`](https://github.com/syl20bnr/spacemacs/commit/a485b5a84b3fa4f8a06b25f51cf6df49b51defb0) Make startup banner scalable (from dotfile)
* [`85edf6a5`](https://github.com/syl20bnr/spacemacs/commit/85edf6a578c81f12537ac0b1d8b98324625e4275) org-contacts no longer built-in
