### PR TITLE
niv fast-syntax-highlighting: update 13dd94ba -> 770bcd98

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "13dd94ba828328c18de3f216ec4a746a9ad0ef55",
-        "sha256": "1l7szi9lc1b0g0c0p1c1pqhbvgz66wp1a1ib6rhsly4vdz8y5ksm",
+        "rev": "770bcd986620d6172097dc161178210855808ee0",
+        "sha256": "1rkdlip487q6jii327s5jjgc5dg46m1xh8hj47ms4spvnjjk92ag",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/13dd94ba828328c18de3f216ec4a746a9ad0ef55.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/770bcd986620d6172097dc161178210855808ee0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@13dd94ba...770bcd98](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/13dd94ba828328c18de3f216ec4a746a9ad0ef55...770bcd986620d6172097dc161178210855808ee0)

* [`770bcd98`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/770bcd986620d6172097dc161178210855808ee0) maint: update links (e.g., `zdharma` -> `zdharma-continuum`) ([zdharma-continuum/fast-syntax-highlighting⁠#41](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/41))
