### PR TITLE
niv spacemacs: update eb809cc6 -> b86b881b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "eb809cc61ce4fbca9ae32aa5f47ed713bb08d7c9",
-        "sha256": "0bz672plaqnpq3x2wjfi9bfsy7i76jy5n4s84j3x1d36sz4jysap",
+        "rev": "b86b881b537128182d5682e32ecb44b7d7a63614",
+        "sha256": "0v0lxp6d4ckamvlasmsrina10l1lyvyif0s4a5m4prb5lrzy1k9q",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/eb809cc61ce4fbca9ae32aa5f47ed713bb08d7c9.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/b86b881b537128182d5682e32ecb44b7d7a63614.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@eb809cc6...b86b881b](https://github.com/syl20bnr/spacemacs/compare/eb809cc61ce4fbca9ae32aa5f47ed713bb08d7c9...b86b881b537128182d5682e32ecb44b7d7a63614)

* [`f63d3c41`](https://github.com/syl20bnr/spacemacs/commit/f63d3c41b05575aca4dd732a9f8ee131210b9219) spacemacs-editing-visual: fix term-cursor logic
* [`d4176773`](https://github.com/syl20bnr/spacemacs/commit/d417677305d7e34082890fb3d1477886e37c3c9a) [bot] built_in_updates ([syl20bnr/spacemacs⁠#15702](https://togithub.com/syl20bnr/spacemacs/issues/15702))
* [`6fc3c8cb`](https://github.com/syl20bnr/spacemacs/commit/6fc3c8cb9526143f510a00a8345b3c714811f505) CONVENTIONS.org: minor typo fix ([syl20bnr/spacemacs⁠#15704](https://togithub.com/syl20bnr/spacemacs/issues/15704))
* [`c99f6a91`](https://github.com/syl20bnr/spacemacs/commit/c99f6a9149b3cf1a739a948447bd7c8ce1a74985) [bot] "built_in_updates" Thu Aug 18 19:55:32 UTC 2022 ([syl20bnr/spacemacs⁠#15705](https://togithub.com/syl20bnr/spacemacs/issues/15705))
* [`b86b881b`](https://github.com/syl20bnr/spacemacs/commit/b86b881b537128182d5682e32ecb44b7d7a63614) search-engine: Add Docker Hub image search engine. ([syl20bnr/spacemacs⁠#15706](https://togithub.com/syl20bnr/spacemacs/issues/15706))
