### PR TITLE
niv devenv: update b25cd5a4 -> 818abeae

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b25cd5a45d3ce61f8b671f5ff26579267ff217ae",
-        "sha256": "1587ynxaifm6m7i244y74vp9srlvy3x7r52l9czm77lsnsp62xrn",
+        "rev": "818abeae2dd2f4911839a079e5c8934fee160a60",
+        "sha256": "1g151mc2hm5yr72rq0rbcp7ajbxnyfcsrqvp5gygm77kgf2harny",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/b25cd5a45d3ce61f8b671f5ff26579267ff217ae.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/818abeae2dd2f4911839a079e5c8934fee160a60.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@b25cd5a4...818abeae](https://github.com/cachix/devenv/compare/b25cd5a45d3ce61f8b671f5ff26579267ff217ae...818abeae2dd2f4911839a079e5c8934fee160a60)

* [`8aebf3a0`](https://github.com/cachix/devenv/commit/8aebf3a035a66b614d42b30a3836e6eaea6ea7b5) fix: avoid infinite recursion
* [`5a98cf3d`](https://github.com/cachix/devenv/commit/5a98cf3d4e9008361b4e74adf0fbf3775e6f28b4) README: add contributing
* [`6ce2910d`](https://github.com/cachix/devenv/commit/6ce2910d34c37fb95a0f81afc2d585f7362f73d5) languages/r: add option for R package
* [`77297e2f`](https://github.com/cachix/devenv/commit/77297e2f3fefabe18a3077c223af0988a9c455bf) Auto generate docs/reference/options.md
* [`60c067de`](https://github.com/cachix/devenv/commit/60c067de3cfd417ce610639d6d4541dd13f24be5) feat: include flakesIntegration flag
* [`10f8661e`](https://github.com/cachix/devenv/commit/10f8661e6741b1898368186f5ee3d19ba84eb41a) feat: add special devenv binary for mkShell
* [`83fa0e02`](https://github.com/cachix/devenv/commit/83fa0e026018e3f3b3c606c9af9e702f6efa25ec) Update src/devenv-devShell.nix
* [`9f697667`](https://github.com/cachix/devenv/commit/9f697667a8aee2a4f855c1e50bdaa19b04f2e112) Auto generate docs/reference/options.md
* [`a2c53ee9`](https://github.com/cachix/devenv/commit/a2c53ee968e8f8aca2f74ace51523600b09bdc53) bump flake deps
* [`0213b44d`](https://github.com/cachix/devenv/commit/0213b44dbb51235b90e78ab9d8719c6420cc7b2e) Auto generate docs/reference/options.md
* [`be2ff6a9`](https://github.com/cachix/devenv/commit/be2ff6a9472efa911c71b0ebb44fbc439113621e) mysql: fix password escaping, fixes [cachix/devenv⁠#281](https://togithub.com/cachix/devenv/issues/281)
* [`34c52284`](https://github.com/cachix/devenv/commit/34c5228406d45d7db19a8c36513593e32d527adb) docs: start common patterns section
* [`4a71a267`](https://github.com/cachix/devenv/commit/4a71a267f858ab4768e080481e350fdc68337478) caddy: fix unused dataDir option
* [`02159d71`](https://github.com/cachix/devenv/commit/02159d714b7745463ab1d7aed9d9971fa53c7bd7) fix: enable descriptions
* [`046bc16c`](https://github.com/cachix/devenv/commit/046bc16c7373444422dafad3bf640fab8b0f7f27) fix eval with flakes on darwin
* [`818abeae`](https://github.com/cachix/devenv/commit/818abeae2dd2f4911839a079e5c8934fee160a60) Auto generate docs/reference/options.md
