### PR TITLE
niv spacemacs: update fdfd9f14 -> fcf3aa7c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "fdfd9f14573855e828d9d523c4ab38e11796f6d2",
-        "sha256": "07fy9qa7vwgis5nz0igbap64kf25vl5185ymm3gvbxvhrijhh6nm",
+        "rev": "fcf3aa7c9eb500845f94194bc7561f4ec4d59976",
+        "sha256": "1zqjd8xn243xd2rqidawafadpjpwifw5bqmldjlwx0qj4rs175hn",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/fdfd9f14573855e828d9d523c4ab38e11796f6d2.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/fcf3aa7c9eb500845f94194bc7561f4ec4d59976.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@fdfd9f14...fcf3aa7c](https://github.com/syl20bnr/spacemacs/compare/fdfd9f14573855e828d9d523c4ab38e11796f6d2...fcf3aa7c9eb500845f94194bc7561f4ec4d59976)

* [`8e3686d2`](https://github.com/syl20bnr/spacemacs/commit/8e3686d254996e131902ad8a9790747dd3072783) nav-flash: better mechanism on determining last point before blink
* [`90f01114`](https://github.com/syl20bnr/spacemacs/commit/90f01114d2d2a5bcfeca1dea389e67e9a2c438a6) nav-flash: clean up
* [`13cb1e0f`](https://github.com/syl20bnr/spacemacs/commit/13cb1e0f12379909c8291dada6a5684b6eb65180) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15666](https://togithub.com/syl20bnr/spacemacs/issues/15666))
* [`e348e4cd`](https://github.com/syl20bnr/spacemacs/commit/e348e4cda478bda0ee33b9773699c0551812a869) Add keybinding for projectile-run-project ([syl20bnr/spacemacs⁠#15637](https://togithub.com/syl20bnr/spacemacs/issues/15637))
* [`d49e7a35`](https://github.com/syl20bnr/spacemacs/commit/d49e7a35c1e07759f913875a76a3a4e30e887d48) Reformat and change new binding to be consistent with upstream
* [`ca728d27`](https://github.com/syl20bnr/spacemacs/commit/ca728d278b9016b5b882d476c31fd051a42e7888) Fix double ownership of posframe package
* [`43f24dfc`](https://github.com/syl20bnr/spacemacs/commit/43f24dfc9c2aaa69c03d3eb91b1b0a1b8ebfccaf) [dap] move posframe package into spacemacs-visual layer
* [`b994a520`](https://github.com/syl20bnr/spacemacs/commit/b994a520e36b54e749384d3fad9b36b9c16a3e66) [translate] Make sure that go-translate is loaded after posframe
* [`d5126be7`](https://github.com/syl20bnr/spacemacs/commit/d5126be700543bca1b60fdae9a2bc0cef7282e6e) [bot] "built_in_updates" Sun Jul 31 14:28:15 UTC 2022
* [`84d0bb3c`](https://github.com/syl20bnr/spacemacs/commit/84d0bb3c4ffb60892858335dcf20f8b4f1eb865b) Improve Docker layer 'dockerfile-mode' major mode keybindings ([syl20bnr/spacemacs⁠#15414](https://togithub.com/syl20bnr/spacemacs/issues/15414))
* [`4c9cd947`](https://github.com/syl20bnr/spacemacs/commit/4c9cd947a0e90782f681a3d78a168b4334b05204) Remove depreciated github layer
* [`61785c07`](https://github.com/syl20bnr/spacemacs/commit/61785c073c872ad1790f33f86693c1c4403a8ba2) [docker] Make sure to prefix compile commands for lsp bindings
* [`fcf3aa7c`](https://github.com/syl20bnr/spacemacs/commit/fcf3aa7c9eb500845f94194bc7561f4ec4d59976) [bot] "documentation_updates" Sun Jul 31 15:33:44 UTC 2022
