### PR TITLE
niv spacemacs: update 201d22bc -> 756ffc5c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "201d22bcc975bd5f4cf459a27c1c42922179f4e2",
-        "sha256": "1rliqbarkwjdg4fmcan3q3fn5994wgwl7qvjnqjrdya4mpyhnrag",
+        "rev": "756ffc5c004fdac5f3c24bab6c692aa3b446a62f",
+        "sha256": "1fw8nvjyiiqjr6nxl5144aa3synp2xvvbl1gq0md87fmpb8ziac3",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/201d22bcc975bd5f4cf459a27c1c42922179f4e2.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/756ffc5c004fdac5f3c24bab6c692aa3b446a62f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@201d22bc...756ffc5c](https://github.com/syl20bnr/spacemacs/compare/201d22bcc975bd5f4cf459a27c1c42922179f4e2...756ffc5c004fdac5f3c24bab6c692aa3b446a62f)

* [`ea027630`](https://github.com/syl20bnr/spacemacs/commit/ea0276309bb2e25a88545f173b6da0141d9950cf) Fix native-compile-p function ([syl20bnr/spacemacs⁠#15718](https://togithub.com/syl20bnr/spacemacs/issues/15718))
* [`73b3b0fe`](https://github.com/syl20bnr/spacemacs/commit/73b3b0fed8c40c3130aacc67916270cc19bbf7ba) [bot] "built_in_updates" Fri Sep  2 03:56:02 UTC 2022 ([syl20bnr/spacemacs⁠#15715](https://togithub.com/syl20bnr/spacemacs/issues/15715))
* [`756ffc5c`](https://github.com/syl20bnr/spacemacs/commit/756ffc5c004fdac5f3c24bab6c692aa3b446a62f) chore(ts-fold): Update repo link for ts-fold module ([syl20bnr/spacemacs⁠#15719](https://togithub.com/syl20bnr/spacemacs/issues/15719))
