### PR TITLE
niv nixpkgs: update adff066f -> 88199c6d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "adff066f00dde76165abbc9679b983fe4706fdc5",
-        "sha256": "129s1znw2a5jdbb7bh3r4ac08mg0kapn7wjglnmgy2fysv4irkiz",
+        "rev": "88199c6df95b3f7a8b8bbcaf4dd8977612f219c0",
+        "sha256": "190rjygpgfcqivmss04q74nx8rjyw10vvgiw2ilm865r44h4yvay",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/adff066f00dde76165abbc9679b983fe4706fdc5.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/88199c6df95b3f7a8b8bbcaf4dd8977612f219c0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@adff066f...88199c6d](https://github.com/nixos/nixpkgs/compare/adff066f00dde76165abbc9679b983fe4706fdc5...88199c6df95b3f7a8b8bbcaf4dd8977612f219c0)

* [`f1871f04`](https://github.com/NixOS/nixpkgs/commit/f1871f04f39815ce15076a778105e31084bcec48) maintainers: add akkesm
* [`6106be44`](https://github.com/NixOS/nixpkgs/commit/6106be44f8f99c8220f41d08ea659b7cae6dcbab) passky-desktop: init at 5.0.0
* [`492720c0`](https://github.com/NixOS/nixpkgs/commit/492720c02da48249ff29babb393265c62cb7a11e) phockup: init at 1.7.1
* [`4b960ba9`](https://github.com/NixOS/nixpkgs/commit/4b960ba9959339cbb4635ef55e4c1b8ec64f9d07) goredo: init at 1.21.0
* [`946aa7b5`](https://github.com/NixOS/nixpkgs/commit/946aa7b5bd5f8c3a291bb42a89948f2a6ef240c2) qelectrotech: init at 0.8.0
* [`b9c47397`](https://github.com/NixOS/nixpkgs/commit/b9c4739708ca95ab2256a300b2b0c419f16c37fa) carapace: init at 0.8.10
* [`1d1dc030`](https://github.com/NixOS/nixpkgs/commit/1d1dc0303895d7d207ce33a893c26e2c50f29161) pythonPackages.ete3: init at 3.1.2
* [`106f645c`](https://github.com/NixOS/nixpkgs/commit/106f645c966ba02426672d973a6a8beda50f778f) maintainers: add delehef
* [`229c47be`](https://github.com/NixOS/nixpkgs/commit/229c47beee23d361d6266f64b2fdef30cfecf1c5) license: Add Volatility Software License
* [`18650071`](https://github.com/NixOS/nixpkgs/commit/1865007144c06be802a5a5a4b4f37e15806eec5f) dwarf2json: init at unstable-2021-04-15
* [`512483d9`](https://github.com/NixOS/nixpkgs/commit/512483d9108b430db9d6fba09ae2676b095c5473) nwg-bar: init at unstable-2021-09-23
* [`07f66fde`](https://github.com/NixOS/nixpkgs/commit/07f66fde013b1a392707ac4adeb36f4dab498e8c) gomi: init at 1.1.1
* [`8dfff66d`](https://github.com/NixOS/nixpkgs/commit/8dfff66db7284671c3018f305169848f763a15b7) bass: init at 1.0
* [`4b57b62c`](https://github.com/NixOS/nixpkgs/commit/4b57b62ca39a889a5f20259aab1fb1d4e618d4b0) maintainers: add sioodmy
* [`6cf27ab2`](https://github.com/NixOS/nixpkgs/commit/6cf27ab2d745889129a7e89f25e06cbb0f4f5f21) rpi-imager: 1.7.1 -> 1.7.2
* [`68b28cf8`](https://github.com/NixOS/nixpkgs/commit/68b28cf8b984ddc323c0627fa4b8255fcfe5c1a7) Added myself as maintainer for packages I post
* [`c4f763d4`](https://github.com/NixOS/nixpkgs/commit/c4f763d4e41978876e72d65bbc1b46bbec624127) terra-station: init at 1.2.0
* [`d54bc531`](https://github.com/NixOS/nixpkgs/commit/d54bc531408252ba69f6bf4cb00c798466ed379d) qjackctl: 0.9.6 -> 0.9.7
* [`89534942`](https://github.com/NixOS/nixpkgs/commit/89534942b4c0d7a765ae79399a475db2844f8ca0) todo: init at 2.4
* [`43428c13`](https://github.com/NixOS/nixpkgs/commit/43428c138663479d941b507b61be73264d6ec1e7) zi: init at unstable-2022-04-09
* [`f193f273`](https://github.com/NixOS/nixpkgs/commit/f193f27344ddfec90585d56dcbaae4dc458918cc) soapysdrplay: unstable-2021-04-25 -> 0.4.0
* [`c0887cc1`](https://github.com/NixOS/nixpkgs/commit/c0887cc1e82fc07d3236c96c52c909c48f68771d) book-summary: init at 0.2.1
* [`87c5e90a`](https://github.com/NixOS/nixpkgs/commit/87c5e90ab72d2bbb023a362572815a3a38efb475) python3Packages.libsixel: init at 1.10.3
* [`1c063489`](https://github.com/NixOS/nixpkgs/commit/1c063489b15062414a1d9f40d2e667bc69bee07d) python39Packages.pylibdmtx: init at 0.1.10
* [`e535593f`](https://github.com/NixOS/nixpkgs/commit/e535593fa257b0fdd8f6b0253f7d2d237d29cedd) scalafmt: 3.4.3 -> 3.5.2
* [`16afcacc`](https://github.com/NixOS/nixpkgs/commit/16afcaccbfd8f28032083f075d870148f110acf0) scalafmt: use setJavaClassPath, drop jdk dep
* [`93e20d45`](https://github.com/NixOS/nixpkgs/commit/93e20d45ca2cf13daf4cfa177e52309cab629538) scalafmt: prefer hash style nix uses these days for easier updating
* [`9cae808f`](https://github.com/NixOS/nixpkgs/commit/9cae808f189abf0067ac74be29a73083e166ed11) headset: init at 4.0.0
* [`c9cb8e3b`](https://github.com/NixOS/nixpkgs/commit/c9cb8e3b0c018ff3482652e72af4e5c9fdc26a8c) gyb: init at 1.62
* [`2bfb0980`](https://github.com/NixOS/nixpkgs/commit/2bfb0980fd8190dca5a6dd22bacb47d1471da229) ipfs-upload-client: init at 0.1.1
* [`8a073a3b`](https://github.com/NixOS/nixpkgs/commit/8a073a3b7ff4bcfeb40903d14cd168f9e61eab10) blightmud: 3.5.0 -> 3.6.2
* [`949f4a22`](https://github.com/NixOS/nixpkgs/commit/949f4a227b5076751140c3df094dd63bc0b08f3f) rscw: init at 0.1e
* [`13352be1`](https://github.com/NixOS/nixpkgs/commit/13352be167d46248f75094591ce30c7ff6abffe4) nasmfmt: init at unstable-2021-04-24
* [`53c3bec1`](https://github.com/NixOS/nixpkgs/commit/53c3bec163ea284fda384f17dded1d9f32faf065) bind: add default rndc.conf
* [`eba55900`](https://github.com/NixOS/nixpkgs/commit/eba559008c5fbfbbd3d3d50e9bb4465e1db8706a) caprine-bin.x86_64-appimage: passthru pname version src
* [`e05b14dd`](https://github.com/NixOS/nixpkgs/commit/e05b14dd27a90b4dfee91d9c30360f41c1c2ecfe) caprine-bin: 2.55.4 -> 2.55.5
* [`390fc0a8`](https://github.com/NixOS/nixpkgs/commit/390fc0a8f3e5e1dd3fb83604cbaee24b3e274d6a) vault-medusa: init at 0.3.5
* [`3afa315b`](https://github.com/NixOS/nixpkgs/commit/3afa315b1bad7429cb1626ffdaacc53d784d6fbe) afsctool: init at 1.7.0
* [`f153f15a`](https://github.com/NixOS/nixpkgs/commit/f153f15a45b549e25adda91dad0075f12aece38c) linux: Remove unused Kernel patches
* [`5091b60d`](https://github.com/NixOS/nixpkgs/commit/5091b60dd55def1c5747e7adefde94d9f53ebc9d) argyllcms: 2.3.0 -> 2.3.1
* [`d8e19a11`](https://github.com/NixOS/nixpkgs/commit/d8e19a116feb931bc3329d409539dd53cee09f25) range-v3: 0.11.0 -> 0.12.0
* [`2746a56f`](https://github.com/NixOS/nixpkgs/commit/2746a56f593437b8b7877b8d27f7ae98795f6849) tinyscheme: add the libraries to the outputs
* [`698cedfa`](https://github.com/NixOS/nixpkgs/commit/698cedfa3c219cf8b8e16077aa215b7d15a2ce2d) tinyscheme: don't require the gcc stdenv
* [`17fb7518`](https://github.com/NixOS/nixpkgs/commit/17fb7518ffc2e9a13ec6c1ecec2be1d2cac9d0a6) tinyscheme: add the changelog link
* [`8f0ec826`](https://github.com/NixOS/nixpkgs/commit/8f0ec8269639500be31b2bae37d515388f12b4d8) tinyscheme: fix the build on macOS
* [`4c958b12`](https://github.com/NixOS/nixpkgs/commit/4c958b12006870b8821410637bd471af052afda3) tinyscheme: add some tests
* [`12257dbc`](https://github.com/NixOS/nixpkgs/commit/12257dbc8296f8f0813d8846262d4ee00dfba69a) tinyscheme: set `mainProgram`
* [`2ddc70dc`](https://github.com/NixOS/nixpkgs/commit/2ddc70dc48634288fe30f9b7207af3c3d6e8f912) mongodb: fix build with boost 1.79
* [`eedcccd2`](https://github.com/NixOS/nixpkgs/commit/eedcccd2914cdbf08c2854005571d9400c5ca974) mongodb: fix double link of isNamedError on darwin.
* [`a0f42fb8`](https://github.com/NixOS/nixpkgs/commit/a0f42fb89924b4a739f2f9101434b0c7de134dd7) mongodb: drem doesn't exist after 3.6
* [`2a7c1ea4`](https://github.com/NixOS/nixpkgs/commit/2a7c1ea47792b28963e9bacb44f290066eed2a43) mongodb: asio-no-experimental-string-view.patch is no longer required on darwin
* [`2ba2e8d8`](https://github.com/NixOS/nixpkgs/commit/2ba2e8d8b2626704931ea077f6bee464dc22d161) mongodb: backport a fix to 5.0 in openssl detection.
* [`62748751`](https://github.com/NixOS/nixpkgs/commit/6274875188277800937719de9dc3a89ab69d73cd) mongodb: fix build with boost 1.79 on linux
* [`f78e768d`](https://github.com/NixOS/nixpkgs/commit/f78e768d4971cabd98bf078f2c0113aafbd939f8) findup: init at 1.0
* [`e7d158d4`](https://github.com/NixOS/nixpkgs/commit/e7d158d4af2bba63e34cbea4154108920d048f54) mongodb-4_4: fic-gcc11-optionnal
* [`eb72be85`](https://github.com/NixOS/nixpkgs/commit/eb72be85415765d1538bdf6e3b06090614f7a6f7) lib/types: add `number`
* [`77307fcf`](https://github.com/NixOS/nixpkgs/commit/77307fcff86d3e56285b006b3e9204c6b45d90f0) nixos/picom: use `types.numbers.between`
* [`5480f45f`](https://github.com/NixOS/nixpkgs/commit/5480f45f63f75d9340d5d48602f47d04d3625a2f) nixos/doc/option-types: refactor, document `number`s
* [`999e37a2`](https://github.com/NixOS/nixpkgs/commit/999e37a21a34ce911dea9bf0b08ee6bf1acd73ab) polymake: 4.6 -> 4.7
* [`d021560e`](https://github.com/NixOS/nixpkgs/commit/d021560e6ffcd54452b34fdee071663228096f95) quodlibet: fix build
* [`50dc0203`](https://github.com/NixOS/nixpkgs/commit/50dc0203707d8473f6fd9f00760b77470bac9890) quodlibet: makeover
* [`aeb77ea9`](https://github.com/NixOS/nixpkgs/commit/aeb77ea9bd9d2804a0f1c1330df4b4782229b2d9) quakespasm: fix darwin build
* [`79ae88a1`](https://github.com/NixOS/nixpkgs/commit/79ae88a1002db5384bc9ad2e8708c77554289f05) nixos/syncthing: Add receiveencrypted folder type
* [`e7b7d885`](https://github.com/NixOS/nixpkgs/commit/e7b7d885f8e5a100eaf57fd1d3013eb81eb6968e) tmuxPlugins.tmux-fzf: unstable-2021-10-20 -> unstable-2022-08-02
* [`be0d0990`](https://github.com/NixOS/nixpkgs/commit/be0d0990ebc9fb8520e01f62f2471ceea3cff27d) tmuxPlugins.fzf-tmux-url: unstable-2019-12-02 -> unstable-2021-12-27
* [`d6ba407e`](https://github.com/NixOS/nixpkgs/commit/d6ba407e5df87cc40d4ef92acf2a21759392dda3) pkgs{Musl,Static}.glog: fix build
* [`37da853f`](https://github.com/NixOS/nixpkgs/commit/37da853f496341eee70170e93095d82bcf60a79a) nixos/installer: mkForce -> mkImageMediaOverride
* [`d1799fe3`](https://github.com/NixOS/nixpkgs/commit/d1799fe3855a5ea0848baf4a09dc8fceb53c0ce3) moltenvk: 1.1.10 -> 1.1.11
* [`641913bd`](https://github.com/NixOS/nixpkgs/commit/641913bdb64425989cbbf073da21785a472721f9) beancount-ing-diba: init 0.6.0
* [`23d21ce9`](https://github.com/NixOS/nixpkgs/commit/23d21ce9c90dc1f2501632e06c02c96fe02d84f9) dtc: fix dylib name on darwin
* [`77525f0f`](https://github.com/NixOS/nixpkgs/commit/77525f0f95505695987411365d9349019ad6e020) libkrunfw: add support for darwin
* [`7642b506`](https://github.com/NixOS/nixpkgs/commit/7642b5064eeddcf21562733bfde7002f1eedb0aa) libkrun: add support for darwin
* [`123570f4`](https://github.com/NixOS/nixpkgs/commit/123570f4b25529225b414f42b41803798f060f17) bazarr: 1.0.3 -> 1.1.0
* [`372b94be`](https://github.com/NixOS/nixpkgs/commit/372b94bef67ceab074a1c11f4429018e66fb4fdd) krunvm: add support for darwin
* [`72d17037`](https://github.com/NixOS/nixpkgs/commit/72d170371ce3b63495b92c03bc0558161e55fb19) ceph-csi: 3.5.1 -> 3.7.0
* [`56112908`](https://github.com/NixOS/nixpkgs/commit/56112908ce5e1e5c8937c92b0a77a5d070fe0bb7) python3.pkgs.pyocr: 0.7.2 -> 0.8.3
* [`609deacf`](https://github.com/NixOS/nixpkgs/commit/609deacfc804d941b947a1f4b123f1963b9811d8) usbguard: remove unused libgcrypt crypto backend
* [`18cd419b`](https://github.com/NixOS/nixpkgs/commit/18cd419becceb83a49c5bdc039f654cbcf19c4e4) gsasl: 1.10.0 -> 2.0.1
* [`00ed8857`](https://github.com/NixOS/nixpkgs/commit/00ed8857e20195f161aeea214d2a3f441721b3c9) vmime: 0.9.2 -> unstable-2022-03-26
* [`b66cc6ba`](https://github.com/NixOS/nixpkgs/commit/b66cc6ba241416fdaa33b305700eebb39f84bf64) rpcs3: add udev rules
* [`4d7f8b50`](https://github.com/NixOS/nixpkgs/commit/4d7f8b50d240ef85b93a64744c21f56ab3c965d7) envoy: 1.21.4 -> 1.21.5
* [`9677d8a7`](https://github.com/NixOS/nixpkgs/commit/9677d8a7a5330f10bea4bf5d7866d957adb374b3) pomerium: build and include ui
* [`4dfa0d23`](https://github.com/NixOS/nixpkgs/commit/4dfa0d23241afc02fe30caef4d6bd26075b48c61) pomerium: 0.17.1 -> 0.18.0
* [`b900ad15`](https://github.com/NixOS/nixpkgs/commit/b900ad154bed259755cfac10aa182937c12c6c2a) pomerium-cli: 0.17.1 -> 0.18.0
* [`1c3aae62`](https://github.com/NixOS/nixpkgs/commit/1c3aae62fe7e5367fc8176d99063beccbff2a787) pagmo2: add platforms and unbreak on darwin
* [`e6428866`](https://github.com/NixOS/nixpkgs/commit/e64288661e4f68d8d6d80478850531e081d8ed2a) nodePackages.vega-lite: Fix vega module availability issue
* [`0c59d1f2`](https://github.com/NixOS/nixpkgs/commit/0c59d1f2a3799c6004435b91d682b4448511ea3c) nixos/docs: updated MBR partitioning steps
* [`45309de8`](https://github.com/NixOS/nixpkgs/commit/45309de8ff0a7cbe417ed00810e9b48bb1f5dc29) pythonPackages.piccolo-theme: init at 0.11.1
* [`e94c6708`](https://github.com/NixOS/nixpkgs/commit/e94c67084c1bc7e2e9b89ab051a63dc6a155f32f) libbluray: backport bugfix
* [`9e60d140`](https://github.com/NixOS/nixpkgs/commit/9e60d14097e9241fc86c7649f64b1b62c01ba085) python39Packages.jupyterlab_server: fix failing build
* [`160cc410`](https://github.com/NixOS/nixpkgs/commit/160cc410687209fc0a11d417bc6563ffa1babc7d) python310Packages.jupyterlab_server: 2.15.0 -> 2.15.1
* [`2aeb3102`](https://github.com/NixOS/nixpkgs/commit/2aeb3102066ab4a1a8e5b1f3529160a754ae9d60) libatomic_ops: 7.6.12 -> 7.6.14
* [`71d09bf6`](https://github.com/NixOS/nixpkgs/commit/71d09bf6e337d243dbb98ba9c2b3e53ca9d7e87d) haskellPackages: stackage LTS 19.19 -> LTS 19.20
* [`f76f8b12`](https://github.com/NixOS/nixpkgs/commit/f76f8b123ddfdf89bb3efeda9facbe8d5212cbdc) all-cabal-hashes: 2022-08-20T06:29:36Z -> 2022-08-28T23:15:42Z
* [`0c4041b7`](https://github.com/NixOS/nixpkgs/commit/0c4041b77b6d79441e3551972dcc423f6f7278f4) haskellPackages: regenerate package set based on current config
* [`06ece659`](https://github.com/NixOS/nixpkgs/commit/06ece659f09716f744ee5e6fcf5565d7dcbab30b) coqPackages.mkCoqDerivation: add a coqPackages.lib.overrideCoqDerivation function
* [`7efd4aa6`](https://github.com/NixOS/nixpkgs/commit/7efd4aa67c44be8fa854daf81243b300cf94259f) tests.coq.overrideCoqDerivation: add test
* [`edb0f105`](https://github.com/NixOS/nixpkgs/commit/edb0f1050349ac74fcadd7d610087bab3430d48c) notmuch-bower: 0.13 -> 1.0
* [`26501c52`](https://github.com/NixOS/nixpkgs/commit/26501c52687e2a33260bc7b6acf1ef51db76a984) python3Packages.markdown2: fix tests to actually run
* [`7f0b3c28`](https://github.com/NixOS/nixpkgs/commit/7f0b3c288fb128c0681e9bec2098aeb70d71252d) python3Packages.markdown2: 2.4.1 -> 2.4.3
* [`c64ca028`](https://github.com/NixOS/nixpkgs/commit/c64ca0283bce0c57678d2d5422bb3227f5850098) python3Packages.markdown2: add patch for xss issue SNYK-PYTHON-MARKDOWN2-2606985
* [`decaeb0f`](https://github.com/NixOS/nixpkgs/commit/decaeb0f654c6e6531b207aa17ab772c41fde2d7) geoclue2: 2.5.7 → 2.6.0
* [`9190f415`](https://github.com/NixOS/nixpkgs/commit/9190f415ad9fab0634e6bd7f6cf72ed0bcdb3b98) git-annex: update sha256 for 10.20220822
* [`8758481c`](https://github.com/NixOS/nixpkgs/commit/8758481cc0dc2717045bb090acf151c6a33c094c) haskell.packages.ghc884.{foundation,basement}: downgrade for GHC 8.8
* [`ea5a5bff`](https://github.com/NixOS/nixpkgs/commit/ea5a5bffbd55dec85d5e506def288bd73566e628) haskellPackages.recursion-schemes: fix patch line ending issues
* [`19f1864e`](https://github.com/NixOS/nixpkgs/commit/19f1864eb317f048a2767dacf4e395272ccceaec) blucontrols: allow building with finite-typelits 0.1.6.0
* [`c6f4784c`](https://github.com/NixOS/nixpkgs/commit/c6f4784cc8992bedc6193b16fd1031ef5f89d292) fwupd: 1.8.3 → 1.8.4
* [`266ea7a6`](https://github.com/NixOS/nixpkgs/commit/266ea7a68284945f04d8b78ad31e355bccd005d0) haskellPackages.haskell-ci: build with cabal-install-parsers 0.4.5
* [`b83be8a1`](https://github.com/NixOS/nixpkgs/commit/b83be8a19362c95c7c346e3798ee77690e61baf2) haskellPackages.haskell-ci-unstable: remove at 0.14.1-8311a99
* [`ae2e5c8e`](https://github.com/NixOS/nixpkgs/commit/ae2e5c8ec3f03aa89e2cde8dfd9c428223874df1) haskellPackages: reflect hspec 2.10.0.1 -> 2.10.1
* [`7689468a`](https://github.com/NixOS/nixpkgs/commit/7689468a4ba2bfbaeaaf30c29bd19c9607a1dd99) nixos/nat: Use the package specified in networking.firewall.package
* [`2c1cf486`](https://github.com/NixOS/nixpkgs/commit/2c1cf4864d531c89900b2c46a839d81cf9b96e42) haskell-ci-unstable: remove at 0.14.1-8311a99
* [`318edf02`](https://github.com/NixOS/nixpkgs/commit/318edf02d1563c3c0dca4c833535972283789215) asciidoc: fix changelog url
* [`2385f028`](https://github.com/NixOS/nixpkgs/commit/2385f0282c1343746c6e7aadd144ff9b1ac227a4) python3Packages.pytest-asyncio: fix changelog URL
* [`51a1c735`](https://github.com/NixOS/nixpkgs/commit/51a1c735428fd07efc4c7fbe6d7b909018b10e57) nixos/systemd.network: Fix `ipv6RoutePrefixes` example
* [`5e492101`](https://github.com/NixOS/nixpkgs/commit/5e4921013b1999196bc07ec9992a72ebade8ae01) nixos/luksroot: Support adding a list of credentials to fido2luks
* [`eae6d67f`](https://github.com/NixOS/nixpkgs/commit/eae6d67f40df390b2dcf0fb25d65a84884bc16d3) gnomeExtensions.arcmenu: 35 -> 37
* [`03a88244`](https://github.com/NixOS/nixpkgs/commit/03a8824481e7717a31331e63706c0f2b470b8f9f) apache-jena: 4.5.0 -> 4.6.0
* [`add9d281`](https://github.com/NixOS/nixpkgs/commit/add9d281cef6ec0960347cbae6203186fdcd08e5) jmol: 14.32.68 -> 14.32.73
* [`09c9d1f9`](https://github.com/NixOS/nixpkgs/commit/09c9d1f93836040b5d8ba5a59b496e7fdec839a5) panoply: 5.1.1 -> 5.2.0
* [`6bb74bef`](https://github.com/NixOS/nixpkgs/commit/6bb74bef5b4656767fbff930047710f709f559ee) libixp: fix darwin build
* [`8ab0b5d3`](https://github.com/NixOS/nixpkgs/commit/8ab0b5d3d7e045181b78592406da045bce397472) haskell.packages.ghc924.dbus: adapt to 1.2.25 -> 1.2.26 update
* [`aad3b569`](https://github.com/NixOS/nixpkgs/commit/aad3b5690b271f1f58693e9853ef525172893da3) haskell.packages.ghc924.th-desugar: adapt to 1.13.1 -> 1.14 update
* [`57304503`](https://github.com/NixOS/nixpkgs/commit/573045038e3276079264ff32b1d044634bd95211) haskell.packages.ghc924.servant-*: make work with lens 5.2
* [`c9627929`](https://github.com/NixOS/nixpkgs/commit/c9627929279ebba679a357e3d5169e8011b2d692) nixos/docs: revised MBR partitioning steps
* [`7c6e5387`](https://github.com/NixOS/nixpkgs/commit/7c6e538767f33c36fdb19592deb382cf22d73f53) dnsproxy: 0.43.1 -> 0.44.0
* [`e8ea44e2`](https://github.com/NixOS/nixpkgs/commit/e8ea44e2e3e299d049b1b4bbace60e88ad056c13) dendrite: 0.9.5 -> 0.9.6
* [`ae39c7af`](https://github.com/NixOS/nixpkgs/commit/ae39c7af41a84c3c0f91690f230f86d8ab293450) haskellPackages.keid-render-basic: Fix missing build tool
* [`de52d136`](https://github.com/NixOS/nixpkgs/commit/de52d13612ccb7dd36c578e94e68f5e5d876b238) deno: 1.23.4 -> 1.25.1
* [`4e427c9d`](https://github.com/NixOS/nixpkgs/commit/4e427c9df0f1d021a8d7dc0437f73d9582b21c67) tinycc: avoid replacing VERSION when it would cause errors
* [`817a35be`](https://github.com/NixOS/nixpkgs/commit/817a35be0bfcb9d29146ef89a2d927a315c67f3e) deno: allow for the build of libtcc.a on darwin
* [`632f36f1`](https://github.com/NixOS/nixpkgs/commit/632f36f133bbe0062baf7edcc03d8d4db422e02f) twitter-color-emoji: use standard ps variable name and with
* [`e939e7ce`](https://github.com/NixOS/nixpkgs/commit/e939e7ce92fbf3656f28eeb64b104ee2cf453dbd) python310Packages.mypy-boto3-builder: update meta.homepage
* [`0b92da79`](https://github.com/NixOS/nixpkgs/commit/0b92da79ce6ec7d255291b9b11e8c9ca912efe5c) json2tsv: init at 1.0
* [`00174c93`](https://github.com/NixOS/nixpkgs/commit/00174c930ee641c8e7dc575a4598a1e8cdddc9b0) haskellPackages.monad-bayes: Jailbreak for GHC 9.*
* [`266f00f9`](https://github.com/NixOS/nixpkgs/commit/266f00f92c1c5cb7816c58bce0ea236c62f5a25c) maintainers: add fbergroth
* [`30ad7637`](https://github.com/NixOS/nixpkgs/commit/30ad7637e4e90ffcf37fac07b4c5dd4cef48f3ac) kind: 0.14.0 -> 0.15.0
* [`e43a7ab7`](https://github.com/NixOS/nixpkgs/commit/e43a7ab7e4da0d9c39f4ea40e32c067376fff4be) haskellPackages: regenerate package set based on current config
* [`5f4b7bba`](https://github.com/NixOS/nixpkgs/commit/5f4b7bbad1d0439bc0ce81f22420cba87ec77dc4) haskellPackages: regenerate package set based on current config
* [`9b067c31`](https://github.com/NixOS/nixpkgs/commit/9b067c31fc4a5b9a3a26448bfc98eaa594dba99d) maintainers: add impl
* [`6f8378e6`](https://github.com/NixOS/nixpkgs/commit/6f8378e6fa60209c733703dd25365687217d2581) jam: fix cross compilation
* [`3c0eaeb8`](https://github.com/NixOS/nixpkgs/commit/3c0eaeb84cf5d2516f152beae399212771bed2ec) ftjam: unify build steps with jam
* [`49e6d1b8`](https://github.com/NixOS/nixpkgs/commit/49e6d1b81329a7847114dfa377f17d144a416acc) tests.coq.overrideCoqDerivation: use runCommand instead of runCommandNoCC
* [`ca1690c2`](https://github.com/NixOS/nixpkgs/commit/ca1690c2edffa735d1df3acd69a3c8e55c30fc11) ipmi_exporter: init at 1.6.1
* [`866d9772`](https://github.com/NixOS/nixpkgs/commit/866d9772120d08b7b6c4f9b9bf7ada44a0550897) nixos/services.prometheus.exporters.ipmi: new module
* [`7bfad6cc`](https://github.com/NixOS/nixpkgs/commit/7bfad6ccae1af10c2a5c4e47f79b869645d31695) python3Packages.hickle: 4.0.4 -> 5.0.2; unbreak
* [`ff03b1fe`](https://github.com/NixOS/nixpkgs/commit/ff03b1fed81d580b933ebf3069f3116f1a568bca) clevis: add various packages to wrapper
* [`be09c163`](https://github.com/NixOS/nixpkgs/commit/be09c1638d116b477c312ec61d55c304f1beb3ee) doc/contributing: enforce full commit hashes on github
* [`60a7d2e5`](https://github.com/NixOS/nixpkgs/commit/60a7d2e58dc4da15dd5f8d2e9c87ec94845a3a68) libAfterImage: fix compatibility with giflib 5
* [`fa5155a4`](https://github.com/NixOS/nixpkgs/commit/fa5155a4e5994774267a6bd529e5f175d203fd4e) libAfterImage: pass --without-x explicitly
* [`6afae5ac`](https://github.com/NixOS/nixpkgs/commit/6afae5ac62ef3d3b79caaefbde0622a77caccc81) diesel-cli: 1.4.1 -> 2.0.0
* [`e7186348`](https://github.com/NixOS/nixpkgs/commit/e718634805356f5a566c44bf01f447ce62bdaead) freeipmi: 1.6.9 -> 1.6.10
* [`36fea681`](https://github.com/NixOS/nixpkgs/commit/36fea681b33276936c5bd0cdc9c74d08abec74b7) wezterm: 20220807-113146-c2fee766 -> 20220903-194523-3bb1ed61
* [`3808a3e7`](https://github.com/NixOS/nixpkgs/commit/3808a3e7892fd6f9e9ad598307b432cb3fc0f865) checkip: 0.40.1 -> 0.40.3
* [`a97ba67b`](https://github.com/NixOS/nixpkgs/commit/a97ba67bf71b1c35ae87b0d8ecfde80e7a827752) python310Packages.rising: remove unused pytest-cov
* [`d1be027e`](https://github.com/NixOS/nixpkgs/commit/d1be027e2dd7876441bb5ce209c3f57dc7333d38) python310Packages.qiskit-machine-learning: remove package variant
* [`dbfd7543`](https://github.com/NixOS/nixpkgs/commit/dbfd75435938888cff88e8325a006ed5130c8b5d) python310Packages.torchgpipe: remove useless pytest-runner, correct disabled
* [`eb7d9127`](https://github.com/NixOS/nixpkgs/commit/eb7d9127e08ec004d776e0536d478fc5bf499eb7) coq: document CoqIDE split
* [`95da3039`](https://github.com/NixOS/nixpkgs/commit/95da30390282c778bcd8058d0ddbaaaec22da1bb) gatk : init at 4.2.6.1
* [`83fa3783`](https://github.com/NixOS/nixpkgs/commit/83fa3783c5a256eca23a0a747204de34a841c5ae) python3Packages.jsons: init at 1.6.3
* [`a08f2e2f`](https://github.com/NixOS/nixpkgs/commit/a08f2e2fe63be0fe796f8fd0b3a2a27960f9a814) python310Packages.ptpython: add meta.homepage, remove redundand meta.platforms
* [`ed3b06d8`](https://github.com/NixOS/nixpkgs/commit/ed3b06d8b5ef6b10a631fffefe7843e9fa88eabe) gzdoom: Fix kdialog not found
* [`50ad4b18`](https://github.com/NixOS/nixpkgs/commit/50ad4b18260af918433fb7aac97ed95c4c1c8d4c) glooctl: 1.12.11 -> 1.12.12
* [`68eee3cd`](https://github.com/NixOS/nixpkgs/commit/68eee3cd52b08dfac63341966c91a5db5907251f) gopass-jsonapi: 1.14.3 -> 1.14.5
* [`ce6656f5`](https://github.com/NixOS/nixpkgs/commit/ce6656f510cb01db5c77b3f7b956016c63100bf0) xfce.xfce4-pulseaudio-plugin: 0.4.3 -> 0.4.4
* [`40fede29`](https://github.com/NixOS/nixpkgs/commit/40fede29e34ad200880b8d6f19198e46a4b2d1a8) ibus: 1.5.26 -> 1.5.27
* [`3a2f9934`](https://github.com/NixOS/nixpkgs/commit/3a2f99340c13a811675e420ed963ab62e1c0c105) ibus: fix installed tests
* [`6e52d15c`](https://github.com/NixOS/nixpkgs/commit/6e52d15cc15075ef41f799502de15d0f8d00f4c3) python310Packages.atomman: 1.4.4 -> 1.4.5
* [`98bd1d65`](https://github.com/NixOS/nixpkgs/commit/98bd1d651d1d6d23aae4c6a1a400713c1a9b4f48) gambit: reenable stackprotector on aarch64-darwin
* [`6c781154`](https://github.com/NixOS/nixpkgs/commit/6c781154aa6bcd3c4d055b99687727a44f65e40b) python3Packages.pywick: unbreak
* [`fba52263`](https://github.com/NixOS/nixpkgs/commit/fba522637639e214d50c2dc5a6701ba08ea6a731) itk-unstable: init at 2022-07-02
* [`961b308f`](https://github.com/NixOS/nixpkgs/commit/961b308fe171ca4b0a5b6b4cc65b19a8af9a0b40) ants: 2.2.0 -> 2.4.1
* [`1280129a`](https://github.com/NixOS/nixpkgs/commit/1280129aab8effd4e0eef9a495f7d178a9122f05) EZminc: itk4 -> itk (formally; package is broken)
* [`671b701d`](https://github.com/NixOS/nixpkgs/commit/671b701d284a26336ab74b01cadc56843bc5cd83) itk4: remove
* [`1d28e5aa`](https://github.com/NixOS/nixpkgs/commit/1d28e5aa476160f09206a40b63eb687d361baa2b) vtk_7: remove
* [`8b95a9d5`](https://github.com/NixOS/nixpkgs/commit/8b95a9d56078f7934c9945598a6abdd9a7009fe8) xprompt: fix cross-compilation
* [`969226fe`](https://github.com/NixOS/nixpkgs/commit/969226fe9941c5b1535b3014e303acd557d228d1) python310Packages.asysocks: 0.2.0 -> 0.2.1
* [`89c025b3`](https://github.com/NixOS/nixpkgs/commit/89c025b3667165b519db7ce82a4ff4fcc27f29a7) nixos/fwupd: add polkit dependency
* [`45000f23`](https://github.com/NixOS/nixpkgs/commit/45000f23f090300175f0fc043be8a236cd1efd9a) ngtcp2: 0.8.0 -> 0.8.1
* [`093edcbf`](https://github.com/NixOS/nixpkgs/commit/093edcbfcbcc1ed43655d1c5235364a4796b90d1) R: reenable stackprotector on aarch64-darwin
* [`bb22a355`](https://github.com/NixOS/nixpkgs/commit/bb22a35529d4c74fb628db7d43546dd51e7b140c) luarocks: 3.9.0 -> 3.9.1
* [`6aaf666a`](https://github.com/NixOS/nixpkgs/commit/6aaf666aaab76d6bd545222e8d79df6cc2c16f4b) bumped luarocks-nix
* [`52ac9805`](https://github.com/NixOS/nixpkgs/commit/52ac9805ef34cd4fcdda962db88031f2af2c7132) luaPackages: update
* [`4fcd42c0`](https://github.com/NixOS/nixpkgs/commit/4fcd42c066fc5450ae643390820005f14a8d872b) luaPackages: update
* [`a3c3acf7`](https://github.com/NixOS/nixpkgs/commit/a3c3acf76b12a740a42cf255e6efd61a87bcadcc) buildbot: 3.5.0 -> 3.6.0
* [`0706423b`](https://github.com/NixOS/nixpkgs/commit/0706423b4b524d0de6654bed4419a4518d8d233a) openmpi: reenable stackprotector on aarch64-darwin
* [`55759fb8`](https://github.com/NixOS/nixpkgs/commit/55759fb8805d75a126c005aca4eeab2ad4aa6ba0) tofi: init at 0.5.0
* [`aa9b7694`](https://github.com/NixOS/nixpkgs/commit/aa9b769451c5b65751b4ae6351030e9b34ebd0af) btop: reenable stackprotector on aarch64-darwin
* [`7f6ab2dd`](https://github.com/NixOS/nixpkgs/commit/7f6ab2ddbc08de30f1e5a3b7644a5523daf51554) pomerium-cli: detach from pomerium versioning
* [`073d3c1b`](https://github.com/NixOS/nixpkgs/commit/073d3c1b77eaa0de36f064b60e47642469887fbf) mavproxy: add lxml dependency
* [`40e6f637`](https://github.com/NixOS/nixpkgs/commit/40e6f6378e18259b9b645e2103a7ce5d4364a5f2) python3Packages.remi: init at 2022.7.27
* [`441e76b3`](https://github.com/NixOS/nixpkgs/commit/441e76b3735a224b404f62e823ff4724ce28991c) sioyek: get rid of rec
* [`3ac5542d`](https://github.com/NixOS/nixpkgs/commit/3ac5542df0f71126fe78c03ece133d09873b433a) rapidfuzz-cpp: 1.2.0 -> 1.3.0
* [`f4b697e6`](https://github.com/NixOS/nixpkgs/commit/f4b697e6bc05beecf3cedf30bcba3578afb9444f) depotdownloader: 2.4.5 -> 2.4.7
* [`16215285`](https://github.com/NixOS/nixpkgs/commit/16215285cd14ee42f1764d93a22bde764b216e7d) envoy: 1.21.5 -> 1.23.1
* [`2ded6702`](https://github.com/NixOS/nixpkgs/commit/2ded6702dcccfdf9c42d0cefa1fb2e15fd0e0676) pomerium: 0.18.0 -> 0.19.0
* [`b4888277`](https://github.com/NixOS/nixpkgs/commit/b48882773a5c0d2b2345996e88417617029df8f5) ventoy-bin: 1.0.78 -> 1.0.79
* [`ea79b7ad`](https://github.com/NixOS/nixpkgs/commit/ea79b7ad0ce89683966953357a52945021a8ecc4) singular: 4.3.1 -> 4.3.1p2
* [`2f70a93b`](https://github.com/NixOS/nixpkgs/commit/2f70a93b3c55418f9aaa8b6bb077db74e65c508f) python310Packages.gehomesdk: 0.5.0 -> 0.5.6
* [`91311e30`](https://github.com/NixOS/nixpkgs/commit/91311e30b34d7607573d0cdd32e6acb04622ce2f) singular: disable docbuilding on darwin
* [`1f80c03c`](https://github.com/NixOS/nixpkgs/commit/1f80c03c0e38122fd622eed97b4a06ff71260507) scilla: 1.2.2 -> 1.2.3
* [`581b84ba`](https://github.com/NixOS/nixpkgs/commit/581b84bae3f21db333ba47fb58280ba9a517711a) sx-go: 0.4.0 -> 0.5.0
* [`1159ce0f`](https://github.com/NixOS/nixpkgs/commit/1159ce0fdbad2be979146262e39f35cab1d88ffd) tlsx: 0.0.6 -> 0.0.7
* [`f9811659`](https://github.com/NixOS/nixpkgs/commit/f98116594dee86e2df3c9a93f52ae4ccd7921f6b) strawberry: 1.0.8 -> 1.0.9
* [`c3c2b2f9`](https://github.com/NixOS/nixpkgs/commit/c3c2b2f9295803e85616dde148ceb76a12d5e175) uncover: 0.0.6 -> 0.0.7
* [`4d4d4587`](https://github.com/NixOS/nixpkgs/commit/4d4d4587ec31b1d722c8aa8074026144c5927b36) {jam,ftjam}: cross-compile without binfmt_misc
* [`7c09cfdc`](https://github.com/NixOS/nixpkgs/commit/7c09cfdc1ad7de866178550fcaeac6076b77024f) treemix: init at 1.13
* [`6e8fbbc9`](https://github.com/NixOS/nixpkgs/commit/6e8fbbc91bad07b4eff7bcd4e6d789613fc68958) dotnet-sdk_3: 3.1.420 -> 3.1.422
* [`7aebe844`](https://github.com/NixOS/nixpkgs/commit/7aebe84470a153d7f1766211d1d0fc33036bb4a1) python310Packages.tesla-wall-connector: 1.0.1 -> 1.0.2
* [`7e8d3e7b`](https://github.com/NixOS/nixpkgs/commit/7e8d3e7bd4684e9d1d8d6245f2a2a459dd7488c2) python310Packages.slack-sdk: 3.18.1 -> 3.18.2
* [`c99daa94`](https://github.com/NixOS/nixpkgs/commit/c99daa941a3d7d5a56014eda3de576e93fd90551) python310Packages.pynetgear: 0.10.7 -> 0.10.8
* [`dc50a6b5`](https://github.com/NixOS/nixpkgs/commit/dc50a6b5489d328e975f3aa552f8ca5f8aa02884) metasploit: 6.2.14 -> 6.2.16
* [`fd67f6de`](https://github.com/NixOS/nixpkgs/commit/fd67f6de3b36367fd49722b3e876225d0ff4b5d4) julia-bin: 1.7.3 -> 1.8.0
* [`6d492c33`](https://github.com/NixOS/nixpkgs/commit/6d492c330d17242d4141802b7810ed7c5206d548) qovery-cli: add version test and shell completion
* [`d5d441d2`](https://github.com/NixOS/nixpkgs/commit/d5d441d2c7d18a3582d4bdc076411ed957008d19) yacreader: 9.8.2 -> 9.9.1
* [`df2d60fe`](https://github.com/NixOS/nixpkgs/commit/df2d60fec7276ea7c55c9b7c9c78ea3a81c51ebd) gitleaks: 8.11.2 -> 8.12.0
* [`ff65a9cf`](https://github.com/NixOS/nixpkgs/commit/ff65a9cf26447b21d4c2d868a6cd15859bbc1d5b) gpxsee: 11.3 → 11.4
* [`310b9fe5`](https://github.com/NixOS/nixpkgs/commit/310b9fe58d34a4d655778bf561e8fb021e2d4b70) nixos/paperless: extract variable `pkg`
* [`684782e8`](https://github.com/NixOS/nixpkgs/commit/684782e874bc78fa691c366fd2dce5f0f282e7e4) dippi: init at 4.0.0
* [`8d991c13`](https://github.com/NixOS/nixpkgs/commit/8d991c13fc9a4835d5b22e98da7e24ba7788d012) arkade: 0.8.39 -> 0.8.41
* [`6a4d7a29`](https://github.com/NixOS/nixpkgs/commit/6a4d7a296816696fb4e4c9ef3143da6e2191cfd1) python310Packages.r2pipe: 1.7.1 -> 1.7.2
* [`ced7dfb1`](https://github.com/NixOS/nixpkgs/commit/ced7dfb13a9c5b3c2f1d198f69675216610c45c1) lsd: 0.22.0 -> 0.23.0
* [`056d8dbc`](https://github.com/NixOS/nixpkgs/commit/056d8dbce48c58bb1a862ae4e86bc5e5cba208e7) cariddi: 1.1.7 -> 1.1.8
* [`d59f2b21`](https://github.com/NixOS/nixpkgs/commit/d59f2b219d51df022cf4055786aee709c7082310) maintainers: remove longkeyid for peterwilli
* [`8dd37a90`](https://github.com/NixOS/nixpkgs/commit/8dd37a90d5304ae1419ddba814c9a2a08809ebd4) cdk-go: 1.3.0 -> 1.4.0
* [`ff185fa2`](https://github.com/NixOS/nixpkgs/commit/ff185fa2dddaa4fea033936b568a239d23571e1f) chezmoi: 2.22.0 -> 2.22.1
* [`b319d6c3`](https://github.com/NixOS/nixpkgs/commit/b319d6c32bc417177dd1727573e5f684e7acc14d) foot: 1.13.0 -> 1.13.1
* [`851594e2`](https://github.com/NixOS/nixpkgs/commit/851594e2b70cdc8eec4c8706078c58987f4e1efb) bazarr: 1.1.0 -> 1.1.1 and add source provenance
* [`271b5dc2`](https://github.com/NixOS/nixpkgs/commit/271b5dc25e08512281d5f0182cd96e16a026050f) nixos/tests/cinnamon: init
* [`33c884dd`](https://github.com/NixOS/nixpkgs/commit/33c884dde5f58bcfad0e3b65e1613f0192ead3f4) .github/labeler.yml: label PR that touches cinnamon modules and tests
* [`dfd14bd5`](https://github.com/NixOS/nixpkgs/commit/dfd14bd58911f0b780ed9fac59874ced517d90f4) buf: Patch out flakey test
* [`a1b37896`](https://github.com/NixOS/nixpkgs/commit/a1b37896b5f286cfd5abf5083a6b1fa5559e49b8)  ledger-live-desktop: 2.46.0 -> 2.46.2 
* [`658c8790`](https://github.com/NixOS/nixpkgs/commit/658c8790d11d9b60b71b39bc40087562926deb7d) epick: 0.8.1 -> 0.8.2
* [`83ee9a8d`](https://github.com/NixOS/nixpkgs/commit/83ee9a8def0b1953162f0770573e885d2ff6c1e7) esbuild: 0.15.6 -> 0.15.7
* [`efca919c`](https://github.com/NixOS/nixpkgs/commit/efca919cfbd0536220b643d93d0e5bd2b22f13a4) fclones: 0.27.1 -> 0.27.2
* [`783f8f16`](https://github.com/NixOS/nixpkgs/commit/783f8f16c16ba47daffff2c6b92a96eb8bb5d363) paperless: move `PYTHONPATH` definition to module
* [`adb14b17`](https://github.com/NixOS/nixpkgs/commit/adb14b1722798eaa4369a7732d415f8eb3e5c94b) grub2: fix initrd in menu entries for probed systems
* [`2f815324`](https://github.com/NixOS/nixpkgs/commit/2f815324317cc7fc41ac296b0e196e5cf707cdc5) chrony: 4.2 -> 4.3
* [`07caa11a`](https://github.com/NixOS/nixpkgs/commit/07caa11af6b25384c412fc1073c978d0e9dd0fa1) eww: 0.3.0 -> 0.4.0
* [`2905eb53`](https://github.com/NixOS/nixpkgs/commit/2905eb5343e5d86fa281c58b1344e2195fd583cb) helix: install completion
* [`518bdf2c`](https://github.com/NixOS/nixpkgs/commit/518bdf2c1cb7ef64bd80783b5aac0f35628bbd7c) folly: 2022.08.29.00 -> 2022.09.05.00
* [`f3e08ac0`](https://github.com/NixOS/nixpkgs/commit/f3e08ac0b1a191856c03e5e89cdd712fc7485f05) nixos/mediatomb: wait for network-online.target
* [`3f72016b`](https://github.com/NixOS/nixpkgs/commit/3f72016bb1960f7bcc76a1f6e920e52440655e38) ft2-clone: 1.56 -> 1.57
* [`f96f77c9`](https://github.com/NixOS/nixpkgs/commit/f96f77c909d8d2a0b81b5404889f5ed4d05cefa3) clickhouse-backup: 1.6.0 -> 2.0.0
* [`ee8fc450`](https://github.com/NixOS/nixpkgs/commit/ee8fc450cae25a1012c91f2b002f2f16c25108ea) intel-gmmlib: 22.1.7 -> 22.1.8
* [`c2347df4`](https://github.com/NixOS/nixpkgs/commit/c2347df4ee1502228d4fdfa4745f4bd26534c7e3) flyway: 9.2.0 -> 9.2.2
* [`800dbe3d`](https://github.com/NixOS/nixpkgs/commit/800dbe3d8a1440ce733fb20811cc76828032f383) ijq: 0.4.0 -> 0.4.1
* [`5f3c0763`](https://github.com/NixOS/nixpkgs/commit/5f3c07633aa1b3c3d56485a78ece850862f9d1f3) nushell: 0.65.0 -> 0.66.2
* [`0d117eb0`](https://github.com/NixOS/nixpkgs/commit/0d117eb087ba91a866922736887b65fdf3a6d2f8) nushell: patch Cargo to use pkgconfig for zstd
* [`c0d73cf8`](https://github.com/NixOS/nixpkgs/commit/c0d73cf864d9b1616ff7f28ddd06cbae6f4da668) nushell: Include Apple SDK for libproc.h / bindgen
* [`5d34561c`](https://github.com/NixOS/nixpkgs/commit/5d34561c4ada684fe511283e920cc366ff7d9965) nushell: 0.66.2 -> 0.67.0
* [`53a4c0be`](https://github.com/NixOS/nixpkgs/commit/53a4c0bec3e166f628d21e88d98def307586f20a) gromacs: 2022.2 -> 2022.3
* [`4969b300`](https://github.com/NixOS/nixpkgs/commit/4969b30021109f5f56a8484a36a46b7f79d53b02) genimage: 15 -> 16
* [`86bfd157`](https://github.com/NixOS/nixpkgs/commit/86bfd1573244eb68f3965f0fa690c8ab0acba76f) nixos/tests/mediatomb: fix test when running with gerbera
* [`b6f5b819`](https://github.com/NixOS/nixpkgs/commit/b6f5b819203d044247f92204d235689640a42634) kanidm: 1.1.0-alpha.8 -> 1.1.0-alpha.9
* [`9ac9449a`](https://github.com/NixOS/nixpkgs/commit/9ac9449a0a50d8daf07b08f46a5b49bc28b045ca) nixos/tests/kanidm: Update recover_account commandline
* [`051a1eb5`](https://github.com/NixOS/nixpkgs/commit/051a1eb521885dda577f0c783cae5c1d10822932) tmate: 2.4.0 -> unstable-2022-08-07
* [`dc66f772`](https://github.com/NixOS/nixpkgs/commit/dc66f772339d4fc0767cb774fbc3eb753b6a7a56) tmate-ssh-server: 2.3.0 -> unstable-2021-10-17
* [`fc2235cd`](https://github.com/NixOS/nixpkgs/commit/fc2235cd61734c384fd02b541e52d565a3ef15f5) clojure-lsp: 2022.07.24-18.25.43 -> 2022.09.01-15.27.31
* [`13d2edaa`](https://github.com/NixOS/nixpkgs/commit/13d2edaa42cf6a3feaa41126d52b3ae04acd1305) sageWithDoc: fix documentation index
* [`c81163c9`](https://github.com/NixOS/nixpkgs/commit/c81163c9167890f3b8074c5cef13c94a9066b719) python3Packages.assay: init at unstable-2022-01-19
* [`a2179118`](https://github.com/NixOS/nixpkgs/commit/a217911800a8cf3351a8e309734800a7fde3dfcf) python3Packages.jplephem: init at 2.17
* [`76a5da1a`](https://github.com/NixOS/nixpkgs/commit/76a5da1aae019e6c7ba0aebda09288bd2af20b50) python3Packages.sgp4: init at 2.21
* [`b915c914`](https://github.com/NixOS/nixpkgs/commit/b915c914827a11996a0673339611a77ae0d333b7) python3Packages.skyfield: init at 1.42
* [`4a77588c`](https://github.com/NixOS/nixpkgs/commit/4a77588c79aef32fa10cbecb77c7bad122f068e8) plex: 1.28.2.6106-44a5bbd28 -> 1.28.2.6151-914ddd2b3
* [`cc1b34f6`](https://github.com/NixOS/nixpkgs/commit/cc1b34f6fb4059260a3dcc9cef30ea4e88f8fad8) helmsman: 3.14.0 -> 3.15.0
* [`f0139430`](https://github.com/NixOS/nixpkgs/commit/f0139430dcb17ca66ad92dcd8bd7ec5e5bf7017e) hydroxide: 0.2.23 -> 0.2.24
* [`3bdac05d`](https://github.com/NixOS/nixpkgs/commit/3bdac05d7b274bd417bd211e0d463cfc44867ecf) obs-studio-plugins.obs-ndi: skip builds in hydra
* [`80426558`](https://github.com/NixOS/nixpkgs/commit/80426558a514fbed858cf327c73b0a02e3527ffa) obs-studio-plugins: normalize
* [`cbfacef7`](https://github.com/NixOS/nixpkgs/commit/cbfacef75b013104b9b8b42cf3df9ed6daba80fc) electrum-grs 4.2.0 -> 4.3.1
* [`c9a75045`](https://github.com/NixOS/nixpkgs/commit/c9a750458fd8a24b976eac6c99c8e98d7510db3e) firefox-unwrapped: 104.0.1 -> 104.0.2
* [`5e03faff`](https://github.com/NixOS/nixpkgs/commit/5e03faff777319f18736c58ec9d59c8c6d8cef0b) firefox-bin-unwrapped: 104.0.1 -> 104.0.2
* [`40e7fcaf`](https://github.com/NixOS/nixpkgs/commit/40e7fcaf288a93a999f36ae981ba4b7494d00f6a) firefox-beta-bin-unwrapped: 105.0b4 -> 105.0b7
* [`18b89d7c`](https://github.com/NixOS/nixpkgs/commit/18b89d7c1e52e7b775c12216b4f2273c254506a5) firefox-devedition-bin-unwrapped: 105.0b4 -> 105.0b7
* [`50dcda12`](https://github.com/NixOS/nixpkgs/commit/50dcda122ec9e0054689b94d64ce78956a9b8200) kanboard: 1.2.22 -> 1.2.23
* [`9c0d34c9`](https://github.com/NixOS/nixpkgs/commit/9c0d34c94094f1c5ac57ab29f8ba9e4d41c3da1f) glitter: 1.6.1 -> 1.6.3
* [`b6a94490`](https://github.com/NixOS/nixpkgs/commit/b6a94490a4f05ea9a80f897de5e89cc179d440be) maintainers: add gp2112
* [`df056ec4`](https://github.com/NixOS/nixpkgs/commit/df056ec4fab56d361183db3976b15a29b710a6c9) zen-kernels: 5.19.6 -> 5.19.7
* [`0b16c982`](https://github.com/NixOS/nixpkgs/commit/0b16c98205c02df91ab72d687a66927f34e3a7aa) pomerium: consolidate ui and base package
* [`8fcca788`](https://github.com/NixOS/nixpkgs/commit/8fcca788fb4b5e0b0d45b75f97d4dced0fc2a336) python3Packages.django_4: 4.1 -> 4.1.1
* [`40788fb9`](https://github.com/NixOS/nixpkgs/commit/40788fb997b792215d8a2c975ba2adb7f10d446a) ksmbd-tools: init at 3.4.5
* [`8212a177`](https://github.com/NixOS/nixpkgs/commit/8212a177cefdb2f6b30684e0291650e5b4c88046) nvidia_x11_vulkan_beta: 515.19.14 -> 515.49.15
* [`aa988f19`](https://github.com/NixOS/nixpkgs/commit/aa988f19ff60994c6b7ee5761479da1f7c771b01) python3Packages.pymoo: init at 0.6.0
* [`70d478f1`](https://github.com/NixOS/nixpkgs/commit/70d478f14738f80be7a6a7ff169547629d050ac6) oxipng: 5.0.1 -> 6.0.0
* [`f17c56b1`](https://github.com/NixOS/nixpkgs/commit/f17c56b165b92f11dd1911d89d2e4bf99713cad3) forgit: 2021-12-05 -> 2022-08-16
* [`2dbc5d06`](https://github.com/NixOS/nixpkgs/commit/2dbc5d06a128368195400fc6dc5477b4a1a78dd5) added solana-validator 1.10.35
* [`5f797c16`](https://github.com/NixOS/nixpkgs/commit/5f797c16a8b973602a7961189606006b4e207a1d) Update maintainer-list.nix
* [`000ac28e`](https://github.com/NixOS/nixpkgs/commit/000ac28e43d2090ba9e7ed84480ef4b33d5f4a25) updated all-packages.nix with solana-vvalidator
* [`1b823602`](https://github.com/NixOS/nixpkgs/commit/1b823602848a04e9d5ad16f58440da45a123c9b0) scanbd: fix cross compile configureFlags
* [`509541c7`](https://github.com/NixOS/nixpkgs/commit/509541c7a735db6346da0f75eda9e7870c078ecc) tautulli: 2.10.2 -> 2.10.4
* [`51d2625b`](https://github.com/NixOS/nixpkgs/commit/51d2625b49567149f642568509fe8406c15f71cf) elixir_1_14: init
* [`6daa5d17`](https://github.com/NixOS/nixpkgs/commit/6daa5d17c0a8f74f0241740ec657b1c0a5d55edf) warpd: 1.3.2 -> 1.3.3
* [`20f50c5f`](https://github.com/NixOS/nixpkgs/commit/20f50c5f55ceb219ab50bdc305257efc8c02f68d) python310Packages.cairo-lang: 0.9.1 -> 0.10.0
* [`9bdc728e`](https://github.com/NixOS/nixpkgs/commit/9bdc728ec4702ffd6a4d2f2b41a0c7554531f2eb) goaccess: 1.6.2 -> 1.6.3
* [`d6ff53dc`](https://github.com/NixOS/nixpkgs/commit/d6ff53dc47ab13e950ebeacefc329e7110104c25) httm: 0.14.9 -> 0.14.10
* [`8b0c26c7`](https://github.com/NixOS/nixpkgs/commit/8b0c26c7a1467ef08408ca77b8e546c68c72c553) haproxy: 2.6.4 -> 2.6.5
* [`0fe6d6f6`](https://github.com/NixOS/nixpkgs/commit/0fe6d6f6b9ab4b512469554b0c4d7520666377a6) root: populate ROOT_INCLUDE_PATH via the setupHook
* [`694fc2ff`](https://github.com/NixOS/nixpkgs/commit/694fc2fffee8a96b473c530d76e06369d6dded1e) klibc: fix KLIBCARCH=riscv64
* [`2e88e9b4`](https://github.com/NixOS/nixpkgs/commit/2e88e9b4d6706310ad03c11c09a3c4ad72b02f41) wezterm: 20220903-194523-3bb1ed61 -> 20220905-102802-7d4b8249
* [`6d0e82f1`](https://github.com/NixOS/nixpkgs/commit/6d0e82f11aeaef74f8f9adcf18c1c77df8c8e2c6) emacs: use withPgtk option more
* [`991d1aa0`](https://github.com/NixOS/nixpkgs/commit/991d1aa0a80be57b24332c58e5f596539eb63547) python3Packages.telegraph: init at 2.1.0
* [`bfe73f95`](https://github.com/NixOS/nixpkgs/commit/bfe73f95430a71daf1d2fdf1ae6832f2a4db0f35) nixos/grafana: loosen systemd syscall sandboxing
* [`77dac2f6`](https://github.com/NixOS/nixpkgs/commit/77dac2f63ec95886284aa76bb39df5c71d2bc46a) python3Packages.psycopg: 3.1 -> 3.1.1
* [`71b85973`](https://github.com/NixOS/nixpkgs/commit/71b85973dd334b983b9ec7b7489953e48316a67c) nodejs-18_x: fix cross compilation to aarch64-linux
* [`f68f6d47`](https://github.com/NixOS/nixpkgs/commit/f68f6d47652abfe86149efa18a1094fe4b1b60c4) cinnamon.bulky: 2.4 -> 2.5
* [`0cac2f53`](https://github.com/NixOS/nixpkgs/commit/0cac2f536fa8d9cb5df8633232e824a76def1577) postgresql11Packages.plpgsql_check: 2.1.8 -> 2.1.9
* [`7d62f9f4`](https://github.com/NixOS/nixpkgs/commit/7d62f9f40f6265f0c16de68eea18d8d387626ba5) php80Packages.php-cs-fixer: 3.10.0 -> 3.11.0
* [`46cae205`](https://github.com/NixOS/nixpkgs/commit/46cae20566d8d85d63d77ab60fc00687c847ec1b) psi-plus: 1.5.1633 -> 1.5.1640
* [`239c3a5d`](https://github.com/NixOS/nixpkgs/commit/239c3a5d0c205405d4b4de6a9929ecde6e989d04) cinnamon.cinnamon-common: 5.4.11 -> 5.4.12
* [`e07cc970`](https://github.com/NixOS/nixpkgs/commit/e07cc970b8468026cad963fbb874e55dd5808ef3) cinnamon.cinnamon-control-center: 5.4.6 -> 5.4.7
* [`8de77a88`](https://github.com/NixOS/nixpkgs/commit/8de77a8869a4e4e3fcf6a36675017acc9d5cb7ca) cinnamon.muffin: 5.4.6 -> 5.4.7
* [`1e4bc856`](https://github.com/NixOS/nixpkgs/commit/1e4bc8569a0e23a00f58f222dac9dc3e17de07c2) cinnamon.warpinator: 1.2.13 -> 1.2.14
* [`f69dfdfa`](https://github.com/NixOS/nixpkgs/commit/f69dfdfa8c6b28a0a37d79d6d7bee95a6ae3386f) cinnamon.xapps: 2.2.14 -> 2.2.15
* [`7e6b294f`](https://github.com/NixOS/nixpkgs/commit/7e6b294f4b96b36d2fa468bb9f3ef2ed8c9936ee) python310Packages.faraday-agent-parameters-types: 1.0.3 -> 1.0.4
* [`d2a6a440`](https://github.com/NixOS/nixpkgs/commit/d2a6a4404548289b401ba4ee179d47386001a662) python310Packages.jupyterlab: 3.4.5 -> 3.4.6
* [`78f2923e`](https://github.com/NixOS/nixpkgs/commit/78f2923e5c319ffcf73eb22ffd245a566b8bd2d3) python310Packages.niapy: 2.0.2 -> 2.0.3
* [`dfee6291`](https://github.com/NixOS/nixpkgs/commit/dfee629102e0eacce8e8372e8f08b127c0c577f2) python310Packages.tilt-ble: init at 0.2.2
* [`bc392314`](https://github.com/NixOS/nixpkgs/commit/bc392314c6d2772e80e2da5004097de463a9ec69) libxslt: fix cross compilation ([nixos/nixpkgs⁠#189766](https://togithub.com/nixos/nixpkgs/issues/189766))
* [`b84625ee`](https://github.com/NixOS/nixpkgs/commit/b84625ee73c35f5a6739ec6d05beb0abdae782ef) steam: Disable udev-based joystick discovery for SDL2
* [`703cb225`](https://github.com/NixOS/nixpkgs/commit/703cb2250a3d7c3fbe3d5f104ec1b3400217a1bf) cargo-public-api: 0.15.0 -> 0.16.0
* [`4d8b3b93`](https://github.com/NixOS/nixpkgs/commit/4d8b3b93cd02e52e305a9b229076b0c986d8c551) cargo-public-api: 0.16.0 -> 0.17.0
* [`1706a798`](https://github.com/NixOS/nixpkgs/commit/1706a7982672b483cf5448ff27011c33395ac337) python310Packages.numpyro: 0.10.0 -> 0.10.1
* [`b5dbb075`](https://github.com/NixOS/nixpkgs/commit/b5dbb07543e8ccd6031a7e04d908a26759917cae) brave: 1.42.88 -> 1.43.89
* [`bb4f09b8`](https://github.com/NixOS/nixpkgs/commit/bb4f09b8a1feeb64e550985d32effc7d387139af) python310Packages.bluemaestro-ble: init at 0.2.0
* [`5ff71680`](https://github.com/NixOS/nixpkgs/commit/5ff71680db21fc2d6c924517165b00650c52996c) arkade: 0.8.41 -> 0.8.42
* [`45119d88`](https://github.com/NixOS/nixpkgs/commit/45119d888016930b6a531941b9c34bca963f19bf) python310Packages.sensorpro-ble: init at 0.5.0
* [`5d172387`](https://github.com/NixOS/nixpkgs/commit/5d17238756ff5489da7dfaf9f08f29b7b0c97864) bazelisk: 1.12.2 -> 1.13.1
* [`aa192bd8`](https://github.com/NixOS/nixpkgs/commit/aa192bd8976b6ad31fd61708e6fa24c6c8310c8c) hashcat: 6.2.5 -> 6.2.6 ([nixos/nixpkgs⁠#189921](https://togithub.com/nixos/nixpkgs/issues/189921))
* [`d98f8e3c`](https://github.com/NixOS/nixpkgs/commit/d98f8e3ca723d69a25bf65504345977da2b9c260) syncthing: 1.20.4 -> 1.21.0
* [`acd6ceaf`](https://github.com/NixOS/nixpkgs/commit/acd6ceaf096df7ccd321b202409b385d09a6a130) exportarr: switch category
* [`2019dffa`](https://github.com/NixOS/nixpkgs/commit/2019dffa1a18de93a0eea18cbc33e5572405aa9b) bzip3: 1.1.4 -> 1.1.5
* [`f7ae362d`](https://github.com/NixOS/nixpkgs/commit/f7ae362df911d52a6239ab5a5cb28a21df09f128) checkmate: 0.8.0 -> 0.8.2
* [`654192bd`](https://github.com/NixOS/nixpkgs/commit/654192bd631548f5689102799f22090ab810682e) garage: 0.7.0 -> 0.7.3
* [`b61fb50d`](https://github.com/NixOS/nixpkgs/commit/b61fb50ddee8727d87b0c4f9ba4ed0b74961bd33) less: 600 -> 608
* [`e0582a72`](https://github.com/NixOS/nixpkgs/commit/e0582a726894684481140c09ef397785a1f3dd08) sshuttle: 1.1.0 -> 1.1.1
* [`a037a50b`](https://github.com/NixOS/nixpkgs/commit/a037a50b4696632977dadd61747b02492a109478) coq_8_16: 8.16+rc1 -> 8.16.0
* [`9caf5f6b`](https://github.com/NixOS/nixpkgs/commit/9caf5f6ba95dc8b62bfe2a71bd01e71f55711ffb) nixos/test-driver: fix formatting of closed port
* [`4bb29bcb`](https://github.com/NixOS/nixpkgs/commit/4bb29bcb0f9bc8a90ea3c7f93969e0ad7071609d) ddosify: 0.8.1 -> 0.8.2
* [`bcb5b1a3`](https://github.com/NixOS/nixpkgs/commit/bcb5b1a30d8efa58f801baa7488303003a501aec) esphome: 2022.8.1 -> 2022.8.3
* [`812ec843`](https://github.com/NixOS/nixpkgs/commit/812ec843c347ff7cb7af2da67faaf8aa6c52f06a) AusweisApp2: 1.24.1 -> 1.24.2
* [`e9ae1818`](https://github.com/NixOS/nixpkgs/commit/e9ae1818e34acd5298116207861cf5c168e6e8af) python310Packages.tcxreader: init at 0.4.1
* [`ecf58409`](https://github.com/NixOS/nixpkgs/commit/ecf58409a27826c8bf1de8c622705607633dba19) grafana: 9.1.2 -> 9.1.3
* [`c91790e2`](https://github.com/NixOS/nixpkgs/commit/c91790e21ca75217d2e7efe8fe516ff14c4b3d1f) add attributes for metacoq subpackages
* [`ebb86f32`](https://github.com/NixOS/nixpkgs/commit/ebb86f32b5b962e5096f1517dd4dbab14f21f026) ghz: 0.109.0 -> 0.110.0
* [`efc31ef8`](https://github.com/NixOS/nixpkgs/commit/efc31ef86eb80bde3fea0dce45222cad058bac43) maintainers: remove longkeyid for akkesm
* [`09711587`](https://github.com/NixOS/nixpkgs/commit/0971158732b6dac88406a9209bd73efbb3534333) grype: 0.42.0 -> 0.49.0
* [`41fac8c3`](https://github.com/NixOS/nixpkgs/commit/41fac8c3f7fe9f1b00bcf5be17000c0a72fe151d) gomi: 1.1.1 -> 1.1.3
* [`f094ede0`](https://github.com/NixOS/nixpkgs/commit/f094ede0abcb9e77fa363978b009914a5a3e9643) gum: 0.5.0 -> 0.6.0
* [`c5fb47d2`](https://github.com/NixOS/nixpkgs/commit/c5fb47d28b604246a7056c3a1cfa6bb95aec3497) icingaweb2-ipl: 0.8.1 -> 0.10.0
* [`ba473eed`](https://github.com/NixOS/nixpkgs/commit/ba473eeda413639d83be3b28c424834043c1fb40) krill: 0.9.6 -> 0.10.0
* [`ba3c562f`](https://github.com/NixOS/nixpkgs/commit/ba3c562fdc397464e03f850e2b60d6e59702f39a) lib/systems: uname.processor is "uname -m", not "uname -p" ([nixos/nixpkgs⁠#189958](https://togithub.com/nixos/nixpkgs/issues/189958))
* [`8b49f44a`](https://github.com/NixOS/nixpkgs/commit/8b49f44a775a43c80420501a23280d2bd4d47277) vscode-extensions.2gua.rainbow-brackets: init at 0.0.6
* [`2c2366f6`](https://github.com/NixOS/nixpkgs/commit/2c2366f68134aa378acdd8dee7a2a18b5e01b5a1) cmctl: fix version encoded inside binary
* [`8173ccd2`](https://github.com/NixOS/nixpkgs/commit/8173ccd23cfdb58a4a261e81d2d20f45f31f1ddf) freenukum: 0.3.5 -> 0.4.0
* [`7937f122`](https://github.com/NixOS/nixpkgs/commit/7937f122cc751b945f627a95f5d9c8d2c73c14aa) govulncheck: init at unstable-2022-09-02
* [`f367b52c`](https://github.com/NixOS/nixpkgs/commit/f367b52ccb85cbecb62de134f3851432e8614aec) maintainers: add ifurther
* [`72a60822`](https://github.com/NixOS/nixpkgs/commit/72a60822a7d1cb5eddc31178dfe82b96c7b46d04) piping-server-rust: 0.14.0 -> 0.14.1
* [`dbd69e7f`](https://github.com/NixOS/nixpkgs/commit/dbd69e7feda41f1381ded06caa27ea540a2cf5da) python3Packages.pyjnius: init at 1.4.0
* [`ab39d3a7`](https://github.com/NixOS/nixpkgs/commit/ab39d3a71c94b4f19d736dcab58ee7121062f375) python310Packages.croniter: 1.3.5 -> 1.3.7
* [`ee85c13d`](https://github.com/NixOS/nixpkgs/commit/ee85c13df19438a55fc1be1f93b7bce7a309ca8b) python310Packages.bayesian-optimization: Fix broken tests ([nixos/nixpkgs⁠#181205](https://togithub.com/nixos/nixpkgs/issues/181205))
* [`4af048fb`](https://github.com/NixOS/nixpkgs/commit/4af048fbb0440744a9e1f5876daed55c955642c9) swaycwd: 0.1.0 -> 0.2.1
* [`023477c4`](https://github.com/NixOS/nixpkgs/commit/023477c44bd9ac9f808fe3fd7d3cb50f8039af11) python310Packages.flufl_i18n: 4.1 -> 4.1.1
* [`cdeffa7c`](https://github.com/NixOS/nixpkgs/commit/cdeffa7ca8c8d5b1b3de2d0ae1ae3689a799839c) python310Packages.google-cloud-bigquery-storage: 2.14.2 -> 2.15.0
* [`977ab682`](https://github.com/NixOS/nixpkgs/commit/977ab682f1bb709b49e3a1a1b6069d86abfe6c52) python310Packages.google-cloud-dlp: 3.8.1 -> 3.9.0
* [`f2625ce4`](https://github.com/NixOS/nixpkgs/commit/f2625ce4446d3a7587b99762fd4e22cb4352c9df) pympress: 1.7.0 -> 1.7.2
* [`97ba09f0`](https://github.com/NixOS/nixpkgs/commit/97ba09f0b5921859ecb1e71e5acb939ee951e41e) zld: fix hash
* [`3cbd5ebd`](https://github.com/NixOS/nixpkgs/commit/3cbd5ebddd0ad16f190f3cc4a5a499a51f801cf4) python310Packages.google-cloud-translate: 3.8.1 -> 3.8.2
* [`7aeff12e`](https://github.com/NixOS/nixpkgs/commit/7aeff12e66ba830770fa0dbf34a2be8f262804a4) emacs: Enable Xaw3d by default
* [`9c0908cb`](https://github.com/NixOS/nixpkgs/commit/9c0908cb829217edc38729eaf4bc603a39145a0f) gen6dns: init at 1.3
* [`bb6a40eb`](https://github.com/NixOS/nixpkgs/commit/bb6a40ebb6a738f95ba973481c5f239c5efe8eda) iwgtk: 0.4.0 -> 0.8.0
* [`71501165`](https://github.com/NixOS/nixpkgs/commit/715011659f57ac8e18205c51b0c1ab317111b2e4) python310Packages.bitcoin-utils-fork-minimal: fix build
* [`9f8ee9cf`](https://github.com/NixOS/nixpkgs/commit/9f8ee9cffee589eb038c04c391cc505452fdb003) python310Packages.numba-scipy: fix build
* [`fd6974be`](https://github.com/NixOS/nixpkgs/commit/fd6974be783d10cc851700dbeb1183a0b7acc138) kratos: 0.9.0-alpha.3 -> 0.10.1
* [`e55b330b`](https://github.com/NixOS/nixpkgs/commit/e55b330b9d3a5b0b253b81877b6b03e0e179f384) lxqt.lxqt-archiver: add missing dependence libraries
* [`a3c15e0d`](https://github.com/NixOS/nixpkgs/commit/a3c15e0dd71b399ebfe265417f787936bceb0dfd) fbmenugen: add update script
* [`bae77b32`](https://github.com/NixOS/nixpkgs/commit/bae77b326760877cd0a65d132350f2a46b888e2d) fbmenugen: 0.86 -> 0.87
* [`087ee031`](https://github.com/NixOS/nixpkgs/commit/087ee031b53574e46eb1bdbee5609ddc489ca092) seaweedfs: 3.24 -> 3.26
* [`1bb33d6d`](https://github.com/NixOS/nixpkgs/commit/1bb33d6dbe46554d08644e5e1026fc7761ecbd8d) doc/contributing: fix whitespace
* [`32d6c5be`](https://github.com/NixOS/nixpkgs/commit/32d6c5be2de2ac59bb4ef3fb59cd62d35c61125d) gitea: 1.17.1 -> 1.17.2
* [`bde6bdeb`](https://github.com/NixOS/nixpkgs/commit/bde6bdeb0fe1d593ecdbfb6c95030b0c07973111) python310Packages.peaqevcore: 5.18.1 -> 5.18.3
* [`648bcc8f`](https://github.com/NixOS/nixpkgs/commit/648bcc8f4288d5526e4d347c4ef404ea51c1d8f6) pympress: Move gobject-introspection to nativeBuildInputs
* [`d14eb621`](https://github.com/NixOS/nixpkgs/commit/d14eb6219d9da8bdcdef50637fa33c7d649d134d) python310Packages.pick: 1.4.0 -> 2.0.0
* [`1a78cf9c`](https://github.com/NixOS/nixpkgs/commit/1a78cf9ce3ba1ecf4adb1e67a4fb3275408814d4) sumneko-lua-language-server: 3.5.3 -> 3.5.4
* [`ca1f9848`](https://github.com/NixOS/nixpkgs/commit/ca1f98483ed71fd5852cb80a0d10bb7896e4e691) terranix: 2.5.4 -> 2.5.5
* [`8aebd406`](https://github.com/NixOS/nixpkgs/commit/8aebd40643fee21f66caf21938050dee48248e69) uncover: 0.0.7 -> 0.0.8
* [`8b3abc87`](https://github.com/NixOS/nixpkgs/commit/8b3abc870cdd373d158326faf6429eb93d3349fb) cargo-expand: 1.0.30 -> 1.0.31
* [`396991db`](https://github.com/NixOS/nixpkgs/commit/396991db24664372080654434e91795084eb287a) vault-medusa: 0.3.5 -> 0.3.6
* [`faed8ef3`](https://github.com/NixOS/nixpkgs/commit/faed8ef36e8942eb6f3127a5071e64896d53c60c) sioyek: mark as broken on Darwin Aarch64
* [`9961e915`](https://github.com/NixOS/nixpkgs/commit/9961e915b3a5f5343417fa7771d60b68b39f54d0) eask: init at 0.6.43
* [`bbe6864a`](https://github.com/NixOS/nixpkgs/commit/bbe6864ab08e5648d31d2050859bf7123bcd521c) python310Packages.flufl_i18n: add meta
* [`0c2299c3`](https://github.com/NixOS/nixpkgs/commit/0c2299c331265948fa00c039ccf75a37b4c66a31) python310Packages.r2pipe: 1.7.2 -> 1.7.3
* [`6c8dcf6a`](https://github.com/NixOS/nixpkgs/commit/6c8dcf6a73283ee44727742b29b6296e6945a58f) logseq: 0.8.4 -> 0.8.5
* [`510c7b9d`](https://github.com/NixOS/nixpkgs/commit/510c7b9d7ff1c4939dca4f048f1f258d4deb7107) python310Packages.sqlmap: 1.6.8 -> 1.6.9
* [`43bf7f32`](https://github.com/NixOS/nixpkgs/commit/43bf7f32c1016486f72159e0deeabc8383c191d1) bat: 0.21.0 -> 0.22.0
* [`b7612601`](https://github.com/NixOS/nixpkgs/commit/b7612601af7a3435fd65105756d608aaf1075fcf) gh: 2.14.7 -> 2.15.0
* [`0277e56e`](https://github.com/NixOS/nixpkgs/commit/0277e56ed5cd301a6a98ba7517c3274babb4485a) p4d: init at 2022.1.2305383
* [`d2d3a9b7`](https://github.com/NixOS/nixpkgs/commit/d2d3a9b77ddd01630d51d4c75aa1a49496b41c90) go_1_19: 1.19 -> 1.19.1
* [`0b0e64ae`](https://github.com/NixOS/nixpkgs/commit/0b0e64aed84a7633d5b07bf8c42500b448996873) python310Packages.versioneer: 0.25 -> 0.26
* [`e9b99943`](https://github.com/NixOS/nixpkgs/commit/e9b99943ddf422f939dff594cbdd88b9e3f16fd5) nixosTests.gitea.*: adapt to option renaming
* [`9071fb55`](https://github.com/NixOS/nixpkgs/commit/9071fb55f680f0e20df851381d3a1cf1659d2335) maintainers: add self to maintainers list
* [`4c8a3de1`](https://github.com/NixOS/nixpkgs/commit/4c8a3de137f9e1aa65fd7dba3778cd16003d75f2) gvisor: 20210518.0 -> 20220905.0
* [`26a727ef`](https://github.com/NixOS/nixpkgs/commit/26a727ef4441d4bdbaa5d9bc4ebdaec19797df66) python3Packages.django-stubs-ext: init at 0.5.0
* [`06680873`](https://github.com/NixOS/nixpkgs/commit/06680873a1f3e84a29d2582d1fe51e1ebed9583c) python3Packages.django-stubs: init at 1.12.0
* [`f9ad9aab`](https://github.com/NixOS/nixpkgs/commit/f9ad9aab790b8e21abef1a6d480714001f9346b8) fftwMpi: add attribute for MPI-enabled fftw
* [`3826784a`](https://github.com/NixOS/nixpkgs/commit/3826784ae914eab98fc6b3ade6b50018b81db29d) libvdwxc: init at 24.02.2020
* [`bb1b2cf2`](https://github.com/NixOS/nixpkgs/commit/bb1b2cf2f2a29f1e8632d253cb358a329574a454) gpaw: init at 22.8.0
* [`02307106`](https://github.com/NixOS/nixpkgs/commit/02307106c4d8037d56d22ff30b588039730be917) claws-mail: do not use fetchgit; upstream has force-pushed ([nixos/nixpkgs⁠#189951](https://togithub.com/nixos/nixpkgs/issues/189951))
* [`1d352157`](https://github.com/NixOS/nixpkgs/commit/1d352157877a09259b0ae396917bc71a30bcd0ac) boulder: 2022-08-29 -> 2022-09-06
* [`48728f5c`](https://github.com/NixOS/nixpkgs/commit/48728f5ca4b90407bc83fd02ab5ca7f6ed9d9d93) mupdf: fix finding pkg-config under cross-compilation
* [`b1bcd5ba`](https://github.com/NixOS/nixpkgs/commit/b1bcd5ba08fcfa70bb6511fe44b91d23c30ba351) checkSSLCert: 2.41.0 -> 2.42.0
* [`7794eb89`](https://github.com/NixOS/nixpkgs/commit/7794eb89c815e92f0311c223a1d6dcf1ec9b0861) rls: remove
* [`ceb7c1d1`](https://github.com/NixOS/nixpkgs/commit/ceb7c1d13c31822765a39d320d090e50198cd72e) cpp-utilities: 5.18.0 -> 5.19.0
* [`319a0fc6`](https://github.com/NixOS/nixpkgs/commit/319a0fc6b4d3a78e1cb2b53997b974038bdbae9b) Add personnal info to maintainers list
* [`777ba23c`](https://github.com/NixOS/nixpkgs/commit/777ba23c173dbe8ce8f5decb203ffb989b0bc031) systemc: Init at 2.3.3
* [`ea3d9cc8`](https://github.com/NixOS/nixpkgs/commit/ea3d9cc8cec22620444abc8baf39b64ee0f207cd) zsh-powerlevel10k: add powerlevel9k.zsh-theme to install phase
* [`d4b1bbb7`](https://github.com/NixOS/nixpkgs/commit/d4b1bbb7d3dbbcd2af90b845686ea2282c704a7e) coccinelle: backport some useful patches
* [`7d6b5d17`](https://github.com/NixOS/nixpkgs/commit/7d6b5d171adaf0a7d6808493629556d270c35c47) update-script-combinators: experimental init
* [`9137e671`](https://github.com/NixOS/nixpkgs/commit/9137e671a2e2f5b46748ae21b21737b3f4194883) update-script-combinators.copyAttrOutputToFile: init
* [`6262fa0b`](https://github.com/NixOS/nixpkgs/commit/6262fa0b1724a32ffe07cf69e3b7284c8ea17ed2) evolution-data-server: generate GSettings patch as part of update script
* [`258615be`](https://github.com/NixOS/nixpkgs/commit/258615beb660d52ed1aa2ef79e3971e8457f4030) dagger: 0.2.32 -> 0.2.33
* [`9cb9dd71`](https://github.com/NixOS/nixpkgs/commit/9cb9dd71561c715968a3d30144f6eb5c959f68c2) hyperfine: 1.14.0 -> 1.15.0
* [`ae455c17`](https://github.com/NixOS/nixpkgs/commit/ae455c17d476c7d95df68defca64d9f31522e8dd) genact: 0.12.0 -> 1.0.0
* [`96e6bc80`](https://github.com/NixOS/nixpkgs/commit/96e6bc8098568d9e6a0b0faf5b8d860a9c8ff4d6) ecs-agent: 1.62.2 -> 1.63.0
* [`51f9cbc4`](https://github.com/NixOS/nixpkgs/commit/51f9cbc44ee42b10cd918148d325a37cedccd684) xmind: 8-update8 -> 8-update9
* [`11c8f03e`](https://github.com/NixOS/nixpkgs/commit/11c8f03ea397e408c7cc26f3d29e2c5bfd9cc5d9) podman: 4.2.0 -> 4.2.1
* [`720cf227`](https://github.com/NixOS/nixpkgs/commit/720cf227e996cbbd2016ac4c93a79c8c143fa1a3) maintainers: add rb
* [`9121f5b0`](https://github.com/NixOS/nixpkgs/commit/9121f5b0f6be9179bbfaeb68fc0e37cd915b46fb) atmos: init at 1.4.28
* [`28967f6f`](https://github.com/NixOS/nixpkgs/commit/28967f6f401accf20a48d207ce90a1e93efb633c) juju: 2.9.33 -> 2.9.34
* [`4c7b6ecc`](https://github.com/NixOS/nixpkgs/commit/4c7b6eccb63e0d23ad82e854b3f7959bf12291c6) kubeaudit: 0.19.0 -> 0.20.0
* [`3155fc87`](https://github.com/NixOS/nixpkgs/commit/3155fc874929aafb7ef5f97aebde6065cca42882) kubespy: 0.6.0 -> 0.6.1
* [`253fd6b7`](https://github.com/NixOS/nixpkgs/commit/253fd6b7d3b52404482ace9e5c66040836948156) kubie: 0.18.0 -> 0.19.0
* [`37102db7`](https://github.com/NixOS/nixpkgs/commit/37102db7a3a1cea307b1e576c26e86819f639f8a) vault-medusa: add onny as a maintainer ([nixos/nixpkgs⁠#190143](https://togithub.com/nixos/nixpkgs/issues/190143))
* [`c9fdaef4`](https://github.com/NixOS/nixpkgs/commit/c9fdaef48f89dc74f2375f99e872c9ab92c79912) oxipng: 6.0.0 -> 6.0.1
* [`d74a6bf2`](https://github.com/NixOS/nixpkgs/commit/d74a6bf2f71d4f11476b309999437a783e46e44a) python3Packages.nilearn: add missing lxml dep
* [`6460e740`](https://github.com/NixOS/nixpkgs/commit/6460e74082970ec01d7d4ae42ea647966d4f5d1d) nerdfonts: 2.2.1 -> 2.2.2
* [`47f5e765`](https://github.com/NixOS/nixpkgs/commit/47f5e765155521956f5cd075765b57e471f372f2) emacsPackages.yes-no: add jcs090218 as maintainer
* [`c5f6fd74`](https://github.com/NixOS/nixpkgs/commit/c5f6fd74daacae5fb5c5a46d27b271633c0f1938) emacsPackages.yes-no: init at 0
* [`8e714abe`](https://github.com/NixOS/nixpkgs/commit/8e714abef5b8b6bd6bb93e1dd76f7b02a172ea36) pdepend: 2.11.1 -> 2.12.0
* [`3419a29d`](https://github.com/NixOS/nixpkgs/commit/3419a29def63fea561d6bc23a8c7f61f71dd468a) pomerium-cli: 0.18.0 -> 0.19.0
* [`4ceb1c03`](https://github.com/NixOS/nixpkgs/commit/4ceb1c03622aa56bb833d2618a47d2311109986f) cargo-zigbuild: init at 0.12.0
* [`29608b72`](https://github.com/NixOS/nixpkgs/commit/29608b72419d737edf8d45f1baa8c88c8757c8f5) openturns: init at 1.19
* [`41697e37`](https://github.com/NixOS/nixpkgs/commit/41697e373db9c29ae5968c8e4f483f4144061578) rmfakecloud: 0.0.8 -> 0.0.9
* [`ef69ebad`](https://github.com/NixOS/nixpkgs/commit/ef69ebad1b1d3331167a13e2bb63965930a611a2) libid3tag: substitute version from src url
* [`63be0d9b`](https://github.com/NixOS/nixpkgs/commit/63be0d9b2c79e6b9f35611fd68aa2b85d5b76baf) mpv: fix cross compilation
* [`5637f276`](https://github.com/NixOS/nixpkgs/commit/5637f276a5026d3d31bcecae915cf1f97d9e0a0d) sumneko-lua-language-server: 3.5.4 -> 3.5.5
* [`0ad4c0f2`](https://github.com/NixOS/nixpkgs/commit/0ad4c0f29cff7821e3ac2cbd1a91bfad8d032d10) ngtcp2: switch to cmake build system to fix aarch64-linux build
* [`4ffd6bd6`](https://github.com/NixOS/nixpkgs/commit/4ffd6bd6f6b6bfdf2c7810bbad09ac46582613b3) spire: 1.4.0 -> 1.4.1
* [`1afe4293`](https://github.com/NixOS/nixpkgs/commit/1afe4293396d49ab1366c27490703205cfeee6c9) systeroid: 0.2.1 -> 0.2.2
* [`218d3e07`](https://github.com/NixOS/nixpkgs/commit/218d3e072accd1071e56e96acca6e60317ca37ff) terraform-ls: 0.28.1 -> 0.29.2
* [`67a6c563`](https://github.com/NixOS/nixpkgs/commit/67a6c56353d1761cc62650385a6dc7da135dc8e9) tflint: 0.39.3 -> 0.40.0
* [`081bce2c`](https://github.com/NixOS/nixpkgs/commit/081bce2c75b53897f847b90c8ca8023e5dba594c) twitterBootstrap: 5.2.0 -> 5.2.1
* [`889069b8`](https://github.com/NixOS/nixpkgs/commit/889069b8b3433895f1a84b8f5ebb2751d867cf32) adguardhome: 0.107.11 -> 0.107.12
* [`2f761d4a`](https://github.com/NixOS/nixpkgs/commit/2f761d4a484301b535ac65865540b70b037f9afe) chromiumBeta: 106.0.5249.21 -> 106.0.5249.30
* [`652f209b`](https://github.com/NixOS/nixpkgs/commit/652f209b80b1bd88fa4844e2ec6c4f6e081fd819) watchexec: 1.20.5 -> 1.20.6
* [`0f91504e`](https://github.com/NixOS/nixpkgs/commit/0f91504e4787a10428e17a22bdc2f6ef8a60d26f) python37: 3.7.13 -> 3.7.14
* [`d1633b50`](https://github.com/NixOS/nixpkgs/commit/d1633b506b536cc298f04cb1a2e5fbdfc49442d7) python38: 3.8.13 -> 3.8.14
* [`14f6760c`](https://github.com/NixOS/nixpkgs/commit/14f6760c5e03b0b3d9fe6b826be7861aa649e41c) babashka: 0.9.160 -> 0.9.162
* [`8b3642d6`](https://github.com/NixOS/nixpkgs/commit/8b3642d6f5b3abf8ca0ecc58a89d1bb36e3b820b) bgpq4: 1.5 -> 1.6
* [`3f34e98d`](https://github.com/NixOS/nixpkgs/commit/3f34e98da887701d5963694306878eff5b6346a2) argocd-autopilot: 0.4.5 -> 0.4.6
* [`9697c9a3`](https://github.com/NixOS/nixpkgs/commit/9697c9a3a3638c5f2279ba39f4e66bbe416a9fcb) nncp: 8.7.2 -> 8.8.0
* [`1ed73dd0`](https://github.com/NixOS/nixpkgs/commit/1ed73dd007fbcd0b62d682d62ed28ae4e7ba4643) gdu: 5.15.0 -> 5.16.0
* [`3e61dc7e`](https://github.com/NixOS/nixpkgs/commit/3e61dc7e2e8334daa4a59d6538084cc6440b0381) closurecompiler: 20220803 -> 20220905
* [`69fcff00`](https://github.com/NixOS/nixpkgs/commit/69fcff00d0fbf7d742f31900f46a5c27c5caf85e) terraform: 1.2.8 -> 1.2.9 ([nixos/nixpkgs⁠#190216](https://togithub.com/nixos/nixpkgs/issues/190216))
* [`1e7eabdf`](https://github.com/NixOS/nixpkgs/commit/1e7eabdf358d5345ebf549592a3503dd9088252d) discordchatexporter-cli: 2.35 -> 2.35.1
* [`49a891ba`](https://github.com/NixOS/nixpkgs/commit/49a891ba59018952aa8236029c4ca6abff8a4fea) kubespy: fix version command
* [`50fafff2`](https://github.com/NixOS/nixpkgs/commit/50fafff2af3d60594322019584f1ad7201c6c4fc) flexget: 3.3.24 -> 3.3.25
* [`87c8afa3`](https://github.com/NixOS/nixpkgs/commit/87c8afa3b4ebd856c677074c2e9660a244caebe1) kubespy: install completion files
* [`e7ec55a7`](https://github.com/NixOS/nixpkgs/commit/e7ec55a72d751b1e9583f854f236e266f9cf4d72) nixos/proxmox-image: fix broken build, reduce build time
* [`24d00356`](https://github.com/NixOS/nixpkgs/commit/24d00356129f58318f72aa1b265b46c6be54a440) hjson-go: 4.0.0 -> 4.1.0
* [`56db5d8a`](https://github.com/NixOS/nixpkgs/commit/56db5d8a0c92a691acf4c8cda3af53411bf2aa77) autotiling: 1.6 -> 1.6.1
* [`76685355`](https://github.com/NixOS/nixpkgs/commit/7668535584910a292d613bde54b31b8c70422404) linode-cli: 5.22.0 -> 5.22.0
* [`50ba9f39`](https://github.com/NixOS/nixpkgs/commit/50ba9f397a320246c0c3e9f9f32b463026306415) audible-cli: 0.2.1 -> 0.2.3
* [`5a6fcb7f`](https://github.com/NixOS/nixpkgs/commit/5a6fcb7ff346e60a1ffa9af8d80c341c7772444e) crlfsuite: 2.1.2 -> 2.5.2
* [`2936948b`](https://github.com/NixOS/nixpkgs/commit/2936948b2859d1ff7585ecdcadca58bd52ff14dc) cfripper: 1.12.0 -> 1.13.0
* [`53af2c93`](https://github.com/NixOS/nixpkgs/commit/53af2c93ce1b947db665638a68720789294189bd) nodejs-18_x: 18.8.0 -> 18.9.0
* [`fa41b55f`](https://github.com/NixOS/nixpkgs/commit/fa41b55fdf1c05457a67e4072951f17a7c86467e) millet: 0.3.6 -> 0.3.8
* [`9c7d190b`](https://github.com/NixOS/nixpkgs/commit/9c7d190b73101a3c7f94a102fbc768e7d2476ed3) gen6dns: install manpage
* [`39447025`](https://github.com/NixOS/nixpkgs/commit/3944702571d32ed4816dd4c386a36a9b19061b82) terra: 1.0.5 -> 1.0.6
* [`60f2de82`](https://github.com/NixOS/nixpkgs/commit/60f2de820d4ff185a6c429bb1cdb6383ee195364) jam: set target-specific macros correctly
* [`ed0a6ffd`](https://github.com/NixOS/nixpkgs/commit/ed0a6ffd7a85b2b904f4725dd40aad06a8358915) bazelisk: 1.13.1 -> 1.13.2
* [`e0ffa866`](https://github.com/NixOS/nixpkgs/commit/e0ffa866dd023dc3bd3c6f2461669da187666419) bundletool: 1.11.1 -> 1.11.2
* [`f04ff20b`](https://github.com/NixOS/nixpkgs/commit/f04ff20bdee858fe9935c60cab337569db98caa6) cargo-public-api: 0.17.0 -> 0.18.0
* [`a2215e90`](https://github.com/NixOS/nixpkgs/commit/a2215e904b8997a4bade3f4924c7cd68883b04cd) emacsPackages.yes-no: Use trivialPackage instead of stdenv.mkDerivation
* [`4fa8e635`](https://github.com/NixOS/nixpkgs/commit/4fa8e635e2b1e01da49bd72cce4c44cb0e54e1fe) electrum: 4.3.0 -> 4.3.1
* [`91ddf9f2`](https://github.com/NixOS/nixpkgs/commit/91ddf9f2c9059841ac78f32ae4576fb502296870) python310Packages.hahomematic: 2022.8.15 -> 2022.9.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
