### PR TITLE
niv spacemacs: update 57a7a0e6 -> 913962b3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "57a7a0e63c4aecf810b19ca3fd49e5ae1a838126",
-        "sha256": "1lwbjfldysqfi4cf7i0fs9gz3iy83zlam45cdvlg0j0279ixbl6b",
+        "rev": "913962b3edde7984df78d91ab94d8b8e109e93f1",
+        "sha256": "1qbljd4vvw7d9ysbd6p8vdz26z44ljs96zszkpvqmmb0mhfzkbzk",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/57a7a0e63c4aecf810b19ca3fd49e5ae1a838126.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/913962b3edde7984df78d91ab94d8b8e109e93f1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@57a7a0e6...913962b3](https://github.com/syl20bnr/spacemacs/compare/57a7a0e63c4aecf810b19ca3fd49e5ae1a838126...913962b3edde7984df78d91ab94d8b8e109e93f1)

* [`04af272b`](https://github.com/syl20bnr/spacemacs/commit/04af272b394e016090e28e77aaadd93c8518aaaa) [themes-megapack] remove obsolete darkburn-theme
* [`266b5b63`](https://github.com/syl20bnr/spacemacs/commit/266b5b6379de39a488b470543a2122e17c2b97b2) [themes-megapack] fix farmhouse-theme package name and its references
* [`2f190e5a`](https://github.com/syl20bnr/spacemacs/commit/2f190e5ae75d7f3496a8e7a7c0a49ab4f1f560ca) [finance] Fix up evil-ledger mode initialization ([syl20bnr/spacemacs⁠#15816](https://togithub.com/syl20bnr/spacemacs/issues/15816))
* [`85a38663`](https://github.com/syl20bnr/spacemacs/commit/85a386632a4d41c8a03cd2d56f732f02d333b2af) [bot] "built_in_updates" Wed Nov 16 15:46:08 UTC 2022
* [`6f34ec4d`](https://github.com/syl20bnr/spacemacs/commit/6f34ec4de91861515a1e0d58e31c713a24dce364) Fix evil bindings in ediff
* [`5b3089fb`](https://github.com/syl20bnr/spacemacs/commit/5b3089fbba808ed084fb402be3c8fc77e5ebb4d3) Deletes uses of org-agenda-filter-by-tag-refine, as Org 9.0 removed it
* [`913962b3`](https://github.com/syl20bnr/spacemacs/commit/913962b3edde7984df78d91ab94d8b8e109e93f1) layers/+tools/shell: vterm depends on emacs module
