### PR TITLE
niv home-manager: update 4c45a8d1 -> 53e91596

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "knl",
         "repo": "home-manager",
-        "rev": "4c45a8d1cebb041a04abb39f6aaaedb3f303571b",
-        "sha256": "0m6khi6gc1mm6l4fxviqjl72d3zw5saxds1pyf4in0wwdj51swji",
+        "rev": "53e91596b2d33c6fbaccea2da18213ab9fa1a0a5",
+        "sha256": "0rzy5h8k7zpi42cfb2q34zxvgg2kzilyhym8wwkjgi8k6xhm09hg",
         "type": "tarball",
-        "url": "https://github.com/knl/home-manager/archive/4c45a8d1cebb041a04abb39f6aaaedb3f303571b.tar.gz",
+        "url": "https://github.com/knl/home-manager/archive/53e91596b2d33c6fbaccea2da18213ab9fa1a0a5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: unbroken
Commits: [knl/home-manager@4c45a8d1...53e91596](https://github.com/knl/home-manager/compare/4c45a8d1cebb041a04abb39f6aaaedb3f303571b...53e91596b2d33c6fbaccea2da18213ab9fa1a0a5)

* [`324fedcf`](https://github.com/knl/home-manager/commit/324fedcf9f1c475e2f522d03af029528e65969bc) Add module for aerc ([knl/home-manager⁠#3070](https://togithub.com/knl/home-manager/issues/3070))
* [`78f96434`](https://github.com/knl/home-manager/commit/78f964347c96b9e72d2176900863c91117f21b02) tests.stubs: set `pname`
* [`8675cfa5`](https://github.com/knl/home-manager/commit/8675cfa549e1240c9d2abb1c878bc427eefcf926) gh: add `extensions` option
* [`44dcad56`](https://github.com/knl/home-manager/commit/44dcad5604785cc80c93bcb1b61140e3e10bf821) wezterm: support color schemes
* [`ff513384`](https://github.com/knl/home-manager/commit/ff5133843c26979f8abb5dd801b32f40287692fa) zathura: add `mappings` option
* [`688e5c85`](https://github.com/knl/home-manager/commit/688e5c85b7537f308b82167c8eb4ecfb70a49861) neovim: fix tests ([knl/home-manager⁠#3147](https://togithub.com/knl/home-manager/issues/3147))
* [`0160a0ce`](https://github.com/knl/home-manager/commit/0160a0cef076294127f8cc0750019410ab94370d) Add flake.lock & workflow to update it ([knl/home-manager⁠#1934](https://togithub.com/knl/home-manager/issues/1934))
* [`ee8e99ad`](https://github.com/knl/home-manager/commit/ee8e99add552e0cd1b861f4b4864dca1b6430723) udiskie: make dependency on tray.target conditional
* [`991ff352`](https://github.com/knl/home-manager/commit/991ff35249305ef1df8ac9151827025f9d12c4d4) udiskie: add tests
* [`8ea0e4d6`](https://github.com/knl/home-manager/commit/8ea0e4d6d8337b8ec4771ab57785c059a17c90c7) udiskie: fix configuration file path typo
* [`353d21e1`](https://github.com/knl/home-manager/commit/353d21e108790a4823c9fae9812dc953e8994399) neovim runtime ([knl/home-manager⁠#3168](https://togithub.com/knl/home-manager/issues/3168))
* [`1d81e629`](https://github.com/knl/home-manager/commit/1d81e6295ca530603478114f4977402d51299ad8) udiskie: add test path to CODEOWNERS
* [`b382b59f`](https://github.com/knl/home-manager/commit/b382b59faf717c5b36f4cd8e1c5d96cdabd382c9) service.xidlehook: add detect-sleep option ([knl/home-manager⁠#3165](https://togithub.com/knl/home-manager/issues/3165))
* [`c5b4177b`](https://github.com/knl/home-manager/commit/c5b4177bda8b17f8f027b8145cd961210e6f4482) i3-sway: allow "container" and "output" in focus.mouseWarping ([knl/home-manager⁠#3154](https://togithub.com/knl/home-manager/issues/3154))
* [`ae474885`](https://github.com/knl/home-manager/commit/ae474885f7b2f13f186d40786e962c97e997e131) email: add yandex and office365 email flavors
* [`7bb4576f`](https://github.com/knl/home-manager/commit/7bb4576f46f7f7590347e21b14d2f6a2dbc76638) pueue: add module
* [`76fbb1b1`](https://github.com/knl/home-manager/commit/76fbb1b15e83a9243efa7efe39d1d0fdd5a4d103) treewide: replace <link> by <xref> where appropriate
* [`4c8c1c99`](https://github.com/knl/home-manager/commit/4c8c1c99770494027599d73c30423d8257a224ef) kitty: produce fewer empty lines
* [`3d3bbdfe`](https://github.com/knl/home-manager/commit/3d3bbdfe955383033fd17c28d2b1e93d48515d7d) clipmenu: add launcher option
* [`5bb1f675`](https://github.com/knl/home-manager/commit/5bb1f67568366fbb2402cf1110f116d74857c3f6) git: add option to define store names for generated include files ([knl/home-manager⁠#3171](https://togithub.com/knl/home-manager/issues/3171))
* [`0884d6c6`](https://github.com/knl/home-manager/commit/0884d6c6e47e75bdd1c40045d4d73e7f6c8e5cb8) programs.neovim: remove 'configure' setting ([knl/home-manager⁠#3177](https://togithub.com/knl/home-manager/issues/3177))
* [`375631f3`](https://github.com/knl/home-manager/commit/375631f35bb011031957d8a581e83ebe071bde13) firefox: support nested folders in bookmarks ([knl/home-manager⁠#3112](https://togithub.com/knl/home-manager/issues/3112))
* [`8e4220e6`](https://github.com/knl/home-manager/commit/8e4220e6c6e937099384740b36343d1704571870) flake: add templates ([knl/home-manager⁠#2892](https://togithub.com/knl/home-manager/issues/2892))
* [`d89bdff4`](https://github.com/knl/home-manager/commit/d89bdff445eadff03fe414e9c30486bc8166b72b) sway, bspwm: add extraConfigEarly ([knl/home-manager⁠#2847](https://togithub.com/knl/home-manager/issues/2847))
* [`5bd66dc6`](https://github.com/knl/home-manager/commit/5bd66dc6cd967033489c69d486402b75d338eeb6) email: fix the office365 smtp host ([knl/home-manager⁠#3191](https://togithub.com/knl/home-manager/issues/3191))
* [`7b512c94`](https://github.com/knl/home-manager/commit/7b512c94ffd714d18067257d08f7b5da6def947a) gpg-agent: invert grab and no-grab behavior
* [`f9a35cac`](https://github.com/knl/home-manager/commit/f9a35cacdc63678e9ace8acd8886ed798d93dc55) msmtp: allow sending email from aliased addresses
* [`66cc5c7e`](https://github.com/knl/home-manager/commit/66cc5c7ef9cae94f41dd52860a69911be33112e6) git-sync: add ssh to path
* [`960c009c`](https://github.com/knl/home-manager/commit/960c009ce04305ebd52fb2b3c10122ded3146c4e) git-sync: minor test cleanup
* [`de079ec3`](https://github.com/knl/home-manager/commit/de079ec3714e7b201c17cbe03b62be8d6dc7b3c0) btop: add module
* [`140aaed3`](https://github.com/knl/home-manager/commit/140aaed3dffbe33bb8b2e0cf333c67f36765c85e) git: gpg sign tags with signing.signByDefault set
* [`583a99f0`](https://github.com/knl/home-manager/commit/583a99f0166e3e5df9539b972091830bb9faf6b8) swayidle: allow wayland targets other than sway-session.target ([knl/home-manager⁠#3202](https://togithub.com/knl/home-manager/issues/3202))
* [`de94878b`](https://github.com/knl/home-manager/commit/de94878b6b83f7f2cfda9cdff005417a6d7ac82c) editorconfig: add module ([knl/home-manager⁠#3204](https://togithub.com/knl/home-manager/issues/3204))
* [`22113a3a`](https://github.com/knl/home-manager/commit/22113a3ae3c8410c682324e1ac3d0b995ceaf82a) ci: bump DeterminateSystems/update-flake-lock from 9 to 13 ([knl/home-manager⁠#3188](https://togithub.com/knl/home-manager/issues/3188))
* [`2e41a1ba`](https://github.com/knl/home-manager/commit/2e41a1bab32e49568a037ddd962ebbe01c8c2f40) systemd: handle `Install.RequiredBy`
* [`340ec22f`](https://github.com/knl/home-manager/commit/340ec22f6f2e9c52e2b555e48ab44ee8c53e0275) git: add config helper for hooks
* [`6ec6b2e3`](https://github.com/knl/home-manager/commit/6ec6b2e362ef91a48cd093eff570842685024c56) nheko: add module
* [`4cfc0a1e`](https://github.com/knl/home-manager/commit/4cfc0a1e02c6374f66acdfd2ff8ae3e87c80c818) yt-dlp: add module
* [`f9f4c8e1`](https://github.com/knl/home-manager/commit/f9f4c8e1e77c7447db5f7edd6b8d343b4c864550) gallery-dl: add module
* [`b92826d0`](https://github.com/knl/home-manager/commit/b92826d0c4a6a7c50fece3caaeaa0cb08536a3f3) codeowners: fix typo ([knl/home-manager⁠#3215](https://togithub.com/knl/home-manager/issues/3215))
* [`9f7fe353`](https://github.com/knl/home-manager/commit/9f7fe353b613d0e45d7a5cdbd1f13c96c15803dd) docs: replace use of `#` by `$ sudo`
* [`60c6bfe3`](https://github.com/knl/home-manager/commit/60c6bfe322944d04bb38e76b64effcbd01258824) zsh: add option for `zsh-history-substring-search` ([knl/home-manager⁠#3156](https://togithub.com/knl/home-manager/issues/3156))
* [`ebd78308`](https://github.com/knl/home-manager/commit/ebd78308144165d65b28f80969a970b8213805b2) exa: add package option
* [`6745da6d`](https://github.com/knl/home-manager/commit/6745da6dce1ae023e934e1ea17f7209641fcb9ee) rtorrent: change settings to extraConfig
* [`5408e279`](https://github.com/knl/home-manager/commit/5408e27961599b1350b651f88715daf6e67244a7) flake.lock: Update
* [`b0247cee`](https://github.com/knl/home-manager/commit/b0247ceedc72322f77c16fb490c0fdf6373a3f6b) xdg.userDirs: avoid using $HOME
* [`5427f3d1`](https://github.com/knl/home-manager/commit/5427f3d1f0ea4357cd4af0bffee7248d640c6ffc) mpd: use XDG music dir if XDG user dirs are enabled
* [`610b1d98`](https://github.com/knl/home-manager/commit/610b1d988ca9f7bc0831a599b7de0b2e26df0669) nix-darwin: improve invocation of activation script
* [`95559181`](https://github.com/knl/home-manager/commit/95559181518533741c516826ae377a51814569c3) nix-darwin: simplify activation script invocation
* [`b4bfe3b2`](https://github.com/knl/home-manager/commit/b4bfe3b2d955f31d6983b4f11ac4095997a11710) Translate using Weblate (Danish)
* [`22ef57a5`](https://github.com/knl/home-manager/commit/22ef57a54c6ec3a0465c84cc3fbba8eabd446bab) Add translation using Weblate (Danish)
* [`df79df8b`](https://github.com/knl/home-manager/commit/df79df8be10bc54d79118ac6167a92b779344228) Translate using Weblate (Danish)
* [`41790ba6`](https://github.com/knl/home-manager/commit/41790ba656bafc023f48ccdbbe7816d30fd52d76) mbsync: extend config type with list of strings
* [`f5e4614c`](https://github.com/knl/home-manager/commit/f5e4614c1163ffe4a30cfb3cf1b76a72f69c3fda) yt-dlp: add `settings` option
* [`f17819f4`](https://github.com/knl/home-manager/commit/f17819f4f198a3973be76797aa8a9370e35c7ca6) fluxbox: add module
* [`bd83eab6`](https://github.com/knl/home-manager/commit/bd83eab6220226085c82e637931a7ae3863d9893) programs.neovim: default to init.lua ([knl/home-manager⁠#3233](https://togithub.com/knl/home-manager/issues/3233))
* [`de3758e3`](https://github.com/knl/home-manager/commit/de3758e31a3a1bc79d569f5deb5dac39791bf9b6) neovim: fix a typo in the generated init.lua ([knl/home-manager⁠#3252](https://togithub.com/knl/home-manager/issues/3252))
* [`3eaadd82`](https://github.com/knl/home-manager/commit/3eaadd82b8fb646a6779839c4f276b810e0354a5) maintainers: add Rosuavio
* [`9b917098`](https://github.com/knl/home-manager/commit/9b91709899ddf20cbead93e4af622bd0a501dd0b) safeeyes: add module
* [`707cb75e`](https://github.com/knl/home-manager/commit/707cb75ed33c59b58e6e03af881a833f3538d3e3) tmate: add module
* [`9e739452`](https://github.com/knl/home-manager/commit/9e7394523eb4f298528d457e316fc752bdf07151) ci: bump DeterminateSystems/update-flake-lock from 13 to 14
* [`65b65ce5`](https://github.com/knl/home-manager/commit/65b65ce5ef08d54bc09336fe3f35e33be487e2fe) broot: use upstream defaults, allow all config options ([knl/home-manager⁠#2644](https://togithub.com/knl/home-manager/issues/2644))
* [`1f5ef2bb`](https://github.com/knl/home-manager/commit/1f5ef2bb419a327fae28a83b50fab50959132c24) broot: fix config file location ([knl/home-manager⁠#3273](https://togithub.com/knl/home-manager/issues/3273))
* [`6dc8a43f`](https://github.com/knl/home-manager/commit/6dc8a43f397c92afbc3f771385ac803d96d5eeb5) flake: list deprecated args in throw
* [`28334988`](https://github.com/knl/home-manager/commit/28334988dbd613012b1b085c37d144889f8e2abc) picom: use `types.numbers.between`
* [`68ea28d3`](https://github.com/knl/home-manager/commit/68ea28d330f2e1ef3fb2c653da42b558f14a1efd) kdeconnect: change package
* [`9da6c023`](https://github.com/knl/home-manager/commit/9da6c0232e22b7fff358db633f6bbc8f97a891e1) docs: explain how to enable flakes on NixOS
* [`864ff685`](https://github.com/knl/home-manager/commit/864ff685fe6443101a0a8f3950d21bcb4330e56a) lib: add two new gvariant types
* [`e7be7c46`](https://github.com/knl/home-manager/commit/e7be7c468842944a9877ad6ff948afd0d1cb2dbe) pls: add module ([knl/home-manager⁠#3285](https://togithub.com/knl/home-manager/issues/3285))
* [`a053da0f`](https://github.com/knl/home-manager/commit/a053da0f22a05ceda845c824cf964077515c7669) fluxbox: use mkPackageOption instead of mkOption ([knl/home-manager⁠#3286](https://togithub.com/knl/home-manager/issues/3286))
* [`5c5a5b9b`](https://github.com/knl/home-manager/commit/5c5a5b9b45ee92995909b7944eefc4284af93849) urxvt: fix package name
* [`9727190b`](https://github.com/knl/home-manager/commit/9727190b804f690c8590bbf191598439a35b0877) mangohud: fix moved link of config file
* [`7a3384c7`](https://github.com/knl/home-manager/commit/7a3384c7969f50e6e3799f8d1c7817b698dd77d3) syncthing: add platform assertion
* [`a7f0cc2d`](https://github.com/knl/home-manager/commit/a7f0cc2d7b271b4a5df9b9e351d556c172f7e903) lorri: add nixPackage and enableNotifications options
* [`e4e639dd`](https://github.com/knl/home-manager/commit/e4e639dd4dc3e431aa5b5f95325f9a66ac7e0dd9) programs/lieer: use lieer package ([knl/home-manager⁠#3262](https://togithub.com/knl/home-manager/issues/3262))
* [`1a8e35d2`](https://github.com/knl/home-manager/commit/1a8e35d2e53ed2ccd9818fad9c9478d56c655661) mpd: add package to home path ([knl/home-manager⁠#3303](https://togithub.com/knl/home-manager/issues/3303))
* [`6427ae95`](https://github.com/knl/home-manager/commit/6427ae95789c04534363d2b68289996f08077c0c) swayidle: fix examples
* [`599e22b1`](https://github.com/knl/home-manager/commit/599e22b1c76dc56172c7bb97bc3cd04266869bd6) sbt: allow managing the `~/.sbt/repositories` file
* [`7fee13eb`](https://github.com/knl/home-manager/commit/7fee13eb4c64740261c774a90e43830f7213c57c) sbt: cache `passwordCommand` output
* [`8c297e18`](https://github.com/knl/home-manager/commit/8c297e1816c9744da5a90d8b7aef8ff5c3a41bad) ledger: add module
* [`be2cade3`](https://github.com/knl/home-manager/commit/be2cade373d96b469e5f4bb22c40cac87cf5a6f0) havoc: add module
* [`9fcae11f`](https://github.com/knl/home-manager/commit/9fcae11ff29ca5f959b05c206f3724486c28ff07) systemd: name slice unit correctly
* [`3b5a8d3d`](https://github.com/knl/home-manager/commit/3b5a8d3dc79e05213d3c428a0b8777e21cb0c6b8) ci: introduce labeler workflow
* [`bd87a34b`](https://github.com/knl/home-manager/commit/bd87a34bb487a655e1282528a70d0d6b10585a37) sioyek: enable multiple bindings for the same command
* [`e1f11602`](https://github.com/knl/home-manager/commit/e1f1160284198a68ea8c7fffbbb1436f99e46ef9) redshift/gammastep: add `enableVerboseLogging` option
* [`ebe6d2c7`](https://github.com/knl/home-manager/commit/ebe6d2c747cc6e2223dd5962bdca258088518b3f) home-manager: set state version when uninstalling
* [`b37a9095`](https://github.com/knl/home-manager/commit/b37a909508edb8d7fdcd04ac90761b2cfa2a5f28) ci: specify files that should be tagged "mail"
* [`5597b3a7`](https://github.com/knl/home-manager/commit/5597b3a7425a9e3f41128308cb1105d3e780f633) dconf: reset keys that become unmanaged on switch
* [`2d8e5a99`](https://github.com/knl/home-manager/commit/2d8e5a99343fc7df3ba7a512ea59a98b75166974) discocss: add module
* [`618ab0f8`](https://github.com/knl/home-manager/commit/618ab0f882167361108475a9f1404fb4c638b73d) discocss: fix attribute name
* [`8eaa3ba5`](https://github.com/knl/home-manager/commit/8eaa3ba56edaf89138549d0854e3a94c0dbad060) lib/bash: remove unused Bash library files
* [`8cbc6500`](https://github.com/knl/home-manager/commit/8cbc6500dfca22d907054f68c564019b3b6cf295) lib/bash: make call to tput more robust
* [`2ecb3ea9`](https://github.com/knl/home-manager/commit/2ecb3ea990cf737cfb42d8cd805fa86347c1afaf) firefox: rename chrome-gnome-shell suggestion to gnome.gnome-browser-connector ([knl/home-manager⁠#3329](https://togithub.com/knl/home-manager/issues/3329))
* [`86bc0e34`](https://github.com/knl/home-manager/commit/86bc0e349fcc7ab7a9ac7e6892c6bd6ac12fd1ee) dconf: handle missing oldGenPath
* [`da3b8049`](https://github.com/knl/home-manager/commit/da3b8049fd3a98fbe5d2e82d217f415e6f01d45e) im/fcitx5: add GLFW_IM_MODULE session variable
* [`04f53999`](https://github.com/knl/home-manager/commit/04f53999788cd47c6ce932d6cbd7cbfd3998712f) borgmatic: add module
* [`bc7432fb`](https://github.com/knl/home-manager/commit/bc7432fbcc5bdd15f90109ac32fc4c7b75b968af) ci: bump cachix/install-nix-action from 17 to 18
* [`a50c0c6f`](https://github.com/knl/home-manager/commit/a50c0c6fe0e87d999022e5ce840aa3700ca58ce7) dependabot: switch target from 21.11 to 22.05
* [`e901c8d8`](https://github.com/knl/home-manager/commit/e901c8d86082be74a8be70773bbb6d401ff21e49) ci: bump cachix/cachix-action from 10 to 11
* [`42f81ac1`](https://github.com/knl/home-manager/commit/42f81ac107c5a9a177888080107094dba57f134e) looking-glass-client: add module
* [`d1191c6d`](https://github.com/knl/home-manager/commit/d1191c6d05120449f3e54e1211518df7c69ee282) docs: bump nmd
* [`c485669c`](https://github.com/knl/home-manager/commit/c485669ca529e01c1505429fa9017c9a93f15559) i3status: add `package` attribute
* [`69d19b98`](https://github.com/knl/home-manager/commit/69d19b9839638fc487b370e0600a03577a559081) firefox: support setting search engines
* [`186d9399`](https://github.com/knl/home-manager/commit/186d9399f9eb64fb06ea4385732c1cf1624ae2b6) borgmatic: specify where to find sleep ([knl/home-manager⁠#3349](https://togithub.com/knl/home-manager/issues/3349))
* [`7dc4e4eb`](https://github.com/knl/home-manager/commit/7dc4e4ebd71280842b4d30975439980baaac9db8) k9s: add module
* [`32fe7d2e`](https://github.com/knl/home-manager/commit/32fe7d2ebb7e338ad95a3ea9393fc6ad681368ce) home-environment: add hm-version file
* [`d3f21617`](https://github.com/knl/home-manager/commit/d3f21617acace32097a53b0b74fb5000d333d094) vscode: add options to disable update checks
* [`f6764930`](https://github.com/knl/home-manager/commit/f67649307d4f81d8fbac68c19d1d1c564ab26dca) home-environment: make getVersion more robust
* [`213a0629`](https://github.com/knl/home-manager/commit/213a06295dff96668a1d673b9fd1c03ce1de6745) ci: don't run tests in GitLab CI
* [`42321140`](https://github.com/knl/home-manager/commit/423211401c245934db5052e3867cac704f658544) home-environment: update hm-version generation
* [`160025ca`](https://github.com/knl/home-manager/commit/160025ca46e48a6a0b2bdb971801a0470f744500) irssi: add option for SASL external authentication
* [`fad4e7c7`](https://github.com/knl/home-manager/commit/fad4e7c79cb6668e9c2f90f008ee3522d9cd298f) flake.lock: Update
* [`2464c21a`](https://github.com/knl/home-manager/commit/2464c21ab2b3607bed3c206a436855c487f35f55) sway: import XDG_SESSION_TYPE in systemd user environment ([knl/home-manager⁠#3328](https://togithub.com/knl/home-manager/issues/3328))
* [`25344cb8`](https://github.com/knl/home-manager/commit/25344cb808759197c0eb5a425e23732041c95062) ci: bump cachix/cachix-action from 11 to 12 ([knl/home-manager⁠#3368](https://togithub.com/knl/home-manager/issues/3368))
* [`722e8d65`](https://github.com/knl/home-manager/commit/722e8d65d3aba6f527100cc2d1539e4ca04d066f) ci: use the cachix auth token
* [`8957d531`](https://github.com/knl/home-manager/commit/8957d531997a2b1f4562a7e6313a78a450d5074b) awesome: fix luaModules using pkgs.lua instead of awesome.lua ([knl/home-manager⁠#3258](https://togithub.com/knl/home-manager/issues/3258))
* [`824202b4`](https://github.com/knl/home-manager/commit/824202b4c4feb02e11fa1a44b140d5b0f218702c) readme: add inofficial option search
* [`183a62f3`](https://github.com/knl/home-manager/commit/183a62f356f16d12ac60f0e4e5d54f0bd78f6ba6) targets/generic-linux: use the correct nix package
* [`04e84409`](https://github.com/knl/home-manager/commit/04e844090ed17298bfbe0f8249109b15770571bc) oh-my-posh: add module
* [`916811c8`](https://github.com/knl/home-manager/commit/916811c8f9ef37beb7705150d76cc88ce79466fd) xfconf: add module
* [`f520832a`](https://github.com/knl/home-manager/commit/f520832a47dbc24d1e2c4e4b9a3dbe910777d1a2) darwin: re-enable ~/Applications symlinks ([knl/home-manager⁠#3139](https://togithub.com/knl/home-manager/issues/3139))
* [`39c1e670`](https://github.com/knl/home-manager/commit/39c1e6704a58cb160d4f6b03215dffc819774f1c) vscode: fix invalid examples
* [`93335810`](https://github.com/knl/home-manager/commit/93335810751f0404fe424e61ad58bc8e94bf8e9d) vscode: add userTasks test
* [`b764068a`](https://github.com/knl/home-manager/commit/b764068a506c6f70dba998efa0e7fcb99cb4deb2) thunderbird: add module
* [`c7283074`](https://github.com/knl/home-manager/commit/c728307482dacc9b2720b8036292b166c7865fa9) darwin: use full path to commands in activation script
* [`ccc9164b`](https://github.com/knl/home-manager/commit/ccc9164b76e4167873ed819f0fb014635453ec68) home-environment: fix activation on new style profiles
* [`989d4fa5`](https://github.com/knl/home-manager/commit/989d4fa536e9bcd6bc2d42b3ac8b9dc07b1f9d26) home-environment: remove no-op commands
* [`c5adf295`](https://github.com/knl/home-manager/commit/c5adf29545b553089ccf9c28b68973ce6f812c1c) i3: fix reloading when there are several sockets
* [`1ef0da32`](https://github.com/knl/home-manager/commit/1ef0da321217c6c19b7a30509631c080a19321e5) flake.lock: Update
* [`5dd3ce3f`](https://github.com/knl/home-manager/commit/5dd3ce3f1eb83cb6d45c27ef7d19fc9913681a82) mu: use absolute path to mu in activation block
* [`d6777656`](https://github.com/knl/home-manager/commit/d67776563ec1f11df401837aa800c212417a6ca6) systemd: fix `systemctlPath` default text
* [`88667599`](https://github.com/knl/home-manager/commit/886675991b643b701a33f533443db165c70692d1) home-environment: reset PATH in activation script
* [`b0cf7245`](https://github.com/knl/home-manager/commit/b0cf7245c430df2ae9e511449e5840bfdfd01cc7) Translate using Weblate (Dutch)
* [`d20e3d07`](https://github.com/knl/home-manager/commit/d20e3d070c78271356a2d5d73c01f1de94586087) screen-locker: minor description fix
* [`6ce3493a`](https://github.com/knl/home-manager/commit/6ce3493a3c5c6a8f4cfa6f5f88723272e0cfd335) kodi: fix syntax error in example
