### PR TITLE
niv emacs-overlay: update 0ccabd77 -> cb0c62c7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0ccabd776050ea80faf610a9dd5b390171ee8037",
-        "sha256": "1i9lqr49jmihxzrhs5965bmhf9zwmfdh4nc1xg4xhkqy3wlahj1s",
+        "rev": "cb0c62c7342810332453969ef453c16e51625438",
+        "sha256": "13lgwhczf7agnnk5gwv50si7bsfaw1ahhgc2kbs97qx62394gwdq",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/0ccabd776050ea80faf610a9dd5b390171ee8037.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/cb0c62c7342810332453969ef453c16e51625438.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@0ccabd77...cb0c62c7](https://github.com/nix-community/emacs-overlay/compare/0ccabd776050ea80faf610a9dd5b390171ee8037...cb0c62c7342810332453969ef453c16e51625438)

* [`e46c7738`](https://github.com/nix-community/emacs-overlay/commit/e46c7738bd06c8bdbe265782ea7072e52fcb6b8b) Build Emacs 29 with libwebp by default
* [`ade68201`](https://github.com/nix-community/emacs-overlay/commit/ade682017b39fd5651b034f678a7a5ec5109075b) Updated repos/emacs
* [`7125a934`](https://github.com/nix-community/emacs-overlay/commit/7125a934f0e1cd8a22ee5bb604c9010965fb27df) Updated repos/melpa
* [`0547829f`](https://github.com/nix-community/emacs-overlay/commit/0547829fc8117c18ebc3fcfc795a7bcbac05d950) Updated repos/emacs
* [`f62e1223`](https://github.com/nix-community/emacs-overlay/commit/f62e12239b7cc83a19268e86948c98a04e48342c) Updated repos/melpa
* [`10d42a1d`](https://github.com/nix-community/emacs-overlay/commit/10d42a1d9e6032992ac047153a9bffd4444bd6ed) Updated repos/melpa
* [`a79315e6`](https://github.com/nix-community/emacs-overlay/commit/a79315e600804fbad481119ec98ce055bc40af91) Updated repos/emacs
* [`f4d60d03`](https://github.com/nix-community/emacs-overlay/commit/f4d60d03ea621634ab3091f2c7c036b6a4ad49c3) Updated repos/melpa
* [`ce91eb05`](https://github.com/nix-community/emacs-overlay/commit/ce91eb0560fd6e315cc245ee97c10baebdf2678e) Updated repos/emacs
* [`26275c35`](https://github.com/nix-community/emacs-overlay/commit/26275c354045b6320dcef29a0b18a244293282ef) Updated repos/melpa
* [`6601196d`](https://github.com/nix-community/emacs-overlay/commit/6601196d5d9fdaf13161aa297218bdcdf915c865) Updated repos/elpa
* [`7f58ceea`](https://github.com/nix-community/emacs-overlay/commit/7f58ceea290ebb546c43c0b2ec435fdbcbdea7df) Updated repos/emacs
* [`6a112319`](https://github.com/nix-community/emacs-overlay/commit/6a11231909c53573b3d0c90a22156cf5d5b2416f) Updated repos/melpa
* [`30e49314`](https://github.com/nix-community/emacs-overlay/commit/30e49314ab028a8accab3d9944a0b719556b3153) Updated repos/nongnu
* [`89c81503`](https://github.com/nix-community/emacs-overlay/commit/89c815033fd7fd248d794b1a52eb3c5806cba629) Updated repos/emacs
* [`806b27fc`](https://github.com/nix-community/emacs-overlay/commit/806b27fc621278d74d647679f0e1dfc6d64850c4) Updated repos/melpa
* [`da35c186`](https://github.com/nix-community/emacs-overlay/commit/da35c186463ac1b7bb04f70b4291ac0572e3ce13) Updated repos/nongnu
* [`3e321b6e`](https://github.com/nix-community/emacs-overlay/commit/3e321b6e5936c9dc4e0df9c2c751cad8c9dd7e51) Updated repos/emacs
* [`a151f9ff`](https://github.com/nix-community/emacs-overlay/commit/a151f9ff5b9fa813ac8918f3a3a67c643e7e2edc) Updated repos/melpa
* [`9081b2a2`](https://github.com/nix-community/emacs-overlay/commit/9081b2a265e8acaf94392fc04ba2ae1c35c6ae6a) Updated repos/elpa
* [`d2473ff8`](https://github.com/nix-community/emacs-overlay/commit/d2473ff8a997883dce48f9f7be891d2a7449fc05) Updated repos/emacs
* [`4a5b9fb6`](https://github.com/nix-community/emacs-overlay/commit/4a5b9fb659456b31d2c15e53694e139077920592) Updated repos/melpa
* [`9019be27`](https://github.com/nix-community/emacs-overlay/commit/9019be27f46ed3a102b2e732cb679eb01217a839) Updated repos/emacs
* [`6f88e779`](https://github.com/nix-community/emacs-overlay/commit/6f88e779ebaf6dcdb6680aca645b5b6dd5efee93) Updated repos/melpa
* [`43460316`](https://github.com/nix-community/emacs-overlay/commit/434603164e8d33c6e7c264672cfd1aa187713a43) Updated repos/nongnu
* [`f66b85f9`](https://github.com/nix-community/emacs-overlay/commit/f66b85f9e4aa50edca0e7cd747ff29fdfd2552d1) Updated repos/emacs
* [`9f5f2134`](https://github.com/nix-community/emacs-overlay/commit/9f5f21345981a89c1ddaf13eb2b7b8417c8e1716) Updated repos/melpa
* [`5a6fa4af`](https://github.com/nix-community/emacs-overlay/commit/5a6fa4af5a83139da484e2e60158a201a003989a) Updated repos/elpa
* [`f236406a`](https://github.com/nix-community/emacs-overlay/commit/f236406af04aff17094788b27a536033c677f656) Updated repos/emacs
* [`a9564c2f`](https://github.com/nix-community/emacs-overlay/commit/a9564c2fd4732dbc4d461440102cc63adb490c1e) Updated repos/melpa
* [`da34ca80`](https://github.com/nix-community/emacs-overlay/commit/da34ca80e23dd8678f52f3a4a3bb0815242a5d3d) Updated repos/emacs
* [`66eac451`](https://github.com/nix-community/emacs-overlay/commit/66eac451469bc8936f5955bafd76f4c9caa46cd7) Updated repos/melpa
* [`599e5a07`](https://github.com/nix-community/emacs-overlay/commit/599e5a07bd0e9a32c0cf72ae5896d4f409721aea) Updated repos/emacs
* [`9e7e8453`](https://github.com/nix-community/emacs-overlay/commit/9e7e84533fa8d0d5fdbb348410bfdae731bca80d) Updated repos/melpa
* [`ca1c3a6d`](https://github.com/nix-community/emacs-overlay/commit/ca1c3a6d29c5c0ce5b998c968b6ec2465298b4be) Updated repos/emacs
* [`993442e8`](https://github.com/nix-community/emacs-overlay/commit/993442e82ab3a796ca9a57d820bedae190a26f6f) Updated repos/melpa
* [`94ea63e5`](https://github.com/nix-community/emacs-overlay/commit/94ea63e5fe0f13c61f7071eee078bcc86632d105) Updated repos/nongnu
* [`9dd0844c`](https://github.com/nix-community/emacs-overlay/commit/9dd0844cfaf200facedc0e2a7a50356dd1c7ce26) Updated repos/emacs
* [`b40d0a6d`](https://github.com/nix-community/emacs-overlay/commit/b40d0a6d121a559693c969d08650f13a3b9c8727) Updated repos/melpa
* [`e1ccf03c`](https://github.com/nix-community/emacs-overlay/commit/e1ccf03cca1f57361226b2037ead142d82ba9bd5) Updated repos/nongnu
* [`16daa6d1`](https://github.com/nix-community/emacs-overlay/commit/16daa6d194f6865743d6a29ac95980f4e3a07a9e) Updated repos/elpa
* [`ac4b3c48`](https://github.com/nix-community/emacs-overlay/commit/ac4b3c48f01d38ac027be82db1af750b5bbe9ead) Updated repos/emacs
* [`c5fc4c4e`](https://github.com/nix-community/emacs-overlay/commit/c5fc4c4e83ea921f9ed826e3187b21febd5b174d) Updated repos/melpa
* [`db0f540f`](https://github.com/nix-community/emacs-overlay/commit/db0f540f9ce8fc55246719526e54cc65c0f3945c) Updated repos/elpa
* [`6be264e5`](https://github.com/nix-community/emacs-overlay/commit/6be264e5ee71a34d15335c6dfe6d2f3d4a85924c) Updated repos/emacs
* [`58e88dbc`](https://github.com/nix-community/emacs-overlay/commit/58e88dbc17d5252b51bff1266c6f10c00997e1f8) Updated repos/melpa
* [`2cb70e97`](https://github.com/nix-community/emacs-overlay/commit/2cb70e97627c96557125f741a69e151887c237b5) Updated repos/emacs
* [`e547e668`](https://github.com/nix-community/emacs-overlay/commit/e547e66852fd84ecdaccb6d247104c6a5c3c9dd8) Updated repos/melpa
* [`495ac468`](https://github.com/nix-community/emacs-overlay/commit/495ac46875635ba3f9ef5c41f6c4497c3e405a93) Updated repos/elpa
* [`91ce887a`](https://github.com/nix-community/emacs-overlay/commit/91ce887adba4e655225241f8c3e04eae13b9046c) Updated repos/emacs
* [`a3770a9a`](https://github.com/nix-community/emacs-overlay/commit/a3770a9a619f508a0828df30cb10858663d4538b) Updated repos/melpa
* [`1203e67c`](https://github.com/nix-community/emacs-overlay/commit/1203e67cb582c4bce565702e947876b01127607a) Updated repos/emacs
* [`4f2132d6`](https://github.com/nix-community/emacs-overlay/commit/4f2132d63bdd2d49c625825d2fb2129cb19a79ec) Updated repos/melpa
* [`359ec6f2`](https://github.com/nix-community/emacs-overlay/commit/359ec6f26899b3723aa86658a2df1650cb98eb58) Updated repos/emacs
* [`d22a3da5`](https://github.com/nix-community/emacs-overlay/commit/d22a3da518a100e31fb0d26c16df8a221cf87914) Updated repos/melpa
* [`4ef493b8`](https://github.com/nix-community/emacs-overlay/commit/4ef493b8be95fd8c76dd660a1e4b11e6bc690e62) Updated repos/nongnu
* [`b3aa957c`](https://github.com/nix-community/emacs-overlay/commit/b3aa957c4f1b6300a5aae9b251b49665ff232090) Updated repos/elpa
* [`991a3e78`](https://github.com/nix-community/emacs-overlay/commit/991a3e78df1eb93d6c0d9ad7678d27bfc83aad9a) Updated repos/emacs
* [`f54f1ef6`](https://github.com/nix-community/emacs-overlay/commit/f54f1ef6a85f892b57c2d020d17afe52f163a651) Updated repos/melpa
* [`521066d3`](https://github.com/nix-community/emacs-overlay/commit/521066d3327c7d28e2e0869c9071b364bb988244) Updated repos/emacs
* [`88f03fb1`](https://github.com/nix-community/emacs-overlay/commit/88f03fb166d6ca0df187d7dbbd86bc2c2754e9da) Updated repos/melpa
* [`b9139aa9`](https://github.com/nix-community/emacs-overlay/commit/b9139aa9a98830ceb268a611495dc47e6b503ac4) Updated repos/nongnu
* [`0c26a7aa`](https://github.com/nix-community/emacs-overlay/commit/0c26a7aa19bdfb601ac1b1e7276024644f997ab7) Updated repos/emacs
* [`08676a68`](https://github.com/nix-community/emacs-overlay/commit/08676a685629ee6744cce8716d29ed408dceaeb3) Updated repos/melpa
* [`bb05af9a`](https://github.com/nix-community/emacs-overlay/commit/bb05af9a18d6bb12bbe240e5c6361983ab970360) Updated repos/emacs
* [`ead1b9e4`](https://github.com/nix-community/emacs-overlay/commit/ead1b9e47f9e2397da8f42da887ed416fc5762b5) Updated repos/melpa
* [`fae6603b`](https://github.com/nix-community/emacs-overlay/commit/fae6603bb1aca6f25334d8308363c380abbe201d) Updated repos/elpa
* [`d464c71c`](https://github.com/nix-community/emacs-overlay/commit/d464c71cfad009cf1b8f61054ea61154665b5236) Updated repos/melpa
* [`b0c1662d`](https://github.com/nix-community/emacs-overlay/commit/b0c1662d662cb3390bbd4e48561c99855fc13c01) Updated repos/emacs
* [`a01fc285`](https://github.com/nix-community/emacs-overlay/commit/a01fc2857fe8bb2c784357961c6eb14da15b46d8) Updated repos/melpa
* [`da0320fc`](https://github.com/nix-community/emacs-overlay/commit/da0320fc0afff7870d20a478d2a031ca1cd0c3ca) Updated repos/nongnu
* [`46d5cfbd`](https://github.com/nix-community/emacs-overlay/commit/46d5cfbd1f5645fdc2501299dca2cdc131f8ba97) Updated repos/emacs
* [`ab5e238d`](https://github.com/nix-community/emacs-overlay/commit/ab5e238d6bc15e112beb82d898efab22426001bf) Updated repos/melpa
* [`c86aad15`](https://github.com/nix-community/emacs-overlay/commit/c86aad15d86522ebe70ad081119873d38671b619) Updated repos/emacs
* [`ba4abf87`](https://github.com/nix-community/emacs-overlay/commit/ba4abf87e0d77e0367bae986020bff4da75a3641) Updated repos/melpa
* [`30101465`](https://github.com/nix-community/emacs-overlay/commit/301014652dac9d572f45cd31b2a918805d68c958) Updated repos/nongnu
* [`1050a49a`](https://github.com/nix-community/emacs-overlay/commit/1050a49afc82cbd8e9fb0b571dda4b336a61e022) Updated repos/emacs
* [`8a7c1d35`](https://github.com/nix-community/emacs-overlay/commit/8a7c1d3582856a2e34942cc4371718ef252784ac) Updated repos/melpa
* [`95e865eb`](https://github.com/nix-community/emacs-overlay/commit/95e865eb064628f73e848b8ab3d621f54e4d8e17) Updated repos/emacs
* [`c87ea178`](https://github.com/nix-community/emacs-overlay/commit/c87ea178146721cc5c3bdb2f0e09e5ed74602f84) Updated repos/melpa
* [`9738e732`](https://github.com/nix-community/emacs-overlay/commit/9738e732faa5104e952b9a1336aa261ea7939fc0) Updated repos/emacs
* [`e8ea1c44`](https://github.com/nix-community/emacs-overlay/commit/e8ea1c440e46dcf900428543438c5fc5c0ea56e0) Updated repos/melpa
* [`0eaf636d`](https://github.com/nix-community/emacs-overlay/commit/0eaf636d5e6aec8c2e86e8616bdb646356113df4) Updated repos/emacs
* [`b94adb88`](https://github.com/nix-community/emacs-overlay/commit/b94adb886b59fd19d9ec5af299d8253b84d5151b) Updated repos/melpa
* [`d73ef414`](https://github.com/nix-community/emacs-overlay/commit/d73ef414f3b07c4e675e9582c4f181580853e53b) Updated repos/nongnu
* [`e61a0020`](https://github.com/nix-community/emacs-overlay/commit/e61a0020cbbeff4f9e97fe320f1e083a27dd0142) Updated repos/emacs
* [`a4962c57`](https://github.com/nix-community/emacs-overlay/commit/a4962c57f6cf03224dac91f10848e503c8e21601) Updated repos/melpa
* [`a41eb4ba`](https://github.com/nix-community/emacs-overlay/commit/a41eb4ba747b7df847a6ceea9f807a4b98b0d5d9) Updated repos/emacs
* [`1804baea`](https://github.com/nix-community/emacs-overlay/commit/1804baeaa57088c172f0c9a9d56aecedd40c20a4) Updated repos/melpa
* [`c6c28e96`](https://github.com/nix-community/emacs-overlay/commit/c6c28e96e85c5945c76eef5fb9814371d2d8a1b5) Updated repos/nongnu
* [`8008b653`](https://github.com/nix-community/emacs-overlay/commit/8008b653d1bb49eeb5a792a46c5da484704a1f98) Updated repos/emacs
* [`c071dc4e`](https://github.com/nix-community/emacs-overlay/commit/c071dc4eeaabe41e9eefdc17aaba64c2ece218a0) Updated repos/melpa
* [`82700d34`](https://github.com/nix-community/emacs-overlay/commit/82700d34e3fd1f62b1d08bf81feabd0081194286) Updated repos/elpa
* [`24b6d803`](https://github.com/nix-community/emacs-overlay/commit/24b6d803b4cebbbfd1e30605407fac85f0360a15) Updated repos/emacs
* [`6f40609b`](https://github.com/nix-community/emacs-overlay/commit/6f40609b4437596a4c208460c422b68495287c71) Updated repos/melpa
* [`65255005`](https://github.com/nix-community/emacs-overlay/commit/65255005b89ed3adb49d2f552188e34ad98d64d0) Use `super.emacs` instead of `self.emacs`
* [`4870db36`](https://github.com/nix-community/emacs-overlay/commit/4870db363445633efea62c393337c762eb1d7c8b) Updated repos/emacs
* [`3d062518`](https://github.com/nix-community/emacs-overlay/commit/3d062518dc99ec4841b08c1a3c4f64ef2df330ca) Updated repos/melpa
* [`35189089`](https://github.com/nix-community/emacs-overlay/commit/35189089c55a3f4a0122a55b7f917d583c268acc) Updated repos/emacs
* [`4f1a6706`](https://github.com/nix-community/emacs-overlay/commit/4f1a670645cd3dc973f6da14565d48232fa01b3a) Updated repos/melpa
* [`007ecd3f`](https://github.com/nix-community/emacs-overlay/commit/007ecd3f8837268923265a97ca7d1d5b919e8f06) Updated repos/emacs
* [`864c7d3e`](https://github.com/nix-community/emacs-overlay/commit/864c7d3ec1e42ac7983d832dea7f737047a9ede9) Updated repos/melpa
* [`67a79249`](https://github.com/nix-community/emacs-overlay/commit/67a79249d30cc0d9705ddce4a3de2407b06c4dd8) Updated repos/emacs
* [`cb0c62c7`](https://github.com/nix-community/emacs-overlay/commit/cb0c62c7342810332453969ef453c16e51625438) Updated repos/melpa
