### PR TITLE
niv nixpkgs: update b1425554 -> 8b786d8d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b142555481cfcc8ebb857f591e1e47583cc28106",
-        "sha256": "1q5j6c11is5afb5326lrlzxr7r91yckg2bh0wlis3a96fnr8rsl9",
+        "rev": "8b786d8dbb29d8df192c0f67bd5f0a72a28260ec",
+        "sha256": "12jxhq86yibim30hin2ycm9h7a12d36p2j2rp226lppxfh9987wd",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/b142555481cfcc8ebb857f591e1e47583cc28106.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8b786d8dbb29d8df192c0f67bd5f0a72a28260ec.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@b1425554...8b786d8d](https://github.com/nixos/nixpkgs/compare/b142555481cfcc8ebb857f591e1e47583cc28106...8b786d8dbb29d8df192c0f67bd5f0a72a28260ec)

* [`95df3315`](https://github.com/NixOS/nixpkgs/commit/95df3315f2c0c91b29690db23131766a92994e14) mpvScripts.mpv-playlistmanager: unstable-2021-09-27 → unstable-2022-08-26
* [`7a75ad1e`](https://github.com/NixOS/nixpkgs/commit/7a75ad1e195c5627eadaf52bf70a26438ac7f11e) rubyPackages: set meta.mainProgram
* [`7c7d89b4`](https://github.com/NixOS/nixpkgs/commit/7c7d89b4163ba808c8ad9372d06b40284916ddc3) doggo: init at 0.5.4
* [`bf177162`](https://github.com/NixOS/nixpkgs/commit/bf177162aeb98b71c30d784a90fb2e718d4df398) maintainers: add georgesalkhouri
* [`6e6f8af7`](https://github.com/NixOS/nixpkgs/commit/6e6f8af7927069fc268bf0e0ff1a7225916a5dbe) sfeed: 1.5 -> 1.6
* [`9136910f`](https://github.com/NixOS/nixpkgs/commit/9136910f1e95407c9763cb97ba122169d238a7d5) libzbc: init at 5.12.0
* [`8a773bd4`](https://github.com/NixOS/nixpkgs/commit/8a773bd46aa618bdd3552af9e973924f1c685789) libzbd: init at 2.0.3
* [`fc653b0a`](https://github.com/NixOS/nixpkgs/commit/fc653b0ad67839a2c267690f725af06c856052f2) libnvme: init at 1.1
* [`2e0daa61`](https://github.com/NixOS/nixpkgs/commit/2e0daa61b50ac4b7ce639d711a35bc4cf1c8d739) discocss: add discordAlias option
* [`73ffb2d0`](https://github.com/NixOS/nixpkgs/commit/73ffb2d003bb816c41e308e4f27a033478fb62c3) mycorrhiza: 1.11.0 -> 1.12.1
* [`7e5617aa`](https://github.com/NixOS/nixpkgs/commit/7e5617aa7a0401e3d765489295d22caf9926a90b) nixos/doc: fix acme dns-01 example
* [`832c7507`](https://github.com/NixOS/nixpkgs/commit/832c7507b7cdffee96b71886ad5922e7dda0b063) maeparser: 1.2.4 -> 1.3.0
* [`adcd8c81`](https://github.com/NixOS/nixpkgs/commit/adcd8c81efc7669e7742666ffc51a32c68012778) xinetd: 2.3.15 -> 2.3.15.4, switch to openSUSE fork
* [`9b201597`](https://github.com/NixOS/nixpkgs/commit/9b2015979d15415327a526a20e4c43b2f0f0e5a4) xinetd: add fgaz to maintainers
* [`208d98a7`](https://github.com/NixOS/nixpkgs/commit/208d98a79e23826babea1fb004195833d21ab4a3) whatip: init at 1.1
* [`3e02e3e7`](https://github.com/NixOS/nixpkgs/commit/3e02e3e723d365a3aa18a129f6763882144782c8) hysteria: 1.2.0 -> 1.2.1
* [`de1dbd7a`](https://github.com/NixOS/nixpkgs/commit/de1dbd7a02196390d849c1d1b07065b8de3b5d06) replibyte: init at 0.9.7
* [`2395aac4`](https://github.com/NixOS/nixpkgs/commit/2395aac40b718fb88c2d3e8b3af96970b4104a9f) numberstation: 1.1.0 -> 1.2.0
* [`4eb213c3`](https://github.com/NixOS/nixpkgs/commit/4eb213c3308439fcbc562491b805dc8bae1dd1e8) xfstests: 2019-09-08 -> 2022-09-04
* [`8a9ffb1b`](https://github.com/NixOS/nixpkgs/commit/8a9ffb1b0bb94a31760b2443a08f8c0baa08c63f) nixosTests.paperless: check if /metadata/ can be accessed
* [`b1a1cb51`](https://github.com/NixOS/nixpkgs/commit/b1a1cb51eaca023fb664f090e2de45e80908ed5e) moodle: 4.0.2 -> 4.0.4
* [`f127398b`](https://github.com/NixOS/nixpkgs/commit/f127398be2b53f602cfea424edbecad2c6f8ce97) flutter: 3.0.4->3.3.0, flutter.dart: 2.17.5->2.18.0
* [`bd0f733c`](https://github.com/NixOS/nixpkgs/commit/bd0f733ce11fc3cca3a32d39ed51ae23440f434a) flutter: regenerate disable-auto-update.patch
* [`89de6982`](https://github.com/NixOS/nixpkgs/commit/89de6982188c70f093a06cebba8f57b59d04200c) flutter: regenerate git-dir.patch
* [`747f298b`](https://github.com/NixOS/nixpkgs/commit/747f298be5ce7f15e127d154411b9a84dbf443be) flutter: regenerate move-cache.patch
* [`ffb72bdc`](https://github.com/NixOS/nixpkgs/commit/ffb72bdc5bb3a9343723f35923a3186be6bf4899) flutter: fix buildPhase after .packages deprecation
* [`41754242`](https://github.com/NixOS/nixpkgs/commit/41754242a6ed0b85227f0944aa9db90f1e92a3b0) flutter: add cache back in for shaders
* [`60cf98b0`](https://github.com/NixOS/nixpkgs/commit/60cf98b0677b080109fd4affa8b965a24d1a5ac4) lib.licenses: add CAL-1.0
* [`11f978d5`](https://github.com/NixOS/nixpkgs/commit/11f978d53355759a47d60d688709921f2e0fb158) holochain-launcher: init at v0.6.0
* [`d8750d7e`](https://github.com/NixOS/nixpkgs/commit/d8750d7e0d0b41c695acb61a1f57c289601fa663) nxpmicro-mfgtools: 1.4.165 -> 1.4.243
* [`0cfbf813`](https://github.com/NixOS/nixpkgs/commit/0cfbf8139d96c05e1a217bbfef3c9941d6e2d7e4) polkadot: 0.9.28 -> 0.9.29
* [`db29c11a`](https://github.com/NixOS/nixpkgs/commit/db29c11af5ff8c5ab3cd5b1cec7942c3d3fa0681) tinygo: 0.23.0 -> 0.25.0
* [`c5c42d4f`](https://github.com/NixOS/nixpkgs/commit/c5c42d4fbe0c68bb79f6178b4c39271275bb4298) nixos/systemd-stage-1: include modprobe confg in initrd
* [`35885217`](https://github.com/NixOS/nixpkgs/commit/3588521718c3869aec53458e68776672ce0dba16) kodiPlugins.waveform-visualization: init at 19.0.2
* [`e915f506`](https://github.com/NixOS/nixpkgs/commit/e915f50626f3fb7844b74fd1236adccd59e176a6) factorio: 1.1.65 -> 1.1.69
* [`61834938`](https://github.com/NixOS/nixpkgs/commit/61834938fdcc8985405b32929daee909ac375e87) python3Packages.catboost: 0.24.4 -> 1.0.5
* [`d8323e21`](https://github.com/NixOS/nixpkgs/commit/d8323e21aab198e456029ac9d6223e0e25443d1c) python3Packages.shap: fix broken package, improve tests
* [`024010b1`](https://github.com/NixOS/nixpkgs/commit/024010b18d0f30b381cec67efc5537775c7c6217) gtkradiant: init at unstable-2022-07-31
* [`eef137b6`](https://github.com/NixOS/nixpkgs/commit/eef137b649c691d6df7ca9b91feea7e341285d8b) maintainers: add wesleyjrz
* [`08e983e7`](https://github.com/NixOS/nixpkgs/commit/08e983e720d6adee670b9f171ee71a07e8d428c2) tym: init at 3.3.0
* [`d77e00f5`](https://github.com/NixOS/nixpkgs/commit/d77e00f5003aee22e2891541e0d770eac1b82720) pkgsCross.armv7l-hf-multiplatform.ubootClearfog: fix build
* [`1faa2167`](https://github.com/NixOS/nixpkgs/commit/1faa21674513e76622775e972fdf11b0bcf08dd7) darwin.iproute2mac: 1.4.0 -> 1.4.1
* [`1e7fbc02`](https://github.com/NixOS/nixpkgs/commit/1e7fbc02b1dd183f841761143dc42f4d64804341) prowlarr: 0.4.5.1960 -> 0.4.6.1969
* [`ffea2d42`](https://github.com/NixOS/nixpkgs/commit/ffea2d42c0e74919714be235e72b8f689abd1091) inklingreader: init at unstable-2017-09-07
* [`3a3d66f9`](https://github.com/NixOS/nixpkgs/commit/3a3d66f9ff213024a720a72b3639bd62ec63a52a) python310Packages.devito: fix darwin build
* [`d470c611`](https://github.com/NixOS/nixpkgs/commit/d470c611f748305b827cc07430598deb6abba285) python310Packages.types-protobuf: 3.20.3 -> 3.20.4
* [`ab3f0771`](https://github.com/NixOS/nixpkgs/commit/ab3f0771a42aef7e691815209119bb49d1c63f93) pymol: use Qt instead of Tk; fixes [nixos/nixpkgs⁠#192555](https://togithub.com/nixos/nixpkgs/issues/192555)
* [`99dc9b9c`](https://github.com/NixOS/nixpkgs/commit/99dc9b9c164af3bc6c08ff4a4db4c2b58e368160) nixos/endlessh-go: init module
* [`d28b72e6`](https://github.com/NixOS/nixpkgs/commit/d28b72e64da51c7639a5b0143eeff7a079a5d57f) python310Packages.pydash: 5.1.0 -> 5.1.1 and fix darwin
* [`d31c82f3`](https://github.com/NixOS/nixpkgs/commit/d31c82f334c6b0ed3db5d148817411efcf5b7dc7) dolibarr: 15.0.3 -> 16.0.0
* [`53256fcd`](https://github.com/NixOS/nixpkgs/commit/53256fcdb5a0dfb6e3c27eb7d73bf2527342a625) openjfx17: use ffmpeg_4
* [`1d4bddae`](https://github.com/NixOS/nixpkgs/commit/1d4bddaed58c23fbfb4df0bf80d5ffd6803a6a34) gnome.nixos-gsettings-override: extract from NixOS module
* [`35e033d4`](https://github.com/NixOS/nixpkgs/commit/35e033d416a512c0a5406ef76b4fe96a1f2e564a) gnome.nixos-gsettings-override: Make compilation strict
* [`dff1ed86`](https://github.com/NixOS/nixpkgs/commit/dff1ed86905e1c3a564aed37b6717d521552be17) cinnamon.cinnamon-gsettings-overrides: Bring closer to GNOME
* [`5e408af4`](https://github.com/NixOS/nixpkgs/commit/5e408af4de6cd0cc296467e2638db21360157df8) cinnamon.cinnamon-gsettings-overrides: Make compilation strict
* [`cb0c70b3`](https://github.com/NixOS/nixpkgs/commit/cb0c70b38855278096bfab28bcf2fcd69cc8b407) pantheon.elementary-gsettings-schemas: Bring closer to GNOME
* [`86d743a9`](https://github.com/NixOS/nixpkgs/commit/86d743a9588b4be715b47b5674a39cec45e93afc) lldb: add support for Lua bindings in LLDB 14
* [`f0938ab8`](https://github.com/NixOS/nixpkgs/commit/f0938ab85f45f45feea9e85156644ad574305256) lldb: add support for Lua bindings in LLDB-git
* [`f893f280`](https://github.com/NixOS/nixpkgs/commit/f893f280190f247c52954f9a3af3f9cec1ac54ee) crystfel-headless: fix wrapProgram dependency
* [`1f393715`](https://github.com/NixOS/nixpkgs/commit/1f3937158bc5ad156b3cbfe70374eabe94c45da3) outline: 0.65.2 -> 0.66.1
* [`4078880a`](https://github.com/NixOS/nixpkgs/commit/4078880ab4ee02cfcfee683f66bba95c8acbb81d) pinniped: 0.19.0 -> 0.20.0
* [`dd480e22`](https://github.com/NixOS/nixpkgs/commit/dd480e2235f849c4f0b8d9cbbf501be916b13d0b) qcad: fix executable path in .desktop file
* [`eaaf02d9`](https://github.com/NixOS/nixpkgs/commit/eaaf02d9c43f900c22a05d44529b14921f432a92) 1password-gui: Patch `op-ssh-sign`
* [`91879ce1`](https://github.com/NixOS/nixpkgs/commit/91879ce1604060e3b91d275f7686b98d2357c9a6) make-options-doc: Make optionIdPrefix configurable ("opt-")
* [`216c5dc1`](https://github.com/NixOS/nixpkgs/commit/216c5dc10dd9d842909fe256567e9aeda3212396) nixos/doc: Disambiguate test option ids
* [`e1db0a9a`](https://github.com/NixOS/nixpkgs/commit/e1db0a9aa59b395fcf7ebc04e9a37451c6f750b5) python310Packages.django-annoying: init at 0.10.6
* [`5a4f2b5a`](https://github.com/NixOS/nixpkgs/commit/5a4f2b5a8adf11bd28e960e8aa24c42d9f91f307) python310Packages.django-autocomplete-light: init at 3.9.4
* [`5c71b233`](https://github.com/NixOS/nixpkgs/commit/5c71b2335b8ecbb0aa18d0c2dfd1c4c4606f4985) python310Packages.django-hcaptcha: init at 0.2.0
* [`1c6d12b9`](https://github.com/NixOS/nixpkgs/commit/1c6d12b9f4719525e6ea67a90152abd3f7aa1334) python310Packages.django-crispy-forms: init at 1.14.0
* [`20c95ad0`](https://github.com/NixOS/nixpkgs/commit/20c95ad03a73d7cadd61d2af8799f55e331e1375) python310Packages.django-js-reverse: init at 2022-09-16
* [`cdb99182`](https://github.com/NixOS/nixpkgs/commit/cdb99182adfecc5a3cb0df158bc9509bce94edf7) python310Packages.django-scopes: init at 1.2.0.post1
* [`682ebaaf`](https://github.com/NixOS/nixpkgs/commit/682ebaafa296239f78852eb456b5b1c7f5d32064) python310Packages.bleach-allowlist: init at 1.0.3
* [`6505d75b`](https://github.com/NixOS/nixpkgs/commit/6505d75bd1aaff52e2d9c7a676b543750e7c1e00) python310Packages.jstyleson: init at 2022-09-16
* [`b0f1f710`](https://github.com/NixOS/nixpkgs/commit/b0f1f710ae3ed2f9c18f655c62c951ded32e568b) python310Packages.microdata: init at 0.8.0
* [`f0b2aba7`](https://github.com/NixOS/nixpkgs/commit/f0b2aba79ca45a0b79b043d11800e300bb1e4bf5) python310Packages.html-text: init at 0.5.2
* [`ac7c5852`](https://github.com/NixOS/nixpkgs/commit/ac7c5852e58ff738895077979b87f34951da94b6) python310Packages.mf2py: init at 1.1.2
* [`8c3ae390`](https://github.com/NixOS/nixpkgs/commit/8c3ae3902d6c87c65cb7f5b90a66ac18cb61e6c4) python310Packages.pyrdfa3: init at 3.5.3
* [`48919bc2`](https://github.com/NixOS/nixpkgs/commit/48919bc2246e23673b322dd02c347473cc67380d) python310Packages.extruct: init at 0.13.0
* [`d1710a21`](https://github.com/NixOS/nixpkgs/commit/d1710a21fc463437d6396b481882c86f07f75050) python310Packages.language-tags: init at 1.1.0
* [`c9185dbf`](https://github.com/NixOS/nixpkgs/commit/c9185dbf9189452c543d93e3888b2cc4445dbc69) python310Packages.recipe-scrapers: init at 14.14.0
* [`81ab6b59`](https://github.com/NixOS/nixpkgs/commit/81ab6b593ba7e9df0be3378587a425b0576b6a2e) python310Packages.drf-writable-nested: init at 0.6.4
* [`f2a7a771`](https://github.com/NixOS/nixpkgs/commit/f2a7a77151999ef7aa074318ca7dadc59452da5b) python310Packages.django-cors-headers: 3.7.0 -> 3.13.0
* [`334ca79a`](https://github.com/NixOS/nixpkgs/commit/334ca79a7b3f0eb8a0e7d6162aae9bbd59a563b5) python310Packages.django-oauth-toolkit: relax 'django' dependency
* [`284e8949`](https://github.com/NixOS/nixpkgs/commit/284e89493f5507c4fa03decaeabf9bd68b980239) python310Packages.djangorestframework: fix 'collectstatic' with django 4.1
* [`be1d3742`](https://github.com/NixOS/nixpkgs/commit/be1d3742e8a019eddc2c2fb99e7670fda16ea8fb) google-cloud-sdk: Fix default component arches
* [`3cb0c662`](https://github.com/NixOS/nixpkgs/commit/3cb0c6624c282ab7cc553d05e8d19005c2e8fab8) libbpf: add libbpf_1 for libbpf 1.0.1
* [`b752a370`](https://github.com/NixOS/nixpkgs/commit/b752a370b1f5911cd6f85fd4c501840c4d17082d) synapse-admin: fix build after 7753a94a354
* [`c75df461`](https://github.com/NixOS/nixpkgs/commit/c75df461fd8614581c54b51c9f83159e7b94d0cb) maintainers: add cwyc
* [`3b17478e`](https://github.com/NixOS/nixpkgs/commit/3b17478e4d926f6a5852454ab5d21ece5e101bc7) androidStudioPackages.stable: 2021.2.1.15 -> 2021.3.1.16
* [`9f9764d7`](https://github.com/NixOS/nixpkgs/commit/9f9764d70293bf75063fed17b24bc84e7362f2aa) androidStudioPackages.canary: 2022.1.1.8 -> 2022.2.1.2
* [`f10cc2ab`](https://github.com/NixOS/nixpkgs/commit/f10cc2ab0fa8933795a5ed79cf644002ac89f058) androidStudioPackages.beta: 2021.3.1.14 -> 2022.1.1.11
* [`f4ab764c`](https://github.com/NixOS/nixpkgs/commit/f4ab764c9d936e177f6835c908d685b8ac4a00f7) arguments: rename name to pname&version
* [`dc5e294e`](https://github.com/NixOS/nixpkgs/commit/dc5e294e0bbb496837e8d21afafbcb2f5f763b23) gotop: 4.1.4 -> 4.2.0
* [`8e7161ed`](https://github.com/NixOS/nixpkgs/commit/8e7161ed80a7c70df2d15c6cf37d7e3bf22a5e2d) rPackages.rmarkdown: add pandoc as buildInput
* [`e03e61f6`](https://github.com/NixOS/nixpkgs/commit/e03e61f62e698b42cfbaed1b86acfd6ae3f0a7b0) nixos.fwupd: add remote list option
* [`1d46810f`](https://github.com/NixOS/nixpkgs/commit/1d46810fc4b372826699a25b114673f82ad30982) slack: fix build on x86_64-darwin
* [`2965d777`](https://github.com/NixOS/nixpkgs/commit/2965d7774d5cbf59c1944d618b426d379e14b75c) nix-prefetch-github: 5.2.1 -> 5.2.2
* [`7414171d`](https://github.com/NixOS/nixpkgs/commit/7414171dd1b127a961efb18a76296b61831e929e) dendrite: 0.9.9 -> 0.10.1
* [`f6e9a942`](https://github.com/NixOS/nixpkgs/commit/f6e9a942863d6dd71917abb4a6e1dee3a63858ad) nordzy-icon-theme: 1.6 -> 1.7
* [`918a5d36`](https://github.com/NixOS/nixpkgs/commit/918a5d36a28328c75e37d94456591bd635137e0a) sonic-lineup: mark broken
* [`5a012749`](https://github.com/NixOS/nixpkgs/commit/5a012749d5c57caf20e8fd89901d18ac9bbcd56c) adom: mark broken
* [`88eed826`](https://github.com/NixOS/nixpkgs/commit/88eed8261dddc85d6f9708302a4004fb9183e5c5) xarchiver: 0.5.4.18 -> 0.5.4.19
* [`4f8178d5`](https://github.com/NixOS/nixpkgs/commit/4f8178d5e39af6eadad1b4c579180771adbf3eaf) linux_testing_bcachefs: unstable-2022-04-25 -> unstable-2022-09-28
* [`a4a5d27b`](https://github.com/NixOS/nixpkgs/commit/a4a5d27b2b87ee5cd409cb7fb292229593858fc3) bcachefs-tools: unstable-2022-05-02 -> unstable-2022-09-28
* [`991585e1`](https://github.com/NixOS/nixpkgs/commit/991585e1512b122d7f45c6a6bca379ceff071367) gotop: split man output
* [`5c24cfdc`](https://github.com/NixOS/nixpkgs/commit/5c24cfdc8866670312b2c967c0702ca01c1d627d) retroarch: 1.10.3 -> 1.11.0
* [`bbcaaeb9`](https://github.com/NixOS/nixpkgs/commit/bbcaaeb97d650db3c10d6c546699fce2140c0afe) retroarch: add nixosTests.retroarch as passthru.tests
* [`8a8ea9ba`](https://github.com/NixOS/nixpkgs/commit/8a8ea9bacdc714e5b237aa50bd6398292d657481) libretro: unstable-2022-04-21 -> unstable-2022-10-01
* [`0eadc3bb`](https://github.com/NixOS/nixpkgs/commit/0eadc3bbf285bd6d66ff2071047148534668b563) maintainers: add libretro team, use it in retroarch/libretro
* [`afb11da7`](https://github.com/NixOS/nixpkgs/commit/afb11da7dd0f47a17fb21ec9aa68d698fe55c100) luaPackages: update
* [`884a2d31`](https://github.com/NixOS/nixpkgs/commit/884a2d31797b71c92aae275ff20f97f9daeb4240) luaPackages.jsregexp: init at 0.0.5-1
* [`19a47178`](https://github.com/NixOS/nixpkgs/commit/19a47178461e509bcd3821cea3b92e8deba20a40) directoryListingUpdater: init
* [`0b9c39e8`](https://github.com/NixOS/nixpkgs/commit/0b9c39e819f7cd10817ee144cd316d2444e98b6f) gitUpdater: fix variable default value
* [`a15e0833`](https://github.com/NixOS/nixpkgs/commit/a15e083372a19aaa04b4a8ce4c36be52295bfe42) httpTwoLevelsUpdater: fix variable default value
* [`767b1fd5`](https://github.com/NixOS/nixpkgs/commit/767b1fd5da953432779e6c684f4b93b7fb4fcac4) enlightenment.enlightenment: add update script
* [`f1b0b727`](https://github.com/NixOS/nixpkgs/commit/f1b0b727b455a44ae45fb27fed39b195910bb671) all-cabal-hashes: 2022-09-28T11:00:39Z -> 2022-10-01T15:28:21Z
* [`f486658d`](https://github.com/NixOS/nixpkgs/commit/f486658da49c6f501f5f99973b5331aa06d952ab) haskell.packages.ghc924.alex: remove obsolete override
* [`c5b04c91`](https://github.com/NixOS/nixpkgs/commit/c5b04c91442728619ec2ac4e192e5400621147c4) firefox: address automated review comments
* [`49bc117c`](https://github.com/NixOS/nixpkgs/commit/49bc117c6c0d35812065e9895632c2bac8163d2b) libretro: remove unnecessary code
* [`ec66f492`](https://github.com/NixOS/nixpkgs/commit/ec66f492688d2e0019794a3e44a1ba524f7ed858) libretro.citra: remove gcc10Stdenv override
* [`a8218609`](https://github.com/NixOS/nixpkgs/commit/a82186094c7b1bb9dbd92a9a70dcc2724a8b3215) libretro.dosbox: remove gcc10Stdenv override
* [`919ac6f9`](https://github.com/NixOS/nixpkgs/commit/919ac6f91fe4096aac1526b211ea0c5573bfbebb) clairvoyance: init at 2.0.4
* [`8c045370`](https://github.com/NixOS/nixpkgs/commit/8c0453705721d167247bc9934492fa09d5eb18fe) dirstalk: init at 1.3.3
* [`51f5c659`](https://github.com/NixOS/nixpkgs/commit/51f5c65914d2adf62907e3fd95acb5d8da3ee076) gnupg: unbreak builds without tpm2-tss
* [`cad97ab9`](https://github.com/NixOS/nixpkgs/commit/cad97ab908b1579651cc4b245b60b5d9eba69727) elpa-packages: updated 2022-10-01 (from overlay)
* [`a2cf6b9e`](https://github.com/NixOS/nixpkgs/commit/a2cf6b9e596403764f489d909da0d08666acdb8d) melpa-packages: updated 2022-10-01 (from overlay)
* [`5320dc63`](https://github.com/NixOS/nixpkgs/commit/5320dc6325c6a214d6d4ba5df4faa7a29aa16103) nongnu-packages: updated 2022-10-01 (from overlay)
* [`95bf0d35`](https://github.com/NixOS/nixpkgs/commit/95bf0d35e0623ec7fad711701eece84dfdee76e4) python310Packages.djangorestframework-simplejwt: 5.2.0 -> 5.2.1
* [`9b22789d`](https://github.com/NixOS/nixpkgs/commit/9b22789d628f93d813defd93a28bed45518e4bbc) argo: 3.3.9 -> 3.4.1
* [`312d7560`](https://github.com/NixOS/nixpkgs/commit/312d75605a3e1faa823e132c04cbf2731e5d0289) hdl-dump: unstable-2021-08-20 -> unstable-2022-09-19
* [`91766f2a`](https://github.com/NixOS/nixpkgs/commit/91766f2ab6bec64f2aad895c69b72760ee61180f) python310Packages.djangorestframework-simplejwt: disable on older Python releases
* [`9d97b342`](https://github.com/NixOS/nixpkgs/commit/9d97b342de4dcbe74a7413c6497a75a42afbf58d) haskell.packages.ghc942: get inital support up
* [`107160d3`](https://github.com/NixOS/nixpkgs/commit/107160d3426d3448492d60436f040d3e69feca44) dotnet-sdk: move license files to the proper folder
* [`d13fec95`](https://github.com/NixOS/nixpkgs/commit/d13fec959153c6a09e06f1df4ee74a8953bc5382) python310Packages.azure-mgmt-containerservice: 20.3.0 -> 20.4.0
* [`eefaaf41`](https://github.com/NixOS/nixpkgs/commit/eefaaf41d67ea28c3f70150958f6a29533dce709) kubo: rename from ipfs
* [`4e62f981`](https://github.com/NixOS/nixpkgs/commit/4e62f9810aab1e90229390af3238a3cc5b1f67e4) python310Packages.ibeacon-ble: init at 0.7.3
* [`5ebce6ac`](https://github.com/NixOS/nixpkgs/commit/5ebce6acee365f5c1b855432a2448cf7ae743484) python310Packages.azure-mgmt-monitor: 4.0.1 -> 5.0.1
* [`49b29907`](https://github.com/NixOS/nixpkgs/commit/49b299074d4fbd2becdc6dbc5362a3d0fc2fb2b1) k3s: convenience change to update script
* [`e63a3267`](https://github.com/NixOS/nixpkgs/commit/e63a3267ca635b085d61ba130400f10bc4cd8aa5) python310Packages.kegtron-ble: init at 0.4.0
* [`737f67bb`](https://github.com/NixOS/nixpkgs/commit/737f67bbcea1ec14f0abb04100bb7112274f9348) maintainers: add nullishamy
* [`049c5e90`](https://github.com/NixOS/nixpkgs/commit/049c5e902652601f24768af59fc6510e6da5b797) diffoscope: revised tests failing
* [`4c0eb8eb`](https://github.com/NixOS/nixpkgs/commit/4c0eb8eb9e3ad2ea1807a622f359ab1baa1bf9b3) nsync: add Luflosi as maintainer
* [`3f2381e4`](https://github.com/NixOS/nixpkgs/commit/3f2381e4bd9144d01bb2f04c79c6e5e7a566b5b3) nsync: fix build on macOS
* [`cd7bcc91`](https://github.com/NixOS/nixpkgs/commit/cd7bcc91744b8d46b0fb882f5b97ff8f123aa02a) nsync: 1.24.0 -> 1.25.0
* [`a95999ea`](https://github.com/NixOS/nixpkgs/commit/a95999ea7f2973823d2c5ecdbb72196b0a87bf4b) flutter: 3.3.0->3.3.3, flutter.dart: 2.18.0->2.18.2
* [`3d200bd9`](https://github.com/NixOS/nixpkgs/commit/3d200bd959e9b448e52212e9989e109c6dce3ab4) nixos/tests/k3s: fix tests
* [`2d55e4d1`](https://github.com/NixOS/nixpkgs/commit/2d55e4d1eed9c39fcadea9ebbbd46ea4f866f3f7) k3s: 1.25.2+k3s1 -> 1.25.2+k3s1
* [`ea6b6a46`](https://github.com/NixOS/nixpkgs/commit/ea6b6a46b6ebccd75a178ce7b331accf864e806f) coreboot-configurator: init at 2022-08-22
* [`fcab0c74`](https://github.com/NixOS/nixpkgs/commit/fcab0c7453fa3e983fcf6e874dffd5e0d6bcfae6) python310Packages.django-reversion: 5.0.2 -> 5.0.3
* [`2bdae5ca`](https://github.com/NixOS/nixpkgs/commit/2bdae5cabd9fa160a9f5892c4ac19082e8aa8939) flutter: refactor packages
* [`82d94d1a`](https://github.com/NixOS/nixpkgs/commit/82d94d1aeda2086c92c817ad0486532cb72a5298) libcec: remove ? null from inputs, use postPatch
* [`058a81c3`](https://github.com/NixOS/nixpkgs/commit/058a81c348d86cc1341e0639e02ace6f9eacc742) nautilus-open-any-terminal: 0.3.0 -> 0.4.0
* [`4a74e239`](https://github.com/NixOS/nixpkgs/commit/4a74e239b5fd022cb5dcb2f788b311ab8ae4699a) flutter: add flutter2 package
* [`30e0247a`](https://github.com/NixOS/nixpkgs/commit/30e0247a1594bd3cc0eafba7d429df525520d672) libretro.mame*: enableParallelBuilding = true
* [`946474ca`](https://github.com/NixOS/nixpkgs/commit/946474ca0fdcde59fc05027fbd511ab3ce46131a) firmware-updater: build with flutter2
* [`7b0109a5`](https://github.com/NixOS/nixpkgs/commit/7b0109a592140fa67c455519599239abc78876d4) fluffychat: build with flutter2
* [`e2a22846`](https://github.com/NixOS/nixpkgs/commit/e2a22846581333e02cca7a79df758a1f2e29f631) electrum: make compatible with protobuf 4+
* [`f3313e87`](https://github.com/NixOS/nixpkgs/commit/f3313e870c74cb2406b1605cf0843eb58e78b5fb) libretro.parallel-n64: return aarch64 patch
* [`400b95cf`](https://github.com/NixOS/nixpkgs/commit/400b95cfb94e78f68c1e48e37e19f0c724d4039a) libretro.blastem: mark it only available in x86
* [`943e48e0`](https://github.com/NixOS/nixpkgs/commit/943e48e0a2b207a8583a43566dc1b70052f3d8aa) python310Packages.huawei-lte-api: 1.6.1 -> 1.6.2
* [`e22ce12a`](https://github.com/NixOS/nixpkgs/commit/e22ce12a8e4d3e6f1400879cd1925845d760e049) apple-music-electron: remove
* [`650e4347`](https://github.com/NixOS/nixpkgs/commit/650e434781a3b0458a610132d0cf1a6d1152f0c1) libretro.flycast: fix aarch64-linux build
* [`5620b7cc`](https://github.com/NixOS/nixpkgs/commit/5620b7ccad9447c8335e56587bcbe7630ab1e592) libretro.mame{2015,2016}: disable enableParallelBuilding again
* [`bcca922d`](https://github.com/NixOS/nixpkgs/commit/bcca922de57099a275284616e63b975fb0e6dce8) prusa-slicer: Fix STEP format support
* [`34687f1a`](https://github.com/NixOS/nixpkgs/commit/34687f1a5e2bd16a0562bc997987f5dbac6e9623) vimPlugins: update
* [`85710fbd`](https://github.com/NixOS/nixpkgs/commit/85710fbd86ca92f6fcb21fa46a57798c79afab80) vimPlugins: resolve github repository redirects
* [`7d0d078d`](https://github.com/NixOS/nixpkgs/commit/7d0d078d504a04dc18a303b7e4c29f354dbdbceb) vimPlugins.template-string-nvim: init at 2022-08-18
* [`3565d556`](https://github.com/NixOS/nixpkgs/commit/3565d5566c399d9625d77efb0e97e1797197c470) vimPlugins.nvim-rename-state: init at 2022-09-29
* [`eadcfe74`](https://github.com/NixOS/nixpkgs/commit/eadcfe74dd9dabd9f4477f9666568071e2d1d9f2) vimPlugins.nvim-highlight-colors: init at 2022-09-28
* [`4607eebf`](https://github.com/NixOS/nixpkgs/commit/4607eebf3a8bd69c2fb0e1dfe1ce7c6090d7346c) vimPlugins.auto-save-nvim: init at 2022-08-06
* [`85301d07`](https://github.com/NixOS/nixpkgs/commit/85301d07cd52c36fadfc1b83fbebd1d3b4d88bff) vimPlugins.vim-clap: fix cargoSha256
* [`90b6f0d2`](https://github.com/NixOS/nixpkgs/commit/90b6f0d20a6e46de0b8a14ee52fe45326c9375ce) kooha: 2.0.1 -> 2.2.2
* [`abb91732`](https://github.com/NixOS/nixpkgs/commit/abb91732c5f32dfb784c7d2fc6c98465da52296c) signal-cli: 0.10.11 -> 0.11.0
* [`6ba7e643`](https://github.com/NixOS/nixpkgs/commit/6ba7e643cd29bcbf96d11629a7cb98d7d95a36df) srain: 1.4.1 -> 1.5.0
* [`8b920d91`](https://github.com/NixOS/nixpkgs/commit/8b920d919c81ebf563aba7d8bb1e12e294605c95) maintainers/team-list: Update feature freeze team selection
* [`e08918e9`](https://github.com/NixOS/nixpkgs/commit/e08918e91dd646e24001dd59fa7999bf39d25981) maintainers/team-list: Extend `enableFeatureFreezePing` documentation
* [`a9d24bd6`](https://github.com/NixOS/nixpkgs/commit/a9d24bd6573bb7d57079eb7701b8588cfb563ebd) julia_18: 1.8.1 -> 1.8.2
* [`c2524134`](https://github.com/NixOS/nixpkgs/commit/c2524134627a12c61f44195ac61418f219eadee5) python310Packages.pydmd: 0.4.0.post2209 -> 0.4.0.post2210
* [`f80241ac`](https://github.com/NixOS/nixpkgs/commit/f80241ac54d9a17d0f5719f5b62d5d80afac3c84) julia_18-bin: 1.8.1 -> 1.8.2
* [`91290ad7`](https://github.com/NixOS/nixpkgs/commit/91290ad711cc18e63d42a2e41ea29d9c97952f4c) python310Packages.pynobo: 1.4.0 -> 1.5.0
* [`fdea7ee0`](https://github.com/NixOS/nixpkgs/commit/fdea7ee093d24adcc96666e4238d08ca656b213e) python310Packages.pyoctoprintapi: 0.1.8 -> 0.1.9
* [`292aab98`](https://github.com/NixOS/nixpkgs/commit/292aab9822c1f0fcdabdfd81e6dd8db1e39df894) nixos/systemd: update extraConfig description
* [`ea3a5307`](https://github.com/NixOS/nixpkgs/commit/ea3a530764ff2b00860ba55286967981bbcc59a5) zfsbackup: unstable-2021-05-26 -> unstable-2022-09-23
* [`009650d1`](https://github.com/NixOS/nixpkgs/commit/009650d1ea1f496103a8ef96ead4d39b4c1f3a01) python310Packages.pyswitchbot: 0.19.8 -> 0.19.13
* [`fca54275`](https://github.com/NixOS/nixpkgs/commit/fca54275947cd6b7698bbc3d7cd25920174666a5) gophernotes: unpin go1.17
* [`97889527`](https://github.com/NixOS/nixpkgs/commit/978895272f8366f1a8545b26365ec0039b42ab5d) safe: unpin go1.17
* [`a4d7d4b0`](https://github.com/NixOS/nixpkgs/commit/a4d7d4b0007079f78238d574725c4b6067c87a45) zoom-us: 5.11.{9.10046,10.4400} -> 5.12.0.{11129,4682}
* [`28fd333c`](https://github.com/NixOS/nixpkgs/commit/28fd333c1dcbcc9893c25702f13f2b867723183e) uwimap: fix build on darwin
* [`a0a570bf`](https://github.com/NixOS/nixpkgs/commit/a0a570bf789c20cc1d7376248c8273500fad6e3a) pkgsStatic.lz4: fix build
* [`897b8fa5`](https://github.com/NixOS/nixpkgs/commit/897b8fa5fbabe0f6cf341ae4899d037826239d56) python310Packages.pynobo: disable on older Python relleases
* [`41963339`](https://github.com/NixOS/nixpkgs/commit/41963339b973da3e3782e227aee22e3537f21909) pkgsStatic.protobuf: fix installation of protoc
* [`d6a4694b`](https://github.com/NixOS/nixpkgs/commit/d6a4694b65b879941a07f544ca9f7b8dfa766dc2) python310Packages.meshtastic: 1.3.36 -> 1.3.37
* [`635a92a2`](https://github.com/NixOS/nixpkgs/commit/635a92a26afecc6be4f90fe4f38768e111296043) python310Packages.velbus-aio: 2022.9.1 -> 2022.10.1
* [`b72c3fe1`](https://github.com/NixOS/nixpkgs/commit/b72c3fe1afedbc5876db3c12a91941e7e3d63546) python310Packages.venstarcolortouch: 0.18 -> 0.19
* [`79ab1e63`](https://github.com/NixOS/nixpkgs/commit/79ab1e634b038667be4b089fca75e3c8d60d2eb1) python310Packages.yolink-api: 0.0.9 -> 0.1.0
* [`635239b6`](https://github.com/NixOS/nixpkgs/commit/635239b68f20904e1af493c6f4f6872e52abe8d7) python310Packages.qcs-api-client: 0.21.1 -> 0.21.2
* [`6428e72f`](https://github.com/NixOS/nixpkgs/commit/6428e72f1a10121cf628446a46ca2a74c75b7e35) python310Packages.time-machine: 2.8.1 -> 2.8.2
* [`9ef4c7f4`](https://github.com/NixOS/nixpkgs/commit/9ef4c7f4f6b23a8f0f4c59fa6de68494389411e6) nmap: 7.92 -> 7.93
* [`cff9cc73`](https://github.com/NixOS/nixpkgs/commit/cff9cc73cf885ef688a6db682b1b08d68bb2a1d3) perlPackages.X11Protocol: drop unused pkgs.xlibsWrapper build input
* [`62c7443b`](https://github.com/NixOS/nixpkgs/commit/62c7443beb8221418eba1d987e5d78be85de8a16) vdr: Set platform to linux
* [`00d53d21`](https://github.com/NixOS/nixpkgs/commit/00d53d212b4cfa317287f3670fd215bdbb5891d3) flyctl: 0.0.402 -> 0.0.403
* [`6a1359e4`](https://github.com/NixOS/nixpkgs/commit/6a1359e4a236ef32d5f9fcdf6e533d269a659bf1) tandoor-recipes: init at 1.4.1
* [`d8b1d348`](https://github.com/NixOS/nixpkgs/commit/d8b1d3480664e226f3d39fa4bae846131f8b9382) nixos/tandoor-recipes: init module
* [`91ba8464`](https://github.com/NixOS/nixpkgs/commit/91ba8464f472250ffebff579a16288321b6ca302) nixos/tandoor-recipes: add test
* [`83f5c2d5`](https://github.com/NixOS/nixpkgs/commit/83f5c2d5ecb08d1aaaae1df0a5d2af02befeea0e) tandoor-recipes: add 'passthru.tests'
* [`d81b7507`](https://github.com/NixOS/nixpkgs/commit/d81b7507f0b40f3137f3b611b963ea5ddb4b14a3) php: enable `imap` extension by default
* [`fcc90e16`](https://github.com/NixOS/nixpkgs/commit/fcc90e16ae0b01605d9090e406a303e5dd9a90bb) perlPackages.X11GUITest: drop pkgs.xlibsWrapper build input
* [`0aede75e`](https://github.com/NixOS/nixpkgs/commit/0aede75ecf9db5bc07119021fbfb3f51101b5fe3) vdrPlugins.femon: switch src
* [`1b015cf5`](https://github.com/NixOS/nixpkgs/commit/1b015cf57b6bc1dac2e066ca991153d022dc81b8) ucx: 1.13.0 -> 1.13.1
* [`fe181e0f`](https://github.com/NixOS/nixpkgs/commit/fe181e0f943b41060cd90c777d34b69fb73aa0e2) vdrPlugins.markad: 3.0.25 -> 3.0.26
* [`2de6316b`](https://github.com/NixOS/nixpkgs/commit/2de6316bbfc1028309210aac1f608d8629115b84) vdrPlugins.epgsearch: switch src
* [`360892ca`](https://github.com/NixOS/nixpkgs/commit/360892caf563ea0c2eb9a86327eb4701775287ac) vdrPlugins.vnsiserver: 1.8.0 -> 1.8.1
* [`59bb395f`](https://github.com/NixOS/nixpkgs/commit/59bb395f1c527afa9e5adbd51c3972183ac1d650) vdrPlugins.softhddevice: 1.9.0 -> 1.9.2
* [`7fae1d6f`](https://github.com/NixOS/nixpkgs/commit/7fae1d6f7a1c702040133ee04083f9ee08aa8a4f) vdrPlugins: get homepage from src
* [`ca12fe8f`](https://github.com/NixOS/nixpkgs/commit/ca12fe8fcd60eeb9ad6b866f319292ab728defe2) panoply: 5.2.0 -> 5.2.1
* [`4d6abfa6`](https://github.com/NixOS/nixpkgs/commit/4d6abfa6b41713fa39eca871800711713c90152b) octopus: 11.4 -> 12.0
* [`16e2cfc5`](https://github.com/NixOS/nixpkgs/commit/16e2cfc5b1157bf3913578bdacb38662251f80fb) aws-sso-cli: 1.9.2 -> 1.9.4
* [`691ce42a`](https://github.com/NixOS/nixpkgs/commit/691ce42a4519e667d83f5f3a46e0584bf955db00) cudatext: 1.171.0 -> 1.172.0
* [`c04611da`](https://github.com/NixOS/nixpkgs/commit/c04611da264995cbaee32c500e2c3b17bd83d9c2) nvtop: 2.0.3->2.0.4
* [`0faffb55`](https://github.com/NixOS/nixpkgs/commit/0faffb55310c6ac42b0741b6a52b88482ae41f96) linux/6.0: init
* [`dbf1d73c`](https://github.com/NixOS/nixpkgs/commit/dbf1d73cd1a17276196afeee169b4cf7834b7a96) perf: fix build with kernel 6.0
* [`0d722e8e`](https://github.com/NixOS/nixpkgs/commit/0d722e8e1b409fddebb33a3d190e32dc89de1d3d) wasm-bindgen-cli: 0.2.82 -> 0.2.83 ([nixos/nixpkgs⁠#194122](https://togithub.com/nixos/nixpkgs/issues/194122))
* [`fad386ba`](https://github.com/NixOS/nixpkgs/commit/fad386bad17441c8954736ffd61935c7af889677) firefox-beta-bin-unwrapped: 106.0b5 -> 106.0b7
* [`f33230dc`](https://github.com/NixOS/nixpkgs/commit/f33230dc4c0a51a8ffa10cb11ae614e9c1e82145) firefox-devedition-bin-unwrapped: 106.0b5 -> 106.0b7
* [`c8841341`](https://github.com/NixOS/nixpkgs/commit/c884134125abd09589cab5cdcae27f791221004c) kitty: 0.25.2 -> 0.26.2
* [`5f53dac6`](https://github.com/NixOS/nixpkgs/commit/5f53dac66aa7df8d2837b60f87aa1fcefb5f3ad1) pkgs/top-level: convert to MD option docs
* [`a75e477c`](https://github.com/NixOS/nixpkgs/commit/a75e477c016b68f0d4a9575f02136f226eaa224e) cargo-lock: init at 8.0.2
* [`a222ca46`](https://github.com/NixOS/nixpkgs/commit/a222ca468ea31c0ebf5ba11488dec4dec4c45b5b) python3Packages.tensorboardx: 2.5 -> 2.5.1
* [`0aee8718`](https://github.com/NixOS/nixpkgs/commit/0aee87185d4307fac15902986085b42ed27ac33f) rippled: unpin protobuf
* [`06ed064a`](https://github.com/NixOS/nixpkgs/commit/06ed064a3ed6d8adbec2704e2f90a4fe31823273) ibus-engines.mozc: unpin protobuf
* [`3d1c9951`](https://github.com/NixOS/nixpkgs/commit/3d1c995185ef4878a21851bc8ad1ab2082f2435d) python3Packages.coqui-trainer: unpin protobuf
* [`397ad93d`](https://github.com/NixOS/nixpkgs/commit/397ad93dd379d33205f7a6522dc3088a135f2ce2) Apply suggestions from code review
* [`66044f7e`](https://github.com/NixOS/nixpkgs/commit/66044f7e4384e12ffd68ce7d7372fcdcb528a358) artem: init at 1.1.5
* [`ada96976`](https://github.com/NixOS/nixpkgs/commit/ada969769ee4a62125ed27253efe4da9f9d518f5) cubiomes-viewer: 2.4.1 -> 2.5.0
* [`e9bd62f6`](https://github.com/NixOS/nixpkgs/commit/e9bd62f650d9ca273d14856bad8bc3326c452f6f) simdjson: 2.2.2 -> 2.2.3
* [`18b770c0`](https://github.com/NixOS/nixpkgs/commit/18b770c06b6c8cb78179f638bed8f31f444d4341) x42-plugins: 20220714 -> 20220923
* [`4ad8209b`](https://github.com/NixOS/nixpkgs/commit/4ad8209b12331a32c779e7f04dc8e60132062b24) pocketbase: 0.7.6 -> 0.7.7
* [`16fde6b3`](https://github.com/NixOS/nixpkgs/commit/16fde6b3487394644da7e3c830bb99c4f0bf4acf) adguardhome: 0.107.12 -> 0.107.14
* [`64eafc25`](https://github.com/NixOS/nixpkgs/commit/64eafc25d69cd84ed9c41e00b9ab8db3e4a02b6e) Update source to fix [nixos/nixpkgs⁠#194116](https://togithub.com/nixos/nixpkgs/issues/194116)
* [`07400e6c`](https://github.com/NixOS/nixpkgs/commit/07400e6c09c8d5242c3526063b5ec822385d7311) oh-my-zsh: 2022-09-10 -> 2022-10-03
* [`d7652698`](https://github.com/NixOS/nixpkgs/commit/d76526987254786d5fe08702f9bea079898cd5fe) traefik: 2.8.8 -> 2.9.1
* [`1085ad55`](https://github.com/NixOS/nixpkgs/commit/1085ad554ffecf098555c77b0a40f4b14b51f940) verilator: 4.224 -> 4.226
* [`25b70355`](https://github.com/NixOS/nixpkgs/commit/25b70355131d06500cdc0d603563c40ebcef5b3a) open-watcom-v2-unwrapped: unstable-2022-08-02 -> unstable-2022-10-03
* [`d1c2066a`](https://github.com/NixOS/nixpkgs/commit/d1c2066afb691ebc97968f43c752e1962ddd303a) ungoogled-chromium: 106.0.5249.62 -> 106.0.5249.91
* [`9c87e6e1`](https://github.com/NixOS/nixpkgs/commit/9c87e6e1a64a79698912be7197fabe9e24d4c48e) vimPlugins.command-t: fix build on darwin
* [`b1e552ef`](https://github.com/NixOS/nixpkgs/commit/b1e552ef27aa8e43a4099bcd138fc9f86666460c) jaq: 0.8.0 -> 0.8.1
* [`ef0c3cfd`](https://github.com/NixOS/nixpkgs/commit/ef0c3cfde614aa72b6362b4d3da62a6c3c30a9a9) jqp: 0.2.0 -> 0.3.0
* [`0827eed1`](https://github.com/NixOS/nixpkgs/commit/0827eed12918b2fd5b1d99eefae056d4333405fd) python310Packages.aioesphomeapi: 11.0.0 -> 11.1.0
* [`f9c2d606`](https://github.com/NixOS/nixpkgs/commit/f9c2d606a1e478daeec4eddb5ecab453e69a5124) python310Packages.atomman: 1.4.5 -> 1.4.6
* [`42e73857`](https://github.com/NixOS/nixpkgs/commit/42e7385777b3d5513534da2e2f1dce81894b4fd4) python310Packages.aiounifi: 35 -> 36
* [`0deec20d`](https://github.com/NixOS/nixpkgs/commit/0deec20d46dd26e5fcfc3ce232ea2de94719d75d) binutils: drop R_ARM_COPY.patch
* [`b3ca7c9f`](https://github.com/NixOS/nixpkgs/commit/b3ca7c9f7b75d1d3753ef62a8272e1da2ad1ed46) canokey-qemu: init at unstable-2022-06-23
* [`4f74ae0d`](https://github.com/NixOS/nixpkgs/commit/4f74ae0d99e7a6299a84c2c782cfc76ecc00c6ba) qemu: add canokeySupport
* [`68df1186`](https://github.com/NixOS/nixpkgs/commit/68df1186376e9c33eab56ca7aa925a4aca751362) pythonPackages.pysdl2: fix build by fixing patch
* [`30cc0cde`](https://github.com/NixOS/nixpkgs/commit/30cc0cde34b5a03652d97bc74867167eb7aab260) stdenv: complete the deprecation of stdenv.glibc
* [`8240e206`](https://github.com/NixOS/nixpkgs/commit/8240e2069a060412bc90c03164a501feb3ec4914) python3Packages.ecos: fix test_interface_bb.py tests
* [`4e224a9a`](https://github.com/NixOS/nixpkgs/commit/4e224a9a64baf80f2775f7d77dbd8eee6e8887c0) maintainers: add net-mist
* [`22080b7d`](https://github.com/NixOS/nixpkgs/commit/22080b7dc0fd3e0c8ef2f65b12ba1a22125600d1) python3Packages.mkdocs-jupyter: init at 0.22.0
* [`00e30f7a`](https://github.com/NixOS/nixpkgs/commit/00e30f7ae076f6d27d047895b42f133ed02f23fd) python3Packages.nbconvert: patch bug that made mkdocs-jupyter failing
* [`69f5fb62`](https://github.com/NixOS/nixpkgs/commit/69f5fb627d32e5b529d86b51a0767cdd08107b2d) cvise: 2.5.0 -> 2.6.0
* [`8e652f2f`](https://github.com/NixOS/nixpkgs/commit/8e652f2f5cdb42c38990b550864c745b86e855bc) minio-client: 2022-09-16T09-16-47Z -> 2022-10-01T07-56-14Z
* [`cbae4c2a`](https://github.com/NixOS/nixpkgs/commit/cbae4c2af6819ea549e6cb2389564030411e9b63) minio: 2022-09-25T15-44-53Z -> 2022-10-02T19-29-29Z
* [`3a2881ab`](https://github.com/NixOS/nixpkgs/commit/3a2881abb219b610c8985fc5abbb204a80485a24) lemmeknow: init at 0.6.0
* [`4f65cecd`](https://github.com/NixOS/nixpkgs/commit/4f65cecd453709aae763e08ccc985ec8db432507) emacs: remove warning of xargs when doing AOT native-comp
* [`bd62717f`](https://github.com/NixOS/nixpkgs/commit/bd62717fd3c263629138fef08897420b2cc673ba) libinput: Add tappingButtonMap option ([nixos/nixpkgs⁠#189612](https://togithub.com/nixos/nixpkgs/issues/189612))
* [`b235629c`](https://github.com/NixOS/nixpkgs/commit/b235629c14493285453bb1325b306c9bccaf18c1) waypoint: 0.10.1 -> 0.10.2
* [`92e4b65d`](https://github.com/NixOS/nixpkgs/commit/92e4b65d22e0f47469337e6f7cff58fc3ac4e8fb) elisp-packages: fix AOT native-comp for several packages
* [`aafe8b96`](https://github.com/NixOS/nixpkgs/commit/aafe8b96171b68eeeb21a96f95c0c9c14c859ffa) ruff: 0.0.50 -> 0.0.52
* [`dfa4024a`](https://github.com/NixOS/nixpkgs/commit/dfa4024ae7145aad3cf3242750bf34ba345cec97) oh-my-posh: 11.1.1 -> 11.3.0
* [`87447d47`](https://github.com/NixOS/nixpkgs/commit/87447d47760082cb69aa0f05e0f59e23a4eb2037) polypane: init at 10.0.1 ([nixos/nixpkgs⁠#158159](https://togithub.com/nixos/nixpkgs/issues/158159))
* [`4b587a7c`](https://github.com/NixOS/nixpkgs/commit/4b587a7cb8051ffb72fa8a5c2c0b172c41a77dbb) python310Packages.pytest-subprocess: 1.4.1 -> 1.4.2
* [`fe271bca`](https://github.com/NixOS/nixpkgs/commit/fe271bcada6f757e7cbdb208c99631db60a7ddc2) goreleaser: 1.11.4 -> 1.11.5
* [`960e4e77`](https://github.com/NixOS/nixpkgs/commit/960e4e772bff4c1900e5730df1d1da9016c17aa5) input-remapper: 1.4.2 -> 1.5.0 ([nixos/nixpkgs⁠#191967](https://togithub.com/nixos/nixpkgs/issues/191967))
* [`3e117af1`](https://github.com/NixOS/nixpkgs/commit/3e117af149cde4bd6ecb5a585872d15eadf7014d) gzdoom: fix libfluidsynth not loading
* [`128f745f`](https://github.com/NixOS/nixpkgs/commit/128f745ffff126f1c90937f239ef4cfed349c3d9) gzdoom: fix IWAD selection menu
* [`35d5dd79`](https://github.com/NixOS/nixpkgs/commit/35d5dd7989580540453f47dd331bc1975949c7d8) readstat: init at 1.1.8
* [`f5355f8a`](https://github.com/NixOS/nixpkgs/commit/f5355f8a3814417490e0dc4783ee8149772ff230) pyreadstat: init at 1.1.9
* [`29ba4c72`](https://github.com/NixOS/nixpkgs/commit/29ba4c72c9ce8ad5f0c5bcab9158cff5755ae809) peertube: 4.2.2 -> 4.3.0
* [`934c03e1`](https://github.com/NixOS/nixpkgs/commit/934c03e19d8b926d960ebf1f454b10503974d397) pulumi-bin: 3.40.1 -> 3.40.2
* [`f5b3a4ab`](https://github.com/NixOS/nixpkgs/commit/f5b3a4ab7ccd0723b2e94ca3c7decc6f61890bc8) python310Packages.sphinx-book-theme: Mark as broken ([nixos/nixpkgs⁠#187401](https://togithub.com/nixos/nixpkgs/issues/187401))
* [`1d9aabad`](https://github.com/NixOS/nixpkgs/commit/1d9aabadc127934a8b65739476598529b9f1c086) pods: 1.0.0-beta.4 -> 1.0.0-beta.5
* [`052662fa`](https://github.com/NixOS/nixpkgs/commit/052662fab431c89e1e8f611aa37983c7bb3cbdac) librepcb: 0.1.6 -> 0.1.7
* [`59e3addf`](https://github.com/NixOS/nixpkgs/commit/59e3addfebc751fa3f9843dda1a831591bb86c3f) lighthouse: init at 3.1.2
* [`1a803657`](https://github.com/NixOS/nixpkgs/commit/1a8036575058f5e788a599cf2ced1f96fe964c3a) netbsd.libc: fix build
* [`388d6c1c`](https://github.com/NixOS/nixpkgs/commit/388d6c1c2f9d69731ec152eec647e1b602df1742) hashi-up: init at 0.16.0
* [`03b51707`](https://github.com/NixOS/nixpkgs/commit/03b51707ff1ac75ceb1435f7d81bbe5e80256920) lego: 4.8.0 -> 4.9.0
* [`5a65614c`](https://github.com/NixOS/nixpkgs/commit/5a65614cbdf083be2f339c645e967869e292ffb1) pythonPackages.versioningit: init at 2.0.1
* [`2034a3da`](https://github.com/NixOS/nixpkgs/commit/2034a3da5a0107070fc420bcce04c3de39d74892) streamlink: 3.2.0 -> 5.0.1
* [`1ca2296b`](https://github.com/NixOS/nixpkgs/commit/1ca2296b0391797d4c5e7260f6e02d3d3f33fe83) electron_21: init at 21.0.1
* [`525dd957`](https://github.com/NixOS/nixpkgs/commit/525dd957a14b681b6fe35ef12d3a23e349a03ca8) nil: 2022-09-26 -> 2022-10-03
* [`01a20540`](https://github.com/NixOS/nixpkgs/commit/01a2054000cff5e12b3902e12a6a8d39782bce1a) python3Packages.nototools: 0.2.16 -> 0.2.17
* [`da60d463`](https://github.com/NixOS/nixpkgs/commit/da60d463c537d2a3220236f9aa328ca57888b9a4) noto-fonts-emoji: 2.034 -> 2.038
* [`0dd481b2`](https://github.com/NixOS/nixpkgs/commit/0dd481b2ad61effd97d7215046d564953a33e526) meilisearch: 0.28.1 -> 0.29.0
* [`75a5a66a`](https://github.com/NixOS/nixpkgs/commit/75a5a66ac9751c130eddb875cbf23de05fa99f0e) python310Packages.google-cloud-appengine-logging: 1.1.4 -> 1.1.5
* [`989a9813`](https://github.com/NixOS/nixpkgs/commit/989a9813eeedd0133384f84e54090ac11420acc9) python310Packages.google-cloud-automl: 2.8.1 -> 2.8.2
* [`cbc4dc1a`](https://github.com/NixOS/nixpkgs/commit/cbc4dc1a06d16b2da564cca465b06f63384db8ef) python310Packages.google-cloud-bigquery-logging: 1.0.5 -> 1.0.6
* [`6f0689dd`](https://github.com/NixOS/nixpkgs/commit/6f0689ddca3b821cec0e758e86365a8b8db58f95) webp-pixbuf-loader: init at 0.0.6
* [`bdabb67e`](https://github.com/NixOS/nixpkgs/commit/bdabb67e3ef7cb527cde47f907fee20906c4cb98) python310Packages.google-cloud-container: 2.12.0 -> 2.12.1
* [`324f9c20`](https://github.com/NixOS/nixpkgs/commit/324f9c2003145be5345a0a8560e3215804993586) python310Packages.google-cloud-datacatalog: 3.9.1 -> 3.9.2
* [`a1526293`](https://github.com/NixOS/nixpkgs/commit/a1526293a996d648442145b5a4820082239d51fd) python310Packages.google-cloud-iot: 2.6.2 -> 2.6.3
* [`b7247cc0`](https://github.com/NixOS/nixpkgs/commit/b7247cc0ca52e2501b771c72997e93b2f95577ac) python310Packages.google-cloud-monitoring: 2.11.1 -> 2.11.2
* [`5045ac33`](https://github.com/NixOS/nixpkgs/commit/5045ac3390ea91b8fba203345a71cf56ff2bb7a6) python310Packages.google-cloud-os-config: 1.12.2 -> 1.12.3
* [`b15043de`](https://github.com/NixOS/nixpkgs/commit/b15043de261fad1ed04ede70832511e6da0bbe3b) python310Packages.google-cloud-redis: 2.9.1 -> 2.9.2
* [`5da5e8b2`](https://github.com/NixOS/nixpkgs/commit/5da5e8b220c9c424b5885b788c24c25281bf04b1) python310Packages.google-cloud-secret-manager: 2.12.4 -> 2.12.5
* [`c7d29ada`](https://github.com/NixOS/nixpkgs/commit/c7d29ada46904d79d4dc340101b57658c9d86e35) python310Packages.google-cloud-speech: 2.15.1 -> 2.16.0
* [`75d050a1`](https://github.com/NixOS/nixpkgs/commit/75d050a1d4e4a336d965736960083a2f4843ed79) python310Packages.google-cloud-tasks: 2.10.2 -> 2.10.3
* [`4e4e9ec3`](https://github.com/NixOS/nixpkgs/commit/4e4e9ec35412b455cc57bb42787a1923a4688626) python310Packages.google-cloud-texttospeech: 2.12.1 -> 2.12.2
* [`c4d202be`](https://github.com/NixOS/nixpkgs/commit/c4d202be1c12304386da8abad1a4c8293394e323) python310Packages.google-cloud-trace: 1.7.1 -> 1.7.2
* [`62597fef`](https://github.com/NixOS/nixpkgs/commit/62597fef3169d7637f401e220bbfcc6761190cf6) python310Packages.google-cloud-translate: 3.8.2 -> 3.8.3
* [`df4acb2c`](https://github.com/NixOS/nixpkgs/commit/df4acb2c9ae5c31a7775ab2b7dfe3ef9b084ef17) python310Packages.google-cloud-videointelligence: 2.8.1 -> 2.8.2
* [`a63e6225`](https://github.com/NixOS/nixpkgs/commit/a63e6225662abb27fdac613c622dcdc4b572d816) python310Packages.google-cloud-websecurityscanner: 1.9.0 -> 1.9.1
* [`6ef43258`](https://github.com/NixOS/nixpkgs/commit/6ef43258cdd11f494425d6950d8f7adcf0ebd283) python310Packages.hahomematic: 2022.9.1 -> 2022.10.0
* [`46ed81df`](https://github.com/NixOS/nixpkgs/commit/46ed81df7998953be91be39caa5b0dcd32f6a412) terraform-providers.updateScript: remove no-build
* [`a8d8d9fe`](https://github.com/NixOS/nixpkgs/commit/a8d8d9fee56c5c5632744f5c973301e6eebdd92e) .github/workflows/update-terraform-providers.yml: re-enable
* [`554317c4`](https://github.com/NixOS/nixpkgs/commit/554317c489b23c4354d14febfc7ae4f8d3b049d6) strongswan: 5.9.7 -> 5.9.8
* [`be3f2e85`](https://github.com/NixOS/nixpkgs/commit/be3f2e855475b36d3a118f9164b69ddb05a8ecea) yt-dlp: 2022.9.1 -> 2022.10.4
* [`f1243822`](https://github.com/NixOS/nixpkgs/commit/f12438228599942236dcc12e8eec069b315a4f7c) wabt: 1.0.29 -> 1.0.30
* [`490a05c4`](https://github.com/NixOS/nixpkgs/commit/490a05c4a82236a86e1e1a4822f714c972e8c4f0) maestral: add missing dbus dependency
* [`da857912`](https://github.com/NixOS/nixpkgs/commit/da8579121945d7f6ce2d7cb816837cc52000a3b3) ihp-new: init at 0.20.0
* [`df956cf4`](https://github.com/NixOS/nixpkgs/commit/df956cf4c1c01a3406da807a75ede58e6f861916) Revert "Revert "cudatoolkit_11_7: init at 11.7.0""
* [`feccefa6`](https://github.com/NixOS/nixpkgs/commit/feccefa6840b0f7f55c9025f992cd11815b8bc78) tensorrt: fix for cudaVerison 11.7
* [`4f43356e`](https://github.com/NixOS/nixpkgs/commit/4f43356eb7b2c867ba21d94b550dbc124564b70e) cuda-samples: throw an error for tag 11.7
* [`38a42b46`](https://github.com/NixOS/nixpkgs/commit/38a42b4623dc08363cf46276b318162be18ff4fb) python3Packages.wandb: relax protobuf version
* [`0a986acd`](https://github.com/NixOS/nixpkgs/commit/0a986acdb60e4b371c6b0bda0e91aa62f8b45a95) python310Packages.google-cloud-videointelligence: disable on older Python releases
* [`e0eab822`](https://github.com/NixOS/nixpkgs/commit/e0eab822a7f36d1654dcf46cf759aa6782e43520) python310Packages.google-cloud-texttospeech: disable on older Python releases
* [`b887f96a`](https://github.com/NixOS/nixpkgs/commit/b887f96a41d6fd03895deab203ef1c54628ae33d) python310Packages.google-cloud-trace: disable on older Python releases
* [`545de296`](https://github.com/NixOS/nixpkgs/commit/545de296e01d54b995b08361c7a72a517b68acbf) python310Packages.google-cloud-speech: update disabled
* [`b2f3292e`](https://github.com/NixOS/nixpkgs/commit/b2f3292ea61cd3093a308af2dced48a56939619a) python310Packages.google-cloud-os-config: disable on older Python releases
* [`c7f2e535`](https://github.com/NixOS/nixpkgs/commit/c7f2e5359babdf02478403a737e479c6f459f99a) python310Packages.google-cloud-secret-manager: update disabled
* [`0162bd26`](https://github.com/NixOS/nixpkgs/commit/0162bd26aefa2176a1712ad6463c5ea41f183d01) python310Packages.google-cloud-redis: update disabled
* [`def8bc92`](https://github.com/NixOS/nixpkgs/commit/def8bc92a92df8f461c3758a9cf7ff5a52c7d144) python310Packages.google-cloud-iot: disable on older Python releases
* [`6f8a7852`](https://github.com/NixOS/nixpkgs/commit/6f8a7852e2f70f44e444c272044536800a1f5eda) python310Packages.google-cloud-datacatalog: update disabled
* [`4a8c795c`](https://github.com/NixOS/nixpkgs/commit/4a8c795c4a8d0d98b3b5e0c2853c3f7c44bd0dd9) python310Packages.google-cloud-bigquery-logging: disable on older Python releases
* [`5e4543e9`](https://github.com/NixOS/nixpkgs/commit/5e4543e9f0ebffdfde9b6a512e9d99924beaa3ad) python310Packages.google-cloud-appengine-logging: update disabled
* [`288222ff`](https://github.com/NixOS/nixpkgs/commit/288222fff98d048c47b7ba96aa79618aa3fff296) python310Packages.django-reversion: disable on older Python releases
* [`d8c964c2`](https://github.com/NixOS/nixpkgs/commit/d8c964c2f7a12bacb4c90b219773304b46b8a615) carapace: 0.16.0 -> 0.17.0
* [`c46bdcba`](https://github.com/NixOS/nixpkgs/commit/c46bdcbaf299064ca935438b6704a2f99394966c) nixos/lib/qemu-common.nix: set qemuSerialDevice for isMips64
* [`3c8f16a2`](https://github.com/NixOS/nixpkgs/commit/3c8f16a2e221a82012e079fd70318b42cb38217a) rust-analyzer-unwrapped: 2022-09-26 -> 2022-10-03
* [`2107211a`](https://github.com/NixOS/nixpkgs/commit/2107211a4eab90116b36a5baae28128b6797c24d) benthos: 4.8.0 -> 4.9.0
* [`b7a6fde1`](https://github.com/NixOS/nixpkgs/commit/b7a6fde153d9470afdb6aa1da51c4117f03b84ed) ferium: 4.1.10 -> 4.1.11
* [`e2f8348f`](https://github.com/NixOS/nixpkgs/commit/e2f8348fabaa1f5fba7e28371e9fc40e8d39e706) buildah: 1.27.2 -> 1.28.0 ([nixos/nixpkgs⁠#194360](https://togithub.com/nixos/nixpkgs/issues/194360))
* [`31852b46`](https://github.com/NixOS/nixpkgs/commit/31852b460051a58339b7a154ad51189f9291d465) kotlin: 1.7.10 -> 1.7.20
* [`28827908`](https://github.com/NixOS/nixpkgs/commit/28827908017f7d628e0ff4e89de91595670c5f02) libplctag: 2.5.1 -> 2.5.2
* [`a2a6cb1a`](https://github.com/NixOS/nixpkgs/commit/a2a6cb1a6940d95e119fa69ac1b9f6a2aa6aaa80) python3Packages.langcodes: add missing setuptools
* [`34d1d336`](https://github.com/NixOS/nixpkgs/commit/34d1d336adec65ecd6547924c5149709eec798de) onnnxruntime, python3Packages.onnxruntime: improve packaging
* [`8ea2ccbc`](https://github.com/NixOS/nixpkgs/commit/8ea2ccbc909e46b809d062e01b721b858ddb456b) pineapple-pictures: 0.6.3 -> 0.6.4
* [`f9af6656`](https://github.com/NixOS/nixpkgs/commit/f9af66562a3e2316eef4d021f231a9e9e77e2be2) neovim-remote: fix build with neovim 0.8
* [`e6edff63`](https://github.com/NixOS/nixpkgs/commit/e6edff633531e853a1e49ddc9a4eb23043650e1e) exoscale-cli: 1.59.1 -> 1.59.3
* [`0406a782`](https://github.com/NixOS/nixpkgs/commit/0406a78202ef273a956b5277b83ce7ae649c7389) python310Packages.pyatmo: 7.0.1 -> 7.1.0
* [`f487fd71`](https://github.com/NixOS/nixpkgs/commit/f487fd711d77ac9bf494086fe5b811badfdb7a53) mercurial: 6.2.2 -> 6.2.3
* [`3d92e818`](https://github.com/NixOS/nixpkgs/commit/3d92e81834bc497b218e1e46f81601a98f9aa39a) icinga2: Add pname to .vim
* [`5ff268a1`](https://github.com/NixOS/nixpkgs/commit/5ff268a184fa41ee6c9cf337975fbdec62f8481e) haskellPackages.rec-def: Unbreak
* [`4094a617`](https://github.com/NixOS/nixpkgs/commit/4094a6176ecc32d0dc551776d210d3dc03a68846) python310Packages.pyhiveapi: 0.5.13 -> 0.5.14
* [`bb3010ea`](https://github.com/NixOS/nixpkgs/commit/bb3010ea13c93b591a7ad16c2650ffea33dff2a3) python3Packages.ducc0: 0.25.0 -> 0.26.0
* [`75436580`](https://github.com/NixOS/nixpkgs/commit/75436580086dfdef0305830c6d3a2cf484b3524a) gum: 0.6.0 -> 0.7.0
* [`0b4cd241`](https://github.com/NixOS/nixpkgs/commit/0b4cd241e277b1395f074c064ab878586031e990) haskellPackages.webauthn: unbreak
* [`f94082ba`](https://github.com/NixOS/nixpkgs/commit/f94082ba5240552f9dddeb8a5fd2dfbc6f5abec1) python3Packages.wandb: reorder attributes
* [`3241ef22`](https://github.com/NixOS/nixpkgs/commit/3241ef22f987ed3dfee7456d0432842ba710736a) vscode-extensions.streetsidesoftware.code-spell-checker: 2.3.1 -> 2.10.1
* [`e9b0609a`](https://github.com/NixOS/nixpkgs/commit/e9b0609af7cd8d7b3365384584efd24408e76180) python310Packages.rns: 0.3.12 -> 0.3.13
* [`052cb086`](https://github.com/NixOS/nixpkgs/commit/052cb0862e1c4facc20d347ced4c3ffdd2fde645) python310Packages.lxmf: 0.1.8 -> 0.1.9
* [`ee42f9b2`](https://github.com/NixOS/nixpkgs/commit/ee42f9b29c2a1f35026ff430d94c9afe5d6af6ec) python310Packages.nomadnet: 0.2.2 -> 0.2.3
* [`85827a5d`](https://github.com/NixOS/nixpkgs/commit/85827a5de806435c1a6042ac000f98362df1ea30) jql: 5.0.2 -> 5.1.0
* [`6520ff3a`](https://github.com/NixOS/nixpkgs/commit/6520ff3aadd400c6547b5ab8996cf50b0226aa9f) python310Packages.identify: 2.5.5 -> 2.5.6
* [`6ffc7353`](https://github.com/NixOS/nixpkgs/commit/6ffc735377f7248d25ab6164e992edecf3c1a74c) k3sup: 0.12.3 -> 0.12.7
* [`fb9afbf0`](https://github.com/NixOS/nixpkgs/commit/fb9afbf070543919c44f262e782547e8f51ae94e) python310Packages.potentials: 0.3.4 -> 0.3.5
* [`d0637e1a`](https://github.com/NixOS/nixpkgs/commit/d0637e1a25b7aa04a123d98cff471420d84aa1fe) vouch-proxy: enable checkPhase
* [`7527505f`](https://github.com/NixOS/nixpkgs/commit/7527505f0be45af148e864a51b0430446cda1a24) schema2ldif: Fix ldap-schema-manager not working
* [`4ef739ad`](https://github.com/NixOS/nixpkgs/commit/4ef739adf11585fa15e9edd943a5049bda9f63e7) scandir: fix build on aarch64-darwin
* [`d8cb6419`](https://github.com/NixOS/nixpkgs/commit/d8cb641929a86d2036a4d16713240af3c5cb6dc0) pygobject: fix build on aarch64-darwin
* [`7994937e`](https://github.com/NixOS/nixpkgs/commit/7994937ed20a50681738e1dd91619a6672e5ac19) pygtk: fix build on aarch64-darwin
* [`49e9431c`](https://github.com/NixOS/nixpkgs/commit/49e9431c2af188836ba25b8127e281bdc06313b2) guile-gcrypt: add make flags and tests
* [`d4cf2b81`](https://github.com/NixOS/nixpkgs/commit/d4cf2b811e3c4af5a44803d7a6ca3b5192f4c073) guile-json: add make flags and tests
* [`826fd759`](https://github.com/NixOS/nixpkgs/commit/826fd7598402596f27548877f5689d2e83a5c783) guile-git: add make flags and tests
* [`10c02745`](https://github.com/NixOS/nixpkgs/commit/10c02745ab7f9d324107ecfd557905677fd04322) scheme-bytestructures: add make flags and tests
* [`a097585e`](https://github.com/NixOS/nixpkgs/commit/a097585ef1506f133ecb754c24b231f07cc48832) ft2-clone: 1.58 -> 1.59
* [`57580e63`](https://github.com/NixOS/nixpkgs/commit/57580e63f7da631895cd4e5551d2d8055990f416) syncthing: 1.21.0 -> 1.22.0
* [`ce8874a1`](https://github.com/NixOS/nixpkgs/commit/ce8874a16cb9fc5d9d47203745f9250d5cdde1ef) eartag: init at 0.2.1
* [`1b6bef9c`](https://github.com/NixOS/nixpkgs/commit/1b6bef9c08aad93643a3c823069f51004d80c7d7) pip-audit: 2.4.3 -> 2.4.4
* [`081db4e4`](https://github.com/NixOS/nixpkgs/commit/081db4e4b79572972e320163dd3e6f7429b9bca0) python3Packages.wxPython4_0: fix build
* [`b794e83b`](https://github.com/NixOS/nixpkgs/commit/b794e83b395253fc46df958a0a12e1fc7b80d069) python3Packages.wxPython4_1: fix build
* [`5bae92a7`](https://github.com/NixOS/nixpkgs/commit/5bae92a7155b885619cbab9d3ddae91aa59e91cc) zfs: 2.1.5 → 2.1.6
* [`5598afb4`](https://github.com/NixOS/nixpkgs/commit/5598afb4208fc35aa011aed90877188385f22c24) mdbook-linkcheck: 0.7.6 -> 0.7.7
* [`453efa31`](https://github.com/NixOS/nixpkgs/commit/453efa3153cc5ce9b782b45861abba60876db10f) python310Packages.versioningit: move patching to postPatch
* [`1c660d1a`](https://github.com/NixOS/nixpkgs/commit/1c660d1a00dff4f57f456db6a0167d473642ed1d) betterlockscreen: wrap with dbus and dunst ([nixos/nixpkgs⁠#176335](https://togithub.com/nixos/nixpkgs/issues/176335))
* [`60c89561`](https://github.com/NixOS/nixpkgs/commit/60c89561041dc66c264c372a133060c557b69b15) python310Packages.velbus-aio: 2022.10.1 -> 2022.10.2 ([nixos/nixpkgs⁠#194409](https://togithub.com/nixos/nixpkgs/issues/194409))
* [`8d764e5a`](https://github.com/NixOS/nixpkgs/commit/8d764e5a35ddf95bafc7430a574a0e3af4ac788a) python310Packages.vt-py: 0.16.0 -> 0.17.1 ([nixos/nixpkgs⁠#194410](https://togithub.com/nixos/nixpkgs/issues/194410))
* [`a2c41adf`](https://github.com/NixOS/nixpkgs/commit/a2c41adf739aaef0e0b3fd81a36b498c08db1291) cfdg: remove src-for-default.nix, cleanups ([nixos/nixpkgs⁠#192727](https://togithub.com/nixos/nixpkgs/issues/192727))
* [`c75b4ee2`](https://github.com/NixOS/nixpkgs/commit/c75b4ee2f0af0b3c66c03219416254088b39da1a) cp2k: 9.1.0 -> 2022.2
* [`04c496c1`](https://github.com/NixOS/nixpkgs/commit/04c496c1551125f409546ed990c817dc8d7dc1d6) telepathy-farstream: rename name to pname&version ([nixos/nixpkgs⁠#193575](https://togithub.com/nixos/nixpkgs/issues/193575))
* [`11bb01e7`](https://github.com/NixOS/nixpkgs/commit/11bb01e7fa509db5a8adce09b5edfc8554f7eee4) python3Packages.dlib: split name to pname&version ([nixos/nixpkgs⁠#194382](https://togithub.com/nixos/nixpkgs/issues/194382))
* [`a4f81e1d`](https://github.com/NixOS/nixpkgs/commit/a4f81e1dbbb919edcaae495405a4969495a4b74d) Revert "ubuntu-font-family: use mkDerivation"
* [`f633575a`](https://github.com/NixOS/nixpkgs/commit/f633575af3ad7b4dcf77fd4cb7733184d5b65e3e) libvori: 210412 -> 220621
* [`ebd65936`](https://github.com/NixOS/nixpkgs/commit/ebd659367f431d9cd126154fe577e5f80082cbec) haskellPackages.sint: unbreak
* [`5a55c0e5`](https://github.com/NixOS/nixpkgs/commit/5a55c0e512a4242d15a5a44ad820f8423b7e1856) haskellPackages.satchmo: unbreak
* [`93c7d807`](https://github.com/NixOS/nixpkgs/commit/93c7d8070c30692d8974fae34f16f54bfe84fb8a) avogadrolibs: 1.95.1 -> 1.97.0, disable mmtf-cpp
* [`b070c222`](https://github.com/NixOS/nixpkgs/commit/b070c222d137ac32d687df7f84997e0e67401ede) avogadro2: 1.95.1 -> 1.97.0
* [`fc95752d`](https://github.com/NixOS/nixpkgs/commit/fc95752d6f7edd65d443c9dd5fd28b4a7b54cf4d) Revert "cooper-hewitt: use mkDerivation"
* [`3ae7efd3`](https://github.com/NixOS/nixpkgs/commit/3ae7efd34aa40bc84ec5d5114c91ba36e0db0ada) python310Packages.pytibber: 0.25.2 -> 0.25.3
* [`11075c26`](https://github.com/NixOS/nixpkgs/commit/11075c265858ba094c49c4bb60e13b922697df7e) maigret: 0.4.3 -> 0.4.4
* [`9817dd37`](https://github.com/NixOS/nixpkgs/commit/9817dd375c1504fc175179583c7534dd3315c247) spglib: 1.16.5 -> 2.0.1
* [`94b9ed29`](https://github.com/NixOS/nixpkgs/commit/94b9ed29b989186a39541667ee37f475626b44ec) wireplumber: 0.4.11 -> 0.4.12
* [`7deac8b8`](https://github.com/NixOS/nixpkgs/commit/7deac8b8f703702d8ec68490dc2be2301696be8a) fetchurl: add pname+version support
* [`b368d66d`](https://github.com/NixOS/nixpkgs/commit/b368d66d752e07f631ed01fce43d09607697b383) gmpc.libmpd: rename name to pname&version
* [`42793abe`](https://github.com/NixOS/nixpkgs/commit/42793abe52f422de44294e8aec05bfa9faeb9a91) pantheon.elementary-iconbrowser: init at 2.0.0
* [`092bb3c6`](https://github.com/NixOS/nixpkgs/commit/092bb3c6e023d91a03a538c092b7768b63393018) python3Packages.libvirt: Fix build on darwin
* [`3646a756`](https://github.com/NixOS/nixpkgs/commit/3646a7561f064e5bcb84df6d01d13ee101f67ac5) maintainers: add naphta
* [`14bb4ee9`](https://github.com/NixOS/nixpkgs/commit/14bb4ee9b7e652409856feefedd8377f9b52727c) opcr-policy: init at 0.1.42
* [`01dfd3cb`](https://github.com/NixOS/nixpkgs/commit/01dfd3cb5827a190e90c2627f4a1714b9deda4af) fetchzip: add pname+version support
* [`50922fe9`](https://github.com/NixOS/nixpkgs/commit/50922fe9fdee27cc95daf01416bfa7defe876e4a) cooper-hewitt: switch to pname+version, fix build
* [`e500cba3`](https://github.com/NixOS/nixpkgs/commit/e500cba3982b24254da246bd4c79c99ff1242253) freefont-ttf: switch to pname+version, fix build
* [`2e19f2fa`](https://github.com/NixOS/nixpkgs/commit/2e19f2fa5391b3b30e9eace7b4b6a60926b828ae) maintainers: remove superherointj
* [`b1c224bf`](https://github.com/NixOS/nixpkgs/commit/b1c224bf833cfa6046e658242986c0618cffc4d4) fq: 0.0.9 -> 0.0.10
* [`f12ebd47`](https://github.com/NixOS/nixpkgs/commit/f12ebd47af76062851b0aa7dbd4bd823cc022d86) python310Packages.slack-sdk: 3.18.4 -> 3.18.5
* [`1374dc16`](https://github.com/NixOS/nixpkgs/commit/1374dc16e87cb4a7b8572b02f11ecd5420f05703) python310Packages.sphinx-argparse: 0.3.1 -> 0.3.2
* [`0b90eee7`](https://github.com/NixOS/nixpkgs/commit/0b90eee76d40751d6824cc8f00900922d6f14ac7) python310Packages.sphinx-jupyterbook-latex: 0.5.0 -> 0.5.1
* [`fbbf9ff6`](https://github.com/NixOS/nixpkgs/commit/fbbf9ff6df94e936ca59b5998de9e273068f71c2) libretro.puae: init at unstable-2022-04-21
* [`fdd0db3a`](https://github.com/NixOS/nixpkgs/commit/fdd0db3a4da4ea6429315b22b29e8d2d3727649a) ubuntu-font-family: switch to pname+version, fix build
* [`b5005d36`](https://github.com/NixOS/nixpkgs/commit/b5005d36ad81828e477112ba4efd78c57e7b33e3) snappymail: 2.18.3 -> 2.18.4
* [`0d3a23d2`](https://github.com/NixOS/nixpkgs/commit/0d3a23d218e69f830d48457ad489ebce391fa5d8) python310Packages.timetagger: 22.6.6 -> 22.9.3
* [`654c7c76`](https://github.com/NixOS/nixpkgs/commit/654c7c76e5c84d61354c4fa778e6a24b78c8ce88) python310Packages.traitsui: 7.4.0 -> 7.4.1
* [`76b6b66d`](https://github.com/NixOS/nixpkgs/commit/76b6b66d8da1b3222f36795d33c6d1f57c445aec) python310Packages.trimesh: 3.15.2 -> 3.15.3
* [`a12dd80a`](https://github.com/NixOS/nixpkgs/commit/a12dd80a496b8d2763eb29b81940e24cc4ece8e4) firefox-unwrapped: 105.0.1 -> 105.0.2
* [`76619655`](https://github.com/NixOS/nixpkgs/commit/766196550b1ba2a39c1f65dbaced59a9b11426d8) firefox-bin-unwrapped: 105.0.1 -> 105.0.2
* [`82092633`](https://github.com/NixOS/nixpkgs/commit/82092633bd44b8c17903ff3258fb06aa0715544c) python310Packages.types-redis: 4.3.21 -> 4.3.21.1
* [`2cf4152b`](https://github.com/NixOS/nixpkgs/commit/2cf4152bc2163cae042d63f813318ae90f338a9d) python310Packages.types-requests: 2.28.11 -> 2.28.11.1
* [`15f76576`](https://github.com/NixOS/nixpkgs/commit/15f7657636c3512633d5753cbbda485246d80dc3) deadd-notification-center: 2021-03-10 -> 2022-04-20
* [`2f93baec`](https://github.com/NixOS/nixpkgs/commit/2f93baecd058da202010cd4bcfc24de4dfa76a8e) python3Packages.django_4: 4.1.1 -> 4.1.2
* [`eb43d1e6`](https://github.com/NixOS/nixpkgs/commit/eb43d1e6e553d318337eda4ae5f3cd20ac9dda9c) telegraf: 1.23.3 -> 1.24.2
* [`6f3d5e6d`](https://github.com/NixOS/nixpkgs/commit/6f3d5e6da2b0f29cbdba964030babaa14de8607f) python310Packages.weconnect: 0.48.1 -> 0.48.2
* [`2bb9abc7`](https://github.com/NixOS/nixpkgs/commit/2bb9abc7623d6feb8660c6cb8b570d274a1b0614) osm2pgsql: 1.7.0 → 1.7.1
* [`94eb56b8`](https://github.com/NixOS/nixpkgs/commit/94eb56b8da7503d7cdd8e22d0d3be19d1c165d7a) hover: remove myself from maintainers
* [`3c660169`](https://github.com/NixOS/nixpkgs/commit/3c660169e540d948dd5f76acddf1d11ac15f1b7b) imlib2: use xorg.* packages directly instead of xlibsWrapper
* [`6b4bcde2`](https://github.com/NixOS/nixpkgs/commit/6b4bcde22d1d2c5ce421111de1bef430c4d33f6b) dart: remove myself from maintainers
* [`7e780b30`](https://github.com/NixOS/nixpkgs/commit/7e780b307986e447cca19d55201132a4708a0140) musikcube: add srapenne as maintainer
* [`a68a20c7`](https://github.com/NixOS/nixpkgs/commit/a68a20c73a0e2bf8a9f851a5948ce5fa0c2bf278) kakoune: add srapenne as maintainer
* [`0b6a5ffd`](https://github.com/NixOS/nixpkgs/commit/0b6a5ffd9b7245cdcea2032503534c3a4764d96d) yacreader: add srapenne as maintainer
* [`ef60a504`](https://github.com/NixOS/nixpkgs/commit/ef60a5042fa2474c93072199f07754fd9d259b54) keepassxc: add srapenne as maintainer
* [`9973855a`](https://github.com/NixOS/nixpkgs/commit/9973855a442d46ff0b14743301161aa2040f4402) claws-mail: add srapenne as maintainer
* [`7fee5950`](https://github.com/NixOS/nixpkgs/commit/7fee5950abe1a3c90b433326e0696dd0b9f8613a) tig: add srapenne as maintainer
* [`8ed6c97f`](https://github.com/NixOS/nixpkgs/commit/8ed6c97f372650599824631ede7efbf018f60753) deltachat: add srapenne as maintainer
* [`5a08000c`](https://github.com/NixOS/nixpkgs/commit/5a08000cad3e9ee1a0c66f94be0eff5355c6679a) pngquant: add srapenne as maintainer
* [`ab53d889`](https://github.com/NixOS/nixpkgs/commit/ab53d889c088351b3372994c112f2c552803384c) rlwrap: add srapenne as maintainer
* [`7d3c04e5`](https://github.com/NixOS/nixpkgs/commit/7d3c04e5095a1b5ceec581ee65b03b32ff0285a5) tmux: add srapenne as maintainer
* [`9b55c336`](https://github.com/NixOS/nixpkgs/commit/9b55c3361ab75e9415cd87f050d088ad0051bc59) bwm-ng: add srapenne as maintainer
* [`3bc29710`](https://github.com/NixOS/nixpkgs/commit/3bc2971030c70a9191b3682346f98067e88d0a94) fix typo
* [`868a6714`](https://github.com/NixOS/nixpkgs/commit/868a6714da40500e22471d60247cef78bb416873) maintainers/team-list.nix: add lua team
* [`b6e8b0c9`](https://github.com/NixOS/nixpkgs/commit/b6e8b0c917d343ccde7fbd41f6c2ac1c42e575b5) cirrus-cli: 0.86.0 -> 0.87.1
* [`f3f06e76`](https://github.com/NixOS/nixpkgs/commit/f3f06e76f46d9b497e36bfa3157f061561ccfa8a) x11_ssh_askpass use xorg.* packages directly instead of xlibsWrapper indirection
* [`645c8426`](https://github.com/NixOS/nixpkgs/commit/645c8426f5c97e7ed7005e544f7d8c0a64d3d2ce) gh: 2.16.1 -> 2.17.0
* [`5662a307`](https://github.com/NixOS/nixpkgs/commit/5662a3075747515e6e1cb5662cb3fa67f8314f10) rain: build with Go 1.18 instead of 1.17
* [`6d982a3b`](https://github.com/NixOS/nixpkgs/commit/6d982a3b7b4a84778b3f5eaaf5c36405760abe71) pgmodeler: 0.9.4 -> 1.0.0-beta
* [`878ccf08`](https://github.com/NixOS/nixpkgs/commit/878ccf08c5bbba3bf06e48379a3887adfc54927f) github-runner: 2.297.0 -> 2.298.2
* [`32a43582`](https://github.com/NixOS/nixpkgs/commit/32a43582e7dc2eadc58c572b8eb83be992cd6ffa) redmine: 4.2.7 -> 4.2.8
* [`e338844d`](https://github.com/NixOS/nixpkgs/commit/e338844d9015050edadc8dde36c16128884e3ddd) usbimager: Fix filechooser dialog
* [`3c920098`](https://github.com/NixOS/nixpkgs/commit/3c92009868109ec8a3695d2ebacf0b53e23778d1) nixos/tests/systemd-initrd-modprobe: init
* [`56c56109`](https://github.com/NixOS/nixpkgs/commit/56c56109a3dc82dc9575412ab7e009962994d459) kubo: 0.15.0 -> 0.16.0
* [`032490f3`](https://github.com/NixOS/nixpkgs/commit/032490f3bff9446e89f552a8c70f81c27d076525) libvirt: 8.7.0 -> 8.8.0
* [`04b714db`](https://github.com/NixOS/nixpkgs/commit/04b714dbc03ce5b4936d2bf77f30297314087b98) adw-gtk3: 3.7 -> 4.0
* [`1c919127`](https://github.com/NixOS/nixpkgs/commit/1c919127c55d69de0731f31982f7947a8edcd83c) uefitool: A61 -> A62
* [`68a8e9aa`](https://github.com/NixOS/nixpkgs/commit/68a8e9aa62b7dfac81ec5c523de9871734f1bb38) jmol: 14.32.75 -> 14.32.76
* [`4076104a`](https://github.com/NixOS/nixpkgs/commit/4076104a385f152b16d338c8bdea0cd0efd40414) coqPackages.category-theory: 20211213 → 1.0.0
* [`c736ed13`](https://github.com/NixOS/nixpkgs/commit/c736ed13b2e3b4781d96e7a2c54a3c6a01386947) linux: 5.19.12 -> 5.19.13
* [`a0e9973e`](https://github.com/NixOS/nixpkgs/commit/a0e9973e64ba3f1277fb10c9ae3ecedf6b0af16a) cudatoolkit: use if instead of versionOlder+versionAtLeast
* [`d745231c`](https://github.com/NixOS/nixpkgs/commit/d745231c7780ec5e3a336a7b03b7b7739d197ed9) weston: avoid removed alias `libseat`
* [`2830aa02`](https://github.com/NixOS/nixpkgs/commit/2830aa0212ddc42181d55757711b1f1f243e77ed) cfssl: 1.6.2 -> 1.6.3
* [`0c7a6a08`](https://github.com/NixOS/nixpkgs/commit/0c7a6a0832b9531217d724a60ddd4377e841d68d) go_1_19: 1.19.1 -> 1.19.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
