### PR TITLE
niv nixpkgs: update 44f236e3 -> f157bef0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44f236e33f44e986d3c0073afabbc9a1bf63fe2b",
-        "sha256": "0c3vhx2a88grakr3l54hk7gkx7w87pq9jhcsfywijhpv88mss9yb",
+        "rev": "f157bef02b0902079561a02a2559e89ccb13236b",
+        "sha256": "1a1vkcnwkp84bcq8wi6slzxk1v6gwl1dzhawz55n2rl7k4jml871",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/44f236e33f44e986d3c0073afabbc9a1bf63fe2b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f157bef02b0902079561a02a2559e89ccb13236b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@44f236e3...f157bef0](https://github.com/nixos/nixpkgs/compare/44f236e33f44e986d3c0073afabbc9a1bf63fe2b...f157bef02b0902079561a02a2559e89ccb13236b)

* [`1e120264`](https://github.com/NixOS/nixpkgs/commit/1e12026447c3c3272ee19d8bb8fb8dcaf75c4e8a) libreoffice: fix [nixos/nixpkgs⁠#152506](https://togithub.com/nixos/nixpkgs/issues/152506) - add explicit dependencies on grep and coreutils to wrapper
* [`30dbdffc`](https://github.com/NixOS/nixpkgs/commit/30dbdffcb51730949cb03cb483fac32163658861) maintainers/scripts/update.nix: Fix deduplication for unstableGitUpdater
* [`97ed34ec`](https://github.com/NixOS/nixpkgs/commit/97ed34ec68f08f4bf28b703e28636d07017ff4e1) libopensmtpd: init at 0.7
* [`f58f0e6b`](https://github.com/NixOS/nixpkgs/commit/f58f0e6b9f98dcae8747c336bcc68c31401eedda) opensmtpd-filter-dkimsign: init at 0.6
* [`dabac4bf`](https://github.com/NixOS/nixpkgs/commit/dabac4bf0c5eefbb07402189d9ba6efce3ff7b34) doc: Document that the staging branches may be restricted
* [`a227563e`](https://github.com/NixOS/nixpkgs/commit/a227563e713edbfc67aef6861c019c29be52bb57) libcerf: 2.0 -> 2.1
* [`ac66a6c2`](https://github.com/NixOS/nixpkgs/commit/ac66a6c23a70a089a3182c7fb519277e1fdd67d6) vk-bootstrap: init at 0.5
* [`20c0b77e`](https://github.com/NixOS/nixpkgs/commit/20c0b77e25c7649edcb11566d613a21602fa88b3) Update pkgs/development/libraries/vk-bootstrap/default.nix
* [`71b05ecc`](https://github.com/NixOS/nixpkgs/commit/71b05eccaaf4dad1f01b13832cb0d692b8e1e761) darwin.cctools: 949.0.1 -> 973.0.1
* [`aa148311`](https://github.com/NixOS/nixpkgs/commit/aa1483114bb329fee7e1266100b8d8921ed4723f) postgresql_10: remove ahead of 22.11 release, because it will go EOL 2022-11-10
* [`817ca369`](https://github.com/NixOS/nixpkgs/commit/817ca3699e94419f8050ef863c023b346103e2cf) treewide: change postgresql_10 in documentation and examples to postgresql_14
* [`e8487786`](https://github.com/NixOS/nixpkgs/commit/e848778692fea8c3bf5bd1f94ee734a13f75b481) guile-config: init at 0.5.1
* [`5dcfe728`](https://github.com/NixOS/nixpkgs/commit/5dcfe728a71e02ce537608604b521d0d3c7a2430) guile-hall: init at 0.4.1
* [`fb91bfc3`](https://github.com/NixOS/nixpkgs/commit/fb91bfc380dfe36ceb07960abeeae8f934c2c986) compiler-rt: build builtins on darwin
* [`96e4a0f0`](https://github.com/NixOS/nixpkgs/commit/96e4a0f05c413f98664349ef94d1391d0b4a0176) libcxxabi: remove link with build libcxxabi
* [`afc9b9a5`](https://github.com/NixOS/nixpkgs/commit/afc9b9a51f76e844b697a73645ee2fadfef4c6b5) vscode-extensions.james-yu.latex-workshop: 8.28.0 -> 8.29.0
* [`37423f5a`](https://github.com/NixOS/nixpkgs/commit/37423f5a4e7beedd32c4c0c9d53131fea51a621e) mc: help with discoverability
* [`7d731f3b`](https://github.com/NixOS/nixpkgs/commit/7d731f3bcab13192bde0cd43a68a3a96d9e17a93) nixos/nspawn: Remove not compliant options
* [`57b727fb`](https://github.com/NixOS/nixpkgs/commit/57b727fb4a3aaff31b61eb244f7350c3affceaf0) thc-hydra: 9.3 -> 9.4
* [`4fa49788`](https://github.com/NixOS/nixpkgs/commit/4fa497886594177b258159c55197969cfbdddf96) blackfire: add missing aarch64-darwin
* [`1de28f9a`](https://github.com/NixOS/nixpkgs/commit/1de28f9abe833a1352993da25c4da34fb7639e5a) PyPDF2: Update homepage
* [`8ca353fb`](https://github.com/NixOS/nixpkgs/commit/8ca353fbacfb006c3bb51bcb920d7c0cdcd25ebf) gildas: 20211101_a -> 20220601_a
* [`d8cdbe82`](https://github.com/NixOS/nixpkgs/commit/d8cdbe829819d2ed0c714319e889f716203e99b7) git: Disable tests that fail on ZFS with formD normalization
* [`0877e1f7`](https://github.com/NixOS/nixpkgs/commit/0877e1f7160028bed163ae84ee6d7de585ad1046) nixos-tests: bring back quake3 test
* [`53e860a4`](https://github.com/NixOS/nixpkgs/commit/53e860a408fdbf518ef951e40f8629cedb82a7b4) bitwarden: 2022.8.1 -> 2022.9.1
* [`231bd216`](https://github.com/NixOS/nixpkgs/commit/231bd21698da59d5510a98549d2adddbc5f35498) modemmanager: 1.18.10 -> 1.18.12
* [`c40a7bff`](https://github.com/NixOS/nixpkgs/commit/c40a7bff7b2bb2b0df8e315470fffc630a40c24d) libsForQt5.plasma-wayland-protocols: 1.7.0 -> 1.8.0
* [`d6ef2ac9`](https://github.com/NixOS/nixpkgs/commit/d6ef2ac944a63bdd51c3fb0264d62ba42be40db3) popt: 1.18 -> 1.19
* [`8a34b9e1`](https://github.com/NixOS/nixpkgs/commit/8a34b9e1368815edfcc1d72a642e0fbf81e14c95) python310Packages.poetry-core: 1.1.0 -> 1.2.0
* [`e4e3dafe`](https://github.com/NixOS/nixpkgs/commit/e4e3dafe21dd3b47a030375ed91eaa60b44786b5) gpgme: fix i686 build
* [`abcaa921`](https://github.com/NixOS/nixpkgs/commit/abcaa9212306c4162292f6b81be1f5486bd966d8) openblas: Enable & honour parallel building
* [`698dbb85`](https://github.com/NixOS/nixpkgs/commit/698dbb85ae5234a1cdf44970947e76cd6b6e8bc5) python310Packages.django-debug-toolbar: 3.5 -> 3.7
* [`1220237a`](https://github.com/NixOS/nixpkgs/commit/1220237a3abe5bda473c9c0c6bf21b245fe87ca4) libfido2: 1.11.0 -> 1.12.0
* [`b5bbc4c6`](https://github.com/NixOS/nixpkgs/commit/b5bbc4c66284d5206a0034bd09dcd6ff97151057) perlPackages.EncodeIMAPUTF7: init at 1.05
* [`07acee59`](https://github.com/NixOS/nixpkgs/commit/07acee59ed679a7fe672be43777013684ac6f00f) maintainers: add Scrumplex
* [`7f991872`](https://github.com/NixOS/nixpkgs/commit/7f991872028884e9e49e1b69ad9fb06e81d81864) copyq: 6.2.0 -> 6.3.2
* [`2fc86340`](https://github.com/NixOS/nixpkgs/commit/2fc8634038284c069c3e84449776b78b294fb334) dnsmasq: 2.86 -> 2.87
* [`65e59177`](https://github.com/NixOS/nixpkgs/commit/65e5917720a19a2b69670b07214b9395e2fa1472) imapsync: 1.727 -> 2.200
* [`a1801d7c`](https://github.com/NixOS/nixpkgs/commit/a1801d7cb343c0f8da6e96ac88b152cfff6be007) apparmor: 3.0.7 -> 3.1.1
* [`400c1712`](https://github.com/NixOS/nixpkgs/commit/400c17120597d009bb3d48ce902cbbbd96974af3) maintainers: add mwolfe
* [`a385c00e`](https://github.com/NixOS/nixpkgs/commit/a385c00ee27ff4b1dbe7e143009cf2f73c9d440e) python3Packages.pycotap: init at 1.2.2
* [`0bea4a19`](https://github.com/NixOS/nixpkgs/commit/0bea4a194f7103fcedc0226a74e50657875a7c4d) cc-wrapper/setup-hook.sh: remove duplicate flags in NIX_CFLAGS_COMPILE
* [`8bbb3e7f`](https://github.com/NixOS/nixpkgs/commit/8bbb3e7f23423d819cd2cb865dd61c7a6d117dc2) ffmpeg: remove not necessary ? null
* [`8d6cdd8a`](https://github.com/NixOS/nixpkgs/commit/8d6cdd8abaa1d944f54330887c301431a404157f) ffmpeg: cleanup darwin frameworks
* [`7719968f`](https://github.com/NixOS/nixpkgs/commit/7719968fb6faf81968db79a9c109edfb1133233c) ffmpeg: cleanup and improve options, add vaapiSupport vpxSupport srtSupport
* [`d369fa4a`](https://github.com/NixOS/nixpkgs/commit/d369fa4ab8af86c874155c4c14cee79420d60009) ffmpeg: remove SDL1 support
* [`eb3fb810`](https://github.com/NixOS/nixpkgs/commit/eb3fb81016f2df5cbd5890c2be65a9fc2c6326d6) ffmpeg: inputs cleanup
* [`8609c559`](https://github.com/NixOS/nixpkgs/commit/8609c5598f73208a6696a41d4139cab4716c165c) ffmpeg: remove 0.X conditions
* [`77e8784f`](https://github.com/NixOS/nixpkgs/commit/77e8784f4efd776bdadb48ce69f3b29d867ae3b9) ffmpeg: remove 1.X conditions
* [`26a3bafb`](https://github.com/NixOS/nixpkgs/commit/26a3bafb69845f66140bf57d21fc022b08309775) ffmpeg: remove 2.X and 3.X conditions
* [`ff3dd668`](https://github.com/NixOS/nixpkgs/commit/ff3dd66849b724cf51c67d58410422067e63641b) libopenmpt: 0.6.5 -> 0.6.6
* [`95059b97`](https://github.com/NixOS/nixpkgs/commit/95059b974e56bced8bf03d0f623e8530bc2abf2b) nodejs-18_x: 18.9.1 -> 18.10.0
* [`fcf1534f`](https://github.com/NixOS/nixpkgs/commit/fcf1534fc7ab9c2b4e62d50b722cbdd443b0bdd6) frawk: init at 0.4.6
* [`05242b2c`](https://github.com/NixOS/nixpkgs/commit/05242b2ccca00e7b1fd02a3f37a5b2c0ac63f8d8) python3Packages.pysol-cards: init at 0.14.2
* [`da4cf04f`](https://github.com/NixOS/nixpkgs/commit/da4cf04fad8167266183dc1310bae9ef91d5b9bb) pysolfc: 2.6.4 -> 2.16.0
* [`4dca7afe`](https://github.com/NixOS/nixpkgs/commit/4dca7afed548262b3da966d884892ae7c1a20739) libaom: 3.4.0 -> 3.5.0
* [`44165d36`](https://github.com/NixOS/nixpkgs/commit/44165d3657676d19a9e46d1b773ec740582223c6) llvmPackages_{14, git}.clang: add nostdlibinc flag
* [`76b7136f`](https://github.com/NixOS/nixpkgs/commit/76b7136f4fc9bff719aa715fd594dee652275c92) python310Packages.iso8601: 1.0.2 -> 1.1.0
* [`fcd50870`](https://github.com/NixOS/nixpkgs/commit/fcd508704649c12281ffc7fa915bf3cb09f1dcd5) systemd: build with portabled by default.
* [`466b73d6`](https://github.com/NixOS/nixpkgs/commit/466b73d659d71b6b00f7ce50dcfc8a6fd70e8c4b) nixos/tests: init systemd-portabled
* [`4a46a86b`](https://github.com/NixOS/nixpkgs/commit/4a46a86bcf0b3abec41391ebc9e6eb5d444c0b9b) dnsmasq: add some nixos tests to passthru.tests
* [`2998b31b`](https://github.com/NixOS/nixpkgs/commit/2998b31b02770f801e43614ac3c42a4fd4412863) nodejs: add back newer bypass-xcrun patch
* [`68821161`](https://github.com/NixOS/nixpkgs/commit/688211615fa5958dc4f194559c4924459093260a) nodePackages: remove usage of xcbuild
* [`f7df1e77`](https://github.com/NixOS/nixpkgs/commit/f7df1e77d56ab4bc51ceca396545d00e81bedc48) sqlite: 3.39.3 -> 3.39.4
* [`32f520bc`](https://github.com/NixOS/nixpkgs/commit/32f520bc09e886f39ce251bf0b6492285c21603c) rsync: 3.2.5 -> 3.2.6
* [`5c12e0ef`](https://github.com/NixOS/nixpkgs/commit/5c12e0efb6108b91bce711337b0ae78b74b8dc1c) sbcl: bootstrap x86-64-darwin 1.2.11 -> 2.2.9
* [`2a9fc046`](https://github.com/NixOS/nixpkgs/commit/2a9fc04635c6c0b9a822f3c0aafeade1422fb8d9) cc-wrapper/add-hardening.sh: always unset _FORTIFY_SOURCE before re-setting it
* [`bb6c08c8`](https://github.com/NixOS/nixpkgs/commit/bb6c08c8d5d9a04fecf18d7a000d99ec96567cc2) flac: build with cmake, fixes cross compilation
* [`1654dc83`](https://github.com/NixOS/nixpkgs/commit/1654dc831cf62f170f4344ee3ce054e5bf68dd9e) tzdata: enable cross-compilation for Windows
* [`26661728`](https://github.com/NixOS/nixpkgs/commit/26661728168b2f5af812bf7b219f152d0d444df0) palemoon: 31.2.0.1 -> 31.3.0.1
* [`dd3fc581`](https://github.com/NixOS/nixpkgs/commit/dd3fc58112987982146bb5978eb6019e457c10ad) mesa: Install radv override configs into $out
* [`32461d55`](https://github.com/NixOS/nixpkgs/commit/32461d551c7fa4c8119cff6c5080cec93f8470f7) harfbuzz: 5.1.0 -> 5.2.0
* [`c8f9aa9f`](https://github.com/NixOS/nixpkgs/commit/c8f9aa9f998bee523f6a1360bebdebc573150f4a) harfbuzz: use upstream's release tarballs
* [`0c1b92bf`](https://github.com/NixOS/nixpkgs/commit/0c1b92bfaf18a875c3514aa5044b0b53640134c2) fcft: 3.1.4 -> 3.1.5
* [`156a0827`](https://github.com/NixOS/nixpkgs/commit/156a0827bd7c9b06703b3cbf94f2035cd984d9f3) python3Packages.mypy-protobuf: Build using buildPythonPackage
* [`974f1ece`](https://github.com/NixOS/nixpkgs/commit/974f1ece20a67a4bc5ae1e7d774833ac75888dd1) python3Packages.python-heatclient: Use buildPythonPackage
* [`17b976e9`](https://github.com/NixOS/nixpkgs/commit/17b976e99f0d19df7ef5d301c5b31d4f38d53f56) python3Packages: Use buildPythonPackage
* [`1ec7b00d`](https://github.com/NixOS/nixpkgs/commit/1ec7b00db38ccc0f126fd453ee55568048d29feb) python3Packages.filecheck: Use buildPythonPackage
* [`a91ecb2e`](https://github.com/NixOS/nixpkgs/commit/a91ecb2e254cab9600babc79848b216f46c72119) rfc-bibtex: Migrate out of python3Packages
* [`b32cb3b7`](https://github.com/NixOS/nixpkgs/commit/b32cb3b75646e9432d4bcf9b8f26c4ea83fba4d7) python3Packages.expiringdict: Use buildPythonPackage
* [`f3416858`](https://github.com/NixOS/nixpkgs/commit/f3416858078bf519609b8559312bf18e1ba1fe3b) python3Packages.python-glanceclient: Use buildPythonPackage
* [`8252b738`](https://github.com/NixOS/nixpkgs/commit/8252b7387e320be45704a28779df6160c00d52ff) python3Packages.mkdocs-material: Use buildPythonPackage
* [`32f2486b`](https://github.com/NixOS/nixpkgs/commit/32f2486bf7f76d8c7d39cf7250c101ffca83581d) python3Packages.clintermission: Use buildPythonPackage
* [`a2b1eaa0`](https://github.com/NixOS/nixpkgs/commit/a2b1eaa06390979fde2fa396d540405ffb9c51f4) poetry2conda: Migrate out of python package set
* [`b75d1a48`](https://github.com/NixOS/nixpkgs/commit/b75d1a480d62b1413dd9619e4f303f7065173db0) python3Packages.gprof2dot: Use buildPythonPackage
* [`565a8187`](https://github.com/NixOS/nixpkgs/commit/565a8187a46ab2b4d3a12f97efab1aa4134fd83f) python3Packages.sybil: Use buildPythonPackage
* [`98de11b3`](https://github.com/NixOS/nixpkgs/commit/98de11b31758ff1b9ab48c48fc44dbde48e7d2e0) mutmut: Migrate out of python package set
* [`2649e800`](https://github.com/NixOS/nixpkgs/commit/2649e800edab06f2fb310e26f90231171ee0cc9c) python3Packages.pypass: Add top-level attribute
* [`227aec9a`](https://github.com/NixOS/nixpkgs/commit/227aec9ac17dc0d4638c4188e1e8c8091728f2f3) python3Packages.griffe: Use buildPythonPackage
* [`d889b1b2`](https://github.com/NixOS/nixpkgs/commit/d889b1b2985784ee8f234f3372ba5e7cbc3d0216) notifymuch: Migrate out of python package set
* [`cd016901`](https://github.com/NixOS/nixpkgs/commit/cd016901b1ede81a8714549ee1048e9a1756612b) phonemizer: Use buildPythonPackage
* [`c2379dbd`](https://github.com/NixOS/nixpkgs/commit/c2379dbd43fbda68b68a4f810c96f8e1195ca79f) python3Packages.python-swiftclient: use buildPythonPackage
* [`b934a91f`](https://github.com/NixOS/nixpkgs/commit/b934a91f704ef61d786b36533651350fbf15326f) gigalixir: Migrate out of python package set
* [`d677311d`](https://github.com/NixOS/nixpkgs/commit/d677311d4613c84469d7a7fb018bdc6b199a7f8f) python3Packages.screeninfo: Use buildPythonPackage
* [`1f71c253`](https://github.com/NixOS/nixpkgs/commit/1f71c25333dcda2ac3f9f9a3587962ccf92b744f) python2Packages.yolk: drop
* [`24110fcf`](https://github.com/NixOS/nixpkgs/commit/24110fcf92897639c003fe7f5e4305788f918c0e) python3Packages.ironicclient: Use buildPythonPackage
* [`97b667de`](https://github.com/NixOS/nixpkgs/commit/97b667de3bbe534c99b5caf8ef1680c9c26e39d5) python3Packages.remarshal: Use buildPythonPackage
* [`28e35ec9`](https://github.com/NixOS/nixpkgs/commit/28e35ec966405e011aca1640c8a1224c119e243d) python3Packages.mkdocs-autorefs: use buildPythonPackage
* [`08ad6072`](https://github.com/NixOS/nixpkgs/commit/08ad607288bcbdf2eec17f4bdfc596fbef5eea9a) python3Packages.language-data: use buildPythonPackage
* [`5f14d6e8`](https://github.com/NixOS/nixpkgs/commit/5f14d6e82813cdf591f99a7add743d7167496691) python3Packages.mkdocstrings: use buildPythonPackage
* [`df99716e`](https://github.com/NixOS/nixpkgs/commit/df99716e494081b3a37dedf756c1faa5629eefe2) python3Packages.codespell: Migrate out of python package set
* [`2cf6c1f1`](https://github.com/NixOS/nixpkgs/commit/2cf6c1f1b3e46894c5bfc957c2382cc5ecadd8cd) python3Packages.drivelib: Use buildPythonPackage
* [`91d0e1f8`](https://github.com/NixOS/nixpkgs/commit/91d0e1f8781983c759edbd31a0e2709bb4318a7d) python3Packages.mkdocs-minify: Use buildPythonPackage
* [`f1510313`](https://github.com/NixOS/nixpkgs/commit/f1510313aa59d85883ec7fe5f7f83f47714d5466) python3Packages.mkdocstrings-python: Use buildPythonPackage
* [`670d2039`](https://github.com/NixOS/nixpkgs/commit/670d203938e1ad55f517deb1151ce731f2c47b47) python3Packages.down: Use buildPythonPackage
* [`a7a6688d`](https://github.com/NixOS/nixpkgs/commit/a7a6688dc352aa91ff347dba0cb4bb2e24dc469d) python3Packages.jsbeautifier: Use buildPythonPackage
* [`e755d64d`](https://github.com/NixOS/nixpkgs/commit/e755d64d655e8605306a2c39ae11728a92f2ba66) python3Packages.python-manilaclient: Use buildPythonPackage
* [`f0e5c494`](https://github.com/NixOS/nixpkgs/commit/f0e5c494b4f79541ab11cea2b46dd54c5e31d15d) python3Packages.coconut: Use buildPythonPackage
* [`f45e641a`](https://github.com/NixOS/nixpkgs/commit/f45e641a9f28b15f182c3c00c7ca15224b1b4530) python3Packages.behave: Use buildPythonPackage
* [`32a3a0a1`](https://github.com/NixOS/nixpkgs/commit/32a3a0a14b3531c02f1d83a1a2c7326aca9b1564) python3Packages.tempest: Use buildPythonPackage
* [`31c87e7d`](https://github.com/NixOS/nixpkgs/commit/31c87e7d7794cb5e1a755a70721852f64ebbdef0) pulseaudio: use xorg.* packages directly instead of xlibsWrapper indirection
* [`9a9b1952`](https://github.com/NixOS/nixpkgs/commit/9a9b1952fe5d9095f3d13f0ad9e66b448f2ee91f) sbcl: 2.2.6 -> 2.2.9
* [`7479aacf`](https://github.com/NixOS/nixpkgs/commit/7479aacffc8835ac8f754befc682c1c712e714dd) sbcl: refactor separate 2.*.nix into single file
* [`2001f8d1`](https://github.com/NixOS/nixpkgs/commit/2001f8d1acd9cfdb68570de29b4f041cbea1c096) palemoon: Further drop parallelism
* [`b8a03cec`](https://github.com/NixOS/nixpkgs/commit/b8a03cec225e78bb112c66836fc85720801cb377) flac: set CFLAGS and CXXFLAGS to match performance of autotools build
* [`c1188732`](https://github.com/NixOS/nixpkgs/commit/c11887327ba5e8a0451bd3b80956f280999cae4e) xz: 5.2.6 -> 5.2.7
* [`5bc624d9`](https://github.com/NixOS/nixpkgs/commit/5bc624d91f60103dd6b18eeedbe0eed98bd66986) gnuplot: 5.4.4 -> 5.4.5
* [`b739da06`](https://github.com/NixOS/nixpkgs/commit/b739da06931e6df03ac18f6d85be40d301042969) buildBazelPackage: optionally run bazel tests in checkPhase
* [`6b1a33be`](https://github.com/NixOS/nixpkgs/commit/6b1a33bede0e96f19b73e64de6dc4b5cbf400771) vertible: run tests before building in buildBazelPackage
* [`20c2a3a9`](https://github.com/NixOS/nixpkgs/commit/20c2a3a9d596a30bff1b28247e40e668329d32a9) systemd: nixpkgs-fmt
* [`0247a5b6`](https://github.com/NixOS/nixpkgs/commit/0247a5b6da0666fe5e40626ccc55c24dbb6b6b93) systemd: 251.4 -> 251.5
* [`f943f70a`](https://github.com/NixOS/nixpkgs/commit/f943f70ae75702eb36412c9ce3cadd2f558ca55b) python310Packages.certifi: 2022.06.15 -> 2022.09.24
* [`9503adb6`](https://github.com/NixOS/nixpkgs/commit/9503adb6660010f132f5574a4d0233aff067367d) python3Packages.scipy: Limit OpenMP threads during check phase
* [`75b887d7`](https://github.com/NixOS/nixpkgs/commit/75b887d7cb91cedb2d58c4ceb1a795b7ff287216) mysql57: use Protobuf 3.21
* [`53e0aec6`](https://github.com/NixOS/nixpkgs/commit/53e0aec6d39f41e118faec3ab7f97935e46f2f3f) protobuf3_7: remove
* [`86482656`](https://github.com/NixOS/nixpkgs/commit/8648265671a66555d8f12c5701b27a1a7a56390f) python310Packages.hatch-fancy-pypi-readme: 22.7.0 -> 22.8.0
* [`31a01a0b`](https://github.com/NixOS/nixpkgs/commit/31a01a0b98fe501d7450f97188616182bae702f8) geographiclib: init at 2.1.1
* [`a13e1e62`](https://github.com/NixOS/nixpkgs/commit/a13e1e6277d561ea3bcaa30782fd2f81dbcf7756) openssh: 9.0p1 -> 9.1p1
* [`2ba40b56`](https://github.com/NixOS/nixpkgs/commit/2ba40b566960fbab1e549a792fe4690cd31bb70f) python3Packages.pytest-xdist: Disable fork safety on darwin
* [`de5951f3`](https://github.com/NixOS/nixpkgs/commit/de5951f3c2dad844f7589228d6b9eb0bf606587c) pythonPackages.pythonRelaxDepsHook: cleanup unpacked folder
* [`69ea4c86`](https://github.com/NixOS/nixpkgs/commit/69ea4c8696f175fb2f40dcbc40e598e10a29346d) pythonPackages.buildPython*: also output dist when using wheel
* [`0afebbb8`](https://github.com/NixOS/nixpkgs/commit/0afebbb8f85dabc00857c2575d05b74d57ea388c) numactl: 2.0.15 -> 2.0.16
* [`c84c6b1c`](https://github.com/NixOS/nixpkgs/commit/c84c6b1cd51e5ab8a9ae12980b53842fb8f07477) protoc-gen-validate: 0.6.12 -> 0.6.13
* [`5a8e48c9`](https://github.com/NixOS/nixpkgs/commit/5a8e48c968c8137bc12ef3c9f09f6285a2ea00c0) systemd: don't taint on unmerged /usr
* [`dad24c51`](https://github.com/NixOS/nixpkgs/commit/dad24c51c1f9b2252ad0af67c59d8763f479412e) systemd-no-tainted: init as regression test
* [`051228ce`](https://github.com/NixOS/nixpkgs/commit/051228cee40636904597fa0251cc7772b2b3cb34) ghostscript: use xorg.* packages directly instead of xlibsWrapper indirection
* [`b0d7504e`](https://github.com/NixOS/nixpkgs/commit/b0d7504e82ab300d0bcef59f9afd02d1699d7bd6) go_1_18: 1.18.6 -> 1.18.7
* [`90c083ff`](https://github.com/NixOS/nixpkgs/commit/90c083ffba01efd0d144218e28bde930ec7ba95c) gnome2.libgnomeui: use xorg.* packages directly instead of xlibsWrapper indirection
* [`953a99b5`](https://github.com/NixOS/nixpkgs/commit/953a99b5084c6af1202f2f7885e4d76a8b525d5d) cotton: init at unstable-2022-10-04
* [`23664c38`](https://github.com/NixOS/nixpkgs/commit/23664c3870c3254db9b0a00bcf500298b69ab70f) linuxHeaders: 5.19 -> 6.0
* [`f42cdfe2`](https://github.com/NixOS/nixpkgs/commit/f42cdfe227d9b16a3036c3b568b12f3f21bc47bf) cryptsetup: Allow reading tokens from relative path
* [`570824e1`](https://github.com/NixOS/nixpkgs/commit/570824e10253f59c9a2332002b061415b2567627) systemd: Wrap in LUKS2 tokens
* [`19c34ac4`](https://github.com/NixOS/nixpkgs/commit/19c34ac44b29f0115ba515c3e2ae724d0360b3f7) systemd/initrd: Add files required by TPM2 and FIDO2 support to the initramfs
* [`9e9637ec`](https://github.com/NixOS/nixpkgs/commit/9e9637ecb6f254f4e659ee5c291908ec3e977303) nixos/tests/systemd-initrd-luks-tpm2: init
* [`21bbef95`](https://github.com/NixOS/nixpkgs/commit/21bbef95481db371a60d3ff900385e44662b648d) nixos/luksroot: Reword message on FIDO2 support with systemd stage 1
* [`b9b45482`](https://github.com/NixOS/nixpkgs/commit/b9b454820a1c587eb646732fc13c7ebd49edfc27) systemd/initrd: Add TPM modules into initrd
* [`78f929c5`](https://github.com/NixOS/nixpkgs/commit/78f929c5a6ac6320f5c99eadd805bac4d208c863) nixos/tests/systemd-initrd-luks-fido2: init
* [`c9ea0b96`](https://github.com/NixOS/nixpkgs/commit/c9ea0b96f6dabd11e9d45c1d0b7eb9d4eddadb2d) krill: 0.10.0 -> 0.11.0
* [`cf7be5db`](https://github.com/NixOS/nixpkgs/commit/cf7be5db710cb6a9160e3a6724894e209a4e9eef) git: 2.37.3 -> 2.38.0
* [`3ed0fafe`](https://github.com/NixOS/nixpkgs/commit/3ed0fafe3b6c2df23b1b7aad3678316fc617c2fa) x264: pull upstream parallel build fix
* [`2349e39e`](https://github.com/NixOS/nixpkgs/commit/2349e39ee4891a1a26c43e0c0b759e5cc52a48fe) karma: init at 0.108
* [`75ffef8f`](https://github.com/NixOS/nixpkgs/commit/75ffef8f2e49dc61ec664f5474f1023964ef52d1) pkgsMusl.texinfoInteractive: fix build ([nixos/nixpkgs⁠#193919](https://togithub.com/nixos/nixpkgs/issues/193919))
* [`aadb9282`](https://github.com/NixOS/nixpkgs/commit/aadb9282ec23ffd13dff0edc3ba5a566e4cebff3) text-engine: init at 0.1.1
* [`8559a955`](https://github.com/NixOS/nixpkgs/commit/8559a955820baa29a1f72895c249ed2db628de4b) gnome-extension-manager: init at 0.4.0
* [`82d5854f`](https://github.com/NixOS/nixpkgs/commit/82d5854fcc8f4bd527f7887b28483b40aae9114e) bundler: 2.3.22 -> 2.3.23
* [`c5e2f3c0`](https://github.com/NixOS/nixpkgs/commit/c5e2f3c06603bc968ad8cc19b6896d4ac6a99d55) ruby: move towards ruby 3
* [`013a2f42`](https://github.com/NixOS/nixpkgs/commit/013a2f421aed8f14f4ef02cfbaf862eefff91ee6) kexec-tools: 2.0.23 -> 2.0.25
* [`b78bf087`](https://github.com/NixOS/nixpkgs/commit/b78bf087ed7e15d48c6484f8b270c86a2f52a6e8) sord: unstable-2021-01-12 -> 0.16.14
* [`dcf7a5ec`](https://github.com/NixOS/nixpkgs/commit/dcf7a5ec3dac6a53ce1a27e0806bd93309b9d053) netbsd: Adapt to BSD-common infra changes for FreeBSD
* [`e3137f73`](https://github.com/NixOS/nixpkgs/commit/e3137f73fd85d6b63a04b4e2d94f48d2f68113f3) netbsd.install: Use `writeShellScript`
* [`044163d6`](https://github.com/NixOS/nixpkgs/commit/044163d6ef477ed41ceca7b294814f9a36d8bee7) bsd: `BSD_PATH` rename to `COMPONENT_PATH`
* [`167fc5aa`](https://github.com/NixOS/nixpkgs/commit/167fc5aa3e3a64a09f085805ef29381f6f292c46) libXft: 2.3.4 -> 2.3.6
* [`d37e1ef8`](https://github.com/NixOS/nixpkgs/commit/d37e1ef86d98783bf5a385f4006eb9878f3e52d3) p11-kit: add darwin tls ca store path
* [`22a90ce5`](https://github.com/NixOS/nixpkgs/commit/22a90ce5027161ca76075aafeb3896e9d5e0161e) bpftools: 5.19.8 -> 5.19.12
* [`ac48f072`](https://github.com/NixOS/nixpkgs/commit/ac48f07282b1e71614f198a241e8f08b252ed509) lib/types: always use `<function body>` instead of `[function body]` to indicate a function inside an option structure
* [`6396482d`](https://github.com/NixOS/nixpkgs/commit/6396482dde41cf3b610f1f56ec77ccf6f82ce502) lib/options/showOption: fix quoting of attr-names that are not identifiers
* [`9069a064`](https://github.com/NixOS/nixpkgs/commit/9069a064f8a8ae0896cda6343464a076599dbcb5) libxml2: enable strictDeps and enable pythonSupport when cross
* [`8e43dec8`](https://github.com/NixOS/nixpkgs/commit/8e43dec8bae3ab15f6214a9b6261a925ee1880e8) libxslt: enable strictDeps and enable pythonSupport when cross
* [`98715e1b`](https://github.com/NixOS/nixpkgs/commit/98715e1b1acda26f0cd86dc2b74abd1672af8644) lib.closePropagation: Remove the quadratic behavior in lib.closePropagation
* [`a2cd604d`](https://github.com/NixOS/nixpkgs/commit/a2cd604de9b9022cff2eda33c90c594140f8e932) nixos/doc: add release-notes entries for lib.closePropagation changes
* [`09226fff`](https://github.com/NixOS/nixpkgs/commit/09226fffcf076f976a9915ec7b9db12f5b2594a3) nixosOptionsDoc: buildInputs -> nativeBuildInputs
* [`e9039323`](https://github.com/NixOS/nixpkgs/commit/e903932306865715f0863fd9d5d975e8c9b0cae3) libical: 3.0.14 -> 3.0.15
* [`e96ef86e`](https://github.com/NixOS/nixpkgs/commit/e96ef86e70060e844c2e6b4b7c60d425099511ac) libical: unbreak on darwin
* [`a8cf5d34`](https://github.com/NixOS/nixpkgs/commit/a8cf5d34970470bed49a336628c77a122cd4dc3b) p4v: 2021.3.2186916 -> 2022.2.2336701
* [`98d026a1`](https://github.com/NixOS/nixpkgs/commit/98d026a144d729d7054067cee6a57e6999d5c03f) p4v: use autoPatchelfHook, upstream libraries
* [`0defcde4`](https://github.com/NixOS/nixpkgs/commit/0defcde4c01baa6c4eda01aad9efbb4d7faab896) p4v: wrap derivation to avoid polluting PATH
* [`49b4e3ad`](https://github.com/NixOS/nixpkgs/commit/49b4e3ad51a59e80f32fcef314ba9ea54b2d065b) luajit_2_0: 2.0.5-2022-03-13 -> 2.0.5-2022-09-13
* [`ac56a47d`](https://github.com/NixOS/nixpkgs/commit/ac56a47df455f58224f58383607185bbe3523c3b) luajit_2_1: 2.1.0-2022-04-05 -> 2.1.0-2022-10-04
* [`a289e7fe`](https://github.com/NixOS/nixpkgs/commit/a289e7feb19e9047dc091063b16c125aa99c6fc3) p4v: add support for x86_64-darwin
* [`cfe59eab`](https://github.com/NixOS/nixpkgs/commit/cfe59eab367f69fe9638ac42f118d99023a2a708) sigtool: 0.1.2 →  0.1.3
* [`844cc21d`](https://github.com/NixOS/nixpkgs/commit/844cc21d55c8b8850db70cf3c7b0347023346b9c) go, buildGoModule, buildGoPackage: default to 1.19
* [`e5b51364`](https://github.com/NixOS/nixpkgs/commit/e5b5136429ab1df2ec1818dd8e8ae4ff04e3cf23) cryptsetup: Remove ruby build dependency from NixOS
* [`e56fb06e`](https://github.com/NixOS/nixpkgs/commit/e56fb06eef794985d73431c2dc1ef757a3664578) cryptsetup: Add tests.nixos
* [`614c3e5d`](https://github.com/NixOS/nixpkgs/commit/614c3e5dc4f50ced1996137132205b7c8baeb387) vscode-extensions.sumneko.lua: init at 3.5.6
* [`2480532b`](https://github.com/NixOS/nixpkgs/commit/2480532bd11d1b26659267033345a4812dc063f5) nixos/doc: fix build
* [`2623fc4a`](https://github.com/NixOS/nixpkgs/commit/2623fc4a78b76cbf4253cb765c80c6d3be8cc03a) lua: add back Darwin makeBinaryWrapper fix
* [`49b5c1f5`](https://github.com/NixOS/nixpkgs/commit/49b5c1f562f5d79e188cee2495e177ac60c5f43e) vimPlugins.plenary-nvim: remove stale comment
* [`93142438`](https://github.com/NixOS/nixpkgs/commit/9314243820135b56287519f2599a4556460210e9) luaPackages.gitsigns-nvim: remove noop override
* [`448bb9bb`](https://github.com/NixOS/nixpkgs/commit/448bb9bbaecd27e90e3a20b761736db25c939e87) vimUtils.buildVimPlugin: prevent building twice
* [`ef30dee2`](https://github.com/NixOS/nixpkgs/commit/ef30dee2d6e0317bbdca083ffc2587e4f0895711) buildVimPlugin: deprecate `rtp` attribute
* [`ff30c899`](https://github.com/NixOS/nixpkgs/commit/ff30c899d8bd92d1a1c9f4d4e81455b04cb0868e) glibc: make crypt support optional
* [`7c29dcb8`](https://github.com/NixOS/nixpkgs/commit/7c29dcb80b3efb13f1018a531d0c67d2de06c481) libxcrypt: use tarball src, prune dependencies
* [`a3691082`](https://github.com/NixOS/nixpkgs/commit/a369108233b0494ccf77f7dd2bf797c8012b113a) perl: allow building without libcrypt
* [`e36bd3c4`](https://github.com/NixOS/nixpkgs/commit/e36bd3c473bf86f0ec18faee2f5aa310316ec7cd) libxcrypt: build using perl without libcrypt support
* [`3624ac24`](https://github.com/NixOS/nixpkgs/commit/3624ac24587b17d96d64446cd8dbbcf2158ab916) perl: fix build with libxcrypt
* [`0097f57b`](https://github.com/NixOS/nixpkgs/commit/0097f57b1fe054aa3b43b4af66786e8f9ee00647) gcc11: fix build with libxcrypt
* [`495e6501`](https://github.com/NixOS/nixpkgs/commit/495e6501b6952a8c0d667f052459d61b70f26701) llvmPackages_11.compiler-rt: fix build with libxcrypt
* [`194d8522`](https://github.com/NixOS/nixpkgs/commit/194d852242928d46be6313dc82821ee13b25114f) cpython: fix build with libxcrypt
* [`872c5244`](https://github.com/NixOS/nixpkgs/commit/872c524454776ff2787812f052609a1da5a09768) cyrus_sasl: fix build with libxcrypt
* [`44a73d01`](https://github.com/NixOS/nixpkgs/commit/44a73d018eb093bc16cfdad606fa13c12dd9497e) libxslt: fix build with libxcrypt
* [`2c2fde95`](https://github.com/NixOS/nixpkgs/commit/2c2fde951cd116908de11759ca0c21302751f6ae) apparmor: fix build with libxcrypt
* [`5df544ac`](https://github.com/NixOS/nixpkgs/commit/5df544acc2a346064ac0186cb9c2485c0b331afd) pam: enable libxcrypt by default
* [`74424224`](https://github.com/NixOS/nixpkgs/commit/74424224fd22d26dc9560445459c32c8a321d971) shadow: fix build with libxcrypt
* [`f6011b26`](https://github.com/NixOS/nixpkgs/commit/f6011b26e4a0ce633aceb33db6f4c4c2e6660920) systemd: fix build with libxcrypt
* [`f9090d58`](https://github.com/NixOS/nixpkgs/commit/f9090d5862c1ebdb8f00b1878372fb286da793d0) libxcrypt: fix build with musl
* [`32e74820`](https://github.com/NixOS/nixpkgs/commit/32e7482074ecc3d7be079e8ed87cd74c7986f202) nixos/tests/shadow: new hashes support with libxcrypt
* [`e8748e2a`](https://github.com/NixOS/nixpkgs/commit/e8748e2afaa900b437d322421ffa1d5fbae7069d) accountsservice: fix build with libxcrypt
* [`dd331ad1`](https://github.com/NixOS/nixpkgs/commit/dd331ad167795eaa8bf8044d750bea4e0fb28233) openldap: fix build with libxcrypt
* [`ae4e703c`](https://github.com/NixOS/nixpkgs/commit/ae4e703c17aaeb207acc12e802655dc7ab70bc2e) tdb: fix build with libxcrypt
* [`77a7b43e`](https://github.com/NixOS/nixpkgs/commit/77a7b43e629918d0f77cdfbf3678c2ea1fc1bb6c) aprutil: fix build with libxcrypt
* [`3028beca`](https://github.com/NixOS/nixpkgs/commit/3028beca394ab608361de9acb1f95d069a30d745) apacheHttpd: fix build with libxcrypt
* [`cc9be15a`](https://github.com/NixOS/nixpkgs/commit/cc9be15a2f6f11a33d28a85857717bebd8312841) alpine: fix build with libxcrypt
* [`5b572c53`](https://github.com/NixOS/nixpkgs/commit/5b572c53779e03b51c4ecebd94a4592d8e765566) talloc: fix build with libxcrypt
* [`52f2785e`](https://github.com/NixOS/nixpkgs/commit/52f2785e67a289486a43081c41934c4510bdd47a) vsftpd: fix build with libxcrypt
* [`c1da1990`](https://github.com/NixOS/nixpkgs/commit/c1da1990ee0631b77f88fa60be293eee21ddf297) opensmtpd: fix build with libxcrypt
* [`057ae3d0`](https://github.com/NixOS/nixpkgs/commit/057ae3d0f141bd8d86e5cfc7ef7650a65cda40f9) llvmPackage_14.compiler-rt: fix build with libxcrypt
* [`be9bc07a`](https://github.com/NixOS/nixpkgs/commit/be9bc07aa182f2e15f26e4f6a800b55d2bc10408) screen: fix build with libxcrypt
* [`43327d29`](https://github.com/NixOS/nixpkgs/commit/43327d2957cfa38e71ef57a43d532b8267f59d95) pppd: fix build with libxcrypt
* [`728c97f8`](https://github.com/NixOS/nixpkgs/commit/728c97f88adf5cf47e6196f082eef37b5eaadd93) pppd: inherit nixos test into passthru.tests
* [`fd944575`](https://github.com/NixOS/nixpkgs/commit/fd944575287b2164eac27e36946b5d6a355c27de) open-vm-tools: fix build with libxcrypt
* [`d438cee6`](https://github.com/NixOS/nixpkgs/commit/d438cee6a6dc5eb7dd0c09bc4da5a40089aea2d0) conserver: fix build with libxcrypt
* [`71dad513`](https://github.com/NixOS/nixpkgs/commit/71dad513b387f047fe88f4f3036d1409ce6f1a9e) dante: fix build with libxcrypt
* [`c82e7ee6`](https://github.com/NixOS/nixpkgs/commit/c82e7ee61b6bda4ab0cc0ffebf38ff599d65b671) hiawatha: fix build with libxcrypt
* [`5c34a535`](https://github.com/NixOS/nixpkgs/commit/5c34a5351a3adbc3554ea3c77874109dab255777) ircdHybrid: fix build with libxcrypt
* [`ce67773d`](https://github.com/NixOS/nixpkgs/commit/ce67773d12f7fde7796565705f6f0acff6d58ce0) libcli: fix build with libxcrypt
* [`f51c3fd4`](https://github.com/NixOS/nixpkgs/commit/f51c3fd469714434e2bd2f194f211479d4777eaf) ldapvi: fix build with libxcrypt
* [`d017316b`](https://github.com/NixOS/nixpkgs/commit/d017316b51a712862b404d681e8f0ce4bc80db69) atheme: fix build with libxcrypt
* [`dbf9333f`](https://github.com/NixOS/nixpkgs/commit/dbf9333f2cdd0c242c28d3a5b07d6175f300fb51) xorg.xdm: fix build with libxcrypt
* [`0465c23d`](https://github.com/NixOS/nixpkgs/commit/0465c23d9aa9ad23389bd415ed9b0356cb517935) wmic-bin: fix build with libxcrypt
* [`555d39b2`](https://github.com/NixOS/nixpkgs/commit/555d39b246e9b7339d27634a483076adbecd0d23) libreswan: fix build with libxcrypt
* [`167544c2`](https://github.com/NixOS/nixpkgs/commit/167544c2df5c76d84819d8421f823be886691ff2) tengine: fix build with libxcrypt
* [`3575e575`](https://github.com/NixOS/nixpkgs/commit/3575e575f87a744f81cf059eaf5111debb1cc3c2) libguestfs: fix build with libxcrypt
* [`ec31b969`](https://github.com/NixOS/nixpkgs/commit/ec31b96900ed4acfe41dec2f0ce04d12e4a5b18b) leafnode: fix build with libxcrypt
* [`84eda8bc`](https://github.com/NixOS/nixpkgs/commit/84eda8bc8b0e9bc9bada2a752b885d82cc804354) lsh: fix build with libxcrypt
* [`31e5ad84`](https://github.com/NixOS/nixpkgs/commit/31e5ad8466035f6de2b6e900837fc8b6ee78d348) pgpool: fix build with libxcrypt
* [`47945f27`](https://github.com/NixOS/nixpkgs/commit/47945f27bfa569c3f1bc010db39d24af2233ce5c) groonga: fix build with libxcrypt
* [`da15c9c2`](https://github.com/NixOS/nixpkgs/commit/da15c9c274a33074f364f2c3c0a38f9c139f5107) mailutils: fix build with libxcrypt
* [`2a7df1ad`](https://github.com/NixOS/nixpkgs/commit/2a7df1adc851f3f78efe797ec5d8dd998d9786e3) popa3d: fix build with libxcrypt
* [`870b0ebd`](https://github.com/NixOS/nixpkgs/commit/870b0ebd13514e4629460d3742c563ef01996c37) tcsh: fix build with libxcrypt
* [`c7b0317c`](https://github.com/NixOS/nixpkgs/commit/c7b0317c909c8c49cc0e1c8a44e7e48f355cc537) swiProlog: fix build with libxcrypt
* [`7f0e9f08`](https://github.com/NixOS/nixpkgs/commit/7f0e9f08599550e7c853e515d4c626150d9a8692) sumo: fix build with libxcrypt
* [`eb2ed865`](https://github.com/NixOS/nixpkgs/commit/eb2ed865eb1bee848d81b188cb23fee4fb2186cb) toybox: fix build with libxcrypt
* [`aac6de8d`](https://github.com/NixOS/nixpkgs/commit/aac6de8d3162de6eb2526a785ea7b5cfa1cbd3cd) gcc10: fix build with libxcrypt
* [`21c552ea`](https://github.com/NixOS/nixpkgs/commit/21c552eaf6bf28b83fbee425bd49e9a049b76fbc) gcc12: fix build with libxcrypt
* [`126319f7`](https://github.com/NixOS/nixpkgs/commit/126319f7b02795005bdc664e88e75818f8f6f56a) xrootd: fix build with libxcrypt
* [`897f5b25`](https://github.com/NixOS/nixpkgs/commit/897f5b25fb35a340bc7b65243fc5de45a3e84109) pounce: fix build with libxcrypt
* [`29392852`](https://github.com/NixOS/nixpkgs/commit/29392852362839e48459f6225997c3609c37f598) uwsgi: fix build with libxcrypt
* [`a1c07a61`](https://github.com/NixOS/nixpkgs/commit/a1c07a61b2b8c12254a69b36f70187ee33c84152) super: fix build with libxcrypt
* [`e1f8bfbb`](https://github.com/NixOS/nixpkgs/commit/e1f8bfbbd1007f74d4e8db08422622ef01d6a5c3) policycoreutils: fix build with libxcrypt
* [`77c50b07`](https://github.com/NixOS/nixpkgs/commit/77c50b072905f6b3c793f600f97455b5df9a5568) pies: fix build with libxcrypt
* [`eee1cec7`](https://github.com/NixOS/nixpkgs/commit/eee1cec722fcb7f934a4e807a10238097f58de6d) partimage: fix build with libxcrypt
* [`55a57630`](https://github.com/NixOS/nixpkgs/commit/55a576305eb0850048edced430bbb95192abd182) otpw: fix build with libxcrypt
* [`f9df47f1`](https://github.com/NixOS/nixpkgs/commit/f9df47f16d1fcd7893dc358ffed8d61d4015a9bb) zeroc-ice: fix build with libxcrypt
* [`2b899ee9`](https://github.com/NixOS/nixpkgs/commit/2b899ee967d64382557cba0f6b39e9d1c53b6e5d) luaPackages.luaposix: fix build with libxcrypt
* [`fe91064c`](https://github.com/NixOS/nixpkgs/commit/fe91064c225215bd8a5095ce3909c6166b8c40c6) monit: fix build with libxcrypt
* [`e963dde6`](https://github.com/NixOS/nixpkgs/commit/e963dde643459007e043fc29a8b89b5a159793be) libfilezilla: fix build with libxcrypt
* [`2e7e4731`](https://github.com/NixOS/nixpkgs/commit/2e7e473125226319b981c72195eb024d69725059) libsigrokdecode: fix build with libxcrypt
* [`67408dea`](https://github.com/NixOS/nixpkgs/commit/67408deaa2d4dcdf958dd6b071c85c127c9f9393) hylafaxplus: fix build with libxcrypt
* [`f0f14f1d`](https://github.com/NixOS/nixpkgs/commit/f0f14f1db5cbf4c291af6e1af4ccff77665a4881) dropbear: fix build with libxcrypt
* [`64e160c0`](https://github.com/NixOS/nixpkgs/commit/64e160c0b01a4f30307defe42834d14d1f57233e) kodi: fix build with libxcrypt
* [`24bc4540`](https://github.com/NixOS/nixpkgs/commit/24bc4540bfd314e90881bade8bed7557090cfa7b) pure-ftpd: fix build with libxcrypt
* [`31f1f362`](https://github.com/NixOS/nixpkgs/commit/31f1f3627dbd5ee02ae639fe146183401fa4c36f) cernlib: fix build with libxcrypt
* [`e33af606`](https://github.com/NixOS/nixpkgs/commit/e33af60685cb9e8d3b3feed8ffe778d7e162af85) bozohttpd: fix build with libxcrypt
* [`519b8c8d`](https://github.com/NixOS/nixpkgs/commit/519b8c8d9aabd437efd584815299d8f6e675570b) sawfish: fix build with libxcrypt
* [`845ae8e6`](https://github.com/NixOS/nixpkgs/commit/845ae8e68479bf07b823254a178fc0854448a4ec) qnial: fix build with libxcrypt
* [`09597d48`](https://github.com/NixOS/nixpkgs/commit/09597d4807616073eb21f695d0400eb7520aaf2f) unicon-lang: fix build with libxcrypt
* [`15f6c0a3`](https://github.com/NixOS/nixpkgs/commit/15f6c0a3557c4246178dbae5640a9c1cd9da2874) gvm-libs: fix build with libxcrypt
* [`8dde32e4`](https://github.com/NixOS/nixpkgs/commit/8dde32e4147d15e788ef2460e8672048bcf3c016) snis: fix build with libxcrypt
* [`125ec340`](https://github.com/NixOS/nixpkgs/commit/125ec340c876d30806fe510c504c0093ac5f4130) slock: fix build with libxcrypt
* [`fd1bcb10`](https://github.com/NixOS/nixpkgs/commit/fd1bcb107a77fdd7f90d21ecea4eee157da48e82) dico: fix build with libxcrypt
* [`ccba311f`](https://github.com/NixOS/nixpkgs/commit/ccba311ff55e4e87526109f1d0fdb15b706916a1) dcap: fix build with libxcrypt
* [`57f4391a`](https://github.com/NixOS/nixpkgs/commit/57f4391a43c34915ab9664e1b83af244cde9ab7d) haproxy: fix build with libxcrypt
* [`cfc636c3`](https://github.com/NixOS/nixpkgs/commit/cfc636c357a07270223ec96c5be507faecada6e1) srelay: fix build with libxcrypt
* [`58bbfeb6`](https://github.com/NixOS/nixpkgs/commit/58bbfeb6985c406ef55ff3cd927bb723c612c023) nntp-proxy: fix build with libxcrypt
* [`7b33ea47`](https://github.com/NixOS/nixpkgs/commit/7b33ea4752ea81e33faf8cba29b4e60252207ca6) shellhub-agent: fix build with libxcrypt
* [`9fb94a82`](https://github.com/NixOS/nixpkgs/commit/9fb94a820df8a469b2f0116540959691d96c4b26) pam_mysql: fix build with libxcrypt
* [`94e54c61`](https://github.com/NixOS/nixpkgs/commit/94e54c615279d156ef6e2c8d8f29ffffb3848714) pam_pgsql: fix build with libxcrypt
* [`3edcff9e`](https://github.com/NixOS/nixpkgs/commit/3edcff9eb2cd962860391099cb58f1faa18bcb9b) sysvinit: fix build with libxcrypt
* [`fc4f68d2`](https://github.com/NixOS/nixpkgs/commit/fc4f68d27c5c10f6e7170f39ab8bbae46fdbb17f) mokutil: fix build with libxcrypt
* [`c755643c`](https://github.com/NixOS/nixpkgs/commit/c755643cde23b589e98f1543171b36f9b5ef6248) epic5: fix build with libxcrypt
* [`bcdde95c`](https://github.com/NixOS/nixpkgs/commit/bcdde95c79c94906ab8693fdd601bb72394d9357) kermit: fix build with libxcrypt
* [`6264d946`](https://github.com/NixOS/nixpkgs/commit/6264d9461670ec4d8e43a3b9cd906c1d1da6d403) root5: fix build with libxcrypt
* [`2c10e089`](https://github.com/NixOS/nixpkgs/commit/2c10e089b9e5b0996e97c98cd57f44517e16d3f4) root: fix build with libxcrypt
* [`9430efb5`](https://github.com/NixOS/nixpkgs/commit/9430efb5bb5873d9ab4a152492ef56cad3ba61cd) pleroma: fix build with libxcrypt
* [`3d6b548f`](https://github.com/NixOS/nixpkgs/commit/3d6b548fd26c7c163bdb58f5369549e5c9c84271) sogo: fix build with libxcrypt
* [`fb591b9d`](https://github.com/NixOS/nixpkgs/commit/fb591b9d8b825b2fab6771b0d2ecf475028c5bfd) cde: fix build with libxcrypt
* [`993839aa`](https://github.com/NixOS/nixpkgs/commit/993839aab56a9eb006d1162155ea43a471784a18) bftpd: fix build with libxcrypt
* [`f64f7708`](https://github.com/NixOS/nixpkgs/commit/f64f7708014550a0ee7055a324aefd52c439142b) llvmPackages_13.compiler-rt: fix build with libxcrypt
* [`efd944cb`](https://github.com/NixOS/nixpkgs/commit/efd944cb72d800366d883679129623edb7a06f13) llvmPackages_12.compiler-rt: fix build with libxcrypt
* [`716a3152`](https://github.com/NixOS/nixpkgs/commit/716a31527a077445eba266b58dcc8ae31afb36da) llvmPackages_10.compiler-rt: fix build with libxcrypt
* [`842a2c23`](https://github.com/NixOS/nixpkgs/commit/842a2c2399ae1557d4543a76d65b900d9ffe8d52) llvmPackages_rocm.llvm: fix build with libxcrypt
* [`284396cf`](https://github.com/NixOS/nixpkgs/commit/284396cf040776e401f309701f490d273c5c7d6b) haskellPackages.crypt-sha512: fix build with libxcrypt
* [`76700598`](https://github.com/NixOS/nixpkgs/commit/76700598c58e2ac10d382bcf717222e637bc918d) freeswitch: fix build with libxcrypt
* [`6f1812a5`](https://github.com/NixOS/nixpkgs/commit/6f1812a59512f79526a1abbf0cd38b0ce089d999) haskellPackages.Unixutils: fix build with libxcrypt
* [`3f4de6d4`](https://github.com/NixOS/nixpkgs/commit/3f4de6d4ca71d9219bf68f32a6c8f36838a43111) thttpd: fix build with libxcrypt
* [`2d19e7cf`](https://github.com/NixOS/nixpkgs/commit/2d19e7cf6b87a754952c038fdc39f82004f5e402) haskellPackages.nano-cryptr: fix build with libxcrypt
* [`9001f0dc`](https://github.com/NixOS/nixpkgs/commit/9001f0dcd7a1adeec190d71b31c800ac31d1755b) haskellPackages.xmonad-utils: fix build with libxcrypt
* [`e02766bc`](https://github.com/NixOS/nixpkgs/commit/e02766bc32b8743b3c52c2e129dad3d9e753b023) ocserv: fix build with libxcrypt
* [`2b83e042`](https://github.com/NixOS/nixpkgs/commit/2b83e042065f2b07c5e88aa732cd11743f1fd081) ladybird: fix build with libxcrypt
* [`0f7ef684`](https://github.com/NixOS/nixpkgs/commit/0f7ef684887a5d108166b5679b607864365ef559) cdesktopenv: fix build with libxcrypt
* [`01f94c29`](https://github.com/NixOS/nixpkgs/commit/01f94c290d5112eec07b8df56a4b86bfa7ff1d22) wiringpi: fix build with libxcrypt
* [`3cedef1b`](https://github.com/NixOS/nixpkgs/commit/3cedef1b6ac07f55786c21bf65f0445720a94326) swift: fix build with libxcrypt
* [`73ffee89`](https://github.com/NixOS/nixpkgs/commit/73ffee897887c5ae7d5077ad5255ecb818ea79eb) util-linux: pass libxcrypt, so sulogin gets built
* [`1b8d6d35`](https://github.com/NixOS/nixpkgs/commit/1b8d6d359f1284b7ede0ce2ac152c74fb1a83f31) python3Packages.twisted: Disable failing crypt test
* [`322b510d`](https://github.com/NixOS/nixpkgs/commit/322b510d6b8d74bd701e5a5c3d9d7575383863cc) python3Packages.pillow{,-simd}: fix build with libxcrypt
* [`338d0cc6`](https://github.com/NixOS/nixpkgs/commit/338d0cc6ea6c4f157709498bcaf16d26e7239a52) libxcrypt: Fix static build by using perl from buildPackages
* [`195aa588`](https://github.com/NixOS/nixpkgs/commit/195aa5887d64007b544311bb6701e2e54cd01714) boost: fix build with enablePython by passing libxcrypt
* [`9b734d12`](https://github.com/NixOS/nixpkgs/commit/9b734d1239f65432072e9b7bcc4216081fd91245) liblc3: init at 1.0.1
* [`96dd839e`](https://github.com/NixOS/nixpkgs/commit/96dd839e8f34eadbba1ab425eaa03bcbb72de8a5) pipewire: 0.3.58 -> 0.3.59
* [`bdb347b4`](https://github.com/NixOS/nixpkgs/commit/bdb347b42cf507871d5b0c0a3bd632ba0cec8018) dbus: 1.14.0 -> 1.14.4
* [`75bdc8d7`](https://github.com/NixOS/nixpkgs/commit/75bdc8d7b00c69738bb4bdb3b192c8cefb6b5a59) cucumber: 3.1.2 -> 8.0.0
* [`41c09640`](https://github.com/NixOS/nixpkgs/commit/41c09640e7315be703af7840cf33e606c220beea) autoPatchelfHook: fix turning `[ "*" ]` into bash array
* [`01535ff0`](https://github.com/NixOS/nixpkgs/commit/01535ff0b07a73c94a3831a2f68bede5a1652ae1) autoPatchelfHook: support glob patterns
* [`8d5a4044`](https://github.com/NixOS/nixpkgs/commit/8d5a404437ab65beeadadb3a65ec1a5647b7b02f) nixos/karma: init
* [`039e1a05`](https://github.com/NixOS/nixpkgs/commit/039e1a05f5db32f5e9ff9dfe13501d631b7001bf) avahi: add patch for CVE-2021-3468
* [`fc7ca788`](https://github.com/NixOS/nixpkgs/commit/fc7ca788a3ff6f044972dcaedd3d1d33f867ca7a) sylpheed: apply patch for CVE-2021-37746
* [`f4ea1208`](https://github.com/NixOS/nixpkgs/commit/f4ea1208ec732d423a784bbb2b882f997b6af902) treewide: *Flags convert to list from str
* [`7e494713`](https://github.com/NixOS/nixpkgs/commit/7e49471316373c471a3bf4b78c130ebc907ae2d2) treewide: optional -> optionals where the argument is a list
* [`94705be4`](https://github.com/NixOS/nixpkgs/commit/94705be41876f2d5ae73f562ad93c54ba6d205f2) ethtool: 5.19 -> 6.0
* [`8918d77d`](https://github.com/NixOS/nixpkgs/commit/8918d77d2495baaa6b4d4d2f8dad3de3043d9946) libxcrypt: divert manpages into man output
* [`9c6406d2`](https://github.com/NixOS/nixpkgs/commit/9c6406d20fcc8c7b9545653fcabab510b65af63b) libxcrypt: add passthru tests
* [`5f7f7398`](https://github.com/NixOS/nixpkgs/commit/5f7f739887155caf7a3b2c1bde2c418334244db7) libxcrypt: adopt
* [`d26276e7`](https://github.com/NixOS/nixpkgs/commit/d26276e72563786fed06206897f05bf8ff088767) weechat: re-enable docs
* [`27738d46`](https://github.com/NixOS/nixpkgs/commit/27738d46f7691786b29edeb82c022d91d82311a4) wavpack: 5.4.0 -> 5.5.0
* [`998083f2`](https://github.com/NixOS/nixpkgs/commit/998083f2adb123f4bad30309f0994b9db9190b3d) github-runner: configurable user, environment, service overrides + multiple runners
* [`f13759e2`](https://github.com/NixOS/nixpkgs/commit/f13759e21fd938b3b7dfd9002e791a0532903ff3) Fix a deprecated types.string -> types.str
* [`327e05c3`](https://github.com/NixOS/nixpkgs/commit/327e05c382991496e37ddb40a5044b8be2a80f99) Get rid of DynamicUser flag
* [`b3de807a`](https://github.com/NixOS/nixpkgs/commit/b3de807a6a691c48d433c45437d4192cae8c4818) Update descriptions to use lib.mdDoc
* [`b744fee8`](https://github.com/NixOS/nixpkgs/commit/b744fee8805876a96c816aa1ec425160d63c3cab) Re-add `DynamicUser = true` per review discussion
* [`9a7f3804`](https://github.com/NixOS/nixpkgs/commit/9a7f38040b43a275f2606023ddef61c2a1ebe3de) Fix user type
* [`0b67081a`](https://github.com/NixOS/nixpkgs/commit/0b67081ad824fe917535bb86cd768cd0ffdce2f8) Cherry-pick 499748b
* [`0c743ca3`](https://github.com/NixOS/nixpkgs/commit/0c743ca36f22e962e9b7ab85cc10b1339c0a3e1a) openssl: 3.0.5 -> 3.0.6
* [`c3ddd95c`](https://github.com/NixOS/nixpkgs/commit/c3ddd95cf24639a6115c7756d78d9946e609e554) luarocks{,-nix}: add necessary programs to PATH
* [`18a17d11`](https://github.com/NixOS/nixpkgs/commit/18a17d11ff6d201530bc529d65d67ce5940e36cb) nixos/jenkins: jdk11 -> jdk17
* [`0bf70959`](https://github.com/NixOS/nixpkgs/commit/0bf7095945924617004e34f83c38849eb360b186) openssl: 1.1.1q -> 1.1.1r
* [`9247a666`](https://github.com/NixOS/nixpkgs/commit/9247a6667c5e44bcd98f2f4415f0579bd0b1467a) Revert "krb5: use openssl_1_1"
* [`071773dc`](https://github.com/NixOS/nixpkgs/commit/071773dc5d995edfc494a4bc46c5526833f12908) ibm-sw-tpm2: 1661 -> 1682
* [`c4849d44`](https://github.com/NixOS/nixpkgs/commit/c4849d44d40910624f28303b3bb5aa5240500595) Revert "ibm-sw-tpm2: Fix build on RISC-V"
* [`3b9c30a8`](https://github.com/NixOS/nixpkgs/commit/3b9c30a8d624b1ecc6d16115a2b8110f96f17e7e) Revert "ibm-sw-tpm2: Pin OpenSSL 1.1.1"
* [`8a2b098a`](https://github.com/NixOS/nixpkgs/commit/8a2b098a1b94ed55efd4e627919da7aa89d0af49) tzdata: 2022d -> 2022e
* [`ee639b42`](https://github.com/NixOS/nixpkgs/commit/ee639b42c6003dea2594739b10aaa4f71a9fbc47) opencl-headers: 2022.09.23 -> 2022.09.30
* [`d35d7ca6`](https://github.com/NixOS/nixpkgs/commit/d35d7ca6f9d4b766570f4fe308395ca2a1f9915b) xorg.libXaw3d: remove in favour of Xaw3d
* [`2905d2a3`](https://github.com/NixOS/nixpkgs/commit/2905d2a32083c1028996b3db9bd8297906b390c2) envypn-font: rename name to pname&version
* [`6321bdbb`](https://github.com/NixOS/nixpkgs/commit/6321bdbbab834599d4f0c6b997cc3fd795d6c938) envypn-font: add pre and post hooks
* [`fda0af13`](https://github.com/NixOS/nixpkgs/commit/fda0af137c285ea36df7264911e9bc11fba492d1) envypn-font: add erdnaxe as maintainer
* [`e264d5c7`](https://github.com/NixOS/nixpkgs/commit/e264d5c77f87b43ffb77afeee7d6b433aefda797) muse: fixup build after `sord` update
* [`092af8f9`](https://github.com/NixOS/nixpkgs/commit/092af8f9981b95fd61779e9195e10376cf19650b) Update srcs.nix
* [`5a197a40`](https://github.com/NixOS/nixpkgs/commit/5a197a40575cf53de17e0d185cd9bb7081a78517) tdlib: fix build on aarch64-darwin
* [`37fbb82f`](https://github.com/NixOS/nixpkgs/commit/37fbb82f57c6fd9aac09e335d6dd88909d5459d5) tdlib-purple: fix build on aarch64-darwin
* [`9d24c1f0`](https://github.com/NixOS/nixpkgs/commit/9d24c1f09e487f6c92c18a0c924948b4c58b80a8) linux: XFS_ONLINE_SCRUB=y ([nixos/nixpkgs⁠#195266](https://togithub.com/nixos/nixpkgs/issues/195266))
* [`1e4c4089`](https://github.com/NixOS/nixpkgs/commit/1e4c40896e25826838109ea7ffac54ea45ae15e9) licenses: Add apsl10
* [`5d79c93d`](https://github.com/NixOS/nixpkgs/commit/5d79c93d7748ed0952b397b5e01611fbb3982964) nixos/prometheus-kea-exporter: Fix `ExecStart` arguments
* [`a77b44f4`](https://github.com/NixOS/nixpkgs/commit/a77b44f4f47dde8bfb96a59a93680aae56f4bbee) libcint: 4.4.6 -> 5.1.6
* [`1ec06bba`](https://github.com/NixOS/nixpkgs/commit/1ec06bba4aa978712e357ecb9b96a16232bfde33) libxc: 5.2.2 -> 5.2.3
* [`663b4219`](https://github.com/NixOS/nixpkgs/commit/663b4219f03399854f9c3e2dc0eb147a800545bd) pyscf: 2.0.1 -> 2.1.1
* [`2aff1116`](https://github.com/NixOS/nixpkgs/commit/2aff11165bd2cbf7507a83054b80498921630cff) libxml2: 2.10.0 → 2.10.2
* [`f32e4645`](https://github.com/NixOS/nixpkgs/commit/f32e46451c4d020662eebdb4f26d0ee5d57965a4) libxslt: 1.1.36 → 1.1.37
* [`78082766`](https://github.com/NixOS/nixpkgs/commit/7808276611de4dbfe66873d6b4285b878916a13d) gildas: 20220601_a -> 20221001_b
* [`28d2fcc4`](https://github.com/NixOS/nixpkgs/commit/28d2fcc400c26a5c48e6affcdc82892283595423) vmagent: init at 1.82.0
* [`1ee0e58e`](https://github.com/NixOS/nixpkgs/commit/1ee0e58e2285085014e90691d8a3dbfc72066c13) xterm: 373 -> 374
* [`747e3420`](https://github.com/NixOS/nixpkgs/commit/747e342075228644d57f39fe7e5d7f55c71b780f) unbound: 1.16.3 -> 1.17.0
* [`a332c25b`](https://github.com/NixOS/nixpkgs/commit/a332c25bb366021d0db9c047497e3fbb79231158) gildas: mark as broken on aarch64-darwin
* [`b30d687d`](https://github.com/NixOS/nixpkgs/commit/b30d687dd063b7b9737bedcdd45b3e3ee820fe9a) Revert "openssl: 1.1.1q -> 1.1.1r"
* [`0755f8c8`](https://github.com/NixOS/nixpkgs/commit/0755f8c8f8212c5252f075a90062098346ec9f13) Revert "openssl: 3.0.5 -> 3.0.6"
* [`7687d9cc`](https://github.com/NixOS/nixpkgs/commit/7687d9cc595a2d5558846181c42ef986a8def170) dotnet-sdk: only set updateScript for sdk projects.
* [`2acce7df`](https://github.com/NixOS/nixpkgs/commit/2acce7dfdcf382757e6fe219e04668e7a63bf48a) vimPlugins: make usage of luaPackages less confusing
* [`a8f559c6`](https://github.com/NixOS/nixpkgs/commit/a8f559c6197d07ebb65a5027b650adcd537258dd) dotnet-sdk_3: 3.1.423 -> 3.1.424
* [`223e3aa9`](https://github.com/NixOS/nixpkgs/commit/223e3aa925059ecc09dca9de86b3cf1b00f08c67) dotnet-sdk: 6.0.401 -> 6.0.402
* [`90b9f78b`](https://github.com/NixOS/nixpkgs/commit/90b9f78bf9f0e5d5e100b8ebcf7bab8dbac4751b) dotnet-sdk_7: 7.0.100-rc.1.22431.12 -> 7.0.100-rc.2.22477.23
* [`445887f6`](https://github.com/NixOS/nixpkgs/commit/445887f636e75d6d057d8d46980d442d7f1cd02d) mesa: 22.1.7 -> 22.2.1
* [`b4b99f16`](https://github.com/NixOS/nixpkgs/commit/b4b99f16da93514101caf5104644dc6456510bdd) mesa: re-enable video-codecs
* [`2bde1919`](https://github.com/NixOS/nixpkgs/commit/2bde19199e8b646a656ef57036f21a914200e034) gnustep.libobjc: 1.9 -> 2.1
* [`e0d89909`](https://github.com/NixOS/nixpkgs/commit/e0d89909382d30d5d631969280f25b60562cfa5f) c-ares: add cmake to default, c-aresMinimal: init
* [`4250a647`](https://github.com/NixOS/nixpkgs/commit/4250a64798a900f66f5677a18535213ebdad118e) c-ares: add dev output
* [`74f7adf0`](https://github.com/NixOS/nixpkgs/commit/74f7adf0be941e8e126532e1cc6f5202f7278c60) c-ares: remove passthru.cmake-config
* [`fe2ffdcc`](https://github.com/NixOS/nixpkgs/commit/fe2ffdcc5e8ad5ead79f1d65b7ce3229b6a0e78b) c-ares: add downstream tests
* [`58e3121f`](https://github.com/NixOS/nixpkgs/commit/58e3121fbd6cd692a192e6b673d7e49171b1cb4b) speex: 1.2.0 -> 1.2.1
* [`8ec485f5`](https://github.com/NixOS/nixpkgs/commit/8ec485f5142d9502e080e0318dba84e0a46f3f62) libksba: 1.6.0 -> 1.6.2
* [`28d31e8f`](https://github.com/NixOS/nixpkgs/commit/28d31e8fbb2cdf56c9a1f79dbfd05edd13aed94a) python3Packages.pytz-deprecation-shim: Disable failing test
* [`cf1b9529`](https://github.com/NixOS/nixpkgs/commit/cf1b9529884999621a9cf06036df8fba4aee99b3) Update nixos/modules/services/continuous-integration/github-runner.nix
* [`69d9538b`](https://github.com/NixOS/nixpkgs/commit/69d9538b345e48a74c2ed3b279f8cb4a73a8261f) Update nixos/modules/services/continuous-integration/github-runners.nix
* [`1e58aeef`](https://github.com/NixOS/nixpkgs/commit/1e58aeefe8d273d9d6c80a44b1f60c2b54f8cfa6) tqsl: migrate to wxGTK32
* [`0d13ad34`](https://github.com/NixOS/nixpkgs/commit/0d13ad34f6008454b1a09c6fb52592e7bc954e58) rapidsvn: migrate to wxGTK30
* [`fc8fdb03`](https://github.com/NixOS/nixpkgs/commit/fc8fdb03a0255e1720bab16c01a5c5e8a9152ae1) Try simpler github-runner.nix
* [`ce12c5fe`](https://github.com/NixOS/nixpkgs/commit/ce12c5fedade2bb8fcfe2af71161931076077d91) asc: migrate to wxGTK32
* [`37494841`](https://github.com/NixOS/nixpkgs/commit/37494841bac048f8845ef39c226a2e80dc608d0a) fsg: migrate to wxGTK32
* [`2c101648`](https://github.com/NixOS/nixpkgs/commit/2c10164855d45eb264bca529d643226507795a55) megaglest: fix broken build
* [`9443d83e`](https://github.com/NixOS/nixpkgs/commit/9443d83e6fee728c1926a783647b45011bd3b514) freshrss: patchShebangs instead of specifying interpreter at use site
* [`9e82ce7a`](https://github.com/NixOS/nixpkgs/commit/9e82ce7a87861ddc655020b7d625af9f212af300) besu: 21.10.8 -> 22.7.6
* [`d700d8e8`](https://github.com/NixOS/nixpkgs/commit/d700d8e8a26427388cbe59149232ee104cf36644) stdenv cc-wrapper: revert a problematic change for non-Linux
* [`24b6d7be`](https://github.com/NixOS/nixpkgs/commit/24b6d7be45391ac685819b76d9c90602688afc73) invidious: fix [nixos/nixpkgs⁠#195779](https://togithub.com/nixos/nixpkgs/issues/195779) by disabling quic when building
* [`f831be55`](https://github.com/NixOS/nixpkgs/commit/f831be559a62a58fe9d2a02ea383894bbc028f10) bpftools: strip path to the binary from prints
* [`3eae0cc0`](https://github.com/NixOS/nixpkgs/commit/3eae0cc0722b14dc0c7ec18c626ddbeb386269ad) cudatookit: 11.8 + redistrib manifest
* [`6d0f92f8`](https://github.com/NixOS/nixpkgs/commit/6d0f92f82ae3d0886fd1cf3a13e312cf015cd6b6) cuddn: 8.5.0
* [`8a63fb02`](https://github.com/NixOS/nixpkgs/commit/8a63fb0236bfc25a27168a55d2a64377c7fc1b96) cuda-samples: 11.8 throw the non-existing tag
* [`ad6aeedf`](https://github.com/NixOS/nixpkgs/commit/ad6aeedf56c6a802a5ddab445811be820824a82b) tensorrt: fix false fallback to tensorRTDefaultVersion
* [`856e04dc`](https://github.com/NixOS/nixpkgs/commit/856e04dc1d17e8baf22450e4d527ca6aa83cb228) cudnn: throw error if the default version is not supported
* [`af83b0c6`](https://github.com/NixOS/nixpkgs/commit/af83b0c6b11c3227c3e084b2d72871c829245820) cudnn: add 8.6.0, set default
* [`bf0a539d`](https://github.com/NixOS/nixpkgs/commit/bf0a539da4e80aa2531bdaca14bace5bb4ed665f) myrddin: cleanup, add -j$NIX_BUILD_CORES to make
* [`c2474f90`](https://github.com/NixOS/nixpkgs/commit/c2474f9052c1f5bdb38e99b0a5867d4c87e91b2e) Revert "modemmanager: fix and re-enable tests"
* [`d5d94626`](https://github.com/NixOS/nixpkgs/commit/d5d94626146cf34b92c3002cccc6554daf3948c9) modemmanager: reenable install tests
* [`5f2785ce`](https://github.com/NixOS/nixpkgs/commit/5f2785ce59eb194a8bcf656027ad80a8e5dd7785) python3Packages.threadpoolctl: Disable failing tests
* [`a247f35a`](https://github.com/NixOS/nixpkgs/commit/a247f35a4a7882dab5fb420c93fb81cc5291a3be) python3Packages.poetry-plugin-export: 1.0.6 -> 1.1.2
* [`844632d2`](https://github.com/NixOS/nixpkgs/commit/844632d2c89f81782a4264bce91a2284db13a557) python3Packages.poetry-core: 1.2.0 -> 1.3.2
* [`35b849d0`](https://github.com/NixOS/nixpkgs/commit/35b849d07b6d24e1a48b7ed53db2ef2160d73d5c) python3Packages.poetry: 1.2.0 -> 1.2.2
* [`53d33caa`](https://github.com/NixOS/nixpkgs/commit/53d33caa8c8a571b61e6c1e3271cbd7691187cdb) systemd: disable portabled on musl
* [`993e453d`](https://github.com/NixOS/nixpkgs/commit/993e453d72933421e2362d1dc66987fb6e1a8c85) freeciv: 3.0.3 -> 3.0.4
* [`28cbbb8b`](https://github.com/NixOS/nixpkgs/commit/28cbbb8bd4f589cb997d7bb2102c9379d07bee46) qcoro: 0.4.0 -> 0.6.0
* [`64e990c7`](https://github.com/NixOS/nixpkgs/commit/64e990c7f61e8fe101b8a9d35c1a9397e3ea3e2c) neochat: Work around AArch64 not using gcc11Stdenv
* [`3a2ba06a`](https://github.com/NixOS/nixpkgs/commit/3a2ba06a838d773aa3dea5cdcdfb1b15b1ede8ae) spacebar: Work around AArch64 not using gcc11Stdenv
* [`07a08a08`](https://github.com/NixOS/nixpkgs/commit/07a08a08b8214ddcf4f31bd5da59cda4b0b5cd5d) python310Packages.codespell: 2.2.1 -> 2.2.2
* [`82d6496f`](https://github.com/NixOS/nixpkgs/commit/82d6496f31b1f4d36b6e88b729d8548bc2d0ad92) dnsproxy: 0.45.3 -> 0.45.4
* [`36bb8d96`](https://github.com/NixOS/nixpkgs/commit/36bb8d969a76020c156530aed1d3fd1588842036) libxml2: use older version during stdenv bootstrap on darwin
* [`9d04ce0b`](https://github.com/NixOS/nixpkgs/commit/9d04ce0b835e025c35c8cdab7ac95b4c8f60b92e) galaxy-buds-client: init at 4.5.2
* [`3abbce58`](https://github.com/NixOS/nixpkgs/commit/3abbce5848bd3da6b626b4b4635612cd339c5026) python3Packages.mautrix: 0.17.8 -> 0.18.4
* [`c3cd97de`](https://github.com/NixOS/nixpkgs/commit/c3cd97ded667fd362577d54ce48256c156af6467) mautrix-telegram: 0.12.0 -> 0.12.1
* [`09d54e08`](https://github.com/NixOS/nixpkgs/commit/09d54e0852a09474c254b4461331b9bff5440b3c) mmctl: 7.3.0 -> 7.4.0
* [`53a5e179`](https://github.com/NixOS/nixpkgs/commit/53a5e17993ff53c33a6d3ad3ef8ac515515eb49d) calibre-web: 0.6.18 -> 0.6.19
* [`04096360`](https://github.com/NixOS/nixpkgs/commit/04096360992c8d8842855e4f722a1690efe04400) prometheus-nginxlog-exporter: 1.9.2 -> 1.10.0
* [`70387841`](https://github.com/NixOS/nixpkgs/commit/703878418fd940d0770954ba8188f4184340f66f) lxgw-wenkai: 1.222 -> 1.245.1
* [`5fd789b1`](https://github.com/NixOS/nixpkgs/commit/5fd789b108716c2f467aad2a8b6a3c96d2fa0689) dart: set sourceProvenance to binaryNativeCode
* [`0057a04a`](https://github.com/NixOS/nixpkgs/commit/0057a04a77e4d58adc7e37a907bdde893d29e070) grandorgue: 0.3.1-r2333 -> 3.8.0-1
* [`a60d215c`](https://github.com/NixOS/nixpkgs/commit/a60d215c2b0ad773b165629431055d4981b41991) snipe-it: 6.0.11 -> 6.0.12
* [`fe3b7c5e`](https://github.com/NixOS/nixpkgs/commit/fe3b7c5e9dbb16d00b8542b264597436d9ab2707) shaderc: fix glslc on aarch64-darwin
* [`6f46852c`](https://github.com/NixOS/nixpkgs/commit/6f46852c6f40b30d41ffa5f81b73221cc842f49e) grass: fix build on aarch64-darwin
* [`0dc4b9fd`](https://github.com/NixOS/nixpkgs/commit/0dc4b9fd9d70fafb0244aaecace1e54ff75358b8) tere: 1.2.0 -> 1.3.0
* [`ccfd1f8c`](https://github.com/NixOS/nixpkgs/commit/ccfd1f8cdab4a2f425da21f21069fc1e732a68dd) python310Packages.enamlx: 0.6.0 -> 0.6.2
* [`017cc2d4`](https://github.com/NixOS/nixpkgs/commit/017cc2d4b7454b63d68c8fe7a1182753304e6f13) libical: fix tests with 32-bit time_t
* [`b2cea2e8`](https://github.com/NixOS/nixpkgs/commit/b2cea2e810784828ad2c89919b04e66dc716f445) tdesktop: tg_owt: use openssl_1_1 to fix video chat incompatibility
* [`95ba52bd`](https://github.com/NixOS/nixpkgs/commit/95ba52bda441d0e8b2d2b7d3e5899c0c196fffa3) python310Packages.launchpadlib: 1.10.16 -> 1.10.17
* [`171ae271`](https://github.com/NixOS/nixpkgs/commit/171ae2717a59233b05d15f376878acac75e92edd) python310Packages.lazr-restfulclient: 0.14.4 -> 0.14.5
* [`1657c311`](https://github.com/NixOS/nixpkgs/commit/1657c3114e93d380dc54441a8ae2ecdf5840ab31) calibre: 6.7.0 -> 6.7.1
* [`910b2be5`](https://github.com/NixOS/nixpkgs/commit/910b2be5ac08264311123d3add6d81e8e6fd05b8) tdesktop: fix for loading libXcursor
* [`6145b7c7`](https://github.com/NixOS/nixpkgs/commit/6145b7c77057794c8e8262c24ae2e0819009ca36) ffmpeg{,_{4,5}}-headless: init
* [`501c5af8`](https://github.com/NixOS/nixpkgs/commit/501c5af829108d0676c1f4152f4c79fdf71dfc95) unpaper: use ffmpeg_5-headless
* [`d1f673e3`](https://github.com/NixOS/nixpkgs/commit/d1f673e3b62964da0f2d88cbd711178e59f51066) navidrome: use ffmpeg-headless
* [`611f2478`](https://github.com/NixOS/nixpkgs/commit/611f247810ab76bedd6ed544068232982c071f06) nixos/tests: Generalize nix-build file.nix hack to testing-python.nix
* [`1d9b9130`](https://github.com/NixOS/nixpkgs/commit/1d9b9130883550f2f928c573b35fe8b8193d5c4b) nixos/lib/testing: Delay nodes.machine.~config~ migration
* [`077faae4`](https://github.com/NixOS/nixpkgs/commit/077faae467f6dfd64746e1c975661b0fed0818f1) libowfat: fix build with glibc 2.34
* [`eca87400`](https://github.com/NixOS/nixpkgs/commit/eca87400bd7344c7fe5d42d000e71fd595047b9b) wordpressPackages.plugins.gutenberg: init at 14.3.0
* [`3ec8d0d5`](https://github.com/NixOS/nixpkgs/commit/3ec8d0d5586257ddde2f3c528a1bef6932fd3c6a) gptfdisk: fix runtime problems with popt 1.19
* [`81986fc7`](https://github.com/NixOS/nixpkgs/commit/81986fc7dfc511052f39764c5b3e9c8a44132310) yandex-browser: 22.1.3.907-1 -> 22.9.1.1110-1
* [`c6cae19d`](https://github.com/NixOS/nixpkgs/commit/c6cae19d1937c21213bd37127d027365942be850) viu: add withSixel option; adopt
* [`1f7dda18`](https://github.com/NixOS/nixpkgs/commit/1f7dda180048a6ea4fb7621e7412357ee60ed555) python310Packages.types-decorator: 5.1.8 -> 5.1.8.1
* [`be19ee47`](https://github.com/NixOS/nixpkgs/commit/be19ee479278a1006ed5ad4955d8bfc8261ab050) python310Packages.types-setuptools: 65.4.0.0 -> 65.5.0.0
* [`ddd6e72b`](https://github.com/NixOS/nixpkgs/commit/ddd6e72b70814d62b0ee6c022801f774d646bdc4) python310Packages.types-urllib3: 1.26.25 -> 1.26.25.1
* [`5b71c0cd`](https://github.com/NixOS/nixpkgs/commit/5b71c0cdb4cacb35d8b892aea85f425e6c49c4f5) python310Packages.types-docutils: 0.19.1 -> 0.19.1.1
* [`1ddc9515`](https://github.com/NixOS/nixpkgs/commit/1ddc951564a026df2d62f45ceff1e5d453eaef8a) python310Packages.types-colorama: 0.4.15 -> 0.4.15.1
* [`3861cc26`](https://github.com/NixOS/nixpkgs/commit/3861cc269e204917de638a9924448be0411dde51) python310Packages.nbclassic: 0.4.5 -> 0.4.6
* [`70c73d77`](https://github.com/NixOS/nixpkgs/commit/70c73d776cc5fbf6776baa3b3c477b9d4c3dce78) python310Packages.openstacksdk: 0.101.0 -> 0.102.0
* [`65cdf3be`](https://github.com/NixOS/nixpkgs/commit/65cdf3be6d353975e4463d9e4c3e687dc5a031ae) qutebrowser: use upstream `make install`
* [`f5b23aa3`](https://github.com/NixOS/nixpkgs/commit/f5b23aa3423b7da09fc554a305aa45477b0d84f0) pods: 1.0.0-beta.5 -> 1.0.0-beta.6
* [`62cace13`](https://github.com/NixOS/nixpkgs/commit/62cace13fea50b41145b77b84033e8c1728a085c) nixos/update-users-groups.pl: sort json file for better reproducibility
* [`1ba4814c`](https://github.com/NixOS/nixpkgs/commit/1ba4814c6ceb117209436952d1f8bfbed45e7c24) auth0-cli: set `auth0` command as main program
* [`cafb3c6f`](https://github.com/NixOS/nixpkgs/commit/cafb3c6f7fb0039354c467f93bdd9fb9098fe0e2) minio: 2022-10-08T20-11-00Z -> 2022-10-15T19-57-03Z
* [`2675c17f`](https://github.com/NixOS/nixpkgs/commit/2675c17f090288c02df77dd1f55e04e811b5683a) hyprland: refactor
* [`0cf5a348`](https://github.com/NixOS/nixpkgs/commit/0cf5a3489a00cd981404af8220c7185637e6cd9c) hyprland: move to hyprwm/hyprland
* [`f04d32e5`](https://github.com/NixOS/nixpkgs/commit/f04d32e599af8e786fcc572274e4d3eab608fcb0) ruff: 0.0.76 -> 0.0.79
* [`7d254361`](https://github.com/NixOS/nixpkgs/commit/7d254361827af3181e3f7c090f83a8435b975d3b) ostree: Do not depend on GTK
* [`b789ab3c`](https://github.com/NixOS/nixpkgs/commit/b789ab3c2497496f80819d1c1d7c8da1a498b306) gnome.gnome-software: Switch to libsoup 3
* [`4f7f85c1`](https://github.com/NixOS/nixpkgs/commit/4f7f85c10246deb78b577fa5f11214f21e33b1ad) spicy: unstable-2020-02-21 -> 0.6.2
* [`5b6b539f`](https://github.com/NixOS/nixpkgs/commit/5b6b539f4fd81179e06f0720ee39e2faf97a1de5) gnome.sushi: Switch to libsoup 3
* [`d5ae32c8`](https://github.com/NixOS/nixpkgs/commit/d5ae32c83ff28aedd7a6922631aad30684ec8316) Update pkgs/tools/misc/tere/default.nix
* [`bc791b77`](https://github.com/NixOS/nixpkgs/commit/bc791b77b9753cbf1ceb0225cd281e45a0d85e7f) remove whitespace
* [`ae621db1`](https://github.com/NixOS/nixpkgs/commit/ae621db1ccc06381ef8b3a0b440e3823d496c1fb) gnome.gitg: drop libsoup dependency
* [`4db165bd`](https://github.com/NixOS/nixpkgs/commit/4db165bd2f32e1d346dee3bcd1fe583189e45613) gnome.gnome-tweaks: Drop libsoup dependency
* [`c19e36ff`](https://github.com/NixOS/nixpkgs/commit/c19e36ff21870cac51a33dec83133cb949ab216d) folks: Remove unused dependencies
* [`cc1368a9`](https://github.com/NixOS/nixpkgs/commit/cc1368a92f4afbb0e719f5d22152e808d2462ac5) gringo: fix darwin build
* [`2d84ec42`](https://github.com/NixOS/nixpkgs/commit/2d84ec42debc60cd5ea4c23577d0b2fa0d4805bb) nfpm: 2.19.2 -> 2.20.0
* [`2c099d1a`](https://github.com/NixOS/nixpkgs/commit/2c099d1a143e7fd5a573a1f4c4288b290383dd46) Set runner name to attr name for github-runners.${name}
* [`5221e7af`](https://github.com/NixOS/nixpkgs/commit/5221e7af04db06e4847ea1af55e16fb140c02b92) Add comments to explain about the name defaults
* [`fc6517a5`](https://github.com/NixOS/nixpkgs/commit/fc6517a55b5049156ebf92bb0e1ad7fc40fc22f4) ballerina: 2201.1.0 -> 2201.2.1
* [`54bfd511`](https://github.com/NixOS/nixpkgs/commit/54bfd51169737bb43be7af2f217016153ca24908) cve: init at 1.0.0
* [`d3818bf8`](https://github.com/NixOS/nixpkgs/commit/d3818bf821ea4a6e297e03315834d9d37b19adbb) python310Packages.types-python-dateutil: 2.8.19 -> 2.8.19.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
