### PR TITLE
niv emacs-overlay: update df64799a -> ab2aad8c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "df64799a97bfe5ebcd35aa66ca198b3cea5cc777",
-        "sha256": "15wmvpcmbipsqmdhb1zj55bl6g0f1jv7c3axnwv6rn3n7k4agnzf",
+        "rev": "ab2aad8ca20c76225aae6d02d9bfedf289db1f72",
+        "sha256": "151mly2wvry3v9b2qq3d2zyphh1qx4j1l8l15xi3iqh1l4vma9vk",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/df64799a97bfe5ebcd35aa66ca198b3cea5cc777.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/ab2aad8ca20c76225aae6d02d9bfedf289db1f72.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@df64799a...ab2aad8c](https://github.com/nix-community/emacs-overlay/compare/df64799a97bfe5ebcd35aa66ca198b3cea5cc777...ab2aad8ca20c76225aae6d02d9bfedf289db1f72)

* [`38268313`](https://github.com/nix-community/emacs-overlay/commit/382683139e3eb1ffb155e34e0e987e77db94aa9c) Updated repos/emacs
* [`e3e61979`](https://github.com/nix-community/emacs-overlay/commit/e3e6197964f04cfbc2f83b8578286375250393cc) Updated repos/emacs
* [`82c7ea1e`](https://github.com/nix-community/emacs-overlay/commit/82c7ea1ec27514ab3c329e65c4f608be80412688) Updated repos/elpa
* [`99b97910`](https://github.com/nix-community/emacs-overlay/commit/99b9791022c7d1904208fed44f9aa8bdf8845da9) Updated repos/emacs
* [`3f6b8861`](https://github.com/nix-community/emacs-overlay/commit/3f6b88611fb21726172cf11d767cf497ee3a9513) Updated repos/emacs
* [`a28218ac`](https://github.com/nix-community/emacs-overlay/commit/a28218ac1fff0e9e4cd9bad9b5ad54dbdea964ad) Updated repos/nongnu
* [`30a7c7ee`](https://github.com/nix-community/emacs-overlay/commit/30a7c7ee7602234f7ae79d46239ae34d57ef0a60) Updated repos/emacs
* [`e6e2da01`](https://github.com/nix-community/emacs-overlay/commit/e6e2da01c61c6ee0a95ea3ecc2fe4d751caa4554) Updated repos/emacs
* [`0ceedad4`](https://github.com/nix-community/emacs-overlay/commit/0ceedad428708e51028305bcb59958003a65b5ab) Updated repos/emacs
* [`6d21d47c`](https://github.com/nix-community/emacs-overlay/commit/6d21d47c97f12d1dcb7d1726a9a4ae22aad11442) Updated repos/nongnu
* [`19952866`](https://github.com/nix-community/emacs-overlay/commit/19952866828a8d8a08e0e264ad1842e585eadc23) Updated repos/emacs
* [`af086e6f`](https://github.com/nix-community/emacs-overlay/commit/af086e6fc0bda5dcf9bc030cd586fc7f41e253ef) Updated repos/elpa
* [`b50178f7`](https://github.com/nix-community/emacs-overlay/commit/b50178f76a7868d0aca28278451141269df137fe) Updated repos/emacs
* [`304e145f`](https://github.com/nix-community/emacs-overlay/commit/304e145fa268928ebc47ed9329ee576a13f93509) Updated repos/emacs
* [`74a1461c`](https://github.com/nix-community/emacs-overlay/commit/74a1461cdc75cdd6949aeef3f7a2f3826edce178) Updated repos/elpa
* [`eea104df`](https://github.com/nix-community/emacs-overlay/commit/eea104df18c7fc4e10f1f1ff20836c540beca587) Updated repos/emacs
* [`856b7b1e`](https://github.com/nix-community/emacs-overlay/commit/856b7b1e21545bf98f67f9f9e31885ed79102ebb) Updated repos/nongnu
* [`8e4c2c2e`](https://github.com/nix-community/emacs-overlay/commit/8e4c2c2e718bd596c8e2146aa4bd3d4bbef57527) Updated repos/emacs
* [`350a3df3`](https://github.com/nix-community/emacs-overlay/commit/350a3df35560f727046192cefd19e0d7e496a652) Updated repos/nongnu
* [`76aa9343`](https://github.com/nix-community/emacs-overlay/commit/76aa93438a5e903e7c862f73cbf2a9fbe5c502dc) Updated repos/emacs
* [`d393851a`](https://github.com/nix-community/emacs-overlay/commit/d393851a128f51152549a09c149b5d1db39a7412) Updated repos/elpa
* [`63f9658c`](https://github.com/nix-community/emacs-overlay/commit/63f9658ce86a068a96415a61696531711817f8f8) Updated repos/emacs
* [`b8c634e9`](https://github.com/nix-community/emacs-overlay/commit/b8c634e9ae9c660c65d1fc41350198926c4a5f1f) Updated repos/emacs
* [`934d0cc5`](https://github.com/nix-community/emacs-overlay/commit/934d0cc53e65053eb3ba2acef8d711d7e93efcf3) Updated repos/elpa
* [`a705e619`](https://github.com/nix-community/emacs-overlay/commit/a705e6198d9cf4c5f7e1f4912f5e23f0b8bd7396) Updated repos/emacs
* [`8ff15244`](https://github.com/nix-community/emacs-overlay/commit/8ff1524472abef7c86c9e9c221d8969911074b4a) Updated repos/emacs
* [`ee074e1f`](https://github.com/nix-community/emacs-overlay/commit/ee074e1fa6a47b481ad14ce87974d09d4eb90e70) Updated repos/emacs
* [`ab2aad8c`](https://github.com/nix-community/emacs-overlay/commit/ab2aad8ca20c76225aae6d02d9bfedf289db1f72) Updated repos/emacs
