### PR TITLE
niv nixpkgs: update a0bf7e25 -> 0eb16c85

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0bf7e251c9e830157475684e19ca6ae129102a4",
-        "sha256": "0qiyhmhgdd4nyfcnhl1wwpmbp24bdlz873f32crcr068aj04rzfl",
+        "rev": "0eb16c85a0dfe013e5585ee02c3033161a8baa9e",
+        "sha256": "00qw4r7w11cxml96l02v4w2cgh50i8wk35azaxbqrrc2n202ysb5",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a0bf7e251c9e830157475684e19ca6ae129102a4.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/0eb16c85a0dfe013e5585ee02c3033161a8baa9e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a0bf7e25...0eb16c85](https://github.com/nixos/nixpkgs/compare/a0bf7e251c9e830157475684e19ca6ae129102a4...0eb16c85a0dfe013e5585ee02c3033161a8baa9e)

* [`e1642afb`](https://github.com/NixOS/nixpkgs/commit/e1642afb01af85c13d3aeb5c0e70840684a03f2a) kernel: common-config.nix: enable FANOTIFY_ACCESS_PERMISSIONS
* [`eabc6d29`](https://github.com/NixOS/nixpkgs/commit/eabc6d2902f792064890a8fd48c6078e68248da4) lib/systems/platforms.nix: fix broken mips32 detection
* [`4d46ee86`](https://github.com/NixOS/nixpkgs/commit/4d46ee8691f11a7c7f4592fb645b4ba4c49dfbe2) platforms.nix: use `inherit` syntax
* [`ee2fafc0`](https://github.com/NixOS/nixpkgs/commit/ee2fafc0d408f2a949344753511aee0094961d04) isolyzer: 1.3.0 -> 1.4.0
* [`6c8d7891`](https://github.com/NixOS/nixpkgs/commit/6c8d7891746e9627c4518c5bd0b3c0077d85ba05) starsector: fix jvm compatibility, startup crashes and sound, add passthru.updateScript
* [`ee1b9e6f`](https://github.com/NixOS/nixpkgs/commit/ee1b9e6f7bd43f05684805ae376caf16330fa96e) qt6.full: add
* [`3daea5fa`](https://github.com/NixOS/nixpkgs/commit/3daea5fa9be672031f97fe3b2c360257821165e5) nixos-containers: Make sure same version of nixos-container is used
* [`a381f9bc`](https://github.com/NixOS/nixpkgs/commit/a381f9bccf279f9d2601525029f847311d8d562d) openssl: Rosetta Stone entry for mips32
* [`db5e8a71`](https://github.com/NixOS/nixpkgs/commit/db5e8a7141dbd0b20f01db1db0837f987bb29819) remove Nix language syntax summary
* [`aad7f1d6`](https://github.com/NixOS/nixpkgs/commit/aad7f1d6b36819115cdfa4ccaa9d39237bfa57c5) doc/../rust.section.md: prominently mention `buildRustXX` names
* [`de8743c2`](https://github.com/NixOS/nixpkgs/commit/de8743c2734c682a750694a51b8cf024c2dd3df5) jetbrains.clion: patch lldb instead of replacing
* [`2018f92e`](https://github.com/NixOS/nixpkgs/commit/2018f92ef25a57c07b4c924476375948cf60164e) Add issue template for unreproducible packages
* [`d3afad85`](https://github.com/NixOS/nixpkgs/commit/d3afad859a147a439f5b5cfe0fcfa2ba9d8a8a08) martian-mono: init at 0.9.1
* [`392801ba`](https://github.com/NixOS/nixpkgs/commit/392801ba21400eb7b6eaabb85d22ed24d6e33baf) pantheon.elementary-default-settings: add files dock item
* [`e24daea3`](https://github.com/NixOS/nixpkgs/commit/e24daea3d3d46bd0ae87b29b9315bd2d0df9c389) tailscale: improve formatting on warning message
* [`12f9d8e7`](https://github.com/NixOS/nixpkgs/commit/12f9d8e7303af57ed2d462c17b772c36fd05d0ea) buildPythonPackage: better error message if no setuptools is used.
* [`e8856a00`](https://github.com/NixOS/nixpkgs/commit/e8856a00da3de06369d68fd2e9960188f246a4a3) nixos/steam: add package option
* [`7e2aec07`](https://github.com/NixOS/nixpkgs/commit/7e2aec079c099f55b991b80356239076705d1bff) nixos/filesystems: escape mount options in fstab
* [`1447e791`](https://github.com/NixOS/nixpkgs/commit/1447e791a0b8a038895e299e199be978b022f8f2) threema-desktop: 1.2.13 -> 1.2.21
* [`56ab2dc7`](https://github.com/NixOS/nixpkgs/commit/56ab2dc73face43b7b1e412e01cbd4d562b8c1f1) mpvScripts.sponsorblock: unstable-2021-12-23 -> unstable-2022-09-24
* [`150a54fe`](https://github.com/NixOS/nixpkgs/commit/150a54fee9d0e09bf8cd0f0d5bc081eda4a2ebb1) tuxpaint: 0.9.27 -> 0.9.28
* [`7d84dbdf`](https://github.com/NixOS/nixpkgs/commit/7d84dbdf5b91439f798363559310d86b21bfa86c) nixos/zsh: don’t be noisy when scripts are run with -u
* [`60805f2f`](https://github.com/NixOS/nixpkgs/commit/60805f2fa5b28e9db1dd9219b27f5e52bb7d4d44) python3Packages.reorder-python-imports: 3.8.1 -> 3.8.5
* [`26b97785`](https://github.com/NixOS/nixpkgs/commit/26b97785e0045ba51cb1c39e64f67f4820f6661e) haste-server: 787d839086faee0b55c76ce5944fa207d22e85b4 -> 20919c946602b8151157f647e475e30687a43727
* [`c19dbef9`](https://github.com/NixOS/nixpkgs/commit/c19dbef946b86c72d7d944a51d3a38dd36d08a61) perlPackages.IOAsync: 0.801 -> 0.802
* [`355a7527`](https://github.com/NixOS/nixpkgs/commit/355a7527cc9d8559a097715db7db7fa7477889b6) phpExtensions.datadog_trace: cleanup
* [`0b5af74c`](https://github.com/NixOS/nixpkgs/commit/0b5af74cb6638fdc7f14393f0fbd06fadcd9a135) phpExtensions.event: cleanup description
* [`e5ef9dc5`](https://github.com/NixOS/nixpkgs/commit/e5ef9dc5bf3f037599970956ab3aee7b049f34d3) phpExtensions.openswoole: split longDescription on new lines
* [`1592f4ca`](https://github.com/NixOS/nixpkgs/commit/1592f4ca84871195b17695656f412f8c2aecdf93) phpExtensions.php-cs-fixer: update homepage
* [`44d0f378`](https://github.com/NixOS/nixpkgs/commit/44d0f3783387cdd7dfe05a32ff9c623eeebd0b57) testers.testBuildFailure: init
* [`e20a3629`](https://github.com/NixOS/nixpkgs/commit/e20a362908fa6d4393efb05390e7dd38a64237da) testers.testEqualContents: init
* [`3cf3fef3`](https://github.com/NixOS/nixpkgs/commit/3cf3fef37260eb9c9cbf00096c48064f11dc83a9) testers: Add missing doc link comments
* [`865fdea4`](https://github.com/NixOS/nixpkgs/commit/865fdea4110b7565e2be8c20b4e08a911f2482ce) coconut: 1.6.0 → 2.1.0
* [`57647829`](https://github.com/NixOS/nixpkgs/commit/5764782921cdf941226f206e650936e95f6dded6) nixos/shells: support defining aliases beginning with a dash or plus
* [`332770b9`](https://github.com/NixOS/nixpkgs/commit/332770b9547ac2ceda2c71bdf97102e111fdd5ef) cyrus_sasl: make compatible with openssl3
* [`a0869efd`](https://github.com/NixOS/nixpkgs/commit/a0869efd093e05863b9e538ea4c512a32f711ad1) Revert "cyrus_sasl: pin to openssl_1_1"
* [`4d30c4aa`](https://github.com/NixOS/nixpkgs/commit/4d30c4aaea76d92792c7cdeff4c4849fe62bdea4) Revert "openldap: pin to openssl_1_1"
* [`017fd895`](https://github.com/NixOS/nixpkgs/commit/017fd895276dc0e45e9a596b1aa1ad199bfc7c4d) Revert "python3: pin to openssl_1_1"
* [`66e6f6f8`](https://github.com/NixOS/nixpkgs/commit/66e6f6f8522001975334b9a27538fc0d8b1adfe4) openldap: disable failing test
* [`fc3e4af7`](https://github.com/NixOS/nixpkgs/commit/fc3e4af7a44ca50e3e75049c286f6565bfce7958) libgeotiff: 1.5.1 -> 1.7.1
* [`c8e545b3`](https://github.com/NixOS/nixpkgs/commit/c8e545b3b89bb1931bb0033c5b81d9cb320a2b7c) brunsli: init at 0.1
* [`b3f94fd5`](https://github.com/NixOS/nixpkgs/commit/b3f94fd518d6004e497b717e5466da046fb5a6e1) lerc: init at 3.0
* [`dcd559e0`](https://github.com/NixOS/nixpkgs/commit/dcd559e08192c8253b7e4027f39b7fd58f655cfb) gdal: 3.4.2 -> 3.5.2
* [`d0f3893d`](https://github.com/NixOS/nixpkgs/commit/d0f3893da05c234cd48a4c7985707b795e963c1f) gplates: use python39
* [`7c224b3e`](https://github.com/NixOS/nixpkgs/commit/7c224b3e127ad37b27f31aaa71ae5959320bd492) python310Packages.fiona: fix tests with GDAL 3.5.1
* [`d35077ae`](https://github.com/NixOS/nixpkgs/commit/d35077ae8bfeba5004438046bffd9515fef33214) mapnik: 3.1.0 -> unstable-2022-04-14
* [`189a229b`](https://github.com/NixOS/nixpkgs/commit/189a229b6d4055eb50d9b61ccecff2e0fef68a4a) python3Packages.python-mapnik: unstable-2020-02-24 -> unstable-2020-09-08
* [`b8d78c77`](https://github.com/NixOS/nixpkgs/commit/b8d78c77609ad0a5269f76828053ceab07effce3) packwiz: unstable-2022-09-25 -> unstable-2022-10-29
* [`5d916d42`](https://github.com/NixOS/nixpkgs/commit/5d916d42b0914232bc81c820e212404e0a108c2e) gdal: skip test failing when using PROJ < 8
* [`e0fb27cc`](https://github.com/NixOS/nixpkgs/commit/e0fb27cc3200d5a52fd9d697bc849365038b0a58) python3Packages.reorder-python-imports: 3.8.5 -> 3.9.0
* [`3d999388`](https://github.com/NixOS/nixpkgs/commit/3d9993882980bba5e7ef2cee63960179b8a174f3) kea: fix build on darwin
* [`33ea1392`](https://github.com/NixOS/nixpkgs/commit/33ea1392610f5e8dba09a98cba24f09ef25795cc) brunsli: tidy patching
* [`434f16a7`](https://github.com/NixOS/nixpkgs/commit/434f16a76492b34b9b43271c65754d332e1fca58) brunsli: fix building on darwin
* [`7bcfaeb2`](https://github.com/NixOS/nixpkgs/commit/7bcfaeb21d57b8b926432bf017a94f030fbb2df8) gdal: fix build on darwin
* [`e9384700`](https://github.com/NixOS/nixpkgs/commit/e9384700049b04cfcd79c3e890bf45111d3a917c) python3Packages.pipenv-poetry-migrate: 0.2.0 -> 0.2.1
* [`f75026a9`](https://github.com/NixOS/nixpkgs/commit/f75026a9372020df8bd2eadaa170f40e888c5e19) python3Packages.apsw: 3.39.3.0 -> 3.39.4.0
* [`9a91d12b`](https://github.com/NixOS/nixpkgs/commit/9a91d12bcd83e344fef21214c377fb4e63d0de27) mapnik: unstable-2022-04-14 -> unstable-2022-10-18
* [`f237e2b8`](https://github.com/NixOS/nixpkgs/commit/f237e2b83e12a1eecc5e61c05ca3f1994469c9a9) onefetch: 2.12.0 -> 2.13.2
* [`d4296648`](https://github.com/NixOS/nixpkgs/commit/d4296648b504b77760025eae2daf1342f1f5bdc9) nixos/peertube: add hsts header to nginx configuration
* [`15959cdc`](https://github.com/NixOS/nixpkgs/commit/15959cdc5f52889585b85abc16c23c17f3d2c73f) nixos/peertube: add quic header to nginx configuration
* [`c4f95388`](https://github.com/NixOS/nixpkgs/commit/c4f9538875af001e6173b192874e2826eab2a148) nixos/peertube: fix start services
* [`d168b8cf`](https://github.com/NixOS/nixpkgs/commit/d168b8cf2ff5094b7c387e0d99456fdbd79a2550) iosevka-bin: 16.0.0 -> 16.3.6
* [`d1a4e078`](https://github.com/NixOS/nixpkgs/commit/d1a4e0784baa88c326e54183a53ec0a1bae91d8d) bottles: don't include system wine by default
* [`7aa3e528`](https://github.com/NixOS/nixpkgs/commit/7aa3e528bfce93c52986dca931be962532d5c985) icoextract: init at 0.1.4
* [`6b802f91`](https://github.com/NixOS/nixpkgs/commit/6b802f913f6bf12ec526f5d2ab33fc88bf4abfa5) fvs: init at 0.3.4
* [`b82316bc`](https://github.com/NixOS/nixpkgs/commit/b82316bc919c1baed0563598adc5346fb05cbc4c) nixos/keycloak: Escape admin password properly
* [`9bebad44`](https://github.com/NixOS/nixpkgs/commit/9bebad4487fb9670e557199e85016839a1d5868f) sitelen-seli-kiwen: init at unstable-2022-06-28
* [`5d4321b7`](https://github.com/NixOS/nixpkgs/commit/5d4321b70390eba3ef64cc4154d22e51cb0daaba) linja-pi-pu-lukin: init at unstable-2021-10-29
* [`76bd24f8`](https://github.com/NixOS/nixpkgs/commit/76bd24f8fc02bd204684912123a226b211c9d3c6) postgresql: remove code for no longer supported versions
* [`10622598`](https://github.com/NixOS/nixpkgs/commit/10622598a73a1b74b73017ab4d9398fb98cb36f0) python310Packages.zipp: 3.8.1 -> 3.10.0
* [`e07e2f59`](https://github.com/NixOS/nixpkgs/commit/e07e2f5925aee9a0d91c6b806e438eb2e3334bfc) python310Packages.tzdata: 2022.2 -> 2022.6
* [`dd2f7389`](https://github.com/NixOS/nixpkgs/commit/dd2f73892969e66a67d11b48a8f544db3d64ed14) python310Packages.incremental: 21.3.0 -> 22.10.0
* [`d155128b`](https://github.com/NixOS/nixpkgs/commit/d155128b531a9b3a7a5dd1fe435f426071a2a7b7) bottles: 2022.5.28-trento-3 -> 2022.10.14.1
* [`99e0091c`](https://github.com/NixOS/nixpkgs/commit/99e0091caea00bbf2e6b39cf15cc4186eeb5eec4) freetube: 0.17.1 -> 0.18.0
* [`4d19f1f3`](https://github.com/NixOS/nixpkgs/commit/4d19f1f3d424e563883bccb18a6b6eeb28a6668a) organicmaps: 2022.09.22-3 -> 2022.11.02-2
* [`edd36190`](https://github.com/NixOS/nixpkgs/commit/edd361904bce01c258b5bef7a85d94cda9952f3a) cmake: 3.24.2 -> 3.24.3
* [`98edc9b2`](https://github.com/NixOS/nixpkgs/commit/98edc9b2531827abd557d6455829b036354cb5ad) linuxPackages.rtl8723ds: init at unstable-2022-10-20
* [`233205c4`](https://github.com/NixOS/nixpkgs/commit/233205c4646e4d1e62ef4da15bf143008945060c) rustBuildCrate: properly handle cargo env pragmas with spaces
* [`2a212e1d`](https://github.com/NixOS/nixpkgs/commit/2a212e1dfd8dbe8a74801c4fe8e527692bbddb39) ulauncher: 5.12.1 -> 5.15.0
* [`5d07c39b`](https://github.com/NixOS/nixpkgs/commit/5d07c39b149797c710ff09abda3ad90da231d53e) nixos/power-management: fix deadlock with post-resume.{target,service}
* [`d6591076`](https://github.com/NixOS/nixpkgs/commit/d65910761c9dc0b842977b7b31d86721513b88dc) nixos/keycloak: Escape database password properly
* [`f938099d`](https://github.com/NixOS/nixpkgs/commit/f938099de1beafc96ddb979537d8e1288e12071c) nixos/modules/config/gtk/gtk-icon-cache: do not generate icon caches for files in $out/share/icons
* [`e5bfecb9`](https://github.com/NixOS/nixpkgs/commit/e5bfecb949c582dd4b1399396eb58e6084c3d678) lsof: 4.95.0 -> 4.96.4
* [`76ac62dc`](https://github.com/NixOS/nixpkgs/commit/76ac62dcdcb77e7e15040846753844b3f4d98206) nut: fix search modes not finding dynamic libs
* [`a893ab25`](https://github.com/NixOS/nixpkgs/commit/a893ab2509808a7f9bea2f73ab9b9c5f44003b5b) tenacity: unstable-2021-10-18 -> unstable-2022-06-30
* [`1a61c13b`](https://github.com/NixOS/nixpkgs/commit/1a61c13bfa63c731e7dd245861b4e36e33a7b969) java-packages.nix: detect i686 using stdenv.hostPlatform
* [`b8dfcc76`](https://github.com/NixOS/nixpkgs/commit/b8dfcc76d6a4622b7a48d1b9de68e6d4ee10c942) grass: migrate to wxPython_4_2
* [`9ec0744e`](https://github.com/NixOS/nixpkgs/commit/9ec0744e2a8a368c1835c7c455d0e3fabfe759eb) krane: 2.4.9 → 3.0.0
* [`afbe7cc8`](https://github.com/NixOS/nixpkgs/commit/afbe7cc83568508f7f18d733678262f69b41eb3a) python3Packages.invoke: 1.7.1 -> 1.7.3
* [`1e154436`](https://github.com/NixOS/nixpkgs/commit/1e154436525547c20b34811bfe32be2937e61d0a) bats.libraries: reduce output size
* [`b67ee6e8`](https://github.com/NixOS/nixpkgs/commit/b67ee6e861903abb04e9024d605dfc7b00922633) lib/trivial: fix 'error: cannot decode virtual path '/nix/store/virtual0000000000000000000000005-source''
* [`90babdcf`](https://github.com/NixOS/nixpkgs/commit/90babdcf38cd283b116fed0d79bf815e270c4638) maintainers: add ercao
* [`84ef2aad`](https://github.com/NixOS/nixpkgs/commit/84ef2aad5d423c7afb37826b7603b979bee577ef) bundler: 2.3.24 -> 2.3.25
* [`bea4f0c3`](https://github.com/NixOS/nixpkgs/commit/bea4f0c359d27b2e93bd1a6a85cbc0461048459d) python310Packages.babel: 2.10.3 -> 2.11.0
* [`a8fe73f1`](https://github.com/NixOS/nixpkgs/commit/a8fe73f1b324f05b3bf8e6e71e845dc5fdb609a2) libva: 2.15.0 -> 2.16.0
* [`24776830`](https://github.com/NixOS/nixpkgs/commit/2477683031cbed6e6b336ffd1902f1f27ca1060e) python310Packages.h11: 0.13.0 -> 0.14.0
* [`4b0fae51`](https://github.com/NixOS/nixpkgs/commit/4b0fae518baeaff700db44abef9329d4bc6e9da1) python310Packages.pyopenssl: 22.0.0 -> 22.1.0
* [`f5cf174a`](https://github.com/NixOS/nixpkgs/commit/f5cf174a3fcf64dbb811295068175285af853299) python310Packages.pbr: 5.10.0 -> 5.11.0
* [`8c1b0192`](https://github.com/NixOS/nixpkgs/commit/8c1b0192c5cf48e176bd4937787ba548e050395d) lib/sources: remove 2 usages of toString on a path which will be read using fileContents
* [`753f883c`](https://github.com/NixOS/nixpkgs/commit/753f883c35d0bd52002ce2d049a26bb1ae37c122) stage-1: escape mount points and options
* [`c2b3c979`](https://github.com/NixOS/nixpkgs/commit/c2b3c9794dfb5a9ec4aa643fca07c1ac8ad3f644) nixosTests: test spaces in mount options via btrfs subvols
* [`9071413f`](https://github.com/NixOS/nixpkgs/commit/9071413f400781d7d460a7d45d3686eaa6d443ce) onefetch: minor improvements, add figsoda as a maintainer
* [`30555839`](https://github.com/NixOS/nixpkgs/commit/3055583921184057312e4869193b9c710dc2a0f5) pcsclite: fix libsystemd switch
* [`19b48bbc`](https://github.com/NixOS/nixpkgs/commit/19b48bbc5a94fe7100e2876943ef5636a46cd002) python3Packages.gpiozero: disable on darwin
* [`06ecc513`](https://github.com/NixOS/nixpkgs/commit/06ecc51368bb4181c313dd6fea1bc573b9b9a033) boehmgc: disable SOFT_VDB on powerpc64le for version 8.2.2
* [`8260aed1`](https://github.com/NixOS/nixpkgs/commit/8260aed123ea511cd10fb5a3385fe07cd12d349a) rephrase to avoid mass-rebuild
* [`140bd1ae`](https://github.com/NixOS/nixpkgs/commit/140bd1aef4e7a71ef0c5e1380d14ed81e6a92e52) hbase: update versions and remove EoL version
* [`7343a3b6`](https://github.com/NixOS/nixpkgs/commit/7343a3b642cbdbac47770fe24d65aa9f9d23e6fa) boehmgc: switch from versionAtLeast to == for powerpc workaround
* [`ec8f8f69`](https://github.com/NixOS/nixpkgs/commit/ec8f8f69bd57b9dfd24ed56ef8f3c53c9ee5f453) lib/sources: Make pathIsGitRepo not evaluate toString path
* [`7456ff8c`](https://github.com/NixOS/nixpkgs/commit/7456ff8ca43ba8e5a5904f40fb7699bc34f8dc79) libsoup_3: 3.2.1 → 3.2.2
* [`e71f3433`](https://github.com/NixOS/nixpkgs/commit/e71f343311e08d49d40811c59191cad1cc4d28ab) krita: 5.1.1 -> 5.1.3
* [`2e02063e`](https://github.com/NixOS/nixpkgs/commit/2e02063e258414a54ae4dbda53f57d733a650510) mysql-shell: 8.0.30 -> 8.0.31
* [`90694755`](https://github.com/NixOS/nixpkgs/commit/906947555d257d0fa7f9b824dde63c3f1c7a6dca) mesa: 22.2.2 -> 22.2.3
* [`dba9750e`](https://github.com/NixOS/nixpkgs/commit/dba9750e76ef3809b11ac7c341b9d300db04337c) apparmor: 3.1.1 -> 3.1.2
* [`adead5e3`](https://github.com/NixOS/nixpkgs/commit/adead5e3a67c9e036c8dd12052c2df73206da8c5) jpsxdec: 1.05 -> 1.06
* [`cb82a002`](https://github.com/NixOS/nixpkgs/commit/cb82a002f8386aa795d9d98741dfdcfead25fe49) nixos: correct install summary
* [`a851743c`](https://github.com/NixOS/nixpkgs/commit/a851743ca1a7676debd1dd053cdfb7a6f5477394) adguardhome: 0.107.16 -> 0.107.18
* [`15484a9f`](https://github.com/NixOS/nixpkgs/commit/15484a9f2f840f44f52997974c5101d3536d2e33) adguardhome: add myself as maintainer
* [`9ef3a446`](https://github.com/NixOS/nixpkgs/commit/9ef3a446da3ef9b2de7eff1d813dcc9ddc6efa16) tautulli: 2.10.4 -> 2.10.5
* [`ce604a83`](https://github.com/NixOS/nixpkgs/commit/ce604a83c116e6e208e5c1c59ca4486ef271a806) tautulli: add myself as maintainer
* [`6a5aab56`](https://github.com/NixOS/nixpkgs/commit/6a5aab566fa90e8e5e0833f78d0fb53ea14cbb74) libmtp: improve cross-compilation support
* [`2ec4eec9`](https://github.com/NixOS/nixpkgs/commit/2ec4eec9fa46bfb5a9ce1489f49d1b3138c72fe4) firmware-updater: update hashes
* [`f9254f47`](https://github.com/NixOS/nixpkgs/commit/f9254f470cea648cfb5783f1c6ef691eda037190) Update pkgs/os-specific/linux/firmware/firmware-updater/default.nix
* [`f9118a8c`](https://github.com/NixOS/nixpkgs/commit/f9118a8c9bd9b84cea11a681f099c51aaf53f268) codeowners: narrower responsibilities for fricklerhandwerk
* [`661ee45c`](https://github.com/NixOS/nixpkgs/commit/661ee45c0c3214a184ee11f87a82dcb2ae89b13a) icinga2: 2.13.5 -> 2.13.6
* [`95567a12`](https://github.com/NixOS/nixpkgs/commit/95567a1283e61c86cd4ef3c9aaad81ba6a7a72eb) yarn2nix: allow running scripts
* [`4729d5d7`](https://github.com/NixOS/nixpkgs/commit/4729d5d7f62a989c1518cac96a3a971da00a7d12) nixos/proxmox-image: allow building UEFI images
* [`f375a123`](https://github.com/NixOS/nixpkgs/commit/f375a1234a73689fac05e5362cd7682bf4acc941) openturns: 1.19 -> 1.20
* [`4fc86ada`](https://github.com/NixOS/nixpkgs/commit/4fc86adaa17692482c524264726e6a5e509ca5b3) polkadot: 0.9.30 -> 0.9.32
* [`c0ce9be6`](https://github.com/NixOS/nixpkgs/commit/c0ce9be646d6109d1352c6e38c1b41d085c009aa) kismet: 2020-09-R2 -> 2022-08-R1
* [`657dd4e8`](https://github.com/NixOS/nixpkgs/commit/657dd4e8bf462565272633f08e7b8705f0d80433) hwdata: 0.360 -> 0.363
* [`f2de4779`](https://github.com/NixOS/nixpkgs/commit/f2de4779f74de8eff66f94c26f6a877f0535c450) entt: 3.10.3 -> 3.11.0
* [`12455a5d`](https://github.com/NixOS/nixpkgs/commit/12455a5d74a1adcada34366cd20d6d4002356d27) proj: 9.0.0 -> 9.1.0
* [`ac986f05`](https://github.com/NixOS/nixpkgs/commit/ac986f055a7d451a3683325b1bda94595e2c3740) python310Packages.pyproj: 3.3.1 -> 3.4.0
* [`07384107`](https://github.com/NixOS/nixpkgs/commit/07384107611f80429f03e0a2e774cbf1945731f7) jitsi-meet-electron: 2022.3.1 -> 2022.10.1
* [`b2f9cd34`](https://github.com/NixOS/nixpkgs/commit/b2f9cd34e75409bd7cd68a90f8754e63f92f4738) gobject-introspection: use wrapper.nix for the native package too
* [`34e8a6de`](https://github.com/NixOS/nixpkgs/commit/34e8a6debd044cdfc894bc18fa18efaa6bbd7ede) i3ipc-glib: fix cross
* [`83f01989`](https://github.com/NixOS/nixpkgs/commit/83f0198962b4016210d20713fd437eb099b06f76) keybinder3: fix cross
* [`62f9cc2b`](https://github.com/NixOS/nixpkgs/commit/62f9cc2bdcc274fb7a06c2b63a67e67334b9a76c) gtksourceview{4,5}: fix cross
* [`5f09efa7`](https://github.com/NixOS/nixpkgs/commit/5f09efa7306838562a05d4fba883cd7f58030746) libwnck: fix cross
* [`eeda27d0`](https://github.com/NixOS/nixpkgs/commit/eeda27d0f2e07600142ba12ddb86a9c2688c26b7) bpftools: fix build on ppc64le
* [`82f891e2`](https://github.com/NixOS/nixpkgs/commit/82f891e22985a69e5fc8f35c9fca181137072cc2) python310Packages.basemap: 1.3.4 -> 1.3.6
* [`3885b6dd`](https://github.com/NixOS/nixpkgs/commit/3885b6dd38d7b1a627217c0cdfe5228901136746) proj: don't add cURL dependency to CMake config
* [`8dc7d564`](https://github.com/NixOS/nixpkgs/commit/8dc7d564aa91fc6efec474320840480dc92adadd) gammu: fix script dependencies on bash and dialog
* [`7eefaeb5`](https://github.com/NixOS/nixpkgs/commit/7eefaeb5e36c2899d15fe8b9a2cd0a693f61471d) nextcloud25: use openssl 1.1 as a PHP extension to fix RC4 encryption
* [`394d4de8`](https://github.com/NixOS/nixpkgs/commit/394d4de8770db0c32c4a01957496d08256cdcaf5) nextcloud25: enable by default broken ciphers for NixOS ≤ 22.11
* [`61128cba`](https://github.com/NixOS/nixpkgs/commit/61128cba67d881a5a741ea2a403bfb43be636fc8) nixos/nextcloud: minor docs cleanup for openssl change
* [`24afcac7`](https://github.com/NixOS/nixpkgs/commit/24afcac7031066696ee2b92432f530c5c4459fd8) syncthingtray: Fix Nix wrapped path in autostart desktop generation
* [`c3f3badd`](https://github.com/NixOS/nixpkgs/commit/c3f3baddaa0405714913f77ebcb61628a871be00) Revert "llvmPackages_11: Add `$rsrc/lib` to default cflags"
* [`952dbf0a`](https://github.com/NixOS/nixpkgs/commit/952dbf0a4aea0661bb9fc21b05a83d31c7cd77d0) mesa: build more Vulkan drivers on aarch64-linux
* [`878a1467`](https://github.com/NixOS/nixpkgs/commit/878a14677fcf5773401b0d084073458535377193) xterm: 374 -> 375
* [`ff8dcc56`](https://github.com/NixOS/nixpkgs/commit/ff8dcc56beb494f6b0c8cef3a43962f6c1bb4106) newsflash: 2.1.2 -> 2.1.3
* [`7d5785de`](https://github.com/NixOS/nixpkgs/commit/7d5785de2bf23f9a2d1f756e8c9ce7f51c6759e3) gns3-server,gns3-gui: 2.2.34 -> 2.2.35.1
* [`bfdffa62`](https://github.com/NixOS/nixpkgs/commit/bfdffa623eae307b588d585db0be2726bad51780) baresip: 2.8.2 -> 2.9.0
* [`e0b64413`](https://github.com/NixOS/nixpkgs/commit/e0b64413b0531f927c88cc0d9d36b1584c4b6304) gns3-server,gns3-gui: clean
* [`1215a5fb`](https://github.com/NixOS/nixpkgs/commit/1215a5fbfea687def06839cc9ceae5dd11dbee99) pipewire: 0.3.59 -> 0.3.60
* [`5e41dbf2`](https://github.com/NixOS/nixpkgs/commit/5e41dbf243ada801adc2754f188882c859d5d9d8) libnftnl: 1.2.3 -> 1.2.4
* [`ae9cb7be`](https://github.com/NixOS/nixpkgs/commit/ae9cb7be8c3b5a3edfd90eff8734861ae89f7df8) lispPackages_new: fixed a bunch of packages
* [`d82f5251`](https://github.com/NixOS/nixpkgs/commit/d82f52519a3a9bd3bc646bb1c9fe380b802cc8fd) nixos/libvirtd: always start libvirtd
* [`95b73dad`](https://github.com/NixOS/nixpkgs/commit/95b73dad899bad669186fe928493cdfcbd0c58ee) python3Packages.orjson: Disable failing tests on 32 bit
* [`223f139e`](https://github.com/NixOS/nixpkgs/commit/223f139e1e234865951698ab705b973ba882c1d7) python3Packages.jsonschema: 4.16.0 -> 4.17.0
* [`0b25ba3d`](https://github.com/NixOS/nixpkgs/commit/0b25ba3d69ab89bf987a84903e46f386ad7e50db) ansible-later: 2.0.22 -> 2.0.23
* [`06a7064e`](https://github.com/NixOS/nixpkgs/commit/06a7064ec3a7170077f40bd96cc4aa7ef6ea529d) postgresql_11: 11.17 -> 11.18
* [`0e7dc253`](https://github.com/NixOS/nixpkgs/commit/0e7dc2534eacdb55ee343c4b0fb7f095721f48cc) postgresql_12: 12.12 -> 12.13
* [`4fc31c25`](https://github.com/NixOS/nixpkgs/commit/4fc31c2539ef7abb4e761b6548e5164deb96aaeb) postgresql_13: 13.8 -> 13.9
* [`9a0ebf5d`](https://github.com/NixOS/nixpkgs/commit/9a0ebf5d4772016da6528165b71e45944c3f41ef) postgresql_14: 14.5 -> 14.6
* [`b38cf2c9`](https://github.com/NixOS/nixpkgs/commit/b38cf2c9ae0402cb00540397df78d616f371e25f) postgresql_15: 15.0 -> 15.1
* [`80703c41`](https://github.com/NixOS/nixpkgs/commit/80703c4155cf59431ae1c595e203334b806278f7) gdal: don't depend on kea
* [`429ba6c7`](https://github.com/NixOS/nixpkgs/commit/429ba6c71426418562b2047cf1433d3ed6f45533) nixosOptionsDoc: Add markdownByDefault parameter
* [`b106ff14`](https://github.com/NixOS/nixpkgs/commit/b106ff14ede4034f8771025f8ac785144358f3cd) nixosOptionsDoc: Report in which option an error occurs
* [`14f9d0c1`](https://github.com/NixOS/nixpkgs/commit/14f9d0c10bf6e00aa4af7165ef359ac2339fd624) feedgnuplot: 1.58 -> 1.61
* [`6fa503af`](https://github.com/NixOS/nixpkgs/commit/6fa503afeff8e4eb5d239463f4dee4fefb18c8ba) python3Packages.orjson: 3.8.0 -> 3.8.1
* [`bea58512`](https://github.com/NixOS/nixpkgs/commit/bea58512db5080fe6e8941c3e627ce8c64badb0b) rust-bindgen: 0.59.2 -> 0.61.0
* [`bf7a3f6d`](https://github.com/NixOS/nixpkgs/commit/bf7a3f6dcf9545464da358f350df32647c92323d) git-cola: 4.0.2 -> 4.0.3
* [`f0f42c08`](https://github.com/NixOS/nixpkgs/commit/f0f42c08cea4fcf14df04e5a3b58d5acef37c836) linux-lqx: 6.0.7-lqx1 -> 6.0.8-lqx1
* [`6cf7ef30`](https://github.com/NixOS/nixpkgs/commit/6cf7ef3010b061a7ea36a59335a24d3da7b83260) linux-zen: 6.0.7-zen1 -> 6.0.8-zen1
* [`9fee934b`](https://github.com/NixOS/nixpkgs/commit/9fee934b09e36d873fd4d65f09dd4f8c501b0286) redis-desktop-manager: 0.9.1 -> 2022.5, rename to RESP.app
* [`35b146ca`](https://github.com/NixOS/nixpkgs/commit/35b146ca31ea5f6cfdeee11dc7ca737fa9fbc1dd) nixos/nextcloud: fixup openssl compat change
* [`f046cc09`](https://github.com/NixOS/nixpkgs/commit/f046cc092332d3b5d3d58736c83abc4dac68b579) nixos/pam: support fscrypt login protectors
* [`9b7903ff`](https://github.com/NixOS/nixpkgs/commit/9b7903ffbaf195f8bcbad80024d28f58f79f8ac3) haskellPackages: stackage LTS 19.31 -> LTS 19.32
* [`09eb71ff`](https://github.com/NixOS/nixpkgs/commit/09eb71ff7c9c5948aa0b6dc047b684de33c6a0d0) all-cabal-hashes: 2022-11-03T21:09:38Z -> 2022-11-11T17:48:48Z
* [`8318b634`](https://github.com/NixOS/nixpkgs/commit/8318b634a1b0d2f7811937155481abe5250afaa5) haskellPackages: regenerate package set based on current config
* [`6e4f74f1`](https://github.com/NixOS/nixpkgs/commit/6e4f74f19b05a348b39f2c932cbcf814bb97d756) haskellPackages.h-raylib: remove broken flag
* [`576649e6`](https://github.com/NixOS/nixpkgs/commit/576649e65ac261e15b024435b5cb7b99950bc7d4) python310Packages.cypari2: 2.1.2 -> 2.1.3
* [`b4622ed8`](https://github.com/NixOS/nixpkgs/commit/b4622ed855b2168a6526a52eb1d94f4e98bc7078) obfs4: add meta fields
* [`5736688c`](https://github.com/NixOS/nixpkgs/commit/5736688c0beec50cb031833b22fd90c20d5bde94) beekeeper-studio: 3.3.8 -> 3.6.2
* [`d82962c6`](https://github.com/NixOS/nixpkgs/commit/d82962c69278ccdd926afb39a4df60e84f61c69e) libfixposix: 0.4.3 -> 0.5.1
* [`cdec3613`](https://github.com/NixOS/nixpkgs/commit/cdec36131ffbd447e1b239c07de014c9e22b8105) pulseeffects-legacy: 4.8.4 -> 4.8.7
* [`da73c860`](https://github.com/NixOS/nixpkgs/commit/da73c860aa144ba988551a96ee1cd4c70c056c37) python3.pkgs.pylpsd: init at 0.1.4
* [`f97c7b38`](https://github.com/NixOS/nixpkgs/commit/f97c7b38a1c7289069282e2603ec0ec9ecf81e0a) python3.pkgs.myhdl: init at unstable-2022-04-26
* [`b6429927`](https://github.com/NixOS/nixpkgs/commit/b6429927c04f8ae66aa3e9eed55d6ed7aa0e6d98) python3.pkgs.asyncserial: init at unstable-2022-06-10
* [`3e3fe0b2`](https://github.com/NixOS/nixpkgs/commit/3e3fe0b2e21107bfcc59a958571f23b98ba5b51a) python3.pkgs.migen: unstable-2021-09-14 -> unstable-2022-09-02
* [`7b365ed5`](https://github.com/NixOS/nixpkgs/commit/7b365ed51518ba4727c3a9130d5ddb5011608062) python3.pkgs.misoc: init at unstable-2022-10-08
* [`c35b5503`](https://github.com/NixOS/nixpkgs/commit/c35b5503f4da5ceeb12ba4370703e18575229f22) dsview: 1.1.2 -> 1.2.1
* [`fd94629a`](https://github.com/NixOS/nixpkgs/commit/fd94629a326306fccfc0b51ecbc38f1c1fdbfc82) qt5/qtwayland: fix popups being placed outside the screen
* [`7a7ce7fa`](https://github.com/NixOS/nixpkgs/commit/7a7ce7fa949b23cf6ffa2b72fb3d6e47a9c843cc) omnisharp-roslyn: 1.39.1 -> 1.39.2
* [`20b81330`](https://github.com/NixOS/nixpkgs/commit/20b813304a2766eefb661ea9585a58f9230d864e) python310Packages.dulwich: add optional-dependencies
* [`ea58c46e`](https://github.com/NixOS/nixpkgs/commit/ea58c46e4f13c4d1bc0ecdbf7d86ce0200716d60) python310Packages.stevedore: 4.1.0 -> 4.1.1
* [`a705b941`](https://github.com/NixOS/nixpkgs/commit/a705b9411cb71bc64e264662f9dad063e110c2c3) sic: 1.2 → 1.3
* [`218a36d6`](https://github.com/NixOS/nixpkgs/commit/218a36d6b9b56546af4f485174782f1d5a609e6c) slock: 1.4 → 1.5
* [`066bb437`](https://github.com/NixOS/nixpkgs/commit/066bb437c93d9323ec8e44c1b5c0618794b0a7f9) python310Packages.asyncio-mqtt: 0.13.0 -> 0.14.0
* [`d7546e18`](https://github.com/NixOS/nixpkgs/commit/d7546e1813cd17e272bd6b4a712513821a462476) python310Packages.aiomysensors: 0.3.2 -> 0.3.3
* [`65967fa6`](https://github.com/NixOS/nixpkgs/commit/65967fa684f4dce0a788779c91c982e2677fcf74) python310Packages.asyncio-mqtt: enable tests
* [`cd74512c`](https://github.com/NixOS/nixpkgs/commit/cd74512c68203cdc2cb88188263785800d5c430b) opentelemetry-collector: 0.64.0 -> 0.64.1
* [`c8f5e3e9`](https://github.com/NixOS/nixpkgs/commit/c8f5e3e9b19942de064cd4ef4de8290ed5d17eee) outline: 0.66.2 -> 0.66.3
* [`743f87f1`](https://github.com/NixOS/nixpkgs/commit/743f87f165e8d382e2363db4a78eb85e6538fc70) maintainers: add gdamjan
* [`3f76f26b`](https://github.com/NixOS/nixpkgs/commit/3f76f26bef306f4184884fe92ece36b6f9975996) sigi: 3.4.3 -> 3.5.0
* [`d77b0bb6`](https://github.com/NixOS/nixpkgs/commit/d77b0bb6a5ac11afb379c981d6d484a95b385961) montserrat: fix build
* [`ffb54f78`](https://github.com/NixOS/nixpkgs/commit/ffb54f78f6163fd3c1e29d80e2b801fda72e941e) flycast: fix vulkan
* [`d3819072`](https://github.com/NixOS/nixpkgs/commit/d3819072613a7ecbee4d75b65dc6c38693e52086) sympa: 6.2.68 -> 6.2.70
* [`3ec4e3b0`](https://github.com/NixOS/nixpkgs/commit/3ec4e3b0ba0f3065efa08a16abadc3be3183427b) victoriametrics: 1.83.0 -> 1.83.1
* [`2eb9e002`](https://github.com/NixOS/nixpkgs/commit/2eb9e002fc119f77585d5e699dee36fb7f484525) python310Packages.libsass: 0.21.0 -> 0.22.0
* [`f8de2411`](https://github.com/NixOS/nixpkgs/commit/f8de2411a175d09ec61e0053353bbd7b81077578) python310Packages.selenium: 4.5.0 -> 4.6.0
* [`aa3396dc`](https://github.com/NixOS/nixpkgs/commit/aa3396dc3216d2e44e4dca26900afb494d4c59ea) mate.caja-extensions: Fix failed substitution
* [`8d9763d0`](https://github.com/NixOS/nixpkgs/commit/8d9763d043a0f3cb6a2c57f1ebc6ee10f99a0174) mate.caja-extensions: Fix wrong schema path
* [`2f103f2b`](https://github.com/NixOS/nixpkgs/commit/2f103f2b1f4a9cd20fe00e331f1177cf31086f26) lispPackages_new: Fix patching without build-with-compile-into-pwd
* [`a25c3c56`](https://github.com/NixOS/nixpkgs/commit/a25c3c56e74ff7827c9326534368bac247106ea0) figma-linux: init at 0.10.1
* [`a505704e`](https://github.com/NixOS/nixpkgs/commit/a505704e8f6c136ab015243c2807e39e012217d7) qtwebkit: Mark known vulnerable
* [`f9e93362`](https://github.com/NixOS/nixpkgs/commit/f9e9336207b9a67b65f859783d502f096a27bf8e) lispPackages_new: fix for patched sources not being picked up
* [`145bd93a`](https://github.com/NixOS/nixpkgs/commit/145bd93a310d0a79f458f06dab3c41fac45f5441) kdevelop: remove qtwebkit from inputs
* [`c1c816dc`](https://github.com/NixOS/nixpkgs/commit/c1c816dcc3a290fc1ae27576542704789111de4a) rocs: remove qtwebkit from inputs
* [`73dc3187`](https://github.com/NixOS/nixpkgs/commit/73dc3187f58a9a4cb9388964011e85c73c013ef4) python310Packages.mne-python: 1.2.1 -> 1.2.2
* [`113a9e98`](https://github.com/NixOS/nixpkgs/commit/113a9e987026274ccc435b895267a6fb08d9b5e2) ecs-agent: use buildGoModule
* [`6a16d555`](https://github.com/NixOS/nixpkgs/commit/6a16d555f34874fdba158911ae394e0f42a86224) python310Packages.mypy-boto3-s3: 1.25.0 -> 1.26.0.post1
* [`dcb405c6`](https://github.com/NixOS/nixpkgs/commit/dcb405c652eee0918baa6edbbe8b68fd633e6d06) wmc-mpris: remove
* [`ed23e9bb`](https://github.com/NixOS/nixpkgs/commit/ed23e9bb9c4aa2e1731509e2dd22b6deccb684d4) python310Packages.peaqevcore: 7.3.2 -> 7.3.3
* [`1b00c83b`](https://github.com/NixOS/nixpkgs/commit/1b00c83b12e45e6d5a84c8f6c4458a67384a3fd4) python310Packages.pex: 2.1.112 -> 2.1.113
* [`95d62439`](https://github.com/NixOS/nixpkgs/commit/95d624394e73cb0b107e0f0214307979a018a997) appleseed: remove
* [`7ba6ae63`](https://github.com/NixOS/nixpkgs/commit/7ba6ae6310e42c11d4f8ea9cb08b9632421b57d8) python310Packages.pyrainbird: 0.4.3 -> 0.6.2
* [`dfa4b898`](https://github.com/NixOS/nixpkgs/commit/dfa4b89852833d080a5b35d6ac9f9b997e198ec5) build: fix build on aarch64-darwin
* [`28609af5`](https://github.com/NixOS/nixpkgs/commit/28609af5c71fad9cb8b3351957bf71ce7f7bbbed) android-tools: 33.0.3 -> 33.0.3p1
* [`118e531c`](https://github.com/NixOS/nixpkgs/commit/118e531c2d1b80389a69fce0a24c0258fff2e5a7) samba: fix cross-compilation
* [`7620992f`](https://github.com/NixOS/nixpkgs/commit/7620992f2214379ec083a6934169af08c6dbd9bd) edk2-uefi-shell: fix build when sandboxing is disabled on x86_64-darwin
* [`404a5ad0`](https://github.com/NixOS/nixpkgs/commit/404a5ad09207f5da9b452c0aa8bb0103b40bd3f3) python310Packages.pycocotools: 2.0.5 -> 2.0.6
* [`8ba634bb`](https://github.com/NixOS/nixpkgs/commit/8ba634bb13b265571eb19084cc5dd32250399ecb) sbclPackages: mark some failing packages as broken
* [`bc8a625a`](https://github.com/NixOS/nixpkgs/commit/bc8a625adc596a2c6ee14b492666548e11279233) sbclPackages: bring over some fixes merged into staging-next
* [`f59352d0`](https://github.com/NixOS/nixpkgs/commit/f59352d0af7e008d93ad1cce4ada9e7e6078b0cd) sbclPackages: fixed pzmq
* [`beb27110`](https://github.com/NixOS/nixpkgs/commit/beb27110edde03076eb77b66fe0bac37f27674b9) sbclPackages: fix typo
* [`354c89dc`](https://github.com/NixOS/nixpkgs/commit/354c89dc0a6fbd5819c69e3a5a5abb03b7ad8f46) sbclPackages: fix cl-cairo2
* [`5376fb46`](https://github.com/NixOS/nixpkgs/commit/5376fb46762f4c823f8f7affe2b7f80197ace71e) _1password-gui: 8.9.4 -> 8.9.8, 8.9.6-30.BETA -> 8.9.10-1.BETA
* [`177732bd`](https://github.com/NixOS/nixpkgs/commit/177732bd36ec4e640f4c893247329967ad5ed1dd) perf: add libbabeltrace dependency
* [`766ad4f6`](https://github.com/NixOS/nixpkgs/commit/766ad4f624a1bcffb8e4b0ef5f1a7ac16fd12a62) python310Packages.pyosmium: 3.4.1 -> 3.5.0
* [`0bcc9969`](https://github.com/NixOS/nixpkgs/commit/0bcc9969b25b9870868a4bc2f5af3ebab7bc28ac) miniflux: 2.0.39 -> 2.0.40
* [`678ccdf7`](https://github.com/NixOS/nixpkgs/commit/678ccdf71645a5ed766f743e81ecdfeb56f3e868) element: mark as broken on darwin
* [`fd8361c4`](https://github.com/NixOS/nixpkgs/commit/fd8361c44a436c852c97d9660b4aa88b3d53e8de) fn-cli: mark as broken on darwin
* [`176d06f5`](https://github.com/NixOS/nixpkgs/commit/176d06f5061739adf241a1d8e94266baa5200180) karlender: 0.7.1 -> 0.8.0
* [`f519ea55`](https://github.com/NixOS/nixpkgs/commit/f519ea5528c1c534e76e963bdf37a31af63167c9) ruff: 0.0.115 -> 0.0.117
* [`5a65cc17`](https://github.com/NixOS/nixpkgs/commit/5a65cc178188ebcc98fb763861b6e378a729d977) python310Packages.pyswitchbot: 0.20.3 -> 0.20.4
* [`2c09426b`](https://github.com/NixOS/nixpkgs/commit/2c09426bcb544db300410dbb1bf8fefd3e498587) python310Packages.ua-parser: 0.15.0 -> 0.16.1
* [`3ef8ee6b`](https://github.com/NixOS/nixpkgs/commit/3ef8ee6b24bd31ad00ce49fbd88b19be0ddd98ec) python310Packages.Wand: run tests
* [`86ccaac0`](https://github.com/NixOS/nixpkgs/commit/86ccaac0dec8542488de0db57e3567d5a02c051a) python310Packages.wand: rename from Wand
* [`adb97478`](https://github.com/NixOS/nixpkgs/commit/adb9747831855c4ead513c7d558b4d1ac40f56ac) flightgear: Fix missing libcurl depedency
* [`843734a2`](https://github.com/NixOS/nixpkgs/commit/843734a265b0dfba3a1b87c4a7d644b10c4dd2e9) dbeaver: remove no longer needed overrides and bump webkitgtk
* [`ff7f75df`](https://github.com/NixOS/nixpkgs/commit/ff7f75dfccec524e33f472e27fad2ca8742d873b) perf-linux: fix build on linux 5.4
* [`b0b25854`](https://github.com/NixOS/nixpkgs/commit/b0b258544faf3843a97db362bc28b2f3f3fbcc1d) python310Packages.pytorch-pfn-extras: 0.6.1 -> 0.6.2
* [`980a853c`](https://github.com/NixOS/nixpkgs/commit/980a853c7fa42a23ce2b874cd1224a35b048497f) python3Packages.wandb: 0.13.4 -> 0.13.5
* [`ee015169`](https://github.com/NixOS/nixpkgs/commit/ee015169b775c88ee7f76a996cf601161abf4a68) awscli2: 2.8.11 -> 2.8.12
* [`4f34f4a8`](https://github.com/NixOS/nixpkgs/commit/4f34f4a8633e1f63c1c18c370d63589527f4afd5) pam_ussh: fix build with go > 1.17
* [`a0212e0f`](https://github.com/NixOS/nixpkgs/commit/a0212e0f8ebb5731d48b41e32dba1cc7e918c1ad) fd: 8.5.2 -> 8.5.3
* [`10a4e2f5`](https://github.com/NixOS/nixpkgs/commit/10a4e2f5584c5ee42ad02b80d6fd18639cb8db80) cargo-auditable: 0.5.2 -> 0.5.3
* [`4d9f2009`](https://github.com/NixOS/nixpkgs/commit/4d9f200932079e93c122cfd820b40f195a6d9c20) efivar: fix cross compilation
* [`b64b1343`](https://github.com/NixOS/nixpkgs/commit/b64b13430961a4ab7842acb4853987088ce9b7f3) comrak: 0.14.0 -> 0.15.0
* [`defcd6b6`](https://github.com/NixOS/nixpkgs/commit/defcd6b623a8956a9780895cbccddc01fb8edd91) python3Packages.geometric: 0.9.7.2 -> 1.0
* [`c4d1b71e`](https://github.com/NixOS/nixpkgs/commit/c4d1b71ec5b3d6fb7052d3c16382a98c3a3a2e9f) synergy: use xorg.* packages directly instead of xlibsWrapper indirection
* [`260fb8b4`](https://github.com/NixOS/nixpkgs/commit/260fb8b482a4a4a427488378f83ac2847b0f4064) maintainers: add robbins
* [`73684a65`](https://github.com/NixOS/nixpkgs/commit/73684a65aa21828d808cf38cad07fe93f4f15514) obs-studio-plugins.obs-source-record: init at 2022-11-10
* [`20faad84`](https://github.com/NixOS/nixpkgs/commit/20faad846339f1fc8e7d50b462d2df7f975cefb8) python310Packages.pyxl3: remove unittest2
* [`beed76d5`](https://github.com/NixOS/nixpkgs/commit/beed76d557b8b5b6af1430a8ba7d32e2a850b867) python310Packages.pychef: removing because it's archived and abandoned
* [`000663a0`](https://github.com/NixOS/nixpkgs/commit/000663a015f2f56d392932f79365021bd5e21c16) survex: use xorg.* packages directly instead of xlibsWrapper indirection
* [`5744a7b2`](https://github.com/NixOS/nixpkgs/commit/5744a7b2c670f432b5b9ab3ddd7f067d3da5303d) cppcheck: 2.9.1 -> 2.9.2
* [`04be2d87`](https://github.com/NixOS/nixpkgs/commit/04be2d8747aad512fc9c907dfc6b9943d2a16412) zoekt: unstable-2021-03-17 -> unstable-2022-11-09
* [`ab44b889`](https://github.com/NixOS/nixpkgs/commit/ab44b8890a41845f55dab39cd96f28cfbe0108ea) dufs: 0.30.0 -> 0.31.0
* [`e3a7c410`](https://github.com/NixOS/nixpkgs/commit/e3a7c410a77fb7ddcd24755ce1406e2994f068bc) jemalloc: fix aarch64-darwin build
* [`fd9eed5b`](https://github.com/NixOS/nixpkgs/commit/fd9eed5bf351ba90c754f2479a56455d101cb597) nixos/nginx: Extend acmeFallbackHost documentation
* [`0baed3d7`](https://github.com/NixOS/nixpkgs/commit/0baed3d787e16ac752e62b08ecf8e45ce4dfa1bb) joplin-desktop: make Icon= more bitrot resistant
* [`0e2c58c7`](https://github.com/NixOS/nixpkgs/commit/0e2c58c77f031d58dcdf8c64928530ad075d085e) emacs: add withSystemd option
* [`7f982588`](https://github.com/NixOS/nixpkgs/commit/7f9825881063fe6ac21782edbb08255883a2df8a) datree: 1.6.42 -> 1.7.3
* [`e3fc19b3`](https://github.com/NixOS/nixpkgs/commit/e3fc19b301f7467df9920cdf721adcb705a783f7) nixos/nginx: docs: Update formatting
* [`3024d77c`](https://github.com/NixOS/nixpkgs/commit/3024d77c8221a8696ca53789169c279ab18ddf3b) deno: 1.27.2 -> 1.28.0
* [`4d2e0a09`](https://github.com/NixOS/nixpkgs/commit/4d2e0a096b96826a6c0a6a9e8611b45a8f69edd2) darkman: build on linux only
* [`8ac4008c`](https://github.com/NixOS/nixpkgs/commit/8ac4008c0918bfcd910535203c8c9caf98da0f39) python3.pkgs.pytest-plt: init at 1.1.0
* [`0e69f6db`](https://github.com/NixOS/nixpkgs/commit/0e69f6db6498ee6f5e6c3b16c1af8d8620a6aeb4) ferium: 4.2.0 -> 4.2.1
* [`aba8af9a`](https://github.com/NixOS/nixpkgs/commit/aba8af9a02c55241fb4bce562c08e20de4939777) batman-adv: 2022.1 -> 2022.3
* [`2f1ca6e2`](https://github.com/NixOS/nixpkgs/commit/2f1ca6e27f0fd2a3dc250eefe53fedbff722fd80) whois: 5.5.13 -> 5.5.14
* [`eebb43a3`](https://github.com/NixOS/nixpkgs/commit/eebb43a334806859a9444d9f99b9c52f1d432dac) lldpd: 1.0.15 -> 1.0.16
* [`b7691ef2`](https://github.com/NixOS/nixpkgs/commit/b7691ef2d35e104c69f47200eeae44996fdb2ce5) ipmitool: 1.8.18 -> 1.8.19
* [`ec7467e2`](https://github.com/NixOS/nixpkgs/commit/ec7467e2ea318b8abd0eb913262b839f1601afb0) jool: 4.1.7 -> 4.1.8
* [`890d0576`](https://github.com/NixOS/nixpkgs/commit/890d0576c5f68852cd3d6ca81c5428122c620560) cross/mingw: make threading library configureable
* [`b08b69c5`](https://github.com/NixOS/nixpkgs/commit/b08b69c5a11c2f21e54c3e9878e5812cb03c7f13) gifski: 1.7.2 -> 1.8.0
* [`5a04b70e`](https://github.com/NixOS/nixpkgs/commit/5a04b70e1463d1ecf18ba819c1b9b6db43c56320) jool-cli: divert man pages
* [`af9a4dd3`](https://github.com/NixOS/nixpkgs/commit/af9a4dd35eb387c527cc04e6cc86c4607e532082) cargo-public-api: 0.21.0 -> 0.22.0
* [`f23a62a5`](https://github.com/NixOS/nixpkgs/commit/f23a62a5dccf7bc7e3f8413e3a8146a2f739f75f) kubernetes-helm: 3.10.1 -> 3.10.2
* [`e5da3f3a`](https://github.com/NixOS/nixpkgs/commit/e5da3f3aef4b692fafc270568449436ec70071b6) v2ray-geoip: 202211030059 -> 202211100058
* [`232a9b93`](https://github.com/NixOS/nixpkgs/commit/232a9b93b2dc6f71194be6b00bb3a9f8dfe434ee) velero: 1.9.2 -> 1.9.3
* [`f955ad16`](https://github.com/NixOS/nixpkgs/commit/f955ad1647fdaf66d9a929cbd101ac93b2d6a60c) mutagen-compose: 0.16.0 -> 0.16.1
* [`36ce4745`](https://github.com/NixOS/nixpkgs/commit/36ce474508e9de1209ca9857907a66fcbc9d27e7) atmos: 1.10.4 -> 1.13.1
* [`84da129f`](https://github.com/NixOS/nixpkgs/commit/84da129f182579be04935e88dc96e77358552ce4) pipenv: 2022.10.25 -> 2022.11.11
* [`9e5bc1df`](https://github.com/NixOS/nixpkgs/commit/9e5bc1df9b2156faeb93537b3362491266153636) gupnp-*: add darwin support
* [`5bc1b01a`](https://github.com/NixOS/nixpkgs/commit/5bc1b01a403e071500a3b0659364fb6ee20391e1) boot.loader.systemd-boot: add extraInstallCommands option ([nixos/nixpkgs⁠#200715](https://togithub.com/nixos/nixpkgs/issues/200715))
* [`0b5f3fed`](https://github.com/NixOS/nixpkgs/commit/0b5f3feddfbab46425fdbf325630f3f3dec659aa) dleyna-*: add darwin support
* [`bd2baae6`](https://github.com/NixOS/nixpkgs/commit/bd2baae6d1a514aec1c5e57bfa7b6f1804c9b85a) grilo: add darwin support
* [`1682b3d0`](https://github.com/NixOS/nixpkgs/commit/1682b3d09480122da4c69928a9122a7647ccbf69) libutempter: 1.1.6 -> 1.2.1
* [`56a57456`](https://github.com/NixOS/nixpkgs/commit/56a574567998855b5f46d6107edf64ed3e66fd3d) tmux: build with utempter
* [`2af80901`](https://github.com/NixOS/nixpkgs/commit/2af809015a65810571e7e8d8541b4ca7ba25b8d4) nixos/tmux: add withUtempter option
* [`4b145674`](https://github.com/NixOS/nixpkgs/commit/4b14567454aa524f6393ba2810930f54e47e3b33) topicctl: 1.6.1 -> 1.7.0
* [`88f2d44d`](https://github.com/NixOS/nixpkgs/commit/88f2d44dc112d156d1b5063f1e27ff2a3d944a01) nix-update: 0.7.0 -> 0.8.0
* [`690fd2b8`](https://github.com/NixOS/nixpkgs/commit/690fd2b8f718188aaf441416bd6806c2cea55d3f) iina: 1.3.0 -> 1.3.1
* [`b676b764`](https://github.com/NixOS/nixpkgs/commit/b676b764e7de2ff56b48c87bee83e879154bd465) rustic-rs: init at 0.3.2
* [`f5ecd16c`](https://github.com/NixOS/nixpkgs/commit/f5ecd16cc8bea85e8adbb49b3ec992998662c9c4) syncstorage-rs: 0.12.4 -> 0.12.5
* [`98fb7354`](https://github.com/NixOS/nixpkgs/commit/98fb73549339eba604eb59ca729042bff1dd18c4) sublime4: 4142 -> 4143
* [`50ab8ea4`](https://github.com/NixOS/nixpkgs/commit/50ab8ea46092e7a6fda8756f2cd5320b0279f495) sublime-merge: 2077 -> 2079
* [`07e5701a`](https://github.com/NixOS/nixpkgs/commit/07e5701aca54f1b5cc5f517ac259d4bcd4208d42) nixos/manual: re-add mention of mdDoc marker
* [`b8ba78f1`](https://github.com/NixOS/nixpkgs/commit/b8ba78f1d614e9faa981c6d74e83aff0c9cf66cf) checkov: Fix build
* [`41c56cad`](https://github.com/NixOS/nixpkgs/commit/41c56cadffe23835e60489f846675cb9e3c0a804) checkov: Fix exe not executable
* [`e88c8f6c`](https://github.com/NixOS/nixpkgs/commit/e88c8f6c53e8b5a96ac58baf365bf9141681cd44) python3.pkgs.ldap: disable failing test ([nixos/nixpkgs⁠#201190](https://togithub.com/nixos/nixpkgs/issues/201190))
* [`cecc5530`](https://github.com/NixOS/nixpkgs/commit/cecc553095ea244e516003f7e0714669afb4af70) schildichat-desktop: copy sqlcipher fix from element-desktop ([nixos/nixpkgs⁠#201179](https://togithub.com/nixos/nixpkgs/issues/201179))
* [`7cac4e55`](https://github.com/NixOS/nixpkgs/commit/7cac4e5579179149a4f7f6082f0dd05ae8b129b0) doublecmd: refactor to new overlay-style overridable attributes
* [`f35f6ff9`](https://github.com/NixOS/nixpkgs/commit/f35f6ff9f962ca65503ae5f9e2759476920ad461) fceux: refactor to new overlay-style overridable attributes
* [`0b7f7b95`](https://github.com/NixOS/nixpkgs/commit/0b7f7b954d0b4157c515246b80de0ec868547d63) ares: 129 -> 130.1
* [`db320184`](https://github.com/NixOS/nixpkgs/commit/db320184662a595b8181ed9bfa684cb22a6c4418) dialog: 1.3-20211214 -> 1.3-20220728
* [`43421bb7`](https://github.com/NixOS/nixpkgs/commit/43421bb7ea9c9c08c4a329fbb5dd0b00ce15b025) desmume: 0.9.11+unstable=2021-09-22 -> 0.9.13
* [`0c48d381`](https://github.com/NixOS/nixpkgs/commit/0c48d381677004bd7c1a6534461ce7fe7f8844cc) desmume: mark as broken on linux-aarch64
* [`9aad525e`](https://github.com/NixOS/nixpkgs/commit/9aad525eac929e5c1e5285226f8cb5a6981335b9) vscode-extensions.timonwong.shellcheck: 0.193 -> 0.26.3
* [`bdd39e57`](https://github.com/NixOS/nixpkgs/commit/bdd39e5757d858bd6ea58ed65b4a2e52c8ed11ca) lollypop: 1.4.24 → 1.4.36
* [`8e4f5036`](https://github.com/NixOS/nixpkgs/commit/8e4f5036eea2e694efc65d758d0b820b6b0dc18f) CONTRIBUTING: Reference release notes in package bumps
* [`a42a85fd`](https://github.com/NixOS/nixpkgs/commit/a42a85fd42c474080a3163eefe480a1f2231767f) twtxt: 1.2.3 -> 1.3.1
* [`e002041d`](https://github.com/NixOS/nixpkgs/commit/e002041da0cef3107ee25d0261cd94068ad2817e) python310Packages.airthings-ble: 0.5.2 -> 0.5.3
* [`6164b7bb`](https://github.com/NixOS/nixpkgs/commit/6164b7bb61395b4488919ca4bbdf918d96a7d4ab) kde-frameworks: 5.99 -> 5.100
* [`47c355de`](https://github.com/NixOS/nixpkgs/commit/47c355de3a093565ba62c268c3309c4db3035b2b) python310Packages.google-nest-sdm: 2.0.0 -> 2.1.0
* [`d3f5b5a6`](https://github.com/NixOS/nixpkgs/commit/d3f5b5a608c482ac9865f71b20c9c6797e054ca3) python310Packages.heatzypy: 2.1.1 -> 2.1.5
* [`460e8381`](https://github.com/NixOS/nixpkgs/commit/460e838124c31eb0d6b1aca16165d3e5e1d18573) python310Packages.growattserver: 1.2.3 -> 1.2.4
* [`11e7a67a`](https://github.com/NixOS/nixpkgs/commit/11e7a67aa6afab6af75aac7ac80fdc3c994f8e63) ludusavi: fix eval
* [`39f75847`](https://github.com/NixOS/nixpkgs/commit/39f75847d44e4dec1ff9ed126df8cb093d24158b) tela-circle-icon-theme: fix eval
* [`37228188`](https://github.com/NixOS/nixpkgs/commit/372281881bbd3526b2e9b38b2835356b3d2bbff7) extra-cmake-modules: drop merged patch
* [`ec106b98`](https://github.com/NixOS/nixpkgs/commit/ec106b98ddaf404474002d3ff32472646fdcafd2) inetutils: fix cross
* [`5fd09198`](https://github.com/NixOS/nixpkgs/commit/5fd091987a63c00acd84e4d3a3444bd2ffd01d0c) karchive: add new dependency
* [`8dfd6ce8`](https://github.com/NixOS/nixpkgs/commit/8dfd6ce864367541cb250b6d4b8d9850438d3c6b) difftastic: 0.37.0 -> 0.38.0
* [`376bd0eb`](https://github.com/NixOS/nixpkgs/commit/376bd0ebe0953a61b174482b258d6df10d556a88) python310Packages.griffe: 0.23.0 -> 0.24.0
* [`749bdf10`](https://github.com/NixOS/nixpkgs/commit/749bdf10232590a1f56f1ce45ab412a2028b1f80) python310Packages.tox: 3.26.0 -> 3.27.1
* [`259f8aaa`](https://github.com/NixOS/nixpkgs/commit/259f8aaa8b71315d9c4cdd8934c22c1dc852361c) sqlfluff: 1.4.1 -> 1.4.2
* [`baf0049a`](https://github.com/NixOS/nixpkgs/commit/baf0049a9fa90dfb94799db351d757267778f7d7) qemacs: use xorg.* packages directly instead of xlibsWrapper indirection
* [`f3a8bb1e`](https://github.com/NixOS/nixpkgs/commit/f3a8bb1ec80dc68f24cfd832f032c53729c23f5f) firefox-unwrapped: 106.0.5 -> 107.0
* [`8ec89ef1`](https://github.com/NixOS/nixpkgs/commit/8ec89ef1b50dd4602a72e6fd8842924f8e56482d) firefox{,-bin}, thunderbird{,-bin}: Set meta.changelog
* [`28b268d3`](https://github.com/NixOS/nixpkgs/commit/28b268d34b55d79bb87e4b462bbc5b50a564c902) firefox-bin-unwrapped: 106.0.5 -> 107.0
* [`22dafab6`](https://github.com/NixOS/nixpkgs/commit/22dafab6506524031abbbf4c40b7610191cd314e) firefox-esr-102-unwrapped: 102.4.0esr -> 102.5.0esr
* [`6edfa4f6`](https://github.com/NixOS/nixpkgs/commit/6edfa4f6954654cab9856880c535b1179247aacb) vimPlugins: update
* [`75a0854b`](https://github.com/NixOS/nixpkgs/commit/75a0854b211969ba834fb96ff2c8819004c8afb3) vimPlugins.telescope-live-grep-args-nvim: init at 2022-11-07
* [`5a1852b2`](https://github.com/NixOS/nixpkgs/commit/5a1852b2d0d6534883b118cb0e5554275d986381) minidlna: 1.3.1 -> 1.3.2
* [`7c3fb577`](https://github.com/NixOS/nixpkgs/commit/7c3fb5774eac09fd3901416cbae69769ce4a66b8) tor: 0.4.7.10 -> 0.4.7.11
* [`d180abe8`](https://github.com/NixOS/nixpkgs/commit/d180abe8840827638f446b0cc299a94bf18bac92) pulumi: 3.43.1 -> 3.46.1
* [`791a23a0`](https://github.com/NixOS/nixpkgs/commit/791a23a00a8575400250ac8eaa6b844aefb23989) ncview: use xorg.* packages directly instead of xlibsWrapper indirection
* [`106e5302`](https://github.com/NixOS/nixpkgs/commit/106e5302d76f86cadcc18456624263407e99c783) aws-sso-cli: 1.9.4 -> 1.9.5
* [`2e320d1a`](https://github.com/NixOS/nixpkgs/commit/2e320d1ac0d67fbe5543ecc1ce34e4d1d0a00a6e) freshrss: 1.20.0 -> 1.20.1
* [`80809553`](https://github.com/NixOS/nixpkgs/commit/808095530a618c70e81c9f2423273860cfbed4d0) glib: Fix infinite loop in GNOME Keyring
* [`1785135b`](https://github.com/NixOS/nixpkgs/commit/1785135be6f813707287e266935a912d54550605) qownnotes: 22.10.2 -> 22.11.4
* [`2f933d60`](https://github.com/NixOS/nixpkgs/commit/2f933d60fb8788a801c43d1c4c7e16fda7af372c) doc/vim: Clarify buildVimPlugin/buildVimPluginFrom2Nix
* [`29ecd6e1`](https://github.com/NixOS/nixpkgs/commit/29ecd6e1d351ba1294d5f4c3900f476eb7ea52cf) vimPlugins.nvim-treesitter: update grammars
* [`45aa39da`](https://github.com/NixOS/nixpkgs/commit/45aa39daec9ddba16ca46bd4c81537a5d14ad354) vimPlugins.legendary-nvim: downgrade to fix duplicate tags
* [`f8a32e2d`](https://github.com/NixOS/nixpkgs/commit/f8a32e2df43290fac1297ab0b846e2dcc13eefb0) mercurial: 6.2.3 -> 6.3.0
* [`53b6d3d9`](https://github.com/NixOS/nixpkgs/commit/53b6d3d9f6114fbe579dc537f11f66a57644dd89) containerd: 1.6.9 -> 1.6.10
* [`4b5d9e65`](https://github.com/NixOS/nixpkgs/commit/4b5d9e651457910ad87c0abd1433475b11183691) discourse: 2.9.0.beta11 -> 2.9.0.beta12
* [`b5a4c7a0`](https://github.com/NixOS/nixpkgs/commit/b5a4c7a052782168c11c9b4f2ab888d18d2617bd) lirc: use xorg.* packages directly instead of xlibsWrapper indirection
* [`f7161f92`](https://github.com/NixOS/nixpkgs/commit/f7161f92ec1bdf07496e5a7b4ed617b9a44cdcc8) ruff: 0.0.117 -> 0.0.118
* [`ab8b9ca3`](https://github.com/NixOS/nixpkgs/commit/ab8b9ca3de11ce372f05256a43f334487cca7099) gnomeExtensions: auto-update
* [`f352d6e2`](https://github.com/NixOS/nixpkgs/commit/f352d6e27b3202bc9d773cd4763201774f7fe5fc) b612: fix build
* [`2832ad57`](https://github.com/NixOS/nixpkgs/commit/2832ad5786147f96926f3dc4ab8dde7477863989) python310Packages.mkdocstrings-python: 0.7.1 -> 0.8.0
* [`06fd3af8`](https://github.com/NixOS/nixpkgs/commit/06fd3af8f33ac49f3e1598fe2decd83dd60dbab4) sony-headphones-client: 1.2 -> 1.3.1
* [`aa357fcf`](https://github.com/NixOS/nixpkgs/commit/aa357fcf6e8af51b7c1c351a4d6a24f62f46ec19) unfs3: 0.9.22 -> 0.10.0
* [`f75b2066`](https://github.com/NixOS/nixpkgs/commit/f75b20666736d255199693f12048d43f3872f717) cargo-edit: 0.11.5 -> 0.11.6
* [`bfc75b74`](https://github.com/NixOS/nixpkgs/commit/bfc75b74d6d3024a81ef0002cbbe0a89aaf2566e) sbclPackages: fixed cl-freetype2
* [`488a73f6`](https://github.com/NixOS/nixpkgs/commit/488a73f6b37df466b49fe4f26327e6d680041e98) spotifywm: 2016-11-28 -> 2022-10-26
* [`01c9df23`](https://github.com/NixOS/nixpkgs/commit/01c9df23e87b6233d8e560436a65a7767a081a0d) cargo-auditable: 0.5.3 -> 0.5.4
* [`6ca354dd`](https://github.com/NixOS/nixpkgs/commit/6ca354dd2f0bab83aadf8b200890c1133bea0c3b) sbclPackages: fixed cl-cairo2-xlib
* [`a4c3b8aa`](https://github.com/NixOS/nixpkgs/commit/a4c3b8aad29a581db3019b7e8f7ffa1ff4657a27) sbclPackages: fixed cl-pango
* [`2964d34b`](https://github.com/NixOS/nixpkgs/commit/2964d34b7cca77ca496b5c033f66e94cdfa210d0) rust-audit-info: 0.5.1 -> 0.5.2
* [`22b79c23`](https://github.com/NixOS/nixpkgs/commit/22b79c23a10cc8179215819f707c69629fed3308) sbclPackages: marked cl-random and cl-random-tests as broken
* [`252ee601`](https://github.com/NixOS/nixpkgs/commit/252ee601a3f5a2e3925a912ef2fa83bf3fb148f4) python310Packages.mitmproxy-wireguard: 0.1.17 -> 0.1.18
* [`3f50d337`](https://github.com/NixOS/nixpkgs/commit/3f50d33747883a3b4dbb31646cb32da9e86ad686) neko: fix build on aarch64-darwin
* [`118863c4`](https://github.com/NixOS/nixpkgs/commit/118863c4f2973571263656f2accb9c75a7d28b56) sbclPackages: fixed cl-gtk2-{gdk,glib,pango}
* [`ba7a40a6`](https://github.com/NixOS/nixpkgs/commit/ba7a40a602b16d121aa1dea41712b567b046d584) sbclPackages: fixed cl-rsvg2
* [`775b15ca`](https://github.com/NixOS/nixpkgs/commit/775b15cabbd86464b93713bc03046d019dc6b202) python3Packages.slixmpp: 1.8.2 -> 1.8.3
* [`8e768a61`](https://github.com/NixOS/nixpkgs/commit/8e768a61d0fac08f8168482c4ef63253b784ff2d) sbclPackages: marked math as broken
* [`e695acf1`](https://github.com/NixOS/nixpkgs/commit/e695acf19250d931f4d0a7e3ab8e5ae4d86c9142) sbclPackages: fixed pzmq-{compat,examples,test}
* [`9f52572d`](https://github.com/NixOS/nixpkgs/commit/9f52572d09a9b8ea12c7536ec203e65c5537436b) mautrix-telegram: fix build
* [`065e85e8`](https://github.com/NixOS/nixpkgs/commit/065e85e8add709b5b3a3b2fe243fde9c41bea022) libstroke: use xorg.* packages directly instead of xlibsWrapper indirection
* [`d72bcc2b`](https://github.com/NixOS/nixpkgs/commit/d72bcc2bc97723c3c9365b334553654525d8f226) erlang: wxmac -> wxGTK
* [`af8d5c51`](https://github.com/NixOS/nixpkgs/commit/af8d5c5185eb365623360652c4321a3cc36409ed) mutt: 2.2.8 -> 2.2.9
* [`79059c95`](https://github.com/NixOS/nixpkgs/commit/79059c9505281998dbfee0b7422ca28390e8bee9) cups-kyocera: fix source URL
* [`11d9ef27`](https://github.com/NixOS/nixpkgs/commit/11d9ef272d6cfc00ab952aa3b3f6829959fa5435) glbinding: dropped unused xlibsWrapper input
* [`54b03e5f`](https://github.com/NixOS/nixpkgs/commit/54b03e5f4a8708f7625454563415ae36d4619d02) vimPlugins.coc-spell-checker: use a node package
* [`5fb4db77`](https://github.com/NixOS/nixpkgs/commit/5fb4db779e0c52b06d47df6b53c3cc1eca8d1bf3) Add cspell to node-packages
* [`a0e343a6`](https://github.com/NixOS/nixpkgs/commit/a0e343a61b42d53cca4c9633080612d69b684d2f) mozillavpn: 2.10.1 → 2.11.0
* [`d9b1bde3`](https://github.com/NixOS/nixpkgs/commit/d9b1bde390eb133a3da66c8abd902ea2b754938c) nixos: Fix fsck with systemd 251.6 and later
* [`c754d1b6`](https://github.com/NixOS/nixpkgs/commit/c754d1b6a30f87aa6b2af08f078cbd9b06dc213e) julia_18: 1.8.2 -> 1.8.3
* [`81cd6b06`](https://github.com/NixOS/nixpkgs/commit/81cd6b06f96c4343ad0932f117acd89237cea477) nixos/nginx: add default listen port options
* [`b60de3b4`](https://github.com/NixOS/nixpkgs/commit/b60de3b41641ca29bc789c8bd946145762dbbbfc) julia_10, julia_15: drop infavor of latest stable versions
* [`afd99c07`](https://github.com/NixOS/nixpkgs/commit/afd99c07525857686208f09b81fb03e78c6be2c0) tellico: 3.4.1 -> 3.4.4
* [`cebf764e`](https://github.com/NixOS/nixpkgs/commit/cebf764e2bf04da20b0a857df13a641fe980bfac) netpbm: 11.0.1 -> 11.0.2
* [`b2a6caa5`](https://github.com/NixOS/nixpkgs/commit/b2a6caa5cbbc73a6a10b7937c6cc650b865fa86f) flyctl: 0.0.430 -> 0.0.431
* [`0660bc5f`](https://github.com/NixOS/nixpkgs/commit/0660bc5fb18bb387f8538bce521884c1efa309fe) ruff: 0.0.118 -> 0.0.119
* [`3537f2cc`](https://github.com/NixOS/nixpkgs/commit/3537f2ccd52f0e54b0a90bff14279c04a1483600) cloudflare-dyndns: remove from python3Packages
* [`5ccc047d`](https://github.com/NixOS/nixpkgs/commit/5ccc047d3a2238623fd8a379fcd205e47e3acd2f) grocy: 3.3.1 -> 3.3.2
* [`3ce72808`](https://github.com/NixOS/nixpkgs/commit/3ce72808da12ef16c7299e8d00b874cdc728ef44) terraform-providers.aiven: 3.8.0 → 3.8.1
* [`8ca1aba4`](https://github.com/NixOS/nixpkgs/commit/8ca1aba4757f47204c1f11c662a5568b5a485f85) terraform-providers.newrelic: 3.6.1 → 3.7.0
* [`af810aa2`](https://github.com/NixOS/nixpkgs/commit/af810aa23290ce98e34208fd1559f82197d0b562) vimPlugins.nvim-treesitter: move grammar generation from fetch to grammar.nix
* [`de55c527`](https://github.com/NixOS/nixpkgs/commit/de55c52759db280803dc8f9a89e7e05d9111d525) icewm: 3.2.1 -> 3.2.2
* [`1671115d`](https://github.com/NixOS/nixpkgs/commit/1671115dbefc87875e513cf70b77e6589ab7ff3c) lazydocker: 0.19.0 -> 0.20.0
* [`b6239d9b`](https://github.com/NixOS/nixpkgs/commit/b6239d9b019b76da41d5965e8d90ba18ec05adb5) lazygit: 0.35 -> 0.36.0
* [`2067822b`](https://github.com/NixOS/nixpkgs/commit/2067822b828cf8460ef2e72f68705c531195350f) got: 0.78 -> 0.79
* [`c0da0ab0`](https://github.com/NixOS/nixpkgs/commit/c0da0ab05bc7bf823370e206dea267f6b5faa2ff) wxGTK30: 3.0.5 -> 3.0.5.1
* [`e3cf5440`](https://github.com/NixOS/nixpkgs/commit/e3cf54408754eaf4c801ed057d8d75ebc58efe45) krunner-pass: fix cmake configuration
* [`360080de`](https://github.com/NixOS/nixpkgs/commit/360080de176a26a572384ea308e623f01eeeea3d) kmplayer: fix cmake configuration
* [`48e236c7`](https://github.com/NixOS/nixpkgs/commit/48e236c7e0153035b6c8198fe56ebcedb44ebedb) ksmoothdock: patch out -Werror
* [`f62a898c`](https://github.com/NixOS/nixpkgs/commit/f62a898c4fdc272008620eb01f2a377fbda3f515) bcompare: 4.4.2.26348 -> 4.4.4.27058
* [`76085e22`](https://github.com/NixOS/nixpkgs/commit/76085e2232eb58df477274350cac10b4bdabb920) openshot-qt: fix Python 3.10 incompatibility
* [`f8d028f2`](https://github.com/NixOS/nixpkgs/commit/f8d028f2715cb8eb54945288902d118b0f7f77fb) python3Packages.datasets: fix build after dill bump
* [`335b2990`](https://github.com/NixOS/nixpkgs/commit/335b2990e64728fc0401b45af61a3d2cdfb0c483) python3Packages.pymemcache: mark broken on 32 bit
* [`7dd0719b`](https://github.com/NixOS/nixpkgs/commit/7dd0719b2ffe3654ab677e1fd66f235658ef7cf7) python310Packages.apache-beam: fix for dill 0.3.6
* [`bae3d999`](https://github.com/NixOS/nixpkgs/commit/bae3d99920ba622703b7b648b570b7b3e6194c0c) prowlarr: 0.4.7.2016 -> 0.4.9.2083
* [`8786f80a`](https://github.com/NixOS/nixpkgs/commit/8786f80a1c7c320f9a0637e9cf36bb8274f3602a) ocamlPackages.js_of_ocaml-ocamlbuild: 4.0.0 → 5.0
* [`0d94bc12`](https://github.com/NixOS/nixpkgs/commit/0d94bc12c754d50f402702fcdccc47375f140455) python310Packages.aiopvapi: 2.0.3 -> 2.0.4
* [`e3a720db`](https://github.com/NixOS/nixpkgs/commit/e3a720db368ed39b2f471d3431b294b6b800c9d6) dune_3: 3.5.0 -> 3.6.0
* [`1a24e792`](https://github.com/NixOS/nixpkgs/commit/1a24e79270dbfb4948ce66dbb442a9e3f5d22dbb) libsigrokdecode: unpin python dependency
* [`78578070`](https://github.com/NixOS/nixpkgs/commit/785780706e9cedab2f32a74c8a121c679a8f7b7e) terraform-providers: support gitlab source
* [`6b476b87`](https://github.com/NixOS/nixpkgs/commit/6b476b87dfc19407f71eb430593c004380f7cc74) terraform-providers.gitlab: 3.18.0 -> 3.19.0
* [`d3ccf64a`](https://github.com/NixOS/nixpkgs/commit/d3ccf64ae14abd26b44f725a1b0aed10654d0aa9) gh: 2.20.0 -> 2.20.2
* [`1177e17c`](https://github.com/NixOS/nixpkgs/commit/1177e17c282f515bcee3255dd7ec64fb1e035fe3) nil: 2022-11-07 -> 2022-11-15
* [`aec2518c`](https://github.com/NixOS/nixpkgs/commit/aec2518c5b144ed2a8d2b7f2a07fb3632a4e42e2) nextcloudPackages: init
* [`88e0973f`](https://github.com/NixOS/nixpkgs/commit/88e0973f46ad4f000049b42f42104e11b5d01afb) nc4nix: unstable-2022-11-12 -> unstable-2022-11-13
* [`f478baba`](https://github.com/NixOS/nixpkgs/commit/f478baba650b3374a82f17ff3534794a7c36a78e) xfce.xfce4-settings: 4.16.4 -> 4.16.5
* [`3f5e89e6`](https://github.com/NixOS/nixpkgs/commit/3f5e89e6468dc56f558b3293bb8d72996ea6ac6c) rure: 0.2.1 -> 0.2.2
* [`d6e3679c`](https://github.com/NixOS/nixpkgs/commit/d6e3679cc543200b0da5318190edb65f717a4d08) libreddit: 0.23.1 -> 0.24.0
* [`3931b0b6`](https://github.com/NixOS/nixpkgs/commit/3931b0b6cf495b723ef0c86a0553bb6e88cb6bf9) asl: 142-bld211 -> 142-bld232
* [`3a856243`](https://github.com/NixOS/nixpkgs/commit/3a856243be8806696b14964f26bd11118a76fb4b) jwasm: add changelog page
* [`51914779`](https://github.com/NixOS/nixpkgs/commit/51914779e29b8f30e3bee4cf4d9db5cc32be2459) cubiomes-viewer: 2.5.1 -> 2.6.1
* [`f010cdca`](https://github.com/NixOS/nixpkgs/commit/f010cdcad38519f71f2468d309a67467929a1fe8) asterisk: 16.26.1 -> 16.29.0, 18.12.1 -> 18.15.0, 19.4.1 -> 19.7.0, init 20.0.0
* [`c3717875`](https://github.com/NixOS/nixpkgs/commit/c371787587daf9e372eb24586aa4bb5fb6bc3c47) jwasm: 2.15 -> 2.16
* [`f7bed8cd`](https://github.com/NixOS/nixpkgs/commit/f7bed8cd449852a75fa46cb42fd1d18f096c7b1d) nixos/nginx: fix default listen port options
* [`ad351809`](https://github.com/NixOS/nixpkgs/commit/ad35180922422d828a38e2d0e990a11d4148ccfd) appthreat-depscan: 2.2.1 -> 2.3.0
* [`946634f5`](https://github.com/NixOS/nixpkgs/commit/946634f56d19b022ee6171683f351ba15545de59) kubecolor: 0.0.20 -> 0.0.21
* [`b54257fb`](https://github.com/NixOS/nixpkgs/commit/b54257fb36b7d2c05778e6ff177dffad965186f4) linkFarm: add entries to passthru
* [`a93aed5b`](https://github.com/NixOS/nixpkgs/commit/a93aed5bab972d3b5201d6067ecec998d8d62eaa) linkFarm: allow entries to be an attrset
* [`845038dc`](https://github.com/NixOS/nixpkgs/commit/845038dc31a2f3cb6c6fef2ab7829ddf6bfc40d6) protonvpn-gui: add meta.mainProgram
* [`0dd4e5e1`](https://github.com/NixOS/nixpkgs/commit/0dd4e5e12b0b76169e8bec8963c9e996779126e2) jenkins: 2.361.3 -> 2.361.4
* [`eee76d2b`](https://github.com/NixOS/nixpkgs/commit/eee76d2b660cf596fd0dda1fe30bb2a119ef0c80) python310Packages.pikepdf: 6.2.2 -> 6.2.4
* [`3380742d`](https://github.com/NixOS/nixpkgs/commit/3380742d55bdb2d9c0c3584b88d73702e5bbb95d) python310Packages.pysvn: 1.9.12 -> 1.9.18
* [`63825986`](https://github.com/NixOS/nixpkgs/commit/6382598677548d5b483dce4ab380067cd91af6d2) linkFarm: make last entry win in case of list repeats
* [`43bf542c`](https://github.com/NixOS/nixpkgs/commit/43bf542ccd8f439964a049f1586689de20bbadb1) tests.trivial-builders.linkFarm: init
* [`085e3f41`](https://github.com/NixOS/nixpkgs/commit/085e3f41c9a84c64bf7e6fd74521232116e1d27f) ruff: 0.0.119 -> 0.0.120
* [`c220703a`](https://github.com/NixOS/nixpkgs/commit/c220703aeea75420753ea3f8e3f0cd401ec80738) prismlauncher: 5.1 -> 5.2
* [`6092075d`](https://github.com/NixOS/nixpkgs/commit/6092075d23bfee851f2a0be1edd76c2b35ebbc3e) neovim: 0.8.0 -> 0.8.1
* [`4a599be7`](https://github.com/NixOS/nixpkgs/commit/4a599be7758b743b2ba2c87e2ac2f46b3e68e620) lunatic: 0.10.1 -> 0.12.0
* [`a428cc4a`](https://github.com/NixOS/nixpkgs/commit/a428cc4a2d3982f2db74c0a3526823f84b3362f5) cargo-raze: 0.12.0 -> 0.16.0
* [`f6b07f0e`](https://github.com/NixOS/nixpkgs/commit/f6b07f0e2f5834b1fd6432a0f4c2bc11096e53ed) fetchgit: make sparseCheckout a list of strings
* [`c95d7d5a`](https://github.com/NixOS/nixpkgs/commit/c95d7d5a8c301cf59fde5ffd9296660bc72c3080) treewide: make sparseCheckout a list of strings
* [`b2933672`](https://github.com/NixOS/nixpkgs/commit/b2933672e2927aaf3f4a768623bdd848c9474b78) python310Packages.diff-cover: 7.0.1 -> 7.0.2
* [`9a2f7b87`](https://github.com/NixOS/nixpkgs/commit/9a2f7b878cb7ee63d6d7234bffa41e1e5c21f41a) librewolf: 106.0.3-1 -> 107.0-1
* [`0551d04c`](https://github.com/NixOS/nixpkgs/commit/0551d04c28fc6fc7eb8b02d03366449b36894303) python310Packages.django-webpack-loader: 1.6.0 -> 1.7.0
* [`9fdf63a7`](https://github.com/NixOS/nixpkgs/commit/9fdf63a7b4cbf217a3d4843eeb1e7d90b97d54ee) python310Packages.django_hijack: 3.2.1 -> 3.2.4
* [`b97cda7d`](https://github.com/NixOS/nixpkgs/commit/b97cda7d44aa78fe915df7b0c18e3d6ed9edd157) mpv-unwrapped: 0.34.1 -> 0.35.0
* [`d951688f`](https://github.com/NixOS/nixpkgs/commit/d951688f801820e628cc9001ea3012e0ddef6fa2) addlicense: unstable-2021-04-22 -> 1.1.0
* [`3b6c0372`](https://github.com/NixOS/nixpkgs/commit/3b6c0372c86bd2f7d5faca942c40e2f0934e0ac0) consul: 1.13.3 -> 1.14.0
* [`75143fad`](https://github.com/NixOS/nixpkgs/commit/75143fad73bf3a09ba0b763d3e6bf52fb147685a) yq-go: 4.30.1 -> 4.30.4
* [`2d788512`](https://github.com/NixOS/nixpkgs/commit/2d788512960586f5d744af24021b786b2ba71c5b) efivar: use clickable homepage
* [`d145c522`](https://github.com/NixOS/nixpkgs/commit/d145c5222bdf1c1866a69a4b1c82311cf4df8c99) terraria-server: 1.4.4.2 -> 1.4.4.8.1
* [`378ed33a`](https://github.com/NixOS/nixpkgs/commit/378ed33aa9134c140baba13aee0d871ba1bbfa84) pocket-casts: 0.5.0 -> 0.6.0
* [`52f1f8f1`](https://github.com/NixOS/nixpkgs/commit/52f1f8f11073d7b5573bf92e013c5d54205fc6ca) haskellPackages/extra: init brick 1.3 for swarm 0.2.0.0
* [`f52a92c2`](https://github.com/NixOS/nixpkgs/commit/f52a92c22678777bb8edee6dffb05047d3781cba) haskellPackages: regenerate package set based on current config
* [`1bb311a8`](https://github.com/NixOS/nixpkgs/commit/1bb311a89e488e36250f5c362eea69dd714824ba) haskellPackages.swarm: fix broken package
* [`4e4a021f`](https://github.com/NixOS/nixpkgs/commit/4e4a021fd77d4af89b7576e6187444df97379707) d-seams: fix failing builds
* [`a71ccfab`](https://github.com/NixOS/nixpkgs/commit/a71ccfabf660ef4da7920a9ce7ffb6cdf5c02654) python310Packages.geopy: 2.2.0 -> 2.3.0
* [`3a98554c`](https://github.com/NixOS/nixpkgs/commit/3a98554ce62a76c1dbe8aecdb5479084148dd818) netatalk: refactor
* [`651cc63d`](https://github.com/NixOS/nixpkgs/commit/651cc63d4d8dbac5705d59aedba2b530904d431d) ruff: 0.0.120 -> 0.0.121
* [`acecd1ec`](https://github.com/NixOS/nixpkgs/commit/acecd1ec7bc009b644e9a6dc64d164583eb23860) Revert "nixos: Fix fsck with systemd 251.6 and later"
* [`1d8aaab8`](https://github.com/NixOS/nixpkgs/commit/1d8aaab8e5aa18ab81abe2a024aa7aaadee5a74b) python310Packages.tld: remove tox, pytest-cov dependency
* [`b28ecff1`](https://github.com/NixOS/nixpkgs/commit/b28ecff1e6ffc17c23314c528c77f082f2b88f4c) nixos: Add util-linux to systemd PATH to fix fsck with systemd 251.6
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
