### PR TITLE
niv spacemacs: update c828fd31 -> 9e3fc598

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "c828fd31bc013a98e78b9169594ec827b2cf2808",
-        "sha256": "1kxrhnpyvx8llgxzp2yss09syjrfqs59dx3vmwfhny9jhswh91ar",
+        "rev": "9e3fc598ad7f7c241b0d60cd3f165f4a34ecf4c2",
+        "sha256": "119fpnnb8j07m5hc9v5p0dwhpj2zw8qk5bdkp9acg6xfxc88m629",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/c828fd31bc013a98e78b9169594ec827b2cf2808.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/9e3fc598ad7f7c241b0d60cd3f165f4a34ecf4c2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@c828fd31...9e3fc598](https://github.com/syl20bnr/spacemacs/compare/c828fd31bc013a98e78b9169594ec827b2cf2808...9e3fc598ad7f7c241b0d60cd3f165f4a34ecf4c2)

* [`fb3b5661`](https://github.com/syl20bnr/spacemacs/commit/fb3b566164bbfd8c7405087d796bc3ba88250d96) fix(clojure): typo clojure/post-init-company function (cide -> cider) ([syl20bnr/spacemacs⁠#15886](https://togithub.com/syl20bnr/spacemacs/issues/15886))
* [`8f4df831`](https://github.com/syl20bnr/spacemacs/commit/8f4df831628e2d941e9c233988a20e5bc21a73b4) Fix paradox-list-package key not being bound on init ([syl20bnr/spacemacs⁠#15888](https://togithub.com/syl20bnr/spacemacs/issues/15888))
* [`50e5a704`](https://github.com/syl20bnr/spacemacs/commit/50e5a704b5e066e7588d52feb9821f5450658593) [bot] "built_in_updates" Thu Jan 12 16:51:33 UTC 2023 ([syl20bnr/spacemacs⁠#15890](https://togithub.com/syl20bnr/spacemacs/issues/15890))
* [`9e3fc598`](https://github.com/syl20bnr/spacemacs/commit/9e3fc598ad7f7c241b0d60cd3f165f4a34ecf4c2) Don't set :foreground/background to nil to avoid font warnings in emacs29 ([syl20bnr/spacemacs⁠#15877](https://togithub.com/syl20bnr/spacemacs/issues/15877))
