### PR TITLE
niv spacemacs: update 913962b3 -> be9b1c89

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "913962b3edde7984df78d91ab94d8b8e109e93f1",
-        "sha256": "1qbljd4vvw7d9ysbd6p8vdz26z44ljs96zszkpvqmmb0mhfzkbzk",
+        "rev": "be9b1c89bc0d1a9dcfdec5362425efa1787f28fa",
+        "sha256": "1c09dhp0wm89g3bpqmdvvv2g73kx2m70z6dnbf1xqm1dp68a3d85",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/913962b3edde7984df78d91ab94d8b8e109e93f1.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/be9b1c89bc0d1a9dcfdec5362425efa1787f28fa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@913962b3...be9b1c89](https://github.com/syl20bnr/spacemacs/compare/913962b3edde7984df78d91ab94d8b8e109e93f1...be9b1c89bc0d1a9dcfdec5362425efa1787f28fa)

* [`32b35b63`](https://github.com/syl20bnr/spacemacs/commit/32b35b63251f7cf5cc36207dab3082f1d7a9ac09) [doc] remove user tracking with google analytics
* [`deae8d59`](https://github.com/syl20bnr/spacemacs/commit/deae8d59e181c85f6bf5709e16cfac5a57cc2111) Defines "B" key bind for ebib to allow direct import from a doi
* [`7881e457`](https://github.com/syl20bnr/spacemacs/commit/7881e45768da568c8c15b6244b08645e20961600) Create layer 'apache' ([syl20bnr/spacemacs⁠#15812](https://togithub.com/syl20bnr/spacemacs/issues/15812))
* [`f31f655f`](https://github.com/syl20bnr/spacemacs/commit/f31f655fc77a9b3c4e58740ffbf5225a865d64ac) [bot] "documentation_updates" Sat Nov 26 06:13:27 UTC 2022
* [`be9b1c89`](https://github.com/syl20bnr/spacemacs/commit/be9b1c89bc0d1a9dcfdec5362425efa1787f28fa) [bot] "built_in_updates" Sat Nov 26 08:34:54 UTC 2022
