### PR TITLE
niv spacemacs: update 264a8ffc -> cdf5045c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "264a8ffc203a3215623330576941d1722bbee1e4",
-        "sha256": "1a9366vij15l1bdwnh9f2w7x9yj02vkpwszyqqf0x3lw0bwph2h5",
+        "rev": "cdf5045cd8e27f7dfea1a56358e6e5772f4957f6",
+        "sha256": "15gzc7kpcbk61jib2smx6wwfy1bh5m782brgjnr1zawa8szya9xw",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/264a8ffc203a3215623330576941d1722bbee1e4.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/cdf5045cd8e27f7dfea1a56358e6e5772f4957f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@264a8ffc...cdf5045c](https://github.com/syl20bnr/spacemacs/compare/264a8ffc203a3215623330576941d1722bbee1e4...cdf5045cd8e27f7dfea1a56358e6e5772f4957f6)

* [`d2ca781a`](https://github.com/syl20bnr/spacemacs/commit/d2ca781a8d1f38a893f2b1466fbc04e36005a0fb) spacemacs-modeline: do not dependent on the neotree
* [`93058241`](https://github.com/syl20bnr/spacemacs/commit/93058241718d5e67b6f495b965028c563644abe3) core/core-configuration-layer: avoid loading the dependence layers
* [`ce0878c3`](https://github.com/syl20bnr/spacemacs/commit/ce0878c353633c9fddfb523e846340c28c17e908) layers/+spacemacs/spacemacs-editing: mark the string-edit to be :defer
* [`95c66b90`](https://github.com/syl20bnr/spacemacs/commit/95c66b9010175b42340541f5cc9983b21476753a) layers/+completion/helm: use default helm fuzzy function, not depend on the helm-flx
* [`b5e75bc6`](https://github.com/syl20bnr/spacemacs/commit/b5e75bc65f383a39fe3c090e3d6c6ab6d2f51df3) layers/+filetree/treemacs: fix the document for key bindings
* [`33743922`](https://github.com/syl20bnr/spacemacs/commit/33743922eb9386a81cc988bbf032bff44e95c128) Add support for multi-vterm
* [`13c5f04d`](https://github.com/syl20bnr/spacemacs/commit/13c5f04dc0edf9e5d5a2f283e33685bbf2154d0f) Added check that *scratch* buffer exists ([syl20bnr/spacemacs⁠#15742](https://togithub.com/syl20bnr/spacemacs/issues/15742))
* [`b9a52cca`](https://github.com/syl20bnr/spacemacs/commit/b9a52ccad3350cec02e07e99e85c9f8acff08cea) Create visual selection from transient paste ([syl20bnr/spacemacs⁠#15745](https://togithub.com/syl20bnr/spacemacs/issues/15745))
* [`c821b660`](https://github.com/syl20bnr/spacemacs/commit/c821b660c329f0299e6822dcc323743a400a7176) Add `shell-scripts-shfmt-args` variable
* [`b8882d07`](https://github.com/syl20bnr/spacemacs/commit/b8882d07416043217cf0b1f6c6f7ed56d452a42b) Fix problem with smartparens when expanding nested snippets
* [`7ec7d843`](https://github.com/syl20bnr/spacemacs/commit/7ec7d843e0fef7f41ccbcd2b1a04989abd9b74e3)  layers/*: remove quote inside the cl-case clauses
* [`323a7389`](https://github.com/syl20bnr/spacemacs/commit/323a7389676bbfa09eb1b8c32911d9283b037c5f) [bot] "documentation_updates" Wed Oct 19 20:20:14 UTC 2022
* [`cdf5045c`](https://github.com/syl20bnr/spacemacs/commit/cdf5045cd8e27f7dfea1a56358e6e5772f4957f6) Switch to maintained fork of evil-escape
