### PR TITLE
niv devenv: update 09b0058b -> b25cd5a4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "09b0058bc750de6075dc0ebd9c72c7b8e23f4f32",
-        "sha256": "19yg64l8abgd6cjrniaqda8ial7nlr59s7y31ngvf6s8y2r0v9f1",
+        "rev": "b25cd5a45d3ce61f8b671f5ff26579267ff217ae",
+        "sha256": "1587ynxaifm6m7i244y74vp9srlvy3x7r52l9czm77lsnsp62xrn",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/09b0058bc750de6075dc0ebd9c72c7b8e23f4f32.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/b25cd5a45d3ce61f8b671f5ff26579267ff217ae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@09b0058b...b25cd5a4](https://github.com/cachix/devenv/compare/09b0058bc750de6075dc0ebd9c72c7b8e23f4f32...b25cd5a45d3ce61f8b671f5ff26579267ff217ae)

* [`c5b65be7`](https://github.com/cachix/devenv/commit/c5b65be7623fab1c630840acaa75597e101f2082) examples/simple/devenv.nix: enable scripts
* [`25c99dce`](https://github.com/cachix/devenv/commit/25c99dce2046339d8fb948c280a525fd95c5d240) fix linting
* [`29d111cb`](https://github.com/cachix/devenv/commit/29d111cb557cc1884bf4480e904da974bf6ad127) flake.nix: add welcomeText about .gitignore
* [`6c9f137a`](https://github.com/cachix/devenv/commit/6c9f137af8b40c8aed177bd628cab313b09d92fb) mkShell: expose config
* [`678ee0c4`](https://github.com/cachix/devenv/commit/678ee0c41d5ae88afdb51429ecf2d2c8b5b59f39) examples/script: use local devenv modules
* [`30bd32f8`](https://github.com/cachix/devenv/commit/30bd32f880a4a84085b2fddd852390e827467fc2) scripts: prioritize over packages
* [`f966ceaf`](https://github.com/cachix/devenv/commit/f966ceafa430606621d181a63928c4e3c001aa04) Fix typo
* [`06e7f8ff`](https://github.com/cachix/devenv/commit/06e7f8ff528f500d57e8fd3dde1e7c7f7cc19c38) Fix instruction for declarative installation w/o flakes
* [`9cc47f65`](https://github.com/cachix/devenv/commit/9cc47f655e7105a0260c7c8156af259f784bb09a) Add Unison language
* [`18359f43`](https://github.com/cachix/devenv/commit/18359f43eb58dc9e651695aa32ff7c1bdf4d2078) Add Zig language
* [`e5409140`](https://github.com/cachix/devenv/commit/e5409140e2c8d372c6d9fbe89695ccaa653ab6b4) Auto generate docs/reference/options.md
* [`825ddc7e`](https://github.com/cachix/devenv/commit/825ddc7e809476f558afe7e31dfad1afb4abfdeb) Auto generate examples/supported-languages/devenv.nix
* [`3a3c650e`](https://github.com/cachix/devenv/commit/3a3c650ea6b20c1a4b03f9391c929847b671ba6d) Auto generate docs/reference/options.md
* [`3fb05f03`](https://github.com/cachix/devenv/commit/3fb05f03803d2f3695b5e87bdb560d8957316d47) Auto generate examples/supported-languages/devenv.nix
* [`509710ac`](https://github.com/cachix/devenv/commit/509710ac0f74b9979445a6bbbb7f61594d2a1fa7) docs: wrap examples and defaults in literals
* [`86154918`](https://github.com/cachix/devenv/commit/86154918c9bc3eb5a161696322a71f6c678d4194) Auto generate docs/reference/options.md
* [`d16c786a`](https://github.com/cachix/devenv/commit/d16c786ac444b1297af53a49d0653cce37083b85) enable default users for mysql commands via mysqlOptions
* [`d0fa8193`](https://github.com/cachix/devenv/commit/d0fa81939939340b8eb4e7852aa73b4343ecf63a) remove additional lib prefix
* [`2ed329b2`](https://github.com/cachix/devenv/commit/2ed329b251c01dcfb9282e624dae3fd7234915a3) home: mention number of supported services and languages
* [`34c97d1c`](https://github.com/cachix/devenv/commit/34c97d1c12c5127ba20815214bd86e71e18d1db0) rust: link frameworks on darwin
