### PR TITLE
niv spacemacs: update bced05b3 -> 866a2d5a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "bced05b3b06843ba4d2d10602f9cf609f05da17b",
-        "sha256": "0iz3gbmyfdm1vvgpyq37cv8lbbal17qk0p5x1yv09f56as7fk076",
+        "rev": "866a2d5ae12706a68acb83f489dd669bc7b29d1e",
+        "sha256": "16vf8gs9k5i47q7fgz63w2kimgi4i25pjpq8cyk7x6aicccj5n8y",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/bced05b3b06843ba4d2d10602f9cf609f05da17b.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/866a2d5ae12706a68acb83f489dd669bc7b29d1e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@bced05b3...866a2d5a](https://github.com/syl20bnr/spacemacs/compare/bced05b3b06843ba4d2d10602f9cf609f05da17b...866a2d5ae12706a68acb83f489dd669bc7b29d1e)

* [`3be65c73`](https://github.com/syl20bnr/spacemacs/commit/3be65c7354f3aab9b28bfed8508d12256fcce0ca) * core: enhance the code to reduce flycheck warnings
* [`866a2d5a`](https://github.com/syl20bnr/spacemacs/commit/866a2d5ae12706a68acb83f489dd669bc7b29d1e) [core] disable internal border ([syl20bnr/spacemacs⁠#15843](https://togithub.com/syl20bnr/spacemacs/issues/15843))
