### PR TITLE
niv zsh-completions: update b736f267 -> 7916ba50

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "b736f2679c4da5b51d80077d3c00f32009cd38e7",
-        "sha256": "0f13f7s94irgkf5b2k3mdcz91yyyiximmcxmj0dq3bpgncmcb0kh",
+        "rev": "7916ba50ed3633b2e85d9d7c4d323c5ec75b39b0",
+        "sha256": "07sklvx32zqk7c1bhajz5niknnhiwqxfm0ki8c38v33fn033s6ms",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/b736f2679c4da5b51d80077d3c00f32009cd38e7.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/7916ba50ed3633b2e85d9d7c4d323c5ec75b39b0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@b736f267...7916ba50](https://github.com/zsh-users/zsh-completions/compare/b736f2679c4da5b51d80077d3c00f32009cd38e7...7916ba50ed3633b2e85d9d7c4d323c5ec75b39b0)

* [`6310817e`](https://github.com/zsh-users/zsh-completions/commit/6310817eb4806a6185a1b8a41b5dfaf41b82977b) Update bundle zsh completion
* [`20edd70f`](https://github.com/zsh-users/zsh-completions/commit/20edd70f84ad4082b7bd51f030910672c1826d5d) Update cppcheck completion
* [`d45e52f6`](https://github.com/zsh-users/zsh-completions/commit/d45e52f60719c21463460e4181a6cb8920b6a574) Update gist completion
* [`27e61dfb`](https://github.com/zsh-users/zsh-completions/commit/27e61dfbaf7984b18a7c5cdde7c42d04636c7f89) Update nvm completion
* [`28affc5c`](https://github.com/zsh-users/zsh-completions/commit/28affc5c8016dfaba51d8458de396c6f6d27a975) Update Teamocil
* [`6470db93`](https://github.com/zsh-users/zsh-completions/commit/6470db93fbd2fdbe33b6584bc274d64866bc2711) fix group completion
* [`2d9d1ffa`](https://github.com/zsh-users/zsh-completions/commit/2d9d1ffa60f6c4125b3a7910ab8de9fa12fd95ad) Update RuboCop completion
* [`c3ff722d`](https://github.com/zsh-users/zsh-completions/commit/c3ff722d2e6149ffe3d2516af795c8a290c6c59d) Add git-revise completion
* [`28070aa9`](https://github.com/zsh-users/zsh-completions/commit/28070aa9e4625ac3809abd235a423713971e4142) Update rslsync completion
