### PR TITLE
niv emacs-overlay: update d215a555 -> 79d813d9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d215a5555c8f3856707c25a74136e51f6137a9fb",
-        "sha256": "0lgz7bfyrm3wp1il8bh6b9yx127lkds3jf438zcay2f45h4lpbdh",
+        "rev": "79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb",
+        "sha256": "1y9l50iy7yyl6xlar261dpsjmgybvraw59ln42fa9xi25vmfvja5",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/d215a5555c8f3856707c25a74136e51f6137a9fb.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@d215a555...79d813d9](https://github.com/nix-community/emacs-overlay/compare/d215a5555c8f3856707c25a74136e51f6137a9fb...79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb)

* [`f3d640d3`](https://github.com/nix-community/emacs-overlay/commit/f3d640d30a09ce6541b2bc3674b2657f36a65405) hydra: bump NixOS stable to 22.05
* [`c01153a2`](https://github.com/nix-community/emacs-overlay/commit/c01153a2c5ddd6e619ca46d62392188f9727ad74) Updated repos/melpa
* [`25ce68a5`](https://github.com/nix-community/emacs-overlay/commit/25ce68a5d0f177f1cc68f48376ee180dc0f9f292) Updated repos/nongnu
* [`b2b9d161`](https://github.com/nix-community/emacs-overlay/commit/b2b9d161af7a2548a9b27b0ba84c2322d99cad6f) Updated repos/emacs
* [`859fbd89`](https://github.com/nix-community/emacs-overlay/commit/859fbd8964ae5605e44020a559d73905f1e1cfa5) Updated repos/melpa
* [`548765ed`](https://github.com/nix-community/emacs-overlay/commit/548765ed9fe91add03a1cf979a6f059a7d22db91) Updated repos/elpa
* [`fcf2dc7a`](https://github.com/nix-community/emacs-overlay/commit/fcf2dc7ae6904a0f385944cb4c123b08f97aa93f) Updated repos/emacs
* [`8eeb6d7e`](https://github.com/nix-community/emacs-overlay/commit/8eeb6d7e922c7b4dcdc87cfa9ff07c1d6ff758e5) Updated repos/melpa
* [`fdc3c01c`](https://github.com/nix-community/emacs-overlay/commit/fdc3c01cfe02fd4f1bfa1281df62afe45689833c) Updated repos/emacs
* [`a19d1737`](https://github.com/nix-community/emacs-overlay/commit/a19d1737147d29272a5cf85a242637712feb98ce) Updated repos/melpa
* [`5a16283b`](https://github.com/nix-community/emacs-overlay/commit/5a16283b229aa4e7403a35b01ef2cc538c33dc03) Updated repos/nongnu
* [`e876750d`](https://github.com/nix-community/emacs-overlay/commit/e876750dd82d565aac1615dfd3bd70b87ca3ef5b) Updated repos/elpa
* [`b7e007a2`](https://github.com/nix-community/emacs-overlay/commit/b7e007a2d32608c2b5682f51386013c3cc9b8e71) Updated repos/emacs
* [`893dd21b`](https://github.com/nix-community/emacs-overlay/commit/893dd21b75f93df959520b3f5095bffa146167a2) Updated repos/melpa
* [`17e3e99f`](https://github.com/nix-community/emacs-overlay/commit/17e3e99f661dc86469e7cfd5464f3e1fc142ec86) Updated repos/emacs
* [`d1305b89`](https://github.com/nix-community/emacs-overlay/commit/d1305b892117b206057b5db0fea56049e1ec9317) Updated repos/melpa
* [`26da9a82`](https://github.com/nix-community/emacs-overlay/commit/26da9a82f2ba0cbd3b7a270130e9e4682852e5a1) Updated repos/emacs
* [`e53bba11`](https://github.com/nix-community/emacs-overlay/commit/e53bba119c56cb4983c84f41b24b8fc01a01b188) Updated repos/melpa
* [`e13e2885`](https://github.com/nix-community/emacs-overlay/commit/e13e288519b9f3bf19fb0a316d5cbfe22397cc1e) Updated repos/emacs
* [`270d5e91`](https://github.com/nix-community/emacs-overlay/commit/270d5e914b4c0425a4982cf585c91d6760e78777) Updated repos/melpa
* [`7aa427b6`](https://github.com/nix-community/emacs-overlay/commit/7aa427b6b5a1881c5652f732ae1070e9b20e333d) Updated repos/emacs
* [`e8aa04ea`](https://github.com/nix-community/emacs-overlay/commit/e8aa04eaa4cb8664a72191547fc2395dddd3c112) Updated repos/melpa
* [`26ad0149`](https://github.com/nix-community/emacs-overlay/commit/26ad0149865eba5f23d810561842a48418b89e21) Updated repos/emacs
* [`dd569be5`](https://github.com/nix-community/emacs-overlay/commit/dd569be57258f80a7d1ef924e6ae00323bd2319e) Updated repos/melpa
* [`5088e314`](https://github.com/nix-community/emacs-overlay/commit/5088e314c7345ecd26e925771e6c69eb315219c1) Updated repos/emacs
* [`0932726b`](https://github.com/nix-community/emacs-overlay/commit/0932726b94cff810d93d5c22194b1c776f4fc446) Updated repos/melpa
* [`b3245be1`](https://github.com/nix-community/emacs-overlay/commit/b3245be123189ba366ee912e06cf29ea92f4314d) Updated repos/emacs
* [`85c03984`](https://github.com/nix-community/emacs-overlay/commit/85c0398418b657c2c91ea8a52fcebca3e04529b5) Updated repos/melpa
* [`5da91d03`](https://github.com/nix-community/emacs-overlay/commit/5da91d039b31bd10042f35c338633eef07c09b5b) Updated repos/emacs
* [`24135029`](https://github.com/nix-community/emacs-overlay/commit/2413502909c9ff32604c8da8dcf337eda99ffef7) Updated repos/melpa
* [`81fa6278`](https://github.com/nix-community/emacs-overlay/commit/81fa62785545e776b5ec707a9a43a0128638b76c) Updated repos/emacs
* [`0293f149`](https://github.com/nix-community/emacs-overlay/commit/0293f1492cb21e8be1927e2c9fefee1ac14f2953) Updated repos/melpa
* [`12301920`](https://github.com/nix-community/emacs-overlay/commit/12301920ca40ada85da73ca6327b6ac6b31a90d2) Updated repos/emacs
* [`6f959937`](https://github.com/nix-community/emacs-overlay/commit/6f9599378424d762738ee8b84a9d6faad186e6f2) Updated repos/melpa
* [`ff03d5bf`](https://github.com/nix-community/emacs-overlay/commit/ff03d5bf3ba83b83785b12bed6580b7923a226e6) Updated repos/nongnu
* [`5417995e`](https://github.com/nix-community/emacs-overlay/commit/5417995e83c09e2d5676b9d8d561a7002bb19f89) Updated repos/emacs
* [`33aa3a6a`](https://github.com/nix-community/emacs-overlay/commit/33aa3a6ae65fd52b6566676b9e5a06308a5ff66c) Updated repos/melpa
* [`194fbad1`](https://github.com/nix-community/emacs-overlay/commit/194fbad11f17b917206600c71174a8df2bdc45f1) Updated repos/emacs
* [`4392cba3`](https://github.com/nix-community/emacs-overlay/commit/4392cba3b33ef8abc1a9c007fc58a6ce86cf0ea1) Updated repos/melpa
* [`d89df4f4`](https://github.com/nix-community/emacs-overlay/commit/d89df4f41f082b0f0f18cd6423838075b35bf71e) Updated repos/elpa
* [`18394ec4`](https://github.com/nix-community/emacs-overlay/commit/18394ec4cc2e7e0e9f59285c6d89870b42b4489c) Updated repos/emacs
* [`7a4d53af`](https://github.com/nix-community/emacs-overlay/commit/7a4d53afd3720e21429533faf38e2ceb9c4cab46) Updated repos/melpa
* [`8f7cb5e6`](https://github.com/nix-community/emacs-overlay/commit/8f7cb5e606f470e436c5154bb4707b39d3e3b7a0) Updated repos/emacs
* [`c81997f4`](https://github.com/nix-community/emacs-overlay/commit/c81997f4e0365136ae3ba784c273046504e23b40) Updated repos/melpa
* [`92bd82ae`](https://github.com/nix-community/emacs-overlay/commit/92bd82ae2d68ddad74c61f07be7fabece7784587) Updated repos/nongnu
* [`d528c7aa`](https://github.com/nix-community/emacs-overlay/commit/d528c7aa178dd633c8a8139326a76a3b0c39a1dd) Updated repos/elpa
* [`b1e8ac1b`](https://github.com/nix-community/emacs-overlay/commit/b1e8ac1b6fe878e68ab59b117aabefd9f95263be) Updated repos/emacs
* [`145e2a2a`](https://github.com/nix-community/emacs-overlay/commit/145e2a2a16a8faea0986c8bc87047bb15aa2c47b) Updated repos/melpa
* [`b3dd55eb`](https://github.com/nix-community/emacs-overlay/commit/b3dd55eb528c0fcd55cb90aed636731868315566) Updated repos/emacs
* [`07499461`](https://github.com/nix-community/emacs-overlay/commit/074994617bfbb72ce5fec3331c363b183383d292) Updated repos/melpa
* [`210aaf0c`](https://github.com/nix-community/emacs-overlay/commit/210aaf0c61a17258c5e3413d83ca16eb2fb7f10b) Updated repos/emacs
* [`24a3db32`](https://github.com/nix-community/emacs-overlay/commit/24a3db32a164c797e66f55270390f3ad69e3c8d3) Updated repos/melpa
* [`79c9e6de`](https://github.com/nix-community/emacs-overlay/commit/79c9e6debdd04c3c1bd48995b3d6ac4d5b66a1b6) Updated repos/emacs
* [`843a9505`](https://github.com/nix-community/emacs-overlay/commit/843a950588e33a0ef1451f255cc1558833e3e474) Updated repos/melpa
* [`8e49b716`](https://github.com/nix-community/emacs-overlay/commit/8e49b716d17218f022ee4d7dc9399ae7d76470a8) Updated repos/elpa
* [`6d33299d`](https://github.com/nix-community/emacs-overlay/commit/6d33299dbcfd4570bd1e34fd386c10b331168316) Updated repos/emacs
* [`c7be74d2`](https://github.com/nix-community/emacs-overlay/commit/c7be74d2119544f7bd293a225840b0b0179fa2ff) Updated repos/melpa
* [`dac7f9c2`](https://github.com/nix-community/emacs-overlay/commit/dac7f9c2f79983c14f0b9608379352217eb5d790) Updated repos/emacs
* [`e0d8cd14`](https://github.com/nix-community/emacs-overlay/commit/e0d8cd1477216ece946d472c51e15a27cacf6664) Updated repos/melpa
* [`b718923c`](https://github.com/nix-community/emacs-overlay/commit/b718923ccdd7da2e4d2e4df92cb9a9702c26a3bc) Updated repos/emacs
* [`78240ea4`](https://github.com/nix-community/emacs-overlay/commit/78240ea4b1211f0eacca7402786ec609c817d363) Updated repos/melpa
* [`374c706c`](https://github.com/nix-community/emacs-overlay/commit/374c706caf71199fed7738cc91cf116268a5607e) Updated repos/emacs
* [`4ce40e35`](https://github.com/nix-community/emacs-overlay/commit/4ce40e3561935b03956b91c188225b559312cee4) Updated repos/melpa
* [`64abec98`](https://github.com/nix-community/emacs-overlay/commit/64abec98203ed8a1f8fc5f46d350d7820d275b0e) Updated repos/emacs
* [`fe861d4a`](https://github.com/nix-community/emacs-overlay/commit/fe861d4aa31ca8f503209f88ece1b5b7584b8f65) Updated repos/melpa
* [`fcd4d53e`](https://github.com/nix-community/emacs-overlay/commit/fcd4d53ee222662823ae216fc5a09f7ad4f813d4) Updated repos/elpa
* [`87e7631f`](https://github.com/nix-community/emacs-overlay/commit/87e7631f72f6ed17ee1d362c9a544dd3cbcf132c) Updated repos/emacs
* [`c5fb32ef`](https://github.com/nix-community/emacs-overlay/commit/c5fb32efa5d3d44b9f36a994c2a0cedae80ab9ab) Updated repos/melpa
* [`7ad58251`](https://github.com/nix-community/emacs-overlay/commit/7ad582515e3360fdf7ef37c3d928fe2d2b0686ab) Updated repos/emacs
* [`5ee1edcc`](https://github.com/nix-community/emacs-overlay/commit/5ee1edccb43dcef50d25a53724987889eebf4c94) Updated repos/melpa
* [`e96ec54c`](https://github.com/nix-community/emacs-overlay/commit/e96ec54c1a392c0df11f8c746b273d6b875200f9) Updated repos/emacs
* [`0dccf4f1`](https://github.com/nix-community/emacs-overlay/commit/0dccf4f10b01b29f7af3b0ffefc696d5bfafc731) Updated repos/melpa
* [`a764f50d`](https://github.com/nix-community/emacs-overlay/commit/a764f50d7667f54e275ec1260de2f8d97b677525) Updated repos/nongnu
* [`808d5ffe`](https://github.com/nix-community/emacs-overlay/commit/808d5ffe30723f2b736b3dd8929f9af469c82c76) Updated repos/melpa
* [`80c41112`](https://github.com/nix-community/emacs-overlay/commit/80c41112392f35830f2053e09a2d558f5f3fa381) Updated repos/elpa
* [`a028c8e0`](https://github.com/nix-community/emacs-overlay/commit/a028c8e04f1667694b5c5d51f1baa095d6677cd4) Updated repos/emacs
* [`d8f91548`](https://github.com/nix-community/emacs-overlay/commit/d8f91548d9aaf62da467844f09398b2e4248886a) Updated repos/melpa
* [`8a7cd0f2`](https://github.com/nix-community/emacs-overlay/commit/8a7cd0f271457701b1f06a83261fb1953e679b58) Updated repos/melpa
* [`26468858`](https://github.com/nix-community/emacs-overlay/commit/26468858db48e2b2106385793e29a348c170bec9) Updated repos/emacs
* [`a04bc2fc`](https://github.com/nix-community/emacs-overlay/commit/a04bc2fc2b6bc9c1ba738cf8de3d33768d298c7c) Updated repos/melpa
* [`909379a2`](https://github.com/nix-community/emacs-overlay/commit/909379a2f93c43d61827a820b26f48a523ea0d5b) Updated repos/emacs
* [`057f91fc`](https://github.com/nix-community/emacs-overlay/commit/057f91fc4ed58b5deeb8319c82bdb0b737e952f0) Updated repos/melpa
* [`573e6a04`](https://github.com/nix-community/emacs-overlay/commit/573e6a044259f6aac1294ee116b43e53b4e81ef3) Updated repos/emacs
* [`606ab40c`](https://github.com/nix-community/emacs-overlay/commit/606ab40c7a24380418f1323de0b993d023014aa2) Updated repos/melpa
* [`7b39dfe5`](https://github.com/nix-community/emacs-overlay/commit/7b39dfe58ad07071ca8d7920dcd81049c73af6ce) Updated repos/elpa
* [`80990dc4`](https://github.com/nix-community/emacs-overlay/commit/80990dc4800a8960522039b658caeb1d7828c30c) Updated repos/emacs
* [`b9464569`](https://github.com/nix-community/emacs-overlay/commit/b9464569ca17c8b4942bea5f9531b78e01806782) Updated repos/melpa
* [`c58ddf28`](https://github.com/nix-community/emacs-overlay/commit/c58ddf28561b0a80a1c55e7db7ae459ab3da4cda) Updated repos/emacs
* [`a2aeb332`](https://github.com/nix-community/emacs-overlay/commit/a2aeb3322386afd899737cc2a7f62db08faf4dc1) Updated repos/melpa
* [`0e483f91`](https://github.com/nix-community/emacs-overlay/commit/0e483f91edc8db88de446b67fa57cf25e822f1ce) Updated repos/nongnu
* [`1f7f8644`](https://github.com/nix-community/emacs-overlay/commit/1f7f86443fcfee054dcb715642a4d6a933ca8981) Updated repos/emacs
* [`7ecd7b32`](https://github.com/nix-community/emacs-overlay/commit/7ecd7b32a5f6395d12c24ba7747c1763f08046ed) Updated repos/melpa
* [`29226125`](https://github.com/nix-community/emacs-overlay/commit/292261251e02a995ad6f37624391f73c07d6aabc) Updated repos/nongnu
* [`bb8ef5ae`](https://github.com/nix-community/emacs-overlay/commit/bb8ef5aed6896b337781217030a10c0c71e5da25) Updated repos/elpa
* [`a0ad4a6c`](https://github.com/nix-community/emacs-overlay/commit/a0ad4a6cbc3bc8e6ab7ce3fd6d95e8e42b3c4649) Updated repos/emacs
* [`1be20988`](https://github.com/nix-community/emacs-overlay/commit/1be2098861500d839711dcdd002c278ed2bdec49) Updated repos/melpa
* [`a1b5bc05`](https://github.com/nix-community/emacs-overlay/commit/a1b5bc059a9be9b35b31b75c7ccb89c4c7de16b0) Updated repos/emacs
* [`d6e0ee38`](https://github.com/nix-community/emacs-overlay/commit/d6e0ee3868a1b0f61f9a0016f167531a5319a98a) Updated repos/melpa
* [`79d813d9`](https://github.com/nix-community/emacs-overlay/commit/79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb) Updated repos/nongnu
