### PR TITLE
niv nixpkgs: update 901978e1 -> 2933077b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "901978e1fd43753d56299a3b4f549b66ea77a744",
-        "sha256": "0wx2szfvyqyvrni0xpwwix9cadxvlih5c10wpfmb7sv1zj8mw2nr",
+        "rev": "2933077b4be4ab7f2167777c73af1039763677c3",
+        "sha256": "0sacdjdgw4h12m14avzd9s7j64rgsf52qi6cxz54f682ip0lkcfh",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/901978e1fd43753d56299a3b4f549b66ea77a744.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/2933077b4be4ab7f2167777c73af1039763677c3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@901978e1...2933077b](https://github.com/nixos/nixpkgs/compare/901978e1fd43753d56299a3b4f549b66ea77a744...2933077b4be4ab7f2167777c73af1039763677c3)

* [`90bfb6dc`](https://github.com/NixOS/nixpkgs/commit/90bfb6dc4b5407fe6b52988c6261e97343cc3e4e) mpvacious: remove hack for multi-file script loading
* [`d8358154`](https://github.com/NixOS/nixpkgs/commit/d83581546941e9dfb22d4f5d406bbd46436f2e3c) rubyPackages: add dip
* [`1575eb8c`](https://github.com/NixOS/nixpkgs/commit/1575eb8c3bc913a2a34f5377269869d6be1afe2c) yajl: fix url for fetching archive
* [`8419c3d2`](https://github.com/NixOS/nixpkgs/commit/8419c3d260ab77169d3bb88508eba2fb467531f0) maintainers: add kephasp
* [`fe4fbbd5`](https://github.com/NixOS/nixpkgs/commit/fe4fbbd5cd86cbd60fbb4e83a3751384431c2f1a) karate: init at 1.2.0
* [`0c127705`](https://github.com/NixOS/nixpkgs/commit/0c127705a0c5ead6c60973c6cb77ce10ce790a10) binbloom: init at 2.0
* [`d926f005`](https://github.com/NixOS/nixpkgs/commit/d926f005262a7316b6854c0383b1646272faa7bb) verilator: 4.222 -> 4.224
* [`50cec7d0`](https://github.com/NixOS/nixpkgs/commit/50cec7d09370d2f8f0ff03dc94f504fa21103e9b) jsonnet-bundler: 0.4.0 -> 0.5.1
* [`d7956c52`](https://github.com/NixOS/nixpkgs/commit/d7956c52e1f56a7c180d2c290fa7b92d0e99f15a) autorandr: WIP Fix distutils import warning
* [`348b8854`](https://github.com/NixOS/nixpkgs/commit/348b88545c26245701d3f8b5ff33ac19310a7c46) nixos/plymouth: fix theme dependency resolution in systemd stage 1
* [`bb7867f1`](https://github.com/NixOS/nixpkgs/commit/bb7867f1e5080de1dfff80e2f7d5a4be49889e23) vscode: simplify helper scripts
* [`3f54dfa4`](https://github.com/NixOS/nixpkgs/commit/3f54dfa4755613dbd3098814a9ab07cb977ca347) treewide: fix bash exit handlers
* [`af2b3939`](https://github.com/NixOS/nixpkgs/commit/af2b3939d8b5391092eb0fceadba7f970fb06422) zsh-completions: 0.33.0 -> 0.34.0
* [`e5af5577`](https://github.com/NixOS/nixpkgs/commit/e5af5577c32ca51591be48d8dd7ebd2a5ee9296a) outils: init at 0.10
* [`80ba8111`](https://github.com/NixOS/nixpkgs/commit/80ba8111d4378be1fc78b413d56fecb0fcfa3399) buildBazelPackage: allow custom impureEnvVars
* [`c8cc2dee`](https://github.com/NixOS/nixpkgs/commit/c8cc2dee7ecb0816a0b483ed2b3205cbd418ebff) kube-bench: init at 0.6.8
* [`ab2bb952`](https://github.com/NixOS/nixpkgs/commit/ab2bb95249236f6afe712926b395c1ac65a93447) acpica-tools: repair installPhase for darwin
* [`00ff7194`](https://github.com/NixOS/nixpkgs/commit/00ff7194e3d6e957139e386398a814f04dfc5265) asdf-vm: 0.10.0 -> 0.10.2
* [`8599c7ad`](https://github.com/NixOS/nixpkgs/commit/8599c7adba2d01bfd48dd3b07cb5b9759913936d) pythonPackages.python-telegram: init at 0.15.0
* [`1ae62d80`](https://github.com/NixOS/nixpkgs/commit/1ae62d806f84dad3d92f12abc5150c75c016b70c) tg: init at 0.19.0
* [`1c6697de`](https://github.com/NixOS/nixpkgs/commit/1c6697dec7b6d81b287ac67d4a79e122700c529b) dolphin-emu-beta: 5.0-16380 -> 5.0-16793
* [`abf573a0`](https://github.com/NixOS/nixpkgs/commit/abf573a0c77e36362b55aa0e5c6589580a7d9ef4) metis-prover: 2.3.20160713 -> 2.4.20200713
* [`7e75f62b`](https://github.com/NixOS/nixpkgs/commit/7e75f62b3e658889df6e623edc1391175ae62ce7) python3Packages.rich: add some key reverse dependencies to passthru.tests
* [`a215794d`](https://github.com/NixOS/nixpkgs/commit/a215794df6119b0bbed13cbaaa2c829804697724) unison-ucm: M3 -> M4
* [`07d2943f`](https://github.com/NixOS/nixpkgs/commit/07d2943f1a7ffdd16f78b119a16c0254b7dfc385) olive-editor: use qt514's overridden glibc++
* [`8d63f783`](https://github.com/NixOS/nixpkgs/commit/8d63f78354cd8aaef92067bd69c02ac9fc86ccc0) uqm: 0.7.0 -> 0.8.0
* [`afc60d01`](https://github.com/NixOS/nixpkgs/commit/afc60d017b238d0aadbaf0c77ff844388e70640b) nixos/qemu-vm: Use disposable EROFS for store when writableStore = false
* [`67ebd123`](https://github.com/NixOS/nixpkgs/commit/67ebd123ff53ed57eb26294f5005572e981d0ed1) nixos/tests/gitlab: Optimize with EROFS
* [`7ba6f74c`](https://github.com/NixOS/nixpkgs/commit/7ba6f74c1c0de034049456c3704e9e48fc483bda) nixos/tests/discourse: Optimize with EROFS
* [`438f6f17`](https://github.com/NixOS/nixpkgs/commit/438f6f17de68353f9d453ef113c40ce6816191cd) nixos/qemu-vm: Warn when wasting space
* [`182892c6`](https://github.com/NixOS/nixpkgs/commit/182892c6f9eff3db7d39c36d8fe7b12f6bef8d5b) gnome-shell: build css from source
* [`af1e4278`](https://github.com/NixOS/nixpkgs/commit/af1e42784b2c98c0de7d46cb64f40e9d5a6b0031) unifiedpush-common-proxies: 1.1.1 -> 1.3.0
* [`fad85f2c`](https://github.com/NixOS/nixpkgs/commit/fad85f2c0a655ab51d76e2444136954770ca36c4) python3Packages.tables: hdf5_1_10 -> hdf5
* [`d5fb429c`](https://github.com/NixOS/nixpkgs/commit/d5fb429c7dcaaabde24d4efb8d96c97ecb356a63) cc-wrapper: Set correct hardening_unsupported_flags for newlib-nano
* [`facbbae4`](https://github.com/NixOS/nixpkgs/commit/facbbae4b7cb818569024a7bd1dbddf1bbdd4c35) gcc: Set --with-newlib when using newlib-nano
* [`4ff2e5d7`](https://github.com/NixOS/nixpkgs/commit/4ff2e5d7e0c6337d46a1e089f9b653a19b9f7aa4) restool: also depend on which
* [`2a6b51e3`](https://github.com/NixOS/nixpkgs/commit/2a6b51e3618a80ea17eec65a9753bb4d50e2d708) maintainers: add virchau13
* [`91e092ab`](https://github.com/NixOS/nixpkgs/commit/91e092ab688c340fffba3b77ac1ffa5a2fa67fc4) uqm: Switch to building with SDL2
* [`bf5b7586`](https://github.com/NixOS/nixpkgs/commit/bf5b75864dbce1e072ac1c1816f6bda97c096e46) lib/modules: Add _module.specialArgs
* [`e135c417`](https://github.com/NixOS/nixpkgs/commit/e135c417bbaaaf29184004b132c74ae120ea17e8) nixos/documentation: Forward the specialArgs
* [`9a0b26b2`](https://github.com/NixOS/nixpkgs/commit/9a0b26b216264d6187b4b5dba5c51c5b50d825a9) nixos/documentation: Make extraModules configurable
* [`5a98c630`](https://github.com/NixOS/nixpkgs/commit/5a98c630778e71ce0573c12a0b586c9a1dcdb4f4) nixos: Move getty helpLine definition to getty module
* [`08e6f457`](https://github.com/NixOS/nixpkgs/commit/08e6f457477042c62629e19fd987b8de95755522) nixos: Declare module dependencies
* [`ec3e1c6a`](https://github.com/NixOS/nixpkgs/commit/ec3e1c6a3a19e1eaf14d8697e99922c192129574) nixos/documentation: Remove systemd/initrd dependency
* [`9aa588ec`](https://github.com/NixOS/nixpkgs/commit/9aa588ecc394f140681a0d68b635b3cf45ade411) nixos/documentation: Add unit test
* [`274b5fa8`](https://github.com/NixOS/nixpkgs/commit/274b5fa829d55c15807651fea15d017240cba97f) python3Packages.monai: init at 0.9.0
* [`cec55883`](https://github.com/NixOS/nixpkgs/commit/cec55883678b1e47863b5f46304bce8b8850fea7) mss-mdns: 0.10.0 -> 0.15.1
* [`4f010615`](https://github.com/NixOS/nixpkgs/commit/4f010615bd29df960e6744996e4104e03697f05e) clipqr: init at 1.0.0
* [`85518f0e`](https://github.com/NixOS/nixpkgs/commit/85518f0ef0c20cdc7852207eaf47bec55c4d86bb) clipqr: add myself as maintainer
* [`744f00c6`](https://github.com/NixOS/nixpkgs/commit/744f00c6b108794bef7b3887d45c52778f1eddcf) restool: 20.12 → 2.4
* [`78873bd8`](https://github.com/NixOS/nixpkgs/commit/78873bd8e4d19701a182ebf6f3c7d02fa606aaac) ipfs-cluster: 1.0.1 -> 1.0.2
* [`7e8e00d6`](https://github.com/NixOS/nixpkgs/commit/7e8e00d656a145a8c72aae94c7d244f25e8f3594) nixos/restic: use postStop for `backupCleanupCommand`
* [`191f777c`](https://github.com/NixOS/nixpkgs/commit/191f777c4af43744eef543ba9c12b3259a055a7d) nixos/amd.sev: init
* [`e44ef9d7`](https://github.com/NixOS/nixpkgs/commit/e44ef9d7eee4b5abdf1f64976d63c515d2c4b57e) musikcube: fix rpath for musikcube
* [`2a57a34e`](https://github.com/NixOS/nixpkgs/commit/2a57a34e41ce5ae7a215fd82dec8c3104640e479) Address PR feedback
* [`1a322c85`](https://github.com/NixOS/nixpkgs/commit/1a322c85b75cf2af2f1f2684c93f44147a9bc1b4) termscp: 0.8.2 -> 0.9.0
* [`cda3541b`](https://github.com/NixOS/nixpkgs/commit/cda3541bff2b138dceaf76d53e453cc67b423e56) libminc: unstable-2020-07-17 -> 2.4.05
* [`125da198`](https://github.com/NixOS/nixpkgs/commit/125da198662adacbeb31d247b96eabdcb2dc3462) mni_autoreg: unstable-2017-02-22 -> unstable-2022-05-20
* [`afda1666`](https://github.com/NixOS/nixpkgs/commit/afda1666364dcfcd820d59b6999fadc2e1b3f776) python311: 3.11.0b4 -> 3.11.0b5
* [`fd184d63`](https://github.com/NixOS/nixpkgs/commit/fd184d63e92958f3ec4d9472d52d079fc800c153) syncstorage-rs: init at 0.11.0
* [`746da73c`](https://github.com/NixOS/nixpkgs/commit/746da73ca6f02121368d09230a72cc903ae690fc) antimicrox: 3.2.4 -> 3.2.5
* [`76953632`](https://github.com/NixOS/nixpkgs/commit/76953632bb4ca477cc3b2560b52fd103ccf73377) alfaview: 8.47.0 -> 8.49.1
* [`3fa1b317`](https://github.com/NixOS/nixpkgs/commit/3fa1b317ac92d2d2cb9148ddf2d17e7850a2aea7) heatshrink: init at 0.4.1
* [`80efc213`](https://github.com/NixOS/nixpkgs/commit/80efc2139bc432920ec5f72ad05cdb2dad6d1b9b) heatseeker: 1.7.1 -> 1.7.2
* [`71d5dd7b`](https://github.com/NixOS/nixpkgs/commit/71d5dd7bbeee41480058dcf2b18f596c56209f1a) htpdate: 1.3.3 -> 1.3.5
* [`53a81e37`](https://github.com/NixOS/nixpkgs/commit/53a81e37c6b06355c39b40480ff8bfe28768acfc) imgui: 1.87 -> 1.88
* [`4cfa06b8`](https://github.com/NixOS/nixpkgs/commit/4cfa06b8e9e71f53ac3c02b17b2c554f5eef1d3d) kubie: 0.16.0 -> 0.17.1
* [`41b1496a`](https://github.com/NixOS/nixpkgs/commit/41b1496aa712b96e0037855638e6e32be6439ca1) kuma-cp: 1.5.0 -> 1.7.1
* [`dba33e2a`](https://github.com/NixOS/nixpkgs/commit/dba33e2ac805ab78e9c5335edc306967f3b89afc) python310Packages.pyroute2: 0.7.1 -> 0.7.2
* [`c8ea776a`](https://github.com/NixOS/nixpkgs/commit/c8ea776a5408b2281582a81f0e90526c5b0ec5fe) libfabric: 1.14.0 -> 1.15.1
* [`7aa68973`](https://github.com/NixOS/nixpkgs/commit/7aa689734ea2fb2109065150b22a55d0a565f9a2) mackerel-agent: 0.72.9 -> 0.73.0
* [`6807e4cb`](https://github.com/NixOS/nixpkgs/commit/6807e4cb096f6a6ba56ef712abe24a0b646c5653) openapi-generator-cli: 5.4.0 -> 6.0.1
* [`e937b6e3`](https://github.com/NixOS/nixpkgs/commit/e937b6e3ba1954d7fac3165f17e432d46985db7c) openjdk17: Remove default java.library.path
* [`6057821d`](https://github.com/NixOS/nixpkgs/commit/6057821dd59b3f97f8e57698c2eed5ea45b0f9ff) randoop: 4.3.0 -> 4.3.1
* [`c86d3388`](https://github.com/NixOS/nixpkgs/commit/c86d33886de6c60d80ec56d89d7e10ba885b0482) rabbitmq-server: 3.9.14 -> 3.10.6
* [`1a1fbf4a`](https://github.com/NixOS/nixpkgs/commit/1a1fbf4a947f37592a7756275ffe9bc3f4ee7c93) sd-local: 1.0.40 -> 1.0.42
* [`f5706406`](https://github.com/NixOS/nixpkgs/commit/f5706406ed1b38f17402929a5a85c701484dffad) smug: 0.2.7 -> 0.3.2
* [`a821f7c9`](https://github.com/NixOS/nixpkgs/commit/a821f7c91a6b9819a6738d6c12ea0ad4a26a1c17) ciftilib: init at 1.6.0
* [`79d65a88`](https://github.com/NixOS/nixpkgs/commit/79d65a8851703f2111df9ea95632c68e7ac6dab4) bind: 9.18.4 -> 9.18.5
* [`bfe067c2`](https://github.com/NixOS/nixpkgs/commit/bfe067c2f6b10ea1cfdf23ef669572ebb24b63cd) t-rec: 0.7.3 -> 0.7.4
* [`c621e100`](https://github.com/NixOS/nixpkgs/commit/c621e100ee79b3d60b6bf2fa92c6874aa2b50a1f) wabt: 1.0.28 -> 1.0.29
* [`321f94fb`](https://github.com/NixOS/nixpkgs/commit/321f94fb46bad176d852daa7be9c345f69921716) awscli: 1.25.31 -> 1.25.42
* [`e38f4a75`](https://github.com/NixOS/nixpkgs/commit/e38f4a75f6c284ec2548854060e55926bbab34db) python3Packages.boto3: 1.24.31 -> 1.24.42
* [`3c78886a`](https://github.com/NixOS/nixpkgs/commit/3c78886a42c5fc82d70c773d5a5c28809958e6a8) python3Packages.botocore: 1.27.31 -> 1.27.42
* [`833352d5`](https://github.com/NixOS/nixpkgs/commit/833352d52c9b278f37ea5635dd3ffe1795df3f89) groonga: 11.1.0 -> 12.0.5
* [`7826c54c`](https://github.com/NixOS/nixpkgs/commit/7826c54c05592429ec912dced39ce64dd8c4aff8) libosmocore: 1.6.0 -> 1.7.0
* [`9a59b1b0`](https://github.com/NixOS/nixpkgs/commit/9a59b1b0fed320fef681f0f3a19590b39c8d840c) libosmocore: fix version in pkg-config file
* [`db8c2303`](https://github.com/NixOS/nixpkgs/commit/db8c23037a5d162d2cb380300102e5ac9b049ebb) python3Packages.mistune_0_8: mark knownVulnerabilities CVE-2022-34749
* [`067ebaa7`](https://github.com/NixOS/nixpkgs/commit/067ebaa7df93c797b6c488d157f197bc58449ef5) python3Packages.threadpoolctl: 3.0.0 -> 3.1.0
* [`13211bf3`](https://github.com/NixOS/nixpkgs/commit/13211bf35948df076de7c9837edc497cb7d4843e) kodiPackages.inputstream-ffmpegdirect: 19.0.1 -> 19.0.3
* [`6660c00c`](https://github.com/NixOS/nixpkgs/commit/6660c00c445124c8387a11c110cf12c3f16ca704) kodiPackages.inputstream-adaptive: 19.0.3 -> 19.0.7
* [`96f6c8ae`](https://github.com/NixOS/nixpkgs/commit/96f6c8aed5eb6ec806bdd65a5cd9e8af09dd5a6a) kodiPackages.pvr-iptvsimple: 19.1.0 -> 19.1.1
* [`a5123553`](https://github.com/NixOS/nixpkgs/commit/a5123553534f81e3163943b70eb4f22283a74823) libpsm2: 11.2.206 -> 11.2.229
* [`a043195d`](https://github.com/NixOS/nixpkgs/commit/a043195d2cf8c16dd78182577e32a9bb4c0370f9) jruby: mark as sourceProvenance binaryBytecode
* [`1ac68fd2`](https://github.com/NixOS/nixpkgs/commit/1ac68fd225721bb7319bb6f51aaa6f2147d3bad2) megapixels: 1.5.0 -> 1.5.2
* [`86486109`](https://github.com/NixOS/nixpkgs/commit/86486109531888ab00e814e838a22cd0c8721523) masterpdfeditor: 5.8.46 -> 5.8.70
* [`62b02108`](https://github.com/NixOS/nixpkgs/commit/62b02108c34fad993b970174b7c80929ad4e5b6a) libmysqlconnectorcpp: 8.0.28 -> 8.0.29
* [`e3202f90`](https://github.com/NixOS/nixpkgs/commit/e3202f90f51280daf6beb5ec7c625c27765a9659) morgen: 2.5.2 -> 2.5.8
* [`fff013f4`](https://github.com/NixOS/nixpkgs/commit/fff013f49fe1a37d995f01cfe7666edef4ca8a97) mercury: 22.01.1 -> 22.01.3
* [`b80af6d0`](https://github.com/NixOS/nixpkgs/commit/b80af6d08dbe58d98cf5dc5ae53c88b00c73ff83) nanopb: 0.4.5 -> 0.4.6
* [`297ea976`](https://github.com/NixOS/nixpkgs/commit/297ea976260efca3f74613de79ad95b81c244fbe) opkg: 0.4.5 -> 0.6.0
* [`014161ff`](https://github.com/NixOS/nixpkgs/commit/014161ff37233e40ebc2b6382044382793810d29) parted: 3.4 -> 3.5
* [`f0af71a9`](https://github.com/NixOS/nixpkgs/commit/f0af71a99242df73b503e29bf7aa7b6a66cd641f) pam_u2f: 1.2.0 -> 1.2.1
* [`25df1de3`](https://github.com/NixOS/nixpkgs/commit/25df1de33479b10e4a682a323c3b145f43280126) pure-ftpd: 1.0.50 -> 1.0.51
* [`3ff276b5`](https://github.com/NixOS/nixpkgs/commit/3ff276b5cd25ea96da27cc4ed6497bcb40ab5ad5) prometheus-systemd-exporter: 0.4.0 -> 0.5.0
* [`7f86bd5a`](https://github.com/NixOS/nixpkgs/commit/7f86bd5a259e72f703de530ffd23c3168364ec1e) profile-sync-daemon: 6.44 -> 6.45
* [`751df2de`](https://github.com/NixOS/nixpkgs/commit/751df2de1f914e962761de7c0612c03ad13cec77) pidgin: 2.14.8 -> 2.14.10
* [`2f54ab5e`](https://github.com/NixOS/nixpkgs/commit/2f54ab5e1ac4605be75bc117ed697755a10e0ec8) pipenv: 2022.6.7 -> 2022.7.24
* [`8682d275`](https://github.com/NixOS/nixpkgs/commit/8682d2757727af49d920aca21898d1ebb0c38e0f) python39Packages.bids-validator: 1.9.5 -> 1.9.7
* [`911c893b`](https://github.com/NixOS/nixpkgs/commit/911c893b3eb0a7d64931a4396e94804e9982b5f0) prometheus-sql-exporter: 0.4.2 -> 0.4.4
* [`5cdb4467`](https://github.com/NixOS/nixpkgs/commit/5cdb4467d2426a59c354eb9f4bd3cedc5ab57d1e) psmisc: 23.4 -> 23.5
* [`cb5453fd`](https://github.com/NixOS/nixpkgs/commit/cb5453fd64cd2c958812dab4d498c3313c64bc86) python310Packages.flask-caching: 2.0.0 -> 2.0.1
* [`588d7238`](https://github.com/NixOS/nixpkgs/commit/588d7238ad333caf8430d9e2429773aff4ab510f) python310Packages.easy-thumbnails: 2.8.1 -> 2.8.2
* [`b256b035`](https://github.com/NixOS/nixpkgs/commit/b256b035bd2f9f88ed42e3f7dbf37b770f5a7741) python310Packages.flask-security-too: 4.1.4 -> 4.1.5
* [`071eff7a`](https://github.com/NixOS/nixpkgs/commit/071eff7a61f814a8ac6798dae962cacd5cc933ed) minio-client: 2022-07-24T02-25-13Z -> 2022-07-29T19-17-16Z
* [`13b3f844`](https://github.com/NixOS/nixpkgs/commit/13b3f8442ed233c2bc91b72bcc3fd2133df85750) minio: 2022-07-26T00-53-03Z -> 2022-07-30T05-21-40Z
* [`6631e48c`](https://github.com/NixOS/nixpkgs/commit/6631e48c0dd64a8073723b76baf5ee0ef8deb5f9) jellyfin-web: 10.8.1 -> 10.8.2
* [`dac87808`](https://github.com/NixOS/nixpkgs/commit/dac87808a58abbc6727f99f0fe99a694b3541a60) jellyfin: 10.8.1 -> 10.8.2
* [`1c795f46`](https://github.com/NixOS/nixpkgs/commit/1c795f46ca9caf5c7143f0095967c6dc991c3949) python3Packages.batchgenerators: 0.21 -> 0.24
* [`86079aa0`](https://github.com/NixOS/nixpkgs/commit/86079aa01f5f375efb79ccb66204a669bf710bcd) snd: 22.2 -> 22.5
* [`313205f8`](https://github.com/NixOS/nixpkgs/commit/313205f8cdf96a41ca3a506cd3581405744e2237) clevis: add various packages to wrapper
* [`9d4ad27d`](https://github.com/NixOS/nixpkgs/commit/9d4ad27d62412b944111616937311fe96e65a748) stress-ng: 0.13.09 -> 0.14.03
* [`91a86129`](https://github.com/NixOS/nixpkgs/commit/91a8612983d6a90a591751699d7b50f2a48899d5) subgit: 3.3.13 -> 3.3.15
* [`a9bb05b6`](https://github.com/NixOS/nixpkgs/commit/a9bb05b68027a71ca6951c79abfc5fd8e43f8927) timescaledb-parallel-copy: 0.3.0 -> 0.4.0
* [`f2831902`](https://github.com/NixOS/nixpkgs/commit/f2831902150efc1c4556e386dd755814be088c5f) uftrace: 0.11 -> 0.12
* [`a99974ef`](https://github.com/NixOS/nixpkgs/commit/a99974ef34095a5f6931a206b82ce2ed6c0e8db8) wallutils: 5.11.0 -> 5.11.1
* [`44fc292b`](https://github.com/NixOS/nixpkgs/commit/44fc292b5e26b0052bfc12cc68b63b6f094c2175) wmutils-core: 1.6 -> 1.7
* [`1a6c5e61`](https://github.com/NixOS/nixpkgs/commit/1a6c5e616af7ebe19cdcf1a7de96777e154d6461) vc: 1.4.2 -> 1.4.3
* [`650a88e3`](https://github.com/NixOS/nixpkgs/commit/650a88e301b8a6cb777fabfa9953b7a273109725) xlockmore: 5.69 -> 5.70
* [`f3fee16b`](https://github.com/NixOS/nixpkgs/commit/f3fee16ba5ada5593718725c1b457c4100b75a1d) yubihsm-shell: 2.3.1 -> 2.3.2
* [`9691d0eb`](https://github.com/NixOS/nixpkgs/commit/9691d0eba7c12d9bd86efc4f3e3000c4fb9912de) zfs-prune-snapshots: 1.3.0 -> 1.5.0
* [`07aeccaa`](https://github.com/NixOS/nixpkgs/commit/07aeccaac2f991711d77f204dba745c41d64f17f) jellyfin: 10.8.2 -> 10.8.3
* [`3b324e8b`](https://github.com/NixOS/nixpkgs/commit/3b324e8bf180e162b9c5316b0f82f6cea6cd9e27) jellyfin-web: 10.8.2 -> 10.8.3
* [`975b892e`](https://github.com/NixOS/nixpkgs/commit/975b892ea8dc00cca9d4e044698b7d70323d7978) dnscrypt-proxy2: 2.1.1 -> 2.1.2
* [`ad8148a9`](https://github.com/NixOS/nixpkgs/commit/ad8148a98bab69cc561b0b47e88365afdfa9718a) faiss: init at 1.7.2
* [`13aaa027`](https://github.com/NixOS/nixpkgs/commit/13aaa027b5fa5d4fdbdaac7ae9eef2fe9ef97005) faiss: comment on why swig4
* [`ad5e59c1`](https://github.com/NixOS/nixpkgs/commit/ad5e59c123e10f09d7fb9ae6895454dea6902eac) python3Packages.faiss: rm comment about windows
* [`cd43db0c`](https://github.com/NixOS/nixpkgs/commit/cd43db0c948f1c2e6650ad6eae2ef88a8cca6e12) python3Packages.faiss: conventional "tests.nix" name
* [`a8be6667`](https://github.com/NixOS/nixpkgs/commit/a8be6667abbcf28205e176d6f8715dfc0b242357) clickhouse-backup: 1.4.9 -> 1.5.0
* [`47444b41`](https://github.com/NixOS/nixpkgs/commit/47444b41c9761581cb04b4e516c953af63025cf6) dolt: 0.40.15 -> 0.40.21
* [`9ba2e74b`](https://github.com/NixOS/nixpkgs/commit/9ba2e74b88a402546113e4518bc1a7295c21ff21) mt32emu-smf2wav: 1.8.2 -> 1.9.0
* [`a0010928`](https://github.com/NixOS/nixpkgs/commit/a00109285cde26ce801fb780086622f82f6e32de) rdkafka: 1.9.1 -> 1.9.2
* [`19b05975`](https://github.com/NixOS/nixpkgs/commit/19b05975eb8086d9f07f8e4f56e59ccfb48d6720) github-desktop: 3.0.3 -> 3.0.5
* [`5c866bc8`](https://github.com/NixOS/nixpkgs/commit/5c866bc8a0c43e19c1143cee17caff5355e15008) openai: 0.22.0 -> 0.22.1
* [`98ed62e4`](https://github.com/NixOS/nixpkgs/commit/98ed62e4eb1dc5e24d9fcfaddd2e5938d5ad6864) cryptomator: 1.6.10 -> 1.6.12
* [`128a3b10`](https://github.com/NixOS/nixpkgs/commit/128a3b10a696a1d29a6f71fad0033520cbd063c5) libguestfs: format using nixpkgs-fmt
* [`c2c7a1bd`](https://github.com/NixOS/nixpkgs/commit/c2c7a1bd6e4cb63165859e8222513cb743243001) railway: 1.8.4 -> 2.0.0
* [`aa30734c`](https://github.com/NixOS/nixpkgs/commit/aa30734c179fdba2efebfad79524d2c685b364cf) open-watcom-v2-unwrapped: unstable-2022-05-04 -> unstable-2022-08-02
* [`29fb8273`](https://github.com/NixOS/nixpkgs/commit/29fb8273cc0518a27a54354f964f6d125916ecc0) fira-go: init at 1.001
* [`134da4ce`](https://github.com/NixOS/nixpkgs/commit/134da4ce3655b84fe7ade62486ab858ee141c3a3) buildDotnetModule: fix build for dotnet-sdk versions below 6
* [`cf6b5e16`](https://github.com/NixOS/nixpkgs/commit/cf6b5e162421e8aa64ff2affd67e327a0187a318) open-watcom-bin-unwrapped: improve meta
* [`16395a97`](https://github.com/NixOS/nixpkgs/commit/16395a9797d82b633e228aab2c0d5170b16937b8) wrapWatcom: use passthru.prettyName
* [`566d1258`](https://github.com/NixOS/nixpkgs/commit/566d1258d1edfc01499a1a3f693aa64c951f12cd) scala-cli: 0.1.10 -> 0.1.11
* [`15978c5c`](https://github.com/NixOS/nixpkgs/commit/15978c5cd91a485e80aa9f21f2d90d5d63d2378c) krane: 2.4.7 → 2.4.9
* [`141ec34c`](https://github.com/NixOS/nixpkgs/commit/141ec34c9a8c3b6ec04324d18b624abec981c5f4) beets: fix pygobject issues
* [`4c2764c6`](https://github.com/NixOS/nixpkgs/commit/4c2764c69c094d6917ff857aa4667f8886ef8d5e) nixos/switch-to-configuration: replace Net::DBus with busctl
* [`bda6036d`](https://github.com/NixOS/nixpkgs/commit/bda6036d2e7d6f9bd475727f861b3bede3c342ae) nixos/xpadneo: don't disable ertm on kernel 5.12 or later
* [`a04107a0`](https://github.com/NixOS/nixpkgs/commit/a04107a0af75c6a7f7f9830dc22df6b91895886a) foremost: unbreak on Darwin
* [`cbbe6272`](https://github.com/NixOS/nixpkgs/commit/cbbe6272f77c3d720882a0f6d4c031b7fc5803e2) circleci-cli: 0.1.17142 -> 0.1.20397
* [`236b0534`](https://github.com/NixOS/nixpkgs/commit/236b053413023b2f0cc82e49be7d9ea551e1487e) nixos/gitea: fix statix warnings
* [`ffbccb20`](https://github.com/NixOS/nixpkgs/commit/ffbccb20bd90acb8db44a53e1201a61ff34b3a7c) nixos/gitea: convert simple settings to freeform settings
* [`4f04f531`](https://github.com/NixOS/nixpkgs/commit/4f04f5312043990ff22411d7c76f40a9f6419754) dendrite: 0.8.9 -> 0.9.1
* [`7b5cf21d`](https://github.com/NixOS/nixpkgs/commit/7b5cf21d2e5f69eb39c444c7296151125673d1c4) offpunk: 1.4 -> 1.5
* [`ff6a0037`](https://github.com/NixOS/nixpkgs/commit/ff6a0037d96b3f3cf864aeac8422bea6bb603f5a) offpunk: Add passthru.tests.version
* [`1c1e0e03`](https://github.com/NixOS/nixpkgs/commit/1c1e0e03536de9df23bd4ffe7c343d88dcd43795) cmake-language-server: remove pyparsing dependency
* [`018acd1e`](https://github.com/NixOS/nixpkgs/commit/018acd1e677e7c4cf5e629ad31d559506715218a) cmake-language-server: 0.1.5 → 0.1.6
* [`82c64d15`](https://github.com/NixOS/nixpkgs/commit/82c64d154b2743f34092bc1be519845c4496142d) nixos/nixos-containers: Fix ineffective warning
* [`1339f1e0`](https://github.com/NixOS/nixpkgs/commit/1339f1e02b23023aa29a12d1f817feab95cfc3c7) nixosTests.isso: fix failing test
* [`6132fda0`](https://github.com/NixOS/nixpkgs/commit/6132fda0205b5549ccc35d091ce9fa0955375da5) oha: 0.5.0 -> 0.5.3
* [`38e3c1e9`](https://github.com/NixOS/nixpkgs/commit/38e3c1e9669bf9daf2e4a63cfbd24ed10bf0cc90) cargo-modules: 0.5.10 -> 0.5.11
* [`42274bc3`](https://github.com/NixOS/nixpkgs/commit/42274bc3f3499ac2d62a90db8e47f956f1ef1a5d) python310Packages.mockito: 1.3.3 -> 1.3.4
* [`18d2c12d`](https://github.com/NixOS/nixpkgs/commit/18d2c12d1d57a4b893fd46e936cca2aba1878888) cargo-deny: 0.12.1 -> 0.12.2
* [`8b7c09d0`](https://github.com/NixOS/nixpkgs/commit/8b7c09d0e68b16f1e13a7a600c139611f166c5ca) delly: 1.0.3 -> 1.1.3
* [`f682d6ed`](https://github.com/NixOS/nixpkgs/commit/f682d6edb584aafa8f1d3f02ab79fe6231da14c0) double-conversion: 3.2.0 -> 3.2.1
* [`ce174a26`](https://github.com/NixOS/nixpkgs/commit/ce174a26dc86eaa39a5d3df4bac801584f67f31c) flyctl: 0.0.363 -> 0.0.366
* [`0d3fc9d1`](https://github.com/NixOS/nixpkgs/commit/0d3fc9d108bf31ad96604c00576711d2ee02f4a8) avro-tools: 1.11.0 -> 1.11.1
* [`f1cccf31`](https://github.com/NixOS/nixpkgs/commit/f1cccf31f3ae3050e760103c10244f898ac5744a) helmsman: 3.13.0 -> 3.13.1
* [`bb887a64`](https://github.com/NixOS/nixpkgs/commit/bb887a641c94aaee2eba8af8720e8e2a024591e1) kics: 1.5.12 -> 1.5.13
* [`431eeed8`](https://github.com/NixOS/nixpkgs/commit/431eeed87ba4f3765ae06269147ce85ce0d99ce4) libupnp: 1.14.12 -> 1.14.13
* [`2fe88023`](https://github.com/NixOS/nixpkgs/commit/2fe88023bcb56f89614fe63706df5218f29d0818) mold: 1.3.1 -> 1.4.0
* [`b6ee99e0`](https://github.com/NixOS/nixpkgs/commit/b6ee99e0c92b1a8aa0204aa9146be3eed854f4a4) radioboat: 0.2.1 -> 0.2.2
* [`46c35072`](https://github.com/NixOS/nixpkgs/commit/46c3507238b11412cee70d5edbcb9d187836d776) rocksdb: 7.4.4 -> 7.4.5
* [`ab0af326`](https://github.com/NixOS/nixpkgs/commit/ab0af3267feab9fa636d65a9b3ff64ad0784af6f) Revert "qemu: fix build w/glibc-2.33"
* [`82dc1edf`](https://github.com/NixOS/nixpkgs/commit/82dc1edf5904ad1a8c0d71cf630ca4dd55949220) system76-keyboard-configurator: 1.0.0 -> 1.2.0
* [`423545fe`](https://github.com/NixOS/nixpkgs/commit/423545fe4865d126e86721ba30da116e29c65004) nixos/*: normalize manpage references to single-line form
* [`84f573b9`](https://github.com/NixOS/nixpkgs/commit/84f573b9d17cc86cc68973c907d216ec735d06cf) temporal: 1.17.1 -> 1.17.2
* [`51a15b7e`](https://github.com/NixOS/nixpkgs/commit/51a15b7e9225ea4cc792facaeaa0042cba7aa33f) appgate-sdp: 5.5.5 -> 6.0.1
* [`88437fc6`](https://github.com/NixOS/nixpkgs/commit/88437fc62ebaa7d52141275c705b28cc72061eea) ArchiSteamFarm: 5.2.7.7 -> 5.2.8.3
* [`6626ca02`](https://github.com/NixOS/nixpkgs/commit/6626ca0232f5ba7e295f0a75f7c8086204de87b9) orcania: 2.2.2 -> 2.3.0
* [`4756347d`](https://github.com/NixOS/nixpkgs/commit/4756347d4947e15c25f98efbdbcdd976bc4f7b13) yder: 1.4.15 -> 1.4.17
* [`d3bbe7fa`](https://github.com/NixOS/nixpkgs/commit/d3bbe7fab6c8fc92b58e8dbdb87f3bd1b2bde55e) fcitx5-gtk: 5.0.16 -> 5.0.17
* [`d08254b9`](https://github.com/NixOS/nixpkgs/commit/d08254b9dd43962ae5ea94255d4cd9b233cc63ca) dendrite: unpin go version
* [`8ed1d4bf`](https://github.com/NixOS/nixpkgs/commit/8ed1d4bf2ab38f3d79d6f08a4b138edf529231ae) arkade: 0.8.29 -> 0.8.30
* [`00859ef4`](https://github.com/NixOS/nixpkgs/commit/00859ef4d00988e528a597f889d951af2e0bd8bb) saleae-logic-2: 2.3.56 -> 2.3.58
* [`aba4ef1f`](https://github.com/NixOS/nixpkgs/commit/aba4ef1f3f7d048444de362d5a022030492f4670) apacheKafka: mark as sourceProvenance binaryBytecode
* [`45cbde4b`](https://github.com/NixOS/nixpkgs/commit/45cbde4b556635c18628d5d17db0e4d10ab0d103) sile: 0.13.3 → 0.14.0
* [`976468d6`](https://github.com/NixOS/nixpkgs/commit/976468d6627d9736a1000933cafe804319829837) oil: 0.12.0 -> 0.12.3
* [`d6905d06`](https://github.com/NixOS/nixpkgs/commit/d6905d065a6521653488b8f7ad96198d1072e27c) pcsx2: 1.7.3128 -> 1.7.3165
* [`0a70cfef`](https://github.com/NixOS/nixpkgs/commit/0a70cfeff417719a53f8147923cf22db012c9a9d) ortp: 5.1.12 -> 5.1.55
* [`74cf8fa9`](https://github.com/NixOS/nixpkgs/commit/74cf8fa942dcb48833c7d64fc5b7bc9be6f0c96f) petsc: 3.17.3 -> 3.17.4
* [`68878c9e`](https://github.com/NixOS/nixpkgs/commit/68878c9e1e73abd83f3120e82445b3dbc63e86df) python39Packages.confluent-kafka: 1.9.0 -> 1.9.2
* [`98ba23d0`](https://github.com/NixOS/nixpkgs/commit/98ba23d04346c36eb359bd254834dad132e88434) python310Packages.mailchecker: 4.1.18 -> 5.0.0
* [`eb6b78a4`](https://github.com/NixOS/nixpkgs/commit/eb6b78a43b4f6474afb308ab8124fa22eef7f930) python310Packages.Wand: 0.6.8 -> 0.6.9
* [`234eb044`](https://github.com/NixOS/nixpkgs/commit/234eb04495155d1e6d7e297f023f6070c55f1918) trino-cli: 390 -> 392
* [`a567b45e`](https://github.com/NixOS/nixpkgs/commit/a567b45ef61810966ab4b71006b72835dd0fd969) libguestfs: 1.48.0 -> 1.48.4
* [`ea501443`](https://github.com/NixOS/nixpkgs/commit/ea5014439245b43bc37d4dad23a64ec79e8c4955) xschem: 3.0.0 -> 3.1.0
* [`4b200c34`](https://github.com/NixOS/nixpkgs/commit/4b200c342c93763ff1dff821caa1af444573bcb2) ytfzf: 2.4.0 -> 2.4.1
* [`c4dc43a8`](https://github.com/NixOS/nixpkgs/commit/c4dc43a8fabad0bdde012207e9055b2c36f1141b) apfsprogs: unstable-2022-02-23 -> unstable-2022-07-21
* [`d3fbc5df`](https://github.com/NixOS/nixpkgs/commit/d3fbc5dfba716633f44399733ace3e322f2e97c5) all-cabal-hashes: 2022-07-31T09:12:37Z -> 2022-08-06T12:01:14Z
* [`9aa722d1`](https://github.com/NixOS/nixpkgs/commit/9aa722d1507a8ea1f1ab6fe4def61720a17bdd9f) haskellPackages.keid-{frp-banana,resource-gltf}: set platforms
* [`b30a82ca`](https://github.com/NixOS/nixpkgs/commit/b30a82caa8d6e02bbf65b00e67b7285efb0979c2) realvnc-vnc-viewer: 6.22.207 -> 6.22.515
* [`3d6e5457`](https://github.com/NixOS/nixpkgs/commit/3d6e54576b99c45eaa7361cd2abf64b8fce5e775) haskell.packages.ghc924: adapt to ormolu update
* [`d05755d9`](https://github.com/NixOS/nixpkgs/commit/d05755d90bb7cd9c3770a1328999fba7c5a8c091) haskellPackages: adapt to hspec updates
* [`4e4028d0`](https://github.com/NixOS/nixpkgs/commit/4e4028d0d8a21d1a4bc789d8cb9a231f6d29914c) padbuster: init at 0.3.3
* [`42a4bf89`](https://github.com/NixOS/nixpkgs/commit/42a4bf892700353993a4e4a220caa1d90b723066) social-engineer-toolkit: init at 8.0.3
* [`409e17a9`](https://github.com/NixOS/nixpkgs/commit/409e17a9b5ff2de3ac5158cd6bb49ab0539a3744) python310Packages.python-gvm: 22.6.1 -> 22.7.0
* [`087472b1`](https://github.com/NixOS/nixpkgs/commit/087472b1e5230ffc8ba642b1e4f9218adf4634a2) nixos/*: automatically convert option docs
* [`f71d32da`](https://github.com/NixOS/nixpkgs/commit/f71d32da64f46e5ed7d9d6c0d412943636e8d83a) shellnoob: init at unstable-2022-03-16
* [`cc477fb3`](https://github.com/NixOS/nixpkgs/commit/cc477fb34d8924c88d29e77b5101070c907a7aac) zfs: Make zpool available for zpool-expand-pools
* [`944a4663`](https://github.com/NixOS/nixpkgs/commit/944a46637360c0235fb9e338bdc8349fefac1ab0) fix whitespace
* [`00b05d1f`](https://github.com/NixOS/nixpkgs/commit/00b05d1fe594cbcccbc05975abd521326980e547) sile: 0.14.0 → 0.14.1
* [`a335e915`](https://github.com/NixOS/nixpkgs/commit/a335e915e1609584d3114cebefd5007d4d83bd50) python310Packages.bitlist: 0.8.0 -> 1.0.1
* [`6ce9c9ad`](https://github.com/NixOS/nixpkgs/commit/6ce9c9ad4de880823afca5f00a877ec1447d8bd3) python310Packages.fountains: 1.3.0 -> 2.0.0
* [`a2bbcde7`](https://github.com/NixOS/nixpkgs/commit/a2bbcde74ebd76b54b1297bf8b71f81c88fb8ed7) vtk_9: 9.0.3 -> 9.1.0
* [`8787835f`](https://github.com/NixOS/nixpkgs/commit/8787835fe3821e47b4e0043d96be329f44416604) flyway: 9.0.4 -> 9.1.2
* [`6a5f7b66`](https://github.com/NixOS/nixpkgs/commit/6a5f7b66ca60fe4df2210b4de25e938642468100) librealsense: add enableGUI option
* [`33f22536`](https://github.com/NixOS/nixpkgs/commit/33f225361cf255feba808053e1c919039a12e8a3) tidy-viewer: 1.4.6 -> 1.4.30
* [`c9d01149`](https://github.com/NixOS/nixpkgs/commit/c9d011497d900f85e1a304610be4722545f80ecb) hsqldb: 2.6.1 -> 2.7.0
* [`00b2e45c`](https://github.com/NixOS/nixpkgs/commit/00b2e45cc947a4119562b4b718aac8ae17b07680) hwinfo: 21.82 -> 22.0
* [`31513846`](https://github.com/NixOS/nixpkgs/commit/31513846001c75d6c1a93acc1eb439c1fae6ee96) grab-site: 2.2.2 -> 2.2.7
* [`fb324910`](https://github.com/NixOS/nixpkgs/commit/fb324910bfb9bc9e870ee8341d88bb6449b3eb27) nixos/stage-1: srestore striping of bin/ and lib/
* [`52e86e2b`](https://github.com/NixOS/nixpkgs/commit/52e86e2b22997bbe98dd654afe9d48fc2905f645) python310Packages.pyperf: 2.4.0 -> 2.4.1
* [`42df18cf`](https://github.com/NixOS/nixpkgs/commit/42df18cf76340a657ba54be574e17da243c5c6ec) sentencepiece: 0.1.96 -> 0.1.97
* [`a2c041a1`](https://github.com/NixOS/nixpkgs/commit/a2c041a1d7ba773b0434ead39a85314381982d49) sentry-native: 0.4.18 -> 0.5.0
* [`28ad278c`](https://github.com/NixOS/nixpkgs/commit/28ad278c79d865d8894684a20f6576cf6905d4b2) tilt: 0.30.5 -> 0.30.6
* [`6c585155`](https://github.com/NixOS/nixpkgs/commit/6c585155287fd0a088fb5c5f97eed35584fd663f) syncthingtray: 1.2.1 -> 1.2.2
* [`7b77d1a6`](https://github.com/NixOS/nixpkgs/commit/7b77d1a62ece3ab68f08123061b3f1379be18f22) wesnoth: 1.16.4 -> 1.16.5
* [`1f7bdfdc`](https://github.com/NixOS/nixpkgs/commit/1f7bdfdc2075d23b8d69055307f8b77e489b3722) maintainers: add samw
* [`cbe518b2`](https://github.com/NixOS/nixpkgs/commit/cbe518b29381638d07ac72c321a2ae1b328d8bfe) pngpaste: init at 0.2.3
* [`6771519b`](https://github.com/NixOS/nixpkgs/commit/6771519bf3c5cdfa05ee9c912af0807392ded55b) tidal-hifi: 4.0.1 -> 4.1.0
* [`0442ab82`](https://github.com/NixOS/nixpkgs/commit/0442ab82e0be6a1b577a58125d731d65de2f5d68) igv: 2.8.13 -> 2.13.2
* [`5e377ca0`](https://github.com/NixOS/nixpkgs/commit/5e377ca0125ff8337a9fa759462079ec59c17301) all-cabal-hashes: 2022-08-06T12:01:14Z -> 2022-08-07T14:05:30Z
* [`00d73d53`](https://github.com/NixOS/nixpkgs/commit/00d73d5385b63e868bd11282fb775f6fe4921fb5) haskellPackages: regenerate package set based on current config
* [`f3e806ed`](https://github.com/NixOS/nixpkgs/commit/f3e806edf4fd27362dad80a02ac96e3f9f485f51) mysql: 8.0.29 -> 8.0.30
* [`b64c6c62`](https://github.com/NixOS/nixpkgs/commit/b64c6c62473f1a3d84e703ed62f5c62664ba9901) python310Packages.python-engineio: 4.3.3 -> 4.3.4
* [`a9daa4bd`](https://github.com/NixOS/nixpkgs/commit/a9daa4bd3e6a5e29868e264d4b10b23ca959d07b) python310Packages.python-socketio: 5.7.0 -> 5.7.1
* [`04e0c8f5`](https://github.com/NixOS/nixpkgs/commit/04e0c8f5f4ec0f7872faca87cfa0c01caa2c68ac) miniz: init at 2.2.0
* [`1015914b`](https://github.com/NixOS/nixpkgs/commit/1015914bdc785a67e539bd61bc06d98f00380a02) python310Packages.readme_renderer: 35.0 -> 36.0
* [`b0a02108`](https://github.com/NixOS/nixpkgs/commit/b0a02108e6d5a5ff5acda2665b1bceb148f4cffc) trenchbroom: 2021.1 -> 2022.1
* [`bf068c01`](https://github.com/NixOS/nixpkgs/commit/bf068c01d991086cd10139d47f5917829d869040) bisq: 1.9.1 -> 1.9.4
* [`aecf8393`](https://github.com/NixOS/nixpkgs/commit/aecf8393c54ec73b32c7fb2a3a65c1c25df59fb4) nbxplorer: 2.3.28 -> 2.3.33
* [`6716c682`](https://github.com/NixOS/nixpkgs/commit/6716c682c845d523d8540b011fe796449c90b77d) btcpayserver: 1.6.1 -> 1.6.6
* [`79277c3f`](https://github.com/NixOS/nixpkgs/commit/79277c3fd5ab394627f40e242189901b4a3edc40) vips: 8.12.2 -> 8.13.0
* [`5d5859df`](https://github.com/NixOS/nixpkgs/commit/5d5859df9b66978da74277df904338b231481bd2) sgtpuzzles-mobile: init
* [`2dd1fdec`](https://github.com/NixOS/nixpkgs/commit/2dd1fdecfe2fb6a577fd1f375af3ac167d2904db) python310Packages.aiohttp-jinja2: disable tests
* [`4cb2de4c`](https://github.com/NixOS/nixpkgs/commit/4cb2de4c49bcde8f6c472ccc958bb2e2c4f302db) python3Packages.bellows: 0.31.2 -> 0.31.3
* [`bf0cdfc8`](https://github.com/NixOS/nixpkgs/commit/bf0cdfc8ab9cf3a4bedfa0b195311ef583125670) python3Packages.greeclimate: 1.2.1 -> 1.3.0
* [`ffbeb99b`](https://github.com/NixOS/nixpkgs/commit/ffbeb99b896d3a5557fecb8422a8f1c6193fa356) python3Packages.zigpy: 0.48.0 -> 0.49.0
* [`76e7ca2c`](https://github.com/NixOS/nixpkgs/commit/76e7ca2cfc1737582623564cd6a886db52f0c7b2) python3Packages.colorzero: init at 2.0
* [`3a8f3937`](https://github.com/NixOS/nixpkgs/commit/3a8f3937a3a21eb5644acaf4f139eee6927d5677) python3Packages.gpiozero: init at 1.6.2
* [`eab827c6`](https://github.com/NixOS/nixpkgs/commit/eab827c6eeb46cc52a24a285dcc88bddfc787707) python3Packages.zigpy-zigate: 0.9.0 -> 0.9.1
* [`22880e58`](https://github.com/NixOS/nixpkgs/commit/22880e58edd8be6024daf9e6fa4bae95b1449810) zee: init at `0.3.2`
* [`fc497efb`](https://github.com/NixOS/nixpkgs/commit/fc497efb780802d2df568f0591674755645519a3) sioyek: unbreak on darwin
* [`2056075f`](https://github.com/NixOS/nixpkgs/commit/2056075fdba17f66fefe456526418d36c48e3519) haskellPackages.text-format: fix GHC 9.2 build
* [`053fb006`](https://github.com/NixOS/nixpkgs/commit/053fb00690945ab06650c4508b98659c6a2343b6) freerdp: 2.7.0 -> 2.8.0
* [`5e14cac0`](https://github.com/NixOS/nixpkgs/commit/5e14cac0b10359c894ee44158a6cc71227506c55) wezterm: 20220624-141144-bd1b7c5d -> 20220807-113146-c2fee766
* [`f51f7225`](https://github.com/NixOS/nixpkgs/commit/f51f722597598eec959df03ea0ffe82444d6609f) cinny: 2.0.4 -> 2.1.1
* [`58567142`](https://github.com/NixOS/nixpkgs/commit/585671427ea3dec2ecf2e6030495a9b208ebfbe4) haskellPackages.text-format: add comment about patch
* [`228a897a`](https://github.com/NixOS/nixpkgs/commit/228a897afd190012b9a32fba096c4a057fa2a7f9) Update nitter.nix
* [`7b6ad60a`](https://github.com/NixOS/nixpkgs/commit/7b6ad60ab4cd0661c5aa515a7de28ddda73a3e70) hackedbox: init at 0.8.5.1
* [`106d7ac6`](https://github.com/NixOS/nixpkgs/commit/106d7ac603f5523d43ae1be96c788b8639c64750) v2ray-geoip: 202207070057 -> 202208040058
* [`b3b45e6b`](https://github.com/NixOS/nixpkgs/commit/b3b45e6b5fad61521c025abc6eb15218630f6a04) v2ray-domain-list-community: 20220708161253 -> 20220808014309
* [`7761d8aa`](https://github.com/NixOS/nixpkgs/commit/7761d8aa56009f01a4ff06782c9ce4ceb3727bec) xp-pen-deco-01-v2-driver: init at 3.2.3.220323-1
* [`66327cf6`](https://github.com/NixOS/nixpkgs/commit/66327cf6873aa286d1d45c9c05be4d59acd7bfc3) pentablet-driver: rename to xp-pen-g430-driver
* [`bf097721`](https://github.com/NixOS/nixpkgs/commit/bf0977210939b2e46fd245d0687e1bf97390331f) gitleaks: 8.9.0 -> 8.10.0
* [`4a501a06`](https://github.com/NixOS/nixpkgs/commit/4a501a0664b92a29b4fe5d46bf7d3ad6ba6ddda1) python310Packages.hahomematic: 2022.8.2 -> 2022.8.3
* [`d8dc3f60`](https://github.com/NixOS/nixpkgs/commit/d8dc3f609c48dca237450da2b85edd4b99418f9c) python310Packages.aioairzone: 0.4.6 -> 0.4.8
* [`81365587`](https://github.com/NixOS/nixpkgs/commit/81365587c22ecec4b52fbbd52cce4f378f044817) papirus-icon-theme: 20220710 -> 20220808
* [`9b3d83d3`](https://github.com/NixOS/nixpkgs/commit/9b3d83d39e0531a33d041ff6e4224bb500f82b13) dnsrecon: 1.1.1 -> 1.1.2
* [`eab023c5`](https://github.com/NixOS/nixpkgs/commit/eab023c51614856844bb09ad2970abf4d995ceb9) python310Packages.aioshelly: 2.0.1 -> 3.0.0
* [`0883143d`](https://github.com/NixOS/nixpkgs/commit/0883143d7101758b9491d7a6e526041bc4ed37d2) python310Packages.fastcore: 1.5.11 -> 1.5.15
* [`8c546d02`](https://github.com/NixOS/nixpkgs/commit/8c546d02897a60d0e64e765d59b7996a316c481c) dbeaver: 22.1.3 -> 22.1.4
* [`8ac0e969`](https://github.com/NixOS/nixpkgs/commit/8ac0e969dd6f70d67e37978713cac43f836c737a) teamspeak5_client: init at 5.0.0-beta70
* [`c44d47db`](https://github.com/NixOS/nixpkgs/commit/c44d47dbe56464cb738b2cd2f70c4823374c632f) arrow-cpp: 8.0.0 -> 9.0.0
* [`cf192f5d`](https://github.com/NixOS/nixpkgs/commit/cf192f5db16c245f3cfe299957347c6b3565edb1) arrow-cpp: remove unused `jemalloc` input
* [`56e9e52c`](https://github.com/NixOS/nixpkgs/commit/56e9e52cc2b4cd0ac8512f69218c54069ec3fcdb) arrow-cpp: add commentary for vendored `jemalloc` and `mimalloc`
* [`829e7c90`](https://github.com/NixOS/nixpkgs/commit/829e7c904dcca618c3ea4a385dd5a77eb0242f0f) python3Packages.pyarrow: get tests working with arrow-cpp 9.0.0
* [`941d9e9b`](https://github.com/NixOS/nixpkgs/commit/941d9e9b3163286d0f910d1a4b88ded53c172d8a) python3Packages.db-dtypes: bump pyarrow upper bound
* [`4b664ed4`](https://github.com/NixOS/nixpkgs/commit/4b664ed4e3b94adb299c3e3b392b8dfb42eedece) python3Packages.apache-beam: remove numpy constraint
* [`bf348917`](https://github.com/NixOS/nixpkgs/commit/bf3489173acbda5ac1113231d616e5b1af7551d5) arrow-cpp: fix failing tests on darwin sandbox
* [`574b3635`](https://github.com/NixOS/nixpkgs/commit/574b3635a8a64dd01fbb6e209fca490157840bff) python3Packages.pyarrow: fix failing tests on darwin sandbox
* [`8b40f591`](https://github.com/NixOS/nixpkgs/commit/8b40f591614e5e3ffa9d880efe5eb732e0b69031) python3Packages.google-cloud-bigquery: bump pyarrow constraint
* [`e41f448f`](https://github.com/NixOS/nixpkgs/commit/e41f448fcc1a0d0b083c8e15932b1059e9f47488) python3Packages.google-cloud-bigquery: ignore network-based test
* [`d9202ab6`](https://github.com/NixOS/nixpkgs/commit/d9202ab62548a564beec192ab1cb4f92b010be9b) python3Packages.apache-beam: unrestrict `pymongo` dependency
* [`21237eed`](https://github.com/NixOS/nixpkgs/commit/21237eedfea249c34aee2277da56420b6d058d11) python3Packages.apache-beam: set `enableParallelBuilding` to `true`
* [`b8dc7a5e`](https://github.com/NixOS/nixpkgs/commit/b8dc7a5e88a82d218fddf6c14a6ccfc830fd296e) audacious: migrate to meson build system, refactor
* [`09302143`](https://github.com/NixOS/nixpkgs/commit/093021431be41e5026a5da041e68e079e1b94d87) audacious-plugins: add qtx11extras
* [`ae62769e`](https://github.com/NixOS/nixpkgs/commit/ae62769e6f8458c5053bbc27c3ade35270e1dd87) python310Packages.plexapi: 4.12.0 -> 4.12.1
* [`8bf7be60`](https://github.com/NixOS/nixpkgs/commit/8bf7be6063116e0a38ab61db416e389046c0e942) lndhub-go: 0.9.0 -> 0.10.0
* [`81dab0a3`](https://github.com/NixOS/nixpkgs/commit/81dab0a302e748f0adfcdaed018e9209000229f0) python310Packages.pescea: 1.0.10 -> 1.0.11
* [`3e9d91af`](https://github.com/NixOS/nixpkgs/commit/3e9d91af1d727443383a138a48cdeac938f64ecb) python310Packages.arc4: init at 0.2.0
* [`50fc8533`](https://github.com/NixOS/nixpkgs/commit/50fc8533e1cfa94f6459397124fc6492212b29f8) python310Packages.aardwolf: init at 0.0.8
* [`7c3a458e`](https://github.com/NixOS/nixpkgs/commit/7c3a458ef50a7646e77a05ae2ae5da0a95f7d6eb) crackmapexec: 5.2.2 -> 5.3.0
* [`6f38b43c`](https://github.com/NixOS/nixpkgs/commit/6f38b43c8c84c800f93465b2241156419fd4fd52) go: minor cleanup
* [`fd6eedeb`](https://github.com/NixOS/nixpkgs/commit/fd6eedeb04279be9f03fdc4f51aa93279ad68d36) maintainers: add oluceps
* [`358dcd9d`](https://github.com/NixOS/nixpkgs/commit/358dcd9dc692a7095d683802b8f326e16bbc08fa) sane-backends: install hwdb file
* [`76889bfa`](https://github.com/NixOS/nixpkgs/commit/76889bfa9fa296a47892eacfb4e82cfcff296938) deploy-rs: 2022-05-26 -> 2022-08-05
* [`f7c98059`](https://github.com/NixOS/nixpkgs/commit/f7c980599e10b9cc53852359a039d54ac60161c9) kernel: fix touchpads on AMD laptops
* [`d68ba1d7`](https://github.com/NixOS/nixpkgs/commit/d68ba1d746e668865254f03cc4f629d0d1a15f66) nixos/plasma5: default runUsingSystemd to on
* [`6efa5c77`](https://github.com/NixOS/nixpkgs/commit/6efa5c77edd931f53f4f68768ec54bbe596c8492) nixos/snipe-it: Add private_uploads to tmpfiles
* [`8dd0076d`](https://github.com/NixOS/nixpkgs/commit/8dd0076d74e412204f4667dcef9dabc3d7263974) python310Packages.colormath: 3.0.0 -> unstable-2021-04-17
* [`ceb18439`](https://github.com/NixOS/nixpkgs/commit/ceb184396d94645b61c0286f24038951e8fa0e1f) mt32emu-qt: 1.10.2 -> 1.11.1
* [`b8819a95`](https://github.com/NixOS/nixpkgs/commit/b8819a95b6cea9321056e6e5395e42920bbd7aa1) logseq: 0.7.9 -> 0.8.0
* [`b938b491`](https://github.com/NixOS/nixpkgs/commit/b938b4917c01819afcb614a69f39470c81e06c2e) python310Packages.pyquil: 3.1.0 -> 3.2.1
* [`bd0a5ce3`](https://github.com/NixOS/nixpkgs/commit/bd0a5ce380fee429032a70b75160b1261d38c868) beets: test to validate gstreamer interop
* [`ba6d6cdb`](https://github.com/NixOS/nixpkgs/commit/ba6d6cdbfc4335cd93157ef7a14cd0ec43e2971d) arduino-cli: 0.21.1 -> 0.25.1
* [`5e268c85`](https://github.com/NixOS/nixpkgs/commit/5e268c85a072c7ea469c197393b2b495d9efccc6) vulkan-caps-viewer: init at 3.24
* [`d1949b73`](https://github.com/NixOS/nixpkgs/commit/d1949b739a57845d0c4a4d4a79ef41620269edd3) bats: init libraries
* [`fbe194fd`](https://github.com/NixOS/nixpkgs/commit/fbe194fdf6e577468bc38a5ee0bd77d130ddca49) bats: Add library wrapper
* [`51bd91d8`](https://github.com/NixOS/nixpkgs/commit/51bd91d8443be925e47295932d25f81dc5f9c069) sonarr: 3.0.8.1507 -> 3.0.9.1549
* [`0b62bc1e`](https://github.com/NixOS/nixpkgs/commit/0b62bc1e217bdd7f7d80bd1c6abace15d45d3dfd) fzf: 0.32.0 -> 0.32.1
* [`9e10ba3e`](https://github.com/NixOS/nixpkgs/commit/9e10ba3ee8b8fb43b7419e90144c530a62876527) factorio-experimental: 1.1.61 -> 1.1.65
* [`8edb7f27`](https://github.com/NixOS/nixpkgs/commit/8edb7f27c3730d41f4c3cbcb47ef3e76c23d89b7) caffeine-ng: don't double wrap
* [`c5b05190`](https://github.com/NixOS/nixpkgs/commit/c5b051905c8838a9f2ecd4918b40e7dcab9c8377) xpra: fix launch
* [`904648c8`](https://github.com/NixOS/nixpkgs/commit/904648c847171a887c78c26dad872ef35623b3d1) python3Packages.cinemagoer: init 2022.2.11
* [`fb520531`](https://github.com/NixOS/nixpkgs/commit/fb520531bbed31c8f4adbc9aa87a786eec2f51f7) ptex: 2.4.1 -> 2.4.2 ([nixos/nixpkgs⁠#185348](https://togithub.com/nixos/nixpkgs/issues/185348))
* [`748145d0`](https://github.com/NixOS/nixpkgs/commit/748145d0828fc16c029ddc4fa7853a70213b865c) hypnotix: rename imdbpy to cinemagoer
* [`93ac320d`](https://github.com/NixOS/nixpkgs/commit/93ac320de69e314519161e0dc85c3d823445b315) electron_20: init at 20.0.1
* [`575bab3e`](https://github.com/NixOS/nixpkgs/commit/575bab3e78da896558edfa0e516cf18c19e7c762) python310Packages.casbin: 1.16.9 -> 1.17.0
* [`de42430f`](https://github.com/NixOS/nixpkgs/commit/de42430fa79467ff2139cffb3c4442cdc6b1f97b) home-assistant: 2022.8.1 -> 2022.8.2
* [`49e5fbba`](https://github.com/NixOS/nixpkgs/commit/49e5fbba0bc7faee9a15540a1be4b314f687ed8e) python310Packages.fe25519: 1.2.0 -> 1.3.0
* [`9a195f05`](https://github.com/NixOS/nixpkgs/commit/9a195f05ffdd637315d5618302357c2f6d8de68e) python310Packages.ge25519: 1.2.0 -> 1.3.0
* [`52aef90b`](https://github.com/NixOS/nixpkgs/commit/52aef90bc679c4b99691221d0780e5b8eb69e895) firefox-unwrapped: 103.0.1 -> 103.0.2
* [`b6854d64`](https://github.com/NixOS/nixpkgs/commit/b6854d6475d4e868af85bf40bcbf050b28d5fd36) python310Packages.hahomematic: 2022.8.3 -> 2022.8.4
* [`27ddc618`](https://github.com/NixOS/nixpkgs/commit/27ddc618ca29e9690f59c1be1154cb74ccc8523f) python310Packages.hstspreload: 2021.12.1 -> 2022.8.1
* [`39b4f099`](https://github.com/NixOS/nixpkgs/commit/39b4f0994edfab71769f0eadefd840c3a838fe88) firefox-bin-unwrapped: 103.0.1 -> 103.0.2
* [`59b3d273`](https://github.com/NixOS/nixpkgs/commit/59b3d2738bb843ba319447b421d205a13ebdcf8a) firefox-beta-bin-unwrapped: 104.0b4 -> 104.0b7
* [`780343cc`](https://github.com/NixOS/nixpkgs/commit/780343cc776996e28b64650578150e32bc92008f) firefox-devedition-bin-unwrapped: 104.0b4 -> 104.0b7
* [`17819194`](https://github.com/NixOS/nixpkgs/commit/17819194f7e2524216f480422c333ba127be8548) hysteria: init at 1.1.0
* [`2abddece`](https://github.com/NixOS/nixpkgs/commit/2abddece9643fc05ac33782b45de461cfa8cc81b) geant4: 11.0.0 -> 11.0.2 ([nixos/nixpkgs⁠#184349](https://togithub.com/nixos/nixpkgs/issues/184349))
* [`6d4b71e6`](https://github.com/NixOS/nixpkgs/commit/6d4b71e6ba823bfd1ad908c62f4b641d7f9ec066) faraday-agent-dispatcher: disable TLS/SSL tests
* [`7363ab9e`](https://github.com/NixOS/nixpkgs/commit/7363ab9ebb2d3f3ce617abd2420ed922647c85de) python311: 3.11.0b5 -> 3.11.0rc1
* [`b5a62999`](https://github.com/NixOS/nixpkgs/commit/b5a62999aa16227194d2f0afd9bf323bee806813) expliot: don't run tests of cmd2 override
* [`2bec83a3`](https://github.com/NixOS/nixpkgs/commit/2bec83a3ed42bf3f6e9f738175bd86b835da3262) python3Packages.python-benedict: fix broken build
* [`14c05dc6`](https://github.com/NixOS/nixpkgs/commit/14c05dc6ac860cbed9b13524cb6adc8f79003c90) libjwt-typed: unbreak with minor changes
* [`5756220a`](https://github.com/NixOS/nixpkgs/commit/5756220adab4ee628a75a74bd846042d3c0cb5d1) dvc: 2.12.0 -> 2.17.0
* [`4df3ae78`](https://github.com/NixOS/nixpkgs/commit/4df3ae78dde81f0d3a817e489bae2f73da711ab4) dvc: add anthonyroussel to maintainers
* [`f0734d72`](https://github.com/NixOS/nixpkgs/commit/f0734d72fc03fb7a997db5eaa7906db98ecac9d7) python310Packages.aiohttp-retry: 2.5.6 -> 2.7.0
* [`cf3216ab`](https://github.com/NixOS/nixpkgs/commit/cf3216ab2c62c18811fcd9133b025ca9e3feb230) python310Packages.python-heatclient: disable failing test
* [`2623306a`](https://github.com/NixOS/nixpkgs/commit/2623306a5d699dc6053d4c6767269045fe906d33) wl-mirror: 0.11.2 -> 0.12.1
* [`ace70575`](https://github.com/NixOS/nixpkgs/commit/ace70575142bc977d1e2405f856649bdfc6131fb) python310Packages.pyprosegur: 0.0.7 -> 0.0.8
* [`078ecdaf`](https://github.com/NixOS/nixpkgs/commit/078ecdaf985ee6f3f6a26100e4b4fec484e0f980) kitty: fix tests on darwin
* [`534b168e`](https://github.com/NixOS/nixpkgs/commit/534b168eaad40e3684aaf0379bf453b997fcca78) python310Packages.pyipma: 3.0.0 -> 3.0.2
* [`a3f954f9`](https://github.com/NixOS/nixpkgs/commit/a3f954f99146a2502083cb7b2a72461556af58c7) gamescope init at 3.11.33-jupiter-3.3-2
* [`a90b5091`](https://github.com/NixOS/nixpkgs/commit/a90b50917c084c067ac64b22762d2ec55f8be193) libdazzle: fix build on darwin
* [`fae17c4f`](https://github.com/NixOS/nixpkgs/commit/fae17c4fe00ad935d8c512221615af1493253651) p910nd: cleanups
* [`603b6f6b`](https://github.com/NixOS/nixpkgs/commit/603b6f6be133a5e36d509e047ce0b05f37de7446) msmtp: resholve queue scripts
* [`70220e79`](https://github.com/NixOS/nixpkgs/commit/70220e79b1b413a9c1e50aab24922b345f839c1a) WIP
* [`8243b319`](https://github.com/NixOS/nixpkgs/commit/8243b319494f2d56e0bdf96133642fb86d481469) ameba: 0.14.3 -> 1.0.1
* [`7e901eea`](https://github.com/NixOS/nixpkgs/commit/7e901eeae0da1f2a4342e9773021e8131d54319f) kernel: only enable PINCTRL_AMD on 5.19+
* [`9f61e20a`](https://github.com/NixOS/nixpkgs/commit/9f61e20a68ceaa8e5a9dcf59eb4c7f04b00cd027) x16-rom: 40 -> 41
* [`ddc57cfc`](https://github.com/NixOS/nixpkgs/commit/ddc57cfc0c2bfc0e5bb47dd6a7697c534080f213) _3mux: fix build on Darwin
* [`326a0fda`](https://github.com/NixOS/nixpkgs/commit/326a0fda17218da1bb8bc72039871547549980aa) x16-rom: mark as broken on aarch64-darwin
* [`8b4479cf`](https://github.com/NixOS/nixpkgs/commit/8b4479cf28ff6dfd2ba1518691d06b278ec3c4f7) x16-emulator: 40 -> 41
* [`534146ea`](https://github.com/NixOS/nixpkgs/commit/534146ea00ce7ea63a357c59b0dfffb5814f9507) x16-emulator: mark as broken on aarch64-darwin
* [`1f720644`](https://github.com/NixOS/nixpkgs/commit/1f720644d8511221eda33ba5f1b722ad4b331d25) difftastic: 0.31.0 -> 0.32.0
* [`aa832eed`](https://github.com/NixOS/nixpkgs/commit/aa832eedd765c9bfce570d3e73117c4dfaaee33b) haskellPackages: mark builds timing-out on hydra as broken
* [`6e8c590e`](https://github.com/NixOS/nixpkgs/commit/6e8c590ec8ab7029ecc2ea0485c02116e730b9f6) haskellPackages: mark builds failing on hydra as broken
* [`ab2e77ea`](https://github.com/NixOS/nixpkgs/commit/ab2e77ea829c20eeb4f451b751b5ddd85e1307c6) nixos/zfs: scrub synchronously
* [`e94f52c3`](https://github.com/NixOS/nixpkgs/commit/e94f52c385b5154d1edd536478553967c900c1c7) haskellPackages.stripeapi: mark as dontDistribute because output exceeds Hydras maximum allowable size
* [`2c84638d`](https://github.com/NixOS/nixpkgs/commit/2c84638d2b848f6b096036a72928097f0c6ec79f) yt-dlp: 2022.07.18 -> 2022.8.8
* [`b1a72782`](https://github.com/NixOS/nixpkgs/commit/b1a72782cf8dd874c298ea067d933e254b78ce3b) haskellPackages.hb3sum: disable on aarch64-linux because of dep
* [`5c8d55cc`](https://github.com/NixOS/nixpkgs/commit/5c8d55cc72b77713977773a9eee3317739e4d8e4) cheat: 4.2.6 -> 4.3.1
* [`6898b758`](https://github.com/NixOS/nixpkgs/commit/6898b758b69222959b16a96412a572bd341a4bc7) luaPackages.lua-subprocess: init at scm-1
* [`a36e146b`](https://github.com/NixOS/nixpkgs/commit/a36e146b7e0c5725a2b512a1008ce2552cf4ecfb) vimUtils.vimrcContent: throw an error when using pathogen
* [`6717d144`](https://github.com/NixOS/nixpkgs/commit/6717d144ec5c78375db496112e9baa464d66a996) vimRcContent: now throws when using pathogen
* [`eb051d99`](https://github.com/NixOS/nixpkgs/commit/eb051d99b04bf7b1b980a6d18807a3730ae12c88) vimRcContent: remove now unused linkLuaPlugin
* [`5d38ae80`](https://github.com/NixOS/nixpkgs/commit/5d38ae801aebda98d1729ff0f16f943a816e99f6) neovimUtils: merge host settings so that they use a single --cmd flag
* [`0fb2e47b`](https://github.com/NixOS/nixpkgs/commit/0fb2e47b7f4ca4cff34739a0d18524eee2514f32) vimUtils: improve comments
* [`d8b356ca`](https://github.com/NixOS/nixpkgs/commit/d8b356caafb34d454737a79bb0fc6076f3da0b5d) fix: ssh-keygen fails if directory does not exist
* [`2d4c0314`](https://github.com/NixOS/nixpkgs/commit/2d4c0314c78e15f407f516e310fc86bb67c4a61d) semgrep: 0.106.0 -> 0.108.0
* [`65f39b91`](https://github.com/NixOS/nixpkgs/commit/65f39b913d0910907ea22be29f108402924644c2) prometheus-zfs-exporter: init at 2.2.5
* [`72a551c1`](https://github.com/NixOS/nixpkgs/commit/72a551c13f167558a7a364a84594695e1335dfa2) python310Packages.bleak-retry-connector: 1.4.0 -> 1.5.0
* [`3c2b21cc`](https://github.com/NixOS/nixpkgs/commit/3c2b21ccf859b43800459a10ae36b251dfe56e14) pkgsStatic.re2: fix build
* [`cd99b542`](https://github.com/NixOS/nixpkgs/commit/cd99b54257664ffadf09f9605f230821c45ea270) crc32c: don't install gtest
* [`e9831074`](https://github.com/NixOS/nixpkgs/commit/e9831074efb92b0f9314e1d2ff34e3d8b3a830c0) ocamlPackages_4_06.num: fix after [nixos/nixpkgs⁠#110571](https://togithub.com/nixos/nixpkgs/issues/110571)
* [`58cda945`](https://github.com/NixOS/nixpkgs/commit/58cda94562ed5a182d040d920b35219f4148051a) python310Packages.azure-mgmt-network: 20.0.0 -> 21.0.0
* [`fbe95db7`](https://github.com/NixOS/nixpkgs/commit/fbe95db7ff8a896fb3c9693d154c705832697749) python310Packages.asdf-standard: 1.0.2 -> 1.0.3
* [`11896e7e`](https://github.com/NixOS/nixpkgs/commit/11896e7e219ada95d9368fc97b49d68283625431) python310Packages.aioairzone: 0.4.8 -> 0.4.9
* [`f018c335`](https://github.com/NixOS/nixpkgs/commit/f018c33574ec3d1f387c3a8adc89528d06cbbf57) python310Packages.aiohomekit: 1.2.5 -> 1.2.6
* [`1c201db2`](https://github.com/NixOS/nixpkgs/commit/1c201db2695cf1d558154c16fb1b636bfd1c5e83) python310Packages.jsbeautifier: 1.14.4 -> 1.14.5
* [`d691e894`](https://github.com/NixOS/nixpkgs/commit/d691e8945bbef5bb43abf89f84e2d662657a586b) python310Packages.plugwise: 0.21.1 -> 0.21.2
* [`9dc35afd`](https://github.com/NixOS/nixpkgs/commit/9dc35afd5f91ed9524af5c5b0eaed2d06fa12b9a) kodelife: 0.9.8.143 -> 1.0.5.161
* [`0f456ce6`](https://github.com/NixOS/nixpkgs/commit/0f456ce6277333ea2d2f20eab8f910ac36c4d292) pkgsStatic.gdb: Fix compile
* [`b03d2f61`](https://github.com/NixOS/nixpkgs/commit/b03d2f610319547fb83ab10b96e68ac57abd4999) python310Packages.azure-mgmt-servicebus: 7.1.0 -> 8.0.0
* [`cda1f8ae`](https://github.com/NixOS/nixpkgs/commit/cda1f8ae46869c429971323717d622d5b17d9854) neovim: pass packpath via the wrapper
* [`748a0872`](https://github.com/NixOS/nixpkgs/commit/748a08728e64cedca5520eceb117eee8de282cf9) touchosc: init at 1.1.4.143
* [`6bc1f400`](https://github.com/NixOS/nixpkgs/commit/6bc1f400f4773244df5a00853d555ae2332571c6) update requirePlugins
* [`b4d8662c`](https://github.com/NixOS/nixpkgs/commit/b4d8662c4a479b7641d28fe866b018adf8d8f2e1) neovimUtils.makeNeovimConfig: remove mention of python2
* [`cc0ff183`](https://github.com/NixOS/nixpkgs/commit/cc0ff183c6afe9951c8fdbf468ea26a9f6920f52) neovimUtils: remove the compatibility layer introduced in 2018
* [`e17fa76b`](https://github.com/NixOS/nixpkgs/commit/e17fa76bdb3740e32440046216626a3a3746b048) nix-bisect: add patch from upstream to fix crashes
* [`f6c77b18`](https://github.com/NixOS/nixpkgs/commit/f6c77b183fc8938f9482c67f98cd7f5d7500204c) snipe-it: Substitute path to mysqldump
* [`567448c3`](https://github.com/NixOS/nixpkgs/commit/567448c3d93904311b8586060bfe621573a1e415) python310Packages.pyunifiprotect: 4.0.11 -> 4.0.12
* [`b336a98f`](https://github.com/NixOS/nixpkgs/commit/b336a98f7320077f9dcd8fccb4560f5be43906ff) gcc-arm-embedded-11: init at 11.3.rel1
* [`9233f74a`](https://github.com/NixOS/nixpkgs/commit/9233f74a3c5a2b33bf6b1faed7b2f05e248d5417) python310Packages.annoy: 1.17.0 -> 1.17.1
* [`e75ba1ab`](https://github.com/NixOS/nixpkgs/commit/e75ba1ab1766bbcdd6976f0eaf00710c79d16994) cargo-make: 0.35.15 -> 0.35.16
* [`d42f6128`](https://github.com/NixOS/nixpkgs/commit/d42f6128c7075a5babf21e4716f0d071724359e1) bats: Add library test
* [`6b5e730e`](https://github.com/NixOS/nixpkgs/commit/6b5e730e7895e0a30cf01e15f8a07663f7f99d61) sbt: 1.6.2 -> 1.7.1
* [`1b803751`](https://github.com/NixOS/nixpkgs/commit/1b8037517127978727bd494bc1fd90807716b0bf) seer: 1.7 -> 1.8
* [`43449503`](https://github.com/NixOS/nixpkgs/commit/4344950312ae0b0775efdd112412b787a1c73bb2) peertube: 4.2.1 -> 4.2.2
* [`0b98d77f`](https://github.com/NixOS/nixpkgs/commit/0b98d77ff50b49d1fe073d17dcf18aa3895ee9fd) nixos/peertube: fix start service
* [`c5229435`](https://github.com/NixOS/nixpkgs/commit/c52294359c012f330ee7e9a2e2cacf8ef9c6ffc8) pkgsStatic.rapidjson: fix build
* [`2f69e982`](https://github.com/NixOS/nixpkgs/commit/2f69e982ace00128c0641c368aee171cb56fb13e) fwupd: drop unnecessary GTK dependency
* [`1c25f36f`](https://github.com/NixOS/nixpkgs/commit/1c25f36fd45358edd5f30d1fecfa380b2a5cc472) just: 1.3.0 -> 1.4.0
* [`cea179eb`](https://github.com/NixOS/nixpkgs/commit/cea179eb8114c410d4e63e702238c0d3c991ce56) python310Packages.pikepdf: 5.3.1 -> 5.4.2
* [`a72636c7`](https://github.com/NixOS/nixpkgs/commit/a72636c7401dee0a92b7fc0c9bea4ab014759088) python310Packages.annoy: add pythonImportsCheck
* [`c7bad4ee`](https://github.com/NixOS/nixpkgs/commit/c7bad4ee0983a745465758298fe5b1f866708856) python310Packages.archinfo: 9.2.12 -> 9.2.13
* [`4dc1f74e`](https://github.com/NixOS/nixpkgs/commit/4dc1f74e105757773e2acc05c2ce6d08636af544) python310Packages.ailment: 9.2.12 -> 9.2.13
* [`703e415f`](https://github.com/NixOS/nixpkgs/commit/703e415fcd9f2d6494fef4be20da5337b45310f2) python310Packages.pyvex: 9.2.12 -> 9.2.13
* [`cacf1c0d`](https://github.com/NixOS/nixpkgs/commit/cacf1c0dc09fd06f564a89b0d225c7c2a6c43b1a) python310Packages.claripy: 9.2.12 -> 9.2.13
* [`eff09241`](https://github.com/NixOS/nixpkgs/commit/eff09241807be41ca61582e967579849f0e7472f) python310Packages.cle: 9.2.12 -> 9.2.13
* [`b8a64b36`](https://github.com/NixOS/nixpkgs/commit/b8a64b360437544cd426639b5d7f9c6182c47fd7) python310Packages.angr: 9.2.12 -> 9.2.13
* [`8bfd38f6`](https://github.com/NixOS/nixpkgs/commit/8bfd38f610493c8184cfdc34466f014dee01b9dd) microcode-intel: 20220510 -> 20220809
* [`10484091`](https://github.com/NixOS/nixpkgs/commit/10484091c9164acddf3a3f4faa4ca7b23eaf9a7b) pythonPackages.sphinx-fortran: init at unstable-2022-03-02
* [`5816d322`](https://github.com/NixOS/nixpkgs/commit/5816d32249440044097631dce3891f65fdd6fb16) yara: 4.2.2 -> 4.2.3
* [`640409c4`](https://github.com/NixOS/nixpkgs/commit/640409c4d65571af96d22519ef56ed84219080af) python310Packages.yara-python: 4.2.0 -> 4.2.3
* [`f38a47d6`](https://github.com/NixOS/nixpkgs/commit/f38a47d64a95881b889a7bbd91f61321ff84a856) opentrack: 2.1.3 → 2022.3.0
* [`3bf4c6f4`](https://github.com/NixOS/nixpkgs/commit/3bf4c6f470dace7de40f0a4f00ebcde66bebf939) lean: 3.45.0 -> 3.46.0
* [`bcad6625`](https://github.com/NixOS/nixpkgs/commit/bcad662517eca96758f92580cdcd0fb5e3fe5e45) python3Packages.glean-sdk: 50.1.2 -> 51.1.0
* [`7e276013`](https://github.com/NixOS/nixpkgs/commit/7e2760130b0015ace19d168cdd681f17e7465ede) steamPackages.steam-runtime: 0.20211102.0 -> 0.20220601.1
* [`70ea3de6`](https://github.com/NixOS/nixpkgs/commit/70ea3de629d36afc35addd648a773a69355a0ba8) remind: 04.00.01 -> 04.00.02
* [`79c27cce`](https://github.com/NixOS/nixpkgs/commit/79c27cceda1b9b66ea5980b696cf093ad0905a7c) python3Packages.callee: init at 0.3.1
* [`519235db`](https://github.com/NixOS/nixpkgs/commit/519235db37ed6903c02edc48fbb864f966b667ab) python310Packages.karton-dashboard: 1.3.0 -> 1.4.0
* [`00c76bcb`](https://github.com/NixOS/nixpkgs/commit/00c76bcb34ef6481ba0cd937155a8805af9e8b80) python310Packages.karton-asciimagic: 1.1.0 -> 1.2.0
* [`f720fd57`](https://github.com/NixOS/nixpkgs/commit/f720fd57d3f14fd0db085cd6453a769c32235b4f) python310Packages.karton-yaramatcher: 1.1.1 -> 1.2.0
* [`b2c965d8`](https://github.com/NixOS/nixpkgs/commit/b2c965d8a0a96b98c2f2a7f11156c32c55d5156e) python310Packages.karton-mwdb-reporter: 1.1.0 -> 1.2.0
* [`3076092b`](https://github.com/NixOS/nixpkgs/commit/3076092b4c04ea7b8f2a6273c19c53ffb62770b5) python310Packages.karton-config-extractor: 2.0.2 -> 2.1.1
* [`5c953fb7`](https://github.com/NixOS/nixpkgs/commit/5c953fb7af849bbb49e87233f9c899c733299aaa) python310Packages.karton-autoit-ripper: 1.1.0 -> 1.2.0
* [`8f39ebba`](https://github.com/NixOS/nixpkgs/commit/8f39ebbaf98abfa39880714278d95cfe4f6dffc0) python310Packages.karton-classifier: 1.3.0 -> 1.4.0
* [`0501066c`](https://github.com/NixOS/nixpkgs/commit/0501066c2328c68635bcfeed05741cdbee2b89d3) python310Packages.karton-core: 4.4.1 -> 5.0.0
* [`22eae24d`](https://github.com/NixOS/nixpkgs/commit/22eae24df0986d32c1f9658bf8498241309697c4) chromiumDev: 105.0.5195.19 -> 106.0.5216.6
* [`14c1f2e1`](https://github.com/NixOS/nixpkgs/commit/14c1f2e10448443e6a84d739c6e26e64c21be770) linux_lqx: 5.18.16-lqx1 -> 5.18.16-lqx2
* [`0795afcc`](https://github.com/NixOS/nixpkgs/commit/0795afcc1dd01c62e83e991caab4a7dde518fb27) anybadge: 1.9.0 -> 1.11.1
* [`fb30d118`](https://github.com/NixOS/nixpkgs/commit/fb30d1182da2afd2c08e0a9e2b6c5b6badd986e5) python310Packages.deap: 1.3.1 -> 1.3.3
* [`3b71c50a`](https://github.com/NixOS/nixpkgs/commit/3b71c50a22807b29708c2163c6f7da16b2ae06b3) python310Packages.pglast: 3.13 -> 3.14
* [`4c476e1c`](https://github.com/NixOS/nixpkgs/commit/4c476e1c70636614637a4c8fc0a1a90c4dee46f4) electron: use wrapper instead of symlink for bin on darwin
* [`9f980dee`](https://github.com/NixOS/nixpkgs/commit/9f980dee7f3a386fd5df9348a9330b1e6999da9f) pkgsStatic.rapidjson: disable checks
* [`45a58291`](https://github.com/NixOS/nixpkgs/commit/45a58291de50d9587fcfaa2e75a3f162282bad9f) deltachat-desktop: remove special case for electron on darwin
* [`2c035ca8`](https://github.com/NixOS/nixpkgs/commit/2c035ca89fa444e8ef492976678de84ac189241d) element-desktop: remove special case for electron on darwin
* [`6877e896`](https://github.com/NixOS/nixpkgs/commit/6877e896fc728e0a09c26954a5ea56e4bfc2a0f6) schildichat-desktop: remove special case for electron on darwin
* [`263b0365`](https://github.com/NixOS/nixpkgs/commit/263b0365db9d78025bbd387c485ab42bfeb2e800) micropad: remove special case for electron on darwin
* [`29e7fcfb`](https://github.com/NixOS/nixpkgs/commit/29e7fcfbbf7a9a9c40a9285243f15f0bf66151bc) maintainers/teams: remove inactive maintainers from `golang`
* [`4fc8bd3d`](https://github.com/NixOS/nixpkgs/commit/4fc8bd3d877a5705226266e93b48e800e1ee6756) python310Packages.tubeup: 0.0.32 -> 0.0.33
* [`c7dcd543`](https://github.com/NixOS/nixpkgs/commit/c7dcd543bef243ee3952e6fcd12792fc9b227652) gcovr: 5.1 -> 5.2
* [`fbecd4da`](https://github.com/NixOS/nixpkgs/commit/fbecd4daec0040b5a943fc53b0731f78e9d2dea7) libproxy: fix build on darwin
* [`9ba8b938`](https://github.com/NixOS/nixpkgs/commit/9ba8b938a46fa4abbc8952d7e32c5621c5a41677) pythonPackages.pythonefl: does not install egg
* [`f7d6f6f5`](https://github.com/NixOS/nixpkgs/commit/f7d6f6f54c815fd29b633b88d0ec955fd8939607) signal-desktop: 5.53.0 -> 5.54.0
* [`08051c14`](https://github.com/NixOS/nixpkgs/commit/08051c14e490c1988af0ce812d0927ce1305c9b4) gomplate: 3.10.0 -> 3.11.2
* [`7e20517a`](https://github.com/NixOS/nixpkgs/commit/7e20517af0ec68beea2036ae3d78929c51e6012b) elisp packages updates 2022-08-10
* [`e6e7b96f`](https://github.com/NixOS/nixpkgs/commit/e6e7b96fda8511a75befba8594c131a22e8620f8) hqplayerd: 4.32.2-92 -> 4.32.4-94
* [`ee0b8a7e`](https://github.com/NixOS/nixpkgs/commit/ee0b8a7eaa96a0b4462870c2367aa96121d565bf) nixos/geoclue2: wait for network to be up when wifi provider is enabled
* [`b4e86d9b`](https://github.com/NixOS/nixpkgs/commit/b4e86d9baa7fb8feff8eec6be00a4848317db2fd) elpa-packages: manual fixup
* [`a6d4e3d8`](https://github.com/NixOS/nixpkgs/commit/a6d4e3d86ab1838dd5e0b4f1eb613f4ff6924e90) cinnamon.cinnamon-common: 5.4.8 -> 5.4.9
* [`880e4a8e`](https://github.com/NixOS/nixpkgs/commit/880e4a8e2456e448d4ea38d64a6a00ee5cc5e4e2) cinnamon.cinnamon-control-center: 5.4.4 -> 5.4.6
* [`6adcb48c`](https://github.com/NixOS/nixpkgs/commit/6adcb48c0da52060eef9437f469b4a57d67a8043) cinnamon.cinnamon-screensaver: 5.4.1 -> 5.4.2
* [`5c5585f7`](https://github.com/NixOS/nixpkgs/commit/5c5585f7ac24db04b9b496552c2b3a9cb54cf497) cinnamon.cinnamon-settings-daemon: 5.4.3 -> 5.4.5
* [`9e2fd038`](https://github.com/NixOS/nixpkgs/commit/9e2fd038fbf470728aa74d270f03406afbda2c4a) cinnamon.mint-themes: 2.0.3 -> 2.0.4
* [`9217c808`](https://github.com/NixOS/nixpkgs/commit/9217c8084d8bc067d48c8edf5768e9dc54962970) cinnamon.mint-y-icons: 1.6.0 -> 1.6.1
* [`b8529450`](https://github.com/NixOS/nixpkgs/commit/b8529450c6a3d4b6ec5ec6a19ef32ef5505f47a9) cinnamon.muffin: 5.4.4 -> 5.4.5
* [`ae47d9f9`](https://github.com/NixOS/nixpkgs/commit/ae47d9f9fa4680b8621ddc3b6d1b2736b28c605e) cinnamon.xviewer: 3.2.9 -> 3.2.10
* [`44d3de22`](https://github.com/NixOS/nixpkgs/commit/44d3de2222753b185b5b49dcbc03dd0afc408b70) xplayer: 2.4.3 -> 2.4.4
* [`5d42df57`](https://github.com/NixOS/nixpkgs/commit/5d42df5739b9172c627dcfaa14f7b16c121ed15b) awsebcli: fix build, update botocore to match upstream
* [`41c5b671`](https://github.com/NixOS/nixpkgs/commit/41c5b671d6fc7368da3625b24e8ee24b526c5b77) lunatic: 0.9.0 -> 0.10.0
* [`161ea79c`](https://github.com/NixOS/nixpkgs/commit/161ea79c15e300e671edf4e5cfd294d221a2e766) python3.pkgs.tensorflow: 2.9.1 -> 2.10.0-rc0
* [`9bbdfff8`](https://github.com/NixOS/nixpkgs/commit/9bbdfff80c3ffde6c2d183185bec1a8013ad161b) Update preface.xml ([nixos/nixpkgs⁠#185868](https://togithub.com/nixos/nixpkgs/issues/185868))
* [`5f71fb6e`](https://github.com/NixOS/nixpkgs/commit/5f71fb6e026093dd84b4df1a522c78d87953c075) harec: 2022-06-20 -> 2022-07-02
* [`80bfe830`](https://github.com/NixOS/nixpkgs/commit/80bfe83082d187b9a91872fff0111ff44cc604fb) vscode-extensions.piousdeer.adwaita-theme: 1.0.7 -> 1.0.8
* [`ca39dc69`](https://github.com/NixOS/nixpkgs/commit/ca39dc6915fc258cc057b37303df44e305512514) hare: 2022-06-18 -> 2022-07-30
* [`d3993e24`](https://github.com/NixOS/nixpkgs/commit/d3993e24c65b51c35edda148e30d251f5dd18cad) harePackages: create subtree
* [`ea860254`](https://github.com/NixOS/nixpkgs/commit/ea860254b74c0c91beffbbee96ebc0a825b84139) python3Packages.django-q: add gador as maintainer, switch to GitHub
* [`c41ed54f`](https://github.com/NixOS/nixpkgs/commit/c41ed54f930e38c6969b04179c1248d399296597) paperless-ngx: 1.7.1 -> 1.8.0
* [`30b62847`](https://github.com/NixOS/nixpkgs/commit/30b628476afe59cf71e62f2a4c17dc76a67f782e) move hare aliases to aliases.nix
* [`1c9931da`](https://github.com/NixOS/nixpkgs/commit/1c9931da1ed3235a481c3300d8a9f64294922850) git-branchless: 0.3.12 -> 0.4.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
