### PR TITLE
niv nixpkgs: update e4cb4bdb -> 06801147

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e4cb4bdb05605d691ca31b54703f2866197944ef",
-        "sha256": "0qmqcisls40qp8va6bj9pamprslrwwwlwdq0bcsq41bgk6nki8dz",
+        "rev": "068011475527fe8a211f2515ba4bf2b76ca74a73",
+        "sha256": "1ycnyyzqcvh4ls3h5gnniw45lad83khr1pwx9vp89gn2qncjzkq5",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e4cb4bdb05605d691ca31b54703f2866197944ef.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/068011475527fe8a211f2515ba4bf2b76ca74a73.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e4cb4bdb...06801147](https://github.com/nixos/nixpkgs/compare/e4cb4bdb05605d691ca31b54703f2866197944ef...068011475527fe8a211f2515ba4bf2b76ca74a73)

* [`9e18a59e`](https://github.com/NixOS/nixpkgs/commit/9e18a59e42783bea55742e244b5185df55291bcb) voms: init at 2021-05-04
* [`d4e1e79e`](https://github.com/NixOS/nixpkgs/commit/d4e1e79ede9de45145eb77358aeb607d6cf7c5c3) xrootd: add voms support
* [`39a1aded`](https://github.com/NixOS/nixpkgs/commit/39a1adedec043464338a8831b5175b81dbd229d8) python310Packages.bitbox02: 5.3.0 -> 6.0.0
* [`94c0e088`](https://github.com/NixOS/nixpkgs/commit/94c0e08808ce3529e4ace6584626d94ca07f21ee) submitting-changes.chapter.md: explain that purple arrows are manual
* [`4f9d0078`](https://github.com/NixOS/nixpkgs/commit/4f9d0078061391f106a8f0b57dedeefffddc1802) mysql57: reduce closure size
* [`9f719ade`](https://github.com/NixOS/nixpkgs/commit/9f719ade9c65ef04e4622c9268cdcedbf3bdda1c) atomEnv: remove pointless GConf dependency
* [`d76f600c`](https://github.com/NixOS/nixpkgs/commit/d76f600c92e9a0d58f94267d3bd3e9cc77a3b4ab) atomEnv: remove libgnome-keyring dependency
* [`e67e81d8`](https://github.com/NixOS/nixpkgs/commit/e67e81d8e383591c9375c26ddf2bcfaa2f74f74d) asap: init at 5.2.0
* [`0757b37a`](https://github.com/NixOS/nixpkgs/commit/0757b37a5395bbda2ab5e4a0e5126ac243110637) kubernetes-controller-tools: 0.6.2 -> 0.8.0
* [`50217b01`](https://github.com/NixOS/nixpkgs/commit/50217b01dd68cb4dfc24ecfa568b7f1b69a092cc) submitting-changes.chapter.md: avoid being specific
* [`6872544c`](https://github.com/NixOS/nixpkgs/commit/6872544c1becda21a6c878aed8d1c3384c8ec10b) haguichi: init at 1.4.5
* [`9497f081`](https://github.com/NixOS/nixpkgs/commit/9497f081a1031632fee9c915941736b33b111b45) nixos/haguichi: init
* [`4d9801a7`](https://github.com/NixOS/nixpkgs/commit/4d9801a78fff121703c4ea4dcef8b6746973165c) lib: add inPureEvalMode
* [`e83b0e96`](https://github.com/NixOS/nixpkgs/commit/e83b0e96496afb70375c1f4b4435c5482655d862) uacme: init at 1.7.1
* [`a82b2192`](https://github.com/NixOS/nixpkgs/commit/a82b2192502a0f4fa139b3f508fdbb6a66e8fd40) ffmpeg_5-full: init at 5.0.1
* [`ceebdcfc`](https://github.com/NixOS/nixpkgs/commit/ceebdcfc2ca2d37872c46f224503a36f4d25daa9) lib/types: allow custom `submoduleWith` descriptions
* [`c79cc67b`](https://github.com/NixOS/nixpkgs/commit/c79cc67bdb77fe442dafd863b68492859f3ccec7) perlPackages.ArrayRefElem: init at 1.00
* [`e14aabb3`](https://github.com/NixOS/nixpkgs/commit/e14aabb3f6e12077fa3450b5fb6f1260e70e1e9c) awsls: init at 0.11.0
* [`2be636a8`](https://github.com/NixOS/nixpkgs/commit/2be636a8c382584396d9a9aa6c1349d9990be1e7) tauon: 7.1.3 -> 7.2.1
* [`85dfb119`](https://github.com/NixOS/nixpkgs/commit/85dfb11907c220c042f1372a2f411520e1efe235) python311: 3.11.0a7 -> 3.11.0b1
* [`5d3a61e4`](https://github.com/NixOS/nixpkgs/commit/5d3a61e402543541473ee9f8988cd87ca3e59648) linuxPackages.rtl8814au: unstable-2022-02-21 -> unstable-2022-05-23
* [`e6b6a9d2`](https://github.com/NixOS/nixpkgs/commit/e6b6a9d2a2df011dec0ef39774a7bc3cbda7a866) fcitx5-qt: add support for qt6 applications
* [`ffc97215`](https://github.com/NixOS/nixpkgs/commit/ffc97215641cd5c240a2edbd95f415432a36198e) perlPackages.IPCConcurrencyLimit: init at 0.17
* [`b39bd462`](https://github.com/NixOS/nixpkgs/commit/b39bd462400c7846fa53f840eb41fcbe4d4f3925) gpsbabel: 1.7.0 → 1.8.0
* [`2c2c558e`](https://github.com/NixOS/nixpkgs/commit/2c2c558e43f7921198be45acbb8dbc720d221236) AusweisApp2: 1.22.5 -> 1.22.7
* [`5dff481d`](https://github.com/NixOS/nixpkgs/commit/5dff481dbadbd85cab0d51553954f022d632fcd0) closurecompiler: 20220202 -> 20220502
* [`53d62cdb`](https://github.com/NixOS/nixpkgs/commit/53d62cdbbd679bd7d4fdb8e24fda66a5cdf522b9) openai: 0.18.1 -> 0.19.0
* [`75bc6da2`](https://github.com/NixOS/nixpkgs/commit/75bc6da23794da02b8bd4fd3bb9acadb17029315) make-options-doc: Filter options after transformOptions
* [`9af313fa`](https://github.com/NixOS/nixpkgs/commit/9af313fae8cb6449e27cd6530bb1140ff74af06f) doctl: 1.72.0 -> 1.76.0
* [`79b8d186`](https://github.com/NixOS/nixpkgs/commit/79b8d186a8d19097aec002abbfd5dd75c9d65955) nixos/fcitx5: add self to QT_PLUGIN_PATH
* [`44011a05`](https://github.com/NixOS/nixpkgs/commit/44011a050288f2d2d9f31f4fa5c54191df090b58) python310Packages.bravado-core: disable failing tests
* [`efec6c02`](https://github.com/NixOS/nixpkgs/commit/efec6c02d593856c3b433fd2b7480b161b0c4684) glpk: 4.65 -> 5.0
* [`58d2ebb2`](https://github.com/NixOS/nixpkgs/commit/58d2ebb2831fa3236598398c7dbba8e205d4e91c) ntfs3g: 2021.8.22 -> 2022.5.17
* [`5ac9f8ef`](https://github.com/NixOS/nixpkgs/commit/5ac9f8ef59f1650d35743d16ce6b999e4ee8cabb) ipfs: build with openssl
* [`f280a5db`](https://github.com/NixOS/nixpkgs/commit/f280a5db2b56daeea61e689e48259ca6ca66a365) pgweb: 0.11.7 -> 0.11.11
* [`d61ce444`](https://github.com/NixOS/nixpkgs/commit/d61ce4445c351a8084c0c5411e4acf5a3fbb6daf) aegisub: 3.2.2 -> 3.3.2
* [`889c8592`](https://github.com/NixOS/nixpkgs/commit/889c8592d52bdc90f9363f2d89b2388b618fe3cb) jwm: 2.4.1 -> 2.4.2
* [`ea469200`](https://github.com/NixOS/nixpkgs/commit/ea4692000b1dbb96a6d4ccac296a5c53c5f9bb67) jwm: add update script
* [`02aa3bff`](https://github.com/NixOS/nixpkgs/commit/02aa3bff8c65e7f42326c4a7977708764208c5f1) jwm: reformat
* [`81291cc7`](https://github.com/NixOS/nixpkgs/commit/81291cc793cf88bd6eff3fd8512e5eb9d037066c) nixos/grafana: Allow setting UID for datasource
* [`924b27e4`](https://github.com/NixOS/nixpkgs/commit/924b27e479a3058d23fa1ed12cb389260e3981bc) CONTRIBUTING.md: use 22.05 as target branch for backports
* [`f888642e`](https://github.com/NixOS/nixpkgs/commit/f888642ec69962a5da2e80c69b731d89e61f637d) Remove nixUnstable
* [`f0c3fe40`](https://github.com/NixOS/nixpkgs/commit/f0c3fe4091d19175b178c095f3dd7cab9be9213f) nixVersions.nix_2_9: init at 2.9.0
* [`7d6eeeb3`](https://github.com/NixOS/nixpkgs/commit/7d6eeeb3d0bc69a2f7fc8d2603dc7564f1fad6e0) nixVersions.stable: nix_2_8 -> nix_2_9
* [`14bc4210`](https://github.com/NixOS/nixpkgs/commit/14bc4210b706d9f58d6dcc13d81d54f79914bba3) element-{web,desktop}: compile from source
* [`093a0036`](https://github.com/NixOS/nixpkgs/commit/093a00363968481243c52cfda6fc66d315674596) yarn2nix: allow setting doDist by calling packages
* [`beb567ac`](https://github.com/NixOS/nixpkgs/commit/beb567ac2a839aa1c6a85baf68664813cd9ea578) globalprotect-openconnect: 1.4.1 -> 1.4.5
* [`48dd2889`](https://github.com/NixOS/nixpkgs/commit/48dd2889c7f408a7602e9bfb56afe3c0932533a7) kibana6: remove
* [`0bb08246`](https://github.com/NixOS/nixpkgs/commit/0bb082468894c28356f60aa647536bc2d353af89) nodejs-10_x: remove
* [`39092265`](https://github.com/NixOS/nixpkgs/commit/390922654444067b796b70b04bda15d8ca5912d1) ec2-amis: add release 22.05
* [`7844de53`](https://github.com/NixOS/nixpkgs/commit/7844de536be8c018cf762aa495ed7447a34cfdf6) go-sct: 20180605-eb1e851 -> unstable-2022-01-32
* [`7812eca4`](https://github.com/NixOS/nixpkgs/commit/7812eca4e911cfdc0affc7b44651f8e794bf2d08) clojure-lsp: 2022.05.23-13.18.11 -> 2022.05.31-17.35.50
* [`cea11fad`](https://github.com/NixOS/nixpkgs/commit/cea11fadae737a6a84c53e38bd5d9d4b3b434c04) bwidget: add support for darwin
* [`f5f11a90`](https://github.com/NixOS/nixpkgs/commit/f5f11a90a496feafd8e2f83e54bd5abadc52f4d4) perlPackages.TkToolBar: init at 0.12
* [`196a7afb`](https://github.com/NixOS/nixpkgs/commit/196a7afb203cdd6ef8ef2c0b6e5428fe5857c7a5) gmad: unstable-2015-04-16 -> unstable-2020-02-24
* [`c9a10a58`](https://github.com/NixOS/nixpkgs/commit/c9a10a58f33ff927d066df4735a3c057cf7ee2af) libmediaart: 1.9.5 -> 1.9.6
* [`050ca6ef`](https://github.com/NixOS/nixpkgs/commit/050ca6ef8faeb3f3519478efafad94b847bd8177) dvc: add overrides for scmrepo and grandalf
* [`a32e4cb3`](https://github.com/NixOS/nixpkgs/commit/a32e4cb320fcce9cad75cc8ef1fa5c9849dc72aa) maxscale: remove after being marked broken for over 18 months
* [`e2e7c44a`](https://github.com/NixOS/nixpkgs/commit/e2e7c44a9e78067087e93c2fe5ddacbd98a78540) iptraf: remove after being marked broken for over 18 months
* [`50788a38`](https://github.com/NixOS/nixpkgs/commit/50788a3831f165fbbd7891bf3cc725d82556f038) pepper: remove after being marked broken for over 18 months
* [`6da0d2b7`](https://github.com/NixOS/nixpkgs/commit/6da0d2b7a642aaa643b002083e5ed1558ecbe335) r4rs & r5rs: remove after being marked broken for over 18 months
* [`8ee01d4d`](https://github.com/NixOS/nixpkgs/commit/8ee01d4d726a7ea41fbfab90f18fa487ba999930) remarkjs: remove after being marked broken for over 18 months
* [`5d42a4bf`](https://github.com/NixOS/nixpkgs/commit/5d42a4bf7e35cac5fac7f2bc1969ee2cdf920852) scilab: remove after being marked broken for over 18 months
* [`8d567a88`](https://github.com/NixOS/nixpkgs/commit/8d567a8863a098dce273de7ecf4ddd7c97086db3) sit: remove after being marked broken for over 18 months
* [`bc8f6085`](https://github.com/NixOS/nixpkgs/commit/bc8f6085c3a3cff3851b7e994b12a148f3029c2a) stlport: remove after being marked broken for over 18 months
* [`100b75a4`](https://github.com/NixOS/nixpkgs/commit/100b75a44b2c30e1bfe9d034cf72c256b11a8a1c) syncthing-gtk: remove after being marked broken for over 18 months
* [`5bb61d6a`](https://github.com/NixOS/nixpkgs/commit/5bb61d6a2520f454c8e40e391955b7aad46e310c) syslogng_incubator: remove after being marked broken for over 18 months
* [`50ade5e2`](https://github.com/NixOS/nixpkgs/commit/50ade5e2b81a48dd0aef370953d61e7aeb8d57fa) telepathy-salut: remove after being marked broken for over 18 months
* [`926b2f72`](https://github.com/NixOS/nixpkgs/commit/926b2f72014488216a0cb8a8d66ae0e0df24935a) toggldesktop: remove after being marked broken for over 18 months
* [`d93dec5b`](https://github.com/NixOS/nixpkgs/commit/d93dec5b844107d46b8b81c5b38a9ec7f62ff8b6) tremulous: remove after being marked broken for over 18 months
* [`b6650a44`](https://github.com/NixOS/nixpkgs/commit/b6650a4438f4b6a8416a4ff81dbdc6c32e7e6420) udisks1: remove after being marked broken for over 18 months
* [`77d9d13f`](https://github.com/NixOS/nixpkgs/commit/77d9d13f3e034c0eb2d822756fd7c28e425f773f) vimiv: remove after being marked broken for over 18 months
* [`7b3ca2f3`](https://github.com/NixOS/nixpkgs/commit/7b3ca2f395ffac488a44c5c56fe3e8299cc5785c) zangband: remove after being marked broken for over 18 months
* [`12d74e3a`](https://github.com/NixOS/nixpkgs/commit/12d74e3abf8392898411d209096484516c2887ca) open-vm-tools: fix shared folders
* [`e1f72ee8`](https://github.com/NixOS/nixpkgs/commit/e1f72ee81b48a1da518a5c3093905ac62fee8872) feedbackd: support cross-compilation
* [`aa9f72b9`](https://github.com/NixOS/nixpkgs/commit/aa9f72b92b6b3dfd848524e9fa64acc3595cfe6c) opencv4: disable hdf5 for cross-compilation
* [`a7a7ef58`](https://github.com/NixOS/nixpkgs/commit/a7a7ef5803d523937caf7c6d35df3c188468d416) python310Packages.wallbox: 0.4.8 -> 0.4.9
* [`fdd7b027`](https://github.com/NixOS/nixpkgs/commit/fdd7b027c7d546a71e73927dc80743906d4a7404) mongosh: init at 1.5.0
* [`1a1e7f77`](https://github.com/NixOS/nixpkgs/commit/1a1e7f77dae8802fc564bae477c10fa3be1f6663) skeema: 1.7.1 -> 1.8.0
* [`bde65d2e`](https://github.com/NixOS/nixpkgs/commit/bde65d2eea592dc1860347e5df74127e262e7844) tootle: pin to vala 0.54
* [`f2352bb5`](https://github.com/NixOS/nixpkgs/commit/f2352bb589b787cf9786de0e9c353b218410697e) gradio: remove
* [`4eeafebc`](https://github.com/NixOS/nixpkgs/commit/4eeafebc3c5c2273b53090ebe79db1aede839575) maintainers: add Jevin Maltais
* [`9e9289f5`](https://github.com/NixOS/nixpkgs/commit/9e9289f506ee813a1090d2703e915ba99bff16a2) codeowners: init at 0.4.0
* [`56048394`](https://github.com/NixOS/nixpkgs/commit/56048394040202e92c5720a03eace36f1dc8d10b) metals: 0.11.5 -> 0.11.6
* [`322a6cc9`](https://github.com/NixOS/nixpkgs/commit/322a6cc95b97cbaeefcdf14800ab936c79ff1dc1) feedbackd: add comment explaining why introspection is disabled for cross
* [`28379c3a`](https://github.com/NixOS/nixpkgs/commit/28379c3a5124758f8adf79f9d20e8d332c854eaf) Revert "nixos/asf: set restrictive home permissions"
* [`4de6a811`](https://github.com/NixOS/nixpkgs/commit/4de6a81193c9c29cd03d34552991422d0e6ba051) nixos/asf: fix state directory permissions, for real
* [`d8cd684b`](https://github.com/NixOS/nixpkgs/commit/d8cd684b62053cb373c1ada9d41434fe737e6177) nixos/asf: restart when self restarting
* [`032f15e5`](https://github.com/NixOS/nixpkgs/commit/032f15e566ad9f68017c23db0f2b70345a19b74e) nixos/asf: add me as maintainer
* [`dcc2f92e`](https://github.com/NixOS/nixpkgs/commit/dcc2f92e8b1f0d0e8d65884fd09a3b9d3b188718) xfsprogs: 5.16.0 -> 5.18.0
* [`89d005bb`](https://github.com/NixOS/nixpkgs/commit/89d005bbb7ed6f1210ceedb213f71d3f09c5575d) diffoscope: 214 -> 215
* [`3a34767c`](https://github.com/NixOS/nixpkgs/commit/3a34767c9bcfeea7809be5284202381c1ae3e675) smatch: 20120924 -> 1.72
* [`cb90b5a8`](https://github.com/NixOS/nixpkgs/commit/cb90b5a8e42e674852dbe2c4f864fca2bd84e50a) smatch: add marsam to maintainers
* [`473bca4b`](https://github.com/NixOS/nixpkgs/commit/473bca4bd27738f487d134e0b3f79305dca09ef0) linuxPackages_hardkernel_latest.usbip: pull upstream fix for -fno-common toolchains
* [`dd4cef3a`](https://github.com/NixOS/nixpkgs/commit/dd4cef3a267f63fbfec88db73ed3cc03779a7809) drawio: 18.1.3 -> 19.0.0
* [`c198b6e7`](https://github.com/NixOS/nixpkgs/commit/c198b6e76e8d00b565f815bb377cc3d11bfd65d2) all-cabal-hashes: 2022-05-29T17:05:02Z -> 2022-06-04T09:01:11Z
* [`f2af2587`](https://github.com/NixOS/nixpkgs/commit/f2af2587970769d5985eab5a0189dc2160014814) haskellPackages: stackage LTS 19.8 -> LTS 19.9
* [`30558578`](https://github.com/NixOS/nixpkgs/commit/305585788bfc5fac4ae1340b144316b9acb942db) haskellPackages: regenerate package set based on current config
* [`28e96668`](https://github.com/NixOS/nixpkgs/commit/28e9666850a6c7ce2512316d7dec38f878b26560) haskell.packages.ghc923.fourmolu: 0.6.0.0 -> 0.7.0.1
* [`2aa6ee92`](https://github.com/NixOS/nixpkgs/commit/2aa6ee92a627fdd39fcf81d7ec6003015d192742) glirc: 2.38 -> 2.39
* [`844c8012`](https://github.com/NixOS/nixpkgs/commit/844c8012b7a94b3d169ed3a81814738b82abda58) amberol: 0.6.3 -> 0.7.0
* [`a65fab6b`](https://github.com/NixOS/nixpkgs/commit/a65fab6b629bbc56573c407545aa646db0c28684) gtg: 0.5 -> 0.6
* [`30b87b00`](https://github.com/NixOS/nixpkgs/commit/30b87b001b282a99afa9342e4486e56624fddb9f) python310Packages.docopt-ng: 0.7.2 -> 0.8.1
* [`cd8f876c`](https://github.com/NixOS/nixpkgs/commit/cd8f876c6188097b20cba9aaf219792d198f1c75) python310Packages.staticjinja: 4.1.2 -> 4.1.3
* [`b28b489a`](https://github.com/NixOS/nixpkgs/commit/b28b489abca5aa6fa8f86a77a427c086db6405cf) nixVersions.nix_2_9: add patch
* [`4bf142e3`](https://github.com/NixOS/nixpkgs/commit/4bf142e3c165d56fd612dea849648411f354cfe7) nix-eval-jobs: 0.0.6 -> 2.9.0
* [`aef9be48`](https://github.com/NixOS/nixpkgs/commit/aef9be48aa53c4e0c70936432e58df8f170525cf) nix-plugins: Apply patch to build with Nix 2.9
* [`9fc54a17`](https://github.com/NixOS/nixpkgs/commit/9fc54a1723bac94a6f7beed0829203e0dfef6f12) symbolic-preview: 0.0.2 -> 0.0.3
* [`e827840a`](https://github.com/NixOS/nixpkgs/commit/e827840ae56079e55d198f42049da6912506f5b0) elasticsearch-plugins: 7.16.1 -> 7.17.4
* [`9afc7425`](https://github.com/NixOS/nixpkgs/commit/9afc7425660270d98bb012934ad46acb2355e97c) vivaldi: 5.2.2623.41-1 -> 5.3.2679.38-1
* [`a6831964`](https://github.com/NixOS/nixpkgs/commit/a68319646a794044c11b21495322c7f04ddf543a) vivaldi-ffmepg-codecs: 101.0.4951.15 -> 102.0.5005.49
* [`72ed5665`](https://github.com/NixOS/nixpkgs/commit/72ed5665a234ac7de86a762e004704c322e8b28f) gcolor2: pull patch pending upstream inclusion for -fno-common toolchains
* [`0df7cba1`](https://github.com/NixOS/nixpkgs/commit/0df7cba1b0ad4dc019a54aa2fec107a8ae5bf404) nixos/asf: ipcPasswordFile use nullOr
* [`44dcb2df`](https://github.com/NixOS/nixpkgs/commit/44dcb2dfb7dc7d73684654ff065f15a478bb6dc2) maintainers: add `booklearner`
* [`b7717516`](https://github.com/NixOS/nixpkgs/commit/b7717516d4a0d0c241fac66fc3d3df27e69cfa21) alps: `2022-03-01` -> `2022-06-03`
* [`4995a873`](https://github.com/NixOS/nixpkgs/commit/4995a873a796c54cc49e5dca9e1d20350eceec7b)  yubikey-agent: 0.1.5 -> unstable-2022-03-17
* [`4537ba53`](https://github.com/NixOS/nixpkgs/commit/4537ba53c00ce2bc072f5c2981f737ed254757be) rmfuse: Re-lock dependencies
* [`2e3017b2`](https://github.com/NixOS/nixpkgs/commit/2e3017b212e3b7e0ac2f47083d14dd6122e4397e) jd: remove
* [`0c3f9871`](https://github.com/NixOS/nixpkgs/commit/0c3f9871066631a731e67d3ee5e2cf403d0c699b) tychus: remove
* [`7584c237`](https://github.com/NixOS/nixpkgs/commit/7584c2373a607c578e8446ed3614d1c4f2bde4cb) ws: remove
* [`6fa503c7`](https://github.com/NixOS/nixpkgs/commit/6fa503c7b3e437a2016bb04d383842d08df3be60) azure-vhd-utils: remove
* [`ad62acc7`](https://github.com/NixOS/nixpkgs/commit/ad62acc7399f667a94f1f1c0f109ab494a013abc) envdir: remove
* [`d6f80617`](https://github.com/NixOS/nixpkgs/commit/d6f80617a3e667ddc89f2f450c7909873bfb18f6) manul: remove
* [`9feb7fe2`](https://github.com/NixOS/nixpkgs/commit/9feb7fe28aeffd762cdfbc78c98c6f7838905cf5) libosinfo: disable devdoc output when cross compiling
* [`a0809c02`](https://github.com/NixOS/nixpkgs/commit/a0809c029330540e35ff5a8cd4295b68271e1e19) haskellPackages.hoogleLocal: allow substitutes again
* [`70d95b25`](https://github.com/NixOS/nixpkgs/commit/70d95b25b6c7130563522aed285374b2b20d7464) haskellPackages.protolude: drop upstreamed patches
* [`d3805f8d`](https://github.com/NixOS/nixpkgs/commit/d3805f8df5dec0e18fdf983734cfb728476e6dd5) darwin.dtrace: add -fcommon workaround
* [`7d6048d0`](https://github.com/NixOS/nixpkgs/commit/7d6048d0adac9b952e3f9c8b9f8fadde514c9324) darwin.file_cmds: add -fcommon workaround
* [`f6e2e3a1`](https://github.com/NixOS/nixpkgs/commit/f6e2e3a1e15a1670a73817f3ef58c561e35ebb40) lens: 5.3.4 -> 5.5.3
* [`e174b463`](https://github.com/NixOS/nixpkgs/commit/e174b463e7f01a32a4347d92f0e7cbc80ea5cd1d) nixops: mark insecure
* [`007ffa60`](https://github.com/NixOS/nixpkgs/commit/007ffa606906411323ef32448ea97c005cffe597) python2Packages.pyjwt: mark insecure
* [`ac4fc73a`](https://github.com/NixOS/nixpkgs/commit/ac4fc73abc159cd8860ce7b61844306335fb3578) python2Packages.urllib3: mark insecure
* [`b9dcfbbd`](https://github.com/NixOS/nixpkgs/commit/b9dcfbbd4dc4a4ca4c40c3a0042e1d121e459eb7) cdesktopenv: add -fcommon workaround
* [`51dd9995`](https://github.com/NixOS/nixpkgs/commit/51dd9995c7afc6fc6d6c5cd4902f0f0c03e146d9) jellyfin-ffmpeg: 4.4.1-4 -> 5.0.1-5
* [`c2e5fbe6`](https://github.com/NixOS/nixpkgs/commit/c2e5fbe6e89598d31a8c61f31a94c05d8a0cbc31) soft-serve: 0.3.0 -> 0.3.1
* [`46e4f3bd`](https://github.com/NixOS/nixpkgs/commit/46e4f3bd77559fe6edb366551530fe50a774849f) cernlib: add -fcommon workaround
* [`d7c6d3d0`](https://github.com/NixOS/nixpkgs/commit/d7c6d3d063d0671e2ce7fd1c5bc4d93771ec6883) coturn: add -fcommon workaround
* [`dcb168b1`](https://github.com/NixOS/nixpkgs/commit/dcb168b10932b1b72396d5ac30ccd9a2394d97ae) dieharder: add -fcommon workaround
* [`82bb52db`](https://github.com/NixOS/nixpkgs/commit/82bb52db8f3f8cb90911e6cb194b5e9602a49c15) eresi: pull fix pending upstream inclusion for -fno-common toolchains
* [`8b7b76a6`](https://github.com/NixOS/nixpkgs/commit/8b7b76a61258cda2407cbf32f3e6b0ade6b9482d) geda: pull upstream fixes for -fno-common toolchains
* [`9440e44a`](https://github.com/NixOS/nixpkgs/commit/9440e44a33cc06a4fa33392a56f86c7f7ea1f077) industrializer: 0.2.6 -> 0.2.7
* [`c7104a2e`](https://github.com/NixOS/nixpkgs/commit/c7104a2e5d6334f76a54a20beaae14e68cd09bc1) libagar_test: add -fcommon workaround
* [`6dd63933`](https://github.com/NixOS/nixpkgs/commit/6dd63933f39a54ee57c6edd8375ad4c6298f6dc4) reaverwps: add -fcommon workaround
* [`fc8061da`](https://github.com/NixOS/nixpkgs/commit/fc8061dae4731f7cd8043df9dc1c3bdbd8b10776) percona-xtrabackup_2_4: add -fcommon workaround
* [`53921eab`](https://github.com/NixOS/nixpkgs/commit/53921eabca7696311ef7ecbe0454100d487301ce) maintainers: Add scoder12
* [`8487b21f`](https://github.com/NixOS/nixpkgs/commit/8487b21ffbfaad8462dc1b37981d84cdc313a0de) memtest86+: 5.01-coreboot-002 -> 6.00-beta2
* [`3586c258`](https://github.com/NixOS/nixpkgs/commit/3586c258e8dfd305b8a6c65dd5c98efabd288e59) haskell.packages.ghc923: pin fourmolu to 0.6.0.0
* [`5962fe07`](https://github.com/NixOS/nixpkgs/commit/5962fe0782dc36ae4a8fa34f96262c0ff5893dbb) python310Packages.wheel-filename: 1.3.0 -> 1.4.1
* [`5f4fe18c`](https://github.com/NixOS/nixpkgs/commit/5f4fe18c16eab71e2ebdd35b536c22d30d579106) python310Packages.wheel-inspect: 1.7.0 -> 1.7.1
* [`834eeb35`](https://github.com/NixOS/nixpkgs/commit/834eeb35e46f3009ca95954941bf35f73af4ed9d) python310Packages.entry-points-txt: 0.1.0 -> 0.2.0
* [`1c61372d`](https://github.com/NixOS/nixpkgs/commit/1c61372d39caded68a1913d9c3e6250d9512ff92) python310Packages.headerparser: enable tests
* [`f74ef9f9`](https://github.com/NixOS/nixpkgs/commit/f74ef9f98a726b718259c51396c0cde796dd0e44) python310Packages.wheel-inspect: relax entry-points-txt constraint
* [`109e13db`](https://github.com/NixOS/nixpkgs/commit/109e13db243249e26b8b8d861424578400aae882) dragonflydb: init at 0.1.0
* [`7cd27bcc`](https://github.com/NixOS/nixpkgs/commit/7cd27bccabc9b3fe9e1ff538c87709b9a1e1625b) python310Packages.snowflake-connector-python: add missing input
* [`1841ad02`](https://github.com/NixOS/nixpkgs/commit/1841ad02a3a6ce601b39c1ad5a9a9fb8ca8c9be6) ArchiSteamFarm: fix shellcheck problems
* [`89d5ef12`](https://github.com/NixOS/nixpkgs/commit/89d5ef1295b0b78d23856741ac914f8868550173) ArchiSteamFarm: update programm and web-ui in one run
* [`70a7d055`](https://github.com/NixOS/nixpkgs/commit/70a7d055f5c3e9bc5569e70fffb48a2d78d0a55d) ArchiSteamFarm: fix tmp filling up
* [`1235314d`](https://github.com/NixOS/nixpkgs/commit/1235314d6cc0a239eb15061f8c3a9e28b11dbf39) ArchiSteamFarm: normalize file names
* [`1d5ccbc4`](https://github.com/NixOS/nixpkgs/commit/1d5ccbc42d9a37cb6619bbb7a5feb3f36e98fcc8) python310Packages.mkdocs-material: 8.3.1 -> 8.3.2
* [`535900e9`](https://github.com/NixOS/nixpkgs/commit/535900e91dab642100660cdecc966dd164b134e3) jpegexiforient: fix cross-compilation
* [`78ecfd54`](https://github.com/NixOS/nixpkgs/commit/78ecfd54e527c794eea1e3b8d1f6afb9020dc92b) xscreensaver: add missing Perl libs
* [`9e762efd`](https://github.com/NixOS/nixpkgs/commit/9e762efdfa11de778a7cc0a305ae36c81fbcec89) python310Packages.siobrultech-protocols: 0.5.0 -> 0.6.0
* [`b108994c`](https://github.com/NixOS/nixpkgs/commit/b108994c1b0444aa0154657de41098c1fc4c4ad9) python310Packages.greeneye-monitor: relax version constraint
* [`36aa013f`](https://github.com/NixOS/nixpkgs/commit/36aa013ff4a84f9316ddc7b9817592cb3e80d12b) borgbackup: 1.2.0 -> 1.2.1
* [`d2a9a19e`](https://github.com/NixOS/nixpkgs/commit/d2a9a19e8aee6fad776bf0f43d9d5dda80444ff7) borgbackup: set meta.mainProgram
* [`d33e96ee`](https://github.com/NixOS/nixpkgs/commit/d33e96ee4a28fda92f9fa159e110a1a825aa85fb) metadata-cleaner: 2.2.2 -> 2.2.3
* [`8dbfd523`](https://github.com/NixOS/nixpkgs/commit/8dbfd523ec9c0dd3c80093875855911666644767) python310Packages.nextcord: 2.0.0a10 -> 2.0.0b2
* [`44e85d3d`](https://github.com/NixOS/nixpkgs/commit/44e85d3d61c55f8a644f14a2defaffae044bcb09) python310Packages.pysptk: 0.1.20 -> 0.1.21
* [`a60358be`](https://github.com/NixOS/nixpkgs/commit/a60358bec9b6f89e7ed727c1d88336d8f0379ea1) kubernetes: drop obsolete workarounds
* [`1ca6d814`](https://github.com/NixOS/nixpkgs/commit/1ca6d814762d1e37ee021807fb94c685fc5b85b4) python310Packages.smbus2: 0.4.1 -> 0.4.2
* [`e9f4412e`](https://github.com/NixOS/nixpkgs/commit/e9f4412eb44c543b12bd8dc472ecb953b3aa2f34) docker-edge: remove
* [`e6299e53`](https://github.com/NixOS/nixpkgs/commit/e6299e53681576838fb13380e088afbee3ff7a3d) ruby: move jemalloc to propagatedBuildInputs
* [`d3d975f7`](https://github.com/NixOS/nixpkgs/commit/d3d975f71c4a038984286d3b25fe964125e80bad) igraph: 0.9.8 -> 0.9.9
* [`046d0253`](https://github.com/NixOS/nixpkgs/commit/046d0253aa88e47e4d424e02bc548897d5eeacfe) python310Packages.safety: improve expression
* [`8ff17155`](https://github.com/NixOS/nixpkgs/commit/8ff17155becf4b2b8dcad32492e5abba3ffc73d9) python310Packages.fastcore: 1.4.3 -> 1.4.4
* [`22f3d4e4`](https://github.com/NixOS/nixpkgs/commit/22f3d4e4dbc415c880dabca13fcc11d45e8d53ab) nixos: move matrix services into their category
* [`20749fc8`](https://github.com/NixOS/nixpkgs/commit/20749fc886cf6ade0726d0ab51a6c08428e51c73) hidapi: 0.11.2 -> 0.12.0
* [`d8cdbde2`](https://github.com/NixOS/nixpkgs/commit/d8cdbde2c94345441235bad1d473b01ec14ca011) terraform-providers: update 2022-06-06
* [`b7b91880`](https://github.com/NixOS/nixpkgs/commit/b7b91880d3f2358a5eacb31476ab937c0df5562a) docker-compose: default to v2
* [`4ffef834`](https://github.com/NixOS/nixpkgs/commit/4ffef8340888dd5c4b7dc748456071e544cca428) docker-compose: add $out/bin symlink
* [`9c7fe48d`](https://github.com/NixOS/nixpkgs/commit/9c7fe48d8d790de036d47a0288abf3dde40ded21) python310Packages.twitchapi: 2.5.3 -> 2.5.4
* [`a487e362`](https://github.com/NixOS/nixpkgs/commit/a487e362a10f318da123083d21df3daeabfc5c2e) fish: fix failing test
* [`bda47d3e`](https://github.com/NixOS/nixpkgs/commit/bda47d3eab420b37e01cce22e7d05915406d7ca9) python310Packages.r2pipe: 1.7.0 -> 1.7.1
* [`b45291a2`](https://github.com/NixOS/nixpkgs/commit/b45291a2bce1e95c966542a7ef8a7e95d9ce6b18) git-blame-ignore-revs: add python format commit
* [`cca70b73`](https://github.com/NixOS/nixpkgs/commit/cca70b73249b0a114d9c3713a16af2bf50b36366) python-minimal: don't clean meta.maintainer
* [`b4857447`](https://github.com/NixOS/nixpkgs/commit/b48574478302062e5b2eb6e94a29320f8a3c3b11) snipe-it: 5.4.3 -> 6.0.2
* [`eb38504a`](https://github.com/NixOS/nixpkgs/commit/eb38504a7483d93f48b28451f99981e1811c8cf2) yersinia: add -fcommon workaround
* [`20011937`](https://github.com/NixOS/nixpkgs/commit/2001193711aa0eeef68dfb71d2e2e67fc040ffc9) python310Packages.pysptk: add pythonImportsCheck
* [`96c3ac67`](https://github.com/NixOS/nixpkgs/commit/96c3ac67ea33ad2da031dce560014b96db0c369c) python310Packages.azure-mgmt-batch: 16.1.0 -> 16.2.0
* [`35d751b2`](https://github.com/NixOS/nixpkgs/commit/35d751b2db4e02f0963b76bf92d654fe56f4c7ce) python310Packages.meross-iot: 0.4.4.5 -> 0.4.4.7
* [`41c46d00`](https://github.com/NixOS/nixpkgs/commit/41c46d00e9abbeb05fc68393c2d4092049f07472) sptk: init at 4.0
* [`d208dd99`](https://github.com/NixOS/nixpkgs/commit/d208dd99f3ce217051299f1d380c7374143f80a1) python310Packages.pysensibo: 1.0.16 -> 1.0.17
* [`a1037629`](https://github.com/NixOS/nixpkgs/commit/a1037629f56dddb1cfe877a48e93996c25d6dacc) python310Packages.azure-mgmt-batch: disable on older Python releases
* [`6f0681dd`](https://github.com/NixOS/nixpkgs/commit/6f0681dd6bb3e3029b78bfc74a812326121bfad6) checkov: 2.0.1188 -> 2.0.1195
* [`46712a64`](https://github.com/NixOS/nixpkgs/commit/46712a646107d7b0d76bbb6aeefe7baf93a34ff7) python310Packages.aioskybell: init at 22.6.0
* [`0be108df`](https://github.com/NixOS/nixpkgs/commit/0be108df2e8068e57a8bcf3c2e024ff054963b36) nixos/tests/firefox: fix return type typing
* [`4bfbbe9d`](https://github.com/NixOS/nixpkgs/commit/4bfbbe9d58f94ea5d54bdcad512605e49cab4fe2) atuin: 0.9.1 -> 0.10.0
* [`acfbab28`](https://github.com/NixOS/nixpkgs/commit/acfbab28afab3420276d1b5f6d1368ea0ee6c7ee) python310Packages.holidays: 0.13 -> 0.14.2
* [`a505bdc3`](https://github.com/NixOS/nixpkgs/commit/a505bdc3f94e6daeb4ab5bb5d59df691b5ec4ef5) fulcrum: 1.6.0 -> 1.7.0
* [`135028b6`](https://github.com/NixOS/nixpkgs/commit/135028b610b7c1254617d3092ccbfb5333f56c1c) python310Packages.holidays: update disabled
* [`ff7b216d`](https://github.com/NixOS/nixpkgs/commit/ff7b216dcf3b3396b24ebd73204f6841839bdd2a) perlPackages: add default meta.mainProgram ([nixos/nixpkgs⁠#176398](https://togithub.com/nixos/nixpkgs/issues/176398))
* [`113f2048`](https://github.com/NixOS/nixpkgs/commit/113f20488ce644858959c77d58e11d8579e715be) roxctl: 3.69.1 -> 3.70.0
* [`6b7b3858`](https://github.com/NixOS/nixpkgs/commit/6b7b3858d6e2dd27eab7f0e63a22410a9fbf9218) python310Packages.pyroute2-core: 0.6.9 -> 0.6.10
* [`b9bbe8bf`](https://github.com/NixOS/nixpkgs/commit/b9bbe8bfd872bdd0459b7c73f5c5277652eb262f) python310Packages.pyroute2-ethtool: 0.6.9 -> 0.6.10
* [`dfbb3544`](https://github.com/NixOS/nixpkgs/commit/dfbb3544b616dad5f8d0750939d8beb8da5a279c) python310Packages.pyroute2-ipdb: 0.6.9 -> 0.6.10
* [`f6742c5c`](https://github.com/NixOS/nixpkgs/commit/f6742c5cf71fd22e22caff0646d1c470674cc6b8) python310Packages.pyroute2-ndb: 0.6.9 -> 0.6.10
* [`b38ab26b`](https://github.com/NixOS/nixpkgs/commit/b38ab26b582da5a48bdd2f948ee58576f2a730d0) python310Packages.pyroute2-nftables: 0.6.9 -> 0.6.10
* [`c2a30780`](https://github.com/NixOS/nixpkgs/commit/c2a307802e8f957fa92079311c3cef6a055e27cc) python310Packages.pyroute2-nslink: 0.6.9 -> 0.6.10
* [`b6bae6fc`](https://github.com/NixOS/nixpkgs/commit/b6bae6fcb2d7a18586d1685aae848f758532ae16) python310Packages.pyroute2-protocols: 0.6.9 -> 0.6.10
* [`ea3223f6`](https://github.com/NixOS/nixpkgs/commit/ea3223f6f840a1139c609d37944dce1261096452) python310Packages.pyroute2: 0.6.9 -> 0.6.10
* [`27723a19`](https://github.com/NixOS/nixpkgs/commit/27723a19429b2525939543091bbb85fd0e592331) python310Packages.pyroute2-ipset: 0.6.9 -> 0.6.10
* [`32d43843`](https://github.com/NixOS/nixpkgs/commit/32d43843d62807d169ae3f8a86068a5d7e08ff4e) perlPackages.WebServiceValidatorHTMLW3C: init 0.28
* [`dbe6bb26`](https://github.com/NixOS/nixpkgs/commit/dbe6bb26a4da46a44941bbe1fd09e238173f42d4) perlPackages.TextLevenshteinXS: init at 0.03
* [`7b3ac6e3`](https://github.com/NixOS/nixpkgs/commit/7b3ac6e3f97cbff22387f0638d896ae7de6af73e) perlPackages.Tcl: init at 1.27
* [`cb104999`](https://github.com/NixOS/nixpkgs/commit/cb104999e59b3c9b2eb31835cfcb209c39cb53cc) perlPackages.TestLWPUserAgent: 0.034 -> 0.036
* [`f0f1fc49`](https://github.com/NixOS/nixpkgs/commit/f0f1fc4902a438fc1ca64f13c09b4adf2a1e33d2) maintainers: add pogobanane
* [`2c01c6b3`](https://github.com/NixOS/nixpkgs/commit/2c01c6b3a967caaac12307da234de700c316dbb1) tgswitch: use buildGoModule
* [`f5bd5bb0`](https://github.com/NixOS/nixpkgs/commit/f5bd5bb0c95dda2f9e7e6d325705da1748bf65df) oh-my-zsh: 2022-06-01 -> 2022-06-05 ([nixos/nixpkgs⁠#176518](https://togithub.com/nixos/nixpkgs/issues/176518))
* [`23be58ef`](https://github.com/NixOS/nixpkgs/commit/23be58ef4c77cf4ff567de3fcd0361930610630f) mdbook-admonish: init at 1.6.0
* [`85731306`](https://github.com/NixOS/nixpkgs/commit/85731306feba7f9b6cd4e35ee7193f88dca9ab5d) htop: 3.2.0 -> 3.2.1
* [`5c871cdf`](https://github.com/NixOS/nixpkgs/commit/5c871cdf838ab4479071f3f5f90c2213e321a444) conform: init at 0.1.0-alpha.25
* [`a0a517f5`](https://github.com/NixOS/nixpkgs/commit/a0a517f5acc59ae5b149cca9f864905f9eedea04) maintainer-list: add jugendhacker
* [`9e22fffe`](https://github.com/NixOS/nixpkgs/commit/9e22fffe94ecdbdc58d091fe4c891eb9ddafd6da) xmppc: init at 0.1.2
* [`282eeff2`](https://github.com/NixOS/nixpkgs/commit/282eeff2443df29629ff5d23dc6fc7025eca98c1) pgadmin4: 6.9 -> 6.10
* [`955d1a6d`](https://github.com/NixOS/nixpkgs/commit/955d1a6dde9862822fbb0f2d6be9bfa51fdbc689) pipewire: create home directory for the pipewire user when running systemwide
* [`3c11b2df`](https://github.com/NixOS/nixpkgs/commit/3c11b2df706c4b8169bb1172035c48060a9188ba) maintainers: add somasis
* [`a42cdc07`](https://github.com/NixOS/nixpkgs/commit/a42cdc07fc27ab4ed58485b927e6edbe1a4900ba) sct: unstable-2015-11-16 -> 0.5
* [`e91d6046`](https://github.com/NixOS/nixpkgs/commit/e91d6046b167e119026e83f9f8a1b9f60d0fcdc1) map: init at 0.1.1
* [`12254d43`](https://github.com/NixOS/nixpkgs/commit/12254d43883006a66b99089f149296a916e899f0) deja-dup: 43.2 → 43.3
* [`5e76c696`](https://github.com/NixOS/nixpkgs/commit/5e76c6961d1b992046781c21c7d7dfd5df60d013) ocamlPackages.ao: init at 0.2.4
* [`fbfd28e8`](https://github.com/NixOS/nixpkgs/commit/fbfd28e8ac8585dd9cb2e5cadfdfaf8597f9ad0a) ocamlPackages.mad: init at 0.5.2
* [`5a862299`](https://github.com/NixOS/nixpkgs/commit/5a862299e02b49126d44844e60d343c74eff8a9f) ocamlPackages.mm: init at 0.8.1
* [`7f42a6cf`](https://github.com/NixOS/nixpkgs/commit/7f42a6cf572ae77c8264737f06e0b2c2deb74159) pySmartDL: init at 1.3.4 ([nixos/nixpkgs⁠#176421](https://togithub.com/nixos/nixpkgs/issues/176421))
* [`0106c4b1`](https://github.com/NixOS/nixpkgs/commit/0106c4b15908ef927c81c43e00c448eaed71a731) appflowy: 0.0.3 -> 0.0.4
* [`5a0bdf69`](https://github.com/NixOS/nixpkgs/commit/5a0bdf69987fb65178952c6c01b1c6e329c9268c) adguardhome: 0.107.6 - 0.107.7
* [`d5069ba9`](https://github.com/NixOS/nixpkgs/commit/d5069ba9020aad592456ac88efbebb78f021f07e) python3Packages.pywlroots: 0.15.15 -> 0.15.17
* [`dae2fec8`](https://github.com/NixOS/nixpkgs/commit/dae2fec8a756f659e8f4affe42fb1de818e0ff1a) cubiomes-viewer: 2.1.1 -> 2.2.2
* [`9b9faa5b`](https://github.com/NixOS/nixpkgs/commit/9b9faa5bf85be51d158848a8e74a711fa760802f) map: rename map-cmd
* [`e2d15bd6`](https://github.com/NixOS/nixpkgs/commit/e2d15bd6fed9a7d2d29599ccf98115090cc53c85) galculator: pull fix pending upstream inclusion for -fno-common toolchains
* [`51224f52`](https://github.com/NixOS/nixpkgs/commit/51224f522f7a7d3a00ac2da4ceeedeea296cd2ed) nixosTests.allDrivers: Move logic to all-packages.nix
* [`03bcd6fd`](https://github.com/NixOS/nixpkgs/commit/03bcd6fd64ce7aead3fd852118267bd69d4eef50) nixos/release.nix: Add nixos.tests.allDrivers
* [`475b0101`](https://github.com/NixOS/nixpkgs/commit/475b010143aa77a584ac51bc4934860cf22d0eb6) htop-vim: unstable-2021-10-11 -> unstable-2022-05-24
* [`30d1a2f2`](https://github.com/NixOS/nixpkgs/commit/30d1a2f29e9b309533567dbe55d5ea72653cc6f9) cfscrape: init at 2.1.1 ([nixos/nixpkgs⁠#176416](https://togithub.com/nixos/nixpkgs/issues/176416))
* [`b1b9ceaa`](https://github.com/NixOS/nixpkgs/commit/b1b9ceaa9590f2adc0a531113e679c33b771ed96) llvm_13: disable tools/gold/X86/split-dwarf.ll test on armv7l
* [`67df7777`](https://github.com/NixOS/nixpkgs/commit/67df7777e7896037150b5162344987462ecccaef) llvm_12: disable failing tests on armv7l
* [`f8c1774e`](https://github.com/NixOS/nixpkgs/commit/f8c1774e25df4cb50b5687b48c347ea8c67317fa) llvm_11: disable tools/gold/X86/split-dwarf.ll test on armv7l
* [`e98b73f3`](https://github.com/NixOS/nixpkgs/commit/e98b73f332ede8df04aa224c607a17e40af7fa01) vscode-extensions.vspacecode.vspacecode: 0.10.1 -> 0.10.9
* [`d8b2dd91`](https://github.com/NixOS/nixpkgs/commit/d8b2dd91e0bf7aba7328f268b20058e281be443e) gargoyle: add -fcommon workaround
* [`430a0e27`](https://github.com/NixOS/nixpkgs/commit/430a0e277ac536f1a41fb26c5bfab9e9bd452894) ifm: add -fcommon workaround
* [`aa080353`](https://github.com/NixOS/nixpkgs/commit/aa080353cf5a41e29ada832da99a957e869a80ac) macopix: add -fcommon workaround
* [`65e363e7`](https://github.com/NixOS/nixpkgs/commit/65e363e753405e1255446b8615b0bc7d29e99714) offrss: add -fcommon workaround
* [`c8f5b17a`](https://github.com/NixOS/nixpkgs/commit/c8f5b17a98b357e24fe0eb5a117820899b363750) nixos/nix-daemon: set LimitNOFILE to 1048576
* [`3ea4263a`](https://github.com/NixOS/nixpkgs/commit/3ea4263a662661d51a4cee83a0e7de9b7ef87c65) python3Packages.vmprof: add -fcommon workaround
* [`60d0be36`](https://github.com/NixOS/nixpkgs/commit/60d0be36a11c3471ca8fee0ededa17944d187a29) drawio: 19.0.0 -> 19.0.1
* [`632a8936`](https://github.com/NixOS/nixpkgs/commit/632a8936b3584a3a979d429f03196a6e2e290459) Revert "python310Packages.flask-restful: remove condition from patch"
* [`6cecab9c`](https://github.com/NixOS/nixpkgs/commit/6cecab9cd84f2c01ebeac82c4ed49ea053315d58) hydra: create runcommand-logs directory
* [`b1b94ab4`](https://github.com/NixOS/nixpkgs/commit/b1b94ab4afc6c3796f01155597b38b05dbb986d4) python310Packages.pynx584: 0.7 -> 0.8
* [`3f82a912`](https://github.com/NixOS/nixpkgs/commit/3f82a9122a4298c9b60cab4528f6f2e9c750b241) python310Packages.pywemo: 0.8.1 -> 0.9.0
* [`3a0ee098`](https://github.com/NixOS/nixpkgs/commit/3a0ee098a1d372bbf6cda961f739fd667b65978f) python310Packages.omnilogic: 0.4.5 -> 0.4.6
* [`e89fea64`](https://github.com/NixOS/nixpkgs/commit/e89fea64d3519a441a8de18675fc56148c131818) python310Packages.safety: fix typo
* [`8886ff1b`](https://github.com/NixOS/nixpkgs/commit/8886ff1be100e4774da368dd3c386d2135a49a1a) kube-prompt: use buildGoModule
* [`33ffdb36`](https://github.com/NixOS/nixpkgs/commit/33ffdb365ba22010b1b40cdafcea39091ec85858) libzim: 7.2.0 -> 7.2.2
* [`eaecf427`](https://github.com/NixOS/nixpkgs/commit/eaecf427885347b61618a4e826a0ba100d8e21a5) terraform-lsp: use buildGoModule
* [`ac719acb`](https://github.com/NixOS/nixpkgs/commit/ac719acb8a3d8fb6996d7ddf01399934834321bb) python310Packages.atenpdu: 0.3.2 -> 0.3.3
* [`0eaa7239`](https://github.com/NixOS/nixpkgs/commit/0eaa72390bacff63a6d2b8f22aeb288a83e53b1f) maintainers: rename to leona
* [`602e1cf7`](https://github.com/NixOS/nixpkgs/commit/602e1cf735128404f2e3312154c07fd6e464419d) python310Packages.yolink-api: 0.0.6 -> 0.0.7
* [`58219392`](https://github.com/NixOS/nixpkgs/commit/5821939268111b756473c531af325a509df219a3) python310Packages.twitterapi: 2.7.12 -> 2.7.13
* [`965c2e12`](https://github.com/NixOS/nixpkgs/commit/965c2e12e74158561080cf7be3d4e3edd4885d5f) radarr: 4.0.5.5981 -> 4.1.0.6175
* [`c08942e1`](https://github.com/NixOS/nixpkgs/commit/c08942e1ad495ec838965a886cb07c42b7e09f75) nixos/tests/radarr: fix type of argument in test script
* [`a6f86e33`](https://github.com/NixOS/nixpkgs/commit/a6f86e33fffb211210b19fabefd68f84c0d4ed7c) python310Packages.pyeight: 0.2.0 -> 0.3.0
* [`9029cf19`](https://github.com/NixOS/nixpkgs/commit/9029cf19cb2b4190af19590426cf15c720eda0c9) maintainers: add patricksjackson
* [`26b1b6a6`](https://github.com/NixOS/nixpkgs/commit/26b1b6a6c60f7d185b460c8643d9c7241c75de4d) perlPackages.TclpTk: init at 1.09
* [`31dc1991`](https://github.com/NixOS/nixpkgs/commit/31dc19919ae1546fb2237169e51114651c73ee9d) textadept: Merge back into a single version.
* [`8de1e9e2`](https://github.com/NixOS/nixpkgs/commit/8de1e9e2f88e82df7fcdc109ed58b2db2da59ce7) nixos/wg-quick: added support for configuration files
* [`6dd66a05`](https://github.com/NixOS/nixpkgs/commit/6dd66a05930d0ffc11796466cb6dea24945f625e) terraform-providers.remote: init at 0.0.24
* [`7708f1e4`](https://github.com/NixOS/nixpkgs/commit/7708f1e48c77d663659b4b961f5976376820293f) cri-o: 1.24.0 -> 1.24.1
* [`84883861`](https://github.com/NixOS/nixpkgs/commit/84883861f9f2dd8e85b56e4892072710829be4b6) httm: 0.10.16 -> 0.11.1
* [`9a8ae4d7`](https://github.com/NixOS/nixpkgs/commit/9a8ae4d72ecbb2c6bc341146a5caebfd8844cf9f) gitlab: 15.0.1 -> 15.0.2 ([nixos/nixpkgs⁠#176629](https://togithub.com/nixos/nixpkgs/issues/176629))
* [`5970407d`](https://github.com/NixOS/nixpkgs/commit/5970407d19b5f836fe74b9ff427309f63d27e0f1) certigo: patch tests and enable checks on Darwin
* [`fd326d0d`](https://github.com/NixOS/nixpkgs/commit/fd326d0d8c73404fc4bba1a299ac64cf81dfc7fb) python3Packages.pyialarmxr-homeassistant: rename from pyialarmxr
* [`d82ca8d4`](https://github.com/NixOS/nixpkgs/commit/d82ca8d422b30ff50505ac99eae0b95775e4dcd6) home-assistant: 2022.6.2 -> 2022.6.3
* [`134a55ab`](https://github.com/NixOS/nixpkgs/commit/134a55abe1845e2be14decf6f99d2351d75ccac3) python310Packages.google-cloud-logging: 3.1.1 -> 3.1.2
* [`826bef9b`](https://github.com/NixOS/nixpkgs/commit/826bef9b514bd5ceb5af55ccd79592778de03277) prometheus-unifi-exporter: remove
* [`1f9c7f33`](https://github.com/NixOS/nixpkgs/commit/1f9c7f33930a657c0c7b0500a097f8c38d474832) runitor: 0.10.0 -> 0.10.1
* [`411f38ef`](https://github.com/NixOS/nixpkgs/commit/411f38ef26f6936a5ecabe1b0edbcfb42045947b) btrfs-progs: 5.18 -> 5.18.1
* [`f9b9e8b1`](https://github.com/NixOS/nixpkgs/commit/f9b9e8b16f26ffd7985a1b4987cd417d295e04cd) rwc: init at 0.2
* [`22f30538`](https://github.com/NixOS/nixpkgs/commit/22f30538f29181226cfd6e90cb1b75fd73f95c9b) scala-cli: 0.1.6 -> 0.1.7
* [`b51489a8`](https://github.com/NixOS/nixpkgs/commit/b51489a8300e8893c9e15c58b40accf7697416ea) python310Packages.google-cloud-vision: 2.7.2 -> 2.7.3
* [`4de7377e`](https://github.com/NixOS/nixpkgs/commit/4de7377e7e694ec76849caaafd347a7fee64f096) python310Packages.google-cloud-access-context-manager: 0.1.11 -> 0.1.12
* [`e3a26944`](https://github.com/NixOS/nixpkgs/commit/e3a269446b7838fcc2cf55d5b18148e00a75793f) python310Packages.google-cloud-videointelligence: 2.7.0 -> 2.7.1
* [`d56a35e1`](https://github.com/NixOS/nixpkgs/commit/d56a35e1334132f0a4f19d5bb91b44cfa743394e) python310Packages.google-cloud-resource-manager: 1.5.0 -> 1.5.1
* [`17b53760`](https://github.com/NixOS/nixpkgs/commit/17b53760f61e2f158024aef79d9aa29e65986301) fluxcd: 0.30.2 -> 0.31.0
* [`a97a4f49`](https://github.com/NixOS/nixpkgs/commit/a97a4f491f59a2efe8e2d6a74932ad101a21fcca) dxvk: work with unpatched MoltenVK on Darwin
* [`2a7827fa`](https://github.com/NixOS/nixpkgs/commit/2a7827fac37219f2576885b36b90486f038cbeaa) dxvk: use function form of mkDerivation
* [`8abfb3fb`](https://github.com/NixOS/nixpkgs/commit/8abfb3fbc60046ab98e8c164991d85d429eb39e4) ltex-ls: init at 15.2.0
* [`5980856c`](https://github.com/NixOS/nixpkgs/commit/5980856caa6f50c6c1e3eaa2a9d28d8a6f51984b) python310Packages.google-cloud-redis: 2.8.0 -> 2.8.1
* [`1ee7ec89`](https://github.com/NixOS/nixpkgs/commit/1ee7ec898a9bff60589e9cfdecd7d9de00e1f3d0) python310Packages.google-cloud-websecurityscanner: 1.7.1 -> 1.7.2
* [`d2941088`](https://github.com/NixOS/nixpkgs/commit/d29410881e176c7cec7b2cbdcba3251cfe04accc) cargo-generate: 0.12.0 -> 0.14.0
* [`1eca09a8`](https://github.com/NixOS/nixpkgs/commit/1eca09a8a139354702eb90f0bd85670067eb71ed) mlton: 20180207 → 20210107
* [`50cac6ed`](https://github.com/NixOS/nixpkgs/commit/50cac6ed5ed534f8a1539349863599ade91295e7) ocamlPackages.unix-errno: init at 0.6.1
* [`cb268456`](https://github.com/NixOS/nixpkgs/commit/cb26845685076ac02be9b9972a712d500fec9384) ocamlPackages.posix-time2: init at 2.0.0
* [`69878331`](https://github.com/NixOS/nixpkgs/commit/69878331fefe69ddc16a2dc756f8ad56ea65f0ed) python310Packages.google-cloud-appengine-logging: 1.1.1 -> 1.1.2
* [`7c3c0f12`](https://github.com/NixOS/nixpkgs/commit/7c3c0f1223680d4891df2178860415af3afa34aa) python310Packages.browser-cookie3: 0.14.1 -> 0.14.2
* [`ed2c6d7e`](https://github.com/NixOS/nixpkgs/commit/ed2c6d7efbac9179a7cadf93f1fb5ad7e17dd4fa) python310Packages.oauthenticator: 14.2.0 -> 15.0.0
* [`05a5e731`](https://github.com/NixOS/nixpkgs/commit/05a5e731f871bed19f5537d1f74151b27e8dccd3) tailscale: 1.24.2 -> 1.26.0
* [`6d70d415`](https://github.com/NixOS/nixpkgs/commit/6d70d415da5470a1672f3b653ed37559c54b0103) python310Packages.aioairzone: 0.4.4 -> 0.4.5
* [`be830ea4`](https://github.com/NixOS/nixpkgs/commit/be830ea4f7be96141e6ea4108538014f6b9447f3) python310Packages.google-cloud-runtimeconfig: 0.33.0 -> 0.33.1
* [`aa9b237e`](https://github.com/NixOS/nixpkgs/commit/aa9b237e5d206735924c04a31b496c980b988764) python310Packages.luxtronik: 0.3.13 -> 0.3.14
* [`0e222cc4`](https://github.com/NixOS/nixpkgs/commit/0e222cc4ec42d8257bae6745fe79903829f41145) checkov: 2.0.1195 -> 2.0.1201
* [`5b9de4e2`](https://github.com/NixOS/nixpkgs/commit/5b9de4e2bba96d26dcd23071ed33a17f47ddc1ff) python310Packages.bravado-core: add input
* [`4ac4c526`](https://github.com/NixOS/nixpkgs/commit/4ac4c526996d6be5d02a609765c37f94d23e20fc) liquidsoap: pin srt dependency
* [`ab7173f6`](https://github.com/NixOS/nixpkgs/commit/ab7173f6db30fcffe01a23d85138449fa990cabf) ocamlPackages.srt: 0.1.1 -> 0.2.1
* [`3c89903a`](https://github.com/NixOS/nixpkgs/commit/3c89903ac88953f8cfeef52f2de6319d367d2fcf) python310Packages.asdf: 2.11.1 -> 2.12.0
* [`d6ade044`](https://github.com/NixOS/nixpkgs/commit/d6ade044a4c6befabe7cd6084609c3d28372057d) oil: 0.9.9 -> 0.10.1
* [`f5ef819e`](https://github.com/NixOS/nixpkgs/commit/f5ef819e24c45331636ad28861bce952f25b2fae) mimir: switch pname to mimir
* [`8974c1ce`](https://github.com/NixOS/nixpkgs/commit/8974c1ced3f693dd717964a5c40697e443df6f23) grapejuice: 4.10.2 -> 5.1.1
* [`1d4bfa2a`](https://github.com/NixOS/nixpkgs/commit/1d4bfa2a9d06ed73f415e8a8e1ad838771f63b9a) python310Packages.oauthenticator: add format
* [`cf594d1f`](https://github.com/NixOS/nixpkgs/commit/cf594d1f6e2dc1beea416d007b70c38a5e54ba7f) cloud-init: fix missing pyserial dependency
* [`a74d69f8`](https://github.com/NixOS/nixpkgs/commit/a74d69f8957a9b773d91b9e984688c397fa9c535) tektoncd-cli: 0.23.1 -> 0.24.0
* [`83ad4f2f`](https://github.com/NixOS/nixpkgs/commit/83ad4f2f938ec5daf2cc8d285f28c3ab2857e543) python310Packages.deezer-python: 5.3.2 -> 5.3.3
* [`0907dc85`](https://github.com/NixOS/nixpkgs/commit/0907dc851fa2e56db75ae260a8ecc9880dc7b492) slack-term: use buildGoModule
* [`1a3924b8`](https://github.com/NixOS/nixpkgs/commit/1a3924b8585d08135245df975e182249f8fea925) python310Packages.pysigma: 0.5.2 -> 0.6.2
* [`0e11ec9a`](https://github.com/NixOS/nixpkgs/commit/0e11ec9a23d6132d86c45deb88b2a32813c48b43) python310Packages.pysigma-pipeline-windows: relax pysigma constraint
* [`1fb02d2e`](https://github.com/NixOS/nixpkgs/commit/1fb02d2eec4e980553bd4766ff7074ed260962f8) python310Packages.pysigma-backend-insightidr: 0.1.5 -> 0.1.6
* [`cd4f6555`](https://github.com/NixOS/nixpkgs/commit/cd4f6555edd34e95d4427efb51ff6589e68cb0be) goresym: init at 1.2
* [`6f0b4a92`](https://github.com/NixOS/nixpkgs/commit/6f0b4a92dc262f68cdf235ebe231cabff6ef4c5d) bluewalker: init at 0.3.0
* [`55b2904c`](https://github.com/NixOS/nixpkgs/commit/55b2904c5ad89529365d957460f5558095ee9937) Maintainers: add cimm
* [`47d633a9`](https://github.com/NixOS/nixpkgs/commit/47d633a96803e6095012b10e16d7bfd50a34a245) Remove obvious comments from ldflags
* [`2247e925`](https://github.com/NixOS/nixpkgs/commit/2247e925d697cdfe529ccdbb021fc6ac90fe8b92) Add homepage URL instead of variable
* [`92e24425`](https://github.com/NixOS/nixpkgs/commit/92e2442544007ab5c341ee7ad31282344f60d2cc) Point changelog to tag instead of master
* [`90946525`](https://github.com/NixOS/nixpkgs/commit/90946525f3380bdc03bb8a1f98fc3b5fcb12bc9a) python310Packages.pysigma-backend-splunk: 0.3.2 -> 0.3.3
* [`387cb3f8`](https://github.com/NixOS/nixpkgs/commit/387cb3f84d7cf075fd9686ffc4a8ef1f6c054ed4) python310Packages.pysigma-pipeline-crowdstrike: 0.1.5 -> 0.1.6
* [`887e366f`](https://github.com/NixOS/nixpkgs/commit/887e366f5380e57809f48d2b143a85dbbefc55b9) python310Packages.pysigma-pipeline-sysmon: 0.1.5 -> 0.1.6
* [`0f7e5941`](https://github.com/NixOS/nixpkgs/commit/0f7e59416039d4178ed0ba9b1fc832cdf367dd7e) dxvk: limit to Intel platforms
* [`54d3d61b`](https://github.com/NixOS/nixpkgs/commit/54d3d61b0c8fa835e135cb286c520d5d0870127d) moltenvk: remove DXVK compatibility patches
* [`22d78732`](https://github.com/NixOS/nixpkgs/commit/22d787323bf0415a9325d3b5a0b3154ee394c007) moltenvk: use functional form of mkDerivation
* [`e78c2d05`](https://github.com/NixOS/nixpkgs/commit/e78c2d05da0cd52fecc82db63a3002ae76859fce) hedgedoc: ensure upload directory exists
* [`311f2101`](https://github.com/NixOS/nixpkgs/commit/311f2101d900befde5ff41b4fb71bfc99cf618ba) sigma-cli: relax pysigma constraint
* [`5c43c429`](https://github.com/NixOS/nixpkgs/commit/5c43c429b7ac1d006749c10e05a4a5e132885c64) glances: 3.2.4.2 -> 3.2.5
* [`c7cb6f95`](https://github.com/NixOS/nixpkgs/commit/c7cb6f953936d06ff34a9ce12aa3cfba42edc242) timeshift: init at 22.06.1
* [`570d347c`](https://github.com/NixOS/nixpkgs/commit/570d347c2ebf515bce37450bfd0e3bbf3746a9c1) python310Packages.fakeredis: 1.8 -> 1.8.1
* [`8df69c55`](https://github.com/NixOS/nixpkgs/commit/8df69c55853d018ac77637f0feff3a75952b6e94) gpgme: fix build on armv7l
* [`56d2f848`](https://github.com/NixOS/nixpkgs/commit/56d2f848b141e3c458e8da826e57be974afe420b) obsidian: 0.14.6 -> 0.14.15
* [`110b8ad1`](https://github.com/NixOS/nixpkgs/commit/110b8ad1ef1759a06b39dc790642558ef767d751) libxmlb: 0.3.8 -> 0.3.9
* [`e9382340`](https://github.com/NixOS/nixpkgs/commit/e93823409f9e6b8e878edf060b430a14353a28f9) wireshark: 3.6.3 -> 3.6.5
* [`ee3b1e9a`](https://github.com/NixOS/nixpkgs/commit/ee3b1e9a42b4024581fa2233529d06177137e2a5) python310Packages.google-cloud-os-config: 1.11.1 -> 1.11.2
* [`43d4ddf2`](https://github.com/NixOS/nixpkgs/commit/43d4ddf28e0facf1e5b8e8cb3cd86871d250ab03) treewide: remove usage of runCommandNoCC aliases
* [`87c7d13b`](https://github.com/NixOS/nixpkgs/commit/87c7d13b22aa0518f7369aeac24894cc21d52396) python310Packages.pyunifiprotect: 3.8.0 -> 3.9.0
* [`b46f168b`](https://github.com/NixOS/nixpkgs/commit/b46f168b21b5568134ec389f6be35c4a05ecf632) python310Packages.google-cloud-tasks: 2.9.0 -> 2.9.1
* [`3e762139`](https://github.com/NixOS/nixpkgs/commit/3e7621390c2f59a54fef2222f4bfab46cb534936) maintainers: mrhedgehog -> thehedgeh0g
* [`b71c76b7`](https://github.com/NixOS/nixpkgs/commit/b71c76b7ffc96b7c8113a39edc49245c04d14653) dex-oidc: 2.31.2 -> 2.32.0
* [`ae9f904e`](https://github.com/NixOS/nixpkgs/commit/ae9f904eb26abb6b0ff871437bf8015a80f32e9f) gajim: 1.4.2 → 1.4.3
* [`7881466e`](https://github.com/NixOS/nixpkgs/commit/7881466e3a9a9a13ac7bd02e4c092fc570929503) gnome-secrets: 6.4 -> 6.5
* [`0922df19`](https://github.com/NixOS/nixpkgs/commit/0922df19a0129eaf345e8c578409024758ab266f) python310Packages.sagemaker: 2.93.0 -> 2.93.1
* [`d55e3439`](https://github.com/NixOS/nixpkgs/commit/d55e34392a6bafb78e83d839d374b1263321b131) python310Packages.google-cloud-texttospeech: 2.11.0 -> 2.11.1
* [`44ad98c7`](https://github.com/NixOS/nixpkgs/commit/44ad98c77b4c2f80ae30904d0f92623ec2462bd4) python310Packages.google-cloud-asset: 3.9.0 -> 3.9.1
* [`bda2cc91`](https://github.com/NixOS/nixpkgs/commit/bda2cc918684680a4cc6783c741b5fbd311b78aa) python310Packages.google-cloud-bigquery-datatransfer: 3.6.1 -> 3.6.2
* [`c383e4e4`](https://github.com/NixOS/nixpkgs/commit/c383e4e4d9001ef0939add3bcc4229f56e247834) python310Packages.google-cloud-bigquery-logging: 1.0.2 -> 1.0.3
* [`bafb8c89`](https://github.com/NixOS/nixpkgs/commit/bafb8c89c2e93826ad98a78277a95390541f3a94) python310Packages.google-cloud-bigquery-storage: 2.13.1 -> 2.13.2
* [`0d1a2359`](https://github.com/NixOS/nixpkgs/commit/0d1a23594c00e0ec9da12fda282d324564178aef) python310Packages.google-cloud-container: 2.10.7 -> 2.10.8
* [`b0e0d8db`](https://github.com/NixOS/nixpkgs/commit/b0e0d8db46b23971a5426104e438daa5f4ef0040) webhook: use buildGoModule
* [`cc7252bc`](https://github.com/NixOS/nixpkgs/commit/cc7252bc3f21b43fa60835630505c5682da40f6b) python310Packages.google-cloud-datacatalog: 3.8.0 -> 3.8.1
* [`fac18419`](https://github.com/NixOS/nixpkgs/commit/fac18419430ebf3da016be13bdee23e175960b1e) python310Packages.google-cloud-dataproc: 4.0.2 -> 4.0.3
* [`f43b2572`](https://github.com/NixOS/nixpkgs/commit/f43b25729d7bb4bfb4077468a9e99f99af00de7f) oh-my-zsh: 2022-06-05 -> 2022-06-06 ([nixos/nixpkgs⁠#176675](https://togithub.com/nixos/nixpkgs/issues/176675))
* [`a3bd84cd`](https://github.com/NixOS/nixpkgs/commit/a3bd84cddeb5107def7242950896a1f091341740) python310Packages.google-cloud-datastore: 2.6.1 -> 2.6.2
* [`771ec20c`](https://github.com/NixOS/nixpkgs/commit/771ec20c06de11939bfe86426aa420fa4d6778a1) python310Packages.google-cloud-dlp: 3.7.0 -> 3.7.1
* [`879a7280`](https://github.com/NixOS/nixpkgs/commit/879a72800537ee5fef99ec7e8955f6ac43675c57) python310Packages.google-cloud-error-reporting: 1.5.2 -> 1.5.3
* [`c2d7efbc`](https://github.com/NixOS/nixpkgs/commit/c2d7efbc09691c456c65ef2fd6ce27b5f93d014e) textadept11: add alias to textadept
* [`6dd563f9`](https://github.com/NixOS/nixpkgs/commit/6dd563f949e844a6d5935b60f410f1d3581cc84a) python310Packages.google-cloud-iam: 2.6.1 -> 2.6.2
* [`20f251ff`](https://github.com/NixOS/nixpkgs/commit/20f251ffc862891dd971ec850622e5d3c9648b54) torchat: remove
* [`4fcb482c`](https://github.com/NixOS/nixpkgs/commit/4fcb482cf33fb7175703e1b3ffed825188e2e420) salut_a_toi: remove
* [`fa289b54`](https://github.com/NixOS/nixpkgs/commit/fa289b54cb1164e5d7531329f59e515558c62bd1) cura_stable: remove
* [`2cbf885d`](https://github.com/NixOS/nixpkgs/commit/2cbf885d3085fcaf47a2c66996ff524001c27217) plover.stable: remove
* [`137d5546`](https://github.com/NixOS/nixpkgs/commit/137d55460ada649ea2703a81a0ffc85dc064e692) python2Packages.wxPython: remove
* [`93f430c1`](https://github.com/NixOS/nixpkgs/commit/93f430c1562ecc1a11383ae03df3eab50991b6a7) python2Packages.vcrpy: remove
* [`ed806bb6`](https://github.com/NixOS/nixpkgs/commit/ed806bb62747da88316c7924898616dbbaec7db0) python2Packages.urllib3: remove
* [`608ec38f`](https://github.com/NixOS/nixpkgs/commit/608ec38f08a807bbe441e02b8feb2433d9477113) python2Packages.pyjwt: remove
* [`ed4ec186`](https://github.com/NixOS/nixpkgs/commit/ed4ec1862bcc7d68e9d70579457fb699561d61d5) privacyidea: update overrides
* [`b566290c`](https://github.com/NixOS/nixpkgs/commit/b566290cdbd987d5117c4e955ef85ba4786233b1) python2Packages.flask: remove
* [`162b4c10`](https://github.com/NixOS/nixpkgs/commit/162b4c10065bb716d09b48ddaa717fe22046c46c) python2Packages.werkzeug: remove
* [`8ceaa66b`](https://github.com/NixOS/nixpkgs/commit/8ceaa66b5a953cd0f69cfc73a52d7580bdaf5b7c) python2Packages.itsdangerous: remove
* [`ddcb0e56`](https://github.com/NixOS/nixpkgs/commit/ddcb0e566a627cae763d2e54427a48bdedeb05fe) csvs-to-sqlite: use click 7.1.2
* [`6f432760`](https://github.com/NixOS/nixpkgs/commit/6f432760f6764c40934878aa32384eed3697abd7) haxor-news: use click 7.1.2
* [`2f3c0f9a`](https://github.com/NixOS/nixpkgs/commit/2f3c0f9a41d9685ddf9ac638621c784ec6f9b090) python2Packages.click: remove
* [`c1c11045`](https://github.com/NixOS/nixpkgs/commit/c1c11045961909ccc876ab0ca25c8c9820b8f410) python2Packages.cryptography: remove
* [`2a54a835`](https://github.com/NixOS/nixpkgs/commit/2a54a8357363dce49e3635979eff471cad66cf2f) python2Packages.decorator: remove
* [`a9aba22c`](https://github.com/NixOS/nixpkgs/commit/a9aba22cdc612c4c704ae1f3173c232e63ecaa89) python2Packages.freezegun: remove
* [`3367f6e4`](https://github.com/NixOS/nixpkgs/commit/3367f6e4e69c06a5063d14e62211a8705af8188e) python2Packages.wsproto: remove
* [`c769a566`](https://github.com/NixOS/nixpkgs/commit/c769a566617a55355252c0c35294d52d439aadc6) python2Packages.ipaddr: remove
* [`f9c76fba`](https://github.com/NixOS/nixpkgs/commit/f9c76fbaec24afba2797130217c97f962374d742) python2Packages.libcloud: remove
* [`e5dcb4ef`](https://github.com/NixOS/nixpkgs/commit/e5dcb4efd2ad2b376949676da1a5203fa7c90603) python2Packages.lpod: remove
* [`41d0c6f0`](https://github.com/NixOS/nixpkgs/commit/41d0c6f080ca4a71ede96f0ba6de77c7c937af88) python310Packages.deezer-python: update disabled
* [`d06a2c8e`](https://github.com/NixOS/nixpkgs/commit/d06a2c8e25cfb7af3949b38631140bb0b304dfb9) python310Packages.google-cloud-iam-logging: 1.0.1 -> 1.0.2
* [`a0378c15`](https://github.com/NixOS/nixpkgs/commit/a0378c15e25ada553df654258475c5b11ad56410) libdeltachat: 1.85.0 -> 1.86.0
* [`0fa2f72a`](https://github.com/NixOS/nixpkgs/commit/0fa2f72a8f68d6d34c7053644277d60b90e0565d) python310Packages.google-cloud-iot: 2.5.0 -> 2.5.1
* [`4d96447e`](https://github.com/NixOS/nixpkgs/commit/4d96447ebf3bf12ce18c9d1e6e0050cde080a0f8) terra: 1.0.0-beta3 -> 1.0.0-beta5
* [`78c918ed`](https://github.com/NixOS/nixpkgs/commit/78c918ed868a4d3cf66f2a54ebf3b4bb7f4287a6) Add elliottslaughter to maintainers list.
* [`764dff48`](https://github.com/NixOS/nixpkgs/commit/764dff4833642c7b6a3cc839d7eb1e713ff18f91) python310Packages.google-cloud-kms: 2.11.1 -> 2.11.2
* [`2ad850d2`](https://github.com/NixOS/nixpkgs/commit/2ad850d21ff13198cf0f88e176a87897a11ff694) python310Packages.google-cloud-language: 2.4.2 -> 2.4.3
* [`c5d1acd5`](https://github.com/NixOS/nixpkgs/commit/c5d1acd593e0ee894445d129815e45da5476d4d3) python310Packages.google-cloud-bigquery-datatransfer: fix editorconfig check
* [`edba69ae`](https://github.com/NixOS/nixpkgs/commit/edba69aee54544a38cb24476436f8107f554865d) drawio: 19.0.1 -> 19.0.2
* [`79b681ed`](https://github.com/NixOS/nixpkgs/commit/79b681ed5d1ac3163b3ca3dd803d125f29b1a71c) python310Packages.google-cloud-org-policy: 1.3.2 -> 1.3.3
* [`2925dab8`](https://github.com/NixOS/nixpkgs/commit/2925dab822fc9b43dd718fc74cb671bbd9785ac5) python310Packages.google-cloud-os-config: 1.11.1 -> 1.11.2
* [`3f1ec25f`](https://github.com/NixOS/nixpkgs/commit/3f1ec25f902bf6cb93db3600d3f6cd69234e4b9d) persistent-evdev: init at unstable-2022-01-14
* [`f9aab9fe`](https://github.com/NixOS/nixpkgs/commit/f9aab9fed00fa7fa8cf3c698d9201d4ea399b183) python310Packages.google-cloud-pubsub: 2.12.1 -> 2.13.0
* [`bb9bd12c`](https://github.com/NixOS/nixpkgs/commit/bb9bd12c1547617f5d1fa20b587221023c012efb) python310Packages.google-cloud-redis: 2.8.0 -> 2.8.1
* [`3410785b`](https://github.com/NixOS/nixpkgs/commit/3410785b9b30c622e8ec1c3a86f6f4aefb1a8b31) python310Packages.google-cloud-secret-manager: 2.11.0 -> 2.11.1
* [`329b885e`](https://github.com/NixOS/nixpkgs/commit/329b885e1edbda775b35b1938289a44bc5547388) minecraft-server: 1.18.2 -> 1.19
* [`ca3260b2`](https://github.com/NixOS/nixpkgs/commit/ca3260b2dfb0579ea928a708e29e62b3506a0793) python310Packages.google-cloud-securitycenter: 1.11.0 -> 1.11.1
* [`38463851`](https://github.com/NixOS/nixpkgs/commit/384638512ca91a098c513ea5a1fcac2f304e4135) python310Packages.google-cloud-speech: 2.14.0 -> 2.14.1
* [`049ce2a9`](https://github.com/NixOS/nixpkgs/commit/049ce2a9ec2cd065ae92643a29fec4ac3c31a6a3) python310Packages.google-cloud-trace: 1.6.1 -> 1.6.2
* [`cc40e864`](https://github.com/NixOS/nixpkgs/commit/cc40e864ecd62ed6485c11f4d69f378ae595d766) libnftnl: 1.2.1 -> 1.2.2
* [`7226082e`](https://github.com/NixOS/nixpkgs/commit/7226082e1a0ccf5bc458e967519504eccc4c2151) nftables: 1.0.2 -> 1.0.4
* [`165602b8`](https://github.com/NixOS/nixpkgs/commit/165602b8016e4c3ca2c8a2e15086bfb84991b2b5) python310Packages.google-cloud-translate: 3.7.3 -> 3.7.4
* [`4908a6e8`](https://github.com/NixOS/nixpkgs/commit/4908a6e888e82e3e32aebf008f204a8d70920357) eww: 0.2.0 -> 0.3.0
* [`43fa64fc`](https://github.com/NixOS/nixpkgs/commit/43fa64fc984ec2a8a45a75f8c21bbe09d2250687) python3Packages.questionary: not broken on darwin
* [`55cadbcf`](https://github.com/NixOS/nixpkgs/commit/55cadbcfa313f4e160fbcf0fa751a6dc4e95e205) mujmap: 0.1.1 -> 0.2.0 ([nixos/nixpkgs⁠#176648](https://togithub.com/nixos/nixpkgs/issues/176648))
* [`c7658a87`](https://github.com/NixOS/nixpkgs/commit/c7658a87ac3e867dc1ea0e11ffc0cf10bb750553) python310Packages.dulwich: 0.20.42 -> 0.20.43
* [`b7100809`](https://github.com/NixOS/nixpkgs/commit/b71008099dc1a15eb0b3953e1479f71f039c700c) protonvpn-gui: 1.9.0 -> 1.10.0
* [`a05afc66`](https://github.com/NixOS/nixpkgs/commit/a05afc66e8adf1c960e276fe91f83c6b21a45a9c) haskellPackages.NGLess: disable incomplete test suite
* [`d826ebc5`](https://github.com/NixOS/nixpkgs/commit/d826ebc5a8e06dd89fbb82589d0f6fc07d52eba3) haskellPackages.aws-sns-verify: disable network dependent tests
* [`aa8115c4`](https://github.com/NixOS/nixpkgs/commit/aa8115c447ab23e2c5496134fc20ec5996619421) sbsigntool: 0.9.1 -> 0.9.4
* [`436bb2e6`](https://github.com/NixOS/nixpkgs/commit/436bb2e60e26919a7b9c6a0d75205a60564c63e1) efficient-compression-tool: init at 0.9.1
* [`3910b36a`](https://github.com/NixOS/nixpkgs/commit/3910b36a708b9e05bab14568bce61c7118ebf9ef) haskellPackages: mark builds failing on hydra as broken
* [`6232c43e`](https://github.com/NixOS/nixpkgs/commit/6232c43e4da390007e8ddb787562c3040533dc11) deltachat-desktop: 1.30.0 -> 1.30.1
* [`9ad297f4`](https://github.com/NixOS/nixpkgs/commit/9ad297f457fad9aa0d9684a5086b27646a414b85) python310Packages.adb-shell: 0.4.2 -> 0.4.3
* [`53b3ad53`](https://github.com/NixOS/nixpkgs/commit/53b3ad5398fa8aace0714a554fe5435718fe86b5) sbsigntool: add hmenke as maintainer
* [`7c825060`](https://github.com/NixOS/nixpkgs/commit/7c82506085269926301086ff96cb4184e0e52da4) python3Packages.pyfxa: fix fxa-client
* [`278423ab`](https://github.com/NixOS/nixpkgs/commit/278423ab654dd742386ca4e911c9b76774ff19ae) python310Packages.plugwise: 0.19.0 -> 0.19.0
* [`1e0e76bf`](https://github.com/NixOS/nixpkgs/commit/1e0e76bfb6370d951f8398690b57c5d860f0970a) talosctl: 1.0.5 -> 1.0.6
* [`5cc98c37`](https://github.com/NixOS/nixpkgs/commit/5cc98c37ad2f2258f7ad4d0cce00617ef853ca2e) python310Packages.pyroute2-core: 0.6.10 -> 0.6.11
* [`49da7da0`](https://github.com/NixOS/nixpkgs/commit/49da7da0b427be4d5b4d4f420a11eea2f429beda) python310Packages.pyroute2-ethtool: 0.6.10 -> 0.6.11
* [`a529fd4c`](https://github.com/NixOS/nixpkgs/commit/a529fd4c2fac012dc9f1166663f7d11ef02ba0b1) python310Packages.pyroute2-ipdb: 0.6.10 -> 0.6.11
* [`93eb7f89`](https://github.com/NixOS/nixpkgs/commit/93eb7f89b8b96e063fd1ef8c9647bed6ddd8698e) python310Packages.pyroute2-ndb: 0.6.10 -> 0.6.11
* [`aacc1079`](https://github.com/NixOS/nixpkgs/commit/aacc1079c7d7f3546cc4e02f0f84fd45024dd0ee) python310Packages.pyroute2-nftables: 0.6.10 -> 0.6.11
* [`14368fc6`](https://github.com/NixOS/nixpkgs/commit/14368fc622ab66b91493874837a5677efe5ae88f) python310Packages.pyroute2-nslink: 0.6.10 -> 0.6.11
* [`61332648`](https://github.com/NixOS/nixpkgs/commit/61332648485146fa10263d959d000f915dbb9d8c) python310Packages.pyroute2-protocols: 0.6.10 -> 0.6.11
* [`4d10c2ce`](https://github.com/NixOS/nixpkgs/commit/4d10c2ce7f8893cd14abcc001b73ae6b91a0508a) python310Packages.pyroute2: 0.6.10 -> 0.6.11
* [`1eae6a3c`](https://github.com/NixOS/nixpkgs/commit/1eae6a3c3a01963f6cc8500fd37ad7f2a40785ad) python310Packages.pyroute2-ipset: 0.6.10 -> 0.6.11
* [`659e7a48`](https://github.com/NixOS/nixpkgs/commit/659e7a4807121278a5a9b0d2fc63d60ff0916710) python310Packages.webexteamssdk: 1.6 -> 1.6.1
* [`87807925`](https://github.com/NixOS/nixpkgs/commit/87807925c47ed18e3e595d75ea6a91eef6443ba8) python310Packages.webexteamssdk: disable on obsolete Python releases
* [`ff71240d`](https://github.com/NixOS/nixpkgs/commit/ff71240d2e5cbb634b42b4bdb05f5a3cd9622493) containerd: 1.6.5 -> 1.6.6
* [`cf68deab`](https://github.com/NixOS/nixpkgs/commit/cf68deab17fde49169ff8d8217d936f7d235385d) terraform-providers.hetznerdns: init at 2.1.0
* [`7fc4e3b8`](https://github.com/NixOS/nixpkgs/commit/7fc4e3b858bb2ab17353f419f9a1587fa3993726) python310Packages.pyfxa: switch to pytestCheckHook
* [`fa1d382b`](https://github.com/NixOS/nixpkgs/commit/fa1d382bd6944b7b2d9f753b455b08ae99b075f1) python3Packages.validphys2: add missing dependencies
* [`273f614b`](https://github.com/NixOS/nixpkgs/commit/273f614b44d99e29f48b62a93505522b90e1aa85) authy: 2.1.0 -> 2.2.0 ([nixos/nixpkgs⁠#175206](https://togithub.com/nixos/nixpkgs/issues/175206))
* [`835be707`](https://github.com/NixOS/nixpkgs/commit/835be707da447620d2684160782b8283104b2551) bzip3: fix build on darwin
* [`712272f8`](https://github.com/NixOS/nixpkgs/commit/712272f895ddb626727ed4049603f4725a935f7a) kodestudio: Remove. The nix package was way out of date and unmaintained.
* [`f4328e7b`](https://github.com/NixOS/nixpkgs/commit/f4328e7b4aa785b2c53935227625acfcbfdbdea7) nixpkgs-review: 2.6.4 -> 2.7.0
* [`70cfd7a2`](https://github.com/NixOS/nixpkgs/commit/70cfd7a2eaa902f51902d8706516ed25375e9ebc) python3Packages.async-upnp-client: 0.31.0 -> 0.31.1
* [`c628b82e`](https://github.com/NixOS/nixpkgs/commit/c628b82e31c049812397d4909393c27efaefe982) python3Packages.pywemo: 0.9.0 -> 0.9.1
* [`0763848b`](https://github.com/NixOS/nixpkgs/commit/0763848b3ccc5df9f7cc0e0ec324d1acc96133c5) home-assistant: 2022.6.3 -> 2022.6.4
* [`e94f0231`](https://github.com/NixOS/nixpkgs/commit/e94f0231b72af69410b6715a2973bf108e3aa655) python310Packages.mkdocs-material: 8.3.2 -> 8.3.3
* [`8866bb65`](https://github.com/NixOS/nixpkgs/commit/8866bb653dfc49ea47bfff628c18c2467fbb34d0) pwninit: init at 3.2.0
* [`51203833`](https://github.com/NixOS/nixpkgs/commit/512038331168b8f15e16f371bc2d0e0a964c29b2) dotter: 0.12.10 -> 0.12.11
* [`fad47110`](https://github.com/NixOS/nixpkgs/commit/fad47110258f30a43492c288f33bc52412ee7fd0) easyjson: remove unnecessary `deps.nix`
* [`09570ee4`](https://github.com/NixOS/nixpkgs/commit/09570ee4a943b5b3e686f71fa93e4745e33316d3) goa: remove unnecessary `deps.nix`
* [`c1e680f8`](https://github.com/NixOS/nixpkgs/commit/c1e680f8da4af10af2b1a79775e8797ee26e31e3) inkscape: 1.1.2 → 1.2
* [`63a13dba`](https://github.com/NixOS/nixpkgs/commit/63a13dba06c8a44b0cf83dc278ea442e9c67cb45) inotify-tools: 3.22.1.0 -> 3.22.6.0
* [`2dcb8491`](https://github.com/NixOS/nixpkgs/commit/2dcb8491343e616fe89e53d0414ee5d49e19964d) stw: init at unstable-2022-02-04
* [`36962c4c`](https://github.com/NixOS/nixpkgs/commit/36962c4c397e7a00a39616cad40641498ae2f769) python310Packages.xknx: 0.21.3 -> 0.21.4
* [`ee8a4e36`](https://github.com/NixOS/nixpkgs/commit/ee8a4e36152edef4599e7475c86bcb4171acc12a) python310Packages.databricks-connect: 9.1.16 -> 9.1.17
* [`d4f57381`](https://github.com/NixOS/nixpkgs/commit/d4f5738137891301b25081f33c493ee033353c8b) myxer: remove
* [`70db11c3`](https://github.com/NixOS/nixpkgs/commit/70db11c3d0a43770ca352bff08fd8b5657ad6498) checkov: 2.0.1201 -> 2.0.1204
* [`364e63d1`](https://github.com/NixOS/nixpkgs/commit/364e63d1640edc7abeac8ac44bd86cc806f9f33b) fbpanel: add -fcommon workaround
* [`fc967934`](https://github.com/NixOS/nixpkgs/commit/fc96793474dc17485480059ee8f5a7d27a8e90af) palemoon: 31.0.0 -> 31.1.0
* [`465622ad`](https://github.com/NixOS/nixpkgs/commit/465622ad432e99c3c5f88f324d3b7043e509d847) apksigner: fix for gradle_5
* [`b5644dfa`](https://github.com/NixOS/nixpkgs/commit/b5644dfa57ab04fd40ecd3080bd67c475a199c3e) gcl: add -fcommon workaround
* [`321e60b2`](https://github.com/NixOS/nixpkgs/commit/321e60b24bc477e80b5b7266953cfefe256e1396) python310Packages.dash: 2.4.1 -> 2.5.0
* [`18aaa33f`](https://github.com/NixOS/nixpkgs/commit/18aaa33f07a5193c18448d6f382a3c6662842ffc) ocamlPackages.elpi: 1.14.1 → 1.15.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
