### PR TITLE
niv powerlevel10k: update be3724bc -> 2dd6a29e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "be3724bc806a2dd7fbcb281a153b11ab19d8923d",
-        "sha256": "095lk51yf3bmh11hv4lb019h77zv9m48cfkh8qd0w2rqrcl6p2sr",
+        "rev": "2dd6a29e4d7a33bfef10973d6550e087be37ddee",
+        "sha256": "0as7grgmmh7d1syr1qia0p4xgd9jvrrw5iic7f7yjd22q1q3ixzn",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/be3724bc806a2dd7fbcb281a153b11ab19d8923d.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/2dd6a29e4d7a33bfef10973d6550e087be37ddee.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@be3724bc...2dd6a29e](https://github.com/romkatv/powerlevel10k/compare/be3724bc806a2dd7fbcb281a153b11ab19d8923d...2dd6a29e4d7a33bfef10973d6550e087be37ddee)

* [`71e4e328`](https://github.com/romkatv/powerlevel10k/commit/71e4e3288d08da5e9817ca64c350a7bc73bf598b) fix typo in README
* [`2dd6a29e`](https://github.com/romkatv/powerlevel10k/commit/2dd6a29e4d7a33bfef10973d6550e087be37ddee) replace a hyperlink in crostini instructions with regular text ([romkatv/powerlevel10k⁠#1934](https://togithub.com/romkatv/powerlevel10k/issues/1934))
