### PR TITLE
niv emacs-overlay: update 79d813d9 -> 7783abca

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb",
-        "sha256": "1y9l50iy7yyl6xlar261dpsjmgybvraw59ln42fa9xi25vmfvja5",
+        "rev": "7783abca6324f2dfdf8ca7d3632c376df416bf88",
+        "sha256": "09glqy5jyshbbk80jwkimszqaik8gi5pxm98qb6176r0qjhy4apz",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/7783abca6324f2dfdf8ca7d3632c376df416bf88.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@79d813d9...7783abca](https://github.com/nix-community/emacs-overlay/compare/79d813d9d4ebbd8ab34c1f755439cab4aedb2ddb...7783abca6324f2dfdf8ca7d3632c376df416bf88)

* [`1ba82898`](https://github.com/nix-community/emacs-overlay/commit/1ba82898e7764b61daa978b45e9f2bbe5cbe3c8d) Updated repos/emacs
* [`8772891c`](https://github.com/nix-community/emacs-overlay/commit/8772891c73e2809df5e5469d14535ea77e123d3e) Updated repos/melpa
* [`df34ae88`](https://github.com/nix-community/emacs-overlay/commit/df34ae880b505d00fc265a47de243a9d575a5fef) Updated repos/elpa
* [`eeb311d9`](https://github.com/nix-community/emacs-overlay/commit/eeb311d92e3df8b2262fa2b95079e5e1db7ecb6c) Updated repos/emacs
* [`1f9bbd1d`](https://github.com/nix-community/emacs-overlay/commit/1f9bbd1df0c78ed6d4444cde96806f038954c078) Updated repos/melpa
* [`3f21945e`](https://github.com/nix-community/emacs-overlay/commit/3f21945eac3ef08d7f3fd329dbe3954fe52f3d10) Updated repos/nongnu
* [`9015841e`](https://github.com/nix-community/emacs-overlay/commit/9015841ee241f98a90aed210225a677c3908afd8) Updated repos/emacs
* [`bdb27d40`](https://github.com/nix-community/emacs-overlay/commit/bdb27d40ec4c5b2cceb8e6b3b0d4180e10f8bbde) Updated repos/melpa
* [`27246259`](https://github.com/nix-community/emacs-overlay/commit/2724625945ddeaeffd94ca56e11b75b98b8bba8b) Updated repos/nongnu
* [`46492f28`](https://github.com/nix-community/emacs-overlay/commit/46492f286aefae3a4993d3c65f182618f98956e9) Updated repos/melpa
* [`5edbe440`](https://github.com/nix-community/emacs-overlay/commit/5edbe4407988b71f85baa2e24402d59bde89d3d2) Updated repos/elpa
* [`2c8d5f45`](https://github.com/nix-community/emacs-overlay/commit/2c8d5f458a677a88806901e0b4b9d4ce3b54e239) Updated repos/emacs
* [`1b8b2da8`](https://github.com/nix-community/emacs-overlay/commit/1b8b2da85c0143b65a7738e04a57bf9b41872a05) Updated repos/melpa
* [`042fec6b`](https://github.com/nix-community/emacs-overlay/commit/042fec6b0b2b81b451e72dfae13224614ce06ee8) Updated repos/emacs
* [`0ed73cdb`](https://github.com/nix-community/emacs-overlay/commit/0ed73cdb0646eb9f425f1d1a24f6c3ae1207f482) Updated repos/melpa
* [`ef0618b6`](https://github.com/nix-community/emacs-overlay/commit/ef0618b6a7ba0f3c8ee6263f52baa4e9faabbde7) Updated repos/emacs
* [`a189248d`](https://github.com/nix-community/emacs-overlay/commit/a189248df5e56b652483675fd1d35727b6cc7a59) Updated repos/melpa
* [`21ccd184`](https://github.com/nix-community/emacs-overlay/commit/21ccd1846c3c9d51b1d53a0c15bc49b7099e9f1d) Updated repos/elpa
* [`a9e9b4b9`](https://github.com/nix-community/emacs-overlay/commit/a9e9b4b9a956fdf407cbeb6135541cffa20aa8d4) Updated repos/emacs
* [`bfa98bb7`](https://github.com/nix-community/emacs-overlay/commit/bfa98bb7e829b62c915e0652fff75564170e3a22) Updated repos/melpa
* [`c0eb75e4`](https://github.com/nix-community/emacs-overlay/commit/c0eb75e456ac4dca22f765f8f4de3f7a4d75a3eb) Updated repos/emacs
* [`32c3ccfc`](https://github.com/nix-community/emacs-overlay/commit/32c3ccfc1a90b101e541c98617704210ef00ca6b) Updated repos/melpa
* [`7ac6aef4`](https://github.com/nix-community/emacs-overlay/commit/7ac6aef457d59da09089754681ec8d642a5372be) Updated repos/nongnu
* [`82fda28c`](https://github.com/nix-community/emacs-overlay/commit/82fda28ccdf51981dfb8a1afe196c492aff1b232) Updated repos/emacs
* [`dc48cd35`](https://github.com/nix-community/emacs-overlay/commit/dc48cd35bdf435d31e4ee6f488ba868b1a07bac5) Updated repos/melpa
* [`653368b5`](https://github.com/nix-community/emacs-overlay/commit/653368b56cd399fd2fa2aa88c43a384a5314d4cd) Updated repos/elpa
* [`5140abbf`](https://github.com/nix-community/emacs-overlay/commit/5140abbfb253165489571bdabb8d042fb789211b) Updated repos/emacs
* [`90a8239e`](https://github.com/nix-community/emacs-overlay/commit/90a8239ebb7c12ddefca43fca4d6b74d630ac433) Updated repos/melpa
* [`9061493f`](https://github.com/nix-community/emacs-overlay/commit/9061493feae8f393fa83eb9853016127445353d5) Updated repos/emacs
* [`7f04caa6`](https://github.com/nix-community/emacs-overlay/commit/7f04caa61e12c942267736a391ec83c3588a7c65) Updated repos/melpa
* [`e72f7202`](https://github.com/nix-community/emacs-overlay/commit/e72f72027366c3987a84a7a6f7d75b91bb800ea8) Updated repos/nongnu
* [`058a08a3`](https://github.com/nix-community/emacs-overlay/commit/058a08a30bce3ce88c66393f5eec7cd3ab980cc2) Updated repos/emacs
* [`143aa8c3`](https://github.com/nix-community/emacs-overlay/commit/143aa8c32b1921faf84e2486bf68dda5e01482e8) Updated repos/melpa
* [`f451bc03`](https://github.com/nix-community/emacs-overlay/commit/f451bc03ceb314c64fbc5f11a8913fde34d59b9b) Updated repos/emacs
* [`ea1129fe`](https://github.com/nix-community/emacs-overlay/commit/ea1129fe388bbeac8495e82b5b04f4a83af88bce) Updated repos/melpa
* [`d28d973d`](https://github.com/nix-community/emacs-overlay/commit/d28d973de1f26d5b750df0be156a23e0ca6d360c) Updated repos/elpa
* [`06553892`](https://github.com/nix-community/emacs-overlay/commit/0655389204c83a014e584121e7a7f47543af4571) Updated repos/emacs
* [`7783abca`](https://github.com/nix-community/emacs-overlay/commit/7783abca6324f2dfdf8ca7d3632c376df416bf88) Updated repos/melpa
