### PR TITLE
niv emacs-overlay: update 3c164745 -> 86fa3768

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c1647451bf5c2391122c794605f5e590badbd6e",
-        "sha256": "10mczcqq2mw1a9kq4nc64dk4x9sf0517flqipgixk18knlnpqa04",
+        "rev": "86fa3768f0eb427a5c773e6dde261e8151135e22",
+        "sha256": "19hf7l3wh34pc0cwf9njzd1lj1fggrpjjpycwg43ir7hs3fam53g",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/3c1647451bf5c2391122c794605f5e590badbd6e.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/86fa3768f0eb427a5c773e6dde261e8151135e22.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@3c164745...86fa3768](https://github.com/nix-community/emacs-overlay/compare/3c1647451bf5c2391122c794605f5e590badbd6e...86fa3768f0eb427a5c773e6dde261e8151135e22)

* [`852da925`](https://github.com/nix-community/emacs-overlay/commit/852da92579324f3aab65408dc07c8e8dabfd45a8) Updated repos/emacs
* [`bb493503`](https://github.com/nix-community/emacs-overlay/commit/bb493503d80488bd1c8f0eced7a210a302ae1999) Updated repos/melpa
* [`b54a1f01`](https://github.com/nix-community/emacs-overlay/commit/b54a1f01c7326d199c687e45c47b741661625f88) Updated repos/emacs
* [`7b8b5a43`](https://github.com/nix-community/emacs-overlay/commit/7b8b5a43f5e7c24b407c5c24c2030938386cd865) Updated repos/melpa
* [`c894e234`](https://github.com/nix-community/emacs-overlay/commit/c894e234e15a123b8cc6f0ed3369b70636fbe394) Updated repos/emacs
* [`74789d57`](https://github.com/nix-community/emacs-overlay/commit/74789d573f6bb8b8b4942f83fa060d76258a7e6e) Updated repos/melpa
* [`6cf71898`](https://github.com/nix-community/emacs-overlay/commit/6cf71898aa2263b83955c7d3b884ac4adc9b93d2) Updated repos/emacs
* [`a870b8d8`](https://github.com/nix-community/emacs-overlay/commit/a870b8d83f171ec34572ecd4355c74181bf7af98) Updated repos/melpa
* [`69a81fdf`](https://github.com/nix-community/emacs-overlay/commit/69a81fdf4f4b3bfcb227a23a0926f5663b355d19) Updated repos/nongnu
* [`d71ca4cd`](https://github.com/nix-community/emacs-overlay/commit/d71ca4cd3aeca28fd49986f7f11e1c022df0ef12) Updated repos/emacs
* [`54030961`](https://github.com/nix-community/emacs-overlay/commit/5403096194fd02e1a5424a365d057d934c705639) Updated repos/melpa
* [`4d90f112`](https://github.com/nix-community/emacs-overlay/commit/4d90f11266b429b8484801dc36a19e5e66cfd650) Updated repos/emacs
* [`8894dc98`](https://github.com/nix-community/emacs-overlay/commit/8894dc985e6aa0f8a3253d8f19ede50bd8b9c93e) Updated repos/melpa
* [`098c2a81`](https://github.com/nix-community/emacs-overlay/commit/098c2a810c937564bff3f57fc406be9c144283ae) Updated repos/nongnu
* [`5d321bc0`](https://github.com/nix-community/emacs-overlay/commit/5d321bc0b453ef6da1224d126cda443f6e9613a3) Updated repos/emacs
* [`c9a123e3`](https://github.com/nix-community/emacs-overlay/commit/c9a123e3d03cdd3a89b448123237618d4fcfae30) Updated repos/melpa
* [`9964dcc6`](https://github.com/nix-community/emacs-overlay/commit/9964dcc695b86aa188e5884384b38e2d8832950d) Updated repos/nongnu
* [`39ecc84b`](https://github.com/nix-community/emacs-overlay/commit/39ecc84bfb684c442ea89f31d513f80ae383470b) Add tree-sitter-bash to list of plugins
* [`df92c810`](https://github.com/nix-community/emacs-overlay/commit/df92c8103baa668b53189e742e989d2b4ad8d577) Updated repos/emacs
* [`51c6e49b`](https://github.com/nix-community/emacs-overlay/commit/51c6e49b08c37ab762c1bdc8060e569197001dfe) Updated repos/melpa
* [`9d4d7f88`](https://github.com/nix-community/emacs-overlay/commit/9d4d7f888359a991936f496c93303f5f84a90d3f) Updated repos/emacs
* [`10f4d8b2`](https://github.com/nix-community/emacs-overlay/commit/10f4d8b2abb398bcf327136a39d9ae9e1d09d5c9) Updated repos/melpa
* [`4e74a795`](https://github.com/nix-community/emacs-overlay/commit/4e74a7957f391f4e086fa4e524d140a0fde37c3b) Updated repos/nongnu
* [`344e943a`](https://github.com/nix-community/emacs-overlay/commit/344e943a6590691b1bdaa3fdca3d4f5fba1ffffb) Updated repos/emacs
* [`f301f0c6`](https://github.com/nix-community/emacs-overlay/commit/f301f0c632a7af8681a02eca35b3e1d271be2c37) Updated repos/melpa
* [`82d347e7`](https://github.com/nix-community/emacs-overlay/commit/82d347e7e26deb5072f0f71e78a8630d14cea3b9) Updated repos/emacs
* [`ec5c4c91`](https://github.com/nix-community/emacs-overlay/commit/ec5c4c91b687adf1b705504379b4c2dea6e46a12) Updated repos/melpa
* [`7974efb8`](https://github.com/nix-community/emacs-overlay/commit/7974efb896723c113f59414172649f18b04d8e21) Updated repos/emacs
* [`145a6e70`](https://github.com/nix-community/emacs-overlay/commit/145a6e7030dee3e99f23e0721979ce6de65a21cd) Updated repos/melpa
* [`faf39a31`](https://github.com/nix-community/emacs-overlay/commit/faf39a31bc76f1cd4eb642d79eeab1d25b038e72) Updated repos/nongnu
* [`2fd65c60`](https://github.com/nix-community/emacs-overlay/commit/2fd65c60a3c43a45f8cdaa47f850a982d06c44b0) Updated repos/emacs
* [`909b090c`](https://github.com/nix-community/emacs-overlay/commit/909b090c1181644ef3def6a37a18e9e3d08d1b07) Updated repos/melpa
* [`3a166882`](https://github.com/nix-community/emacs-overlay/commit/3a1668827fc96c32e3b268d5df16a6e92523eba7) Updated repos/emacs
* [`1ddaf3ee`](https://github.com/nix-community/emacs-overlay/commit/1ddaf3eea07315ee3923c161e6a358b53d9fceea) Updated repos/melpa
* [`1c527416`](https://github.com/nix-community/emacs-overlay/commit/1c5274164f7a16e62b7b16f81998ca4c0a6423da) Updated repos/emacs
* [`e380486c`](https://github.com/nix-community/emacs-overlay/commit/e380486c5be07345c5738a2df78660c3c2c8a2f0) Updated repos/melpa
* [`e883ec1c`](https://github.com/nix-community/emacs-overlay/commit/e883ec1ccbecceadb3b38cb3b3c45a67e2ece6b1) Updated repos/nongnu
* [`050483d3`](https://github.com/nix-community/emacs-overlay/commit/050483d37f6c6d31d33aeff307f1af20b5bc0f8f) Updated repos/emacs
* [`a385a268`](https://github.com/nix-community/emacs-overlay/commit/a385a268c2bd4a411caff28adc785f6ba479d79f) Updated repos/melpa
* [`2f074498`](https://github.com/nix-community/emacs-overlay/commit/2f074498a0a5035b3b426b21f80793bbee6e4662) Updated repos/emacs
* [`983af3c0`](https://github.com/nix-community/emacs-overlay/commit/983af3c08a4cec7fbe1eec336fc1894f2bf2e678) Updated repos/melpa
* [`721aa34f`](https://github.com/nix-community/emacs-overlay/commit/721aa34f1468f13b664c5f42aed1e4a560c2801c) Updated repos/nongnu
* [`6d000fba`](https://github.com/nix-community/emacs-overlay/commit/6d000fba594c4ad90e51ef7af17dc7fdd4ec7125) Updated repos/emacs
* [`dde00fb4`](https://github.com/nix-community/emacs-overlay/commit/dde00fb44e5d4a799da069fec92bed7ca6ebbf2d) Updated repos/melpa
* [`acbbcb78`](https://github.com/nix-community/emacs-overlay/commit/acbbcb781724648f206068e230a7a5f77fba510c) Updated repos/nongnu
* [`3f886f65`](https://github.com/nix-community/emacs-overlay/commit/3f886f65be24a57a90e4849bb83f991e3b68a31c) Updated repos/emacs
* [`28824526`](https://github.com/nix-community/emacs-overlay/commit/2882452693f3abf29ef583519618519e25f9fdad) Updated repos/melpa
* [`d7a3f296`](https://github.com/nix-community/emacs-overlay/commit/d7a3f296877ea991deae4c6b220836bfaa006b62) Updated repos/emacs
* [`88b5da0b`](https://github.com/nix-community/emacs-overlay/commit/88b5da0b83c722e033671728c1141c91f014a9b7) Updated repos/melpa
* [`35a111ea`](https://github.com/nix-community/emacs-overlay/commit/35a111eafb2489b044fb0e6edbefd9e5d3ca3365) Build emacsGitTreeSitter from master
* [`75c8accd`](https://github.com/nix-community/emacs-overlay/commit/75c8accdc205d59c65f4f5b17e9130f155e61646) Updated repos/melpa
* [`86fa3768`](https://github.com/nix-community/emacs-overlay/commit/86fa3768f0eb427a5c773e6dde261e8151135e22) Updated repos/nongnu
