### PR TITLE
niv emacs-overlay: update 2f7fff8e -> 832ce469

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2f7fff8ee668c01803cab2f0847151fdf647134e",
-        "sha256": "0pshwldb93g88d8mh8pfqzplhady2wspa9vjbqyshnbb7h2k717s",
+        "rev": "832ce4696acba9b6c353495d4f6fd751107f4eca",
+        "sha256": "0licp3vbl2148072yr5bnv4mf3js65r3x2wxa9kwwkq0cm7d4x7h",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/2f7fff8ee668c01803cab2f0847151fdf647134e.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/832ce4696acba9b6c353495d4f6fd751107f4eca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@2f7fff8e...832ce469](https://github.com/nix-community/emacs-overlay/compare/2f7fff8ee668c01803cab2f0847151fdf647134e...832ce4696acba9b6c353495d4f6fd751107f4eca)

* [`a5342a40`](https://github.com/nix-community/emacs-overlay/commit/a5342a40845f3117a77a664511b77cd9735203f3) Updated repos/elpa
* [`dcebfe77`](https://github.com/nix-community/emacs-overlay/commit/dcebfe77d4e54c74bdf98863abd6a33878b94301) Updated repos/emacs
* [`49e3c66d`](https://github.com/nix-community/emacs-overlay/commit/49e3c66d211d5110909375fe48d85c3c43753d61) Updated repos/melpa
* [`b57c104d`](https://github.com/nix-community/emacs-overlay/commit/b57c104d0b4bcea51426271b32f18776d7667a72) Revert "Revert "add tree sitter languages to rpath ([nix-community/emacs-overlay⁠#273](https://togithub.com/nix-community/emacs-overlay/issues/273))""
* [`a5be945a`](https://github.com/nix-community/emacs-overlay/commit/a5be945aa03d73be973225e184556b5473ce77b6) Updated repos/elpa
* [`241bcc1a`](https://github.com/nix-community/emacs-overlay/commit/241bcc1a4852542f3999061670eb03a3d6414960) Updated repos/emacs
* [`c8aaf8c9`](https://github.com/nix-community/emacs-overlay/commit/c8aaf8c9cecfb457153d0003e4536a7a90997296) Updated repos/melpa
* [`f45b1882`](https://github.com/nix-community/emacs-overlay/commit/f45b18820505d7b3549c6cf886a90cdd39ca33b4) Updated repos/nongnu
* [`e2355f56`](https://github.com/nix-community/emacs-overlay/commit/e2355f5689f49ba43477a1a05a80df4b1d5b51d0) Updated repos/emacs
* [`467fee47`](https://github.com/nix-community/emacs-overlay/commit/467fee473347adb1f4527a3375e996f879bf817a) Updated repos/melpa
* [`52db2512`](https://github.com/nix-community/emacs-overlay/commit/52db25120dde17364e07c8a4f6fceb701f96a98c) Updated repos/emacs
* [`e9c4d10b`](https://github.com/nix-community/emacs-overlay/commit/e9c4d10bbb4e810cbfe5e31248fe835e08efb35a) Updated repos/melpa
* [`c063e231`](https://github.com/nix-community/emacs-overlay/commit/c063e23166531c32b686178ac149ccff94b4740f) Updated repos/emacs
* [`fb984310`](https://github.com/nix-community/emacs-overlay/commit/fb9843108f6e09d381c857f733996448d121e855) Updated repos/melpa
* [`45cc4b01`](https://github.com/nix-community/emacs-overlay/commit/45cc4b01c55c0b18944637b186d37942517901e9) Updated repos/nongnu
* [`97b7d6b7`](https://github.com/nix-community/emacs-overlay/commit/97b7d6b717a038f6443c88faf410c116ef97a898) Updated repos/emacs
* [`269cf763`](https://github.com/nix-community/emacs-overlay/commit/269cf7633d51bd316e00ba35467e8a5f5136d28c) Updated repos/melpa
* [`3306f7ef`](https://github.com/nix-community/emacs-overlay/commit/3306f7eff4ee529355e3b154458e3fe798f4bf92) Updated repos/elpa
* [`2b62f775`](https://github.com/nix-community/emacs-overlay/commit/2b62f775f93ad31105f0cf286947c11a588698e8) Updated repos/emacs
* [`1b6e5b25`](https://github.com/nix-community/emacs-overlay/commit/1b6e5b25af402e9f2fd49cf210cada9444c32504) Updated repos/melpa
* [`fc2edb9d`](https://github.com/nix-community/emacs-overlay/commit/fc2edb9d2b4c38cf8f37a7ec6d22a3b5ea779976) Updated repos/elpa
* [`45140e7a`](https://github.com/nix-community/emacs-overlay/commit/45140e7a7d3c3ca461e2ea46a86d7ff505c0829a) Updated repos/emacs
* [`bbed443d`](https://github.com/nix-community/emacs-overlay/commit/bbed443de7f90e1d556d577769fce2ef8063b7cc) Updated repos/melpa
* [`4559b97a`](https://github.com/nix-community/emacs-overlay/commit/4559b97a147399cb39ed3da7d3acf99a087ec581) Updated repos/nongnu
* [`7279dc6f`](https://github.com/nix-community/emacs-overlay/commit/7279dc6f75d0983a552eeacef992246c53473aea) Add tree-sitter-dockerfile
* [`971239d4`](https://github.com/nix-community/emacs-overlay/commit/971239d4dea81088c831fa3682d500c69ae3c0b3) Updated repos/emacs
* [`ff0c1ead`](https://github.com/nix-community/emacs-overlay/commit/ff0c1ead7f28972ba4b63ffc9353a132b163386a) Updated repos/melpa
* [`dd69f1ac`](https://github.com/nix-community/emacs-overlay/commit/dd69f1ac41341780a6a9b4561f7691772ab8ac0c) Updated repos/emacs
* [`a242f161`](https://github.com/nix-community/emacs-overlay/commit/a242f161c1d5d0610e6f11a4924656762e0094d6) Updated repos/melpa
* [`3a0b5dd7`](https://github.com/nix-community/emacs-overlay/commit/3a0b5dd7756173e63c2bbbe70dd5484a7463257d) Updated repos/melpa
* [`99bdadf6`](https://github.com/nix-community/emacs-overlay/commit/99bdadf6d39d0678f26cd4e4f134bdfb4c8304cc) Updated repos/emacs
* [`67b8eb82`](https://github.com/nix-community/emacs-overlay/commit/67b8eb822dbb8e51d45f6b0663b4442b1601ffda) Updated repos/melpa
* [`10340eb1`](https://github.com/nix-community/emacs-overlay/commit/10340eb1ef82fbfdc21885761703589c16364b1d) Updated repos/elpa
* [`75d4ce9b`](https://github.com/nix-community/emacs-overlay/commit/75d4ce9b88538cb5b86cb62c63372bae12510df1) Updated repos/emacs
* [`e29a31a6`](https://github.com/nix-community/emacs-overlay/commit/e29a31a6f79cdd40088263bcc3edda29384ecf94) Updated repos/melpa
* [`341727fd`](https://github.com/nix-community/emacs-overlay/commit/341727fd5924eaaf8a05272becdbe5cd6499bd3f) Updated repos/melpa
* [`72ceefe3`](https://github.com/nix-community/emacs-overlay/commit/72ceefe367325f41481b85a1cb85df000352791b) Updated repos/nongnu
* [`712685d2`](https://github.com/nix-community/emacs-overlay/commit/712685d28c3774170b1856b9ed3cfa17a787d0c1) Updated repos/emacs
* [`6e51884a`](https://github.com/nix-community/emacs-overlay/commit/6e51884abe30b5c57ad248b1a8196929dfbbe029) Updated repos/melpa
* [`bcfc4049`](https://github.com/nix-community/emacs-overlay/commit/bcfc40496862d0ed0d93a53dc977a5d412f64c94) Updated repos/elpa
* [`eaca39aa`](https://github.com/nix-community/emacs-overlay/commit/eaca39aa568d361a8c080e71a2d158b7f550c4f6) Updated repos/emacs
* [`9fe20594`](https://github.com/nix-community/emacs-overlay/commit/9fe20594a0dce5fdba2f683d2c4cba3371ce7581) Updated repos/melpa
* [`6fad8d32`](https://github.com/nix-community/emacs-overlay/commit/6fad8d32db4b3225e72ec8ca4bfc0de249f9c1be) Add tree-sitter-cmake
* [`48c2fe6b`](https://github.com/nix-community/emacs-overlay/commit/48c2fe6b2798fd6297bedf0b290632019e00869e) Updated repos/emacs
* [`88fdfc09`](https://github.com/nix-community/emacs-overlay/commit/88fdfc0924959842b8d155a7f4b14056c3aa1d18) Updated repos/melpa
* [`290e3660`](https://github.com/nix-community/emacs-overlay/commit/290e366022a72225fed4f378e525de955c2edce5) Updated repos/nongnu
* [`61e8c316`](https://github.com/nix-community/emacs-overlay/commit/61e8c3167cd2a748a7a805caca3ae5756b2b6eb5) Updated repos/melpa
* [`5e73ace8`](https://github.com/nix-community/emacs-overlay/commit/5e73ace8e46e94329f9e95f9c904ac6a9b5e0738) Updated repos/emacs
* [`811fd5be`](https://github.com/nix-community/emacs-overlay/commit/811fd5be2bc3f973760854b525e42221ddaf72e9) Updated repos/melpa
* [`f877d256`](https://github.com/nix-community/emacs-overlay/commit/f877d2569e1e9c6dd225f6674ef2f8777582215f) Updated repos/nongnu
* [`19377d6d`](https://github.com/nix-community/emacs-overlay/commit/19377d6d61b8a2f11f990eae08333835eeafe844) Updated repos/elpa
* [`832ce469`](https://github.com/nix-community/emacs-overlay/commit/832ce4696acba9b6c353495d4f6fd751107f4eca) Updated repos/melpa
