### PR TITLE
niv niv: update 82e5cd1a -> 351d8bc3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
-        "sha256": "090l219mzc0gi33i3psgph6s2pwsc8qy4lyrqjdj4qzkvmaj65a7",
+        "rev": "351d8bc316bf901a81885bab5f52687ec8ccab6e",
+        "sha256": "1yzhz7ihkh6p2sxhp3amqfbmm2yqzaadqqii1xijymvl8alw5rrr",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/351d8bc316bf901a81885bab5f52687ec8ccab6e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@82e5cd1a...351d8bc3](https://github.com/nmattia/niv/compare/82e5cd1ad3c387863f0545d7591512e76ab0fc41...351d8bc316bf901a81885bab5f52687ec8ccab6e)

* [`acdb1726`](https://github.com/nmattia/niv/commit/acdb1726783637852c01e0ad639ac9cbec28d8c8) Fix GH rate-limiting link
* [`351d8bc3`](https://github.com/nmattia/niv/commit/351d8bc316bf901a81885bab5f52687ec8ccab6e) Update workflows
