### PR TITLE
niv zsh-you-should-use: update 13c86356 -> 5b316f4a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -252,10 +252,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "13c86356553b80e0e0cbf1ecf6d82cfa79751b5a",
-        "sha256": "0bk7svjmn8h2dx4z72crhg9b1qid0b9cf0ssvqfc52yg73ajfwym",
+        "rev": "5b316f4af3ac90e044f386003aacdaa0ad606488",
+        "sha256": "192jb680f1sc5xpgzgccncsb98xa414aysprl52a0bsmd1slnyxs",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/13c86356553b80e0e0cbf1ecf6d82cfa79751b5a.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/5b316f4af3ac90e044f386003aacdaa0ad606488.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@13c86356...5b316f4a](https://github.com/MichaelAquilina/zsh-you-should-use/compare/13c86356553b80e0e0cbf1ecf6d82cfa79751b5a...5b316f4af3ac90e044f386003aacdaa0ad606488)

* [`800e5ca9`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/800e5ca92bd61c4eac60edd3c1e38d496230a372) Add zsh 5.9 to CircleCI jobs
