### PR TITLE
niv spacemacs: update b86b881b -> 201d22bc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "b86b881b537128182d5682e32ecb44b7d7a63614",
-        "sha256": "0v0lxp6d4ckamvlasmsrina10l1lyvyif0s4a5m4prb5lrzy1k9q",
+        "rev": "201d22bcc975bd5f4cf459a27c1c42922179f4e2",
+        "sha256": "1rliqbarkwjdg4fmcan3q3fn5994wgwl7qvjnqjrdya4mpyhnrag",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/b86b881b537128182d5682e32ecb44b7d7a63614.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/201d22bcc975bd5f4cf459a27c1c42922179f4e2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@b86b881b...201d22bc](https://github.com/syl20bnr/spacemacs/compare/b86b881b537128182d5682e32ecb44b7d7a63614...201d22bcc975bd5f4cf459a27c1c42922179f4e2)

* [`244b8a8c`](https://github.com/syl20bnr/spacemacs/commit/244b8a8cb9666368c07a3cddeb6b7cb9d68eb053) Removes references to the github layer ([syl20bnr/spacemacs⁠#15709](https://togithub.com/syl20bnr/spacemacs/issues/15709))
* [`99eb20e1`](https://github.com/syl20bnr/spacemacs/commit/99eb20e13c3b698bb8ba95ed278fb79861625f5b) Docker: Followup for [syl20bnr/spacemacs⁠#15414](https://togithub.com/syl20bnr/spacemacs/issues/15414): fix bindings not loading, add docs ([syl20bnr/spacemacs⁠#15707](https://togithub.com/syl20bnr/spacemacs/issues/15707))
* [`d6c34826`](https://github.com/syl20bnr/spacemacs/commit/d6c34826635035f68137fdc3de6c87440bd5d55f) compleseus: disable ido and respect minibuffer binds evilification setting ([syl20bnr/spacemacs⁠#15710](https://togithub.com/syl20bnr/spacemacs/issues/15710))
* [`1ed08595`](https://github.com/syl20bnr/spacemacs/commit/1ed08595bfee63ee88dcc282767c37f34c6c911c) [bot] "built_in_updates" Sat Aug 27 08:46:27 UTC 2022
* [`201d22bc`](https://github.com/syl20bnr/spacemacs/commit/201d22bcc975bd5f4cf459a27c1c42922179f4e2) compleseus: use the correct predicate for minibuffer hjkl bindings
