### PR TITLE
niv emacs-overlay: update 56367de0 -> ebbb2251

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "56367de0ad78e1f1db0946ae896e4017d9dde785",
-        "sha256": "1g5fs6xpv7ydf098cyxgamdh30n17lh9p8hs53765b2p147nphnw",
+        "rev": "ebbb22510930b5153de22357518ebd8ce7ed93b3",
+        "sha256": "1vmsk0znvjc6qlmiqgpzx07644rhfg0kgxx5l9ig9lrga1wwh8bs",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/56367de0ad78e1f1db0946ae896e4017d9dde785.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/ebbb22510930b5153de22357518ebd8ce7ed93b3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@56367de0...ebbb2251](https://github.com/nix-community/emacs-overlay/compare/56367de0ad78e1f1db0946ae896e4017d9dde785...ebbb22510930b5153de22357518ebd8ce7ed93b3)

* [`00cdfbd3`](https://github.com/nix-community/emacs-overlay/commit/00cdfbd36d40d529003d521ab32ca570dfcd453e) emacs-lsp: bump + fix update script
* [`44cba6f3`](https://github.com/nix-community/emacs-overlay/commit/44cba6f3eaf4dfaf7190c3d69bcb322eac75b729) Updated repos/emacs
* [`74a1e57f`](https://github.com/nix-community/emacs-overlay/commit/74a1e57fc7228d715c666172ffe11e38ab31e312) Updated repos/melpa
* [`afa90d7b`](https://github.com/nix-community/emacs-overlay/commit/afa90d7b802a94ef75d6d72486b88235e9079087) Updated repos/elpa
* [`e71f8a21`](https://github.com/nix-community/emacs-overlay/commit/e71f8a21852969faf10369fd186d0f85671232ca) Updated repos/emacs
* [`a201dcf3`](https://github.com/nix-community/emacs-overlay/commit/a201dcf3d712cf6d3934b396d523041781ff9589) Updated repos/melpa
* [`7cb61586`](https://github.com/nix-community/emacs-overlay/commit/7cb61586b4bcf08df6d0f030cef42cfe843b2862) Updated repos/emacs
* [`5508c1bb`](https://github.com/nix-community/emacs-overlay/commit/5508c1bb56768e5c583ac72a2e71bf957f2e6697) Updated repos/melpa
* [`04c69f9d`](https://github.com/nix-community/emacs-overlay/commit/04c69f9d921e5090965f92842f225734652835e0) Updated repos/nongnu
* [`273dc312`](https://github.com/nix-community/emacs-overlay/commit/273dc312af02166bf7d99b8ec201d22add9af4fa) Updated repos/emacs
* [`6f3b16d9`](https://github.com/nix-community/emacs-overlay/commit/6f3b16d93634babeb7cc4727d880a096a12c3851) Updated repos/melpa
* [`75f08c34`](https://github.com/nix-community/emacs-overlay/commit/75f08c349147a291cb18ef3dba2e87e129d467be) Updated repos/nongnu
* [`374a5b86`](https://github.com/nix-community/emacs-overlay/commit/374a5b8673c0ec6166ded1736e6b01cf994a49e9) Updated repos/emacs
* [`b7a13b83`](https://github.com/nix-community/emacs-overlay/commit/b7a13b83ce72c7038d1871ccb63d055b23fc6021) Updated repos/melpa
* [`05a0dbab`](https://github.com/nix-community/emacs-overlay/commit/05a0dbab720f96496aee098cfa9d40d92c0b8894) Updated repos/melpa
* [`6964a2e7`](https://github.com/nix-community/emacs-overlay/commit/6964a2e706251a3465b24e2593f7afea902e04a3) Updated repos/nongnu
* [`7535e2c0`](https://github.com/nix-community/emacs-overlay/commit/7535e2c08b91b471e10c09e5c5d6658f815df83c) Build emacsGit without Xcode
* [`db424bb6`](https://github.com/nix-community/emacs-overlay/commit/db424bb6a20b7aff38533ca77840c51a8350b5bb) Updated repos/emacs
* [`9e922672`](https://github.com/nix-community/emacs-overlay/commit/9e9226725def97c722597984175d6f1cb2ecc320) Updated repos/melpa
* [`9c95614e`](https://github.com/nix-community/emacs-overlay/commit/9c95614e0b1a2f6a3f4cf9b99b17439887ea0373) Updated repos/melpa
* [`9abbf91a`](https://github.com/nix-community/emacs-overlay/commit/9abbf91a2da6b987da1c5aebc5b18fa1d899e1c3) Updated repos/elpa
* [`3711313b`](https://github.com/nix-community/emacs-overlay/commit/3711313bc3d1acb747b4d0317a632b7943311712) Updated repos/emacs
* [`818a69d6`](https://github.com/nix-community/emacs-overlay/commit/818a69d6150a57defcd3ac3544c2674cf14383be) Updated repos/melpa
* [`f77f910a`](https://github.com/nix-community/emacs-overlay/commit/f77f910a6038ec76993fc4ca36dbb2209cc0272c) Updated repos/emacs
* [`984fa17b`](https://github.com/nix-community/emacs-overlay/commit/984fa17b3b0eaa4cc95538b400554da6aa47c680) Updated repos/melpa
* [`ad814066`](https://github.com/nix-community/emacs-overlay/commit/ad814066607eb2b9400f7f7dbb45eea5178d295c) Updated repos/nongnu
* [`7b4936ec`](https://github.com/nix-community/emacs-overlay/commit/7b4936ec6bb985770ef34a3cfe81b05cb3d3970e) Updated repos/emacs
* [`d89f91c7`](https://github.com/nix-community/emacs-overlay/commit/d89f91c7c5ba124348e097c45f1bf8882f5c60be) Updated repos/melpa
* [`2d1ce436`](https://github.com/nix-community/emacs-overlay/commit/2d1ce4360a144302ef25a3a0da91bd67a3b13924) Updated repos/elpa
* [`68d6a8c8`](https://github.com/nix-community/emacs-overlay/commit/68d6a8c8a0f24a79e9563b9b21c28f8e8d6a67dd) Updated repos/emacs
* [`2fccc125`](https://github.com/nix-community/emacs-overlay/commit/2fccc125312dc674157e9ce50bebc70d5e88b5ff) Updated repos/melpa
* [`bc9ad2cd`](https://github.com/nix-community/emacs-overlay/commit/bc9ad2cd35760953c145107dc75a413081c38fd3) Updated repos/nongnu
* [`8125f1be`](https://github.com/nix-community/emacs-overlay/commit/8125f1becba85cabec29c52557dc95a60906844c) Updated repos/emacs
* [`1cb44099`](https://github.com/nix-community/emacs-overlay/commit/1cb4409944f776fbf9ca79bbd25cd8f4c3b70069) Updated repos/melpa
* [`0192f376`](https://github.com/nix-community/emacs-overlay/commit/0192f376436e4ba88b2125d26f403a5605bf59b3) Updated repos/emacs
* [`c2698d13`](https://github.com/nix-community/emacs-overlay/commit/c2698d134aa2f1c1ba491f851d6c1a0114a4b1e6) Updated repos/melpa
* [`14b7aa33`](https://github.com/nix-community/emacs-overlay/commit/14b7aa33d99ae870b3e5f054cacee2318ade4cf7) Updated repos/emacs
* [`4f772972`](https://github.com/nix-community/emacs-overlay/commit/4f772972b47e249bf740c0aae78ce8352d367bc3) Updated repos/melpa
* [`8d3626c8`](https://github.com/nix-community/emacs-overlay/commit/8d3626c8bfc1ea3a88571dd07c2b9f0aaec9594d) Updated repos/nongnu
* [`785d196f`](https://github.com/nix-community/emacs-overlay/commit/785d196ffa59eb260025cafa6025498dd6aede50) Updated repos/emacs
* [`9b2084bd`](https://github.com/nix-community/emacs-overlay/commit/9b2084bd40761de6be748981275bcfd35444c820) Updated repos/melpa
* [`5fb59e49`](https://github.com/nix-community/emacs-overlay/commit/5fb59e496f0b080f3e2b4a9586cd5afda50e3189) Updated repos/melpa
* [`b666adfa`](https://github.com/nix-community/emacs-overlay/commit/b666adfa16346297668dd0b0f1e396d635856fa6) Updated repos/melpa
* [`f4ed3f57`](https://github.com/nix-community/emacs-overlay/commit/f4ed3f57816ae096dc3ec5cfeed4374706da4324) Updated repos/nongnu
* [`1ce5b56a`](https://github.com/nix-community/emacs-overlay/commit/1ce5b56a618f6deff53db0390928288eab3372ac) Updated repos/emacs
* [`f7adfd0e`](https://github.com/nix-community/emacs-overlay/commit/f7adfd0ee21536c165342b22c499fcbf7586650e) Updated repos/melpa
* [`10e47e47`](https://github.com/nix-community/emacs-overlay/commit/10e47e476a57353486c90883f869a699734a828a) Updated repos/nongnu
* [`30d1964f`](https://github.com/nix-community/emacs-overlay/commit/30d1964fb145ffc5192cba00de93626f33747a10) Updated repos/emacs
* [`c41dee3c`](https://github.com/nix-community/emacs-overlay/commit/c41dee3c8ab52ce197ec6bdb614ba8e9459f6a0f) Updated repos/melpa
* [`b42f258a`](https://github.com/nix-community/emacs-overlay/commit/b42f258adddd337952c6ad745ffe02a8a8f1e858) Updated repos/elpa
* [`f172a005`](https://github.com/nix-community/emacs-overlay/commit/f172a0050e6a7558d8f59ca6e353515389cf2ad9) Updated repos/emacs
* [`06d88ea2`](https://github.com/nix-community/emacs-overlay/commit/06d88ea2a783a7c563ce57e62d794313ae1e4855) Updated repos/melpa
* [`ebbb2251`](https://github.com/nix-community/emacs-overlay/commit/ebbb22510930b5153de22357518ebd8ce7ed93b3) Updated repos/melpa
