### PR TITLE
niv emacs-overlay: update 817a3300 -> df64799a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "817a33003090677244ad5157d3148911e14372af",
-        "sha256": "1f3ng4g7kzjj18ja34836s2k52fd3y5njvag27q9d8j3v3jgkdzr",
+        "rev": "df64799a97bfe5ebcd35aa66ca198b3cea5cc777",
+        "sha256": "15wmvpcmbipsqmdhb1zj55bl6g0f1jv7c3axnwv6rn3n7k4agnzf",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/817a33003090677244ad5157d3148911e14372af.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/df64799a97bfe5ebcd35aa66ca198b3cea5cc777.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@817a3300...df64799a](https://github.com/nix-community/emacs-overlay/compare/817a33003090677244ad5157d3148911e14372af...df64799a97bfe5ebcd35aa66ca198b3cea5cc777)

* [`c62d7d09`](https://github.com/nix-community/emacs-overlay/commit/c62d7d09d480a083f4be5b069634fd32aafd59f2) Move flags for Emacs 29 bonus features to mkGitEmacs
* [`ff1e7016`](https://github.com/nix-community/emacs-overlay/commit/ff1e7016d1760ff9c5bd91b290bf18211dde34c5) Remove mkPgtkEmacs and use withPgtk flag instead
* [`1daa8fc2`](https://github.com/nix-community/emacs-overlay/commit/1daa8fc225180a3dbc30f8cd5116d5596b2f9123) Update emacs-master.json
* [`9bebb050`](https://github.com/nix-community/emacs-overlay/commit/9bebb050cbdac9e9a12815fa683404788b31da88) Adapt to nixos-unstable default setting of nativeComp = true
* [`12f87fb1`](https://github.com/nix-community/emacs-overlay/commit/12f87fb10e5a256c5cd361d7f0fb183c84c21cb8) Updated repos/nongnu
* [`7d143d61`](https://github.com/nix-community/emacs-overlay/commit/7d143d61f8eea4d81ec029a52109900d31d033a6) Revert "Use `withPgtk` option to fix failing `emacsPgtk` build"
* [`62c2d63c`](https://github.com/nix-community/emacs-overlay/commit/62c2d63c4fcb29719d2d4f722010c671d4497814) Updated repos/elpa
* [`1afc1044`](https://github.com/nix-community/emacs-overlay/commit/1afc104468f0b85d7af8ae24499db7829170a1ab) Updated repos/nongnu
* [`70e241d5`](https://github.com/nix-community/emacs-overlay/commit/70e241d5b189982dabc1fe55829475c5c483c89d) Updated repos/elpa
* [`c4e5bbe7`](https://github.com/nix-community/emacs-overlay/commit/c4e5bbe7e02bcc3c70a187e826f4950e5a3066bc) Updated repos/elpa
* [`71739f7f`](https://github.com/nix-community/emacs-overlay/commit/71739f7fe9ea259e82facd98930b6300cb340279) Updated repos/nongnu
* [`36d568cc`](https://github.com/nix-community/emacs-overlay/commit/36d568cc76f0425a25a46770aae818e5a6cb7cf4) Updated repos/nongnu
* [`919c47af`](https://github.com/nix-community/emacs-overlay/commit/919c47aff0d191f8c6d6cc2e5602b137574c8606) Updated repos/elpa
* [`0b8915f5`](https://github.com/nix-community/emacs-overlay/commit/0b8915f5b20356941e901d1d477fb1ec7e4efe60) Updated repos/elpa
* [`c1cc59de`](https://github.com/nix-community/emacs-overlay/commit/c1cc59de6fe2c4218fe79356ff46b3f3d46cf204) Updated repos/nongnu
* [`463d805e`](https://github.com/nix-community/emacs-overlay/commit/463d805e875fc1ff1d15ae9c664e5aaf9b7618d3) Updated repos/elpa
* [`0425737b`](https://github.com/nix-community/emacs-overlay/commit/0425737bc10d487b1e4be570aed62941ef528f8f) Updated repos/elpa
* [`246ff03a`](https://github.com/nix-community/emacs-overlay/commit/246ff03a67d0ae7b3fcc6f40658395fe79d3b1ff) Enable withGTK3 flag for emacs-pgtk derivations
* [`4ff1b990`](https://github.com/nix-community/emacs-overlay/commit/4ff1b9906362e07c19e629481cae3ea11e2c9f6c) Updated repos/nongnu
* [`d347fad6`](https://github.com/nix-community/emacs-overlay/commit/d347fad6699152f2c1b770374b96f58c581cc697) Remove tracking issue from README.org
* [`ecf00d93`](https://github.com/nix-community/emacs-overlay/commit/ecf00d9329ddee289c6509df7befd9f9a6089a94) Updated repos/emacs
* [`ef78dcc3`](https://github.com/nix-community/emacs-overlay/commit/ef78dcc36ae5c4882bc7d77d093461b2ffa81636) Updated repos/nongnu
* [`bea99be8`](https://github.com/nix-community/emacs-overlay/commit/bea99be8af6249f15616c7ab7065e849c2a42d8d) Updated repos/elpa
* [`9d1492fb`](https://github.com/nix-community/emacs-overlay/commit/9d1492fb30447b52d195dbb230c0ee708b772342) Updated repos/emacs
* [`e773a096`](https://github.com/nix-community/emacs-overlay/commit/e773a09689c3d3ce0e3dc92ed663b80c5641fdba) Updated repos/elpa
* [`228185ec`](https://github.com/nix-community/emacs-overlay/commit/228185ec052bfded437b2593fbf9751722ed4a8f) Updated repos/emacs
* [`46c1067b`](https://github.com/nix-community/emacs-overlay/commit/46c1067b0b397df28de5e8f551d2df54f7da7a93) Updated repos/nongnu
* [`bee7e398`](https://github.com/nix-community/emacs-overlay/commit/bee7e3986183f05242a0c40d246baf66439aae9e) Updated repos/emacs
* [`f88370b8`](https://github.com/nix-community/emacs-overlay/commit/f88370b84a0db1e0dd0abe5661b154046c2f6882) Updated repos/elpa
* [`5b8031ed`](https://github.com/nix-community/emacs-overlay/commit/5b8031ed8aa42fe7e4e5dd0f895a5b3fd4994690) Updated repos/emacs
* [`df64799a`](https://github.com/nix-community/emacs-overlay/commit/df64799a97bfe5ebcd35aa66ca198b3cea5cc777) Updated repos/emacs
