### PR TITLE
niv devenv: update f574b064 -> b14264df

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "f574b0640ec60c729bb92fe4693956317a65ba6e",
-        "sha256": "1vnbdnbgj3msn6hq7aqcpq2k9k0bsqdpzj7iff8lqvkmnvdm5bl4",
+        "rev": "b14264df26eb6709a7e831213be904c488b0bbe2",
+        "sha256": "1k252mmrdkvkpxqrbskvv70za1slrk1l8sgm91488qnvxsjp8f0k",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/f574b0640ec60c729bb92fe4693956317a65ba6e.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/b14264df26eb6709a7e831213be904c488b0bbe2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@f574b064...b14264df](https://github.com/cachix/devenv/compare/f574b0640ec60c729bb92fe4693956317a65ba6e...b14264df26eb6709a7e831213be904c488b0bbe2)

* [`2c4fa3a7`](https://github.com/cachix/devenv/commit/2c4fa3a7211201c298377237dd0716b3cfe93082) devcontainer: improvements
* [`ecfb0c84`](https://github.com/cachix/devenv/commit/ecfb0c84eb745a393effed30ede5a732ed1688f5) reduce closure size
* [`f3d3f9c9`](https://github.com/cachix/devenv/commit/f3d3f9c922aa9de3bdf4a52c03b6ba31cdf37a56) flake: avoid creating another instance of nixpkgs
* [`719e76bd`](https://github.com/cachix/devenv/commit/719e76bd834374870dcc5e3db60e4a734d0b7136) Update src/devenv.nix
* [`fe044c43`](https://github.com/cachix/devenv/commit/fe044c43f617be27bb156ce8097dd0f56277790f) Propagate the nixpkgs dependency to reduce the amount of nixpkgs instances.
* [`df047fcf`](https://github.com/cachix/devenv/commit/df047fcfcc8126818d804bf045cbba729b8a8ed3) nix flake update && devenv update
* [`c803d6e4`](https://github.com/cachix/devenv/commit/c803d6e4900822af822b380b6231fcdd25ac9218) nix flake update && devenv update
* [`b999eb9e`](https://github.com/cachix/devenv/commit/b999eb9e8b2c757deed064c3baa0623a2718418a) Use follows in devenv.yaml as well to mirror flake.nix.
* [`5f531de7`](https://github.com/cachix/devenv/commit/5f531de72b0be2ffddcad4d06fd5a1025d769279) Auto generate docs/reference/options.md
* [`a1efd082`](https://github.com/cachix/devenv/commit/a1efd0824b7fb99fff5cdafcbede126582a31035) feat: add memcached support
* [`726fd62b`](https://github.com/cachix/devenv/commit/726fd62b94e70f0a58da1127e9205299830bb350) Auto generate docs/reference/options.md
* [`ab2e60c9`](https://github.com/cachix/devenv/commit/ab2e60c9c6a4aff9aeda428f207504f97945110b) flake: add lib.mkConfig and lib.mkShell
* [`a2bb200b`](https://github.com/cachix/devenv/commit/a2bb200bef0f629eb192bbaaf220b73db8e7e8a8) flake: add simple Nix flake template
* [`f5f69380`](https://github.com/cachix/devenv/commit/f5f693804b3c1b385b366937657b20fa0edb2578) test: nix flake init and nix develop
* [`0437284c`](https://github.com/cachix/devenv/commit/0437284c37983459ca8e6443d2556f0fbc725609) docs: add guide for using flake devshell
* [`789599c9`](https://github.com/cachix/devenv/commit/789599c99b0b1eb91d89ca80e465701218d0df73) Update templates/simple/flake.nix
* [`12ee6282`](https://github.com/cachix/devenv/commit/12ee6282ffc76078a49f7e0f90b067c81ee9b9c1) fix docs
* [`3cc80b2f`](https://github.com/cachix/devenv/commit/3cc80b2feaea5f63dea6e2e4a6f3afce3301ab0b) feat: adminer module
* [`6f21e370`](https://github.com/cachix/devenv/commit/6f21e3708790e8142163bcdb0e3119697a8a6c9e) mysql: allow creating additional users
* [`3f3f1bd0`](https://github.com/cachix/devenv/commit/3f3f1bd0963396313a98e9bde7361fdac9cd4883) Auto generate docs/reference/options.md
* [`f967383b`](https://github.com/cachix/devenv/commit/f967383b86c7631348f20df37d6ff5d79609369c) inputs: suggest noogle.dev
* [`508f5414`](https://github.com/cachix/devenv/commit/508f5414489df4c26ac85592ea0bd8747da248c3) update-checker: warn correctly if devenv input is older than the cli
* [`212d47b5`](https://github.com/cachix/devenv/commit/212d47b524c6ce9813b21ed6dd4126dfcceec663) fix [cachix/devenv⁠#157](https://togithub.com/cachix/devenv/issues/157)
* [`e430be7d`](https://github.com/cachix/devenv/commit/e430be7dc4f75af8a42c309dca3d03403783ecd2) move all services in their prefix
* [`b3a58e63`](https://github.com/cachix/devenv/commit/b3a58e63ce18bc531a985b1ca483fec4f159b7c5) docs: fix services reference
