### PR TITLE
niv powerlevel10k: update 2dd6a29e -> e72264e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "2dd6a29e4d7a33bfef10973d6550e087be37ddee",
-        "sha256": "0as7grgmmh7d1syr1qia0p4xgd9jvrrw5iic7f7yjd22q1q3ixzn",
+        "rev": "e72264e01cb24431455ed6e398a769bca0da7ffe",
+        "sha256": "05nprnnxf3y6zhcg2xgi3ah6q1xqjc4li8gk3a2mzqhxp8wf7f0m",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/2dd6a29e4d7a33bfef10973d6550e087be37ddee.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/e72264e01cb24431455ed6e398a769bca0da7ffe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@2dd6a29e...e72264e0](https://github.com/romkatv/powerlevel10k/compare/2dd6a29e4d7a33bfef10973d6550e087be37ddee...e72264e01cb24431455ed6e398a769bca0da7ffe)

* [`cb82b1f5`](https://github.com/romkatv/powerlevel10k/commit/cb82b1f5d97322d07c1c210d1c9666b02a62e469) use HOST for distrobox detection
* [`fd5fa095`](https://github.com/romkatv/powerlevel10k/commit/fd5fa095046233c7b4cddc3f1b7de04aae36f9fe) fix toolbox segment ([romkatv/powerlevel10k⁠#1916](https://togithub.com/romkatv/powerlevel10k/issues/1916))
* [`e72264e0`](https://github.com/romkatv/powerlevel10k/commit/e72264e01cb24431455ed6e398a769bca0da7ffe) don't trust cnorm as it's incorrect in some combinations of terminals and terminfo ([romkatv/powerlevel10k⁠#1699](https://togithub.com/romkatv/powerlevel10k/issues/1699))
