### PR TITLE
niv nixpkgs: update 3ec797ef -> a0bf7e25

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ec797ef2ada075b52be5bfd8ce92635b6154ad3",
-        "sha256": "05v14fnjqxa2sdxbirv6wl8jcsnl6ah286bdji84y59y75sr1n2i",
+        "rev": "a0bf7e251c9e830157475684e19ca6ae129102a4",
+        "sha256": "0qiyhmhgdd4nyfcnhl1wwpmbp24bdlz873f32crcr068aj04rzfl",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/3ec797ef2ada075b52be5bfd8ce92635b6154ad3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a0bf7e251c9e830157475684e19ca6ae129102a4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@3ec797ef...a0bf7e25](https://github.com/nixos/nixpkgs/compare/3ec797ef2ada075b52be5bfd8ce92635b6154ad3...a0bf7e251c9e830157475684e19ca6ae129102a4)

* [`263c233e`](https://github.com/NixOS/nixpkgs/commit/263c233e514ea4a49d1e5c904d78c31b19c450ae) prometheus-exporter/unifi-poller: Add loki config
* [`786216df`](https://github.com/NixOS/nixpkgs/commit/786216dfcb12fa850a8d79b18a44f0c03fe23df1) top-level: Ignore Emacs lock files when looking for overlays
* [`26ca4d15`](https://github.com/NixOS/nixpkgs/commit/26ca4d15878e89ee428b8908f350256e3210998e) nixos/prometheus: Harden systemd service
* [`58919907`](https://github.com/NixOS/nixpkgs/commit/58919907a73f2bd0329f8943875d7bab9c5eca8e) phpPackages: set meta.mainProgram
* [`3149b6ff`](https://github.com/NixOS/nixpkgs/commit/3149b6ff316e2c015acc708fc06bdc4ddc02af8e) python310Packages.sanic: 22.3.2 -> 22.6.2
* [`e8995b4f`](https://github.com/NixOS/nixpkgs/commit/e8995b4f1657beebfc1d06e53d57efafb7277d94) python310Packages.aioquic: init at 0.9.20
* [`8c000f26`](https://github.com/NixOS/nixpkgs/commit/8c000f265156a3c056626c3fe388914aa06ac4be) python310Packages.pysqpack: init at 0.3.16
* [`6eaabd29`](https://github.com/NixOS/nixpkgs/commit/6eaabd29a3c87c8c0155352faffd81944ed36e6e) roundcubePlugins.contextmenu: init at 3.3.1
* [`73f2fb24`](https://github.com/NixOS/nixpkgs/commit/73f2fb2441f59b516e9a444fe931e45d4ee8f82b) renderdoc: 1.21 -> 1.22
* [`aa5e70ec`](https://github.com/NixOS/nixpkgs/commit/aa5e70ecc7da1d7e3b1d0351a2d43e8a89bdffe0) lidarr: 0.8.1.2135 -> 1.0.2.2592
* [`823e4d2f`](https://github.com/NixOS/nixpkgs/commit/823e4d2fdbd213c2c85806fe4ee3e2c824c9030c) nixos/nextcloud: handle passwords with spaces
* [`7bec82f4`](https://github.com/NixOS/nixpkgs/commit/7bec82f49e00b89a7f0c52e1a0c653138a2a77b1) cmake: check if NIX_CC exists before using it
* [`a1e07d8e`](https://github.com/NixOS/nixpkgs/commit/a1e07d8eda7818c8b5b8fd5c1dc59d1f37771960) gllvm: 1.3.0 -> 1.3.1
* [`6877efb1`](https://github.com/NixOS/nixpkgs/commit/6877efb1354030630ab35d06a3b51cd1409331c0) jitsi-videobridge: add openssl to LD_LIBRARY_PATH
* [`f43716f2`](https://github.com/NixOS/nixpkgs/commit/f43716f28e1c7c787e003bd83dd1e897b360240a) nixos: Add networking.fqdnOrHostName option, readOnly
* [`fec3f62d`](https://github.com/NixOS/nixpkgs/commit/fec3f62d38585455fe8bac4634e307d8728c387b) nixos/kubelet: Refactor to use config.networking.fqdnOrHostName
* [`185f12d9`](https://github.com/NixOS/nixpkgs/commit/185f12d96f46460e77589a079b079fd1d037b736) nixos/smartd: Refactor to use config.networking.fqdnOrHostName
* [`06a1a294`](https://github.com/NixOS/nixpkgs/commit/06a1a2946776aa5b50ac355c7641d23b17c9546e) nixos/flannel: Refactor to use config.networking.fqdnOrHostName
* [`12da62fe`](https://github.com/NixOS/nixpkgs/commit/12da62fef52151d67fe497c9b6af43b813fdd43b) nixos/jitsi-videobridge: Refactor to use config.networking.fqdnOrHostName
* [`c069475f`](https://github.com/NixOS/nixpkgs/commit/c069475f82927b401313b722437f52d0e577d45e) nixos/bookstack: Refactor to use config.networking.fqdnOrHostName
* [`5699ff52`](https://github.com/NixOS/nixpkgs/commit/5699ff529ad9d5959a4584531e242b5ab86a3889) nixos/discourse: Refactor to use config.networking.fqdnOrHostName
* [`ed5aa53f`](https://github.com/NixOS/nixpkgs/commit/ed5aa53f451ee1bea1922f8ffa9e2f3b73280723) nixos/matamo: Refactor to use config.networking.fqdnOrHostName
* [`1ab9d1be`](https://github.com/NixOS/nixpkgs/commit/1ab9d1beb1668e4cd3da2bfdd52851de0972a781) nixos/snipe-it: Refactor to use config.networking.fqdnOrHostName
* [`33c8c0fb`](https://github.com/NixOS/nixpkgs/commit/33c8c0fb00c5a5ca6a13cd0e61c43175ad73d21d) flake.nix: Improve nixosModules.notDetected error location reporting
* [`762a9d22`](https://github.com/NixOS/nixpkgs/commit/762a9d2222a8cbcdcc441b6e4fa1a4c37f7ae207) obs-studio-plugins.obs-pipewire-audio-capture: fix build for obs-28
* [`ddffb609`](https://github.com/NixOS/nixpkgs/commit/ddffb609f5d509c90d72d39525dce439a9f2362b) obs-studio-plugins.obs-move-transition: 2.4.3 -> 2.6.4
* [`d7ea3d70`](https://github.com/NixOS/nixpkgs/commit/d7ea3d708bf0a430ac7e23b4f5cbff7160d4b8d0) smokegen: init at v4.14.3
* [`fd3646f5`](https://github.com/NixOS/nixpkgs/commit/fd3646f5177ec74430218f1f24c1bc40be4990a2) smokeqt: init at v4.14.3
* [`422f1c24`](https://github.com/NixOS/nixpkgs/commit/422f1c24bd9ebb0c413d74bf11f28eb82441e525) sbclPackages: fix build of qt, qt-libs and qtools
* [`926e56c8`](https://github.com/NixOS/nixpkgs/commit/926e56c8880d125e558c9350fb93050f3ccfb5a0) obs-studio-plugins.wlrobs: 4184a4a8ea7dc054c993efa16007f3a75b2c6f51 -> 78be323b25e1365f5c8f9dcba6938063ca10f71f
* [`7a9d47de`](https://github.com/NixOS/nixpkgs/commit/7a9d47dea69555e7e3e7fd45895bd4f35be8e53d) cmake: check for `$ENV{NIX_CC}` with quotes
* [`18e3f431`](https://github.com/NixOS/nixpkgs/commit/18e3f431e1b36d4f569ddddd415f95921e1b7748) networking.fqdnOrHostName: Elaborate and format the descriptions
* [`36ebfaf8`](https://github.com/NixOS/nixpkgs/commit/36ebfaf8938b852423863f37c18602ecc0a550b7) libcamera: unstable-2022-09-15 -> 0.0.1
* [`2610d7de`](https://github.com/NixOS/nixpkgs/commit/2610d7dee38c830e297a16ebbd490492f5243a19) libcamera: fix IPA module signatures
* [`e0c70d5e`](https://github.com/NixOS/nixpkgs/commit/e0c70d5e0fb18605ce70a00eb7f18743a1eee29a) stdenvBootstrapTools: fix cycle on aarch64-darwin
* [`8fb885a1`](https://github.com/NixOS/nixpkgs/commit/8fb885a19e05bcdebc0215a85cbd623c4227d25b) qt{5,6}: disable QML disk cache by default
* [`39d6cfd6`](https://github.com/NixOS/nixpkgs/commit/39d6cfd68f8bdb531034feaff8e5e95482123642) nixos/sddm: remove stale qmlcache workaround
* [`04706f6b`](https://github.com/NixOS/nixpkgs/commit/04706f6b127d7f48044269f4c985a88870d3006e) release-notes: add info about disabled QML cache
* [`043ada92`](https://github.com/NixOS/nixpkgs/commit/043ada923e786546a0b18f21e7fd5cd0694fd774) nicotine-plus: 3.2.4 -> 3.2.6
* [`9f7914af`](https://github.com/NixOS/nixpkgs/commit/9f7914afa2cd3ddf95621731e486eff2d3993c14) obs-studio: add 28.0.3 (parallel to 27.x)
* [`f1ed31ae`](https://github.com/NixOS/nixpkgs/commit/f1ed31ae01b565dbefe8db13537603572e253c8a) python310Packages.google-cloud-bigtable: 2.11.3 -> 2.13.2
* [`0231a79c`](https://github.com/NixOS/nixpkgs/commit/0231a79c1dcde4e1ec5a4ca15e6240fd50bb8ccb) ocamlPackages.ppxlib: 0.24.0 -> 0.28.0
* [`9413e942`](https://github.com/NixOS/nixpkgs/commit/9413e94226fc2568f189b7a717d2b3abf735a430) ocamlPackages.ppx_sexp_conv: 0.15.0 -> 0.15.1
* [`d66b2d9f`](https://github.com/NixOS/nixpkgs/commit/d66b2d9f0223e69560bd81694f291021490d581a) ocamlPackages.sedlex: 2.5 -> 2.6
* [`d2547fef`](https://github.com/NixOS/nixpkgs/commit/d2547fef54c9de3db95f390018e6147f083fb733) ocamlPackages.ppx_deriving_yojson: 3.6.1 -> 3.7.0
* [`b1e1e9cb`](https://github.com/NixOS/nixpkgs/commit/b1e1e9cbb53007c66245db6675f2aca4342ab906) ocamlPackages.ppx_import: add version 1.10.0
* [`8cd130f9`](https://github.com/NixOS/nixpkgs/commit/8cd130f9f94aad1b7a4b489efb5c6ebb0b20dd57) ocamlPackages.gen_js_api: 1.0.9 -> 1.1.1
* [`af190256`](https://github.com/NixOS/nixpkgs/commit/af1902560395f6f7fcb0283794127ed66e5d31a5) ocamlPackages.piqi: 0.6.15 -> 0.6.16
* [`3a669e05`](https://github.com/NixOS/nixpkgs/commit/3a669e05fde40fdf274f5a01796aa3a376e1eec7) ocamlpackages.piqi-ocaml: 0.7.7 -> 0.7.8
* [`c486b148`](https://github.com/NixOS/nixpkgs/commit/c486b14861116a214c0d72eb7fba17e95dd3f9b4) ocamlPackages.ppx_deriving_cmdliner: compatibility with ppxlib-0.26
* [`ab89457d`](https://github.com/NixOS/nixpkgs/commit/ab89457dd110f7582336e7717121de78e926e2d6) ocamlPackages.bisect_ppx: compatibility with ppxlib-0.28
* [`15b6e9ef`](https://github.com/NixOS/nixpkgs/commit/15b6e9efd4f4f7a2f0d530f102edd2f07f787d78) fstar: do not use ppxlib >= 0.26
* [`4b73e231`](https://github.com/NixOS/nixpkgs/commit/4b73e231f9bb41a2fbc7720923715899b26bdb97) linuxHeaders: use elf-header from build packages
* [`5f5bb450`](https://github.com/NixOS/nixpkgs/commit/5f5bb45093f45332b975beaf0507c875dfaf1512) octopus-caller: backport patch to fix build
* [`7df1d0fd`](https://github.com/NixOS/nixpkgs/commit/7df1d0fd99f7d18a26c7139a0dcde37c4a59532f) openfortivpn: 1.17.3 -> 1.19.0
* [`bd7c85ec`](https://github.com/NixOS/nixpkgs/commit/bd7c85ecad8966b2ce706812944bf225ae20c635) linuxPackages.perf: fix cross-compilation by providing HOSTLD
* [`0b5be61c`](https://github.com/NixOS/nixpkgs/commit/0b5be61ca10651c60fb762e4332d9725a5cc4624) glib: 2.74.0 → 2.74.1
* [`b9467872`](https://github.com/NixOS/nixpkgs/commit/b946787204aea4d67126c31ac4851dee618125df) spark2014: init at unstable-2022-05-25
* [`77bd639c`](https://github.com/NixOS/nixpkgs/commit/77bd639c4c92c819c1f4444a112d2bcc72c5b92f) cc-wrapper: adding a cc-wrapper-hook to the cc-wrapper
* [`1bab4177`](https://github.com/NixOS/nixpkgs/commit/1bab4177ac5dc56369910b03ab3cc37a231bf3cb) tracker: 3.4.0 → 3.4.1
* [`65778c0d`](https://github.com/NixOS/nixpkgs/commit/65778c0da29330227ccc2e08144484964a8ae196) signald: 0.19.1 -> 0.23.0
* [`84d67f05`](https://github.com/NixOS/nixpkgs/commit/84d67f05746038382426c3d72ebb7daf3fab1557) licenses: remove fdl11
* [`06d0490a`](https://github.com/NixOS/nixpkgs/commit/06d0490ab3f6b7e65b30916ffc394ebd07215fbb) licenses: remove fdl12
* [`79f51744`](https://github.com/NixOS/nixpkgs/commit/79f517445587287d330355a6047a7a9883ffc5e5) licenses: remove fdl13
* [`d3b690da`](https://github.com/NixOS/nixpkgs/commit/d3b690da9b7a75dcd6c7d589e37a8c28845c12d8) mozillavpn: 2.9.0 → 2.10.1
* [`f980fb04`](https://github.com/NixOS/nixpkgs/commit/f980fb0485b9d88f3a373c05c11ed73e4f482a8a) python310Packages.psutil: 5.9.2 -> 5.9.3
* [`ac82616a`](https://github.com/NixOS/nixpkgs/commit/ac82616ab524910f8efe48db941d8dbcb6c8d3ab) open-vm-tools: format
* [`d982d062`](https://github.com/NixOS/nixpkgs/commit/d982d062d80eaca95a4156b3eb1314f091a13cde) python310Packages.exceptiongroup: 1.0.0rc9 -> 1.0.0
* [`867ebb31`](https://github.com/NixOS/nixpkgs/commit/867ebb3100f94a10f0975f3b4bb7235d6125c16a) python310Packages.cattrs: 22.1.0 -> 22.2.0
* [`31e379c2`](https://github.com/NixOS/nixpkgs/commit/31e379c2bbcc1ae6e6343d9374fdd68d72c25681) python310Packages.requests-cache: 0.9.7 -> 0.9.7
* [`8c6ed9a2`](https://github.com/NixOS/nixpkgs/commit/8c6ed9a2496b215eb4ba6c86028b0089fe72537d) python310Packages.build: 0.8.0 -> 0.9.0
* [`824662f6`](https://github.com/NixOS/nixpkgs/commit/824662f6c06ccbb9764a34d5fe5f140b15b6446a) xmlsec: propagate libxslt, cleanup meta
* [`4f28fea3`](https://github.com/NixOS/nixpkgs/commit/4f28fea37e6638c6f9e4030843028836242bec61) open-vm-tools: compile vgauth tool
* [`2f054ca9`](https://github.com/NixOS/nixpkgs/commit/2f054ca910062859398dc07753e083a96de67fa0) python310Packages.pymemcache: 3.5.2 -> 4.0.0
* [`ef5beda9`](https://github.com/NixOS/nixpkgs/commit/ef5beda91c592e14bee1f2aee6bf333d3df1a2de) python311Packages.cython: add patch for python3.11 compatibility
* [`1ee6495b`](https://github.com/NixOS/nixpkgs/commit/1ee6495bfef025d834ef0949f8b8f3bac97d2fd6) python310Packages.jupyter_core: 4.9.2 -> 4.11.2
* [`7e5832d0`](https://github.com/NixOS/nixpkgs/commit/7e5832d0039e51bb4b85d62b66212881abc4ccdf) python310Packages.mpmath: fix CVE-2021-29063
* [`0bd476ef`](https://github.com/NixOS/nixpkgs/commit/0bd476ef6e563bc013305f6092f7de5184618a7b) easeprobe: init at 1.9.0
* [`2b34a5c5`](https://github.com/NixOS/nixpkgs/commit/2b34a5c5fc145a3b64f8a77d22a11f318fb484e4) tailspin: init at 0.1
* [`723523d0`](https://github.com/NixOS/nixpkgs/commit/723523d07d6b07c3452bbd38aacf8e20e32bb12f) b2sum: unstable-2018-06-11 -> 20190724
* [`d2cd38dd`](https://github.com/NixOS/nixpkgs/commit/d2cd38dd31451c6aaa0bda526af32ccceb4909fc) python310Packages.py-cpuinfo: 8.0.0 -> 9.0.0
* [`21b06b57`](https://github.com/NixOS/nixpkgs/commit/21b06b57bc19648fe8a2dbe11979b2fd662f1e60) arduino-cli: 0.27.1 -> 0.28.0
* [`7d5f5e1f`](https://github.com/NixOS/nixpkgs/commit/7d5f5e1f2a9cac7ca960e1aa757f3bdb28bfddd1) tzdata: 2022e -> 2022f
* [`9f11933b`](https://github.com/NixOS/nixpkgs/commit/9f11933b1eb65c276aeead6f0280ab9037e27675) python3Packages.pytest-subtests: 0.8.0 -> 0.9.0
* [`06bc65dd`](https://github.com/NixOS/nixpkgs/commit/06bc65dd161c70417b797c5279d5c8436ca9bbdc) nixos/languagetool: fix startup configuration option
* [`a65d5339`](https://github.com/NixOS/nixpkgs/commit/a65d5339c50e79227b16b985d9c9a7a9a06f68f1) gotktrix: 0.1.4 -> unstable-2022-09-29
* [`d9246eab`](https://github.com/NixOS/nixpkgs/commit/d9246eabc6853a1bc8b1250555b8725e046c91f5) taglib: 1.12 -> 1.13
* [`b0bce6ae`](https://github.com/NixOS/nixpkgs/commit/b0bce6ae731d5be0aed3277eab29d7ae7491d08d) maintainers: add farnoy
* [`4e74b208`](https://github.com/NixOS/nixpkgs/commit/4e74b20841728a352a4d6fc915b160b2c521d017) flac: 1.4.1 -> 1.4.2
* [`6f7a7cff`](https://github.com/NixOS/nixpkgs/commit/6f7a7cffd2a5cab4460c0722b7ac4ee8cf8d6f07) flac: add meta.changelog
* [`a54597eb`](https://github.com/NixOS/nixpkgs/commit/a54597eb3d18590c111e97bd5a7ce39f556ebd29) oksh: 7.1 -> 7.2
* [`ccbce7e7`](https://github.com/NixOS/nixpkgs/commit/ccbce7e7eab24cb1e66e612ce39fbd62f5cc211f) icu72: init at 72.1
* [`aa09845c`](https://github.com/NixOS/nixpkgs/commit/aa09845c06698a8c696fadefc48b992b65d872d4) icu: 71.1 -> 72.1
* [`13736965`](https://github.com/NixOS/nixpkgs/commit/13736965d8378412fe16fc29bcf5fbfcc3bcb13f) jekyll-favicon: init at 1.1.0
* [`845c39ba`](https://github.com/NixOS/nixpkgs/commit/845c39bab5865e0d73ed03ceeddaaa97fcb887be) pythonFull: drop unused xlibsWrapper input
* [`6be6c336`](https://github.com/NixOS/nixpkgs/commit/6be6c336ba49417f3ea99af4e5b947066c085335) arangodb_3_9: init at 3.9.3
* [`d58d66e4`](https://github.com/NixOS/nixpkgs/commit/d58d66e466d1f8b37d239bbc65f908c15c4e3820) arangodb: 3.4.8 -> 3.9.3
* [`db418cf3`](https://github.com/NixOS/nixpkgs/commit/db418cf3d1f11921fdf58568aece49803ad498a4) arangodb/default.nix: format with nixpkgs-fmt
* [`45dd4a16`](https://github.com/NixOS/nixpkgs/commit/45dd4a163346fbb927063a8050e84e2bad0da716) arangodb_3_x: remove unsupported versions
* [`e1df4f5f`](https://github.com/NixOS/nixpkgs/commit/e1df4f5f210a08e4e1df3a43765d993cfb331fe2) arangodb: use gcc 10 (supported version)
* [`0da384e7`](https://github.com/NixOS/nixpkgs/commit/0da384e7aca3697b7049aaa00b751d8c8c055da9) arangodb: remove enableParallelBuilding
* [`a6ffb2d9`](https://github.com/NixOS/nixpkgs/commit/a6ffb2d9cb46dbb2f051767b3baa765cf5eeb8d2) arangodb: drop boost patch
* [`6c75f962`](https://github.com/NixOS/nixpkgs/commit/6c75f9621db94bee9ccebbe72102f8c6ad8d0a36) arangodb: 3.9.3 -> 3.10.0
* [`86e1247a`](https://github.com/NixOS/nixpkgs/commit/86e1247a47faf84a87c308050d6455db60c9f735) arangodb: note removal of old versions in rl-2211 notes
* [`c3bfecd1`](https://github.com/NixOS/nixpkgs/commit/c3bfecd161463fca58c8f7beb14eabd5d833c158) arangodb: disable "maintainer mode"
* [`cd06546e`](https://github.com/NixOS/nixpkgs/commit/cd06546e4e8ce307f60ef67e77d72da6029783c8) aliases.nix: add `throws` for arangodb_3_{3,4,5}
* [`9f1e7c2f`](https://github.com/NixOS/nixpkgs/commit/9f1e7c2f69eccffbbeb0acdc13d84e8c844e0025) arangodb: annotate gcc10Stdenv reasoning
* [`704d2dcc`](https://github.com/NixOS/nixpkgs/commit/704d2dccb95cb63d8f36f7a97b4e7fd975762691) arangodb: stdenvGcc10->stdenv since gcc 11+ is suggested
* [`b671f4f0`](https://github.com/NixOS/nixpkgs/commit/b671f4f09f32918ee830e0e4a721bf19fc1c9db7) arangodb: remove unused cmake flags
* [`56eecdae`](https://github.com/NixOS/nixpkgs/commit/56eecdae11307e6440709d74001246ff54638dcb) arangodb: stdenv->gcc10Stdenv to compile
* [`2f6e24b8`](https://github.com/NixOS/nixpkgs/commit/2f6e24b810aebf1ab37935f76e6aff6f45b771dd) arangodb: additional cmake flags for releases
* [`10fda118`](https://github.com/NixOS/nixpkgs/commit/10fda118ee23265d8bc55a81d7d8c650929b1ec9) arangodb: avoid reading /proc/cpuinfo during build
* [`6cb592a4`](https://github.com/NixOS/nixpkgs/commit/6cb592a4f271adc43fb417310487b07d562f2f41) arangodb: capitalize cmake flag
* [`1e171106`](https://github.com/NixOS/nixpkgs/commit/1e1711061ec2e9e7ac58505a15a71c11644e4860) arangodb: annotate reasoning for gcc 11->10 downgrade
* [`b594ac0d`](https://github.com/NixOS/nixpkgs/commit/b594ac0d726e58f1d9c4353fbee7af70de646dc5) arangodb: parameterize target architecture
* [`f5bab1e0`](https://github.com/NixOS/nixpkgs/commit/f5bab1e08332366b4c80c5ab5f7d7f5e7d1a8d3e) arangodb: no warning when defaulting target arch
* [`ad424ad8`](https://github.com/NixOS/nixpkgs/commit/ad424ad8007e7fecba3adfedfdc4f760c9d6951f) arangodb: parameterize whether to enable asm optimizations
* [`c2eaaae5`](https://github.com/NixOS/nixpkgs/commit/c2eaaae50d66a933e38256bdf5a3ae43430592a3) cargoSetupHook: pass host config flags
* [`7852c61b`](https://github.com/NixOS/nixpkgs/commit/7852c61b6ec7a4fb5f56b0bd06219224d9650dc8) cargo: no longer broken on musl
* [`6dbc4d9f`](https://github.com/NixOS/nixpkgs/commit/6dbc4d9fba4fba735ba8018f091a54a38c7a6c1c) python3Packages.ruamel-yaml-clib: 0.2.6 -> 0.2.7
* [`3f86920a`](https://github.com/NixOS/nixpkgs/commit/3f86920ae8de1aea22e16ce6ae7efa82da82692a) rPackages: CRAN and BioC update
* [`ab3e70ae`](https://github.com/NixOS/nixpkgs/commit/ab3e70ae07388b5f68edc82be64ccc827eee81fe) inetutils: 2.3 -> 2.4
* [`26e69f69`](https://github.com/NixOS/nixpkgs/commit/26e69f693f2b79d12282c759de54dc25a2b86c32) libcpuid: 0.6.0 -> 0.6.1
* [`065e2fe7`](https://github.com/NixOS/nixpkgs/commit/065e2fe7fb35fb0a03db35136228dd9e68280e93) libcpuid: add meta.changelog
* [`f9969a94`](https://github.com/NixOS/nixpkgs/commit/f9969a941e38239a25fdeb9ddf559ef6d31d4149) efivar: 37 -> 38
* [`49d994ef`](https://github.com/NixOS/nixpkgs/commit/49d994ef5bf70fa64e73f5ea0c9ceffe170f85e7) efibootmgr: 17 -> 18
* [`2e318e05`](https://github.com/NixOS/nixpkgs/commit/2e318e05ce6c2940f4736ed71a97ce6637177172) sparrow: 1.6.5 -> 1.7.0
* [`047448b0`](https://github.com/NixOS/nixpkgs/commit/047448b04c4e8ba270ae0e5a1189e5c7eff6e7de) sparrow: add update script
* [`1f197e24`](https://github.com/NixOS/nixpkgs/commit/1f197e240e837cc9b21714b79441cf823f0db13a) pythonRelaxDepsHook: improve Requires-Dist parsing
* [`8e364316`](https://github.com/NixOS/nixpkgs/commit/8e3643168858aa0d503ee2a4d39fb40eb582e503) arangodb: remove aarch64 support
* [`f2585031`](https://github.com/NixOS/nixpkgs/commit/f2585031bf963706bd33dad0aaa5f58280567533) arangodb: document new parameters and aarch64-linux drop
* [`7765dd12`](https://github.com/NixOS/nixpkgs/commit/7765dd12f1959dd5651bf9f113f3ee01598aa9b4) libxcrypt: 4.4.28 -> 4.4.29
* [`a8c76426`](https://github.com/NixOS/nixpkgs/commit/a8c76426460d8d5814db47b8224dc0feaa353b58) cldr-annotations: 41.0 -> 42.0
* [`fb2032f8`](https://github.com/NixOS/nixpkgs/commit/fb2032f86c6b1b80d50a5f73c298e79e925588dc) cogl: fix build on darwin
* [`51e07dff`](https://github.com/NixOS/nixpkgs/commit/51e07dffd0dd320135b42cb697916541cc9c1829) clutter: fix build on darwin
* [`7f25fde3`](https://github.com/NixOS/nixpkgs/commit/7f25fde30da558c29bde3d275857e38c6beb755e) clutter-gst: add darwin support
* [`6b93450a`](https://github.com/NixOS/nixpkgs/commit/6b93450a5c284f873f71a7c81d2dd5745808e2eb) clutter-gtk: add darwin support
* [`bc0889b9`](https://github.com/NixOS/nixpkgs/commit/bc0889b9e2877cb7e18b84bcf2fdeb6336a332cc) cogl: cleanup
* [`cf354582`](https://github.com/NixOS/nixpkgs/commit/cf354582c4e4398ebb1a2bdc738bc431d4868da5) safeeyes: move to all-packages
* [`2cd9eb8d`](https://github.com/NixOS/nixpkgs/commit/2cd9eb8daf4173a14a35f05e6ad8dcba65ea2b9f) sunshine: 0.14.1 -> 0.15.0
* [`bba03d39`](https://github.com/NixOS/nixpkgs/commit/bba03d39a96f81fa583f0bcfa1fa71ee2e6699c2) python310Packages.dill: 0.3.5.1 -> 0.3.6
* [`8ef33c9c`](https://github.com/NixOS/nixpkgs/commit/8ef33c9c5342287a32d31f03491a9c125ea68bf5) wine{Unstable,Staging}: 7.17 -> 7.18
* [`5f113c0a`](https://github.com/NixOS/nixpkgs/commit/5f113c0a806e4fdc0b792e99d543adcd41a9db06) wine{Unstable,Staging}: 7.18 -> 7.19
* [`1266a4df`](https://github.com/NixOS/nixpkgs/commit/1266a4dff56ca21b55460dc27873c297290ca4d3) vkd3d: 1.4 -> 1.5
* [`a90a8809`](https://github.com/NixOS/nixpkgs/commit/a90a880943c398ee4967b40d6e24d7f8fe7ba78e) wine{Unstable,Staging}: 7.19 -> 7.20
* [`979149b3`](https://github.com/NixOS/nixpkgs/commit/979149b3238427e54456018ea6735f9dda98fa03) yacreader: 9.9.2 -> 9.10.0
* [`186bd908`](https://github.com/NixOS/nixpkgs/commit/186bd9088465860b98e21948f76bfd93c3fbbf4f) python310Packages.fsspec: 2022.8.2 -> 2022.10.0
* [`deea4c34`](https://github.com/NixOS/nixpkgs/commit/deea4c34afb7741db6cfa51c97f5b0b0f7defd8d) python310Packages.gcsfs: 2022.8.2 -> 2022.10.0
* [`d7ab2aa5`](https://github.com/NixOS/nixpkgs/commit/d7ab2aa51ced7f2ffc92c2aebf35c0db5413c987) python310Packages.s3fs: 2022.8.2 -> 2022.10.0
* [`32ebb91f`](https://github.com/NixOS/nixpkgs/commit/32ebb91f4bee39fd1ff6f4ab0fcc78aa9c1856d9) openssl_1_1: 1.1.1q -> 1.1.1s
* [`6aa0c5e9`](https://github.com/NixOS/nixpkgs/commit/6aa0c5e9186dc9022fbab2290516aaa862add8b7) openssl_1_1: drop a long unused patch
* [`5245e732`](https://github.com/NixOS/nixpkgs/commit/5245e7324b185886a4627afcb19b137fe52bcb0f) cmake: put the `DEFINED` check in the same if-statement
* [`a3b7b770`](https://github.com/NixOS/nixpkgs/commit/a3b7b770cec93c0f9714090b09659588ce78aa4b) platformio: work around fallout from [nixos/nixpkgs⁠#194205](https://togithub.com/nixos/nixpkgs/issues/194205)
* [`ebb0a9b9`](https://github.com/NixOS/nixpkgs/commit/ebb0a9b939409faf3b80c8c680812d69c2791271) buf: remove reliance of tests on git file transport
* [`499c2f11`](https://github.com/NixOS/nixpkgs/commit/499c2f11bb4d3beabd54d539942df8a2d6cdb523) gnomeExtensions.system-monitor: Patch for GNOME 43 compatibility
* [`86e8528f`](https://github.com/NixOS/nixpkgs/commit/86e8528f27efa9e10b8c07fcefb9c9420a049bef) cppunit: disable blanket -Werror
* [`fb505678`](https://github.com/NixOS/nixpkgs/commit/fb505678edb023279448a6144087c9cbb165d134) libxcrypt: 4.4.29 -> 4.4.30
* [`b6b54ccd`](https://github.com/NixOS/nixpkgs/commit/b6b54ccd0e17d2656773306cb133c8bd04330482) spirv-tools: disable blanket -Werror
* [`54bd7f6c`](https://github.com/NixOS/nixpkgs/commit/54bd7f6c53721eda95a409f36f0bfff435e2d6e0) python310Packages.av: 9.2.0 -> 10.0.0
* [`644b5a7a`](https://github.com/NixOS/nixpkgs/commit/644b5a7ac7c5ff72b8602434ad43a2e7bb3614d7) rPackages.bigmemory: add missing dependency
* [`1249b086`](https://github.com/NixOS/nixpkgs/commit/1249b086768178bfaadfc1b9ff61881f2f2c4d64) rPackages.RNifti: fix build
* [`0b581a36`](https://github.com/NixOS/nixpkgs/commit/0b581a366f749250dd475790f1b76bb137149650) libre: 2.8.0 -> 2.9.0
* [`9fa023fa`](https://github.com/NixOS/nixpkgs/commit/9fa023faa50e3397655bb1a29098027076bc6935) librem: 2.8.0 -> 2.9.0
* [`02adfe68`](https://github.com/NixOS/nixpkgs/commit/02adfe681e59b4006a080a78fe5e4fe3d9d2fa60) apksigcopier: 1.0.1 -> 1.1.0
* [`a3c00da9`](https://github.com/NixOS/nixpkgs/commit/a3c00da98305ca0239634383b8bb1991cbb105ca) libcamera: disable blanket -Werror
* [`627b4dc4`](https://github.com/NixOS/nixpkgs/commit/627b4dc438fdf3a6248cf5c833c153b942a8c469) aws-sdk-cpp: disable blanket -Werror
* [`1cbf1266`](https://github.com/NixOS/nixpkgs/commit/1cbf12663c52e38c9d35c92494b45d28664b5dfe) cvise: disable blanket -Werror
* [`6ef670fe`](https://github.com/NixOS/nixpkgs/commit/6ef670fee37e81ce92de59ef9ecc910300e99d23) go-mockery: 2.9.2 -> 2.14.1
* [`ed88ec18`](https://github.com/NixOS/nixpkgs/commit/ed88ec182e49369a72f4fd25a174daf589816dba) keycloak: 19.0.2 -> 20.0.0
* [`0e4af0e8`](https://github.com/NixOS/nixpkgs/commit/0e4af0e816cd7ce0b4165616662972bcc472680a) calamares: add locale path patch
* [`40ade452`](https://github.com/NixOS/nixpkgs/commit/40ade45200726769ce94a4f73a2a553f5373874d) glib-locales: store SUPPORTED locales file
* [`f4e54142`](https://github.com/NixOS/nixpkgs/commit/f4e541427e33c16c7e574c3b5606d214e7a981c9) calamares-cd: default supporting all locales
* [`57abb43c`](https://github.com/NixOS/nixpkgs/commit/57abb43cfccac8cc2eef14129201f977a162e6b2) calamares-nixos-extensions: 0.3.10 -> 0.3.11
* [`381160ca`](https://github.com/NixOS/nixpkgs/commit/381160ca2a4267641a64da3a71cbde690c4b7582) python310Packages.boltons: allow local net for Darwin
* [`eb6caa8d`](https://github.com/NixOS/nixpkgs/commit/eb6caa8ddfe689cf49b006793ec22854a09ee4a4) elfutils: 0.187 -> 0.188
* [`456fd57a`](https://github.com/NixOS/nixpkgs/commit/456fd57a05f6af1d93a3bc1b7ad77ccef57e992e) json-plot: init at 1.1.12
* [`b8f23688`](https://github.com/NixOS/nixpkgs/commit/b8f23688058053b84e25728556712a5573df0811) uwsgi: 2.0.20 -> 2.0.21
* [`34f6edc8`](https://github.com/NixOS/nixpkgs/commit/34f6edc870a420f1edc0b32cf85b8b5f3ee2949c) haskellPackages.hercules-ci-agent: add patch
* [`47ac939e`](https://github.com/NixOS/nixpkgs/commit/47ac939ed1a55a0daa3c6329b0bd3edc250a8234) musikcube: split dev output
* [`e1b3ee8b`](https://github.com/NixOS/nixpkgs/commit/e1b3ee8b4365a509e706ade3e13be4fab0ee02e4) dolphin-emu-beta: fix mainProgram on Linux
* [`edb6a65f`](https://github.com/NixOS/nixpkgs/commit/edb6a65fc905845a24bc1a3c0efd399951d57c58) bpytop: No longer broken on Darwin
* [`afe3ad49`](https://github.com/NixOS/nixpkgs/commit/afe3ad49e5da82c86d02c71508007400c3ea3949) kpmcore: patch trustedprefixes
* [`b7e7ce25`](https://github.com/NixOS/nixpkgs/commit/b7e7ce25b1c94d81cbde3385dc69e9dd090008e3) haskellPackages: stackage LTS 19.30 -> LTS 19.31
* [`418ea338`](https://github.com/NixOS/nixpkgs/commit/418ea338061294b6845fe37b12d9474c0fb80227) all-cabal-hashes: 2022-10-27T19:26:33Z -> 2022-11-03T21:09:38Z
* [`06bde9f7`](https://github.com/NixOS/nixpkgs/commit/06bde9f7459176683bc99282126e7921d4cdbf6a) haskellPackages: regenerate package set based on current config
* [`5924132e`](https://github.com/NixOS/nixpkgs/commit/5924132e507dfda1b25039c47193776f76f77a78) xorg.libXi: propagate libXext due to header dependencies
* [`dd362484`](https://github.com/NixOS/nixpkgs/commit/dd3624849e79c8b9d2d63d5e6251a71092ab3390) tzdata: fix build on darwin
* [`eb0b83a1`](https://github.com/NixOS/nixpkgs/commit/eb0b83a10495948fa0226d7dd73f9079e6870611) victor-mono: Move LICENSE.txt to fonts directory
* [`de64530f`](https://github.com/NixOS/nixpkgs/commit/de64530f8d9850c9c0ae3d19367a01cd93f93fcf) pkgsStatic.c-ares: fix build
* [`50f308b0`](https://github.com/NixOS/nixpkgs/commit/50f308b059844d94b1fb28bdef99653b2178945f) nixos/prometheus-zfs-exporter: init
* [`a379c577`](https://github.com/NixOS/nixpkgs/commit/a379c57701f5dea1e5031d41bf59529a7ed59f94) haskell.packages.ghc942.co-log-core: drop now unnecessary jailbreak
* [`9226c0b1`](https://github.com/NixOS/nixpkgs/commit/9226c0b10b1133fee5b9e8d68e2f68b9dc886713) haskellPackages.xlsx: run tests again
* [`e358319a`](https://github.com/NixOS/nixpkgs/commit/e358319a5b5aaba76186253e52671023c81d157c) goeland: init at version 0.11.0
* [`c5df8359`](https://github.com/NixOS/nixpkgs/commit/c5df8359dffe616b2d151a5514c4f4821911a002) nixos/wireguard: start new peers when they are added
* [`677ff51c`](https://github.com/NixOS/nixpkgs/commit/677ff51cfaf7adff8055281a6e2917c6efb9a5e5) haskell.compiler: ghc942 -> ghc943
* [`46a21956`](https://github.com/NixOS/nixpkgs/commit/46a219568818797a547a3ffd92280bb0f65dc5dc) wxGTK28, wxGTK29: drop
* [`b4cbe1da`](https://github.com/NixOS/nixpkgs/commit/b4cbe1dac3684e732d1cc5c12c0a788859080c2d) sane_backends: more complete hwdb files
* [`07920069`](https://github.com/NixOS/nixpkgs/commit/079200691f64ddf2fb717b91a67646ac76f0e298) sage: patches to fix aarch64 crashes and skip known timeout
* [`c95706ac`](https://github.com/NixOS/nixpkgs/commit/c95706ac44ffa749779bace03b115eab89c66cae) vimPlugins: also update nvim-treesitter grammars in the update script
* [`f172d86a`](https://github.com/NixOS/nixpkgs/commit/f172d86a4e1bd84e6d2f4de3bceba36f58095484) lib/systems: Simplify NetBSD examples
* [`66aa02f1`](https://github.com/NixOS/nixpkgs/commit/66aa02f190d17b4e7c4bf0f7f891984647a38234) lib/systems: Support FreeBSD
* [`0afe9d1f`](https://github.com/NixOS/nixpkgs/commit/0afe9d1f70434c02b1efb84629b75385a57936cf) freebsd packages: Init at 13.1
* [`8017d9e2`](https://github.com/NixOS/nixpkgs/commit/8017d9e2da429f5fa326ecdc4599c28a17e8b00f) nixos/nix-daemon: don't give daemon by default high io priority
* [`d3ac0938`](https://github.com/NixOS/nixpkgs/commit/d3ac0938a7a0ce6455fc580f16eb7476cca87dc6) nixos/top-level.nix: Make extensible
* [`35dbaabc`](https://github.com/NixOS/nixpkgs/commit/35dbaabc7885bdfb45723b5e01d9065815717ea6) ocamlPackages.ppx_yojson_conv: init at 0.15.1
* [`0b05ed2c`](https://github.com/NixOS/nixpkgs/commit/0b05ed2c786cfd347c1e1bbd62a79595663a9407) nixos/specialisation.nix: Extract module
* [`37fa46a2`](https://github.com/NixOS/nixpkgs/commit/37fa46a224eacf9010be8fd1525c173d819efb52) nixos/top-level.nix: Remove workaround for [nixos/nixpkgs⁠#156533](https://togithub.com/nixos/nixpkgs/issues/156533)
* [`92994836`](https://github.com/NixOS/nixpkgs/commit/9299483604fa46c5de6614e5f643bcca8f5859ac) nixos/top-level.nix: Move configurationName to grub.nix
* [`8b4a5f4d`](https://github.com/NixOS/nixpkgs/commit/8b4a5f4d3efdcdf3f251b5fe77435a1602c495cf) emanote: init at 0.8.0.0
* [`f3186e48`](https://github.com/NixOS/nixpkgs/commit/f3186e4857e41f507dfa5273b4c3999dda7b87a0) plexamp: 4.4.0 -> 4.5.2
* [`004544d3`](https://github.com/NixOS/nixpkgs/commit/004544d38b4f519088b3b76f649990e9329435dc) haskellPackages.tzdata: dontCheck
* [`844a08cc`](https://github.com/NixOS/nixpkgs/commit/844a08cc06b5c0703ba37f2318ef5b7d90665d04) systemd: 251.5 -> 251.7
* [`810962c7`](https://github.com/NixOS/nixpkgs/commit/810962c7310a7b0b8f110cdd7fd658b5ecc39e1d) thanos: 0.28.1 -> 0.29.0
* [`bfe9eade`](https://github.com/NixOS/nixpkgs/commit/bfe9eadec9720b1ba4647f4508a774561f4888c8) python3Packages.pytest-datadir: 1.3.1 → 1.4.1
* [`14c1762e`](https://github.com/NixOS/nixpkgs/commit/14c1762e07efd1727e5e591d1e336e3f11c72dbb) unicorn: 2.0.0-rc7 -> 2.0.1
* [`b45cf446`](https://github.com/NixOS/nixpkgs/commit/b45cf446ea501649bdccef866fb01e5b1042143c) linuxHeaders: fix cross-compilation from darwin to mips
* [`4fbec87a`](https://github.com/NixOS/nixpkgs/commit/4fbec87a5bfc11e60b98523e55c813c6fadf655b) nixos/sane: point env vars to /etc for quick reload
* [`904e346d`](https://github.com/NixOS/nixpkgs/commit/904e346d5495d7f1f196f7bc3683df16253bb75c) syncthingtray: 1.2.3 -> 1.3.0
* [`54511498`](https://github.com/NixOS/nixpkgs/commit/54511498d7e14e52ee169bf98ae7bdfbdfdab624) libsForQt5.qtforkawesome: 0.0.4 -> 0.1.0
* [`9d2f0aff`](https://github.com/NixOS/nixpkgs/commit/9d2f0affe3b365ab817a268f168c2bf67f95a53e) libsForQt5.qtutilities: 6.8.0 -> 6.10.0
* [`16b4c7f0`](https://github.com/NixOS/nixpkgs/commit/16b4c7f0adbf63a69554e3954c2bf443e932b090) python3Packages.protobuf: fix derivation version
* [`53dfc257`](https://github.com/NixOS/nixpkgs/commit/53dfc2573b48664e620dbd140b3dbc8d2c9996ff) python3Packages.sagamaker: relax protobuf and attrs
* [`8bd4d92e`](https://github.com/NixOS/nixpkgs/commit/8bd4d92e2f586f3622621a0e5fbf18c81ab3bb55) nrfutil: relax protobuf
* [`a12a0047`](https://github.com/NixOS/nixpkgs/commit/a12a0047d031934a07f940e31b0bd7a7d892be25) expat: 2.4.9 -> 2.5.0
* [`050fd1c1`](https://github.com/NixOS/nixpkgs/commit/050fd1c134ff5803317bdd3ed0fd9a7842c44bf6) haskell.packages.ghc943.cabal2nix: aarch64-linux works again
* [`deae58ac`](https://github.com/NixOS/nixpkgs/commit/deae58ac8ca720892dead362f640b4a2913973c6) emanote: disable on darwin-x86_64
* [`b105efc1`](https://github.com/NixOS/nixpkgs/commit/b105efc145b59730b9f62b422fd9d4e7ee992481) calcmysky: 0.1.0 -> 0.2.1
* [`74fd5f0c`](https://github.com/NixOS/nixpkgs/commit/74fd5f0cbab50f850b5005433102655bf6e04fa2) stellarium: 1.0 -> 1.1
* [`423d2dad`](https://github.com/NixOS/nixpkgs/commit/423d2dada006e1b09095a1524b43e107e18ee34d) qt6.qtbase: add patch for correctly loading tzdata
* [`170ab463`](https://github.com/NixOS/nixpkgs/commit/170ab46380ada1f20d4ac3adbccd7d99960c0a5d) qt6Packages.qxlsx: init
* [`f2870ff9`](https://github.com/NixOS/nixpkgs/commit/f2870ff9e2e35e4e338fd8af9483394605f1585f) calcmysky: build with qt6
* [`e177a194`](https://github.com/NixOS/nixpkgs/commit/e177a194c0c4cf0e80258ddef3a38e018b4d44cd) qt6.qtmultimedia: add and propagate the required/recommended gst plugins
* [`e562fc6e`](https://github.com/NixOS/nixpkgs/commit/e562fc6e0535d85fcbb681d506a3a3cb3366213e) stellarium: build with qt6
* [`735ab198`](https://github.com/NixOS/nixpkgs/commit/735ab1984b84b5fce9447d4643026981128f8534) wireshark: 3.6.5 -> 4.0.1
* [`00479e2d`](https://github.com/NixOS/nixpkgs/commit/00479e2d5a153337309abd68e550768216c2c4a2) python3.packages.pyshark: fix build with wireshark4
* [`3d459ebf`](https://github.com/NixOS/nixpkgs/commit/3d459ebf01918ea330677190280bf9164b003966) pixman: 0.38.4 -> 0.42.2
* [`9c826a75`](https://github.com/NixOS/nixpkgs/commit/9c826a7514dde0219ef222ed9b194d97f6b0b67e) sourcehut.metasrht: 0.58.18 -> 0.61.3
* [`3495a98c`](https://github.com/NixOS/nixpkgs/commit/3495a98c385e46c8498aa0004dd3c70c0a8d12a4) haskellPackages.patat: unbreak
* [`11bc7ca6`](https://github.com/NixOS/nixpkgs/commit/11bc7ca6dc5f70be0ebeb203d4a3705a185f778e) vorta: 0.8.7 -> 0.8.9
* [`5568a4d2`](https://github.com/NixOS/nixpkgs/commit/5568a4d25ca406809530420996d57e0876ca1a01) xfce: fix cross-compilation by using makeScopeWithSplicing
* [`acc7b1b5`](https://github.com/NixOS/nixpkgs/commit/acc7b1b56f3914cae5b1e094192c4a123e4c3262) haskellPackages.patat: unset platform none
* [`88f085e9`](https://github.com/NixOS/nixpkgs/commit/88f085e96eeb2b26c92d092d20a265c694506adb) python310Packages.deep-translator: 1.9.0 -> 1.9.1
* [`ea062f45`](https://github.com/NixOS/nixpkgs/commit/ea062f45ec6aa64f38da9e6433ec18c617a31c73) google-cloud-sdk: 405.0.0 -> 408.0.1
* [`139cd9af`](https://github.com/NixOS/nixpkgs/commit/139cd9afbd765bfbe0b7006d0f691baa3871d4f4) gnome.gnome-shell-extensions: 43.0 → 43.1
* [`dd1ded18`](https://github.com/NixOS/nixpkgs/commit/dd1ded186fdaffd2e25369e0c9012eb568de04ba) gnome.gnome-shell: 43.0 → 43.1
* [`51582715`](https://github.com/NixOS/nixpkgs/commit/515827156120e3e1649f757326acd007d4819e3d) gnome.mutter: 43.0 → 43.1
* [`3d64cd31`](https://github.com/NixOS/nixpkgs/commit/3d64cd31a201b877c2a72d2de7d36d3810a029ff) python3Packages.PyICU: 2.9 -> 2.10.2
* [`d9a7fcb2`](https://github.com/NixOS/nixpkgs/commit/d9a7fcb2ee4aefef248065452af8c846062ab840) python3Packages.scikit-learn: 1.1.2 -> 1.1.3
* [`40b08794`](https://github.com/NixOS/nixpkgs/commit/40b0879469f32f365b943f20b7b452c7c3016fe9) nanomq: init at 0.13.0
* [`1758ec7e`](https://github.com/NixOS/nixpkgs/commit/1758ec7e00b94abd0ce0a16bc4ce4918cc87d8bd) topgrade: 10.0.1 -> 10.1.1
* [`86aeb9fc`](https://github.com/NixOS/nixpkgs/commit/86aeb9fc2326690fe8b3fa01d4f3232f964a03b7) python310Packages.gsd: 2.6.0 -> 2.6.1
* [`f572b05f`](https://github.com/NixOS/nixpkgs/commit/f572b05f8417109d82cd55fdfb8faa97a2168330) pulumi-bin: rename directory to reflect package name
* [`35657c42`](https://github.com/NixOS/nixpkgs/commit/35657c42623f858deff6f3a9990224e47a0884a0) pulumi: init at 3.43.1
* [`0412ead8`](https://github.com/NixOS/nixpkgs/commit/0412ead84e62ee28b58d634a0958d4eab5067124) pulumiPackages: add base package derivation
* [`76cffac2`](https://github.com/NixOS/nixpkgs/commit/76cffac29b1f6a71d680963d11b4e1664235afd3) pulumiPackages.pulumi-random: init at 4.8.2
* [`54e896ed`](https://github.com/NixOS/nixpkgs/commit/54e896edba273f406c39701b9e464863b1389262) pulumiPackages.pulumi-language-python: init at 3.43.1
* [`3582d5c4`](https://github.com/NixOS/nixpkgs/commit/3582d5c4aa39a1072e2476fc2ef7a242c76ba721) pulumiPackages: add support for Python SDKs
* [`08328db2`](https://github.com/NixOS/nixpkgs/commit/08328db2a42c9be6d9080cc208fba34e56dbc906) python310Packages.pulumi-random: init at 4.8.2
* [`9d673866`](https://github.com/NixOS/nixpkgs/commit/9d6738665745c9aacf1cf3d6743b517d0a973771) python310Packages.pulumi: use `pulumi` instead of `pulumi-bin`
* [`80e25a15`](https://github.com/NixOS/nixpkgs/commit/80e25a1566ec172ad9b3b971a33082822e6724dc) pulumiPackages.pulumi-azure-native: init at 1.81.0
* [`b725a0b6`](https://github.com/NixOS/nixpkgs/commit/b725a0b647c2ed13b342c3c1f43bbbb5610bafbc) python310Packages.pulumi-azure-native: init at 1.81.0
* [`ce1faf92`](https://github.com/NixOS/nixpkgs/commit/ce1faf92f29eaff45cbe922ffee970b1f2e2c007) pulumi: passthru.{pkgs,withPackages}
* [`634ab27f`](https://github.com/NixOS/nixpkgs/commit/634ab27f9aa65206acf98a365aa7c7a57c967425) pulumiPackages.pulumi-aws-native: init at 0.38.0
* [`4653ebd5`](https://github.com/NixOS/nixpkgs/commit/4653ebd52d59e62d0171a59511fe4d2f147b62f9) python310Packages.pulumi-aws-native: init at 0.38.0
* [`e747d0a3`](https://github.com/NixOS/nixpkgs/commit/e747d0a3683629d878ad86c344abf3b33ae27742) protonup-ng: init at 0.2.1
* [`9014fb79`](https://github.com/NixOS/nixpkgs/commit/9014fb790dd2566cd42b07c2beb1148482365a11) erlang: 25.1 -> 25.1.2
* [`12508ac7`](https://github.com/NixOS/nixpkgs/commit/12508ac79a3b940d42580e9cfb7d2037e7af3b00) nixos-container: force systemd-nspawn to use unified cgroups hierarchy
* [`a8899fab`](https://github.com/NixOS/nixpkgs/commit/a8899fabffe6a798d14f3633b206a30228bef166) python310Packages.gsd: disable on older Python releases
* [`58ca173f`](https://github.com/NixOS/nixpkgs/commit/58ca173fd67eb2c70ad399d386e9374f68574672) unicorn: patch endian.h for aarch64-darwin
* [`d16405fb`](https://github.com/NixOS/nixpkgs/commit/d16405fb97fac9903a1592e0e838913d39bae248) xfce: run nixpkgs-fmt
* [`910ab0bd`](https://github.com/NixOS/nixpkgs/commit/910ab0bda82b41458ed9e6a4d617b71aa43e006a) mutt: 2.2.7 -> 2.2.8
* [`6068b854`](https://github.com/NixOS/nixpkgs/commit/6068b8549d791d43b7880bb0571048dc115d1604) oh-my-zsh: 2022-11-04 -> 2022-11-06
* [`4925b7cd`](https://github.com/NixOS/nixpkgs/commit/4925b7cd80dbdc655feda8ef2f1b716703d7e744) cargo-nextest: skip breaking tests
* [`673f7d02`](https://github.com/NixOS/nixpkgs/commit/673f7d025b5634682a8b009e149a2c6ea9c5636f) nixos/tests/chromium: Re-enable the chrome://gpu test for M107
* [`4ef72e5d`](https://github.com/NixOS/nixpkgs/commit/4ef72e5d103e79b0c85235de19d009c73bdee99e) haskellPackages.implicit-hie: Don‘t override Cabal-syntax on ghc 9.4
* [`f9dc0cdf`](https://github.com/NixOS/nixpkgs/commit/f9dc0cdf5abf4c96b3c41e4e8dda6292688efb1e) bencode: init at 0.5.0
* [`521b33da`](https://github.com/NixOS/nixpkgs/commit/521b33dae27779a03937274a7c0a1a3fc4675cf1) carapace: 0.17.1 -> 0.18.0
* [`bc7e9b1b`](https://github.com/NixOS/nixpkgs/commit/bc7e9b1b43b6a429f2a9b17c11834087a9a01061) cheat: 4.3.3 -> 4.4.0
* [`4d3207ec`](https://github.com/NixOS/nixpkgs/commit/4d3207ecf7e3fc97d183cd001498a04437745da1) edk2: fix build on x86_64-darwin
* [`9af8b018`](https://github.com/NixOS/nixpkgs/commit/9af8b018423289f0422ad8fcfcf8b0bb5855faa6) openjdk: mark 18 as EOL
* [`b808a354`](https://github.com/NixOS/nixpkgs/commit/b808a354d215ffa1bb9c5988112ec9adadf7365d) OVMF: fix build on x86_64-darwin
* [`0aa21a70`](https://github.com/NixOS/nixpkgs/commit/0aa21a70530618bfdd18c532b4af0c290ad7d070) edk2-uefi-shell: fix build on x86_64-darwin
* [`6698fca1`](https://github.com/NixOS/nixpkgs/commit/6698fca169904f39e8adecef7878ff40f278d84e) osu-lazer: 2022.723.0 -> 2022.1101.0
* [`c94492f3`](https://github.com/NixOS/nixpkgs/commit/c94492f30a952e3a72dbef3c7a1621e296b19044) linuxPackages.rtw88: 2022-06-03 to 2022-11-05
* [`75229f7d`](https://github.com/NixOS/nixpkgs/commit/75229f7d189fe1ef924e25ba4c087d27552770d8) esbuild_netlify: fix darwin build
* [`37517fd1`](https://github.com/NixOS/nixpkgs/commit/37517fd1271a05694fd6bb9761f1fa8b735fdc61) lingot: 1.0.1 -> 1.1.1
* [`659fc3d8`](https://github.com/NixOS/nixpkgs/commit/659fc3d8f47c311d86ca680a4c705d210602b6b8) maintainers: add calavera
* [`83255472`](https://github.com/NixOS/nixpkgs/commit/83255472687e2e4eb68c82c435b35a93cb8b39ac) cargo-lambda: 0.11.2 -> 0.11.3
* [`cc22af58`](https://github.com/NixOS/nixpkgs/commit/cc22af58523df6383c7aca7709cdeb6e121f931e) ruff: 0.0.102 -> 0.0.105
* [`7a3b6039`](https://github.com/NixOS/nixpkgs/commit/7a3b60394b20637bff664e94a07f2f37f29e36a0) gyb: 1.71 -> 1.72
* [`bbfdc6ce`](https://github.com/NixOS/nixpkgs/commit/bbfdc6ce4d312b56aa57b38f23c88d339430b38c) nixos/tests/podman: move docker tests to separate node
* [`58a59738`](https://github.com/NixOS/nixpkgs/commit/58a59738d5420fbf5b320a0ece48e58664b1a309) nixos/tests/podman: fix rootless systemd
* [`6fbb4b1e`](https://github.com/NixOS/nixpkgs/commit/6fbb4b1eec44f89e7240c60a796edd73dfd076bd) odo: 3.1.0 -> 3.2.0
* [`c8a8b641`](https://github.com/NixOS/nixpkgs/commit/c8a8b641b32e2434b99bb4d7a489956b47ee708d) terraform-providers.avi: 22.1.1 -> 22.1.2
* [`0c8bb927`](https://github.com/NixOS/nixpkgs/commit/0c8bb9272f3ebf2d9452bb9bac887c380c7c772f) nats-server: 2.9.4 -> 2.9.6
* [`256b8388`](https://github.com/NixOS/nixpkgs/commit/256b838850db66a9278d4bfe1b23ea262a37d80a) oapi-codegen: 1.11.0 -> 1.12.2
* [`de717369`](https://github.com/NixOS/nixpkgs/commit/de717369b02a71988186198dbab10a059fd850c3) fio: 3.32 -> 3.33
* [`0f0224f7`](https://github.com/NixOS/nixpkgs/commit/0f0224f7e8e9ba5735966aab2dcec5cbc99f34e9) ghorg: 1.8.8 -> 1.9.0
* [`4f150a78`](https://github.com/NixOS/nixpkgs/commit/4f150a789fd17e11edd3760b62737f5289eb0e54) oil: 0.12.7 -> 0.12.8
* [`41892731`](https://github.com/NixOS/nixpkgs/commit/41892731bd3ea6b9b27e0693b8e332b1e48eb7dd) gitoxide: 0.16.0 -> 0.17.0
* [`73264125`](https://github.com/NixOS/nixpkgs/commit/73264125a2132ccff657195eabbe8f5a68c26590) ashuffle: 3.12.5 -> 3.13.4
* [`9d1e84f7`](https://github.com/NixOS/nixpkgs/commit/9d1e84f7125d4477b546a638cb26cc937e687be7) python310Packages.amaranth: make compatible with newer setuptools
* [`7442928e`](https://github.com/NixOS/nixpkgs/commit/7442928ed30285cfe2745900b2dcc66c0de8bcf7) atuin: 11.0.0 -> 12.0.0
* [`34c43658`](https://github.com/NixOS/nixpkgs/commit/34c4365854efb3bd47e4be041e2b5b235990524e) kronometer: 2.2.3 -> 2.3.0
* [`29702a30`](https://github.com/NixOS/nixpkgs/commit/29702a307c6fa06a43350b18720c4302d025a82d) pythonPackages.nbxmpp: 3.2.4 → 3.2.5
* [`b5aecf9c`](https://github.com/NixOS/nixpkgs/commit/b5aecf9c5ed431a3810ce0fbbccc028c2f6101f6) gajim: 1.5.2 → 1.5.3
* [`f5823fd5`](https://github.com/NixOS/nixpkgs/commit/f5823fd5244a8f03a2606825a2a653d90cfee8e1) aws-c-sdkutils: 0.1.4 -> 0.1.6
* [`d327e408`](https://github.com/NixOS/nixpkgs/commit/d327e40814a4867edcbfd1328d142c541acd9bd6) python3Packages.zeroconf: disable tests on darwin
* [`bb94951b`](https://github.com/NixOS/nixpkgs/commit/bb94951bd32a6e2bd0805cb7119dc878ddab53f7) aws-c-common: 0.8.4 -> 0.8.5
* [`61f87a8d`](https://github.com/NixOS/nixpkgs/commit/61f87a8dc31587ea7738c9e14f46f8a3199874e5) eww: add gdk-pixbuf dependency
* [`cef7cd60`](https://github.com/NixOS/nixpkgs/commit/cef7cd60607d0f3a291bf68e961469269ac5b5f3) aws-c-mqtt: 0.7.12 -> 0.7.13
* [`f57a6923`](https://github.com/NixOS/nixpkgs/commit/f57a69236018b07195845ce26876aaa5626b67d1) flexget: 3.4.2 -> 3.5.4
* [`e8805267`](https://github.com/NixOS/nixpkgs/commit/e8805267fe7f1bb6a688a16765a3b368472479e5) hedgedoc: 1.9.5 -> 1.9.6
* [`24323d10`](https://github.com/NixOS/nixpkgs/commit/24323d103cd20a6b665eab03c2ec324caccb99b8) electron: mark versions < 18 as EOL
* [`8c60992e`](https://github.com/NixOS/nixpkgs/commit/8c60992ea9ce55bd280200cbaa2a95f7cd6d34bf) webkitgtk: unset separateDebugInfo for 32 bit platforms
* [`24c0592e`](https://github.com/NixOS/nixpkgs/commit/24c0592e58f2846ac3d2022732fbb986de05b80d) isync: Fix "Buffer too small" error
* [`e844d8ad`](https://github.com/NixOS/nixpkgs/commit/e844d8adbd0cb29298f24e489feea5d5dbe0743f) closurecompiler: 20221004 -> 20221102
* [`9998ec71`](https://github.com/NixOS/nixpkgs/commit/9998ec71ccea8f6f794c9484412b90010fd9959d) pkgsStatic.cmark: fix build
* [`9b7725ff`](https://github.com/NixOS/nixpkgs/commit/9b7725ff8a1169c4c55602a078acd079ff47c5c5) sshs: 3.3.0 -> 3.4.0
* [`4488784f`](https://github.com/NixOS/nixpkgs/commit/4488784f4924c8d696c9bc1d6b04646be0c1db3f) maintainers: fix name for obfusk
* [`667e5581`](https://github.com/NixOS/nixpkgs/commit/667e5581d16745bcda791300ae7e2d73f49fff25) bazarr: update expr
* [`ea396831`](https://github.com/NixOS/nixpkgs/commit/ea396831fa5d6bc6ad5ded7447d5e2d17a79c4c1) mdevctl: init at 1.2.0
* [`83ecc90d`](https://github.com/NixOS/nixpkgs/commit/83ecc90d1012eeb3dc379c737edc42974ddb41b1) nixos/mdevctl: init module
* [`b40b8b92`](https://github.com/NixOS/nixpkgs/commit/b40b8b92e200373f85854d197bc3d1687c43d38f) nixos/wordpress: ensure that fonts already exists
* [`3138f960`](https://github.com/NixOS/nixpkgs/commit/3138f960513761cf938824a1716e87726d7d9f99) tor-browser-bundle-bin: 11.5.6 -> 11.5.7
* [`0738e162`](https://github.com/NixOS/nixpkgs/commit/0738e1622cad4cf7db86a6ea3ed66cb0b82df864) nil: 2022-10-03 -> 2022-11-07
* [`e0f93084`](https://github.com/NixOS/nixpkgs/commit/e0f93084f7d45421a91a6bd2d2f92ff51d9c61cb) ccache: 4.7.2 -> 4.7.3
* [`9185b136`](https://github.com/NixOS/nixpkgs/commit/9185b136d3e211a1f2237a8074698eb8e08a5af5) discord-canary: 0.0.142 -> 0.0.143
* [`762fcbb8`](https://github.com/NixOS/nixpkgs/commit/762fcbb80b5ec8746d4c0f9c41b90e0556905870) python310Packages.rpi-gpio: only build on Linux
* [`29ea368e`](https://github.com/NixOS/nixpkgs/commit/29ea368e3c5924d83344e614dd42cf81301097dd) python3Packages.construct-classes: init at 0.1.2
* [`9519670e`](https://github.com/NixOS/nixpkgs/commit/9519670e6f3441c54dbdf85339632ef8c3a7abcf) pyinfra: 2.5.1 -> 2.5.2
* [`ad83bff0`](https://github.com/NixOS/nixpkgs/commit/ad83bff0088bcefd621fcf16b0db5d34f0cebf1c) nixos/binfmt: restart systemd-binfmt when registrations change
* [`574f3838`](https://github.com/NixOS/nixpkgs/commit/574f38381636b7abc37f96fd69a87cc9d180e75f) python3Packages.trezor: 0.13.3 -> 0.13.4
* [`cd5c84e8`](https://github.com/NixOS/nixpkgs/commit/cd5c84e886f34520a088e92cc8379454c985cb97) nodePackages.localtunnel: init at 2.0.2
* [`6704831a`](https://github.com/NixOS/nixpkgs/commit/6704831a47c7d57b7d8773a63edb9791973d46c0) fuzzel: 1.7.0 -> 1.8.2
* [`66d4d937`](https://github.com/NixOS/nixpkgs/commit/66d4d937948f435505939ffcaf32291d2748a224) python310Packages.lightwave2: 0.8.15 -> 0.8.16
* [`ab0ae8f5`](https://github.com/NixOS/nixpkgs/commit/ab0ae8f5e11bacdf249c27c49f1fe30a3bf8b77f) nixos/pam: add option failDelay
* [`a8ed4be9`](https://github.com/NixOS/nixpkgs/commit/a8ed4be9a67c98770dceb00b52f7caa2d0c73eca) gmsh: 4.10.5 -> 4.11.0
* [`286e7fbb`](https://github.com/NixOS/nixpkgs/commit/286e7fbbe9ef8c5ea930f7f6ad535dc8e26f5d81) lispPackages_new.sbclPackages.pgloader: add
* [`dd947cf3`](https://github.com/NixOS/nixpkgs/commit/dd947cf33a9fd2ebbd056690e1783c4869690c38) grype: fix for darwin
* [`590a40e1`](https://github.com/NixOS/nixpkgs/commit/590a40e13423cf7f575fc140a54cebeaff9819cd) android-studio: 2021.3.1.16 -> 2021.3.1.17
* [`4cf3912d`](https://github.com/NixOS/nixpkgs/commit/4cf3912d54fa82b22a6f8ac32d907fe0d31063b5) nix-du: 0.6.0 -> 1.0.0
* [`dbca24a8`](https://github.com/NixOS/nixpkgs/commit/dbca24a803409f5bbfee35c0aef9a76613634117) networkmanagerapplet: 1.28.0 -> 1.30.0
* [`b234d4f0`](https://github.com/NixOS/nixpkgs/commit/b234d4f06d75dc2ac2caafb6e3be83d940715a96) esbuild_netlify: Add netlify-cli to tests
* [`ac4ed49f`](https://github.com/NixOS/nixpkgs/commit/ac4ed49fa5ff12e6eb6aac72b17f5df01088d4b4) crun: 1.6 -> 1.7
* [`acc4e8eb`](https://github.com/NixOS/nixpkgs/commit/acc4e8eb237f83d0e85463722c9411ee0de44f8a) btcd: init at 0.23.3
* [`1528a7ca`](https://github.com/NixOS/nixpkgs/commit/1528a7ca86b19830e87590113e9db15955fbffe9) cinnamon.cinnamon-gsettings-overrides: Override gnome-terminal settings with Fedora's default
* [`92cb304f`](https://github.com/NixOS/nixpkgs/commit/92cb304f3be713edb9cb02da9dbaec1d018fc0bb) python310Packages.pick: 2.0.2 -> 2.1.0
* [`f9c04d85`](https://github.com/NixOS/nixpkgs/commit/f9c04d85570252777530fe2495b96352cbac7f3c) neovide: 0.10.1 -> 0.10.3
* [`f4ff9c26`](https://github.com/NixOS/nixpkgs/commit/f4ff9c26499a600fcc2459cfc6d8bbc5c1dfc5ea) lighthouse: init module
* [`ddc69ddd`](https://github.com/NixOS/nixpkgs/commit/ddc69ddd7756534ba78a8835e7d4367ee0ecabd6) nodePackages.elm-test: init at 0.19.1-revision10
* [`17c25013`](https://github.com/NixOS/nixpkgs/commit/17c250135f8c9dd74771db3537bf9657a6badf88) sumneko-lua-language-server: set logpath and metapath to `$XDG_CACHE_HOME` if set
* [`0778d6e0`](https://github.com/NixOS/nixpkgs/commit/0778d6e0c447a7f8ee3e579af97a0cab04954a88) metasploit: 6.2.24 -> 6.2.25
* [`370c1a9a`](https://github.com/NixOS/nixpkgs/commit/370c1a9ad0388df4c3677fa82899353ae19dee40) python3Packages.sh: disable flaky tests
* [`ce752bc6`](https://github.com/NixOS/nixpkgs/commit/ce752bc694f87fb3967967536c076099e95e13c3) python310Packages.docker: 6.0.0 -> 6.0.1
* [`d284ffaa`](https://github.com/NixOS/nixpkgs/commit/d284ffaa15bde72742ea78b01f88496ce6e56500) trueseeing: relax docker contraint
* [`32b67fe0`](https://github.com/NixOS/nixpkgs/commit/32b67fe06229fb39023fd8ca4b6d8ed3342e2df4) lightdm-mobile-greeter: init at 2022-10-30
* [`ed9998cf`](https://github.com/NixOS/nixpkgs/commit/ed9998cf2a5ebb181ee604d2f0a2b0c64718c082) nixos/lightdm: add `greeters.mobile` config option
* [`d3e91e9b`](https://github.com/NixOS/nixpkgs/commit/d3e91e9b3d5937880dc1fe49689b290b039e0c32) qMasterPassword: 1.2.3 -> 1.2.4
* [`2d1dc67f`](https://github.com/NixOS/nixpkgs/commit/2d1dc67fe1d2abbd86051c59eaa597ef85c09129) aspellDicts.is, aspellDicts.nb: fix build on darwin
* [`4222a3f7`](https://github.com/NixOS/nixpkgs/commit/4222a3f727cac4d0d999fbd80fdef1e56707b882) python310Packages.tensorboard: widen version pinning (again)
* [`5d959cdf`](https://github.com/NixOS/nixpkgs/commit/5d959cdfdbb8da186a2942f8dd86c90d99b87f1f) python310Packages.pyunifiprotect: 4.3.4 -> 4.4.0
* [`c777fbab`](https://github.com/NixOS/nixpkgs/commit/c777fbabdb98195ee58d32e620921dfd162387ad) EBTKS: fix build on aarch64-darwin
* [`91242146`](https://github.com/NixOS/nixpkgs/commit/91242146f55ca72ebbbbbe532ae0b48198e8d786) nodePackages.manta, nodePackages.triton: add myself as maintainer
* [`1ef74a78`](https://github.com/NixOS/nixpkgs/commit/1ef74a785480396ba179200196cac8256a67cfce) lighthouse: module add defaults
* [`56ab9dd7`](https://github.com/NixOS/nixpkgs/commit/56ab9dd70c4b2ec2d030ab72398c4fbba551b290) garage: add myself as maintainer
* [`92cfa056`](https://github.com/NixOS/nixpkgs/commit/92cfa0563ec121ca180c7ec9c5c9ab9d564cab15) qMasterPassword: use qt6
* [`e87a760a`](https://github.com/NixOS/nixpkgs/commit/e87a760a3c6f4166b11024c573ee4876bacf554d) qMasterPassword: add myself as maintainer
* [`89c92a92`](https://github.com/NixOS/nixpkgs/commit/89c92a92062746bc12cb066614ca4c59f13ea3bc) SDL2: 2.24.0 -> 2.24.1
* [`6d7127b1`](https://github.com/NixOS/nixpkgs/commit/6d7127b1765578183ad428b5d99e4d113f13fe4c) lzlib: fix darwin build
* [`6b94441f`](https://github.com/NixOS/nixpkgs/commit/6b94441f88d051332367539413ecd16aad6dfc67) lightningcss: 1.16.0 → 1.16.1
* [`3384acc1`](https://github.com/NixOS/nixpkgs/commit/3384acc17a6421ccaceddb1b29f7f54cb3c88bc8) hurl: 1.7.0 -> 1.8.0, add figsoda as a maintainer
* [`4db7dc72`](https://github.com/NixOS/nixpkgs/commit/4db7dc72d27f94483d759beeb7d4c1914b4da1e2) SDL2: 2.24.1 -> 2.24.2
* [`37171a5d`](https://github.com/NixOS/nixpkgs/commit/37171a5d906a609ca593b3a47965b4cae941e3c4) yamlpath: 3.6.8 -> 3.6.9
* [`427e4959`](https://github.com/NixOS/nixpkgs/commit/427e49595b477a911b97253e6c17be70070a77f9) mangal: 4.0.1 -> 4.0.2
* [`82e844aa`](https://github.com/NixOS/nixpkgs/commit/82e844aad1688d071429140d6307d23a888c4501) endeavour: move to pkgs/applications/office
* [`91a82f14`](https://github.com/NixOS/nixpkgs/commit/91a82f14d2c22f9c606c8c3df5579549796e393f) endeavour: 42.0 → 43.0
* [`6a01d889`](https://github.com/NixOS/nixpkgs/commit/6a01d889b387d2b0212c1d2ccb14a8b2724f1eaa) platformio: unmark as broken on aarch64-linux
* [`996fa2bc`](https://github.com/NixOS/nixpkgs/commit/996fa2bca21a1bde349cf02f76a807a564c8e565) fdroidserver: 2.1 -> 2.1.1
* [`7a509caa`](https://github.com/NixOS/nixpkgs/commit/7a509caabd7a21c508b6e9233ad0131ab3febf37) qt6.qtwebengine: unmark broken on aarch64-linux
* [`f6260b00`](https://github.com/NixOS/nixpkgs/commit/f6260b00baa812e13e8235cf47459d7d52ed3431) dillong: init at unstable-2021-12-13
* [`caed6c00`](https://github.com/NixOS/nixpkgs/commit/caed6c004d52649e5c4a80d247c62289b67e0d6a) oh-my-zsh: 2022-11-06 -> 2022-11-07
* [`26ac2781`](https://github.com/NixOS/nixpkgs/commit/26ac27810ebf747744bebecee643c8440fbccc57) python310Packages.bleak: 0.19.1 -> 0.19.4
* [`ee436f94`](https://github.com/NixOS/nixpkgs/commit/ee436f945a50c2f0943fed50e0b23841cb83ae13) python310Packages.bleak-retry-connector: 2.8.2 -> 2.8.3
* [`e357df00`](https://github.com/NixOS/nixpkgs/commit/e357df0063b76e99268602e49c204e03714380e1) nanodbc: 2.13.0 -> 2.14.0 and fix build
* [`c7a0d75b`](https://github.com/NixOS/nixpkgs/commit/c7a0d75bd17cd2fcfe977cf9fdd44987b7b4f753) haskell.compiler.ghc92: 9.2.4 -> 9.2.5
* [`b1959a11`](https://github.com/NixOS/nixpkgs/commit/b1959a116bdcd248aadd66cd1491046c49dcd739) python310Packages.aiohomekit: 2.2.17 -> 2.2.18
* [`5b5ed0d9`](https://github.com/NixOS/nixpkgs/commit/5b5ed0d9a491a6165d837850437e795d4e87e715) scaleway-cli: 2.6.1 -> 2.6.2
* [`7f1a41d9`](https://github.com/NixOS/nixpkgs/commit/7f1a41d9abc7155ed2cfb433d2942eeedfd9300d) haskellPackages.dice: remove upstreamed patch
* [`87b39ba9`](https://github.com/NixOS/nixpkgs/commit/87b39ba9dcd73070d9bbaa0040fbfe5b871b2ac5) git-annex: update sha256 for 10.20221103
* [`4493598d`](https://github.com/NixOS/nixpkgs/commit/4493598d4b0e6cd13a40a297cd01d6222665a68c) php.packages.php-parallel-lint: fix build
* [`eb33bec8`](https://github.com/NixOS/nixpkgs/commit/eb33bec8b3e515e63859f3751aa23e0e1684f44d) nixos/less: fix spacing
* [`41b1a58f`](https://github.com/NixOS/nixpkgs/commit/41b1a58f40664a4422144d505cc5bc774758696b) python310Packages.stubserver: init at 1.1
* [`ffefe17d`](https://github.com/NixOS/nixpkgs/commit/ffefe17d31c8cd219a83991b5e978fd15954f6af) element-web: add wrapper
* [`e6aec927`](https://github.com/NixOS/nixpkgs/commit/e6aec927b4fdbe5984835e1c59e680fcc3fa8220) python310Packages.aiopyarr: 22.10.0 -> 22.11.0
* [`ae5ed8ce`](https://github.com/NixOS/nixpkgs/commit/ae5ed8ce226db3913adf7b1107487f53bd8c69da) mudlet: 4.15.1 -> 4.16.0
* [`f77d334a`](https://github.com/NixOS/nixpkgs/commit/f77d334af1dc5b0bf9b15b2bcbdc5aa0f5fc7338) clingo: 5.6.1 -> 5.6.2
* [`891dfb1b`](https://github.com/NixOS/nixpkgs/commit/891dfb1b636737be2f4d8d235233b08e4d2ffb67) nixos/mastodon: add option mediaAutoRemove
* [`b9d792c5`](https://github.com/NixOS/nixpkgs/commit/b9d792c57d8f111a2b1f25facfa69726780be4a0) haskellPackages.hledger_1_27_1: Fix dependency toward hledger-lib
* [`07761139`](https://github.com/NixOS/nixpkgs/commit/07761139b73296117dfb2a9d9718374105037d58) kde/gear: 22.08.2 -> 22.08.3
* [`0b9d587d`](https://github.com/NixOS/nixpkgs/commit/0b9d587d923e984f7f4cf5a83c3520eba56d3a06) devbox: init at 0.1.0
* [`2aa5c8d3`](https://github.com/NixOS/nixpkgs/commit/2aa5c8d3abd627a871619260bc5cd83defa6c042) nixos/teamviewer: fix for non-NetworkManager environments
* [`a8cc51be`](https://github.com/NixOS/nixpkgs/commit/a8cc51be4dbf21834284b08d488fe0cddb709f76) coder: init at 0.12.4
* [`e6b77730`](https://github.com/NixOS/nixpkgs/commit/e6b77730725277ce96284c715ac26d0c10215876) mepo: 0.4.2 -> 1.1
* [`5f07247a`](https://github.com/NixOS/nixpkgs/commit/5f07247a07387d29e2323e4856d5992b67efdac6) mepo: init module
* [`2abc0277`](https://github.com/NixOS/nixpkgs/commit/2abc0277f01dd09dfcf250cd371256df249dba7a) glib-networking: fix cross and enable strictDeps
* [`22ec8cd8`](https://github.com/NixOS/nixpkgs/commit/22ec8cd807e867d7678f41e9e6e705c0775b1da5) ffmpeg: fix cross
* [`6298f5fa`](https://github.com/NixOS/nixpkgs/commit/6298f5fa1d158851f55e194981c31c6734d655e1) Revert ".github/dependabot.yml: disable"
* [`f0c8df5c`](https://github.com/NixOS/nixpkgs/commit/f0c8df5cb6f31e9490381edcb017b7b58fa78370) python310Packages.pycfdns: 1.2.2 -> 2.0.0
* [`8490af63`](https://github.com/NixOS/nixpkgs/commit/8490af631e9aa17090e6a3829560bee5b75fcf91) ferretdb: 0.6.0 -> 0.6.1
* [`953c8abe`](https://github.com/NixOS/nixpkgs/commit/953c8abe0a9e92bb038172a3bd006683b516ab4c) maintainers: add catouc
* [`a9531a1a`](https://github.com/NixOS/nixpkgs/commit/a9531a1a270f5b4c4b300999827aa21963427c57) folly: 2022.09.05.00 -> 2022.11.07.00
* [`5d3c4579`](https://github.com/NixOS/nixpkgs/commit/5d3c45798e0c5e0e2724518b4c4b29bde142d4ba) torrenttools: init at 0.6.2
* [`9cf5bc9f`](https://github.com/NixOS/nixpkgs/commit/9cf5bc9fc06aedd2ada291b1214f86cfdee582b7) ghz: 0.110.0 -> 0.111.0
* [`6008f4ec`](https://github.com/NixOS/nixpkgs/commit/6008f4ec11e00dfc1e9020f6e757d0822d265c5f) zigbee2mqtt: enable nixpkgs-update to find update script
* [`1172afbe`](https://github.com/NixOS/nixpkgs/commit/1172afbef14e8dbeed4c930be001b46eb121e6ca) python310Packages.pymunk: 6.2.1 -> 6.3.0
* [`6d4a903d`](https://github.com/NixOS/nixpkgs/commit/6d4a903dfc907c31fa927739304fa1e57671a9b1) semver: init at v1.0.0
* [`78a694ff`](https://github.com/NixOS/nixpkgs/commit/78a694fff420f5bcd52dbc266d5df96e60cf05a5) clipqr: mark broken on darwin
* [`962a8105`](https://github.com/NixOS/nixpkgs/commit/962a81051315a8a9506778f13f04295ced8017c1) nixpkgs/doc/stdenv: fix admonition class
* [`ed6c74e8`](https://github.com/NixOS/nixpkgs/commit/ed6c74e81f8d9729867f2b7e2156b47c9728ebc7) libiio: allow build on systems without avahi
* [`e697aa47`](https://github.com/NixOS/nixpkgs/commit/e697aa47b5fb654146d2138ee5bf1c1c1a9926bf) werf: 1.2.184 -> 1.2.187
* [`fda57931`](https://github.com/NixOS/nixpkgs/commit/fda57931f6a36f802c4576fe37f9f7410a341c0e) synfigstudio: add missing intltool to nativeBuildInputs
* [`5d3d98a1`](https://github.com/NixOS/nixpkgs/commit/5d3d98a18653308245a3c5ad5ec43c6b20208fee) fluent-bit: support PostgreSQL output
* [`085101b0`](https://github.com/NixOS/nixpkgs/commit/085101b00fb01f5de398fa7a4c441630674816a3) gnome2.scrollkeeper: remove
* [`c0615ec2`](https://github.com/NixOS/nixpkgs/commit/c0615ec21ac51960368b9b4379f16f4300a41060) xvidcap: remove
* [`30260eac`](https://github.com/NixOS/nixpkgs/commit/30260eac707435f5896e5039bd38027d1e2a9e77) libvirt: fix running EFI VM images on aarch64-darwin
* [`a7597701`](https://github.com/NixOS/nixpkgs/commit/a75977016b3469bb9df30714158ed56316ffc2dd) bzip3: 1.1.8 -> 1.2.0
* [`8ec25278`](https://github.com/NixOS/nixpkgs/commit/8ec252784ed0a348c2a752bee96f23a7a81c5755) zrepl: 0.5.0 -> 0.6.0
* [`110c34d3`](https://github.com/NixOS/nixpkgs/commit/110c34d3b77299ff339d9bbef9c1a39e7cabed74) python3Packages.scikit-fuzzy: unstable-2021-03-31 -> unstable-2022-11-07
* [`e777028c`](https://github.com/NixOS/nixpkgs/commit/e777028c53f89b9c48261f11004f18e716fe9776) lefthook: 1.1.4 -> 1.2.0
* [`27d20670`](https://github.com/NixOS/nixpkgs/commit/27d20670578efbe918d8ef53773d6fc4ecc43e52) kubie: 0.19.0 -> 0.19.1
* [`3368f48d`](https://github.com/NixOS/nixpkgs/commit/3368f48dec91a4092b3cac1ca223ece33b5e7cde) python310Packages.s3-credentials: disable failing tests
* [`bafe84ca`](https://github.com/NixOS/nixpkgs/commit/bafe84ca6244e44c00f6fc967a692b93325d4607) linuxkit: 1.0.0 -> 1.0.1
* [`cacb8033`](https://github.com/NixOS/nixpkgs/commit/cacb803367e1914edc41f569411787ef65e61c55) lux: 0.15.0 -> 0.16.0
* [`1e3628c0`](https://github.com/NixOS/nixpkgs/commit/1e3628c0e17609402f3f153ed96f87f20bd6aaf5) sheldon: fix build missing Security
* [`034d8b4e`](https://github.com/NixOS/nixpkgs/commit/034d8b4e52b82814c81cd5eb8dd9e082c7768b94) python310Packages.oslo-concurrency: disable tests
* [`1df9c7e0`](https://github.com/NixOS/nixpkgs/commit/1df9c7e0ec20c679aae8a832fab5677f28dc5d77) mucommander: 0.9.3-3 -> 1.1.0-1
* [`683f25a6`](https://github.com/NixOS/nixpkgs/commit/683f25a6af6e5642cd426c69a4de1d434971a695) tdesktop: 4.3.0 -> 4.3.1
* [`25f3b1cb`](https://github.com/NixOS/nixpkgs/commit/25f3b1cbcbe3165986c6691fe6fbe7187bf4eb3b) python310Packages.pyspellchecker: init at 0.7.0
* [`ec1dd542`](https://github.com/NixOS/nixpkgs/commit/ec1dd542530a8856e527c5c9970ca31135a359d4) cargo-hakari: 0.9.15 -> 0.9.16
* [`b7a3d4bb`](https://github.com/NixOS/nixpkgs/commit/b7a3d4bb11ad8cf8ca6e8a023704fd0370612098) verible: fix build for aarch64-linux
* [`7c3d2e6c`](https://github.com/NixOS/nixpkgs/commit/7c3d2e6cca58bd1fabc83d5f7a3af4ff69c977bd) cargo-guppy: unstable-2022-10-29 -> unstable-2022-11-07
* [`21621146`](https://github.com/NixOS/nixpkgs/commit/21621146c498cb9e4713d6712fa58d432e013ec2) owofetch: mark as x86_64 only
* [`b27746b8`](https://github.com/NixOS/nixpkgs/commit/b27746b804ac69f36e397a73baf5eefeef72ce6f) ruff: 0.0.105 -> 0.0.107
* [`4078ed75`](https://github.com/NixOS/nixpkgs/commit/4078ed7536c84fcabe62d70afd6b0f3b43812cb0) janet: 1.24.1 -> 1.25.1
* [`e18c1528`](https://github.com/NixOS/nixpkgs/commit/e18c1528d0d1908884e39b11b5d8edc358aa08a4) emoji-picker: init at 0.2.0
* [`c4c025e2`](https://github.com/NixOS/nixpkgs/commit/c4c025e250a966a976d6d262b13e0f71fd5d3ff3) verible: 0.0-2172-g238b6df60 -> 0.0-2472-ga80124e1
* [`d54da1f2`](https://github.com/NixOS/nixpkgs/commit/d54da1f2ff2434d193b884d5f680d3bc41cfc5f7) python310Packages.google-cloud-spanner: 3.22.2 -> 3.23.0
* [`88caa3b5`](https://github.com/NixOS/nixpkgs/commit/88caa3b5381619706c563fa20a68201cb43c4096) python310Packages.graphql-subscription-manager: 0.6.1 -> 0.7.0
* [`ee47da83`](https://github.com/NixOS/nixpkgs/commit/ee47da83d178913d0f425fad5971c6baa2c6a9d0) luau: 0.551 -> 0.552
* [`8819081e`](https://github.com/NixOS/nixpkgs/commit/8819081eeb01143b0d00b34e02216a4ba0f60067) millet: 0.5.12 -> 0.5.13
* [`c4c95950`](https://github.com/NixOS/nixpkgs/commit/c4c95950c5ce51b71228bef31144850064eeb76c) aws-c-common: add nix as reverse dependency to passthru.tests
* [`403af417`](https://github.com/NixOS/nixpkgs/commit/403af417dfed28510c5a8aa5abdf34a151191603) nixpacks: 0.12.2 -> 0.12.3
* [`b59a8cf7`](https://github.com/NixOS/nixpkgs/commit/b59a8cf7862370c968f3a82a8df345468b1dfb9a) terraform-providers.auth0: 0.39.0 → 0.40.0
* [`f293a4f4`](https://github.com/NixOS/nixpkgs/commit/f293a4f4871ec5a5819ff817072806c53b8f9757) terraform-providers.baiducloud: 1.17.0 → 1.17.1
* [`003025aa`](https://github.com/NixOS/nixpkgs/commit/003025aa3c1bd84c370ce8fd203cc6cf41abbb7a) terraform-providers.google: 4.42.1 → 4.43.0
* [`474b97d7`](https://github.com/NixOS/nixpkgs/commit/474b97d748f94c3a47b2fbc70449607b64e7ee98) terraform-providers.google-beta: 4.42.1 → 4.43.0
* [`782c8381`](https://github.com/NixOS/nixpkgs/commit/782c83817695602baef09247902e6610516162fa) terraform-providers.gridscale: 1.16.1 → 1.16.2
* [`ae3df9e9`](https://github.com/NixOS/nixpkgs/commit/ae3df9e9df965deaec2ef5f5cff19eea87052a21) terraform-providers.http: 3.2.0 → 3.2.1
* [`42dfb67b`](https://github.com/NixOS/nixpkgs/commit/42dfb67bb0d777397e657a827627d5ec947e46c5) terraform-providers.mongodbatlas: 1.4.6 → 1.5.0
* [`f5da6461`](https://github.com/NixOS/nixpkgs/commit/f5da646112cf75163e37906c1eaf8829e5291239) terraform-providers.scaleway: 2.5.0 → 2.6.0
* [`2fcd4677`](https://github.com/NixOS/nixpkgs/commit/2fcd46776cf3dec20b4eac1bef22a68724a07dbd) terraform-providers.snowflake: 0.50.0 → 0.51.0
* [`15048810`](https://github.com/NixOS/nixpkgs/commit/150488101f3f86e7e4168cd4a9da474ce04e6c90) terraform-providers.ucloud: 1.32.4 → 1.32.5
* [`2424f83a`](https://github.com/NixOS/nixpkgs/commit/2424f83ab748c8d78606f9346529236df68543ca) oh-my-posh: 12.12.1 -> 12.13.0
* [`e09f6f4f`](https://github.com/NixOS/nixpkgs/commit/e09f6f4fa12da17d8692af0b865f6e6fe9aa7aa7) verible: add newAM to maintainers
* [`45ab6cf9`](https://github.com/NixOS/nixpkgs/commit/45ab6cf9c84d74734200391aa872e79ad32f789d) python310Packages.nbconvert: 6.5.3 -> 7.2.3
* [`f0e84b66`](https://github.com/NixOS/nixpkgs/commit/f0e84b668fc0a588f8958d4d2fdaec83a7fb7785) python310Packages.huawei-lte-api: 1.6.4 -> 1.6.6
* [`77306d37`](https://github.com/NixOS/nixpkgs/commit/77306d371e34fb03ffe8daa356d9ea0ce31d9eba) python310Packages.nbformat: 5.5.0 -> 5.7.0
* [`cbda4425`](https://github.com/NixOS/nixpkgs/commit/cbda4425eccd61e4ab2d2833342507a310c417c3) linuxPackages.nvidia_x11.open: set platforms to only x86_64-linux
* [`30395529`](https://github.com/NixOS/nixpkgs/commit/3039552944add3456ccaa03e86378b51e5e4f4b7) python310Packages.jupytext: fix tests
* [`894f2bfd`](https://github.com/NixOS/nixpkgs/commit/894f2bfdcd57ef335e46b7a339108d12e5f1e6c1) imagemagick: 7.1.0-51 -> 7.1.0-52
* [`6ee6ee22`](https://github.com/NixOS/nixpkgs/commit/6ee6ee226baa77082b1bfdc851e34af6a2283731) julia: refresh patches, disable failing Zlib_jll version test
* [`0ae850e1`](https://github.com/NixOS/nixpkgs/commit/0ae850e1ca14627cd7ae338e35179c99da81efc0) eva: 0.3.0-2 -> 0.3.1
* [`6acfc788`](https://github.com/NixOS/nixpkgs/commit/6acfc788cc93f6e79a2dee1faf4328df208835f0) buildMozillaMach: add curl into crashreporter rpath
* [`3cf71169`](https://github.com/NixOS/nixpkgs/commit/3cf711696e4075b5198a03d46e75f24bb9a2bf1c) python310Packages.mastodon-py: 1.5.1 -> 1.5.2
* [`0402e1f0`](https://github.com/NixOS/nixpkgs/commit/0402e1f00b59eaf2f9108e3b558f51ed25bef430) pgmetrics: 1.13.1 -> 1.14.0
* [`5160daf9`](https://github.com/NixOS/nixpkgs/commit/5160daf97925551b014576c894d7e4f0ad99350d) davix: never use vendored curl
* [`693d8798`](https://github.com/NixOS/nixpkgs/commit/693d87982737c4819c73303db8b079c9d184240f) fwbuilder: fix build
* [`2f9d6a03`](https://github.com/NixOS/nixpkgs/commit/2f9d6a033cb92d8c7524e59548f990cc02087ad8) python310Packages.gql: use optional-dependencies
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
