### PR TITLE
niv nixpkgs: update f16be356 -> 0483b2b2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f16be356415452ee0eb8221b90dda72b85aaca96",
-        "sha256": "1vwmpnzj91j33rn6czx49ldckpfa6rc3zs58lpgp8d93wk2wdrh3",
+        "rev": "0483b2b2e620a4afa74624e0ac173f1c7376fe27",
+        "sha256": "0crshsm5jmys1v99hk1xbfb1wssvgs5kl1pg651wh7bqiylf1zfr",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f16be356415452ee0eb8221b90dda72b85aaca96.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/0483b2b2e620a4afa74624e0ac173f1c7376fe27.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f16be356...0483b2b2](https://github.com/nixos/nixpkgs/compare/f16be356415452ee0eb8221b90dda72b85aaca96...0483b2b2e620a4afa74624e0ac173f1c7376fe27)

* [`10030672`](https://github.com/NixOS/nixpkgs/commit/10030672ab9ab4cd961e414b7026f78d94c6ecc9) stdenv/cross: remove now-redundant `file` nativeBuildInput on mingw
* [`ae45c235`](https://github.com/NixOS/nixpkgs/commit/ae45c235fae586c6da092e3e0d56c52be1b183b3) multiple-output.sh: fix moveToOutput comment
* [`be07c1ba`](https://github.com/NixOS/nixpkgs/commit/be07c1bad9f639b1e739eaa94605d939efe759b5) nixos/zram: support built-in zram
* [`f24148ab`](https://github.com/NixOS/nixpkgs/commit/f24148ab1fabeb1a12e2c28d995fac16ba321bef) openjdk/meta.nix: add powerpc64le-linux to platforms
* [`20b67d38`](https://github.com/NixOS/nixpkgs/commit/20b67d38c727b0c02efac117d403f6cd68f77546) Add muldefs to ld-flags
* [`b60fb3b2`](https://github.com/NixOS/nixpkgs/commit/b60fb3b293879fb0442ac3f9e3d9c7fd6ca3f83b) material-design-icons: 6.6.96 -> 7.0.96
* [`28468124`](https://github.com/NixOS/nixpkgs/commit/2846812404b9948828129f9ddfe417015335b964) iproute2: 5.19.0 -> 6.0.0
* [`74de1215`](https://github.com/NixOS/nixpkgs/commit/74de121572732797c944a0f94273bc4044eae223) default-crate-overrides: add alsa-lib for alsa-sys crate
* [`2e38eee4`](https://github.com/NixOS/nixpkgs/commit/2e38eee4a16e1bc2dcfd23e76585806fd4e39d64) graphite2: Remove libgcc
* [`4a0d1650`](https://github.com/NixOS/nixpkgs/commit/4a0d1650c9b020fdb0fcbf4644165f2a8c4918cb) valgrind: 3.19.0 -> 3.20.0
* [`dd8a4975`](https://github.com/NixOS/nixpkgs/commit/dd8a4975aa2ceec5a6cc56db4cdab33f099d5b8c) gd: remove null overwrites
* [`ddb5ea3e`](https://github.com/NixOS/nixpkgs/commit/ddb5ea3e6989a1c1128dc4642771dbe53a7b5293) gcc11: Update back to 11.3 on Darwin
* [`2c38b025`](https://github.com/NixOS/nixpkgs/commit/2c38b02598ff1fb6109797e02483d7fe95c78c18) autoconf-archive: 2022.02.11 -> 2022.09.03
* [`a1115f5e`](https://github.com/NixOS/nixpkgs/commit/a1115f5ea5a82c5758194e7ad72718237a85c1ba) factorio: make it easier to supply a custom versions.json
* [`c6e6d44f`](https://github.com/NixOS/nixpkgs/commit/c6e6d44fe5f6c4ee4350ed330eb7996b57232ed8) factorio: let us change mod settings
* [`eac67059`](https://github.com/NixOS/nixpkgs/commit/eac67059ddf294daec978806ec4b952ff5f26208) yaup: init at unstable-2019-10-16
* [`9508a4ac`](https://github.com/NixOS/nixpkgs/commit/9508a4ac68b3818631ae644e9c0beea597fc9dcf) fetchCrate: rewrite in terms of fetchzip
* [`8c7c3323`](https://github.com/NixOS/nixpkgs/commit/8c7c33237bb551bb99ab604539d4596502fa13b7) procps: 3.3.16 -> 3.3.17
* [`e7396960`](https://github.com/NixOS/nixpkgs/commit/e73969607e7fee0e4ff812e6e98e2b597961101f) maintainers: add tonyshkurenko
* [`3abe0af9`](https://github.com/NixOS/nixpkgs/commit/3abe0af96b10f5a8737ac76bf75523aeab86be76) twingate: init at 1.0.60
* [`acf17b3b`](https://github.com/NixOS/nixpkgs/commit/acf17b3b4b2d42707078a6aedf9e3822b30fb7a9) nixos/twingate: init module
* [`ad5aecbb`](https://github.com/NixOS/nixpkgs/commit/ad5aecbb6b1f0da2c1e0cfda1d4e7bcd48e051ff) llvmpackages: patch shebangs for python subpackages
* [`c100d631`](https://github.com/NixOS/nixpkgs/commit/c100d631369a4279fa99a87b8d9563a8b13d4ab8) navidrome: depend on ffmpeg-headless explicitly
* [`e64d154c`](https://github.com/NixOS/nixpkgs/commit/e64d154cb0c62a4f544db05b6f37c5adaaebb7f5) unpaper: depend on ffmpeg_5-headless explicitly
* [`c4cea038`](https://github.com/NixOS/nixpkgs/commit/c4cea0389b2ece8ffaafe6cd92b0aa6a72fa4309) nixos/no-x-libs: use headless ffmpeg variants
* [`8a1506d0`](https://github.com/NixOS/nixpkgs/commit/8a1506d06460138757984ec9ada9c4a60c673e15) ffmpegthumbnailer: switch to ffmpeg-headless
* [`58211b7b`](https://github.com/NixOS/nixpkgs/commit/58211b7b139e6692c4eb53057b5a75b2964433e8) ffmpegthumbnailer: allow build on unix platforms
* [`0cf541b3`](https://github.com/NixOS/nixpkgs/commit/0cf541b3dd0bd7dffdeec4b2b93a7655b5549d34) pipewire: use ffmpeg-headless
* [`5900f320`](https://github.com/NixOS/nixpkgs/commit/5900f3205e1632e931bb9d18023db090e02f2055) cyanrip: use ffmpeg-headless
* [`e7bce809`](https://github.com/NixOS/nixpkgs/commit/e7bce809ef956ab9b8cd58976ea511def621b07a) openjfx{11,15,17}: use ffmpeg_4-headless
* [`05a5700a`](https://github.com/NixOS/nixpkgs/commit/05a5700ae2856f1e6ef827d671a5dc1395acb525) gst_all_1: use ffmpeg-headless
* [`24268b64`](https://github.com/NixOS/nixpkgs/commit/24268b64b064d95131f151ee950cfa6427228915) fetchzip: auto generate name from pname-version
* [`3f623f2b`](https://github.com/NixOS/nixpkgs/commit/3f623f2b19c52fd639f3e4457cd2252ce64f446a) python310Packages.pybind11: 2.10.0 -> 2.10.1
* [`6bf31817`](https://github.com/NixOS/nixpkgs/commit/6bf318171bcea970cbc9d2ef9033b03298c18073) python3Packages.wrapt: 1.13.3 -> 1.14.1
* [`4750b447`](https://github.com/NixOS/nixpkgs/commit/4750b447cf964857c5a495eac0ddd104563f37d9) ruby: Do not assume gemPath
* [`cf5fa5ea`](https://github.com/NixOS/nixpkgs/commit/cf5fa5eab2faeae72a1ce7e8d5edf8f079c8343e) ruby: Make reproducible
* [`481c3f0a`](https://github.com/NixOS/nixpkgs/commit/481c3f0acd2e5cfad7a5a73d8a25b432a3df2abe) lvm2_2_02: 2.02.187 -> 2.02.188
* [`3454a6b4`](https://github.com/NixOS/nixpkgs/commit/3454a6b4e4a4511990aeb646928dfde88e9ac9b3) lvm2: sha256 -> hash
* [`9b056912`](https://github.com/NixOS/nixpkgs/commit/9b056912e09f92eec39a387d22b504cd1f8b1f0b) lvm2: 2.03.16 -> 2.03.17
* [`28ffdbd0`](https://github.com/NixOS/nixpkgs/commit/28ffdbd0e37d9581cabe2307c922cd98949c92dc) python310Packages.pytz: 2022.2.1 -> 2022.6
* [`6ac6beaf`](https://github.com/NixOS/nixpkgs/commit/6ac6beaf83af64ab1460b935de75055c12b6c0b4) jekyll-webmention_io: init at 3.3.6
* [`f9cb30c4`](https://github.com/NixOS/nixpkgs/commit/f9cb30c4e79877e44a7abeb3e45e96f1d6de2979) python310Packages.curio: 1.5 -> 1.6
* [`bc2eeb02`](https://github.com/NixOS/nixpkgs/commit/bc2eeb02ab82848346bf51eaa9f8efeeebe292a6) bbin: init at 0.1.4
* [`ddb88250`](https://github.com/NixOS/nixpkgs/commit/ddb88250e40a7a68f07130413efae0c863831125) xorg.imake: fix cross
* [`efb9b804`](https://github.com/NixOS/nixpkgs/commit/efb9b804a7aae14aec9872650e0cf5d12acd47fe) xorg.xdm: fix cross
* [`4940c009`](https://github.com/NixOS/nixpkgs/commit/4940c0094fa3d8337e5cd8d2ef224bcb8cf2fd85) systemd: 251.7 -> 251.8
* [`e9c35f11`](https://github.com/NixOS/nixpkgs/commit/e9c35f11c2f90d80ad33854525f5a16c8d3f8cfc) glib: fix cross compile
* [`aa1b96ff`](https://github.com/NixOS/nixpkgs/commit/aa1b96ff78b59878cee48bce2cdbc974568e8f6c) boost: enable cross-compiling Boost.Python
* [`3bb157ac`](https://github.com/NixOS/nixpkgs/commit/3bb157ac20c479bac646186d5f2f0b9f02e14540) lapack-reference: 3.10.1 -> 3.11
* [`fb213161`](https://github.com/NixOS/nixpkgs/commit/fb213161c307649ad2a1987de861ad0a48bcc097) gi-docgen: 2022.1 → 2022.2
* [`762e22d0`](https://github.com/NixOS/nixpkgs/commit/762e22d0634ae1675e6b7a3ba137ec8889e59cb9) python3.pkgs.scipy: 1.9.1 -> 1.9.3
* [`91056104`](https://github.com/NixOS/nixpkgs/commit/9105610435a02a0204956ecb5feb80980b7c37be) python3Packages.pillow: 9.2.0 -> 9.3.0
* [`9a0946a1`](https://github.com/NixOS/nixpkgs/commit/9a0946a1b1fc31d24bced17af3f4181a9328d169) python310Packages.psutil: 5.9.3 -> 5.9.4
* [`b40e6283`](https://github.com/NixOS/nixpkgs/commit/b40e6283a748cdee21e9cbae45be94fe66451709) harfbuzz: 5.2.0 -> 5.3.1
* [`1487ab90`](https://github.com/NixOS/nixpkgs/commit/1487ab90a5c8462bb6dd60261e01f7d4b58dedea) python310Packages.exceptiongroup: 1.0.0 -> 1.0.1
* [`46827e6a`](https://github.com/NixOS/nixpkgs/commit/46827e6a5b3ef3ef8cffbe6ce93ef9aba41ea05e) python310Packages.frozenlist: 1.3.1 -> 1.3.3
* [`75921c99`](https://github.com/NixOS/nixpkgs/commit/75921c996ce1e7ffc1951f863f50f612f88d88e4) python310Packages.httplib2: 0.20.4 -> 0.21.0
* [`ae0e3712`](https://github.com/NixOS/nixpkgs/commit/ae0e37125b83e241763e635e29703f075d1de2b6) python310Packages.platformdirs: 2.5.2 -> 2.5.3
* [`eaab93d6`](https://github.com/NixOS/nixpkgs/commit/eaab93d6389e80a72f4ba2281b72de44c4bf4496) xdg-utils: add patch which adds NIXOS_XDG_OPEN_USE_PORTAL env var
* [`7a908bec`](https://github.com/NixOS/nixpkgs/commit/7a908bec558f9b105424d9a25769c7dabd66bed4) nixos/xdg/portal: add option `xdgOpenUsePortal` which sets `NIXOS_XDG_OPEN_USE_PORTAL`
* [`17b70a26`](https://github.com/NixOS/nixpkgs/commit/17b70a263540b063f1fe299a0b0e99b68c7f707e) xdg-utils: fix missing glib dependency for xdg-open.in and xdg-email.in
* [`9f4143e9`](https://github.com/NixOS/nixpkgs/commit/9f4143e964bff2d96d2e2c370182b7973a226e07) stdenv: fix succeedOnFailure
* [`b6622231`](https://github.com/NixOS/nixpkgs/commit/b662223102564762bf0f7b42e8abd496f90f5edf) python310Packages.cvelib: 1.0.0 -> 1.1.0
* [`dbb1aacc`](https://github.com/NixOS/nixpkgs/commit/dbb1aacce0bdf4b150d8853ef4177d52ae442313) sbcl: v2.2.10
* [`d7626595`](https://github.com/NixOS/nixpkgs/commit/d7626595e8d5ed4aa46a4e68fbaeb6a53a105403) python3Packages.jpylyzer: 2.0.1 -> 2.1.0
* [`e6f280c6`](https://github.com/NixOS/nixpkgs/commit/e6f280c62b9176c0b35a35d9868bdb0069c4e973) python3.pkgs.meson-python: 0.8.1 -> 0.10.0
* [`faaceef0`](https://github.com/NixOS/nixpkgs/commit/faaceef064934497da4a83820220edd8893807cf) man-db: 2.10.2 -> 2.11.0
* [`b7e217d3`](https://github.com/NixOS/nixpkgs/commit/b7e217d3bde931544dc7e029cb932ec558d8a12f) sbcl: apply /bin/cat -> $PATH/cat patch for 2.2.10
* [`d456674f`](https://github.com/NixOS/nixpkgs/commit/d456674f5863f9e49d21c0ee76f824273b14d5e3) libxcrypt: 4.4.30 -> 4.4.31
* [`e2fbe408`](https://github.com/NixOS/nixpkgs/commit/e2fbe408dc3680cfb52876a7f8a24b552c17fe71) sbcl 2.2.10: nix-prefetch-url output confusion
* [`f281935a`](https://github.com/NixOS/nixpkgs/commit/f281935aaa36fe799d306d75c0a093ad33eee434) python310Packages.twisted: 22.8.0 -> 22.10.0
* [`19c5ad80`](https://github.com/NixOS/nixpkgs/commit/19c5ad8058d5423140fcd6c77584b4eadc38c6f2) python3.pkgs.pybind11: don't build tests if not needed
* [`4ebd3670`](https://github.com/NixOS/nixpkgs/commit/4ebd36707e861e39f3f6b1865615f09a0598cb8c) iana-etc: 20220915 -> 20221107
* [`f74e68b7`](https://github.com/NixOS/nixpkgs/commit/f74e68b70a4f79d8f8ed76424ede069751a610f7) systemd: configure as release build
* [`51518a5f`](https://github.com/NixOS/nixpkgs/commit/51518a5fd34ca9eb5e7aa203f89023b91f029028) stdenv.tests: Add succeedOnFailure
* [`f930ba6a`](https://github.com/NixOS/nixpkgs/commit/f930ba6aba43853d1f1733a9718585c6c80d890d) webkitgtk: Bind NixOS directories to sandbox last
* [`eea038cc`](https://github.com/NixOS/nixpkgs/commit/eea038cc8f7f32b5f88229bf046a13e6ed2338d4) rustc: 1.64.0 -> 1.65.0
* [`6bd5e60a`](https://github.com/NixOS/nixpkgs/commit/6bd5e60a4072a06621f722c724375cd8e2b54d26) openjdk17: 17.0.4+8 → 17.0.5+8
* [`24d02f17`](https://github.com/NixOS/nixpkgs/commit/24d02f17a94fefd007afa64f6ab17b5c08a3a444) wayland-protocols: 1.27 -> 1.29
* [`1613432d`](https://github.com/NixOS/nixpkgs/commit/1613432da81fa351bbef257f713b344bc19dedab) libdrm: 2.4.113 -> 2.4.114
* [`d3153abe`](https://github.com/NixOS/nixpkgs/commit/d3153abe7d4c6a59c98d05d293e28a0f15bfa601) accelergy: init at unstable-2022-05-03
* [`48f69ab3`](https://github.com/NixOS/nixpkgs/commit/48f69ab38dfd142af8dc3b4bb98768548dcac002) python3Packages.jsonschema: 4.16.0 -> 4.17.0
* [`a30aa05f`](https://github.com/NixOS/nixpkgs/commit/a30aa05f56052bb84d448426dc8e23ab1ccd7102) synth: apply patch to fix on rust 1.65
* [`359e6f8f`](https://github.com/NixOS/nixpkgs/commit/359e6f8fd98b64c111d7e096e1faaba1a370102d) python310Packages.rich: 12.5.1 -> 12.6.0
* [`c865c8c4`](https://github.com/NixOS/nixpkgs/commit/c865c8c4a8f73c31427aab8eca16b675af8efc4d) python3Packages.zopfli: 0.2.1 -> 0.2.2
* [`e5673f90`](https://github.com/NixOS/nixpkgs/commit/e5673f902522f47408d7ef3c88ee90d80fb0d4d7) pomerium: 0.19.1 -> 0.20.0
* [`46514cc0`](https://github.com/NixOS/nixpkgs/commit/46514cc0d3c98f12b726d66b82ebc45e91c6f0e8) pomerium-cli: 0.19.0 -> 0.20.0
* [`a56ecf20`](https://github.com/NixOS/nixpkgs/commit/a56ecf201e0f11663e9d992f2598b50878233a4e) trustme: Fix enabled tests on darwin
* [`6925777f`](https://github.com/NixOS/nixpkgs/commit/6925777fe4c1c1581045e0e7b3f83cf01a955d87) systemd: 251.8 -> 252.1
* [`fe5f1a42`](https://github.com/NixOS/nixpkgs/commit/fe5f1a422aa70970aafebf27e89628fcdb7db67f) sysstat: 12.6.0 -> 12.6.1
* [`b9b269f6`](https://github.com/NixOS/nixpkgs/commit/b9b269f6e6c82d0d2a5016c1d4ffb01a0f76d08c) python310Packages.asttokens: 2.0.8 -> 2.1.0
* [`11563bf9`](https://github.com/NixOS/nixpkgs/commit/11563bf92fc8ea48ecdb5157b92854395e190d8b) bundler: 2.3.25 -> 2.3.26
* [`86b196f1`](https://github.com/NixOS/nixpkgs/commit/86b196f1553cd3307e28e1ce8e98a6f417b6d5e2) bundler: add meta.changelog
* [`72c16839`](https://github.com/NixOS/nixpkgs/commit/72c16839ea42806f2b2e0df7b2865b5e362ce77d) mpfr: 4.1.0 -> 4.1.1
* [`606ea22b`](https://github.com/NixOS/nixpkgs/commit/606ea22b7e5953dd15bd53c4fc5c97b1bc36cc38) sqlite: 3.39.4 -> 3.40.0
* [`b6c1fc2b`](https://github.com/NixOS/nixpkgs/commit/b6c1fc2b90e2207043e16a495688265d6f9539ae) jdupes: apply some critical unreleased fixes from upstream
* [`a79bf2bf`](https://github.com/NixOS/nixpkgs/commit/a79bf2bfeafba7767993f8af7808ac638d2d81d9) zinc: init at 0.3.5
* [`5dc55761`](https://github.com/NixOS/nixpkgs/commit/5dc55761c95901f14cded3d70ab41b0d477da99e) semver: init at 0.3.0
* [`4e7bf713`](https://github.com/NixOS/nixpkgs/commit/4e7bf713cfdf337d5ea5378a4a1ab39b32e093e6) fancypp: init at 2021-04-08
* [`171bd946`](https://github.com/NixOS/nixpkgs/commit/171bd946e76a4c030062970515e14694591442ff) httplib: init at 0.11.1
* [`1e2b2255`](https://github.com/NixOS/nixpkgs/commit/1e2b2255d7780498fbc5e2a2e63cf215040c2d5d) fancypp: 2021-04-08 -> unstable-2021-04-08
* [`28b3bd03`](https://github.com/NixOS/nixpkgs/commit/28b3bd0395a56a7b6100e35cdde3082fff81dfa0) soundux: init at 0.2.7
* [`1b3d8a0d`](https://github.com/NixOS/nixpkgs/commit/1b3d8a0dc893d5382f00958bb0f7407b71bb68cf) Revert "python3Packages.scipy: pull an upstream patch"
* [`c0374c59`](https://github.com/NixOS/nixpkgs/commit/c0374c59e0bce036b341917b636abb9643da1c66) libxcrypt: 4.4.31 -> 4.4.33
* [`40655660`](https://github.com/NixOS/nixpkgs/commit/40655660032852e0ab88ec6164c53e5c6329a9ed) glslang: fix broken paths in output cmake files
* [`ddd1e566`](https://github.com/NixOS/nixpkgs/commit/ddd1e56610607ceec26054fee2afb8421678b1c3) libyuv: fix libyuv.so not linking against libjpeg
* [`49c59226`](https://github.com/NixOS/nixpkgs/commit/49c5922675469bcd8b2c5aa457a806b4b1fd384b) tiled: 1.8.4 > 1.9.2
* [`ca95ee09`](https://github.com/NixOS/nixpkgs/commit/ca95ee0977881c30b6abb516580e0478c795f7b4) glibc: backport make-4.4 fix
* [`7312b9ad`](https://github.com/NixOS/nixpkgs/commit/7312b9ad2fc50010e6e952170512f31816b96e22) python310Packages.simplejson: 3.17.6 -> 3.18.0
* [`e835141b`](https://github.com/NixOS/nixpkgs/commit/e835141b0921c5024616097a9bd120346e8cb6bf) librsvg: enable vala on darwin ([nixos/nixpkgs⁠#200567](https://togithub.com/nixos/nixpkgs/issues/200567))
* [`2a694d7b`](https://github.com/NixOS/nixpkgs/commit/2a694d7ba22dc08b6ab27821d3d0d1543735fbb6) luajit: mark as broken on riscv64
* [`ca213228`](https://github.com/NixOS/nixpkgs/commit/ca213228f063bb8d64feb2660fbae57e6b4700d3) libvterm: fix cross compilation
* [`e2ba7e6e`](https://github.com/NixOS/nixpkgs/commit/e2ba7e6e9220e86114759ecbc4cdd23470757666) libvterm-neovim: fix cross compilation
* [`1272bae2`](https://github.com/NixOS/nixpkgs/commit/1272bae282eb91e182452903e2493609ae30b370) neovim-unwrapped: don't use luajit on riscv
* [`7d4abc2b`](https://github.com/NixOS/nixpkgs/commit/7d4abc2b9413f699559c2cfe0145fd27859cc22e) crystal: Unmark 1.2 broken for aarch64-darwin
* [`f7944fdd`](https://github.com/NixOS/nixpkgs/commit/f7944fddae69c86674273db33c6692c66b7c3a1b) synth: 0.6.8 -> 0.6.9
* [`085c646b`](https://github.com/NixOS/nixpkgs/commit/085c646bbbea83a4e006f4465a442933bcfdb5e8) python3Packages.orjson: 3.8.1 -> 3.8.2
* [`d0e0baba`](https://github.com/NixOS/nixpkgs/commit/d0e0bababe8d010a8abac3c1c2372f5ec42a3905) python310Packages.astroid: 2.11.7 -> 2.12.12
* [`89527266`](https://github.com/NixOS/nixpkgs/commit/89527266969961de64df67d372afbed07a03c816) python310Packages.pylint: 2.14.5 -> 2.15.5
* [`cb56c352`](https://github.com/NixOS/nixpkgs/commit/cb56c35264c62906b11718b31fa18446e3d2da76) z3, python310Packages.deal-solver: pass python dependencies
* [`9a4cba42`](https://github.com/NixOS/nixpkgs/commit/9a4cba4233c87a2a883b631f6aa97d68dca972d9) libtiff: add patch for CVE-2022-3970
* [`9afbff9b`](https://github.com/NixOS/nixpkgs/commit/9afbff9b31cf50b85a8c2d1ffe2e8e713eaa4092) python310Packages.protobuf: remove unused pyext
* [`435fc65e`](https://github.com/NixOS/nixpkgs/commit/435fc65e74c0f62eed8e7bd3f42dea6f42560c0e) python310Packages.pyext: remove unmaintained and unused package
* [`867c3f3c`](https://github.com/NixOS/nixpkgs/commit/867c3f3cb63ec9556e012f5c006179d081b39b85) python310Packages.rsa: update and fix tests
* [`89987638`](https://github.com/NixOS/nixpkgs/commit/89987638fa594ae5520435de94293a65e92e8916) subunit, python310Packages.subunit: 1.4.0 -> 1.4.2
* [`2d5805c3`](https://github.com/NixOS/nixpkgs/commit/2d5805c332bee620254b98d7b70a62b1fa26183c) iosevka-bin: 16.3.6 -> 16.4.0
* [`0f49483d`](https://github.com/NixOS/nixpkgs/commit/0f49483ded4e5a55be0034e0927ff326322fc670) maintainers: add @⁠montchr
* [`4cb7fffa`](https://github.com/NixOS/nixpkgs/commit/4cb7fffa6e8823563c2f4408201b57af5b9aa9ef) iosevka-bin: add @⁠montchr as maintainer
* [`1996190b`](https://github.com/NixOS/nixpkgs/commit/1996190b651a63f08d9942805658aa153440c1c3) openssl_legacy: init
* [`f06f9501`](https://github.com/NixOS/nixpkgs/commit/f06f950183ee5e124486b2bb64bf6ef0fcdfed1e) Revert "Revert "python3: pin to openssl_1_1""
* [`2b3c7296`](https://github.com/NixOS/nixpkgs/commit/2b3c729654525b10e1af6a6779c2912e551edd9b) python3: use openssl_legacy
* [`578b6d33`](https://github.com/NixOS/nixpkgs/commit/578b6d336f28f48c762d0d90d2db56791ba031df) Revert "openldap: disable failing test"
* [`ff4dcc55`](https://github.com/NixOS/nixpkgs/commit/ff4dcc5559fee6f139c4e8c951888b98563f1194) openldap: use openssl_legacy
* [`82fe3d27`](https://github.com/NixOS/nixpkgs/commit/82fe3d27fbe6faa9b2523f3162dbbfcb50903aa6) rsync: 3.2.6 -> 3.2.7
* [`304d0412`](https://github.com/NixOS/nixpkgs/commit/304d0412a8ed30821f5a3b738adcc7a4a94af7bd) python3Packages.cryptography: 38.0.1 -> 38.0.3
* [`1fb092b8`](https://github.com/NixOS/nixpkgs/commit/1fb092b81ef3b8c1a0d50a9c15875374493231fa) pam_reattach: init at 1.3
* [`40d493c5`](https://github.com/NixOS/nixpkgs/commit/40d493c5fbe1755c3bda076134e22b1bfdbdbc5a) gobject-introspection: use overrideAttrs in the wrapper
* [`559ae378`](https://github.com/NixOS/nixpkgs/commit/559ae3789ada45b17c5894a028966e1686a85d6d) findutils: Fix the build on Android by disabling hardening
* [`67f11a21`](https://github.com/NixOS/nixpkgs/commit/67f11a2185dba0851c520e617526b65d82fb8c5b) libcxx: Link libc++.dylib to matching libc++abi.dylib
* [`252ea651`](https://github.com/NixOS/nixpkgs/commit/252ea6511df5327518b65043d6813684813c067a) libcxxabi: Skip dylib fixups for version symlinks
* [`2252245f`](https://github.com/NixOS/nixpkgs/commit/2252245f9228f460542166450631d2bc6c534d0f) llvm: Find otool bin from targetPrefix
* [`a7517380`](https://github.com/NixOS/nixpkgs/commit/a7517380b5c5505f7ea6e8b517a09eea255fb87a) wayland-protocols: 1.29 -> 1.30
* [`d7a9f5f0`](https://github.com/NixOS/nixpkgs/commit/d7a9f5f001ea6a93389453d4e071ab340603fff0) tracker: backport fixes for SQLite 3.40
* [`e3c8c463`](https://github.com/NixOS/nixpkgs/commit/e3c8c4636786154731b35cfb1bc25bc73e475caf) unixODBCDrivers.psql: unbreak on darwin
* [`06a54ab0`](https://github.com/NixOS/nixpkgs/commit/06a54ab073bc0fad87d33f0f6d28027820b81318) unixODBCDrivers.sqlite: unbreak on darwin
* [`cc12a9ae`](https://github.com/NixOS/nixpkgs/commit/cc12a9ae0362084079df41923897010d415b998d) unixODBCDrivers.mariadb: fix build on darwin
* [`0cf7fb8f`](https://github.com/NixOS/nixpkgs/commit/0cf7fb8f055d27f599b7e6d597009bf1cece5983) pythonPackages.pip: make package reproducible
* [`416f7b44`](https://github.com/NixOS/nixpkgs/commit/416f7b44321e4ff50f29abd9968bd23a1d08f80e) pythonPackages.bootstrapped-pip: inherit pip postPatch
* [`dc361460`](https://github.com/NixOS/nixpkgs/commit/dc3614605fc435c06d159db8fd69c381f4b50578) graphviz: 7.0.0 -> 7.0.2
* [`26eeca7b`](https://github.com/NixOS/nixpkgs/commit/26eeca7b9de36e798997607bb6dae817598ce0d3) organicmaps: 2022.11.02-2 -> 2022.11.24-3
* [`71eee85d`](https://github.com/NixOS/nixpkgs/commit/71eee85daa5b6743d55a1a9f96a0f1064fa666f7) rml: init at 1.09.07
* [`a774e052`](https://github.com/NixOS/nixpkgs/commit/a774e052e6c00a979ca5d7f525a39b861c9c6d3b) hunspell: fix hash
* [`44eb899e`](https://github.com/NixOS/nixpkgs/commit/44eb899e608464615480721716a4d40df5b1a673) victoriametrics: 1.83.1 -> 1.84.0
* [`7227dfb7`](https://github.com/NixOS/nixpkgs/commit/7227dfb7d8fd9daf6479c8e08c69ddf768eea1a3) man-db: 2.11.0 -> 2.11.1
* [`e7d9b0b1`](https://github.com/NixOS/nixpkgs/commit/e7d9b0b19dcf8aad5905992bda555e376931378e) python27: add patches for known security issues
* [`caf8e009`](https://github.com/NixOS/nixpkgs/commit/caf8e0091d294c6f343e792a138d0397ffcf0919) meta: 22.2.3 -> 22.2.4
* [`14334cb6`](https://github.com/NixOS/nixpkgs/commit/14334cb68316f32552b750a6afaf7cb92bfbf4fc) python27: switch to ActiveState's fork for Python 2
* [`b3d02fb8`](https://github.com/NixOS/nixpkgs/commit/b3d02fb8b5c6b822faaeb22afbb9fefabf38982f) python27: add thiagokokada as maintainer
* [`d345fb25`](https://github.com/NixOS/nixpkgs/commit/d345fb25003313c0af43f867c9b5660fdfcae59a) python27: fix CVE-2021-3733
* [`bed5e752`](https://github.com/NixOS/nixpkgs/commit/bed5e75287ba700d2b9a3faa748e0eea1b0ebb69) julia: backport test tweak for mpfr-4.1.1
* [`1b23119f`](https://github.com/NixOS/nixpkgs/commit/1b23119f2186d594f2adb1543bcc1bf293c42ca6) qt6.qtconnectivity: fix build on aarch64-darwin
* [`8091739d`](https://github.com/NixOS/nixpkgs/commit/8091739d36c795d937689eafc496f8f86f49eb14) qt6.qtmultimedia: unbreak on aarch64-darwin
* [`2e7f0a84`](https://github.com/NixOS/nixpkgs/commit/2e7f0a84c0203dc2ca0d146d88905b302261d27e) qt6.qtserialport: unbreak on aarch64-darwin
* [`65a2669c`](https://github.com/NixOS/nixpkgs/commit/65a2669c011e25b1799b5c58ee13668f160a4a94) qt6.qtspeech: unbreak on aarch64-darwin
* [`dfb9d038`](https://github.com/NixOS/nixpkgs/commit/dfb9d038c512b078442d982b1ee4ce9694610c49) qt6.qttools: fix build on aarch64-darwin
* [`df46edff`](https://github.com/NixOS/nixpkgs/commit/df46edff3e5fbe5b4a1d47e0b95889160990339c) qt6.qtwebview: add aarch64-darwin support
* [`c44dd89b`](https://github.com/NixOS/nixpkgs/commit/c44dd89beff94c7b1c41904894f93a03e74d0c08) qt6.qtbase: fix build on x86_64-darwin
* [`5821ec24`](https://github.com/NixOS/nixpkgs/commit/5821ec24784bb9f7063d3a09d16f5f5967f172c5) qt6.qtquick3dphysics: fix build on x86_64-darwin
* [`743fdc3a`](https://github.com/NixOS/nixpkgs/commit/743fdc3a47e8fdfd36889a19d2c983cca42fe48f) python3Packages.pyqt6: mark as broken on darwin
* [`c0d8c84f`](https://github.com/NixOS/nixpkgs/commit/c0d8c84f4024a3b2b6a7b648a3b692532bd84a2c) qt6.qtbase: add aarch64-darwin support
* [`44b66a31`](https://github.com/NixOS/nixpkgs/commit/44b66a31f8533bf55797ba080a42f3a91e17e959) qt6Packages.qtpbfimageplugin: fix build on aarch64-darwin
* [`9f97f464`](https://github.com/NixOS/nixpkgs/commit/9f97f46403500b3a5fc1efeaac14ccbf55793319) snowflake: 2.3.1 -> 2.4.0
* [`42740da2`](https://github.com/NixOS/nixpkgs/commit/42740da241e6cdf251cadf3fa44ad6b284f13600) python310Packages.trustme: Fix tests on aarch64
* [`68329308`](https://github.com/NixOS/nixpkgs/commit/683293089feb2c517689525bddcf5cd237f2b751) mpv-unwrapped: build with meson
* [`35bd85a8`](https://github.com/NixOS/nixpkgs/commit/35bd85a82ff8e0e95baf22855b751781e7997a59) python310Packages.django_hijack: 3.2.4 -> 3.2.5
* [`fde3b570`](https://github.com/NixOS/nixpkgs/commit/fde3b57055a370dd43041b38ef07af66c86fbc3e) buildRustCrate: Support `cargo:rustc-link-arg` and some friends from build.rs
* [`67d671d5`](https://github.com/NixOS/nixpkgs/commit/67d671d5b7b353e3cc8261e829a0f1b933cfda8e) nixos/firejail: remove the need for qualifications
* [`5b3321b4`](https://github.com/NixOS/nixpkgs/commit/5b3321b4e829887e08c5c49dd1e4fc1b38d6b588) jetbrains.jdk: 17.0.3-b469.37 → 17.0.5-b653.14
* [`7776a316`](https://github.com/NixOS/nixpkgs/commit/7776a31612f18700542513f95ed187d32faee339) dendrite: 0.10.7 -> 0.10.8
* [`ad3c91ce`](https://github.com/NixOS/nixpkgs/commit/ad3c91ce355c5a650dedc60f341f697f85363c18) guestfs-tools: fix virt-builder lookup path
* [`74a15450`](https://github.com/NixOS/nixpkgs/commit/74a154509028f703bd828e4629f76a79b120d19b) guestfs-tools: add virt-builder runtime deps
* [`8fa1983b`](https://github.com/NixOS/nixpkgs/commit/8fa1983b3bf19a35a40787d62dfdcb6ea932ce5b) ledger-live-desktop: 2.49.2 -> 2.50.0
* [`d7ea8361`](https://github.com/NixOS/nixpkgs/commit/d7ea83612a285d49fed792382330de61a9900c8e) tt-rss-plugin-auth-ldap: unstable-2022-10-31 -> unstable-2022-11-30
* [`cd8ffa29`](https://github.com/NixOS/nixpkgs/commit/cd8ffa2910d00f1a461c5dce4e11889544766b57) matrix-appservice-slack: 2.0.1 -> 2.0.2
* [`321e4a5a`](https://github.com/NixOS/nixpkgs/commit/321e4a5a9fd07eb6ffa7dd61f4284015012a772e) python3Packages.sphinxext-opengraph: 0.6.3 -> 0.7.3
* [`909cfd2b`](https://github.com/NixOS/nixpkgs/commit/909cfd2b8dd8bd43078975043c5deceeb1cae492) cups-kyodialog: 8.1601 -> 9.2-20220928
* [`53495400`](https://github.com/NixOS/nixpkgs/commit/53495400fbbbdf6791f417982ad46b0169de568e) edk2: 202205 -> 202211
* [`3c2124c4`](https://github.com/NixOS/nixpkgs/commit/3c2124c471814ba196e82e077ac3235c79430b07) lib/strings: simplify `splitString`
* [`d4902bcc`](https://github.com/NixOS/nixpkgs/commit/d4902bcc2cce2a798d5481a60d891230b659aa95) mailmap: cleanup shortlog stats for nixos-22.11 release
* [`cda13fae`](https://github.com/NixOS/nixpkgs/commit/cda13fae0370e557c094bffb2df5ee9575e092ae) vimUtils.packdir: only include python3 if needed
* [`32b27a62`](https://github.com/NixOS/nixpkgs/commit/32b27a62259e21712f6ba84d41c830ca0d17eb8f) chickenPackages_4.chicken: use install_name_tool
* [`7887ed0c`](https://github.com/NixOS/nixpkgs/commit/7887ed0c01d1e44e278d3fa5199b7f1b23f76d86) ugarit, ugarit-manifest-maker: fix build on aarch64-darwin
* [`a34d7b67`](https://github.com/NixOS/nixpkgs/commit/a34d7b67fd8366edaff9e558ac3711d3d8623e47) nixos/top-level.nix: add forbiddenDependenciesRegex option
* [`e8e5cba9`](https://github.com/NixOS/nixpkgs/commit/e8e5cba9414caea6f6b4626f2b47829d8ad85a6b) libint: 2.7.1 -> 2.7.2 & exposed config options
* [`22f749eb`](https://github.com/NixOS/nixpkgs/commit/22f749ebacd6f0b5af7c2078a5e8feb49ffab41e) fox: 1.7.9 -> 1.7.81
* [`b7d5205f`](https://github.com/NixOS/nixpkgs/commit/b7d5205f1af90562599d48244c109a12736cf389) openssl: clean up configure script decision
* [`07cd65be`](https://github.com/NixOS/nixpkgs/commit/07cd65bea252c7cf7aeaec9d9b63d51bb8308af5) treewide: drop wxGTK30-gtk2
* [`51b5602b`](https://github.com/NixOS/nixpkgs/commit/51b5602b458f8ab2b62f397fe98dcd16b7f44135) nixos/networkd: add wait-online.enable option
* [`f8404eba`](https://github.com/NixOS/nixpkgs/commit/f8404eba3fa6a1001fc21dddfbda295615c41dd7) esbuild: 0.15.16 -> 0.15.17
* [`be18e792`](https://github.com/NixOS/nixpkgs/commit/be18e7928b1054aca999786420891fae8af0291a) luau: 0.554 -> 0.555
* [`7b19557a`](https://github.com/NixOS/nixpkgs/commit/7b19557a8db8d5ae0ba4fa793495c9202c2a9c9e) snowflake: 2.4.0 -> 2.4.1
* [`1b55e1aa`](https://github.com/NixOS/nixpkgs/commit/1b55e1aa6bd253782c9ecb110563dbeeade0fb8e) invidious: unstable-2022-11-17 -> unstable-2022-11-22
* [`2bdd5b2b`](https://github.com/NixOS/nixpkgs/commit/2bdd5b2b7b3f667ce2dce5867fb5750d1321a2e6) json-schema-for-humans: 0.42.1 -> 0.44
* [`657de1e3`](https://github.com/NixOS/nixpkgs/commit/657de1e32fa6888b08f363789b32359755b5d4dc) python310Packages.json-schema-for-humans: add changelog to meta
* [`4f619877`](https://github.com/NixOS/nixpkgs/commit/4f61987758d2573577325e5f857aeaa43aa8f039) discourse: 2.9.0.beta12 -> 2.9.0.beta14
* [`f7b8a5d7`](https://github.com/NixOS/nixpkgs/commit/f7b8a5d7f636c37f0a46ac2c5ca69a342bfccc90) python310Packages.websocket-client: 1.4.1 -> 1.4.2
* [`bcfe2a82`](https://github.com/NixOS/nixpkgs/commit/bcfe2a82e4de7d32807b8fbe7f9ac132fa4ed1cf) opensnitch: transfer maintainership to onny
* [`cfdd900d`](https://github.com/NixOS/nixpkgs/commit/cfdd900d66a39636851ba61e821b70fba94a7b62) manual: update meta-attributes section
* [`9cbe4d60`](https://github.com/NixOS/nixpkgs/commit/9cbe4d60b1d0836dcbb02ac61750fc8ee34ab2f4) pkgsMusl.procps: fix build ([nixos/nixpkgs⁠#204212](https://togithub.com/nixos/nixpkgs/issues/204212))
* [`367897a6`](https://github.com/NixOS/nixpkgs/commit/367897a68b3ba59b7f849fd38a49bb0cd0a6ef7d) nixos/mailman: remove trailing slash from `/static` location
* [`8b811912`](https://github.com/NixOS/nixpkgs/commit/8b81191211cb530b7a07e8e2eb72a0998e3383b2) discoursePlugins: update all
* [`13f89aee`](https://github.com/NixOS/nixpkgs/commit/13f89aee64e9a2ba69b32672253728f51b7c7f81) linux: further cleanup config after drop of 4.9
* [`d5299641`](https://github.com/NixOS/nixpkgs/commit/d5299641bb35b3ead5db880a02a27d1665587f5e) isabelle: make withComponents function use finalAttrs
* [`26c36921`](https://github.com/NixOS/nixpkgs/commit/26c369214e6f76216ac3ef6ed7dddfaad486ab3e) isabelle: use prebuilt z3
* [`64e9a730`](https://github.com/NixOS/nixpkgs/commit/64e9a730e3fa6d4e62455bd1146a8c1980e06f06) python310Packages.elegy: add changelog to meta
* [`23de10a4`](https://github.com/NixOS/nixpkgs/commit/23de10a41a0566cb2267bfacb496cba3c5ec2715) zeronet-conservancy: 0.7.8 -> 0.7.8.1
* [`ceb969f7`](https://github.com/NixOS/nixpkgs/commit/ceb969f75be211e00cbe2433076a42bf2e133d70) amtk: 5.6.0 → 5.6.1
* [`c10edbf4`](https://github.com/NixOS/nixpkgs/commit/c10edbf4c2652adac5858ecfc39392c2d2cb1983) gnome.gedit: 43.1 → 43.2
* [`8398ce69`](https://github.com/NixOS/nixpkgs/commit/8398ce6976a546e61940bb0f9789fb7d24d5c004) gnome-builder: 43.2 → 43.3
* [`671b52b2`](https://github.com/NixOS/nixpkgs/commit/671b52b22ca54df9ff92080a76fcf458b26ba492) gssdp_1_6: 1.6.1 → 1.6.2
* [`b4ecfbde`](https://github.com/NixOS/nixpkgs/commit/b4ecfbde37a04c5b25d2af767a33d3ea3a190e24) gupnp_1_6: 1.6.1 → 1.6.2
* [`dd06e817`](https://github.com/NixOS/nixpkgs/commit/dd06e8176b0c45c7103f301c028a287d3a8522c3) evolution-data-server: 3.46.1 → 3.46.2
* [`4efd0771`](https://github.com/NixOS/nixpkgs/commit/4efd0771043e07a3fdea3afe19b3753394d6a512) evolution: 3.46.1 → 3.46.2
* [`d54b1e0c`](https://github.com/NixOS/nixpkgs/commit/d54b1e0cafbf02bdd0272b4a5b45443ebf6e2c1f) evolution-ews: 3.46.1 → 3.46.2
* [`03ba6cda`](https://github.com/NixOS/nixpkgs/commit/03ba6cdacf4924a413db2216f1bc382f3d3999ad) gnome.gnome-initial-setup: 43.1 → 43.2
* [`0e873690`](https://github.com/NixOS/nixpkgs/commit/0e873690ff4da272f742681fff4df40e54f234b0) libshumate: 1.0.2 → 1.0.3
* [`734220a7`](https://github.com/NixOS/nixpkgs/commit/734220a7a783d0deb7dc5eae7f12fc3c12b9e101) gnome.gnome-maps: 43.1 → 43.2
* [`834f5cff`](https://github.com/NixOS/nixpkgs/commit/834f5cffdcc8dbc75adaeb48f4b98fa036f09dab) gnome.gnome-remote-desktop: 43.1 → 43.2
* [`2b67e1c4`](https://github.com/NixOS/nixpkgs/commit/2b67e1c493fae917a19a14ca507d6dadc3cc816b) gnome.gnome-software: 43.1 → 43.2
* [`8db42c7e`](https://github.com/NixOS/nixpkgs/commit/8db42c7e6e1f034c60defe8e2ba1e7bcea781114) gnome.nautilus: 43.0 → 43.1
* [`497c2254`](https://github.com/NixOS/nixpkgs/commit/497c2254ee749f70fa989f71d8fc937b8a3529b0) gnome-builder: 43.3 → 43.4
* [`5ac64b29`](https://github.com/NixOS/nixpkgs/commit/5ac64b2956e92c2411f14ba77b9e93a81825f5d2) libnma: 1.10.2 → 1.10.4
* [`055749be`](https://github.com/NixOS/nixpkgs/commit/055749be190c80d0bb480b980b9a53f0c632df3e) mm-common: 1.0.4 → 1.0.5
* [`1830f9dc`](https://github.com/NixOS/nixpkgs/commit/1830f9dc306611adecba0c2b64ca81850591087d) patsh: 0.1.3 -> 0.2.0
* [`1011d2a1`](https://github.com/NixOS/nixpkgs/commit/1011d2a118ebcaa7a974e01820df655d3dedc7d7) xdg-desktop-portal-gtk: 1.14.0 → 1.14.1
* [`34100e45`](https://github.com/NixOS/nixpkgs/commit/34100e456b022b66fee882963dfd54cbd1cbff86) vte: 0.70.1 → 0.70.2
* [`2fdf1f39`](https://github.com/NixOS/nixpkgs/commit/2fdf1f390340daf5ad815e6110b7ac7710af84f7) gnome.gucharmap: 15.0.1 → 15.0.2
* [`b492a2c6`](https://github.com/NixOS/nixpkgs/commit/b492a2c6987751b44611feb2d5115dab26df2e7d) deja-dup: 43.4 → 44.0
* [`9f79d634`](https://github.com/NixOS/nixpkgs/commit/9f79d634c4547c2d4b4c39c22b0df149014303b5) python310Packages.django_classytags: 3.0.1 -> 4.0.0
* [`2eb15da4`](https://github.com/NixOS/nixpkgs/commit/2eb15da44871f226a8ce0392aec9121db0bde34b) python2Packages.qpid-python: remove
* [`c99c95f7`](https://github.com/NixOS/nixpkgs/commit/c99c95f795407fa3b26b29b163d06b12994572de) python2Packages.mutagen: remove
* [`53013ae6`](https://github.com/NixOS/nixpkgs/commit/53013ae601d744e100b4bc7b1309368fcceb85fa) python2Packages.prettytable: remove
* [`1d3f70b5`](https://github.com/NixOS/nixpkgs/commit/1d3f70b5fb9935eaa6c58fc71d3769f85c712217) python2Packages.httpretty: remove
* [`23f36e46`](https://github.com/NixOS/nixpkgs/commit/23f36e463eebee0562a6df428cfefa2fb032ff57) mongodb: use cheetah3
* [`d3b70b47`](https://github.com/NixOS/nixpkgs/commit/d3b70b47e3068c80693bc7ae091ed672e6523175) python2Packages.TurboCheetah: remove
* [`ccd71595`](https://github.com/NixOS/nixpkgs/commit/ccd71595e9a541519a8c0a9e5b09ba1c19f5967a) python2Packages.cheetah: remove
* [`8b8b6349`](https://github.com/NixOS/nixpkgs/commit/8b8b63492d607b884869b1a5f96b20abfb1544e6) python310Packages.configargparse: test YAMLConfigFileParser
* [`47cd6b0a`](https://github.com/NixOS/nixpkgs/commit/47cd6b0a4ed85894f4b80e1d651bb4b0fb607278) python2Packages.markdown: remove
* [`b6062cc5`](https://github.com/NixOS/nixpkgs/commit/b6062cc56e04cb29465c97813d2aa806ebe41609) mongodb: don't depend on pyyaml
* [`b64c0b1a`](https://github.com/NixOS/nixpkgs/commit/b64c0b1a12457fd04c2a239a326f2be1f90d4ac0) python2Packages.pyyaml: remove
* [`76320a7d`](https://github.com/NixOS/nixpkgs/commit/76320a7d94e1097f5d7e3b82226e6a8433665c80) python2Packages.pillow: remove
* [`e5f735ef`](https://github.com/NixOS/nixpkgs/commit/e5f735efd30b502c05f7855a35f0a84046038d69) python2Packages.construct: remove
* [`0fa639e2`](https://github.com/NixOS/nixpkgs/commit/0fa639e2aa3a53a8afbffedc62f7ab36c0aee581) python2Packages.numpy: remove
* [`1d6a709f`](https://github.com/NixOS/nixpkgs/commit/1d6a709f5c10c165d7dbe35ae31829d3fcbb17f8) metal-cli: 0.11.0 -> 0.12.0
* [`9622693a`](https://github.com/NixOS/nixpkgs/commit/9622693a4bb4d981d40316c5530b4c52035bd286) nixos/bluetooth: remove bluezFull alias from examples
* [`bbe5d44c`](https://github.com/NixOS/nixpkgs/commit/bbe5d44cf25fb17805951711b1ff8d1aece5e946) python310Packages.django_classytags: add changelog to meta
* [`34ddff29`](https://github.com/NixOS/nixpkgs/commit/34ddff29a498b8167e4e684ca87a4f4801cd0a63) libreddit: Add package option
* [`a705dca5`](https://github.com/NixOS/nixpkgs/commit/a705dca58f5aebc65beb95ae5cf38b0cf27dbde5) python3Packages.twisted: disable failing tests on aarch64-darwin
* [`364d3609`](https://github.com/NixOS/nixpkgs/commit/364d3609cd8e90c179a577d122fb76659a247d3a) nixos/installer/cd-dvd: use filtered nixpkgs source
* [`563fad90`](https://github.com/NixOS/nixpkgs/commit/563fad90a56cb5000282b06a170ea4b0b899f76f) deploy-rs: 2022-08-15 -> 2022-11-18
* [`9330a280`](https://github.com/NixOS/nixpkgs/commit/9330a280be868d669f3a163cb9a1bd138135900d) feishu: 5.14.14 -> 5.18.11
* [`9d1896eb`](https://github.com/NixOS/nixpkgs/commit/9d1896eb120c8e4de2d32ea4132c00088c809288) python310Packages.mapbox-earcut: 1.0.0 -> 1.0.1
* [`517ce3ab`](https://github.com/NixOS/nixpkgs/commit/517ce3aba91ea04f0d33eec3f87285cbce0d8eec) metal-cli: add changelog to meta
* [`215be027`](https://github.com/NixOS/nixpkgs/commit/215be027c56e8621ebc5bb6de5ebc22591c9e4b4) python310Packages.oauthlib: 3.2.1 -> 3.2.2
* [`1625a788`](https://github.com/NixOS/nixpkgs/commit/1625a78826ee3b141074418c58b21d301677bda0) python310Packages.weconnect: 0.48.3 -> 0.49.0
* [`e19bb575`](https://github.com/NixOS/nixpkgs/commit/e19bb575cf569dec11061b9b16f951942086154a) python310Packages.weconnect: add changelog to meta
* [`a86f7bdf`](https://github.com/NixOS/nixpkgs/commit/a86f7bdfeeb7c04605d066cd7138f1daba5b4449) python310Packages.weconnect: 0.49.0 -> 0.50.0
* [`8fd54278`](https://github.com/NixOS/nixpkgs/commit/8fd54278951c839f7d437d716e1886d0c5fd7c98) python310Packages.weconnect-mqtt: add changelog to meta
* [`a6a38c57`](https://github.com/NixOS/nixpkgs/commit/a6a38c57c8b48b038d0a4086d199412c7ea2d488) pritunl-client: 1.3.3343.50 -> 1.3.3370.14
* [`55ef419a`](https://github.com/NixOS/nixpkgs/commit/55ef419a6e2b4536549e6115d66a11f611674cbc) prometheus-blackbox-exporter: 0.22.0 -> 0.23.0
* [`aece0863`](https://github.com/NixOS/nixpkgs/commit/aece0863ab889953c0d09f1454e7c4f507caeaa8) python310Packages.weconnect: 0.50.0 -> 0.50.1
* [`a3d46593`](https://github.com/NixOS/nixpkgs/commit/a3d4659349693b7f406e3441f6e77814a145d838) python310Packages.weconnect-mqtt: 0.40.3 -> 0.41.1
* [`619fc8f2`](https://github.com/NixOS/nixpkgs/commit/619fc8f27878d581de363b369171b9a75ebe7f12) python310Packages.mapbox-earcut: add changelog to meta
* [`1cca42b6`](https://github.com/NixOS/nixpkgs/commit/1cca42b6ad2c38dcdc133363070e3109fe9f43db) portfolio: 0.59.4 -> 0.59.5
* [`a4966eec`](https://github.com/NixOS/nixpkgs/commit/a4966eecb99e8f732fe91aecc1d991ad16e5e41a) libredwg: 0.12.4 -> 0.12.5
* [`97eaeee7`](https://github.com/NixOS/nixpkgs/commit/97eaeee775071cb4c63b0134a346bf1c78ace871) github-runner: make `ldd` and `ldconfig` paths absolute on Linux
* [`d911353c`](https://github.com/NixOS/nixpkgs/commit/d911353cf8af68ca67f24fe193a6bcdfe12d598f) mbuffer: fix cross compilation
* [`37d44151`](https://github.com/NixOS/nixpkgs/commit/37d44151f3141092079eff9c63daf622835ae440) deploy-rs: adjust description
* [`08e041d8`](https://github.com/NixOS/nixpkgs/commit/08e041d8faeb7c5133a852d5bb11e8f8f0b7d9d6) mailspring: add libappindicator
* [`c5b0d1ec`](https://github.com/NixOS/nixpkgs/commit/c5b0d1ec8e323f7f2c2a4436e6ece299ed69e6d8) rPackages.imager: use xorg.* packages directly instead of xlibsWrapper indirection
* [`2c004295`](https://github.com/NixOS/nixpkgs/commit/2c0042956018b6b0dbe41195362afacf704b7214) nixos/dnsmasq: Use attrs instead of plain text config
* [`c1e0845d`](https://github.com/NixOS/nixpkgs/commit/c1e0845d84a0442eacb06c5748461af06eef17d7) openldap: try to fix test error
* [`8b2af89c`](https://github.com/NixOS/nixpkgs/commit/8b2af89c98fb7edfadc606c06255bf6f5fa3bc64) s2n-tls: 1.3.28 -> 1.3.29
* [`75f2f8e7`](https://github.com/NixOS/nixpkgs/commit/75f2f8e753a07519713c3113f859a679c52045ce) passthrough config if there are no secrets defined
* [`c0e33249`](https://github.com/NixOS/nixpkgs/commit/c0e332492fdbfd81a220d2755ba0ab67542e96b2) python3Packages.libredwg: fix build on darwin
* [`9a2a145f`](https://github.com/NixOS/nixpkgs/commit/9a2a145ff374fc23c585223fa3b00bd7124d101f) streamlink: 5.0.1 -> 5.1.2
* [`bfff474f`](https://github.com/NixOS/nixpkgs/commit/bfff474f8f12c4b6ed9a41c5197a2038a2049acd) plocate: 1.1.16 -> 1.1.17
* [`ffe45e95`](https://github.com/NixOS/nixpkgs/commit/ffe45e9509d7ea49f6691e7cf8fc736388fa83ce) pinentry: remove global with lib
* [`39089253`](https://github.com/NixOS/nixpkgs/commit/39089253c0cbd2a3bde3a337ce87e790050f269e) pinentry: add option to build without libsecret
* [`f2bd1b83`](https://github.com/NixOS/nixpkgs/commit/f2bd1b839c1eee3016d20a6b65ecbea13de620d6) nixos/no-x-libs: add pinentry
* [`797c642f`](https://github.com/NixOS/nixpkgs/commit/797c642fdc929be150f2716c47810642a84f9691) sensu-go-agent: 6.9.0 -> 6.9.1
* [`04084c17`](https://github.com/NixOS/nixpkgs/commit/04084c1775a7719e53d55bc465410ea5f8540504) sentry-cli: 2.9.0 -> 2.10.0
* [`59cbf207`](https://github.com/NixOS/nixpkgs/commit/59cbf207dffcce7d4a55b54592e0ebd952eae1ae) mysocketw: fix build on darwin
* [`57d1829c`](https://github.com/NixOS/nixpkgs/commit/57d1829c5e9bc08315464de94bf2d1001ce5a350) netbird: 0.11.1 -> 0.11.3
* [`709ab669`](https://github.com/NixOS/nixpkgs/commit/709ab669fe59aca3c984c90211bfe89d674da744) skaffold: 2.0.2 -> 2.0.3
* [`17a7494d`](https://github.com/NixOS/nixpkgs/commit/17a7494dae1c9250d5dd8b15adeec486c60b7135) cargo-hakari: 0.9.16 -> 0.9.17
* [`8c7a5074`](https://github.com/NixOS/nixpkgs/commit/8c7a50749d8d7e66bc8c3956846a13aa16ccb8e4) cargo-guppy: unstable-2022-11-07 -> unstable-2022-12-05
* [`02d25d3f`](https://github.com/NixOS/nixpkgs/commit/02d25d3fee5431990cc69df296dc44c53d573edf) esbuild: 0.15.17 -> 0.15.18
* [`47a9f2f8`](https://github.com/NixOS/nixpkgs/commit/47a9f2f8f892b8c32f1736e6bac759465d949be9) spdx-license-list-data: 3.18 -> 3.19
* [`83e09f27`](https://github.com/NixOS/nixpkgs/commit/83e09f27c24dfde5223dfade9026f90c115670a8) aws-c-s3: 0.1.51 -> 0.2.0
* [`61aacee7`](https://github.com/NixOS/nixpkgs/commit/61aacee77d6c293d7e36e6655408479c5868360c) sniffnet: init at 1.0.1
* [`e37ec17e`](https://github.com/NixOS/nixpkgs/commit/e37ec17e4400f8770292989fca5b74477ceb3418) cargo-nextest: 0.9.44 -> 0.9.45
* [`cff76b9e`](https://github.com/NixOS/nixpkgs/commit/cff76b9e7cbd8c15b526118ef820968f64e60726) simp1e-cursors: init at 20221103.2
* [`42754564`](https://github.com/NixOS/nixpkgs/commit/427545645623e496f9215f1a6c8d4fbfe068332b) eureka-ideas: enable cargo parallel tests with nextest
* [`a1bf5b35`](https://github.com/NixOS/nixpkgs/commit/a1bf5b35153a9a3c8468c0031ee1d2976096c5fe) castor: enable parallels tests with nextest
* [`7833b95d`](https://github.com/NixOS/nixpkgs/commit/7833b95d8e30660533fe1ef0ec62715f18fcc65a) python310Packages.invisible-watermark: pytorch -> torch
* [`4590da9d`](https://github.com/NixOS/nixpkgs/commit/4590da9d9c2c4d59ea10667124b0092b1e2a041a) terraform-providers.keycloak: 4.0.1 → 4.1.0
* [`f9b369ec`](https://github.com/NixOS/nixpkgs/commit/f9b369ec2e18b9afaf20cd081ef0e48e5e393b23) python310Packages.buildbot: 3.6.1 -> 3.7.0
* [`26f0929f`](https://github.com/NixOS/nixpkgs/commit/26f0929fb7d2a57ce9676e58258bff06e399512a) coturn: 4.6.0 -> 4.6.1
* [`8236c5eb`](https://github.com/NixOS/nixpkgs/commit/8236c5ebbd9e75087179d47c9545b8534e1722dd) python310Packages.aliyun-python-sdk-cdn: add changelog to meta
* [`e69a8d0a`](https://github.com/NixOS/nixpkgs/commit/e69a8d0a40268b68aadc94adc37b3e2cfedb6d11) python310Packages.aliyun-python-sdk-config: add changelog to meta
* [`4013d847`](https://github.com/NixOS/nixpkgs/commit/4013d8477d39de73dcac6074903d69991feeacf2) python310Packages.aliyun-python-sdk-dbfs: add changelog to meta
* [`0c768a11`](https://github.com/NixOS/nixpkgs/commit/0c768a11a13ab8845629074d9c061caf4bd15580) python310Packages.aliyun-python-sdk-core: add changelog to meta
* [`2d75d45a`](https://github.com/NixOS/nixpkgs/commit/2d75d45a00518a37aa9438445a787369389b20ec) python310Packages.aliyun-python-sdk-iot: add changelog to meta
* [`280482e8`](https://github.com/NixOS/nixpkgs/commit/280482e845b580ef55de671704528740cea51859) python310Packages.aliyun-python-sdk-ksm: add changelog to meta
* [`326da6b3`](https://github.com/NixOS/nixpkgs/commit/326da6b31b96f9e73d40948024fecbd41bc048fc) python310Packages.aliyun-python-sdk-sts: add changelog to meta
* [`97cbe0ea`](https://github.com/NixOS/nixpkgs/commit/97cbe0ea6f4f11554cf4ad3820bd5bfb47bd9fb8) python310Packages.aliyun-python-sdk-iot: 8.45.0 -> 8.47.0
* [`698fb287`](https://github.com/NixOS/nixpkgs/commit/698fb287cf129c5f63812ca0c4958d883cd31f38) python310Packages.aliyun-python-sdk-config: 2.2.1 -> 2.2.2
* [`539fe9be`](https://github.com/NixOS/nixpkgs/commit/539fe9be905c042d7a518c62d5696086999ee1e3) python310Packages.aliyun-python-sdk-cdn: 3.7.7 -> 3.7.8
* [`89386300`](https://github.com/NixOS/nixpkgs/commit/893863003052ad6e8d14f8807a1a3a1978d1b2f8) python310Packages.pyswitchbot: 0.20.8 -> 0.22.0
* [`7612975a`](https://github.com/NixOS/nixpkgs/commit/7612975ad049e85fb2b01a7881b4ea19bcfa7de9) python310Packages.sentry-sdk: 1.11.0 -> 1.11.1
* [`17bc8d4b`](https://github.com/NixOS/nixpkgs/commit/17bc8d4b6a3cd1171a42e08fe21ba07fcb9eca9e) python310Packages.twilio: add changelog to meta
* [`b0a76368`](https://github.com/NixOS/nixpkgs/commit/b0a76368f3fb2bb93a56a00a3360fc90ad1406c3) python310Packages.twilio: 7.15.3 -> 7.15.4
* [`96b6cfb7`](https://github.com/NixOS/nixpkgs/commit/96b6cfb7be83440302a2800337bfae23ddad9ab8) python310Packages.buildbot: add changelog to meta
* [`108f679f`](https://github.com/NixOS/nixpkgs/commit/108f679f4f80689571205adf375607b0bac49cc2) python310Packages.buildbot: fix lint issues
* [`3ee29831`](https://github.com/NixOS/nixpkgs/commit/3ee2983103952069b96407aeee2248a0e74a243c) coturn: add changelog to meta
* [`2c16d64e`](https://github.com/NixOS/nixpkgs/commit/2c16d64efdceea43826cf6c7e7a407b8555898da) coturn: fix typo
* [`3eb6874b`](https://github.com/NixOS/nixpkgs/commit/3eb6874bda0b517574ecfa06a7cf536fe322b42b) compcert: add support for Coq 8.16.1
* [`da52ce18`](https://github.com/NixOS/nixpkgs/commit/da52ce18b67bad743a45b314693b8a143b7c906a) coqPackages.VST: add support for Coq 8.16.1
* [`221b44a0`](https://github.com/NixOS/nixpkgs/commit/221b44a07175050f7ed4534e5ea75cd180edc6d5) coq: 8.16.0 → 8.16.1
* [`60259cb9`](https://github.com/NixOS/nixpkgs/commit/60259cb9eab3a361dc0d4762aae8f8a530dfefcd) python310Packages.ttls: add changelog to meta
* [`4e3a77ec`](https://github.com/NixOS/nixpkgs/commit/4e3a77ecf0cc79f00d870a6babde63b5a2c3ebbe) python310Packages.ttls: 1.4.3 -> 1.5.1
* [`ba2f6a3a`](https://github.com/NixOS/nixpkgs/commit/ba2f6a3aa27aef45d876758891dae8ad387ea68f) digikam: 7.8.0 -> 7.9.0
* [`9924a10a`](https://github.com/NixOS/nixpkgs/commit/9924a10a52eb020ec2a0943dfc1d48690d95fe37) python310Packages.ttp-templates: add changelog to meta
* [`1090778a`](https://github.com/NixOS/nixpkgs/commit/1090778a4304ac15dc0dceb5265ad7746dc1f784) python310Packages.ttp-templates: 0.3.1 -> 0.3.2
* [`e7ebafeb`](https://github.com/NixOS/nixpkgs/commit/e7ebafeb0227dfe72de8bf516c4c9d1b67ee6b07) python310Packages.slowapi: add changelog to meta
* [`b735e42a`](https://github.com/NixOS/nixpkgs/commit/b735e42a08681f79741e2d8c41311a3d8b579b2f) python310Packages.slowapi: 0.1.6 -> 0.1.7
* [`8fb65a54`](https://github.com/NixOS/nixpkgs/commit/8fb65a543a8b2d0fd563736751f945c8cb08ca30) python310Packages.boschshcpy: 0.2.37 -> 0.2.38
* [`2b982eee`](https://github.com/NixOS/nixpkgs/commit/2b982eee2103689bbc3e29291c5ff6111f41712f) python310Packages.elmax-api: add changelog to meta
* [`bdfcc251`](https://github.com/NixOS/nixpkgs/commit/bdfcc251ab2c5ed55283705253caadee4bf4d732) python310Packages.elmax-api: 0.0.2 -> 0.0.3
* [`18c78672`](https://github.com/NixOS/nixpkgs/commit/18c786729c2f90bea00fd3d7b6c0380a27fcc6ce) python310Packages.buildbot: remove whitespace
* [`547614a2`](https://github.com/NixOS/nixpkgs/commit/547614a2ec53acbd7937ce5acc28b4f89ce04622) freecad: 0.20.1 -> 0.20.2
* [`4495daaa`](https://github.com/NixOS/nixpkgs/commit/4495daaa3bfbe9db41847c5f43a43759a5b26f2e) python310Packages.fakeredis: 2.1.0 -> 2.2.0
* [`440211d4`](https://github.com/NixOS/nixpkgs/commit/440211d4d9da3db32234aa054e5c97f8b32a4679) python310Packages.adlfs: 2022.10.0 -> 2022.11.2
* [`7c31a00b`](https://github.com/NixOS/nixpkgs/commit/7c31a00bd8f0354d38b790138372229d7c2736aa) python310Packages.adlfs: add changelog to meta
* [`31a9917a`](https://github.com/NixOS/nixpkgs/commit/31a9917ad28cb6c0d4b27057d7d03886d86d964c) roundcubePlugins.custom_from: init at 1.6.6
* [`543070ea`](https://github.com/NixOS/nixpkgs/commit/543070eafe8d5e86ebaa3095fd1e568db09b9b73) ocamlPackages.gen: 0.5 → 1.0
* [`99775242`](https://github.com/NixOS/nixpkgs/commit/99775242d3e3ac17174a09103ea4f55b40858b2d) appthreat-depscan: 3.2.3 -> 3.2.7
* [`535c434f`](https://github.com/NixOS/nixpkgs/commit/535c434fa831cb5f6bc9018e4477589d8d5eea47) nixos/snapserver: openFirewall default to false
* [`efeb1e50`](https://github.com/NixOS/nixpkgs/commit/efeb1e50d94d32f6bd8d5821b870a85c1b0a1a9a) nixos/avahi-daemon: openFirewall default to false
* [`659803e8`](https://github.com/NixOS/nixpkgs/commit/659803e8794fcb6df44cbe2eceb9abaced8b7a05) nixos/tmate-ssh-server: openFirewall default to false
* [`372a2d21`](https://github.com/NixOS/nixpkgs/commit/372a2d211115178be0af566a8621f25041015bde) nixos/unifi-video: openFirewall default to false
* [`0d805d3a`](https://github.com/NixOS/nixpkgs/commit/0d805d3a0b4a6913ac65a0d1e981e529779a22b5) nixos/rl-2305: mention openFirewall changed to false for services
* [`600a84ae`](https://github.com/NixOS/nixpkgs/commit/600a84ae16a679f1d504d5bcb3e76dd244e2e533) python310Packages.teslajsonpy: 3.4.0 -> 3.4.1
* [`ccabe4e6`](https://github.com/NixOS/nixpkgs/commit/ccabe4e63265f99f955600d3444e826e1c2322db) python310Packages.slack-sdk: 3.19.4 -> 3.19.5
* [`ab268cd1`](https://github.com/NixOS/nixpkgs/commit/ab268cd1be5367e1f23d3a7bc9c32991fa4ea8f6) aliyun-cli: 3.0.139 -> 3.0.140
* [`53f5d708`](https://github.com/NixOS/nixpkgs/commit/53f5d708b65cc86ab062a71125c957db149e3276) linuxKernel.kernels.linux_zen: 6.0.10-zen2 -> 6.0.11-zen1
* [`dc970c83`](https://github.com/NixOS/nixpkgs/commit/dc970c83493742d20ce314eb53c6379ebb753f96) linuxKernel.kernels.linux_lqx: 6.0.10-lqx1 -> 6.0.11-lqx2
* [`790134b2`](https://github.com/NixOS/nixpkgs/commit/790134b280661d903a8fb2f3e3ef0074ebe0852f) aws-sso-cli: 1.9.5 -> 1.9.6
* [`462e0731`](https://github.com/NixOS/nixpkgs/commit/462e073113035e49fd80fd33a139217cad2f30e7) speechd: prevent leak of mbrola into closure if espeak is disabled
* [`0d5cfedb`](https://github.com/NixOS/nixpkgs/commit/0d5cfedbe4f572360093ca449ac96517d17c0069) pmbootstrap: 1.50.0 -> 1.50.1
* [`50bb886a`](https://github.com/NixOS/nixpkgs/commit/50bb886acc6f240980c9b010c89c58434d7d0fa5) the-way: 0.17.1 -> 0.18.0, add figsoda as a maintainer, use nextest
* [`dcbb3c0b`](https://github.com/NixOS/nixpkgs/commit/dcbb3c0b48aefbeaa2881815a63711bd2d08f29c) jemalloc: move comment to right place, update website
* [`adc3eb32`](https://github.com/NixOS/nixpkgs/commit/adc3eb3244c69758317c8af83761efa8b115596f) ogre: 1.12.1 -> 13.5.3
* [`ac9af8d2`](https://github.com/NixOS/nixpkgs/commit/ac9af8d268060f355c4c4ab3df44ac14dd65b244) ogrepaged: use ogre1_9
* [`904280a5`](https://github.com/NixOS/nixpkgs/commit/904280a5147e114a0cd17c7a9f8711f99b30330f) opendungeons: fix build on aarch64-linux
* [`c6059ff8`](https://github.com/NixOS/nixpkgs/commit/c6059ff8b6dee55564aca53338dd8c4e619698e1) resholve: use system from stdenv.hostPlatform instead of alias
* [`d4f0deff`](https://github.com/NixOS/nixpkgs/commit/d4f0deff85676ce565cd8b8e3f9b51b099b116ed) gitmux: init at 0.7.10
* [`3132d4e2`](https://github.com/NixOS/nixpkgs/commit/3132d4e2f2e8420c872808bad6dde82325ec3fe6) mmtc: 0.3.0 -> 0.3.1
* [`4636b0f7`](https://github.com/NixOS/nixpkgs/commit/4636b0f75121b01d0d5d9df772398f82211f914f) checkSSLCert: 2.56.0 -> 2.57.0
* [`6c6111a6`](https://github.com/NixOS/nixpkgs/commit/6c6111a66c695c73a0877c8dc04cdd282e11b06e) jackett: 0.20.2318 -> 0.20.2325
* [`1a0449ab`](https://github.com/NixOS/nixpkgs/commit/1a0449aba32cebf7dddee42b44601dd78ce43ce9) scryer-prolog: 0.9.0 -> 0.9.1
* [`4acbee46`](https://github.com/NixOS/nixpkgs/commit/4acbee468cd78915c8e91ba59839f8bb12125ceb) hexyl: 0.10.0 -> 0.11.0
* [`470cc589`](https://github.com/NixOS/nixpkgs/commit/470cc589bcfab8b6ad52507918d4dd0070c9b9c0) python310Packages.winacl: add changelog to meta
* [`a8b32d01`](https://github.com/NixOS/nixpkgs/commit/a8b32d0184655cd41e1694806e87eba24550a872) python310Packages.winacl: 0.1.5 -> 0.1.6
* [`20e9c067`](https://github.com/NixOS/nixpkgs/commit/20e9c067c7b394443b05378015d1148ffd482040) bazarr: 1.1.2 -> 1.1.3
* [`831fc4f8`](https://github.com/NixOS/nixpkgs/commit/831fc4f86ae716f702ba39e2e4b1ca95198fec35) nixos/tests/bazarr: remove unneeded timezone workaround
* [`a91db52d`](https://github.com/NixOS/nixpkgs/commit/a91db52d87517d2314601fe7c11fc8de29704637) gnome.gnome-characters: 43.0 → 43.1
* [`adb82d61`](https://github.com/NixOS/nixpkgs/commit/adb82d6119f3753ca42d41b256cb16930d60861e) tracker-miners: 3.4.1 → 3.4.2
* [`e75cfd21`](https://github.com/NixOS/nixpkgs/commit/e75cfd2174f24a133ed513e0d5facfbe1c3decb6) python310Packages.GitPython: 3.1.27 -> 3.1.29
* [`9b691fbe`](https://github.com/NixOS/nixpkgs/commit/9b691fbedd3d1a87fa16215c973146ee77851ffb) python310Packages.gitpython: rename
* [`332bc239`](https://github.com/NixOS/nixpkgs/commit/332bc23944d918a70a847b4c566b8e4b8aae311b) python310Packages.angr: rename GitPython
* [`cffbf91b`](https://github.com/NixOS/nixpkgs/commit/cffbf91bb6426f763f90c281cd051b4ab80561d4) python310Packages.bandit: rename GitPython
* [`ce5ee4b2`](https://github.com/NixOS/nixpkgs/commit/ce5ee4b2bbaa89d171a221148886ca46e16cca51) python310Packages.bandit: add changelog to meta
* [`5f1d7c26`](https://github.com/NixOS/nixpkgs/commit/5f1d7c26167f27ba970a64adb6013a638465a425) python310Packages.opentimestamps: rename GitPython
* [`5b73b859`](https://github.com/NixOS/nixpkgs/commit/5b73b8591a0532d52ac202cba19c00f8ff05ef08) python310Packages.opentimestamps: add changelog to meta
* [`24147918`](https://github.com/NixOS/nixpkgs/commit/24147918a762ea54257913055f8a1066a1445d1e) python310Packages.git-sweep: rename GitPython
* [`914539a5`](https://github.com/NixOS/nixpkgs/commit/914539a5c3bb3cd3210c18413d99584749f309e0) python310Packages.dateparser: rename GitPython
* [`911735a3`](https://github.com/NixOS/nixpkgs/commit/911735a399366cce4b9b198e525ef5939159b913) python310Packages.tern: rename GitPython
* [`b7947193`](https://github.com/NixOS/nixpkgs/commit/b7947193243e45127eb8c205e3fe172919740456) python310Packages.tern: add changelog to meta
* [`1275fda4`](https://github.com/NixOS/nixpkgs/commit/1275fda4a0e897718ae023b45ddad6b9b53c5978) python310Packages.tilequant: rename GitPython
* [`f4c62a23`](https://github.com/NixOS/nixpkgs/commit/f4c62a2380bd3e303db30b42024d5396322f2c96) python310Packages.versionfinder: rename GitPython
* [`5626551c`](https://github.com/NixOS/nixpkgs/commit/5626551cbb2fa352e5018f167d2c089b9bbe09d4) python310Packages.versionfinder: add changelog to meta
* [`95779041`](https://github.com/NixOS/nixpkgs/commit/957790410031fcea6de97efbbcce197c931c634f) unpoller: 2.2.0 -> 2.3.1
* [`87849c90`](https://github.com/NixOS/nixpkgs/commit/87849c9009979276b09390ce7a3e2832d6cbea4c) unpoller: add Frostman to maintainers
* [`0ade4c5f`](https://github.com/NixOS/nixpkgs/commit/0ade4c5f538af4c2aa709fd29ab74eb706d97598) python310Packages.cccolutils: rename GitPython
* [`3c97a66e`](https://github.com/NixOS/nixpkgs/commit/3c97a66e91b0e122e134d95b990835f1e8836e70) python310Packages.py-desmume: rename GitPython
* [`4b04aa9b`](https://github.com/NixOS/nixpkgs/commit/4b04aa9b0b81d1a04a3f36d3dc9e5a78ffe15411) python310Packages.apache-airflow: rename GitPython
* [`51df401d`](https://github.com/NixOS/nixpkgs/commit/51df401da6334f3c26c0f6b2e57e0ba000c0b6e9) python310Packages.stytra: rename GitPython
* [`11661145`](https://github.com/NixOS/nixpkgs/commit/11661145664ac214c3d61c3a32b5ce403c19021b) python310Packages.pylint: rename GitPython
* [`b8ee16d6`](https://github.com/NixOS/nixpkgs/commit/b8ee16d6c7b2ed407f0cbb15fadb9c5cd90b91b1) opentimestamps-client: update style
* [`fdbefaab`](https://github.com/NixOS/nixpkgs/commit/fdbefaab1d0890c5f2448c9df65dc9e3a5754a06) truffleHog: rename GitPython
* [`66a25fc6`](https://github.com/NixOS/nixpkgs/commit/66a25fc6848bcd6bb9c46e1007ab34dde2c862a0) python310Packages.wandb: rename GitPython
* [`be06709e`](https://github.com/NixOS/nixpkgs/commit/be06709e65101b69eb124c64ecb92bf4dd728636) python310Packages.nbdime: rename GitPython
* [`9e7da918`](https://github.com/NixOS/nixpkgs/commit/9e7da918e4b55f0a0ad22f8cca2972360d6dc3c6) python310Packages.mlflow: rename GitPython
* [`eeb1fad1`](https://github.com/NixOS/nixpkgs/commit/eeb1fad1bc5995dc2b36e5cff7a78ace4621a17f) neovide: drop python2, clean up
* [`706a7d15`](https://github.com/NixOS/nixpkgs/commit/706a7d1548fd840bcdde73d9a715fecb5115ff63) python310Packages.mlflow: add changelog to meta
* [`929771b9`](https://github.com/NixOS/nixpkgs/commit/929771b9ed06bc8405647267101fb75dec43cc03) ocaml-ng.ocamlPackages_5_0: 5.0.0-β1 → 5.0.0-β2
* [`e08ac7c2`](https://github.com/NixOS/nixpkgs/commit/e08ac7c24697cc9dbf66b16d598ae8b2c1352201) freecad: rename GitPython
* [`cea83563`](https://github.com/NixOS/nixpkgs/commit/cea835630c78262fa366e115c93dab98a957dcbf) python310Packages.jupytext: rename GitPython
* [`0a7fafb9`](https://github.com/NixOS/nixpkgs/commit/0a7fafb92942f94ae9c032b6c601738fe195d237) python310Packages.mathlibtools: rename GitPython
* [`30b36b98`](https://github.com/NixOS/nixpkgs/commit/30b36b9874f3ea115c5fec57b39117ea882485ef) mcfly: update description to latest from repo
* [`c8366d7f`](https://github.com/NixOS/nixpkgs/commit/c8366d7f3e282c46b3dba73c305692089c924d55) python310Packages.ale-py: init at 0.8.0 ([nixos/nixpkgs⁠#199118](https://togithub.com/nixos/nixpkgs/issues/199118))
* [`02844805`](https://github.com/NixOS/nixpkgs/commit/0284480527be8935b21600cf1cdfaf3d7274bfb6) patsh: add comments explaining the patches
* [`5d723f6a`](https://github.com/NixOS/nixpkgs/commit/5d723f6ad4126ae0e2525c85e6995209c3cf0e15) ansible-language-server: init at 1.0.2-next.0
* [`3a5e1d62`](https://github.com/NixOS/nixpkgs/commit/3a5e1d626cea9459a8e4ce65ef1ba77bbeef61e9) nodePackages."@⁠ansible/ansible-language-server": drop
* [`5a756162`](https://github.com/NixOS/nixpkgs/commit/5a756162648ace359e00dd924e2389e237b789ef) trilium-{desktop,server}: 0.56.2 -> 0.57.3
* [`2a897799`](https://github.com/NixOS/nixpkgs/commit/2a8977997a3c979611bbb0c51b4ade28455fdf0d) unpoller: add passthru.tests
* [`d192be5a`](https://github.com/NixOS/nixpkgs/commit/d192be5adb78fab19b4ccad345c4d8c864b4c40b) python310Packages.py-desmume: add missing input
* [`dfd2b91e`](https://github.com/NixOS/nixpkgs/commit/dfd2b91e743bf2210182e08d1812290feea7bade) update-luarocks-shell: rename GitPython
* [`24b181fd`](https://github.com/NixOS/nixpkgs/commit/24b181fd2f057d32e3a402f90626af3f78f9a1d1) kakoune: rename GitPython
* [`7d151228`](https://github.com/NixOS/nixpkgs/commit/7d151228af1e271d0bec1af83ef2f86439114207) vim: rename GitPython
* [`06cc6353`](https://github.com/NixOS/nixpkgs/commit/06cc6353857978127bff3317cf1e3e3f7f0d3ed5) terraform-compliance: rename GitPython
* [`49dc2b70`](https://github.com/NixOS/nixpkgs/commit/49dc2b7042c2e9c42c129200c4304cd014b2a3d6) streamlit: rename GitPython
* [`7d3c53e6`](https://github.com/NixOS/nixpkgs/commit/7d3c53e6d1bff8bddbb3a8bb84e221536127469f) snakemake: rename GitPython
* [`1700f565`](https://github.com/NixOS/nixpkgs/commit/1700f5659740a866282af577a381f22610bb989a) git-annex-remote-googledrive: rename GitPython
* [`61cb307e`](https://github.com/NixOS/nixpkgs/commit/61cb307ec72734388d7846b299314423db767210) git-privacy: rename GitPython
* [`80fbc24e`](https://github.com/NixOS/nixpkgs/commit/80fbc24e341daa0eff166775385e26f83e711d6d) git-repo-updater: rename GitPython
* [`40ab86df`](https://github.com/NixOS/nixpkgs/commit/40ab86df5ebd7f1fd08ec5542642d4a46c35ca51) git-up: rename GitPython
* [`60a6c602`](https://github.com/NixOS/nixpkgs/commit/60a6c602f73ad916af3242e41b9050bd1fedfb74) legit: rename GitPython
* [`10767e0a`](https://github.com/NixOS/nixpkgs/commit/10767e0a5eb72856866d7daf512b4355f2f3facb) popsicle: unstable-2021-12-20 -> 1.3.1, add figsoda as a maintainer
* [`3d2cdabd`](https://github.com/NixOS/nixpkgs/commit/3d2cdabd1a55201f64311a0495fd36882e8ac3b7) portmod: rename Gitpython
* [`9d6b73b2`](https://github.com/NixOS/nixpkgs/commit/9d6b73b2171f402d2cb54b477afbaf11ec0f701f) agda-pkg: rename GitPython
* [`35284543`](https://github.com/NixOS/nixpkgs/commit/35284543f7f14be713529fd24975ab64a4ad3892) checkov: rename GitPython
* [`2c61d891`](https://github.com/NixOS/nixpkgs/commit/2c61d89177b1576bc725eb5eb8f804ecf6e81c09) cvehound: rename GitPython
* [`91b4118c`](https://github.com/NixOS/nixpkgs/commit/91b4118cd45aebb68c06511d82b06b449dc34084) fdroidserver: rename GitPython
* [`71b77c86`](https://github.com/NixOS/nixpkgs/commit/71b77c86307337d45dbff0c13643b12d3a7e59f8) transifex-client: rename GitPython
* [`969af560`](https://github.com/NixOS/nixpkgs/commit/969af5605d2fd9d8a50b5263a264d0c3ef9ebfbe) python310Packages.scmrepo: rename GitPython
* [`a2fbaae0`](https://github.com/NixOS/nixpkgs/commit/a2fbaae04a31e62c45e0c1a7858797fa6877aafc) rPackages.devEMF: use xorg.* packages directly instead of xlibsWrapper indirection
* [`b2b5c4db`](https://github.com/NixOS/nixpkgs/commit/b2b5c4db0bad90fc83a83670d22853f8bc73497d) rPackages.Cairo: use xorg.* packages directly instead of xlibsWrapper indirection
* [`4244a76a`](https://github.com/NixOS/nixpkgs/commit/4244a76a36560ae57dfef97336f2e6a21c57cab3) python3Packages.azure-storage-queue: 2.1.0 -> 12.5.0
* [`12850888`](https://github.com/NixOS/nixpkgs/commit/12850888ab6f9e53fe08b54d696aaaf654caae76) qt6Packages.qtbase: drop unused xlibsWrapper
* [`87818caa`](https://github.com/NixOS/nixpkgs/commit/87818caa00fb98bf297c02df39270ecdd2bc0778) qt6Packages.qtwayland: drop unused xlibsWrapper
* [`668c2b82`](https://github.com/NixOS/nixpkgs/commit/668c2b8246663e5c130e66d242db90304caaacfc) trilium-desktop: stop auto generating desktop item
* [`9990b010`](https://github.com/NixOS/nixpkgs/commit/9990b010f7fa2f1a967719ff168922230808a55b) pods: 1.0.0-beta.8 -> 1.0.0-beta.9
* [`4619e1c0`](https://github.com/NixOS/nixpkgs/commit/4619e1c05b5746f92c8af4635415aa2d0f9d3218) zbar: fix build on darwin
* [`3b03e122`](https://github.com/NixOS/nixpkgs/commit/3b03e122ef0a5cdb3e8f8228e32eb258fc46ccab) python310Packages.aioesphomeapi: 13.0.0 -> 13.0.1
* [`cf42f9ad`](https://github.com/NixOS/nixpkgs/commit/cf42f9ad107ec8168fefd2076d12cda59d7e1e7e) python310Packages.homematicip: 1.0.12 -> 1.0.13
* [`421c55aa`](https://github.com/NixOS/nixpkgs/commit/421c55aa71d835fe665dd209563cdf285c65a3da) python310Packages.rich-click: add changelog to meta
* [`51cdaaa0`](https://github.com/NixOS/nixpkgs/commit/51cdaaa0d9216d6c4d8d3530712cb389868e90c9) python310Packages.rich-click: 1.5.2 -> 1.6.0
* [`a6a28058`](https://github.com/NixOS/nixpkgs/commit/a6a28058dbb6d61b4e07a6fb189c21d771ff328f) python310Packages.zamg: add changelog to meta
* [`8454f41c`](https://github.com/NixOS/nixpkgs/commit/8454f41cb48dbaab26111c6f9803863064854d21) python310Packages.zamg: 0.1.2 -> 0.2.0
* [`384e0e48`](https://github.com/NixOS/nixpkgs/commit/384e0e48e9344a54433ccfe2113d5a2e5c8594d2) python310Packages.pycryptodome: fix build failure with march set
* [`e059ee05`](https://github.com/NixOS/nixpkgs/commit/e059ee05fdc82091db481455eaec6c8582af0d25) python310Packages.python-novaclient: 18.1.0 -> 18.2.0
* [`6729236d`](https://github.com/NixOS/nixpkgs/commit/6729236d1eedda0cd350b405e0e096c64fdca9c0) python310Packages.python-manilaclient: 4.1.0 -> 4.2.0
* [`c834eb83`](https://github.com/NixOS/nixpkgs/commit/c834eb8374db1fb50201fac03576185e2532025c) python310Packages.python-glanceclient: 4.1.0 -> 4.2.0
* [`7038c53f`](https://github.com/NixOS/nixpkgs/commit/7038c53fbf6ea431a66b3d764eaaf4819b32c89f) python310Packages.ical: 4.1.2 -> 4.2.0
* [`d3d61529`](https://github.com/NixOS/nixpkgs/commit/d3d61529959b449c8c762b5e23ad8ed6676db2c7) python310Packages.gcal-sync: 4.0.3 -> 4.0.4
* [`1e89ee13`](https://github.com/NixOS/nixpkgs/commit/1e89ee13ceae337cd3d64873cd61d399fec9dc08) python310Packages.ical: 4.2.0 -> 4.2.1
* [`0d36b2ab`](https://github.com/NixOS/nixpkgs/commit/0d36b2ab7c22c58a0b1d3d5ebde9663bbb43aa7d) python310Packages.aiogithubapi: 22.10.1 -> 22.12.2
* [`2a9daf76`](https://github.com/NixOS/nixpkgs/commit/2a9daf7668b12876bc493485b1d4b7f8e7cf7158) python310Packages.aiogithubapi: add changelog to meta
* [`09a033a6`](https://github.com/NixOS/nixpkgs/commit/09a033a6af2f0efc2181e07cee564dd4ab76bb0e) python3Packages.python-arango: init at 7.5.3
* [`42056e77`](https://github.com/NixOS/nixpkgs/commit/42056e77ead02e9ec4d325325892ea46d144cbaf) ferretdb: 0.6.2 -> 0.7.0
* [`bbd7a151`](https://github.com/NixOS/nixpkgs/commit/bbd7a1511c7c84a59141290bc930dc8b87293b2f) macvim: remove python2 option
* [`5cbf1101`](https://github.com/NixOS/nixpkgs/commit/5cbf11012396201d8dd0f334e785380ef337206b) lexend: bump version, install variable fonts
* [`17161081`](https://github.com/NixOS/nixpkgs/commit/171610815f4fc9f1bcf3b28ddfe0135f6631d792) icewm: 3.2.2 -> 3.2.3
* [`faef21d3`](https://github.com/NixOS/nixpkgs/commit/faef21d3dbd3ffee3d06ac9e1ffbf63325e80a32) imagemagick: 7.1.0-52 -> 7.1.0-53
* [`49b375b5`](https://github.com/NixOS/nixpkgs/commit/49b375b56e7d28fe03524ff7ce63b224973219e1) jujutsu: 0.5.1 -> 0.6.0
* [`ccdfaa8d`](https://github.com/NixOS/nixpkgs/commit/ccdfaa8de744a01cd46aaef748ddba5bb46ab1d2) hugin: cherrypick fix for segfault on empty XDG_DATA_DIR
* [`41dbb7be`](https://github.com/NixOS/nixpkgs/commit/41dbb7be26b5c8bfb5db3a38abddeb0139e54b0b) heroic: Add extra Wine dependencies
* [`19bae515`](https://github.com/NixOS/nixpkgs/commit/19bae515ba694ef334cd320d403e6bfa487f4f09) heroic: Add Feral Interactive GameMode to Heroic FHS environment
* [`2528455a`](https://github.com/NixOS/nixpkgs/commit/2528455a41c6f1a72ac75b3c6879879e5788bd2a) heroic: Add cabextract for winetricks hacks
* [`3b94b2c0`](https://github.com/NixOS/nixpkgs/commit/3b94b2c03168c5a0ec0cc45830002ee153bea1da) python310Packages.docstring-to-markdown: 0.10 -> 0.11
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
