### PR TITLE
niv spacemacs: update ed8ddd95 -> fdfd9f14

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "ed8ddd955a22541f815baaa5329d95097c0154ac",
-        "sha256": "049f625fi6g9dng8lqcazhmaj5zhw7wify2lk9gj0pfcdnqrzxsn",
+        "rev": "fdfd9f14573855e828d9d523c4ab38e11796f6d2",
+        "sha256": "07fy9qa7vwgis5nz0igbap64kf25vl5185ymm3gvbxvhrijhh6nm",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/ed8ddd955a22541f815baaa5329d95097c0154ac.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/fdfd9f14573855e828d9d523c4ab38e11796f6d2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@ed8ddd95...fdfd9f14](https://github.com/syl20bnr/spacemacs/compare/ed8ddd955a22541f815baaa5329d95097c0154ac...fdfd9f14573855e828d9d523c4ab38e11796f6d2)

* [`d428d71a`](https://github.com/syl20bnr/spacemacs/commit/d428d71a1f00df597d10aba236901fd783cbced4) core-configuration-layer: fix quelpa on opensuse
* [`5dc773e9`](https://github.com/syl20bnr/spacemacs/commit/5dc773e90f0355559b9eee7ccae1ec4e18c86159) [compleseus] fix hack for company-capf ([syl20bnr/spacemacs⁠#15652](https://togithub.com/syl20bnr/spacemacs/issues/15652))
* [`c49e80d7`](https://github.com/syl20bnr/spacemacs/commit/c49e80d7946a6fac0b802ad93c1134cdeabcf74f) Revert "[spacemacs-bootstrap] Remove whitespace from kill ring. ([syl20bnr/spacemacs⁠#15634](https://togithub.com/syl20bnr/spacemacs/issues/15634))"
* [`a1f82b73`](https://github.com/syl20bnr/spacemacs/commit/a1f82b73672c8bd44aaecf9da6326ac984187688) [major-modes] move gemini-mode source to MELPA ([syl20bnr/spacemacs⁠#15656](https://togithub.com/syl20bnr/spacemacs/issues/15656))
* [`2e897fcc`](https://github.com/syl20bnr/spacemacs/commit/2e897fcc89a6c30d4709fd79d068cfcdd7fbe3c7) fixup! core-configuration-layer: fix quelpa on opensuse
* [`00d19c36`](https://github.com/syl20bnr/spacemacs/commit/00d19c3656249a02ee3257569c59e6450ef7273b) core-fonts-support: clarify comment, removed unnecessary codepoints
* [`03ccb174`](https://github.com/syl20bnr/spacemacs/commit/03ccb174db61c994bca669f44a482d0bdcf8a503) FAQ: added two questions
* [`45bf3825`](https://github.com/syl20bnr/spacemacs/commit/45bf3825ddc8137a31df8a25ae8057d0d11105f1) README: rewrite ([syl20bnr/spacemacs⁠#15660](https://togithub.com/syl20bnr/spacemacs/issues/15660))
* [`861ea131`](https://github.com/syl20bnr/spacemacs/commit/861ea131e1be7963b9602e774024f687fe9d4a29) core-dotspacemacs: cleaning up ([syl20bnr/spacemacs⁠#15661](https://togithub.com/syl20bnr/spacemacs/issues/15661))
* [`c8c7c859`](https://github.com/syl20bnr/spacemacs/commit/c8c7c85909c6de5219c26c12e7f308ca1700b2e0) fix: dotspacemacs-directory is expected to end with a slash ([syl20bnr/spacemacs⁠#15662](https://togithub.com/syl20bnr/spacemacs/issues/15662))
* [`c5330deb`](https://github.com/syl20bnr/spacemacs/commit/c5330deb69e1d3af5556e0808cb356a0132e3781) Update README.org ([syl20bnr/spacemacs⁠#15657](https://togithub.com/syl20bnr/spacemacs/issues/15657))
* [`e1f844a8`](https://github.com/syl20bnr/spacemacs/commit/e1f844a85241810e9c73e9585ccc8a30d93f7318) [bot] "documentation_updates" Mon Jul 25 18:38:07 UTC 2022 ([syl20bnr/spacemacs⁠#15663](https://togithub.com/syl20bnr/spacemacs/issues/15663))
* [`c2903ad6`](https://github.com/syl20bnr/spacemacs/commit/c2903ad64a6317d0b88a3ce721bebe5aa1c14896) COPYRIGHT: add license info of nav-flash layer
* [`ef912d7e`](https://github.com/syl20bnr/spacemacs/commit/ef912d7e7a799d4ea51b027668a9550ec16b2f8d) nav-layer: add credit section to layer documentation
* [`fdfd9f14`](https://github.com/syl20bnr/spacemacs/commit/fdfd9f14573855e828d9d523c4ab38e11796f6d2) nav-flash: fix [syl20bnr/spacemacs⁠#15617](https://togithub.com/syl20bnr/spacemacs/issues/15617)
