### PR TITLE
niv nixpkgs: update 06dd62f9 -> 54cf191a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "06dd62f9b49f77cb1f757953ff0c1ded85c0a7bf",
-        "sha256": "02jk2xiq77afmqnksjh9ni53ihsn9m7ivm4w1bm13l41z8fz11gh",
+        "rev": "54cf191a16f67d4904dacdce8a6722dfc86fe42a",
+        "sha256": "1kfydc6j5zpljivjfj7kb7ywabycgn1h7r6bx4dd84p05dyw3q6k",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/06dd62f9b49f77cb1f757953ff0c1ded85c0a7bf.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/54cf191a16f67d4904dacdce8a6722dfc86fe42a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@06dd62f9...54cf191a](https://github.com/nixos/nixpkgs/compare/06dd62f9b49f77cb1f757953ff0c1ded85c0a7bf...54cf191a16f67d4904dacdce8a6722dfc86fe42a)

* [`488aa85c`](https://github.com/NixOS/nixpkgs/commit/488aa85ca13ac6d432838cd2aca89351abd34978) Increase override priority for DeviceAllow
* [`30ff3e31`](https://github.com/NixOS/nixpkgs/commit/30ff3e31460f1220dfeed0048e5a9f78a32c762d) schemaspy: 6.1.0 -> dev
* [`5a9b7f45`](https://github.com/NixOS/nixpkgs/commit/5a9b7f45146fce474fce41536502c59c2fe3e1a1) nixos/portunus: fix typo in option usage
* [`836505de`](https://github.com/NixOS/nixpkgs/commit/836505dee4a27ce850cfff33ac083b6d1ad70503) nixos/portunus: fix specification of client secret
* [`8b7b2d42`](https://github.com/NixOS/nixpkgs/commit/8b7b2d42c187f7f46225b4ebc6aeb00a776799ae) python310Packages.mypy-protobuf: 3.2.0 -> 3.3.0
* [`31161d2f`](https://github.com/NixOS/nixpkgs/commit/31161d2fd2f7b33b077c46c171e1bd26a6420384) cemu-ti: 1.3 -> unstable-2022-06-29
* [`ed528b1c`](https://github.com/NixOS/nixpkgs/commit/ed528b1c44740615f41c728d2d5dfe5ae5a1cf18) yabai: 3.3.10 -> 4.0.2
* [`1b8e3d4d`](https://github.com/NixOS/nixpkgs/commit/1b8e3d4dbced5223031072bb1cb271a9c0184e6a) yabai: 3.3.10 -> 4.0.4
* [`22bb5607`](https://github.com/NixOS/nixpkgs/commit/22bb5607ed8060cbae0190f205ee3eb5a8431875) cocogitto: refactor to use libgit2
* [`86025fbd`](https://github.com/NixOS/nixpkgs/commit/86025fbdb82f7fee1813b5c2a05e271a83432871) axel: add $out/share/doc/axelrc.example
* [`895ee26c`](https://github.com/NixOS/nixpkgs/commit/895ee26c05434809cc6dbe1d0d7a8d8ac5c58795) python310Packages.azure-identity: 1.10.0 -> 1.11.0
* [`b8ac53c7`](https://github.com/NixOS/nixpkgs/commit/b8ac53c772b198c1d6de20ea4e67084edca6f2b0) atlassian-confluence: 7.18.1 -> 7.19.1
* [`2ee08ee5`](https://github.com/NixOS/nixpkgs/commit/2ee08ee585215d7cfbb7332c2aacf7279e7aaf6c) atlassian-bamboo: 8.1.4 -> 8.2.6
* [`45496e43`](https://github.com/NixOS/nixpkgs/commit/45496e434c30d5ce32c94c83c773694f1b301e0d) aws-crt-cpp: 0.17.32 -> 0.18.7
* [`3eb83269`](https://github.com/NixOS/nixpkgs/commit/3eb83269ecef33a8874da777b9b9dcca86825bfd) inav-configurator: 4.1.0 -> 5.1.0
* [`cae93dfd`](https://github.com/NixOS/nixpkgs/commit/cae93dfd54b6d05cc85c7fea038e3982700562cb) pacman: set PATH in compress.sh
* [`eccbe141`](https://github.com/NixOS/nixpkgs/commit/eccbe1413dd2c5776f6fc959bb4a3ceb99afa5a7) openapi-generator-cli: 6.1.0 -> 6.2.0
* [`9296ad07`](https://github.com/NixOS/nixpkgs/commit/9296ad0724eee0e4ebe3d32bfac8e0fb50092a16) tpm2-tools: 5.2 -> 5.3
* [`6ed59cb1`](https://github.com/NixOS/nixpkgs/commit/6ed59cb1f4c09287c369c76585e0ad8d0d6aa54c) watchmate: init at 0.3.0
* [`9dfe5c15`](https://github.com/NixOS/nixpkgs/commit/9dfe5c15cec10a329b6186174bddc08acd87aaa7) rubberband: 3.0.0 -> 3.1.0
* [`60908ec0`](https://github.com/NixOS/nixpkgs/commit/60908ec03f8a4dde4ee87ea02c0e10ac4df5f200) aws-c-common: 0.7.4 -> 0.8.2
* [`a4995b6f`](https://github.com/NixOS/nixpkgs/commit/a4995b6f0a9817e74a95005feba10c1f225ffc13) nixos/polkit: Add debug option
* [`a7fed3ac`](https://github.com/NixOS/nixpkgs/commit/a7fed3ac1e7180aa8590277aaa1c166540a99636) whitebophir: 1.17.0 -> 1.19.0
* [`7994821a`](https://github.com/NixOS/nixpkgs/commit/7994821acc7990b05c63aa75535caa2b8f6ab015) python3Packages.ezxdf: 0.12 -> 0.18.1
* [`47324bf9`](https://github.com/NixOS/nixpkgs/commit/47324bf9644095836459fc8715f0085698dc030f) python3Packages.wxPython_4_0: propagate six
* [`c4c7f4d7`](https://github.com/NixOS/nixpkgs/commit/c4c7f4d700612cdeece46869e31c9945039ba950) python3Packages.wxPython_4_1: propagate six
* [`838cdc75`](https://github.com/NixOS/nixpkgs/commit/838cdc756057f117116d338b40b92fecfadf6fc1) python3Packages.wxPython_4_2: init at 4.2.0
* [`446a718d`](https://github.com/NixOS/nixpkgs/commit/446a718d13088aea9e15503f04e56d5f868ed91c) meerk40t: init at 0.8.0031
* [`c738c193`](https://github.com/NixOS/nixpkgs/commit/c738c193b2b16b57da4f97dba778c5af7b3c4fd1) qpdf: 11.1.0 -> 11.1.1
* [`adfb6598`](https://github.com/NixOS/nixpkgs/commit/adfb6598af79447fb7e0ed64a3b857be7afff734) sil-q: use .sil-q to avoid clashing with sil's data
* [`4db70611`](https://github.com/NixOS/nixpkgs/commit/4db7061162a10c7b4ec7cbe4bf07234f3c68ce3a) Sort the /etc/.clean file
* [`b88ab6f6`](https://github.com/NixOS/nixpkgs/commit/b88ab6f620c9328a75e391856d326d2b9bc493a6) pahole: 1.23 -> 1.24
* [`a5a10110`](https://github.com/NixOS/nixpkgs/commit/a5a10110be2c4e6f471627421bec626444991d60) protoscope: init at unstable-2022-08-01
* [`49c4a6d6`](https://github.com/NixOS/nixpkgs/commit/49c4a6d6021a29e862383bf678d34fba7def9a83) nixos/getty: mkdefault for etc/issue
* [`e10848c3`](https://github.com/NixOS/nixpkgs/commit/e10848c39bf74c8638f2a715d72f362f599b0e88) maestral-qt: 1.5.3 -> 1.6.3
* [`b68afa85`](https://github.com/NixOS/nixpkgs/commit/b68afa8569dc3fac0f54bd300da93916fdb5715a) prometheus-postfix-exporter: 0.1.2 -> 0.3.0
* [`78cae51b`](https://github.com/NixOS/nixpkgs/commit/78cae51b62dba89d8c2c49939b732cc2dbaaf84d) dmenu: 5.1 -> 5.2
* [`2e4b12ae`](https://github.com/NixOS/nixpkgs/commit/2e4b12aefe8ece59780581cdc06eab12e9220140) python310Packages.add-trailing-comma: 2.2.3 -> 2.3.0
* [`fd9350b6`](https://github.com/NixOS/nixpkgs/commit/fd9350b60278c82b1e465bb78443b18c78be19e8) cppzmq: 4.8.1 -> 4.9.0
* [`eb9f3bd1`](https://github.com/NixOS/nixpkgs/commit/eb9f3bd1b08c38135c239f465a9cd5433ab9a6bf) RestSharp: 105.2.3 -> 106.12.0
* [`4a90d82f`](https://github.com/NixOS/nixpkgs/commit/4a90d82f1ac1ba3f4cea71273a92e9c820777067) cqrlog: switch from mysql57 to mariadb
* [`44cbcce4`](https://github.com/NixOS/nixpkgs/commit/44cbcce4123eb5a539842d53b82fcca7b5c3fdcd) dspam: switch from mysql57 to mariadb-connector-c
* [`9517864e`](https://github.com/NixOS/nixpkgs/commit/9517864e93f760e6ac56f114b73ecdcbb1db87db) mariadb-embedded: add override to enable building libmysqld.so
* [`8b30afdd`](https://github.com/NixOS/nixpkgs/commit/8b30afdd78c761bfeb92a6509b4fad2ad1461f75) mariadb: move callPackage down one layer to preserve .override
* [`7218edb9`](https://github.com/NixOS/nixpkgs/commit/7218edb94a28680f433e6ebd14ed98c252a06a76) amarok: switch form mysql57 to mariadb-embedded
* [`0edf1ffc`](https://github.com/NixOS/nixpkgs/commit/0edf1ffc3f236488baa4c09e564923c2c99322c6) mysql-workbench: switch from mysql57 to mysql80
* [`a5c92909`](https://github.com/NixOS/nixpkgs/commit/a5c9290979cc03b30284f02e7002a35f2c609cd1) mysql57: drop
* [`0d6d7a1f`](https://github.com/NixOS/nixpkgs/commit/0d6d7a1fc1b7441ce5f6e00f8446083bf8ea5b23) release-notes: update release notes about mysql57 drop
* [`1cfac7d2`](https://github.com/NixOS/nixpkgs/commit/1cfac7d2bc779771e647c3bb888fc565d2c3feb4) legendary-gl: use latest python
* [`ee408d3a`](https://github.com/NixOS/nixpkgs/commit/ee408d3a022b3b4c1a466c0956eaa96be9d2ac66) btrfs-progs: 5.19.1 -> 6.0
* [`75b49c1f`](https://github.com/NixOS/nixpkgs/commit/75b49c1fcadab17c2bcbae03c81b775b389586a1) wxGTK30: refactor
* [`5fb1244d`](https://github.com/NixOS/nixpkgs/commit/5fb1244dcf7cbbac02fbf6b0bd8b2365f53622ed) python3Packages.wxPython_4_0: fix build on aarch64-darwin
* [`35892425`](https://github.com/NixOS/nixpkgs/commit/35892425f21f5d0519ff2b0300e90e97987bcb79) python310Packages.Rtree: 1.0.0 -> 1.0.1
* [`36019e61`](https://github.com/NixOS/nixpkgs/commit/36019e6120219339b9921977548eeb7521f81893) antlr4_11: init
* [`35dd06d6`](https://github.com/NixOS/nixpkgs/commit/35dd06d6e75b689108724064e33943e44c2069b6) antlr4_8, antlr4_9, antlr4_11: refactor definition
* [`fec2375d`](https://github.com/NixOS/nixpkgs/commit/fec2375d1ac0d9babaf47e458b6fbd2c7aeed58d) immudb: 1.3.2 -> 1.4.0
* [`8e5adfe9`](https://github.com/NixOS/nixpkgs/commit/8e5adfe988bb2a4c5fa860a3c8bef68eda322e31) aws-c-http: 0.6.20 -> 0.6.22
* [`ff1e32d8`](https://github.com/NixOS/nixpkgs/commit/ff1e32d81d4caf081e7d3657077c815477407d9b) aws-c-event-stream: 0.2.14 -> 0.2.15
* [`9fe967f9`](https://github.com/NixOS/nixpkgs/commit/9fe967f934f767cfc41864c38cfa26dbc24f07e4) workrave: 1.10.31 -> 1.10.50
* [`aa3e25f1`](https://github.com/NixOS/nixpkgs/commit/aa3e25f1a6a6a98645b1a5467462b62a2e65d2a6) libsForQt5.bismuth: 3.1.3 -> 3.1.4
* [`8231febc`](https://github.com/NixOS/nixpkgs/commit/8231febc5d5094e9efa3c32e875ddbc8aa5759e6) Apache Kafka upgrade to 3.x
* [`e55474ec`](https://github.com/NixOS/nixpkgs/commit/e55474ecc3e594de41f7696e8b537ffff5353e81) requested review changes, and kafka 3.3
* [`fcf5df8a`](https://github.com/NixOS/nixpkgs/commit/fcf5df8aadb4763bad6286eb8cb016c4b171ab47) update hashes for new versions
* [`63034f74`](https://github.com/NixOS/nixpkgs/commit/63034f742d8a45f71839a5ceb8feb946473c95f0) guile-ssh: 0.15.1 -> 0.16.0
* [`011a4df1`](https://github.com/NixOS/nixpkgs/commit/011a4df13bf4312a450fa44308ebad738e646583) gocd-agent: 19.3.0 -> 22.2.0
* [`4f54ef20`](https://github.com/NixOS/nixpkgs/commit/4f54ef201d889572f86fad3ad571d7962ba1904d) gocd-server: 19.3.0 -> 22.2.0
* [`5d8650e3`](https://github.com/NixOS/nixpkgs/commit/5d8650e38dabf52b2f845f90c1f30aa35d699412) gocd-server: add nixos test to passthru.tests
* [`2296727a`](https://github.com/NixOS/nixpkgs/commit/2296727a58c0e216aae0cb55c871df2d24675f78) gocd-agent, gocd-server: set sourceProvenance
* [`f5db8779`](https://github.com/NixOS/nixpkgs/commit/f5db877954c6839a2de43b3e2a4f70f0836fad3b) android-tools: add patch to fix build against 6.0 kernel headers
* [`fa12c2b4`](https://github.com/NixOS/nixpkgs/commit/fa12c2b481cf5688057126597a1f53dabcba8de4) etebase-server: 0.9.1 -> 0.10.0
* [`56616ba3`](https://github.com/NixOS/nixpkgs/commit/56616ba336b7678145bd87bf1b1e8e258d0b5f1c) haskellPackages: stackage LTS 19.27 -> LTS 19.28
* [`ff736687`](https://github.com/NixOS/nixpkgs/commit/ff736687d8f2d4428cf0a9ff69df79ada62942c0) all-cabal-hashes: 2022-10-05T14:24:18Z -> 2022-10-11T19:16:50Z
* [`43385443`](https://github.com/NixOS/nixpkgs/commit/433854432c04d2defedb9c1383e555f1e2b5ff8f) haskellPackages: regenerate package set based on current config
* [`bf32c053`](https://github.com/NixOS/nixpkgs/commit/bf32c0534e78c3ba3e3ac6a8d6ebea2670f13663) haskellPackages.colourista: remove no longer needed doJailbreak
* [`42cc7c14`](https://github.com/NixOS/nixpkgs/commit/42cc7c146684fb513f7f7ca8c9979ea367a382f4) passky-desktop: 5.0.0 -> 7.1.0
* [`9310061a`](https://github.com/NixOS/nixpkgs/commit/9310061a5bfb9f8c7fbbffb246c087f73b03fe3f) nusmv: init at 2.6.0
* [`117119f9`](https://github.com/NixOS/nixpkgs/commit/117119f96fdb892c09a60cfe8e619c6789da1eaa) build2.bootstrap: 0.14.0 -> 0.15.0
* [`f74d48e5`](https://github.com/NixOS/nixpkgs/commit/f74d48e53a36fa2a5b210789c61b67660274e0ab) libbutl: 0.14.0 -> 0.15.0
* [`6154d63d`](https://github.com/NixOS/nixpkgs/commit/6154d63d4c16f877bc433ba27872328ccd843f96) nix-store-gcs-proxy: use buildGoModule
* [`99a8919f`](https://github.com/NixOS/nixpkgs/commit/99a8919f91a74cd0a8e2635612e65f22a44d1b79) aws-c-cal: 0.5.19 -> 0.5.20
* [`85d72284`](https://github.com/NixOS/nixpkgs/commit/85d72284df36258cebb95d6599e56393cb20b1e6) asn2quickder: 1.3.0 -> 1.7.1
* [`ceee8090`](https://github.com/NixOS/nixpkgs/commit/ceee8090d1d0bf3561ab3a58e77f5c3970e8a8a3) qemu: add patch for CVE-2022-3165
* [`8eabf7a6`](https://github.com/NixOS/nixpkgs/commit/8eabf7a637809ac9e5f7c7f1e45c1921d3ea41dc) percona-xtrabackup_*: fix version test, cleanup
* [`213e8e92`](https://github.com/NixOS/nixpkgs/commit/213e8e9224be6555c460067ad75a4ffc1d319197) percona-xtrabackup_8_0: 8.0.13 -> 8.0.29-22
* [`4b32f379`](https://github.com/NixOS/nixpkgs/commit/4b32f3795e9f38cd12f8606e0ac01b18fb9f08fe) percona-xtrabackup_2_4: 2.4.20 -> 2.4.26
* [`2b138fed`](https://github.com/NixOS/nixpkgs/commit/2b138fed5b545770f8febe5619aed101c50ead5c) oras: 0.14.1 -> 0.15.1
* [`a53978e3`](https://github.com/NixOS/nixpkgs/commit/a53978e38ea4517442a6e36cb6067439639dc814) python310Packages.fiona: 1.8.21 -> 1.8.22
* [`02408545`](https://github.com/NixOS/nixpkgs/commit/024085452c9824503f64be880835821c23f320b9) build2: 0.14.0 -> 0.15.0
* [`434aa9f6`](https://github.com/NixOS/nixpkgs/commit/434aa9f6d26d8d3e950ae15bd58bbb35efd70b8a) libbpkg: 0.14.0 -> 0.15.0
* [`45330e6b`](https://github.com/NixOS/nixpkgs/commit/45330e6bad8f4c60247c20b93a560955c00a0efb) libodb: 2.5.0-b.21 -> 2.5.0-b.23
* [`dedd41a5`](https://github.com/NixOS/nixpkgs/commit/dedd41a5fc56feaf64cfdb271eb8208e416ce38b) libodb-sqlite: 2.5.0-b.21 -> 2.5.0-b.23
* [`b499b5a5`](https://github.com/NixOS/nixpkgs/commit/b499b5a5d066b00bbd0d77870b19132579cc9206) bpkg: 0.14.0 -> 0.15.0
* [`37806ebf`](https://github.com/NixOS/nixpkgs/commit/37806ebf308d646ed8d0007bdf474d766b4d40a9) bdep: 0.14.0 -> 0.15.0
* [`6acda25a`](https://github.com/NixOS/nixpkgs/commit/6acda25af6a6570ca18fe826e2c1ab0e2d4022d4) bpkg: add postInstall rpath fixup needed on darwin
* [`7da4a238`](https://github.com/NixOS/nixpkgs/commit/7da4a238ecbc404a8bfd31708d3671fc118526c5) rmapi: 0.0.21 -> 0.0.22.1
* [`d446a8f9`](https://github.com/NixOS/nixpkgs/commit/d446a8f913087a110f692e910f7587138f0e934b) plover: remove python27Packages
* [`c4b8f31f`](https://github.com/NixOS/nixpkgs/commit/c4b8f31fcb83898299423af34a926adf1fb58a86) circleci-cli: 0.1.21812 -> 0.1.22322
* [`46142236`](https://github.com/NixOS/nixpkgs/commit/46142236d9f80d7328fa50ee31f9535701a0c225) wire-desktop: linux 3.28.2946 -> 3.29.2997
* [`aa3e6347`](https://github.com/NixOS/nixpkgs/commit/aa3e6347fc46c5498019823f7df189438ff05638) wire-desktop: mac 3.28.4393 -> 3.29.4477
* [`4e6324b4`](https://github.com/NixOS/nixpkgs/commit/4e6324b414fbd1edda5b9ba369b76eacbd7eaae5) jujutsu: 0.4.0 -> 0.5.1
* [`7e9745d8`](https://github.com/NixOS/nixpkgs/commit/7e9745d879cbff4e7e0c1b52024b661fe0216535) flintlock: 0.3.0 -> 0.4.0
* [`f4ccaa51`](https://github.com/NixOS/nixpkgs/commit/f4ccaa51e00d1fa9dde060a90e4b721ddbe5024a) nixos/containers: support nixpkgs.hostPlatform
* [`d442c160`](https://github.com/NixOS/nixpkgs/commit/d442c160dcc3884b6869980af604b5fe0813c67e) python310Packages.geventhttpclient: 2.0.2 -> 2.0.8
* [`585c6be9`](https://github.com/NixOS/nixpkgs/commit/585c6be99461b6e56f15455a994291e366ba03e5) pscale: 0.115.0 -> 0.122.0
* [`1ef31a55`](https://github.com/NixOS/nixpkgs/commit/1ef31a5586fb26ee3be328c41724c48b58f50504) stratisd: 3.2.2 -> 3.3.0
* [`36948f3c`](https://github.com/NixOS/nixpkgs/commit/36948f3c65496d39c99cb8ef0e84c12265754a6c) stratis-cli: 3.2.0 -> 3.3.0
* [`a195a65e`](https://github.com/NixOS/nixpkgs/commit/a195a65efe8fd561c256eaea2c9c2076f8ce4220) antlr4_10: init
* [`b0827a60`](https://github.com/NixOS/nixpkgs/commit/b0827a60c0ee58daacdef0770abd175b6e6350f5) CODEOWNERS: Add myself for kea-exporter module
* [`c1e7bd7f`](https://github.com/NixOS/nixpkgs/commit/c1e7bd7fa0e14fce7cf4847eb8fef2b21f73bff8) cider: 1.5.6 -> 1.5.7
* [`54170bdb`](https://github.com/NixOS/nixpkgs/commit/54170bdb1c86951560e5d031abbf13c57c734f83) haskellPackages.http-client-websockets: unbreak
* [`edad2ee5`](https://github.com/NixOS/nixpkgs/commit/edad2ee58cfe3ce74edc7821beb67ca70a9763d9) moltenvk: 1.1.11 -> 1.2.0
* [`bae32f7c`](https://github.com/NixOS/nixpkgs/commit/bae32f7c87e8596c8d2923d301e082ead967d820) haskellPackages.binsm: unbreak
* [`12821d19`](https://github.com/NixOS/nixpkgs/commit/12821d191e300b974d3954154fdc2a5a5c443e9b) haskellPackages.copilot-c99: unbreak
* [`8e5422d2`](https://github.com/NixOS/nixpkgs/commit/8e5422d2460610122d29a6d25280fb76889c7d2a) haskellPackages.data-compat: unbreak
* [`2815fdc6`](https://github.com/NixOS/nixpkgs/commit/2815fdc6f1df5f393855f46fed5e536387d3ea59) haskellPackages.scotty-form: unbreak
* [`cd79af49`](https://github.com/NixOS/nixpkgs/commit/cd79af496804bb34c8c7bbae079329fa605e4d35) haskellPackages.uuid-bytes: unbreak
* [`0717d94c`](https://github.com/NixOS/nixpkgs/commit/0717d94ccfa989d9dda322c0c590f4e9e710c0dd) haskellPackages.vado: unbreak
* [`536e8c55`](https://github.com/NixOS/nixpkgs/commit/536e8c558eb7c5ce7d7b3a8bf1500f40a4cfcb5f) ncnn: fix build
* [`252f131e`](https://github.com/NixOS/nixpkgs/commit/252f131e67e0c296f3cb5a2ee172e720fe1f4143) realesrgan-ncnn-vulkan: fix build
* [`fd81adec`](https://github.com/NixOS/nixpkgs/commit/fd81adec4a5baba3286e64c3c9824690ce9cb5b4) diffoscope: 223 -> 224
* [`23511ff5`](https://github.com/NixOS/nixpkgs/commit/23511ff5b64143dfc1f60313f3eb6842fe3d9b37) mysql80: 8.0.30 -> 8.0.31
* [`27f0b039`](https://github.com/NixOS/nixpkgs/commit/27f0b03926b1cf67256d5279b7388dbd60ff8fa9) urdfdom-headers: 1.0.5 -> 1.1.0
* [`14b63e7d`](https://github.com/NixOS/nixpkgs/commit/14b63e7daa38d2a8faca736d170eec6e9c2f5d5e) woodpecker: 0.15.3 -> 0.15.5
* [`4aaf5378`](https://github.com/NixOS/nixpkgs/commit/4aaf5378d8bd4b94d80d112669d81a7d28c2e04e) kaldi: fix build on darwin
* [`351632dd`](https://github.com/NixOS/nixpkgs/commit/351632dd32a303908311ceaa30894426ebe452a8) open-stage-control: turn on strictDeps and add updateScript
* [`2499446e`](https://github.com/NixOS/nixpkgs/commit/2499446e9ececdfd25b1d4962c3b62f05940834f) coldsnap: init at 0.4.2
* [`cdfb740b`](https://github.com/NixOS/nixpkgs/commit/cdfb740bc4aa5e926be05bc49c5382abc87dafb4) qownnotes: 22.9.2 -> 22.10.2
* [`f19bcee3`](https://github.com/NixOS/nixpkgs/commit/f19bcee3763151c1401ffa5a05384a0581b1ff3e) webp-pixbuf-loader: Adopt by GNOME
* [`4fb7c5fd`](https://github.com/NixOS/nixpkgs/commit/4fb7c5fd58b363414383b8d16936a08172459583) gnome.nautilus: Support thumbnailing WebP files
* [`c789af60`](https://github.com/NixOS/nixpkgs/commit/c789af60650f3f0f83f7dd0457802283430fa10a) gnome._gdkPixbufCacheBuilder_DO_NOT_USE: Extract from nixos/gdk-pixbuf
* [`7140875a`](https://github.com/NixOS/nixpkgs/commit/7140875a66167240d502ff2205fd67892417fda8) xdg-desktop-portal-gnome: Support WebP files
* [`e674c5bd`](https://github.com/NixOS/nixpkgs/commit/e674c5bd2a85e3765edf41b8f381137d9d2d45be) gnome.gnome-shell: Support WebP files
* [`b6804f78`](https://github.com/NixOS/nixpkgs/commit/b6804f78b76016eaddf1026ad918ed8db9175884) gnome.gnome-control-center: Support WebP files
* [`a8e19491`](https://github.com/NixOS/nixpkgs/commit/a8e19491ddee91c4885e0c3282c0f6448ad023b6) gnome.eog: Support WebP files
* [`63b25b50`](https://github.com/NixOS/nixpkgs/commit/63b25b50b9059cf0fe84a684e7f6b11c1528847c) caerbannog: fix launching
* [`f86d8fc2`](https://github.com/NixOS/nixpkgs/commit/f86d8fc24f2c3f32e9585c67dac1760f1fc64637) mojave-gtk-theme: 2022-06-07 -> 2022-10-21
* [`9e99c019`](https://github.com/NixOS/nixpkgs/commit/9e99c0195db854285e11af1c99c17fd503c1bd19) gnome.nixos-gsettings-overrides: Ensure the settings are not overwritten
* [`4c116b77`](https://github.com/NixOS/nixpkgs/commit/4c116b77c7bbc36d4c7ec66c7aa4c4007306c2f3) cxxtest: use python3
* [`3bb69836`](https://github.com/NixOS/nixpkgs/commit/3bb69836cb478b7c899684915a96e4af312d3c05) nixos/profiles/minimal: don't install freedesktop files
* [`6674d1f4`](https://github.com/NixOS/nixpkgs/commit/6674d1f42002ddbbffaa9d8a63bb2f2dbd0af342) ncdu: fix cpu impurity
* [`9ae845e3`](https://github.com/NixOS/nixpkgs/commit/9ae845e3bf139905fedc55e629a127937f34ef80) touchosc: add updateScript
* [`6e8a52e8`](https://github.com/NixOS/nixpkgs/commit/6e8a52e8b6c68bfc94adaa619c5f3037fac1b643) touchosc: 1.1.5.145 → 1.1.6.150
* [`f948d141`](https://github.com/NixOS/nixpkgs/commit/f948d14139f45ebe2cc07a4f9ab1a8f2b8349d5d) manticoresearch: init at 5.0.3
* [`02a56e37`](https://github.com/NixOS/nixpkgs/commit/02a56e375f070dcb1ec8bdbc6cd84a59fa19db05) maintainers: add jdelStrother
* [`6d7fbc78`](https://github.com/NixOS/nixpkgs/commit/6d7fbc7887a1a122ac003a6f88be002b061f5f49) snappymail: 2.18.6 -> 2.19.2
* [`08aaa97b`](https://github.com/NixOS/nixpkgs/commit/08aaa97b1e1b7f82d7994b8714aa57036890f199) gummy: 0.2 -> 0.3
* [`a255c43f`](https://github.com/NixOS/nixpkgs/commit/a255c43f4437c695b8406f03678b331bda6151e9) nixos/kubo: convert to RFC42-style settings
* [`07b3eb7c`](https://github.com/NixOS/nixpkgs/commit/07b3eb7c6b2d74e5ff7c3a7517ab9c0fc7c7f685) lifecycled: 3.2.0 -> 3.3.0
* [`08ac27cd`](https://github.com/NixOS/nixpkgs/commit/08ac27cd9afb55df4526f5b3e6b2c3f99ead2850) nordzy-icon-theme: 1.7 -> 1.7.3
* [`fa7d5ddf`](https://github.com/NixOS/nixpkgs/commit/fa7d5ddf9279f549ef2afd6035be4276133e2942) onlyoffice-documentserver: 7.2.0 -> 7.2.1
* [`22c53756`](https://github.com/NixOS/nixpkgs/commit/22c53756ffd666fd052f448d8cbf5ad411df1778) scaleway-cli: 2.6.0 -> 2.6.1
* [`2cf27dbe`](https://github.com/NixOS/nixpkgs/commit/2cf27dbed8059c3f5398c558910c74a12174c7de) luau: init at 0.550
* [`98b114ee`](https://github.com/NixOS/nixpkgs/commit/98b114eee2bd625d3172724ca68ae988774b1360) antlr4: simplify package definitions
* [`83b0d09f`](https://github.com/NixOS/nixpkgs/commit/83b0d09f1c0988883af87a3e469c51d1a6c12444) antlr4: remove redundant settings
* [`705e150b`](https://github.com/NixOS/nixpkgs/commit/705e150b600fb56273b3479bb3265533d687fd2f) jitsi: fix update scripts
* [`3e617311`](https://github.com/NixOS/nixpkgs/commit/3e6173115684d710550af0b1d9b59a8d602bf52f) dendrite: 0.10.3 -> 0.10.4
* [`591fd945`](https://github.com/NixOS/nixpkgs/commit/591fd945b2f20a98696c16409a3c6103dfa6f948) evolution-data-server: 3.46.0 → 3.46.1
* [`c9249676`](https://github.com/NixOS/nixpkgs/commit/c9249676868451f30f59bc0d0dbd650f5e08f5d2) evolution: 3.46.0 → 3.46.1
* [`beb72269`](https://github.com/NixOS/nixpkgs/commit/beb72269160030d0290cf0f5a1bb3c8fe1e159f3) evolution-ews: 3.46.0 → 3.46.1
* [`04c83422`](https://github.com/NixOS/nixpkgs/commit/04c8342237e77835968bb8cf1b94796a1eee9ade) gnome.gnome-calendar: 43.0 → 43.1
* [`f3faf1a6`](https://github.com/NixOS/nixpkgs/commit/f3faf1a6ba4ccf861230b560102628e2579f92e3) gnome.gnome-control-center: 43.0 → 43.1
* [`c3491bec`](https://github.com/NixOS/nixpkgs/commit/c3491bec6acee71ed593f5990a558a3d03c01266) gnome.gnome-initial-setup: 43.0 → 43.1
* [`90649d15`](https://github.com/NixOS/nixpkgs/commit/90649d153cc203acd48ac6eac8c0478fe495f941) gnome.gnome-maps: 43.0 → 43.1
* [`dad58286`](https://github.com/NixOS/nixpkgs/commit/dad58286f9d1bb4dadcf7808e292d816573099cb) gnome.gnome-software: 43.0 → 43.1
* [`eee72ead`](https://github.com/NixOS/nixpkgs/commit/eee72ead3ac1abb0cbf5f2435c008f19ff10d881) libshumate: 1.0.1 → 1.0.2
* [`511468c3`](https://github.com/NixOS/nixpkgs/commit/511468c36cf68f3848fa732056a46cdc2acf8d28) xdg-desktop-portal-gnome: 43.0 → 43.1
* [`a7f6c1dd`](https://github.com/NixOS/nixpkgs/commit/a7f6c1dd96e2fccc5055dfe2568dd6381ab245e7) prismlauncher: pass -DLauncher_QT_VERSION_MAJOR=6 on qt6, add qtsvg dep for icons
* [`2a4f267c`](https://github.com/NixOS/nixpkgs/commit/2a4f267ce4f61c9292f5fc6e612321be9df2c33a) prismlauncher,prismlauncher-qt5: add separate qt5 and qt6 aliases
* [`98074f31`](https://github.com/NixOS/nixpkgs/commit/98074f31c4a8b11b5dc95a56213a97c0cfcdc991) gurk-rs: 0.2.4 -> 0.2.5
* [`0955cf63`](https://github.com/NixOS/nixpkgs/commit/0955cf639bc6b583dafe0b119bbca6719c853cdc) jwm: 2.4.2 -> 2.4.3
* [`8c8e4f10`](https://github.com/NixOS/nixpkgs/commit/8c8e4f10a6ed6131633103d3519ccf7c909d5f74) virtualglLib: 2.6.5 -> 3.0.2
* [`b167f1bb`](https://github.com/NixOS/nixpkgs/commit/b167f1bb1401e71ddefe3e6afff4af33f8c50a48) haskellPackages.cabal2nix-unstable: 2022-10-10 -> 2022-10-22
* [`a9fdb380`](https://github.com/NixOS/nixpkgs/commit/a9fdb38041e0f645284463957ad5b8fa7c751f10) python310Packages.soco: 0.28.0 -> 0.28.1
* [`bff3c5c4`](https://github.com/NixOS/nixpkgs/commit/bff3c5c4782008ac46982b37ade3d897c3d184be) python310Packages.playwright: fix path to firefox
* [`c0c24c4f`](https://github.com/NixOS/nixpkgs/commit/c0c24c4ff904389c2e7b6e62f7eea1a1ff24b38e) s2n-tls: 1.3.20 -> 1.3.25
* [`5375f831`](https://github.com/NixOS/nixpkgs/commit/5375f831940da9f32eeee19082d3c3176e1debf8) dawncut: init at 1.54a
* [`2f60b0e2`](https://github.com/NixOS/nixpkgs/commit/2f60b0e25e2b2a3ea71eed61645d75a1768f28b6) shortwave: 3.0.0 -> 3.1.0
* [`62b5fa80`](https://github.com/NixOS/nixpkgs/commit/62b5fa807f34e70a3a7a452f81c50d3041d0419e) dawn: provide path to wish for the GUI
* [`fc92284f`](https://github.com/NixOS/nixpkgs/commit/fc92284f59382aeafa61f071fbf412658465b37c) s3rs: 0.4.8 -> 0.4.16
* [`713369c4`](https://github.com/NixOS/nixpkgs/commit/713369c44b1bcf17b5d2f209bb229656ce2613bf) doc/contributing: Explicitly allow trivial changes by non-authors
* [`4be2be76`](https://github.com/NixOS/nixpkgs/commit/4be2be76cd126f2ebe94adb9470e05a7c12967a6) urlhunter: 0.1.1 -> 0.1.2
* [`5c931e3c`](https://github.com/NixOS/nixpkgs/commit/5c931e3cc9176ed916958bbefea614f8cc28b852) ccache: 4.7 -> 4.7.1
* [`5b7d3d28`](https://github.com/NixOS/nixpkgs/commit/5b7d3d28ca4c5cf991e36a870ea4a3be3ee2a491) paperless-ngx: remove unused build input
* [`52b1e2fd`](https://github.com/NixOS/nixpkgs/commit/52b1e2fdf77f04ff2634b3bcd5a1f1d910d2745e) ocamlPackages.angstrom: add update script
* [`c0934911`](https://github.com/NixOS/nixpkgs/commit/c0934911583303bad2ba1003a07285fb21f17520) ocamlPackages.earlybird: use fetchFromGitHub
* [`dbfbaae0`](https://github.com/NixOS/nixpkgs/commit/dbfbaae0fa62dbead4bb05bc83b80d491c648d36) ocamlPackages.earlybird: add update script
* [`100c5989`](https://github.com/NixOS/nixpkgs/commit/100c5989ae79e54b0a2e40200138714cf18d1d88) ocamlPackages.mdx: use fetchFromGitHub
* [`8d91e1d0`](https://github.com/NixOS/nixpkgs/commit/8d91e1d053056a67601bed167012e9837f08eec7) ocamlPackages.mdx: add update script
* [`100bc48b`](https://github.com/NixOS/nixpkgs/commit/100bc48bf09c3b3e9527aa1f0137e7a211de93ac) ocamlPackages.ppx_deriving_cmdliner: add update script
* [`00b9b68c`](https://github.com/NixOS/nixpkgs/commit/00b9b68cf1be5f8ef9470f3191056ad3ed0e1388) ocamlPackages.printbox: add update script
* [`3f4c00e7`](https://github.com/NixOS/nixpkgs/commit/3f4c00e7950fa49e845fe0a4e6b1b376f38283c4) ocamlPackages.xml-light: add update script
* [`d406db08`](https://github.com/NixOS/nixpkgs/commit/d406db08ba2751f398ae36a79a1a97c415511e04) open-stage-control: 1.17.0 → 1.18.3
* [`c4e0d766`](https://github.com/NixOS/nixpkgs/commit/c4e0d766b75363e20c2beca5fbbaa61312911785) nixos/unitGenerator: fix generation for nspawn files
* [`808f2ab8`](https://github.com/NixOS/nixpkgs/commit/808f2ab87b075b56200858e24633436d2b4eacb4) ldc: 1.27.1 -> 1.30.0, change hashes to SRI format
* [`9695c4ee`](https://github.com/NixOS/nixpkgs/commit/9695c4ee8d1d6eec93304fd56757b5c0ba46945c) dmd: 2.097.2 -> 2.100.2, refactor, fix on Darwin
* [`982a1bfd`](https://github.com/NixOS/nixpkgs/commit/982a1bfd803a4b41f5ba36c51a3076f5e542fbd9) sambamba: fix compilation on Darwin, cleanup installPhase
* [`4c102acb`](https://github.com/NixOS/nixpkgs/commit/4c102acb1674710bec65224f71473fac06425db7) python310Packages.zeroconf: 0.39.1 -> 0.39.2
* [`d31cf8ca`](https://github.com/NixOS/nixpkgs/commit/d31cf8ca0cbfe01419db3599aa6dc25a13f9766a) nixos/uvesafb: init
* [`d0bf6d9d`](https://github.com/NixOS/nixpkgs/commit/d0bf6d9d630fa40f84bec9dc2047761d66116863) python310Packages.playwright.drivers: fix mac hash
* [`efdcbdfc`](https://github.com/NixOS/nixpkgs/commit/efdcbdfc251f2b3311c6fddc38607be568421318) vscode-extensions: add a few popular extensions
* [`bd5597dc`](https://github.com/NixOS/nixpkgs/commit/bd5597dce4a9f7ca7608c62a35c0eb7b977cd7aa) openmolcas: 22.06 -> 22.10
* [`9b7dc6cb`](https://github.com/NixOS/nixpkgs/commit/9b7dc6cb1c6b949eacd5aa56febb02c1988dc297) services/garage: init
* [`3ec90ef8`](https://github.com/NixOS/nixpkgs/commit/3ec90ef87f2ac82991d91e109b6a92bd5bf560ea) nixos/filesystems: add nfs4 to fsToSkipCheck
* [`765e7419`](https://github.com/NixOS/nixpkgs/commit/765e7419275d021b96f8318b5d5fb1dbf20ac9d1) keepassxc: 2.7.1 -> 2.7.3
* [`53f5456f`](https://github.com/NixOS/nixpkgs/commit/53f5456f3bf2aa0a2c5bd0c724225e45f738b9f1) sunshine: init at 0.14.1
* [`85cc98a9`](https://github.com/NixOS/nixpkgs/commit/85cc98a9da45a3e8491b73c9af2e854c14d377fb) python310Packages.fastapi: 0.85.0 -> 0.85.1
* [`a621d58f`](https://github.com/NixOS/nixpkgs/commit/a621d58f5fc17d71b1df435da0102b076616047a) python310Packages.aiofile: disable failing tests
* [`a42e1ccd`](https://github.com/NixOS/nixpkgs/commit/a42e1ccdb30f1fc35e0a94a4b06394c6c408e401) minio: 2022-10-20T00-55-09Z -> 2022-10-21T22-37-48Z
* [`e149ae24`](https://github.com/NixOS/nixpkgs/commit/e149ae24298a0052d66795726fcb624315612fa8) godot_4: init at 4.0-beta3
* [`72ee279a`](https://github.com/NixOS/nixpkgs/commit/72ee279ab451d7e7b7b0cb0f4df433967c4c745e) nixos/vdirsyncer: init
* [`febff1dc`](https://github.com/NixOS/nixpkgs/commit/febff1dccd2c173472fe4a6bed2e620429c5b1ba) lib/strings: allow toInt to parse zero-padded strings
* [`3d196a5f`](https://github.com/NixOS/nixpkgs/commit/3d196a5f2a72595b14c439a9b4aba7737c0f1ebe) lib/strings: Update toInt to handle intermixed ws and zeros. Added tests
* [`39a4ab78`](https://github.com/NixOS/nixpkgs/commit/39a4ab78a1245eb45d333fc14ec56f3a8f045986) lib/strings: Refactor toInt into toInt and toIntBase10
* [`88b18dcf`](https://github.com/NixOS/nixpkgs/commit/88b18dcf445a1be963a6bd2f9e8c075edd668f71) lib/strings: Improve error message for octal ambiguity in toInt
* [`ed711738`](https://github.com/NixOS/nixpkgs/commit/ed71173841618bd4c69f40d07fb467ccabc5db0b) lib/strings: Update docs and restructured code to improve readability of toInt and toIntBase10.
* [`0f8774f5`](https://github.com/NixOS/nixpkgs/commit/0f8774f5ac287e771ca4e216a98f68e495e1a3a8) chickenPackages.egg2nix: fix build on aarch64-darwin
* [`5bf52a42`](https://github.com/NixOS/nixpkgs/commit/5bf52a421e683f41ead75b2a5a121253accb7537) ugarit*: mark broken on aarch64-darwin
* [`7370e165`](https://github.com/NixOS/nixpkgs/commit/7370e16542bc8bbaaac54c3290af5ac6d3742b3c) operator-sdk: 1.24.1 -> 1.25.0
* [`98d2540a`](https://github.com/NixOS/nixpkgs/commit/98d2540aefd570dc7aeab3ce386d8809dc5fd8c2) nixosTests.dnscrypt-proxy2: Check that a UDP port is being listened on
* [`91efab3b`](https://github.com/NixOS/nixpkgs/commit/91efab3b81a5e55ed155617de1ef9326e4768297) fava: 1.22.3 -> 1.23
* [`2c5942b2`](https://github.com/NixOS/nixpkgs/commit/2c5942b26510b0e46e513c269af85386ff77610a) python310Packages.mailmanclient: 3.3.3 -> 3.3.4
* [`f24c4d8a`](https://github.com/NixOS/nixpkgs/commit/f24c4d8a285e3c501d393aada37fedc357c54c56) nixos/changedetection-io: fix typo
* [`feb4be1b`](https://github.com/NixOS/nixpkgs/commit/feb4be1b9789cf5d5ab90c2267972ab9a7cffc9a) changedetection-io: remove no longer required override
* [`44b909a9`](https://github.com/NixOS/nixpkgs/commit/44b909a9b4074480cb409cd1c4057025ef85ef2d) outline: 0.66.1 -> 0.66.2
* [`ecd305b4`](https://github.com/NixOS/nixpkgs/commit/ecd305b43600d39f057bbef49c12195f9aa78187) flavours: 0.5.2 -> 0.6.1
* [`50eb816d`](https://github.com/NixOS/nixpkgs/commit/50eb816d2994682b3269205b5cf7a4bdeb4a482c) nixos/btrbk: fix ordering of subsections and refactor
* [`a4e14d92`](https://github.com/NixOS/nixpkgs/commit/a4e14d92d3e157a78ff7aadcea645295f23d0083) rdma-core: 42.0 -> 43.0
* [`169d4a17`](https://github.com/NixOS/nixpkgs/commit/169d4a1704fc124eef376593b278f2a15dc87817) vym: 2.7.1 -> 2.8.42
* [`5b87b36f`](https://github.com/NixOS/nixpkgs/commit/5b87b36f60b04f7836da39e683c9e42f19a2a36e) python310Packages.ormar: 0.11.3 -> 0.12.0
* [`905f022f`](https://github.com/NixOS/nixpkgs/commit/905f022f9b0a02a32069fb052bce2976657af9fe) python310Packages.oslo-db: 12.1.0 -> 12.2.0
* [`0447862b`](https://github.com/NixOS/nixpkgs/commit/0447862b540435846b28f377667e5a690c179c34) python310Packages.peaqevcore: 7.0.8 -> 7.0.10
* [`8a5338ea`](https://github.com/NixOS/nixpkgs/commit/8a5338ea644e454f15d2a7050686ab3cff3a6927) python310Packages.pex: 2.1.111 -> 2.1.112
* [`2c828466`](https://github.com/NixOS/nixpkgs/commit/2c8284664f533db61a968feffc5123a43d70ed2a) python310Packages.plugwise: 0.25.3 -> 0.25.4
* [`8c964ca6`](https://github.com/NixOS/nixpkgs/commit/8c964ca615000b53fd437768e5762766bf297692) tagger: 2022.10.4 -> 2022.10.5
* [`06ac0387`](https://github.com/NixOS/nixpkgs/commit/06ac03877f114d842cfad2083d089773bb3ce812) xmrig: 6.18.0 -> 6.18.1
* [`5abe9ce6`](https://github.com/NixOS/nixpkgs/commit/5abe9ce6c9441273a4b533ef9b21fa0e537df811) python310Packages.pydal: 20220814.1 -> 20220916.1
* [`5d290730`](https://github.com/NixOS/nixpkgs/commit/5d2907308f9f5f35653fb0cb5c1b93325886da12) widelands 1.0 -> 1.1
* [`c3611ef0`](https://github.com/NixOS/nixpkgs/commit/c3611ef08745b96fb1a6987a824be0c320795c5d) postfix: 3.6.6 -> 3.7.3
* [`15eb3b9d`](https://github.com/NixOS/nixpkgs/commit/15eb3b9d7c3acb7758bc7b1e370adb60f1b20478) aws-c-s3: 0.1.46 -> 0.1.50
* [`c2ad51b7`](https://github.com/NixOS/nixpkgs/commit/c2ad51b7497ee5d846b87a1419fbe6f10702e256) libowfat: pull a(nother) patch from Gentoo
* [`d1a518c1`](https://github.com/NixOS/nixpkgs/commit/d1a518c1d3fabb0f8686bac846744790b6ba48d9) iosevka-comfy: 1.0.0 -> 1.1.1
* [`7d39ebe5`](https://github.com/NixOS/nixpkgs/commit/7d39ebe56c412a6bb515fb702cf4f6383b62ff75) webex: Add libxcrypt for libcrypt.so.1
* [`acf1d993`](https://github.com/NixOS/nixpkgs/commit/acf1d993b9321c02bfec3e64ba43edef14dd480f) release-notes: Move PolyMC from "highlights"
* [`610c33b0`](https://github.com/NixOS/nixpkgs/commit/610c33b0413c034fda13fa92df134c2067b15d72) payload_dumper: init at unstable-2022-04-11
* [`8dad5a22`](https://github.com/NixOS/nixpkgs/commit/8dad5a22399782a4ef681174219546cb050e580f) nixos/zsh: prefer added completions over completions shipped with Zsh
* [`e0181205`](https://github.com/NixOS/nixpkgs/commit/e0181205fe7808bfd17a05d156aa67a430b2fa94) aws-c-auth: 0.6.16 -> 0.6.18
* [`0d0251b5`](https://github.com/NixOS/nixpkgs/commit/0d0251b5cefa8434855315062e8e36596788f081) argo: 3.4.1 -> 3.4.2
* [`e175bd9f`](https://github.com/NixOS/nixpkgs/commit/e175bd9f85b623ecb2075def4c91c941ad2ab43e) ocamlPackages.arp: ethernet is a buildInputs
* [`3d62cd9a`](https://github.com/NixOS/nixpkgs/commit/3d62cd9a6c3119a04bcc314300addbe4a333b6b3) sudo: 1.9.11p3 -> 1.9.12
* [`062bc0d3`](https://github.com/NixOS/nixpkgs/commit/062bc0d32e53740838ef3134a84fb826c5a7a592) python310Packages.mailmanclient: add pythonImportsCheck
* [`8ac33953`](https://github.com/NixOS/nixpkgs/commit/8ac339533fe67b680dfe14f0fcecad7cb59d1097) nixos/snipe-it: Add missing upload directories
* [`fde66f34`](https://github.com/NixOS/nixpkgs/commit/fde66f34532f3e81cd6f2958c8716a13ac784bba) cargo-cache: 0.8.2 -> 0.8.3
* [`4e9c16be`](https://github.com/NixOS/nixpkgs/commit/4e9c16bee9c153ef7b9ae3304b9c2b77b6e7843a) phrase-cli: 2.5.2 -> 2.5.3
* [`5679f85f`](https://github.com/NixOS/nixpkgs/commit/5679f85f4da8f0f29d5d8db5d990b9a3dfae3c40) eget: 1.2.0 -> 1.2.1
* [`dd3ce87f`](https://github.com/NixOS/nixpkgs/commit/dd3ce87f425f4656246c125e5a1a790a1dcdbf22) cargo-pgx: 0.5.3 -> 0.5.6
* [`074da18a`](https://github.com/NixOS/nixpkgs/commit/074da18a72269cc5a6cf444dce42daea5649b2fe) codeowners: 0.4.0 -> 1.0.0
* [`cb7eb7ee`](https://github.com/NixOS/nixpkgs/commit/cb7eb7ee381e85db97ee31081b3ab62c94a7a664) cppcheck: 2.9 -> 2.9.1
* [`e0bf48e3`](https://github.com/NixOS/nixpkgs/commit/e0bf48e315af5216988c817d07820db55f94c487) trash-cli: 0.22.8.27 -> 0.22.10.20
* [`14932d0b`](https://github.com/NixOS/nixpkgs/commit/14932d0bba39ec02ac2f2551457b5cf3f9371d4c) vimPlugins.keymap-layer-nvim: init at 2022-07-16
* [`ef19ad48`](https://github.com/NixOS/nixpkgs/commit/ef19ad48752d38813617bf2257b7269688fc1bb6) cpu-x: 4.5.0 -> 4.5.1
* [`abefe7fa`](https://github.com/NixOS/nixpkgs/commit/abefe7facd9ffb24e1c51d4f070d026695721e39) filezilla: 3.60.2 -> 3.61.0
* [`573a1fc1`](https://github.com/NixOS/nixpkgs/commit/573a1fc1677fab51c6ffa845fff61aa5f9e9440e) textpieces: init at 3.3.0
* [`df9da891`](https://github.com/NixOS/nixpkgs/commit/df9da891637929d52a8a189ea3399c1ee555ef51) chrony: remove unused assertion
* [`0b35b258`](https://github.com/NixOS/nixpkgs/commit/0b35b258aed68d2aac1924a583e11d8c4e11f54e) blueman: 2.3.2 -> 2.3.4
* [`5b84c0c0`](https://github.com/NixOS/nixpkgs/commit/5b84c0c04ddc11cc1f5637ae4c972982038097fe) python310Packages.moto: disable failing tests
* [`b65f049b`](https://github.com/NixOS/nixpkgs/commit/b65f049b6b1010ac644c23d19529b3ef6b4d608c) clojure: 1.11.1.1165 -> 1.11.1.1177
* [`bf8375da`](https://github.com/NixOS/nixpkgs/commit/bf8375dad03eba971170bff722745df2e54c2e49) btrbk: update passthru.tests
* [`fc3e6936`](https://github.com/NixOS/nixpkgs/commit/fc3e69368031cd1ebf93f6ec5f9356bf20667cd6) e16: 1.0.25 -> 1.0.26
* [`0a657fb3`](https://github.com/NixOS/nixpkgs/commit/0a657fb3e6da28c63439bb9e4e514026c27d91fe) gitea: unpin Go 1.18
* [`e04013af`](https://github.com/NixOS/nixpkgs/commit/e04013af1a9320fd78819119adf5696a167506c9) nixos/gitea: set proper SystemCallFilter
* [`19b481fb`](https://github.com/NixOS/nixpkgs/commit/19b481fbc634ffb81b449de4f38751ab9a031a3c) nixos/galene: set proper SystemCallFilter
* [`db029623`](https://github.com/NixOS/nixpkgs/commit/db029623b732cfa34eae29b6eb98e2b0c7d62f68) nixos/dnscrypt-proxy2: properly set SystemCallFilter
* [`7415970a`](https://github.com/NixOS/nixpkgs/commit/7415970a3e853ba153c4e8147147751d15e7ea98) nixos/endlessh-go: set proper SystemCallFilter
* [`0ce08acd`](https://github.com/NixOS/nixpkgs/commit/0ce08acdce4bc021f8dba9ed035cf7d1426dac86) nixos/navidrome: set proper SystemCallFilter
* [`f93f9f43`](https://github.com/NixOS/nixpkgs/commit/f93f9f43c6b3347b2091a8a41421d31e84cb9275) ocamlPackages.bls12-381-signature: init at 1.0.0
* [`b9cdce45`](https://github.com/NixOS/nixpkgs/commit/b9cdce459b8f12895b7d20921f73ffa15913d066) thonny: 3.3.14 -> 4.0.1
* [`e136e787`](https://github.com/NixOS/nixpkgs/commit/e136e7877f396f2ae4069180d7f30d79b2f37201) whitebophir: 1.19.0 -> 1.19.1
* [`3758f7fa`](https://github.com/NixOS/nixpkgs/commit/3758f7fa4ab4002b427d3e256db9df4a96d75b66) maintainers: update @⁠mgttlinger's name
* [`7b5475e8`](https://github.com/NixOS/nixpkgs/commit/7b5475e8d7b84256e98407fd318d3d91376c7b02) jadx: allow local networking on Darwin
* [`924d4a9b`](https://github.com/NixOS/nixpkgs/commit/924d4a9bb3919fc477538e259fcfbd264e2d1862) berry: 0.1.11 -> 0.1.12
* [`3a10bbd4`](https://github.com/NixOS/nixpkgs/commit/3a10bbd4be77064ea2e71ca6ad821e8488f58c4b) arch-install-scripts: 26 -> 27
* [`36d93e8c`](https://github.com/NixOS/nixpkgs/commit/36d93e8cc2392a4067ea69a2b9a517ef7f33298b) clickhouse-backup: 2.1.1 -> 2.1.2
* [`640fc611`](https://github.com/NixOS/nixpkgs/commit/640fc61141e63804c927bb02e979b3e8cb9ecece) python310Packages.aiobiketrax: 0.3.0 -> 0.4.0
* [`19d86c4e`](https://github.com/NixOS/nixpkgs/commit/19d86c4e2d2fb00bbee0bf12faf639266aa22876) python310Packages.pynobo: 1.5.0 -> 1.6.0
* [`62347d16`](https://github.com/NixOS/nixpkgs/commit/62347d1669eeb3003f093a376d5e350d5c0d08ae) python310Packages.rns: 0.3.16 -> 0.3.17
* [`e551494a`](https://github.com/NixOS/nixpkgs/commit/e551494aac1c409a4254db38998b798f34ff4f84) python310Packages.lxmf: 0.2.1 -> 0.2.2
* [`70e271ac`](https://github.com/NixOS/nixpkgs/commit/70e271ac32ee385267ea341d847cb7f57bdb1701) got: 0.76 -> 0.77
* [`bd609296`](https://github.com/NixOS/nixpkgs/commit/bd60929673f55fd0b65c24238e7ef068b4806e23) python310Packages.griffe: 0.22.0 -> 0.22.2
* [`f0d96ab4`](https://github.com/NixOS/nixpkgs/commit/f0d96ab473b06aa11ba1ac9ebe263f8f115cb7ae) emacsPackages.irony: fix build on aarch64-darwin
* [`6fe8b8ed`](https://github.com/NixOS/nixpkgs/commit/6fe8b8ed3c2eec7df228f1dbdafd9aa875ec94e6) jadx: 1.4.4 -> 1.4.5
* [`eafdbcc9`](https://github.com/NixOS/nixpkgs/commit/eafdbcc9b4c9f0312a276f2c2c5f097d2f6e7846) ocamlPackages.tezos-bls12-381-polynomial: 0.1.2 -> 0.1.3
* [`ff817774`](https://github.com/NixOS/nixpkgs/commit/ff817774a5790bc3f6b09c74bcc2c9dd16fdd8b3) python310Packages.pyhumps: 3.7.3 -> 3.8.0
* [`1d867f97`](https://github.com/NixOS/nixpkgs/commit/1d867f974f582ec6d02da5dee0aab1f2e1bebcdf) hysteria: 1.2.1 -> 1.2.2
* [`8ca05656`](https://github.com/NixOS/nixpkgs/commit/8ca056561304e7d7cbe2b593bc13b3e89d0d6b21) python310Packages.sentry-sdk: 1.10.0 -> 1.10.1
* [`4297bec6`](https://github.com/NixOS/nixpkgs/commit/4297bec6429373cc1bd1fd4f9a62c46a97245187) python310Packages.types-python-dateutil: 2.8.19.1 -> 2.8.19.2
* [`0766c657`](https://github.com/NixOS/nixpkgs/commit/0766c6574776957774ffa4fc7eda0f36dad5b91b) Update ocaml packages.git and paf le chien ([nixos/nixpkgs⁠#197422](https://togithub.com/nixos/nixpkgs/issues/197422))
* [`5a326796`](https://github.com/NixOS/nixpkgs/commit/5a32679673e89134b90f735dc2ce6081cbc90d3f) senpai: unstable-2022-07-25 → unstable-2022-10-19
* [`5e35744c`](https://github.com/NixOS/nixpkgs/commit/5e35744c4cf3440f34e7dbf4af870eab524a85b2) maintainers: add lheckemann and hoverbear to determinatesystems
* [`ac70b1c2`](https://github.com/NixOS/nixpkgs/commit/ac70b1c269399f8d31b0238e869c6d7ede3ef0ec) coldsnap: maintained by Determinate Systems
* [`587c9cb3`](https://github.com/NixOS/nixpkgs/commit/587c9cb3a9aef1e04029f5a6bbb010f31b56bab3) freefilesync: 11.26 -> 11.27
* [`55325e23`](https://github.com/NixOS/nixpkgs/commit/55325e23f81f28b4b65a7b5cf115c9b187d45529) ballerina: 2201.2.1 -> 2201.2.2
* [`3dcfce65`](https://github.com/NixOS/nixpkgs/commit/3dcfce65a0fc64dbf662d9fa6fd338d59fe932b6) armadillo: 11.4.1 -> 11.4.2
* [`4a177de7`](https://github.com/NixOS/nixpkgs/commit/4a177de7f287d10dd889063b86bc9c54d3029606) mangal: 3.12.0 -> 3.14.0
* [`f3cb29a5`](https://github.com/NixOS/nixpkgs/commit/f3cb29a5b88794d733fd87dcc46ba7824db98491) nixos/grafana: fix issues with rfc42 refactoring
* [`31a74e48`](https://github.com/NixOS/nixpkgs/commit/31a74e4893c29cc641f762d40671b0f82fa4eb36) btop: 1.2.9 -> 1.2.12
* [`00b4c335`](https://github.com/NixOS/nixpkgs/commit/00b4c3351d3bd8eb3332f6184df05afd627cc1fc) python3Packages.pyscf: fix build with libxc-6.0.0
* [`2ddb4ec4`](https://github.com/NixOS/nixpkgs/commit/2ddb4ec4cfb37b5d879f7bac714a6229e44d78a2) zoom-us: 5.12.0.{11129,4682} -> 5.12.{3.11845,2.4816}
* [`6d90b301`](https://github.com/NixOS/nixpkgs/commit/6d90b301aff1e836786b8c9c1f72ab8864eb8342) vscode-extensions.scalameta.metals: 1.12.18 -> 1.20.0
* [`60a19822`](https://github.com/NixOS/nixpkgs/commit/60a198228e5e859bf07c1fb4da6beee36c110e8c) safeeyes: add xprop runtime dependency
* [`488da5d8`](https://github.com/NixOS/nixpkgs/commit/488da5d839dfe8a7e87d9afaccf3d8884026423d) exoscale-cli: 1.59.3 -> 1.60.0
* [`fc487564`](https://github.com/NixOS/nixpkgs/commit/fc4875649185061c3b229629fda736d8f6587d4e) nvme-cli: 1.16 -> 2.1.2
* [`97c97f5c`](https://github.com/NixOS/nixpkgs/commit/97c97f5c4ee38e9c34f91c41b931f82af295719d) xivlauncher: 1.0.1.0 -> 1.0.2
* [`51d7d359`](https://github.com/NixOS/nixpkgs/commit/51d7d3592d94002a7337483a997782aaa6c4b149) python3Packages.dm-tree: unstable-2021-12-20 -> 0.1.7
* [`547d1276`](https://github.com/NixOS/nixpkgs/commit/547d127691be2d834bc10e979faf6c1d2cc15edd) python3Packages.chex: 0.1.4 -> 0.1.5
* [`3d8c5c14`](https://github.com/NixOS/nixpkgs/commit/3d8c5c14743874030749ac63b6da5adbfde865f8) oh-my-zsh: 2022-10-22 -> 2022-10-24
* [`97141064`](https://github.com/NixOS/nixpkgs/commit/9714106447e4dca5f6b2f7655742732db49c398a) python3Packages.flax: 0.6.0 -> 0.6.1
* [`aa473065`](https://github.com/NixOS/nixpkgs/commit/aa473065cb9b9cfae16426056bc631deaec9b39e) boost180: init at 1.80.0
* [`6eeb9af1`](https://github.com/NixOS/nixpkgs/commit/6eeb9af177d7d18a12a1ec6ed3af4b3d65f48aa6) python3Packages.localstack-ext: 1.1.0 -> 1.2.0
* [`53e15a5f`](https://github.com/NixOS/nixpkgs/commit/53e15a5f2f86b16c5f6622d77a4d3bae8fd3a38e) python3Packages.localstack-client: 1.36 -> 1.39
* [`831fe254`](https://github.com/NixOS/nixpkgs/commit/831fe25421e9d6c195a58f25cef62ed056f43103) python3Packages.localstack: 1.0.4 -> 1.2.0
* [`7b0122ae`](https://github.com/NixOS/nixpkgs/commit/7b0122aede0382ec215b8d455d821d7134515979) python3Packages.localstack*: add localstack as test
* [`55258a5c`](https://github.com/NixOS/nixpkgs/commit/55258a5cb55da034d7d26e60e39b68e0eb74dafe) python310Packages.cvxpy: fix build on aarch64-darwin
* [`44331791`](https://github.com/NixOS/nixpkgs/commit/44331791273ba9250d5511b2d2881ca642c1f645) discord: make update script work for all branches
* [`f869098b`](https://github.com/NixOS/nixpkgs/commit/f869098b67550eaf1752dc9592cc4daaef771c52) discord-ptb: 0.0.29 -> 0.0.34
* [`ae54952c`](https://github.com/NixOS/nixpkgs/commit/ae54952c4e2d8e3cdebd2947bc07afb9ace4fee6) nwg-wrapper: 0.1.2 -> 0.1.3
* [`6444c18e`](https://github.com/NixOS/nixpkgs/commit/6444c18e9ce2d4bc883b9b356952d701f77f2d6a) flashfocus: 2.2.3 -> 2.3.1
* [`2ebe637b`](https://github.com/NixOS/nixpkgs/commit/2ebe637b8d5db6c6059936112611230ab1dc9273) fishPlugins.forgit: 2022-08-16 -> 2022-10-14
* [`0fa4d177`](https://github.com/NixOS/nixpkgs/commit/0fa4d17725f846951f2b80502a5f6c3695a31f99) nixos/tests/chromium: Fix the tests for Google Chrome
* [`5389fbe7`](https://github.com/NixOS/nixpkgs/commit/5389fbe7839749354df38517124a55259ebf3453) nixos/tests/chromium: Disable a failing test for M107+
* [`2e121cf0`](https://github.com/NixOS/nixpkgs/commit/2e121cf048719f9c9de80cbc10297a9c5280802c) session-desktop: 1.10.1 -> 1.10.3
* [`2900412c`](https://github.com/NixOS/nixpkgs/commit/2900412c48d9859890dc9e28ef05e238ec44cd3f) libvarlink: 22 -> 23
* [`da346e48`](https://github.com/NixOS/nixpkgs/commit/da346e48237cd6339cc690ee52d4a114622f03a6) pdfstudio: v2022.0.2 -> v2022.1.1
* [`3faf69cd`](https://github.com/NixOS/nixpkgs/commit/3faf69cd2ab2e1adfbcead9487d677d39792ee17) vimPlugins.neo-tree-nvim: init at 2022-10-22
* [`fcf2d05d`](https://github.com/NixOS/nixpkgs/commit/fcf2d05d817fad1dc212b4c5bfd4e70c37f59f69) nixos/acme: Relax syscall filter after go upgrade
* [`2b85fb12`](https://github.com/NixOS/nixpkgs/commit/2b85fb12da34c2ef48fc44d060c14ac8480c0c41) nixos/release: add acme to tested set
* [`00b57fb2`](https://github.com/NixOS/nixpkgs/commit/00b57fb2c09774fa376b3f5935af78b7b981d9fa) rare: 1.8.9 -> 1.9.2
* [`4932ed92`](https://github.com/NixOS/nixpkgs/commit/4932ed92a494cf1cd85ac52883b3837cb364c956) python311: 3.11.0-rc2 -> 3.11.0
* [`1b520939`](https://github.com/NixOS/nixpkgs/commit/1b520939443275380bf071f118490959475ddadf) home-assistant-cli: 0.9.5 -> 0.9.6
* [`31bf4f6d`](https://github.com/NixOS/nixpkgs/commit/31bf4f6d11e3317a104c2f1f4f2a38c64b533eeb) gnomeExtensions: auto-update
* [`1c465142`](https://github.com/NixOS/nixpkgs/commit/1c4651424905d23f60033061f93cb332eccde42b) python310Packages.denonavr: 0.10.11 -> 0.10.12
* [`06e2ebc0`](https://github.com/NixOS/nixpkgs/commit/06e2ebc0c52ef9ffd9e9d3dc6dc4861d73253012) python310Packages.hahomematic: 2022.10.8 -> 2022.10.9
* [`8e9f8876`](https://github.com/NixOS/nixpkgs/commit/8e9f8876af9bfd57e057b788a541622a0a0b593b) svd2rust: 0.26.0 -> 0.27.0
* [`f30cb3a6`](https://github.com/NixOS/nixpkgs/commit/f30cb3a6c0843d882adade917cdcb762cefaaa5b) python3Packages.flake8-bugbear: 22.9.23 -> 22.10.25
* [`1206839c`](https://github.com/NixOS/nixpkgs/commit/1206839ce994703645a906e680912d4530da1f1d) cmctl: set passthru.updateScript option
* [`1d54d38e`](https://github.com/NixOS/nixpkgs/commit/1d54d38e41cbad99e630c387922728e6374da76e) navidrome: 0.47.5 -> 0.48.0
* [`545b74f0`](https://github.com/NixOS/nixpkgs/commit/545b74f075e16c1588e2ba445d2cfa1a5edd8cd5) brscan4-etc-files: rename name to pname&version
* [`422f7cb3`](https://github.com/NixOS/nixpkgs/commit/422f7cb3613fdc4740dced36ec0d52511405c287) fluxcd: 0.35.0 -> 0.36.0
* [`d4f8e537`](https://github.com/NixOS/nixpkgs/commit/d4f8e53720b554b6dac71c7ec62b3b51158905f9) bitwig-studio: 4.4 -> 4.4.1
* [`5573c0dc`](https://github.com/NixOS/nixpkgs/commit/5573c0dc56b94f46df97dba689d8485267e85941) oh-my-posh: 12.6.8 -> 12.7.1
* [`00ebdd89`](https://github.com/NixOS/nixpkgs/commit/00ebdd89472aa7cfad3c1936d3a0e52f281733c2) guile-sqlite3: init at 0.1.3
* [`1401fdb2`](https://github.com/NixOS/nixpkgs/commit/1401fdb2d400f7e6174dd684868bb34046e864f0) opensmt: 2.4.1 -> 2.4.2
* [`e6d2faa0`](https://github.com/NixOS/nixpkgs/commit/e6d2faa0e1689fe8631b9ac2d3bd56f7e168a971) python3Packages.requests-hawk: Update homepage
* [`92ffa1d7`](https://github.com/NixOS/nixpkgs/commit/92ffa1d783deda23f828fc10a2aa1a3af3d76d44) python3Packages.google-cloud-iam: 2.8.2 -> 2.9.0
* [`f6dfe13e`](https://github.com/NixOS/nixpkgs/commit/f6dfe13ef9305320d42d254561cb42022cde56a0) python3Packages.apache-beam: relax protobuf dependency to fix build
* [`6fb4508e`](https://github.com/NixOS/nixpkgs/commit/6fb4508eb48d09b317f888648c869c2334b91946) fx_cast_bridge: Update node deps for v0.3.1
* [`87e25e63`](https://github.com/NixOS/nixpkgs/commit/87e25e63c3bd2695b38481a7ee292092f24e71bb) qovery-cli: 0.46.3 -> 0.46.4
* [`ba8041fc`](https://github.com/NixOS/nixpkgs/commit/ba8041fc2bf51480e58b2985f184eb58a7777b4d) nixos/croc: set proper SystemCallFilter
* [`d3a95ce3`](https://github.com/NixOS/nixpkgs/commit/d3a95ce32c6d3a83ed661eaf0a066a3b44e906e0) nixos/listmonk: set proper SystemCallFilter
* [`fd47630b`](https://github.com/NixOS/nixpkgs/commit/fd47630b8b6fb814af7768384dc9cdcfe7d69664) python3Packages.connexion: add missing dependency on 'packages'
* [`3b968771`](https://github.com/NixOS/nixpkgs/commit/3b968771afb08bbcbeaf5617700617feebadb45e) sentry-cli: 2.7.0 -> 2.8.0
* [`d28ecd04`](https://github.com/NixOS/nixpkgs/commit/d28ecd04d7c8baad99ec6cafc4b8c03d4592f030) terraform-providers.baiducloud: 1.15.11 → 1.16.0
* [`4e2c53f3`](https://github.com/NixOS/nixpkgs/commit/4e2c53f33cdecd3d4b6333f26a881a1efa44ab89) terraform-providers.cloudamqp: 1.19.3 → 1.20.0
* [`14d3d128`](https://github.com/NixOS/nixpkgs/commit/14d3d1285c2db5547b1650d2ebbf978b0a62a370) terraform-providers.datadog: 3.16.0 → 3.17.0
* [`2d40ae86`](https://github.com/NixOS/nixpkgs/commit/2d40ae863d6708cd87638e870e50ece30613bb12) terraform-providers.alicloud: 1.188.0 → 1.189.0
* [`e15e5f6a`](https://github.com/NixOS/nixpkgs/commit/e15e5f6ac577f185ba15172a4b415529f735b6fe) terraform-providers.heroku: 5.1.5 → 5.1.6
* [`3f9cfa8c`](https://github.com/NixOS/nixpkgs/commit/3f9cfa8c574730a21ed17fc5eff11069f2acf342) terraform-providers.github: 5.5.0 → 5.6.0
* [`e0e0c4db`](https://github.com/NixOS/nixpkgs/commit/e0e0c4dbd95c997cf1124b4dbeb172d530ade7f7) terraform-providers.tfe: 0.37.0 → 0.38.0
* [`7cf9baa7`](https://github.com/NixOS/nixpkgs/commit/7cf9baa7e3cb1a44619270048d9157d31459746a) python310Packages.google-re2: 0.2.20220601 -> 1.0
* [`a34410f2`](https://github.com/NixOS/nixpkgs/commit/a34410f26fed07133f6955c372f3c86428409c4b) python310Packages.hcloud: 1.18.0 -> 1.18.1
* [`37a30e69`](https://github.com/NixOS/nixpkgs/commit/37a30e698badb555cc618cff0d781c1702105d2e) python310Packages.jc: 1.22.0 -> 1.22.1
* [`0ba3ec71`](https://github.com/NixOS/nixpkgs/commit/0ba3ec71be94de50d8117f76fbddc19e29e828f5) python310Packages.jupyterlab: 3.4.8 -> 3.5.0
* [`5111a6c7`](https://github.com/NixOS/nixpkgs/commit/5111a6c7a75b296ca52a76c3f79e7ddb38f9d2cb) sundials: 6.3.0 -> 6.4.0
* [`55bdefa1`](https://github.com/NixOS/nixpkgs/commit/55bdefa15f93a742d60eddadae69d4ec3142109e) python310Packages.ciscoconfparse: 1.6.40 -> 1.6.50
* [`47032f39`](https://github.com/NixOS/nixpkgs/commit/47032f39ed89afa24de198b3d5dbf632e066314e) python310Packages.identify: 2.5.6 -> 2.5.7
* [`e241f02b`](https://github.com/NixOS/nixpkgs/commit/e241f02b548d996e1d214360f6967698d415ff21) tflint: 0.42.0 -> 0.42.1
* [`184c58fd`](https://github.com/NixOS/nixpkgs/commit/184c58fd4a446a70620688cd8938b8451ae7b612) tidal-hifi: 4.3.0 -> 4.3.1
* [`580c24f1`](https://github.com/NixOS/nixpkgs/commit/580c24f1d2ea31072990bce5925be97d12fcb303) timescaledb-tune: 0.14.1 -> 0.14.2
* [`ada6c249`](https://github.com/NixOS/nixpkgs/commit/ada6c249c6031ddf248c1c51a5faac5ff12e3e2a) zellij: 0.31.4 -> 0.32.0
* [`5641fce0`](https://github.com/NixOS/nixpkgs/commit/5641fce009b1012f0e77d6165d64315a72a90159) gnome.gnome-settings-daemon338: avoid libsoup2 symbols
* [`b42a0ec2`](https://github.com/NixOS/nixpkgs/commit/b42a0ec29ad2bf5aff18d9d4cdd2c6ba12711734) ocamlPackages.pipebang: remove at 113.00.00
* [`fbd94299`](https://github.com/NixOS/nixpkgs/commit/fbd942993f1e5d1215749f51a7ef42fd7948583b) ocamlPackages.herelib: remove at 112.35.00
* [`8b11f0a5`](https://github.com/NixOS/nixpkgs/commit/8b11f0a5138c23c0be6e6a04caaf647fca644856) ocamlPackages.buildOcaml: remove
* [`bd8413e8`](https://github.com/NixOS/nixpkgs/commit/bd8413e8e1d6b698186c4b8cd428110e71b5b463) nixos/snowflake-proxy: set proper SystemCallFilter
* [`b0a67023`](https://github.com/NixOS/nixpkgs/commit/b0a67023be5e1d3ae840e60fa26e612f37a44a24) uncover: 0.0.8 -> 0.0.9
* [`ae025da5`](https://github.com/NixOS/nixpkgs/commit/ae025da558802211d597191ffcf2a7273c030400) nixos/dex-oidc: set proper SystemCallFilter
* [`7742cd54`](https://github.com/NixOS/nixpkgs/commit/7742cd543da19a9b7bc32ead0394dfa9ff5c4bd1) nixos/yggdrasil: set proper SystemCallFilter
* [`5c983ac3`](https://github.com/NixOS/nixpkgs/commit/5c983ac37b52b36c0df06ef390870e7cfdcac5c3) nixos/prosody-filer: set proper SystemCallFilter
* [`4557c2c9`](https://github.com/NixOS/nixpkgs/commit/4557c2c983b94792f205c6dcfad14d47090b8558) pantheon.wingpanel-indicator-sound: 6.0.1 -> 6.0.2
* [`5af05d2a`](https://github.com/NixOS/nixpkgs/commit/5af05d2a487c6f79988960814c8924481b200cce) cie-middleware-linux: 1.4.3.1 -> 1.4.4.0
* [`4fffb0e5`](https://github.com/NixOS/nixpkgs/commit/4fffb0e5fe2015bdbf29a83ae486cd836ff1ce94) containerd: 1.6.8 -> 1.6.9
* [`f1d5de69`](https://github.com/NixOS/nixpkgs/commit/f1d5de69576bf4c6c3e9bb06bd770e13d030249b) pantheon.sideload: 6.0.2 -> 6.1.0
* [`f4342c11`](https://github.com/NixOS/nixpkgs/commit/f4342c11e5feee7dd805045ed4dd3fb069d5ac83) nixos/geoipupdate: set proper SystemCallFilter
* [`afb8d0e5`](https://github.com/NixOS/nixpkgs/commit/afb8d0e5a62c6018c4cd3545c76e672cec6ccabb) nixos/prometheus-smartctl: set proper SystemCallFilter
* [`9b8fd74d`](https://github.com/NixOS/nixpkgs/commit/9b8fd74d68fca9eace442379fc74b80bbab894c1) nixos/nats: set proper SystemCallFilter
* [`6724d222`](https://github.com/NixOS/nixpkgs/commit/6724d2221a98815eda9cdc4142ccec144be64b92) nixos/shiori: set proper SystemCallFilter
* [`4e8c7697`](https://github.com/NixOS/nixpkgs/commit/4e8c7697f2a4e99a2a5314410dc41002737f5514) luaPackages.luafilesystem: 1.7.0 -> 1.8.0
* [`e0b300e2`](https://github.com/NixOS/nixpkgs/commit/e0b300e22d0d1f2aeb551659960dcc72b82f9678) python310Packages.mypy-boto3-s3: 1.24.94 -> 1.25.0
* [`c13dc734`](https://github.com/NixOS/nixpkgs/commit/c13dc7344ad50c46599dba7398f0c8978a481a1a) vimPlugins: update
* [`be2236ae`](https://github.com/NixOS/nixpkgs/commit/be2236aeb3041b434b3bf23e6e0b0bb039af5588) icewm: 3.0.1 -> 3.1.0
* [`73d23f29`](https://github.com/NixOS/nixpkgs/commit/73d23f29678559c0f19f46d9c5358266475c3132) ginkgo: 2.3.1 -> 2.4.0
* [`4deb9416`](https://github.com/NixOS/nixpkgs/commit/4deb94160637058c0f629d5057db988033b76c06) aliyun-cli: 3.0.132 -> 3.0.133
* [`74068484`](https://github.com/NixOS/nixpkgs/commit/740684843578f5cdb73bce68a5cc55b726c583ff) rust-analyzer-unwrapped: 2022-10-17 -> 2022-10-24
* [`e0dbcf32`](https://github.com/NixOS/nixpkgs/commit/e0dbcf32483479314f8620fd216bd2c3ff65bc00) skaffold: 1.39.2 -> 2.0.0
* [`08c31fef`](https://github.com/NixOS/nixpkgs/commit/08c31feff777611d10ace152c466cf7e0d668664) netbird: 0.10.1 -> 0.10.2
* [`e4235c60`](https://github.com/NixOS/nixpkgs/commit/e4235c60b71bec66fe8f811cdbdd229bcf98915f) freshrss: use an absolute path for ExecStart
* [`2886c499`](https://github.com/NixOS/nixpkgs/commit/2886c499ccae282ac38d349e4bd180fb695b25e2) crow-translate: 2.10.0 -> 2.10.1
* [`c03626c2`](https://github.com/NixOS/nixpkgs/commit/c03626c2e34779d417fe4bb3968da73623b1b413) catppuccin-cursors: init at unstable-2022-08-23
* [`68505781`](https://github.com/NixOS/nixpkgs/commit/68505781e333e1a5df0a7c32f86df5b53df7a712) gnome.updateScript: More Python
* [`1bac4d0f`](https://github.com/NixOS/nixpkgs/commit/1bac4d0f77c8d85e5fb49800a9615cf369bbbf20) perf: add python.interpreter to PATH
* [`a9b97f18`](https://github.com/NixOS/nixpkgs/commit/a9b97f18d003ebca2e0b8a0c04fe14f02e4505be) gnome.updateScript: Return explicitly set attr path
* [`fdb0b136`](https://github.com/NixOS/nixpkgs/commit/fdb0b13687bca6aa72e64a7b5fdb2d18d805a5e7) luaPackages: update
* [`812dd30e`](https://github.com/NixOS/nixpkgs/commit/812dd30e629dbc6cf7be240de004ca70799cce87) gnome.updateScript: Prevent downgrading packages
* [`f92f3339`](https://github.com/NixOS/nixpkgs/commit/f92f333983165cf863731efb8b6697af986566fc) smt2-parser is no longer broken
* [`2813d781`](https://github.com/NixOS/nixpkgs/commit/2813d781c5fc6e24d48e0468f08d9a2747aa20e1) magnetico: 0.12.0 -> unstable-2022-08-10
* [`f994293d`](https://github.com/NixOS/nixpkgs/commit/f994293d1eb8812f032e8919e10a594567cf6ef7) cmctl: 1.9.1 -> 1.10.0
* [`bee83055`](https://github.com/NixOS/nixpkgs/commit/bee830554a801d8666e16b30aed99dfa7edbaa2e) matrix-appservice-irc: 0.35.1 -> 0.36.0
* [`c4a4d75b`](https://github.com/NixOS/nixpkgs/commit/c4a4d75bf209ef17e1ea080a8ec8bae73cf909e3) home-manager: 2022-04-17 -> 2022-10-25
* [`e78bb965`](https://github.com/NixOS/nixpkgs/commit/e78bb96546fd2ba5f75ff6983971d9b094512349) ncdns: 2020-07-18 -> 2022-10-07
* [`1085127c`](https://github.com/NixOS/nixpkgs/commit/1085127c339a9f829a7b1c40d534ae43f367556e) ansible-lint: remove myself from maintainers
* [`dfad2c6e`](https://github.com/NixOS/nixpkgs/commit/dfad2c6e978ed2a5430e01938cef885e5ec6e422) gvfs: add darwin support
* [`079a950f`](https://github.com/NixOS/nixpkgs/commit/079a950f524db708d59491b1f84a528925766790) gnome-online-accounts: add darwin support
* [`b082de98`](https://github.com/NixOS/nixpkgs/commit/b082de986e23822fb63984e908e87abdd40ed239) evolution-data-server: add darwin support
* [`17371df3`](https://github.com/NixOS/nixpkgs/commit/17371df3ec3c981230c13675fe129b971f048434) ArchiSteamFarm: 5.2.8.3 -> 5.3.1.2
* [`0f386859`](https://github.com/NixOS/nixpkgs/commit/0f386859f50c843c8e10a0ba1f3a6b9aa5d9a186) build-dotnet-module: don't end with exit code 1 when update was sucessfull
* [`b38799bb`](https://github.com/NixOS/nixpkgs/commit/b38799bbb4b7b01d111f814f6f741dd4bc25c563) ArchiSteamFarm: make update scripts indepent from where they are run, cleanups
* [`a1de6d54`](https://github.com/NixOS/nixpkgs/commit/a1de6d54679d966533a4482e7d06955406619747) gnome.updateScript: Add more type annotations
* [`2bbee744`](https://github.com/NixOS/nixpkgs/commit/2bbee744183166bf7a7d6925a44527b8c7f33e3b) python3Packages.black: 22.8.0 -> 22.10.0
* [`1f04ae9e`](https://github.com/NixOS/nixpkgs/commit/1f04ae9e63de3dbbf611bb8fac684c994bf085dc) amtk: 5.5.1 → 5.5.2
* [`d4a8bdec`](https://github.com/NixOS/nixpkgs/commit/d4a8bdecc7d6e0d5c2e399a23f6624fd0d746327) gnome.eog: 43.0 → 43.1
* [`91135c92`](https://github.com/NixOS/nixpkgs/commit/91135c92cc7f6c72c021ad88160b3c9452c403db) gnome.gnome-remote-desktop: 43.0 → 43.1
* [`93868687`](https://github.com/NixOS/nixpkgs/commit/938686871d6f12570fd64a93f0da025dc2a56c37) gtk4: 4.8.1 → 4.8.2
* [`95aa107f`](https://github.com/NixOS/nixpkgs/commit/95aa107f7c7b9e2626ca4e125a689fdd7cc3d85a) werf: 1.2.180 -> 1.2.184
* [`4135fb7e`](https://github.com/NixOS/nixpkgs/commit/4135fb7eaf82dca8cbb1ad34e764c4d52e85082f) Musescore: make QT_QPA_PLATFORM env var overridable
* [`22834c42`](https://github.com/NixOS/nixpkgs/commit/22834c42cc688b4e52a96d17b0d2a71698125239) gnome.nautilus: use the gtk4 FileChooser settings schema (fixes crash-on-start)
* [`159848d8`](https://github.com/NixOS/nixpkgs/commit/159848d8eb0fe08a4037c604683eb837265c2cb9) python310Packages.pyskyqremote: 0.3.16 -> 0.3.17
* [`1526a1b0`](https://github.com/NixOS/nixpkgs/commit/1526a1b04145ba66e10127c7d6f0ef1a3d30cfcd) adguardhome: Add schema_version
* [`f20d74f0`](https://github.com/NixOS/nixpkgs/commit/f20d74f0d9aa3f97a05c695db8d35dfc360a782e) cjose: 0.6.2 -> 0.6.2.1
* [`fd0a5f37`](https://github.com/NixOS/nixpkgs/commit/fd0a5f378b546007d78f197d01f4e1b4a37a1bc3) cargo-llvm-lines: 0.4.18 -> 0.4.19
* [`882cedd1`](https://github.com/NixOS/nixpkgs/commit/882cedd1a9fc2b12db719706c3376e7ad09fc1e6) cargo-update: 10.0.1 -> 11.0.0
* [`bf3d4513`](https://github.com/NixOS/nixpkgs/commit/bf3d4513a1e80f98cc652d3af2d76b167a2d74b9) bzip3: 1.1.6 -> 1.1.7
* [`5136fd87`](https://github.com/NixOS/nixpkgs/commit/5136fd872073849e9e777b90a998fe037034943b) brev-cli: 0.6.128 -> 0.6.130
* [`c17abb36`](https://github.com/NixOS/nixpkgs/commit/c17abb3648fc1ad60692582b3a54c75ffaa62dbf) antimicrox: 3.2.5 -> 3.3.1
* [`4986855c`](https://github.com/NixOS/nixpkgs/commit/4986855cd5af22a76ff938caa65773b5e9e2d87a) memtest86plus: 6.00-beta2 -> 6.00
* [`36bf8e0b`](https://github.com/NixOS/nixpkgs/commit/36bf8e0b54d758297014054f67d192da9548ab12) datree: 1.6.40 -> 1.6.42
* [`b942daaf`](https://github.com/NixOS/nixpkgs/commit/b942daaf3f8bd0a4a042dba82014f738bc43e8fd) flexget: 3.3.39 -> 3.4.0
* [`21099908`](https://github.com/NixOS/nixpkgs/commit/2109990852da1206a3e65c1a1ea35b63e96accaf) docker-slim: 1.38.0 -> 1.39.0
* [`b8995de2`](https://github.com/NixOS/nixpkgs/commit/b8995de2c5d42fc97f23737efc3a8179219af8a5) python310Packages.policy-sentry: 0.12.4 -> 0.12.5
* [`1c06cf97`](https://github.com/NixOS/nixpkgs/commit/1c06cf972cdefeb7453e4b130a4db3bac45a1fbe) flyctl: 0.0.417 -> 0.0.419
* [`0d067d9a`](https://github.com/NixOS/nixpkgs/commit/0d067d9a2961cf7cf4df41d2c75667cd4d80952c) autotiling: 1.6.1 -> 1.7
* [`625e4a55`](https://github.com/NixOS/nixpkgs/commit/625e4a55d1d00e444004107aab36d0b475a0c858) wishlist: 0.7.0 -> 0.8.0
* [`1a7a61b7`](https://github.com/NixOS/nixpkgs/commit/1a7a61b7bd42e52f7e8c85f58664116af83d836e) mu: 1.8.10 -> 1.8.11
* [`e45e796c`](https://github.com/NixOS/nixpkgs/commit/e45e796ceb32fb395ef79c1d206c77ba7d59add0) fwanalyzer: 1.4.3 -> 1.4.4
* [`b410bee3`](https://github.com/NixOS/nixpkgs/commit/b410bee3cdea9365afcd9f342839d5b6e51c2df4) SDL_compat: 1.2.56 -> 1.2.60
* [`9f8a55ae`](https://github.com/NixOS/nixpkgs/commit/9f8a55aee51d118f81fb66af3691b359a306d00b) python3Packages.flit-scm: init at 1.7.0
* [`d3f82570`](https://github.com/NixOS/nixpkgs/commit/d3f8257013372d089a3e84a0c5df6cee0f83650a) gucci: 1.5.4 -> 1.6.5
* [`ff3cb04f`](https://github.com/NixOS/nixpkgs/commit/ff3cb04f66fc9931cd4fea6892edaffc3cb5c376) python310Packages.pytest-qt: 4.1.0 -> 4.2.0
* [`706d5a92`](https://github.com/NixOS/nixpkgs/commit/706d5a92377d9b5ae3717208bb51affea804dbfa) python310Packages.pytest-testmon: 1.3.7 -> 1.4.0
* [`2fed795f`](https://github.com/NixOS/nixpkgs/commit/2fed795fb20a676d36c196cd8225453b6dcbddee) ihp-new: 0.20.0 -> 1.0.0
* [`46d60946`](https://github.com/NixOS/nixpkgs/commit/46d6094610e4208c3f5661bbc8c3739bc532054e) colloid-icon-theme: 2022-04-22 -> 2022-10-26
* [`b9c49361`](https://github.com/NixOS/nixpkgs/commit/b9c493616b37cfd3859554a68e8207bcfca9e307) joker: 1.0.1 -> 1.0.2
* [`4a089cd6`](https://github.com/NixOS/nixpkgs/commit/4a089cd67f5c60d29cf350704032cbcff5b599d4) nodePackages.graphite-cli: add bash and zsh completion
* [`0e8152a5`](https://github.com/NixOS/nixpkgs/commit/0e8152a5bf83689fc1b4d3f2f8cabdb1b1ede34c) rehex: 0.5.3 -> 0.5.4
* [`35da064e`](https://github.com/NixOS/nixpkgs/commit/35da064ed5748393e7851759bad25c3c655a1dd5) sonic-server: init at 1.4.0
* [`fe16cfef`](https://github.com/NixOS/nixpkgs/commit/fe16cfefc1209a7e740b93326b620d12ecc31134) python310Packages.pytibber: 0.25.4 -> 0.25.6
* [`b62ef865`](https://github.com/NixOS/nixpkgs/commit/b62ef86559d949e619cbf1771bf1489736107135) sagoin: init at 0.1.0
* [`dd60a2df`](https://github.com/NixOS/nixpkgs/commit/dd60a2dfeef8e1e9d08c382968a023d781f0dcde) cargo-hack: 0.5.21 -> 0.5.22
* [`22250fdc`](https://github.com/NixOS/nixpkgs/commit/22250fdc684bb3c18314feefb38e01da1a43d3b3) nix-output-monitor: 2.0.0.2 -> 2.0.0.3
* [`0e6c2eeb`](https://github.com/NixOS/nixpkgs/commit/0e6c2eebc5a1beb3771a6bdef4ec874806ed7995) limesctl: 3.0.2 -> 3.0.3
* [`ccd82997`](https://github.com/NixOS/nixpkgs/commit/ccd829971495b1af11970f68207da10efa6acf03) zeroad: fix build
* [`f709a74f`](https://github.com/NixOS/nixpkgs/commit/f709a74fa331b30b0bfce73eefef646a030a49c2) chromium{Beta,Dev}: Fix the configuration phase
* [`8c98001a`](https://github.com/NixOS/nixpkgs/commit/8c98001a29082b83d83357d3ef38f78f48956a21) mangal: 3.14.0 -> 3.14.2
* [`7bc5b257`](https://github.com/NixOS/nixpkgs/commit/7bc5b257fb0600381807203aa38411a2428efe1e) minio-client: 2022-10-20T23-26-33Z -> 2022-10-22T03-39-29Z
* [`1c1d1c70`](https://github.com/NixOS/nixpkgs/commit/1c1d1c70b8def22ae495c4d833230d66b0dbdb8d) minio: 2022-10-21T22-37-48Z -> 2022-10-24T18-35-07Z
* [`3689a766`](https://github.com/NixOS/nixpkgs/commit/3689a76637f9b233529ec79d0927142ff28b0a5a) awscli2: 2.7.33 -> 2.8.5 ([nixos/nixpkgs⁠#197270](https://togithub.com/nixos/nixpkgs/issues/197270))
* [`a8536ad1`](https://github.com/NixOS/nixpkgs/commit/a8536ad12ea6d4afa5439913c0d48bfcb973d19d) svtplay-dl: 4.13 -> 4.14
* [`2bdcaca2`](https://github.com/NixOS/nixpkgs/commit/2bdcaca2968f3ef79fa3133c351fdc32c1535e65) svtplay-dl: update formatting and float version
* [`8bec7996`](https://github.com/NixOS/nixpkgs/commit/8bec7996cc29c64b8bb402241597ad4141d01406) doc: fix syntax error in Lua documentation
* [`fc7d8341`](https://github.com/NixOS/nixpkgs/commit/fc7d834148746d489a5c4b920859ff5a2e887209) mattermost: 7.3.0 -> 7.4.0
* [`fedb67d1`](https://github.com/NixOS/nixpkgs/commit/fedb67d110921ee0b27bf5366e5d813ff5b59323) python310Packages.cpyparsing: 2.4.7.1.1.0 -> 2.4.7.1.2.0
* [`4a63622b`](https://github.com/NixOS/nixpkgs/commit/4a63622bd1d5ffdf6f50bc55c8219c22cc715009) arkade: 0.8.47 -> 0.8.48
* [`ac6cf8a7`](https://github.com/NixOS/nixpkgs/commit/ac6cf8a78b688fdae6e4f6c3008a0b3925d3f22d) smokeping: Link to test
* [`f5c53868`](https://github.com/NixOS/nixpkgs/commit/f5c53868700881084a0d132aa18e24d3b71698a3) nixos/smokeping: Don't show `413 Forbidden` on thttpd `/`. Fixes [nixos/nixpkgs⁠#197704](https://togithub.com/nixos/nixpkgs/issues/197704)
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
