### PR TITLE
niv spacemacs: update 866a2d5a -> b74da79d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "866a2d5ae12706a68acb83f489dd669bc7b29d1e",
-        "sha256": "16vf8gs9k5i47q7fgz63w2kimgi4i25pjpq8cyk7x6aicccj5n8y",
+        "rev": "b74da79dbbd8573ab4f43721c74014d6f54d8bd0",
+        "sha256": "0llr4ywz7h6jifds62v3y0pm6jb83wvpmw2fv0va05pm2229vk6a",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/866a2d5ae12706a68acb83f489dd669bc7b29d1e.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/b74da79dbbd8573ab4f43721c74014d6f54d8bd0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@866a2d5a...b74da79d](https://github.com/syl20bnr/spacemacs/compare/866a2d5ae12706a68acb83f489dd669bc7b29d1e...b74da79dbbd8573ab4f43721c74014d6f54d8bd0)

* [`7b738c2b`](https://github.com/syl20bnr/spacemacs/commit/7b738c2b0b4a14e36b4ea5390524b929b098930a) * core: eval-and-compile the functions used in eager macro expansion
* [`6fcde67b`](https://github.com/syl20bnr/spacemacs/commit/6fcde67b3372c71a6c03e21e372603c00390e546) Fix [syl20bnr/spacemacs⁠#15658](https://togithub.com/syl20bnr/spacemacs/issues/15658): replace geiser-company-backend with company-capf
* [`52deec4b`](https://github.com/syl20bnr/spacemacs/commit/52deec4bb15f065627fca6a5840d00027e602517) Add temporary fix for eager-macro-expansion of use-package
* [`b28d65b7`](https://github.com/syl20bnr/spacemacs/commit/b28d65b7aa7a936cdab7fc0453df86b21ac1496f) Load use-package extensions before usual layer loading
* [`b74da79d`](https://github.com/syl20bnr/spacemacs/commit/b74da79dbbd8573ab4f43721c74014d6f54d8bd0) Fix load issues with org-trello package
