### PR TITLE
niv powerlevel10k: update 8091c8a3 -> 5a3109e4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "8091c8a3a8a845c70046684235a01cd500075def",
-        "sha256": "16kfg9073qxzdbn8a7i631ciiqbw2vxbrkc467hrsvf2sn9fskr3",
+        "rev": "5a3109e40d2843d5e93d238568abaf5d5bc5d85a",
+        "sha256": "0lh58n9iym1n296yv9cf0zfh2jbv12rn9p0cbjqc9g2sqgywrq6x",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/8091c8a3a8a845c70046684235a01cd500075def.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/5a3109e40d2843d5e93d238568abaf5d5bc5d85a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@8091c8a3...5a3109e4](https://github.com/romkatv/powerlevel10k/compare/8091c8a3a8a845c70046684235a01cd500075def...5a3109e40d2843d5e93d238568abaf5d5bc5d85a)

* [`b8c6c6f4`](https://github.com/romkatv/powerlevel10k/commit/b8c6c6f42f8b40fb7668bcb23c4abbd416234fc1) Add chruby config to hide RUBY_ENGINE when "ruby"
* [`5a3109e4`](https://github.com/romkatv/powerlevel10k/commit/5a3109e40d2843d5e93d238568abaf5d5bc5d85a) replace POWERLEVEL9K_CHRUBY_SHOW_ENGINE_IF_RUBY with POWERLEVEL9K_CHRUBY_SHOW_ENGINE_PATTERN ([romkatv/powerlevel10k⁠#2072](https://togithub.com/romkatv/powerlevel10k/issues/2072))
