### PR TITLE
niv zsh-completions: update 2e3c3f6c -> 07c37ce8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "2e3c3f6cf06bfdf0adf96a5b67f1eff2d67d85de",
-        "sha256": "10fnsjgwrsipncgrnn2anx945pz6dkk1yhrila8imc8cbnx8m5rx",
+        "rev": "07c37ce8c43a67e4214cc2023ef92b42e2a825a8",
+        "sha256": "1w12pq5gjdra53q0lq4kk3y32nm8lzg3x30d70fk0m3fzn4c8mix",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/2e3c3f6cf06bfdf0adf96a5b67f1eff2d67d85de.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/07c37ce8c43a67e4214cc2023ef92b42e2a825a8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@2e3c3f6c...07c37ce8](https://github.com/zsh-users/zsh-completions/compare/2e3c3f6cf06bfdf0adf96a5b67f1eff2d67d85de...07c37ce8c43a67e4214cc2023ef92b42e2a825a8)

* [`63d333ce`](https://github.com/zsh-users/zsh-completions/commit/63d333ce8845af99ab798850eafbc69ce9e66c5a) Update to flutter3
* [`28ef391e`](https://github.com/zsh-users/zsh-completions/commit/28ef391e35d977d044c9d7c57e5246c384381403) Add Fig as an installation method to the README
* [`45cb3bec`](https://github.com/zsh-users/zsh-completions/commit/45cb3becd8ca388505910a6cc6917c07b3aee4a9) Revert "Merge pull request [zsh-users/zsh-completions⁠#868](https://togithub.com/zsh-users/zsh-completions/issues/868) from ibayramli2001/fig"
* [`6f407f52`](https://github.com/zsh-users/zsh-completions/commit/6f407f52877845cac5b7305bbc8066cb50203118) update completions for 1.18
* [`af030b38`](https://github.com/zsh-users/zsh-completions/commit/af030b381f433ae20104381f1f8d0f8f04230bc8) fix typos
* [`bacf79fc`](https://github.com/zsh-users/zsh-completions/commit/bacf79fc34f665fe3a4c81e5d1349b074d658e7c) Update tox options
* [`fc517dd8`](https://github.com/zsh-users/zsh-completions/commit/fc517dd8ad64accc217e44f977e2b8050c84b46a) Update httpie completion
