### PR TITLE
niv nixpkgs: update 2933077b -> a2cd5706

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2933077b4be4ab7f2167777c73af1039763677c3",
-        "sha256": "0sacdjdgw4h12m14avzd9s7j64rgsf52qi6cxz54f682ip0lkcfh",
+        "rev": "a2cd57069d78bce6bef4a8b85f422bb4d0e91ecb",
+        "sha256": "0w4w0gawdwq9k9s1zzib45z0wqs0gsnfs0iq8yhmycxa1s43g5n9",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/2933077b4be4ab7f2167777c73af1039763677c3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a2cd57069d78bce6bef4a8b85f422bb4d0e91ecb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@2933077b...a2cd5706](https://github.com/nixos/nixpkgs/compare/2933077b4be4ab7f2167777c73af1039763677c3...a2cd57069d78bce6bef4a8b85f422bb4d0e91ecb)

* [`ad735b87`](https://github.com/NixOS/nixpkgs/commit/ad735b87e4607f535586b329d9030fbf6974f38b) hidpi: Use gray-scale antialiasing for fonts
* [`acef4bfe`](https://github.com/NixOS/nixpkgs/commit/acef4bfe614d4b826015498b9dff2052516523c7) chromium: improve kerberos support
* [`e234e5e8`](https://github.com/NixOS/nixpkgs/commit/e234e5e8f871b21dce4db2b856d5ed5f40aad5d8) NixOS manual: fix ACME certificates in Nginx configuration example
* [`fbc8dbb0`](https://github.com/NixOS/nixpkgs/commit/fbc8dbb075a5c63a5c15008f05a8f9be78dff235) nixos/systemd: Add onSuccess module option for units
* [`a04fa422`](https://github.com/NixOS/nixpkgs/commit/a04fa422f000aa1f6bd477094b7aaac669b76329) nixos/tests/bitcoind: fix test
* [`f18befaa`](https://github.com/NixOS/nixpkgs/commit/f18befaaf4cdb84e20da306ea853e497f4fe4bdf) nixos/doc/installation: fix alignment of created partitions
* [`305b6334`](https://github.com/NixOS/nixpkgs/commit/305b633423fce2fc4848bcf9e45379ef51eb738c) nixos/modules/security/pam: fix [nixos/nixpkgs⁠#95798](https://togithub.com/nixos/nixpkgs/issues/95798) & [nixos/nixpkgs⁠#128116](https://togithub.com/nixos/nixpkgs/issues/128116)
* [`6a004f7e`](https://github.com/NixOS/nixpkgs/commit/6a004f7e4cc0f819dcec2c67f2e57760e6c5115d) gtk-layer-shell: 0.6.0 -> 0.7.0
* [`291e69a6`](https://github.com/NixOS/nixpkgs/commit/291e69a67a207a637726fcaa6bdc80cafd05fd72) gtk-layer-shell: install demo
* [`2fa9280b`](https://github.com/NixOS/nixpkgs/commit/2fa9280b1ea76d5c73763b21245e92a616b8f0fa) dictu: 0.24.0 -> 0.25.0
* [`d2990717`](https://github.com/NixOS/nixpkgs/commit/d2990717f165acba5817d20f332159c797fad508) CONTRIBUTING.md: simplify rebasing instructions
* [`4549f693`](https://github.com/NixOS/nixpkgs/commit/4549f69311dfc7b40218ef08c525749e648674d5) cura: 4.12.1 -> 4.13.1
* [`2b42b1ad`](https://github.com/NixOS/nixpkgs/commit/2b42b1adbbd297eba7cd4a131c80854784f772ff) rustypaste: init at 0.7.1
* [`f880ea69`](https://github.com/NixOS/nixpkgs/commit/f880ea69baef7e6b7a639fab64ebc1fdde15962d) nixos/globalprotect: add settings option for service configuration
* [`d6915ebb`](https://github.com/NixOS/nixpkgs/commit/d6915ebb3f5011bc66b88a591b267b71ff884525) buildFHSUserEnvBubblewrap: allow for non-x86 platforms
* [`d48f6467`](https://github.com/NixOS/nixpkgs/commit/d48f6467e223216fbb886043c51de8c8dcbf2cfe) plex: use buildFHSUserEnvBubblewrap
* [`2c09ab4c`](https://github.com/NixOS/nixpkgs/commit/2c09ab4c6ed26814bef7eb893fbe51412196c707) maintainers: add k3a
* [`0570ae05`](https://github.com/NixOS/nixpkgs/commit/0570ae054a7b60f4572987f8db0718fa36d08050) openboardview: init at 9.0.3
* [`71d3f34e`](https://github.com/NixOS/nixpkgs/commit/71d3f34e68d265305e801ffad46209f742368204) yubikey-personalization-gui: fix pixmap installation
* [`59990a61`](https://github.com/NixOS/nixpkgs/commit/59990a614f9a641f52d196a71d8350c9d1c516ad) gam init at 6.22
* [`3e74cc90`](https://github.com/NixOS/nixpkgs/commit/3e74cc9087d0a267f4233bcd9cfb839d64335bd8) fnlfmt: 0.2.2 -> 0.2.3
* [`6f874543`](https://github.com/NixOS/nixpkgs/commit/6f874543c8f62aa05b7501ece0db00a7fd76b5ac) embree: 3.13.3 -> 3.13.4
* [`45be84d3`](https://github.com/NixOS/nixpkgs/commit/45be84d314d6094c1a83f5c30852604a00f9ad67) fldigi: 4.1.20 -> 4.1.23
* [`041e449f`](https://github.com/NixOS/nixpkgs/commit/041e449f8820a1479b8e8f41990595455e4533b2) flmsg: 4.0.19 -> 4.0.20
* [`a70da63f`](https://github.com/NixOS/nixpkgs/commit/a70da63f18dcf3ca8786a9aa5b14862ad5eaf91d) editres: 1.0.7 -> 1.0.8
* [`06ba031a`](https://github.com/NixOS/nixpkgs/commit/06ba031afa2730fc085ca7aba49fabd12576fe59) avizo: 1.2 -> 1.2.1
* [`4f92d7c0`](https://github.com/NixOS/nixpkgs/commit/4f92d7c0e22258358664f5289fcc94f8bde522e3) calamares: 3.2.59 -> 3.2.60
* [`3772903e`](https://github.com/NixOS/nixpkgs/commit/3772903ede363ece60ad52aff739ba56663e35be) duo-unix: 1.12.0 -> 1.12.1
* [`ad4097bb`](https://github.com/NixOS/nixpkgs/commit/ad4097bbf450c646989ef559ac38f2da54454ad4) dcw-gmt: 2.1.0 -> 2.1.1
* [`e16e9e91`](https://github.com/NixOS/nixpkgs/commit/e16e9e91340f3e208d339cb87d595139c72c538f) cgreen: 1.4.1 -> 1.6.0
* [`4f64659d`](https://github.com/NixOS/nixpkgs/commit/4f64659d54ce6dd1002707cec1fad3fcc649fbd4) fast-downward: 21.12.0 -> 22.06.0
* [`2cdbc00b`](https://github.com/NixOS/nixpkgs/commit/2cdbc00b2c3c74d0ad1b78d7e809d6c94cddad82) flutter: use `dart pub` instead of deprecated pub command
* [`04699b7b`](https://github.com/NixOS/nixpkgs/commit/04699b7b7e30b53d8eeb4817f9aa69bf6baeff51) flutter: 2.10.1->3.0.4
* [`02e10382`](https://github.com/NixOS/nixpkgs/commit/02e10382d53894fdac31b6ac02c6eca3194cbdc0) flutter: patch git version check
* [`43d2b919`](https://github.com/NixOS/nixpkgs/commit/43d2b91944bd628cf91aadddd18cb48768f8f37e) flutter: amend move-cache patch after update
* [`043de04d`](https://github.com/NixOS/nixpkgs/commit/043de04db8a6b0391b3fefaaade160514d866946) update hashes for fluffychat and firmware-updater
* [`570d61a7`](https://github.com/NixOS/nixpkgs/commit/570d61a7dceccad53dce9273fc96dc9803da1380) mongosh: 1.5.0 -> 1.4.2
* [`2856eb20`](https://github.com/NixOS/nixpkgs/commit/2856eb20469aec5de5aec8fa464f82a07888d92a) vault: fix assertions when raft backend is used
* [`bd2caca3`](https://github.com/NixOS/nixpkgs/commit/bd2caca375c2e5607fed6e117d9dd0bef808aaa0) Fix salt with ZeroMQ 23.0.0 and newer
* [`a05a338d`](https://github.com/NixOS/nixpkgs/commit/a05a338df5f42676a64347122d9fe94e05e92f79) barman: patch out subprocess wrapper
* [`fe44207a`](https://github.com/NixOS/nixpkgs/commit/fe44207a715771e6103e0874c9b9bd693fd79955) nixos/power-management: run post-resume after suspend-then-hibernate
* [`a79c8da1`](https://github.com/NixOS/nixpkgs/commit/a79c8da189ec590939d7fdf8d141b39275e5ecf9) libfido2: 1.10.0 -> 1.11.0
* [`56d0dd7f`](https://github.com/NixOS/nixpkgs/commit/56d0dd7fc421e021a4df3f28e8ee1e3fe4cf1631) polkit: use systemdMinimal to avoid dep cycle
* [`dad55752`](https://github.com/NixOS/nixpkgs/commit/dad557524a8572426d03640c6f7b193027dac51a) pcsclite: use systemdMinimal to avoid dep cycle
* [`3b9048a3`](https://github.com/NixOS/nixpkgs/commit/3b9048a3cefb6e86af60348513624ea691cd7f41) bluez: use systemdMinimal to avoid dep cycle
* [`5f43dbea`](https://github.com/NixOS/nixpkgs/commit/5f43dbea703c44643dcc280308c6ec40e0e198b4) dbus: use systemdMinimal to avoid dep cycle
* [`aa5659c1`](https://github.com/NixOS/nixpkgs/commit/aa5659c1a773964840945d9a41b424812e5437d1) python-dbusmock: refactor check, avoid dep cycle
* [`e384d91b`](https://github.com/NixOS/nixpkgs/commit/e384d91be48f18fc28fdd0ac9be87b117c4c5806) libfido2: depend on pcsclite to support nfc keys
* [`728e1c02`](https://github.com/NixOS/nixpkgs/commit/728e1c026b4b58651c82af3c6e06ad2b36bfdb26) python310Packages.sentinel: 0.3.0 -> 1.0.0
* [`0c4d481d`](https://github.com/NixOS/nixpkgs/commit/0c4d481dbc2c5f631656b128d5d5261c1c02e5eb) openjdk17: 17.0.3+7 -> 17.0.4+8
* [`a885d2af`](https://github.com/NixOS/nixpkgs/commit/a885d2af2249f4c4d8868d3a1ab34547f0ba0ef6) python310Packages.python-dbusmock: 0.28.3 -> 0.28.4
* [`fa84750c`](https://github.com/NixOS/nixpkgs/commit/fa84750cdbb105699a019d97766ece2f0ad00358) libbdplus: 0.1.2 -> 0.2.0
* [`7c302eb4`](https://github.com/NixOS/nixpkgs/commit/7c302eb4e5fba7b0c97f99ad165fd5af051ca3a9) ladybird: init at unstable-2022-07-20
* [`40e13156`](https://github.com/NixOS/nixpkgs/commit/40e13156af02f27c40b5020136e39790e4216fc9) libyang: 2.0.194 -> 2.0.231
* [`43f0842a`](https://github.com/NixOS/nixpkgs/commit/43f0842a919aff11eb92334ad0c12f434c8c2b71) freeglut: 3.2.1 -> 3.2.2
* [`c1787950`](https://github.com/NixOS/nixpkgs/commit/c178795063fd86755fad525dc8e98afa9ca2e155) atlantis: 0.19.6 -> 0.19.7
* [`e57b2715`](https://github.com/NixOS/nixpkgs/commit/e57b2715396a68001dcd6dbbbdebc1134b5f6e75) asciidoctorj: 2.5.4 -> 2.5.5
* [`bf817382`](https://github.com/NixOS/nixpkgs/commit/bf817382e7364435fc460e43d2fb14c6d93b1b77) gnupg: 2.3.6 -> 2.3.7
* [`4303cfcc`](https://github.com/NixOS/nixpkgs/commit/4303cfcc641f804ec1b480955be661cccc35d428) ceph: 16.2.9 -> 16.2.10
* [`d338b732`](https://github.com/NixOS/nixpkgs/commit/d338b7326154e8fcfb3b9dc885372c8c07fa3c66) ell: 0.51 -> 0.52
* [`8ecdb522`](https://github.com/NixOS/nixpkgs/commit/8ecdb52267295647b272c236e226e2bcbfd6f14e) graphia: 3.0 -> 3.1
* [`f06b37c4`](https://github.com/NixOS/nixpkgs/commit/f06b37c413a6780e6fb8bae5026aa2fb82db89aa) grocy: 3.3.0 -> 3.3.1
* [`4c1987dd`](https://github.com/NixOS/nixpkgs/commit/4c1987ddb18460406e1b701a9328572804f6bbdf) python310Packages.urllib3: 1.26.10 -> 1.26.11
* [`287c3993`](https://github.com/NixOS/nixpkgs/commit/287c39936273cbc9fff56fb9c9e49bec5d42f51c) kubeconform: 0.4.13 -> 0.4.14
* [`49015108`](https://github.com/NixOS/nixpkgs/commit/490151083e4d739960f2114f240a3ab844a63253) leo-editor: 6.6-b2 -> 6.6.3
* [`51d1d82c`](https://github.com/NixOS/nixpkgs/commit/51d1d82cc1cc34f997a934464a8700ec55cf4ba2) libass: 0.15.2 -> 0.16.0
* [`d82ce045`](https://github.com/NixOS/nixpkgs/commit/d82ce045579a36df43120d8174255ef49470e5e3) windows.mingw_w64: enable stripping
* [`2c7cc797`](https://github.com/NixOS/nixpkgs/commit/2c7cc7977f400be7b3194725ac4112b3d5f3e37f) libp11: 0.4.11 -> 0.4.12
* [`efb35dff`](https://github.com/NixOS/nixpkgs/commit/efb35dff8a38ea5277fa29aecc5920de2c022714) stdenv/linux/bootstrap-files: add mipsel-linux (mips32)
* [`8f512e2c`](https://github.com/NixOS/nixpkgs/commit/8f512e2c5d8ba8ae8a8e9756ce401a92f0a4b180) librepo: 1.14.2 -> 1.14.3
* [`f7c4f709`](https://github.com/NixOS/nixpkgs/commit/f7c4f709fd08543705f95b60bc6d0ec77314a649) mark: 8.0 -> 8.3
* [`36706394`](https://github.com/NixOS/nixpkgs/commit/3670639415ad0e12934af9df2b833217c2102c66) mod: 0.4.1 -> 0.4.2
* [`3aa2d937`](https://github.com/NixOS/nixpkgs/commit/3aa2d9376dc7d9b8a23b9bd43785e127f7e00ba4) mustache-go: 1.3.1 -> 1.4.0
* [`db004ed2`](https://github.com/NixOS/nixpkgs/commit/db004ed2dc159bc5717a5f3380804586f8e9bd3f) nanoflann: 1.4.2 -> 1.4.3
* [`0f2b280b`](https://github.com/NixOS/nixpkgs/commit/0f2b280b275b824b5ef57f1125818850059c31de) oapi-codegen: 1.9.1 -> 1.11.0
* [`c826b18a`](https://github.com/NixOS/nixpkgs/commit/c826b18a286e27686495f6035d57167cf99a1109) patchelf: 0.14.5 -> 0.15.0
* [`dc449c9b`](https://github.com/NixOS/nixpkgs/commit/dc449c9bcf31db50adb6404819650dc969d38244) pgweb: 0.11.11 -> 0.11.12
* [`9338d8c9`](https://github.com/NixOS/nixpkgs/commit/9338d8c9b7b512ddb3cf3e18bc50a0d7631d5d88) picard-tools: 2.26.11 -> 2.27.4
* [`6c099892`](https://github.com/NixOS/nixpkgs/commit/6c099892f409f7f3b36e475575c2b6a5f68dd83b) pulumictl: 0.0.30 -> 0.0.32
* [`ae5575f7`](https://github.com/NixOS/nixpkgs/commit/ae5575f7c1889c68d23add3a84aabc529f5c1a5f) pure-maps: 3.0.0 -> 3.1.0
* [`f6ee60dd`](https://github.com/NixOS/nixpkgs/commit/f6ee60dde4a00f94d57f44ae768b3f5ccb228672) gnumake: unconditionally disable guileSupport on bootstrap
* [`32904b78`](https://github.com/NixOS/nixpkgs/commit/32904b78709b92defe39aeb67861911b483fbd3a) gnupg: remove ? null from inputs, remove with lib
* [`ddeaf735`](https://github.com/NixOS/nixpkgs/commit/ddeaf73584feae32e1643fcaaff98fb60860ee82) systemd: remove null overwrites for gnupg
* [`d1f9948e`](https://github.com/NixOS/nixpkgs/commit/d1f9948ea500398028325a7e067998acc11c2f5f) qdirstat: 1.8 -> 1.8.1
* [`fd169062`](https://github.com/NixOS/nixpkgs/commit/fd1690622fb79776376cd54d6ffcf3cac1e0c7a9) qtads: 3.2.0 -> 3.3.0
* [`6c93364c`](https://github.com/NixOS/nixpkgs/commit/6c93364cc2fb61e6be2d2cad687d516959638763) rsync: enable parallel building
* [`bf0aa680`](https://github.com/NixOS/nixpkgs/commit/bf0aa680881de6d6523b73b35b3f66977ded3c93) Revert "rsync: Work around upstream cross-compilation issue"
* [`b4964ee4`](https://github.com/NixOS/nixpkgs/commit/b4964ee4a27c03fe6a839bc548da56795eb9e53c) rauc: 1.6 -> 1.7
* [`d11d06ba`](https://github.com/NixOS/nixpkgs/commit/d11d06ba01c6292121aac1cbc052dc4c09c1101d) groff: remove ? null from inputs
* [`65246294`](https://github.com/NixOS/nixpkgs/commit/652462942a92bb98ef2a2d0e839663998876cdf8) edgetx: 2.6.0 -> 2.7.1
* [`da9cc2bf`](https://github.com/NixOS/nixpkgs/commit/da9cc2bf6c0f1610824b550ec9ea3d792f15dba2) ruplacer: 0.6.4 -> 0.8.0
* [`74e09435`](https://github.com/NixOS/nixpkgs/commit/74e09435660560d903ecd943a3684ba20e90e1d6) saml2aws: 2.34.0 -> 2.36.0
* [`ea2a35df`](https://github.com/NixOS/nixpkgs/commit/ea2a35dfb6f77c191d841115e482e5d55155c2f7) scheme-bytestructures: 1.0.10 -> 2.0.1
* [`d8aa76c9`](https://github.com/NixOS/nixpkgs/commit/d8aa76c9a13d1fbbbae674a14fe18f89cbef21ea) schismtracker: 20220125 -> 20220506
* [`451da460`](https://github.com/NixOS/nixpkgs/commit/451da4603151f8e1f3dad4d50d5565a74ff7c708) shiori: 1.5.2 -> 1.5.3
* [`5c6a588b`](https://github.com/NixOS/nixpkgs/commit/5c6a588b2812766811eed5b9b8ecf0137a4d2b9c) sigil: 1.9.2 -> 1.9.10
* [`24b899fd`](https://github.com/NixOS/nixpkgs/commit/24b899fde319414704c5546981284cf8977fc581) snazy: 0.10.0 -> 0.10.1
* [`00ad9a37`](https://github.com/NixOS/nixpkgs/commit/00ad9a373f9b4b4dbbdb5829b47b0416ac32796f) erlfmt: 1.0.0 -> 1.1.0
* [`7f2a80da`](https://github.com/NixOS/nixpkgs/commit/7f2a80da51255497971d70b703622a730caf70c7) mdbook-mermaid: 0.11.1 -> 0.11.2
* [`88291875`](https://github.com/NixOS/nixpkgs/commit/8829187576676233191b663ffa9f477cf0bce48f) s3ql: 3.8.1 -> 4.0.0
* [`2cf12b61`](https://github.com/NixOS/nixpkgs/commit/2cf12b619dc6917852070658589e3458d8e54af0) sov: 0.71 -> 0.72
* [`3a3ad4c7`](https://github.com/NixOS/nixpkgs/commit/3a3ad4c7a6beb86e094b32bcc4aabdab614c485b) souffle: 2.2 -> 2.3
* [`4c46cc0b`](https://github.com/NixOS/nixpkgs/commit/4c46cc0b5290acea22e5de3f2c7dc20e172eda59) spotify-qt: 3.8 -> 3.9
* [`83657ee1`](https://github.com/NixOS/nixpkgs/commit/83657ee1601ce7535211e6ae3737004c16a09bd9) pdns: 4.6.2 -> 4.6.3, fix pname
* [`aaebb21a`](https://github.com/NixOS/nixpkgs/commit/aaebb21a9e6104106eb0c208c114e8f13ad38649) nixosTests.powerdns: fix test script for type checking
* [`51583cc6`](https://github.com/NixOS/nixpkgs/commit/51583cc66ca3962e34658a73617a2e3b3966876e) material-kwin-decoration: unstable-2021-10-28 -> unstable-2022-01-19, add update script
* [`64f69cc3`](https://github.com/NixOS/nixpkgs/commit/64f69cc3eb24e92ab87d92d5d0b297a6b2061c34) libtiff: get rid of aarch64-darwin.nix
* [`ab9a97de`](https://github.com/NixOS/nixpkgs/commit/ab9a97de6b5b5138ad8f23d5a1534f0fda838acb) python3Packages.hatchling: 1.5.0 -> 1.6.0
* [`8377a224`](https://github.com/NixOS/nixpkgs/commit/8377a22472cbd04728217cf88d2c992e4ae2f9d6) python310Packages.lark: Enable more tests
* [`be77d9d4`](https://github.com/NixOS/nixpkgs/commit/be77d9d444a800fdd9d36609c78c8c6284de74d8) openalSoft: workaround a cross-compilation issue
* [`6eb810b5`](https://github.com/NixOS/nixpkgs/commit/6eb810b500096334f906909f086c6765a0aa6b3b) linux_xanmod: 5.15.54 -> 5.15.58
* [`a4cfeb7c`](https://github.com/NixOS/nixpkgs/commit/a4cfeb7cf18e0cc1ea6f60ab1935a77982a70b7a) cmake: 3.23.2 -> 3.23.3
* [`4d47a0ef`](https://github.com/NixOS/nixpkgs/commit/4d47a0ef9003534c48f6275f3b31b2ca38720599) gpm: remove ncurses null override ([nixos/nixpkgs⁠#183810](https://togithub.com/nixos/nixpkgs/issues/183810))
* [`79932833`](https://github.com/NixOS/nixpkgs/commit/799328334dfc0eda5199961e20c93ef9c080284d) fricas: 1.3.7 -> 1.3.8
* [`44387033`](https://github.com/NixOS/nixpkgs/commit/44387033837bd7b4503c89616e6375eba633324d) s-tui: 1.1.3 -> 1.1.4
* [`9ffab81e`](https://github.com/NixOS/nixpkgs/commit/9ffab81e141bb7c7b243d16feb3e08f68d6b1fef) stellarsolver: 2.3 -> 2.4
* [`388c37c1`](https://github.com/NixOS/nixpkgs/commit/388c37c1fb0e33a0c4a0958a2a36824eae2115ab) surface-control: 0.4.1-2 -> 0.4.2-1
* [`286e8874`](https://github.com/NixOS/nixpkgs/commit/286e8874f84c69fb31d2875f05cbe929a4fcf046) tar2ext4: 0.9.2 -> 0.9.4
* [`72700e74`](https://github.com/NixOS/nixpkgs/commit/72700e7414ba7bdb7499029d8507f532e51cd88f) termshark: 2.3.0 -> 2.4.0
* [`62931610`](https://github.com/NixOS/nixpkgs/commit/62931610a62f1a9a3471df8c39074e4844ae63a7) the-way: 0.13.0 -> 0.17.1
* [`a483b846`](https://github.com/NixOS/nixpkgs/commit/a483b846005cf68e3d7815ccbc3f417d7830063f) tinyproxy: 1.11.0 -> 1.11.1
* [`834daa7b`](https://github.com/NixOS/nixpkgs/commit/834daa7b5d4be053bcf847017207a31b8d11d1e5) tvm: 0.8.0 -> 0.9.0
* [`55097caf`](https://github.com/NixOS/nixpkgs/commit/55097caf2d6e084c4a016a255db22ddc71f5bbd9) valum: 0.3.16 -> 0.3.17
* [`443504ce`](https://github.com/NixOS/nixpkgs/commit/443504ce16cabf08a9137d5e5bd14587b6fad022) viddy: 0.3.5 -> 0.3.6
* [`d3d0224c`](https://github.com/NixOS/nixpkgs/commit/d3d0224cc21752ee7cc15e536437678ed737d2f5) vkquake: 1.13.0 -> 1.20.3
* [`2106c63c`](https://github.com/NixOS/nixpkgs/commit/2106c63cad0c22e75b74e2fbd2b81e66da6d494e) wvkbd: 0.7 -> 0.9
* [`ae256f78`](https://github.com/NixOS/nixpkgs/commit/ae256f7864273a8c9fa4838a49a8bcdc1210d03f) gpm-ncurses: enable `ncurses` depend
* [`109e0932`](https://github.com/NixOS/nixpkgs/commit/109e0932b88eb78d273b9ae30c97976024e71baa) zef: 0.13.7 -> 0.13.8
* [`6b9494f9`](https://github.com/NixOS/nixpkgs/commit/6b9494f949e2b71464463c723468068d2a1c6dda) snappymail: init at 2.17.0
* [`8920fe09`](https://github.com/NixOS/nixpkgs/commit/8920fe09fa1c6ecee42445b2b5c1b5b199042c4e) gmm: 5.4 -> 5.4.2
* [`735450e1`](https://github.com/NixOS/nixpkgs/commit/735450e173f8e532d21e4e81ea377b40b04970ac) gnomeExtensions.arcmenu: 30 -> 35
* [`5dfbe0ac`](https://github.com/NixOS/nixpkgs/commit/5dfbe0ac192e541685d9cff0381729a1c9dc9ef5) iwd: 1.28 -> 1.29
* [`ecc85e21`](https://github.com/NixOS/nixpkgs/commit/ecc85e21a170d49d6ef01fc8f194605360e3eb87) heaptrack: 1.3.0 -> 1.4.0
* [`1716daf7`](https://github.com/NixOS/nixpkgs/commit/1716daf7860befb5f0b114fad992aa3c46a93970) influxdb2-cli: 2.2.1 -> 2.3.0
* [`8c53477f`](https://github.com/NixOS/nixpkgs/commit/8c53477f36850279da7be9884684c9b91c925454) ipopt: 3.14.5 -> 3.14.9
* [`35bb4e4a`](https://github.com/NixOS/nixpkgs/commit/35bb4e4accd18cbd62059fa26d12915b28a145bd) leftwm: 0.2.11 -> 0.3.0
* [`a650ba22`](https://github.com/NixOS/nixpkgs/commit/a650ba227162a31a3fa97956426e36223ad23413) libdsk: 1.5.18 -> 1.5.19
* [`a9d4bed7`](https://github.com/NixOS/nixpkgs/commit/a9d4bed7d979c19950ce6beaf8f66cb008f15ee9) libinput-gestures: 2.72 -> 2.73
* [`c5576b41`](https://github.com/NixOS/nixpkgs/commit/c5576b41f32ad8e36e192c098ffc23fc5a564584) libinklevel: 0.9.3 -> 0.9.4
* [`13300fdc`](https://github.com/NixOS/nixpkgs/commit/13300fdc2b7df8fa491351408ba947d8776aba75) libguestfs: 1.48.0 -> 1.48.4
* [`51fa0c57`](https://github.com/NixOS/nixpkgs/commit/51fa0c57fd4fa914418a868e181fb0450a66b9f8) libbde: 20210605 -> 20220121
* [`e6f4a740`](https://github.com/NixOS/nixpkgs/commit/e6f4a740fd90c5e46467cd03f521eaa53db595fd) kpcli: 3.6 -> 3.8.1
* [`063d68ac`](https://github.com/NixOS/nixpkgs/commit/063d68accc0931d58611199d615a0b525f6ac04b) log4cplus: 2.0.7 -> 2.0.8
* [`8d8ec920`](https://github.com/NixOS/nixpkgs/commit/8d8ec9207690565302cb7fd8a3056dc9ff53ca00) linphone: 4.4.1 -> 4.4.8
* [`6741a9f3`](https://github.com/NixOS/nixpkgs/commit/6741a9f308db5f60cac969f4d4c170f41fc7634f) lombok: 1.18.22 -> 1.18.24
* [`964ee6f5`](https://github.com/NixOS/nixpkgs/commit/964ee6f55f23058eead4bbfd3c3c037213a251f0) libwebp: 1.2.2 -> 1.2.3
* [`d1cc42ef`](https://github.com/NixOS/nixpkgs/commit/d1cc42ef52428320183f8e31ea41871a6a1209fd) libnl: 3.5.0 -> 3.7.0
* [`ec11cf53`](https://github.com/NixOS/nixpkgs/commit/ec11cf53377a3d4626a29135b206641012c41cb5) json-glib: add installed tests
* [`9b423576`](https://github.com/NixOS/nixpkgs/commit/9b4235768b671476c9947f36f86c7b0f92ecbd5d) minixml: 3.3 -> 3.3.1
* [`15e3765c`](https://github.com/NixOS/nixpkgs/commit/15e3765c4e5ec347935e737f57c1b20874f2de69) maven: 3.8.5 -> 3.8.6
* [`82edfabb`](https://github.com/NixOS/nixpkgs/commit/82edfabb2909f52949584a94d4577531d25287d3) nss_wrapper: 1.1.11 -> 1.1.12
* [`37bfb2a8`](https://github.com/NixOS/nixpkgs/commit/37bfb2a8a3903ab8e445259eb44e10f2a64ba46a) json-glib: simplify meson-add-installed-tests-prefix-option.patch
* [`99872acd`](https://github.com/NixOS/nixpkgs/commit/99872acdebe5a7799b8e02b9cbeaa3e078a79b8f) phoronix-test-suite: 10.8.2 -> 10.8.4
* [`c78ef1c7`](https://github.com/NixOS/nixpkgs/commit/c78ef1c764fcce326a1d2980ad8218b21350f813) libdvdread: 6.1.2 -> 6.1.3 ([nixos/nixpkgs⁠#184291](https://togithub.com/nixos/nixpkgs/issues/184291))
* [`a7b9a7b1`](https://github.com/NixOS/nixpkgs/commit/a7b9a7b1e8c74843a321a5ad36e9b90da763bd6e) pkcs11helper: 1.28 -> 1.29.0
* [`cce0acf4`](https://github.com/NixOS/nixpkgs/commit/cce0acf4bcce6baf64b6f236549c0ae0754390fe) elinks: 0.15.0 -> 0.15.1
* [`5d3bd137`](https://github.com/NixOS/nixpkgs/commit/5d3bd1377ed9a9cc22ea64514fb2a85b8a314e76) speedtest-exporter: init at 0.3.2
* [`706481d3`](https://github.com/NixOS/nixpkgs/commit/706481d39642e0a0bf670b31696a3c2cac47fd02) add jonaenz to maintainer list
* [`f2298fcf`](https://github.com/NixOS/nixpkgs/commit/f2298fcf8f528e25f1e5da2bde63f6d714b40183) unbound: 1.16.0 -> 1.16.2
* [`982f8b6f`](https://github.com/NixOS/nixpkgs/commit/982f8b6f4ee97775dcb4caeb83aeb776f3ab1440) unbound: set myself as maintainer
* [`c99ff464`](https://github.com/NixOS/nixpkgs/commit/c99ff464e0cf6014a9ddf7701bc2497ab3499718) python3Packages.dbus-python: add missing egg-info
* [`8907016b`](https://github.com/NixOS/nixpkgs/commit/8907016b22e29d93816faa121246816ce92e320e) linuxHeaders: 5.18 -> 5.19
* [`596a678b`](https://github.com/NixOS/nixpkgs/commit/596a678b7f9e11505fd455837764a955166047e7) meson: pull patch to use more binutils variables
* [`48851381`](https://github.com/NixOS/nixpkgs/commit/4885138129c5f5c11bc36c6e6395dcd69ba98f1b) treewide: remove unnecessary meson find_program patches
* [`9f309c87`](https://github.com/NixOS/nixpkgs/commit/9f309c8792577a16b319956ad92a2df2ae9aa4f1) stdenv: mesonFlags: use canExecute in needs_exe_wrapper
* [`db9c9781`](https://github.com/NixOS/nixpkgs/commit/db9c978119e74cd74980143e93026740f3d0b0ea) media-downloader: 2.4.0 -> 2.5.0
* [`35ae59f4`](https://github.com/NixOS/nixpkgs/commit/35ae59f47b4497cdf0c90728233e1a96188e95ed) pythonPackages: drop dbus-python workarounds
* [`81163361`](https://github.com/NixOS/nixpkgs/commit/81163361cc34cd188455a65bd81fcf15adf27510) openh264: 2.2.0 -> 2.3.0
* [`eba5f13c`](https://github.com/NixOS/nixpkgs/commit/eba5f13c08cd9fda50b4cf0e6499b7e39e729bc4) go_1_18: 1.18.4 -> 1.18.5
* [`20868cb2`](https://github.com/NixOS/nixpkgs/commit/20868cb2d07dffa645e736d676a1e8df3e082284) perl: 5.34.1 -> 5.36.0
* [`aea35e23`](https://github.com/NixOS/nixpkgs/commit/aea35e23d218e03547490d88d378c18df7d4eba6) unit: add perl536 as default, remove perl532
* [`5e2471df`](https://github.com/NixOS/nixpkgs/commit/5e2471dfecfcc797a0385672c9f2a5b95e2c5716) perldevel: 5.35.9 -> 5.37.0, perl-cross: 31dac3e2 -> c8760457
* [`36eea7e9`](https://github.com/NixOS/nixpkgs/commit/36eea7e9301dbc6f62302d8e76b3e4e2ddac98fa) perlPackages.BKeywords: 1.22 -> 1.24
* [`a57fef47`](https://github.com/NixOS/nixpkgs/commit/a57fef4702c564d82263801c022bfa6e8cee9395) perlPackages.DBIxClass: 0.082842 -> 0.082843
* [`b18e7a18`](https://github.com/NixOS/nixpkgs/commit/b18e7a1813647896bbdcbe726ef7a71a75ca5dc9) Revert "go_1_18: backport CL417615"
* [`9fb2ea94`](https://github.com/NixOS/nixpkgs/commit/9fb2ea94ad44edfd33d508697304b465f86d7c72) sofia_sip: 1.13.7 -> 1.13.8
* [`f393b319`](https://github.com/NixOS/nixpkgs/commit/f393b3190b695c2989e115bc6b383f6286778807) socket_wrapper: 1.3.3 -> 1.3.4
* [`09c61607`](https://github.com/NixOS/nixpkgs/commit/09c6160746029dece28cd3677bbb0fad4eb2a97d) libcap: 2.63 -> 2.65
* [`11b8569e`](https://github.com/NixOS/nixpkgs/commit/11b8569e72df6372e29442353740ad79dadb47f5) skrooge: 2.27.0 -> 2.28.0
* [`cb9699aa`](https://github.com/NixOS/nixpkgs/commit/cb9699aa773b695ac4bd36f2ac42ae53f1f908fe) siril: 1.0.0 -> 1.0.3
* [`a3068144`](https://github.com/NixOS/nixpkgs/commit/a3068144a497bf58250d19555880546dccbd2e9e) suricata: 6.0.4 -> 6.0.6
* [`e6e69f18`](https://github.com/NixOS/nixpkgs/commit/e6e69f18b31bce071c9541910675277203297b02) tdrop: 0.4.0 -> 0.5.0
* [`9a32f0f4`](https://github.com/NixOS/nixpkgs/commit/9a32f0f4ff1cbdeb9ba8c69c79e783bb429a476d) transcribe: 9.10 -> 9.21
* [`dc2629bc`](https://github.com/NixOS/nixpkgs/commit/dc2629bc80a2d940878b2e9e90324f2f7072bf5d) thermald: 2.4.9 -> 2.5
* [`f2c21d72`](https://github.com/NixOS/nixpkgs/commit/f2c21d72e415037bc18d62c04f8c1c1f57b46b49) trace-cmd: 3.1.1 -> 3.1.2
* [`5f439dcf`](https://github.com/NixOS/nixpkgs/commit/5f439dcf51522331f21076df00b8ef38fba06ceb) xarchiver: 0.5.4.17 -> 0.5.4.18
* [`eb2c58cd`](https://github.com/NixOS/nixpkgs/commit/eb2c58cde327ab8f8bbb60a486508176f6407a9e) yoshimi: 2.1.2.2 -> 2.2.1
* [`fb6a1ae9`](https://github.com/NixOS/nixpkgs/commit/fb6a1ae938e132f33e510952fa5d775ba87e03b6) dvdisaster: 0.79.9 -> 0.79.10
* [`f4517711`](https://github.com/NixOS/nixpkgs/commit/f45177116b1566118dd3a9a6f3421ef7ebdcc9d8) xsser: init at 1.8.4
* [`e9439969`](https://github.com/NixOS/nixpkgs/commit/e943996962994289694b8c31a50f9d92574ba1a8) websploit: init at 4.0.4
* [`3d17b4c3`](https://github.com/NixOS/nixpkgs/commit/3d17b4c305cefef284109fa9d426b00f3e5072c6) cmake/setup.sh: allow for cmakeBuildDir to be configured
* [`ae26091d`](https://github.com/NixOS/nixpkgs/commit/ae26091d3732dc009c9e14e4cf763c049e5907dd) python3Packages.django_3: 3.2.14 -> 3.2.15
* [`112cd59c`](https://github.com/NixOS/nixpkgs/commit/112cd59c6ab540203f9e88d16868bd87825a8574) vim: 9.0.0115 -> 9.0.0135
* [`b4ba441d`](https://github.com/NixOS/nixpkgs/commit/b4ba441d7c831a2400dd0a3ffd068ed002d88230) python310: 3.10.5 -> 3.10.6
* [`2d6481a4`](https://github.com/NixOS/nixpkgs/commit/2d6481a4fd35069c271bbb2967a4c59989b010fc) mangohud: statically link spdlog
* [`2834c932`](https://github.com/NixOS/nixpkgs/commit/2834c932a986bc060e813b56bd0c9247d8eae013) fractal-next: unstable-2022-07-10 -> unstable-2022-07-21
* [`272864df`](https://github.com/NixOS/nixpkgs/commit/272864df3face1fb3bf1cceb399ec3a7cd9bb64e) libfido2: Add openssl to propagatedBuildInputs
* [`decaf3e0`](https://github.com/NixOS/nixpkgs/commit/decaf3e0efe2f3fa2fb4ad328914fe7fb8cbce64) nixos/dex: replace arbitrary secrets via environmentFile
* [`16dbcfa7`](https://github.com/NixOS/nixpkgs/commit/16dbcfa7d696192c00c31c0c0df48b4925f43835) maintainers: add majewsky
* [`c39114c2`](https://github.com/NixOS/nixpkgs/commit/c39114c27961a88c3c7ae6731c1654d77e5a829f) linux_xanmod_latest: 5.18.11 -> 5.18.15
* [`244953f7`](https://github.com/NixOS/nixpkgs/commit/244953f7895c0f40ba4ec8e4feb9bb808f5686cd) linux_xanmod_latest: 5.18.15 -> 5.19.0
* [`dc0a907d`](https://github.com/NixOS/nixpkgs/commit/dc0a907d87a457ab06a69463d3c0afd045b74a3c) zynaddsubfx: use Zyn-Fusion logo for zest build
* [`5b44e601`](https://github.com/NixOS/nixpkgs/commit/5b44e6010db36f0213bb422da67daec9dae90308) zynaddsubfx: separate doc output
* [`6c3be14a`](https://github.com/NixOS/nixpkgs/commit/6c3be14afeb6d8fb35bece14feae092469a4c9dc) zynaddsubfx: use for loop to set rpath for vst libraries
* [`fbaac3ad`](https://github.com/NixOS/nixpkgs/commit/fbaac3ad4fbce6b9abaa031c1dddf96640f27a13) zynaddsubfx: disable PortChecker test when building with lashSupport
* [`2bc2b175`](https://github.com/NixOS/nixpkgs/commit/2bc2b175600b6e153b8185e7677caec6135cb066) dino: add tests
* [`e9a27ca6`](https://github.com/NixOS/nixpkgs/commit/e9a27ca6f6a0810ac91892e373a5fd671ad35e26) Fix the test if statement
* [`31842253`](https://github.com/NixOS/nixpkgs/commit/31842253bfb3638bc4706af4bb94a0e3707e4b5e) ddcui: 0.2.1 -> 0.3.0
* [`83daa6a3`](https://github.com/NixOS/nixpkgs/commit/83daa6a316157ac3fde35410d82d7f7e06a6fd38) nspr: 4.34 -> 4.34.1
* [`d6b6e4fa`](https://github.com/NixOS/nixpkgs/commit/d6b6e4fa6b68205a1508ed4f55690e7b77809451) hatch: init at 1.3.1
* [`5eb0a6c2`](https://github.com/NixOS/nixpkgs/commit/5eb0a6c22f495d0e4419fd4e9db89c95c32eeb4b) featherpad: 1.3.0 -> 1.3.1
* [`05374e3b`](https://github.com/NixOS/nixpkgs/commit/05374e3b209792e074623132b400234cf74941b4) fluidd: 1.19.0 -> 1.19.1
* [`b34a4df8`](https://github.com/NixOS/nixpkgs/commit/b34a4df857420eb045cde051d1d3e248bf8b02a6) [staging] cmake: 3.23.3 -> 3.24.0
* [`67dece3b`](https://github.com/NixOS/nixpkgs/commit/67dece3b2c0639f2c006f0b81d8113dcf6e2bb1e) python310Packages.attrs: 21.4.0 -> 22.1.0
* [`e37d2a63`](https://github.com/NixOS/nixpkgs/commit/e37d2a63c4f75012fb51b29b0fd0f2093f90c84f) stuffbin: init at 1.1.0
* [`4b7937fd`](https://github.com/NixOS/nixpkgs/commit/4b7937fd7b735caa6ef46aee4318f9007e51c195) streamlit: 1.2.0 -> 1.11.1
* [`19c5c57e`](https://github.com/NixOS/nixpkgs/commit/19c5c57e72da4f3289cd216fd7b190035eea3187) libtiff: add patch for CVE-2022-34526
* [`6f8fdc5b`](https://github.com/NixOS/nixpkgs/commit/6f8fdc5b87b3887d17c8207149bc11acd3ef1b3e) SDL: add patch for CVE-2022-34568
* [`b55345f1`](https://github.com/NixOS/nixpkgs/commit/b55345f13146e097f4564a71e0ef66a4987d9c66) cairo: pull upstream fix for grayscale aliasing bug
* [`1369d3ed`](https://github.com/NixOS/nixpkgs/commit/1369d3edb72fa17967a0ac465bca6774fc9a6137) MMA: 20.12 -> 21.09
* [`4df9e264`](https://github.com/NixOS/nixpkgs/commit/4df9e2647a8c57f9da2ab8cd332181ac86f28c0a) lsp-plugins: 1.2.1 -> 1.2.2
* [`c22150c0`](https://github.com/NixOS/nixpkgs/commit/c22150c09efc25a79400448ff246afeb5942f178) python310Packages.jsonschema: 4.7.2 -> 4.9.1
* [`dd80fa1e`](https://github.com/NixOS/nixpkgs/commit/dd80fa1e9bed5af95fe2a02109f1852d447c9471) nixos/filesystems: skip fsck for more filesystems
* [`52642aca`](https://github.com/NixOS/nixpkgs/commit/52642acac01c5b364ff80d32ea4dd2d73ef60145) instaloader: init at 4.9.2
* [`9d8e6c29`](https://github.com/NixOS/nixpkgs/commit/9d8e6c29d2fb517e05d5b14f3c758f8e59e66356) python3Packages.pyunbound: inherit patches from unbound if present
* [`62e6c1a5`](https://github.com/NixOS/nixpkgs/commit/62e6c1a561ec39ca23145f25263a5f86aad727da) unbound: add gnutls to passthru.tests
* [`22c9c6cb`](https://github.com/NixOS/nixpkgs/commit/22c9c6cb712e42a36bc00cb562e5bb866a866858) unbound: add comment clarifying unbound's python support
* [`89f69079`](https://github.com/NixOS/nixpkgs/commit/89f690790ae8638042a450a94d22d9bd94fd72d1) stegsolve: init at 1.3
* [`a2ac470f`](https://github.com/NixOS/nixpkgs/commit/a2ac470fb209e5af789912ebd7c531b6bd32bbf7) libnss-mysql: init at 1.7.1
* [`5c2783bc`](https://github.com/NixOS/nixpkgs/commit/5c2783bccba5e6c27c2e9456a79447864d48e97a) pam_mysql: init at 1.0.0-beta2
* [`7a6c3cf4`](https://github.com/NixOS/nixpkgs/commit/7a6c3cf4aefbf7d11641008ed580c1470d82c87d) nixos/nscd: use a static user instead of systemd DynamicUser
* [`f23a1e6a`](https://github.com/NixOS/nixpkgs/commit/f23a1e6a54bb78d4aaec085964205899a5f0e83e) nixos: add mysql/mariadb user authentication
* [`1a35b5aa`](https://github.com/NixOS/nixpkgs/commit/1a35b5aacb88c0fe3160c78e2ef43430eac42252) nixos/pam: move pam_unix to the end of the account chain
* [`e23ace62`](https://github.com/NixOS/nixpkgs/commit/e23ace62686fb974353e86299c7003e089f323dd) nixos/mysql-auth: add VM-Test
* [`940adc38`](https://github.com/NixOS/nixpkgs/commit/940adc38beabf73fc166720f83b124701da52706) cloudcompare: 2.12.1 -> 2.12.4
* [`495266d3`](https://github.com/NixOS/nixpkgs/commit/495266d3d0a241834b14421a420873659dcfdb36) pdal_2_3: remove
* [`2bfb78e2`](https://github.com/NixOS/nixpkgs/commit/2bfb78e22c9620b4cec1a0c14ee87584bd6e61c2) netease-cloud-music-gtk: 1.2.2 -> 2.0.1
* [`99cd181f`](https://github.com/NixOS/nixpkgs/commit/99cd181f19cf3712c416e7a2477454c7da46f05e) squashfuse: 0.1.103 -> 0.1.105
* [`ea345cd9`](https://github.com/NixOS/nixpkgs/commit/ea345cd9bc31843585a9dd3b63dbf878bb66fc5c) python3Packages.eventlet: disable failing test
* [`c49c7a94`](https://github.com/NixOS/nixpkgs/commit/c49c7a94954dc7c361e88075a919cc2d2371264c) python3Packages.uvloop: disable hanging test
* [`9fce7523`](https://github.com/NixOS/nixpkgs/commit/9fce752330987d73a304b9fbf3759aced9e41d0d) texstudio: 4.2.3 -> 4.3.0
* [`2ea1a7a7`](https://github.com/NixOS/nixpkgs/commit/2ea1a7a7c953efd0c6bf01df99ee6ade4c88980f) rr: 5.5.0 -> 5.6.0
* [`9f548218`](https://github.com/NixOS/nixpkgs/commit/9f54821839aa92156837dcfb63a8bb85a85ce464) portunus: init at 1.1.0-beta.2
* [`49da9075`](https://github.com/NixOS/nixpkgs/commit/49da90755b3c9d9d94246c0cabefc5d5fbac9550) nixos/portunus: init
* [`9778f081`](https://github.com/NixOS/nixpkgs/commit/9778f0814155b228baa880438cff95ea50e2f622) pythonPackages.nix-prefetch-github: 5.1.2 -> 5.2.0
* [`40ba925d`](https://github.com/NixOS/nixpkgs/commit/40ba925d3ebda1e91a24feed00ffd75a0356215a) wails: 2.0.0-beta.42 -> 2.0.0-beta.43
* [`b908beb1`](https://github.com/NixOS/nixpkgs/commit/b908beb1a743f3371b966dfce38027c9bdc7edfa) subedit: init at 1.2.2
* [`e6768d39`](https://github.com/NixOS/nixpkgs/commit/e6768d39050a27808fd7ab24dfb0b25ce99559a5) irpf: 2022-1.6 -> 2022-1.7
* [`d7cfb2ce`](https://github.com/NixOS/nixpkgs/commit/d7cfb2ce9a2ae15b48e181a985b65ccf53e4b903) sqlc: 1.14.0 -> 1.15.0
* [`b933addd`](https://github.com/NixOS/nixpkgs/commit/b933addd2278570a2f24f30b795d986c9ef63686) haskellPackages: stackage LTS 19.17 -> LTS 19.18
* [`898ef5ee`](https://github.com/NixOS/nixpkgs/commit/898ef5ee50d8f8598fe0f4f1f20a94f267a441ee) all-cabal-hashes: 2022-08-07T14:05:30Z -> 2022-08-09T06:14:32Z
* [`1b711bc5`](https://github.com/NixOS/nixpkgs/commit/1b711bc5c461aab2919a03ab62c183c593a75ec6) haskellPackages: regenerate package set based on current config
* [`5e3486c1`](https://github.com/NixOS/nixpkgs/commit/5e3486c15c26c0e0053bbebdf59fac2b6b995ba1) sqlc: Eliminate use of `with`
* [`10a43777`](https://github.com/NixOS/nixpkgs/commit/10a43777e05970d00ce6b02de161d9d877f88ee5) snipe-it: 6.0.8 -> 6.0.9
* [`87942da0`](https://github.com/NixOS/nixpkgs/commit/87942da08e3221f32c7a43a17b165fabfdb04082) nixos/sssd: Add secrets handling
* [`4cbdad20`](https://github.com/NixOS/nixpkgs/commit/4cbdad20ee3661cfffab491aa48cf06519da3520) iosevka: 15.5.2 -> 15.6.3
* [`433dcfc2`](https://github.com/NixOS/nixpkgs/commit/433dcfc215d8d99cce265441a94c9fa99d60ed43) iosevka-bin: 15.6.1 -> 15.6.3
* [`d6a1ddd9`](https://github.com/NixOS/nixpkgs/commit/d6a1ddd9d064f0ac7ec76194a3f4b5c1f1f10ccf) octoprint: 1.8.1 -> 1.8.2
* [`fad97868`](https://github.com/NixOS/nixpkgs/commit/fad978682576b329cd79063c08157542eb5bc0d4) python3Packages.ipython: patch test after python update
* [`8f9ef1c3`](https://github.com/NixOS/nixpkgs/commit/8f9ef1c30eb211a7cee99b8621d6cff4980fbd79) headscale: fix tls challengeType enum possible values
* [`323f8b5d`](https://github.com/NixOS/nixpkgs/commit/323f8b5d00065fde1b32af8a737e9b67875d6da2) haskellPackages: remove brick-related overrides
* [`2db723b0`](https://github.com/NixOS/nixpkgs/commit/2db723b01fb765a6824531ea6673b94359ba4c68) git-town: 7.7.0 -> 7.8.0
* [`7c8cdf1d`](https://github.com/NixOS/nixpkgs/commit/7c8cdf1de15c76139da1b04c18e43422fb22c9d9) haskellPackages: sort extra-packages
* [`389a9b25`](https://github.com/NixOS/nixpkgs/commit/389a9b25845e685d11ccc077d3876b9abb060119) haskellPackages: add ghc-9.2 versions for ghc-lib-parser and ghc-lib-parser-ex
* [`6a6de265`](https://github.com/NixOS/nixpkgs/commit/6a6de265315c82fae4aec6096455de5bb346fff9) gopsuinfo: init at 0.1.1
* [`e2fc23b9`](https://github.com/NixOS/nixpkgs/commit/e2fc23b9c678567b52f6ec8bd19d685fefa84942) dar: 2.7.6 -> 2.7.7
* [`50f7eed9`](https://github.com/NixOS/nixpkgs/commit/50f7eed980c3885654e8e3416cc8b66cdd7bdc3d) fityk: 1.3.1 -> 1.3.2
* [`a47212c1`](https://github.com/NixOS/nixpkgs/commit/a47212c175d3c484e05551fce118ac74cd44a674) fio: 3.30 -> 3.31
* [`a0bc125f`](https://github.com/NixOS/nixpkgs/commit/a0bc125f9452eb67dd5ba4004de6cc81f674dec8) haskellPackages.ghc-lib_9_2_4_20220729: generate for ghc-9.2
* [`bbdaab12`](https://github.com/NixOS/nixpkgs/commit/bbdaab12e6ca7a9f3bd20323252c67b747beb041) soft-serve: 0.3.3 -> 0.4.0
* [`b6c54aab`](https://github.com/NixOS/nixpkgs/commit/b6c54aab2492a39316b1ce3f3761edd1465c8cee) setzer: 0.4.7 -> 0.4.8
* [`bd22b4c9`](https://github.com/NixOS/nixpkgs/commit/bd22b4c9786bd1bcf4f7e91f40d31743cc15d8c4) linux_xanmod_latest: 5.19.0-xanmod1 -> 5.19.0-xanmod2
* [`894f16c3`](https://github.com/NixOS/nixpkgs/commit/894f16c36e50ab4cc7f0ee52109b72e1f85b46a2) prometheus-pihole-exporter: 0.2.0 -> 0.3.0
* [`00f0d306`](https://github.com/NixOS/nixpkgs/commit/00f0d306d42e18aa082dbc5a93921c084dd6171d) perlPackages.Encode: 3.08 -> 3.19
* [`676ff15d`](https://github.com/NixOS/nixpkgs/commit/676ff15d5a3e11b3634cf60e9ab22fa03db4b856) perlPackages.CryptX: 0.069 -> 0.076
* [`7a48520c`](https://github.com/NixOS/nixpkgs/commit/7a48520c7bf50e59af492c39eda01d4939bd058b) perlPackages.ScopeUpper: 0.32 -> 0.33
* [`fe082eac`](https://github.com/NixOS/nixpkgs/commit/fe082eacee0dbf110b142f104b63a38ff630b545) perlPackages.CpanelJSONXS: 4.25 -> 4.31
* [`cab3b516`](https://github.com/NixOS/nixpkgs/commit/cab3b5169adc13ffd02aaa31020e8c40971f7ef3) perlPackages.SerealDecoder: 4.018 -> 4.025
* [`21e025e1`](https://github.com/NixOS/nixpkgs/commit/21e025e18d36c7f3b46d53e2e76db84b57711679) perlPackages.SerealEncoder: 4.018 -> 4.025
* [`e777ee8b`](https://github.com/NixOS/nixpkgs/commit/e777ee8b0f1e85da66fd79284bf3001b88571d29) perlPackages.Sereal: 4.018 -> 4.025
* [`6f67f850`](https://github.com/NixOS/nixpkgs/commit/6f67f8505181672ac2e29af6e8ef8763f63ada54) python3Packages.univers: init at 30.7.0
* [`7feea0d0`](https://github.com/NixOS/nixpkgs/commit/7feea0d062f74588ba614b58aa2c753599befc9c) discourse: 2.9.0.beta4 -> 2.9.0.beta9
* [`f34bc06a`](https://github.com/NixOS/nixpkgs/commit/f34bc06abc7af57dd6074d7e2a0d2dd1ca386ccb) discourse: Filter out :require_name option when creating the Gemfile
* [`a3cc1609`](https://github.com/NixOS/nixpkgs/commit/a3cc1609cdfcf5988ad1f6966b5c275f4b4a00a1) discourse: Update plugins
* [`8130a074`](https://github.com/NixOS/nixpkgs/commit/8130a074085a6654df0212870fa99bf351bdc323) linux_xanmod_latest: 5.19.0-xanmod2 -> 5.19.1
* [`c9d4f8fa`](https://github.com/NixOS/nixpkgs/commit/c9d4f8fa5fdb96f5e2526fa09be261302be799fd) linux_xanmod: 5.15.58 -> 5.15.60
* [`839d828b`](https://github.com/NixOS/nixpkgs/commit/839d828b9c367e384c41077d4c76494515c156aa) treewide: firmware: stdenv -> stdenvNoCC
* [`1cd88b09`](https://github.com/NixOS/nixpkgs/commit/1cd88b09ecf0148348efa0d0702b096209b0c1fb) python310Packages.js2py: init at 0.71
* [`f83576d7`](https://github.com/NixOS/nixpkgs/commit/f83576d77e02d72b5b07eadc630a8ad6c48363df) python310Packages.pyjsparser: init at 2.7.1
* [`8fb63401`](https://github.com/NixOS/nixpkgs/commit/8fb63401afa3d252bc41f6857a56cca3a39f66e7) nixos/switch-to-configuration: fix units starting with dash
* [`633d5cb1`](https://github.com/NixOS/nixpkgs/commit/633d5cb10fba4d1cddaa462f25c45a14e3726296) python3Packages.jaxlib: fix darwin build
* [`cedffc07`](https://github.com/NixOS/nixpkgs/commit/cedffc07f545c6556394511f775b6b612ba2f986) mpvScripts.thumbnail: switch to maintained fork, unstable-2020-01-16 -> 0.4.9
* [`a6ce9617`](https://github.com/NixOS/nixpkgs/commit/a6ce9617eb9456f603205eee44fb9bac5da3f734) renpy: 8.0.0 -> 8.0.1
* [`c68c1947`](https://github.com/NixOS/nixpkgs/commit/c68c19478951abc8ab4ebdf30304de7c58641e6b) x11vnc: remove extraneous preConfigure
* [`911880f7`](https://github.com/NixOS/nixpkgs/commit/911880f76310219fa8da24268060a209379d4710) xfce.xfdashboard: 0.9.5 -> 1.0.0
* [`72f0457e`](https://github.com/NixOS/nixpkgs/commit/72f0457ed64edf41363c32d26471a6ea03b0ccd4) xfce.tumbler: 4.16.0 -> 4.16.1
* [`90eb3d4d`](https://github.com/NixOS/nixpkgs/commit/90eb3d4d635bd4c71e9d05dd3d840d1830435abf) haskellPackages: unbreak nvim-hs-contrib
* [`d8bddf35`](https://github.com/NixOS/nixpkgs/commit/d8bddf35281fc7b9efffeece0f6530b99bcf61bd) matterhorn: build with brick 0.70.1
* [`5b5e7723`](https://github.com/NixOS/nixpkgs/commit/5b5e7723ee450b32b14ae1394a12ad5ea974e395) entt: 3.10.0 -> 3.10.3
* [`938ea3de`](https://github.com/NixOS/nixpkgs/commit/938ea3de88533910e50355b82ab185d8e7d47ecb) libbluray: fix broken BDJ patch
* [`44c848bc`](https://github.com/NixOS/nixpkgs/commit/44c848bc0230252290495b10ac7f03a77f8a949c) haskell.compilers.ghc941: 9.4.0.20220721 -> 9.4.1
* [`d0706da5`](https://github.com/NixOS/nixpkgs/commit/d0706da55e4f028b8f91d32ea6c9d20a5f4429b0) haskell.compiler.ghc941: bootstrap using (binary) GHC 8.10.7
* [`74b420b6`](https://github.com/NixOS/nixpkgs/commit/74b420b612c19c4ea7a19eeb493fcb72ab75c031) gcc12: apply working patch for darwin-aarch64
* [`71eb3c8e`](https://github.com/NixOS/nixpkgs/commit/71eb3c8e8e72c6591afbeb86f20062eafd8389b0) phrase-cli: 2.4.12 -> 2.5.1
* [`77fa2518`](https://github.com/NixOS/nixpkgs/commit/77fa2518f3c54a71a33260c2e4af6c62d707bf40) prometheus-artifactory-exporter: 1.9.1 -> 1.9.4
* [`3c7d9d62`](https://github.com/NixOS/nixpkgs/commit/3c7d9d62c3e8a92c3865a1dc8863407123d617a3) prometheus-fastly-exporter: 7.0.1 -> 7.2.4
* [`4f95e245`](https://github.com/NixOS/nixpkgs/commit/4f95e2453ef2385d1bb9d81007a51d3fdbf002af) qnotero: 2.3.0 -> 2.3.1
* [`ebf9a4ad`](https://github.com/NixOS/nixpkgs/commit/ebf9a4ad8961ac1ef65b762bf374b42044b174aa) miniflux: 2.0.37 → 2.0.38
* [`49b49780`](https://github.com/NixOS/nixpkgs/commit/49b497809cfa14845c85485f76d174b945570a15) reaverwps-t6x: 1.6.5 -> 1.6.6
* [`6aff16d2`](https://github.com/NixOS/nixpkgs/commit/6aff16d259f1773c27f83a3e151987fe50a9626d) cage: fix cross
* [`f6e0ba1b`](https://github.com/NixOS/nixpkgs/commit/f6e0ba1bafc3f3263787f6b46c754b7a63bd6b45) phodav: expose udev rules
* [`b146c4fc`](https://github.com/NixOS/nixpkgs/commit/b146c4fcfb66c6ee97aefc97ce3c9182e2d79d77) hyfetch: 1.3.0 -> 1.4.0
* [`1c395dba`](https://github.com/NixOS/nixpkgs/commit/1c395dbabe0bef15698c10959b82752f29facbdf) zynaddsubfx: 3.0.5 → 3.0.6
* [`c36152b3`](https://github.com/NixOS/nixpkgs/commit/c36152b37999fe34af1379f533b3fef227527061) python310Packages.django-maintenance-mode: Fix missing python-fsutil dependency
* [`3ea22dab`](https://github.com/NixOS/nixpkgs/commit/3ea22dab7d906f400cc5983874dbadeb8127c662) iterm2: fix on macOS 13
* [`b518a7d8`](https://github.com/NixOS/nixpkgs/commit/b518a7d877a52a78d4411026538718daf72f2b38) python310Packages.loguru: fix failing tests
* [`e4f2c0b0`](https://github.com/NixOS/nixpkgs/commit/e4f2c0b0c2c92b3589691f6a9d6d452d0badbbfa) hyfetch: remove unneeded postPatch
* [`f28b2999`](https://github.com/NixOS/nixpkgs/commit/f28b29999b4351b2ed9dc5f06cd50879bd698da5) fishPlugins.fzf-fish: 9.0 -> 9.2
* [`4ade948b`](https://github.com/NixOS/nixpkgs/commit/4ade948bb313fb841f73b1effa31bfe7c8dc898b) terragrunt: 0.37.0 -> 0.38.7
* [`83519fe9`](https://github.com/NixOS/nixpkgs/commit/83519fe97684e52bac2a82c2457ed934bff2dfb0) iosevka: fix build
* [`a37b09fe`](https://github.com/NixOS/nixpkgs/commit/a37b09fef9f66e12d870f4ee299743e23fd1faee) image-roll: fix hydra build on darwin
* [`97f7cf06`](https://github.com/NixOS/nixpkgs/commit/97f7cf06d25037b49c18ef4d558d7c191f25d9d8) git-cinnabar: 0.5.7 -> 0.5.10
* [`ad4d16a8`](https://github.com/NixOS/nixpkgs/commit/ad4d16a8d5c55fed7fe8030d826c2f890e6479a9) vassal: 3.6.5 -> 3.6.7
* [`db1c79d7`](https://github.com/NixOS/nixpkgs/commit/db1c79d7673f2f15a9fe86e2b600348202d98b9e) vendir: 0.26.0 -> 0.30.0
* [`0dc9748c`](https://github.com/NixOS/nixpkgs/commit/0dc9748c6fecc7abc0f26bda888c3f0019bae0d8) starship: 1.9.1 -> 1.10.0
* [`72f459c7`](https://github.com/NixOS/nixpkgs/commit/72f459c734d65a319d6a8be5adf588bd74f5d9c6) python310Packages.gehomesdk: 0.4.27 -> 0.5.0
* [`7153a7ca`](https://github.com/NixOS/nixpkgs/commit/7153a7caca4e40e43e58755a3a9c11cc48747dd2) backward-cpp: 1.3 -> 1.6
* [`6dc3ef5e`](https://github.com/NixOS/nixpkgs/commit/6dc3ef5e1a99bdb9a1bb0f5136b67fadab92c122) php8*: disable PCRE2 JIT SEAlloc to avoid crashes
* [`2b92abdd`](https://github.com/NixOS/nixpkgs/commit/2b92abdd337f79bd53222f53201cc7278bc98b30) bukubrow: 5.0.0 -> 5.4.0
* [`3e34d40f`](https://github.com/NixOS/nixpkgs/commit/3e34d40f8b8f4f9230f95b9e6a13816e9fab15dc) jellyfin-web: 10.8.3 -> 10.8.4
* [`4a793d7b`](https://github.com/NixOS/nixpkgs/commit/4a793d7b44940280a8bc18af66be74c664ddca85) jellyfin: 10.8.3 -> 10.8.4
* [`ff34d457`](https://github.com/NixOS/nixpkgs/commit/ff34d4573edf770ca1db54c4f187541d37f03cb4) python310Packages.pytest-quickcheck: Add upstream bug report
* [`c93e578c`](https://github.com/NixOS/nixpkgs/commit/c93e578cb9ff236a78d56549bcecaadba5ee1c5b) python310Packages.cloudflare: 2.9.11 -> 2.9.12
* [`664b01f0`](https://github.com/NixOS/nixpkgs/commit/664b01f0829987affdaa361207bfd0b698db0ec2) nixos/mirakurun: set the LOGO_DATA_DIR_PATH environment variable
* [`a3cdf49d`](https://github.com/NixOS/nixpkgs/commit/a3cdf49dbf5483656a22e5f7481892022b59e577) ppsspp: add SDL and headless
* [`10f06f9a`](https://github.com/NixOS/nixpkgs/commit/10f06f9ae7a1da748f9a5a72be4d3605511e1f48) qtbase: remove mkspecs/features/mac/sdk.mk
* [`e4b89c06`](https://github.com/NixOS/nixpkgs/commit/e4b89c06c398e3b89730bad725c838dc3ca27816) sourcetrail: remove
* [`e7cc0899`](https://github.com/NixOS/nixpkgs/commit/e7cc08991b47ac4261f211befb4294ea9cd82959) docker-machine: 0.16.1 -> 0.16.2
* [`0c99a804`](https://github.com/NixOS/nixpkgs/commit/0c99a804a3c976553d8b46641cb9e264f1a2c679) duckscript: 0.8.10 -> 0.8.14
* [`b1b537f2`](https://github.com/NixOS/nixpkgs/commit/b1b537f2c78d41e44a9b20bc3d3467360819bb67) ecs-agent: 1.18.0 -> 1.62.1
* [`54da62af`](https://github.com/NixOS/nixpkgs/commit/54da62afdda50818489c065aecb0531b039ed9ea) elasticmq-server-bin: 1.2.0 -> 1.3.9
* [`5c8381a7`](https://github.com/NixOS/nixpkgs/commit/5c8381a7a203fa16422ea18bf32f4243bf3db2bb) fend: 1.0.4 -> 1.0.5
* [`ffb91d08`](https://github.com/NixOS/nixpkgs/commit/ffb91d08a917b2fb8b74bc7c49b96a5092aa00fa) pythonPackages.nix-prefetch-github: v5.2.0 -> v5.2.1
* [`bb202ec7`](https://github.com/NixOS/nixpkgs/commit/bb202ec7218af0327d8b9b87758a96a35e1e6e7f) randomx: 1.1.9 -> 1.1.10
* [`32733dc5`](https://github.com/NixOS/nixpkgs/commit/32733dc51e67cd750a7d90188cb8b89a6f8cbbb0) google-guest-agent: 20220104.00 -> 20220713.00
* [`4a8e60ca`](https://github.com/NixOS/nixpkgs/commit/4a8e60ca8815bb17d20c1e77ead54f3347fa6b61) ic-keysmith: 1.6.0 -> 1.6.2
* [`0a59f0ae`](https://github.com/NixOS/nixpkgs/commit/0a59f0aecb5738127ea093d3dc2769b8a184d02f) wine{Unstable,Staging}: 7.13 -> 7.14
* [`22087c57`](https://github.com/NixOS/nixpkgs/commit/22087c57e3a1b4d94a85b257cf0075cce9875a86) wine{Unstable,Staging}: 7.14 -> 7.15
* [`72540a2a`](https://github.com/NixOS/nixpkgs/commit/72540a2a804f521ce039dc3abd975e81855da2c5) hpx: 1.7.1 -> 1.8.1
* [`3be7f470`](https://github.com/NixOS/nixpkgs/commit/3be7f4708db919146ac7b9b5b28d36048db092ac) pax-utils: 1.3.4 -> 1.3.5
* [`8261de6e`](https://github.com/NixOS/nixpkgs/commit/8261de6e5df84d53d39d27e6a4b228dfbe9d91d6) p2pool: 2.1 -> 2.2.1
* [`4e868821`](https://github.com/NixOS/nixpkgs/commit/4e8688215ff5ef090fddbe63b9b8b365a707c6bf) kubernetes-controller-tools: 0.8.0 -> 0.9.2
* [`8650da69`](https://github.com/NixOS/nixpkgs/commit/8650da694bd505c8e6d46dd60f8a4289fe204484) kubie: 0.17.2 -> 0.18.0
* [`8a40257c`](https://github.com/NixOS/nixpkgs/commit/8a40257c734bbeb3199c89d9e3c43ccd99703e1d) gcl_2_6_13_pre: 2.6.13pre50 -> 2.6.13pre124 (fix build)
* [`192dece2`](https://github.com/NixOS/nixpkgs/commit/192dece221433ebf45a3d2b7eb3def9aada6636f) evdi: 1.11.0 -> 1.12.0
* [`020c641a`](https://github.com/NixOS/nixpkgs/commit/020c641a88bd27658a6a9f193bdaeb41b015581b) crosvm: 103.3 -> 104.0
* [`ef5c9a32`](https://github.com/NixOS/nixpkgs/commit/ef5c9a329db7ac3dab78a52d01dbc17c94a2eab3) zim: 0.74.2 -> 0.74.3
* [`66b605e5`](https://github.com/NixOS/nixpkgs/commit/66b605e5d532c1221eec6714ad202c8a223bd634) mar1d: 0.3.0 -> 0.3.1
* [`c37112d2`](https://github.com/NixOS/nixpkgs/commit/c37112d2d017bec5556fc2b12aa394aaca356958) messer-slim: 3.7.1 -> 4.0
* [`0b3c6edb`](https://github.com/NixOS/nixpkgs/commit/0b3c6edb04bd86eeb7c68ba0873aec47e1b562e5) ombi: 4.16.12 -> 4.22.5
* [`3d058aee`](https://github.com/NixOS/nixpkgs/commit/3d058aeef7cb6c9d67fca760f885eb422722235c) perlPackages.TestMockHTTPTiny: init at 0.002
* [`813a4ba8`](https://github.com/NixOS/nixpkgs/commit/813a4ba8a095ca6dcb6b2b71cb81c3bdd075e82b) pipewire: 0.3.56 -> 0.3.56
* [`c8e49f8f`](https://github.com/NixOS/nixpkgs/commit/c8e49f8f29471e945cba60ba211919b5e7b943e2) minio: 2022-08-11T04-37-28Z -> 2022-08-13T21-54-44Z
* [`565a729f`](https://github.com/NixOS/nixpkgs/commit/565a729f7cbc33f3c99536b844aaeba80dd1bafd) make plausible service start after clickhouse service
* [`41a517e7`](https://github.com/NixOS/nixpkgs/commit/41a517e7bb5bcbaf77ccc13c1449ef5b3e407d6d) netbox: 3.2.7 -> 3.2.8
* [`ddada35b`](https://github.com/NixOS/nixpkgs/commit/ddada35b50fb79d7448f68380bf995a80d5cbb72) haskell.compiler.ghc941: bootstrap using GHC 9.0.2 on arm
* [`2a8ce2f6`](https://github.com/NixOS/nixpkgs/commit/2a8ce2f681df5f145be67d97852b70b9f6ad4816) oq: 1.3.2 -> 1.3.3
* [`b0de4903`](https://github.com/NixOS/nixpkgs/commit/b0de4903142e92c9c5d50fcc0d89320ed4663959) prometheus-openldap-exporter: 2.2.1 -> 2.2.2
* [`9c52987b`](https://github.com/NixOS/nixpkgs/commit/9c52987b51dc3af5dade4dcaa04a3b0ff0bd1d0a) nixos/spice-webdavd: init
* [`44a7c41b`](https://github.com/NixOS/nixpkgs/commit/44a7c41b57a5d4f0208baba466f30d66c1e0008a) geeqie: 1.7.3 -> 2.0.1
* [`9afb8af2`](https://github.com/NixOS/nixpkgs/commit/9afb8af2525f395faa73f3402516831f03011db8) python3Packages.cattrs: fix build by upstreamed patch
* [`b932bf6f`](https://github.com/NixOS/nixpkgs/commit/b932bf6fc697674c5d53bad8621a6ab15083b85c) python310Packages.aiohue: 4.4.2 -> 4.5.0
* [`4929601f`](https://github.com/NixOS/nixpkgs/commit/4929601fe98960014a7b8a9e6bb491432178e398) bitwuzla: unstable-2021-07-01 -> unstable-2022-08-07
* [`35980a2c`](https://github.com/NixOS/nixpkgs/commit/35980a2c246c12f084dcf724d997087498725424) ticker: 4.5.2 -> 4.5.3
* [`08e9805a`](https://github.com/NixOS/nixpkgs/commit/08e9805a36264312f793cb99bcae3871d4a51388) tilt: 0.30.6 -> 0.30.7
* [`219c2c79`](https://github.com/NixOS/nixpkgs/commit/219c2c7942dc38e9d83f4e4bc708c185b4ecde31) prl-tools: 17.1.4-51567 -> 18.0.0-53049
* [`25b5181c`](https://github.com/NixOS/nixpkgs/commit/25b5181c2e28bb385bcfa29ece130397f03f63ae) zola: 0.16.0 -> 0.16.1
* [`4ad43e6b`](https://github.com/NixOS/nixpkgs/commit/4ad43e6b4712a6620453c9d1aecf17a628571db5) python3Packages.stim: init at 1.9.0
* [`a5c352ed`](https://github.com/NixOS/nixpkgs/commit/a5c352edae438c7bfb9cd90bdab1e8b66518844b) python310Packages.databricks-cli: 0.17.0 -> 0.17.1
* [`895a5fa6`](https://github.com/NixOS/nixpkgs/commit/895a5fa6e1b6f690528a96837cee6e355b4012d8) python310Packages.homeconnect: 0.7.1 -> 0.7.2
* [`8a19bf49`](https://github.com/NixOS/nixpkgs/commit/8a19bf497c05b009d6040d3d0231baa4c27d57d3) cinnamon.cinnamon-common: 5.4.9 -> 5.4.10
* [`620175f8`](https://github.com/NixOS/nixpkgs/commit/620175f898f6d7c200ef21803a6d40e30784ec70) cinnamon.nemo: 5.4.2 -> 5.4.3
* [`53abe2aa`](https://github.com/NixOS/nixpkgs/commit/53abe2aa3e442414a93048e9bec79ff78204a6a4) cinnamon.xreader: 3.4.3 -> 3.4.4
* [`ffd1c042`](https://github.com/NixOS/nixpkgs/commit/ffd1c042421ec9e546cca5b314c1df65ac43930a) sticky: 1.11 -> 1.12
* [`dd05ebc5`](https://github.com/NixOS/nixpkgs/commit/dd05ebc58a2611b76e65552cd959a949b8ae4290) python310Packages.limnoria: 2022.6.23 -> 2022.8.7
* [`7fcd6a54`](https://github.com/NixOS/nixpkgs/commit/7fcd6a542741b78d7bf3a0d521b83f717430bed2) python310Packages.mailsuite: 1.9.4 -> 1.9.5
* [`ffc279b6`](https://github.com/NixOS/nixpkgs/commit/ffc279b64c0b026ee22eda01f586ad5383623f0b) hysteria: 1.1.0 -> 1.2.0
* [`1f546560`](https://github.com/NixOS/nixpkgs/commit/1f546560cfb1e353ae0de05936261be5042896ff) haskellPackages: mark builds failing on hydra as broken
* [`58e5bd56`](https://github.com/NixOS/nixpkgs/commit/58e5bd56d67b46208a6eef2539bb000b7a146580) default-crate-overrides.nix: add libevdev for evdev-rs
* [`92f6f6b7`](https://github.com/NixOS/nixpkgs/commit/92f6f6b72b6ebd250a3480b59166cc43d959c1df) python310Packages.p1monitor: 2.0.0 -> 2.1.0
* [`8a36e147`](https://github.com/NixOS/nixpkgs/commit/8a36e1472b53f7adfaa9267a13967094636401d2) swaynotificationcenter: 0.6.1 -> 0.6.3
* [`6737d2cf`](https://github.com/NixOS/nixpkgs/commit/6737d2cfc8987d3b01c2fde5189d3313ef2248e9) pipectl: 0.3.0 -> 0.4.1
* [`7fdb2802`](https://github.com/NixOS/nixpkgs/commit/7fdb28022fe5b52c75b43ae8fb7df59df871df02) ihaskell: don't build on hydra
* [`13203f81`](https://github.com/NixOS/nixpkgs/commit/13203f81c0c7c4ca9a04727fc1adfe1e16dffc95) python310Packages.genpy: 2021.1 -> 2022.1
* [`7aeffe56`](https://github.com/NixOS/nixpkgs/commit/7aeffe56b0ebb903dfd2711dc47f4f581238d9c4) backblaze-b2: 3.2.0 -> 3.5.0
* [`387f876b`](https://github.com/NixOS/nixpkgs/commit/387f876b2d1db0beba775fa6ac917aaeda4edd03) backblaze-b2: add tomhoule to maintainers
* [`f253ea72`](https://github.com/NixOS/nixpkgs/commit/f253ea7289d9beaa3fb8e72d3f99a2e5ca443977) headscale: 0.16.1 -> 0.16.2
* [`2ad332f6`](https://github.com/NixOS/nixpkgs/commit/2ad332f6250934c0cb4db49e7bd6fbd5b6dcfb85) ugrep: 3.9.0 -> 3.9.1
* [`e0660190`](https://github.com/NixOS/nixpkgs/commit/e066019096f11ab84b304e2f1e262f692385294e) hydra_unstable: 2022-06-30 -> 2022-08-08
* [`f1660d80`](https://github.com/NixOS/nixpkgs/commit/f1660d80277fda710668edff8ec5ab05c91422d1) aliyun-cli: 3.0.123 -> 3.0.124
* [`3ddd0f90`](https://github.com/NixOS/nixpkgs/commit/3ddd0f9002d8630a34a86cc30196a963d0b2c545) maintainers: add monaaraj
* [`9f1da18a`](https://github.com/NixOS/nixpkgs/commit/9f1da18a1e9c48d43854811362b75236b61164cc) colemak-dh: init at unstable-2022-08-07
* [`243053e5`](https://github.com/NixOS/nixpkgs/commit/243053e521dc90b825a17bf5ee9f5dfe7f56af84) python310Packages.mistune: 0.8.4 -> 2.0.4
* [`eb642f80`](https://github.com/NixOS/nixpkgs/commit/eb642f80f9aecc19312909e08601a3c2020b5ce2) m2r: use toPythonApplication
* [`8a732719`](https://github.com/NixOS/nixpkgs/commit/8a73271911445fc2206b6572956dd578beb227ef) zq: init at v1.2.0
* [`52539e41`](https://github.com/NixOS/nixpkgs/commit/52539e410cf310b0517989d68a80caf90af486fb) google-cloud-sdk: 387.0.0 -> 397.0.0
* [`88132767`](https://github.com/NixOS/nixpkgs/commit/88132767ceb5cfdde740a25e4d0f7ce933f588b1) git: actually add fetchgit tests to passthru.tests
* [`497d1a5b`](https://github.com/NixOS/nixpkgs/commit/497d1a5b7298b603424718b1db237e9bc082edac) matrix-commander: 2.37.3 -> 3.5.0
* [`f212eaf3`](https://github.com/NixOS/nixpkgs/commit/f212eaf3acca4c9bdff7888240d04e7170373224) xfsprogs: 5.18.0 -> 5.19.0
* [`ef44cfa2`](https://github.com/NixOS/nixpkgs/commit/ef44cfa256a0e79e4dfe6bb0205943c1400d2f73) irrlichtmt: remove unused library
* [`89e04473`](https://github.com/NixOS/nixpkgs/commit/89e044737697d6000c40d7c0ce22f30cc4d9bea7) minetest: cleanup
* [`e381ce6f`](https://github.com/NixOS/nixpkgs/commit/e381ce6fcf97cda135170592c14d4fc48e4c6ef8) dnsmonster: 0.9.4 -> 0.9.5
* [`7e44c3c3`](https://github.com/NixOS/nixpkgs/commit/7e44c3c38268ced3292a58f5f43d8aefc9ec6f21) python310Packages.bluetooth-sensor-state-data: 1.5.0 -> 1.6.0
* [`77331374`](https://github.com/NixOS/nixpkgs/commit/77331374d3ee76e013e61ac1857ab28314eb9288) python310Packages.sensorpush-ble: 1.5.1 -> 1.5.2
* [`7001e052`](https://github.com/NixOS/nixpkgs/commit/7001e052e99e35e8d77272a361d3045402f167ce) ioccheck: fix build
* [`53149fe1`](https://github.com/NixOS/nixpkgs/commit/53149fe1311fcd9aa2470b3376e39435875797cb) python310Packages.Wand: 0.6.9 -> 0.6.10
* [`b75502a9`](https://github.com/NixOS/nixpkgs/commit/b75502a971f9ba28d1347990eb1f12636c54344d) maigret: ignore DeprecationWarning
* [`52dad0c5`](https://github.com/NixOS/nixpkgs/commit/52dad0c5bda1caae1a3fc03bba020635cbac390e) esbuild: 0.15.2 -> 0.15.3
* [`c3860d32`](https://github.com/NixOS/nixpkgs/commit/c3860d32dcb8cc5dbe589f04b2c801a1d12db489) folly: 2022.08.08.00 -> 2022.08.15.00
* [`47b3196a`](https://github.com/NixOS/nixpkgs/commit/47b3196aabdf11b43dafb35960f88885beb825e2) python3Packages.flask-appbuilder: fix build
* [`04d4ab51`](https://github.com/NixOS/nixpkgs/commit/04d4ab516f835d43012e404e033c842c9fa2029a) k4dirstat: 3.4.0 -> 3.4.2
* [`8cef7eec`](https://github.com/NixOS/nixpkgs/commit/8cef7eec93fb18bf40aa5a83bd0760ea2934f0e0) nixos/nscd: Add requiredBy for the nss targets
* [`342d67be`](https://github.com/NixOS/nixpkgs/commit/342d67be61a28c840c945875908dcedeebd74bec) obs-studio: resolve failed wrapping if a plugin has no data path
* [`9c69f307`](https://github.com/NixOS/nixpkgs/commit/9c69f307ce6e869b5ff43c242b7cf6d5f5fd9013) nixos/cinnamon: install gnome-screenshot
* [`67272ce2`](https://github.com/NixOS/nixpkgs/commit/67272ce26850f3137ea2b0115844287d48502726) xprintidle: 0.2.4 -> 0.2.5
* [`ff1dce12`](https://github.com/NixOS/nixpkgs/commit/ff1dce127b2a2f98beeeb81199e649f18a48ff37) monolith: 2.6.1 -> 2.6.2
* [`1e00dcc8`](https://github.com/NixOS/nixpkgs/commit/1e00dcc8f03d18ceb5abda3380befa7efca74dad) mozjpeg: 4.0.3 -> 4.1.1
* [`ea677891`](https://github.com/NixOS/nixpkgs/commit/ea677891fd18d793cd76280e85c4753637a00245) nali: 0.5.0 -> 0.5.3
* [`07a56496`](https://github.com/NixOS/nixpkgs/commit/07a564964c0dfb1fa15f9be701b2fba55b252a9d) git-team: fix build on aarch64-darwin
* [`3dc23730`](https://github.com/NixOS/nixpkgs/commit/3dc237306e8f20b1f8af52efef92abf7530147cc) dino: simplify checkPhase
* [`27e6c747`](https://github.com/NixOS/nixpkgs/commit/27e6c7477b4069023c00518cb939dbfd5d7edfeb) neovide: 0.10.0 -> 0.10.1
* [`a29ca0ec`](https://github.com/NixOS/nixpkgs/commit/a29ca0ec205210ff208c5f00d6a5b9d3413f4287) cinnamon.cinnamon-common: fix msgfmt path for Spices.py
* [`442538f8`](https://github.com/NixOS/nixpkgs/commit/442538f8f0a0a95dd16c992ac48fa6f12341d46a) postsrsd: 1.11 -> 1.12
* [`e44311aa`](https://github.com/NixOS/nixpkgs/commit/e44311aaad9378f9c542a77b8a087e0f001a479e) cargo-public-api: 0.13.0 -> 0.14.0
* [`bec3c175`](https://github.com/NixOS/nixpkgs/commit/bec3c1757918f88d4e8ac149fbfda4fc0b2998cc) python3Packages.jupyter: fix missing logos
* [`37ef4030`](https://github.com/NixOS/nixpkgs/commit/37ef4030062204ca0ba1bfd316f18d773aacc789) python3Packages.ibis-framework: 3.0.2 -> 3.1.0
* [`e2115fec`](https://github.com/NixOS/nixpkgs/commit/e2115fec63d7dab7e333ccc01768f0444ea61aad) gnomeExtensions: auto-update
* [`8f72f03e`](https://github.com/NixOS/nixpkgs/commit/8f72f03e07173fcdfad861e67c2fc6e19873d76b) werf: 1.2.153 -> 1.2.154
* [`4fb53a56`](https://github.com/NixOS/nixpkgs/commit/4fb53a5647b71266107020d6a9cdb84e01d87ff0) python310Packages.iminuit: 2.13.0 -> 2.15.2
* [`3ea5fcb7`](https://github.com/NixOS/nixpkgs/commit/3ea5fcb7dab13943b380860ecacb921a5a163a12) octoprint: 1.8.2 fix sha256 aufter upstream change
* [`b6fcfe82`](https://github.com/NixOS/nixpkgs/commit/b6fcfe826ce875696066b68649b88d8e9467686c) listmonk: init at 2.2.0
* [`9a1bb9fc`](https://github.com/NixOS/nixpkgs/commit/9a1bb9fc17d8a68250ae0817f218da71d237df26) python310Packages.envisage: 6.0.1 -> 6.1.0
* [`3b1f5eab`](https://github.com/NixOS/nixpkgs/commit/3b1f5eab31b33fb1621ba7823317990951bf45e6) firefox: add application actions to .desktop file
* [`50500713`](https://github.com/NixOS/nixpkgs/commit/50500713c37b40c570cd6a8cefcda713d5e43688) python310Packages.flask-jwt-extended: 4.4.2 -> 4.4.4
* [`dbf97a4f`](https://github.com/NixOS/nixpkgs/commit/dbf97a4f55844aab09ec0fb5f0ae315611ee3fe4) kubelogin-oidc: 1.25.1 -> 1.25.2 ([nixos/nixpkgs⁠#186641](https://togithub.com/nixos/nixpkgs/issues/186641))
* [`73216024`](https://github.com/NixOS/nixpkgs/commit/73216024d1669bedfd5e41371ead35ec97c043a5) dex-oidc: 2.32.0 -> 2.33.0 ([nixos/nixpkgs⁠#186589](https://togithub.com/nixos/nixpkgs/issues/186589))
* [`e2329a87`](https://github.com/NixOS/nixpkgs/commit/e2329a8786bfb2ff8318325278980ac71b7f8b69) python310Packages.bleak-retry-connector: 1.7.2 -> 1.8.0
* [`e2dd5729`](https://github.com/NixOS/nixpkgs/commit/e2dd5729e03c178f0f3713bd0ce6054b0050af07) python310Packages.google-cloud-access-context-manager: 0.1.13 -> 0.1.14
* [`65542a63`](https://github.com/NixOS/nixpkgs/commit/65542a6348b50d62198a1a992723cdd6dbaaa137) nixos/github-runner: use state instead of runtime dir as `RUNNER_ROOT`
* [`3f075e5b`](https://github.com/NixOS/nixpkgs/commit/3f075e5bb1ea2e74923b43a2203123fbd1514535) nixos/github-runner: add PAT support
* [`987a4b42`](https://github.com/NixOS/nixpkgs/commit/987a4b42317a52426d25357bc98b5f97b4082cb2) nixos/github-runner: add support for ephemeral runners
* [`006d9d2d`](https://github.com/NixOS/nixpkgs/commit/006d9d2dfbc192257890f7d85c129f40b631b34f) release-notes: add github-runner support for PAT and ephemeral
* [`786f72c3`](https://github.com/NixOS/nixpkgs/commit/786f72c32e2a05528ae546ce48da2db2dc7facce) nixos/github-runner: start `Runner.Listener` directly in `ExecStart=`
* [`5e502ceb`](https://github.com/NixOS/nixpkgs/commit/5e502ceb4f0c1e8f22e7f0ce0b24601f955ab842) theharvester: 4.0.3 -> 4.2.0
* [`212c683d`](https://github.com/NixOS/nixpkgs/commit/212c683dee102fa3b56cacd0e0d8aa171bbc0b86) jira-cli-go: 1.0.0 -> 1.1.0
* [`d8039076`](https://github.com/NixOS/nixpkgs/commit/d8039076287525f47d8b4ec4105d2fd363badfc7) python310Packages.aiohomekit: 1.2.10 -> 1.2.11
* [`2f2e8936`](https://github.com/NixOS/nixpkgs/commit/2f2e89365ee6d8673cd781487da33ca8d18cd541) python310Packages.debuglater: 1.4.1 -> 1.4.2
* [`99bc6920`](https://github.com/NixOS/nixpkgs/commit/99bc6920c216d97434ba358395f20d0512cc936b) proxysql: 2.3.2 -> 2.4.3
* [`785ca266`](https://github.com/NixOS/nixpkgs/commit/785ca266b69a4aa343fe67c9255d178203557023) libbluray: fix build failure on 1.3.1 with java
* [`cbf423d7`](https://github.com/NixOS/nixpkgs/commit/cbf423d754116227bf1e1eb3bef47728ac0c5272) python310Packages.netmiko: 4.1.1 -> 4.1.2
* [`b6dad2af`](https://github.com/NixOS/nixpkgs/commit/b6dad2afe6684c6db2b33d7a5b0191eff2a2a5a4) moq: init at 0.2.7
* [`b8d78111`](https://github.com/NixOS/nixpkgs/commit/b8d78111a42a2aa194a2f1f83680b8bba5cef71d) python310Packages.pyswitchbot: 0.18.7 -> 0.18.10
* [`cf87c044`](https://github.com/NixOS/nixpkgs/commit/cf87c044567f3a3a030a4dd6a3f31f5d6414b115) radicle-cli: correct license to `gpl3Plus`
* [`fddb4533`](https://github.com/NixOS/nixpkgs/commit/fddb453352f20ffddd3fce75a3da04682d5a25ff) patchelfUnstable: unstable-2022-02-21 -> unstable-2022-07-16
* [`09d5adcc`](https://github.com/NixOS/nixpkgs/commit/09d5adccb75b151a1bee0bce7b8bfc9d3c832bca) python310Packages.weconnect-mqtt: 0.39.0 -> 0.39.1
* [`928eb9fc`](https://github.com/NixOS/nixpkgs/commit/928eb9fc0b1ffee6d1a2facc8b97467aec66c473)  starship: 1.10.0 -> 1.10.1
* [`8069c9c8`](https://github.com/NixOS/nixpkgs/commit/8069c9c802832adea30ca020e3aef6f750772753) python310Packages.peaqevcore: 5.1.3 -> 5.2.0
* [`6a4213ff`](https://github.com/NixOS/nixpkgs/commit/6a4213ff8cff1b23455d47e8390482397d2988e6) latex2html: 2022 -> 2022.2
* [`c667ead4`](https://github.com/NixOS/nixpkgs/commit/c667ead423b7d2a3130400f9f6c248068992812a) python310Packages.time-machine: 2.7.1 -> 2.8.0
* [`7b25ce4f`](https://github.com/NixOS/nixpkgs/commit/7b25ce4f793a03f12e97aebe560890922e091030) darkplaces: init at unstable-2022-05-10
* [`fcc47aec`](https://github.com/NixOS/nixpkgs/commit/fcc47aec15d3eea8fc1fe685bb5efa1b4af37467) collectd: unpin libsigrok
* [`a8b05f0e`](https://github.com/NixOS/nixpkgs/commit/a8b05f0e61a7b80a87c4473cd6bdb7cf62216e38) Revert "mullvad-vpn: 2022.2 -> 2022.3"
* [`a1e1e5b2`](https://github.com/NixOS/nixpkgs/commit/a1e1e5b2a7115454e50751fbbe6382addf232b95) lunatic: fix hydra build
* [`22775563`](https://github.com/NixOS/nixpkgs/commit/2277556362e175af2715062a9a17170fb2ae8984) capnproto: add optional deps, cleanup cmakeFlags
* [`7d1867e8`](https://github.com/NixOS/nixpkgs/commit/7d1867e864a05019e0e7699da955b58bfe98c462) smartmontools: fix missing sed
* [`61063f32`](https://github.com/NixOS/nixpkgs/commit/61063f32767364f1b9c8c7c51a24b1a50d2fee1d) chromiumBeta: 105.0.5195.19 -> 105.0.5195.28
* [`0e03ad36`](https://github.com/NixOS/nixpkgs/commit/0e03ad366a4a07354a7a09866fd0b2d8a524a1f0) chromiumDev: 106.0.5216.6 -> 106.0.5231.2
* [`1ed8874b`](https://github.com/NixOS/nixpkgs/commit/1ed8874bc8f6a5958a9bbd39318b0bdbfd86e1ee) python310Packages.scikit-survival: 0.17.2 -> 0.18.0
* [`3fe4330f`](https://github.com/NixOS/nixpkgs/commit/3fe4330f180591b1c54c175bcf334a55ed8137ff) doctl: 1.78.0 -> 1.79.0
* [`16f38da8`](https://github.com/NixOS/nixpkgs/commit/16f38da8d60f527631145ec32ee0df136994c913) dendrite: 0.9.1 -> 0.9.3
* [`96e643e8`](https://github.com/NixOS/nixpkgs/commit/96e643e8d6f6368cee969dc523b517ac53b6c723) python310Packages.pyathena: 2.13.0 -> 2.14.0
* [`017b57c6`](https://github.com/NixOS/nixpkgs/commit/017b57c6a73ce6a51d35ae4c745481b0f98b7c3a) exoscale-cli: 1.58.0 -> 1.59.0
* [`3e730a51`](https://github.com/NixOS/nixpkgs/commit/3e730a51e61f46d5ec55451181f8792d054efd26) fioctl: 0.26 -> 0.27
* [`90ba8bfb`](https://github.com/NixOS/nixpkgs/commit/90ba8bfb8a8cadb6736d24d18473274647d8a105) findomain: 8.1.1 -> 8.2.0
* [`8138a92a`](https://github.com/NixOS/nixpkgs/commit/8138a92a2af2b5071e8d2b8e5e066dd4f7c10dbf) clusterctl: 1.2.0 -> 1.2.1
* [`07730a7b`](https://github.com/NixOS/nixpkgs/commit/07730a7b4992a3c7e1b637cc24bb5fbc47b6bad8) nomad_1_3: 1.3.2 -> 1.3.3
* [`b4745995`](https://github.com/NixOS/nixpkgs/commit/b474599529b4572e0e07088e15e6e7818231a9f1) nomad: default to nomad_1_3, add to release notes
* [`dc2d94a3`](https://github.com/NixOS/nixpkgs/commit/dc2d94a32999357566857a05f29bd6c544116431) python310Packages.python-gitlab: 3.6.0 -> 3.8.1
* [`9c6f7712`](https://github.com/NixOS/nixpkgs/commit/9c6f7712a246d1c1aae7279de9684897dc015542) mariadb: sha256 -> hash
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
