### PR TITLE
niv emacs-overlay: update de8f6b86 -> 2f7fff8e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "de8f6b86ab55753fa40b7f1b815d2126d203dddc",
-        "sha256": "0hmxjykq05lvzgbyy4ybjrq1f19bq8gv4a751njlw8ppcd908s47",
+        "rev": "2f7fff8ee668c01803cab2f0847151fdf647134e",
+        "sha256": "0pshwldb93g88d8mh8pfqzplhady2wspa9vjbqyshnbb7h2k717s",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/de8f6b86ab55753fa40b7f1b815d2126d203dddc.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/2f7fff8ee668c01803cab2f0847151fdf647134e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@de8f6b86...2f7fff8e](https://github.com/nix-community/emacs-overlay/compare/de8f6b86ab55753fa40b7f1b815d2126d203dddc...2f7fff8ee668c01803cab2f0847151fdf647134e)

* [`b152560f`](https://github.com/nix-community/emacs-overlay/commit/b152560f00867f85c441a2b2981f7ab4b787194e) Updated repos/melpa
* [`c918c9dd`](https://github.com/nix-community/emacs-overlay/commit/c918c9ddb8b7159cb2dd65bf15416272121d1c25) Updated repos/melpa
* [`5c03fb3e`](https://github.com/nix-community/emacs-overlay/commit/5c03fb3e6636b7121b8c3b126d2351e78cb54d4f) Updated repos/nongnu
* [`7eff712c`](https://github.com/nix-community/emacs-overlay/commit/7eff712ca5e587707520eb321cef49fdb48c5b7d) Updated repos/melpa
* [`234b1957`](https://github.com/nix-community/emacs-overlay/commit/234b19572a6c0fd9af8f911bdd1ec4dde6e0a7e5) Updated repos/nongnu
* [`a686fa48`](https://github.com/nix-community/emacs-overlay/commit/a686fa48a89b0cba053143ba155506c93718037f) Updated repos/melpa
* [`6a456047`](https://github.com/nix-community/emacs-overlay/commit/6a45604758434ba36c3f6ee83bb5af943ab627e9) Updated repos/emacs
* [`18ad9323`](https://github.com/nix-community/emacs-overlay/commit/18ad932352033ead8fe60c3ec399626b7bdc5bc5) Updated repos/melpa
* [`b8ed2226`](https://github.com/nix-community/emacs-overlay/commit/b8ed2226758cbd6c2d19b28f1fa9f26b9f78073c) Updated repos/nongnu
* [`8a4525b4`](https://github.com/nix-community/emacs-overlay/commit/8a4525b412bd5fc5e8c943843fab9f9d27c1df9d) Updated repos/emacs
* [`0c0e6046`](https://github.com/nix-community/emacs-overlay/commit/0c0e604638266c71d2411121db83411c3d4cbb0b) Updated repos/melpa
* [`6530a233`](https://github.com/nix-community/emacs-overlay/commit/6530a233351a806e88e83d10312d7dd9e8bc6cd3) Updated repos/nongnu
* [`a7500019`](https://github.com/nix-community/emacs-overlay/commit/a7500019b6c53eb07b383e309308b7a141b01afd) Updated repos/emacs
* [`9e53c246`](https://github.com/nix-community/emacs-overlay/commit/9e53c246a9f9db278b8e881b796f099119befe79) Updated repos/melpa
* [`5723b609`](https://github.com/nix-community/emacs-overlay/commit/5723b609030c3810e7fcf07d21b63197de0b42f5) Updated repos/elpa
* [`ea49c574`](https://github.com/nix-community/emacs-overlay/commit/ea49c574e00df70922c2ed4d17530a76fec6831c) Updated repos/emacs
* [`7419dbeb`](https://github.com/nix-community/emacs-overlay/commit/7419dbeb120e44bfb8cbbb74f1b4e77b3f8401ab) Updated repos/melpa
* [`0e3679f4`](https://github.com/nix-community/emacs-overlay/commit/0e3679f4cfe7d53f02ffd42eac757647687ea539) Updated repos/elpa
* [`1b9f5259`](https://github.com/nix-community/emacs-overlay/commit/1b9f52597f61f2d8f6d40251e033410163735634) Updated repos/melpa
* [`4d6714a9`](https://github.com/nix-community/emacs-overlay/commit/4d6714a912e2ee801c5880c147eecb387e223f30) Updated repos/melpa
* [`57e74388`](https://github.com/nix-community/emacs-overlay/commit/57e743882976214a6ca0524b0de3bdba2d30cd8d) Add tree-sitter-typescript grammar
* [`303b370c`](https://github.com/nix-community/emacs-overlay/commit/303b370c0cc20459da559bf41c4ef4419a971586) Updated repos/elpa
* [`6f4aa4e8`](https://github.com/nix-community/emacs-overlay/commit/6f4aa4e86646b6e209170b9d0be17d1a90d5bb08) Updated repos/emacs
* [`85a88777`](https://github.com/nix-community/emacs-overlay/commit/85a88777a9d1410c79ef95487a8378802d30cc64) Updated repos/melpa
* [`e88e8c7f`](https://github.com/nix-community/emacs-overlay/commit/e88e8c7f0c77622bb3704ea38f146a6e353445b6) Updated repos/nongnu
* [`5ead1de8`](https://github.com/nix-community/emacs-overlay/commit/5ead1de8409206364a611aca63f4fbebd88ec656) TODO: write commit message
* [`f2710ca9`](https://github.com/nix-community/emacs-overlay/commit/f2710ca9fa79bef0f41ee0fc80d26ee07ac98c96) TODO: write commit message
* [`fd0da6cc`](https://github.com/nix-community/emacs-overlay/commit/fd0da6cc6c3bb214363d1c28f73d58c673e6cda6) TODO: write commit message
* [`d4684817`](https://github.com/nix-community/emacs-overlay/commit/d4684817168d71cd7167f6cec7d910f1311e1cd0) TODO: write commit message
* [`7f6e28bd`](https://github.com/nix-community/emacs-overlay/commit/7f6e28bdd8958d8446797f201172c3e43dada0de) TODO: write commit message
* [`c4eaac82`](https://github.com/nix-community/emacs-overlay/commit/c4eaac8256718db0377d2365c9bc33252b4096c7) remove newline, remove clojure
* [`b816a3e7`](https://github.com/nix-community/emacs-overlay/commit/b816a3e73b48dacffc5c180854462b38bb04a51f) Enable tree-sitter by default when applicable
* [`e9276629`](https://github.com/nix-community/emacs-overlay/commit/e92766297a7ef6b4be7a8b9ebf5fb2dc3bc7989a) Alias redundant attributes since in 22.11, nativeComp = true
* [`2b59221e`](https://github.com/nix-community/emacs-overlay/commit/2b59221ede94cce7db3aef6e2bfb707c1ddc5e70) Enable WebP support for emacsPgtk
* [`0743ae0e`](https://github.com/nix-community/emacs-overlay/commit/0743ae0eb85b4e1087fc20fd0c9bcf8efb1fdc4f) Add Darwin notes for tree-sitter
* [`7f75e987`](https://github.com/nix-community/emacs-overlay/commit/7f75e987402f3db4062e68638a3d0b520cadd750) Updated repos/emacs
* [`873ca1b7`](https://github.com/nix-community/emacs-overlay/commit/873ca1b703a7cf9aa607634dcfcf0d71acc35c62) Updated repos/melpa
* [`d165f262`](https://github.com/nix-community/emacs-overlay/commit/d165f262eb824a9e687d6cf43ea6508bc7fddab8) Don't mention aliased *nativeComp attributes
* [`64b233cc`](https://github.com/nix-community/emacs-overlay/commit/64b233cc9cfb1239f3725d0c5953581b43148956) add tree sitter languages to rpath ([nix-community/emacs-overlay⁠#273](https://togithub.com/nix-community/emacs-overlay/issues/273))
* [`c3c3fca2`](https://github.com/nix-community/emacs-overlay/commit/c3c3fca2d83de244852b4dd062b1edd4f6eaea8b) Updated repos/emacs
* [`d3905234`](https://github.com/nix-community/emacs-overlay/commit/d39052346c5fbb66c8210c263b0c8db8afd9fed2) Updated repos/melpa
* [`50d7ddad`](https://github.com/nix-community/emacs-overlay/commit/50d7ddad7e53b634c9896bf180a9a00847055457) Updated repos/elpa
* [`fd64ab7f`](https://github.com/nix-community/emacs-overlay/commit/fd64ab7f71b2b4e555afd606d9060ee3366fe07b) Updated repos/emacs
* [`ae94e8c0`](https://github.com/nix-community/emacs-overlay/commit/ae94e8c0b06c2b5b8b4e2fe7766f443c96718c39) Updated repos/melpa
* [`336402eb`](https://github.com/nix-community/emacs-overlay/commit/336402eba8c78f6f36fa995549add0b834be994c) Remove unnecessary substituteInPlace
* [`c9fb6136`](https://github.com/nix-community/emacs-overlay/commit/c9fb613635a8420cac9419ead7d0cd69126c4d26) Don't wipe patches
* [`543a3b39`](https://github.com/nix-community/emacs-overlay/commit/543a3b394f6822ea5d52666ca063c85bec2d1ca0) Revert "Don't wipe patches"
* [`2ce014a4`](https://github.com/nix-community/emacs-overlay/commit/2ce014a48bf6845b9bbeca6eabbff9ba5783c30d) Revert "Remove unnecessary substituteInPlace"
* [`ae96a429`](https://github.com/nix-community/emacs-overlay/commit/ae96a42959585ec167a80b7e706151469dd47057) Updated repos/elpa
* [`a5d8c362`](https://github.com/nix-community/emacs-overlay/commit/a5d8c362c535b1c180caf08d7a8bf183cc2d2f92) Updated repos/melpa
* [`d4443a55`](https://github.com/nix-community/emacs-overlay/commit/d4443a55b8f260e4c31bf848059eb5aed5b75002) Updated repos/nongnu
* [`ed5e6fc5`](https://github.com/nix-community/emacs-overlay/commit/ed5e6fc55e30b437aa38e1bda2d895c7672ea48b) Updated repos/emacs
* [`b0500fca`](https://github.com/nix-community/emacs-overlay/commit/b0500fcaf519c6def2d1d98689941cac5d921e45) Updated repos/melpa
* [`7b8fd092`](https://github.com/nix-community/emacs-overlay/commit/7b8fd092ec74c9026b1049b6a5f7aa1a6c40ff04) Updated repos/emacs
* [`0e96e55b`](https://github.com/nix-community/emacs-overlay/commit/0e96e55b373d71eb69bab9acd6699bf95b45db98) Updated repos/melpa
* [`1e4763dd`](https://github.com/nix-community/emacs-overlay/commit/1e4763dd90ad8712b459d1f5e53cbbc047b75dd0) Revert "add tree sitter languages to rpath ([nix-community/emacs-overlay⁠#273](https://togithub.com/nix-community/emacs-overlay/issues/273))"
* [`add580f7`](https://github.com/nix-community/emacs-overlay/commit/add580f7d29b08f66182b0cc4c1a9262d77ba2c0) chore(Hydra): Changed stable: 22.05 -> 22.11
* [`881c7123`](https://github.com/nix-community/emacs-overlay/commit/881c7123cc1d0b31c18703c570d437b670fd9016) Updated repos/elpa
* [`a3a53c9b`](https://github.com/nix-community/emacs-overlay/commit/a3a53c9b51e51d4a55a9be1921daf560a9693300) Updated repos/melpa
* [`241117af`](https://github.com/nix-community/emacs-overlay/commit/241117af1c8aea2ea99419724391139a34f7014d) Updated repos/emacs
* [`d12878da`](https://github.com/nix-community/emacs-overlay/commit/d12878da7e42851edf113341e5bde3192f5b1473) Updated repos/melpa
* [`dd60ef06`](https://github.com/nix-community/emacs-overlay/commit/dd60ef06981fec354663054e608bbfcd7f8f1cff) Updated repos/nongnu
* [`bca9f55d`](https://github.com/nix-community/emacs-overlay/commit/bca9f55d6c959a3845b5cf5b48a9adddec5e9f3e) Updated repos/emacs
* [`612fc9ab`](https://github.com/nix-community/emacs-overlay/commit/612fc9ab31d2cdfe6ca99d606c49072d90c4e42b) Updated repos/melpa
* [`4aa6dfff`](https://github.com/nix-community/emacs-overlay/commit/4aa6dfff1ed8618cdd244e58d70569e538127f93) Remove redundant hydra jobs
* [`647e33aa`](https://github.com/nix-community/emacs-overlay/commit/647e33aacdb08d59b0b593e5e9121d02cd7edfdd) Updated repos/emacs
* [`cfa0166b`](https://github.com/nix-community/emacs-overlay/commit/cfa0166bf39870927c55ca6dd4c871ee558af37d) Updated repos/melpa
* [`2f7fff8e`](https://github.com/nix-community/emacs-overlay/commit/2f7fff8ee668c01803cab2f0847151fdf647134e) Updated repos/nongnu
