### PR TITLE
niv spacemacs: update 85edf6a5 -> e75e925e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "85edf6a578c81f12537ac0b1d8b98324625e4275",
-        "sha256": "1amr4b8iz56z7xqknm8lh92v5h72alx26l32862vzifg4vr1d0p2",
+        "rev": "e75e925e3727136c5e1ef51fdd725c72c5f10b9b",
+        "sha256": "17z7ibc9w55fgjma6f22kc7sq45rjpg60b5w75vzrbcl8j58kclv",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/85edf6a578c81f12537ac0b1d8b98324625e4275.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/e75e925e3727136c5e1ef51fdd725c72c5f10b9b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@85edf6a5...e75e925e](https://github.com/syl20bnr/spacemacs/compare/85edf6a578c81f12537ac0b1d8b98324625e4275...e75e925e3727136c5e1ef51fdd725c72c5f10b9b)

* [`216b98c1`](https://github.com/syl20bnr/spacemacs/commit/216b98c11e57b97647cbc3bb9b54feecce8d952e) [core] Add variable `dotspacemacs-startup-banner-scale' to scale the banner
* [`5a715c85`](https://github.com/syl20bnr/spacemacs/commit/5a715c85c263762af477fe753662c0919586c57c) [pdf] Evilify the pdf-outline-buffer-mode-map after its mode be loaded
* [`d1bdf6c6`](https://github.com/syl20bnr/spacemacs/commit/d1bdf6c6349246774b1116b81666f19b8f8484fe) Evilify the pyim-dict-manager-mode-map after its mode be loaded
* [`fa28a4f3`](https://github.com/syl20bnr/spacemacs/commit/fa28a4f302d95a92bc1a942bcbd58b1b32192762) [source-control] Evilify the svn/git/hg mode-maps after its mode file be loaded
* [`87823c30`](https://github.com/syl20bnr/spacemacs/commit/87823c308176b8ae39348498d0b7ea7c2fbaa032) [shell-scripts] Install shfmt unconditionally
* [`e31804f5`](https://github.com/syl20bnr/spacemacs/commit/e31804f5c893cd4c9fa8c5261c6a8efe26a732c7) Fix broken recentf functionality due to PR [syl20bnr/spacemacs⁠#15574](https://togithub.com/syl20bnr/spacemacs/issues/15574)
* [`19bae11b`](https://github.com/syl20bnr/spacemacs/commit/19bae11b3b4f0ab1f4aad5cc35f9cd15deac6159) [doc] correct grammar for homepage README file
* [`46d15dc3`](https://github.com/syl20bnr/spacemacs/commit/46d15dc36751a65f5d0ebd9478474499cbaf827d) Allow setting flycheck buffer location on screen.
* [`02c667e8`](https://github.com/syl20bnr/spacemacs/commit/02c667e8d8efdf69bab1f9093440b1644c7829bf) [syntax-checking] Revise layer
* [`2556ecd3`](https://github.com/syl20bnr/spacemacs/commit/2556ecd31c200038bf445086cd2679447633f0aa) [doc] shell-scripts: explain backend auto-select
* [`44a032b6`](https://github.com/syl20bnr/spacemacs/commit/44a032b6152e11ba9fe2b4256863556d5540ca8b) [bot] "documentation_updates" Sat Jun 11 11:42:05 UTC 2022
* [`c41bb140`](https://github.com/syl20bnr/spacemacs/commit/c41bb1406bf89026c34875df73e31aa4434c117e) Try to fix name clash in emacs 29
* [`e75e925e`](https://github.com/syl20bnr/spacemacs/commit/e75e925e3727136c5e1ef51fdd725c72c5f10b9b) Second try to fix restart-emacs in emacs 29
