### PR TITLE
niv nixpkgs: update 0483b2b2 -> e83d9efe

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0483b2b2e620a4afa74624e0ac173f1c7376fe27",
-        "sha256": "0crshsm5jmys1v99hk1xbfb1wssvgs5kl1pg651wh7bqiylf1zfr",
+        "rev": "e83d9efe4d520414346248dfcdb883701048c847",
+        "sha256": "19jwn99slf2a61mwyvdcw2a83ymwy10bxp1m55h2nrlyh0vdkn0k",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/0483b2b2e620a4afa74624e0ac173f1c7376fe27.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e83d9efe4d520414346248dfcdb883701048c847.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@0483b2b2...e83d9efe](https://github.com/nixos/nixpkgs/compare/0483b2b2e620a4afa74624e0ac173f1c7376fe27...e83d9efe4d520414346248dfcdb883701048c847)

* [`dd358e21`](https://github.com/NixOS/nixpkgs/commit/dd358e2111ff9c24a8b30aa3ba9b5daf397b9797) readline: default to readline81 instead of readline6
* [`3a2124dd`](https://github.com/NixOS/nixpkgs/commit/3a2124ddabc8def85af4fed4703636945a170fff) xgboost: add headers from dmlc-core and rabit
* [`75734fa5`](https://github.com/NixOS/nixpkgs/commit/75734fa56d725f1e074eac624d7edc4d58afa943) python310Packages.pyhamcrest: 2.0.3 -> 2.0.4
* [`a37017ff`](https://github.com/NixOS/nixpkgs/commit/a37017ffd60c740c28ca3f524679173f7b80b3d6) makeRustPlatform: inherit cargo in import-cargo-lock
* [`833155db`](https://github.com/NixOS/nixpkgs/commit/833155db7ec45f6b9ebd023f350b05f7c368421f) geckodriver: 0.31.0 -> 0.32.0
* [`d87d9845`](https://github.com/NixOS/nixpkgs/commit/d87d9845153bbcf11686ef9e719fcaaa3167f950) python3Packages.azure-core: Fix sandboxed build on Darwin
* [`0d9e314d`](https://github.com/NixOS/nixpkgs/commit/0d9e314d08633bb11b7b204f1639944354ca7e4f) ispc: 1.18.0 -> 1.18.1
* [`84394f88`](https://github.com/NixOS/nixpkgs/commit/84394f885dc6939ffcca62716614850923e96559) polkit: 121 → 122
* [`0bb8e949`](https://github.com/NixOS/nixpkgs/commit/0bb8e949007c292e179a2690f1837157376e6560) yarn2nix: Handle lockfile entries with multiple integrity hashes
* [`965665f7`](https://github.com/NixOS/nixpkgs/commit/965665f7888c60fbd73d51e115bf6143f7678268) yarn2nix: format code
* [`c3a0c554`](https://github.com/NixOS/nixpkgs/commit/c3a0c55434a0c0b043fb1cb0f9a862c78d6ff000) tracy: 0.8.2.1 -> 0.9
* [`b2355813`](https://github.com/NixOS/nixpkgs/commit/b2355813d8952f2e35a142d31f580a81e66008af) python3Packages.xxhash: 3.0.0 -> 3.1.0
* [`49d249ed`](https://github.com/NixOS/nixpkgs/commit/49d249ed0a4739a43bfd9f7197e458c6538aeb2e) sweethome3d: 6.6 -> 7.0.2
* [`1948179a`](https://github.com/NixOS/nixpkgs/commit/1948179a74e81ff0033535cbf4ad3d17820333be) yarn2nix: limit ssri parsing to supported algorithms
* [`df7b6e6a`](https://github.com/NixOS/nixpkgs/commit/df7b6e6accaceadc1ba5a25e8fde78bbad3acebe) gnumake: 4.3 -> 4.4
* [`e691cae3`](https://github.com/NixOS/nixpkgs/commit/e691cae38e954f8d90ae63f732f18fb3f387f81d) gitignore: add emacs "swap files"
* [`2427e9a0`](https://github.com/NixOS/nixpkgs/commit/2427e9a0cce12c0550d04e4feae73a6a8ce41545) python310Packages.pysqlcipher3: fix build
* [`57d1e946`](https://github.com/NixOS/nixpkgs/commit/57d1e946c663d89adb458a0d6075c72390075d8f) hmat-oss: 1.7.1 -> 1.8.1
* [`51721c6b`](https://github.com/NixOS/nixpkgs/commit/51721c6b3873cd8d2506e5d766ab542c1574dc83) python3Packages.imageio: 2.22.1 -> 2.22.4
* [`ab060f9d`](https://github.com/NixOS/nixpkgs/commit/ab060f9db9bc39218cf4bed7ec42ca5df4fab7a6) bupstash: 0.11.0 -> 0.12.0
* [`bab1ba48`](https://github.com/NixOS/nixpkgs/commit/bab1ba485c5c46c964e003fae943e2461d748d9c) superd: init at 0.7
* [`8b5bf426`](https://github.com/NixOS/nixpkgs/commit/8b5bf4260fb912ab893da2b58861cca1103b5839) vulkan-headers: add Windows to meta.platforms
* [`33b682eb`](https://github.com/NixOS/nixpkgs/commit/33b682ebaf5df1db6db775e23ab4356a266cff62) dxvk: 1.10.3 -> 2.0
* [`19f7b566`](https://github.com/NixOS/nixpkgs/commit/19f7b566a1e94513a44f009e4d16cfcb76002d86) streamdeck-ui: add option to select the package
* [`c2068e0f`](https://github.com/NixOS/nixpkgs/commit/c2068e0fff4d10a63ea46ee2db5917de8b9f7095) python310Packages.responses: 0.21.0 -> 0.22.0
* [`712c2080`](https://github.com/NixOS/nixpkgs/commit/712c208054ba08387f164e1acf7fd4732b4417b1) cdogs-sdl: 1.3.1 -> 1.4.0
* [`2ee32650`](https://github.com/NixOS/nixpkgs/commit/2ee326500f882cb1373e8d8c99ef0828712148f4) bluez: 5.65 -> 5.66
* [`13c891ef`](https://github.com/NixOS/nixpkgs/commit/13c891efa5309d1555fda72132ab4806609aff17) easyeffects: 6.3.0 -> 7.0.0
* [`35c91b96`](https://github.com/NixOS/nixpkgs/commit/35c91b9630e73dc0960d951a9fd998fa04f4832b) php80.packages.php-parallel-lint: Fix build
* [`a09bb2d5`](https://github.com/NixOS/nixpkgs/commit/a09bb2d5e50093c7f9db03bac558053db6807596) headlines: init at 0.7.2
* [`39b6dc8a`](https://github.com/NixOS/nixpkgs/commit/39b6dc8a293e3980e6a10000d9f99e1512cb4e72) maintainers: add henkery
* [`35b6a772`](https://github.com/NixOS/nixpkgs/commit/35b6a7722d348690490a2d207fd4597da3468f3b) code-server: 4.0.1 -> 4.8.3
* [`df0200d5`](https://github.com/NixOS/nixpkgs/commit/df0200d5fb91a3f08e33d336b77b0cfa60574047) libpwquality: 1.4.4 -> 1.4.5
* [`d215aedb`](https://github.com/NixOS/nixpkgs/commit/d215aedb48e3ede553f60f098c0a44114687949c) ntfy-sh: 1.28.0 -> 1.29.1
* [`277dab89`](https://github.com/NixOS/nixpkgs/commit/277dab8929e45ffc8b2921a043f50465293477c4) pineapple-pictures: 0.6.4 -> 0.6.5
* [`7dc198a8`](https://github.com/NixOS/nixpkgs/commit/7dc198a889cd79c9b274aabfb3cb76f01ab2bfed) pythonPackages.executing: 0.8.2 -> 1.2.0
* [`c38900f5`](https://github.com/NixOS/nixpkgs/commit/c38900f57f7a76526ab88b4fc52eebca3536d357) Add dependency on `rich`
* [`a19c5eab`](https://github.com/NixOS/nixpkgs/commit/a19c5eab67f981ee3b0d1c06590aeb0fc997eaf4) Upgrade to pyproject
* [`4fc97dce`](https://github.com/NixOS/nixpkgs/commit/4fc97dce3cfe544151c49e072180863d586084d4) python310Packages.cffi: patch closures to work on M1 machines
* [`607fe05e`](https://github.com/NixOS/nixpkgs/commit/607fe05ebb2c40d53f2456c26ee593b4dfaefcec) ell: 0.53 -> 0.54
* [`1c81d6c3`](https://github.com/NixOS/nixpkgs/commit/1c81d6c33aed674aebdeb8e16312e64b01e0a765) discord: add libglvnd and fix electron flags
* [`f4c278ca`](https://github.com/NixOS/nixpkgs/commit/f4c278ca0e7969356df58d84a949f78dbe84c505) jekyll-favicon: Add to full Jekyll setup
* [`6165976b`](https://github.com/NixOS/nixpkgs/commit/6165976b7d94161eac338816a7cf9e554251bfe9) meson: 0.63.1 -> 0.64.1
* [`68b44c86`](https://github.com/NixOS/nixpkgs/commit/68b44c86c202e2e7c88573da9832fa981167db7d) glibc: bump the minimum kernel version
* [`443798ec`](https://github.com/NixOS/nixpkgs/commit/443798ece0b6f14af7dbedf49f19119af3a7063d) prometheus-modemmanager-exporter: 0.1.0 -> 0.2.0
* [`742d9d0f`](https://github.com/NixOS/nixpkgs/commit/742d9d0fd80200b80bbf6842aa817b329f44d62e) gradle: 7.5 -> 7.6, 6.9.2 -> 6.9.3
* [`412e0fce`](https://github.com/NixOS/nixpkgs/commit/412e0fce5e2cc5d7d5ad771b67ea8a96f3e3b8ff) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.5.0 -> 1.6.1
* [`fbe88168`](https://github.com/NixOS/nixpkgs/commit/fbe881688593179cd89eaa3dd4e519807bc2bf34) hwdata: 0.363 -> 0.364
* [`02590ae0`](https://github.com/NixOS/nixpkgs/commit/02590ae0639f8f7f17ef2812d191f4b29fb77e87) thumbdrives: init at 0.3.1
* [`8a892ef8`](https://github.com/NixOS/nixpkgs/commit/8a892ef88376036225c910276712536ce9139bd1) minetest: put the app in $out/Applications/ to let it appear in /Applications/
* [`cd3cadc0`](https://github.com/NixOS/nixpkgs/commit/cd3cadc00a2bad1a6b614ffa85ac75251d65e003) xz: 5.2.7 -> 5.2.8
* [`cd726c9a`](https://github.com/NixOS/nixpkgs/commit/cd726c9a915c16b2d616a60f79eb77d126aa0ada) python311Packages.cchardet: fix for python 3.11
* [`e4a160eb`](https://github.com/NixOS/nixpkgs/commit/e4a160eb7f1910695779e31577ea9d29c54a6339) perlPackages.IOSocketINET6: rename to match expected name from upstream name
* [`58be1bf4`](https://github.com/NixOS/nixpkgs/commit/58be1bf4577132ef8dcbf1efa6427a0679b9b634) ddclient: 3.9.1 -> 3.10.0
* [`8cef4f30`](https://github.com/NixOS/nixpkgs/commit/8cef4f301163223f0712546c137ed1dccfc8d498) Revert "Revert "python310Packages.h11: 0.13.0 -> 0.14.0""
* [`30eeef2e`](https://github.com/NixOS/nixpkgs/commit/30eeef2e792e7287727f9cc6a66e7bf4b17b287f) python310Packages.h11: add last regression from httpcore and wsproto to passthru.tests
* [`f59a206a`](https://github.com/NixOS/nixpkgs/commit/f59a206a68f393388f8ba1feeae3d00af3f35fda) python310Packages.httpcore: 0.15.0 -> 0.16.2
* [`d32346df`](https://github.com/NixOS/nixpkgs/commit/d32346df9a42870f1e70ab60155b9ab6fbe3c061) emptty: init at 0.9.0
* [`193aa6fa`](https://github.com/NixOS/nixpkgs/commit/193aa6faf4c9f881d58df7baa4447958bf61c4ac) Add declarative role config to postgres.service
* [`7aa96eae`](https://github.com/NixOS/nixpkgs/commit/7aa96eae81e63aa2ddc2f0adb97775e89619ecdd) python310Packages.pycryptodome: 3.15.0 -> 3.16.0
* [`c181a522`](https://github.com/NixOS/nixpkgs/commit/c181a522727e44254c3831d05d77413b65040dd2) python310Packages.pycryptodome-test-vectors: 1.0.8 -> 1.0.10
* [`4e502a1c`](https://github.com/NixOS/nixpkgs/commit/4e502a1c4d207610b0964b92bb41e574ed62e9c9) Update nixos/modules/services/databases/postgresql.nix
* [`425f6107`](https://github.com/NixOS/nixpkgs/commit/425f61070ad33d4867ce671ea444db2bf678d765) intel-graphics-compiler: 1.0.11061 -> 1.0.12812.4, adopt
* [`2669b04d`](https://github.com/NixOS/nixpkgs/commit/2669b04d02b04dfb2e6fa18277b45b14cea23500) spirv-llvm-translator: update llvm 11 variant to recommend version from intel-graphic-compiler version 1.0.12260.1, reduce platform to unix
* [`25896f50`](https://github.com/NixOS/nixpkgs/commit/25896f50fd028fc1b88c4ffe0d22191e3077e462) opencl-clang: simplify, cleanup, adopt
* [`7bf27e56`](https://github.com/NixOS/nixpkgs/commit/7bf27e562a7847831d45e2f1045b6d9cc44cd998) python3Packages.rig: drop
* [`df2d130e`](https://github.com/NixOS/nixpkgs/commit/df2d130ee0f9f32ac43a36c40535b731d8b4bf03) python3Packages.dataclasses: drop
* [`380af694`](https://github.com/NixOS/nixpkgs/commit/380af694c2803f7bbdb695651646f2fb15371560) python3Packages.contextvars: drop
* [`8d9ba3f1`](https://github.com/NixOS/nixpkgs/commit/8d9ba3f121793977416e06a90ee95f86cb760e98) python3Packages.mailman-fix: drop isPy36 reference
* [`5143e438`](https://github.com/NixOS/nixpkgs/commit/5143e438e27194d929859d4e248f4dd227f3cd38) python3Packages.clickclick: drop isPy36 reference
* [`b5a4d776`](https://github.com/NixOS/nixpkgs/commit/b5a4d7760ddcf0ea8cf25c0c4fbd067763c15377) cpython: drop leftover 3.5/3.6 logic and patches
* [`b5665050`](https://github.com/NixOS/nixpkgs/commit/b56650507918e7f217060fe7f348770b346f98ca) python3Packages.easysnmp: drop
* [`d6940e54`](https://github.com/NixOS/nixpkgs/commit/d6940e54e9f8aa3fce41ce2fae2cd0d731c57e4d) python3Packages.backports_abc: drop
* [`ec002996`](https://github.com/NixOS/nixpkgs/commit/ec0029965cb9274eb69d5bb1f67a253db48b28d7) python3Packages.backports-datetime-fromisoformat: 1.0.0 -> 2.0.0
* [`f9d1ea26`](https://github.com/NixOS/nixpkgs/commit/f9d1ea261f276f956003cd29d59c7fe3781086c5) python3Packages.backports-entry-points-selectable: 1.1.1 -> 1.2.0
* [`243defc4`](https://github.com/NixOS/nixpkgs/commit/243defc46a1fa7c5e908867b2e2a6638839a8f2e) python3Packages.backports_ssl_match_hostname: drop
* [`df500fa5`](https://github.com/NixOS/nixpkgs/commit/df500fa527cc384f2f1802e700ecee5616e539d8) python3Packages.aiocontextvars: use pytestCheckHook
* [`19e6e26e`](https://github.com/NixOS/nixpkgs/commit/19e6e26e8a43a830e123449f376d1604f163d262) python3Packages.sniffio: Use pytestCheckHook
* [`adae7334`](https://github.com/NixOS/nixpkgs/commit/adae7334e4a639804ae5735ce6e1dee5eae1c951) python312: init at 3.12.0a2
* [`9897662c`](https://github.com/NixOS/nixpkgs/commit/9897662ca42b8b4ea690ff296d0fbae5e371c0f4) python3Packages.pytest-freezegun: don't rely on distutils
* [`41d11e36`](https://github.com/NixOS/nixpkgs/commit/41d11e36244bbd39027095601aaed1e372c4f75c) maestro: 1.11.3 -> 1.15.0
* [`6f6f5f90`](https://github.com/NixOS/nixpkgs/commit/6f6f5f908b5bdf1ecb241dbb677e0658767eab4c) sbcl: 2.2.10 -> 2.2.11
* [`94721904`](https://github.com/NixOS/nixpkgs/commit/9472190421345df29e79b45c55b9bc5abb39f7bb) tzdata: 2022f -> 2022g
* [`4642e8b1`](https://github.com/NixOS/nixpkgs/commit/4642e8b1332c68e97921ffdd775acd052cf30c67) python310Packages.logilab_astng: remove
* [`bc946d95`](https://github.com/NixOS/nixpkgs/commit/bc946d95e2c39e1b6fd5a2d4361d8a1e812c1d87) pkgsMusl.cmocka: fix build on aarch64 ([nixos/nixpkgs⁠#203307](https://togithub.com/nixos/nixpkgs/issues/203307))
* [`74965741`](https://github.com/NixOS/nixpkgs/commit/74965741696bf79fd67501a55b1b60683c2b5d62) llvmPackages_14: Use GCC 11 on aarch64-linux
* [`38c793c1`](https://github.com/NixOS/nixpkgs/commit/38c793c1de415b72ded0798b048fd5c9a713a92a) llvmPackages_14: Add -lgcc to NIX_LDFLAGS to lld, lldb, llvm, compiler-rt and clang
* [`518ef4d8`](https://github.com/NixOS/nixpkgs/commit/518ef4d8d87d763acec0b0c8e4c1bd19ca2f6373) nixos/roon-server: persist installation ID to avoid re-login
* [`3bef3f8c`](https://github.com/NixOS/nixpkgs/commit/3bef3f8c4dfc05dc7efdb0727d4f08fd1b970da5) pkgsCross.mingwW64.windows.mingw_w64: backport parallel build fixes
* [`33448e2d`](https://github.com/NixOS/nixpkgs/commit/33448e2db25955d7a932b430f832103bbaafa380) reuse: 1.0.0 -> 1.1.0
* [`531207e3`](https://github.com/NixOS/nixpkgs/commit/531207e37c87f212d0a669b369bbd495834e7730) reuse: add Luflosi as maintainer
* [`fcd6daef`](https://github.com/NixOS/nixpkgs/commit/fcd6daeffeea3a01fd87a1a98c73dae967a386c2) cups: unpin 2.2.6 on darwin ([nixos/nixpkgs⁠#200206](https://togithub.com/nixos/nixpkgs/issues/200206))
* [`6fc43b51`](https://github.com/NixOS/nixpkgs/commit/6fc43b5182977d995c0be4747c2068aa26b6860a) python{27,310}Packages.ciso8601: remove unittest2, break on Python 2 ([nixos/nixpkgs⁠#203984](https://togithub.com/nixos/nixpkgs/issues/203984))
* [`9240dc4a`](https://github.com/NixOS/nixpkgs/commit/9240dc4a532404c130cb0e3ecdade184f30a8d40) atlassian-jira: 9.2.0 -> 9.4.0
* [`c0ae4817`](https://github.com/NixOS/nixpkgs/commit/c0ae4817572173a4b4c45899d5d6e5a9c7c01d73) linux: enable AMD SME, SEV, SEV-SE, SEV-SNP on x86_64
* [`f7cbf3f7`](https://github.com/NixOS/nixpkgs/commit/f7cbf3f7caf71cbc189f770fea80d7221baa84c7) build-support: Quote expansions inside `${…}`
* [`f6ca99b8`](https://github.com/NixOS/nixpkgs/commit/f6ca99b86d2e75b4fc416f04ad138aef3c747aae) semgrep{,-core}: 0.112.1 -> 1.0.0
* [`b4adc07d`](https://github.com/NixOS/nixpkgs/commit/b4adc07d7dca1f765489be94ee026cac5d0d82d4) firefox-beta-bin-unwrapped: 107.0b9 -> 108.0b9
* [`f4e55630`](https://github.com/NixOS/nixpkgs/commit/f4e55630539a4481ed373bdfcd77d264088ada02) firefox-devedition-bin-unwrapped: 107.0b9 -> 108.0b9
* [`dc05d07a`](https://github.com/NixOS/nixpkgs/commit/dc05d07a6afa70dd6878ebec7509fe58404b0fd5) python310Packages.pyopenssl: unbreak on aarch64-darwin
* [`14662035`](https://github.com/NixOS/nixpkgs/commit/146620355f7861545722b1e6b112f4d1acc6b249) nixosTests.postgresql: Fix attribute name shadowing
* [`32c854e0`](https://github.com/NixOS/nixpkgs/commit/32c854e0e41eddd0758257c6e13ae567bd42204a) libvirt: 8.9.0 -> 8.10.0
* [`ce512b67`](https://github.com/NixOS/nixpkgs/commit/ce512b678cac6d100b48e6dab90cae5626df08d2) x265: disable asm on riscv
* [`72231c91`](https://github.com/NixOS/nixpkgs/commit/72231c917775e59330199b46915d74cb2722e502) cpython: Restore libxcrypt CFLAGS and LIBS in configureFlags
* [`7328b78f`](https://github.com/NixOS/nixpkgs/commit/7328b78fb58b8bb26d29b9421d2fa6b55bcf2199) libhwy: 0.15.0 -> 1.0.2
* [`a31e0568`](https://github.com/NixOS/nixpkgs/commit/a31e0568a71360bf0407585935ebbb5a654227dd) libjxl: 0.6.1 -> 0.7.0
* [`1d0b9702`](https://github.com/NixOS/nixpkgs/commit/1d0b9702fccd3cad33384c73f5dc8a37608c54e1) bintools-wrapper: add dlltool, dllwrap, windmc, and windres
* [`fa9f9f83`](https://github.com/NixOS/nixpkgs/commit/fa9f9f8361dcc87cbc496d76ff0cd6a40083c58f) mesa: Actually build more Vulkan drivers on aarch64-linux
* [`7e0c2c18`](https://github.com/NixOS/nixpkgs/commit/7e0c2c183533c41761811b2fbd17accd061e7ad5) libvirt: add changelog to meta
* [`370593ba`](https://github.com/NixOS/nixpkgs/commit/370593baf8cc557bb2126e8bead1a7ca5b40bd9e) olaris-server: init at 0.4.0
* [`ad35d94e`](https://github.com/NixOS/nixpkgs/commit/ad35d94ecc75db6dccebe18d83cd71a92f3b16cb) xonsh: migrate to /etc/xonsh/xonshrc
* [`6fcc794d`](https://github.com/NixOS/nixpkgs/commit/6fcc794d278e31e8e93a9607e102770520566e01) gv: add explicit libXext build depend
* [`90c066a6`](https://github.com/NixOS/nixpkgs/commit/90c066a6db7cc3e52a9df19fc4308dee6e434928) Xaw3d: use xorg.* packages directly instead of xlibsWrapper indirection
* [`cfe4a8d8`](https://github.com/NixOS/nixpkgs/commit/cfe4a8d8702a18389e95c81d89c15adf87bc1b40) mpfr: apply patch from upstream
* [`4ff395c0`](https://github.com/NixOS/nixpkgs/commit/4ff395c061a479ff8a7d2b1b920e0918f874e2be) xz: 5.2.8 -> 5.2.9
* [`35cff8f5`](https://github.com/NixOS/nixpkgs/commit/35cff8f5b844144fc83f73d4156e0112cf1e97c5) mpfr: revert the `version` change
* [`97e2e764`](https://github.com/NixOS/nixpkgs/commit/97e2e764e699f0bb136a5f7c266eb273ea8fcb54) jobber: init at 1.4.4
* [`8337de24`](https://github.com/NixOS/nixpkgs/commit/8337de24f57e006b2c58a799e02b694fcb3b6f4f) pipewire: 0.3.60 -> 0.3.61
* [`685837d6`](https://github.com/NixOS/nixpkgs/commit/685837d634ce9d1c1be20c8c644fb5654cf9f325) guile-gcrypt: 0.3.0 → 0.4.0
* [`36e072c8`](https://github.com/NixOS/nixpkgs/commit/36e072c88bbe8d92b999fde31e581080229c0b77) python310Packages.skia-pathops: 0.7.2 -> 0.7.4
* [`a77f49d1`](https://github.com/NixOS/nixpkgs/commit/a77f49d19b77fb9ea290c098886d4c823920d960) python310Packages.cryptography: 38.0.3 -> 38.0.4
* [`f9743988`](https://github.com/NixOS/nixpkgs/commit/f9743988adab260740f30950614ef88c3a9d3ef9) linuxPackages.hyperv-daemons: add path conditions for kvp and vss
* [`4a94d777`](https://github.com/NixOS/nixpkgs/commit/4a94d77712e5d0e758e1df019542f97efe2999ae) buildGo{module,package}: do not build with verbose flags
* [`33a5eb7b`](https://github.com/NixOS/nixpkgs/commit/33a5eb7be13f3ef0366be6d1d7435a809c51ade4) rocm-related: 5.3.3 → 5.4.0
* [`ea101189`](https://github.com/NixOS/nixpkgs/commit/ea1011899346928c5882fdb8d6cb1db771dbc1f2) wayland-protocols: 1.30 -> 1.31 ([nixos/nixpkgs⁠#204057](https://togithub.com/nixos/nixpkgs/issues/204057))
* [`0f362f6c`](https://github.com/NixOS/nixpkgs/commit/0f362f6cc05883521cfaa1fda8ca54f40efae692) minecraft-server-hibernation: init at 2.4.10
* [`78746f56`](https://github.com/NixOS/nixpkgs/commit/78746f5621ee65a381b4be1d309c65a79d48c3e6) python310Packages.click-command-tree: init at 1.1.0
* [`6545a924`](https://github.com/NixOS/nixpkgs/commit/6545a9245d94e71e63982c1c2877ec2bae79702d) python310Packages.spsdk: 1.6.3 -> 1.8.0
* [`1c2448d2`](https://github.com/NixOS/nixpkgs/commit/1c2448d27eef9db204497b8e7d8bfb02b79e0ef1) metamorphose2: remove misspelled buildInput attribute
* [`51e6f868`](https://github.com/NixOS/nixpkgs/commit/51e6f868385792422682131427228c74d1757760) remmina: add kwallet plugin support
* [`c571595d`](https://github.com/NixOS/nixpkgs/commit/c571595dca9379edfeb0ad9d1316efce34b86e37) re2: 2022-06-01 -> 2022-12-01
* [`ca445883`](https://github.com/NixOS/nixpkgs/commit/ca4458830d84d9f425ed5e6420bc4695f3de3705) rav1e: 0.5.1 -> 0.6.1
* [`0111e954`](https://github.com/NixOS/nixpkgs/commit/0111e9547e857021a3cdab7ac5ba85707cccd654) nixos/borgbackup: Add option for inhibiting sleep
* [`be874693`](https://github.com/NixOS/nixpkgs/commit/be874693ce486078ab019a6e9221f5cdab67e457) linuxPackages.apfs: add passthru.tests
* [`732b59e3`](https://github.com/NixOS/nixpkgs/commit/732b59e37016f247a62819163b85f120e7c79b11) linuxPackages.apfs: unstable-2022-08-15 -> unstable-2022-10-20
* [`d6e3bd19`](https://github.com/NixOS/nixpkgs/commit/d6e3bd1943332b6db5d45075ccae413de7f14511) networkmanager: 1.40.2 → 1.40.6
* [`26c6895e`](https://github.com/NixOS/nixpkgs/commit/26c6895e1005b3e4f6dfe0d16afbd1f12d0a054c) mobile-broadband-provider-info: 20220725 → 20221107
* [`c4f9092c`](https://github.com/NixOS/nixpkgs/commit/c4f9092cfe802af5bb0748070785a835e1e0ecac) gtk3: 3.24.34 → 3.24.35
* [`87e2db44`](https://github.com/NixOS/nixpkgs/commit/87e2db4486d96d34eeb365ad5ca9f62837842899) tracker: 3.4.1 → 3.4.2
* [`423e7b38`](https://github.com/NixOS/nixpkgs/commit/423e7b38f562a97a7c094fa0abe05f9b1ce2dc6b) pango: 1.50.11 → 1.50.12
* [`2edad4b9`](https://github.com/NixOS/nixpkgs/commit/2edad4b9c2f0e197c0d016566efdcff3f147edea) glib: 2.74.1 → 2.74.3
* [`8d2372e4`](https://github.com/NixOS/nixpkgs/commit/8d2372e44a4d77f6595300d981e7b13ca49f3ea1) spirv-llvm-translator: bump to intel-graphics-compiler recommended version
* [`19b27fb2`](https://github.com/NixOS/nixpkgs/commit/19b27fb2bfe64a9a73c40e0fac2383f87e77bed9) intel-graphics-compiler: 1.0.12260.1 -> 1.0.12504.5
* [`4bdc54de`](https://github.com/NixOS/nixpkgs/commit/4bdc54de0e39ea43932d32e4bae1aea281f8b698) python310Packages.tzdata: 2022.6 -> 2022.7
* [`e2c79b3e`](https://github.com/NixOS/nixpkgs/commit/e2c79b3e4a2d9e9ef4072417be10a8faf888d081) python310Packages.openrazer: 3.3.0 -> 3.5.1
* [`a899f747`](https://github.com/NixOS/nixpkgs/commit/a899f74775f43761f66667cd6658ec150e383ab5) petsc: reenable stackprotector on aarch64-darwin
* [`88c21743`](https://github.com/NixOS/nixpkgs/commit/88c217435303a3375fb5e818bbb36b86f1f8fe54) python310Packages.exceptiongroup: add changelog to meta
* [`9dd5cd84`](https://github.com/NixOS/nixpkgs/commit/9dd5cd844102bd7e826a47fcd565e6671ca93a58) python310Packages.exceptiongroup: 1.0.1 -> 1.0.4
* [`7df3e9ec`](https://github.com/NixOS/nixpkgs/commit/7df3e9ec5b1e10032dbb57d0a455e10e146bfad6) nixos/doc/manual: add chapter on VA-API
* [`ec7567ba`](https://github.com/NixOS/nixpkgs/commit/ec7567ba190d60a090952066bec4d3d53d003380) glibc: 2.35-163 -> 2.35-224
* [`2e785329`](https://github.com/NixOS/nixpkgs/commit/2e7853293da7eb49c8aaa10aa4ba2d8ffa64acac) cacert: Distrust TrustCor root certificates
* [`91dde6fc`](https://github.com/NixOS/nixpkgs/commit/91dde6fc89a9fb2baee53df5a389a92189983f75) python310Packages.numcodecs: remove explicit gcc8
* [`5b349b72`](https://github.com/NixOS/nixpkgs/commit/5b349b72d51af3fa7592b6cfe421d55fa25ad616) go_1_19: 1.19.3 -> 1.19.4
* [`5770a027`](https://github.com/NixOS/nixpkgs/commit/5770a027990d6da936fe0ae577735f9bf446e052) qrencode: move SDL2 to tests to easily disable dependency on xorg
* [`714cd4a0`](https://github.com/NixOS/nixpkgs/commit/714cd4a0a5564fa1b23f71e7da574c28f43ef65f) nixos/no-x-libs: add qrencode
* [`c3552b53`](https://github.com/NixOS/nixpkgs/commit/c3552b534046bdd9b8e333106ea819c153b0a9c8) stochas: 1.3.8 -> 1.3.9
* [`bfbfcb70`](https://github.com/NixOS/nixpkgs/commit/bfbfcb70c4bfc167491b6c3fc989693da4716673) tracker: drop sqlite compat patch
* [`0fe29671`](https://github.com/NixOS/nixpkgs/commit/0fe2967175d0060b8f2fce8eda7c58d566e64fb2) lutris: 0.5.11 -> 0.5.12
* [`c4ae704b`](https://github.com/NixOS/nixpkgs/commit/c4ae704be63c52069e97df7adc8b1183005e16a8) nixos/fwupd: Make daemon.conf structured
* [`48bc7784`](https://github.com/NixOS/nixpkgs/commit/48bc7784ab34a517a597dcbee0dec4d0a23a4a7d) rl-2305: Mention services.fwupd.daemonSettings
* [`1328f79d`](https://github.com/NixOS/nixpkgs/commit/1328f79d819c57eae0b392b6c1860e70cebf28f7) python312: 3.12.0a2 -> 3.12.0a3
* [`0e41778c`](https://github.com/NixOS/nixpkgs/commit/0e41778ce25a585c8dd4247fd363cd9d1644912f) newman: 5.2.2 -> 5.3.2
* [`2fce4883`](https://github.com/NixOS/nixpkgs/commit/2fce48831cbaa39699bb81e1efee772c75dff14e) python39: 3.9.15 -> 3.9.16
* [`e824b21b`](https://github.com/NixOS/nixpkgs/commit/e824b21ba79789daf8cb8bc3e84f42b1f62078fb) python310: 3.10.8 -> 3.10.9
* [`58d1860e`](https://github.com/NixOS/nixpkgs/commit/58d1860ed85e0612a2003c26838166483b456ef5) gnome.five-or-more: add darwin support
* [`b857855b`](https://github.com/NixOS/nixpkgs/commit/b857855b0e24f0128f1d6d8a53849268e76bc736) gnome.four-in-a-row: add darwin support
* [`90602c66`](https://github.com/NixOS/nixpkgs/commit/90602c66e3acba91335ff45d7bda27cf61ad4bee) gnome.gnome-chess: add darwin support
* [`24ae8152`](https://github.com/NixOS/nixpkgs/commit/24ae8152a402e8f1e0dfb984005cbcbf429a6902) gnome.gnome-klotski: add darwin support
* [`da5fa08c`](https://github.com/NixOS/nixpkgs/commit/da5fa08c699aca46e6537da6c72f0006a49c897e) gnome.gnome-mahjongg: add darwin support
* [`8bf5d95e`](https://github.com/NixOS/nixpkgs/commit/8bf5d95eb7fb504ce785c8ead430515137ef0ef7) gnome.gnome-mines: add darwin support
* [`d2e1ec44`](https://github.com/NixOS/nixpkgs/commit/d2e1ec446e0594b927483bdddccf0644c9724f3f) gnome.gnome-robots: add darwin support
* [`eececd00`](https://github.com/NixOS/nixpkgs/commit/eececd0079d9bc8cbeff950b4d21e417d0d929af) qqwing: add darwin support
* [`ce94e877`](https://github.com/NixOS/nixpkgs/commit/ce94e8776893c5818b80059fa84d621717500846) gnome.gnome-sudoku: add darwin support
* [`c44d56a9`](https://github.com/NixOS/nixpkgs/commit/c44d56a93fa31107f3dae2d3c44bf48d99d078c2) gnome.gnome-taquin: add darwin support
* [`436ae017`](https://github.com/NixOS/nixpkgs/commit/436ae01708544d80785246b10f3085ac31b4e611) gnome.gnome-tetravex: add darwin support
* [`9384db3a`](https://github.com/NixOS/nixpkgs/commit/9384db3a7acd6c42911b9bc85dc804cd98e8f2e8) gnome.iagno: add darwin support
* [`09dad325`](https://github.com/NixOS/nixpkgs/commit/09dad325e747a74c2da5699b7796ab670a16eab4) gnome.lightsoff: add darwin support
* [`be153331`](https://github.com/NixOS/nixpkgs/commit/be1533317c8100f6ed7b1c68f257c1f5d9e02ce2) intel-media-driver: 22.6.3 -> 22.6.4
* [`de0f03b5`](https://github.com/NixOS/nixpkgs/commit/de0f03b56d15ac17959bc1ee4cf8496db339cd01) python{27,310}Packages.unittest2: move to python2-modules
* [`73dea7fb`](https://github.com/NixOS/nixpkgs/commit/73dea7fb5646122d8db3357dd03286696bd74c4a) python27Packages.unittest: remove completely
* [`cd11ab58`](https://github.com/NixOS/nixpkgs/commit/cd11ab58c56a56a97ac86394c261a39b9e5c579d) python3Packages.eigenpy: init at 2.8.1
* [`217f72ac`](https://github.com/NixOS/nixpkgs/commit/217f72acc3d3c4e9fb18fba74bb65ba02d8b89ba) pinocchio, python3Packages.pinocchio: init at 2.6.12
* [`2192f88c`](https://github.com/NixOS/nixpkgs/commit/2192f88c20c2b23a6f22de5ba3cc2589554174f5) example-robot-data, python3Packages.example-robot-data: init at 4.0.3
* [`561083d2`](https://github.com/NixOS/nixpkgs/commit/561083d21b8599eb966adc91471892eefde5ef3b) crocoddyl, python3Packages.crocoddyl: init at 1.9.0
* [`fedd4d02`](https://github.com/NixOS/nixpkgs/commit/fedd4d02f5d06d0846c60232ee9fc8bebf846783) pinocchio: fix build on x86_64-darwin
* [`3cf332fd`](https://github.com/NixOS/nixpkgs/commit/3cf332fdb895ca61837a3c9ff1b8aeaf83c09938) vcv-rack: 2.2.0 -> 2.2.1
* [`dc6d81e8`](https://github.com/NixOS/nixpkgs/commit/dc6d81e816845eb74f842aa0df2439ff93a44f68) kakoune-unwrapped: 2021.11.08 -> 2022.10.31
* [`a8352345`](https://github.com/NixOS/nixpkgs/commit/a83523455409340c51e5b4a458651f26230bf3ba) duckdb: 0.6.0 -> 0.6.1
* [`5dffcba8`](https://github.com/NixOS/nixpkgs/commit/5dffcba8fe7bd664d0da16dbe2a155a674ab9088) glibc: revert one patch from those added in parent commit
* [`bd2a5f00`](https://github.com/NixOS/nixpkgs/commit/bd2a5f009a87fcfd33797b31407b4dfe2aee269b) losslesscut-bin: refactor the build expression
* [`f7860c59`](https://github.com/NixOS/nixpkgs/commit/f7860c59a374653b84d8403be06735cd3c6dc5f0) losslesscut-bin: 3.46.2 -> 3.48.2 and add aarch64-darwin support
* [`8d7cc9ca`](https://github.com/NixOS/nixpkgs/commit/8d7cc9cac9ecdf95f554c5ea7ca15118baa06c39) python3Packages.certifi: use system ca-bundle
* [`b40cf0d0`](https://github.com/NixOS/nixpkgs/commit/b40cf0d095cc95c6f4c9ff927f1a869c3548946d) python3Packages.certifi: 2022.09.24 -> 2022.12.07
* [`8456141e`](https://github.com/NixOS/nixpkgs/commit/8456141e25c6b2cc293ed6b147c2a0a2d01c2d0a) python3Packages.requests: rely on patched certifi
* [`3e82f96a`](https://github.com/NixOS/nixpkgs/commit/3e82f96a2e901f0d453c41e1732123e8b795c386) mpdscribble: Support more platforms
* [`2fd67cb3`](https://github.com/NixOS/nixpkgs/commit/2fd67cb36dc6992e1e7871c33ff6cc96636fc201) minecraft-server: 1.19.2 -> 1.19.3
* [`73fddfcc`](https://github.com/NixOS/nixpkgs/commit/73fddfcc38fa5c57f8897b2c7165a818b9bc9dc2) dosbox: fix build on darwin
* [`50e4fd18`](https://github.com/NixOS/nixpkgs/commit/50e4fd186916c1ce02cdfc2a761f7ba08aeb9928) python310Packages.py-vapid: 1.8.2 -> 1.9.0
* [`89f245f0`](https://github.com/NixOS/nixpkgs/commit/89f245f012266326999ecd7000638c8adbd857ba) iwd: 1.30 -> 2.0
* [`942dcd23`](https://github.com/NixOS/nixpkgs/commit/942dcd238b49ecd3020e75d0a193e9eedf45a0ab) nixos/activation/bootspec: init bootspec support (RFC-0125)
* [`83d06ce1`](https://github.com/NixOS/nixpkgs/commit/83d06ce16d3c0f8aa7fec4d6f8cf069c3b16205a) nixos/boot/external: init
* [`6c0e4e89`](https://github.com/NixOS/nixpkgs/commit/6c0e4e892ff70b2875da3fd04e37b7fe3019850d) nixos/activation/bootspec: embed the entire contents of specialisation's bootspecs into the parent
* [`e9c85d6d`](https://github.com/NixOS/nixpkgs/commit/e9c85d6d0f5d76f82d99bfc90f672afefdadc358) nixos/activation/bootspec: embed the document into a bootspec subdir
* [`e69c37ea`](https://github.com/NixOS/nixpkgs/commit/e69c37eae9b4b8fee2dc0397bec57163a732ea10) nixos/activation: don't generate bootspec for containers
* [`ee27291b`](https://github.com/NixOS/nixpkgs/commit/ee27291b34cf97ca195797733045da1a1ad49ddb) nixos/activation/bootspec: fix slurping specialisation bootspecs
* [`9a431a57`](https://github.com/NixOS/nixpkgs/commit/9a431a57b1b0172e86729a2ed56f4c51bc6a8701) nixos/activation/bootspec: add @⁠raitobezarius as a code-owner
* [`348ba1b3`](https://github.com/NixOS/nixpkgs/commit/348ba1b33c039a3524dcda2a874c83fb44680f9c) nixos/activation/bootspec: module-ify
* [`092e6d39`](https://github.com/NixOS/nixpkgs/commit/092e6d39cd50f3282a2694b0a3000bf0d27012fe) nixos/tests/bootspec: init
* [`980f5012`](https://github.com/NixOS/nixpkgs/commit/980f50124f6b0b611c348aaa96292ffca0f25b37) nixos/boot/external: add @⁠raitobezarius as maintainer and allow initrd secrets
* [`9832e3e9`](https://github.com/NixOS/nixpkgs/commit/9832e3e9b9c88384d5c92f33bfd980ac0503e624) nixos/activation/bootspec: remove SB extension example in Cue schema
* [`11dfbee0`](https://github.com/NixOS/nixpkgs/commit/11dfbee0a4a2309515608a890e91d4d1a2a43626) nixos/activation/bootspec: add bootspec chapter in NixOS manual
* [`680369e5`](https://github.com/NixOS/nixpkgs/commit/680369e504e9c241fdbd1d7621a7c3011649edcc) nixos/activation/bootspec: add some comments to explain the delicate manipulations
* [`ad6ea546`](https://github.com/NixOS/nixpkgs/commit/ad6ea546b4da50faff7961c2eb260a68aa1c65f6) nixos/boot/external: DocBook -> Markdown
* [`cc63293b`](https://github.com/NixOS/nixpkgs/commit/cc63293b50cbc33c3e0519690fbaaec1b2434289) nixos/boot/external: fixup typo in generated docs, regenerate docs
* [`97f657c7`](https://github.com/NixOS/nixpkgs/commit/97f657c742a60ff272881528268b1af7b10b6938) nixos/activation/bootspec: DocBook -> Markdown, add description for extensions field
* [`38e50898`](https://github.com/NixOS/nixpkgs/commit/38e50898148a137bfbd97ed9acf52b87af37f19e) nixos/activation/bootspec: drop problematic comment, only generate bootspec when bootspec is enabled
* [`dce9add0`](https://github.com/NixOS/nixpkgs/commit/dce9add02b24d8ee02a2afb79ce972a9ebc0aaa3) nixos/activation/bootspec: refactor the generator script
* [`fc88e4cf`](https://github.com/NixOS/nixpkgs/commit/fc88e4cf7d4e86657042d0da7bf91446d19c8d43) nixos/boot/external: drop duplicated external bootloader documentation
* [`b37cee3d`](https://github.com/NixOS/nixpkgs/commit/b37cee3dba9401b264ee9fd91e9848260503f0ef) bootspec: init at unstable-2022-12-05
* [`5af481f6`](https://github.com/NixOS/nixpkgs/commit/5af481f67f2967bf7db0a05053331c4b9d4906f7) nixos/activation/bootspec: fixup improper $out substitution
* [`6eb04c57`](https://github.com/NixOS/nixpkgs/commit/6eb04c578d69b3d719743ccaa40103fc62ec72ea) nixos/activation/bootspec: bootspec owners also own the cue file
* [`d8f6360c`](https://github.com/NixOS/nixpkgs/commit/d8f6360c160b88fdbf08c1e52ab659af92bbb65f) chromiumBeta: 109.0.5414.25 -> 109.0.5414.36
* [`e5212aaa`](https://github.com/NixOS/nixpkgs/commit/e5212aaa67b7ac0bf70714efbe7309800f565b9b) cacert: 3.83 -> 3.86
* [`c13ed541`](https://github.com/NixOS/nixpkgs/commit/c13ed541dbd016b9132de3ba55f88b5b1b626d3b) nss_latest: 3.85 -> 3.86
* [`78c4cda8`](https://github.com/NixOS/nixpkgs/commit/78c4cda8021203faee0f9748e30496153d8c103f) python310Packages.exceptiongroup: run tests
* [`3cf9d223`](https://github.com/NixOS/nixpkgs/commit/3cf9d223857fd3195b60a9ebb8a1152bebb413bb) unpoller: 2.3.1 -> 2.4.0
* [`a8b96a01`](https://github.com/NixOS/nixpkgs/commit/a8b96a014024e2771e7d578d2b0e6f513a47c3e2) mygui: add darwin support
* [`f4ef149e`](https://github.com/NixOS/nixpkgs/commit/f4ef149e9c529e929c1b039dea0f26ab0c79a823) clash-geoip: 20220912 -> 20221112
* [`b32d7053`](https://github.com/NixOS/nixpkgs/commit/b32d7053fa6155897b4b6aa113c2f96f066114f2) clash-geoip: add update script
* [`5313e0bd`](https://github.com/NixOS/nixpkgs/commit/5313e0bdffbc1553f3f66cc719e47844d19373f1) python3Packages.sphinx: Fix tests after certifi patch
* [`d54ee5ea`](https://github.com/NixOS/nixpkgs/commit/d54ee5eaca0d760c947fb785ff56888f8e46ab68) nextcloud24: 24.0.7 -> 24.0.8
* [`e7ee5bf3`](https://github.com/NixOS/nixpkgs/commit/e7ee5bf36b147900c4ae6dddd9486826a844054e) nextcloud25: 25.0.1 -> 25.0.2
* [`8b9cf3b0`](https://github.com/NixOS/nixpkgs/commit/8b9cf3b0ab48c5944567fc5124f00347434a8425) Revert "python3Packages.sphinx: Fix tests after certifi patch"
* [`35750bad`](https://github.com/NixOS/nixpkgs/commit/35750bad505058f11cffbbba28c6e12491e5da81) python3Packages.certifi: propgate cacert for its setup-hook
* [`56dadda1`](https://github.com/NixOS/nixpkgs/commit/56dadda1413276fa216b51ca7657909aed65b12d) azure-cli: fix eval
* [`2b6bfed7`](https://github.com/NixOS/nixpkgs/commit/2b6bfed79c1082e0ab1aabac258f4785fa6fd659) nixos/lxc-container: undo some of the minimal profile stuff
* [`4165ff32`](https://github.com/NixOS/nixpkgs/commit/4165ff32cfe7071d2a36f3cba0c85dc57d93d7a5) Release notes: fix typo
* [`e4d2c760`](https://github.com/NixOS/nixpkgs/commit/e4d2c760beabe517824c5b881b0dd084bcbe61f9) awscli2: 2.9.4 -> 2.9.6
* [`78965437`](https://github.com/NixOS/nixpkgs/commit/7896543799efb5b8b3fd64cfe79ffa998bbc81b4) exiftool: 12.51 -> 12.52
* [`89b5dddf`](https://github.com/NixOS/nixpkgs/commit/89b5dddf990fd7fe99528a972ff037002e8e3046) nixos/avahi: revert closing firewall port by default
* [`3836639c`](https://github.com/NixOS/nixpkgs/commit/3836639c13c483ec85fedd292d5363401be7266f) avahi: remove not required ? null from inputs
* [`136b81be`](https://github.com/NixOS/nixpkgs/commit/136b81be7d7090c615d28900d08dbab0a935035e) nixos/tests/prometheuts-exporters.unpoller: fix test script
* [`b05e62fc`](https://github.com/NixOS/nixpkgs/commit/b05e62fc64f1cfcd1101365dbc6595cef3432292) python310Packages.cleo: clean up crashtest patch
* [`74c12f3e`](https://github.com/NixOS/nixpkgs/commit/74c12f3e47568076bfe202a81e5574190aafef06) prowlarr: 0.4.9.2083 -> 0.4.10.2111
* [`929ba985`](https://github.com/NixOS/nixpkgs/commit/929ba985be80ebe53096bcffe9de6c71e64ccf1f) discord: 0.0.21 -> 0.0.22
* [`06a53254`](https://github.com/NixOS/nixpkgs/commit/06a53254e220b0291442f98868e28d262754d824) mesa: 22.2.4 -> 22.2.5
* [`ec7af32b`](https://github.com/NixOS/nixpkgs/commit/ec7af32b2f5c114e742aebbd5c56316f4eb51dfb) python310Packages.apycula: 0.4 -> 0.5.1
* [`7561ba59`](https://github.com/NixOS/nixpkgs/commit/7561ba5987b928c47ac2ffee8468e62940881b4f) dateutils: drop a test failing since tzdata-2022g
* [`c492cf49`](https://github.com/NixOS/nixpkgs/commit/c492cf49d1766efbe4eb8a166cf824a9e794f0bb) gajim: 1.5.3 → 1.5.4
* [`820c539e`](https://github.com/NixOS/nixpkgs/commit/820c539e86629a875a56f77200edbc9328718eec) linux_logo: 6.0 -> 6.01
* [`6603ebb0`](https://github.com/NixOS/nixpkgs/commit/6603ebb0e5d59c20a5a179342c050a690623b9a4) groestlcoin: 23.0 -> 24.0.1
* [`c03c334e`](https://github.com/NixOS/nixpkgs/commit/c03c334ee31aeaa700204ff85aa52cba6f4b0fd0) librem: 2.9.0 -> 2.10.0
* [`c5b5dc00`](https://github.com/NixOS/nixpkgs/commit/c5b5dc0074b87098135000aa154a7d8f9e22fec8) python310Packages.pyproject-metadata: add changelog to meta
* [`12afcda3`](https://github.com/NixOS/nixpkgs/commit/12afcda3c0f9d04dbdda5bfda02da28e5404484b) python310Packages.pyproject-metadata: 0.5.0 -> 0.6.1
* [`cb4547a4`](https://github.com/NixOS/nixpkgs/commit/cb4547a433dfb0581c5ab389eedb49618fa902e7) nixos/borgbackup: add option "patterns"
* [`1cda9f6e`](https://github.com/NixOS/nixpkgs/commit/1cda9f6e11111d9d51340a5a57e6021441382e4c) mob: 4.0.0 -> 4.1.1
* [`c1188a55`](https://github.com/NixOS/nixpkgs/commit/c1188a559b143950fd1dc55b22820fffc3013b1d) common-updater-scripts: list-directory-versions: scan for absolute urls too
* [`19e4b53b`](https://github.com/NixOS/nixpkgs/commit/19e4b53b090c7aa150af40232b2c75c80d53a017) common-updater-scripts,directoryListingUpdater: add extraRegex parameter
* [`400ec429`](https://github.com/NixOS/nixpkgs/commit/400ec42904919bfcd19fe86d8f27f99044ec85d1) lbreakouthd: add updateScript
* [`082d60f9`](https://github.com/NixOS/nixpkgs/commit/082d60f9fcd78172c4e4032877af10ce3fccfa9c) ltris: add updateScript
* [`848ec40f`](https://github.com/NixOS/nixpkgs/commit/848ec40f5ccf090e26d32f591d9ec0218c1ead09) lpairs2: add updateScript
* [`9b52b756`](https://github.com/NixOS/nixpkgs/commit/9b52b75600653899d5b08c85bed4d80ae094f0bd) diffoscope: 225 -> 228
* [`2fbf439b`](https://github.com/NixOS/nixpkgs/commit/2fbf439bf21dc35b4d2385f28a7be3cde7b8580d) tsm-client: 8.1.15.1 -> 8.1.17.0
* [`c770b44a`](https://github.com/NixOS/nixpkgs/commit/c770b44aff6e7eb7e19c64e4442fe2332af9d7b4) nixos/cloudflared: init
* [`a4960669`](https://github.com/NixOS/nixpkgs/commit/a49606696e32c106b4a203b95128930f3f65d185) nixos/alertmanager: fix renamed option
* [`72f5af19`](https://github.com/NixOS/nixpkgs/commit/72f5af191f2c799131bfb67398a12301e7663239) fetchGitHub: inherit owner and repo for use with rocmUpdateScript
* [`9b98f843`](https://github.com/NixOS/nixpkgs/commit/9b98f8433af210894f4bd9d6a76a1602fb9419ae) rocm-related: create and use a generic updater script
* [`463ca676`](https://github.com/NixOS/nixpkgs/commit/463ca6768c129e71ba9cb7870dc04bf2683f4df9) miopen: disable fetching KDBs by default
* [`fbb79459`](https://github.com/NixOS/nixpkgs/commit/fbb79459e6f57e8c7e1fe0419e9e90960879c517) composable_kernel: use unstableGitUpdater
* [`89f8ab0e`](https://github.com/NixOS/nixpkgs/commit/89f8ab0e19f8c0a564de62079878acf502e32294) python3Packages.geopandas: 0.12.1 → 0.12.2
* [`64dfa559`](https://github.com/NixOS/nixpkgs/commit/64dfa559041eeac2459fef26d07db6e035c20e4a) python310Packages.aiohttp-openmetrics: init at 0.0.11
* [`d9f5e185`](https://github.com/NixOS/nixpkgs/commit/d9f5e18533809c24846199604faa3feafb43bccd) prometheus-xmpp-alerts: 0.5.3 -> 0.5.6
* [`7776739d`](https://github.com/NixOS/nixpkgs/commit/7776739d6590219ff39f9145c59f674105506420) python310Packages.geopandas: add changelog to meta
* [`90e3db28`](https://github.com/NixOS/nixpkgs/commit/90e3db28758406b25ea941bc971a3e1ae5a294ab) composable_kernel: unstable-2022-11-19 → unstable-2022-12-08
* [`75d7299d`](https://github.com/NixOS/nixpkgs/commit/75d7299df1438a2f96fa6f47ef454a2cb41e6be3) Revert "rocm-llvm: enable clang-tools-extra for clang-tidy"
* [`1806785b`](https://github.com/NixOS/nixpkgs/commit/1806785beb2a1c4b84259d1688d04c1b33410852) python310Packages.todoist: add pythonImportsCheck
* [`657a5766`](https://github.com/NixOS/nixpkgs/commit/657a5766d24438c185b6e1a8ab4ee2796459de84) qgis-ltr: 3.22.10 -> 3.22.13
* [`bceabe0c`](https://github.com/NixOS/nixpkgs/commit/bceabe0ca9eee6a461168b0d409683bfc69310b2) amberol: 0.9.1 -> 0.9.2
* [`a73d7d35`](https://github.com/NixOS/nixpkgs/commit/a73d7d35fca41241ebe10b8fb396e65603a16935) rtsp-simple-server: 0.20.2 -> 0.20.3
* [`529a6969`](https://github.com/NixOS/nixpkgs/commit/529a6969ac7390a275ddfeb8b18e3b231c44ef4c) s2n-tls: 1.3.29 -> 1.3.30
* [`9ade6f00`](https://github.com/NixOS/nixpkgs/commit/9ade6f0054bf8dfcf3f89f05531d91c667e54969) snappymail: 2.22.6 -> 2.23.0
* [`1307b902`](https://github.com/NixOS/nixpkgs/commit/1307b9020b9a23779dc9409d3fbb7f5ebf149912) python310Packages.appthreat-vulnerability-db: 4.1.6 -> 4.1.7
* [`0e88ae20`](https://github.com/NixOS/nixpkgs/commit/0e88ae207e53d73fb89dd919997ff62f31e1bf69) python310Packages.appthreat-vulnerability-db: 4.1.7 -> 4.1.8
* [`f6f0d0c1`](https://github.com/NixOS/nixpkgs/commit/f6f0d0c184c642e2305854c3bff0bc61465b5f31) python310Packages.life360: 5.4.0 -> 5.4.1
* [`464e17c1`](https://github.com/NixOS/nixpkgs/commit/464e17c11cacc6e2d68b26d24fa442ed4c208197) python310Packages.todoist-api-python: init at 2.0.2
* [`526c70d7`](https://github.com/NixOS/nixpkgs/commit/526c70d75f55558ec703d0ea03d71ad87b3dd955) python310Packages.peaqevcore: 9.0.1 -> 9.1.0
* [`56a34c94`](https://github.com/NixOS/nixpkgs/commit/56a34c940ed2e4284ef8653781db7cfbf7fe7def) python310Packages.teslajsonpy: 3.5.0 -> 3.5.1
* [`8dd92828`](https://github.com/NixOS/nixpkgs/commit/8dd928280f516ab1ed883c9b6c68fd0e1a9d9888) python310Packages.pykeyatome: add changelog to meta
* [`b3e7f691`](https://github.com/NixOS/nixpkgs/commit/b3e7f69126bbc9e3255a7e08fd734137b0bcb5ff) python310Packages.pykeyatome: 2.1.0 -> 2.1.1
* [`77e91a3f`](https://github.com/NixOS/nixpkgs/commit/77e91a3f80f3f50ad3d69669108bfa66f62a0481) python310Packages.pyeconet: add changelog to meta
* [`8e7e106f`](https://github.com/NixOS/nixpkgs/commit/8e7e106fac79a55f34b1471fae03dd9b03345821) python310Packages.pyeconet: 0.1.15 -> 0.1.16
* [`77061274`](https://github.com/NixOS/nixpkgs/commit/7706127402d57850ca99b8b70c00404724379c0d) python310Packages.pyeconet: 0.1.16 -> 0.1.17
* [`53f8736f`](https://github.com/NixOS/nixpkgs/commit/53f8736f10065812b0b38fcb2f1de3b5a7e0ea03) root: adjust format
* [`35519155`](https://github.com/NixOS/nixpkgs/commit/35519155de7fd95957db20b973c96fe735f8b521) snappymail: add changelog to meta
* [`83b917a9`](https://github.com/NixOS/nixpkgs/commit/83b917a960d1d637f0ad36ab709adba4dd69f8f8) nixos/manpages: Explain -I option and how to build manpages
* [`f2fcf446`](https://github.com/NixOS/nixpkgs/commit/f2fcf446d0c5715358749a3e8df723b026ba118b) root: add xrootd support and workaround the xrootd runpath bug
* [`e23f5f4f`](https://github.com/NixOS/nixpkgs/commit/e23f5f4f92948f35ba2c355654bd1ce3684b9450) root: 6.26.8 -> 6.26.10
* [`682eac0d`](https://github.com/NixOS/nixpkgs/commit/682eac0d2222909f5b8914e5d66d145d1d67783d) hepmc3: adjust format
* [`92f67f68`](https://github.com/NixOS/nixpkgs/commit/92f67f68b380ca7e7a94a9fccf641441e7ab35de) python3Packages.certifi: Ignore /no-cert-file.crt in NIX_SSL_CERT_FILE
* [`6b57fa7d`](https://github.com/NixOS/nixpkgs/commit/6b57fa7d400ba65e9e22e570de2f8f2a9f4b8c6d) tlsx: 0.0.9 -> 1.0.0
* [`a4985920`](https://github.com/NixOS/nixpkgs/commit/a4985920649696e26e6936a987cf5898a1679b13) cyclonedx-gomod: init at 1.3.0
* [`600bec87`](https://github.com/NixOS/nixpkgs/commit/600bec87813ed7cd0149799f2dd50c4f4eadd911) python310Packages.aranet4: init at 2.1.2
* [`fc4f3845`](https://github.com/NixOS/nixpkgs/commit/fc4f384532e3bcc8e119ffbc97d788386f65cc3e) home-assistant: update component-packages
* [`bcd290f4`](https://github.com/NixOS/nixpkgs/commit/bcd290f427a28b7ff3a2405d83967d1894e83205) python310Packages.aiolivisi: init at 0.0.14
* [`1a1f3523`](https://github.com/NixOS/nixpkgs/commit/1a1f352310fc6058b2061ae7aece6949edeb1ed7) home-assistant: update component-packages
* [`eee8cd06`](https://github.com/NixOS/nixpkgs/commit/eee8cd063f23d2946e6b61b4a6f03aa1c0a3ee2c) hysteria: 1.3.1 -> 1.3.2
* [`c0c48fe6`](https://github.com/NixOS/nixpkgs/commit/c0c48fe6ae178e6c125cd678f0b3af62aff00a1f) python310Packages.google-cloud-bigtable: 2.14.0 -> 2.14.1
* [`cea45d38`](https://github.com/NixOS/nixpkgs/commit/cea45d387a03c0448dcc69fd1847bb4a40c14730) python3Packages.ical: drop a test failing since tzdata-2022g
* [`7daf8fba`](https://github.com/NixOS/nixpkgs/commit/7daf8fbabc82dcb272a757f9e9ae71fc05c1bb21) python310Packages.aranet4: 2.1.2 -> 2.1.3
* [`7b6987ea`](https://github.com/NixOS/nixpkgs/commit/7b6987ea4e040338c7bb83eb89c0c9a2d176b698) hugin: use glew-egl to fix startup crash
* [`1dd03283`](https://github.com/NixOS/nixpkgs/commit/1dd0328344af0fe49fd06d39dd9fa5fcebbefd7a) appflowy: 0.0.8 -> 0.0.8.1
* [`b09e866b`](https://github.com/NixOS/nixpkgs/commit/b09e866b851d1cf76080c6991fa011357fd54f22) miniupnpc: install binaries and manpages
* [`1d3a9a96`](https://github.com/NixOS/nixpkgs/commit/1d3a9a9601021f1a81a6d22f3dd83c3e47b70f30) invidious: fix build on aarch64-darwin
* [`632eb143`](https://github.com/NixOS/nixpkgs/commit/632eb1438177eb1a8847566b0d9ebc2faa942dd6) v2ray-geoip: 202212010055 -> 202212080044
* [`178bae00`](https://github.com/NixOS/nixpkgs/commit/178bae00c015566fb7f7da1b5051c5020e23a7de) python310Packages.hydra: 1.2.0 -> 1.3.0
* [`329f50dc`](https://github.com/NixOS/nixpkgs/commit/329f50dc4e911bc048c0be21fc6218694a9cc86c) libnma: bug fix removing path from eap scheme
* [`1f0f9ada`](https://github.com/NixOS/nixpkgs/commit/1f0f9ada8614c59717bf8e9e342c4d1c71df84fe) weka: 3.9.2 -> 3.9.6
* [`a281c4ab`](https://github.com/NixOS/nixpkgs/commit/a281c4ab3ecf703bb2994299075f1ed2844c61d9) bird: 2.0.10 -> 2.0.11
* [`7e6e7b69`](https://github.com/NixOS/nixpkgs/commit/7e6e7b6936ef1b57554064838ba7fc5c8a062314) felix-fm: 2.1.1 -> 2.2.0
* [`7f220a04`](https://github.com/NixOS/nixpkgs/commit/7f220a0422e865735ff9d99cff32775859df23dd) nixos/installer/netboot-minimal: add missing lib
* [`596fbeba`](https://github.com/NixOS/nixpkgs/commit/596fbebaab939de7b499f0cea33809406b142c4b) podman: add mac-helper patch
* [`00c12525`](https://github.com/NixOS/nixpkgs/commit/00c12525ac5047ebbfe9eeb4a3ae3a49d641f4f7) bencode: 0.5.0 -> 1.0.1
* [`83e84a5e`](https://github.com/NixOS/nixpkgs/commit/83e84a5e94c2fdfe5164edb78d168f47dc114f3c) automatic-timezoned: 1.0.49 -> 1.0.50
* [`62e87cba`](https://github.com/NixOS/nixpkgs/commit/62e87cbada15fbb45f579c0b977ef8834212f3cd) aws-nuke: 2.20.0 -> 2.21.2
* [`a05192a4`](https://github.com/NixOS/nixpkgs/commit/a05192a4769ea3292ba2364be389c68239493731) ruff: 0.0.176 -> 0.0.177
* [`89aab97e`](https://github.com/NixOS/nixpkgs/commit/89aab97e63fe80d8598c9e38043450323795818b) asusctl: 4.5.5 -> 4.5.6
* [`4fbc7a37`](https://github.com/NixOS/nixpkgs/commit/4fbc7a3783e0941593af26e39b75e05299bf75d3) phrase-cli: 2.6.0 -> 2.6.1
* [`49cfc00f`](https://github.com/NixOS/nixpkgs/commit/49cfc00fc35e31ae0c682a92d96a61cc95e7dd99) python310Packages.foolscap: fix tests with Twisted 22.10.0
* [`2542e776`](https://github.com/NixOS/nixpkgs/commit/2542e7765bea53d697d08730fb9ce21271b6a33f) clj-kondo: 2022.12.08 -> 2022.12.10
* [`ffca9ffa`](https://github.com/NixOS/nixpkgs/commit/ffca9ffaaafb38c8979068cee98b2644bd3f14cb) ocamlPackages.uecc: 0.3 → 0.4
* [`b980f12b`](https://github.com/NixOS/nixpkgs/commit/b980f12b66e427befb784123e4512ea09535e1cb) knot-dns: 3.2.3 -> 3.2.4
* [`bd35bc1f`](https://github.com/NixOS/nixpkgs/commit/bd35bc1f873a09f0b8c7fbf1a3860a9debe45a05) signal-desktop-beta: reinit at 6.1.0-beta.1
* [`609ef3f7`](https://github.com/NixOS/nixpkgs/commit/609ef3f74ebf5c91162948d771ac32f80c77c7db) linux: add 6.1
* [`bdca4eb8`](https://github.com/NixOS/nixpkgs/commit/bdca4eb87ed855a6629a9ed4bcec7a5290d1d013) wtwitch: init at 2.6.0
* [`ea26cd3f`](https://github.com/NixOS/nixpkgs/commit/ea26cd3f0d27ef740f59671e1ea39d6dd1dc9b93) code-generator: init at 0.25.4
* [`d2e71071`](https://github.com/NixOS/nixpkgs/commit/d2e710716a75a4e48ab86333f2c1766b07421c86) kubernetes-controller-tools: set version
* [`8782ccac`](https://github.com/NixOS/nixpkgs/commit/8782ccac95b375dae4d38132065edbfe21be5a00) shfmt: 3.5.1 -> 3.6.0
* [`0fecf164`](https://github.com/NixOS/nixpkgs/commit/0fecf164a2a7d7ab51eb1ecfe0d4fc4d5f80011c) sbcl_*: fix build by adding a #define
* [`eaa43948`](https://github.com/NixOS/nixpkgs/commit/eaa4394823006000c135e89664be72df59e00271) flexget: 3.5.9 -> 3.5.10
* [`94166d15`](https://github.com/NixOS/nixpkgs/commit/94166d15c1604484506b55c1cf84225df5dab7b1) flexget: add changelog to meta
* [`7765d08b`](https://github.com/NixOS/nixpkgs/commit/7765d08b5206c481a56ceb9bedff60154b7ad4d8) amass: 3.21.1 -> 3.21.2
* [`c70263ec`](https://github.com/NixOS/nixpkgs/commit/c70263ec3ce2679c92bdc3661833c6929371f06d) python310Packages.aioqsw: add changelog to meta
* [`c3b18f64`](https://github.com/NixOS/nixpkgs/commit/c3b18f64e6494c57aaa767e6a1768646e68fd2b2) python310Packages.aioqsw: 0.2.2 -> 0.3.1
* [`2c4de226`](https://github.com/NixOS/nixpkgs/commit/2c4de226587fed1ec7d1a8def3b0ac8ca542f21d) python310Packages.appthreat-vulnerability-db: 4.1.8 -> 4.1.11
* [`1d17ca13`](https://github.com/NixOS/nixpkgs/commit/1d17ca131e7a769112cb57184e7dc17a4bba9bb5) python310Packages.pyvicare: 2.20.0 -> 2.21.0
* [`373f74f9`](https://github.com/NixOS/nixpkgs/commit/373f74f918419981b37d225baa9f05c8d7c79fc0) python310Packages.lupupy: 0.2.1 -> 0.2.3
* [`8e832b78`](https://github.com/NixOS/nixpkgs/commit/8e832b78fdb99c22e254a001028f84a5cb1a81ee) element-{web,desktop}: 1.11.15 -> 1.11.16
* [`233eac77`](https://github.com/NixOS/nixpkgs/commit/233eac778b28fa37aef2376c04ed0f6e0bdc0088) python310Packages.hahomematic: 2022.12.1 -> 2022.12.2
* [`132ac650`](https://github.com/NixOS/nixpkgs/commit/132ac650012fe7062cad1f8db67ddf577a0571e6) wiki-js: 2.5.292 -> 2.5.294
* [`be0e7994`](https://github.com/NixOS/nixpkgs/commit/be0e799467058b4ed1e729cb79af320b2b9efb4c) pdal: 2.4.0 -> 2.4.3
* [`170b2221`](https://github.com/NixOS/nixpkgs/commit/170b2221a4da46837201d26dd30e3e6ed38ac805) python310Packages.griffe: 0.24.1 -> 0.25.0
* [`25511005`](https://github.com/NixOS/nixpkgs/commit/25511005d353b23c5e09fffdbef3d997264193c7) python310Packages.yalexs-ble: 1.10.3 -> 1.11.0
* [`b0e0d0ce`](https://github.com/NixOS/nixpkgs/commit/b0e0d0ce7799e978ee6bb534938dea04dcab2cd3) python310Packages.yalexs-ble: 1.11.0 -> 1.11.1
* [`3082a900`](https://github.com/NixOS/nixpkgs/commit/3082a90095f9cd3ecf26dc142e4b48d927fcb9fd) python310Packages.yalexs-ble: 1.11.1 -> 1.11.2
* [`082372df`](https://github.com/NixOS/nixpkgs/commit/082372df5a5c8a0d08c9cad6eab32f6401404e56) python310Packages.yalexs-ble: 1.11.2 -> 1.11.3
* [`ee0d2e1f`](https://github.com/NixOS/nixpkgs/commit/ee0d2e1f7c72edc888e4d51c75d955a4a85c97f9) python310Packages.yalexs-ble: 1.11.3 -> 1.11.4
* [`f6919f62`](https://github.com/NixOS/nixpkgs/commit/f6919f6299a2f924dec1772d67c8c062b60e912e) fcitx5: remove global with
* [`095d61f3`](https://github.com/NixOS/nixpkgs/commit/095d61f3e96f95a1e330a7c0c4d458839b56b0b4) openasar: unstable-2022-12-01 -> unstable-2022-12-11
* [`f4793e27`](https://github.com/NixOS/nixpkgs/commit/f4793e27c55360b4eec6bffd915af53bdbd78524) appthreat-depscan: 3.2.7 -> 3.3.0
* [`d7c4e4ff`](https://github.com/NixOS/nixpkgs/commit/d7c4e4ff63f9f3ee7587d828d50b38d6ce4e639b) zsh-forgit: 22.11.0 -> 22.12.0
* [`c2366647`](https://github.com/NixOS/nixpkgs/commit/c23666473c8bf88a46ea24444a6c40a5dacb16bd) doc: Remove all section numbers
* [`28a54761`](https://github.com/NixOS/nixpkgs/commit/28a5476184f8f8a78b7414a9a1bc482ccc7b5b36) treewide: remove e-user from maintainers
* [`0c293b2d`](https://github.com/NixOS/nixpkgs/commit/0c293b2dd7fc3a5458edb2a6d181a56e38c8f642) aegisub: incorporate darwin into its expression
* [`e88150fa`](https://github.com/NixOS/nixpkgs/commit/e88150faaa3afc1b948300b9f2197b1fe7520439) ftgl: incorporate darwin into its expression
* [`d8e45aef`](https://github.com/NixOS/nixpkgs/commit/d8e45aef2aa4b9217ead6dcdb9b67bbf76373f44) plan9port: incorporate darwin into its expression
* [`c3db1f27`](https://github.com/NixOS/nixpkgs/commit/c3db1f27518009a750ff1abbdee8f4065ffc5cf7) circup: 1.1.3 -> 1.1.4
* [`0cbaaf47`](https://github.com/NixOS/nixpkgs/commit/0cbaaf47d5d718be70d40a09b940eb805036a73a) wxSVG: incorporate darwin into its expression
* [`7f00403e`](https://github.com/NixOS/nixpkgs/commit/7f00403e5f6ae1a743d3f7ddc8ed232403dc6407) mpv-unwrapped: incorporate darwin into its expression
* [`d9411df6`](https://github.com/NixOS/nixpkgs/commit/d9411df65bea20d202be54a78543c4f868c500ea) soundOfSorting: incorporate darwin into its expression
* [`ebb5623e`](https://github.com/NixOS/nixpkgs/commit/ebb5623e04adcac6ea289baff97bc77b56b6b6f0) clojure: 1.11.1.1200 -> 1.11.1.1208
* [`11061c6d`](https://github.com/NixOS/nixpkgs/commit/11061c6ddf20e54ce3d51eca5291367f0a2297a0) plantuml-server: 1.2022.13 -> 1.2022.14
* [`101c6852`](https://github.com/NixOS/nixpkgs/commit/101c685296f97d6c19df6be36ab5b9cc4bee0cd9) autosuspend: 4.2.0 -> 4.3.0
* [`9ee1d16c`](https://github.com/NixOS/nixpkgs/commit/9ee1d16c36b8bdca9fa5ac3a0d701a8c6d1f9dc3) python310: revert asyncio changes done in 3.10.9
* [`68c2954e`](https://github.com/NixOS/nixpkgs/commit/68c2954ea5644f2924c523b9d9b4c6f8d543e846) bitcoin: 24.0 -> 24.0.1
* [`709a8136`](https://github.com/NixOS/nixpkgs/commit/709a81362c77b9e09718a962084b8ca0a53dc569) xonsh: 0.13.3 -> 0.13.4
* [`1a5af953`](https://github.com/NixOS/nixpkgs/commit/1a5af953677c61b4724b2d3843f4650c00688fd8) python311: revert asyncio changes done in 3.11.1
* [`578bd38b`](https://github.com/NixOS/nixpkgs/commit/578bd38b65db7c2f92a04066134134ff1bfbc9ae) rambox: 0.7.9 -> 2.0.9
* [`0927d7e8`](https://github.com/NixOS/nixpkgs/commit/0927d7e8893670960a1922ee35e1d2c3e473cf6d) lib2geom: fix tests on i686
* [`d6f4f458`](https://github.com/NixOS/nixpkgs/commit/d6f4f4584ae5f04c4f5caf7574106025b34ab883) nixos/botamusique: allow syscalls in the @⁠resources group
* [`729486a6`](https://github.com/NixOS/nixpkgs/commit/729486a6670feeb91c4305f0090e1a03cd28ca96) wine, winetricks: add updateScript
* [`89df194c`](https://github.com/NixOS/nixpkgs/commit/89df194cbf0f38123bce7f913f1efde54c233568) toml11: init at 3.7.1
* [`179e20b4`](https://github.com/NixOS/nixpkgs/commit/179e20b4922a156042f17442fb91054c1d610c6f) libverto: init at 0.3.2
* [`6b27ccc1`](https://github.com/NixOS/nixpkgs/commit/6b27ccc1fb7f39321fec23680e6394938e523e9d) sysdig: 0.29.3 -> 0.30.2
* [`2c840708`](https://github.com/NixOS/nixpkgs/commit/2c8407089b399e0796678d440289eee829298f42) sgx-sdk: pin to openssl_1_1
* [`c0a50076`](https://github.com/NixOS/nixpkgs/commit/c0a50076f29e5023358a12e5f1067e034644e7e9) changie: 1.10.0 -> 1.10.1
* [`0a8826e7`](https://github.com/NixOS/nixpkgs/commit/0a8826e7582cf357c1248e10653fd946e6570f99) clightning: 22.11 -> 22.11.1
* [`c9563115`](https://github.com/NixOS/nixpkgs/commit/c9563115f333a88a0898449621e7e5c4d26ee6fe) nuclei: 2.8.2 -> 2.8.3
* [`659eadaf`](https://github.com/NixOS/nixpkgs/commit/659eadaf12fe7be4e13999f853260a571a169468) jackett: 0.20.2352 -> 0.20.2365
* [`ea588cd3`](https://github.com/NixOS/nixpkgs/commit/ea588cd3640f4de19f840dd9933174a017612151) kodiPackages.youtube: 6.8.22+matrix.1 -> 6.8.23+matrix.1
* [`85f91f3f`](https://github.com/NixOS/nixpkgs/commit/85f91f3f47229eb0a3cdbee1f97abe3a390d0469) firefox*: 107.0.1 -> 108.0
* [`18289a67`](https://github.com/NixOS/nixpkgs/commit/18289a67b03f02876065a06f34c3acd52be25127) khard: 0.17.0->0.18.0
* [`33881cc5`](https://github.com/NixOS/nixpkgs/commit/33881cc55864ebfa5c0bcb21d2ebf30338000de3) khard: Add passthru.tests.version
* [`105607e1`](https://github.com/NixOS/nixpkgs/commit/105607e11799140c8883b1b889e34ce4f6ec9194) delve: 1.20.0 -> 1.20.1
* [`c53f7181`](https://github.com/NixOS/nixpkgs/commit/c53f71817bd738d62add4359c0411bcfbd56f09b) cargo-modules: 0.7.0 -> 0.7.1
* [`f5d555c2`](https://github.com/NixOS/nixpkgs/commit/f5d555c28ea5ba734604dd14433e556f77370eac) teams: add figsoda to the vim team and codeowners
* [`ae339869`](https://github.com/NixOS/nixpkgs/commit/ae339869beaf30072fe68e47049e3b4920b93ad1) delve: set meta.mainProgram
* [`568e01e6`](https://github.com/NixOS/nixpkgs/commit/568e01e675d136c05c31bda743dcf64d849d63d3) cmake: incorporate darwin and libsForQt5 into its expression
* [`0348abd7`](https://github.com/NixOS/nixpkgs/commit/0348abd7fc538b3c6be4889c68a102d889416a8a) cpm-cmake: use github source
* [`495b7190`](https://github.com/NixOS/nixpkgs/commit/495b71906c2b63e90ef7dbed334222c00c82738d) docs: added missing semicolon in example
* [`547c3341`](https://github.com/NixOS/nixpkgs/commit/547c334142c7283cde59385d0e7f00817ba8c634) nerdctl: 1.0.0 -> 1.1.0
* [`7db82980`](https://github.com/NixOS/nixpkgs/commit/7db82980f1ed7fcbf324a72376a5ffd94b1691df) purescript: 0.15.6 -> 0.15.7
* [`5766b2b5`](https://github.com/NixOS/nixpkgs/commit/5766b2b5e2fea889f9ad8e8b1afeff06103dabd9) newsflash: 2.2.2 -> 2.2.3
* [`d25c7aa2`](https://github.com/NixOS/nixpkgs/commit/d25c7aa2f08b1e7f1efa59086906c54a2f3bfdab) python310Packages.PyChromecast: 13.0.2 -> 13.0.3
* [`c04f46c9`](https://github.com/NixOS/nixpkgs/commit/c04f46c96397eab978c1d20ad6901c3f6a3a862b) zmusic: init at 1.1.11
* [`3f275272`](https://github.com/NixOS/nixpkgs/commit/3f2752723f642c3a2cade8e26c0a9f5e32b5e221) gzdoom: 4.8.2 -> 4.10.0
* [`845ac5dc`](https://github.com/NixOS/nixpkgs/commit/845ac5dc21634595f65a624e883e2b5cf14ac900) docs: generate docs
* [`cd44ef37`](https://github.com/NixOS/nixpkgs/commit/cd44ef375fefe8a99e6edb1705464394bc8dcca0) vimPlugins: update
* [`ee017f0c`](https://github.com/NixOS/nixpkgs/commit/ee017f0c68e4e593e3e37b1ca6a5952db08a886d) vimPlugins.lspsaga-nvim-original: init at 2022-12-12
* [`ac962507`](https://github.com/NixOS/nixpkgs/commit/ac96250768795ae53aa14067e2ceb4306e7c658d) vimPlugins.winbar-nvim: init at 2022-07-18
* [`ea69f1a8`](https://github.com/NixOS/nixpkgs/commit/ea69f1a8b8fe2b7b6a7de01a01d74d5a248d6f55) jd-gui: patch to work with Gradle 6
* [`096991f2`](https://github.com/NixOS/nixpkgs/commit/096991f29fcb644903731b629ada89e0d1e35591) unpoller: 2.4.0 -> 2.4.1
* [`20206a44`](https://github.com/NixOS/nixpkgs/commit/20206a44e1b4acd2e658fbb868122596c7ac1f0f) ltris: 1.2.5 -> 1.2.6
* [`f19799de`](https://github.com/NixOS/nixpkgs/commit/f19799deb98372856a9473a2859db82d86ca2061) lbreakouthd: 1.0.10 -> 1.1
* [`cc74858a`](https://github.com/NixOS/nixpkgs/commit/cc74858a5aa674aa0a36fef2575447cb0cab1009) impy: 0.1 -> 0.2
* [`32e71f7f`](https://github.com/NixOS/nixpkgs/commit/32e71f7f2ab029132d528ec56d9ed00696e3733d) sic-image-cli: 0.20.0 -> 0.20.1
* [`ea393e26`](https://github.com/NixOS/nixpkgs/commit/ea393e2697944ca3306d2c359e12338f575b9cf0) cirrus-cli: 0.92.0 -> 0.92.1
* [`fe7d02b5`](https://github.com/NixOS/nixpkgs/commit/fe7d02b5f09ecc421b04d68e57b13038e3ec7875) git-team: 1.8.0 -> 1.8.1
* [`51ce0ddd`](https://github.com/NixOS/nixpkgs/commit/51ce0ddd48aa653583ad8c15ce6a61f70ab69a15) vimPlugins.vim-teal: init at 2021-01-05
* [`72bb5fec`](https://github.com/NixOS/nixpkgs/commit/72bb5fec7484b20aaa4787dbea794ca22f2586ad) fd: skip flaky test, add figsoda as a maintainer
* [`8514b2d6`](https://github.com/NixOS/nixpkgs/commit/8514b2d62a593a9539fcb7a63c346500711b61d5) python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12
* [`f5c7a97d`](https://github.com/NixOS/nixpkgs/commit/f5c7a97d534a6cd0a5774e9f3a5fd045f998374d) cbqn: remove unnecessary darwin build flag
* [`24fdc402`](https://github.com/NixOS/nixpkgs/commit/24fdc402751a61fcde65230e6fe2469a9673efa1) vimPlugins.skim-vim: fix dependencies
* [`b20aa7ff`](https://github.com/NixOS/nixpkgs/commit/b20aa7ffb85b7ca71d50061acdab5ffe86156136) vimPlugins.forms: remove unused with
* [`6450cba8`](https://github.com/NixOS/nixpkgs/commit/6450cba8b68f14dbd63dbf8319de779f1d2bce6a) xgboost: adding self to maintainers list
* [`1d0b181e`](https://github.com/NixOS/nixpkgs/commit/1d0b181e2fb96136ae8b755114b7f7d1799f44e5) slurp: fix cross compilation after https://github.com/emersion/slurp/commit/e5fe57abcc3a1a9f25c9e488f952ba1900afafe4
* [`4c9a5864`](https://github.com/NixOS/nixpkgs/commit/4c9a58643fcf87f36d8ef57604f318aca6bab2be) lib2geom: 1.2 → 1.2.2
* [`3b3f77b1`](https://github.com/NixOS/nixpkgs/commit/3b3f77b1815388c6a320265ea4262dadb47914ed) inkscape: 1.2.1 → 1.2.2
* [`508b7cb3`](https://github.com/NixOS/nixpkgs/commit/508b7cb367e545d168f2f6f07536e4a6e8596342) python3Packages.tensorflow: fix overrides needed for darwin
* [`c2720ceb`](https://github.com/NixOS/nixpkgs/commit/c2720cebe7eacb1b637c1906b4ab6e8c09a0ab98) python3Packges.tensorflow: workaround buggy std::optional detection in abseil-cpp
* [`f4edf5db`](https://github.com/NixOS/nixpkgs/commit/f4edf5dbb9a5b08e1087315b225db5426328121a) python310Packages.pytest-filter-subpackage: 0.1.1 -> 0.1.2
* [`77b73327`](https://github.com/NixOS/nixpkgs/commit/77b73327e345cef628685852bb66084185c0a4ac) spice-gtk: fix cross compilation
* [`6f4d63b2`](https://github.com/NixOS/nixpkgs/commit/6f4d63b20543430d4d86bae4ba0f52764e3a6234) srvc: 0.8.0 -> 0.9.0
* [`75a9a064`](https://github.com/NixOS/nixpkgs/commit/75a9a06486cb21d96edff0f75cda278744d528bb) ghorg: 1.9.0 -> 1.9.1
* [`bd71a881`](https://github.com/NixOS/nixpkgs/commit/bd71a88128d05a68b2bd962ebecd24b91d96ca3f) ginkgo: 2.5.1 -> 2.6.0
* [`62e1d58a`](https://github.com/NixOS/nixpkgs/commit/62e1d58a6fbced03205afd00ec0e896d2ac26c45) trivial-builders.writeShellApplication: use unwrapped pandoc
* [`61d84e14`](https://github.com/NixOS/nixpkgs/commit/61d84e1441383164f289141b18323f66f211156f) goresym: 1.8 -> 2.0
* [`4fa694ad`](https://github.com/NixOS/nixpkgs/commit/4fa694adf210b63f58380a5fb75d538acb38f5ec) govc: 0.29.0 -> 0.30.0
* [`8fb4a5b3`](https://github.com/NixOS/nixpkgs/commit/8fb4a5b389864e657e20214275953fde840f73e5) pjsip-jami: patch for CVE
* [`58bbc587`](https://github.com/NixOS/nixpkgs/commit/58bbc58725545597058907aa1081c77b8402ef9c) terraform-providers.argocd: 4.1.0 → 4.2.0
* [`4332592c`](https://github.com/NixOS/nixpkgs/commit/4332592cafdff3f7504e9166d2362c5f3716f726) terraform-providers.alicloud: 1.193.1 → 1.194.0
* [`b0f7bbe9`](https://github.com/NixOS/nixpkgs/commit/b0f7bbe9e46fdd9ef4d4ad6c3458308a345ed6e5) terraform-providers.google: 4.45.0 → 4.46.0
* [`01bd3f3e`](https://github.com/NixOS/nixpkgs/commit/01bd3f3e24550b640020e3f42cf2f08263a42986) terraform-providers.google-beta: 4.45.0 → 4.46.0
* [`c6ac6db4`](https://github.com/NixOS/nixpkgs/commit/c6ac6db431c1505215947978965a2516fe2531ec) terraform-providers.grafana: 1.31.1 → 1.32.0
* [`5f5d24c5`](https://github.com/NixOS/nixpkgs/commit/5f5d24c55f2f59d5499c89492c5f68ce9c338542) terraform-providers.pagerduty: 2.6.4 → 2.7.0
* [`3039dc51`](https://github.com/NixOS/nixpkgs/commit/3039dc51985cb681fe5a3ef9feb6b5a3518453d3) quickemu: 4.4 -> 4.5
* [`f0dda807`](https://github.com/NixOS/nixpkgs/commit/f0dda807b29b61d1ab4ec44662767d0f9bd221b3) ocamlPackages.merlin: 4.6 → 4.7
* [`058d817f`](https://github.com/NixOS/nixpkgs/commit/058d817fd4d6956ff23cdb3129a3b29799142937) python3Packages.autopep8: patch for pycodestyle-2.10.0
* [`81503a91`](https://github.com/NixOS/nixpkgs/commit/81503a91c8b74fa2a4dfd2c21c2232d00dce8d34) python310Packages.pytest-filter-subpackage: add changelog to meta
* [`87267bb8`](https://github.com/NixOS/nixpkgs/commit/87267bb8cff5041bb967a6b61c407083305287be) prismlauncher: 5.2 -> 6.0
* [`a950e5b2`](https://github.com/NixOS/nixpkgs/commit/a950e5b2dca868d06c356846c2d76e153a5aa875) heimer: 3.6.2 -> 3.6.3
* [`980cc45e`](https://github.com/NixOS/nixpkgs/commit/980cc45e15cfff107634524735735d960947eed1) imagemagick: 7.1.0-53 -> 7.1.0-54
* [`b037e632`](https://github.com/NixOS/nixpkgs/commit/b037e632e8fd70176f91e8fbc548bd18f5733612) pocketbase: 0.9.0 -> 0.9.2
* [`d2449c76`](https://github.com/NixOS/nixpkgs/commit/d2449c7695217bc67f607158393ee1634ae15609) mutagen-compose: 0.16.2 -> 0.16.3
* [`051fa105`](https://github.com/NixOS/nixpkgs/commit/051fa1056dfb833166768f11bd74885b4c343162) crystfel: fix symlib hard-coding
* [`7fedb7f3`](https://github.com/NixOS/nixpkgs/commit/7fedb7f3324ccd1c2bb69338147c4f3eabfafd73) kyverno: 1.8.3 -> 1.8.4
* [`7673d511`](https://github.com/NixOS/nixpkgs/commit/7673d5110f3f12c2fb058b8e8a08a29179704de3) firefox-esr-unwrapped: 102.5.0esr -> 102.6.0esr
* [`4cb98810`](https://github.com/NixOS/nixpkgs/commit/4cb98810baf7960d28576edfc39a7df8aa8ccb18) packer: 1.8.4 -> 1.8.5 ([nixos/nixpkgs⁠#205879](https://togithub.com/nixos/nixpkgs/issues/205879))
* [`ca01321f`](https://github.com/NixOS/nixpkgs/commit/ca01321f0572552adc10845dc069cb8dfac0c1d8) python310Packages.jupyterlab: 3.5.0 -> 3.5.1 ([nixos/nixpkgs⁠#205023](https://togithub.com/nixos/nixpkgs/issues/205023))
* [`9fb6ca96`](https://github.com/NixOS/nixpkgs/commit/9fb6ca9609ec11383d0e4f4138b66626e5384533) jellyfin-ffmpeg: 5.1.2-4 -> 5.1.2-5
* [`7b37acd9`](https://github.com/NixOS/nixpkgs/commit/7b37acd9bab693262f67d1511fe64abb92527e32) jove: 4.17.4.7 -> 4.17.4.8
* [`c913b406`](https://github.com/NixOS/nixpkgs/commit/c913b406e3029ac5597634a6bbe0b3ad5a39fe06) gleam: 0.25.0 -> 0.25.1
* [`beaf7262`](https://github.com/NixOS/nixpkgs/commit/beaf7262e6a1d8276eccc93b3fd9ea2dd2e11470) ocamlPackages.stdcompat: 18 → 19
* [`35e2079b`](https://github.com/NixOS/nixpkgs/commit/35e2079bd5a3c5a213068c9fae1fa766cf1fb249) ocamlPackages.pyml: 20220615 → 20220905
* [`2afa2a25`](https://github.com/NixOS/nixpkgs/commit/2afa2a25ad1540e64565f6a312d417f3d07ae5bf) python310Packages.graphene: 3.2.0 -> 3.2.1
* [`e53d1600`](https://github.com/NixOS/nixpkgs/commit/e53d1600cb67069ed39a4b7a00ca21b48ae7860b) Revert [nixos/nixpkgs⁠#201485](https://togithub.com/nixos/nixpkgs/issues/201485): llvmPackages_14: Fix build on aarch64-linux
* [`a79359b9`](https://github.com/NixOS/nixpkgs/commit/a79359b974b7aff7072430c2b04d92a191655c69) watchlog: 1.152.0 →  1.197.0
* [`9a70465b`](https://github.com/NixOS/nixpkgs/commit/9a70465be7aeed940c6ec2db9de65ec4b288331b) python310Packages.hahomematic: 2022.12.2 -> 2022.12.3
* [`5315838a`](https://github.com/NixOS/nixpkgs/commit/5315838a26b3f5491a4b65d1b107d53ae9d80af7) wireplumber: 0.4.12 -> 0.4.13
* [`4f1ab095`](https://github.com/NixOS/nixpkgs/commit/4f1ab0953d7aa2553f58dcd6d20db4706e29f3d3) python310Packages.devtools: 0.8.0 -> 0.10.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
