### PR TITLE
niv spacemacs: update e75e925e -> c9db0284

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "e75e925e3727136c5e1ef51fdd725c72c5f10b9b",
-        "sha256": "17z7ibc9w55fgjma6f22kc7sq45rjpg60b5w75vzrbcl8j58kclv",
+        "rev": "c9db028421a74eb8339152ae3c2fe694dc322216",
+        "sha256": "1h5vglj1rq91ihmwzjs75hhkdb1p7cap8z1dzy91nlim2pzvxly7",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/e75e925e3727136c5e1ef51fdd725c72c5f10b9b.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/c9db028421a74eb8339152ae3c2fe694dc322216.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@e75e925e...c9db0284](https://github.com/syl20bnr/spacemacs/compare/e75e925e3727136c5e1ef51fdd725c72c5f10b9b...c9db028421a74eb8339152ae3c2fe694dc322216)

* [`22eaeb8e`](https://github.com/syl20bnr/spacemacs/commit/22eaeb8ef2e1c90a953ff7ba172aa1654af167d0) [core] fix functions missed for byte-compiled core-spacemacs-buffer.el
* [`44894c71`](https://github.com/syl20bnr/spacemacs/commit/44894c7132e9853d86ab1a8088b91f903954f04d) [git] Fix forge warning
* [`03f0ce75`](https://github.com/syl20bnr/spacemacs/commit/03f0ce75f7e0a091ff85cea116661031dd7c0408) go: add variable to allow selection of new dap-dlv-mode
* [`07a08813`](https://github.com/syl20bnr/spacemacs/commit/07a08813240ba1764fca3804b66dc721f6ecdd3c) [go] Revise support for multiple dap integrations
* [`8eb1ebfa`](https://github.com/syl20bnr/spacemacs/commit/8eb1ebfa6b7b82ac2b54b1f8119dc7192717ab12) [go] Fix issues in README
* [`9c44ecf1`](https://github.com/syl20bnr/spacemacs/commit/9c44ecf13cc7f5ed1ac71a7e7ead0f06b13b42f3) [bot] "documentation_updates" Fri Jun 17 15:35:54 UTC 2022
* [`ee95121e`](https://github.com/syl20bnr/spacemacs/commit/ee95121e6bd3deb139cb724a389a2e2e28e4ece6) [helm] Fix dangerous implementation for helm-use-fuzzy
* [`ebd920e2`](https://github.com/syl20bnr/spacemacs/commit/ebd920e23a287eacf0a42ff0e3eef4b2db95d3dd) Delete vim-empty-lines layer and merge its code into spacemacs-evil
* [`cb09f57c`](https://github.com/syl20bnr/spacemacs/commit/cb09f57cf7a5e153c5209a499ce83d12177a464a) Revise vim-empty-lines integration into spacemacs-evil
* [`31ccdca0`](https://github.com/syl20bnr/spacemacs/commit/31ccdca0970e61084e3bb6f0ba5ae7aa318c4395) [core] Fix wrong type for "dotspacemacs-startup-banner-scale"
* [`e74610dd`](https://github.com/syl20bnr/spacemacs/commit/e74610ddb50818ee11b496d5f7f883b882cee1c0) [python] fix config issue for native-comp
* [`fbe05e3e`](https://github.com/syl20bnr/spacemacs/commit/fbe05e3e087a879059b3a14a3d340cb60fec06d8) [core] fix error msg from byte-compiling core-configuration-layer.el
* [`48a8599c`](https://github.com/syl20bnr/spacemacs/commit/48a8599cbe76f6ad352a3968b67a72945ae95079) [finance] Fix void-variable ledger-report-mode-map
* [`4eaff252`](https://github.com/syl20bnr/spacemacs/commit/4eaff25268634fcb8137b91fb7d0b7598588cbca) [git] Disable evil-surround-mode in all magit modes
* [`af530454`](https://github.com/syl20bnr/spacemacs/commit/af53045448ed16bc799877c327dcfe8c7a872fe6) [git] Remove magit-git-executable hack, which is no longer needed
* [`c9db0284`](https://github.com/syl20bnr/spacemacs/commit/c9db028421a74eb8339152ae3c2fe694dc322216) [defaults] Exclude `custom-file` correctly in recentf
