### PR TITLE
niv emacs-overlay: update 7783abca -> 4d342a55

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7783abca6324f2dfdf8ca7d3632c376df416bf88",
-        "sha256": "09glqy5jyshbbk80jwkimszqaik8gi5pxm98qb6176r0qjhy4apz",
+        "rev": "4d342a55aa298e8ed5168be77c2262cf5fb8a0c4",
+        "sha256": "1fybr7r3nvbqwl5km4f73jlvqy5waw8xny81yq2jd0n3lcscfb04",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/7783abca6324f2dfdf8ca7d3632c376df416bf88.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/4d342a55aa298e8ed5168be77c2262cf5fb8a0c4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@7783abca...4d342a55](https://github.com/nix-community/emacs-overlay/compare/7783abca6324f2dfdf8ca7d3632c376df416bf88...4d342a55aa298e8ed5168be77c2262cf5fb8a0c4)

* [`7d898090`](https://github.com/nix-community/emacs-overlay/commit/7d8980907738b174c14b73e5d24f55481d334b3a) Updated repos/emacs
* [`beec8777`](https://github.com/nix-community/emacs-overlay/commit/beec877720e2b09b0b1a96450286459bcd7e6435) Updated repos/melpa
* [`eb2d9468`](https://github.com/nix-community/emacs-overlay/commit/eb2d9468c08568193523abb29aea32b17a5a22b0) Updated repos/emacs
* [`6ad17c8e`](https://github.com/nix-community/emacs-overlay/commit/6ad17c8e39b64221557d1753252850f8f0b8a275) Updated repos/melpa
* [`2922cf24`](https://github.com/nix-community/emacs-overlay/commit/2922cf24903063fec62e4ccc9a19e4f3e7b1ff94) Updated repos/elpa
* [`2591bf8e`](https://github.com/nix-community/emacs-overlay/commit/2591bf8eeed03d9fede8ceeb0560213faee47583) Updated repos/emacs
* [`0448a9be`](https://github.com/nix-community/emacs-overlay/commit/0448a9be0e842e3e80696fb5951487803dc8e018) Updated repos/melpa
* [`00f0fb99`](https://github.com/nix-community/emacs-overlay/commit/00f0fb99762db554116a116f73c3e7ecc2e6545b) Updated repos/nongnu
* [`f793d988`](https://github.com/nix-community/emacs-overlay/commit/f793d988f092c6238b5d5b06a7c67f4e45cfd7e7) Updated repos/emacs
* [`816b1671`](https://github.com/nix-community/emacs-overlay/commit/816b1671de57269ed12c44722571b553cbf093b2) Updated repos/melpa
* [`88bfbe0c`](https://github.com/nix-community/emacs-overlay/commit/88bfbe0c218e095f0d9e9aaa2ba18dc0df410244) Updated repos/nongnu
* [`bfd1a4df`](https://github.com/nix-community/emacs-overlay/commit/bfd1a4dfb9aee0c0abb712f74f94866d8a91bc65) Updated repos/elpa
* [`4c2a624c`](https://github.com/nix-community/emacs-overlay/commit/4c2a624c44a75d0146dcb04cced20a2021435f5f) Updated repos/emacs
* [`3f19b970`](https://github.com/nix-community/emacs-overlay/commit/3f19b9701fc7a8a3a75af5d67d0075e0a5bddc13) Updated repos/melpa
* [`4750b70f`](https://github.com/nix-community/emacs-overlay/commit/4750b70f2ce68a2a4122069c8458a82289c6686a) Updated repos/emacs
* [`f363cd08`](https://github.com/nix-community/emacs-overlay/commit/f363cd08f63d71f07ee087a7fc16d914702c8b93) Updated repos/melpa
* [`bd7cafb7`](https://github.com/nix-community/emacs-overlay/commit/bd7cafb7df51eff52732a0a6bddfc9c75fb5c5b8) Updated repos/emacs
* [`06f397cb`](https://github.com/nix-community/emacs-overlay/commit/06f397cbbd804d2b5df8c7258b5cf89e2a521ae7) Updated repos/melpa
* [`55945268`](https://github.com/nix-community/emacs-overlay/commit/55945268c43c8a0b0a70b79efa1fea226e5b57e8) Updated repos/emacs
* [`7c367081`](https://github.com/nix-community/emacs-overlay/commit/7c367081f2f47f5ea3d5e18c958856294180256e) Updated repos/melpa
* [`984715b2`](https://github.com/nix-community/emacs-overlay/commit/984715b2bfae191b0309d387f89a5435512a9505) Updated repos/elpa
* [`1e45ead7`](https://github.com/nix-community/emacs-overlay/commit/1e45ead79cc6c568f81a4bba11183e2699982e8f) Updated repos/emacs
* [`7950429a`](https://github.com/nix-community/emacs-overlay/commit/7950429a1872caf8846ee4ee4aa0027e7bd52b2c) Updated repos/melpa
* [`c99ada09`](https://github.com/nix-community/emacs-overlay/commit/c99ada091baf3c086d4cca4e8f053fbd948c75e9) Updated repos/nongnu
* [`49856252`](https://github.com/nix-community/emacs-overlay/commit/4985625222c092db9da3f89d294cc43ce279f47c) Updated repos/emacs
* [`26d7e369`](https://github.com/nix-community/emacs-overlay/commit/26d7e369627011aa142950667d589b53f7d0669e) Updated repos/melpa
* [`22448c09`](https://github.com/nix-community/emacs-overlay/commit/22448c09bae21969ca14d1558a120dafe9853c73) Updated repos/nongnu
* [`16fefbfd`](https://github.com/nix-community/emacs-overlay/commit/16fefbfd5f50bd0263605506b70c15615bc93031) Updated repos/elpa
* [`1a00c6b7`](https://github.com/nix-community/emacs-overlay/commit/1a00c6b75e05b151f60fca17cca65226477e9c7f) Updated repos/emacs
* [`eae26b7d`](https://github.com/nix-community/emacs-overlay/commit/eae26b7d5fc04699078a1687185d65077bc73c96) Updated repos/melpa
* [`71712d28`](https://github.com/nix-community/emacs-overlay/commit/71712d2809814bbb7ff76edc7a9ebac8aa391713) Updated repos/emacs
* [`18d17217`](https://github.com/nix-community/emacs-overlay/commit/18d1721765e9c4d8bd5c4191ac094fb3af49b444) Updated repos/melpa
* [`30a0861e`](https://github.com/nix-community/emacs-overlay/commit/30a0861e0d4b9944ee01595436de5e2d58303105) Updated repos/nongnu
* [`51b2fc64`](https://github.com/nix-community/emacs-overlay/commit/51b2fc644c1774671e0f9b3cfab5ddd58a94e001) Updated repos/emacs
* [`eb65bc95`](https://github.com/nix-community/emacs-overlay/commit/eb65bc9557a798a4f22e9f2a4f1416fd2efa2af0) Updated repos/melpa
* [`e1c34ef6`](https://github.com/nix-community/emacs-overlay/commit/e1c34ef6f6eb7d966af5011eeeec6342017cd535) Updated repos/nongnu
* [`61a75b50`](https://github.com/nix-community/emacs-overlay/commit/61a75b50e97aaff61a748f073f646cde47455a92) Updated repos/elpa
* [`e037805d`](https://github.com/nix-community/emacs-overlay/commit/e037805da1abdc4f023ad6cdcb26e828a2731c6a) Updated repos/emacs
* [`f6ea0808`](https://github.com/nix-community/emacs-overlay/commit/f6ea0808082826283775ca329aa63a2315b6e155) Updated repos/melpa
* [`96050b72`](https://github.com/nix-community/emacs-overlay/commit/96050b7295b81ff46a66fda1eca97f6bab29594b) Updated repos/emacs
* [`0dacb772`](https://github.com/nix-community/emacs-overlay/commit/0dacb7728fb27e30525d7cb6af1a2a1f61cc7326) Updated repos/melpa
* [`e9fd3df6`](https://github.com/nix-community/emacs-overlay/commit/e9fd3df6001f2e28d6cf3da77a015bb5a5cf70ba) Updated repos/nongnu
* [`7778bba2`](https://github.com/nix-community/emacs-overlay/commit/7778bba2a1768d16e47c76d8342bfe2c466e108b) Updated repos/emacs
* [`49911452`](https://github.com/nix-community/emacs-overlay/commit/4991145289960c4d5cdd7664c74740d232b258f4) Updated repos/melpa
* [`4993b3ca`](https://github.com/nix-community/emacs-overlay/commit/4993b3ca0158225301703f0e3780d5f48fd63033) Updated repos/nongnu
* [`252a1a56`](https://github.com/nix-community/emacs-overlay/commit/252a1a56b768b833b8f3caeaabbef7e08d4b0864) Updated repos/elpa
* [`293ccbb9`](https://github.com/nix-community/emacs-overlay/commit/293ccbb9f4d1bdaa6419bcf438c5f1f5fdb83507) Updated repos/emacs
* [`23c09e04`](https://github.com/nix-community/emacs-overlay/commit/23c09e04995402b7d97b18d72ce262cb60549df1) Updated repos/melpa
* [`bf3c0759`](https://github.com/nix-community/emacs-overlay/commit/bf3c075951d4487090debddb3cbb16e1552b8712) Updated repos/elpa
* [`9bb5bf45`](https://github.com/nix-community/emacs-overlay/commit/9bb5bf45d3ba623541d7354d2f023a489efafff8) Updated repos/emacs
* [`bf01abcb`](https://github.com/nix-community/emacs-overlay/commit/bf01abcbac11803f79a3fe082a996110d3e855b0) Updated repos/melpa
* [`b5542a32`](https://github.com/nix-community/emacs-overlay/commit/b5542a32e051bc51b950eae68da7f6b544e7e8d0) Updated repos/emacs
* [`eb4dd0a2`](https://github.com/nix-community/emacs-overlay/commit/eb4dd0a2296e805e6dc2981c28a3583d9a89db64) Updated repos/melpa
* [`4f95fe20`](https://github.com/nix-community/emacs-overlay/commit/4f95fe202c5e2c796adab52afff568b23ffadda2) Updated repos/nongnu
* [`c84a9c45`](https://github.com/nix-community/emacs-overlay/commit/c84a9c452f62c8b604e5de9a1df64f8ca00854d3) Updated repos/emacs
* [`d6614609`](https://github.com/nix-community/emacs-overlay/commit/d66146093627b60ee245249adc75029abc49db13) Updated repos/melpa
* [`e1373b07`](https://github.com/nix-community/emacs-overlay/commit/e1373b072bba84cefc5c182425bc6c420b80815f) Updated repos/elpa
* [`bb6e8912`](https://github.com/nix-community/emacs-overlay/commit/bb6e8912dba0c6bda2a802b49686dae750d34ce5) Updated repos/emacs
* [`167d38fd`](https://github.com/nix-community/emacs-overlay/commit/167d38fdc98984b24a0d6893151759de16d0ddbc) Updated repos/melpa
* [`4d342a55`](https://github.com/nix-community/emacs-overlay/commit/4d342a55aa298e8ed5168be77c2262cf5fb8a0c4) Updated repos/nongnu
