### PR TITLE
niv emacs-overlay: update 5b17f330 -> 817a3300

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5b17f330ba968f090da178f4316bb193dae6e6b3",
-        "sha256": "11if5j4zr65n9a9lcg2fg5msn9d8kvvaszrqqkqfxr1l5kzgwwvs",
+        "rev": "817a33003090677244ad5157d3148911e14372af",
+        "sha256": "1f3ng4g7kzjj18ja34836s2k52fd3y5njvag27q9d8j3v3jgkdzr",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/5b17f330ba968f090da178f4316bb193dae6e6b3.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/817a33003090677244ad5157d3148911e14372af.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@5b17f330...817a3300](https://github.com/nix-community/emacs-overlay/compare/5b17f330ba968f090da178f4316bb193dae6e6b3...817a33003090677244ad5157d3148911e14372af)

* [`3d1a1972`](https://github.com/nix-community/emacs-overlay/commit/3d1a197255d113201c89a8fcb7097cf393090758) Updated repos/emacs
* [`f8efd708`](https://github.com/nix-community/emacs-overlay/commit/f8efd708c26e6b42879d10238020ec09c2f2f332) Updated repos/melpa
* [`2cd8b574`](https://github.com/nix-community/emacs-overlay/commit/2cd8b574051e77161ea028d37fe5f43aa733e27e) Updated repos/nongnu
* [`14b2df58`](https://github.com/nix-community/emacs-overlay/commit/14b2df58dfa803bc77b58a45f1a160a908fb1f6a) Updated repos/elpa
* [`877103d2`](https://github.com/nix-community/emacs-overlay/commit/877103d23f5ef614aebb1b2c3a88e3c0e4b9baae) Updated repos/emacs
* [`88cb5bfd`](https://github.com/nix-community/emacs-overlay/commit/88cb5bfd3f9aa6c133a2f841c94042f238c0f24a) Updated repos/melpa
* [`b7e0dc28`](https://github.com/nix-community/emacs-overlay/commit/b7e0dc28effdf226cdd5790e1f201e270971583a) Updated repos/elpa
* [`e64d886e`](https://github.com/nix-community/emacs-overlay/commit/e64d886e1582455ecc6110aa44c7a0114b0124a5) Updated repos/emacs
* [`9df78985`](https://github.com/nix-community/emacs-overlay/commit/9df7898566fe546ddebc15e665a938a9dec84d01) Updated repos/melpa
* [`766c53f6`](https://github.com/nix-community/emacs-overlay/commit/766c53f6dc1233e6b0d01e5d42d791125839b481) Updated repos/emacs
* [`4c5bd32c`](https://github.com/nix-community/emacs-overlay/commit/4c5bd32cb095903a19644b550433c4847dc2ac5a) Updated repos/melpa
* [`021be83c`](https://github.com/nix-community/emacs-overlay/commit/021be83c7300166b6f984ac543edf9481f7e76fc) Updated repos/nongnu
* [`7a86497d`](https://github.com/nix-community/emacs-overlay/commit/7a86497d81554fd89479bff5b1cbd9b0f420dadd) Updated repos/elpa
* [`c3a3fc09`](https://github.com/nix-community/emacs-overlay/commit/c3a3fc09d9ce06242f7402dc4d61162ddff6a239) Updated repos/emacs
* [`5cf9609f`](https://github.com/nix-community/emacs-overlay/commit/5cf9609f0bb8567f2f5c951fcd31b62a2f0302f5) Updated repos/melpa
* [`bb3a1a07`](https://github.com/nix-community/emacs-overlay/commit/bb3a1a079308414349c77aa91d6f880271e56d4f) Updated repos/elpa
* [`506675e3`](https://github.com/nix-community/emacs-overlay/commit/506675e3dbe4c65bf3ec97dd8a829208b30ae9b3) Updated repos/emacs
* [`a9d94944`](https://github.com/nix-community/emacs-overlay/commit/a9d949448fa81ed4df7ce420226c88df52f6cb28) Updated repos/melpa
* [`9ae7f962`](https://github.com/nix-community/emacs-overlay/commit/9ae7f9624d24124f0b5b580638c2f34454107f14) Updated repos/emacs
* [`44a9e4a1`](https://github.com/nix-community/emacs-overlay/commit/44a9e4a1b5fbd08e786c976ce3046d436174c16a) Updated repos/melpa
* [`f9ae61e7`](https://github.com/nix-community/emacs-overlay/commit/f9ae61e7793b2dd0a2beef59270fc4b4e9f54a46) Updated repos/nongnu
* [`c456764c`](https://github.com/nix-community/emacs-overlay/commit/c456764cdce036f0340b2a5f138416cf39dcca6f) Updated repos/emacs
* [`ab44a390`](https://github.com/nix-community/emacs-overlay/commit/ab44a3901e018644915a46c713f0a8cff77f45e5) Updated repos/elpa
* [`8cc929b6`](https://github.com/nix-community/emacs-overlay/commit/8cc929b624558882923d59c3eae7dca1eabc2207) Updated repos/emacs
* [`77e195ec`](https://github.com/nix-community/emacs-overlay/commit/77e195ec366bf53d084b735de228f3efc5800d0e) Updated repos/nongnu
* [`9f50a8d3`](https://github.com/nix-community/emacs-overlay/commit/9f50a8d3be2291db155cb751448eb2e34d12b5e4) Updated repos/emacs
* [`cde6b0fd`](https://github.com/nix-community/emacs-overlay/commit/cde6b0fd7cad645fc069fe4bf54d2944ee0d8d95) Updated repos/emacs
* [`b16db084`](https://github.com/nix-community/emacs-overlay/commit/b16db08460bae5437834863d9dd5cffc30aff89d) Updated repos/elpa
* [`4dc13be2`](https://github.com/nix-community/emacs-overlay/commit/4dc13be2f27e6143e702103342bc4e143f9f095c) Updated repos/emacs
* [`d8891991`](https://github.com/nix-community/emacs-overlay/commit/d8891991eef88a53a979ff242663429cef82a094) Updated repos/emacs
* [`0dd2d05b`](https://github.com/nix-community/emacs-overlay/commit/0dd2d05b103931f7192ab62c9e7a4b5950155c17) Updated repos/emacs
* [`f1a2b2e4`](https://github.com/nix-community/emacs-overlay/commit/f1a2b2e4dde0e5064e0641b426c52e9825700d5d) Updated repos/elpa
* [`6c95fb87`](https://github.com/nix-community/emacs-overlay/commit/6c95fb87c40fc976f5de5f00ba5cca92b7537e88) Updated repos/emacs
* [`0bb59bd0`](https://github.com/nix-community/emacs-overlay/commit/0bb59bd04ff65270b34434edde00654f43a0dec8) Updated repos/emacs
* [`0bbab674`](https://github.com/nix-community/emacs-overlay/commit/0bbab6748fe821b637d6b7df517b910540e38260) Updated repos/elpa
* [`5046cc71`](https://github.com/nix-community/emacs-overlay/commit/5046cc71d33022f237191f2a8d8df18315910d13) Updated repos/emacs
* [`f7caedcd`](https://github.com/nix-community/emacs-overlay/commit/f7caedcd0df6710e5c33b493220f729385664ae7) Updated repos/emacs
* [`56a80e1c`](https://github.com/nix-community/emacs-overlay/commit/56a80e1c2f6e63ce32dcff9f9d17643bb4ed9b8c) Updated repos/elpa
* [`a5ec2328`](https://github.com/nix-community/emacs-overlay/commit/a5ec23280df5d9bf27ae266fdafcf375656487ba) Updated repos/emacs
* [`22ce4e9f`](https://github.com/nix-community/emacs-overlay/commit/22ce4e9f643973754396a7133649f361bb0f2760) Updated repos/elpa
* [`f1f72f64`](https://github.com/nix-community/emacs-overlay/commit/f1f72f642ebb77e6fd9fd7bc01aee69639c791df) Updated repos/emacs
* [`c507c227`](https://github.com/nix-community/emacs-overlay/commit/c507c22745155a848b5928a5051c9aad28994d78) Updated repos/nongnu
* [`2c3024c1`](https://github.com/nix-community/emacs-overlay/commit/2c3024c10d7a8916bb1680c39638c7e248321d60) Updated repos/emacs
* [`b726259d`](https://github.com/nix-community/emacs-overlay/commit/b726259df1d6defe5af8c5be45ff6457885f2a5f) Updated repos/nongnu
* [`abe8b13a`](https://github.com/nix-community/emacs-overlay/commit/abe8b13adf351ca1d578b8ce073e33b70d73e7a6) Updated repos/elpa
* [`8c04b52f`](https://github.com/nix-community/emacs-overlay/commit/8c04b52f615b7906cc7929f2bc87e8dd3a3c2c5c) Updated repos/emacs
* [`d2ef237d`](https://github.com/nix-community/emacs-overlay/commit/d2ef237d85c5967bc00da2d0e4e179a3118b4490) Updated repos/emacs
* [`3eebcf9f`](https://github.com/nix-community/emacs-overlay/commit/3eebcf9f1f4ae2bbfd3bb69d6d31355f4acd1362) Updated repos/elpa
* [`4b8f329f`](https://github.com/nix-community/emacs-overlay/commit/4b8f329fb51cd65be249f478672f70dbf1c0a5ad) Updated repos/emacs
* [`798962d1`](https://github.com/nix-community/emacs-overlay/commit/798962d10c7b7b9f969493de4ca3bb750d7a74d2) Updated repos/elpa
* [`60a3d819`](https://github.com/nix-community/emacs-overlay/commit/60a3d81954e22bec763576e8ed3f308703da3e02) Updated repos/emacs
* [`9a0afba2`](https://github.com/nix-community/emacs-overlay/commit/9a0afba2114ca5170fe959f0432bf7bd2b272114) Updated repos/emacs
* [`e9e42c13`](https://github.com/nix-community/emacs-overlay/commit/e9e42c132521c19d886ce6ae3239e36edf76af8d) Updated repos/elpa
* [`6b4445aa`](https://github.com/nix-community/emacs-overlay/commit/6b4445aa659fa26b4f36d9975b34632312699a85) Updated repos/emacs
* [`da577848`](https://github.com/nix-community/emacs-overlay/commit/da577848fae9c043bf9260e3f417fa8d7ab1e409) Updated repos/elpa
* [`68fbdf4f`](https://github.com/nix-community/emacs-overlay/commit/68fbdf4f08f19f95b1c64b21c4db16403b5498e3) Updated repos/emacs
* [`eceb7cab`](https://github.com/nix-community/emacs-overlay/commit/eceb7cab0c141a216a2fccf937986ce28b71c67e) Updated repos/elpa
* [`8707d84e`](https://github.com/nix-community/emacs-overlay/commit/8707d84ec67b39d5655929fc974055bcb9a160fb) Updated repos/emacs
* [`48779acc`](https://github.com/nix-community/emacs-overlay/commit/48779accfc5af3b846e10581296cb90219d6661b) Updated repos/elpa
* [`9fb9d068`](https://github.com/nix-community/emacs-overlay/commit/9fb9d0684336f7aed0a762f2536c8fa0188b653b) Updated repos/emacs
* [`b042c46b`](https://github.com/nix-community/emacs-overlay/commit/b042c46bb68bbd24b3b8f80f21889237b3b23eef) Updated repos/nongnu
* [`ee09baca`](https://github.com/nix-community/emacs-overlay/commit/ee09bacab85d5fa4384466905831a2c9f9bf6514) Updated repos/emacs
* [`4c4dfc55`](https://github.com/nix-community/emacs-overlay/commit/4c4dfc55e6bde89634ce6c2a706cd903eefe4474) Updated repos/elpa
* [`ff5ca7b5`](https://github.com/nix-community/emacs-overlay/commit/ff5ca7b5bed8e67ebf7dabc11e37424c696e8ce8) Updated repos/elpa
* [`3633040a`](https://github.com/nix-community/emacs-overlay/commit/3633040a41dc3379b5c4d53a4ec0fc0eb68b236d) Updated repos/nongnu
* [`57251491`](https://github.com/nix-community/emacs-overlay/commit/572514917abdfcf673c17afcca21b1597e151c99) Disable webp support in emacsGit-nox and emacsUnstable-nox
* [`817a3300`](https://github.com/nix-community/emacs-overlay/commit/817a33003090677244ad5157d3148911e14372af) Updated repos/nongnu
