### PR TITLE
niv nixpkgs: update 0eb16c85 -> 67762b63

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0eb16c85a0dfe013e5585ee02c3033161a8baa9e",
-        "sha256": "00qw4r7w11cxml96l02v4w2cgh50i8wk35azaxbqrrc2n202ysb5",
+        "rev": "67762b63179d7efd4613b4f0bbd5153261c3d702",
+        "sha256": "1hvbdnf0msykw8kra7rlqwbmys1cz0vw1b0y9b9qa7fm77xqs6d8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/0eb16c85a0dfe013e5585ee02c3033161a8baa9e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/67762b63179d7efd4613b4f0bbd5153261c3d702.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@0eb16c85...67762b63](https://github.com/nixos/nixpkgs/compare/0eb16c85a0dfe013e5585ee02c3033161a8baa9e...67762b63179d7efd4613b4f0bbd5153261c3d702)

* [`d0e7f4d5`](https://github.com/NixOS/nixpkgs/commit/d0e7f4d5ed44b1676ca7152918f05308f865c142) maintainers: add CaptainJawZ
* [`4a841f87`](https://github.com/NixOS/nixpkgs/commit/4a841f87b8db52558deb053bd1c609e1db1faac8) AMB-plugins: fix cross compilation by replacing hardcoded g++ with CXX
* [`cc7deb7e`](https://github.com/NixOS/nixpkgs/commit/cc7deb7e4a1b34d539230abe33ace25e41953b53) openafs: remove null overwrites, fix tsm package name, move openafs_1_8 to aliases
* [`9235a048`](https://github.com/NixOS/nixpkgs/commit/9235a0486b5455ab67a3c828e9c76f06f8e4121f) python3Packages.setproctitle: 1.2.3 -> 1.3.2
* [`8b56c422`](https://github.com/NixOS/nixpkgs/commit/8b56c422e4c10ccadef50f4747d4a79e79059ba6) ffmpeg-full: enable videotoolbox for hw accelerated encode on darwin
* [`5bd7d45b`](https://github.com/NixOS/nixpkgs/commit/5bd7d45bc200f5701f5f2fc98eedd04a10a605ad) vscode-extensions.yzhang.markdown-all-in-one: 3.4.0 -> 3.4.4
* [`ff81b059`](https://github.com/NixOS/nixpkgs/commit/ff81b059498dc691464906478a6608c8c9d7c150) furtherance: init at 1.6.0
* [`79ae4eb9`](https://github.com/NixOS/nixpkgs/commit/79ae4eb9979bf89a6d5e6f0804a216b3b86106a5) fake-nss: Add support for extra passwd and group lines
* [`a8ba0914`](https://github.com/NixOS/nixpkgs/commit/a8ba09146cb47795cf95dc4a2fd7f0ebc6b282f5) sienna: 1.0c -> 1.0d
* [`8ec0837a`](https://github.com/NixOS/nixpkgs/commit/8ec0837a72b532df84d61b3f8571793f15326b29) Introduce dockerTools.buildNixShellImage
* [`c36f929d`](https://github.com/NixOS/nixpkgs/commit/c36f929dee42c13ffa5e02adfdf749ec789fc5f4) nixos/tests: Add tests for dockerTools.buildNixShellImage
* [`adb2e740`](https://github.com/NixOS/nixpkgs/commit/adb2e740cfbc5d0f91e21d5ebf91441c70ccbf96) gcc-arm-embedded: 10.3 -> 11.3.rel1
* [`81e43017`](https://github.com/NixOS/nixpkgs/commit/81e43017331decb4649e5513e47bedc44e8c595d) git-annex-remote-rclone: 0.6 -> 0.7
* [`3ac5f93a`](https://github.com/NixOS/nixpkgs/commit/3ac5f93afcedb639b35b07f3dfb644fb4711520e) nix-serve-ng: add to top-level packages
* [`2072485a`](https://github.com/NixOS/nixpkgs/commit/2072485ad911cd6e71d63cfb49f02b862823f4e9) diswall: init at 0.2.0
* [`4b07aeae`](https://github.com/NixOS/nixpkgs/commit/4b07aeae16811bcb6ab2cef67133180bcb30ed67) openmp: fix cross compile
* [`24b4cfb8`](https://github.com/NixOS/nixpkgs/commit/24b4cfb8800e56b3fb092430e70e030af52a9e57) vexctl: init at 0.0.2
* [`d421186d`](https://github.com/NixOS/nixpkgs/commit/d421186dc5ba39963d4b37ef0bfb9dda49d0ba4f) onmetal-image: init at unstable-2022-09-28
* [`8d7ab388`](https://github.com/NixOS/nixpkgs/commit/8d7ab388bfc291fc92369c0e68301fa89dffb9b6) kak-lsp: 14.0.0 -> 14.1.0
* [`57069c33`](https://github.com/NixOS/nixpkgs/commit/57069c33661703b841c3c2a279cb9fdf08c7be27) QtRVSim: 0.9.3 -> 0.9.4
* [`544c5263`](https://github.com/NixOS/nixpkgs/commit/544c526393f15c946a77ed0f6f11f5d3b90e50b8) nginx: change temp path location
* [`3802a1d3`](https://github.com/NixOS/nixpkgs/commit/3802a1d38b5e524f26f893674995f46e15fbaca8) rgbds: 0.5.2 -> 0.6.0
* [`bfd95776`](https://github.com/NixOS/nixpkgs/commit/bfd9577640a6da76f18a4946c43ee531c6c7072e) sameboy: add rgbds 0.6 compatibility
* [`219ad1a8`](https://github.com/NixOS/nixpkgs/commit/219ad1a8567ee98cd2efc745ffdfeb344625a1c5) Add harrisonthorne as a maintainer
* [`4af0feab`](https://github.com/NixOS/nixpkgs/commit/4af0feab9ec40691d9da488ca8f8489e1ace7f0d) palapeli: init at 22.08.2
* [`7bfdb025`](https://github.com/NixOS/nixpkgs/commit/7bfdb025288e5607661a1212ad2e04cbe6e32057) dropbear: 2020.81 -> 2022.82
* [`a77b1b7c`](https://github.com/NixOS/nixpkgs/commit/a77b1b7c5e7e354a0a4499c26f6e5c071dc43d60) metabase: 0.44.3 -> 0.44.5
* [`26a6ef7f`](https://github.com/NixOS/nixpkgs/commit/26a6ef7f17e1bd46661359af3751ce57511d9962) ntfs3g: 2022.5.17 -> 2022.10.3
* [`c09fd120`](https://github.com/NixOS/nixpkgs/commit/c09fd120cc056a324559aa8fcc9184968c9d0713) nixos/nginx: add proxyCache options
* [`8ff6f635`](https://github.com/NixOS/nixpkgs/commit/8ff6f635f4fe640f66339b48de6e486967107071) krill: 0.11.0 -> 0.12.0
* [`afa77561`](https://github.com/NixOS/nixpkgs/commit/afa775618da7af998227a7e82f4b5ae6a294f40a) openpgp-card-tools: 0.0.12 -> 0.9.0
* [`906c2a94`](https://github.com/NixOS/nixpkgs/commit/906c2a94866bb8685100f040fcd5c549fc5f7e63) odamex: migrate to wxGTK32
* [`0a2b4e72`](https://github.com/NixOS/nixpkgs/commit/0a2b4e72f9846e9b3ba4a4fed65110d9663337f0) electricsheep: migrate to wxGTK32
* [`d0a03f4c`](https://github.com/NixOS/nixpkgs/commit/d0a03f4c6892d857fc82935d2915568a21613b98) xchm: migrate to wxGTK32
* [`b20b3bde`](https://github.com/NixOS/nixpkgs/commit/b20b3bde80a6455bcd60dfe805883b4a8622e9d7) xylib: migrate to wxGTK32
* [`7f0b7f4c`](https://github.com/NixOS/nixpkgs/commit/7f0b7f4cf3c1bee6f1b2bc20d117ebc13daa04f2) fityk: migrate to wxGTK32
* [`0c541660`](https://github.com/NixOS/nixpkgs/commit/0c5416604e86972c4e150238ae55d140ed2132fa) strace-analyzer: init at 0.5.1
* [`e54401a2`](https://github.com/NixOS/nixpkgs/commit/e54401a274a45a67f3bfecfef26d09cfe214f264) libzbc: 5.12.0 -> 5.13.0
* [`8b0f29d8`](https://github.com/NixOS/nixpkgs/commit/8b0f29d8bb6b5fa3f83dfee1d00bd02c63feb771) python310Packages.fireflyalgorithm: 0.3.2 -> 0.3.3
* [`78452c78`](https://github.com/NixOS/nixpkgs/commit/78452c78f37c63cff11886a3a198a286e5803950) jetbrains.mps: 2021.3.1 -> 2022.2
* [`62104560`](https://github.com/NixOS/nixpkgs/commit/62104560c436896e5d06d531c5d1033b63c0ee5f) jetbrains.mps: Fix build
* [`0920175c`](https://github.com/NixOS/nixpkgs/commit/0920175cfccca2747e875e10ae15bbaac9e150b3) dendrite: 0.10.5 -> 0.10.7
* [`e43e91a2`](https://github.com/NixOS/nixpkgs/commit/e43e91a2a25a00141c9c35a6e498c55580304955) upx: apply patch for CVE-2021-20285
* [`6e52acee`](https://github.com/NixOS/nixpkgs/commit/6e52acee6326ab4d2cd146297a1d6c70847b4b6e) python310Packages.gaphas: 3.8.1 -> 3.8.4
* [`9a0c2eec`](https://github.com/NixOS/nixpkgs/commit/9a0c2eecf358a993aae769a9b1763b992ac847ad) vscode-extensions.james-yu.latex-workshop: 8.29.0 -> 9.0.0
* [`a1cf2493`](https://github.com/NixOS/nixpkgs/commit/a1cf24939404560acaac6555ae55942ae4163b9f) dockerTools.buildNixShellImage: Chown nix directories
* [`3997a524`](https://github.com/NixOS/nixpkgs/commit/3997a524992d207ad1a8178bb526f4921b14106c) element: remove piwiki disabling
* [`936bcaf7`](https://github.com/NixOS/nixpkgs/commit/936bcaf7327e02dfebbeaeb5ab537dfd2109bc6f) maintainers: add nagy
* [`d190c705`](https://github.com/NixOS/nixpkgs/commit/d190c70591b802a5160951d264d65b22bbdded70) freenet: build01480 -> build01494
* [`48932d34`](https://github.com/NixOS/nixpkgs/commit/48932d34080693ae5ec7de428cd696d58a8b1127) python310Packages.jinja2-time: normalise attr and path, enable tests, cleanups
* [`dd538e9a`](https://github.com/NixOS/nixpkgs/commit/dd538e9aed4211008aac6b65d771470d896a6c45) python310Packages.jq: 1.2.3 -> 1.3.0
* [`01001f04`](https://github.com/NixOS/nixpkgs/commit/01001f04dab445dd1efcc55ad4ad4e6a7d2187d5) changedetection-io: 0.39.20.4 -> 0.39.21.1
* [`677d6f16`](https://github.com/NixOS/nixpkgs/commit/677d6f1623b1054ce9832c55c5be3a9b049bc086) nixos/changedetection-io: hide referer by default
* [`e0e6444e`](https://github.com/NixOS/nixpkgs/commit/e0e6444e5058a9de3d555df5be9dc15e52b9a924) boinc: unbreak on aarch64-linux
* [`6760c8b4`](https://github.com/NixOS/nixpkgs/commit/6760c8b488cebb19b80ddbed0d2b1f5d71398913) lenmus: unbreak on aarch64-linux
* [`b2c5490f`](https://github.com/NixOS/nixpkgs/commit/b2c5490fdfdc6127d212e2c9890fd51a6e6824ed) flamerobin: 0.9.3.1 -> 0.9.3.12
* [`ac92d9c5`](https://github.com/NixOS/nixpkgs/commit/ac92d9c5b924026b4a73fe09b464e7aea4ea4c79) urbackup-client: 2.4.11 -> 2.5.20
* [`827ea229`](https://github.com/NixOS/nixpkgs/commit/827ea229e7b55d3c0eb7fddd1429519979798d29) sooperlooper: migrate to wxGTK30-gtk3
* [`c985936c`](https://github.com/NixOS/nixpkgs/commit/c985936c3949f840c99f13b4a7e9a890ea0e342c) pwsafe: migrate to wxGTK30-gtk3
* [`dd9aa5d6`](https://github.com/NixOS/nixpkgs/commit/dd9aa5d6c948fc9f6955d9d271e868beee773840) dolphin-emu: add aarch64-linux support
* [`faa599ce`](https://github.com/NixOS/nixpkgs/commit/faa599ced67936ce4746b549a8b6dde8af3e003c) springLobby: reformat
* [`0f8d48c3`](https://github.com/NixOS/nixpkgs/commit/0f8d48c3e9458d8534eba2817e8e826accbf2166) fluent-reader: init at 1.1.3
* [`5452a260`](https://github.com/NixOS/nixpkgs/commit/5452a260774ac78d71232896aa69734ed1e9607a) nixos/lvm: replace boot.isContainer with services.lvm.enable
* [`4a7925fc`](https://github.com/NixOS/nixpkgs/commit/4a7925fcc4bf81e70ed3d4fe0ecc7bd0300c586d) lkrg: init at 0.9.5
* [`6917409e`](https://github.com/NixOS/nixpkgs/commit/6917409e3c4913bfd325c013b33cdb88d769085c) museeks: init at 0.13.1
* [`80bcd651`](https://github.com/NixOS/nixpkgs/commit/80bcd651fbd459f2e0909870ee5ba1c1d5915237) feedbackd: 0.0.0+git20220520 -> 0.0.1
* [`58ae5c16`](https://github.com/NixOS/nixpkgs/commit/58ae5c163b8583620d825581f6b0afffbe7b203c) bkcrack: init at 1.5.0
* [`d46a8620`](https://github.com/NixOS/nixpkgs/commit/d46a86208ae62e3d3bfcce21a068dc88b84c58ed) drogon: 1.8.1 -> 1.8.2
* [`2cf7928b`](https://github.com/NixOS/nixpkgs/commit/2cf7928b262c66009b6b896f61caeb7b7c43c90c) mozart: add h7x4 as maintainer
* [`2bb2eec8`](https://github.com/NixOS/nixpkgs/commit/2bb2eec81373190a3f2de82aaa81beab3f08b649) flutter: add h7x4 as maintainer
* [`4d6d1884`](https://github.com/NixOS/nixpkgs/commit/4d6d188495c2bafe0ac0b609158b063a723a1ba5) swtpm: 0.7.3 -> 0.8.0
* [`ba3f3b73`](https://github.com/NixOS/nixpkgs/commit/ba3f3b73ad1a4ef881936ee0a3ebb3e745d2760a) sqlite3-to-mysql: init at 1.4.16
* [`ee8ae2da`](https://github.com/NixOS/nixpkgs/commit/ee8ae2da4c3fe46c5aa40a80185861db9d45ba5c) nixos/doc: fix installing from other distro
* [`36a566b7`](https://github.com/NixOS/nixpkgs/commit/36a566b78fe4904913c1c8d16e75da1a7aa6eadb) lib/systems/parse.nix: mkSkeletonFromList: improve readability
* [`f88afab6`](https://github.com/NixOS/nixpkgs/commit/f88afab66348db57290e953a8d7c9a84b7d2d8af) pulumiPackages.pulumi-azure-native: 1.81.0 -> 1.85.0
* [`b8867a1b`](https://github.com/NixOS/nixpkgs/commit/b8867a1b2ee088966706caa924bf72467f1820e9) fluentd: 1.14.3 -> 1.15.3
* [`78c09ae1`](https://github.com/NixOS/nixpkgs/commit/78c09ae1423b4fc663d35874d61307ecfcd13d24) python310Packages.sgp4: remove tox
* [`b1a9d5fe`](https://github.com/NixOS/nixpkgs/commit/b1a9d5fefc0d647de19f6799719cc3c6e4872352) python310Packages.textwrap3: cleanup checkInputs
* [`a9db54b7`](https://github.com/NixOS/nixpkgs/commit/a9db54b790ad3f0631c618db02084bfb346d7661) hyprland, hyprpaper: fix build on aarch64-linux
* [`cb9fc545`](https://github.com/NixOS/nixpkgs/commit/cb9fc54533c0f45a8e2f8950399868bcc4a5e3a0) libsForQt5.juk: init at 22.08.3
* [`84f5df93`](https://github.com/NixOS/nixpkgs/commit/84f5df939ec76c496147313e61f7ee4935a13059) new-lg4ff: 0.3.3 -> 0.4.0
* [`339f7258`](https://github.com/NixOS/nixpkgs/commit/339f72586a39bbffb5b149bd5367d971349796a4) giac: 1.9.0-5 -> 1.9.0-29
* [`e872c300`](https://github.com/NixOS/nixpkgs/commit/e872c30015a6427a6d5e926889616ec3644cfcf4) linuxPackages.nvidia_x11_vulkan_beta: 515.49.24 -> 515.49.25
* [`c2cf2b76`](https://github.com/NixOS/nixpkgs/commit/c2cf2b76ff7d8b1d5c9d3aa06bd504df75372807) briar-desktop: 0.2.1-beta -> 0.3.1-beta
* [`d9d2e34c`](https://github.com/NixOS/nixpkgs/commit/d9d2e34c5b2cdafb6cf63510ab2fdd7da5483b81) python310Packages.python-bsblan: 0.5.7 -> 0.5.8
* [`31531c74`](https://github.com/NixOS/nixpkgs/commit/31531c747a964adb678d732035a15a5ef2eef8c2) linux: cleanup common-config after drop of 4.9
* [`5502cf64`](https://github.com/NixOS/nixpkgs/commit/5502cf6441fa85f6f392e1c23e39142ce7c37cdf) netease-music-tui: 0.1.4 -> 0.1.5
* [`8847df6a`](https://github.com/NixOS/nixpkgs/commit/8847df6a9a60f9d7789b2a7f6dde6fd292d4b823) netease-music-tui: unpin to openssl_1_1
* [`330c9ce3`](https://github.com/NixOS/nixpkgs/commit/330c9ce3723b08f0209e57f0ce88f163f70b9cc6) simple-http-server: unpin to openssl_1_1
* [`30a62610`](https://github.com/NixOS/nixpkgs/commit/30a62610d513f3186d46627f94ef86ad78f7785b) istioctl: 1.15.3 -> 1.16.0
* [`92f1bc47`](https://github.com/NixOS/nixpkgs/commit/92f1bc4787e7e3fde95c9688d728dfe4fd113cce) python310Packages.smbprotocol: 1.9.0 -> 1.10.0
* [`e6ab90e1`](https://github.com/NixOS/nixpkgs/commit/e6ab90e164f17d68b6550f7f81bfd14d3db430e1) python310Packages.smbprotocol: 1.10.0 -> 1.10.1
* [`51119b87`](https://github.com/NixOS/nixpkgs/commit/51119b8759e18fc6bf2ecfab16120d90fa156d4a) minio-client: 2022-11-07T23-47-39Z -> 2022-11-17T21-20-39Z
* [`7a31c71e`](https://github.com/NixOS/nixpkgs/commit/7a31c71ee50d43a51037801a0ba3ae1c410db459) gomuks: 0.2.4 -> 0.3.0
* [`fafbbb3c`](https://github.com/NixOS/nixpkgs/commit/fafbbb3c08a0770b9e5390b234010f772e204a79) gammastep: 2.0.8 -> 2.0.9
* [`2beff937`](https://github.com/NixOS/nixpkgs/commit/2beff9375cda53f2ab42844eb85d9c60175f3434) nixos/picom: add `egl` backend to options
* [`7295e4a7`](https://github.com/NixOS/nixpkgs/commit/7295e4a728a8c1934981795a461b95ddc94ef2f2) lerc: 3.0 -> 4.0.0
* [`b9a8eae2`](https://github.com/NixOS/nixpkgs/commit/b9a8eae2a4068c05c253508e2063fd0d3d193311) teamviewer: remove qtwebkit
* [`f7835037`](https://github.com/NixOS/nixpkgs/commit/f7835037da3c9827b1e1938556d67f0fd3821334) python310Packages.smbprotocol: add changelog to meta
* [`949caf33`](https://github.com/NixOS/nixpkgs/commit/949caf335a7f65c862c6becf49580aba0b2bad95) libime: 1.0.14 -> 1.0.15
* [`ce20988c`](https://github.com/NixOS/nixpkgs/commit/ce20988c647fcd6d1dd49eb06b075849e932474b) xcb-imdkit: 1.0.3 -> 1.0.4
* [`f160eff8`](https://github.com/NixOS/nixpkgs/commit/f160eff8e7761c69e0e3a5fac77f81a5d463869c) libnvme: fix cross compiling
* [`50f24d3b`](https://github.com/NixOS/nixpkgs/commit/50f24d3b9798d7e063df4d2a8178b88b3a9635c0) gdal: 3.5.2 -> 3.6.0.1
* [`4a1f0598`](https://github.com/NixOS/nixpkgs/commit/4a1f0598b26907a445d9facc36b3a795072fa664) python310Packages.fiona: disable failing test
* [`3cb8af38`](https://github.com/NixOS/nixpkgs/commit/3cb8af381c45b7cf36d7c081bb2ffe9a6c6ce39c) nodePackages.pnpm: 7.14.2 -> 7.17.0
* [`b710efb0`](https://github.com/NixOS/nixpkgs/commit/b710efb0cd10576a3afd495bb943ffd8f17de391) bob: 0.7.0 -> 0.7.1
* [`54aa1856`](https://github.com/NixOS/nixpkgs/commit/54aa1856e224d0d603a58a7f8897d62cd921ffdc) python310Packages.peaqevcore: 7.4.0 -> 8.0.2
* [`74bd116d`](https://github.com/NixOS/nixpkgs/commit/74bd116d60568988a8b5084c9a37aafa4db783c2) grpc: 1.50.0 -> 1.51.0
* [`70c8641f`](https://github.com/NixOS/nixpkgs/commit/70c8641f6a59bc3aa62f5b68c6da5fd0fcf4bd9e) python310Packages.grpcio-status: 1.50.0 -> 1.51.0
* [`2b778dbd`](https://github.com/NixOS/nixpkgs/commit/2b778dbd81451983146e102e5d0528d4c5bde3ad) shadowenv: 2.0.6 -> 2.1.0
* [`e8ef6a4e`](https://github.com/NixOS/nixpkgs/commit/e8ef6a4eb6baecbd90f29f577c49831f94798129) postgresqlPackages.postgis: 3.3.1 -> 3.3.2
* [`55d1f5ea`](https://github.com/NixOS/nixpkgs/commit/55d1f5ea3c446ac6d022182449ac814b96f7e1ef) brakeman: 5.3.1 -> 5.4.0
* [`28e61b50`](https://github.com/NixOS/nixpkgs/commit/28e61b5057b86cb3731254a0d99349b40dda46d1) python310Packages.grpcio-tools: 1.50.0 -> 1.51.0
* [`f072ce13`](https://github.com/NixOS/nixpkgs/commit/f072ce1373104ba695baeab1aa8f91f5219991eb) _3270font: 2.3.1 -> 3.0.1
* [`53c31d03`](https://github.com/NixOS/nixpkgs/commit/53c31d03d55dad7d00c25b5c2fcf9fbb75ffedb8) scdoc: fix cross compilation by setting HOST_SCDOC
* [`f8eea402`](https://github.com/NixOS/nixpkgs/commit/f8eea402836c5f7f538b2b380c977503873b306a) cfitsio: 4.1.0 -> 4.2.0
* [`1bff5de9`](https://github.com/NixOS/nixpkgs/commit/1bff5de944494e32885961fade67e93d4a40624e) python310Packages.h5py: remove unittest2 and six
* [`a793a1aa`](https://github.com/NixOS/nixpkgs/commit/a793a1aa45ad42d4fac3bbb798362b6ef9523161) todoist-electron: 1.0.3 -> 1.0.9
* [`cbe0fcda`](https://github.com/NixOS/nixpkgs/commit/cbe0fcda8db9032524f8f4b5763ba66471464489) python310Packages.robotsuite: remove unittest2
* [`66b3fa29`](https://github.com/NixOS/nixpkgs/commit/66b3fa296d1292fb145c1287e5a7539e2260ae5d) bzflag: 2.4.24 -> 2.4.26
* [`4f184818`](https://github.com/NixOS/nixpkgs/commit/4f18481878be17e7b6d65b31810c988ecb13ab5a) harmonist: use buildGoModule
* [`384293bb`](https://github.com/NixOS/nixpkgs/commit/384293bbbb59b8af9ad24c50bb108d792c6ca38f) nixos/alps: fixes for service hardening
* [`3520a6df`](https://github.com/NixOS/nixpkgs/commit/3520a6df8fb34dd01e4e70f87bf4a1f500daef53) python310Packages.imap-tools: 0.57.0 -> 1.0.0
* [`733dee4f`](https://github.com/NixOS/nixpkgs/commit/733dee4f84cc4df22cadb365262cce3f78bf8f70) python310Packages.aiomusiccast: 0.14.5 -> 0.14.6
* [`7274df35`](https://github.com/NixOS/nixpkgs/commit/7274df353c0e98c4cfb2e72daa51c87eb2c3cda8) nixos/tests/acme/server: patch certificate generation for longer validity
* [`57abd8c1`](https://github.com/NixOS/nixpkgs/commit/57abd8c1cff97e2a05609f32700c687a29b89a8a) nixos/tests/acme/server: generate certs with longer validity
* [`00519772`](https://github.com/NixOS/nixpkgs/commit/005197727bd4987e6cd1fd3f27e20bb693fb7074) cargo-llvm-lines: 0.4.20 -> 0.4.21
* [`a2387066`](https://github.com/NixOS/nixpkgs/commit/a238706683907dbd009f1ebf5788e13508db77ea) retroarchBare: 1.12.0 -> 1.13.0
* [`3fbd8b76`](https://github.com/NixOS/nixpkgs/commit/3fbd8b76110b587cd04678e3f43b83b40dda7ce7) libretro-core-info: 1.12.0 -> 1.13.0
* [`4eb8ee1f`](https://github.com/NixOS/nixpkgs/commit/4eb8ee1f9ee4a8140b97e89982baadce51829484) erosmb: 0.1.2 -> 0.1.4
* [`36a7a78e`](https://github.com/NixOS/nixpkgs/commit/36a7a78ed5d70ed9f6db541048b7ed0ddf3810c1) tut: 1.0.17 -> 1.0.19
* [`c7f5becb`](https://github.com/NixOS/nixpkgs/commit/c7f5becba357f9dd8480ab635a07d106024dc6a6) dbus: remove unused daemon passhtru
* [`9fc764a0`](https://github.com/NixOS/nixpkgs/commit/9fc764a0bb370f58964d0735cd527fb5c2a60225) toot: 0.28.0 -> 0.29.0
* [`29624484`](https://github.com/NixOS/nixpkgs/commit/296244844a362590f089ea4746df96979369d49d) clib: 2.8.1 -> 2.8.2
* [`88026925`](https://github.com/NixOS/nixpkgs/commit/88026925377e682708e7edb439bbac3c05c1c492) usql: 0.12.13 -> 0.13.1
* [`6492d646`](https://github.com/NixOS/nixpkgs/commit/6492d64628390ea421829b15e6f19626657df01d) chromiumDev: 109.0.5410.0 -> 109.0.5414.10
* [`f904a646`](https://github.com/NixOS/nixpkgs/commit/f904a646c3f85147ef48e70a8d241cbf7a1b1a69) do-agent: 3.13.1 -> 3.14.1
* [`b7d37b2f`](https://github.com/NixOS/nixpkgs/commit/b7d37b2f12b108a1002f77a41a11227a932d36d8) klipper: unstable-2022-11-03 -> unstable-2022-11-21
* [`1e6a2cfa`](https://github.com/NixOS/nixpkgs/commit/1e6a2cfaa041216fa29accece7ab30b9d62c59ee) ghostunnel: 1.7.0 -> 1.7.1
* [`efb156bf`](https://github.com/NixOS/nixpkgs/commit/efb156bf9a63732e75f3f908ecfee95b21d264b9) ginkgo: 2.5.0 -> 2.5.1
* [`b96679c3`](https://github.com/NixOS/nixpkgs/commit/b96679c3e9dd7ca72b67a7ac702f0d91814352dc) python310Packages.arcam-fmj: 0.12.0 -> 1.0.1
* [`63a66fc2`](https://github.com/NixOS/nixpkgs/commit/63a66fc2ff036710a4b4bbf3511e69a09fcbb6f6) esbuild_netlify: 0.13.6 -> 0.14.39
* [`ae83b9c7`](https://github.com/NixOS/nixpkgs/commit/ae83b9c7c656f4556ff2af3115d13aa90742d527) netlify-cli: 6.13.2 -> 12.2.4
* [`03f2f6b9`](https://github.com/NixOS/nixpkgs/commit/03f2f6b9c458431ee114ba8b8b1b0f3b3439cb9d) wezterm: 20220905-102802-7d4b8249 -> 20221119-145034-49b9839f
* [`b04fe397`](https://github.com/NixOS/nixpkgs/commit/b04fe397c6183f4749d4d8d0f853179051808bee) esbuild_netlify: fix trailing space in esbuild_netlify
* [`669067ed`](https://github.com/NixOS/nixpkgs/commit/669067ed047e1a1f5c1ee7f17f4055e7b1d3c99d) netlify-cli: update release note for updating netlify-cli
* [`5d5f5a7c`](https://github.com/NixOS/nixpkgs/commit/5d5f5a7c2160e7a6ba14b54027ee25c511d08aa1) python310Packages.PyChromecast: 12.1.4 -> 13.0.1
* [`e28ee8bb`](https://github.com/NixOS/nixpkgs/commit/e28ee8bb32b2407053d63cefc495ce7d1bab81bc) xpaste: 1.5 -> 1.6
* [`909afd71`](https://github.com/NixOS/nixpkgs/commit/909afd71f8f0893b3250e99daa2ac91e456dbe30) python310Packages.adafruit-platformdetect: 3.33.0 -> 3.34.0
* [`2d6a6457`](https://github.com/NixOS/nixpkgs/commit/2d6a645776d29db49d2b6ebfdb779dc7708e88b9) pgadmin4: 6.15 -> 6.16
* [`57f2bb49`](https://github.com/NixOS/nixpkgs/commit/57f2bb494d81f4d43441cbadc78fc8747225478d) i2pd: 2.43.0 -> 2.44.0
* [`b42d97f5`](https://github.com/NixOS/nixpkgs/commit/b42d97f572ed427bb420652015378541164e18dd) emacs: build pgtk variant with full image support
* [`7aac181e`](https://github.com/NixOS/nixpkgs/commit/7aac181e81b904943709a609e2d6725c2b1367ad) cargo-lambda: 0.11.3 -> 0.12.0
* [`847e77dd`](https://github.com/NixOS/nixpkgs/commit/847e77dd2bbb539454d97fbd4d267bb6f48293ea) ferretdb: 0.6.1 -> 0.6.2
* [`8e3c88f6`](https://github.com/NixOS/nixpkgs/commit/8e3c88f66e670528efd699a859ce4579f0f6a691) pocketbase: 0.7.10 -> 0.8.0
* [`766cc473`](https://github.com/NixOS/nixpkgs/commit/766cc473f7a92163617808190da869357f89f6ce) ikill: 1.5.0 -> 1.6.0
* [`200d629a`](https://github.com/NixOS/nixpkgs/commit/200d629ac694d5a4db5d3800e0291ee639a3cbc0) kubelogin-oidc: 1.25.3 -> 1.25.4
* [`287131c4`](https://github.com/NixOS/nixpkgs/commit/287131c409bcb8fb53c401ed028815c3e20b6b39) ocamlPackages.phylogenetics: run full test suite
* [`c6980427`](https://github.com/NixOS/nixpkgs/commit/c6980427cececbfec6754e3edb618573f9b70da2) zotero: 6.0.16 -> 6.0.18
* [`152ed82e`](https://github.com/NixOS/nixpkgs/commit/152ed82e8f880d732565d63634d7333e48eb7a83) xwayland: 22.1.3 -> 22.1.5
* [`de6c1202`](https://github.com/NixOS/nixpkgs/commit/de6c1202d079b110412b5194997d15395ddf52f9) rocksdb: use SSE 4.2 only when supported
* [`a5f162fb`](https://github.com/NixOS/nixpkgs/commit/a5f162fb93f5e0bdf7737eebc96e298da4574357) python310Packages.bellows: 0.34.3 -> 0.34.4
* [`deca1167`](https://github.com/NixOS/nixpkgs/commit/deca1167154bacb009e819beb7a52960283c6036) python310Packages.broadlink: 0.18.2 -> 0.18.3
* [`29b20985`](https://github.com/NixOS/nixpkgs/commit/29b2098551a1ce45495d7be949ffd77e0e7ed667) samba: explicitly enable libunwind ([nixos/nixpkgs⁠#201875](https://togithub.com/nixos/nixpkgs/issues/201875))
* [`9778ba41`](https://github.com/NixOS/nixpkgs/commit/9778ba41fdcdfc3a45b8eb00aaeae5d576489a6e) python310Packages.cherrypy: fix url
* [`50934990`](https://github.com/NixOS/nixpkgs/commit/509349900629c455c84d79f3dbadf7580ab3e934) python310Packages.debian: 0.1.48 -> 0.1.49
* [`5c3f27d2`](https://github.com/NixOS/nixpkgs/commit/5c3f27d2d9493655df5137e1e809d699d587115e) python310Packages.deezer-python: 5.7.0 -> 5.8.0
* [`bbc89727`](https://github.com/NixOS/nixpkgs/commit/bbc897272f4fdef7f9649594b45738b91bc4bd42) cemu: 2.0-13 -> 2.0-17 ([nixos/nixpkgs⁠#201077](https://togithub.com/nixos/nixpkgs/issues/201077))
* [`6b3271eb`](https://github.com/NixOS/nixpkgs/commit/6b3271ebeed4aa5b371286437e6a95010fb66666) martin: 0.5.0 → 0.6.1
* [`9735765d`](https://github.com/NixOS/nixpkgs/commit/9735765d9dadce98ce64c6185b03cad10e0f56e9) limesctl: 3.0.3 -> 3.1.1
* [`5b9b6dee`](https://github.com/NixOS/nixpkgs/commit/5b9b6dee86550b483ac4af6c31cd1b935db85858) seahub: fix build
* [`61e288ec`](https://github.com/NixOS/nixpkgs/commit/61e288ecd750b7677e79d6bdb64e931be80961b7) python310Packages.django-maintenance-mode: 0.16.3 -> 0.17.1
* [`17d22b5e`](https://github.com/NixOS/nixpkgs/commit/17d22b5ea55929ca8bdf0f1bac359fc868ea5919) typos: 1.11.1 -> 1.13.0
* [`e9fed0ca`](https://github.com/NixOS/nixpkgs/commit/e9fed0cae10863d3a03b85941cba98c71cc453ed) liquid-dsp: 1.4.0 -> 1.5.0
* [`6ac16c26`](https://github.com/NixOS/nixpkgs/commit/6ac16c2697031fab70705c0bab3a2bed67014fa0) matrix-synapse: 1.71.0 -> 1.72.0
* [`f6b4b52a`](https://github.com/NixOS/nixpkgs/commit/f6b4b52a17e47707e9ab6b252c50b663781f34c1) autojump: fixup python shebang after cross fix
* [`dd5ba982`](https://github.com/NixOS/nixpkgs/commit/dd5ba982a6c93eeb5a761b5c5e7f874d15bd963f) python3Packages.plum-py: 0.4.0 -> 0.8.5
* [`2b0b18b1`](https://github.com/NixOS/nixpkgs/commit/2b0b18b1703e50b97f68d45938eab7d32304ea9f) python3Packages.exif: 1.2.0 -> 1.3.5
* [`76a4adc1`](https://github.com/NixOS/nixpkgs/commit/76a4adc19c3febde1ca3aa6ec031446cba925d16) makeImpureTest: init function for hardware tests
* [`fded5825`](https://github.com/NixOS/nixpkgs/commit/fded5825fde7f0454fe2ec192c147307795c5c27) rocm-opencl-icd: add nixos test
* [`3ac01325`](https://github.com/NixOS/nixpkgs/commit/3ac01325a6f46fcf81ea71321e8b70795b12665b) amdvlk: add nixos test
* [`f0e298c0`](https://github.com/NixOS/nixpkgs/commit/f0e298c00272d745fba42be2c6e782cd2aa64444) Revert "lib/trivial: fix 'error: cannot decode virtual path '/nix/store/virtual0000000000000000000000005-source''"
* [`7e88b2be`](https://github.com/NixOS/nixpkgs/commit/7e88b2bef5bf969baac40b3847cdc7c0e8089d97) form: 4.2.1 -> 4.3.0
* [`eb11b252`](https://github.com/NixOS/nixpkgs/commit/eb11b252089789ba01013954ff75fda3f5726e22) ghostunnel: add changelog to meta
* [`b23f6b12`](https://github.com/NixOS/nixpkgs/commit/b23f6b129e6db8f2fe16a65041e13660f6be204b) python310Packages.arcam-fmj: add changelog to meta
* [`f01bcf0b`](https://github.com/NixOS/nixpkgs/commit/f01bcf0b88cbd9ff2096cd1a141b6195cfc2000d) python310Packages.PyChromecast: add changelog to meta
* [`03c92f54`](https://github.com/NixOS/nixpkgs/commit/03c92f54a4e10feb5a13d8ff1730e00c2d04f1b8) python310Packages.adafruit-platformdetect: add changelog to meta
* [`dbde15a5`](https://github.com/NixOS/nixpkgs/commit/dbde15a513603821875b40e1f848d88c6f5f92d4) python310Packages.broadlink: add changelog to meta
* [`62f4c61a`](https://github.com/NixOS/nixpkgs/commit/62f4c61a1fbb73bd06b1dbe83f51f791ead70a93) python310Packages.django-maintenance-mode: add changelog to meta
* [`221f5245`](https://github.com/NixOS/nixpkgs/commit/221f524563b9d3215e895fbd85c6c6300b97a734) python310Packages.aiomusiccast: add changelog to meta
* [`ee2c00a0`](https://github.com/NixOS/nixpkgs/commit/ee2c00a01de055767fffd51b8b27e46b22980e48) python310Packages.deezer-python: add changelog to meta
* [`0ea13cc6`](https://github.com/NixOS/nixpkgs/commit/0ea13cc6ca439da8c18d4e09abcc3694a781ecb8) python310Packages.django-maintenance-mode: fix lint issue
* [`5fcd9011`](https://github.com/NixOS/nixpkgs/commit/5fcd9011b95bc52bc4689af05f62370bf9cbf3f8) pip-audit: add changelog to meta
* [`7478ccb1`](https://github.com/NixOS/nixpkgs/commit/7478ccb19310121a97245c7c1ba5b95a5351b6c5) pip-audit: 2.4.5 -> 2.4.6
* [`700aa487`](https://github.com/NixOS/nixpkgs/commit/700aa487d5714c6098e7ec2974a679ebbcd7e4a2) miniplayer: 1.7.1 -> 1.7.3
* [`20ba511c`](https://github.com/NixOS/nixpkgs/commit/20ba511c986b17c9641bff5843c7bf639d704409) python310Packages.fastapi-mail: add changelog to meta
* [`f7857b2a`](https://github.com/NixOS/nixpkgs/commit/f7857b2acca7416992b5e5eeb91d9c9de5cfc26c) python310Packages.fastapi-mail: 1.2.0 -> 1.2.1
* [`1c416b8c`](https://github.com/NixOS/nixpkgs/commit/1c416b8ce3d01786b88eba0399eb0d2dcd536d9f) python310Packages.teslajsonpy: 3.2.0 -> 3.2.2
* [`433ba342`](https://github.com/NixOS/nixpkgs/commit/433ba342ee7f86bd7c928861aca091460d4c9590) moq: 0.2.7 -> 0.3.0
* [`85681df5`](https://github.com/NixOS/nixpkgs/commit/85681df5522c04ef6d1d4d50d0f07b2d4fe30adf) cinnamon.warpinator: 1.2.14 -> 1.2.15
* [`da31e2c1`](https://github.com/NixOS/nixpkgs/commit/da31e2c1b725de78d5fcf4125962e595ce4e3b16) typeshare: init at 1.0.0
* [`1ca3d39a`](https://github.com/NixOS/nixpkgs/commit/1ca3d39a10a8ac55d303f66c9e45cf1727ec311a) nanomq: 0.13.0 -> 0.13.1
* [`2a65c2a4`](https://github.com/NixOS/nixpkgs/commit/2a65c2a491126cf714779d8e3cf0ee47f457f013) nix-direnv: 2.1.2 -> 2.2.0
* [`d9441f4c`](https://github.com/NixOS/nixpkgs/commit/d9441f4cd556c15bff123ed4c1df59bd381f24c4) nmap-formatter: 2.0.1 -> 2.0.2
* [`82fe76d1`](https://github.com/NixOS/nixpkgs/commit/82fe76d1cd0ff6607c4c6383fb9620f6615a84a0) carnix,cratesIO: remove
* [`35b95aab`](https://github.com/NixOS/nixpkgs/commit/35b95aab695de9a221339e72b3c5847ed617f716) oh-my-posh: 12.16.0 -> 12.17.2
* [`d7c8595f`](https://github.com/NixOS/nixpkgs/commit/d7c8595f622939bdbd70e1aaf3989cdb21f3d764) muscle: 3.8.31 -> 5.1.0
* [`35d3a6fa`](https://github.com/NixOS/nixpkgs/commit/35d3a6fa79a1a7bee909db00734392a0d657d817) muscle: add myself to maintainers
* [`e98c6622`](https://github.com/NixOS/nixpkgs/commit/e98c66220b35f566de51815f4d83bf808f61426e) yggdrasil: 0.4.6 -> 0.4.7
* [`694cd662`](https://github.com/NixOS/nixpkgs/commit/694cd66276770dd067d3160b4147ef78d3647f27) honeycomb-refinery: init at 1.19.0 ([nixos/nixpkgs⁠#200424](https://togithub.com/nixos/nixpkgs/issues/200424))
* [`5ca57377`](https://github.com/NixOS/nixpkgs/commit/5ca573772c30154f5c912edfd51951aa811fa34f) filtron: converted to goPackage.
* [`0582bcd3`](https://github.com/NixOS/nixpkgs/commit/0582bcd382067102617c38438253af7ba3e1882d) python310Packages.generic: 1.1.0 -> 1.1.1
* [`541aa8dc`](https://github.com/NixOS/nixpkgs/commit/541aa8dcd24c1fdce5aea628c2e215696b991ebc) kubelogin: 0.0.23 -> 0.0.24
* [`cdcb7946`](https://github.com/NixOS/nixpkgs/commit/cdcb7946baf70b37b81c3579e0827d9138142502) veryfasttree: init at 3.1.1
* [`d02af660`](https://github.com/NixOS/nixpkgs/commit/d02af66091e3233af01a2d6184ca5b47f7d7e726) nixos/alps: fix for Hydra failure
* [`471d8bb0`](https://github.com/NixOS/nixpkgs/commit/471d8bb07a167e502ca8fa60b5027742e2adb63c) opensmt: 2.4.2 -> 2.4.3
* [`7ee71825`](https://github.com/NixOS/nixpkgs/commit/7ee71825071e8a370698f68a68ac743742213c69) libretro: unstable-2022-10-18 -> unstable-2022-11-21
* [`78162b12`](https://github.com/NixOS/nixpkgs/commit/78162b12ca39b075fa35c2bbd1757f50d0d5f4e1) opentelemetry-collector-contrib: 0.64.0 -> 0.65.0
* [`ca063690`](https://github.com/NixOS/nixpkgs/commit/ca063690208864c0b7ba9fc8c04f607f81cd65c5) yubioath-desktop: drop as has been replaced by upstream
* [`81f5aad3`](https://github.com/NixOS/nixpkgs/commit/81f5aad3e4532e36c856eb5e3a52146376a2297e) factorio: 1.1.70 -> 1.1.72
* [`bc4b3e28`](https://github.com/NixOS/nixpkgs/commit/bc4b3e28515da502b073426398176d0a1c22ebbf) python310Packages.pysnmplib: add changelog to meta
* [`791238f1`](https://github.com/NixOS/nixpkgs/commit/791238f17fa4b1c0f0ebb76127ae75792012e97a) python310Packages.pysnmplib: 5.0.19 -> 5.0.20
* [`ee53f65f`](https://github.com/NixOS/nixpkgs/commit/ee53f65f0598a7e721c71ff2e34da591241a3629) nmap-formatter: add changelog to meta
* [`b6bc6d08`](https://github.com/NixOS/nixpkgs/commit/b6bc6d08d0a9943cdc27228e9e59124dca97c333) pgbackrest: 2.41 -> 2.42
* [`1b08e4e3`](https://github.com/NixOS/nixpkgs/commit/1b08e4e353d4386fde04d232ed4c2adc25ba0684) erosmb: add changelog to meta
* [`76d23c8a`](https://github.com/NixOS/nixpkgs/commit/76d23c8a5f6edfe673532a72d4b69dc495a4540e) python310Packages.xknx: add changelog to meta
* [`1e91f3fe`](https://github.com/NixOS/nixpkgs/commit/1e91f3feee908f94f04555feee3dbe91820820d4) nvme-cli: fix cross compiling
* [`e0e86de3`](https://github.com/NixOS/nixpkgs/commit/e0e86de33fd671db6e589783babfe25829345333) plantuml-server: 1.2022.12 -> 1.2022.13
* [`00d4e145`](https://github.com/NixOS/nixpkgs/commit/00d4e1453322d22e382a84b4918456789f178cb8) python310Packages.slack-sdk: add changelog to meta
* [`eb8e4765`](https://github.com/NixOS/nixpkgs/commit/eb8e476531a722a378d296c96048184a64257744) python310Packages.slack-sdk: 3.19.3 -> 3.19.4
* [`48026590`](https://github.com/NixOS/nixpkgs/commit/48026590202f3b79e4b66909a2d16ab1778e3fad) sub-batch: 1.0.0 -> 1.0.1
* [`b44ad252`](https://github.com/NixOS/nixpkgs/commit/b44ad252a54bb1bbeb803bac798e488c3b2feb27) python310Packages.pycmarkgfm: 1.1.0 -> 1.2.0
* [`3296a4be`](https://github.com/NixOS/nixpkgs/commit/3296a4be033fcc9632973e0aee496cbf08c236f5) python310Packages.pycmarkgfm: add format attribute
* [`7a62174d`](https://github.com/NixOS/nixpkgs/commit/7a62174dc21ba7538856a00a095eccd575f9694d) python310Packages.pycmarkgfm: add changelog to meta
* [`a7d485a2`](https://github.com/NixOS/nixpkgs/commit/a7d485a21d650dd6ae94b521769374723d9ee19a) talosctl: 1.2.6 -> 1.2.7
* [`7430ccc8`](https://github.com/NixOS/nixpkgs/commit/7430ccc824d9a248fa76f21485e0460c5a9b2172) signalbackup-tools: 20221025 -> 20221122
* [`3fcd17d1`](https://github.com/NixOS/nixpkgs/commit/3fcd17d197ebcbc3ee0003a931516e167fc205be) signalbackup-tools: use new `--config` option in build script
* [`ece6f129`](https://github.com/NixOS/nixpkgs/commit/ece6f129b26dcd60546a235033772e53b94a24c8) python310Packages.googlemaps: 4.7.0 -> 4.7.3
* [`b5570921`](https://github.com/NixOS/nixpkgs/commit/b557092159d3d37293aa6756dc8d44b569db93ba) python310Packages.pick: add changelog to meta
* [`e00bdab4`](https://github.com/NixOS/nixpkgs/commit/e00bdab42cdd4425cef1bdeb88bb952ab4481222) python310Packages.pick: 2.1.0 -> 2.2.0
* [`29384778`](https://github.com/NixOS/nixpkgs/commit/29384778fef15dc727f0a17e9ad3ba81723760c9) clusterctl: 1.2.5 -> 1.2.6
* [`7bc4b766`](https://github.com/NixOS/nixpkgs/commit/7bc4b7661a6938d3ae35d04fc05093e31e5c9597) picard: 2.8.3 -> 2.8.4
* [`ffcfa322`](https://github.com/NixOS/nixpkgs/commit/ffcfa322b902f7a333f03e1b6bd81ee36e3ce3c8) docker: add overrides options back
* [`ac458802`](https://github.com/NixOS/nixpkgs/commit/ac45880256276d93ce9ee22a70c6aa11d99f4edf) docker: remove with lib
* [`eb127e2e`](https://github.com/NixOS/nixpkgs/commit/eb127e2eadd853c85d28cf3c83b04e39db6c5e67) docker: move inherit into passthru
* [`41f6bb83`](https://github.com/NixOS/nixpkgs/commit/41f6bb837b2ffc7acc7a73f20d202778560f099d) python3Packages.ariadne: init at 0.16.1
* [`ab27a2c6`](https://github.com/NixOS/nixpkgs/commit/ab27a2c699032756c308616972da7da37728cbf5) ananicy-cpp: unstable-2021-10-13 -> 1.0.1
* [`22bee934`](https://github.com/NixOS/nixpkgs/commit/22bee934d07ff4d494492f2bd9747ef2c4928349) mitschemeX11: use xorg.* packages directly instead of xlibsWrapper indirection
* [`365c1a5a`](https://github.com/NixOS/nixpkgs/commit/365c1a5abbbbf49dd4bbf382d7c382e64ee29e40) maintainer-list.nix: sort
* [`b6320d0c`](https://github.com/NixOS/nixpkgs/commit/b6320d0c45b8ecdc4fc206975dff08b1f28cdabf) python310Packages.pymbolic: 2022.1 -> 2022.2
* [`9d9bb3b9`](https://github.com/NixOS/nixpkgs/commit/9d9bb3b9ae1ca2d62dd7583287edbc7f4246eab9) python310Packages.ntlm-auth: disable failing tests
* [`e599c2ae`](https://github.com/NixOS/nixpkgs/commit/e599c2ae330b2779a8c1700809383f950575ea77) python310Packages.httpx-socks: 0.7.4 -> 0.7.5
* [`5dc6218a`](https://github.com/NixOS/nixpkgs/commit/5dc6218a33588e009798169e56de7211fbf40ebb) searx: 1.0.0 -> 1.1.0
* [`9746690d`](https://github.com/NixOS/nixpkgs/commit/9746690d4a37ac926f3a1679d93eca5ad3c0daea) python310Packages.masky: init at 0.1.1
* [`58ae822d`](https://github.com/NixOS/nixpkgs/commit/58ae822d2471bc8836030f61d5d76687b217b9a2) python310Packages.junitparser: 1.4.1 -> 2.8.0 ([nixos/nixpkgs⁠#200443](https://togithub.com/nixos/nixpkgs/issues/200443))
* [`9161d4a8`](https://github.com/NixOS/nixpkgs/commit/9161d4a8fcc7588a06695d186d9558a1f92426bb) crackmapexec: 5.3.0 -> 5.4.0
* [`1f2f987b`](https://github.com/NixOS/nixpkgs/commit/1f2f987b51f1c7f8818b2f1782063a8b7b02f79d) python310Packages.httpx-socks: add changelog to meta
* [`30709c15`](https://github.com/NixOS/nixpkgs/commit/30709c1574ccf9bdb957241682ef11b029f24f37) pspg: 5.5.9 -> 5.5.12
* [`c2ab8369`](https://github.com/NixOS/nixpkgs/commit/c2ab8369fac82977f808878fcc9a3789b19f3d87) python310Packages.googlemaps: add changelog to meta
* [`7ef66a73`](https://github.com/NixOS/nixpkgs/commit/7ef66a7340d8ea62d93a054641ff4255b9b402fe) pods: 1.0.0-beta.7 -> 1.0.0-beta.8
* [`4800b30f`](https://github.com/NixOS/nixpkgs/commit/4800b30f39e1fa333e57cd74ff8daee07a8ef655) csdr: fix build on aarch64
* [`bf6a7fa5`](https://github.com/NixOS/nixpkgs/commit/bf6a7fa54c1d3ee5ce54471a71383e362fba6c8f) qpdf: 11.1.1 -> 11.2.0
* [`25b2efe9`](https://github.com/NixOS/nixpkgs/commit/25b2efe9dfc622db95d07ed11497abea2c42b737) cargo-llvm-lines: 0.4.21 -> 0.4.22
* [`3c95f2c9`](https://github.com/NixOS/nixpkgs/commit/3c95f2c96802eca4f32c685ac06d1e2c7a771a32) nomad_1_2: 1.2.14 -> 1.2.15
* [`cfd38d7a`](https://github.com/NixOS/nixpkgs/commit/cfd38d7a561a849a1c88f514c658dcfe8c947bb9) nomad_1_3: 1.3.7 -> 1.3.8
* [`40c825f8`](https://github.com/NixOS/nixpkgs/commit/40c825f840531d0e601f27b61313f6e0f7ea9567) nomad_1_4: 1.4.2 -> 1.4.3
* [`b72a75e7`](https://github.com/NixOS/nixpkgs/commit/b72a75e7d7e68cfaf6a802d633797052920ab3cf) nomad: 1.3 -> 1.4
* [`87823cc8`](https://github.com/NixOS/nixpkgs/commit/87823cc82806658cf8babb8698d343886652a586) resvg: 0.25.0 -> 0.26.1
* [`a1ff1691`](https://github.com/NixOS/nixpkgs/commit/a1ff1691faf2dea10e288f566c308eece400744f) vimPlugins: update
* [`2273459f`](https://github.com/NixOS/nixpkgs/commit/2273459f982a1a24e85ba035ee8c66a20787bc48) vimPlugins.neoconf-nvim: init at 2022-11-22
* [`aeacc063`](https://github.com/NixOS/nixpkgs/commit/aeacc063c76049f8263885943566bb9aee228327) vimPlugins.nvim-treesitter: update grammars
* [`a9b8f8f2`](https://github.com/NixOS/nixpkgs/commit/a9b8f8f209a394238f218cd9b071a531ad12fdab) telegraf: 1.24.2 -> 1.24.3
* [`4cfd3541`](https://github.com/NixOS/nixpkgs/commit/4cfd35418295ad55cbf5f833b6da6c4314d2d46d) linux: fix unused option warnings on 5.x kernels
* [`d2b9c669`](https://github.com/NixOS/nixpkgs/commit/d2b9c6691ec4ec20774bc1bda66e3503d9fc181c) qtpbfimageplugin: build with qt6 too
* [`091e6d7c`](https://github.com/NixOS/nixpkgs/commit/091e6d7c69f3101501b91cecd35b0d200d9bd9f6) gpxsee: 11.6 -> 11.9
* [`dc7783ec`](https://github.com/NixOS/nixpkgs/commit/dc7783ece2224cc38b725551e903af65633fa6b3) qt6Packages.qttools: fix tool path
* [`5b8c42f9`](https://github.com/NixOS/nixpkgs/commit/5b8c42f98c59e748201a882ead093fe48efd6a75) nixos/lighthouse: add dataDirs to unit ReadWritePaths
* [`443f5eb9`](https://github.com/NixOS/nixpkgs/commit/443f5eb97f63017b37cf19916240c5f42ba5971b) python3Packages.monero: 1.0.1 -> 1.1.1
* [`247840af`](https://github.com/NixOS/nixpkgs/commit/247840af626f8b16216b1fa6408b53585dc30ce2) safety-cli: 2.3.1 -> 2.3.2
* [`d07d74ef`](https://github.com/NixOS/nixpkgs/commit/d07d74efee42b3ff4db429080a33fe764bd5758c) terraform-providers.dnsimple: 0.14.1 → 0.15.0
* [`326447b6`](https://github.com/NixOS/nixpkgs/commit/326447b6106a7e21183a10bac823b9f89589bc13) terraform-providers.cloudfoundry: 0.15.5 → 0.50.0
* [`3f7e939d`](https://github.com/NixOS/nixpkgs/commit/3f7e939dd95a711f79634d26caddeb27c7745cd4) terraform-providers.fastly: 3.0.0 → 3.0.1
* [`de92ad30`](https://github.com/NixOS/nixpkgs/commit/de92ad302d95f4a64a4feb023d5c8c435bae990b) terraform-providers.github: 5.9.0 → 5.9.1
* [`17ce3fff`](https://github.com/NixOS/nixpkgs/commit/17ce3fff32f5349739a5ec6d4cf95c45d1bc0211) terraform-providers.google: 4.44.0 → 4.44.1
* [`bebf9d49`](https://github.com/NixOS/nixpkgs/commit/bebf9d494c82ac1cc7aaf28b70c02602d2f4131b) terraform-providers.google-beta: 4.44.0 → 4.44.1
* [`97114c7a`](https://github.com/NixOS/nixpkgs/commit/97114c7ae07a77ededf2c64f2adbcd8f982ff6ad) terraform-providers.grafana: 1.30.0 → 1.31.1
* [`8aa683bf`](https://github.com/NixOS/nixpkgs/commit/8aa683bfafb1932ca1693897af84c669d8a79d2c) terraform-providers.okta: 3.38.0 → 3.39.0
* [`9e38073c`](https://github.com/NixOS/nixpkgs/commit/9e38073c85907616641456d8b82d34e5bc051eab) terraform-providers.ovh: 0.22.0 → 0.23.0
* [`7dd87915`](https://github.com/NixOS/nixpkgs/commit/7dd87915b4b9ddbd7e85108dff8d1afdff19fdc2) terraform-providers.scaleway: 2.6.0 → 2.7.1
* [`ed2c0adb`](https://github.com/NixOS/nixpkgs/commit/ed2c0adb45d63f73c943bf174e3d470ef49eba3b) comma: 1.3.0 -> 1.4.0
* [`ed537115`](https://github.com/NixOS/nixpkgs/commit/ed53711511d8e59da1f142338724243caafce79a) git-annex-remote-rclone: use stdenvNoCC
* [`1ef34b5a`](https://github.com/NixOS/nixpkgs/commit/1ef34b5ae875a9bbb81bb6e1f12703b7d20fca22) comma: use nix from environment
* [`c69d1a21`](https://github.com/NixOS/nixpkgs/commit/c69d1a21c6b24c0953c2886821f67c88a50256dd) git-annex-remote-rclone: update meta
* [`4607cb53`](https://github.com/NixOS/nixpkgs/commit/4607cb53b4bd796441020baab133e81c9a1b221e) zsv: 2022-11-12 -> 0.3.3-alpha
* [`eed26dd1`](https://github.com/NixOS/nixpkgs/commit/eed26dd1059b778dd463388f794413897d34b9e8) zuo: 2022-11-12 -> 2022-11-15
* [`727fcd40`](https://github.com/NixOS/nixpkgs/commit/727fcd407ed27025c4abd41fc2e264f7c68e9e83) postgresqlPackages.plpgsql_check: 2.2.3 -> 2.2.4
* [`a0a8d47f`](https://github.com/NixOS/nixpkgs/commit/a0a8d47f2cbc3aca20169f3319fb1582c208c220) python310Packages.patiencediff: 0.2.6 -> 0.2.8
* [`70158e0b`](https://github.com/NixOS/nixpkgs/commit/70158e0be06201707f855fc2cede524e5403905c) scdl: 2.7.2 -> 2.7.3
* [`81830797`](https://github.com/NixOS/nixpkgs/commit/8183079716e67518a8fc62f701f280924374bf67) comma: add marsam to maintainers
* [`764fb93f`](https://github.com/NixOS/nixpkgs/commit/764fb93f3746caa16ce21131c658d171671a446e) postgresqlPackages.pgvector: 0.3.0 -> 0.3.2
* [`c4c53595`](https://github.com/NixOS/nixpkgs/commit/c4c53595c4cebd22cb64d00fdf188e652f94bbfb) ocamlPackages.sexplib: 0.15.0 → 0.15.1
* [`a428c94a`](https://github.com/NixOS/nixpkgs/commit/a428c94ab6b78e8f500408c482cfff5c2ca6d41a) ocamlPackages.ppx_expect: 0.15.0 → 0.15.1
* [`c3ef258b`](https://github.com/NixOS/nixpkgs/commit/c3ef258b6ff7ce731625330f7815f8218e6c26d2) ocamlPackages.core: 0.15.0 → 0.15.1
* [`6a7cc8d5`](https://github.com/NixOS/nixpkgs/commit/6a7cc8d58779ebcfac2f1c4a4418b07725c06d05) snappymail: 2.21.3 -> 2.21.4
* [`f0261636`](https://github.com/NixOS/nixpkgs/commit/f02616368a84ae17448f4d0e14253ab562cfaabe) spicetify-cli: 2.14.1 -> 2.14.2
* [`6d48f87e`](https://github.com/NixOS/nixpkgs/commit/6d48f87ec36e77c92d4fd514e120f4ff423882c7) python310Packages.lxmf: 0.2.4 -> 0.2.5
* [`3d0df173`](https://github.com/NixOS/nixpkgs/commit/3d0df173b98031f0f50d75d2766cb388f015b80d) cargo-public-api: 0.23.0 -> 0.24.0
* [`c998cad4`](https://github.com/NixOS/nixpkgs/commit/c998cad49d07e8686a805a088a679ab15e0b0551) rocm-llvm: enable clang-tools-extra for clang-tidy
* [`4682f63a`](https://github.com/NixOS/nixpkgs/commit/4682f63a73d0e4666a65c0ec03dc62a58328cfac) maintainers: add deejayem
* [`3732d9e3`](https://github.com/NixOS/nixpkgs/commit/3732d9e3677395d094ed4c4480ab82333cc0e759) stochas: 1.3.5 -> 1.3.8
* [`7c81f8bc`](https://github.com/NixOS/nixpkgs/commit/7c81f8bc2acb4e4a8edfe211aef56582decaad49) syft: 0.62.0 -> 0.62.1
* [`639d8523`](https://github.com/NixOS/nixpkgs/commit/639d8523a99d451feb114188da83a2072901e3e4) plantuml: 1.2022.12 -> 1.2022.13
* [`ee7bc620`](https://github.com/NixOS/nixpkgs/commit/ee7bc6209d85445ae790c3ce7948338fc8b94e6d) taskwarrior-tui: 0.23.6 -> 0.23.7
* [`c94a435e`](https://github.com/NixOS/nixpkgs/commit/c94a435e943054ac740fef0c42cb863fb1c9d4d6) taskwarrior-tui: install completions and manpage
* [`798c76ea`](https://github.com/NixOS/nixpkgs/commit/798c76ea130ba0b348bcf9db6f6bb7c25d0d2f7f) python3Packages.autopep8: replace toml with tomli
* [`67a1a34e`](https://github.com/NixOS/nixpkgs/commit/67a1a34ed67bcf082c46bd03524c601b2f580330) python3Packages.python-lsp-server: Add undeclared but necessary optional dependency
* [`5ab18b18`](https://github.com/NixOS/nixpkgs/commit/5ab18b18ed158e2daf924b2a40fc91224804abd2) ocamlPackages.reactivedata: 0.2.2 → 0.3
* [`e16488c5`](https://github.com/NixOS/nixpkgs/commit/e16488c50eb2595aee5156d07b5f616b4f0b938c) itd: 0.0.9 -> 1.0.0
* [`74ad812b`](https://github.com/NixOS/nixpkgs/commit/74ad812b931aef32941c4823a04bf9e90f06fbc1) mkYarnPackage: fix meta
* [`7c8d7b8d`](https://github.com/NixOS/nixpkgs/commit/7c8d7b8d1c3387dbf04f12f73aac1254dd36e780) texlab: 4.3.1 -> 4.3.2
* [`2d8cbb5a`](https://github.com/NixOS/nixpkgs/commit/2d8cbb5a215d2b854280be74e2d18f669751668c) unifi7: 7.2.92 -> 7.2.95
* [`32c3417c`](https://github.com/NixOS/nixpkgs/commit/32c3417c0f06c2c116127d9866f5ab2192dc2f08) tile38: 1.29.1 -> 1.30.0
* [`501d684d`](https://github.com/NixOS/nixpkgs/commit/501d684de8fb70cac2e72eaaff0dcc94aa2af459) nixosTests/prosody: add timeout
* [`8040c468`](https://github.com/NixOS/nixpkgs/commit/8040c468ed9188c33fb851921327d9d9d6850f2c) nixosTests/prosody[-mysql]: fix tests TLS setup
* [`1297203f`](https://github.com/NixOS/nixpkgs/commit/1297203f6f91e74885c3ef47af6ddd6d5a458c27) exploitdb: 2022-11-12 -> 2022-11-22
* [`8f2f7589`](https://github.com/NixOS/nixpkgs/commit/8f2f7589a5702acb66b407a92141235a0fa3ed22) unciv: 4.2.20 -> 4.3.1
* [`6c534a48`](https://github.com/NixOS/nixpkgs/commit/6c534a48f46b6a6768cbc8547cf0d4989bdc3dbc) antimony: 2020-03-28 -> 2022-11-23
* [`4b36b3cd`](https://github.com/NixOS/nixpkgs/commit/4b36b3cd43a9d22ab83e1d76c22f36520a96268b) workflows/backport-action 0.0.8 -> 0.0.9
* [`1e99c150`](https://github.com/NixOS/nixpkgs/commit/1e99c15089f6563dc0d36cff0181fb2e24de0698) vale: 2.21.0 -> 2.21.1
* [`20c50761`](https://github.com/NixOS/nixpkgs/commit/20c5076170eb9e885fa8b656dcc2168f73783890) twitterBootstrap: 5.2.2 -> 5.2.3
* [`cb3339b8`](https://github.com/NixOS/nixpkgs/commit/cb3339b84287079adb8bb6f56d62f452c86d001f) python310Packages.autopep8: 1.7.1 -> 2.0.0
* [`c33ec106`](https://github.com/NixOS/nixpkgs/commit/c33ec106999b959c692a788c232f9f4bb12cf073) qownnotes: 22.11.5 -> 22.11.7
* [`de50b1dc`](https://github.com/NixOS/nixpkgs/commit/de50b1dc24cacd22db180f37b164e8e08e2f01af) wasmtime: 2.0.2 -> 3.0.0
* [`d7ab7262`](https://github.com/NixOS/nixpkgs/commit/d7ab72620d45cfff6b744fea7ab48305a1e67f22) fcitx5: 5.0.19 -> 5.0.20
* [`6b274039`](https://github.com/NixOS/nixpkgs/commit/6b2740393ea8247f0d3cf4a4634af5262b7f67d3) fcitx5-chewing: 5.0.12 -> 5.0.13
* [`a5dcd0fe`](https://github.com/NixOS/nixpkgs/commit/a5dcd0fe353188f41e94003822c8d6f1444fad70) fcitx5-chinese-addons: 5.0.15 -> 5.0.16
* [`1c1d6523`](https://github.com/NixOS/nixpkgs/commit/1c1d65231ec4b4ff1eaad8cc6977cb2ad66780c3) fcitx5-configtool: 5.0.15 -> 5.0.16
* [`48005968`](https://github.com/NixOS/nixpkgs/commit/48005968c770e6d12c451762d4594487ace94c91) fcitx5-gtk: 5.0.19 -> 5.0.20
* [`80df6e86`](https://github.com/NixOS/nixpkgs/commit/80df6e8613ca2e56e691e3e999e928f7dae80ac6) fcitx5-m17n: 5.0.10 -> 5.0.11
* [`e7f071f6`](https://github.com/NixOS/nixpkgs/commit/e7f071f699b62394e5d21e5e5c0b0ba5c75099c2) libsForQt5.fcitx5-qt: 5.0.15 -> 5.0.16
* [`599fd132`](https://github.com/NixOS/nixpkgs/commit/599fd132818687e4b88701d2e6f3ee05a97f3bbb) fcitx5-rime: 5.0.14 -> 5.0.15
* [`e2af29d9`](https://github.com/NixOS/nixpkgs/commit/e2af29d997dd547ba732246e1d686d5ac0f49174) fcitx5-table-extra: 5.0.11 -> 5.0.12
* [`d79ab83b`](https://github.com/NixOS/nixpkgs/commit/d79ab83bbca433c9c160de4e71d805f06e459a5c) fcitx5-unikey: 5.0.11 -> 5.0.12
* [`d0ebe6b8`](https://github.com/NixOS/nixpkgs/commit/d0ebe6b8763154152e7729e8f4fccb7c9fd064f9) jekyll: force ruby platform when updating dependencies
* [`a6e66052`](https://github.com/NixOS/nixpkgs/commit/a6e66052f28b2f6a7a45eb900ea848a0669cae83) wgetpaste: 2.32 -> 2.33
* [`962c8cba`](https://github.com/NixOS/nixpkgs/commit/962c8cba72d074a907f7739fd17f125421cb2112) tmux: enable utf8proc everywhere
* [`689f5904`](https://github.com/NixOS/nixpkgs/commit/689f5904888c41e28c78ff1d19d30484f450863c) subsurface: 5.0.2 -> 5.0.10 ([nixos/nixpkgs⁠#202145](https://togithub.com/nixos/nixpkgs/issues/202145))
* [`625e691a`](https://github.com/NixOS/nixpkgs/commit/625e691a67c3c699afefb497772e7669e67fd1e1) sayonara: build against latest Qt5
* [`c7ae87cf`](https://github.com/NixOS/nixpkgs/commit/c7ae87cfbf43a88c8a36e43b838af5c923eabd55) jekyll: update dependencies
* [`f5f27446`](https://github.com/NixOS/nixpkgs/commit/f5f27446bf90d7bd34686feabab5ac86530abf33) heisenbridge: Fix double-hash caused by [nixos/nixpkgs⁠#202060](https://togithub.com/nixos/nixpkgs/issues/202060)
* [`6fa4fa65`](https://github.com/NixOS/nixpkgs/commit/6fa4fa650890811ab4728e4f045e5824c3297550) portfolio: 0.59.3 -> 0.59.4
* [`2ab2d1ea`](https://github.com/NixOS/nixpkgs/commit/2ab2d1ea8cce120d2cb712cb1815039e3425876f) kyverno: 1.8.1 -> 1.8.2
* [`1f5c55be`](https://github.com/NixOS/nixpkgs/commit/1f5c55be64894d2a258cee001c85bdb91e59dc99) datree: 1.8.0 -> 1.8.1
* [`62d46c43`](https://github.com/NixOS/nixpkgs/commit/62d46c43cb0dc902725f0a37b9ab5c216ed95b8b) swappy: 1.4.0 -> 1.5.1
* [`2440674e`](https://github.com/NixOS/nixpkgs/commit/2440674e5f43ab1aac121b7f5f1d0bca379d55a5) yad: 12.0 -> 12.1
* [`2530e9b1`](https://github.com/NixOS/nixpkgs/commit/2530e9b106b4502372be28ffab07108fa472472d) mercurial: 6.3.0 -> 6.3.1
* [`5a8af240`](https://github.com/NixOS/nixpkgs/commit/5a8af2401c15c69ba1e72fc96686007ae44c1097) gnome-secrets: 6.5 -> 7.0
* [`71a4ac6d`](https://github.com/NixOS/nixpkgs/commit/71a4ac6d8b00fb40815fcd0532149ff6b7fb1a39) zq: 1.2.0 -> 1.3.0
* [`49454c3e`](https://github.com/NixOS/nixpkgs/commit/49454c3e224d7bdbdd751cee4418c91ea1662d33) vscode-extensions.streetsidesoftware.code-spell-checker: 2.11.0 -> 2.11.1
* [`20515701`](https://github.com/NixOS/nixpkgs/commit/2051570194656f89884acb924cbbbde82ebbda95) advancecomp: 2.3 -> 2.4
* [`7393a554`](https://github.com/NixOS/nixpkgs/commit/7393a554e85f10480d111e4ee2e95c82952ff3e0) heroku: 7.60.2 -> 7.66.4
* [`62ff8337`](https://github.com/NixOS/nixpkgs/commit/62ff8337e1c1305b91c0d401e515c0c3ecaad7ac) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.11.0 -> 0.12.0
* [`c0d004af`](https://github.com/NixOS/nixpkgs/commit/c0d004afa0e9110f147a49d351ad2e3298cceb86) pkgsStatic.rcshist: fix static build
* [`05f0b061`](https://github.com/NixOS/nixpkgs/commit/05f0b0614b61010b71a81211bf6cab210a032c73) echidna: 2.0.3 -> 2.0.4
* [`31a73a22`](https://github.com/NixOS/nixpkgs/commit/31a73a22063eea13e09335414531e84d4987e579) aliyun-cli: 3.0.135 -> 3.0.136
* [`639d80dd`](https://github.com/NixOS/nixpkgs/commit/639d80dd828a5dda21fe84c044e877d7059e4be2) kubo: 0.16.0 -> 0.17.0
* [`12cadc9f`](https://github.com/NixOS/nixpkgs/commit/12cadc9f1147200a13914468ddeb7c11705d049c) rustic-rs: 0.3.2 -> 0.4.0
* [`0781b244`](https://github.com/NixOS/nixpkgs/commit/0781b2448963c8c37c15e0024b7da16c4dcb342a) python310Packages.sensor-state-data: add changelog to meta
* [`d6693545`](https://github.com/NixOS/nixpkgs/commit/d669354552227bf9567ff0d40bff8129bfe18063) python310Packages.sensor-state-data: 2.12.0 -> 2.12.1
* [`d0732c94`](https://github.com/NixOS/nixpkgs/commit/d0732c9470dbadec5812d97746423409728dbbae) python310Packages.pytenable: add changelog to meta
* [`e977728a`](https://github.com/NixOS/nixpkgs/commit/e977728a5b627a461ce71d3b4b9ff9ca385c1ffc) python310Packages.pytenable: 1.4.9 -> 1.4.10
* [`f97b4920`](https://github.com/NixOS/nixpkgs/commit/f97b4920b9f5bf0864bc71f63b8b4f614e59ee79)  python310Packages.lxmf: add chagnelog to meta
* [`24e33a4d`](https://github.com/NixOS/nixpkgs/commit/24e33a4d2e41fc1201034e0cd1a6bd5a642d94c5) nixos/ec2: remove paravirtualization-specific code
* [`eddfcf86`](https://github.com/NixOS/nixpkgs/commit/eddfcf8622f547676d36c42619b68de766a78a6d) amazon-image: fetch metadata only in stage-2
* [`6fb582e0`](https://github.com/NixOS/nixpkgs/commit/6fb582e0301da53d6d5a32d02b8ecbaf0f91c188) ec2-metadata-fetcher: ignore failure when fetching metadata parts
* [`36ca2b49`](https://github.com/NixOS/nixpkgs/commit/36ca2b495fc58d303d60af87f5e2568c5ed2f967) nixos/ec2: use only curl in metadata fetcher, log to console
* [`a29584f0`](https://github.com/NixOS/nixpkgs/commit/a29584f0d4a8ed247a5fb230e3b51cb9f431ff03) kubectx: show version fix
* [`63808344`](https://github.com/NixOS/nixpkgs/commit/6380834436e2d6c4555d3797a148161ff4db3864) python310Packages.aiohomekit: add changelog to meta
* [`8793ae39`](https://github.com/NixOS/nixpkgs/commit/8793ae39e6bcfc0048e5a016794df58314745d2b) bchoppr: 1.10.10 -> 1.12.2
* [`14791e09`](https://github.com/NixOS/nixpkgs/commit/14791e09aa377424a6f0ccf87100654762bbff97) python310Packages.aiocoap: add changelog to meta
* [`4edf9eda`](https://github.com/NixOS/nixpkgs/commit/4edf9edaf461f1f206383dfce1bd4fdc48437324) python310Packages.aiocoap: 0.4.4 -> 0.4.5
* [`e57f897d`](https://github.com/NixOS/nixpkgs/commit/e57f897d25bd432d422709c1f944193ded0447f6) python310Packages.aiohomekit: 2.3.0 -> 2.3.1
* [`58930f0b`](https://github.com/NixOS/nixpkgs/commit/58930f0b7f3171d398fbc7b297ff0a8eb18de537) ocamlPackages.mtime: 1.2.0 → 1.4.0
* [`d37848e5`](https://github.com/NixOS/nixpkgs/commit/d37848e5c01f4f1b51991ca90d6b7aefdf03f237) python310Packages.griffe: add changelog to meta
* [`5a166bbb`](https://github.com/NixOS/nixpkgs/commit/5a166bbbc3058583bf4d69a21946dec4849b36ce) winbox: fix startup of the application
* [`16fa9150`](https://github.com/NixOS/nixpkgs/commit/16fa9150c6f541cf90f863ec08f3c834578ab11d) pulumi: 3.47.0 -> 3.47.2
* [`579ec5c8`](https://github.com/NixOS/nixpkgs/commit/579ec5c894f99c85aa24c825b9b9c2c308c3682d) python310Packages.griffe: 0.24.0 -> 0.24.1
* [`e7f761fe`](https://github.com/NixOS/nixpkgs/commit/e7f761fe60905081166a0bc07474a64683574754) Fix executable name
* [`90e22fde`](https://github.com/NixOS/nixpkgs/commit/90e22fde4b2e718b44d03b0041d72264e98e7708) rofimoji: 5.6.0 -> 6.0.0
* [`3efbc1f9`](https://github.com/NixOS/nixpkgs/commit/3efbc1f9e58b7ca4d8f1f258eb91f9fe84cdf429) rofimoji: install man page
* [`476ffc08`](https://github.com/NixOS/nixpkgs/commit/476ffc0880965d0c8f7585b08d500ad280438629) brev-cli: 0.6.179 -> 0.6.181
* [`9fdc90c6`](https://github.com/NixOS/nixpkgs/commit/9fdc90c65dfd4734a2e787f8311d639c746f1ebe) python310Packages.meshtastic: add changelog to meta
* [`a22a9603`](https://github.com/NixOS/nixpkgs/commit/a22a960374e13063c69e88b3a37e19847350afaf) python310Packages.meshtastic: 2.0.3 -> 2.0.4
* [`4df4d16a`](https://github.com/NixOS/nixpkgs/commit/4df4d16a87f8826b95a8259730245501464c4e6c) ccache: 4.7.3 -> 4.7.4
* [`2507b02a`](https://github.com/NixOS/nixpkgs/commit/2507b02a1c3de3ee1cd65d4503cc8a248041a97b) chaos: 0.3.0 -> 0.4.0
* [`1462c3cc`](https://github.com/NixOS/nixpkgs/commit/1462c3cc487e282988fa0a2747b021fb934f6cf6) zlint: init at 3.4.0
* [`4415badd`](https://github.com/NixOS/nixpkgs/commit/4415baddd8ead057344cf87898a6029b0ef27012) zlint: apply review's comment
* [`f9cdaba4`](https://github.com/NixOS/nixpkgs/commit/f9cdaba46e67f71663fe03c4174cab9f7b03520b) part ways with leaveDotGit
* [`5ad8ce4b`](https://github.com/NixOS/nixpkgs/commit/5ad8ce4b97b0f359a242c3642975a55f5a31b46f) cilium-cli: 0.12.7 -> 0.12.8
* [`40c27fe2`](https://github.com/NixOS/nixpkgs/commit/40c27fe25b4fb5a512b26fead90dd063abbfb122) clair: 4.5.0 -> 4.5.1
* [`e83efab6`](https://github.com/NixOS/nixpkgs/commit/e83efab60db3e597635255332047b110b862eb19) chaos: add changelog to meta
* [`eed28ead`](https://github.com/NixOS/nixpkgs/commit/eed28ead0c1ea5cea8f592d16c93f9391b21f6d4) Workaround for upstream crash when !datadog
* [`0b420a24`](https://github.com/NixOS/nixpkgs/commit/0b420a24f84247c78ba845ae1ca2aed973dc34ab) prometheus-snmp-exporter: 0.20.0 -> 0.21.0
* [`c99cfce6`](https://github.com/NixOS/nixpkgs/commit/c99cfce6ad59b83f111fa124f3f876e3a157a1e2) tor-browser-bundle-bin: 11.5.7 -> 11.5.8
* [`cfa112c8`](https://github.com/NixOS/nixpkgs/commit/cfa112c8355b754c9eb39fd2f0fa046504ba98ad) cargo-nextest: 0.9.43 -> 0.9.44
* [`b8ffc572`](https://github.com/NixOS/nixpkgs/commit/b8ffc572d27ec671366ef4937ed0f90b73638a42) nixos/patroni: only run tests on x86_64-linux
* [`b9c24877`](https://github.com/NixOS/nixpkgs/commit/b9c24877d0271b1fe122e65579fa4e9bb33f65a9) prometheus: 2.40.0 -> 2.40.2
* [`21ef1b91`](https://github.com/NixOS/nixpkgs/commit/21ef1b91290fb033376e1b4a0162f99332e86b63) zlint: 3.4.0 -> 3.4.1
* [`9a5dc3a7`](https://github.com/NixOS/nixpkgs/commit/9a5dc3a76008f68ebba2d6ccfbdfbdffd471cf0b) etcd_3_5: 3.5.5 -> 3.5.6
* [`76a812d1`](https://github.com/NixOS/nixpkgs/commit/76a812d168d5fdf79485fa71fd922a3a71ab307a) Enpass: Add dritter as maintainer
* [`6cb5f7bb`](https://github.com/NixOS/nixpkgs/commit/6cb5f7bb7e340da3385960b6e1dea452712862b2) libp11: build reverse dependencies with same openssl version
* [`de485793`](https://github.com/NixOS/nixpkgs/commit/de4857930b919d33b3de9e140782876bda6704b2) python310Packages.regenmaschine: add changelog to meta
* [`6af34d90`](https://github.com/NixOS/nixpkgs/commit/6af34d90cafd78732edd78f16b7b7893addf03d9) python310Packages.regenmaschine: 2022.11.0 -> 2022.11.1
* [`9fef864d`](https://github.com/NixOS/nixpkgs/commit/9fef864d5f2cb8b46bdd618c1a9478dc917add12) grafana: 9.2.5 -> 9.2.6
* [`c5f01dc2`](https://github.com/NixOS/nixpkgs/commit/c5f01dc25fceec2e0e9b06f7d61d84f9904f59b7) python310Packages.pyotgw: 2.1.2 -> 2.1.3
* [`3d97d9cc`](https://github.com/NixOS/nixpkgs/commit/3d97d9cc46096e853efd0c7622d096a458b31552) senv: mark broken on darwin
* [`af5c172f`](https://github.com/NixOS/nixpkgs/commit/af5c172fabf634d6cb1366cc0c0570af6e0812d5) writefreely: remove myself from maintainers
* [`9e279b7b`](https://github.com/NixOS/nixpkgs/commit/9e279b7bd3d89850d21b2cbfc876f9cac1157241) ouch: 0.3.1 -> 0.4.0
* [`b449bc1e`](https://github.com/NixOS/nixpkgs/commit/b449bc1ee82bd9f79f426174b22a7d1a7a2e689f) docker-compose: 2.12.2 -> 2.13.0
* [`0f56f1ef`](https://github.com/NixOS/nixpkgs/commit/0f56f1ef549d1726b9350982b6300627e0fb04d2) python310Packages.optax: 0.1.3 -> 0.1.4
* [`63fa4df6`](https://github.com/NixOS/nixpkgs/commit/63fa4df63c735c37b56bbf5f995668830d26bb65) qrcp: mark broken on darwin
* [`125bd1f0`](https://github.com/NixOS/nixpkgs/commit/125bd1f0b55d6fbf43dcaef44d523aec0710d06e) doc/languages-frameworks/javascript: update deps hash in example
* [`b023946d`](https://github.com/NixOS/nixpkgs/commit/b023946d2bbfe19e3b7ba6249ef48cd59f386949) prefetch-npm-deps: fix hash stability
* [`4aff99b7`](https://github.com/NixOS/nixpkgs/commit/4aff99b78c0e391e2152ab673bf27e66574d817e) stratisd: 3.3.0 -> 3.4.0
* [`ed71b75e`](https://github.com/NixOS/nixpkgs/commit/ed71b75ee887da93e8f9cc7314986b5bc058f20d) stratis-cli: 3.3.0 -> 3.4.0
* [`7d2faad3`](https://github.com/NixOS/nixpkgs/commit/7d2faad3b747b7c3d294bbdd2d367e1436782a26) nixos/stratis: update tests to use new features
* [`a80fa825`](https://github.com/NixOS/nixpkgs/commit/a80fa825e617e53dae7a00e97ea6d75caea3fa11) rocm-related: add update script
* [`81da5899`](https://github.com/NixOS/nixpkgs/commit/81da589991fd4475212e34e696f146d1894b857a) rocm-related: ignore same hash
* [`e7a1f844`](https://github.com/NixOS/nixpkgs/commit/e7a1f8449869c64d0e333bf711dc28c7abb9bfd6) gitui: 0.22.0 -> 0.22.1
* [`621bb272`](https://github.com/NixOS/nixpkgs/commit/621bb272a16599e1bf12d35dffed1840187e3b77) postgresql_15: build with support for zstd compression
* [`0f5f6db0`](https://github.com/NixOS/nixpkgs/commit/0f5f6db01ffe7ecec858943b51795e2f2d4b73d8) python310Packages.peaqevcore: 8.0.2 -> 8.2.0
* [`8c037af9`](https://github.com/NixOS/nixpkgs/commit/8c037af94ca44a2139ab1ddad595d4e72e94106d) terraform-providers.fastly: 3.0.1 → 3.0.2
* [`831394a8`](https://github.com/NixOS/nixpkgs/commit/831394a8daa89a3a5bd9bc699fcda1e5f69978ac) terraform-providers.docker: 2.23.0 → 2.23.1
* [`3e85b631`](https://github.com/NixOS/nixpkgs/commit/3e85b631812b7984d38c24ae94069c09d40778a2) terraform-providers.opsgenie: 0.6.17 → 0.6.18
* [`8e8b5f3b`](https://github.com/NixOS/nixpkgs/commit/8e8b5f3b1e899bf5d250279578c0283705b8cdb4) terraform-providers.tencentcloud: 1.78.13 → 1.78.14
* [`a914e20f`](https://github.com/NixOS/nixpkgs/commit/a914e20f8be75beab0ec80472bfd47c8c4b7e367) cmctl: 1.10.0 -> 1.10.1
* [`db27456a`](https://github.com/NixOS/nixpkgs/commit/db27456a925305c222f3e68432de8b70ac912577) cmdstan: 2.30.1 -> 2.31.0
* [`b2891427`](https://github.com/NixOS/nixpkgs/commit/b2891427b201a12ae9071309817a2abc5357c7a7) open-stage-control: update npmDepsHash
* [`bca36e1f`](https://github.com/NixOS/nixpkgs/commit/bca36e1fc66dd6f24364ad7f7b4ca20784c2fb9c) consul: 1.14.0 -> 1.14.1
* [`88ce3dfe`](https://github.com/NixOS/nixpkgs/commit/88ce3dfe202834c5319c9951db4ce4462887a3d1) python310Packages.persistent: 4.9.2 -> 4.9.3
* [`54939cde`](https://github.com/NixOS/nixpkgs/commit/54939cdeda11de9ad8d9376f50fb198677261b11) python310Packages.pex: 2.1.113 -> 2.1.114
* [`19b83bd0`](https://github.com/NixOS/nixpkgs/commit/19b83bd016e436f3f0cec6e737bc3b3d7fd4c2f7) python310Packages.pex: add changelog to meta
* [`68caf32b`](https://github.com/NixOS/nixpkgs/commit/68caf32ba7abe5aec62cd5659735c6d4ca5a5bb1) python310Packages.optax: add changelog to meta
* [`c25a9f03`](https://github.com/NixOS/nixpkgs/commit/c25a9f03f370188785518dc2717768db2dee50ac) python310Packages.persistent: add changelog to meta
* [`dab1673e`](https://github.com/NixOS/nixpkgs/commit/dab1673e9f4dcb19999ed188fb94d5f2ead66e8d) mitmproxy2swagger: add changelog to meta
* [`d1f2d1a6`](https://github.com/NixOS/nixpkgs/commit/d1f2d1a60fb31c84762b5af22511b59e015ff627) mitmproxy2swagger: 0.7.0 -> 0.7.1
* [`44c09ae9`](https://github.com/NixOS/nixpkgs/commit/44c09ae9811acf061c30930b4eb346dbcf2ddc3b) python310Packages.adafruit-platformdetect: 3.34.0 -> 3.35.0
* [`11fc0c7d`](https://github.com/NixOS/nixpkgs/commit/11fc0c7dd64e19339613edee81dd137a5b08ba40) python310Packages.plaid-python: 11.1.0 -> 11.2.0
* [`16ce635d`](https://github.com/NixOS/nixpkgs/commit/16ce635de479a0a1f9c73b550adf8624a017debe) python310Packages.boschshcpy: 0.2.36 -> 0.2.37
* [`8d1f580a`](https://github.com/NixOS/nixpkgs/commit/8d1f580ade6eaea61ec9c291eab7ff87f18a784e) unifi-poller: 2.1.9 -> 2.2.0
* [`aee1facf`](https://github.com/NixOS/nixpkgs/commit/aee1facf771de55b8f556b2598d0af631e03dd08) python310Packages.mitmproxy-wireguard: 0.1.18 -> 0.1.19
* [`09565dad`](https://github.com/NixOS/nixpkgs/commit/09565dad814964d676a3a3ac25b7830277c6e9af) python310Packages.python-homewizard-energy: 1.2.0 -> 1.3.1
* [`e76e9ed9`](https://github.com/NixOS/nixpkgs/commit/e76e9ed99c2fb8688443736deb345dec5fe9b1b7) rPackages.bigmemory: fix evaluation on darwin
* [`ca44edf1`](https://github.com/NixOS/nixpkgs/commit/ca44edf11cf58dde99350c9ce125c761d438a899) devbox: 0.1.0 -> 0.1.1 ([nixos/nixpkgs⁠#202607](https://togithub.com/nixos/nixpkgs/issues/202607))
* [`47dfc53f`](https://github.com/NixOS/nixpkgs/commit/47dfc53feab971ef125444fd9981c6340c1a8f0b) sapling: init at 0.1.20221118-210929-cfbb68aa ([nixos/nixpkgs⁠#201798](https://togithub.com/nixos/nixpkgs/issues/201798))
* [`6eefaa03`](https://github.com/NixOS/nixpkgs/commit/6eefaa031c52a54aff3e8a3b18dc4e2ebb075335) rocm-related: 5.3.1 → 5.3.3
* [`b3d651c7`](https://github.com/NixOS/nixpkgs/commit/b3d651c79a9cd9541de031d419e7bb22d421a636) composable_kernel: unstable-2022-11-02 -> unstable-2022-11-19
* [`574727ed`](https://github.com/NixOS/nixpkgs/commit/574727ed487478d3c3a853246435f890d8314c32) rocm-related: change maintainers to rocm team
* [`0190a12a`](https://github.com/NixOS/nixpkgs/commit/0190a12af56afabed5c3b4f367870e04baf9da52) rocm-related: change maintainers to rocm team + old
* [`6bb3a9ba`](https://github.com/NixOS/nixpkgs/commit/6bb3a9baee74655ebbe1f3d9c5b2693e65846146) rocm-related: use finalAttrs
* [`aef58508`](https://github.com/NixOS/nixpkgs/commit/aef58508e5e88f682b15de4aa045eab83eb474db) apache-airflow: 2.4.1 -> 2.4.3
* [`090dabd0`](https://github.com/NixOS/nixpkgs/commit/090dabd043659ff45e8f92c1d2fb4e22492e01fa) rocrand: init at 2.10.15-5.3.3
* [`e11030af`](https://github.com/NixOS/nixpkgs/commit/e11030af6e7ea135291ebe151879bd1259e2ba73) python310Packages.angr: remove unicorn override (fixes [nixos/nixpkgs⁠#120113](https://togithub.com/nixos/nixpkgs/issues/120113))
* [`b4708bef`](https://github.com/NixOS/nixpkgs/commit/b4708beff841e565e389c7b0d98366e8538c8e3f) python310Packages.archinfo: 9.2.25 -> 9.2.26
* [`a9419b64`](https://github.com/NixOS/nixpkgs/commit/a9419b6439117e943e817b1d236700ed13053d37) python310Packages.ailment: 9.2.25 -> 9.2.26
* [`047b2c3f`](https://github.com/NixOS/nixpkgs/commit/047b2c3f33688c9d61a109dab31db10cbbd53583) python310Packages.pyvex: 9.2.25 -> 9.2.26
* [`d2bb5fbb`](https://github.com/NixOS/nixpkgs/commit/d2bb5fbb6e40193dfb538628bbcc9abdcbd49af7) python310Packages.claripy: 9.2.25 -> 9.2.26
* [`23bca5f6`](https://github.com/NixOS/nixpkgs/commit/23bca5f6d2e9c93cc8ad6ac6005d094b6795a064) python310Packages.cle: 9.2.25 -> 9.2.26
* [`53ec84d1`](https://github.com/NixOS/nixpkgs/commit/53ec84d1160d5c8d4479ae6769b5efdb6569ee15) python310Packages.angr: 9.2.25 -> 9.2.26
* [`62323057`](https://github.com/NixOS/nixpkgs/commit/62323057043baabd7aecd4829c8a208f64140075) opcr-policy: 0.1.42 -> 0.1.43
* [`0676b5af`](https://github.com/NixOS/nixpkgs/commit/0676b5af6964518cc6c6820da7ccf83843b08572) mlt: Add rubberband support
* [`9c363bae`](https://github.com/NixOS/nixpkgs/commit/9c363bae166f0581fb3cd6eb709baa95ee6c0c2f) qalculate-qt: update supported platforms
* [`9fff86f3`](https://github.com/NixOS/nixpkgs/commit/9fff86f3eba18c1370e47485a2758611d3dda237) bitcoin-classic: remove
* [`2dc0434d`](https://github.com/NixOS/nixpkgs/commit/2dc0434dcc0481f3c99bc1668a10a1359ab027c5) threatest: init at 1.1.0
* [`7331988b`](https://github.com/NixOS/nixpkgs/commit/7331988b07d48241ebd4e4f9bc8ade37e199a4bb) linuxPackages.nvidia_x11: 515.76 -> 515.86.01, 470.141.03 -> 470.161.03, 390.154 -> 390.157
* [`c1254eeb`](https://github.com/NixOS/nixpkgs/commit/c1254eebab9a7257e978af1009d9ba2133befcec) linuxPackages.nvidia_x11_vulkan_beta: 515.49.24 -> 515.49.25
* [`c97cd4f4`](https://github.com/NixOS/nixpkgs/commit/c97cd4f4a84646deb6cb13664f645c622a265380) chain-bench: 0.1.6 -> 0.1.7
* [`2ff4e9ea`](https://github.com/NixOS/nixpkgs/commit/2ff4e9ea8463bff0f7646b17a6028d7b20a2ec1f) netlify-cli: refactor
* [`e341cd3b`](https://github.com/NixOS/nixpkgs/commit/e341cd3ba4c5505c5b6e96ac29ade3d84b3a1c1d) netlify-cli.tests.test: Add ps on darwin
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
