### PR TITLE
niv zsh-completions: update 10b46f92 -> b4ec85ed

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "10b46f923a81146d4ab45764ac1cba7d5fd958b2",
-        "sha256": "18djyiq2i3qcamdk9v3dn7cczxwx7hdmfk64vbb9gar0kx9vg66n",
+        "rev": "b4ec85ede711a4854542682d43c7ae47d7df6d35",
+        "sha256": "060krascgyjv0lwi855x2xqcgil0izpixp3mzkq8nl9l6l14bf82",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/10b46f923a81146d4ab45764ac1cba7d5fd958b2.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/b4ec85ede711a4854542682d43c7ae47d7df6d35.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@10b46f92...b4ec85ed](https://github.com/zsh-users/zsh-completions/compare/10b46f923a81146d4ab45764ac1cba7d5fd958b2...b4ec85ede711a4854542682d43c7ae47d7df6d35)

* [`79b34184`](https://github.com/zsh-users/zsh-completions/commit/79b3418462f77909929a91cc441c90154de2bf12) Update node.js completion to 19.0.0
* [`2dfe3ca2`](https://github.com/zsh-users/zsh-completions/commit/2dfe3ca220d178f45c17292f19a29fc7a488d433) Update tmuxp
* [`aedae136`](https://github.com/zsh-users/zsh-completions/commit/aedae136e7c265be2081de4b3dbe33c22a69b78f) Add fvm completion
