### PR TITLE
niv powerlevel10k: update cf67cad4 -> be3724bc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "cf67cad46557d57d5d2399e6d893c317126e037c",
-        "sha256": "109k9kj4xjjrdzkd44sm5cdm97d6i81ljfbkfxryj098g5yi3995",
+        "rev": "be3724bc806a2dd7fbcb281a153b11ab19d8923d",
+        "sha256": "095lk51yf3bmh11hv4lb019h77zv9m48cfkh8qd0w2rqrcl6p2sr",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/cf67cad46557d57d5d2399e6d893c317126e037c.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/be3724bc806a2dd7fbcb281a153b11ab19d8923d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@cf67cad4...be3724bc](https://github.com/romkatv/powerlevel10k/compare/cf67cad46557d57d5d2399e6d893c317126e037c...be3724bc806a2dd7fbcb281a153b11ab19d8923d)

* [`9a3c2f48`](https://github.com/romkatv/powerlevel10k/commit/9a3c2f48a462cbc56fc5bd0e17e04528bde4783d) add Crostini installation instructions
* [`487a388d`](https://github.com/romkatv/powerlevel10k/commit/487a388dbd50b18dd794cffbed0f78b01d4cc01b) make crostini font instructions stylistically similar to the rest and copy them over to font.md ([romkatv/powerlevel10k⁠#1934](https://togithub.com/romkatv/powerlevel10k/issues/1934))
* [`be3724bc`](https://github.com/romkatv/powerlevel10k/commit/be3724bc806a2dd7fbcb281a153b11ab19d8923d) typo in comments
