### PR TITLE
niv nixpkgs: update a753a425 -> e68618ed

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a753a425963129f149459cbaea1f46a4bea67636",
-        "sha256": "0618pjcb35y4hb7njrwxfcacfj9jrkj5b52hyhvrx7vv1xrwmp8m",
+        "rev": "e68618ed4c73fe2566e69ef04034b958e66f69ff",
+        "sha256": "1y3d82n1hrvh8sql9ivi9b2qspniwpfbrxn6z067kg7wqwipw0n1",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a753a425963129f149459cbaea1f46a4bea67636.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e68618ed4c73fe2566e69ef04034b958e66f69ff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a753a425...e68618ed](https://github.com/nixos/nixpkgs/compare/a753a425963129f149459cbaea1f46a4bea67636...e68618ed4c73fe2566e69ef04034b958e66f69ff)

* [`3ff04d2f`](https://github.com/NixOS/nixpkgs/commit/3ff04d2fc26b8d487a02843a804b8ee8995f6521) logstash7: Fix passthru.tests since -oss variant removal
* [`87aa24b6`](https://github.com/NixOS/nixpkgs/commit/87aa24b63759c08158170e301fe43a69a0c12073) obsPlugins.looking-glass-obs: fix src name usage
* [`8e01188b`](https://github.com/NixOS/nixpkgs/commit/8e01188bdfd8bac2c32d7ac6404b9623dea88744) cmt: 1.17 -> 1.18
* [`2a6d0bdf`](https://github.com/NixOS/nixpkgs/commit/2a6d0bdf94a97eec69bdcc0c58929eb3b1aa4075) swaylock-effects: changed source repository
* [`6d9a4909`](https://github.com/NixOS/nixpkgs/commit/6d9a490980711d9501465fabc53c48bf41762d8f) default-crate-overrides.nix: remove unnecessary attrs from previous commit
* [`63d99130`](https://github.com/NixOS/nixpkgs/commit/63d9913007113c7cbd699c90160e045d064ee3f3) release-cross.nix: skip job which requires build.canExec host
* [`4ceec727`](https://github.com/NixOS/nixpkgs/commit/4ceec72751fdab4cbfbf407e4b4500dd388232d6) default-crate-overrides.nix: add cairo-sys-rs
* [`c804cea7`](https://github.com/NixOS/nixpkgs/commit/c804cea71d27d74becebc677bd2bc0064adfe025) default-crate-overrides.nix: add {gtk4,gdk4,gsk4}-sys
* [`02de33ca`](https://github.com/NixOS/nixpkgs/commit/02de33cacd279f143086c8bdacd84985ba0f882d) default-crate-overrides.nix: add atk-sys
* [`2ab5cfe7`](https://github.com/NixOS/nixpkgs/commit/2ab5cfe7ced072a34bd53e723e42292ab354bff5) default-crate-overrides.nix: import pango
* [`31e5930b`](https://github.com/NixOS/nixpkgs/commit/31e5930b57d07db694237622a09c8f73b885e32e) default-crate-overrides.nix: add pangocairo-sys
* [`ea9a09c9`](https://github.com/NixOS/nixpkgs/commit/ea9a09c9af59ddb8c38e8cb79e7156218df41bcf) nwg-wrapper: 0.1.2 -> 0.1.3
* [`50a4a15e`](https://github.com/NixOS/nixpkgs/commit/50a4a15e56cc304759a4e7ec4a406fa73b76ca77) mlt: fixed compilation with opencv
* [`d03162e8`](https://github.com/NixOS/nixpkgs/commit/d03162e8bf6d2884f41cc430677539513c26f568) sagetex: 3.6 -> 3.6.1
* [`d3b65938`](https://github.com/NixOS/nixpkgs/commit/d3b65938d453f27c5ca747630ad1e5eb842475a2) nixos/../nix-daemon.nix: allow architectures with no inferiors
* [`05e99c3a`](https://github.com/NixOS/nixpkgs/commit/05e99c3a8c210b8ff3b80055b3fa7776049043d3) apple-cursor: init at 2.0.0
* [`519d3392`](https://github.com/NixOS/nixpkgs/commit/519d3392a1403ed9e629f7bedb66992a9db94dde) python3Packages.cachecontrol: Fix sandboxed build on Darwin
* [`e51b3e39`](https://github.com/NixOS/nixpkgs/commit/e51b3e39d7ae666b66c25e3558f1b43b2d6a3a23) vscode-fhs: add lttng-ust to FHS env
* [`fcb9211b`](https://github.com/NixOS/nixpkgs/commit/fcb9211bf1ad27dd1361e19073f50b44b7fd77e8) newsboat: Avoid duplicate contrib files
* [`71b2fdc8`](https://github.com/NixOS/nixpkgs/commit/71b2fdc8dcc6f70ef7aad8fd20e315180f56d1d6) kitty: 0.26.2 -> 0.26.5
* [`66f4b2e9`](https://github.com/NixOS/nixpkgs/commit/66f4b2e97ffd845b039e95003f9f031bf9f739ed) super-productivity: bump electron version
* [`e00397a9`](https://github.com/NixOS/nixpkgs/commit/e00397a97c20970b1d1a118e51806d60d687c986) python310Packages.APScheduler: 3.9.1 -> 3.9.1.post1
* [`5cb63d88`](https://github.com/NixOS/nixpkgs/commit/5cb63d880948eeb31ce997f08c466a388bd4ce8c) vipsdisp: init at 2.4.1
* [`6a376d9a`](https://github.com/NixOS/nixpkgs/commit/6a376d9a78dd97df3710b27ce5b21e2897373740) flutter: Expose internal derivation creation functions
* [`ff0fc41c`](https://github.com/NixOS/nixpkgs/commit/ff0fc41c423a8c7984ccc72bb4c52ba6ef06e1b3) cpu-x: 4.5.1 -> 4.5.2
* [`a13bc3e8`](https://github.com/NixOS/nixpkgs/commit/a13bc3e8ac0f69d3eeb71f85e9aae607325dcaba) cubeb: adjust dependencies
* [`a23af657`](https://github.com/NixOS/nixpkgs/commit/a23af657103e8a368907fe2012b8b92f8df735bd) cubeb: Add Darwin support
* [`475bce53`](https://github.com/NixOS/nixpkgs/commit/475bce53557ad338d6ca0c1c689adaa5f80f4906) osc-lib: Mark as unbroken on darwin
* [`973c7b12`](https://github.com/NixOS/nixpkgs/commit/973c7b12caebf5dd8dee48f15b14e5525551f95d) gnupg: fix smartcards (yubikeys) on Darwin
* [`579f230b`](https://github.com/NixOS/nixpkgs/commit/579f230b0a0e00427c038a8b5948aff5ee082f3b) nixos/environment: accept path for variables and sessionVariables
* [`d8f0f3eb`](https://github.com/NixOS/nixpkgs/commit/d8f0f3ebd1f99f344675198e460a1ab898761421) python310Packages.proxy-py: add changelog to meta
* [`31f5f62c`](https://github.com/NixOS/nixpkgs/commit/31f5f62c50931addae2a0f3de4e7a89521b284f7) noto-fonts: 2020-01-23 -> v20201206-phase3
* [`ee04a188`](https://github.com/NixOS/nixpkgs/commit/ee04a188bd7db2443e9d2a1eb5376475bf57d5dd) cpu-x: update homepage and annotate a known issue
* [`fc000805`](https://github.com/NixOS/nixpkgs/commit/fc0008053f8a25e915e0277957355de8e0360beb) qt6.qtbase: update cmake patch to not move bin directory to dev output
* [`fe2b297c`](https://github.com/NixOS/nixpkgs/commit/fe2b297ca4abceb25aa2b56461aad060de1fa006) qt6.qtbase: do not unconditionally move $out/bin to $dev/bin
* [`a1f94136`](https://github.com/NixOS/nixpkgs/commit/a1f9413602644dd2acb006241355cc67eafcc5e8) qt6.qttools: set devTools
* [`b6c36716`](https://github.com/NixOS/nixpkgs/commit/b6c367162cd3ad16ee1347e02466ad2faa90602e) nixos/nixos-enter: add full path for systemd-tmpfiles
* [`063ae6f8`](https://github.com/NixOS/nixpkgs/commit/063ae6f8b1099b6d30ca02d79050646eb63f7b08) mautrix-googlechat: init at 0.4.0
* [`c0643549`](https://github.com/NixOS/nixpkgs/commit/c064354949a6b864c26d37afafda0b6325e5a971) qview: 4.0 -> 5.0
* [`e23147a6`](https://github.com/NixOS/nixpkgs/commit/e23147a67c701961646e98baec5bef23e9e41a26) cagebreak: 1.8.1 -> 1.9.1
* [`ad221e06`](https://github.com/NixOS/nixpkgs/commit/ad221e06d03086b8730a38e6d926c8e4937233b8) pkgsStatic.redis: make checkPhase pass
* [`873074ac`](https://github.com/NixOS/nixpkgs/commit/873074ac6024a36f828f6e44f0c004607e93cba7) nixos/binfmt: add interpreter path to sandbox
* [`0e89c822`](https://github.com/NixOS/nixpkgs/commit/0e89c822afd4d60b4bf5c96a35d77b2de9ad624b) nixos/binfmt: mkDefault auto-detected interpreter
* [`9f8d0107`](https://github.com/NixOS/nixpkgs/commit/9f8d0107c6e56f3fd0d9cbdc46511482fe964a0f) xidel: unpin to openssl_1_1
* [`a02d834d`](https://github.com/NixOS/nixpkgs/commit/a02d834dd7a7113eb1eb0bbc10089f6aeeb15481) nfd: unpin to openssl_1_1
* [`d985007d`](https://github.com/NixOS/nixpkgs/commit/d985007db9553496729d71e155c86654e88eed24) libstrophe: unpin to openssl_1_1
* [`3b9cba8b`](https://github.com/NixOS/nixpkgs/commit/3b9cba8bdc646f0104c9694f359570d56e3f28a5) quill: unpin to openssl_1_1
* [`66d43c60`](https://github.com/NixOS/nixpkgs/commit/66d43c605b914141d3bee374454712207a3786f1) lighttpd: unpin to openssl_1_1
* [`7f756175`](https://github.com/NixOS/nixpkgs/commit/7f7561758b92dabadd7da945776625499022e566) kubo: unpin to openssl_1_1
* [`4c876c26`](https://github.com/NixOS/nixpkgs/commit/4c876c2646cd858761bb4baf42d5a7ea2544ccc9) mdbook-plantuml: unpin to openssl_1_1
* [`a1d55b71`](https://github.com/NixOS/nixpkgs/commit/a1d55b7102c37466de9de5516504135e96c67bba) nim: unpin to openssl_1_1
* [`18eacafe`](https://github.com/NixOS/nixpkgs/commit/18eacafefb55f5b81e11f256357bb222edea450a) protonmail-bridge: 2.1.3 -> 2.3.0
* [`9f874dd9`](https://github.com/NixOS/nixpkgs/commit/9f874dd95e4375a86daa4dc5251fa79de890ab5b) nixos/tests/initrd-network-openvpn: fix
* [`cb929a89`](https://github.com/NixOS/nixpkgs/commit/cb929a89515992f529afa183cf98ce3ba6157868) Add linux-rt-5.15
* [`0b8ac7d2`](https://github.com/NixOS/nixpkgs/commit/0b8ac7d2b31c339d8327a51aa16031b1a70179f7) pythonPackages.cvelib: add version test
* [`16e96c45`](https://github.com/NixOS/nixpkgs/commit/16e96c45c6957e7f0dd29fdbb5b63fa3db76bcfb) aws-c-http: 0.6.27 -> 0.6.28
* [`f943c3fb`](https://github.com/NixOS/nixpkgs/commit/f943c3fb899aa6f620cd85918f89a67574b50493) add `buildGems` to ruby passthru
* [`56bc902b`](https://github.com/NixOS/nixpkgs/commit/56bc902b236bac6db8211ac8c48e441a82d84feb) cups-pdf-to-pdf: init at unstable-2021-12-22
* [`49a129ab`](https://github.com/NixOS/nixpkgs/commit/49a129ab4027ceeee3d4f67898ff6ee8067daeac) nixos/cups-pdf: init
* [`85aeeac2`](https://github.com/NixOS/nixpkgs/commit/85aeeac28dea421c53cc4380e34750e8d23c2aaf) cups-pdf: add vm test
* [`3f11bdb2`](https://github.com/NixOS/nixpkgs/commit/3f11bdb2e7128e5dc0622b405f5095ba588d18de) cups-pdf: mention new package/module in 23.05 release notes
* [`57d03613`](https://github.com/NixOS/nixpkgs/commit/57d036135a288e3bcb96c8b3e4a22ee6a7550ba6) kubecfg: 0.28.0 -> 0.28.1
* [`826597de`](https://github.com/NixOS/nixpkgs/commit/826597de64ec5c5d6c17dc02690283ef9f3928d6) kubecfg: add changelog to meta
* [`95e84d99`](https://github.com/NixOS/nixpkgs/commit/95e84d99a1857cba790a2201d518b6d36876e9e0) spaceship-prompt: 3.16.7 -> 4.12.0
* [`9fd8c4c6`](https://github.com/NixOS/nixpkgs/commit/9fd8c4c6ef06c7a336919aa6fa88f2561880afef) blockbench-electron: 4.1.1 -> 4.5.2; cleanup; fix
* [`299a2ed8`](https://github.com/NixOS/nixpkgs/commit/299a2ed8fcc72aa4baaee1a3af609b366ab05adc) aws-c-s3: 0.2.0 -> 0.2.1
* [`562c4541`](https://github.com/NixOS/nixpkgs/commit/562c45418116e85ef8f1ef0be17c378607994df3) aws-checksums: 0.1.13 -> 0.1.14
* [`32c2a129`](https://github.com/NixOS/nixpkgs/commit/32c2a1295e6b1eea40d189c420dfed931807b907) maintainers: add federicoschonborn
* [`d45b01a9`](https://github.com/NixOS/nixpkgs/commit/d45b01a9852c757f7ca783c4d0c9d4f6db19f1c9) xrdp: add many knownVulnerabilities
* [`cf5ab019`](https://github.com/NixOS/nixpkgs/commit/cf5ab0191d8582c77a8062646afe6fa09b7d4748) nixos/nix-daemon: remove nixbld users if auto-allocating UIDs
* [`d8c8e9ab`](https://github.com/NixOS/nixpkgs/commit/d8c8e9abb733b57d8534c6765d308b37eae39c39) toolbox: init at 0.0.99.3
* [`80d9e24c`](https://github.com/NixOS/nixpkgs/commit/80d9e24cbf15faba75acd955770add1344315e41) linx-server: init at unstable-2021-12-24
* [`7b4b80a4`](https://github.com/NixOS/nixpkgs/commit/7b4b80a4d4638ae0c7ae9a97a5eef706a1b4b8f1) python3Packages.embrace: 4.1.0 -> 4.2.0
* [`87afead7`](https://github.com/NixOS/nixpkgs/commit/87afead7d26c8a1f60a4846b098ccf3667de5afa) xdp-tools: 1.2.8 -> 1.2.9
* [`816614bd`](https://github.com/NixOS/nixpkgs/commit/816614bd62bcdb0b72b48a55d9a5a8ffb76ce2ea) nixos/exim: allow using service credentials
* [`e915d303`](https://github.com/NixOS/nixpkgs/commit/e915d3030dd10b4db9ff0c6acdc40d37a314dbc2) brave: 1.46.133 -> 1.46.144
* [`8d649974`](https://github.com/NixOS/nixpkgs/commit/8d6499746489f84b073e1525cbd7603400fa04bb) dufs: skip checkPhase on darwin
* [`292ee77c`](https://github.com/NixOS/nixpkgs/commit/292ee77c817b5b0d00d096e28a6cf9825dc5c466) maintainers: add emattiza
* [`46846079`](https://github.com/NixOS/nixpkgs/commit/4684607935932853e918ad07fa37ec07f13e8d90) booster: init at 0.9
* [`1ea8eab3`](https://github.com/NixOS/nixpkgs/commit/1ea8eab31e0ec4f008523a7b5293ecd30b3eb14d) lean: 3.49.0 -> 3.49.1
* [`4e4d9624`](https://github.com/NixOS/nixpkgs/commit/4e4d9624451fdac9b4ccd1b20839d60258edb57e) lean: 3.49.1 -> 3.50.0
* [`10afcc35`](https://github.com/NixOS/nixpkgs/commit/10afcc353001bd9b39a70c52e825f1e5adb0ab52) aws-c-mqtt: 0.8.1 -> 0.8.2
* [`34e2d794`](https://github.com/NixOS/nixpkgs/commit/34e2d794504188864c28c6e94c6083ce96bb1dca) noto-fonts-lgc-plus: init at 20201206-phase3
* [`3546fca5`](https://github.com/NixOS/nixpkgs/commit/3546fca5a4c4b550f0335d8fad920fd8abc89c2a) plasma5: add notoPackage option
* [`7adad939`](https://github.com/NixOS/nixpkgs/commit/7adad93912459caa35e8a591464792b8e1dc3a41) tree-sitter/update: use `unionOfDisjoints`
* [`a00d2880`](https://github.com/NixOS/nixpkgs/commit/a00d2880d17f11feb6f42a359615f1ee56ca72f1) libpg_query: 14-3.0.0 -> 15-4.0.0
* [`e92783ff`](https://github.com/NixOS/nixpkgs/commit/e92783ffeaa79988ffadae32f5efb6868d86e810) limesctl: 3.1.1 -> 3.1.3
* [`a9b5e5ea`](https://github.com/NixOS/nixpkgs/commit/a9b5e5ea44bf263cf56ff6a28718b4fed3891e0e) python3Packages.mip: init at 1.14.1
* [`ab742f9d`](https://github.com/NixOS/nixpkgs/commit/ab742f9d08cbb4334055977c387f5adf0c22a9c8) python3Packages.quadprog: init at 0.1.11
* [`97933260`](https://github.com/NixOS/nixpkgs/commit/979332605c3ad44a6102cf857ea04f4f82abbefe) spotifyd: 0.3.3 -> 0.3.4
* [`d93e341a`](https://github.com/NixOS/nixpkgs/commit/d93e341a2745b9738802a472fb40cfd617a3d1f2) s2n-tls: 1.3.30 -> 1.3.31
* [`47f904ba`](https://github.com/NixOS/nixpkgs/commit/47f904bad14c906e223ac0e7a5536b9042e5b3e2) python27: use ffi/expat as system libraries
* [`b3f1fee9`](https://github.com/NixOS/nixpkgs/commit/b3f1fee9401466faa76a0b2d5923f770eebd2d0c) postgresqlPackages.pg_ivm: 1.3 -> 1.4
* [`58b20af6`](https://github.com/NixOS/nixpkgs/commit/58b20af68b5fc160e77224b0ca6c1051aaa59e72) postgresqlPackages.pgroonga: 2.4.0 -> 2.4.2
* [`65d2d4d6`](https://github.com/NixOS/nixpkgs/commit/65d2d4d6de724be96bcd8af7db99c757cbb970c5) pinegrow: add version 7, keep version 6
* [`4f312b4d`](https://github.com/NixOS/nixpkgs/commit/4f312b4d13a04dfbd4c76d0cc0c3583087d5b144) simplescreenrecorder: Make available on more platforms
* [`e1929f01`](https://github.com/NixOS/nixpkgs/commit/e1929f01625de6856ed1462e01791cec23211d74) dotnet-sdk_3.1 3.1.425 -> 3.1.426
* [`641fd77f`](https://github.com/NixOS/nixpkgs/commit/641fd77f1f975d79b90b8f816aa834b44929e655) dotnet-sdk_7.0: 7.0.100 -> 7.0.101
* [`8b8352a9`](https://github.com/NixOS/nixpkgs/commit/8b8352a9e6f05b570269491e0c8b2f340c5b0d89) gnome.gnome-music: add darwin support
* [`f3bc5bb7`](https://github.com/NixOS/nixpkgs/commit/f3bc5bb7af6b30f0eded5268435dc33abd8b7730) gnome.baobab: add darwin support
* [`e66840a0`](https://github.com/NixOS/nixpkgs/commit/e66840a0e6f7f8218284d68d0e287203fc3de753) gnome.dconf-editor: add darwin support
* [`cd639a4c`](https://github.com/NixOS/nixpkgs/commit/cd639a4cd84feb3e325bb968395cac81a44ac7d5) gnome.gnome-calculator: add darwin support
* [`b7e6bfac`](https://github.com/NixOS/nixpkgs/commit/b7e6bfac77a0d16096ce512549fdba452c58e80f) gnome.gnome-dictionary: add darwin support
* [`a5ae256a`](https://github.com/NixOS/nixpkgs/commit/a5ae256aa85515050aff9982ce437ade2be3e12c) gnome.gnome-font-viewer: add darwin support
* [`f1a91678`](https://github.com/NixOS/nixpkgs/commit/f1a916787c49d9544228005b6a708e8ebe6dd556) gnome.gnome-themes-extra: add darwin support
* [`dad22d2f`](https://github.com/NixOS/nixpkgs/commit/dad22d2fdc1aaf04a899a9b6cc581082416b0c71) folks: add darwin support
* [`db6df98c`](https://github.com/NixOS/nixpkgs/commit/db6df98cb0f1f4cb5e2b1f628df3294563a0a3ae) gnome-video-effects: add darwin support
* [`066a710a`](https://github.com/NixOS/nixpkgs/commit/066a710a9cccc9e556ed200c6a8ab3a773d20667) maintainers: add borlaag
* [`c8663bb8`](https://github.com/NixOS/nixpkgs/commit/c8663bb893b9a3abf57a9e9cf3080277992f641c) postgresql11Packages.plpgsql_check: 2.2.4 -> 2.2.5
* [`f240364f`](https://github.com/NixOS/nixpkgs/commit/f240364f73182345de8135750c573bcd67207a5b) extism-cli: init at 0.1.0
* [`e57f4501`](https://github.com/NixOS/nixpkgs/commit/e57f45012551e6be9f85551207ec38a1ecbb9b79) highlight: 4.2 -> 4.4
* [`56a9ace9`](https://github.com/NixOS/nixpkgs/commit/56a9ace9335180b6702f039c770e561478f428db) otel-cli: init at 0.0.20
* [`b62a567b`](https://github.com/NixOS/nixpkgs/commit/b62a567b747d9e5333e292a21c6647ad03f8ab58) qgis-ltr: 3.22.13 -> 3.22.14
* [`61780671`](https://github.com/NixOS/nixpkgs/commit/617806713853c8e22b0a946317bcc632eb4459d3) devd: 0.9 -> unstable-2020-04-27
* [`64866119`](https://github.com/NixOS/nixpkgs/commit/64866119846ef9c03739cbd77451f4623d1e695d) linux: build with support for Multi-Gen LRU
* [`95c27f59`](https://github.com/NixOS/nixpkgs/commit/95c27f5975e241b9359d886c48c420f384792450) linux: enable Multi-Gen LRU by default
* [`be2ee8b4`](https://github.com/NixOS/nixpkgs/commit/be2ee8b4a485a56b98cf71583c3cb96acd5fbc0c) linux_xanmod: note on Multigen. LRU being on by default
* [`471deafb`](https://github.com/NixOS/nixpkgs/commit/471deafbaf10b0ed62c0a6242454999dfb55be71) shadowsocks-rust: 1.14.3 -> 1.15.1
* [`0c21d777`](https://github.com/NixOS/nixpkgs/commit/0c21d777352f55c177f27f7e64683e0a7825142c) python3Packages.imageio: 2.22.4 -> 2.23.0
* [`0f28dc18`](https://github.com/NixOS/nixpkgs/commit/0f28dc189a470f102864079e730b7103388c24ab) spaceship-promt: add async.zsh to package
* [`ca591e70`](https://github.com/NixOS/nixpkgs/commit/ca591e700875b8439557cdc02a271014c35fcd0e) nixos/services.tinc: Add all generated /etc/ files to reloadTriggers
* [`705392e0`](https://github.com/NixOS/nixpkgs/commit/705392e011ecb72fd1cb0064bebfdff6fa94ae61) nixos/services.tinc: Fix whitespace
* [`03554797`](https://github.com/NixOS/nixpkgs/commit/03554797153aa90263161784c296ef6518af3358) lib/versions: add `pad`
* [`fc346c5e`](https://github.com/NixOS/nixpkgs/commit/fc346c5e6282c8e5a4115da7420505a2fbdd3d12) linux: use `lib.versions.pad` for `modDirVersion`
* [`cf568d20`](https://github.com/NixOS/nixpkgs/commit/cf568d20d5bc094292fc02fdce92201b11a7f169) linux: remove `modDirVersionArg` argument
* [`3a8fd0ef`](https://github.com/NixOS/nixpkgs/commit/3a8fd0ef47c22a1262dbf4ef80936b27cfa13157) nixos/installation-cd-minimal: disable `noXlibs`
* [`e12cb295`](https://github.com/NixOS/nixpkgs/commit/e12cb295ca3ace996f505c32ce7428189efbea10) rsyslog: 8.2210.0 -> 8.2212.0
* [`69ff175d`](https://github.com/NixOS/nixpkgs/commit/69ff175d7cd3816384c33b28981013aba9525374) solaar: 1.1.5 -> 1.1.8
* [`6c5d77c4`](https://github.com/NixOS/nixpkgs/commit/6c5d77c487c7d2bb542431ef087eea6b754df5b7) soapui: 5.6.0 -> 5.7.0
* [`273bd3bc`](https://github.com/NixOS/nixpkgs/commit/273bd3bc96332b51bdb183ec0ea6e1b9d8af929d) dwm-status: 1.8.0 -> 1.8.1
* [`aaafc9dc`](https://github.com/NixOS/nixpkgs/commit/aaafc9dc02a4ec776b780861afa2b1833d990ad6) dwm-status: add meta.changelog
* [`2c8a4001`](https://github.com/NixOS/nixpkgs/commit/2c8a4001d220a4941645392f34caa0ca267de69e) virtiofsd: 1.4.0 -> 1.5.0
* [`f677cbab`](https://github.com/NixOS/nixpkgs/commit/f677cbabe93e039a9d4ac995a49f9ca7991d0a9c) nixos/tests: remove minimal-kernel module
* [`6c563f30`](https://github.com/NixOS/nixpkgs/commit/6c563f30fe9415fff6ab33df738a7b9ddc84cf4e) linuxManualConfig: don't require lib and stdenv arguments
* [`a8fd50b7`](https://github.com/NixOS/nixpkgs/commit/a8fd50b79c899b3b4958f8bb95bb5717906a37b6) nixos/doc: update custom kernel instructions
* [`b1acd654`](https://github.com/NixOS/nixpkgs/commit/b1acd65415bd5210c83a9e093c124a149fadc52b) librewolf-unwrapped: 108.0-1 -> 108.0.1-1
* [`53dca0bf`](https://github.com/NixOS/nixpkgs/commit/53dca0bfadde81c870ddb18f102e7aaea5747081) krankerl: 0.13.3 -> 0.14.0
* [`960bbc02`](https://github.com/NixOS/nixpkgs/commit/960bbc021eb64e68caaf4035b17d2df0e3dcb190) postfix: build with pcre2
* [`cd5d9f62`](https://github.com/NixOS/nixpkgs/commit/cd5d9f62066a93b4a0c8169c2fa9f092faf8248b) nix-bash-completions: don't handle the `nix` command
* [`d46651e0`](https://github.com/NixOS/nixpkgs/commit/d46651e06331f07c05aff8a93c63951bcbc3622b) polkadot: 0.9.33 -> 0.9.36
* [`29b07eb0`](https://github.com/NixOS/nixpkgs/commit/29b07eb02e648e042824157fa3d59dc490045544) clickhouse: 22.8.5.29 -> 22.8.11.15
* [`c8980dbb`](https://github.com/NixOS/nixpkgs/commit/c8980dbb3edf5312e932f0c1a2d54c001cc364f6) rubyPackages.rails-html-sanitizer: 1.4.3 -> 1.4.4
* [`6054e49c`](https://github.com/NixOS/nixpkgs/commit/6054e49c022871b913f0ec68e5351cb6f067b131) dm-sans: init at 1.002
* [`d6e3f549`](https://github.com/NixOS/nixpkgs/commit/d6e3f5491b55c91c86e46b916416d074e6a5624f) pacparser: 1.3.7 -> 1.4.0
* [`689ff65c`](https://github.com/NixOS/nixpkgs/commit/689ff65cde1fed980a5c32bf0e6f80a0affab609) lean: 3.50.0 -> 3.50.1
* [`75e91565`](https://github.com/NixOS/nixpkgs/commit/75e915659b8334c75bca160f812cd5f3313066c3) ligo: 0.55.0 -> 0.58.0
* [`b5926224`](https://github.com/NixOS/nixpkgs/commit/b59262243cbef49abf04921f5b26f6c415c38ecf) ocamlPackages.class_group_vdf: mark broken on x86_64-darwin
* [`73a926b4`](https://github.com/NixOS/nixpkgs/commit/73a926b415751a779d18e9f1d63ec5311d3ef760) lsyncd: unbreak on aarch64-darwin
* [`4d6bbf16`](https://github.com/NixOS/nixpkgs/commit/4d6bbf1620f3c1b753deb742bb1168a3ce5d7f6c) krita: 5.1.3 -> 5.1.4
* [`358da2fc`](https://github.com/NixOS/nixpkgs/commit/358da2fc96bce09a4a56fa9248b37a59aec2ae25) freefilesync: 11.28 -> 11.29
* [`61805d30`](https://github.com/NixOS/nixpkgs/commit/61805d30920efe8d56dff6f808e760f35a925dbf) tutanota-desktop: don't fail if tmp dir exists
* [`6cf06287`](https://github.com/NixOS/nixpkgs/commit/6cf062877f092e3f10fa0c0a246808ba0e21c668) freefilesync: add update script
* [`13b82a8c`](https://github.com/NixOS/nixpkgs/commit/13b82a8cde26ca331d63e3f3dde6e48442a83b8d) nodePackages.rush: init at 5.88.0
* [`91fe8e2f`](https://github.com/NixOS/nixpkgs/commit/91fe8e2f43ff10e575449e2f9e86791604460c1f) ptags: 0.3.2 -> 0.3.4
* [`633f90df`](https://github.com/NixOS/nixpkgs/commit/633f90dfd9ffff9e11b43530001aa41e8fcffc04) kivy: 2.0.0 -> 2.1.0
* [`35bb28b3`](https://github.com/NixOS/nixpkgs/commit/35bb28b367312d94815f03d07d5600ecd362fb26) nixos: Add iso_minimal_new_kernel_no_zfs
* [`d91e1f98`](https://github.com/NixOS/nixpkgs/commit/d91e1f98fa83fecf614111b3bfde9bf2b3c3aa3d) nixos: Add sd_image_minimal_new_kernel_no_zfs
* [`b33b9122`](https://github.com/NixOS/nixpkgs/commit/b33b9122bc11a7b9c0b339bcabd0e287b2d4b7ff) mmctl: 7.5.1 -> 7.5.2
* [`27d6a8b4`](https://github.com/NixOS/nixpkgs/commit/27d6a8b410d9e5280d6e76692156dce5d9d6ef86) yabai: 4.0.4 -> 5.0.2
* [`b8e08c01`](https://github.com/NixOS/nixpkgs/commit/b8e08c014e8cc810b401d53314f8d1db6a52c5d2) pgadmin4: 6.17 -> 6.18
* [`b3c19ad3`](https://github.com/NixOS/nixpkgs/commit/b3c19ad3ce221fbfd4dfd25173315961a02b9d08) python3Packages.tidyexc: init at 0.10.0
* [`da625fb8`](https://github.com/NixOS/nixpkgs/commit/da625fb824416eab6f931fff8741c27512135b03) python310Packages.yoda: 1.9.6 -> 1.9.7
* [`af1c088a`](https://github.com/NixOS/nixpkgs/commit/af1c088addbb1a4639cc41d79c379d0d274db34e) python3Packages.parametrize-from-file: init at 0.17.0
* [`7cb68c8f`](https://github.com/NixOS/nixpkgs/commit/7cb68c8fbcd6beaf9b8962cbc372e540be80f749) python3Packages.rkm-codes: init at 0.5
* [`0ed791f0`](https://github.com/NixOS/nixpkgs/commit/0ed791f015fb8584a6a78d73df63458cb3c5dbb0) python3Packages.quantiphy-eval: init at 0.5
* [`bc20ca6f`](https://github.com/NixOS/nixpkgs/commit/bc20ca6f34f58ba428a13a90cedf5c76040fcf3f) python3Packages.quantiphy: init at 2.18
* [`defb6bb7`](https://github.com/NixOS/nixpkgs/commit/defb6bb79809c021f9070677e2689efb45a463bf) python3Packages.shlib: init at 1.5
* [`5b26020a`](https://github.com/NixOS/nixpkgs/commit/5b26020a9f13f7d2013597f8b2a09705adc5337d) python3Packages.emborg: init at 1.34
* [`0adbfe53`](https://github.com/NixOS/nixpkgs/commit/0adbfe53763f70b1ae34d65ceaef1076a689ac45) tautulli: 2.10.5 -> 2.11.1
* [`d666d47b`](https://github.com/NixOS/nixpkgs/commit/d666d47b9638e3219b813d45b14d3db3aaff931a) python310Packages.yoda: add changelog to meta
* [`b3792b44`](https://github.com/NixOS/nixpkgs/commit/b3792b44c55ce58147055e553cd45f1f04ca3e51) lib: correctly render docs for nested identifiers
* [`8496683e`](https://github.com/NixOS/nixpkgs/commit/8496683ec95f26b00035b5a965021dfffae269a6) lib: Allow doc rendering for lib/<name>/default.nix
* [`7bf40ca1`](https://github.com/NixOS/nixpkgs/commit/7bf40ca14040c63a55a18b86a3f16ab80579dcd7) dune_3: 3.6.1 -> 3.6.2
* [`1ed91531`](https://github.com/NixOS/nixpkgs/commit/1ed91531b68f820ba026e3cb8fd1e6ed40d64ee1) jetbrains: version file cleanup
* [`d611eb73`](https://github.com/NixOS/nixpkgs/commit/d611eb737ab33c8b44be23a91a4f9dbf68cc8774) hotspot: 1.3.0 -> 1.4.0
* [`76b44d81`](https://github.com/NixOS/nixpkgs/commit/76b44d81b2e24022200ae60dc81e7b4c58af196f) proxysql: 2.4.4 -> 2.4.5
* [`1dbcda5a`](https://github.com/NixOS/nixpkgs/commit/1dbcda5a246c93e0d5b17d39aa25021815200ba7) prusa-slicer: fix binary name on Darwin
* [`0a3d3512`](https://github.com/NixOS/nixpkgs/commit/0a3d3512401648f6b760111552a7f59dae412023) splice.nix: run nixpkgs-fmt
* [`a323b125`](https://github.com/NixOS/nixpkgs/commit/a323b125e21f22cd13ba72c842b77068bd7602e1) tfk8s: 0.1.8 -> 0.1.10
* [`7e1a3e4a`](https://github.com/NixOS/nixpkgs/commit/7e1a3e4a8f6cf85cd39d460222e52fe041a95c1c) nixos/installer/cd-dvd/iso-image: Honor boot.loader.timeout for EFI
* [`42267486`](https://github.com/NixOS/nixpkgs/commit/422674866c40470b9af91fe438f982f7577f2667) firefox_decrypt: unstable-2021-12-29 -> unstable-2022-12-21
* [`39ec6f95`](https://github.com/NixOS/nixpkgs/commit/39ec6f95b9888120b187538df4999fe717253162) all-cabal-hashes: 2022-12-18T22:10:13Z -> 2022-12-24T13:11:25Z
* [`04833f84`](https://github.com/NixOS/nixpkgs/commit/04833f84ba0d12a0614c0bffd351e8736223db96) haskellPackages: regenerate package set based on current config
* [`62b3018d`](https://github.com/NixOS/nixpkgs/commit/62b3018d91b0dfba0d9a3f95c98dafa3bec98b50) ledger: Import patch to fix ledger/ledger[nixos/nixpkgs⁠#2075](https://togithub.com/nixos/nixpkgs/issues/2075)
* [`84d7fbef`](https://github.com/NixOS/nixpkgs/commit/84d7fbefcf76461e0928e6ab46649f754e17a891) stalonetray: 0.8.4 -> 0.8.5
* [`a45968c1`](https://github.com/NixOS/nixpkgs/commit/a45968c1e42527e3e2442f63205033b95d29959a) nixos/zfs: Ensure pool has datasets to decrypt
* [`9ac2ccfe`](https://github.com/NixOS/nixpkgs/commit/9ac2ccfe92f34bd51dda3c0c4d85880ca3096e7b) svt-av1: 1.2.1 -> 1.4.1
* [`9a497aab`](https://github.com/NixOS/nixpkgs/commit/9a497aab1bcc2fc7a8acf2119df83a83290ff9ba) systemd-stage-1: Improve test-instrumentation output
* [`8550c752`](https://github.com/NixOS/nixpkgs/commit/8550c75203549b9e3bea914ab6196ba31f140bbf) python310Packages.spacy-transformers: 1.1.8 -> 1.1.9
* [`f0cab3b0`](https://github.com/NixOS/nixpkgs/commit/f0cab3b001399c652f15a9bcdd81aca4e17400b1) haskell: hspec_2_10_7 -> hspec_2_10_8
* [`9850c78e`](https://github.com/NixOS/nixpkgs/commit/9850c78e00cf2802042b6bf7869e29e40b4d2002) python310Packages.spacy-transformers: add changelog to meta
* [`5287710f`](https://github.com/NixOS/nixpkgs/commit/5287710f1e6677c502768314aa3a4ad59fb86987) xfce.ristretto: 0.12.3 -> 0.12.4
* [`a16918eb`](https://github.com/NixOS/nixpkgs/commit/a16918ebf4e196be8cb9a6fe8555cd33c602f8a6) xfce.thunar: 4.18.0 -> 4.18.1
* [`7900499c`](https://github.com/NixOS/nixpkgs/commit/7900499cbcb1f561791eea52399b02ea515d4e30) xfce.xfce4-screenshooter: 1.9.11 -> 1.10.1
* [`071664ab`](https://github.com/NixOS/nixpkgs/commit/071664ab488f0e6fe21827d9c36b1028ba060d77) xfce.xfce4-settings: 4.18.0 -> 4.18.1
* [`15d38386`](https://github.com/NixOS/nixpkgs/commit/15d383867ff7e49f3d977b1cefbf35c179f68f28) xfce.xfce4-systemload-plugin: 1.3.1 -> 1.3.2
* [`665e15ee`](https://github.com/NixOS/nixpkgs/commit/665e15ee407ea3d08c80344fa1da2bad34e78650) splice.nix: add convenience functions
* [`58fa7807`](https://github.com/NixOS/nixpkgs/commit/58fa78077c937e1879a20fc66fe7c6c57e4f75b7) treewide: use splicing convenience functions
* [`097ada0e`](https://github.com/NixOS/nixpkgs/commit/097ada0efa7be69fb813085e0dbf5dc23bbc9da6) kanshi: 1.3.0 -> 1.3.1
* [`ca595aca`](https://github.com/NixOS/nixpkgs/commit/ca595aca5b53e747540b0090d0082a3cae804428) mathematica: 13.1.0 -> 13.2.0
* [`f40a383b`](https://github.com/NixOS/nixpkgs/commit/f40a383b2fe91f7e008351b00d43c89982ed4577) python310Packages.sybil: add changelog to meta
* [`8906a6fc`](https://github.com/NixOS/nixpkgs/commit/8906a6fc0a519a15e94b5d7430fef12e594d2a7a) python310Packages.seedir: init at 0.4.2
* [`34cd4905`](https://github.com/NixOS/nixpkgs/commit/34cd4905d1dd6aca830e95ddaecccd879e5bcf30) mathematica: use installer name to decide if it contains local docs
* [`bd0698de`](https://github.com/NixOS/nixpkgs/commit/bd0698de5bd2be4f31911c8cd9c7205adcf7e872) python310Packages.sybil: 3.0.1 -> 4.0.0
* [`f6d1571c`](https://github.com/NixOS/nixpkgs/commit/f6d1571c9e12ded1c3e924521fd77c0d9be1a1ca) python310Packages.testfixtures: add changelog to meta
* [`0442c2e3`](https://github.com/NixOS/nixpkgs/commit/0442c2e3dc1e2245013151567daa975610e1978d) python310Packages.testfixtures: 7.0.0 -> 7.0.4
* [`927a44f5`](https://github.com/NixOS/nixpkgs/commit/927a44f5cf589852c70c1389f41034e5f1974c39) awscli2: 2.9.8 -> 2.9.10
* [`ffb3415f`](https://github.com/NixOS/nixpkgs/commit/ffb3415f02bc2b8bc222e2078c7ace8377272235) python310Packages.sybil: remove whitespace
* [`ecbf09c8`](https://github.com/NixOS/nixpkgs/commit/ecbf09c86f1d4d5551977f0a1b8451a639fae479) newsboat: 2.29 -> 2.30
* [`a78861db`](https://github.com/NixOS/nixpkgs/commit/a78861db45f194b3d829233602dc124c1c257e0d) gnome.gnome-control-center: enable debug info
* [`0f39f3b1`](https://github.com/NixOS/nixpkgs/commit/0f39f3b19456295cd062d2b9f01694cce4662027) gnome-online-accounts: enable debug info
* [`a9f02a84`](https://github.com/NixOS/nixpkgs/commit/a9f02a84d8d517832359da1f7e73053b2eebabbf) librest_1_0: enable debug info
* [`ce98c228`](https://github.com/NixOS/nixpkgs/commit/ce98c228246508fcef720668f8256720310cef47) gvfs: enable debug info
* [`d78711a3`](https://github.com/NixOS/nixpkgs/commit/d78711a3e146fd3da8965e2b82037ced8c9eb7e5) gnustep.base: use multiple outputs and support multiple outputs in hook
* [`6821ff04`](https://github.com/NixOS/nixpkgs/commit/6821ff041ac691bd2afd97d4ebef0392b723b937) mpv: inline lib
* [`bfad8cd5`](https://github.com/NixOS/nixpkgs/commit/bfad8cd5e0c52e2c8db7dab6a843c8d0f0e89f59) paperless-ngx: add celery wrapper
* [`2d7b8ef5`](https://github.com/NixOS/nixpkgs/commit/2d7b8ef56f960645cf4833426e354ac90e3b4c45) nixos/paperless: update for paperless-ngx 1.10.2
* [`cb1e2bf9`](https://github.com/NixOS/nixpkgs/commit/cb1e2bf9c33683ca2fc1df00def5144175f4d117) talosctl: 1.2.8 -> 1.3.0
* [`f1da0f9c`](https://github.com/NixOS/nixpkgs/commit/f1da0f9c8468a46f143e9652bbaa29f68e5745a8) tut: 1.0.26 -> 1.0.30
* [`64a957a7`](https://github.com/NixOS/nixpkgs/commit/64a957a7d1c3e7d1d0efbaa71d52eecb9e2e6f1c) nixos/powerdns: add secretFile option
* [`56acc456`](https://github.com/NixOS/nixpkgs/commit/56acc4566e22310e3ddd72c749c2b93865977a23) luajit_openresty: init at 2.1-20220915
* [`861c7554`](https://github.com/NixOS/nixpkgs/commit/861c7554d18200137a1480d733cbbb337614b500) buildLuaPackage: make makeFlags expandable
* [`40ff955c`](https://github.com/NixOS/nixpkgs/commit/40ff955c07786cf3f5dad27b4f08f1df0f280458) luaPlugins.lua-resty-lrucache: init at 0.13
* [`e33fb741`](https://github.com/NixOS/nixpkgs/commit/e33fb7418d3974b623df53a463f94010d3a101bb) luaPlugins.lua-resty-core: init at 0.1.24
* [`7f64e371`](https://github.com/NixOS/nixpkgs/commit/7f64e371c182a8018fde2eda5f1b44bf118a5e8f) steamtinkerlaunch: 11.11 -> 12.0
* [`fe0a477f`](https://github.com/NixOS/nixpkgs/commit/fe0a477fa2a697b9704150cc3c986cd818628df2) quarto: 1.2.269 -> 1.2.280
* [`5f9146da`](https://github.com/NixOS/nixpkgs/commit/5f9146daee699d5ad3dc21313f77cece4d7afe87) freedv: 1.8.5 -> 1.8.6
* [`0a4fa3fd`](https://github.com/NixOS/nixpkgs/commit/0a4fa3fdc37a71cf4201caea62c1755fb9a973ee) prowlarr: 0.4.10.2111 -> 1.0.0.2171
* [`dc1e00bd`](https://github.com/NixOS/nixpkgs/commit/dc1e00bd8bcf7040573a3a6721fd264d900d13d4) nixos/wg-quick: use `networking.firewall.package`
* [`75050d06`](https://github.com/NixOS/nixpkgs/commit/75050d0675c1ef13bddcf13aab061eb9a77def53) cargo2junit: add alekseysidorov to list of maintainers
* [`62f1c406`](https://github.com/NixOS/nixpkgs/commit/62f1c406b75cacab042f059d29adad9ba5f82b28) cargo2junit: init at 0.1.12
* [`aaa42443`](https://github.com/NixOS/nixpkgs/commit/aaa4244387032623f0f7a749f3c2bd003e64fb2f) vmTools: add ubuntu 22.04
* [`c4bd20a6`](https://github.com/NixOS/nixpkgs/commit/c4bd20a68602c22ef8a872c7c14ad69c13d4f503) nixos/wg-quick: add nftables test
* [`138d4389`](https://github.com/NixOS/nixpkgs/commit/138d4389cc1e2e22637ced70cf3a45c3eaa4f8f7) wireguard-tools: move `iptables` to PATH suffix
* [`2452bd1c`](https://github.com/NixOS/nixpkgs/commit/2452bd1c491fbfa213eea77ce57066777535a69b) osv-scanner: init at 1.0.2
* [`b36e8f73`](https://github.com/NixOS/nixpkgs/commit/b36e8f733df3ca8a60fec114e1ce85e15fb198b2) plasma5: allow pipewire-pulse instead of pulseaudio for mobile
* [`4b7e7275`](https://github.com/NixOS/nixpkgs/commit/4b7e72757bca2ed3f8dd41ec9fa29821e7f5a262) cargo-zigbuild: 0.14.2 -> 0.14.3
* [`93224c21`](https://github.com/NixOS/nixpkgs/commit/93224c214eb3340e2c7c9cb9f063c2220cd9ab74) nixos/iay: add module; iay: add myself as a maintainer
* [`487b51e7`](https://github.com/NixOS/nixpkgs/commit/487b51e77c35a683ca99206a12478f9957a6e942) nixos/nginx: Deduplicate modules.
* [`da4fd3a5`](https://github.com/NixOS/nixpkgs/commit/da4fd3a5a92ad795abef7b9deac8739599782953) python310Packages.vertica-python: 1.1.1 -> 1.2.0
* [`9bc0aeb7`](https://github.com/NixOS/nixpkgs/commit/9bc0aeb745cdfb696856a125c9ac60ea3c28d428) nixos/uptime-kuma: fix link
* [`c361b8af`](https://github.com/NixOS/nixpkgs/commit/c361b8af775a7a934032ddd7283cd0b41e0c04b1) openafs: 1.8.8.1 → 1.8.9
* [`b75aad03`](https://github.com/NixOS/nixpkgs/commit/b75aad03d4ffe4fe94def30b02a261cdcde49d14) electron-fiddle: init 0.31.0
* [`72ea4253`](https://github.com/NixOS/nixpkgs/commit/72ea4253a114117d44df0cc05f4df853cf7030f8) lean: 3.50.1 -> 3.50.2
* [`a8fa345c`](https://github.com/NixOS/nixpkgs/commit/a8fa345c5eb182b68c50102528fb16daf475f880) lean: 3.50.2 -> 3.50.3
* [`cf48fd52`](https://github.com/NixOS/nixpkgs/commit/cf48fd52483b2753fa5271833c64ac8c6109701c) tautulli: remove maintainer csingley
* [`d57af94b`](https://github.com/NixOS/nixpkgs/commit/d57af94bdeab4e7ec068945c63d632f8b43eed05) python310Packages.scikit-hep-testdata: 0.4.24 -> 0.4.25
* [`0fe0ee99`](https://github.com/NixOS/nixpkgs/commit/0fe0ee997ff8914b198f305f48f5de8695e8601d) pipewire: 0.3.63 -> 0.3.63
* [`6ef390ad`](https://github.com/NixOS/nixpkgs/commit/6ef390adbf7b83504d5fed981b8561e7c51031e4) python310Packages.django-storages: 1.13.1 -> 1.13.2
* [`474198f8`](https://github.com/NixOS/nixpkgs/commit/474198f808502a76f636bb677a5d028d2ca5a5c9) darwin.builder: Fix gratuitous rebuilds
* [`e6fbc469`](https://github.com/NixOS/nixpkgs/commit/e6fbc469ad428cb139e8cd5fbc3105ff86c8cd67) httm: 0.17.10 -> 0.18.3
* [`48adc162`](https://github.com/NixOS/nixpkgs/commit/48adc1627bc7efc33f0f964cc2eafea0b1902f71) python39Packages.nvidia-ml-py: 11.515.48 -> 11.515.75
* [`c09bdb1f`](https://github.com/NixOS/nixpkgs/commit/c09bdb1fc4557b310a41bc1a01c58a1e32d55c3a) python39Packages.ezyrb: 1.3.0.post2209 -> 1.3.0.post2212
* [`939606a9`](https://github.com/NixOS/nixpkgs/commit/939606a99ce0eaf217d047302885ae14aea605d2) wbg: use lib.mesonEnable
* [`7b705d15`](https://github.com/NixOS/nixpkgs/commit/7b705d1546ec6c6a623c4586551e58788dbea479) fcft: use lib.mesonEnable
* [`5e3e81f6`](https://github.com/NixOS/nixpkgs/commit/5e3e81f6048239c821e7663a2371d4cd018b1ef1)  harfbuzz: use lib.mesonEnable, cleanup up let in
* [`35cea3b2`](https://github.com/NixOS/nixpkgs/commit/35cea3b24c1fb38908920bc15b417a46e6dbceaf) vals: 0.19.0 -> 0.21.0
* [`c2ea8983`](https://github.com/NixOS/nixpkgs/commit/c2ea89836082775acfef4beb4526a022e6ad656d) opencpn: migrate to apple_sdk_11_0
* [`7d23200c`](https://github.com/NixOS/nixpkgs/commit/7d23200c0682010e02113b3f27385f932c3a6d82) didyoumean: 1.1.3 -> 1.1.4
* [`ad9d4e57`](https://github.com/NixOS/nixpkgs/commit/ad9d4e57f6796e6d984d43bd7349e32d2459a3a3) trackballs: 1.3.3 -> 1.3.4
* [`42943086`](https://github.com/NixOS/nixpkgs/commit/42943086571097d24157ae7424009225564a412c) python39Packages.coinmetrics-api-client: 2022.9.22.15 -> 2022.11.14.16
* [`ba6d6537`](https://github.com/NixOS/nixpkgs/commit/ba6d653707c56e658394926553c0cbd1efbda4a5) mongodb: default to mongodb-6_0
* [`06ce75d7`](https://github.com/NixOS/nixpkgs/commit/06ce75d72429de2fba0fa2c2b2e3011c5ece5654) mongodb-3_4, mongodb-3_6: drop
* [`19efc99a`](https://github.com/NixOS/nixpkgs/commit/19efc99aee4cc3d07b074945decd38590da1760f) php80Packages.composer: 2.5.0 -> 2.5.1
* [`ec36ffd7`](https://github.com/NixOS/nixpkgs/commit/ec36ffd7cc683b72913514f1db64c9dca3478375) polymake: 4.7 -> 4.8
* [`391de01d`](https://github.com/NixOS/nixpkgs/commit/391de01d3c096de5fcde5e30311e7ceb6491a1ab) python39Packages.coinmetrics-api-client: use optional-dependencies for test deps
* [`581f3759`](https://github.com/NixOS/nixpkgs/commit/581f37593551a90ae2a95c8f868b00ff03e45226) python310Packages.django-storages: add changelog to meta
* [`b089c076`](https://github.com/NixOS/nixpkgs/commit/b089c076aa98cfcb58746b293908a09760ec3487) python310Packages.vertica-python: add changelog to meta
* [`fc4b3677`](https://github.com/NixOS/nixpkgs/commit/fc4b36771be28f05d2051c2d449b5736082e7e93) polymake: add changelog to meta
* [`a2080cf0`](https://github.com/NixOS/nixpkgs/commit/a2080cf0b1ab7fc4b9448a4d9ad7b84f4f0c41d8) python310Packages.aliyun-python-sdk-cdn: 3.7.9 -> 3.7.10
* [`3c240f5f`](https://github.com/NixOS/nixpkgs/commit/3c240f5f78072054bb0b7aef9703de6b70e345f9) python310Packages.aliyun-python-sdk-config: 2.2.2 -> 2.2.3
* [`0947e46d`](https://github.com/NixOS/nixpkgs/commit/0947e46d11b28adb4ddcd9db42806c08966abf46) python310Packages.plugwise: 0.26.0 -> 0.27.0
* [`688042d2`](https://github.com/NixOS/nixpkgs/commit/688042d20021e9e271993ca8a2183348e099797c) python310Packages.pyskyqremote: 0.3.21 -> 0.3.22
* [`fdabe557`](https://github.com/NixOS/nixpkgs/commit/fdabe5577d855c27e8b36b054983c5179c09718a) python310Packages.skodaconnect: 1.2.2 -> 1.2.5
* [`4bb6b5ee`](https://github.com/NixOS/nixpkgs/commit/4bb6b5ee5fed43d4e5719d86af59404ef6b76990) libacr38u: unbreak on aarch64-darwin
* [`569d65e6`](https://github.com/NixOS/nixpkgs/commit/569d65e69ea980f9ed74715bdb2bb87fb9efda2c) k6: 0.41.0 -> 0.42.0
* [`c874cd0b`](https://github.com/NixOS/nixpkgs/commit/c874cd0b3825124a3b067f7f8db4f060f209956c) libsForQt5.libopenshot-audio: unbreak on aarch64-darwin
* [`abc198bf`](https://github.com/NixOS/nixpkgs/commit/abc198bf73e5ded6f1eebb4982596f114d1186ba) libsForQt5.libopenshot: add darwin support
* [`3148ec4f`](https://github.com/NixOS/nixpkgs/commit/3148ec4f6c088eff4f4a43f1f4e78f4418d7f5be) cachix-agent: always restart
* [`385c252b`](https://github.com/NixOS/nixpkgs/commit/385c252b3aa291f2689047ae364f8158eeb030a3) jumanpp: unbreak on aarch64-darwin
* [`c549ba2a`](https://github.com/NixOS/nixpkgs/commit/c549ba2a2724ff9f2a5a686fee69a56c248249bb) mongoose: unbreak on aarch64-darwin
* [`a91852b7`](https://github.com/NixOS/nixpkgs/commit/a91852b7bb9d7a122eb42bc721423ed44fc98be4) python310Packages.statsmodels: 0.13.2 -> 0.13.4
* [`1e929f36`](https://github.com/NixOS/nixpkgs/commit/1e929f36fb9af24b28afad6a078b2d18f4086687) python310Packages.tenacity: 8.0.1 -> 8.1.0
* [`a4b7d0e6`](https://github.com/NixOS/nixpkgs/commit/a4b7d0e650678ce616b07d3006a9bdcb85f4894d) python310Packages.teslajsonpy: 3.6.0 -> 3.7.0
* [`649fa431`](https://github.com/NixOS/nixpkgs/commit/649fa431c10c7f889d6ba5fa6e3bde47697ad547) vimPlugins.sniprun: 1.1.2 -> 1.2.8
* [`112fa929`](https://github.com/NixOS/nixpkgs/commit/112fa92938583e841128d65d4637b409d00fc4a6) calico-various,calicoctl,confd-calico: init at 3.24.5
* [`faae415d`](https://github.com/NixOS/nixpkgs/commit/faae415dcda7e23c5d22fef7a8a92c6cf80abfdc) akkoma: init at 3.5.0
* [`6658dfbe`](https://github.com/NixOS/nixpkgs/commit/6658dfbefbf4de06efc4df3fdd4b416dae53daf4) akkoma-frontends/pleroma-fe: init at unstable-2022-12-10
* [`628b61f3`](https://github.com/NixOS/nixpkgs/commit/628b61f33fcbb2530da55e9419c99bc5924675ad) akkoma-frontends/admin-fe: init at unstable-2022-09-10
* [`faa2d4fd`](https://github.com/NixOS/nixpkgs/commit/faa2d4fd40051070b1b042ed0f21fc0e50728df5) akkoma-emoji/blobs_gg: init at unstable-2019-17-24
* [`d84d630e`](https://github.com/NixOS/nixpkgs/commit/d84d630ec807f0af758c4c0c6443019501be901a) python310Packages.levenshtein: 0.20.8 -> 0.20.9
* [`32abeeae`](https://github.com/NixOS/nixpkgs/commit/32abeeae5f3e45b78801ff9393c9cb222528f455) google-cloud-sdk: add numpy dependency for IAP performances. ([nixos/nixpkgs⁠#206105](https://togithub.com/nixos/nixpkgs/issues/206105))
* [`ea1b1810`](https://github.com/NixOS/nixpkgs/commit/ea1b1810233b6c306efc4532506b3d369429efd0) python310Packages.jupyterlab: 3.5.1 -> 3.5.2 ([nixos/nixpkgs⁠#207258](https://togithub.com/nixos/nixpkgs/issues/207258))
* [`2490ee90`](https://github.com/NixOS/nixpkgs/commit/2490ee906edf4a75624c590350760a66030a863f) nixos/akkoma: init
* [`a6f1bae9`](https://github.com/NixOS/nixpkgs/commit/a6f1bae94614e1efc007bd61ab9e7279cebc3864) nixos/tests/akkoma: init
* [`a9601933`](https://github.com/NixOS/nixpkgs/commit/a9601933ea41b1af21554d9a6558f950e24619f5) rl-2305: Mention Akkoma addition
* [`e677218d`](https://github.com/NixOS/nixpkgs/commit/e677218d32e46605b40ac198b163f75943e37a81) Haskell: Fix dead link in report
* [`69d576fa`](https://github.com/NixOS/nixpkgs/commit/69d576fa5d1834fbf7a1592d90160e57721ab1ed) python310Packages.asana: 2.0.0 -> 3.0.0
* [`d11832fd`](https://github.com/NixOS/nixpkgs/commit/d11832fd96ec146fc57ad11ec71dda7c0a2dee9c) doc,nixos/doc: unescape apostrophes
* [`e9e65810`](https://github.com/NixOS/nixpkgs/commit/e9e65810aca80e38dbc36f59a4400cfd5defaf82) doc,nixos/doc: unescape double quotes
* [`3f6fed2e`](https://github.com/NixOS/nixpkgs/commit/3f6fed2e59d556a5cec475b14b7af54558e19f25) doc,nixos/doc: unescape ellipses
* [`07cb3bf3`](https://github.com/NixOS/nixpkgs/commit/07cb3bf3ccaff42789336a0a22c49ea4d25d309b) nixos/doc: bump Pandoc
* [`73c0b5c4`](https://github.com/NixOS/nixpkgs/commit/73c0b5c4e87b8fadcaf0f06b5adf95f995bfeeae) nixos/users-groups: make isNormalUser description readable
* [`b1a9bf53`](https://github.com/NixOS/nixpkgs/commit/b1a9bf530cdf5a3e48740bda6ef5cbcb5433f5fe) default-crate-overrides.nix: add pango-sys ([nixos/nixpkgs⁠#190604](https://togithub.com/nixos/nixpkgs/issues/190604))
* [`ab6f4b5a`](https://github.com/NixOS/nixpkgs/commit/ab6f4b5ac3eb0e084d75f679d83c0776f761f8e8) gnirehtet: patch for recent rust versions
* [`e378e123`](https://github.com/NixOS/nixpkgs/commit/e378e12329351f53fffa847ffe0fae815f85b202) python310Packages.asana: add changelog to meta
* [`807d41c7`](https://github.com/NixOS/nixpkgs/commit/807d41c77fdc3068eb03f03a86b65ab9f822c63d) python310Packages.scikit-hep-testdata: add changelog to meta
* [`6f70efb6`](https://github.com/NixOS/nixpkgs/commit/6f70efb6fb81ef07d4fc0c356952951a04831815) got: unbreak on x86_64-darwin
* [`bc60f09f`](https://github.com/NixOS/nixpkgs/commit/bc60f09f795e0ceaec2a1f153e94969f282b9ccc) qdrant: unbreak on x86_64-darwin
* [`685bf1f6`](https://github.com/NixOS/nixpkgs/commit/685bf1f69094172dd56a989ea015886ea0e83e7c) coqPackages.coq: fix typo
* [`bce57f37`](https://github.com/NixOS/nixpkgs/commit/bce57f372f295a198037c7ddebb8735d4b4e49a8) python310Packages.pyunifiprotect: 4.5.2 -> 4.5.3
* [`d20c3567`](https://github.com/NixOS/nixpkgs/commit/d20c3567fdd54ce5b90253c59a4cd7347c898d3d) python310Packages.archinfo: 9.2.30 -> 9.2.31
* [`2fa0c1a8`](https://github.com/NixOS/nixpkgs/commit/2fa0c1a8c9c20925cf945937725fcd76d0da9eae) python310Packages.ailment: 9.2.30 -> 9.2.31
* [`56832a46`](https://github.com/NixOS/nixpkgs/commit/56832a46318e9fabfcae0fb45abd88eb2b234fec) python310Packages.pyvex: 9.2.30 -> 9.2.31
* [`d83f8e90`](https://github.com/NixOS/nixpkgs/commit/d83f8e90fafd7ed7c9694841291fd727c61f1db3) python310Packages.claripy: 9.2.30 -> 9.2.31
* [`32faf7f3`](https://github.com/NixOS/nixpkgs/commit/32faf7f348543875ce3ff52f15c0518a991d48fa) python310Packages.cle: 9.2.30 -> 9.2.31
* [`c3277d00`](https://github.com/NixOS/nixpkgs/commit/c3277d0055f6718096d69fec82da8648a7edee08) python310Packages.angr: 9.2.30 -> 9.2.31
* [`96645175`](https://github.com/NixOS/nixpkgs/commit/966451750621f247b702135dfc5e4aaec6856fc5) python310Packages.yoda: rename lib.optional
* [`ce4b239b`](https://github.com/NixOS/nixpkgs/commit/ce4b239b10a090728de4e60920f6bf4d56163424) gtk2: drop unused xlibsWrapper import
* [`644c9c2f`](https://github.com/NixOS/nixpkgs/commit/644c9c2f087a8267fcb318b5bb830f86b65e1320) postgresql11Packages.pgrouting: 3.3.2 -> 3.4.2
* [`f2957604`](https://github.com/NixOS/nixpkgs/commit/f295760430847562b5b22797353743fa9f501c61) ruff: 0.0.194 -> 0.0.196
* [`2bcb3229`](https://github.com/NixOS/nixpkgs/commit/2bcb322973e6b28ebb13f12a1ca03563775c82e3) jquake: 1.8.1 -> 1.8.4
* [`ede90bb8`](https://github.com/NixOS/nixpkgs/commit/ede90bb8e12e26702efec3cc0e6f67745b6df67d) trafficserver: 9.1.3 -> 9.1.4
* [`f16c027c`](https://github.com/NixOS/nixpkgs/commit/f16c027c8253accd72dcad020d928982e007ef9a) fornalder: unstable-2022-07-23 -> unstable-2022-12-25
* [`28472732`](https://github.com/NixOS/nixpkgs/commit/284727327925b0c9c053efe1a74bd50416e58f3a) vitess: init at 15.0.0 ([nixos/nixpkgs⁠#203905](https://togithub.com/nixos/nixpkgs/issues/203905))
* [`e0cc9fdc`](https://github.com/NixOS/nixpkgs/commit/e0cc9fdce779eaf24e54a759ca1dfaea53d6054b) python310Packages.pontos: 22.12.1 -> 22.12.1
* [`85106a20`](https://github.com/NixOS/nixpkgs/commit/85106a20c1fe9e34a4de711ac2c21002f3f2be29) python310Packages.pyunifiprotect: 4.5.2 -> 4.5.3
* [`c31dae0c`](https://github.com/NixOS/nixpkgs/commit/c31dae0c15d5b98ba0058732ef02c10c9edff6f6) python310Packages.whois: add changelog to meta
* [`896ed909`](https://github.com/NixOS/nixpkgs/commit/896ed909723bcf0839a92e3e228d9c4aadc3df61) python310Packages.whois: 0.9.18 -> 0.9.19
* [`4c9aec5d`](https://github.com/NixOS/nixpkgs/commit/4c9aec5db8cd3751a01fcdb23c797cbffd94e571) python310Packages.ghrepo-stats: add changelog to meta
* [`ea69fe42`](https://github.com/NixOS/nixpkgs/commit/ea69fe428f0e0d08c2d16eb2db9c54cb24c22cc6) python310Packages.ghrepo-stats: 0.3.1 -> 0.4.0
* [`518bede4`](https://github.com/NixOS/nixpkgs/commit/518bede442e8be0fc668811d84c7a6df78e5f4ce) xorg:xhost: 1.0.8 -> 1.0.9
* [`17b0cfb2`](https://github.com/NixOS/nixpkgs/commit/17b0cfb2ea76021921d5f5e5266dfcace5eefeca) python310Packages.asana: fix typo
* [`f7bcf776`](https://github.com/NixOS/nixpkgs/commit/f7bcf776cea59d8301f0f89e186bbb94e5ab6d5c) python310Packages.sanic-testing: 22.9.0 -> 22.12.0
* [`1a0329fa`](https://github.com/NixOS/nixpkgs/commit/1a0329fa5b5d6f5be74e6ba9767b3085aee91a18) debian-devscripts: Fix up a /bin/bash reference
* [`da8ac76b`](https://github.com/NixOS/nixpkgs/commit/da8ac76bc4f8dae3b79af76558febf0a03b5d4fb) debian-devscripts: Add missing symlinks
* [`c3161d81`](https://github.com/NixOS/nixpkgs/commit/c3161d81bd54122c26021a26e3e571de86d593ce) linuxdoc-tools: init at 0.9.82
* [`77763b4c`](https://github.com/NixOS/nixpkgs/commit/77763b4c88fcb64be548d419fc8a4f0ac04548ea) ulogd: init at 2.0.8
* [`bcbedfee`](https://github.com/NixOS/nixpkgs/commit/bcbedfeefc21fee3e3f7f897c803adfad425f6d0) nixos/ulogd: init
* [`c5b3696c`](https://github.com/NixOS/nixpkgs/commit/c5b3696c8e17383851a2cf719fc0d9a779f71437) signal-desktop-beta: v6.2.0-beta.1 -> v6.2.0-beta.2
* [`8e311bfa`](https://github.com/NixOS/nixpkgs/commit/8e311bfac4f46758e037b3c58333e8a13e782614) jumpy: remove duplicate build inputs
* [`4cb228c8`](https://github.com/NixOS/nixpkgs/commit/4cb228c88c6d45d025da3776c79be143f0e3c1b9) shellcheck, haskellPackages.ShellCheck: add maintainer
* [`232b5080`](https://github.com/NixOS/nixpkgs/commit/232b50805970de8453532dfdbc52375f80175bf3) haskellPackages.ShellCheck: unpin
* [`5cf58a84`](https://github.com/NixOS/nixpkgs/commit/5cf58a844e313f61f6138d9c3126949d0c1b5f0f) haskellPackages.haskell-ci: pin to ShellCheck_0_8_0
* [`3bc05714`](https://github.com/NixOS/nixpkgs/commit/3bc05714b6fd12bbef6bb34bf40d863610b92649) haskellPackages: regenerate package set based on current config
* [`929341ff`](https://github.com/NixOS/nixpkgs/commit/929341ffa2f4f98b1a4554ade62009f4c1c19dd8) python310Packages.pytools: 2022.1.12 -> 2022.1.14
* [`8c89ee54`](https://github.com/NixOS/nixpkgs/commit/8c89ee54be14f26b3555c5ce442d45cbb21bae2c) goreleaser: 1.13.1 -> 1.14.0
* [`9d733987`](https://github.com/NixOS/nixpkgs/commit/9d7339877a6d615fad1a0dd488e9d2dc7197fa63) nixos/environment: fix variables type
* [`2778689b`](https://github.com/NixOS/nixpkgs/commit/2778689bd217ec9472da4134bc0bb2cd0e7610d6) aws-vault: 6.6.0 -> 6.6.1
* [`f0613936`](https://github.com/NixOS/nixpkgs/commit/f0613936814fba08463a3be2713db6dec9308c70) sofia_sip: 1.13.9 -> 1.13.10
* [`882ea7d5`](https://github.com/NixOS/nixpkgs/commit/882ea7d516acabe8845f177abf639d913e44f246) buf: 1.9.0 -> 1.11.0
* [`04adf61a`](https://github.com/NixOS/nixpkgs/commit/04adf61af7df769fc01e7dd4c6c339ffffaeecd9) ruff: 0.0.196 -> 0.0.198
* [`b1bc204c`](https://github.com/NixOS/nixpkgs/commit/b1bc204c5cd697eee9942a3b2bff92da4adc1f84) python310Packages.google-nest-sdm: 2.1.0 -> 2.1.2
* [`eede9fe3`](https://github.com/NixOS/nixpkgs/commit/eede9fe3b6364a30b6b83ff617416d60b4196822) ocenaudio: 3.11.15 -> 3.11.20
* [`57dbff42`](https://github.com/NixOS/nixpkgs/commit/57dbff4228a9d8fba7aedf439ffdd841a2326427) erlang_odbc: 24.3.4.6 -> 24.3.4.7
* [`800d3b75`](https://github.com/NixOS/nixpkgs/commit/800d3b75f05ab8157480c836deb0b49909522526) gnome.gnome-flashback: fix crash on start due to not finding .desktops
* [`6be1c77f`](https://github.com/NixOS/nixpkgs/commit/6be1c77f05332b635eef7a3e9d8c789eeb5291b8) ares: add darwin support
* [`ca743b7a`](https://github.com/NixOS/nixpkgs/commit/ca743b7afc87b9cd55ea6126a19be9fc384badd5) topgrade: 10.2.2 -> 10.2.4
* [`fc5ddb40`](https://github.com/NixOS/nixpkgs/commit/fc5ddb4093f5a5cba7a6d39ad9a2f17e3833f6e4) diffsitter: 0.7.2 -> 0.7.3
* [`0dd2658b`](https://github.com/NixOS/nixpkgs/commit/0dd2658bf3b4610fece1e130454cb01e89c48794) q 0.8.2 -> 0.8.4
* [`97e489fe`](https://github.com/NixOS/nixpkgs/commit/97e489feea9c8804caad35df283a0c56f537173b) scummvm: 2.5.1 -> 2.6.1
* [`66d8803c`](https://github.com/NixOS/nixpkgs/commit/66d8803cad0c2f35643799094e03daa4ef6d2f14) motion: 4.5.0 -> 4.5.1
* [`3a38b6b3`](https://github.com/NixOS/nixpkgs/commit/3a38b6b342d1e287cbec24cdf651f799d2ce4b86) quark-engine: 21.10.2 -> 22.12.1
* [`b851cbd5`](https://github.com/NixOS/nixpkgs/commit/b851cbd5b28e9951e54f0301be62b8443648e075) sing-box: init at 1.1.1
* [`9fdbe9dd`](https://github.com/NixOS/nixpkgs/commit/9fdbe9dd4604cb90d6c42060af3c0ed5debaa2a3) haskellPackages.singletons-base: jailbreak in order to get compiling
* [`1bc62c44`](https://github.com/NixOS/nixpkgs/commit/1bc62c4476b9adfd66117479b63eab1876de515b) mold: 1.7.1 -> 1.8.0
* [`a9dc71a3`](https://github.com/NixOS/nixpkgs/commit/a9dc71a31712e10a1226aff7cc0ac2bbe1bdc81b) topgrade: add changelog to meta
* [`dc3b1ab1`](https://github.com/NixOS/nixpkgs/commit/dc3b1ab179dc19b516ece4611575200bf395d444) python310Packages.google-nest-sdm: add changelog to meta
* [`50f2ae4d`](https://github.com/NixOS/nixpkgs/commit/50f2ae4d57976b2d10244e1494356c49b4af8b76) cpeditor: 6.10.1 -> 6.11.1
* [`59f24bec`](https://github.com/NixOS/nixpkgs/commit/59f24bec41c1bae7b2c2179df6d603ccbfc1851f) cutecom: enable on darwin
* [`753b4713`](https://github.com/NixOS/nixpkgs/commit/753b4713328bdbd8d53b4ffbff32c7a70648754b) protobufc: fix cross compilation
* [`5c15e1c8`](https://github.com/NixOS/nixpkgs/commit/5c15e1c8cf7a0399cbd1bceab6b1fb2094f81bd1) ocamlPackages.jwto: 0.3.0 → 0.4.0
* [`8b6d55d9`](https://github.com/NixOS/nixpkgs/commit/8b6d55d9695afa3a5fe2634428ad9d507ad20fa3) clasp: remove at 3.1.4
* [`816f545d`](https://github.com/NixOS/nixpkgs/commit/816f545d36c6be0b1a9085eaaacb5d8b6a05a157) netflix: allow passing flags to google-chrome
* [`433a78bc`](https://github.com/NixOS/nixpkgs/commit/433a78bcdb650335dbc7cf926e07318a2cbea3b9) sing-box: install shell completions
* [`fbd5b7c6`](https://github.com/NixOS/nixpkgs/commit/fbd5b7c68a1d32cf8448baabe1e56749bd7d17bd) gnomeExtensions.paperwm: 38.2 -> unstable-2022-12-14
* [`8e083efd`](https://github.com/NixOS/nixpkgs/commit/8e083efd2e4da9acaec2ef2a8d313165dfc20f49) python310Packages.meshtastic: 2.0.6 -> 2.0.7
* [`2d1dee4f`](https://github.com/NixOS/nixpkgs/commit/2d1dee4f6a6dac81b3bc4a3e7bdf76c9e5ec4008) colima: 0.5.0 -> 0.5.2
* [`503c4c1b`](https://github.com/NixOS/nixpkgs/commit/503c4c1b68703ece131a8738a5d5e5610b62503a) antlr4: 4.8.x -> 4.11.x
* [`fd2a0bdd`](https://github.com/NixOS/nixpkgs/commit/fd2a0bdd6bd430c57fd1bb6dc489cb218e043142) python3Packages.antlr4-python-runtime: remove versioned variants
* [`22581566`](https://github.com/NixOS/nixpkgs/commit/2258156699eecd4cb22ab1d48694fda1a0ea418a) python3Packages.antlr4-python3-runtime: run correct tests
* [`e98704b1`](https://github.com/NixOS/nixpkgs/commit/e98704b1974e671d5912f3d53c52d24df6fc3191) luaformatter: pin antlr4_9
* [`9de9273f`](https://github.com/NixOS/nixpkgs/commit/9de9273f33adee23ecf633ea4c8d90eb271415a6) baserow: Use antlr4_9 in antlr4-python3-runtime
* [`56918eeb`](https://github.com/NixOS/nixpkgs/commit/56918eebbaeb5e7cdd1101e8fc707b89716440fe) python3Packages.hydra-core: rename from hydra
* [`47967562`](https://github.com/NixOS/nixpkgs/commit/47967562fad687ba6d6ce0fc2a8d075455da6162) python3Packages.omegaconf: relax antlr4 version
* [`b71ad921`](https://github.com/NixOS/nixpkgs/commit/b71ad92137d9487af9374e59c0c9d2068b6c0465) python3Packages.hydra-core: unpin antlr4-python3-runtime
* [`4a0fefa6`](https://github.com/NixOS/nixpkgs/commit/4a0fefa62c63ade30b58bc05514c2fae9e45b36a) python3Packages.explorerscript: unpin antlr4-python3-runtime
* [`c561e401`](https://github.com/NixOS/nixpkgs/commit/c561e4010a8582d1dc1bd92f48dac31d63ef1ad5) python3Packages.hydra-core: Unbreak on aarch64-linux
* [`e0beb61e`](https://github.com/NixOS/nixpkgs/commit/e0beb61e601c1c4451dee3430ce520f0d2defc60) python3Packages.hassil: init at 0.1.3
* [`3e0afdcc`](https://github.com/NixOS/nixpkgs/commit/3e0afdcc87141850c548b17d782ed903e644d1c1) qovery-cli: 0.46.7 -> 0.47.2
* [`ca71219e`](https://github.com/NixOS/nixpkgs/commit/ca71219e61b592f53c3856e737e0db097ea88bf4) simdjson: fix build on powerpc64
* [`0f0929f4`](https://github.com/NixOS/nixpkgs/commit/0f0929f4aa73b731130be5f9ebe7426eb4c0661d) nixos/borgbackup: fix ~/.cache, ~/.config ownership
* [`a278b2d6`](https://github.com/NixOS/nixpkgs/commit/a278b2d65df126e02536544d18c1d24e98eb4adb) vcmi: 1.0.0 -> 1.1.0
* [`cfe303f7`](https://github.com/NixOS/nixpkgs/commit/cfe303f7a4e70d4ace7315b0530b7c05c197014b) ares: refactor against [nixos/nixpkgs⁠#204303](https://togithub.com/nixos/nixpkgs/issues/204303)
* [`e238c3fd`](https://github.com/NixOS/nixpkgs/commit/e238c3fdaab710a2ce0135e5a77cd7e6bb023a22) haskell.packages.*.binary-orphans: provide OneTuple when necessary
* [`f55c9ff2`](https://github.com/NixOS/nixpkgs/commit/f55c9ff28870d6eacf79fededc96a87f46740078) rhoas: 0.51.7 -> 0.51.9
* [`f03c7fb8`](https://github.com/NixOS/nixpkgs/commit/f03c7fb8d4e5fa75962f41b821b17e5ef8154c96) nixos/version: Only warn about unset stateVersion if used
* [`30548793`](https://github.com/NixOS/nixpkgs/commit/30548793ab82c2a57239f71a413fd869cd67b300) darwin.builder: Avoid unnecessary dependency on stateVersion
* [`62c8b5bf`](https://github.com/NixOS/nixpkgs/commit/62c8b5bf85b064478e9696c365ead13a8981898a) nixos/macos-builder: Simplify error message
* [`91050a9d`](https://github.com/NixOS/nixpkgs/commit/91050a9d9d21c18660da4b5cc88a3c9b2b23adda) nixos/macos-builder: Remove unnecessary paragraph
* [`f76e5335`](https://github.com/NixOS/nixpkgs/commit/f76e5335d68ae2e4196e77d2f4bd2ad4a00d31fe) sptk: 4.0 -> 4.1
* [`d1b54838`](https://github.com/NixOS/nixpkgs/commit/d1b54838bd6bd1c9ecaea34ec5c5b02edcf5ae1c) libsForQt5.libopenshot-audio: convert to patch
* [`79a92931`](https://github.com/NixOS/nixpkgs/commit/79a92931f33f5e14387784c2c0ccf51c844343d1) vscode-extensions.james-yu.latex-workshop: 9.2.0 -> 9.2.1
* [`f955d78e`](https://github.com/NixOS/nixpkgs/commit/f955d78e27ecfc7f66d3d141a309de2d77095747) hypr: unbreak on darwin
* [`fe4b57ac`](https://github.com/NixOS/nixpkgs/commit/fe4b57acf16f494b9208f231a59e38052e8a48e5) jenkins 2.361.4 -> 2.375.1
* [`e772ade4`](https://github.com/NixOS/nixpkgs/commit/e772ade40ac721e48a1897672b517e3babeb7c17) plasma5Packages.okular: add option to build without qtspeech
* [`bf2067d0`](https://github.com/NixOS/nixpkgs/commit/bf2067d09da64db45c00ee2f9f6a39c4008a29eb) ocamlPackages.conduit: 5.1.0 -> 6.1.0
* [`17234774`](https://github.com/NixOS/nixpkgs/commit/172347745ffb457e47cf5386f2ae3ff6678c2b02) nixVersion.nix_{2_6,2_7,2_8,2_9}: remove
* [`b9e503a3`](https://github.com/NixOS/nixpkgs/commit/b9e503a35e564c6ad4e5d8560b80468a93a406a4) cachix,hercules-ci-{agent,cnix-expr,cnix-store}: bump nix pin to 2_10
* [`2ecd8cbb`](https://github.com/NixOS/nixpkgs/commit/2ecd8cbbc506c55702612edb7b4e047c82ed5ee4) rnix-lsp: 0.2.5 -> unstable-2022-11-27
* [`a519bddf`](https://github.com/NixOS/nixpkgs/commit/a519bddf0d7a2736046b4cabbd59954be1d07bd3) packagekit: disable nix backend
* [`c594a1dc`](https://github.com/NixOS/nixpkgs/commit/c594a1dce6f28c6d5bdf31dd36c3a85adde79c5c) python310Packages.certbot-dns-inwx: 2.1.3 -> 2.2.0
* [`4d1d526c`](https://github.com/NixOS/nixpkgs/commit/4d1d526ca74e1989acdd3b9c0a119f69951f119e) haskellPackages.reflex: Pin to < 0.9
* [`6322eff4`](https://github.com/NixOS/nixpkgs/commit/6322eff41e59a74ad2493da7e8ceca3a995e8cea) ocamlPackages.tsdl: 0.9.8 -> 0.9.9
* [`741a0f5a`](https://github.com/NixOS/nixpkgs/commit/741a0f5a7f0dc997b775cb3bc45b469ba23e4675) envfs: init at 1.0.0
* [`b08fa40e`](https://github.com/NixOS/nixpkgs/commit/b08fa40e69294c2b745cc9bbff188839dfcc915a) pkgsStatic.dash: fix build
* [`54c973aa`](https://github.com/NixOS/nixpkgs/commit/54c973aa91e7ad2b35dacf9a27d356ed3d3a4bdc) python310Packages.wled: 0.14.1 -> 0.15.0
* [`374cfcfa`](https://github.com/NixOS/nixpkgs/commit/374cfcfa35fe358185f54354e3f4a6d5fae8e389) pulumictl: 0.0.32 -> 0.0.38
* [`d3291f4f`](https://github.com/NixOS/nixpkgs/commit/d3291f4f2ae9e96bb542caae58ca6cf9cd1df3fa) devilutionx: 1.4.0 -> 1.4.1
* [`76aaf902`](https://github.com/NixOS/nixpkgs/commit/76aaf902a52f3df46d4f7852627c9603251eee63) bsnes-hd: unbreak on x86_64-darwin
* [`d3f1d149`](https://github.com/NixOS/nixpkgs/commit/d3f1d1491233e4a92add5cdc958a82981766f3a8) haskellPackages: mark builds failing on hydra as broken
* [`7e74ec53`](https://github.com/NixOS/nixpkgs/commit/7e74ec53da20c288f9a45047e67e8227d95b2a55) libwebsockets: use multiple outputs
* [`7fb1be82`](https://github.com/NixOS/nixpkgs/commit/7fb1be82f4e180da9b53fb06de4d91c43b605b0f) libwebsockets: build static library only when necessary
* [`f7fba032`](https://github.com/NixOS/nixpkgs/commit/f7fba0329f662ca23f6a2ac2c0e576354a7203a7) maestro: 1.17.2 -> 1.18.2
* [`3a58dfb3`](https://github.com/NixOS/nixpkgs/commit/3a58dfb33e083278b0215a8a0f693dcbe25c04b7) python3Packages.maestral: 1.6.3 -> 1.6.4
* [`253f19bf`](https://github.com/NixOS/nixpkgs/commit/253f19bf957ecc442481d567582514a202c819d8) maestral-gui: 1.6.3 -> 1.6.4
* [`9499f943`](https://github.com/NixOS/nixpkgs/commit/9499f943dd2735d721892c3506fe7f9a2c69fb82) haskellPackages: mark builds failing on hydra as broken
* [`025d862b`](https://github.com/NixOS/nixpkgs/commit/025d862be6a2231278fc68246b3d5b67f7228e6e) vimPlugins.orgmode: add treesitter dependencies
* [`1f573777`](https://github.com/NixOS/nixpkgs/commit/1f573777e36bb3c9e29d47f3c2f010e1efbddb03) vimPlugins.rest-nvim: add treesitter dependencies
* [`d62ef663`](https://github.com/NixOS/nixpkgs/commit/d62ef66317fe1eddfe404a1f1b62c19b4522ecc8) python3Packages.maestral: 1.6.4 -> 1.6.5
* [`dbeea537`](https://github.com/NixOS/nixpkgs/commit/dbeea53715caf8730d6acf7d8b6a38d589daf12f) maestral-gui: 1.6.4 -> 1.6.5
* [`b2025a30`](https://github.com/NixOS/nixpkgs/commit/b2025a306f8ef05ed7f98141466a29d13797c9cd) superd: 0.7 -> 0.7.1
* [`d0d025d1`](https://github.com/NixOS/nixpkgs/commit/d0d025d151a7eb2928cb24d4dfb46e5a9d39aff8) all-cabal-hashes: 2022-12-24T13:11:25Z -> 2022-12-28T16:35:05Z
* [`b95d9164`](https://github.com/NixOS/nixpkgs/commit/b95d9164eca31f9432efc6eea0df8abe9c97fd10) haskellPackages: regenerate package set based on current config
* [`b86d1f49`](https://github.com/NixOS/nixpkgs/commit/b86d1f49363d299128433a2489f03cdee9dc22a8) python310Packages.fireflyalgorithm: 0.3.3 -> 0.3.4
* [`a1f6c65b`](https://github.com/NixOS/nixpkgs/commit/a1f6c65bfc8d640738d4683b62a61b91b7c346d6) haskellPackages.git-brunch: unbreak
* [`78555d75`](https://github.com/NixOS/nixpkgs/commit/78555d7540db828a8bbcd708263b6439470a9abe) matrix-synapse: Use improved user search
* [`bbbb7a79`](https://github.com/NixOS/nixpkgs/commit/bbbb7a79cd05f8cfe483616f1edeb6679ae94e72) python3Packges.pyicu: rename from PyICU
* [`31f2a1bd`](https://github.com/NixOS/nixpkgs/commit/31f2a1bdb5848e8579149faa21551080749f8053) python310Packages.google-cloud-iam: add changelog to meta
* [`76784926`](https://github.com/NixOS/nixpkgs/commit/76784926c3d59742ede374c15f30c869343ae15e) python310Packages.google-auth: 2.14.0 -> 2.15.0
* [`ef2b8791`](https://github.com/NixOS/nixpkgs/commit/ef2b8791454427f8dffd99f975d8770838b5b557) python310Packages.google-api-core: 2.10.2 -> 2.11.0
* [`2afd589a`](https://github.com/NixOS/nixpkgs/commit/2afd589a89b4aa2121d694f1e694dae0062aeba5) python310Packages.google-cloud-iam: 2.9.0 -> 2.10.0
* [`8e3b49b4`](https://github.com/NixOS/nixpkgs/commit/8e3b49b456cd88ccb73e767b8751b3160a09e22f) python310Packages.google-cloud-iam-logging: add changelog to meta
* [`9a911023`](https://github.com/NixOS/nixpkgs/commit/9a911023c1a49f98775965b24b3df4d42df0a677) python310Packages.google-cloud-iam-logging: 1.0.6 -> 1.1.0
* [`da853fc1`](https://github.com/NixOS/nixpkgs/commit/da853fc1fd072b1930238d82a9eac4faaa7fb91c) python310Packages.google-cloud-bigquery-logging: add changelog to meta
* [`849e8145`](https://github.com/NixOS/nixpkgs/commit/849e8145efb9b87571ca3881eea3efcac590d56b) python310Packages.google-cloud-bigquery-logging: 1.0.7 -> 1.1.0
* [`b5cf8c96`](https://github.com/NixOS/nixpkgs/commit/b5cf8c9686fd87713483ec64be2bc0947fa1e196) python310Packages.google-cloud-appengine-logging: add changelog to meta
* [`22bc63ac`](https://github.com/NixOS/nixpkgs/commit/22bc63acd5fd29822ca60dcc168fddecdfd3ed3a) python310Packages.google-cloud-appengine-logging: 1.1.6 -> 1.2.0
* [`374cf3fa`](https://github.com/NixOS/nixpkgs/commit/374cf3fabfa734699432d6cf2cc97d30c5a598ff) python310Packages.cirq-google: update input
* [`e1f5ee21`](https://github.com/NixOS/nixpkgs/commit/e1f5ee21381dec50f082b9860d2a209b4f53cb25) python310Packages.google-cloud-bigquery-datatransfer: add changelog to meta
* [`3e2ee86e`](https://github.com/NixOS/nixpkgs/commit/3e2ee86eeeb58fe8111e751efa83d77f1a6adde7) python310Packages.google-cloud-bigquery-datatransfer: 3.7.3 -> 3.8.0
* [`e8f8113e`](https://github.com/NixOS/nixpkgs/commit/e8f8113ee86452a733051fa38d16bbb79839e262) python310Packages.google-cloud-access-context-manager: adjust inputs
* [`a2c497b0`](https://github.com/NixOS/nixpkgs/commit/a2c497b0e8ef3b406178020b02ccbc8d05f5726b) python310Packages.google-cloud-bigquery-storage: add changelog to meta
* [`fe003a9a`](https://github.com/NixOS/nixpkgs/commit/fe003a9af24dc2f1ed16ced397814b277973deaf) python310Packages.google-cloud-bigquery-storage: 2.16.2 -> 2.17.0
* [`e077e20d`](https://github.com/NixOS/nixpkgs/commit/e077e20d10679bb77ed7fe4debed79f26c72d253) pythpn310Packages.google-cloud-dataproc: add changelog to meta
* [`f7768632`](https://github.com/NixOS/nixpkgs/commit/f77686325fb7c9f98af121ba9cc6fe835be8ae3b) pythpn310Packages.google-cloud-dataproc: adjust inputs
* [`96167f03`](https://github.com/NixOS/nixpkgs/commit/96167f031b185bf864931b853080f925f3262c2a) pythpn310Packages.google-cloud-iot: add changelog to meta
* [`795c9fb0`](https://github.com/NixOS/nixpkgs/commit/795c9fb0e218fac36ce0347715149458a1366aab) python310Packages.google-cloud-iot: 2.6.4 -> 2.7.0
* [`ec7cdd6c`](https://github.com/NixOS/nixpkgs/commit/ec7cdd6c4cea64c8c4c093c48657b11a152d0b8a) python310Packages.google-cloud-container: add changelog to meta
* [`0f35ebf0`](https://github.com/NixOS/nixpkgs/commit/0f35ebf09443983ca2d5e457c382beb0568f358e) python310Packages.google-cloud-container: 2.13.0 -> 2.14.0
* [`c0f32aa4`](https://github.com/NixOS/nixpkgs/commit/c0f32aa42ebef5c2c82e80dfb92a471936fea8e6) pythpn310Packages.google-cloud-datacatalog: add changelog to meta
* [`e159d8c9`](https://github.com/NixOS/nixpkgs/commit/e159d8c9f04f2671a491eb84c39b0244fd6d1f8d) python310Packages.google-cloud-datacatalog: 3.9.3 -> 3.10.0
* [`defc6358`](https://github.com/NixOS/nixpkgs/commit/defc63589b924d3d6caa9be70b0e33dbdbd5baf9) python310Packages.google-cloud-compute: add changelog to meta
* [`d8c2d51b`](https://github.com/NixOS/nixpkgs/commit/d8c2d51b1c4b3339f809c92cab5d874cd44f664f) python310Packages.google-cloud-compute: 1.5.2 -> 1.8.0
* [`a7cf0bbf`](https://github.com/NixOS/nixpkgs/commit/a7cf0bbfa665b09a76db1022b9ce9828e6118764) python310Packages.google-cloud-core: add changelog to meta
* [`555624c9`](https://github.com/NixOS/nixpkgs/commit/555624c9bf2afefc21f8b8bab1d66d668552db23) python310Packages.google-cloud-core: adjust inputs
* [`a4f5f7c2`](https://github.com/NixOS/nixpkgs/commit/a4f5f7c217ec17b0e05463ff08756e63dfd2fc0a) python310Packages.google-cloud-bigtable: adjust inputs
* [`150e09e2`](https://github.com/NixOS/nixpkgs/commit/150e09e2134742584ba275340c2d9b2bf50ede94) python310Packages.google-cloud-asset: add changelog to meta
* [`d9096521`](https://github.com/NixOS/nixpkgs/commit/d909652126ce5600c1b3ad2ed7a702247e45399b) python310Packages.google-cloud-asset: adjust inputs
* [`75cbc843`](https://github.com/NixOS/nixpkgs/commit/75cbc843f365cdc7a4d35324c0fa620276d3343e) python310Packages.google-cloud-audit-log: add changelog to meta
* [`e566d9e6`](https://github.com/NixOS/nixpkgs/commit/e566d9e683b13b4d4d83399922bf2571a1961a7b) python310Packages.google-cloud-automl: add changelog to meta
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
