### PR TITLE
niv niv: update 351d8bc3 -> 689d0e55

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "351d8bc316bf901a81885bab5f52687ec8ccab6e",
-        "sha256": "1yzhz7ihkh6p2sxhp3amqfbmm2yqzaadqqii1xijymvl8alw5rrr",
+        "rev": "689d0e5539eddd0b0f566aee7bb18629eee7df74",
+        "sha256": "1rld3lk42l6b01f2gcrhq8qm9vry1awmfl29zmpiqda9dy89vbx0",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/351d8bc316bf901a81885bab5f52687ec8ccab6e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/689d0e5539eddd0b0f566aee7bb18629eee7df74.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@351d8bc3...689d0e55](https://github.com/nmattia/niv/compare/351d8bc316bf901a81885bab5f52687ec8ccab6e...689d0e5539eddd0b0f566aee7bb18629eee7df74)

* [`0b7666ef`](https://github.com/nmattia/niv/commit/0b7666effaee0738cdea56b2e7aecdd4193c41fb) Add motivation paragraph to 'Getting Started'
* [`6b6fffd7`](https://github.com/nmattia/niv/commit/6b6fffd73e08f5e361bb5bf7451481796fb73008) Update nixpkgs
* [`689d0e55`](https://github.com/nmattia/niv/commit/689d0e5539eddd0b0f566aee7bb18629eee7df74) Update formatting
