### PR TITLE
niv powerlevel10k: update 5a3109e4 -> bc598354

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "5a3109e40d2843d5e93d238568abaf5d5bc5d85a",
-        "sha256": "0lh58n9iym1n296yv9cf0zfh2jbv12rn9p0cbjqc9g2sqgywrq6x",
+        "rev": "bc5983543a10cff2eac30cced9208bbfd91428b8",
+        "sha256": "0s8ndbpmlqakg7s7hryyi1pqij1h5dv0xv9xvr2qwwyhyj6zrx2i",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/5a3109e40d2843d5e93d238568abaf5d5bc5d85a.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/bc5983543a10cff2eac30cced9208bbfd91428b8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@5a3109e4...bc598354](https://github.com/romkatv/powerlevel10k/compare/5a3109e40d2843d5e93d238568abaf5d5bc5d85a...bc5983543a10cff2eac30cced9208bbfd91428b8)

* [`8c55eb4f`](https://github.com/romkatv/powerlevel10k/commit/8c55eb4fa3a33f9a0a5c52775a253ad3b18b988c) wizad: add a hint pointing to the frame when asking for frame color
* [`5691a418`](https://github.com/romkatv/powerlevel10k/commit/5691a418e09ccc982cf8f58d40849d46be01be2c) Prefer `ip` over `ifconfig` for i/f detection.
