### PR TITLE
niv zsh-history-substring-search: update 4abed97b -> 400e58a8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -228,10 +228,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-history-substring-search",
-        "rev": "4abed97b6e67eb5590b39bcd59080aa23192f25d",
-        "sha256": "0s8xdddb6zppc5lj28w44nl4n45wg9ic8x3b5pm1139cv038yj7j",
+        "rev": "400e58a87f72ecec14f783fbd29bc6be4ff1641c",
+        "sha256": "0vjw4s0h4sams1a1jg9jx92d6hd2swq4z908nbmmm2qnz212y88r",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/4abed97b6e67eb5590b39bcd59080aa23192f25d.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/400e58a87f72ecec14f783fbd29bc6be4ff1641c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for zsh-history-substring-search:
Branch: master
Commits: [zsh-users/zsh-history-substring-search@4abed97b...400e58a8](https://github.com/zsh-users/zsh-history-substring-search/compare/4abed97b6e67eb5590b39bcd59080aa23192f25d...400e58a87f72ecec14f783fbd29bc6be4ff1641c)

* [`563a5511`](https://github.com/zsh-users/zsh-history-substring-search/commit/563a5511655f2d63b248538a4637110263d20c7b) Use SPDX snippet tags instead of copy-pasting full license text
* [`b4fb93de`](https://github.com/zsh-users/zsh-history-substring-search/commit/b4fb93de0e911ae0c09685d9b0cf0602d88b7156) Fix compatibility with latest zsh-syntax-highlighting
* [`fcbdb897`](https://github.com/zsh-users/zsh-history-substring-search/commit/fcbdb897546f0c6868fddf9ab2be0e9a23e4ba90) Use new zsh 'memo=' feature to improve interoperability with others
