### PR TITLE
niv zsh-completions: update 53f2eab0 -> acd4de52

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "53f2eab090d054a877d45092d6f90562fa663d1a",
-        "sha256": "0yysxc2las0v370l043p9818h5lafa6wdm5ddhk3v1lqcn81kj54",
+        "rev": "acd4de5268ee23ffa3ec1f6f13a2ec91266e1564",
+        "sha256": "1wj7gpsiakgq661pmii6dvnqmjhxp9ad0l62a345nl8y6kqn6lb4",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/53f2eab090d054a877d45092d6f90562fa663d1a.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/acd4de5268ee23ffa3ec1f6f13a2ec91266e1564.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@53f2eab0...acd4de52](https://github.com/zsh-users/zsh-completions/compare/53f2eab090d054a877d45092d6f90562fa663d1a...acd4de5268ee23ffa3ec1f6f13a2ec91266e1564)

* [`e6fdabb9`](https://github.com/zsh-users/zsh-completions/commit/e6fdabb97d8fc01c3eb7322f623638f5311db75f) Utilize grep -E instead of deprecated/obsolescent egrep
