### PR TITLE
niv emacs-overlay: update 4d342a55 -> c2b890a1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d342a55aa298e8ed5168be77c2262cf5fb8a0c4",
-        "sha256": "1fybr7r3nvbqwl5km4f73jlvqy5waw8xny81yq2jd0n3lcscfb04",
+        "rev": "c2b890a1886646d8c3a40bba3397d6a344fe986e",
+        "sha256": "062ys4jlj1jqc6r841klx61x75cfzh01gppqrz69jc36450xpswg",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/4d342a55aa298e8ed5168be77c2262cf5fb8a0c4.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/c2b890a1886646d8c3a40bba3397d6a344fe986e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@4d342a55...c2b890a1](https://github.com/nix-community/emacs-overlay/compare/4d342a55aa298e8ed5168be77c2262cf5fb8a0c4...c2b890a1886646d8c3a40bba3397d6a344fe986e)

* [`e39ac49c`](https://github.com/nix-community/emacs-overlay/commit/e39ac49c212dd5c6e92c26d0815141348d9b4368) Updated repos/emacs
* [`eb9324be`](https://github.com/nix-community/emacs-overlay/commit/eb9324be909d20ef724e939340a88bd9d7948be0) Updated repos/melpa
* [`855a6e3c`](https://github.com/nix-community/emacs-overlay/commit/855a6e3c3f77c96acd90c17526dc5e9361e3435f) Updated repos/elpa
* [`57bf6994`](https://github.com/nix-community/emacs-overlay/commit/57bf6994449856dbd0c5dbf1ee132f64f29a695d) Updated repos/emacs
* [`416d7f8a`](https://github.com/nix-community/emacs-overlay/commit/416d7f8a7acf4ef8f8453cba03215b42c8d94429) Updated repos/melpa
* [`15cb8ad5`](https://github.com/nix-community/emacs-overlay/commit/15cb8ad52b524651b105973502d64d45452aefcc) Updated repos/emacs
* [`3ae151f2`](https://github.com/nix-community/emacs-overlay/commit/3ae151f2e68bfb663d44e27c9670b3b3171c6f84) Updated repos/melpa
* [`7c84781e`](https://github.com/nix-community/emacs-overlay/commit/7c84781eb79f2da436850f8b24da0f7c3a13f72c) Updated repos/emacs
* [`edd30ea6`](https://github.com/nix-community/emacs-overlay/commit/edd30ea6e6daae76cf05a1f2b52aed19ba5b5a69) Updated repos/melpa
* [`38ae9f74`](https://github.com/nix-community/emacs-overlay/commit/38ae9f744b4c3fbb61e506f04c6d4dd7f0b04579) Updated repos/elpa
* [`41a6914c`](https://github.com/nix-community/emacs-overlay/commit/41a6914c819a0d44f1e86c75b0ffe92429a5f2f2) Updated repos/emacs
* [`6608997a`](https://github.com/nix-community/emacs-overlay/commit/6608997ad0224f59cae68b0c9db0eeb8c4c32e8f) Updated repos/melpa
* [`655e3e21`](https://github.com/nix-community/emacs-overlay/commit/655e3e210f810d65a4b9b9536be8944d5034ecf4) Updated repos/emacs
* [`40244bd6`](https://github.com/nix-community/emacs-overlay/commit/40244bd6b0e9474b8c5867791a8bed54bd2b1948) Updated repos/melpa
* [`27297eec`](https://github.com/nix-community/emacs-overlay/commit/27297eece41ecca4b26cd7dcb0af665bf1fca0e4) Updated repos/nongnu
* [`4080e815`](https://github.com/nix-community/emacs-overlay/commit/4080e815865bd5e903a28d3f6635850aa8d9d594) Updated repos/emacs
* [`5c014cdf`](https://github.com/nix-community/emacs-overlay/commit/5c014cdf9a52b37d9d27754b8be07d3bc07ecce5) Updated repos/melpa
* [`5ef44167`](https://github.com/nix-community/emacs-overlay/commit/5ef44167cd9c8b3fbb6310bc148a270c61cb07d3) Updated repos/emacs
* [`5d793f13`](https://github.com/nix-community/emacs-overlay/commit/5d793f134d5b3ff60e890a2e0cce2483e6e745b7) Updated repos/melpa
* [`b51bea50`](https://github.com/nix-community/emacs-overlay/commit/b51bea50371cc7a98863fb64bf1aaa1126a68a36) Jobsets for cross building emacsen ([nix-community/emacs-overlay⁠#231](https://togithub.com/nix-community/emacs-overlay/issues/231))
* [`554e0a45`](https://github.com/nix-community/emacs-overlay/commit/554e0a4504f900b3e06117c6abe7a23ed974fd4f) Updated repos/emacs
* [`a2f9d8ba`](https://github.com/nix-community/emacs-overlay/commit/a2f9d8baec7afbbb35f4f4c5e7bb4f6f24d8ea1b) Updated repos/melpa
* [`c6505414`](https://github.com/nix-community/emacs-overlay/commit/c6505414fb369ba67e9b944830c7c5722aad7f18) Updated repos/emacs
* [`ca102234`](https://github.com/nix-community/emacs-overlay/commit/ca1022340ea6988ac63fb38c0776182f7c535ead) Updated repos/melpa
* [`8001e380`](https://github.com/nix-community/emacs-overlay/commit/8001e380d2a199808e5adf69c3a6722b81fd9d01) Updated repos/nongnu
* [`616fca7a`](https://github.com/nix-community/emacs-overlay/commit/616fca7aeba7e682674e2a196eee3aa4d585843d) Updated repos/emacs
* [`adf22503`](https://github.com/nix-community/emacs-overlay/commit/adf225036341945726878b2fc3a761fcb38637db) Updated repos/melpa
* [`59c87178`](https://github.com/nix-community/emacs-overlay/commit/59c87178783b3d3cca65a7d9c9ca54e4612eeddf) Updated repos/emacs
* [`2f6f0362`](https://github.com/nix-community/emacs-overlay/commit/2f6f0362b4ce58636381d1ced3c39607ad5e80ac) Updated repos/melpa
* [`91804f38`](https://github.com/nix-community/emacs-overlay/commit/91804f38a4d3c41914d579ac1cb6a35785405c14) Updated repos/nongnu
* [`67bd8ad1`](https://github.com/nix-community/emacs-overlay/commit/67bd8ad1eba022384519d28064411802efe9fcd6) Updated repos/emacs
* [`82f28256`](https://github.com/nix-community/emacs-overlay/commit/82f28256c57e54c37886e77a2608973acfdd356c) Updated repos/melpa
* [`69255023`](https://github.com/nix-community/emacs-overlay/commit/692550239fba8a483a4bad5f796995cc8a3aac07) Updated repos/emacs
* [`f892d726`](https://github.com/nix-community/emacs-overlay/commit/f892d7265db477dbc84fc7c711a3fb70be101854) Updated repos/melpa
* [`a7dfe28a`](https://github.com/nix-community/emacs-overlay/commit/a7dfe28a6c8b3090b94ae167d6d1851f4b56c979) Updated repos/emacs
* [`1d0bad62`](https://github.com/nix-community/emacs-overlay/commit/1d0bad6294cd4228070a60f936c6e74976d2b327) Updated repos/melpa
* [`0e46b9d7`](https://github.com/nix-community/emacs-overlay/commit/0e46b9d7bb2a6912d614f893465bac539f0c28e7) Updated repos/emacs
* [`afb0f1be`](https://github.com/nix-community/emacs-overlay/commit/afb0f1be5bdcb7ba95495a536ed1ddea96653ee0) Updated repos/melpa
* [`9ad756ae`](https://github.com/nix-community/emacs-overlay/commit/9ad756aeaa074fbc390baad9e9dcad84bb3a094d) Updated repos/elpa
* [`9b441d1a`](https://github.com/nix-community/emacs-overlay/commit/9b441d1abe2953c7f09706250fa2b8db280c0aaf) Updated repos/emacs
* [`e5751991`](https://github.com/nix-community/emacs-overlay/commit/e575199132c3c975f718ada1b0b8a744b0fb5186) Updated repos/melpa
* [`f279d24b`](https://github.com/nix-community/emacs-overlay/commit/f279d24bba0d1ee262aaf1e2325fd1e0ce0aece7) Updated repos/emacs
* [`c108db97`](https://github.com/nix-community/emacs-overlay/commit/c108db97f42195eb2cb9e2146ed334b647ebcd9f) Updated repos/melpa
* [`d8f78f54`](https://github.com/nix-community/emacs-overlay/commit/d8f78f54b3ffc48079b9dcaa5f4538de769827ca) Updated repos/elpa
* [`17418057`](https://github.com/nix-community/emacs-overlay/commit/1741805792c37d35bc24639d1746cbe353bf2e51) Updated repos/emacs
* [`9fd14c3a`](https://github.com/nix-community/emacs-overlay/commit/9fd14c3ad83603804e5f42d4a6095f9021b49ede) Updated repos/melpa
* [`b9499ce3`](https://github.com/nix-community/emacs-overlay/commit/b9499ce3a6b59285cdd9f915aa57f7a19dd54c58) Updated repos/emacs
* [`c2b890a1`](https://github.com/nix-community/emacs-overlay/commit/c2b890a1886646d8c3a40bba3397d6a344fe986e) Updated repos/melpa
