### PR TITLE
niv spacemacs: update 4688cd7d -> 264a8ffc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "4688cd7dcea36ee346d1aafba7f0638f4d816c28",
-        "sha256": "1k7wr1a1qmhzkbj7q5nw3n4dsqhwq8x00a5ghgrad239jki6p71k",
+        "rev": "264a8ffc203a3215623330576941d1722bbee1e4",
+        "sha256": "1a9366vij15l1bdwnh9f2w7x9yj02vkpwszyqqf0x3lw0bwph2h5",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/4688cd7dcea36ee346d1aafba7f0638f4d816c28.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/264a8ffc203a3215623330576941d1722bbee1e4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@4688cd7d...264a8ffc](https://github.com/syl20bnr/spacemacs/compare/4688cd7dcea36ee346d1aafba7f0638f4d816c28...264a8ffc203a3215623330576941d1722bbee1e4)

* [`fe01603d`](https://github.com/syl20bnr/spacemacs/commit/fe01603df9f3a11fc77fab6c56253a7cda4a9540) feat: add consult-imenu for Java LSP ([syl20bnr/spacemacs⁠#15758](https://togithub.com/syl20bnr/spacemacs/issues/15758))
* [`2ad413c8`](https://github.com/syl20bnr/spacemacs/commit/2ad413c8e1bbb3595c9bb2d53a928c969dd2825b) [bot] "built_in_updates" Wed Oct  5 18:21:45 UTC 2022 ([syl20bnr/spacemacs⁠#15761](https://togithub.com/syl20bnr/spacemacs/issues/15761))
* [`264a8ffc`](https://github.com/syl20bnr/spacemacs/commit/264a8ffc203a3215623330576941d1722bbee1e4) refactor: improve pdf-tools selection (PR [syl20bnr/spacemacs⁠#15740](https://togithub.com/syl20bnr/spacemacs/issues/15740)) ([syl20bnr/spacemacs⁠#15762](https://togithub.com/syl20bnr/spacemacs/issues/15762))
