### PR TITLE
niv spacemacs: update fd749704 -> 1100ee84

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "fd749704ff567c4766e2b8e192d6fa46708a7ee3",
-        "sha256": "0i12kdvkig2nd5124z6866gmahhaj3v8wp3zrbm5rpcy4i6jlliv",
+        "rev": "1100ee841aa616d80cb04fdd6a25d6a41afcdd78",
+        "sha256": "1rlqa825ns5mzvqjn9p3kz625fmnrvhn66zrbb8wmkybjsfqw8xn",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/fd749704ff567c4766e2b8e192d6fa46708a7ee3.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/1100ee841aa616d80cb04fdd6a25d6a41afcdd78.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@fd749704...1100ee84](https://github.com/syl20bnr/spacemacs/compare/fd749704ff567c4766e2b8e192d6fa46708a7ee3...1100ee841aa616d80cb04fdd6a25d6a41afcdd78)

* [`37cdd506`](https://github.com/syl20bnr/spacemacs/commit/37cdd5069f3d28455cb4a50605456467de1db18f) layers/+lang/python/packages.el: Fix the invalid 'args' in the condition
* [`445e0d40`](https://github.com/syl20bnr/spacemacs/commit/445e0d40ebe190c4dfa80aefc8d73a7f9c801a93) [vue] Make vue lsp integration adhere to current standards
* [`7795337a`](https://github.com/syl20bnr/spacemacs/commit/7795337a5e3fa91f726e87a5ee1bd19e8af9ae6d) Fix links to obsolete http://spacemacs.org
* [`025e9f7e`](https://github.com/syl20bnr/spacemacs/commit/025e9f7e325ef2c71de1aee9ba0ef3d52c8dc5b2) Fix broken format statement in doc generation
* [`7991003a`](https://github.com/syl20bnr/spacemacs/commit/7991003a086622b03b30184aa51b45373823a2c8) * core-spacemacs-buffer.el: avoid to call functions from org-mode at startup
* [`f9efd1bd`](https://github.com/syl20bnr/spacemacs/commit/f9efd1bdf7232daea5de7f8b7f6a68b977511fa5) org-layer: Update to org version 9.6
* [`2462c055`](https://github.com/syl20bnr/spacemacs/commit/2462c055284293d5baea1399be92a0a07571f257) [tree-sitter] use global ts-fold modes
* [`e1c11109`](https://github.com/syl20bnr/spacemacs/commit/e1c11109261c422231b8442d0f39a4be2919e6b6) Fix widget-button-click for core Spacemacs buffer
* [`178a3ab1`](https://github.com/syl20bnr/spacemacs/commit/178a3ab186dd33e2561a73941a45aa33ad12aa2e) [bot] "documentation_updates" Sun Jan  1 14:09:54 UTC 2023
* [`e043c861`](https://github.com/syl20bnr/spacemacs/commit/e043c861637560a82218114e3e57fd4a9df7573a) Fix 15861: detect the audoload function more robustly
* [`1100ee84`](https://github.com/syl20bnr/spacemacs/commit/1100ee841aa616d80cb04fdd6a25d6a41afcdd78) Suppress false positive emacs warning
