### PR TITLE
niv emacs-overlay: update cb7c1a56 -> f04cb6f6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cb7c1a5695d398a4c11501073d67735a5f876388",
-        "sha256": "15wxkfyghamnpaj3i988zkbxcx4yvrvk66b6zj3346xlrkp101wp",
+        "rev": "f04cb6f6724ba4568a7f6dae0863e507477667b7",
+        "sha256": "0bf79q471177ygiax2kyz0nh3j0h61k9rgkz5bn98zawzkvmd1c6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/cb7c1a5695d398a4c11501073d67735a5f876388.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/f04cb6f6724ba4568a7f6dae0863e507477667b7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@cb7c1a56...f04cb6f6](https://github.com/nix-community/emacs-overlay/compare/cb7c1a5695d398a4c11501073d67735a5f876388...f04cb6f6724ba4568a7f6dae0863e507477667b7)

* [`e2f22abd`](https://github.com/nix-community/emacs-overlay/commit/e2f22abd1e08a71a1c78a4a743e9d64f08a41bba) Updated repos/emacs
* [`ab39e411`](https://github.com/nix-community/emacs-overlay/commit/ab39e4112f2f97fa5e13865fa6792e00e6344558) Updated repos/melpa
* [`bcd8263a`](https://github.com/nix-community/emacs-overlay/commit/bcd8263acbcfc7ed9b832e06b39fb4ab419cfe40) Updated repos/emacs
* [`ae21b52e`](https://github.com/nix-community/emacs-overlay/commit/ae21b52edf29524933af2b25dfc49f4667676c55) Updated repos/melpa
* [`28776440`](https://github.com/nix-community/emacs-overlay/commit/28776440391fa59b7a46ad2f351d160e308a7012) Updated repos/elpa
* [`79fed4c4`](https://github.com/nix-community/emacs-overlay/commit/79fed4c4a5fdef7023f5ba5263d05575d3c5d5b0) Updated repos/emacs
* [`743eac3d`](https://github.com/nix-community/emacs-overlay/commit/743eac3d8c14d8fac226be1ca33f1f1da6cd3a33) Updated repos/melpa
* [`11f8196d`](https://github.com/nix-community/emacs-overlay/commit/11f8196d36b283a17697e8cb69ba1e03421c64ce) Updated repos/emacs
* [`334faf0d`](https://github.com/nix-community/emacs-overlay/commit/334faf0d8b667c6a4b0b8f16a809bc3c24e132bd) Updated repos/melpa
* [`f8e2ddd5`](https://github.com/nix-community/emacs-overlay/commit/f8e2ddd5bc27b1d5be1a63f27fdde58dc5a1297f) Updated repos/nongnu
* [`380e40d4`](https://github.com/nix-community/emacs-overlay/commit/380e40d49b71b43c6d18738afc631f8e80ba3e79) Updated repos/emacs
* [`89f4ae75`](https://github.com/nix-community/emacs-overlay/commit/89f4ae7539fa59eb122d9ce8198e1926f925727e) Updated repos/melpa
* [`76be734c`](https://github.com/nix-community/emacs-overlay/commit/76be734ca0a6a3c9649de4beab626e8990e10333) Updated repos/nongnu
* [`c3faa1e8`](https://github.com/nix-community/emacs-overlay/commit/c3faa1e8ddf2bf4e859c3cbeba913de67f75fa27) Updated repos/elpa
* [`e2e67e3a`](https://github.com/nix-community/emacs-overlay/commit/e2e67e3a5327bccb0eafac46cf0a72dbf9cf9bce) Updated repos/emacs
* [`a0d5fcbe`](https://github.com/nix-community/emacs-overlay/commit/a0d5fcbec0f9b5613c3109d434b6ff4e5b419ae8) Updated repos/melpa
* [`2a5cbb86`](https://github.com/nix-community/emacs-overlay/commit/2a5cbb864ea7d5eab87b13eabcf8d883e24326e0) Updated repos/emacs
* [`620f79f8`](https://github.com/nix-community/emacs-overlay/commit/620f79f8ca3c3f30536a9a3cd27e74fc6e34af36) Updated repos/melpa
* [`5fb7020f`](https://github.com/nix-community/emacs-overlay/commit/5fb7020f50844c8a9e4b2de8b51a42354e420dfd) Updated repos/elpa
* [`20d0237f`](https://github.com/nix-community/emacs-overlay/commit/20d0237f2d863a816ef6c6c1c0ec818c8bece502) Updated repos/emacs
* [`ccefa5f7`](https://github.com/nix-community/emacs-overlay/commit/ccefa5f7ddbb036656d8617ed2862fe057d60fb4) Updated repos/melpa
* [`5970c1a2`](https://github.com/nix-community/emacs-overlay/commit/5970c1a2687c002167b9c0b9a941f67efc2c6787) Updated repos/elpa
* [`f192bf30`](https://github.com/nix-community/emacs-overlay/commit/f192bf30615fa3f600e543293522f566a8dd40aa) Updated repos/emacs
* [`6f5b9e6e`](https://github.com/nix-community/emacs-overlay/commit/6f5b9e6e9b04a750edfa9e706173635186e2c7ea) Updated repos/melpa
* [`35d69d22`](https://github.com/nix-community/emacs-overlay/commit/35d69d22102ab227f95358cf7aa4da0f54429727) Updated repos/emacs
* [`ee6fe6ed`](https://github.com/nix-community/emacs-overlay/commit/ee6fe6ed0c5e101d1ef87d6ad843ec5b646fb993) Updated repos/melpa
* [`307dfb67`](https://github.com/nix-community/emacs-overlay/commit/307dfb67a8080125c50d0c99f6bf6178a23395f7) Updated repos/nongnu
* [`e897fe14`](https://github.com/nix-community/emacs-overlay/commit/e897fe145640937ff8454600f2f0721d7cf04dfc) Updated repos/elpa
* [`2630c11c`](https://github.com/nix-community/emacs-overlay/commit/2630c11cc69a95579e7a6aab094926f84477e3ac) Updated repos/emacs
* [`e465278b`](https://github.com/nix-community/emacs-overlay/commit/e465278b72617d97fb11ac49962c8093bace982d) Updated repos/melpa
* [`43adfe4c`](https://github.com/nix-community/emacs-overlay/commit/43adfe4cb4c9a9018960851495de626e7f525ffe) Updated repos/elpa
* [`f96963ab`](https://github.com/nix-community/emacs-overlay/commit/f96963ab9d5bed499f50bcb479f539c3e4f6ec8a) Updated repos/exwm
* [`b7dcebff`](https://github.com/nix-community/emacs-overlay/commit/b7dcebffaf478570c73595bd690ae7daf2e7d9f3) Updated repos/melpa
* [`6c99919f`](https://github.com/nix-community/emacs-overlay/commit/6c99919ff23ccd79c5fec1753da21ff0944403b2) Updated repos/melpa
* [`b41d21c5`](https://github.com/nix-community/emacs-overlay/commit/b41d21c59570026872ca7791290a7f4a5ef72213) Updated repos/emacs
* [`38fc8434`](https://github.com/nix-community/emacs-overlay/commit/38fc843411aa7cd8406dfc4a2e457a7081bf2a91) Updated repos/melpa
* [`7faa1ab6`](https://github.com/nix-community/emacs-overlay/commit/7faa1ab63f64748c4fb86e2e75471d0385f1b5e8) Updated repos/emacs
* [`dbd801d1`](https://github.com/nix-community/emacs-overlay/commit/dbd801d11a1e65af31524fddede8d524151c737e) Updated repos/melpa
* [`7317731b`](https://github.com/nix-community/emacs-overlay/commit/7317731bc2a3eafafb294c5e68e097bfd13e18f1) Updated repos/emacs
* [`c009b388`](https://github.com/nix-community/emacs-overlay/commit/c009b388c8c2514b24baf6231c5612192c25745c) Updated repos/melpa
* [`f572f85e`](https://github.com/nix-community/emacs-overlay/commit/f572f85e47623837f908862492684fb0469d7e11) Updated repos/elpa
* [`df8c7f08`](https://github.com/nix-community/emacs-overlay/commit/df8c7f0840a2e488fcc76e6b87f4b5690d2083c5) Updated repos/emacs
* [`5d990c40`](https://github.com/nix-community/emacs-overlay/commit/5d990c40dade9eb7353fbb7ca3713310c1e86cad) Updated repos/melpa
* [`c2b0f1e3`](https://github.com/nix-community/emacs-overlay/commit/c2b0f1e33097e7bc4f7cdbd307b1e28ad8777ad3) Updated repos/emacs
* [`4d8d63d6`](https://github.com/nix-community/emacs-overlay/commit/4d8d63d6c02ffb4d6830812ce1358a0920d94495) Updated repos/melpa
* [`ef160fd0`](https://github.com/nix-community/emacs-overlay/commit/ef160fd067799a9a56752793c0d785909a65630f) Updated repos/emacs
* [`bf6140f8`](https://github.com/nix-community/emacs-overlay/commit/bf6140f871c21c7d0c4b0c37f0918400c5bedb89) Updated repos/melpa
* [`a864e84b`](https://github.com/nix-community/emacs-overlay/commit/a864e84bd842d00d686e040f552e2fa7030351a0) Updated repos/nongnu
* [`c6b2079b`](https://github.com/nix-community/emacs-overlay/commit/c6b2079be7bc013a4167fd127ab45afb8ebf2e64) Updated repos/elpa
* [`479b8d4b`](https://github.com/nix-community/emacs-overlay/commit/479b8d4b0fb624c6469d476f850952943f18b6fb) Updated repos/emacs
* [`b4b8a50d`](https://github.com/nix-community/emacs-overlay/commit/b4b8a50d8084f9ec21cdc1410f76cedc87c2a997) Updated repos/melpa
* [`68f498ae`](https://github.com/nix-community/emacs-overlay/commit/68f498ae593a711f7399bd841da982e7e9576e9f) Updated repos/emacs
* [`3cdc5328`](https://github.com/nix-community/emacs-overlay/commit/3cdc5328d2cd752bd479ff098a8aac9be0c23bf1) Updated repos/melpa
* [`f04cb6f6`](https://github.com/nix-community/emacs-overlay/commit/f04cb6f6724ba4568a7f6dae0863e507477667b7) Updated repos/nongnu
