### PR TITLE
niv nixpkgs: update e68618ed -> 2f1948af

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e68618ed4c73fe2566e69ef04034b958e66f69ff",
-        "sha256": "1y3d82n1hrvh8sql9ivi9b2qspniwpfbrxn6z067kg7wqwipw0n1",
+        "rev": "2f1948af9c984ebb82dfd618e67dc949755823e2",
+        "sha256": "0c22xd0b95kdwzn5r1jh1yv5dflzrm8q6gzvn6lxx6kcpi8a2krm",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e68618ed4c73fe2566e69ef04034b958e66f69ff.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/2f1948af9c984ebb82dfd618e67dc949755823e2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e68618ed...2f1948af](https://github.com/nixos/nixpkgs/compare/e68618ed4c73fe2566e69ef04034b958e66f69ff...2f1948af9c984ebb82dfd618e67dc949755823e2)

* [`3957ab13`](https://github.com/NixOS/nixpkgs/commit/3957ab13791c2df3cd324310dc86a5605ea011ec) munge: 0.5.14 -> 0.5.15
* [`584cfd8c`](https://github.com/NixOS/nixpkgs/commit/584cfd8caa3927f8acdde9eaffbb3a21162bb4ec) lib/systems/inspect.nix: Add riscv to isEfi
* [`a77366a2`](https://github.com/NixOS/nixpkgs/commit/a77366a2660f0b60d82b249ff3842b5e11757128) grub2: Add support for riscv{32,64}-linux
* [`c8a1838d`](https://github.com/NixOS/nixpkgs/commit/c8a1838d30fc1f7606b74ada544c73e8a868c0eb) fetchgit: remove "security" from comment about "security risk"
* [`45ed9e44`](https://github.com/NixOS/nixpkgs/commit/45ed9e44ca4651c7be766e653209248961803f20) netdata: remove judy from buildInputs as it is vendored by upstream
* [`6dd51641`](https://github.com/NixOS/nixpkgs/commit/6dd516414ad3dd0317b05c3f4129291a307f3659) conan: 1.49.0 -> 1.53.0
* [`21c0a5be`](https://github.com/NixOS/nixpkgs/commit/21c0a5bedb2e7daa1d7e5bd99028bd522977ddf0) libavif: 0.10.0 -> 0.11.1
* [`c31ccef6`](https://github.com/NixOS/nixpkgs/commit/c31ccef68094aeed816b001b2a5b43e8be73bf15) netdata: cleanup unnecessary .dev in buildInputs
* [`8344bf1a`](https://github.com/NixOS/nixpkgs/commit/8344bf1ac2485c6e0d7132bc66156a6705128d69) netdata: mark broken for cross compilation
* [`f5b4adae`](https://github.com/NixOS/nixpkgs/commit/f5b4adae0ba43bde6e0688c50a0ad076b21a3a2c) ntfsprogs: 2022.5.17 -> 2022.10.3
* [`e039cb9d`](https://github.com/NixOS/nixpkgs/commit/e039cb9d97d4a5939b6567c4b683cd8a8aa98777) nixos/qemu-vm: add option "restrictNetwork"
* [`88527c2e`](https://github.com/NixOS/nixpkgs/commit/88527c2e3175f10337ac2cefda6a3737c44daa46) element-web: export element-web-unwrapped
* [`285d1398`](https://github.com/NixOS/nixpkgs/commit/285d1398d1af8cf69527bd9ece47388534305539) maintainers: add davsanchez
* [`54c8b865`](https://github.com/NixOS/nixpkgs/commit/54c8b865d7d9abd738b86bafc7a1cdc61f66c815) cotp: init at 1.1.0
* [`9301018d`](https://github.com/NixOS/nixpkgs/commit/9301018d90943b049e3bc592a20709a2ae544ca5) octavePackages.image: 2.12.0 -> 2.14.0
* [`f68c3579`](https://github.com/NixOS/nixpkgs/commit/f68c35790ec749b72ad0607ab84cae11016fdd1e) nodePackages.readability-cli: add missing build inputs for canvas module
* [`ee2571e8`](https://github.com/NixOS/nixpkgs/commit/ee2571e8fe2222725e74547cd898654429ae7a22) nodePackages.readability-cli: do not patch a deno shebang line
* [`dfac3e29`](https://github.com/NixOS/nixpkgs/commit/dfac3e29cb489552a308dd422a84f65419d61736) nodePackages.readability-cli: use srcOnly (thanks to @⁠marsam)
* [`d8cf9632`](https://github.com/NixOS/nixpkgs/commit/d8cf963200b7afe73b4a2736ec45ee123cd8c904) opentelemetry-collector-contrib: 0.65.0 -> 0.66.0
* [`ad651f02`](https://github.com/NixOS/nixpkgs/commit/ad651f02dd28c56248fdd1fa837c75a04d63113b) mark gdb as unsupported on aarch64-darwin
* [`a5eb3b03`](https://github.com/NixOS/nixpkgs/commit/a5eb3b03ffff6e709412c7f3e1e57e04df2349ed) cups: fix cups.socket unit
* [`f5b54324`](https://github.com/NixOS/nixpkgs/commit/f5b5432450264c8a2c571061259d9cfe0f65a1ee) ruby: fix cross compiling extensions
* [`3a61d6d7`](https://github.com/NixOS/nixpkgs/commit/3a61d6d707752ebed77bf60e450176b00913cd74) agdaPackages.cubical: 0.4prec3e097a -> 0.4
* [`d402e05f`](https://github.com/NixOS/nixpkgs/commit/d402e05f6a6a2b87b15cde6d04cf251d6ee94407) libdevil: cleanup, add proper option for X support
* [`7c473eb6`](https://github.com/NixOS/nixpkgs/commit/7c473eb699d1c92db5f8aa1fe96d79eb2ae4aebc) gd: add withXorg flag, little cleanups
* [`88800d58`](https://github.com/NixOS/nixpkgs/commit/88800d588b6ccc28ff8dfa0bd7420945996e7cec) dnsmasq: 2.87 -> 2.88
* [`8a041c63`](https://github.com/NixOS/nixpkgs/commit/8a041c63c00ab9f03cfc468dcdecf2138e31513e) rustPlatform.buildRustPackage: build auditable binaries
* [`6c016816`](https://github.com/NixOS/nixpkgs/commit/6c01681679f7d2da1d300b6d16d11d58ba8b2286) make-symlinks-relative: fix no such file or directory if output is created in postFixup
* [`0e5137f2`](https://github.com/NixOS/nixpkgs/commit/0e5137f267ecf7dc0c9d68cc1b6fde13f5dc77ef) rustPlatform.buildRustPackage: make it not auditable by default
* [`0024ffa7`](https://github.com/NixOS/nixpkgs/commit/0024ffa7c26ecaff146cae9f04f465dd5ee144cc) alacritty: make auditable
* [`6f52f4b6`](https://github.com/NixOS/nixpkgs/commit/6f52f4b6776cb711ff2fe93128767d828bd066af) rust-analyzer: make auditable
* [`e4186ccd`](https://github.com/NixOS/nixpkgs/commit/e4186ccd21b5e7c4253ec12768648f77180fb03b) jumpy: make auditable
* [`506762f6`](https://github.com/NixOS/nixpkgs/commit/506762f643c53fc3687bd72821e9f88b52243596) fd: make auditable
* [`f053bc83`](https://github.com/NixOS/nixpkgs/commit/f053bc8339e2fa2598eac55814ef10d4ce7cd157) ripgrep: make auditable
* [`b632d78a`](https://github.com/NixOS/nixpkgs/commit/b632d78aeacc6259065e4471c1817d3a99b4f305) rav1e: make auditable
* [`9e3db33a`](https://github.com/NixOS/nixpkgs/commit/9e3db33a6b05806ec098f54d89d2bdb74fdbbfb1) mdbook: make auditable
* [`4fed4b8d`](https://github.com/NixOS/nixpkgs/commit/4fed4b8da8e91c01a9d28e9d3b936c16dd098a4f) nixos/znc: Doc fix about `services.znc.config`
* [`2b191a3b`](https://github.com/NixOS/nixpkgs/commit/2b191a3bd4f96d2aec1f901d585c83b1c378a632) quodlibet: Add WMA support
* [`ac17e99f`](https://github.com/NixOS/nixpkgs/commit/ac17e99f6c3022ce5d8fae790dc98431395a105e) cargo-auditable: 0.5.5 -> unstable-2022-12-07
* [`a6137b73`](https://github.com/NixOS/nixpkgs/commit/a6137b73f9656c0c5d7c8422c0f7444abbdfc14b) cargo-auditable-cargo-wrapper: init
* [`4ab0618b`](https://github.com/NixOS/nixpkgs/commit/4ab0618bc585ce69c2f34c0e1f12c7d86522f114) librsvg: make auditable
* [`e1b4c1f7`](https://github.com/NixOS/nixpkgs/commit/e1b4c1f7bdf9a568c034839998a2dd37671ded5d) ghostscript_headless: init
* [`d896fa53`](https://github.com/NixOS/nixpkgs/commit/d896fa5370e423b5d7dd5b51ffb12620c5da813e) texlive: Use ghostscriptX -> ghostscript_headless
* [`64c6e21d`](https://github.com/NixOS/nixpkgs/commit/64c6e21de5a3eb05303912eec356d9e1b6727119) matplotlib: Use ghostscript_headless
* [`47d9e7d3`](https://github.com/NixOS/nixpkgs/commit/47d9e7d3d7d8ad19e29be1445171726bf7d602b6) nixos/hardware/printers: stop cupsd when unneeded
* [`43cb1eb2`](https://github.com/NixOS/nixpkgs/commit/43cb1eb2f9b02356f130637dabcdc7fe10ee20fe) nixos/cupsd: stop managing /run/cups directory
* [`28034190`](https://github.com/NixOS/nixpkgs/commit/28034190def8d40c7cce31fb98960072a84a9a1a) nixos/cupsd: fix /var/run/ warning in cups.socket
* [`4f673654`](https://github.com/NixOS/nixpkgs/commit/4f67365482305a0fec444b725b131c82c563982b) nixos/tests/printing: split into service/socket
* [`06c51c46`](https://github.com/NixOS/nixpkgs/commit/06c51c4604dc73feea77dd612ea4b3d85097fcc5) boehmgc: little cleanup
* [`fa132338`](https://github.com/NixOS/nixpkgs/commit/fa132338fd56264bc85019e5bb441b68d03fc3d0) python310Packages.jsonschema: 4.17.0 -> 4.17.3
* [`0f4a7276`](https://github.com/NixOS/nixpkgs/commit/0f4a7276c4840bfe1db3dd4467eece3e76d4ee43) cargo-auditable: unstable-2022-12-07 -> 0.6.0
* [`238a6053`](https://github.com/NixOS/nixpkgs/commit/238a6053c43f7ac2e3dcc3d3c7f29f1e0c0be589) stdenv: support opt-in __structuredAttrs
* [`1c4820ef`](https://github.com/NixOS/nixpkgs/commit/1c4820efdd26a7ff2a06871ccc614781c31bd4a3) work around a nix bug
* [`8ad0103a`](https://github.com/NixOS/nixpkgs/commit/8ad0103a349b827b48bfaa908dbf5cd7a9371076) config.structuredAttrsByDefault: add option
* [`734d7df2`](https://github.com/NixOS/nixpkgs/commit/734d7df2351ac1a10774e665447c5cdc286fc16e) allow derivation attributes in env
* [`0cc87ab9`](https://github.com/NixOS/nixpkgs/commit/0cc87ab901909ae949d22caf071e446bed83e47a) nixos/systemd/userdbd: add method to enable service
* [`adc8900d`](https://github.com/NixOS/nixpkgs/commit/adc8900df1758eda56abd68f7d781d1df74fa531) treewide: fix some core package structuredAttrs
* [`18d00c58`](https://github.com/NixOS/nixpkgs/commit/18d00c5814ce49b64a228ab78b8e834900db0519) tests.stdenv: add some env attrset tests
* [`bb914d86`](https://github.com/NixOS/nixpkgs/commit/bb914d8676e8e0261bcd4d604c653618f53ffbd8) stdenv: export system pname name version for substituteAll
* [`c01f509e`](https://github.com/NixOS/nixpkgs/commit/c01f509e4438fd50faae0fa0175277b7b16728dc) treewide: source .attrs in builders
* [`02e3f51d`](https://github.com/NixOS/nixpkgs/commit/02e3f51d27417f2775982281fc39e31a4978ae39) darwin: use // for binutils-unwrapped and cctools to preserve the other
* [`c41cc9e7`](https://github.com/NixOS/nixpkgs/commit/c41cc9e762a97c20ec3be01db254787c046510e2) treewide: move some perl vars to env attrset
* [`c577eb68`](https://github.com/NixOS/nixpkgs/commit/c577eb6892a1128c1dd52846596217653ea87f14) wrapNonDeterministicGcc: fix
* [`89dc806f`](https://github.com/NixOS/nixpkgs/commit/89dc806f131ae9318d47d43befbe9a3ef7f7a765) what to do about attrs.env or {} maybe have a empty env attrset always
* [`11b49fa7`](https://github.com/NixOS/nixpkgs/commit/11b49fa7915f35251e18fe967fc63b4900dbad81) tests.hooks.default-stdenv-hooks.make-symlinks-relative: init
* [`7180c666`](https://github.com/NixOS/nixpkgs/commit/7180c66687dd21546d904f916234e1f70f1c3590) ffmpeg: 4.4.2 -> 4.4.3
* [`6459f8f8`](https://github.com/NixOS/nixpkgs/commit/6459f8f88f36c55b9b7bf4b5d90dadf792ee1202) rhash: 1.4.2 -> 1.4.3
* [`9578c261`](https://github.com/NixOS/nixpkgs/commit/9578c26172e2881eba2af08c5a34904c654ea719) libdrm: mark unsupported on Darwin
* [`8bf18f78`](https://github.com/NixOS/nixpkgs/commit/8bf18f7862ea9c10c1669f6e82e6d0b4e7600ea8) mesa: use libdrm on all supported platforms
* [`93b89c7b`](https://github.com/NixOS/nixpkgs/commit/93b89c7bfcb67f45a660e017f034974c911ae874) wayland: disable tests if libraries are disabled
* [`11dffd15`](https://github.com/NixOS/nixpkgs/commit/11dffd155d01d30e07d4dbfe6c6d6de05383be3a) Revert "wayland: broken for darwin"
* [`53b6c15d`](https://github.com/NixOS/nixpkgs/commit/53b6c15df2ed9ff30b22016da87d76841aa866bc) wayland-protocols: only run tests with libwayland
* [`2017fba3`](https://github.com/NixOS/nixpkgs/commit/2017fba3a2552519dbf918a19251a452ea90d4cc) wayland-protocols: broaden platforms
* [`e79dbb91`](https://github.com/NixOS/nixpkgs/commit/e79dbb918a261599e2e0bfc32548494681de1561) mesa-demos: fix build on Darwin
* [`05420f34`](https://github.com/NixOS/nixpkgs/commit/05420f34cf7b8eb6acb1e18d918b1a9a78762473) nixos: add systemd-homed support
* [`3046b67e`](https://github.com/NixOS/nixpkgs/commit/3046b67ec7a41654c8ecec0087110670a4ffdaf3) python310Packages.aiosignal: 1.3.1 -> 1.3.1
* [`519da3c1`](https://github.com/NixOS/nixpkgs/commit/519da3c1633c446cfcc2d97c0382e64123e59bcb) python310Packages.aiosignal: add changelog to meta
* [`6be612f6`](https://github.com/NixOS/nixpkgs/commit/6be612f64b5c41623a6f5c4ac3aa4835fef79bfa) fluidsynth: fix build on aarch64-darwin
* [`b6346180`](https://github.com/NixOS/nixpkgs/commit/b6346180fcd1e40b1fb9e39077796bc91cc45915) python310Packages.h2: fix tests on python 3.11
* [`515c893c`](https://github.com/NixOS/nixpkgs/commit/515c893cdac14b28075e61b1135ffb61c6ca5a3b) nghttp2: 1.49.0 -> 1.51.0
* [`fda61e90`](https://github.com/NixOS/nixpkgs/commit/fda61e9066f545fca1eb440d249131edac040c30) add docs for prependToVar and appendToVar
* [`68fb254b`](https://github.com/NixOS/nixpkgs/commit/68fb254bf22178bee1c3009348bc7206bac59fa6) tests.stdenv: deduplicate
* [`bf972f18`](https://github.com/NixOS/nixpkgs/commit/bf972f18736478dad213ce2c409239af36417787) tests.stdenv: add tests for prependToVar and appendToVar
* [`11c3127e`](https://github.com/NixOS/nixpkgs/commit/11c3127e38dafdf95ca71a85b1591a29b67e0c09) stdenv: detect the type of variable in {prepend,append}ToVar
* [`ba25f45c`](https://github.com/NixOS/nixpkgs/commit/ba25f45c729cf7fed14b683f2cd6cea44e281646) maturin: 0.13.0 -> 0.14.5
* [`662c9e21`](https://github.com/NixOS/nixpkgs/commit/662c9e2187c312cf3a3c94525bbd48f4d60f2463) python310Packages.platformdirs: add changelog to meta
* [`a3166ada`](https://github.com/NixOS/nixpkgs/commit/a3166adae7e45b9f5f96e30d6766ae2157637682) python310Packages.platformdirs: 2.5.3 -> 2.5.4
* [`e502357e`](https://github.com/NixOS/nixpkgs/commit/e502357e1255403f403689dfa7627a3bb592dc55) python310Packages.platformdirs: 2.5.4 -> 2.6.0
* [`bef9c1c3`](https://github.com/NixOS/nixpkgs/commit/bef9c1c3b2e0357e28156a43702313cd3fc18b95) python310Packages.urllib3: add changelog to meta
* [`c033f340`](https://github.com/NixOS/nixpkgs/commit/c033f340de6b9ea78cc5fbc3c296b99b27354dd5) python310Packages.urllib3: 1.26.12 -> 1.26.13
* [`54705413`](https://github.com/NixOS/nixpkgs/commit/54705413479d6deb288bc3c95308163ddfbf5261) oniguruma,jq: add artturin as maintainer
* [`aae20cf5`](https://github.com/NixOS/nixpkgs/commit/aae20cf5c05f9478c1933471f2ac1e841376eb91) jq,oniguruma: make suitable for inclusion in common-path.nix
* [`84a7cadf`](https://github.com/NixOS/nixpkgs/commit/84a7cadfd2d419b00148b5b826568c5ba59b93d5) tests.stdenv: add test-golden-example-structuredAttrs
* [`9cb56621`](https://github.com/NixOS/nixpkgs/commit/9cb5662187377146daf2b2abd54f4bce9ab59343) tests: move stdenv hook tests to stdenv.hooks
* [`daab80e0`](https://github.com/NixOS/nixpkgs/commit/daab80e08d43830c17b693f1b09eef1e2b59994c) move-docs.sh: update comment
* [`60b1f09a`](https://github.com/NixOS/nixpkgs/commit/60b1f09aa4e5e0a5c7fe95e72c323ba1a2471e08) tests.stdenv.hooks: add more tests
* [`04701ab5`](https://github.com/NixOS/nixpkgs/commit/04701ab5f5c0e7320361c97061f1014027cd6582) python310Packages.h2: disable timing sensitive test
* [`af70ba03`](https://github.com/NixOS/nixpkgs/commit/af70ba03d30779f965bd2c776e2dced6a82c9430) build-support/setup-hooks: change shebang to shellcheck directive
* [`7866db71`](https://github.com/NixOS/nixpkgs/commit/7866db71cc4e6c31b3ba1b6dae3bb9394128ad74) stdenv/generic: fix todo
* [`3b3ef7b7`](https://github.com/NixOS/nixpkgs/commit/3b3ef7b7666e8881478582443847322b6c2354c1) audit-tmpdir.sh: fix on darwin
* [`b3717f6c`](https://github.com/NixOS/nixpkgs/commit/b3717f6c143be42b3abb8f18302901df5372fbe9) stdenv: remove now unneeded linux conditional
* [`29c4626d`](https://github.com/NixOS/nixpkgs/commit/29c4626da89036f157ea7784fdcc38b5f79929d8) linuxHeaders: 6.0 -> 6.1
* [`630bb71a`](https://github.com/NixOS/nixpkgs/commit/630bb71ac5216135f4f576f03be465ccdc16d46a) stdenv: sort defaultNativeBuildInputs alphabetically
* [`64b335ce`](https://github.com/NixOS/nixpkgs/commit/64b335ce75a0115920adb033d7d2d90288fc2294) openjdk8: 322-ga -> 352-ga
* [`951304c4`](https://github.com/NixOS/nixpkgs/commit/951304c4598f293b1028c76f2d30d66d1a595246) openjdk11: 11.0.15+10 -> 11.0.17+8
* [`9e5e9c57`](https://github.com/NixOS/nixpkgs/commit/9e5e9c57bb8958004134806eef8e31aed9375ea6) openjfx11: 11.0.11+1 -> 11.0.17+1
* [`e1451322`](https://github.com/NixOS/nixpkgs/commit/e1451322584ed86b40165a96ed2c14f6b0342491) openjfx15: mark it as EOL
* [`f2cd590c`](https://github.com/NixOS/nixpkgs/commit/f2cd590cfbeea458910dfc238aa9b28dca538b84) openjfx17: 17.0.0.1+1 -> 17.0.5+1
* [`2ee1577a`](https://github.com/NixOS/nixpkgs/commit/2ee1577a1a91b6ba1577ef70ed31670a1e1836ca) openjfx15: gradle_5 -> gradle_6
* [`fa8c56b8`](https://github.com/NixOS/nixpkgs/commit/fa8c56b8c747493f18b70ba6436e162e32b311c7) openssl_3: patch CVE-2022-3996
* [`ed9e8cd6`](https://github.com/NixOS/nixpkgs/commit/ed9e8cd687b08a4e8f3d673f25c12e345afd65cb) systemd: 252.1 -> 252.3
* [`29b38799`](https://github.com/NixOS/nixpkgs/commit/29b38799e9ddd054411cf9fe79c981964a772e68) python310Packages.poetry-core: 1.3.2 -> 1.4.0
* [`95c657b1`](https://github.com/NixOS/nixpkgs/commit/95c657b15f252d26020e91fd1a2cc60b600103aa) python310Packages.poetry-plugin-export: 1.1.2 -> 1.2.0
* [`6de86a09`](https://github.com/NixOS/nixpkgs/commit/6de86a0981d48bbb4d426797eac5e4036022223b) python310Packages.trove-classifiers: init at 2022.12.1
* [`3186183e`](https://github.com/NixOS/nixpkgs/commit/3186183ec05cb44818647678db9810952e953479) python310Packages.poetry: 1.2.2 -> 1.3.0
* [`047b5821`](https://github.com/NixOS/nixpkgs/commit/047b5821350ec8ae4fc6fb725b13d4d725c7f62c) libarchive: 3.6.1 -> 3.6.2
* [`1f299ec9`](https://github.com/NixOS/nixpkgs/commit/1f299ec958b7f0f8c93faeaee0e5f11fbf8281bd) coredns: install man pages
* [`6a5211f1`](https://github.com/NixOS/nixpkgs/commit/6a5211f123c14f95cbbb6d17c21d9e78cb178952) nodejs-{16,18,19}_x: backport `npm pack` fixes from npm v9
* [`f1292b31`](https://github.com/NixOS/nixpkgs/commit/f1292b31d60bb804b1a9cc486a7cfd06b47c9a11) doc/languages-frameworks/javascript: use --ignore-scripts flag in example
* [`a37c3a6b`](https://github.com/NixOS/nixpkgs/commit/a37c3a6b942ef752d937afd407de87a3e3e47f99) ansible-language-server: use `npm pack --ignore-scripts`
* [`44ab6c7e`](https://github.com/NixOS/nixpkgs/commit/44ab6c7eebcaa704093918c9eeb3179e9f478b62) pcre2: 10.40 -> 10.42
* [`cf63ef8b`](https://github.com/NixOS/nixpkgs/commit/cf63ef8b34724aed31e3b4702865bcd4260c23d5) glib: Pick security patches
* [`6ba47391`](https://github.com/NixOS/nixpkgs/commit/6ba4739114dee7d0374f6acc38d26d666f50fc8d) python310Packages.limits: 2.7.0 -> 2.7.2
* [`9551ca33`](https://github.com/NixOS/nixpkgs/commit/9551ca33185d70acefd9cdc84f9ccc6b12df0b0c) python310Packages.six: run tests
* [`3954989b`](https://github.com/NixOS/nixpkgs/commit/3954989b5b2843db6905309a1e955513df4ad136) python310Packages.yarl: 1.8.1 -> 1.8.2
* [`31c93ff0`](https://github.com/NixOS/nixpkgs/commit/31c93ff0b873add319265cb2dd9ce41a57a2a5ff) python310Packages.multidict: 6.0.2 -> 6.0.3
* [`804a0f03`](https://github.com/NixOS/nixpkgs/commit/804a0f037d4ebad40d6f21713eec01a8f951a35a) libclc: 12.0.1 -> 14.0.6
* [`cd53c071`](https://github.com/NixOS/nixpkgs/commit/cd53c071f2ce8ed43365c519aad49bf58ec5dd97) mesa: 22.2.5 -> 22.3.1, enable rusticl
* [`fde44ef9`](https://github.com/NixOS/nixpkgs/commit/fde44ef915f67047277fbc601fac320a7c3955f0) x265: only disable assembly on riscv-cross builds
* [`e14de226`](https://github.com/NixOS/nixpkgs/commit/e14de22618dc6c547f7c89f57eefe98e9e0bb8c4) stdenv: handle `env` gracefully
* [`9b1e8d72`](https://github.com/NixOS/nixpkgs/commit/9b1e8d7267ad7999677ea1900a5613ee1f23d0fc) tests.stdenv: check that attrs in env are exported
* [`52502e26`](https://github.com/NixOS/nixpkgs/commit/52502e26699ddae3333ad54c0481b66812eeac2a) AusweisApp2: 1.24.4 -> 1.26.1
* [`1ffbdda6`](https://github.com/NixOS/nixpkgs/commit/1ffbdda604b5c0daf6cbd521aa09b21cdc72f55c) rustc: 1.65.0 -> 1.66.0
* [`bea06ddf`](https://github.com/NixOS/nixpkgs/commit/bea06ddf3546721446744b732265c4683b8533b9) kiwix: 2.2.1 -> 2.3.1
* [`931fc456`](https://github.com/NixOS/nixpkgs/commit/931fc456ded386d80b81cd62730cda5c0631df99) shadow: 4.11.1 -> 4.13
* [`c72dd688`](https://github.com/NixOS/nixpkgs/commit/c72dd6887516c762d73dfb6ee35aad5ffb88a29f) vulkan-headers: 1.3.231.0 -> 1.3.236.0
* [`7a28a0b6`](https://github.com/NixOS/nixpkgs/commit/7a28a0b6593403633b93c8396818fb78f610f768) spirv-headers: 1.3.231.0 -> 1.3.236.0
* [`705ca8e2`](https://github.com/NixOS/nixpkgs/commit/705ca8e2b23a5c8595bc49798203d0192ed5112b) spirv-tools: 1.3.231.0 -> 1.3.236.0
* [`ca81eb84`](https://github.com/NixOS/nixpkgs/commit/ca81eb8452393ef7380b0f33708e3a664bc4d188) glslang: 1.3.231.0 -> 1.3.236.0
* [`c08c7dda`](https://github.com/NixOS/nixpkgs/commit/c08c7dda802473d436e199518e2b240e0d500b20) vulkan-loader: 1.3.231.0 -> 1.3.236.0
* [`57e6c338`](https://github.com/NixOS/nixpkgs/commit/57e6c338f17f8565334da75da88b302403a241c5) vulkan-validation-layers: 1.3.231.0 -> 1.3.236.0
* [`4beaa32e`](https://github.com/NixOS/nixpkgs/commit/4beaa32eaec4d8401f753ee846c0bc774867f4ac) vulkan-tools: 1.3.231.0 -> 1.3.236.0
* [`eaaafb78`](https://github.com/NixOS/nixpkgs/commit/eaaafb78663b8c988f8f77a02d13cc654a277bb9) vulkan-extension-layer: 1.3.231.0 -> 1.3.236.0
* [`d9f6f43d`](https://github.com/NixOS/nixpkgs/commit/d9f6f43d2b4be0a324e05cd10902fde374570e25) vulkan-tools-lunarg: 1.3.231.0 -> 1.3.236.0
* [`620c7eae`](https://github.com/NixOS/nixpkgs/commit/620c7eaeeeaed47156d51b04e50ea220614cfa62) python310Packages.tomlkit: 0.11.4 -> 0.11.6
* [`8e94a436`](https://github.com/NixOS/nixpkgs/commit/8e94a4368799224d38bdae20ddcfbf81261feeea) sioyek: unstable-2022-08-30 -> 2.0.0
* [`0e321916`](https://github.com/NixOS/nixpkgs/commit/0e32191623d9827d58b627a9cb0f2a37756c77ff) shadow: add tcb support
* [`05046655`](https://github.com/NixOS/nixpkgs/commit/05046655d84faf0fc6031bf78a384160050a3fc0) shadow: cleanup
* [`0b067316`](https://github.com/NixOS/nixpkgs/commit/0b067316d40845426bc6f6dd44aa74c0b7f66028) stdenv: use `intersectAttrs` instead of `intersectLists`
* [`cbb000c6`](https://github.com/NixOS/nixpkgs/commit/cbb000c6dba8369cf2cbb0ff368305b830c18e5a) perlPackages.LaTeXML: 0.8.6 -> 0.8.7
* [`29362413`](https://github.com/NixOS/nixpkgs/commit/2936241324cedfd599cee314f83e8e8849f4e17f) mssql_jdbc: 7.2.2 -> 11.2.2
* [`e00c0498`](https://github.com/NixOS/nixpkgs/commit/e00c04989763ef0c9649509b5c5d4c62d67d0f1a) nvidia-vaapi-driver: unstable-2022-12-01 -> 0.0.8
* [`428107f8`](https://github.com/NixOS/nixpkgs/commit/428107f8376695a51c2eb1376ca968f781cf965f) stdenv: set `enableParallelBuilding` explicitly if `enableParallelBuildingByDefault` is set
* [`d8b734f6`](https://github.com/NixOS/nixpkgs/commit/d8b734f6a4658b004711c98370d673d6e6317be6) pciutils: add trivial updater
* [`21337279`](https://github.com/NixOS/nixpkgs/commit/21337279c1478c3660b9be1fd05c2a27a60ff962) pciutils: 3.8.0 -> 3.9.0
* [`73e6d3ed`](https://github.com/NixOS/nixpkgs/commit/73e6d3ed00b6452eb55cc7f9c40c00c6deba0320) xz: 5.2.9 -> 5.4.0
* [`d1e7498d`](https://github.com/NixOS/nixpkgs/commit/d1e7498dbbc7d8fe5419110aa1f1fe57ffb8d1d8) commitizen: 2.37.0 -> 2.38.0
* [`61ac4200`](https://github.com/NixOS/nixpkgs/commit/61ac4200206f23026e198aa98779f28ae05ba389) sphinx-automodapi: fix tests
* [`7f864b4a`](https://github.com/NixOS/nixpkgs/commit/7f864b4a32f0c556e85400d6b0a7659576c48045) lit: 14.0.0 -> 15.0.6
* [`8be466f7`](https://github.com/NixOS/nixpkgs/commit/8be466f7444daaef4d308a46dae2671c006a9cdb) spirv-llvm-translator: allow rocm versioning
* [`3b271b7e`](https://github.com/NixOS/nixpkgs/commit/3b271b7ebc25648daa08997e7758dad11e321d21) python3Packages: sphinx-markdown-tables: init at 0.0.17
* [`0ee533a8`](https://github.com/NixOS/nixpkgs/commit/0ee533a8e00d7131b7a7d5d6d5f605f18af07426) rocm-llvm: rewrite and separate
* [`785ed480`](https://github.com/NixOS/nixpkgs/commit/785ed480aafdde6cbbffb7605f1cd988f8524dab) rocm-related: standardize
* [`fb8a7b62`](https://github.com/NixOS/nixpkgs/commit/fb8a7b62bb3f0c3e381761eb3332c8abefbbd9e6) rocm-related: standardize and fix tests/benchmarks
* [`f6e28e20`](https://github.com/NixOS/nixpkgs/commit/f6e28e20587fbfef6b84cedb13afe25860cb33b8) hip: rewrite and separate
* [`b9435451`](https://github.com/NixOS/nixpkgs/commit/b943545109674c85163b9e034a6f4798262ef3c3) rocprofiler: init at 5.4.0
* [`5b74e4ef`](https://github.com/NixOS/nixpkgs/commit/5b74e4ef126b19831cdcaa6f3b7052fb4d637162) roctracer: init at 5.4.0
* [`ecaaa49b`](https://github.com/NixOS/nixpkgs/commit/ecaaa49b651b8385ba86e9ede313a8e337289d93) rocsolver: init at 5.4.0
* [`f69c8df2`](https://github.com/NixOS/nixpkgs/commit/f69c8df2f3b6f64e4432e5feeb0be12afc158f6a) rocalution: init at 5.4.0
* [`9e0472e2`](https://github.com/NixOS/nixpkgs/commit/9e0472e20658de07cbb16b3af6476ffde98fbf4f) rocm-related: 5.4.0 → 5.4.1
* [`187452f5`](https://github.com/NixOS/nixpkgs/commit/187452f58e6c5b0d4f50ca155c1a4b912006d630) rocmlir: don't enable broken as long as minor version is the same
* [`93ec556b`](https://github.com/NixOS/nixpkgs/commit/93ec556b19a9cddc7798231536c7eed470e9da64) rocmUpdateScript: fix llvmPackages_rocm updating
* [`f84b81a2`](https://github.com/NixOS/nixpkgs/commit/f84b81a23c4483f1b6b3309e9be5dedf6b22535b) composable_kernel: fix tests, disable examples
* [`e86c679d`](https://github.com/NixOS/nixpkgs/commit/e86c679d092b06e5edfd324eecc66b37f61b6d98) miopen: fixup, enable kdbs by default, symlink for hydra
* [`8de23957`](https://github.com/NixOS/nixpkgs/commit/8de23957e97b7bb04978829e62f53a4b848a500b) rocm-related: add release notes
* [`31c7a1b6`](https://github.com/NixOS/nixpkgs/commit/31c7a1b61466e9323973a487288e9b98fbb4d746) python310Packages.trustme: remove aarch64-darwin workarounds
* [`967b87ea`](https://github.com/NixOS/nixpkgs/commit/967b87ea6e287814a099f2177f38dbc31211e000) krb5: 1.20 -> 1.20.1
* [`8e80bc7d`](https://github.com/NixOS/nixpkgs/commit/8e80bc7dd2179cbb4733edfde76b00e103bae363) hipsparse: fixup samples
* [`ce1fd653`](https://github.com/NixOS/nixpkgs/commit/ce1fd653e3e02ba3420b1edfe5d2374b44b70e5c) miopen: fixup tests
* [`3690ec3a`](https://github.com/NixOS/nixpkgs/commit/3690ec3a8d4385cc34edbee0aab3828bc2f74656) roctracer: fixup tests
* [`aebf6f67`](https://github.com/NixOS/nixpkgs/commit/aebf6f67c269dc383a4ceececf7e36458c348b53) python310Packages.pycares: add changelog to meta
* [`1ca0fd7d`](https://github.com/NixOS/nixpkgs/commit/1ca0fd7d6d623a8c5189d0ba18f09a09a791a167) python310Packages.pycares: 4.2.2 -> 4.3.0
* [`2b169659`](https://github.com/NixOS/nixpkgs/commit/2b1696598917eef6d0e4d2f5467a9c208a6cacdd) python310Packages.pycares: add passthru.tests
* [`811a1563`](https://github.com/NixOS/nixpkgs/commit/811a1563a0933254b909c41d7a7295232752e569) python310Packages.watchdog: add changelog to meta
* [`dbecef29`](https://github.com/NixOS/nixpkgs/commit/dbecef299504803e718f7e6b31f2c358f9365d0f) python310Packages.watchdog: 2.1.9 -> 2.2.0
* [`c53bf3af`](https://github.com/NixOS/nixpkgs/commit/c53bf3afbad0016428fda2bf6b0e605aa289ca57) python310Packages.pyelftools: add changelog to meta
* [`1c45ce63`](https://github.com/NixOS/nixpkgs/commit/1c45ce632716eaad9d002cb5bae65e0d0d5a3a15) python310Packages.pyelftools: 0.28 -> 0.29
* [`f8fa52c4`](https://github.com/NixOS/nixpkgs/commit/f8fa52c4edeeca248053a135c8110bb4689b9c18) python310Packages.unidecode: add changelog to meta
* [`8e63b888`](https://github.com/NixOS/nixpkgs/commit/8e63b88831614b507e22a4c4a3ca966aab5cd21e) python310Packages.unidecode: 1.34 -> 1.3.6
* [`7b9adf4d`](https://github.com/NixOS/nixpkgs/commit/7b9adf4dee7614a0621758819d2db601bf853bc1) libarchive: refactor
* [`1e724278`](https://github.com/NixOS/nixpkgs/commit/1e724278031b714aa83a33517ae6c383d38c1281) bazel_6: 6.0.0-pre.20220720.3 -> 6.0.0
* [`decf41be`](https://github.com/NixOS/nixpkgs/commit/decf41beb3699461889fd2b98dd33e5e0d177c0e) gwenhywfar: 5.9.0 -> 5.10.1
* [`36ee125e`](https://github.com/NixOS/nixpkgs/commit/36ee125efe686918f7753de341e440c3358040b3) obsidian: 1.0.3 -> 1.1.8
* [`4e3db444`](https://github.com/NixOS/nixpkgs/commit/4e3db444a5b574837e0b3c4a62349ba8cde296b4) directx-shader-compiler: 1.7.2207 -> 1.7.2212
* [`45f1d701`](https://github.com/NixOS/nixpkgs/commit/45f1d701019d43b63299e8a0bb79055f6dfc190e) pwndbg: 2022.08.30 -> 2022.12.19
* [`47de6eca`](https://github.com/NixOS/nixpkgs/commit/47de6ecabb0609bc8b4212842fb01533b3616874) systemd: 252.3 -> 252.4
* [`b86dab08`](https://github.com/NixOS/nixpkgs/commit/b86dab08a2695a511292977f2568eef09174b8a6) Use darwin.apple_sdk_11_0.callPackage
* [`c44fb852`](https://github.com/NixOS/nixpkgs/commit/c44fb852ce2cf9edff9a8825419a820fc80884d8) curl: 7.86.0 -> 7.87.0
* [`bae75df2`](https://github.com/NixOS/nixpkgs/commit/bae75df20ec7f187b9995f4f27016de54f3ca02b) libksba: 1.6.2 -> 1.6.3
* [`5aef081f`](https://github.com/NixOS/nixpkgs/commit/5aef081f74333a74ee4d5022adf27d0c421f08ad) freetype: add brotli
* [`729c7fb1`](https://github.com/NixOS/nixpkgs/commit/729c7fb1c8c610a360d652c7047ef0da10f6a04c) nasm: 2.15.05 -> 2.16.01
* [`cdf92e56`](https://github.com/NixOS/nixpkgs/commit/cdf92e56f7e51e97c7acf3020977be20ba8086c4) mesa: enable separateDebugInfo
* [`b1834a46`](https://github.com/NixOS/nixpkgs/commit/b1834a461edf7abf4a6fb89db0ed65904a48a01c) Revert "rustc: propagate libiconv on darwin"
* [`edfbbaf2`](https://github.com/NixOS/nixpkgs/commit/edfbbaf28258d968de64b364d4a0868a80cdf1c2) rustc: add note about libiconv dependency
* [`f402b4b2`](https://github.com/NixOS/nixpkgs/commit/f402b4b29e8c75f2fd0ea491b2c1a982fd5b0398) python310Packages.pytz: 2022.6 -> 2022.7
* [`e07df68f`](https://github.com/NixOS/nixpkgs/commit/e07df68f1ecae8e74171aa459c836e6a6b9b5f26) sqlite: add patch for CVE-2022-46908
* [`02ffcc0b`](https://github.com/NixOS/nixpkgs/commit/02ffcc0ba31ed9d216b8c8ca0790b48573050ce8) gnused: 4.8 -> 4.9
* [`81465ba9`](https://github.com/NixOS/nixpkgs/commit/81465ba9497e05a3ef1c1dcb6a15223ca1cfa2a1) python310Packages.pybind11: 2.10.1 -> 2.10.2
* [`5c924eeb`](https://github.com/NixOS/nixpkgs/commit/5c924eeb218d3ef056dace189044fd08d02c0549) nbxplorer: use fetch-deps instead of custom create-deps.sh
* [`ebd9eeed`](https://github.com/NixOS/nixpkgs/commit/ebd9eeedeef1da2b7dc447a394d26ecc9f047c82) btcpayserver: 1.7.2 -> 1.7.3
* [`4b477763`](https://github.com/NixOS/nixpkgs/commit/4b4777638c424fa29224330d078b065503806aad) soundtouch: 2.3.1 -> 2.3.2
* [`74d2a819`](https://github.com/NixOS/nixpkgs/commit/74d2a819f39b2ad8f9db215d4e154c22af91e7e5) btcpayserver: add btcpayserver-altcoins alias to enable altcoinSupport
* [`a16c64bf`](https://github.com/NixOS/nixpkgs/commit/a16c64bf42513ea5353d235a050b629e58517cd4) libbpf: 1.0.1 -> 1.1.0
* [`392d0df1`](https://github.com/NixOS/nixpkgs/commit/392d0df157fbab524bee99500f948126638d156c) tewisay: unstable-2017-04-14 -> unstable-2022-11-04
* [`b4b746ca`](https://github.com/NixOS/nixpkgs/commit/b4b746ca00bb6ee7e21be8ed6826892fdf0ee4ed) libcamera: 0.0.1 -> 0.0.3
* [`1e8999d1`](https://github.com/NixOS/nixpkgs/commit/1e8999d1ff29ca2c1bcbf25fd975df936b60491a) zam-plugins: 3.14 -> 4.1
* [`9a82a9b5`](https://github.com/NixOS/nixpkgs/commit/9a82a9b5248919805a2400266ebd881d5783df2a) bazel: 5.2.0 -> 5.3.2
* [`78c276f9`](https://github.com/NixOS/nixpkgs/commit/78c276f9b14436ca2ea45a90d53a3e221a7689d5) nixos/no-x-libs: add gst_all_1.gst-plugins-base, turn gstreamer back on for libextractor
* [`c5551f19`](https://github.com/NixOS/nixpkgs/commit/c5551f19e5d76d3ed1e83fbc659686a56a297cb4) nixos/no-x-libs: add mpv-unwrapped
* [`1557d417`](https://github.com/NixOS/nixpkgs/commit/1557d417975bd1369c11a72715e36e23cf982a33) gst_all_1.gst-plugins-base: fix build without x11
* [`a4a1e28e`](https://github.com/NixOS/nixpkgs/commit/a4a1e28e2d3fcbb9efa9e4f4fdc238623148a0d8) python310Packages.pytest-httpserver: add changelog to meta
* [`69ba914b`](https://github.com/NixOS/nixpkgs/commit/69ba914b99bc7c43f5d821f7afef8d28a4d73d22) git: 2.38.1 -> 2.39.0
* [`67ce2eda`](https://github.com/NixOS/nixpkgs/commit/67ce2eda82f8bc27b9abf9a63882532264f6bd3d) tcb: fix cross-compilation of tcb
* [`5e2d7188`](https://github.com/NixOS/nixpkgs/commit/5e2d7188e799a79d1d2fb1a433c837934700d316) krb5: add some key reverse-dependencies to passthru.tests
* [`37a44b41`](https://github.com/NixOS/nixpkgs/commit/37a44b41fcf1aebd06e4417bde5cbb1e5be3bc2b) git: set reasonable default features
* [`8f421eef`](https://github.com/NixOS/nixpkgs/commit/8f421eef7d265e53eb24aa33ba583bee19738a97) maintainers: add realsnick
* [`fff47fb0`](https://github.com/NixOS/nixpkgs/commit/fff47fb03946e6036bad1a7e22de2d47aed1c211) libusb1: add option to build with examples
* [`4b365604`](https://github.com/NixOS/nixpkgs/commit/4b3656046b2d00fef857d731f871947377392dd0) python3Packages.datatable: 0.11.0 -> unstable-2022-12-15
* [`6257a5ae`](https://github.com/NixOS/nixpkgs/commit/6257a5ae5d24bbb23e37c65902875a65ae438f15) gtk3: add missing libXdamage, explicitly add libXfixes
* [`7843a268`](https://github.com/NixOS/nixpkgs/commit/7843a268f214f89dba7fdab1030872bdc96b9606) poetry2nix: drop unused pkgs.xlibsWrapper import
* [`807a91eb`](https://github.com/NixOS/nixpkgs/commit/807a91eb8a8bf6fc49c1b45d1a94ced569fefe91) maintainers: add sephi
* [`3eec3c8f`](https://github.com/NixOS/nixpkgs/commit/3eec3c8fed0251563841e26e044600139c2f92eb) buildRustPackage: remove git from nativeBuildInputs
* [`348e4856`](https://github.com/NixOS/nixpkgs/commit/348e485608705007d639a609e91d6882000fdbd9) python3Packages.django-rest-registration: init at 0.7.3
* [`8820ea8f`](https://github.com/NixOS/nixpkgs/commit/8820ea8fc570fe6fe144efe247084c5b6bc12d85) python3Packages.django-phonenumber-field: init at 6.4.0
* [`c88535bc`](https://github.com/NixOS/nixpkgs/commit/c88535bc54bd665d82172a581286f4ccc429becb) pipewire: backport a few fixes
* [`cb752b3f`](https://github.com/NixOS/nixpkgs/commit/cb752b3fd662c863aebeeeb3d0a33a3cfd1cf5c3) roundcubePlugins.carddav: 4.4.4 -> 4.4.6
* [`b21655f6`](https://github.com/NixOS/nixpkgs/commit/b21655f6617e1c6eea3fa6b38ab1ec5934f9fb70) ell: 0.54 -> 0.55
* [`d6f100fb`](https://github.com/NixOS/nixpkgs/commit/d6f100fbf022c7ff28f6e98e54eff94e489ab265) hugin: 2021.0.0 → 2022.0.0
* [`3fba3bf5`](https://github.com/NixOS/nixpkgs/commit/3fba3bf53f2412cc5e324c3ad19215c058de5617) gawk: 5.1.1 -> 5.2.1
* [`3c478e4b`](https://github.com/NixOS/nixpkgs/commit/3c478e4b5db3bb02d981980e00b6470f6addea6f) xlibsWrapper: remove deprecated and now unused wrapper package
* [`97b4a0e4`](https://github.com/NixOS/nixpkgs/commit/97b4a0e4a7cc205615d05a8e17f47e40c4cbcf23) ansible-language-server: restore lost updater and prepactk handling on merge
* [`93e794c9`](https://github.com/NixOS/nixpkgs/commit/93e794c979d8d60c6ab81af76fffba44a5973088) obsidian: 1.1.8 -> 1.1.9
* [`72ea3c7f`](https://github.com/NixOS/nixpkgs/commit/72ea3c7f445dfbc8a8459dc8868721c1964efe6c) wiki-js: 2.5.294 -> 2.5.295
* [`dfd957c8`](https://github.com/NixOS/nixpkgs/commit/dfd957c8192967bb5dc3425f4bfb4ebae9dc7646) yubikey-agent: unstable-2022-03-17 -> 0.1.6
* [`781c993a`](https://github.com/NixOS/nixpkgs/commit/781c993a8ae7a813e88e1ff5a510d9fd2716d8ff) python310Packages.boto3: 1.24.75 -> 1.26.38
* [`9a0aed0d`](https://github.com/NixOS/nixpkgs/commit/9a0aed0dc19b8fc31dd00183216c2fc29830c013) python310Packages.botocore: 1.27.75 -> 1.29.38
* [`4e2ee61d`](https://github.com/NixOS/nixpkgs/commit/4e2ee61dfd04d98be1a9cae62391cc80ace112c5) awscli: 1.25.76 -> 1.27.38
* [`b1d1ff02`](https://github.com/NixOS/nixpkgs/commit/b1d1ff029af05d15838b273c299d5231c7b42095) python310Packages.moto: 4.0.3 -> 4.0.12
* [`b3304bb5`](https://github.com/NixOS/nixpkgs/commit/b3304bb53f39134cd857561386758e2de79f345e) musl: add bin output.
* [`021eed6b`](https://github.com/NixOS/nixpkgs/commit/021eed6b752f466e7931fc1e63071a7a0ebe85d5) opencv: 4.6.0 -> 4.7.0
* [`50adabdd`](https://github.com/NixOS/nixpkgs/commit/50adabdd60d590c951824974356a9ccb9bb73ffc) readline: 8.1 -> 8.2
* [`aae36e68`](https://github.com/NixOS/nixpkgs/commit/aae36e6869162e97b6ff02b6bdfdeb23e55f3c5d) bash: 5.1 -> 5.2
* [`e9f67d5a`](https://github.com/NixOS/nixpkgs/commit/e9f67d5ae55e2107ef0ece3a537b29375a1e9b00) gst_all_1.gst-plugins-bad: bump opencv version range
* [`968ff666`](https://github.com/NixOS/nixpkgs/commit/968ff666d88bdd36ff5d74ff66b424a5effd30a5) burp: 2.2.18 -> 2.4.0
* [`e30a8ca0`](https://github.com/NixOS/nixpkgs/commit/e30a8ca06cadad2e5aaa9ce25dbf10c2fac55c4c) python3Packages.sqlalchemy: 1.4.41 -> 1.4.45
* [`c1bd736b`](https://github.com/NixOS/nixpkgs/commit/c1bd736beed16f5bc7e0827d4d40ea255d15b973) python3Packages.databases: 0.6.2 -> 0.7.0
* [`0201a054`](https://github.com/NixOS/nixpkgs/commit/0201a0546956c4d55600ddd70481af6f85c4ce4b) iwd: 2.0 -> 2.1
* [`fa3feb9f`](https://github.com/NixOS/nixpkgs/commit/fa3feb9f655e7f417bdd2fc83f5bf43085a64597) python3Packages.pythonImportsCheck: set $PYTHONPATH
* [`72c7d7c2`](https://github.com/NixOS/nixpkgs/commit/72c7d7c27ea766ebe2ba6447ea9686c73169b6b8) opencv4: add reverse deps to tests
* [`65902d64`](https://github.com/NixOS/nixpkgs/commit/65902d647ca8723fbc71546f9e8b6264d842021c) asn1c: re-init at 0.9.28
* [`aebbd7a4`](https://github.com/NixOS/nixpkgs/commit/aebbd7a483853a79437ceb667f4831f202d941cb) easyrsa: 3.0.8 -> 3.1.1
* [`53d105f8`](https://github.com/NixOS/nixpkgs/commit/53d105f80eae0291ae4cb613a2cf01c59a399393) easyrsa2: remove
* [`c2eda91e`](https://github.com/NixOS/nixpkgs/commit/c2eda91e012577ef86faa358ad0940111357c1a0) libpng: 1.6.37 -> 1.6.39
* [`3f5d99e9`](https://github.com/NixOS/nixpkgs/commit/3f5d99e914f7878c124aa97bf2fe6bda27fbe802) gdb: backport readline-8.2 fix
* [`afd803ca`](https://github.com/NixOS/nixpkgs/commit/afd803ca9569a951555fed16afadae6933d0c8b4) opentelemetry-collector: 0.66.0 -> 0.68.0
* [`90af686d`](https://github.com/NixOS/nixpkgs/commit/90af686ddb32dd565244ef53ce3a8d5e5cbae1be) xorgcffiles: add aarch64-darwin support
* [`34878aa6`](https://github.com/NixOS/nixpkgs/commit/34878aa66d8346b5e84c6904a0445d44bb75ea79) oneko: unbreak on aarch64-darwin
* [`e70ea256`](https://github.com/NixOS/nixpkgs/commit/e70ea256f42f71f9ca7e5376024e80eb469ad6c3) xearth: unbreak on aarch64-darwin
* [`42e4d047`](https://github.com/NixOS/nixpkgs/commit/42e4d047d12f09bb6249b0385825a7e91f6b08ec) xskat: unbreak on aarch64-darwin
* [`bdaff9db`](https://github.com/NixOS/nixpkgs/commit/bdaff9db296aac8dc70448b921873ce2f2bf82e4) xsok: unbreak on aarch64-darwin
* [`064207b7`](https://github.com/NixOS/nixpkgs/commit/064207b723a0f0e2ccb2fb89a4326e672133905f) x11_ssh_askpass: unbreak on aarch64-darwin
* [`689aaa51`](https://github.com/NixOS/nixpkgs/commit/689aaa51d4151ab75b632cdf7633a0e10771a161) Add wrapGAppsHook to build inputs
* [`c730732b`](https://github.com/NixOS/nixpkgs/commit/c730732bdafbfc931bfbf6a8cf4cdd5ea9d8dd45) sqlite: 3.40.0 -> 3.40.1
* [`049e3877`](https://github.com/NixOS/nixpkgs/commit/049e3877c6e290b06660148e8cfc91dc0ef2f6fa) wolf-shaper: 0.1.8 -> 1.0.0
* [`60f6a46b`](https://github.com/NixOS/nixpkgs/commit/60f6a46bbd29b6a9f7e7a0ae8b42ddc1b02f2b40) qt6.qtbase: remove valgrind from propagatedBuildInputs
* [`753da128`](https://github.com/NixOS/nixpkgs/commit/753da128bd2ce4a5e8108fb0617e31a87e458fac) qt6.qtvirtualkeyboard: add dev output
* [`650f51f3`](https://github.com/NixOS/nixpkgs/commit/650f51f373f2fea2ace997ad29390d679abbbc2e) qt6Packages.quazip: add dev output
* [`bffa10ff`](https://github.com/NixOS/nixpkgs/commit/bffa10ffa3db5aaaa9f505de2c34879faaed06cd) openboard: fix build
* [`443560c8`](https://github.com/NixOS/nixpkgs/commit/443560c8312c5dd8a9f97f61998a5072b5383be3) fritzing: fix build
* [`01c8e3d8`](https://github.com/NixOS/nixpkgs/commit/01c8e3d8bbada41a0caeb7b48292aad1fa3d7838) Revert "qt6.qtdeclarative: reduce closure size by removing reference to qtbase.dev"
* [`496a2f43`](https://github.com/NixOS/nixpkgs/commit/496a2f43b4455959a7a7aece0bece913003c5bf5) qt6.qtbase: patch QTEST_ASSERT and other macros to remove reference to qtbase.dev via __FILE__ macro
* [`05c8b62e`](https://github.com/NixOS/nixpkgs/commit/05c8b62e27509f4808036ac8552e83869affc0de) orc: 0.4.32 -> 0.4.33
* [`58a27a65`](https://github.com/NixOS/nixpkgs/commit/58a27a65e449454d735b50a142ad585a22baee9c) qbs: 1.23.1 -> 1.24.0
* [`bceccb7f`](https://github.com/NixOS/nixpkgs/commit/bceccb7f707c0b0cfba7288cfcb11c4832ac1272) androidenv: Replace deploy-androidpackage.nix with deploy-androidpackages.nix
* [`b2557f76`](https://github.com/NixOS/nixpkgs/commit/b2557f76532a4d3804615f9e64cff3bc732b199b) gmsh: Enable shared library
* [`24de35c6`](https://github.com/NixOS/nixpkgs/commit/24de35c698cf210cc23a711e7ce5ca40044d93fb) gmsh: 4.11 -> 4.11.1
* [`d1a1f2fa`](https://github.com/NixOS/nixpkgs/commit/d1a1f2fa06fac055a57b28f3e15db7f8a793574c) androidenv: Fix we are using 2 spaces to intend nix code in
* [`027f7687`](https://github.com/NixOS/nixpkgs/commit/027f7687583d1a9f2e5291907b4e121a247bcd23) dina-font: fix encoding
* [`9025e3da`](https://github.com/NixOS/nixpkgs/commit/9025e3da4c14220a120399f37e7d71e025d69f4a) nex: init at unstable-2021-03-30
* [`6fd7e66a`](https://github.com/NixOS/nixpkgs/commit/6fd7e66a529979b64f823699e4fb4e8b915449b9) rednotebook: 2.26 -> 2.29
* [`a837cde0`](https://github.com/NixOS/nixpkgs/commit/a837cde0789aab541386de367a21d9b3efb89b04) kotlin: 1.7.20 -> 1.8.0
* [`1e1b7c77`](https://github.com/NixOS/nixpkgs/commit/1e1b7c77654d7b907000b7bb73ad3e674aaa0539) orc: add some key reverse-dependencies to passthru.tests
* [`3cd6cd41`](https://github.com/NixOS/nixpkgs/commit/3cd6cd412043a513c04259d32468259332ff95d1) mesa: 22.3.1 -> 22.3.2
* [`04b55451`](https://github.com/NixOS/nixpkgs/commit/04b55451e8373190114df534087749ac0b61376b) runescape-launcher: Switch to openssl_1_1
* [`a5b7b6e4`](https://github.com/NixOS/nixpkgs/commit/a5b7b6e47a3b4e5cdb12e6367d3136ff60529036) nixos/nixos-enter: hide systemd-tmpfiles errors
* [`19cfb3e4`](https://github.com/NixOS/nixpkgs/commit/19cfb3e48c775d3ef5d045265d3ded5cdb16df2c) nixos/tests/installer: test initrd secrets and nix-build
* [`d307bbb6`](https://github.com/NixOS/nixpkgs/commit/d307bbb698c8256a86b92ac96ee04ca91b52274d) burp: adopt maintainership from tokudan
* [`624a0bc4`](https://github.com/NixOS/nixpkgs/commit/624a0bc4cd19722f947a0ada959655fa0463ffaa) python3Packages.psutil: disable a problematic test
* [`37e42d01`](https://github.com/NixOS/nixpkgs/commit/37e42d01a025b4b80f20cff18a3641451a1d947d) nixos/etc: skip resolv.conf in nixos-enter chroot
* [`ed060ff9`](https://github.com/NixOS/nixpkgs/commit/ed060ff92b34bba159fe52a5697030be6e3a4805) prometheus-exporters: update rspamd exporter for prometheus-json-exporter >=0.5.0
* [`a8ec44af`](https://github.com/NixOS/nixpkgs/commit/a8ec44af72ad1e57db58418f0f2000b7fc3a924d) procmail: update from 3.22 to 3.24
* [`f6fd1b9a`](https://github.com/NixOS/nixpkgs/commit/f6fd1b9a53d0ae24f7e1c14da2f021f9aedaa8bd) python312: fix build on darwin
* [`a8d4cf14`](https://github.com/NixOS/nixpkgs/commit/a8d4cf149cda4f82145291cc9a6819a9baa3951e) doc: separate manpage URLs from the Pandoc filter
* [`4d4af86d`](https://github.com/NixOS/nixpkgs/commit/4d4af86db63955be68118f1507ce51e576b88016) libtiff: 4.4 -> 4.5
* [`47e314e9`](https://github.com/NixOS/nixpkgs/commit/47e314e92e58f51853cc4f39267eb11cbf4350a8) ddcci-driver: patch to support linux 6.1
* [`97c99054`](https://github.com/NixOS/nixpkgs/commit/97c990547782382d47a354affab0946270ce8660) gridtracker: init at 1.22.1226
* [`865723cd`](https://github.com/NixOS/nixpkgs/commit/865723cd53a5f8758e00d09dab76b636c2460976) Revert "nixos/stage-1: fix `modprobe` in initial ramdisk on systems w/glibc-2.34"
* [`2ee3ad53`](https://github.com/NixOS/nixpkgs/commit/2ee3ad53b22f2b638ab438236f9792311605a628) pyinfra: 2.6 -> 2.6.1
* [`e13ee020`](https://github.com/NixOS/nixpkgs/commit/e13ee020d26208f39d1eaead83c5de148e277c89) fxload: updated to newer version from libusb1
* [`5afd4f69`](https://github.com/NixOS/nixpkgs/commit/5afd4f691d29e3ab918cca9a5d7fe69f51937a87) go-bindata-assetfs: 20160814-e1a2a7e -> unstable-2022-04-12
* [`4434e57c`](https://github.com/NixOS/nixpkgs/commit/4434e57cf7c64b25bba9e03b32c818d704d1b389) go-bindata: Use buildGoModule
* [`4fc374b3`](https://github.com/NixOS/nixpkgs/commit/4fc374b314ab097d2105d3705eefdd5520b16ad1) captive-browser: Use buildGoModule
* [`88ee42a4`](https://github.com/NixOS/nixpkgs/commit/88ee42a4bdd2f39d440faeb20009a13223c59695) python3Packages.hydra-core: fix [nixos/nixpkgs⁠#208843](https://togithub.com/nixos/nixpkgs/issues/208843)
* [`8f48e1ca`](https://github.com/NixOS/nixpkgs/commit/8f48e1cadbacb530571d969e07233aef68908cf0) doc/languages-frameworks/qt: remove outdated information
* [`f61e538c`](https://github.com/NixOS/nixpkgs/commit/f61e538c432a87eb0601d5da910abda131459fdb) nixos/make-options-doc: link manpages
* [`4fb500d6`](https://github.com/NixOS/nixpkgs/commit/4fb500d62937dcce11c84e7c36fcc0d5db354d5c) nixos/doc: fix some manpage references
* [`2f06edee`](https://github.com/NixOS/nixpkgs/commit/2f06edee4f9dd193167b53abd22ea75f2aeee415) Update pkgs/development/mobile/androidenv/deploy-androidpackages.nix
* [`277a523d`](https://github.com/NixOS/nixpkgs/commit/277a523ddaedd38e0017754b8425e12ebbabc409) xorg: add wrapWithXFileSearchPathHook
* [`65957400`](https://github.com/NixOS/nixpkgs/commit/659574008e1f07330b8f055927c2b538e2a9b383) xorg.{libFS,libWindowsWM}: fix cross
* [`68ed486d`](https://github.com/NixOS/nixpkgs/commit/68ed486d30487599d7ef85feec2c838036ce77cc) xorg: remove unnecessary overrides
* [`050a94b3`](https://github.com/NixOS/nixpkgs/commit/050a94b3df68f29ef6fc48706b7796e45bab5c30) xorg.xauth: 1.1.0 -> 1.1.2
* [`e349e798`](https://github.com/NixOS/nixpkgs/commit/e349e79866e9d32091e0f2e03ac8f0b01fbb656a) xorg.xf86videomga: 2.0.0 -> 2.0.1
* [`7576a5ba`](https://github.com/NixOS/nixpkgs/commit/7576a5ba078644c21fcc13bdec09f850f9b32c75) shim: init at 15.7
* [`c42e7b71`](https://github.com/NixOS/nixpkgs/commit/c42e7b71d294000d0c5d84a83a09590dc5410823) xorg.xf86videor128: 6.11.0 -> 6.12.1
* [`c09f6c3d`](https://github.com/NixOS/nixpkgs/commit/c09f6c3db0207702d95f966236c975a49beb29ee) nixos-version: output configurationRevision
* [`3b545660`](https://github.com/NixOS/nixpkgs/commit/3b5456608a680a0cf7e488c7ddd250b6fef3eac1) nixos-version: print error for missing revision to stderr
* [`19e31cd6`](https://github.com/NixOS/nixpkgs/commit/19e31cd67750b1b34486009d14ccd143414da942) php80: 8.0.26 -> 8.0.27
* [`793d5252`](https://github.com/NixOS/nixpkgs/commit/793d5252beb54471d34ea3656f113bda44f5b2a2) php82: 8.2.0 -> 8.2.1
* [`8ca4470a`](https://github.com/NixOS/nixpkgs/commit/8ca4470a5e72131b3687856cd60848dd46dda4a7) androidenv: use unzip in nativeBuildInputs
* [`82ae2e8f`](https://github.com/NixOS/nixpkgs/commit/82ae2e8f068ee5b336c108816c5ace316b295ae0) python3.pkgs.sphinxHook: fix co-installability of generated documentation
* [`bb032385`](https://github.com/NixOS/nixpkgs/commit/bb0323856c995614679ea507f8ec01b1fcbebfe5) mgmt: init at unstable-2022-10-24
* [`ffc8a1c8`](https://github.com/NixOS/nixpkgs/commit/ffc8a1c8c27efb0af2f7d8f50137c2f80cc8b522) nexus: 3.37.3-02 -> 3.45.0-01
* [`0af966f3`](https://github.com/NixOS/nixpkgs/commit/0af966f3681e7608b3afaf6a68713c7d87ed68a0) gmsh: Enable OpenMP support
* [`b066191d`](https://github.com/NixOS/nixpkgs/commit/b066191d42b1a4313c34ee4d52e7916b98c6482d) harfbuzz: 5.3.1 -> 6.0.0
* [`4835c7a7`](https://github.com/NixOS/nixpkgs/commit/4835c7a74c1419837263c6c78fca10bb52138929) glibc, python3Packages.twisted: resolve temporary workaround
* [`041d5513`](https://github.com/NixOS/nixpkgs/commit/041d551384b3d151bb8c484e172257270f389f7c) php81: 8.1.13 -> 8.1.14
* [`ccb3146b`](https://github.com/NixOS/nixpkgs/commit/ccb3146bf27b954399648f7d12c3af8efeab1f13) iproute2: 6.0.0 -> 6.1.0 ([nixos/nixpkgs⁠#206932](https://togithub.com/nixos/nixpkgs/issues/206932))
* [`9110eca9`](https://github.com/NixOS/nixpkgs/commit/9110eca901936b41d17fd88a1868184e872348b0) maintainers: add traxys
* [`7a5b362e`](https://github.com/NixOS/nixpkgs/commit/7a5b362ea10978a00dde812922388db2956dcb09) dynamips: 0.2.22 -> 0.2.23
* [`8442601c`](https://github.com/NixOS/nixpkgs/commit/8442601c6445894b350e8b2b10717c1f609bedaf) rust: fix on aarch64-linux by using GCC 11 and passing `-lgcc`
* [`b4cf86d7`](https://github.com/NixOS/nixpkgs/commit/b4cf86d7e045730c716472b927798c9489c0509f) python39Packages: Stop recursing into package set
* [`75553226`](https://github.com/NixOS/nixpkgs/commit/755532262d295682fe2adcd4aa8a19c8585da2c2) python311Packages: Recurse into package set
* [`bdc18031`](https://github.com/NixOS/nixpkgs/commit/bdc18031e57f663d2db63ef96ed013bf853e5a40) python311Packages.tensorflow-bin: Disable
* [`b511bf59`](https://github.com/NixOS/nixpkgs/commit/b511bf59bd6754ad49c637f390dbb6bc1acea000) python3Packages.setuptools: 65.3.0 -> 65.6.3
* [`272a94a6`](https://github.com/NixOS/nixpkgs/commit/272a94a6c578da23760a79b509cab0f60aeac731) python3Packages.pip: 22.2.2 -> 22.3.1
* [`ea04a1f3`](https://github.com/NixOS/nixpkgs/commit/ea04a1f38a7e49e66606666738a82c53943661b7) python3Packages.hypothesis: 6.54.5 -> 6.61.0
* [`de08f0ba`](https://github.com/NixOS/nixpkgs/commit/de08f0ba6decb6387fc54304eb0ebd5d53c71371) python3Packages.flit-scm: Trim dependencies and refactor
* [`39f4004b`](https://github.com/NixOS/nixpkgs/commit/39f4004b0ea3c750b264bbf4f183eb7c542e610e) python3Packages.exceptiongroup: Disable tests on python310
* [`6d9c7244`](https://github.com/NixOS/nixpkgs/commit/6d9c72445899838d00828e85b2c5057b99ccc8b0) python3Packages.pytest: 7.1.3 -> 7.2.0
* [`44f365a9`](https://github.com/NixOS/nixpkgs/commit/44f365a9310d4b38e5bd984e5c7a229e96472297) python310Packages.pytest-xdist: 2.5.0 -> 3.1.0
* [`f6bd32f9`](https://github.com/NixOS/nixpkgs/commit/f6bd32f9f87b060785c06b9326d1d985f65567fd) python310Packages.pytest-forked: add setup hook
* [`621f845e`](https://github.com/NixOS/nixpkgs/commit/621f845e8040f6ad8bf72b1c609746a74c308267) python3Packages.typing-extensions: 4.3.0 -> 4.4.0
* [`b9b53676`](https://github.com/NixOS/nixpkgs/commit/b9b53676235f78cce2939913bd16480173ed6479) python3Packages.pytest-mock: 3.8.2 -> 3.10.0
* [`af8b9c21`](https://github.com/NixOS/nixpkgs/commit/af8b9c216bad5380ba0d912f5f8e9d3f99f8abd4) python3Packages.cffi: Apply patches for pytest 7.2.0 compat
* [`a8a664f2`](https://github.com/NixOS/nixpkgs/commit/a8a664f206ce7ac14b1fb830c3d38a6654cd655e) python3Packages.pytest-xprocess: 0.20.0 -> 0.21.0
* [`31aa25d9`](https://github.com/NixOS/nixpkgs/commit/31aa25d9c910bd9d8fa1f3cb71bdf684b752d9e4) python3Packages.execnet: Fix compat with pytest 7.2.0
* [`cbe9daf4`](https://github.com/NixOS/nixpkgs/commit/cbe9daf4d52064c54d6a050a5a275147c88f7fca) python3Packages.flit: 3.7.1 -> 3.8.0
* [`f019f1ed`](https://github.com/NixOS/nixpkgs/commit/f019f1ede8b33a359ddeb7389bef8de431216f3f) python3Packages.pytest-forked: fix tests
* [`98e3547b`](https://github.com/NixOS/nixpkgs/commit/98e3547b3509a37bca2aba063e7145f721341ccd) python3Packages.filelock: 3.8.0 -> 3.9.0
* [`0b8bc535`](https://github.com/NixOS/nixpkgs/commit/0b8bc5359dd9516b8d77ac64fac4e45c63554926) python310Packages.attrs: 22.1.0 -> 22.2.0
* [`f2d8a768`](https://github.com/NixOS/nixpkgs/commit/f2d8a76868a4ab4b8236ccc89ba6bfd1eb0e82ea) python3Packages.packaging: 21.3 -> 22.0
* [`c8ff2315`](https://github.com/NixOS/nixpkgs/commit/c8ff23158ecd1b0bfafab7dc4a0daaf82fda06fb) python3Packages.pyproject-api: init at 1.2.1
* [`7f5e0620`](https://github.com/NixOS/nixpkgs/commit/7f5e062065bf568322f94ba8b6e7abc0f464cbed) python3Packages.chardet: 5.0.0 -> 5.1.0
* [`66de0472`](https://github.com/NixOS/nixpkgs/commit/66de0472ab71a4d8d8fee40fc11873a64748ae88) python3Packages.virtualenv: 20.16.5 -> 20.17.1
* [`bd4e0b28`](https://github.com/NixOS/nixpkgs/commit/bd4e0b28f937d8e44a98eee61237ac4856de2887) python3Packages.tox: 3.27.1 -> 4.0.16
* [`b5901055`](https://github.com/NixOS/nixpkgs/commit/b5901055ef7d478257dab994ae5b69b24e42c7e2) Revert "python3Packages.packaging: 21.3 -> 22.0"
* [`cc00c294`](https://github.com/NixOS/nixpkgs/commit/cc00c2949b8196cdffa56b1cc3151e5b8eb5cb92) python3Packages.cryptography: Pass py into checkInputs
* [`86a15156`](https://github.com/NixOS/nixpkgs/commit/86a151563d166cf0c2e99bb00e15730dcc808638) python3Packages.devpi: Pass py into checkInputs
* [`57eb9f06`](https://github.com/NixOS/nixpkgs/commit/57eb9f068120efc4a48eec5c4acc3deaf81f54fe) devpi-server: Pass py into checkInputs to fix tests
* [`04af8bfa`](https://github.com/NixOS/nixpkgs/commit/04af8bfa8a5d56bb35ce367d75847dc9a51ca4f6) python311Packages.jedi: disable some tests
* [`8afcb446`](https://github.com/NixOS/nixpkgs/commit/8afcb44617eba8424b1e86d0ede855f108913ae4) python3Packages.pandas: 1.4.4 -> 1.5.2
* [`bf6d21b7`](https://github.com/NixOS/nixpkgs/commit/bf6d21b7d4fc2e171d600d49ce9a2246f0f0dbfe) python310Packages.pytest-asyncio: 0.19.0 -> 0.20.3
* [`88fc8c7b`](https://github.com/NixOS/nixpkgs/commit/88fc8c7b0d512e173007e8470bb00cbcaf3c1551) python3Packages.aardwolf: 0.0.8 -> 0.2.1
* [`ce24ef2a`](https://github.com/NixOS/nixpkgs/commit/ce24ef2a991594046d8f6ffdadfeac25ad5d9b79) python3Packages.absl-py: 1.2.0 -> 1.3.0
* [`ed51b8f4`](https://github.com/NixOS/nixpkgs/commit/ed51b8f495ea096b63d7a5ec22b3bb22d6b75db5) python3Packages.advantage-air: 0.4.1 -> 0.4.2
* [`813f9c74`](https://github.com/NixOS/nixpkgs/commit/813f9c741bc81254da7478a48932e07420e4221a) python3Packages.aeppl: 0.0.39 -> 0.0.50
* [`3342fd0c`](https://github.com/NixOS/nixpkgs/commit/3342fd0c2bbc509cf3b2269803771990d0da7ed4) python3Packages.aiojobs: 1.0.0 -> 1.1.0
* [`24618632`](https://github.com/NixOS/nixpkgs/commit/24618632944a6eaac19971f6cd73a7236cf47465) python3Packages.aiolifx-themes: 0.4.0 -> 0.4.1
* [`377a28a6`](https://github.com/NixOS/nixpkgs/commit/377a28a6a8f2876e1be9ffcb6a1d45c1e239207a) python3Packages.aiomysensors: 0.3.3 -> 0.3.5
* [`7b54bcfc`](https://github.com/NixOS/nixpkgs/commit/7b54bcfc2c4766d73d4e9725bfb781a1ed83360e) python3Packages.aioresponses: 0.7.3 -> 0.7.4
* [`a6f2dd1e`](https://github.com/NixOS/nixpkgs/commit/a6f2dd1e2ae1e03857fc51296b63cee8389a8ee2) python3Packages.aiosmtpd: 1.4.2 -> 1.4.3
* [`94ae566e`](https://github.com/NixOS/nixpkgs/commit/94ae566e12dfb8d78acf20c48f3df9d2afa80da5) python3Packages.aiosqlite: 0.17.0 -> 0.18.0
* [`46a29d49`](https://github.com/NixOS/nixpkgs/commit/46a29d49cbc55257e8fd3bf4979ab3dc8de29d06) python3Packages.aiowatttime: 2021.10.0 -> 2022.10.0
* [`5fe2e97a`](https://github.com/NixOS/nixpkgs/commit/5fe2e97ab7510e11f2680cea3139cf97a436798d) python3Packages.alembic: 1.8.1 -> 1.9.1
* [`41b94cb5`](https://github.com/NixOS/nixpkgs/commit/41b94cb5e98744e314d6304490f58bac94772116) python3Packages.allure-behave: 2.10.0 -> 2.12.0
* [`c995631e`](https://github.com/NixOS/nixpkgs/commit/c995631e0d2b0c20194fe13571f72c19300f7b42) python3Packages.allure-pytest: 2.10.0 -> 2.12.0
* [`e4d51fe1`](https://github.com/NixOS/nixpkgs/commit/e4d51fe165f00f58c7d99f2b0a7fd9b9a58d69ee) python3Packages.allure-python-commons: 2.10.0 -> 2.12.0
* [`10893565`](https://github.com/NixOS/nixpkgs/commit/108935657c2d6ad31805689b2e53aadc1359cc91) python3Packages.allure-python-commons-test: 2.11.0 -> 2.12.0
* [`a22f0ea9`](https://github.com/NixOS/nixpkgs/commit/a22f0ea99167ba948492f201d0a7ebbd5fb41f31) python3Packages.amarna: 0.1.3 -> 0.1.5
* [`1f6ff640`](https://github.com/NixOS/nixpkgs/commit/1f6ff640b44ad1e5f3045ccdfb07d2919d8dbffc) python3Packages.ansible: 6.6.0 -> 7.1.0
* [`72e14f23`](https://github.com/NixOS/nixpkgs/commit/72e14f23c3e8759cd3f3f26fb9cb94ca3c0f072a) python3Packages.anybadge: 1.11.1 -> 1.14.0
* [`3e1c8797`](https://github.com/NixOS/nixpkgs/commit/3e1c8797cddcc16e8a3a1846b117de5274aabb60) python3Packages.apache-airflow: 2.4.3 -> 2.5.0
* [`b744a3cd`](https://github.com/NixOS/nixpkgs/commit/b744a3cd49cba33c622e22549270a4027f289c43) python3Packages.apache-beam: 2.40.0 -> 2.43.0
* [`8b1f6ea6`](https://github.com/NixOS/nixpkgs/commit/8b1f6ea6fd5d01f08de8d3b247cd23614420e197) python3Packages.apispec: 5.2.2 -> 6.0.2
* [`7dffb34a`](https://github.com/NixOS/nixpkgs/commit/7dffb34a83a173aa3b8e8a16e4356ad5cac03662) python3Packages.apscheduler: 3.9.1 -> 3.9.1.post1
* [`b07a63d7`](https://github.com/NixOS/nixpkgs/commit/b07a63d78c6fb65b3549c3778d128fc4dc64de31) python3Packages.asf-search: 5.0.2 -> 6.0.2
* [`58ba66ed`](https://github.com/NixOS/nixpkgs/commit/58ba66ed8134a80267aa6c394674c5c73eb8c32a) python3Packages.astral: 2.2 -> 3.2
* [`b1db8777`](https://github.com/NixOS/nixpkgs/commit/b1db877742169b3b95d3d6d0863c4c6528c10624) python3Packages.astroid: 2.12.12 -> 2.12.13
* [`c7051552`](https://github.com/NixOS/nixpkgs/commit/c7051552b9e5eaddfb63beb04a39434d55a37370) python3Packages.astropy: 5.1 -> 5.2
* [`45efd07b`](https://github.com/NixOS/nixpkgs/commit/45efd07b42950daa1f9f478cd20e545d9964bd2c) python3Packages.asttokens: 2.1.0 -> 2.2.1
* [`048bf8ac`](https://github.com/NixOS/nixpkgs/commit/048bf8acc5129974e8466212df6dc1802bd70f16) python3Packages.asyncio-mqtt: 0.14.0 -> 0.16.1
* [`3396b16c`](https://github.com/NixOS/nixpkgs/commit/3396b16c4ed4cda1a03ad469053b1a464671f596) python3Packages.async-modbus: 0.2.0 -> 0.2.1
* [`e04d194f`](https://github.com/NixOS/nixpkgs/commit/e04d194fc693f0fa5e92294e59df63d7d5f44f90) python3Packages.atlassian-python-api: 3.28.1 -> 3.32.0
* [`108d7e7a`](https://github.com/NixOS/nixpkgs/commit/108d7e7a1104f2bb0ff2c4fd602b53c7835dae2f) python3Packages.automat: 20.2.0 -> 22.10.0
* [`5bfc071b`](https://github.com/NixOS/nixpkgs/commit/5bfc071b3c47fb637151ae327b87edf5ed672ea5) python3Packages.autopep8: 2.0.0 -> 2.0.1
* [`5338c67c`](https://github.com/NixOS/nixpkgs/commit/5338c67cc030652b3a12b7eb0e18c5f349021d13) python3Packages.awkward-cpp: 2 -> 5
* [`834f4dc8`](https://github.com/NixOS/nixpkgs/commit/834f4dc87af6f3cbfc8ef4f3dcf53ffbcfc7de38) python3Packages.awkward: 2.0.0 -> 2.0.4
* [`ce7ca243`](https://github.com/NixOS/nixpkgs/commit/ce7ca24385a2d4b530fb7950b6bbf46a80b49c45) python3Packages.aws-sam-translator: 1.47.0 -> 1.55.0
* [`df670821`](https://github.com/NixOS/nixpkgs/commit/df6708218124861c04dd4139cd627e1b71cf8918) python3Packages.aws-xray-sdk: 2.10.0 -> 2.11.0
* [`a65d9faa`](https://github.com/NixOS/nixpkgs/commit/a65d9faad78c930be4f4402aa8e5f98e13613c62) python3Packages.azure-core: 1.25.1 -> 1.26.1
* [`46dd1df9`](https://github.com/NixOS/nixpkgs/commit/46dd1df9f6307c8306904e8326a701f86a46bcc7) python3Packages.azure-data-tables: 12.4.0 -> 12.4.1
* [`2a803d2b`](https://github.com/NixOS/nixpkgs/commit/2a803d2ba5646d0f85ca328d74815a8b1741907d) python3Packages.azure-mgmt-batch: 16.2.0 -> 17.0.0
* [`273ad952`](https://github.com/NixOS/nixpkgs/commit/273ad9529ca3f5c3adc09b9237eabb0a3ba31c15) python3Packages.azure-mgmt-cognitiveservices: 13.2.0 -> 13.3.0
* [`84751ddb`](https://github.com/NixOS/nixpkgs/commit/84751ddb56554074a1ebbe4c5aaf1adfa36104b8) python3Packages.azure-mgmt-compute: 27.2.0 -> 29.0.0
* [`fd39cc5e`](https://github.com/NixOS/nixpkgs/commit/fd39cc5e1b0178cf2606e69b87cd03244ded40f9) python3Packages.azure-mgmt-datafactory: 2.8.1 -> 2.10.0
* [`0a0d0ffa`](https://github.com/NixOS/nixpkgs/commit/0a0d0ffadd7f09d21c4118edc48a4de39835f824) python3Packages.azure-multiapi-storage: 0.10.0 -> 1.0.0
* [`4544f40a`](https://github.com/NixOS/nixpkgs/commit/4544f40a2315c0946ccd7074dcc6debed06b9770) python3Packages.azure-servicebus: 7.8.0 -> 7.8.1
* [`cae4698b`](https://github.com/NixOS/nixpkgs/commit/cae4698b9d08af3b72c27cbbdac75d5183545642) python3Packages.azure-synapse-artifacts: 0.13.0 -> 0.14.0
* [`031f9246`](https://github.com/NixOS/nixpkgs/commit/031f92461919ac17adbd0a115757ef6f12621fab) python3Packages.backoff: 2.1.2 -> 2.2.1
* [`c52f23e4`](https://github.com/NixOS/nixpkgs/commit/c52f23e4df4248e46ae80b40762d4921541704d9) python3Packages.bids-validator: 1.9.8 -> 1.9.9
* [`4380cb7c`](https://github.com/NixOS/nixpkgs/commit/4380cb7c55bd0356f81ec41b34d194a1330b5af6) python3Packages.biliass: 1.3.5 -> 1.3.7
* [`39e8f6dc`](https://github.com/NixOS/nixpkgs/commit/39e8f6dc0d6ab82f1a82e2d0f89015237bf13c5d) python3Packages.billiard: 4.0.0 -> 4.1.0
* [`03810781`](https://github.com/NixOS/nixpkgs/commit/03810781446d318598f2b05aaeb25a9c6c64acd3) python3Packages.bimmer-connected: 0.10.4 -> 0.11.0
* [`725c51a6`](https://github.com/NixOS/nixpkgs/commit/725c51a670f223d1f0063bafcbed182874837c37) python3Packages.biopython: 1.79 -> 1.80
* [`7aa63d57`](https://github.com/NixOS/nixpkgs/commit/7aa63d57e08672f6cd559b429f9cdfc398675610) python3Packages.bitarray: 2.6.0 -> 2.6.1
* [`d9365899`](https://github.com/NixOS/nixpkgs/commit/d936589982002468f4cadd832f634163c11d153a) python3Packages.bleak: 0.19.4 -> 0.19.5
* [`eca61ccf`](https://github.com/NixOS/nixpkgs/commit/eca61ccf9a31cca9c7a1034d5bf55c186a1ace9e) python3Packages.xyzservices: init at 2022.9.0
* [`1ac65c00`](https://github.com/NixOS/nixpkgs/commit/1ac65c004e1954799f54900135a2d89557b77757) python3Packages.bokeh: 2.4.3 -> 3.0.3
* [`664abe1d`](https://github.com/NixOS/nixpkgs/commit/664abe1d30f9fa80d386d9175233f20bbd152a3a) python3Packages.botocore: 1.29.38 -> 1.29.40
* [`f8e87178`](https://github.com/NixOS/nixpkgs/commit/f8e87178be4da8aa22c59a67edf5b9f50bc88ac5) python3Packages.branca: 0.5.0 -> 0.6.0
* [`29bfdbc7`](https://github.com/NixOS/nixpkgs/commit/29bfdbc7af232b9bddaf9a01b0f51ff8546e6c8d) python3Packages.browser-cookie3: 0.16.2 -> 0.16.3
* [`5d5c0abf`](https://github.com/NixOS/nixpkgs/commit/5d5c0abf058e4ed2b0fddb635cca0cdbd8281a88) python3Packages.bthome-ble: 2.3.1 -> 2.4.0
* [`791de492`](https://github.com/NixOS/nixpkgs/commit/791de49240f8bff95814de484138882f258a9c67) python3Packages.btrees: 4.11.0 -> 4.11.3
* [`50c0b784`](https://github.com/NixOS/nixpkgs/commit/50c0b78421a5e5b5bfe5b4530f8a5786d1ea8e85) python3Packages.bytecode: 0.13.0 -> 0.14.0
* [`72b7f21a`](https://github.com/NixOS/nixpkgs/commit/72b7f21a1c9bba961954e8863f6881532ff2597a) python3Packages.catboost: 1.0.5 -> 1.1.1
* [`5632fa15`](https://github.com/NixOS/nixpkgs/commit/5632fa15f05d3f673697ff2f0d5293c21af21dac) python3Packages.cbor2: 5.4.3 -> 5.4.6
* [`b2306955`](https://github.com/NixOS/nixpkgs/commit/b23069550f4d30c45ae0221e34b0c59dbab339b1) python3Packages.cepa: 1.8.3 -> 1.8.4
* [`d251aafb`](https://github.com/NixOS/nixpkgs/commit/d251aafb314fa14fa681a99eadb0c1c370a3e74c) python3Packages.certbot: 1.31.0 -> 2.1.1
* [`68eff1c4`](https://github.com/NixOS/nixpkgs/commit/68eff1c4d2de0a806027ce22e76cde5dc1020012) python3Packages.cfn-lint: 0.61.2 -> 0.72.5
* [`9f368220`](https://github.com/NixOS/nixpkgs/commit/9f368220da6066db35480efba0b3c3a9cd92e847) python3Packages.charset-normalizer: 2.1.0 -> 3.0.1
* [`36bd7d20`](https://github.com/NixOS/nixpkgs/commit/36bd7d20af4df905333ccf20d8e49b87e289d74c) python3Packages.chart-studio: 5.10.0 -> 5.11.0
* [`52f00b87`](https://github.com/NixOS/nixpkgs/commit/52f00b87dcea78f6b912957b3de0e81539f3ed6d) python3Packages.cheroot: 8.6.0 -> 9.0.0
* [`9ad4234d`](https://github.com/NixOS/nixpkgs/commit/9ad4234dea6a6c36483c7ba80176d48a6677f25c) python3Packages.chiapos: 1.0.10 -> 1.0.11
* [`1ff8ddb8`](https://github.com/NixOS/nixpkgs/commit/1ff8ddb86222cf377433384460a1d91ce8455d50) python3Packages.chia-rs: 0.1.5 -> 0.1.16
* [`ddce16c9`](https://github.com/NixOS/nixpkgs/commit/ddce16c924b2ed0a6924af17403fdd35ea18b181) python3Packages.chiavdf: 1.0.7 -> 1.0.8
* [`6efba12c`](https://github.com/NixOS/nixpkgs/commit/6efba12c3a0a9aaf418e6bc2e02d1e6be7529681) python3Packages.cinemagoer: 2022.2.11 -> 2022.12.27
* [`6fbffa48`](https://github.com/NixOS/nixpkgs/commit/6fbffa480f976977ad3bd2b803cf3ba97cc040e4) python3Packages.ciso8601: 2.2.0 -> 2.3.0
* [`c2ea958f`](https://github.com/NixOS/nixpkgs/commit/c2ea958f132bd9791e7437d904641ea730fed4b7) python3Packages.clickgen: 1.2.0 -> 2.1.3
* [`f11dcdc9`](https://github.com/NixOS/nixpkgs/commit/f11dcdc933ad0c50897c201d0175218376d28f31) python3Packages.cliff: 4.0.0 -> 4.1.0
* [`e44d56c9`](https://github.com/NixOS/nixpkgs/commit/e44d56c9570110ee8183ed879c4a5a07fa1b2686) python3Packages.cloudflare: 2.10.1 -> 2.11.1
* [`9e84f531`](https://github.com/NixOS/nixpkgs/commit/9e84f53110148a8351e85a3c4b0c945bf2ea9d97) python3Packages.cloudsmith-api: 1.142.3 -> 2.0.0
* [`5f58c9f6`](https://github.com/NixOS/nixpkgs/commit/5f58c9f641f355257d1c6851ba75c2dbb404f5c4) python3Packages.cloup: 1.0.1 -> 2.0.0.post1
* [`befddc30`](https://github.com/NixOS/nixpkgs/commit/befddc3068337fbca7cff4634263e624bc2b5c43) python3Packages.ClusterShell: 1.8.4 -> 1.9
* [`70910787`](https://github.com/NixOS/nixpkgs/commit/709107879cd8728ee4aca5bb1c063356a5226f27) python3Packages.cmarkgfm: 0.8.0 -> 2022.10.27
* [`4bb78a9e`](https://github.com/NixOS/nixpkgs/commit/4bb78a9ef55540a1165377428088efdcc9b73e20) python3Packages.cmsis-pack-manager: 0.4.0 -> 0.5.1
* [`3528b5f5`](https://github.com/NixOS/nixpkgs/commit/3528b5f5f763635978d463035a983f1239263a54) python3Packages.coconut: 2.1.0 -> 2.1.1
* [`2cee6097`](https://github.com/NixOS/nixpkgs/commit/2cee609768c8e36619c5ee664a44248ac3c7c432) python3Packages.cocotb: 1.7.1 -> 1.7.2
* [`44925be9`](https://github.com/NixOS/nixpkgs/commit/44925be96f6918c24f9d93f7473254df1e5010e3) python3Packages.coincurve: 17.0.0 -> 18.0.0
* [`0696f995`](https://github.com/NixOS/nixpkgs/commit/0696f995ae509848a45922c9ee782157093f8d5b) python3Packages.colorcet: 3.0.0 -> 3.0.1
* [`7f80647b`](https://github.com/NixOS/nixpkgs/commit/7f80647bb138299c143f152f700a2fc5c6b4c558) python3Packages.coverage: 6.4.4 -> 7.0.1
* [`504f1167`](https://github.com/NixOS/nixpkgs/commit/504f11676d85b1db74b4d4beed9ea4e349f4ca22) python3Packages.crate: 0.28.0 -> 0.29.0
* [`0aeb3911`](https://github.com/NixOS/nixpkgs/commit/0aeb39115ff074c013947acd1433be4eb5f4fb99) python3Packages.crccheck: 1.1 -> 1.3.0
* [`3f4351ac`](https://github.com/NixOS/nixpkgs/commit/3f4351acca24301016a72f73a4349abb91ed4fd3) python3Packages.croniter: 1.3.7 -> 1.3.8
* [`bc31c7fd`](https://github.com/NixOS/nixpkgs/commit/bc31c7fd049af3c9c38e86101864cb258135b33c) python3Packages.cssselect2: 0.6.0 -> 0.7.0
* [`88961820`](https://github.com/NixOS/nixpkgs/commit/889618204d89c690906b82e105278323512da345) python3Packages.cupy: 11.2.0 -> 11.4.0
* [`ebbaab65`](https://github.com/NixOS/nixpkgs/commit/ebbaab656c96aad2f8358655ef1e6fd236949395) python3Packages.cvxpy: 1.2.1 -> 1.2.3
* [`5c1ebe54`](https://github.com/NixOS/nixpkgs/commit/5c1ebe5499391cdaca9b4d8f326decc734cc8a8d) python3Packages.cwcwidth: 0.1.7 -> 0.1.8
* [`611dd9d7`](https://github.com/NixOS/nixpkgs/commit/611dd9d7e90b013ac42f4db4668fd2b617df8167) python3Packages.cx-freeze: 6.11.1 -> 6.13.1
* [`11d47b76`](https://github.com/NixOS/nixpkgs/commit/11d47b76c237d5dc6a44bd295d421f889557912e) python3Packages.cymem: 2.0.6 -> 2.0.7
* [`14d2b144`](https://github.com/NixOS/nixpkgs/commit/14d2b144facda75ea7275d295ba618ed8707eefa) python3Packages.cytoolz: 0.12.0 -> 0.12.1
* [`6ad9cb0b`](https://github.com/NixOS/nixpkgs/commit/6ad9cb0b5f4645a45eee094721de30b547021218) python3Packages.dasbus: 1.6 -> 1.7
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
