### PR TITLE
niv nixpkgs: update 576bc65c -> ef3fe254

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "576bc65c5ac542d2b9f17e9332fd778e31cc583c",
-        "sha256": "16mlyawmpkvhpb6qgz0kkmjyhm416dfzx0vfw1cvd4yz6d6icjsl",
+        "rev": "ef3fe254f3c59455386bc92fe84164f9679b92b1",
+        "sha256": "0zk3b4qwjzjh3ih91f1lq176jypqsj9c5radlq1csjigg93m8k8g",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/576bc65c5ac542d2b9f17e9332fd778e31cc583c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ef3fe254f3c59455386bc92fe84164f9679b92b1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@576bc65c...ef3fe254](https://github.com/nixos/nixpkgs/compare/576bc65c5ac542d2b9f17e9332fd778e31cc583c...ef3fe254f3c59455386bc92fe84164f9679b92b1)

* [`4400063c`](https://github.com/NixOS/nixpkgs/commit/4400063cfa87247a6167c1c84100f996ab969b1f) delayarchitect: init at unstable-2022-01-16
* [`d011ca20`](https://github.com/NixOS/nixpkgs/commit/d011ca205fdd40828186d196cc1a678638687211) jupyter-kernel: Link extraPaths
* [`5536b561`](https://github.com/NixOS/nixpkgs/commit/5536b56135a3d2909651535b7b66ecad2dd8f882) nixos/jupyter: Add kernels.<name>.extraPaths option
* [`9a409fc5`](https://github.com/NixOS/nixpkgs/commit/9a409fc5028fa1fc3e448383c08a375b8cb35d66) sage: link doc in jupyter kernel
* [`d85989da`](https://github.com/NixOS/nixpkgs/commit/d85989da311dbad712b17e084bd235eba8975503) ocamlPackages.fmt: 0.8.9 -> 0.9.0
* [`86c902d6`](https://github.com/NixOS/nixpkgs/commit/86c902d67374a83d54f0bfabab67951e8e312d69) fetchurl: Introduce curlOptsList as an improvement over curlOpts
* [`b4047049`](https://github.com/NixOS/nixpkgs/commit/b404704911f2e3d078d5d0287006bbe263167202) factorio: Use curlOptsList to fix warning
* [`245cbd78`](https://github.com/NixOS/nixpkgs/commit/245cbd783ab65ee8a0ed28294e7f991ff071e824) remarkable-mouse: 7.0.1 -> 7.0.2
* [`2a341bd2`](https://github.com/NixOS/nixpkgs/commit/2a341bd2f4c202781c118b46c6ecde75a2935e7e) nixos/filesystems/zfs: Escape dataset names
* [`d1754b1a`](https://github.com/NixOS/nixpkgs/commit/d1754b1ab08027265ff7dec1148eebcc6e128080) nixos/filesystems/zfs: Use proper script mode
* [`69267309`](https://github.com/NixOS/nixpkgs/commit/69267309a727c4700f2e13a59b1dcc5a76db2c98) lsp-plugins: 1.1.31 -> 1.2.1
* [`4eb9c577`](https://github.com/NixOS/nixpkgs/commit/4eb9c577b7296f37ab35067979c29f3c76c4edb4) perlPackages.AWSSignature4: init at 1.02
* [`7d1458b6`](https://github.com/NixOS/nixpkgs/commit/7d1458b6b6385d0e29a911622a41e17ea514b1cc) batsignal: 1.3.5 -> 1.5.0
* [`49396154`](https://github.com/NixOS/nixpkgs/commit/493961541da8dbab36862acd580eb63e5c051e04) airwindows-lv2: 1.0 -> 5.0
* [`fd3fc309`](https://github.com/NixOS/nixpkgs/commit/fd3fc309f462895a662929ed71aeceabeefe9eed) nixos/doc: explain how to run appimages
* [`a0c1511d`](https://github.com/NixOS/nixpkgs/commit/a0c1511d86ad609f3814f2a4d086fd276e49505d) tmuxPlugins.gruvbox: unstable-2019-05-05 -> unstable-2022-04-19
* [`2d92bf2a`](https://github.com/NixOS/nixpkgs/commit/2d92bf2a3c731998a72bf8333a0768f38a33c0e7) audible-cli: 0.1.3 -> 0.2.0
* [`4f0cf3d6`](https://github.com/NixOS/nixpkgs/commit/4f0cf3d6787d0062634521b68841fd4f34b7efe5) rex: init at 1.13.4
* [`3ff92453`](https://github.com/NixOS/nixpkgs/commit/3ff9245301a38b3e2cd344e3296e724b9dc95e40) lib.formats.keyValue: init
* [`e6ca30b1`](https://github.com/NixOS/nixpkgs/commit/e6ca30b1bd0fd5665a18255e116f58282759545a) orchis-theme: 2022-05-01 -> 2022-05-29
* [`0d2842a4`](https://github.com/NixOS/nixpkgs/commit/0d2842a4353f55eb2fc79ec7ad6490c1f5a2b88e) formats.keyValue: add tests
* [`21738df6`](https://github.com/NixOS/nixpkgs/commit/21738df66b20c274118395cd63460097b0a3e8fd) mattermost: 6.3.6 -> 7.0.0
* [`ad439443`](https://github.com/NixOS/nixpkgs/commit/ad439443f11aeeff9a63171b604bd8dc6d78321d) mmctl: 6.4.2 -> 7.0.0
* [`a746fa43`](https://github.com/NixOS/nixpkgs/commit/a746fa431d4a5c81caeaac30cbc7bd250c33365a) kicad: 6.0.5 -> 6.0.6
* [`6a66c082`](https://github.com/NixOS/nixpkgs/commit/6a66c0822235c02da517ad849c9627e52d8fb3b8) kicad-unstable: 2022-05-06 -> 2022-06-21
* [`eeb657a9`](https://github.com/NixOS/nixpkgs/commit/eeb657a96be67fdaff92d53e9920323659fd7a69) pythonPackages.keyring: depend on dbus-python on Linux
* [`ea7336a0`](https://github.com/NixOS/nixpkgs/commit/ea7336a084a37d99548781ddeb4de41f394ca3f1) nixops_unstable: set Python interpreter to python39
* [`fce17bf6`](https://github.com/NixOS/nixpkgs/commit/fce17bf68bb5706a78adf6f8ed3770e245a3a6eb) nixops_unstable: update lock file
* [`c750d488`](https://github.com/NixOS/nixpkgs/commit/c750d488035c9dc234523f3b5e62575cb784124c) mattermost: 7.0.0 -> 7.0.1
* [`09724b15`](https://github.com/NixOS/nixpkgs/commit/09724b15170081415c1559dc4508584b4de61b42) mmctl: 7.0.0 -> 7.0.1
* [`6cc57b00`](https://github.com/NixOS/nixpkgs/commit/6cc57b007b346146471df8396465264bb6c85c10) birdfont: 2.30.0 -> 2.32.0
* [`348904a0`](https://github.com/NixOS/nixpkgs/commit/348904a00454b5889c2d5438b807a9236bde72c6) alfaview: 8.45.0 -> 8.47.0
* [`f025b234`](https://github.com/NixOS/nixpkgs/commit/f025b2340ba4627cc731fb2db5eb44884f614d24) sage: depend on python3Packages.notebook
* [`4dbd2a12`](https://github.com/NixOS/nixpkgs/commit/4dbd2a12775a01df83f2471e68ce867de108ad90) amberol: 0.8.0 -> 0.8.1
* [`9165cba8`](https://github.com/NixOS/nixpkgs/commit/9165cba85ee4eaca13fdb39ce5772f2f7133ba6b) bluejeans-gui: 2.27.0.130 -> 2.29.1.3
* [`8d048edb`](https://github.com/NixOS/nixpkgs/commit/8d048edb7c93b148c37b279aae449747ba2ecd0b) pony-corral: 0.5.7 -> 0.6.0
* [`285970c3`](https://github.com/NixOS/nixpkgs/commit/285970c35f383aa46f41e382042095e7a208dd08) flacon: 9.0.0 -> 9.1.0
* [`433961e2`](https://github.com/NixOS/nixpkgs/commit/433961e2b5f32ee83732fbbe4764135ab339f0c4) megasync: 4.6.5.0 -> 4.6.7.0
* [`83aaee54`](https://github.com/NixOS/nixpkgs/commit/83aaee5434a6e26327b0e6ee99ddc1a2a398adbc) flat-remix-gtk: 20220427 -> 20220527
* [`e2633217`](https://github.com/NixOS/nixpkgs/commit/e2633217affc4f2e7a1664ccae111f96caeae4d9) flat-remix-icon-theme: 20220304 -> 20220525
* [`1d00e386`](https://github.com/NixOS/nixpkgs/commit/1d00e3862c8b4fd7cac0b49d02102d40038e5804) featherpad: 1.2.0 -> 1.3.0
* [`479d8f4f`](https://github.com/NixOS/nixpkgs/commit/479d8f4fd82b042627d2e6b7e9ffacdcf32b7a6f) qutebrowser: 2.5.1 -> 2.5.2
* [`f410db89`](https://github.com/NixOS/nixpkgs/commit/f410db89dc5ff01bd7718291468c8d712a54dc04) libime: 1.0.11 -> 1.0.12
* [`5416c7a0`](https://github.com/NixOS/nixpkgs/commit/5416c7a0ec311ad354735e7f9d0341e5ece47023) fcitx5: 5.0.16 -> 5.0.17
* [`0595b6c5`](https://github.com/NixOS/nixpkgs/commit/0595b6c5593572e269def36fd2346428084b970b) fcitx5-chinese-addons: 5.0.12 -> 5.0.13
* [`539920f3`](https://github.com/NixOS/nixpkgs/commit/539920f342fdeeeffc4b3513d27c55a7cd0c2ea2) fcitx5-gtk: 5.0.14 -> 5.0.15
* [`8eb59b31`](https://github.com/NixOS/nixpkgs/commit/8eb59b316568979febc227001257c016c32bca71) libsForQt5.fcitx5-qt: 5.0.12 -> 5.0.13
* [`75ca3807`](https://github.com/NixOS/nixpkgs/commit/75ca3807524e1ac806d15b802f90ed2c557921ae) fcitx5-unikey: 5.0.9 -> 5.0.10
* [`d18aeb63`](https://github.com/NixOS/nixpkgs/commit/d18aeb6351482911fc63cb086ca49d20acabc4d0) nixos/xfconf: init
* [`c4025efc`](https://github.com/NixOS/nixpkgs/commit/c4025efcc15a2e0940e9d98f350091e9396b92b7) wasynth: init at 0.10.0
* [`93fb6d19`](https://github.com/NixOS/nixpkgs/commit/93fb6d19ab349f2661e52b7d710f1cbeff9a65d5) schleuder: 4.0.2 -> 4.0.3
* [`69ca5c98`](https://github.com/NixOS/nixpkgs/commit/69ca5c9898b26c2063d0e8a4db013e4ba0548159) wasm-bindgen-cli: 0.2.80 -> 0.2.81
* [`40990c35`](https://github.com/NixOS/nixpkgs/commit/40990c35863d38ca49e5d3b136fdc33525699165) treewide: don't use utillinux alias
* [`162c51e8`](https://github.com/NixOS/nixpkgs/commit/162c51e86fe800eb3cc4e6b3de6645f7dbd34121) ocamlPackages.mirage-channel: 4.0.1 → 4.1.0
* [`5c21665b`](https://github.com/NixOS/nixpkgs/commit/5c21665ba8c0546bf0fdabd9da368f5e9f91c344) jellyfin-media-player: 1.7.0 -> 1.7.1
* [`de611c1c`](https://github.com/NixOS/nixpkgs/commit/de611c1c8196f7e3b7b09d766679343faf3f9ffd) sirula: unstable-2021-10-12 -> 1.0.0
* [`65b8af2a`](https://github.com/NixOS/nixpkgs/commit/65b8af2a7f3f6dcc050af17d0993ba256bece346) exim: 4.95 -> 4.96
* [`a53e0f65`](https://github.com/NixOS/nixpkgs/commit/a53e0f65ecff638b77174e951eb6ff5324c79986) arrterian.nix-env-selector: 1.0.7 -> 1.0.9
* [`be2b04c7`](https://github.com/NixOS/nixpkgs/commit/be2b04c7c282b123f3c04a1cdf747ae6233155b6) eamodio.gitlens: 12.0.7 -> 12.1.1
* [`84272aca`](https://github.com/NixOS/nixpkgs/commit/84272acac28848498149fd2611c08ed26068feb1) github.vscode-pull-request-github: 0.37.2022030309 -> 0.45.2022062709
* [`81c27ba2`](https://github.com/NixOS/nixpkgs/commit/81c27ba26056ff61ae2df33530ed576946504f9b) llvm-vs-code-extensions.vscode-clangd -> 0.1.15 -> 0.1.17
* [`7ce0d679`](https://github.com/NixOS/nixpkgs/commit/7ce0d6794405b94d11a8620f61ee7995e5543661) vscode-extensions.arcticicestudio.nord-visual-studio-code: 0.18.0 -> 0.19.0
* [`454cb7de`](https://github.com/NixOS/nixpkgs/commit/454cb7de87fb5213310be623185c7744c0cacdad) streetsidesoftware.code-spell-checker: 2.1.7 -> 2.2.5
* [`537dc78c`](https://github.com/NixOS/nixpkgs/commit/537dc78c73ebc06d1d863cd5370866391d1fb5c6) rizin: 0.3.4 -> 0.4.0
* [`236877bb`](https://github.com/NixOS/nixpkgs/commit/236877bbaa620c252db0678c6054467fecf16ed5) cutter: 2.0.5 -> 2.1.0
* [`0f136070`](https://github.com/NixOS/nixpkgs/commit/0f13607076326c35b1cba3d241d8a0e6840e9c20) unison: M2l -> M3
* [`7c3d4d3a`](https://github.com/NixOS/nixpkgs/commit/7c3d4d3af8e9319ccd2a74c31cf247b0fcd08bc2) bazel: 5.1.1 -> 5.2.0
* [`567bcc92`](https://github.com/NixOS/nixpkgs/commit/567bcc9216a31d4431784b844148ec2f9c2fc45a) k3s: 1.24.1+k3s1 -> 1.24.2+k3s1
* [`4f9fc50b`](https://github.com/NixOS/nixpkgs/commit/4f9fc50b1941b81119e28c850cf6cdb36e0aa741) tilt: 0.30.0 -> 0.30.4
* [`b6104eec`](https://github.com/NixOS/nixpkgs/commit/b6104eecad5ed414beda446b07a5fda272d17bca) eid-mw: 5.0.28 -> 5.1.4
* [`4684ff77`](https://github.com/NixOS/nixpkgs/commit/4684ff771e9433c83d642caf075cbeaa079d6aed) nixos/dictd: make dict use local server
* [`67496fc3`](https://github.com/NixOS/nixpkgs/commit/67496fc37c8f6d7fadef52df232f931d007cb29e) prisma-engines: 3.15.1 -> 4.0.0
* [`a7d864f0`](https://github.com/NixOS/nixpkgs/commit/a7d864f07c75a57e658684c05a664a165aad6ab0) nodePackages.prisma: 3.15.1 -> 4.0.0
* [`07ce509e`](https://github.com/NixOS/nixpkgs/commit/07ce509e9cac2bb61c06190b06cc3861336ab620) python310Packages.packageurl-python: 0.9.9 -> 0.10.0
* [`0cb24e2d`](https://github.com/NixOS/nixpkgs/commit/0cb24e2d32a82b447492e8fb9de43a019fd981e2) teensy-udev-rules: init at version 2022-05-15
* [`c070fba7`](https://github.com/NixOS/nixpkgs/commit/c070fba77fb9f03e3fa1015fb6502120a4dc5eea) pdftk: use regular jre
* [`92bde872`](https://github.com/NixOS/nixpkgs/commit/92bde872f7ceb1e85139b18eccb8ff0766fc2b72) python310Packages.safety: 1.10.3 -> 2.0.0
* [`90ea3117`](https://github.com/NixOS/nixpkgs/commit/90ea31176120ec417589d8e19b8212f268811800) arti: init at 0.5.0
* [`604a9086`](https://github.com/NixOS/nixpkgs/commit/604a9086940c2f438fdf45e4670e2c49f54539a3) ocamlPackages.mirage-console: 4.0.0 → 5.1.0
* [`bb8d6d0b`](https://github.com/NixOS/nixpkgs/commit/bb8d6d0bc6e636e1b5aff7c516455a2f976137e4) vim: 8.2.4975 -> 9.0.0001
* [`c8941fc6`](https://github.com/NixOS/nixpkgs/commit/c8941fc6c858e8f310c758e66f7a62d86ccb2fa7) zotero: 6.0.8 -> 6.0.9
* [`0a6483ce`](https://github.com/NixOS/nixpkgs/commit/0a6483ce41e2cb8a98e2faba6ff4c90da293c077) grafana: 9.0.1 -> 9.0.2
* [`9884fac5`](https://github.com/NixOS/nixpkgs/commit/9884fac5dfe81ce68ec788d56d7df472103a147c) lapce: 0.1.0 -> 0.1.2
* [`a5cb4532`](https://github.com/NixOS/nixpkgs/commit/a5cb45329edea6564149f63a031d5c07156292e8) thunderbird*: 91.11.0 -> 102.0
* [`4ecde975`](https://github.com/NixOS/nixpkgs/commit/4ecde975ea8b53f38561f1e6af73291a7eece23d) hilbish: 1.0.4 -> 1.2.0
* [`7a8c5414`](https://github.com/NixOS/nixpkgs/commit/7a8c541412ff6c714c06f4c8f953e0e250879a8b) nginxMainline: 1.22.0 -> 1.23.0
* [`ec443943`](https://github.com/NixOS/nixpkgs/commit/ec443943f5b3e96e704b8cdc69c1f300548cea35) nginxQuic: 5b1011b5702b -> 8d0753760546
* [`ccff32fa`](https://github.com/NixOS/nixpkgs/commit/ccff32fa91711f2c05b4f4b7ce80d2890690814a) nginxModules.moreheaders: v0.33 -> unstable-2022-06-21
* [`f169a1af`](https://github.com/NixOS/nixpkgs/commit/f169a1af97b28a0835e6447873ff7e4d5f4041db) nixos/tests: small update nginx-http3 test
* [`bc6a464c`](https://github.com/NixOS/nixpkgs/commit/bc6a464c32f22fc1f12c136d5b29a757594e9da3) nginx: build with pcre
* [`2ab459bd`](https://github.com/NixOS/nixpkgs/commit/2ab459bd9a7bec7c27a93ec23279b1bd660d3418) monoid: 2018-06-03 -> 2020-10-26
* [`4d62e9dd`](https://github.com/NixOS/nixpkgs/commit/4d62e9dd512ef60bff1c76e458d43882e85f1214) minikube: 1.25.2 -> 1.26.0
* [`d49c491b`](https://github.com/NixOS/nixpkgs/commit/d49c491b9ea7a6a6cff70347f310c5779b71230b) spicetify-cli: 2.10.1 -> 2.10.2
* [`f4aa10f8`](https://github.com/NixOS/nixpkgs/commit/f4aa10f82aec3727abf5c61347697f5f80113003) maintainers: add catap
* [`ccef4ede`](https://github.com/NixOS/nixpkgs/commit/ccef4edeaf5175edb5c6a9fa3f81c7d833fb69d5) python310Packages.sagemaker: 2.96.0 -> 2.97.0
* [`ba533129`](https://github.com/NixOS/nixpkgs/commit/ba533129002f7fc5974df424679c4a3a8d4d3520) python310Packages.sanic-testing: 22.3.0 -> 22.3.1
* [`07ca6845`](https://github.com/NixOS/nixpkgs/commit/07ca6845da48793e39bb4443f1f619f0442db40c) aws-sam-cli: relax overly-restrictive cookiecutter bound
* [`25473f79`](https://github.com/NixOS/nixpkgs/commit/25473f79481f0f9949618019cbd6334349d4de2e) python310Packages.multitasking: 0.0.10 -> 0.0.11
* [`133573bd`](https://github.com/NixOS/nixpkgs/commit/133573bd5b79abc728c41f111bb5fb29adf63cbc) pantheon.switchboard-plug-printers: 2.1.10 -> 2.2.0
* [`f7d9436e`](https://github.com/NixOS/nixpkgs/commit/f7d9436ead245b0a99c94155c8d20840ecfd9c9e) clojure-lsp: 2022.06.22-14.09.50 -> 2022.06.29-19.32.13
* [`e2649aef`](https://github.com/NixOS/nixpkgs/commit/e2649aef4e48696cc2eaef204a385649ec4c9444) python310Packages.pulumi-aws: 5.9.1 -> 5.9.2
* [`e22d80eb`](https://github.com/NixOS/nixpkgs/commit/e22d80eb77ed284e426f69644518def0d5915e81) ugrep: 3.8.2 -> 3.8.3
* [`ba1db2b2`](https://github.com/NixOS/nixpkgs/commit/ba1db2b2055358d42ea77f74c0958e91109c8fec) dsq: 0.20.2 -> 0.21.0
* [`3e2582c1`](https://github.com/NixOS/nixpkgs/commit/3e2582c14b53062bf83ef3dba8ac7374f4868cca) fluxcd: 0.31.2 -> 0.31.3
* [`873d7f1f`](https://github.com/NixOS/nixpkgs/commit/873d7f1f18e4a3e6689a210bc259ad863e387d3b) addlicense: 1.0.0 -> unstable-2021-04-22
* [`d12a3655`](https://github.com/NixOS/nixpkgs/commit/d12a36559b57c01d73066eb7960498a55e2d08dd) ipget: 0.8.1->0.9.1
* [`2c7fcab1`](https://github.com/NixOS/nixpkgs/commit/2c7fcab1ce3ff2d024713498475e18d260e8f887) lagrange: 1.13.6 -> 1.13.7
* [`89b90fe3`](https://github.com/NixOS/nixpkgs/commit/89b90fe3d1695d126990be52be9134a4c0a0b897) bookstack: 21.12 -> 22.06.2
* [`51267049`](https://github.com/NixOS/nixpkgs/commit/512670498f288c98279bfae0910a2811b9dd51e2) phylactery: init at 0.1.1
* [`81fe5f1b`](https://github.com/NixOS/nixpkgs/commit/81fe5f1b2f01e12874974b654bf51cdc01d32588) schleuder: allow running on aarch64-linux
* [`b091bae6`](https://github.com/NixOS/nixpkgs/commit/b091bae60a0fe244d38bb20f84fc0b86e6a29aa8) schleuder-cli: allow running on aarch64-linux
* [`a16bc445`](https://github.com/NixOS/nixpkgs/commit/a16bc44532bbfe8ae0b6c4c9098fb9619ad4599c) python310Packages.pglast: 3.12 -> 3.13
* [`d5720b7b`](https://github.com/NixOS/nixpkgs/commit/d5720b7be76fb6f292e596e9a644e7b25b3710ff) thunderbirdPackages: make thunderbird an alias to thunderbird-102
* [`d6b64a69`](https://github.com/NixOS/nixpkgs/commit/d6b64a69851d430b128ecbeaea714f5de283dc64) python310Packages.temescal: 0.3 -> 0.5
* [`bad5dfb4`](https://github.com/NixOS/nixpkgs/commit/bad5dfb4f6fec988116c49f6059f0dbefec16ced) pulumi-bin: 3.34.1 -> 3.35.2
* [`baa6fca6`](https://github.com/NixOS/nixpkgs/commit/baa6fca638c98cbec386c4c0ff4b397e2515f1df) nix-du: 0.5.1 -> 0.6.0
* [`41122605`](https://github.com/NixOS/nixpkgs/commit/411226059152365c13a94da80e70ef43178b7f5c) python310Packages.twilio: 7.9.3 -> 7.10.0
* [`783e2ef4`](https://github.com/NixOS/nixpkgs/commit/783e2ef46e9ec6639d914aa3f9ecd5cc6b812868) Revert "nix-prefetch-git: Fix inconsistency with fetchgit regarding deepClone"
* [`6ed6ef2e`](https://github.com/NixOS/nixpkgs/commit/6ed6ef2ea1b60edbf2f47932494b62c3486a7973) linux: 5.10.126 -> 5.10.127
* [`5a52c819`](https://github.com/NixOS/nixpkgs/commit/5a52c81969a9c8d6b32753adb0c2fe41e1379775) linux: 5.15.50 -> 5.15.51
* [`7c4567e0`](https://github.com/NixOS/nixpkgs/commit/7c4567e0d4bb5a54c3827ca95d1222ac5b5b39df) linux: 5.18.7 -> 5.18.8
* [`7b061f8e`](https://github.com/NixOS/nixpkgs/commit/7b061f8eb6de460c9622ad473f9ee4cc6efca8ee) linux: 5.4.201 -> 5.4.202
* [`02281899`](https://github.com/NixOS/nixpkgs/commit/02281899164fd848736c8ad278e25c98e76df85e) linux/hardened/patches/5.10: 5.10.125-hardened1 -> 5.10.127-hardened1
* [`362d5a56`](https://github.com/NixOS/nixpkgs/commit/362d5a564f3c2b8cf93ea33381ab86a9126cb8fa) linux/hardened/patches/5.15: 5.15.50-hardened1 -> 5.15.51-hardened1
* [`87f3f3ab`](https://github.com/NixOS/nixpkgs/commit/87f3f3ab17074e6e969ce0aa4425e792d076e311) linux/hardened/patches/5.18: 5.18.7-hardened1 -> 5.18.8-hardened1
* [`f8b452f1`](https://github.com/NixOS/nixpkgs/commit/f8b452f1278baa0530d354facfbcd7ead5a9f773) linux/hardened/patches/5.4: 5.4.201-hardened1 -> 5.4.202-hardened1
* [`6c8432f3`](https://github.com/NixOS/nixpkgs/commit/6c8432f34616100e7cdd60dc9eac2b86f26c6424) checkov: 2.1.16 -> 2.1.20
* [`e7f35074`](https://github.com/NixOS/nixpkgs/commit/e7f35074a20441009cc4b2301107e76a82b6c91a) python310Packages.hahomematic: 1.9.0 -> 1.9.1
* [`36634aa9`](https://github.com/NixOS/nixpkgs/commit/36634aa9d1ce6db3b351ea2c9c96f40fab76d452) python310Packages.motionblinds: 0.6.8 -> 0.6.10
* [`9e106c15`](https://github.com/NixOS/nixpkgs/commit/9e106c15a4be9d1ddd057ddf9c34851ffd76cf52) wesnoth: 1.16.1 -> 1.16.3
* [`13165465`](https://github.com/NixOS/nixpkgs/commit/1316546506ad0b591a0e782172abdbc12af349a5) neovim: 0.7.0 -> 0.7.2
* [`37b1b4ec`](https://github.com/NixOS/nixpkgs/commit/37b1b4ec6a48d17807e06e054a9d70b5b5449045) gosca: drop
* [`f6fb8628`](https://github.com/NixOS/nixpkgs/commit/f6fb8628f8ed4d0832dbbfc5fe2f7bcd90f86318) go-langserver: drop
* [`2b9ed9cf`](https://github.com/NixOS/nixpkgs/commit/2b9ed9cf28ab5c533993029b1f374174d46609f5) mynewt-newt: 1.7.0 -> 1.10.0
* [`64eb5ec8`](https://github.com/NixOS/nixpkgs/commit/64eb5ec86305e6547d5a7a37efda936584fbbafc) maintainer: add myself
* [`47d35130`](https://github.com/NixOS/nixpkgs/commit/47d35130e118eb160e967b505db9c3586e2be0cb) pngloss: init at unstable-2020-11-25
* [`78f355a1`](https://github.com/NixOS/nixpkgs/commit/78f355a11e163912ccab31079514aa3b55946599) davmail: 5.5.1 -> 6.0.1
* [`7727befa`](https://github.com/NixOS/nixpkgs/commit/7727befa4d5968d41cb7778d0abe0f5accdae77d) nrfconnect: init at 3.11.1
* [`f5f338c8`](https://github.com/NixOS/nixpkgs/commit/f5f338c8468a84b624980c2fd2cf2fa32d14741b) nixos/phylactery: init
* [`ce910fca`](https://github.com/NixOS/nixpkgs/commit/ce910fca8841061e86bfbfd15f8976132c2bfd78) nixos/tests: add phlactery
* [`461bdf0a`](https://github.com/NixOS/nixpkgs/commit/461bdf0a7abde1521d9a8ed5c19f57bd3d412126) lokinet: init at 0.9.9
* [`69e1e00e`](https://github.com/NixOS/nixpkgs/commit/69e1e00ebbdf40c1a1b2cc622f7e58aa927b4044) nixos/lokinet: init
* [`56c5f3f3`](https://github.com/NixOS/nixpkgs/commit/56c5f3f36672a71a00dc498cfbd90f1d9ff47ad2) python310Packages.cron-descriptor: 1.2.24 -> 1.2.27
* [`989565d6`](https://github.com/NixOS/nixpkgs/commit/989565d67661918799c6190a43db60590600dd01) cachix-agent: expose verbose option
* [`7e63d01a`](https://github.com/NixOS/nixpkgs/commit/7e63d01a23e9064ebfa5efd9b9393326bb208ad3) python310Packages.schwifty: 2022.6.2 -> 2022.6.3
* [`cb7ddc7f`](https://github.com/NixOS/nixpkgs/commit/cb7ddc7f34db03b4fc479df592c85b7176c85db2) signal-desktop: revert "Allow overriding the spell checker language ([nixos/nixpkgs⁠#44456](https://togithub.com/nixos/nixpkgs/issues/44456))"
* [`fc102563`](https://github.com/NixOS/nixpkgs/commit/fc102563a6d9631c69b3a6229be3c71e7b788212) hydra_unstable: 2022-06-16 -> 2022-06-30
* [`6724234f`](https://github.com/NixOS/nixpkgs/commit/6724234f2821eafed028c98501edb5a4bfdb9aa3) ocamlPackages.mirage-vnetif: 0.5.0 → 0.6.0
* [`c856c35f`](https://github.com/NixOS/nixpkgs/commit/c856c35fe9cc736ebab69027f2c2191d7dc2720d) python310Packages.hcloud: 1.16.0 -> 1.17.0
* [`e1ea5220`](https://github.com/NixOS/nixpkgs/commit/e1ea5220b49449c16cd04fa47047b19ecdb39036) protonvpn-gui: add glib-networking dependency
* [`0ccd98ca`](https://github.com/NixOS/nixpkgs/commit/0ccd98cae581613816aacdc0bb8ea3845cf9ca61) python310Packages.onetimepad: init at 1.4
* [`3ac24f48`](https://github.com/NixOS/nixpkgs/commit/3ac24f48357076ef5c823d550bf5c9118c03b969) python310Packages.pysqlitecipher: init at 0.22
* [`649c644b`](https://github.com/NixOS/nixpkgs/commit/649c644ba84193f8ef2ee12291a61296901cf457) banking: 0.4.0 -> 0.5.1
* [`588439e1`](https://github.com/NixOS/nixpkgs/commit/588439e1311c41a5779877d4d8ef603410b79cd4) fetchurl: Add curlOptsList test
* [`323b6dfb`](https://github.com/NixOS/nixpkgs/commit/323b6dfb62806caa4e02cc5fb007917ebdd49a27) python3Packages.simple-rlp: init at 0.1.2
* [`8771f95f`](https://github.com/NixOS/nixpkgs/commit/8771f95f71ffb6aecd67f5743467e0961844e0a9) python3Packages.trezor: 0.13.0 -> 0.13.2
* [`d80162d1`](https://github.com/NixOS/nixpkgs/commit/d80162d105e3665b1e2acb205a2acddad4135df1) solo2-cli: 0.1.1 -> 0.2.0
* [`e7d52cc2`](https://github.com/NixOS/nixpkgs/commit/e7d52cc26c5cbbfffa7dcedc7ab9b7ddff6bc234) scala-cli: 0.1.8 -> 0.1.9
* [`08173c03`](https://github.com/NixOS/nixpkgs/commit/08173c03f052fed9c71d1b58ff7106ae19d4c6d8) python310Packages.resampy: 0.2.2 -> 0.3.0
* [`a1ad66a4`](https://github.com/NixOS/nixpkgs/commit/a1ad66a4afa34b4517bd6adeb0812901271a5a58) vector: 0.22.2 -> 0.22.3
* [`e427ac59`](https://github.com/NixOS/nixpkgs/commit/e427ac5955f4b3abdc17636a80865b1b3fe720ae) ktunnel: init at 1.4.8
* [`ece1a9fe`](https://github.com/NixOS/nixpkgs/commit/ece1a9fe66e849dae0a081b38d08b9111acf0cd6) arandr: refactor derivation
* [`4387a866`](https://github.com/NixOS/nixpkgs/commit/4387a86646d5414c1172e3075a51561ccc7d35ea) libpg_query: not just for x86_64!
* [`30ab1697`](https://github.com/NixOS/nixpkgs/commit/30ab1697a9c4f08cefb845f1eb2438154ac8d7d4) python310Packages.resampy: switch to pytestCheckHook
* [`4dc5e4c9`](https://github.com/NixOS/nixpkgs/commit/4dc5e4c97e0748a5cb00ac42d628eadc45b04aa5) python310Packages.venstarcolortouch: 0.16 -> 0.17
* [`4abac2ba`](https://github.com/NixOS/nixpkgs/commit/4abac2ba6c471eda9e2f490261c0c46fdac791a8) python310Packages.qiskit-optimization: 0.3.2 -> 0.4.0
* [`cdcded8d`](https://github.com/NixOS/nixpkgs/commit/cdcded8d8c09cd62f32fd6890a2b93ffec2372db) python310Packages.textdistance: 4.2.2 -> 4.3.0
* [`eb94c5c5`](https://github.com/NixOS/nixpkgs/commit/eb94c5c57e08d41856d4ad9db496cb9213c16d94) python310Packages.traitsui: 7.3.1 -> 7.4.0
* [`b360ddc8`](https://github.com/NixOS/nixpkgs/commit/b360ddc88c87951161cb25e4d6f1fc9aa5da61fc) nushell: 0.63.0 -> 0.64.0
* [`51b2b750`](https://github.com/NixOS/nixpkgs/commit/51b2b750524b3f99e3a9a96a6950956f5b0e98ed) python310Packages.pikepdf: 5.1.5 -> 5.1.5.post1
* [`40b11c14`](https://github.com/NixOS/nixpkgs/commit/40b11c149bb4f2ffd6cba9ebb4fe5f96459fad1e) vopono: 0.9.1 -> 0.9.2
* [`1bf827d0`](https://github.com/NixOS/nixpkgs/commit/1bf827d026e8f4f31de1fb483f6d3b3df90a21c6) python310Packages.pykeepass: 4.0.2 -> 4.0.3
* [`04fcf7fc`](https://github.com/NixOS/nixpkgs/commit/04fcf7fcded8cf8f261ec61c1f9065f188bad4e5) passExtensions.pass-import: support pykeepass 4.0.3
* [`14f3b5b7`](https://github.com/NixOS/nixpkgs/commit/14f3b5b7dac1d2ed8d51cdd2e893a7a0d33fbdd8) megapixels: 1.4.3 -> 1.5.0
* [`f84a03ad`](https://github.com/NixOS/nixpkgs/commit/f84a03ad38b5996c74a7632cbde2880c79a41583) warp: 0.2.0 -> 0.2.1
* [`76928386`](https://github.com/NixOS/nixpkgs/commit/76928386b0141dffc95b50a1b64df7ed25eeba5b) newsboat: 2.27 -> 2.28
* [`b0feee64`](https://github.com/NixOS/nixpkgs/commit/b0feee646713c08da547723ef483f5de0ee75491) hypnotix: 2.7 -> 2.8
* [`e47f1d25`](https://github.com/NixOS/nixpkgs/commit/e47f1d2527f6109ea74940f01fcfe168a00bc5f7) communi: 3.5.0 -> 3.6.0
* [`9fcfdda1`](https://github.com/NixOS/nixpkgs/commit/9fcfdda1accdcafa6b65ccc3637741adcc8f6cab) python310Packages.zope-cachedescriptors: init at 4.3.1
* [`eb92ef3a`](https://github.com/NixOS/nixpkgs/commit/eb92ef3a74d17ec23ca86affdfd90c2dafae246e) python310Packages.zope-testbrowser: init at 5.6.1
* [`3b953b5a`](https://github.com/NixOS/nixpkgs/commit/3b953b5a6973d3762b60f3f91ba7c233bfa4490c) ruby-packages: update
* [`9a578a2c`](https://github.com/NixOS/nixpkgs/commit/9a578a2c083bf21a8688088c3ef787f6faae892a) python310Packages.splinter: 0.17.0 -> 0.18.0
* [`d54b22f9`](https://github.com/NixOS/nixpkgs/commit/d54b22f9ac6271e3e2b158ed80770ad8a7f552b0) python310Packages.qiskit-finance: 0.3.2 -> 0.3.3
* [`959efb47`](https://github.com/NixOS/nixpkgs/commit/959efb4705741f193ece980bbc331b10ece725c7) geoip: pass through the dataDir so consumers know where to look
* [`1e698a79`](https://github.com/NixOS/nixpkgs/commit/1e698a79791b81a2da341009fd0ecc15271b2557) ipcalc: add geoip support
* [`c8f1f64a`](https://github.com/NixOS/nixpkgs/commit/c8f1f64a8d5bb0f090fb551757088f1ee39fdbf1) maintainers: add billhuang
* [`808b08df`](https://github.com/NixOS/nixpkgs/commit/808b08df16b7745809a87df423dd67b68f22b393) mu: 1.8.1 -> 1.8.2
* [`22f96886`](https://github.com/NixOS/nixpkgs/commit/22f96886cfb31111f35f91761eadf60c22df0460) netcdf: 4.8.1 -> 4.9.0
* [`8d1a4469`](https://github.com/NixOS/nixpkgs/commit/8d1a4469dd9000bf9d3d445f59531ff9673271e8) python310Packages.netcdf4: 1.5.8 -> 1.6.0
* [`9d144953`](https://github.com/NixOS/nixpkgs/commit/9d144953c4f77c3b83c08eaf47bc3a51067e1134) python310Packages.skia-pathops: fix build on darwin
* [`dbdee604`](https://github.com/NixOS/nixpkgs/commit/dbdee6040ec38a93cb8bfd43f2fbd674fda2a659) python310Packages.jupyter-cache: init at 0.5.0
* [`4c2ff9c6`](https://github.com/NixOS/nixpkgs/commit/4c2ff9c6f52a1844fcae173bcb2808a5c705927d) python310Packages.sphinx-togglebutton: init at 0.3.1
* [`543652ab`](https://github.com/NixOS/nixpkgs/commit/543652ab74c0917576cbdb3eb75d6be12d8469bb) python310Packages.myst-nb: init at 0.16.0
* [`018764c3`](https://github.com/NixOS/nixpkgs/commit/018764c3b3776ab2170a79d498339d18e0dd7129) python310Packages.sphinx-comments: init at 0.0.3
* [`dd9632d2`](https://github.com/NixOS/nixpkgs/commit/dd9632d2227e5d5d2bc205f208c05231d00383f1) python310Packages.sphinx-external-toc: init at 0.3.0
* [`f5c3ceaf`](https://github.com/NixOS/nixpkgs/commit/f5c3ceaf9190148f20dfc0c73db3f4fb5be5e1ae) python310Packages.sphinx-jupyterbook-latex: init at 0.4.6
* [`7eca257a`](https://github.com/NixOS/nixpkgs/commit/7eca257a4a37bf2ed821a6fc99a0651c5b5bbf43) python310Packages.sphinx-design: init at 0.2.0
* [`eccb49d4`](https://github.com/NixOS/nixpkgs/commit/eccb49d429991ee66497309328379b312ff27cc3) python310Packages.sphinx-thebe: init at 0.1.2
* [`50825202`](https://github.com/NixOS/nixpkgs/commit/50825202d73ba82541dd564754fb01d6e65e22da) python310Packages.pydata-sphinx-theme: init at 0.8.1
* [`2c4c660d`](https://github.com/NixOS/nixpkgs/commit/2c4c660dc6b0f0cf65113d3e7d07b99f03ba5469) python310Packages.sphinx-book-theme: init at 0.3.2
* [`97ea6594`](https://github.com/NixOS/nixpkgs/commit/97ea65945b712db46c93b6fd91eb684f3987f076) python310Packages.sphinx-multitoc-numbering: init at 0.1.3
* [`bcfbf82a`](https://github.com/NixOS/nixpkgs/commit/bcfbf82aed30dd60b68827bff628ce981d6dd358) millet: 0.1.12 -> 0.1.14
* [`d5423b92`](https://github.com/NixOS/nixpkgs/commit/d5423b92bc4eb0a8fa5be1f5d558f1e917412be6) esbuild: 0.14.47 -> 0.14.48
* [`c8a97d3f`](https://github.com/NixOS/nixpkgs/commit/c8a97d3f54e010d0e0e387c2ec6033889a528468) nvchecker: 2.8 -> 2.9
* [`a584258d`](https://github.com/NixOS/nixpkgs/commit/a584258d5268524e7415fabf0a35468769881d89) python310Packages.jupyter-book: init at 0.13.0
* [`6806e4e8`](https://github.com/NixOS/nixpkgs/commit/6806e4e8b78eae240cb9e657b168c13dd58f9a3f) ocamlPackages.shared-memory-ring: 3.1.0 → 3.1.1
* [`816079d8`](https://github.com/NixOS/nixpkgs/commit/816079d8857c9ca69969b0c0b8388c274962f3b3) feishu: init at 5.9.18
* [`b5d5648d`](https://github.com/NixOS/nixpkgs/commit/b5d5648d817695555174ea8675cc5df01cb87497) maintainers: add aacebedo
* [`4cb1c832`](https://github.com/NixOS/nixpkgs/commit/4cb1c832e4e8060b9c1ffa2cf80a943a92409c06) swaysettings: init at 0.3.0
* [`a046e6c8`](https://github.com/NixOS/nixpkgs/commit/a046e6c8f31a4766d8374c5269ebb492f623072a) python310Packages.hcloud: enable all tests
* [`eb5d09dd`](https://github.com/NixOS/nixpkgs/commit/eb5d09dd0fd8ca1d9925a0d4005087cdc7c7335d) pip-audit: 2.3.4 -> 2.4.0
* [`96876767`](https://github.com/NixOS/nixpkgs/commit/968767675404db4144dd83c7760c39ef2d99ead9) yara: 4.2.1 -> 4.2.2
* [`d20dd119`](https://github.com/NixOS/nixpkgs/commit/d20dd119683e1b9b2f8ca557e3ca8414424bb9c3) pantheon.wingpanel-indicator-network: 2.3.2 -> 2.3.3
* [`283d9754`](https://github.com/NixOS/nixpkgs/commit/283d9754bba49eda627c146ad745d1635a08d550) python310Packages.tempest: 31.0.0 -> 31.1.0
* [`1fc2aa77`](https://github.com/NixOS/nixpkgs/commit/1fc2aa773b8a3054929a8f7527440b9eeaa6e2c8) signal-desktop: 5.47.0 -> 5.48.0
* [`aa6d3e68`](https://github.com/NixOS/nixpkgs/commit/aa6d3e68171d35e68d6aa7f9987f8aa651bf8d66) top-level/linux-kernels.nix: add vendor kernels note
* [`59321863`](https://github.com/NixOS/nixpkgs/commit/5932186344b312cbb3fa9b0b0be7a90b688843ae) signal-desktop: fix missing tray icon
* [`12ae5d95`](https://github.com/NixOS/nixpkgs/commit/12ae5d953db66bcb18bdbee0b3afee179f88680c) python310Packages.asana: 0.10.9 -> 1.0.0
* [`84a29ac2`](https://github.com/NixOS/nixpkgs/commit/84a29ac208037849c25a355cc141c7d7b9b378b1) jprofiler: init at 13.0.2
* [`f3e8668b`](https://github.com/NixOS/nixpkgs/commit/f3e8668b8f4ac4c886ed273f5851aec410221e24) mill: 0.10.4 -> 0.10.5
* [`28385978`](https://github.com/NixOS/nixpkgs/commit/28385978bc9c827d642091e5e39aa1ff1c478eb7) bitcoin: fix broken build on aarch64-darwin
* [`987400b8`](https://github.com/NixOS/nixpkgs/commit/987400b848773e4f274c96d33630273ea7d7d02f) nixos/desktop-manager: Use literal newline to fix shell syntax
* [`f78aac93`](https://github.com/NixOS/nixpkgs/commit/f78aac931a7bcb65bfc8d060866bf2b24c2fd5d6) python310Packages.cftime: 1.6.0 -> 1.6.1
* [`2439ddbd`](https://github.com/NixOS/nixpkgs/commit/2439ddbd9b7781e5316fa16bce66dac4f171b7d1) gnome.gnome-control-center: 42.2 -> 42.3
* [`991aa3f4`](https://github.com/NixOS/nixpkgs/commit/991aa3f49ac22b71996515ba184feeb800d99ee4) gnome.gnome-software: 42.2 -> 42.3
* [`4c357290`](https://github.com/NixOS/nixpkgs/commit/4c35729086139bae51d0575e47687e845f180eb5) glib-networking: 2.72.0 -> 2.72.1
* [`a034fd52`](https://github.com/NixOS/nixpkgs/commit/a034fd5235f4cb7d61e4e2ff1e00b9f2af9a053c) duckdb: add patch to fix list type inference ([nixos/nixpkgs⁠#178886](https://togithub.com/nixos/nixpkgs/issues/178886))
* [`09ef743e`](https://github.com/NixOS/nixpkgs/commit/09ef743e10fd7923fe8a417956a1a462c74c8fc1) act: 0.2.28 -> 0.2.29
* [`e94f1b45`](https://github.com/NixOS/nixpkgs/commit/e94f1b45efd69a6ad89b28dd4944a2bc6e825007) lesspipe: 1.85 -> 2.05 ([nixos/nixpkgs⁠#178581](https://togithub.com/nixos/nixpkgs/issues/178581))
* [`2f37856d`](https://github.com/NixOS/nixpkgs/commit/2f37856d4afd90aebd193db888b70b5c876f5de9) python310Packages.ua-parser: 0.10.0 -> 0.15.0
* [`e03a8338`](https://github.com/NixOS/nixpkgs/commit/e03a83380d2aa2901d094c3418d92f0e15babc2e) ytfzf: 2.3 -> 2.4.0
* [`638a2fbb`](https://github.com/NixOS/nixpkgs/commit/638a2fbbee9e4a6dcccd18fdfcd3469c95710dbf) python310Packages.jarowinkler: 1.0.4 -> 1.0.5
* [`78958dd5`](https://github.com/NixOS/nixpkgs/commit/78958dd5fefe96687d5968d8fca8f8e758bede57) rapidfuzz-cpp: 1.0.3 -> 1.0.4
* [`b6b5216a`](https://github.com/NixOS/nixpkgs/commit/b6b5216a70a0aab0e8f4aa9f02d088b195a52420) python310Packages.rapidfuzz: 2.0.15 -> 2.1.0
* [`fc8b57d8`](https://github.com/NixOS/nixpkgs/commit/fc8b57d850b83a964a2c81c32f9f29d3c5bbf964) libdeltachat: 1.86.0 -> 1.87.0
* [`415492eb`](https://github.com/NixOS/nixpkgs/commit/415492eb719197cf436909ad01e4ac02f71f166e) amtk: 5.4.1 -> 5.5.1
* [`1321d086`](https://github.com/NixOS/nixpkgs/commit/1321d086fa38d8cee4a458fbfb9bb9be4ecd13b9) revive: init at 1.2.1
* [`b0997ca8`](https://github.com/NixOS/nixpkgs/commit/b0997ca8989ca2d04bba728f0040cf072273bece) pretendard: 1.3.0 -> 1.3.3
* [`f7386088`](https://github.com/NixOS/nixpkgs/commit/f73860882de91393fd29219288cbab67841c2dfa) lefthook: 1.0.0 -> 1.0.4
* [`9c544193`](https://github.com/NixOS/nixpkgs/commit/9c544193df8a1e7f083a7d3261f78e71f588f3e7) ocrfeeder: Fix launch with patch ([nixos/nixpkgs⁠#179675](https://togithub.com/nixos/nixpkgs/issues/179675))
* [`420f7d19`](https://github.com/NixOS/nixpkgs/commit/420f7d191ca25d7fd99c11bbede4875015c2f208) blueprint-compiler: 2022-05-27 -> 0.2.0
* [`dd3a47ef`](https://github.com/NixOS/nixpkgs/commit/dd3a47ef86bc25570c4419529eef37cf1305fc62) neovide: 0.8 -> 0.9
* [`1a4ec9ef`](https://github.com/NixOS/nixpkgs/commit/1a4ec9ef7f79f84c84078abb3f6ddf04a5e8bedc) zoom-us: 5.10.{4,6} -> 5.11.1 ([nixos/nixpkgs⁠#178587](https://togithub.com/nixos/nixpkgs/issues/178587))
* [`268a0c5a`](https://github.com/NixOS/nixpkgs/commit/268a0c5a62045f4a2f996feec308ddbbf0366e61) python310Packages.env-canada: 0.5.23 -> 0.5.24
* [`62ebe417`](https://github.com/NixOS/nixpkgs/commit/62ebe4176a4f513daf2aceb9a20f2505292b01cd) python310Packages.stripe: 3.4.0 -> 3.5.0
* [`6593cea2`](https://github.com/NixOS/nixpkgs/commit/6593cea2596952bd27f1a786d86d99229346e354) python310Packages.boxx: 0.10.4 -> 0.10.5
* [`a2dfde58`](https://github.com/NixOS/nixpkgs/commit/a2dfde58bc28cde00d96bc6a8e9fc5c61078e820) Revert "sage: link doc in jupyter kernel"
* [`258bf7f1`](https://github.com/NixOS/nixpkgs/commit/258bf7f10ad8746ca8010033cb15ea4d2cc63994) python3Packages.flake8-bugbear: 22.6.22 -> 22.7.1
* [`c1a59f40`](https://github.com/NixOS/nixpkgs/commit/c1a59f40e04b4703a8983510e74eeda595fb0470) xonotic: 0.8.2 -> 0.8.5
* [`7446edab`](https://github.com/NixOS/nixpkgs/commit/7446edab41042812a25b54c9209377d3876cba4f) python310Packages.lsassy: 3.1.1 -> 3.1.2
* [`84f7babb`](https://github.com/NixOS/nixpkgs/commit/84f7babbca50075ddb5ab4454e5bc7ffa684fd43) python310Packages.pikepdf: 5.1.5.post1 -> 5.2.0
* [`0669fd6f`](https://github.com/NixOS/nixpkgs/commit/0669fd6f204262354c2c10f00e4829097d1b4118) python310Packages.wandb: 0.12.19 -> 0.12.20
* [`b35a0fcd`](https://github.com/NixOS/nixpkgs/commit/b35a0fcd898549d675af496de30064f79fc77dc2) mutt: 2.2.5 -> 2.2.6
* [`95999dfb`](https://github.com/NixOS/nixpkgs/commit/95999dfb49e78f2bfd3e170b2ef8f38b3c469144) python310Packages.fastbencode: 0.0.7 -> 0.0.9
* [`555f9ae1`](https://github.com/NixOS/nixpkgs/commit/555f9ae132806ec686493ffd156591cb3f234f95) python310Packages.fastbencode: fix license
* [`2833461e`](https://github.com/NixOS/nixpkgs/commit/2833461e230a75770d93bf8e63da311cce67f8cd) iosevka-bin: 15.3.0 -> 15.5.2
* [`3d07a3f9`](https://github.com/NixOS/nixpkgs/commit/3d07a3f961e28b340ab430ee6f68a348fcdaebd6) iosevka: 15.5.0 -> 15.5.2
* [`12218a56`](https://github.com/NixOS/nixpkgs/commit/12218a56e0b541f1d97d5797fa771f47dd419957) wireless-regdb: 2022.02.18 -> 2022.06.06
* [`977a9b91`](https://github.com/NixOS/nixpkgs/commit/977a9b915e15514e009e36f14e18590243635daf) prometheus-blackbox-exporter: 0.21.0 -> 0.21.1
* [`c6e76ab7`](https://github.com/NixOS/nixpkgs/commit/c6e76ab7c91d16bd627095e6a55848bc97ea31df) nixos/radvd: add package option
* [`337a032c`](https://github.com/NixOS/nixpkgs/commit/337a032c262b336f588665316042dc90ed705cca) matrix-conduit: 0.3.0 -> 0.4.0
* [`782b85a9`](https://github.com/NixOS/nixpkgs/commit/782b85a9c24fb137a710840954f489614599249e) lxqt.lximage-qt: add qtimageformats plugin
* [`4e9369f6`](https://github.com/NixOS/nixpkgs/commit/4e9369f65e5babf442ded90dcf0f4ebe919df869) lxqt.pcmanfm-qt: add qtimageformats plugin
* [`339665a9`](https://github.com/NixOS/nixpkgs/commit/339665a9b0ce43c916c482a93a481d7377c60dbf) libvirt: add zfs to PATH when enabled
* [`28915606`](https://github.com/NixOS/nixpkgs/commit/28915606ba138a7016a0030c97ce95613c63c7ac) prometheus: add flag for dns plugin, enable by default
* [`28a328a1`](https://github.com/NixOS/nixpkgs/commit/28a328a1246669a534898054cda351d37fce8ce4) zulu: build for aarch64-darwin
* [`627579b7`](https://github.com/NixOS/nixpkgs/commit/627579b71a4243f833445fb96c312d283b198651) mattermost: Don't restrict system types
* [`8b00147f`](https://github.com/NixOS/nixpkgs/commit/8b00147f1d20a3d3c4b7dc2a88cdc6c2d648abaf) ratman: 0.3.1 -> 0.4.0 ([nixos/nixpkgs⁠#179814](https://togithub.com/nixos/nixpkgs/issues/179814))
* [`a8c71a47`](https://github.com/NixOS/nixpkgs/commit/a8c71a477fa3337c5cde8e5ac8b862c807c0385d) gitlab: 15.1.0 -> 15.1.1 ([nixos/nixpkgs⁠#179810](https://togithub.com/nixos/nixpkgs/issues/179810))
* [`e4ec043d`](https://github.com/NixOS/nixpkgs/commit/e4ec043d8a74940b1730d0ec98fd47667652aa4b) pythonPackages.klein: don't mark as broken
* [`86481006`](https://github.com/NixOS/nixpkgs/commit/86481006e78633eccd6b849b88697c7f4d70f04d) deno: 1.23.1 -> 1.23.2
* [`e953e73b`](https://github.com/NixOS/nixpkgs/commit/e953e73b6f303ab97dcd0c6843e5114a8c57556d) go-tools: 2021.1.2 -> 2022.1.2 ([nixos/nixpkgs⁠#179827](https://togithub.com/nixos/nixpkgs/issues/179827))
* [`78abe603`](https://github.com/NixOS/nixpkgs/commit/78abe603afefa3f644000b0fe6bdc6eec11e37f8) openasar: add unzip; remove autoupdater; unstable-2022-06-10 -> unstable-2022-06-27
* [`bf528b86`](https://github.com/NixOS/nixpkgs/commit/bf528b867adcc00b8a02883c6677f157ec56bbac) power-profiles-daemon: 0.11.1 → 0.12
* [`e88d3738`](https://github.com/NixOS/nixpkgs/commit/e88d37389cb58827dd39d7a2712ef34cc5dc190d) evolution-ews: 3.44.2 → 3.44.3
* [`d87a011c`](https://github.com/NixOS/nixpkgs/commit/d87a011c1e38153508bf6940d6bc2a5221069220) evolution-data-server: 3.44.2 → 3.44.3
* [`bd9e9f51`](https://github.com/NixOS/nixpkgs/commit/bd9e9f512daf9b8f1bad82f7a3c8eb8fe70df17b) evolution: 3.44.2 → 3.44.3
* [`5e2d29c7`](https://github.com/NixOS/nixpkgs/commit/5e2d29c7f2cfa964153d60095c3fa08584b5a928) gnome.gnome-boxes: 42.1 → 42.2
* [`6654f950`](https://github.com/NixOS/nixpkgs/commit/6654f950105717b7401a0d140fa9c00043c235f1) gnome.gnome-calculator: 42.1 → 42.2
* [`679a373a`](https://github.com/NixOS/nixpkgs/commit/679a373a81d3e88bd76afe10c9d3cd6205965937) gnome.gnome-maps: 42.2 → 42.3
* [`ac47a22a`](https://github.com/NixOS/nixpkgs/commit/ac47a22add424a0f35dda0949862e702e94e3d4a) gnome.sushi: 41.2 → 42.0
* [`dbb3c8d6`](https://github.com/NixOS/nixpkgs/commit/dbb3c8d6a716809dfcb1bb159d2576c53bb461d6) orca: 42.1 → 42.2
* [`c6217958`](https://github.com/NixOS/nixpkgs/commit/c6217958d040ffd004c6d553a6481ca9d92d0357) rhythmbox: 3.4.5 → 3.4.6
* [`e13726c8`](https://github.com/NixOS/nixpkgs/commit/e13726c80ea86cb356293cd7d2d2ab44995ee4f9) pitivi: 2021.05 → 2022.06
* [`fb2877c3`](https://github.com/NixOS/nixpkgs/commit/fb2877c36f3e2a6de74dce7310160d9673a4a48f) geocode-glib: 3.26.2 → 3.26.3
* [`e2d48d0e`](https://github.com/NixOS/nixpkgs/commit/e2d48d0ece7aa3033c670f2bcae727e0ed0ae0d7) deja-dup: 43.3 → 43.4
* [`5aebd3c2`](https://github.com/NixOS/nixpkgs/commit/5aebd3c2f7fce801d36d5be0e17d8a43c6e0a6cb) maddy: 0.5.4 -> 0.6.2
* [`c9c93251`](https://github.com/NixOS/nixpkgs/commit/c9c932511e2e0afbf87505f6bb3a90e2a96829a8) babashka: 0.8.156 -> 0.8.157
* [`37e00a37`](https://github.com/NixOS/nixpkgs/commit/37e00a373eaa0b9a83d587f66e69ed4da2b47b6b) flyctl: 0.0.335 -> 0.0.346
* [`bf1904c3`](https://github.com/NixOS/nixpkgs/commit/bf1904c305d6471ed2840bcbc00798a845f13f8a) openconnect: 8.20 -> 9.01
* [`589f060a`](https://github.com/NixOS/nixpkgs/commit/589f060ab8d98f0858d79af678b6330a27001b84) bookstack: fix unquoted URLs
* [`0ef69d1f`](https://github.com/NixOS/nixpkgs/commit/0ef69d1fab57f88ab257cd6ef22cf7271b3bfa88) hydra_unstable: change 5s timeout for init to 30s in tests
* [`dd18a29f`](https://github.com/NixOS/nixpkgs/commit/dd18a29f985394206fbeff03e16399b6ce1a8176) mold: 1.3.0 -> 1.3.1
* [`bf0608a6`](https://github.com/NixOS/nixpkgs/commit/bf0608a64253ee1b4baec38e0297b4801c59b09d) lib.licenses: add Aladdin Free Public License
* [`bcd503e7`](https://github.com/NixOS/nixpkgs/commit/bcd503e7fc940501c5f679edf04d8f1e0b5b5b4a) u001-font: init at unstable-2016-08-01
* [`cd0c2b23`](https://github.com/NixOS/nixpkgs/commit/cd0c2b23749bc4084e7ff5f3643a581aa193f84a) thrift: fix expired certs in tests
* [`6f9359a5`](https://github.com/NixOS/nixpkgs/commit/6f9359a504ae930346156b2428b47d48d950aea3) rustc: mark broken for dynamic Musl target
* [`f4b3fb07`](https://github.com/NixOS/nixpkgs/commit/f4b3fb0703974703b171f2afee744c881b35125d) khal: 0.10.4 -> 0.10.5
* [`2de1b09b`](https://github.com/NixOS/nixpkgs/commit/2de1b09bf049a4a838f95e7ae0fcd99be0a3a36e) neovide: fixup hash
* [`269b5000`](https://github.com/NixOS/nixpkgs/commit/269b50007315c08ebb9a86d778fca2e39ed6ac21) freecad: fix crash when selecting color of a solid
* [`a2403ed3`](https://github.com/NixOS/nixpkgs/commit/a2403ed37f4e8bb2f581b7ad0bb25a9e30fb435a) trackma: init at 0.8.4
* [`8f9d0669`](https://github.com/NixOS/nixpkgs/commit/8f9d06690909cc74f34b25e848b68471f00163f2) python310Packages.pywayland: 0.4.12 -> 0.4.13
* [`7f74d98b`](https://github.com/NixOS/nixpkgs/commit/7f74d98bdc1588212c7144b25ba4c45904315919) python310Packages.pyjet: 1.8.2 -> 1.9.0
* [`bd6fe08c`](https://github.com/NixOS/nixpkgs/commit/bd6fe08cc047416e9b991dffa2aaf8506282ab99) python310Packages.peaqevcore: 2.1.1 -> 3.0.5
* [`b8b42d6c`](https://github.com/NixOS/nixpkgs/commit/b8b42d6c77311f16780640d684e2c90151762edf) python310Packages.asf-search: 3.2.2 -> 4.0.1
* [`13b9616f`](https://github.com/NixOS/nixpkgs/commit/13b9616f7e79ec92a1edcda62332c49b79c11c94) python310Packages.pex: 2.1.93 -> 2.1.94
* [`d9d051d6`](https://github.com/NixOS/nixpkgs/commit/d9d051d6dd089cc6f1762a8a154f6bff0b60b94a) python310Packages.aesara: 2.7.3 -> 2.7.4
* [`d7d1174c`](https://github.com/NixOS/nixpkgs/commit/d7d1174c934e2645e2ec1702992afb7b001b4073) bochs: new recursive style
* [`c00e3a79`](https://github.com/NixOS/nixpkgs/commit/c00e3a79c155dd16605f9f827fa2bd22140de3eb) openfpgaloader: add optional dependencies
* [`388dfb39`](https://github.com/NixOS/nixpkgs/commit/388dfb39f520f32a50f4f38ac1d9d66bf01a1c8a) openfpgaloader: 0.6.0 -> 0.8.0
* [`6b820ecf`](https://github.com/NixOS/nixpkgs/commit/6b820ecfab44378d05b2f0ea5996c25876d56acb) nixos: systemd: add missing sliceToUnit ([nixos/nixpkgs⁠#179841](https://togithub.com/nixos/nixpkgs/issues/179841))
* [`85752ae3`](https://github.com/NixOS/nixpkgs/commit/85752ae3906029642d015b8ed30a54560d1213d8) python310Packages.trimesh: 3.12.6 -> 3.12.7
* [`f5ad4e79`](https://github.com/NixOS/nixpkgs/commit/f5ad4e7964c733ca0ebdfbf15b266590567a6b32) ocamlPackages.awa: 0.0.5 → 0.1.0
* [`22a183bf`](https://github.com/NixOS/nixpkgs/commit/22a183bf789cb60a2d80d757b1b6c25786cf3829) ocamlPackages.hacl_x25519: remove at 0.2.2
* [`f76ac449`](https://github.com/NixOS/nixpkgs/commit/f76ac449d1bdbd9cd9b76fbf98c511d26f849abc) srcOnly: fix with separateDebugInfo and/or multiple outputs
* [`85ab32d7`](https://github.com/NixOS/nixpkgs/commit/85ab32d794cec27fdb4807198e48df3884372b4e) wasynth: 0.10.0 -> 0.11.0
* [`7be0e091`](https://github.com/NixOS/nixpkgs/commit/7be0e091bd8fa7d3647c0821aad59fea77472c3a) sbcl: pull darwin fix pending upstream inclusion for -fno-common toolchains
* [`6a7da5b5`](https://github.com/NixOS/nixpkgs/commit/6a7da5b520eba152f200cd761e4d90e6aa404af5) geocode-glib: fix installed tests
* [`2d7728a3`](https://github.com/NixOS/nixpkgs/commit/2d7728a34f7c9145e5f4c375fbedbf2855341d42) page: 2.3.5 -> 3.0.0
* [`d5bacc3c`](https://github.com/NixOS/nixpkgs/commit/d5bacc3c95ff818defca93d88125672fcf524148) exploitdb: 2022-06-28 -> 2022-07-02
* [`5a642588`](https://github.com/NixOS/nixpkgs/commit/5a64258831adf4c5d4ca23f0ea10adb435cb1990) python310Packages.hahomematic: 1.9.1 -> 1.9.3
* [`ccf802df`](https://github.com/NixOS/nixpkgs/commit/ccf802df3145f2cf2041fee0c80034a8790a46e1) patatt: 0.4.9 -> 0.5.0
* [`9eba797f`](https://github.com/NixOS/nixpkgs/commit/9eba797f29c79f8ad0014f3ea6304266bdaada38) python310Packages.s3-credentials: 0.11 -> 0.12
* [`988e15ee`](https://github.com/NixOS/nixpkgs/commit/988e15ee3b8a557e73dc24ae765203ccb2bdb3ad) ktlint: 0.45.2 -> 0.46.1
* [`07428e9c`](https://github.com/NixOS/nixpkgs/commit/07428e9c2f417a4cddd1c50e4a257ff55f70eb2d) pantheon.elementary-files: 6.1.3 -> 6.1.4
* [`a173b861`](https://github.com/NixOS/nixpkgs/commit/a173b861ff1994e0b7cdce0db9ef757d610699f2) pantheon.elementary-camera: 6.1.0 -> 6.2.0
* [`11254579`](https://github.com/NixOS/nixpkgs/commit/11254579e366e396c9f7f179dca78dd3074203d1) obs-nvfbc: 0.0.5 -> 0.0.6
* [`88d8a2a0`](https://github.com/NixOS/nixpkgs/commit/88d8a2a0632d78d149bb314b2f9c80fa67d0be19) obs-nvfbc: update metadata
* [`76dff1dd`](https://github.com/NixOS/nixpkgs/commit/76dff1dd20bf708c1a40209721403586dbb2bbf6) flexget: 3.3.18 -> 3.3.19
* [`7d072a2e`](https://github.com/NixOS/nixpkgs/commit/7d072a2e44374ee17e6062f47ce457432f9656c6) aegisub: fix build on aarch64
* [`b752d82c`](https://github.com/NixOS/nixpkgs/commit/b752d82cdd323bb38c61d8142d682f306e6999b3) python310Packages.pysyncobj: 0.3.10 -> 0.3.11
* [`b1c6e1b8`](https://github.com/NixOS/nixpkgs/commit/b1c6e1b8a21075a78bfa2b668c7ea310f90cd9f3) python310Packages.pylutron-caseta: 0.13.1 -> 0.14.0
* [`4d1e5c11`](https://github.com/NixOS/nixpkgs/commit/4d1e5c1140938c0e6f2891cd9093676c9f0715b8) erigon: 2022.02.04 -> 2022.07.01
* [`867a0b9c`](https://github.com/NixOS/nixpkgs/commit/867a0b9c690ac274101a3c8c6aaf367a991e16e8) pantheon.switchboard-plug-network: 2.4.2 -> 2.4.3
* [`eccf2df6`](https://github.com/NixOS/nixpkgs/commit/eccf2df672c3358d3f067d0603a3125a703c884c) pantheon.switchboard-plug-pantheon-shell: 6.1.0 -> 6.2.0
* [`b4cbc031`](https://github.com/NixOS/nixpkgs/commit/b4cbc03186a339351bf78eae7a36905ce3ee8252) sigi: 3.4.0 -> 3.4.2
* [`e7b7d2f9`](https://github.com/NixOS/nixpkgs/commit/e7b7d2f9e26487c3727b5f7358e28a0134c930bd) rofi-rbw: 1.0.0 -> 1.0.1
* [`7a084f42`](https://github.com/NixOS/nixpkgs/commit/7a084f4285d6af8b57ebb9820d5141deeca61dfa) junction: init at 1.5.0
* [`e18baa03`](https://github.com/NixOS/nixpkgs/commit/e18baa03098c702b64bd386b865cf19af7bc7a46) gtk4: 4.6.5 -> 4.6.6
* [`3eec36f8`](https://github.com/NixOS/nixpkgs/commit/3eec36f837f4dd5fcd6437eda2279cdafd60080f) gnome.zenity: 3.42.1 -> 3.43.0
* [`31eaa5fa`](https://github.com/NixOS/nixpkgs/commit/31eaa5fac345d4fd99f0a83342b6074be5c0eec2) kotlin-language-server: 1.3.0 -> 1.3.1
* [`390681fd`](https://github.com/NixOS/nixpkgs/commit/390681fdaff64e29a30e03a20c12f937ec3a1902) ocamlPackages.optint: 0.1.0 → 0.2.0
* [`2923cde9`](https://github.com/NixOS/nixpkgs/commit/2923cde911a6361d278f9c7b88c9b3ecf1040220) python310Packages.bottleneck: 1.3.4 -> 1.3.5
* [`c70172f9`](https://github.com/NixOS/nixpkgs/commit/c70172f9d0f2f74da000ce08ce4484a079b05860) pam_tmpdir: init at 0.09
* [`6994e160`](https://github.com/NixOS/nixpkgs/commit/6994e16075190d4eb0e77533c43b5b731c0ee20a) mu: 1.8.2 -> 1.8.3
* [`6bc3638c`](https://github.com/NixOS/nixpkgs/commit/6bc3638cf4c1b421d2aceeb598ce848b6e41af76) ocamlPackages.duff: 0.4 → 0.5
* [`76d6294b`](https://github.com/NixOS/nixpkgs/commit/76d6294b641c56258ba49f1498d543634498ec93) python310Packages.insteon-frontend-home-assistant: 0.1.1 -> 0.2.0
* [`60971eb6`](https://github.com/NixOS/nixpkgs/commit/60971eb672da0dfcec76828089726b5cfc3e1488) python310Packages.peaqevcore: 3.0.5 -> 3.0.6
* [`ba211a5a`](https://github.com/NixOS/nixpkgs/commit/ba211a5aefe44c3768ab194cf70fd56f8b16aa89) btdu: 0.4.0 -> 0.4.1
* [`8f58bc3a`](https://github.com/NixOS/nixpkgs/commit/8f58bc3a1db23ca20e1d07d336b46d25f08282c7) buildGraalvmNativeImage: allow LC_ALL overrides
* [`5f14f77b`](https://github.com/NixOS/nixpkgs/commit/5f14f77bf29fc69c1e2654f905738f5c444f8049) ckb-next: remove myself from maintainers ([nixos/nixpkgs⁠#179573](https://togithub.com/nixos/nixpkgs/issues/179573))
* [`468d2bdc`](https://github.com/NixOS/nixpkgs/commit/468d2bdcf11b4e166286f92ce67a45d0f64eb248) darktable: 3.8.1 -> 4.0.0 ([nixos/nixpkgs⁠#180012](https://togithub.com/nixos/nixpkgs/issues/180012))
* [`b6e76635`](https://github.com/NixOS/nixpkgs/commit/b6e76635561f4fed78a49124061f3d841627090d) ocamlPackages.atdgen: 2.4.1 → 2.9.1
* [`941756bb`](https://github.com/NixOS/nixpkgs/commit/941756bbe4bde818c5e1809f83713631921d40a1) deno: fix build
* [`7e40e815`](https://github.com/NixOS/nixpkgs/commit/7e40e8154eda2174197bfd7d8d220568a960d6ad) vscode-extensions.bradlc.vscode-tailwindcss: 0.6.13 -> 0.8.6
* [`5020795f`](https://github.com/NixOS/nixpkgs/commit/5020795f0174ffddf9faef5b2bc2c2ff88c5c252) vscode-extensions.vscodevim.vim: 1.22.2 -> 1.23.1
* [`e8d7d52f`](https://github.com/NixOS/nixpkgs/commit/e8d7d52fae1319ade68491d0bf66eb9e3a87b7b2) lib.systems.examples: canonicalize MIPS triples
