### PR TITLE
niv home-manager: update f2539b53 -> bc1a057a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "knl",
         "repo": "home-manager",
-        "rev": "f2539b5312669171cf6ec250904e18eea361de3e",
-        "sha256": "1srkzlr75a1bkrmiyd0d0by8frg28z3agpm0sjn5ly0lmqbkkls5",
+        "rev": "bc1a057a9810863957cbbb2661368b96fc0ba6d8",
+        "sha256": "1fhdzhjynzdapwb3ynx4fhsva2pasajhdhq0vys5407sda4mfz2y",
         "type": "tarball",
-        "url": "https://github.com/knl/home-manager/archive/f2539b5312669171cf6ec250904e18eea361de3e.tar.gz",
+        "url": "https://github.com/knl/home-manager/archive/bc1a057a9810863957cbbb2661368b96fc0ba6d8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: unbroken
Commits: [knl/home-manager@f2539b53...bc1a057a](https://github.com/knl/home-manager/compare/f2539b5312669171cf6ec250904e18eea361de3e...bc1a057a9810863957cbbb2661368b96fc0ba6d8)

* [`62cb5bcf`](https://github.com/knl/home-manager/commit/62cb5bcf93896e4dd6b4507dac7ba2e2e3abc9d7) Switch master branch version to 23.05
* [`bf99255f`](https://github.com/knl/home-manager/commit/bf99255fc9a092ef0272df598ab70eeecc93ca78) kitty: silently drop darwin-specific options ([knl/home-manager⁠#3394](https://togithub.com/knl/home-manager/issues/3394))
* [`64f7a775`](https://github.com/knl/home-manager/commit/64f7a775175bff9f7d4ba31d7ef425fed494df71) polybar: don't generate config if no options are set ([knl/home-manager⁠#3383](https://togithub.com/knl/home-manager/issues/3383))
* [`5c98a8d8`](https://github.com/knl/home-manager/commit/5c98a8d8609c9a5b3d1df0a153e3d57ce32e2cef) flake.lock: Update ([knl/home-manager⁠#3403](https://togithub.com/knl/home-manager/issues/3403))
* [`cc58d319`](https://github.com/knl/home-manager/commit/cc58d3195342fee3574b5544565696a210d5d5ea) flake: Expose tests to allow running purely ([knl/home-manager⁠#3412](https://togithub.com/knl/home-manager/issues/3412))
* [`e999dfe7`](https://github.com/knl/home-manager/commit/e999dfe7cba2e1fd59ab135e7496545bd4f82b76) kakoune: allow custom package ([knl/home-manager⁠#3434](https://togithub.com/knl/home-manager/issues/3434))
* [`4a12f304`](https://github.com/knl/home-manager/commit/4a12f304e0abc3f24c3c7d36423d84d7d8021364) nushell: add options 'extraConfig' and 'extraEnv'
* [`7ae7250d`](https://github.com/knl/home-manager/commit/7ae7250df8f38c4efc8cd6669a36272ab7a575ed) starship: add nushell integration support
* [`1bdbebc3`](https://github.com/knl/home-manager/commit/1bdbebc3f83a7b6a69f84797d5cda9ece8ca3c37) ssh: add generic Match support for matchBlocks ([knl/home-manager⁠#2992](https://togithub.com/knl/home-manager/issues/2992))
* [`f7fed4dd`](https://github.com/knl/home-manager/commit/f7fed4dd3d9086ff4b7813a8600a262423cb63c1) picom: add `egl` backend to options ([knl/home-manager⁠#3441](https://togithub.com/knl/home-manager/issues/3441))
* [`fa671f17`](https://github.com/knl/home-manager/commit/fa671f1795824ea2e92629555d63e2b8196f6f99) programs.zsh: set ZPLUG_HOME before loading zplug ([knl/home-manager⁠#2987](https://togithub.com/knl/home-manager/issues/2987))
* [`50c9bccb`](https://github.com/knl/home-manager/commit/50c9bccb6abc52811a59db620606e016fcde32bd) bat: add extraPackages option
