### PR TITLE
niv nixpkgs: update a34c70c2 -> b1425554

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a34c70c2a2ab6bf4bd9cf8d20af6c10ffff98f97",
-        "sha256": "0z75p4pa7q9dp982cv64hw4x1ps944c6sxvdpwnlspzc3i72zyc8",
+        "rev": "b142555481cfcc8ebb857f591e1e47583cc28106",
+        "sha256": "1q5j6c11is5afb5326lrlzxr7r91yckg2bh0wlis3a96fnr8rsl9",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a34c70c2a2ab6bf4bd9cf8d20af6c10ffff98f97.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/b142555481cfcc8ebb857f591e1e47583cc28106.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a34c70c2...b1425554](https://github.com/nixos/nixpkgs/compare/a34c70c2a2ab6bf4bd9cf8d20af6c10ffff98f97...b142555481cfcc8ebb857f591e1e47583cc28106)

* [`4fd65e88`](https://github.com/NixOS/nixpkgs/commit/4fd65e8810dcace1763da8ededc84367e3f0fd12) maintainers: add trobert
* [`365db22b`](https://github.com/NixOS/nixpkgs/commit/365db22b059dd2e7cf488a7aaf81c458ce6f2d0e) conduktor: init at 2.15.1
* [`ee9eec33`](https://github.com/NixOS/nixpkgs/commit/ee9eec33539e1e2961334374b5ae1f7560ea871b) adoptopenjdk: add 17.0.1
* [`131105df`](https://github.com/NixOS/nixpkgs/commit/131105df1df06729c05bef3e812dbe083273a5a2) edk2: 202202 -> 202205
* [`6aa7258b`](https://github.com/NixOS/nixpkgs/commit/6aa7258b1cbf2aaa61af9b6b0b469cb1772f67f3) kbd: 2.4.0 -> 2.5.1
* [`4cf8a071`](https://github.com/NixOS/nixpkgs/commit/4cf8a071b0091c44a9cf4a850e1f57fd0c7fd922) quill: 0.2.7 -> 0.2.17
* [`b4c48699`](https://github.com/NixOS/nixpkgs/commit/b4c4869942dc2513701e7ec124343ba106f28e67) python310Packages.requests-wsgi-adapter: init at 0.4.1
* [`355a150e`](https://github.com/NixOS/nixpkgs/commit/355a150e8aa39c40861825fcc55452ac7d92eae1) python310Packages.unearth: init at 0.6.1
* [`d5fdcb7e`](https://github.com/NixOS/nixpkgs/commit/d5fdcb7e777b1dd2d219f2e232f6073736da983d) python310Packages.pdm-pep517: 1.0.2 -> 1.0.4
* [`1f6366d3`](https://github.com/NixOS/nixpkgs/commit/1f6366d38cdd8b858b903ebcad9166cd48196f40) cc-wrapper: fortran: enable stackprotector on M1
* [`ac18c55b`](https://github.com/NixOS/nixpkgs/commit/ac18c55b5698abac81164d66d5a7eabd1ae66c90) make-system-tarball: use `pixz -t`
* [`0a32d87b`](https://github.com/NixOS/nixpkgs/commit/0a32d87be64f16f14108ca81f481683691698912) libstemmer: unstable-2017-03-02 -> 2.2.0
* [`2c59b125`](https://github.com/NixOS/nixpkgs/commit/2c59b12503f70bf743f24424ac295abf3feb434e) libcap_ng: remove unused code for python bindings
* [`4db470ac`](https://github.com/NixOS/nixpkgs/commit/4db470acb63e4990c0c5b693561671d4375e62bd) libopenmpt: 0.6.4 -> 0.6.5
* [`465ab2af`](https://github.com/NixOS/nixpkgs/commit/465ab2af0ec3317b2973ee9f6066caefb33e7ff9) ethtool: 5.18 -> 5.19
* [`c49f26dd`](https://github.com/NixOS/nixpkgs/commit/c49f26ddd1a44246942163631dd092b9319e76c1) nghttp2: 1.47.0 -> 1.49.0
* [`3c697db9`](https://github.com/NixOS/nixpkgs/commit/3c697db9725f56e61c72f0d80051267a4fa4c32c) removeReferencesTo: kill lone hashes
* [`56060403`](https://github.com/NixOS/nixpkgs/commit/560604038a9bcd6f81f3512e559f3342e0a3fad5) w3m: 0.5.3+git20190105 -> 0.5.3+git20220429
* [`545e00fa`](https://github.com/NixOS/nixpkgs/commit/545e00fab7cae14b1269482388802fbf9912efb6) w3m: add anthonyroussel to maintainers
* [`9e77929f`](https://github.com/NixOS/nixpkgs/commit/9e77929f19641a8c2dae0adbfb5d67b20aaae44d) boost: allow enablePython in cross compilation
* [`b1f80738`](https://github.com/NixOS/nixpkgs/commit/b1f80738f157c37fe8d150b7ee19bdd9abd5d5dc) lua-packages.nix: run nixpkgs-fmt
* [`f0ba5915`](https://github.com/NixOS/nixpkgs/commit/f0ba59156ff76082ba5c9aebd8247a0b3eb6cee3) lua-packages.nix: remove unused args
* [`613c4107`](https://github.com/NixOS/nixpkgs/commit/613c4107502b9d9906584dec11487947bcc70c53) lua-modules: use composeManyExtensions
* [`ec35f634`](https://github.com/NixOS/nixpkgs/commit/ec35f6341bc64bea3cfd4f384085c6c28f3590b8) lua-packages: try splicing
* [`a2c61752`](https://github.com/NixOS/nixpkgs/commit/a2c61752fb424f0f4345113d18a1b4a14a10c381) lua.pkgs.luarocks: fix usage in cross-compilation
* [`a59a6bc4`](https://github.com/NixOS/nixpkgs/commit/a59a6bc4ea5ef1cd5d9148e8420b42495785592d) lua-modules/overrides.nix: run nixpkgs-fmt
* [`0345bab9`](https://github.com/NixOS/nixpkgs/commit/0345bab9a67b41b0d1b7fbe6f126e80174a20169) lua-modules/overrides.nix: using pkgs. messes up splicing, dont use it
* [`a13d3870`](https://github.com/NixOS/nixpkgs/commit/a13d38708998938c8f95e35292ef2ace24108a54) build-lua-package: remove unnecessary adding of buildInputs to nativeBuildInputs
* [`50a629cc`](https://github.com/NixOS/nixpkgs/commit/50a629cc3ade2e77c807702c14460239258a8016) libmpack: fix cross
* [`bdb8ca17`](https://github.com/NixOS/nixpkgs/commit/bdb8ca175ab6c65d2b7db2c085f0c4e4ef4743f5) luaPackages.lgi: fix cross
* [`39571bd6`](https://github.com/NixOS/nixpkgs/commit/39571bd6fa6d558c45d67e91333a3cfda645b738) luaPackages: copy passthruFun from python
* [`7b24b57c`](https://github.com/NixOS/nixpkgs/commit/7b24b57c14b954ff15a0b49b8a0404a222e3f258) luaPackages.luarocks: don't refer to luaOnBuild
* [`b84e8342`](https://github.com/NixOS/nixpkgs/commit/b84e8342dfe0f8aaea6dabf7531bd62a9c7e216d) libssh: 0.9.6 -> 0.10.0
* [`17257924`](https://github.com/NixOS/nixpkgs/commit/1725792452dc9c2e095acf426fbb6a9f1f741680) python3Packages.pybind11: use python interpreter from pythonForBuild
* [`557684da`](https://github.com/NixOS/nixpkgs/commit/557684da242e2b8bb3e6a1abe2d09eb4b7ffcb44) doxygen: 1.9.4 -> 1.9.5
* [`2e7c3920`](https://github.com/NixOS/nixpkgs/commit/2e7c3920a07136c9b7321ba7b24dbdf5528d533f) pythonPackages: fix cross compilation
* [`0b3ec7fb`](https://github.com/NixOS/nixpkgs/commit/0b3ec7fbc83637a33d004f296c1b743ea4fafdcb) mpv: fix cross compilation
* [`5e04a1fd`](https://github.com/NixOS/nixpkgs/commit/5e04a1fd5d803a1e533be51e2273d6d4d140dbaa) mpv: fix build with wayland support
* [`992773b8`](https://github.com/NixOS/nixpkgs/commit/992773b898176baeb4934e90718ed3c61f7e4674) boehmgc: 8.0.6 -> 8.2.2
* [`372315ed`](https://github.com/NixOS/nixpkgs/commit/372315edb82844e01b9e94c17d9f6c40dcc6f058) hunspell: 1.7.0 -> 1.7.1
* [`1ab5ab5f`](https://github.com/NixOS/nixpkgs/commit/1ab5ab5fca0f03881d3f356a03dd039c1212c4c9) xorg.libX11: 1.7.2 → 1.8.1
* [`267ef1f2`](https://github.com/NixOS/nixpkgs/commit/267ef1f2dee1baee4d5da59a1c669e1e4e08065f) gobject-introspection: wrapper: add .libs to LD_LIBRARY_PATH for emulator
* [`39bcbc32`](https://github.com/NixOS/nixpkgs/commit/39bcbc32f10b122aed3f402455af9d9b7e1e3290) libtiff: add patch for CVE-2022-2953
* [`190a5fe5`](https://github.com/NixOS/nixpkgs/commit/190a5fe56d08fe1474d3975f6c07dbede3d0a6d3) nix/boehmgc: Rebase patch
* [`a42926f2`](https://github.com/NixOS/nixpkgs/commit/a42926f2fe61dbba2d116955c07821f1c2f3dbd2) gobject-introspection: enable building doctool
* [`3284f4fa`](https://github.com/NixOS/nixpkgs/commit/3284f4fa19597828c778b1cc0b79cc1f6d06fef9) nixos/systemd-oomd: Add a new module + test
* [`23670076`](https://github.com/NixOS/nixpkgs/commit/2367007613f53172caedd0e958506b7f2fc3a36d) nixos/modules/installer/cd-dvd/channel.nix: pin nixpkgs registry to pkgs.path via boot.postBootCommands
* [`154a5538`](https://github.com/NixOS/nixpkgs/commit/154a55389c64dd28fc7c2c1a284a2e8b6cf7ba32) libstemmer: install and use snowball binary from buildPackages
* [`f1927d01`](https://github.com/NixOS/nixpkgs/commit/f1927d014edeea6322c159821cb78a6a82381be6) ninja: 1.11.0 -> 1.11.1
* [`3d1f96e1`](https://github.com/NixOS/nixpkgs/commit/3d1f96e1b4aecea4ebca6edb0627c5ddbc91ed7c) gobject-introspection: enable strictDeps and improve cross conditional
* [`4e2901d7`](https://github.com/NixOS/nixpkgs/commit/4e2901d7cbdbc5e536ac6507eb1218640ab6dde0) python310Packages.jsonschema: 4.13.0 -> 4.15.0
* [`7e626703`](https://github.com/NixOS/nixpkgs/commit/7e626703b0b892181cc1bc700d9b1cc88550243c) nixos/nullmailer: Always adjust ownership of spool directories
* [`8f40fcbb`](https://github.com/NixOS/nixpkgs/commit/8f40fcbb4cab70262f298070a68602288fcfc742) gobject-introspection: propagate self/targetself to avoid having to add gobject-introspection to buildInputs
* [`d4645efa`](https://github.com/NixOS/nixpkgs/commit/d4645efac056f348be418aaa3fc4f4e731617329) pdm: 1.14.0 -> 2.1.2
* [`f3ac787b`](https://github.com/NixOS/nixpkgs/commit/f3ac787b7a3734d6e6c3e252b4dc76438cbb303c) git: 2.37.2 -> 2.37.3
* [`1cf70d77`](https://github.com/NixOS/nixpkgs/commit/1cf70d770d189ff13248d8e99fed6c561139de24) nghttp3: 0.6.0 -> 0.7.0
* [`237da4a2`](https://github.com/NixOS/nixpkgs/commit/237da4a2c046b26f20614ae62b2b24fbfa759358) gtk4: fix cross
* [`0c61634a`](https://github.com/NixOS/nixpkgs/commit/0c61634ac9c9b77c5f00b3b529d048f5d50dc7c2) Re-Revert "Merge [nixos/nixpkgs⁠#188995](https://togithub.com/nixos/nixpkgs/issues/188995): bundler: 2.3.20 -> 2.3.21"
* [`6a378e9c`](https://github.com/NixOS/nixpkgs/commit/6a378e9c44064628234a1c783504f5a1ea833e11) binutils: 2.38 -> 2.39
* [`322e4d8f`](https://github.com/NixOS/nixpkgs/commit/322e4d8fa39af8fdd3f085313a4f2bec7b2bd6c0) graphene: build gir when cross
* [`24723644`](https://github.com/NixOS/nixpkgs/commit/24723644acd2d50aa30cd4d6829cc2d8949d5824) gsettings-desktop-schemas: build gir when cross
* [`a32cd711`](https://github.com/NixOS/nixpkgs/commit/a32cd711efe2b934b7a32b175f15ecba9962ba9b) gnome-tour: work towards fixing cross
* [`0f64ae72`](https://github.com/NixOS/nixpkgs/commit/0f64ae72eae13bff1d1d5d8b50ea6932c172a1ef) curl: 7.84.0 -> 7.85.0
* [`d1e2a371`](https://github.com/NixOS/nixpkgs/commit/d1e2a371f039a448806472664a0ac89ae8b89f49) nss: 3.68.4 -> 3.79.1
* [`e68c8e82`](https://github.com/NixOS/nixpkgs/commit/e68c8e82f12a42bc575ddd05b8a8e62b5924945d) poppler: enable tests
* [`27ff1af1`](https://github.com/NixOS/nixpkgs/commit/27ff1af1cbf21eb4e24f6d4ac3598bb3c986ba45) python3Packages.nose: fix cross-compiling
* [`1c93ab36`](https://github.com/NixOS/nixpkgs/commit/1c93ab362bc9c2a9275d7d2dd0a6268be86e495a) libxml2: 2.9.14 → 2.10.0
* [`16a84888`](https://github.com/NixOS/nixpkgs/commit/16a848885ebc8bdb02f0816df7c7d09d0457364a) libxslt: 1.1.35 → 1.1.36
* [`851e74a2`](https://github.com/NixOS/nixpkgs/commit/851e74a2f13aaceb448cf47aa0146ef993ebd202) libcamera: unstable-2022-07-15 -> unstable-2022-09-03
* [`092f4eb6`](https://github.com/NixOS/nixpkgs/commit/092f4eb681a6aee6b50614eedac74629cb48db23) pipewire: 0.3.56 -> 0.3.57
* [`6c6f4a97`](https://github.com/NixOS/nixpkgs/commit/6c6f4a97242017ada74071f947e6538d353d62b2) llvm*: Fix core usage in tests
* [`bd332c84`](https://github.com/NixOS/nixpkgs/commit/bd332c848c521de8cdaf664ce307e914c5e5987d) llvm*: Don't show progress bar on tests
* [`8e4f6b26`](https://github.com/NixOS/nixpkgs/commit/8e4f6b26e144ee1d8626141221c50c823f9f2cf1) jdupes: 1.20.2 -> 1.21.0
* [`72d2cd32`](https://github.com/NixOS/nixpkgs/commit/72d2cd3208e8e293f7addb115f001405f6aee74c) inetutils: add patch for CVE-2022-39028
* [`816cb20b`](https://github.com/NixOS/nixpkgs/commit/816cb20bd320714b17164ba950d82736578e9984) gcc12: switch to Homebrew patch on aarch64-darwin
* [`0856bf81`](https://github.com/NixOS/nixpkgs/commit/0856bf8144233a1209a3069179ce79d5e9f70781) glib: remove unnecessary substituteInPlace
* [`3f3f318a`](https://github.com/NixOS/nixpkgs/commit/3f3f318a6ba69e7d1453b02a5ed0c8ea1828c9ba) glib: fix paths of tests in sed
* [`1ea4a3ba`](https://github.com/NixOS/nixpkgs/commit/1ea4a3bab629f62ce28730c41a415076bd8c99f0) glib: fix tests by patching Python shebangs
* [`e1656e23`](https://github.com/NixOS/nixpkgs/commit/e1656e231c8352c56d8e78e916700ef98026a4c7) glib: move test substitutions into postPatch
* [`6b836517`](https://github.com/NixOS/nixpkgs/commit/6b836517dba469b8aea63c7317cd1ad3e4ae32f2) glib: skip g-file-info test if atime unsupported
* [`14adc917`](https://github.com/NixOS/nixpkgs/commit/14adc91759c0566ae6be8c659c7c708a706cdf7e) glib: unconditionally apply test patch
* [`2be1bcb3`](https://github.com/NixOS/nixpkgs/commit/2be1bcb3d2291d406a280d38860e42706e5bcf76) glib: use finalAttrs instead of rec
* [`d65d8002`](https://github.com/NixOS/nixpkgs/commit/d65d8002c7fbca2144fce2480a65bec36768da9a) glib.tests.withChecks: init
* [`6393cb76`](https://github.com/NixOS/nixpkgs/commit/6393cb765e0b6ee5fc57abb4fabaf4b58a7521e1) nixos/boot/stage-1-init: umount /findiso in stage-1
* [`81c37edc`](https://github.com/NixOS/nixpkgs/commit/81c37edce4ce14a25ff7b35cbd0e1cb22a48c401) glibcLocales: follow host platform endianness
* [`09df3d55`](https://github.com/NixOS/nixpkgs/commit/09df3d551527d858fe1a870c54f59942586c9d2e) nixos/i18n: use glibcLocales from the host packages
* [`269df4a6`](https://github.com/NixOS/nixpkgs/commit/269df4a6e5a393ab8ca2fb568812b2c3b8cba381) vulkan-sdk: 1.3.224.0 -> 1.3.224.1
* [`fef040af`](https://github.com/NixOS/nixpkgs/commit/fef040afae46c0471820ecfd0b3657b52096f167) binutils: restore `nm` autodetection on darwin
* [`8e00bc6e`](https://github.com/NixOS/nixpkgs/commit/8e00bc6e771c758dfdd0614faa56fdaa44334c87) neon: 0.32.2 -> 0.32.3
* [`d2fa4f8f`](https://github.com/NixOS/nixpkgs/commit/d2fa4f8f7a068fdc1544ecda039528c377a3385f) sqlite: 3.39.2 -> 3.39.3
* [`cdf358d2`](https://github.com/NixOS/nixpkgs/commit/cdf358d28c0b9672b9f256b0db6b60af52ba56fd) fluidsynth: 2.2.8 -> 2.2.9
* [`2f32fe9e`](https://github.com/NixOS/nixpkgs/commit/2f32fe9e6dc833fff338188621405bc32fbcda2b) vengi-tools: 0.0.20 -> 0.0.21
* [`7c0b72f4`](https://github.com/NixOS/nixpkgs/commit/7c0b72f40b6f2c7915d8877856b0735b76297e82) go_1_18: 1.18.5 -> 1.18.6
* [`da9a9a44`](https://github.com/NixOS/nixpkgs/commit/da9a9a440415b236f22f57ba67a24ab3fb53f595) treewide: cross fixes
* [`a52d95ac`](https://github.com/NixOS/nixpkgs/commit/a52d95ac10bda7b81383bac1c1f69d8ab1d6f842) libgnomekbd: fix cross and build introspection data
* [`b59f0138`](https://github.com/NixOS/nixpkgs/commit/b59f013860edef42fbabcb010932d4e2bb63d5f2) uhttpmock: fix cross
* [`740ebffd`](https://github.com/NixOS/nixpkgs/commit/740ebffd5a07ff07c96f03bdd6531c6110fc65a0) gobject-introspection: use lddtree instead of objdump as ldd wrapper
* [`61bffac9`](https://github.com/NixOS/nixpkgs/commit/61bffac9fa8efe418bcc3ba6bea9968bf56c52d6) zxing: fix paths in pkg-config file
* [`1554ab55`](https://github.com/NixOS/nixpkgs/commit/1554ab553bce931d0b4ab3b0415c6c937ea9d47d) gst_all_1.gst-plugins-bad: link with zxing-cpp
* [`2ddb8858`](https://github.com/NixOS/nixpkgs/commit/2ddb885824fafd5a188851aa92f253ba94f4cb13) spirv-tools: fix paths in pkg-config files
* [`aa473c64`](https://github.com/NixOS/nixpkgs/commit/aa473c6476da21135b8dc5b28298f451252f4aa0) libjxl: fix paths in pkg-config files
* [`10249211`](https://github.com/NixOS/nixpkgs/commit/10249211987c6f4231a3d02abb35b89e61f985de) wildmidi: fix paths in pkg-config file
* [`7baca962`](https://github.com/NixOS/nixpkgs/commit/7baca962de986c6635ab74a3e8cfcff8df7b875e) usrsctp: fix paths in pkg-config file
* [`869539e0`](https://github.com/NixOS/nixpkgs/commit/869539e07d199b1aacf583a360667401b00c3125) openalSoft: update homepage URL
* [`4f7b421c`](https://github.com/NixOS/nixpkgs/commit/4f7b421cc9be4cc12465ac59c549de72c29fbefe) openalSoft: fix paths in pkg-config file
* [`52938dde`](https://github.com/NixOS/nixpkgs/commit/52938dde0d15a662d5ef180ae8c7260a91173fe3) libebur128: fix paths in pkg-config file
* [`5b12efa3`](https://github.com/NixOS/nixpkgs/commit/5b12efa3f2480cbcc960755812e80ac177bfecf5) openobex: fix paths in pkg-config file
* [`ca049040`](https://github.com/NixOS/nixpkgs/commit/ca049040de130c77f671fef17442ab60da465c0b) ffmpegthumbnailer: fix path in pkg-config file
* [`5dedecfd`](https://github.com/NixOS/nixpkgs/commit/5dedecfd4c7e901ed492362b23a04aaa7575f49b) libmatroska: fix paths in pkg-config file
* [`a693b0cd`](https://github.com/NixOS/nixpkgs/commit/a693b0cda68d6e7ae0428cb16aba621ddcda75ce) extra-cmake-modules: fix paths in generated pkg-config files
* [`bb1d2fab`](https://github.com/NixOS/nixpkgs/commit/bb1d2fab3d2f967f567b247c2add781ed3ed3ecd) libebml: fix paths in pkg-config file
* [`d5ad233c`](https://github.com/NixOS/nixpkgs/commit/d5ad233c153b8060615f827d05d8dfedc8fb8c53) libargs: fix path in pkg-config file
* [`89f39f58`](https://github.com/NixOS/nixpkgs/commit/89f39f58e571a0b2a9ef356163a9e65eff9d1289) arrow-cpp: fix paths in CMake and pkg-config files
* [`427ae9a1`](https://github.com/NixOS/nixpkgs/commit/427ae9a1e147fe39385f6ac344e443a18623ba63) bcc: fix path in pkg-config file
* [`da6a9549`](https://github.com/NixOS/nixpkgs/commit/da6a95493f416883f2d6b33cbe2ee3c3305110e1) bcg729: fix path in pkg-config file
* [`3bf5a3ce`](https://github.com/NixOS/nixpkgs/commit/3bf5a3cecfe22d1a26662edad3e235a7cb2550e2) cglm: fix paths in pkg-config file
* [`6f1dd9a2`](https://github.com/NixOS/nixpkgs/commit/6f1dd9a2094588b518fdb455f062e48bc4b2e499) cm256cc: fix path in pkg-config file
* [`23fa3f2f`](https://github.com/NixOS/nixpkgs/commit/23fa3f2fde63f77e83c79cfffc1b5b48e5a4a7fc) cog: fix path in pkg-config file
* [`4f047072`](https://github.com/NixOS/nixpkgs/commit/4f047072ffdf1eb45ffafcd99dcbb461908f48ee) cxxopts: fix path in pkg-config file
* [`44acd934`](https://github.com/NixOS/nixpkgs/commit/44acd93456aa7365f492ca32c1a4fe45fb5a49cb) plasma5Packages.drumstick: fix paths in pkg-config files
* [`092a1ea9`](https://github.com/NixOS/nixpkgs/commit/092a1ea9ac519b0ac73d864561d84e20cecfb7fc) eccodes: fix paths in pkg-config files
* [`1c099469`](https://github.com/NixOS/nixpkgs/commit/1c09946985d1d496edb6d0652c7bcd3ce29be8f0) entt: fix path in pkg-config file
* [`499b90f3`](https://github.com/NixOS/nixpkgs/commit/499b90f3190f3cbaeb52ed487648a2c986882d8e) gbenchmark: fix paths in pkg-config file
* [`0035e659`](https://github.com/NixOS/nixpkgs/commit/0035e659fba980c695259743022fbd03fc58af28) getdns: fix paths in pkg-config file
* [`f2e74c16`](https://github.com/NixOS/nixpkgs/commit/f2e74c1616f6269d917626d20ba8a40ab270ad24) google-cloud-cpp: fix paths in pkg-config files
* [`7b77d68b`](https://github.com/NixOS/nixpkgs/commit/7b77d68bcf38fbb0eeb2b6651fb4c5eddbba4fe5) libbaseencode: fix paths in pkg-config file
* [`e1adfee0`](https://github.com/NixOS/nixpkgs/commit/e1adfee035b40429567d40b94165008264112e68) libbtbb: fix paths in pkg-config file
* [`d1f14fab`](https://github.com/NixOS/nixpkgs/commit/d1f14fab9be24b6170d129d2ea61482a0deba7de) libcork: fix paths in pkg-config file
* [`3bbc6d78`](https://github.com/NixOS/nixpkgs/commit/3bbc6d7842fcfeb8c575f9581e00e185229c2069) libcotp: fix paths in pkg-config file
* [`722cacf9`](https://github.com/NixOS/nixpkgs/commit/722cacf9ecec02c2aa3de9ba3b886f3be42ceedf) libdnf: fix path in pkg-config file
* [`ad67699d`](https://github.com/NixOS/nixpkgs/commit/ad67699dfbed5af771efc31c437188f198acfe1a) libkeyfinder: fix paths in pkg-config file
* [`34816092`](https://github.com/NixOS/nixpkgs/commit/3481609210ef2b0acedd16ba70bfd3effbc6c5a5) lxqt.lxqt-build-tools: fix paths in generated pkg-config files
* [`0fb6766c`](https://github.com/NixOS/nixpkgs/commit/0fb6766ccbaa1c030a562f782fcb0ff8f0133b5f) libmodule: fix paths in pkg-config file
* [`4c5e1c74`](https://github.com/NixOS/nixpkgs/commit/4c5e1c74aedd9aad74815fd292327c4b610b3bb1) libnats-c: fix path in pkg-config file
* [`50cee473`](https://github.com/NixOS/nixpkgs/commit/50cee473aeb5ffe959605fa5e492dcdf3675b42d) libquotient: fix paths in pkg-config file
* [`91bbd956`](https://github.com/NixOS/nixpkgs/commit/91bbd9567bf01dd3d9901d8ae3e43b88f48723e2) libsurvive: fix path in pkg-config file
* [`e7b9363c`](https://github.com/NixOS/nixpkgs/commit/e7b9363c99ad8f8fa0d9ae1e5adfc093340fd963) libtorrent-rasterbar: fix paths in pkg-config file
* [`c29cb15a`](https://github.com/NixOS/nixpkgs/commit/c29cb15ac1310a880c460aad94addd730685734a) libtsm: fix paths in pkg-config file
* [`4523fb56`](https://github.com/NixOS/nixpkgs/commit/4523fb567e5b6ac115537411db4c82759f8f2cd6) libunarr: fix paths in pkg-config file
* [`32e540e5`](https://github.com/NixOS/nixpkgs/commit/32e540e559b94443a90bec50c7c79be9cd0ed011) maliit-framework: fix paths in pkg-config files
* [`3e6abe1c`](https://github.com/NixOS/nixpkgs/commit/3e6abe1c777ff92888478aa7d31c81f91fabca44) mysocketw: fix path in pkg-config file
* [`e3d63b73`](https://github.com/NixOS/nixpkgs/commit/e3d63b734b8806b2e362429c04ba33c20efd9ec3) nanomsg: fix path in pkg-config file
* [`b3d98587`](https://github.com/NixOS/nixpkgs/commit/b3d98587484570717ca3401eaf0523fc08eaff31) notcurses: fix paths in pkg-config files
* [`96a487c3`](https://github.com/NixOS/nixpkgs/commit/96a487c3e650c59795cb7a7d960e930cb84f7bf1) obexftp: fix paths in pkg-config file
* [`c709dd4c`](https://github.com/NixOS/nixpkgs/commit/c709dd4c56996fe6f1a56aa1d11b2055612fad24) olm: fix paths in pkg-config file
* [`d6ad6c47`](https://github.com/NixOS/nixpkgs/commit/d6ad6c479343bdb50a06152861398ca2913101ea) opencolorio: fix path in pkg-config file
* [`8b387ff1`](https://github.com/NixOS/nixpkgs/commit/8b387ff166328edbbe8ca5759e79e8d74d94c68c) opendht: fix paths in pkg-config file
* [`cb3a81d1`](https://github.com/NixOS/nixpkgs/commit/cb3a81d16cfde6cddf3db3834440b7aee82a847d) openxr-loader: fix path in pkg-config file
* [`bf76af55`](https://github.com/NixOS/nixpkgs/commit/bf76af55353b160fab6c0af1f9cd424ddd36d977) orcania: fix paths in pkg-config file
* [`5c421079`](https://github.com/NixOS/nixpkgs/commit/5c4210793dde29b702a2c138f9567c89a0562e84) powercap: fix paths in pkg-config file
* [`ce8e6574`](https://github.com/NixOS/nixpkgs/commit/ce8e657451cd39c37f0a68669b5be08dc6b46101) proj: fix paths in CMake and pkg-config files
* [`00b52816`](https://github.com/NixOS/nixpkgs/commit/00b52816d85420ac4f91ad639dd25cea63740c7e) rabbitmq-c: fix paths in pkg-config file
* [`73f88f1d`](https://github.com/NixOS/nixpkgs/commit/73f88f1ddd5f058eeeb3234853989925fb9c2fa0) recastnavigation: fix paths in pkg-config file
* [`e0594214`](https://github.com/NixOS/nixpkgs/commit/e05942145d0374e5527bd40dc43a6d2b396dc4eb) reproc: fix paths in pkg-config files
* [`7a2593d3`](https://github.com/NixOS/nixpkgs/commit/7a2593d3c9e3c0fa635ef5cc8ee6b44996a0477c) rinutils: fix path in pkg-config file
* [`d5f218a2`](https://github.com/NixOS/nixpkgs/commit/d5f218a228a9406286dc34b4e522c987fa48be50) rnp: fix path in pkg-config file
* [`2e07f8a7`](https://github.com/NixOS/nixpkgs/commit/2e07f8a7bf0d4e3d57bd4521850baa2f3b7c92e1) rocm-thunk: fix paths in pkg-config file
* [`a6ef202b`](https://github.com/NixOS/nixpkgs/commit/a6ef202baf4bd11a09980c5125f09644fbf510a1) seexpr: fix path in pkg-config file
* [`18c0a8b1`](https://github.com/NixOS/nixpkgs/commit/18c0a8b1c51c53c8c6dcffc62863f6909eb2d425) sentencepiece: fix paths in pkg-config file
* [`02f6b12a`](https://github.com/NixOS/nixpkgs/commit/02f6b12ab18206c17fa9e2e5f4d7f5d7068450f9) shadowsocks-libev: fix paths in pkg-config files
* [`9d05c944`](https://github.com/NixOS/nixpkgs/commit/9d05c944628c016a9f0accb74aa35b22f46b5683) soapysdr: fix paths in pkg-config file
* [`2d03092f`](https://github.com/NixOS/nixpkgs/commit/2d03092f09013563e0076a6b813456117e41d23e) spdlog: fix path in pkg-config file
* [`ab2ace0b`](https://github.com/NixOS/nixpkgs/commit/ab2ace0b8c8410259bb2f48dab0c026440218a5a) spirv-headers: fix path in pkg-config file
* [`960e3c40`](https://github.com/NixOS/nixpkgs/commit/960e3c40c64f36dca6742363c92caff9f21f3c5a) tdlib: fix paths in pkg-config files
* [`347b676a`](https://github.com/NixOS/nixpkgs/commit/347b676aeb5fd563d51e646a2d145144099124fe) tinyobjloader: fix paths in pkg-config file
* [`89f5bb4d`](https://github.com/NixOS/nixpkgs/commit/89f5bb4d181cc55decbcb10be521de54b132fcc2) libbaseencode: 1.0.12 -> 1.0.14
* [`9b66b717`](https://github.com/NixOS/nixpkgs/commit/9b66b717b7514dc49e9c3fa3e1b7be28a9dbbc1d) libcotp: 1.2.4 -> 1.2.6
* [`6a0a4f94`](https://github.com/NixOS/nixpkgs/commit/6a0a4f9456acda5819a35ae1bb0a1f39d00acf32) xsimd: fix path in pkg-config file
* [`a2a8c38e`](https://github.com/NixOS/nixpkgs/commit/a2a8c38e1dcbb9cfc3ac693b8d839fa4c3f427c6) xtensor: fix path in pkg-config file
* [`00c23f46`](https://github.com/NixOS/nixpkgs/commit/00c23f460b99e55563f05175397982eea39b3c92) libzra: fix paths in pkg-config file
* [`e4544335`](https://github.com/NixOS/nixpkgs/commit/e4544335f5ae850dc2433c0906e20e3180e11dad) jdupes: fix darwin build
* [`6b6a8fe7`](https://github.com/NixOS/nixpkgs/commit/6b6a8fe7c0863e9b2c187e47c9d181010117bfe3) python310: 3.10.6 -> 3.10.7
* [`34182bc8`](https://github.com/NixOS/nixpkgs/commit/34182bc865ea34e2914e8c2817ce4c931a1936f9) python39: 3.9.13 -> 3.9.14
* [`24e4500f`](https://github.com/NixOS/nixpkgs/commit/24e4500fcdf39a17c723f2352de6a439181e044d) libid3tag: fix cross compile
* [`3a6d60dc`](https://github.com/NixOS/nixpkgs/commit/3a6d60dcafa96fc1ff7e0c5af1d20b1aa336e5e1) mpd: fix cross compile
* [`a6c3003f`](https://github.com/NixOS/nixpkgs/commit/a6c3003f34bba763dc3ace21e07bc0dcf9140319) coreutils: Skip another test that fails on btrfs
* [`36431022`](https://github.com/NixOS/nixpkgs/commit/36431022b19df245e8e3a37de2487902c1563c8a) libiio: 0.21 -> 0.23
* [`08796acf`](https://github.com/NixOS/nixpkgs/commit/08796acf8062881607fa93c9afbb32d5315b795a) python310Packages.nose: cleanup
* [`47827683`](https://github.com/NixOS/nixpkgs/commit/478276838a689d3a48c0a8dbb3707f961bc1d35d) unvanquished: 0.53.1 -> 0.53.2
* [`b1149dc3`](https://github.com/NixOS/nixpkgs/commit/b1149dc3031fc7d0994ae990f495a27a490725d8) cmake: add check-pc-files hook to check broken pc files
* [`c9b34f76`](https://github.com/NixOS/nixpkgs/commit/c9b34f760175584e0e77cd84fa2b97e0f060b57d) treewide: remove unnecessary cmake pkg-config patchs
* [`68310af1`](https://github.com/NixOS/nixpkgs/commit/68310af1075f4b8f00736a49839032847987506f) numactl: 2.0.14 -> 2.0.15
* [`b87e290e`](https://github.com/NixOS/nixpkgs/commit/b87e290ebe0af11acaac5b22c91a07ed8bda545a) clj-kondo: 2022.08.03 -> 2022.09.08
* [`27d08a0b`](https://github.com/NixOS/nixpkgs/commit/27d08a0bd35aa7124f548fb144a7442421e50088) python310Packages.jsonschema: 4.15.0 -> 4.16.0
* [`b51b1f1e`](https://github.com/NixOS/nixpkgs/commit/b51b1f1e9dc499485d47281b8b36a85f0c196076) bundler: 2.3.21 -> 2.3.22
* [`52004247`](https://github.com/NixOS/nixpkgs/commit/520042472c5b150838adceff26be93076f214552) python3Packages.Mako: 1.2.1 -> 1.2.2
* [`a2448e35`](https://github.com/NixOS/nixpkgs/commit/a2448e354a9ff91b1c501fd1b8e2984ca7d36aef) python3Packages.sqlalchemy: 1.4.40 -> 1.4.41
* [`9aed7b7c`](https://github.com/NixOS/nixpkgs/commit/9aed7b7cbb3097961c92a7bb818c5b63a629485f) python3Packages.oauthlib: 3.2.0 -> 3.2.1
* [`4795707c`](https://github.com/NixOS/nixpkgs/commit/4795707c9aaa0760eaf24172982ce6fb94a0c7f2) lirc: fix cross compile
* [`fe87f6ee`](https://github.com/NixOS/nixpkgs/commit/fe87f6ee53bd8093fce5b4a7dcfbf9f4d9f9204b) multitail: 6.5.0 -> 6.5.2
* [`c7422183`](https://github.com/NixOS/nixpkgs/commit/c74221839b5e20a1260a77a9823ab7d3d9d1a5fa) temurin-bin, semeru-bin: init at 17.0.3, adoptopenjdk-bin: remove 13, 14, 17
* [`58c0dece`](https://github.com/NixOS/nixpkgs/commit/58c0decef2cfd4c8040fa8ec2559d27fffbb9b7b) libbfd: add CC_FOR_BUILD into depends
* [`f878b256`](https://github.com/NixOS/nixpkgs/commit/f878b256329b12b894e799f43f40e7e19e405408) nspr: 4.34.1 -> 4.35
* [`adbc59c9`](https://github.com/NixOS/nixpkgs/commit/adbc59c9d3b6be2cdb1c29b84afa8b30d9cc7593) buildPython*: store dist (wheel/sdist) in dist output
* [`5f9e6b82`](https://github.com/NixOS/nixpkgs/commit/5f9e6b829c51bc09b4b3bbe44b9ffc4f2d1cb03b) pkgsMusl.iproute2: fix build ([nixos/nixpkgs⁠#190957](https://togithub.com/nixos/nixpkgs/issues/190957))
* [`2444caed`](https://github.com/NixOS/nixpkgs/commit/2444caed5af0e535220faf19929bc7b969cf35c1) systemd: set withTpm2Tss and withUserDb to true on musl ([nixos/nixpkgs⁠#191030](https://togithub.com/nixos/nixpkgs/issues/191030))
* [`13bb0f49`](https://github.com/NixOS/nixpkgs/commit/13bb0f49f7afe8296452d70e7782ac1d67b064da) buildPython*: wrap setuptools in hook for catching conflicts
* [`198e56fa`](https://github.com/NixOS/nixpkgs/commit/198e56fa7858ce15e4061f4fe0fc1e14f4a7afc1) vdrPlugins.markad: 2.0.4 -> 3.0.25
* [`dd145a16`](https://github.com/NixOS/nixpkgs/commit/dd145a16d6382aacdc527d375b82c1bfe8927a71) python310Packages.jsonschema: remove patch
* [`4c510f32`](https://github.com/NixOS/nixpkgs/commit/4c510f32feb018050c85868b176cac91a5363d65) file: 5.42 -> 5.43
* [`e04d1ff7`](https://github.com/NixOS/nixpkgs/commit/e04d1ff7a96a06e4e1c3d6d5ec29f34ca003da82) python3Packages.pdm-pep517: add 'setuptools' test depend
* [`2443294b`](https://github.com/NixOS/nixpkgs/commit/2443294b32c667fc2d922177bce0168ae2165bbf) tortoisehg: 6.1->6.2.2
* [`48bf1dd7`](https://github.com/NixOS/nixpkgs/commit/48bf1dd780a71096ef93ed2373e087ec6cba1351) pipewire: 0.3.57 -> 0.3.58
* [`4ddd0b37`](https://github.com/NixOS/nixpkgs/commit/4ddd0b379a0249ed0b017c01627636d7c10b5136) python3Packages.mypy: add setuptools as native build input
* [`d0688973`](https://github.com/NixOS/nixpkgs/commit/d0688973477c89dbfcce20f046d0318903abecaa) python3Packages.pdm-pep517: add missing setuptools test dependency
* [`df6feb4c`](https://github.com/NixOS/nixpkgs/commit/df6feb4c08a00a90a0dc37b3feba49c49bad4b27) python3Packages.numpy: fix format and folder to run tests in
* [`3eed5434`](https://github.com/NixOS/nixpkgs/commit/3eed54349f1d6db1a7046088c3feb574f974e358) python2Packages.numpy: fix format and folder ests are run in
* [`fdd87f11`](https://github.com/NixOS/nixpkgs/commit/fdd87f1121e680cb68cf56d5d88c74fde3e9a5f6) python3Packages.scipy: fix folder tests are run in
* [`12d64e04`](https://github.com/NixOS/nixpkgs/commit/12d64e041b4f97e936a560fe624695a57d8338f3) nixos/networking: add a suggestion to use networkd options
* [`161f8174`](https://github.com/NixOS/nixpkgs/commit/161f8174b0adedcea1fbf07f32275db97d4e6905) python2Packages.numpy: don't use setuptools hook
* [`53614025`](https://github.com/NixOS/nixpkgs/commit/53614025a90064e53346b36a4a235520eab6e8be) python3Packages.semver: don't try to remove dist folder
* [`40d29622`](https://github.com/NixOS/nixpkgs/commit/40d29622590938bac1fc66e698f29917f452a7ee) python3Packages.archinfo: add missing setuptools dependency
* [`8b101bac`](https://github.com/NixOS/nixpkgs/commit/8b101bac4a86c501c40f323516985bab689f36f2) python3Packages.autopage: add missing setuptools dep
* [`699eaf86`](https://github.com/NixOS/nixpkgs/commit/699eaf8646fca3eaa1a1c57c31b32931b1cef8b7) python3Packages.bleak: add setuptools as dep
* [`370cce6a`](https://github.com/NixOS/nixpkgs/commit/370cce6a3c65c026f80c4861c7c80ab60edc7f2a) python3Packages.cvise: fix build after moving dist folder
* [`fe4ffc09`](https://github.com/NixOS/nixpkgs/commit/fe4ffc0988d2a1468e90b60192dd5f9b0474d09c) python3Packages.build: uses setuptools instead of flit as build system
* [`ceb78d53`](https://github.com/NixOS/nixpkgs/commit/ceb78d53dc6dd9d49ce7c38fe445d9391dccb574) python3Packages.claripy: fix build needing setuptools
* [`029b261f`](https://github.com/NixOS/nixpkgs/commit/029b261fb3531d9d1f63bc8b1d724acddf600691) python3Packages.cwcwidth: fix build needing setuptools
* [`f02c89bf`](https://github.com/NixOS/nixpkgs/commit/f02c89bfd23b1403ae9245c78017e710f4f22e1f) python3Packages.poetry-core: add missing setuptools test dep
* [`373feb46`](https://github.com/NixOS/nixpkgs/commit/373feb46cffabdbf76079789c1b60f2ebf8ba87e) nixos: Only use compatible kernels for ZFS tests
* [`d8d7fe93`](https://github.com/NixOS/nixpkgs/commit/d8d7fe93199126ca6a1e4d4e0f31059a96c51f26) python3Packages.exdown: add setuptools to nativeBuildInputs
* [`4fb1130b`](https://github.com/NixOS/nixpkgs/commit/4fb1130b71f8e728ea15a0cc55613d36c14a9d31) python3Packages.http-parser: add setuptools to nativeBuildInputs
* [`1d20d677`](https://github.com/NixOS/nixpkgs/commit/1d20d67783f7eb4a73d0e311f819c64e528dbeac) python2Packages.pygtk: format should be other
* [`3e2f9a09`](https://github.com/NixOS/nixpkgs/commit/3e2f9a09b6dde94fb0221b3f1f945aa8dcfe15b1) python3Packages.goodwe: add setuptools to nativeBuildInputs
* [`e6606bcb`](https://github.com/NixOS/nixpkgs/commit/e6606bcb009fc218fd8fad4311d956b2494d4b51) python3Packages.mdformat: add setuptools to nativeBuildInputs
* [`28040cdb`](https://github.com/NixOS/nixpkgs/commit/28040cdbe30a67ddcb4b43723b7a23da3ed1667b) python3Packages.dunamai: add setuptools to checkInputs
* [`f6ddcc36`](https://github.com/NixOS/nixpkgs/commit/f6ddcc36b475d9fa4d5266354c26d3a2e947d6ce) python3Packages.pg8000: add setuptools to nativeBuildInputs
* [`e78b9c81`](https://github.com/NixOS/nixpkgs/commit/e78b9c8116d7b87fbde83064c6aa770603db14d5) python3Packages.pypng: add setuptools to nativeBuildInputs
* [`e07d2186`](https://github.com/NixOS/nixpkgs/commit/e07d2186dc4ef230f902bb767106d9118615414d) python3Packages.teletype: add setuptools to nativeBuildInputs
* [`9fa36b4a`](https://github.com/NixOS/nixpkgs/commit/9fa36b4ab21e87957af3c352da0e384f8673458e) python3Packages.json-stream: add setuptools to nativeBuildInputs
* [`58064e42`](https://github.com/NixOS/nixpkgs/commit/58064e424c2c817227e69e3e226f839c81e254cd) python3Packages.aiomusiccast: propagate setuptools
* [`20b9217e`](https://github.com/NixOS/nixpkgs/commit/20b9217e2f6726d98b476b91331be8758aef2938) python3Packages.aiosenz: add setuptools to nativeBuildInputs
* [`33c34bea`](https://github.com/NixOS/nixpkgs/commit/33c34beac0d67761f058796941c3a95e0bc169d6) python3Packages.pyrituals: add setuptools to nativeBuildInputs
* [`5ad59cba`](https://github.com/NixOS/nixpkgs/commit/5ad59cbaa32416d55e3dbc0b2b15c3133b381e73) python3Packages.peco: add setuptools to nativeBuildInputs
* [`b0e6efd3`](https://github.com/NixOS/nixpkgs/commit/b0e6efd39d498ff53031c036ff864001ad205fd3) python3Packages.pylutron-caseta: add setuptools to nativeBuildInputs
* [`6c931b25`](https://github.com/NixOS/nixpkgs/commit/6c931b258b97ceae5569b7d85f984c377be11147) python3Packages.homeconnect: add setuptools to nativeBuildInputs
* [`9426aa38`](https://github.com/NixOS/nixpkgs/commit/9426aa38d096990e5518d1fba9f96a590a215bcf) python3Packages.py-canary: add setuptools to nativeBuildInputs
* [`8b2674fa`](https://github.com/NixOS/nixpkgs/commit/8b2674fab167d659a3b7c89cde6138dfb0a1a354) python3Packages.aurorapy: add setuptools to nativeBuildInputs
* [`157f5a4d`](https://github.com/NixOS/nixpkgs/commit/157f5a4d75ff310a563264c647839d013b0b58da) python3Packages.python-vagrant: add setuptools to nativeBuildInputs
* [`cbcd8e2c`](https://github.com/NixOS/nixpkgs/commit/cbcd8e2cc40cab35f69da348a01ea3b260f72953) python3Packages.toposort: add setuptools to nativeBuildInputs
* [`f58ad05a`](https://github.com/NixOS/nixpkgs/commit/f58ad05a042fd75f5542740a73f607bf87ecb3a5) python3Packages.simpleeval: add setuptools to nativeBuildInputs
* [`617ed473`](https://github.com/NixOS/nixpkgs/commit/617ed4733ba5a6923637cbabbe60115eb21b9c0c) python3Packages.desktop-notifier: add setuptools to nativeBuildInputs
* [`f1b5f555`](https://github.com/NixOS/nixpkgs/commit/f1b5f555561f80d26218004c9bd26425adce7d58) python3Packages.scmrepo: add setuptools to nativeBuildInputs
* [`e54e3658`](https://github.com/NixOS/nixpkgs/commit/e54e365857e1671ca144ba420b0b5244f4c28e5a) python3Packages.rpi-bad-power: add setuptools to nativeBuildInputs
* [`a30bb4c6`](https://github.com/NixOS/nixpkgs/commit/a30bb4c64a63f093a6cc3db11b773f62523de17f) python3Packages.aioaseko: add setuptools to nativeBuildInputs
* [`074c3166`](https://github.com/NixOS/nixpkgs/commit/074c316654327ce8434ed5dbb6fcc18a51c7a4b6) python3Packages.bitlist: add setuptools to nativeBuildInputs
* [`7e1912c9`](https://github.com/NixOS/nixpkgs/commit/7e1912c9b0ff8c0799557b2be0e9abff136195e5) python3Packages.pyeapi: add setuptools to nativeBuildInputs
* [`86e73676`](https://github.com/NixOS/nixpkgs/commit/86e73676233f6eae23b5115a6752a77cf6da5fdf) python3Packages.python-pam: add setuptools to nativeBuildInputs
* [`9d8964ac`](https://github.com/NixOS/nixpkgs/commit/9d8964ac4fa02be5f8a2c3caabf8c86ce7fe9068) python3Packages.matrix-common: add setuptools to nativeBuildInputs
* [`6cebc6e1`](https://github.com/NixOS/nixpkgs/commit/6cebc6e11684ded7a63d25f7e2868c4a870f9f7a) python3Packages.av: add setuptools to nativeBuildInputs
* [`faf6ac66`](https://github.com/NixOS/nixpkgs/commit/faf6ac661d546b539e6805fe5be7ef9ebe61281b) python3Packages.pyvex: add setuptools to nativeBuildInputs
* [`a7854ae9`](https://github.com/NixOS/nixpkgs/commit/a7854ae9327b0dfda04668b4ef1fd0e7b51c53b3) python3Packages.falcon: add setuptools to nativeBuildInputs
* [`f0327dff`](https://github.com/NixOS/nixpkgs/commit/f0327dffbe601e0268136fe0722e8872bee6c797) python3Packages.pytest-test-utils: add setuptools to nativeBuildInputs
* [`3302f623`](https://github.com/NixOS/nixpkgs/commit/3302f623d60485e7612d57e720a0d94542436a33) python3Packages.shellingham: add setuptools to nativeBuildInputs
* [`7ea64155`](https://github.com/NixOS/nixpkgs/commit/7ea64155e74faab815f865ca5f8eb14cc6b33588) python3Packages.fasteners: add setuptools to nativeBuildInputs
* [`46445f00`](https://github.com/NixOS/nixpkgs/commit/46445f00a9c09166cb4a2b6f79ec10c766375fa7) python310Packages.parts: add setuptools to nativeBuildInputs
* [`68380d60`](https://github.com/NixOS/nixpkgs/commit/68380d60446c06c6c0e2328dc6ee05fa4438ba2c) python3Packages.portpicker: add setuptools to nativeBuildInputs
* [`f75bb52d`](https://github.com/NixOS/nixpkgs/commit/f75bb52d8e82eac47f715d431ce55f19da1b637e) python3Packages.tensorboard-plugin-profile: add setuptools
* [`32a0abe4`](https://github.com/NixOS/nixpkgs/commit/32a0abe40cc19a170299f7802f1e4592f37dee50) python310Packages.mistune: add setuptools to nativeBuildInputs
* [`014bb5cb`](https://github.com/NixOS/nixpkgs/commit/014bb5cb7da61c92ec094171e0e1cace46d219cb) python3Packages.mdit-py-plugins: add setuptools to nativeBuildInputs
* [`b73038be`](https://github.com/NixOS/nixpkgs/commit/b73038be33e2f1b8bcfbf135d4f993149e45075e) python3Packages.python-gnupg: add setuptools to nativeBuildInputs
* [`d9a9dcca`](https://github.com/NixOS/nixpkgs/commit/d9a9dcca20f43d793dce231536f1e9b9ef094d33) gnupg: add withPcsc flag to disable PC/SC support
* [`d9522aa4`](https://github.com/NixOS/nixpkgs/commit/d9522aa4c57999f0034ef9ce699e80c5e32b48c0) python3Packages.gevent: add setuptools to nativeBuildInputs
* [`6a851472`](https://github.com/NixOS/nixpkgs/commit/6a851472f226f63eb8b886cbe5f214428b6bd282) python3Packages.astor: disabled failing test
* [`6141f3cf`](https://github.com/NixOS/nixpkgs/commit/6141f3cfde2bde6de7886637bb7cb2397edc5f4b) distrobox: 1.4.0 -> 1.4.1
* [`c221631c`](https://github.com/NixOS/nixpkgs/commit/c221631cee8e8a19bfbc631c4c180aa0158c71e0) python3Packages.pyqt5: add setuptools
* [`339e2e25`](https://github.com/NixOS/nixpkgs/commit/339e2e25d2998d1ebc3d4cfed39a811af6acc68e) multitail: 6.5.2 -> 7.0.0
* [`9f13bd89`](https://github.com/NixOS/nixpkgs/commit/9f13bd89e026915f2add6e8abfbd2eb8d1a25df2) jsonmerge: skip failed tests
* [`dab125e1`](https://github.com/NixOS/nixpkgs/commit/dab125e1a34e44001de042e90357894c91b8c540) ceph-csi: 3.7.0 -> 3.7.1
* [`a1bad743`](https://github.com/NixOS/nixpkgs/commit/a1bad74390af6504969b0e40f4dba1a2d2ecb1ac) glslang: fixup paths in .pc files
* [`b00a475d`](https://github.com/NixOS/nixpkgs/commit/b00a475d624a1d80289245e7922c5b6607e79f89) ubidump: use format other and propagate setuptools
* [`88373b39`](https://github.com/NixOS/nixpkgs/commit/88373b3900b890ea00b8bd38dd4007112eaa2b9b) steck: add setuptools to nativeBuildInputs
* [`872a77c5`](https://github.com/NixOS/nixpkgs/commit/872a77c58e51174c4cc289043516fcd0a6308f8f) python3Packages.widgetsnbextension: add setuptools to nativeBuildInputs
* [`54438385`](https://github.com/NixOS/nixpkgs/commit/544383852c5de6da03b09672507cb8cc8d3ad260) python3Packages.pandoc-xnos: add setuptools to nativeBuildInputs
* [`9bb71c71`](https://github.com/NixOS/nixpkgs/commit/9bb71c7136d5ad2d2bac0eddf3f505b373f5a13f) python3Packages.py-tree-sitter: add setuptools to nativeBuildInputs
* [`81eb7083`](https://github.com/NixOS/nixpkgs/commit/81eb7083e799d39572a85a4c10c6b036d98a3421) python3Packages.labmath: add setuptools to nativeBuildInputs
* [`ef24b1fc`](https://github.com/NixOS/nixpkgs/commit/ef24b1fc55d0f995bb6a463905c7bb3c73108ee0) python3Packages.http-sfv: add setuptools to nativeBuildInputs
* [`00ae3641`](https://github.com/NixOS/nixpkgs/commit/00ae36410a6209f34055e4eca97940eafaab2600) python3Packages.headerparser: add setuptools to nativeBuildInputs
* [`1751da91`](https://github.com/NixOS/nixpkgs/commit/1751da9129b941e51abc5ead9c365fb6da68ec05) asciinema: add setuptools to nativeBuildInputs
* [`00c4064a`](https://github.com/NixOS/nixpkgs/commit/00c4064a792ddee3201cf1f89ecacd1949bbd707) python3Packages.pytesseract: add setuptools to nativeBuildInputs
* [`52277c1e`](https://github.com/NixOS/nixpkgs/commit/52277c1e0af1822d279ec0f2306da8ba51526e0d) kcov: pull upstream port to binutils-2.39
* [`1aba4df6`](https://github.com/NixOS/nixpkgs/commit/1aba4df60dda9cd5041bdc4831e88bef399c2d7d) python3Packages.tzdata: add setuptools to nativeBuildInputs
* [`cc47efce`](https://github.com/NixOS/nixpkgs/commit/cc47efce231f4e9131b81b1fe705d58e138d5613) darwin.xattr: add setuptools
* [`f2374557`](https://github.com/NixOS/nixpkgs/commit/f2374557b1c9f13b99ba06ee1f78a019ada8d591) python3Packages.isort: add setuptools
* [`e100b746`](https://github.com/NixOS/nixpkgs/commit/e100b7462775b418ccf8c4dc3aa427d9acb56f82) buildDotnetModule: format with nixpkgs-fmt
* [`a7c598e4`](https://github.com/NixOS/nixpkgs/commit/a7c598e458183b30a7218f3b1301a689b39a6542) buildDotnetModule: minor changes to hooks
* [`03a1b62c`](https://github.com/NixOS/nixpkgs/commit/03a1b62cb38cf6a60c496c896dbdccd4e4d9b03a) buildDotnetModule: dont require specifing a projectFile
* [`8e00d6ac`](https://github.com/NixOS/nixpkgs/commit/8e00d6ac269e87705141f817f619d82cf45b6e24) buildDotnetModule: move nugetDeps throw to when its actually needed
* [`4a8eb528`](https://github.com/NixOS/nixpkgs/commit/4a8eb528bee9c9b76f5b3400b684bdb6ac83661e) buildDotnetModule: add the option to keep sources to fetch-deps
* [`0b0b187d`](https://github.com/NixOS/nixpkgs/commit/0b0b187d1281f3dc7f4ed9796a9d23e4bb9060f5) influxdb2-server: 2.1.1 -> 2.4.0
* [`b67f292e`](https://github.com/NixOS/nixpkgs/commit/b67f292eb3d083c6ea16e2adbc012fa19a29b68b) saleae-logic-2: 2.3.59 -> 2.4.0
* [`e7ff7d64`](https://github.com/NixOS/nixpkgs/commit/e7ff7d64032aa147eac92a6b6ffdbd5238c1f6b6) fixup! glslang: fixup paths in .pc files
* [`038edcf9`](https://github.com/NixOS/nixpkgs/commit/038edcf9a5c71a7639c0cac45ee4d4f7e86a50f9) shaderc: fixup paths in .pc files
* [`b97580ff`](https://github.com/NixOS/nixpkgs/commit/b97580ffa2409a11a9a51027d0906b283f0402ce) gixy: fix overriden pyparsing by passing setuptools
* [`1655d5ab`](https://github.com/NixOS/nixpkgs/commit/1655d5ab7a7a259f53393a369459ff533fcce9e6) nixos/rust-motd: fix systemd service checks
* [`3acd5782`](https://github.com/NixOS/nixpkgs/commit/3acd57825e2f4f887318d3e20a7759e7c571065a) python3Packages.javaproperties: add setuptools to nativeBuildInputs
* [`dcd21563`](https://github.com/NixOS/nixpkgs/commit/dcd21563ad39bfce978b00546f8fb5fa8a67b7dd) python3Packages.pytz-deprecation-shim: add setuptools to nativeBuildInputs
* [`f3b29870`](https://github.com/NixOS/nixpkgs/commit/f3b298708e2f18dd06daf4ff6567dd7df6ed15f1) python3Packages.setuptools: 63.2.0 -> 65.3.0
* [`2686f778`](https://github.com/NixOS/nixpkgs/commit/2686f7782e78c5d22cfea56fbe9f9be7d392f45a) python3Packages.pip: 22.1.2 -> 22.2.2
* [`a89d7bfe`](https://github.com/NixOS/nixpkgs/commit/a89d7bfe17b5c39f62c6304e6256f9b8a48c9159) python3Packages.poetry-core: 1.0.8 -> 1.1.0
* [`0fcb93d8`](https://github.com/NixOS/nixpkgs/commit/0fcb93d85a12fe5ba86a47ee44e0f7dafe7ac0e4) python3Packages.pytest: 7.1.2 -> 7.1.3
* [`66c62423`](https://github.com/NixOS/nixpkgs/commit/66c6242371a9fdfe686ebb32b566fd57fa76d5b3) python3Packages.hypothesis: 6.50.1 -> 6.54.5
* [`c6d042ea`](https://github.com/NixOS/nixpkgs/commit/c6d042ea3692f184f81b10e6d743adc343e03d52) python3Packages.exceptiongroup: 1.0.0rc8 -> 1.0.0rc9
* [`d7977ef9`](https://github.com/NixOS/nixpkgs/commit/d7977ef9e9f3c66e9c025af48db8d680e3bab62a) python3Packages.numpy: 1.23.1 -> 1.23.3
* [`7f310b50`](https://github.com/NixOS/nixpkgs/commit/7f310b505ccd7a41f2549bf40a746357a8f5a972) python3Packages.orjson: 3.7.12 -> 3.8.0
* [`eed7179c`](https://github.com/NixOS/nixpkgs/commit/eed7179cd728f3380081925b87fa5236c22a09a5) python3Packages.cryptography: 37.0.4 -> 38.0.1
* [`3038f171`](https://github.com/NixOS/nixpkgs/commit/3038f1715dbfa21b5b786ccc0083bec9fd3acec0) python3Packages.poetry-plugin-export: init at 1.0.6
* [`abebdcdd`](https://github.com/NixOS/nixpkgs/commit/abebdcdd59f0d18104ed15f7397625835994e1d8) python3Packages.cleo: 0.8.1 -> 1.0.0a5
* [`eeaaa453`](https://github.com/NixOS/nixpkgs/commit/eeaaa4536ebb9347d9cca4ab53c542fd89060a9b) python3Packages.shellingham: 1.4.0 -> 1.5.0
* [`b465fcfe`](https://github.com/NixOS/nixpkgs/commit/b465fcfef3fdbace3f6e3d5a27a4b5833a71b7fe) python3Packages.cython: 0.29.30 -> 0.29.32
* [`f1ebf775`](https://github.com/NixOS/nixpkgs/commit/f1ebf7751e2ab62dfea5cdb7f51fc9fe06111c06) python3Packages.pandas: 1.4.3 -> 1.4.4
* [`f63960a8`](https://github.com/NixOS/nixpkgs/commit/f63960a83ef4acf8ab01785bd04bd7372cca5998) python3Packages.clevercsv: 0.7.1 -> 0.7.4
* [`bb1864a8`](https://github.com/NixOS/nixpkgs/commit/bb1864a88a72058773449d909a5738c4b77901c0) python3Packages.dulwich: 0.20.45 -> 0.20.46
* [`f2a71e95`](https://github.com/NixOS/nixpkgs/commit/f2a71e956b04db5cd94fff527c4bb780ee8dde8a) python3Packages.poetry: 1.1.14 -> 1.2.0
* [`3b269688`](https://github.com/NixOS/nixpkgs/commit/3b269688f14f4b6f154fc53cbb2a5daff9a40f6a) python3Packages.cython_3: 3.0.0a10 -> 3.0.0a11
* [`d4c59450`](https://github.com/NixOS/nixpkgs/commit/d4c5945064970dd51601bd73c74b7b3be811d4f0) python3Packages.sphinxcontrib-asyncio: init at 0.3.0
* [`22217650`](https://github.com/NixOS/nixpkgs/commit/22217650964394fa87c36d2845386a34c989de39) python3Packages.dbus-fast: init at 1.4.0
* [`ee0ba2e1`](https://github.com/NixOS/nixpkgs/commit/ee0ba2e1d8f20658af21ba79358da0955efbd580) python3Packages.bleak: 0.16.0 -> 0.17.0
* [`7e7a2ddd`](https://github.com/NixOS/nixpkgs/commit/7e7a2ddd218b0c30e1a767a70520489b996122b7) python3Packages.bleak-retry-connector: 1.11.0 -> 1.16.0
* [`91f51360`](https://github.com/NixOS/nixpkgs/commit/91f513601decbbc26d307dc3aacfaf50f4cd3165) python3Packages.pyswitchbot: 0.18.27 -> 0.19.8
* [`ea569071`](https://github.com/NixOS/nixpkgs/commit/ea569071ad80a9ab679d995621e9e1a6273ce7fb) python3Packages.scipy: 1.8.1 -> 1.9.1
* [`a26911d0`](https://github.com/NixOS/nixpkgs/commit/a26911d0cba282214e57177afad9c6efe6c6a047) python3Packages.uvloop: 0.16.0 -> 0.17.0
* [`9623e1d0`](https://github.com/NixOS/nixpkgs/commit/9623e1d07a64c5ee2bbca7c1ef8ef6283ed05262) python3Packages.absl-py: 1.1.0 -> 1.2.0
* [`665b1784`](https://github.com/NixOS/nixpkgs/commit/665b17847a0dba1c9d2fd4ea9aeec46fc7ccbd1f) python3Packages.aeppl: 0.0.33 -> 0.0.35
* [`feeeab92`](https://github.com/NixOS/nixpkgs/commit/feeeab92637e96e15ab0091709fa5462ff89051b) python3Packages.aesara: 2.7.9 -> 2.8.4
* [`246216e5`](https://github.com/NixOS/nixpkgs/commit/246216e599eefe157169d2deaec801206fd735d8) python3Packages.afdko: 3.9.0 -> 3.9.1
* [`d4579920`](https://github.com/NixOS/nixpkgs/commit/d4579920f807231bdc73201c8838ffc1d28eb325) python3Packages.aiobotocore: 2.3.4 -> 2.4.0
* [`53c0dcf2`](https://github.com/NixOS/nixpkgs/commit/53c0dcf2d38b51ff2ddb29b25cae533f7b9f828d) python3Packages.aioserial: 1.3.0 -> 1.3.1
* [`73ddd627`](https://github.com/NixOS/nixpkgs/commit/73ddd6270127e65a509c05649d80be29e2cc5f3f) python3Packages.aliyun-python-sdk-cdn: 3.7.2 -> 3.7.4
* [`d8472b92`](https://github.com/NixOS/nixpkgs/commit/d8472b9205d2353236024f395a0564ddd081c0bc) python3Packages.aliyun-python-sdk-iot: 8.42.0 -> 8.43.0
* [`ca8e47fb`](https://github.com/NixOS/nixpkgs/commit/ca8e47fba0ddc327b15f54afb26421f03156ee2d) python3Packages.ansible: 6.2.0 -> 6.3.0
* [`bc6e37cb`](https://github.com/NixOS/nixpkgs/commit/bc6e37cbf4adb493c46b87b761d2d40fca1bf51b) python3Packages.ansible-lint: 6.4.0 -> 6.5.2
* [`b13af2a0`](https://github.com/NixOS/nixpkgs/commit/b13af2a001ffd6f90d16ad88610e93032607fa94) python3Packages.arrow: 1.2.2 -> 1.2.3
* [`f2816124`](https://github.com/NixOS/nixpkgs/commit/f2816124016cc043ffc0e7684ca31816c71d2426) python3Packages.asttokens: 2.0.5 -> 2.0.8
* [`a3b847e5`](https://github.com/NixOS/nixpkgs/commit/a3b847e55241d32224dbd5439b1b518d92fe9ef2) python3Packages.atpublic: 3.0.1 -> 3.1.1
* [`fbf427f1`](https://github.com/NixOS/nixpkgs/commit/fbf427f1de47d90a91316b4b97561dc2e6b7fcc2) python3Packages.autobahn: 22.6.1 -> 22.7.1
* [`9595c927`](https://github.com/NixOS/nixpkgs/commit/9595c927ab1dca1e0fb6d596e0cea1654655fd3c) python3Packages.autopep8: 1.6.0 -> 1.7.0
* [`82e553ae`](https://github.com/NixOS/nixpkgs/commit/82e553aeba701a06160cca89ae2fb505ba7f76c0) python3Packages.azure-core: 1.24.2 -> 1.25.1
* [`7bcb7289`](https://github.com/NixOS/nixpkgs/commit/7bcb7289c137a0302bff319846384b297a92a50b) python3Packages.azure-eventhub: 5.10.0 -> 5.10.1
* [`5d12551c`](https://github.com/NixOS/nixpkgs/commit/5d12551cd29ead0b68d95c2f19406ac0e74acd64) python3Packages.azure-mgmt-appconfiguration: 2.1.0 -> 2.2.0
* [`479a8b2f`](https://github.com/NixOS/nixpkgs/commit/479a8b2f834b9e983b4ef647ee090640c53bdd55) python3Packages.azure-mgmt-containerinstance: 9.2.0 -> 10.0.0
* [`03c54643`](https://github.com/NixOS/nixpkgs/commit/03c546433ac8ffe5f3fdc643112e8c1cf916b31f) python3Packages.azure-mgmt-containerservice: 20.2.0 -> 20.3.0
* [`25b4b572`](https://github.com/NixOS/nixpkgs/commit/25b4b57233369fe44100384794e96fe17f33a6de) python3Packages.azure-mgmt-core: 1.3.1 -> 1.3.2
* [`9d7379f3`](https://github.com/NixOS/nixpkgs/commit/9d7379f3e04b03449df1be8547347ad9fd3c3b36) python3Packages.azure-mgmt-cosmosdb: 7.0.0 -> 8.0.0
* [`22057951`](https://github.com/NixOS/nixpkgs/commit/220579518ab8f4e576627a6b63166e75f0578d2a) python3Packages.azure-mgmt-datafactory: 2.7.0 -> 2.8.0
* [`26c3674b`](https://github.com/NixOS/nixpkgs/commit/26c3674b89d5e5677b2a02594c50c6657b57f202) python3Packages.azure-mgmt-iothub: 2.2.0 -> 2.3.0
* [`bfb4df79`](https://github.com/NixOS/nixpkgs/commit/bfb4df79393dd578f18669c0c1ff7ba488c0e870) python3Packages.azure-mgmt-media: 10.0.0 -> 10.1.0
* [`3eb58859`](https://github.com/NixOS/nixpkgs/commit/3eb5885907416b39ec149530072ac39356b172ee) python3Packages.azure-mgmt-redis: 13.1.0 -> 14.0.0
* [`de95e595`](https://github.com/NixOS/nixpkgs/commit/de95e5952b212d10d11e199143e3a0a9baa3fa21) python3Packages.azure-mgmt-subscription: 3.0.0 -> 3.1.1
* [`fb34aec6`](https://github.com/NixOS/nixpkgs/commit/fb34aec664a3e4055e36f15c457ed2abf0755f37) python3Packages.azure-storage-blob: 12.13.0 -> 12.13.1
* [`ee396774`](https://github.com/NixOS/nixpkgs/commit/ee39677406f7bbdc19ae333d3ec8c7d736cea680) python3Packages.bcrypt: 3.2.2 -> 4.0.0
* [`102116aa`](https://github.com/NixOS/nixpkgs/commit/102116aa42a3f301c0a107365d9d3abf83113bfe) python3Packages.biliass: 1.3.4 -> 1.3.5
* [`e21f3eac`](https://github.com/NixOS/nixpkgs/commit/e21f3eacf34a220d192ace9a5002da2af624e839) python3Packages.billiard: 4.0.0 -> 4.0.2
* [`dfb3c87e`](https://github.com/NixOS/nixpkgs/commit/dfb3c87ef930dca0a6cdfefbebfec3bd6e97b884) python3Packages.bincopy: 17.10.3 -> 17.11.0
* [`e07985cd`](https://github.com/NixOS/nixpkgs/commit/e07985cd7cdb019fb38dfca390f9837bb58def0b) python3Packages.bitarray: 2.5.1 -> 2.6.0
* [`16370b1e`](https://github.com/NixOS/nixpkgs/commit/16370b1e7a903e2e044fb59ece5295c4464c2ce9) python3Packages.bitbox02: 6.0.0 -> 6.1.1
* [`31bed7b6`](https://github.com/NixOS/nixpkgs/commit/31bed7b63576358bab27da28802bb5c793f9af96) python3Packages.bitcoin-utils-fork-minimal: 0.4.11.4 -> 0.4.11.6
* [`4421425e`](https://github.com/NixOS/nixpkgs/commit/4421425e6f0ea4a1fb42540001fa57a628a6294f) python3Packages.blis: 0.9.0 -> 0.9.1
* [`534d5f16`](https://github.com/NixOS/nixpkgs/commit/534d5f169d8bc40ebb2291949f657051b41bd812) python3Packages.block-io: 2.0.5 -> 2.0.6
* [`5ed928e0`](https://github.com/NixOS/nixpkgs/commit/5ed928e0d7181efe8d0044ecefc2819a982b7887) python3Packages.boto3: 1.24.42 -> 1.24.75
* [`f4335622`](https://github.com/NixOS/nixpkgs/commit/f4335622ae47d59e1ef5f75cabf39a34e174f547) python3Packages.botocore: 1.27.42 -> 1.27.75
* [`c43cb430`](https://github.com/NixOS/nixpkgs/commit/c43cb4306a3128a1c8998c786c9c500475e053ee) python3Packages.bottle: 0.12.21 -> 0.12.23
* [`3c50c3b6`](https://github.com/NixOS/nixpkgs/commit/3c50c3b69f899a6665a24f5e04c2647575b44b11) python3Packages.boxx: 0.10.5 -> 0.10.6
* [`ef1cb885`](https://github.com/NixOS/nixpkgs/commit/ef1cb88551c1744c88f7423191c86fa2f94df1d1) python3Packages.bpython: 0.22.1 -> 0.23
* [`5a7c3d23`](https://github.com/NixOS/nixpkgs/commit/5a7c3d2322e79dbcb5fddecc302ce22c08398ee5) python3Packages.cartopy: 0.20.3 -> 0.21.0
* [`01b6f56f`](https://github.com/NixOS/nixpkgs/commit/01b6f56f4c13ffaa4533bcccb641a5bf8474f8e1) python3Packages.cherrypy: 18.7.0 -> 18.8.0
* [`06619ade`](https://github.com/NixOS/nixpkgs/commit/06619ade5f30e1b76cd65dfe37e07699c63115d9) python3Packages.cliff: 3.10.1 -> 4.0.0
* [`faac1657`](https://github.com/NixOS/nixpkgs/commit/faac1657275298e1e4737c9e44c27a808748ea0a) python3Packages.cloudpickle: 2.1.0 -> 2.2.0
* [`0c5026f1`](https://github.com/NixOS/nixpkgs/commit/0c5026f18b92ff4481efcf589c970445c931b795) python3Packages.cloudsmith-api: 1.61.3 -> 1.120.3
* [`bbd66905`](https://github.com/NixOS/nixpkgs/commit/bbd66905e5dccaccab3d5393010f15b909f7ee59) python3Packages.cocotb: 1.6.2 -> 1.7.0
* [`7f92259b`](https://github.com/NixOS/nixpkgs/commit/7f92259b8553da0030cc4a44dd3ab3dc68f3f7c2) python3Packages.colorlog: 6.6.0 -> 6.7.0
* [`5db734c0`](https://github.com/NixOS/nixpkgs/commit/5db734c002ca251e2f070bdf002b74d2f08d9d0b) python3Packages.commoncode: 30.2.0 -> 31.0.0
* [`41c50f25`](https://github.com/NixOS/nixpkgs/commit/41c50f2587671a9bd5059012c5f34646be829885) python3Packages.configparser: 5.2.0 -> 5.3.0
* [`6e04511d`](https://github.com/NixOS/nixpkgs/commit/6e04511d8b2858b7eb3b5a35ea7153823429f5b6) python3Packages.coverage: 6.4.2 -> 6.4.4
* [`f30f2148`](https://github.com/NixOS/nixpkgs/commit/f30f2148a4ec0964d14589a5aea0d37469152058) python3Packages.crashtest: 0.3.1 -> 0.4.0
* [`773c11ad`](https://github.com/NixOS/nixpkgs/commit/773c11ad12a9b4789afe651e5ff8ed8a4d434f13) python3Packages.cupy: 10.6.0 -> 11.1.0
* [`5b94561d`](https://github.com/NixOS/nixpkgs/commit/5b94561d92ff22811f4ceecba9d470cfa8ae16c1) python3Packages.curtsies: 0.3.10 -> 0.4.0
* [`17978a97`](https://github.com/NixOS/nixpkgs/commit/17978a97530a178842cffd05dadcb0442e865923) python3Packages.dask-jobqueue: 0.7.4 -> 0.8.0
* [`bf3375dd`](https://github.com/NixOS/nixpkgs/commit/bf3375dd6c3d6baba42ef4376c461f1ef1f45037) python3Packages.databricks-connect: 10.4.6 -> 10.4.12
* [`341a7c89`](https://github.com/NixOS/nixpkgs/commit/341a7c890054d9499956190acf721e750955515e) python3Packages.devpi-common: 3.6.0 -> 3.7.0
* [`c876b71f`](https://github.com/NixOS/nixpkgs/commit/c876b71f61a87186d13e15fd92027798ea6de8a0) python3Packages.distributed: 2022.7.0 -> 2022.9.0
* [`d469728b`](https://github.com/NixOS/nixpkgs/commit/d469728bf891ae0a78774c9c26f9e311a901b3d8) python3Packages.dj-database-url: 0.5.0 -> 1.0.0
* [`e7cc94a2`](https://github.com/NixOS/nixpkgs/commit/e7cc94a20a6e59f561defac1a7d7b4653138248a) python3Packages.docformatter: 1.4 -> 1.5.0
* [`20d4ce69`](https://github.com/NixOS/nixpkgs/commit/20d4ce6981af1ad90d4ea4aa4ff84d8aab12c814) python3Packages.docker: 5.0.3 -> 6.0.0
* [`4edab54f`](https://github.com/NixOS/nixpkgs/commit/4edab54f8028e0a5dd48b95c3c55425a2436dfa7) python3Packages.dpkt: 1.9.7.2 -> 1.9.8
* [`ad07650f`](https://github.com/NixOS/nixpkgs/commit/ad07650f7c93a3dc01b468d7fc1e5a4bf95b2cb9) python3Packages.etils: 0.7.1 -> 0.8.0
* [`f8461e03`](https://github.com/NixOS/nixpkgs/commit/f8461e03ba626a1b636a049fbbd1e9fc14ddc4b1) python3Packages.evdev: 1.5.0 -> 1.6.0
* [`e8fd120e`](https://github.com/NixOS/nixpkgs/commit/e8fd120ee4617b9e8ddaf58feef608f1b4cfb7b9) python3Packages.faker: 13.15.0 -> 14.2.0
* [`389875c8`](https://github.com/NixOS/nixpkgs/commit/389875c8285fc2a4ce39bf64cd26f6c0ced374cc) python3Packages.filelock: 3.7.1 -> 3.8.0
* [`00a31710`](https://github.com/NixOS/nixpkgs/commit/00a317107e1e735f18b49641c3396575cd7e4d9b) python3Packages.flask-security-too: 4.1.5 -> 5.0.1
* [`cf9ae523`](https://github.com/NixOS/nixpkgs/commit/cf9ae52369a813401d39e8f916da191aa46c0f85) python3Packages.fontParts: 0.10.7 -> 0.10.8
* [`f75b8276`](https://github.com/NixOS/nixpkgs/commit/f75b8276afdda77d36663dba96911dc2fba4e384) python3Packages.freezegun: 1.2.1 -> 1.2.2
* [`eb22d2c1`](https://github.com/NixOS/nixpkgs/commit/eb22d2c184e8dcad5c7e3a164697aadba17bdf19) python3Packages.glean-parser: 6.1.2 -> 6.2.0
* [`e2c42ac0`](https://github.com/NixOS/nixpkgs/commit/e2c42ac0ccb4e1f7643378794269b6e5e7bae5a7) python3Packages.google-api-core: 2.8.2 -> 2.10.1
* [`5a43c952`](https://github.com/NixOS/nixpkgs/commit/5a43c9529d373c847056f063b02f0c65ba370867) python3Packages.google-api-python-client: 2.57.0 -> 2.61.0
* [`49551a49`](https://github.com/NixOS/nixpkgs/commit/49551a49476a04bba37846cffe548787a2360ff4) python3Packages.google-cloud-asset: 3.13.0 -> 3.13.1
* [`e8672b4c`](https://github.com/NixOS/nixpkgs/commit/e8672b4ccecb0724c7711d244b1db0198f8afa57) python3Packages.google-cloud-compute: 1.5.1 -> 1.5.2
* [`dbbf80b2`](https://github.com/NixOS/nixpkgs/commit/dbbf80b20fbbb29a43a31ba1748bfda7c36e15a7) python3Packages.google-cloud-spanner: 3.19.0 -> 3.20.0
* [`5763e070`](https://github.com/NixOS/nixpkgs/commit/5763e070e8e7fd6c9f400b6f70d3714db37d47c3) python3Packages.gradient: 2.0.5 -> 2.0.6
* [`c4f9177d`](https://github.com/NixOS/nixpkgs/commit/c4f9177d3609df1dbd757a4d2a5a597f8d12b9b3) python3Packages.greenlet: 1.1.2 -> 1.1.3
* [`ec348571`](https://github.com/NixOS/nixpkgs/commit/ec348571a416f2ed626a907729eb10168e14f9e8) python3Packages.hatch-fancy-pypi-readme: 22.3.0 -> 22.7.0
* [`c5c0c3f9`](https://github.com/NixOS/nixpkgs/commit/c5c0c3f9ddf540c42d6be8cd489d939164deedd9) python3Packages.hatchling: 1.8.0 -> 1.9.0
* [`3de48e8c`](https://github.com/NixOS/nixpkgs/commit/3de48e8c32ef4f0e3104a4f7c61808962bd0620e) python3Packages.idna: 3.3 -> 3.4
* [`c4f68dca`](https://github.com/NixOS/nixpkgs/commit/c4f68dcaf2c3d9344eb03c4ebb0115198883f8cc) python3Packages.imageio: 2.19.3 -> 2.21.3
* [`bab313a9`](https://github.com/NixOS/nixpkgs/commit/bab313a9e7555ed6f5f5d9d1e68ea479cddf28a0) python3Packages.importlib-resources: 5.8.0 -> 5.9.0
* [`48b79709`](https://github.com/NixOS/nixpkgs/commit/48b797097751d4b88883e006b8d1f7be44019fbc) python3Packages.inflect: 5.6.2 -> 6.0.0
* [`e32ce4b6`](https://github.com/NixOS/nixpkgs/commit/e32ce4b6f600c1e0d9d782536a7849840dca64e8) python3Packages.ipykernel: 6.15.1 -> 6.15.3
* [`d2ab35f5`](https://github.com/NixOS/nixpkgs/commit/d2ab35f5e02e8de117b76bdf399b551a58d9200a) python3Packages.ipyvuetify: 1.8.2 -> 1.8.4
* [`f98b0af6`](https://github.com/NixOS/nixpkgs/commit/f98b0af6fca9ceb95dc4c3a19950031543d3e555) minipro: 0.5 -> 0.6
* [`eeb99118`](https://github.com/NixOS/nixpkgs/commit/eeb99118277e52e5584d58b17519a896f853a847) python3Packages.openapi-spec-validator: add setuptools
* [`43bc0848`](https://github.com/NixOS/nixpkgs/commit/43bc08486cf41c61b165c2dd5f40ae0adec62d70) python3Packages.pyroute2: add setuptools
* [`75475e4c`](https://github.com/NixOS/nixpkgs/commit/75475e4cd409ba0033474060178cdde83ea149bb) getmail6: 6.18.9 -> 6.18.10
* [`0a4898c2`](https://github.com/NixOS/nixpkgs/commit/0a4898c21a04336bf9919da3ec95050890e77e5b) Revert "buildPython*: store dist (wheel/sdist) in dist output"
* [`3ff2d936`](https://github.com/NixOS/nixpkgs/commit/3ff2d9362ce18cab4bebd6ebf17892e431df34e2) Revert "buildPython*: wrap setuptools in hook for catching conflicts"
* [`172f9cf8`](https://github.com/NixOS/nixpkgs/commit/172f9cf80723482ab506365902a21025963bf4da) boehmgc: disabled tests on x86_64-darwin
* [`cfe3eabb`](https://github.com/NixOS/nixpkgs/commit/cfe3eabb1be28f3120b3be2148b18154c67b8054) python3Packages.ipywidgets: 7.7.1 -> 8.0.2
* [`33b94889`](https://github.com/NixOS/nixpkgs/commit/33b94889fd4f52ee58108c98257cd0f0b36ef205) python3Packages.jaraco.logging: 3.1.0 -> 3.1.2
* [`dfd910af`](https://github.com/NixOS/nixpkgs/commit/dfd910af8ddb64396ca06868005b29a40b4f7c70) python3Packages.jaraco.text: 3.8.1 -> 3.9.1
* [`241d8b74`](https://github.com/NixOS/nixpkgs/commit/241d8b744adc4840ac91bdfaf2af00039214fae1) python3Packages.jupyter-book: 0.13.0 -> 0.13.1
* [`c2f5f238`](https://github.com/NixOS/nixpkgs/commit/c2f5f2381a87c6a18c8fa8d45027d0dfba4c4b7b) python3Packages.jupyter_client: 7.3.4 -> 7.3.5
* [`ea128f1a`](https://github.com/NixOS/nixpkgs/commit/ea128f1aeee2a1d167c6ab26eabf1d77b9ab4f55) python3Packages.jupyterlab: 3.4.6 -> 3.4.7
* [`2462c676`](https://github.com/NixOS/nixpkgs/commit/2462c67625d95b7cc9597e57a011b2eccd470832) python3Packages.jupyterlab-git: 0.39.0 -> 0.39.2
* [`8495fb43`](https://github.com/NixOS/nixpkgs/commit/8495fb43efdaef13485cf9dc6774236f60af2f31) python3Packages.jupyterlab-widgets: 2.0.0b1 -> 3.0.3
* [`f0424a78`](https://github.com/NixOS/nixpkgs/commit/f0424a78f7d58a118b2babb1dcdbcfc6afbea40a) python3Packages.jupyter-packaging: 0.12.2 -> 0.12.3
* [`2f55dfbc`](https://github.com/NixOS/nixpkgs/commit/2f55dfbc268f8428ee7a87895b2863d82d9d524d) python3Packages.keras: 2.9.0 -> 2.10.0
* [`d809e536`](https://github.com/NixOS/nixpkgs/commit/d809e53667aaf900fac7844674f8f650da2bea65) python3Packages.keyring: 23.7.0 -> 23.9.1
* [`4240a4ba`](https://github.com/NixOS/nixpkgs/commit/4240a4ba5d60e1cc89773fabd3a77ce2cd2fc580) python3Packages.keyrings.alt: 4.1.1 -> 4.2.0
* [`0b47da7a`](https://github.com/NixOS/nixpkgs/commit/0b47da7a13bf8b812b50bce53ea0a9ad79d0ac3c) python3Packages.llvmlite: 0.38.1 -> 0.39.1
* [`2dd3d11c`](https://github.com/NixOS/nixpkgs/commit/2dd3d11c7424279a75e2ac7d899a6d40f4edc765) python3Packages.localstack-ext: 1.0.4 -> 1.1.0
* [`dbe80f4b`](https://github.com/NixOS/nixpkgs/commit/dbe80f4b2c007120eb8244883de8e3ea3140b7f1) python3Packages.matplotlib: 3.5.2 -> 3.5.3
* [`a4862455`](https://github.com/NixOS/nixpkgs/commit/a486245526a3d9593e61d1a1be33364035aef178) python3Packages.matplotlib-inline: 0.1.3 -> 0.1.6
* [`17aab92d`](https://github.com/NixOS/nixpkgs/commit/17aab92d816d4335cb538fb9f8eccfe843741d88) python3Packages.metakernel: 0.29.0 -> 0.29.2
* [`135ebd6c`](https://github.com/NixOS/nixpkgs/commit/135ebd6c82313b81c882517e3f272549cfccd56e) python3Packages.mocket: 3.10.6 -> 3.10.8
* [`cd931da1`](https://github.com/NixOS/nixpkgs/commit/cd931da1393893a35d1015d216b09fa3b3661a1e) python3Packages.more-itertools: 8.13.0 -> 8.14.0
* [`c0d11692`](https://github.com/NixOS/nixpkgs/commit/c0d116921b0738801721b1dfa3d4d80d2884b09e) python3Packages.moto: 3.1.16 -> 4.0.3
* [`f0ac1bb5`](https://github.com/NixOS/nixpkgs/commit/f0ac1bb51eb90ed08664f3eecffa39899ecb5197) python3Packages.msldap: 0.3.40 -> 0.4.1
* [`c44b3259`](https://github.com/NixOS/nixpkgs/commit/c44b32597986d3014b53620a960d4dc27999e3e5) python3Packages.murmurhash: 1.0.7 -> 1.0.8
* [`bde09a92`](https://github.com/NixOS/nixpkgs/commit/bde09a920dc6128772fafcaad09cfb9f5322c938) python3Packages.myfitnesspal: 1.17.0 -> 2.0.0
* [`3adc90e4`](https://github.com/NixOS/nixpkgs/commit/3adc90e49ccf50bf2df95774dee74e5f7cf38f0c) python3Packages.mypy-protobuf: 3.2.0 -> 3.3.0
* [`113ebb03`](https://github.com/NixOS/nixpkgs/commit/113ebb039c5fc84d0892567540779b552ba04cc7) python3Packages.natsort: 8.1.0 -> 8.2.0
* [`eb91570c`](https://github.com/NixOS/nixpkgs/commit/eb91570c7a496e1125ff2964dbdf02345746da08) python3Packages.nbformat: 5.4.0 -> 5.5.0
* [`8fe0a134`](https://github.com/NixOS/nixpkgs/commit/8fe0a13463c65661f5d5e2aba1ccaebafe396bf4) python3Packages.neo: 0.10.2 -> 0.11.0
* [`3fd41495`](https://github.com/NixOS/nixpkgs/commit/3fd41495a503eac662dec88b7dfd164b6d154298) python3Packages.networkx: 2.8.4 -> 2.8.6
* [`3259ef37`](https://github.com/NixOS/nixpkgs/commit/3259ef3795f69b2b0d54f798394b2783e5e1183c) python3Packages.nilearn: 0.9.1 -> 0.9.2
* [`9c161fa6`](https://github.com/NixOS/nixpkgs/commit/9c161fa66255b34a85fdaf0ae7f329671fdd9bf9) python3Packages.nipype: 1.8.3 -> 1.8.4
* [`5028050a`](https://github.com/NixOS/nixpkgs/commit/5028050a62612c0da85afdaa6886476dd85a35b5) python3Packages.num2words: 0.5.11 -> 0.5.12
* [`79849def`](https://github.com/NixOS/nixpkgs/commit/79849def01e5345b05ee12e5dc8c150f5ee83741) python3Packages.numba: 0.55.2 -> 0.56.2
* [`d4143512`](https://github.com/NixOS/nixpkgs/commit/d414351266009fa586cb4b623a144c72d7149435) python3Packages.numcodecs: 0.10.0 -> 0.10.2
* [`422ce181`](https://github.com/NixOS/nixpkgs/commit/422ce1815d4fb46c13bd53e8f71b3c8c4604214d) python3Packages.oauthenticator: 15.0.1 -> 15.1.0
* [`37bead23`](https://github.com/NixOS/nixpkgs/commit/37bead230547d22d0d3a07bde1e5f2dbfdfed8a2) python3Packages.openstackdocstheme: 2.4.0 -> 3.0.0
* [`f4cc27e7`](https://github.com/NixOS/nixpkgs/commit/f4cc27e7b639016c360a0cb18bd7a553a7421164) python3Packages.oslo-concurrency: 5.0.0 -> 5.0.1
* [`3a2fd43a`](https://github.com/NixOS/nixpkgs/commit/3a2fd43ad016f05ce91531e8f87b55cd9d3cb1cb) python3Packages.oslo-utils: 6.0.0 -> 6.0.1
* [`7a498f27`](https://github.com/NixOS/nixpkgs/commit/7a498f272c1a69cdb03b7ff673ef78fa1f5f01be) python3Packages.OWSLib: 0.26.0 -> 0.27.2
* [`4c2aaa2f`](https://github.com/NixOS/nixpkgs/commit/4c2aaa2f08f4527008b5648304bde2f6a961c032) python3Packages.parsimonious: 0.9.0 -> 0.10.0
* [`25d75f0c`](https://github.com/NixOS/nixpkgs/commit/25d75f0c97d72cc16ca651d20b6c5b4abb09c4d8) python3Packages.partd: 1.2.0 -> 1.3.0
* [`dfdb6f4e`](https://github.com/NixOS/nixpkgs/commit/dfdb6f4e7b280bf2f9c8e9cf144ba142b75d9da5) python3Packages.pathspec: 0.9.0 -> 0.10.1
* [`15aaccd1`](https://github.com/NixOS/nixpkgs/commit/15aaccd1b3c8ad5d6e073c3952f39893420969b8) python3Packages.pbr: 5.9.0 -> 5.10.0
* [`9792a8ba`](https://github.com/NixOS/nixpkgs/commit/9792a8bad4a71c6329f899f4ffbeaaf5ac3f6ede) python3Packages.pep517: 0.12.0 -> 0.13.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
