### PR TITLE
niv emacs-overlay: update e6c5abf9 -> d5dbc29a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e6c5abf9ff42495cd8a3845fc32a17baa7c54790",
-        "sha256": "0y72j9gn8psgdm3py39c5ap08f5mkga7pjxcy2xq7n7hw96m9q62",
+        "rev": "d5dbc29af6033b0c9ea25c5382a15612c527ae96",
+        "sha256": "0kymrncgv9ac5na0xhj8jyd9xg45crsx0ps3f16fxx2s8b7js6j2",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/e6c5abf9ff42495cd8a3845fc32a17baa7c54790.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/d5dbc29af6033b0c9ea25c5382a15612c527ae96.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@e6c5abf9...d5dbc29a](https://github.com/nix-community/emacs-overlay/compare/e6c5abf9ff42495cd8a3845fc32a17baa7c54790...d5dbc29af6033b0c9ea25c5382a15612c527ae96)

* [`88c3ea32`](https://github.com/nix-community/emacs-overlay/commit/88c3ea32e2546d958381893020738c2f06d8ed99) Updated repos/emacs
* [`d0455895`](https://github.com/nix-community/emacs-overlay/commit/d04558957e2bef64780144486becbdc1c731fe7f) Updated repos/melpa
* [`55bed8e9`](https://github.com/nix-community/emacs-overlay/commit/55bed8e9255fd9b7cf99c2034dc1eb83548441b4) Updated repos/emacs
* [`f5dd8b46`](https://github.com/nix-community/emacs-overlay/commit/f5dd8b46c50a2d22c450c9628b955f970412cc8c) Updated repos/melpa
* [`14a9ff2c`](https://github.com/nix-community/emacs-overlay/commit/14a9ff2c6201158d6d42c988a47be702a70b89b9) Updated repos/elpa
* [`6d94980f`](https://github.com/nix-community/emacs-overlay/commit/6d94980f8974d7b774309364c6cc13da6f9a0ce6) Updated repos/emacs
* [`b1fcd0a5`](https://github.com/nix-community/emacs-overlay/commit/b1fcd0a5edc39918762441fa7ccf3be24d663336) Updated repos/melpa
* [`77b97dd6`](https://github.com/nix-community/emacs-overlay/commit/77b97dd68027a01b0743581f27d4258c48de33ed) Updated repos/emacs
* [`49c3f4e5`](https://github.com/nix-community/emacs-overlay/commit/49c3f4e5a1166390248436d493739d7e6ba83fde) Updated repos/melpa
* [`63e405c4`](https://github.com/nix-community/emacs-overlay/commit/63e405c4207a8ff3d3739e3a0f6f7ff7e8b37844) Updated repos/nongnu
* [`eb891529`](https://github.com/nix-community/emacs-overlay/commit/eb891529a8944d9d40928ea3d16d725c444859d1) Updated repos/elpa
* [`2142ce37`](https://github.com/nix-community/emacs-overlay/commit/2142ce3789d2ac230a225eb078d3bf2f85046532) Add `feature/tree-sitter` derivation to emacs overlay
* [`f55075f7`](https://github.com/nix-community/emacs-overlay/commit/f55075f7fb607310aa7d487099a5d001c2b221d4) Updated repos/emacs
* [`a828f7f2`](https://github.com/nix-community/emacs-overlay/commit/a828f7f2ea3f79110b26ea40763326cd788e43e3) Make `withTreeSitterPlugins` overridable.
* [`977b205a`](https://github.com/nix-community/emacs-overlay/commit/977b205ab9ce857f3440dff2a114a35bf2758c05) Updated repos/melpa
* [`fdd2f0c3`](https://github.com/nix-community/emacs-overlay/commit/fdd2f0c3e0a22e02b2d772d8266855520f072c24) Updated repos/elpa
* [`35ee7772`](https://github.com/nix-community/emacs-overlay/commit/35ee7772e536b39b1bc42127e089220daf01c992) Updated repos/emacs
* [`3da50fda`](https://github.com/nix-community/emacs-overlay/commit/3da50fdaa0d507be27d3483fc89aa40a8f830b9c) Updated repos/melpa
* [`388aac78`](https://github.com/nix-community/emacs-overlay/commit/388aac7847e619fc8fbe3cb69c70d23406238fa3) Updated repos/nongnu
* [`89e9a718`](https://github.com/nix-community/emacs-overlay/commit/89e9a718918fdc327c785b2c1ab05d688e93c2b3) Updated repos/emacs
* [`6814c3b7`](https://github.com/nix-community/emacs-overlay/commit/6814c3b76972c3c0c5535f089e3ebe6d894543b6) Updated repos/melpa
* [`dddc3dcd`](https://github.com/nix-community/emacs-overlay/commit/dddc3dcd012a749ea7d86623d93db2ae99213aff) Updated repos/nongnu
* [`72bd545c`](https://github.com/nix-community/emacs-overlay/commit/72bd545cc40827ea7a409dd859dc07750459e54d) Updated repos/emacs
* [`a84e4909`](https://github.com/nix-community/emacs-overlay/commit/a84e49092938264218cf67549619084a269e9129) Updated repos/melpa
* [`bb8e0002`](https://github.com/nix-community/emacs-overlay/commit/bb8e0002116c4a09092e34e743b04d65c65c30eb) Updated repos/elpa
* [`1a3881c4`](https://github.com/nix-community/emacs-overlay/commit/1a3881c44752cddd06ddc5b9353ef9263f3184e6) Updated repos/emacs
* [`28e2a597`](https://github.com/nix-community/emacs-overlay/commit/28e2a59713f822679a174720ad3fe70554ab0457) Updated repos/melpa
* [`17508435`](https://github.com/nix-community/emacs-overlay/commit/175084356587427b7ae06f8edab8219d3a9aa8b1) Updated repos/emacs
* [`c2b0e0cf`](https://github.com/nix-community/emacs-overlay/commit/c2b0e0cfa4c9cdb7ed96e3fb984f5ce92eb9e4e7) Updated repos/melpa
* [`caf856bd`](https://github.com/nix-community/emacs-overlay/commit/caf856bd53157cdd6cc6949ff7720927e88bdc0a) Updated repos/elpa
* [`86e60523`](https://github.com/nix-community/emacs-overlay/commit/86e60523105c9bb8ea70f271c87ad28f19dfbdb9) flake.nix: fix the hack of getting overlayAttrs
* [`fd9d1779`](https://github.com/nix-community/emacs-overlay/commit/fd9d1779bb1ce35e362857987faa0f0a132ee6a6) Updated repos/emacs
* [`472a238c`](https://github.com/nix-community/emacs-overlay/commit/472a238cc3c0074bf056857c002bfa2f0eb8b0b5) Updated repos/melpa
* [`3e7e2969`](https://github.com/nix-community/emacs-overlay/commit/3e7e2969ba3934644ad40074c93758d356b43b7f) Updated repos/emacs
* [`05484486`](https://github.com/nix-community/emacs-overlay/commit/054844861c327a4e4f5f16022b9218ecdf1aefe1) Updated repos/melpa
* [`4fd0bbbe`](https://github.com/nix-community/emacs-overlay/commit/4fd0bbbedf9f1e559870fb35fe53f358b195024a) elisp.nix: add a param to include user config as a default init file
* [`57ee1eaa`](https://github.com/nix-community/emacs-overlay/commit/57ee1eaab60a67b0ed80f787fe3caa3959eb69d5) README: add doc for defaultInitFile
* [`68323cbc`](https://github.com/nix-community/emacs-overlay/commit/68323cbc9866e5309de80febda1436a487e2bd6a) Updated repos/emacs
* [`36f1317b`](https://github.com/nix-community/emacs-overlay/commit/36f1317b2690f89889676f3ca6cfdd78a4fe173b) Updated repos/melpa
* [`4cec379c`](https://github.com/nix-community/emacs-overlay/commit/4cec379c853658bc1eab0344b1e525e1ab3acc73) Updated repos/nongnu
* [`981cb38e`](https://github.com/nix-community/emacs-overlay/commit/981cb38ebeb25e542f0c4b17adce8adfa001c19e) Updated repos/emacs
* [`dc4c0a71`](https://github.com/nix-community/emacs-overlay/commit/dc4c0a71631588eaf6fe917e677f0f5a530c0b6f) Updated repos/melpa
* [`bcd60c7e`](https://github.com/nix-community/emacs-overlay/commit/bcd60c7ed335f46570d9c9a9f6695c6ebf13ef1b) Updated repos/nongnu
* [`9471e5ac`](https://github.com/nix-community/emacs-overlay/commit/9471e5ac1d2172ed5463f6b5f30d8c3b760e16f3) Updated repos/emacs
* [`33ce8dab`](https://github.com/nix-community/emacs-overlay/commit/33ce8dabfd3dc4968bae24126766e60d67b39dbb) Updated repos/melpa
* [`45471f48`](https://github.com/nix-community/emacs-overlay/commit/45471f48c9001b70f4a4e2918d79507245496622) Updated repos/elpa
* [`fd2d832e`](https://github.com/nix-community/emacs-overlay/commit/fd2d832ec5a43a7565cc41cbf0edab4d0435a442) Updated repos/emacs
* [`7627a31c`](https://github.com/nix-community/emacs-overlay/commit/7627a31cb49b9dfafe0ecf21ac2734374730d06a) Updated repos/melpa
* [`938cc191`](https://github.com/nix-community/emacs-overlay/commit/938cc191ca312d42ff35da5fd7705dc229ff3a2d) Updated repos/elpa
* [`38c79c10`](https://github.com/nix-community/emacs-overlay/commit/38c79c1083f8955fc7d99ad4483f79e3423e4538) Updated repos/emacs
* [`d5848dc2`](https://github.com/nix-community/emacs-overlay/commit/d5848dc28fb89d25f5cd7ae9c573aedff6a0eefa) Updated repos/melpa
* [`154e5cd6`](https://github.com/nix-community/emacs-overlay/commit/154e5cd6920f804827f3161007ea2a2541336e30) Updated repos/nongnu
* [`c1143602`](https://github.com/nix-community/emacs-overlay/commit/c1143602cb97fa717bacdf5668ceca1bb487918d) address comments
* [`bcc88357`](https://github.com/nix-community/emacs-overlay/commit/bcc8835700e1d7ab948b74278fa52e8c646127f5) Updated repos/emacs
* [`c41ae1b1`](https://github.com/nix-community/emacs-overlay/commit/c41ae1b159b945e303e590ae5dde25b9e5d0f718) Updated repos/melpa
* [`f8d2c22b`](https://github.com/nix-community/emacs-overlay/commit/f8d2c22b0714629bb7f8e90071b12fa56cd620be) Updated repos/nongnu
* [`be190d94`](https://github.com/nix-community/emacs-overlay/commit/be190d94084695bec96a1a238b5f79ab9e6a55df) Updated repos/emacs
* [`80f4cebe`](https://github.com/nix-community/emacs-overlay/commit/80f4cebe57d8c6e7153f8837ce262bc6576a9498) Updated repos/melpa
* [`52d45a4f`](https://github.com/nix-community/emacs-overlay/commit/52d45a4f4a90334095409d4f0f6cd7e5ff5100f3) Updated repos/elpa
* [`43e724fa`](https://github.com/nix-community/emacs-overlay/commit/43e724face73cfad63ca68220fed5f61a070fd2d) Updated repos/emacs
* [`f5ef8526`](https://github.com/nix-community/emacs-overlay/commit/f5ef8526cef8d7ab6da729883f14623f55b42811) Updated repos/melpa
* [`d5dbc29a`](https://github.com/nix-community/emacs-overlay/commit/d5dbc29af6033b0c9ea25c5382a15612c527ae96) Updated repos/nongnu
