### PR TITLE
niv devenv: update 27f49091 -> 3a0dbd2d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "27f490910057a989ecac0851c5d3085bcebe1093",
-        "sha256": "008zn1z6wyka7yxyi2wbycmw81pxnh7m2bykzgalwli4f6rd5pg7",
+        "rev": "3a0dbd2d209b6e3730e51b675e9069bd68f4f662",
+        "sha256": "0f2f4w3akr4bqznc3d3nsiqaalrxq0ixcbwnfd95s8dw1iq0i502",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/27f490910057a989ecac0851c5d3085bcebe1093.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/3a0dbd2d209b6e3730e51b675e9069bd68f4f662.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@27f49091...3a0dbd2d](https://github.com/cachix/devenv/compare/27f490910057a989ecac0851c5d3085bcebe1093...3a0dbd2d209b6e3730e51b675e9069bd68f4f662)

* [`8696634a`](https://github.com/cachix/devenv/commit/8696634a2e2559b17564c9da8c1bcda3db8bad94) Revert "Revert "Merge pull request [cachix/devenv⁠#105](https://togithub.com/cachix/devenv/issues/105) from thenonameguy/naked-shell""
* [`16411242`](https://github.com/cachix/devenv/commit/16411242a5ec3daa953fc6d7e2e1468b9d26dabf) Add common env vars to mkNakedShell
* [`218514a9`](https://github.com/cachix/devenv/commit/218514a9f9c184106e009a320afeb4f1406cbe99) Fix indentation
* [`dbc9b17c`](https://github.com/cachix/devenv/commit/dbc9b17c93cc4fb50e7b5624787b70918d0f4087) Update flake.lock
* [`f55b6479`](https://github.com/cachix/devenv/commit/f55b64796427901f8ecf20b5ba71f61dd9e3436d) Add services.postgres.initialDatabases option
* [`2030aaf6`](https://github.com/cachix/devenv/commit/2030aaf6c61d9c731e9ef143baf91c86ac625d7d) Use nix-direnv in flake template for maximum speed
* [`63074e6a`](https://github.com/cachix/devenv/commit/63074e6a6c73f73ca7ff9db5e0cc25c9eb93e576) Include devenv package in flake usage scenario, fix template
* [`f7b5e925`](https://github.com/cachix/devenv/commit/f7b5e925cfd700a56854a3f1a9c67c8ae2f5461b) Use pg_isready on DB that always exists
* [`cebf544c`](https://github.com/cachix/devenv/commit/cebf544c646b9bc843b1b3f485a1273e0a12490c) add docs about $DEVENV_PROFILE
* [`a5a304f6`](https://github.com/cachix/devenv/commit/a5a304f69a720d9655222223fbdc590b537197fd) Include all package outputs by default in profile
* [`0a1333b2`](https://github.com/cachix/devenv/commit/0a1333b2b341d7294eebd2ee4561436c890f7fcf) Optionally depend on nix-direnv hint users about #speed
* [`d2947ee5`](https://github.com/cachix/devenv/commit/d2947ee53e89394c7f88caabc11f6d42aa4c7392) Fix postgres readiness probe
* [`ccee09d3`](https://github.com/cachix/devenv/commit/ccee09d30ff456a66610b146968849e91c34a84e) Update process-compose example to use new packages flattening
* [`4717da80`](https://github.com/cachix/devenv/commit/4717da802b1868318ab60758c244c4b37774f426) Automatically install nix-direnv, fixes [cachix/devenv⁠#133](https://togithub.com/cachix/devenv/issues/133)
* [`63f7e518`](https://github.com/cachix/devenv/commit/63f7e518b93bf2ca0fc1d4e0889cf9d08a5e3bf9) add starship integration
* [`b58ce83b`](https://github.com/cachix/devenv/commit/b58ce83b3da7347f2418853e9a6b967b2f390994) Double dot
* [`3664872c`](https://github.com/cachix/devenv/commit/3664872cdc530d7adce7cb5e2e2196857870d1a1) Auto generate docs/reference/options.md
* [`9663bd3e`](https://github.com/cachix/devenv/commit/9663bd3e0ff8c7c748d5101fc75bbdffcf873aa5) Support `devenv search` over options.
* [`d66960d0`](https://github.com/cachix/devenv/commit/d66960d08df6adf30892913a7fb4e507489beb47) Auto generate docs/reference/options.md
* [`b22e0ca8`](https://github.com/cachix/devenv/commit/b22e0ca8c8d39895cc4eabce6c2985e916b33948) bump nix
* [`d475a313`](https://github.com/cachix/devenv/commit/d475a31302c3f7790bdfeff6adf3417e80d317d5) doc fixes
* [`2fcef1f1`](https://github.com/cachix/devenv/commit/2fcef1f1626ff2703b84891450caa61a49b6d67f) Auto generate docs/reference/options.md
* [`7d0a948a`](https://github.com/cachix/devenv/commit/7d0a948a979078043c328227b13e587f9006e63a) mysql: fix missing coreutils
* [`e2f25192`](https://github.com/cachix/devenv/commit/e2f251923488385e6a906d038b5ecedbcb65043c) mysql: fix ensure users, database for mariadb
* [`a21e0731`](https://github.com/cachix/devenv/commit/a21e073100e56a9aa511f72492e3fa9b3ede27db) rust: feature parity with fenix
* [`25fe8649`](https://github.com/cachix/devenv/commit/25fe8649b095f7746d6885cea591860900d393e9) rust: overridable fenix packages
* [`d535e206`](https://github.com/cachix/devenv/commit/d535e206bb403a148f173c2597608dac059eb348) rust: configurable rust-src
* [`bd1659f4`](https://github.com/cachix/devenv/commit/bd1659f4ece25af9c33976e19966e4686d768f02) Auto generate docs/reference/options.md
* [`e2e00488`](https://github.com/cachix/devenv/commit/e2e004886fa28edbbf9908f838391576e9e8e7d8) python: set PYTHONPATH
* [`72732b4f`](https://github.com/cachix/devenv/commit/72732b4f820dea21cc013181d78375e0fde3c2a7) devenv 0.5
* [`ba6818f4`](https://github.com/cachix/devenv/commit/ba6818f4c39fd95aebdb6dc441401f2b60484652) v0.5
* [`aa902f05`](https://github.com/cachix/devenv/commit/aa902f059430797197b0dceedcd7d070834c576d) Auto generate docs/reference/options.md
* [`ea7de664`](https://github.com/cachix/devenv/commit/ea7de664e8f1166930da205af577d0dd67c49579) Fix typo
* [`88afd0d5`](https://github.com/cachix/devenv/commit/88afd0d5423cabd1e2937ae26e8f6a3aed80b484) Auto generate docs/reference/options.md
* [`44ff4de7`](https://github.com/cachix/devenv/commit/44ff4de7d66c4bc99854dc1eaaf08036be0ff28f) Color `(devenv)` in PS1 blue
* [`b18d01c7`](https://github.com/cachix/devenv/commit/b18d01c7df5d4442b8eb13248409fd449c6f5c71) packages: update output
* [`56d2851d`](https://github.com/cachix/devenv/commit/56d2851db266720b787945c3911bdb84c45f8f64) ruby: do not depend on host make, setup $RUBYLIB
* [`9a996cd4`](https://github.com/cachix/devenv/commit/9a996cd42cb3e07cca29c1ec736057a00f607af3) docs: contributing guide
* [`a921d8b0`](https://github.com/cachix/devenv/commit/a921d8b040068dd6a8e06babbc14c6bb4d74434b) Use word recommended for cachix
* [`ca56a5a7`](https://github.com/cachix/devenv/commit/ca56a5a7ae0474bd2775f855c1ddb8ba87584183) Allow adding derivations directly to packages
* [`cdda9822`](https://github.com/cachix/devenv/commit/cdda98220df27ca5fa865ac8d3c4b8b91d5d677a) Add languages.ruby.compilers.{enable,packages} options
* [`96f0f018`](https://github.com/cachix/devenv/commit/96f0f0181a48a960af98ae6324323507be7bc054) Turn on languages.ruby.compilers.enable by default
* [`979304d6`](https://github.com/cachix/devenv/commit/979304d66177ba0cb9171bb7ba7b2e69a76c606c) feat: auto run direnv allow
* [`a35f6750`](https://github.com/cachix/devenv/commit/a35f675031efa96f2926531f07f740a89215e460) cli: init create missing files
* [`c19a68bf`](https://github.com/cachix/devenv/commit/c19a68bf1d7db7030f64da3f80e02f1cfcc43832) feat: symlink profile into local devenv folder
* [`07d26a15`](https://github.com/cachix/devenv/commit/07d26a159286b984527fb2b24a37fb32e342a261) env: allow merging values
* [`59c09e64`](https://github.com/cachix/devenv/commit/59c09e642580c3135895425f47161d33ea5645fd) make sure ci fails for examples
* [`a14d697e`](https://github.com/cachix/devenv/commit/a14d697e0cf1a1da8a8b6aac4c2bbd3cb36fb663) Auto generate docs/reference/options.md
* [`3132bfc7`](https://github.com/cachix/devenv/commit/3132bfc7a8af76a794812fc9a18f6f92be5b5368) fix nur example
* [`256ca8f2`](https://github.com/cachix/devenv/commit/256ca8f2f39c0a671905b6b6180e4620169472d7) fix scripts example
* [`2e5ce4bc`](https://github.com/cachix/devenv/commit/2e5ce4bc3fa6ce34458238b526458b90aa0acf66) fix rust example
* [`9f49511a`](https://github.com/cachix/devenv/commit/9f49511a96a57a4b4666a1be6761db97c1174a8c) Auto generate docs/reference/options.md
* [`cadd736a`](https://github.com/cachix/devenv/commit/cadd736adbf12a5bf9c838d754e12885d0f6a676) Move C related packages to language module, enable for Ruby by default
* [`d97b450d`](https://github.com/cachix/devenv/commit/d97b450df07129626385792503157b890ed20868) fix [cachix/devenv⁠#253](https://togithub.com/cachix/devenv/issues/253)
