### PR TITLE
niv nixpkgs: update 67762b63 -> f16be356

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "67762b63179d7efd4613b4f0bbd5153261c3d702",
-        "sha256": "1hvbdnf0msykw8kra7rlqwbmys1cz0vw1b0y9b9qa7fm77xqs6d8",
+        "rev": "f16be356415452ee0eb8221b90dda72b85aaca96",
+        "sha256": "1vwmpnzj91j33rn6czx49ldckpfa6rc3zs58lpgp8d93wk2wdrh3",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/67762b63179d7efd4613b4f0bbd5153261c3d702.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f16be356415452ee0eb8221b90dda72b85aaca96.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@67762b63...f16be356](https://github.com/nixos/nixpkgs/compare/67762b63179d7efd4613b4f0bbd5153261c3d702...f16be356415452ee0eb8221b90dda72b85aaca96)

* [`7fa1ba2c`](https://github.com/NixOS/nixpkgs/commit/7fa1ba2ca088969906c31e351e29c676bc909239) profiles: add 'hpsa' scsi driver to all-hardware.nix
* [`857c6490`](https://github.com/NixOS/nixpkgs/commit/857c6490832fb5dccbac6ca7a679496e85a85e21) network-interfaces: set hostname from sysctl if defined
* [`1c659c99`](https://github.com/NixOS/nixpkgs/commit/1c659c9958d1f8c278eeccf8f71bc72798b51fbe) nixos/isso: systemd unit hardening
* [`3af06f55`](https://github.com/NixOS/nixpkgs/commit/3af06f553150512b3b3b37627eb135e7cdcd4527) libconfig: fix static windows build
* [`3e07992f`](https://github.com/NixOS/nixpkgs/commit/3e07992f322c6e37ed5f3df7913a4eafcb2bb189) online-judge-template-generator: init at 4.8.1
* [`ad492582`](https://github.com/NixOS/nixpkgs/commit/ad49258230e49424b447fd7eb88c47c5fd037052) fishPlugins.autopair: init at 1.0.3
* [`3be58b2a`](https://github.com/NixOS/nixpkgs/commit/3be58b2afc2369c777f987359c0843e219e78590) nixos/redmine: Drop darcs integration
* [`92b1cf8b`](https://github.com/NixOS/nixpkgs/commit/92b1cf8b4ccc16e42b04d518f9d23de42cc97c07) nixos/redmine: Make optional components configurable
* [`4d23eae9`](https://github.com/NixOS/nixpkgs/commit/4d23eae938b33fd9cf5ad046d18fb0266b3ca8de) nixos/redmine: Add PDF export support for gant
* [`66ef66fc`](https://github.com/NixOS/nixpkgs/commit/66ef66fc6215fa22f1f216d00ae258db93fe9441) nixos/redmine: Configure imagemagick_convert_command
* [`562bc5c2`](https://github.com/NixOS/nixpkgs/commit/562bc5c2a9c4479b11e454d2ac75fccd13e043b9) nixos/redmine: Fix PNG generation of Gant diagrams
* [`41877098`](https://github.com/NixOS/nixpkgs/commit/41877098f3ac00295a2a9d5e5846201b969a689b) fetchpatch2: init
* [`7f026cc6`](https://github.com/NixOS/nixpkgs/commit/7f026cc6d02746d553e5e3701d44fc89869bc7af) qemu-vm: ensure we do not overwrite the partition table when EFI is in use
* [`8afdfd9e`](https://github.com/NixOS/nixpkgs/commit/8afdfd9e643b81d7a1ec8eb7f8ae259e61ca6782) clang: specify meta.mainProgram
* [`5b520df3`](https://github.com/NixOS/nixpkgs/commit/5b520df32f3da8b2df9e7cb055e6115586955534) nixos/jupyter: add env kernel option
* [`8eafc61e`](https://github.com/NixOS/nixpkgs/commit/8eafc61e238d53da35dad025f2925e50d485606d) nixos/jupyter: make kernel options freeform JSON
* [`714f9439`](https://github.com/NixOS/nixpkgs/commit/714f94398434a948095c5ee597e69661974cd7fe) CONTRIBUTING.md: "no squash merges"
* [`6fdd3837`](https://github.com/NixOS/nixpkgs/commit/6fdd38373ef9667ef959538908275701597c09c8) BeatSaberModManager: init at 0.0.2
* [`0fb17c04`](https://github.com/NixOS/nixpkgs/commit/0fb17c04fe34ac45247d35a1e4e0521652d9c494) BeatSaberModManager: install as single file
* [`ea570d1e`](https://github.com/NixOS/nixpkgs/commit/ea570d1ed3a1779ed48109766998480d7e2a9e87) BeatSaberModManager: leave link to PR comment for context
* [`4d6a7480`](https://github.com/NixOS/nixpkgs/commit/4d6a7480991970801c0d195eebac90180026367b) BeatSaberModManager: use substituteAll instead of custom postPatch
* [`40d0d325`](https://github.com/NixOS/nixpkgs/commit/40d0d325d3e62d2e4d9a095f461d7a247499d289) obsidian: enable wayland flag if NIXOS_OZONE_WL is set
* [`06e4c871`](https://github.com/NixOS/nixpkgs/commit/06e4c8718f9e09d03514f0e2675f69672ee17d79) jugglinglab: 1.2.1 -> 1.6.3
* [`269c1f5e`](https://github.com/NixOS/nixpkgs/commit/269c1f5e9047559328b9259be64884809812f996) naproche: 2022-04-19 -> 2022-10-24
* [`c012d55d`](https://github.com/NixOS/nixpkgs/commit/c012d55d9f6fdd1c9c873d0d389c59ea1a53c031) scala_3: expose scala3-bare as attribute
* [`8ff2a804`](https://github.com/NixOS/nixpkgs/commit/8ff2a80445e05743e252acd5a223452230757617) python311Packages.cffi: patch failing test
* [`82c5c3c9`](https://github.com/NixOS/nixpkgs/commit/82c5c3c9a9b5309a329f8b247621b0f36fd9210e) wireguard: when dyn-dns refresh is enabled, reconnect after failures
* [`f6b110fb`](https://github.com/NixOS/nixpkgs/commit/f6b110fb50d805b5cc0178fd4ff85a90b955ee2d) isabelle: 2021-1 -> 2022
* [`fa28ed48`](https://github.com/NixOS/nixpkgs/commit/fa28ed48582cb30afdce232a3313bb6fe32644e4) isabelle-linter: 2021-1 -> 2022-09-05
* [`f5426f1f`](https://github.com/NixOS/nixpkgs/commit/f5426f1f8dff45f68d7e129898e2361d137722e1) maintainers: add tylerjl
* [`8538873d`](https://github.com/NixOS/nixpkgs/commit/8538873dab56a6f2237f36f9541188642c8e5987) sourcehut.dispatchsrht: remove
* [`7f36d671`](https://github.com/NixOS/nixpkgs/commit/7f36d671a126880a1c44f4ff1bc02cb199bc6fe8) lua-modules: unpin to openssl_1_1
* [`ee090cd8`](https://github.com/NixOS/nixpkgs/commit/ee090cd8081d99a82ec12191df5fff9e93d5fd2c) nixos/physlock: add muteKernelMessages options
* [`c3cff074`](https://github.com/NixOS/nixpkgs/commit/c3cff074f8dc3aaa4739ae0f60d0b3c907aba164) nixos/sane: add openFirewall option
* [`1e8a85f1`](https://github.com/NixOS/nixpkgs/commit/1e8a85f136a9e90fd5a739f707f93a426d314de3) retext: 7.2.3 -> 8.0.0
* [`8d953293`](https://github.com/NixOS/nixpkgs/commit/8d9532935c5a2bc730f962d971a29dde8509696d) BeatSaberModManager: add upstream issue link
* [`df8fdece`](https://github.com/NixOS/nixpkgs/commit/df8fdece7e52491bdd4e5bc8f30b3a0b86674c3e) temurin-bin: 8.0.345 -> 8.0.352; 11.0.16 -> 11.0.17; 17.0.4 -> 17.0.5
* [`943b9366`](https://github.com/NixOS/nixpkgs/commit/943b9366cc2074d46cebc03eedb40a5d43464a8c) openjdk: reduce number of places where default jdk version is specified
* [`0e33de85`](https://github.com/NixOS/nixpkgs/commit/0e33de85ae1ffcc43c1cdc9a64bae23bf2c79085) temurin-bin: init 18.0.2 and 19.0.1
* [`b5bf049a`](https://github.com/NixOS/nixpkgs/commit/b5bf049ab1a5a727a980cd074915ab0962eb417d) platformio: 6.1.4 -> 6.1.5
* [`d15b54d0`](https://github.com/NixOS/nixpkgs/commit/d15b54d045362dffb4a88298798604d4e8269af5) fuzzel: use nanosvg instead librsvg
* [`f9104ee9`](https://github.com/NixOS/nixpkgs/commit/f9104ee9735d54a34801a67a46d6fcbe64599b33) maintainers: add rodrgz
* [`46f653ac`](https://github.com/NixOS/nixpkgs/commit/46f653ac369428a9b17af04cf4d11931f6f2dd30) lirc: 0.10.1 -> 0.10.2
* [`a20fd6e9`](https://github.com/NixOS/nixpkgs/commit/a20fd6e97e1b48f085ebc894a43e00cd6e055ea4) zotero: 6.0.16 -> 6.0.18
* [`418ab602`](https://github.com/NixOS/nixpkgs/commit/418ab60256080063c1c347b2118ab2135497075d) python310Packages.zodb: 5.7.0 -> 5.8.0
* [`f09718c2`](https://github.com/NixOS/nixpkgs/commit/f09718c20109725d5c1bc94d09df07b51952acb6) python310Packages.mathlibtools: 1.1.2 -> 1.3.0
* [`6f2abc0b`](https://github.com/NixOS/nixpkgs/commit/6f2abc0b6f387ff90cef9da05e9a38a645cbf0a5) python310Packages.protonvpn-nm-lib: 3.13.0 -> 3.14.0
* [`ff7422b7`](https://github.com/NixOS/nixpkgs/commit/ff7422b755906f824f448a60888d1cdd20159770) python310Packages.pudb: 2022.1.2 -> 2022.1.3
* [`ee12835a`](https://github.com/NixOS/nixpkgs/commit/ee12835a09528b79e66e6a41079cc94a32f48814) python310Packages.pydal: 20220916.1 -> 20221110.1
* [`f106e2c5`](https://github.com/NixOS/nixpkgs/commit/f106e2c5c1a4a97beb2707bbea25e4f8fc72ea61) python310Packages.pymupdf: 1.20.2 -> 1.21.0
* [`a11c7f3b`](https://github.com/NixOS/nixpkgs/commit/a11c7f3b810a42b98fa334fb175b4a06b589846e) findimagedupes: 2.19.1 -> 2.20.1
* [`152d645e`](https://github.com/NixOS/nixpkgs/commit/152d645ec6549e6f23f0fd2b3ce5873a9d98f1db) python3Packages.invisible-watermark: init at 0.1.5
* [`804fddcf`](https://github.com/NixOS/nixpkgs/commit/804fddcf9b0a8f556a9b38efbc7c8eec1de52444) notmuch-mailmover: init at 0.1.0
* [`3c9ab688`](https://github.com/NixOS/nixpkgs/commit/3c9ab688dd3a33b2be3ad172eea21818bc8bd521) notmuch-mailmover: correct hash
* [`4e44595c`](https://github.com/NixOS/nixpkgs/commit/4e44595cf8c48d4d2e71124b3411f55e167738fd) notmuch: added to pkgs/top-level/all-packages.nix
* [`3d81bc93`](https://github.com/NixOS/nixpkgs/commit/3d81bc93014d6d9a233cffea453412e72ab55e67) Add myself to mantainers list
* [`5f0638ea`](https://github.com/NixOS/nixpkgs/commit/5f0638eadad674bd436423b90af5d6ac02933523) added author to maintainers list
* [`2beafcde`](https://github.com/NixOS/nixpkgs/commit/2beafcdebacbcae1bcdd3870aa658319f257b640) kanboard: 1.2.24 -> 1.2.25
* [`88707c9d`](https://github.com/NixOS/nixpkgs/commit/88707c9dc70e0c2674902b72a1e27b1d73b17aa0) python3Packages.asyncua: init at 1.0.0
* [`8851a62a`](https://github.com/NixOS/nixpkgs/commit/8851a62a86f6b79c879b1cc5b3505e07404a6ac6) lirc: fix plugin ftdi [nixos/nixpkgs⁠#200566](https://togithub.com/nixos/nixpkgs/issues/200566)
* [`a0297ff0`](https://github.com/NixOS/nixpkgs/commit/a0297ff0e78388da3785df96b9c4a43e72cc071f) quarto: 1.1.251 -> 1.2.269
* [`839fdd10`](https://github.com/NixOS/nixpkgs/commit/839fdd101c3749468d44348114a2994bb8414546) dwarf-fortress.dfhack: make overridable
* [`cff44486`](https://github.com/NixOS/nixpkgs/commit/cff44486bc580eb18d243002409c1caabd600964) dwarf-fortress: add `settings`
* [`e786b3ec`](https://github.com/NixOS/nixpkgs/commit/e786b3ec21bd7a722d7eb4839baaf941f8de061a) dwarf-fortress.dfhack: updates and fixes
* [`ab693c75`](https://github.com/NixOS/nixpkgs/commit/ab693c7592847ca17c8c41fea0d6fbe1f6a55deb) dwarf-fortress.dfhack: drop broken versions
* [`a515239b`](https://github.com/NixOS/nixpkgs/commit/a515239b521fe2fd4b0af5f4b93ef7e540ad5db4) dwarf-fortress,dwarf-fortress.dfhack: add ncfavier as maintainer
* [`2870a6be`](https://github.com/NixOS/nixpkgs/commit/2870a6be78a5d2f383590941ba8005cb57198a34) datefmt: 0.2.1 -> 0.2.2
* [`b0eb6ce9`](https://github.com/NixOS/nixpkgs/commit/b0eb6ce9ae7585f31497fee4b7a27eb75b777bbf) invidious: unstable-2022-11-02 -> unstable-2022-11-17
* [`6b237a4a`](https://github.com/NixOS/nixpkgs/commit/6b237a4a0688b633b1321501cefa008adb0be073) jami: 20220825.0828.c10f01f -> 20221031.1308.130cc26
* [`34e0667b`](https://github.com/NixOS/nixpkgs/commit/34e0667b74c5055f81986c759344e3a7de6414c1) dwarf-fortress.dfhack: use CXXFLAGS instead of NIX_CFLAGS_COMPILE
* [`1a55c66f`](https://github.com/NixOS/nixpkgs/commit/1a55c66f8e96c8460cf55bd45ebe9dc766ed2cb3) clematis: init at 2022-04-16
* [`097eb825`](https://github.com/NixOS/nixpkgs/commit/097eb8257edf3ae428ae41d7ce404c75117f293f) maintainers: add jhh
* [`af13f1dd`](https://github.com/NixOS/nixpkgs/commit/af13f1dd9e39c9dcbe6cce4cd09e16deef49b023) python3Packages.rdkit: 2022.03.5 -> 2022.09.1
* [`6120738e`](https://github.com/NixOS/nixpkgs/commit/6120738eaad48d46ec81f90c62762886fc557c37) nixos/firefox: fix "The option is used but not defined"
* [`b9778b3a`](https://github.com/NixOS/nixpkgs/commit/b9778b3a9555a571b019e4dec5434e5e470c1ece) nixos/firefox: lint
* [`958cdd7c`](https://github.com/NixOS/nixpkgs/commit/958cdd7c6bc9482b43040662f03861b3836a964a) nixos/firefox: add preferencesStatus, autoConfig
* [`7370fcf5`](https://github.com/NixOS/nixpkgs/commit/7370fcf517830810ceab1fcca65ba634dd85827d) nixos/firefox: remove firefox-wayland
* [`3c2dd8d5`](https://github.com/NixOS/nixpkgs/commit/3c2dd8d5f33800eb449c621753e0a6310fe47d91) rakkess: 0.5.0 -> 0.5.1
* [`2b8c8aef`](https://github.com/NixOS/nixpkgs/commit/2b8c8aef5ff276f9cb34d16e6431bb6b9aebb504) ripe-atlas-tools: 3.0.2 -> 3.0.3
* [`f7e4c188`](https://github.com/NixOS/nixpkgs/commit/f7e4c1882d0b077fa426f8ef9ed05c7f9ed1b23f) mattermost: 7.4.0 -> 7.5.1
* [`bffa625a`](https://github.com/NixOS/nixpkgs/commit/bffa625a046b781835c53bacbfca100a4abf1dd4) soft-serve: 0.4.1 -> 0.4.4
* [`388f05d7`](https://github.com/NixOS/nixpkgs/commit/388f05d704a87629504a6d97672e6f0f057bdc28) libgbinder: 1.1.25 -> 1.1.26
* [`5a5c6d3f`](https://github.com/NixOS/nixpkgs/commit/5a5c6d3fdc0fdb5bef79699f09b346582cefe1f7) python3Packages.tensorflow: 2.10.0 -> 2.10.1
* [`6921d244`](https://github.com/NixOS/nixpkgs/commit/6921d24405d47b287bbf966d1993c24764ba7f67) python3Packages.tensorflow-bin: 2.9.1 -> 2.9.3
* [`932c0bc6`](https://github.com/NixOS/nixpkgs/commit/932c0bc69f6f34e5e1d160cffee0d69b6aded210) zabbix-cli: 2.3.0 -> 2.3.1
* [`e90452a5`](https://github.com/NixOS/nixpkgs/commit/e90452a53485deb405475fc9eede70868f85f6a1) python310Packages.line_profiler: 3.5.1 -> 4.0.1
* [`d1f37e87`](https://github.com/NixOS/nixpkgs/commit/d1f37e875382249798bb3cec1cdd00ed0e04bd19) python310Packages.netcdf4: 1.6.1 -> 1.6.2
* [`c6fdb155`](https://github.com/NixOS/nixpkgs/commit/c6fdb1557565b2d241cce917239d5092db8b4934) wob: 0.13 -> 0.14.2
* [`c8502694`](https://github.com/NixOS/nixpkgs/commit/c8502694cd87c0001948500818280b03819122c3) freeoffice: 2018-982 -> 2021-1054
* [`2d40e4bc`](https://github.com/NixOS/nixpkgs/commit/2d40e4bc7f616feb53e6048aa8cbda83c89a7828) flameshot: Add darwin support
* [`7e21be19`](https://github.com/NixOS/nixpkgs/commit/7e21be19d61c9544820a7723c44f215de30de350) python310Packages.django-discover-runner: remove
* [`5ed08d83`](https://github.com/NixOS/nixpkgs/commit/5ed08d83f71a7eea1963fb77f1f1f3092e3a001d) nixos/prometheus-pve-exporter: Use LoadCredentials to make configFiles readable to DynamicUser
* [`1d026f61`](https://github.com/NixOS/nixpkgs/commit/1d026f612e40d1cac7df90c1be6d21ce77e22109) safeeyes: 2.1.3 -> 2.1.4
* [`bb1d4caf`](https://github.com/NixOS/nixpkgs/commit/bb1d4caffd2bf4892f36a27dd1919ba968f4cc7f) squeezelite: 1.9.9.1411 -> 1.9.9.1414
* [`4318e517`](https://github.com/NixOS/nixpkgs/commit/4318e51734c215d6e6b9a53d5cb86d58678744ba) python3Packages.pymanopt: skip test_second_order_function_approximation tests
* [`cac076a0`](https://github.com/NixOS/nixpkgs/commit/cac076a0cc896f27ac5e5613bc4fe3722d2306ec) enpass: 6.6.1.809 -> 6.8.5.1173
* [`0355bc86`](https://github.com/NixOS/nixpkgs/commit/0355bc86539c871567ed66df8b2a170aac6e85b3) enpass: Fix baseurl
* [`4f9f1408`](https://github.com/NixOS/nixpkgs/commit/4f9f1408070157cb7c3a3c072e054180925b3fc5) bosun: 0.8.0-preview -> unstable-2021-05-13
* [`896198cd`](https://github.com/NixOS/nixpkgs/commit/896198cd9f238fe13693237fb1a3b31b12f749d9) nap: init at 0.1.1
* [`98cd1161`](https://github.com/NixOS/nixpkgs/commit/98cd1161b0ac02cb490904315470d4036c51f914) yuzu-mainline: 1162 -> 1245
* [`5ec9630d`](https://github.com/NixOS/nixpkgs/commit/5ec9630dc0e3e170d577215965990ea689dde417) systrayhelper: 0.0.5 -> unstable-2021-05-20
* [`5df4f77b`](https://github.com/NixOS/nixpkgs/commit/5df4f77b3416e501bce99f307c506197ac998299) python310Packages.desktop-notifier: 3.4.1 -> 3.4.2
* [`7d7e1dd7`](https://github.com/NixOS/nixpkgs/commit/7d7e1dd7e07c3546053ea4b1e17c0d3482b25613) python310Packages.duckdb-engine: 0.6.4 -> 0.6.5
* [`5ff3d893`](https://github.com/NixOS/nixpkgs/commit/5ff3d89331a265384a89c7e5080541d43f595fb4) python310Packages.desktop-notifier: add changelog to meta
* [`d743a9a3`](https://github.com/NixOS/nixpkgs/commit/d743a9a36ad1dd5e72480cc3daf5958ac44ab927) clerk: mark as broken
* [`b73565ca`](https://github.com/NixOS/nixpkgs/commit/b73565cad5946b3ccb7f03c82d9e386fc6f42066) oapi-codegen: 1.12.2 -> 1.12.3
* [`a42f7a08`](https://github.com/NixOS/nixpkgs/commit/a42f7a08755a3d14db770c833133fca32633f212) nixos/mandb: fix cross compiling
* [`ae212ceb`](https://github.com/NixOS/nixpkgs/commit/ae212ceb1686de5c47d9af6a739a1d8350d105fb) prometheus-wireguard-exporter: 3.6.3 -> 3.6.6
* [`e7cfa26a`](https://github.com/NixOS/nixpkgs/commit/e7cfa26a8684bbc1a73ccc22be0cecf39c830b58) openjdk: init 19.0.1
* [`ca9f905b`](https://github.com/NixOS/nixpkgs/commit/ca9f905b449bc12ec5a88115f563e0838ee51122) nelua: init at 2022-11-20
* [`0f96e086`](https://github.com/NixOS/nixpkgs/commit/0f96e0860c7d0f290f7b09d9b8425855d04d3be5) samba: add notes for darwin
* [`5822b984`](https://github.com/NixOS/nixpkgs/commit/5822b984c305722b3865ee8c2e1a2ffb14ebe91b) wsysmon: init at 0.1.0
* [`702b43df`](https://github.com/NixOS/nixpkgs/commit/702b43dfa2d4984ca7b7a864d1155af07c40861d) webssh: 1.6.0 -> 1.6.1
* [`32029f63`](https://github.com/NixOS/nixpkgs/commit/32029f6316bd4f6c895dd767f300f4896884f847) wxsqlite3: 4.9.0 -> 4.9.1
* [`a0365c41`](https://github.com/NixOS/nixpkgs/commit/a0365c414c541b4259eeee1fbb5407c1d4cfa3e3) python3Packages.zc-buildout: 3.0.0b2 -> 3.0.1
* [`79017c76`](https://github.com/NixOS/nixpkgs/commit/79017c764dcfdc634ef494e60df5ed7e13a73d1f) process-compose: 0.24.1 -> 0.28.0
* [`aa2c2765`](https://github.com/NixOS/nixpkgs/commit/aa2c276581cf15f660251e02623f3dda063fb096) zydis: 3.2.1 -> 4.0.0
* [`ca5f7a9b`](https://github.com/NixOS/nixpkgs/commit/ca5f7a9bba18db04b9c61decf59c3017a4034aab) gitlab: 15.4.4 -> 15.6.0
* [`6b3629a3`](https://github.com/NixOS/nixpkgs/commit/6b3629a3a29773f28f4069d24fc7cbc872c783dc) Revert "nixos/gitlab: Use Git 2.35.x to work around git bug"
* [`2ce0f5c3`](https://github.com/NixOS/nixpkgs/commit/2ce0f5c31e00fa88a5cd82e852fca124dcb367ac) webssh: add changelog to meta
* [`25551116`](https://github.com/NixOS/nixpkgs/commit/25551116a472c95aab5e01c120557f188383f69c) brave: fix commandLineArgs option also requiring vulkanSupport
* [`75298846`](https://github.com/NixOS/nixpkgs/commit/752988463a4f05f655314d01632ac9161f980e30) castxml: 0.4.7 -> 0.4.8
* [`42f777d9`](https://github.com/NixOS/nixpkgs/commit/42f777d9bf5587b191faac47534c33429d72d1fd) ryujinx: 1.1.327 -> 1.1.373
* [`78708cb7`](https://github.com/NixOS/nixpkgs/commit/78708cb7b220ae191083305e0528afb60c3fa506) mongoc: 1.8.0 -> 1.23.1
* [`7dafcde4`](https://github.com/NixOS/nixpkgs/commit/7dafcde4520b699d7fca712ca738902879c2f863) refurb: init at 1.7.0
* [`eaea7d9e`](https://github.com/NixOS/nixpkgs/commit/eaea7d9eabb3dd0bf57a016861082d720d84745e) pachyderm: 1.8.5 -> 2.4.0
* [`03365bdf`](https://github.com/NixOS/nixpkgs/commit/03365bdf549231fa6836bf0b4a3f058027f88cb3) sane-backends: 1.0.32 -> 1.1.1
* [`d1ce7607`](https://github.com/NixOS/nixpkgs/commit/d1ce7607d5cbf4dad31fdc9d1c01a88b73dc777c) airgeddon: 11.02 -> 11.10
* [`0dc5bbbd`](https://github.com/NixOS/nixpkgs/commit/0dc5bbbde9bd7e50c0438c9f1be8880424e0ce6a) prometheus-nut-exporter: init at 2.4.2
* [`a587e528`](https://github.com/NixOS/nixpkgs/commit/a587e528c50d11b4d4e26a7dbd0b4ec6bd511bf3) Add prometheus-nut-exporter module
* [`f0f55381`](https://github.com/NixOS/nixpkgs/commit/f0f553816e9db6294af97c6193862befce265a3e) enpass: Add missing libraries
* [`18e8f906`](https://github.com/NixOS/nixpkgs/commit/18e8f906f31778fb84010a615d6dba2c40962e9f) python310Packages.opytimark: init at 1.0.8
* [`ec8e3c7d`](https://github.com/NixOS/nixpkgs/commit/ec8e3c7dec15c1c9007380a29c181e06c3cb8e2b) minitube: unbreak the build
* [`782c75a8`](https://github.com/NixOS/nixpkgs/commit/782c75a8f30eb5fe082f78b3f0e0f648fcddc461) git-credential-keepassxc: 0.10.1 -> 0.11.0
* [`c35e1f6c`](https://github.com/NixOS/nixpkgs/commit/c35e1f6c26b643598a0726fc0b9fcdb00962de36) nix-zsh-completions: remove broken _nix completion function
* [`c4d336b2`](https://github.com/NixOS/nixpkgs/commit/c4d336b239c982c11c0354ae27ceb65375261387) pkgsStatic.xstow: fix undefined reference error
* [`8889c8ac`](https://github.com/NixOS/nixpkgs/commit/8889c8ac50bc868d682be52116ac92d21d8de112) freefilesync: 11.27 -> 11.28
* [`47d50d78`](https://github.com/NixOS/nixpkgs/commit/47d50d7842aa0fb0b5f8a47a95c35939824951e0) lapce: unstable-2022-09-21 -> 0.2.4
* [`45ccb6df`](https://github.com/NixOS/nixpkgs/commit/45ccb6df0e29f9cc474c62e86edb6028952fe2fe) lapce: Add passthru.updateScript
* [`9f736748`](https://github.com/NixOS/nixpkgs/commit/9f73674898850c76ad27a7a0289393ab48cc81bd) perlPackages.Wx: migrate to wxGTK30-gtk3
* [`0f49f88a`](https://github.com/NixOS/nixpkgs/commit/0f49f88a87a9771c1e041ce2ba7c1e19354a4552) z3: use python3
* [`d9af3976`](https://github.com/NixOS/nixpkgs/commit/d9af397634ce7325d2e6b837ebb19cbfa1e2c18a) cbmc: 5.70.0 -> 5.71.0
* [`0f37726b`](https://github.com/NixOS/nixpkgs/commit/0f37726b7763bd8f622e2aca931afc417f657374) csound: 6.17.0 -> 6.18.1
* [`94f15b68`](https://github.com/NixOS/nixpkgs/commit/94f15b682ddda65a6dc7c54bc0819c51ae669cdb) flatbuffers: 22.10.26 -> 22.11.23
* [`775a7cca`](https://github.com/NixOS/nixpkgs/commit/775a7cca8a7134cb99b274c37f234f4887ea25e0) tdesktop: 4.3.1 -> 4.3.4
* [`6e120367`](https://github.com/NixOS/nixpkgs/commit/6e12036721c8e15fa090e6f20470f4469578221c) sonobuoy: 0.56.10 -> 0.56.12
* [`8e7296e9`](https://github.com/NixOS/nixpkgs/commit/8e7296e984b6a4627ff04c4337a28933a442d95a) buildDotnetModule: generate a NuGet.config with source
* [`2d1b7b85`](https://github.com/NixOS/nixpkgs/commit/2d1b7b8557831fbcb6bf42568b237ea3fa0ed9ca) roslyn: use buildDotnetModule
* [`96cc5f97`](https://github.com/NixOS/nixpkgs/commit/96cc5f97c75988c01db7732b06c5cef20bb0f429) roslyn: 3.10.0-1.21102.26 -> 4.2.0
* [`3ec15a35`](https://github.com/NixOS/nixpkgs/commit/3ec15a353f39287a0bc22ff47d21b464f4997bbb) nbxplorer: 2.3.41 -> 2.3.49
* [`19da0d12`](https://github.com/NixOS/nixpkgs/commit/19da0d125c82fb74b5f90523558f59cad6b50ec6) blackfire: 2.10.0 -> 2.13.1
* [`152d3200`](https://github.com/NixOS/nixpkgs/commit/152d32009174d62527dd36f8a1d472763a087586) php81Extensions.blackfire: 1.78.1 -> 1.84.0
* [`fa2a25f1`](https://github.com/NixOS/nixpkgs/commit/fa2a25f1eb1c9168567815e617e2cbd2d638b1f7) gnomeExtensions: auto-update
* [`badc84b6`](https://github.com/NixOS/nixpkgs/commit/badc84b69e4b3028466c0f8189f23ae51d92e7f6) hashrat: init at 1.15
* [`f604963c`](https://github.com/NixOS/nixpkgs/commit/f604963c0688f1bfac7a6e824fbf21c4fd5b3385) mkchromecast: 2020-10-17 -> 2022-10-31
* [`1703f6fd`](https://github.com/NixOS/nixpkgs/commit/1703f6fd43acb5bc662e7f2eb24abb853a51f897) pipenv: 2022.11.11 -> 2022.11.25
* [`bfaf545a`](https://github.com/NixOS/nixpkgs/commit/bfaf545a33f23f605218e7c68a1527a0c51b09d8) dynamic-wallpaper: init at 0.1.0
* [`cdb450dc`](https://github.com/NixOS/nixpkgs/commit/cdb450dcbaed137886897fc5497bade0c895b296) maintainers: add huyngo
* [`656aac9b`](https://github.com/NixOS/nixpkgs/commit/656aac9b5f446c5c1cc09c6f7e6ee63a1150e02f) go-swag: 1.8.7 -> 1.8.8
* [`21e91b42`](https://github.com/NixOS/nixpkgs/commit/21e91b4261dddb511e37b2ab07b08ceb53fe74a9) filelight: add missing dependencies
* [`f19d1955`](https://github.com/NixOS/nixpkgs/commit/f19d19557f54ebb65957963ba654fe5098878d64) filelight: fmt with nixpkgs-fmt
* [`24703a94`](https://github.com/NixOS/nixpkgs/commit/24703a94e5d17cb52f8a379a9342f5517e82d0f5) graphia: 3.1 -> 3.2
* [`3fae5920`](https://github.com/NixOS/nixpkgs/commit/3fae5920e1cf4aecd6862a371af648dcfa01b916) highfive: 2.6.1 -> 2.6.2
* [`3c914b66`](https://github.com/NixOS/nixpkgs/commit/3c914b66c233c73c094e28f3b62383476c980027) imgui: 1.89 -> 1.89.1
* [`59a1c1bf`](https://github.com/NixOS/nixpkgs/commit/59a1c1bfe753b64ff15fc7fdc893af90082ee29a) jwx: 2.0.7 -> 2.0.8
* [`d3aed3dc`](https://github.com/NixOS/nixpkgs/commit/d3aed3dccf63c888da64ab7b367b661e4b4a17d4) kics: 1.6.4 -> 1.6.5
* [`ec635b51`](https://github.com/NixOS/nixpkgs/commit/ec635b51d6ca9536830c0b82d2d41256fde34641) geogebra: 5-0-723-0 → 5-0-745-0
* [`507629f9`](https://github.com/NixOS/nixpkgs/commit/507629f968b946eb493acfff821ec6b27843ee8d) komga: 0.157.4 -> 0.157.5
* [`5b4bf092`](https://github.com/NixOS/nixpkgs/commit/5b4bf09237ec95189037003bb97a7b47997635f5) geogebra6: fix the meta data to allow autoupdate
* [`bb92198f`](https://github.com/NixOS/nixpkgs/commit/bb92198f4c3dcf923f0f9ee21aafbefcd9d4ed86) geogebra6: 6-0-723-0 → 6-0-745-0
* [`42c3b4b1`](https://github.com/NixOS/nixpkgs/commit/42c3b4b1eccb4b3d0ffcc76fa79776b0d76282c3) python310Packages.aws-lambda-builders: 1.23.0 -> 1.23.1
* [`be825b65`](https://github.com/NixOS/nixpkgs/commit/be825b650a91ce7558fbac2190d5f496b16268fc) palemoon: 31.3.1 -> 31.4.0
* [`11ad3491`](https://github.com/NixOS/nixpkgs/commit/11ad3491691627d6ac3a1ff82694f504d4be39bc) python310Packages.aws-lambda-builders: add changelog to meta
* [`7dd3214c`](https://github.com/NixOS/nixpkgs/commit/7dd3214c52964a435d1fd3ccf902f214803a0a52) nixos/tests/musescore: fix
* [`04f6a47f`](https://github.com/NixOS/nixpkgs/commit/04f6a47f0a23a0918250116cbcb4aeeae65dc42b) lego: 4.9.0 -> 4.9.1
* [`86e5f2fc`](https://github.com/NixOS/nixpkgs/commit/86e5f2fcd418509d2882ee85ebb97162adda8daa) gx-go: 1.9.0 -> unstable-2020-03-03
* [`bc07c78d`](https://github.com/NixOS/nixpkgs/commit/bc07c78d85af5525f85a743b2983614b9713dd42) python310Packages.fasteners: add changelog to meta
* [`f118aac1`](https://github.com/NixOS/nixpkgs/commit/f118aac1f5c3903cff8adc2a63fe4c0b15e06941) python310Packages.fasteners: 0.17.3 -> 0.18
* [`0ece3c5d`](https://github.com/NixOS/nixpkgs/commit/0ece3c5d91eddb09161b3f0bcd509ab678f0e4e1) python310Packages.logilab-common: 1.6.1 -> 1.9.7
* [`10c2b21c`](https://github.com/NixOS/nixpkgs/commit/10c2b21c3f8dea83cfa4304109eac00d00be707e) python310Packages.logilab-common: rename using hyphen
* [`36a05174`](https://github.com/NixOS/nixpkgs/commit/36a0517448efa84116c03c2a6b76f89a443c11a9) python310Packages.bugzilla: clean up dependencies and enable tests
* [`f1a397de`](https://github.com/NixOS/nixpkgs/commit/f1a397de0cca88a70d5dadfe74ee03b65af2cab4) python310Packages.pyperf: 2.4.1 -> 2.5.0
* [`b5fe06f1`](https://github.com/NixOS/nixpkgs/commit/b5fe06f1d2e163355662a010e52e90cbac379a29) mongodb-compass: 1.33.1 -> 1.34.1
* [`ce571fce`](https://github.com/NixOS/nixpkgs/commit/ce571fce9f505981debcc7efda9432654b1135e0) soundtracker: 1.0.2.1 -> 1.0.3
* [`2db377af`](https://github.com/NixOS/nixpkgs/commit/2db377afd15d6bfc564fa6df9b7ae3b0c54479f0) checkSSLCert: Add missing runtime dependencies
* [`b1d525cd`](https://github.com/NixOS/nixpkgs/commit/b1d525cd1d5bb92de67881c517326b43160ed66b) maintainers: add sielicki
* [`c1e78581`](https://github.com/NixOS/nixpkgs/commit/c1e785814141a1410214b28ef415c361a088009f) prusa-slicer: add darwin support
* [`32bbf73f`](https://github.com/NixOS/nixpkgs/commit/32bbf73f49d6504196468691d2f33a3ef71273e9) opentelemetry-collector: 0.64.1 -> 0.66.0
* [`ea6aa983`](https://github.com/NixOS/nixpkgs/commit/ea6aa983289bfb059d6a132b3904a59dbc5663b5) super-slicer, super-slicer-latest: add darwin support
* [`d5fd2b7e`](https://github.com/NixOS/nixpkgs/commit/d5fd2b7e052b35b1df1fdc446da4528ecd3f2b3d) chickenPackages: fix build on aarch64-darwin
* [`9dc44924`](https://github.com/NixOS/nixpkgs/commit/9dc44924fd86115961dd9447a5d1c4d11ec25135) python310Packages.h5netcdf: 1.0.2 -> 1.1.0
* [`dde0ac4c`](https://github.com/NixOS/nixpkgs/commit/dde0ac4ca9227ffe33b754b3c83566c0f2fb1d70) tdlib: 1.8.7 -> 1.8.8
* [`898769de`](https://github.com/NixOS/nixpkgs/commit/898769de6266b08bd35fde051db83c6064c7e53f) _3mux: update patches
* [`48e8a5c7`](https://github.com/NixOS/nixpkgs/commit/48e8a5c7fcd1ef1edfe1d8a69a05403a62cdd38e) xterm: 375 -> 377
* [`5ab0a8d1`](https://github.com/NixOS/nixpkgs/commit/5ab0a8d16aae2746603dd566f5f686d63eab6d74) ngtcp2-gnutls: 0.10.0 -> 0.11.0
* [`3a164026`](https://github.com/NixOS/nixpkgs/commit/3a1640263c69bc294506d200dc2d0c066be44394) python310Packages.h5netcdf: add changelog to meta
* [`bf23d0e4`](https://github.com/NixOS/nixpkgs/commit/bf23d0e45b6bab9df98aa6d3c1de9beb5ea0dd5f) mdbook-katex: 0.2.10 -> 0.2.17
* [`486b420b`](https://github.com/NixOS/nixpkgs/commit/486b420ba3df99590604c981a10e20608270aa86) cryptopp: 8.6.0 -> 8.7.0
* [`77cfcd49`](https://github.com/NixOS/nixpkgs/commit/77cfcd49406196294b5aebb20f6167377f94aace) python3Packages.atomman: relax dependency
* [`9e572f25`](https://github.com/NixOS/nixpkgs/commit/9e572f250a171878c034d42471405c9950f43c06) exiftool: 12.50 -> 12.51
* [`ca3bf650`](https://github.com/NixOS/nixpkgs/commit/ca3bf6506aa4915ce2102dc92c0d3474b6434dc9) Launch signal-desktop in background, pipe stdout to log file to avoid crash
* [`79dd29df`](https://github.com/NixOS/nixpkgs/commit/79dd29df93de2dd4d66d92bc73e9841bd917db1c) vmagent: 1.83.0 -> 1.84.0
* [`6033e4e5`](https://github.com/NixOS/nixpkgs/commit/6033e4e5ed285759726050faaf6f75fbdbb33b20) gitea: needs gnupg in its path to sign commits
* [`78b19e0c`](https://github.com/NixOS/nixpkgs/commit/78b19e0c37886f20af93f093ae66c61b138c3a91) python310Packages.mailchecker: 5.0.3 -> 5.0.4
* [`ba8982dd`](https://github.com/NixOS/nixpkgs/commit/ba8982dd3344c89a64a0419f465050ece65bd493) ngrok: 3.0.4 -> 3.1.0
* [`6d43ede8`](https://github.com/NixOS/nixpkgs/commit/6d43ede855855f94b79d4194388e03a45ac0b7ee) deltachat-desktop: 1.30.1 -> 1.34.0
* [`9ee630a9`](https://github.com/NixOS/nixpkgs/commit/9ee630a93e2b226daaea17b454fba0069208826e) pe-bear: init at 0.6.1
* [`7cb7cac6`](https://github.com/NixOS/nixpkgs/commit/7cb7cac6a543c25918c2b8272668c353e10aaea0) kamid: fix cross-compilation
* [`0ba4faa6`](https://github.com/NixOS/nixpkgs/commit/0ba4faa6b07d2bd12fc84c62f09da787f65818b1) python310Packages.dateparser: 1.1.3 -> 1.1.4
* [`4d40b87e`](https://github.com/NixOS/nixpkgs/commit/4d40b87e35a6511b8870e819e1bff1eff41bb5c8) xournalpp: 1.1.2 -> 1.1.3
* [`7c51c518`](https://github.com/NixOS/nixpkgs/commit/7c51c518c95b3e612ad41d5ee0cdcb4ea2a4f3b7) python310Packages.angrop: patch to work with newer angr version
* [`7a6755b9`](https://github.com/NixOS/nixpkgs/commit/7a6755b91ac392a7cc8d1afb9163da77a8fb986b) pythonPackages.weakrefmethod: init at 1.0.3
* [`c7094d2c`](https://github.com/NixOS/nixpkgs/commit/c7094d2c9c0a33782f6e7aa9abed6ea9fbb11bde) pythonPackages.signalslot: init at 0.1.2
* [`1dbbfb41`](https://github.com/NixOS/nixpkgs/commit/1dbbfb411ece9c61fad23025448ee14778ea8e83) maintainers: add myaats
* [`58ff418f`](https://github.com/NixOS/nixpkgs/commit/58ff418feca3b032b4c1744329887c57ee9b9036) patsh: init at 0.1.3
* [`3e3f5eba`](https://github.com/NixOS/nixpkgs/commit/3e3f5eba2cd987822478b8e5db57fb759a85043e) sx: use patsh instead of resholve
* [`cf50cc13`](https://github.com/NixOS/nixpkgs/commit/cf50cc1363396c20cda9d39d9175e7845af9c0a0) cairo: remove unnecessary ? null from inputs, little cleanups
* [`0811f83e`](https://github.com/NixOS/nixpkgs/commit/0811f83e3cf5a6a6d1d457556fd62fd01750524a) libdbi-drivers: remove global with lib, add TODO
* [`69dc4796`](https://github.com/NixOS/nixpkgs/commit/69dc4796f25ce2add14bc3ebb4fd4d729ecdb59d) hexdino: 0.1.1 -> 0.1.2
* [`df1d517b`](https://github.com/NixOS/nixpkgs/commit/df1d517b3ea690dcb1f0214fafcfc7bc23e13d79) async-profiler: 2.8.3 -> 2.9
* [`2e1966a7`](https://github.com/NixOS/nixpkgs/commit/2e1966a7e3cd5259af433a97cf2b335724be4ae8) onefetch: 2.13.2 -> 2.14.2
* [`98d14710`](https://github.com/NixOS/nixpkgs/commit/98d14710200ad518738a3c9b4d27f702c6183c77) hqplayer-desktop: mark broken because src link is 403
* [`f5d62d41`](https://github.com/NixOS/nixpkgs/commit/f5d62d419e86249c9910f43d6d6c4e9c156d3ac3) nix-update-script: add extraArgs to pass custom arguments to nix-update
* [`7d513237`](https://github.com/NixOS/nixpkgs/commit/7d5132376eddab09884ffbffdf65521e94fc2614) zoneminder: fix linking against mariadb
* [`08128960`](https://github.com/NixOS/nixpkgs/commit/081289609ec6a274793bd47f9e302fc3a6500c5b) pari: 2.13.4 -> 2.15.1
* [`3b258a60`](https://github.com/NixOS/nixpkgs/commit/3b258a60a65d208d5cd38cc66e2bdd43b3564d4b) sage: import pari 2.15.1 update patch
* [`5a04b35b`](https://github.com/NixOS/nixpkgs/commit/5a04b35bd33dddec96625e996f9241980ca46f26) steamtinkerlaunch: init at 11.11
* [`db4c1fb5`](https://github.com/NixOS/nixpkgs/commit/db4c1fb5cee910879645713e252ad9315fdbd0f5) yex-lang: unbreak on aarch64-linux
* [`80f99bc8`](https://github.com/NixOS/nixpkgs/commit/80f99bc8f6cd9e81af942fea7b25b47a5b0b35d1) mono: cleanup
* [`c36077d3`](https://github.com/NixOS/nixpkgs/commit/c36077d3e83b109f64e0b27a8fa247ae508f8e0d) haskellPackages: add ivanbrennan as a maintainer
* [`a4f053f0`](https://github.com/NixOS/nixpkgs/commit/a4f053f0e4f5cfe53d8d3a4d9c7f5bf2630812c9) nixos/release-notes: add entry for [nixos/nixpkgs⁠#191713](https://togithub.com/nixos/nixpkgs/issues/191713)
* [`31dae4a6`](https://github.com/NixOS/nixpkgs/commit/31dae4a6c0a6a88457011647cdd6c6c237129461) formula: unbreak on aarch64-linux
* [`4ffc4eba`](https://github.com/NixOS/nixpkgs/commit/4ffc4ebacd4964eeab56ddf251ba0fb22cfe1267) python310Packages.pex: 2.1.114 -> 2.1.116
* [`9b5fafa4`](https://github.com/NixOS/nixpkgs/commit/9b5fafa4d3fc001b4e80524ee4890f8a9bf9b2c9) python310Packages.apprise: 1.1.0 -> 1.2.0
* [`b0302752`](https://github.com/NixOS/nixpkgs/commit/b03027524f8092c76e611b86924eafaaa389849b) python310Packages.x-wr-timezone: init at 0.0.5
* [`0fe50170`](https://github.com/NixOS/nixpkgs/commit/0fe5017065d24b7f44700e29aa213e151aab8463) python310Packages.recurring-ical-events: init at 1.1.0b0
* [`d008be1f`](https://github.com/NixOS/nixpkgs/commit/d008be1ff19f1d3ae421ba5e2779b78217aac106) python310Packages.caldav: 0.9.1 -> 0.11.0
* [`37103c03`](https://github.com/NixOS/nixpkgs/commit/37103c0358e04c53b8f1dd371fcda740bb5bdc5c) calendar-cli: 0.13.0 -> 0.14.1
* [`6949cecb`](https://github.com/NixOS/nixpkgs/commit/6949cecbd6b3b9e78ae91b8b97dc001075378abc) home-assistant: use caldav 0.9.1
* [`064cfac4`](https://github.com/NixOS/nixpkgs/commit/064cfac4f9ef9863fef761b0afa263192e46405c) python310Packages.posix_ipc: 1.0.5 -> 1.1.0
* [`5aaa6f33`](https://github.com/NixOS/nixpkgs/commit/5aaa6f33d600b6d7b0087c0b14f837dade96f474) python310Packages.snowflake-connector-python: 2.8.0 -> 2.8.2
* [`c3a00241`](https://github.com/NixOS/nixpkgs/commit/c3a00241700de8c4c7bee20614a6f918346be66e) python310Packages.snowflake-sqlalchemy: 1.4.3 -> 1.4.4
* [`25dfb66d`](https://github.com/NixOS/nixpkgs/commit/25dfb66d5442d5b519c914de87423aed44e70870) spirv-headers: use clickable homepage
* [`df509993`](https://github.com/NixOS/nixpkgs/commit/df509993c857c428bfbf672b506b50ca4fe44453) spirv-tools: use clickable homepage
* [`b71a6f04`](https://github.com/NixOS/nixpkgs/commit/b71a6f048a2907beb307e32a84c4f468e2dce0e6) hysteria: 1.3.0 -> 1.3.1
* [`39770aee`](https://github.com/NixOS/nixpkgs/commit/39770aeebd0c2ac87553c97e72a9f281e9320453) altair: 4.6.2 -> 5.0.5
* [`df96da7b`](https://github.com/NixOS/nixpkgs/commit/df96da7bca06c3e44c6f96e850f4c441315ce3b8) aws-c-mqtt: 0.7.13 -> 0.8.0
* [`362b2232`](https://github.com/NixOS/nixpkgs/commit/362b22325577969aa095f9ef331720343a7019b3) resholve: 0.8.1 -> 0.8.3
* [`311adbd5`](https://github.com/NixOS/nixpkgs/commit/311adbd52d663ffed6d1b201adc8bd75717c5578) appgate-sdp: 6.0.2 -> 6.0.3
* [`1bd51589`](https://github.com/NixOS/nixpkgs/commit/1bd5158963136e7c211faf1a5a315771b82e9ae1) buttercup-desktop: 2.16.0 -> 2.17.0
* [`2494ce82`](https://github.com/NixOS/nixpkgs/commit/2494ce82be2d34fa6dca54c14e7a350b9f817a12) ola: build with ftdidmx support
* [`e9073ef0`](https://github.com/NixOS/nixpkgs/commit/e9073ef081289511d1551ea575e37b28b7eb351a) julia-mono: 0.044 → 0.046
* [`065af611`](https://github.com/NixOS/nixpkgs/commit/065af611420dc1ebb34cafc2265b649fb379896f) libvirt, perlPackages.SysVirt: 8.8.0 -> 8.9.0
* [`32a12a9e`](https://github.com/NixOS/nixpkgs/commit/32a12a9e3ebcbb33dc914b682cd1e3a2fa465fdb) haskellPackages: add dschrempf xmonad maintainer
* [`f92cb295`](https://github.com/NixOS/nixpkgs/commit/f92cb29575b1a9efb0805a10e1161e0d413d4a23) bundlewrap: 4.15.0 -> 4.16.0
* [`535e40a6`](https://github.com/NixOS/nixpkgs/commit/535e40a6b8c06200190422004f199da3078674d5) rocm-related: build documentation by default
* [`d54ee59f`](https://github.com/NixOS/nixpkgs/commit/d54ee59ff5c0c499fc710a507afa0a303f2e9484) miopen: don't use nativeBuildInputs in test fixup
* [`686606ea`](https://github.com/NixOS/nixpkgs/commit/686606ead1fef695d864c2f8f3cfe925299a03de) rocm-related: use empty list instead of null for gpuTargets
* [`2a44f631`](https://github.com/NixOS/nixpkgs/commit/2a44f631fa69676d7f63d7833c1e98ec7632ba00) rocm-related: remove ? null and related asserts
* [`3ced8179`](https://github.com/NixOS/nixpkgs/commit/3ced8179cd48d784d8a68b4d9c5cd332a3ed48e4) rocm-related: optional GITHUB_TOKEN for update script
* [`9dca9850`](https://github.com/NixOS/nixpkgs/commit/9dca98505c176cbdd327a188007e9cf4f1e90535) rocm-related: lib.strings -> lib
* [`e48d21ab`](https://github.com/NixOS/nixpkgs/commit/e48d21ab76b3329dd9ee4e702646c6f941617453) rlaunch: fix build on aarch64-linux
* [`c4f0b1dc`](https://github.com/NixOS/nixpkgs/commit/c4f0b1dc6774f8b3eccece07894da47a112b5e00) rustracer: remove (deprecated)
* [`45b1938b`](https://github.com/NixOS/nixpkgs/commit/45b1938b497f981a144994a97033ea18f37e2a51) e16: 1.0.26 -> 1.0.27
* [`5775846a`](https://github.com/NixOS/nixpkgs/commit/5775846a954277f0f98cab1cd5ad4fa33f78f7ae) flatpak-builder: 1.2.2 -> 1.2.3
* [`1a25877c`](https://github.com/NixOS/nixpkgs/commit/1a25877c44aa664ebba7c58a9d91c8873ef4f9d3) electron-mail: 5.0.1 -> 5.1.2
* [`925e1483`](https://github.com/NixOS/nixpkgs/commit/925e1483b8e01c234a62eea77a6f96c2c5facea4) snabb: fix build
* [`c89ae66c`](https://github.com/NixOS/nixpkgs/commit/c89ae66c22fdfa03275fd6266cfafe569fdfb5c5) b3sum: 1.3.1 -> 1.3.3
* [`fe922ba3`](https://github.com/NixOS/nixpkgs/commit/fe922ba370a3857b308bc0f61ba28df2a37c92e3) esbuild: 0.15.15 -> 0.15.16
* [`be1187e3`](https://github.com/NixOS/nixpkgs/commit/be1187e30f67992c683487bf5ab74d10189c71d2) nitter: use nix-update in update script
* [`a6415e61`](https://github.com/NixOS/nixpkgs/commit/a6415e6158f7cef321c695ddfa774ce0e2c9737a) python310Packages.openstacksdk: 0.102.0 -> 0.103.0
* [`33db1dc0`](https://github.com/NixOS/nixpkgs/commit/33db1dc000cd1ff1092f315a42bca602f20afa49) d2: init at 0.0.13 ([nixos/nixpkgs⁠#202355](https://togithub.com/nixos/nixpkgs/issues/202355))
* [`93de6bf9`](https://github.com/NixOS/nixpkgs/commit/93de6bf9ed923bf2d0991db61c2fd127f6e984ae) nixos/mastodon: add smtp assertions
* [`b1a2e9c9`](https://github.com/NixOS/nixpkgs/commit/b1a2e9c9acdef88b639385db96c7ebc5e83b27a5) firefox_decrypt: replace update script with nix-update
* [`fe025789`](https://github.com/NixOS/nixpkgs/commit/fe0257891bbc5c39b6c225e0c35633d9da478404) mpvScripts.sponsorblock: replace update script with nix-update
* [`78c7e665`](https://github.com/NixOS/nixpkgs/commit/78c7e665d4d3f83cdd7fd444099f2851f463dee7) rocm-related: move asserts to broken
* [`1ffa9810`](https://github.com/NixOS/nixpkgs/commit/1ffa9810879da4a0de01d9fc47da4f3099486f9f) git-delete-merged-branches: 7.2.0 -> 7.2.2
* [`930d8d5c`](https://github.com/NixOS/nixpkgs/commit/930d8d5c74cfe0997b6e5ebfdee84c8e1a9679d8) grive2: 0.5.1 -> 0.5.3
* [`30a6bef0`](https://github.com/NixOS/nixpkgs/commit/30a6bef0266576857c3597f8aac19326bfee4983) rocm-related: deprecate rocmVersion and repoVersion
* [`40fddeb8`](https://github.com/NixOS/nixpkgs/commit/40fddeb8fc422a57b3f025b0bd1d1078fbe0591a) giac: mark as broken on aarch64-darwin
* [`17f6139f`](https://github.com/NixOS/nixpkgs/commit/17f6139f92f89b9de04c1126dc5935312cd68e7b) qmmp: 1.4.4 -> 2.1.2
* [`b95d3db4`](https://github.com/NixOS/nixpkgs/commit/b95d3db40c551a95330f38c5cff2fd4f72f2e48c) mari0: use copyDesktopItems
* [`f5339d23`](https://github.com/NixOS/nixpkgs/commit/f5339d2339ebc728e32131c8141786b0e5e30cce) honk: init at 0.9.8
* [`2311dabe`](https://github.com/NixOS/nixpkgs/commit/2311dabeab316fa88e38b375cf18e84621bf60ae) python3Packages.tensorflow: set LIBTOOL env on aarch64-darwin
* [`1bd32e6b`](https://github.com/NixOS/nixpkgs/commit/1bd32e6b425f5f942a453e8136c786d48df31fab) python3Packages.tensorflow: patch even more shebangs
* [`37f9d286`](https://github.com/NixOS/nixpkgs/commit/37f9d28634c4b5c3326fd8120ab2ac04708ae0f3) mpris-scrobbler: 0.4.95 -> 0.5.0
* [`2fc9e88c`](https://github.com/NixOS/nixpkgs/commit/2fc9e88c8c474a03f1fea90fa1926395582fd3a3) nixos/erigon: add extraArgs
* [`84e05961`](https://github.com/NixOS/nixpkgs/commit/84e05961f86c37a66018c9d2e9137a0508a87223) nixos/tests/restic: cleanup
* [`7cdb3135`](https://github.com/NixOS/nixpkgs/commit/7cdb313558d926bf33927aaddf6d0a9651867604) nixos/tests/restic: unify naming
* [`ccfc1d24`](https://github.com/NixOS/nixpkgs/commit/ccfc1d24214c436b192eebac15d2d8b9129b192f) nixos/tests/restic: use machine-readable output
* [`3ff61b60`](https://github.com/NixOS/nixpkgs/commit/3ff61b60949d7480a0200cd79eaaa565d23a695b) Revert "Launch signal-desktop in background, pipe stdout to log file to avoid crash"
* [`848ef66f`](https://github.com/NixOS/nixpkgs/commit/848ef66feba6aa04a50f8daaf57f7a8a8145d4b5) mbqn: 0.pre+date=2022-10-03 -> 0.pre+date=2022-11-24
* [`957408ce`](https://github.com/NixOS/nixpkgs/commit/957408ced4ae24259908e98e53e335fe83c3e02b) cbqn: 0.pre+date=2022-10-04 -> 0.pre+date=2022-11-27
* [`34a7008e`](https://github.com/NixOS/nixpkgs/commit/34a7008ed4c47946df0f9984575c7f151ba9fdb4) qcoro: 0.6.0 -> 0.7.0
* [`edc3ece6`](https://github.com/NixOS/nixpkgs/commit/edc3ece6df8f30ee81d1477a27f438b79911ef2a) gtklock: init at 2.0.1
* [`9c8f2f67`](https://github.com/NixOS/nixpkgs/commit/9c8f2f6767d4978397ded62dc6dfdb70772f68d8) flexget: 3.5.5 -> 3.5.6
* [`6c0f637b`](https://github.com/NixOS/nixpkgs/commit/6c0f637b50ad9b0764aeeace12fea8955238d204) zed: 1.2.0 -> 1.3.0
* [`5c620e22`](https://github.com/NixOS/nixpkgs/commit/5c620e2243a52b095b2c76a0d684d914736975f5) imageworsener: 1.3.4 -> 1.3.5
* [`d0690595`](https://github.com/NixOS/nixpkgs/commit/d0690595a6c9f72775f25b8f7395b8251bc40f33) protoc-gen-connect-go: 1.1.0 -> 1.2.0
* [`385fc8e4`](https://github.com/NixOS/nixpkgs/commit/385fc8e434eb92e8fb002b069946de3484618578) kapp: 0.53.0 -> 0.54.0
* [`c5be637c`](https://github.com/NixOS/nixpkgs/commit/c5be637c729588cbe6ead72995569e68660e52bf) vowpal-wabbit: 9.0.1 -> 9.6.0
* [`c0ba4332`](https://github.com/NixOS/nixpkgs/commit/c0ba43324cff51dbe238fb81c86bac1237adab66) immudb: 1.4.0 -> 1.4.1 ([nixos/nixpkgs⁠#202309](https://togithub.com/nixos/nixpkgs/issues/202309))
* [`ebdafd72`](https://github.com/NixOS/nixpkgs/commit/ebdafd7244832f1f52cacd3eda39f2156988957e) okteto: 2.9.0 -> 2.9.1
* [`4396203d`](https://github.com/NixOS/nixpkgs/commit/4396203d2d4d8ad6b3cdebd8ea269a25747b1fa5) bunyan-rs: 0.1.7 -> 0.1.9
* [`c5637ea7`](https://github.com/NixOS/nixpkgs/commit/c5637ea757fa2113846d0062a9fa6a56e87f676a) cargo-llvm-cov: 0.5.0 -> 0.5.2
* [`b33cc1ec`](https://github.com/NixOS/nixpkgs/commit/b33cc1ecc684daf124d4d34499b112a8f7339653) checkSSLCert: 2.54.0 -> 2.55.0
* [`81322c4c`](https://github.com/NixOS/nixpkgs/commit/81322c4c87ea2ae3aa417f8bfc5a88f0abee7fd8) checkstyle: 10.4 -> 10.5.0
* [`6e1ffe2c`](https://github.com/NixOS/nixpkgs/commit/6e1ffe2cc815ce9148e91d96b7ab2e138e593d1a) jet: 0.1.0 -> 0.3.21
* [`0b4ef3e8`](https://github.com/NixOS/nixpkgs/commit/0b4ef3e8ea7001dd2ee69ebf22c6d0d692d94447) river: install session file
* [`4768e630`](https://github.com/NixOS/nixpkgs/commit/4768e63088333674ae75b8af5556b8c82f7c2aa0) ursadb: 1.2.0 -> 1.5.0
* [`4a8aa91b`](https://github.com/NixOS/nixpkgs/commit/4a8aa91be6290d0f6dceb929a8e8478ec9dd8246) python-launcher: init at 1.0.0
* [`96424ddf`](https://github.com/NixOS/nixpkgs/commit/96424ddf55485130af9565701db78fc9429f8aad) lxd: Check if `lxcfs` is enabled before adding it as service dependency
* [`08026e6d`](https://github.com/NixOS/nixpkgs/commit/08026e6dcf5019e4267226dc844c85b918a5768e) pdfarranger: 1.9.1 -> 1.9.2
* [`50e6f4b7`](https://github.com/NixOS/nixpkgs/commit/50e6f4b7c1d8de89c594c6915415b4c1fc42ee96) swaynotificationcenter: 0.7.2 -> 0.7.3
* [`7e783164`](https://github.com/NixOS/nixpkgs/commit/7e7831645c6145d005c2c3d46bcfd943450621c3) signalbackup-tools: 20221122 -> 20221128
* [`6c492a69`](https://github.com/NixOS/nixpkgs/commit/6c492a6936ce806ce5a73b7d21ca8f56f15a231b) nim: 1.6.8 -> 1.6.10
* [`88c9a926`](https://github.com/NixOS/nixpkgs/commit/88c9a92624c7e44396390b03c27dbb6212962f3b) Nim: resurrect bootstrap compiler
* [`19b9e5d6`](https://github.com/NixOS/nixpkgs/commit/19b9e5d658dcdec77a4e6629eefcbcedc5f24365) python310Packages.pypykatz: add changelog to meta
* [`e214a073`](https://github.com/NixOS/nixpkgs/commit/e214a073dfe8040c253ed3582064409b2b695bc3) python310Packages.minikerberos: add changelog to meta
* [`3dd6a802`](https://github.com/NixOS/nixpkgs/commit/3dd6a802e56bbfa2213602e558a70493d1000005) python310Packages.minikerberos: 0.3.3 -> 0.3.5
* [`d3ef305b`](https://github.com/NixOS/nixpkgs/commit/d3ef305bd7dbffbbd9c8e2886daf25d99f0fac92) python310Packages.asyauth: 0.0.7 -> 0.0.9
* [`af99a33c`](https://github.com/NixOS/nixpkgs/commit/af99a33caf7d5312cfb36f6b6b375f99fa95b7f7) python310Packages.pypykatz: 0.6.2 -> 0.6.3
* [`ab1c9756`](https://github.com/NixOS/nixpkgs/commit/ab1c9756f036098ee2f2ce9fac7ce29465009922) inql: 4.0.5 -> 4.0.6
* [`5fa06e50`](https://github.com/NixOS/nixpkgs/commit/5fa06e50af9a72b79586ec84c9db4573a47a34aa) python310Packages.pyoverkiz: add changelog to meta
* [`fe3417a5`](https://github.com/NixOS/nixpkgs/commit/fe3417a555febf11712065b1415a64035ab6f73f) python310Packages.pyoverkiz: 1.6.0 -> 1.7.0
* [`5ab19aa4`](https://github.com/NixOS/nixpkgs/commit/5ab19aa443db496577f07ed9f2ab0f30a1e318d1) python310Packages.proxmoxer: add achangelog to meta
* [`a1d742d7`](https://github.com/NixOS/nixpkgs/commit/a1d742d758b6556713e944badbb3062516c9c220) jackett: 0.20.2291 -> 0.20.2297
* [`3aff9169`](https://github.com/NixOS/nixpkgs/commit/3aff91691488ead5cf637ba17720aed377c5d6bf) nixos/opensnitch: Add option to configure rules
* [`f63510fa`](https://github.com/NixOS/nixpkgs/commit/f63510fa80ce35cda0d090ec586b80a1387bcc0d) kodiPackages.certifi: 2022.5.18+matrix.1 -> 2022.9.24
* [`29ab8d3a`](https://github.com/NixOS/nixpkgs/commit/29ab8d3acfa0d1a96044c0e6e7329b7836f0946d) kodiPackages.idna: 3.3.0+matrix.1 -> 3.4.0
* [`44dca86b`](https://github.com/NixOS/nixpkgs/commit/44dca86b16b7a001b179f912accb7eb9defb75ce) sameboy: fix build by removing upstreamed patch
* [`69f16ac7`](https://github.com/NixOS/nixpkgs/commit/69f16ac7e1204bbbf7af90733f00e79112021453) kodiPackages.urllib3: 1.26.9+matrix.1 -> 1.26.13+matrix.1
* [`9d5f23a2`](https://github.com/NixOS/nixpkgs/commit/9d5f23a2d4dab09c8e89c88d6c9ff73411a28cf4) python310Packages.proxmoxer: 1.3.1 -> 2.0.0
* [`029bc771`](https://github.com/NixOS/nixpkgs/commit/029bc7714a589476a4f2eae6e27d39b9638331ef) changedetection-io: 0.39.21.1 -> 0.39.22.1
* [`6dbbe217`](https://github.com/NixOS/nixpkgs/commit/6dbbe21770853556e7f48abdc1bf2e1648492c07) emacs: override built-in cl-print as null
* [`bebe0f71`](https://github.com/NixOS/nixpkgs/commit/bebe0f71df8ce8b7912db1853a3fd1d866b38d39) buildah-unwrapped: 1.28.1 -> 1.28.2
* [`693a660f`](https://github.com/NixOS/nixpkgs/commit/693a660f07fe14d16affbe59c70c710e55105235) python3Packages.apsw: 3.39.4.0 -> 3.40.0.0
* [`f90701b4`](https://github.com/NixOS/nixpkgs/commit/f90701b40507a5767ab21ba5ae090ad42a3dfacf) maintainers: add imincik
* [`4024dedc`](https://github.com/NixOS/nixpkgs/commit/4024dedc4dc9980fc731d48be3ec67b642a9a838) chromiumBeta: Fix the build
* [`18271606`](https://github.com/NixOS/nixpkgs/commit/18271606a27dbd337515e74387e994f6079c3462) elasticsearch6: add libcrypt dependency to fix build
* [`9c3dc3cf`](https://github.com/NixOS/nixpkgs/commit/9c3dc3cfeb15d4073eacb3802e8795abce848607) linux: kernel: enable DRM_HYPERV
* [`5f6ad4d8`](https://github.com/NixOS/nixpkgs/commit/5f6ad4d8341b0ea58ba658edefc8b5f1bf3a7f91) appthreat-depscan: 3.2.0 -> 3.2.1
* [`e608cf56`](https://github.com/NixOS/nixpkgs/commit/e608cf560075b5563fae2482e080b203df74d868) zine: 0.7.0 -> 0.8.0
* [`6b5081d1`](https://github.com/NixOS/nixpkgs/commit/6b5081d127df6764083866f3b1133a721c3b789b) ocamlPackages.js_of_ocaml-camlp4: remove at 3.2.1
* [`11e329ae`](https://github.com/NixOS/nixpkgs/commit/11e329ae8c251cabb38f4b00ec33607e74c188e9) ocamlPackages.ocsigen_deriving: remove at 0.8.2
* [`a6df3667`](https://github.com/NixOS/nixpkgs/commit/a6df36675104250ecf117b1042a1200ee5c03255) evcc: 0.108.0 -> 0.108.2
* [`0643540f`](https://github.com/NixOS/nixpkgs/commit/0643540f97995e785b5e1d9b62be6876da3d2d20) rustPlatform.cargoNextestHook: init
* [`d3eb6062`](https://github.com/NixOS/nixpkgs/commit/d3eb6062965ddfec2e0bc029bfbab21a6421b751) rustPlatform.buildRustPackage: add useNextest option to check with cargo-nextest
* [`52153336`](https://github.com/NixOS/nixpkgs/commit/52153336fef629cf60422c9265e757f5ade160b6) python-launcher: check with cargo-nextest
* [`79426ce4`](https://github.com/NixOS/nixpkgs/commit/79426ce44526c562b063d04c6078b75523d65cba) linuxPackages.nvidia_x11_production:  515.86.01 -> 525.60.11
* [`1befba0d`](https://github.com/NixOS/nixpkgs/commit/1befba0d66b9738212adbbf7c094cba1bd72fe04) portfolio: add update script and make it nix-run-able ([nixos/nixpkgs⁠#199904](https://togithub.com/nixos/nixpkgs/issues/199904))
* [`bb498e02`](https://github.com/NixOS/nixpkgs/commit/bb498e020254ebf7ccc0c806663f6de42c363f94) blender: fix on darwin ([nixos/nixpkgs⁠#200185](https://togithub.com/nixos/nixpkgs/issues/200185))
* [`4981121b`](https://github.com/NixOS/nixpkgs/commit/4981121b4feed9564a2a27aa7747accf8e434104) smartgithg: 21.2.2 -> 22.1.0
* [`d6d5ddb9`](https://github.com/NixOS/nixpkgs/commit/d6d5ddb9b623b8aa0e8a1dab72c1cb00a64e4480) zsa-udev-rules: 2.1.3 -> unstable-2022-10-26
* [`255cfa73`](https://github.com/NixOS/nixpkgs/commit/255cfa731a7d12554e1dedb8bc78b653c0c19171) desmume: unbreak on aarch64-linux
* [`395e4773`](https://github.com/NixOS/nixpkgs/commit/395e4773c8390b436b4f568a1b06c749a40bd285) numix-icon-theme-circle: 22.11.05 -> 22.11.26
* [`4ca28642`](https://github.com/NixOS/nixpkgs/commit/4ca286427d996aea6cbeef6a0981f11fae524b08) numix-icon-theme-square: 22.11.05 -> 22.11.26
* [`c6ab0931`](https://github.com/NixOS/nixpkgs/commit/c6ab0931c5d97fddcd3ee05f99f4fad8108e6a71) vimPlugins: update
* [`390c6824`](https://github.com/NixOS/nixpkgs/commit/390c6824022d6bfc3753ca4127acf077f3c7c0c5) ladybird: fix build
* [`0f386d18`](https://github.com/NixOS/nixpkgs/commit/0f386d18962d699c2a9d29f5b62fa645ad887d5f) docs/rust: document `cargoNextestHook` and `useNextest`
* [`6e14a6d3`](https://github.com/NixOS/nixpkgs/commit/6e14a6d3d16cb92c3ab522a7f53412b4edc46fb3) vimPlugins.bufferize-vim: init at 2022-06-25
* [`ea861057`](https://github.com/NixOS/nixpkgs/commit/ea8610577652e5424e85c183a1c31ee946b01b4f) folly: 2022.11.07.00 -> 2022.11.28.00
* [`a5bcff8e`](https://github.com/NixOS/nixpkgs/commit/a5bcff8ef2a64dea7efcdb109ebe090e02e5f69a) vimPlugins.vim-openscad: init at 2022-07-26
* [`c531e5b3`](https://github.com/NixOS/nixpkgs/commit/c531e5b329fe8226f46acb0931b58f9172877520) python310Packages.cypherpunkpay: fix the package
* [`0f98326a`](https://github.com/NixOS/nixpkgs/commit/0f98326a56cf6e21b5b6badf948f677e195457ad) vimPlugins.nvim-treesitter: update grammars
* [`fa3fc2c9`](https://github.com/NixOS/nixpkgs/commit/fa3fc2c985d6fe7544c43ba6fe1360e2c38f9428) sqlcl: init at 22.3.1
* [`446dd861`](https://github.com/NixOS/nixpkgs/commit/446dd861c66c5e176fbee0045be76ed6a2284d41) httm: 0.16.5 -> 0.17.7
* [`8b89e2b8`](https://github.com/NixOS/nixpkgs/commit/8b89e2b819ef66f4faaf1c1b2550e714e1dc5dad) motrix: init at 1.6.11 ([nixos/nixpkgs⁠#185804](https://togithub.com/nixos/nixpkgs/issues/185804))
* [`d865afb0`](https://github.com/NixOS/nixpkgs/commit/d865afb0a5c957b1c2dddd0e744b21bda726bf53) screenkey: 1.4 -> 1.5
* [`f577e15c`](https://github.com/NixOS/nixpkgs/commit/f577e15cb842211f4c4d1b66b44a605cd90e5273) jql: 5.1.2 -> 5.1.3
* [`383d720a`](https://github.com/NixOS/nixpkgs/commit/383d720af2e39b5d8ef6d6f99372445d24638853) cinnamon.cinnamon-menus: 5.4.0 -> 5.6.0
* [`b40cf400`](https://github.com/NixOS/nixpkgs/commit/b40cf400d68dd3b9e3fc0b19484b55e69ca752b1) cinnamon.xapp: 2.2.15 -> 2.4.1
* [`7e4fb8da`](https://github.com/NixOS/nixpkgs/commit/7e4fb8daf5d727b00660949a7ef2d4dd50fc6152) python3.pkgs.xapp: 2.2.2 -> 2.4.0
* [`faed103f`](https://github.com/NixOS/nixpkgs/commit/faed103fb70e9370ffe2d1f4cddd3cf45c1cb2d4) cinnamon.mint-artwork: 1.6.0 -> 1.6.8
* [`840f7dda`](https://github.com/NixOS/nixpkgs/commit/840f7dda71a8d01337cd3a441751f929e9e04097) cinnamon.cinnamon-control-center: 5.4.7 -> 5.6.0
* [`559038ec`](https://github.com/NixOS/nixpkgs/commit/559038ec30f939300648a80596f61d89c9207f59) cinnamon.cinnamon-translations: 5.4.2 -> 5.6.0
* [`0c216fdb`](https://github.com/NixOS/nixpkgs/commit/0c216fdba9fed7407c20376461d57f0e9bd1a325) cinnamon.cinnamon-session: 5.4.0 -> 5.6.0
* [`2274c282`](https://github.com/NixOS/nixpkgs/commit/2274c282ed724ba167de49abd9f161c2fba3c92a) cinnamon.cinnamon-settings-daemon: 5.4.5 -> 5.6.0
* [`921e69e4`](https://github.com/NixOS/nixpkgs/commit/921e69e46383d5e6e0294bd3cd26d9395aa62438) cinnamon.cinnamon-screensaver: 5.4.4 -> 5.6.1
* [`a44d01d3`](https://github.com/NixOS/nixpkgs/commit/a44d01d30f4fcda118ce4f70be9a42e6629b7335) cinnamon.xreader: 3.4.5 -> 3.6.0
* [`02a8d3d4`](https://github.com/NixOS/nixpkgs/commit/02a8d3d47282879b0a5242c7adda26f7af255390) cinnamon.cinnamon-control-center: Clean up
* [`0c0912a6`](https://github.com/NixOS/nixpkgs/commit/0c0912a61df2ccbeac20581262e9bd50e5b68dca) cinnamon.muffin: 5.4.7 -> 5.6.0
* [`9d380ac7`](https://github.com/NixOS/nixpkgs/commit/9d380ac70ee8718b9d19d23659491c2d57af2a36) cinnamon.cinnamon-desktop: 5.4.2 -> 5.6.0
* [`cb0e280e`](https://github.com/NixOS/nixpkgs/commit/cb0e280e719aaa9daed1644c9c79731726114b33) cinnamon.cjs: 5.4.1 -> 5.6.1
* [`c6e57ec1`](https://github.com/NixOS/nixpkgs/commit/c6e57ec126c607547e97019c9f345e9ad6bcecc2) cinnamon.cinnamon-common: 5.4.12 -> 5.6.2
* [`d1f60944`](https://github.com/NixOS/nixpkgs/commit/d1f60944d497ee5deb4d44769397041bf6f39773) xed-editor: 3.2.7 -> 3.2.8
* [`6e8d5bb2`](https://github.com/NixOS/nixpkgs/commit/6e8d5bb296eb881abdb19f76c629e74fa61eab2f) cinnamon.nemo: 5.4.3 -> 5.6.0
* [`f0c5278e`](https://github.com/NixOS/nixpkgs/commit/f0c5278e99749866c47a78cdb1c695d55fdabc89) hypnotix: Fix launching with mpv 0.35.0
* [`d2f95e9c`](https://github.com/NixOS/nixpkgs/commit/d2f95e9cfdd218870a90c39d35015399c53ccd12) hypnotix: 2.9 -> 3.0
* [`02c5143f`](https://github.com/NixOS/nixpkgs/commit/02c5143f6044a441a0dbe312e04fc366384dc6ca) cinnamon.pix: 2.8.7 -> 2.8.8
* [`e0a6bde8`](https://github.com/NixOS/nixpkgs/commit/e0a6bde8943c35122ff4f6a542630ee1956fcb0b) cinnamon.xviewer: 3.2.10 -> 3.2.11
* [`e6cc44d9`](https://github.com/NixOS/nixpkgs/commit/e6cc44d960ccfed42a5577c7be7d0c373cb90aa9) cinnamon.mint-x-icons: Switch to tags, use stdenvNoCC
* [`74925675`](https://github.com/NixOS/nixpkgs/commit/74925675b4fe6e36857759a2a818f984edc5c12d) cinnamon.mint-y-icons: Switch to tags, use stdenvNoCC
* [`4035cd52`](https://github.com/NixOS/nixpkgs/commit/4035cd5222bac5ee929b393f7d1d764caf96f73b) cinnamon.mint-themes: Switch to tags, use stdenvNoCC
* [`131c145e`](https://github.com/NixOS/nixpkgs/commit/131c145e61bd509a5fd4b00cd97f70068b646ebe) timeshift: 22.06.5 -> 22.11.1
* [`9bb2e8dc`](https://github.com/NixOS/nixpkgs/commit/9bb2e8dcada0decfd4e7bafa579e1bd3bceeacfe) cinnamon.mint-y-icons: 1.6.1 -> 1.6.5
* [`7891c258`](https://github.com/NixOS/nixpkgs/commit/7891c2582cb5fe649bb6781071ae280040c402a8) cinnamon.mint-themes: 2.0.5 -> 2.0.7
* [`89f3049f`](https://github.com/NixOS/nixpkgs/commit/89f3049f9dfd1b03f70dde44737c245f889b2d13) rl-23.05: Mention cinnamon 5.6 update
* [`00ec1e35`](https://github.com/NixOS/nixpkgs/commit/00ec1e3578a7f6a87b9bdc76f13095b9a33597b4) python310Packages.adafruit-platformdetect: 3.35.0 -> 3.36.0
* [`c60603e6`](https://github.com/NixOS/nixpkgs/commit/c60603e6e1678e339fd6f692107dda3fe29cc8d6) python310Packages.aioaladdinconnect: 0.1.47 -> 0.1.48
* [`18a67c1e`](https://github.com/NixOS/nixpkgs/commit/18a67c1ed3c09ab6d4d6a6798ffc9d6cda8c17cf) python310Packages.aioesphomeapi: 12.0.0 -> 12.1.0
* [`4eeced50`](https://github.com/NixOS/nixpkgs/commit/4eeced50c462efdce2b7aed0929c08d01ac757f1) python310Packages.retrying: 1.3.3 -> 1.3.4
* [`295923f4`](https://github.com/NixOS/nixpkgs/commit/295923f4bcb3af822d077692320fb1e475a48e99) grpc: 1.51.0 -> 1.51.1
* [`d9685eb1`](https://github.com/NixOS/nixpkgs/commit/d9685eb1a34a299863ceac1cb6f79a03e151268c) obfs4: 0.0.12 -> 0.0.14
* [`4a1156fc`](https://github.com/NixOS/nixpkgs/commit/4a1156fcddf73f3fd3f2a640235736f99442ae9c) python310Packages.sphinx-external-toc: 0.3.0 -> 0.3.1
* [`2904fdf8`](https://github.com/NixOS/nixpkgs/commit/2904fdf8390e0fbdd12cdee8b7e77271ae2cc74b) python310Packages.mathlibtools: 1.3.0 -> 1.3.1
* [`cd837257`](https://github.com/NixOS/nixpkgs/commit/cd837257c579f2842ca894f39f30fd25647188d6) python310Packages.grpcio-status: 1.51.0 -> 1.51.1
* [`734632e4`](https://github.com/NixOS/nixpkgs/commit/734632e4c122880e7d447436ae550eb6f64cc326) obfs4: update meta
* [`6b4f497e`](https://github.com/NixOS/nixpkgs/commit/6b4f497e1fe83f6ca092f83515d50839329f6253) python310Packages.pex: 2.1.116 -> 2.1.117
* [`7ee31588`](https://github.com/NixOS/nixpkgs/commit/7ee31588735de1238c8f54288aaadee97ef134c7) python310Packages.sphinx-external-toc: add changelog to meta
* [`b239fcd2`](https://github.com/NixOS/nixpkgs/commit/b239fcd2fac9ee5a591acf105f0edfc8ce7a30ba) resvg: 0.26.1 -> 0.27.0
* [`b014ff9e`](https://github.com/NixOS/nixpkgs/commit/b014ff9e0bf3cd172bef39527a60be1ac8de0172) python310Packages.mathlibtools: add changelog to meta
* [`a14f83a2`](https://github.com/NixOS/nixpkgs/commit/a14f83a20a7b0fbb11b40912bb62474538eb46a1) python310Packages.grpcio-tools: 1.51.0 -> 1.51.1
* [`ae780c2e`](https://github.com/NixOS/nixpkgs/commit/ae780c2e92b10f4c066b270d235aa35c1e858480) arti: 1.0.1 -> 1.1.0
* [`92e37217`](https://github.com/NixOS/nixpkgs/commit/92e372174cc0109b9987f7a1888245ac6b196102) obfs4: install manpage
* [`c9fe0f83`](https://github.com/NixOS/nixpkgs/commit/c9fe0f83fa55ba55ac6a8d939a035c6e4ad85d1f) ocamlPackages.integers: 0.5.1 → 0.7.0
* [`dba8c055`](https://github.com/NixOS/nixpkgs/commit/dba8c05520f0e706c2f6486036f0d8c048f457fa) python310Packages.appthreat-vulnerability-db: 4.0.0 -> 4.0.4
* [`81353462`](https://github.com/NixOS/nixpkgs/commit/81353462668d7dc886a84926e6efb12c9c25a854) libjwt: 1.13.1 -> 1.15.2
* [`0f3ad0e8`](https://github.com/NixOS/nixpkgs/commit/0f3ad0e8b20f49d381880756fc6ff4384a93e407) moar: 1.11.0 -> 1.11.1
* [`2a028c4f`](https://github.com/NixOS/nixpkgs/commit/2a028c4f467610e42c62dfa79e29810e1e980193) build-support: Use equivalent valid exit code
* [`280b4b82`](https://github.com/NixOS/nixpkgs/commit/280b4b8279563836c8ff978605492eed6c782392) root: fix build on aarch64-linux ([nixos/nixpkgs⁠#203267](https://togithub.com/nixos/nixpkgs/issues/203267))
* [`ea5fcc02`](https://github.com/NixOS/nixpkgs/commit/ea5fcc0204d1ac481e65e75e8f8a67060691db76) maintainers/scripts: Use Bash shebang line for files with bashisms
* [`39636edd`](https://github.com/NixOS/nixpkgs/commit/39636edd57a44d75659c749798e7cf232319c824) vcv-rack: 2.1.2 -> 2.2.0
* [`0517db94`](https://github.com/NixOS/nixpkgs/commit/0517db94db621c370e20ad293fcaf4c1349edcab) btcpayserver: 1.6.12 -> 1.7.1
* [`da7e49ef`](https://github.com/NixOS/nixpkgs/commit/da7e49efe9be3c095cec639d4801bdf8dc006e42) miller: 6.4.0 -> 6.5.0
* [`6920a9b6`](https://github.com/NixOS/nixpkgs/commit/6920a9b6d7cfa2df0a4f348cc3dc5e7e1195638e) protoc-gen-twirp_php: 0.8.1 -> 0.9.1
* [`11b4ede6`](https://github.com/NixOS/nixpkgs/commit/11b4ede68ac6c5101fa8e2e0ab9aced6ec3fa6cb) gnome.eog: mark as broken on darwin
* [`4eb17f3a`](https://github.com/NixOS/nixpkgs/commit/4eb17f3a37582b8059eabdd148673f0a9442867d) gnome.ghex: restrict platforms
* [`ec992804`](https://github.com/NixOS/nixpkgs/commit/ec992804b42df6715e8704805b647bb50e1c0799) tightvnc: use xorg.* packages directly instead of xlibsWrapper indirection
* [`a980f120`](https://github.com/NixOS/nixpkgs/commit/a980f120e602db7ac88623d68a44e6c761420399) gnome.gnome-calendar: add darwin support
* [`885901f2`](https://github.com/NixOS/nixpkgs/commit/885901f20a7fedec69f0feeec82bd4309842ab17) gnome.gnome-clocks: add darwin support
* [`2d5a1dc1`](https://github.com/NixOS/nixpkgs/commit/2d5a1dc13fee53581153b07dd467654e40c3fe17) gnome.vinagre: add darwin support
* [`1d0badab`](https://github.com/NixOS/nixpkgs/commit/1d0badab26b49191106de3213e356ec9fbc795f1) gnome.atomix: add darwin support
* [`8c318e81`](https://github.com/NixOS/nixpkgs/commit/8c318e81d1e64b77f8f6aa8caf440504bc709e3f) gnome.hitori: add darwin support
* [`78099fa1`](https://github.com/NixOS/nixpkgs/commit/78099fa10d97b7074711d573d902fe3844d1d5e6) gnome.tali: add darwin support
* [`affff597`](https://github.com/NixOS/nixpkgs/commit/affff597fd3564ae5457492dcd0435e30f63c941) weston: use xorg.* packages directly instead of xlibsWrapper indirection
* [`8039ea1b`](https://github.com/NixOS/nixpkgs/commit/8039ea1b4ead2e228f40aeeae6afdfea4125e13c) mopidy: 3.3.0 -> 3.4.0
* [`ef693e09`](https://github.com/NixOS/nixpkgs/commit/ef693e09b9702560e37b3bd5abb23d397d39d1a9) python3Packages.tensorflow: set LIBTOOL on darwin only
* [`83c75c0f`](https://github.com/NixOS/nixpkgs/commit/83c75c0f43b7fb62d7902630a0068165871dcc46) firefox-unwrapped: 107.0 -> 107.0.1
* [`5834fbb9`](https://github.com/NixOS/nixpkgs/commit/5834fbb994f0d8e266ab3e1a861f8c3e7d689772) firefox-bin-unwrapped: 107.0 -> 107.0.1
* [`80013363`](https://github.com/NixOS/nixpkgs/commit/8001336320fba24158a0474e574e5ede1543a6ba) geant4: use xorg.* packages directly instead of xlibsWrapper indirection ([nixos/nixpkgs⁠#203570](https://togithub.com/nixos/nixpkgs/issues/203570))
* [`26cdf77a`](https://github.com/NixOS/nixpkgs/commit/26cdf77ac6d3fb626ebce4dd2f135e3a69ab646e) oh-my-posh: 12.20.0 -> 12.22.0
* [`624ebdc1`](https://github.com/NixOS/nixpkgs/commit/624ebdc10d479d0aecc63c9963b7652742abd69d) nixos/rosetta: init module
* [`11fbf96e`](https://github.com/NixOS/nixpkgs/commit/11fbf96e2b08d563c9166a958c3372e93a55257c) nixos/rosetta: add release notes
* [`1a14fc42`](https://github.com/NixOS/nixpkgs/commit/1a14fc42621532d9850d045785cfd9bb02372ab9) owncast: 0.0.12 -> 0.0.13
* [`2d2f2738`](https://github.com/NixOS/nixpkgs/commit/2d2f2738f10b8d066dc1280de8fa1dd7fb9f348d) cinnamon.mint-cursor-themes: init at unstable-2022-11-29
* [`66f6e18a`](https://github.com/NixOS/nixpkgs/commit/66f6e18a296e1e4d5dd241ce5d43860eac4fcfd4) python310Packages.bc-python-hcl2: 0.3.47 -> 0.3.51
* [`7e5e6625`](https://github.com/NixOS/nixpkgs/commit/7e5e6625e2c9c35942e0f0a97fee18cd53991187) Update HoTT and drop archaic 8.6 specific install
* [`c0cdf0ad`](https://github.com/NixOS/nixpkgs/commit/c0cdf0ad4bac64d96bd7c581878d4507c53234c8) appimage-run: export OWD
* [`bcb5f0de`](https://github.com/NixOS/nixpkgs/commit/bcb5f0decca13c2bd666ee0a2b306b162117bd71) nixos/nix-daemon: allow registry paths to be... paths
* [`22b02022`](https://github.com/NixOS/nixpkgs/commit/22b020228f034fbfa436033b091112b1f699c2fa) python310Packages.pylsp-mypy: fix test
* [`852ef6e9`](https://github.com/NixOS/nixpkgs/commit/852ef6e9716b00e6400ee905ee80e62e11192e3c) doc: Fix grammar
* [`22d3b5a9`](https://github.com/NixOS/nixpkgs/commit/22d3b5a9e9ce78947bcf70fc970301708df0b7e4) doc: Quote variable references
* [`9cf0ee43`](https://github.com/NixOS/nixpkgs/commit/9cf0ee43e72dec65365ffa2e2c2da4cb2ebc3b5d) doc: Use POSIX syntax to source file
* [`b330de2e`](https://github.com/NixOS/nixpkgs/commit/b330de2e1aa0a22744ccfbcbe920182961a2d084) meilisearch: 0.29.2 -> 0.30.0
* [`2158497b`](https://github.com/NixOS/nixpkgs/commit/2158497bb99f747a5642f26efe7bedd20f427bbf) python310Packages.cyclonedx-python-lib: 3.1.0 -> 3.1.1
* [`8b542d1f`](https://github.com/NixOS/nixpkgs/commit/8b542d1f936ebea47560f4406066e54beb9fbb62) plasma: 5.26.3 -> 5.26.4
* [`a38051bf`](https://github.com/NixOS/nixpkgs/commit/a38051bfe0a12f1bd08e9a059e0b62dd78ed0429) python3Packages.tensorflow: refactor fetchAttrs
* [`85b0ae49`](https://github.com/NixOS/nixpkgs/commit/85b0ae49da67dfc2ae5922583d4f274d618d6efd) python310Packages.debugpy: 1.6.3 -> 1.6.4
* [`9790786a`](https://github.com/NixOS/nixpkgs/commit/9790786a00880d1b7240d519953274f141a0ceaf) stratisd: 3.4.0 -> 3.4.1
* [`1c1f4b76`](https://github.com/NixOS/nixpkgs/commit/1c1f4b76350702be20074588bea6f1bf087f1efe) python310Packages.diff-cover: 7.1.0 -> 7.1.1
* [`f3466a31`](https://github.com/NixOS/nixpkgs/commit/f3466a31c75653e81cd79c85ad2cf3d19c165660) opensc: 0.22.0 -> 0.23.0
* [`58871bb9`](https://github.com/NixOS/nixpkgs/commit/58871bb9ee273732921a1285472e27426fcfa495) pgbackrest: 2.42 -> 2.43
* [`5822bee6`](https://github.com/NixOS/nixpkgs/commit/5822bee639c7877e45690f7d91c3e1c31a1182e5) ngn-k: unstable-2021-12-17 -> 2022-11-27
* [`f68fdcfc`](https://github.com/NixOS/nixpkgs/commit/f68fdcfc4e86335a4fa1b02d6abfb69a3545aaee) ngn-k: build k-libc flavor by default
* [`5c3e0a28`](https://github.com/NixOS/nixpkgs/commit/5c3e0a2899b6a9bb6048bdd5b63ea8273d08297a) ngn-k: allow cross compilation to FreeBSD 13
* [`8b868b56`](https://github.com/NixOS/nixpkgs/commit/8b868b5616c3406c8737c4dba50f394528475732) racket-minimal: fix build on aarch64-darwin
* [`81e8d927`](https://github.com/NixOS/nixpkgs/commit/81e8d927e019d1f8bc9ed5c2fe75d7e88b9c6d59) polkadot: 0.9.32 -> 0.9.33
* [`e8b8afb2`](https://github.com/NixOS/nixpkgs/commit/e8b8afb2552b76e9ac2cf8b9245c9fe31f8ac9d2) Revert "libguestfs: remove unnecessary ? null from inputs"
* [`12ac85bb`](https://github.com/NixOS/nixpkgs/commit/12ac85bbe7010dbe6d05e2f54b86aa600327f202) pspg: 5.5.13 -> 5.6.0
* [`b0998ceb`](https://github.com/NixOS/nixpkgs/commit/b0998ceb7144ea39bf6eb4c67ca84542924399ed) vimPlugins: update
* [`2067c9cc`](https://github.com/NixOS/nixpkgs/commit/2067c9ccaf9a0c004184eae7884230c4b27f8469) vimPlugins.nvim-treesitter: update grammars
* [`314ba121`](https://github.com/NixOS/nixpkgs/commit/314ba121753634c10689a14e75eb417a54a41ab6) easyocr: init at 1.6.2
* [`7c3eeb56`](https://github.com/NixOS/nixpkgs/commit/7c3eeb5667f5f5be7aa4c9374f01a72e59f415bb) keepassxc: Fix GApps wrapping
* [`92a734cf`](https://github.com/NixOS/nixpkgs/commit/92a734cf89e08e2e7194e5fc4d8b5953b63c64c5) lisp-modules-new: Reorder alphabetically
* [`30221cd9`](https://github.com/NixOS/nixpkgs/commit/30221cd98aa912d86ecb8553ee651bebad84fe58) lispPackages_new.sbclPackages.png: fix build
* [`c269147d`](https://github.com/NixOS/nixpkgs/commit/c269147d1deb0f5dc74acf4e6ea27a123a5685c4) lispPackages_new.sbclPackages.cl-devil: Fix build
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
