### PR TITLE
niv zsh-you-should-use: update 773ae5f4 -> 09d9aa2c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -240,10 +240,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "773ae5f414b296b4100f1ab6668ecffdab795128",
-        "sha256": "1im305039cmfqhp4z0v0fkr7savgx2dvq7qgb5kkcsij7k8p10c3",
+        "rev": "09d9aa2cad2b7caf48cce8f321ebbbf8f47ce1c3",
+        "sha256": "07iqlry4mim5cqi8x5vi64dvwqqp298jbaz3ycks9rxsqlczzlnl",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/773ae5f414b296b4100f1ab6668ecffdab795128.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/09d9aa2cad2b7caf48cce8f321ebbbf8f47ce1c3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@773ae5f4...09d9aa2c](https://github.com/MichaelAquilina/zsh-you-should-use/compare/773ae5f414b296b4100f1ab6668ecffdab795128...09d9aa2cad2b7caf48cce8f321ebbbf8f47ce1c3)

* [`63198b9b`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/63198b9b04c15983881b4cfc156d6c0b529e54c7) Add Fig as an installation method to the README
* [`15997ea1`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/15997ea114039d7716a6ab95670dceab7eb5425d) Add image
* [`7d98cd43`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/7d98cd437dd6c6e1067cade40bab7e98ab5daa88) Add hyperlink to install button
* [`11edf068`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/11edf0682c5986f4180b5a286c8bf9b642856b42) Update README.rst
