### PR TITLE
niv powerlevel10k: update 6609767a -> a7bf4c83

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "6609767abd81aed3101cb67908df727998b0b619",
-        "sha256": "1vxng2y2sq2hdy6m8lbrh4fhz64a4s4srbzyyb715zqjjn3x7y1k",
+        "rev": "a7bf4c83dee601f91aaabf3956c93f5ebe26699d",
+        "sha256": "0bxv887wpyppmmwayk2zamfanjdvbcvc678d0p8x8clj92v0z6in",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/6609767abd81aed3101cb67908df727998b0b619.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/a7bf4c83dee601f91aaabf3956c93f5ebe26699d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@6609767a...a7bf4c83](https://github.com/romkatv/powerlevel10k/compare/6609767abd81aed3101cb67908df727998b0b619...a7bf4c83dee601f91aaabf3956c93f5ebe26699d)

* [`45758d95`](https://github.com/romkatv/powerlevel10k/commit/45758d95fb43730f75b3f75c6c7034de7e81b7cf) Use "machine" where available for CPU arch
* [`edafcb5a`](https://github.com/romkatv/powerlevel10k/commit/edafcb5a7dbe809d40264643a55b72a25c3bbe05) fix bugs in cpu_arch
* [`a7bf4c83`](https://github.com/romkatv/powerlevel10k/commit/a7bf4c83dee601f91aaabf3956c93f5ebe26699d) docs: add cpu_arch
