### PR TITLE
niv devenv: update 2316585d -> f574b064

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2316585d14b256a77044ebef5d3e61a14339eecd",
-        "sha256": "0n4ka9kal30zhdd1wr4wq96hyld4riapwnby668hbdbw260vmfvz",
+        "rev": "f574b0640ec60c729bb92fe4693956317a65ba6e",
+        "sha256": "1vnbdnbgj3msn6hq7aqcpq2k9k0bsqdpzj7iff8lqvkmnvdm5bl4",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/2316585d14b256a77044ebef5d3e61a14339eecd.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/f574b0640ec60c729bb92fe4693956317a65ba6e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@2316585d...f574b064](https://github.com/cachix/devenv/compare/2316585d14b256a77044ebef5d3e61a14339eecd...f574b0640ec60c729bb92fe4693956317a65ba6e)

* [`55035b97`](https://github.com/cachix/devenv/commit/55035b970611514b9761d60122bf854528a9cd24) Update ruby.nix file
* [`c8f36956`](https://github.com/cachix/devenv/commit/c8f369560073828f6f8b5fb6bf66971b4b7499fe) Default template should not create files
* [`f40ea4eb`](https://github.com/cachix/devenv/commit/f40ea4ebe7041b227f62d954135bf167c3e0a254) Add a comment into gitignore
* [`62c6569a`](https://github.com/cachix/devenv/commit/62c6569a5cb17417456aa5e4a3d7f33bb1e1ffb3) Update issue templates
* [`7d1896a3`](https://github.com/cachix/devenv/commit/7d1896a30031cecfea94731c8af98ceb44d3204a) Update .github/ISSUE_TEMPLATE/bug_report.md
* [`c9358347`](https://github.com/cachix/devenv/commit/c9358347b9970f727bce61605ca5663def4caa25) Add nur example
* [`28dbd747`](https://github.com/cachix/devenv/commit/28dbd7479c9ab44c20ef1dd9004a9bf055b3b768) mysql: rename MYSQLDATA to MYSQL_HOME
* [`e6d97ea0`](https://github.com/cachix/devenv/commit/e6d97ea0b45ff6fa51c47d0fb8aca75b4af8204a) mysql: rename MYSQLSOCKET to MYSQL_UNIX_SOCKET
* [`96fae5db`](https://github.com/cachix/devenv/commit/96fae5db72e5d31341f86365be265ae5a763f4b4) mysql: fix arguments passing with spaces
* [`c36344eb`](https://github.com/cachix/devenv/commit/c36344eb00644ecda15a42b3c8c01dd567d79483) mysql: add MYSQL_TCP_PORT envvar if port is set
* [`71bb2333`](https://github.com/cachix/devenv/commit/71bb2333ec88405a4f521f299b18d35bafed958b) mysql: remove --socket option
* [`2befe068`](https://github.com/cachix/devenv/commit/2befe068b0917b16cf9edbc0fe36670b675c3f57) mysql: fix error on MYSQL_TCP_PORT when no port set
* [`72441b22`](https://github.com/cachix/devenv/commit/72441b22f609cd149929c4a7857a3639be6a9adb) Accept nix flake config without user agreement in gitpod
* [`035b008a`](https://github.com/cachix/devenv/commit/035b008afe6e710ba7775c103930057ab7c8c7a8) feat: add caddy module
* [`a4f2babd`](https://github.com/cachix/devenv/commit/a4f2babd1cebc10d3f33f9f1533e1ed092d7efde) Auto generate docs/reference/options.md
* [`7f48716a`](https://github.com/cachix/devenv/commit/7f48716a83a5ae0f253c6ced42b50695f2a5e5ba) docs: improve config explanation
* [`8ddd3eff`](https://github.com/cachix/devenv/commit/8ddd3eff0da784ca2ae4443a19f9c4ad19323321) improve basics by adding environment information
* [`2786c1a2`](https://github.com/cachix/devenv/commit/2786c1a2566f7fdb179d996b4fbf0a262135c07a) docs: load faster
* [`4bfa2660`](https://github.com/cachix/devenv/commit/4bfa266054819438c0f015681b607f35207f541c) processes: don't evaluate implementation if none is set
* [`660395e4`](https://github.com/cachix/devenv/commit/660395e4c39303b4fc276b2cf3906c497a2ca9e7) typo
* [`c63c24e3`](https://github.com/cachix/devenv/commit/c63c24e39d9eaf1ae3b49d4fa031c4df98982f63) feat: add phpfpm options
* [`5b0c14d5`](https://github.com/cachix/devenv/commit/5b0c14d5148940ed80cf3c4c8e687612e526657d) auto tag latest
* [`4614dad7`](https://github.com/cachix/devenv/commit/4614dad772ea7e2006761020342351430556cd15) Auto generate docs/reference/options.md
* [`d82b6647`](https://github.com/cachix/devenv/commit/d82b664739a4fea7b028beb968e229415db3f5db) fix: redis working directory
* [`1217c2ef`](https://github.com/cachix/devenv/commit/1217c2efcceabb552e913ecb56a0736190b72afc) feat: add rabbitmq
* [`f6657c9d`](https://github.com/cachix/devenv/commit/f6657c9dd7f5e490b3f303e96b11a0654613768f) improve postgres
* [`b78e4b3d`](https://github.com/cachix/devenv/commit/b78e4b3d476ab0a947fd6d13708f2866298c9a43) fix: remove psql-devenv
* [`881f41b2`](https://github.com/cachix/devenv/commit/881f41b2c3dc4fb26ad6f142655654d100ba939a) feat: add example for listen address
* [`d174b6ff`](https://github.com/cachix/devenv/commit/d174b6ff868a119b19703ac02aa92f19fc862c52) fix: docs generation
* [`a78080c3`](https://github.com/cachix/devenv/commit/a78080c3fad27933bf89693a8d50f88dc5fe8c64) fix: remove unused rabbitmq option
* [`41eb6285`](https://github.com/cachix/devenv/commit/41eb628598d7e1efc46eb000a925bc3ef0714151) fix: setup also docs on gitpod
* [`afe0345c`](https://github.com/cachix/devenv/commit/afe0345c91692ff8853826467001f39f65ec1f63) Auto generate docs/reference/options.md
* [`ccab68d5`](https://github.com/cachix/devenv/commit/ccab68d5025bce4690e6f1730410a0771a73c3ff) fix: mysql init with userland my.cnf
* [`d22166f1`](https://github.com/cachix/devenv/commit/d22166f1c53b4ed84730b4595e79d8bc09a2d84c) devcontainer
* [`5c2f69c6`](https://github.com/cachix/devenv/commit/5c2f69c6eba92bd2162f8fa761ae704e3d744d6d) Auto generate docs/reference/options.md
* [`d72653c7`](https://github.com/cachix/devenv/commit/d72653c76857fa549c1e9ad602bdd0f959e1062e) Fix typo
* [`89cd0f7d`](https://github.com/cachix/devenv/commit/89cd0f7d6122cbe1f351e8f6fccc7fc638690e9f) devenv shell: make sure commands propagate exit code
* [`79c97b89`](https://github.com/cachix/devenv/commit/79c97b892255e696c50f64477305a7f56e79b0e1) feat: add elasticsearch
* [`407c24e2`](https://github.com/cachix/devenv/commit/407c24e29c938a81d45c6e9b7ffb85d18e40a86c) fix: ignore mkdocs cache folder
* [`b8047d8a`](https://github.com/cachix/devenv/commit/b8047d8a4e84b7b34528ee2af87980990d6247ed) fix: run python commands inside devenv
* [`791efcdd`](https://github.com/cachix/devenv/commit/791efcdd89a582d2a517fe83064f818a609c1e2a) Auto generate docs/reference/options.md
* [`cb6393f9`](https://github.com/cachix/devenv/commit/cb6393f91d9d8e2e0537972a6a6f78b0f87bee88) feat: add blackfire support
* [`54eb8f15`](https://github.com/cachix/devenv/commit/54eb8f1517264e98ad0dbba6c73b4217ab9f4137) feat: add example for option
* [`00573a12`](https://github.com/cachix/devenv/commit/00573a12e45443930f68b5804dfe06ddd3e8d5ed) fix: postgres startup if folder is missing
* [`b336015d`](https://github.com/cachix/devenv/commit/b336015d484c136d67b64cdf4de54a55d7a63097) bump nix
* [`bd36f715`](https://github.com/cachix/devenv/commit/bd36f71570c8cec11f43dfcc76619f3642e2725d) Auto generate docs/reference/options.md
* [`20a6fc05`](https://github.com/cachix/devenv/commit/20a6fc05a8290a4817d41b9567aa8a3625041bec) Avoid duplicate instances of dependencies by using follows.
* [`93b562bd`](https://github.com/cachix/devenv/commit/93b562bd8706d1d5bb330c25be7ca780ddadbb8c) darwin: use nix readlink explicitly
* [`7bae0aea`](https://github.com/cachix/devenv/commit/7bae0aea6711448245fbb14efe9e6a4dbd2beefe) fix doc generation
* [`ccfc2889`](https://github.com/cachix/devenv/commit/ccfc28894d8d77549bc150b10cfa621b56b2d765) Auto generate docs/reference/options.md
* [`96e75192`](https://github.com/cachix/devenv/commit/96e75192d21b9e25a6fbd14bf93d04abdc887a12) Rust: allow picking the version of the toolchain
* [`599d1b94`](https://github.com/cachix/devenv/commit/599d1b94351dddc6a6d09a7984067d353d4c6541) Auto generate docs/reference/options.md
* [`dc858d19`](https://github.com/cachix/devenv/commit/dc858d195e9e97d2086848b54d2f1f13cd68a7aa) Update devenv.nix
* [`39b006ec`](https://github.com/cachix/devenv/commit/39b006ec83a7f50d6cbdd4042b6e992b855a4dac) make postgres more configureable
* [`dc7fc9e2`](https://github.com/cachix/devenv/commit/dc7fc9e22a9ccd8cf29e29921dd13efa56fc66e9) postgres: make init db more safe, fixes [cachix/devenv⁠#107](https://togithub.com/cachix/devenv/issues/107)
* [`d797172a`](https://github.com/cachix/devenv/commit/d797172a2bcce96da4f52bee48ab330085de514a) postgres: add example for package. fixes [cachix/devenv⁠#139](https://togithub.com/cachix/devenv/issues/139)
* [`cc0b4235`](https://github.com/cachix/devenv/commit/cc0b4235b7968d66c8497ecea14126962cf25397) Auto generate docs/reference/options.md
* [`f574b064`](https://github.com/cachix/devenv/commit/f574b0640ec60c729bb92fe4693956317a65ba6e) Auto generate docs/reference/options.md
