### PR TITLE
niv powerlevel10k: update cf83ab21 -> 6609767a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "cf83ab21e440ffa276a13ab5fd63b6372b674b5e",
-        "sha256": "0wp6f7x294hdvlhgzz3yrdnpzsk0hjxrngiijkxz1df5whbv4504",
+        "rev": "6609767abd81aed3101cb67908df727998b0b619",
+        "sha256": "1vxng2y2sq2hdy6m8lbrh4fhz64a4s4srbzyyb715zqjjn3x7y1k",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/cf83ab21e440ffa276a13ab5fd63b6372b674b5e.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/6609767abd81aed3101cb67908df727998b0b619.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@cf83ab21...6609767a](https://github.com/romkatv/powerlevel10k/compare/cf83ab21e440ffa276a13ab5fd63b6372b674b5e...6609767abd81aed3101cb67908df727998b0b619)

* [`176f7811`](https://github.com/romkatv/powerlevel10k/commit/176f781121c02af7c504746619eab910a457e935) assume that dotnet version may depend on the content of global.json ([romkatv/powerlevel10k⁠#2103](https://togithub.com/romkatv/powerlevel10k/issues/2103))
* [`8d47270e`](https://github.com/romkatv/powerlevel10k/commit/8d47270e8c17672e9323373e4df3699cb43545ff) don't invoke mktemp if it doesn't exist
* [`6609767a`](https://github.com/romkatv/powerlevel10k/commit/6609767abd81aed3101cb67908df727998b0b619) don't invoke mktemp if it doesn't exist
