### PR TITLE
niv zsh-completions: update f9373c96 -> 7b8bb64c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "f9373c96c727e1c8ef7fb48fe49524c1a786fa80",
-        "sha256": "1ydldzv282wg1bfhllafhkrrrg5f8bh5anv791b6xrwzmjj53x4f",
+        "rev": "7b8bb64cbb2014de66204b800bdac9ea149b6932",
+        "sha256": "0jmgx9y4mqq8dj9n6lsc4rg8ccpjyad2ba4yp59r5fvlvyzfngfr",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/f9373c96c727e1c8ef7fb48fe49524c1a786fa80.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/7b8bb64cbb2014de66204b800bdac9ea149b6932.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@f9373c96...7b8bb64c](https://github.com/zsh-users/zsh-completions/compare/f9373c96c727e1c8ef7fb48fe49524c1a786fa80...7b8bb64cbb2014de66204b800bdac9ea149b6932)

* [`3d26c204`](https://github.com/zsh-users/zsh-completions/commit/3d26c20452e1fd534d91df6ced587b20120ed864) Add clang-check completion
* [`3b047749`](https://github.com/zsh-users/zsh-completions/commit/3b0477499ea3367bf75fcaf833691ac3dba09196) Add clang-format completion
* [`d6e88179`](https://github.com/zsh-users/zsh-completions/commit/d6e881799130a977dfe9c0b26431b368bff47701) Add clang-tidy completion
* [`07a062b7`](https://github.com/zsh-users/zsh-completions/commit/07a062b77eee66f02291fd00a612c4c4d633543b) Update go1.20
