### PR TITLE
niv powerlevel10k: update 33916e91 -> 35165798

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "33916e91a743a73472a15f3fc27dd0aa9f7abbdf",
-        "sha256": "0slrihns6rn5hwk4933z300q4884l9qjsziw9gi80piq5xr3xvsd",
+        "rev": "35165798a83e2e4f2f0aa6c820e2f7fba23e0179",
+        "sha256": "1i8v2sv4zch2f16bv0qvhwpacmvwf79imli4wgy9329l45360f5m",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/33916e91a743a73472a15f3fc27dd0aa9f7abbdf.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/35165798a83e2e4f2f0aa6c820e2f7fba23e0179.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@33916e91...35165798](https://github.com/romkatv/powerlevel10k/compare/33916e91a743a73472a15f3fc27dd0aa9f7abbdf...35165798a83e2e4f2f0aa6c820e2f7fba23e0179)

* [`35165798`](https://github.com/romkatv/powerlevel10k/commit/35165798a83e2e4f2f0aa6c820e2f7fba23e0179) Added kubent to KUBECONTEXT_SHOW_ON_COMMAND
