### PR TITLE
niv emacs-overlay: update c2b890a1 -> 79d28f83

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c2b890a1886646d8c3a40bba3397d6a344fe986e",
-        "sha256": "062ys4jlj1jqc6r841klx61x75cfzh01gppqrz69jc36450xpswg",
+        "rev": "79d28f8388bfe9e1933e4aa769676d2452cc6ad6",
+        "sha256": "1vn59vdqshxwlb0dfz8db4zwrmg1291c51mmdqdw3z6s3s32ss83",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/c2b890a1886646d8c3a40bba3397d6a344fe986e.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/79d28f8388bfe9e1933e4aa769676d2452cc6ad6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@c2b890a1...79d28f83](https://github.com/nix-community/emacs-overlay/compare/c2b890a1886646d8c3a40bba3397d6a344fe986e...79d28f8388bfe9e1933e4aa769676d2452cc6ad6)

* [`4ec41054`](https://github.com/nix-community/emacs-overlay/commit/4ec41054a2b7b912fc5037a01cc2ebb800293419) Updated repos/emacs
* [`49b2fec8`](https://github.com/nix-community/emacs-overlay/commit/49b2fec856b3d7ad0321b74fbe453708af8906f8) Updated repos/melpa
* [`793e65c4`](https://github.com/nix-community/emacs-overlay/commit/793e65c4283453d3be26815a5f877c507f52ad19) Updated repos/elpa
* [`cb4f80e4`](https://github.com/nix-community/emacs-overlay/commit/cb4f80e4817ef21d1a2d240b15ccc6653fa20b01) Updated repos/emacs
* [`fe7e6cf5`](https://github.com/nix-community/emacs-overlay/commit/fe7e6cf5de691688e49cbfc007e78f9af4c730af) Updated repos/melpa
* [`9b50baef`](https://github.com/nix-community/emacs-overlay/commit/9b50baefd34772bfc42002d19c829b20565a6b06) Updated repos/elpa
* [`a3685ec1`](https://github.com/nix-community/emacs-overlay/commit/a3685ec1e8eb81d867a1ad048904a4c7b59f1797) Updated repos/emacs
* [`62781996`](https://github.com/nix-community/emacs-overlay/commit/62781996590a3793d4f33c6bd35701a99e2295e9) Updated repos/melpa
* [`b9b68fa3`](https://github.com/nix-community/emacs-overlay/commit/b9b68fa326b821c1c63588121bfbef5ffdf5a38a) Updated repos/nongnu
* [`ede522b3`](https://github.com/nix-community/emacs-overlay/commit/ede522b3cfa53a5ca09ba9c3b2d99ec874a2bba0) Updated repos/emacs
* [`12c96109`](https://github.com/nix-community/emacs-overlay/commit/12c96109a215d8f676a573c2ccbe93fb26d5b5db) Updated repos/melpa
* [`a0e13495`](https://github.com/nix-community/emacs-overlay/commit/a0e13495a2cbd0a1bdbaae64b2c022bd0cfecd18) Updated repos/elpa
* [`456f1adf`](https://github.com/nix-community/emacs-overlay/commit/456f1adfdb56cc7ebccbf673f9e41b3b3f60abcf) Updated repos/emacs
* [`bdc5736d`](https://github.com/nix-community/emacs-overlay/commit/bdc5736d1644f41e1291cd48545e202a737d98f7) Updated repos/melpa
* [`87fd918a`](https://github.com/nix-community/emacs-overlay/commit/87fd918a7bde81c91d01221804875798922ef1ad) Updated repos/emacs
* [`46ffe03d`](https://github.com/nix-community/emacs-overlay/commit/46ffe03d0ac9f371501fd0030d7ca434c856c0c4) Updated repos/melpa
* [`bdeb65c8`](https://github.com/nix-community/emacs-overlay/commit/bdeb65c828e9a7c5c1bb772c3d88d2b19610c1ef) Updated repos/emacs
* [`76b9c0cd`](https://github.com/nix-community/emacs-overlay/commit/76b9c0cd881b1af278b955eb4d89a6a2d850de99) Updated repos/melpa
* [`97478261`](https://github.com/nix-community/emacs-overlay/commit/97478261cf8c3a798560a46f6578d0f3d5d4e031) Updated repos/emacs
* [`6c868dba`](https://github.com/nix-community/emacs-overlay/commit/6c868dbad387da912e2a47f63a913c8a62555127) Updated repos/melpa
* [`33f5565a`](https://github.com/nix-community/emacs-overlay/commit/33f5565a186c2805552036de143b341d8a79abfd) Updated repos/emacs
* [`f93feff3`](https://github.com/nix-community/emacs-overlay/commit/f93feff3ed6a0686af48c9571f03e53821cefd1a) Updated repos/melpa
* [`18833cfc`](https://github.com/nix-community/emacs-overlay/commit/18833cfcea159c7f895ec6c956f43fff48c34c0e) Updated repos/emacs
* [`8d7a0882`](https://github.com/nix-community/emacs-overlay/commit/8d7a0882c8f35476da7490ab7f10898f2b1916e3) Updated repos/melpa
* [`7c2397bc`](https://github.com/nix-community/emacs-overlay/commit/7c2397bcc1012a17cae20339456526dce978986a) Updated repos/nongnu
* [`69c893bd`](https://github.com/nix-community/emacs-overlay/commit/69c893bd4f16139723f4e40faab79371f1491af2) Updated repos/emacs
* [`6bf61f97`](https://github.com/nix-community/emacs-overlay/commit/6bf61f978a906be45be0aa3227942eec8a85a883) Updated repos/melpa
* [`f4ebd37c`](https://github.com/nix-community/emacs-overlay/commit/f4ebd37cc46af7dc3588dd0e57484faf3c3bb705) Updated repos/elpa
* [`d8ea7056`](https://github.com/nix-community/emacs-overlay/commit/d8ea70564e24919cda129431f5b7c3c3ea2ac2da) Updated repos/emacs
* [`af0818a2`](https://github.com/nix-community/emacs-overlay/commit/af0818a229683f75096a9598de1026bb3484c147) Updated repos/melpa
* [`f22fe28d`](https://github.com/nix-community/emacs-overlay/commit/f22fe28d687085b9c969f84b8784aca67b7340f4) Updated repos/nongnu
* [`a4732259`](https://github.com/nix-community/emacs-overlay/commit/a4732259483b73fe9e678c3b1c38c58902e609b9) Updated repos/emacs
* [`58ace00f`](https://github.com/nix-community/emacs-overlay/commit/58ace00febb5ba29aba23b6c70afa58ad5da9edb) Updated repos/melpa
* [`76978f21`](https://github.com/nix-community/emacs-overlay/commit/76978f21170db47dd945d2875b3460d4934a343f) Updated repos/emacs
* [`20e53f39`](https://github.com/nix-community/emacs-overlay/commit/20e53f39d4144c26ab98eda94e6ba80638c5b565) Updated repos/melpa
* [`49080fd2`](https://github.com/nix-community/emacs-overlay/commit/49080fd2d5ff4975d318fde6d70ff3618bf99a0f) Updated repos/elpa
* [`58f214b4`](https://github.com/nix-community/emacs-overlay/commit/58f214b49b4c057f6e145c45ea93405ea6b63b6c) Updated repos/emacs
* [`920e88c4`](https://github.com/nix-community/emacs-overlay/commit/920e88c44073e2a5394d2731c1cac265c6cbf2dd) Updated repos/melpa
* [`21674d30`](https://github.com/nix-community/emacs-overlay/commit/21674d307afceab82f471f6aa50e8f140bb84e5a) Updated repos/emacs
* [`9e75e2c6`](https://github.com/nix-community/emacs-overlay/commit/9e75e2c6c772f4c8ac411f4982ed656dec3be29f) Updated repos/melpa
* [`8adc64d7`](https://github.com/nix-community/emacs-overlay/commit/8adc64d7036635dc691f37a19081e4fa093e47c0) Updated repos/emacs
* [`8105f0f8`](https://github.com/nix-community/emacs-overlay/commit/8105f0f88edf635dbe97dc3b40984b90b2e76029) Updated repos/melpa
* [`5b91173f`](https://github.com/nix-community/emacs-overlay/commit/5b91173fcd7958035271eefa3527024efaebc7da) Updated repos/emacs
* [`26386599`](https://github.com/nix-community/emacs-overlay/commit/26386599653aa6040645f99a7446c47eefee05c4) Updated repos/melpa
* [`973cb8f4`](https://github.com/nix-community/emacs-overlay/commit/973cb8f433469a8959001ac79630b8025c9f640f) Updated repos/emacs
* [`2c4a47fb`](https://github.com/nix-community/emacs-overlay/commit/2c4a47fb84a07ebcf53446504b48e3f1594cb72b) Updated repos/melpa
* [`7570fbb3`](https://github.com/nix-community/emacs-overlay/commit/7570fbb326335edc675b5d964ed0892b508562b6) Updated repos/nongnu
* [`3b50e7a5`](https://github.com/nix-community/emacs-overlay/commit/3b50e7a53936a3c1f732836933c224a8dd810aa5) Updated repos/elpa
* [`0b08d211`](https://github.com/nix-community/emacs-overlay/commit/0b08d211820634f49229d89c797815bd0af8f198) Updated repos/emacs
* [`e6787f62`](https://github.com/nix-community/emacs-overlay/commit/e6787f627285bf1963ad582c7d635c97efea524d) Updated repos/melpa
* [`6d7d3b27`](https://github.com/nix-community/emacs-overlay/commit/6d7d3b27f8fbddbaf286f383cda9b753541ceb6b) Updated repos/elpa
* [`c2e19aa2`](https://github.com/nix-community/emacs-overlay/commit/c2e19aa2e259dcb38a869e2469455b83842dc6d2) Updated repos/emacs
* [`79d28f83`](https://github.com/nix-community/emacs-overlay/commit/79d28f8388bfe9e1933e4aa769676d2452cc6ad6) Updated repos/melpa
