### PR TITLE
niv nixpkgs: update e83d9efe -> a753a425

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e83d9efe4d520414346248dfcdb883701048c847",
-        "sha256": "19jwn99slf2a61mwyvdcw2a83ymwy10bxp1m55h2nrlyh0vdkn0k",
+        "rev": "a753a425963129f149459cbaea1f46a4bea67636",
+        "sha256": "0618pjcb35y4hb7njrwxfcacfj9jrkj5b52hyhvrx7vv1xrwmp8m",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e83d9efe4d520414346248dfcdb883701048c847.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a753a425963129f149459cbaea1f46a4bea67636.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e83d9efe...a753a425](https://github.com/nixos/nixpkgs/compare/e83d9efe4d520414346248dfcdb883701048c847...a753a425963129f149459cbaea1f46a4bea67636)

* [`57beeedb`](https://github.com/NixOS/nixpkgs/commit/57beeedbdff89e3d1fbe80d6445e4925c36205e4) nixos/test-driver: allow multiple entry of polling condition
* [`1db0dcdf`](https://github.com/NixOS/nixpkgs/commit/1db0dcdfec9c927ce83011451c69c2ee5e78289f) nixos/test-driver: add wait_before_entry to polling_condition
* [`2a3834b7`](https://github.com/NixOS/nixpkgs/commit/2a3834b7eb93face07083a6d06b858af5ddca791) nixosTests.vscodium: use new wait_before_entry
* [`976f0096`](https://github.com/NixOS/nixpkgs/commit/976f00963fb3006616efa1d7794aa5e5ea6cb712) nixos/test-driver: rewrite wait_before_entry to wait
* [`8403b412`](https://github.com/NixOS/nixpkgs/commit/8403b412ce347a7d520dd605e3c22aeccb2bd288) pdepend: Remove extra `default.nix`.
* [`3624f0bb`](https://github.com/NixOS/nixpkgs/commit/3624f0bbf016e948f8f88d7e93f4a7d441979f13) services.prometheus.exporters.statsd: init service
* [`7706797a`](https://github.com/NixOS/nixpkgs/commit/7706797a90018cf6eb57bc39b5504cb2b37ead20) nordzy-cursor-theme: 0.1.0 -> 0.6.0
* [`d970656e`](https://github.com/NixOS/nixpkgs/commit/d970656eb49f05987ae0a57b2624ccf1ae2c7304) PageEdit: 1.9.10 -> 1.9.20
* [`eb931a6d`](https://github.com/NixOS/nixpkgs/commit/eb931a6d41b6acdf9ec4b96588459c26705fef7f) netbeans: mark sourceProvenance binaryBytecode & binaryNativeCode
* [`b0264d88`](https://github.com/NixOS/nixpkgs/commit/b0264d88581c0ad9163ac36721df553f1501ad23) suricata: 6.0.6 -> 6.0.8
* [`8419e265`](https://github.com/NixOS/nixpkgs/commit/8419e265f3ec000017d40b321f22c3cb6f6a6753) beam-modules/rebar3WithPlugins: Allow overriding the rebar3 package used
* [`9a99aff2`](https://github.com/NixOS/nixpkgs/commit/9a99aff2f343ac3836051acde2ba8a419a0ee149) mongoDB: Enable 6.0 update for darwin
* [`7258c38a`](https://github.com/NixOS/nixpkgs/commit/7258c38a9f2d16a470382a831042443fafbf854c) python3Packages.plantuml-markdown: 3.6.3 -> 3.7.3
* [`52606360`](https://github.com/NixOS/nixpkgs/commit/5260636043a28a8fc24dd61555101f3dfb3422ca) python310Packages.garminconnect: 0.1.48 -> 0.1.49
* [`f54eac60`](https://github.com/NixOS/nixpkgs/commit/f54eac6053bd57d257cf38129c3e5de340c502ab) wire-desktop: linux 3.29.2997 -> 3.29.3004
* [`c08bef1f`](https://github.com/NixOS/nixpkgs/commit/c08bef1fc110f2e580056be45b99f1be76d740ca) wire-desktop: mac 3.29.4477 -> 3.29.4490
* [`aa00f0df`](https://github.com/NixOS/nixpkgs/commit/aa00f0dfe96df010a76e4d196defa61893082c17) svlint: 0.5.1 -> 0.6.0
* [`195f48cb`](https://github.com/NixOS/nixpkgs/commit/195f48cb7884e22cfb70f1a4ad6bdfc18b990692) python3Packages.wn: init at 0.9.2
* [`2f6c2249`](https://github.com/NixOS/nixpkgs/commit/2f6c22496ae0fda9f3c6715f2be7148b7d60ca34) wineStable: 7.0 -> 7.0.1
* [`7f683df0`](https://github.com/NixOS/nixpkgs/commit/7f683df02bc725e1cf18bf92f5b3f4a3624d4b39) gdcm: 3.0.17 -> 3.0.20
* [`159a6347`](https://github.com/NixOS/nixpkgs/commit/159a634719166fe15b24f13d1f102a4704942cb9) nwg-dock: init at 0.3.2
* [`b8f083b4`](https://github.com/NixOS/nixpkgs/commit/b8f083b48f11e8ff5f9dc6fc5972272683c7c021) vals: init at 0.19.0
* [`1addcfec`](https://github.com/NixOS/nixpkgs/commit/1addcfec040474857680572e0ecc9e128d10a700) remote-ssh: fix Node not patching automatically
* [`3f889b58`](https://github.com/NixOS/nixpkgs/commit/3f889b587fbe664745307a5ba6250e4e5fb8c488) haskellPackages: stackage LTS 19.32 -> LTS 20.1
* [`4af90f1f`](https://github.com/NixOS/nixpkgs/commit/4af90f1f5fc6dfffaf1f50eb3d1af552f1376fd7) all-cabal-hashes: 2022-11-11T17:48:48Z -> 2022-11-20T07:33:12Z
* [`2ea451a9`](https://github.com/NixOS/nixpkgs/commit/2ea451a9644b0f3ae9dec3141931b1939fadc490) haskellPackages: regenerate package set based on current config
* [`7505248d`](https://github.com/NixOS/nixpkgs/commit/7505248de32d15265afc14ddc746412b5a18e047) Revert "haskellPackages.hercules-ci-agent: add patch"
* [`a25927d0`](https://github.com/NixOS/nixpkgs/commit/a25927d07f21d58667d32660b98433cf0dae852a) bootiso: actually fix finding syslinux
* [`a586df9f`](https://github.com/NixOS/nixpkgs/commit/a586df9f44aa2c62c673d2a8419e3321e1a57972) morpheus-graphql not broken
* [`51990439`](https://github.com/NixOS/nixpkgs/commit/51990439e9297087e1f6dc939c2efd7ea27069d4) hpack: work around test suite choking on CRLF
* [`216efb0d`](https://github.com/NixOS/nixpkgs/commit/216efb0d9c52a4067834d2a2eb96b24e490683d8) haskellPackages: bump default GHC to 9.2.x
* [`ea84ce75`](https://github.com/NixOS/nixpkgs/commit/ea84ce75936893bd9a8e47476814608ad8872c35) haskellPackages: fixes
* [`81d6f1c7`](https://github.com/NixOS/nixpkgs/commit/81d6f1c7dc78ea07a6516efec4dafbc32fee9738) sratoolkit: init at 2.11.3
* [`e217979f`](https://github.com/NixOS/nixpkgs/commit/e217979fc7696486cd6445224ffe8700f18dfe70) nixos/rpcbind: add dependency for systemd-tmpfiles-setup
* [`cfd3e36a`](https://github.com/NixOS/nixpkgs/commit/cfd3e36aaf8a6ca23ececa6d5341a266a3151f35) haskellPackages.oeis: jailbreak
* [`cd55072f`](https://github.com/NixOS/nixpkgs/commit/cd55072f6a1d3cab99c42fad6fc50102c2378dfe) lambdabot: remove upstreamed patches
* [`eb935bc5`](https://github.com/NixOS/nixpkgs/commit/eb935bc5404974d7190466da50bec7e613ff0d8f) haskellPackages.vinyl: remove unnecessary override
* [`8e52ed5e`](https://github.com/NixOS/nixpkgs/commit/8e52ed5ec4c4165f0862e0ff90fa042f2b07c19e) haskellPackages.aeson-diff: remove unnecessary jailbreak
* [`e34601f4`](https://github.com/NixOS/nixpkgs/commit/e34601f42e74a0d2407548c880a0b9bab16f2af9) haskellPackages.heist: remove unnecessary overrides
* [`359553eb`](https://github.com/NixOS/nixpkgs/commit/359553ebbbc97fee47553d58a811b95ab7c54d75) haskellPackages.flat: remove unnecessary overrides
* [`49b7ff68`](https://github.com/NixOS/nixpkgs/commit/49b7ff686e83b0428c4ead198303e5f454d92967) haskell.packages.ghc94.doctest: don't force specific version
* [`bdfbb16f`](https://github.com/NixOS/nixpkgs/commit/bdfbb16f9368d13f9b24f538cc290c9747d734f9) haskellPackages.linear-base: remove unnecessary overrides
* [`7e7a8ca3`](https://github.com/NixOS/nixpkgs/commit/7e7a8ca3e2428b1af159790fcf781f1ede809682) haskell.packages.ghc94.invariant: remove jailbreak
* [`4d8f23c5`](https://github.com/NixOS/nixpkgs/commit/4d8f23c5c8fd517f221311a25227be51671c3dd9) haskell.packages.ghc94.implicit-hie-cradle: remove jailbreak
* [`d57e1530`](https://github.com/NixOS/nixpkgs/commit/d57e1530999db9e59aaa42c8d73e45a22bc1cd71) haskell.packages.ghc94.tasty-hedgehog: override version 1.3.1.0 with 1.4.0.0
* [`3fb38eeb`](https://github.com/NixOS/nixpkgs/commit/3fb38eeb2f455449d0768bfbfdca4c596a567fb4) haskell.packages.ghc94.retry: remove dontCheck
* [`96024bde`](https://github.com/NixOS/nixpkgs/commit/96024bde812b5ebfb317a70fdb53b57caa108feb) haskell.packages.ghc94.rerebase: remove jailbreak
* [`39bc33d6`](https://github.com/NixOS/nixpkgs/commit/39bc33d6b42c6f5e8ef2560ba9258e7be1f52f6c) haskell.packages.ghc94.hashtables: remove jailbreak
* [`53fcbbea`](https://github.com/NixOS/nixpkgs/commit/53fcbbea24f25496651967bae3aa60aa6c24907f) haskellPackages.lens: ship lens 5.1.1 which is from stackage
* [`71849002`](https://github.com/NixOS/nixpkgs/commit/718490028a7274754138ed0d8f2a364ae35bd88b) haskellPackages.swagger2: dont jailbreak
* [`a2b2b3c3`](https://github.com/NixOS/nixpkgs/commit/a2b2b3c3728b0df780a9b356f89ccbc16ccfe924) haskellPackages.servant-*: remove doJailbreak
* [`c249e29d`](https://github.com/NixOS/nixpkgs/commit/c249e29d973d4497a4b7a240c8e476fabd4fcae4) haskellPackages.servant-swagger: dont jailbreak
* [`a8f4aa3f`](https://github.com/NixOS/nixpkgs/commit/a8f4aa3f49f185ce56ccdaca0d3046bbc4b1ea7d) haskell.packages.ghc94.swagger2: dont jailbreak
* [`0c188689`](https://github.com/NixOS/nixpkgs/commit/0c1886899e8e1c6123ee4c4d2c4a050a214cf58f) haskell.packages.ghc94.lens-aeson: remove unnecessary override
* [`54a19eec`](https://github.com/NixOS/nixpkgs/commit/54a19eec61220e84cb7e9e59ddd18791894a2799) haskell.packages.ghc92.ghc-lib-parser-ex: use stackage version
* [`2fccb315`](https://github.com/NixOS/nixpkgs/commit/2fccb31598aa0e858ccf9eaea369a720294099b7) haskell.packages.ghc8{8,10}.base-compat-batteries: add missing dep
* [`58b85321`](https://github.com/NixOS/nixpkgs/commit/58b8532158c7e4757a01b5dddb498bb0b1cb4c96) haskellPackages.OrderedBits: restrict to x86 platforms
* [`26f659e6`](https://github.com/NixOS/nixpkgs/commit/26f659e65f326b9f134e625dadcfa0881ec4e545) haskellPackages.mbox: fix build for time >= 1.10
* [`1c546b5c`](https://github.com/NixOS/nixpkgs/commit/1c546b5c9816dc4a450ad0a83f9307c047c35915) haskellPackages: remove unnecessary overrides from ghc-9.2.x
* [`5b4ed2a6`](https://github.com/NixOS/nixpkgs/commit/5b4ed2a6aa6ef7bad85746181242c3b5de50da05) haskellPackages: configuration cleanup
* [`d43d883c`](https://github.com/NixOS/nixpkgs/commit/d43d883cc948ff874be29cc5e3be76dea3113cd8) haskellPackages: update base compiler and core pkgs in hackage2nix cfg
* [`b48e351e`](https://github.com/NixOS/nixpkgs/commit/b48e351eeb475ae9dfc7e0170a3ff3b5bc2904ab) haskellPackages.wide-word: lift constraint on hedgehog
* [`fc4cfafb`](https://github.com/NixOS/nixpkgs/commit/fc4cfafbb4c8553d3f19887016f97e057ec13412) haskellPackages.type-errors: apply upstream patch for 9.2
* [`7fd2271a`](https://github.com/NixOS/nixpkgs/commit/7fd2271afc82f50f84232c6998d3605488787404) haskell: Fix typo
* [`469f2b8d`](https://github.com/NixOS/nixpkgs/commit/469f2b8d9d5bc108beec95ebb35fea246c5c426e) haskellPackages.monad-bayes: Mark unbroken
* [`686cd3ec`](https://github.com/NixOS/nixpkgs/commit/686cd3ec03b0c2ada195e7bb13aa6c459c75ae40) haskellPackages: Sort and extend my maintainership
* [`3d095b8b`](https://github.com/NixOS/nixpkgs/commit/3d095b8b6e706d446b795115a55065ca01c5d63e) haskellPackages.singleton-th: allow th-desugar-1.14
* [`38b38881`](https://github.com/NixOS/nixpkgs/commit/38b38881a465d96d2182d01b75628e39e1dee8cd) haskell.packages.ghc9{2,4}.haskell-language-server: remove plugin overrides
* [`1d8f8eaf`](https://github.com/NixOS/nixpkgs/commit/1d8f8eaf380f7c6bff3564bf6288f906a8646b53) haskellPackages.haskell-language-server: add missing dep
* [`ca3fb231`](https://github.com/NixOS/nixpkgs/commit/ca3fb231997ff2e3d181bde1a776b6e34ffec5bf) haskell-language-server: Update wrapper to ghc 92 and don‘t provide version less executable
* [`521c788e`](https://github.com/NixOS/nixpkgs/commit/521c788e8f27987e22ab367b63f894a3e4d77848) haskellPackages.multipart: allow bytestring-0.11
* [`07ac1b4f`](https://github.com/NixOS/nixpkgs/commit/07ac1b4fa03ae86a183ad38c2b3dd3afa5aa5341) haskellPackages.tasty-discover: disable broken test suite
* [`b76addd0`](https://github.com/NixOS/nixpkgs/commit/b76addd0d51b9e21d32d1a2b216f26fb2adf313b) haskellPackages.irc-{client,conduit}: lift upper bound on time and bytestring
* [`4d26fe5c`](https://github.com/NixOS/nixpkgs/commit/4d26fe5c573e022f7790cf1be6d73fab3f58756b) haskellPackages.hashing: allow bytestring-0.11.*
* [`736497d7`](https://github.com/NixOS/nixpkgs/commit/736497d797a5a0c95f953b1bcc5af694c06b2e7d) haskellPackages.dhall-nix: 1.1.24 -> 1.1.25
* [`597ed022`](https://github.com/NixOS/nixpkgs/commit/597ed02231d295e322669299f86d671f72861d76) haskellPackages.hspec-contrib: dontCheck
* [`561e8fdc`](https://github.com/NixOS/nixpkgs/commit/561e8fdcf39d7582debe7525ffd875240efdd944) stack: remove overrides
* [`6116709e`](https://github.com/NixOS/nixpkgs/commit/6116709ed0790d0fdf99df0b379c938346ecc3bd) haskell.packages.ghc90.hashable: add missing dep of base-orphans
* [`3eafa296`](https://github.com/NixOS/nixpkgs/commit/3eafa296cf3124549a56fd4371bcbbdf4305c9da) haskell.packages.ghc90.hashable: change addExtraLibrary to addBuildDepend
* [`72760068`](https://github.com/NixOS/nixpkgs/commit/72760068185dfe528abf4c89390dc9462b67b73d) spago: build with ghc90 instead of ghc92
* [`c63bff06`](https://github.com/NixOS/nixpkgs/commit/c63bff0622b4796847554d54859d169bf91ff39c) haskell.packages.ghc810.hashable: add build depend on base-orphans
* [`f3b87b40`](https://github.com/NixOS/nixpkgs/commit/f3b87b407534824ea9968cee985b54984aec3684) haskell.packages.ghc88.hashable: add build depend on base-orphans
* [`63ad9460`](https://github.com/NixOS/nixpkgs/commit/63ad94602d2cfd3a0c8e529714a77b555bc7b3a5) spago: mark broken in ghc92
* [`685e53f5`](https://github.com/NixOS/nixpkgs/commit/685e53f56ea10813a287363c4fdf826df902bfa2) haskellPackages.Unique: allow hashable 1.4.*
* [`d3df35b7`](https://github.com/NixOS/nixpkgs/commit/d3df35b7b2f18856d6bcd9187e4839392c00ae54) haskellPackages.rope-utf16-splay: downgrade to match text version
* [`446357bc`](https://github.com/NixOS/nixpkgs/commit/446357bccacca3898b50c0f21b8f59f7b6d08285) haskell-ci: allow Stackage LTS-20 dependency version
* [`574eaa26`](https://github.com/NixOS/nixpkgs/commit/574eaa26375f9b6bdd1956fd2cfc9318e9c72675) haskellPackages: adopt maintainership of core haskell infra pkgs
* [`ac475812`](https://github.com/NixOS/nixpkgs/commit/ac47581226f4d0ecafee094d4a917f6bdad6e919) haskellPackages.{pandoc,hlegder}: adopt maintainership from peti
* [`1a14b05a`](https://github.com/NixOS/nixpkgs/commit/1a14b05aa3d1e1da96cbabd6e39c2fb29ba2e435) haskellPackages: maralorn adopts packages from peti
* [`3d851b64`](https://github.com/NixOS/nixpkgs/commit/3d851b64b8b3f28851ddef5321fa497d43ffab2e) haskell.compiler.ghc92*: backport Cabal bugfix for Paths_ modules
* [`dc2d31d6`](https://github.com/NixOS/nixpkgs/commit/dc2d31d6ae1a40c7a7972efd2591e53354af8ce5) all-cabal-hashes: 2022-11-20T07:33:12Z -> 2022-11-26T14:57:41Z
* [`dd1c4ff5`](https://github.com/NixOS/nixpkgs/commit/dd1c4ff5fc4ee926b7640ef2eecd81c7bbb4d2c4) vmTools: update current maintained debian versions
* [`755ae77e`](https://github.com/NixOS/nixpkgs/commit/755ae77ecc7b5337e1c3f8af05a86b51e8814a6e) haskellPackages.text-format: drop upstreamed patch
* [`444c0d02`](https://github.com/NixOS/nixpkgs/commit/444c0d020667c150d4fd6231a49d8b8fb01e9502) haskellPackages.purenix: adjust override for pure purescript dep
* [`d3b5468d`](https://github.com/NixOS/nixpkgs/commit/d3b5468d9adaa31dbe5f8b2f5f89117ff28dfe08) haskell.packages.ghc8107.purescript-*st: mark as broken
* [`a2da422e`](https://github.com/NixOS/nixpkgs/commit/a2da422ee3f476613abf75bbe62459d707e89c61) haskellPackages.purescript: drop unnecessary overrides
* [`2c0e0d2b`](https://github.com/NixOS/nixpkgs/commit/2c0e0d2b1c1ca13be0dc78782ddc4965c4e5f470) haskellPackages: move purescript override block into inherit
* [`793aa60f`](https://github.com/NixOS/nixpkgs/commit/793aa60fad0d207b05460dbecca9e01a61315500) openvscode-server: 1.69.2 -> 1.73.1
* [`62e19542`](https://github.com/NixOS/nixpkgs/commit/62e19542b6ef587f01be8ec90fe0ba4e3095c7c9) hledger-check-fancyassertions: update source hash for 1.27.1
* [`560818fd`](https://github.com/NixOS/nixpkgs/commit/560818fddf80533bd1a1868b0c1c07248d628a26) haskellPackages: configuration common cleanup
* [`a3b01f74`](https://github.com/NixOS/nixpkgs/commit/a3b01f7434df2f7a3e507257e31b6742a580dce1) haskellPackages: unbreak selected packages
* [`b239a47c`](https://github.com/NixOS/nixpkgs/commit/b239a47c8d7e00f2dfefd3017c3277d13654e7fc) haskellPackages.vinyl-updates: remove unused override
* [`42d19139`](https://github.com/NixOS/nixpkgs/commit/42d1913978b31a246bb3e7c28ba1b16148ac1a4d) haskellPackages.htoml: mark broken
* [`b05635da`](https://github.com/NixOS/nixpkgs/commit/b05635daf62c0b5050fb386c9111e7ff724596cc) haskellPackages: unbreak selected packages
* [`242949ca`](https://github.com/NixOS/nixpkgs/commit/242949ca5f47129aa630a782de2e5f154d7e0b96) wordbook: init at unstable-2022-11-02
* [`ca1c7d00`](https://github.com/NixOS/nixpkgs/commit/ca1c7d0009e18f93efaa072af558014d34cb3365) haskellPackages.snaplet-sqlite-simple: unmark as broken
* [`80867b74`](https://github.com/NixOS/nixpkgs/commit/80867b7446399804f310dfaa314204d0be1f0744) haskellPackages: regenerate
* [`df2c438c`](https://github.com/NixOS/nixpkgs/commit/df2c438cece32e6f1f4e9f41940b856371e27d75) rhoas: init at 0.51.7
* [`1ddd3a64`](https://github.com/NixOS/nixpkgs/commit/1ddd3a6480250fae62d5a2de9e73a5c77d3cfc54) tmuxPlugins.mode-indicator: init at 2021-10-01
* [`21c4d08c`](https://github.com/NixOS/nixpkgs/commit/21c4d08cd65ac374b2ad02aebb5552edd46edb6c) haskellPackages.hnix: 0.14.0.8 -> 0.16
* [`ec896426`](https://github.com/NixOS/nixpkgs/commit/ec8964267338b5664b6667f7850a33a2ddcaa910) dhall-nix: patch for compatibility with hnix 0.16
* [`ca6af0b6`](https://github.com/NixOS/nixpkgs/commit/ca6af0b6133f24f21ae3d36fe1da1e3192524f50) dhall-nixpkgs: allow building with hnix 0.16
* [`471e4279`](https://github.com/NixOS/nixpkgs/commit/471e42794cbdd1b60d2b6e72201e49caf4b25ae2) nixos/plasma5: Add iio sensors proxy for Plasma Mobile
* [`04568a04`](https://github.com/NixOS/nixpkgs/commit/04568a04cebd20cdad199cc6f96c0762e677e3cb) plasma-mobile: Add kirigami-addons dependency
* [`869042bf`](https://github.com/NixOS/nixpkgs/commit/869042bfcc5777701b7211e029ca6a39cc2a400b) libsForQt5.plasmaMobileGear: 22.09 -> 22.11
* [`83dfdaba`](https://github.com/NixOS/nixpkgs/commit/83dfdabad731b19dccf0e569226de641cf407bd4) kirigami-addons: 0.4 -> 0.6
* [`41092fea`](https://github.com/NixOS/nixpkgs/commit/41092feabdea3cd145e6b326a00e43b3fcfec9d1) alligator: Add dependency on kirigami-addons
* [`e11e162c`](https://github.com/NixOS/nixpkgs/commit/e11e162cb0c40b61ac3cbae4db2a0bc8d1546b61) angelfish: Update deps for 22.11
* [`e9c04435`](https://github.com/NixOS/nixpkgs/commit/e9c04435d2e0e37f84fa987ba22cc78344ec961a) kclock: Add dependency on kirigami-addons
* [`880e9f9c`](https://github.com/NixOS/nixpkgs/commit/880e9f9cda9745a5786bd8172477d3d3be929de6) krecorder: Add dependency on kwindowsystem
* [`f48809f1`](https://github.com/NixOS/nixpkgs/commit/f48809f11039595a3150918f566723f001920c5f) neochat: Add dependency on kirigami-addons
* [`873f33ef`](https://github.com/NixOS/nixpkgs/commit/873f33ef250618369c265d3c006e473975923472) plasma-dialer: Add dependency on kirigami-addons
* [`491064f1`](https://github.com/NixOS/nixpkgs/commit/491064f1e5f1791521d6b6d06b4167ae6ca88003) plasmatube: Fix runtime use of yt-dlp
* [`4b8a04a3`](https://github.com/NixOS/nixpkgs/commit/4b8a04a32bf837f86e7ffdfaed02eadfd77471bc) plasmatube: Add gst wrapping to fix playback
* [`9035cb11`](https://github.com/NixOS/nixpkgs/commit/9035cb111a20dfdf791d6ba9ea73f64132692ea7) audiotube: Add missing qtimageformats dependency
* [`371e0bbc`](https://github.com/NixOS/nixpkgs/commit/371e0bbc7cbb9d64a82e7f2a75478ee53563702e) audiotube: Remove now unneeded workaround
* [`832b15fc`](https://github.com/NixOS/nixpkgs/commit/832b15fcd6170d554f05069fce3678566c2d72c2) audiotube: Add gst wrapping to fix playback
* [`e1364fe5`](https://github.com/NixOS/nixpkgs/commit/e1364fe5eb4be0492f0a8e2f0e8d91a487e96c64) haskellPackages: stackage LTS 20.1 -> LTS 20.2
* [`5e2fc0cb`](https://github.com/NixOS/nixpkgs/commit/5e2fc0cbe547c650662da7cae78ffb408eaacfcb) all-cabal-hashes: 2022-11-26T14:57:41Z -> 2022-12-01T21:24:50Z
* [`e63e64bf`](https://github.com/NixOS/nixpkgs/commit/e63e64bf2604b851475bb2ecc0212bbe83f3afe9) haskellPackages: regenerate package set based on current config
* [`da7988fe`](https://github.com/NixOS/nixpkgs/commit/da7988fe440ef5b8779d4f76340ad7dc79ff3b33) Revert "haskellPackages.type-errors: apply upstream patch for 9.2"
* [`10384aaf`](https://github.com/NixOS/nixpkgs/commit/10384aaf6fc9e8661f538bc6db8cf7844ff892d3) haskellPackages.hercules-ci-optparse-applicative: bump
* [`9de7befd`](https://github.com/NixOS/nixpkgs/commit/9de7befdb2e2777634ed7c4fcffa037b99128ddc) haskellPackages.postgrest: 9.0.1 -> 10.1.1
* [`6f7b7da6`](https://github.com/NixOS/nixpkgs/commit/6f7b7da6174db26d8c24319b587fdc89c5003f20) all-cabal-hashes: 2022-12-01T21:24:50Z -> 2022-12-03T02:23:34Z
* [`ed62aa65`](https://github.com/NixOS/nixpkgs/commit/ed62aa65c80dcf54ff292c5cd83237d824852a0a) haskellPackages: regenerate package set based on current config
* [`1c546779`](https://github.com/NixOS/nixpkgs/commit/1c54677902d9f94fb5234acd27de76d1d2dd2ceb) haskellPackages.steeloverseer: mark as unbroken
* [`5602fa17`](https://github.com/NixOS/nixpkgs/commit/5602fa17337df0d18ce167c7ceb24d32bef9f15f) haskell.packages.ghc884.exceptions: 0.10.5 -> 0.10.6
* [`7de32b0c`](https://github.com/NixOS/nixpkgs/commit/7de32b0ce90bc507479ce6a4d83602c51e9eeb47) sgx-azure-dcap-client: init at 1.11.2
* [`da0dc833`](https://github.com/NixOS/nixpkgs/commit/da0dc8339ceca52b962d91e56d8764fcdc0ecdd8) nixos/aesmd: add option to configure quote provider library
* [`4e937f0d`](https://github.com/NixOS/nixpkgs/commit/4e937f0d6b8f5f5e34d2215a3d71620a8e89fa13) sgx-azure-quote-provider: add test-suite derivation
* [`dbff3c22`](https://github.com/NixOS/nixpkgs/commit/dbff3c22c156de370cd8771688651becd62cab6b) nixos/aesmd: add option `environment`
* [`ef90ce70`](https://github.com/NixOS/nixpkgs/commit/ef90ce7093f36a74523afbbf3714a466aa59bb79) nixos/grafana: add Admin to valid auto_assign_org_role values
* [`60273333`](https://github.com/NixOS/nixpkgs/commit/602733331fe760fe777826e72d852e49c33f59e8) plexamp: 4.5.2 -> 4.6.1
* [`a3a8bcee`](https://github.com/NixOS/nixpkgs/commit/a3a8bceef85ef99235735a6349f1397a3c02c0a8) netdata: 1.36.1 -> 1.37.1
* [`469b1eca`](https://github.com/NixOS/nixpkgs/commit/469b1ecaae57e670ec0c409ebdd0e177b04488c0) sumneko-lua-language-server: 3.6.3 -> 3.6.4
* [`6d96212b`](https://github.com/NixOS/nixpkgs/commit/6d96212b842d7f086c7e6b009fea4cd9e4741b2a) swaybg: 1.1.1 -> 1.2.0
* [`5453971b`](https://github.com/NixOS/nixpkgs/commit/5453971b64ed41244c00ffa67f2b08fec7825ae7) usbmuxd2: init at unstable-2022-02-07
* [`0bb9486e`](https://github.com/NixOS/nixpkgs/commit/0bb9486e518e66e41c37d137e845bea28d537d71) elmPackages.elm: fix build
* [`70567f67`](https://github.com/NixOS/nixpkgs/commit/70567f670918888c14091f51d7e2f6582c6c9293) haskellPackages.gitit: allow newer pandoc, skylighting, hoauth2
* [`37de16ca`](https://github.com/NixOS/nixpkgs/commit/37de16cab72cb9cd8f31b3ee776eeab982110d54) haskellPackages.jack: allow bytestring 0.11
* [`1001c044`](https://github.com/NixOS/nixpkgs/commit/1001c044978dda87d10c59a72f8dd26d18413208) haskellPackages.rate-limit: allow time 0.11
* [`7d9a2585`](https://github.com/NixOS/nixpkgs/commit/7d9a258576c294270235349e81ea3675495c9f23) haskellPackages.vulkan-utils: dontCheck
* [`5bc95ac1`](https://github.com/NixOS/nixpkgs/commit/5bc95ac1b571a33557e52e074f2ecade7bedcb98) haskellPackages.cabal2nix-unstable: 2022-10-22 -> 2022-12-08
* [`413bc28e`](https://github.com/NixOS/nixpkgs/commit/413bc28e5751add6faf6409b9610c234e34db3d2) hydra: 2022-11-24 -> unstable-2022-12-05
* [`76076c40`](https://github.com/NixOS/nixpkgs/commit/76076c404a9dfc0d07dbb1adda431b91dbed27e6) plistwatch: init at unstable-2020-12-22
* [`0bb5be98`](https://github.com/NixOS/nixpkgs/commit/0bb5be984b41f5da24161b7fe022659fb47231cb) all-cabal-hashes: 2022-12-03T02:23:34Z -> 2022-12-08T20:17:19Z
* [`6dea49b6`](https://github.com/NixOS/nixpkgs/commit/6dea49b6622dd8925b59580d2f533469f3a33575) haskellPackages: stackage LTS 20.2 -> LTS 20.3
* [`735480cd`](https://github.com/NixOS/nixpkgs/commit/735480cd0cccae0a3bcc7fe7edd21ab4c57b4add) haskellPackages: regenerate package set based on current config
* [`1bb1559d`](https://github.com/NixOS/nixpkgs/commit/1bb1559d754dce75c80cd6e42741f66697255931) haskellPackages: Fix eval errors
* [`4816483d`](https://github.com/NixOS/nixpkgs/commit/4816483d8b31466808b34225d77b2c08d8a28607) esphome: pass through platformio
* [`7a03b5aa`](https://github.com/NixOS/nixpkgs/commit/7a03b5aa8208dc64eb520ff24e59ddfcbabb1ad4) haskellPackages.jack: drop now unnecessary jailbreak
* [`319e8912`](https://github.com/NixOS/nixpkgs/commit/319e89124f45c0527086400ce0f86a7fbfb4e1aa) raspberrypi-eeprom: 2022.04.26-138a1 -> 2022.12.07-138a1
* [`678b3134`](https://github.com/NixOS/nixpkgs/commit/678b3134ac37bf1c9bef398f801058b859dd938b) elmPackages.elm-format: disable checks
* [`cbd77f4e`](https://github.com/NixOS/nixpkgs/commit/cbd77f4e7455d9641ebfaad71144afef32a6beef) linuxPackages.tuxedo-keyboard: 3.0.9 -> 3.1.1
* [`126229f8`](https://github.com/NixOS/nixpkgs/commit/126229f810b8c53514f17f46082e72ec9d1f0965) llvm: disable libpfm on all non-Linux platforms
* [`6e8f32f1`](https://github.com/NixOS/nixpkgs/commit/6e8f32f140dffc818225caceb36a21a3a43a2adb) jffi: 1.3.9 -> 1.3.10
* [`ca797ba9`](https://github.com/NixOS/nixpkgs/commit/ca797ba9d2754950d6a876796d1dfc4ad2c10cba) python310Packages.ansible-compat: 2.2.5 -> 2.2.7
* [`207e2c9b`](https://github.com/NixOS/nixpkgs/commit/207e2c9b031cb2c51403850a90ea898d41cbda18) all-cabal-hashes: 2022-12-08T20:17:19Z -> 2022-12-10T08:47:27Z
* [`ba24102e`](https://github.com/NixOS/nixpkgs/commit/ba24102ee85f52ce758d864ebfa08f67fca0aede) haskellPackages: regenerate package set based on current config
* [`ef4b47f7`](https://github.com/NixOS/nixpkgs/commit/ef4b47f72569e8993ff3f76f76c155328f01a165) openboard: 1.6.1 -> unstable-2022-11-28
* [`a984b76b`](https://github.com/NixOS/nixpkgs/commit/a984b76bfd477719a1d58655f9073460d24c62ed) haskellPackages.pipes-http: allow bytestring 0.11
* [`0f5b6d94`](https://github.com/NixOS/nixpkgs/commit/0f5b6d94b4aa7becf9d93d9910bc37230bc67707) all-cabal-hashes: 2022-12-10T08:47:27Z -> 2022-12-10T20:56:02Z
* [`3bc6ac0a`](https://github.com/NixOS/nixpkgs/commit/3bc6ac0af97320e17288ba2ce7b7b34729a29f76) haskellPackages: regenerate package set based on current config
* [`a7688719`](https://github.com/NixOS/nixpkgs/commit/a768871934dd263423fca2979cedd7f5e8c7379d) nixos/nginx: validate syntax of config file at build time
* [`26a411b2`](https://github.com/NixOS/nixpkgs/commit/26a411b2cb177f88856dfbd1c85367a7647d4d61) nixos: add release notes for nginx config validation
* [`5fb20d2f`](https://github.com/NixOS/nixpkgs/commit/5fb20d2f8cad7a6332baafbb2986ac0ef16c6fc7) lib.modules: Add error context to rendered default and example attrs
* [`1a440800`](https://github.com/NixOS/nixpkgs/commit/1a44080088c3a4384da7e4529928f7a0a7b1aa4e) lib.generators.toPretty: Add attribute name to error context
* [`1e7261a2`](https://github.com/NixOS/nixpkgs/commit/1e7261a27995b0a9c938155ec6578cb01d3941fb) gonic: 0.14.0 -> 0.15.0
* [`adf4a468`](https://github.com/NixOS/nixpkgs/commit/adf4a46812b6eb3353c942fef18c9dc19414a3db) netbeans: 15 -> 16
* [`8f99f341`](https://github.com/NixOS/nixpkgs/commit/8f99f34194330846742f9fca77eb3d6295455801) nixos/opengl: cleanup suggestions for extraPackages
* [`cd05f871`](https://github.com/NixOS/nixpkgs/commit/cd05f8718a8f7a33e97a6fbe08f2c686bbeab05d) intel-media-driver: build i686 variant on hydra
* [`46f442ae`](https://github.com/NixOS/nixpkgs/commit/46f442aea52e63802fa53e08cda490c3f20ab839) haskellPackages.update-nix-fetchgit: Fix build with upstream patch
* [`9be81d0a`](https://github.com/NixOS/nixpkgs/commit/9be81d0acfd8a5ac8c6a2222255ea9665f66d511) nixos/grafana: allow @⁠chown syscalls when using unix sockets
* [`f2a5bc37`](https://github.com/NixOS/nixpkgs/commit/f2a5bc37a0d0e4d01e5ada9053fd968ec27587fe) gtkcord4: install desktop item and icons, optional libadwaita
* [`1e02d0c8`](https://github.com/NixOS/nixpkgs/commit/1e02d0c815354662792587e1637436a83e631290) all-cabal-hashes: 2022-12-10T20:56:02Z -> 2022-12-12T14:16:14Z
* [`8605595b`](https://github.com/NixOS/nixpkgs/commit/8605595bca74b15ee1dc7f264bd6ddc009e451de) haskellPackages.html-charset: fix
* [`26417865`](https://github.com/NixOS/nixpkgs/commit/264178657fd05dfdfc53fac0a3b58e9b27279588) haskell.packages.ghc902.haskell-language-server: fix
* [`9d461091`](https://github.com/NixOS/nixpkgs/commit/9d4610919e4bc2ffc311b04bdf58f3da35ac6d63) haskellPackages: regenerate hackage-packages and transitive-broken
* [`e3aea0cf`](https://github.com/NixOS/nixpkgs/commit/e3aea0cfbad4a51fb1436bfb73d1ac5eb730305c) pythonPackages.bootstrapped-pip: do not assume pip has a postPatch field
* [`cce3dc63`](https://github.com/NixOS/nixpkgs/commit/cce3dc63a02b34d61326dc155a933a91d6937ccc) rustPlatform.importCargoLock: add allowBuiltinFetchGit option
* [`4b8c218e`](https://github.com/NixOS/nixpkgs/commit/4b8c218e773478650c5c1dcc85d27f2be275d2d5) coreboot-configurator: fix exec path in desktop file
* [`a946e186`](https://github.com/NixOS/nixpkgs/commit/a946e186c571d8f542ac6d00750f2944c958aaf8) lxd: 5.8 -> 5.9
* [`45057471`](https://github.com/NixOS/nixpkgs/commit/45057471f4002574eb56549961bbb8fa1b75f193) minio: 2022-10-24T18-35-07Z -> 2022-12-12T19-27-27Z
* [`0904a516`](https://github.com/NixOS/nixpkgs/commit/0904a51639fa0677e362eb75c0402e0213b9e4fb) scala-cli: 0.1.17 -> 0.1.18
* [`e065a546`](https://github.com/NixOS/nixpkgs/commit/e065a546dde6c0bca8b472f7fcb1939cbea610cf) make me a nixpkgs maintainer
* [`4d394bfb`](https://github.com/NixOS/nixpkgs/commit/4d394bfb48e1af09369ec731eb39b6d6946d54e7) R: 4.2.1 -> 4.2.2
* [`a0b60725`](https://github.com/NixOS/nixpkgs/commit/a0b60725473c3f0646f5b6f9b1352a8d848c8b9e) nixos/grafana: add test case for socket proxy
* [`98111739`](https://github.com/NixOS/nixpkgs/commit/98111739deebf583ae1f301311fbd44f580fc45e) wine-wayland: restore hyphen to pname
* [`7ed992a3`](https://github.com/NixOS/nixpkgs/commit/7ed992a3fb95d92c4d374df393b9f5fa4abda7d3) rPackages: CRAN and BioC update
* [`4afecd32`](https://github.com/NixOS/nixpkgs/commit/4afecd32e6a1ded3a55dfd3a41cd37d72baccda0) python3Packages.twine: 4.0.1 -> 4.0.2
* [`e35ea936`](https://github.com/NixOS/nixpkgs/commit/e35ea936eed2fd6727e0ec9bd77d4d1f23efd8dc) maintainers: add indeednotjames
* [`aabe9cbc`](https://github.com/NixOS/nixpkgs/commit/aabe9cbc1b7e7af28042cd22f80f38218969622d) drone-runner-docker: 1.8.1 -> 1.8.2
* [`dc8f2294`](https://github.com/NixOS/nixpkgs/commit/dc8f22941241625de7629f997fc4e70ffdfbad06) okteto: 2.9.1 -> 2.10.2
* [`f1b32890`](https://github.com/NixOS/nixpkgs/commit/f1b328906eab50184e1548821aaecf6a4a01ef02) mongosh: 1.6.0 -> 1.6.1
* [`ee958a33`](https://github.com/NixOS/nixpkgs/commit/ee958a33f29c50345a5068a9f851729b7477ebb7) pdf-quench: fix "Namespace Gtk not available"
* [`355042e2`](https://github.com/NixOS/nixpkgs/commit/355042e2ff5933b245e804c5eaff4ec3f340e71b) broadcom_sta: fix build on linux 6.1
* [`1b6e649d`](https://github.com/NixOS/nixpkgs/commit/1b6e649d78171a1d1ed3bded95db6654fc729b3d) python310Packages.pytorch-metric-learning: 1.6.2 -> 1.6.3
* [`2411f06c`](https://github.com/NixOS/nixpkgs/commit/2411f06cfa988d01bc70d13b193771a154d9f6a5) _1password: 2.9.1 -> 2.10.0
* [`a72bee00`](https://github.com/NixOS/nixpkgs/commit/a72bee00a92a187ce0bce4fd972eeb462614a4a7) broot: 1.16.2 -> 1.17.1
* [`41299467`](https://github.com/NixOS/nixpkgs/commit/41299467cc70cb45cc414a3b885e5194bb9d6c29) gitkraken: 8.9.1 -> 9.0.0
* [`dee969ba`](https://github.com/NixOS/nixpkgs/commit/dee969ba6e1b782db3516018143adbd886c42b26) python310Packages.qutip: 4.7.0 -> 4.7.1
* [`d70098ec`](https://github.com/NixOS/nixpkgs/commit/d70098ec63b6339d877ad47594d9f518b495f616) flatpak: 1.14.0 → 1.14.1
* [`94cc90f0`](https://github.com/NixOS/nixpkgs/commit/94cc90f0d15a2d0bd7c2af20689c082df5d5b963) xdg-desktop-portal: 1.15.0 → 1.16.0
* [`b5d5d71a`](https://github.com/NixOS/nixpkgs/commit/b5d5d71a456af5f9031f24bf471d8b2f5c1c3ecd) ibus-engines.typing-booster: 2.7.5 -> 2.19.10
* [`fdb9784f`](https://github.com/NixOS/nixpkgs/commit/fdb9784f141138946224c5b3d51e0dea0aedd5b0) drone-oss: 2.15.0 -> 2.16.0
* [`14ac198b`](https://github.com/NixOS/nixpkgs/commit/14ac198bbedaae82b747e9a8535c81a3c71f1dfa) prl-tools: 18.1.0-53311 -> 18.1.1-53328
* [`e65c721d`](https://github.com/NixOS/nixpkgs/commit/e65c721dfa8e4d903367b75d4d4965773b65bb5c) waypoint: 0.10.4 -> 0.10.5
* [`e5ebe9f0`](https://github.com/NixOS/nixpkgs/commit/e5ebe9f083173737e1702a1892b16bf305465369) ktlint: 0.47.1 -> 0.48.0
* [`c953801e`](https://github.com/NixOS/nixpkgs/commit/c953801e405d5f5860f89906caa3b24b6b4f3320) cemu: 2.0-17 -> 2.0-22
* [`9273f45c`](https://github.com/NixOS/nixpkgs/commit/9273f45cd470eee7b85911d3943411f97f27e571) infracost: 0.10.14 -> 0.10.15
* [`cba9effe`](https://github.com/NixOS/nixpkgs/commit/cba9effee9712bb550211150e4413a4dc8e05db3) intel-cmt-cat: 4.4.1 -> 4.5.0
* [`9fe8c033`](https://github.com/NixOS/nixpkgs/commit/9fe8c033064370022f8190b1f6c643cf003752c2) asdf-vm: 0.10.2 -> 0.11.0
* [`e19cdbeb`](https://github.com/NixOS/nixpkgs/commit/e19cdbebc991fa1e7e3ecd00464c848066841ccd) haskell.packages.ghc902.haskell-language-server: oops
* [`754f8312`](https://github.com/NixOS/nixpkgs/commit/754f831250219b28f66810c30045be62cd1c56b3) maintainers: add rafael
* [`d1eca0bf`](https://github.com/NixOS/nixpkgs/commit/d1eca0bf6cf04326b746c60e187bc8fca753c859) ta-lib: init at 0.4.0
* [`ba294ae6`](https://github.com/NixOS/nixpkgs/commit/ba294ae64aa994c50a1b4b5dec9760fbbb1bccd3) factorio: 1.1.72 -> 1.1.74
* [`debcf570`](https://github.com/NixOS/nixpkgs/commit/debcf570c6a94fb6b6ff60e5f9ae8d90aec35ff2) nixos/no-x-libs: add msmtp
* [`da75629e`](https://github.com/NixOS/nixpkgs/commit/da75629e3451171653ff57de7125d82c42cf8a1e) msmtp: little cleanups
* [`c01a28d0`](https://github.com/NixOS/nixpkgs/commit/c01a28d0216dfa7d60cca2dfd90eb9771882241d) nixos/no-x-libs: add libextractor
* [`3d7b9b03`](https://github.com/NixOS/nixpkgs/commit/3d7b9b03568d1a9e08a08b13c9ac945bd43e8e64) libextractor: cleanup
* [`3d260d18`](https://github.com/NixOS/nixpkgs/commit/3d260d18b61bab7b7c38a51d8bb2d01ffd386403) cemu: Add updateScript
* [`95bf258d`](https://github.com/NixOS/nixpkgs/commit/95bf258d3ef9963e62b05b68693990a3b345dbb7) haskellPackages.hls-pragmas-plugin: Disable flaky test
* [`4fc62a4b`](https://github.com/NixOS/nixpkgs/commit/4fc62a4bbef9ff3c55fa72314adc3fd4fa18e5ad) haskellPackages: Regenerate hackage-packages.nix with lens-aeson_1_1_3
* [`093d158f`](https://github.com/NixOS/nixpkgs/commit/093d158f5b96338bc876ecda874fcebc3306e800) haskell.packages.ghc88.haskell-language-server: Fix build
* [`b9b319d3`](https://github.com/NixOS/nixpkgs/commit/b9b319d3480fbf11c486adf8388c5dc6f525e990) haskell.packages.ghc88.hlint: Fix build
* [`ad0d7cf9`](https://github.com/NixOS/nixpkgs/commit/ad0d7cf936cda0f4c446ec8589f8c8778d610e8c) haskell.packages.ghc810.haskell-language-server: Fix build
* [`662b1942`](https://github.com/NixOS/nixpkgs/commit/662b19424a5a14d6867d9d349319cf8872e0956e) emanote: Fix build
* [`9105bfd0`](https://github.com/NixOS/nixpkgs/commit/9105bfd039e6c19f689ae3a876c5b2978ed23836) nginx: expose ngx_http_slice_module through "withSlice"
* [`d0955299`](https://github.com/NixOS/nixpkgs/commit/d0955299dee97dd5c252bbc5810801331397e6df) lutris: avoid mount suid wrapper error in fhsenv by using none suid binary
* [`697f7383`](https://github.com/NixOS/nixpkgs/commit/697f738354e7958303cb0490a27f1562ea112068) lutris: cleanup, match attr and pname
* [`f4a0cbac`](https://github.com/NixOS/nixpkgs/commit/f4a0cbac4a0cf4c07e712a44a82d0104f3f8daa4) fioctl: 0.29 -> 0.30.1
* [`59f52095`](https://github.com/NixOS/nixpkgs/commit/59f5209593c5c27c012bab28816d3d8305f165d6) evilpixie: 0.3 -> 0.3.1
* [`cd08de82`](https://github.com/NixOS/nixpkgs/commit/cd08de8221910a46a38fad3e57d942acefa252de) update-nix-fetchgit: remove patches
* [`32d8afa7`](https://github.com/NixOS/nixpkgs/commit/32d8afa72125788ff477b84ba889d35d9d5e836f) textpieces: 3.3.0 -> 3.4.0
* [`c70f0473`](https://github.com/NixOS/nixpkgs/commit/c70f0473153c63ad1cf6fbea19f290db6b15291f) nixos/zfs: assert no force import with hibernation
* [`04cdb23c`](https://github.com/NixOS/nixpkgs/commit/04cdb23c4682f190cc8f0fbce3aa97affe702c29) _1password: 2.9.1 -> 2.11.0
* [`1f56c74b`](https://github.com/NixOS/nixpkgs/commit/1f56c74b7878ee5bf29929e0e53b6ab36c0c6b3b) xfce.libxfce4util: 4.16.0 -> 4.18.0
* [`98952621`](https://github.com/NixOS/nixpkgs/commit/98952621219e1dbe39c0cfecdea4df8fd3e56204) xfce.libxfce4ui: 4.16.1 -> 4.18.0
* [`9c6bd398`](https://github.com/NixOS/nixpkgs/commit/9c6bd398106f69980707fb9658d39bb9f9df92e9) xfce.xfce4-dev-tools: 4.16.0 -> 4.18.0
* [`3ba93dfa`](https://github.com/NixOS/nixpkgs/commit/3ba93dfa5c6c0e3802edf500231e69fe6e33402a) xfce.xfce4-panel: 4.16.5 -> 4.18.0
* [`39593bc0`](https://github.com/NixOS/nixpkgs/commit/39593bc0c3ce7f53dac4c464a686465d6b172194) xfce.xfce4-power-manager: 4.16.0 -> 4.18.0
* [`e3c321a0`](https://github.com/NixOS/nixpkgs/commit/e3c321a0d26e4327caceb82d16f2eae508e2def8) xfce.xfce4-session: 4.16.0 -> 4.18.0
* [`14724daa`](https://github.com/NixOS/nixpkgs/commit/14724daacb288a689a8f5a143745a40de35941f0) xfce.xfce4-settings: 4.16.5 -> 4.18.0
* [`7e968b1c`](https://github.com/NixOS/nixpkgs/commit/7e968b1c1063058d83a587d121cdf534a7383714) xfce.xfconf: 4.16.0 -> 4.18.0
* [`dd6c8302`](https://github.com/NixOS/nixpkgs/commit/dd6c8302444d6e8178dcd0d7af95d31a5b34aab5) xfce.xfdesktop: 4.16.1 -> 4.18.0
* [`d81262fb`](https://github.com/NixOS/nixpkgs/commit/d81262fb733698e2acc0dc2d569a6dca01dc4976) xfce.xfwm4: 4.16.1 -> 4.18.0
* [`1b845e3e`](https://github.com/NixOS/nixpkgs/commit/1b845e3e84c7153d0a154b59a7cfbf993931e3f5) xfce.thunar: 4.16.11 -> 4.18.0
* [`44e238e2`](https://github.com/NixOS/nixpkgs/commit/44e238e2fdefcc14380cde5fdb08298c8419b9fe) xfce.exo: 4.16.4 -> 4.18.0
* [`a58e6336`](https://github.com/NixOS/nixpkgs/commit/a58e63360fd1a4bec821355fe505a8ac355eb04f) xfce.garcon: 4.16.1 -> 4.18.0
* [`290c91f8`](https://github.com/NixOS/nixpkgs/commit/290c91f81d59a57368630842075ad45e4a1911d2) xfce.thunar-volman: 4.16.0 -> 4.18.0
* [`e45c6aab`](https://github.com/NixOS/nixpkgs/commit/e45c6aabec06293db734d09e13d81f15af40af05) xfce.tumbler: 4.16.1 -> 4.18.0
* [`4467a158`](https://github.com/NixOS/nixpkgs/commit/4467a1585fc80276eaf31194b9f0a5fc3c964b05) xfce.xfce4-appfinder: 4.16.1 -> 4.18.0
* [`2a79b490`](https://github.com/NixOS/nixpkgs/commit/2a79b49063d2bcaf1e1d17da0b9676e3ba72b8b0) xfce.xfce4-terminal: fix build
* [`81c12cbe`](https://github.com/NixOS/nixpkgs/commit/81c12cbec69310145425254d0cec70515a4fe796) maintainers/teams: add muscaln to xfce
* [`2c1b5c90`](https://github.com/NixOS/nixpkgs/commit/2c1b5c90eb2d00d22a84e53c39cc785baded1230) xfce.xfce4-notifyd: 0.6.4 -> 0.6.5
* [`73cc73f4`](https://github.com/NixOS/nixpkgs/commit/73cc73f41aba510ddb3a4f97e6a85c2fdfab4b8b) xfce.xfce4-taskmanager: 1.4.2 -> 1.5.5
* [`1eb5c58c`](https://github.com/NixOS/nixpkgs/commit/1eb5c58c78914a0485b656c81262f0dd6c27b970) xfce.xfce4-cpufreq-plugin: 1.2.7 -> 1.2.8
* [`8c66de8b`](https://github.com/NixOS/nixpkgs/commit/8c66de8bc64fcf102d8cd30d067a756e3bd1ab87) xfce.xfce4-cpugraph-plugin : 1.2.6 -> 1.2.7
* [`f6c0fe67`](https://github.com/NixOS/nixpkgs/commit/f6c0fe67d869b29c819bb1431f91496aa8ee93f5) xfce.xfce4-sensors-plugin: 1.4.3 -> 1.4.4
* [`47a8b1b2`](https://github.com/NixOS/nixpkgs/commit/47a8b1b2d6b49b49ffac56a89c35573086b88b72) xfce.xfce4-volumed-pulse: fix build
* [`fe93b2c4`](https://github.com/NixOS/nixpkgs/commit/fe93b2c418c994603abb480d73b7c43dabb8a43b) libva-utils: 2.15.0 -> 2.16.0
* [`0893176e`](https://github.com/NixOS/nixpkgs/commit/0893176e14865d016bd7744a5b084e8e878c6636) matrix-conduit: unbreak on darwin, remove unused inputs
* [`c9a5bf4a`](https://github.com/NixOS/nixpkgs/commit/c9a5bf4a3897f61956bf8a25b652fcf535e5e821) nixos/acme: Increase number of retries in testing
* [`af375039`](https://github.com/NixOS/nixpkgs/commit/af375039f186d3561d7dfc2a8c5add5f620a8aa4) linuxPackages.bcc: 0.25.0 -> 0.26.0
* [`98f89ba6`](https://github.com/NixOS/nixpkgs/commit/98f89ba643aadc908588acab7e897ca7d168a4ba) tutanota-desktop: 3.98.20 -> 3.105.9
* [`b19612cb`](https://github.com/NixOS/nixpkgs/commit/b19612cb24b61132d57cd1e8abeba09fdf2a5d86) nixos/services/dolibarr: decouple nginx and let other web servers be used
* [`34950865`](https://github.com/NixOS/nixpkgs/commit/34950865858fed66e16881b15ea25334300b07b4) rocksdb_lite: 7.7.3 -> 7.8.3
* [`97eabbe5`](https://github.com/NixOS/nixpkgs/commit/97eabbe5aedc86c5d344b9960cec0dc2be2b6520) vgmtools: unstable-2022-10-31 -> unstable-2022-12-03
* [`f44f4260`](https://github.com/NixOS/nixpkgs/commit/f44f4260358cea96e4c3e7ca386da5bda35a0438) arch-install-scripts: avoid using setuid wrappers
* [`bd558678`](https://github.com/NixOS/nixpkgs/commit/bd558678855676e247f7b79cdb07d1bed6088a59) intel-gmmlib: 22.3.1 -> 22.3.2
* [`088bc1c0`](https://github.com/NixOS/nixpkgs/commit/088bc1c0eafe8173b72e8c16aa044322967626bc) haskellPackages: stackage LTS 20.3 -> LTS 20.4
* [`cb3b3eb1`](https://github.com/NixOS/nixpkgs/commit/cb3b3eb19e7322acfc74603aba4ada5f184619fd) all-cabal-hashes: 2022-12-12T14:16:14Z -> 2022-12-18T02:26:05Z
* [`8e10587e`](https://github.com/NixOS/nixpkgs/commit/8e10587e9054a0c8a0667e4e56623f2004987bfb) haskellPackages: regenerate package set based on current config
* [`ad83b5e7`](https://github.com/NixOS/nixpkgs/commit/ad83b5e7c3366a21d4764a346b705e4f50bf77ed) vscode: add missing wayland runtimeDependency
* [`bd8e2231`](https://github.com/NixOS/nixpkgs/commit/bd8e2231bc534c355dbcdcada8ba04f6801a37ae) fluent-gtk-theme: init at 2022-12-15
* [`0d10cc91`](https://github.com/NixOS/nixpkgs/commit/0d10cc917530f69f636c8848c3b1127d0b75aa8a) vengi-tools: 0.0.22 -> 0.0.23
* [`caf6b766`](https://github.com/NixOS/nixpkgs/commit/caf6b766b8e76daef3e36c13c29f5438a297c1a1) maintainers: add aaqaishtyaq
* [`a6fa6abb`](https://github.com/NixOS/nixpkgs/commit/a6fa6abb15c2f55f0daf08ac2030cdc15bbc348d) nixos/man-db: use nativeBuildInputs
* [`2814d19a`](https://github.com/NixOS/nixpkgs/commit/2814d19a3f10b51a7e0606bbca925cae1953eb23) texlive.combine: move perl and texlinks to nativeBuildInputs
* [`9de2f02a`](https://github.com/NixOS/nixpkgs/commit/9de2f02af62ec9aa90202c53faf93e0ed43fc602) texlive.combine: remove unset TEXMCNF as mtxrun is already wrapped
* [`589a929b`](https://github.com/NixOS/nixpkgs/commit/589a929baea24d59e1e1384cfa90c1cfacfaff01) texlive.combine: avoid subshells
* [`bbc1e625`](https://github.com/NixOS/nixpkgs/commit/bbc1e62548a4be157e78fca71c00c4cf56640180) texlive.combine: simplify updmap linking
* [`1d37fc54`](https://github.com/NixOS/nixpkgs/commit/1d37fc5426ec13fae512a3b531c2da6b3a698fda) texlive.combine: call perl scripts directly
* [`24d0b421`](https://github.com/NixOS/nixpkgs/commit/24d0b421f92c7deecfed5cb803e5f3e9cbc7578b) texlive.combine: remove redundant call to realpath when copying epstopdf
* [`43e69f17`](https://github.com/NixOS/nixpkgs/commit/43e69f171dd844a78b4b68e757e197cb7fd675c1) texlive.combine: use absolute paths and do not cd into $out
* [`31846cf1`](https://github.com/NixOS/nixpkgs/commit/31846cf133ed5f6444432f078f09cb7c8468b813) texlive.combine: do not export redundant variables
* [`85e670d3`](https://github.com/NixOS/nixpkgs/commit/85e670d377c3aa886c4dee3573d7aed7a7576b69) texlive.combine: use environment variables where possible
* [`59fb0606`](https://github.com/NixOS/nixpkgs/commit/59fb0606d1d37a8f4dc08f2fa088706dd8df4a21) redmine: 4.2.8 -> 4.2.9
* [`fd95e78b`](https://github.com/NixOS/nixpkgs/commit/fd95e78bd2bad40386c3be7f73979c130f676aa7) matrix-conduit: add NixOS Test to passthru.tests
* [`8c1dd61c`](https://github.com/NixOS/nixpkgs/commit/8c1dd61cf884d037050f1bcce02b2c5be9d2a6dd) static-web-server: init at 2.14.1
* [`13c9d909`](https://github.com/NixOS/nixpkgs/commit/13c9d909c7d64fddbf49f37f88e162998a1f4eff) mpvScripts.inhibit_gnome: init at 0.1.3
* [`dd281101`](https://github.com/NixOS/nixpkgs/commit/dd28110140e39552eb11eeef37e0afcbd9d64bb2) python39Packages.tablib: 3.2.1 -> 3.3.0
* [`7ce807ee`](https://github.com/NixOS/nixpkgs/commit/7ce807ee2c420337f7c5744d3c034b16f7126ee7) hwloc: 2.8.0 -> 2.9.0
* [`317cb9db`](https://github.com/NixOS/nixpkgs/commit/317cb9dba3ef1986f86ccca8593719d4c043607d) hwloc: allow for optional build with CUDA
* [`0ccdbb39`](https://github.com/NixOS/nixpkgs/commit/0ccdbb399ab6562cc760d27585046b809e9068a8) epkowa: add plugin for GT-X750, Perfection 4490
* [`83f6bedd`](https://github.com/NixOS/nixpkgs/commit/83f6beddab6999712d93f4f865055be4f0d0c63f) clisp: pin to readline6 to fix the build
* [`2f39745c`](https://github.com/NixOS/nixpkgs/commit/2f39745cc482cfa31675703cf575564ffe320319) gap: 4.12.1 -> 4.12.2
* [`90500667`](https://github.com/NixOS/nixpkgs/commit/90500667a009a204f4126508b29aeef5bcb4201d) python310Packages.phonenumbers: 8.12.57 -> 8.13.2
* [`1cd6b068`](https://github.com/NixOS/nixpkgs/commit/1cd6b0681e36933ffd36d0d51f520e4f66f3440a) nixos/i3lock: i3lock program with u2fSupport option
* [`131619a3`](https://github.com/NixOS/nixpkgs/commit/131619a3978ee88b8554a32f422c8fdf38a0a197) i3lock*: symlink for u2fSupport
* [`71223d3b`](https://github.com/NixOS/nixpkgs/commit/71223d3bae2b7ab1460edfd3b826c3685d922510) python310Packages.pre-commit-hooks: add changelog to meta
* [`b4dd2e11`](https://github.com/NixOS/nixpkgs/commit/b4dd2e11c9a4a7f8c9417ea67a4f89319909af6e) python310Packages.pre-commit-hooks: 4.3.0 -> 4.4.0
* [`1336dec3`](https://github.com/NixOS/nixpkgs/commit/1336dec317f0a010df6162b415f0d1b2cce8912f) portfolio: 0.59.5 -> 0.60.0
* [`f76ec839`](https://github.com/NixOS/nixpkgs/commit/f76ec8395344718882cc94342e09b090f0c99273) python310Packages.trimesh: 3.15.8 -> 3.17.1
* [`d25cbb60`](https://github.com/NixOS/nixpkgs/commit/d25cbb609b4b352af5c910c475375dd33b6ea127) all-cabal-hashes: 2022-12-18T02:26:05Z -> 2022-12-18T22:10:13Z
* [`7187fd45`](https://github.com/NixOS/nixpkgs/commit/7187fd458d6cf8c57d0bd38ee1e777f4d4cd1b8e) haskellPackages: regenerate package set based on current config
* [`26f704b5`](https://github.com/NixOS/nixpkgs/commit/26f704b545838084e334f37d434a648c0c564ffd) treewide: use nativeBuildInputs with runCommand instead of inlining
* [`8897b523`](https://github.com/NixOS/nixpkgs/commit/8897b523311d0eabf8e6ae360b3247b65911456f) haskellPackages.implicit-hie: remove unneeded Cabal-syntax override
* [`3977aad9`](https://github.com/NixOS/nixpkgs/commit/3977aad964d4525224047fe68530311766cdbb2f) flyctl: 0.0.440 -> 0.0.441
* [`5d40eaa6`](https://github.com/NixOS/nixpkgs/commit/5d40eaa66fec25b00acb333215a1d2991bc0f0da) haskell.packages.ghc943.implicit-hie: remove unneeded Cabal-syntax override
* [`0a319cbd`](https://github.com/NixOS/nixpkgs/commit/0a319cbdc24d011245dc0f4c70b49d4e77002337) nixops-hetznercloud: init at 0.1.2
* [`901a78b6`](https://github.com/NixOS/nixpkgs/commit/901a78b6ad93472619d8079f7ab5ce827c5c5baf) gkraken: Fix wrapping
* [`c92ffdd2`](https://github.com/NixOS/nixpkgs/commit/c92ffdd222ab8c10966c46970b163144228e7fb5) labwc: 0.5.3 -> 0.6.0
* [`799eba97`](https://github.com/NixOS/nixpkgs/commit/799eba97dd98ad56ba8a97860a0b5aa2dfd9ffbc) iosevka-bin: 16.7.0 -> 16.8.2
* [`8fb83fa6`](https://github.com/NixOS/nixpkgs/commit/8fb83fa6e7e8a80b71aeabb268b8a373f3f95084) lightning: 2.1.3 -> 2.2.0
* [`bb31220c`](https://github.com/NixOS/nixpkgs/commit/bb31220cca6d044baa6dc2715b07497a2a7c4bc7) nimPackages.c2nim: 0.9.18 -> 0.9.19
* [`eab19784`](https://github.com/NixOS/nixpkgs/commit/eab197845fbc9849b97a4957cc7ffee55e9436ea) appthreat-depscan: 3.5.0 -> 3.5.3
* [`39938dac`](https://github.com/NixOS/nixpkgs/commit/39938dacb3bf66d3ec460337dc2700a21b8271a3) grpc: expose cxxStandard
* [`6b15d096`](https://github.com/NixOS/nixpkgs/commit/6b15d096d7e4362679b3c2debfffa014643bb506) google-cloud-cpp: inherit cxxStandard from grpc
* [`6f2d0134`](https://github.com/NixOS/nixpkgs/commit/6f2d0134d154897f3888792533cccd6ea87d7fc9) arrow-cpp: inherit cxxStandard from grpc
* [`30f98b9c`](https://github.com/NixOS/nixpkgs/commit/30f98b9cf0d33155c3789241b3b4df85ab13a53b) jira-cli-go: 1.1.0 -> 1.2.0
* [`f26977c5`](https://github.com/NixOS/nixpkgs/commit/f26977c50d4675a73e09f25ab439376bb89a6ff1) lightning: mark as broken on Darwin
* [`e3fbf880`](https://github.com/NixOS/nixpkgs/commit/e3fbf88004b6573011a0ab1bb32936ece76ec092) awscli2: 2.9.6 -> 2.9.8
* [`6f8a0e61`](https://github.com/NixOS/nixpkgs/commit/6f8a0e61204431e58c96feaf1405ea4756ca0657) python310Packages.awscrt: 0.15.1 -> 0.16.1
* [`3350d422`](https://github.com/NixOS/nixpkgs/commit/3350d422445fab17d302caa912d909ad947e2849) prismlauncher: use jdk17 instead of jdk
* [`33ec7bf5`](https://github.com/NixOS/nixpkgs/commit/33ec7bf54fcfc506353ad877273ea857c172c4df) airshipper: 0.7.0 -> 0.10.0 https://gitlab.com/veloren/airshipper/-/blob/v0.10.0/CHANGELOG.md
* [`3eda3c20`](https://github.com/NixOS/nixpkgs/commit/3eda3c20117af54ab65f2ea6f1408aa672769591) slack: add wayland dependency
* [`c8c538f2`](https://github.com/NixOS/nixpkgs/commit/c8c538f2ab2432f2dd1eb637657c1bf5b54a147f) lib/types: remove loaOf
* [`7f2d5f36`](https://github.com/NixOS/nixpkgs/commit/7f2d5f369ce7a386c51c505dc08e21a8e94255f4) openresty: 1.19.9 -> 1.21.4
* [`a7f34992`](https://github.com/NixOS/nixpkgs/commit/a7f34992d54982d2ee7951b99b6218dd9f012a95) nginxModules: make single packages overridable
* [`c2b2f29d`](https://github.com/NixOS/nixpkgs/commit/c2b2f29d2b96b9d9bde49f522c4cb9b9a06f4adb) nginxModules.pagespeed: cleanup
* [`0e25cc73`](https://github.com/NixOS/nixpkgs/commit/0e25cc73c831e8af11b72aa6a84f99ef21dd4de7) nginxModules.lua: 0.10.15 -> 0.10.22
* [`b33ee831`](https://github.com/NixOS/nixpkgs/commit/b33ee831d3032014d2277a4902e41d67fe599fa3) build-support: order comments above corresponding line
* [`74adcac5`](https://github.com/NixOS/nixpkgs/commit/74adcac57c6bac86e9ac10fce02e6f28c61ea608) python310Packages.aiolifx-themes: 0.3.0 -> 0.4.0
* [`acbe5771`](https://github.com/NixOS/nixpkgs/commit/acbe577109cadefae67cc5aac89ea233453d8091) python310Packages.types-python-dateutil: 2.8.19.4 -> 2.8.19.5
* [`435b8a6d`](https://github.com/NixOS/nixpkgs/commit/435b8a6d639d54c95994d3e12d0d7739ed679320) python310Packages.types-pytz: 2022.6.0.1 -> 2022.7.0.0
* [`49836f4b`](https://github.com/NixOS/nixpkgs/commit/49836f4b8df454f6cca4d290cb8ee5611959134c) python310Packages.types-redis: 4.3.21.3 -> 4.3.21.6
* [`0e23c91f`](https://github.com/NixOS/nixpkgs/commit/0e23c91f087f0eac1df01c27b289749ce31a8e88) python310Packages.types-typed-ast: 1.5.8.1 -> 1.5.8.3
* [`2198c022`](https://github.com/NixOS/nixpkgs/commit/2198c022f828e821d493fdd5402b8299fcc71356) gitlab: 15.6.1 -> 15.6.2
* [`8aeaaac2`](https://github.com/NixOS/nixpkgs/commit/8aeaaac2390963b30098cbe0258b4ddcdd4331c1) gitlab: workaround: remove attr_encrypted gem from rubyEnv
* [`f7089f73`](https://github.com/NixOS/nixpkgs/commit/f7089f73c09b3834a9998893c7e60789fae80b26) python310Packages.yfinance: add changelog to meta
* [`3c5393bf`](https://github.com/NixOS/nixpkgs/commit/3c5393bfdb7e5c826b1cc4d2a2bc66849dcc7919) python310Packages.yfinance: 0.1.77 -> 0.1.80
* [`62ab4cee`](https://github.com/NixOS/nixpkgs/commit/62ab4ceea4e378b8a2f7267f4e68d4497ecec30c) python310Packages.yfinance: 0.1.80 -> 0.1.82
* [`e556617f`](https://github.com/NixOS/nixpkgs/commit/e556617f917628d63c4d53bdcec517273bacb493) python310Packages.yfinance: 0.1.82 -> 0.1.83
* [`b64b52c0`](https://github.com/NixOS/nixpkgs/commit/b64b52c0076356fcd34250118e24d73887d3a06d) python310Packages.yfinance: 0.1.83 -> 0.1.85
* [`4fdaf109`](https://github.com/NixOS/nixpkgs/commit/4fdaf1097ec0ed92b58658e8451744349c20b4fa) python310Packages.yfinance: 0.1.85 -> 0.1.86
* [`9c27ba31`](https://github.com/NixOS/nixpkgs/commit/9c27ba3135c87304f852f62423819e130697a914) python310Packages.yfinance: 0.1.86 -> 0.1.89
* [`b3c7a238`](https://github.com/NixOS/nixpkgs/commit/b3c7a238dd25be674c9f79d69422003f64499c10) python310Packages.yfinance: 0.1.89 -> 0.1.90
* [`89dc2434`](https://github.com/NixOS/nixpkgs/commit/89dc2434b47bd63e39e4c37b1aecfc0738f97bc4) python310Packages.yfinance: 0.1.90 -> 0.1.91
* [`3f74b2b6`](https://github.com/NixOS/nixpkgs/commit/3f74b2b67e471a5c4e63b775a43b54bc79acc11f) python310Packages.yfinance: 0.1.91 -> 0.1.92
* [`36da2f61`](https://github.com/NixOS/nixpkgs/commit/36da2f615f1273a03fa6334250fb91400070b547) python310Packages.yfinance: 0.1.92 -> 0.1.93
* [`41456d91`](https://github.com/NixOS/nixpkgs/commit/41456d91188621c2fbd9bb3b6f3fdda25d5e626a) python310Packages.tweepy: add changelog to meta
* [`5b7c3a32`](https://github.com/NixOS/nixpkgs/commit/5b7c3a327082edd8f4ecfcb3cd94888fe17ae6b0) python310Packages.tweepy: 4.12.0 -> 4.12.1
* [`e4dc6cb9`](https://github.com/NixOS/nixpkgs/commit/e4dc6cb94ab678fd87a4404a0cacbac65e4c53ec) python310Packages.python-engineio: add changelog to meta
* [`24c01b4d`](https://github.com/NixOS/nixpkgs/commit/24c01b4df59ae6d557911138bd63d82b97a64fe0) python310Packages.python-socketio: add changelog to meta
* [`9cf8875a`](https://github.com/NixOS/nixpkgs/commit/9cf8875ab07d387d053487e79bdcf3f97146a4e5) python39Packages.tpm2-pytss: 1.2.0 -> 2.0.0
* [`fba6c4a9`](https://github.com/NixOS/nixpkgs/commit/fba6c4a986e73eedcfc247bc4fdc1ff9ee5e5999) python310Packages.python-socketio: 5.7.1 -> 5.7.2
* [`d03e4fe4`](https://github.com/NixOS/nixpkgs/commit/d03e4fe4d510aae83f02a3269473bce669edffe4) ocamlPackages.xenstore_transport: minor cleaning
* [`0a95411b`](https://github.com/NixOS/nixpkgs/commit/0a95411b713688133b0227363fce49de48f32313) ocamlPackages.xenstore: 2.1.1 → 2.2.0
* [`07589a63`](https://github.com/NixOS/nixpkgs/commit/07589a631c1556399c55bff3d651ad682a0747da) python310Packages.tpm2-pytss: add changelog to meta
* [`9c8472b0`](https://github.com/NixOS/nixpkgs/commit/9c8472b021cb2018a0790d2b98d557d217276531) python310Packages.ripe-atlas-cousteau: add changelog to meta
* [`38ddf5a4`](https://github.com/NixOS/nixpkgs/commit/38ddf5a423de63c14b9816bc6a28c055d908edbd) python310Packages.ripe-atlas-cousteau: adjust python-socketio input
* [`65ffdcab`](https://github.com/NixOS/nixpkgs/commit/65ffdcabee71be34b0782b7f7281a7f5cef981dc) neuron-notes: Remove
* [`465f0b48`](https://github.com/NixOS/nixpkgs/commit/465f0b483785d14e8760a38ca2fe1abcfa41e0e5) haskellPackages.reflex-dom: Fix build
* [`cb93ebae`](https://github.com/NixOS/nixpkgs/commit/cb93ebaeec23e0f4814667a6e1c956bb0db08783) retroarch-assets: init at unstable-2022-10-24
* [`189fa87e`](https://github.com/NixOS/nixpkgs/commit/189fa87ed29d6e08dd942d8b884f78d5da7c863c) haskellPackages.bloomfilter: patch for GHC >= 9.2
* [`4a6483ea`](https://github.com/NixOS/nixpkgs/commit/4a6483eace57eac63c2234815a64182d89830d79) git-annex: update sha256 for 10.20221212
* [`1b930e7a`](https://github.com/NixOS/nixpkgs/commit/1b930e7ad8fd67c0f85e29055dd445d2f0809907) srsran: 22.04.1 -> 22.10
* [`7503cafe`](https://github.com/NixOS/nixpkgs/commit/7503cafe0022e151f02517b9cb7c74d1ae4b0469) python39Packages.tabula-py: 2.5.1 -> 2.6.0
* [`4a120995`](https://github.com/NixOS/nixpkgs/commit/4a1209950345f255cb725229990fd79492c72ed4) enlightenment.terminology: 1.12.1 -> 1.13.0
* [`016553e5`](https://github.com/NixOS/nixpkgs/commit/016553e5c3b499f0d04b5f63ef41b1eba7d24a36) duplicacy: 3.0.1 -> 3.1.0
* [`a9e3b1c0`](https://github.com/NixOS/nixpkgs/commit/a9e3b1c0f2761e0adf7c46ac8b65e5e55f52c967) nixos/usbmuxd: Ability to change package
* [`aa92b04c`](https://github.com/NixOS/nixpkgs/commit/aa92b04cacaab8ac7105d1c2225e427b07797e68) uniffi-bindgen: 0.21.0 -> 0.22.0
* [`e37ef84b`](https://github.com/NixOS/nixpkgs/commit/e37ef84b478fa8da0ced96522adfd956fde9047a) sbt-extras: 2022-10-17 -> 2022-11-11 ([nixos/nixpkgs⁠#199112](https://togithub.com/nixos/nixpkgs/issues/199112))
* [`727e715e`](https://github.com/NixOS/nixpkgs/commit/727e715e1cd515aee5fecc3ac6ae831068c75241) synology-drive-client: 3.1.0-12923 -> 3.2.0-13258
* [`2c8f296b`](https://github.com/NixOS/nixpkgs/commit/2c8f296b3795c91e6bb983fbcfb492e550d0bcf3) python310Packages.versioneer: add changelog to meta
* [`04ebf457`](https://github.com/NixOS/nixpkgs/commit/04ebf457aecb4711666de3fdb53d46c7659de325) python310Packages.versioneer: 0.26 -> 0.27
* [`08a508da`](https://github.com/NixOS/nixpkgs/commit/08a508da5d1b07daa7dca2ac0794715c6dccae59) python310Packages.versioneer: 0.27 -> 0.28
* [`16e4fc2b`](https://github.com/NixOS/nixpkgs/commit/16e4fc2b25cf9df1fe009d7c3547e6a9a9a9ecf0) pyparsing: refactor
* [`ff17e998`](https://github.com/NixOS/nixpkgs/commit/ff17e9982d84ac30855d838d277816f60b9b663f) pulumiPackages.pulumi-language-nodejs: 3.47.0 -> 3.49.0
* [`247defe5`](https://github.com/NixOS/nixpkgs/commit/247defe5990e4613bcecc542180abf57e40d7a15) linux-firmware: 20221109 -> 20221214
* [`4ce47012`](https://github.com/NixOS/nixpkgs/commit/4ce47012a6f5f6c1c65f370fd06d33a81c2df332) nixos/nix-ld: set NIX_LD by default
* [`aa65dd12`](https://github.com/NixOS/nixpkgs/commit/aa65dd1225b268a0ed3631b20c812aea16c18d37) nix-ld: 1.0.2 -> 1.0.3
* [`3fca3bc7`](https://github.com/NixOS/nixpkgs/commit/3fca3bc7e7797de58cfc4a0f207e417e747c53ea) python310Packages.w3lib: add changelog to meta
* [`6ec77211`](https://github.com/NixOS/nixpkgs/commit/6ec77211c7e40a362079f58486861be3b3b839f1) python310Packages.w3lib: 2.0.1 -> 2.1.1
* [`35d24b51`](https://github.com/NixOS/nixpkgs/commit/35d24b51f536cf3ead96b284e862ef8d9fe47edc) makeHardcodeGsettingsPatch: Rename from glib.mkHardcodeGsettingsPatch
* [`3ff39f98`](https://github.com/NixOS/nixpkgs/commit/3ff39f984faa5f528f7ac5e548110d4e20327aa1) supabase-cli: init at 1.27.0
* [`98e84e79`](https://github.com/NixOS/nixpkgs/commit/98e84e79a97155cf748cbca8d1abbd56038c11f9) makeHardcodeGsettingsPatch: Add simple tests
* [`4346dee4`](https://github.com/NixOS/nixpkgs/commit/4346dee4243e2f3b900b710cf800a1ee7309d2b1) makeHardcodeGsettingsPatch: Support other constructors
* [`9f7f6fdc`](https://github.com/NixOS/nixpkgs/commit/9f7f6fdcb9646bb5018f2c11636d1fc317ee7e17) arc-theme: 20220405 -> 20221218
* [`69e8c713`](https://github.com/NixOS/nixpkgs/commit/69e8c7131da2d8642a3481ce3bff87ce4161161a) gitlab-runner: 15.5.1 -> 15.7.1
* [`92cdce93`](https://github.com/NixOS/nixpkgs/commit/92cdce932696e0138554920c1c24330fd7befc8d) prismlauncher: 6.0 -> 6.1
* [`d3c6ea9d`](https://github.com/NixOS/nixpkgs/commit/d3c6ea9d46c389109dc6e1f96302886ac226edd4) greetd: use service-type 'idle' in systemd-service to avoid overlapping systemd-output
* [`77b9f3da`](https://github.com/NixOS/nixpkgs/commit/77b9f3da7ca9123d840c21a170853408779ce97a) ruff: 0.0.186 -> 0.0.188
* [`87562534`](https://github.com/NixOS/nixpkgs/commit/87562534e466037e983a32cb327e2a2ace431d37) felix-fm: 2.2.1 -> 2.2.2
* [`a05100b1`](https://github.com/NixOS/nixpkgs/commit/a05100b1c9ca9d854b923f2579b71877130e3a5b) difftastic: 0.38.0 -> 0.39.0
* [`bfb61b58`](https://github.com/NixOS/nixpkgs/commit/bfb61b580964d96c537739ef01a245f71e6eef27) scraper: 0.13.0 -> 0.14.0
* [`d0be85dd`](https://github.com/NixOS/nixpkgs/commit/d0be85dd11eb919bedd912d7125767dfbfa728be) imagemagick: 7.1.0-54 -> 7.1.0-55
* [`d994daba`](https://github.com/NixOS/nixpkgs/commit/d994dabacef6a7e13a41d144cd6d800f8e21a11f) treewide: remove git-and-tools directory
* [`8ea4892e`](https://github.com/NixOS/nixpkgs/commit/8ea4892e392b2ed176ca1de127e86be9dbfedf76) tio: 2.4 -> 2.5
* [`36f2ac48`](https://github.com/NixOS/nixpkgs/commit/36f2ac4895e857ad69096ec10a2c41e572ed3412) dumb-init: fix musl
* [`ffc203e4`](https://github.com/NixOS/nixpkgs/commit/ffc203e4ba7cd61aaf8a0722d4a0c276494d06c5) python310Packages.scrapy: disable failing tests
* [`2c1e43dd`](https://github.com/NixOS/nixpkgs/commit/2c1e43dd752b4d42d6a468009a57b883ee0418f4) {libqalculate, qalculate-gtk, qalculate-qt}: 4.4.0 -> 4.5.0
* [`c8cee0bf`](https://github.com/NixOS/nixpkgs/commit/c8cee0bfe9fa7ae03702bbc227bfa0c6d7136f57) usql: 0.13.1 -> 0.13.3
* [`3fdb6c5a`](https://github.com/NixOS/nixpkgs/commit/3fdb6c5a9010690eb4c2676dcc40693094de590d) dotnetCorePackages: move systemToDotnetRid out of sdk
* [`06e4d899`](https://github.com/NixOS/nixpkgs/commit/06e4d89943603a309db2d5fe07ff2abf59edc8f5) build-dotnet-module: strip --runtime flags without using rid
* [`507eff88`](https://github.com/NixOS/nixpkgs/commit/507eff880d1f07988dbff228306a2eadceac4c10) build-dotnet: make passthru.packages a derivation
* [`f6cb288f`](https://github.com/NixOS/nixpkgs/commit/f6cb288fff50c4bab872f5be76d99cf3ce99eadc) omnisharp-roslyn: set runtime flag instead of patching project
* [`62ecb39a`](https://github.com/NixOS/nixpkgs/commit/62ecb39a1f9a58e0dc4bbaaec84968dc552b80c2) buildDotnetModule: run tests on projectFile if testProjectFile is unset
* [`4c861dd2`](https://github.com/NixOS/nixpkgs/commit/4c861dd26c1681fdd4fbcf4d31b5652695086c73) build-dotnet-module: add useAppHost parameter so it can be disabled
* [`858da95d`](https://github.com/NixOS/nixpkgs/commit/858da95dc011544f2901c9bfc965dad8c979cb4a) github-runner: use fake HOME in dependency fetcher
* [`13861970`](https://github.com/NixOS/nixpkgs/commit/13861970f4ae8d029d6609ece5c31200233d49f4) treewide: update all dotnet lockfiles
* [`824d40aa`](https://github.com/NixOS/nixpkgs/commit/824d40aa0400e547c07c054ed7eddcf42b68955e) build-dotnet-module: restore for current runtime by default
* [`627cbab3`](https://github.com/NixOS/nixpkgs/commit/627cbab3f4ef8c784335d79999bdfadfba015f9a) dotnet: add windows RIDs to systemToDotnetRid
* [`265690e3`](https://github.com/NixOS/nixpkgs/commit/265690e33554b2d22236b3a4f90c4fee228dd40c) gfxreconstruct: init at 0.9.15
* [`b8ea64d6`](https://github.com/NixOS/nixpkgs/commit/b8ea64d6acb1f0c6e32b1d2268558355a053032e) openrct2: 0.4.2 -> 0.4.3
* [`6f172932`](https://github.com/NixOS/nixpkgs/commit/6f1729326aca6faadfb3e8f6e574e6d86c995808) resholve: 0.8.3 -> 0.8.4
* [`1b8b20bf`](https://github.com/NixOS/nixpkgs/commit/1b8b20bfc0bed52cbdc3e8712d0ce587e3d98cb0) postgresqlPackages.timescaledb: 2.8.1 -> 2.9.0
* [`6ecf1403`](https://github.com/NixOS/nixpkgs/commit/6ecf1403e3bf8a87872dc253a075caceed24f091) rtl88x2bu: 2022-08-18 -> 2022-12-17
* [`c546c682`](https://github.com/NixOS/nixpkgs/commit/c546c68212d1711db42c5c90f924dd71b4ec83ca) snapper: 0.10.3 -> 0.10.4
* [`4f87a148`](https://github.com/NixOS/nixpkgs/commit/4f87a14804dd1a721cd1919d5782b4f69f496487) python310Packages.casbin: add changelog to meta
* [`05bbf2aa`](https://github.com/NixOS/nixpkgs/commit/05bbf2aa964efee21a576692fd4ac5e2b2e74a6c) python310Packages.casbin: 1.17.4 -> 1.17.5
* [`7609d9d9`](https://github.com/NixOS/nixpkgs/commit/7609d9d94b3b548b2856c7f680587d69f6ef9370) python310Packages.hahomematic: 2022.12.4 -> 2022.12.5
* [`17d75b32`](https://github.com/NixOS/nixpkgs/commit/17d75b320568f2ba227226da093bc5a9e95ef0d5) python310Packages.hahomematic: 2022.12.5 -> 2022.12.6
* [`50c3204e`](https://github.com/NixOS/nixpkgs/commit/50c3204e89da2d8e6be8316b0c82b0a91a507d56) maintainers: add Math-42
* [`0c28043e`](https://github.com/NixOS/nixpkgs/commit/0c28043e1903844225de33d8a04ae635b78260af) tut: 1.0.25 -> 1.0.26
* [`083debc2`](https://github.com/NixOS/nixpkgs/commit/083debc290b445884184b1dfc4c2e87360cc405c) open-pdf-sign: init at 0.1.0
* [`d410c735`](https://github.com/NixOS/nixpkgs/commit/d410c735927364efcc3f0d2106a8e7976ae4344e) tcsh: 6.24.00 -> 6.24.06
* [`63754031`](https://github.com/NixOS/nixpkgs/commit/63754031ca7ce6193c05f6a69205ba03c834c835) vscode-fhs: allow editing /etc/nixos
* [`3c346b0d`](https://github.com/NixOS/nixpkgs/commit/3c346b0d323570cb9988fd03a8c4f515160c3344) vimPlugins: add glacambre/firenvim
* [`813a0ef8`](https://github.com/NixOS/nixpkgs/commit/813a0ef8093292454c2c702eab754117c0941bcd) lighthouse: fix validator service not setting arguments properly
* [`726ab86a`](https://github.com/NixOS/nixpkgs/commit/726ab86a09d222e520bab20082d8a8a2ee9a9202) python310Packages.lupupy: 0.2.3 -> 0.2.4
* [`0cf56dad`](https://github.com/NixOS/nixpkgs/commit/0cf56dad9ef9c554bf0760a6e0581086d64d2515) haskellPackages.iCalendar: Fix build
* [`ecafd2ac`](https://github.com/NixOS/nixpkgs/commit/ecafd2ac274fa4f7991643a06adb66763ccc2adc) vimPlugins: update
* [`21871569`](https://github.com/NixOS/nixpkgs/commit/218715695d5e48cd4bf4b946530eb19c8052e474) vimPlugins: update
* [`c07b83d3`](https://github.com/NixOS/nixpkgs/commit/c07b83d35cc3690ec85f119182eed0005d6c016c) vimPlugins.ChatGPT-nvim: init at 2022-12-19
* [`e247ae0b`](https://github.com/NixOS/nixpkgs/commit/e247ae0b9f5b2f7de49f731456dcaa0c218b771d) vimPlugins.nvim-treesitter: update grammars
* [`db01e7b2`](https://github.com/NixOS/nixpkgs/commit/db01e7b2207e0de45d9c346036f22322495ab249) grap: init at 1.3.1 ([nixos/nixpkgs⁠#114129](https://togithub.com/nixos/nixpkgs/issues/114129))
* [`80229b0f`](https://github.com/NixOS/nixpkgs/commit/80229b0f42953e880bbfa1c043e42dd1a6bf37e7) python39Packages.tabula-py: add changelog to meta
* [`cf339f3d`](https://github.com/NixOS/nixpkgs/commit/cf339f3d1446df83a8cedf3fda0c225ea997e162) vtk_9: propagate libX11 and libGL on Linux
* [`07e9140c`](https://github.com/NixOS/nixpkgs/commit/07e9140c54d290ae566094c7bc468db04cc0b401) python310Packages.atenpdu: 0.3.6 -> 0.4.0
* [`d579742a`](https://github.com/NixOS/nixpkgs/commit/d579742a476498ad12160808106692ac8254dc09) all-packages.nix: small reorder
* [`adb83363`](https://github.com/NixOS/nixpkgs/commit/adb83363009dcc8f93bcfa684f7dd978f89bda7a) git-branchstack: init at 0.2.0
* [`669f0193`](https://github.com/NixOS/nixpkgs/commit/669f0193790fe08dd1f974fbf331fd0dda31f708) npmHooks.npmConfigHook: make diagnostic match prefetch-npm-deps
* [`86538706`](https://github.com/NixOS/nixpkgs/commit/865387061ffe924e1536a959f1e995903d468894) npmHooks.npmBuildHook: fix diagnostic
* [`3472d757`](https://github.com/NixOS/nixpkgs/commit/3472d757747b9452dcb0110926141d0e2f738152) add edrex to maintainers list
* [`8ef43c6c`](https://github.com/NixOS/nixpkgs/commit/8ef43c6cf9adfc53bc981f15977263d9af4f3b7f) lswt: init at 1.0.4
* [`b2c37012`](https://github.com/NixOS/nixpkgs/commit/b2c370128e06261e996abbf1e8e9d3bf5dc2fc09) sq: 0.15.11 -> 0.16.0
* [`6a08bcf1`](https://github.com/NixOS/nixpkgs/commit/6a08bcf1d5a58a528b1b9a00c99ed7a49fc2fbef) haskell-modules/configuration-common.nix: Bring fetchpatch2 into scope
* [`50da2249`](https://github.com/NixOS/nixpkgs/commit/50da22497914903fd0b01ff247fe59556bd5aefc) hercules-ci-agent: Patch for cachix 1.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
