### PR TITLE
niv powerlevel10k: update 843dcf01 -> 8091c8a3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "843dcf016710a4fe39f8ad65da2929f9128436fd",
-        "sha256": "1q5xynvk5hafb0kd54i79f598j1c6ks8ms3plsyhamlp8z2kwvbs",
+        "rev": "8091c8a3a8a845c70046684235a01cd500075def",
+        "sha256": "16kfg9073qxzdbn8a7i631ciiqbw2vxbrkc467hrsvf2sn9fskr3",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/843dcf016710a4fe39f8ad65da2929f9128436fd.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/8091c8a3a8a845c70046684235a01cd500075def.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@843dcf01...8091c8a3](https://github.com/romkatv/powerlevel10k/compare/843dcf016710a4fe39f8ad65da2929f9128436fd...8091c8a3a8a845c70046684235a01cd500075def)

* [`c5203a3d`](https://github.com/romkatv/powerlevel10k/commit/c5203a3da2a8814992c91b20f8246b19ea88401c) Add `arch` prompt for displaying CPU architecture
* [`01467fae`](https://github.com/romkatv/powerlevel10k/commit/01467fae4f72dd1bf4b73708e6e356b5417dfc68) Change arch prompt colors to better match default themes
* [`59e90bd8`](https://github.com/romkatv/powerlevel10k/commit/59e90bd8b0bee6b00bc9153f13336f6cafeae08a) Add instant prompt for arch
* [`cf1b5865`](https://github.com/romkatv/powerlevel10k/commit/cf1b58651505a3d5799a7f6bb5b8ce964c729c51) fix bugs introduced in 843dcf016710a4fe39f8ad65da2929f9128436fd
* [`5ee78478`](https://github.com/romkatv/powerlevel10k/commit/5ee784787fe3c1855ee6f365cbf045712843989e) fix a bug introduced in cf1b58651505a3d5799a7f6bb5b8ce964c729c51
* [`efffc87c`](https://github.com/romkatv/powerlevel10k/commit/efffc87cf54eb4609fa960ba28b04221b08d56dc) Rename "mainland China" to "China"
* [`3e952468`](https://github.com/romkatv/powerlevel10k/commit/3e952468aac3823324430f5212fecb2a9f916ca5) "mainland China" to "China"
* [`bd0c9f4e`](https://github.com/romkatv/powerlevel10k/commit/bd0c9f4ec7511f51851f9bde0e2e24b05fd1c10e) rename arch to cpu_arch and rewrite it ([romkatv/powerlevel10k⁠#1752](https://togithub.com/romkatv/powerlevel10k/issues/1752))
* [`ed1b02ef`](https://github.com/romkatv/powerlevel10k/commit/ed1b02efd5f7691d72cf9b657d939e3adc31034c) Squashed 'gitstatus/' changes from 6dc0738c0..4b47ca047
