### PR TITLE
niv zsh-completions: update 6a5b7245 -> a09284a7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "6a5b7245bed56083839c037aa0d37d8bd30df281",
-        "sha256": "1gasv6jpshnszjcfmixcrb40kgn9jdzfx1nli5rz8rr56df6ra38",
+        "rev": "a09284a73443d4a0288c5a984c5adb5f55ace520",
+        "sha256": "0kn6b12mhgfylc3zk8zhixr3qwmf35shx2vpn985n7z5adxcbs37",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/6a5b7245bed56083839c037aa0d37d8bd30df281.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/a09284a73443d4a0288c5a984c5adb5f55ace520.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@6a5b7245...a09284a7](https://github.com/zsh-users/zsh-completions/compare/6a5b7245bed56083839c037aa0d37d8bd30df281...a09284a73443d4a0288c5a984c5adb5f55ace520)

* [`92199f20`](https://github.com/zsh-users/zsh-completions/commit/92199f20b2f8d14269bd94c0583164110d29ab5d) Update mvn completion
* [`3a9bc83c`](https://github.com/zsh-users/zsh-completions/commit/3a9bc83c91a095183a5a9a72ecfd76a68b109e35) Update inxi completion
* [`4527ea4c`](https://github.com/zsh-users/zsh-completions/commit/4527ea4c6467f2ff7636462f605ee0d02ff704ac) Update conan completion
* [`0b6e0648`](https://github.com/zsh-users/zsh-completions/commit/0b6e0648504382f68dbfc547bd4392a3d85e8513) Update links
* [`b263de07`](https://github.com/zsh-users/zsh-completions/commit/b263de0778bd7b1e6477c98a8c726e4782e78f97) Update dget completion
* [`2b16b33a`](https://github.com/zsh-users/zsh-completions/commit/2b16b33a10c18afabfd012a43cbfebee31068ba5) Remove _debuild completion
* [`17f57c2b`](https://github.com/zsh-users/zsh-completions/commit/17f57c2b2ef10b90ccf8353c0645eb6506294737) Update ccache
* [`fc9ff87d`](https://github.com/zsh-users/zsh-completions/commit/fc9ff87d128bbbe053d4a625abc077575bbd172b) Remove completions that zsh supports itself
* [`2a284cfe`](https://github.com/zsh-users/zsh-completions/commit/2a284cfefaefef0830f80b1c1033cf9d2f53b32c) Update pixz
* [`3b7609ad`](https://github.com/zsh-users/zsh-completions/commit/3b7609ad4f8a952e3c5c84b8047a6424b73f57bd) Update qmk completion
* [`fc35e4e6`](https://github.com/zsh-users/zsh-completions/commit/fc35e4e6c345a79cb0b2d8a99bbeca0b2afca03f) Update setcap
* [`fa0b8386`](https://github.com/zsh-users/zsh-completions/commit/fa0b8386b4227c560e7395557da075dcb042db57) Update dhcpcd completion
