### PR TITLE
niv emacs-overlay: update cb0c62c7 -> 5b17f330

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cb0c62c7342810332453969ef453c16e51625438",
-        "sha256": "13lgwhczf7agnnk5gwv50si7bsfaw1ahhgc2kbs97qx62394gwdq",
+        "rev": "5b17f330ba968f090da178f4316bb193dae6e6b3",
+        "sha256": "11if5j4zr65n9a9lcg2fg5msn9d8kvvaszrqqkqfxr1l5kzgwwvs",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/cb0c62c7342810332453969ef453c16e51625438.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/5b17f330ba968f090da178f4316bb193dae6e6b3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@cb0c62c7...5b17f330](https://github.com/nix-community/emacs-overlay/compare/cb0c62c7342810332453969ef453c16e51625438...5b17f330ba968f090da178f4316bb193dae6e6b3)

* [`48704146`](https://github.com/nix-community/emacs-overlay/commit/487041468db3c85f7482b1472f40bcb8dc29c867) Updated repos/emacs
* [`b7f32252`](https://github.com/nix-community/emacs-overlay/commit/b7f322524d077b01f63d413cea4059c5fffaa362) Updated repos/melpa
* [`4418438e`](https://github.com/nix-community/emacs-overlay/commit/4418438e70ff6cddbae5c28b238954dd3ed14dfc) Updated repos/elpa
* [`33b473f1`](https://github.com/nix-community/emacs-overlay/commit/33b473f1f037d2b5138e1660f96e2509be2f8d79) Updated repos/emacs
* [`50eb2134`](https://github.com/nix-community/emacs-overlay/commit/50eb213413b3e6c865e7006159f2aba3f7a71f34) Updated repos/melpa
* [`f3a42164`](https://github.com/nix-community/emacs-overlay/commit/f3a4216461b2e568d418715ea0dd8482e45d9a38) Updated repos/elpa
* [`e6fb9bdd`](https://github.com/nix-community/emacs-overlay/commit/e6fb9bddf24d303364ac2bc28c471dcf9d8c98fe) Updated repos/emacs
* [`8925d05d`](https://github.com/nix-community/emacs-overlay/commit/8925d05d615773f5407669a2e9ec00212eb0edab) Updated repos/melpa
* [`a673e18d`](https://github.com/nix-community/emacs-overlay/commit/a673e18d00feb05ac486ef9e641bc63265d4dc7c) Updated repos/emacs
* [`8a8ab565`](https://github.com/nix-community/emacs-overlay/commit/8a8ab5655af3e7a741b8230a2c36453622ea330d) Updated repos/melpa
* [`6430ac36`](https://github.com/nix-community/emacs-overlay/commit/6430ac36e0b870bc5833302b81e5cdd8663c5233) Updated repos/elpa
* [`8949819c`](https://github.com/nix-community/emacs-overlay/commit/8949819ca34643553189b31c425d1673897344fb) Updated repos/emacs
* [`f391425e`](https://github.com/nix-community/emacs-overlay/commit/f391425e518aae894dd95c9165140f1dda8283af) Updated repos/melpa
* [`0ccaf348`](https://github.com/nix-community/emacs-overlay/commit/0ccaf3482f58fa96465566f4fd810fe01e385db3) Updated repos/elpa
* [`efa045cf`](https://github.com/nix-community/emacs-overlay/commit/efa045cf3f50bf7f5abfbc57e2c5dcf302851996) Updated repos/emacs
* [`720a9722`](https://github.com/nix-community/emacs-overlay/commit/720a9722d3fb67ef37a0b1e8394047298b7b9b1c) Updated repos/melpa
* [`dd7b6b1c`](https://github.com/nix-community/emacs-overlay/commit/dd7b6b1ce303f24a4f8cfd5155bdd701ee93abde) Updated repos/emacs
* [`14443210`](https://github.com/nix-community/emacs-overlay/commit/14443210f27375d5efc0cc554ad477d052e47b59) Updated repos/melpa
* [`46f1eb47`](https://github.com/nix-community/emacs-overlay/commit/46f1eb47efc573ab8db9c025a95d48c821487369) Updated repos/elpa
* [`1220e2f9`](https://github.com/nix-community/emacs-overlay/commit/1220e2f91990377c94b3baf10a9e18b448f1b817) Updated repos/emacs
* [`3bc69e76`](https://github.com/nix-community/emacs-overlay/commit/3bc69e76fc1004c85a1e337656a6d4a6eb0ca260) Updated repos/melpa
* [`5faa2abd`](https://github.com/nix-community/emacs-overlay/commit/5faa2abde9cd8aa08cba96ac123f94751a942b95) Updated repos/emacs
* [`7fafcb89`](https://github.com/nix-community/emacs-overlay/commit/7fafcb893b962b5d480f5682ea15effe898547aa) Updated repos/melpa
* [`29d3a70a`](https://github.com/nix-community/emacs-overlay/commit/29d3a70af302db1ebb25672d68ada374ef64fad6) Updated repos/nongnu
* [`9e551fa5`](https://github.com/nix-community/emacs-overlay/commit/9e551fa5186a96a29b7f7a299306bba13ebb90ba) Updated repos/elpa
* [`ac52210d`](https://github.com/nix-community/emacs-overlay/commit/ac52210de95d05f77e81015a2be2b60f1a42c4dd) Updated repos/emacs
* [`f66d6692`](https://github.com/nix-community/emacs-overlay/commit/f66d669288605e8dff2e1596ba596a47cc599600) Updated repos/melpa
* [`47194758`](https://github.com/nix-community/emacs-overlay/commit/47194758ad8c76ced6b2b8a38b34674b737b1395) Updated repos/elpa
* [`f2a9115e`](https://github.com/nix-community/emacs-overlay/commit/f2a9115e2256530f600005bc63a162ed0f31f917) Updated repos/emacs
* [`7f8f0c91`](https://github.com/nix-community/emacs-overlay/commit/7f8f0c9108746598b33029abcb296aac12a7dfe7) Updated repos/melpa
* [`d35281af`](https://github.com/nix-community/emacs-overlay/commit/d35281af15d9daedcbb749cb24a77ba330e0d4b3) Updated repos/nongnu
* [`1eef20d1`](https://github.com/nix-community/emacs-overlay/commit/1eef20d1c8ccc8bdf0fb193da6cc1d0c28001b39) Updated repos/emacs
* [`9207a289`](https://github.com/nix-community/emacs-overlay/commit/9207a28927659d6f3fc5d603ea9cf680c9305f8b) Updated repos/melpa
* [`e3c49d6e`](https://github.com/nix-community/emacs-overlay/commit/e3c49d6ea647d5727271d6858a6f414912704b79) Updated repos/nongnu
* [`bdca297f`](https://github.com/nix-community/emacs-overlay/commit/bdca297f3aee6179109a714f978f9e3011036ae0) Updated repos/elpa
* [`a748f651`](https://github.com/nix-community/emacs-overlay/commit/a748f65165a0e319e848612b29e3223121a66d41) Updated repos/emacs
* [`788726b7`](https://github.com/nix-community/emacs-overlay/commit/788726b74db76ddcde3130055bc6434065a7449d) Updated repos/melpa
* [`0189e818`](https://github.com/nix-community/emacs-overlay/commit/0189e818c5be122fd919ad28b50b779fdcdd126a) Updated repos/elpa
* [`798ab8fd`](https://github.com/nix-community/emacs-overlay/commit/798ab8fd2043e8b800a70a3eebd42388e34cf708) Updated repos/melpa
* [`48b2f357`](https://github.com/nix-community/emacs-overlay/commit/48b2f357c5dbe265143fdb82c11735855220d493) Updated repos/emacs
* [`c89ea9ef`](https://github.com/nix-community/emacs-overlay/commit/c89ea9ef9bed55f524afc66b4832f55d5be746cf) Updated repos/melpa
* [`b0d961b4`](https://github.com/nix-community/emacs-overlay/commit/b0d961b43472d9c95a55fd106a1c0e43944ad10a) Updated repos/nongnu
* [`f12465df`](https://github.com/nix-community/emacs-overlay/commit/f12465df1c07593abe5c48d328f932e6f51755de) Updated repos/elpa
* [`fd4347dc`](https://github.com/nix-community/emacs-overlay/commit/fd4347dceb0d0b7ea60963c823019478e93a77c3) Updated repos/emacs
* [`3a6945c2`](https://github.com/nix-community/emacs-overlay/commit/3a6945c269fcbdc433b8c81afd3b36c7ac4926a1) Updated repos/melpa
* [`16319e2c`](https://github.com/nix-community/emacs-overlay/commit/16319e2c7b53a334d09be6e2eedb1e9c5340c5c6) Updated repos/emacs
* [`cda3e85d`](https://github.com/nix-community/emacs-overlay/commit/cda3e85dc7c08c7ba952f374914637765a225e07) Updated repos/melpa
* [`97a0b4e8`](https://github.com/nix-community/emacs-overlay/commit/97a0b4e8d1bfc77f1159bad987c119394b7c2f26) Updated repos/nongnu
* [`b953e5c0`](https://github.com/nix-community/emacs-overlay/commit/b953e5c04196c24a1f347a5f1a4db471fd8881cd) Updated repos/emacs
* [`f7084ae4`](https://github.com/nix-community/emacs-overlay/commit/f7084ae4176f6779f8de9bfa724e67002db3174c) Updated repos/melpa
* [`d0b5c74f`](https://github.com/nix-community/emacs-overlay/commit/d0b5c74f592ac6cfd03a10938f18ea9430735bbc) Updated repos/emacs
* [`f274dc1c`](https://github.com/nix-community/emacs-overlay/commit/f274dc1c9c898f140755c5d8061b21cff1219445) Updated repos/melpa
* [`69987982`](https://github.com/nix-community/emacs-overlay/commit/699879821fee3d766066c45e5d6c3ca26dbb106e) Updated repos/emacs
* [`5b17f330`](https://github.com/nix-community/emacs-overlay/commit/5b17f330ba968f090da178f4316bb193dae6e6b3) Updated repos/melpa
