### PR TITLE
niv spacemacs: update b74da79d -> fd749704

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "b74da79dbbd8573ab4f43721c74014d6f54d8bd0",
-        "sha256": "0llr4ywz7h6jifds62v3y0pm6jb83wvpmw2fv0va05pm2229vk6a",
+        "rev": "fd749704ff567c4766e2b8e192d6fa46708a7ee3",
+        "sha256": "0i12kdvkig2nd5124z6866gmahhaj3v8wp3zrbm5rpcy4i6jlliv",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/b74da79dbbd8573ab4f43721c74014d6f54d8bd0.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/fd749704ff567c4766e2b8e192d6fa46708a7ee3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@b74da79d...fd749704](https://github.com/syl20bnr/spacemacs/compare/b74da79dbbd8573ab4f43721c74014d6f54d8bd0...fd749704ff567c4766e2b8e192d6fa46708a7ee3)

* [`3afc9afa`](https://github.com/syl20bnr/spacemacs/commit/3afc9afa4cd113f1bafee74c4ecf04af58b20372) *layers/+lang/python: enahnce the virtual environment detection
* [`f1c7979b`](https://github.com/syl20bnr/spacemacs/commit/f1c7979b63a9f0d01c38348177ed27094d95de75) [bot] "built_in_updates" Thu Dec 22 07:42:58 UTC 2022
* [`fd749704`](https://github.com/syl20bnr/spacemacs/commit/fd749704ff567c4766e2b8e192d6fa46708a7ee3) Fix the [syl20bnr/spacemacs⁠#15852](https://togithub.com/syl20bnr/spacemacs/issues/15852) Wrong type argument
