### PR TITLE
niv zsh-syntax-highlighting: update caa749d0 -> 122dc464

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -228,10 +228,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "caa749d030d22168445c4cb97befd406d2828db0",
-        "sha256": "17ck9lm8j6bv9fhag827kxrbwdwbhhss0sw7p1yz7nhpknj6apv1",
+        "rev": "122dc464392302114556b53ec01a1390c54f739f",
+        "sha256": "04m2165z48nkc1niq19z2vwa71c0hd5hmn8cx625nngxfy4g9w3x",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/caa749d030d22168445c4cb97befd406d2828db0.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/122dc464392302114556b53ec01a1390c54f739f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@caa749d0...122dc464](https://github.com/zsh-users/zsh-syntax-highlighting/compare/caa749d030d22168445c4cb97befd406d2828db0...122dc464392302114556b53ec01a1390c54f739f)

* [`b828f45d`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/b828f45da63fe57295ab6fafac240af6bd320f5c) main precommands += torsocks
* [`122dc464`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/122dc464392302114556b53ec01a1390c54f739f) main: Add cpulimit to precommands
