### PR TITLE
niv zsh-completions: update b2151312 -> b46602db

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "b215131217582b1c634c57ffc61bf3e33190c5f1",
-        "sha256": "060q372z81vwknkv0zgn54mgv6ddzcd63kgzddrh8cy88khrmf07",
+        "rev": "b46602db397bf1af6bb6906e1a749da09fdda27d",
+        "sha256": "1ddxkhmpfx5blwfhp43j1cxy3zy06zs58h4gzdr7aalfk5vvc15f",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/b215131217582b1c634c57ffc61bf3e33190c5f1.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/b46602db397bf1af6bb6906e1a749da09fdda27d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@b2151312...b46602db](https://github.com/zsh-users/zsh-completions/compare/b215131217582b1c634c57ffc61bf3e33190c5f1...b46602db397bf1af6bb6906e1a749da09fdda27d)

* [`021da0cd`](https://github.com/zsh-users/zsh-completions/commit/021da0cde55debc94d347bf5e8cd274f15d7b0f3) Add set property completion
* [`7ec9280e`](https://github.com/zsh-users/zsh-completions/commit/7ec9280e88c4ae6c49e399c52b6ab75fcdfd0b05) Implement encryptvm subcommand
* [`0211e566`](https://github.com/zsh-users/zsh-completions/commit/0211e566da43c354cfb74e247bb7c81ce46ae04a) Add bandwidthctl subcommand completion
* [`a2d4ea00`](https://github.com/zsh-users/zsh-completions/commit/a2d4ea00d93a38cfc8d4f29731010fb0c575be83) Add mediumio subcommand completion
* [`7aba5946`](https://github.com/zsh-users/zsh-completions/commit/7aba5946ca28eef92c040ca083ff39e217a8da2b) Add cloudprofile subcommand completion
* [`61ccfe35`](https://github.com/zsh-users/zsh-completions/commit/61ccfe353f8b7a0febf9f81bc42e462719101abd) Add unattended subcommand completion
* [`2228daef`](https://github.com/zsh-users/zsh-completions/commit/2228daef0eb4744dbb00df8a9c7a04de27779d7d) Add snapshot subcommand completion
* [`6ec58b68`](https://github.com/zsh-users/zsh-completions/commit/6ec58b685e43ec80ab73723146c43b48a119f12f) Add cloud subcommand completion
* [`4f8614d0`](https://github.com/zsh-users/zsh-completions/commit/4f8614d0ac32b27cbc32eabdf2fe849d4e3790a0) Add guestproperty subcommand completion
* [`eff72eac`](https://github.com/zsh-users/zsh-completions/commit/eff72eacf6da7b2169cf748fa099237167c77dff) Add usbfilter subcommand completion
* [`01c0875b`](https://github.com/zsh-users/zsh-completions/commit/01c0875bb560f3969b92b18e1a09556c73319128) Add updatecheck subcommand completion
* [`a5cc26ee`](https://github.com/zsh-users/zsh-completions/commit/a5cc26eee15a778802f3c71736e92cd180113c42) Add modifynvram subcommand completion
* [`793c77ec`](https://github.com/zsh-users/zsh-completions/commit/793c77ece970299354d1e85cde30b561b6c5f250) Add extpack subcommand completion
* [`2e02fa2b`](https://github.com/zsh-users/zsh-completions/commit/2e02fa2bc40e0d1f3f276634bb8b5a315e8609b4) Add usbdevsource subcommand completion
* [`a6f3ed26`](https://github.com/zsh-users/zsh-completions/commit/a6f3ed261637ec5a5cb1b4cba602319f76ab6cea) Implement sharedfolder subcommand completion
* [`8d40ac67`](https://github.com/zsh-users/zsh-completions/commit/8d40ac67bf68dd9e3a22a0883ad5d7ae9127edeb) Add natnetwork subcommand completion
* [`fa57596f`](https://github.com/zsh-users/zsh-completions/commit/fa57596f67b4e6357ab343540ea8e0319cdb18ba) ADd guestcontrol subcommand completion
* [`d54db07d`](https://github.com/zsh-users/zsh-completions/commit/d54db07dd5f7f4c15f9c2cc9097080078907e7fc) Add debugvm subcommand completion
* [`46e5e954`](https://github.com/zsh-users/zsh-completions/commit/46e5e954053cf0bdb33d318c5b9cf44e155da2dd) Add metrics subcommand completion
* [`337c4306`](https://github.com/zsh-users/zsh-completions/commit/337c43064e5cbd4496a00f5f805106ae19fd4c83) Add hostonlyif subcommand completion
* [`4c66875a`](https://github.com/zsh-users/zsh-completions/commit/4c66875a7b037b93c07f209894b4894478d73d66) Add hostonlynet subcommand completion
* [`9035bfb0`](https://github.com/zsh-users/zsh-completions/commit/9035bfb0a8d6f5023c197cc808823a07efe18690) Reduce functions
* [`2df4d300`](https://github.com/zsh-users/zsh-completions/commit/2df4d30003e9b0009ea011cb80d321ef6dd128ac) Add dhcpserver subcommand completion
* [`eecf5d5c`](https://github.com/zsh-users/zsh-completions/commit/eecf5d5c1057729cac257a747b4af3d56ab2c7d3) Update author list
* [`b3eb7818`](https://github.com/zsh-users/zsh-completions/commit/b3eb7818371a740fa444b09a9346ba1e3667f562) Update sbt completion
* [`0491bd2c`](https://github.com/zsh-users/zsh-completions/commit/0491bd2cbedb82997573e63d72167654c4b88666) Update bundle completion
* [`ed5394d6`](https://github.com/zsh-users/zsh-completions/commit/ed5394d671fa51632b4c8a96873ce814bedf9c12) Fix typo in node.js completion
