### PR TITLE
niv emacs-overlay: update ebbb2251 -> 178e41eb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ebbb22510930b5153de22357518ebd8ce7ed93b3",
-        "sha256": "1vmsk0znvjc6qlmiqgpzx07644rhfg0kgxx5l9ig9lrga1wwh8bs",
+        "rev": "178e41ebc708a2f11d9a87d54d519d24ab9a69ca",
+        "sha256": "1n7dxxznqxq947gc7si6zmbk6n649idw9c2hhw2r5q1zzl2p17pi",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/ebbb22510930b5153de22357518ebd8ce7ed93b3.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/178e41ebc708a2f11d9a87d54d519d24ab9a69ca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@ebbb2251...178e41eb](https://github.com/nix-community/emacs-overlay/compare/ebbb22510930b5153de22357518ebd8ce7ed93b3...178e41ebc708a2f11d9a87d54d519d24ab9a69ca)

* [`dba6e04a`](https://github.com/nix-community/emacs-overlay/commit/dba6e04ab5479beadf0d5b8b6c1b4bbf3717b41e) Updated repos/elpa
* [`08a79765`](https://github.com/nix-community/emacs-overlay/commit/08a79765bbc6c1b967cd2d7ebd123910044b9463) Updated repos/melpa
* [`0ba3a153`](https://github.com/nix-community/emacs-overlay/commit/0ba3a153eb5f1865eafb62cce5f3943438a79310) Updated repos/elpa
* [`2052e031`](https://github.com/nix-community/emacs-overlay/commit/2052e031a352505b51d4e278c906bf653312a59b) Updated repos/melpa
* [`6e48e5ac`](https://github.com/nix-community/emacs-overlay/commit/6e48e5ac6406ac60717e4118e09292de1b288ff4) Updated repos/emacs
* [`044ec940`](https://github.com/nix-community/emacs-overlay/commit/044ec940110982eb6d110cc6e9cbede8f6f196a6) Updated repos/melpa
* [`089d42b5`](https://github.com/nix-community/emacs-overlay/commit/089d42b5ec8dcea90e4748da482bb3a2178bc1a2) Updated repos/nongnu
* [`13852936`](https://github.com/nix-community/emacs-overlay/commit/1385293665202c9dee786efcd34705a034b155ff) Updated repos/elpa
* [`8ad6bfa7`](https://github.com/nix-community/emacs-overlay/commit/8ad6bfa7413d59d408bf1ea8680a03b17a949082) Updated repos/melpa
* [`48c4a0b2`](https://github.com/nix-community/emacs-overlay/commit/48c4a0b231b49f3304730482c828c46f958d5352) Updated repos/elpa
* [`4dfd78ce`](https://github.com/nix-community/emacs-overlay/commit/4dfd78ce893fa7c030d0df4b79f426b778387beb) Updated repos/emacs
* [`e30cc7d7`](https://github.com/nix-community/emacs-overlay/commit/e30cc7d7ffe40b25fee518c6549fd4893322519d) Updated repos/melpa
* [`ddfaed7f`](https://github.com/nix-community/emacs-overlay/commit/ddfaed7f3b59d7590d94c5ea781e5ab8a58bc961) Updated repos/nongnu
* [`d180321c`](https://github.com/nix-community/emacs-overlay/commit/d180321cd3992dd71477192163f27348a5aa31cd) Updated repos/emacs
* [`d9ddea54`](https://github.com/nix-community/emacs-overlay/commit/d9ddea546f88f021ee6ab6a587eea9fa7c185b0c) Updated repos/melpa
* [`af6a79c2`](https://github.com/nix-community/emacs-overlay/commit/af6a79c2034dfe1a763254b86ddacea06bcc65fa) Updated repos/elpa
* [`f0315cd7`](https://github.com/nix-community/emacs-overlay/commit/f0315cd760b9a98b6f9c5ae08ce78bf6c94f8920) Updated repos/emacs
* [`86863292`](https://github.com/nix-community/emacs-overlay/commit/86863292e6c99256cde3f994b433055e3dff48cc) Updated repos/melpa
* [`e3cb87d5`](https://github.com/nix-community/emacs-overlay/commit/e3cb87d5f5e6c49690221b939c36b4eca89d77b3) Updated repos/emacs
* [`4b6761d8`](https://github.com/nix-community/emacs-overlay/commit/4b6761d828a861526c3acb7712395986274cfd9e) Updated repos/melpa
* [`656363b3`](https://github.com/nix-community/emacs-overlay/commit/656363b34a83384866f558346210483edb02c4c8) Updated repos/emacs
* [`8de6bdbf`](https://github.com/nix-community/emacs-overlay/commit/8de6bdbf7902c0650eeccc53b8efff7692165171) Updated repos/melpa
* [`d5b7eee0`](https://github.com/nix-community/emacs-overlay/commit/d5b7eee098fe6a7b79b659fcf17834ca368c0bf9) Updated repos/nongnu
* [`ff34ea9b`](https://github.com/nix-community/emacs-overlay/commit/ff34ea9bd39216ab86ca33042982948b7e2a2c5d) Updated repos/elpa
* [`ba9631e0`](https://github.com/nix-community/emacs-overlay/commit/ba9631e0becf8f4d0cff7bada4e49d57d34b53ec) Updated repos/emacs
* [`6108369b`](https://github.com/nix-community/emacs-overlay/commit/6108369b3fa789e2b2683127043c0dd118009a73) Updated repos/melpa
* [`70d208c5`](https://github.com/nix-community/emacs-overlay/commit/70d208c56da7a6fef7c3485c30aa9b0baa0e95cb) Updated repos/elpa
* [`92b2f5b4`](https://github.com/nix-community/emacs-overlay/commit/92b2f5b48798e389ea9fde1c8f322727b74f56fb) Updated repos/emacs
* [`240c1b5e`](https://github.com/nix-community/emacs-overlay/commit/240c1b5ebd1a675480cc203fdd98268166ff3fe2) Updated repos/melpa
* [`29710775`](https://github.com/nix-community/emacs-overlay/commit/297107759dabf44f3d3bde8c98dfc736d16e77b1) Updated repos/emacs
* [`27ecb795`](https://github.com/nix-community/emacs-overlay/commit/27ecb795fbcd192d09a07a647696a92bbb6138ff) Updated repos/melpa
* [`d3720b89`](https://github.com/nix-community/emacs-overlay/commit/d3720b8981a72a6fbdf5baeb9d3d4a83938ffd15) Updated repos/elpa
* [`d58bc561`](https://github.com/nix-community/emacs-overlay/commit/d58bc5614e09a58c4f248e3e27725e1ca82c215a) Updated repos/emacs
* [`3c1fbbbe`](https://github.com/nix-community/emacs-overlay/commit/3c1fbbbe250bde48a947099ae61534f018290ff4) Updated repos/melpa
* [`eb92f8cb`](https://github.com/nix-community/emacs-overlay/commit/eb92f8cbb45c9923fb61031c28040c19f78f92dd) Updated repos/elpa
* [`898c89ac`](https://github.com/nix-community/emacs-overlay/commit/898c89ac1ea4f198a4fe96d37c6559f612b74648) Updated repos/melpa
* [`5c440de8`](https://github.com/nix-community/emacs-overlay/commit/5c440de888f0ca43c8a68784c6b34f55c3bf031e) Updated repos/emacs
* [`524c8844`](https://github.com/nix-community/emacs-overlay/commit/524c884484c312b76cb4bc9fbf37eec66e2f8406) Updated repos/melpa
* [`1c3c01a1`](https://github.com/nix-community/emacs-overlay/commit/1c3c01a1ae0d85a1ab83ca24c24e315e9a0cdc47) Updated repos/emacs
* [`cd444d8f`](https://github.com/nix-community/emacs-overlay/commit/cd444d8f2d284c90a1e898bd102a40176e6dfcfa) Updated repos/melpa
* [`e4651781`](https://github.com/nix-community/emacs-overlay/commit/e465178187fd62eaed9c7637e7315e0800e02209) Add tree-sitter-ruby
* [`b281ef33`](https://github.com/nix-community/emacs-overlay/commit/b281ef3306bd37ac1c8ed7e83fcb241f6757a61c) Alphabetize tree-sitter grammars
* [`9ffea899`](https://github.com/nix-community/emacs-overlay/commit/9ffea899b1125bb4459da2fbb7a3a61e9ff0f8a6) Updated repos/elpa
* [`3fcb8573`](https://github.com/nix-community/emacs-overlay/commit/3fcb8573583cf5d70299cf93eeef92fab8f979e0) Updated repos/emacs
* [`523f0621`](https://github.com/nix-community/emacs-overlay/commit/523f062104b48f5e0a46bb7c0fd77a486eaa8fda) Updated repos/melpa
* [`2fa6cca2`](https://github.com/nix-community/emacs-overlay/commit/2fa6cca26891f696c13fe910bb659ecd69ed3842) Updated repos/nongnu
* [`ba6ca039`](https://github.com/nix-community/emacs-overlay/commit/ba6ca0397eee6d322755d9128495010b70db790e) Updated repos/melpa
* [`af77f8ab`](https://github.com/nix-community/emacs-overlay/commit/af77f8abd56f0190008cd6e33806d1fa6eedd946) Updated repos/elpa
* [`4bab411f`](https://github.com/nix-community/emacs-overlay/commit/4bab411f17128c335f603b1bfc69f4a1b34ada0c) Updated repos/emacs
* [`b7c9a32d`](https://github.com/nix-community/emacs-overlay/commit/b7c9a32d384b007916769e969b4ca56ecefc721d) Updated repos/melpa
* [`9ef42377`](https://github.com/nix-community/emacs-overlay/commit/9ef42377c7985840cfb65b5b9403e518d7d97afb) Updated repos/nongnu
* [`24308373`](https://github.com/nix-community/emacs-overlay/commit/2430837315cfb9d2d0cbc7002ee9a1e8e9b63417) Use build flags to add tree-sitter-grammars to RPATH on Darwin
* [`064b7da1`](https://github.com/nix-community/emacs-overlay/commit/064b7da13b1827ef60b85795b8d2e3333d6cccc4) Updated repos/elpa
* [`896f556e`](https://github.com/nix-community/emacs-overlay/commit/896f556ee09b7fd1470a473ea38fe1cae87ce56d) Updated repos/emacs
* [`e7e3438f`](https://github.com/nix-community/emacs-overlay/commit/e7e3438f31376520875f2f1e86891cf69bb42e67) Updated repos/melpa
* [`178e41eb`](https://github.com/nix-community/emacs-overlay/commit/178e41ebc708a2f11d9a87d54d519d24ab9a69ca) Updated repos/nongnu
