### PR TITLE
niv emacs-overlay: update 832ce469 -> 56367de0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "832ce4696acba9b6c353495d4f6fd751107f4eca",
-        "sha256": "0licp3vbl2148072yr5bnv4mf3js65r3x2wxa9kwwkq0cm7d4x7h",
+        "rev": "56367de0ad78e1f1db0946ae896e4017d9dde785",
+        "sha256": "1g5fs6xpv7ydf098cyxgamdh30n17lh9p8hs53765b2p147nphnw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/832ce4696acba9b6c353495d4f6fd751107f4eca.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/56367de0ad78e1f1db0946ae896e4017d9dde785.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@832ce469...56367de0](https://github.com/nix-community/emacs-overlay/compare/832ce4696acba9b6c353495d4f6fd751107f4eca...56367de0ad78e1f1db0946ae896e4017d9dde785)

* [`bb5acdde`](https://github.com/nix-community/emacs-overlay/commit/bb5acdde9b19f0332a29a9e44db632203768a3a3) Updated repos/melpa
* [`2cd06d6a`](https://github.com/nix-community/emacs-overlay/commit/2cd06d6a3bece1b07b0dd149da0df68379f52baa) Updated repos/elpa
* [`640c4070`](https://github.com/nix-community/emacs-overlay/commit/640c4070f56ab539a98e1c4527b3d66e70c5c997) Updated repos/emacs
* [`70e9d626`](https://github.com/nix-community/emacs-overlay/commit/70e9d626142f34239f1363e957810cd3a5af431c) Updated repos/melpa
* [`194e3548`](https://github.com/nix-community/emacs-overlay/commit/194e3548ba5e081b5b496f66738dfb8ad8159c4a) Updated repos/nongnu
* [`a55b3879`](https://github.com/nix-community/emacs-overlay/commit/a55b3879c0984535b825737af294418d3fca58b1) Updated repos/emacs
* [`81a7ac1c`](https://github.com/nix-community/emacs-overlay/commit/81a7ac1c3d363ce5bdb716d63819a61e53eeb11c) Updated repos/melpa
* [`3b89af68`](https://github.com/nix-community/emacs-overlay/commit/3b89af681919a4235ee0aefcdcdb1dc39935129c) Updated repos/nongnu
* [`766e5a23`](https://github.com/nix-community/emacs-overlay/commit/766e5a23610edee0666b4a1a570543167e127d68) Use withPgtk = true in emacsPgtk
* [`ea098ae4`](https://github.com/nix-community/emacs-overlay/commit/ea098ae4c4e43ae76f2c5a39ab614749fe28e99f) Drop mkPgtkEmacs function
* [`e31afe71`](https://github.com/nix-community/emacs-overlay/commit/e31afe71f86d75fdf82c6096babdf3c083e48193) Updated repos/emacs
* [`fbc7b794`](https://github.com/nix-community/emacs-overlay/commit/fbc7b7949f173ccfa63b81883517eb24e7c7ae2c) Updated repos/melpa
* [`21bc6afe`](https://github.com/nix-community/emacs-overlay/commit/21bc6afe66d63036cb4d5dba77473f55b61a9524) Updated repos/nongnu
* [`66cd81c0`](https://github.com/nix-community/emacs-overlay/commit/66cd81c0ec485ec4b1fcaaedaef2e238231d9413) Updated repos/elpa
* [`6080d46a`](https://github.com/nix-community/emacs-overlay/commit/6080d46a220dd393c56d555286dee75488abbe2c) Updated repos/emacs
* [`49fd7961`](https://github.com/nix-community/emacs-overlay/commit/49fd7961fd9e46796ddf6e52a258f08bcd9ad4f8) Updated repos/melpa
* [`706bea96`](https://github.com/nix-community/emacs-overlay/commit/706bea96aaa2266a2658c047d2da1b472fb1587d) Updated repos/elpa
* [`dec7f00a`](https://github.com/nix-community/emacs-overlay/commit/dec7f00ad9b53137a6e9d14c8fa21742e043bdcb) Updated repos/emacs
* [`e42736e0`](https://github.com/nix-community/emacs-overlay/commit/e42736e0c404b29ed648662fb9f62f744309581e) Updated repos/melpa
* [`1f20ccc1`](https://github.com/nix-community/emacs-overlay/commit/1f20ccc1b8cb303a2651e9c18e1c65bfce8ce6d1) Updated repos/nongnu
* [`2ebeedce`](https://github.com/nix-community/emacs-overlay/commit/2ebeedce886e890983c53c4fe535f4e4f81d5dfb) Updated repos/emacs
* [`1243a1cc`](https://github.com/nix-community/emacs-overlay/commit/1243a1ccf6e073d47fda5c5dfb74ab3c9b73c5d9) Updated repos/melpa
* [`0e1a47ea`](https://github.com/nix-community/emacs-overlay/commit/0e1a47eadd23dc5669f056f28de606c9d00a1c29) Updated repos/nongnu
* [`e0a9de13`](https://github.com/nix-community/emacs-overlay/commit/e0a9de13f4334f174e07baced0965adfffc6dcc9) Updated repos/emacs
* [`c873175c`](https://github.com/nix-community/emacs-overlay/commit/c873175c2f8d96cd77c5b6552f411ddd0959e483) Updated repos/melpa
* [`77579c71`](https://github.com/nix-community/emacs-overlay/commit/77579c7153a8b50c073df0954140386c24a43789) Updated repos/emacs
* [`af726f49`](https://github.com/nix-community/emacs-overlay/commit/af726f4941acc7367d75bc8e35c2ad047fd727f9) Updated repos/melpa
* [`bc6e5900`](https://github.com/nix-community/emacs-overlay/commit/bc6e5900781577c1d472ef28548b7cb2bc42490e) Updated repos/emacs
* [`815f5a9b`](https://github.com/nix-community/emacs-overlay/commit/815f5a9bd21891286f4d8ea7c9f08afa2cd6ac4b) Updated repos/melpa
* [`1147eaab`](https://github.com/nix-community/emacs-overlay/commit/1147eaabf15edecfc405bace11c35bf2051a46d4) Updated repos/elpa
* [`4bd4accc`](https://github.com/nix-community/emacs-overlay/commit/4bd4acccbed7961c038592e932432dcac103193d) Updated repos/emacs
* [`6158c43e`](https://github.com/nix-community/emacs-overlay/commit/6158c43e32fa81eb3a5b208c89ae6d1b5e60a806) Updated repos/melpa
* [`b0c95db5`](https://github.com/nix-community/emacs-overlay/commit/b0c95db59fef979eb72a29f5ad7e9f3c866c8ffd) Add more tree-sitter grammars
* [`22f9d2f1`](https://github.com/nix-community/emacs-overlay/commit/22f9d2f1668314a9f5374d3c548c54237fda3572) Updated repos/emacs
* [`f6aea82e`](https://github.com/nix-community/emacs-overlay/commit/f6aea82ed51e17d1b36178620a3cff62340e2385) Updated repos/melpa
* [`0a570f81`](https://github.com/nix-community/emacs-overlay/commit/0a570f813accfee8074a4486f14295c0badbec9f) Updated repos/nongnu
* [`249d14bd`](https://github.com/nix-community/emacs-overlay/commit/249d14bdd55995eea2e0c9cfed8a230525faebde) Updated repos/melpa
* [`e369f1a0`](https://github.com/nix-community/emacs-overlay/commit/e369f1a08bd2a9ba7735673f351d6167f58a5883) Updated repos/emacs
* [`ac897e92`](https://github.com/nix-community/emacs-overlay/commit/ac897e92fbd826af47541efc65a186bff1159960) Updated repos/melpa
* [`d4a1b408`](https://github.com/nix-community/emacs-overlay/commit/d4a1b408a76e760dcad125916f4c75496f161018) Updated repos/nongnu
* [`e38a4d0a`](https://github.com/nix-community/emacs-overlay/commit/e38a4d0ac4cfb473da82859b4494aea1f993517c) fixes segfaults that only occur on aarch64-linux (issue [nix-community/emacs-overlay⁠#264](https://togithub.com/nix-community/emacs-overlay/issues/264))
* [`76ca62d7`](https://github.com/nix-community/emacs-overlay/commit/76ca62d7ab5fb1309d8df3abc45392d54d5d8cdd) Updated repos/elpa
* [`55805642`](https://github.com/nix-community/emacs-overlay/commit/558056421c941d2eb240a99a62d2c03bc1ccf9be) Updated repos/emacs
* [`9a32f60e`](https://github.com/nix-community/emacs-overlay/commit/9a32f60ec8d8f5566b65c227c0fad96cfabbf260) Updated repos/melpa
* [`759e4f1d`](https://github.com/nix-community/emacs-overlay/commit/759e4f1d0e2ac706bd6ac22af793b1f7d02aabc6) Updated repos/nongnu
* [`355e3328`](https://github.com/nix-community/emacs-overlay/commit/355e3328075735ea93d5dd1d29884d251e45529e) Add tree-sitter-rust
* [`dfb237dc`](https://github.com/nix-community/emacs-overlay/commit/dfb237dc6fe20ab963d0390dc153ad7efbd2a2a5) Updated repos/emacs
* [`196b8ae9`](https://github.com/nix-community/emacs-overlay/commit/196b8ae969df6550e4c39bf38b1186d897eb500b) Updated repos/melpa
* [`d8baf8af`](https://github.com/nix-community/emacs-overlay/commit/d8baf8af22511e7526d9336eede54bbfa6aed13e) Updated repos/nongnu
* [`54c91790`](https://github.com/nix-community/emacs-overlay/commit/54c9179039e173d5ce1cd26ed9ba77d4d3c1ff00) Updated repos/emacs
* [`233d2937`](https://github.com/nix-community/emacs-overlay/commit/233d2937a35960459f8d0958548fccf67c060330) Updated repos/melpa
* [`713c4b92`](https://github.com/nix-community/emacs-overlay/commit/713c4b92f2e539d5157ca4b08fd3e55f02068549) Updated repos/elpa
* [`54eb70a7`](https://github.com/nix-community/emacs-overlay/commit/54eb70a7a5c91212db0f94ad5227d080e251d366) Updated repos/emacs
* [`b178f5d0`](https://github.com/nix-community/emacs-overlay/commit/b178f5d0cfb97181ac1503f805ca7e0649202441) Updated repos/melpa
* [`e66b050b`](https://github.com/nix-community/emacs-overlay/commit/e66b050baad96f62f541c0eb47af041b9d4805b8) Updated repos/emacs
* [`9207a281`](https://github.com/nix-community/emacs-overlay/commit/9207a2810c29dac8d2621aeb4584a6ab54f25373) Updated repos/melpa
* [`45c07681`](https://github.com/nix-community/emacs-overlay/commit/45c076814b2f8f616116df47c101e1a9faa40bc5) Updated repos/elpa
* [`8f901318`](https://github.com/nix-community/emacs-overlay/commit/8f901318601e996ddf6530ae2afaefa47721dc5d) Updated repos/emacs
* [`d50df98a`](https://github.com/nix-community/emacs-overlay/commit/d50df98aaf28405432814d3b1a15eaf0e133d04d) Updated repos/melpa
* [`66c09dd3`](https://github.com/nix-community/emacs-overlay/commit/66c09dd318a5b8049064373bcefd118457f4d22b) Updated repos/emacs
* [`6511f9a3`](https://github.com/nix-community/emacs-overlay/commit/6511f9a3d0be0bbb7ef0183fb03f2b936fe42582) Updated repos/melpa
* [`56367de0`](https://github.com/nix-community/emacs-overlay/commit/56367de0ad78e1f1db0946ae896e4017d9dde785) Updated repos/nongnu
