### PR TITLE
niv nixpkgs: update ab0f5208 -> adff066f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab0f52080fd0d50babb45aae14f605ffdb096e62",
-        "sha256": "080fl35ls59g72y270fw2rlyd5lisv052bawfx8pa0ifhmh9zw2a",
+        "rev": "adff066f00dde76165abbc9679b983fe4706fdc5",
+        "sha256": "129s1znw2a5jdbb7bh3r4ac08mg0kapn7wjglnmgy2fysv4irkiz",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ab0f52080fd0d50babb45aae14f605ffdb096e62.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/adff066f00dde76165abbc9679b983fe4706fdc5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ab0f5208...adff066f](https://github.com/nixos/nixpkgs/compare/ab0f52080fd0d50babb45aae14f605ffdb096e62...adff066f00dde76165abbc9679b983fe4706fdc5)

* [`2b936d9a`](https://github.com/NixOS/nixpkgs/commit/2b936d9a002563a0b953764dad607297870a1606) kafkactl: init at 1.23.1
* [`f238aa98`](https://github.com/NixOS/nixpkgs/commit/f238aa983364b2ac8e5cfd7862b5edc19348a105) dockerTools: add caCertificates helper
* [`3dd348cc`](https://github.com/NixOS/nixpkgs/commit/3dd348cca9f60717cee2568b1cd83b11901e9777) footswitch: 20201-03-17 -> 2022-04-12
* [`c15d568d`](https://github.com/NixOS/nixpkgs/commit/c15d568d0bb61747ca038c2aee0ae829f31386cd) iqtree: init at 2.2.0.4
* [`b391f5ff`](https://github.com/NixOS/nixpkgs/commit/b391f5ff2a59e59bba578c896bcef38585271367) manuskript: 0.13.1 -> 0.14.0
* [`930c2f30`](https://github.com/NixOS/nixpkgs/commit/930c2f308e074258702b357d28489bcc9cff48c7) lunar-client: 2.10.0 -> 2.10.1
* [`d678accd`](https://github.com/NixOS/nixpkgs/commit/d678accdf871a0ec007953af177ee46ee8674edc) ufiformat: init at 0.9.9
* [`e43319d0`](https://github.com/NixOS/nixpkgs/commit/e43319d045acf4a4f2f9bb12b5d41393c1a18ebb) avizo: 1.2 -> 1.2.1
* [`4936e482`](https://github.com/NixOS/nixpkgs/commit/4936e482aca2f5d56da98e3bb8b1378837b07a85) maintainers: add CactiChameleon9
* [`8be83b16`](https://github.com/NixOS/nixpkgs/commit/8be83b166332bcbb9256ac5407145eb9a9bfe9eb) pingu: init at 0.0.3
* [`1639e10d`](https://github.com/NixOS/nixpkgs/commit/1639e10d340d638bda0f14dd69060d8470c4da02) Update perseus
* [`923e4415`](https://github.com/NixOS/nixpkgs/commit/923e4415d26da2db76229c1ab10c5a4be5752746) Update perseus
* [`cd52b6d8`](https://github.com/NixOS/nixpkgs/commit/cd52b6d893c50f464d618a079e37253572fda102) Update
* [`22bccbcd`](https://github.com/NixOS/nixpkgs/commit/22bccbcd9780c39ab08f4791e1de401b306a3923) Update perseus
* [`061ffd99`](https://github.com/NixOS/nixpkgs/commit/061ffd99beb56d29921a0b9c86c067db256222bb) scenic-view: use jdk11
* [`cddb7a9d`](https://github.com/NixOS/nixpkgs/commit/cddb7a9d3b7b5de1f101ab859ed86a06c8ffc5c4) freesweep: 1.0.1 -> 1.0.2
* [`b1b7d683`](https://github.com/NixOS/nixpkgs/commit/b1b7d683c602af1cefa71c7fb60c05376c0539d9) freesweep: enable parallel build
* [`e2a322b3`](https://github.com/NixOS/nixpkgs/commit/e2a322b3cdd8e851c6c9f9c744e307a2b9a1ce33) nixos/gitlab: fix registry.issuer setting
* [`fb609df7`](https://github.com/NixOS/nixpkgs/commit/fb609df70883e1612aacc618e8a96586f62da307) python310Packages.sphinxcontrib-plantuml: 0.23 -> 0.24
* [`c9d8e34f`](https://github.com/NixOS/nixpkgs/commit/c9d8e34fc44c103f402275e13d010ed3febd2424) dockerTools: document environment helpers
* [`197f0c7c`](https://github.com/NixOS/nixpkgs/commit/197f0c7c9a1919ec83a30cd8aee491b0820a5b3b) ace: 7.0.6 -> 7.0.8
* [`cd67516d`](https://github.com/NixOS/nixpkgs/commit/cd67516dcf747871b5bd384f15c7074289a6c8a4) dhewm3: 1.5.1 -> 1.5.2
* [`bd3e665a`](https://github.com/NixOS/nixpkgs/commit/bd3e665a6f59d1afdcf76a38a2b9a886121bdc37) cherrytree: 0.99.47 -> 0.99.48
* [`41bb9c6d`](https://github.com/NixOS/nixpkgs/commit/41bb9c6d6d2c2c9222b213a026820b8c7bae8855) dapper: 0.5.8 -> 0.6.0
* [`1456316b`](https://github.com/NixOS/nixpkgs/commit/1456316b1567e14722e37965d03ad4afe4c930cb) catcli: 0.8.1 -> 0.8.2
* [`d322c2aa`](https://github.com/NixOS/nixpkgs/commit/d322c2aaf149eecd729b74be9f49da70c0cf7f31) rtl8189es: 2021-10-01 -> 2022-05-21
* [`6f3abbd2`](https://github.com/NixOS/nixpkgs/commit/6f3abbd21df1a7d139d25cfba11be7dba0d0d418) python3Packages.pdoc: init at 12.0.2
* [`bbd78d60`](https://github.com/NixOS/nixpkgs/commit/bbd78d6030ff6e8d78fbc575f9de1ef3809bd990) libgme: remove
* [`69831729`](https://github.com/NixOS/nixpkgs/commit/698317297468f59fb4d4d810ff9eb6d6d026e4e2) treewide: replace references to libgme with game-music-emu
* [`b6739f8e`](https://github.com/NixOS/nixpkgs/commit/b6739f8ebd6fd09daef8e2ad6133e23209286233) termius: 7.42.1 -> 7.45.3
* [`f6d7d394`](https://github.com/NixOS/nixpkgs/commit/f6d7d394f400d2426866a7df53fb29e04f93b2bd) elfinfo: 1.1.0 -> 1.2.1
* [`7580e17e`](https://github.com/NixOS/nixpkgs/commit/7580e17e4660bf93b30cb3923cd7c5e1f833071b) gnuplot: 5.4.3 -> 5.4.4
* [`b0544e5c`](https://github.com/NixOS/nixpkgs/commit/b0544e5c718e1c0b07bf02f23ca60a19ca98e40d) glfw: 3.3.7 -> 3.3.8
* [`2bf5770f`](https://github.com/NixOS/nixpkgs/commit/2bf5770f6e33b54f2f5b129bc79cd4e38665c010) python310Packages.doc8: 0.11.2 -> 1.0.0
* [`2ce2b14a`](https://github.com/NixOS/nixpkgs/commit/2ce2b14a96417e0f511e485ec73827866eef503a) inih: 53 -> 56
* [`5d581f50`](https://github.com/NixOS/nixpkgs/commit/5d581f506d0fe195fea2befbf3de838b2c4d62c1) libcouchbase: 3.2.5 -> 3.3.1
* [`21fbed7c`](https://github.com/NixOS/nixpkgs/commit/21fbed7cbb8432139df4a825f574c2093381de42) libofx: 0.10.3 -> 0.10.5
* [`3357f714`](https://github.com/NixOS/nixpkgs/commit/3357f7142c8cc96ffda31f78a777c12a7f9b2be7) libsemanage: 3.3 -> 3.4
* [`651cefb9`](https://github.com/NixOS/nixpkgs/commit/651cefb9c2abe4aa5bdc9af0a4e0a8436b5cc1d4) ligolo-ng: 0.3.2 -> 0.3.3
* [`bdeaedd9`](https://github.com/NixOS/nixpkgs/commit/bdeaedd9949a11db9b23c11c5c28736053d9c7c3) litestream: 0.3.8 -> 0.3.9
* [`bfecef1a`](https://github.com/NixOS/nixpkgs/commit/bfecef1ab22fe311e7665f25bb0de5e12d9edbd5) mapcidr: 0.0.8 -> 1.0.1
* [`64aeada8`](https://github.com/NixOS/nixpkgs/commit/64aeada883fb85dc349827322f9930886735012d) mob: 3.1.3 -> 3.1.5
* [`fdee2bbc`](https://github.com/NixOS/nixpkgs/commit/fdee2bbc8c08d9d99c7b1a1d517cc5dab1d55666) crc: 2.4.1 -> 2.6.0
* [`96ec44f3`](https://github.com/NixOS/nixpkgs/commit/96ec44f3f12e72bc24ca10458164ce39dc7d0c1e) crd2pulumi: 1.2.0 -> 1.2.2
* [`546a3ad5`](https://github.com/NixOS/nixpkgs/commit/546a3ad5b1ea815a207174b8228a116ba21ab72b) orcania: 2.2.2 -> 2.3.0
* [`f7ce1084`](https://github.com/NixOS/nixpkgs/commit/f7ce10843b8a5f7da571919835177ec497af8045) owncast: 0.0.11 -> 0.0.12
* [`ffc83c71`](https://github.com/NixOS/nixpkgs/commit/ffc83c71c7280e79951bbe2ffdbd1aa5396eb0cd) partclone: 0.3.18 -> 0.3.20
* [`cf7fc313`](https://github.com/NixOS/nixpkgs/commit/cf7fc31384e502ecd379a7722ae790fcbecff26c) noisetorch: install desktop item
* [`fd20ff8a`](https://github.com/NixOS/nixpkgs/commit/fd20ff8a464c7ee6ccaa9984f5a38b32864605ab) tagainijisho: 1.2.0 -> 1.2.1
* [`b1bb3bca`](https://github.com/NixOS/nixpkgs/commit/b1bb3bcad8b508def149a4c2eb520bdacfef6b85) nixos/systemd.network: Add `IPv6RoutePrefix` options
* [`83a6b120`](https://github.com/NixOS/nixpkgs/commit/83a6b120cbb1178ed849a0c6442fae423e364a3b) medfile: 4.1.0 -> 4.1.1
* [`bca883c3`](https://github.com/NixOS/nixpkgs/commit/bca883c30742a73c18ce3dd527550fe40264497a) ecpdap: 0.1.7 -> 0.1.8
* [`424911a0`](https://github.com/NixOS/nixpkgs/commit/424911a03efd255e6a8c87d418831410746665dc) dokuwiki: 2020-07-29 -> 2022-07-31
* [`6f065481`](https://github.com/NixOS/nixpkgs/commit/6f0654817a2e9c2a113aeb0fdb8865c0dc590b9d) datadog: fix python integration
* [`39165f29`](https://github.com/NixOS/nixpkgs/commit/39165f2938fc0379600d76e9afe7a121dd111e45) datadog-integrations-core: 7.30.1 -> 7.38.0
* [`fab8a905`](https://github.com/NixOS/nixpkgs/commit/fab8a905ab871c3c054e2ff9951de7a96160f0d0) datadog-agent: 7.36.0 -> 7.38.1
* [`005aa4f4`](https://github.com/NixOS/nixpkgs/commit/005aa4f4a8f79d0bbeb2696f8659018f66499f1b) litecoin: 0.18.1 -> 0.21.2.1
* [`4c258245`](https://github.com/NixOS/nixpkgs/commit/4c258245ec559edf6cf72e657a225acbcb3352e6) precice: 2.4.0 -> 2.5.0
* [`882d0a3b`](https://github.com/NixOS/nixpkgs/commit/882d0a3b7adce59afdabdf56fd80584832646d0e) bazel_6: init with a WIP implem
* [`fce6d3c3`](https://github.com/NixOS/nixpkgs/commit/fce6d3c3be9693cbd6fa7622b2789b30105407ca) runescape-launcher: add .desktop file
* [`ce8d6722`](https://github.com/NixOS/nixpkgs/commit/ce8d6722f98dc92b2f9416b69c02aaa2d1e9123b) maintainers: add fmoda3
* [`d51e8de8`](https://github.com/NixOS/nixpkgs/commit/d51e8de8c6c3f55d19b0e1a5961b75417ff9e31f) python3Packages.typish: init at 1.9.3
* [`fff3c3b7`](https://github.com/NixOS/nixpkgs/commit/fff3c3b7a74d57fcdd0720e1c21c592d937d45fe) WIP v2
* [`d36ce415`](https://github.com/NixOS/nixpkgs/commit/d36ce4154e4fe0f559ae1e3889284111cafe835b) ckbcomp: 1.207 -> 1.209
* [`d50bd820`](https://github.com/NixOS/nixpkgs/commit/d50bd820c4235b77953e154e335b0e861c10106e) driftctl: 0.34.1 -> 0.37.0
* [`8a9dfaed`](https://github.com/NixOS/nixpkgs/commit/8a9dfaed41e8383ef923d95a059c984c965d8c85) ablog: 0.10.24 -> 0.10.29
* [`6f6018dc`](https://github.com/NixOS/nixpkgs/commit/6f6018dcc3a4c679145d0ca64f0903a5d850645a) indicator-sound-switcher: 2.3.7 -> 2.3.9
* [`328448a1`](https://github.com/NixOS/nixpkgs/commit/328448a15306ef65319af532364d33cbe7bdf8cb) waydroid: 1.2.1 -> 1.3.0
* [`e066ea73`](https://github.com/NixOS/nixpkgs/commit/e066ea73b72d087e67bf60c2b6b292a689bbfbc3) icinga2: 2.13.3 -> 2.13.5
* [`8a1fdb52`](https://github.com/NixOS/nixpkgs/commit/8a1fdb52932b0b27def59c9fb04d92a4079537c4) displaylink: 5.6.0-59.176 -> 5.6.1-59.184
* [`6d4c3b07`](https://github.com/NixOS/nixpkgs/commit/6d4c3b07c2038988a35191410b792fcc37040f0a) itk: enable additional modules
* [`f72c0727`](https://github.com/NixOS/nixpkgs/commit/f72c072710f53d79db5281dc1667b4b279360296) webex: 42.8.0.22907 → 42.10.0.23251
* [`18124282`](https://github.com/NixOS/nixpkgs/commit/18124282d27b0e9b64aef4092122dad0699312ba) snowcrash: fix on aarch64-darwin
* [`16f934eb`](https://github.com/NixOS/nixpkgs/commit/16f934eb47c3957653272546dd7ca9e5fbc74c62) vimPlugins.vim-isort: fix build
* [`095a37e1`](https://github.com/NixOS/nixpkgs/commit/095a37e13e878915ad292eb0d68ac443ba5955c7) bazel_6: Working fix for java toolchain on linux
* [`c4ed73fa`](https://github.com/NixOS/nixpkgs/commit/c4ed73fabd7f8bb2822afc50fe9fc2deea724464) qt4: Remove overzealous and obsolete patch.
* [`0bab8f16`](https://github.com/NixOS/nixpkgs/commit/0bab8f164ca3efd360299065e9d75a27304798de) qt4: add aarch64-darwin to list of bad platforms
* [`748f2f34`](https://github.com/NixOS/nixpkgs/commit/748f2f342c3471e16aad47d5584b72d1f8369fbf) microsoft-edge: 102.0.1245.44 -> 104.0.1293.54
* [`82374716`](https://github.com/NixOS/nixpkgs/commit/823747166fed45488e1c199a49c2a2128d4ebb84) toybox: 0.8.6 -> 0.8.8
* [`6f0138cc`](https://github.com/NixOS/nixpkgs/commit/6f0138cc08c0ad4921c8b7373261c709c1d09889) microsoft-edge: fix hardware acceleration
* [`2b67c8b0`](https://github.com/NixOS/nixpkgs/commit/2b67c8b041496f1a56c86e97bb6eb2c2b6b5c9f7) python310Packages.nextcord: 2.0.0 -> 2.1.0
* [`771ef9f7`](https://github.com/NixOS/nixpkgs/commit/771ef9f73897ee57ec28a8f0861b556959db4d48) nixos/systemd-boot: use esp-path instead of path when calling bootctl
* [`d5130db7`](https://github.com/NixOS/nixpkgs/commit/d5130db7cf002738ce329d57732c0f354f12da92) itch: fix icons location
* [`03317d0e`](https://github.com/NixOS/nixpkgs/commit/03317d0edb637b3106327f2ac2343dbdd7b9bdda) session-desktop-appimage: 1.8.6 -> 1.9.1
* [`d4c8d3db`](https://github.com/NixOS/nixpkgs/commit/d4c8d3dbdcdc2fdf8c74bdf9a8be63801cc999db) python310Packages.coqui-trainer: 0.0.13 -> 0.0.14
* [`00aa2c0b`](https://github.com/NixOS/nixpkgs/commit/00aa2c0b1be9fe18a22c9bf332911f8fe09842cf) multus-cni: 3.8 -> 3.9.1
* [`3f3f0d94`](https://github.com/NixOS/nixpkgs/commit/3f3f0d9492796cf4a5ecec4b515e02f2e4efdfda) qFlipper: 1.1.2 -> 1.1.3
* [`3ffcb4a7`](https://github.com/NixOS/nixpkgs/commit/3ffcb4a7d8106d7648fce81719ba6dd23ae46f26) catppuccin-gtk: unstable-2022-08-01 -> 0.2.7
* [`252079fa`](https://github.com/NixOS/nixpkgs/commit/252079fa5d695e784044328d7682a5b57c5830ab) doppler: 3.40.1 -> 3.41.0
* [`4da31b92`](https://github.com/NixOS/nixpkgs/commit/4da31b92340750b37a1fa1de2e8f35a8a4bafe10) nwg-panel: 0.7.2 -> 0.7.4
* [`bfe89e44`](https://github.com/NixOS/nixpkgs/commit/bfe89e44b283dcecf7dffe28e7fbfbfe824bb1be) gotestsum: 1.8.1 -> 1.8.2
* [`8785efcc`](https://github.com/NixOS/nixpkgs/commit/8785efccc2598105071c410b83c67b92f3e772f3) papermc: 1.18.2r313 -> 1.19.2r131
* [`48ed969f`](https://github.com/NixOS/nixpkgs/commit/48ed969f3ed05b049894698a3c8339b496414fb3) mullvad: 2022.2 -> 2022.4
* [`797b2e0e`](https://github.com/NixOS/nixpkgs/commit/797b2e0ea00edc42005a447ec2a1e8ba1577f276) mullvad-vpn: 2022.2 -> 2022.4
* [`9e3015da`](https://github.com/NixOS/nixpkgs/commit/9e3015dab88b428e88435efd091a07dfa36933f6) librepo: 1.14.3 -> 1.14.4
* [`c52f565d`](https://github.com/NixOS/nixpkgs/commit/c52f565d3a211efc476db5ab6f78d135a5482b27) Revert "nixos/lightdm: make lightdm user shell bash"
* [`8d467cb6`](https://github.com/NixOS/nixpkgs/commit/8d467cb6b988aec7e89489e1c76e7bff72a09579) stenc: 1.0.8 -> 1.1.1
* [`f5125bb9`](https://github.com/NixOS/nixpkgs/commit/f5125bb910adc96fc223e24b872d5e23bf465d6c) tartube-yt-dlp: 2.3.367 -> 2.4.093
* [`52401e81`](https://github.com/NixOS/nixpkgs/commit/52401e81bb03f33700df6ae304093c882ccce575) ttyd: 1.7.0 -> 1.7.1
* [`c8eea84e`](https://github.com/NixOS/nixpkgs/commit/c8eea84e7e7dd3c2c76509a7046888ba9b25fe2d) python310Packages.online-judge-api-client: 10.10.0 -> 10.10.1
* [`e5555e08`](https://github.com/NixOS/nixpkgs/commit/e5555e088117b7106bfcc87d75af0969e95af8a8) python310Packages.dash: 2.6.0 -> 2.6.1
* [`33a19cf3`](https://github.com/NixOS/nixpkgs/commit/33a19cf3aa177a54c5cb901795fce5b9c18138b2) python310Packages.icontract: 2.6.1 -> 2.6.2
* [`5356b815`](https://github.com/NixOS/nixpkgs/commit/5356b81503b764e62afe49d59b2060a860c769e1) python310Packages.jupyterlab-git: 0.37.1 -> 0.39.0
* [`1d956f8a`](https://github.com/NixOS/nixpkgs/commit/1d956f8a85d860db2d13453a89b2106fbe440b33) cargo-nextest: 0.9.34 -> 0.9.35
* [`86096c95`](https://github.com/NixOS/nixpkgs/commit/86096c958f8d04998866513c21a2b9c6b7b3656b) python310Packages.magic-wormhole: Fix tests
* [`51c74db2`](https://github.com/NixOS/nixpkgs/commit/51c74db26bbfc5cc9a956bde55dd5af4f0d4a00e) ghorg: 1.8.5 -> 1.8.7
* [`ec5823f7`](https://github.com/NixOS/nixpkgs/commit/ec5823f7b3e613e5ab85d2e458814b833a987245) goresym: 1.2 -> 1.4
* [`b48df2eb`](https://github.com/NixOS/nixpkgs/commit/b48df2eb42094b0486e8b8b8d2addc6852afb688) rapidfuzz-cpp: 1.1.1 -> 1.2.0
* [`84fe5b58`](https://github.com/NixOS/nixpkgs/commit/84fe5b580b5c6b4c5ae9f5d5723dd660736abc86) grml-zsh-config: 0.19.2 -> 0.19.3
* [`a5c742a3`](https://github.com/NixOS/nixpkgs/commit/a5c742a34e209037373b24877daa0f48c7cfc72f) ibus-engines.libpinyin: 1.12.1 -> 1.13.0
* [`e3336e99`](https://github.com/NixOS/nixpkgs/commit/e3336e99ea3d9dc1be73ad39eaaa7983cbc8388b) libsForQt5.kpmcore: 22.04.3 -> 22.08.0
* [`44cc09c2`](https://github.com/NixOS/nixpkgs/commit/44cc09c2b492585986eaba093f4ac9b450a5c111) utsushi: Fix scanning
* [`9f601b24`](https://github.com/NixOS/nixpkgs/commit/9f601b24c8d80b448ab2fdb0a4765eeb8dff83c3) neomutt: enable zstd support by default, offer mixmaster support
* [`e053ba25`](https://github.com/NixOS/nixpkgs/commit/e053ba251631f62a92935a1fc32818bb45f88cbd) python310Packages.recordlinkage: 0.14 -> 0.15
* [`7f00e18e`](https://github.com/NixOS/nixpkgs/commit/7f00e18ed527df904910ff63874ebec1667a7ab5) spoofer: 1.4.8 -> 1.4.11
* [`d90207f2`](https://github.com/NixOS/nixpkgs/commit/d90207f252e57af268238e7e74cd9e6f0d764ab6) snapraid: 12.1 -> 12.2
* [`2e58154e`](https://github.com/NixOS/nixpkgs/commit/2e58154e9046ff5a08459ad2650f76cda564d750) ustreamer: 5.17 -> 5.20
* [`96a5b415`](https://github.com/NixOS/nixpkgs/commit/96a5b41506c0d4ff183f79cb3a020eedf95eef0c) xlockmore: 5.70 -> 5.71
* [`1305e714`](https://github.com/NixOS/nixpkgs/commit/1305e7149866cd116bb153a93e54033c640207b7) nicotine-plus: 3.2.2 -> 3.2.4
* [`49f4071f`](https://github.com/NixOS/nixpkgs/commit/49f4071f30a88289a30642265c881dab694cda6d) eggnog-mapper: 2.1.7 -> 2.1.9
* [`cda1c9e5`](https://github.com/NixOS/nixpkgs/commit/cda1c9e5add2495c9e4ecbe77be3887efe0906b5) klaus: 1.5.2 -> 2.0.0
* [`4c55439a`](https://github.com/NixOS/nixpkgs/commit/4c55439a366aa142332bbc59b55c9e26501db955) iosevka-bin: 15.6.3 -> 16.0.0
* [`2c9226d8`](https://github.com/NixOS/nixpkgs/commit/2c9226d8de3ed3ac64d44b3624876f6b0456b74f) kubectl-evict-pod: 0.0.10 -> 0.0.12
* [`bc3d4bb2`](https://github.com/NixOS/nixpkgs/commit/bc3d4bb2956eadef8452b06542b2d3b9ecdf5a40) session-desktop: refactor
* [`f0d35d87`](https://github.com/NixOS/nixpkgs/commit/f0d35d87956ea418636a8bdd5b5851cde2b0ad62) bluejeans-gui: 2.29.1.3 -> 2.30.0.89
* [`1e6931da`](https://github.com/NixOS/nixpkgs/commit/1e6931dac85fc1cc8d668bdd9160cbfab247a7cf) vopono: 0.10.1 -> 0.10.3
* [`ca780fa5`](https://github.com/NixOS/nixpkgs/commit/ca780fa58e564bca1d4923c665ed23906fc562f3) ddnet: 16.2.2 -> 16.3
* [`411a0f1f`](https://github.com/NixOS/nixpkgs/commit/411a0f1fb8703af547f1fc478e3c08154e1a1b35) python310Packages.rpy2: 3.5.3 -> 3.5.4
* [`80a29b82`](https://github.com/NixOS/nixpkgs/commit/80a29b820558c084121ab546e84c77d0048af34b) linode-cli: 5.22.0 -> 5.22.0
* [`7fad6abd`](https://github.com/NixOS/nixpkgs/commit/7fad6abd10e3e2456dbb0b4c913bbe5bc0d2615f) python310Packages.holidays: 0.14.2 -> 0.15
* [`b1f1945e`](https://github.com/NixOS/nixpkgs/commit/b1f1945e3e0dedd6033bf4ae2c5c01319a59be9d) ngtcp2: 0.7.0 -> 0.8.0
* [`e660ff47`](https://github.com/NixOS/nixpkgs/commit/e660ff477a876d5b26dc6b2bf3360b047d5da723) prosody: 0.12.0 -> 0.12.1
* [`a5923a71`](https://github.com/NixOS/nixpkgs/commit/a5923a71395c4d418db8b4524db451f984adbe9b) i2pd: 2.42.1 -> 2.43.0
* [`c93e2e58`](https://github.com/NixOS/nixpkgs/commit/c93e2e58ec0b797f04ec844447297c59e105493e) hyper: 3.2.3 -> 3.3.0
* [`85f93fb9`](https://github.com/NixOS/nixpkgs/commit/85f93fb9c2ece947bdb65f758b9d444cc6b77aa2) adguardhome: 0.107.9 - 0.107.11
* [`b383b5d3`](https://github.com/NixOS/nixpkgs/commit/b383b5d386d86603c9838abe523568a42f21f0d2) python310Packages.mautrix: 0.17.3 -> 0.17.8
* [`838d46c0`](https://github.com/NixOS/nixpkgs/commit/838d46c003fd8f60e987cf0444748e5786fc3d34) session-desktop: etc
* [`e0052173`](https://github.com/NixOS/nixpkgs/commit/e005217333d5d6a43b56d3e1234accaaaf233904) ddnet: 16.3 -> 16.3.1
* [`203f58e9`](https://github.com/NixOS/nixpkgs/commit/203f58e96c3982a36f1f017e595df75f8e3723f5) python310Packages.xsdata: 22.7 -> 22.8
* [`6b252786`](https://github.com/NixOS/nixpkgs/commit/6b2527860fd2c84394e8f5d5a68c48c807e73857) aws-c-cal: 0.5.17 -> 0.5.18
* [`59d92ec2`](https://github.com/NixOS/nixpkgs/commit/59d92ec2d1b47c6dd345b74373e42c68541f271c) belr: 5.1.12 -> 5.1.55
* [`2d92da3f`](https://github.com/NixOS/nixpkgs/commit/2d92da3f830f2a44199b64ac19333e23ab5bea82) cargo-udeps: 0.1.30 -> 0.1.32
* [`73c90bad`](https://github.com/NixOS/nixpkgs/commit/73c90badf31492c8cf67745d46de277321b4712a) emacs: Simplify patchelf invocation when building with lucid
* [`ca25a9c7`](https://github.com/NixOS/nixpkgs/commit/ca25a9c7b2025deafaab976912117e1ca31fc061) emacs: Enable xinput2 on version 29 and newer
* [`f8de0c5d`](https://github.com/NixOS/nixpkgs/commit/f8de0c5d72652f602beec176300a75cc98d37772) python310Packages.xsdata: update disabled
* [`69c21d5b`](https://github.com/NixOS/nixpkgs/commit/69c21d5bff5458bd5e42bfdc55a96e3a7cd66276) bazel_6: fix darwin build
* [`c8dc3956`](https://github.com/NixOS/nixpkgs/commit/c8dc3956f424cd4cd7229f0e7873aeedf7ea8373) kubevirt: 0.55.1 -> 0.56.0
* [`c2b1044d`](https://github.com/NixOS/nixpkgs/commit/c2b1044d073730d3edb5fb44c8b8a3a6a3d7a029) minio-client: 2022-08-11T00-30-48Z -> 2022-08-23T05-45-20Z
* [`b21d2654`](https://github.com/NixOS/nixpkgs/commit/b21d26541fe785a54376cf5377db9851bc0a5719) pwsafe: 1.14.0 -> 1.15.0
* [`a720c3b2`](https://github.com/NixOS/nixpkgs/commit/a720c3b2acc67ecd124fc94ad0888a5e605ca5e7) mutagen-compose: 0.15.1 -> 0.15.2
* [`c924ea1e`](https://github.com/NixOS/nixpkgs/commit/c924ea1eaa50e2d5bc88affcbf66362616225d3a) dlib: add Darwin support
* [`d84b39df`](https://github.com/NixOS/nixpkgs/commit/d84b39df2bafbf7f506ea4ac49e770abff9cd4ab) s2n-tls: 1.3.12 -> 1.3.20
* [`ec405741`](https://github.com/NixOS/nixpkgs/commit/ec405741495a8a27edd0a8b16cbbe090778cebc8) rubberband: fix build on darwin
* [`78b312a8`](https://github.com/NixOS/nixpkgs/commit/78b312a895f8368746318bacb2634a151e8ea6ae) grafana: fix cross compile
* [`a0dc4385`](https://github.com/NixOS/nixpkgs/commit/a0dc43851655a0099bf3216f7c08c99da85897c3) Drop Python 3.6 support
* [`88d68414`](https://github.com/NixOS/nixpkgs/commit/88d684142210185f17d3a525f0a75b9a1f94aca9) ycmd: unstable-2020-02-22 -> unstable-2022-08-15
* [`89f81fb9`](https://github.com/NixOS/nixpkgs/commit/89f81fb91c83513cf1daa81b61c3ae9c6aaed25e) Update license according to upstream changelog
* [`6f8f90e0`](https://github.com/NixOS/nixpkgs/commit/6f8f90e056b93cf7efddf59aa45b906a8a573ab9) crawl: 0.28.0 -> 0.29.0
* [`249dfd09`](https://github.com/NixOS/nixpkgs/commit/249dfd092cfcfe2dc991a433750ab5f5ae94a7e2) crawlTiles: 0.28.0 -> 0.29.0
* [`9ae30fe4`](https://github.com/NixOS/nixpkgs/commit/9ae30fe404e891430672344ddec8f025da8d1d02) dolt: 0.40.26 -> 0.40.28
* [`b3f68591`](https://github.com/NixOS/nixpkgs/commit/b3f68591e1a80130f1619cfd74d98422d579559c) lilypond-unstable: 2.23.11 -> 2.23.12
* [`0b6cce1c`](https://github.com/NixOS/nixpkgs/commit/0b6cce1cc13e5695c4df5eca5f2833bfdf1e8bf4) google-guest-agent: 20220713.00 -> 20220824.00
* [`d3d99c71`](https://github.com/NixOS/nixpkgs/commit/d3d99c715f57deec29000c626f458f8c0be0964a) binance: 1.36.0 -> 1.39.0
* [`189c57aa`](https://github.com/NixOS/nixpkgs/commit/189c57aaa6814e33355122bc6e3d14094071297a) mpvacious: 0.15 -> 0.18
* [`a2fd7e4f`](https://github.com/NixOS/nixpkgs/commit/a2fd7e4f8618fb32fc5a3235bcce4b00949d1fd4) xfce.xfce4-panel: 4.16.4 -> 4.16.5
* [`709c2767`](https://github.com/NixOS/nixpkgs/commit/709c27676cc468e22b12eb501b2fbd4e0e0c7128) murex: init at 2.10.2400
* [`47d95a05`](https://github.com/NixOS/nixpkgs/commit/47d95a05df3beb00fac786f400226e39c59c862d) haproxy: 2.6.2 -> 2.6.4
* [`41fa2436`](https://github.com/NixOS/nixpkgs/commit/41fa2436ddf466895d51adbc07e583b20e6be120) xfce.xfdesktop: 4.16.0 -> 4.16.1
* [`38a637bf`](https://github.com/NixOS/nixpkgs/commit/38a637bf92c3290c0deb6aa785a3df22bdfbea9e) kore: 4.2.2 -> 4.2.3
* [`e9a09bea`](https://github.com/NixOS/nixpkgs/commit/e9a09beacbca7f9ad33da3934e7c2443a258b429) purpur: 1.18.1r1522 -> 1.19.2r1763
* [`d8bb7ec1`](https://github.com/NixOS/nixpkgs/commit/d8bb7ec120d2472caf84785cc5271ed899a67517) prometheus-v2ray-exporter: init at 0.6.0
* [`6bff3605`](https://github.com/NixOS/nixpkgs/commit/6bff360532ceee13b268c0c8229212aa585a043a) python310Packages.jax: 0.3.6 -> 0.3.16
* [`3f682fbe`](https://github.com/NixOS/nixpkgs/commit/3f682fbe444169a7447050b8841278f8d58f64ec) obconf: add GSettings schemas path
* [`e193ece4`](https://github.com/NixOS/nixpkgs/commit/e193ece45d579d8e4ce63f86ac0e3a96132d38a7) obconf: improve code layout
* [`04648b8d`](https://github.com/NixOS/nixpkgs/commit/04648b8dcf42fbfdfc8d35c1e5456f0f2507961a) nixos/qemu: Add pkgs option for allowing other systems to run the VM
* [`8a25d56a`](https://github.com/NixOS/nixpkgs/commit/8a25d56a6d30c6d1f38bdf88ca76a26e1b5d1302) nixos/qemu: nixpkgs-fmt nixos/lib/qemu-common.nix
* [`e0fd1313`](https://github.com/NixOS/nixpkgs/commit/e0fd1313108ba200669d3e4e6a84d63b84a72a5a) nixos/qemu: Add QEMU arguments for HVF on Darwin
* [`cc457c59`](https://github.com/NixOS/nixpkgs/commit/cc457c5912ffe25e658ea0e232f57a493b43b6d4) ocamlformat_0_24_1: added
* [`b71a9802`](https://github.com/NixOS/nixpkgs/commit/b71a9802d7ac89718f4d465c320e32299f3beda5) arpack: reenable stackprotector on aarch64-darwin
* [`1c86d5c8`](https://github.com/NixOS/nixpkgs/commit/1c86d5c8a2e44f273649f264eb807f866f882215) xsimd: 7.5.0 -> 8.1.0
* [`56486fab`](https://github.com/NixOS/nixpkgs/commit/56486fab3bb89832ed91968ce385295015fa7b27) sundials: reenable stackprotector on aarch64-darwin
* [`f4356850`](https://github.com/NixOS/nixpkgs/commit/f435685046fc6816cdfc169212c6af441b9db8da) ngtcp2-gnutls: init at 0.7.0
* [`b17757e4`](https://github.com/NixOS/nixpkgs/commit/b17757e458b878b987d9aaddf8a48b0595e01d90) knot-dns: add QUIC support
* [`9646f307`](https://github.com/NixOS/nixpkgs/commit/9646f307a2a53e986b86f03a6ccc6c378b2a87a0) signal-desktop: 5.54.0 -> 5.56.0
* [`72a667cb`](https://github.com/NixOS/nixpkgs/commit/72a667cbd912f78256c7a67826021601c23d2a75) mattermost: 7.1.1 -> 7.2.0
* [`6c2479f6`](https://github.com/NixOS/nixpkgs/commit/6c2479f6e999a2168dafe1e6ada2dbec4ca4d80a) trilium-{desktop,server}: 0.54.2 -> 0.54.3
* [`7753d63d`](https://github.com/NixOS/nixpkgs/commit/7753d63d114e9b7da7a92356511552d052cfb620) gitleaks: 8.11.0 -> 8.11.2
* [`4efdbfcb`](https://github.com/NixOS/nixpkgs/commit/4efdbfcbb4089195b3bb574cc4bcf33718f13434) vscode-extensions.usernamehw.errorlens: 3.5.1 -> 3.6.0
* [`d751d98d`](https://github.com/NixOS/nixpkgs/commit/d751d98dedcad2d1be5b5a851d0b38a8a36bea6a) netease-cloud-music-gtk: 2.0.1 -> 2.0.2
* [`95a66526`](https://github.com/NixOS/nixpkgs/commit/95a6652630e0f72dc41ebec62bb3c88f889823fe) maintainers: add baitinq
* [`74653c22`](https://github.com/NixOS/nixpkgs/commit/74653c2289a542172ec2061948f5b3f1882ff4e8) python.pkgs.sphinx-mdinclude: init at 0.5.2
* [`ee51f569`](https://github.com/NixOS/nixpkgs/commit/ee51f569cc06b2649202fe84f6b1b47c661a7392) python.pkgs.picobox: init
* [`4c9c4cf9`](https://github.com/NixOS/nixpkgs/commit/4c9c4cf95ae1c00953e26c0a55c6f608e6bcdfdc) python.pkgs.sphinxcontrib-openapi: switch to cilium fork
* [`1e2363fd`](https://github.com/NixOS/nixpkgs/commit/1e2363fd985f9be42f00e7158dd21ae05a50e3b0) python310Packages.databricks-cli: 0.17.1 -> 0.17.3
* [`84d4ab85`](https://github.com/NixOS/nixpkgs/commit/84d4ab856a26c05c3a19926b6df68186c2d9d793) python310Packages.ipydatawidgets: 4.3.1.post1 -> 4.3.2
* [`bf7d05e6`](https://github.com/NixOS/nixpkgs/commit/bf7d05e64d1172ad9356b87bc8c2a643f600e1f0) nixos/keepalived: add secrets support
* [`f9b83ece`](https://github.com/NixOS/nixpkgs/commit/f9b83ece2bc18d3e297159a76e7d0c8011bd55bc) linuxPackages.apfs: unstable-2022-07-24 -> unstable-2022-08-15
* [`5ac6f87f`](https://github.com/NixOS/nixpkgs/commit/5ac6f87f64aae63b5074f31346b72bc6880c537c) hydrus: 496 -> 497
* [`a5077042`](https://github.com/NixOS/nixpkgs/commit/a50770424afd750552501d670447de1d632c3db4) rss2email: 3.13.1 -> 3.14
* [`e123a3b3`](https://github.com/NixOS/nixpkgs/commit/e123a3b3805ab9a47858ef875288efbc91e18c08) streamlit: 1.11.1 -> 1.12.2
* [`2b948ee0`](https://github.com/NixOS/nixpkgs/commit/2b948ee0a4fb4a607e3667900305ae25137b434d) uefitool.new-engine: A59 -> A60
* [`576005a3`](https://github.com/NixOS/nixpkgs/commit/576005a34a9b3bbdb0fbe1ce1548fb1fb02fd9ef) nixos/gnupg: use better trick to update the agent TTY
* [`3be5a4dd`](https://github.com/NixOS/nixpkgs/commit/3be5a4dd6a0c8937bcd87630e81855f5b93dca32) pythonPackages.edalize: init at 0.4.0
* [`44572506`](https://github.com/NixOS/nixpkgs/commit/445725069637eff203031bf23b72434ef6092168) silice: init at unstable-2022-08-05
* [`b3c82f44`](https://github.com/NixOS/nixpkgs/commit/b3c82f445c89c39191dc97b266519ef13e66f513) gamescope: 3.11.39 -> 3.11.43
* [`f6390497`](https://github.com/NixOS/nixpkgs/commit/f63904976fdb2fb8e515c8031b13d8f589dc7a16) aws-c-sdkutils: 0.1.2 -> 0.1.3
* [`75c83fcd`](https://github.com/NixOS/nixpkgs/commit/75c83fcd07b9d12958fc4d5d16fbb314a2ff654e) abcmidi: 2022.08.01 -> 2022.08.23
* [`0a9081c2`](https://github.com/NixOS/nixpkgs/commit/0a9081c251bfc2b9c5c1d3fe0bf7e5fabee5d7bd) aws-checksums: 0.1.12 -> 0.1.13
* [`c165305d`](https://github.com/NixOS/nixpkgs/commit/c165305dcd4ae02855a88fe0edc31b043178a980) aws-c-compression: 0.2.14 -> 0.2.15
* [`4ae959e9`](https://github.com/NixOS/nixpkgs/commit/4ae959e94913a257ebf40255f6ddc7ca0eda4811) btcpayserver: 1.6.9 -> 1.6.10
* [`d7af68bd`](https://github.com/NixOS/nixpkgs/commit/d7af68bd878ab7a6385f192d670e6a0122c46337) cargo-whatfeatures: 0.9.7 -> 0.9.9
* [`9fdbea27`](https://github.com/NixOS/nixpkgs/commit/9fdbea27fdc16771bd8a3201b7d942a244f082e2) cudatext: 1.168.0 → 1.169.2
* [`a9ec42c4`](https://github.com/NixOS/nixpkgs/commit/a9ec42c41bcf536deec16123a992baec87ba09d0) waylevel: init at 1.0.0
* [`ea51fbc9`](https://github.com/NixOS/nixpkgs/commit/ea51fbc96e7ce5c2edd81eff19d3e55e69b61260) emacsPackages.ebuild-mode: 1.55 -> 1.60
* [`7af3a97e`](https://github.com/NixOS/nixpkgs/commit/7af3a97ed275bc31d2b60fb7ae6a9e6bc20cd607) pipenv: 2022.8.14 -> 2022.8.24
* [`0808d110`](https://github.com/NixOS/nixpkgs/commit/0808d1107f2eb3da8a02091de693cbfc61151fea) mautrix-signal: fix failing build
* [`7f227409`](https://github.com/NixOS/nixpkgs/commit/7f227409836dcdd49024dc76417544b407f99e7c) nixos/syncthing: fix path setting for versioning
* [`8fb82d80`](https://github.com/NixOS/nixpkgs/commit/8fb82d80fe1133fbbae641b74472cb1bb3b63aae) cmark-gfm: 0.29.0.gfm.4 -> 0.29.0.gfm.5
* [`c05b6623`](https://github.com/NixOS/nixpkgs/commit/c05b66233ec7389769cdc14eb65b4202715486bb) z3: 4.8 -> 4.11 https://github.com/Z3Prover/z3/releases/tag/z3-4.11.0
* [`ece58d32`](https://github.com/NixOS/nixpkgs/commit/ece58d3205fa365daf494106a024f4fbe7783cf2) erigon: 2022.08.02 -> 2022.08.03
* [`a1b94d6f`](https://github.com/NixOS/nixpkgs/commit/a1b94d6f2df6bef8078760de38009aacc27f053e) gcsfuse: 0.41.4 -> 0.41.6
* [`d5af8dec`](https://github.com/NixOS/nixpkgs/commit/d5af8dec4ea1f616d7954b9b497e5a08d37beecb) go-graft: 0.2.8 -> 0.2.9
* [`cded789f`](https://github.com/NixOS/nixpkgs/commit/cded789fb110749bb6cd4d4f13a78f3d761afe9d) inspircdMinimal: 3.13.0 -> 3.14.0
* [`b71bb7d8`](https://github.com/NixOS/nixpkgs/commit/b71bb7d806c24eff704ae376c7a7b54c565f7d48) intel-compute-runtime: 22.32.23937 -> 22.34.24023
* [`c04cd3ab`](https://github.com/NixOS/nixpkgs/commit/c04cd3abcb4465cde1ffd083b2068c63863ec7d1) kuma: 1.7.1 -> 1.8.0
* [`a2001ac0`](https://github.com/NixOS/nixpkgs/commit/a2001ac0ff9d8bcbd257ab970922e42eb1fa6d38) kuma-cp: 1.7.1 -> 1.8.0
* [`3ef6193e`](https://github.com/NixOS/nixpkgs/commit/3ef6193ec892f82cbde4f3b612ea8a8320f3c7e0) kuma-dp: 1.7.1 -> 1.8.0
* [`0fa191ed`](https://github.com/NixOS/nixpkgs/commit/0fa191edda1971ce6be7e6c8d358040367583b65) kuma-experimental: 1.7.1 -> 1.8.0
* [`4aa1f67d`](https://github.com/NixOS/nixpkgs/commit/4aa1f67d0e3ceb475ff16c0486c9c9eaf459b28b) libcgroup: 2.0.2 -> 3.0
* [`8066ee50`](https://github.com/NixOS/nixpkgs/commit/8066ee50b7c176e4ba738eb56a90147f2fa52d06) minio: 2022-08-13T21-54-44Z -> 2022-08-25T07-17-05Z
* [`817413c0`](https://github.com/NixOS/nixpkgs/commit/817413c0425d3e95f0ce5f1c98b7df489c4a1825) manga-cli: init at 1.0.5
* [`4644eba2`](https://github.com/NixOS/nixpkgs/commit/4644eba22cdd2330df1237611cef0a420d3bdd6a) netbird: 0.8.9 -> 0.8.10
* [`ff458a81`](https://github.com/NixOS/nixpkgs/commit/ff458a81b7136e1b25b47b5acad97dfc9e269dbc) nixpacks: 0.3.3 -> 0.3.8
* [`9ec7c66b`](https://github.com/NixOS/nixpkgs/commit/9ec7c66bb46f0ad512b46a9555e5183830f7d8c0) oh-my-posh: 8.33.0 -> 8.36.1
* [`0a8dcdfb`](https://github.com/NixOS/nixpkgs/commit/0a8dcdfbb0ac94d070762e2af5e8fcbd47fedd86) electron_20: 20.0.1 -> 20.1.0
* [`dc452a3e`](https://github.com/NixOS/nixpkgs/commit/dc452a3e036f534c14fa87fcbd2a42f0818b3b9c) operator-sdk: 1.22.2 -> 1.23.0
* [`e2a4913d`](https://github.com/NixOS/nixpkgs/commit/e2a4913db5cfa4edf3b78a5ce2cc6068866e231c) plantuml-server: 1.2022.6 -> 1.2022.7
* [`ff736cd9`](https://github.com/NixOS/nixpkgs/commit/ff736cd9e3eebbd47a1ae7d74d20e48453edf09e) pocketbase: 0.4.2 -> 0.5.1
* [`666b8597`](https://github.com/NixOS/nixpkgs/commit/666b8597dabcca0ba1c4d9e3f4eaff5f74abe8b1) polkadot: 0.9.27 -> 0.9.28
* [`17f69801`](https://github.com/NixOS/nixpkgs/commit/17f698012250efcf22dc593aefa15f253207ac94) prometheus-gitlab-ci-pipelines-exporter: 0.5.3 -> 0.5.4
* [`a983d4e7`](https://github.com/NixOS/nixpkgs/commit/a983d4e779dcd0fa05e5d227233cdd29702e7e89) fuzzel: refactor configure options
* [`08c4bda4`](https://github.com/NixOS/nixpkgs/commit/08c4bda495d3450d4791145196376ba1108f80a8) prometheus-redis-exporter: 1.43.1 -> 1.44.0
* [`314d7814`](https://github.com/NixOS/nixpkgs/commit/314d7814e6d7e8867730733ea929e96e2b5bc99c) railway: 2.0.8 -> 2.0.10
* [`ff997b83`](https://github.com/NixOS/nixpkgs/commit/ff997b83e1db3feb17670eb0735da562abfa7bcc) nixos/writefreely: init
* [`a8d96b8b`](https://github.com/NixOS/nixpkgs/commit/a8d96b8b9902be561baad7a1d221ad6806805836) ripes: 2.2.4 -> 2.2.5
* [`5f90d904`](https://github.com/NixOS/nixpkgs/commit/5f90d90447d0d4867adf103de55e9893afa62c25) verible: init at 0.0-2172-g238b6df6
* [`c2efe5de`](https://github.com/NixOS/nixpkgs/commit/c2efe5ded0032204ff2e4862dce9667538982599) rocksdb: 7.4.5 -> 7.5.3
* [`5d9c4908`](https://github.com/NixOS/nixpkgs/commit/5d9c49086d5c9b981ccc09a9153f9ff1c247ca8b) rocketchat-desktop: 3.8.7 -> 3.8.8
* [`6de85da8`](https://github.com/NixOS/nixpkgs/commit/6de85da84cb24b46149371d06c05682e7bdfcb51) rofi-wayland-unwrapped: 1.7.3+wayland1 -> 1.7.5+wayland1
* [`72dc88a9`](https://github.com/NixOS/nixpkgs/commit/72dc88a9aa24586d088d037839e462098645e18f) fuzzel: revert CFLAGS workaround for librsvg regression
* [`f889b498`](https://github.com/NixOS/nixpkgs/commit/f889b49865fdc01ca09705497a70e1895bdc0830) rpm-ostree: 2022.12 -> 2022.13
* [`e71897f8`](https://github.com/NixOS/nixpkgs/commit/e71897f8ce44db00910963fb94122a3210ed1fe1) git-remote-gcrypt: 1.4 -> 1.5
* [`0e0a7446`](https://github.com/NixOS/nixpkgs/commit/0e0a74465bb368f62385db59dce44e6ef00a16a0) python310Packages.mkdocs-redirects: 1.0.4 -> 1.1.0
* [`a6fcfd14`](https://github.com/NixOS/nixpkgs/commit/a6fcfd14a09ccb724ef3979203b9c72c1ddc78a7) gocyclo: 0.4.0 -> 0.6.0
* [`be9f2e02`](https://github.com/NixOS/nixpkgs/commit/be9f2e02a3a273e09f90002cdb849f3bf2c49e94) safe: 1.6.1 -> 1.7.0
* [`8bbc22d0`](https://github.com/NixOS/nixpkgs/commit/8bbc22d0942c0cec3b3a9f8b6f6cb87b5af6588e) seasocks: 1.4.4 -> 1.4.5
* [`70f3866d`](https://github.com/NixOS/nixpkgs/commit/70f3866df8c225cc1f54c67b9cd55b688b341a45) sish: 2.5.0 -> 2.6.0
* [`7eac217d`](https://github.com/NixOS/nixpkgs/commit/7eac217de70b94132c5f09d7befe17daa969efee) snipe-it: 6.0.9 -> 6.0.10
* [`494711ab`](https://github.com/NixOS/nixpkgs/commit/494711ab254f6e717e6487dffdce44d732ee090b) so: 0.4.8 -> 0.4.9
* [`d7f61154`](https://github.com/NixOS/nixpkgs/commit/d7f61154c3450a0fc034d6f681a9acd4143db14e) zoom-us: fix virtual backgrounds
* [`10faabf1`](https://github.com/NixOS/nixpkgs/commit/10faabf1fd83882186ba0f43116034bfee09e130) sov: 0.72 -> 0.73
* [`f96ea768`](https://github.com/NixOS/nixpkgs/commit/f96ea768e7d57fe141ddbf448e74e975e4b9eb0d) sqlite-utils: 3.28 -> 3.29
* [`bb2f4375`](https://github.com/NixOS/nixpkgs/commit/bb2f43757348b3c5fe9b55c86331c0ca07cc2a0a) sssd: 2.7.3 -> 2.7.4
* [`3165c318`](https://github.com/NixOS/nixpkgs/commit/3165c31822ff4f7d5c0d91d99df4cbfe81693e08) step-ca: 0.21.0 -> 0.22.0
* [`7e275916`](https://github.com/NixOS/nixpkgs/commit/7e275916bac39b945ade25f28b7f13c343b39afb) step-cli: 0.21.0 -> 0.22.0
* [`875e3168`](https://github.com/NixOS/nixpkgs/commit/875e3168c432d50f0416b2d038a6db859ca57e17) python310Packages.pybase64: 1.2.2 -> 1.2.3
* [`6051d295`](https://github.com/NixOS/nixpkgs/commit/6051d2959b8455c63bb504b12defb00f11ef06f4) fzf: 0.32.1 -> 0.33.0
* [`44e9995d`](https://github.com/NixOS/nixpkgs/commit/44e9995dbea7de5b2331e74061b21cf143944c12) taoup: 1.1.17 -> 1.1.18
* [`2692e682`](https://github.com/NixOS/nixpkgs/commit/2692e682c7fe5001388449c82eb82982f3f2ed59) taskwarrior-tui: 0.23.5 -> 0.23.6
* [`0ec9c55a`](https://github.com/NixOS/nixpkgs/commit/0ec9c55a3dead4e06a23073eb44f4ddd587d6eb4) tcpreplay: 4.4.1 -> 4.4.2
* [`187e3ee8`](https://github.com/NixOS/nixpkgs/commit/187e3ee88f9f9f0c3aca604f7a671bb06f5d6910) terragrunt: 0.38.7 -> 0.38.8
* [`2203cc84`](https://github.com/NixOS/nixpkgs/commit/2203cc848241849393509cf80ee9d379c6cb7e41) thanos: 0.27.0 -> 0.28.0
* [`31ac6d79`](https://github.com/NixOS/nixpkgs/commit/31ac6d793c38d2385998a59bad75b58411998f9f) texlab: 4.2.1 -> 4.2.2
* [`2af57386`](https://github.com/NixOS/nixpkgs/commit/2af57386fd94b777ea26bac64fc5bfb3b66fa647) ticker: 4.5.3 -> 4.5.4
* [`27de2973`](https://github.com/NixOS/nixpkgs/commit/27de2973bddce863a1c5836706cacd41b98cc6df) ttchat: 0.1.6 -> 0.1.7
* [`769468ad`](https://github.com/NixOS/nixpkgs/commit/769468add8d441978846e5b040641f1441fa9959) vgrep: 2.6.0 -> 2.6.1
* [`a6444465`](https://github.com/NixOS/nixpkgs/commit/a6444465fd22912ec0a62a55e28fbc701634cafd) waf-tester: 0.6.10 -> 0.6.12
* [`289ace3d`](https://github.com/NixOS/nixpkgs/commit/289ace3de1ec233ba5adfa0077ce0cbddbf40e8e) grapejuice: 5.2.2 -> 5.5.4
* [`ae9628b3`](https://github.com/NixOS/nixpkgs/commit/ae9628b3cdfd711cb77351ddbe1bda98bd7a7a11) wslu: 3.2.4 -> 4.0.0
* [`3a796f62`](https://github.com/NixOS/nixpkgs/commit/3a796f62bbc22df71ae3a543ca157d0079c6209a) python310Packages.debian: 0.1.44 -> 0.1.47
* [`5e6302fa`](https://github.com/NixOS/nixpkgs/commit/5e6302fadc369fb36d1308dcbd748e35e15f0e7c) mapproxy: move to servers/geospatial
* [`56779553`](https://github.com/NixOS/nixpkgs/commit/56779553579fb31723f66a116d44a4bd71f3e570) python310Packages.flufl_lock: 7.0 -> 7.1
* [`1bfbba73`](https://github.com/NixOS/nixpkgs/commit/1bfbba73a9f6b602e3707774f265543e75e20506) brotab: 1.3.0 -> 1.4.2
* [`827e4119`](https://github.com/NixOS/nixpkgs/commit/827e411977772bd7c5d204b55e4fe016088cd504) forge-mtg: be less verbose when building
* [`da766bde`](https://github.com/NixOS/nixpkgs/commit/da766bde28a0b7a8acad094b5c6c187eb858c232) ocamlPackages.odoc: disable tests with yojson ≥ 2.0
* [`f09f7f17`](https://github.com/NixOS/nixpkgs/commit/f09f7f1778d7113651967e53bfbc2b0e92976d2e) ocamlPackages.yojson: 1.7.0 → 2.0.2
* [`53683c2b`](https://github.com/NixOS/nixpkgs/commit/53683c2b868226c7c583969a96946a309c6c5ecc) metals: 0.11.7 -> 0.11.8
* [`bc3de602`](https://github.com/NixOS/nixpkgs/commit/bc3de6023057f177c9dfa56262a6f343916c9c7f) bloop: 1.5.2 -> 1.5.3
* [`73d00063`](https://github.com/NixOS/nixpkgs/commit/73d00063e9d7669345537a7291c9c1bb8d9355f6) python310Packages.mailsuite: 1.9.5 -> 1.9.7
* [`9fc7a29d`](https://github.com/NixOS/nixpkgs/commit/9fc7a29da5e2e69033a6ee933acbe8dad49ade1f) nix-fallback-paths.nix: Update to 2.11.0
* [`a7bfb90e`](https://github.com/NixOS/nixpkgs/commit/a7bfb90ea82b360885dec4b9b2370189bd874d7e) nixos/vaultwarden: protect the default data directory more
* [`3e9b9905`](https://github.com/NixOS/nixpkgs/commit/3e9b99058e8182e29d866185c90129cc2572713d) pretender: init at 1.0.0
* [`9297cc12`](https://github.com/NixOS/nixpkgs/commit/9297cc1268fab03b26c22a718ffe1253ce40e687) python310Packages.airthings-ble: 0.3.0 -> 0.4.0
* [`f9bc715a`](https://github.com/NixOS/nixpkgs/commit/f9bc715a0ee0492e0cc80b7931cc710d24acd1df) python310Packages.airthings-ble: 0.4.0 -> 0.5.0
* [`1a0e572d`](https://github.com/NixOS/nixpkgs/commit/1a0e572d6dbe10d62f1410aaeddf78e3247b3a6a) nixVersions.nix_2_11: init at 2.11.0
* [`6e56024e`](https://github.com/NixOS/nixpkgs/commit/6e56024e67fb31c07d3531965d6c9210e638e84b) nixVersions.stable: 2.10 -> 2.11
* [`d2969188`](https://github.com/NixOS/nixpkgs/commit/d2969188461a3f29da7d32172c327af43d72b575) python310Packages.debian: specify license
* [`23073ad4`](https://github.com/NixOS/nixpkgs/commit/23073ad416ddfdb27aa4dad9b68c65d3285560f7) python310Packages.pykostalpiko: 1.1.1-1 -> 1.1.2
* [`c6e0e397`](https://github.com/NixOS/nixpkgs/commit/c6e0e3974860d8452c0dba8034bc443596be6601) actionlint: 1.6.16 -> 1.6.17
* [`2504a09d`](https://github.com/NixOS/nixpkgs/commit/2504a09d5b0b93558d46678ef579d89b0d6c8462) python310Packages.pymicrobot: 0.0.5 -> 0.0.6
* [`50596129`](https://github.com/NixOS/nixpkgs/commit/50596129c880eb48176aa7e1e2fe5055ff702c38) python310Packages.plugwise: 0.21.3 -> 0.22.0
* [`4d9dc378`](https://github.com/NixOS/nixpkgs/commit/4d9dc378814eaaddd3d1ffc78743a55e80709f1c) remarkable-mouse: 7.0.2 -> 7.0.3
* [`72bc74de`](https://github.com/NixOS/nixpkgs/commit/72bc74de82d5a34fff060e149e2aca2502216699) cppcheck: 2.8.2 -> 2.9
* [`5682ba0e`](https://github.com/NixOS/nixpkgs/commit/5682ba0e19915420893ab37de3186f2b19e653c0) python310Packages.peaqevcore: 5.14.0 -> 5.16.7
* [`d62730e1`](https://github.com/NixOS/nixpkgs/commit/d62730e1adafdb3055c20b91853054a9163ca279) purple-signald: fix output path
* [`af2cf176`](https://github.com/NixOS/nixpkgs/commit/af2cf176a4000afeb4b3014b9fe2b0d593d960ca) python310Packages.pex: 2.1.103 -> 2.1.104
* [`c8f7cc2b`](https://github.com/NixOS/nixpkgs/commit/c8f7cc2b2da9438bc42b1802fc4c3dd4d3d2391d) fluidd: 1.19.1 -> 1.20.0
* [`9fa4cd59`](https://github.com/NixOS/nixpkgs/commit/9fa4cd59de42f0123247959e5803821b7a2cd4a8) inspircd: 3.13.0 -> 3.14.0
* [`dec78712`](https://github.com/NixOS/nixpkgs/commit/dec78712ca04f97677f61d9933c97037556dac5f) python3Packages.markdownify: init at 0.11.4
* [`d0e1ddcc`](https://github.com/NixOS/nixpkgs/commit/d0e1ddccb7e9d2f5119fdb22a4f70139525b83ba) python3Packages.rsskey: init at 0.2.0
* [`577ffe14`](https://github.com/NixOS/nixpkgs/commit/577ffe149156dfa8d22db3033422ac47dec85ba9) helmsman: 3.13.1 -> 3.14.0
* [`d894f23f`](https://github.com/NixOS/nixpkgs/commit/d894f23f37c2b5807cf4a47c313dcac90cb94c9b) hugo: 0.101.0 -> 0.102.0
* [`ddec8f0a`](https://github.com/NixOS/nixpkgs/commit/ddec8f0ab7069a0aa051891dec1c46f7edcdb12f) jc: 1.21.0 -> 1.21.1
* [`de2ae287`](https://github.com/NixOS/nixpkgs/commit/de2ae287d56322cc8ab53e23563bc840a4ffa1dc) clightning: 0.11.2 -> 0.12.0
* [`6ae834ea`](https://github.com/NixOS/nixpkgs/commit/6ae834ea905832f197bf2cb64e7dfe385aa15604) python310Packages.pypdf2: 2.10.0 -> 2.10.4
* [`d6be3828`](https://github.com/NixOS/nixpkgs/commit/d6be38280c48808937dfa8b03ae3b89e48f0ed0c) obs-studio-plugins.obs-vkcapture: enable 32bit support ([nixos/nixpkgs⁠#188699](https://togithub.com/nixos/nixpkgs/issues/188699))
* [`c1d21222`](https://github.com/NixOS/nixpkgs/commit/c1d2122235225cccb0a69f23ea7de50232898623) diffoscope: 219 -> 221
* [`0ced469b`](https://github.com/NixOS/nixpkgs/commit/0ced469b215c4515b9e9348cd84ab9f77b72ac47) opentimestamps-client: 0.7.0 -> 0.7.1
* [`235337fa`](https://github.com/NixOS/nixpkgs/commit/235337fa800a0096a23593770d45d078f02eb728) pdd: 1.5 -> 1.6
* [`05c2b750`](https://github.com/NixOS/nixpkgs/commit/05c2b7507cdcd8d03a395b6a74f107bb20ae2c30) ffmpeg-normalize: 1.25.0 -> 1.25.1
* [`dfbbf249`](https://github.com/NixOS/nixpkgs/commit/dfbbf249b7d2ea3faf112715a1d5be4391b03231) cpu-x: 4.3.1 -> 4.4.0
* [`ed4caff5`](https://github.com/NixOS/nixpkgs/commit/ed4caff57e1f2614e1c70e76a04501580fd2cd20) biliass: 1.3.5 -> 1.3.4
* [`0178db0d`](https://github.com/NixOS/nixpkgs/commit/0178db0da3271cc04ad44de38997f405b19703fa) nixos/rust-motd: init
* [`77a4ffda`](https://github.com/NixOS/nixpkgs/commit/77a4ffda073bc7c5bcd281c931f876b6fa6f3935) fluxcd: 0.32.0 -> 0.33.0
* [`711aa833`](https://github.com/NixOS/nixpkgs/commit/711aa8336adf0f4dc228164cd2b2d090846fe070) bluetuith: 0.0.7 -> 0.1.2
* [`b79f9e9b`](https://github.com/NixOS/nixpkgs/commit/b79f9e9b8a822ac64710d67d26b558f9aba6d47b) nixos/awesome: fix luaModules using pkgs.lua instead of awesome.lua
* [`1e0cd07d`](https://github.com/NixOS/nixpkgs/commit/1e0cd07d8f12244be69d0f94e662a2fc618fc71e) calamares: 3.2.60 -> 3.2.61
* [`0f54dcf3`](https://github.com/NixOS/nixpkgs/commit/0f54dcf32021faaa0d78fa573eff718d76f6cd75) changie: 1.8.0 -> 1.9.0
* [`1001dc5d`](https://github.com/NixOS/nixpkgs/commit/1001dc5d8b1067f0861c414c6fc7948ac49e8e70) checkstyle: 10.3.2 -> 10.3.3
* [`cad61be2`](https://github.com/NixOS/nixpkgs/commit/cad61be25ef50805176641ad8d702864ad308ef2) python3Packages.screeninfo: fix on X11
* [`616e78d3`](https://github.com/NixOS/nixpkgs/commit/616e78d3163c762d16d4c763b47d4024bfb415f6) cvc5: 1.0.1 -> 1.0.2
* [`cbeafa65`](https://github.com/NixOS/nixpkgs/commit/cbeafa6526d2b63c7bc6a790ccc96798f79bfe4f) ddccontrol-db: 20220720 -> 20220829
* [`01f70337`](https://github.com/NixOS/nixpkgs/commit/01f70337fd58ea9afd1776f1b17154598c6cd108) epick: 0.7.0 -> 0.8.0
* [`3ee25a45`](https://github.com/NixOS/nixpkgs/commit/3ee25a45edd13c0e6ea893f48fa7942fb24f7812) hyperspace-cli: remove
* [`ae51ce17`](https://github.com/NixOS/nixpkgs/commit/ae51ce1742a90f4b198613ee0eade9b41168bd4b) python3Packages.google-cloud-compute: init at 1.4.0
* [`4f39ada7`](https://github.com/NixOS/nixpkgs/commit/4f39ada71b93575fc5a2353c2e6f4e84ce1fdde8) FAHClient: 7.6.13 -> 7.6.21 ([nixos/nixpkgs⁠#188476](https://togithub.com/nixos/nixpkgs/issues/188476))
* [`2f88279a`](https://github.com/NixOS/nixpkgs/commit/2f88279ab9486518879e5a8f9f9e96d3559b14a7) doc: specify that `longDescription` should be Markdown
* [`19c2f199`](https://github.com/NixOS/nixpkgs/commit/19c2f199c1890b1ca6f43f602bf988288db75385) python310Packages.sensor-state-data: 2.3.2 -> 2.4.0
* [`11067cee`](https://github.com/NixOS/nixpkgs/commit/11067cee9c64ba016971fba4d58cf005af9b3002) python310Packages.sensor-state-data: 2.4.0 -> 2.5.0
* [`1c645853`](https://github.com/NixOS/nixpkgs/commit/1c6458534d5d2179cc45a0cb699f17fd4e3c49f6) python310Packages.bthome-ble: 0.4.0 -> 0.5.0
* [`082ac9d2`](https://github.com/NixOS/nixpkgs/commit/082ac9d2bf3c99d10deaddb16ecea17237e246bb) python310Packages.bthome-ble: 0.5.0 -> 0.5.1
* [`72d888fe`](https://github.com/NixOS/nixpkgs/commit/72d888febd61a21d62029c3f6824cb6bca07b056) python310Packages.teslajsonpy: 2.4.3 -> 2.4.4
* [`d731a70f`](https://github.com/NixOS/nixpkgs/commit/d731a70f0ddd0b2afe39d39cdec42234cd59cb32) taler-merchant: fix git source
* [`b6e861e4`](https://github.com/NixOS/nixpkgs/commit/b6e861e418a022f963c23d25acc0085aef778645) use z3 4.8 as default z3
* [`29d9c256`](https://github.com/NixOS/nixpkgs/commit/29d9c256267deb6d5b1f8146f85733932834136e) hal-hardware-analyzer: use overridden fmt 8.0.1 for spdlog
* [`d542d385`](https://github.com/NixOS/nixpkgs/commit/d542d385a2aabdd3c4a36b1a122e8d6836e555c7) Add macalinao to maintainer-list.nix
* [`c09343f7`](https://github.com/NixOS/nixpkgs/commit/c09343f749b2f9345ad301a5e419b0c9a5ab1d7c) evtx: 0.7.2 -> 0.8.0
* [`a601f828`](https://github.com/NixOS/nixpkgs/commit/a601f828590f4a1cbb6c6c8a9a2f8a67f5f94135) flacon: 9.1.0 -> 9.2.0
* [`66184435`](https://github.com/NixOS/nixpkgs/commit/661844351c6ab02c8deff596298cebdd752f83fc) flycast: 1.3 -> 2.0
* [`c2d13f60`](https://github.com/NixOS/nixpkgs/commit/c2d13f6099a2eaaefdc8357ab0774e9ea743cdfc) folly: 2022.08.22.00 -> 2022.08.29.00
* [`98584efa`](https://github.com/NixOS/nixpkgs/commit/98584efa4b2562041e6937ae680a7a35f8f76224) sublime4.updateScript: fix on different systems
* [`75dc7411`](https://github.com/NixOS/nixpkgs/commit/75dc7411abe2bcfa72f0228e90b278e4da4497fb) sublime4.updateScript: Pass versionFile path through arguments
* [`424802ff`](https://github.com/NixOS/nixpkgs/commit/424802ffc5e99f2532c8f2a55601ee28803693d3) sublime-merge.updateScript: sync with sublime4
* [`49bab5e4`](https://github.com/NixOS/nixpkgs/commit/49bab5e44bb55e3ece1c252f0c71688b73822d67) sublime-merge-dev: 2073 → 2076
* [`b52054fa`](https://github.com/NixOS/nixpkgs/commit/b52054fab411bbba5226cbac76c546d59af68ca7) sublime4-dev: 4125 → 4134
* [`2dbf5a0a`](https://github.com/NixOS/nixpkgs/commit/2dbf5a0a1e6170707c0c127c51fd18d32365d37a) ccache: 4.6.2 -> 4.6.3
* [`96e98016`](https://github.com/NixOS/nixpkgs/commit/96e9801607733d20a59c0595d8332c913c58aa33) valentina: 0.6.1 → 0.7.51
* [`9ad0551c`](https://github.com/NixOS/nixpkgs/commit/9ad0551cf9bfbfc3cdd282525cd9d46886d4f079) glooctl: 1.12.9 -> 1.12.10
* [`51228d18`](https://github.com/NixOS/nixpkgs/commit/51228d186f47fcba643eaa16dcbc45a4e1daee93) php.extensions.inotify: init at 3.0.0
* [`bae4911d`](https://github.com/NixOS/nixpkgs/commit/bae4911dce6fd2e955135faa9a57fff6e4da01cf) Remove six dependency, not needed anymore
* [`83293ef3`](https://github.com/NixOS/nixpkgs/commit/83293ef3181c763157f5fcbea53cc2247fb37353) cargo-hakari: init at 0.9.14 ([nixos/nixpkgs⁠#188653](https://togithub.com/nixos/nixpkgs/issues/188653))
* [`ee27ae19`](https://github.com/NixOS/nixpkgs/commit/ee27ae199e68f527fa48c13d8f6973594770571e) python3Packages.pyschemes: Enable python 3.10
* [`6ca6ce1f`](https://github.com/NixOS/nixpkgs/commit/6ca6ce1f9d26c7338ed78ffe7d7814d3241fea36) python3Packages.icontract: Enable more tests
* [`af7b1414`](https://github.com/NixOS/nixpkgs/commit/af7b141444daa3bcc12186a566070b3f8c83f0a5) python3Packages.deal: Remove unneeded dependencies
* [`b8ec5dc2`](https://github.com/NixOS/nixpkgs/commit/b8ec5dc2b06ffa66394086eb4808a026742da4f3) conmon: 2.1.3 -> 2.1.4
* [`9bf849a0`](https://github.com/NixOS/nixpkgs/commit/9bf849a06fee21400bcd6fa9825ae52aed0c4f22) whitesur-icon-theme: 2022-05-11 -> 2022-08-30
* [`560ab4f7`](https://github.com/NixOS/nixpkgs/commit/560ab4f71568d7416a36b23e0b7c00caf718b508) pandoc-katex: init at 0.1.9
* [`03769f09`](https://github.com/NixOS/nixpkgs/commit/03769f0963c3bff1128babaedb6af20655fe29ef) yq-go: 4.27.2 -> 4.27.3
* [`f5bed3ba`](https://github.com/NixOS/nixpkgs/commit/f5bed3ba5de0ec048df15c5e8d355237497acbb4) kafkactl: 1.23.1 -> 2.5.0
* [`1aa7b598`](https://github.com/NixOS/nixpkgs/commit/1aa7b598cb257084f5f5a652c90719b8d5740d70) kak-lsp: 13.0.0 -> 14.0.0
* [`471ebeef`](https://github.com/NixOS/nixpkgs/commit/471ebeef4e604be21cf30d8d29e5eaa0a3092196) keycloak: 18.0.0 -> 19.0.1
* [`64e9c704`](https://github.com/NixOS/nixpkgs/commit/64e9c7049974389dd8c835dd02f3aa1ac8894822) btop: 1.2.8 -> 1.2.9
* [`c2ca372b`](https://github.com/NixOS/nixpkgs/commit/c2ca372b2dcde0fd6d68dcc1ce5576904024e6e9) lightspark: 0.8.6 -> 0.8.6.1
* [`e3aa534e`](https://github.com/NixOS/nixpkgs/commit/e3aa534e500dc43a655c1dd8722790e1e4f05c44) tts: 0.7.1 -> 0.8.0
* [`cb40cdf4`](https://github.com/NixOS/nixpkgs/commit/cb40cdf49a9dfb5ebaa4dbfbc564420803e5a5cb) webkitgtk: 2.36.6 -> 2.36.7
* [`43296127`](https://github.com/NixOS/nixpkgs/commit/4329612761d2ef413ea553307d623585faf082ca) minio: 2022-08-25T07-17-05Z -> 2022-08-26T19-53-15Z
* [`22354b30`](https://github.com/NixOS/nixpkgs/commit/22354b30a39175cb3152700d58235acf46d31b1f) chirp: 20211016 -> 20220823
* [`dce67ae4`](https://github.com/NixOS/nixpkgs/commit/dce67ae4528b68a7bd117fd2146e5f3292260220) libsoundio: fix build on darwin
* [`e645fe7a`](https://github.com/NixOS/nixpkgs/commit/e645fe7a5563cb5cddc78fb6e888b975f0b64b87) neatvnc: 0.5.1 -> 0.5.3
* [`0d7868b4`](https://github.com/NixOS/nixpkgs/commit/0d7868b45f9669032c34720a8e4254ded814316f) linux: 5.10.138 -> 5.10.139
* [`bb0eb96d`](https://github.com/NixOS/nixpkgs/commit/bb0eb96d45cfcb964a35b713b60c063ffc04ffd7) linux: 5.19.4 -> 5.19.5
* [`3235fcb1`](https://github.com/NixOS/nixpkgs/commit/3235fcb17d68a34da6492c2e3eba4d2f2a35b737) linux/hardened/patches/4.14: 4.14.290-hardened1 -> 4.14.291-hardened1
* [`c963a9fd`](https://github.com/NixOS/nixpkgs/commit/c963a9fd677e4b856f0e88db5f9402b327df0124) linux/hardened/patches/4.19: 4.19.255-hardened1 -> 4.19.256-hardened1
* [`18e3f842`](https://github.com/NixOS/nixpkgs/commit/18e3f842ec560410fae12b571171579b5d435ad1) linux/hardened/patches/5.10: 5.10.137-hardened1 -> 5.10.139-hardened1
* [`9c522171`](https://github.com/NixOS/nixpkgs/commit/9c522171418fb4a4941b0acc710967cf695d93e6) linux/hardened/patches/5.15: 5.15.62-hardened1 -> 5.15.63-hardened1
* [`6c64bc15`](https://github.com/NixOS/nixpkgs/commit/6c64bc1513af234e55ef7fe543a2538052b2af62) linux/hardened/patches/5.19: init at 5.19.5-hardened1
* [`8720e911`](https://github.com/NixOS/nixpkgs/commit/8720e91143440e1940a9971dc2aabc888fa0bd4c) linux/hardened/patches/5.4: 5.4.210-hardened1 -> 5.4.211-hardened1
* [`2c2a2c63`](https://github.com/NixOS/nixpkgs/commit/2c2a2c6311ac20fe97d7890bddbcdccee220c53a) oed: 6.7 -> 7.1
* [`a698615e`](https://github.com/NixOS/nixpkgs/commit/a698615e1d023dc57417d2ce5317d8c8c2f7d97c) python3.pkgs.pallets-sphinx-themes: init at 2.0.2
* [`4e731641`](https://github.com/NixOS/nixpkgs/commit/4e731641752a5e0e33edd842eb0b64f6092111d0) pdepend: 2.10.3 -> 2.11.0
* [`3897b361`](https://github.com/NixOS/nixpkgs/commit/3897b361233c96f4ff267e598646f6d8f32c26ea) pluto: 5.10.5 -> 5.10.6
* [`93104079`](https://github.com/NixOS/nixpkgs/commit/93104079d6393a4cfa9569c0cb52fa7586f949a5) praat: 6.2.16 -> 6.2.17
* [`77a42381`](https://github.com/NixOS/nixpkgs/commit/77a42381738d6178167d86da06964c8eed0fe98e) pure-maps: 3.1.0 -> 3.1.1
* [`d49aa612`](https://github.com/NixOS/nixpkgs/commit/d49aa612864d976c5684e315359e5ece3e900052) yubikey-manager: fix build on aarch64-darwin
* [`191189f3`](https://github.com/NixOS/nixpkgs/commit/191189f35f6c4ff79f8cdb772d8497036231faf8) beets-unstable: unstable-2022-05-08 -> unstable-2022-08-27
* [`66124eff`](https://github.com/NixOS/nixpkgs/commit/66124effe6a835461ef9659589e3060ee5a333f8) firefox-unwrapped: 104.0 -> 104.0.1
* [`0955d646`](https://github.com/NixOS/nixpkgs/commit/0955d646f50c13b2a7240db436749228264fdee8) firefox-bin-unwrapped: 104.0 -> 104.0.1
* [`0437543d`](https://github.com/NixOS/nixpkgs/commit/0437543dc599ac2e2eaeeccd5f6f48079631ae7e) firefox-beta-bin-unwrapped: 104.0b9 -> 105.0b4
* [`27c45326`](https://github.com/NixOS/nixpkgs/commit/27c45326b51f03531e04bf9ceeae71b4f98d71f4) firefox-devedition-bin-unwrapped: 104.0b10 -> 105.0b4
* [`7ce0cb62`](https://github.com/NixOS/nixpkgs/commit/7ce0cb62bf68b77105b1cccfed86a1eb8b6f7d89) regctl: 0.4.2 -> 0.4.4
* [`e076113f`](https://github.com/NixOS/nixpkgs/commit/e076113fbef1d64c7c02e53d8aa116fc90b6b15f) regsync: 0.4.2 -> 0.4.4
* [`ca8f183d`](https://github.com/NixOS/nixpkgs/commit/ca8f183dff92ee669c0bdb965dc6272c0520dd01) sameboy: 0.15.4 -> 0.15.5
* [`fbd0ca02`](https://github.com/NixOS/nixpkgs/commit/fbd0ca02dea32de9ec88350c6a28dd74ea76ff7c) seaweedfs: 3.23 -> 3.24
* [`8269c024`](https://github.com/NixOS/nixpkgs/commit/8269c0247d4d5536e022cc7fd290219f456d299d) sensu-go-agent: 6.7.5 -> 6.8.0
* [`1b3013e4`](https://github.com/NixOS/nixpkgs/commit/1b3013e460aba90a38c6f639cef7a30a0e0847fe) sensu-go-backend: 6.7.5 -> 6.8.0
* [`5a125f8b`](https://github.com/NixOS/nixpkgs/commit/5a125f8b2f401d030655d419125f806310e7c08a) snappymail: 2.17.2 -> 2.17.3
* [`5ecb51bc`](https://github.com/NixOS/nixpkgs/commit/5ecb51bc7957aca8b1f95c2dbaeb2ef85366e66a) speechd: 0.11.1 -> 0.11.2
* [`b5bce344`](https://github.com/NixOS/nixpkgs/commit/b5bce3443452e373a3e1db4b26c4ec7c6911d4ae) syft: 0.54.0 -> 0.55.0
* [`210fe87f`](https://github.com/NixOS/nixpkgs/commit/210fe87f051a5a10c2be10ef8f510e6f2a7124cf) syslogng: 3.37.1 -> 3.38.1
* [`db1e0c2a`](https://github.com/NixOS/nixpkgs/commit/db1e0c2abf901e5e69c76d728f1afbc30af14829) terragrunt: 0.38.8 -> 0.38.9
* [`7b10bc4b`](https://github.com/NixOS/nixpkgs/commit/7b10bc4b8a74f21378ac693685b6ee1a7164a2ee) timescaledb-tune: 0.13.1 -> 0.14.0
* [`99759c02`](https://github.com/NixOS/nixpkgs/commit/99759c026456c3d34d9ae3e81ba8d1d0334ad307) trivy: 0.31.2 -> 0.31.3
* [`cc587e67`](https://github.com/NixOS/nixpkgs/commit/cc587e67628c4c8e6385985ed5f1834e11c97fa3) unciv: 4.2.5-patch1 -> 4.2.6
* [`72672a2f`](https://github.com/NixOS/nixpkgs/commit/72672a2f7f39acf1dc057e45bb75b13a66073a61) wakatime: 1.53.4 -> 1.54.0
* [`e5aa0b26`](https://github.com/NixOS/nixpkgs/commit/e5aa0b2666e12640ca1901a08c8b2b05bac71569) whitesur-gtk-theme: 2022-02-21 -> 2022-08-26
* [`bbc1f115`](https://github.com/NixOS/nixpkgs/commit/bbc1f1157f72054b783142b87b1ef8b7e8b2bc4b) plexRaw: 1.28.1.6104-788f82488 -> 1.28.2.6106-44a5bbd28
* [`e61ffae1`](https://github.com/NixOS/nixpkgs/commit/e61ffae1360ee4e05daf7665e831514d07d20318) freedv: fix build on darwin
* [`9e04257d`](https://github.com/NixOS/nixpkgs/commit/9e04257d4513b1572664167cfe9d74c8d4665e18) python310Packages.google-cloud-secret-manager: 2.12.3 -> 2.12.4
* [`4aa12673`](https://github.com/NixOS/nixpkgs/commit/4aa12673f6d4c8310f3238443abfd680e482b050) python310Packages.google-cloud-securitycenter: 1.13.0 -> 1.14.0
* [`550c5b19`](https://github.com/NixOS/nixpkgs/commit/550c5b19477363907678915e9b9d4e8c2ed51eff) pacman: 5.2.2 -> 6.0.1
* [`4ae459c3`](https://github.com/NixOS/nixpkgs/commit/4ae459c3ac138b3fdf1137bf7adb410e516afed2) coturn: enable sqlite support
* [`6c875877`](https://github.com/NixOS/nixpkgs/commit/6c87587737b45c837250a51c8e061f3930d2f4b8) arkade: 0.8.36 -> 0.8.38
* [`2178c1b4`](https://github.com/NixOS/nixpkgs/commit/2178c1b44b7aeb766828e9e52eaec222fac3fc9a) python310Packages.west: 0.13.1 -> 0.14.0
* [`57a6bb9d`](https://github.com/NixOS/nixpkgs/commit/57a6bb9d0a24cb47a383d97f5e13e1105fc0b07c) icewm: 2.9.8 -> 2.9.9 ([nixos/nixpkgs⁠#184854](https://togithub.com/nixos/nixpkgs/issues/184854))
* [`be42f4bc`](https://github.com/NixOS/nixpkgs/commit/be42f4bc34f4c9e0d4b5feab35281af01ebabb17) python310Packages.towncrier: 21.9.0 -> 22.8.0
* [`c7adbf41`](https://github.com/NixOS/nixpkgs/commit/c7adbf41456f1605f221ddf3a919e0893f97d181) python310Packages.asysocks: 0.1.7 -> 0.2.0
* [`96f44883`](https://github.com/NixOS/nixpkgs/commit/96f44883129e91c903e83fd92e5ede0de69b2791) fluent-icon-theme: init at 2022-02-28
* [`464944c3`](https://github.com/NixOS/nixpkgs/commit/464944c3f4f13175386812a2dcf18f79e33b29c4) nixos/{containers,cri-o/podman}: drop outdated remove/rename
* [`70ea9f9e`](https://github.com/NixOS/nixpkgs/commit/70ea9f9ebf3cdd3d1c9791b6b7cd04cec7aa7490) python310Packages.mathlibtools: 1.1.1 -> 1.1.2 ([nixos/nixpkgs⁠#188491](https://togithub.com/nixos/nixpkgs/issues/188491))
* [`d7dade46`](https://github.com/NixOS/nixpkgs/commit/d7dade46c61caf018b85731c817c5577b73acc01) cargo-make: 0.35.16 -> 0.36.0
* [`70e934f9`](https://github.com/NixOS/nixpkgs/commit/70e934f9bb55f6d320622d52f406a5b446143c8a) cargo-tally: 1.0.9 -> 1.0.12
* [`9a1b8cc7`](https://github.com/NixOS/nixpkgs/commit/9a1b8cc7d6d615d6045a5298fbc930699f13f98d) chezmoi: 2.21.0 -> 2.21.1
* [`191726ee`](https://github.com/NixOS/nixpkgs/commit/191726ee706ef4246671e0e79f672eab7d93f92d) circleci-cli: 0.1.20788 -> 0.1.20856
* [`7aabe71f`](https://github.com/NixOS/nixpkgs/commit/7aabe71f78e3267d241ccca2cd10d68e9506359f) zoom-us: 5.11.{1.8356,3.3882} -> 5.11.{9.10046,10.4400}
* [`a274c6d2`](https://github.com/NixOS/nixpkgs/commit/a274c6d21ad2709a3c0ae8875918e05238036bf7) cri-o: 1.24.2 -> 1.25.0
* [`7a9a36df`](https://github.com/NixOS/nixpkgs/commit/7a9a36df947d3f12fde93cbfb7dfec40e9dd1413) kubectl-evict-pod: remove unnecessary override
* [`60e0d3d7`](https://github.com/NixOS/nixpkgs/commit/60e0d3d73670ef8ddca24aa546a40283e3838e69) k3s: streamline HA setup
* [`d4b68195`](https://github.com/NixOS/nixpkgs/commit/d4b68195fd0bd3559f58b23e130f8b4e0b2a6e19) strawberry: 1.0.7 -> 1.0.8
* [`93d7507b`](https://github.com/NixOS/nixpkgs/commit/93d7507b9276c6c6df0d6cd5fbae2a55b8d7ba85) python310Packages.unicrypto: 0.0.8 -> 0.0.9
* [`239d4cd9`](https://github.com/NixOS/nixpkgs/commit/239d4cd9ccb58591adc54bfbb8cc1f457570d84e) esbuild: 0.15.5 -> 0.15.6
* [`9639a3b9`](https://github.com/NixOS/nixpkgs/commit/9639a3b941fa1882155284bf358d6bf937a2294f) linuxPackages.rtl8189es: 2022-05-21 -> 2022-08-30
* [`b00b755b`](https://github.com/NixOS/nixpkgs/commit/b00b755b6753d9d739b14b35430c9b53352eaf6b) frugal: 3.16.1 -> 3.16.2
* [`a207c4ca`](https://github.com/NixOS/nixpkgs/commit/a207c4ca74cf0acf0b26db66790d5283a7642b9d) python310Packages.sensor-state-data: 2.5.0 -> 2.6.0
* [`3f0693c3`](https://github.com/NixOS/nixpkgs/commit/3f0693c348e305a97de55a903fba1ef5f0a793d9) gource: 0.51 → 0.53
* [`9e5f1cce`](https://github.com/NixOS/nixpkgs/commit/9e5f1cce01ca05296fde1a5f8a6617ca2c67c573) ginkgo: 2.1.4 -> 2.1.5
* [`b655ac08`](https://github.com/NixOS/nixpkgs/commit/b655ac089a9c308374b73b4a13d5290cc1d6edd9) gifski: 1.7.1 -> 1.7.2
* [`ff3c99ec`](https://github.com/NixOS/nixpkgs/commit/ff3c99ec9fb6616eeb9ad89261a9332ebc6c222e) python310Packages.aioaladdinconnect: 0.1.43 -> 0.1.44
* [`c355e4c5`](https://github.com/NixOS/nixpkgs/commit/c355e4c5371f73c98268865689d4ad2d14bb804a) python3Packages.psycopg: 3.0.16 -> 3.1
* [`90c688a3`](https://github.com/NixOS/nixpkgs/commit/90c688a3ae16904388ed8038a8362ea2cc5d1a50) python310Packages.awscrt: 0.14.0 -> 0.14.3
* [`9382ce19`](https://github.com/NixOS/nixpkgs/commit/9382ce191fb5cf27e0d7449118380309802ab897) zld: 1.3.3 -> 1.3.4
* [`152b5653`](https://github.com/NixOS/nixpkgs/commit/152b5653e1cf46128ca0f16df4bd647388677485) go-swagger: 0.29.0 -> 0.30.0
* [`9bb82c35`](https://github.com/NixOS/nixpkgs/commit/9bb82c35b750b5ffdebb906b696b135ef028b4f6) lib/options: add mdDoc support to mkEnableOption
* [`d5f7483b`](https://github.com/NixOS/nixpkgs/commit/d5f7483b9620a5fd3bbc083aa1838859e5ef1cc1) gum: 0.4.0 -> 0.5.0
* [`65847ae5`](https://github.com/NixOS/nixpkgs/commit/65847ae58b2e2b7eff42e66fbd7738d47054f55b) hugo: 0.102.0 -> 0.102.1
* [`312b2eb1`](https://github.com/NixOS/nixpkgs/commit/312b2eb1b8ca1ebae3039654f0bf7c1e93fbbc22) hugo: add ldflags
* [`b55e48b6`](https://github.com/NixOS/nixpkgs/commit/b55e48b643ce2f0cd6dee92a200d9972fb96391f) ack: 3.5.0 -> 3.6.0
* [`0a3d5175`](https://github.com/NixOS/nixpkgs/commit/0a3d517599256c901ca5b7f009bde21e2962729f) python310Packages.azure-multiapi-storage: 0.9.0 -> 0.10.0
* [`51f22af8`](https://github.com/NixOS/nixpkgs/commit/51f22af8aa024c5d5fd59cb3d547ff34920da55f) jc: 1.21.1 -> 1.21.2
* [`3830ae9a`](https://github.com/NixOS/nixpkgs/commit/3830ae9a27d3adb3478ed1872e9d0a2a25ae64d3) python310Packages.cloudscraper: 1.2.63 -> 1.2.64
* [`3c73b03f`](https://github.com/NixOS/nixpkgs/commit/3c73b03f1db67918798bf96103f0277fdfbacf47) python3Packages.dicom2nifti: 2.3.0 -> 2.4.3
* [`a4fda24f`](https://github.com/NixOS/nixpkgs/commit/a4fda24f16d374ce70eb97f2186f417b5753221a) kleopatra: fix broken build
* [`5bd13553`](https://github.com/NixOS/nixpkgs/commit/5bd13553d01d95f572d19386399714bcb67b2da0) ipfs: 0.14.0 -> 0.15.0
* [`c6239c5d`](https://github.com/NixOS/nixpkgs/commit/c6239c5de0aa6075cd21f7059f96e8e8e3a635d2) ocamlPackages.lwt_log: 1.1.1 → 1.1.2
* [`577aecb7`](https://github.com/NixOS/nixpkgs/commit/577aecb787dd87bee7de2cad6f6662ad019f505f) libcouchbase: 3.3.1 -> 3.3.2
* [`e7ea2829`](https://github.com/NixOS/nixpkgs/commit/e7ea2829dc9a56b74375ccb74159ebf786a61f1d) limesctl: 3.0.0 -> 3.0.2
* [`a6be71e6`](https://github.com/NixOS/nixpkgs/commit/a6be71e6fc1a7f6a3dcdf97093db4b9ffa395d80) aws-sdk-cpp: unpin i686 instead remove failing test and mark broken when building ec2, little cleanup
* [`1925106b`](https://github.com/NixOS/nixpkgs/commit/1925106bf1d9de60ffd6d66d90d5117f7c18dfd9) minio-client: 2022-08-23T05-45-20Z -> 2022-08-28T20-08-11Z
* [`bafce1c7`](https://github.com/NixOS/nixpkgs/commit/bafce1c7cdaed1af39b804a660aa3ce6307886af) mmark: 2.2.26 -> 2.2.28
* [`afe8ee8b`](https://github.com/NixOS/nixpkgs/commit/afe8ee8b470974ef8f8ce17a316c6ac8eb30df15) python3Packages.torch{,-bin}: rename from pytorch{,-bin}
* [`5391dc4f`](https://github.com/NixOS/nixpkgs/commit/5391dc4fd00f77c8b56eb94c39c6aafb8f747274) goreleaser: 1.10.3 -> 1.11.1
* [`bcf56ef8`](https://github.com/NixOS/nixpkgs/commit/bcf56ef81d32d2e1073a275eca1a6ef056410a49) mympd: 9.5.2 -> 9.5.3
* [`c5d03ea1`](https://github.com/NixOS/nixpkgs/commit/c5d03ea1cf4a5c9f9fd1fad323d4ec39e829a8b0) cargo-workspaces: init at 0.2.35
* [`c335189e`](https://github.com/NixOS/nixpkgs/commit/c335189e81d35885fc797bc2a25469693055a916) elmPackages.lamdera: init at 1.0.1
* [`ef49a845`](https://github.com/NixOS/nixpkgs/commit/ef49a84500e0bdcb31668c24fa906008ebe9c821) python3Packages.coinmetrics-api-client: init at 2022.8.29.6
* [`ce1e76ef`](https://github.com/NixOS/nixpkgs/commit/ce1e76efe8659ec7f22bcb539bb872a56814e67b) oh-my-posh: 8.36.1 -> 8.36.4
* [`4b24143b`](https://github.com/NixOS/nixpkgs/commit/4b24143bf5a27b26b70466a21d11d716100f0c66) qt6Packages.poppler: init at 22.08.0
* [`83a5f628`](https://github.com/NixOS/nixpkgs/commit/83a5f62886c8df8e9fb7ff4561a537b64a492db9) beamerpresenter-poppler: init at 0.2.2
* [`b38c93f8`](https://github.com/NixOS/nixpkgs/commit/b38c93f803630c026bcc7912efab089ec736be05) python310Packages.flower: 1.1.0 -> 1.2.0
* [`2a494cae`](https://github.com/NixOS/nixpkgs/commit/2a494cae1ede37303bc01c645512bbef6b6f8c25) pwndbg: 2022.01.05 -> 2022.08.30
* [`3402d9c4`](https://github.com/NixOS/nixpkgs/commit/3402d9c4a4fe77e245c1b3b061997a83e6f7504e) python3Packages.sanic: add patch for CVE-2022-35920
* [`4e5a4eb4`](https://github.com/NixOS/nixpkgs/commit/4e5a4eb4d617575f3163228ebb0feab41c24eb5d) psst: add .desktop file
* [`69e85c98`](https://github.com/NixOS/nixpkgs/commit/69e85c98a60aec085b9c558eb9a1781f60d43a97) cvise: 2.4.0 -> 2.5.0
* [`3bfe6bfc`](https://github.com/NixOS/nixpkgs/commit/3bfe6bfca2fbe5f7f6c9d640172d482bfdcec815) openscad: add patches for CVE-2022-0496 & CVE-2022-0497
* [`87414a57`](https://github.com/NixOS/nixpkgs/commit/87414a5738031cba923132172a894fae147cb7c3) python310Packages.peaqevcore: 5.16.7 -> 5.18.1
* [`db28e9a0`](https://github.com/NixOS/nixpkgs/commit/db28e9a05fb01793159b97c48126f7c82dcee8e8) sonic-pi: 4.0.3 -> 4.1.0
* [`0be3a104`](https://github.com/NixOS/nixpkgs/commit/0be3a104aaac9bc4aec1b38e46e075fbde6522aa) systeroid: 0.2.0 -> 0.2.1
* [`f58bdc5d`](https://github.com/NixOS/nixpkgs/commit/f58bdc5d4cbb6da8d8d43e8ea53daf0549b92895) werf: 1.2.165 -> 1.2.166
* [`46322929`](https://github.com/NixOS/nixpkgs/commit/463229292d6b61fbff8a60d24dac0a22de2909c3) elmPackages.lamdera: homepage from URL literal to string
* [`956618e8`](https://github.com/NixOS/nixpkgs/commit/956618e8d42e88052b30fabf2966c005fb3cbe69) cargo-semver-checks: init at 0.9.2
* [`8949a6c9`](https://github.com/NixOS/nixpkgs/commit/8949a6c91e3aa0ef88d9fb9211279c8aca8b6475) google-cloud-sdk: 397.0.0 -> 400.0.0
* [`a7951df2`](https://github.com/NixOS/nixpkgs/commit/a7951df278adb5be699603eb960b802ec5713853) python310Packages.minikerberos: 0.2.20 -> 0.3.0
* [`3b6f1cfc`](https://github.com/NixOS/nixpkgs/commit/3b6f1cfcf9a7fdac1dc78de2edb10031574c2ebb) gitlab: 15.3.1 -> 15.3.2 ([nixos/nixpkgs⁠#189005](https://togithub.com/nixos/nixpkgs/issues/189005))
* [`6d09a026`](https://github.com/NixOS/nixpkgs/commit/6d09a0268c8082923cbee097ef40af07f6340b13) python310Packages.oslo-db: 12.0.0 -> 12.1.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
