### PR TITLE
niv home-manager: update d3fb1eff -> 4c45a8d1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "knl",
         "repo": "home-manager",
-        "rev": "d3fb1eff06f7c69399433aeb71b0091ea22bf9d4",
-        "sha256": "11vpqmrsf1xlcwqp6hr787vhpy1prmsb7pwmf7pdy6f11zvalhr5",
+        "rev": "4c45a8d1cebb041a04abb39f6aaaedb3f303571b",
+        "sha256": "0m6khi6gc1mm6l4fxviqjl72d3zw5saxds1pyf4in0wwdj51swji",
         "type": "tarball",
-        "url": "https://github.com/knl/home-manager/archive/d3fb1eff06f7c69399433aeb71b0091ea22bf9d4.tar.gz",
+        "url": "https://github.com/knl/home-manager/archive/4c45a8d1cebb041a04abb39f6aaaedb3f303571b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: unbroken
Commits: [knl/home-manager@d3fb1eff...4c45a8d1](https://github.com/knl/home-manager/compare/d3fb1eff06f7c69399433aeb71b0091ea22bf9d4...4c45a8d1cebb041a04abb39f6aaaedb3f303571b)

* [`ac722cdd`](https://github.com/knl/home-manager/commit/ac722cddf44276d2b11d797b2ace273d0b674000) swayidle: Fix position of extraArgs ([knl/home-manager⁠#2932](https://togithub.com/knl/home-manager/issues/2932))
* [`c13ffa3e`](https://github.com/knl/home-manager/commit/c13ffa3ed42a653c058d78771f4ff0ef8798e7fd) home.pointerCursor: init ([knl/home-manager⁠#2891](https://togithub.com/knl/home-manager/issues/2891))
* [`267462df`](https://github.com/knl/home-manager/commit/267462dfb36d447421c789a3adf9d460cd09c147) cursor: fix coercion error
* [`4036f1a7`](https://github.com/knl/home-manager/commit/4036f1a751885718b324f3792819e119f98e56f2) home-cursor: fix x11 cursor path using invalid option ([knl/home-manager⁠#2940](https://togithub.com/knl/home-manager/issues/2940))
* [`538343be`](https://github.com/knl/home-manager/commit/538343be863cb0b9e9f1471e6dc09e0e140c7b3d) Make sway onChange script use cfg.package if set ([knl/home-manager⁠#2937](https://togithub.com/knl/home-manager/issues/2937))
* [`882bd811`](https://github.com/knl/home-manager/commit/882bd8118bdbff3a6e53e5ced393932b351ce2f6) gtk: Update example strings for gtk.theme.package ([knl/home-manager⁠#2904](https://togithub.com/knl/home-manager/issues/2904))
* [`4293902b`](https://github.com/knl/home-manager/commit/4293902b64990d43847fe90e50ef7908f7dc1e30) offlineimap: remove dependency on python2 ([knl/home-manager⁠#2909](https://togithub.com/knl/home-manager/issues/2909)) ([knl/home-manager⁠#2951](https://togithub.com/knl/home-manager/issues/2951))
* [`f735a850`](https://github.com/knl/home-manager/commit/f735a8502b098962ae965c2600c7be9f7711b814) programs.pywal: init ([knl/home-manager⁠#2949](https://togithub.com/knl/home-manager/issues/2949))
* [`273598f5`](https://github.com/knl/home-manager/commit/273598f53e04f0111dca5724b37640e3907edaaf) mako: add package option ([knl/home-manager⁠#2955](https://togithub.com/knl/home-manager/issues/2955))
* [`32a7da69`](https://github.com/knl/home-manager/commit/32a7da69dc53c9eb5ad0675eb7fdc58f7fe35272) Translate using Weblate (Chinese (Simplified))
* [`cb9f03d5`](https://github.com/knl/home-manager/commit/cb9f03d519cf96fcd7dfb990cc0e586a62ca6e69) mopidy: add module
* [`e6869735`](https://github.com/knl/home-manager/commit/e6869735d25bb2d33a93ac8e5fcc9a02bbbb5351) htop: fix darwin defaults
* [`97fac4f2`](https://github.com/knl/home-manager/commit/97fac4f2820212a00ed134f9c7e5409d3ecbbf77) Translate using Weblate (Chinese (Simplified))
* [`02b15de8`](https://github.com/knl/home-manager/commit/02b15de8ad714409358cffdc6ed518ade03402c4) Translate using Weblate (French)
* [`94780dd8`](https://github.com/knl/home-manager/commit/94780dd888881bf35165dfdd334a57ef6b14ead8) neovim/coc: add package option ([knl/home-manager⁠#2972](https://togithub.com/knl/home-manager/issues/2972))
* [`e66f0ff6`](https://github.com/knl/home-manager/commit/e66f0ff69a6c0698b35034b842c4b68814440778) docs: bump nmd
* [`d73ba6a5`](https://github.com/knl/home-manager/commit/d73ba6a534a3619b64391e69e2cbcb1d9196ff78) mpdris2: add password option
* [`9042c756`](https://github.com/knl/home-manager/commit/9042c756faaaa773107e5409ac0a9973c84cae8a) mpdris2: remove assertion on mpd module
* [`2c8489e5`](https://github.com/knl/home-manager/commit/2c8489e57a04c913ba9e029cc2849a4bbac9673b) mpdris2: add basic test cases
* [`51ea4217`](https://github.com/knl/home-manager/commit/51ea4217f724c049fde3d29a6aaa77ed2707c4ba) docs: fix README links
* [`64831f93`](https://github.com/knl/home-manager/commit/64831f938bd413cefde0b0cf871febc494afaa4f) emacs: allow extraConfig to reference extraPackages
* [`bda2c80b`](https://github.com/knl/home-manager/commit/bda2c80b4c1a8d85c84c343a25ac7303fbc7999d) himalaya: fix account.folders to new config syntax
* [`8f3e2670`](https://github.com/knl/home-manager/commit/8f3e26705178cc8c1d982d37d881fc0d5b5b1837) doc: make documentation links more visible
* [`acad715f`](https://github.com/knl/home-manager/commit/acad715f788d07ac320662c52b41d3edae48ec2d) docs: update copyright year
* [`1808cb66`](https://github.com/knl/home-manager/commit/1808cb66aa2134d9e627d4aa868ee95e5fe683ed) news: remove a bunch of old (>1 year) entries
* [`ac2287df`](https://github.com/knl/home-manager/commit/ac2287df5a2d6f0a44bbcbd11701dbbf6ec43675) docs: set 22.05 as stable version
* [`684e85d0`](https://github.com/knl/home-manager/commit/684e85d01d333be91c4875baebb05b93c7d2ffaa) docs: set 22.11 as next version
* [`a3638db0`](https://github.com/knl/home-manager/commit/a3638db009f3dbcca5f44b8f858af9d7e22bf2b7) Use newer getmail6 over getmail package ([knl/home-manager⁠#2982](https://togithub.com/knl/home-manager/issues/2982))
* [`20703892`](https://github.com/knl/home-manager/commit/20703892473d01c70fb10248442231fe94f4ceb4) htop: add missing fields ([knl/home-manager⁠#2989](https://togithub.com/knl/home-manager/issues/2989))
* [`64ab7d6e`](https://github.com/knl/home-manager/commit/64ab7d6e8d157848ec285cd267db29e2f14c1076) Prepare inclusion in nixos-search ([knl/home-manager⁠#2971](https://togithub.com/knl/home-manager/issues/2971))
* [`70824bb5`](https://github.com/knl/home-manager/commit/70824bb5c790b820b189f62f643f795b1d2ade2e) swaylock: Add module ([knl/home-manager⁠#3003](https://togithub.com/knl/home-manager/issues/3003))
* [`935ecea6`](https://github.com/knl/home-manager/commit/935ecea67d59f2af9d9f56d18a8f0dc12fb18cfd) neovim: add missing literalExpression in module docs ([knl/home-manager⁠#3012](https://togithub.com/knl/home-manager/issues/3012))
* [`cd3dd218`](https://github.com/knl/home-manager/commit/cd3dd2188c19416bc70d9703f84e07a0646af5bf) nixos: allow setting fonts.fontconfig.enable without mkForce ([knl/home-manager⁠#3014](https://togithub.com/knl/home-manager/issues/3014))
* [`87d30c16`](https://github.com/knl/home-manager/commit/87d30c164849a7471d99749aa4d2d28b81564f69) nixos: fix fontconfig mkDefault call ([knl/home-manager⁠#3021](https://togithub.com/knl/home-manager/issues/3021))
* [`07dbd4c0`](https://github.com/knl/home-manager/commit/07dbd4c0dd15718a2a0b4457de7a10f9db0b342f) pywal: fixed i3 config ([knl/home-manager⁠#3002](https://togithub.com/knl/home-manager/issues/3002))
* [`1342f4a0`](https://github.com/knl/home-manager/commit/1342f4a07c14bc40592b5faaa258736a12bc1327) Translate using Weblate (Catalan)
* [`68edbc7f`](https://github.com/knl/home-manager/commit/68edbc7f2839bde0abea2bb381d401d813e3adeb) Add translation using Weblate (Finnish)
* [`a9b027b8`](https://github.com/knl/home-manager/commit/a9b027b826fb9644515f045e115d1466297da958) Translate using Weblate (Catalan)
* [`504d6de6`](https://github.com/knl/home-manager/commit/504d6de6a061993c3f585f9a86c6a9f68927b1c0) Add translation using Weblate (Finnish)
* [`1de492f6`](https://github.com/knl/home-manager/commit/1de492f6f8e9937c822333739c5d5b20d93bf49f) format: update and remove exceptions ([knl/home-manager⁠#3029](https://togithub.com/knl/home-manager/issues/3029))
* [`a0e7ffe7`](https://github.com/knl/home-manager/commit/a0e7ffe7aa6c37b33b80fa7ac03a5327b81bd8d8) docs: use `$` prompts for nix-channel commands
* [`2ff38c64`](https://github.com/knl/home-manager/commit/2ff38c646f6e22e20f703ad1940a5e5e9faa252b) flake: make pkgs required in homeManagerConfiguration
* [`69e80483`](https://github.com/knl/home-manager/commit/69e804839e0ab067cbdd6f8ba6e60c32c63fd261) flake: don't reinstantiate nixpkgs
* [`586ac1fd`](https://github.com/knl/home-manager/commit/586ac1fd58d2de10b926ce3d544b3179891e58cb) Move `integration-common.nix` to `nixos/common.nix`
* [`931653b9`](https://github.com/knl/home-manager/commit/931653b99f876c6ddee0f9b864707cf228d162f1) emacs: optionally start service with the session
* [`5197e5df`](https://github.com/knl/home-manager/commit/5197e5df7d3a148b1ad080235f70800987bc3549) Bump .release file
* [`ce8266de`](https://github.com/knl/home-manager/commit/ce8266dedcba66155624eca88280ee425f4d3611) docs: revert to `#` prompt on NixOS
* [`3d8265c5`](https://github.com/knl/home-manager/commit/3d8265c5efd5e4d3ad8a90686bc81d49353fdb08) email: minor formatting fix
* [`3c710201`](https://github.com/knl/home-manager/commit/3c710201d59188754517eca0e6bd89ca34863e9c) version: remove default value
* [`931e6105`](https://github.com/knl/home-manager/commit/931e6105523a9f4a50967558a896a6987dd99cac) nushell: update configuration management
* [`60b06424`](https://github.com/knl/home-manager/commit/60b064249d613eadc9020b146034d946287283f3) treewide: remove trailing white spaces and tabs
* [`ce563f59`](https://github.com/knl/home-manager/commit/ce563f591195cf363bca382fe02ea5ca87754773) mopidy: add support for extraConfigFiles
* [`206ded40`](https://github.com/knl/home-manager/commit/206ded407eb8cc80104fae41252705a67037f137) dunst: fix settings example
* [`1ebbef86`](https://github.com/knl/home-manager/commit/1ebbef8642c511b289730e3985ec1d53c5c48908) barrier: change `enableCrypto` behaviour
* [`46761794`](https://github.com/knl/home-manager/commit/467617947d25077d178fe060c841d8a92b9c3c2f) email: add support for JMAP
* [`d059b944`](https://github.com/knl/home-manager/commit/d059b9448a04100cdd231872254283dc278a4ea0) mujmap: add module
* [`77f1c763`](https://github.com/knl/home-manager/commit/77f1c7636a92973be913ec21be5203edba017100) docs: bump nmd
* [`06bb67ab`](https://github.com/knl/home-manager/commit/06bb67ab24bd6e6c6d2bc97ecbcddd6c8b07ac18) flake.lock: use SRI hash for nmd
* [`e622bad1`](https://github.com/knl/home-manager/commit/e622bad16372aa5ada79a7fa749ec78715dffc54) neovim/coc: fix `withNodeJs` value when enabling coc ([knl/home-manager⁠#3048](https://togithub.com/knl/home-manager/issues/3048))
* [`fd047c84`](https://github.com/knl/home-manager/commit/fd047c84f705442f04105e363ed450f54309591e) mcfly: add fuzzy search factor option
* [`65bcfacc`](https://github.com/knl/home-manager/commit/65bcfaccc5584e3c04ac883dc0501faf1ec9025f) micro: add module
* [`223b9dee`](https://github.com/knl/home-manager/commit/223b9deeaddb9b8e2a6325fb661d2f62abe8450d) pistol: add module
* [`da55d18b`](https://github.com/knl/home-manager/commit/da55d18ba2412d7102a915955dce0c916546447a) docs: fix typo in nix-darwin flake
* [`e0baf8ee`](https://github.com/knl/home-manager/commit/e0baf8ee0c3578ea158df99f4443fdd30b9bfe14) docs: disable _module.check for nixos/nix-darwin modules
* [`f2694685`](https://github.com/knl/home-manager/commit/f26946858e07384860bf288f20e39a8d32ed5b71) flake: remove superfluous arguments
* [`1dbac84b`](https://github.com/knl/home-manager/commit/1dbac84b846e4bfa21a08e31e95e11f0965ed042) mpd-discord-rpc: restart on failure
* [`72a135b0`](https://github.com/knl/home-manager/commit/72a135b093cbf3497a287bd5b1a605dcdcc73b7a) docs: fix homeManagerConfiguration documentation
* [`0ca0b910`](https://github.com/knl/home-manager/commit/0ca0b91088a462d4cac888baad3c3732d6dedb51) sctd: add module
* [`0434f8e4`](https://github.com/knl/home-manager/commit/0434f8e4cab4f200c9b4d3741a9e5d89705e6754) integration-common: set hmModule's description directly
* [`95505955`](https://github.com/knl/home-manager/commit/9550595502bf437be7eb32f312a924ec891872d1) docs,tests: fetch nmd and nmt using fetchTarball
* [`be3adf99`](https://github.com/knl/home-manager/commit/be3adf9920febf26ff5221ed5c8c76a43b2d94d6) Revert "integration-common: set hmModule's description directly"
* [`3bf16c0f`](https://github.com/knl/home-manager/commit/3bf16c0fd141c28312be52945d1543f9ce557bb1) udiskie: add option settings
* [`f2445620`](https://github.com/knl/home-manager/commit/f2445620d177e295e711c1b2bc6c01ed6df26c16) redshift: remove petabyteboy from maintainers
* [`face4094`](https://github.com/knl/home-manager/commit/face4094d499c84c782873464794cb976c94f079) bspwm: add missing rule setting `rectangle` ([knl/home-manager⁠#2974](https://togithub.com/knl/home-manager/issues/2974))
* [`ef990143`](https://github.com/knl/home-manager/commit/ef990143b6ae86685fc24a8d40538834a28fc994) nushell: fix non-nullable configFile and envFile, fixes [knl/home-manager⁠#3050](https://togithub.com/knl/home-manager/issues/3050) ([knl/home-manager⁠#3060](https://togithub.com/knl/home-manager/issues/3060))
* [`12cfcc1b`](https://github.com/knl/home-manager/commit/12cfcc1b9dc9a8a7a0b4cf538841b85af5c4cd98) fusuma: fix settings example ([knl/home-manager⁠#3067](https://togithub.com/knl/home-manager/issues/3067))
* [`25a99483`](https://github.com/knl/home-manager/commit/25a9948361cc6676e70c1b439e4d40f0610e8f76) sway: import dbus env vars and explicitly specify them ([knl/home-manager⁠#3031](https://togithub.com/knl/home-manager/issues/3031))
* [`8160b3b4`](https://github.com/knl/home-manager/commit/8160b3b45b8457d58d2b3af2aeb2eb6f47042e0f) zsh: source zsh-syntax-highlighting at the end of .zshrc ([knl/home-manager⁠#3068](https://togithub.com/knl/home-manager/issues/3068))
* [`8d5b07fc`](https://github.com/knl/home-manager/commit/8d5b07fc83d579cd196125e698454b4eb4850646) tests: fix impurity of _module.args.pkgsPath
* [`f2b216c3`](https://github.com/knl/home-manager/commit/f2b216c3204bbe4ae1c2c70261174b64f37b7f47) Translate using Weblate (Japanese)
* [`c645cc9f`](https://github.com/knl/home-manager/commit/c645cc9f82c7753450d1fa4d1bc73b64960a9d7a) Translate using Weblate (Japanese)
* [`0639aa34`](https://github.com/knl/home-manager/commit/0639aa34f1c2e584598c19a38990e81ad2b86ae2) git: add option to set difftastic display setting
* [`b908e61d`](https://github.com/knl/home-manager/commit/b908e61dfad269d97376c1832eb9127e444953a3) picom: sync module with the NixOS version
* [`177f1887`](https://github.com/knl/home-manager/commit/177f1887d4d4eb347c6a8328fbd8ca0f346887bc) compton: remove
* [`6311f4ad`](https://github.com/knl/home-manager/commit/6311f4adc39fc8ce77f7b80212024fe4286280d1) lib/types: make DAG entries mergeable
* [`43ea4c51`](https://github.com/knl/home-manager/commit/43ea4c5123d9d335ff4eba6341509d45f60ceeec) swayidle: fix systemd service
* [`45ef70cc`](https://github.com/knl/home-manager/commit/45ef70cc73540fbf9718cce5da65e2aa6e7ab2f7) swayidle: remove unnecessary config wrapper
* [`1e66e035`](https://github.com/knl/home-manager/commit/1e66e035e18ca02d72ebbbc83e4e75fa0acdf1af) gpg-agent: set Environment to a list
* [`c5fc1575`](https://github.com/knl/home-manager/commit/c5fc157554e24a75cf4fb7a8827caa43f51df708) picom: fix option name
* [`b8bb5f29`](https://github.com/knl/home-manager/commit/b8bb5f291a4131e94b1a49b15d2735fcff581fa3) xdg-desktop-entries: allow icon path type
* [`d4081057`](https://github.com/knl/home-manager/commit/d4081057e56dee1a720b1eda5a84eef032715f05) codeowners: cleanup alphabetization
* [`d6d600e7`](https://github.com/knl/home-manager/commit/d6d600e76d227920cb20cab9e9a630ff45e55469) docs: remove bit about Nix 2.4 not being supported
* [`602f2ce5`](https://github.com/knl/home-manager/commit/602f2ce59c0150755fa30a23e6921a1c7453f8c7) docs: note support for 2.4 or later for Flake
* [`241a375f`](https://github.com/knl/home-manager/commit/241a375f49737a64300dcee35d6566837d27ef93) keychain: set SHELL correctly in bash and zsh
* [`66d7007e`](https://github.com/knl/home-manager/commit/66d7007e4354e7c19257e0b4fc576f61fde2e1e0) mpv: prohibit string values in scripts
* [`2c94b980`](https://github.com/knl/home-manager/commit/2c94b9801f1a11cde0fc97aa850687bb9137d42c) librewolf: add module
* [`3b5330c8`](https://github.com/knl/home-manager/commit/3b5330c80f9bb5dbca882a22b0e265d14e92888a) Translate using Weblate (Dutch)
* [`8385408c`](https://github.com/knl/home-manager/commit/8385408c658345bb28c5d2d30f9b494d4045e0e2) Add translation using Weblate (Dutch)
* [`4c5106ed`](https://github.com/knl/home-manager/commit/4c5106ed0f3168ff2df21b646aef67e86cbfc11c) firefox: reuse `escapeXML` from Nixpkgs
* [`64c745fe`](https://github.com/knl/home-manager/commit/64c745fe1c019b724e241a4f3cfbe3c661f54712) firefox: add support for nested bookmarks
* [`30dda628`](https://github.com/knl/home-manager/commit/30dda628bcd0814f65393359a4763f1afaee25a0) home-manager: add ncurses to PATH
* [`4a724cb8`](https://github.com/knl/home-manager/commit/4a724cb84cc3aa464af1713d11bf0cfbbdb56c00) lib: improve DAG library
* [`70d59298`](https://github.com/knl/home-manager/commit/70d5929885ccec8dde8585894dd3ebe606e75f41) integration-common: set hmModule's description directly
* [`9cf40a43`](https://github.com/knl/home-manager/commit/9cf40a43fce5c0eab563435b4dd719b1ea610d40) github: ensure using the right branch of Home Manager
* [`f47611fb`](https://github.com/knl/home-manager/commit/f47611fb171d967e0c65cfc99896913d62fa0d29) github: fix line wrapping
* [`f91fb470`](https://github.com/knl/home-manager/commit/f91fb470bc5404b0198bbe2c427aaf8bac5857fa) firefox: use `coercedTo` to convert bookmarks to a list
* [`218cb3ae`](https://github.com/knl/home-manager/commit/218cb3aee270aa7c073f2861864e921799bff360) firefox: fix empty check of bookmarks list
* [`d86c1891`](https://github.com/knl/home-manager/commit/d86c189158cb345e351190e362672a8485a52117) firefox: support showing bookmarks on toolbar
* [`1d3380af`](https://github.com/knl/home-manager/commit/1d3380afba625fdfcc131033e571140a09a993af) flake: fix self referential lib output
* [`572f348a`](https://github.com/knl/home-manager/commit/572f348a10826b2207caaf394e9ad2e9ffc6ffa7) darwin: add support for 'defaults -currentHost' options
* [`a3b778e6`](https://github.com/knl/home-manager/commit/a3b778e672e2a24f9307190da320782aa654b712) spectrwm: add module
* [`8419dfd3`](https://github.com/knl/home-manager/commit/8419dfd39d678afd5bc40df48f21fcaad8fc1332) fish: enable manpage completion
* [`dbed4c79`](https://github.com/knl/home-manager/commit/dbed4c794d20d51027fc1107f063ec5be027dafc) xdg-user-dirs: create directories after `linkGeneration`
* [`0b7fd187`](https://github.com/knl/home-manager/commit/0b7fd187e2dc8364cf31ed69347e4793c2d83a57) xdg-mime-apps: fix regex in `mimeAssociations`
* [`119febc4`](https://github.com/knl/home-manager/commit/119febc46489fc2b366fb5915667a6eb5d688059) vscode: avoid unnecessary IFD (again)
* [`b1394643`](https://github.com/knl/home-manager/commit/b13946438f235a002c6a1c966b84b124123b26cf) docs: improve contributing documentation
* [`0e2f7876`](https://github.com/knl/home-manager/commit/0e2f7876d2f2ae98a67d89a8bef8c49332aae5af) recoll: add module
* [`7146638e`](https://github.com/knl/home-manager/commit/7146638e9ef74aba6736cbbf12dbe60e1ed24c1e) Fix typo. ([knl/home-manager⁠#3118](https://togithub.com/knl/home-manager/issues/3118))
* [`d1c677ac`](https://github.com/knl/home-manager/commit/d1c677ac257affed8d026f418b81ed5de2c8d963) hyfetch: add module
* [`77648a07`](https://github.com/knl/home-manager/commit/77648a07e459adff69b2c4033a77b2cababb5843) hyfetch: prevent writing config with default/empty settings ([knl/home-manager⁠#3124](https://togithub.com/knl/home-manager/issues/3124))
* [`d8d9ff0b`](https://github.com/knl/home-manager/commit/d8d9ff0b2df77defa10375c6665b51f0251c34d6) tint2: correctly reference the provided package ([knl/home-manager⁠#3125](https://togithub.com/knl/home-manager/issues/3125))
* [`91f26e0b`](https://github.com/knl/home-manager/commit/91f26e0b0e88b6431740055c598bd586c275276a) polybar: use add `.ini` suffix to configuration file
* [`d9e03b7f`](https://github.com/knl/home-manager/commit/d9e03b7f8c67890b920c92d8154dd9b60bb1242f) wezterm: add module
* [`f5e9879e`](https://github.com/knl/home-manager/commit/f5e9879e74e6202e2dbb3628fad2d20eac0d8be4) bash: support bash completion
* [`389f2b20`](https://github.com/knl/home-manager/commit/389f2b20371b7c0c7e52ceb817d7c8bbc63435a4) bashmount: add module
* [`c1addfda`](https://github.com/knl/home-manager/commit/c1addfdad3825f75a66f8d73ec7d2f68c78ba6f8) gammastep: wait on geoclue-agent when configured
