### PR TITLE
niv emacs-overlay: update 5ea4edff -> d215a555

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5ea4edff63d066fae8e89d32f1e9a4ee0dcf056d",
-        "sha256": "1d53sm1j9vpa79mvzlpgyl1jhldk95vmf81jc2d0777d64hss0mp",
+        "rev": "d215a5555c8f3856707c25a74136e51f6137a9fb",
+        "sha256": "0lgz7bfyrm3wp1il8bh6b9yx127lkds3jf438zcay2f45h4lpbdh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/5ea4edff63d066fae8e89d32f1e9a4ee0dcf056d.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/d215a5555c8f3856707c25a74136e51f6137a9fb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@5ea4edff...d215a555](https://github.com/nix-community/emacs-overlay/compare/5ea4edff63d066fae8e89d32f1e9a4ee0dcf056d...d215a5555c8f3856707c25a74136e51f6137a9fb)

* [`8b70697e`](https://github.com/nix-community/emacs-overlay/commit/8b70697e6ded18b0806c926287d6c4172db19312) Updated repos/emacs
* [`a943bdc9`](https://github.com/nix-community/emacs-overlay/commit/a943bdc9f4ff65136e8500586b74092d4570b3ee) Updated repos/melpa
* [`71d67b8b`](https://github.com/nix-community/emacs-overlay/commit/71d67b8b0ca4fbd8a26d07ca5a2cc253d56d466e) Updated repos/emacs
* [`54dba338`](https://github.com/nix-community/emacs-overlay/commit/54dba3386dceeb967c56e9c477f44cc82b8fad01) Updated repos/melpa
* [`20cfb98d`](https://github.com/nix-community/emacs-overlay/commit/20cfb98d73f220799e517c4168311987d6cec1b2) Updated repos/emacs
* [`1d001e0a`](https://github.com/nix-community/emacs-overlay/commit/1d001e0a1dfefe832522d69b4096afcc2c6c3876) Updated repos/melpa
* [`d1c0415c`](https://github.com/nix-community/emacs-overlay/commit/d1c0415cbb9f2f5fdef103bd931bfb8c7b55dff5) Updated repos/emacs
* [`71a37a76`](https://github.com/nix-community/emacs-overlay/commit/71a37a76c851547a0241d7f6ba25a751bc337b92) Updated repos/melpa
* [`d45ba585`](https://github.com/nix-community/emacs-overlay/commit/d45ba58534afe4f3511e9ddddc01984ca9353a91) Updated repos/emacs
* [`0756dbd3`](https://github.com/nix-community/emacs-overlay/commit/0756dbd32d75990468b170339bb68aab5f595da7) Updated repos/melpa
* [`b6100ff7`](https://github.com/nix-community/emacs-overlay/commit/b6100ff7052bd0b9b9c860da0759a6775dd5b705) Updated repos/emacs
* [`7ea96f12`](https://github.com/nix-community/emacs-overlay/commit/7ea96f12648f59c2a46b42ad18195ba11095d6f0) Updated repos/melpa
* [`5107c259`](https://github.com/nix-community/emacs-overlay/commit/5107c2599c546f19ac147a0c6240a9a6036a78f5) Updated repos/emacs
* [`ee98b1b4`](https://github.com/nix-community/emacs-overlay/commit/ee98b1b41106dd7bd43f2764d7fe9bb8924ca7f8) Updated repos/melpa
* [`17c4af8f`](https://github.com/nix-community/emacs-overlay/commit/17c4af8fcb6200c894fb1351a423676ba34f7f01) Updated repos/nongnu
* [`73f52c43`](https://github.com/nix-community/emacs-overlay/commit/73f52c43d4202dd3ba78562d34a4fc60fdac1553) Updated repos/elpa
* [`e2cbc073`](https://github.com/nix-community/emacs-overlay/commit/e2cbc073bc9c7c15c5c6ebc2dde8c1cecac785f8) Updated repos/emacs
* [`cf5a17b2`](https://github.com/nix-community/emacs-overlay/commit/cf5a17b22ffd987e24770d33b5b59ea496eeac49) Updated repos/melpa
* [`c874a16d`](https://github.com/nix-community/emacs-overlay/commit/c874a16d1c924b929cd6172a53ac5b9c69eed4f8) Updated repos/elpa
* [`172693ea`](https://github.com/nix-community/emacs-overlay/commit/172693ea77bf6ce333124c902878770fc9a9fa15) Updated repos/emacs
* [`a73125db`](https://github.com/nix-community/emacs-overlay/commit/a73125db1db85e79b3c89cfd11e2c59195b6be95) Updated repos/melpa
* [`499e2748`](https://github.com/nix-community/emacs-overlay/commit/499e274857d2de6883f9c1face56c604b37c7ecc) Updated repos/emacs
* [`651c417e`](https://github.com/nix-community/emacs-overlay/commit/651c417e7fd8d8f1ee67560bc0b2f85aba2c9cab) Updated repos/melpa
* [`d14e7f53`](https://github.com/nix-community/emacs-overlay/commit/d14e7f539d615c8a35412bb1cb7d434b17bd44c6) Updated repos/emacs
* [`e2d3ca22`](https://github.com/nix-community/emacs-overlay/commit/e2d3ca22117b5d39c92f5014a14150c9b573f7de) Updated repos/melpa
* [`fd396882`](https://github.com/nix-community/emacs-overlay/commit/fd3968820ce44677f35e38a149c1f1eed016544f) Updated repos/elpa
* [`24fd6019`](https://github.com/nix-community/emacs-overlay/commit/24fd60194d031f7e9af898b13602c51a68b90bd4) Updated repos/emacs
* [`ae1a1774`](https://github.com/nix-community/emacs-overlay/commit/ae1a1774095fae839ca2da8ef9d1bedcc33f3f9b) Updated repos/melpa
* [`5f5a91a0`](https://github.com/nix-community/emacs-overlay/commit/5f5a91a0b7d776945affec1c0b93dd4765fe0249) Updated repos/emacs
* [`df3fae13`](https://github.com/nix-community/emacs-overlay/commit/df3fae1303de23dc3bbbec8e9ae35ff6faa9fd73) Updated repos/melpa
* [`9d6d99bf`](https://github.com/nix-community/emacs-overlay/commit/9d6d99bf0641297f48720c5d3f15ad0bcd08e109) Updated repos/emacs
* [`8a5064ee`](https://github.com/nix-community/emacs-overlay/commit/8a5064eefe2662589475aaba320ff8fcb663dd75) Updated repos/melpa
* [`c6d3e97f`](https://github.com/nix-community/emacs-overlay/commit/c6d3e97f556bd1a0bf161f3278b8aa3ca5b46c59) Updated repos/emacs
* [`a4455d43`](https://github.com/nix-community/emacs-overlay/commit/a4455d4339dab970075856abd0e58b664a92310e) Updated repos/melpa
* [`d7c44723`](https://github.com/nix-community/emacs-overlay/commit/d7c447232405c5db078067ca7fe5643edc742e9b) Updated repos/emacs
* [`a73897fc`](https://github.com/nix-community/emacs-overlay/commit/a73897fc387a83c8dd2142ed597041113954ec23) Updated repos/melpa
* [`06d09722`](https://github.com/nix-community/emacs-overlay/commit/06d09722eb4d2315294dd8319ab9417c227613d4) Updated repos/emacs
* [`94aeb45d`](https://github.com/nix-community/emacs-overlay/commit/94aeb45d43fb1d794cefe6d4594636b7469eae6f) Updated repos/melpa
* [`aba7ee73`](https://github.com/nix-community/emacs-overlay/commit/aba7ee7399661cd6fe090ff856462b0e3381855b) Updated repos/elpa
* [`e7bc5ecc`](https://github.com/nix-community/emacs-overlay/commit/e7bc5ecc5ad2b2df75aee4cdf2977dacbfb48c49) Updated repos/emacs
* [`a4bfcfd5`](https://github.com/nix-community/emacs-overlay/commit/a4bfcfd5e500969320ed2155d51f6918734e9c1b) Updated repos/melpa
* [`4e8d0496`](https://github.com/nix-community/emacs-overlay/commit/4e8d0496a9038d3fd8b8d084318524564177d67c) Updated repos/nongnu
* [`45994463`](https://github.com/nix-community/emacs-overlay/commit/4599446347ebbe70e4f370d95ffd1ab37f7d7fb8) Updated repos/emacs
* [`0c15f321`](https://github.com/nix-community/emacs-overlay/commit/0c15f3218e04f12f632228c29170b820766d8627) Updated repos/melpa
* [`29dcfbc1`](https://github.com/nix-community/emacs-overlay/commit/29dcfbc1b29ae7281e95367e0f2358b44224a46e) Updated repos/nongnu
* [`214568b0`](https://github.com/nix-community/emacs-overlay/commit/214568b0e36d704086258ddab1c846c0d6e0dd09) Updated repos/emacs
* [`18caabdf`](https://github.com/nix-community/emacs-overlay/commit/18caabdf606d1449ed83ee02d8721c5ade30c3c5) Updated repos/melpa
* [`1992789f`](https://github.com/nix-community/emacs-overlay/commit/1992789f00b42909f1b9ba715e564c46f5bb9daf) Updated repos/emacs
* [`d215a555`](https://github.com/nix-community/emacs-overlay/commit/d215a5555c8f3856707c25a74136e51f6137a9fb) Updated repos/melpa
