### PR TITLE
niv powerlevel10k: update 6b128d48 -> cf67cad4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "6b128d48d675509666ff222eb08922cc6a7b6753",
-        "sha256": "0wqqd9mdwnk1s4c3pdhrjakcifrd7zdkkjspq73wvdx7qmw6nfv4",
+        "rev": "cf67cad46557d57d5d2399e6d893c317126e037c",
+        "sha256": "109k9kj4xjjrdzkd44sm5cdm97d6i81ljfbkfxryj098g5yi3995",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/6b128d48d675509666ff222eb08922cc6a7b6753.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/cf67cad46557d57d5d2399e6d893c317126e037c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@6b128d48...cf67cad4](https://github.com/romkatv/powerlevel10k/compare/6b128d48d675509666ff222eb08922cc6a7b6753...cf67cad46557d57d5d2399e6d893c317126e037c)

* [`19bcd379`](https://github.com/romkatv/powerlevel10k/commit/19bcd37935a7d8684304cccd9d6b4ca06c343339) Add Fig as an installation method to the README
* [`0bef490c`](https://github.com/romkatv/powerlevel10k/commit/0bef490cdaedd992a27a50e14d536c4a795ebc2d) replace fig ads with installation instructions
* [`0c197ed4`](https://github.com/romkatv/powerlevel10k/commit/0c197ed4a51e10ed613e48a080f23b1ee7968006) battery plugin: Support Linux on Librem5 phone
* [`cf67cad4`](https://github.com/romkatv/powerlevel10k/commit/cf67cad46557d57d5d2399e6d893c317126e037c) fix the UNICODE code point for powerline "branch" icon in comments ([romkatv/powerlevel10k⁠#1911](https://togithub.com/romkatv/powerlevel10k/issues/1911))
