### PR TITLE
niv zsh-completions: update f360827b -> 53f2eab0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "f360827b882e0b651ff85ce27dc2a6287351fc22",
-        "sha256": "0y0n682v4ij0drx1r99w7vkxfxiq4mj11ildjygwp37ffvaarcfp",
+        "rev": "53f2eab090d054a877d45092d6f90562fa663d1a",
+        "sha256": "0yysxc2las0v370l043p9818h5lafa6wdm5ddhk3v1lqcn81kj54",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/f360827b882e0b651ff85ce27dc2a6287351fc22.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/53f2eab090d054a877d45092d6f90562fa663d1a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@f360827b...53f2eab0](https://github.com/zsh-users/zsh-completions/compare/f360827b882e0b651ff85ce27dc2a6287351fc22...53f2eab090d054a877d45092d6f90562fa663d1a)

* [`87f190da`](https://github.com/zsh-users/zsh-completions/commit/87f190da853e3773ca612cc8418cb6b44cc2e44b) Update node.js options
* [`11ad45a6`](https://github.com/zsh-users/zsh-completions/commit/11ad45a66e6f088d315f8f1e2b1f6ce325f71dac) Fix node completion typo
