### PR TITLE
niv nixpkgs: update ec83cde0 -> 901978e1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ec83cde062c65bf241d4be1f4edc0b4939d02512",
-        "sha256": "1c6sbnz1ps0n5lycbw21pv7wnyadcf0p0z829s1k5xnin5cfna4l",
+        "rev": "901978e1fd43753d56299a3b4f549b66ea77a744",
+        "sha256": "0wx2szfvyqyvrni0xpwwix9cadxvlih5c10wpfmb7sv1zj8mw2nr",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ec83cde062c65bf241d4be1f4edc0b4939d02512.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/901978e1fd43753d56299a3b4f549b66ea77a744.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ec83cde0...901978e1](https://github.com/nixos/nixpkgs/compare/ec83cde062c65bf241d4be1f4edc0b4939d02512...901978e1fd43753d56299a3b4f549b66ea77a744)

* [`4ca2f27a`](https://github.com/NixOS/nixpkgs/commit/4ca2f27a60e28504be679204e672756fa9bd9d82) nixos/nextcloud: allow more declarative config
* [`fb389cb0`](https://github.com/NixOS/nixpkgs/commit/fb389cb0dbe94b08733d4c875e6c38ae2b25748d) nixos/nextcloud: add test for declaratively defined redis
* [`727bdd73`](https://github.com/NixOS/nixpkgs/commit/727bdd736c3977e17ba3c3051280fe9aa21914da) nixos/nextcloud: use array_merge instead of array_push
* [`83a669a0`](https://github.com/NixOS/nixpkgs/commit/83a669a0bef463b3202a544b33efc9109605ce83) nixos/nextcloud: better json typechecking
* [`164f8c94`](https://github.com/NixOS/nixpkgs/commit/164f8c9457180e50db0c97aaa54cda46d6bdf97f) nixos/nextcloud: deduplicate file reading
* [`64e943d4`](https://github.com/NixOS/nixpkgs/commit/64e943d4a2d6089bce18c7635b546edeba297278) nixos/nextcloud: test for secretFile option
* [`a8ecb909`](https://github.com/NixOS/nixpkgs/commit/a8ecb909c0774eac06c32a1fa18d7c1c0bc7d142) nixos/nextcloud: fixed secretFile example
* [`2140fed7`](https://github.com/NixOS/nixpkgs/commit/2140fed72679917fc0b266e9e443cb02e3133f85) profiles/all-hardware.nix: add reset-raspberry for USB on RPi 4
* [`0f2537f7`](https://github.com/NixOS/nixpkgs/commit/0f2537f7a5a4eb2285003ef296651c0b62861ef1) ocamlPackages.ocaml-compiler-libs: 0.12.3 -> 0.12.4
* [`10dfde23`](https://github.com/NixOS/nixpkgs/commit/10dfde238a7500b37d7de633255fe7b6c11e0296) ocamlPackages.fix: 20211231 -> 20220121
* [`61585d1c`](https://github.com/NixOS/nixpkgs/commit/61585d1cd7f699dd9187ade7c0b21735c96b53ee) nixos/tests/stunnel: init
* [`0acc6381`](https://github.com/NixOS/nixpkgs/commit/0acc6381b98baaff045b3739dd3ced2161c54218) python3Packages.py-tree-sitter: init at unstable-2022-02-08
* [`131399ef`](https://github.com/NixOS/nixpkgs/commit/131399effb405114449d7777da650d0977931178) nixos/stunnel: Make free-form
* [`0e857fc1`](https://github.com/NixOS/nixpkgs/commit/0e857fc1d92ab5ce0c8b53e2a1df558892c3b2ff) nixos/tests/stunnel: Add mutual authentication test
* [`fd1a8696`](https://github.com/NixOS/nixpkgs/commit/fd1a86960331433545d23160ba6259110a747c0c) klipper-firmware: init at klipper.version
* [`72871a35`](https://github.com/NixOS/nixpkgs/commit/72871a3596632c150fb896061661264f29fdada6) nixos/klipper: Add klipper-firmware options
* [`c49f15e8`](https://github.com/NixOS/nixpkgs/commit/c49f15e87b09fc26b6150dbf48e26d1381460f74) klipper-firmware: Fix IFD error and minor refactoring
* [`c8b873fc`](https://github.com/NixOS/nixpkgs/commit/c8b873fcd8f12e33dd399b4d69cd02324cd389b8) nixos/klipper: Fix working of assertion
* [`bc96bf2e`](https://github.com/NixOS/nixpkgs/commit/bc96bf2e0681be3f8f4805ce8f682a1b6cbd5163) nixos/klipper: Rename `firmware` option to `firmwares`
* [`7200dc66`](https://github.com/NixOS/nixpkgs/commit/7200dc665118e227855a6fc03cc8a93a0628f3bd) nixos/klipper: Rename `flashingEnable` to `flashing.enable`
* [`9271773a`](https://github.com/NixOS/nixpkgs/commit/9271773a7bfd0871a1673c32fd372a0769cb4942) nixos/klipper: Rename `firmwareConfig` to `configFile`
* [`2da038a9`](https://github.com/NixOS/nixpkgs/commit/2da038a900f36ee75847f717fa447c02fd4c2df2) klipper-firmware: Make runtimeInput conditional
* [`b391d98a`](https://github.com/NixOS/nixpkgs/commit/b391d98a710378a6f930877adb5fa6433ae71928) nixos/klipper: Remove automatic flashing option `flashing.enable`
* [`6911fefe`](https://github.com/NixOS/nixpkgs/commit/6911fefec185de63a254c2a88f161ce00041971b) vscode-extensions.eugleo.magic-racket: 0.5.7 -> 0.6.4
* [`d8fcdf8e`](https://github.com/NixOS/nixpkgs/commit/d8fcdf8edab9b30ea9f00d4e366d812e8a40ee5f) eureka-ideas: 1.8.1 -> 2.0.0
* [`9d60e3dd`](https://github.com/NixOS/nixpkgs/commit/9d60e3dd29cf2d95f707223bedcb3260716911f9) stdenv: use disallowedRequisites to check forbidden requisites
* [`2cc754a7`](https://github.com/NixOS/nixpkgs/commit/2cc754a7baa72659430ec961608f0fc1dbe128df) cc-wrapper: Fortran: disable stackprotector hardening on darwin aarch64
* [`251b2195`](https://github.com/NixOS/nixpkgs/commit/251b2195f0e407042146f5100792a7524cbe653e) jackett: 0.20.709 -> 0.20.915
* [`b5af0719`](https://github.com/NixOS/nixpkgs/commit/b5af07194680c15246b5859a6313c028fc8cdd68) services/nextcloud: apply suggestions from PR 118093
* [`095c27c9`](https://github.com/NixOS/nixpkgs/commit/095c27c9d5e6b5d4d8f7a067ee413ca0ca47c56b) services/nixos: decode secret file correctly
* [`439243d3`](https://github.com/NixOS/nixpkgs/commit/439243d38fe369cadf2481c5e1f759a7b543f4fc) services/nextcloud: check redis config
* [`1c9c4a8e`](https://github.com/NixOS/nixpkgs/commit/1c9c4a8e807703e0414c01a1a05b45cef974e177) services/nextcloud: better secretFile test
* [`3e608713`](https://github.com/NixOS/nixpkgs/commit/3e60871330bde389d89c4d6585a259109c716960) lib/systems/platforms.nix: use "32" instead of "o32" for mips32 ABI
* [`f87f5ae3`](https://github.com/NixOS/nixpkgs/commit/f87f5ae301c39e8adeed184d908bd9dd083de3f7) libxml2: re-enable tests for darwin
* [`337d65fe`](https://github.com/NixOS/nixpkgs/commit/337d65fe6204ab58594c507076ba4b40e24646a0) inkcut: avoid dirty PYTHONPATH
* [`2830a797`](https://github.com/NixOS/nixpkgs/commit/2830a7976f547daac90656de6e1aaa505963a800) bind: add some more nixosTests to passthru.tests
* [`41142897`](https://github.com/NixOS/nixpkgs/commit/41142897bbd5fd6982ede3a7e5df79dc13ee7917) python310Packages.JPype1: 1.3.0 -> 1.4.0
* [`2cde336e`](https://github.com/NixOS/nixpkgs/commit/2cde336e3abee58f7a8b00edb8e6037c93e7ff94) python310Packages.django_hijack: 3.2.0 -> 3.2.1
* [`3ac203db`](https://github.com/NixOS/nixpkgs/commit/3ac203dbaed23712789160d6619d42795aaa5eb5) python310Packages.gigalixir: 1.2.5 -> 1.2.6
* [`c130b913`](https://github.com/NixOS/nixpkgs/commit/c130b9133f8f43db86084a7d22d6a5783a99701a) pianoteq.{stage-trial,standard-trial}: 7.4.1 -> 7.5.4
* [`b5e42214`](https://github.com/NixOS/nixpkgs/commit/b5e422140290398e01e06d7a7592d1e8b1eddb4e) xserver: fix cross-compilation
* [`18c899d9`](https://github.com/NixOS/nixpkgs/commit/18c899d963a29d343dd3e312bfaf98f3530d694f) nixos/headscale: only set oidc secret if not null
* [`f1669775`](https://github.com/NixOS/nixpkgs/commit/f1669775bc34e3a578d711ddc6514b174b11d2d1) nixos/headscale: do not run gin webframework in debug mode
* [`1b18f0e3`](https://github.com/NixOS/nixpkgs/commit/1b18f0e3758a6b82d6c4b8a142cfab9a0123bd7e) oraclejdk14: Removed as it's end of life since 09/2020
* [`6b913c40`](https://github.com/NixOS/nixpkgs/commit/6b913c40f0761e6ebee8b5c3d8e53542463387f8) gitea: bugfix: add check for empty file for secrets
* [`8b8e7483`](https://github.com/NixOS/nixpkgs/commit/8b8e7483ca4202f95c7b3459f35199b2e6fb166f) cmdstan: 2.30.0 -> 2.30.1
* [`4e1ebe4f`](https://github.com/NixOS/nixpkgs/commit/4e1ebe4f37358a6b7fd01fea457c509fc3b4948a) cmdstan: fix build on darwin
* [`3562c1d5`](https://github.com/NixOS/nixpkgs/commit/3562c1d5c6ff868924fe95ba7b51344f3c141311) nixos/console: add required store paths to initrd for systemd stage 1
* [`d70b4df6`](https://github.com/NixOS/nixpkgs/commit/d70b4df686a714f4a7f97bdf67eda1473f87707a) tensorrt: init at 8.4.0.6
* [`c41fc85e`](https://github.com/NixOS/nixpkgs/commit/c41fc85e4067921e29950cfc6d53a70943c416ac) coreboot-toolchain: add allowedRequisites=[]
* [`f18e17b2`](https://github.com/NixOS/nixpkgs/commit/f18e17b2d2dc383c26f19fed82fa8fd1260aaf0f) coreboot-toolchain: move patchShebangs outside of fetchgit
* [`b60e7072`](https://github.com/NixOS/nixpkgs/commit/b60e7072c94fde3e1cdc69ba9a713e100b7a29a8) Updated Haxe 4.2.1 -> 4.2.5 and added myself to the maintainer list
* [`4e000b4b`](https://github.com/NixOS/nixpkgs/commit/4e000b4b6a03d948eee00e6ed2dcf62c9dd15e27) firefox-beta-bin-unwrapped: 102.0b9 -> 103.0b1
* [`8dc48954`](https://github.com/NixOS/nixpkgs/commit/8dc489545df5a335af1c93fb428b1c0ca3d193a7) firefox-devedition-bin-unwrapped: 102.0b9 -> 103.0b1
* [`bef316ed`](https://github.com/NixOS/nixpkgs/commit/bef316ed2eeb5e3332291183212486a38d0a3495) ffmpeg-full: add cuda features, jellyfin-ffmpeg: fix CUDA tonemap
* [`48d5f38c`](https://github.com/NixOS/nixpkgs/commit/48d5f38c6a2e5d21c22abb2485aaeeb66ca8a50a) doc/builders/fetchers: Add examples, reduce sentence complexity
* [`df653dcf`](https://github.com/NixOS/nixpkgs/commit/df653dcfbc4a23aa46aeba2f49f81a2d59dd4160) cudatoolkit: get redistrib_11.7.0.json
* [`6e6f33ad`](https://github.com/NixOS/nixpkgs/commit/6e6f33ad838a4935fb51684a56f6f27bcc56c4e6) openldap: remove deprecated options
* [`d1f55ce0`](https://github.com/NixOS/nixpkgs/commit/d1f55ce0a462a036f3d54631c24a8f344ad32902) openldap: change default ldapi directory
* [`d72f89a8`](https://github.com/NixOS/nixpkgs/commit/d72f89a8fc8af8239575ca417e01deeef89f1a1e) openldap: Allow notify outside of main thread
* [`38ead944`](https://github.com/NixOS/nixpkgs/commit/38ead944cee78c8ee5543067b3ec839bbb36eed6) openldap: run in foreground
* [`fd7d9011`](https://github.com/NixOS/nixpkgs/commit/fd7d901133f9fbfc893cdb33f7d630846bb21f9c) openldap: run under systemd-defined user/group
* [`ad5acb9b`](https://github.com/NixOS/nixpkgs/commit/ad5acb9b0ec738c9bede7ec12947236992e78d2d) openldap: use specialisations for tests
* [`8a7193fc`](https://github.com/NixOS/nixpkgs/commit/8a7193fc0a9fa7fa098299a321fd2bd3f4fa2d7c) openldap: test and fix mutable config
* [`334d622e`](https://github.com/NixOS/nixpkgs/commit/334d622ec72c79a23bc5102f424ca535685e3dfb) openldap: test starting with empty DB
* [`60d1c1d9`](https://github.com/NixOS/nixpkgs/commit/60d1c1d9ad3717150fc38bd2b1b974b511cd17b4) openldap: change runtime directory
* [`24e95a44`](https://github.com/NixOS/nixpkgs/commit/24e95a44613d9731e459ba98a9cfc011c4edd922) Remove possessive apostrophes
* [`ba1efa71`](https://github.com/NixOS/nixpkgs/commit/ba1efa71ae3d5055e3076eaad7cf7e6a6e800066) stdenv: substituteInPlace: accept multiple filenames
* [`ea32f3e5`](https://github.com/NixOS/nixpkgs/commit/ea32f3e523af2f82d8ca9c9878ac79e09c87d47b) make-bootstrap-tools-cross: enable Hydra builds of mips32el bootstrap-files
* [`c673e1ff`](https://github.com/NixOS/nixpkgs/commit/c673e1ff023fb30ef4ee5506287c8947da94aa78) docker-buildx: pass version to ldflags
* [`b3702049`](https://github.com/NixOS/nixpkgs/commit/b37020499c314528dc6198e47019fdbd0b671161) metabase: only require jdk11_headless to reduce closure size
* [`ef75aab6`](https://github.com/NixOS/nixpkgs/commit/ef75aab6125710231873bc04b9a6507228d4e814) services/nextcloud: more consistent code
* [`787d4b3a`](https://github.com/NixOS/nixpkgs/commit/787d4b3a1cb4c1c0a7a10c10b93217240ee38035) gtest: 1.11.0 -> 1.12.1
* [`c8fba825`](https://github.com/NixOS/nixpkgs/commit/c8fba8254a5f984a215164f84a4fd43c28c6ed82) tensorrt: support multiple CUDA versions
* [`e28a8e07`](https://github.com/NixOS/nixpkgs/commit/e28a8e07a6a518645625d0041d72493e3a0e2764) cudnn: fix incorrect hash
* [`61f6ac99`](https://github.com/NixOS/nixpkgs/commit/61f6ac995ddf8940718ae944a01eaae072f1aa00) qgroundcontrol: Fix gst dependencies
* [`c0fc8f51`](https://github.com/NixOS/nixpkgs/commit/c0fc8f51a216ab872bc6a5cf2eba2e225f1011d5) zstd: Fix build on riscv hosts
* [`8927d4d9`](https://github.com/NixOS/nixpkgs/commit/8927d4d9e7dbbd23f8406c12d747089984660cc4) qgroundcontrol: 4.2.1 -> 4.2.3
* [`10d615c8`](https://github.com/NixOS/nixpkgs/commit/10d615c89d1986e57798eb6a7dda6dbd48c4f245) kexec-tools: fix build with elfv2 abi on ppc64be
* [`261f0900`](https://github.com/NixOS/nixpkgs/commit/261f090079616e6823a076f6ce30ee0c78c5dab4) git-lfs: remove leaveDotGit=true
* [`320e4dbc`](https://github.com/NixOS/nixpkgs/commit/320e4dbcc3e8b9f951ed56ae12da0cff2c17fa61) nixos/nginx: fix broken listenAddresses example
* [`038f3485`](https://github.com/NixOS/nixpkgs/commit/038f3485e7ddb98738a9375c53aad298a6e4bee6) openafs_1_9: Remove
* [`6a9987a0`](https://github.com/NixOS/nixpkgs/commit/6a9987a0951e2657fe57787bc2d5aafcba4b1ac9) Updated wording from code review
* [`71e172b8`](https://github.com/NixOS/nixpkgs/commit/71e172b857ed4ff7884ab1b33f561f0126c88a9e) rkdeveloptool: unstable-2021-02-03 -> unstable-2021-04-08
* [`2abf031a`](https://github.com/NixOS/nixpkgs/commit/2abf031a476eb38678688a9133a68fcca36a363a) txtpbfmt: init at unstable-2022-06-08
* [`dd9200c0`](https://github.com/NixOS/nixpkgs/commit/dd9200c0a4781a8eaf6e4233bd1d4c60423f8f01) services/nextcloud: fix a bug
* [`5f4d5fcf`](https://github.com/NixOS/nixpkgs/commit/5f4d5fcfa4e633682c8e1c06cd4872316fdaac51) services/nextcloud: apply suggestions
* [`3fbc2a43`](https://github.com/NixOS/nixpkgs/commit/3fbc2a433d76115730ef159d712fae78a1e5631a) services/nextcloud: impossible error message
* [`5bb4355a`](https://github.com/NixOS/nixpkgs/commit/5bb4355ad45579deba552649a1e5854000f004bc) curl: fix build on certain platforms
* [`b5ee4eca`](https://github.com/NixOS/nixpkgs/commit/b5ee4eca8e232a0fc9fc7dcd3cc31b60f6710024) linux: disable ASHMEM on >= 5.18
* [`339ce46a`](https://github.com/NixOS/nixpkgs/commit/339ce46af2c4ff6f52b8ccb1dc3c87abf542b091) nixos/waydroid: add FIXME regarding ASHMEM removal in 5.18
* [`10362d72`](https://github.com/NixOS/nixpkgs/commit/10362d728084d8810f6af2f8588b172e092b01e6) librdf_raptor2: 2.0.15 -> unstable-2022-06-06
* [`a83d2f7c`](https://github.com/NixOS/nixpkgs/commit/a83d2f7c918a5badab204d57d8620adb926e618b) gobject-introspection: cross improvements
* [`71cbf3b8`](https://github.com/NixOS/nixpkgs/commit/71cbf3b809b5a380d3434171ba5caabffdafb919) gobject-introspection: use targetOffset to look for libraries for target
* [`2cbce6b0`](https://github.com/NixOS/nixpkgs/commit/2cbce6b01297b623dc7d098e39b78e6935c11569) mesonEmulatorHook: check if the target binaries can be executed
* [`31f99a8a`](https://github.com/NixOS/nixpkgs/commit/31f99a8a28c7e6c406ee27d5dc86510d75245d83) gst_all_1: don't disable gobject-introspection when cross
* [`c5d7fc0b`](https://github.com/NixOS/nixpkgs/commit/c5d7fc0b3cfa92f7b0442b1828495d46ccee52ba) python310Packages.pygobject3: fix cross
* [`83bdd276`](https://github.com/NixOS/nixpkgs/commit/83bdd27670b8fce01d1ed7c256fd42caad96e268) python310Packages.certbot: 1.28.0 -> 1.29.0
* [`4ea0a92d`](https://github.com/NixOS/nixpkgs/commit/4ea0a92d47199cd0eca8af77af3a79c29cb1c3dc) clapper: 0.5.1 -> 0.5.2
* [`8c1be1e9`](https://github.com/NixOS/nixpkgs/commit/8c1be1e9050ceded438f9fa383f55b050d9facff) dolt: 0.39.2 -> 0.40.15
* [`f6e06709`](https://github.com/NixOS/nixpkgs/commit/f6e067090dc09950d55db44341c0854e7d27460f) closurecompiler: 20220502 -> 20220601
* [`28ca82a8`](https://github.com/NixOS/nixpkgs/commit/28ca82a86bbead53b1a5724bbb96a6dc88dfbde3) libgudev: dont specialcase cross and pull patch
* [`bf15263d`](https://github.com/NixOS/nixpkgs/commit/bf15263d1c87f64a86828786b54455fa1210036d) networkmanager: fix cross
* [`1bd8727a`](https://github.com/NixOS/nixpkgs/commit/1bd8727a4ca5cd4ed33a3e9349a42637f0f3a3bc) various: enable gobject-introspection when cross-compiling
* [`2e456668`](https://github.com/NixOS/nixpkgs/commit/2e456668844e1a7c39f271a8694e5a93ea8569a2) inkcut: 2.1.3 -> 2.1.5
* [`55ac3271`](https://github.com/NixOS/nixpkgs/commit/55ac327102cf9acc731d7bbd484731592b493586) cmark-gfm: 0.29.0.gfm.3 -> 0.29.0.gfm.4
* [`437781b5`](https://github.com/NixOS/nixpkgs/commit/437781b5b11b952cc099378b421afdaee0f13151) fluidsynth: 2.2.5 -> 2.2.7
* [`350faa44`](https://github.com/NixOS/nixpkgs/commit/350faa448412235963eed0f3eb6a995795a739d0) alps: fix handling of themes and plugins
* [`56f24b5e`](https://github.com/NixOS/nixpkgs/commit/56f24b5ef87085e55c3f5aa84231de44da6c61f9) kissfftFloat: init float version of kissfft from datatype override
* [`cfe56470`](https://github.com/NixOS/nixpkgs/commit/cfe56470cb641985d43adba690d5bca5453110fe) polaris-web: build-50 -> build-54
* [`2274a721`](https://github.com/NixOS/nixpkgs/commit/2274a721c7588c5ddc051272b29048e437f96731) metabase: 0.43.1 → 0.43.3
* [`2d8f2d93`](https://github.com/NixOS/nixpkgs/commit/2d8f2d938c8c5444ce9a5e0da279e6fde5644952) bison: only run install check
* [`e1ed913a`](https://github.com/NixOS/nixpkgs/commit/e1ed913a9ffa7c9cc28067885ad0f70af50b7b4c) feishu: fix the missing maintainer
* [`e4106d47`](https://github.com/NixOS/nixpkgs/commit/e4106d474541d6ab3304f4f8ff03185c769bbe1f) signalbackup-tools: use Apple SDK 11 for all darwin systems
* [`1be5d0ea`](https://github.com/NixOS/nixpkgs/commit/1be5d0ea4ab86f3e8b54677825a383e69519bed6) sumneko-lua-language-server: use Apple SDK 11 for all darwin systems
* [`4b1975ac`](https://github.com/NixOS/nixpkgs/commit/4b1975accafc4b65b312d4f53d1be8ed9bc6807b) zecwallet-lite: init at 1.7.13
* [`e1530872`](https://github.com/NixOS/nixpkgs/commit/e15308727693143d45904eeba3cd0b72fd643be5) nixos: Fix use of nixpkgs.localSystem
* [`711e653a`](https://github.com/NixOS/nixpkgs/commit/711e653a65300652f680aa9aa7e26b609f7d232e) nixos/eval-config: Allow system to be set modularly when arg is null
* [`62314ccc`](https://github.com/NixOS/nixpkgs/commit/62314ccc17684bcc9310f3b380cffe15bae177d6) flake.lib.nixosSystem: Allow nixpkgs.system to be set instead
* [`82378f9c`](https://github.com/NixOS/nixpkgs/commit/82378f9c0ca67445e915fab1af5f14b0327019e6) flake.nix: Format
* [`acd969a4`](https://github.com/NixOS/nixpkgs/commit/acd969a4ddfdc45eca90ac4d920857ec50c5c1cd) nixos/nixpkgs.nix: Recommend hostPlatform instead of system
* [`429fcad6`](https://github.com/NixOS/nixpkgs/commit/429fcad615726b2b1fe21e9f9b5ab95b23fe317f) {lib}mediainfo{-gui}: 22.03 -> 22.06
* [`e93e2526`](https://github.com/NixOS/nixpkgs/commit/e93e2526704994da12eb759e0882d58a8527d0da) source-highlight: fix lazy bash-completion loading when loaded through XDG_DATA_DIRS
* [`62f2aebc`](https://github.com/NixOS/nixpkgs/commit/62f2aebc4deaea045d26b1765839fba3ae97e336) imlib2: 1.8.1 -> 1.9.1
* [`7a1fcc94`](https://github.com/NixOS/nixpkgs/commit/7a1fcc94a77c7df416507cb536261d6df41a3992) feh: fix failing testPhase
* [`d1407dbf`](https://github.com/NixOS/nixpkgs/commit/d1407dbf2dfcf26104571a14835d2a57cd9660cb) frp: 0.43.0 -> 0.44.0
* [`ea4a17f5`](https://github.com/NixOS/nixpkgs/commit/ea4a17f576d1b7ee6e87ae1f94ee155a4ff1e46f) python310Packages.lru-dict: 1.1.7 -> 1.1.8
* [`c06a3121`](https://github.com/NixOS/nixpkgs/commit/c06a3121b7c2054a4107e9819b23058ef2b5824f) prosody: use lua 5.2
* [`3feca2a0`](https://github.com/NixOS/nixpkgs/commit/3feca2a040927cffcb78a47598b92e390f0d7b68) kmod: 29 -> 30
* [`eb829035`](https://github.com/NixOS/nixpkgs/commit/eb829035c938022bb064faef56a7b1346443e034) gobject-introspection: do not propagate target gobject-introspection in wrapper
* [`d4b70f3b`](https://github.com/NixOS/nixpkgs/commit/d4b70f3b5685afe612b0c1af3d2b1a27bbe1edfc) python310Packages.awscrt: 0.13.13 -> 0.13.14
* [`20642e2a`](https://github.com/NixOS/nixpkgs/commit/20642e2ab0c278f1e51ca2e63ec0836f91b5451d) various: readd gobject-introspection to buildInputs
* [`d938f942`](https://github.com/NixOS/nixpkgs/commit/d938f94279d5c255ab9fb007deae7dda39679105) Revert "Revert "release: add tests.packageTestsForChannelBlockers.curl.withCh…"
* [`db4fdd62`](https://github.com/NixOS/nixpkgs/commit/db4fdd6247ec191677ac84e08da274ab88a0682e) nixos/filesystems: skip fsck for bind mounts
* [`527595cc`](https://github.com/NixOS/nixpkgs/commit/527595cc2068eb3502bbaf760faee2566ae639ab) bzip2: 1.0.6.0.2 -> 1.0.8
* [`a05f2b15`](https://github.com/NixOS/nixpkgs/commit/a05f2b15b9a1525d7b72924730c0a1034100627e) libuv: 1.44.1 -> 1.44.2
* [`c16db99d`](https://github.com/NixOS/nixpkgs/commit/c16db99d3b38a558caabd66f4d59621ed6c7f49b) libssh2: fix build with libressl 3.5.x
* [`9b817daa`](https://github.com/NixOS/nixpkgs/commit/9b817daa229d574db77e37f1d1b03c96fe6dd088) qt5.15: restore the version override
* [`f0c7e180`](https://github.com/NixOS/nixpkgs/commit/f0c7e18075cda82615d692e303f5db3496f8332d) pango: 1.50.7 → 1.50.8
* [`f95591ae`](https://github.com/NixOS/nixpkgs/commit/f95591ae903eede2e7928a8320cb9361bb8e33f0) tracker: 3.3.1 → 3.3.2
* [`614a4d2b`](https://github.com/NixOS/nixpkgs/commit/614a4d2bd55c6beaa23212fc730d7e13fb8bd6ad) python310Packages.zipp: 3.8.0 -> 3.8.1
* [`11c43f0a`](https://github.com/NixOS/nixpkgs/commit/11c43f0a137f56eecc3c55b155f48cc6d0d2d17c) pipewire: 0.3.54 -> 0.3.55, fix pw-v4l2
* [`41455801`](https://github.com/NixOS/nixpkgs/commit/414558010282f8ba85b39362ae7185936033be4e) pipewire: import upstream-recommended crash fix patch
* [`b060076e`](https://github.com/NixOS/nixpkgs/commit/b060076e21257cd46b5bf8e83e1c3efa61187a76) cc-wrapper: broaden explicit libc++abi linking for LLVM stdenv
* [`3130f293`](https://github.com/NixOS/nixpkgs/commit/3130f29301d59002a7e2cbb4ce6fa2e99ed03ea4) python310Packages.pymavlink: 2.4.29 -> 2.4.31
* [`44283fc5`](https://github.com/NixOS/nixpkgs/commit/44283fc5574794c21cae6acfc90bb630640cb084) graphviz: 3.0.0 -> 5.0.0
* [`15cdfd5e`](https://github.com/NixOS/nixpkgs/commit/15cdfd5e31f13e621fd8fa54a41a06ff3e984090) polkit: 0.120 → 121
* [`ef791b29`](https://github.com/NixOS/nixpkgs/commit/ef791b29a8015e37274b1fe31a1bb11ca0c334a6) python310Packages.setuptools-scm-git-archive: 1.1 -> 1.4
* [`e8ecd00e`](https://github.com/NixOS/nixpkgs/commit/e8ecd00e4699472f861113e525536b4f16f68689) gobject-introspection: override pkg-config variables in a setup hook
* [`a59654ad`](https://github.com/NixOS/nixpkgs/commit/a59654ade0f13498c7dc907f320d80790b0bb9b4) libevent: fix build with libressl 3.5.x
* [`4a257755`](https://github.com/NixOS/nixpkgs/commit/4a257755460272f8a2287c7afdcd4f332a9c44fb) lua-packages: fix eval failure when cross-compiling
* [`99a52394`](https://github.com/NixOS/nixpkgs/commit/99a52394e9a5f4a1993609d826292a935ab64a5f) mpv: move makeWrapper to nativeBuildInputs to fix cross eval
* [`9e53565b`](https://github.com/NixOS/nixpkgs/commit/9e53565bfee17014fe19a3124c59e7f9d184aa65) python310Packages.mutagen: fix cross
* [`a42a1cbc`](https://github.com/NixOS/nixpkgs/commit/a42a1cbc19d6d54fe392bb66a31b642449021eb9) luarocks: fix cross-compiling
* [`271665ec`](https://github.com/NixOS/nixpkgs/commit/271665ec4c38636b19ae40079f48256407883d1b) bundlerApp: put makeWrapper in nativeBuildInputs
* [`c87635d9`](https://github.com/NixOS/nixpkgs/commit/c87635d9178354c4743ace7398632d661685c9fe) doc: move makeWrapper to nativeBuildInputs from buildInputs
* [`6a249036`](https://github.com/NixOS/nixpkgs/commit/6a249036fb7d4546d7ab482589d06d14da7480e3) gnustep.gsmakeDerivation: fix cross eval
* [`7db9cda1`](https://github.com/NixOS/nixpkgs/commit/7db9cda1b5e0038b7a5c93ec7d058fb6318a82fe) gnustep.make: fix cross
* [`c2495832`](https://github.com/NixOS/nixpkgs/commit/c249583234f0797f1ab5b107887f77113c282994) openssh: enable kerberos on aarch64-darwin
* [`d7fff811`](https://github.com/NixOS/nixpkgs/commit/d7fff81159bc2fd18159eec60f253002f4de7e29) separateDebugInfo: enable full Rust debug info
* [`4a53aba9`](https://github.com/NixOS/nixpkgs/commit/4a53aba96852f06d26e47d43c1a3ac9852c0a2ed) Revert "luarocks: fix cross-compiling"
* [`0fe8cf02`](https://github.com/NixOS/nixpkgs/commit/0fe8cf0293eefd711e30266d074a2db2ad831fbf) sqlite: 3.39.0 -> 3.39.1
* [`8d1c1184`](https://github.com/NixOS/nixpkgs/commit/8d1c1184e603865f17f7c2e04f7830c09a32398a) make-bootstrap-tools: add pbzx and tbd tools on x86_64-darwin
* [`7cc97950`](https://github.com/NixOS/nixpkgs/commit/7cc979502c3dc5480ef3e4ffe1a05c897084d34b) kdiskmark: init at 2.3.0
* [`c1fe33bc`](https://github.com/NixOS/nixpkgs/commit/c1fe33bc63cdbc3ce9cc332f5d90a6b6323080e4) perlPackages.HTTPDaemon: 6.01 -> 6.14
* [`dd6f2768`](https://github.com/NixOS/nixpkgs/commit/dd6f2768b17f7d81ee2398ca7b1cb789534778f2) git: 2.37.0 -> 2.37.1
* [`b4a0bdcf`](https://github.com/NixOS/nixpkgs/commit/b4a0bdcf924ee4ab02954493cfeca44b8edf8b17) rpm: compile --with-cap
* [`ee63b2cd`](https://github.com/NixOS/nixpkgs/commit/ee63b2cd5ff502818db1547a90b9dfe957d61013) steampipe: 0.15.0 -> 0.15.3
* [`4ec68389`](https://github.com/NixOS/nixpkgs/commit/4ec68389db085461debb5739600d009d22b4cf77) feishu: misc updates
* [`41bf342f`](https://github.com/NixOS/nixpkgs/commit/41bf342f0ae0286c8fc0a0d8a36af5f9f49630df) unzip: fix symlink unpacking issues on larger zips
* [`9aebffaa`](https://github.com/NixOS/nixpkgs/commit/9aebffaaa00d63454cb6ff82b5b61dd8f0988f9a) maintainers: add keksbg
* [`b47afc34`](https://github.com/NixOS/nixpkgs/commit/b47afc347d60a2819e0db0c4335e337c91aa0df5) perlPackages.HTTPDaemon: Patch for CVE-2022-3108
* [`8dc07687`](https://github.com/NixOS/nixpkgs/commit/8dc0768762dd87c6836807b5969cd17be8816887) git: don't doInstallCheck on darwin by default
* [`922bb560`](https://github.com/NixOS/nixpkgs/commit/922bb56029fdee1ae004e006a59e05c32e49bd91) glusterfs: patch around SSL_CERT_PATH detection
* [`c7433084`](https://github.com/NixOS/nixpkgs/commit/c74330843816fb834f2cf2cd3c24b2d065625c7e) llvm14: Skip broken tests on riscv
* [`0a94d610`](https://github.com/NixOS/nixpkgs/commit/0a94d61013616c1ea498a4b3536c627f00af32f5) python3Packages.rdkit: 2022.03.3 -> 2022.03.4
* [`604a88a7`](https://github.com/NixOS/nixpkgs/commit/604a88a787cc260b6a8908b46d1607943c8fc9d7) wf-recorder: Remove myself and CrazedProgrammer as maintainers
* [`0793afce`](https://github.com/NixOS/nixpkgs/commit/0793afce9e7ef30036ac635b86f829cac9c90c23) mesa: 22.1.3 -> 22.1.4
* [`367bae1a`](https://github.com/NixOS/nixpkgs/commit/367bae1a8c4176205742afd9071b7f3d0e80bcb3) stellarium: 0.22.1 → 0.22.2
* [`4a5bc261`](https://github.com/NixOS/nixpkgs/commit/4a5bc261380ec592ebe9c98a40ad5b865b991849) kdiskmark: cleanup meta
* [`036ed9b9`](https://github.com/NixOS/nixpkgs/commit/036ed9b9f1fdb28a87017f5bc6c6e5c64786391b) libdecor: add missing dep egl (fix cross-compile)
* [`643c7249`](https://github.com/NixOS/nixpkgs/commit/643c72495e46c7f71fbb6a3a58359b1bc33c40c5) boehmgc: refactor
* [`50fcf971`](https://github.com/NixOS/nixpkgs/commit/50fcf9717c8de6ebb7cd35ed2b14623333609122) aws-sam-cli: 1.52.0 -> 1.53.0
* [`a14d1a2e`](https://github.com/NixOS/nixpkgs/commit/a14d1a2e7e8c19087897bc646a37f50096b736b1) systemd: 250.4 -> 251.3
* [`b70dc26a`](https://github.com/NixOS/nixpkgs/commit/b70dc26a77310460265fea16b8ced6c9b74b8241) libnotify: 0.7.12 → 0.8.1
* [`20a92ba9`](https://github.com/NixOS/nixpkgs/commit/20a92ba9c556f22c9dfe37130f42b49ac635fc4f) xf86_input_wacom: 1.0.0 -> 1.1.0
* [`f25dd500`](https://github.com/NixOS/nixpkgs/commit/f25dd50085bb7d76550e092546d92c3bafa5b0f8) Update doc/builders/fetchers.chapter.md
* [`769956d6`](https://github.com/NixOS/nixpkgs/commit/769956d65b185471b2214441731528122e9f0a6c) gcc: drop outdated sed for system headers clobber
* [`052d5fae`](https://github.com/NixOS/nixpkgs/commit/052d5faec31031f8c532ab9731c7914bc8a40e49) signalbackup-tools: 20220526 -> 20220711
* [`0fa69e9e`](https://github.com/NixOS/nixpkgs/commit/0fa69e9e78f2682db2657ec77da3c00b8e7b40db) maintainers: add desttinghim
* [`1c44717f`](https://github.com/NixOS/nixpkgs/commit/1c44717f11ce05c1a41efcab161fc526d41b4cf9) httm: 0.12.2 -> 0.13.4
* [`61b0cd2d`](https://github.com/NixOS/nixpkgs/commit/61b0cd2d13e5a88ea175f762212d24246f3b4ebc) mopidy-bandcamp init at 1.1.5
* [`99fb9abf`](https://github.com/NixOS/nixpkgs/commit/99fb9abfaae6d37b28005ffe0ba5ed8349d09127) bedops: 2.4.40 -> 2.4.41
* [`9c6b1fbc`](https://github.com/NixOS/nixpkgs/commit/9c6b1fbce39382b152f068f364af85dad96b7eab) grpc: 1.47.0 -> 1.48.0
* [`bb5955f5`](https://github.com/NixOS/nixpkgs/commit/bb5955f59abf49b3356432bccdf5a4ec6299cd95) maintainers: add squarepear
* [`314446ff`](https://github.com/NixOS/nixpkgs/commit/314446ff5ded65293053fabe93e1bc3814c8d588) sioyek: 1.2.0 -> 1.4.0
* [`3cc2fa21`](https://github.com/NixOS/nixpkgs/commit/3cc2fa21dcc7a3e8f60966168a2d23a61c27bdd3) electrum-ltc: 4.0.9.3 -> 4.2.2.1
* [`e11279e9`](https://github.com/NixOS/nixpkgs/commit/e11279e9629b7bce7839dfc07778774b61ab452d) openldap: 2.6.2 -> 2.6.3
* [`47e2cadf`](https://github.com/NixOS/nixpkgs/commit/47e2cadfa1e04d7018652b0a7be8b58e643403e1) perlPackages.Mojolicious: 9.19 -> 9.26
* [`c6a404c7`](https://github.com/NixOS/nixpkgs/commit/c6a404c7e217d27beb4eaa22ed1b26fb91e8daad) perlPackages.MojoliciousPluginSyslog: 0.05 -> 0.06
* [`5de8c6b0`](https://github.com/NixOS/nixpkgs/commit/5de8c6b05503e412e9cf6a9c652e2a80b4dda999) perlPackages.Mojomysql: 1.20 -> 1.25
* [`a586fbb7`](https://github.com/NixOS/nixpkgs/commit/a586fbb7d2af73832221c00d3a89017c040a087d) perlPackages.MojoPg: 4.22 -> 4.27
* [`37adafce`](https://github.com/NixOS/nixpkgs/commit/37adafce313646005933421cd14a282951909c06) perlPackages.JSONValidator: 4.16 -> 5.08
* [`1fb7198d`](https://github.com/NixOS/nixpkgs/commit/1fb7198d868fdd2330030f153c3ed57094926ecc) perlPackages.MojoliciousPluginOpenAPI: 4.02 -> 5.05
* [`23504a5b`](https://github.com/NixOS/nixpkgs/commit/23504a5b7aaa0f2c059a6bde4de7a6e5b76380ba) perlPackages.Minion: 10.14 -> 10.25
* [`33f153db`](https://github.com/NixOS/nixpkgs/commit/33f153db807fa77bc7da245d6c2de9df209803de) perlPackages.MinionBackendSQLite: 5.0.4 -> 5.0.6
* [`27b68fc2`](https://github.com/NixOS/nixpkgs/commit/27b68fc26a8616857de882096ae04be4b3a0a94c) perlPackages.MinionBackendmysql: 0.21 -> 1.000
* [`988915a1`](https://github.com/NixOS/nixpkgs/commit/988915a17d9743b8c9fb0458c5a1a20ba885daba) perlPackages.SQLAbstractPg: init at 1.0
* [`6c165096`](https://github.com/NixOS/nixpkgs/commit/6c1650969d4cecdc39e56f8df9629a7722ca07f1) perlPackages.SQLAbstract: 1.87 -> 2.000001
* [`ae5eb1ac`](https://github.com/NixOS/nixpkgs/commit/ae5eb1acbe96bfcc0fa519045d0ff8b3fbaf83dc) perlPackages.YAMLLibYAML: 0.82 -> 0.83
* [`188403c7`](https://github.com/NixOS/nixpkgs/commit/188403c7f1432c1c17bfbeed2f381af415bf380b) perlPackages.OpenAPIClient: 1.00 -> 1.04
* [`369bd2a9`](https://github.com/NixOS/nixpkgs/commit/369bd2a93a6f04af5ed98d4e5bf8289b0435d8de) perlPackages.MojoUserAgentCached: 1.16 -> 1.19
* [`bfaae5a6`](https://github.com/NixOS/nixpkgs/commit/bfaae5a65df6610e15ce8af05895746062fe35d8) perlPackages.MojoRedis: 3.25 -> 3.29
* [`82e8ace0`](https://github.com/NixOS/nixpkgs/commit/82e8ace090c5ec81cee527687b7fda2f7271f8cf) perlPackages.MojoIOLoopForkCall: 0.20 -> 0.21
* [`c14ede52`](https://github.com/NixOS/nixpkgs/commit/c14ede52e0b09db74f0e192c86019eeff97ec179) perlPackages.SQLAbstractLimit: 0.142 -> 0.143
* [`530cb82b`](https://github.com/NixOS/nixpkgs/commit/530cb82b7fd06851c9404deeaa67428ec0d7add1) perlPackages.DBDMariaDB: 1.21 -> 1.22
* [`59dca5cc`](https://github.com/NixOS/nixpkgs/commit/59dca5cc57720cb54622f5dc57967b630d9e9372) mlc: 3.9 -> 3.9a
* [`032d0b3a`](https://github.com/NixOS/nixpkgs/commit/032d0b3a3c1aa003640d9ee2e81f673c0487c08e) python310Packages.fastavro: 1.5.2 -> 1.5.3
* [`8bf97d63`](https://github.com/NixOS/nixpkgs/commit/8bf97d639d8e637098047424d67356d75a407423) rustc: 1.62.0 -> 1.62.1 ([nixos/nixpkgs⁠#182140](https://togithub.com/nixos/nixpkgs/issues/182140))
* [`719e3504`](https://github.com/NixOS/nixpkgs/commit/719e350414e6a4f4ac0ee6a19e79cceac82b3313) pixman: Limit threads
* [`b9962699`](https://github.com/NixOS/nixpkgs/commit/b9962699889e8b61df146edc76d9f740382c8d58) nixos/doc: don't advise to build master
* [`b390eb96`](https://github.com/NixOS/nixpkgs/commit/b390eb96c268da8057863fe31903e4dafa57ed01) bzip2: fix hardcoded version
* [`940b020f`](https://github.com/NixOS/nixpkgs/commit/940b020fe73f1882163060e90300bc46732f19f9) qtbase: Fix build for aarch64-darwin
* [`3c7cb614`](https://github.com/NixOS/nixpkgs/commit/3c7cb614f11ff6ecb7e840e57e33437bcea4385e) visidata: add runtime dependency of clipboard commands
* [`34b92568`](https://github.com/NixOS/nixpkgs/commit/34b92568d1dead83fef0a2e6bc6f466e9ba8cfae) glibc: remove obsolete configure option
* [`8f3c8aee`](https://github.com/NixOS/nixpkgs/commit/8f3c8aee8adfceab3730367e400ccbb8d9d835ce) glibc: explicitly enable stack-protector
* [`1487fabf`](https://github.com/NixOS/nixpkgs/commit/1487fabf6091f169a4d70b5cf4dd3b89072aec1f) glibc: enable Intel CET on x86
* [`229ecd4b`](https://github.com/NixOS/nixpkgs/commit/229ecd4bbc6f739578d9fc1ec4ed0ea1ceb74397) systemd: update substituteInPlace to restore cross
* [`bbe8931b`](https://github.com/NixOS/nixpkgs/commit/bbe8931b36199d505042195cc86b24a7d776f78a) pipewire: 0.3.55 -> 0.3.56
* [`1f7ab584`](https://github.com/NixOS/nixpkgs/commit/1f7ab584cf86c10466c35046f4880a388f8dcf21) ocamlPackages.metrics: 0.2.0 → 0.4.0
* [`69c108fd`](https://github.com/NixOS/nixpkgs/commit/69c108fd354aff0a1529af1faf63ad35c8705bf7) checkSSLCert: 2.34.0 -> 2.35.0
* [`f9881742`](https://github.com/NixOS/nixpkgs/commit/f9881742e3f07dc4eab79ed050e19166f92159e4) mavproxy: 1.8.50 -> 1.8.52
* [`9910ecd6`](https://github.com/NixOS/nixpkgs/commit/9910ecd692368bc7edfd3bd6d0495e878a3a957c) srcml: remove
* [`ddf8182d`](https://github.com/NixOS/nixpkgs/commit/ddf8182d5be8bcd275cfd102fff265547102fc9a) sshd: Don't remove symlinks to host key files
* [`bff5824e`](https://github.com/NixOS/nixpkgs/commit/bff5824e32b934aa3766e23ce389b1490976cde9) python310Packages.frozendict: 2.3.1 -> 2.3.3
* [`1197a69e`](https://github.com/NixOS/nixpkgs/commit/1197a69edfd27c8fab83ea3d4408f1e13b504248) python3Packages.setuptools: 61.2.0 -> 63.2.0
* [`ef671f9b`](https://github.com/NixOS/nixpkgs/commit/ef671f9b3b20361e9e40e219df112ec8347f104c) python3Packages.setuptools-rust: 1.3.0 -> 1.4.1
* [`9e68ab7b`](https://github.com/NixOS/nixpkgs/commit/9e68ab7b83d76635fb39fb38653990670853a921) python3Packages.docutils: 0.18.1 -> 0.19
* [`f5a52761`](https://github.com/NixOS/nixpkgs/commit/f5a52761724eaf521f0e2c0ba7a482dcd9f4a621) python3Packages.pytest: 7.1.1 -> 7.1.2
* [`fe126704`](https://github.com/NixOS/nixpkgs/commit/fe12670469e6a22fbc284d25a8636c12e655c7a7) python3Packages.pytest: extract test into passthru
* [`2742ea65`](https://github.com/NixOS/nixpkgs/commit/2742ea65c666c3b0abdc3b70f2dbe9760bb5a56c) python3Packages.pytest-asyncio: extract tests into passthru
* [`d516874a`](https://github.com/NixOS/nixpkgs/commit/d516874a41b502f295ed0c17c1e35c5b5b7df3c1) python3Packages.hypothesis: 6.46.10 -> 6.50.1
* [`dab5a2ca`](https://github.com/NixOS/nixpkgs/commit/dab5a2ca786d2ef5c0d35e4c628db42f86da8d8e) python3Packages.pytest-mock: 3.8.1 -> 3.8.2
* [`a93740e9`](https://github.com/NixOS/nixpkgs/commit/a93740e9ba0a211e35fd19ef6aed8516799ab0b6) python3Packages.numpy: 1.21.6 -> 1.23.1
* [`09943a0c`](https://github.com/NixOS/nixpkgs/commit/09943a0c2cf054a3455a11e79da3fcd43861d5a0) python3Packages.scipy: 1.8.0 -> 1.8.1
* [`41b3e0bf`](https://github.com/NixOS/nixpkgs/commit/41b3e0bf31c49bc1bfcc5fd77e6d255f32114ee9) python3Packages.m2r: patch docutils 0.19 compat
* [`27668c57`](https://github.com/NixOS/nixpkgs/commit/27668c5709f8e68760f521c0d91943dafeeea939) python3Packages.scikit-learn: 1.0.2 -> 1.1.1
* [`599d078a`](https://github.com/NixOS/nixpkgs/commit/599d078a2866dd2b48ad64d74f49c90e5e245275) python3Packages.pandas: 1.4.2 -> 1.4.3
* [`b9a02149`](https://github.com/NixOS/nixpkgs/commit/b9a02149bb76b475f572c767e781d65988d025ce) python3Packages.astroid: 2.11.5 -> 2.11.7
* [`c01db367`](https://github.com/NixOS/nixpkgs/commit/c01db367136472469fe93c910626b6f8b6d6a69b) python3Packages.pylint: 2.14.1 -> 2.14.4
* [`96a1286e`](https://github.com/NixOS/nixpkgs/commit/96a1286ea8a0edf0955367d346f4a70d505be6a5) python3Packages.cryptography: 37.0.2 -> 37.0.4
* [`b628b6ef`](https://github.com/NixOS/nixpkgs/commit/b628b6efac94233621a6b2907666cccac9cb3fed) python310Packages.uvicorn: 0.17.6 -> 0.18.1
* [`eb09880c`](https://github.com/NixOS/nixpkgs/commit/eb09880cbb8798ed7105adc03d11118e519225e2) platformio: relax uvicorn
* [`968ff229`](https://github.com/NixOS/nixpkgs/commit/968ff229bd32fac67aca88aa4051613a79ca91a1) python310Packages.uvicorn: 0.18.1 -> 0.18.2
* [`5f413aa5`](https://github.com/NixOS/nixpkgs/commit/5f413aa5807b95954ef9237f297954b2cb978606) awsebcli: drop requests override, relax constraint
* [`bc63ba0d`](https://github.com/NixOS/nixpkgs/commit/bc63ba0d5ab45652a67dafbd4ed3c39fd5d0db7c) python310Packages.flask: 2.1.2 -> 2.1.3
* [`af6f861b`](https://github.com/NixOS/nixpkgs/commit/af6f861b8eaac59b6607cb53f7a955a7f1d04a05) python3Packages.traitlets: 5.1.1 -> 5.3.0
* [`c9589a96`](https://github.com/NixOS/nixpkgs/commit/c9589a96eedc19c6db1aabd1c6a9d934aaf41f1e) python3Packages.nbclient: 0.6.3 -> 0.6.6
* [`9e8501bd`](https://github.com/NixOS/nixpkgs/commit/9e8501bd82bc0312eb88893d12b8f27901c86a18) python3Packages.semantic-version: 2.9.0 -> 2.10.0
* [`d07b2d20`](https://github.com/NixOS/nixpkgs/commit/d07b2d20dd54dd33c828cc5a80d1160a3b6a9c61) cheroot: remove pyopenssl dep
* [`3cfff64a`](https://github.com/NixOS/nixpkgs/commit/3cfff64a5809f11b71418f11930a713603051160) cherrypy: remove pyopenssl dep
* [`259be5e9`](https://github.com/NixOS/nixpkgs/commit/259be5e98495b3ffcda862625e5901d2c8f5a559) httpretty: remove unused check deps and use pytest
* [`05ccfd2c`](https://github.com/NixOS/nixpkgs/commit/05ccfd2c53826937700316ff7ddaf8924cc4eb16) requests-toolbelt: remove pyopenssl dep
* [`0e0fdbef`](https://github.com/NixOS/nixpkgs/commit/0e0fdbef578ab307b94e04afadecddacf843153c) vscode-extensions.ms-python.python: 2022.0.1814523869 -> 2022.11.11881005
* [`ca32f878`](https://github.com/NixOS/nixpkgs/commit/ca32f8782e75c86a01a23d36bdd26e0cbefb0933) python310Packages.rich: 12.4.4 -> 12.5.1
* [`a6f32052`](https://github.com/NixOS/nixpkgs/commit/a6f320529ce6c0a70b67e49a8cf286d028883483) python310Packages.jsonschema: 4.6.1 -> 4.7.2
* [`a21497ad`](https://github.com/NixOS/nixpkgs/commit/a21497ad68c0920f89b8018addad5b85c0f3e34a) python3Packages.absl-py: 1.0.0 -> 1.1.0
* [`da0b2a52`](https://github.com/NixOS/nixpkgs/commit/da0b2a52924c866e7f7a4cc6b5106c3000b0fb82) python3Packages.acoustics: 0.2.4.post0 -> 0.2.6
* [`c79efddf`](https://github.com/NixOS/nixpkgs/commit/c79efddf40b4a1a53de0f04ee8158966e2f9f3aa) python3Packages.aiohomekit: 0.7.20 -> 1.1.0
* [`8afd6cd6`](https://github.com/NixOS/nixpkgs/commit/8afd6cd6e822f0b0d5a9ee1eae314db16d19d16f) python3Packages.aiounittest: 1.4.1 -> 1.4.2
* [`cbcac3a1`](https://github.com/NixOS/nixpkgs/commit/cbcac3a1a2536b6811413c96fae8fba2fd18d9a4) python3Packages.alembic: 1.7.7 -> 1.8.1
* [`fc76fdd0`](https://github.com/NixOS/nixpkgs/commit/fc76fdd0f378b48bceba18b5af2a2ef6c5b3a8b6) python3Packages.amazon-ion: 0.9.1 -> 0.9.2
* [`94244738`](https://github.com/NixOS/nixpkgs/commit/94244738319fca5077616115b32a433d53ca5e25) python3Packages.ansi2html: 1.7.0 -> 1.8.0
* [`030dc026`](https://github.com/NixOS/nixpkgs/commit/030dc026e832c1e14ba98844ae83670962b0079f) python3Packages.ansible-doctor: 1.4.0 -> 1.4.1
* [`65904b4f`](https://github.com/NixOS/nixpkgs/commit/65904b4f7ed4d08888c0ac14691ee4c899687e63) python3Packages.ansible-later: 2.0.14 -> 2.0.16
* [`7c5b1084`](https://github.com/NixOS/nixpkgs/commit/7c5b10841f0d714bbe63cadd7945a869e00e2c78) python3Packages.ansible-runner: 2.1.3 -> 2.2.1
* [`5c46e00e`](https://github.com/NixOS/nixpkgs/commit/5c46e00eb7d89e26b17d68dae268a20c1d9aa076) python3Packages.anyascii: 0.3.0 -> 0.3.1
* [`a7098964`](https://github.com/NixOS/nixpkgs/commit/a70989643dc4071bad529c538ba4ee06f4f461e4) python3Packages.apache-airflow: 2.2.4 -> 2.3.3
* [`3bfa89f8`](https://github.com/NixOS/nixpkgs/commit/3bfa89f878a5011a2f664d9d8f5360fb16ff0c0f) python3Packages.apipkg: 2.1.1 -> 3.0.1
* [`dab05809`](https://github.com/NixOS/nixpkgs/commit/dab05809030737be12ab919fd500cc6a65c120e8) python3Packages.appnope: 0.1.2 -> 0.1.3
* [`25252743`](https://github.com/NixOS/nixpkgs/commit/252527436da8ee36dd06e096e1e28eca93a0ebe6) python3Packages.apsw: 3.38.1-r1 -> 3.38.5-r1
* [`75354a0e`](https://github.com/NixOS/nixpkgs/commit/75354a0e9e3de3df6ca6067c5400a3247dbaf33f) python3Packages.astropy: 5.0.3 -> 5.1
* [`d94ac1de`](https://github.com/NixOS/nixpkgs/commit/d94ac1de1cca662a87af2dbb1170c25ca068208a) python3Packages.asyncpg: 0.25.0 -> 0.26.0
* [`479ff1e9`](https://github.com/NixOS/nixpkgs/commit/479ff1e9d5df00c3268abe0b2b197d3470a2afec) python3Packages.atenpdu: 0.3.3 -> 0.3.4
* [`4abaa07e`](https://github.com/NixOS/nixpkgs/commit/4abaa07e13ae746a77efe54f7aa935df1c71cbe8) python3Packages.atomicwrites: 1.4.0 -> 1.4.1
* [`3dec3ae3`](https://github.com/NixOS/nixpkgs/commit/3dec3ae3c756c2b0fcdd29294e77bbfb1c903064) python3Packages.auth0-python: 3.22.0 -> 3.23.1
* [`44733cf0`](https://github.com/NixOS/nixpkgs/commit/44733cf01c6d27425ed7aa58121fc5fe3d3cf17c) python3Packages.authlib: 0.15.5 -> 1.0.1
* [`2e5f80c6`](https://github.com/NixOS/nixpkgs/commit/2e5f80c6f856269286eafcc2173dee478282c363) python3Packages.autobahn: 22.5.1 -> 22.6.1
* [`0e92dced`](https://github.com/NixOS/nixpkgs/commit/0e92dcedcefaf73d53e66ccd06eee329018688bb) python3Packages.awscrt: 0.13.13 -> 0.13.14
* [`0b7ef2dc`](https://github.com/NixOS/nixpkgs/commit/0b7ef2dcbd6db3b6a9b7aefaa8e9fabd4efab677) python3Packages.aws-sam-translator: 1.46.0 -> 1.47.0
* [`42389b38`](https://github.com/NixOS/nixpkgs/commit/42389b3827853ff283e869ff003abbadebb1f8c6) python3Packages.aws-xray-sdk: 2.9.0 -> 2.10.0
* [`a4d9a186`](https://github.com/NixOS/nixpkgs/commit/a4d9a1867c72335974505af5528bc54a991a1478) python3Packages.azure-mgmt-appconfiguration: 2.0.0 -> 2.1.0
* [`cd58438d`](https://github.com/NixOS/nixpkgs/commit/cd58438d1067ff77f221bccde48e2f5fc0cdf1bb) python3Packages.azure-mgmt-compute: 27.1.0 -> 27.2.0
* [`6bc4b574`](https://github.com/NixOS/nixpkgs/commit/6bc4b5745273d03fa75f7d7ca2485cf1fbd63341) python3Packages.azure-mgmt-consumption: 9.0.0 -> 10.0.0
* [`c6a86180`](https://github.com/NixOS/nixpkgs/commit/c6a86180e5f2613178c6513646f4dac66ebfae05) python3Packages.azure-mgmt-core: 1.3.0 -> 1.3.1
* [`d0178e5b`](https://github.com/NixOS/nixpkgs/commit/d0178e5bf9b55c8192a457f6294971aa6a1f50e1) python3Packages.azure-mgmt-datafactory: 2.6.0 -> 2.7.0
* [`717a0f1a`](https://github.com/NixOS/nixpkgs/commit/717a0f1a7fabd251ea2d9d353c7aa95b3656ee55) python3Packages.azure-mgmt-extendedlocation: 1.0.0 -> 1.1.0
* [`16b65004`](https://github.com/NixOS/nixpkgs/commit/16b650042445106ac2d2014a813daefed302a2bf) python3Packages.azure-mgmt-imagebuilder: 1.0.0 -> 1.1.0
* [`9b292eb5`](https://github.com/NixOS/nixpkgs/commit/9b292eb50de20bf89fa21632b4518ee367d688cf) python3Packages.azure-mgmt-media: 9.0.0 -> 10.0.0
* [`64582d0d`](https://github.com/NixOS/nixpkgs/commit/64582d0d9d560c95138e3ad1f434f46336f4d0b6) python3Packages.azure-mgmt-msi: 6.0.1 -> 6.1.0
* [`23a1652a`](https://github.com/NixOS/nixpkgs/commit/23a1652a3da61630be06fdb4b7585beaa465c930) python3Packages.azure-mgmt-web: 6.1.0 -> 7.0.0
* [`ddea8709`](https://github.com/NixOS/nixpkgs/commit/ddea87095e9b7b2137985579f84cd93c9175b166) python3Packages.b2sdk: 1.14.1 -> 1.17.3
* [`a82e28f1`](https://github.com/NixOS/nixpkgs/commit/a82e28f1b5a6f761645da122235d2298b80257ee) python3Packages.backoff: 1.11.1 -> 2.1.2
* [`48cf8c5d`](https://github.com/NixOS/nixpkgs/commit/48cf8c5d514230814f652bef224a6a68f7261c8f) python3Packages.basemap: 1.3.2 -> 1.3.3
* [`3e4bcc32`](https://github.com/NixOS/nixpkgs/commit/3e4bcc32fb70b092bb76e2a027dc35f96126f862) python3Packages.bcrypt: 3.2.0 -> 3.2.2
* [`6a74fee0`](https://github.com/NixOS/nixpkgs/commit/6a74fee081eb9eb4d3c2a24391c5925b213ce419) python3Packages.bibtexparser: 1.2.0 -> 1.3.0
* [`3805f963`](https://github.com/NixOS/nixpkgs/commit/3805f9638c105ec5ba6d257d60062105c13dc0dd) python3Packages.bids-validator: 1.9.3 -> 1.9.5
* [`2e63bb9c`](https://github.com/NixOS/nixpkgs/commit/2e63bb9ccbd20eeab2682b913fcb79a16edabcc8) python3Packages.biliass: 1.3.4 -> 1.3.5
* [`755bd2cb`](https://github.com/NixOS/nixpkgs/commit/755bd2cbc7673c1b8b795fb55a9ee93922e13c08) python3Packages.billiard: 3.6.4.0 -> 4.0.0
* [`3b6abb97`](https://github.com/NixOS/nixpkgs/commit/3b6abb970583ed4dab0dc3be36b13181da8be46a) python3Packages.bimmer-connected: 0.10.0 -> 0.10.1
* [`29629b3b`](https://github.com/NixOS/nixpkgs/commit/29629b3b066e69a825df178c7b7d37d45824622f) python3Packages.bip_utils: 2.2.1 -> 2.5.1
* [`e49bca53`](https://github.com/NixOS/nixpkgs/commit/e49bca53bc699946adc47316cfeff6441e5c0096) python3Packages.bitstruct: 8.14.1 -> 8.15.1
* [`69f29168`](https://github.com/NixOS/nixpkgs/commit/69f29168566d62d611bb04ab1604266b94200045) python3Packages.bleach: 5.0.0 -> 5.0.1
* [`4246b8e0`](https://github.com/NixOS/nixpkgs/commit/4246b8e0c7047cbe52670b63c117eb5d99e4d4d2) python3Packages.blebox-uniapi: 1.3.3 -> 2.0.2
* [`11b17f45`](https://github.com/NixOS/nixpkgs/commit/11b17f457275afe44d56f7afef96c3c4c0885c18) python3Packages.blis: 0.7.7 -> 0.9.0
* [`196c5a36`](https://github.com/NixOS/nixpkgs/commit/196c5a36cd3fc92ff7352f65424afdefb53b8a54) python3Packages.bokeh: 2.4.2 -> 2.4.3
* [`5f02b3ec`](https://github.com/NixOS/nixpkgs/commit/5f02b3ece85ac811276693953de47329b3229828) python3Packages.boltztrap2: 22.4.1 -> 22.6.1
* [`58722010`](https://github.com/NixOS/nixpkgs/commit/587220102b9515790266e21c5c94888de7ed76a7) python3Packages.boto3: 1.21.30 -> 1.24.31
* [`214c58cb`](https://github.com/NixOS/nixpkgs/commit/214c58cb4fff25801fabd63d7d79a8d1a18a998c) python3Packages.botocore: 1.24.33 -> 1.27.31
* [`6957d6c4`](https://github.com/NixOS/nixpkgs/commit/6957d6c40735c710e1fa182d8d334f083d75625c) python3Packages.branca: 0.4.2 -> 0.5.0
* [`fb0720df`](https://github.com/NixOS/nixpkgs/commit/fb0720dfa324e62f44b731148cdc776395f9e4a4) python3Packages.carbon: 1.1.8 -> 1.1.10
* [`d1a37454`](https://github.com/NixOS/nixpkgs/commit/d1a374548c0e4e55981729a3eb1440c693dcdab0) python3Packages.catalogue: 2.0.7 -> 2.1.0
* [`4fc678a1`](https://github.com/NixOS/nixpkgs/commit/4fc678a1499f9d0291ec02cc3b76fbf948f54b37) python3Packages.cffi: 1.15.0 -> 1.15.1
* [`ba4bed6b`](https://github.com/NixOS/nixpkgs/commit/ba4bed6b8c58392d5e7cce0d9916a8c665374c56) python3Packages.cfn-lint: 0.58.2 -> 0.61.2
* [`ca5112ce`](https://github.com/NixOS/nixpkgs/commit/ca5112ceff69441243a7f8f5fbfff054ee6b022f) python3Packages.chainer: 7.8.1 -> 7.8.1.post1
* [`4775efd1`](https://github.com/NixOS/nixpkgs/commit/4775efd1f48bd2df2e41aeea2b4137f6c2b51daf) python3Packages.chardet: 4.0.0 -> 5.0.0
* [`1d01cc39`](https://github.com/NixOS/nixpkgs/commit/1d01cc396d57b37e99463dc6c845ab77dc4f6cf8) python3Packages.charset-normalizer: 2.0.12 -> 2.1.0
* [`38b7c639`](https://github.com/NixOS/nixpkgs/commit/38b7c639b8729a05dff1e5f290ddd989717bb217) python3Packages.chart-studio: 5.6.0 -> 5.9.0
* [`7870a691`](https://github.com/NixOS/nixpkgs/commit/7870a6919d0f49aada6e4348938f6dbe6014b474) python3Packages.cherrypy: 18.6.1 -> 18.7.0
* [`78bd5e62`](https://github.com/NixOS/nixpkgs/commit/78bd5e627943e91eb6a84ceefcc50d3c9b1a9b09) python3Packages.chex: 0.1.2 -> 0.1.3
* [`3ef76211`](https://github.com/NixOS/nixpkgs/commit/3ef7621167df207d13fbe288b78cb9f8573bc465) python3Packages.chiapos: 1.0.9 -> 1.0.10
* [`851fb03f`](https://github.com/NixOS/nixpkgs/commit/851fb03ffe05ebc265dba4c233ca4ce7cfebee7d) python3Packages.cloudsmith-api: 1.42.3 -> 1.61.3
* [`830b0bd9`](https://github.com/NixOS/nixpkgs/commit/830b0bd9c23e6447e4daed581adfd9cfe44cfdf2) python3Packages.cma: 3.2.1 -> 3.2.2
* [`f72be338`](https://github.com/NixOS/nixpkgs/commit/f72be33834c26cc88137e75f4492c3e8d7b5ae7a) python3Packages.cmd2: 2.4.0 -> 2.4.2
* [`b6df93f2`](https://github.com/NixOS/nixpkgs/commit/b6df93f2ac849ac54a6c5855cb99f6af026bbb22) python3Packages.colorama: 0.4.4 -> 0.4.5
* [`aa7ae620`](https://github.com/NixOS/nixpkgs/commit/aa7ae6204a69f87c24167607d67735308e73ea7c) python3Packages.confluent-kafka: 1.8.2 -> 1.9.0
* [`cb9e7069`](https://github.com/NixOS/nixpkgs/commit/cb9e7069cfaf9089a01f69d1deb31767028723c8) python3Packages.coqui-trainer: 0.0.12 -> 0.0.13
* [`99930388`](https://github.com/NixOS/nixpkgs/commit/999303884625cc0cf2bb042b08c32102b854182f) python3Packages.coverage: 6.3.2 -> 6.4.2
* [`47a2e8da`](https://github.com/NixOS/nixpkgs/commit/47a2e8da9780e3958bf2d85c24d8d3a510c97bb8) python3Packages.crate: 0.26.0 -> 0.27.1
* [`7f952797`](https://github.com/NixOS/nixpkgs/commit/7f95279713329e051f0b1169616422071cad79d8) python3Packages.croniter: 1.3.4 -> 1.3.5
* [`ea92ebea`](https://github.com/NixOS/nixpkgs/commit/ea92ebea4d5f1d46d2d841e396d7b13e97d2a39d) python3Packages.cssselect2: 0.5.0 -> 0.6.0
* [`1a572725`](https://github.com/NixOS/nixpkgs/commit/1a57272550588c88c9732792e3937d58c7f0b791) python3Packages.cupy: 10.3.1 -> 10.6.0
* [`0201bcb6`](https://github.com/NixOS/nixpkgs/commit/0201bcb6c6345a93264ad9db3abca4b734b8cbd2) python3Packages.cx_Freeze: 6.10 -> 6.11.1
* [`b1aa3457`](https://github.com/NixOS/nixpkgs/commit/b1aa3457abc05bf5d6f1ef210ce1fd2a1687e960) python3Packages.cypherpunkpay: 1.0.15 -> 1.0.16
* [`63676d7c`](https://github.com/NixOS/nixpkgs/commit/63676d7caff1e1e7d6eb236a0678926a6f5d1b7e) python3Packages.cytoolz: 0.11.2 -> 0.12.0
* [`18bd313e`](https://github.com/NixOS/nixpkgs/commit/18bd313e88465f0f955624990120a661d6028b31) python3Packages.dask-gateway: 0.9.0 -> 2022.6.1
* [`a24423aa`](https://github.com/NixOS/nixpkgs/commit/a24423aa14dae91351201aac2c0c88584f4eaad3) python3Packages.dask-jobqueue: 0.7.3 -> 0.7.4
* [`5494a5a9`](https://github.com/NixOS/nixpkgs/commit/5494a5a9e69b4961be429eeb6fe678ce05ba64bf) python3Packages.databricks-cli: 0.16.4 -> 0.17.0
* [`7f9d2458`](https://github.com/NixOS/nixpkgs/commit/7f9d245894e08c457bcb1eba379ea8f91baaedf1) python3Packages.databricks-connect: 9.1.17 -> 10.4.6
* [`068bb5b0`](https://github.com/NixOS/nixpkgs/commit/068bb5b0f289138ce1e62748439366d0f0565304) python3Packages.datasets: 1.18.3 -> 2.3.2
* [`58ae8110`](https://github.com/NixOS/nixpkgs/commit/58ae81109bcd9673a819a831d274deedb2cb5a0e) python3Packages.ddt: 1.4.4 -> 1.5.0
* [`1edc56ac`](https://github.com/NixOS/nixpkgs/commit/1edc56aceef2aa77f5b70d471fd6d93bc97c69dc) python3Packages.debugpy: 1.6.0 -> 1.6.2
* [`2b016b02`](https://github.com/NixOS/nixpkgs/commit/2b016b02f6765f056aee0d81ee5a0f27da401263) python3Packages.dill: 0.3.4 -> 0.3.5.1
* [`8fc8d62b`](https://github.com/NixOS/nixpkgs/commit/8fc8d62be8dc22f143abb0f912e1000d01f30e86) python3Packages.distributed: 2022.5.2 -> 2022.7.0
* [`a3349806`](https://github.com/NixOS/nixpkgs/commit/a3349806df71afc18ff31b8c4ef8261449837e34) python3Packages.django_compressor: 3.1 -> 4.0
* [`f67697fd`](https://github.com/NixOS/nixpkgs/commit/f67697fd5137465706556d7a65363ddd3206d9a8) python3Packages.django-dynamic-preferences: 1.12.0 -> 1.13.0
* [`a8224fbb`](https://github.com/NixOS/nixpkgs/commit/a8224fbbe76cfd20866734c053828815aca9855a) python3Packages.django-environ: 0.8.1 -> 0.9.0
* [`cac26f05`](https://github.com/NixOS/nixpkgs/commit/cac26f05aab1839df2e3f66f5c38685efe1d62bd) python3Packages.django-haystack: 3.1.1 -> 3.2.1
* [`aa205afb`](https://github.com/NixOS/nixpkgs/commit/aa205afb137d14511638b2a68a2559e45d46e537) python3Packages.django-hijack: 3.2.0 -> 3.2.1
* [`ddefa1f4`](https://github.com/NixOS/nixpkgs/commit/ddefa1f49aa60d712e6ce0228d8cc97142041af5) python3Packages.django-maintenance-mode: 0.16.2 -> 0.16.3
* [`c0fa301b`](https://github.com/NixOS/nixpkgs/commit/c0fa301b00ece72f8cd14adcb26c287c31b7c45e) python3Packages.djangorestframework-simplejwt: 5.1.0 -> 5.2.0
* [`af41adb4`](https://github.com/NixOS/nixpkgs/commit/af41adb402ac95e80cd2ec29a75315f74a36af48) python3Packages.dogpile-cache: 1.1.7 -> 1.1.8
* [`70de5051`](https://github.com/NixOS/nixpkgs/commit/70de50515205151198a464af5a75b3f62eeb4ba6) python3Packages.doit: 0.35.0 -> 0.36.0
* [`99634fac`](https://github.com/NixOS/nixpkgs/commit/99634fac8473e64e676664a8b4745ab0fa921bd3) python3Packages.drf-yasg: 1.20.0 -> 1.21.0
* [`8f9af348`](https://github.com/NixOS/nixpkgs/commit/8f9af348e60548437265a1d5fbff74159d37e536) python3Packages.duckdb-engine: 0.1.11 -> 0.2.0
* [`c9a62edc`](https://github.com/NixOS/nixpkgs/commit/c9a62edcbbde06f3ec86bb60828434a5bb528d5a) python3Packages.dulwich: 0.20.44 -> 0.20.45
* [`f8219c95`](https://github.com/NixOS/nixpkgs/commit/f8219c956727c6fcc13d536641f13884d6cd5c6d) python3Packages.dvc-render: 0.0.7 -> 0.0.8
* [`44368f46`](https://github.com/NixOS/nixpkgs/commit/44368f46ca5405c5f13ca0b02aedb0781e9dfc01) python3Packages.dynalite-devices: 0.46 -> 0.47
* [`fcf9c148`](https://github.com/NixOS/nixpkgs/commit/fcf9c1489c4ddf3d92a6976af9ca8992573759ff) python3Packages.ecdsa: 0.17.0 -> 0.18.0
* [`eb35cbf7`](https://github.com/NixOS/nixpkgs/commit/eb35cbf79ad1048c5c7b7f9a07a0f178fadb92a4) python3Packages.email-validator: 1.1.3 -> 1.2.1
* [`3920fde6`](https://github.com/NixOS/nixpkgs/commit/3920fde6f0624bb9b6652f416b713d4528ef4434) python3Packages.emoji: 1.7.0 -> 2.0.0
* [`1b4c7443`](https://github.com/NixOS/nixpkgs/commit/1b4c744327c5d3538466b97d82c8b4895ebf37e3) python3Packages.epson-projector: 0.4.2 -> 0.4.6
* [`7fc1cf74`](https://github.com/NixOS/nixpkgs/commit/7fc1cf74c11575864bc75af2e39f92fc77671254) python3Packages.eradicate: 2.0.0 -> 2.1.0
* [`478d154a`](https://github.com/NixOS/nixpkgs/commit/478d154afb0c9e2b8e5a3f745d23b24109ef9ef4) python3Packages.ExifRead: 2.3.2 -> 3.0.0
* [`67257c62`](https://github.com/NixOS/nixpkgs/commit/67257c62f1c7bd14f92e3258cb670361490d83fd) python3Packages.faker: 13.3.4 -> 13.15.0
* [`7c0ea4f0`](https://github.com/NixOS/nixpkgs/commit/7c0ea4f0bc891832b2c1ecd90adc4baa2699ea68) python3Packages.filetype: 1.0.13 -> 1.1.0
* [`b742863f`](https://github.com/NixOS/nixpkgs/commit/b742863f127e71dcf6041dd0f98731aa7aeb0e45) python3Packages.findpython: 0.1.6 -> 0.2.0
* [`62dda1ad`](https://github.com/NixOS/nixpkgs/commit/62dda1ad7192cb3c2ebad1ddba92d096f7b5a1e9) python3Packages.flask-appbuilder: 4.0.0 -> 4.1.3
* [`5845ae79`](https://github.com/NixOS/nixpkgs/commit/5845ae797395332b89eff676fe4b6ffb0e54c6ba) python3Packages.Flask-Caching: 1.11.1 -> 2.0.0
* [`d9117fb8`](https://github.com/NixOS/nixpkgs/commit/d9117fb872c8c20998fadfc5464a4b0c67faf02e) python3Packages.flask-swagger-ui: 3.36.0 -> 4.11.1
* [`b23817c7`](https://github.com/NixOS/nixpkgs/commit/b23817c73145ae1dd7bae85f0dbd8df34d560ca2) python3Packages.flax: 0.4.1 -> 0.5.2
* [`f82a54ab`](https://github.com/NixOS/nixpkgs/commit/f82a54ab891eea15f9597053ac4fbf70241d507e) python3Packages.flower: 1.0.0 -> 1.1.0
* [`af193152`](https://github.com/NixOS/nixpkgs/commit/af1931527c67413c459ddaff8c43223a41be2039) python3Packages.fontmake: 3.3.0 -> 3.4.0
* [`8f557351`](https://github.com/NixOS/nixpkgs/commit/8f557351e903d4c7655c694b1c5dd8234a61c120) python3Packages.fonttools: 4.33.3 -> 4.34.4
* [`4b9c71f4`](https://github.com/NixOS/nixpkgs/commit/4b9c71f4a5c23360410f27c7573eb01a6e48ff11) python3Packages.frozendict: 2.3.1 -> 2.3.2
* [`94281bdb`](https://github.com/NixOS/nixpkgs/commit/94281bdbae705deca2a2cb72ff676f0a28198928) python3Packages.functorch: 0.1.1 -> 0.2.0
* [`e4973d04`](https://github.com/NixOS/nixpkgs/commit/e4973d047433ccc88017847b2154d8d0de19e405) python3Packages.generic: 1.0.1 -> 1.1.0
* [`8e174083`](https://github.com/NixOS/nixpkgs/commit/8e17408336ac978580c4ae5b90377c43d8cd214e) python3Packages.GeoAlchemy2: 0.11.1 -> 0.12.1
* [`6517a4f6`](https://github.com/NixOS/nixpkgs/commit/6517a4f6e48465b635dfd09de00a4716211fe557) python3Packages.geographiclib: 1.52 -> 2.0
* [`86e3bfe5`](https://github.com/NixOS/nixpkgs/commit/86e3bfe5f8d7e886a3ec01ad9945bdba8043d9e4) python3Packages.geventhttpclient: 1.5.3 -> 1.5.5
* [`ccb6e611`](https://github.com/NixOS/nixpkgs/commit/ccb6e6113cad920d089355606737bdec6b5eec77) python3Packages.gigalixir: 1.2.5 -> 1.2.6
* [`1cd71848`](https://github.com/NixOS/nixpkgs/commit/1cd71848df70be585dce211b7f86f506ce7e632f) python3Packages.glean-parser: 5.1.2 -> 6.1.1
* [`dc5131ef`](https://github.com/NixOS/nixpkgs/commit/dc5131ef10d3167bbb832ba7ef0a9f443e218637) python3Packages.glean-sdk: 44.0.0 -> 50.1.2
* [`112373c6`](https://github.com/NixOS/nixpkgs/commit/112373c620d6998c1665caef1d6f1afb0519ac30) python3Packages.glyphslib: 6.0.4 -> 6.0.6
* [`66894c07`](https://github.com/NixOS/nixpkgs/commit/66894c078b04678ad16be9bf4459fc0aa045f424) python3Packages.goobook: 3.5.1 -> 3.5.2
* [`ce29e81f`](https://github.com/NixOS/nixpkgs/commit/ce29e81fafb753d7627fd666e756f7b7d179781e) python3Packages.google-api-core: 2.8.1 -> 2.8.2
* [`c43a9fa0`](https://github.com/NixOS/nixpkgs/commit/c43a9fa0c3b2d3e302ca5d85e57b2bb20a76a16e) python3Packages.google-api-python-client: 2.42.0 -> 2.53.0
* [`47601eb4`](https://github.com/NixOS/nixpkgs/commit/47601eb438e2f73df74601bded2c027b2d35c7dd) python3Packages.googleapis-common-protos: 1.56.2 -> 1.56.4
* [`d75b4ed4`](https://github.com/NixOS/nixpkgs/commit/d75b4ed48a1477cdab55929d79ec176b3a623861) python3Packages.google-auth: 2.6.6 -> 2.9.1
* [`756a86d8`](https://github.com/NixOS/nixpkgs/commit/756a86d86ad512eeb33ac495774451423cecf935) python3Packages.google-auth-oauthlib: 0.5.1 -> 0.5.2
* [`be9d56e9`](https://github.com/NixOS/nixpkgs/commit/be9d56e99076756fa816d0637e686653fc58d76f) python3Packages.google-cloud-bigquery: 3.1.0 -> 3.2.0
* [`472f014a`](https://github.com/NixOS/nixpkgs/commit/472f014ac6d1bfbd487434162e9e06a26bcce683) python3Packages.google-cloud-core: 2.3.0 -> 2.3.1
* [`d03aa8d6`](https://github.com/NixOS/nixpkgs/commit/d03aa8d6108acbec77a98e11c60d3a79396f842a) python3Packages.google-cloud-datastore: 2.7.2 -> 2.8.0
* [`353b078a`](https://github.com/NixOS/nixpkgs/commit/353b078a3733a6b238e914e445ff6e7e733a88d3) python3Packages.google-cloud-iam: 2.6.2 -> 2.8.0
* [`7964e60f`](https://github.com/NixOS/nixpkgs/commit/7964e60fdf3250ba5c891b3f7c11f5c9d4c6c3f9) python3Packages.google-cloud-kms: 2.11.2 -> 2.12.0
* [`9505ee68`](https://github.com/NixOS/nixpkgs/commit/9505ee68a09bc8bc028c59524e6c2ef86ec00026) python3Packages.google-cloud-testutils: 1.3.1 -> 1.3.3
* [`3b8e5214`](https://github.com/NixOS/nixpkgs/commit/3b8e5214bef2c812c8d28a0d1787826a64b011ad) python3Packages.gql: 3.1.0 -> 3.4.0
* [`1f40a05b`](https://github.com/NixOS/nixpkgs/commit/1f40a05b389755e2e26eb8cd5624e1ad64fccdef) python3Packages.graphql-core: 3.2.0 -> 3.2.1
* [`cd6116b1`](https://github.com/NixOS/nixpkgs/commit/cd6116b1b9b05fed4a63e57a9c07c632ecff2838) python3Packages.green: 3.4.1 -> 3.4.2
* [`bb609c18`](https://github.com/NixOS/nixpkgs/commit/bb609c18817442d39a88edfbbef59cadd547b1dc) python3Packages.gridnet: 4.0.0 -> 4.1.0
* [`d7953986`](https://github.com/NixOS/nixpkgs/commit/d795398635a696f3168b1f7461637d51bf602a42) python3Packages.gruut: 2.2.3 -> 2.3.4
* [`ad25b703`](https://github.com/NixOS/nixpkgs/commit/ad25b70375176c61ead6769a56eedb67706033c3) python3Packages.h5py: 3.6.0 -> 3.7.0
* [`6180d22d`](https://github.com/NixOS/nixpkgs/commit/6180d22daa4e48a0080ba386ea0a023d952276f6) python3Packages.hap-python: 4.4.0 -> 4.5.0
* [`c3a1ca71`](https://github.com/NixOS/nixpkgs/commit/c3a1ca7151093a866771bf3ea453cd2c65d6c98d) python3Packages.hatchling: 1.0.0 -> 1.5.0
* [`cfd9bf14`](https://github.com/NixOS/nixpkgs/commit/cfd9bf147b43d27ee46a25d87620406201889a98) python3Packages.hiyapyco: 0.4.16 -> 0.5.0
* [`476d4431`](https://github.com/NixOS/nixpkgs/commit/476d443121c1fcb615f0bccbb70322faccf5d188) python3Packages.hydra: 1.1.1 -> 1.2.0
* [`beb251a1`](https://github.com/NixOS/nixpkgs/commit/beb251a1d00d46ed282ce7ad886c36bb5035721b) python3Packages.hyrule: 0.1 -> 0.2
* [`1896e87e`](https://github.com/NixOS/nixpkgs/commit/1896e87ea80d1406305e04f600b82c7ed612c178) python3Packages.ifaddr: 0.1.7 -> 0.2.0
* [`5fa9557d`](https://github.com/NixOS/nixpkgs/commit/5fa9557dec1e5ac33795f6c3d8d19d0792b510c3) python3Packages.ignite: 0.4.8 -> 0.4.9
* [`f4f6ce94`](https://github.com/NixOS/nixpkgs/commit/f4f6ce94c25b3db08978e43f3dd3cac9e225f396) python3Packages.imageio: 2.19.2 -> 2.19.3
* [`a9fb4452`](https://github.com/NixOS/nixpkgs/commit/a9fb44523578304d5588ca323a0ddcc385bf0d96) python3Packages.imageio-ffmpeg: 0.4.5 -> 0.4.7
* [`3ed4b8cf`](https://github.com/NixOS/nixpkgs/commit/3ed4b8cf78d163ff4a4d5d3943d587285e5e9b33) python3Packages.imagesize: 1.3.0 -> 1.4.1
* [`23c0e823`](https://github.com/NixOS/nixpkgs/commit/23c0e823b79d23aed2010207bb9fa84c05b440f8) python3Packages.imbalanced-learn: 0.9.0 -> 0.9.1
* [`fc49f363`](https://github.com/NixOS/nixpkgs/commit/fc49f363b32665d180ebccdff59570fa189f2fb4) python3Packages.imdbpy: 2021.4.18 -> 2022.7.9
* [`ce199e18`](https://github.com/NixOS/nixpkgs/commit/ce199e184981e5e3e7e11c128b8becf4dcc94ef6) python3Packages.importlib-metadata: 4.11.3 -> 4.12.0
* [`ffabc48c`](https://github.com/NixOS/nixpkgs/commit/ffabc48c30140192359760e63bc5d2c1da38540d) python3Packages.importlib-resources: 5.6.0 -> 5.8.0
* [`6f3b154c`](https://github.com/NixOS/nixpkgs/commit/6f3b154c0e8b399573898d6279b9ac863930b4c3) python3Packages.inflect: 5.4.0 -> 5.6.2
* [`095e6c4e`](https://github.com/NixOS/nixpkgs/commit/095e6c4e2b7fefc7bf718a50de7f6c7e3c2e8ede) python3Packages.influxdb-client: 1.27.0 -> 1.30.0
* [`9be24d49`](https://github.com/NixOS/nixpkgs/commit/9be24d492b18eb1bb2d89df1ff5d09b39a9c4e11) python3Packages.ipydatawidgets: 4.2.0 -> 4.3.1.post1
* [`df60e8e5`](https://github.com/NixOS/nixpkgs/commit/df60e8e592daa5f138e2805659ed43692ed7b3f6) python3Packages.ipykernel: 6.12.1 -> 6.15.1
* [`90967ab4`](https://github.com/NixOS/nixpkgs/commit/90967ab4f37ecd9c436c8116f2ec1f468259601a) python3Packages.ipyparallel: 8.2.1 -> 8.4.1
* [`96d86ea9`](https://github.com/NixOS/nixpkgs/commit/96d86ea9769160924efa558e5ee829afad381d26) python3Packages.ipywidgets: 7.7.0 -> 7.7.1
* [`f2869cd8`](https://github.com/NixOS/nixpkgs/commit/f2869cd8f4d0151920a4b06a8f8d73722516d1be) python3Packages.irc: 20.0.0 -> 20.1.0
* [`d3b07e48`](https://github.com/NixOS/nixpkgs/commit/d3b07e4801226bb74b86c127e2be1b0e09019e26) python3Packages.iterm2: 2.1 -> 2.6
* [`f1c11ecf`](https://github.com/NixOS/nixpkgs/commit/f1c11ecfc844bdf13841f890edb3d09891579a07) python3Packages.jaraco.collections: 3.5.1 -> 3.5.2
* [`23864b8f`](https://github.com/NixOS/nixpkgs/commit/23864b8f518c4103d47f32962d7ba155e6c02916) python3Packages.jaraco-context: 4.1.1 -> 4.1.2
* [`b484ec11`](https://github.com/NixOS/nixpkgs/commit/b484ec11043e0d7493f373bc490830e05879e444) python3Packages.jaraco.functools: 3.5.0 -> 3.5.1
* [`6a2ba659`](https://github.com/NixOS/nixpkgs/commit/6a2ba659cb1ae2e34a456e18ddbbb986029843a6) python3Packages.jaraco.text: 3.7.0 -> 3.8.1
* [`876b0840`](https://github.com/NixOS/nixpkgs/commit/876b0840955e6e917cc72625576b8bed888ba65b) python3Packages.jedi-language-server: 0.36.0 -> 0.36.1
* [`d439f928`](https://github.com/NixOS/nixpkgs/commit/d439f928dfd4815cb59790a0f87b2daa006b9206) python3Packages.jira: 3.1.1 -> 3.3.0
* [`73ad5788`](https://github.com/NixOS/nixpkgs/commit/73ad57882e2f5e37f2865ef1f049f4802950ec17) python3Packages.jmespath: 1.0.0 -> 1.0.1
* [`dd54aeed`](https://github.com/NixOS/nixpkgs/commit/dd54aeedabf97ccb63ce86e2b798e59ba3b65a99) python3Packages.JPype1: 1.3.0 -> 1.4.0
* [`f62bf073`](https://github.com/NixOS/nixpkgs/commit/f62bf073f49eaf5020edf14c82e70a1a5e7af81b) python3Packages.jsondiff: 1.3.1 -> 2.0.0
* [`a0fe49ef`](https://github.com/NixOS/nixpkgs/commit/a0fe49ef8736ede9e2749c54edec3bf923bd118c) python3Packages.jsonpickle: 2.1.0 -> 2.2.0
* [`62cfd1c6`](https://github.com/NixOS/nixpkgs/commit/62cfd1c65fb4785445e6302c493158695d5bbc46) python3Packages.jsonpointer: 2.2 -> 2.3
* [`dcd8af0f`](https://github.com/NixOS/nixpkgs/commit/dcd8af0f8b98a0e00cb0ee39ad9522fd940a323e) python3Packages.jug: 2.2.0 -> 2.2.1
* [`046ae7a6`](https://github.com/NixOS/nixpkgs/commit/046ae7a6874caca7abfdacc002bea703686f4471) python3Packages.jupyter_client: 7.2.1 -> 7.3.4
* [`9f75ab78`](https://github.com/NixOS/nixpkgs/commit/9f75ab78ea51b57182ab91bc5c47de52e63c2183) python3Packages.jupyter_console: 6.4.3 -> 6.4.4
* [`599a5b12`](https://github.com/NixOS/nixpkgs/commit/599a5b1295588bd861aff19732b5bd49d72807aa) python3Packages.jupyterlab-git: 0.36.0 -> 0.37.1
* [`861fd706`](https://github.com/NixOS/nixpkgs/commit/861fd706ff0971445c49ff6e0752c74655883b44) python3Packages.jupyterlab_server: 2.12.0 -> 2.15.0
* [`f5ad1e2f`](https://github.com/NixOS/nixpkgs/commit/f5ad1e2f57b3f7c16b1078e0271cd1ad64085858) python3Packages.jupyter-packaging: 0.12.0 -> 0.12.2
* [`f9f69a78`](https://github.com/NixOS/nixpkgs/commit/f9f69a783fd11ed0b6fcc5bd1723de821fd0736e) python3Packages.jupyter_server: 1.17.1 -> 1.18.1
* [`6ea7de3c`](https://github.com/NixOS/nixpkgs/commit/6ea7de3cf03f7b53b6a8ce7d1ec215a9f6e07bfe) python3Packages.jupyter-server-mathjax: 0.2.5 -> 0.2.6
* [`daac281f`](https://github.com/NixOS/nixpkgs/commit/daac281f4a2088f2168c7dcabd7fbb86e8c351fc) python3Packages.jupyter-sphinx: 0.3.2 -> 0.4.0
* [`94869f3b`](https://github.com/NixOS/nixpkgs/commit/94869f3b2ea52ee36a7d998659a52ae086027574) python3Packages.kajiki: 0.9.0 -> 0.9.1
* [`408b56de`](https://github.com/NixOS/nixpkgs/commit/408b56de38c7996650e93adb995086fb639aba3e) python3Packages.karton-dashboard: 1.2.1 -> 1.3.0
* [`212d0b76`](https://github.com/NixOS/nixpkgs/commit/212d0b767b5653bc129df23533b2fe385cd1f0c0) python3Packages.keras: 2.8.0 -> 2.9.0
* [`a6f10aab`](https://github.com/NixOS/nixpkgs/commit/a6f10aab441d59257506e376d0e0f2ea2acece6b) python3Packages.keyring: 23.6.0 -> 23.7.0
* [`dd9b2432`](https://github.com/NixOS/nixpkgs/commit/dd9b24328a515ac3b27f6c37aea64940ba037fb5) python3Packages.keyrings.alt: 4.1.0 -> 4.1.1
* [`934ca944`](https://github.com/NixOS/nixpkgs/commit/934ca944fe44f85c376d8d65b8a5d48efdaba607) python3Packages.keystoneauth1: 4.6.0 -> 5.0.0
* [`e4aa0ae3`](https://github.com/NixOS/nixpkgs/commit/e4aa0ae3f5ecec316081a895fda6f02c7f721e48) python3Packages.kiwisolver: 1.4.2 -> 1.4.4
* [`7aef4920`](https://github.com/NixOS/nixpkgs/commit/7aef49209f5d0b414f24e4bc0cd663561d3abf3b) python3Packages.labelbox: 3.15.0 -> 3.24.1
* [`e0db4289`](https://github.com/NixOS/nixpkgs/commit/e0db42893ad301b8aead9f71e5a005e6cd61bc8e) python3Packages.libcst: 0.4.3 -> 0.4.7
* [`18fe7d99`](https://github.com/NixOS/nixpkgs/commit/18fe7d9978acfd6b66aea5b71ceac0abf667b066) python3Packages.libevdev: 0.10 -> 0.11
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
