### PR TITLE
niv zsh-completions: update 7b8bb64c -> b2151312

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "7b8bb64cbb2014de66204b800bdac9ea149b6932",
-        "sha256": "0jmgx9y4mqq8dj9n6lsc4rg8ccpjyad2ba4yp59r5fvlvyzfngfr",
+        "rev": "b215131217582b1c634c57ffc61bf3e33190c5f1",
+        "sha256": "060q372z81vwknkv0zgn54mgv6ddzcd63kgzddrh8cy88khrmf07",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/7b8bb64cbb2014de66204b800bdac9ea149b6932.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/b215131217582b1c634c57ffc61bf3e33190c5f1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@7b8bb64c...b2151312](https://github.com/zsh-users/zsh-completions/compare/7b8bb64cbb2014de66204b800bdac9ea149b6932...b215131217582b1c634c57ffc61bf3e33190c5f1)

* [`9a1ec0e9`](https://github.com/zsh-users/zsh-completions/commit/9a1ec0e9eebb1bcf68cf9a8832bb25c07fa12de0) Update virtualbox completion
