### PR TITLE
niv emacs-overlay: update 86fa3768 -> de8f6b86

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86fa3768f0eb427a5c773e6dde261e8151135e22",
-        "sha256": "19hf7l3wh34pc0cwf9njzd1lj1fggrpjjpycwg43ir7hs3fam53g",
+        "rev": "de8f6b86ab55753fa40b7f1b815d2126d203dddc",
+        "sha256": "0hmxjykq05lvzgbyy4ybjrq1f19bq8gv4a751njlw8ppcd908s47",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/86fa3768f0eb427a5c773e6dde261e8151135e22.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/de8f6b86ab55753fa40b7f1b815d2126d203dddc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@86fa3768...de8f6b86](https://github.com/nix-community/emacs-overlay/compare/86fa3768f0eb427a5c773e6dde261e8151135e22...de8f6b86ab55753fa40b7f1b815d2126d203dddc)

* [`6e2a6d8d`](https://github.com/nix-community/emacs-overlay/commit/6e2a6d8d863751c677f9e404a3502860ea03957f) Updated repos/emacs
* [`1e2c5e4e`](https://github.com/nix-community/emacs-overlay/commit/1e2c5e4e0c05145ee1ac4baa458a97ac1a9b05b6) Updated repos/melpa
* [`a9c2a436`](https://github.com/nix-community/emacs-overlay/commit/a9c2a436757f09abc4c7bc0abc4d2529b312e42b) Updated repos/nongnu
* [`57b38b76`](https://github.com/nix-community/emacs-overlay/commit/57b38b7671a064bcc29fc1ef0061c4a440d41bf4) Updated repos/emacs
* [`89f2e82f`](https://github.com/nix-community/emacs-overlay/commit/89f2e82fec9f7c2dde0381976266a245f0072217) Updated repos/melpa
* [`f5786c44`](https://github.com/nix-community/emacs-overlay/commit/f5786c44249607e5865f901f26b4716affed44d9) Updated repos/emacs
* [`99ccc301`](https://github.com/nix-community/emacs-overlay/commit/99ccc3010d0fe24c32c85db997283761eaafb7d2) Updated repos/exwm
* [`501fb94b`](https://github.com/nix-community/emacs-overlay/commit/501fb94b5e5eb4d2d7bf5da6d7d328d95c4ed03f) Updated repos/melpa
* [`2139a4a0`](https://github.com/nix-community/emacs-overlay/commit/2139a4a0721fefe892edefaaec520e037feefd97) Updated repos/nongnu
* [`d1490be1`](https://github.com/nix-community/emacs-overlay/commit/d1490be1e430d49604c88825004f9e1af964680d) Updated repos/emacs
* [`a131c18e`](https://github.com/nix-community/emacs-overlay/commit/a131c18e862d23b83400355dae6594840f179d00) Updated repos/melpa
* [`eb4061df`](https://github.com/nix-community/emacs-overlay/commit/eb4061df471adea29378843a5ead22035af8ba8b) Updated repos/emacs
* [`decf4c58`](https://github.com/nix-community/emacs-overlay/commit/decf4c588c7e1a056bc7da2f25794018590ad1bf) Updated repos/melpa
* [`d381dcca`](https://github.com/nix-community/emacs-overlay/commit/d381dcca8193bce5c65aca58832b53b79e31d167) Add C# grammar to list of tree-sitter plugins
* [`a88a530b`](https://github.com/nix-community/emacs-overlay/commit/a88a530b9b9040dba3208f94fc0689fcac57075f) Updated repos/emacs
* [`4cb6d2cc`](https://github.com/nix-community/emacs-overlay/commit/4cb6d2cc8bcadcf979fe3eda2511483af29677e3) Updated repos/melpa
* [`6ebe7fe0`](https://github.com/nix-community/emacs-overlay/commit/6ebe7fe01e32cb4ac95f456427d308fa8ce1c0fb) Updated repos/nongnu
* [`a7bc3dc1`](https://github.com/nix-community/emacs-overlay/commit/a7bc3dc1595f8da021a8cfddeffb02537caeabac) Updated repos/emacs
* [`fa293d98`](https://github.com/nix-community/emacs-overlay/commit/fa293d98210547e943c1e64df8d0e0aa24174eab) Updated repos/melpa
* [`21ec0719`](https://github.com/nix-community/emacs-overlay/commit/21ec0719682b5ae8c02b06ce03b523731d8347e0) Updated repos/emacs
* [`49d5cbd3`](https://github.com/nix-community/emacs-overlay/commit/49d5cbd389a3fb843793cd7503ad7abdb4f40a9d) Updated repos/melpa
* [`aa1bd9d2`](https://github.com/nix-community/emacs-overlay/commit/aa1bd9d2f3b17e92f0e86b80e53e3ae61c0c7ee9) Updated repos/emacs
* [`aa709808`](https://github.com/nix-community/emacs-overlay/commit/aa7098087716090efaa89a3966f3c3cdcfe9a9c3) Updated repos/melpa
* [`bd94203b`](https://github.com/nix-community/emacs-overlay/commit/bd94203b79be2a92a9e0c9a8cab5da8ffd790af3) Updated repos/emacs
* [`4b6569a0`](https://github.com/nix-community/emacs-overlay/commit/4b6569a054e693a9a7d6eef423fac9b506961b76) Updated repos/melpa
* [`0e90f23b`](https://github.com/nix-community/emacs-overlay/commit/0e90f23b9374966d042ae6625e9511ab6c9a70ed) Updated repos/emacs
* [`1be5f860`](https://github.com/nix-community/emacs-overlay/commit/1be5f86016b1eb5bc5e12ec0d6759e3c51ec7e00) Updated repos/melpa
* [`4fd789cb`](https://github.com/nix-community/emacs-overlay/commit/4fd789cbe350bf816fe0375f283a71878269a435) Updated repos/emacs
* [`1e0a1afb`](https://github.com/nix-community/emacs-overlay/commit/1e0a1afb1bbcb634d0e78768a723b7749c03014d) Updated repos/melpa
* [`838bd1e5`](https://github.com/nix-community/emacs-overlay/commit/838bd1e55d9168d2df9dc0331565f884c3be3250) Updated repos/nongnu
* [`e2fc95d5`](https://github.com/nix-community/emacs-overlay/commit/e2fc95d5e82dc7bdbbfb7f5e6cb70eabf0e63101) Updated repos/emacs
* [`3d5e5cfa`](https://github.com/nix-community/emacs-overlay/commit/3d5e5cfa91ed10d39e0504387242750996e8b027) Updated repos/melpa
* [`e1e62e32`](https://github.com/nix-community/emacs-overlay/commit/e1e62e32a137c846d57b240f786ea6dbc5eb0f30) Updated repos/emacs
* [`8885dd26`](https://github.com/nix-community/emacs-overlay/commit/8885dd262fab18c7972c037977037a35c3cbfba1) Updated repos/melpa
* [`81a7ffa7`](https://github.com/nix-community/emacs-overlay/commit/81a7ffa7100f1792b82dbaacb2d0fa33c19e11a9) Updated repos/emacs
* [`c254c14d`](https://github.com/nix-community/emacs-overlay/commit/c254c14d4d2a6dc9367e6d8f60b320004df70b76) Updated repos/melpa
* [`7aa0c963`](https://github.com/nix-community/emacs-overlay/commit/7aa0c96397c4864853fa91a66191fb2336a08783) Updated repos/nongnu
* [`bccdbc1f`](https://github.com/nix-community/emacs-overlay/commit/bccdbc1f7886c014481eba5bd773a0e3cea39b89) Updated repos/emacs
* [`d37787d5`](https://github.com/nix-community/emacs-overlay/commit/d37787d5ae65c536b89d89a865e6647aa784438d) Updated repos/melpa
* [`5c16b451`](https://github.com/nix-community/emacs-overlay/commit/5c16b4515d956c2db9334ac7f1a7982baca0ba4e) Updated repos/nongnu
* [`19ccc6da`](https://github.com/nix-community/emacs-overlay/commit/19ccc6da2799902d2eaef5368a13797dfc9bfe16) Updated repos/emacs
* [`affa8f7f`](https://github.com/nix-community/emacs-overlay/commit/affa8f7f6bae6d7f16df320d0b5d1683712ddf25) Updated repos/melpa
* [`aa91ccd6`](https://github.com/nix-community/emacs-overlay/commit/aa91ccd60349c0361ab920fcfe2602bf894edf6d) Updated repos/emacs
* [`d6cd4615`](https://github.com/nix-community/emacs-overlay/commit/d6cd46156ea17c803f56657c87dc3d0292e89609) Updated repos/melpa
* [`0052cb41`](https://github.com/nix-community/emacs-overlay/commit/0052cb41ba2d278fca5ed8b48a5b3e9bff6cbed4) Updated repos/nongnu
* [`ec3600b1`](https://github.com/nix-community/emacs-overlay/commit/ec3600b1959137ecf56774206b15c5930cfa07e4) Updated repos/emacs
* [`585d6bbb`](https://github.com/nix-community/emacs-overlay/commit/585d6bbb593e2013fec75941e9e502cbd85cff67) Updated repos/melpa
* [`d54a1521`](https://github.com/nix-community/emacs-overlay/commit/d54a1521619daa37c9aa8c9e3362abb34e676007) Updated repos/nongnu
* [`32329085`](https://github.com/nix-community/emacs-overlay/commit/32329085c481f8ace921da5ddbcb070f19682536) Updated repos/emacs
* [`c231c739`](https://github.com/nix-community/emacs-overlay/commit/c231c73992cf9a024070b841fdcfdf067da1a3dd) Updated repos/melpa
* [`ce16b980`](https://github.com/nix-community/emacs-overlay/commit/ce16b98056ddcb47221823072269df39de4cb930) Updated repos/emacs
* [`5db1a158`](https://github.com/nix-community/emacs-overlay/commit/5db1a15886a8f7de934fdd3e8106cea7380b086c) Updated repos/melpa
* [`de8f6b86`](https://github.com/nix-community/emacs-overlay/commit/de8f6b86ab55753fa40b7f1b815d2126d203dddc) Updated repos/nongnu
