### PR TITLE
niv nixpkgs: update a2cd5706 -> ab0f5208

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a2cd57069d78bce6bef4a8b85f422bb4d0e91ecb",
-        "sha256": "0w4w0gawdwq9k9s1zzib45z0wqs0gsnfs0iq8yhmycxa1s43g5n9",
+        "rev": "ab0f52080fd0d50babb45aae14f605ffdb096e62",
+        "sha256": "080fl35ls59g72y270fw2rlyd5lisv052bawfx8pa0ifhmh9zw2a",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a2cd57069d78bce6bef4a8b85f422bb4d0e91ecb.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ab0f52080fd0d50babb45aae14f605ffdb096e62.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a2cd5706...ab0f5208](https://github.com/nixos/nixpkgs/compare/a2cd57069d78bce6bef4a8b85f422bb4d0e91ecb...ab0f52080fd0d50babb45aae14f605ffdb096e62)

* [`1c545a95`](https://github.com/NixOS/nixpkgs/commit/1c545a9593849450b4f3229e94f82dda5881ddc1) maintainers: add raitobezarius to the list
* [`a131be8f`](https://github.com/NixOS/nixpkgs/commit/a131be8f99862d5fdb34c2aa809c8716493ef56e) emacs: populate load-path recursively
* [`0349c745`](https://github.com/NixOS/nixpkgs/commit/0349c745d1f615f2dc1c7ce78248c13af2bf5944) xkb-switch-i3: 1.8.1 -> 1.8.5
* [`47188071`](https://github.com/NixOS/nixpkgs/commit/47188071d22aa49aea03ba3ee6a0c57cf9fa5eb5) nixos/{jitsi-meet,prosody}: Reload prosody after switch
* [`534151f9`](https://github.com/NixOS/nixpkgs/commit/534151f999b7f6dd2483ae08df64364c51e40773) gwe: 0.15.4 -> 0.15.5
* [`b95551e7`](https://github.com/NixOS/nixpkgs/commit/b95551e70ee1308e2b6d953550fb8ae3d0da2344) hubstaff: 1.6.5-31be26f1 -> 1.6.6-61e2338c
* [`73de9bea`](https://github.com/NixOS/nixpkgs/commit/73de9bea44571d7f3a13d4169836fe92b20f9da2) libisds: 0.11.1 -> 0.11.2
* [`9b8d6933`](https://github.com/NixOS/nixpkgs/commit/9b8d6933591f08f61a5c1c78e38199ceec0f0099) bobcat: 5.09.01 -> 5.10.01
* [`75efb826`](https://github.com/NixOS/nixpkgs/commit/75efb8267438dd0788cef7573bb70e808a7b98f4) cudaPackages.cudnn: fix source fetching
* [`11d9682b`](https://github.com/NixOS/nixpkgs/commit/11d9682b5770adb4b61964213bcedac61e20fa20) moserial: init at 3.0.21
* [`cb49b926`](https://github.com/NixOS/nixpkgs/commit/cb49b9265913deda398cde5c439517360ba93d93) dropbear: expose optional scp support (fixes [nixos/nixpkgs⁠#135849](https://togithub.com/nixos/nixpkgs/issues/135849))
* [`f7baa65d`](https://github.com/NixOS/nixpkgs/commit/f7baa65db75b32db49894296646a1b9b74115482) nixos/caddy: improve security about acme certs
* [`0bae8e87`](https://github.com/NixOS/nixpkgs/commit/0bae8e87bbe6a4fc03bbeef4c401fd2562e6dc70) kmscon: unstable-2018-09-07 -> 9.0.0
* [`ee44aeef`](https://github.com/NixOS/nixpkgs/commit/ee44aeef707dc85489a06b2274d56e89ac0187ad) mariadb: fix build on riscv
* [`7f930f85`](https://github.com/NixOS/nixpkgs/commit/7f930f85a16afe2cf044c4ebacb267ef34cc23bd) mariadb: move cross compilation related cmake flags to common section
* [`168cdcd9`](https://github.com/NixOS/nixpkgs/commit/168cdcd9bdaf42abfbfe317b3e6b223c0e022dbd) linux_lqx, linux_zen: avoid unnecessary prefetch
* [`f6cf9a97`](https://github.com/NixOS/nixpkgs/commit/f6cf9a97c3a9b7bbcc2bd572c97687f221a1f5b4) eclipse-mat: 1.12.0.20210602 -> 1.13.0.20220615
* [`a28c6dda`](https://github.com/NixOS/nixpkgs/commit/a28c6ddae0e66e2433069a840ed59e3eca73af9e) flatcc: 0.6.0 -> 0.6.1
* [`70d8afaf`](https://github.com/NixOS/nixpkgs/commit/70d8afaf722017bf66e2e1c289a8a13bed975665) aspectj: 1.9.7 -> 1.9.9.1
* [`788c10d7`](https://github.com/NixOS/nixpkgs/commit/788c10d7e5716a1ba59d3829fe69ff621af8a5b6) libsForQt5.alkimia: 8.1.0 -> 8.1.1
* [`1834c512`](https://github.com/NixOS/nixpkgs/commit/1834c5123e5bda3d9b6126bd9d992c860e98bdcf) android-udev-rules: 20220102 -> 20220611
* [`4a9aee18`](https://github.com/NixOS/nixpkgs/commit/4a9aee188d35c755a2a0362b8bf94bebf5dbf833) cassowary: 0.14.0 -> 0.14.1
* [`1cd84253`](https://github.com/NixOS/nixpkgs/commit/1cd842531e2159c12c64d6409a0bd23fafd82490) bluez-alsa: 3.1.0 -> 4.0.0
* [`a23a085a`](https://github.com/NixOS/nixpkgs/commit/a23a085a261006b35905c6318103a1e71183130a) clifm: 1.5.1 -> 1.6
* [`0276d2fc`](https://github.com/NixOS/nixpkgs/commit/0276d2fcbb41f7a59c00be34949133e97e5b8880) common-updater-scripts/update-source-version: Add flag required for nix-command
* [`88294163`](https://github.com/NixOS/nixpkgs/commit/8829416344a88de4ab23c79b6daec69ff8c34c13) cups-filters: 1.28.12 -> 1.28.15
* [`778b2153`](https://github.com/NixOS/nixpkgs/commit/778b215342c254c377857fcf9a4ee4e1337aae57) cmus: 2.9.1 -> 2.10.0
* [`180de978`](https://github.com/NixOS/nixpkgs/commit/180de978faa9c05d0b8084d6ad2f6eed5918b1b5) davix: 0.8.0 -> 0.8.2
* [`58e7457e`](https://github.com/NixOS/nixpkgs/commit/58e7457e2afb0a0f88df0d58214d29a3f2e514c0) dtrx: 8.2.2 -> 8.3.1
* [`5d0a3c07`](https://github.com/NixOS/nixpkgs/commit/5d0a3c070e514ed70bee22d85cf7a98954a243d8) kopia: 0.11.2 -> 0.11.3
* [`eda07a0e`](https://github.com/NixOS/nixpkgs/commit/eda07a0e8f116803c4120aa26e248c86b531b91c) mesa-demos: 8.4.0 -> 8.5.0
* [`5e765ecc`](https://github.com/NixOS/nixpkgs/commit/5e765ecc68a02fbad7ae1626558f5a58a8825764) diamond: 0.8.36 -> 2.0.15
* [`4e79b5e3`](https://github.com/NixOS/nixpkgs/commit/4e79b5e370d92197d53713e49884ab3f6045711c) diamond: remove patch
* [`55853ae0`](https://github.com/NixOS/nixpkgs/commit/55853ae09676ecd78170f514d4d8961908d2adbe) maintainers: add thyol
* [`0d6e3afd`](https://github.com/NixOS/nixpkgs/commit/0d6e3afdba59da87eecc3aed8b1bef73a78f38fd) diamond: update metadata
* [`bb3ed09b`](https://github.com/NixOS/nixpkgs/commit/bb3ed09b06bd4ac113b6192b45f3f993cf28be84) diamond: add release notes
* [`9126d975`](https://github.com/NixOS/nixpkgs/commit/9126d975e85c7700dc8f0580933f0104016ecf24) wire-desktop: linux 3.27.2944 -> 3.28.2946
* [`5aaae1dd`](https://github.com/NixOS/nixpkgs/commit/5aaae1ddc9f4340291f1d60aeb89eff2781d8423) wire-desktop: mac 3.27.4357 -> 3.28.4393
* [`871cf9f7`](https://github.com/NixOS/nixpkgs/commit/871cf9f7b3e5a54b6cc1f08487846ff79c26db83) cmake: detect libc location at runtime
* [`1588db30`](https://github.com/NixOS/nixpkgs/commit/1588db305ad8f3be179a47458e5754b38a3b1962) smartdeblur: unstable-2013-01-09 -> unstable-2018-10-29
* [`83a9b3c4`](https://github.com/NixOS/nixpkgs/commit/83a9b3c4155f5da4ba507de5b5a09036b2a77d6e) man-db: use lib.makeBinPath when wrapping
* [`ba812e56`](https://github.com/NixOS/nixpkgs/commit/ba812e56568a0417cfe54df31116588a8e9effcf) man-db: add gzip to the PATH of the executable wrapper
* [`965a2c57`](https://github.com/NixOS/nixpkgs/commit/965a2c573d1b5e2f01220262ccefe704bd51f019) python310Packages.marshmallow-sqlalchemy: 0.28.0 -> 0.28.1
* [`3bf6fc58`](https://github.com/NixOS/nixpkgs/commit/3bf6fc58622edd66769944f971d53cbb56b908a1) hyprpaper: unstable-2022-07-04 -> unstable-2022-07-24
* [`02c2eda2`](https://github.com/NixOS/nixpkgs/commit/02c2eda2636e487d20e2a2c34b3744697d2f8263) manim: 0.16.0 -> 0.16.0.post0
* [`cb704bf9`](https://github.com/NixOS/nixpkgs/commit/cb704bf922aac3032a8bd98d73d708197fa661d9) fetchurl: disallow specifying both `sha256` and `hash`
* [`ccf609a9`](https://github.com/NixOS/nixpkgs/commit/ccf609a92600e9efd6dcff02b9f2fa762c113286) home-assistant: don't pass two different hashes to fetchPypi
* [`28eee98b`](https://github.com/NixOS/nixpkgs/commit/28eee98b4431ee15cfddb33d8659e39f4ffd894f) tts: don't override librosa fetcher, replace it
* [`28f348cd`](https://github.com/NixOS/nixpkgs/commit/28f348cd3b796a0bb3dbd7017d77907ec26e5cea) mask: 0.11.1 -> 0.11.2
* [`8c0e56fc`](https://github.com/NixOS/nixpkgs/commit/8c0e56fc14638c81850ba4e3cfb0e598002def20) angsd: 0.937 -> 0.938
* [`695726b7`](https://github.com/NixOS/nixpkgs/commit/695726b7aca96965f0b411e968f8d6117e50b64a) async-profiler: 2.8.1 -> 2.8.3
* [`16392f90`](https://github.com/NixOS/nixpkgs/commit/16392f90bcec6c245e10d98a56d26109c00aeea5) roxctl: 3.70.1 -> 3.71.0
* [`b79a04fd`](https://github.com/NixOS/nixpkgs/commit/b79a04fd1ddeac676e8cfd3dbf7f47c46f7f3bbc) frugal: 3.15.4 -> 3.16.1
* [`3e23d21b`](https://github.com/NixOS/nixpkgs/commit/3e23d21b5c86b258bc5abdc87a3e0a58e2bb608f) gerbera: 1.10.0 -> 1.11.0
* [`682f5266`](https://github.com/NixOS/nixpkgs/commit/682f5266ff6b4b20db822a6c9b12294e05a453ae) gh-eco: 0.1.0 -> 0.1.2
* [`1670ecbd`](https://github.com/NixOS/nixpkgs/commit/1670ecbd75a27a08cef1040aa3b34a349153429e) go-junit-report: 1.0.0 -> 2.0.0
* [`fcf61619`](https://github.com/NixOS/nixpkgs/commit/fcf616190501a1ba079a27e8860cc62a0a40a2b7) goflow: 3.4.3 -> 3.4.4
* [`4ccc3e14`](https://github.com/NixOS/nixpkgs/commit/4ccc3e14b4cecd2a7ca8868767b1b0664b7c3ffd) gophernotes: 0.7.4 -> 0.7.5
* [`a03d63ef`](https://github.com/NixOS/nixpkgs/commit/a03d63efb329cd6591a406c0a85362e681cdc622) icingaweb2-thirdparty: 0.10.0 -> 0.11.0
* [`73d362a9`](https://github.com/NixOS/nixpkgs/commit/73d362a90419cf349ada085d459ac3113e38efdb) imgbrd-grabber: 7.7.1 -> 7.9.1
* [`c97d875f`](https://github.com/NixOS/nixpkgs/commit/c97d875f3da765b1df03149d5b37660ae1c77e67) indilib: 1.9.5 -> 1.9.6
* [`83128ae4`](https://github.com/NixOS/nixpkgs/commit/83128ae4d943ebc8a1ea41c8162a08466cd5e722) interactsh: 1.0.2 -> 1.0.6
* [`e9c34acb`](https://github.com/NixOS/nixpkgs/commit/e9c34acbaeb12c997b2d406404bc68bcf0da0b37) iotop-c: 1.21 -> 1.22
* [`df97dbf9`](https://github.com/NixOS/nixpkgs/commit/df97dbf9a840e508160471bfe2b9c24816dd6ac9) ip2location-c: 8.4.1 -> 8.5.1
* [`a9342d9f`](https://github.com/NixOS/nixpkgs/commit/a9342d9f704905720ac2d142bad4b660bc955fb3) replay-io: 20220516 -> 20220726
* [`056296c1`](https://github.com/NixOS/nixpkgs/commit/056296c1425aa9f31061f0c3614a9004e866ec3f) iptsd: 0.5 -> 0.5.1
* [`a79dbf9a`](https://github.com/NixOS/nixpkgs/commit/a79dbf9ae696d48082b4df24d2f1930468e7a739) json2hcl: 0.0.7 -> 0.1.1
* [`838487b0`](https://github.com/NixOS/nixpkgs/commit/838487b081aaca9309e408bbce8c7a349f2cd617) kamid: 0.1 -> 0.2
* [`32577c51`](https://github.com/NixOS/nixpkgs/commit/32577c51330cb1c46cacb6c5439deff2351da446) kdigger: 1.2.1 -> 1.3.0
* [`034a5245`](https://github.com/NixOS/nixpkgs/commit/034a5245a9778247aa72739fb4306fc1e025f6f2) kitsas: 3.1.1 -> 3.2.1
* [`13e426bb`](https://github.com/NixOS/nixpkgs/commit/13e426bbe649d9066235251cd1132a82dfe3c175) i2p: 1.6.1 -> 1.8.0
* [`b1e35a31`](https://github.com/NixOS/nixpkgs/commit/b1e35a316ecaace85e0f92a9b32f755506aec243) lcov: 1.15 -> 1.16
* [`faadffd4`](https://github.com/NixOS/nixpkgs/commit/faadffd421a0a3f61ae8f25bf01ac384b6476ecb) leatherman: 1.12.7 -> 1.12.8
* [`32c289de`](https://github.com/NixOS/nixpkgs/commit/32c289de1d43536cd23a950d6f70c79bfe1dd4b4) mani: 0.12.2 -> 0.21.0
* [`cf0fad12`](https://github.com/NixOS/nixpkgs/commit/cf0fad125c6a535df84ac567a34e8abf6fe60aa3) mdbook-admonish: 1.6.0 -> 1.7.0
* [`2255fa1f`](https://github.com/NixOS/nixpkgs/commit/2255fa1f01d8f69de38da2419c5dde2aa793f940) microserver: 0.2.0 -> 0.2.1
* [`abdae9d6`](https://github.com/NixOS/nixpkgs/commit/abdae9d60e764336816466e0f74d5d511a7f910e) mkp224o: 1.5.0 -> 1.6.1
* [`e4e74b95`](https://github.com/NixOS/nixpkgs/commit/e4e74b959cf76a9fa6810afbff6a9516db845b3a) moonlight-qt: 4.0.0 -> 4.1.0
* [`aaaabcc9`](https://github.com/NixOS/nixpkgs/commit/aaaabcc9656eae24e0402eb402ae84b50c1f19e5) mutt-wizard: 3.2.1 -> 3.3.1
* [`70867bd5`](https://github.com/NixOS/nixpkgs/commit/70867bd51ee72f3ef633f7495f65d8ab24a5814a) nats-streaming-server: 0.24.3 -> 0.24.6
* [`92ba3b3d`](https://github.com/NixOS/nixpkgs/commit/92ba3b3d19dc41b822b20b374233a6da6ca066c7) new-session-manager: 1.5.3 -> 1.6.0
* [`b8cc49ad`](https://github.com/NixOS/nixpkgs/commit/b8cc49adbe3e520690549252fd8be7d95e36722b) nextflow: 21.10.6 -> 22.04.5
* [`959f2532`](https://github.com/NixOS/nixpkgs/commit/959f2532d859691ef0e3772864e94d39b8501de2) comby: 1.7.1 -> 1.8.1
* [`8d276ace`](https://github.com/NixOS/nixpkgs/commit/8d276aceaf7c9c08eedb009f47f8c0a217b33d8c) ninja: 1.10.2 -> 1.11.0
* [`efd9edd8`](https://github.com/NixOS/nixpkgs/commit/efd9edd88b6f299c8b368b16711ec75463a53b0b) nmrpflash: 0.9.16 -> 0.9.18.2
* [`aee10c89`](https://github.com/NixOS/nixpkgs/commit/aee10c890865717b87b860bcc0fed6409ff1cc81) air: 1.29.0 -> 1.40.4
* [`b0c160b5`](https://github.com/NixOS/nixpkgs/commit/b0c160b51a6b96c4b2e5e528cc552627bf6e73e0) aspcud: 1.9.5 -> 1.9.6
* [`07919a7c`](https://github.com/NixOS/nixpkgs/commit/07919a7c6c667e6c03397718fc35b38693c4a4df) apacheHttpdPackages.mod_wsgi: 4.9.0 -> 4.9.3
* [`84c8e568`](https://github.com/NixOS/nixpkgs/commit/84c8e568539d176704584688947910f0a038a8e5) do-agent: 3.13.0 -> 3.13.1
* [`f20dae74`](https://github.com/NixOS/nixpkgs/commit/f20dae74031e71706666db57ac828517da5f9407) flex-ncat: 0.1-20211223.0 -> 0.1-20220505.0
* [`fc9146eb`](https://github.com/NixOS/nixpkgs/commit/fc9146eb703492c4d5bec48f5ddb9e57c8c2e865) frr: 8.2.2 -> 8.3
* [`55a85164`](https://github.com/NixOS/nixpkgs/commit/55a85164037bee6e469c9266936634506f2f2172) guile-fibers: 1.0.0 -> 1.1.1
* [`2968e9ac`](https://github.com/NixOS/nixpkgs/commit/2968e9acf16a4d62a130537d98dd58ac3bc25b5b) inherd-quake: 0.5.0 -> 0.5.1
* [`e48cd628`](https://github.com/NixOS/nixpkgs/commit/e48cd6280c5f26ddeb0d034be3a324577c34b4b9) krill: 0.9.4 -> 0.9.6
* [`3744a1ca`](https://github.com/NixOS/nixpkgs/commit/3744a1cace31338a2d0e4aa8381e635cce4644b3) mergerfs: 2.33.3 -> 2.33.5
* [`15e28e03`](https://github.com/NixOS/nixpkgs/commit/15e28e03bd00376ee822b5977e5f7b7435a1d5cd) hedgedoc-cli: fix `installPhase`, use `makeWrapper`.
* [`711fcadc`](https://github.com/NixOS/nixpkgs/commit/711fcadc67d6d9c923b721b8ccba9e1bac7953e4) nwg-drawer: 0.2.8 -> 0.3.0
* [`22408c49`](https://github.com/NixOS/nixpkgs/commit/22408c4919a585540a2871be2d03eb3e1d47759e) pico-sdk: 1.3.1 -> 1.4.0
* [`0ebc8394`](https://github.com/NixOS/nixpkgs/commit/0ebc83941c89b14463a888ec31f35c18a9d29128) pritunl-ssh: 1.0.1674.4 -> 1.0.2435.24
* [`1ba772e9`](https://github.com/NixOS/nixpkgs/commit/1ba772e96ec65f173058e922a0fdb22ec4bbae2f) prometheus-cpp: 1.0.0 -> 1.0.1
* [`722d9490`](https://github.com/NixOS/nixpkgs/commit/722d94902f5ffeacbbaef5efe4f92007278d940d) prometheus-json-exporter: 0.4.0 -> 0.5.0
* [`f5cec2c8`](https://github.com/NixOS/nixpkgs/commit/f5cec2c8145c486d14001befa65e399c16a9f8a5) qpdf: 10.6.2 -> 10.6.3
* [`79a2bf1b`](https://github.com/NixOS/nixpkgs/commit/79a2bf1b4f68df7a185383c1c9dc17f66c1d691a) rinutils: 0.10.0 -> 0.10.1
* [`7671d644`](https://github.com/NixOS/nixpkgs/commit/7671d6446dc8d7af7bbebffcab7823d0eb689716) rmapi: 0.0.19 -> 0.0.20
* [`3a41ccaf`](https://github.com/NixOS/nixpkgs/commit/3a41ccaf8c66299ae76558abe70d7e8182bbf237) rtrtr: 0.1.2 -> 0.2.2
* [`d5fa9f11`](https://github.com/NixOS/nixpkgs/commit/d5fa9f1119f618183a0564b2abd7dd8b36abedcd) semodule-utils: 3.3 -> 3.4
* [`ef3b83b8`](https://github.com/NixOS/nixpkgs/commit/ef3b83b808293519166e3e19c78e940dd3f2a02d) songrec: 0.3.0 -> 0.3.2
* [`bd164308`](https://github.com/NixOS/nixpkgs/commit/bd1643088335cf894cc9dc09050a30a3feaa57cd) emuflight-configurator: 0.4.0 -> 0.4.1
* [`c1a8b32d`](https://github.com/NixOS/nixpkgs/commit/c1a8b32d9de00eb351219520116f6b5d9dd09736) galene: 0.4.4 -> 0.5.5
* [`980ac95f`](https://github.com/NixOS/nixpkgs/commit/980ac95f2f735879c6057fc4bd3c0b1d4fd5ed3f) ibus-qt: 1.3.3 -> 1.3.4
* [`6171fee7`](https://github.com/NixOS/nixpkgs/commit/6171fee72955096348d4cc09cc7513923ed49673) streamlink-twitch-gui-bin: 2.0.0 -> 2.1.0
* [`bb846cbb`](https://github.com/NixOS/nixpkgs/commit/bb846cbbc384955ce5e9c52106f65d07b63f38e5) tegola: 0.15.0 -> 0.15.2
* [`06feb653`](https://github.com/NixOS/nixpkgs/commit/06feb653aaed8dd386f30191dd2d32e837f41072) tt-rss-theme-feedly: 2.9.1 -> 2.10.0
* [`acc7dd7c`](https://github.com/NixOS/nixpkgs/commit/acc7dd7cd946221e032769eb9bdd5fb25fcccfe4) python310Packages.cloup: 0.15.1 -> 1.0.0
* [`4d723006`](https://github.com/NixOS/nixpkgs/commit/4d723006964dd96c48cc8909146a029ecfdc21d8) wxsqlite3: 4.7.6 -> 4.8.2
* [`2abf10ca`](https://github.com/NixOS/nixpkgs/commit/2abf10ca211a6621a0148804e20077318cedada0) yubikey-touch-detector: 1.9.3 -> 1.10.0
* [`e580321b`](https://github.com/NixOS/nixpkgs/commit/e580321b984df7929e851f5e4ea3b515dd9df913) gsm: 1.0.19 -> 1.0.20
* [`0bba0f15`](https://github.com/NixOS/nixpkgs/commit/0bba0f15dc10d2c9a1ab19d3374f6a45f22f9748) gwyddion: 2.60 -> 2.61
* [`a3cb00e4`](https://github.com/NixOS/nixpkgs/commit/a3cb00e4b2eb44ec2cf2463cd109cf872b7a8582) isocodes: 4.9.0 -> 4.11.0
* [`223bf02e`](https://github.com/NixOS/nixpkgs/commit/223bf02ebea6caa7af055764c842532d51b83769) iw: 5.16 -> 5.19
* [`cbd6deeb`](https://github.com/NixOS/nixpkgs/commit/cbd6deeb809306d167341472b132a575cc22297f) ircdHybrid: 8.2.39 -> 8.2.41
* [`ac444f4b`](https://github.com/NixOS/nixpkgs/commit/ac444f4b87ec2d18d13111d68fb671895c504011) ibus-engines.bamboo: 0.7.7 -> 0.7.8
* [`e6927bd8`](https://github.com/NixOS/nixpkgs/commit/e6927bd8553da91c8ba5140eb4318aa0a5575890) inetutils: 2.2 -> 2.3
* [`a1901b9f`](https://github.com/NixOS/nixpkgs/commit/a1901b9fdb1544f094d51f052b740ed70da818b8) java-service-wrapper: 3.5.49 -> 3.5.50
* [`549e08c8`](https://github.com/NixOS/nixpkgs/commit/549e08c8e8a0e79952227c3300702d3d0fbb71a8) bintools-wrapper, cc-wrapper: avoid invalid export of 'expand-response-params'
* [`60abe56b`](https://github.com/NixOS/nixpkgs/commit/60abe56b089cba8a122148dd6555de08da170180) languagetool: 5.7 -> 5.8
* [`4697faa8`](https://github.com/NixOS/nixpkgs/commit/4697faa87a6d74b9f72a2ea222ba8ad15e0a89f6) libidn: 1.38 -> 1.41
* [`f9726225`](https://github.com/NixOS/nixpkgs/commit/f97262253e63640c018002cc6c4c185b8e691e16) kernelshark: 2.1.0 -> 2.1.1
* [`8e8bd997`](https://github.com/NixOS/nixpkgs/commit/8e8bd9977b2b54e20497915065f2c4dea3f7be22) libvpx: 1.11.0 -> 1.12.0
* [`37ad7e2f`](https://github.com/NixOS/nixpkgs/commit/37ad7e2f9849a3bd9558530cc9ae221526871245) mtools: 4.0.38 -> 4.0.40
* [`9ac84ad2`](https://github.com/NixOS/nixpkgs/commit/9ac84ad25fe4e08ed7a4dc1fe76a74b96b1ed404) mbuffer: 20211018 -> 20220418
* [`b5e7879c`](https://github.com/NixOS/nixpkgs/commit/b5e7879cd9634eb6201c6cc2692898a69a364f6d) marvin: 22.8.0 -> 22.13.0
* [`547a2d87`](https://github.com/NixOS/nixpkgs/commit/547a2d87d46bcce668b348875bcbcb5b9e140f37) ocamlPackages.markup: 1.0.2 -> 1.0.3
* [`4851b2f7`](https://github.com/NixOS/nixpkgs/commit/4851b2f7697d85ec7ef43617f568d03217a752ae) ocamlPackages.opus: 0.2.1 -> 0.2.2
* [`f08d168b`](https://github.com/NixOS/nixpkgs/commit/f08d168bdb9db573156219cb86d16cc526b68e91) ocamlPackages.ogg: 0.7.1 -> 0.7.2
* [`51ec59da`](https://github.com/NixOS/nixpkgs/commit/51ec59da173adb9a6eea12e31a85fbc78acc2a64) ocamlPackages.camlp-streams: 5.0 -> 5.0.1
* [`a3f0d914`](https://github.com/NixOS/nixpkgs/commit/a3f0d914033a3391fd23f8283dfcb2f9f69cd9f9) patchage: 1.0.4 -> 1.0.6
* [`1f241270`](https://github.com/NixOS/nixpkgs/commit/1f241270bff7a041c0eeb92ce03d3d0691805526) pciutils: 3.7.0 -> 3.8.0
* [`c5f89e27`](https://github.com/NixOS/nixpkgs/commit/c5f89e2711a1047124e8893645cb14510acb0082) openfortivpn: 1.17.2 -> 1.17.3
* [`aa06793c`](https://github.com/NixOS/nixpkgs/commit/aa06793cb4450b3ae1e9c60ad9d579245a4e78be) ovito: 3.7.1 -> 3.7.7
* [`0902f1d5`](https://github.com/NixOS/nixpkgs/commit/0902f1d59b02f79b1d3431702d987318cb3efbcb) onscripter-en: 20110930 -> 20111009
* [`b408d0f6`](https://github.com/NixOS/nixpkgs/commit/b408d0f602b63057c7d4b3c60d5de2afa113ca89) pulseaudio: 15.0 -> 16.1
* [`ecccd539`](https://github.com/NixOS/nixpkgs/commit/ecccd5395f4c34691a429604bb05083bf54a17db) python310Packages.pytest-httpserver: 1.0.4 -> 1.0.5
* [`780e0d69`](https://github.com/NixOS/nixpkgs/commit/780e0d69e7e840217548b43792e40c11c5ffa879) rssguard: 4.1.2 -> 4.2.3
* [`ecc304df`](https://github.com/NixOS/nixpkgs/commit/ecc304df445bae378c503d9c870683e4fdd45039) glib: add command man pages
* [`0cbedad0`](https://github.com/NixOS/nixpkgs/commit/0cbedad03fd3bb506158e1e4b7c93eb49a21c119) glib: move bash completions to right outputs
* [`3a41a77d`](https://github.com/NixOS/nixpkgs/commit/3a41a77d29ed062645045f0ae4e5e7a49d0c40b5) aws-c-io: 0.11.0 -> 0.11.2
* [`5ba34503`](https://github.com/NixOS/nixpkgs/commit/5ba345031630fa9278023cd3a493b061622cf8ce) aws-c-common: 0.7.0 -> 0.7.4
* [`7b3b1790`](https://github.com/NixOS/nixpkgs/commit/7b3b1790cab6aadb87d9148e710d8ad57c20f868) aws-c-event-stream: 0.2.7 -> 0.2.12
* [`ec591e72`](https://github.com/NixOS/nixpkgs/commit/ec591e72e7ef1531cc6dde0816bb77b724273aa4) aws-c-http: 0.6.15 -> 0.6.17
* [`bc3ef23c`](https://github.com/NixOS/nixpkgs/commit/bc3ef23c8dc84260794a383452953ccf9f869c70) aws-c-mqtt: 0.7.10 -> 0.7.11
* [`93bcddc2`](https://github.com/NixOS/nixpkgs/commit/93bcddc2f8ff548a63d6ac3085c101cee3df47dc) aws-c-s3: 0.1.39 -> 0.1.43
* [`6e701d7c`](https://github.com/NixOS/nixpkgs/commit/6e701d7c442b595677f24d2ffbefadbbf1252023) aws-crt-cpp: 0.17.28 -> 0.17.32
* [`2e84bb97`](https://github.com/NixOS/nixpkgs/commit/2e84bb9740460f4b7a961ca8a5f8cd9332d6d919) aws-sdk-cpp: 1.9.238 -> 1.9.294
* [`921b8174`](https://github.com/NixOS/nixpkgs/commit/921b81745d34d07c767d2d0c32623b83126314e8) SPAdes: 3.15.4 -> 3.15.5
* [`2aefcbca`](https://github.com/NixOS/nixpkgs/commit/2aefcbcab39bff7713e7ab16c174a821868d7931) speexdsp: 1.2.0 -> 1.2.1
* [`7675a78e`](https://github.com/NixOS/nixpkgs/commit/7675a78e191be83dd989cce6a9633cee450a3530) stm32cubemx: 6.5.0 -> 6.6.1
* [`ccd27a93`](https://github.com/NixOS/nixpkgs/commit/ccd27a930e23d8e8fedf5c4c25b5e07da2a6f438) x42-plugins: 20220327 -> 20220714
* [`ab7fd187`](https://github.com/NixOS/nixpkgs/commit/ab7fd187bcedcbb1febe0ba253b16098958887e9) vmpk: 0.8.6 -> 0.8.7
* [`bc569904`](https://github.com/NixOS/nixpkgs/commit/bc569904fe9e47a8c029c19102f3a28506a73de8) yquake2: 8.01 -> 8.10
* [`f22cd644`](https://github.com/NixOS/nixpkgs/commit/f22cd644b0e573bc041c4e4ed9f759711ef0b6d8) aws-c-auth: 0.6.13 -> 0.6.14
* [`c06d389e`](https://github.com/NixOS/nixpkgs/commit/c06d389e4203b7ebaeee30eb7c87f41efdf07b64) aws-c-http: 0.6.17 -> 0.6.19
* [`fd031c02`](https://github.com/NixOS/nixpkgs/commit/fd031c029969f8efdc1b39d37cbafa252f9d9d0b) pulseaudio: add darwin support
* [`60514b55`](https://github.com/NixOS/nixpkgs/commit/60514b555d16027ba4f12da72291747e37f38f5d) libcanberra: fix build on darwin
* [`aac52a92`](https://github.com/NixOS/nixpkgs/commit/aac52a923f909ca282e4f63e3860973e4eb61594) gsound: add darwin support
* [`64164a5b`](https://github.com/NixOS/nixpkgs/commit/64164a5b3806b7c94f6fa68a9111c0780ff6e07a) python310Packages.Nikola: 8.2.2 -> 8.2.3
* [`68647c00`](https://github.com/NixOS/nixpkgs/commit/68647c002a9e7697fa3d6d881ef309e8bf065377) wvkbd: 0.7 -> 0.9
* [`ff630bdc`](https://github.com/NixOS/nixpkgs/commit/ff630bdc67ac5135ecd679c96fe51395dca5467e) liblqr1: split outputs
* [`4eb32471`](https://github.com/NixOS/nixpkgs/commit/4eb32471e07342a43d9c0f11a387fa525e7e0a4c) libjxl: split outputs
* [`fde348bb`](https://github.com/NixOS/nixpkgs/commit/fde348bb4adc3b45299cadb59a94e725319ad462) vtm: 0.7.6 -> 0.8.0
* [`c7b38c87`](https://github.com/NixOS/nixpkgs/commit/c7b38c877b74ec690336f582c4eaa2cabaa1206a) zprint: 1.2.3 -> 1.2.4
* [`b1b8f456`](https://github.com/NixOS/nixpkgs/commit/b1b8f456a15561ed92a1ee35f290741b8a7b8b96) libevdev: 1.12.1 -> 1.13.0
* [`1d20aa4b`](https://github.com/NixOS/nixpkgs/commit/1d20aa4bf5a68c9440d6a3ec2f12d36ca97e1b85) python39Packages.easy-thumbnails: 2.8.1 -> 2.8.3
* [`c817efe6`](https://github.com/NixOS/nixpkgs/commit/c817efe660f035b5533b45fb9ba9962e65fe5209) gcc: extend stripping of .a libraries and .o objects
* [`a454a706`](https://github.com/NixOS/nixpkgs/commit/a454a706b584fa5c6583ecd8071b662caaedd9ca) shutdown: Protect system from make-initrd-ng
* [`86a160ea`](https://github.com/NixOS/nixpkgs/commit/86a160ea18b661c8bc59c0e359dc1cb13241c675) buku: fix build failing for bukuserver
* [`61a1465e`](https://github.com/NixOS/nixpkgs/commit/61a1465e26dbcf9941c6e035b7d9a3b476b315a1) buku: fix check inputs and remove PYTHONIOENCODING hack
* [`6122297e`](https://github.com/NixOS/nixpkgs/commit/6122297eab17cd48b364ecb25c622d864e28f98f) pkgs/stdenv/linux: update powerpc64le bootstrap-files
* [`cbc80ff3`](https://github.com/NixOS/nixpkgs/commit/cbc80ff32b7c827f6a780688f251a6d592a873d5) gcc: add linkLib32toLib to create lib32->lib links
* [`dfba0bf9`](https://github.com/NixOS/nixpkgs/commit/dfba0bf93b716a72b107fd182e01e5ba859dc013) gcc: do not create lib64->lib links on mips64n32
* [`a6daffb1`](https://github.com/NixOS/nixpkgs/commit/a6daffb11876769af3f079a37516c1832048b9ea) gcc: factor out $linkLib64toLib, move it from bash to nix
* [`eb99d7f9`](https://github.com/NixOS/nixpkgs/commit/eb99d7f93727026e710f773809b2e8239b33fbc8) ymuse: init at 0.20
* [`dca493fe`](https://github.com/NixOS/nixpkgs/commit/dca493fe1d6457d0f4f9cddacfc921c5e31b9592) sqlcipher: 4.5.1 -> 4.5.2
* [`b1094917`](https://github.com/NixOS/nixpkgs/commit/b109491732c7f35c1a81bf244795be6076b7b0ad) system76-firmware: 1.0.39 -> 1.0.42
* [`6d774530`](https://github.com/NixOS/nixpkgs/commit/6d7745301842659de7a36e907a3974b9bd48df1c) plecost: init at 1.1.4
* [`f4012060`](https://github.com/NixOS/nixpkgs/commit/f4012060a37b8b5c897e08b724334aa9f649cf0e) ibus-engines.m17n: 1.4.9 -> 1.4.10
* [`b3b672d5`](https://github.com/NixOS/nixpkgs/commit/b3b672d5a16a0e99dc112b9f65436555b11c3ab7) setup-hooks/separate-debug-info.sh: don't inhibit strip hook
* [`c8f7a21e`](https://github.com/NixOS/nixpkgs/commit/c8f7a21ea26eafc7fc49712d560cd72cd09357c1) zlib: add patch for CVE-2022-37434
* [`f0eb20ae`](https://github.com/NixOS/nixpkgs/commit/f0eb20ae862586a44d6473c2a5bcff82badf2dfe) libgpg-error: 1.42 -> 1.45 ([nixos/nixpkgs⁠#185541](https://togithub.com/nixos/nixpkgs/issues/185541))
* [`717e7bd2`](https://github.com/NixOS/nixpkgs/commit/717e7bd2919620e06e3c97154216d68c28276c0b) tree-sitter: strip only debug info by default
* [`1ed23120`](https://github.com/NixOS/nixpkgs/commit/1ed23120107c6b4bb36a8c8b8ddd3aafc543ffeb) onetun: init at 0.3.3
* [`c9c802df`](https://github.com/NixOS/nixpkgs/commit/c9c802dfd8de386698ce97fde995fcca0cf14e9e) gnutls: 3.7.6 -> 3.7.7, fix CVE-2022-2509
* [`3d2ae0fb`](https://github.com/NixOS/nixpkgs/commit/3d2ae0fbb4761067d7110b55cead69246e3f98e8) python39Packages.web3.py: init at 5.30.0
* [`d65fdad9`](https://github.com/NixOS/nixpkgs/commit/d65fdad9d1666b565957fdb010be1494f80c0a8e) python3Packages.folium: fix build
* [`1813cd92`](https://github.com/NixOS/nixpkgs/commit/1813cd922f331050a9e88de8f98e3fb54ffe6e9f) python3Packages.osmnx: 1.2.0 → 1.2.2
* [`4ed8247e`](https://github.com/NixOS/nixpkgs/commit/4ed8247e1bf59829a4c2d68748900b0fe35a5a58) Vulkan: 1.3.211.0 -> 1.3.216.0
* [`d5aaf150`](https://github.com/NixOS/nixpkgs/commit/d5aaf15094e607fa87d04486d41db4e771c200fb) Revert "zlib: add patch for CVE-2022-37434"
* [`597b9502`](https://github.com/NixOS/nixpkgs/commit/597b9502cbb8bdacb3bfc8d401ed310871685dfc) gnu-efi: 3.0.14 -> 3.0.15
* [`5323fa88`](https://github.com/NixOS/nixpkgs/commit/5323fa886e74e3d2195b3c962a6b14029d3c1e6f) zlib: remove superfluous patch files
* [`d56d587e`](https://github.com/NixOS/nixpkgs/commit/d56d587e855d762dab920a5a537ee317c066952b) zlib: add fixed patch for CVE-2022-37434
* [`ff3cb21d`](https://github.com/NixOS/nixpkgs/commit/ff3cb21db78a9de3babe3b09d15d2d6259f11e64) python3Packages.sqlalchemy: 1.4.39 -> 1.4.40
* [`e3d4450e`](https://github.com/NixOS/nixpkgs/commit/e3d4450eff5e6a7044311fbd3d7e162b2d68289c) libwebp: 1.2.3 -> 1.2.4
* [`c1b8900c`](https://github.com/NixOS/nixpkgs/commit/c1b8900cb9b5f249802fa8cb8673cf2c09088bfe) python3Packages.recursivePthLoader: fix cross compilation
* [`e1a75d08`](https://github.com/NixOS/nixpkgs/commit/e1a75d080ee2a9e6c6e144e8ccca0d7a76c7ed1c) libtirpc: 1.2.7-rc4 -> 1.3.3, fix CVE-2021-46828
* [`3bb4b724`](https://github.com/NixOS/nixpkgs/commit/3bb4b724b46a46af0fb04946b8f9d150f1c8eb4d) python310Packages.pybind11: 2.9.2 -> 2.10.0
* [`9ea21918`](https://github.com/NixOS/nixpkgs/commit/9ea219186dc0ddc0e538ded443a4072e50078159) apparmor: 3.0.4 -> 3.0.7
* [`a42db97e`](https://github.com/NixOS/nixpkgs/commit/a42db97eb7cad4ec7df7ed9dc5e50131ad12db0f) vim: 9.0.0135 -> 9.0.0180 and replace inactive maintainer
* [`984fc1a1`](https://github.com/NixOS/nixpkgs/commit/984fc1a18ba84e22b8c4d53ac7036c5eca528335) mpvpaper: init at 1.2.1
* [`8f9fefa9`](https://github.com/NixOS/nixpkgs/commit/8f9fefa98be860c3997c375eec6719f987438c92) python3Packages.sphinx: 5.0.2 -> 5.1.1
* [`fc5ade9c`](https://github.com/NixOS/nixpkgs/commit/fc5ade9c4c0d102471fc0a746b5dc2ffd1a8e929) python3Packages.sphinx-autodoc-typehints: 1.19.1 -> 1.19.2
* [`277164ef`](https://github.com/NixOS/nixpkgs/commit/277164ef6c39b1639a7b5d4f917c562f16219c20) claws-mail: fix build with perl 5.36+
* [`aba6e724`](https://github.com/NixOS/nixpkgs/commit/aba6e72405707fd4c857d72cd5ff54b84c648455) memtier-benchmark: 1.3.0 -> 1.4.0
* [`1253ce60`](https://github.com/NixOS/nixpkgs/commit/1253ce601393f6ee2d05f7831d614ef3eb2f4974) libnftnl: 1.2.2 -> 1.2.3
* [`7659f31d`](https://github.com/NixOS/nixpkgs/commit/7659f31d69e512e19e1242c79f73227b69e2b8c5) systemd: 251.3 -> 251.4
* [`9be211b6`](https://github.com/NixOS/nixpkgs/commit/9be211b6a7ff658426fe9a12515663387b7b9c62) gst_all_1: 1.20.1 -> 1.20.3, fix CVE-2022-(192[0-5]|2122)
* [`54a173c0`](https://github.com/NixOS/nixpkgs/commit/54a173c0c1b67783b4ae09f309330b9746e1e548) gpgme: 1.17.1 -> 1.18.0
* [`8dd1594d`](https://github.com/NixOS/nixpkgs/commit/8dd1594d04bd0e208241ce44c78109f3b2a10cb1) gamescope: rename libseat to seatd
* [`335a7492`](https://github.com/NixOS/nixpkgs/commit/335a7492c0f000489cff0cce45bf2fa8c53ae6d1) mesa: 22.1.4 -> 22.1.6; patch darwin instead of freezing version
* [`ba541afc`](https://github.com/NixOS/nixpkgs/commit/ba541afca3eaec1424035843807d4a683f5cae11) nftables: 1.0.4 -> 1.0.5
* [`b18abe34`](https://github.com/NixOS/nixpkgs/commit/b18abe34031486381206e71b27209480d23de131) element-{web,desktop}: use stdenv.mkDerivation
* [`8c63b2f4`](https://github.com/NixOS/nixpkgs/commit/8c63b2f4f3fa67bfe0f87175bf9428ba0c709c26) python310Packages.setuptools-rust: 1.4.1 -> 1.5.0
* [`993dde13`](https://github.com/NixOS/nixpkgs/commit/993dde135fa5cc3622b6f4293f80acc3e6dc4de0) postgresql: sha256 -> hash
* [`c9aa86be`](https://github.com/NixOS/nixpkgs/commit/c9aa86be1159c8a3ac949387dc8c505383c443d4) postgresql_14: 14.4 -> 14.5
* [`40596367`](https://github.com/NixOS/nixpkgs/commit/4059636757ad2bdc9dcaac3e529cc7006d6ad50e) postgresql_13: 13.7 -> 13.8
* [`2793fbe7`](https://github.com/NixOS/nixpkgs/commit/2793fbe755d72d1cc5fa236d0d3764e3367a284b) postgresql_12: 12.11 -> 12.12
* [`d1213d3d`](https://github.com/NixOS/nixpkgs/commit/d1213d3dc8ade1eaa7c369b6c9628393ab2e2842) postgresql_11: 11.16 -> 11.17
* [`6d980c0d`](https://github.com/NixOS/nixpkgs/commit/6d980c0d8b9e9de643e5a153ef55d013e8746ecb) postgresql_10: 10.21 -> 10.22
* [`619489a2`](https://github.com/NixOS/nixpkgs/commit/619489a2b9eeb18c326c5fee6fc43a91b449a329) python310Packages.ddt: 1.5.0 -> 1.6.0
* [`b5709883`](https://github.com/NixOS/nixpkgs/commit/b57098835729f0117f84a31294dfb78b6fbe263b) gitkraken: 8.6.0 -> 8.8.0
* [`9a2f75fc`](https://github.com/NixOS/nixpkgs/commit/9a2f75fc98b43de8dfdb5fa9cebfeaba9e9ebc31) tutanota-desktop: 3.98.17 -> 3.98.20
* [`d9972a62`](https://github.com/NixOS/nixpkgs/commit/d9972a62eb33f8f5f69bb223f298c53f3e2af84c) rubygems: 3.2.26 -> 3.3.20
* [`b171096a`](https://github.com/NixOS/nixpkgs/commit/b171096af9bd881274f0bea5411c7368ff8103e3) ruby: update railsexpress patchset
* [`b0447f04`](https://github.com/NixOS/nixpkgs/commit/b0447f04cbf62a70c560d75b2d8161fbcf856f23) ruby: remove deprecated passthru variables
* [`0565bd8b`](https://github.com/NixOS/nixpkgs/commit/0565bd8b591ffc1985b00d3581509b819116a82e) ruby: update meta
* [`59dd915c`](https://github.com/NixOS/nixpkgs/commit/59dd915c110fad911067c18aaffb53ac75b99015) rustc: 1.62.1 -> 1.63.0
* [`af21e11d`](https://github.com/NixOS/nixpkgs/commit/af21e11d3f2618b848969c4f888a392f24580c19) llvmPackages_latest: 13 -> 14
* [`a7eb0a18`](https://github.com/NixOS/nixpkgs/commit/a7eb0a180b054e57b597528d92826f578b17bd36) darwin.Libsystem: add missing modulemaps
* [`a4a300df`](https://github.com/NixOS/nixpkgs/commit/a4a300dfffa7f3fff348d22dda3ddd5abcfa62a2) meson: 0.61.2 → 0.62.2
* [`e474134e`](https://github.com/NixOS/nixpkgs/commit/e474134ea0b474c29a9644b2fa09b35fabc060fb) meson: 0.62.2 → 0.63.0
* [`e8d794e3`](https://github.com/NixOS/nixpkgs/commit/e8d794e3197d64ed5e999d2c63e6efdda6ee3b57) libjpeg: 2.1.3 -> 2.1.4
* [`1557ff44`](https://github.com/NixOS/nixpkgs/commit/1557ff44fd1b86232742c5bdf423733236a12a15) cifs-utils: 6.15 -> 7.0
* [`46f98c15`](https://github.com/NixOS/nixpkgs/commit/46f98c157dceb3c6004388e7a92766c211e28ac8) tzdata: 2022a -> 2022b
* [`3133c979`](https://github.com/NixOS/nixpkgs/commit/3133c979f9a432af01679a277c6b042309f3def0) harePackages.hare: fix evaluation for riscv
* [`123cb930`](https://github.com/NixOS/nixpkgs/commit/123cb930b3dee4d56a1924d1c33699c7b329af44) evcxr: 0.12.0 -> 0.13.0
* [`fb7811bf`](https://github.com/NixOS/nixpkgs/commit/fb7811bf03398ced5cada7476e089a417db5c962) rustc: use autoPatchelfHook for bootstrap binaries
* [`0a9c3640`](https://github.com/NixOS/nixpkgs/commit/0a9c3640d319a284095bbd53214c92d7a99c1c2a) rustc: set crt-static flag
* [`202524dd`](https://github.com/NixOS/nixpkgs/commit/202524ddf7e3a6931fd245ca0cbe959cd19769e3) rustc: remove broken flag for musl
* [`acf9dd62`](https://github.com/NixOS/nixpkgs/commit/acf9dd62386cda3dbcaf8603ce57f8caac7effee) cargo: add broken flag for musl
* [`66ac47bd`](https://github.com/NixOS/nixpkgs/commit/66ac47bdf6aa5d46678ae82802fe06f7376a22cc) cargoSetupHook: remove unneeded rustflags for aarch64+static cross
* [`51c62063`](https://github.com/NixOS/nixpkgs/commit/51c62063e366d14e4353c85f22adb085330b9684) cargoSetupHook: set crt-static
* [`a67c5f82`](https://github.com/NixOS/nixpkgs/commit/a67c5f82c0558147c9310a45d2dd450095cc2a83) python3.pkgs.pyelftools: skip tests on non-glibc targets
* [`ee7dd02f`](https://github.com/NixOS/nixpkgs/commit/ee7dd02fa146015db05276240f9bf76b3ebdef02) aeon: 0.14.1.0 -> 0.14.2.2
* [`a5fc2ede`](https://github.com/NixOS/nixpkgs/commit/a5fc2ede43716c792879dc7a320c904b7b81b825) cloud-sql-proxy: 1.30.0 -> 1.31.2
* [`2e4cf931`](https://github.com/NixOS/nixpkgs/commit/2e4cf931aaa7c51e1b6635713ef42b0199b199d5) corectrl: 1.2.4 -> 1.2.7
* [`73b3b950`](https://github.com/NixOS/nixpkgs/commit/73b3b950bd47a4a88cccb3979d1ebc13b8f12706) cargo-insta: 1.15.0 -> 1.18.1
* [`35e2da1d`](https://github.com/NixOS/nixpkgs/commit/35e2da1d663590bebf4991addd941b36c31acebd) ddccontrol-db: 20220414 -> 20220720
* [`4e817e1d`](https://github.com/NixOS/nixpkgs/commit/4e817e1d1a7f1e4c794e2a485feab9c1e04bb7ce) fetchmail: 6.4.30 -> 6.4.32
* [`2645812e`](https://github.com/NixOS/nixpkgs/commit/2645812e7957e19ee4989eeb72a2c496c6d49abd) flrig: 1.4.5 -> 1.4.7
* [`39818451`](https://github.com/NixOS/nixpkgs/commit/39818451f4d491cf4693341d7c843e4ccd32ca77) faudio: 22.04 -> 22.08
* [`e8fbb38a`](https://github.com/NixOS/nixpkgs/commit/e8fbb38a51380fe6e56351b5750dddcccff79c4c) pythonPackages.unittestCheckHook: init
* [`19adc334`](https://github.com/NixOS/nixpkgs/commit/19adc3341cf3adfdbd408646aedbf8e62ce3eece) treewide: migrate to pythonPackages.unittestCheckHook
* [`cf206e9d`](https://github.com/NixOS/nixpkgs/commit/cf206e9d000c2be75a7fa23d5cf96df6d3cce477) gcc11: pick up bugfixes for darwin-aarch64
* [`69f3e761`](https://github.com/NixOS/nixpkgs/commit/69f3e761d69f25d097f24e4a573a0b8aaf85c58c) harfbuzz: 5.0.1 -> 5.1.0
* [`ad21bc4e`](https://github.com/NixOS/nixpkgs/commit/ad21bc4efb392942c4556172111cd22323171680) foxotron: 2022-03-06 -> 2022-08-06
* [`19e1a68f`](https://github.com/NixOS/nixpkgs/commit/19e1a68fec59f389a422ea5dedcf26c9bd1048c8) pspg: 5.5.4 -> 5.5.6
* [`066177e5`](https://github.com/NixOS/nixpkgs/commit/066177e5a95af2dcdf26d701bc1c93f2630c61b9) qtstyleplugin-kvantum-qt4: 1.0.1 -> 1.0.4
* [`2dc14118`](https://github.com/NixOS/nixpkgs/commit/2dc141182b5388c57846cfb220665f02caf5622d) ryzenadj: 0.10.0 -> 0.11.1
* [`7cb13910`](https://github.com/NixOS/nixpkgs/commit/7cb13910efd7f2d613c89a7c480b042d47d2f688) s3-credentials: 0.12.1 -> 0.13
* [`aa97ee8b`](https://github.com/NixOS/nixpkgs/commit/aa97ee8bfaf6bf2aea56a0a1e904aa8eb909bf6e) sameboy: 0.14.7 -> 0.15.4
* [`9c115694`](https://github.com/NixOS/nixpkgs/commit/9c1156941e9ac15e8d0e66468a412b967264cdc7) sensu-go-agent: 6.6.6 -> 6.7.5
* [`2c77e973`](https://github.com/NixOS/nixpkgs/commit/2c77e973885f95b900d10fc5546e4511e633379b) sensu-go-backend: 6.6.6 -> 6.7.5
* [`95898d79`](https://github.com/NixOS/nixpkgs/commit/95898d794e963265790ac427f7c1566356609b19) sensu-go-cli: 6.6.6 -> 6.7.5
* [`effe5d44`](https://github.com/NixOS/nixpkgs/commit/effe5d44ddfdd2877e485e053f1c68314334e2fe) serfdom: 0.9.8 -> 0.10.0
* [`c20092f8`](https://github.com/NixOS/nixpkgs/commit/c20092f87855c6f92f1bad20203b2631a6a97b6f) git: 2.37.1 -> 2.37.2
* [`f6b43797`](https://github.com/NixOS/nixpkgs/commit/f6b4379720f4ffd404aed6b2ae295b0ca45537ae) python310Packages.pypinyin: 0.46.0 -> 0.47.0
* [`a516c3c1`](https://github.com/NixOS/nixpkgs/commit/a516c3c1a3b2e6e5dd412935a9c19430b09c35b6) xcbuild: implement additional xcrun flags
* [`7450d599`](https://github.com/NixOS/nixpkgs/commit/7450d599d0b8860780d3fdfbb12d8b469be572bd) xcbuild: allow using xcrun separately
* [`f53a48bd`](https://github.com/NixOS/nixpkgs/commit/f53a48bd190e8a052a2a5c60bae2f1cfc22df6bd) xcbuild: reject invalid xcrun sdk name
* [`e15d8744`](https://github.com/NixOS/nixpkgs/commit/e15d874463adba4f953f5ebe3f8c7c00579e4a60) tesseract5: 5.1.0 -> 5.2.0
* [`211fdaa0`](https://github.com/NixOS/nixpkgs/commit/211fdaa087a98b0eb3b2ba04ab22d3eca555a89b) treewide: bundlerApp makeWrapper buildInputs -> nativeBuildInputs
* [`2fe86cc2`](https://github.com/NixOS/nixpkgs/commit/2fe86cc267b5637b73602b3e30a9d1eea8e5ecc9) cabal2nix: fix cross-eval
* [`21c671e1`](https://github.com/NixOS/nixpkgs/commit/21c671e14ec5038ff052920680e0031d8e7bb2d7) wakatime: 1.38.0 -> 1.53.4
* [`93841d5a`](https://github.com/NixOS/nixpkgs/commit/93841d5a4996f7313885c215ebb51c179ee8c4d5) x11docker: 7.1.4 -> 7.4.2
* [`f95d9a66`](https://github.com/NixOS/nixpkgs/commit/f95d9a668efd28bd867709b60ed72335d0964f28) pkgsMusl.polkit: fix build
* [`53b36c9c`](https://github.com/NixOS/nixpkgs/commit/53b36c9c5b9a4a02860e114807f692432dccff87) cryptsetup: skip tests on musl
* [`358b1aa4`](https://github.com/NixOS/nixpkgs/commit/358b1aa4f31923aeab48c903b7133a9f64be79e1) invidious: unstable-2022-07-10 -> unstable-2022-08-13
* [`ad0cd6e5`](https://github.com/NixOS/nixpkgs/commit/ad0cd6e56a9a469edfbc77242b0bac8783e8e9b4) cryptsetup: 2.4.3 -> 2.5.0 ([nixos/nixpkgs⁠#186249](https://togithub.com/nixos/nixpkgs/issues/186249))
* [`9cad3c27`](https://github.com/NixOS/nixpkgs/commit/9cad3c278999b073098e140cfe983eaf8be7659b) pinentry-mac: 0.9.4 -> 1.1.1.1
* [`8ff6f668`](https://github.com/NixOS/nixpkgs/commit/8ff6f668888503babab8737ccdf8db8d16f0c3c7) heimer: 3.2.0 -> 3.5.0
* [`7a49222e`](https://github.com/NixOS/nixpkgs/commit/7a49222e122141ec204d129894d260b764129386) icinga2-agent: 2.13.3 -> 2.13.5
* [`3cc71806`](https://github.com/NixOS/nixpkgs/commit/3cc71806a96286c4037688c8910a8bd4abedba4e) slang: 2.3.2 -> 2.3.3
* [`dc78b636`](https://github.com/NixOS/nixpkgs/commit/dc78b6368e1fe0e5ff9e718540209c80f322024e) jbang: 0.92.2 -> 0.97.0
* [`55cb9c8b`](https://github.com/NixOS/nixpkgs/commit/55cb9c8bffb9b3770b985f8b8d23d95565e0b119) jftui: 0.5.1 -> 0.6.0
* [`ea4892bc`](https://github.com/NixOS/nixpkgs/commit/ea4892bc4204148bb9ba234dd55da089d34ebd32) juju: 2.9.31 -> 2.9.33
* [`96c5cdbe`](https://github.com/NixOS/nixpkgs/commit/96c5cdbefe26d8f9c3459d7f36afd42ee97d6836) kak-lsp: 12.2.0 -> 13.0.0
* [`a65ad5de`](https://github.com/NixOS/nixpkgs/commit/a65ad5de3101b26877d6bf62aa72cda2409fd21e) keycloak: 18.0.0 -> 19.0.1
* [`e760223f`](https://github.com/NixOS/nixpkgs/commit/e760223faa7d65cb0294edd44bde757e2be89b35) iproute: 5.18.0 -> 5.19.0
* [`8dc61765`](https://github.com/NixOS/nixpkgs/commit/8dc617656b5071253730fadcdb3d097375c7cb7d) konstraint: 0.20.0 -> 0.23.0
* [`0e775e7c`](https://github.com/NixOS/nixpkgs/commit/0e775e7c0163582c649192556ba90d67a843d76f) kube-router: 1.4.0 -> 1.5.1
* [`181ab967`](https://github.com/NixOS/nixpkgs/commit/181ab9671ad666514afdff216ac13ad60e8c6dd2) kubelogin: 0.0.11 -> 0.0.20
* [`29075f8e`](https://github.com/NixOS/nixpkgs/commit/29075f8e06bc74d9a7bb1726fa165dfb979f499f) klayout: 0.27.8 -> 0.27.11
* [`36efb08d`](https://github.com/NixOS/nixpkgs/commit/36efb08db4fd6168ff2b38dea4dac50c6143c219) mycorrhiza: 1.9.0 -> 1.11.0
* [`6130491c`](https://github.com/NixOS/nixpkgs/commit/6130491cdf2ab4ceceeea8c07bbaf1d02080374a) openhantek6022: 3.2.5 -> 3.3.1
* [`b2db8358`](https://github.com/NixOS/nixpkgs/commit/b2db8358f9125efbc56887740c3d90c58e6e77bb) python310Packages.orjson: 3.7.8 -> 3.7.12
* [`2f51f9b7`](https://github.com/NixOS/nixpkgs/commit/2f51f9b7480caa5547d8efe0b07f3c2cd38bd6a7) python3Packages.psycopg: package pool and c variants
* [`803c5636`](https://github.com/NixOS/nixpkgs/commit/803c563622007fab4f727a8e7265c90674b61cba) python3Packages.psycopg: disable test_sched{,_error} on darwin
* [`c0ce2f30`](https://github.com/NixOS/nixpkgs/commit/c0ce2f3070210e38d1883f250584eb4f70462d86) wxGTK31-gtk2: 3.1.5 -> 3.2.0
* [`a8c50530`](https://github.com/NixOS/nixpkgs/commit/a8c50530fc5d9ea950bd8bb0120a4b77c5dac2ce) systemd: Enable oomd by default
* [`70bffb6e`](https://github.com/NixOS/nixpkgs/commit/70bffb6ec1a434b69ad02fd694fa3d3d2cf1aa7b) harfbuzz: fix aarch64-linux build by upstream patch
* [`afb4471a`](https://github.com/NixOS/nixpkgs/commit/afb4471ac3fcddbcd73e47eb397f309416caf6a5) gjs: 1.72.1 -> 1.72.2
* [`e442c908`](https://github.com/NixOS/nixpkgs/commit/e442c9084ba66e37a63c79ece5c27537778f5f50) meson: 0.63.0 → 0.63.1
* [`f5a02eb8`](https://github.com/NixOS/nixpkgs/commit/f5a02eb84e626f6401b7e0a732b3a2275ceb539f) archivebox: use hash instead of sha256
* [`b632dba0`](https://github.com/NixOS/nixpkgs/commit/b632dba0985cf840358cbec6b0444b97c4f23821) charm: 0.12.3 -> 0.12.4
* [`febb86fd`](https://github.com/NixOS/nixpkgs/commit/febb86fd6c304f035c3cf52e091368a2a0586143) python3Packages.pydantic: 1.9.1 -> 1.9.2
* [`22f88666`](https://github.com/NixOS/nixpkgs/commit/22f88666343154dc36bce43db9e8d1cc36725028) python310Packages.scikit-fmm: 2022.3.26 -> 2022.8.15
* [`c53649f2`](https://github.com/NixOS/nixpkgs/commit/c53649f2f2ebd203d74be4df8b243f40318bbe25) python310Packages.zcs: 0.1.18 -> 0.1.21
* [`26fcb83b`](https://github.com/NixOS/nixpkgs/commit/26fcb83b996b0c9d3dcb0d662a4b848f5edf3890) openexr: 2.5.7 -> 2.5.8
* [`047f694b`](https://github.com/NixOS/nixpkgs/commit/047f694bbb4f46b71ea47c994718fa64cd69ae11) openexr*: Fix statically building
* [`90bb9606`](https://github.com/NixOS/nixpkgs/commit/90bb9606027b06cbbf4933b8936d8ba21bdc59d9) gperftools: 2.9.1 -> 2.10
* [`90b0c0b7`](https://github.com/NixOS/nixpkgs/commit/90b0c0b742d93c4e36b1af60e6d4bf126347a9b2) gperftools: remove libunwind when building statically
* [`4b4ee5af`](https://github.com/NixOS/nixpkgs/commit/4b4ee5af9c4bb97b2028c390e2c3897ad361ef45) libwebp: don't patch shebangs
* [`70ec0e7e`](https://github.com/NixOS/nixpkgs/commit/70ec0e7ec4bc889ba6518fbe382a9c1a3cad6619) giflib: Remove xml dependencies
* [`875d77ca`](https://github.com/NixOS/nixpkgs/commit/875d77ca0328df20cb4db308b29ef77bb25749d8) lib/systems: Add staticLibrary and library
* [`4dbf8f69`](https://github.com/NixOS/nixpkgs/commit/4dbf8f6915596e54bb6610045ad484b594eb30fb) libhwy: fix tests when cross-compiling
* [`0628889e`](https://github.com/NixOS/nixpkgs/commit/0628889e6684702f053f1b7ca07de02e5bbfebb8) libjxl: Fix static compilation
* [`0e2a3681`](https://github.com/NixOS/nixpkgs/commit/0e2a36815d2310886458ac1aab14350160e6b12a) go: refactor bootstrap
* [`cec343a1`](https://github.com/NixOS/nixpkgs/commit/cec343a18996b21986a1480489b7929473a1f427) go: remove checkPhase
* [`8eadecd9`](https://github.com/NixOS/nixpkgs/commit/8eadecd9bfdd8f35ab9c49f7b3e50a4e2ed76cfc) go: prePatch -> postPatch
* [`6285da30`](https://github.com/NixOS/nixpkgs/commit/6285da30c01e93affb30c576ac9b01dd76c4a14d) go: remove outdated seds
* [`4fd2bcb0`](https://github.com/NixOS/nixpkgs/commit/4fd2bcb0fee6f737421c005d6d02a74a9132e7e0) go: convert seds to substitute patches
* [`1b031d9a`](https://github.com/NixOS/nixpkgs/commit/1b031d9a350e7c8f50c4839b6442ca3735a9b3b9) go: drop ssl cert patch
* [`40a0f3ac`](https://github.com/NixOS/nixpkgs/commit/40a0f3acb35ee1955054af965a880f2d2609658b) go: remove hardeningDisable
* [`0ec77e3f`](https://github.com/NixOS/nixpkgs/commit/0ec77e3f738cdc6bc627ddb4fcc7896a8b5adf5e) go: move xcbuild to depsTargetTargetPropagated
* [`0197bfee`](https://github.com/NixOS/nixpkgs/commit/0197bfeeea226fdcdf8286079e59c9867b14af66) go: merge postConfigure/postBuild into empty buildPhase
* [`924206c3`](https://github.com/NixOS/nixpkgs/commit/924206c3682ce72020d803d3e660f3649b729f05) go: remove unneeded inputs
* [`bf9a88db`](https://github.com/NixOS/nixpkgs/commit/bf9a88db617fed06a6303373bbdc9201a36b1b8b) go: add smoke test to passthru
* [`8a03bcaa`](https://github.com/NixOS/nixpkgs/commit/8a03bcaa1bd6ef8d61fe1f5df9d5e6c734004f4b) nodePackages.orval: init at 6.9.6
* [`8344f3e8`](https://github.com/NixOS/nixpkgs/commit/8344f3e888ce844612578c6d19bf2d95f9547a6b) cdmemu: fix cross eval
* [`2f27d033`](https://github.com/NixOS/nixpkgs/commit/2f27d033805fdb0b619bad6316d6228662947712) nodePackages: fix cross-eval of overrides.nix
* [`8ba9b8be`](https://github.com/NixOS/nixpkgs/commit/8ba9b8bed612b9624d0cc03b532a879aebc2b7ce) node-packages.json: unformat file
* [`c6568adb`](https://github.com/NixOS/nixpkgs/commit/c6568adb005175fb77ef94fee09aa4e8cc248a60) treewide: makeWrapper buildInputs to nativeBuildInputs
* [`f97c3252`](https://github.com/NixOS/nixpkgs/commit/f97c3252e88b54375e4e459b40ce5b0d94ebb3ed) bundlerApp: accept nativeBuildInputs
* [`1b7635bb`](https://github.com/NixOS/nixpkgs/commit/1b7635bb0529c95bfd5a8f8079aa960341ab2934) ibus-engines.table: 1.16.7 -> 1.16.11
* [`7e4e39d9`](https://github.com/NixOS/nixpkgs/commit/7e4e39d9d7be05d6a2273b89afbe4d17566b66b4) intel-media-sdk: 22.5.1 -> 22.5.2
* [`b025c8cc`](https://github.com/NixOS/nixpkgs/commit/b025c8cc5e8b0a21456d715d5d8d068fa4a8d21b) pinentry_mac: use pregenerated nib files
* [`65754996`](https://github.com/NixOS/nixpkgs/commit/6575499615c33cc1d05de0632241912103ea9209) ocenaudio: 3.11.11 -> 3.11.14
* [`cbd3e2ba`](https://github.com/NixOS/nixpkgs/commit/cbd3e2ba7196bcb0d6b163458d3189ee090150e6) psi-notify: 1.2.1 -> 1.3.1
* [`3b873dc8`](https://github.com/NixOS/nixpkgs/commit/3b873dc867ea9b6615596f487fac39b1ebb6562e) linux-hardened: use default python3 version in update script
* [`89aad7ce`](https://github.com/NixOS/nixpkgs/commit/89aad7ce8d6f1f873a5446013c63c62df6bbabcd) regbot: 0.4.0 -> 0.4.2
* [`5ee8b7f4`](https://github.com/NixOS/nixpkgs/commit/5ee8b7f46b89b8e50992901d0da4be5fc2a469a7) sysvinit: 3.01 -> 3.04
* [`356ea489`](https://github.com/NixOS/nixpkgs/commit/356ea489afc21e70a3c927dd4684e2dde75fc5e6) nfs-utils: 2.5.1 -> 2.6.2
* [`5fdd6f33`](https://github.com/NixOS/nixpkgs/commit/5fdd6f336056c731ed5a776b5cbe0bc5d413c0a3) tgt: 1.0.82 -> 1.0.84
* [`5333e243`](https://github.com/NixOS/nixpkgs/commit/5333e243e993776c888cfddfc2136d341cf3a865) stdman: 2021.12.21 -> 2022.07.30
* [`4b500842`](https://github.com/NixOS/nixpkgs/commit/4b500842dc602e08b41a3da86416244be2afbe9b) alfaview: 8.49.1 -> 8.51.0
* [`688fe550`](https://github.com/NixOS/nixpkgs/commit/688fe5500cd1cbfc52b03eba336fd8f6d6e74d4c) erigon: 2022.07.03 -> 2022.08.02
* [`52487697`](https://github.com/NixOS/nixpkgs/commit/52487697902c7a48b31569d033659bff00a618bd) python3Packages.mkdocs-swagger-ui-tag: init at 0.4.0
* [`584ec678`](https://github.com/NixOS/nixpkgs/commit/584ec678389a6538dad94e7f74a72e278619a2a1) consul-template: 0.29.0 -> 0.29.2
* [`36a4a09a`](https://github.com/NixOS/nixpkgs/commit/36a4a09aabbc7c03bb4063ee5831c87de3868598) python3Packages.kanidm: init at 0.0.3
* [`23218d87`](https://github.com/NixOS/nixpkgs/commit/23218d872e1de9734fe9f10da9a5ccf566fd9aab) linux-hardened: specify system when calling nix-instantiate in update script
* [`72152f2b`](https://github.com/NixOS/nixpkgs/commit/72152f2bcf9ba93a7889a13485a356ad1b267b7f) .editorconfig: disable for Apple nib files
* [`9898e975`](https://github.com/NixOS/nixpkgs/commit/9898e975af5a0ccb6604553a7b22d5f0db2b9033) outline: init at 0.65.2
* [`6f1e8c31`](https://github.com/NixOS/nixpkgs/commit/6f1e8c316001b997d553aca000fcb80737ae9406) python3Packages.ripe-atlas-sagan: init at 1.3.1
* [`d7bf754c`](https://github.com/NixOS/nixpkgs/commit/d7bf754c96ada0532e784538a63d8fb8f0aaf9de) rPackages: CRAN and BioC update
* [`9a7b08c6`](https://github.com/NixOS/nixpkgs/commit/9a7b08c637c6d5ae279a1fd39610d1e215d1db1c) shipyard: 0.3.48 -> 0.4.10
* [`ba2b996c`](https://github.com/NixOS/nixpkgs/commit/ba2b996cdc5b94abae57bd175452bdc033dd6f46) syft: 0.51.0 -> 0.54.0
* [`1cf24a9a`](https://github.com/NixOS/nixpkgs/commit/1cf24a9a0c0049af84cee4f79437cdf4acbd8d18) python310Packages.requests-cache: remove attrs version constraint
* [`a1d817e2`](https://github.com/NixOS/nixpkgs/commit/a1d817e29f2dce01ac68c1ccc7b53510a852ff7f) babl: fix compilation with meson 0.63
* [`316b53b7`](https://github.com/NixOS/nixpkgs/commit/316b53b78cf6f3178ff2074687f8c1175f482762) reaper: 6.61 -> 6.66
* [`7977381c`](https://github.com/NixOS/nixpkgs/commit/7977381c1b256ea191d095d92acbb6d02283103c) insomnia: 2022.3.0 -> 2022.5.1
* [`9d19dcbf`](https://github.com/NixOS/nixpkgs/commit/9d19dcbf16a1658b01b7fd11135bbe288323e32a) elixir-ls: 0.10.0 -> 0.11.0
* [`69347cc5`](https://github.com/NixOS/nixpkgs/commit/69347cc5fc2a1835bfa98230829184c567de1561) hedgedoc: add SAML `providerName` option
* [`0af28a74`](https://github.com/NixOS/nixpkgs/commit/0af28a74e00e9b32105251bf1443e846a81440aa) ecs-agent: 1.62.1 -> 1.62.2
* [`41725459`](https://github.com/NixOS/nixpkgs/commit/417254598fdc7bd5e037c0e95119fdfb6dccae09) element-{web,desktop}: 1.11.0 -> 1.11.3
* [`2e4158a4`](https://github.com/NixOS/nixpkgs/commit/2e4158a4686c67629a5ff2ca1c012bf7740281f6) element-web: remove the matrix-analytics-events hack
* [`6b419536`](https://github.com/NixOS/nixpkgs/commit/6b4195366acc308eeeaadf628e3c984fd9ee8e5c) libreoffice*: hack-fix build after gpgme update
* [`9233d461`](https://github.com/NixOS/nixpkgs/commit/9233d4617120154af57879a2f8095c1d71501df4) fixup! libreoffice*: hack-fix build after gpgme update
* [`ffdee611`](https://github.com/NixOS/nixpkgs/commit/ffdee611142da5ad6cd4b83a76450bf602de27f8) pluto: 5.7.0 -> 5.10.5
* [`40cefe17`](https://github.com/NixOS/nixpkgs/commit/40cefe1733f98f96ab9b36bdeb217f2f9fae5b81) manim: fix build failure due to failing tests
* [`98d1f4c3`](https://github.com/NixOS/nixpkgs/commit/98d1f4c35da8eb4149fc61645340f9633e84297e) bcftools: 1.15 -> 1.16
* [`c01bc426`](https://github.com/NixOS/nixpkgs/commit/c01bc4268aefe17bb2a9b8b9682e485f664934bc) wolfram-engine: 13.0.1 -> 13.1.0
* [`3435f469`](https://github.com/NixOS/nixpkgs/commit/3435f469ecf0ce7126a15c487d0a2ff68714abe3) yuzu-{ea,mainline}: {2901,1131} -> {2907,1137}
* [`5d2d3ce2`](https://github.com/NixOS/nixpkgs/commit/5d2d3ce279605b89553df6d159cb84e113ed709c) plex: use buildFHSUserEnvBubblewrap
* [`1ba19d36`](https://github.com/NixOS/nixpkgs/commit/1ba19d36ed8e298d6ee687f64a86d5f9d90484db) praat: 6.2.10 -> 6.2.16
* [`55812d7b`](https://github.com/NixOS/nixpkgs/commit/55812d7b48ed50ed2c50cb2dd28b5991eaa37dbb) linux_5_4_hardened: don't build on x86_64-linux anymore
* [`a20e4b80`](https://github.com/NixOS/nixpkgs/commit/a20e4b808a256498c0950da10f5056fccedfddb8) jetbrains: update
* [`f3b9971e`](https://github.com/NixOS/nixpkgs/commit/f3b9971e4a77bf180b1dca7e976850b58c91afcf) docker-buildx: 0.9.0 -> 0.9.1
* [`f50bf586`](https://github.com/NixOS/nixpkgs/commit/f50bf5864827281a50d46269e84f7262694f74d6) dotnetCorePackages.{sdk,runtime,aspnetcore}_7_0: init at {7.0.100-preview.7.22377.5,7.0.0-preview.7.22375.6,7.0.0-preview.7.22376.6}
* [`90de9ee6`](https://github.com/NixOS/nixpkgs/commit/90de9ee6892da32b9854e0b94c828ac97fdf9c45)  nixos/modules/system/boot/networkd.nix: added Group= option in sectionLink of systemd.networkd config
* [`506cb62c`](https://github.com/NixOS/nixpkgs/commit/506cb62c4e4d7c97d862665233fba55f894177e4) 	modified:   nixos/modules/system/boot/networkd.nix
* [`21b24009`](https://github.com/NixOS/nixpkgs/commit/21b240095f19feab031ccf3adb9f4799fed1b937) picard: 2.8.1 -> 2.8.3
* [`66d196c6`](https://github.com/NixOS/nixpkgs/commit/66d196c6aeaf3bfe53b40871567542f3262a6298) instaloader: 4.9.2 -> 4.9.3
* [`42ddae4f`](https://github.com/NixOS/nixpkgs/commit/42ddae4fe4a25f5c87aff7fe687b62123327c4e7) pyradio: 0.8.9.22 -> 0.8.9.25
* [`2a83c2c5`](https://github.com/NixOS/nixpkgs/commit/2a83c2c53045ea13656e97c0979508630a1f4cc0) handbrake: remove not required ? null
* [`3c3e5cfc`](https://github.com/NixOS/nixpkgs/commit/3c3e5cfcbfbb16cbb560e365d150a9e154c27249) rekor-cli: 0.10.0 -> 0.11.0
* [`af57fd06`](https://github.com/NixOS/nixpkgs/commit/af57fd0655880339da39cb9ec832cf6e66f3ae1c) scorecard: 4.3.0 -> 4.6.0
* [`af9f6cf6`](https://github.com/NixOS/nixpkgs/commit/af9f6cf68d2fd2c485075b0f9ad0817a6f2944c4) sonobuoy: 0.56.4 -> 0.56.10
* [`237864c7`](https://github.com/NixOS/nixpkgs/commit/237864c772fd79b44244fae0cd95b1259bc75c25) srsran: 21.10 -> 22.0.4.1
* [`75088c19`](https://github.com/NixOS/nixpkgs/commit/75088c195c41224fb24545e950cd8c38f5b476a0) srsran: fix soapysdr inputs
* [`fcb99b4e`](https://github.com/NixOS/nixpkgs/commit/fcb99b4efa646f42d2a20698db11f5fe90944d6d) python310Packages.sqlite-fts4: 1.0.1 -> 1.0.3
* [`8f0df21e`](https://github.com/NixOS/nixpkgs/commit/8f0df21eb35b2e8ec41bc82556b0da2fdc45fddf) wiki-js: 2.5.285 -> 2.5.286
* [`132794f7`](https://github.com/NixOS/nixpkgs/commit/132794f7af8c70109d6b84a8cba172ac3a6ce07c) dendrite: 0.9.3 -> 0.9.4
* [`df4e0c3e`](https://github.com/NixOS/nixpkgs/commit/df4e0c3e64ed365b3faf1fd3ac9a18f163818eda) dendrite: disable tests
* [`89d680fa`](https://github.com/NixOS/nixpkgs/commit/89d680fa2b71b418c7578e8a60168c00e3c20395) bind: 9.18.5 -> 9.18.6
* [`c37f44b7`](https://github.com/NixOS/nixpkgs/commit/c37f44b755d9464f53eae4f319206659d8624318) python310Packages.bitstring: fix unit tests
* [`6ae304bd`](https://github.com/NixOS/nixpkgs/commit/6ae304bdb742714e638a4517735c79e976053534) earthly: 0.6.21 -> 0.6.22
* [`b4ee555d`](https://github.com/NixOS/nixpkgs/commit/b4ee555d0294d748d4cdff500ae23569765a4781) haskellPackages: stackage LTS 19.18 -> LTS 19.19
* [`47406851`](https://github.com/NixOS/nixpkgs/commit/4740685175a4ee931f13d6a17669341df3e98496) all-cabal-hashes: 2022-08-09T06:14:32Z -> 2022-08-20T06:29:36Z
* [`3937af9c`](https://github.com/NixOS/nixpkgs/commit/3937af9cde9093457c87f1b6d50e5ec48bc97bf9) haskellPackages: regenerate package set based on current config
* [`73c57d4d`](https://github.com/NixOS/nixpkgs/commit/73c57d4da8906be934d21285fea011a5a5e4bc19) haskell.packages.ghc924.base-compat*: adapt to 0.12.1 -> 0.12.2
* [`ff6962c8`](https://github.com/NixOS/nixpkgs/commit/ff6962c8299e626fa4d20f18f29f2b7467399009) haskell.packages.ghc924.hashable: adapt to 1.4.0.2 -> 1.4.1.0
* [`4ad395f0`](https://github.com/NixOS/nixpkgs/commit/4ad395f0c91f53c9e9df445b85dd6dee181bb877) cabal-install: adapt to changes for 3.8.1.0
* [`3e1875cd`](https://github.com/NixOS/nixpkgs/commit/3e1875cdffb624b76181dde662f38f36c5595410) flintlock: 0.1.1 -> 0.3.0
* [`916ca8f2`](https://github.com/NixOS/nixpkgs/commit/916ca8f2b0c208def051f8ea9760c534a40309db) nixos/hardware/device-tree: make overlays more reliable
* [`1f7186ab`](https://github.com/NixOS/nixpkgs/commit/1f7186ab5c6e9a2f282941617cec79479974fd74) libgccjit: don't try to enter into non-existent $lib output
* [`c17520f2`](https://github.com/NixOS/nixpkgs/commit/c17520f298d230c68343832f677460c867fda2f6) ktlint: 0.46.1 -> 0.47.0
* [`c9aaee90`](https://github.com/NixOS/nixpkgs/commit/c9aaee902c9e48b2ab07738e9eb783abc7fee63d) python310Packages.sqlite-fts4: add pythonImportsCheck
* [`c5871724`](https://github.com/NixOS/nixpkgs/commit/c58717244dfa52b4e3c09a60553bfa89a1e3b128) nixpacks: 0.3.2 -> 0.3.3
* [`b4b732bc`](https://github.com/NixOS/nixpkgs/commit/b4b732bc4223163f65fc2a616525e82cc41c7382) p4c: 1.2.2.1 -> 1.2.3.0
* [`01dd4610`](https://github.com/NixOS/nixpkgs/commit/01dd4610f8aa23df5e80e7daf579797013e5d1c4) dotnetCorePackages.combinePackages: refactor
* [`a48bd06a`](https://github.com/NixOS/nixpkgs/commit/a48bd06a09c5836eed9a0a20672470bc0c1ad57b) metabase: 0.43.3 -> 0.44.1
* [`2270a389`](https://github.com/NixOS/nixpkgs/commit/2270a389a9b0df5c738d4872432b2f221e666746) mongodb-tools: 100.5.4 -> 100.6.0
* [`13bec6b5`](https://github.com/NixOS/nixpkgs/commit/13bec6b5b71c8f4ad0772d0246a7c7a0320dbaf7) opera: 84.0.4316.42 -> 90.0.4480.48
* [`988f4d10`](https://github.com/NixOS/nixpkgs/commit/988f4d10f51045d61b8382a6e0f4f34f4488f83e) owncloud-client: 2.10.1.7187 -> 2.11.0.8354
* [`0014103d`](https://github.com/NixOS/nixpkgs/commit/0014103da647d951130b28cbf5e9d7731fd71456) php80Packages.composer: 2.4.0 -> 2.4.1
* [`9cdc6382`](https://github.com/NixOS/nixpkgs/commit/9cdc6382a8451e0b54ce0d88ae3e5ce41d5c94df) php80Packages.php-cs-fixer: 3.9.5 -> 3.10.0
* [`2f4ea5f4`](https://github.com/NixOS/nixpkgs/commit/2f4ea5f402725c0601516df03b6238a733a5a85a) rapidfuzz-cpp: 1.1.1 -> 1.2.0
* [`6c63c0df`](https://github.com/NixOS/nixpkgs/commit/6c63c0df74dfbd7f0335a59f612763511ea96942) python310Packages.rapidfuzz: 2.5.0 -> 2.6.0
* [`950a4974`](https://github.com/NixOS/nixpkgs/commit/950a497439aa8776a4ff56f1f18b0e3a2adfb9a5) python310Packages.pywlroots: 0.15.19 -> 0.15.20
* [`d9e979ee`](https://github.com/NixOS/nixpkgs/commit/d9e979ee2d96d69d454ef8e5817a5e9e34f09c33) qpwgraph: 0.3.4 -> 0.3.5
* [`87e981de`](https://github.com/NixOS/nixpkgs/commit/87e981de6f07b44097f54e94f3071db5ba45e0d3) qownnotes: 22.8.1 -> 22.8.3
* [`0fee8eeb`](https://github.com/NixOS/nixpkgs/commit/0fee8eebdb0cb9df3b9c5440a0205c0dded8f003) remind: 04.00.02 -> 04.00.03
* [`9c59fd91`](https://github.com/NixOS/nixpkgs/commit/9c59fd919f7eb9ee1756d4773fc5bc4d36c03064) wasmtime: disable tests on x86_64-darwin
* [`edfbc766`](https://github.com/NixOS/nixpkgs/commit/edfbc76693c4a7c9a6fb9af3d0071defff4f915e) haskellPackages.Cabal_3_6_3_0: generate for cabal-install-parsers etc
* [`5ff39ca4`](https://github.com/NixOS/nixpkgs/commit/5ff39ca4f6f8ef550ab0f42034c2c52eea5e39c5) haskell.packages.ghc924.lens: bump to lens-5.2
* [`d08667ab`](https://github.com/NixOS/nixpkgs/commit/d08667ab87c0371fd43dcb160b74a1d33e9126cb) haskellPackages.ema: appears to now require ghc-9.2
* [`1d143536`](https://github.com/NixOS/nixpkgs/commit/1d143536d38e33f84184ee994297fca41796d750) python310Packages.scikitimage: 0.18.3 -> 0.19.3
* [`eb677c22`](https://github.com/NixOS/nixpkgs/commit/eb677c22c67ca6e46b49ef4e278f84e2cc4b8acb) erlang-ls: 0.35.0 -> 0.41.2
* [`b6b997d6`](https://github.com/NixOS/nixpkgs/commit/b6b997d6de7058dca397f60a4db9179823673ffe) haskellPackages.servant-cassava: remove unneeded doJailbreak
* [`657075f9`](https://github.com/NixOS/nixpkgs/commit/657075f9fa5993602d7b881c0e1247e143c50302) gcc12: 12.1.0 -> 12.2.0
* [`942765e3`](https://github.com/NixOS/nixpkgs/commit/942765e3cdafaaa3fc060783ec9b6c7906882aab) cinnamon.cinnamon-common: 5.4.10 -> 5.4.11
* [`aacdb9c6`](https://github.com/NixOS/nixpkgs/commit/aacdb9c6f1717c1be0f919e056a4ae4d8ac36a6c) jackett: 0.20.1473 -> 0.20.1768
* [`3d3188ba`](https://github.com/NixOS/nixpkgs/commit/3d3188ba0b8bd16ece1303f668d7342c3567eaa0) perlPackages: Regenerate metadata (phase 1)
* [`f3558890`](https://github.com/NixOS/nixpkgs/commit/f355889075209d11f10fd8d38786938dc0b1cbba) lkl: move all patching to postPatch, simplify meta.platforms, cleanup
* [`2cf76d7f`](https://github.com/NixOS/nixpkgs/commit/2cf76d7f89a589c8b20980569fd009443274dc23) ugrep: 3.9.1 -> 3.9.2
* [`8dac0eef`](https://github.com/NixOS/nixpkgs/commit/8dac0eefc1df108bb39e916624731b4fdc700d66) lightspark: 0.8.5 -> 0.8.6
* [`f40cda6e`](https://github.com/NixOS/nixpkgs/commit/f40cda6e84edd7269c17f91679fda7742c248163) miller: 6.3.0 -> 6.4.0
* [`530852a9`](https://github.com/NixOS/nixpkgs/commit/530852a971909b923ca3a62be5acc4667be43349) python3Packages.plac: fix/disable tests
* [`98716fb2`](https://github.com/NixOS/nixpkgs/commit/98716fb27113517c8547e1a6a4e5b4c9d7ddacd8) perlPackages: Regenerate metadata (phase 2)
* [`a8a3e722`](https://github.com/NixOS/nixpkgs/commit/a8a3e7225d1c257ff263e5b776fadf29cb7246bc) perlPackages: Regenerate metadata (phase 3)
* [`758aeebf`](https://github.com/NixOS/nixpkgs/commit/758aeebf418be84b5f1d9d26f8f280fb6ce94939) python310Packages.dunamai: 1.12.0 -> 1.13.0
* [`6bc379f6`](https://github.com/NixOS/nixpkgs/commit/6bc379f63597bf4809d18af40655032560ed08df) perlPackages: Use https where possible
* [`d8334159`](https://github.com/NixOS/nixpkgs/commit/d8334159bfccaf8091d47e6374bd541d08dcec0f) btrbk: 0.32.2 -> 0.32.4
* [`aef84a79`](https://github.com/NixOS/nixpkgs/commit/aef84a7987026fad03dc27f3c01cec7922a50158) python310Packages.robotsuite: fix failing build
* [`96a8cd2b`](https://github.com/NixOS/nixpkgs/commit/96a8cd2bd337d31589bd2999f0ad3e5d9d1913b6) python310Packages.robotsuite: fix stale substitute
* [`ee08b8ce`](https://github.com/NixOS/nixpkgs/commit/ee08b8ce6a702bdc19cb0e6bd10af93326e328cf) python310Packages.robotsuite: fix deprecated gpl3 license
* [`8546d723`](https://github.com/NixOS/nixpkgs/commit/8546d723f3bfb01ef23b2207d9eea4a75a529cc3) shellhub-agent: 0.9.5 -> 0.9.6
* [`42a51b5c`](https://github.com/NixOS/nixpkgs/commit/42a51b5cc6592fe00bbbf29ae966414c51ed49b6) python310Packages.gigalixir: 1.2.6 -> 1.3.0
* [`cec0476a`](https://github.com/NixOS/nixpkgs/commit/cec0476a12d5518b54e4f6b29f755fb68f91f946) python310Packages.hacking: make less brittle with flake8 updates
* [`95a77857`](https://github.com/NixOS/nixpkgs/commit/95a77857ef1db1825cbd02d038bacf02a3913111) google-cloud-sdk: add support for components
* [`883654c7`](https://github.com/NixOS/nixpkgs/commit/883654c7abfb55a1488014f7f7dd69560a861e3e) unifi-protect-backup: 0.7.1 -> 0.7.4
* [`9f659b65`](https://github.com/NixOS/nixpkgs/commit/9f659b65f8f9a141bd5e15d67468cc209af95ecb) python3Packages.cymem: 2.0.3 -> 2.0.6, switch to pytest
* [`4dcc74ff`](https://github.com/NixOS/nixpkgs/commit/4dcc74ff1ff635d81059b7944ead3a97a19fbed2) python310Packages.jupytext: 1.14.0 -> 1.14.1
* [`97b068de`](https://github.com/NixOS/nixpkgs/commit/97b068de11f42f00644bb49457b5b4002ca9bc31) zlog: 1.2.15 -> 1.2.16
* [`2bdcc9e5`](https://github.com/NixOS/nixpkgs/commit/2bdcc9e537c50e0feee28d9f1c0e2f72887f3c44) libvirt: 8.5.0 -> 8.6.0
* [`e280e544`](https://github.com/NixOS/nixpkgs/commit/e280e5446f2c668216c5ff5db42e36e5c485abbe) openvswitch: 2.17.0 -> 2.17.2
* [`5094590a`](https://github.com/NixOS/nixpkgs/commit/5094590ad5d97581c4b0c283250d4b2863fd0182) python3Packages.flask-basicauth: init at 0.2.0
* [`ba3564f7`](https://github.com/NixOS/nixpkgs/commit/ba3564f74bb944ef279d6f5ec94f89ee4f3b5b5f) rPackages.s2: fix openssl linking
* [`361bd073`](https://github.com/NixOS/nixpkgs/commit/361bd073a957cd63df0c46b295216141754fdfaf) libsForQt5.qtdbusextended: init at 0.0.3
* [`602fcc86`](https://github.com/NixOS/nixpkgs/commit/602fcc8608cb270d53adc97dc4db3e955e6192c9) libvirt: hardcode path to parted
* [`3e373de3`](https://github.com/NixOS/nixpkgs/commit/3e373de30151f03ce839aabbf2c62d5e767b5dd3) nixos/libvirtd: point qemu-bridge-helper to store path
* [`e88d6cf4`](https://github.com/NixOS/nixpkgs/commit/e88d6cf49cb0a85f8db8f16c33a12bcc893ade2a) python310Packages.jira: 3.3.0 -> 3.4.0
* [`1a6cfb69`](https://github.com/NixOS/nixpkgs/commit/1a6cfb6980aa88e660f8dbf62a6e7b636bff2bd8) python310Packages.hahomematic: 2022.8.10 -> 2022.8.11
* [`a9bd62f8`](https://github.com/NixOS/nixpkgs/commit/a9bd62f88c5918afb48044118780413f3f42d9ed) python310Packages.holidays: 0.14.2 -> 0.15
* [`5342f0ba`](https://github.com/NixOS/nixpkgs/commit/5342f0baeab2ce3de7cb451396055ffdb228920e) python310Packages.jedi-language-server: 0.36.1 -> 0.37.0
* [`b655b616`](https://github.com/NixOS/nixpkgs/commit/b655b6161ef186e052bbd113d7c75dad63f2699e) freetds: 1.3.9 -> 1.3.13
* [`7a5a66b3`](https://github.com/NixOS/nixpkgs/commit/7a5a66b387171d5817ff4c043f98dc8928721972) aliyun-cli: 3.0.124 -> 3.0.125
* [`4688d3ef`](https://github.com/NixOS/nixpkgs/commit/4688d3efc8a9368328ee6015b3430852e2f29a33) coreboot: fix buildgcc patching
* [`e9d5d4d7`](https://github.com/NixOS/nixpkgs/commit/e9d5d4d7dc9c07d36cef4e06418f8f3d6e11cb50) python3Packages.exchangelib: patch tests after tzdata update
* [`d59b78dd`](https://github.com/NixOS/nixpkgs/commit/d59b78dd9bf596b5a8f0852820c98c0d200e4766) gnome3.gnome-books: meta.broken = true
* [`921d7b7a`](https://github.com/NixOS/nixpkgs/commit/921d7b7a7864bac83dca75eb5c4c6a5a6552bde6) python310Packages.textdistance: 4.3.0 -> 4.4.0
* [`4d9bdff8`](https://github.com/NixOS/nixpkgs/commit/4d9bdff8258755c98e9187f02c4bdffc31a0e3f5) knot-dns: 3.1.9 -> 3.2.0
* [`323d2052`](https://github.com/NixOS/nixpkgs/commit/323d2052b7f280112865776c4b34c4e7836f918a) soupault: 4.0.1 → 4.1.0
* [`59356f11`](https://github.com/NixOS/nixpkgs/commit/59356f11c1fc07e51758198640b4f91f77d1066e) perlPackages: Ensure all packages have a license
* [`42928915`](https://github.com/NixOS/nixpkgs/commit/42928915a9192317591c33550a7e4082f5246c81) perlPackages: Add descriptions to all packages
* [`92f22ae0`](https://github.com/NixOS/nixpkgs/commit/92f22ae0b49c18c61dfcd85b617163e1e5df053f) cubiomes-viewer: 2.2.2 -> 2.3.3
* [`ba6cf1cc`](https://github.com/NixOS/nixpkgs/commit/ba6cf1cc5dfc0e76ea95a2e46fd4a62e8ee9dc28) python310Packages.diff-cover: update check section
* [`72119420`](https://github.com/NixOS/nixpkgs/commit/72119420672a64f5b51e083f8eeb08f896242d16) amdvlk: 2022.Q2.2 -> 2022.Q3.3
* [`e6b89a5a`](https://github.com/NixOS/nixpkgs/commit/e6b89a5a52398c41f9fe49025acd6f9f8688c42a) perlPackages: Clarify all unfree licenses
* [`8f8b184c`](https://github.com/NixOS/nixpkgs/commit/8f8b184c454863885448ba0b0dc0b26f19531308) perlPackages: Clarify free licenses
* [`14fa34e9`](https://github.com/NixOS/nixpkgs/commit/14fa34e9ad49453fb1040f7bd6dde5a01d6191e0) trivy: fix on darwin
* [`8682bd0a`](https://github.com/NixOS/nixpkgs/commit/8682bd0a81797f64a825c8941272df2a6342bb5c) build-support/rust: toTargetArch: strip off endianness
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
