### PR TITLE
niv nixpkgs: update 06801147 -> 576bc65c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "068011475527fe8a211f2515ba4bf2b76ca74a73",
-        "sha256": "1ycnyyzqcvh4ls3h5gnniw45lad83khr1pwx9vp89gn2qncjzkq5",
+        "rev": "576bc65c5ac542d2b9f17e9332fd778e31cc583c",
+        "sha256": "16mlyawmpkvhpb6qgz0kkmjyhm416dfzx0vfw1cvd4yz6d6icjsl",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/068011475527fe8a211f2515ba4bf2b76ca74a73.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/576bc65c5ac542d2b9f17e9332fd778e31cc583c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@06801147...576bc65c](https://github.com/nixos/nixpkgs/compare/068011475527fe8a211f2515ba4bf2b76ca74a73...576bc65c5ac542d2b9f17e9332fd778e31cc583c)

* [`121e2f7e`](https://github.com/NixOS/nixpkgs/commit/121e2f7e1554794e7392427cf77e94ab9887871e) honor sdImage.compressImage in intermediate build steps
* [`f993a0a2`](https://github.com/NixOS/nixpkgs/commit/f993a0a27d260feda4a98d9554ccdceb9117fe25) navidrome: Allow read access to /etc
* [`f86de05c`](https://github.com/NixOS/nixpkgs/commit/f86de05ca6a4975cffbd6031af2f9a2a72c4d525) nixos/systemd: Custom error when mixing list/non-list defs
* [`876cc63e`](https://github.com/NixOS/nixpkgs/commit/876cc63e8756c610d1f151436bb7d3baf06d0076) libipt: 2.0.4 -> 2.0.5
* [`372b7d8d`](https://github.com/NixOS/nixpkgs/commit/372b7d8db4ac160f7ff42e1c4276b3ebea53ed5f) ginac: 1.8.2 -> 1.8.3
* [`5850ce19`](https://github.com/NixOS/nixpkgs/commit/5850ce19a3cba5beb232e8b1b434680ae51714e1) python310Packages.pygmt: 0.6.0 -> 0.6.1
* [`72d6d73e`](https://github.com/NixOS/nixpkgs/commit/72d6d73e3750b6ec4dfffeb05eb0688d6358aeab) nixos/ipfs: Only set ReadWritePaths when hardened
* [`699e389f`](https://github.com/NixOS/nixpkgs/commit/699e389f8343fb14f7ca3bda09e8871c705c9dde) nixos/ipfs: test FUSE mount
* [`0c0be749`](https://github.com/NixOS/nixpkgs/commit/0c0be749646ce642bf50acfee75a484996556c0e) radarr: allow overriding package in module
* [`e008bf75`](https://github.com/NixOS/nixpkgs/commit/e008bf75ab6618cb2e0fecec189f72bbad5f70e3) starfetch: init at 0.0.2
* [`2a9691e0`](https://github.com/NixOS/nixpkgs/commit/2a9691e0c00a4d14f52bd35ec40f9d2b174534f4) nixos/systemd: prepare tests for formatters
* [`691d9ad8`](https://github.com/NixOS/nixpkgs/commit/691d9ad82f756b4ff41a395eeed3d866c6f235f5) electron-mail: 4.12.7 -> 4.14.0
* [`24b40a25`](https://github.com/NixOS/nixpkgs/commit/24b40a255c6adc6ab32c69737e8b4cfc50d8c8b4) umoria: init at 5.7.15
* [`74ed19af`](https://github.com/NixOS/nixpkgs/commit/74ed19af6aa359a4c132c393a207be936e202a26) cherrytree: 0.99.46 -> 0.99.47
* [`ae52a3c7`](https://github.com/NixOS/nixpkgs/commit/ae52a3c76589523302fd731a9108cd9403891a2b) faudio: 22.02 -> 22.04
* [`55b54803`](https://github.com/NixOS/nixpkgs/commit/55b54803f0a964dc4d63c12a735cec678912da5b) gcompris: 2.3 -> 2.4
* [`83a83784`](https://github.com/NixOS/nixpkgs/commit/83a83784ed655ecfdd15e020c1968449eb6a1ec4) pebble: 2.3.1 -> 2.4.0
* [`88894e72`](https://github.com/NixOS/nixpkgs/commit/88894e721828972fc0a163204ef25315dd726f74) change github hash to locally working version
* [`060ab346`](https://github.com/NixOS/nixpkgs/commit/060ab346461b5f4ac118a49050c9fbd7d4eac5d6) featherpad: 1.1.1 -> 1.2.0
* [`9a73a65f`](https://github.com/NixOS/nixpkgs/commit/9a73a65fc279d71b2ad87eb55782569121fe459e) opencv2: remove python2 option
* [`b855d0a6`](https://github.com/NixOS/nixpkgs/commit/b855d0a6aa7cbfe438eb993e9526f76000637163) discord: fix desktop icon location
* [`c64cc3fb`](https://github.com/NixOS/nixpkgs/commit/c64cc3fbd431c02b7a9faf190d5a7a152da897ae) decoder: init at unstable-2021-11-20
* [`61013d7c`](https://github.com/NixOS/nixpkgs/commit/61013d7c56d7837dc2799c79cd2f74600884d69b) python3Packages.watchdog: fix darwin-x86_64 build
* [`20a7e7eb`](https://github.com/NixOS/nixpkgs/commit/20a7e7eb0aadcd56e8eee38908cd518bd3435255) python3Packages.watchdog: patch tests; rename patch file
* [`614aa6d0`](https://github.com/NixOS/nixpkgs/commit/614aa6d016edd00e7693778437c931bc4d406cd6) python3Packages.watchdog: treat more tests as bsd
* [`2e37657b`](https://github.com/NixOS/nixpkgs/commit/2e37657b63743bbbf90622273d8b6a90a665d61f) python3Packages.watchdog: don't run test_delete on darwin
* [`9925e7b2`](https://github.com/NixOS/nixpkgs/commit/9925e7b28297ff70985ae091a5a5e5e416097fef) gnu-efi: 3.0.11 -> 3.0.14
* [`89a903ae`](https://github.com/NixOS/nixpkgs/commit/89a903ae8bb1427169a42f2b5b7dfe740697b1de) v8: Add libv8_monolith.a symbolic link
* [`bac0d3b0`](https://github.com/NixOS/nixpkgs/commit/bac0d3b001a693fabaf89e24761ae47ada371c52) dotnetPackages.SharpZipLib: 0.86.0 -> 1.3.3
* [`df2ded87`](https://github.com/NixOS/nixpkgs/commit/df2ded87a38c8abe51189de996e1f3616f795e6f) darwin.bsdmake: fix for systems with non-standard RLIMIT_NOFILE
* [`b3535ee9`](https://github.com/NixOS/nixpkgs/commit/b3535ee9054e32f9a1c873f56f97ac2652621f92) maintainers: add cmm to maintainers
* [`7a959a64`](https://github.com/NixOS/nixpkgs/commit/7a959a64dffe725d7f6a3b1ace1afc5e99c242ca) vscode-extensions.ms-toolsai.jupyter: 2021.9.1101343141 - > 2022.5.1001411044
* [`e8a77d7c`](https://github.com/NixOS/nixpkgs/commit/e8a77d7c63e1a6ecf937c28f8015afe76a7d0a7d) titanion: init at 0.3
* [`d5cf13f4`](https://github.com/NixOS/nixpkgs/commit/d5cf13f483e7805b4a8aa9b703d7d5d86dda631a) avahi: format the expression
* [`c55e200b`](https://github.com/NixOS/nixpkgs/commit/c55e200bb0855b4276438c71a8730d184e73a573) avahi: drop intltool & outdated flags
* [`14dafc19`](https://github.com/NixOS/nixpkgs/commit/14dafc194f2b1166084110de1689efac20f1b6af) avahi: Simplify pkg-config cross fix
* [`8fa4e66d`](https://github.com/NixOS/nixpkgs/commit/8fa4e66def1aa4d465d6ab26d155074cf2ec4381) avahi: simplify path handling
* [`83602a5a`](https://github.com/NixOS/nixpkgs/commit/83602a5aba89105ba5b8d6cbf30c88e497d1e482) htmldoc: 1.9.15 -> 1.9.16
* [`fa22eab4`](https://github.com/NixOS/nixpkgs/commit/fa22eab4c1313eeb57a8c77b4bf6b01bd3f05e6e) metabase: 0.42.1 -> 0.43.1
* [`c3182eac`](https://github.com/NixOS/nixpkgs/commit/c3182eace3fe93b30e4e245254bd0503c6bd183f) panotools: 2.9.20 -> 2.9.21
* [`cf5e2d51`](https://github.com/NixOS/nixpkgs/commit/cf5e2d510316ae0e2e78486e28b79b1fa30799fa) haskellPackages: Add buildFromCabalSdist (faster, tested)
* [`392fba11`](https://github.com/NixOS/nixpkgs/commit/392fba113292aa10ba8ea9b68710a73ca17cac0e) pkgs.tests.haskell.cabalSdist: Avoid IFD
* [`1bf834a1`](https://github.com/NixOS/nixpkgs/commit/1bf834a1dd58c68e55e80fa6b9ee20956f6c509a) qjoypad: 4.1.0 -> 4.3.1
* [`da8d1384`](https://github.com/NixOS/nixpkgs/commit/da8d138459f52ce11f6e4481535682a8e04a4c4c) atlantis: 0.19.2 -> 0.19.3
* [`24bb1b1c`](https://github.com/NixOS/nixpkgs/commit/24bb1b1c9acf0de5bf2e72910b18669ea0e6c12b) chafa: 1.8.0 -> 1.10.3
* [`03d0929b`](https://github.com/NixOS/nixpkgs/commit/03d0929ba954f7dba1b304a6cd83c1ab5957ffb3) python310Packages.audible: 0.8.1 -> 0.8.2
* [`9f598bb8`](https://github.com/NixOS/nixpkgs/commit/9f598bb87ddbf33e8cd995c2d66a270e72573697) amtk: 5.4.0 -> 5.4.1
* [`6ad120be`](https://github.com/NixOS/nixpkgs/commit/6ad120be1f7d61113607fd3dfd509f65bd5dde11) geonkick: 2.9.0 -> 2.9.1
* [`c41b541b`](https://github.com/NixOS/nixpkgs/commit/c41b541b22fb02bfae325446f58da81b76be148d) frostwire-bin: 6.9.7 -> 6.9.8
* [`f6112663`](https://github.com/NixOS/nixpkgs/commit/f61126632787f98d2e4e7dac010e2f65fe683d86) geekbench: 5.4.4 -> 5.4.5
* [`7b185e04`](https://github.com/NixOS/nixpkgs/commit/7b185e04a9644caf263d1bd4a166062b0258f821) cc-wrapper: Fortran: disable format hardening
* [`97c43828`](https://github.com/NixOS/nixpkgs/commit/97c43828fb7e016b4ee8fe434bc4d5e0b8a8b4be) fixLibtool(): patch ./configure, add `file` to common-path.nix
* [`88e182b3`](https://github.com/NixOS/nixpkgs/commit/88e182b3bf46aaa820d2f56a3c02323ff66285e8) maintainers: add jsimonetti
* [`b2165ee1`](https://github.com/NixOS/nixpkgs/commit/b2165ee1edaff3b5d9cc198dc4845de7cd85235e) python310Packages.gunicorn: adopt, run tests, fix eventlet compability
* [`bf5acbc1`](https://github.com/NixOS/nixpkgs/commit/bf5acbc122031d4e0756c0372f504468de8f1d55) openldap: make extraContribModules actually overrideable
* [`4d80d6be`](https://github.com/NixOS/nixpkgs/commit/4d80d6be86bfc75339ba08a6c76ae196b0a67ca6) linuxHeaders: 5.17 -> 5.18
* [`50b21c66`](https://github.com/NixOS/nixpkgs/commit/50b21c666f4c0cc1527fcbb595f84f8e651e6173) pipewire: add option to disable systemd support
* [`9b8ef71d`](https://github.com/NixOS/nixpkgs/commit/9b8ef71d92f5df248779b14fbe0069d3a7c90681) python310Packages.psycopg2: add python imports check
* [`e9a40716`](https://github.com/NixOS/nixpkgs/commit/e9a407161256e3a958ef78345bf749ed228b6d5d) comby: 1.7.0 -> 1.7.1
* [`17958d77`](https://github.com/NixOS/nixpkgs/commit/17958d7718829e8942ad94e6195f44aa57dcc49d) xdg-utils: fix cross-compilation
* [`9bb2ef14`](https://github.com/NixOS/nixpkgs/commit/9bb2ef14aad39acaa225705fd2c7b7f639e37e56) pycryptodome,pycryptodomex: execute tests, unify
* [`860c2a1d`](https://github.com/NixOS/nixpkgs/commit/860c2a1d9591f5d2d3dcd097c68092d68b52c512) pkgs/tools/misc/file: add cannot-use-fetchpatch warning
* [`14366425`](https://github.com/NixOS/nixpkgs/commit/14366425cdeffb980738e18a33853873befb1ac2) python310Packages.paramiko: 2.10.4 -> 2.11.0
* [`f8b7b90a`](https://github.com/NixOS/nixpkgs/commit/f8b7b90a57fd287537413b7fbbbdbb164c69e5df) python310Packages.psutil: 5.9.0 -> 5.9.1
* [`a02ab4d6`](https://github.com/NixOS/nixpkgs/commit/a02ab4d6aee9e31d61741a9fccea8189f4d9d7e7) python310Packages.pyjwt: 2.3.0 -> 2.4.0
* [`a54a9557`](https://github.com/NixOS/nixpkgs/commit/a54a95575a6dff779e6cca738c44c30a1cc5afa4) python310Packages.colorama: add pythonImportsCheck, update meta
* [`6691fccb`](https://github.com/NixOS/nixpkgs/commit/6691fccb423315ea03fa226781761b61e1627889) python310Packages.uvicorn: remove windows only dependency
* [`0cd80c48`](https://github.com/NixOS/nixpkgs/commit/0cd80c488e89f0ec39b6cc4e7d6ae3e27a2c32a7) python310Packages.constantly: add pythonImportsCheck
* [`6d5d2abc`](https://github.com/NixOS/nixpkgs/commit/6d5d2abc6a9b696a5d855914b191dc3efce332e5) python310Packages.ifaddr: remove backport ipaddress, run test with pytestCheckHook
* [`8bcb1ef0`](https://github.com/NixOS/nixpkgs/commit/8bcb1ef0067dd6271d1839695f61e8b4fac4392b) python310Packages.limits: 2.6.1 -> 2.6.2
* [`fea73bfd`](https://github.com/NixOS/nixpkgs/commit/fea73bfd63669e0a22d240e89bb7b451f1888157) linux: disable WERROR by default
* [`116832ed`](https://github.com/NixOS/nixpkgs/commit/116832edbf8da93dedaca69384083e57b7c9f9a0) dockerTools: Add example of using NixOS' etc
* [`44522c1d`](https://github.com/NixOS/nixpkgs/commit/44522c1d5996ac1a16a2f7672b7306d557bd5a26) dockerTools.examples.etc: Make it a reliable test
* [`6a803b01`](https://github.com/NixOS/nixpkgs/commit/6a803b01aedd366a6a46eea6351cc91afb95de33) bind: remove broken configure flags
* [`04d41ba8`](https://github.com/NixOS/nixpkgs/commit/04d41ba8cc770aecc76a72b50f09c281d88a5022) lua5_2: add patch for CVE-2022-28805
* [`5a7d0b6b`](https://github.com/NixOS/nixpkgs/commit/5a7d0b6b34e1414c7fe1e9ddd4c8407e03510bff) lua5_4: fix CVE-2022-28805
* [`ada88148`](https://github.com/NixOS/nixpkgs/commit/ada881482879e5ab93be766a0305b55ad3705b70) python310Packages.ipaddress: drop
* [`1c70b694`](https://github.com/NixOS/nixpkgs/commit/1c70b694fe0fece5ae74beb747a40f1b7237d251) makeWrapper,makeBinaryWrapper: implement `--append-flags`
* [`002669d2`](https://github.com/NixOS/nixpkgs/commit/002669d20a1ff982f4bf9278fd1deef56625a384) glib: 2.72.1 -> 2.72.2
* [`da814333`](https://github.com/NixOS/nixpkgs/commit/da814333e90072dfd28ce0be4dee30ecc8276919) python3.pkgs.mdx-truly-sane-lists: init at 1.2
* [`19ceefe0`](https://github.com/NixOS/nixpkgs/commit/19ceefe041d6663b5b86bf04b9b370c68842bb50) python3.pkgs.mkdocs-exclude: init at 1.0.2
* [`d65f2b38`](https://github.com/NixOS/nixpkgs/commit/d65f2b385a5285c9858fe7a8e11ac984d286288f) python3.pkgs.pydantic: build offline documentation
* [`c0822338`](https://github.com/NixOS/nixpkgs/commit/c082233850baf2232ef377fc649172d273675970) python3Packages.mkdocs-gitlab-plugin: init at 0.1.4
* [`bf5c00fc`](https://github.com/NixOS/nixpkgs/commit/bf5c00fc75b36f9647d9832d1262f07f433d02d7) nss_esr: 3.68.3 -> 3.68.4
* [`ae1f1709`](https://github.com/NixOS/nixpkgs/commit/ae1f1709b7cb5e8cd9b72ac3e9c6f82462abcff5) nss_latest: 3.78 -> 3.79
* [`309bfdf2`](https://github.com/NixOS/nixpkgs/commit/309bfdf2e25a513dcc28f52b23efb1d114c5e45b) nss: sha256 -> hash
* [`2f62b09a`](https://github.com/NixOS/nixpkgs/commit/2f62b09ac8975825cfe9f8f383d48e02f52bb1c4) giac-with-xcas: fix command to open help inside browser
* [`e673666c`](https://github.com/NixOS/nixpkgs/commit/e673666c66d4c1491048f6cacfca2b3ad3977356) tautulli: 2.9.5 -> 2.10.1
* [`581143fa`](https://github.com/NixOS/nixpkgs/commit/581143fafd43a113e8aa7a353551d82538f30395) beancount: 2.3.4 -> 2.3.5
* [`c035336c`](https://github.com/NixOS/nixpkgs/commit/c035336c8d6fd97e8db2165a5f7f5d0cd0ba3df3) sm64ex-coop: init at 0.pre+date=2022-05-14
* [`7a687b7d`](https://github.com/NixOS/nixpkgs/commit/7a687b7dbe4c09fc72e6f6e4beab2d0596e8bde7) shairport-sync: add dbus, mpris, and metadata flags
* [`bc588218`](https://github.com/NixOS/nixpkgs/commit/bc5882186725ab95194d2d26bd50c694ed3efa8b) grpc-client-cli: init at 1.12.0
* [`25c990a6`](https://github.com/NixOS/nixpkgs/commit/25c990a60b524efae7c4cd0e58317248ade3eacc) libtiff: 4.3.0 -> 4.4.0
* [`cd3d17f3`](https://github.com/NixOS/nixpkgs/commit/cd3d17f3e2404b4d2bb056f0ad89b0520a7a40c8) mesa: 22.0.4 -> 22.1.1
* [`4293c8d9`](https://github.com/NixOS/nixpkgs/commit/4293c8d970cf3df37be59ff99468bd2533c69625) libqmi: disable introspection and gtk-doc when cross-compiling
* [`55886c39`](https://github.com/NixOS/nixpkgs/commit/55886c3946b443fe23b3d1a17c1047d4e8f4a365) pkgsCross.ppc64.libffi: pull upstream patch to support gcc-12
* [`5dcb09d3`](https://github.com/NixOS/nixpkgs/commit/5dcb09d3cbeecf8ff707aac0309507fee270cc34) freeimage: Add patch to fix build with libtiff 4.4.0
* [`be560224`](https://github.com/NixOS/nixpkgs/commit/be560224beabe7da5fa543cf8f59592015a36ccb) binutils: Reduce closure size when building for cross platform
* [`f1142c5a`](https://github.com/NixOS/nixpkgs/commit/f1142c5a20ef36b8c26be76c52bce4c0c092a757) nvidia_x11: vulkan_beta: mark as broken on linux 5.17
* [`94f5bd20`](https://github.com/NixOS/nixpkgs/commit/94f5bd2051f59e9e9cdb3f0db1ad88680370117a) nvidia_x11: init opensource kernel driver
* [`e84828b9`](https://github.com/NixOS/nixpkgs/commit/e84828b973364de21a18a9bab50e9399abdd7e43) nixos/nvidia: add option hardware.nvidia.open for selecting the opensource kernel driver
* [`6959d265`](https://github.com/NixOS/nixpkgs/commit/6959d265b8c9cca53a9f5dafd435afec242d2c62) linuxPackages.nvidia_x11_open: remove temporarily due to evaluation
* [`6c1c885d`](https://github.com/NixOS/nixpkgs/commit/6c1c885da26bf74d045ed8c59aba40ea97637d56) prefer-remote-fetch: don't overwrite fetcher's which set preferLocalBuild explicitly
* [`06dd4caa`](https://github.com/NixOS/nixpkgs/commit/06dd4caa34dd9c33d6c9cfed98a07971562272ca) json-c: 0.15 -> 0.16
* [`6ffe4109`](https://github.com/NixOS/nixpkgs/commit/6ffe4109839c62ccd7347f915f6b810768fc99f8) freeimage: cleanup suggestions from code review
* [`c4897187`](https://github.com/NixOS/nixpkgs/commit/c4897187fb65ea76dd18d22f6ca292834dcafacb) python3Packages.pillow: Add patch to fix failing test with libtiff 4.4.0
* [`728c5e0d`](https://github.com/NixOS/nixpkgs/commit/728c5e0d1a312462ad27bbc2716c09b60effcd04) bikeshed: 3.5.2 -> 3.7.0
* [`9ac2a6f0`](https://github.com/NixOS/nixpkgs/commit/9ac2a6f064700a75dbd674b2706a22fe00f95c78) jansson: 2.13.1 -> 2.14
* [`2b6596c4`](https://github.com/NixOS/nixpkgs/commit/2b6596c426cf3c3e0bf4b588571bfc8b74c93f33) jansson: add marsam to maintainers
* [`85be5352`](https://github.com/NixOS/nixpkgs/commit/85be5352c3c9c5970716b4bd1a77801da8731b5e) xxHash: Build with cmake and allow all platforms ([nixos/nixpkgs⁠#163279](https://togithub.com/nixos/nixpkgs/issues/163279))
* [`b32df807`](https://github.com/NixOS/nixpkgs/commit/b32df807ea2c244b566c2a619b132509d75a85c7) openldap: Fix some issues by applying patches
* [`81c57a84`](https://github.com/NixOS/nixpkgs/commit/81c57a8407e943526cc5ba445ed2b65c87038b2d) cacert: use buildcatrust build with python3Minimal
* [`80f9a78c`](https://github.com/NixOS/nixpkgs/commit/80f9a78c01df1fafc4e0743a8ca763018bc0ff45) mailcap: fix build
* [`2de8b939`](https://github.com/NixOS/nixpkgs/commit/2de8b939481550e4e62b69a7227fae1aa6002a23) solvespace: 3.0 -> 3.1
* [`e9af7d15`](https://github.com/NixOS/nixpkgs/commit/e9af7d1551294850757430c468ec3ac48a9b82f1) cvehound: 1.0.9 -> 1.1.0
* [`ac66ff97`](https://github.com/NixOS/nixpkgs/commit/ac66ff97ed1f86d2ac98e1f49cfff427fe1e526d) doc/builders/images/dockertools: improve shadowSetup example
* [`1711b306`](https://github.com/NixOS/nixpkgs/commit/1711b30687175b37bc32094a342017f3c39fa4e5) jami: 20211223.2.37be4c3 ->  20220503.1550.0f35faa
* [`421ca6d6`](https://github.com/NixOS/nixpkgs/commit/421ca6d67b2388d7d954d9cf171740f47f001ce7) gstreamer: add bluezSupport flag
* [`088b2915`](https://github.com/NixOS/nixpkgs/commit/088b29159d2e14a6e722cdc2a8204af7b3118b76) libidn2: hack to avoid referencing bootstrap tools
* [`6868bb9c`](https://github.com/NixOS/nixpkgs/commit/6868bb9ceb91799a700b0386dea3df17f99d68e1) darwin.top: add -fcommon workaround
* [`0510392e`](https://github.com/NixOS/nixpkgs/commit/0510392e0740643262d1b03d8fa09b8525786ee9) gotags: remove
* [`810ccde6`](https://github.com/NixOS/nixpkgs/commit/810ccde60641164ca8389cbad9f3ae051256eb66) s3gof3r: remove
* [`31a4ac01`](https://github.com/NixOS/nixpkgs/commit/31a4ac0113166a701715126706fd9f8d50f397c4) kubicorn: remove
* [`a5632ab9`](https://github.com/NixOS/nixpkgs/commit/a5632ab95b0fbaa7d60751d0ce9b1ee2682ca423) phraseapp-client: remove
* [`e5cb0069`](https://github.com/NixOS/nixpkgs/commit/e5cb0069141235c32c740b688355fbd640b84e80) portaudio: fix cross compilation
* [`ec00b4bb`](https://github.com/NixOS/nixpkgs/commit/ec00b4bb1186719bbee30a89ca7f519c30001abd) nixos/network-interfaces-scripted: remove network-setup unit if unused
* [`2923e724`](https://github.com/NixOS/nixpkgs/commit/2923e72443fe791333ee6ec4e3244b60dfca1db5) darwin.developer_cmds: add -fcommon workaround
* [`9e1c9405`](https://github.com/NixOS/nixpkgs/commit/9e1c94057ca6152b32e7860b76b8f340a0e18f7c) rsync: adopt, greatly simplify package
* [`fd84f6bb`](https://github.com/NixOS/nixpkgs/commit/fd84f6bb0c645f8be1f66b9b1514c606fea295da) sane-backends: fix udev rule generation
* [`8b501a10`](https://github.com/NixOS/nixpkgs/commit/8b501a1089c346ea6efcddd6de18015512467493) rss-glx: fix build
* [`c50f620c`](https://github.com/NixOS/nixpkgs/commit/c50f620c3351e87b84eea8159673a6ca4081005a) calamares: 3.2.57 -> 3.2.59
* [`5bd650e0`](https://github.com/NixOS/nixpkgs/commit/5bd650e06216d13e6db91c4b5dda5b94632dfb39) dapper: use buildGoModule
* [`ce4fc55f`](https://github.com/NixOS/nixpkgs/commit/ce4fc55f31f04e90e56eff4cc95cf38e4f3f8c21) matrix-commander: unstable-2021-08-05 -> 2.30.0
* [`4b863a02`](https://github.com/NixOS/nixpkgs/commit/4b863a0256a24517caad65400bc6664407e10a73) calamares: increase default verbosity
* [`54fcba5b`](https://github.com/NixOS/nixpkgs/commit/54fcba5b3bb4d77dd58aa08a489aced93ff5da18) installation-cd: prevent gnome from sleeping
* [`06b472c4`](https://github.com/NixOS/nixpkgs/commit/06b472c49f60cbc452950718a960ac4cba14c9d3) gcc9: 9.3.0 -> 9.5.0
* [`b7526918`](https://github.com/NixOS/nixpkgs/commit/b7526918cbf9a4819010c877f56355593be8cb8e) vulkan-tools: fix Hydra breakage on Darwin
* [`a9bb8e4c`](https://github.com/NixOS/nixpkgs/commit/a9bb8e4c98da7ab71ca36ae7d8a3bb71eae70f84) unclutter-xfixes: fix cross-compilation
* [`94d64660`](https://github.com/NixOS/nixpkgs/commit/94d64660218a109c4b6ac8985271434689292131) lc3tools: fix build on macOS
* [`3bceabcb`](https://github.com/NixOS/nixpkgs/commit/3bceabcb78cc88108208e51d157690fb2423008b) wine{Unstable,Staging}: 7.8 -> 7.9
* [`d90ca916`](https://github.com/NixOS/nixpkgs/commit/d90ca9162d1216e34ad65ae05547fd1e3bf5393c) wine{Unstable,Staging}: 7.9 -> 7.10
* [`df640d47`](https://github.com/NixOS/nixpkgs/commit/df640d47ad3867a419e71543ad99a61c5092e7dc) valgrind: fix build error for armv7l
* [`295bb5dc`](https://github.com/NixOS/nixpkgs/commit/295bb5dc03cccc31bc4b03bc456b731a4aad78b4) libdrm: 2.4.110 -> 2.4.111
* [`aa4fe119`](https://github.com/NixOS/nixpkgs/commit/aa4fe119c54e6850e72f236aece4166a3039abaa) pipelight: Fix build with wine-7.10
* [`62f0b2fa`](https://github.com/NixOS/nixpkgs/commit/62f0b2fa4e6de1d640634ef30b4e1a12cb70bb7a) checkbashisms: 2.21.1 -> 2.22.1
* [`c5384006`](https://github.com/NixOS/nixpkgs/commit/c53840067c489898bf34229924de5f0350bd7eee) juju: 2.9.27 -> 2.9.31
* [`11ea0e99`](https://github.com/NixOS/nixpkgs/commit/11ea0e99b713744b5e76141fb26a3d4b4d16c507) python3: 3.9 -> 3.10
* [`f1ac3fa3`](https://github.com/NixOS/nixpkgs/commit/f1ac3fa330a57dbbffe3e88d9435e6e9fefa3ee8) python3Minimal: 3.9 -> 3.10
* [`4566beb3`](https://github.com/NixOS/nixpkgs/commit/4566beb39019f6343dd9227b1b53491a9cfb726f) doc/python: update python version references
* [`a15f7ddc`](https://github.com/NixOS/nixpkgs/commit/a15f7ddc2847f1c7c865288d9db32611b1d3297b) spidermonkey_78: pin python39
* [`7986ff22`](https://github.com/NixOS/nixpkgs/commit/7986ff22a0b5c2eed30066860d2516546ab4ff59) python3Packages.gyp: 2020-05-12 -> unstable-2022-04-01
* [`4571d1db`](https://github.com/NixOS/nixpkgs/commit/4571d1db96a7ffeb635ded9afa887d88b5e824dc) python310Packages.asgiref: 3.5.0 -> 3.5.2
* [`fa3f5e15`](https://github.com/NixOS/nixpkgs/commit/fa3f5e15246ff9539b1aff4f1b869f3d08c850d7) python310Packages.astroid: 2.11.2 -> 2.11.4, adopt
* [`374f134e`](https://github.com/NixOS/nixpkgs/commit/374f134e245c0578f9f9ee940b7802ce2d832a6a) python310Packages.pylint: 2.13.5 -> 2.14.0, adopt
* [`b5f8c41f`](https://github.com/NixOS/nixpkgs/commit/b5f8c41fa075bca182130e36ab35c90e8c31db97) python310Packages.certifi: 2021.10.08 -> 2022.05.18.1
* [`8abc97c2`](https://github.com/NixOS/nixpkgs/commit/8abc97c217a7e06504f31d6a177963e9473ac765) python310Packages.hypothesis: 6.40.0 -> 6.46.3
* [`055e0f91`](https://github.com/NixOS/nixpkgs/commit/055e0f9147f654c5d5874adab4e54b33d658388a) python310Packages.hypothesis: 6.46.3 -> 6.46.10
* [`4561bf04`](https://github.com/NixOS/nixpkgs/commit/4561bf0464c55d4871ca7d32042bf8f2ec81cad4) python310Packages.cryptography: 36.0.2 -> 37.0.2
* [`f68add06`](https://github.com/NixOS/nixpkgs/commit/f68add0632a7a6c04461fdb643d87dcc8f549e69) python310Packages.pure-eval: 0.2.1 -> 0.2.2
* [`cfe5a6b8`](https://github.com/NixOS/nixpkgs/commit/cfe5a6b8624739fe3e0d144d5caff8f6f27fb526) python310Packages.aiomysql: 0.1.0 -> 0.1.1
* [`205524d1`](https://github.com/NixOS/nixpkgs/commit/205524d190080d38414cddc054028bb55ce813ea) python310Packages.pytest-httpbin: 1.0.1 -> 1.0.2
* [`b19bb22d`](https://github.com/NixOS/nixpkgs/commit/b19bb22dc700b846255b3f26e18c3310ae0f8519) python310Packages.pytest-localserver: 0.5.1.post0 -> 0.6.0
* [`14f95645`](https://github.com/NixOS/nixpkgs/commit/14f956459324d7bd2c01dc506c26054ff4e2d5cf) python310Packages.sopel: 7.1.8 -> 7.1.9
* [`181ec21d`](https://github.com/NixOS/nixpkgs/commit/181ec21de33feffa0900a9402c2bf10012c5e135) python310Packages.pytest-randomly: 3.11.0 -> 3.12.0
* [`276654d8`](https://github.com/NixOS/nixpkgs/commit/276654d888a24d6dff171512e1a4420965200012) python310Packages.vulture: 2.3 -> 2.4
* [`6ca651b8`](https://github.com/NixOS/nixpkgs/commit/6ca651b824710024b3fbc73a07678b38a6eadc55) python310Packages.pytest-subtests: 0.7.0 -> 0.8.0
* [`39d1306d`](https://github.com/NixOS/nixpkgs/commit/39d1306d96e7b5ad47370a2e63f701c675afdff4) python310Packages.apipkg: 2.1.0 -> 2.1.1
* [`b31b5f18`](https://github.com/NixOS/nixpkgs/commit/b31b5f18c794a58f10eb2b7158dbbdea7d6c862f) python310Packages.webob: switch to pytestCheckHook
* [`774f6930`](https://github.com/NixOS/nixpkgs/commit/774f6930664a35c3ff451c067f1c28d79332001d) python310Packages.pyzmq: 22.3.0 -> 23.0.0
* [`04b30697`](https://github.com/NixOS/nixpkgs/commit/04b30697eddc27e7c36b15caf3fe49d92dd7b55d) python310Packages.GitPython: 3.1.25 -> 3.1.27
* [`91696299`](https://github.com/NixOS/nixpkgs/commit/91696299e5b86b022baddcab43235bb5be9f6f12) python310Packages.lxml: 4.8.0 -> 4.9.0
* [`76170bf8`](https://github.com/NixOS/nixpkgs/commit/76170bf8e5984fb9cd71854e954aaf000e102365) python310Packages.typed-ast: 1.5.2 -> 1.5.4
* [`8842868b`](https://github.com/NixOS/nixpkgs/commit/8842868bf3bf73d20e89f91f763a5704c2329856) python310Packages.types-typed-ast: 1.5.4 -> 1.5.6
* [`9a7c0666`](https://github.com/NixOS/nixpkgs/commit/9a7c0666dafb4f8b2d3d7f345b51edb0ccbe8ef0) python310Packages.xmltodict: 0.12.0 -> 0.13.0
* [`989872eb`](https://github.com/NixOS/nixpkgs/commit/989872eb44a7b8d078f490982bdb3148a160cf55) python310Packages.raven: update dependencies, description, comment
* [`2d25c8e4`](https://github.com/NixOS/nixpkgs/commit/2d25c8e449e9a60d7a47952f0d38267eec82a103) python310Packages.httpbin: fix dependencies
* [`1f5366f2`](https://github.com/NixOS/nixpkgs/commit/1f5366f237972aa60cf553360bd10ae60651bfdb) python310Packages.zipp: 3.7.0 -> 3.8.0
* [`473c5663`](https://github.com/NixOS/nixpkgs/commit/473c5663894d9aff47e410cdeeb4a02510d78a31) python310Packages.pysqueezebox: fix formatting
* [`29226990`](https://github.com/NixOS/nixpkgs/commit/292269900315d5b952a99ec95aa4ccfc099952e0) python310Packages.urllib3: add optional-dependencies
* [`7895b854`](https://github.com/NixOS/nixpkgs/commit/7895b85444e3aef1de0b37afe9d4cf757d95d027) python310Packages.pillow: 9.1.0 -> 9.1.1
* [`ab0b9034`](https://github.com/NixOS/nixpkgs/commit/ab0b9034b5b0da30e0020f6d73d4c65ae9658a73) python310Packages.ordereddict: drop
* [`014c7bd8`](https://github.com/NixOS/nixpkgs/commit/014c7bd869013b9ad774d1baf5747931bb73a784) python310Packages.botocore: drop ordereddict
* [`1e861c4e`](https://github.com/NixOS/nixpkgs/commit/1e861c4e034f244d051df9da9dc7c74ebcab2921) python310Packages.flask-limiter: drop ordereddict
* [`9e3cbe04`](https://github.com/NixOS/nixpkgs/commit/9e3cbe04c6416ec955671b9bec5e65db1b826cb7) python310Packages.yamlordereddictloader: drop ordereddict
* [`d6252cb7`](https://github.com/NixOS/nixpkgs/commit/d6252cb72c5705cf979703457fd8af8417c224ab) python27Packages.botocore: drop ordereddict
* [`bbe515c4`](https://github.com/NixOS/nixpkgs/commit/bbe515c4c254f2d6c0d788d3ea00ef4771255e76) jira_cli: drop ordereddict
* [`cb24b62e`](https://github.com/NixOS/nixpkgs/commit/cb24b62e368b7aebdc4987668e2a00e8d3af29f7) python310Packages.pyscss: drop ordereddict
* [`9d0985f5`](https://github.com/NixOS/nixpkgs/commit/9d0985f5d7cb3738e3f3c19807f452d5ee928d17) python310Packages.pyscss: switch to pytestCheckHook
* [`a4a4d9b2`](https://github.com/NixOS/nixpkgs/commit/a4a4d9b2c0f6707a2db26bb90f2bc7fac454f287) python310Packages.pbr: 5.8.1 -> 5.9.0
* [`92ea6713`](https://github.com/NixOS/nixpkgs/commit/92ea671321165b23fbb22a498e73e3fe73ba33b7) python310Packages.libcst: 0.4.1 -> 0.4.3, drop inactive maintainer
* [`6944e6c4`](https://github.com/NixOS/nixpkgs/commit/6944e6c445af28781abfe04016964998c6b4ea83) python310Packages.cachecontrol: 0.12.10 -> 0.12.11
* [`55531cfb`](https://github.com/NixOS/nixpkgs/commit/55531cfbfb22a83bd488aafa8bb7e5dc480c89a0) python310Packages.cherrypy: properly declare optional  dependencies
* [`84657298`](https://github.com/NixOS/nixpkgs/commit/84657298de0a8f93a11aec8e688e67efe14bd745) python310Packages.repoze_lru: add pythonImportsCheck
* [`a40d0cbc`](https://github.com/NixOS/nixpkgs/commit/a40d0cbc5bb510e79cfeebf6d10a6382325aed37) python310Packages.routes: update meta, normalize pname, cleanup
* [`1d5ed925`](https://github.com/NixOS/nixpkgs/commit/1d5ed925d529cbb37e8d666d968802c48fd6c602) python310Packages.soupsieve: document circular dependency, cleanup
* [`548ae98b`](https://github.com/NixOS/nixpkgs/commit/548ae98b588e433a2f82e6338052c7fd5e92fcc3) dtc: fix python 3.10 compatibility
* [`00f527c9`](https://github.com/NixOS/nixpkgs/commit/00f527c9233ca5e006bcc05274820cf69ccb6795) python3Packages.osmnx: 1.1.2 → 1.2.0
* [`a972e002`](https://github.com/NixOS/nixpkgs/commit/a972e002a8cb43582756d246bc8268b84710ccee) python3Packages.networkx: 2.7.1 → 2.8.2
* [`eebbe8c3`](https://github.com/NixOS/nixpkgs/commit/eebbe8c318f9875827675078ea45c1607bad5cce) python3Packages.Rtree: 0.9.7 → 1.0.0
* [`2933cc95`](https://github.com/NixOS/nixpkgs/commit/2933cc953c68c352835a53a3df8eef16e802384f) python310Packages.responses: 0.20.0 -> 0.21.0
* [`af4aa2f2`](https://github.com/NixOS/nixpkgs/commit/af4aa2f2e4faeb10e6e8f4ed00e902c2d8600cb9) python310Packages.cachetools: 5.0.0 -> 5.2.0
* [`d028f1ee`](https://github.com/NixOS/nixpkgs/commit/d028f1ee858df6d4da01cff2413d1eeb35b186ef) python310Packages.httpcore: 0.14.7 -> 0.15.0
* [`99ecb8de`](https://github.com/NixOS/nixpkgs/commit/99ecb8ded55ac57929d4e8b462bd3a81d81bd2a8) python310Packages.httpx: 0.22.0 -> 0.23.0
* [`a9221ef2`](https://github.com/NixOS/nixpkgs/commit/a9221ef2bf5d2875531dfd4c03ffb1b132ce79f0) python310Packages.pytest-httpx: 0.20.0 -> 0.21.0
* [`0af0534f`](https://github.com/NixOS/nixpkgs/commit/0af0534fc4e8533e4b11e63923a87e0496cac9ba) python310Packages.python-slugify: 6.1.1 -> 6.1.2
* [`c43e4f66`](https://github.com/NixOS/nixpkgs/commit/c43e4f66293b0f8386983ea662e52c668820af23) python310Packages.simple-rest-client: 1.1.2 -> 1.1.3
* [`d465833b`](https://github.com/NixOS/nixpkgs/commit/d465833babb27397a1d5bbbda96bd561904fde4e) unicorn: 2.0.0-rc5 -> 2.0.0-rc7
* [`2370e4ec`](https://github.com/NixOS/nixpkgs/commit/2370e4ec3afaeccb05ac0ede7f7affa0a293a6db) python310Packages.pefile: 2021.9.3 -> 2022.5.30
* [`ca783473`](https://github.com/NixOS/nixpkgs/commit/ca7834736495c8d44c9784ee42bb38c8d52d37c1) python310Packages.pyelftools: 0.27 -> 0.28
* [`7931c07d`](https://github.com/NixOS/nixpkgs/commit/7931c07d3ab893e24bdeeef8b22141c082d98e5d) python310Packages.qiling: 1.4.2 -> 1.4.3
* [`d7be0514`](https://github.com/NixOS/nixpkgs/commit/d7be0514dfae639f88faa7aa5972b4d2970e4de0) python310Packages.xdis: unstable-2022-04-13 -> 6.0.4
* [`a2004aff`](https://github.com/NixOS/nixpkgs/commit/a2004aff3706d807013b92dca84fd55d9e25a220) python3Packages.numpy: 1.21.5 -> 1.21.6
* [`00908f68`](https://github.com/NixOS/nixpkgs/commit/00908f68a09cfeac3df876fff39502ef570b5359) python3Packages.sqlalchemy: 1.4.36 -> 1.4.37
* [`ac1db344`](https://github.com/NixOS/nixpkgs/commit/ac1db344b61a385a224bde671f31a7ed23fde426) python310Packages.m2r: fix tests under python 3.10
* [`f3270c33`](https://github.com/NixOS/nixpkgs/commit/f3270c331160880ded29098a6088380e3fb980b4) python310Packages.billiard: disable flaky test
* [`270c6472`](https://github.com/NixOS/nixpkgs/commit/270c6472ad26a00df238dcc73bed1b34a365dec0) python310Packages.pgpy: ignore broken test
* [`fd028a2a`](https://github.com/NixOS/nixpkgs/commit/fd028a2a645f9b926368c0084405c1d1e8d76abd) python310Packages.pylink-square: 0.8.1 -> 0.13.0
* [`7a83c76d`](https://github.com/NixOS/nixpkgs/commit/7a83c76d9d413966d21f93e23c1f6accf116453a) sftpman: 1.1.3 -> 1.2.2
* [`0f14467d`](https://github.com/NixOS/nixpkgs/commit/0f14467d4444db0fbf0de2dc0c1fdd4ee7aa64f1) MACS2: mark broken
* [`e460b285`](https://github.com/NixOS/nixpkgs/commit/e460b285e60c7884413c41ea483c5e466bf2f73a) python310Packages.jsonschema: 4.5.1 -> 4.6.0
* [`5a8116fb`](https://github.com/NixOS/nixpkgs/commit/5a8116fb973ec236328bb098624d0a638539fe00) python3Packages.moto: 3.1.3 -> 3.1.11
* [`cd49d603`](https://github.com/NixOS/nixpkgs/commit/cd49d603d997f200057942bf8dd0d3d57efdf214) python3Packages.certbot: 1.24.0 -> 1.27.0
* [`34423b1b`](https://github.com/NixOS/nixpkgs/commit/34423b1b2675cf319cbdc9df65b1e37d9185a1ab) python3Packages.hass-nabuacasa: update dependency constraints
* [`ac2e6fbd`](https://github.com/NixOS/nixpkgs/commit/ac2e6fbd27539cca8e569bc5b7e2d423a3106579) home-assistant: update python-slugify override
* [`962a3258`](https://github.com/NixOS/nixpkgs/commit/962a3258619f252e4f435def2c8e35111c92abc0) python310Packages.cssutils: 2.4.0 -> 2.4.1
* [`d11da8c2`](https://github.com/NixOS/nixpkgs/commit/d11da8c226563d50fd2670f2bd5921705fd746b4) python310Packages.fonttools: specify passthru.optional-dependencies
* [`17e9bab2`](https://github.com/NixOS/nixpkgs/commit/17e9bab270e8d4ec637ae6544422ac9f4f68067a) python310Packages.weasyprint: update dependencies
* [`d8c38002`](https://github.com/NixOS/nixpkgs/commit/d8c380026cf41293e1bf0457c4c11dff2ba75dd9) python310Packages.pygal: update dependencies
* [`2dce5a72`](https://github.com/NixOS/nixpkgs/commit/2dce5a72042883ea153e02fdbd635904d569797c) python310Packages.trio-websocket: init at 0.9.2
* [`8466ac28`](https://github.com/NixOS/nixpkgs/commit/8466ac2820966da53ff0d8aafbb01380cab195e4) python310Packages.selenium: 3.141.0 -> 4.2.0
* [`15f74ff7`](https://github.com/NixOS/nixpkgs/commit/15f74ff79e5b099bf6d1115b9e87c863e338b792) python3Packages.ansible-later: 2.0.13 -> 2.0.14
* [`4104ea1e`](https://github.com/NixOS/nixpkgs/commit/4104ea1e7a3105cd207dc950a5c5679c1b391b31) python310Packages.splinter: disable by design not working test, remove six dependency
* [`a7ed20d5`](https://github.com/NixOS/nixpkgs/commit/a7ed20d51bc7973f6adbe43446ab473346216343) python3Packages.audible: update httpx constraint, disable check phase
* [`17da2b4c`](https://github.com/NixOS/nixpkgs/commit/17da2b4c251f23f68229bd1daae28b1dbfdd076c) python3Packages.sanic-tesing: relax httpx constraint
* [`731a3c93`](https://github.com/NixOS/nixpkgs/commit/731a3c93bb507da27b586b8f4dea9725b8cd4455) python3Packages.fastapi-mail: relax http constraint
* [`ea66d031`](https://github.com/NixOS/nixpkgs/commit/ea66d0313576837b4dc99789c295ad526f965fec) python3Packages.graph-tool: 2.43 -> 2.45
* [`0d1516e1`](https://github.com/NixOS/nixpkgs/commit/0d1516e198bf71a4d7857585ff6dbaacb6f53330) python3Packages.sleekxmpp: disable on python3.10
* [`e5b1832b`](https://github.com/NixOS/nixpkgs/commit/e5b1832b36ca470b6b0222dcfb56875c659c1406) python3Packages.homeconnect: propagate six
* [`a543fd1b`](https://github.com/NixOS/nixpkgs/commit/a543fd1bb15dbdce00e35d4895fee8bd968e2648) python3Packages.aiosteamist: relax xmltodict constraint
* [`313d44af`](https://github.com/NixOS/nixpkgs/commit/313d44af435714b147bbff9e23a2cc59c574d614) python310Packages.cloudpickle: 2.0.0 -> 2.1.0
* [`5d96f579`](https://github.com/NixOS/nixpkgs/commit/5d96f579a5005f7dba08948ae0a7e99da1bdcd7a) python310Packages.msgpack: 1.0.3 -> 1.0.4
* [`c5b343cf`](https://github.com/NixOS/nixpkgs/commit/c5b343cfd87403458ffcdcdfb199e3dbd39ff423) home-assistant: relax cryptography constraint
* [`80577b64`](https://github.com/NixOS/nixpkgs/commit/80577b644cfee47ad180cdc98e92163f6e980f44) python3Packages.cfn-flip: fix hash
* [`3a5f9026`](https://github.com/NixOS/nixpkgs/commit/3a5f90269a98ba782b0133314b434f4df8c1d017) python3Packages.node_progressive: mark unconditionally as broken
* [`c9d25b2a`](https://github.com/NixOS/nixpkgs/commit/c9d25b2a2fddec4721f91c1deb5c86fdf45e4b38) python3Packages.sphinxcontrib_bayesnet: mark unconditionally broken
* [`1c701dd3`](https://github.com/NixOS/nixpkgs/commit/1c701dd3689de71189e3afddefaa849081d289ed) python3Packages.selectors2: fix mapping import
* [`323bc125`](https://github.com/NixOS/nixpkgs/commit/323bc125fe3d07b4aa6e816f5426a7d0427dc40d) python3Packages.snowflake-connector-python: relax cryptography constraint
* [`1d1120aa`](https://github.com/NixOS/nixpkgs/commit/1d1120aab019d96c52ed67cf42572a2e8d38be4e) quodlibet: 4.4.0 -> 4.5.0
* [`ae784e7d`](https://github.com/NixOS/nixpkgs/commit/ae784e7d3ed26a4649723aa431317bd3923a8f40) diffoscope: 214 -> 215
* [`61d056d2`](https://github.com/NixOS/nixpkgs/commit/61d056d212b22b985e06b4212a45fb8f40afa302) python3Packages.hyperion-py: fix python3.10 support
* [`77cf0414`](https://github.com/NixOS/nixpkgs/commit/77cf0414e46a86bb5805f9fb9d921e0252d618f8) python3Packages.requests: expose optional-dependencies
* [`665aec3e`](https://github.com/NixOS/nixpkgs/commit/665aec3e7f7bff9d3c6768051d7271eb76985daf) python3Packages.beautifulsoup4: propagate chardet
* [`397cf8e5`](https://github.com/NixOS/nixpkgs/commit/397cf8e50381702df50e3ae34451511f2c1cc432) gdown: propagate requests[socks]
* [`2600e7d5`](https://github.com/NixOS/nixpkgs/commit/2600e7d5deeeb1c528a99db8254857762cbe78e9) python3Packages.starlette: 0.19.0 -> 0.20.1
* [`39e1366d`](https://github.com/NixOS/nixpkgs/commit/39e1366decb154d1eb8ce0c7e8f6634090da334d) python3Packages.fastapi: 0.75.2 -> 0.78.0
* [`ce67d25d`](https://github.com/NixOS/nixpkgs/commit/ce67d25d41c0a05fa4c34b73126f367e682b2db3) python3Packages.fastapi-mail: relax fastapi constraint
* [`a45f138a`](https://github.com/NixOS/nixpkgs/commit/a45f138a414e63445747870f54a3be77e9b25c6c) mapnik: unvendor scons
* [`c146fde7`](https://github.com/NixOS/nixpkgs/commit/c146fde7a03d6adb8ce456e9dc5bbb117c6886b1) python310Packages.limits: 2.6.2 -> 2.6.3
* [`852ef21b`](https://github.com/NixOS/nixpkgs/commit/852ef21b34da1c745aa78a18b36eba2c7547963a) cantoolz: fix python3.10 support
* [`9641ef02`](https://github.com/NixOS/nixpkgs/commit/9641ef024d6ff2cf4af13bff9884b6e7026ac53d) i3a: relax python version constraint
* [`b6f6f1f7`](https://github.com/NixOS/nixpkgs/commit/b6f6f1f7d540491b34125f1672456e32abe32a29) python3Packages.flickrapi: propagate six
* [`a4b86d4e`](https://github.com/NixOS/nixpkgs/commit/a4b86d4e75768dce6c6198f3de06ae07976af823) python3Packages.globus-sdk: fix tests
* [`b670cf8d`](https://github.com/NixOS/nixpkgs/commit/b670cf8df67de266d8c5f029f5442ab57392e424) python3Packages.snscrape: propagate requests[socks]
* [`51fd3fec`](https://github.com/NixOS/nixpkgs/commit/51fd3fec9e5df5dc528aaf89765d50428695ecdf) turses: update tweepy override
* [`b10d49ee`](https://github.com/NixOS/nixpkgs/commit/b10d49ee09e486adfd264ba7dfc106fab4f0a53e) errbot: use python39
* [`418a929d`](https://github.com/NixOS/nixpkgs/commit/418a929ded10f1c2509336eef24d665f0abbe3df) ntfy: use python39 and remove ntfy-webpush from python3Packages
* [`d588e9ac`](https://github.com/NixOS/nixpkgs/commit/d588e9acfe5cba35aadea6bc8ea3195e44b108d5) python3Packages.snowflake-sqlalchemy: propgate six
* [`cbda7b33`](https://github.com/NixOS/nixpkgs/commit/cbda7b33aa22957ebed2bd01ff372cdb2704717c) python310Packages.twine: 4.0.0 -> 4.0.1
* [`0eb07062`](https://github.com/NixOS/nixpkgs/commit/0eb07062a2ad0343ea08f62f52626e405627e75d) python310Packages.snscrape: unstable-2021-08-30 -> 0.4.3.20220106
* [`fe428eb0`](https://github.com/NixOS/nixpkgs/commit/fe428eb0b7240552fe871d95535ad8367c38e1a4) python310Packages.websockets: 10.1 -> 10.3
* [`d07a5a33`](https://github.com/NixOS/nixpkgs/commit/d07a5a33496d00d3e432c0b05c74d0dc781b9110) python310Packages.unidecode: 1.3.2 -> 1.3.4
* [`87592180`](https://github.com/NixOS/nixpkgs/commit/87592180599135587298be397afca7758bb80ba9) python310Packages.databases: 0.5.5 -> 0.6.0
* [`b5751da4`](https://github.com/NixOS/nixpkgs/commit/b5751da441446657da7b4724490fb6d4a2b1075d) python310Packages.filelock: 3.6.0 -> 3.7.1
* [`a91744fb`](https://github.com/NixOS/nixpkgs/commit/a91744fb8b4501b568c003dc4d4d625e97fd7396) python310Packages.pybase64: 1.2.1 -> 1.2.2
* [`269e8cfe`](https://github.com/NixOS/nixpkgs/commit/269e8cfefb64119fe17c0c8fc14463a3449d6792) python310Packages.immutables: 0.17 -> 0.18
* [`141824ed`](https://github.com/NixOS/nixpkgs/commit/141824ed0dc2aad39fc95c02177ab3fdaab8cc7f) python310Packages.pyathena: 2.5.2 -> 2.9.1
* [`3e1a60f5`](https://github.com/NixOS/nixpkgs/commit/3e1a60f561d71e0fc4d0aaba8dd336004bf3e43e) python310Packages.gcsfs: 2022.3.0 -> 2022.5.0
* [`3bd9157c`](https://github.com/NixOS/nixpkgs/commit/3bd9157c129eda55dd15727f1fd5005cf3da725c) python310Packages.dask-gateway-server: 0.9.0 -> 2022.4.0
* [`6d106f05`](https://github.com/NixOS/nixpkgs/commit/6d106f05825b8ba42103436289e608c35c6e5c9b) python310Packages.distributed: 2022.2.1 -> 2022.5.0
* [`348353cf`](https://github.com/NixOS/nixpkgs/commit/348353cf3616d9b597d1a4ef7bf0b565eac44dbb) python310Packages.locket: 0.2.1 -> 1.0.0
* [`9cf7ead1`](https://github.com/NixOS/nixpkgs/commit/9cf7ead180687b2211c34035551008a2f14db42d) python310Packages.s3fs: 2022.2.0 -> 2022.5.0
* [`55c67f40`](https://github.com/NixOS/nixpkgs/commit/55c67f40aa85d4a9c53bd25fc41e2f53bf94037f) python310Packages.tifffile: 2022.3.25 -> 2022.5.4
* [`630241e6`](https://github.com/NixOS/nixpkgs/commit/630241e628ed174ec7b5c4fd69fdf91fa07ebad6) python310Packages.imageio: 2.16.1 -> 2.19.2
* [`f76d963f`](https://github.com/NixOS/nixpkgs/commit/f76d963ffa2a9357e980a4ebbe3a3e0e85f57801) python310Packages.pyarrow: disable flaky test
* [`15b67040`](https://github.com/NixOS/nixpkgs/commit/15b67040bb14c12b3e4d47efac7a2ad2885cd2c2) python310Packages.dask: 2022.05.0 -> 2022.05.2
* [`71d5ec64`](https://github.com/NixOS/nixpkgs/commit/71d5ec64ffc00157c29ddc3deb21ecf7afc95e53) python310Packages.distributed: 2022.5.0 -> 2022.5.2
* [`ddb88d2e`](https://github.com/NixOS/nixpkgs/commit/ddb88d2ea46c01ac08ba98aee9b2e93d39ae43d0) python310Packages.streamz: disable flaky tests
* [`0220a623`](https://github.com/NixOS/nixpkgs/commit/0220a623b414975e624dde56bfa30fe951d3dbd3) python310Packages.pyarrow: disable flaky test
* [`792e5af4`](https://github.com/NixOS/nixpkgs/commit/792e5af45bb43455d5096f88ba7ba9a9767b3272) python310Packages.intake: 0.6.4 -> 0.6.5
* [`e35789db`](https://github.com/NixOS/nixpkgs/commit/e35789db92dcfa13456cde8d179184fb7f72d693) python310Packages.fsspec: 2022.3.0 -> 2022.5.0
* [`b352fc55`](https://github.com/NixOS/nixpkgs/commit/b352fc55435afa66ca338c6a0a9da1f8cc2a9232) python310Packages.dask: 2022.02.1 -> 2022.05.0
* [`32a2f6fe`](https://github.com/NixOS/nixpkgs/commit/32a2f6fe6f9bfe0be84e126e712b56633eb21330) python310Packages.fastparquet: add optional dependency
* [`ea658301`](https://github.com/NixOS/nixpkgs/commit/ea658301e1c0fe55f82489d05ecc84b887b7d762) python310Packages.s3fs: disable on older Python releases
* [`077cf7c7`](https://github.com/NixOS/nixpkgs/commit/077cf7c76be38b0ae63c932e2bc2d70143bdcbd8) Python310Packages.sparse: disable on older Python releases
* [`fc78ec96`](https://github.com/NixOS/nixpkgs/commit/fc78ec96796fc371f5851d792e9f8ca1fc5a232c) python310Packages.dask-glm: handle optional dependencies
* [`e3873e7f`](https://github.com/NixOS/nixpkgs/commit/e3873e7f7e182fd71564f522721b6234ba71befa) python310Packages.dask-ml: handle optional dependencies
* [`e18f93ca`](https://github.com/NixOS/nixpkgs/commit/e18f93caedc2946ea3d5b4973a5d7574a8617290) python310Packages.dask: 2022.05.0 -> 2022.05.2
* [`b0451997`](https://github.com/NixOS/nixpkgs/commit/b045199796dea02c2aa206506f930e0a058efa5e) privacyidea: use python39
* [`37cc04e7`](https://github.com/NixOS/nixpkgs/commit/37cc04e721e677e556e0fb6c4aa6287f2b003dfd) odoo: use python39
* [`c2aa1074`](https://github.com/NixOS/nixpkgs/commit/c2aa1074c140b82f8ff9327d14260faed98792cc) python3Packages.azure-mgmt-containerinstance: 9.1.0 -> 9.2.0
* [`42caf48c`](https://github.com/NixOS/nixpkgs/commit/42caf48cd0800838b18e3585384194ccc2d4f99b) python3Packages.azure-mgmt-containerregistry: 9.1.0 -> 10.0.0
* [`7c16cc8c`](https://github.com/NixOS/nixpkgs/commit/7c16cc8c54913f0d8ad5950ebd377c17662ab8c9) python3Packages.azure-storage-blob: 12.11.0 -> 12.12.0
* [`8f482ad9`](https://github.com/NixOS/nixpkgs/commit/8f482ad98f6c25954afb4ddeee81b0f7f520a0b1) plocate: 1.1.15 -> 1.1.16
* [`1a602dda`](https://github.com/NixOS/nixpkgs/commit/1a602dda633179d90803fe149c9a7309d235e608) python310Packages.hahomematic: 1.8.4 -> 1.8.5
* [`cb93a026`](https://github.com/NixOS/nixpkgs/commit/cb93a026a55dd996b918861155d21ef68808c630) python310Packages.glances-api: 0.3.5 -> 0.3.6
* [`8b040682`](https://github.com/NixOS/nixpkgs/commit/8b04068283db099cecf44427d0c6aff460e6eced) python310Packages.pymemcache: 3.5.1 -> 3.5.2
* [`43629f3d`](https://github.com/NixOS/nixpkgs/commit/43629f3d2e57da46b403b681909c324a7614aa1d) fancy-motd: unstable-2021-07-15 -> unstable-2022-06-06
* [`c9b86a26`](https://github.com/NixOS/nixpkgs/commit/c9b86a269bc453f2326ebd7509f4249821ea25c6) python3Packages.azure-data-tables: init at 12.4.0
* [`c055b9b7`](https://github.com/NixOS/nixpkgs/commit/c055b9b796d532b2ccfa22190551d6c03a728b59) python3Packages.antlr4-python3-runtime: fix tests for 4.9+
* [`40e0a8d9`](https://github.com/NixOS/nixpkgs/commit/40e0a8d9d5e499a9fbe4cd9ffd366c1e85c56ff6) azure-cli: remove blanket python2 compat logic
* [`ce0ebc2e`](https://github.com/NixOS/nixpkgs/commit/ce0ebc2e1599b20b46baacc3094d2e9cda317d66) azure-cli: 2.34.1 -> 2.37.0
* [`77cdee19`](https://github.com/NixOS/nixpkgs/commit/77cdee19460acb111ed280ffd4b966b2cbaff2b9) fixup! python3Packages.azure-data-tables: init at 12.4.0
* [`daad0beb`](https://github.com/NixOS/nixpkgs/commit/daad0beb4207882d485b23560b1c20acdb449ad8) fixup! azure-cli: 2.34.1 -> 2.37.0
* [`499c5044`](https://github.com/NixOS/nixpkgs/commit/499c5044ffc457687d1edc2b50eb45bd26d0215d) python310Packages.pylint: 2.14.0 -> 2.14.1
* [`a0aeec7e`](https://github.com/NixOS/nixpkgs/commit/a0aeec7e43d0e162070340e5986f6e8caa22f4a6) portaudio: set strictDeps
* [`8807cab8`](https://github.com/NixOS/nixpkgs/commit/8807cab81b09fa3c1d611e44a3ba4ac446d09f08) libffi: Pass --build and --host to configure script
* [`7f8d28e9`](https://github.com/NixOS/nixpkgs/commit/7f8d28e99bb43316e8b8d57edb02bd84ac3e2376) libusb1: 1.0.25 -> 1.0.26
* [`360206ab`](https://github.com/NixOS/nixpkgs/commit/360206abd00bea2ec8ddc0f714f5845e7c2210f6) tfplugindocs: init at 0.9.0
* [`0031ccab`](https://github.com/NixOS/nixpkgs/commit/0031ccab55e72a1ca59128882f9f98de2a049226) python310Packages.pyserial: add pythonImportsCheck
* [`0dbb26a3`](https://github.com/NixOS/nixpkgs/commit/0dbb26a3914d086b06ade061f920239a562de645) python310Packages.configobj: switch to pytestCheckHook
* [`13a4a870`](https://github.com/NixOS/nixpkgs/commit/13a4a8702cf72010efedd4e7cb52cd9c5b76f88b) python310Packages.jsonpatch: enable tests
* [`069f9a07`](https://github.com/NixOS/nixpkgs/commit/069f9a077ed3cc885ee781dd92cc32a7a1e0f37f) python310Packages.netifaces: add format
* [`9af97d30`](https://github.com/NixOS/nixpkgs/commit/9af97d300480c9d4b448d9f1850bca62496706eb) python310Packages.pyannotate: switch to pytestCheckHook
* [`209c3faf`](https://github.com/NixOS/nixpkgs/commit/209c3fafde2b571ceb06553f839523a056cd8415) python310Packages.pytest-annotate: relax pytest constraint
* [`c422b656`](https://github.com/NixOS/nixpkgs/commit/c422b6566c9665de0e3406c2d9c6856256445c3e) pip-audit: adjust inputs
* [`70b31373`](https://github.com/NixOS/nixpkgs/commit/70b31373b4b4c5673e36f1bb6fe88045304d705f) tt-rss: downgrade to php 8.0
* [`1661ce82`](https://github.com/NixOS/nixpkgs/commit/1661ce8227f568dbb97c0ee86c755b911e1ac96e) vscode-extensions.njpwerner.autodocstring: init at 6.0.1
* [`8c9b8d03`](https://github.com/NixOS/nixpkgs/commit/8c9b8d03b06804e24c01f2897bb9f24c6914f1b0) haskellPackages: stackage LTS 19.9 -> LTS 19.10
* [`bf5ada3d`](https://github.com/NixOS/nixpkgs/commit/bf5ada3db15c4bbd09931edf5d815fc4bb6d7402) all-cabal-hashes: 2022-06-04T09:01:11Z -> 2022-06-07T15:13:17Z
* [`c9eb5b7a`](https://github.com/NixOS/nixpkgs/commit/c9eb5b7acd8fff8a0e104ed6416194b1debf37e4) haskellPackages: regenerate package set based on current config
* [`61223d51`](https://github.com/NixOS/nixpkgs/commit/61223d51de5824c57754990c606f91aeae0fc730) pythonRelaxDepsHook: fix usage in packages with `-` in pname
* [`0d71f8a2`](https://github.com/NixOS/nixpkgs/commit/0d71f8a2bc0b47189e348e68245334971ba0d05f) pysigma-backend-insightidr: use pythonRelaxDepsHook
* [`caf6e09b`](https://github.com/NixOS/nixpkgs/commit/caf6e09b7066022ba4f24560b41141787579c203) dbus: fix paths in catalog
* [`d1720612`](https://github.com/NixOS/nixpkgs/commit/d172061281406669cd7b820c9f566a8784b3c21d) makeDBusConf: use upstream XML catalog
* [`95052027`](https://github.com/NixOS/nixpkgs/commit/95052027078143e62c65869474d33bb2023ab184) gpxsee: 11.0 → 11.1
* [`f98680b4`](https://github.com/NixOS/nixpkgs/commit/f98680b4e4faa5babb86e01541e7198366a94ad6) python3Packages.tensorflow: 2.8.0 -> 2.9.0
* [`ba40bab6`](https://github.com/NixOS/nixpkgs/commit/ba40bab6e5dbbbd4d18383f6d776f98dc41c1650) perlPackages: add meta.mainProgram to pacakges with single executable
* [`25b59437`](https://github.com/NixOS/nixpkgs/commit/25b5943729726370ff86a06929b36041d607036a) perlPackages: add meta.mainProgram to packages with multiple executables
* [`1a5f9411`](https://github.com/NixOS/nixpkgs/commit/1a5f94115ce86f6ec861ec136fee8b64a53dffac) perlPackages: fix indentation
* [`1a3ff178`](https://github.com/NixOS/nixpkgs/commit/1a3ff178aaadfb3525242cb90f12bf0802d37752) rust-cbindgen: 0.23.0 -> 0.24.2
* [`f7862834`](https://github.com/NixOS/nixpkgs/commit/f7862834d88ef4ced6e615a908d4eeacf734e969) haskellPackages.highlight: unbreak
* [`bf3cb6de`](https://github.com/NixOS/nixpkgs/commit/bf3cb6dec22b6fdc399c519221ba962ad1502908) networkmanagerapplet: 1.26.0 -> 1.28.0
* [`4c33f198`](https://github.com/NixOS/nixpkgs/commit/4c33f198e31bd6c95ae7b063bda6a0d6c233946e) fped: add -fcommon workaround
* [`47728bde`](https://github.com/NixOS/nixpkgs/commit/47728bdeb050bd558f697be1b0dd8ee71031dc15) klystrack: add -fcommon workaround
* [`24fc52a1`](https://github.com/NixOS/nixpkgs/commit/24fc52a14b89d2f24b440b9745f4bbc568e66142) haskellPackages.ghc-lib-parser-ex_9_2_1_0: update overrides for this version
* [`53c8f97a`](https://github.com/NixOS/nixpkgs/commit/53c8f97a537abb85fb35e88cb4801fa62692813f) autoflake: switch to pytestCheckHook
* [`d0ee55d6`](https://github.com/NixOS/nixpkgs/commit/d0ee55d6d303adb6283a983b8e47707ace722f6d) thrift: disable failing tests
* [`7770164a`](https://github.com/NixOS/nixpkgs/commit/7770164a072968dc6373beb1763082b7c1061796) python310Packages.qutip: 4.6.3 -> 4.7.0
* [`66bb79f6`](https://github.com/NixOS/nixpkgs/commit/66bb79f6409d3f598e5a85b3a36dcdea2ff87881) python39Packages.rokuecp: disable failing tests
* [`4f1fa2f3`](https://github.com/NixOS/nixpkgs/commit/4f1fa2f3fea2ddc2c7db6c706058d42b1ef5be26) python310Packages.graphite-web: 1.1.8 -> 1.1.10
* [`3b754ded`](https://github.com/NixOS/nixpkgs/commit/3b754ded2098664c5307e708b97c983dd52c86b3) python310Packages.graphite-web: remove patch
* [`7e2f6fa1`](https://github.com/NixOS/nixpkgs/commit/7e2f6fa137c0f4ecb53922fd54f666a91c9c2e09) calibre-web: add missing input
* [`8dd18c10`](https://github.com/NixOS/nixpkgs/commit/8dd18c109013d8cb7ffff5ecbf4a13cd6d02f00b) plik: 1.3.4 -> 1.3.6
* [`98ff4139`](https://github.com/NixOS/nixpkgs/commit/98ff4139d1cf6a235e92a041b48abedf6b623dee) maintainers: add tejasag
* [`74ffc379`](https://github.com/NixOS/nixpkgs/commit/74ffc379504d21d031e559d37bb1c43d399ea6e1) oak: init at 0.2
* [`276699cd`](https://github.com/NixOS/nixpkgs/commit/276699cdacc78392b6cd474ace837aec8ed55b46) xplr: 0.18.0 -> 0.19.0
* [`9b200575`](https://github.com/NixOS/nixpkgs/commit/9b2005751229d7698a95211ce55bf72eecfa2df3) prometheus: 2.35.0 -> 2.36.0
* [`48275dbd`](https://github.com/NixOS/nixpkgs/commit/48275dbd5617b55d98f6def9792b3ee95bcf6664) python3Packages.dropbox: Re-add setuptools to propagatedBuildInputs
* [`81b8cb86`](https://github.com/NixOS/nixpkgs/commit/81b8cb86244a877304c0a066bce688c9db52950f) haskell.packages.ghcjs.ghcjs-base: fix build
* [`27d3d3bb`](https://github.com/NixOS/nixpkgs/commit/27d3d3bb04718ba356e758a4329774f1df237594) megaglest: pull upstream fix for -fno-common toolchains
* [`46c025be`](https://github.com/NixOS/nixpkgs/commit/46c025be1514723c8d477db8e45c7f3403500603) olm: 3.2.11 -> 3.2.12
* [`299b9a1b`](https://github.com/NixOS/nixpkgs/commit/299b9a1b59d43ff157cd2e9579a6fc588feff1a9) buildMozillaMach: add patch for rust-cbindgen 0.24 compat
* [`47016de7`](https://github.com/NixOS/nixpkgs/commit/47016de7effddab56c374598de8de7c704543c84) go_1_17: 1.17.10 -> 1.17.11
* [`6e7fb72f`](https://github.com/NixOS/nixpkgs/commit/6e7fb72f0f91273f308285347128915025eb58c1) go_1_18: 1.18.2 -> 1.18.3
* [`1c76a270`](https://github.com/NixOS/nixpkgs/commit/1c76a270d2d0331aaed02a308acb607e81e5c414) nss: 3.68.4 -> 3.79
* [`e8ce7487`](https://github.com/NixOS/nixpkgs/commit/e8ce74879d88a35caa83a1a76b3f232bf777c60d) packwiz: unstable-2022-05-25 -> unstable-2022-06-08
* [`6ab28719`](https://github.com/NixOS/nixpkgs/commit/6ab2871989ea231dd5252e679cc5bdf1f78a17d5) python3Packages.rdkit: 2020.09.5 -> 2022.03.3
* [`7593e005`](https://github.com/NixOS/nixpkgs/commit/7593e005e12013734a6db87b38bafa5aedcfbc56) vinagre: pull fix pending upstream inclusiong for -fno-common toolchain support
* [`1cc20264`](https://github.com/NixOS/nixpkgs/commit/1cc2026421f1d31079bc94bb1cce16fdc4bb032c) upower: 0.99.17 → 0.99.19
* [`0a6632d6`](https://github.com/NixOS/nixpkgs/commit/0a6632d654ed220dce1f7eed03e3e13e4a51e0db) flacon: 7.0.1 -> 9.0.0
* [`ba8a998c`](https://github.com/NixOS/nixpkgs/commit/ba8a998c1841a7b2b81e255c5864f4fc26a9ba0e) boost: 1.77.0 -> 1.79.0
* [`efb6d291`](https://github.com/NixOS/nixpkgs/commit/efb6d291612c08e7e9dd1934beff0d5bbc95617f) tracker: 3.3.0 → 3.3.1
* [`938f2ce1`](https://github.com/NixOS/nixpkgs/commit/938f2ce1017ff1fdb25abec3f22a0821618af8cb) jansson: enable shared library installation
* [`d7f012f3`](https://github.com/NixOS/nixpkgs/commit/d7f012f33ce5ee308f75f3f53a1e8189c6dc15d8) mobile-broadband-provider-info: 20220315 -> 20220511
* [`05373e13`](https://github.com/NixOS/nixpkgs/commit/05373e130b16bc9080c7fc1908b8c9702e8bbc22) libnetfilter_cthelper: 1.0.0 -> 1.0.1
* [`d5d49c40`](https://github.com/NixOS/nixpkgs/commit/d5d49c402d45c95f9467ae5c255e6d4e4d3e3fe4) libnetfilter_cttimeout: 1.0.0 -> 1.0.1
* [`131fce41`](https://github.com/NixOS/nixpkgs/commit/131fce41a3b25eed5f0d7b16819f8811f5e26af9) iptables: 1.8.7 -> 1.8.8
* [`a12e5254`](https://github.com/NixOS/nixpkgs/commit/a12e52541099e5239d645018daf26a02cc60dd5d) nixos/bitlbee: allow writing to configDir
* [`6dd69475`](https://github.com/NixOS/nixpkgs/commit/6dd69475e244c6c47c6afd0d7a4d846b37147dd8) fontconfig: 2.13.94 → 2.14.0
* [`e91b5670`](https://github.com/NixOS/nixpkgs/commit/e91b5670e3fc0a7e39b9f3e469bedfe742d42eda) cc-wrapper: Use case statements instead of bunch of if/elif checks
* [`19b6ccd9`](https://github.com/NixOS/nixpkgs/commit/19b6ccd9acb89585cb9df7fae22e68baacda3534) cc-wrapper: Allow for override of -target for clang/clang++
* [`8fc1c425`](https://github.com/NixOS/nixpkgs/commit/8fc1c4255f383937ef60c06a3365b2bce427befe) garden-of-coloured-lights: add -fcommon workaround
* [`ae2d8278`](https://github.com/NixOS/nixpkgs/commit/ae2d8278061209e7fa14fe8767c9e9a99927b22b) spaceFM: add -fcommon workaround
* [`2294dace`](https://github.com/NixOS/nixpkgs/commit/2294dace6ae30d095719a6dd8413242ec61ca8e5) python3Packages.setuptools: add distutils patch to support cross-compilation
* [`cf32ea06`](https://github.com/NixOS/nixpkgs/commit/cf32ea06a472828674203e08ef728a116e3f04de) unbound: 1.14.0 -> 1.16.0
* [`bcf29733`](https://github.com/NixOS/nixpkgs/commit/bcf29733e9367d2c3a1da2d6bfdb9afa553d23ec) hwdata: 0.347 -> 0.360
* [`8335c466`](https://github.com/NixOS/nixpkgs/commit/8335c46632910d9b9dc13c0701b2755311b62ea9) zlib: backport upstream fix on CRC validation
* [`d4f419a1`](https://github.com/NixOS/nixpkgs/commit/d4f419a1103d0e7ac31b19c8a9dd58f9bf9456f9) maintainers: add devusb
* [`8a56b32c`](https://github.com/NixOS/nixpkgs/commit/8a56b32c663b4ff55f95bd2d9f965f6741532cf2) aws-sso-cli: init at 1.9.2
* [`eb31cd04`](https://github.com/NixOS/nixpkgs/commit/eb31cd04f1ac7aaa7d0f95cad42d36e148ebec23) avahi: remove Qt 4 support
* [`fae6144d`](https://github.com/NixOS/nixpkgs/commit/fae6144d7deac0e42d69661cdfe88e7d62e0cab8) vscodium: 1.67.2 -> 1.68.0
* [`572ffd45`](https://github.com/NixOS/nixpkgs/commit/572ffd4513aefc4c04143f8a6be2c294a06c07c6) dendrite: 0.8.7 -> 0.8.8
* [`701a79a7`](https://github.com/NixOS/nixpkgs/commit/701a79a798f9f2e2ec66bdac53db6af0e4c162a2) lsof: pull fix pending upstream inclusion for -fno-common toolchains
* [`6080c1e2`](https://github.com/NixOS/nixpkgs/commit/6080c1e20b258783afe6990ad96e6a66bbcd5a00) josm: 18427 → 18463
* [`fefca2f6`](https://github.com/NixOS/nixpkgs/commit/fefca2f6222be0235a128c656d06a8215c006426) libjxl: Gate building docs behind setting
* [`39772417`](https://github.com/NixOS/nixpkgs/commit/397724176b474080a09422fdc29d3fc85cd43f2a) libaom: Add support for butteraugli and vmaf tunes
* [`2300d831`](https://github.com/NixOS/nixpkgs/commit/2300d8312dc1b9d9bb2d7ad2f8007b3ca69f71c1) .gitignore: prepend slash to result and source
* [`b0a641eb`](https://github.com/NixOS/nixpkgs/commit/b0a641eb0189c4c51f1c039981d15c3ba2d0ce65) zotero: 6.0.4 -> 6.0.8
* [`24ff314c`](https://github.com/NixOS/nixpkgs/commit/24ff314c9be729068ff1e0368bf2719325c7daf1) appimagekit: set TOOLS_PREFIX to fix cross compilation
* [`7bb5b6ce`](https://github.com/NixOS/nixpkgs/commit/7bb5b6ce9cbeba2dabe7adf158d2280d4d880804) python310Packages.hatchling: 0.25.0 -> 1.0.0 ([nixos/nixpkgs⁠#173450](https://togithub.com/nixos/nixpkgs/issues/173450))
* [`67eb7a1d`](https://github.com/NixOS/nixpkgs/commit/67eb7a1d55171c64c81602ebc94696739a9a8862) zeronet-conservancy: 0.7.5 -> 0.7.6
* [`0df74af7`](https://github.com/NixOS/nixpkgs/commit/0df74af7a913d8b869ba07a44786bfcb964e403b) github-runner: 2.292.0 -> 2.293.0
* [`b9495cc3`](https://github.com/NixOS/nixpkgs/commit/b9495cc30f5cbb32cf2b6243ce775361dc31bf52) zimlib: 6.3.2 -> 7.2.2
* [`8320da21`](https://github.com/NixOS/nixpkgs/commit/8320da218e04e672a64873b949bf2578373da308) zimwriterfs 1.0 -> zim-tools 3.1.1
* [`207e649a`](https://github.com/NixOS/nixpkgs/commit/207e649ab90fce65db78e89eab956c8567348cc5) kiwix: 2.0.5 -> 2.2.1
* [`edfc49fb`](https://github.com/NixOS/nixpkgs/commit/edfc49fbcf9e0884754f8a2cc406ba731e29baff) python310Packages.ledger: use default boost
* [`efac9dab`](https://github.com/NixOS/nixpkgs/commit/efac9dabcacaaf7dfad80b281c22a11c510855df) ipfs: 0.12.2 -> 0.13.0
* [`04a5460f`](https://github.com/NixOS/nixpkgs/commit/04a5460f05815736fb9bfe53332eb218453cbe9d) ipfs-cluster: 1.0.0 -> 1.0.1
* [`9fc90429`](https://github.com/NixOS/nixpkgs/commit/9fc90429c3bdc4c1d800777b0ba61c325dfb8e0f) treewide/games,misc: add sourceType binaryNativeCode for many packages
* [`6e629227`](https://github.com/NixOS/nixpkgs/commit/6e6292279e89ff6240c77159fec15970b0d5db7a) meson: add mesonEmulatorHook
* [`163ffce3`](https://github.com/NixOS/nixpkgs/commit/163ffce31d78d54fb95366bdebe3143f636f491c) prelink: 20130503 -> unstable-2019-06-24 cross_prelink branch
* [`79d349b0`](https://github.com/NixOS/nixpkgs/commit/79d349b0877cf22b693882c9a28f9052ae66cf2d) gobject-introspection: support cross-compilation
* [`41f87220`](https://github.com/NixOS/nixpkgs/commit/41f8722078be674d185db03d0947e0df84a7ae2c) gobject-introspection: add artturin as maintainer
* [`944781be`](https://github.com/NixOS/nixpkgs/commit/944781be23e853575128a319846c8962af78bb92) gobject-introspection: revert patch to ignore return codes from ldd
* [`c8f918e0`](https://github.com/NixOS/nixpkgs/commit/c8f918e0ef6b4fba6f1d311ae96349c7c0c2d7ab) keybase: 5.9.3 -> 6.0.2 https://github.com/keybase/client/releases/tag/v6.0.2
* [`edc88086`](https://github.com/NixOS/nixpkgs/commit/edc8808603be2e13cf5b6ec3cbcca61de3de3ba0) ceph: use python39
* [`eb3469e5`](https://github.com/NixOS/nixpkgs/commit/eb3469e52624fbe1204b22effa8aa084a42fe771) mesa: revert to 22.0 on darwin
* [`80a07604`](https://github.com/NixOS/nixpkgs/commit/80a0760433d179ac0e9f8702639f335378625eb6) librsvg: 2.54.3 -> 2.54.4
* [`0045581c`](https://github.com/NixOS/nixpkgs/commit/0045581c231ae96ccc1b14c62c465c8aafe6eb8d) boinc: 7.18.1 -> 7.20.0
* [`8e73fa15`](https://github.com/NixOS/nixpkgs/commit/8e73fa158789b1df09f073152e923958732eb0fb) fuse3: 3.10.5 -> 3.11.0
* [`0da898ca`](https://github.com/NixOS/nixpkgs/commit/0da898ca39a9b860fbd50cdde781286ec52f4194) glibcLocalesUtf8: init at 2.34
* [`ffb456ae`](https://github.com/NixOS/nixpkgs/commit/ffb456ae61d1740b5b254f6d431801782d7ab0d7) fetchzip: force UTF-8 compatibel locale to unpack non-ASCII symbols
* [`b543ad56`](https://github.com/NixOS/nixpkgs/commit/b543ad569161f123b4652a5b88476f7105887451) eduli.src: update hash change with fetchzip update
* [`742dfb63`](https://github.com/NixOS/nixpkgs/commit/742dfb63ae8e17dd51a5090bf5f1b1d56a61498a) haskellPackages.lvmrun: mark as proken
* [`c078673f`](https://github.com/NixOS/nixpkgs/commit/c078673f07aa272309bb6d26902c5d92d25be8eb) hyperledger-fabric: 1.3.0 -> 2.4.3
* [`6920e6d3`](https://github.com/NixOS/nixpkgs/commit/6920e6d3474e5751f8929f495d43d9a0800dca64) f2fs-tools: 1.14.0 -> 1.15.0
* [`5f46ce46`](https://github.com/NixOS/nixpkgs/commit/5f46ce46b3a56485947f06541c048ad596c2885b) vmware-workstation: remove shipped fonts.conf
* [`aa095641`](https://github.com/NixOS/nixpkgs/commit/aa0956415eec884de67f76c34e4048691e9734dc) fpm2: 0.79 -> 0.90
* [`a0c9b8b4`](https://github.com/NixOS/nixpkgs/commit/a0c9b8b4fae3e56c1ed7ae6a45d5a3979aca763b) gnome.nautilus-python: add -fcommon workaround
* [`6449d45e`](https://github.com/NixOS/nixpkgs/commit/6449d45e25661722127fd19819992201c15b79ee) Delete unused release-notes.xml
* [`9a41cd62`](https://github.com/NixOS/nixpkgs/commit/9a41cd6236b46ec45670b6c905fc9ebb0b265547) mkvtoolnix: 67.0.0 -> 68.0.0
* [`9b015b6c`](https://github.com/NixOS/nixpkgs/commit/9b015b6c16ae725e1b092fc2dfb61db4962a1aad) nodePackages: add aws-cdk
* [`806da9d0`](https://github.com/NixOS/nixpkgs/commit/806da9d0294aab969c705a793b574a9f0fc4e9ab) v8_8_x: use python39
* [`6be823dd`](https://github.com/NixOS/nixpkgs/commit/6be823dd77ecd67bc335c272b6892bb5d7e24d7b) youtube-dl: fallback to throttled downloads instead of aborting
* [`e8573094`](https://github.com/NixOS/nixpkgs/commit/e8573094f3495d29790b6e8761b70ba2cf31a32c) matrix-commander: 2.30.0 -> 2.36.0
* [`ad5243d9`](https://github.com/NixOS/nixpkgs/commit/ad5243d94041b3618c10f51833e7e9e68f45a673) smpeg: 390 -> 0.4.5
* [`60988fb9`](https://github.com/NixOS/nixpkgs/commit/60988fb96b2143bcea11379def67463e70d4ed24) zettlr: 2.2.6 -> 2.3.0
* [`739ab383`](https://github.com/NixOS/nixpkgs/commit/739ab383a5f99fe7cd9bbc9ef8f0f6ff51e8c290) coq_8_13.src, coq_8_14.src, coq_8_15.src: update hash change with fetchzip update
* [`6095bc6e`](https://github.com/NixOS/nixpkgs/commit/6095bc6eb2d3ee94f804d8f6385afe43757dbb77) appimageTools.wrapAppImage: default produced derivations to sourceProvenance binaryNativeCode
* [`3da65d09`](https://github.com/NixOS/nixpkgs/commit/3da65d0955d2e5d76ee9d7e24ada9e6fc86ea60a) smpeg2: unstable-2017-10-18 -> unstable-2022-05-26
* [`6a7744bc`](https://github.com/NixOS/nixpkgs/commit/6a7744bc4166eb65ea9d606582ec55c345118c66) haskellPackages.jsaddle-warp: no longer broken
* [`4c05d15a`](https://github.com/NixOS/nixpkgs/commit/4c05d15a08b4a600743287b742d3a88f256fdc5b) colorpanes: init at 3.0.1
* [`5ed49441`](https://github.com/NixOS/nixpkgs/commit/5ed4944130468764f705fcc600bea923223252ec) fetchgit: allow passing allowedRequisites through to stdenv.mkDerivation
* [`92775fc6`](https://github.com/NixOS/nixpkgs/commit/92775fc62fe541d780d89877345e4cb07637132c) rapidjson: run tests
* [`11cc18cd`](https://github.com/NixOS/nixpkgs/commit/11cc18cddd0a1c7aa7c5e008b91696ed8ac5a04e) python310Packages.python-rapidjson: unvendor rapidjson
* [`80798d3a`](https://github.com/NixOS/nixpkgs/commit/80798d3a6d0ca9b4105ba43e9a92c6de599199c9) certbot: 1.24.0 -> 1.28.0
* [`49f69d19`](https://github.com/NixOS/nixpkgs/commit/49f69d198833b2ad0f46d1c9a0ddba48f7df04f1) rust-cbindgen: 0.24.2 -> 0.24.3
* [`515b36c0`](https://github.com/NixOS/nixpkgs/commit/515b36c0939b2fd96072eef7e58722900218897b) nixos/i18n: don't build all supportedLocales by default
* [`63576fb5`](https://github.com/NixOS/nixpkgs/commit/63576fb5c33a3e7cb2d826799f17cc336bafab9a) awsebcli: fixup, use python.pkgs.six from nixpkgs
* [`ae2cdd7c`](https://github.com/NixOS/nixpkgs/commit/ae2cdd7ca482f1039349ab799a5aa8c2e6279ad0) brig: use buildGoModule
* [`0af7e9c4`](https://github.com/NixOS/nixpkgs/commit/0af7e9c4075119bd0b9e2c912604c2ab084dd99f) Revert "nss: 3.68.4 -> 3.79"
* [`08f841f0`](https://github.com/NixOS/nixpkgs/commit/08f841f03d45c9858789940ec9267cfc1df5f828) asmfmt: use buildGoModule
* [`e90ede62`](https://github.com/NixOS/nixpkgs/commit/e90ede62f2fce749887f980fd2a99cff6e7e6ce7) go-check: 2018-09-12 -> unstable-2018-12-24
* [`7f0406a1`](https://github.com/NixOS/nixpkgs/commit/7f0406a183c11e0c9ecf529627b13d3abb47893d) ineffassign: 2018-09-09 -> unstable-2021-09-04
* [`9a373323`](https://github.com/NixOS/nixpkgs/commit/9a373323142ad35737ab74fa7b29d4fa6ccf0542) maligned: 2018-07-07 -> unstable-2022-02-04
* [`f6281356`](https://github.com/NixOS/nixpkgs/commit/f6281356b46526e11c47ed3240ed733fdac81e59) elfinfo: use buildGoModule
* [`208af5a5`](https://github.com/NixOS/nixpkgs/commit/208af5a5995a7c5ab8d8e6148bd1bc88e5eb941c) arm-trusted-firmware: 2.6 -> 2.7
* [`faacc88c`](https://github.com/NixOS/nixpkgs/commit/faacc88c93086982e2c95708176863f415e03810) munge: fix cross compilation
* [`9ca889d0`](https://github.com/NixOS/nixpkgs/commit/9ca889d0fb951356f7ad6b41f95f978a8bff8268) nixos/pantheon: switch to xdg.mime.enable
* [`c1559a07`](https://github.com/NixOS/nixpkgs/commit/c1559a07fe071d2c3bae13042bd16a3b7a8ca0f3) nixos/pantheon: switch to xdg.icons.enable
* [`1097e3e8`](https://github.com/NixOS/nixpkgs/commit/1097e3e80c41b9da193cd0b290735d4cd76c4f78) nixos/pantheon: make it possible to remove core packages
* [`aedd39d8`](https://github.com/NixOS/nixpkgs/commit/aedd39d86911adb45ea06fa0bb8153282f37c0b3) archivebox: update Django to 3.1.14
* [`067314d8`](https://github.com/NixOS/nixpkgs/commit/067314d87fef67f713a06b64042da4e7442c851f) archivebox: mark insecure
* [`860781d9`](https://github.com/NixOS/nixpkgs/commit/860781d909d3119b32619d8135598bc40816ab15) nixos/pantheon: allow disabling pantheon-agent-geoclue2
* [`2375fac9`](https://github.com/NixOS/nixpkgs/commit/2375fac93dfbf47bc2d0e7679c38fa0154b6a3db) nixos/pantheon: treat evince and file-roller as optional app
* [`a3f25678`](https://github.com/NixOS/nixpkgs/commit/a3f2567847712d1139c06319a7b83bc8f0b899d2) libinput: 1.20.1 -> 1.21.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
