### PR TITLE
niv spacemacs: update a7bfe0bf -> 4688cd7d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "a7bfe0bfd6d8a7951e5b70645236bfe70c323650",
-        "sha256": "1p8br518bzqqg4lch4knrwg6ggq3wipsiqv90a1cbafn9jfplnyx",
+        "rev": "4688cd7dcea36ee346d1aafba7f0638f4d816c28",
+        "sha256": "1k7wr1a1qmhzkbj7q5nw3n4dsqhwq8x00a5ghgrad239jki6p71k",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/a7bfe0bfd6d8a7951e5b70645236bfe70c323650.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/4688cd7dcea36ee346d1aafba7f0638f4d816c28.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@a7bfe0bf...4688cd7d](https://github.com/syl20bnr/spacemacs/compare/a7bfe0bfd6d8a7951e5b70645236bfe70c323650...4688cd7dcea36ee346d1aafba7f0638f4d816c28)

* [`58c56f80`](https://github.com/syl20bnr/spacemacs/commit/58c56f80669d3cfda07334846034a239ec417ec0) fix: fix code-cells-mode setup to avoid undefined symbol errors on define-key
* [`591c036d`](https://github.com/syl20bnr/spacemacs/commit/591c036dc560572ea3f771fca91738ff14864886) build: harden rebase.yml permissions
* [`fb716158`](https://github.com/syl20bnr/spacemacs/commit/fb71615810f38137b2a250ccc6eac6182b18a54c) build: harden stale.yml permissions
* [`4688cd7d`](https://github.com/syl20bnr/spacemacs/commit/4688cd7dcea36ee346d1aafba7f0638f4d816c28) build: harden elisp_test.yml permissions
