### PR TITLE
niv spacemacs: update c1ef3c3f -> a7bfe0bf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "c1ef3c3f66a6bbf5a852341c7dfe83f34f60347e",
-        "sha256": "0yg2nrpnv60nvcjv09dzylzria0xdhamr0i17hl3jdf450vpwa31",
+        "rev": "a7bfe0bfd6d8a7951e5b70645236bfe70c323650",
+        "sha256": "1p8br518bzqqg4lch4knrwg6ggq3wipsiqv90a1cbafn9jfplnyx",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/c1ef3c3f66a6bbf5a852341c7dfe83f34f60347e.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/a7bfe0bfd6d8a7951e5b70645236bfe70c323650.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@c1ef3c3f...a7bfe0bf](https://github.com/syl20bnr/spacemacs/compare/c1ef3c3f66a6bbf5a852341c7dfe83f34f60347e...a7bfe0bfd6d8a7951e5b70645236bfe70c323650)

* [`8d4c114a`](https://github.com/syl20bnr/spacemacs/commit/8d4c114aa02315591effb179b8d4d4d11f3d5b52) Remove trailing space from .spacemacs.template ([syl20bnr/spacemacs⁠#15733](https://togithub.com/syl20bnr/spacemacs/issues/15733))
* [`438fceea`](https://github.com/syl20bnr/spacemacs/commit/438fceea88d29348f20d319369153354fcacb1b4) Fix cumbersome pdf-tools selection behavior
* [`54f12b66`](https://github.com/syl20bnr/spacemacs/commit/54f12b66f00967529cc8effb9818104500819112) Revise latest code-cells-mode fix
* [`cd19efdd`](https://github.com/syl20bnr/spacemacs/commit/cd19efdd6457835a49c6eb1aad66650a3bb6efff) [bot] "built_in_updates" Thu Sep 15 15:41:36 UTC 2022 ([syl20bnr/spacemacs⁠#15737](https://togithub.com/syl20bnr/spacemacs/issues/15737))
* [`9cdf97f8`](https://github.com/syl20bnr/spacemacs/commit/9cdf97f87e89b3f5045da84e181057e82bfc13aa) Fix PR [syl20bnr/spacemacs⁠#15736](https://togithub.com/syl20bnr/spacemacs/issues/15736) ([syl20bnr/spacemacs⁠#15740](https://togithub.com/syl20bnr/spacemacs/issues/15740))
* [`3370a45e`](https://github.com/syl20bnr/spacemacs/commit/3370a45e1133447758d0cbfe0a1d6267c00a0fd8) Update nyan cat package to be compatible with emacs 29
* [`a7bfe0bf`](https://github.com/syl20bnr/spacemacs/commit/a7bfe0bfd6d8a7951e5b70645236bfe70c323650) Fix `spacemacs//dir-byte-compile-state` which returned nil
