### PR TITLE
niv spacemacs: update be9b1c89 -> bced05b3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "be9b1c89bc0d1a9dcfdec5362425efa1787f28fa",
-        "sha256": "1c09dhp0wm89g3bpqmdvvv2g73kx2m70z6dnbf1xqm1dp68a3d85",
+        "rev": "bced05b3b06843ba4d2d10602f9cf609f05da17b",
+        "sha256": "0iz3gbmyfdm1vvgpyq37cv8lbbal17qk0p5x1yv09f56as7fk076",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/be9b1c89bc0d1a9dcfdec5362425efa1787f28fa.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/bced05b3b06843ba4d2d10602f9cf609f05da17b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@be9b1c89...bced05b3](https://github.com/syl20bnr/spacemacs/compare/be9b1c89bc0d1a9dcfdec5362425efa1787f28fa...bced05b3b06843ba4d2d10602f9cf609f05da17b)

* [`bbbea08d`](https://github.com/syl20bnr/spacemacs/commit/bbbea08db23019c683cdd428eab6ea514ddaee6c) add binding for all the awesome tide refactorings ([syl20bnr/spacemacs⁠#15836](https://togithub.com/syl20bnr/spacemacs/issues/15836))
* [`ecb87b53`](https://github.com/syl20bnr/spacemacs/commit/ecb87b53f795d4e7a14b54831419cf998110fb20) core/core-load-path.el: auto locate spacemacs-start-directory
* [`748ed301`](https://github.com/syl20bnr/spacemacs/commit/748ed301718ade73f5c2aa1762379e7ed64c662a) core/core-dotspacemacs.el: speedup dotspacemacs/get-variable-string-list
* [`1bae6aa7`](https://github.com/syl20bnr/spacemacs/commit/1bae6aa79cd21ce285adb4bf929b8b80b8651e22) [bot] "built_in_updates" Thu Dec  1 22:50:47 UTC 2022
* [`bced05b3`](https://github.com/syl20bnr/spacemacs/commit/bced05b3b06843ba4d2d10602f9cf609f05da17b) [themes-megapack] fix eziam-theme package name and its references
