### PR TITLE
niv emacs-overlay: update d5dbc29a -> cb7c1a56

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d5dbc29af6033b0c9ea25c5382a15612c527ae96",
-        "sha256": "0kymrncgv9ac5na0xhj8jyd9xg45crsx0ps3f16fxx2s8b7js6j2",
+        "rev": "cb7c1a5695d398a4c11501073d67735a5f876388",
+        "sha256": "15wxkfyghamnpaj3i988zkbxcx4yvrvk66b6zj3346xlrkp101wp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/d5dbc29af6033b0c9ea25c5382a15612c527ae96.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/cb7c1a5695d398a4c11501073d67735a5f876388.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@d5dbc29a...cb7c1a56](https://github.com/nix-community/emacs-overlay/compare/d5dbc29af6033b0c9ea25c5382a15612c527ae96...cb7c1a5695d398a4c11501073d67735a5f876388)

* [`a03c0961`](https://github.com/nix-community/emacs-overlay/commit/a03c0961009f0028c794bd740f2e049f568247d7) overlays: use a better and clearer way to compose overlays
* [`46c6c90e`](https://github.com/nix-community/emacs-overlay/commit/46c6c90eff894f4c060e97f6902eecd06994690d) Revert "flake.nix: fix the hack of getting overlayAttrs"
* [`286ead3d`](https://github.com/nix-community/emacs-overlay/commit/286ead3db69a26e4f2636b48b338a98e4812d36a) Updated repos/melpa
* [`73b967f3`](https://github.com/nix-community/emacs-overlay/commit/73b967f3b7d97bfc33feac0190288692f7fcffe4) Updated repos/emacs
* [`d0198a7a`](https://github.com/nix-community/emacs-overlay/commit/d0198a7a1826347de95dfdb7abd973ec5c478f67) Updated repos/melpa
* [`4d784812`](https://github.com/nix-community/emacs-overlay/commit/4d784812384bd559e15b6d0934621821d2947622) Updated repos/emacs
* [`d47de60c`](https://github.com/nix-community/emacs-overlay/commit/d47de60c7244e689e961c75f1ca0facbba50cfbb) Updated repos/melpa
* [`85821499`](https://github.com/nix-community/emacs-overlay/commit/858214991200eccc2f0a4f929f4baa0ffd8281c6) Updated repos/nongnu
* [`3f5b0278`](https://github.com/nix-community/emacs-overlay/commit/3f5b02783c49ed5ab6dc19cfa82db405b281651a) Updated repos/emacs
* [`519402f4`](https://github.com/nix-community/emacs-overlay/commit/519402f40cb0ea2aa55e06f11c99784a172ad2a4) Updated repos/melpa
* [`e365c1b1`](https://github.com/nix-community/emacs-overlay/commit/e365c1b1d9e8f96967ae4934dad854b416069568) Updated repos/nongnu
* [`574d2e16`](https://github.com/nix-community/emacs-overlay/commit/574d2e166892c90b67326a710dc6c7d4b8d918d1) Updated repos/elpa
* [`184d6546`](https://github.com/nix-community/emacs-overlay/commit/184d6546730289883d4d1597139b0557f8c08db8) Updated repos/emacs
* [`9fab503d`](https://github.com/nix-community/emacs-overlay/commit/9fab503d5d690a5b3c006346f9837ed3c608908e) Updated repos/melpa
* [`89a45176`](https://github.com/nix-community/emacs-overlay/commit/89a45176df94b0e6985a8e7620b0551782d0d93d) Updated repos/elpa
* [`d153555e`](https://github.com/nix-community/emacs-overlay/commit/d153555ea6f4bd432cdb91f813929b4003fae49d) Updated repos/emacs
* [`62180668`](https://github.com/nix-community/emacs-overlay/commit/62180668ad617d98bbafc9468048b62f6808a13c) Updated repos/melpa
* [`afc9e622`](https://github.com/nix-community/emacs-overlay/commit/afc9e622611f8d53293184bec0397fe69431fb78) Updated repos/emacs
* [`0573574a`](https://github.com/nix-community/emacs-overlay/commit/0573574af28ce9f7113c73679fd328bb057ae759) Updated repos/melpa
* [`ce0c5e0d`](https://github.com/nix-community/emacs-overlay/commit/ce0c5e0de85f090a41412d8fe9c9b8126a7eb89f) Updated repos/emacs
* [`b8e24cec`](https://github.com/nix-community/emacs-overlay/commit/b8e24cec99ff68f8a875b6f842a10b6b2ab398d3) Updated repos/melpa
* [`301c54b9`](https://github.com/nix-community/emacs-overlay/commit/301c54b9c1b080cb818656a5ce3592ee5e347f05) Updated repos/elpa
* [`608a3146`](https://github.com/nix-community/emacs-overlay/commit/608a3146b2e170cd9b2272cf634d6e91f6ab1747) Updated repos/emacs
* [`d4f2658a`](https://github.com/nix-community/emacs-overlay/commit/d4f2658a2778a53be080a89a981059088e44889b) Updated repos/melpa
* [`4deb8259`](https://github.com/nix-community/emacs-overlay/commit/4deb8259b99eeabe4a4343c3ecb90c40d51d5d8a) Updated repos/nongnu
* [`9d3e3cf5`](https://github.com/nix-community/emacs-overlay/commit/9d3e3cf5330f7c280f50f1b16d9b7f117d9d7ed3) Updated repos/emacs
* [`3d7c61b6`](https://github.com/nix-community/emacs-overlay/commit/3d7c61b6dc5fc9d7c5e4a74e575c582aa567d547) Updated repos/melpa
* [`b50e9d52`](https://github.com/nix-community/emacs-overlay/commit/b50e9d5295af0b332a0faf8af0c0dd3e1cb4cc53) Updated repos/emacs
* [`ffc00124`](https://github.com/nix-community/emacs-overlay/commit/ffc00124f627fd5dec1d649555aa128b66ce6bc7) Updated repos/melpa
* [`1e8f0fa9`](https://github.com/nix-community/emacs-overlay/commit/1e8f0fa9ecdd024c0cba09b0eeca7d002bffddb1) Updated repos/emacs
* [`06a3e6d7`](https://github.com/nix-community/emacs-overlay/commit/06a3e6d7d9d40eb7351f2e70fda9b5f1461c56d0) Updated repos/melpa
* [`096fe0d5`](https://github.com/nix-community/emacs-overlay/commit/096fe0d58d13c8b600627c7445369b06f1816f4b) Updated repos/emacs
* [`94418315`](https://github.com/nix-community/emacs-overlay/commit/94418315592771cf69e380cf0f4eb78532410284) Updated repos/melpa
* [`e0e50591`](https://github.com/nix-community/emacs-overlay/commit/e0e505919ed5f3e92a3ed7319da0d13766a12e27) Updated repos/emacs
* [`ef5d67c5`](https://github.com/nix-community/emacs-overlay/commit/ef5d67c561a8b6ce001dbc555814fdb21c7bd5dd) Updated repos/melpa
* [`3ac83b37`](https://github.com/nix-community/emacs-overlay/commit/3ac83b37f7aa31c50b2e231322bb35ba81ed139d) Updated repos/elpa
* [`c498ad90`](https://github.com/nix-community/emacs-overlay/commit/c498ad9091a221b197c6887124fe3663c4d8820e) Updated repos/emacs
* [`bf945807`](https://github.com/nix-community/emacs-overlay/commit/bf94580785aa4b291f30d0f23345fa13fa50531d) Updated repos/melpa
* [`4bf8caf3`](https://github.com/nix-community/emacs-overlay/commit/4bf8caf3960ec720088711cc24a541b5180dd83f) Updated repos/nongnu
* [`49f234fe`](https://github.com/nix-community/emacs-overlay/commit/49f234feb36d10cfa31df6f00ae3c199433f28ee) Updated repos/emacs
* [`92c3c295`](https://github.com/nix-community/emacs-overlay/commit/92c3c295daea9e71578b2e4f0cbe9906013c1adc) Updated repos/melpa
* [`68677ad3`](https://github.com/nix-community/emacs-overlay/commit/68677ad3456455c0d50338111e46bfe248ce3561) Updated repos/melpa
* [`81ff5c1b`](https://github.com/nix-community/emacs-overlay/commit/81ff5c1bb6cfadbb35f05f71e441da7bc8089a59) Updated repos/emacs
* [`29b06fa3`](https://github.com/nix-community/emacs-overlay/commit/29b06fa38f6ab1669a4a9e580569da57b1650a45) Updated repos/melpa
* [`c3e508d7`](https://github.com/nix-community/emacs-overlay/commit/c3e508d7f6429e17283836350764d13ba564e391) Updated repos/nongnu
* [`deef17ed`](https://github.com/nix-community/emacs-overlay/commit/deef17ed2172013214167ed6a06c67f4f30c059e) Updated repos/emacs
* [`483c0162`](https://github.com/nix-community/emacs-overlay/commit/483c0162371d4a3e33c7f0dd83419c8645ed6db5) Updated repos/melpa
* [`5d838805`](https://github.com/nix-community/emacs-overlay/commit/5d838805ff6587d0b4eafae44c9ff74fc6beeca3) Updated repos/nongnu
* [`bba39bf9`](https://github.com/nix-community/emacs-overlay/commit/bba39bf9b2e5e616e4527a18e86f06f87608848d) Updated repos/emacs
* [`58d63216`](https://github.com/nix-community/emacs-overlay/commit/58d63216b84f9399db23048c537ee7c5d1842524) Updated repos/melpa
* [`120a9c83`](https://github.com/nix-community/emacs-overlay/commit/120a9c830d9605fc4dd4ef85120a09ce2ac07f38) Updated repos/emacs
* [`ca817b6f`](https://github.com/nix-community/emacs-overlay/commit/ca817b6f306f15ba8a8f3c1841acbf15a4375af1) Updated repos/melpa
* [`6ad04079`](https://github.com/nix-community/emacs-overlay/commit/6ad04079d54ca9ae6770dc72b51184537c8e768b) Updated repos/nongnu
* [`d13cb8a2`](https://github.com/nix-community/emacs-overlay/commit/d13cb8a200caa5bb2d78ef083179e96c340fd2da) Updated repos/melpa
* [`87099c47`](https://github.com/nix-community/emacs-overlay/commit/87099c473e76a499ee78fcc4cda9f7c0a88db0ca) Updated repos/nongnu
* [`e82a3411`](https://github.com/nix-community/emacs-overlay/commit/e82a341152b39cb1e12398abc799b1dc983047e5) Updated repos/elpa
* [`ccaceb6f`](https://github.com/nix-community/emacs-overlay/commit/ccaceb6fc03ff975843a699ced2c83dfe580bbc7) Updated repos/emacs
* [`90ba71c4`](https://github.com/nix-community/emacs-overlay/commit/90ba71c4d9f760a6463023c8e9f67093f0d65ae4) Updated repos/melpa
* [`0e7e0149`](https://github.com/nix-community/emacs-overlay/commit/0e7e0149d1ce872b09def88190b25d05e7fc3fdf) Updated repos/emacs
* [`53c8b2ca`](https://github.com/nix-community/emacs-overlay/commit/53c8b2cad2ded6cac3646b47d5898a172b9b3e8e) Updated repos/melpa
* [`67e25181`](https://github.com/nix-community/emacs-overlay/commit/67e2518161654552886a3eb6fbf9db35ac9df64f) Updated repos/nongnu
* [`737f27c6`](https://github.com/nix-community/emacs-overlay/commit/737f27c6571c125013888f458409a5ad465e78ca) Updated repos/emacs
* [`51fff9b2`](https://github.com/nix-community/emacs-overlay/commit/51fff9b287c92cb398839db4480b9ee19c0a98c6) Updated repos/melpa
* [`52b4a584`](https://github.com/nix-community/emacs-overlay/commit/52b4a58403f9103951631db70bcb740c8ca42a8d) Updated repos/nongnu
* [`994ccd9f`](https://github.com/nix-community/emacs-overlay/commit/994ccd9fc07aa20f5236d6d477c1d29be0fc4677) Updated repos/elpa
* [`1a1da13a`](https://github.com/nix-community/emacs-overlay/commit/1a1da13a5694c63750650bb78ba03032815aa58d) Updated repos/emacs
* [`4efda86f`](https://github.com/nix-community/emacs-overlay/commit/4efda86fd44a8fecf9d35dd47ab262b40ff79394) Updated repos/melpa
* [`dcb9b0d1`](https://github.com/nix-community/emacs-overlay/commit/dcb9b0d1d3fb45fd65a128a35fe4aa1e76c279e3) Updated repos/elpa
* [`fa938ece`](https://github.com/nix-community/emacs-overlay/commit/fa938ece18408d9c938c175f6f3ea4539d7f74c9) Updated repos/melpa
* [`cdaafbd7`](https://github.com/nix-community/emacs-overlay/commit/cdaafbd7700b461f13869610954014f317338600) Updated repos/nongnu
* [`0422f1e6`](https://github.com/nix-community/emacs-overlay/commit/0422f1e6cec711e75dd7a43710b86d4d6f9db992) Updated repos/emacs
* [`8c3e6c2f`](https://github.com/nix-community/emacs-overlay/commit/8c3e6c2f6bacda8f86e87207b8509ceaec7f5853) Updated repos/melpa
* [`8a7061d6`](https://github.com/nix-community/emacs-overlay/commit/8a7061d6d072c7d42ebad78fe7fb8c61bdaa286f) Updated repos/emacs
* [`b3f81bcb`](https://github.com/nix-community/emacs-overlay/commit/b3f81bcbda84bf2ef957cfff6cf89aedbdfa2be9) Updated repos/melpa
* [`921976d5`](https://github.com/nix-community/emacs-overlay/commit/921976d53781cf8c92b2ef26f3705c54b33f747f) Updated repos/elpa
* [`4201e102`](https://github.com/nix-community/emacs-overlay/commit/4201e10223f4d8654a131f48f2db9cfd9537a3bf) Updated repos/emacs
* [`f63a5f5f`](https://github.com/nix-community/emacs-overlay/commit/f63a5f5f3826318d19f2fdb896d235c4c95722e7) Updated repos/melpa
* [`a1ffca78`](https://github.com/nix-community/emacs-overlay/commit/a1ffca78cf018cf9078a015b268cf5b22dddb017) Updated repos/nongnu
* [`93250939`](https://github.com/nix-community/emacs-overlay/commit/932509390d4005f18725a30471ad84de85c4b018) Updated repos/emacs
* [`c5a67519`](https://github.com/nix-community/emacs-overlay/commit/c5a67519099ded10354a96c268a9bdef8087161d) Updated repos/melpa
* [`206b2ac5`](https://github.com/nix-community/emacs-overlay/commit/206b2ac5119038fdeb77961444bdf6e8386be11c) Updated repos/elpa
* [`74cc6c27`](https://github.com/nix-community/emacs-overlay/commit/74cc6c27d89cd5c2854432f1cfd135fc921d80f9) Updated repos/emacs
* [`87fd982e`](https://github.com/nix-community/emacs-overlay/commit/87fd982e510d78c7ed61df5a0e339fe57f858f87) Updated repos/melpa
* [`79ce2e59`](https://github.com/nix-community/emacs-overlay/commit/79ce2e59fc8da99cc9853dccbc4b446fad047676) Updated repos/elpa
* [`b05302d5`](https://github.com/nix-community/emacs-overlay/commit/b05302d56cdf4fe1e09bee58707e671ca8532784) Updated repos/emacs
* [`2891c0c1`](https://github.com/nix-community/emacs-overlay/commit/2891c0c12ad28fb24eafbce9a273553d3ef94def) Updated repos/melpa
* [`9675b4e1`](https://github.com/nix-community/emacs-overlay/commit/9675b4e1d86fe90d27f6b61b96e24a72b3f862bc) Updated repos/emacs
* [`feea89fb`](https://github.com/nix-community/emacs-overlay/commit/feea89fbc310afc87dff52ae0a1bc4afabfcbd43) Updated repos/melpa
* [`19f915a7`](https://github.com/nix-community/emacs-overlay/commit/19f915a726ae8dcd99e4a1b4cd76111f91914a61) Updated repos/elpa
* [`b52e5604`](https://github.com/nix-community/emacs-overlay/commit/b52e56040e56fec18d9da5f221b05e97429fde1c) Updated repos/emacs
* [`d078c99b`](https://github.com/nix-community/emacs-overlay/commit/d078c99b943d96fdffe831dfb9ea1cbfca57a357) Updated repos/melpa
* [`e8b9a442`](https://github.com/nix-community/emacs-overlay/commit/e8b9a442257fce8ad6282a634b82c3fc74a27775) Updated repos/elpa
* [`86928a52`](https://github.com/nix-community/emacs-overlay/commit/86928a5201089a30c0e3f59dd48c0fd29db1f53e) Updated repos/emacs
* [`9ec3de0f`](https://github.com/nix-community/emacs-overlay/commit/9ec3de0fef1399241be32a730385d6e738d6703b) Updated repos/melpa
* [`4a44c7df`](https://github.com/nix-community/emacs-overlay/commit/4a44c7dfdea3e794b25eae37773c9a89c4fb1526) Updated repos/nongnu
* [`ded9d24b`](https://github.com/nix-community/emacs-overlay/commit/ded9d24bcc29676fb75c66fd879e86be4f98382e) Updated repos/emacs
* [`dcc80577`](https://github.com/nix-community/emacs-overlay/commit/dcc8057790ff01b7d745123e61e037bf32c8c753) Updated repos/melpa
* [`2b63b968`](https://github.com/nix-community/emacs-overlay/commit/2b63b96857b5707d249afeccbd9ed393b4dca4b8) Updated repos/elpa
* [`ea41c1a2`](https://github.com/nix-community/emacs-overlay/commit/ea41c1a2973d87998ef9f6308a80cb02d1be11c7) Updated repos/emacs
* [`d5395935`](https://github.com/nix-community/emacs-overlay/commit/d53959356bf17656f82d90ab5d7346fb3107896f) Updated repos/melpa
* [`b19a04ef`](https://github.com/nix-community/emacs-overlay/commit/b19a04efef3d883c3c70ae1467c1c44596b16519) Updated repos/elpa
* [`7b44a070`](https://github.com/nix-community/emacs-overlay/commit/7b44a070e4957ae59ad37ae18a7e66ef23510500) Updated repos/emacs
* [`dd6b9bbc`](https://github.com/nix-community/emacs-overlay/commit/dd6b9bbc728b9eb1c53738cf64d067384dfa269a) Updated repos/melpa
* [`e541634b`](https://github.com/nix-community/emacs-overlay/commit/e541634ba14d3a04e52ca0af9735ccef0e10c271) Updated repos/emacs
* [`04e3051b`](https://github.com/nix-community/emacs-overlay/commit/04e3051b28ced95ffb63d6b5ee12da25d33a5760) Updated repos/melpa
* [`84217c53`](https://github.com/nix-community/emacs-overlay/commit/84217c538479607814bfeac188ab090d66a47083) Updated repos/nongnu
* [`7d7dee93`](https://github.com/nix-community/emacs-overlay/commit/7d7dee932bf72472a7bf8eba2707cfc7ffe629ab) Updated repos/elpa
* [`f63f2c63`](https://github.com/nix-community/emacs-overlay/commit/f63f2c63f3a50ab45a465c8983a7e77ff453e1b2) Updated repos/emacs
* [`eb10ed32`](https://github.com/nix-community/emacs-overlay/commit/eb10ed32ed3808545382c9509ef6ee46f3716804) Updated repos/melpa
* [`ff110333`](https://github.com/nix-community/emacs-overlay/commit/ff110333dae4e7d2999177ec21a50fd17b5c0efe) Updated repos/elpa
* [`46985e57`](https://github.com/nix-community/emacs-overlay/commit/46985e574492dca56e71b0e54c88e663dc068e6d) Updated repos/emacs
* [`562f03ce`](https://github.com/nix-community/emacs-overlay/commit/562f03ce976b536e7d0e3ebd3d169252832a0535) Updated repos/melpa
* [`cb7c1a56`](https://github.com/nix-community/emacs-overlay/commit/cb7c1a5695d398a4c11501073d67735a5f876388) Updated repos/nongnu
