### PR TITLE
niv nixpkgs: update ef3fe254 -> f904e356

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ef3fe254f3c59455386bc92fe84164f9679b92b1",
-        "sha256": "0zk3b4qwjzjh3ih91f1lq176jypqsj9c5radlq1csjigg93m8k8g",
+        "rev": "f904e3562aabca382d12f8471ca2330b3f82899a",
+        "sha256": "1lsa3sjwp1v3nv2jjpkl5lf9dncplwihmavasalg9fq1217pmzmb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ef3fe254f3c59455386bc92fe84164f9679b92b1.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f904e3562aabca382d12f8471ca2330b3f82899a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ef3fe254...f904e356](https://github.com/nixos/nixpkgs/compare/ef3fe254f3c59455386bc92fe84164f9679b92b1...f904e3562aabca382d12f8471ca2330b3f82899a)

* [`e5b24e6d`](https://github.com/NixOS/nixpkgs/commit/e5b24e6da2b638a4519ba2cda380cfe8d47c2ba2) nixos/prometheus-node-exporter: do not protect home
* [`0c4f8e78`](https://github.com/NixOS/nixpkgs/commit/0c4f8e78b522711ca72724248393d7f5d57f6b57) nixos/gitlab: fix gitlab-registry-cert path condition
* [`8e45ee9e`](https://github.com/NixOS/nixpkgs/commit/8e45ee9e4aebaebc27586ba58d17cf3dd975545e) acme: unstable-2021-02-14 -> unstable-2021-11-05
* [`1cd8006f`](https://github.com/NixOS/nixpkgs/commit/1cd8006fdd9c67fb3717d491bd0796c34fe2f4cf) networkmanager_dmenu: 1.6.0 -> 2.1.0
* [`1a170493`](https://github.com/NixOS/nixpkgs/commit/1a170493e56b5a322317d2d70798e5dbce213e20) fsverity-utils: init at 1.5
* [`31c82b62`](https://github.com/NixOS/nixpkgs/commit/31c82b62ff71115d93e5d71279229235d8f6099f) innernet: package systemd units
* [`6b9080d3`](https://github.com/NixOS/nixpkgs/commit/6b9080d336945a00344b1ec20ce8bc6e1122d28b) innernet: only package systemd units for linux
* [`81ed7d88`](https://github.com/NixOS/nixpkgs/commit/81ed7d886156c0085d900b84415d40eef2362a2d) nixos/calibre-web: Add quotes to test for calibre library
* [`94b87103`](https://github.com/NixOS/nixpkgs/commit/94b8710342f7a83739315c6e45be5070a32e6748) weylus: Add GST plugins to GST_PLUGIN_PATH
* [`89864413`](https://github.com/NixOS/nixpkgs/commit/89864413b28a787ee61e46a7ff510587eb041e32) go-modules/packages: Run unit tests under subdirs
* [`17672c8d`](https://github.com/NixOS/nixpkgs/commit/17672c8de18503137817b66fe9cd640d652f7f8a) gucci: Disable integration tests.
* [`1b748f08`](https://github.com/NixOS/nixpkgs/commit/1b748f081ad7ef034ce6c7438305d9957e771aec) skeema: Disable tests requiring network & fix deps
* [`7f2ef311`](https://github.com/NixOS/nixpkgs/commit/7f2ef311e2e3eb04f127cf0059aa1f2720904c69) mmake: Disable non-localhost network access tests
* [`032f261f`](https://github.com/NixOS/nixpkgs/commit/032f261fae00459598a7aac3c4893c668c9d41cc) delve: Fix tests on Linux, disable tests on Darwin
* [`aee4df7e`](https://github.com/NixOS/nixpkgs/commit/aee4df7eeb9c250f5f03cbb46fb408d56cadf3a2) go-mtpfs: Disable tests req'ing USB attached devs
* [`a3205db0`](https://github.com/NixOS/nixpkgs/commit/a3205db0c5a056bbd9dc8c33f81fa5f921354ea9) gitbatch: Fix tests requiring .git & writable HOME
* [`9d09650c`](https://github.com/NixOS/nixpkgs/commit/9d09650cef6cf183500d3e4c8ae0356fa0e878e4) kompose: Fix test dependencies
* [`7fd74900`](https://github.com/NixOS/nixpkgs/commit/7fd749009f63569a6e862527dcea661495277e90) stdenv: force gmp to rebuild in stage4 of the bootstrap
* [`122b6930`](https://github.com/NixOS/nixpkgs/commit/122b6930b0b5b8aa9911c6025ed12a7e5a8b9fab) stdenv: cause makeStaticLibraries usage to agree with usage spec
* [`23ea8b35`](https://github.com/NixOS/nixpkgs/commit/23ea8b35dacd9152c9e0e21577d5afe3e39b6255) stdenv: label the ephemeral coreutils-stage4 package
* [`a9e0d864`](https://github.com/NixOS/nixpkgs/commit/a9e0d864119c0313ece2cbb836c71821818e38c1) Update pkgs/stdenv/linux/default.nix
* [`02630180`](https://github.com/NixOS/nixpkgs/commit/02630180fad510ee877fa51112b7c7b230ef2f13) stdenv: add -stageX markers to gmp, mpfr, libmpc, and isl
* [`1b2929cd`](https://github.com/NixOS/nixpkgs/commit/1b2929cd91ad76a9b46555d01beb8a0f84ccb418) gnupg: 2.3.4 -> 2.3.6
* [`61beb33b`](https://github.com/NixOS/nixpkgs/commit/61beb33b83c16339fdcd96680d2942040730679e) Revert "perlPackages: add default meta.mainProgram ([nixos/nixpkgs⁠#176398](https://togithub.com/nixos/nixpkgs/issues/176398))"
* [`399732b4`](https://github.com/NixOS/nixpkgs/commit/399732b449262e8e3183fd239274b284901c8d08) buildPerlPackage: don't mess with `pname` and phase out use of `name`
* [`64589bce`](https://github.com/NixOS/nixpkgs/commit/64589bcefaa6f0225327525de602f5754781583d) nixos/netboot: use `makeInitrdNG` to shrink ramdisk size
* [`d8b840a6`](https://github.com/NixOS/nixpkgs/commit/d8b840a60f70d07de496572fa706ace44f90ef78) bpftrace: 0.14.1 -> 0.15.0
* [`9f75123e`](https://github.com/NixOS/nixpkgs/commit/9f75123e00657d28e617d41c17280740bf08877a) libbpf: 0.7.0 -> 0.8.0
* [`6350d8d9`](https://github.com/NixOS/nixpkgs/commit/6350d8d9b366fd6553dfe2160c4b43c28af97ac4) nixos/plasma5: add excludePackages option
* [`a5f11a69`](https://github.com/NixOS/nixpkgs/commit/a5f11a6938a0cc475391e81c998f4439092a5d7b) nixos/tests/plasma5: also test excludePackages works as expected
* [`2cf08210`](https://github.com/NixOS/nixpkgs/commit/2cf08210fd98a99dbe0ac59eb58ecbda3d5d7795) ghc8107-ghc923: patch haddock to generate correct source links
* [`d276229d`](https://github.com/NixOS/nixpkgs/commit/d276229d7c868c3a58bbe7b1cfd39ab8849cf632) ell: 0.50 -> 0.51
* [`518f3eab`](https://github.com/NixOS/nixpkgs/commit/518f3eab1754f305101200f57fd00f254250256f) iwd: 1.27 -> 1.28
* [`f6302025`](https://github.com/NixOS/nixpkgs/commit/f63020259750bb2433ce9333009516ff20fb67fa) libtracefs: 1.3.0 -> 1.3.1
* [`8d9773fe`](https://github.com/NixOS/nixpkgs/commit/8d9773fec413cb7641306fa30a48f0988c45a734) libtraceevent: 1.5.1 -> 1.5.3
* [`3a9bdc3f`](https://github.com/NixOS/nixpkgs/commit/3a9bdc3f3e474627fa9e898887d0d543679431fe) trace-cmd: 2.9.7 -> 3.0.3
* [`98d99554`](https://github.com/NixOS/nixpkgs/commit/98d99554a8acf95a8d7fceaa74e9f8d6af66c918) iproute: 5.17.0 -> 5.18.0
* [`148eea33`](https://github.com/NixOS/nixpkgs/commit/148eea3390a0eaad6d15c64ddf1faed4c11bab17) re2: 2022-04-01 -> 2022-06-01
* [`60c8c66d`](https://github.com/NixOS/nixpkgs/commit/60c8c66d00b1b0b588b7ad79d12d13cb0949eb19) libtracefs: 1.3.1->1.4.1
* [`9786d883`](https://github.com/NixOS/nixpkgs/commit/9786d883ac44fe0877c934e88e9f491fa49f9cc3) libtraceevent: 1.5.3->1.6.1
* [`c29a4892`](https://github.com/NixOS/nixpkgs/commit/c29a4892723e6ca61c5425cbce714bb89384e0b5) tempo: 1.1.0 -> 1.4.1
* [`30bfac60`](https://github.com/NixOS/nixpkgs/commit/30bfac609563c402d7fdb58cf5b0cbfb992e22b9) texinfo: fix build references when cross-compiling
* [`350e8ad0`](https://github.com/NixOS/nixpkgs/commit/350e8ad0e4fc7723e327c53bd5580e41c8c8a4f8) gpm: fix texinfo dependency platform when cross-compiling
* [`c916601f`](https://github.com/NixOS/nixpkgs/commit/c916601fd4778f087563740c4f57db510552238b) nodePackages.lv_font_conv: init at 1.5.2
* [`203696f0`](https://github.com/NixOS/nixpkgs/commit/203696f098d3041b0fc97a0b8358a703de6f0672) nixos/resolvconf: add `package`
* [`fd662e5c`](https://github.com/NixOS/nixpkgs/commit/fd662e5c4657f451d1fa534fccdc61aebba841ca) wireguard-tools: use resolvconf from PATH if available
* [`458ac47a`](https://github.com/NixOS/nixpkgs/commit/458ac47a1d5491dfb610cb8faaffcf5d5445b224) nixos/wg-quick: improve usage with systemd-networkd
* [`953a5bd3`](https://github.com/NixOS/nixpkgs/commit/953a5bd3dd3c527d6549592e0b7dbb96d5999bc2) nixos/tailscale: use `networking.resolvconf.package`
* [`4af5c46f`](https://github.com/NixOS/nixpkgs/commit/4af5c46faa589c0fa1142cc59b83fd97a9e5a3ba) nixos/dhcpcd: use `networking.resolvconf.package`
* [`2e5490f1`](https://github.com/NixOS/nixpkgs/commit/2e5490f108260b5d6739bd4dc1853e104be2ef70) cypress: 10.0.3 -> 10.2.0
* [`033cfaca`](https://github.com/NixOS/nixpkgs/commit/033cfacaf25a640404103904922d3532a037445e) cmake: reformat expression
* [`131a97e8`](https://github.com/NixOS/nixpkgs/commit/131a97e8c8790621fde729335339668463a4604f) gnu-efi: pull fix pending upstream inclusion for parallel build failures
* [`d6f12ab2`](https://github.com/NixOS/nixpkgs/commit/d6f12ab2f64aa8b1523e9d02d4b1e92bfde8432f) cmake: use a list of suitable uiToolkits instead of Boolean values
* [`02155ca9`](https://github.com/NixOS/nixpkgs/commit/02155ca9164e4649f5633f6466840dd685e876de) cmake: rename patches
* [`cd39674d`](https://github.com/NixOS/nixpkgs/commit/cd39674dc035c5c46208e4a058e650d349069aff) cmake: add myself as maintainer
* [`d867d916`](https://github.com/NixOS/nixpkgs/commit/d867d91690208c8dbe4fb8c98100c18a1f64ac16) cmake: use callPackage instead of libsForQt5.callPackage
* [`fc881d3a`](https://github.com/NixOS/nixpkgs/commit/fc881d3a4b269c89415ade8ce8ef4041f0813395) cmake: 3.22.3 -> 3.23.2
* [`f59fcefd`](https://github.com/NixOS/nixpkgs/commit/f59fcefd8d18f6471c75ae03cd6e776d4511b09e) luarocks: explicitly set 'configurePlatforms = [ ];'
* [`f8d1cada`](https://github.com/NixOS/nixpkgs/commit/f8d1cada7dbb7358614316e00e552e1a4cc9b441) python310Packages.urllib3: correct propagatedBuildInputs
* [`b6a3ccfa`](https://github.com/NixOS/nixpkgs/commit/b6a3ccfaf72e486444903fab3f89730210395f19) python3Packages.sqlalchemy: 1.4.37 -> 1.4.38
* [`2999d018`](https://github.com/NixOS/nixpkgs/commit/2999d0186fe8cbbca282ee1964fbcbbf2073c59d) nss_latest: 3.79 -> 3.80
* [`badbca89`](https://github.com/NixOS/nixpkgs/commit/badbca891cbe10c4ab52531b4b0210bf326715c2) python310Packages.babel: 2.10.1 -> 2.10.3
* [`f9323453`](https://github.com/NixOS/nixpkgs/commit/f93234530f930393a50bf8341b2e0b5184982937) python310Packages.certifi: 2022.05.18.1 -> 2022.06.15
* [`04be37de`](https://github.com/NixOS/nixpkgs/commit/04be37dead641c3d08cc179428e106e01352c907) cacert: 3.77 -> 3.80
* [`6771aaec`](https://github.com/NixOS/nixpkgs/commit/6771aaec5c21b59975f3e9e707f90706e502e05c) weylus: 0.11.4 -> unstable-2022-06-07
* [`beff393c`](https://github.com/NixOS/nixpkgs/commit/beff393cc732ecdfe76b3377e23a19a3cf13cecb) python3Packages.sqlalchemy: 1.4.38 -> 1.4.39
* [`8f1e861f`](https://github.com/NixOS/nixpkgs/commit/8f1e861f4b76b1d283cc70d5d09842aa2c4bcd51) R: 4.2.0 -> 4.2.1
* [`20f3160f`](https://github.com/NixOS/nixpkgs/commit/20f3160f41f423485ddf34cac582d64144292405) ninja: disable line-clearing with TERM=dumb
* [`eaf4ec26`](https://github.com/NixOS/nixpkgs/commit/eaf4ec26347eb6fa4e55a933810967ab94cd8c03) plasma5Package.baloo: Unbreak kde-baloo.service startup
* [`0eac24a1`](https://github.com/NixOS/nixpkgs/commit/0eac24a1475c6829b4dcecbac27ab7b51d0dc1f2) m4: build offline documentation
* [`e9d95b52`](https://github.com/NixOS/nixpkgs/commit/e9d95b52236204d6742c510f20e664b7064f63d8) texinfo4: use recent config.guess script
* [`fb3951c8`](https://github.com/NixOS/nixpkgs/commit/fb3951c8aff3014ab9b244279fe61b611107c2f5) Revert "texinfo4: use recent config.guess script"
* [`6cc6b907`](https://github.com/NixOS/nixpkgs/commit/6cc6b907d55665b04cb23046c74f952e55e594c0) Revert "m4: build offline documentation"
* [`7d5108c5`](https://github.com/NixOS/nixpkgs/commit/7d5108c5dc6bf1f3479c0f859922ba1b09fa6dc3) sqlite: 3.38.5 -> 3.39.0
* [`c9afe80b`](https://github.com/NixOS/nixpkgs/commit/c9afe80ba58ec9ea31e154572633b084fdbcbcd7) coreutils: reintroduce patch disabling SEEK_HOLE in cp for darwin x86_64
* [`88223bcc`](https://github.com/NixOS/nixpkgs/commit/88223bcc015834ed93bf9ca3dcc8e51cd1f684ee) libsForQt5.phonon-backend-gstreamer: backport fix for https://bugs.kde.org/show_bug.cgi?id=445196
* [`e838f7e1`](https://github.com/NixOS/nixpkgs/commit/e838f7e117c5b448a6983d07535c8107c5b35bd7) python310Packages.pytest-mock: 3.7.0 -> 3.8.1
* [`5d6372d1`](https://github.com/NixOS/nixpkgs/commit/5d6372d13ec405b973f9adfd70d9116f192ba181) async-profiler: 2.0 -> 2.8.1
* [`fe5d77ff`](https://github.com/NixOS/nixpkgs/commit/fe5d77ff39bd4fecde619ed598c7a9c5fc7e6eb8) liburing: 2.1 -> 2.2
* [`caea0835`](https://github.com/NixOS/nixpkgs/commit/caea0835e4448ba2af01c22b4726c40df346578c) haskellPackages: stackage LTS 19.12 -> LTS 19.13
* [`b5ea8072`](https://github.com/NixOS/nixpkgs/commit/b5ea807275040d364a22c6e96383e53b8e485914) all-cabal-hashes: 2022-06-23T03:01:47Z -> 2022-06-26T16:08:53Z
* [`7cc8942e`](https://github.com/NixOS/nixpkgs/commit/7cc8942e14a3fc4f7be49277d04803bb66fecf35) haskellPackages: regenerate package set based on current config
* [`daa5698a`](https://github.com/NixOS/nixpkgs/commit/daa5698a8c2bd3c2ac150c01ea36d5b5da4eb365) python310Packages.pycares: 4.1.2 -> 4.2.0
* [`f31a28d1`](https://github.com/NixOS/nixpkgs/commit/f31a28d12cf62cc73ade8eefa6d3feb1ab91035c) vaultwarden-vault: 2.27.0 -> 2022.5.2
* [`7d32b083`](https://github.com/NixOS/nixpkgs/commit/7d32b083ff3c6411c40172750c99d8340f112ad8) ntfy-sh: 1.26.0 -> 1.27.2
* [`66fc1099`](https://github.com/NixOS/nixpkgs/commit/66fc10995b501419b584ae56eeffaa475e24b6fe) sollya: build on darwin and enable tests
* [`31b1f371`](https://github.com/NixOS/nixpkgs/commit/31b1f3716ab5a66b65297ec277f7ac52e0ccefd8) autoconf-archive: 2021.02.19 -> 2022.02.11
* [`0aec6813`](https://github.com/NixOS/nixpkgs/commit/0aec6813da2cb760c0315df7287ce94b5e24b8fb) gtkwave: support darwin build
* [`b6141fb7`](https://github.com/NixOS/nixpkgs/commit/b6141fb75d16e812209e01e1f8ad73e13503457b) libaom: 3.3.0 -> 3.4.0
* [`a8320c33`](https://github.com/NixOS/nixpkgs/commit/a8320c3361b50baf06659550347b355f413efd48) neomutt: fix sendmail default value
* [`54a65b5c`](https://github.com/NixOS/nixpkgs/commit/54a65b5cd5b14f989056d210518ebba0e47cd3af) cmake: Fix darwin-specific remove-systemconfiguration-dep patch
* [`fb763091`](https://github.com/NixOS/nixpkgs/commit/fb76309157844cd573ebb47c81d7583f8b5ac619) python310Packages.urllib3: remove pyopenssl as it is no longer recommended
* [`71260be5`](https://github.com/NixOS/nixpkgs/commit/71260be594f49b03c66fd054dd6040993d8ac208) doxygen: 1.9.3 -> 1.9.4
* [`5abffc8c`](https://github.com/NixOS/nixpkgs/commit/5abffc8c5eabe78f19583d05149f65d9dfa8f4d8) python310Packages.pycryptodome: 3.14.1 -> 3.15.0
* [`fa0f161e`](https://github.com/NixOS/nixpkgs/commit/fa0f161ef7adab47866e16f78c35bdb9ef584d85) epson-escpr2: 1.1.46 -> 1.1.48
* [`8d49c0ba`](https://github.com/NixOS/nixpkgs/commit/8d49c0ba6d5ddae5eba45d39a7e66b9b6200adb6) all-cabal-hashes: 2022-06-26T16:08:53Z -> 2022-06-28T01:15:54Z
* [`352c7eaf`](https://github.com/NixOS/nixpkgs/commit/352c7eaf9d4582462e06ca0c4bc2b27eed7234db) haskellPackages: regenerate package set based on current config
* [`32895548`](https://github.com/NixOS/nixpkgs/commit/32895548fec56f8f994d712ecd8db1e245413aa0) gitleaks: 8.8.8 -> 8.8.10
* [`9a40b19b`](https://github.com/NixOS/nixpkgs/commit/9a40b19bedee45a583cb7dce92b8cf20e6e14d44) python3Packages.cython: 0.29.28 -> 0.29.30
* [`365831bb`](https://github.com/NixOS/nixpkgs/commit/365831bb446c67be2b26793eab40e6f58a672500) pcre2: fix gitea websearch crashing when searching for a plain string
* [`160aaf5d`](https://github.com/NixOS/nixpkgs/commit/160aaf5dd3a74d708e8a1478e98835c38f7ca8cc) nvidia-driver: Install windows libraries needed by Proton to support DLSS
* [`26105516`](https://github.com/NixOS/nixpkgs/commit/261055164319f5327eee2eb6511a9a28f8dae9b2) python3Packages.pythran: 0.9.12 -> 0.11.0, clean up a bit
* [`611edec7`](https://github.com/NixOS/nixpkgs/commit/611edec7fd2fdedb0f4ef28b7db8535d8728a155) python310Packages.jsonschema: 4.6.0 -> 4.6.1
* [`d97e9110`](https://github.com/NixOS/nixpkgs/commit/d97e911074994432b24edfd166178ac4efbdc32d) python310Packages.pycares: 4.2.0 -> 4.2.1
* [`8e3c7a1f`](https://github.com/NixOS/nixpkgs/commit/8e3c7a1fd54577b49d56f40a58d6927e6027ce6a) maintainers: add a helper script for the options doc conversion
* [`33ca33b0`](https://github.com/NixOS/nixpkgs/commit/33ca33b0edaef43fd7b821c347691b4aee13148f) Revert "sphinx_offline: init"
* [`4650f244`](https://github.com/NixOS/nixpkgs/commit/4650f24496ca779167540ed2fa5518700c70ce40) Revert "ghc: Work around broken pyopenssl on aarch64-darwin"
* [`919e04f5`](https://github.com/NixOS/nixpkgs/commit/919e04f5d75773bfd8c1b8f76ce1cf030bcd8d68) asciidoc: 9.1.0 -> 10.2.0
* [`601d9db2`](https://github.com/NixOS/nixpkgs/commit/601d9db27f32df51461627b0fc8099ea80c98e23) asciidoc: get rid of `? null`
* [`3f88d51e`](https://github.com/NixOS/nixpkgs/commit/3f88d51e025bcbdb03119352c436ef0c922f6e91) gcc10: 10.3.0 -> 10.4.0
* [`f167634b`](https://github.com/NixOS/nixpkgs/commit/f167634b357bb205e3001797be83720dc6abaaa4) maintainers: add 0xd61
* [`e1919b24`](https://github.com/NixOS/nixpkgs/commit/e1919b24c94ee6f7c37f2ebe8b71ad79722f71b8) pkgsMusl.iptables: fix build with upstream patch
* [`aebe4d27`](https://github.com/NixOS/nixpkgs/commit/aebe4d27c7bbd18753cd0138f169a5ac47969093) nvidia_x11: 515.48.07 → 515.57
* [`956dd00d`](https://github.com/NixOS/nixpkgs/commit/956dd00dc73e2e3fe12d0f803a7c1151004adfd0) cachix: pin to nix_2_9
* [`c15e73a0`](https://github.com/NixOS/nixpkgs/commit/c15e73a012d48fb4f1eee463b161a333add587b7) hercules-ci-{agent,cnix-expr,cnix-store}: pin to nix_2_9
* [`c51b11be`](https://github.com/NixOS/nixpkgs/commit/c51b11bef5b35605243f12a658b7f49b6d5e0bdc) python310Packages.requests: 2.28.0 -> 2.28.1
* [`70daeea1`](https://github.com/NixOS/nixpkgs/commit/70daeea1c01e1531135db8cab53dc2dbee376e8c) surf: enable audio & video support
* [`c1fc59a7`](https://github.com/NixOS/nixpkgs/commit/c1fc59a7956543a0ab93be816595987981faae30) libdwarf_0_4: 0.4.0 -> 0.4.1
* [`77454bd3`](https://github.com/NixOS/nixpkgs/commit/77454bd32bcf84ba38c4b6e0f460a3e83ffbcfdb) libjxl: fix build with asciidoc wrapped in shell script
* [`f031dafc`](https://github.com/NixOS/nixpkgs/commit/f031dafcc83f08a137e50569d77a51873ebf28ac) libv4l: fix build for non-glibc platforms
* [`cbf77c4a`](https://github.com/NixOS/nixpkgs/commit/cbf77c4a1e99b771648bceee024c0c99b8a79681) geant4: remove configuration for optional non-toolkit dependencies
* [`210830ec`](https://github.com/NixOS/nixpkgs/commit/210830ec771bf937592001a2f2aea24a0ba6ce7e) geant4: s/enableQT/enableQt/g
* [`b7e50b7b`](https://github.com/NixOS/nixpkgs/commit/b7e50b7b21911385c9e50bf52fb54e033de692af) geant4: add geant4.passthru.enableQt
* [`714b6a76`](https://github.com/NixOS/nixpkgs/commit/714b6a7665d86acecea99e52e3e2af19bdb5712b) geant4: propagate wrapQtAppsHook if enableQt
* [`6489c1e2`](https://github.com/NixOS/nixpkgs/commit/6489c1e2a643c4cf7115eacabd31c0cfc898b1de) geant4.data: refactor to use callPackage
* [`77e6eda9`](https://github.com/NixOS/nixpkgs/commit/77e6eda9b237561d8e3da020e20c84d17d4aaf27) python310Packages.setuptools-scm: fix cross compile of dependents
* [`a1edc2fe`](https://github.com/NixOS/nixpkgs/commit/a1edc2fe67a6efd0c4fd0febb8008091daa5c2ef) alsa-lib: 1.2.6.1 -> 1.2.7.1
* [`6e621eac`](https://github.com/NixOS/nixpkgs/commit/6e621eac20e17e5a113f35f44267ec47e4ee97dc) alsa-plugins: 1.2.6 -> 1.2.7.1
* [`92370d9f`](https://github.com/NixOS/nixpkgs/commit/92370d9feab8b38ddbc83a2fddeac22ca8069d74) alsa-ucm-conf: 1.2.6.3 -> 1.2.7.1
* [`cfa642c7`](https://github.com/NixOS/nixpkgs/commit/cfa642c755f5fcda4aa1b33ec0e66aab11fe647f) go-graft: init at 0.2.6
* [`7a1c2f78`](https://github.com/NixOS/nixpkgs/commit/7a1c2f78088726c000ccc87e511c9dc5a4eb34ae) sbcl_2_2_6: init at 2.2.6
* [`7f939523`](https://github.com/NixOS/nixpkgs/commit/7f939523608cc9c47e9a1df19d30bcca14ff7a86) sbcl: 2.2.4 -> 2.2.6
* [`1a96397c`](https://github.com/NixOS/nixpkgs/commit/1a96397c081e0056abb0236ec29ca6422e333d01) libsepol: enable parallel building
* [`86c7c091`](https://github.com/NixOS/nixpkgs/commit/86c7c0917face6c771e4244a90d22c0ec04ce68c) haskell.compiler.ghc865Binary: add powerpc64le bootstrap
* [`88738c79`](https://github.com/NixOS/nixpkgs/commit/88738c79df4d09f4ec62cc5b5f25e0686f5885d9) libsoup_3: 3.0.6 -> 3.0.7
* [`c99ba0c4`](https://github.com/NixOS/nixpkgs/commit/c99ba0c467261c483fb9b06d177f44082921f8ce) glib: 2.72.2 -> 2.72.3
* [`1badcfab`](https://github.com/NixOS/nixpkgs/commit/1badcfab27a4345617035f6c269e252afa355539) mate.mate-tweak: 22.04.4 -> 22.04.8
* [`0e9dd6bd`](https://github.com/NixOS/nixpkgs/commit/0e9dd6bd57d1fa6d58ddcfa28547ee2037a1a808) libopenmpt: 0.6.3 -> 0.6.4
* [`20f94696`](https://github.com/NixOS/nixpkgs/commit/20f946962596c3f99ce5d04f402799aa35f88da1) rare: cleanup
* [`af15cfb5`](https://github.com/NixOS/nixpkgs/commit/af15cfb5b371f2bf9844f41405b6ee4f81bfea04) mypy: 0.941 → 0.961
* [`6e70d1d3`](https://github.com/NixOS/nixpkgs/commit/6e70d1d303f1b765b184bce97ed1f96bdb4a6851) jellyfin: fix arm{,64} compilation
* [`6723b43a`](https://github.com/NixOS/nixpkgs/commit/6723b43aa8c98a34dfe786b3a0f26c7f65aa0e30) osinfo-db: 20220214 -> 20220516
* [`3ed1328b`](https://github.com/NixOS/nixpkgs/commit/3ed1328b9bdc61bb220d516fbbcdbf7befa74b41) hplip: 3.21.12 -> 3.22.6
* [`7b5ee6d9`](https://github.com/NixOS/nixpkgs/commit/7b5ee6d9275a26fdbcdbfc169cddab4d4a1d098a) python3Packages.afdko: 3.8.3 -> 3.9.0
* [`cb9a3349`](https://github.com/NixOS/nixpkgs/commit/cb9a33497fb96262973c4c64ca767cb09e568dbc) generic-updater: fix nix edit command line
* [`09528e6d`](https://github.com/NixOS/nixpkgs/commit/09528e6db80e34dbc764550c8cb1f6383f26168f) rPackages: CRAN and BioC update
* [`3d6c926c`](https://github.com/NixOS/nixpkgs/commit/3d6c926c4f6464ba73a176686d65536f3ce17da4) treewide/servers,shells,tools: add sourceType for more packages
* [`322472c5`](https://github.com/NixOS/nixpkgs/commit/322472c5fea968ec5ed5e98dca81a7752ff0cb5b) archisteamfarm: 5.2.6.3 -> 5.2.7.7
* [`c96e95f5`](https://github.com/NixOS/nixpkgs/commit/c96e95f5867919431021211a45b48747b4028bca) archisteamfarm.ui: update
* [`87cd533a`](https://github.com/NixOS/nixpkgs/commit/87cd533a328750587e9545c12e4a81f7af67a8a4) nixos/qemu-vm: allow custom partitions and filesystems in VM
* [`4c77ffb3`](https://github.com/NixOS/nixpkgs/commit/4c77ffb38fcdb2accf3760966e4e6bc8628316b4) nixos/tests: add non-default-filesystems test
* [`52490316`](https://github.com/NixOS/nixpkgs/commit/5249031660b21610e291272fd2a9ebd172fda812) nixos/tests: add swap-partition test
* [`6eea8662`](https://github.com/NixOS/nixpkgs/commit/6eea86625ea6e2d9dcb2290b909f5892ac6589be) boinc: 7.20.0 -> 7.20.1
* [`98365428`](https://github.com/NixOS/nixpkgs/commit/98365428b067485a32f23fcf70552c9882203f18) all-cabal-hashes: 2022-07-02T15:59:48Z -> 2022-07-02T15:59:48Z
* [`3865a901`](https://github.com/NixOS/nixpkgs/commit/3865a901725e316fe0a98d1df025527ef7348f8f) haskellPackages: regenerate package set based on current config
* [`c996ce44`](https://github.com/NixOS/nixpkgs/commit/c996ce44157e11713b4b6fd588f09becc2252ab0) haskellPackages.misfortune: remove patch
* [`54897154`](https://github.com/NixOS/nixpkgs/commit/5489715475abb729df345038584ab72b1a881e38) deepwave: init at 0.0.11
* [`55c5a83c`](https://github.com/NixOS/nixpkgs/commit/55c5a83c4c8a3ba59e62d612383b1a4aacf27be0) librewolf: 101.0.1-1 -> 102.0-2
* [`58e2a184`](https://github.com/NixOS/nixpkgs/commit/58e2a1848067d3482d4c88c03440c5ecdf3d1e95) texlive.bin.xdvi: pull upstream darwin fix for -fno-common toolchains
* [`b41d4fb8`](https://github.com/NixOS/nixpkgs/commit/b41d4fb8d49bcc9728da679fc7fe86d46ed4ae24) python310Packages.aiopg: 1.3.3 -> 1.3.4
* [`f452ce73`](https://github.com/NixOS/nixpkgs/commit/f452ce73961cd7217208b07d6de5477630b239d8) cudatext: 1.166.2 -> 1.166.5
* [`3d0e70ae`](https://github.com/NixOS/nixpkgs/commit/3d0e70ae2ad9a6545eb70b067b5c081eba45ee6c) gnupg: Add patch for CVE-2022-34903
* [`060e4ecb`](https://github.com/NixOS/nixpkgs/commit/060e4ecb2f6fe1fbf4d3a07367aec41884123b8d) checkSSLCert: 2.32.0 -> 2.33.0
* [`37084f74`](https://github.com/NixOS/nixpkgs/commit/37084f74518a0cb91d6fdbed2b54555a5a7432be) python310Packages.pysmt: 0.9.1.dev132 -> 0.9.5
* [`9b41c6a1`](https://github.com/NixOS/nixpkgs/commit/9b41c6a18a43e8598bb6829b9b0374ff9409dfd4) python310Packages.pyhumps: 3.7.1 -> 3.7.2
* [`72b001fd`](https://github.com/NixOS/nixpkgs/commit/72b001fd68cff13d000a3f1e8be57722cb4a1284) pyradio: 0.8.9.21 -> 0.8.9.22
* [`07729dfc`](https://github.com/NixOS/nixpkgs/commit/07729dfccff5e092c5e18821a5e077d5fd573863) wapiti: remove condition for importlib-metadata
* [`432bd70f`](https://github.com/NixOS/nixpkgs/commit/432bd70f7db8558b44cf52d713eb1de8bba6fac8) jdt-language-server: 1.8.0 -> 1.13.0
* [`de0d0a2f`](https://github.com/NixOS/nixpkgs/commit/de0d0a2fb0dd87320ce633378a5183dfb1a56b35) frece: init at 1.0.6
* [`efcfeb4c`](https://github.com/NixOS/nixpkgs/commit/efcfeb4cd9ffc26a5b639be01e027f067bed641a) check-jsonschema: init at 0.16.2
* [`5c152509`](https://github.com/NixOS/nixpkgs/commit/5c15250962e7a856896063e7cf88a3c5dd63710f) synapse-admin: source build
* [`cf19e964`](https://github.com/NixOS/nixpkgs/commit/cf19e96438c4b772ed7f4600d35348ccca90ccae) edgedb: init at unstable-2022-06-27
* [`3ac5490e`](https://github.com/NixOS/nixpkgs/commit/3ac5490e4efe69fbdf861e972b78a646332bd2a7) python310Packages.pecan: 1.4.1 -> 1.4.2
* [`31c14633`](https://github.com/NixOS/nixpkgs/commit/31c14633431c17520333ed6d18eaa0e63688ab12) offpunk: init at 1.4
* [`b6805190`](https://github.com/NixOS/nixpkgs/commit/b6805190a2b5d65e93aba36d87404c4dd5cb4cbc) tor-browser-bundle-bin: 11.0.14 -> 11.0.15
* [`3f4d5f2c`](https://github.com/NixOS/nixpkgs/commit/3f4d5f2cf8794f09892b73b786447ee8bb0b6173) haskellPackages.rio: skip a broken test on aarch64-darwin
* [`25bd9f55`](https://github.com/NixOS/nixpkgs/commit/25bd9f555151ab3e6f860c286b49b651f36e181b) vopono: 0.9.2 -> 0.10.0
* [`a18f8633`](https://github.com/NixOS/nixpkgs/commit/a18f8633c79ab103d81df702f141019f1160f17f) your-editor: 1400 -> 1403
* [`1c153a86`](https://github.com/NixOS/nixpkgs/commit/1c153a860df313079e19cbedfe6624a5273623fc) fetchit: init at 0.0.1
* [`d1dcbade`](https://github.com/NixOS/nixpkgs/commit/d1dcbade3dbe4ed018c8f25d58c8e02b282d1348) python3Packages.humanize: add Luflosi as maintainer
* [`228c2d6c`](https://github.com/NixOS/nixpkgs/commit/228c2d6c1c3e7f76a630ba1c7fb69d09c3227c27) python3Packages.humanize: include generated translations
* [`dcc323e1`](https://github.com/NixOS/nixpkgs/commit/dcc323e1f181f670904185a08b791f27991c6dea) python3Packages.humanize: 4.1.0 -> 4.2.3
* [`9435afe2`](https://github.com/NixOS/nixpkgs/commit/9435afe202ba907d9273066abc13adbe73743f30) python310Packages.cron-descriptor: 1.2.27 -> 1.2.30
* [`2fcd2a4e`](https://github.com/NixOS/nixpkgs/commit/2fcd2a4e779b157584a3cdf446083b35f97d9b3f) jose: 10 -> 11
* [`fcd299ab`](https://github.com/NixOS/nixpkgs/commit/fcd299ab70ed48092d91e7f305e51f0eff7df2b8) pantheon.switchboard-plug-wacom: 1.0.0 -> 1.0.1
* [`ba48a66d`](https://github.com/NixOS/nixpkgs/commit/ba48a66dec0322fc87eabec63b7e96804c1b8133) pantheon.wingpanel-indicator-notifications: 6.0.4 -> 6.0.5
* [`5deff958`](https://github.com/NixOS/nixpkgs/commit/5deff9583cf6c8fad702bfd9e835bd726aeed308) chore: Set permissions for GitHub actions
* [`363c10d9`](https://github.com/NixOS/nixpkgs/commit/363c10d92205d46a0e8abfcbad9559b3e08f840d) gitqlient: 1.4.3 -> 1.5.0
* [`fb2d1c86`](https://github.com/NixOS/nixpkgs/commit/fb2d1c864545b0e178fc240b745b041bc1ac6318) commix: 3.4 -> 3.5
* [`02ff680b`](https://github.com/NixOS/nixpkgs/commit/02ff680b4d6e57d211307a2c2aef1be0ba395745) flameshot: 12.0.0 -> 12.1.0
* [`8e8231f1`](https://github.com/NixOS/nixpkgs/commit/8e8231f1f028151e4d97bed7d4be7f6512e7d858) terraform-providers: update 2022-07-04
* [`a9b933df`](https://github.com/NixOS/nixpkgs/commit/a9b933df1cc93c2fedd5b9d06a1d4daa48d8c15b) linux: 4.14.285 -> 4.14.286
* [`67b230bd`](https://github.com/NixOS/nixpkgs/commit/67b230bd08146e4a822ff1e6bc314501dc7b768c) linux: 4.19.249 -> 4.19.250
* [`734b6f6d`](https://github.com/NixOS/nixpkgs/commit/734b6f6d30aebb10f0eacd47f73a9ad05f625213) linux: 4.9.320 -> 4.9.321
* [`1e013585`](https://github.com/NixOS/nixpkgs/commit/1e013585246f212144f7f7da5124706d5061c121) linux: 5.10.127 -> 5.10.128
* [`edd230fb`](https://github.com/NixOS/nixpkgs/commit/edd230fbc47fae924ce94153c3c393e8b83a1ae0) linux: 5.15.51 -> 5.15.52
* [`39a8cebc`](https://github.com/NixOS/nixpkgs/commit/39a8cebc2b637f6a9a14ae448939d2ff81785cd7) linux: 5.18.8 -> 5.18.9
* [`11175187`](https://github.com/NixOS/nixpkgs/commit/111751879d8a0d59c20eae929b95b93fc7aef68f) linux: 5.4.202 -> 5.4.203
* [`513b8a9d`](https://github.com/NixOS/nixpkgs/commit/513b8a9d2b7650e3d6ba33edc739245fbce6fff7) pantheon.gala: fix initial alt-tab switcher indicator visibility
* [`6841314b`](https://github.com/NixOS/nixpkgs/commit/6841314b45158eb8251b4fa98ce576bf13aa64c2) pantheon.granite7: fix large height bug for MessageDialog
* [`f31f162b`](https://github.com/NixOS/nixpkgs/commit/f31f162bbf6fa22ea57d9f6af52d81ab1e453166) tracker: skip broken tests
* [`b3aee32a`](https://github.com/NixOS/nixpkgs/commit/b3aee32add2396c1521b83b5c6c92e4c53108bcc) hdf5_1_10: 1.10.6 -> 1.10.9
* [`e69aee32`](https://github.com/NixOS/nixpkgs/commit/e69aee3280033dd7fbf90bfe479fc279e43a365e) ocamlPackages.io-page: 2.3.0 → 2.4.0
* [`6791c3ae`](https://github.com/NixOS/nixpkgs/commit/6791c3ae1163be0f6b5fd9d1da61366f2e0f246e) ocamlPackages.io-page: 2.4.0 → 3.0.0
* [`8aaed36d`](https://github.com/NixOS/nixpkgs/commit/8aaed36df32bcff840489b7083b4cb077a7cf97a) archimedes: use latest toolchain, not gcc-6
* [`4b0803ff`](https://github.com/NixOS/nixpkgs/commit/4b0803ffb279bdada1ec1ffc2294ff86346b56ea) phylactery: 0.1.1 -> 0.1.2
* [`1cfe539b`](https://github.com/NixOS/nixpkgs/commit/1cfe539b03993e01600ef55bbbaa1163f35d5b78) ocamlPackages.digestif: 1.1.0 → 1.1.2
* [`a5ce71d4`](https://github.com/NixOS/nixpkgs/commit/a5ce71d4e8cbe1d3311aeddc86a8d847989d6099) xmr-stak: drop gcc6 requrement (and cuda support)
* [`8782d22f`](https://github.com/NixOS/nixpkgs/commit/8782d22f98fd74c6f3de12476f60492e180df294) python310Packages.hahomematic: 1.9.3 -> 1.9.4
* [`41e24f5f`](https://github.com/NixOS/nixpkgs/commit/41e24f5f4bf1bc1d444c17a66a220f75be550d6e) tracker: use upstream patch instead of disabling test
* [`50dff7c6`](https://github.com/NixOS/nixpkgs/commit/50dff7c678cf9f17ae27f6465a21ff366eb18f08) atlassian-jira: 8.22.2 -> 8.22.4
* [`62e5acd0`](https://github.com/NixOS/nixpkgs/commit/62e5acd0a7573c0001c92cb36e38de0b247ccc01) ruby: Expose generic builder ([nixos/nixpkgs⁠#173390](https://togithub.com/nixos/nixpkgs/issues/173390))
* [`899a37d1`](https://github.com/NixOS/nixpkgs/commit/899a37d1909be0d4a11102bbdaeaebef793a5177) nixos/matrix-synapse: update docs
* [`4145dfe7`](https://github.com/NixOS/nixpkgs/commit/4145dfe7517985594d1b630c4893bb4a6eed2210) pls: 5.1.2 -> 5.2.0
* [`20c5555a`](https://github.com/NixOS/nixpkgs/commit/20c5555a46a864c3429c82f7fb14f5934027321d) moolticute: 0.53.7 → 0.55.0
* [`5da31db7`](https://github.com/NixOS/nixpkgs/commit/5da31db7444b050af5d1ae313d74a75875e1d5dc) janet: 1.22.0 -> 1.23.0
* [`d4fee295`](https://github.com/NixOS/nixpkgs/commit/d4fee295429e35e242c39d6b0eb67c011955d541) jpm: 0.0.2 -> 1.1.0
* [`47b3ccc3`](https://github.com/NixOS/nixpkgs/commit/47b3ccc305ca5f3b6b484979448765cc763eb733) python3Packages.unittest2: unbreak
* [`e45d0464`](https://github.com/NixOS/nixpkgs/commit/e45d0464d5016f2795e567738652b6bf07443ee7) qt6: 6.3.0 -> 6.3.1
* [`ccddf9a0`](https://github.com/NixOS/nixpkgs/commit/ccddf9a017151fd8ad2bc65a7e8778a5f69290f6) amiri: 0.114 → 0.117
* [`76a24f2d`](https://github.com/NixOS/nixpkgs/commit/76a24f2d7955f245a0e7eb2fbc595fd3cb562f6c) ocamlPackages.secp256k1-internal: 0.2 → 0.3
* [`57398709`](https://github.com/NixOS/nixpkgs/commit/5739870901c737eca6ec03472a86fb0ecc1cf086) zfp: use python3Packages
* [`ac8fadc7`](https://github.com/NixOS/nixpkgs/commit/ac8fadc7f35009bf0fd81e9306c92a4238b0fe4c) colima: 0.4.2 -> 0.4.4 ([nixos/nixpkgs⁠#179522](https://togithub.com/nixos/nixpkgs/issues/179522))
* [`2a1a6e53`](https://github.com/NixOS/nixpkgs/commit/2a1a6e53571fe8eb26f4450025df53b8a36b9449) neovim-qt: 0.2.16.1 -> 0.2.17
* [`b80115e8`](https://github.com/NixOS/nixpkgs/commit/b80115e85f7c64635ab7d5f9d8024178447b4849) gnome.gnome-remote-desktop: 42.2 -> 42.3
* [`df3148fa`](https://github.com/NixOS/nixpkgs/commit/df3148fa1bacdb87d5633f294fc2a071cc520fe2) panolpy: 5.0.6 -> 5.1.0
* [`47342c28`](https://github.com/NixOS/nixpkgs/commit/47342c280a91a1a8fa0ecf2f7f78dfb27c18310a) gtk-engine-murrine: move intltool to nativeBuildInputs, set strictDeps
* [`383ee3c1`](https://github.com/NixOS/nixpkgs/commit/383ee3c194359482710e25cf07ab071cf5ad10cd) kdigger: 1.2.0 -> 1.2.1
* [`887f70ff`](https://github.com/NixOS/nixpkgs/commit/887f70ffbd6b95c74def8451b0de65926670b863) open-policy-agent: 0.41.0 -> 0.42.0
* [`24209086`](https://github.com/NixOS/nixpkgs/commit/242090860a2d2f9d665d5b1629402996c12af4b1) nixos/openwebrx: add codec2, js8call
* [`9d8c5fee`](https://github.com/NixOS/nixpkgs/commit/9d8c5fee6b5e587a52a9eb39ba84715fcff2ca24) github-runner: remove nodejs-12_x references
* [`c4b88286`](https://github.com/NixOS/nixpkgs/commit/c4b88286304b7b48b1e58922790fc279241536ca) treewide: node*.nix remove references to nodejs-12_x
* [`126bd386`](https://github.com/NixOS/nixpkgs/commit/126bd386d802ac9b99b9a2deb30d3800dd26013c) cryptpad: remove
* [`1c0cc017`](https://github.com/NixOS/nixpkgs/commit/1c0cc017b5e8788451e919cbf81b29b60916dda1) nixos/cryptpad: remove
* [`26748944`](https://github.com/NixOS/nixpkgs/commit/2674894432ab1c175c19a8de2d8f993d01615ae5) nodejs-12_x: remove
* [`e1da4644`](https://github.com/NixOS/nixpkgs/commit/e1da4644111638d3510aea4e4139034ea136a959) python310Packages.mcstatus: 9.1.0 -> 9.2.0
* [`c9bf5769`](https://github.com/NixOS/nixpkgs/commit/c9bf57696dbf140e6bde21959f445eb0fc24bde6) python310Packages.python-whois: 0.7.3 -> 0.8.0
* [`98d3deb5`](https://github.com/NixOS/nixpkgs/commit/98d3deb5240538c0c601d81e618434de84146e9a) offensive-azure: relax python-whois constraint
* [`669577c0`](https://github.com/NixOS/nixpkgs/commit/669577c0bb222d3b850b8444e9713f61d277ee21) python310Packages.google-auth: remove pyopenssl
* [`bee55a9c`](https://github.com/NixOS/nixpkgs/commit/bee55a9c67327851808adc8459c27648802e439d) sierra-breeze-enhanced: 1.0.3 -> 1.1.0
* [`6902d290`](https://github.com/NixOS/nixpkgs/commit/6902d29037ee0be1df30093c5f2bca04411fae0d) sqlfluff: 1.0.0 -> 1.1.0
* [`f6c3cd0c`](https://github.com/NixOS/nixpkgs/commit/f6c3cd0c8b8c2b5578c6b086285853a8f2181a60) python310Packages.iminuit: 2.12.0 -> 2.12.1 ([nixos/nixpkgs⁠#179976](https://togithub.com/nixos/nixpkgs/issues/179976))
* [`b0849050`](https://github.com/NixOS/nixpkgs/commit/b0849050570a0aced6c1a8550f56fba12d07b0a9) weston: fix race condition in build system
* [`4ed794f1`](https://github.com/NixOS/nixpkgs/commit/4ed794f1bc5183df62f436be0230e8b4b1eb7767) got: 0.70 -> 0.73
* [`f06686be`](https://github.com/NixOS/nixpkgs/commit/f06686be1b37d49fcd7b86610ddd35ef7fe43b89) LibreArp: 2.2 -> 2.4
* [`09f71f17`](https://github.com/NixOS/nixpkgs/commit/09f71f17e6774fdc4351d90cbe6e6dddeb13aa9f) python310Packages.peaqevcore: 3.0.6 -> 3.0.7
* [`25bf1272`](https://github.com/NixOS/nixpkgs/commit/25bf12720179eaa7bf9868bbe5907be35220d1e0) python310Packages.phonenumbers: 8.12.49 -> 8.12.51
* [`200d8c50`](https://github.com/NixOS/nixpkgs/commit/200d8c500acfb390feb7c7d652a6400a31acbc72) snakemake: 7.8.3 -> 7.8.5 ([nixos/nixpkgs⁠#179874](https://togithub.com/nixos/nixpkgs/issues/179874))
* [`17a62d74`](https://github.com/NixOS/nixpkgs/commit/17a62d74b783a47069cab75438f7b5c5ce865607) kubescape: 2.0.158 -> 2.0.160
* [`576a97a0`](https://github.com/NixOS/nixpkgs/commit/576a97a0d0574af262e89ff2f3332a8493977d09) xcftools: patch CVE-2019-5086 and CVE-2019-5087
* [`df304cc7`](https://github.com/NixOS/nixpkgs/commit/df304cc7737dd27cb44861c853b74ad8f0c447d4) vxl: 1.17.0-nix1 -> 3.3.2
* [`8befefd1`](https://github.com/NixOS/nixpkgs/commit/8befefd1a72da597bdb1d01e97127e0c9866912e) workflows: Remove 21.11 merges
* [`68da5b2a`](https://github.com/NixOS/nixpkgs/commit/68da5b2a225a7865898623a7aba92eaa494ee84a) lib/trivial: Update oldestSupportedRelease
* [`e5cded32`](https://github.com/NixOS/nixpkgs/commit/e5cded3294e84e05c34513f5668cc0f87db3140a) dvc: update optional dependencies
* [`d9d73134`](https://github.com/NixOS/nixpkgs/commit/d9d731345e3c5480fa8e1b620968bcfd4b858a3d) python310Packages.dvc-objects: init at 0.0.18
* [`29a77fc1`](https://github.com/NixOS/nixpkgs/commit/29a77fc1ad992a9b23436ea2be155dadbc1f7eed) python310Packages.dvc-data: init at 0.0.18
* [`1544008c`](https://github.com/NixOS/nixpkgs/commit/1544008cf3920f8adf179f33cfc2d9f78297db6e) python310Packages.dvc-render: add missing input
* [`c2f68f08`](https://github.com/NixOS/nixpkgs/commit/c2f68f081c92d51df57154522a283739ab724a49) ocamlPackages.batteries: 3.4.0 -> 3.5.1
* [`6bc5810d`](https://github.com/NixOS/nixpkgs/commit/6bc5810d7c9ed6feba26139be3610398f71f5d56) pywinrm: remove optional insecure dependency (kerberos)
* [`72bd7c85`](https://github.com/NixOS/nixpkgs/commit/72bd7c85b0a055b1f3a3c42b759116cc3809d3e6) logseq: 0.7.5 -> 0.7.6
* [`8814dd19`](https://github.com/NixOS/nixpkgs/commit/8814dd1962fe3ed87ab18df17a92ce11c144ea39) python310Packages.dulwich: 0.20.43 -> 0.20.44
* [`30c34254`](https://github.com/NixOS/nixpkgs/commit/30c34254603c5a61ae5e861034456f2a35083692) dvc: 2.10.2 -> 2.12.0
* [`e31799b4`](https://github.com/NixOS/nixpkgs/commit/e31799b4742e1bd29ad44414c655a17183b390d9) irssi: 1.2.3 -> 1.4.1
* [`35152923`](https://github.com/NixOS/nixpkgs/commit/351529231b162f61c00c59a4e913bedb765929a0) python3Packages.privacyidea-ldap-proxy: add patch to support LDAPCompareRequest
* [`dd4b6b81`](https://github.com/NixOS/nixpkgs/commit/dd4b6b81fa95dbd71d9f2db5dee968dd8bcb5e29) nixos/mailman: implement LDAP support for postorius
* [`6c7fbcd2`](https://github.com/NixOS/nixpkgs/commit/6c7fbcd21e7e137f4fde9a5c4acaec1d2b594b94) mailman: make `mailmanPackages.extend` actually work in overlays
* [`6a5b1bc0`](https://github.com/NixOS/nixpkgs/commit/6a5b1bc0a376b4bb3e9199ed396c7f73b567cd14) nixos/mailman: strip trailing `\n` when reading the secret
* [`ec2bee24`](https://github.com/NixOS/nixpkgs/commit/ec2bee240424b71886cc11f36fc4a1d241371a12) maintainers: remove elseym
* [`95cc37ab`](https://github.com/NixOS/nixpkgs/commit/95cc37ab9a2b9d402a2f6df83d520e7dd19c5f4d) nicotine-plus: 3.2.1 -> 3.2.2
* [`0ad873b4`](https://github.com/NixOS/nixpkgs/commit/0ad873b44b73ab2fde8c378470cd1b75b7a3c4d2) virtualbox: update patch linux-5.18 -> linux-5.19
* [`4d6eacab`](https://github.com/NixOS/nixpkgs/commit/4d6eacab55e0afef2ed16a6ca05302b46b1e3caf) canon-cups-ufr2: fix libdir pointing to bindir, little format
* [`9996eae4`](https://github.com/NixOS/nixpkgs/commit/9996eae4da616c68c381fd884e3604732896e7ac) arkade: 0.8.28 -> 0.8.29
* [`3a96c0a4`](https://github.com/NixOS/nixpkgs/commit/3a96c0a4f289c19e5d366658f034d434d7b8a17d) autokey: fix No GSettings schemas are installed and clean wrapping
* [`414af487`](https://github.com/NixOS/nixpkgs/commit/414af487b179af0d7792134c79bb83ab2b9617ce) Revert "ocamlPackages.fmt: 0.8.9 -> 0.9.0"
* [`57ca6c39`](https://github.com/NixOS/nixpkgs/commit/57ca6c3933ae42a3ccc0e71c9f5921afe4f929cf) mullvad-vpn: 2022.1 -> 2022.2
* [`5556ee0e`](https://github.com/NixOS/nixpkgs/commit/5556ee0ed63c04113146b037b76097887199b5bd) python3Packages.ua-parser: fix hash
* [`295656a4`](https://github.com/NixOS/nixpkgs/commit/295656a45ae179886c78b232442200e21eb7d747) mullvad: 2022.1 -> 2022.2
* [`141e3f04`](https://github.com/NixOS/nixpkgs/commit/141e3f04af8a5cdabefc99b5608fc85ad75aaa02) kopia: 0.10.7 -> 0.11.0
* [`6a9e4bd1`](https://github.com/NixOS/nixpkgs/commit/6a9e4bd161f5bd821611f976a00ec32cf00073d5) vimv-rs: init at 1.7.5
* [`5ae098c5`](https://github.com/NixOS/nixpkgs/commit/5ae098c5a024bf87bb00f491a8a9e6a1138b36fa) clusterctl: 1.1.4 -> 1.1.5
* [`dff0428a`](https://github.com/NixOS/nixpkgs/commit/dff0428a45de0523860e783d4d2db7e5fdf61c5c) kubectl: override kubernetes
* [`52d499ba`](https://github.com/NixOS/nixpkgs/commit/52d499ba29fa9c894a7064c7651fdf5cead2b974) python310Packages.python-whois: 0.7.3 -> 0.8.0
* [`1468b339`](https://github.com/NixOS/nixpkgs/commit/1468b339d0f3d577f0a3cd1662b9050358672a78) gnome.gnome-shell: 42.2 -> 42.3.1
* [`042db7e1`](https://github.com/NixOS/nixpkgs/commit/042db7e16cab47374eef343e46a4b7e395aa5a13) gnome.gnome-shell-extensions: 42.2 -> 42.3
* [`95ffdc6b`](https://github.com/NixOS/nixpkgs/commit/95ffdc6b7386103936a4d8c153a15aefb3de44e9) gnome.mutter: 42.2 -> 42.3
* [`95325c17`](https://github.com/NixOS/nixpkgs/commit/95325c17936468c12027f3b2aca10cb60ee5b962) gnome.polari: 42.0 -> 42.1
* [`4dcf4a23`](https://github.com/NixOS/nixpkgs/commit/4dcf4a23199f07e8f5e0d713ff01f685df96bba2) python310Packages.typer: 0.4.1 -> 0.4.2
* [`0fc7b58c`](https://github.com/NixOS/nixpkgs/commit/0fc7b58cdb293b5ba13ccfb2070ae7145d9a5e7b) pijul: 1.0.0-beta.1 -> 1.0.0-beta.2
* [`8fed4ee6`](https://github.com/NixOS/nixpkgs/commit/8fed4ee6bbf18d5cb1e7086d2f5d9fd8304943dd) chain-bench: 0.0.3 -> 0.1.0
* [`f5522fb7`](https://github.com/NixOS/nixpkgs/commit/f5522fb775353e6858d33b4986d344d1ba4adb83) nextcloud-client: 3.5.1 -> 3.5.2
* [`d819f155`](https://github.com/NixOS/nixpkgs/commit/d819f155032abaa4752122d184d21ed1beec09de) libwebsockets: 4.3.1 -> 4.3.2
* [`826c20dc`](https://github.com/NixOS/nixpkgs/commit/826c20dcae34f7e3be4d1a638b07fb7d95570ba0) nixos/vault: add option to start in dev mode. ([nixos/nixpkgs⁠#180114](https://togithub.com/nixos/nixpkgs/issues/180114))
* [`fd92b928`](https://github.com/NixOS/nixpkgs/commit/fd92b928276798535889a983f161ea23504e4148) python3.pkgs.xarray: add missing packaging dependency
* [`369ab300`](https://github.com/NixOS/nixpkgs/commit/369ab30030d8c56fe87a06c1fe3b2c0e85ba6253) syncthing: 1.20.2 -> 1.20.3
* [`c30f978f`](https://github.com/NixOS/nixpkgs/commit/c30f978f233f7adace4e8fffff12745486008751) trace-cmd: 3.0.3->3.1.1
* [`01660583`](https://github.com/NixOS/nixpkgs/commit/01660583c015a330a77e0dde4f5609db60af8cb7) topgrade: fix build on darwin
* [`58aad4ee`](https://github.com/NixOS/nixpkgs/commit/58aad4ee0322b6a1173056124c29513dcda0116a) catatonit: set enableParallelBuilding/strictDeps
* [`b71ee18b`](https://github.com/NixOS/nixpkgs/commit/b71ee18bfd0c01b119b450a32cbfa84e152427cf) conmon: set enableParallelBuilding/strictDeps
* [`8de4ffe8`](https://github.com/NixOS/nixpkgs/commit/8de4ffe811527569b0eb0d118c8f27794edcfe5b) crun: set strictDeps
* [`fb8e8ac9`](https://github.com/NixOS/nixpkgs/commit/fb8e8ac918a79d73bd43e23c36631822cf5ca9b8) fuse-overlayfs: set enableParallelBuilding/strictDeps
* [`8b0bc7ce`](https://github.com/NixOS/nixpkgs/commit/8b0bc7ce83bf2d39af03e1f2803eccfb04409e8d) slirp4netns: set strictDeps
* [`919bd2f3`](https://github.com/NixOS/nixpkgs/commit/919bd2f364b493d9996b18a4a5c967291e9f8cc8) n8n: 0.184.0 → 0.185.0
* [`9dc9efef`](https://github.com/NixOS/nixpkgs/commit/9dc9efefc458309fceab286c5a2fae8dd0f65372) jsonnet-language-server: init at 0.7.2
* [`1a28fca8`](https://github.com/NixOS/nixpkgs/commit/1a28fca817d81896f00f5064e76e8f363dbb05cb) difftastic: 0.29.1 -> 0.30.0
* [`568d2e77`](https://github.com/NixOS/nixpkgs/commit/568d2e77f43efd26b387ae43ddc4c3352920ab10) nixos.redis: Fix disabling of RDB persistence.
* [`493c076e`](https://github.com/NixOS/nixpkgs/commit/493c076ec6103bfc9bcf7663ce54859e28545333) vscode-extensions.ms-vscode.cpptools: 1.9.1 -> 1.11.0
* [`2785e3ca`](https://github.com/NixOS/nixpkgs/commit/2785e3ca786dd16136dd29753021a3144ba0f86f) hdf4: simplify javaSupport
* [`4a12c56e`](https://github.com/NixOS/nixpkgs/commit/4a12c56ebdf3066692061f71376e22bcc48375c8) hdfview: add support for darwin
* [`08af7583`](https://github.com/NixOS/nixpkgs/commit/08af758396433af628747879dc4430176c48992a) gf: init at unstable-2022-06-22
* [`273dce6c`](https://github.com/NixOS/nixpkgs/commit/273dce6c32f322bd6ab59bf1fc259d34c1031d93) goreleaser: 1.9.2 -> 1.10.1
* [`a238ca28`](https://github.com/NixOS/nixpkgs/commit/a238ca2853b59b81fb3f2e4d7151295a0fd3935c) webkitgtk: 2.36.3 → 2.36.4
* [`70dc91a4`](https://github.com/NixOS/nixpkgs/commit/70dc91a415ab21cdaacb431abbfdfe313300f211) libsForQt5.bismuth: 3.1.1 -> 3.1.2
* [`75ec318b`](https://github.com/NixOS/nixpkgs/commit/75ec318b8000e5adfe27015607afffab346d72b5) wireplumber: 0.4.10 -> 0.4.11
* [`df23b42a`](https://github.com/NixOS/nixpkgs/commit/df23b42a9aca5ef4abbd50b53cdfd5a301f9a489) udocker: fix build failure
* [`5139952b`](https://github.com/NixOS/nixpkgs/commit/5139952befe5f8f90b88e69f8dd3fe4592d758ac) matrix-common: 1.1.0 -> 1.2.1
* [`8c5079ef`](https://github.com/NixOS/nixpkgs/commit/8c5079ef3e3d77692d0f127b3ae8b8a120ed71d0) matrix-synapse: 1.61.1 -> 1.62.0
* [`a264a86d`](https://github.com/NixOS/nixpkgs/commit/a264a86d935fae69558f363881d65a19a4f4d735) nixos/qt5: add qt5ct as a possible platform theme
* [`a7111548`](https://github.com/NixOS/nixpkgs/commit/a71115488920ce212479a012ba241200826faaeb) blueman: 2.2.5 -> 2.3
* [`4b3793e0`](https://github.com/NixOS/nixpkgs/commit/4b3793e092a0cb181b71c619d2968097e8077446) python310Packages.rflink: 0.0.62 -> 0.0.63
* [`5ee14a73`](https://github.com/NixOS/nixpkgs/commit/5ee14a73f75d03aa61cc666a9c00bb612fb949cf) slurm: move perl to nativeBuildInputs
* [`c29d8a06`](https://github.com/NixOS/nixpkgs/commit/c29d8a06e1338fbec4fdb665bbf62e7ab36999ed) haskellPackages.powerdns: unbreak
* [`b28aebf8`](https://github.com/NixOS/nixpkgs/commit/b28aebf8bbdbc5ea135683c17d064488565bf58b) python310Packages.splinter: 0.18.0 -> 0.18.1
* [`11c38f0a`](https://github.com/NixOS/nixpkgs/commit/11c38f0a6bdc5baebadd903049f43b76c7b3b953) _1password-gui: 8.7.1 -> 8.7.3
* [`04d6b89b`](https://github.com/NixOS/nixpkgs/commit/04d6b89bcc7b21f06259b040659b60d918a5df70) _1password-gui-beta: 8.8.0-119.BETA -> 8.8.0-165.BETA
* [`47ba8cdc`](https://github.com/NixOS/nixpkgs/commit/47ba8cdcc7096242bd98f9d9631fa9dd4974cf53) nixos/qt5: add maintainer
* [`2f19bff1`](https://github.com/NixOS/nixpkgs/commit/2f19bff1b14cf94472c871a164b10123c1d5115e) kopia: 0.11.0 -> 0.11.1
* [`097b70ec`](https://github.com/NixOS/nixpkgs/commit/097b70ec5c3aede047a2c3322933bf3c2fb075f5) wtf: Set `meta.mainProgram` to "wtfutil"
* [`68cc57cc`](https://github.com/NixOS/nixpkgs/commit/68cc57cce147e52f382802c8b257c8f319aac173) nixos/qt5ct: remove enable option and suggests qt5.platformTheme
* [`2a478c94`](https://github.com/NixOS/nixpkgs/commit/2a478c942a672d588e33daef7c5ae4d9a7b83265) broot: 1.13.3 -> 1.14.0
* [`89100132`](https://github.com/NixOS/nixpkgs/commit/89100132771105e851d4f9e43207ef8f59dcb9b9) dendrite: 0.8.8 -> 0.8.9
* [`d10999d7`](https://github.com/NixOS/nixpkgs/commit/d10999d7335191ec644cf89ba81624a73300f893) Add knownVulnerabilities to libdwarf
* [`eded0d65`](https://github.com/NixOS/nixpkgs/commit/eded0d654ceffd5d29113c396af268bcbfea0b8d) octomap: 1.9.7 -> 1.9.8
* [`20f5ebdd`](https://github.com/NixOS/nixpkgs/commit/20f5ebdd3cec7df91fc4e9805a7d002d0f7fc0ae) maintainers/mdize-module: Add known limitations
* [`1360dd9d`](https://github.com/NixOS/nixpkgs/commit/1360dd9d71eed35465e46318e3b4a26af466827d) privacyidea: 3.7.1 -> 3.7.2
* [`000d72eb`](https://github.com/NixOS/nixpkgs/commit/000d72eb7fc02d116fe27fe2cf58f46b29d83b1e) nixos/privacyidea: pin python to 3.9
* [`cbc4d517`](https://github.com/NixOS/nixpkgs/commit/cbc4d51711102e80013917eea84705cc471febdb) zen-kernels: 5.18.7 -> 5.18.9
* [`0c564ffe`](https://github.com/NixOS/nixpkgs/commit/0c564ffe7876338179c32ff9a6b63c36eb0c6a25) python3Packages.pyuv: backport python3.10 build fix
* [`e2a624dd`](https://github.com/NixOS/nixpkgs/commit/e2a624ddc6644c84cbff5283b25f43267d7e3775) circup: 1.1.0 -> 1.1.2
* [`83562c61`](https://github.com/NixOS/nixpkgs/commit/83562c61752b398dabe88be79ab03c914ff901af) k9s: 0.25.18 -> 0.25.21
* [`e3e78bb4`](https://github.com/NixOS/nixpkgs/commit/e3e78bb4095ea946d507fa5ee8ec7f5a43628565) firefox-unwrapped: 102.0 -> 102.0.1
* [`838e78a8`](https://github.com/NixOS/nixpkgs/commit/838e78a8a602456d01d4590aa209b75daca6a926) firefox-bin-unwrapped: 102.0 -> 102.0.1
* [`af7323d1`](https://github.com/NixOS/nixpkgs/commit/af7323d1a8ca96d2cd623e628407223c2fad92a2) discord: fix override
* [`23ee5ac4`](https://github.com/NixOS/nixpkgs/commit/23ee5ac46ad942208b82f3631d891cdb60bb8409) vscode-extensions.piousdeer.adwaita-theme: init at 1.0.7
* [`94053017`](https://github.com/NixOS/nixpkgs/commit/94053017142fdbd44579375b495e4e4035413879) python310Packages.rns: 0.3.8 -> 0.3.9
* [`2da5797c`](https://github.com/NixOS/nixpkgs/commit/2da5797ca521e3b62ab3262b38a0fb09bfa066b9) Add vrl-vscode extension for Visual Studio Code
* [`1dd5fa64`](https://github.com/NixOS/nixpkgs/commit/1dd5fa64c1b8cf372523380e6719ca6ab468343b) Add lucperkins to list of maintainers
* [`d1dd3b2a`](https://github.com/NixOS/nixpkgs/commit/d1dd3b2aad2030f76fee68928b6718320664b232) Add remaining extension metadata
* [`a2012c49`](https://github.com/NixOS/nixpkgs/commit/a2012c49fc3e34581cf4b302513319c8cd45cbfe) hyprpaper: init at unstable-2022-07-04 ([nixos/nixpkgs⁠#180192](https://togithub.com/nixos/nixpkgs/issues/180192))
* [`a2642faa`](https://github.com/NixOS/nixpkgs/commit/a2642faaead939295d279b64abb50c45f1b12b93) virtctl: 0.53.0 -> 0.54.0
* [`183b236e`](https://github.com/NixOS/nixpkgs/commit/183b236eef3004945512d0ac507faf9828b53244) nebula: 1.5.2 -> 1.6.0
* [`9f97d67c`](https://github.com/NixOS/nixpkgs/commit/9f97d67c3a9093cbc0c2119ecacf043c766022a7) oil: 0.10.1 -> 0.11.0 ([nixos/nixpkgs⁠#179637](https://togithub.com/nixos/nixpkgs/issues/179637))
* [`2169ff54`](https://github.com/NixOS/nixpkgs/commit/2169ff54f191e4cd7a47c80207d9b58b7e50202a) cloc: 1.92 -> 1.94
* [`ae2d1ed9`](https://github.com/NixOS/nixpkgs/commit/ae2d1ed93257d75124daa578459eca692f88d5ad) sumneko-lua-language-server: 3.2.3 -> 3.4.1
* [`002e147b`](https://github.com/NixOS/nixpkgs/commit/002e147b103041e8ac2a0785a8232796f6451714) python3Packages.python-utils: 3.1.0 → 3.3.3
* [`d47f646d`](https://github.com/NixOS/nixpkgs/commit/d47f646d16e5db553b6a30a218dbf0337ab23c42) python3Packages.progressbar2: re-enable check since the issue was solved upstream
* [`336cc168`](https://github.com/NixOS/nixpkgs/commit/336cc1683a4199f25310f7a4b7a2c6b04f25cc89) mars: fix build on gcc-10
* [`6785b339`](https://github.com/NixOS/nixpkgs/commit/6785b339ccdab11cc44ae971077969b513b46f43) python3Packages.gradient_statsd: propagate chardet
* [`aeb97834`](https://github.com/NixOS/nixpkgs/commit/aeb97834a8052814fdaf078adf4befbfb03aed37) werf: 1.2.117 -> 1.2.120
* [`14af83b8`](https://github.com/NixOS/nixpkgs/commit/14af83b82a6a1eb9aec9049a94b25b098d4c312d) vscode-extensions.ms-python.vscode-pylance: 2022.1.5 -> 2022.6.30
* [`8558ab08`](https://github.com/NixOS/nixpkgs/commit/8558ab08b6258d2964442d447527082d3c0cc081) vscode-extensions.ms-python.vscode-pylance: 2022.6.30 -> 2022.7.11
* [`f378595f`](https://github.com/NixOS/nixpkgs/commit/f378595fd32b825dc9e53eb89da5676657606dbf) jfsutils: keep include files and libfs.a
* [`00b2db64`](https://github.com/NixOS/nixpkgs/commit/00b2db645cea9941d8c2bafc7fdd509dbf5a908c) python310Packages.vispy: 0.10.0 -> 0.11.0
* [`597db2e3`](https://github.com/NixOS/nixpkgs/commit/597db2e3b443f417ca71f5158d1031f08e83bd7d) python310Packages.spacy-transformers: 1.1.6 -> 1.1.7
* [`42db1e66`](https://github.com/NixOS/nixpkgs/commit/42db1e66f3cf7026cdfdc341d13f8ba12e9fad4d) python310Packages.yq: 2.14.0 -> 3.0.2
* [`2f12a8d2`](https://github.com/NixOS/nixpkgs/commit/2f12a8d2b8247f3cf62e024132314dc352cb6597) python310Packages.pygmt: 0.6.1 -> 0.7.0
* [`33cda578`](https://github.com/NixOS/nixpkgs/commit/33cda5786fe4dcba66603e2feb93d254f3890182) libvirt: 8.4.0 -> 8.5.0
* [`14a84624`](https://github.com/NixOS/nixpkgs/commit/14a846241865ad63780e0be63379ff8584eeffcc) python310Packages.islpy: 2022.1.2 -> 2022.2
* [`41e0ebb9`](https://github.com/NixOS/nixpkgs/commit/41e0ebb94d075e287e11a9fd1089c92ef3d003a2) python310Packages.pytest-test-utils: 0.0.6 -> 0.0.7
* [`069be5d4`](https://github.com/NixOS/nixpkgs/commit/069be5d42791b21d02e0c3da980cefab46271de6) python310Packages.ics: 0.7 -> 0.7.1
* [`17c42e33`](https://github.com/NixOS/nixpkgs/commit/17c42e33b087b652218a69defa60f692de445ace) crlfsuite: 2.0 -> 2.1.1
* [`7ea869f7`](https://github.com/NixOS/nixpkgs/commit/7ea869f74ccf4b414f397fb77756ac5aa2df8785) deno: 1.23.2 -> 1.23.3
* [`bf35d801`](https://github.com/NixOS/nixpkgs/commit/bf35d8018738ad3b4bf871dfd64f1ae7e83c5997) python310Packages.skodaconnect: 1.1.20 -> 1.1.21
* [`4066f82a`](https://github.com/NixOS/nixpkgs/commit/4066f82a4de90e25b41451486bdcbf2c45805a48) all-packages.nix: cosmetic formatting of some comments
* [`c2c8e8fd`](https://github.com/NixOS/nixpkgs/commit/c2c8e8fdd2e30937fc746c54a7b76c6ee87417b1) xosview: init at 1.23
* [`f4b885df`](https://github.com/NixOS/nixpkgs/commit/f4b885df97aafe36fd08637cb2d770463f1997aa) xosview2: remove spurious doCheck = false
* [`25c4a062`](https://github.com/NixOS/nixpkgs/commit/25c4a062c63fb7bf4448e040bd79593353008a8d) puddletag: 2.1.1 -> 2.2.0
* [`3b1cbcc9`](https://github.com/NixOS/nixpkgs/commit/3b1cbcc92bbd97b890dde90805e5cae347846f9c) ocamlPackages.yaml: 3.0.0 -> 3.1.0 ([nixos/nixpkgs⁠#180139](https://togithub.com/nixos/nixpkgs/issues/180139))
* [`e007eb48`](https://github.com/NixOS/nixpkgs/commit/e007eb480c6041fd98b8f9e53bdac2ba82e4648c) dockerTools.buildImage: Add copyToRoot to replace contents, explain usage
* [`3a27c404`](https://github.com/NixOS/nixpkgs/commit/3a27c40463a0be4c0a8a656a68e8b36fa27a8b1f) workflows/nixos-manual: Add command to run to error message
* [`2126944e`](https://github.com/NixOS/nixpkgs/commit/2126944e09428a10729bb84c9e432fc530056bec) papirus-folders: init at 1.12.0
* [`21d9b20b`](https://github.com/NixOS/nixpkgs/commit/21d9b20b035ef2870d3121c3238f6cce87de5479) godns: 2.7.9 -> 2.8.1
* [`ce09a0b4`](https://github.com/NixOS/nixpkgs/commit/ce09a0b40d9f152f5d9d784b6572b77c5482e397) python310Packages.archinfo: 9.2.8 -> 9.2.9
* [`18f1a0cd`](https://github.com/NixOS/nixpkgs/commit/18f1a0cd1b0c17ec01ef45ca28a6e3c33f4e91ee) python310Packages.ailment: 9.2.8 -> 9.2.9
* [`7dd4647c`](https://github.com/NixOS/nixpkgs/commit/7dd4647c9b8a2f8012d131c576ad5fc90007bf4c) python310Packages.pyvex: 9.2.8 -> 9.2.9
* [`0e75a027`](https://github.com/NixOS/nixpkgs/commit/0e75a027497353f8ce3c2ad2b1ed4c09e566e7b9) python310Packages.claripy: 9.2.8 -> 9.2.9
* [`d6d12be2`](https://github.com/NixOS/nixpkgs/commit/d6d12be2dda7fa6a3cb6d6771dcc69b50323a9ab) python310Packages.cle: 9.2.8 -> 9.2.9
* [`de478735`](https://github.com/NixOS/nixpkgs/commit/de4787355ee25c47818dd9ef61cf9fe997aa1c3d) python310Packages.angr: 9.2.8 -> 9.2.9
* [`fef6723f`](https://github.com/NixOS/nixpkgs/commit/fef6723f9bea16c6530beefd20349e0e10a8d1ff) qemu-utils: remove qemu dependency
* [`934a622f`](https://github.com/NixOS/nixpkgs/commit/934a622f7ecf9bc18940e799bdc5f2b7c0c213a5) qemu-utils: ensure we cut off qemu dependency
* [`234be397`](https://github.com/NixOS/nixpkgs/commit/234be397d65393c16d562fda3f397c6de6fd2510) xprompt: init at 2.5.0
* [`bf40759a`](https://github.com/NixOS/nixpkgs/commit/bf40759a3579135def7f5dc4d8aa0b10f1c03eda) zint: init at 2.11.0
* [`ed40dba1`](https://github.com/NixOS/nixpkgs/commit/ed40dba171076f270b4958ca7c9e0b0570882fda) python310Packages.jarowinkler: 1.0.5 -> 1.1.0
* [`07f1d6ba`](https://github.com/NixOS/nixpkgs/commit/07f1d6bab7586bbdf0e1e94ebdfe031b32946724) python310Packages.rapidfuzz: 2.1.0 -> 2.1.2
* [`ec9ce3c9`](https://github.com/NixOS/nixpkgs/commit/ec9ce3c94bb763973bde1b860d217c1d16e3d5e8) python310Packages.levenshtein: 0.18.1 -> 0.18.2
* [`d2184ac8`](https://github.com/NixOS/nixpkgs/commit/d2184ac8686da08f294b875e9a0ec0121c3a8b1d) electron: fix headers location
* [`21e22c7f`](https://github.com/NixOS/nixpkgs/commit/21e22c7f6be273a9083cdec47910425b5688babf) plex: 1.27.1.5916-6b0e31a64 -> 1.27.2.5929-a806c5905
* [`8ef7523c`](https://github.com/NixOS/nixpkgs/commit/8ef7523c8e11da7fd23e6b87371e7aa1eab718bb) pineapple-pictures: init at 0.6.1 ([nixos/nixpkgs⁠#178583](https://togithub.com/nixos/nixpkgs/issues/178583))
* [`651842bd`](https://github.com/NixOS/nixpkgs/commit/651842bd856effbcdbbd888b704613547a1c89cb) reiser4progs: share libreiser4misc.a.la
* [`9573c61a`](https://github.com/NixOS/nixpkgs/commit/9573c61a7ce2e4e98a8f16103f90566735b04200) wipefreespace: init at 2.5
* [`22e81f39`](https://github.com/NixOS/nixpkgs/commit/22e81f39ace64964bae3b6c89662d1221a11324c) gnupg: add patch disallowing compressed signatures and certificates
* [`da4c6be0`](https://github.com/NixOS/nixpkgs/commit/da4c6be0187a694bdeb3efc28b29ee0e4c30702f) openssh_gssapi: 8.4p1 -> 9.0p1
* [`72e26a9f`](https://github.com/NixOS/nixpkgs/commit/72e26a9f5b2bebec3ca84036ac532e9ccd73ffab) hcloud: 1.29.5 -> 1.30.0
* [`452c0ddf`](https://github.com/NixOS/nixpkgs/commit/452c0ddf8ac095fcc950a6326878c3ec1570fd77) cardinal: 22.04 -> 22.06
* [`1d5a0c0f`](https://github.com/NixOS/nixpkgs/commit/1d5a0c0f4a0b7db109adf484b953fd9921ea0877) mu: 1.8.3 -> 1.8.5
* [`0c0cb9db`](https://github.com/NixOS/nixpkgs/commit/0c0cb9dbe5466dc44de97d7821320f70a8360e38) musescore: 2.1 -> 3.6.2.548020600 on darwin
* [`a5c867d9`](https://github.com/NixOS/nixpkgs/commit/a5c867d9fe9e4380452628e8f171c26b69fa9d3d) libschrift: 0.10.1 -> 0.10.2
* [`3bd20fe6`](https://github.com/NixOS/nixpkgs/commit/3bd20fe6f718860930c94d36da069366db5d410d) luna-icons: 2.0 -> 2.1
* [`6496c250`](https://github.com/NixOS/nixpkgs/commit/6496c250ce843c2d1339f96a0b1aa60f85751462) furnace: 0.5.8 -> 0.6pre1
* [`3248f322`](https://github.com/NixOS/nixpkgs/commit/3248f32201edaae264bc746e7992d22bdc81bfaf) Revert "amdvlk: 2022.Q2.2 -> 2022.Q2.3"
* [`a96092b6`](https://github.com/NixOS/nixpkgs/commit/a96092b642d1506c782866a8672ed7d44cbd3ba4) jc: 1.20.1 -> 1.20.2
* [`e332ad7a`](https://github.com/NixOS/nixpkgs/commit/e332ad7a33e4815fe730514598bea98d8ddd32d4) tagainijisho: 1.0.3 -> 1.2.0
* [`4622c4e1`](https://github.com/NixOS/nixpkgs/commit/4622c4e103312c25d50d7864a9766d1475de7d6d) goda: init at 0.5.1
* [`f447c0ca`](https://github.com/NixOS/nixpkgs/commit/f447c0cad89455b4096131830dede19b5e2213a3) python310Packages.azure-eventgrid: 4.8.0 -> 4.9.0
* [`be9b19d0`](https://github.com/NixOS/nixpkgs/commit/be9b19d0d5f69f82bbda29d4c97f21af71d6359d) python310Packages.google-auth: Fix tests after removing pyopenssl ([nixos/nixpkgs⁠#180301](https://togithub.com/nixos/nixpkgs/issues/180301))
* [`85998e36`](https://github.com/NixOS/nixpkgs/commit/85998e36ce88c628c2fa0399006f8200a32c0b99) butane: 0.14.0 -> 0.15.0
* [`3d6de3db`](https://github.com/NixOS/nixpkgs/commit/3d6de3dba02f3ffdcde8f95af5937e3acb35065f) python310Packages.dvc-objects: 0.0.18 -> 0.0.19
* [`da4602bf`](https://github.com/NixOS/nixpkgs/commit/da4602bf6bc710817ba4a8a1465a4ed6c79805b6) zafiro-icons: 1.1 -> 1.2
* [`1fe8edb6`](https://github.com/NixOS/nixpkgs/commit/1fe8edb6ddfd23c99822d268b6cf27e19f16a588) onlyoffice-bin: 6.3.1 -> 7.1.0
* [`6870d49f`](https://github.com/NixOS/nixpkgs/commit/6870d49feace5011d1ada61ce6600a141dca35fd) dovecot: fix CVE-2022-30550
* [`5ee41500`](https://github.com/NixOS/nixpkgs/commit/5ee415007381c4bcd5775f8262afa717844d95eb) sonic-pi: use supercollider with sc3-plugins ([nixos/nixpkgs⁠#169851](https://togithub.com/nixos/nixpkgs/issues/169851))
* [`5e59efd7`](https://github.com/NixOS/nixpkgs/commit/5e59efd70e90ad35a2705c0e3e1b89a19f1c1cc7) vimPlugins: update
* [`44d4627e`](https://github.com/NixOS/nixpkgs/commit/44d4627e1aadd0ae842d659e613521aa110b04bb) vimPlugins: resolve github repository redirects
* [`55f6f6c6`](https://github.com/NixOS/nixpkgs/commit/55f6f6c60ae5e8f45a5f825d2a1279b9d20349e1) vimPlugins.substrata-nvim: init at 2022-06-21
* [`efc92be1`](https://github.com/NixOS/nixpkgs/commit/efc92be1f7b947b6fc7e2b645bc6b04912344d2f) vimPlugins: update
* [`137caea3`](https://github.com/NixOS/nixpkgs/commit/137caea3fbf9ed6b45bea2ab1529185642fe006a) vimPlugins.vim-substrata: init at 2021-03-23
* [`38139e46`](https://github.com/NixOS/nixpkgs/commit/38139e464a745a9bfa457344b11dcd041c036c39) vimPlugins: resolve github repository redirects
* [`b511382c`](https://github.com/NixOS/nixpkgs/commit/b511382c95f3f0d7fbaba1edb8968bf71f941134) vimPlugins.vim-printer: init at 2022-03-01
* [`a3cc156c`](https://github.com/NixOS/nixpkgs/commit/a3cc156ce10c6045734e6b278c1c7bae44b54193) barman: 2.17 -> 3.0.0
* [`d50fffb0`](https://github.com/NixOS/nixpkgs/commit/d50fffb079e484a68dcf8d117103016060e1996e) maintainers: update email for squalus
* [`c1f05af6`](https://github.com/NixOS/nixpkgs/commit/c1f05af680f2a1de3abaf1ecc34f1100932b60f7) conftest: 0.32.1 -> 0.33.0
* [`f25ae922`](https://github.com/NixOS/nixpkgs/commit/f25ae9227e06e528bd162ad309049f731aa10c62) vivaldi: 5.3.2679.61-1 -> 5.3.2679.68-1
* [`7e5afad9`](https://github.com/NixOS/nixpkgs/commit/7e5afad992702fade5879a7a18fe1ae6abb5dce3) vivaldi-ffmepg-codecs: 102.0.5005.49 -> 103.0.5060.53
* [`f009b690`](https://github.com/NixOS/nixpkgs/commit/f009b690eb96b595c4a4251427ab2cb73bc1fa30) dolphin-emu-primehack: 1.0.6 -> 1.0.6a
* [`6e7b75c2`](https://github.com/NixOS/nixpkgs/commit/6e7b75c2f53d61c62bb9897920bc025504896ef3) mako: 1.6 -> 1.7
* [`63b81ee7`](https://github.com/NixOS/nixpkgs/commit/63b81ee7fd7244888e91185c211a36050a36b832) bloop: 1.5.0 -> 1.5.2
* [`759cf488`](https://github.com/NixOS/nixpkgs/commit/759cf488a87ed74b5d7ab0c2ec7eee8b95686eb8) maintainers: add jsoo1
* [`eea01cd1`](https://github.com/NixOS/nixpkgs/commit/eea01cd11db90c1b6e6c7ad89d452e69cc89ba5c) ocamlPackages.netchannel: 2.0.0 → 2.1.1
* [`b6236dbd`](https://github.com/NixOS/nixpkgs/commit/b6236dbddb6852a9567588f1a87ba2521bb71e58) ocamlPackages.chacha: 1.0.0 → 1.1.0
* [`abbdfc25`](https://github.com/NixOS/nixpkgs/commit/abbdfc25d174a46dfa4a96f055ce4cb7172b4367) powerdns-admin: 0.2.4 -> 0.3.0
* [`c4dee2fd`](https://github.com/NixOS/nixpkgs/commit/c4dee2fd10d0e551cbb91ad8200db23521b949ed) python310Packages.aioconsole: 0.4.1 -> 0.5.0
* [`39d53920`](https://github.com/NixOS/nixpkgs/commit/39d53920becb0ca3f91938119321688c8b7610bc) python310Packages.browser-cookie3: 0.15.0 -> 0.16.0
* [`8b491055`](https://github.com/NixOS/nixpkgs/commit/8b4910551355999a45b665991da2a5f3fc553ae0) python310Packages.aioslimproto: 2.0.1 -> 2.1.1
* [`c39e2068`](https://github.com/NixOS/nixpkgs/commit/c39e2068119f54cb09e72317999dc055a0db3dbd) linux_logo: init at 6.0
* [`ae555af6`](https://github.com/NixOS/nixpkgs/commit/ae555af60a87b55e2ac209cc1c58b7aeff9169e0) virtiofsd: 1.2.0 -> 1.3.0
* [`c7d14520`](https://github.com/NixOS/nixpkgs/commit/c7d145203852f706e587b78cd6e4416343632857) python310Packages.aesara: 2.7.4 -> 2.7.5
* [`ba60ee5d`](https://github.com/NixOS/nixpkgs/commit/ba60ee5dc3c4393a438c187724d6f28e5c0dedad) kiln: 0.3.0 → 0.3.2
* [`1bf922e0`](https://github.com/NixOS/nixpkgs/commit/1bf922e038ec816ba7238c786e4c89e216933308) cdogs-sdl: 0.13.0 -> 1.3.1
* [`9f31bcc4`](https://github.com/NixOS/nixpkgs/commit/9f31bcc45b56649e978c512fe4f2d675adcf32c6) tailscale: 1.26.1 -> 1.26.2
* [`dd10dbfc`](https://github.com/NixOS/nixpkgs/commit/dd10dbfc5be3b4edf7609da892a7564be4b8252a) python310Packages.plugwise: 0.20.0 -> 0.20.1
* [`4439918c`](https://github.com/NixOS/nixpkgs/commit/4439918c3aa22593d3b34ceddedb532462766969) python310Packages.dogpile-cache: 1.1.6 -> 1.1.7
* [`d0cdd897`](https://github.com/NixOS/nixpkgs/commit/d0cdd897c347d73f98031f5143b0cd872e57874f) cpulimit: use github sources at 0.2
* [`44a21779`](https://github.com/NixOS/nixpkgs/commit/44a2177997c0f3a641956e169dc0628f3b6746ba) limitcpu: init at 2.7
* [`79453546`](https://github.com/NixOS/nixpkgs/commit/7945354659cfa0b9aeea729fd925d2c3151ffd0c) kubesec: 2.11.4 -> 2.11.5
* [`f0658798`](https://github.com/NixOS/nixpkgs/commit/f065879806938152be1adca5b5999130a8462dad) broot: 1.14.0 -> 1.14.1
* [`78d0a068`](https://github.com/NixOS/nixpkgs/commit/78d0a0688cfe05d820f197bc50d95dce8ea25519) ocamlPackages.xmlm: 1.3.0 -> 1.4.0
* [`6be62ba2`](https://github.com/NixOS/nixpkgs/commit/6be62ba201b3d9a16aa042edece140931977e1b1) mako: 1.7 -> 1.7.1
* [`ff494fa0`](https://github.com/NixOS/nixpkgs/commit/ff494fa028e7e982bb17d50f8abae34a51284bcb) ocamlPackages.hxd: 0.3.1 -> 0.3.2
* [`9674356b`](https://github.com/NixOS/nixpkgs/commit/9674356b09aa50d5a92f79e3bde0ba08b87d4b36) ddnet 16.1 -> 16.2
* [`fbdffd67`](https://github.com/NixOS/nixpkgs/commit/fbdffd67ff40b082cb607aaed0ff9515b0861120) kube-linter: 0.3.0 -> 0.4.0
* [`98e651e8`](https://github.com/NixOS/nixpkgs/commit/98e651e89148eab0afbe420e58fd80c9545f370c) python3Packages.chacha20poly1305-reusable: init at 0.0.4
* [`485a3dd6`](https://github.com/NixOS/nixpkgs/commit/485a3dd64c0c6fd2406115b021d50ed16d37f0bf) python3Packages.aiohomekit: 0.7.17 -> 0.7.20
* [`e233468d`](https://github.com/NixOS/nixpkgs/commit/e233468d9fa78b1f34e4da3447c5bb7d5d67e2ab) haskellPackages.purescript: adjust for 0.15.4
* [`6cb53d76`](https://github.com/NixOS/nixpkgs/commit/6cb53d76573dfae6d14d14ffa66fe3ea064abd90) python310Packages.goodwe: 0.2.17 -> 0.2.18
* [`337a8031`](https://github.com/NixOS/nixpkgs/commit/337a8031fe180599ff8bb00644ae75d711600f82) foma: fix cross-compilation
* [`a885d43d`](https://github.com/NixOS/nixpkgs/commit/a885d43d61a501ffc777809a70ca55c1ce4f29d3) adl: init at 3.0.1
* [`bcd5ad6d`](https://github.com/NixOS/nixpkgs/commit/bcd5ad6d83f89e2f0b16137cfc280a952dba9406) libwebsockets: remove generic function, format
* [`eff6a8d4`](https://github.com/NixOS/nixpkgs/commit/eff6a8d480c60e3a238de038453228517bac8f4d) python3Packages.aioimaplib: 0.9.0 -> 1.0.0
* [`c462805a`](https://github.com/NixOS/nixpkgs/commit/c462805a47ac648dc067d45ac6705970c73af139) python3Packages.aiounifi: 33 -> 34
* [`db537d13`](https://github.com/NixOS/nixpkgs/commit/db537d13e1e7de2e7cb8fd49cdcdbb256d39597a) python3Packages.async-upnp-client: 0.31.1 -> 0.31.2
* [`68040ff2`](https://github.com/NixOS/nixpkgs/commit/68040ff2c6166fd11ac37feaa6e97042e63074b6) python3Packages.homematicip: 1.0.2 -> 1.0.3
* [`1271b83b`](https://github.com/NixOS/nixpkgs/commit/1271b83b6364cfcb9761e4b1a581094eee5aa487) faust: 2.40.0 -> 2.41.1
* [`aa2c8f20`](https://github.com/NixOS/nixpkgs/commit/aa2c8f202652ec02db8477b7bc1db9ca01abdc67) faustlive: 2.5.10 -> 2.5.11
* [`dc1a8000`](https://github.com/NixOS/nixpkgs/commit/dc1a8000ef0866341b4bf1616fc7efe23017f162) python310Packages.intellifire4py: 1.0.5 -> 2.0.1 ([nixos/nixpkgs⁠#174986](https://togithub.com/nixos/nixpkgs/issues/174986))
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
