### PR TITLE
niv zsh-completions: update a09284a7 -> f9373c96

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "a09284a73443d4a0288c5a984c5adb5f55ace520",
-        "sha256": "0kn6b12mhgfylc3zk8zhixr3qwmf35shx2vpn985n7z5adxcbs37",
+        "rev": "f9373c96c727e1c8ef7fb48fe49524c1a786fa80",
+        "sha256": "1ydldzv282wg1bfhllafhkrrrg5f8bh5anv791b6xrwzmjj53x4f",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/a09284a73443d4a0288c5a984c5adb5f55ace520.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/f9373c96c727e1c8ef7fb48fe49524c1a786fa80.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@a09284a7...f9373c96](https://github.com/zsh-users/zsh-completions/compare/a09284a73443d4a0288c5a984c5adb5f55ace520...f9373c96c727e1c8ef7fb48fe49524c1a786fa80)

* [`10a706d3`](https://github.com/zsh-users/zsh-completions/commit/10a706d3379ccb3db1395cbfb4d40041ff0be95b) Fix broken boolean parameter completion
