### PR TITLE
niv powerlevel10k: update bc598354 -> cf83ab21

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "bc5983543a10cff2eac30cced9208bbfd91428b8",
-        "sha256": "0s8ndbpmlqakg7s7hryyi1pqij1h5dv0xv9xvr2qwwyhyj6zrx2i",
+        "rev": "cf83ab21e440ffa276a13ab5fd63b6372b674b5e",
+        "sha256": "0wp6f7x294hdvlhgzz3yrdnpzsk0hjxrngiijkxz1df5whbv4504",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/bc5983543a10cff2eac30cced9208bbfd91428b8.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/cf83ab21e440ffa276a13ab5fd63b6372b674b5e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@bc598354...cf83ab21](https://github.com/romkatv/powerlevel10k/compare/bc5983543a10cff2eac30cced9208bbfd91428b8...cf83ab21e440ffa276a13ab5fd63b6372b674b5e)

* [`d5123401`](https://github.com/romkatv/powerlevel10k/commit/d5123401be1933c955efdad0f9eb7197a0ee7415) Add reference to Zap plugin manager
* [`cf83ab21`](https://github.com/romkatv/powerlevel10k/commit/cf83ab21e440ffa276a13ab5fd63b6372b674b5e) fix a bug in zap install instructions and add uninstall instructions ([romkatv/powerlevel10k⁠#2093](https://togithub.com/romkatv/powerlevel10k/issues/2093))
