### PR TITLE
niv nixpkgs: update 8b786d8d -> 44f236e3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8b786d8dbb29d8df192c0f67bd5f0a72a28260ec",
-        "sha256": "12jxhq86yibim30hin2ycm9h7a12d36p2j2rp226lppxfh9987wd",
+        "rev": "44f236e33f44e986d3c0073afabbc9a1bf63fe2b",
+        "sha256": "0c3vhx2a88grakr3l54hk7gkx7w87pq9jhcsfywijhpv88mss9yb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/8b786d8dbb29d8df192c0f67bd5f0a72a28260ec.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/44f236e33f44e986d3c0073afabbc9a1bf63fe2b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@8b786d8d...44f236e3](https://github.com/nixos/nixpkgs/compare/8b786d8dbb29d8df192c0f67bd5f0a72a28260ec...44f236e33f44e986d3c0073afabbc9a1bf63fe2b)

* [`09abb91d`](https://github.com/NixOS/nixpkgs/commit/09abb91d144afc26689d557afa0933e319b6eda6) buildMaven: Update buildMaven to pure Nix
* [`9f7e4020`](https://github.com/NixOS/nixpkgs/commit/9f7e40205ee83731c450c034953a067ee724e487)  nixos/virtualisation.oci-containers: follow podman-generated systemd units more closely
* [`4af6cbcc`](https://github.com/NixOS/nixpkgs/commit/4af6cbccfe454235507a27ab63356526a76f4928) texlive.bin.core: fix cross-compilation
* [`f07a0615`](https://github.com/NixOS/nixpkgs/commit/f07a0615ea82351bbddc0799364774cb350ff759) openblas: 0.3.20 -> 0.3.21
* [`ba895a7d`](https://github.com/NixOS/nixpkgs/commit/ba895a7da8f86c6f924fc96026d8f1cb1ea2af1e) trivial-builders.nix: Add input argument `passthru` to makeSetupHook
* [`4dc28e00`](https://github.com/NixOS/nixpkgs/commit/4dc28e00570adc4de10acab768c291f68178a6b0) setup hooks: substitutions.passthru -> passthru
* [`e8a38a2f`](https://github.com/NixOS/nixpkgs/commit/e8a38a2f521488d715a1568b494d9891619771e5) makeSetupHook: Deprecate substitutions.passthru
* [`c078d552`](https://github.com/NixOS/nixpkgs/commit/c078d552fe1e5c35931997c24c8e9b6cf48e3c7b) wrapGAppsHook: Set name
* [`9bf8ddf3`](https://github.com/NixOS/nixpkgs/commit/9bf8ddf3b30f6c49c1f83205f4cea84d124eb7b5) libpipeline: 1.5.4 -> 1.5.6
* [`7df2bb19`](https://github.com/NixOS/nixpkgs/commit/7df2bb1902e5bfe7a9891c66e11ac9ce20a6a226) nixos/tests/pulseaudio: fix url to mp3 sample file
* [`0fd25386`](https://github.com/NixOS/nixpkgs/commit/0fd253867885cebd9a8384110c0f0f50e9a5b327) nixos/tests/pulseaudio: fix pavucontrol detection
* [`7ba07950`](https://github.com/NixOS/nixpkgs/commit/7ba079505aa414bb01c53f9d1ed6f97112f791c4) nixos/pulseaudio: add pulse-access group
* [`78e5c0c9`](https://github.com/NixOS/nixpkgs/commit/78e5c0c97f9ab98b53ba8f1935bba1b1369c0ae5) nixos/tests/pulseaudio: add tests for pkgs.pulseaudioFull
* [`3871f8be`](https://github.com/NixOS/nixpkgs/commit/3871f8be8d6de48d5f094fbe90a09e42cc0b289c) pulseaudioFull: fix wrapGApp wrapping
* [`64d256ab`](https://github.com/NixOS/nixpkgs/commit/64d256ab15392c3b4059422e9dfe2eec46a9fece) nixos/tests/pulseaudio: add test for pacmd
* [`23e5407b`](https://github.com/NixOS/nixpkgs/commit/23e5407bd45f0364263d53b534bf2823abd9e24d) gzip: build and install zless which went missing in gzip-1.12
* [`e9a59426`](https://github.com/NixOS/nixpkgs/commit/e9a5942610d09b77e355ba6327a261a60ed96bcf) add new maintainer astrobeastie
* [`61405895`](https://github.com/NixOS/nixpkgs/commit/61405895687427cb98a2f7bb83f8cc1e515c791e) cargo-hf2: init at 0.3.3
* [`3e0987eb`](https://github.com/NixOS/nixpkgs/commit/3e0987eba142b8bbb8b0e2eb25554c8e3f1f268f) cargo-hf2: add AppKit dependency for Darwin
* [`34dbaede`](https://github.com/NixOS/nixpkgs/commit/34dbaede64a094d59b04a8e76f366f4da4f396cf) openjpeg: 2.4.0 -> 2.5.0
* [`609fb5b5`](https://github.com/NixOS/nixpkgs/commit/609fb5b5ab4d754fb88395474574daf5a8b6bf1f) octavePackages.signal: 1.4.1 -> 1.4.2
* [`79944c7a`](https://github.com/NixOS/nixpkgs/commit/79944c7aff43cbce1b3b7f67b97577d6725c5d75) libgsf: fix cross-compilation
* [`f0296497`](https://github.com/NixOS/nixpkgs/commit/f02964978cdc18b6c54fedec8c0e7ecc05e5532a) libcdr: 0.1.6 → 0.1.7
* [`a0ed105a`](https://github.com/NixOS/nixpkgs/commit/a0ed105ac4d06810075c6f23d25d22e03a222e1f) qbittorrent: 4.4.3.1 -> 4.4.5
* [`3a1054bf`](https://github.com/NixOS/nixpkgs/commit/3a1054bfd9c472c94587e88bc53985e8a198bbcd) ulauncher: fix gobject-introspection
* [`793d0a0f`](https://github.com/NixOS/nixpkgs/commit/793d0a0f84a38c2d3f3ea9c6da0e2790be4c3fda) rmapi: 0.0.20 -> 0.0.21
* [`d5436fa9`](https://github.com/NixOS/nixpkgs/commit/d5436fa98677d5d63cc5597f76d556f3fe655e6d) gst-plugins-bad: patch nvidia runtime paths
* [`b6fc00b8`](https://github.com/NixOS/nixpkgs/commit/b6fc00b8f4bc25a72c43320b70082bbee06321db) rustc: propagate libiconv on darwin
* [`6ab84fc1`](https://github.com/NixOS/nixpkgs/commit/6ab84fc184797dd6666b71a4af80f185b77847dc) tree-sitter: 0.20.6 -> 0.20.7
* [`b4dc06bc`](https://github.com/NixOS/nixpkgs/commit/b4dc06bc9e4f0a0585236f70f7990982b5d5ff42) libtapi: update for cross-compilation
* [`b3b5eced`](https://github.com/NixOS/nixpkgs/commit/b3b5eced13b0366363af63491fe45b7c03e9c492) rmfakecloud: build the web ui
* [`5cf49931`](https://github.com/NixOS/nixpkgs/commit/5cf499310fbd3d55d6946798195381337bc75ea3) cyan: init at 1.2.4
* [`f016bedd`](https://github.com/NixOS/nixpkgs/commit/f016bedd7b2babbcc6d6da3e34dea516535edcdc) mongodb: wrap overly long lines
* [`f2de05f5`](https://github.com/NixOS/nixpkgs/commit/f2de05f59b5871e2702d3d18ded34de966d15ab2) mongodb: add note about mongosh
* [`9f392269`](https://github.com/NixOS/nixpkgs/commit/9f392269783b544b9b1755d9c2deb349e1a7ad86) mongodb-6_0: init at 6.0.1
* [`9201d116`](https://github.com/NixOS/nixpkgs/commit/9201d1163ed9e3624fb7bb1860e3838b7b88d78b) mongodb-6_0: restrict platform to linux
* [`1357f903`](https://github.com/NixOS/nixpkgs/commit/1357f9032706df952345e7f896b6f981ac32c402) maintainers: remove mkaito from serokell team
* [`588a2551`](https://github.com/NixOS/nixpkgs/commit/588a2551a676983a6ef34a25b27a5d087c1ade43) cutter: 2.1.0 -> 2.1.2
* [`09d4fd0f`](https://github.com/NixOS/nixpkgs/commit/09d4fd0f771392252592355387f3015596caed0d) release.nix: pass missing parameter
* [`bf4312de`](https://github.com/NixOS/nixpkgs/commit/bf4312de3eb33c4967c32cdf123a2d97edeb1e4a) freshBootstrapTools: rename from stdenvBootstrapTools
* [`47de66b1`](https://github.com/NixOS/nixpkgs/commit/47de66b1a437c8dbef29b03be51dedb2274d0006) lib/attrsets.nix: add unionOfDisjoint
* [`e7bafc81`](https://github.com/NixOS/nixpkgs/commit/e7bafc814c26812bdad587f347d9a1856287719b) pkgs/top-level/release.nix: disallow symbol clash between 'pkgs' and local jobs
* [`99da1938`](https://github.com/NixOS/nixpkgs/commit/99da19387705b90647741f020ad2f835e6c8056b) note that `unionOfDisjoint` is commutative, unlike //
* [`4610260d`](https://github.com/NixOS/nixpkgs/commit/4610260d9938249f2c5ef0c317744c185a55485a) pkgsStatic.glib: fix build
* [`4a226525`](https://github.com/NixOS/nixpkgs/commit/4a226525b3d4b61a688a0f004266f31ce10b6219) python3Packages.psutil: fix on darwin
* [`7948566b`](https://github.com/NixOS/nixpkgs/commit/7948566b404436f4a7adb96c95a9eee22977173c) libdrm: 2.4.112 -> 2.4.113
* [`d2749ccd`](https://github.com/NixOS/nixpkgs/commit/d2749ccd12a3ca62afc0b2817bafd2277c0b9680) cmake: 3.24.1 -> 3.24.2
* [`554996a3`](https://github.com/NixOS/nixpkgs/commit/554996a3b5ea528a91d8b7e097ac912a7c44fa06) ell: 0.52 -> 0.53
* [`f5838835`](https://github.com/NixOS/nixpkgs/commit/f58388357b4d7e4f530a246198f35be914ed705c) protonvpn-gui: 1.10.0 -> 1.11.0
* [`27a0edfd`](https://github.com/NixOS/nixpkgs/commit/27a0edfd6065e8421dd390071d956b2ce76903ef) gitkraken: 8.8.0 -> 8.9.1
* [`aeda2014`](https://github.com/NixOS/nixpkgs/commit/aeda2014ea97755dc8c02dbe845e046a85cd0ac0) fx_cast_bridge: 0.2.0 -> 0.3.1
* [`b52db2e4`](https://github.com/NixOS/nixpkgs/commit/b52db2e48020e7a7499aa66e51288530413214fc) flac: 1.3.4 -> 1.4.0
* [`2c9b5857`](https://github.com/NixOS/nixpkgs/commit/2c9b58573f5f4ae51a4de1f39a3b3ddf72506bae) cacert: 3.80 -> 3.83
* [`e0aa46d5`](https://github.com/NixOS/nixpkgs/commit/e0aa46d57b86ffc3d6843e651c3e7929df627881) ninja: reorder setup-hook.sh
* [`476d97b9`](https://github.com/NixOS/nixpkgs/commit/476d97b9bf9df1d4dcb7b632608a25c147e99959) ninja: format expression
* [`cc0f29fe`](https://github.com/NixOS/nixpkgs/commit/cc0f29feddc43e86b256217af8cb8a96b130fc71) ninja: add runHook's
* [`35227b31`](https://github.com/NixOS/nixpkgs/commit/35227b3105f29547eee7aac8b353334cfcd0a8d6) ninja: use installShellCompletion
* [`dee33e8f`](https://github.com/NixOS/nixpkgs/commit/dee33e8fe394066f7c0d1e37559714978c638c02) ninja: revert to the old rec format
* [`8db1ad78`](https://github.com/NixOS/nixpkgs/commit/8db1ad7850854beff268deaebaafe4e5867d76dc) linux: enable PERSISTENT_KEYRINGS and KEYS_REQUEST_CACHE
* [`732950b2`](https://github.com/NixOS/nixpkgs/commit/732950b26b452cc6762df0d3a2998f010da76624) nixos/stratis: add test for encryption support
* [`8e4dd2f3`](https://github.com/NixOS/nixpkgs/commit/8e4dd2f3716d471f87fa2bd98f172d6a5f341e48) protonvpn-cli: 3.12.0 -> 3.13.0
* [`b9c3107c`](https://github.com/NixOS/nixpkgs/commit/b9c3107cbfe94380f5cca1725d2bb64341dd153f) m17n-lib: pull fix pending upstream inclusion for parallel builds
* [`0b77dd35`](https://github.com/NixOS/nixpkgs/commit/0b77dd35985d7609e2046f485c942bf43d9f33dd) libpfm: 4.11.0 -> 4.12.0
* [`68bc381e`](https://github.com/NixOS/nixpkgs/commit/68bc381eb58a643d2b4fd014b0ba882929743e82) iwd: 1.29 -> 1.30
* [`dcf36ba9`](https://github.com/NixOS/nixpkgs/commit/dcf36ba9fda225152d4816952e23134c7df129ec) ofono: 1.34 -> 2.0
* [`3011c875`](https://github.com/NixOS/nixpkgs/commit/3011c87506357a3b5e7b3e2a774979a8c67c0603) iana-etc: 20220520 -> 20220915
* [`d04acb8a`](https://github.com/NixOS/nixpkgs/commit/d04acb8a96c2ae37dd4ff58db65dedfab8d3d79f) libfido2: add "dev" and "man" outputs
* [`40368ccc`](https://github.com/NixOS/nixpkgs/commit/40368cccd24bfd46faf6486f883fac9070fbaed6) opusfile: add "dev" output
* [`6bcea10f`](https://github.com/NixOS/nixpkgs/commit/6bcea10f5830f0c9377c565fe4e9cb1d9d16563f) SDL2: 2.0.22 -> 2.24.0
* [`0f39b3a8`](https://github.com/NixOS/nixpkgs/commit/0f39b3a85d35c2303a0ae57a1438af6fbf0c0337) ffmpeg_4: patch for new SDL2 versioning scheme
* [`169f01dd`](https://github.com/NixOS/nixpkgs/commit/169f01ddce66d729a03208b1b1de65d9b5e3bf7b) SDL2: fix post-install condition
* [`0b4c7ceb`](https://github.com/NixOS/nixpkgs/commit/0b4c7ceb1b934b59e1387a1cc047f86e7b9bcb8f) bats: 1.7.0 -> 1.8.0
* [`5267176a`](https://github.com/NixOS/nixpkgs/commit/5267176a3876362820ce360ec105a77b96bd8779) nixos/ddclient: document that daemon should not be set
* [`62dc18c5`](https://github.com/NixOS/nixpkgs/commit/62dc18c5bca16e41f84a61e5f32b8caad7c82cdf) libffi: 3.4.2 -> 3.4.3
* [`5d337370`](https://github.com/NixOS/nixpkgs/commit/5d3373708fd1ffca38d2b79f49b5749115fd157d) lz4: fix static build
* [`a72a02af`](https://github.com/NixOS/nixpkgs/commit/a72a02afad092301b0bcd903ec202f9bea3563a8) python3Packages.pywlroots: 0.15.21 -> 0.15.22
* [`fa44ead7`](https://github.com/NixOS/nixpkgs/commit/fa44ead70018770852bf7978c15dfc366619debc) libcamera: unstable-2022-09-03 -> unstable-2022-09-15
* [`6515b568`](https://github.com/NixOS/nixpkgs/commit/6515b56871f8d2a88026813cda685c83d18f0494) darwin.apple_sdk_11_0: use stdenv objc4
* [`9dc3b148`](https://github.com/NixOS/nixpkgs/commit/9dc3b1485936943f6a432dbb32a9f7c576cdab45) IOSurface: remove xpc dependency
* [`ac6d052f`](https://github.com/NixOS/nixpkgs/commit/ac6d052fd9c611821d34e8e41b550fb7530f8fbe) apple_sdk: clean up unused Libsystem parameter
* [`c319d8ae`](https://github.com/NixOS/nixpkgs/commit/c319d8ae3b7522656f74085281672f61c7112a98) cc-wrapper: comment explaining C++ stdlib order
* [`7beaf4c9`](https://github.com/NixOS/nixpkgs/commit/7beaf4c94173de1f76285c4bd68e5c3a797c9d5a) atlassian-jira: 8.22.4 -> 9.2.0
* [`880fa3ec`](https://github.com/NixOS/nixpkgs/commit/880fa3ec19d74adc1098383e02cfa2de74229ac5) expat: 2.4.8 -> 2.4.9
* [`a5f42f7e`](https://github.com/NixOS/nixpkgs/commit/a5f42f7eaa09ed3874b4bfedc06b7593adc9cc28) libmikmod: split out/dev/man outputs
* [`ee85543d`](https://github.com/NixOS/nixpkgs/commit/ee85543dd9b935716094389f747cb096bb3adaef) glew110: split out/dev outputs
* [`3c0d96a1`](https://github.com/NixOS/nixpkgs/commit/3c0d96a18dbf5fa018e580a69b88e6c5e952235e) openalSoft: remove leaked reference to pipewire.dev output
* [`0e3de4e7`](https://github.com/NixOS/nixpkgs/commit/0e3de4e73d47961e7b922885f898173bc6c2f6f4) smpeg: split out/dev outputs
* [`66f79ca2`](https://github.com/NixOS/nixpkgs/commit/66f79ca2a573506352109673f9e6a7e20dfa28c3) python310Packages.pulumi-aws: mark as working on darwin and aarch64
* [`83b01dd4`](https://github.com/NixOS/nixpkgs/commit/83b01dd4ecc38725be5ae3639d0bcb4c4cd2d697) SDL2_mixer: add "dev" output
* [`d3970b64`](https://github.com/NixOS/nixpkgs/commit/d3970b64bfce56c2f1dd0783e37a85127aead542) unbound: 1.16.2 -> 1.16.3
* [`0e2ed4b8`](https://github.com/NixOS/nixpkgs/commit/0e2ed4b8ae1a00b7543e985add2dbb45157649b8) lttng-ust: reduce runtime closure size
* [`73f3eedb`](https://github.com/NixOS/nixpkgs/commit/73f3eedb29272774a33062120e59bafbd109a2cd) expect: fix cross compile
* [`7fe991a9`](https://github.com/NixOS/nixpkgs/commit/7fe991a9b022e7b6cf32854038c76b346833de03) smpeg2: add "dev" and "man" outputs
* [`5e54883e`](https://github.com/NixOS/nixpkgs/commit/5e54883ea53a6635cb0035ba122c66441a34a7d8) openh264: 2.3.0 -> 2.3.1
* [`247ce091`](https://github.com/NixOS/nixpkgs/commit/247ce0911b70f2797da43c4e444af5c90e5f9414) python310Packages.pyjwt: 2.4.0 -> 2.5.0
* [`0e247a33`](https://github.com/NixOS/nixpkgs/commit/0e247a3313ee800791615280ca325749ebae38cf) python310Packages.setuptools-rust: 1.5.1 -> 1.5.2
* [`c2b898da`](https://github.com/NixOS/nixpkgs/commit/c2b898da7623a39e3c9b6265d311fe182aa526f0) treewide: drop -l$NIX_BUILD_CORES
* [`0ef51b4a`](https://github.com/NixOS/nixpkgs/commit/0ef51b4a15d7b9a85322799ad0da9d04fd9bdfe1) augustus: 3.1.0 -> 3.2.0
* [`e0ba645e`](https://github.com/NixOS/nixpkgs/commit/e0ba645ec16c5f412b880841148eb4504aeeece9) calls: 42.0 -> 43.0
* [`19313d0f`](https://github.com/NixOS/nixpkgs/commit/19313d0fa25e0180133ae9dfb936db80f68d0a13) openjdk*: Make bootstrap headless
* [`59356a83`](https://github.com/NixOS/nixpkgs/commit/59356a835155af8082f3e7b0db4e200f79a5ef1b) openjpeg: fix cmake files
* [`fb4ee289`](https://github.com/NixOS/nixpkgs/commit/fb4ee289d0d087cd080257ff21823ac402f43fb0) openjpeg: add poppler to passthru.tests
* [`8f7b2534`](https://github.com/NixOS/nixpkgs/commit/8f7b25344084335aaa55bda890559ab3a139c4a8) rustc: 1.63.0 -> 1.64.0
* [`02c85e57`](https://github.com/NixOS/nixpkgs/commit/02c85e57b96eae7c3fe841d16b4e2a351b2d607a) openjpeg: fix typo
* [`4267dbb5`](https://github.com/NixOS/nixpkgs/commit/4267dbb57b2f524a49ab020395ac0ec20a64c826) gst_all_1.gst-plugins-bad: add missing lcms2 depend
* [`b46221d7`](https://github.com/NixOS/nixpkgs/commit/b46221d76478c492547fbee3ec2e1a3a47655834) media-player-info: rename name to pname&version
* [`1e589865`](https://github.com/NixOS/nixpkgs/commit/1e589865f7bb11c413e2f6db03fb793247e84d8c) asciidoc: pass `SOURCE_DATE_EPOCH` to xsltproc
* [`43efa490`](https://github.com/NixOS/nixpkgs/commit/43efa4900ccc8726528ed35a3f866b4c19721591) lib.types.unspecified: Make name match attribute name again
* [`ee73d3a9`](https://github.com/NixOS/nixpkgs/commit/ee73d3a942f5c63e88ad0b9bc89c50521eb28e82) tzdata: 2022c -> 2022d
* [`15fd077b`](https://github.com/NixOS/nixpkgs/commit/15fd077b12aa006f9b0ab48e09a2c1a36464fea5) plasma-wayland-protocols: 1.7.0 -> 1.8.0
* [`02aa0798`](https://github.com/NixOS/nixpkgs/commit/02aa07986e377c0472a9e3bbdc8e3e806352c41a) opencl-headers: 2021.06.30 -> 2022.09.23
* [`037cf2fa`](https://github.com/NixOS/nixpkgs/commit/037cf2fad190766319c6c40b931b49c075ce5e78) unionOfDisjoint: use builtins.intersectAttrs
* [`987d32bb`](https://github.com/NixOS/nixpkgs/commit/987d32bbaca9b58c4aa652bdf7a26c86b70c182b) buildRustPackage: dont rely on NIX_BUILD_TOP in cargoSetupPostPatchHook
* [`91fa7c10`](https://github.com/NixOS/nixpkgs/commit/91fa7c10a4116b62e5635ef9f6d80c99139ca5c2) popsicle: update reference to cargoDepsCopy
* [`7ca1c451`](https://github.com/NixOS/nixpkgs/commit/7ca1c4517b4584b64f42384d459d7891ca37a921) zcash: update reference to cargoDepsCopy
* [`f2772c77`](https://github.com/NixOS/nixpkgs/commit/f2772c774972e33989b5b63e9b10a137fa4f15b0) perlPackages.Po4a: make devdoc reproducible
* [`a04d5445`](https://github.com/NixOS/nixpkgs/commit/a04d5445535c16eb13472e32d0d0b7435968b8cb) haproxy: 2.6.5 -> 2.6.6
* [`9984d87f`](https://github.com/NixOS/nixpkgs/commit/9984d87f051c90ebb7af035813a4f88bc1394cc1) gsasl: 2.0.1 -> 2.2.0
* [`53d7a002`](https://github.com/NixOS/nixpkgs/commit/53d7a0025779269085debd594e55ac1b6456d7c6) linphone: 4.4.9 -> 4.4.10
* [`0f3c5ed7`](https://github.com/NixOS/nixpkgs/commit/0f3c5ed71e725e6d9cc5a411444d428df6b5842e) libcap: 2.65 -> 2.66
* [`f98ce6c0`](https://github.com/NixOS/nixpkgs/commit/f98ce6c06def9576772af5a9a7161e00d0d12a3e) wolfebin: 5.4 -> 5.6
* [`6910a4ee`](https://github.com/NixOS/nixpkgs/commit/6910a4eea0038728a2f10ce84122806f2cb6b170) treewide: makeWrapper to nativeBuildInputs
* [`0734f54e`](https://github.com/NixOS/nixpkgs/commit/0734f54ef262ad642eec1166a416bae86779ed9f) treewide: move pkg-config, autoreconfHook, intltool to nativeBuildInputs
* [`3ca9b9a8`](https://github.com/NixOS/nixpkgs/commit/3ca9b9a8ad1b9dee2ec40eecca557f0578786b93) fetchNextcloudApp: rewrite with fetchzip & applyPatches
* [`04bb21e5`](https://github.com/NixOS/nixpkgs/commit/04bb21e5a27aa2891f6b0a807134c49cc4bb905e) imlib2: enable webp support by default
* [`c84404e4`](https://github.com/NixOS/nixpkgs/commit/c84404e4b61b7d77f5ed30fbc3259d4c2a07a836) feh: use imlib2Full
* [`bd6b07a2`](https://github.com/NixOS/nixpkgs/commit/bd6b07a2c1cce70ea6c114df289744329ff762f8) sxiv,nsxiv: use imlib2Full
* [`178aaddb`](https://github.com/NixOS/nixpkgs/commit/178aaddb934b983068e1cf129d2b2c87f10b3e64) qiv: use imlib2Full
* [`55c37b6a`](https://github.com/NixOS/nixpkgs/commit/55c37b6ac2295d29156dec4b73152c6a90249f62) jfbview: use imlib2Full
* [`1813980c`](https://github.com/NixOS/nixpkgs/commit/1813980c9101f929cd61242a2df8a34f9b71a3b6) srt: 1.4.4 -> 1.5.1
* [`7c49efdd`](https://github.com/NixOS/nixpkgs/commit/7c49efdd2a6b4f4860ccc67cfdca16f0d525b868) linux: Enable HARDENED_USERCOPY
* [`d83a3d03`](https://github.com/NixOS/nixpkgs/commit/d83a3d03a34b2537d92e47fdb1fea0169bceb9f1) meson: Use explicit setup subcommand
* [`45406f81`](https://github.com/NixOS/nixpkgs/commit/45406f811683dd36232155b7aa4ee5dea6259ca1) gnutls: 3.7.7 -> 3.7.8
* [`9785e4a3`](https://github.com/NixOS/nixpkgs/commit/9785e4a37e57642b09a57a0c5faf83d3b4b4654b) flac: 1.4.0 -> 1.4.1
* [`d02ac63f`](https://github.com/NixOS/nixpkgs/commit/d02ac63f4f4db57f0924fda26ee71e90947f2be4) stdenv/check-meta: fix support for NIXPKGS_ALLOW_NONSOURCE=1
* [`870d6f4a`](https://github.com/NixOS/nixpkgs/commit/870d6f4a98f19374d1188006574b8d55ca4a6547) licenses: remove gpl1
* [`8013bed6`](https://github.com/NixOS/nixpkgs/commit/8013bed698d12f3f0d4a09f59b214416e6c34000) ciao: 1.21.0-m1 -> 1.22.0-m1
* [`d1d0aa0d`](https://github.com/NixOS/nixpkgs/commit/d1d0aa0d88cc7add01a7d577c4e9b18fc9394f5a) pass-genphrase: fix error when run without python in PATH
* [`359b5bd1`](https://github.com/NixOS/nixpkgs/commit/359b5bd17166f670ad3073106c7f5cd724f886c7) tanka: 0.22.1 -> 0.23.1
* [`164865d9`](https://github.com/NixOS/nixpkgs/commit/164865d98e94967c05fe90d20c896174f8a66262) Revert "Revert "rustc: build with jemalloc""
* [`0be05bd9`](https://github.com/NixOS/nixpkgs/commit/0be05bd970b3b3b379e691c69240d6a89816113a) rustc: fix building emulated x86_64-darwin with jemalloc on aarch64-darwin
* [`18110dfd`](https://github.com/NixOS/nixpkgs/commit/18110dfde8e8b45a43f4bc0e648e1a2c8b55f088) organicmaps: 2022.07.27-3 -> 2022.09.22-3
* [`9399cda0`](https://github.com/NixOS/nixpkgs/commit/9399cda0bf3471445cd8123c785ebc167465eddc) sonic-pi: 4.2.0 -> 4.3.0
* [`42572c63`](https://github.com/NixOS/nixpkgs/commit/42572c637dd726d16487bb4e1fcc3ebeaae2d094) kafkactl: 2.5.0 -> 3.0.0
* [`5a35c971`](https://github.com/NixOS/nixpkgs/commit/5a35c971bf2e9e079673c0bc551c5841ea4bce79) kops: 1.24.3 -> 1.25.1
* [`4eb5696d`](https://github.com/NixOS/nixpkgs/commit/4eb5696d61ebc9ea5832ae00cb6b86dbb008d6f4) calls: update meta.homepage to gitlab.gnome.org
* [`1bc7c2dc`](https://github.com/NixOS/nixpkgs/commit/1bc7c2dcc93a14a286cad17891e9fe174e7294a8) swayr: 0.20.1 -> 0.22.0
* [`e19150be`](https://github.com/NixOS/nixpkgs/commit/e19150be4fdc0cfb313560584467208b4117fad7) vintagestory: 1.16.5 -> 1.17.4
* [`d271eed0`](https://github.com/NixOS/nixpkgs/commit/d271eed0ba06260724c301aca3c1c19c5da6780b) libsForQt5.plasmaMobileGear: 22.06 -> 22.09
* [`71ba09e6`](https://github.com/NixOS/nixpkgs/commit/71ba09e60e192239f9734d33812453d2e72380bd) libsForQt5.kweathercore: 0.5 -> 0.6
* [`19e66a67`](https://github.com/NixOS/nixpkgs/commit/19e66a67b0b1090b0d9c9623a688465efe4a428f) kirigami-addons: 21.05 -> 0.4
* [`035448ea`](https://github.com/NixOS/nixpkgs/commit/035448ea710a4c1329f2cd13e6ab0ff227bc7181) spacebar: Fixes for 22.09
* [`42840113`](https://github.com/NixOS/nixpkgs/commit/428401133f7131517399aa460258424e99cde1e2) openblas: fix build on aarch64-linux (PR [nixos/nixpkgs⁠#193729](https://togithub.com/nixos/nixpkgs/issues/193729))
* [`a31ad3bb`](https://github.com/NixOS/nixpkgs/commit/a31ad3bbf01c823407625ebe302a5481d4d43383) carla: 2.5.0 -> 2.5.1
* [`5a0cd9c7`](https://github.com/NixOS/nixpkgs/commit/5a0cd9c748c37c9792564856957aa0d199c4c313) fwts: 21.07.00 -> 22.09.00
* [`5f070790`](https://github.com/NixOS/nixpkgs/commit/5f070790ccdcc28cf0590ff5b740bec25ca69d75) azure-functions-core-tools: Add darwin support, upgrade to v4
* [`d41b3813`](https://github.com/NixOS/nixpkgs/commit/d41b381310f5dcde1434b23406532f54ebdeea22) nixos/release-notes: document `fetchNextcloudApp` changes
* [`d709a706`](https://github.com/NixOS/nixpkgs/commit/d709a706c90559f60448289286c454778f7db5f4) super-slicer: use non-EGL version of wxWidgets.
* [`1a90756a`](https://github.com/NixOS/nixpkgs/commit/1a90756aa752aef6d6910eaac29b8e8d7e0f99de) tracee: 0.7.0 -> 0.8.3
* [`ec7884c3`](https://github.com/NixOS/nixpkgs/commit/ec7884c35ab646814a88b3191fa70f3f7e46e65c) file-roller: remove unzip
* [`c800d3fc`](https://github.com/NixOS/nixpkgs/commit/c800d3fc4002c4034558699079cf9608e3c7c981) python3Packages.sphinx-basic-ng: 0.0.1.a12 -> 1.0.0.beta1
* [`f1275630`](https://github.com/NixOS/nixpkgs/commit/f1275630eb46c96cb8ef83841dd8fa72051e913f) maintainers: add fee1-dead
* [`eb20178f`](https://github.com/NixOS/nixpkgs/commit/eb20178f3a7ab337c65269b6bd08f483ee897469) losslesscut: 3.43.0 -> 3.46.2
* [`fd1d3373`](https://github.com/NixOS/nixpkgs/commit/fd1d3373721082f7dc874cb504a776d82461be60) latte-dock: 0.10.4 -> unstable-2022-09-06
* [`594db699`](https://github.com/NixOS/nixpkgs/commit/594db69923befb320b4b16cf29bb9686e6fc36c2) maintainer/scripts/feature-freeze-teams: Fix HTTP status line log
* [`d63d265c`](https://github.com/NixOS/nixpkgs/commit/d63d265c4efac3d5b1e6aa19b066b88cb75502a0) gogdl: init at 0.3
* [`81b9d5ca`](https://github.com/NixOS/nixpkgs/commit/81b9d5cab6f40d41b288cac918110279978a6277) openjdk*: fix darwin eval failure
* [`1abe038d`](https://github.com/NixOS/nixpkgs/commit/1abe038db935f54db3669d705ebb3cd05a4651fd) heroic: Repackage from source and wrap in FHS
* [`0bb0a0ff`](https://github.com/NixOS/nixpkgs/commit/0bb0a0ffb38ff418dd491e6fbf3b96519996c992) wasmedge: 0.11.0 -> 0.11.1
* [`a9668e31`](https://github.com/NixOS/nixpkgs/commit/a9668e31ee8451dea5226c3ad4ed8f82f78cd92e) datree: 1.6.33 -> 1.6.37
* [`6f857485`](https://github.com/NixOS/nixpkgs/commit/6f8574855488fdf3e0e0ae44a427f8815edefdcd) tcllib: 1.20 -> 1.21
* [`6297062e`](https://github.com/NixOS/nixpkgs/commit/6297062e6883e07733bd0850f2380ac65302625f) tcllib: add fgaz to maintainers
* [`9188e144`](https://github.com/NixOS/nixpkgs/commit/9188e144344c73be1b0d49110a589c5b0a411128) qFlipper: 1.1.3 -> 1.2.1
* [`69e6f91e`](https://github.com/NixOS/nixpkgs/commit/69e6f91ed189151671c4922658df66ff81c3e161) bitwuzla: build with SymFPU
* [`18663fd1`](https://github.com/NixOS/nixpkgs/commit/18663fd1c1132d659d8f68d101b14a96b5857b2e) bitwuzla: unstable-2022-08-07 -> unstable-2022-10-03
* [`7a494b61`](https://github.com/NixOS/nixpkgs/commit/7a494b61e070fd27afc502970eaef87fe6cb27a2) polychromatic: cleanup dependencies
* [`ee335f7d`](https://github.com/NixOS/nixpkgs/commit/ee335f7dede27ac359c25d87b9346191bb3722a6) ffmpeg-full: don't disable rav1e
* [`d71a0b97`](https://github.com/NixOS/nixpkgs/commit/d71a0b97b18a86afc937e9e3860cef73ca019b2f) postman: 9.25.2 -> 9.31.0
* [`147a5bb2`](https://github.com/NixOS/nixpkgs/commit/147a5bb2ded2d2a93247c3cc9cf3fdb3c156fedc) shotman: init at 0.2.0
* [`750da022`](https://github.com/NixOS/nixpkgs/commit/750da0225bf6577f2716c19695be7f4e6be2a599) python3Packages.pyjwt: Update various packaging details
* [`aae955fc`](https://github.com/NixOS/nixpkgs/commit/aae955fcfb4d504f36253ceef8cd72a1997cf5f7) python3Packages.django-allauth: propagate pyjwt[crypto]
* [`b5393c3f`](https://github.com/NixOS/nixpkgs/commit/b5393c3f78a19da8e56e6a02f48a958e5d6592cb) seahub: build with format other
* [`37803dde`](https://github.com/NixOS/nixpkgs/commit/37803ddef74ca4381ece080eefcdd65bed0e4fcb) python3Packages.adal: drop cryptography requirement
* [`264cd5ab`](https://github.com/NixOS/nixpkgs/commit/264cd5ab5ff156e8fd2ba94a62778f7cad4872eb) python3Packages.gidgethub: propagete pyjwt[crypto]
* [`0962181e`](https://github.com/NixOS/nixpkgs/commit/0962181e61c23f9794732dd673d0c7f907966735) python3Packages.auth0-python: propagete pyjwt[crypto]
* [`b4c307de`](https://github.com/NixOS/nixpkgs/commit/b4c307de89c771b1f584cce4ad0028d2e8ecb014) python3Packages.twilio: add cryptography to checkInputs
* [`d5966357`](https://github.com/NixOS/nixpkgs/commit/d59663577d9038673e67b1efafed9e64f12b337f) python3Packages.flask-jwt-extended: set up optional-dependencies
* [`56aacce4`](https://github.com/NixOS/nixpkgs/commit/56aacce44e7d78b5453bb1be4cf0c259ab05d230) python3Packages.apache-airflow: relax pathspec constraint
* [`9b4117a2`](https://github.com/NixOS/nixpkgs/commit/9b4117a29b8827bc638261a943607a7d659d51a0) python3Packages.msal: propagate pyjwt[crypto]
* [`d3af3569`](https://github.com/NixOS/nixpkgs/commit/d3af35696a7f4b825d053b50d5962bed42b3b381) python3Packages.github3_py: propagate pyjwt[crypto]
* [`92a3dbd7`](https://github.com/NixOS/nixpkgs/commit/92a3dbd7f3ae5aaa973d228c406b72b560d6aba7) python3Packages.drf-jwt: propagate pyjwt[crypto]
* [`f9176cf7`](https://github.com/NixOS/nixpkgs/commit/f9176cf7cd2cca0ee92b8da4ef730f801bdfbace) python3Packages.social-auth-core: simplify passing optional-dependencies into checkInputs
* [`450e7db0`](https://github.com/NixOS/nixpkgs/commit/450e7db0661c904c3f0d5a7002c7e82e4ca34170) blightmud: use rustPlatform.bindgenHook
* [`aa88e214`](https://github.com/NixOS/nixpkgs/commit/aa88e214ef4ca7aaa7c8ee78402be7b1e572d4d3) blightmud: apply nixpkgs-format
* [`deed43a7`](https://github.com/NixOS/nixpkgs/commit/deed43a7257ea861e00d627b98f0e62d2072d790) blightmud: remove unused derivation arg.
* [`68a2367f`](https://github.com/NixOS/nixpkgs/commit/68a2367f8977fc71aef00f0dc0883a9d0a231b5c) python3Packages.eth-keys: Disable failing test
* [`b1dca559`](https://github.com/NixOS/nixpkgs/commit/b1dca5596ee6d664c38c18553c5756afca5bb113) python3Packages.django_3: 3.2.15 -> 3.2.16
* [`6cd9dfb7`](https://github.com/NixOS/nixpkgs/commit/6cd9dfb705685fda29cb6cd895001412ec565f91) linux_xanmod: 5.15.60 -> 5.15.70
* [`2f0b33c4`](https://github.com/NixOS/nixpkgs/commit/2f0b33c47a5d86289fdb73fe23ece7111d7a3920) linux_xanmod_latest: 5.19.1 -> 5.19.12
* [`c2fab026`](https://github.com/NixOS/nixpkgs/commit/c2fab026d8100d4d3b4b02dff1e1ee0f7c027952) linux_xanmod_latest: 5.19.12 -> 6.0.0, rename edge to next
* [`ceda251f`](https://github.com/NixOS/nixpkgs/commit/ceda251f7d12a234665d9f945a880e5fd8e564c2) linux_xanmod_stable: init at 5.19.13
* [`32e91ab1`](https://github.com/NixOS/nixpkgs/commit/32e91ab1de0fa2b6cf5229d94939dda5beec3899) antibody: mark broken on darwin
* [`a1e9f1e0`](https://github.com/NixOS/nixpkgs/commit/a1e9f1e0365626ad61936244c570a3dff1ea5904) nixos/firewall: move rpfilter from raw to mangle
* [`f7e3f959`](https://github.com/NixOS/nixpkgs/commit/f7e3f959eaeee76855c104ec1c278de7a44a2c5a) faustPhysicalModeling: 2.41.1 -> 2.50.6
* [`74484341`](https://github.com/NixOS/nixpkgs/commit/744843416862fb61d2bc7efc50bd194ba727814e) vscode-extensions.chenglou92.rescript-vscode: 1.6.0 -> 1.8.1
* [`ec813f2e`](https://github.com/NixOS/nixpkgs/commit/ec813f2e372137cafa0bacdae52892f34bc7f22b) linux_xanmod_latest: remove CC_OPTIMIZE_FOR_PERFORMANCE_O3
* [`bbcc162a`](https://github.com/NixOS/nixpkgs/commit/bbcc162a42be96579ce25dd67b93f7cfad8b9f5c) haskellPackages: stackage LTS 19.25 -> LTS 19.27
* [`c0078a4d`](https://github.com/NixOS/nixpkgs/commit/c0078a4d3026c687415d0a5511e688494093fde9) all-cabal-hashes: 2022-10-01T15:28:21Z -> 2022-10-05T14:24:18Z
* [`bbd00e86`](https://github.com/NixOS/nixpkgs/commit/bbd00e8632c232da12a610d53b53951c0441b18e) haskellPackages: regenerate package set based on current config
* [`f88a7573`](https://github.com/NixOS/nixpkgs/commit/f88a75731c8400830ef8236d81eca01270e47d18) mdbook-admonish: patch to work with rust 1.64
* [`22d82d16`](https://github.com/NixOS/nixpkgs/commit/22d82d169c2e192b32d6d17db75913c3f7eb28e9) python3Packages.skia-pathops: fix build on aarch64-darwin
* [`007a6b6f`](https://github.com/NixOS/nixpkgs/commit/007a6b6fd6ab7fd228612a43934810d5332bcc53) mdbook-graphviz: patch to work with rust 1.64
* [`282f2362`](https://github.com/NixOS/nixpkgs/commit/282f236230b1e39d056aaa8fc12082e87ab4b0c7) mdbook-katex: patch to work with rust 1.64
* [`af03e7f5`](https://github.com/NixOS/nixpkgs/commit/af03e7f59f11de6c533b6101bc51e1da7017dd70) python3Packages.pyregion: 2.0 -> 2.1.1
* [`d61f6896`](https://github.com/NixOS/nixpkgs/commit/d61f68964facc8fb12ae6b321740aa2e3879f6f7) python3Packages.reproject: fix tests
* [`d0474997`](https://github.com/NixOS/nixpkgs/commit/d0474997c548c664ed956af903ec20cb054250c3) haskellPackages.gnuidn: unmark as broken
* [`c51c61e8`](https://github.com/NixOS/nixpkgs/commit/c51c61e8c7e638e0dbc1dd5cadc89e3cfc175e93) toxiproxy: fix darwin build
* [`dcda00d4`](https://github.com/NixOS/nixpkgs/commit/dcda00d4ac91823f7dd7ae96ba71f26ec188fbfb) haskell.packages.ghc942.haskell-language-server: Disable unsupported plugins to fix build
* [`193ffabf`](https://github.com/NixOS/nixpkgs/commit/193ffabf5589d87ff35c32f0d90be11b8c5fd179) haskell.packages.ghc942.haskell-language-server: Enable hydra job
* [`1fdd1a46`](https://github.com/NixOS/nixpkgs/commit/1fdd1a462b530ab7ec61bfcdeae7d1942a4e64e7) haskell.packages.ghc924.haskell-language-server: Fix eval by pinning ghc-exactprint
* [`ba418750`](https://github.com/NixOS/nixpkgs/commit/ba418750fa5027385968a51a44983f030a3cfd35) satysfi: 0.0.7 -> 0.0.8
* [`04d4d8d2`](https://github.com/NixOS/nixpkgs/commit/04d4d8d2e689218cf0d22c577cca19bb8071d1bf) vscode-extensions.apollographql.vscode-apollo: 1.19.9 -> 1.19.11
* [`1a30a70f`](https://github.com/NixOS/nixpkgs/commit/1a30a70fb37d86f2e7b82b296dcd89eb7a364c26) vscode-extensions.davidanson.vscode-markdownlint: 0.47.0 -> 0.48.1
* [`57c92176`](https://github.com/NixOS/nixpkgs/commit/57c921763aeb0f0f660eef267cd43f41d5bc5af8) vscode-extensions.esbenp.prettier-vscode: 9.8.0 -> 9.9.0
* [`31111502`](https://github.com/NixOS/nixpkgs/commit/31111502eb3ea824bf67652bd11b51ce8304c1ee) vscode-extensions.naumovs.color-highlight: 2.5.0 -> 2.6.0
* [`64f0a698`](https://github.com/NixOS/nixpkgs/commit/64f0a698a56b6f3da3ca1b94ab3c3c58935bd84b) vscode-extensions.stkb.rewrap: 1.16.1 -> 1.16.3
* [`04cfb304`](https://github.com/NixOS/nixpkgs/commit/04cfb304072420df756c1012fef334d225e3b4df) vscode-extensions.dbaeumer.vscode-eslint: 2.2.2 -> 2.2.6
* [`df369b38`](https://github.com/NixOS/nixpkgs/commit/df369b38a0f10a9538ce007171d461fd2cc954a7) netbox: 3.3.4 -> 3.3.5
* [`412a7f08`](https://github.com/NixOS/nixpkgs/commit/412a7f084feab1a2cf34cbfe24b94ced58325477) xfce.xfce4-datetime-plugin: 0.8.1 -> 0.8.2
* [`8a0365ae`](https://github.com/NixOS/nixpkgs/commit/8a0365aeebaa7e999ec0543b6fa0559fbacbbf7d) mate.mate-tweak: 22.04.8 -> 22.10.0
* [`4a99a449`](https://github.com/NixOS/nixpkgs/commit/4a99a449ca4205b5d712694250ca12d8cd935223) mdbook-man: unstable-2021-08-26 -> unstable-2022-11-05
* [`c1092777`](https://github.com/NixOS/nixpkgs/commit/c10927773fc55a32195b525d5731bee556fc373a) mdbook-mermaid: patch to work with rust 1.64
* [`5aae5330`](https://github.com/NixOS/nixpkgs/commit/5aae5330ee516cff4e132c24f685f9ced9916f09) mdbook-open-on-gh: patch to work with rust 1.64
* [`3d5d6fc7`](https://github.com/NixOS/nixpkgs/commit/3d5d6fc78c0f529d4d8c62fa5e9975877d96ec75) nixos: luksroot: toString-ify keyFileSize usage
* [`e7b47a72`](https://github.com/NixOS/nixpkgs/commit/e7b47a72fef2eb23342cd4f395ac305b8afa1ad4) haskell.packages.ghc884.cabal-fmt: drop stale override
* [`ac1f1ad0`](https://github.com/NixOS/nixpkgs/commit/ac1f1ad0e0a8cfd35db476529c82354e033a48cc) haskell: support cross in generateOptparseApplicativeCompletions
* [`9e9b7f4d`](https://github.com/NixOS/nixpkgs/commit/9e9b7f4d99086901f95d856fb8cdd63e7818fc6e) haskell.lib.compose.addOptparseApplicativeCompletionScripts: remove
* [`1853d303`](https://github.com/NixOS/nixpkgs/commit/1853d303516f91c958aae5ba9a86f9cfa840f364) mbqn: 0.pre+date=2021-12-13 -> 0.pre+date=2022-10-03
* [`1d7d8b4b`](https://github.com/NixOS/nixpkgs/commit/1d7d8b4b0a4cef86bb7d70ec94d510f3ff4e4a0e) cbqn: 0.pre+date=2022-05-06 -> 0.pre+date=2022-10-04
* [`436c831f`](https://github.com/NixOS/nixpkgs/commit/436c831f9a7fc2bf8195077dbf4540c68fdd0e96) probe-run: 0.3.4 -> 0.3.5
* [`75591a10`](https://github.com/NixOS/nixpkgs/commit/75591a10daad0e905ca015965949c1188e66229c) appflowy: pin openssl_1_1
* [`4dede45d`](https://github.com/NixOS/nixpkgs/commit/4dede45d4e1f18fd2a84a70bb5434cb04f6e5976) python310Packages.gaphas: 3.8.0 -> 3.8.1
* [`1136247c`](https://github.com/NixOS/nixpkgs/commit/1136247c758639b401187cf7e0b63e6a5ffff1a6) dwm: 6.3 -> 6.4
* [`6ea2906e`](https://github.com/NixOS/nixpkgs/commit/6ea2906e492da4fd69ded2b41ca080170bcc598f) git-extras: 6.4.0 -> 6.5.0
* [`64232393`](https://github.com/NixOS/nixpkgs/commit/642323930effc0c520c66ff31d84e00d481f2813) nixos/systemd-boot: correctly find gen_number for specialisation
* [`12243684`](https://github.com/NixOS/nixpkgs/commit/1224368495429216cac2418225e0f46c6f8acbe4) nixosTests.nscd: init, move DynamicUser test into there
* [`437f73dd`](https://github.com/NixOS/nixpkgs/commit/437f73dd546e1cbaaa9de576608bdfa0281659e3) nixos/systemd-boot: fix entry match condition in remove_old_entries
* [`fc4fa263`](https://github.com/NixOS/nixpkgs/commit/fc4fa263ff7d4f6c0c4de8c3a78b2d509c5f9a0f) probe-run: modernize
* [`508d498c`](https://github.com/NixOS/nixpkgs/commit/508d498cbce318718880870fcc3283163cdfa29f) mdbook-pdf: 0.1.2 -> 0.1.3
* [`ee04f163`](https://github.com/NixOS/nixpkgs/commit/ee04f163bda709001dcc4d237ae83a84e863da1e) mdbook-plantuml: 0.7.0 -> 0.8.0
* [`9627ed21`](https://github.com/NixOS/nixpkgs/commit/9627ed21dbbada09b399f5440f5f239ea4122401) mdzk: patch to work with rust 1.64
* [`5a01cf10`](https://github.com/NixOS/nixpkgs/commit/5a01cf108466331a3223bbcc3afc7d014b18d351) pre-commit: use absolute path for binary in hook
* [`9047260b`](https://github.com/NixOS/nixpkgs/commit/9047260b63938c428ca9caa2ccc93b27642403d1) aumix: fix build when not using GTK
* [`67e57d81`](https://github.com/NixOS/nixpkgs/commit/67e57d811b5437ca3da8ef03205eb74ffcb368f0) intel-media-driver: 22.5.2 -> 22.5.3.1
* [`06eccdaa`](https://github.com/NixOS/nixpkgs/commit/06eccdaa8b8d6074a6ed575751d45f2e023fef60) martin: patch to work with rust 1.64
* [`941c79b6`](https://github.com/NixOS/nixpkgs/commit/941c79b6207fa84612b4170ca3bc04984f3d79fc) nixos/github-runner: fix bugs related to `InaccessiblePaths=`
* [`2fe04152`](https://github.com/NixOS/nixpkgs/commit/2fe04152028c9992410acf43bb0a0e3fdcd4fe47) rehex: 0.4.1 -> 0.5.3
* [`0e80a8ae`](https://github.com/NixOS/nixpkgs/commit/0e80a8aedfc51cc064cbfea29b904c7b5b43beda) cargo-bisect-rustc: 0.6.3 -> 0.6.4
* [`60a141cb`](https://github.com/NixOS/nixpkgs/commit/60a141cbcf8f26a6c0078f2988f7ef8d4790d9f7) bandwhich: patch to work with rust 1.64
* [`bccd2d14`](https://github.com/NixOS/nixpkgs/commit/bccd2d144fec9c2e990509c8d9f330ed22e606f8) cliscord: unstable-2020-12-08 -> unstable-2022-10-07
* [`e907f766`](https://github.com/NixOS/nixpkgs/commit/e907f76622709cf366059f16af3e6966da787398) fundoc: patch to work with rust 1.64
* [`052dca32`](https://github.com/NixOS/nixpkgs/commit/052dca32e2cb8d06fbb4db11c708f7b8a3711831) mozwire: 0.7.0 -> 0.8.0
* [`3c6fbacc`](https://github.com/NixOS/nixpkgs/commit/3c6fbacc9e43b88aa42835811b1fc310143b3282) tdns-cli: 0.0.5 -> unstable-2021-02-19
* [`03e29459`](https://github.com/NixOS/nixpkgs/commit/03e29459fa21006d6017c33d2d16ef95874202bd) spotify-tui: patch to work with rust 1.64
* [`425ccd7c`](https://github.com/NixOS/nixpkgs/commit/425ccd7c84ee4048c03a611ad3ed17c751552974) fractal: patch to work with rust 1.64
* [`1659fbf3`](https://github.com/NixOS/nixpkgs/commit/1659fbf3223e87094f3b00fdd47bc6c18c5a2e19) ostree: 2022.5 -> 2022.6
* [`804100e6`](https://github.com/NixOS/nixpkgs/commit/804100e6e198136b8f993e0148e23cbc42420ebb) survex: 1.4.1 -> 1.4.3
* [`bc2ce963`](https://github.com/NixOS/nixpkgs/commit/bc2ce9630aa6d0dc28105becb260988136cd9ef6) vector: patch to compile with rust 1.64.
* [`f3e5a863`](https://github.com/NixOS/nixpkgs/commit/f3e5a863919f146badbea3a090e51e8efe1c0023) postgresqlPackages.pgroonga: 2.3.9 -> 2.4.0
* [`1919d33a`](https://github.com/NixOS/nixpkgs/commit/1919d33acdf2f901f54e15955759a87658e1a1e7) wvkbd: 0.10 -> 0.11
* [`5ba1236b`](https://github.com/NixOS/nixpkgs/commit/5ba1236b0c0b1f7ed0d879ceead6be9f90bd8d36) python310Packages.kazoo: 2.8.0 -> 2.9.0
* [`d55a6740`](https://github.com/NixOS/nixpkgs/commit/d55a67404f4a5b42f6cc75e28ae0eaa3e8bb6a30) astromenace: use xorg.* packages directly instead of xlibsWrapper indirection
* [`acc3247d`](https://github.com/NixOS/nixpkgs/commit/acc3247db8a2c00eb19195d99185386ad4e10138) python3Packages.pyregion: fetch each patch commit individually
* [`1ec792a0`](https://github.com/NixOS/nixpkgs/commit/1ec792a0dcb5ce9cf955d924b23c76574bcef4a2) gns3-gui,gns3-server: 2.2.31 -> 2.2.34
* [`78fe5b0a`](https://github.com/NixOS/nixpkgs/commit/78fe5b0a4fabb9b7e1bd560b146fde572ebed36d) gns3-gui,gns3-server: add anthonyroussel to maintainers
* [`7c45233b`](https://github.com/NixOS/nixpkgs/commit/7c45233bcb76c1f9820657cd9cfb505307d27447) diff-pdf: migrate to wxGTK32
* [`f1f98cc1`](https://github.com/NixOS/nixpkgs/commit/f1f98cc18fd017bf3afde0a36bb65ead46ce55c3) wxsqlite3: 4.8.2 -> 4.9.0
* [`05962d95`](https://github.com/NixOS/nixpkgs/commit/05962d95f77be7d75424033b9827d349b00042ca) openrct2: 0.4.1 -> 0.4.2
* [`7280f5b4`](https://github.com/NixOS/nixpkgs/commit/7280f5b4994f73dc2a6686060e4310202a219714) nginx-config-formatter: 2019-02-13 -> 1.2.2
* [`96df86a0`](https://github.com/NixOS/nixpkgs/commit/96df86a00143dd515d5244db017de97c07c1694d) freqtweak: migrate to wxGTK32
* [`d6447546`](https://github.com/NixOS/nixpkgs/commit/d64475464c1922e3420f70f1defc5823f5d13b46) libgtkflow: split into 3 separate derivations
* [`697a72e8`](https://github.com/NixOS/nixpkgs/commit/697a72e8a9ff127d4ccbabc0bfeb765494b58875) qt5: 5.15.5 -> 5.15.6
* [`28555454`](https://github.com/NixOS/nixpkgs/commit/28555454d30c3f86403a8457c29034464a5ebdb2) plasma5Packages.plasma-wayland-protocols: 1.8.0 -> 1.9.0
* [`472f1979`](https://github.com/NixOS/nixpkgs/commit/472f197978224bb542a0cab0b0503f456be27504) neovide: remove dependency to skia sources
* [`6ed7e545`](https://github.com/NixOS/nixpkgs/commit/6ed7e545ecfa1db9c6e5f93571a93e7848c449cf) nixos/virtualbox-host: Fix hardening with headless vbox
* [`bc8d6d8f`](https://github.com/NixOS/nixpkgs/commit/bc8d6d8f968fcc37b6495526b805e0de18f9f849) nixos/networkd: `DHCPv6PrefixDelegation` -> `DHCPPrefixDelegation`
* [`036489ff`](https://github.com/NixOS/nixpkgs/commit/036489ffaa477774a0cfad0377598aaf3120aa58) nixos/networkd: adapt `dhcpV6Config`
* [`4367b782`](https://github.com/NixOS/nixpkgs/commit/4367b782bc0371702ec398256d68a9e43b95decc) nixos/networkd: deprecate `IPv6Token=`
* [`4f442dde`](https://github.com/NixOS/nixpkgs/commit/4f442dde0ec8412d7eeb024dcb568620787901b3) nixos/networkd: add new options
* [`f6a77964`](https://github.com/NixOS/nixpkgs/commit/f6a7796471ddf758eeef0865aba942a10e55df00) ser2net: 4.3.7 -> 4.3.8
* [`5c45ba98`](https://github.com/NixOS/nixpkgs/commit/5c45ba9850dfeeba2b9823b06c234b6c761448c3) python3Packages.wxPython_4_1: fix build on aarch64-darwin
* [`8171f7c8`](https://github.com/NixOS/nixpkgs/commit/8171f7c8d8142ef7aee5bce3d99a506131cb0a80) ivy: 0.1.13 -> 0.2.8
* [`d20c8697`](https://github.com/NixOS/nixpkgs/commit/d20c8697ebdbecada47fac8ffb7e30d322fd517c) llvmPackages_{13,14}.lldb: fix build on x86 macOS
* [`9911a25a`](https://github.com/NixOS/nixpkgs/commit/9911a25a56815caa0d9858775d14addb3f8825fe) python310Packages.eyeD3: 0.9.6 -> 0.9.7
* [`7cce28d5`](https://github.com/NixOS/nixpkgs/commit/7cce28d594fcc094dfb76eb89430806002c04352) qt5.qtscript: drop the version override
* [`89a2e809`](https://github.com/NixOS/nixpkgs/commit/89a2e8099024a601ff77ae620efe53f1dd7fd650) python310Packages.aiopvapi: 2.0.2 -> 2.0.3
* [`d6bb779e`](https://github.com/NixOS/nixpkgs/commit/d6bb779ebec84a9ae89ffe218f4a2eed9eac0b67) python310Packages.pymsteams: 0.2.1 -> 0.2.2
* [`1a7ef0f4`](https://github.com/NixOS/nixpkgs/commit/1a7ef0f4345e69e849ac9b8591699d8a2429699a) python310Packages.graphql-core: 3.2.1 -> 3.2.3
* [`c0f308b7`](https://github.com/NixOS/nixpkgs/commit/c0f308b7872e90700c1e099e08314091275c8a2c) conky: use xorg.* packages directly instead of xlibsWrapper indirection
* [`662f8712`](https://github.com/NixOS/nixpkgs/commit/662f871224df3b32cacb2cf8f7de0bd01299b870) python310Packages.homematicip: 1.0.8 -> 1.0.9
* [`ef47e552`](https://github.com/NixOS/nixpkgs/commit/ef47e552b7cbb75be9f857192bc35797cfd392a4) python310Packages.huawei-lte-api: 1.6.2 -> 1.6.3
* [`ba7332ae`](https://github.com/NixOS/nixpkgs/commit/ba7332ae0d56c4d9ba66ac04512199831a981102) python310Packages.teslajsonpy: 2.4.4 -> 2.4.5
* [`c971baec`](https://github.com/NixOS/nixpkgs/commit/c971baec071551dea1b137dfa3ea87a31e69237c) python310Packages.yfinance: 0.1.74 -> 0.1.77
* [`26e666d3`](https://github.com/NixOS/nixpkgs/commit/26e666d33ce5351061bff37aafe15d3cb3a365e4) haskellPackages.espial: Apply patch to work with GHC 9.X
* [`5819054b`](https://github.com/NixOS/nixpkgs/commit/5819054b67906123fbf2dfceb1d2b8c7c2189da8) guake: 3.6.3 -> 3.9.0
* [`d34cf478`](https://github.com/NixOS/nixpkgs/commit/d34cf47881fe1d1cd46b96df1f73e991332b2973) guake: update release notes
* [`07acd3e4`](https://github.com/NixOS/nixpkgs/commit/07acd3e407932d413a2c0d8f33fe723cce0714ee) nuspell: 5.0.1 -> 5.1.2
* [`5523ff8d`](https://github.com/NixOS/nixpkgs/commit/5523ff8d7a7964485842f5e520c7f8ed42c5b501) clanlib: drop unused xlibsWrapper input
* [`903b5751`](https://github.com/NixOS/nixpkgs/commit/903b57513e96a761a3efccdaef1f02f6b83c25ac) haskellPackages.snaplet-purescript: GHC9 compatibility
* [`a2436fc5`](https://github.com/NixOS/nixpkgs/commit/a2436fc54d519c0e40de9588e34e3362bf16916a) flutter: enable aarch64-linux support
* [`5bc6d8ae`](https://github.com/NixOS/nixpkgs/commit/5bc6d8ae75f708aa7dc5a031b01c882dff61f3b1) zoneminder: 1.36.15 -> 1.36.28
* [`c83582e4`](https://github.com/NixOS/nixpkgs/commit/c83582e4490c5168f829a96b8156f899ee0423f6) google-cloud-sdk: 404.0.0 -> 405.0.0
* [`d04558dd`](https://github.com/NixOS/nixpkgs/commit/d04558dd37e851e32f005c6efc1be8a3b0b0df1d) libmysofa: 1.2.1 -> 1.3.1
* [`3356bbc3`](https://github.com/NixOS/nixpkgs/commit/3356bbc32a3fcba96337bd9fccda43aaafb04560) uboot: 2022.07 -> 2022.10
* [`86b0bec1`](https://github.com/NixOS/nixpkgs/commit/86b0bec1921f3a2a53018e90fb52423de91e37ac) weechat: 3.6 -> 3.7
* [`d3be9f90`](https://github.com/NixOS/nixpkgs/commit/d3be9f90a702105919a7cff02d11fccdd408422b) csview: 1.2.1 -> 1.2.2
* [`88c678ca`](https://github.com/NixOS/nixpkgs/commit/88c678cae81ce989c2c7d37cbeb0cc475cf97fc9) haskell.packages.ghc942.cabal2nix: mark as broken on aarch64-linux
* [`84e76a4d`](https://github.com/NixOS/nixpkgs/commit/84e76a4d356303b4bd029c0488de8ea983b97ade) python310Packages.yaspin: 2.1.0 -> 2.2.0
* [`9878eebb`](https://github.com/NixOS/nixpkgs/commit/9878eebbeadbcd4f6fc648d44787a14cde3066b5) nodePackages.pnpm: 7.13.2 -> 7.13.3
* [`71622903`](https://github.com/NixOS/nixpkgs/commit/7162290393e11245b2f42f6b14dd104cbb17748d) gnomeExtensions: auto-update
* [`012d718b`](https://github.com/NixOS/nixpkgs/commit/012d718bc18ef0f89225bad0238577ded0aa38ba) timedoctor: remove broken uninstallable package
* [`b60d756a`](https://github.com/NixOS/nixpkgs/commit/b60d756a713d80673b2a6f4716e94d040bb59870) yamlpath: 3.6.3 -> 3.6.7
* [`347df551`](https://github.com/NixOS/nixpkgs/commit/347df551d57534bb169bfbcbaafaf924d7e20c5c) python310Packages.pg8000: 1.29.1 -> 1.29.2
* [`bd9cdb02`](https://github.com/NixOS/nixpkgs/commit/bd9cdb02de6a4a409ada1bd40e5a09e7482bb7d0) patatt: 0.5.0 -> 0.6.2; adopt
* [`b3a4414d`](https://github.com/NixOS/nixpkgs/commit/b3a4414dd40e00768db5a093cd4a0e52ca6006d6) b4: 0.8.0 -> 0.10.1; adopt
* [`4ea1c745`](https://github.com/NixOS/nixpkgs/commit/4ea1c7450a4e14b390ef08f43dc2e64074a6b128) pods: switch to wrapGAppsHook4
* [`dc9f2500`](https://github.com/NixOS/nixpkgs/commit/dc9f25006f02f093587845b3e81674c5a975aa7e) python310Packages.jupyterlab: 3.4.7 -> 3.4.8
* [`681bc219`](https://github.com/NixOS/nixpkgs/commit/681bc21924acdec47a4ccd619719c54139583916) spot: switch to wrapGAppsHook4
* [`20e594d0`](https://github.com/NixOS/nixpkgs/commit/20e594d00505c561cddec4f08a849e6b43b86b9e) showmethekey: switch to wrapGAppsHook4
* [`9f723885`](https://github.com/NixOS/nixpkgs/commit/9f723885c698e9f82065a8b0e83a8b7ebf286318) iwgtk: switch to wrapGAppsHook4
* [`8f365ed1`](https://github.com/NixOS/nixpkgs/commit/8f365ed1da80c18c492fd0f586eb994b854bf543) czkawka: switch to wrapGAppsHook4
* [`4273a0c1`](https://github.com/NixOS/nixpkgs/commit/4273a0c10d784ebc25860cc18de1afd263ea894f) blanket: switch to wrapGAppsHook4
* [`02204ec8`](https://github.com/NixOS/nixpkgs/commit/02204ec825b36b2c9f7b4312dfe4da9175a85102) image-roll: switch to wrapGAppsHook4, fix typo
* [`d3237e3e`](https://github.com/NixOS/nixpkgs/commit/d3237e3e7467e7eef139a3632bc1d37a6e3a6e40) overcommit: 0.51.0 -> 0.59.1
* [`6ceaf4b1`](https://github.com/NixOS/nixpkgs/commit/6ceaf4b1152f2f9e46a2bf5743c73e83ee4d85ac) portfolio: 0.59.1 -> 0.59.2
* [`ddb0ac63`](https://github.com/NixOS/nixpkgs/commit/ddb0ac635709866853d4037367449ef61455ef62) overcommit: add anthonyroussel to maintainers
* [`a2688acf`](https://github.com/NixOS/nixpkgs/commit/a2688acfd5b993e252f293d8d72918d39c68f422) Revert "seahub: fix build"
* [`528fcc87`](https://github.com/NixOS/nixpkgs/commit/528fcc87626f1f6fa15fb5c8e8e097f33ebbea6e) armTrustedFirmware: Fix bintools 2.39 regression (LOAD segment with RWX)
* [`cea0c626`](https://github.com/NixOS/nixpkgs/commit/cea0c62688fba15ecbe4b94541e30c0773320e9b) weechat: add PHP support
* [`8985f7e6`](https://github.com/NixOS/nixpkgs/commit/8985f7e681ecfb048c7fdeeb4f7cfe1c5dd1be86) maintainers: add rrbutani
* [`a4dfb6cb`](https://github.com/NixOS/nixpkgs/commit/a4dfb6cb0b5943c36592b3aa6fb5872a118ba7f6) python310Packages.nbclassic: 0.4.3 -> 0.4.5
* [`1fbfdb6b`](https://github.com/NixOS/nixpkgs/commit/1fbfdb6bdfe8e0639e8874ee8d1144d08c1c9712) utm: init at 3.2.4
* [`2576bb2c`](https://github.com/NixOS/nixpkgs/commit/2576bb2c1831aa22f7dfaf8c5ca3aed5e1619995) p4: 2021.2.2201121 -> 2022.1.2305383, build from source
* [`453192aa`](https://github.com/NixOS/nixpkgs/commit/453192aa4ba3c76e3071531132417d45cf214485) p4d: add corngood to maintainers
* [`728bc745`](https://github.com/NixOS/nixpkgs/commit/728bc745abafdfc01b58200177c05e2240a998c9) aocd: 1.1.2 -> 1.1.3
* [`5457fdf2`](https://github.com/NixOS/nixpkgs/commit/5457fdf27380a821b2944f1ab1ccee1e20a07675) gitlab-runner: Install `clear-docker-cache` script
* [`fb9e7d16`](https://github.com/NixOS/nixpkgs/commit/fb9e7d16e2942414c35ccd4d4222997b56bef098) atlantis: 0.19.8 -> 0.20.1
* [`beba358f`](https://github.com/NixOS/nixpkgs/commit/beba358f942049dde9f41db2c5ced065cf81b280) cudatext: 1.172.0 -> 1.172.5
* [`8ab37281`](https://github.com/NixOS/nixpkgs/commit/8ab372812329670a886a775e1879708c0f55db75) ruff: 0.0.63 -> 0.0.65
* [`3556c180`](https://github.com/NixOS/nixpkgs/commit/3556c180757708247f9a4834093ff605adb38034) maintainers: add bigzilla
* [`98f55dff`](https://github.com/NixOS/nixpkgs/commit/98f55dff1a651ec59d434317c2b019c3e9f810a6) pritunl-client: init at 1.3.3300.95
* [`252d8c43`](https://github.com/NixOS/nixpkgs/commit/252d8c43cedba2e8f4846bee68d4c56b74d3f1d8) python310Packages.pylsp-mypy: 0.6.2 -> 0.6.3
* [`c9c28d62`](https://github.com/NixOS/nixpkgs/commit/c9c28d62bf23d616f27014f776282c70f5ec6b7a) python310Packages.pypdf2: 2.11.0 -> 2.11.1
* [`f8c5fbfb`](https://github.com/NixOS/nixpkgs/commit/f8c5fbfb54d59a86ec2b9b401ba50834b4ca1d24) flexget: 3.3.32 -> 3.3.33
* [`ec610610`](https://github.com/NixOS/nixpkgs/commit/ec6106104896e037ce213c40c479306e18290075) gh-dash: 3.4.1 -> 3.4.2
* [`7f4114fd`](https://github.com/NixOS/nixpkgs/commit/7f4114fd2edd6710d175db33a408dea6af3aea95) terraform-providers.fortios: 1.15.0 → 1.16.0
* [`3c22ee3f`](https://github.com/NixOS/nixpkgs/commit/3c22ee3fd0ad7e39544af76e6c34f6effb421244) terraform-providers.ksyun: 1.3.54 → 1.3.55
* [`a54bf008`](https://github.com/NixOS/nixpkgs/commit/a54bf00865f2f297b3b0157d8cbd1509e56c8d3d) terraform-providers.libvirt: 0.6.14 → 0.7.0
* [`ff111964`](https://github.com/NixOS/nixpkgs/commit/ff1119646e0de51824958c4882753acd2a93fc41) terraform-providers.acme: 2.10.0 -> 2.11.1
* [`83453bb2`](https://github.com/NixOS/nixpkgs/commit/83453bb2b4c5b2689ed1b51a685b22c804182348) python310Packages.pyswitchbot: 0.19.14 -> 0.19.15
* [`9dd7699a`](https://github.com/NixOS/nixpkgs/commit/9dd7699a050a3700b90eac3e6f7e6d9a78c74f04) kanboard: 1.2.23 -> 1.2.24
* [`0621cbf4`](https://github.com/NixOS/nixpkgs/commit/0621cbf4798b345531bd02a22a3fe73c30db632d) poetry2nix: 1.33.0 -> 1.34.1
* [`bbbda58c`](https://github.com/NixOS/nixpkgs/commit/bbbda58c4e99601935728cc568874897d98221c1) nixos/fwupd: Fix configuration file merging
* [`00a62633`](https://github.com/NixOS/nixpkgs/commit/00a62633db0819ebc0397a934d69bf57eb1a26c1) ungoogled-chromium: 106.0.5249.91 -> 106.0.5249.103
* [`e907371b`](https://github.com/NixOS/nixpkgs/commit/e907371b6199c5ef77364aea81a57989d0e1edd0) elfutils: move libmicrohttpd to 0.9.71
* [`4beb9675`](https://github.com/NixOS/nixpkgs/commit/4beb9675e32cde5ee323335c6404e4025ce70084) osmscout-server: move libmicrohttpd to 0.9.71
* [`342e2816`](https://github.com/NixOS/nixpkgs/commit/342e2816248ac4a96093d123dd3582373c8b1508) xmr-stak: switch libmicrohttpd to 0.9.71
* [`fe2d699e`](https://github.com/NixOS/nixpkgs/commit/fe2d699e41317beadb4b075f8d1bb40309fe1a0d) libmicrohttpd_0_9_69: init at 0.9.69
* [`a9cd1354`](https://github.com/NixOS/nixpkgs/commit/a9cd13546b0bfea319ce71f359a12710946b84a1) proxysql: switch libmicrohttpd from 0.9.70 to 0.9.69
* [`4902637c`](https://github.com/NixOS/nixpkgs/commit/4902637cc2c816e5746f09b01b62305302584be8) libmicrohttpd_0_9_70: mark as insecure
* [`32f16786`](https://github.com/NixOS/nixpkgs/commit/32f1678683e05e82b454ab3234c10bd01bf0ce6e) libmicrohttpd_0_9_70: drop
* [`12712055`](https://github.com/NixOS/nixpkgs/commit/127120551a5c75a84d30705ce7064ee6be871fff) mangal: 3.11.0 -> 3.12.0
* [`2230d0f4`](https://github.com/NixOS/nixpkgs/commit/2230d0f441af812b0e890964d4e57f7456cc0fc6) minio-client: 2022-10-06T01-20-06Z -> 2022-10-09T21-10-59Z
* [`e77f9f2f`](https://github.com/NixOS/nixpkgs/commit/e77f9f2f9b32c61a9493ef04154518394c8191b1) minio: 2022-10-05T14-58-27Z -> 2022-10-08T20-11-00Z
* [`4329682c`](https://github.com/NixOS/nixpkgs/commit/4329682cb697ea0ce5d0df6e520dcdb0cfd07786) ocamlPackages.x509: 0.16.0 → 0.16.2
* [`a152b034`](https://github.com/NixOS/nixpkgs/commit/a152b034a554cccf4f2949e6ee5e65eaa3ed4225) waydroid: 1.3.0 -> 1.3.3
* [`91d1eb9f`](https://github.com/NixOS/nixpkgs/commit/91d1eb9f2a9c4e3c9d68a59f6c0cada8c63d5340) jasmin-compiler: 2022.04.0 → 2022.09.0
* [`1a6c1c95`](https://github.com/NixOS/nixpkgs/commit/1a6c1c951ddda480f390eb20734cdc54e035c3c0) python310Packages.radish-bdd: 0.13.4 -> 0.14.0
* [`b2f0054d`](https://github.com/NixOS/nixpkgs/commit/b2f0054dd0a8644956b5cf27e132eb06d696237a) plib: patch for CVE-2021-38714
* [`e622de22`](https://github.com/NixOS/nixpkgs/commit/e622de224ea183380c4b13636b0182ab289074bd) eclair: 0.6.2 -> 0.7.0-patch-disconnect
* [`51397791`](https://github.com/NixOS/nixpkgs/commit/513977914734deac7ebf8695b0a7c9d4c674f21a) system76-power: 1.1.20 -> 1.1.23
* [`f0957986`](https://github.com/NixOS/nixpkgs/commit/f095798678e0fdfc00d374fe675e944de5023d49) onionshare: 2.5 -> 2.6
* [`b01d7c80`](https://github.com/NixOS/nixpkgs/commit/b01d7c80a0f3639d87801dd5619b512222717a08) matrix-conduit: don't use pkgs directly
* [`ad0537ab`](https://github.com/NixOS/nixpkgs/commit/ad0537ab1f03d32783feb7d6f2d5906e12efa9fa) cbqn: pass adjusted linker flags for darwin
* [`0e5f7501`](https://github.com/NixOS/nixpkgs/commit/0e5f7501b613b09e2f22db4a1609470fa5bdab81) cbqn: always compile using clang
* [`1407d621`](https://github.com/NixOS/nixpkgs/commit/1407d6211e863123708e29f0a6775a826e189728) metals: 0.11.8 -> 0.11.9
* [`d74b3668`](https://github.com/NixOS/nixpkgs/commit/d74b3668e7bf0eb2e765fdfcb6665b6d4b751edf) lnd: 0.15.1-beta -> 0.15.2-beta
* [`eac905ea`](https://github.com/NixOS/nixpkgs/commit/eac905ea816316be2a3e418ee2667aef16f26e88) dbeaver: 22.2.0 -> 22.2.2
* [`f3ef5751`](https://github.com/NixOS/nixpkgs/commit/f3ef575175292b774369fce964ff09801eca34b6) lorri: 1.5.0 -> 1.6.0
* [`1c5a8bfa`](https://github.com/NixOS/nixpkgs/commit/1c5a8bfa7d383791ddfe7b26e0b62e5b791023a8) python310Packages.sphinxcontrib-spelling: 7.6.0 -> 7.6.1
* [`e0d476da`](https://github.com/NixOS/nixpkgs/commit/e0d476da339bf13eec41bdd468587a3964f3342a) symfony-cli: 5.4.14 -> 5.4.15
* [`9bccf6da`](https://github.com/NixOS/nixpkgs/commit/9bccf6da14884e6d511d578cc9bf77d1d046bd95) swapspace: 1.17 -> 1.18
* [`2c335c73`](https://github.com/NixOS/nixpkgs/commit/2c335c73e361b839876ab72c0495c4573783c810) mycli: 1.25.0 -> 1.26.1
* [`d2ac2cda`](https://github.com/NixOS/nixpkgs/commit/d2ac2cda661bc2d66f4434448ba2710c3118ace2) pipenv: 2022.9.8 -> 2022.10.9
* [`151b6a4d`](https://github.com/NixOS/nixpkgs/commit/151b6a4daf39e2ffe7784face07b6919de2d733a) mill: 0.10.7 -> 0.10.8
* [`282ac912`](https://github.com/NixOS/nixpkgs/commit/282ac9121fbd772ff461d16bc57ccdb8e8db8d84) python310Packages.transmission-rpc: 3.3.2 -> 3.4.0
* [`f859f274`](https://github.com/NixOS/nixpkgs/commit/f859f274b18f4434050efcf043a9e5c009105790) python310Packages.typed-settings: 1.1.0 -> 1.1.1
* [`8f2f7c10`](https://github.com/NixOS/nixpkgs/commit/8f2f7c1097258ee2ed91a85c33a40ad4963ae6c8) tilt: 0.30.8 -> 0.30.9
* [`f0f5aa60`](https://github.com/NixOS/nixpkgs/commit/f0f5aa601e99c9415c57ce67ca5e3351d0e38d3c) tanka: Update ldflags
* [`852bf558`](https://github.com/NixOS/nixpkgs/commit/852bf558eb909143aacb7d40262746468be4a3d7) fend: install man page
* [`2182ed70`](https://github.com/NixOS/nixpkgs/commit/2182ed7064699d395f07177295ba835eb672750f) rust-analyzer-unwrapped: 2022-10-03 -> 2022-10-10
* [`b0b4b047`](https://github.com/NixOS/nixpkgs/commit/b0b4b047ae6eb03f907ca705db02559953c467b7) python310Packages.wallbox: 0.4.9 -> 0.4.10
* [`165b20ea`](https://github.com/NixOS/nixpkgs/commit/165b20eafab7f8170fdfb9456ac7b4959a566683) genact: 1.2.0 -> 1.2.2
* [`6e4a14b5`](https://github.com/NixOS/nixpkgs/commit/6e4a14b54f3f62e078f999bf746ebfa2020890f8) writers: add writeFish and writeFishBin
* [`1a2d832e`](https://github.com/NixOS/nixpkgs/commit/1a2d832e3f3514341cbc25226d6fe0197fd617d5) mlterm: use apple_sdk_11
* [`77a0f1af`](https://github.com/NixOS/nixpkgs/commit/77a0f1af20097f831f3f47ecb78476351406e4a3) freefilesync: 11.25 -> 11.26
* [`cd6bdcb4`](https://github.com/NixOS/nixpkgs/commit/cd6bdcb4cae9b0d846eeec3d5fda8154851cc972) bloop: 1.5.3 -> 1.5.4 ([nixos/nixpkgs⁠#195349](https://togithub.com/nixos/nixpkgs/issues/195349))
* [`ab305c56`](https://github.com/NixOS/nixpkgs/commit/ab305c56e2e3f51c8abd221e0b8adda42665aa60) eclipses: 2022-06 -> 2022-09
* [`67246fbf`](https://github.com/NixOS/nixpkgs/commit/67246fbffa8eef29eec444ad73e3963fde6e0f12) nixos/ssh: pass WAYLAND_DISPLAY to ssh-askpass
* [`d8648e49`](https://github.com/NixOS/nixpkgs/commit/d8648e4924017891c3a01906a4c6db4f618ad103) swaywsr: 1.1.0 -> 1.1.1
* [`8a4c3732`](https://github.com/NixOS/nixpkgs/commit/8a4c3732163f847455b3e6940f24cabe361829e4) Revert "parlatype: remove"
* [`1d6b5d36`](https://github.com/NixOS/nixpkgs/commit/1d6b5d368e9efdefceeecd93a73d965bf0edf61c) Added BattleCh1cken to the maintainer list.
* [`81738843`](https://github.com/NixOS/nixpkgs/commit/81738843e9511ef7609a46496ea8b07cacde1107) parlatype: disable pocketsphinx integration
* [`0aa7db60`](https://github.com/NixOS/nixpkgs/commit/0aa7db6030704cfef15de8e3fd90bfe26b01793c) parlatype: 2.1 -> 3.1
* [`4e1ffaca`](https://github.com/NixOS/nixpkgs/commit/4e1ffaca0158f91704114fbb4543161bff45f624) nixos/neovim: add note about not loading init.vim
* [`352bcbb3`](https://github.com/NixOS/nixpkgs/commit/352bcbb3b15f6206753c10fdb1e1715e9ad1a2e1) n8n: 0.194.0 → 0.197.1
* [`ce3d0adb`](https://github.com/NixOS/nixpkgs/commit/ce3d0adbd7d8b43836d7fd0d761d2f19f2303e57) nodePackages.eas-cli: init at 2.3.0
* [`d5264e6c`](https://github.com/NixOS/nixpkgs/commit/d5264e6c8dc40be11b1031e38a804ce330fd7bac) python310Packages.meshtastic: 1.3.37 -> 1.3.39
* [`fea031c3`](https://github.com/NixOS/nixpkgs/commit/fea031c3e8c1c3f9e2b2dc057f4d1949a9f7ae05) python310Packages.pysnmplib: 5.0.18 -> 5.0.19
* [`732633fd`](https://github.com/NixOS/nixpkgs/commit/732633fdff202425e644559bd4b70a76bfd451e9) python310Packages.transmission-rpc: enable tests
* [`b5ef8c03`](https://github.com/NixOS/nixpkgs/commit/b5ef8c035e72d0d1676c1a177028b180b33b74ec) python310Packages.radish-bdd: add pythonImportsCheck
* [`c8eae7a5`](https://github.com/NixOS/nixpkgs/commit/c8eae7a5261a0d2ceaf0ad8a8b08050ec5bf40f2) nixos/gitlab-runner: Add `gitlab-runner.clear-docker-cache` service
* [`a145fcca`](https://github.com/NixOS/nixpkgs/commit/a145fccac4d004e8398e01dcb35b509a6876a1cf) ruff: 0.0.65 -> 0.0.67
* [`ba3ead48`](https://github.com/NixOS/nixpkgs/commit/ba3ead48e0a83bff0a6aba213f9ece8fc6d50cb4) gf: unstable-2022-08-01 -> unstable-2022-09-26
* [`3f2a81f1`](https://github.com/NixOS/nixpkgs/commit/3f2a81f1ba8fc6f6ea2a864528493bade28438d0) fheroes2: 0.9.19 -> 0.9.20
* [`dee4fee1`](https://github.com/NixOS/nixpkgs/commit/dee4fee1c7beeeaea4a27a3c88bf5cf0eed761ff) rocm-smi: 5.2.3 → 5.3.0
* [`3bdbc120`](https://github.com/NixOS/nixpkgs/commit/3bdbc120f80f25bdf5b808efc9c13c02eac0c97a) rocm-cmake: 5.2.0 → 5.3.0
* [`421b8086`](https://github.com/NixOS/nixpkgs/commit/421b8086f0cc09778fb11d5d873eb17b5aedd240) rocm-thunk: 5.2.1 → 5.3.0
* [`79ef038e`](https://github.com/NixOS/nixpkgs/commit/79ef038e49d4dfe806bd3f20395cbe42dc48ccba) rocm-runtime: 5.2.0 → 5.3.0
* [`8ec49a85`](https://github.com/NixOS/nixpkgs/commit/8ec49a85c560892f324da9265b7459da0636f772) rocm-opencl-runtime: 5.2.1 → 5.3.0
* [`1d6f9948`](https://github.com/NixOS/nixpkgs/commit/1d6f9948cb24ee92fdc43798179be21454179874) rocm-device-libs: 5.2.0 → 5.3.0
* [`6bd35937`](https://github.com/NixOS/nixpkgs/commit/6bd359374957bae5df7ba8c4da83995b1fcfa3d4) rocm-comgr: 5.2.0 → 5.3.0
* [`692bc4c5`](https://github.com/NixOS/nixpkgs/commit/692bc4c5496219bf96ec275d5fb71f731661f213) rocclr: 5.2.3 → 5.3.0
* [`4ee2665a`](https://github.com/NixOS/nixpkgs/commit/4ee2665a6d9d7a04004054562abdfe4604aa8d17) rocminfo: 5.1.1 → 5.3.0
* [`72aaaa78`](https://github.com/NixOS/nixpkgs/commit/72aaaa782ab3e1950b4c9e80afb7c0f9e9f19b73) llvmPackages_rocm.llvm: 5.2.3 → 5.3.0
* [`01819dae`](https://github.com/NixOS/nixpkgs/commit/01819daec129639a040e86804af87842bdf734ca) hip: 5.2.3 → 5.3.0
* [`0f57e757`](https://github.com/NixOS/nixpkgs/commit/0f57e757f62a68206d67eef451ec2d5a930c2280) git-machete: 3.12.0 -> 3.12.4
* [`5f20362a`](https://github.com/NixOS/nixpkgs/commit/5f20362a4ab5caab81abad55b485056d316bca06) nixos/tests: Use kea in networkd prefix-delegation test
* [`c915c462`](https://github.com/NixOS/nixpkgs/commit/c915c462d88e17547af1bdcb8595a4cf89e5e88c) kea: Add the networkd prefix-delegation test to passthru
* [`94ec74b3`](https://github.com/NixOS/nixpkgs/commit/94ec74b398068c3a85ffede422e52c838f074ad8) vimPlugins: update
* [`14adbf88`](https://github.com/NixOS/nixpkgs/commit/14adbf88f9137e19ade8ddb196420108b2f38922) vimPlugins.hydra-nvim: init at 2022-10-02
* [`6b7c0d59`](https://github.com/NixOS/nixpkgs/commit/6b7c0d59c0ee1a8d617e24b993142d0d705afd12) alerta-server: propagate cryptography
* [`420363e3`](https://github.com/NixOS/nixpkgs/commit/420363e3ce35ad5c1ae19e3d46e88f3265ed840b) chromium: 106.0.5249.91 -> 106.0.5249.103
* [`979047f7`](https://github.com/NixOS/nixpkgs/commit/979047f73232b1066c4f3bea69831a4e314d954f) chromiumBeta: 107.0.5304.18 -> 107.0.5304.29
* [`6ea106f4`](https://github.com/NixOS/nixpkgs/commit/6ea106f4d83a5545638c00ff1cdb7b5daf6b8297) chromiumDev: 108.0.5327.0 -> 108.0.5343.2
* [`7cc67d5e`](https://github.com/NixOS/nixpkgs/commit/7cc67d5e6b6c860f2e6b33ab5063f92cafe6a063) spatialite_gui: Fix build by adding xz
* [`fd41bc31`](https://github.com/NixOS/nixpkgs/commit/fd41bc31b8cf83f14e015ef490a89ade5e91d405) parsec-bin: init at 150_28
* [`a5b2107a`](https://github.com/NixOS/nixpkgs/commit/a5b2107a233b9888372d33602fc5e7bfcfc87e0a) talosctl: 1.2.3 -> 1.2.4
* [`0f2b83ce`](https://github.com/NixOS/nixpkgs/commit/0f2b83ce4d52f30f3ddae770406554c231db69eb) ruff: 0.0.67 -> 0.0.68
* [`2ce78bd5`](https://github.com/NixOS/nixpkgs/commit/2ce78bd571a7985f40024af2d4ac2aa407c3e383) gatk: add java and python to PATH
* [`c365b0d4`](https://github.com/NixOS/nixpkgs/commit/c365b0d47b530827ba829ca140d8ecc36f0ff78a) guestfs-tools: use libguestfs-with-appliance
* [`fd7f6be0`](https://github.com/NixOS/nixpkgs/commit/fd7f6be003960f6c0b624cd553d6802a0df716da) guestfs-tools: patch less shebangs
* [`960cc8f3`](https://github.com/NixOS/nixpkgs/commit/960cc8f3f1b4a71ca67d8a8d55ba6f0c9058ab8c) guestfs-tools: install bash-completion scripts
* [`4886f37b`](https://github.com/NixOS/nixpkgs/commit/4886f37b9710c77cb9c988799f7eddbde5afb25e) guestfs-tools: add optional dependency openssl
* [`bb49ddeb`](https://github.com/NixOS/nixpkgs/commit/bb49ddebc9d706d122a63fb16b5f6867feb11570) pkgsMusl.vte: fix build ([nixos/nixpkgs⁠#193930](https://togithub.com/nixos/nixpkgs/issues/193930))
* [`0495b021`](https://github.com/NixOS/nixpkgs/commit/0495b0217b539a41f343c61f78511d133424d872) writers.writeFish: avoid loading user config files
* [`6259f1f4`](https://github.com/NixOS/nixpkgs/commit/6259f1f47f693dff7b4f2484f0c15f0189181c2f) tandoor-recipes: 1.4.1 -> 1.4.4
* [`01faaeb4`](https://github.com/NixOS/nixpkgs/commit/01faaeb4bdb9e7952093f3699f2f4b1b36a811cd) nixos/gitolite: add 'description' module option
* [`2af32dd4`](https://github.com/NixOS/nixpkgs/commit/2af32dd4820ae062104d47c0c745b455ac8317dc) clusterctl: 1.2.2 -> 1.2.3
* [`0ffd51df`](https://github.com/NixOS/nixpkgs/commit/0ffd51df20117c9fb85d8709f04b706bf153feb5) smart-wallpaper: Add missing 'redshift' dependency
* [`1a62113d`](https://github.com/NixOS/nixpkgs/commit/1a62113dd9b25fd278e473f3de0a6cd2c2f8de6c) toxprpl: mark broken, unmantained and doesn't build
* [`93ea7dd8`](https://github.com/NixOS/nixpkgs/commit/93ea7dd8f9752f68d8bf34b0cf0ecf1f447200e1) libtoxcore_0_1: remove
* [`4fd6adc3`](https://github.com/NixOS/nixpkgs/commit/4fd6adc34b13def2d4a80aa25e53b8fc28f686c7) libtoxcore: 0.2.17 -> 0.2.18
* [`5314192d`](https://github.com/NixOS/nixpkgs/commit/5314192d1bece042e758d45e32eb79bb686b85f2) toxic: 0.11.1 -> 0.11.3
* [`34741445`](https://github.com/NixOS/nixpkgs/commit/347414457166d7e28c5b5dd6fd309a191a4685a3) firecracker: 1.1.1 -> 1.1.2
* [`3fe097dc`](https://github.com/NixOS/nixpkgs/commit/3fe097dced49de2273e5e2a5cd37d6d43cdec905) flyctl: 0.0.406 -> 0.0.407
* [`b96de6c2`](https://github.com/NixOS/nixpkgs/commit/b96de6c275ede7bcc74ea1101ca6ba6ecf8deddf) infracost: mark broken on x86_64
* [`38ad005d`](https://github.com/NixOS/nixpkgs/commit/38ad005da6e6a1aec5072a045222ccab828f2b34) brev-cli: pin to go 1.18
* [`35263612`](https://github.com/NixOS/nixpkgs/commit/352636126b005430314d9486be574d36b2863102) cue: pin to go 1.18
* [`aa8e4b78`](https://github.com/NixOS/nixpkgs/commit/aa8e4b78d3fb2b16f9cc0c905de016d9e6e1f70a) doggo: pin to go 1.18
* [`c38edb84`](https://github.com/NixOS/nixpkgs/commit/c38edb843b1a42d6b5889f06330ead9f76f3f15f) ipget: pin to go 1.18
* [`18e70667`](https://github.com/NixOS/nixpkgs/commit/18e70667703536f060ab2e48f0ea5bb45ec22b77) podman: pin to go 1.18
* [`d53de6f8`](https://github.com/NixOS/nixpkgs/commit/d53de6f8d541dc4fa316780bdabfbf73cb4ba339) ivy: pin to go 1.18
* [`eb307f80`](https://github.com/NixOS/nixpkgs/commit/eb307f8075032a78d0d6b3f0a0cb255e089209c1) grafana-agent: pin to go 1.18
* [`5a8dcde9`](https://github.com/NixOS/nixpkgs/commit/5a8dcde91a7298220615e3cf69606bc75ccc1a16) norouter: pin to go 1.18
* [`c8412d00`](https://github.com/NixOS/nixpkgs/commit/c8412d00f175ca87e4eeb8d54dcbc43bc5fc50b2) zrepl: pin to go 1.18
* [`5c438706`](https://github.com/NixOS/nixpkgs/commit/5c43870684a38969243af016189d766dda77af98) kube3d: pin to go 1.18
* [`157a2144`](https://github.com/NixOS/nixpkgs/commit/157a2144d06dd64f80c4f1087ebfc0677f76d420) routedns: pin to go 1.18
* [`b011bb05`](https://github.com/NixOS/nixpkgs/commit/b011bb05615cc34db8ab76fe01429db7ae7fcc6e) stripe-cli: pin to go 1.18
* [`15971fd5`](https://github.com/NixOS/nixpkgs/commit/15971fd54a842a639f3ee90d1b9147cbac53c7e5) tracee: pin to go 1.18
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
