### PR TITLE
niv zsh-completions: update b46602db -> 1204f451

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "b46602db397bf1af6bb6906e1a749da09fdda27d",
-        "sha256": "1ddxkhmpfx5blwfhp43j1cxy3zy06zs58h4gzdr7aalfk5vvc15f",
+        "rev": "1204f45161b0e53a275f6226d0cfbc71c176ad38",
+        "sha256": "16aq5y38rba1lh9261435pl9qh1virldm51kz4bx24yqb5mpy1sg",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/b46602db397bf1af6bb6906e1a749da09fdda27d.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/1204f45161b0e53a275f6226d0cfbc71c176ad38.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@b46602db...1204f451](https://github.com/zsh-users/zsh-completions/compare/b46602db397bf1af6bb6906e1a749da09fdda27d...1204f45161b0e53a275f6226d0cfbc71c176ad38)

* [`3acaeebf`](https://github.com/zsh-users/zsh-completions/commit/3acaeebfcbd5f3e21d93a02c41be66da6666eb54) Add emacs and emacsclient completion
* [`d368e2a3`](https://github.com/zsh-users/zsh-completions/commit/d368e2a3b81b07ae4acc3cff6daa3d8b4b212c8c) Add macOS screencapture command completion
* [`7a3387ed`](https://github.com/zsh-users/zsh-completions/commit/7a3387ed46232b4196e50b2e45f98b47ea992d04) Fix broken scala/scalac completion and update to version 3.2.1
* [`1d492c71`](https://github.com/zsh-users/zsh-completions/commit/1d492c7151106a298f5c188369e04c3dce2b1366) Fix typos
* [`8c6ffb73`](https://github.com/zsh-users/zsh-completions/commit/8c6ffb73e9434b2cf14c46fede4488dbd577cdb0) Add avdmanager and sdkmanager completion
* [`4ac91730`](https://github.com/zsh-users/zsh-completions/commit/4ac9173088ff15e3c89b8c103748321ef70f9764) Fix broken completion and use awk instead of perl for portability
