### PR TITLE
niv nixpkgs: update f904e356 -> ec83cde0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f904e3562aabca382d12f8471ca2330b3f82899a",
-        "sha256": "1lsa3sjwp1v3nv2jjpkl5lf9dncplwihmavasalg9fq1217pmzmb",
+        "rev": "ec83cde062c65bf241d4be1f4edc0b4939d02512",
+        "sha256": "1c6sbnz1ps0n5lycbw21pv7wnyadcf0p0z829s1k5xnin5cfna4l",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f904e3562aabca382d12f8471ca2330b3f82899a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ec83cde062c65bf241d4be1f4edc0b4939d02512.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f904e356...ec83cde0](https://github.com/nixos/nixpkgs/compare/f904e3562aabca382d12f8471ca2330b3f82899a...ec83cde062c65bf241d4be1f4edc0b4939d02512)

* [`bdf68ddb`](https://github.com/NixOS/nixpkgs/commit/bdf68ddb6af5046dd4880ff077327e72131420f5) maintainers: Add natsukium
* [`ff76ac91`](https://github.com/NixOS/nixpkgs/commit/ff76ac91562bca8b113df5b3dac946b8fe6877fa) mafft: init at 7.487
* [`f31d4de3`](https://github.com/NixOS/nixpkgs/commit/f31d4de37b81657b417f0ccea6f9d7c0b79d8fd9) xidel: add TLS support
* [`0e838b31`](https://github.com/NixOS/nixpkgs/commit/0e838b311522d7d83475a0f02558d1548fd8f170) firefox-bin: HTTPS for homepage and updateScript
* [`ef025e29`](https://github.com/NixOS/nixpkgs/commit/ef025e29984d8be59d1295829352d5653042cff6) i2pd: add yggdrasil settings
* [`0524e885`](https://github.com/NixOS/nixpkgs/commit/0524e8856b9e72aa436b24e19e14e670a02a97f3) mafft: 7.487 -> 7.490
* [`06ea5e78`](https://github.com/NixOS/nixpkgs/commit/06ea5e780b08bd4a4254f83e90168bb76cbd0ee1) nixos/glusterfs: exclude hook "S10selinux-label-brick.sh"
* [`d6dbe070`](https://github.com/NixOS/nixpkgs/commit/d6dbe0703566c8d6baa2246a6eb79a53365199c9) patool: fix the non-use of hard-coded binary
* [`b0fce27c`](https://github.com/NixOS/nixpkgs/commit/b0fce27ce22c1c2b5c1198feee92bec708fa3a1d) docs: expand explanation of patchShebangs hook
* [`e3883d2c`](https://github.com/NixOS/nixpkgs/commit/e3883d2ce0e23f07d0ffe90da37d08e65f1e534e) docs: clarify note on existing store paths
* [`b4d9d682`](https://github.com/NixOS/nixpkgs/commit/b4d9d682c8cdfdfc8919f3140578971dcb64bd25) docs: clean up and update links to source code
* [`9a2ed653`](https://github.com/NixOS/nixpkgs/commit/9a2ed653704baabceb6c5a74603d1814583426be) fix wording, remove too much specificity
* [`311d322f`](https://github.com/NixOS/nixpkgs/commit/311d322febdc3e931b0a22b018121ad055dca0ce) docs: sync `patchShebangs` comments with manual
* [`fed2a91f`](https://github.com/NixOS/nixpkgs/commit/fed2a91f4102c5d162b0c37e2621cb77092a2cd0) drone-runner-docker: 1.8.0 -> 1.8.1
* [`87f831c3`](https://github.com/NixOS/nixpkgs/commit/87f831c382113e79d3e1a62c15d8ba048347fd57) patool: remove unused compression utilities
* [`6852ee5f`](https://github.com/NixOS/nixpkgs/commit/6852ee5fec45a0b97f51ce75908d82539fb0abd3) libbencodetools: unstable-2021-04-15 -> unstable-2022-05-11
* [`c2966329`](https://github.com/NixOS/nixpkgs/commit/c2966329bdfcd0341d020559d8b6bc965890c050) uade123: unstable-2021-05-21 -> 3.01
* [`2a589072`](https://github.com/NixOS/nixpkgs/commit/2a58907251af76c67c6d14c1e84e73f7eaeb95e8) nixos/_1password{,-gui}: use a static gid
* [`25d02e65`](https://github.com/NixOS/nixpkgs/commit/25d02e65d0b97d8a73d275b80efb2a35b8020838) generate-expr-from-tarballs.pl: enable strictDeps
* [`aae766d5`](https://github.com/NixOS/nixpkgs/commit/aae766d5d040f5971e57871dee8208833cccd849) sky: fix [nixos/nixpkgs⁠#157521](https://togithub.com/nixos/nixpkgs/issues/157521)
* [`a1ba737c`](https://github.com/NixOS/nixpkgs/commit/a1ba737c5ee13938f9d4208b2c67073caed14a2b) folly: enable jemalloc
* [`2582a1bf`](https://github.com/NixOS/nixpkgs/commit/2582a1bfce61aae0c6f98d6b37d0bfa9ec41d8e7) nengo-gui: 0.4.8 -> 0.4.9
* [`af43752f`](https://github.com/NixOS/nixpkgs/commit/af43752ff1cb63afe77c354a2fb97903b227d884) netbox: 3.2.1 -> 3.2.3
* [`cd2e7aea`](https://github.com/NixOS/nixpkgs/commit/cd2e7aea476553360dcbca5c9dc83d7970fdf97c) pylode: 2.12.0 -> 2.13.3
* [`7adf1db4`](https://github.com/NixOS/nixpkgs/commit/7adf1db45066efa315c3488eeed92c53b778d2aa) maintainers: add pbsds
* [`0e3b2276`](https://github.com/NixOS/nixpkgs/commit/0e3b22768dd80530401af2757a1bd9e0b6a4612b) Android Studio: allow to pass shell arguments
* [`360b3170`](https://github.com/NixOS/nixpkgs/commit/360b31707a08803bd54a44a078e95e4c539450c2) purescript: mark meta.sourceProvenance
* [`16ad8ea5`](https://github.com/NixOS/nixpkgs/commit/16ad8ea53c95f9f9902a0c3a8c5d3968f9b88128) s/sourceTypes/source-types/
* [`dbe99b57`](https://github.com/NixOS/nixpkgs/commit/dbe99b573cdf265f201165f45e025b4d325b582c) vscode-extensions.haskell.haskell: 1.8.0 -> 2.2.0
* [`c6c20f53`](https://github.com/NixOS/nixpkgs/commit/c6c20f53439548ad8a52ba56e8af9d4c4662cc7b) vscode-extensions.justusadam.language-haskell: 3.4.0 -> 3.6.0
* [`d6f311f3`](https://github.com/NixOS/nixpkgs/commit/d6f311f306195e77c41dc15dc29068d7e8830faa) zchaff: 2004.5.13 -> 2007.3.12
* [`91dde6ef`](https://github.com/NixOS/nixpkgs/commit/91dde6efd20ec03d61ba752f8eb59baf3d4ea33b) coqPackages.smtcoq: itp22 -> 2021-09-17
* [`3de12b09`](https://github.com/NixOS/nixpkgs/commit/3de12b09872b1758ebb3b1fd5c9399fe11dac880) smtcoq: fix cvc4 dependency
* [`c831d910`](https://github.com/NixOS/nixpkgs/commit/c831d910bfce00f31a8389762922c406ee24fc49) python310Packages.transmission-rpc: 3.3.0 -> 3.3.2
* [`558f0452`](https://github.com/NixOS/nixpkgs/commit/558f045240d6ab234f1d0217b868ea46b2ccf604) vscode-extensions.sanaajani.taskrunnercode: init at 0.3.0
* [`71d8d2db`](https://github.com/NixOS/nixpkgs/commit/71d8d2dbb6cf4233c09d789907513f07996947dd) vscode-extensions.shd101wyy.markdown-preview-enhanced : init at 0.6.3
* [`30e3db63`](https://github.com/NixOS/nixpkgs/commit/30e3db6365d6a44c3f88f3e6db93bad751240498) vscode-extenions.tomoki1207.pdf: add metadata
* [`f70073d7`](https://github.com/NixOS/nixpkgs/commit/f70073d72d44717d18200595873a09f7f7ccfb98) remove specifics on where build inputs come from in `PATH`
* [`e132e6be`](https://github.com/NixOS/nixpkgs/commit/e132e6be3c7ea5d05dd8e817b6165c3b11eb7e7b) fix heading level
* [`1f4324c3`](https://github.com/NixOS/nixpkgs/commit/1f4324c3de95e7a1237abcf07e103248a7b7bcdd) build-support/makeDesktopItem: make overridable
* [`18155c86`](https://github.com/NixOS/nixpkgs/commit/18155c86ce89abf267989a95bc43d4a2962ce6cf) bear: 3.0.14 -> 3.0.19
* [`c3ea8c4d`](https://github.com/NixOS/nixpkgs/commit/c3ea8c4dd909d081ff6aae007f1872b367dacc14) do not mention trivial builders
* [`0ab53669`](https://github.com/NixOS/nixpkgs/commit/0ab5366945457afca70a6b997b53001288ef7837) linuxPackages.vmware: w16.2.3-k5.17 -> w16.2.3-k5.18
* [`fd30e1de`](https://github.com/NixOS/nixpkgs/commit/fd30e1de1e9f5e192b392d9fd2f7909229f35b05) rtl8192eu: update at 4.4.1.20220614
* [`c5edc1d3`](https://github.com/NixOS/nixpkgs/commit/c5edc1d38aaa960a04ad2c675af102debde12462) mle: 1.4.3 -> 1.5.0
* [`231b0420`](https://github.com/NixOS/nixpkgs/commit/231b04201c2bd09f1c739343369400356c531242) logseq: make dugite use the `git` in nixpkgs
* [`18a60d21`](https://github.com/NixOS/nixpkgs/commit/18a60d21caac32d0c606309d0bef0d4c19409365) xow_dongle-firmware: don't perform unpack & installation in buildPhase
* [`4258952d`](https://github.com/NixOS/nixpkgs/commit/4258952dc69ea2b2063b53c584d2d285b9423abe) nixos/jellyfin: sync up with hardening provided in upstream
* [`d47874da`](https://github.com/NixOS/nixpkgs/commit/d47874da481548b0355052b9ce2ac5400cafd367) exodus: 22.2.25 -> 22.6.17
* [`33206dc2`](https://github.com/NixOS/nixpkgs/commit/33206dc202153b5699615e67059a64d946bf0fde) OSCAR: 1.3.1 -> 1.4.0
* [`5b70697f`](https://github.com/NixOS/nixpkgs/commit/5b70697f7ba0a3484c756a2544012d91082ef28d) lexend: init at 0.pre+date=2022-01-27
* [`051f3f94`](https://github.com/NixOS/nixpkgs/commit/051f3f948f7261dd6472a45c2a1ee17e42f2a4e2) dotnet: fix cross compilation
* [`0d8b21b3`](https://github.com/NixOS/nixpkgs/commit/0d8b21b3c840510191c539175be6a60f2a6a6c77) buildDotnetModule: fix cross compilation
* [`ddb0914a`](https://github.com/NixOS/nixpkgs/commit/ddb0914a7d2f438c3e12804edc407368be144fc7) doc/languages-frameworks: typos
* [`84f1f79a`](https://github.com/NixOS/nixpkgs/commit/84f1f79a8d9219ddaabdbaf6c3dab09cc409c2a7) nixos/doc: test-driver: Note on skipTypeCheck with extraPythonPackages
* [`4e03320e`](https://github.com/NixOS/nixpkgs/commit/4e03320ec514e3150ea56df543035c8879604490) grpc: 1.46.3 -> 1.47.0
* [`53898d0d`](https://github.com/NixOS/nixpkgs/commit/53898d0d2c4d55c16113e3858f32a1ddf65f6bf4) python310Packages.grpcio-tools: 1.46.3 -> 1.47.0
* [`04bc892e`](https://github.com/NixOS/nixpkgs/commit/04bc892e808429080a23839196781c49c088fe3d) python310Packages.grpcio-status: 1.46.3 -> 1.47.0
* [`67d19f47`](https://github.com/NixOS/nixpkgs/commit/67d19f473ccd3e89c7af3d547e21cb2ba800a5bb) phpPackage.mkExtension: makeOverridable
* [`6bce3fc6`](https://github.com/NixOS/nixpkgs/commit/6bce3fc64efd39e7e6b6cc2917eb533afbe33719) curl: use finalAttrs
* [`e2610640`](https://github.com/NixOS/nixpkgs/commit/e2610640c424eb95b3a40f5a3f2908441ef19c58) nixos/release.nix: fixed commands in comment
* [`574a9077`](https://github.com/NixOS/nixpkgs/commit/574a90771f3c0eeeeab798c38fea5f7bf6b44066) lib.types, nixos/users: Make passwdEntry available
* [`30c36b47`](https://github.com/NixOS/nixpkgs/commit/30c36b47062f5cab53da07d9ed4ff1bd2b98ce36) nixos/systemd-stage-1: use types.passwdEntry in emergencyAccess
* [`cd13a207`](https://github.com/NixOS/nixpkgs/commit/cd13a2074b6c8c909b1f73cc641e2481d921db02) nixos/network-interfaces-scripted: don't bindTo absent network-setup.service
* [`b69a5525`](https://github.com/NixOS/nixpkgs/commit/b69a5525f44d3854beae46409a2208478acebe00) po4a: add alias
* [`9112270b`](https://github.com/NixOS/nixpkgs/commit/9112270b9308ca4cf1b558ae31d54a7683fbdb7a) util-linux: 2.37.4 -> 2.38
* [`b622a654`](https://github.com/NixOS/nixpkgs/commit/b622a654771b41fe0e7e8d1902846ff28e400fba) sigal: add `setuptools` to deps
* [`47b58ff4`](https://github.com/NixOS/nixpkgs/commit/47b58ff43ebaef0307f4ef2de4e760ced3066cbf) curl: put tests in tests.withCheck
* [`fdc792bf`](https://github.com/NixOS/nixpkgs/commit/fdc792bf61781fe34815e502f7fc3dcacee1f0fb) openafs: Patch for Linux kernel 5.18
* [`403e4336`](https://github.com/NixOS/nixpkgs/commit/403e43366cbaaa164116327de27474f8fab36a85) yubikey-manager-qt: fix application icons
* [`76ff0191`](https://github.com/NixOS/nixpkgs/commit/76ff0191534b2123b6c56e09e674b4e86362165e) firefox: Extend upgrade script with version prefix
* [`d1b90cf5`](https://github.com/NixOS/nixpkgs/commit/d1b90cf54005e690f30bdf991df05a68ca0762d3) nixos/caddy: force caddy to reload config in ExecReload
* [`435959ce`](https://github.com/NixOS/nixpkgs/commit/435959ce6fd6588f7f7ecd5c2bf48773ae79aa96) jpegoptim: 1.4.6 -> 1.4.7
* [`5f1923d6`](https://github.com/NixOS/nixpkgs/commit/5f1923d67e1ecdc2176f017d7d2008aa1c908baf) androidenv: fix android cross-compilers
* [`0aded46f`](https://github.com/NixOS/nixpkgs/commit/0aded46f0838502361356497fc37825a9c3f9410) androidenv: update packages
* [`2a914f02`](https://github.com/NixOS/nixpkgs/commit/2a914f022c533d78a86a23d99fe72952af1be990) update android targets to recommended ones
* [`539222e8`](https://github.com/NixOS/nixpkgs/commit/539222e8d4bafaf783814c747e0ace40affa3761) canExecute: check for android
* [`2408ef3c`](https://github.com/NixOS/nixpkgs/commit/2408ef3c6faa0ba0d513257378563ddc886f1020) androidndk: remove legacy ndks
* [`cd414d01`](https://github.com/NixOS/nixpkgs/commit/cd414d016b2711f36627823f76cbef7e6ffccf85) python3Packages.jupyterlab_server: create temp home for tests
* [`55463392`](https://github.com/NixOS/nixpkgs/commit/55463392f03790b8d32e2e909834a15e8e799dac) shared-mime-info: 2021-21-03 -> 2.2
* [`51619a50`](https://github.com/NixOS/nixpkgs/commit/51619a501fc9736283932fe020388ff876946a05) libwebp: 1.2.1 -> 1.2.2
* [`51d67570`](https://github.com/NixOS/nixpkgs/commit/51d67570541489e442f159690dbe4ab05db11fa4) cimg: 3.0.2 → 3.1.4
* [`7ba0e47f`](https://github.com/NixOS/nixpkgs/commit/7ba0e47ff2ffccb47be7aab4913342aced3d6516) searxng: init at 2022-06-29
* [`46aa0a49`](https://github.com/NixOS/nixpkgs/commit/46aa0a4930259e0c4a076bbdfb656e754c38b4a8) gmic: 3.0.0 → 3.1.5
* [`f8a4f628`](https://github.com/NixOS/nixpkgs/commit/f8a4f628701df8d7f4012d42aac3e0c2cb5bfc0a) gmic-qt: 3.0.0 → 3.1.5
* [`82f4659c`](https://github.com/NixOS/nixpkgs/commit/82f4659c4779862bb45bded7ac25257b00e24f57) (craftos-pc): 2.4.5 -> 2.6.6
* [`1c80cbf3`](https://github.com/NixOS/nixpkgs/commit/1c80cbf38527e89a79963e9627399e481b344112) colord: use wrapGAppsHookNoGui
* [`449d6ce3`](https://github.com/NixOS/nixpkgs/commit/449d6ce32b2c7bd1fdff344d58b19ca1b5d06bb2) nixos/minidlna: add more configuration options
* [`7113eb55`](https://github.com/NixOS/nixpkgs/commit/7113eb557455d2c270ded37c494b937d9b72941f) nixos/minidlna: convert to structural settings
* [`136574f2`](https://github.com/NixOS/nixpkgs/commit/136574f2a3bb8800344cc7e14f21589cb858ecba) hadoop: security updates
* [`46339db6`](https://github.com/NixOS/nixpkgs/commit/46339db687cb7daf92af20db1c14152ade29c4a1) colord: make the daemon disablable
* [`d6ae2c36`](https://github.com/NixOS/nixpkgs/commit/d6ae2c369c94404135859283d915ce7c65d08060) zigbee2mqtt: 1.25.2 - 1.26.0
* [`a720bc44`](https://github.com/NixOS/nixpkgs/commit/a720bc44c23c80a49dab05c7907c2e58681b425d) buildRubyGem: fix bundix cross
* [`6b8ce2ac`](https://github.com/NixOS/nixpkgs/commit/6b8ce2acdf842f17878c4f059ccede137eb9b199) buildRubyGem: inherit libobjc from darwin
* [`023a9bf2`](https://github.com/NixOS/nixpkgs/commit/023a9bf29bc7b2c2ab62d50741755b056c84cb86) iosevka-comfy: Add passthru.updateScript
* [`bae6a92d`](https://github.com/NixOS/nixpkgs/commit/bae6a92d4feb2bef4aa6a3da9097199d1d6897a1) iosevka-comfy: 0.1.0 -> 0.2.1
* [`419dd6e1`](https://github.com/NixOS/nixpkgs/commit/419dd6e12db8139588d2e26830e93c54bf8e4d1d) curl: remove ``? null``
* [`7141ab0f`](https://github.com/NixOS/nixpkgs/commit/7141ab0f0b404a95509503e7b16a7f0072a66902) release: add tests.packageTestsForChannelBlockers.curl.withCheck as a channel blocker
* [`8004d0e4`](https://github.com/NixOS/nixpkgs/commit/8004d0e497b3b0d5908bcd0ffb1ffc748eb8d934) rustc: 1.61.0 -> 1.62.0
* [`3d13fbab`](https://github.com/NixOS/nixpkgs/commit/3d13fbab0570d2ca6b685ff9c53e32921cca837f) lsof: 4.94.0 -> 4.95.0
* [`dc5bdd68`](https://github.com/NixOS/nixpkgs/commit/dc5bdd685252c2be9432f274186283e00bd23ac9) Revert "stdenv: label the ephemeral coreutils-stage4 package"
* [`01bbab73`](https://github.com/NixOS/nixpkgs/commit/01bbab739bbb50366d103da5c755831eda1cd9c1) kodi.packages.invidious: init at 0.1.0+matrix.1
* [`f3ce5543`](https://github.com/NixOS/nixpkgs/commit/f3ce55435843e147c87e42c70d981e93b5d900f7) phrase-cli: 2.4.4 -> 2.4.12
* [`b745609d`](https://github.com/NixOS/nixpkgs/commit/b745609d608690f760306b2e529b0cdd34ed10e7) python3Packages.sphinx-basic-ng: 0.0.1.a11 -> 0.0.1.a12
* [`f0100c6f`](https://github.com/NixOS/nixpkgs/commit/f0100c6fa7095afdacd956b6f616997ef5e5565e) doc/contributing: replace outdated 'nix run' commands
* [`f7414e2b`](https://github.com/NixOS/nixpkgs/commit/f7414e2b3ac69f220e19b1ef9ddfe8d64650c5ca) cmake/setup-hook.sh: Don't skip build-RPATH
* [`1ca04aa9`](https://github.com/NixOS/nixpkgs/commit/1ca04aa9f1bec24bd4e01bac7932bbdb91737abb) treewide: Stop setting CMAKE_SKIP_BUILD_RPATH=OFF
* [`bcd70459`](https://github.com/NixOS/nixpkgs/commit/bcd70459981a6411418c2d8b0c13039270bdbf30) treewide: Remove now-unneeded LD_LIBRARY_PATH in cmake derivations
* [`b729ef3d`](https://github.com/NixOS/nixpkgs/commit/b729ef3ddde4cd90d16f3be0304c3e8b71491efe) nvpy: 2.1.0 -> 2.2.0
* [`cb730cf2`](https://github.com/NixOS/nixpkgs/commit/cb730cf239b855b1dfab54e0b7598ad294a718ab) nixpkgs-basic-release-checks: check for case-insensitive path conflicts
* [`30864517`](https://github.com/NixOS/nixpkgs/commit/3086451764dfed1e5fc5d6721c013c62d632a6dd) python3Packages.django_4: 4.0.5 -> 4.0.6
* [`8f3b6c83`](https://github.com/NixOS/nixpkgs/commit/8f3b6c83d94d617071e29efa436efbd6c430b005) python3Packages.django_3: 3.2.13 -> 3.2.14
* [`35278579`](https://github.com/NixOS/nixpkgs/commit/35278579b004a0f73646300d30c6fcedbf031dfa) friture: pin python to 3.9
* [`d09303b3`](https://github.com/NixOS/nixpkgs/commit/d09303b31d762378db24546fa862aead93241906) Update nixos/modules/services/misc/jellyfin.nix
* [`4affa141`](https://github.com/NixOS/nixpkgs/commit/4affa1417d50b503403ae7d3d4bb2461a192de38) svd2rust: 0.24.0 -> 0.24.1
* [`aa602d56`](https://github.com/NixOS/nixpkgs/commit/aa602d563c30125ecf255fe8f47ed43f1ddfa5bc) pyinfra: 2.1 -> 2.2
* [`d8e80628`](https://github.com/NixOS/nixpkgs/commit/d8e8062839a06cf2e368c814f2f3a62d74686ebe) python3Packages.pillow: 9.1.1 -> 9.2.0
* [`257a8075`](https://github.com/NixOS/nixpkgs/commit/257a8075681b514e4e4821509672de34bd5267f7) wayland: 1.20.0 -> 1.21.0
* [`826ab996`](https://github.com/NixOS/nixpkgs/commit/826ab9966b61618304c22acd20607246aa890e13) mesa: 22.1.1 -> 22.1.3
* [`eb9d6edb`](https://github.com/NixOS/nixpkgs/commit/eb9d6edb5abf509813eeabf1d3d8ab3c08287e30) curl: 7.83.1 -> 7.84.0
* [`e7cd9046`](https://github.com/NixOS/nixpkgs/commit/e7cd9046cac64ab6ff84d1fae8d5355af74c3e1b) git: 2.36.1 -> 2.37.0
* [`3173c3b6`](https://github.com/NixOS/nixpkgs/commit/3173c3b6b61cd06620bda26ac8f0b674866d6101) stdenv: start deprecating non-list cmakeFlags
* [`732f1d81`](https://github.com/NixOS/nixpkgs/commit/732f1d8142f7ea873fd38255db1ab1b4d07a8cc3) treewide: convert string cmakeFlags to list of strings
* [`f4697343`](https://github.com/NixOS/nixpkgs/commit/f4697343c6dfc114d9788655f51ca5047e345745) solaar: 1.1.3 -> 1.1.4 and move udev rules to an individual output
* [`cce5385d`](https://github.com/NixOS/nixpkgs/commit/cce5385de5f6766e55ff52d0975a122bc4b347dd) logitech-udev-rules: make it an alias of solaar.udev
* [`a53c70b6`](https://github.com/NixOS/nixpkgs/commit/a53c70b65de57e66ae000d63f948387b37eff91b) a52dec: fix build on aarch64-darwin
* [`ef9afda3`](https://github.com/NixOS/nixpkgs/commit/ef9afda3891d3f9cdf862a876edc1340b427ce94) codeowners: add fricklerhandwerk to documentation
* [`0083a683`](https://github.com/NixOS/nixpkgs/commit/0083a683d7ef0e8b6ad0a11d1806e407a41fff37) Revert "llvmPackages: do not include static archives when shared…"
* [`5bb06a69`](https://github.com/NixOS/nixpkgs/commit/5bb06a6970f5a2927bd412faeed17ac0d157553d) unzip: no-lchmod build flag
* [`aacc2f67`](https://github.com/NixOS/nixpkgs/commit/aacc2f67f860fc744e875ca366a2d8fd2b8f4c07) openasar: remove unzip hotfix
* [`f727b0bf`](https://github.com/NixOS/nixpkgs/commit/f727b0bfefa4afb6cc3ac22df1921638f76c161a) python310Packages.typogrify: reduce dependencies
* [`434f17b3`](https://github.com/NixOS/nixpkgs/commit/434f17b3e708f5f6628f0ed84ab0d54d49627931) conform: 0.1.0-alpha.25 -> 0.1.0-alpha.26
* [`73811b37`](https://github.com/NixOS/nixpkgs/commit/73811b372e5434ef83c189c7df9a3ed7adc2b87e) pkgs/stdenv/linux: add mips64el bootstrap-files
* [`3aa30346`](https://github.com/NixOS/nixpkgs/commit/3aa303469eaed70bec10168b7f7bf61e05842094) pgadmin: 6.10 -> 6.11
* [`cdaaedd8`](https://github.com/NixOS/nixpkgs/commit/cdaaedd8078e08fe94a43360e88d201f2d1716a1) python3Packages.uvloop: unbreak on aarch64-darwin
* [`1dbf7b45`](https://github.com/NixOS/nixpkgs/commit/1dbf7b45e26a6ef990ea72387dc1195e185c5fa0) openssl_3: 3.0.4 -> 3.0.5
* [`82da6eb4`](https://github.com/NixOS/nixpkgs/commit/82da6eb46dbbedb12dc740ff54d5c73749df4780) openssl_1_1: 1.1.1p -> 1.1.1q
* [`c99706f8`](https://github.com/NixOS/nixpkgs/commit/c99706f826fdd86ced5af6daf4621994cdfa1e9d) openrct2: 0.4.0 -> 0.4.1
* [`469ed5a8`](https://github.com/NixOS/nixpkgs/commit/469ed5a81262da29abaa16f01e2ac052c3f7b936) dt-shell-color-scripts: unstable-2022-02-22 -> unstable-2022-07-25
* [`03d159b4`](https://github.com/NixOS/nixpkgs/commit/03d159b493e7d3d08bd06d2a816f5c68567f2c20) coreutils: enable /proc/uptime support when cross-compiling
* [`4975868d`](https://github.com/NixOS/nixpkgs/commit/4975868d54636aae086d8e7cbf75c3723ce31db5) bada-bib: 0.6.2 -> 0.7.2
* [`4195ac32`](https://github.com/NixOS/nixpkgs/commit/4195ac320b9420cad19c03fa4f70cf3737f1e9ee) libtool,libtool_1_5: don't fix libtool
* [`5b47eb13`](https://github.com/NixOS/nixpkgs/commit/5b47eb13accbe58e5f8ee3b4483fa4a4556ac9cf) gcc, clang11: don't force -fcommon on GCC 10 or clang11
* [`5d3bef55`](https://github.com/NixOS/nixpkgs/commit/5d3bef551c671f75ed1eb1978d7fd1ee51cfa59d) cairo: add patch to fix crashes on darwin
* [`ca2ca8b1`](https://github.com/NixOS/nixpkgs/commit/ca2ca8b194d619e8ab050831463b04a5472abbd5) stdenv: start deprecating non-list mesonFlags
* [`c57fb11a`](https://github.com/NixOS/nixpkgs/commit/c57fb11a5050ea78ba23e3a185323b8cd7d94170) treewide: convert string mesonFlags to list of strings
* [`30333af9`](https://github.com/NixOS/nixpkgs/commit/30333af92878944b9c55e37247482b395c44a8b3) python310Packages.pytest-bdd: 5.0.0 -> 6.0.0
* [`e4c43186`](https://github.com/NixOS/nixpkgs/commit/e4c43186c4a5b3366e93c1299608709c03779c2c) pkgs/data/icons: use stdenvNoCC where possible
* [`757ab933`](https://github.com/NixOS/nixpkgs/commit/757ab9339d7b5fe2fad692d4398a0a9bd59a0071) beyond-identity: 2.49.0-0 -> 2.60.0-0
* [`fea398ab`](https://github.com/NixOS/nixpkgs/commit/fea398ab65e5c405779f16fc9b1bd4e394675c97) ffmpeg: 4.4.1 -> 4.4.2
* [`29946c6c`](https://github.com/NixOS/nixpkgs/commit/29946c6c213e6e0272a8b420b846279201429949) snipe-it: 6.0.5 -> 6.0.7
* [`a3eca010`](https://github.com/NixOS/nixpkgs/commit/a3eca010b04d93a531002154c005a638af8c65ed) remote-touchpad: 1.2.0 -> 1.2.1
* [`4f6ddfdd`](https://github.com/NixOS/nixpkgs/commit/4f6ddfdd23f0c3571af65465c8937b2640f988ff) Add Jane Street ocaml packages version 0.15
* [`f9d0937e`](https://github.com/NixOS/nixpkgs/commit/f9d0937e014aaf7249102b8d9370501045b00a8a) ocamlPackages.jst-config: fetch upstream patch
* [`1b76f055`](https://github.com/NixOS/nixpkgs/commit/1b76f05512532a73edaa6b2a5d19ab32d2d43f17) ocamlPackages.ppx_css: fix eval
* [`99047f1f`](https://github.com/NixOS/nixpkgs/commit/99047f1f141637bfa0108f5624b022091e4e86bf) bash_unit: 1.9.1 -> 2.0.0
* [`10e21aef`](https://github.com/NixOS/nixpkgs/commit/10e21aef1ceb24c5a8b7b33547138060c354e24e) mysql-shell: fix missing pyyaml dependency
* [`a64e151d`](https://github.com/NixOS/nixpkgs/commit/a64e151d26c7b1acb9ac45c46affb790ad32ca1d) lp_solve: fix build on aarch64-darwin
* [`4c4e75b3`](https://github.com/NixOS/nixpkgs/commit/4c4e75b3d6688a89ddecb0cfebdd7c5ec2270817) gnomeExtensions: auto-update
* [`56b7b2ca`](https://github.com/NixOS/nixpkgs/commit/56b7b2ca09d1642815aa1120a364f7e0098c55b7) libsForQt5.qtstyleplugin-kvantum: 1.0.2 -> 1.0.3
* [`f45fce50`](https://github.com/NixOS/nixpkgs/commit/f45fce503deb0977a84ef34fdd795b46667c3ef6) haskellPackages: stackage LTS 19.13 -> LTS 19.14
* [`6e3da6f9`](https://github.com/NixOS/nixpkgs/commit/6e3da6f98e7fd37f02d9fa8a1084b7e881f61a0c) all-cabal-hashes: 2022-07-02T15:59:48Z -> 2022-07-07T10:54:07Z
* [`6be4be4b`](https://github.com/NixOS/nixpkgs/commit/6be4be4b1198363c8545237ab6ac77f29446f230) haskellPackages: regenerate package set based on current config
* [`414b8ff0`](https://github.com/NixOS/nixpkgs/commit/414b8ff01420ee824263722a921c0fc3b2bf34f0) flat-remix-gtk: 20220527 -> 20220627
* [`f5f9bd03`](https://github.com/NixOS/nixpkgs/commit/f5f9bd035109e85b8b0452ed37d7b6ed439a86ee) voms: 2021-05-04 -> 2022-06-14
* [`cfebc8fc`](https://github.com/NixOS/nixpkgs/commit/cfebc8fc6477d65cbb2387a715107a5eae60a298) krb5: 1.19.3 -> 1.20
* [`92b24dad`](https://github.com/NixOS/nixpkgs/commit/92b24dade32073eba89208b502163e768d5be501) haskellPackages.futhark: remove futhark source override
* [`211a3313`](https://github.com/NixOS/nixpkgs/commit/211a3313bf015c69517ca37cbc0e80c387e8c360) haskellPackages.matterhorn: bump brick version
* [`5c8e8f74`](https://github.com/NixOS/nixpkgs/commit/5c8e8f748ffdfda0b95c468088e2fc9bc963e3ea) kopia: 0.11.1 -> 0.11.2
* [`a11073ee`](https://github.com/NixOS/nixpkgs/commit/a11073eef8f98d1245266299a21d283ff69bc270) pipewire: 0.3.52 -> 0.3.53
* [`844f03a9`](https://github.com/NixOS/nixpkgs/commit/844f03a9dd7ef3e4f1bd3e15d2fac74cafaccac4) pipewire: 0.3.53 -> 0.3.54
* [`ee803e03`](https://github.com/NixOS/nixpkgs/commit/ee803e037976e5475849618c3ac07272ec219df3) draco: 1.5.2 -> 1.5.3
* [`b2224764`](https://github.com/NixOS/nixpkgs/commit/b2224764eeaab6792054e98780cf05be6baec601) nixos-generate-config: substitute nix-instantiate
* [`2b7224c8`](https://github.com/NixOS/nixpkgs/commit/2b7224c8e07c5cb01c2c8f87b0fae280b8c7b7c1) krb5: preConfigure -> sourceRoot
* [`2736dc90`](https://github.com/NixOS/nixpkgs/commit/2736dc901692f830da02bd6aea47d3495dfd8352) krb5: run hooks and replace subshells with make -C
* [`b0c63ef0`](https://github.com/NixOS/nixpkgs/commit/b0c63ef0d1a16109d6aecdbfb164d96ba8712cc2) fetch-kde-qt.sh: get sha256 from server
* [`81085841`](https://github.com/NixOS/nixpkgs/commit/8108584109e0d567a8d355f8647643942d0bcd8a) krb5: remove file-wide with lib;
* [`95c8e573`](https://github.com/NixOS/nixpkgs/commit/95c8e5731ae93090f08a6fedb0b632a3fced285e) github-desktop: 2.9.12 -> 3.0.3
* [`b376d600`](https://github.com/NixOS/nixpkgs/commit/b376d600e63e067c6c149572e6a3877ac58361f1) argocd-autopilot: 0.3.7 -> 0.3.9
* [`c92c834a`](https://github.com/NixOS/nixpkgs/commit/c92c834ac0c6f8106baa1b45f2702ea45ffe50de) armadillo: 11.2.0 -> 11.2.2
* [`d7c19be9`](https://github.com/NixOS/nixpkgs/commit/d7c19be9dfbbb829a63ddb58919cb08a7afb53f2) bemenu: 0.6.7 -> 0.6.10
* [`34c77f1e`](https://github.com/NixOS/nixpkgs/commit/34c77f1e8d352e68074a89564a5c14106f0a4c0b) llvmPackages_14: 14.0.1 -> 14.0.6
* [`54ba715d`](https://github.com/NixOS/nixpkgs/commit/54ba715d0025ffd8a05a8fd888ebea7073d63002) brave: 1.39.122 -> 1.40.113
* [`3e546f30`](https://github.com/NixOS/nixpkgs/commit/3e546f30e49ffdb15245f2d98bf2ecbf7b475f07) bitwig-studio: 4.2.3 -> 4.3.1
* [`cd51d7ac`](https://github.com/NixOS/nixpkgs/commit/cd51d7ac4b6a4f71a35c660920008dad865d71ce) cpuid: 20220224 -> 20220620
* [`23efe820`](https://github.com/NixOS/nixpkgs/commit/23efe8200948f32e342c44854872969d1393e110) dasel: 1.24.3 -> 1.25.0
* [`0494aebc`](https://github.com/NixOS/nixpkgs/commit/0494aebc0d0362e323e7586e03a3746489aa93ce) cwm: 6.7 -> 7.1
* [`b17f5220`](https://github.com/NixOS/nixpkgs/commit/b17f522053dbd627bc599f9cab3a7f63200778de) palemoon: 31.1.0 -> 31.1.1
* [`5ea1c721`](https://github.com/NixOS/nixpkgs/commit/5ea1c721e1d8532742a559e6eec67da9dd7b6536) delly: 0.9.1 -> 1.0.3
* [`2cc04cca`](https://github.com/NixOS/nixpkgs/commit/2cc04ccafe7775b498ac9fbf33e828ec2a098059) palemoon: Further limit build cores count
* [`f297d1eb`](https://github.com/NixOS/nixpkgs/commit/f297d1ebd98985e7fd64089dde0906d3829a3f82) glirc: generate vty version that is compatible
* [`9b702d62`](https://github.com/NixOS/nixpkgs/commit/9b702d6270418c9d00701a55c6ec98e45f15bda8) Add myself as maintainer for git-annex
* [`5905c0de`](https://github.com/NixOS/nixpkgs/commit/5905c0de691efb4ec01a7a827b0ce4e83d2231f2) clash: 1.11.0 -> 1.11.4
* [`7f7bfa5e`](https://github.com/NixOS/nixpkgs/commit/7f7bfa5e5ffe9460d78c472ce9c79d0f3f89e21f) haskellPackages: regenerate package set based on current config
* [`92230534`](https://github.com/NixOS/nixpkgs/commit/92230534fea390a47d6e9a91ea32829ef6cb8a4d) cmdstan: 2.29.2 -> 2.30.0
* [`28f8307a`](https://github.com/NixOS/nixpkgs/commit/28f8307a267f958cc50ea50ec36e0e9c1dfa1c38) kops: 1.23.2 -> 1.24.0
* [`c7e60ccf`](https://github.com/NixOS/nixpkgs/commit/c7e60ccfd127f8f3025ffdd31de7631a16b472d0) kops: drop 1.21
* [`acf97a1d`](https://github.com/NixOS/nixpkgs/commit/acf97a1d046dad827ec2dace9c6cc4c050779a27) lucenepp: fix libdir for pkgconfig
* [`aa922e66`](https://github.com/NixOS/nixpkgs/commit/aa922e6648c51e401e9fe3a12964d4cdbb2cb34c) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.4.2 -> 1.5.0
* [`73094a00`](https://github.com/NixOS/nixpkgs/commit/73094a006e4c0a7085d93439d2a8a0ab38a09211) drush: 8.4.10 -> 8.4.11
* [`f276a443`](https://github.com/NixOS/nixpkgs/commit/f276a4435be2b497048c92fbe7d98a4fd32223ef) ergo: 4.0.30 -> 4.0.34
* [`3087ec9f`](https://github.com/NixOS/nixpkgs/commit/3087ec9f2141949dc95a39a211e7df5defbfd7d0) linux_xanmod: 5.15.43 -> 5.15.53
* [`bc799b32`](https://github.com/NixOS/nixpkgs/commit/bc799b322259bdfb5f95f28bf3338dbbbbbe6a73) linux_xanmod_latest: 5.18.1 -> 5.18.10
* [`100c1bcc`](https://github.com/NixOS/nixpkgs/commit/100c1bcc117196c51aaa3493f1e316fd3a7de768) linux_xanmod: remove LRNG option
* [`82dc6d63`](https://github.com/NixOS/nixpkgs/commit/82dc6d6354ca74c1a926ce63e0db23fb33be0d8e) frugal: 3.15.1 -> 3.15.4
* [`54b7074d`](https://github.com/NixOS/nixpkgs/commit/54b7074d065bedda4f073cea2e4d73fa0acc51ef) spotify-tui: add collection variant patch
* [`e7575622`](https://github.com/NixOS/nixpkgs/commit/e7575622c0846dcba2fb77892aac6af3119c35e6) wkhtmltopdf: unbreak on darwin
* [`23db2972`](https://github.com/NixOS/nixpkgs/commit/23db297291296e55659e278f2950ac5323da325e) util-linux: 2.37.4 -> 2.38
* [`45ddcc04`](https://github.com/NixOS/nixpkgs/commit/45ddcc04cd9350c64fbabda5c5d32539da9e549b) wluma: 4.1.0 -> 4.1.2
* [`7a4e9099`](https://github.com/NixOS/nixpkgs/commit/7a4e90990562f575f66e4aeb7bc5147a7f04046d) nixos/plasma5: enable power-profiles-daemon by default
* [`5e84f789`](https://github.com/NixOS/nixpkgs/commit/5e84f7899e5322d3c83a6ade298004cb9eb11e2d) nixos/plasma5: expose qdbus in PATH
* [`b47c0f45`](https://github.com/NixOS/nixpkgs/commit/b47c0f454f99945c9c1a746825ee50fd390a14aa) vimPlugins: update
* [`990187fe`](https://github.com/NixOS/nixpkgs/commit/990187fea626e3528ac731be373033f66eb363bc) vimPlugins.zk-nvim: init at 2022-06-30
* [`22c85441`](https://github.com/NixOS/nixpkgs/commit/22c854414f3b6668d67c71e0664a322d872e641b) osu-lazer: 2022.409.0 -> 2022.709.1
* [`3593e17c`](https://github.com/NixOS/nixpkgs/commit/3593e17c89e761e7570de44a7aec03038ddca476) terra: 1.0.0-beta5 -> 1.0.4
* [`1065fb56`](https://github.com/NixOS/nixpkgs/commit/1065fb56be0a73e9bfd7732738cde4da8c37a1fa) confluent-platform: 7.1.0 -> 7.2.0
* [`88fe25c2`](https://github.com/NixOS/nixpkgs/commit/88fe25c28d9075a308b2985986b4e3ff9560e37b) cppcheck: 2.8 -> 2.8.1
* [`f1485955`](https://github.com/NixOS/nixpkgs/commit/f1485955248e4776febff40edcc95311649955f8) mopidy-youtube: 3.5 -> 3.6
* [`27d6965d`](https://github.com/NixOS/nixpkgs/commit/27d6965d8e620bcf35f201f3f56b03ab5499c70c) pidgin, libmaxminddb, simutrans, tiptop: remove myself
* [`58d35e01`](https://github.com/NixOS/nixpkgs/commit/58d35e01aa029ee430fbd44732265bee236f0269) nextinspace: 2.0.3 -> 2.0.5
* [`8886f798`](https://github.com/NixOS/nixpkgs/commit/8886f798329eb16fbc5190697b8e17b35cc08e2a) python3Packages.uvloop: fix linux build
* [`e60e4e01`](https://github.com/NixOS/nixpkgs/commit/e60e4e01369a868ecd963c9558f8295585ce3495) wayland-protocols: 1.25 -> 1.26
* [`e310b2d8`](https://github.com/NixOS/nixpkgs/commit/e310b2d8761a08907e481f459262ac61b89e226e) libdrm: 2.4.111 -> 2.4.112
* [`9d0d1d49`](https://github.com/NixOS/nixpkgs/commit/9d0d1d499ef0919a2bd3ec97cbad9dcd08d5f003) libfinity: replace mkFlag with lib.withFeature
* [`54ed2aa8`](https://github.com/NixOS/nixpkgs/commit/54ed2aa8c177aab0fd8d801e9ae2e4a6d105e6df) lame: replace mkFlag with lib.enableFeature
* [`9d1b0d95`](https://github.com/NixOS/nixpkgs/commit/9d1b0d95e84f4d16e5e03195e80c1fbf5d8ed183) libass: replace mkFlag with lib.enableFeature
* [`4646c62e`](https://github.com/NixOS/nixpkgs/commit/4646c62ecbb8ef81ba273fee48caef6b3e4e4ac1) moc: replace mkFlag with lib.withFeature
* [`daa8d8b4`](https://github.com/NixOS/nixpkgs/commit/daa8d8b42ca676df16783d263bac3e3045869975) rsyslog: replace mkFlag with lib.enableFeature
* [`b912253a`](https://github.com/NixOS/nixpkgs/commit/b912253a5d4b4e243bea8289b26606c87c376cde) wiredtiger: replace mkFlag with lib.enableFeature and lib.withFeature
* [`72848cc7`](https://github.com/NixOS/nixpkgs/commit/72848cc78ef91a52e1da27f66d04742de4e7c9ff) shishi: replace mkFlag with lib.enableFeature and lib.withFeature
* [`3d881da9`](https://github.com/NixOS/nixpkgs/commit/3d881da967f5befe80d261b9af91e2c274e572f1) pinentry: replace mkFlag with lib.enableFeature and lib.withFeature
* [`905e33f5`](https://github.com/NixOS/nixpkgs/commit/905e33f5f4a10a8c74ba5e9bdae1c8d7db5c4f5d) ghorg: 1.7.16 -> 1.8.0
* [`9ca453de`](https://github.com/NixOS/nixpkgs/commit/9ca453deebdba804a91f4e7355a04d68d67ea1f9) imgcat: 2.3.1 -> 2.5.1
* [`f41fc221`](https://github.com/NixOS/nixpkgs/commit/f41fc22111e9d12a3e0fa2d99cee1165853a5869) prl-tools: 12.2.1-41615 -> 17.1.4-51567
* [`0db2c988`](https://github.com/NixOS/nixpkgs/commit/0db2c988d3e86a5b5cfdeceb67123302b31ac2cb) aws-workspaces: pin icu
* [`bc9d72b9`](https://github.com/NixOS/nixpkgs/commit/bc9d72b9dcdda848c122a295ed45054f27adf6f2) aws-workspaces: 4.0.1.1302 -> 4.1.0.1523
* [`8073a6fb`](https://github.com/NixOS/nixpkgs/commit/8073a6fb0988654c84f1c1c63301f9b854a3925f) darwin.xnu: fix build on aarch64-darwin ([nixos/nixpkgs⁠#179921](https://togithub.com/nixos/nixpkgs/issues/179921))
* [`f6411523`](https://github.com/NixOS/nixpkgs/commit/f6411523e399498c5468c237b1b7d21e7fdc3c7f) vala-language-server: 0.48.4 -> 0.48.5
* [`1ba2a7f3`](https://github.com/NixOS/nixpkgs/commit/1ba2a7f398c7dcab78ac4e3e8d93d3066c550b59) anime-downloader: fix bug with qt build
* [`5719e205`](https://github.com/NixOS/nixpkgs/commit/5719e205476a953643856c41fad464dc9df15fb4) krb5: add pasthru.tests
* [`bc0bf248`](https://github.com/NixOS/nixpkgs/commit/bc0bf248d365e37c6ed93f7e88975bc48c13fd73) albert: 0.17.2 -> 0.17.3
* [`f83e3d91`](https://github.com/NixOS/nixpkgs/commit/f83e3d91a4cdddd7ea3f3426caaf792911445d3e) emote: 3.0.3 -> 3.1.0
* [`096ea49a`](https://github.com/NixOS/nixpkgs/commit/096ea49aa8b463cc444c56dbac2ad292fe263acf) haskellPackages.clash-prelude: fix build by disabling tests
* [`f97b02c5`](https://github.com/NixOS/nixpkgs/commit/f97b02c505df199277e2512f012af1fdf56e2e36) python310Packages.jarowinkler: 1.1.0 -> 1.1.1
* [`04eb893b`](https://github.com/NixOS/nixpkgs/commit/04eb893beb851563010cd3158fac617e5d2ff123) weechat: 3.5 -> 3.6
* [`cc6b603b`](https://github.com/NixOS/nixpkgs/commit/cc6b603b6b3965cddcf39ce58764b429773d0c43) neatvnc: 0.4.0 -> 0.5.1
* [`6ff9229f`](https://github.com/NixOS/nixpkgs/commit/6ff9229f84a4d6abf8603944a5e16a6d6e97f14c) wayvnc: 0.4.1 -> 0.5.0
* [`a2d05bac`](https://github.com/NixOS/nixpkgs/commit/a2d05bac402454f365a3afa0143ac18e2cf464d9) cargo-public-api: init 0.12.2
* [`99ebc20c`](https://github.com/NixOS/nixpkgs/commit/99ebc20c1ec7e7e96f85d6354a2e1162074d3def) telegram-purple: remove
* [`53e959f2`](https://github.com/NixOS/nixpkgs/commit/53e959f2958e25f11dca830c735f0325a09dd93f) tdlib-purple: init at 0.8.1
* [`549c0e99`](https://github.com/NixOS/nixpkgs/commit/549c0e99714911e6034dcf396703a6e50393d462) carp: 0.5.4 -> 0.5.5
* [`8a84ef79`](https://github.com/NixOS/nixpkgs/commit/8a84ef79723c5a34476f01ad3a6692a5c2405a35) hdf5: 1.12.1 -> 1.12.2
* [`a9f4a2ea`](https://github.com/NixOS/nixpkgs/commit/a9f4a2eadf5c9949f99b820d38292c852501efe8) cjose: 0.6.1 -> 0.6.2 (fork)
* [`1e8ca70a`](https://github.com/NixOS/nixpkgs/commit/1e8ca70a0a18bec6650356647f61dcf3b1bfbfc5) libhandy: 1.6.2 → 1.6.3
* [`5ef90871`](https://github.com/NixOS/nixpkgs/commit/5ef908713a80136f53ceaa42d5730fdf0e294d3f) libhandy: fix updateScript versionPolicy
* [`3fd82bba`](https://github.com/NixOS/nixpkgs/commit/3fd82bba7f3a80d106136f34fe1325db1a7ebcf1) lxqt.xdg-desktop-portal-lxqt: allow extra qt styles
* [`3e2996c3`](https://github.com/NixOS/nixpkgs/commit/3e2996c31e071ccedfebbe2c072aafac019a35b4) libstrophe: 0.12.0 -> 0.12.1
* [`0511ecea`](https://github.com/NixOS/nixpkgs/commit/0511eceae6d9cecc8b28f72650f44aa6946650a1) ferium: Update description and homepage
* [`1eddccf2`](https://github.com/NixOS/nixpkgs/commit/1eddccf258e54a5b71a954df5e394639d07f5196) ftxui: 2.0.0 -> 3.0.0
* [`1e68a02e`](https://github.com/NixOS/nixpkgs/commit/1e68a02e4aeb4bdcd65882bc0aab20d04bc78651) aqbanking: 6.3.0 -> 6.5.0
* [`81804181`](https://github.com/NixOS/nixpkgs/commit/81804181d1beac7b4019202d1781d48045166b89) libchipcard: 5.0.4 -> 5.1.6
* [`77af6669`](https://github.com/NixOS/nixpkgs/commit/77af6669db8e39b5fecbbac968751b0cb6d3aa44) gwenhyfar: 5.6.0 -> 5.9.0
* [`5a6722b0`](https://github.com/NixOS/nixpkgs/commit/5a6722b0e101c364a27bc870c1da997b665c49bf) voms: make meta.description more clearly
* [`f0b4a5da`](https://github.com/NixOS/nixpkgs/commit/f0b4a5da478003f11da0aaaa38be02afacd4e4d9) voms: default to symlink $out/etc to /etc
* [`e2e8e381`](https://github.com/NixOS/nixpkgs/commit/e2e8e38186060cf7af23bcb813c0506afc2ca965) xrootd: 5.4.2 -> 5.4.3
* [`b2a65251`](https://github.com/NixOS/nixpkgs/commit/b2a6525191bc7a3a2f5f98588cc57dcacc1b4e17) gnunet: 0.17.1 -> 0.17.2
* [`602e9830`](https://github.com/NixOS/nixpkgs/commit/602e9830e9a3b0f7f4cfacbc599d4714a9ac126a) maintainers: add ihatethefrench
* [`1d068486`](https://github.com/NixOS/nixpkgs/commit/1d0684862c988e2d99ec2445bd0c59fb030dd5a3) page: 3.0.0 -> 3.1.0
* [`baed548b`](https://github.com/NixOS/nixpkgs/commit/baed548bcf906f628e5094fb33b017181118e818) navidrome: build from source
* [`6e87ec81`](https://github.com/NixOS/nixpkgs/commit/6e87ec81629bf514c886838259d5f438108929a6) librewolf: 102.0-2 -> 102.0.1-1
* [`190a8c32`](https://github.com/NixOS/nixpkgs/commit/190a8c326c5c7ce8bc8d28d4909a2f5e86d49fda) sshs: init at 3.2.0
* [`df27adac`](https://github.com/NixOS/nixpkgs/commit/df27adac6aa7660f687b0b9ba61d4718de887ac2) boulder: 2022-06-21 -> 2022-07-05
* [`ef6d6d4c`](https://github.com/NixOS/nixpkgs/commit/ef6d6d4c4ae396b9cd4b3a7cb9d61067ff5dcb11) Add `bash` to netdata service path
* [`61c9f44a`](https://github.com/NixOS/nixpkgs/commit/61c9f44a1d1b854cb12e0173fb548094355cfe8f) pipewire: fix bluetooth for system-wide configuration
* [`72259eaf`](https://github.com/NixOS/nixpkgs/commit/72259eaf9b32d111ee4f520585a34580e21e4b68) jtag-remote-server: init at unstable-2022-06-09
* [`0b616033`](https://github.com/NixOS/nixpkgs/commit/0b616033068b946ac3f9bc019f8a725d16474a3e) agi: 3.1.0-dev-20220314 -> 3.1.0-dev-20220627
* [`71ee25ae`](https://github.com/NixOS/nixpkgs/commit/71ee25aecfb9535454f0aaa586db946545504aa8) alfis: 0.7.3 -> 0.7.4
* [`15fd4547`](https://github.com/NixOS/nixpkgs/commit/15fd45470f38fe91c997eff1a42e34a663c13c74) wander: init at 0.4.1
* [`4b4576fa`](https://github.com/NixOS/nixpkgs/commit/4b4576faf9452e394309219b38d9dc6c13c429ff) Revert "linux-kernel: disable BTF on 32-bit platforms on kernels 5.15+"
* [`53daacc6`](https://github.com/NixOS/nixpkgs/commit/53daacc626871885029c0f6da21a2c22b0767934) python310Packages.bc-python-hcl2: 0.3.44 -> 0.3.45
* [`ab26c636`](https://github.com/NixOS/nixpkgs/commit/ab26c6364ece4f02aa8a620ddbeebcddc16e869d) dmidecode: 3.2 -> 3.4
* [`93f5569b`](https://github.com/NixOS/nixpkgs/commit/93f5569bd15246f3d7ae5058ef8c8ff011adefd7) python310Packages.teslajsonpy: 2.2.1 -> 2.3.0
* [`4d9ac2f7`](https://github.com/NixOS/nixpkgs/commit/4d9ac2f79753e503ceea8ee03943fd43df5ad57f) cdk-go: 1.2.0 -> 1.3.0
* [`ff9bfb09`](https://github.com/NixOS/nixpkgs/commit/ff9bfb09093c6e54af91e6913748f72fff04f3dd) godns: 2.8.1 -> 2.8.3
* [`19677953`](https://github.com/NixOS/nixpkgs/commit/196779537293cdd32ce5e3ca877d2750ec1df977) python310Packages.hahomematic: 2022.7.1 -> 2022.7.3
* [`26382865`](https://github.com/NixOS/nixpkgs/commit/26382865b32c4442b6dc92ce013e0994c098e45a) conftest: 0.33.0 -> 0.33.1
* [`bf326172`](https://github.com/NixOS/nixpkgs/commit/bf3261722cf7bd3c2ccb77d2cbf68efa5309daa1) convco: 0.3.10 -> 0.3.11
* [`1547a2b7`](https://github.com/NixOS/nixpkgs/commit/1547a2b7cbdc51ed331fc9dabde3de00674355ff) terranix: 2.5.3 -> 2.5.4
* [`9c52a623`](https://github.com/NixOS/nixpkgs/commit/9c52a623fc5a11fbe56f352b2b271da983ddc23f) audacious: 4.1 -> 4.2
* [`509a3cb0`](https://github.com/NixOS/nixpkgs/commit/509a3cb0ad5c42bc9eb15b7bc2f8c1ccd478d916) libsolv: enable more compression methods
* [`03a10be9`](https://github.com/NixOS/nixpkgs/commit/03a10be9721cc30f5eb65f11f7aeb2e4390ba99c) python310Packages.google-cloud-datastore: 2.7.1 -> 2.7.2
* [`8cae924b`](https://github.com/NixOS/nixpkgs/commit/8cae924bc20ed6155d633caf73caa67c7fb32e3f) croc: 9.5.6 -> 9.6.0
* [`9104b29c`](https://github.com/NixOS/nixpkgs/commit/9104b29c39cee2b50bf93e00374e22474a0fef9a) radioboat: init at 0.2.1
* [`afd8c1ca`](https://github.com/NixOS/nixpkgs/commit/afd8c1ca500e79d77bc2edc15c77a901093f1a2d) linuxPackages.nvidia_x11: fix build failure due to wrong install args
* [`3b541e59`](https://github.com/NixOS/nixpkgs/commit/3b541e59ac72e126f4f1fe70a39ba3d8f8997389) linode-cli: 5.17.2 -> 5.21.0
* [`02d3c0f0`](https://github.com/NixOS/nixpkgs/commit/02d3c0f0570859b524308e2a187abec797615e36) drill: 0.7.2 -> 0.8.0
* [`292eed75`](https://github.com/NixOS/nixpkgs/commit/292eed7510bb8ecb70696a15b1299bc983d2cfa3) gtkterm: 1.1.1 -> 1.2.1
* [`06e537ad`](https://github.com/NixOS/nixpkgs/commit/06e537ad60b199ebbf31da8537a45f6b28a7591e) bada-bib: add missing libadwaita and gtksourceview5 dependency
* [`07f2b4be`](https://github.com/NixOS/nixpkgs/commit/07f2b4bebf1a457d4e709ad20b3c53aa55a960e7) linux-firmware: 20220610 -> 20220708
* [`600133b8`](https://github.com/NixOS/nixpkgs/commit/600133b855579cf4067136c5e505695fb060a1ed) mono: 6.12.0.122 -> 6.12.0.182
* [`cfa1a2bc`](https://github.com/NixOS/nixpkgs/commit/cfa1a2bc6377940c534ad65fbfbb19b5dfe03c81) esbuild: 0.14.48 -> 0.14.49
* [`7887f5b9`](https://github.com/NixOS/nixpkgs/commit/7887f5b9d05053f4f0d4e05ca857c6e1286056b0) python310Packages.huawei-lte-api: 1.6 -> 1.6.1
* [`3b12ce3d`](https://github.com/NixOS/nixpkgs/commit/3b12ce3da644b5d0d79491eea05406e79876b579) kde: sort apps alphabetically
* [`0f72d3c8`](https://github.com/NixOS/nixpkgs/commit/0f72d3c8cc8e2328d3aa23bddae2616a206661d1) konversation: Update/move to KDE Gear
* [`735e0d7f`](https://github.com/NixOS/nixpkgs/commit/735e0d7fa802f4b0a0c940dd1ccff8bc08a3cdc4) konversation: Remove maintainer
* [`8b788def`](https://github.com/NixOS/nixpkgs/commit/8b788def0fcd41438b6fbc173eca310592ac0bcd) kde/gear: 22.04.2 -> 22.04.3
* [`6de4f6b3`](https://github.com/NixOS/nixpkgs/commit/6de4f6b39fd26751bb096acd709ea30c645eab4e) digikam: 7.6.0 -> 7.7.0
* [`3217a8b0`](https://github.com/NixOS/nixpkgs/commit/3217a8b0c25af95da14d73085ad6bacd5683bf5d) materia-kde-theme: 20210814 -> 20220607
* [`66281325`](https://github.com/NixOS/nixpkgs/commit/662813256c0852b535c1b2de06da54d066e89b83) ntl: explicitly set 'configurePlatforms = [ ];'
* [`24eb6920`](https://github.com/NixOS/nixpkgs/commit/24eb6920dcb43604f660b3bf8879ea1ff4ee5e8e) ddnet: 16.2 -> 16.2.1
* [`9805aedb`](https://github.com/NixOS/nixpkgs/commit/9805aedbcccadd363aeaf8e7b6be9b82688b9d8b) pre-commit: 2.19.0 -> 2.20.0
* [`982e67f4`](https://github.com/NixOS/nixpkgs/commit/982e67f4dd03d39f7ca1a06c488f7836a8b8edc7) flyctl: 0.0.350 -> 0.0.351
* [`6bca1a64`](https://github.com/NixOS/nixpkgs/commit/6bca1a64167f539bef4294fe98fe880e963f4be4) rustdesk: 1.1.8 -> 1.1.9, fix
* [`836daa7b`](https://github.com/NixOS/nixpkgs/commit/836daa7b457e18618ffd63978a265120bfda6204) loki: 2.5.0 -> 2.6.0
* [`2a07fadb`](https://github.com/NixOS/nixpkgs/commit/2a07fadbbaa200df3eae4489489d71bc4e6832fd) python310Packages.myst-docutils: 0.17.2 -> 0.18.0
* [`d7f5c978`](https://github.com/NixOS/nixpkgs/commit/d7f5c97885e46c91bd870a56b8b179ad25dd61df) eclib: 20210625 -> 20220621
* [`55a53e1d`](https://github.com/NixOS/nixpkgs/commit/55a53e1dec01d618a5f448b6a774fc0a05d813a5) sage: apply eclib 20220621 update patch
* [`bc604964`](https://github.com/NixOS/nixpkgs/commit/bc60496489beeed7432fd080e3856baef9377f05) pinentry-rofi: init at 2.0.3
* [`6d9df519`](https://github.com/NixOS/nixpkgs/commit/6d9df51984da5e8b7ed1191d416ff8a09aad80db) teams: add revol-xut to c3d2
* [`b9854d66`](https://github.com/NixOS/nixpkgs/commit/b9854d669e0bf71c9874933544082da0d975eaed) nauty: 2.7r3 -> 2.7r4
* [`8d01b570`](https://github.com/NixOS/nixpkgs/commit/8d01b570f22ddf79d42f86bd92bc534f4a7fa28d) intel-gmmlib: 22.1.3 -> 22.1.5
* [`64c1e5af`](https://github.com/NixOS/nixpkgs/commit/64c1e5af0f16d4931cd2ab5844a2f996158a6a41) papirus-icon-theme: changed color argument handling
* [`1cdeb202`](https://github.com/NixOS/nixpkgs/commit/1cdeb202976c39cc757e66580bd7f0bffa3b4392) go-task: 3.12.1 -> 3.14.0
* [`4e169fe7`](https://github.com/NixOS/nixpkgs/commit/4e169fe7ee39757f59bd1b238e665de1f1f3e81d) hdparm: 9.63 -> 9.64
* [`76e20e84`](https://github.com/NixOS/nixpkgs/commit/76e20e84b63d5f8098a28952d8c3d04f97beeb1c) gmsh: 4.10.4 -> 4.10.5
* [`d58cc561`](https://github.com/NixOS/nixpkgs/commit/d58cc561037eeeca0e185caafac78c50cccf564c) i3lock: 2.13 -> 2.14.1
* [`5cccce30`](https://github.com/NixOS/nixpkgs/commit/5cccce3077fee88f185d5b6b060b5e377e9e6467) rust-analyzer: 2022-06-13 -> 2022-07-11
* [`cc5a1c91`](https://github.com/NixOS/nixpkgs/commit/cc5a1c91353836de9f9ea3fca757573be2b525d6) python310Packages.dvc-objects: 0.0.20 -> 0.0.23
* [`67258310`](https://github.com/NixOS/nixpkgs/commit/67258310baaa0d6fd42e1d6efa8e36c161ce3605) python310Packages.casbin: 1.16.8 -> 1.16.9
* [`76a6979f`](https://github.com/NixOS/nixpkgs/commit/76a6979fbd660d6270584097ab5d9b7dc29b19eb) pcloud: 1.9.7 -> 1.9.9
* [`55d3af25`](https://github.com/NixOS/nixpkgs/commit/55d3af25beb3d159e1dd0ea329a21e7d8eb38683) python310Packages.bayespy: Fix tests
* [`fa36ef2f`](https://github.com/NixOS/nixpkgs/commit/fa36ef2f25b1357feb17d7e702c6be4397647ee2) bun: 0.1.1 → 0.1.2
* [`efb1ce5c`](https://github.com/NixOS/nixpkgs/commit/efb1ce5cd0098252aa9022220e3ae7de9247e0a1) glances: fix tests on darwin
* [`b89b1fdd`](https://github.com/NixOS/nixpkgs/commit/b89b1fddb5da103c37817902d278e87d9bf0584d) python310Packages.tatsu: 5.8.0 -> 5.8.1
* [`63d72966`](https://github.com/NixOS/nixpkgs/commit/63d729665c2835be0c507ced648ccc024620afb6) glimpse: Drop package and plugins
* [`e67a0094`](https://github.com/NixOS/nixpkgs/commit/e67a009406ee822ecfec95a5c5d875a645f035fb) terminal-colors: 3.0.1 -> 3.0.2
* [`220238e2`](https://github.com/NixOS/nixpkgs/commit/220238e223d89488fb3fdd9a6a8113c18714f8ca) musikcube: 0.97.0 -> 0.98.0
* [`29b37f58`](https://github.com/NixOS/nixpkgs/commit/29b37f58e9f8d0321a0e5ffe1b42ddad4150df03) python310Packages.pyupgrade: 2.34.0 -> 2.37.1
* [`8dcdd419`](https://github.com/NixOS/nixpkgs/commit/8dcdd419d1103a8f2d5cd96bd9df70b66baa87e1) media-downloader: init at 2.4.0
* [`da1f2915`](https://github.com/NixOS/nixpkgs/commit/da1f29154acc04d1abd1fec6a7d53d49ee6fb33a) libime: 1.0.12 -> 1.0.13
* [`f32ab0fd`](https://github.com/NixOS/nixpkgs/commit/f32ab0fd3bd67a5003181c804190358c405f61d9) fcitx5: 5.0.17 -> 5.0.18
* [`58c7532c`](https://github.com/NixOS/nixpkgs/commit/58c7532c55de5476d2f7b46bd887dc1661e13471) fcitx5-chewing: 5.0.11 -> 5.0.12
* [`77da20f2`](https://github.com/NixOS/nixpkgs/commit/77da20f2452c3c96cb95d2fc843d9a7794c235a6) fcitx5-chinese-addons: 5.0.13 -> 5.0.14
* [`88dd9e75`](https://github.com/NixOS/nixpkgs/commit/88dd9e751f6b25aaa6e873dbefb8f6309cc408c6) fcitx5-configtool: 5.0.13 -> 5.0.14
* [`9c941540`](https://github.com/NixOS/nixpkgs/commit/9c941540a7cbc5c9a29dc1a604873b123cc058b2) fcitx5-gtk: 5.0.15 -> 5.0.16
* [`166516b4`](https://github.com/NixOS/nixpkgs/commit/166516b41f842cda510e21419a226baf20b00e62) fcitx5-hangul: 5.0.9 -> 5.0.10
* [`5282c704`](https://github.com/NixOS/nixpkgs/commit/5282c704ed098553231973c81fabb1d745cc89d7) fcitx5-lua: 5.0.8 -> 5.0.9
* [`54edb75b`](https://github.com/NixOS/nixpkgs/commit/54edb75b5bd6b547f930cc3c84e9288df991492c) fcitx5-m17n: 5.0.9 -> 5.0.10
* [`63f6a1d4`](https://github.com/NixOS/nixpkgs/commit/63f6a1d44661e635896dfa4c1ed1c981f4e02310) libsForQt5.fcitx5-qt: 5.0.13 -> 5.0.14
* [`2396cf8b`](https://github.com/NixOS/nixpkgs/commit/2396cf8b80ae3abf47fc3053097be6b538067c69) fcitx5-rime: 5.0.13 -> 5.0.14
* [`8207ef88`](https://github.com/NixOS/nixpkgs/commit/8207ef880fe9f8ed13c6980229ad77416a1d137b) fcitx5-table-extra: 5.0.10 -> 5.0.11
* [`6dbbc92f`](https://github.com/NixOS/nixpkgs/commit/6dbbc92f961808054665dcbba2fef5c0c845b56c) fcitx5-table-other: 5.0.9 -> 5.0.10
* [`c60312b6`](https://github.com/NixOS/nixpkgs/commit/c60312b6d8924aa731d639da18bd0065a07af805) fcitx5-unikey: 5.0.10 -> 5.0.11
* [`f617400b`](https://github.com/NixOS/nixpkgs/commit/f617400bf2a1888f4370dcc466062fe75ba813ab) fcitx5-configtool: add new dependencies
* [`c78023cb`](https://github.com/NixOS/nixpkgs/commit/c78023cbbfed055866fa6e876f19b4249ddb1c5a) fastjet-contrib: explicitly set 'configurePlatforms = [ ];' ([nixos/nixpkgs⁠#181062](https://togithub.com/nixos/nixpkgs/issues/181062))
* [`f69e9bc2`](https://github.com/NixOS/nixpkgs/commit/f69e9bc2cca16c0c40bc3b3504c9653d383c9874) nixpacks: init at 0.1.7 ([nixos/nixpkgs⁠#179932](https://togithub.com/nixos/nixpkgs/issues/179932))
* [`51ae0c2a`](https://github.com/NixOS/nixpkgs/commit/51ae0c2a8cdfc729fe0ed68f630d12d5e3f6594d) haskell.packages.ghc923.protolude: drop obsolete patch
* [`5a2ed3e8`](https://github.com/NixOS/nixpkgs/commit/5a2ed3e8f6b48008fd3d3e70fc1df8aba3072de5) glimpse: add alias notifying about its deletion
* [`d5cf5f7c`](https://github.com/NixOS/nixpkgs/commit/d5cf5f7c3309c12e0c8de8ce9a16d751768f5e01) libime: 1.0.13 -> unstable-2022-07-11
* [`3bfab7bf`](https://github.com/NixOS/nixpkgs/commit/3bfab7bf3bba1fd2e0e629d2c2250836c7ba692b) python310Packages.dotty-dict: 1.3.0 -> 1.3.1
* [`ac42c6c9`](https://github.com/NixOS/nixpkgs/commit/ac42c6c976d84712f2423f82f0a59866997a893a) python310Packages.dvc-data: 0.0.18 -> 0.0.23
* [`f4710680`](https://github.com/NixOS/nixpkgs/commit/f4710680afea5f958d81c6412f43cefcfc47bb26) fprintd-tod: fix build
* [`16a1651a`](https://github.com/NixOS/nixpkgs/commit/16a1651a4affd59157722e5488091d5e267d3465) gephi: 0.9.2 -> 0.9.6
* [`865abf08`](https://github.com/NixOS/nixpkgs/commit/865abf08400d3acdcfc177200f2ab7bc53e88d53) python3Packages.jupytext: 1.13.8 -> 1.14.0
* [`8f2c49ec`](https://github.com/NixOS/nixpkgs/commit/8f2c49ece6e7c589299dee84299dd46837459baa) nixos/home-assistant: make the reload triggers dependent upon cfg.config
* [`bc72fda6`](https://github.com/NixOS/nixpkgs/commit/bc72fda636482dae1e9adba733c28dca2e958be4) hugo: 0.99.1 -> 0.101.0
* [`64369775`](https://github.com/NixOS/nixpkgs/commit/643697757d0a452b2cfe70b77d551159e00ddfa0) haskellPackages: unbreak configurator-pg, hasql-implicits
* [`b30074d2`](https://github.com/NixOS/nixpkgs/commit/b30074d274794462f642587a3e82e42a05f5c834) hexedit: 1.2.13 -> 1.6
* [`091129a2`](https://github.com/NixOS/nixpkgs/commit/091129a2aeaafb7c74383d9d94fa2e0ba140a9c7) qt5.15: update to latest KDE patchsets
* [`5d974958`](https://github.com/NixOS/nixpkgs/commit/5d9749589d7d6049e644b3dc9674d8f641b1684f) yabridge, yabridgectl: 3.8.1 → 4.0.0
* [`660595c1`](https://github.com/NixOS/nixpkgs/commit/660595c115da1f076e0afc3ca1c5f2f8b884f65e) yabridge, yabridgectl: 4.0.0 → 4.0.1
* [`7dae6db2`](https://github.com/NixOS/nixpkgs/commit/7dae6db257f5e71846d7c51f72ae0f2be6f9b43b) yabridge, yabridgectl: 4.0.1 → 4.0.2
* [`7df70d88`](https://github.com/NixOS/nixpkgs/commit/7df70d8899935654a747ba8eb7d230640af4896b) standardnotes: 3.11.1 -> 3.23.69
* [`a91cea12`](https://github.com/NixOS/nixpkgs/commit/a91cea12b15e4941570928533a21e64293e9d8b6) rrsync: change per script to python script
* [`cf5db5cd`](https://github.com/NixOS/nixpkgs/commit/cf5db5cd18cd1accc7ff839f464547183faa2197) factorio: 1.1.59 -> 1.1.61
* [`cc0d38b5`](https://github.com/NixOS/nixpkgs/commit/cc0d38b58e5127007ad4126fb2e43a9e8df7a52a) nixos/i18n: normalise locale codeset names in supportedLocales
* [`512d30b8`](https://github.com/NixOS/nixpkgs/commit/512d30b8a07d335203df533912b2b12629c6f50e) python3Packages.debugpy: remove unnecessary arch specifiers
* [`122db56f`](https://github.com/NixOS/nixpkgs/commit/122db56f1472481435432b546521e930a70782c5) musikcube: Replace local patch with upstream patch
* [`b08c9d9d`](https://github.com/NixOS/nixpkgs/commit/b08c9d9d87fc637ad8efbd2e4d8d54f9b42409b1) krane: 2.4.6 → 2.4.7
* [`206de254`](https://github.com/NixOS/nixpkgs/commit/206de2540d7253053e64ad126c6f0d06f716441f) python310Packages.casbin: 1.16.8 -> 1.16.9
* [`7d074643`](https://github.com/NixOS/nixpkgs/commit/7d07464337593b07f7f3f1256c83e638d318f0f5) python310Packages.haversine: 2.5.1 -> 2.6.0
* [`af66b47b`](https://github.com/NixOS/nixpkgs/commit/af66b47b3aa13b24f6cc1e1db925d721d5ed6d64) nixos/postgresql-backup: allow setting compression level
* [`9d7d8c11`](https://github.com/NixOS/nixpkgs/commit/9d7d8c11ebc7f055b212859a17671683996129be) rrsync: fixed python3 and add braceexpand module
* [`d9119dbb`](https://github.com/NixOS/nixpkgs/commit/d9119dbbdfc3b2224a61c9f696191e033dc13fbd) pass-secret-service: unstable-2020-04-12 -> unstable-2022-03-21
* [`31cffb8d`](https://github.com/NixOS/nixpkgs/commit/31cffb8d364f0217c41e443d253d78ea24956be4) wapiti: 3.1.2 -> 3.1.3
* [`20390cad`](https://github.com/NixOS/nixpkgs/commit/20390cad8a470ba2fffe95524db0a308384f70c0) gjs: add profiler support
* [`28c6e6d7`](https://github.com/NixOS/nixpkgs/commit/28c6e6d71121ac34659033977c50e5ac24936412) gitleaks: 8.8.11 -> 8.8.12
* [`ca52ff66`](https://github.com/NixOS/nixpkgs/commit/ca52ff66efe8666553bd0310d55e9ae2ba1dd307) sslscan: 2.0.14 -> 2.0.15
* [`64421536`](https://github.com/NixOS/nixpkgs/commit/644215361ef867a1c030248415c5ed7ed6251fd6) step-cli: 0.20.0 -> 0.21.0
* [`819ea69a`](https://github.com/NixOS/nixpkgs/commit/819ea69a46554af1575464783d357ff87ee446cb) trivy: 0.29.1 -> 0.29.2
* [`4c942133`](https://github.com/NixOS/nixpkgs/commit/4c942133b702ebc4f2ca0a03c2c85cb65de3c3a5) ventoy-bin: add meta.mainProgram
* [`2da28c61`](https://github.com/NixOS/nixpkgs/commit/2da28c610f5485b2b5e09bcc417cc3dbbad8021f) release-cross.nix: explain how to run jobs individually
* [`60fbfadd`](https://github.com/NixOS/nixpkgs/commit/60fbfadd5b14207ae6f851d1f43990904ab5dcb8) add --arg supportedSystems '[builtins.currentSystem]'
* [`16ac6b05`](https://github.com/NixOS/nixpkgs/commit/16ac6b056767cc74a0ffeee87d379a71d7b846bb) python310Packages.python-engineio: 4.3.2 -> 4.3.3
* [`4dabde8e`](https://github.com/NixOS/nixpkgs/commit/4dabde8e873684f2b4cf3805c5ca9c1ff8bdf329) python310Packages.python-socketio: 5.6.0 -> 5.7.0
* [`84592483`](https://github.com/NixOS/nixpkgs/commit/8459248345f10fec81db6d8fb6d9f5e105e23b61) aerc: 0.10.0 → 0.11.0
* [`0d5757c9`](https://github.com/NixOS/nixpkgs/commit/0d5757c9cb1bbf8d0a318b3ede87367240f7158e) python310Packages.timezonefinder: 5.2.0 -> 6.0.2
* [`95e83fe0`](https://github.com/NixOS/nixpkgs/commit/95e83fe0e1ba11e5faf5c1a60c7a9ba9d2a8c0aa) broot: 1.14.1 -> 1.14.2
* [`1cb6918b`](https://github.com/NixOS/nixpkgs/commit/1cb6918b9bdc25641940494682458e1f4157aa3c) invidious: use nix-hash in update script
* [`21dc8ddc`](https://github.com/NixOS/nixpkgs/commit/21dc8ddc411e60fb94c2d5deb999b9d590c6d610) invidious: unstable-2022-05-11 -> unstable-2022-07-10
* [`edd709dc`](https://github.com/NixOS/nixpkgs/commit/edd709dcfc0e15e6b8b50c0dc320a6d16654b6f2) vector: 0.22.3 -> 0.23.0
* [`017fa2d7`](https://github.com/NixOS/nixpkgs/commit/017fa2d7a0f3873fbb621bde5dae81b7a33ab4d4) emacsWithPackages: Rely on package.el for autoloads
* [`47b0cc57`](https://github.com/NixOS/nixpkgs/commit/47b0cc576175605d52801cbdc02ae0908c6aa0f8) .github/CODEOWNERS: remove non-committer
* [`3003cd35`](https://github.com/NixOS/nixpkgs/commit/3003cd353abfc90549a2f830b37a96b08d3497f6) pantheon.wingpanel-indicator-notifications: 6.0.5 -> 6.0.6
* [`d2319f92`](https://github.com/NixOS/nixpkgs/commit/d2319f92aa60fb593324510c95a004c0b227ee2e) kde/frameworks: 5.95 -> 5.96
* [`1120fa53`](https://github.com/NixOS/nixpkgs/commit/1120fa53d87edd1ff13d7621a40a73b0cab13d49) Revert "kf5/plasma-framework: backport patch to fix thumbnails in task manager"
* [`5cc64d91`](https://github.com/NixOS/nixpkgs/commit/5cc64d917f542cb23f89bd42efa198d4bc7ff497) fheroes2: 0.9.16 -> 0.9.17
* [`26d10548`](https://github.com/NixOS/nixpkgs/commit/26d105482be5d0ebb3e21c97752ab498bf9ee9cc) mercurial: 6.1.4 -> 6.2
* [`7498aa2c`](https://github.com/NixOS/nixpkgs/commit/7498aa2c9d35e94b89443a9a87a8c4158fb555c5) python310Packages.hahomematic: 2022.7.3 -> 2022.7.5
* [`92b7ba08`](https://github.com/NixOS/nixpkgs/commit/92b7ba081fd76b2ab87fb2d1581df24ca4fed16e) terraform-providers: remove outdated throw
* [`77b2ff80`](https://github.com/NixOS/nixpkgs/commit/77b2ff803d29a1d86b08333bf228fc751aad477e) terraform-providers: switch to go_1_18
* [`f3021890`](https://github.com/NixOS/nixpkgs/commit/f302189002cb46fa281fae3a737c5cdc63a031da) alfis: 0.7.4 -> 0.7.6
* [`df8f5801`](https://github.com/NixOS/nixpkgs/commit/df8f580137e9120ffc60b2cc85d62fcc928c2eab) texlab: 4.0.0 → 4.2.0 ([nixos/nixpkgs⁠#181149](https://togithub.com/nixos/nixpkgs/issues/181149))
* [`cecee2a6`](https://github.com/NixOS/nixpkgs/commit/cecee2a6d90c2147d3b60f06f6b26a3c133bbabf) tautulli: 2.10.1 -> 2.10.2
* [`fa748c2e`](https://github.com/NixOS/nixpkgs/commit/fa748c2e5d509a30b3c7fbcc1f21de7668250048) gajim: 1.4.3 → 1.4.6
* [`c3fafea4`](https://github.com/NixOS/nixpkgs/commit/c3fafea4edcfed02a37f5f9dfa36c871d1b00e8d) nixos: remove unused "system tarball" modules
* [`cdb5bea3`](https://github.com/NixOS/nixpkgs/commit/cdb5bea321baa03f347c72961390a3e5be7693f9) python310Packages.icalendar: 4.0.9 -> 4.1.0
* [`e0f2f7f9`](https://github.com/NixOS/nixpkgs/commit/e0f2f7f9eadadab6d464ea63ab4dda04fe075d75) nixos/ddclient: don't leak password in process listings
* [`447e562f`](https://github.com/NixOS/nixpkgs/commit/447e562f815e8c89c3fb1824a3316dc9058cf0ea) wibo: init at 0.2.0
* [`16478032`](https://github.com/NixOS/nixpkgs/commit/164780329f02fe35c8ffece9006129f8e5ffb03e) xrectsel: fix download url
* [`70f25ecb`](https://github.com/NixOS/nixpkgs/commit/70f25ecbcbec88e123f11794b9171a9350b4f4bd) ffcast: fix cross-compilation
* [`95b83ed8`](https://github.com/NixOS/nixpkgs/commit/95b83ed8677129da470fad4caadd3fed1474d327) python310Packages.google-cloud-pubsub: 2.13.1 -> 2.13.2
* [`7732635d`](https://github.com/NixOS/nixpkgs/commit/7732635d42dedb809a6e6c9a607f56cff1e438e8) ddnet: 16.2.1 -> 16.2.2
* [`f33ee395`](https://github.com/NixOS/nixpkgs/commit/f33ee395b2690cf7098045cdd1d9d3511be63ff6) python310Packages.aesara: 2.7.5 -> 2.7.6
* [`c19c7d96`](https://github.com/NixOS/nixpkgs/commit/c19c7d96c52c4b37e6c608e34d4159c93b84967e) rrsync: clean unused part
* [`dd874e78`](https://github.com/NixOS/nixpkgs/commit/dd874e783e5ea5e85bf4f03732bbe86e41c31fa5) python310Packages.awslambdaric: Fix tests
* [`fe1cab9c`](https://github.com/NixOS/nixpkgs/commit/fe1cab9c80a14edbbcffdba51dd0bd0e7400255f) python310Packages.afsapi: 0.2.5 -> 0.2.6
* [`802ec5de`](https://github.com/NixOS/nixpkgs/commit/802ec5de4b5386738901e16fb5030b6550f56868) python311: 3.11.0b3 -> 3.11.0b4
* [`6c9b8372`](https://github.com/NixOS/nixpkgs/commit/6c9b837231884843ee563fa6e77bf24da8f2ab0f) python310Packages.types-setuptools: 62.6.0 -> 62.6.1
* [`354cd9ea`](https://github.com/NixOS/nixpkgs/commit/354cd9ea0086815fe6a00db500b443600e71215c) python310Packages.types-redis: 4.3.2 -> 4.3.3
* [`05525621`](https://github.com/NixOS/nixpkgs/commit/05525621ab2666cd62d43add22e7cec3e70e44fa) python310Packages.types-pyyaml: 6.0.8 -> 6.0.9
* [`7ddf40ae`](https://github.com/NixOS/nixpkgs/commit/7ddf40aec25cf16b01729dd24da850bf44a176cc) python310Packages.sentry-sdk: 1.6.0 -> 1.7.0
* [`81860a87`](https://github.com/NixOS/nixpkgs/commit/81860a87e2fc51da7369e54300368a6ae2fe8f6a) python310Packages.google-cloud-spanner: 3.15.1 -> 3.16.0
* [`deeb80c0`](https://github.com/NixOS/nixpkgs/commit/deeb80c04abf0d19fb0159a48df6cc4649774ae6) mate: reformat nix expressions
* [`ea8e40cd`](https://github.com/NixOS/nixpkgs/commit/ea8e40cd0ac3ae51324dc8f4bdcd89cf9cb1b422) Revert "release: add tests.packageTestsForChannelBlockers.curl.withCheck as a channel blocker"
* [`6b0546c4`](https://github.com/NixOS/nixpkgs/commit/6b0546c40b215b8b0b5363a8cfbeb8bccfa62414) qownnotes: 22.6.1 -> 22.7.1
* [`de29ce21`](https://github.com/NixOS/nixpkgs/commit/de29ce21e9f9626e34aca2795db8f5a11a3b162f) crystal2nix: 0.1.1 -> 0.3.0
* [`59f11eb3`](https://github.com/NixOS/nixpkgs/commit/59f11eb3cfed9aa6b9828dbf89fac0e29e4f8bd5) lucky-cli: 0.29.0 -> 0.30.0
* [`2b7a01a6`](https://github.com/NixOS/nixpkgs/commit/2b7a01a6ea32740777ebd6396bffb369fe618d0b) netdata: update build options, build with jemalloc ([nixos/nixpkgs⁠#179848](https://togithub.com/nixos/nixpkgs/issues/179848))
* [`5723e473`](https://github.com/NixOS/nixpkgs/commit/5723e473bee7e5ec3abc3f13edf75fca7cfd8234) gh: 2.13.0 -> 2.14.0
* [`25594fc0`](https://github.com/NixOS/nixpkgs/commit/25594fc07693e26f3d1e25fc1b12d8f04e7193fd) python310Packages.injector: 0.20.0 -> 0.20.1
* [`f26e356b`](https://github.com/NixOS/nixpkgs/commit/f26e356bf1d699a824fd4b92aa4221f196e61b30) mate: update script list versions from the git repository
* [`6537fa2a`](https://github.com/NixOS/nixpkgs/commit/6537fa2abb2f9e28e8f2c2768b853e386619b61f) steam/fhsenv.nix: Add libindicator-gtk2 and libdbusmenu-gtk2 ([nixos/nixpkgs⁠#181023](https://togithub.com/nixos/nixpkgs/issues/181023))
* [`a18260a6`](https://github.com/NixOS/nixpkgs/commit/a18260a6ec00b043972e8467cbe51428118061d6) python310Packages.zigpy-znp: 0.8.0 -> 0.8.1
* [`668df390`](https://github.com/NixOS/nixpkgs/commit/668df39084e0bb8cfdfda3abbec55019f9975c9f) pinegrow: 6.5 -> 6.6
* [`dc030343`](https://github.com/NixOS/nixpkgs/commit/dc030343f2928530b9e85c225fe8d99f6270ef07) exploitdb: 2022-07-02 -> 2022-07-12
* [`2349dd5c`](https://github.com/NixOS/nixpkgs/commit/2349dd5cb24516730e811929f99a4dca453f4000) graphia: 2.2 -> 3.0
* [`d7da02c1`](https://github.com/NixOS/nixpkgs/commit/d7da02c1e0948229a13d98559da7c955231102c9) zulip-term: 0.6.0 -> 0.7.0
* [`164afe48`](https://github.com/NixOS/nixpkgs/commit/164afe48014dbdbd986c801ff4a828203921b8bf) libfprint: 1.94.3 -> 1.94.4
* [`726c7daa`](https://github.com/NixOS/nixpkgs/commit/726c7daaf5c59218ed38ab9522f4d2c07352eec4) python310Packages.channels-redis: 3.4.0 -> 3.4.1
* [`c77489d5`](https://github.com/NixOS/nixpkgs/commit/c77489d524339f28b805f0643413d37db1e3074a) libressl: fix build on aarch64-darwin
* [`bd97387c`](https://github.com/NixOS/nixpkgs/commit/bd97387c0e9469dd20a6063b954cff37893384d3) boringtun: 0.4.0 -> 0.5.0
* [`6c6dd0e3`](https://github.com/NixOS/nixpkgs/commit/6c6dd0e32b6419ed1bc1c938185c41fe13149b66) python3Packages.classify-imports: init at 4.1.0
* [`83b4764d`](https://github.com/NixOS/nixpkgs/commit/83b4764dc3154eac2a5b4bde444ecd7aa10b1039) treewide: fix fallout from 'cmake/setup-hook.sh: Don't skip build-RPATH'
* [`1ea04d95`](https://github.com/NixOS/nixpkgs/commit/1ea04d956737f1b4656a5006a22b7858df751270) python310Packages.meilisearch: 0.18.3 -> 0.19.0
* [`72eb38a8`](https://github.com/NixOS/nixpkgs/commit/72eb38a823b851cb62cc8e1922f043866a96c581) haskell.packages.ghc923.validity: drop obsolete overrides
* [`62840ca1`](https://github.com/NixOS/nixpkgs/commit/62840ca1d90c6255b838abe54d0f4c303d4f66af) python310Packages.cssutils: 2.4.2 -> 2.5.0
* [`900632c3`](https://github.com/NixOS/nixpkgs/commit/900632c3a39490fdb13c25ef53ddd351129c3482) haskellPackages.monad-validate: drop obsolete override
* [`454100e8`](https://github.com/NixOS/nixpkgs/commit/454100e88135c939a9e55a9a6094f79f0bc83b82) figlet: package with contributed fonts
* [`15a5556d`](https://github.com/NixOS/nixpkgs/commit/15a5556d2a3c4abfd327fcc43b04eae1d78ef897) python310Packages.globus-sdk: 3.10.0 -> 3.10.1
* [`47f61aae`](https://github.com/NixOS/nixpkgs/commit/47f61aaeb7e38618f3ac3c3bed8e7b11db12a493) python310Packages.django-extensions: 3.1.5 -> 3.2.0
* [`0c95ce31`](https://github.com/NixOS/nixpkgs/commit/0c95ce31ed17db6e463769919ebd24f8a88415d4) python310Packages.mayavi: 4.7.4 -> 4.8.0
* [`8d73ee91`](https://github.com/NixOS/nixpkgs/commit/8d73ee918766ada5c2caed6cf4aeac310ae45f88) chromiumBeta: 104.0.5112.29 -> 104.0.5112.39
* [`8d79dfe6`](https://github.com/NixOS/nixpkgs/commit/8d79dfe6f0a9b6d8d0540889644904e07980af02) nuget-to-nix: enable default netrc
* [`b6ec9e49`](https://github.com/NixOS/nixpkgs/commit/b6ec9e4914a616162c3166451d2fd2b352762732) python310Packages.pylint-django: Fix tests
* [`7e30ebb2`](https://github.com/NixOS/nixpkgs/commit/7e30ebb2c2b90dc866643c6409e1424f7e651baa) nixos/lxqt: add a module for the lxqt portal
* [`03a9bec4`](https://github.com/NixOS/nixpkgs/commit/03a9bec472bd9a180288305c446da1fc2636e38e) python310Packages.aeppl: 0.0.31 -> 0.0.33
* [`45c4f3b4`](https://github.com/NixOS/nixpkgs/commit/45c4f3b422498a081631ab715c937e720d9bd705) python310Packages.yfinance: 0.1.72 -> 0.1.74
* [`37e4ff1b`](https://github.com/NixOS/nixpkgs/commit/37e4ff1b4c05431c821cd9ce1a77619f4ca49a7e) helmfile: 0.144.0 -> 0.145.2
* [`af1462f0`](https://github.com/NixOS/nixpkgs/commit/af1462f0a227f676a5163b92bfc5e5646bbc7e28) helmfile: install autocompletion
* [`7373f4ac`](https://github.com/NixOS/nixpkgs/commit/7373f4ac1613e839448b3ef90337ecb33d3b4f21) python310Packages.homematicip: 1.0.3 -> 1.0.4
* [`2c994cf1`](https://github.com/NixOS/nixpkgs/commit/2c994cf1c73698ea343d74b8eb1fe1b25a2ceb1f) linux_zen: 5.18.10-zen1 -> 5.18.11-zen1
* [`c1f94c40`](https://github.com/NixOS/nixpkgs/commit/c1f94c40dfa3efcf7568f5c24c36c005260d1b38) linux_lqx: 5.18.10-lqx1 -> 5.18.11-lqx1
* [`c2fa5569`](https://github.com/NixOS/nixpkgs/commit/c2fa5569a0a575e9ac3f8551f20bbcc6e9eb18be) zen-kernels: add pedrohlc as maintainer
* [`b110339b`](https://github.com/NixOS/nixpkgs/commit/b110339bdf776535271783030ee3c4dc9bd11a9a) python310Packages.archinfo: 9.2.9 -> 9.2.10
* [`d136a481`](https://github.com/NixOS/nixpkgs/commit/d136a4817fc6b72c66e260802c807dcdd07fc8d2) python310Packages.ailment: 9.2.9 -> 9.2.10
* [`7fac31ca`](https://github.com/NixOS/nixpkgs/commit/7fac31ca95ce8bca3c5f945a5833e7a8d86ee9ee) python310Packages.pyvex: 9.2.9 -> 9.2.10
* [`bfa99e47`](https://github.com/NixOS/nixpkgs/commit/bfa99e4705f3764fb8b9572a8eff94503bf70f80) python310Packages.claripy: 9.2.9 -> 9.2.10
* [`9b89244b`](https://github.com/NixOS/nixpkgs/commit/9b89244b24b8c3ae29b7529d8c0863e0379d4ae3) python310Packages.cle: 9.2.9 -> 9.2.10
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
