### PR TITLE
niv devenv: update b14264df -> 27f49091

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b14264df26eb6709a7e831213be904c488b0bbe2",
-        "sha256": "1k252mmrdkvkpxqrbskvv70za1slrk1l8sgm91488qnvxsjp8f0k",
+        "rev": "27f490910057a989ecac0851c5d3085bcebe1093",
+        "sha256": "008zn1z6wyka7yxyi2wbycmw81pxnh7m2bykzgalwli4f6rd5pg7",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/b14264df26eb6709a7e831213be904c488b0bbe2.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/27f490910057a989ecac0851c5d3085bcebe1093.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@b14264df...27f49091](https://github.com/cachix/devenv/compare/b14264df26eb6709a7e831213be904c488b0bbe2...27f490910057a989ecac0851c5d3085bcebe1093)

* [`a07529ab`](https://github.com/cachix/devenv/commit/a07529ab761ea4d890295fb806e8bf2af972c96e) ruby: update GEM_HOME, GEM_PATH and PATH
* [`7d09daa1`](https://github.com/cachix/devenv/commit/7d09daa18d909446a042b0aba3789ffeee4b005d) add ruby example
* [`95fae723`](https://github.com/cachix/devenv/commit/95fae72304394c9a0a1e756d4513f8821dec86bf) examples/ruby: add Gemfile
* [`8f319ae3`](https://github.com/cachix/devenv/commit/8f319ae3ba80c2ceaa009d6285174ac103145ace) remove version output on enterShell
* [`6240d965`](https://github.com/cachix/devenv/commit/6240d965495722e9f57c53f2b90c3a3a60069e52) add wiremock module
* [`23c3ff93`](https://github.com/cachix/devenv/commit/23c3ff93dedcd756d66645eaed671df624a71d70) add wiremock example
* [`3fc62a61`](https://github.com/cachix/devenv/commit/3fc62a61ab6d7ea6ae8f0d62d1d539ea9aa5a939) Auto generate docs/reference/options.md
* [`9c1ccbaa`](https://github.com/cachix/devenv/commit/9c1ccbaaf95f63d0fd67ea98289f6e86d9ba39a6) bump deps
* [`6c233f07`](https://github.com/cachix/devenv/commit/6c233f079257c19c781a354559239889554f7262) Auto generate docs/reference/options.md
* [`d7e9663e`](https://github.com/cachix/devenv/commit/d7e9663e31056a3e7e474dc57e186623984bf856) Fix example in flakes guide
* [`55ff8c10`](https://github.com/cachix/devenv/commit/55ff8c10f6b5f4ba594207e671187f55cc7d0c59) check-update: disable when using flakes
* [`22b2a603`](https://github.com/cachix/devenv/commit/22b2a603c7c0c56bbe3b06a9636d5d5849e2d663) ruby: bump to 3.1.x
* [`ab89609e`](https://github.com/cachix/devenv/commit/ab89609ec1144e8fc8ab94841f8a93630126edbf) Auto generate docs/reference/options.md
* [`8dff90bb`](https://github.com/cachix/devenv/commit/8dff90bbfe28eb9b75a2475df49083a86c6b446b) simplify
* [`557cb2d3`](https://github.com/cachix/devenv/commit/557cb2d3e7628a76b42754f36663010af768c837) Add the correct RUST_SRC_PATH
* [`64e19203`](https://github.com/cachix/devenv/commit/64e192037a71df3241529dcf6862dffc5c86cffe) mailhog: init module
* [`934f1d1c`](https://github.com/cachix/devenv/commit/934f1d1c58fb80baee7a8f991b0ea5358b8c1d49) mailhog: fix typo
* [`0cec2e6a`](https://github.com/cachix/devenv/commit/0cec2e6a55b31bb4fa8d5dd1a806bc4663b66aa6) Auto generate docs/reference/options.md
* [`927bee61`](https://github.com/cachix/devenv/commit/927bee6104838e5d07a9a143ebfe14ec1cc37ca7) add minio
* [`250b47f6`](https://github.com/cachix/devenv/commit/250b47f69fe1bc98c864270649ca96827d44ada6) Auto generate docs/reference/options.md
* [`d657a02a`](https://github.com/cachix/devenv/commit/d657a02a7a01276e7d100c0087ba9491d35bab7f) Enable rust-src by default
* [`7ac94b79`](https://github.com/cachix/devenv/commit/7ac94b7926a242dc618157ecb18095f55d2cb9a5) Remove the extra function args
* [`04bee1d3`](https://github.com/cachix/devenv/commit/04bee1d37423b0595464847ff9a8617b1b7f7f49) expose config.ciDerivation for flakes
* [`2d859647`](https://github.com/cachix/devenv/commit/2d859647dec00fc77ac662e6bb44012bc3dd2cd3) process: add the script to the ci in the correct place
* [`d524084f`](https://github.com/cachix/devenv/commit/d524084f9e09fc4b069088f8de4ecfd9a76f6598) add difftastic integration
* [`8a13ec48`](https://github.com/cachix/devenv/commit/8a13ec4834d62ca277aa29606b2515559ccab021) enable diffstatic for devenv itself
* [`27f49091`](https://github.com/cachix/devenv/commit/27f490910057a989ecac0851c5d3085bcebe1093) Auto generate docs/reference/options.md
