### PR TITLE
niv emacs-overlay: update 550ce566 -> 20dc7a0a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "550ce5667fee8f74aa20ad6456720ed84ebdd241",
-        "sha256": "0x1brzy1j4arygncgdvj8klqkx7fyndn2mdl5d3cn0smmny0mzfm",
+        "rev": "20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b",
+        "sha256": "1fvx2pn64bwpj5jkzc927riv89g8aq2g7s46bsswgvj72qr4mqfp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/550ce5667fee8f74aa20ad6456720ed84ebdd241.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@550ce566...20dc7a0a](https://github.com/nix-community/emacs-overlay/compare/550ce5667fee8f74aa20ad6456720ed84ebdd241...20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b)

* [`38c31f5f`](https://github.com/nix-community/emacs-overlay/commit/38c31f5fddc50891c7f60e383e5630b0ac354f7a) Updated repos/elpa
* [`7f08e288`](https://github.com/nix-community/emacs-overlay/commit/7f08e2886e97c6d57ab29e8ba7ed0c094d2d0d49) Updated repos/melpa
* [`9192cc4f`](https://github.com/nix-community/emacs-overlay/commit/9192cc4f15615b1905dcf109fad8abe482dc5e51) Updated repos/elpa
* [`485c8482`](https://github.com/nix-community/emacs-overlay/commit/485c8482763b14a381e5579bc55d1c08d9622b58) Updated repos/melpa
* [`0b9139a3`](https://github.com/nix-community/emacs-overlay/commit/0b9139a3474b85be53f7ab0939442c024b981043) Updated repos/nongnu
* [`74d82923`](https://github.com/nix-community/emacs-overlay/commit/74d82923d5575583e4a12bded5b05685b4d94bf1) Updated repos/melpa
* [`5a0d13e0`](https://github.com/nix-community/emacs-overlay/commit/5a0d13e02555d20144d34fb8c9af4900fe55ce06) Updated repos/melpa
* [`2c1081e6`](https://github.com/nix-community/emacs-overlay/commit/2c1081e6da62d5d9899527a97949c3f2b507c4a8) Updated repos/elpa
* [`989f6856`](https://github.com/nix-community/emacs-overlay/commit/989f6856f51ae5dc9ae690d28d6ca2a14a6f9331) Updated repos/melpa
* [`306c410e`](https://github.com/nix-community/emacs-overlay/commit/306c410e513bdf7ea6a2940ba280dfcdcebf0df5) Updated repos/nongnu
* [`de800a57`](https://github.com/nix-community/emacs-overlay/commit/de800a5746d6abf096734db407ef0323f05cf6b6) Updated repos/melpa
* [`1f0aa204`](https://github.com/nix-community/emacs-overlay/commit/1f0aa2040fad4bfbe6212b20394ac57ee4cff7b5) Updated repos/elpa
* [`6c78924b`](https://github.com/nix-community/emacs-overlay/commit/6c78924bc5b6daaf98c0dbe63bdfcf80e6433f4b) Updated repos/melpa
* [`9450c5a8`](https://github.com/nix-community/emacs-overlay/commit/9450c5a84f0e15af3473ffe6a72d508e2a0a1441) Updated repos/elpa
* [`a330005e`](https://github.com/nix-community/emacs-overlay/commit/a330005ee3e3c9a0ac342b6655a4f5cb59729e3e) Updated repos/melpa
* [`a4b6aca2`](https://github.com/nix-community/emacs-overlay/commit/a4b6aca2d96b3e13eae240952414a5c40782d2e5) Updated repos/nongnu
* [`15345108`](https://github.com/nix-community/emacs-overlay/commit/15345108d2c8d742ed6e3c40457797932e32bd0a) Updated repos/melpa
* [`95f7b518`](https://github.com/nix-community/emacs-overlay/commit/95f7b51821535cf1e2d6e74a7172314029819010) Updated repos/nongnu
* [`9af725ee`](https://github.com/nix-community/emacs-overlay/commit/9af725ee5de9395eb9751a1dee84991c05fba261) Updated repos/elpa
* [`9a02dc2c`](https://github.com/nix-community/emacs-overlay/commit/9a02dc2ccb23e99abed65102b76f01b7bc59e73e) Updated repos/melpa
* [`b7f294e9`](https://github.com/nix-community/emacs-overlay/commit/b7f294e967867868a8e5a0756bada7e0b7de2441) Updated repos/melpa
* [`a2783e10`](https://github.com/nix-community/emacs-overlay/commit/a2783e10a9cbd749482975b87a79de6326ebc44e) Updated repos/nongnu
* [`9e18e2e8`](https://github.com/nix-community/emacs-overlay/commit/9e18e2e8a995b88159e36dfd10ceca902a756225) Updated repos/melpa
* [`3b1cd61c`](https://github.com/nix-community/emacs-overlay/commit/3b1cd61c04f93d870f38d8e6ccd7f657c953c975) Updated repos/elpa
* [`99f60719`](https://github.com/nix-community/emacs-overlay/commit/99f607199684071fef8e8a411d4e5d862cd5647a) Updated repos/melpa
* [`81634354`](https://github.com/nix-community/emacs-overlay/commit/81634354412acf5d007d657a570fb2eeacb1a5a0) Updated repos/melpa
* [`4bbc5d56`](https://github.com/nix-community/emacs-overlay/commit/4bbc5d56111833bad701ac97279625ee17f08352) Updated repos/nongnu
* [`70787f42`](https://github.com/nix-community/emacs-overlay/commit/70787f42dbf53b8a57c4b9181fd98da1d710ac5b) Updated repos/melpa
* [`4544e7ba`](https://github.com/nix-community/emacs-overlay/commit/4544e7ba035b25e0abb74364192f73ef04e3e599) Updated repos/melpa
* [`f3661c50`](https://github.com/nix-community/emacs-overlay/commit/f3661c501388f80f9fa0d09f5dadf275f3dc0d4f) Updated repos/elpa
* [`bcd8fd24`](https://github.com/nix-community/emacs-overlay/commit/bcd8fd243f70247e0c5792abb3e57204f5b30409) Updated repos/melpa
* [`6c1b2aae`](https://github.com/nix-community/emacs-overlay/commit/6c1b2aae7d74f1f41fe7a54579981ae742f160dd) Add workaround to fix failing Hydra for emacsGit
* [`8ff39aa2`](https://github.com/nix-community/emacs-overlay/commit/8ff39aa20ce4d206baa22e10d807fcac77ccfe91) Updated repos/melpa
* [`be61e563`](https://github.com/nix-community/emacs-overlay/commit/be61e5636f4c7478c0093ace59bc7512e320feaa) Updated repos/nongnu
* [`15d6f9f2`](https://github.com/nix-community/emacs-overlay/commit/15d6f9f211088faedba7e8a491a724a620d211e9) Updated repos/emacs
* [`a28b388b`](https://github.com/nix-community/emacs-overlay/commit/a28b388b022a5fb6f8700ba04eb4d57d2e36abb6) Updated repos/melpa
* [`469f35d4`](https://github.com/nix-community/emacs-overlay/commit/469f35d4da07e041dd1059ba26fc9a2cdaa72da3) Updated repos/emacs
* [`20dc7a0a`](https://github.com/nix-community/emacs-overlay/commit/20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b) Updated repos/melpa
