### PR TITLE
niv spacemacs: update cdf5045c -> 0acf65c4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "cdf5045cd8e27f7dfea1a56358e6e5772f4957f6",
-        "sha256": "15gzc7kpcbk61jib2smx6wwfy1bh5m782brgjnr1zawa8szya9xw",
+        "rev": "0acf65c4c5b15bcd05902d5aa981f5831476ae18",
+        "sha256": "1kk50s3g6qzv1w4dfsjmvykigqhkm0hg0m1jqp0glnv70g4dbsc9",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/cdf5045cd8e27f7dfea1a56358e6e5772f4957f6.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/0acf65c4c5b15bcd05902d5aa981f5831476ae18.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@cdf5045c...0acf65c4](https://github.com/syl20bnr/spacemacs/compare/cdf5045cd8e27f7dfea1a56358e6e5772f4957f6...0acf65c4c5b15bcd05902d5aa981f5831476ae18)

* [`9541a8e0`](https://github.com/syl20bnr/spacemacs/commit/9541a8e0a8234d894faffdd20fa5c920b700c868) Add support for background transparency toggling.
* [`e3895f21`](https://github.com/syl20bnr/spacemacs/commit/e3895f2168f856849efafc120b06e1660626e73b) core/core-spacemacs-buffer.el: fix error for using `set' on a lexical varaible
* [`089d513f`](https://github.com/syl20bnr/spacemacs/commit/089d513fecdea1e18e036abce7b5eb60d880630b) core/core-release-management: load "core/core-load-paths" without suffix
* [`5cb690b3`](https://github.com/syl20bnr/spacemacs/commit/5cb690b3874f1f0ed7a7d93b9fd8e0e642d38fd2) fix: https://github.com/syl20bnr/spacemacs/issues/15699
* [`24114c3b`](https://github.com/syl20bnr/spacemacs/commit/24114c3b06f325c203d470cc7ceca6226fde334e) layers/+spacemacs: project: add projectile-install binding
* [`0acf65c4`](https://github.com/syl20bnr/spacemacs/commit/0acf65c4c5b15bcd05902d5aa981f5831476ae18) Add missing description of projectile-install-project
