### PR TITLE
niv emacs-overlay: update 20dc7a0a -> e6c5abf9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b",
-        "sha256": "1fvx2pn64bwpj5jkzc927riv89g8aq2g7s46bsswgvj72qr4mqfp",
+        "rev": "e6c5abf9ff42495cd8a3845fc32a17baa7c54790",
+        "sha256": "0y72j9gn8psgdm3py39c5ap08f5mkga7pjxcy2xq7n7hw96m9q62",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/e6c5abf9ff42495cd8a3845fc32a17baa7c54790.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@20dc7a0a...e6c5abf9](https://github.com/nix-community/emacs-overlay/compare/20dc7a0a1ea9c40201c8fe1e29b91a50b5ecba9b...e6c5abf9ff42495cd8a3845fc32a17baa7c54790)

* [`88c386d4`](https://github.com/nix-community/emacs-overlay/commit/88c386d4fd4572cd9aef4eed589c843dab30456a) Updated repos/emacs
* [`078ea145`](https://github.com/nix-community/emacs-overlay/commit/078ea145c926a5a12269a8cba43282802e3dd1d0) Updated repos/melpa
* [`a6329647`](https://github.com/nix-community/emacs-overlay/commit/a6329647be7d68aa5525cdec42c3f5a0e4a11a39) Move default.nix into overlays dir
* [`dfa7c2a8`](https://github.com/nix-community/emacs-overlay/commit/dfa7c2a85b230ca01f259fa8a7305ece9a0c953c) Fix non-flake overlay usage
* [`c91c353b`](https://github.com/nix-community/emacs-overlay/commit/c91c353b5dcc077c4ea60d7104ed784330109fe7) Split into two overlays: one for emacs and one for emacs packages
* [`d0c070ee`](https://github.com/nix-community/emacs-overlay/commit/d0c070ee87cfabfc54dab3f4b4585ee02cb2be14) Updated repos/melpa
* [`13e7244f`](https://github.com/nix-community/emacs-overlay/commit/13e7244f79bf4a75def43173386f7a693cd3a696) Don't prepend an extra "emacs-" to the unstable tarball
* [`f0fff2e0`](https://github.com/nix-community/emacs-overlay/commit/f0fff2e0952e97a9ad733ef96e6fa7d4f3b9fafe) Updated repos/melpa
* [`c24191e5`](https://github.com/nix-community/emacs-overlay/commit/c24191e588b66cf98f0f5d24991dab91f93b8f4f) Pin to Nix 2.11.0 for now
* [`7403ebb7`](https://github.com/nix-community/emacs-overlay/commit/7403ebb77e93517a55ad1ab1e5831429fdae8806) Revert "Pin to Nix 2.11.0 for now"
* [`4ff762be`](https://github.com/nix-community/emacs-overlay/commit/4ff762be71c3f2c733f5e2247b3e32097b91d998) Revert "Use nixpkgs master for now"
* [`8feddbc3`](https://github.com/nix-community/emacs-overlay/commit/8feddbc301c5858af111a8cf750162d4367b718f) Updated repos/elpa
* [`779f67ba`](https://github.com/nix-community/emacs-overlay/commit/779f67baed49c2568d51142d41aa5eff21d9c865) Updated repos/emacs
* [`f24ebfcf`](https://github.com/nix-community/emacs-overlay/commit/f24ebfcf553f04f1f6ed2e7b4db0c30d574c17ab) Updated repos/melpa
* [`15ff42e0`](https://github.com/nix-community/emacs-overlay/commit/15ff42e01d0758d16f30994b4075fec8dc8df860) Updated repos/emacs
* [`81cff349`](https://github.com/nix-community/emacs-overlay/commit/81cff349f6dccdbe7f0acf45846d2c3a737bc8f9) Updated repos/melpa
* [`c993a91c`](https://github.com/nix-community/emacs-overlay/commit/c993a91cc553ab5e4a5b5268ff7077ab8bdfd7ad) Updated repos/melpa
* [`8aa90769`](https://github.com/nix-community/emacs-overlay/commit/8aa90769af2ec3aaa481d641213864d0aa944acf) Updated repos/elpa
* [`42f0bd08`](https://github.com/nix-community/emacs-overlay/commit/42f0bd088f22742746551d36d2ae6f7ec5194ddc) Updated repos/emacs
* [`4d79c6e0`](https://github.com/nix-community/emacs-overlay/commit/4d79c6e096b671c371f75bc99d367a464474f55d) Updated repos/melpa
* [`63526575`](https://github.com/nix-community/emacs-overlay/commit/63526575d9c3e95f0f65b23fadf2a0e3fc248c6c) Updated repos/elpa
* [`80c01c5b`](https://github.com/nix-community/emacs-overlay/commit/80c01c5baa127816edc5e1f15684847a9f7e8a94) Updated repos/emacs
* [`1236963f`](https://github.com/nix-community/emacs-overlay/commit/1236963fffa5d7b04706009ff49668c52c91df85) Updated repos/melpa
* [`06a7ca36`](https://github.com/nix-community/emacs-overlay/commit/06a7ca3676f441101ef1c1e16d829117ea846f73) Updated repos/emacs
* [`bfb74a16`](https://github.com/nix-community/emacs-overlay/commit/bfb74a16f85faf1cd14746ae117a991fadf412c3) Updated repos/melpa
* [`04351718`](https://github.com/nix-community/emacs-overlay/commit/04351718792c2e50bf30a5d1a433c9af221168cf) Updated repos/nongnu
* [`1a6894c6`](https://github.com/nix-community/emacs-overlay/commit/1a6894c6b4f625d54412208cdc674e889c2cd597) Updated repos/elpa
* [`797070ba`](https://github.com/nix-community/emacs-overlay/commit/797070baa6fb4a80886f189ca49a3d3915063667) Updated repos/emacs
* [`91c29a06`](https://github.com/nix-community/emacs-overlay/commit/91c29a0653afdbda4e75c37babdc1c598a2d13f5) Updated repos/melpa
* [`916eb550`](https://github.com/nix-community/emacs-overlay/commit/916eb550651a64845d70ae96aa11790501a14cc2) Updated repos/elpa
* [`9f2a8882`](https://github.com/nix-community/emacs-overlay/commit/9f2a88822e8009c7959a9ca9e8d507369ffc74d3) Updated repos/emacs
* [`b59774ea`](https://github.com/nix-community/emacs-overlay/commit/b59774ea3268799c487d2f68ad2645614be59caf) Updated repos/melpa
* [`db1c01c5`](https://github.com/nix-community/emacs-overlay/commit/db1c01c5faeea34547fff2017324f8a2d2253402) Updated repos/nongnu
* [`404aa01a`](https://github.com/nix-community/emacs-overlay/commit/404aa01a3fa33e5043d88e8719476d23bd93926e) Updated repos/emacs
* [`69001f72`](https://github.com/nix-community/emacs-overlay/commit/69001f7209d3baae5685e657511a0d6ec9104751) Updated repos/melpa
* [`bb224e7e`](https://github.com/nix-community/emacs-overlay/commit/bb224e7e82ac962031be7a36e1c4b01fb56ae8d9) Updated repos/nongnu
* [`adc46fcc`](https://github.com/nix-community/emacs-overlay/commit/adc46fcc2b963730d8b9e8c4f9a8167dbf23f842) Updated repos/emacs
* [`3aa20d38`](https://github.com/nix-community/emacs-overlay/commit/3aa20d38aeb38220dcccd3e53ac666d7df322053) Updated repos/melpa
* [`4020b039`](https://github.com/nix-community/emacs-overlay/commit/4020b03991a43e54014b160b2608dd94aaa88dbb) Updated repos/elpa
* [`6acc25a4`](https://github.com/nix-community/emacs-overlay/commit/6acc25a4b34c7a03e51e119d6eb71a6f73e5423a) Updated repos/emacs
* [`6ce42e32`](https://github.com/nix-community/emacs-overlay/commit/6ce42e32559c8dea4fd5ef59203441a85e5eb6c7) Updated repos/melpa
* [`fa664e37`](https://github.com/nix-community/emacs-overlay/commit/fa664e37c200b1ead93a0274d10ee25dc1e75eef) Updated repos/nongnu
* [`3b1aaf3a`](https://github.com/nix-community/emacs-overlay/commit/3b1aaf3ac15752e9f91f08a433b197dbf7548b39) Updated repos/emacs
* [`c3b3d88e`](https://github.com/nix-community/emacs-overlay/commit/c3b3d88eb0fd75557fd5c91223233a6a2c6df8be) Updated repos/melpa
* [`dcc349c3`](https://github.com/nix-community/emacs-overlay/commit/dcc349c3a306202385132ea7305a425b94e563e7) Updated repos/elpa
* [`f3a3557a`](https://github.com/nix-community/emacs-overlay/commit/f3a3557a3906d95bef8d776895bee1e9f630791c) Updated repos/emacs
* [`053ed377`](https://github.com/nix-community/emacs-overlay/commit/053ed3777e6dfd90561a75237a2365834696fa5e) Updated repos/melpa
* [`49f1e815`](https://github.com/nix-community/emacs-overlay/commit/49f1e815d9ae9338ac056c593b214cb88cc7f6b7) Updated repos/emacs
* [`0ca40a77`](https://github.com/nix-community/emacs-overlay/commit/0ca40a7728a2bf31cc453f85b146b7c5e0a4d7ca) Updated repos/melpa
* [`2cf9caa0`](https://github.com/nix-community/emacs-overlay/commit/2cf9caa06c8fbe3f973afd597584f08e3d56fdd6) Updated repos/nongnu
* [`432b11df`](https://github.com/nix-community/emacs-overlay/commit/432b11dfa20c762901f60f0ba447203bb7fe1d8d) Updated repos/emacs
* [`d6ab2ecd`](https://github.com/nix-community/emacs-overlay/commit/d6ab2ecd8dd6e9432a4c8cced2dce2922cd3bff7) Updated repos/melpa
* [`6929dda2`](https://github.com/nix-community/emacs-overlay/commit/6929dda248acd2092c3eae77e481553d21f20531) Updated repos/elpa
* [`1c238920`](https://github.com/nix-community/emacs-overlay/commit/1c238920a92d39650cd39824053cc31b843dc317) Updated repos/emacs
* [`fed2cdc6`](https://github.com/nix-community/emacs-overlay/commit/fed2cdc688cf1d2612634ca31861f4f253091c73) Updated repos/melpa
* [`eb793466`](https://github.com/nix-community/emacs-overlay/commit/eb793466ab9d69220c0ba6031baddf7608aa64d4) Updated repos/emacs
* [`e6fa2829`](https://github.com/nix-community/emacs-overlay/commit/e6fa28293af4ad344753a0a24fb64d8314b4c438) Updated repos/melpa
* [`af36e7fe`](https://github.com/nix-community/emacs-overlay/commit/af36e7feb452a1732b34226c4419396dfa2f7ea7) Updated repos/nongnu
* [`05539d02`](https://github.com/nix-community/emacs-overlay/commit/05539d020082e6888ce2483f48e2c5890ca23a20) Updated repos/emacs
* [`31389685`](https://github.com/nix-community/emacs-overlay/commit/31389685a5613c5abad2b79a68e080f07073a16c) Updated repos/melpa
* [`b8553aae`](https://github.com/nix-community/emacs-overlay/commit/b8553aae68463c9f6037cb7d5077366ced08dbdc) Updated repos/emacs
* [`4e73aa5b`](https://github.com/nix-community/emacs-overlay/commit/4e73aa5b1c63d4e34fddd5cc40c5a072dc80fdb4) Updated repos/melpa
* [`91739821`](https://github.com/nix-community/emacs-overlay/commit/917398213ea0f3b3ab63e6cd3434905396eb5bbe) Updated repos/emacs
* [`16c2a6d3`](https://github.com/nix-community/emacs-overlay/commit/16c2a6d3456ba0b4304e61f78022dc5a42df772f) Updated repos/melpa
* [`e6c5abf9`](https://github.com/nix-community/emacs-overlay/commit/e6c5abf9ff42495cd8a3845fc32a17baa7c54790) Updated repos/nongnu
