### PR TITLE
niv zsh-completions: update b4ec85ed -> b736f267

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "b4ec85ede711a4854542682d43c7ae47d7df6d35",
-        "sha256": "060krascgyjv0lwi855x2xqcgil0izpixp3mzkq8nl9l6l14bf82",
+        "rev": "b736f2679c4da5b51d80077d3c00f32009cd38e7",
+        "sha256": "0f13f7s94irgkf5b2k3mdcz91yyyiximmcxmj0dq3bpgncmcb0kh",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/b4ec85ede711a4854542682d43c7ae47d7df6d35.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/b736f2679c4da5b51d80077d3c00f32009cd38e7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@b4ec85ed...b736f267](https://github.com/zsh-users/zsh-completions/compare/b4ec85ede711a4854542682d43c7ae47d7df6d35...b736f2679c4da5b51d80077d3c00f32009cd38e7)

* [`c1de68a8`](https://github.com/zsh-users/zsh-completions/commit/c1de68a88ffc548a14048be2616e8fa8464c1a28) make httpie completion work for both `http` and `https`
* [`3e46a875`](https://github.com/zsh-users/zsh-completions/commit/3e46a875d43cd82020e5ec0772880cdc9dc405d4) Original sed code does not work on BSD sed with BRE
* [`4bf24327`](https://github.com/zsh-users/zsh-completions/commit/4bf24327bac61442716f02c38f7382c9e89ace7e) Extract generators from 'cmake --help'
* [`bfc56a2e`](https://github.com/zsh-users/zsh-completions/commit/bfc56a2e4cd4a02c324e6fcee99bed9d4e947136) Update httpie completion and reformat code
* [`09131435`](https://github.com/zsh-users/zsh-completions/commit/0913143538c0b04a73670e3eede383529d6cea0b) Update afew
