### PR TITLE
niv zsh-you-should-use: update 09d9aa2c -> 13c86356

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -240,10 +240,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "09d9aa2cad2b7caf48cce8f321ebbbf8f47ce1c3",
-        "sha256": "07iqlry4mim5cqi8x5vi64dvwqqp298jbaz3ycks9rxsqlczzlnl",
+        "rev": "13c86356553b80e0e0cbf1ecf6d82cfa79751b5a",
+        "sha256": "0bk7svjmn8h2dx4z72crhg9b1qid0b9cf0ssvqfc52yg73ajfwym",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/09d9aa2cad2b7caf48cce8f321ebbbf8f47ce1c3.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/13c86356553b80e0e0cbf1ecf6d82cfa79751b5a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@09d9aa2c...13c86356](https://github.com/MichaelAquilina/zsh-you-should-use/compare/09d9aa2cad2b7caf48cce8f321ebbbf8f47ce1c3...13c86356553b80e0e0cbf1ecf6d82cfa79751b5a)

* [`5637e381`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/5637e3817e9f3bb3c1b20ae4327e02ca9d751369) Change yaourt to yay since yaourt is deprecated
