### PR TITLE
niv emacs-overlay: update 178e41eb -> fc341b52

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "178e41ebc708a2f11d9a87d54d519d24ab9a69ca",
-        "sha256": "1n7dxxznqxq947gc7si6zmbk6n649idw9c2hhw2r5q1zzl2p17pi",
+        "rev": "fc341b52fe5837ef313cfe79eea7e2a05b6efffa",
+        "sha256": "1s4kh044jx4890zzfv7lbf2r5z86alha592bkcj6fhzs8ml3w32w",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/178e41ebc708a2f11d9a87d54d519d24ab9a69ca.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/fc341b52fe5837ef313cfe79eea7e2a05b6efffa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@178e41eb...fc341b52](https://github.com/nix-community/emacs-overlay/compare/178e41ebc708a2f11d9a87d54d519d24ab9a69ca...fc341b52fe5837ef313cfe79eea7e2a05b6efffa)

* [`88a4109e`](https://github.com/nix-community/emacs-overlay/commit/88a4109e9aa231f843284df8bc9913a754552a0b) Updated repos/emacs
* [`0505d6fa`](https://github.com/nix-community/emacs-overlay/commit/0505d6fa58724b02898c3ca2b7373dcf699ae3b5) Updated repos/melpa
* [`acee13c2`](https://github.com/nix-community/emacs-overlay/commit/acee13c2f8f5cb113d42925ca2cc91ff40e5f2af) Updated repos/elpa
* [`e630ba3d`](https://github.com/nix-community/emacs-overlay/commit/e630ba3d2b79c4ab825b8c1beaa6362a31d4471b) Updated repos/emacs
* [`1a5a0d89`](https://github.com/nix-community/emacs-overlay/commit/1a5a0d8953242f28f66662285c7f7dab3d21d2ea) Updated repos/melpa
* [`ac50f86e`](https://github.com/nix-community/emacs-overlay/commit/ac50f86ecfbce8ed5377ede8d6fd2c8dd19669e8) Updated repos/elpa
* [`41e808eb`](https://github.com/nix-community/emacs-overlay/commit/41e808eba509a9e6e7f0ffcea9806ae0b803646d) Updated repos/emacs
* [`d59511b8`](https://github.com/nix-community/emacs-overlay/commit/d59511b86c8090d92f501ffabbd4b2b804ad1da6) Updated repos/melpa
* [`47e1b0a7`](https://github.com/nix-community/emacs-overlay/commit/47e1b0a7ec48a59e6f7d5b135a1be352d5d43aab) Updated repos/emacs
* [`8fa53f45`](https://github.com/nix-community/emacs-overlay/commit/8fa53f45e6ae0e3b120f4fed99517f34c0311502) Updated repos/melpa
* [`ed004536`](https://github.com/nix-community/emacs-overlay/commit/ed0045366fc3bcc7ecd3dccdbf66c2cfa979fe18) Updated repos/melpa
* [`c66c4f64`](https://github.com/nix-community/emacs-overlay/commit/c66c4f6447c1b464c0a0fc97bcd689ead5dbf415) Updated repos/melpa
* [`c26c90d9`](https://github.com/nix-community/emacs-overlay/commit/c26c90d90940390c81aa0fbffd847ec84348b873) Updated repos/emacs
* [`b7ce6bbf`](https://github.com/nix-community/emacs-overlay/commit/b7ce6bbf53b52f2059020ecf14127ffd1c375e90) Updated repos/melpa
* [`df9951ad`](https://github.com/nix-community/emacs-overlay/commit/df9951ada0956ca46b0b25493178392090664d9e) Updated repos/elpa
* [`0b2f8790`](https://github.com/nix-community/emacs-overlay/commit/0b2f8790dccea9ae4ce0a43f137fd4b002f70b1b) Updated repos/emacs
* [`6024c026`](https://github.com/nix-community/emacs-overlay/commit/6024c026ffb3d6ed3a1d79fe07be965147cb43b8) Updated repos/melpa
* [`e8119023`](https://github.com/nix-community/emacs-overlay/commit/e811902390ea0ab4ae8ae7c84f3a938d5dc662b1) Updated repos/elpa
* [`e6415620`](https://github.com/nix-community/emacs-overlay/commit/e641562007b44a6dd12e2fbea3f9e10f02ddd6a9) Updated repos/melpa
* [`fcce0d8d`](https://github.com/nix-community/emacs-overlay/commit/fcce0d8df02b4657ed413cf9991a0d81852569de) Updated repos/nongnu
* [`3b3242d4`](https://github.com/nix-community/emacs-overlay/commit/3b3242d4eddce4ef16bdab6764ee6d7b22a15978) Updated repos/emacs
* [`3897ea6c`](https://github.com/nix-community/emacs-overlay/commit/3897ea6c4604c54f168d2f67bc5c2f91305b3b4e) Updated repos/melpa
* [`b1c6994a`](https://github.com/nix-community/emacs-overlay/commit/b1c6994a31804d48539536ab69e12fcfe34d2446) Updated repos/melpa
* [`b7107924`](https://github.com/nix-community/emacs-overlay/commit/b71079240e9d31a8e80b1170381cd7ab52c5770a) Updated repos/elpa
* [`d341bf57`](https://github.com/nix-community/emacs-overlay/commit/d341bf57684afda83208d66d96a3dd9147959ffe) Updated repos/emacs
* [`9c53e4d4`](https://github.com/nix-community/emacs-overlay/commit/9c53e4d43c5ff7be7c97da0784b6ddd8e0a4658b) Updated repos/melpa
* [`18fd7d7d`](https://github.com/nix-community/emacs-overlay/commit/18fd7d7d4106fa447adde02b172037fac1676950) Updated repos/nongnu
* [`a5405285`](https://github.com/nix-community/emacs-overlay/commit/a5405285a69c21b2dea75c1b6c165442e58ee864) Updated repos/emacs
* [`5eaac6cb`](https://github.com/nix-community/emacs-overlay/commit/5eaac6cbfff7aec96450c5ef6c6e1f10035d25ab) Updated repos/melpa
* [`f5f51705`](https://github.com/nix-community/emacs-overlay/commit/f5f51705d5d8886d2c9aba5e6a19484711175e3f) Updated repos/nongnu
* [`6819db6d`](https://github.com/nix-community/emacs-overlay/commit/6819db6d051ba48f93777518f4eeca16523d7bc8) Updated repos/emacs
* [`738b3cff`](https://github.com/nix-community/emacs-overlay/commit/738b3cfffacf4234d6b6a0b39ce2355574687074) Updated repos/melpa
* [`79714c5f`](https://github.com/nix-community/emacs-overlay/commit/79714c5f674eb020cba9e3fad1f38ece2b7016c7) Updated repos/elpa
* [`e57369df`](https://github.com/nix-community/emacs-overlay/commit/e57369df9737216cf542639bf279960fd3b986f2) Updated repos/emacs
* [`a8d8372e`](https://github.com/nix-community/emacs-overlay/commit/a8d8372eb02914ebb42e727f3ffa3765b4de0f4f) Updated repos/melpa
* [`77633dd3`](https://github.com/nix-community/emacs-overlay/commit/77633dd37d94ade8e927b519722ed5481e4c9425) Updated repos/melpa
* [`af506f49`](https://github.com/nix-community/emacs-overlay/commit/af506f49e0df0ce7d30f18a60f77d602601b15fd) Updated repos/melpa
* [`076ee4ed`](https://github.com/nix-community/emacs-overlay/commit/076ee4edf295eb9543a1416186085aa2b67042af) Updated repos/nongnu
* [`06ea0364`](https://github.com/nix-community/emacs-overlay/commit/06ea036435621202f39fe9213bf354ecc82c889a) Updated repos/elpa
* [`198ae94a`](https://github.com/nix-community/emacs-overlay/commit/198ae94a8dcd011480e0231cbfa8849419dbae55) Updated repos/emacs
* [`6fa004ad`](https://github.com/nix-community/emacs-overlay/commit/6fa004ad6204ffcd746654ed60fd8dee394ff388) Updated repos/melpa
* [`070389cd`](https://github.com/nix-community/emacs-overlay/commit/070389cdd38008ad49d8097e18817db7cd6ddc2b) Updated repos/melpa
* [`dca61513`](https://github.com/nix-community/emacs-overlay/commit/dca61513fcd032f348aa2e3fe4606d52e848e7ce) Updated repos/melpa
* [`0b73a17b`](https://github.com/nix-community/emacs-overlay/commit/0b73a17b7ed05dd915790023a4207d27a1f8335d) Updated repos/emacs
* [`fc341b52`](https://github.com/nix-community/emacs-overlay/commit/fc341b52fe5837ef313cfe79eea7e2a05b6efffa) Updated repos/melpa
