### PR TITLE
niv zsh-completions: update 11258bcd -> f360827b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "11258bcd48521b5bc7b683104bb0f5cb9375edee",
-        "sha256": "1xd63031zxpdxz53md5xbwapfnklq392dh5s9ympm14fyfdwa3bg",
+        "rev": "f360827b882e0b651ff85ce27dc2a6287351fc22",
+        "sha256": "0y0n682v4ij0drx1r99w7vkxfxiq4mj11ildjygwp37ffvaarcfp",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/11258bcd48521b5bc7b683104bb0f5cb9375edee.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/f360827b882e0b651ff85ce27dc2a6287351fc22.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@11258bcd...f360827b](https://github.com/zsh-users/zsh-completions/compare/11258bcd48521b5bc7b683104bb0f5cb9375edee...f360827b882e0b651ff85ce27dc2a6287351fc22)

* [`530ee90b`](https://github.com/zsh-users/zsh-completions/commit/530ee90b48c70b605f2aec75958b41d65748a8b8) Remove _tarsnap
* [`40c1e442`](https://github.com/zsh-users/zsh-completions/commit/40c1e442160de626cf5f991392ea723d2ab82d49) Update for go 1.19
* [`88b284dc`](https://github.com/zsh-users/zsh-completions/commit/88b284dc6d51f1439e1e8d6ee12f9a2fbd18c27b) Update go environment variable completion
* [`ae63b5ae`](https://github.com/zsh-users/zsh-completions/commit/ae63b5ae41a86f76b8bb1eaa89ebfd8e54d4be8d) Update cmake options for version 3.24
