### PR TITLE
niv spacemacs: update 1100ee84 -> c828fd31

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "1100ee841aa616d80cb04fdd6a25d6a41afcdd78",
-        "sha256": "1rlqa825ns5mzvqjn9p3kz625fmnrvhn66zrbb8wmkybjsfqw8xn",
+        "rev": "c828fd31bc013a98e78b9169594ec827b2cf2808",
+        "sha256": "1kxrhnpyvx8llgxzp2yss09syjrfqs59dx3vmwfhny9jhswh91ar",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/1100ee841aa616d80cb04fdd6a25d6a41afcdd78.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/c828fd31bc013a98e78b9169594ec827b2cf2808.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@1100ee84...c828fd31](https://github.com/syl20bnr/spacemacs/compare/1100ee841aa616d80cb04fdd6a25d6a41afcdd78...c828fd31bc013a98e78b9169594ec827b2cf2808)

* [`e71a6863`](https://github.com/syl20bnr/spacemacs/commit/e71a68633b17f8ac69fcf33d3d486184e71fcf8d) [core] Hotfix org version mismatch during startup
* [`5705c541`](https://github.com/syl20bnr/spacemacs/commit/5705c541680397cd2f481e1dc5913d4c96da7466) fix(spacemacs-buffer): mouse click ([syl20bnr/spacemacs⁠#15867](https://togithub.com/syl20bnr/spacemacs/issues/15867))
* [`c22d3d17`](https://github.com/syl20bnr/spacemacs/commit/c22d3d174f260e3b913a4faadcaa2377c81815da) fix(haskell): missing haskell-debug-mode-map ([syl20bnr/spacemacs⁠#15868](https://togithub.com/syl20bnr/spacemacs/issues/15868))
* [`948fb138`](https://github.com/syl20bnr/spacemacs/commit/948fb1389ad2dc0dab64ddac904d9179a66f8f89) fix(spacemacs-buffer): fix mouse clicks and drags ([syl20bnr/spacemacs⁠#15872](https://togithub.com/syl20bnr/spacemacs/issues/15872))
* [`d1c42338`](https://github.com/syl20bnr/spacemacs/commit/d1c42338a786ffbfa219c14ad33ae069df3cbd16) fix(spacemacs-buffer): fix retrieval org-agenda-files ([syl20bnr/spacemacs⁠#15871](https://togithub.com/syl20bnr/spacemacs/issues/15871))
* [`a46e7ce0`](https://github.com/syl20bnr/spacemacs/commit/a46e7ce022cd43cab23b475cfec58b60ffe4e8d7) change(readme): require GNU Tar as dependency ([syl20bnr/spacemacs⁠#15874](https://togithub.com/syl20bnr/spacemacs/issues/15874))
* [`290d873f`](https://github.com/syl20bnr/spacemacs/commit/290d873f916d5d0a030342ffb91a4ccb06bb9f26) fix: helm-display-header-line must be set when helm-echo-input-in-header-line is t ([syl20bnr/spacemacs⁠#15876](https://togithub.com/syl20bnr/spacemacs/issues/15876))
* [`84d649ac`](https://github.com/syl20bnr/spacemacs/commit/84d649ac2e5e6de508d3e5b57be38b6e00d5cdc1) Defer to load the input-method and clang-format packages ([syl20bnr/spacemacs⁠#15878](https://togithub.com/syl20bnr/spacemacs/issues/15878))
* [`f51fab4b`](https://github.com/syl20bnr/spacemacs/commit/f51fab4baa15800c261d3dfd07bf65cdec5eaabe) use spacemacs distro to build web docs
* [`43d76ebe`](https://github.com/syl20bnr/spacemacs/commit/43d76ebe42702418595bb7cbde5c3344a963f105) fix(typescript) fix ts init process with .tsx files ([syl20bnr/spacemacs⁠#15885](https://togithub.com/syl20bnr/spacemacs/issues/15885))
* [`d10056b2`](https://github.com/syl20bnr/spacemacs/commit/d10056b2d12f6308b2c17a4ec735767cdda42558) fix(python/autoflake): deal with non-zero exit, and better docs
* [`c828fd31`](https://github.com/syl20bnr/spacemacs/commit/c828fd31bc013a98e78b9169594ec827b2cf2808) elisp tests Emacs 28.1 -> 28.2
