### PR TITLE
niv devenv: update 3a0dbd2d -> 09b0058b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "3a0dbd2d209b6e3730e51b675e9069bd68f4f662",
-        "sha256": "0f2f4w3akr4bqznc3d3nsiqaalrxq0ixcbwnfd95s8dw1iq0i502",
+        "rev": "09b0058bc750de6075dc0ebd9c72c7b8e23f4f32",
+        "sha256": "19yg64l8abgd6cjrniaqda8ial7nlr59s7y31ngvf6s8y2r0v9f1",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/3a0dbd2d209b6e3730e51b675e9069bd68f4f662.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/09b0058bc750de6075dc0ebd9c72c7b8e23f4f32.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@3a0dbd2d...09b0058b](https://github.com/cachix/devenv/compare/3a0dbd2d209b6e3730e51b675e9069bd68f4f662...09b0058bc750de6075dc0ebd9c72c7b8e23f4f32)

* [`d0318f21`](https://github.com/cachix/devenv/commit/d0318f2186515c98c28c8bc9d6d0f17d8f1e8e12) newsletter: apply spacing
* [`122474ed`](https://github.com/cachix/devenv/commit/122474ed2213f6486f6fe78e290326a80319f7b7) rust: expose C compiler tooling by default, fixes [cachix/devenv⁠#256](https://togithub.com/cachix/devenv/issues/256)
* [`da6435ae`](https://github.com/cachix/devenv/commit/da6435aebff1c2e016fe0d23f841414fe105cd51) feature/add-deno - added deno
* [`a9785980`](https://github.com/cachix/devenv/commit/a978598046c013b71c52933913b54471c997de8c) feature/add-deno - fix lang order
* [`ea105e39`](https://github.com/cachix/devenv/commit/ea105e395b23139bb1fd10ca6c00175ebf7ad893) feature/add-deno - fix typo
* [`ea8c41ac`](https://github.com/cachix/devenv/commit/ea8c41ac20f36f8fd7f695c3a44296670fe141ae) Auto generate docs/reference/options.md
* [`e0daa639`](https://github.com/cachix/devenv/commit/e0daa639c2fd5579c4206a5f25b82a3c1d4e3b90) rust: fix iconv missing darwin
* [`1d8f8863`](https://github.com/cachix/devenv/commit/1d8f8863c59b58f2d1845c3394b68c048e49c225) run builds on m1
* [`f2b8e1bb`](https://github.com/cachix/devenv/commit/f2b8e1bb4553190c52321b1c76d31d12a315260b) fix github PR CI labeling
* [`739413ca`](https://github.com/cachix/devenv/commit/739413ca01cda1ca5378344485fe24a0bf0b773d) bump deps
* [`2c38d9d7`](https://github.com/cachix/devenv/commit/2c38d9d79a9623625033c319d0e1804593abcdf9) split github actions into trusted and untrusted
* [`02bb707c`](https://github.com/cachix/devenv/commit/02bb707c8f1e09d43ecdede7a5e60f41a1c35ac3) make sure .devenv folder exists
* [`2ea29ad8`](https://github.com/cachix/devenv/commit/2ea29ad82c5ae5442c4b5e1039dbf8ecba6896be) simplify logic what runners to use
* [`493738c3`](https://github.com/cachix/devenv/commit/493738c368612aec1f63ad9f28aa7726e057f411) Auto generate docs/reference/options.md
* [`ff083a4e`](https://github.com/cachix/devenv/commit/ff083a4e526a432236f7a3837408e93d467132b6) purescript: support via rosetta
* [`494e7291`](https://github.com/cachix/devenv/commit/494e72911e229225c07d141ee241c655709cbf91) starship: support aarch64-darwin, fixes [cachix/devenv⁠#266](https://togithub.com/cachix/devenv/issues/266)
* [`f168801c`](https://github.com/cachix/devenv/commit/f168801cd8d1bb17b13a14a5e1020af3f22b775a) ci: don't require CACHIX_AUTH_TOKEN
* [`5fa8587c`](https://github.com/cachix/devenv/commit/5fa8587cff20c354a738f95b4634aa16a7c1bf38) add workaround for tmpdir errors on Darwin, fixes [cachix/devenv⁠#255](https://togithub.com/cachix/devenv/issues/255)
