### PR TITLE
niv spacemacs: update c9db0284 -> 42b6ff3f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "c9db028421a74eb8339152ae3c2fe694dc322216",
-        "sha256": "1h5vglj1rq91ihmwzjs75hhkdb1p7cap8z1dzy91nlim2pzvxly7",
+        "rev": "42b6ff3f09021ab4b59dc1a75c1ff75301d90d7e",
+        "sha256": "0ib4h6m8lqvky1b7r3yf8lx5z1xr8cq3xbjs64xxfhmjbf6dnfbm",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/c9db028421a74eb8339152ae3c2fe694dc322216.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/42b6ff3f09021ab4b59dc1a75c1ff75301d90d7e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@c9db0284...42b6ff3f](https://github.com/syl20bnr/spacemacs/compare/c9db028421a74eb8339152ae3c2fe694dc322216...42b6ff3f09021ab4b59dc1a75c1ff75301d90d7e)

* [`0ce1201a`](https://github.com/syl20bnr/spacemacs/commit/0ce1201a3e634d24b67ab87ab2e909308ae7b3b1) Use a different require on newer mu versions.
* [`b4d84a4e`](https://github.com/syl20bnr/spacemacs/commit/b4d84a4e1ac38f87bd788874c5483d4af850f01b) [editing] lazy binding for string-edit-mode
* [`f3c73178`](https://github.com/syl20bnr/spacemacs/commit/f3c73178bab8a53f5b8df930829288d29c3c870d) [lsp] update consult-lsp init
* [`d059c4c0`](https://github.com/syl20bnr/spacemacs/commit/d059c4c0b2739a8a10c3e9b28f3e98de89d21a17) [evil] bring back vi-tilde-fringe
* [`7af1a217`](https://github.com/syl20bnr/spacemacs/commit/7af1a2172442a756bee9935350247924bea8e663) [bot] "built_in_updates" Fri Jul  1 14:06:03 UTC 2022
* [`1435c95a`](https://github.com/syl20bnr/spacemacs/commit/1435c95a7999e50157d0e1f56abc90b00ff16ac4) Fix a previous attempted fix loading mu4e.
* [`42b6ff3f`](https://github.com/syl20bnr/spacemacs/commit/42b6ff3f09021ab4b59dc1a75c1ff75301d90d7e) Add /recentf~ to .gitignore
