### PR TITLE
niv spacemacs: update fcf3aa7c -> eb809cc6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "fcf3aa7c9eb500845f94194bc7561f4ec4d59976",
-        "sha256": "1zqjd8xn243xd2rqidawafadpjpwifw5bqmldjlwx0qj4rs175hn",
+        "rev": "eb809cc61ce4fbca9ae32aa5f47ed713bb08d7c9",
+        "sha256": "0bz672plaqnpq3x2wjfi9bfsy7i76jy5n4s84j3x1d36sz4jysap",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/fcf3aa7c9eb500845f94194bc7561f4ec4d59976.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/eb809cc61ce4fbca9ae32aa5f47ed713bb08d7c9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@fcf3aa7c...eb809cc6](https://github.com/syl20bnr/spacemacs/compare/fcf3aa7c9eb500845f94194bc7561f4ec4d59976...eb809cc61ce4fbca9ae32aa5f47ed713bb08d7c9)

* [`a611a602`](https://github.com/syl20bnr/spacemacs/commit/a611a602c0f9b0500738a687c43ded6ad9f1396a) parinfer: cleaning up
* [`7706f0ff`](https://github.com/syl20bnr/spacemacs/commit/7706f0ffd2ce0356fa1829faf4ab45951eb07f73) helm: remove unnecessary setting on xref-show-xrefs-function
* [`a99d90b3`](https://github.com/syl20bnr/spacemacs/commit/a99d90b31f91c74c7e4427e0ea077b9303f013e5) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15676](https://togithub.com/syl20bnr/spacemacs/issues/15676))
* [`9010d8d3`](https://github.com/syl20bnr/spacemacs/commit/9010d8d3cae530b5a29e6b34883f860d411088d0) README.md
* [`37bad602`](https://github.com/syl20bnr/spacemacs/commit/37bad602e21eff3cfd02ab79b31355c9eb588495) unicode fonts: multiple improvements
* [`4f5fddc9`](https://github.com/syl20bnr/spacemacs/commit/4f5fddc96d67503f1ab3e1c483dc8237a87dce9d) [bot] documentation_updates ([syl20bnr/spacemacs⁠#15679](https://togithub.com/syl20bnr/spacemacs/issues/15679))
* [`2ec9614d`](https://github.com/syl20bnr/spacemacs/commit/2ec9614d5eee2a42e61609e6ebf5b75afefd18fd) spacemacs-editing-visual: fix [syl20bnr/spacemacs⁠#15667](https://togithub.com/syl20bnr/spacemacs/issues/15667)
* [`7d60d894`](https://github.com/syl20bnr/spacemacs/commit/7d60d894a7c6015566eaa1d728dd784e8565ac9e) updated COPYRIGHT
* [`e7b87114`](https://github.com/syl20bnr/spacemacs/commit/e7b871147f6043e3a083956e7061a238d9fdeaa6) Added documentation to set julia envornment location for lsp server
* [`f452ff28`](https://github.com/syl20bnr/spacemacs/commit/f452ff28b81eafb3f3e0fbc5fbd97b3c5b0af365) [bot] "documentation_updates" Fri Aug  5 21:31:39 UTC 2022 ([syl20bnr/spacemacs⁠#15682](https://togithub.com/syl20bnr/spacemacs/issues/15682))
* [`4f6413e8`](https://github.com/syl20bnr/spacemacs/commit/4f6413e82ff9778e7ac1e85ece6b3218f0c888e4) fixup! unicode fonts: multiple improvements
* [`eef9f4ed`](https://github.com/syl20bnr/spacemacs/commit/eef9f4ed7fd7401d044fa6c22bd5d1ec4e5b3029) plantuml: minor clean up
* [`26a975d6`](https://github.com/syl20bnr/spacemacs/commit/26a975d69a7c9396622afd62cb66862d0a006461) * core/core-configuration-layer.el: fix log for rshadow relationship ([syl20bnr/spacemacs⁠#15685](https://togithub.com/syl20bnr/spacemacs/issues/15685))
* [`9acd3411`](https://github.com/syl20bnr/spacemacs/commit/9acd3411128dd85a2538c962dab61f2597b6cdf7) *core/core-dumper.el: Enhance for native-compile support ([syl20bnr/spacemacs⁠#15686](https://togithub.com/syl20bnr/spacemacs/issues/15686))
* [`6415adea`](https://github.com/syl20bnr/spacemacs/commit/6415adea49a7ca96e6cfcf63c96cb0857de97f75) Fixed [syl20bnr/spacemacs⁠#15583](https://togithub.com/syl20bnr/spacemacs/issues/15583) and also bound SPC T g to toggle gui elements
* [`4c027d0a`](https://github.com/syl20bnr/spacemacs/commit/4c027d0abfc9f5293981cbabbb8f1dd890d35114) [evil] restore original evil-lion bindings as defaults. ([syl20bnr/spacemacs⁠#15684](https://togithub.com/syl20bnr/spacemacs/issues/15684))
* [`71e56d75`](https://github.com/syl20bnr/spacemacs/commit/71e56d75fbb71bd9269dbeb4aed234c253a3b4e1) core: remove unused variable ([syl20bnr/spacemacs⁠#15693](https://togithub.com/syl20bnr/spacemacs/issues/15693))
* [`73267ea0`](https://github.com/syl20bnr/spacemacs/commit/73267ea02b0a0f28202386424ee38ca9ebb3bfba) [bot] "built_in_updates" Wed Aug 10 18:49:03 UTC 2022 ([syl20bnr/spacemacs⁠#15694](https://togithub.com/syl20bnr/spacemacs/issues/15694))
* [`c5c69ce2`](https://github.com/syl20bnr/spacemacs/commit/c5c69ce239577ce1e0fb468698d7aeb2453a6cbb) core: more precise directory byte-compile status for "core/libs/" folder
* [`913c8b0f`](https://github.com/syl20bnr/spacemacs/commit/913c8b0f9fe08f169c980ad99e3bc19386681ece) Disable incompatible optimisation in init.el
* [`eb809cc6`](https://github.com/syl20bnr/spacemacs/commit/eb809cc61ce4fbca9ae32aa5f47ed713bb08d7c9) vagrant | use 'vagrant-tramp-shell if 'shell-default-shell is 'shell ([syl20bnr/spacemacs⁠#15701](https://togithub.com/syl20bnr/spacemacs/issues/15701))
