### PR TITLE
niv emacs-overlay: update f04cb6f6 -> 3c164745

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f04cb6f6724ba4568a7f6dae0863e507477667b7",
-        "sha256": "0bf79q471177ygiax2kyz0nh3j0h61k9rgkz5bn98zawzkvmd1c6",
+        "rev": "3c1647451bf5c2391122c794605f5e590badbd6e",
+        "sha256": "10mczcqq2mw1a9kq4nc64dk4x9sf0517flqipgixk18knlnpqa04",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/f04cb6f6724ba4568a7f6dae0863e507477667b7.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/3c1647451bf5c2391122c794605f5e590badbd6e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@f04cb6f6...3c164745](https://github.com/nix-community/emacs-overlay/compare/f04cb6f6724ba4568a7f6dae0863e507477667b7...3c1647451bf5c2391122c794605f5e590badbd6e)

* [`88749da2`](https://github.com/nix-community/emacs-overlay/commit/88749da29c07c2ae565c9906565dbc895d736282) Updated repos/melpa
* [`acd095ae`](https://github.com/nix-community/emacs-overlay/commit/acd095aeb5b11864824182a2766b4123c365e18c) Updated repos/elpa
* [`194cd5d8`](https://github.com/nix-community/emacs-overlay/commit/194cd5d85845c3c04a42c68a93131dd1f7bb72cf) Updated repos/emacs
* [`cff0588f`](https://github.com/nix-community/emacs-overlay/commit/cff0588fd51f95b9f87b95540ea35640b14cd133) Updated repos/melpa
* [`9f24858d`](https://github.com/nix-community/emacs-overlay/commit/9f24858dc5c03a69e89bd70067fd5945be6d8bc9) Updated repos/emacs
* [`dd48b168`](https://github.com/nix-community/emacs-overlay/commit/dd48b16890264f6b033796c2c809e177f510c66d) Updated repos/melpa
* [`8ad6ae26`](https://github.com/nix-community/emacs-overlay/commit/8ad6ae2619bbed75b41d07682f914d1c694ed424) Updated repos/emacs
* [`931ac5f6`](https://github.com/nix-community/emacs-overlay/commit/931ac5f67eb8f273325097f2347f3e6fbe3b1a2a) Updated repos/melpa
* [`a5f66f40`](https://github.com/nix-community/emacs-overlay/commit/a5f66f4040d205e4b5aa94a1a4bb35a583024546) Updated repos/elpa
* [`bf014659`](https://github.com/nix-community/emacs-overlay/commit/bf0146592bf8b960266b4adcc315f13a6ff06471) Updated repos/emacs
* [`3f3be217`](https://github.com/nix-community/emacs-overlay/commit/3f3be217a2342f706705b7de4a7cae6e7a5b1140) Updated repos/melpa
* [`a22d7910`](https://github.com/nix-community/emacs-overlay/commit/a22d79104426b9442ec3540da7e27864beae564a) emacs: add emacsLsp
* [`c1b780cb`](https://github.com/nix-community/emacs-overlay/commit/c1b780cbfaee634d77f2855d07870be1d8e40403) Updated repos/emacs
* [`ea25aef6`](https://github.com/nix-community/emacs-overlay/commit/ea25aef6be5d11833b6fcfbbae30f488b721079b) Updated repos/melpa
* [`393b1d44`](https://github.com/nix-community/emacs-overlay/commit/393b1d44acf6a7ae5522e459dde3d42045c765ea) Updated repos/nongnu
* [`cf0a990a`](https://github.com/nix-community/emacs-overlay/commit/cf0a990ab58f1cd6dbe1ead35c94c3dbbf226996) Updated repos/emacs
* [`e58b5f1d`](https://github.com/nix-community/emacs-overlay/commit/e58b5f1dac80f717f41121a0e4008b3050d79b9d) Updated repos/melpa
* [`0b01e1fd`](https://github.com/nix-community/emacs-overlay/commit/0b01e1fd7c40a8b97e3f4754d6bcdecd4b2effc7) Updated repos/melpa
* [`8c7a6b03`](https://github.com/nix-community/emacs-overlay/commit/8c7a6b03fddd1acd38175657ed338445d6936979) Updated repos/emacs
* [`7aaab890`](https://github.com/nix-community/emacs-overlay/commit/7aaab890738ccdbe06d539f12b4c43c34c8a6abf) Updated repos/exwm
* [`038cd97c`](https://github.com/nix-community/emacs-overlay/commit/038cd97c32294a323d411bf78872844be82a2acb) Updated repos/melpa
* [`5960fb7e`](https://github.com/nix-community/emacs-overlay/commit/5960fb7e82389435b6dffb909342c271589b36a9) Updated repos/nongnu
* [`e74bed66`](https://github.com/nix-community/emacs-overlay/commit/e74bed661af99f9b6cb30f62431e00899180cf52) Updated repos/emacs
* [`7b58afb8`](https://github.com/nix-community/emacs-overlay/commit/7b58afb8604c9d53fe11bfb76e2ce903cb658b66) Updated repos/melpa
* [`4e064f7f`](https://github.com/nix-community/emacs-overlay/commit/4e064f7fde6738760c354ae73b8fdd05d30feaa9) Updated repos/elpa
* [`26c41596`](https://github.com/nix-community/emacs-overlay/commit/26c41596596cceffc38865815fc8de960b80d059) Updated repos/emacs
* [`c6869293`](https://github.com/nix-community/emacs-overlay/commit/c6869293b585efa58e44d871611a6702fd3bdf8a) Updated repos/melpa
* [`963baa4e`](https://github.com/nix-community/emacs-overlay/commit/963baa4e7b4c42d1ac776b510e96d999471c945d) Updated repos/emacs
* [`3c609f07`](https://github.com/nix-community/emacs-overlay/commit/3c609f0758588d318207991c38fe3c998d305411) Updated repos/melpa
* [`af4ea11d`](https://github.com/nix-community/emacs-overlay/commit/af4ea11d77395728c49e9dd006cd7a381eca2d78) Updated repos/nongnu
* [`e5759cd1`](https://github.com/nix-community/emacs-overlay/commit/e5759cd19921a0f890a14719564e1995979dc6cb) Updated repos/emacs
* [`7e80fed2`](https://github.com/nix-community/emacs-overlay/commit/7e80fed2300b097fede379c32e966d47c5ff50a2) Updated repos/melpa
* [`1872c729`](https://github.com/nix-community/emacs-overlay/commit/1872c7297d7dfcba2d5f206baa5fcb0094575ad8) Updated repos/nongnu
* [`caa22ae0`](https://github.com/nix-community/emacs-overlay/commit/caa22ae0ba14709f83da4be78b535afc883be882) Updated repos/elpa
* [`79c1a5f7`](https://github.com/nix-community/emacs-overlay/commit/79c1a5f75050e2b1100b42bb99122039b3afd7fd) Updated repos/emacs
* [`c5e7dafe`](https://github.com/nix-community/emacs-overlay/commit/c5e7dafee9514e8961289f81a52dfc45c419a13f) Updated repos/melpa
* [`69812253`](https://github.com/nix-community/emacs-overlay/commit/69812253cf13702aa0d6e6e0403b6282408561ec) Add more tree-sitter plugins
* [`550a115b`](https://github.com/nix-community/emacs-overlay/commit/550a115bab7d9d7e8c725f26469e5a9bfc2a8125) Updated repos/elpa
* [`90467757`](https://github.com/nix-community/emacs-overlay/commit/90467757b2d1c8959c8b7d03b866db5494b0e75a) Updated repos/emacs
* [`84ca738e`](https://github.com/nix-community/emacs-overlay/commit/84ca738e23c50c3b7c5fbc2773de3c85e66a8784) Updated repos/melpa
* [`e65da89e`](https://github.com/nix-community/emacs-overlay/commit/e65da89ecdf7e728610bf93c603e9b8761607f07) Updated repos/nongnu
* [`ea453849`](https://github.com/nix-community/emacs-overlay/commit/ea45384949c27847fae37096858833754440d3ae) Updated repos/emacs
* [`7e501eb6`](https://github.com/nix-community/emacs-overlay/commit/7e501eb660cdc127f282d88f169fabb6eca7a08c) Updated repos/melpa
* [`ec244f95`](https://github.com/nix-community/emacs-overlay/commit/ec244f95e9df58c7a51d8029b404bd45081f88a0) Updated repos/nongnu
* [`5f7e8164`](https://github.com/nix-community/emacs-overlay/commit/5f7e81648d4670e152ff8001c77a17f56e34f706) Updated repos/elpa
* [`90530888`](https://github.com/nix-community/emacs-overlay/commit/90530888811ea4e15b221a051f54cc3a50e62f1f) Updated repos/melpa
* [`bc1041f6`](https://github.com/nix-community/emacs-overlay/commit/bc1041f640f5fbb74a31c84c6704f191e2b31a0c) Bump emacs-lsp
* [`f714e4e1`](https://github.com/nix-community/emacs-overlay/commit/f714e4e11fdf87dffcf822b185a387943a248c9b) Updated repos/elpa
* [`6cee62d9`](https://github.com/nix-community/emacs-overlay/commit/6cee62d984b76a01998ec7961277f650574aef61) Updated repos/melpa
* [`1a701b70`](https://github.com/nix-community/emacs-overlay/commit/1a701b706e51b69d7874847b209a48c03b11ffc1) Updated repos/emacs
* [`9b1df30f`](https://github.com/nix-community/emacs-overlay/commit/9b1df30f4c14bef457f8de6733b281441f5ba22c) Updated repos/melpa
* [`2461f7bc`](https://github.com/nix-community/emacs-overlay/commit/2461f7bc39cfa3299593f8ad9c13fe74f0c1c4c9) Updated repos/elpa
* [`d5dc5d93`](https://github.com/nix-community/emacs-overlay/commit/d5dc5d9317d69a826fd34ff1a591df3ecf3d5e9f) Updated repos/emacs
* [`297fa39a`](https://github.com/nix-community/emacs-overlay/commit/297fa39a6fda037a676227826d4308fd21d8d8e4) Updated repos/melpa
* [`adfd6537`](https://github.com/nix-community/emacs-overlay/commit/adfd6537cadf5393c3f9880e4bad2e8a7b999d6d) Updated repos/emacs
* [`35a963fa`](https://github.com/nix-community/emacs-overlay/commit/35a963fa01988bf545d78a578cd01aca09a0a567) Updated repos/melpa
* [`3c164745`](https://github.com/nix-community/emacs-overlay/commit/3c1647451bf5c2391122c794605f5e590badbd6e) Updated repos/nongnu
