### PR TITLE
niv spacemacs: update 0acf65c4 -> 57a7a0e6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "0acf65c4c5b15bcd05902d5aa981f5831476ae18",
-        "sha256": "1kk50s3g6qzv1w4dfsjmvykigqhkm0hg0m1jqp0glnv70g4dbsc9",
+        "rev": "57a7a0e63c4aecf810b19ca3fd49e5ae1a838126",
+        "sha256": "1lwbjfldysqfi4cf7i0fs9gz3iy83zlam45cdvlg0j0279ixbl6b",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/0acf65c4c5b15bcd05902d5aa981f5831476ae18.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/57a7a0e63c4aecf810b19ca3fd49e5ae1a838126.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@0acf65c4...57a7a0e6](https://github.com/syl20bnr/spacemacs/compare/0acf65c4c5b15bcd05902d5aa981f5831476ae18...57a7a0e63c4aecf810b19ca3fd49e5ae1a838126)

* [`44884003`](https://github.com/syl20bnr/spacemacs/commit/44884003aad5f46349aa54693658fc871c910748) Remove evil-ediff ([syl20bnr/spacemacs⁠#15801](https://togithub.com/syl20bnr/spacemacs/issues/15801))
* [`df39c561`](https://github.com/syl20bnr/spacemacs/commit/df39c561bbe8eaea08e9ae0509f4d3269d311673) Reporting.tmp: added github account is needed note
* [`ab5911fa`](https://github.com/syl20bnr/spacemacs/commit/ab5911fabd892c1029c081685ec782b44477899e) * spacemacs-defaults: fix err msg when copy file path in a dired buffer
* [`77dfcb21`](https://github.com/syl20bnr/spacemacs/commit/77dfcb2149f3ccba293c94ad5f3f5d102d21e6ee) * spacemacs-editing: expect the vterm-mode for the hungry-delete
* [`52da38e7`](https://github.com/syl20bnr/spacemacs/commit/52da38e71dd32c0d35c94a9b8ec681c8803c3c7e) [org] keybindings for managing org agenda files
* [`03c9139a`](https://github.com/syl20bnr/spacemacs/commit/03c9139ade0b9ff57d5b416a4428add2cfd31aab) [finance] Evilify ledger-reconcile-mode-map
* [`90fb8138`](https://github.com/syl20bnr/spacemacs/commit/90fb81382a847f77ea352a3d606cfc0e8c1f39c0) Use string-edit-at-point instead of string-edit
* [`906bcf0e`](https://github.com/syl20bnr/spacemacs/commit/906bcf0ec9ab4749e621e077aa0a5ae8cb6f7be7) [project] Add `SPC p E` for newly added `projectile-find-references` (closes [syl20bnr/spacemacs⁠#15789](https://togithub.com/syl20bnr/spacemacs/issues/15789))
* [`2a56871b`](https://github.com/syl20bnr/spacemacs/commit/2a56871ba472d6780708dc2e12d4ec248add146b) [bot] "built_in_updates" Sat Nov 12 22:52:15 UTC 2022
* [`69fbbeee`](https://github.com/syl20bnr/spacemacs/commit/69fbbeee1c33c20509a771d41714e8389f1837be) [bot] "documentation_updates" Sat Nov 12 22:59:16 UTC 2022
* [`57a7a0e6`](https://github.com/syl20bnr/spacemacs/commit/57a7a0e63c4aecf810b19ca3fd49e5ae1a838126) * layers/+spacemacs/spacemacs-editing: use the string-edit-at-point-mode
