### PR TITLE
niv emacs-overlay: update 79d28f83 -> 0ccabd77

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "79d28f8388bfe9e1933e4aa769676d2452cc6ad6",
-        "sha256": "1vn59vdqshxwlb0dfz8db4zwrmg1291c51mmdqdw3z6s3s32ss83",
+        "rev": "0ccabd776050ea80faf610a9dd5b390171ee8037",
+        "sha256": "1i9lqr49jmihxzrhs5965bmhf9zwmfdh4nc1xg4xhkqy3wlahj1s",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/79d28f8388bfe9e1933e4aa769676d2452cc6ad6.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/0ccabd776050ea80faf610a9dd5b390171ee8037.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@79d28f83...0ccabd77](https://github.com/nix-community/emacs-overlay/compare/79d28f8388bfe9e1933e4aa769676d2452cc6ad6...0ccabd776050ea80faf610a9dd5b390171ee8037)

* [`3b253e01`](https://github.com/nix-community/emacs-overlay/commit/3b253e01ca280766a6f8d1694dca9b40ce1d6dc5) Updated repos/emacs
* [`4d03024a`](https://github.com/nix-community/emacs-overlay/commit/4d03024af95e8338ccd4d238a46c4bbe01ecdb89) Updated repos/melpa
* [`d73a1154`](https://github.com/nix-community/emacs-overlay/commit/d73a1154f68195b33d706ff90cfb49a4be42c96e) Updated repos/emacs
* [`560bb95b`](https://github.com/nix-community/emacs-overlay/commit/560bb95b7831ae6ad643e41f1281af1dc595c045) Updated repos/melpa
* [`07ed934e`](https://github.com/nix-community/emacs-overlay/commit/07ed934ecdcf38a29385f57cecbc02a99c3bbf1c) Updated repos/elpa
* [`b6c82f50`](https://github.com/nix-community/emacs-overlay/commit/b6c82f50769de54aabcaff5f3df1d935ea5a9b56) Updated repos/emacs
* [`7db56cda`](https://github.com/nix-community/emacs-overlay/commit/7db56cda30c3165f385cbbfeadbc5b55fe66b6a8) Updated repos/melpa
* [`a3ff607b`](https://github.com/nix-community/emacs-overlay/commit/a3ff607bc96bc9ff051177c4b510e77c916c25ae) Updated repos/nongnu
* [`3ac9bcc7`](https://github.com/nix-community/emacs-overlay/commit/3ac9bcc7eada88f0ae6a63465bcde4e17c516362) Updated repos/emacs
* [`a12c123f`](https://github.com/nix-community/emacs-overlay/commit/a12c123fd91e3206e136f5ed6f91b5390845a107) Updated repos/melpa
* [`97e085df`](https://github.com/nix-community/emacs-overlay/commit/97e085dfd85e2cfd6fd28d237878bff1cafd3f1a) Updated repos/emacs
* [`ccaa74f9`](https://github.com/nix-community/emacs-overlay/commit/ccaa74f90962196b00a6acaa2c2fb206cf0983a5) Updated repos/melpa
* [`ffeee606`](https://github.com/nix-community/emacs-overlay/commit/ffeee606ac744b682e8233135bfde57a94360e26) Updated repos/emacs
* [`ea94e179`](https://github.com/nix-community/emacs-overlay/commit/ea94e1798b8fb96668b9cebb1900aef62ad3526e) Updated repos/melpa
* [`0c8f0386`](https://github.com/nix-community/emacs-overlay/commit/0c8f0386d80783f6fb04d5d0292a6937a875e335) Updated repos/nongnu
* [`7fd6faf9`](https://github.com/nix-community/emacs-overlay/commit/7fd6faf9ddd2b91024cc05ad413ffaf2914cd570) Updated repos/emacs
* [`9aea9957`](https://github.com/nix-community/emacs-overlay/commit/9aea99573b75a77d6b82ef389a3fc825e52dea4e) Updated repos/melpa
* [`e11ff59e`](https://github.com/nix-community/emacs-overlay/commit/e11ff59e05e56042073aacc33f36567efe4fd1e2) Updated repos/elpa
* [`ff1758af`](https://github.com/nix-community/emacs-overlay/commit/ff1758aff712994c2a9366be837a2e716c8170d2) Updated repos/emacs
* [`962851d3`](https://github.com/nix-community/emacs-overlay/commit/962851d3e66ce26c65693ab9e2eadd87c24b5c7c) Updated repos/melpa
* [`ab903538`](https://github.com/nix-community/emacs-overlay/commit/ab903538da378145133c788cdb7153a182776a28) Updated repos/elpa
* [`022cb714`](https://github.com/nix-community/emacs-overlay/commit/022cb7140607ea739c3a8c7807d64ff3f8aa4046) Updated repos/emacs
* [`2882396c`](https://github.com/nix-community/emacs-overlay/commit/2882396c157712b2a58c7f04320e262df5adada8) Updated repos/melpa
* [`30a3d95b`](https://github.com/nix-community/emacs-overlay/commit/30a3d95bb4d9812e26822260b6ac45efde0d7700) Updated repos/melpa
* [`5440e1b1`](https://github.com/nix-community/emacs-overlay/commit/5440e1b14de5f124f4cc86649901b702d91b1707) Updated repos/emacs
* [`fa0de2ae`](https://github.com/nix-community/emacs-overlay/commit/fa0de2aeb1115285c65238e07ea0aecd52765667) Updated repos/melpa
* [`2836cf40`](https://github.com/nix-community/emacs-overlay/commit/2836cf40bb4c19b2afdc480f0d658310a0b19094) Updated repos/elpa
* [`db59fa23`](https://github.com/nix-community/emacs-overlay/commit/db59fa2322d64780a972b6b387f28cf5ca45a399) Updated repos/emacs
* [`c2bf3dea`](https://github.com/nix-community/emacs-overlay/commit/c2bf3dea5dbc634eef4d3ef531a47ee707987ca5) Updated repos/melpa
* [`61a375ab`](https://github.com/nix-community/emacs-overlay/commit/61a375aba42a5761de8e0954ab7aecdd108097f9) Updated repos/emacs
* [`120eed6d`](https://github.com/nix-community/emacs-overlay/commit/120eed6ddd00a9de849a7d498a5208ddeb57bd15) Updated repos/melpa
* [`34074146`](https://github.com/nix-community/emacs-overlay/commit/34074146972552177d529af38f5395ef4c6eab73) Updated repos/nongnu
* [`2320fe4e`](https://github.com/nix-community/emacs-overlay/commit/2320fe4ee10ee33dc0b2ae8c68abb35a285afd88) Updated repos/elpa
* [`32c95120`](https://github.com/nix-community/emacs-overlay/commit/32c9512027d98f3ce65cb8472f14210338420e2b) Updated repos/emacs
* [`697a2c5f`](https://github.com/nix-community/emacs-overlay/commit/697a2c5f0a4958d383be0e4067f44cffe8af9a8a) Updated repos/melpa
* [`0846f792`](https://github.com/nix-community/emacs-overlay/commit/0846f7927044b3f1de5ad398b2edc1e7c65073ac) Updated repos/emacs
* [`fe461abf`](https://github.com/nix-community/emacs-overlay/commit/fe461abf7f0718e8010aa31753173bf3001b1c73) Updated repos/melpa
* [`a67973c4`](https://github.com/nix-community/emacs-overlay/commit/a67973c45ab7d516881baa8e4e5756ab6ddd11ae) Updated repos/emacs
* [`a6e98d6e`](https://github.com/nix-community/emacs-overlay/commit/a6e98d6e2e88c5cb354eed291c3a977e7816cec5) Updated repos/melpa
* [`7ace153f`](https://github.com/nix-community/emacs-overlay/commit/7ace153f21c41d98fdc76ec5dcd82e9bc920fb74) Updated repos/emacs
* [`b27eeeb1`](https://github.com/nix-community/emacs-overlay/commit/b27eeeb1a74214b0490f4faf1ff50c213e2eb33b) Updated repos/melpa
* [`90ac16e7`](https://github.com/nix-community/emacs-overlay/commit/90ac16e769db86cf919d6c6d9577ee07d35acafb) Updated repos/emacs
* [`e0f99212`](https://github.com/nix-community/emacs-overlay/commit/e0f99212b780c7f55af5d5b9d6ed20528d9fbee2) Updated repos/melpa
* [`18c1bf35`](https://github.com/nix-community/emacs-overlay/commit/18c1bf356efb2fc52cf97ca67acc251df9067176) Updated repos/emacs
* [`49173ef2`](https://github.com/nix-community/emacs-overlay/commit/49173ef266e5968f16b7007481f05b2e5ccbfa56) Updated repos/melpa
* [`520725c7`](https://github.com/nix-community/emacs-overlay/commit/520725c7bce9295af7558468a315ad7feb801985) Updated repos/emacs
* [`e911c43b`](https://github.com/nix-community/emacs-overlay/commit/e911c43b99c7b9c94ee408c38b0c6e2c6a01132e) Updated repos/melpa
* [`77546f92`](https://github.com/nix-community/emacs-overlay/commit/77546f927f044801c8ffd452ed4186c246350b50) Updated repos/emacs
* [`0ccabd77`](https://github.com/nix-community/emacs-overlay/commit/0ccabd776050ea80faf610a9dd5b390171ee8037) Updated repos/melpa
