### PR TITLE
niv emacs-overlay: update ab2aad8c -> 550ce566

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ab2aad8ca20c76225aae6d02d9bfedf289db1f72",
-        "sha256": "151mly2wvry3v9b2qq3d2zyphh1qx4j1l8l15xi3iqh1l4vma9vk",
+        "rev": "550ce5667fee8f74aa20ad6456720ed84ebdd241",
+        "sha256": "0x1brzy1j4arygncgdvj8klqkx7fyndn2mdl5d3cn0smmny0mzfm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/ab2aad8ca20c76225aae6d02d9bfedf289db1f72.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/550ce5667fee8f74aa20ad6456720ed84ebdd241.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@ab2aad8c...550ce566](https://github.com/nix-community/emacs-overlay/compare/ab2aad8ca20c76225aae6d02d9bfedf289db1f72...550ce5667fee8f74aa20ad6456720ed84ebdd241)

* [`ca910427`](https://github.com/nix-community/emacs-overlay/commit/ca910427295d869ace0345e99931d0ac3a15ccca) Move Emacs 29's bonus-feature flags to mkGitEmacs
* [`3cba3fe7`](https://github.com/nix-community/emacs-overlay/commit/3cba3fe7341611e8f7ebe047f38a82e852c1231d) Use upstream withPgtk input attribute and remove mkPgtkEmacs
* [`d561db31`](https://github.com/nix-community/emacs-overlay/commit/d561db310f51e8bd705d53058f08c6ae7ed3d23b) Updated repos/emacs
* [`7ef85ab9`](https://github.com/nix-community/emacs-overlay/commit/7ef85ab94b2d6c1f81bbb9844875c005b5f9641f) Updated repos/elpa
* [`8e54a898`](https://github.com/nix-community/emacs-overlay/commit/8e54a8980aa438c4f35807ad676acbf7578acce3) Updated repos/emacs
* [`7f496cc6`](https://github.com/nix-community/emacs-overlay/commit/7f496cc689b53d662738825ed3db1b3482cd4689) Updated repos/emacs
* [`7f2a4ca1`](https://github.com/nix-community/emacs-overlay/commit/7f2a4ca1a890f69d23054831d1a4e19f6b7af09c) Updated repos/melpa
* [`8c4c2b39`](https://github.com/nix-community/emacs-overlay/commit/8c4c2b3925183b939cf57301e96d14c0130d0a1e) Updated repos/nongnu
* [`25478542`](https://github.com/nix-community/emacs-overlay/commit/25478542c481dad076af170fa57afc1e17aaa0c9) Updated repos/emacs
* [`c6938da6`](https://github.com/nix-community/emacs-overlay/commit/c6938da6e6dec21d3e366adafab24a396d8b7914) Updated repos/melpa
* [`fb16bf96`](https://github.com/nix-community/emacs-overlay/commit/fb16bf96c7fdd70de3aa04fc53680145155fc515) Updated repos/elpa
* [`d46a5401`](https://github.com/nix-community/emacs-overlay/commit/d46a5401ea87235782c6fa0898371c0bbf7b0c7f) Updated repos/melpa
* [`14fb7b0c`](https://github.com/nix-community/emacs-overlay/commit/14fb7b0c8ed56562dd381652b7820ea53f6e836f) Updated repos/elpa
* [`73b54a0d`](https://github.com/nix-community/emacs-overlay/commit/73b54a0d7d72f83b5b46531ae420019acddda966) Updated repos/melpa
* [`5add6e68`](https://github.com/nix-community/emacs-overlay/commit/5add6e6859f738b9e65d9d86dea5a328e0883ec9) Updated repos/nongnu
* [`4582fb26`](https://github.com/nix-community/emacs-overlay/commit/4582fb2655008aeb04fb7052dcafc435c890f977) Updated repos/melpa
* [`c1826e0c`](https://github.com/nix-community/emacs-overlay/commit/c1826e0ccb73efb4a010f537e1d4f3f6b7ef094c) Updated repos/melpa
* [`eced86c6`](https://github.com/nix-community/emacs-overlay/commit/eced86c6b5a4e0a06f5cedea5f5bf8905ad498c7) Updated repos/melpa
* [`5cd15c2a`](https://github.com/nix-community/emacs-overlay/commit/5cd15c2ae971e71c78c9559c0d195fb6c240d11d) Updated repos/nongnu
* [`6ac93f12`](https://github.com/nix-community/emacs-overlay/commit/6ac93f1274802cc5775b04c22b1cd7068afa29bc) Revert "Use upstream `withPgtk` input attribute and remove `mkPgtkEmacs`"
* [`8ceb667f`](https://github.com/nix-community/emacs-overlay/commit/8ceb667f19671220f53341355352cd8a51ef5c53) Updated repos/melpa
* [`cae16c54`](https://github.com/nix-community/emacs-overlay/commit/cae16c54e59af727e2df6e6d3d273cb07ca5eb79) Updated repos/melpa
* [`1799a8c4`](https://github.com/nix-community/emacs-overlay/commit/1799a8c458576ce347eed6372aceee1b5969adfb) Updated repos/melpa
* [`583ad7ba`](https://github.com/nix-community/emacs-overlay/commit/583ad7baf08792c0edce8d6461a2e40be6c11115) Updated repos/melpa
* [`2e55cb17`](https://github.com/nix-community/emacs-overlay/commit/2e55cb17d012acfa7b68f6d6a16f4d8f148b21c9) Updated repos/melpa
* [`40b81307`](https://github.com/nix-community/emacs-overlay/commit/40b813077fe2d10d41b2ba64541399712434594b) Updated repos/melpa
* [`c847b622`](https://github.com/nix-community/emacs-overlay/commit/c847b622f1f93833cffde28fb7787b85ada85510) Updated repos/melpa
* [`803856df`](https://github.com/nix-community/emacs-overlay/commit/803856dff99db488215ca5c74067abd5a6543d34) Updated repos/melpa
* [`c224e399`](https://github.com/nix-community/emacs-overlay/commit/c224e399e36f2511ae5c9495d26b5968dbf97415) Updated repos/melpa
* [`117975b8`](https://github.com/nix-community/emacs-overlay/commit/117975b8082f22730778f9ad4529ff001b01b6cf) Updated repos/melpa
* [`2f8b367f`](https://github.com/nix-community/emacs-overlay/commit/2f8b367fc85905bd883d88aca4f0e16cde2ebbdd) Updated repos/elpa
* [`6381c637`](https://github.com/nix-community/emacs-overlay/commit/6381c637f61409bc0fd1d46d3e309568b610abeb) Updated repos/melpa
* [`7c05f0e9`](https://github.com/nix-community/emacs-overlay/commit/7c05f0e985e2dfd999afe690abbc5c87d9b0dfaa) Updated repos/elpa
* [`550ce566`](https://github.com/nix-community/emacs-overlay/commit/550ce5667fee8f74aa20ad6456720ed84ebdd241) Updated repos/melpa
