### PR TITLE
niv powerlevel10k: update 04938868 -> 4bbb198a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0493886837595bdfb0d8ee36a8b25556ac0a64ea",
-        "sha256": "0l52xq826mgmac3yvdgni6jfcrg8rp45x6hnz4wrnhkclvrjk5vf",
+        "rev": "4bbb198a606b69dfb2d86ac33686e3d41f6d0141",
+        "sha256": "0b10h626h4883avipd5ivy0vyg0jc8a3v25s9piw437vq00r13f2",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0493886837595bdfb0d8ee36a8b25556ac0a64ea.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/4bbb198a606b69dfb2d86ac33686e3d41f6d0141.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@04938868...4bbb198a](https://github.com/romkatv/powerlevel10k/compare/0493886837595bdfb0d8ee36a8b25556ac0a64ea...4bbb198a606b69dfb2d86ac33686e3d41f6d0141)

* [`5d223b83`](https://github.com/romkatv/powerlevel10k/commit/5d223b8351708685b8dd88b3e3556cbff4b95c1e) docs: update Windows Terminal font configuration
* [`cbca1bd8`](https://github.com/romkatv/powerlevel10k/commit/cbca1bd8c1259df640d77e06fb9385d8441ef746) docs: set font in Windows Terminal through the Settings UI
* [`3bfbb829`](https://github.com/romkatv/powerlevel10k/commit/3bfbb8294fd61d3fb9f75f944b178eb9c8c2c0f7) sync fonts.md with README.md
* [`18f939d3`](https://github.com/romkatv/powerlevel10k/commit/18f939d34445e314f58ed815794ea6337f54bfd8) Add references to Antidote
* [`4bbb198a`](https://github.com/romkatv/powerlevel10k/commit/4bbb198a606b69dfb2d86ac33686e3d41f6d0141) fix tables broken by the last commit
