### PR TITLE
niv nixpkgs: update 88199c6d -> 5cd66a72

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88199c6df95b3f7a8b8bbcaf4dd8977612f219c0",
-        "sha256": "190rjygpgfcqivmss04q74nx8rjyw10vvgiw2ilm865r44h4yvay",
+        "rev": "5cd66a72e8698e49b89d5df66365215470eea295",
+        "sha256": "1i959imw4k8gbff3vnr3zppyb4ds6mmb1k71ygnmr51knwnc8d8p",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/88199c6df95b3f7a8b8bbcaf4dd8977612f219c0.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5cd66a72e8698e49b89d5df66365215470eea295.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@88199c6d...5cd66a72](https://github.com/nixos/nixpkgs/compare/88199c6df95b3f7a8b8bbcaf4dd8977612f219c0...5cd66a72e8698e49b89d5df66365215470eea295)

* [`b6cb656c`](https://github.com/NixOS/nixpkgs/commit/b6cb656c0d897050f2487e7fda9d14ebf88e0405) adoptopenjdk: add 17.0.2
* [`da40a449`](https://github.com/NixOS/nixpkgs/commit/da40a449e9e77e451ebd544f926d4e7871ba7337) openjdk18: init at 18+36
* [`6932bbea`](https://github.com/NixOS/nixpkgs/commit/6932bbea63011e044a52990edceb67a39237dfff) mingw-w64: 9.0.0 -> 10.0.0
* [`00a0eeb2`](https://github.com/NixOS/nixpkgs/commit/00a0eeb2cb9f63b42dbc15d4a15b5d2a403852f5) stdenv: switch default from gcc10 to gcc11
* [`27701d90`](https://github.com/NixOS/nixpkgs/commit/27701d90d09cdb41b8d4e8a9f2fdee6a2ddbba55) php80Extensions.blackfire: 1.77.0 -> 1.78.1
* [`841cccb5`](https://github.com/NixOS/nixpkgs/commit/841cccb5793fa26271f16561b8205f8830aaa8e7) tt-rss-plugin-auth-ldap: fix ldaps connection issue
* [`a1b40785`](https://github.com/NixOS/nixpkgs/commit/a1b40785e4633bd5a3abbdbb7c6f3704099388f0) add the release 1.0 of metacoq for coq 8.16
* [`41120b50`](https://github.com/NixOS/nixpkgs/commit/41120b50de2ce05744dca568418329329f263cc7) qFlipper: use udev rules from upstream instead of inlining them in nixpkgs
* [`6ebfecc5`](https://github.com/NixOS/nixpkgs/commit/6ebfecc5465a13fa4682e876f6f399a6509900c5) rubberband: 2.0.2 -> 3.0.0
* [`b51e4f63`](https://github.com/NixOS/nixpkgs/commit/b51e4f631e694b0ada2c227fa1d833e4194b33e5) waf: 2.0.23 -> 2.0.24
* [`a73156c6`](https://github.com/NixOS/nixpkgs/commit/a73156c64cc44a3b0270706ab9044e89c698ba99) util-linux: 2.38 -> 2.38.1
* [`3d332125`](https://github.com/NixOS/nixpkgs/commit/3d332125a4ebdcbf0c9b6d3cf76203d8eee6bd64) discourse.plugins.discourse-bbcode-color: init
* [`f411f4ae`](https://github.com/NixOS/nixpkgs/commit/f411f4ae7a034e654b603c16c25ec10c33869af5) safeeyes: fix double wrap
* [`17c8b2e3`](https://github.com/NixOS/nixpkgs/commit/17c8b2e3a7fbb8be0a227931bbd817127288bbda) xz: 5.2.5 -> 5.2.6
* [`7233d35e`](https://github.com/NixOS/nixpkgs/commit/7233d35e49e3254b782ca7d36b8ae0494fb61464) python310Packages.setuptools-rust: 1.5.0 -> 1.5.1
* [`bdc07d61`](https://github.com/NixOS/nixpkgs/commit/bdc07d61f9dd9721b6cb2833895925d93e33be4c) python310Packages.pygments: 2.12.0 -> 2.13.0
* [`913ea47f`](https://github.com/NixOS/nixpkgs/commit/913ea47f6ba806e964251061ed58989a12b78577) tzdata: 2022b -> 2022c
* [`16e24b17`](https://github.com/NixOS/nixpkgs/commit/16e24b17eaa2d2d6e637990ad9f8cad416032fef) svt-av1: 1.2.0 -> 1.2.1
* [`f96b6627`](https://github.com/NixOS/nixpkgs/commit/f96b6627529aa21ce9a7dd08b74350a2b4d71873) lz4: 1.9.3 -> 1.9.4
* [`bd01cc76`](https://github.com/NixOS/nixpkgs/commit/bd01cc76fb1f3202714e735865167dd8c0ee7ea8) python310Packages.markdown: 3.3.7 -> 3.4.1
* [`775ba786`](https://github.com/NixOS/nixpkgs/commit/775ba78608546df5f8273b79f1062ab2f391257b) python310Packages.Nikola: 8.2.2 -> 8.2.3
* [`36c03d0f`](https://github.com/NixOS/nixpkgs/commit/36c03d0f55d3fcc0518f898fa5da9a0b5fba7090) pkgsMusl.colord: enable the daemon
* [`bf44c7ec`](https://github.com/NixOS/nixpkgs/commit/bf44c7ec3e53a9aebc92078910a15258b78a4685) bluez: 5.64 -> 5.65
* [`f16be229`](https://github.com/NixOS/nixpkgs/commit/f16be229dcb9e3bb914820ed0f74a0009b0235dc) gcc/: correct gnused conditionals and move to nativeBuildInputs
* [`0565276a`](https://github.com/NixOS/nixpkgs/commit/0565276a075531b6dad21171de459473dd5e6a27) openssl: Default version to 3.0
* [`c6de1d4b`](https://github.com/NixOS/nixpkgs/commit/c6de1d4b2442b96b66f0cd8bafcc0b50e62179a3) openssl: fix static build
* [`075b8528`](https://github.com/NixOS/nixpkgs/commit/075b85282026478801afaa7680f99d8a047c7fe8) openssl: versionAtLeast 1.1.0 -> 1.1.1
* [`ac6e552a`](https://github.com/NixOS/nixpkgs/commit/ac6e552a3049218b13362b4fed3b1fe4042dc0b8) oven-media-engine: openssl_3_0 -> openssl
* [`af91144e`](https://github.com/NixOS/nixpkgs/commit/af91144ef52a2ccb929b7af29cd16a4cf689c5ea) ibm-sw-tpm2: Pin OpenSSL 1.1.1
* [`8b1f1657`](https://github.com/NixOS/nixpkgs/commit/8b1f16573cc6fa50facc3fe3154ba437e64a9220) python3.pkgs.cryptography: use openssl_1_1
* [`5cb3e070`](https://github.com/NixOS/nixpkgs/commit/5cb3e0708147327d5f5fa8c8008a06cf462210c0) openvpn*: use matching openssl version for each release
* [`a9022772`](https://github.com/NixOS/nixpkgs/commit/a90227726294c7de57fee120c3a193d9272a89a7) ruby*: use matching openssl version for each release
* [`498d67e4`](https://github.com/NixOS/nixpkgs/commit/498d67e45efa175e324f0811a613f9b6c5a55212) krb5: use openssl_1_1
* [`7cf34b26`](https://github.com/NixOS/nixpkgs/commit/7cf34b26e97e72100557aa4903dea4d1607b1e95) coturn: use openssl_1_1
* [`94d80869`](https://github.com/NixOS/nixpkgs/commit/94d808692485abbdf2f60743502e873243de9ccf) lighttpd: pin to openssl_1_1
* [`ed3fab51`](https://github.com/NixOS/nixpkgs/commit/ed3fab51733f66c455c5b828891cd40580680a93) nodejs-14_x: pin to openssl_1_1
* [`bf95b6e4`](https://github.com/NixOS/nixpkgs/commit/bf95b6e456e80a820e2d27f6b8c4a56ef74a5b2b) qca2: remove
* [`1c6327d7`](https://github.com/NixOS/nixpkgs/commit/1c6327d79d72bdb2526341903ceedbe05017b3ef) freeswitch: pin to openssl_1_1
* [`08ed8cfc`](https://github.com/NixOS/nixpkgs/commit/08ed8cfc65d70bf19fc2aa46526ed31d013fe978) libsForQt.qca-qt5_2_3_2: pin to openssl_1_1
* [`3c332191`](https://github.com/NixOS/nixpkgs/commit/3c33219182cc4666754a2022a60f1aae5a7f2b5e) mysql57: pin to openssl_1_1
* [`b802fc1e`](https://github.com/NixOS/nixpkgs/commit/b802fc1e5c6aae7a8800433938cbba7df707bed0) mysql80: pin to openssl_1_1
* [`1f48d6fd`](https://github.com/NixOS/nixpkgs/commit/1f48d6fd5000461e7501942f4f2da9b62330bfe8) cyrus_sasl: pin to openssl_1_1
* [`de5a1214`](https://github.com/NixOS/nixpkgs/commit/de5a1214ce07075f3800fe4a9e2c10821a32bf10) openldap: pin to openssl_1_1
* [`484f8ab0`](https://github.com/NixOS/nixpkgs/commit/484f8ab00c9a5074fe1558ded47100b29d5c6901) python3.pkgs.m2crypto: pin to openssl_1_1
* [`e472d363`](https://github.com/NixOS/nixpkgs/commit/e472d36311af193497efaef846d025985ca074b6) perlPackages.CryptOpenSSLRSA: pin to openssl_1_1
* [`f8ce3f93`](https://github.com/NixOS/nixpkgs/commit/f8ce3f931111401eebd2e1753577ab66b38e2ddf) lua-modules: pin to openssl_1_1
* [`c88c43e5`](https://github.com/NixOS/nixpkgs/commit/c88c43e559d84e2fdcc406bfb083b1616b74ece3) libs3: update and fix build against openssl3
* [`58edfe97`](https://github.com/NixOS/nixpkgs/commit/58edfe972f134b964a1bd7a60c9aef05fde58727) apk-tools: pin to openssl_1_1
* [`2a49c87b`](https://github.com/NixOS/nixpkgs/commit/2a49c87bc5365ebbaad4cc3eebdec78b2474cf6e) haskellPackages.hopenssl: use openssl_1_1
* [`2a32ce73`](https://github.com/NixOS/nixpkgs/commit/2a32ce73ac50846e064f767609098aebba9301e0) serf: pin to openssl_1_1
* [`35099b99`](https://github.com/NixOS/nixpkgs/commit/35099b99b018338d0c5b5a538e81c1b135e6f01c) dovecot: pin to openssl_1_1
* [`96019810`](https://github.com/NixOS/nixpkgs/commit/9601981023536af15822c11673d8891c9e1a26d1) libewf: fix build with OpenSSL 3.0
* [`6ebaf853`](https://github.com/NixOS/nixpkgs/commit/6ebaf8532ecc4b467518622b188e6737b44faf4d) thrift: pin to openssl_1_1
* [`84f17a30`](https://github.com/NixOS/nixpkgs/commit/84f17a3082491d6a01baa840e3a94c5fb6128941) mariadb: use openssl_1_1 for older releases
* [`e51d2c27`](https://github.com/NixOS/nixpkgs/commit/e51d2c27156721c47842429dc824ec39fc094321) erlang*: use matching openssl version for each release
* [`80f2c05c`](https://github.com/NixOS/nixpkgs/commit/80f2c05c52ce35177e87ae40c6cc591632da55ad) php80Extensions.openssl: pin to openssl_1_1
* [`8d8f4cde`](https://github.com/NixOS/nixpkgs/commit/8d8f4cde9bfd1dd77fc68cd432a6f6fcbb9b7406) sbsigntool: pin to openssl_1_1
* [`3ab75249`](https://github.com/NixOS/nixpkgs/commit/3ab75249abcbb1b2352999bfb97e2c7bb6f8e5c8) sbsigntool: clean up a bit
* [`8496e1a4`](https://github.com/NixOS/nixpkgs/commit/8496e1a448c6aef75afeae2bb3ed4084da3b8729) dot-http: pin to openssl_1_1
* [`f38d2ae2`](https://github.com/NixOS/nixpkgs/commit/f38d2ae25a095fc031f5d85b7ceb95fa4f420aa5) dogdns: pin to openssl_1_1
* [`42d8c348`](https://github.com/NixOS/nixpkgs/commit/42d8c348f8c34aa859f67124e0c25be79b735afb) freeradius: pin to openssl_1_1
* [`69f1ec7f`](https://github.com/NixOS/nixpkgs/commit/69f1ec7f3a394353161b12eb99fb60d02e5a8e4b) qt5_openssl_1_1: init
* [`e20f0040`](https://github.com/NixOS/nixpkgs/commit/e20f0040c63c73a866bada759831d66a64c808c9) mumble: fix build by using qt5_openssl_1_1
* [`302e4e8c`](https://github.com/NixOS/nixpkgs/commit/302e4e8c75eba6bf26e717959ee50120f2de3d2b) amarok: pin to openssl 1.1
* [`d39a635d`](https://github.com/NixOS/nixpkgs/commit/d39a635d8ce3f5a67c4a4d1ae288a66149381923) hurl: pin to openssl 1.1
* [`ece71cc3`](https://github.com/NixOS/nixpkgs/commit/ece71cc343eff654ddc5a9560fa37c84b90fcf7c) nodejs-16_x-openssl_1_1 & yarn2nix-moretea-openssl_1_1: init
* [`d1b2156d`](https://github.com/NixOS/nixpkgs/commit/d1b2156d4288ef9e0df05933426745fcc48bb86f) element-web: use openssl 1.1
* [`945ac1c9`](https://github.com/NixOS/nixpkgs/commit/945ac1c9d83c7d216b7a655d02b3e7eefb9e2393) google-cloud-cpp: pin to openssl 1.1
* [`cc120206`](https://github.com/NixOS/nixpkgs/commit/cc120206d830998a1bcb8ad7aa9f1b2e8c213b31) tqsl: pin to openssl_1_1
* [`b9c0db8d`](https://github.com/NixOS/nixpkgs/commit/b9c0db8d86d7a2d278fb5d439c3a2504ff010073) odp-dpdk: pin to openssl_1_1
* [`659ea66a`](https://github.com/NixOS/nixpkgs/commit/659ea66a8ece39d414e02f66819619edf52aad35) rustup: pin to openssl_1_1
* [`50e225d4`](https://github.com/NixOS/nixpkgs/commit/50e225d42b7be18e5b11233f8a7e58201a26b061) s3rs: pin to openssl_1_1
* [`ea94d17d`](https://github.com/NixOS/nixpkgs/commit/ea94d17deba812a1d928ccd2c6a76dbcf4a96d54) simple-http-server: pin to openssl_1_1
* [`faac333e`](https://github.com/NixOS/nixpkgs/commit/faac333edd78482aa743627e85fc41d9e5abcafb) python3.pkgs.uamqp: pin to openssl_1_1
* [`04e9a388`](https://github.com/NixOS/nixpkgs/commit/04e9a388b208832a32acac6749e69a473a1c1fd1) nginx: remove openssl_3 override
* [`3908614f`](https://github.com/NixOS/nixpkgs/commit/3908614fe9061c51800c6451f620819ee687d1ee) tengine: pin to openssl_1_1
* [`03d1fd84`](https://github.com/NixOS/nixpkgs/commit/03d1fd84d5a5e9af1eaca2b10c13330a3f6fd2cd) gemConfig/openssl: pin to openssl_1_1
* [`b6aad166`](https://github.com/NixOS/nixpkgs/commit/b6aad16660f0b7d3e5027b1d7556a8d07e8a3964) gitlab: pin to openssl_1_1
* [`240ace01`](https://github.com/NixOS/nixpkgs/commit/240ace010db8979fed8c0246fe978497b4404484) sysdig: pin to openssl_1_1
* [`09f53a86`](https://github.com/NixOS/nixpkgs/commit/09f53a8624ba3b7a9bea9da5a64f8e680b68c0fd) swiProlog: pin to openssl_1_1
* [`f6390b35`](https://github.com/NixOS/nixpkgs/commit/f6390b357d4a3c6f96cefdd9c5d4f56ae762c42d) percona-server56: pin to openssl_1_1
* [`4915e591`](https://github.com/NixOS/nixpkgs/commit/4915e5913604c4ee246156ad584ce7856b99f8dc) pam_p11: pin to openssl_1_1
* [`bf4c3206`](https://github.com/NixOS/nixpkgs/commit/bf4c320600c3a28d0c1e5910076c446245b712f9) umurmur: pin to openssl_1_1
* [`a9fc19c7`](https://github.com/NixOS/nixpkgs/commit/a9fc19c7cfdb532bc24d3461a5031bf5563ea529) libstrophe: pin to openssl_1_1
* [`0a90c5d1`](https://github.com/NixOS/nixpkgs/commit/0a90c5d1603ee14f5c8438ffcfa9eb4a8bf10716) zookeeper_mt: pin to openssl_1_1
* [`8dfc9982`](https://github.com/NixOS/nixpkgs/commit/8dfc998207dca2e2928cd1f204e4f37444aa40a6) python3: pin to openssl_1_1
* [`b2bed487`](https://github.com/NixOS/nixpkgs/commit/b2bed48781c1e78aca4044f7af598f09549d948a) fractal: pin to openssl_1_1
* [`ad76e3dd`](https://github.com/NixOS/nixpkgs/commit/ad76e3dd39255770ddba7774c5bab96d1317858e) ceph: pin to openssl_1_1
* [`9c8e33f2`](https://github.com/NixOS/nixpkgs/commit/9c8e33f2cebde1c1e0ad17598021517bccfc0069) git-crypt: fix build with openssl_3
* [`14f18b31`](https://github.com/NixOS/nixpkgs/commit/14f18b31c3f9c7d6762f4b687ae8a5ccac35fe13) git-backup: pin to openssl_1_1
* [`ce6deb53`](https://github.com/NixOS/nixpkgs/commit/ce6deb535b6d300dfbe107315d63f58cac1d9620) firmware-manager: pin to openssl_1_1
* [`e891feb2`](https://github.com/NixOS/nixpkgs/commit/e891feb271e036cfac4fd20e1827164519996965) meli: pin to openssl_1_1
* [`dd5518bd`](https://github.com/NixOS/nixpkgs/commit/dd5518bd8fafa8be0e9e00562225649418b72ae3) squid: pin to openssl_1_1
* [`5cc75bbb`](https://github.com/NixOS/nixpkgs/commit/5cc75bbb98cd5dc94be1dee3aba10547b62dbdd1) percona-xtrabackup_*: pin to openssl_1_1
* [`dc13b70a`](https://github.com/NixOS/nixpkgs/commit/dc13b70ad9cc5f5f55b2b93373bd4a649c806a8a) ipfs: pin to openssl_1_1
* [`fffda8a6`](https://github.com/NixOS/nixpkgs/commit/fffda8a63ff9ce66ecd89a577745901255bb9bfd) nzbget: pin to openssl_1_1
* [`b17c551a`](https://github.com/NixOS/nixpkgs/commit/b17c551aa2bc948181a5e62e4fd4e813c2cb224c) libmysqlconnectorcpp: pin to openssl_1_1
* [`4921d947`](https://github.com/NixOS/nixpkgs/commit/4921d9473fbc5e4095b35bd42ab6e07ee458fd41) git-trim: pin to openssl_1_1
* [`76064ccc`](https://github.com/NixOS/nixpkgs/commit/76064cccc240946a80a972ca64ede231920b51dd) git-subset: pin to openssl_1_1
* [`424885f5`](https://github.com/NixOS/nixpkgs/commit/424885f5f8f1db8df2991d5ddfbc579bc4719c74) perlPackages.CryptOpenSSLGuess: 0.11 -> 0.15
* [`1a75cc1f`](https://github.com/NixOS/nixpkgs/commit/1a75cc1f1f77a0842e8b6c2d5d462c03f9e14bec) perlPackages.CryptOpenSSLX509: 1.813 -> 1.914
* [`cc375c4d`](https://github.com/NixOS/nixpkgs/commit/cc375c4d89c4cedf7de1fc26b2888fabb155e597) wraith: pin to openssl_1_1
* [`d761390c`](https://github.com/NixOS/nixpkgs/commit/d761390cd04a1a9510b9a4f42803878e0ca268ba) sgx/sdk/ipp-crypto: pin to openssl_1_1
* [`63adbbdb`](https://github.com/NixOS/nixpkgs/commit/63adbbdb6611e0eb7f4db06ea862052cd799d7d4) nixos/changelog: Mention openssl3 update
* [`0df0cbff`](https://github.com/NixOS/nixpkgs/commit/0df0cbff9482893c5db2d6c98c372c9973ed4d8c) proxysql: don't reference openssl_3 explicitly
* [`dbc5a792`](https://github.com/NixOS/nixpkgs/commit/dbc5a792a26189e2e610b9736b218d3f5df50ebf) llvmPackages*.libunwind: Don't redo install phase from scratch
* [`3b60b31d`](https://github.com/NixOS/nixpkgs/commit/3b60b31d6072055195a07b175c4999326e26ab14) gcc: drop unused libelf dependency
* [`c864ea9d`](https://github.com/NixOS/nixpkgs/commit/c864ea9d03ecbb2e401a6a0bf8004356367021b9) gpgme: respect the doCheck parameter
* [`c6e106cd`](https://github.com/NixOS/nixpkgs/commit/c6e106cd9e8ef4d97c6df98f43a93809a53ff2aa) python3Packages.werkzeug: 2.1.2 -> 2.2.2
* [`ad3c038f`](https://github.com/NixOS/nixpkgs/commit/ad3c038fa5813224ad3de21ebb3b73dd5efe2b19) python3Packages.flask: 2.1.3 -> 2.2.2
* [`7f01443e`](https://github.com/NixOS/nixpkgs/commit/7f01443ef1cf09be0dd772af0a58409a4a02ccb1) nss: Drop nss-pem patchset
* [`df214678`](https://github.com/NixOS/nixpkgs/commit/df214678dcf8444d290e835c6039a48cefed65b9) nss: Drop ckpem patch
* [`dcf4dc23`](https://github.com/NixOS/nixpkgs/commit/dcf4dc23c703cf86678f212668dba7733d500f02) pythonPackages.twisted: fix sandboxed build on Darwin
* [`cc369000`](https://github.com/NixOS/nixpkgs/commit/cc3690002460dc1ad6ad4572f767ffe45e52a4ca) bluez: remove unused fetchpatch import
* [`0aea8ac8`](https://github.com/NixOS/nixpkgs/commit/0aea8ac8d215e700022686c9fa7a8c74f4c0d027) python310Packages.mistletoe: 0.8.2 -> 0.9.0
* [`9d2a6192`](https://github.com/NixOS/nixpkgs/commit/9d2a6192d8a00b7be9a14b79543b404262db0de6) nettle: 3.8 -> 3.8.1
* [`977cbb7e`](https://github.com/NixOS/nixpkgs/commit/977cbb7e822028cc51a1cf02908af9074daff6ad) python3Packages.django_3: patch in zoneinfo directory
* [`0badc238`](https://github.com/NixOS/nixpkgs/commit/0badc2389af6f730d2acab4cb66554ddab39b57a) nss: migrate manual patching into postPatch
* [`5b709277`](https://github.com/NixOS/nixpkgs/commit/5b709277f48df630c8fa7aab0cf6157f71a5b45c) perl: `verify_SSL=>1` by default in HTTP::Tiny
* [`5b76f423`](https://github.com/NixOS/nixpkgs/commit/5b76f42372dd0784d5661626c8ce23a7bea9ccfd) buildGo{Module,Package}: don't run vet linter
* [`42424759`](https://github.com/NixOS/nixpkgs/commit/42424759c19e0c4eb5948f2abbe0badea321287c) python310Packages.fastapi: 0.79.0 -> 0.79.1
* [`3bd64845`](https://github.com/NixOS/nixpkgs/commit/3bd6484563edae14ac528b5dc30d018bef66bf61) Re-Revert Merge [nixos/nixpkgs⁠#184360](https://togithub.com/nixos/nixpkgs/issues/184360): json-glib: add installed tests
* [`f2805f29`](https://github.com/NixOS/nixpkgs/commit/f2805f293dd95bbc32bd49134263f52d8212508d) gnupg: Fix regression when using YubiKey devices
* [`410a9ae7`](https://github.com/NixOS/nixpkgs/commit/410a9ae7000e5dc2c6ca55b1c8b3cb188b841708) cmake: 3.24.0 -> 3.24.1
* [`457e2672`](https://github.com/NixOS/nixpkgs/commit/457e2672066c8dc0df2df1a3193139c659581639) rsync: 3.2.4 -> 3.2.5
* [`57c69625`](https://github.com/NixOS/nixpkgs/commit/57c6962509b2810eb2a083663f28bfcdd984c544) python3Packages.pyqt5: fix build for aarch64-darwin
* [`b5aad8ad`](https://github.com/NixOS/nixpkgs/commit/b5aad8addf1d4a84dbf7545965584bd19fb7e42e) libtool: fix shebang-fixing from 2.4.7 version bump
* [`64d5ca08`](https://github.com/NixOS/nixpkgs/commit/64d5ca085a8cfb55b9c9780642e79a4020ec717c) nodejs_18: fix eval
* [`1609e4a6`](https://github.com/NixOS/nixpkgs/commit/1609e4a63e268f5e4e33fee1b6a3c7687d331bb6) python310Packages.jsonschema: 4.9.1 -> 4.13.0
* [`44b594e6`](https://github.com/NixOS/nixpkgs/commit/44b594e6192fdab87a3019818be797967fbe7950) python310Packages.hatchling: 1.6.0 -> 1.8.0
* [`7059a8ee`](https://github.com/NixOS/nixpkgs/commit/7059a8ee8fd50d678c008cb044ff0694a83f79cb) aitrack: init at 0.6.5
* [`656e3022`](https://github.com/NixOS/nixpkgs/commit/656e3022f4caa11905bad996866bf07b848afc0b) fetch-cargo-tarball: allow use index mirror
* [`51a6ac79`](https://github.com/NixOS/nixpkgs/commit/51a6ac79d2971ed44994af138914a70c1b04762d) fetch-cargo-tarball:  fix for packages without dep
* [`64a83a9b`](https://github.com/NixOS/nixpkgs/commit/64a83a9b83b9eaefb42da521f4f3f7945dbaede2) elfcat: add cargoHash
* [`7d8f9ee6`](https://github.com/NixOS/nixpkgs/commit/7d8f9ee62ea2aab31b3e71e499302d67861718db) build-rust-package: cargoSha256 and cargoHash must not be null
* [`ca0120a4`](https://github.com/NixOS/nixpkgs/commit/ca0120a4bcb759b9a9040219b1f0a5e5a86e34a1) systemd: enable `BPF_FRAMEWORK` by default (`withLibBPF=true`)
* [`029137d9`](https://github.com/NixOS/nixpkgs/commit/029137d9eaf89cd8a97a18a2d1a6e18434441761) soundtouch: 2.2 -> 2.3.1 and update the repo URL
* [`da0a5e5f`](https://github.com/NixOS/nixpkgs/commit/da0a5e5f3b88ce34314f1c4b29fd7c9526263ca6) cmake: fix crash on CC without libc support
* [`262d3eba`](https://github.com/NixOS/nixpkgs/commit/262d3eba50c03d7b65c8a220ba3b51bec3c0f650) Revert "nodejs_18: fix eval"
* [`5b59025b`](https://github.com/NixOS/nixpkgs/commit/5b59025b266da0f96b650abd51fe1f45ce239e52) Revert "element-web: use openssl 1.1"
* [`dc3e7580`](https://github.com/NixOS/nixpkgs/commit/dc3e75802bf3ca99dffb64a0578d3403d8e27ecd) python310Packages.cryptography: remove empty dev output
* [`37a43659`](https://github.com/NixOS/nixpkgs/commit/37a4365913235e405575a02d6e1765887f38527a) libtirpc: remove no longer required postPatch
* [`ec4019f6`](https://github.com/NixOS/nixpkgs/commit/ec4019f6dcecbacb1c07882d8bb1fac021e8873b) Set inherit_errexit after bash version check
* [`e924a39a`](https://github.com/NixOS/nixpkgs/commit/e924a39abd4f2e4b66cd02e2686d64ac01ea96cc) jemalloc: support page size up to 64KB on AArch64
* [`e5497839`](https://github.com/NixOS/nixpkgs/commit/e54978395b37826a27bc8bba9f0cecf3794d1003) liburcu: 0.13.1 -> 0.13.2
* [`28dd7515`](https://github.com/NixOS/nixpkgs/commit/28dd75158d0a9c25814dd2496d430053a12610d0) mesa: 22.1.6 -> 22.1.7
* [`bfd2a6d4`](https://github.com/NixOS/nixpkgs/commit/bfd2a6d47112f13ccae556aa56a1320d348b89e1) vim: 9.0.0180 -> 9.0.0244
* [`3e2a4210`](https://github.com/NixOS/nixpkgs/commit/3e2a42102bfb4598cbb330b4ca5e0f28e7bdfc94) Vulkan: 1.3.216.0 -> 1.3.224.0
* [`5a78501d`](https://github.com/NixOS/nixpkgs/commit/5a78501dd3b816d7a8c7d08ee6e6a7415ba8ec58) SDL2_ttf: 2.0.18 -> 2.20.1
* [`06b6e303`](https://github.com/NixOS/nixpkgs/commit/06b6e303b02bffb16e83ec9cd41e453700371cd8) vid-stab: 1.1.0 -> unstable-2022-05-30, fix linking against it with clang
* [`10c1827e`](https://github.com/NixOS/nixpkgs/commit/10c1827eab020e6c4c3a88b2c9d8fb04b92a3174) graphviz: 5.0.0 -> 5.0.1
* [`1acad4d8`](https://github.com/NixOS/nixpkgs/commit/1acad4d826e4011c168edb89be3b2fac400f8332) libtasn1: 4.18.0 -> 4.19.0
* [`4a0eaf9d`](https://github.com/NixOS/nixpkgs/commit/4a0eaf9dccadfcfe80927c2510057843fb55dab5) libglvnd: 1.4.0 -> 1.5.0
* [`abaa4b5e`](https://github.com/NixOS/nixpkgs/commit/abaa4b5e514b93011c23cc05b21c13c20fbb93f9) Imlib2: Add JPEGXL and Postscript support, make webp support optional ([nixos/nixpkgs⁠#186492](https://togithub.com/nixos/nixpkgs/issues/186492))
* [`1f07b6e5`](https://github.com/NixOS/nixpkgs/commit/1f07b6e50d0b23e6c9e041c147dd731a7721f3e8) python3Packages.requests: Fix sandboxed build on Darwin
* [`39281170`](https://github.com/NixOS/nixpkgs/commit/392811708825f15e0c43b46e677e950a9deaec79) python3Packages.responses: Fix sandboxed build on Darwin
* [`e1c29269`](https://github.com/NixOS/nixpkgs/commit/e1c292692ff8a78222ceca5c812340b20557d7e6) python3Packages.cffi: drop empty dev output
* [`daa11b3e`](https://github.com/NixOS/nixpkgs/commit/daa11b3e4677d7e7bd81b31c0c7a79669cbd7e51) python3Packages.pytest-aiohttp: Fix sandboxed build on Darwin
* [`6c0348fe`](https://github.com/NixOS/nixpkgs/commit/6c0348fe8760352e8fe9e2ea7182cf70b200e156) python3Packages.python-socks: Fix sandboxed build on Darwin
* [`767c3e5f`](https://github.com/NixOS/nixpkgs/commit/767c3e5fa97605fafb29d89be5bac43abf9ceb80) systemd: fix cross compilation with libbpf enabled
* [`ad83ae51`](https://github.com/NixOS/nixpkgs/commit/ad83ae5119dc3c00901e649fbe6897800e47210f) python3Packages.flask-restx: fix build with werkzeug>=2.2.0
* [`b33f9716`](https://github.com/NixOS/nixpkgs/commit/b33f9716e74e535db3bb0f6c13bd11dd30cd49fe) python3Packages.limits: fix package version
* [`530c690c`](https://github.com/NixOS/nixpkgs/commit/530c690c47a2870c9a93b32240fb41dcff7d5317) python3Packages.flask-limiter: 1.4 -> 2.6.2
* [`b7c258d3`](https://github.com/NixOS/nixpkgs/commit/b7c258d38788ea017f220801b71c45b45454aa72) python3Packages.limits: update meta
* [`4e4104a9`](https://github.com/NixOS/nixpkgs/commit/4e4104a96199a7ba9eed44c96487955b7a45b5c7) python3Packages.flask-restful: disable failing test
* [`360ad99e`](https://github.com/NixOS/nixpkgs/commit/360ad99eacc23766c50e47ca615ca2682ce50f5d) python3Packages.flask-sqlalchemy: disable failing test
* [`a92964ec`](https://github.com/NixOS/nixpkgs/commit/a92964ec5df651e584dee79c8794a8f69542e11b) python3Packages.mdx_truly_sane_lists: 1.2 -> 1.3
* [`bcd41f28`](https://github.com/NixOS/nixpkgs/commit/bcd41f289122c4a182f892ee740b37e436daf89e) linux: Disable DRM_LEGACY, NOUVEAU_LEGACY_CTX_SUPPORT
* [`d78648fe`](https://github.com/NixOS/nixpkgs/commit/d78648fec4c046777175b1a3bdc74eca9ca28abf) python3Packages.flask-login: 0.6.1 -> 0.6.2
* [`4ccddf5d`](https://github.com/NixOS/nixpkgs/commit/4ccddf5d9a531a274af335daab0665364f2ef03d) xml2rfc: 3.14.1 -> 3.14.2
* [`45af48e4`](https://github.com/NixOS/nixpkgs/commit/45af48e472b56a6f5d7b5227a5ebb437e6a8eb05) klee: use the same LLVM version for clang
* [`ad41e043`](https://github.com/NixOS/nixpkgs/commit/ad41e043760ed1da3d8c957b3bf168bdfc9bd9e2) python310Packages.moto: disable failing tests after werkzeug update
* [`d7dce5f2`](https://github.com/NixOS/nixpkgs/commit/d7dce5f206907871ecb1ed90e5243c51b91963a1) fio: 3.31 -> 3.32
* [`78f3f779`](https://github.com/NixOS/nixpkgs/commit/78f3f7790b40b870c43ff3b05cb278e8718be55f) perlPackages.IOAsyncSSL: fix test
* [`f5f1d11b`](https://github.com/NixOS/nixpkgs/commit/f5f1d11b9e5f33b5037fe896e69510d0fcad86c3) aws-sdk-cpp: ignore openssl 3 deprecation warnings
* [`0762cbf1`](https://github.com/NixOS/nixpkgs/commit/0762cbf11624c232ac3425a233d12947cc43e5a6) ircdHybrid: 8.2.41 -> 8.2.42
* [`ef7442b1`](https://github.com/NixOS/nixpkgs/commit/ef7442b11d1be4f0dd5afe23b76ce818e20f0832) linphone: 4.4.8 -> 4.4.9
* [`38442bac`](https://github.com/NixOS/nixpkgs/commit/38442bac4d4c74c9b65c1195fbfddc61a517c2f6) metabase: 0.44.1 -> 0.44.2
* [`b42c6070`](https://github.com/NixOS/nixpkgs/commit/b42c6070c6cc27ac79595dce791c39979c5d7e7f) jbig2dec: Correct license information.
* [`5bc94fdc`](https://github.com/NixOS/nixpkgs/commit/5bc94fdc1f4beee081ad20d05175284ab10255cb) gdcm: 3.0.15 -> 3.0.17
* [`0e66a976`](https://github.com/NixOS/nixpkgs/commit/0e66a97683694d8071315fb0d6227f6850a5ba36) usbguard: 1.1.1 -> 1.1.2
* [`7d009061`](https://github.com/NixOS/nixpkgs/commit/7d009061c96d51b56c475016b9d9183902dc0699) nixos/vaultwarden: Restart=always
* [`7160e94e`](https://github.com/NixOS/nixpkgs/commit/7160e94e270984312e93719b03f268cc1a393af9) nixos/vaultwarden: fix race with backup
* [`70b8ef1d`](https://github.com/NixOS/nixpkgs/commit/70b8ef1df6ff5a998b76d2263af2d1f4e73116ed) nixos/vaultwarden: fix typo in timer alias
* [`e82401d8`](https://github.com/NixOS/nixpkgs/commit/e82401d87f8dcad4ae9dd6e2b1d4cf662ffd36e3) ddccontrol-db: 20220829 -> 20220903
* [`6f05f7c1`](https://github.com/NixOS/nixpkgs/commit/6f05f7c172b182e5d467de829953d9937291f9c9) joker: 1.0.0 -> 1.0.1
* [`e0a5a1c3`](https://github.com/NixOS/nixpkgs/commit/e0a5a1c3a0851aeb6e896bfe52b212c30f9ce3c7) rPackages: reenable stackprotector on aarch64-darwin
* [`a813457d`](https://github.com/NixOS/nixpkgs/commit/a813457d190b863e1de3d9cb48c4f2b8f1cd46b3) gerbil: reenable stackprotector on aarch64-darwin
* [`4e130db5`](https://github.com/NixOS/nixpkgs/commit/4e130db5087a257019e8f1bfe4fda181330fe75a) virt-top: 1.0.9 -> 1.1.1
* [`a0e9f038`](https://github.com/NixOS/nixpkgs/commit/a0e9f038eb07df749067ee6325b5e61f01a345a0) synergy: 1.14.1.32 -> 1.14.5.17
* [`5286ab3e`](https://github.com/NixOS/nixpkgs/commit/5286ab3ecd8cbd862ff74ece602787456b4ce847) dart: 2.17.3 -> 2.18.0
* [`52fd3468`](https://github.com/NixOS/nixpkgs/commit/52fd3468374dab2e2b693846f4fb065182936084) graphviz: patch a regression in 5.0.1
* [`1713b095`](https://github.com/NixOS/nixpkgs/commit/1713b09533223035d822206be5039a1e0a699d75) dbeaver: 22.1.5 -> 22.2.0
* [`c358992d`](https://github.com/NixOS/nixpkgs/commit/c358992d69569a40c5f636c6cc208fb7bf90c20d) fsearch: 2021-06-23 -> 0.2.2
* [`03dc13d9`](https://github.com/NixOS/nixpkgs/commit/03dc13d93c453a673901ca0e56218109d564aeed) libltc: 1.3.1 -> 1.3.2
* [`74934944`](https://github.com/NixOS/nixpkgs/commit/749349441edea85039cce75f6dcb9100ac1fa520) liblouis: 3.22.0 -> 3.23.0
* [`5fd65097`](https://github.com/NixOS/nixpkgs/commit/5fd65097dade08e43c0face3572e0d462d6357f0) oras: 0.14.0 -> 0.14.1
* [`e888eaac`](https://github.com/NixOS/nixpkgs/commit/e888eaac9097aac9efe41ae4db0a37708eae50b3) profile-sync-daemon: 6.45 -> 6.47
* [`7b8c90a4`](https://github.com/NixOS/nixpkgs/commit/7b8c90a498c6b12b180ce5938defd12fc176c6d2) rssguard: 4.2.3 -> 4.2.4
* [`37dca418`](https://github.com/NixOS/nixpkgs/commit/37dca4189efff7f432a2427395e85ba6a0c13618) gmic-qt: 3.1.5 -> 3.1.6
* [`3bced256`](https://github.com/NixOS/nixpkgs/commit/3bced2562997bf9c4bb55530af6dbcd0385a5337) gama: 2.21 -> 2.22
* [`5f841bd8`](https://github.com/NixOS/nixpkgs/commit/5f841bd80f97659c6c4b4b48ab12ee06be1c6f91) jquake: 1.7.1 -> 1.8.1
* [`c7832514`](https://github.com/NixOS/nixpkgs/commit/c7832514eff82299bfb01ac0bbb132f63497ee79) igv: 2.14.0 -> 2.14.1
* [`a59c0cd1`](https://github.com/NixOS/nixpkgs/commit/a59c0cd11533f26cfb9d79cc75f979a9a4e29d82) libglibutil: 1.0.66 -> 1.0.67
* [`1717df91`](https://github.com/NixOS/nixpkgs/commit/1717df9134474b3773c9653914e318b99a407d13) beamerpresenter: 0.2.2 -> 0.2.3
* [`9a067292`](https://github.com/NixOS/nixpkgs/commit/9a067292d3b97257c72abdd9c4d89591ec0686d2) beamerpresenter: set compile time options explicitly
* [`f0f68ccc`](https://github.com/NixOS/nixpkgs/commit/f0f68ccc99420fddea0902d22d4152ef88ed3d7c) opera: 90.0.4480.48 -> 90.0.4480.84
* [`cfa2b55a`](https://github.com/NixOS/nixpkgs/commit/cfa2b55a4bcc96c0befbae53fb05846f54e50441) objconv: 2.52 -> 2.54
* [`1ad9e312`](https://github.com/NixOS/nixpkgs/commit/1ad9e312b4dc8374c92c18ab89e4b1e13ad9e501) quick-lint-js: 2.6.0 -> 2.9.0
* [`dc2d82a3`](https://github.com/NixOS/nixpkgs/commit/dc2d82a38225265dfb7f09bc02fd9b23aa59ba93) ctlptl: 0.8.6 -> 0.8.7
* [`3df41451`](https://github.com/NixOS/nixpkgs/commit/3df41451e3f5179e1d02cf8366f1646ff3eb94ae) nixos/kanidm: Bind mount cacert path in unixd service
* [`ab5169d6`](https://github.com/NixOS/nixpkgs/commit/ab5169d64c0fa81e6804575f444746c198979baa) hobbits: 0.53.1 → 0.53.2
* [`28a84b5c`](https://github.com/NixOS/nixpkgs/commit/28a84b5cfeb2ff2a018ebcafb27e583cf8bcd9a0) headset: 4.0.0 -> 4.2.1
* [`4e4e8b52`](https://github.com/NixOS/nixpkgs/commit/4e4e8b529502bc1d72b2ced55529571d07703d5d) alfis: 0.7.7 -> 0.8.2
* [`593ab7df`](https://github.com/NixOS/nixpkgs/commit/593ab7df22a8a790558b25338697beb823d9d713) everspace: add desktop file
* [`d5656236`](https://github.com/NixOS/nixpkgs/commit/d5656236191580303cced83df778444a53842609) python310Packages.mitmproxy: fix failing tests with Flask 2.2
* [`0e291be6`](https://github.com/NixOS/nixpkgs/commit/0e291be64432dd355747de6abdf2a1cadd5844e8) mediawiki: fix correctly setting --dbtype flag
* [`731b27b8`](https://github.com/NixOS/nixpkgs/commit/731b27b83fdcf49092e970727567fb73cc4d8bc4) egl-wayland: 1.1.10 -> 1.1.11
* [`96398396`](https://github.com/NixOS/nixpkgs/commit/96398396ebf7caea18a9a25e14421f2a67844b4f) nginxModules.vts: 0.1.18 -> 0.2.0
* [`b1a70d4a`](https://github.com/NixOS/nixpkgs/commit/b1a70d4a7b1bc3a7f8fc7d26dca132db2cebad1d) kde/plasma: 5.25.4 -> 5.25.5
* [`347f44d6`](https://github.com/NixOS/nixpkgs/commit/347f44d6727bac56f3ea304d5838755b66078090) quick-lint-js: work around CMake bug causing missing libstdc++.so.6
* [`ae4ff7f8`](https://github.com/NixOS/nixpkgs/commit/ae4ff7f847364882aedc312ad93374f25b457323) maintainers: add thetallestjj
* [`72f66aa7`](https://github.com/NixOS/nixpkgs/commit/72f66aa7add4639a1abae3918481beb9c4a24013) coordgenlibs: 3.0.0 -> 3.0.1
* [`09800d7f`](https://github.com/NixOS/nixpkgs/commit/09800d7f75b2c31820b43ce9287212efba2f523b) firefox wrapper: write extraPrefsFiles before extraPrefs
* [`05d426b1`](https://github.com/NixOS/nixpkgs/commit/05d426b195638dc8970834d7a4b7d6844a9f1b3d) lsp-plugins: 1.2.2 -> 1.2.3
* [`1faa05a7`](https://github.com/NixOS/nixpkgs/commit/1faa05a789bc42b492f0ba745c0420a6c421b84e) datalad: python3 -> python39 (unbreaks due to `boto` dep)
* [`d900a17b`](https://github.com/NixOS/nixpkgs/commit/d900a17b187c65e5b68e94f1a770549cde613f12) o: 2.55.1 -> 2.56.0
* [`43b28931`](https://github.com/NixOS/nixpkgs/commit/43b28931132b8f4f59713716b4427f0f430d59f3) brev-cli: 0.6.95 -> 0.6.102
* [`7bc322a7`](https://github.com/NixOS/nixpkgs/commit/7bc322a73634746f836e22ebec325eb155d119cc) netbird: 0.8.11 -> 0.9.1
* [`315d7764`](https://github.com/NixOS/nixpkgs/commit/315d77643c17479f962eb92655f705dc46400e23) signal-desktop: 5.57.0 -> 5.58.0
* [`f14e2088`](https://github.com/NixOS/nixpkgs/commit/f14e2088bcee1371ef598dbfb115297ff88e4d7c) python310Packages.poetry-dynamic-versioning: 0.17.1 -> 0.18.0
* [`f5e995a8`](https://github.com/NixOS/nixpkgs/commit/f5e995a8d61c1d52f41da72fb5e14b6b16e4728b) kde/gear: 22.08.0 -> 22.08.1
* [`cbffc686`](https://github.com/NixOS/nixpkgs/commit/cbffc686f43e6307a52ffc9a1bb1766954b3ceef) Revert "kleopatra: fix broken build"
* [`22566b2e`](https://github.com/NixOS/nixpkgs/commit/22566b2e5f194420b9ffea3f2dbfe2639ad0c7ec) python310Packages.patiencediff: 0.2.2 -> 0.2.3
* [`ce6daeb7`](https://github.com/NixOS/nixpkgs/commit/ce6daeb7f2854dbd63df4f7d8f72f353f22cc682) python310Packages.monty: 2022.4.26 -> 2022.9.8
* [`fe771c64`](https://github.com/NixOS/nixpkgs/commit/fe771c647975efee0b751f7362ff338eda572a6d) python310Packages.cloudflare: 2.9.12 -> 2.10.1
* [`7c6977b3`](https://github.com/NixOS/nixpkgs/commit/7c6977b318edd43c2af23b0dbe6c7e7e75b4a614) victoriametrics: 1.81.0 -> 1.81.2
* [`76f61e7e`](https://github.com/NixOS/nixpkgs/commit/76f61e7eeef747d6e4acc386eac096b69fc1f999) python310Packages.epson-projector: 0.4.6 -> 0.5.0
* [`3cac015a`](https://github.com/NixOS/nixpkgs/commit/3cac015a69c68eb89906ed75ca0528ada595f844) wiki-js: 2.5.286 -> 2.5.287
* [`033ae6be`](https://github.com/NixOS/nixpkgs/commit/033ae6bee8b831a3a93133cf3cfd4081871a198d) mpvc: 2017-03-18 -> 1.3
* [`5fafee99`](https://github.com/NixOS/nixpkgs/commit/5fafee995a876ef914a6a8e204e0991d67c4b99c) python310Packages.glfw: 2.5.4 -> 2.5.5
* [`1c916452`](https://github.com/NixOS/nixpkgs/commit/1c916452137a1102715df0230b8a8396490a6870) python310Packages.globus-sdk: 3.10.1 -> 3.11.0
* [`288b8863`](https://github.com/NixOS/nixpkgs/commit/288b886396efd7ae461477485cd8b014557adb34) jetbrains.rider: fix startup
* [`c1ad7b90`](https://github.com/NixOS/nixpkgs/commit/c1ad7b9056598690422dd13e245350dc1702fb74) jetbrains.rider: add raphaelr to maintainers
* [`9d90d802`](https://github.com/NixOS/nixpkgs/commit/9d90d80225aa713ab189e4dcc010ca8925d6c80e) python310Packages.makefun: 1.14.0 -> 1.15.0
* [`52269bd2`](https://github.com/NixOS/nixpkgs/commit/52269bd2f400821ef462ad0e956fbdd3a81f6aef) python310Packages.mkdocs-material: 8.3.9 -> 8.4.3
* [`9dcc2d84`](https://github.com/NixOS/nixpkgs/commit/9dcc2d84676315728c27e0ec657c3289dd940bff) pipenv: 2022.9.2 -> 2022.9.8
* [`252c8629`](https://github.com/NixOS/nixpkgs/commit/252c86291c46a975f711de78dfa05411b6a3bc37) python310Packages.plexapi: 4.12.1 -> 4.13.0
* [`d3a2e544`](https://github.com/NixOS/nixpkgs/commit/d3a2e5448d5853e65e043e4e11629702ef02ee28) python310Packages.pivy: 0.6.7 -> 0.6.8
* [`daaa438f`](https://github.com/NixOS/nixpkgs/commit/daaa438fb653b6480e0d2dc974c6a766f7ca107e) python310Packages.pyisy: 3.0.7 -> 3.0.8
* [`94df850d`](https://github.com/NixOS/nixpkgs/commit/94df850d3e9a753f37e5eccc6a7211e933e24676) python310Packages.protonvpn-nm-lib: 3.11.0 -> 3.12.0
* [`1f5af4a4`](https://github.com/NixOS/nixpkgs/commit/1f5af4a485de1cd28769372879a94f7e174fbfb3) maintainers: add posch
* [`ecaafbff`](https://github.com/NixOS/nixpkgs/commit/ecaafbff29e17085f2ff0509ed72ee8ce4ae5e5e) python310Packages.pytorch-metric-learning: 1.5.1 -> 1.6.0
* [`499921d6`](https://github.com/NixOS/nixpkgs/commit/499921d643d2962c580e76e0aa48753fe980898b) emacs: avoid installing gsettings-desktop-schemas on Darwin
* [`0e753fca`](https://github.com/NixOS/nixpkgs/commit/0e753fca65f704fea8a8508f46e672ed17e69d57) libofx: 0.10.5 -> 0.10.7
* [`b03b12a1`](https://github.com/NixOS/nixpkgs/commit/b03b12a1d4467a032f089e7a76a67485df25d1a9) limesuite: 20.10.0 -> 22.09.0
* [`d7f7edc2`](https://github.com/NixOS/nixpkgs/commit/d7f7edc29cc33e5bd83ccf674cfdd0e26e1c1ca2) libime: 2022-07-11 -> 1.0.14
* [`f00da34f`](https://github.com/NixOS/nixpkgs/commit/f00da34f2cabcef66b5f179ceab67dcf58340573) fcitx5: 5.0.18 -> 5.0.19
* [`c0b5ab78`](https://github.com/NixOS/nixpkgs/commit/c0b5ab7841a67b158ed35e68faae0c39260dff0f) fcitx5-chinese-addons: 5.0.14 -> 5.0.15
* [`b7029e3c`](https://github.com/NixOS/nixpkgs/commit/b7029e3c81682170acab831a5c4594c05a3f14f6) fcitx5-gtk: 5.0.17 -> 5.0.18
* [`58ff3e03`](https://github.com/NixOS/nixpkgs/commit/58ff3e03e2e45fe462f911a7db5ec6ceec5c0c8b) riot-redis: 2.17.0 -> 2.18.1
* [`2bae7ca6`](https://github.com/NixOS/nixpkgs/commit/2bae7ca60b3c95d676e3ee6e6bbbad9bd32a91bb) wakatime: 1.54.0 -> 1.55.1
* [`3a2a763a`](https://github.com/NixOS/nixpkgs/commit/3a2a763a4265712a972952880933bb2342b0550e) python310Packages.tensorflow-datasets: fix tests
* [`8676f60f`](https://github.com/NixOS/nixpkgs/commit/8676f60f1f301981bb9a7cd347ea2e592c6f6494) nheko: 0.10.0 -> 0.10.1-1
* [`0ad235a4`](https://github.com/NixOS/nixpkgs/commit/0ad235a42b197831030fd54195de979aa3a16390) python310Packages.flask-wtf: fix failing build
* [`7083952d`](https://github.com/NixOS/nixpkgs/commit/7083952d2b6c3fc112f3738f94ef6f6fa148fd07) python310Packages.flask-wtf: add anthonyroussel to maintainers
* [`5ed6dd76`](https://github.com/NixOS/nixpkgs/commit/5ed6dd7666568055c3c1f49f5a8fdca6b2597ca1) uefitool: A60 -> A61
* [`2a5bb722`](https://github.com/NixOS/nixpkgs/commit/2a5bb722e991d4e1bbfa29b63aef9672ed98d513) chit: pin to openssl_1_1
* [`e3755a38`](https://github.com/NixOS/nixpkgs/commit/e3755a384c902dc9ba44ca4488d7e902f62fa5e6) tunnelto: pin to openssl_1_1
* [`191c4487`](https://github.com/NixOS/nixpkgs/commit/191c4487032452274d46a2feb620fb5762b8b691) wkhtmltopdf-bin: pin to openssl_1_1
* [`b909c461`](https://github.com/NixOS/nixpkgs/commit/b909c461bf3d90472d7d40ada3cb226a66c15a10) eidolon: pin to openssl_1_1
* [`823d14f3`](https://github.com/NixOS/nixpkgs/commit/823d14f3e53d95e064b7705619e5964a63144241) xbps: pin to openssl_1_1
* [`7646a6de`](https://github.com/NixOS/nixpkgs/commit/7646a6defcd647c43c286d407ccaa62d3f8605bf) coinlive: pin to openssl_1_1
* [`5765cef3`](https://github.com/NixOS/nixpkgs/commit/5765cef3ae5216f5ea58775d5238c8c38d0362ad) cliscord: pin to openssl_1_1
* [`ab0cb98d`](https://github.com/NixOS/nixpkgs/commit/ab0cb98d4cba994e893e95adf91defb334c83ba7) devserver: pin to openssl_1_1
* [`5a57ba3b`](https://github.com/NixOS/nixpkgs/commit/5a57ba3bddf8714641112d39b64d4d69a845d3ba) finalfrontier: pin to openssl_1_1
* [`c9a1beb2`](https://github.com/NixOS/nixpkgs/commit/c9a1beb23895e85beda47b7920962f8eaa9ac194) git-series: pin to openssl_1_1
* [`12ad2541`](https://github.com/NixOS/nixpkgs/commit/12ad25411d9dcbf2556b1e8aafd54de8fb24db98) gmnisrv: pin to openssl_1_1
* [`a0c0a349`](https://github.com/NixOS/nixpkgs/commit/a0c0a349d267de3f7aaa39264f994efad0f2149b) habitat: pin to openssl_1_1
* [`d4e0a8f1`](https://github.com/NixOS/nixpkgs/commit/d4e0a8f1d2a044a65bfdfde5ed2e211927a92572) hash_extender: pin to openssl_1_1
* [`45c8684e`](https://github.com/NixOS/nixpkgs/commit/45c8684e2cc4b15978cfee4ced4177faa73e8838) hydra-cli: pin to openssl_1_1
* [`85d62cef`](https://github.com/NixOS/nixpkgs/commit/85d62cef64570cf17314673642757bb8153e856e) imag: pin to openssl_1_1
* [`62ee0617`](https://github.com/NixOS/nixpkgs/commit/62ee0617103bffa1e64256684a78f889ac7a15de) mdbook-plantuml: pin to openssl_1_1
* [`18ee52ca`](https://github.com/NixOS/nixpkgs/commit/18ee52cae45993d7c5e66d8930e57c49bdcb9d2e) paperoni: pin to openssl_1_1
* [`60283ad9`](https://github.com/NixOS/nixpkgs/commit/60283ad9539d0caaf2d9c913a710239a224bd9fb) netease-music-tui: pin to openssl_1_1
* [`dee738a1`](https://github.com/NixOS/nixpkgs/commit/dee738a1d0280043d3132c76c37d57d58c2130df) quill: pin to openssl_1_1
* [`a1ce22e7`](https://github.com/NixOS/nixpkgs/commit/a1ce22e7a9846e50f997c64e844e451499625d9b) rucredstash: pin to openssl_1_1
* [`ceb1673c`](https://github.com/NixOS/nixpkgs/commit/ceb1673ca7a187471ae071a6fb1af0b7cd070e72) shticker-book-unwritten: pin to openssl_1_1
* [`4c84ab3f`](https://github.com/NixOS/nixpkgs/commit/4c84ab3fa59ac47dfb75bc58a154fa2c12c501a0) ndn-cxx: pin to openssl_1_1
* [`cfca6eb1`](https://github.com/NixOS/nixpkgs/commit/cfca6eb1d995587684e5c47526617f89148c038c) ndn-tools: pin to openssl_1_1
* [`72827e4b`](https://github.com/NixOS/nixpkgs/commit/72827e4b5dc95f9ef506728d91717b88b337bc4d) spotify-tui: pin to openssl_1_1
* [`7fae589a`](https://github.com/NixOS/nixpkgs/commit/7fae589af3ad4f1c07131bd1ce559ca803543c03) synapse-bt: pin to openssl_1_1
* [`fdbb3e2b`](https://github.com/NixOS/nixpkgs/commit/fdbb3e2b6a162f1070fccb8c9b90fb3779015456) taizen: pin to openssl_1_1
* [`7a1078c5`](https://github.com/NixOS/nixpkgs/commit/7a1078c5c0a5c53d31fdf79336cd8d0e26fe0c5e) tensorman: pin to openssl_1_1
* [`5b3be0c3`](https://github.com/NixOS/nixpkgs/commit/5b3be0c3bfeb6d5dd0352b171bebda2d859303d3) tremor-rs: pin to openssl_1_1
* [`954f49b6`](https://github.com/NixOS/nixpkgs/commit/954f49b653af6289c72675344df4771d6ae395eb) sslsplit: pin to openssl_1_1
* [`76c7f573`](https://github.com/NixOS/nixpkgs/commit/76c7f5739dad79888d96512b513c0b4eb6df90e8) nfd: pin to openssl_1_1
* [`cc43c149`](https://github.com/NixOS/nixpkgs/commit/cc43c149ce4ae6f21805dde414626eec3f093296) mrustc-bootstrap: pin to openssl_1_1
* [`3d248461`](https://github.com/NixOS/nixpkgs/commit/3d248461ec3458e68e70026592bc4e2e9dabade6) hadoop: pin to openssl_1_1
* [`5311245e`](https://github.com/NixOS/nixpkgs/commit/5311245e0d1f444a2fbb8e66f05762196a49325a) archiveopteryx: pin to openssl_1_1
* [`3bd60b6f`](https://github.com/NixOS/nixpkgs/commit/3bd60b6f2a27f74d81b7a1ca617801218755dd01) bip: pin to openssl_1_1
* [`69b6d651`](https://github.com/NixOS/nixpkgs/commit/69b6d651fbab83eb1674bd79506bbbf020501e3e) break-time: pin to openssl_1_1
* [`b2a6d7d7`](https://github.com/NixOS/nixpkgs/commit/b2a6d7d7d4ef0595c4b58146139b54a64e017640) cargo-bisect-rustc: pin to openssl_1_1
* [`e41500b6`](https://github.com/NixOS/nixpkgs/commit/e41500b6e66b2797c93cef2098552096e73b7587) cargo-dephell: pin to openssl_1_1
* [`faa8136e`](https://github.com/NixOS/nixpkgs/commit/faa8136e81f5d485d2e5cd2bbca8836467ae1d40) cargo-raze: pin to openssl_1_1
* [`3aa4e012`](https://github.com/NixOS/nixpkgs/commit/3aa4e0127a49e17be590b3c53c7cd33a5d4391ca) cfdyndns: pin to openssl_1_1
* [`0d75ceba`](https://github.com/NixOS/nixpkgs/commit/0d75cebac7cfb847e10e10e43333eb17a3d45544) espanso: pin to openssl_1_1
* [`23022b27`](https://github.com/NixOS/nixpkgs/commit/23022b2779ca1d06955069d00ddc349e0d7ca263) journaldriver: pin to openssl_1_1
* [`7033bc7e`](https://github.com/NixOS/nixpkgs/commit/7033bc7e3bd2726dd5994e831ba0716591bdafb6) kore: pin to openssl_1_1
* [`6449e23d`](https://github.com/NixOS/nixpkgs/commit/6449e23dbc5ab40101e2cc984becf9c9f9eeec96) movine: pin to openssl_1_1
* [`782138c7`](https://github.com/NixOS/nixpkgs/commit/782138c792b2e9c6e5f80ddc7c0b9baa316d492e) perl534Packages.ZonemasterLDNS: pin to openssl_1_1
* [`cfc8c934`](https://github.com/NixOS/nixpkgs/commit/cfc8c93472f3f7d6fbc8908a7ee3b1078b85f4dd) picom-next: unstable-2022-02-05 -> unstable-2022-08-23
* [`f32644bc`](https://github.com/NixOS/nixpkgs/commit/f32644bc53a29eeeb465c2af6edab06fa030f64d) haskellPackages: stackage LTS 19.20 -> LTS 19.22
* [`14168f59`](https://github.com/NixOS/nixpkgs/commit/14168f59cd597f40195e2ef25ca83cac362c533a) all-cabal-hashes: 2022-08-28T23:15:42Z -> 2022-09-11T02:31:18Z
* [`5410c01a`](https://github.com/NixOS/nixpkgs/commit/5410c01af1c68a57c6cc5c6288566927adbc9abc) haskellPackages: regenerate package set based on current config
* [`08b6da8c`](https://github.com/NixOS/nixpkgs/commit/08b6da8c089a30d1e8c6d6b3db5e50047d8f89bf) konf: init at 0.2.0
* [`7a6a8b41`](https://github.com/NixOS/nixpkgs/commit/7a6a8b41fc4eeb26eaf77936470b908230c19965) git-credential-gopass: 1.14.3 -> 1.14.6
* [`cfbf9bd1`](https://github.com/NixOS/nixpkgs/commit/cfbf9bd15c15338bfd4406feb50337590aaa430b) nixos/nspawn: Fix configuration name PrivateUsersOwnership
* [`24a24101`](https://github.com/NixOS/nixpkgs/commit/24a24101223681e6c73671c69f3df9a401f97a54) reformat code
* [`fa3e7042`](https://github.com/NixOS/nixpkgs/commit/fa3e7042dd0eddf339d2e52e8d0d1dedd3de9880) use `hash`/`vendorHash` in favor of `sha256`/`vendorSha256`
* [`27dee934`](https://github.com/NixOS/nixpkgs/commit/27dee9344ad3355828d125a187894388d6420117) add `ldflags` -s and -w
* [`a1887683`](https://github.com/NixOS/nixpkgs/commit/a188768396b61029de0573ef4b01dd2f3e1b14ea) linode-cli: 5.22.0 -> 5.22.0
* [`d2e32869`](https://github.com/NixOS/nixpkgs/commit/d2e32869962884d5f18f08b372bb1737c55906ba) specify version in `rev`
* [`03870e93`](https://github.com/NixOS/nixpkgs/commit/03870e938a90ce9df600f2442fc576f51227bda6) vimPlugins.haskell-with-unicode-vim: init at 2022-09-11
* [`801760e9`](https://github.com/NixOS/nixpkgs/commit/801760e9e4712f4ad453ca5dad9e066dc70548a1) haskellPackages.hspec_2_10_5: bump
* [`f7077ba1`](https://github.com/NixOS/nixpkgs/commit/f7077ba1311a49c91493a6696f4ec0dd568f297a) nixos: Fix cross compilation of derivations defined in NixOS via pkgs
* [`25accd2a`](https://github.com/NixOS/nixpkgs/commit/25accd2a11f71d336d3b2ea636e191e16fcca75a) meld: 3.21.2 -> 3.22.0
* [`4770866f`](https://github.com/NixOS/nixpkgs/commit/4770866f937654609fc0abcd6a486999f3a1ed3e) nixos/vector: remove no longer required workaround for cross compiling
* [`d9038bd6`](https://github.com/NixOS/nixpkgs/commit/d9038bd6e65fa5d919745917990b0d64590ff025) zq: remove noop overwrite
* [`9d8ebb0b`](https://github.com/NixOS/nixpkgs/commit/9d8ebb0b58668620e759e575509d77e492024fde) hostname-debian: init at 3.23
* [`5dc12356`](https://github.com/NixOS/nixpkgs/commit/5dc123563a833c673b4e86c7e46bce1c307fb7e5) cyberchef: 9.46.0 -> 9.46.4
* [`3a8d85fe`](https://github.com/NixOS/nixpkgs/commit/3a8d85fef170cf8dfe70457f18f96f64751812d4) bob: init at 0.5.3
* [`e5f2f2c7`](https://github.com/NixOS/nixpkgs/commit/e5f2f2c76c9aba499a98a7f378e43f9918ba3e6b) maintainers: add zuzuleinen
* [`ae852f56`](https://github.com/NixOS/nixpkgs/commit/ae852f5692b37c0e4bb409341b7cfc1bd640f2ce) datree: 1.6.13 -> 1.6.19
* [`eb1df01d`](https://github.com/NixOS/nixpkgs/commit/eb1df01d46e245119c809ca175d7927ea2474d9a) opencolorio: fix build on darwin x86_64
* [`649cd671`](https://github.com/NixOS/nixpkgs/commit/649cd671b515366d04fe025a5c930b79811703f0) eksctl: 0.110.0 -> 0.111.0
* [`20f90d39`](https://github.com/NixOS/nixpkgs/commit/20f90d392141a155386ea2143048b4d755d07988) lib/systems: add emulatorAvailable
* [`a27f6b1b`](https://github.com/NixOS/nixpkgs/commit/a27f6b1b0423fbfb37779087b4201f0d7df65ab2) gh-dash: 3.2.0 -> 3.3.0
* [`8926897c`](https://github.com/NixOS/nixpkgs/commit/8926897c2bde06bf76feaacbb9f9e77af581b865) mopidy-iris: 3.60.0 -> 3.64.0
* [`eefbc3da`](https://github.com/NixOS/nixpkgs/commit/eefbc3dad4bcde46b9c6d3804a6c963a03eb29f1) mopidy-ytmusic: 0.3.5 -> 0.3.7
* [`95eb1009`](https://github.com/NixOS/nixpkgs/commit/95eb10093a4e06f00de767e9f08f17296c5d8d07) gopass-hibp: 1.14.3 -> 1.14.6
* [`1f720955`](https://github.com/NixOS/nixpkgs/commit/1f720955aed5f089d89c5022bd22311a22358a95) gopass-summon-provider: 1.14.3 -> 1.14.6
* [`75478e09`](https://github.com/NixOS/nixpkgs/commit/75478e097cff0ac2e817b1d3ff9356a17ae754ce) postgresqlPackages.rum: 1.3.11 -> 1.3.12
* [`dca7412a`](https://github.com/NixOS/nixpkgs/commit/dca7412a8b050ecf5b7a0fa7efe299c57ae6418a) borgmatic: Add bash completion (no other supported shell)
* [`31d2aff2`](https://github.com/NixOS/nixpkgs/commit/31d2aff2430b978a888c47ea2630e6914078963f) borgmatic: Add passthru.tests.version
* [`1f5aa244`](https://github.com/NixOS/nixpkgs/commit/1f5aa244353e6e2d4bc23c48c5f7d054fa332e0f) jql: 5.0.1 -> 5.0.2
* [`71357946`](https://github.com/NixOS/nixpkgs/commit/7135794653b3093b5c90c3926acc693a0613e585) got: 0.74 -> 0.75
* [`f7723d08`](https://github.com/NixOS/nixpkgs/commit/f7723d082d210bb0e7454f4487d379294997fac2) baresip: Build the GTK module
* [`3c3f3a16`](https://github.com/NixOS/nixpkgs/commit/3c3f3a160c2aef45d4bae87e6cd2947af3254a97) flake8-bugbear: 22.8.23 -> 22.9.11
* [`e3be4ad2`](https://github.com/NixOS/nixpkgs/commit/e3be4ad2f06450b43ee723250cb96bb39a1b50a7) paperless: fix array formatting
* [`a611c674`](https://github.com/NixOS/nixpkgs/commit/a611c674c211fe776588dda9a9df88cb914046da) paperless: use `imagemagickBig`
* [`19cd03d4`](https://github.com/NixOS/nixpkgs/commit/19cd03d456109f4fffa6e848525e4d4fe61243c3) clojure: use latest java LTS
* [`302133fd`](https://github.com/NixOS/nixpkgs/commit/302133fd226905709017b4c1b4f1bf2b1cb4c142) icingaweb2: 2.10.1 -> 2.11.1
* [`1778eb5f`](https://github.com/NixOS/nixpkgs/commit/1778eb5fdc44e1cbcb1620f574d368daa16fa2bd) mani: 0.21.0 -> 0.22.0
* [`cb62326e`](https://github.com/NixOS/nixpkgs/commit/cb62326e36148b60a95898b26c07ab221209cf9a) hex: init at 0.4.2
* [`0a586cd4`](https://github.com/NixOS/nixpkgs/commit/0a586cd4d5e82bcf949a3734c0cf48b73c03bfe1) php: 8.1.9 -> 8.1.10
* [`755e7195`](https://github.com/NixOS/nixpkgs/commit/755e7195b298d3151ab3be4a50d7ffda46b1ad43) samba: 4.15.5 -> 4.15.9
* [`195f1fb5`](https://github.com/NixOS/nixpkgs/commit/195f1fb59aafe80090f74431e541a54109140a4a) cargo-raze: pin to openssl_1_1
* [`949f55c0`](https://github.com/NixOS/nixpkgs/commit/949f55c0dda937f84d0d5c532ebfac1910f9f01a) mrustc-bootstrap: pin to openssl_1_1
* [`e3d748a9`](https://github.com/NixOS/nixpkgs/commit/e3d748a92bec86330d1ab86a1836bbf4386cff06) hip: fix hip cmake config
* [`5f4bfbbe`](https://github.com/NixOS/nixpkgs/commit/5f4bfbbe11d5042071b41b9fc361daf24366682c) rubyPackages.sqlite3: simplify build flags
* [`fabbaeda`](https://github.com/NixOS/nixpkgs/commit/fabbaedaa24056a0c18d48028f4017744551e5e2) openapi-generator-cli: 6.0.1 -> 6.1.0
* [`8d3a55ba`](https://github.com/NixOS/nixpkgs/commit/8d3a55ba445ccf2e978d3bf37ec07057ff6e7c92) oneDNN: 2.6.1 -> 2.6.2
* [`9b3213ba`](https://github.com/NixOS/nixpkgs/commit/9b3213ba9939989413488d4e1518be9ed00c1949) Handle melpa new fetchers (sourcehut, codeberg)
* [`59696319`](https://github.com/NixOS/nixpkgs/commit/59696319ad54010bbf2fcc757696a29751711a8f) pocketbase: 0.6.0 -> 0.7.2
* [`bf0d91a4`](https://github.com/NixOS/nixpkgs/commit/bf0d91a4e2ca1c94597bdf07e403764342cf43aa) ppsspp-qt: 1.13.1 -> 1.13.2
* [`01d0040b`](https://github.com/NixOS/nixpkgs/commit/01d0040bac5d9845ff0d842de517bf4254753d2e) pure-prompt: 1.20.1 -> 1.20.3
* [`375b453c`](https://github.com/NixOS/nixpkgs/commit/375b453c7d72d83d4b09e6cc63e4ba103cc6975d) sharedown: 4.0.2 -> 5.0.2
* [`1a20be1a`](https://github.com/NixOS/nixpkgs/commit/1a20be1a312b69c13b40d246358cf7d315d52b60) sish: 2.6.0 -> 2.7.0
* [`1dbade40`](https://github.com/NixOS/nixpkgs/commit/1dbade400dd7c3705298e212b5ce0dd372ced2d8) exaile: 4.1.1 -> 4.1.2
* [`eebe8d36`](https://github.com/NixOS/nixpkgs/commit/eebe8d3655a72783d860de78258717fed38c4491) just: 1.4.0 -> 1.5.0
* [`d103a918`](https://github.com/NixOS/nixpkgs/commit/d103a9186b98ac92ae601703b7cd3b713d98f772) tere: 1.1.0 -> 1.2.0
* [`7a02685e`](https://github.com/NixOS/nixpkgs/commit/7a02685e60a5c4fb9c3907edab66b84c2c46a2b3) tidal-hifi: 4.1.1 -> 4.1.2
* [`5f1dfe2c`](https://github.com/NixOS/nixpkgs/commit/5f1dfe2c0ffba6cd4615bc46cf5d9a0f3b57deba) php80: 8.0.22 -> 8.0.23
* [`04eb0eba`](https://github.com/NixOS/nixpkgs/commit/04eb0eba96af2383a5eced4ca03cead88e82e0b4) juicefs: init at 1.0.0
* [`bbe49339`](https://github.com/NixOS/nixpkgs/commit/bbe49339b81aa7acc13612d78ace0e4cfcaaaa6b) .github/workflows: fix permissions
* [`53769ebc`](https://github.com/NixOS/nixpkgs/commit/53769ebc79e6de6c6bda995277dc7f7b63ddb421) immudb: init at 1.3.2
* [`c006419b`](https://github.com/NixOS/nixpkgs/commit/c006419bc9b6ae49f4e885b54bbd21c7682885ad) intel-media-sdk: 22.5.2 -> 22.5.3
* [`fce8e220`](https://github.com/NixOS/nixpkgs/commit/fce8e2200adcfe848f40758190d8be10cea8603f) ipinfo: 2.8.1 -> 2.9.0
* [`096aba38`](https://github.com/NixOS/nixpkgs/commit/096aba38647c5efd82c3751aaddde9b16076c025) python3Packages.hs-dbus-signature: init at 0.7
* [`dc168de3`](https://github.com/NixOS/nixpkgs/commit/dc168de323e6ea34c49153b0c9b592800206d2af) python3Packages.dbus-signature-pyparsing: init at 0.04
* [`de6160d4`](https://github.com/NixOS/nixpkgs/commit/de6160d4ff407d948f5604607ee4ac2eb1b84f3a) python3Packages.into-dbus-python: init at 0.08
* [`91dee8a4`](https://github.com/NixOS/nixpkgs/commit/91dee8a4562c62e7af4f612c4d1106193a8d01e0) python3Packages.dbus-python-client-gen: init at 0.8
* [`bb307c91`](https://github.com/NixOS/nixpkgs/commit/bb307c917dde9f6f80114cd5b43b210ed552b884) stratis-cli: init at 3.2.0
* [`7073dcc0`](https://github.com/NixOS/nixpkgs/commit/7073dcc0903f41b7ea23c2d407a9f9b22c13a5df) variety: add app indicator support
* [`121aeadd`](https://github.com/NixOS/nixpkgs/commit/121aeadda77f42fa272fff45518eacbec08bfc3a) apache-jena: 4.6.0 -> 4.6.1
* [`55e1e9a1`](https://github.com/NixOS/nixpkgs/commit/55e1e9a10419922d2be9bf33730f5108f73c9bbd) jmol: 14.32.73 -> 14.32.74
* [`ca03f2dc`](https://github.com/NixOS/nixpkgs/commit/ca03f2dc0fff2d30387714e43886af5e74425820) nixos/stratis: init
* [`4abf0ee7`](https://github.com/NixOS/nixpkgs/commit/4abf0ee79352df4f107d7eb0fccced381a9f673b) nixos/stratis: add test for simple usecases
* [`fdead18e`](https://github.com/NixOS/nixpkgs/commit/fdead18e9e7c5f157c572858494b1c292430eede) nixos/paperless: use python from pkg for gunicorn
* [`7398c337`](https://github.com/NixOS/nixpkgs/commit/7398c337c9ce56c16bb93756f3e2f763058a9efa) nixos/stratis: passthru tests to stratis-cli and stratisd
* [`a953aca3`](https://github.com/NixOS/nixpkgs/commit/a953aca3d73cee231c4f852524d6f336d027ece0) fclones: 0.27.2 -> 0.27.3
* [`133d72aa`](https://github.com/NixOS/nixpkgs/commit/133d72aa16b4d5f2d2b5c1e841c21a377be93015) gopass-jsonapi: 1.14.5 -> 1.14.6
* [`58fe78b9`](https://github.com/NixOS/nixpkgs/commit/58fe78b99b167a51acd6ba87ba7c7e47da9cbb85) change order in `fetchFromGitHub`
* [`f847472d`](https://github.com/NixOS/nixpkgs/commit/f847472df6996c2ec4dd98c459b6734d0729d498) neatvnc: 0.5.3 -> 0.5.4
* [`98c04c5d`](https://github.com/NixOS/nixpkgs/commit/98c04c5da214c9f09329484813cccd41f540cb6c) libzim: 8.0.0 -> 8.0.1
* [`564fb910`](https://github.com/NixOS/nixpkgs/commit/564fb910650c72a9e11aab2e9068aafebcd67564) libusb-compat-0_1: remove patchelf from nativeBuildInputs as it is includ… ([nixos/nixpkgs⁠#190201](https://togithub.com/nixos/nixpkgs/issues/190201))
* [`f085846e`](https://github.com/NixOS/nixpkgs/commit/f085846ed2b1cec849bd27f88f5edbc03b5f5da6) knot-dns: add a test for version-sensitive dependencies
* [`997fb2b5`](https://github.com/NixOS/nixpkgs/commit/997fb2b5709372f893d264e045c7b826e41d7ad4) knot-dns: 3.2.0 -> 3.2.1
* [`33956f6f`](https://github.com/NixOS/nixpkgs/commit/33956f6fdb079ade70493f23da421cf4471cba64) ngtcp2-gnutls: 0.7.0 -> 0.8.1
* [`5b79100c`](https://github.com/NixOS/nixpkgs/commit/5b79100cadb9c802d65a84a278a901343a1c53e7)  ledger-live-desktop: 2.46.2 -> 2.47.0
* [`8cfaeb65`](https://github.com/NixOS/nixpkgs/commit/8cfaeb650611e5ffd058ec96648cad8edae5aa84) qownnotes: 22.8.4 -> 22.9.0
* [`5125710c`](https://github.com/NixOS/nixpkgs/commit/5125710c4d0d23895cb3b544d4b5ab3880435d80) arkade: 0.8.42 -> 0.8.44
* [`48ff7279`](https://github.com/NixOS/nixpkgs/commit/48ff72799226ddcf8720c3f5c267e6bf5978897b) atmos: 1.4.28 -> 1.7.0
* [`6d36e7b0`](https://github.com/NixOS/nixpkgs/commit/6d36e7b05709eb5ec0049b33c09c6d7fde944f50) cinnamon.cinnamon-common: Fix upload-system-info path
* [`d99a622f`](https://github.com/NixOS/nixpkgs/commit/d99a622f7e901e4a2c81033b2217e049199ad9f1) cf-vault: 0.0.11 -> 0.0.13
* [`5b4e5204`](https://github.com/NixOS/nixpkgs/commit/5b4e5204671c13549d7acc9359573dd17a116a5d) cherrytree: 0.99.48 -> 0.99.49
* [`93c121f6`](https://github.com/NixOS/nixpkgs/commit/93c121f6888986f9148a33afd39d714f4b2ca98c) emacs: 28.1 -> 28.2
* [`09bed085`](https://github.com/NixOS/nixpkgs/commit/09bed085c31a9cb12bdf0a59f909e7785555b051) clingo: 5.5.2 -> 5.6.0
* [`bd4508d0`](https://github.com/NixOS/nixpkgs/commit/bd4508d0777cd3c73986aa23257e5e8c6feb8276) cudatext: 1.169.2 → 1.170.5
* [`f9403831`](https://github.com/NixOS/nixpkgs/commit/f940383130e605332052abd23c9cfe153d63e90d) cocogitto: 5.1.0 -> 5.2.0
* [`dd22a79c`](https://github.com/NixOS/nixpkgs/commit/dd22a79c0aef00fd6f7c7257b1f785fe91e19480) xplr: 0.19.0 -> 0.19.3
* [`07290f1e`](https://github.com/NixOS/nixpkgs/commit/07290f1eb63c1550957982421921e7e5d7911c0d) omnisharp-roslyn: add tests
* [`bc7d278a`](https://github.com/NixOS/nixpkgs/commit/bc7d278ac67666ce98c03152a87062b8f9e17f3c) libjcat: 0.1.11 -> 0.1.12
* [`344d5219`](https://github.com/NixOS/nixpkgs/commit/344d5219dd8898ba8f05c6bd9e4a374cb287de5f) python310Packages.tcxparser: init at 2.3.0
* [`e449f76a`](https://github.com/NixOS/nixpkgs/commit/e449f76a1f333c96f9494bd28a7fcd3b40b563c6) libxmlb: 0.3.9 -> 0.3.10
* [`31f69654`](https://github.com/NixOS/nixpkgs/commit/31f69654820318de1d0cde6c640f82282c56b0ae) ibus-engines.m17n: 1.4.10 -> 1.4.11
* [`be9e813d`](https://github.com/NixOS/nixpkgs/commit/be9e813d762cc138e499ae49a2d43ff27fbfb20d) sierra-breeze-enhanced: 1.2.0 -> 1.3.1
* [`16889211`](https://github.com/NixOS/nixpkgs/commit/1688921199efbf10b785cd787b9282de77a47ab2) fheroes2: 0.9.18 -> 0.9.19
* [`7c1a6f0b`](https://github.com/NixOS/nixpkgs/commit/7c1a6f0bc7699ac18b72338e5129f5b20c8fe555) libcifpp: 4.2.0 -> 4.2.2
* [`446f8cc5`](https://github.com/NixOS/nixpkgs/commit/446f8cc58969c063c03670234f294626e16871be) fluxcd: 0.33.0 -> 0.34.0
* [`e00c1364`](https://github.com/NixOS/nixpkgs/commit/e00c13649f07a0adf62ddd1562aa821ae2991fc3) octoprint: fix build error on staging-next
* [`25d00141`](https://github.com/NixOS/nixpkgs/commit/25d00141a81262f5a607a194ec45314e8647468c) tsduck: init at 3.31-2761
* [`6ec928d7`](https://github.com/NixOS/nixpkgs/commit/6ec928d73d0580692e75c54c79a0f5a69c1edcf2) nixos/stratis: wait for devices to appear in tests
* [`f0f4ad0c`](https://github.com/NixOS/nixpkgs/commit/f0f4ad0cb0723e8962e18d1fa805df6a80029483) nixos/self-deploy: add tar to path.
* [`3b964bc8`](https://github.com/NixOS/nixpkgs/commit/3b964bc829c5607fc6c91cc581486d11a9c22da4) session-desktop: 1.9.1 -> 1.10.0
* [`1694bba9`](https://github.com/NixOS/nixpkgs/commit/1694bba9154099bbf00ac2e710bbb58518a2ed62) miniserve: remove unnecessary dependencies, add figsoda as a maintainer
* [`41ab8c0b`](https://github.com/NixOS/nixpkgs/commit/41ab8c0b8a4327debbbdcbe5e1777a27afef9676) klipper: unstable-2022-06-18 -> unstable-2022-09-11
* [`c619f9ca`](https://github.com/NixOS/nixpkgs/commit/c619f9ca0415b4b43dc2f9c51cef10ff18e700b2) linuxKernel.kernels.linux_testing: 6.0-rc1 -> 6.0-rc5
* [`a9c4243e`](https://github.com/NixOS/nixpkgs/commit/a9c4243eec6d0daaf13308662e65a0d5dcce8e23) tabnine: 4.4.123 -> 4.4.139
* [`e7e7e386`](https://github.com/NixOS/nixpkgs/commit/e7e7e386a8b631bfadbb15f6da41e6afbffa5b03) doublecmd: 1.0.6 -> 1.0.7
* [`a594429b`](https://github.com/NixOS/nixpkgs/commit/a594429bfa1eda2c909a08d00eb76a83d9a3e907) dua: 2.17.8 -> 2.18.0
* [`fb3f7d70`](https://github.com/NixOS/nixpkgs/commit/fb3f7d70b438a729f4f10d2e31f546d24bfeb6b2) nixos/kanidm: Add unixd test
* [`070b3966`](https://github.com/NixOS/nixpkgs/commit/070b3966fcb1f514a0e7ea4c7689561321ae3400) nixos/cachix-agent: fix type for host option
* [`141acc16`](https://github.com/NixOS/nixpkgs/commit/141acc16dc907ab426d26a93672cd734734d449c) wineasio: init at 1.1.0
* [`2bf2f458`](https://github.com/NixOS/nixpkgs/commit/2bf2f4583a269c110d17fbc268c9b44f88ee91ed) shellhub-agent: 0.9.6 -> 0.10.1
* [`2e3e0081`](https://github.com/NixOS/nixpkgs/commit/2e3e0081e5e843599aaa8f7128d2a139bda7dbca) element-web: allow older openssl codecs ([nixos/nixpkgs⁠#190950](https://togithub.com/nixos/nixpkgs/issues/190950))
* [`4fbc5fa7`](https://github.com/NixOS/nixpkgs/commit/4fbc5fa77f4931dbaf062ffafde9e1054039f29c) nanovna-saver: 0.5.1 -> 0.5.2
* [`1090ad11`](https://github.com/NixOS/nixpkgs/commit/1090ad11c8ea50238d46623096cade1c03a11972) numix-icon-theme-circle: 22.09.04 -> 22.09.12
* [`fa1c0d87`](https://github.com/NixOS/nixpkgs/commit/fa1c0d87c497359f036e36708aba04eb37420f54) numix-icon-theme-square: 22.09.04 -> 22.09.12
* [`0e632469`](https://github.com/NixOS/nixpkgs/commit/0e632469a0593e2565e5c37452abcad72e5d7706) er-patcher: 1.06-1 -> 1.06-2
* [`bcbfcce6`](https://github.com/NixOS/nixpkgs/commit/bcbfcce62f9ff014c215e233c8c578093571400b) github-desktop: 3.0.5 -> 3.0.6
* [`94a4cfb5`](https://github.com/NixOS/nixpkgs/commit/94a4cfb58e5dce5d9bcdc7ba41cb7fd06571d0e0) github-desktop: pin to openssl_1_1
* [`97b0196d`](https://github.com/NixOS/nixpkgs/commit/97b0196da51300190293de357779d5e1a8618124) jellyfin-ffmpeg: 5.1-2 -> 5.1.1-1
* [`99e71eee`](https://github.com/NixOS/nixpkgs/commit/99e71eee21a2b8c5b2b0258a4e8d599b763c0b9a) dendrite: 0.9.6 -> 0.9.8
* [`e8db71f5`](https://github.com/NixOS/nixpkgs/commit/e8db71f5f8e95e20e28b735b29afe7b2fe925bad) usql: 0.12.0 -> 0.12.13
* [`49426793`](https://github.com/NixOS/nixpkgs/commit/49426793cd9422a6bfcaa53bcbdfba8a19e5dd0f) usql: add anthonyroussel to maintainers
* [`cbb33405`](https://github.com/NixOS/nixpkgs/commit/cbb334055707102ed5f762d732420eb6c57cbfc7) usql: add platforms
* [`25ab59d4`](https://github.com/NixOS/nixpkgs/commit/25ab59d428103b0ca361927849c8dd011885548b) glooctl: 1.12.12 -> 1.12.15
* [`6025d243`](https://github.com/NixOS/nixpkgs/commit/6025d243641c1f8af437ba8cf5637c7005c3c1db) cglm: install correct include/lib dir in pkg-config
* [`f906897d`](https://github.com/NixOS/nixpkgs/commit/f906897d4b8829159b27f17accfefddb9ad3effd) ddnet: 16.3.1 -> 16.3.2
* [`c23686e1`](https://github.com/NixOS/nixpkgs/commit/c23686e115650a9fdf04c3d6e3825379ab4c89d6) imagemagick: 7.1.0-47 -> 7.1.0-48
* [`54c911ff`](https://github.com/NixOS/nixpkgs/commit/54c911ff3ba41c4c4a77d4a45b4d3bccb72c073e) gdu: 5.17.0 -> 5.17.1
* [`fdabbea2`](https://github.com/NixOS/nixpkgs/commit/fdabbea239e9bbe723df31fb93adb3fdb0bf3f9a) python310Packages.certbot-dns-inwx: init at 2.1.3
* [`ff8aa750`](https://github.com/NixOS/nixpkgs/commit/ff8aa750ae88928917e9508176e3b98d4661b50e) giara: 1.0 -> 1.0.1
* [`5519e1b8`](https://github.com/NixOS/nixpkgs/commit/5519e1b89bf02443b056fac9acf5f6d607bb622f) nixos/lemmy: remove `services.lemmy.jwtSecretPath`
* [`c231a20d`](https://github.com/NixOS/nixpkgs/commit/c231a20d98ec8b7cc521c490ab9d957c9778fa0a) nixos/lemmy: move systemd script to serviceConfig
* [`953918a0`](https://github.com/NixOS/nixpkgs/commit/953918a0f9d7e24b45aefc47cdc6a607fc108767) trojita-unstable: unstable-2020-07-06 -> unstable-2022-08-22
* [`3a818092`](https://github.com/NixOS/nixpkgs/commit/3a818092242b3de9debe9033ef60513e3db10cb4) maintainers: add Necior
* [`4def9649`](https://github.com/NixOS/nixpkgs/commit/4def96490a620e457b10f80efcb9d36172ca686a) rsstail: add Necior to maintainers
* [`77746d1d`](https://github.com/NixOS/nixpkgs/commit/77746d1ddf48ab48136b8952e28b1472dfc5b784) rsstail: update repository location
* [`9717e20f`](https://github.com/NixOS/nixpkgs/commit/9717e20f4b8daea22d1dc6bc96477831150512e1) blender: 3.2.0 -> 3.3.0 ([nixos/nixpkgs⁠#190732](https://togithub.com/nixos/nixpkgs/issues/190732))
* [`f44aef1c`](https://github.com/NixOS/nixpkgs/commit/f44aef1c16ee43ff4b4a65e4081a69154e30a31a) cargo-valgrind: 2.0.3 -> 2.1.0
* [`60ec6ff7`](https://github.com/NixOS/nixpkgs/commit/60ec6ff76c44b619d61d626307eee03d8a706bbf) idasen: 0.9.1 -> 0.9.2
* [`af91d05b`](https://github.com/NixOS/nixpkgs/commit/af91d05b1cd353d198c9619ef95d3ea31d5f2bf1) libamqpcpp: 4.3.16 -> 4.3.17
* [`aac17cda`](https://github.com/NixOS/nixpkgs/commit/aac17cda3ffa0758ab134f193617eab0cbf46749) python310Packages.BTrees: 4.10.0 -> 4.10.1
* [`662b8da3`](https://github.com/NixOS/nixpkgs/commit/662b8da3f1e6c5bcc7d397e8327f08bb334645b1) python310Packages.adafruit-platformdetect: 3.27.3 -> 3.29.0
* [`813eb2b2`](https://github.com/NixOS/nixpkgs/commit/813eb2b223028fabe04fdc7a6450598d23cd1d19) python310Packages.openwrt-luci-rpc: 1.1.11 -> 1.1.12
* [`22b097e8`](https://github.com/NixOS/nixpkgs/commit/22b097e86b135c253e4eab83309fa7d3ff5811c7) nvtop: 2.0.2->2.0.3
* [`54f0e005`](https://github.com/NixOS/nixpkgs/commit/54f0e005de02b1a04894c704bb12d4a1c6cf93e8) vector: 0.24.0 -> 0.24.1
* [`8efd0a82`](https://github.com/NixOS/nixpkgs/commit/8efd0a822e65173143a3655ec565075c71a545f3) apacheHttpdPackages.mod_wsgi: 4.9.3 -> 4.9.4
* [`1ee25bd6`](https://github.com/NixOS/nixpkgs/commit/1ee25bd6975e0a4ee61afc86cb170923d4977d60) fcitx5-mozc: package ut dictionary
* [`778ac91f`](https://github.com/NixOS/nixpkgs/commit/778ac91f3545e70b9be072dbca66207a35244e2c) fcitx5-mozc: add govanify as maintainer
* [`33027f72`](https://github.com/NixOS/nixpkgs/commit/33027f727d1a73a9ca10a104b70b5ffbfbd618a8) moonlight-qt: 4.1.0 -> 4.2.1
* [`bfe0a4be`](https://github.com/NixOS/nixpkgs/commit/bfe0a4be229d7ddff93825929f9f807cbf26c2a5) mympd: 9.5.3 -> 9.5.4
* [`dfcbbdaa`](https://github.com/NixOS/nixpkgs/commit/dfcbbdaa93cd78b8122b2d92e9a921eb223573ca) postgresqlPackages.postgis: 3.3.0 -> 3.3.1
* [`16074f96`](https://github.com/NixOS/nixpkgs/commit/16074f96ce0f86050b5c3733df270cf342e52e77) postgresql11Packages.age: 1.0.0-rc1 -> 1.1.0-rc0
* [`0db05edd`](https://github.com/NixOS/nixpkgs/commit/0db05edd090647e244ab28688b804f437bfe0fac) hedgewars: 1.0.0 -> 1.0.2
* [`be3db7e7`](https://github.com/NixOS/nixpkgs/commit/be3db7e78f956a87fbf8f6b967fa48fe3004e215) lsd: 0.23.0 -> 0.23.1
* [`408390eb`](https://github.com/NixOS/nixpkgs/commit/408390eb3fece42e432d395e49a4a9e1b865e910) nwg-panel: 0.7.4 -> 0.7.8
* [`48c763e4`](https://github.com/NixOS/nixpkgs/commit/48c763e47364d43ec222c6fac29dd6a6c5cf4e1c) oh-my-posh: 9.0.0 -> 9.1.0
* [`d97e7267`](https://github.com/NixOS/nixpkgs/commit/d97e7267f7da2ed21e65e1e7d6a9982e4e90cf51) python310Packages.ansible-core: 2.13.2 -> 2.13.4
* [`9c1bc56f`](https://github.com/NixOS/nixpkgs/commit/9c1bc56fdd74f81c8c390b256abcd45b1cbc74bb) angband: add kenran to maintainers
* [`bbbbe0e9`](https://github.com/NixOS/nixpkgs/commit/bbbbe0e90058e0189cbba9b8cd041756fe586b47) pluto: 5.10.6 -> 5.10.7
* [`6bd6aa41`](https://github.com/NixOS/nixpkgs/commit/6bd6aa41431725616c873f6d49b126b985b41af7) ymuse: 0.20 -> 0.21
* [`22a7681d`](https://github.com/NixOS/nixpkgs/commit/22a7681dd7d5b7df15ff9e7cf65e0245d37c2fbe) pomerium: 0.19.0 -> 0.19.1
* [`278fd09d`](https://github.com/NixOS/nixpkgs/commit/278fd09d49ac79e86f65db14468a92bfa404211c) i-dot-ming: 7.01 -> 8.00
* [`657aec38`](https://github.com/NixOS/nixpkgs/commit/657aec38e1a0ea80424468916f284813645ae8d3) broot: 1.14.2 -> 1.14.3
* [`8c4a8f96`](https://github.com/NixOS/nixpkgs/commit/8c4a8f96cebc8178a38a2fc3d38281bd36aaf356) schildichat-web: allow older openssl codecs ([nixos/nixpkgs⁠#190964](https://togithub.com/nixos/nixpkgs/issues/190964))
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
