### PR TITLE
niv zsh-completions: update 7916ba50 -> 6a5b7245

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "7916ba50ed3633b2e85d9d7c4d323c5ec75b39b0",
-        "sha256": "07sklvx32zqk7c1bhajz5niknnhiwqxfm0ki8c38v33fn033s6ms",
+        "rev": "6a5b7245bed56083839c037aa0d37d8bd30df281",
+        "sha256": "1gasv6jpshnszjcfmixcrb40kgn9jdzfx1nli5rz8rr56df6ra38",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/7916ba50ed3633b2e85d9d7c4d323c5ec75b39b0.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/6a5b7245bed56083839c037aa0d37d8bd30df281.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@7916ba50...6a5b7245](https://github.com/zsh-users/zsh-completions/compare/7916ba50ed3633b2e85d9d7c4d323c5ec75b39b0...6a5b7245bed56083839c037aa0d37d8bd30df281)

* [`90fc2e1c`](https://github.com/zsh-users/zsh-completions/commit/90fc2e1c44961542722cbc350d857593c9ecfca9) Update 'bundle clean --force' completion document
* [`4ab4eaea`](https://github.com/zsh-users/zsh-completions/commit/4ab4eaea2da8d4bf182e4e2a53f5240ff2b4d1d1) nvm: remove extra space in exec command description
* [`645936e0`](https://github.com/zsh-users/zsh-completions/commit/645936e0555747209db63e0ad8bd135e97a8384b) Update glances completion
* [`3e07b1e0`](https://github.com/zsh-users/zsh-completions/commit/3e07b1e03081cb28f02aa9c97738603be557d5ef) Update subliminal completion
* [`6de723fd`](https://github.com/zsh-users/zsh-completions/commit/6de723fd36d40715ca1c4f04de3f6df2c5167e0b) Update pygmentize completion
* [`63a275bc`](https://github.com/zsh-users/zsh-completions/commit/63a275bc2e292f6e0d7af6d30ffcbc2776245a7e) Update thor completion
* [`d62dcaf8`](https://github.com/zsh-users/zsh-completions/commit/d62dcaf896c96f969a90f8988e794e7cd6c3da1c) Update docpad
* [`8c8c42e1`](https://github.com/zsh-users/zsh-completions/commit/8c8c42e1232c1d72489550207d7c3e7b9459fda6) Remove git-journal completion
* [`7cea53d4`](https://github.com/zsh-users/zsh-completions/commit/7cea53d40d97e909b06a4d75170d37c2eea4b62e) Update kak completion
* [`789054ed`](https://github.com/zsh-users/zsh-completions/commit/789054ed274b89b3134db5a7918733d53b3c0dc7) Remove subl completion
* [`80f7f13d`](https://github.com/zsh-users/zsh-completions/commit/80f7f13d6d342c3f6fde7f74ccab18e1dd8b1c56) Update showoff completion
* [`47e55a87`](https://github.com/zsh-users/zsh-completions/commit/47e55a87154df8f3ce5dd9ac7e5a402f1b00e817) Update Capistrano completion
* [`3eec22b0`](https://github.com/zsh-users/zsh-completions/commit/3eec22b0f6222bc93bf684c187b456359b746bfe) Update lilypond completion
* [`812d2202`](https://github.com/zsh-users/zsh-completions/commit/812d2202c05e9eb80b59a360f9973bc40d333bb5) Remove composer
* [`6569c7df`](https://github.com/zsh-users/zsh-completions/commit/6569c7df343fa2a52428b80330f89d1ec09bbe06) Add description of mc command
* [`e7d3f4c6`](https://github.com/zsh-users/zsh-completions/commit/e7d3f4c6c66d7ccaf904471d563e4c6f1a3a200b) Update lunchy completion
* [`bfe43af6`](https://github.com/zsh-users/zsh-completions/commit/bfe43af637bb44f107b9540b5986e0c621c9d4e0) Update ibus
* [`b920d83b`](https://github.com/zsh-users/zsh-completions/commit/b920d83b9aab57a72d65bcaf32b518fb0b184e7b) Update coffee completion
* [`e001c1e5`](https://github.com/zsh-users/zsh-completions/commit/e001c1e52379db85cc34e9425c75be24e35c3374) Remove vagrant
* [`83842b03`](https://github.com/zsh-users/zsh-completions/commit/83842b03d6f374f27d22ab62fac205dadae45136) Remove perf completion
* [`88401909`](https://github.com/zsh-users/zsh-completions/commit/884019098571a09224e936eb7818dbc5e8a44b83) Format scrub completion and improve pattern completion
* [`6b33831a`](https://github.com/zsh-users/zsh-completions/commit/6b33831ab38e57f279b67d6ee7447efbb6c4761c) Refactoring flutter completion
* [`df4f71fb`](https://github.com/zsh-users/zsh-completions/commit/df4f71fb8c56ffa50963353390405ea85a26c4f7) Remove force completion
* [`df1bba98`](https://github.com/zsh-users/zsh-completions/commit/df1bba9803eb522bf39c0db1b6e6809a42c71113) Update cmake completion
* [`0f4dddf7`](https://github.com/zsh-users/zsh-completions/commit/0f4dddf7d8e5e20db0ae5f3f62b0fa05093dd281) Update svm
* [`bffb7ef7`](https://github.com/zsh-users/zsh-completions/commit/bffb7ef7477073f7d7f0b5295b7bc4790dca39b4) Update pm2 completion
