### PR TITLE
niv fast-syntax-highlighting: update 721be2a9 -> 13dd94ba

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "721be2a93501bbb5e6ca20a05a008d21811cb8fa",
-        "sha256": "0445gghjafsb2c03pa429cn8s23r4rp3b58ix9dzjm6008r6z2zh",
+        "rev": "13dd94ba828328c18de3f216ec4a746a9ad0ef55",
+        "sha256": "1l7szi9lc1b0g0c0p1c1pqhbvgz66wp1a1ib6rhsly4vdz8y5ksm",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/721be2a93501bbb5e6ca20a05a008d21811cb8fa.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/13dd94ba828328c18de3f216ec4a746a9ad0ef55.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@721be2a9...13dd94ba](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/721be2a93501bbb5e6ca20a05a008d21811cb8fa...13dd94ba828328c18de3f216ec4a746a9ad0ef55)

* [`13dd94ba`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/13dd94ba828328c18de3f216ec4a746a9ad0ef55) docs: Fig installation instructions ([zdharma-continuum/fast-syntax-highlighting⁠#37](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/37))
