### PR TITLE
niv nixpkgs: update 2f1948af -> 9d801f40

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2f1948af9c984ebb82dfd618e67dc949755823e2",
-        "sha256": "0c22xd0b95kdwzn5r1jh1yv5dflzrm8q6gzvn6lxx6kcpi8a2krm",
+        "rev": "9d801f40e6f7a46fe47204547cd286ba20f354dc",
+        "sha256": "1g80dwgzpib8fja7zz4scvqlyas1wr3bds4l9hqhiqjq5k7k937k",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/2f1948af9c984ebb82dfd618e67dc949755823e2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9d801f40e6f7a46fe47204547cd286ba20f354dc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@2f1948af...9d801f40](https://github.com/nixos/nixpkgs/compare/2f1948af9c984ebb82dfd618e67dc949755823e2...9d801f40e6f7a46fe47204547cd286ba20f354dc)

* [`64b7c29d`](https://github.com/NixOS/nixpkgs/commit/64b7c29da1b0187a2a496f6e7df294baa72bdd62) darwin.cctools-apple: init at 973.0.1-609
* [`7327f38e`](https://github.com/NixOS/nixpkgs/commit/7327f38ef494f71bc884e41bdc72c90ccc98c9ba) ocamlPackages.rresult: 0.6.0 -> 0.7.0
* [`41e710b3`](https://github.com/NixOS/nixpkgs/commit/41e710b34ea4b9d49cc5191bfba2b5594c8adaf3) ocamlPackages.ocaml_sqlite3: 5.0.2 -> 5.1.0
* [`a871c599`](https://github.com/NixOS/nixpkgs/commit/a871c5996b7b162568dfa794c7de3078b249b947) mwprocapture: fix compile on new GCC and new linux kernel
* [`6c6d100c`](https://github.com/NixOS/nixpkgs/commit/6c6d100c5fbe5d7a02d66638e2f66018c2290a86) aeolus: 0.9.9 -> 0.10.4
* [`b8942b84`](https://github.com/NixOS/nixpkgs/commit/b8942b84795af66a20b7c791ec71f5c8e7d5b5a7) bacula: 11.0.6 -> 13.0.1
* [`00bb254d`](https://github.com/NixOS/nixpkgs/commit/00bb254d94357bc91d51ede95e99dcd2e48fde70) berglas: 0.6.2 -> 1.0.1
* [`4d4f149f`](https://github.com/NixOS/nixpkgs/commit/4d4f149f1e735dbb4351ade2fa522ece7c05ae67) bonzomatic: 2022-02-05 -> 2022-08-20
* [`aaa1ee0f`](https://github.com/NixOS/nixpkgs/commit/aaa1ee0fc75db9679162be9848c643be553c803a) belle-sip: linphone-4.4.1 -> 5.1.55
* [`ca6d2e00`](https://github.com/NixOS/nixpkgs/commit/ca6d2e003bf7c732654a88801f6094eba0aad9ff) python310Packages.flufl_lock: 7.1 -> 7.1.1
* [`995853d1`](https://github.com/NixOS/nixpkgs/commit/995853d13c53c182781b14e00b91ea20ce98257f) nixos/oci-containers: wait for network before starting container
* [`717ce7ac`](https://github.com/NixOS/nixpkgs/commit/717ce7ac2c7d637e3b242a50995a9a411b81ea4c) gam: 6.22 -> 6.25
* [`76da07eb`](https://github.com/NixOS/nixpkgs/commit/76da07ebfb0cdcb295c58bdfd3066a2fe41f6525) bada-bib: 0.7.2 -> 0.8.0
* [`7b41fe49`](https://github.com/NixOS/nixpkgs/commit/7b41fe494fc7586b92bdf5b2b77d87589d934b81) catcli: 0.8.2 -> 0.8.7
* [`1dbabf28`](https://github.com/NixOS/nixpkgs/commit/1dbabf2811847dfbc01e4f13c183f65a33ade89b) drumgizmo: 0.9.19 -> 0.9.20
* [`2208ff59`](https://github.com/NixOS/nixpkgs/commit/2208ff5992e08f3e08693238d8310bdeae52b6ed) embree: 3.13.4 -> 3.13.5
* [`17f3cf36`](https://github.com/NixOS/nixpkgs/commit/17f3cf36e849bd2845a42f00f5e15a8784d0bbc6) ibus-engines.m17n: 1.4.11 -> 1.4.17
* [`d4ef6462`](https://github.com/NixOS/nixpkgs/commit/d4ef646216f03b42a3942f41acd99be9d4bc8457) profile-sync-daemon: 6.47 -> 6.48
* [`8820f4bb`](https://github.com/NixOS/nixpkgs/commit/8820f4bbd0570170f21f70c2df6bfeabdfb09bbc) moonlight-embedded: 2.5.2 -> 2.5.3
* [`ee700a2f`](https://github.com/NixOS/nixpkgs/commit/ee700a2f127c7a45b016a88e15cb7654d8c3f690) gromit-mpx: 1.4.2 -> 1.4.3
* [`54333fd4`](https://github.com/NixOS/nixpkgs/commit/54333fd494f32cb3ef20784b4a826f02638319a1) sstp: 1.0.17 -> 1.0.18
* [`77f00071`](https://github.com/NixOS/nixpkgs/commit/77f00071714905146061aa8efd22ebe3317e4638) wcslib: 7.11 -> 7.12
* [`881895aa`](https://github.com/NixOS/nixpkgs/commit/881895aae2ac656da0fb5f45c97a8644f727e47b) logisim-evolution: 3.7.2 -> 3.8.0
* [`5239a347`](https://github.com/NixOS/nixpkgs/commit/5239a347440cfdb666c29b051d11c7f1a35344d7) envconsul: 0.13.0 -> 0.13.1
* [`2d296495`](https://github.com/NixOS/nixpkgs/commit/2d296495e7a8d042a173cab98fcba598f49404ac) libofx: 0.10.7 -> 0.10.9
* [`80d45bff`](https://github.com/NixOS/nixpkgs/commit/80d45bffa6b3bafe44dfbba469ba7fbf5f550746) leatherman: 1.12.8 -> 1.12.9
* [`92bc5dbb`](https://github.com/NixOS/nixpkgs/commit/92bc5dbbae7089db294898dedc7c2b876adeb497) picard-tools: 2.27.4 -> 2.27.5
* [`12cab28e`](https://github.com/NixOS/nixpkgs/commit/12cab28e364b27e3a6194b9fb25446ab0eca5f54) agi: 3.0.1 -> 3.2.1
* [`00cb2a10`](https://github.com/NixOS/nixpkgs/commit/00cb2a10cc5cd07e4cd3a26d0741d66d7401d94f) gama: 2.22 -> 2.23
* [`e0d0d1c0`](https://github.com/NixOS/nixpkgs/commit/e0d0d1c0938f97f082f47d2af95990ef9b1fa900) crystal: 1.2 -> 1.6
* [`d5f0439c`](https://github.com/NixOS/nixpkgs/commit/d5f0439c6e93f89ff7e6987c64593538ccc00080) semver-tool: 3.3.0 -> 3.4.0
* [`c266e3d6`](https://github.com/NixOS/nixpkgs/commit/c266e3d61dd523d0b6cee75185f308509cbc699b) python310Packages.azure-mgmt-compute: 27.2.0 -> 29.0.0
* [`60f30ce2`](https://github.com/NixOS/nixpkgs/commit/60f30ce2149b812d0ae5a33f87fc1ffdefddf44f) kubevirt: 0.57.1 -> 0.58.0
* [`a7b81720`](https://github.com/NixOS/nixpkgs/commit/a7b8172046add8cd82c7624b8bfbe4fafe741801) surface-control: 0.4.3-1 -> 0.4.3-2
* [`c9e34491`](https://github.com/NixOS/nixpkgs/commit/c9e344912b5d0dae7184e3e228d95693d65f673d) csound-manual: 6.17.0 -> 6.18.0
* [`9b6172aa`](https://github.com/NixOS/nixpkgs/commit/9b6172aa2deb23c280e250fbf50781bc51aa5132) fix: re-enable 1.0.x - 1.2.x
* [`ffa22c68`](https://github.com/NixOS/nixpkgs/commit/ffa22c68ea210b041efe56d7a0bffc194711fe64) fix: mark broken if > 1.3.x and 1686-linux
* [`c3df8b78`](https://github.com/NixOS/nixpkgs/commit/c3df8b7855909c181b73b01107e0223c5d39889e) dbmate: 1.15.0 -> 1.16.0
* [`f8b18c10`](https://github.com/NixOS/nixpkgs/commit/f8b18c100b9fea36b0289770476baecc2c009c49) ocamlPackages.ocaml: Migrate to integrated assembler for Darwin
* [`22d482f9`](https://github.com/NixOS/nixpkgs/commit/22d482f9c4926b5c558f67fda5baa27dfd8fb39a) python310Packages.azure-mgmt-cognitiveservices: 13.2.0 -> 13.3.0
* [`b1c253fe`](https://github.com/NixOS/nixpkgs/commit/b1c253feba8c73dd18be20653fffb7e542699df3) nwg-launchers: 0.6.3 -> 0.7.1.1
* [`9a48ce4f`](https://github.com/NixOS/nixpkgs/commit/9a48ce4fb2aaae9febcec4bb8ea76d37b0c18964) nixos/plasma5: make kpackage able to resolve dependencies
* [`600a5eb2`](https://github.com/NixOS/nixpkgs/commit/600a5eb28957b89a38a37f695b926f9ce65ea479) irqbalance: 1.9.0 -> 1.9.2
* [`757fff82`](https://github.com/NixOS/nixpkgs/commit/757fff82ba941ef513ca647e21a1d52d46285bae) ibus-engines.table: 1.16.11 -> 1.16.13
* [`ae9790eb`](https://github.com/NixOS/nixpkgs/commit/ae9790ebe658336d89feaea979053163983a56e8) remarkable-mouse: 7.0.3 -> 7.1.1
* [`3f6b17e9`](https://github.com/NixOS/nixpkgs/commit/3f6b17e9e2503b5a51d0a53c13264cbb703240bc) azure-storage-azcopy: 10.16.0 -> 10.16.2
* [`78898fa2`](https://github.com/NixOS/nixpkgs/commit/78898fa218991593988d5fb88de06ac22e4b6894) elasticmq-server-bin: 1.3.9 -> 1.3.14
* [`ac753f72`](https://github.com/NixOS/nixpkgs/commit/ac753f724b6d63c84a3d5f54bd82aba0fb8c9ab3) vikunja-frontend: 0.19.1 -> 0.20.1
* [`50f0d459`](https://github.com/NixOS/nixpkgs/commit/50f0d4596a5bc920a79dc4183e1a90eb1fa6f7b7) vikunja-frontend: 0.19.2 -> 0.20.1
* [`89dab4d1`](https://github.com/NixOS/nixpkgs/commit/89dab4d1843129be23308c4ae6587ad4696d71f7) feat: bump 1.6.x to 1.6.2
* [`4bd897e5`](https://github.com/NixOS/nixpkgs/commit/4bd897e55011adf9662a76f10ba2e15cc1e68ecf) fix: add another patch for < 1.6.0
* [`b8ae9f94`](https://github.com/NixOS/nixpkgs/commit/b8ae9f94aa85b154963779cc5e75f1937525a8bd) fix: supported platforms per version
* [`fe205fd1`](https://github.com/NixOS/nixpkgs/commit/fe205fd152be1e367c95cf648bfa4716142b171c) python310Packages.dropbox: 11.35.0 -> 11.36.0
* [`acd4d5ba`](https://github.com/NixOS/nixpkgs/commit/acd4d5bae07250f672ffd8cfb63355519d707127) clini: init at 0.1.0
* [`ce5ce4bf`](https://github.com/NixOS/nixpkgs/commit/ce5ce4bfefca34ef220c242c21d4de1858bdf5da) fix: downstreams
* [`c8e2d5bd`](https://github.com/NixOS/nixpkgs/commit/c8e2d5bd74d37a893134e45f9e961ad3ef401a5f) ace: 7.0.8 -> 7.0.10
* [`f988244e`](https://github.com/NixOS/nixpkgs/commit/f988244e9fff4b8a5ed0e3e31c4e0e5664159298) flacon: 9.2.0 -> 9.5.1
* [`8a4536cb`](https://github.com/NixOS/nixpkgs/commit/8a4536cba8feb567471da7d9174c6523eb91e375) fix: make kakoune-cr use crystal 1.2
* [`b1be7340`](https://github.com/NixOS/nixpkgs/commit/b1be734009b3b9aa217d8561846fce9c9beafb37) fix: disable ffi on < 1.6.1 instead of patching the spec
* [`5564346d`](https://github.com/NixOS/nixpkgs/commit/5564346d68f6696e18dab41cf3546325e7b4647a) feat: use release mode only on the compiler and not the specs
* [`392df0cf`](https://github.com/NixOS/nixpkgs/commit/392df0cf61d6d2ea4a370d266a32dad0eb61adda) feat: 1.5.0 -> 1.5.1 and enable aarch64-linux builds
* [`159ddb54`](https://github.com/NixOS/nixpkgs/commit/159ddb54957e58b52588ce592f995f57f02f2a77) feat: get rid of unused versions
* [`f26a4827`](https://github.com/NixOS/nixpkgs/commit/f26a48275eaa7f71722a2a0c0d5b7550c29bb17a) kube-router: 1.5.1 -> 1.5.3
* [`bad89588`](https://github.com/NixOS/nixpkgs/commit/bad89588755c9640f530deef5db1bb0b42f55015) python310Packages.azure-mgmt-datafactory: 2.8.1 -> 2.10.0
* [`96ff3f8e`](https://github.com/NixOS/nixpkgs/commit/96ff3f8e5e949cba6a448ebe148b4c356e611ba1) python310Packages.azure-mgmt-batch: 16.2.0 -> 17.0.0
* [`512fafc4`](https://github.com/NixOS/nixpkgs/commit/512fafc446ded1ce304016979e5c1c4616b0cb02) basex: 10.2 -> 10.4
* [`f4170e0a`](https://github.com/NixOS/nixpkgs/commit/f4170e0ab28461d9884b27b9aef648edf498fc8a) commonsDaemon: 1.3.1 -> 1.3.3
* [`45bc5679`](https://github.com/NixOS/nixpkgs/commit/45bc567937022fdf56959fd6c9b7c9f13dfcfd3d) qtstyleplugin-kvantum-qt4: 1.0.4 -> 1.0.7
* [`bc42cb99`](https://github.com/NixOS/nixpkgs/commit/bc42cb997fc98c29a0eea6af4951ed3a44ca761a) rgbds: 0.6.0 -> 0.6.1
* [`7c92e0c6`](https://github.com/NixOS/nixpkgs/commit/7c92e0c6b65c6cf10e0b3dc5769eee0104986396) python310Packages.azure-multiapi-storage: 0.10.0 -> 1.0.0
* [`7f0dea39`](https://github.com/NixOS/nixpkgs/commit/7f0dea39c874c3e191273105cd3902c8a92c5868) authy: 2.2.1 -> 2.2.2
* [`6f5ce31f`](https://github.com/NixOS/nixpkgs/commit/6f5ce31ff8f7d98aab228841a6a7ce5160c0567e) clojure-lsp: 2022.11.03-00.14.57 -> 2022.12.09-15.51.10
* [`56172aec`](https://github.com/NixOS/nixpkgs/commit/56172aec1a5354e5462f2c3a8777e368739ba697) bctoolbox: 5.1.17 -> 5.2.0
* [`69b683ad`](https://github.com/NixOS/nixpkgs/commit/69b683ad17c8f0860a67790b9accf30af4951de7) cglm: 0.8.5 -> 0.8.8
* [`9d00dfc2`](https://github.com/NixOS/nixpkgs/commit/9d00dfc285fafffe2044590550b7c8e6c575bbb0) erlang-ls: 0.41.2 -> 0.46.1
* [`2c3439ef`](https://github.com/NixOS/nixpkgs/commit/2c3439ef741cf13e341d72a36977551f23ea31a7) besu: 22.7.6 -> 22.10.3
* [`336925f7`](https://github.com/NixOS/nixpkgs/commit/336925f7c4ad7a2f2f62279c6eaa3f69c3b02033) amdvlk: 2022.Q3.5 -> 2022.Q4.4
* [`1ddba4aa`](https://github.com/NixOS/nixpkgs/commit/1ddba4aadbe9670d7329ef4470f347a75b98e955) chromium: fix web app linking
* [`9ca6696f`](https://github.com/NixOS/nixpkgs/commit/9ca6696f2cac074214e55c887a4c81a6e2feb6e8) ruffle: nightly-2022-09-26 -> nightly-2022-12-16
* [`84463a44`](https://github.com/NixOS/nixpkgs/commit/84463a443e3c74d61320395fe11d04b8c0e82fdf) trillian: 1.5.0 -> 1.5.1
* [`6099bd12`](https://github.com/NixOS/nixpkgs/commit/6099bd12c3614a44b19f3d4ed1d20140abc4e76c) vk-bootstrap: 0.5 -> 0.6
* [`eab3f4d8`](https://github.com/NixOS/nixpkgs/commit/eab3f4d896caa291fbe824efa9e2e1f2cbf6ed16) fix: darwin compile errors
* [`3efc4e5f`](https://github.com/NixOS/nixpkgs/commit/3efc4e5f0365462048da25bed62d1b237f733a55) fix: versionOlder => lib.versionOlder
* [`44073f6d`](https://github.com/NixOS/nixpkgs/commit/44073f6d1667ba1c723a6240b91ebacb3e72ee05) fix: version limits on unix_spec
* [`0b7ec912`](https://github.com/NixOS/nixpkgs/commit/0b7ec912c93e1aa0d8ce5377480a223c9b5b441c) vulkan-cts: init at 1.3.4.1
* [`c09e03c1`](https://github.com/NixOS/nixpkgs/commit/c09e03c1a69306c58d2f97453fe9f071171ec48a) root: remove the already-default CMAKE_INSTALL_*DIR flags
* [`c1027175`](https://github.com/NixOS/nixpkgs/commit/c1027175c1cd3fa4c903e340dc7b75768ff99ede) root: fix output directory layout with -Dgnuinstall=ON
* [`2b152c57`](https://github.com/NixOS/nixpkgs/commit/2b152c57276bee650bd2269d0f9de7588dc3bac1) test/coturn: add some sanity-checks
* [`a979bd92`](https://github.com/NixOS/nixpkgs/commit/a979bd9214a622ef444a20e2023d37c268c43ea4) fix(tzdata): prepend to ZONE_SOURCES instead of substituting in place
* [`f83a8afc`](https://github.com/NixOS/nixpkgs/commit/f83a8afc99364cf0085ae9764edbc611fd1a487f) kotatogram-desktop/tg_owt: supply right openssl version
* [`0006d8ae`](https://github.com/NixOS/nixpkgs/commit/0006d8ae77677ad3fab03ededd9eb31846646ea7) php80Extensions.blackfire: 1.78.1 -> 1.86.3
* [`8177caca`](https://github.com/NixOS/nixpkgs/commit/8177caca2cf6fab309ed6643933586bdb8349e60) mopidy-notify: init at 0.2.0
* [`0df348ed`](https://github.com/NixOS/nixpkgs/commit/0df348ed0a446a3e29d10f1e84436250421818b0) zef: 0.14.2 -> 0.14.6
* [`53b3a6bc`](https://github.com/NixOS/nixpkgs/commit/53b3a6bc4dd6b5931e6b9a4394574ee0b90d303a) rssguard: 4.2.4 -> 4.2.7
* [`f47b9eec`](https://github.com/NixOS/nixpkgs/commit/f47b9eeceba06cc601a1468924b65a70479425cc) phockup: 1.7.1 -> 1.9.2
* [`84f7075b`](https://github.com/NixOS/nixpkgs/commit/84f7075b5fe899c4a6dc5a51c50a0338b5be5ba0) firefox-devedition-bin-unwrapped: 108.0b9 -> 109.0b6
* [`be34feec`](https://github.com/NixOS/nixpkgs/commit/be34feecc4c41fe8118939971999a2a2184d07e4) uptime-kuma: 1.18.5 -> 1.19.2
* [`106f731a`](https://github.com/NixOS/nixpkgs/commit/106f731a598a0b9c5550079ce552660feef2870c) vieb: 7.2.0 -> 9.5.0
* [`ef1b67da`](https://github.com/NixOS/nixpkgs/commit/ef1b67da0ec3d89d2075537d34997f463f68c7a3) libfabric -> 1.17.0 and opx activation
* [`ca014f24`](https://github.com/NixOS/nixpkgs/commit/ca014f24e29bf8a6329784798a9ade4d05bf2619) gtk-layer-shell: 0.7.0 -> 0.8.0
* [`3affae09`](https://github.com/NixOS/nixpkgs/commit/3affae099a93ec2933f251851118d4f4874aaaa9) ocamlPackages.ssl: 0.5.12 -> 0.5.13
* [`9b8bcfcf`](https://github.com/NixOS/nixpkgs/commit/9b8bcfcf158a405332f91483b941a892aaf498d2) teleport: 10.3.1 -> 11.1.4
* [`b3f148a4`](https://github.com/NixOS/nixpkgs/commit/b3f148a4d0728a13b548c091cea20c505de0c2fc) opam: 2.1.3 -> 2.1.4
* [`cf6a45f6`](https://github.com/NixOS/nixpkgs/commit/cf6a45f65b1956dd866f5840cea527552fe8a4ce) pinegrow: 7.03 -> 7.05.2
* [`e44e907d`](https://github.com/NixOS/nixpkgs/commit/e44e907de3d5dbbe84f315e60b724998e06046d2) python3Packages.pipenv-poetry-migrate: 0.2.1 -> 0.3.0
* [`53373b76`](https://github.com/NixOS/nixpkgs/commit/53373b761a8fb0a5dec96bffa497e58534804791) nixos/profiles/base: add tcpdump
* [`06dce76d`](https://github.com/NixOS/nixpkgs/commit/06dce76d214d7b0b20cf19a16c032305feee60ce) python3Packages.pyngrok: init at 5.2.1
* [`6ef5d97e`](https://github.com/NixOS/nixpkgs/commit/6ef5d97ea1cd35630f386e4bc8f4d2edec04c926) python3Packages.meshcat: init at 0.3.2
* [`31e19529`](https://github.com/NixOS/nixpkgs/commit/31e19529525a725edf4e5d0d940c638fd1f15d1b) argo: build staticfiles with buildGoModule
* [`a43ad0c9`](https://github.com/NixOS/nixpkgs/commit/a43ad0c99513fe46d2cdc90dd0281fc16f0c7a59) kotlin-native: 1.7.10 -> 1.8.0
* [`75f45721`](https://github.com/NixOS/nixpkgs/commit/75f45721161ac52b1de1a4040271eb0eebc59f82) libbde: 20220121 -> 20221031
* [`a946ae14`](https://github.com/NixOS/nixpkgs/commit/a946ae14b47fe8b0620e115cedf8d4568995495d) pkgs/graalvm: add graaljs installable
* [`168c2b62`](https://github.com/NixOS/nixpkgs/commit/168c2b6245ecec7ae090b91d7b2263165f3204b6) opensbi: 1.1 -> 1.2
* [`a8153ead`](https://github.com/NixOS/nixpkgs/commit/a8153eadb44ee6d014bf0a10abc16fe59346b26a) ligo: 0.58.0 -> 0.59.0
* [`fe3f9a42`](https://github.com/NixOS/nixpkgs/commit/fe3f9a42edd0ced21000f29695e4a3c60c06f6f8) libbaseencode: 1.0.14 -> 1.0.15
* [`9fb025d0`](https://github.com/NixOS/nixpkgs/commit/9fb025d0ed24bccbfd6d32137460801c51d714a9) arrow-cpp: Use minimal aws-sdk-cpp, reducing closure 1.0G->417M
* [`056d990d`](https://github.com/NixOS/nixpkgs/commit/056d990d4755c71152cc8756efa0b6ac85229ae1) python310Packages.gassist-text: init at 0.0.7
* [`7fa675ec`](https://github.com/NixOS/nixpkgs/commit/7fa675ecd2ea086ddf0218433855ea7df5e1dd71) home-assistant: update component-packages
* [`16ce51d8`](https://github.com/NixOS/nixpkgs/commit/16ce51d8e5e7633dd55d851930eb61c85d4a43e4) libtorrent-rasterbar-2_0_x: unbreak on darwin
* [`fe496f58`](https://github.com/NixOS/nixpkgs/commit/fe496f58976116d520222f430ebc4690360259fd) qbittorrent: add darwin support
* [`b8a81fd7`](https://github.com/NixOS/nixpkgs/commit/b8a81fd742e777e9de0cf116f9481440c20a9ec6) pluto: 5.11.0 -> 5.12.0
* [`5ad20ca7`](https://github.com/NixOS/nixpkgs/commit/5ad20ca731e21b35428dc6fb7c78f4aa64838d6a) nextpnr: 0.4 -> 0.5
* [`7001c5c0`](https://github.com/NixOS/nixpkgs/commit/7001c5c07d086f1b356e77ad4958a61ed8b59692) kronosnet: 1.23 -> 1.25
* [`e1fbea00`](https://github.com/NixOS/nixpkgs/commit/e1fbea009d8ba5915c58067acc4fb3121564cf17) faudio: 22.08 -> 23.01
* [`ee41b6b4`](https://github.com/NixOS/nixpkgs/commit/ee41b6b45713ccd327eedc3e50d5d58580571638) dokuwiki: Combine mechanism for plugins and templates
* [`eaf0fdb5`](https://github.com/NixOS/nixpkgs/commit/eaf0fdb58b344a2b3322b1f67909f2015369062d) wasabibackend: 1.1.13.1 -> 2.0.2.1
* [`53f23ccd`](https://github.com/NixOS/nixpkgs/commit/53f23ccd4c608eb98277cc1c5b26fed71f8a0ffb) memtest86plus: 6.00 -> 6.01
* [`17c15cc3`](https://github.com/NixOS/nixpkgs/commit/17c15cc3ff1e51f2c3621589e8e6cc9d33826ae5) poetry: don't use poetry2nix
* [`b8867af8`](https://github.com/NixOS/nixpkgs/commit/b8867af84abdbd93c72cbf9482cb9e07e717fef0) nicotine-plus: 3.2.7 -> 3.2.8
* [`9fa54ab2`](https://github.com/NixOS/nixpkgs/commit/9fa54ab2b851c97b103cf46904b5f664ee949c35) opencolorio: move cmake file to correct place
* [`0f5cf127`](https://github.com/NixOS/nixpkgs/commit/0f5cf127fd8a7ceed19fa3591516d24361983b77) orcania: 2.3.0 -> 2.3.2
* [`c7b39758`](https://github.com/NixOS/nixpkgs/commit/c7b39758be3157dc91875c7cc5c363ab6dad17fe) firefox-beta-bin-unwrapped: 109.0b6 -> 109.0b9
* [`8c06ece1`](https://github.com/NixOS/nixpkgs/commit/8c06ece107f49be172b97935d136a946ea856d62) obs-studio: 28.1.2 -> 29.0.0
* [`f2b64348`](https://github.com/NixOS/nixpkgs/commit/f2b6434843c418ecd4b4f19912d287d8518e2efd) pwsafe: add darwin support
* [`f35b1d03`](https://github.com/NixOS/nixpkgs/commit/f35b1d038daafb2a71a6dd1c84437a41a03b7f38) librest_1_0: pick up crash fix with libsoup 3
* [`3301ba74`](https://github.com/NixOS/nixpkgs/commit/3301ba748d95c9b371b1315efee20438fd28aae2) azure-functions-core-tools: 4.0.4785 -> 4.0.4915
* [`fb43ee0c`](https://github.com/NixOS/nixpkgs/commit/fb43ee0c09172977028bfbd696550788898390a2) classads: unbreak on aarch64-darwin
* [`635cace7`](https://github.com/NixOS/nixpkgs/commit/635cace785003762d76220fa242ae69f9a81f5e6) libadwaita: 1.2.0 -> 1.2.1
* [`8fcba0f7`](https://github.com/NixOS/nixpkgs/commit/8fcba0f7228c0aaddae93b94c08893e0b0e8dcdd) poetry: remove from pythonPackages
* [`35e24243`](https://github.com/NixOS/nixpkgs/commit/35e24243c386a31c6693b51b55a9767f08e9c205) gitkraken: fix broken interpreter after recent update
* [`63471863`](https://github.com/NixOS/nixpkgs/commit/634718637cd8fefd0c46de1d6c4b9e094e5d26e7) beancount-ing-diba: use poetry-core
* [`d05abd44`](https://github.com/NixOS/nixpkgs/commit/d05abd44c7db6c307eecdeca34f29bff44288a72) snd: 22.5 -> 23.0
* [`f29f0d07`](https://github.com/NixOS/nixpkgs/commit/f29f0d07982c8ec766adef7106b69c5af42882f8) feat: 1.7.0
* [`05e665a9`](https://github.com/NixOS/nixpkgs/commit/05e665a9adb58d5ad2292a1b7751385060cabd36) seer: 1.11 -> 1.14
* [`791af942`](https://github.com/NixOS/nixpkgs/commit/791af942253a88b29d8bba9d5609293ac88d4d03) libratbag: 0.16 -> 0.17
* [`c40708f9`](https://github.com/NixOS/nixpkgs/commit/c40708f924d3548b435416c5cee760ef96bc9fb8) darwin.apple_sdk.frameworks.DisplayServices: init
* [`b31bb0e1`](https://github.com/NixOS/nixpkgs/commit/b31bb0e1d144d5a15644f7f919f01b95ce3d7d1e) sketchybar: 2.8.2 -> 2.13.2
* [`4e852c57`](https://github.com/NixOS/nixpkgs/commit/4e852c5791a12149b22c3c9f53b3d9dc3a3e902a) maintainers: add elnudev
* [`751b9063`](https://github.com/NixOS/nixpkgs/commit/751b9063a7b865defeafcc13cff7ef2758e1a678) nixos/restic: assert that repository name is specified
* [`2a46ef4f`](https://github.com/NixOS/nixpkgs/commit/2a46ef4fff95d3ac23b65a97a1c9be54cca3ddb4) nixos/tests/restic: test that restoring works
* [`9dbdb059`](https://github.com/NixOS/nixpkgs/commit/9dbdb059245ccdb8e7e8161c6a37301a5397ef6d) nixos/restic: add exclude parameter
* [`5ebf548b`](https://github.com/NixOS/nixpkgs/commit/5ebf548b742be55dcc7e157e492d501e3984dac5) sickgear: 0.25.47 -> 0.25.60
* [`035e7d3d`](https://github.com/NixOS/nixpkgs/commit/035e7d3d75a1088cd9cb69126c37a3673c49ed45) cudaPackages_12: init at 12.0.0
* [`3e6ea2bf`](https://github.com/NixOS/nixpkgs/commit/3e6ea2bf69330b5fd7c6b453b6bd0a43663be6ae) mongosh: 1.6.1 -> 1.6.2
* [`2abe4983`](https://github.com/NixOS/nixpkgs/commit/2abe4983620828a00bb83fdd3a01792ed64db2ad) yacreader: 9.10.0 -> 9.11.0
* [`12c63ab0`](https://github.com/NixOS/nixpkgs/commit/12c63ab03c3b552ac00ac487d2710c969b412581) xdot: fix Gtk error
* [`f923b135`](https://github.com/NixOS/nixpkgs/commit/f923b135ebf1d324e228d6fd03532d3fcb694156) python310Packages.google-cloud-container: 2.14.0 -> 2.16.0
* [`efe9c9ef`](https://github.com/NixOS/nixpkgs/commit/efe9c9ef62b7efa97ef9b065683522ebc460984e) virglrenderer: 0.10.3 -> 0.10.4
* [`487dff80`](https://github.com/NixOS/nixpkgs/commit/487dff809ef831ce0edd9e1e0f9a46affef31c84) jenkins: 2.375.1 -> 2.375.2
* [`0a291783`](https://github.com/NixOS/nixpkgs/commit/0a2917831f403e1ce3cda9995ee8b58fab829fe3) featherpad: 1.3.1 -> 1.3.5
* [`aff371a6`](https://github.com/NixOS/nixpkgs/commit/aff371a6db958bf096e65a0467213aa37c15ae31) hyperrogue: 12.1a -> 12.1h
* [`70208939`](https://github.com/NixOS/nixpkgs/commit/7020893918157a0c67ce3b61967afc3a5205b13e) poetry: don't propagate dependencies
* [`397d5aab`](https://github.com/NixOS/nixpkgs/commit/397d5aab5304514db1b77649ad72bd081fc55607) python310Packages.recurring-ical-events: 1.1.0b0 -> 2.0.0
* [`af0675c5`](https://github.com/NixOS/nixpkgs/commit/af0675c578a558e7d443d892807d29d5b63c07cd) poetry: 1.3.1 -> 1.3.2
* [`33c511a0`](https://github.com/NixOS/nixpkgs/commit/33c511a094f611f9b97a4b607c7df74b83301efb) nqptp: init at unstable-2022-09-12
* [`1bc5ddcf`](https://github.com/NixOS/nixpkgs/commit/1bc5ddcff4071394a793320f7cc1d7b5766c6c1a) agdaPackages.cubical: clean up
* [`6ca0697f`](https://github.com/NixOS/nixpkgs/commit/6ca0697f8f18c27e8be40b17d8f795329a9d490e) dolphin-emu-beta: 5.0-17269 -> 5.0-17995
* [`f400af6d`](https://github.com/NixOS/nixpkgs/commit/f400af6df1e9d65b15e9b9a357517618baf6c1f2) google-cloud-sdk: deprecate phases
* [`297a1eb8`](https://github.com/NixOS/nixpkgs/commit/297a1eb83ac9e2585388b94f59b14b058692929f) apache-jena: 4.6.1 -> 4.7.0
* [`f8f5332f`](https://github.com/NixOS/nixpkgs/commit/f8f5332f58e9e2c4726d1287183f90e629b1ac36) prs: 0.4.0 -> 0.4.1
* [`b449745e`](https://github.com/NixOS/nixpkgs/commit/b449745eee6040765b387ad7cef30d2dc813ad70) i2p: 1.9.0 -> 2.1.0
* [`f5c7c70d`](https://github.com/NixOS/nixpkgs/commit/f5c7c70dde720e990fa7e0748d1dc4764d6e4406) whalebird: 4.6.5 -> 4.7.4
* [`317f537c`](https://github.com/NixOS/nixpkgs/commit/317f537c961d00cece1d351404187f0a17195ef7) tcpflow: broaden platforms
* [`107d556b`](https://github.com/NixOS/nixpkgs/commit/107d556bb01ae57e76dedb63bb4fc8d5081f6512) buf: 1.11.0 -> 1.12.0
* [`18e1e760`](https://github.com/NixOS/nixpkgs/commit/18e1e760b6c168f675e6b91d77ea88d4a191c4c8) catppuccin-kde: init at unstable-2022-11-26
* [`7fdc4345`](https://github.com/NixOS/nixpkgs/commit/7fdc4345297e6c01eacbfd125547a0d218064398) lucenepp: add darwin support
* [`7f2fb535`](https://github.com/NixOS/nixpkgs/commit/7f2fb535b496eff6d03b5050a419c292205b732a) poedit: 3.1.1 -> 3.2.2
* [`bb125c06`](https://github.com/NixOS/nixpkgs/commit/bb125c06983e9c2146ebb9d8545f845078a58732) notepad-next: 0.5.6 -> 0.6
* [`007e4b16`](https://github.com/NixOS/nixpkgs/commit/007e4b16c8b31bb18a4b25ccd9b39d8c29bb6dd2) libversion: 3.0.2 -> 3.0.3
* [`5c79c428`](https://github.com/NixOS/nixpkgs/commit/5c79c4289a298280d554efa8a7a4a0ec95195b2e) octoprint: fix overlay composition
* [`d3b25c42`](https://github.com/NixOS/nixpkgs/commit/d3b25c422a1a06a702ef9e3875c9c42defc37b1a) cargo-watch: 8.1.2 -> 8.3.0
* [`1794a76e`](https://github.com/NixOS/nixpkgs/commit/1794a76e4035c754eae97c343064902d724d2124) pinocchio: 2.6.12 -> 2.6.14
* [`0b1ecd67`](https://github.com/NixOS/nixpkgs/commit/0b1ecd675d7741ce812b05b4383df0ce280ef42d) gtkwave: 3.3.113 -> 3.3.114
* [`9a6aa3f0`](https://github.com/NixOS/nixpkgs/commit/9a6aa3f003ae3a88ebcf7c20a5dbf2ff071d974c) python310Packages.google-cloud-error-reporting: 1.7.0 -> 1.8.0
* [`85905e4d`](https://github.com/NixOS/nixpkgs/commit/85905e4de4142b648b551ea7316c716e3bb6c3ad) python310Packages.google-cloud-bigquery-storage: 2.17.0 -> 2.18.0
* [`5a89f148`](https://github.com/NixOS/nixpkgs/commit/5a89f1480c641ac5c3c9662c32daa8eb5f6e6db2) python310Packages.gassist-text: 0.0.7 -> 0.0.10
* [`8b427b92`](https://github.com/NixOS/nixpkgs/commit/8b427b92778ba196ef41a4675df42249f2ff5511) nwg-drawer: 0.3.0 -> 0.3.7
* [`2ed8ff81`](https://github.com/NixOS/nixpkgs/commit/2ed8ff81c5660a62c1c85846f6edb4af858b4e3e) ceph: add missing python library
* [`de8a3279`](https://github.com/NixOS/nixpkgs/commit/de8a327954d866959503a0a79f592051baa911f4) wireshark: 4.0.1 -> 4.0.2
* [`8f760110`](https://github.com/NixOS/nixpkgs/commit/8f76011059f06fd744384cc562740e79b1dfc71e) fdm: 2.1 -> 2.2
* [`d0852f2f`](https://github.com/NixOS/nixpkgs/commit/d0852f2fdfcbfbc628ccbddbe85e4f08ed8c3d80) cp2k: 2022.2 -> 2023.1
* [`762741bb`](https://github.com/NixOS/nixpkgs/commit/762741bbb6fa3f4173c0565fd5dede1898aa8ddc) xfsprogs: 6.1.0 -> 6.1.1
* [`74d3b543`](https://github.com/NixOS/nixpkgs/commit/74d3b543fa8a7fa47feda75f85c087e77fba55ee) commitizen: 2.38.0 -> 2.39.1
* [`789381a5`](https://github.com/NixOS/nixpkgs/commit/789381a50df85580a34d4c5c641a0eaa34ba95ed) trilium-{desktop,server}: 0.57.5 -> 0.58.5
* [`01158eab`](https://github.com/NixOS/nixpkgs/commit/01158eab1df7661606f8c309d9d1f1ae89be414b) linuxKernel.kernels.linux_zen: 6.1.3-zen1 -> 6.1.6-zen1
* [`96bfec19`](https://github.com/NixOS/nixpkgs/commit/96bfec195899f3bc293b50f3da3bea62318d7c08) linuxKernel.kernels.linux_lqx: 6.1.3-lqx1 -> 6.1.6-lqx1
* [`f32351f8`](https://github.com/NixOS/nixpkgs/commit/f32351f87b8f73227118f8d5c722a977362529dc) brook: 20221010 -> 20230101
* [`c9960f6b`](https://github.com/NixOS/nixpkgs/commit/c9960f6b5b9d61b4e58ce05ad5106af8580cdcab) igprof: 5.9.16 -> 5.9.18
* [`95df79b0`](https://github.com/NixOS/nixpkgs/commit/95df79b06320962698220b87fbccbfa55a6da3dc) qt6.qtbase: disable cxx17 features on darwin
* [`2de4b613`](https://github.com/NixOS/nixpkgs/commit/2de4b6139e7fa5fd70e3e6d33766f20a2cb66e99) qt6.qtbase: enable framework builds
* [`100cf570`](https://github.com/NixOS/nixpkgs/commit/100cf5700debf3caa2925813539c24b978a305f9) qt6.qtbase: enable sandbox builds
* [`0d5713c6`](https://github.com/NixOS/nixpkgs/commit/0d5713c6d1f51df022e8d204ef352381f0d8e31a) python3Packages.pyqt6: unbreak on darwin
* [`54452b04`](https://github.com/NixOS/nixpkgs/commit/54452b041dde6ead47ca13616d1e45f0056703db) qt6.qtbase: detect if file exists
* [`37d4c2c7`](https://github.com/NixOS/nixpkgs/commit/37d4c2c752f8149dbb48a20e3e4bc15b30fd79ec) smartdns: 37.1 -> 40
* [`d5ca8029`](https://github.com/NixOS/nixpkgs/commit/d5ca8029a527e3442fc9125bf57c349935940836) recursive: 1.084 -> 1.085
* [`56986b9f`](https://github.com/NixOS/nixpkgs/commit/56986b9fb6197d08d19658faf4cbcec428a1a54c) lesspipe: 2.06 -> 2.07
* [`adaa5289`](https://github.com/NixOS/nixpkgs/commit/adaa5289673eea472d9c9ced26f09f6d79fbde75) codeql: 2.11.0 -> 2.12.0
* [`f30f496d`](https://github.com/NixOS/nixpkgs/commit/f30f496d9250dd90ac81ddd0e7292fb2df38a720) consul-template: 0.29.4 -> 0.30.0
* [`40389e76`](https://github.com/NixOS/nixpkgs/commit/40389e7669cc09078909a1f24eb54b237f419e8c) intel-gmmlib: 22.3.2 -> 22.3.3
* [`de3e6bd4`](https://github.com/NixOS/nixpkgs/commit/de3e6bd4e9659d573c9d186c4c0d57e8aff19d8f) linux-router-without-wifi: 0.6.6 -> 0.6.7
* [`1c9d9ef3`](https://github.com/NixOS/nixpkgs/commit/1c9d9ef3a8e7d66c63fe921e1d68fda5ca8b73a2) linux-router-without-wifi: add changelog to meta
* [`713988a1`](https://github.com/NixOS/nixpkgs/commit/713988a1db329ef18fa426e88666df13e26d7356) python310Packages.pyahocorasick: add changelog to meta
* [`6a23c1aa`](https://github.com/NixOS/nixpkgs/commit/6a23c1aac46283b58f138343228ba05505c66012) python310Packages.pyahocorasick: 2.0.0b1 -> 2.0.0
* [`18c2d73c`](https://github.com/NixOS/nixpkgs/commit/18c2d73cc734ae123e8ff5c9a3e786b0bc46c166) beluga: use Dune 3
* [`911525af`](https://github.com/NixOS/nixpkgs/commit/911525afcee092bcbf50e30c539d8ab031a7264b) anders: use Dune 3
* [`f5ed6406`](https://github.com/NixOS/nixpkgs/commit/f5ed6406521559916eeabe6a96d63207eb01612a) satysfi: use Dune 3
* [`f3f8ae2f`](https://github.com/NixOS/nixpkgs/commit/f3f8ae2fa2f553b438d721e73ad2506da2b86cce) obelisk: use Dune 3
* [`93df5691`](https://github.com/NixOS/nixpkgs/commit/93df56918c571d5323468f8cec39986a93933a9c) orpie: use Dune 3
* [`97ea0e72`](https://github.com/NixOS/nixpkgs/commit/97ea0e7236f3cd189d2b9ed10449cb1b6ce5fd05) opam-installer: use Dune 3
* [`689c7010`](https://github.com/NixOS/nixpkgs/commit/689c7010dea10fedb96d241c6c2208c311c8b6a2) ocamlPackages.ocaml-recovery-parser: use Dune 3
* [`2d967b6e`](https://github.com/NixOS/nixpkgs/commit/2d967b6e3a2cde356a020d7dae878f42478f0d5c) hipify: init at 5.4.1
* [`089bf2e3`](https://github.com/NixOS/nixpkgs/commit/089bf2e38a9834291c5451fec371262b8079250c) rocdbgapi: init at 5.4.1
* [`ae4c3a90`](https://github.com/NixOS/nixpkgs/commit/ae4c3a900d46ef9158d7403c9b90b7e1a1035796) python311Packages.twisted: fix tests
* [`5b90cec9`](https://github.com/NixOS/nixpkgs/commit/5b90cec99c7a212aca340a40401f9df3e4302b7c) python311Packages.protobuf: fix tests
* [`c2dc3100`](https://github.com/NixOS/nixpkgs/commit/c2dc3100be320541b05c08e4485227da0e767938) blflash: 0.3.3 -> 0.3.5
* [`e074b1c7`](https://github.com/NixOS/nixpkgs/commit/e074b1c7d7400aa536520a91d60edf2d16ea9fba) kodi.packages.jellyfin: 0.7.7 -> 0.7.10
* [`c02617ba`](https://github.com/NixOS/nixpkgs/commit/c02617ba9e724f681978ff5315d279a66ec16049) kodi.packages.netflix: 1.18.2 -> 1.20.2
* [`28f6d03a`](https://github.com/NixOS/nixpkgs/commit/28f6d03a43a1f5a050384e33138fc59a5b394f8b) kodi.packages.a4ksubtitles: 2.8.0 -> 3.3.0
* [`e0af32d2`](https://github.com/NixOS/nixpkgs/commit/e0af32d2a0719e7e036efa19a2e7e49603d566f3) kodi.packages.controller-topology-project: unstable-2022-01-22 -> unstable-2022-11-19
* [`052ec011`](https://github.com/NixOS/nixpkgs/commit/052ec011cd6eb46a4b9cfd0ea6443a12790fb94a) kodi.packages.iagl: 3.0.5 -> 3.0.6
* [`557c527b`](https://github.com/NixOS/nixpkgs/commit/557c527b43b2e466c339ea8cff68d7742c89c227) kodi.packages.joystick: 1.7.1 -> 19.0.1
* [`413c4d4d`](https://github.com/NixOS/nixpkgs/commit/413c4d4d8e1d4a498481977ca7fb732922aa7d57) kodi.packages.keymap: 1.1.3 -> 1.1.4
* [`09fe7a42`](https://github.com/NixOS/nixpkgs/commit/09fe7a42d91428b26a0e97ac49dd9dcc6a86028a) kodi.packages.libretro-genplus: 1.7.4.31 -> 1.7.4.35
* [`3932ca56`](https://github.com/NixOS/nixpkgs/commit/3932ca569ffe2b40e22c26a1ac922d553b41c703) kodi.packages.libretro-mgba: 0.9.2.31 -> 0.10.0.35
* [`7e5f67d4`](https://github.com/NixOS/nixpkgs/commit/7e5f67d413f71a9985cddfdfcfa23bb5222d1067) kodi.packages.libretro-snes9x: 1.60.0.29 -> 1.61.0.34
* [`72edf9a3`](https://github.com/NixOS/nixpkgs/commit/72edf9a33c1848bd87903f0f16a81e5161e3e133) kodi.packages.orftvthek: 0.12.3 -> 0.12.6
* [`edcb4fc5`](https://github.com/NixOS/nixpkgs/commit/edcb4fc5affc59c8c6c2fca8a6b1eec17b618fa6) kodi.packages.pvr-iptvsimple: 19.1.1 -> 19.2.2
* [`6182f17d`](https://github.com/NixOS/nixpkgs/commit/6182f17d4c7a81311de36283e82a98b7f00fccc4) kodi.packages.vfs-libarchive: 2.0.0 -> 19.0.1
* [`1ae9de7d`](https://github.com/NixOS/nixpkgs/commit/1ae9de7dac02c386b434d562058d8a9ed1b63c36) kodi.packages.vfs-sftp: 2.0.0 -> 19.0.1
* [`b749e681`](https://github.com/NixOS/nixpkgs/commit/b749e6811954680cad7365bde3d4f8d540cf67f5) kodi.packages.visualization-waveform: 19.0.2 -> 19.0.3
* [`a935fde7`](https://github.com/NixOS/nixpkgs/commit/a935fde7916b36bcb0835f06649a11d67b1a6f09) exodus: fix source url
* [`393e23ce`](https://github.com/NixOS/nixpkgs/commit/393e23cef04488dee788bd0999d1325565f27bdd) python310Packages.google-cloud-securitycenter: 1.17.0 -> 1.18.0
* [`03f32348`](https://github.com/NixOS/nixpkgs/commit/03f32348f47025b2acc7878533b6613d98e4a0aa) imhex: 1.19.3 -> 1.26.2
* [`9b04ea4e`](https://github.com/NixOS/nixpkgs/commit/9b04ea4e25193959bdcc72bc12df55d00d933acb) o: 2.57.0 → 2.58.0
* [`f42e2263`](https://github.com/NixOS/nixpkgs/commit/f42e22636d988f03d8d53231e744c33cdcb7bdea) libepoxy: disable more cgl tests on x86_64-darwin
* [`06f0e49d`](https://github.com/NixOS/nixpkgs/commit/06f0e49dc60bccbcce9fed65c9f6fda53ba722af) lib: make extender available on self-references
* [`23d63549`](https://github.com/NixOS/nixpkgs/commit/23d63549dfbda8def7c0609a6c6bc5c74560a60f) chia-dev-tools: init at 1.1.4
* [`bf9643c2`](https://github.com/NixOS/nixpkgs/commit/bf9643c2b7ae079b681f6676241936e05759c5b4) libiconv: don't use libiconvReal on NetBSD
* [`4895fb60`](https://github.com/NixOS/nixpkgs/commit/4895fb609815795e3ea7a71b9fcd2bb2e505436d) xnotify: unstable-2022-02-18 -> 0.9.3
* [`8e6f6d7d`](https://github.com/NixOS/nixpkgs/commit/8e6f6d7db15002a5e91fabc4aa0888d5ecf5f9e1) nixos/gitea: add tar.zst to the dump type
* [`d0fd5de4`](https://github.com/NixOS/nixpkgs/commit/d0fd5de42a261c5e9369b6764a0a8d04eef028c5) aws-c-common: 0.8.5 -> 0.8.9
* [`be98950c`](https://github.com/NixOS/nixpkgs/commit/be98950cc4f8bdc19ec7347f62d2b9f0bc534b34) aws-c-io: 0.13.12 -> 0.13.14
* [`d3c4ef1e`](https://github.com/NixOS/nixpkgs/commit/d3c4ef1ef892d16dfbd05c873d4c0887c87c0979) aws-c-event-stream: 0.2.15 -> 0.2.18
* [`cec18209`](https://github.com/NixOS/nixpkgs/commit/cec1820952e4270092197e81e290e49987395c04) aws-c-http: 0.6.28 -> 0.7.3
* [`5c4ad3bd`](https://github.com/NixOS/nixpkgs/commit/5c4ad3bdad1f592ae67325936c9097bdd7d71c59) aws-c-mqtt: 0.8.2 -> 0.8.4
* [`af5fa39b`](https://github.com/NixOS/nixpkgs/commit/af5fa39b59acd4b72f764911eed7f550fb027fb9) aws-c-auth: 0.6.21 -> 0.6.22
* [`4e59c6c9`](https://github.com/NixOS/nixpkgs/commit/4e59c6c991fbe5410a0fdced0a58ab8aeebd071b) aws-c-s3: 0.2.1 -> 0.2.2
* [`eccc1e5b`](https://github.com/NixOS/nixpkgs/commit/eccc1e5bf482491187e914a4c37ba45a5de56703) install-grub.pl: improve initrd-secrets error messages
* [`9fc47e6d`](https://github.com/NixOS/nixpkgs/commit/9fc47e6db3f2369e90cc0dec6c99b7a2501693e7) nixos-install: fix missing initrd.secrets paths
* [`928181b5`](https://github.com/NixOS/nixpkgs/commit/928181b5f38b5dacfa011a48fc66e10c1fefafd7) nixos/tests/installer: add full disk encryption test
* [`9bb888c9`](https://github.com/NixOS/nixpkgs/commit/9bb888c9f8224e45fc54d9f345369786cbd78bb6) nixos/tests/installer: test relative paths in initrd secrets
* [`8efb217f`](https://github.com/NixOS/nixpkgs/commit/8efb217f88c49b66b85458df261f8cd089baaaf5) typos: 1.13.6 -> 1.13.7
* [`81649c99`](https://github.com/NixOS/nixpkgs/commit/81649c99ea061880fd10f6f7513d6585751a31f3) python310Packages.jaraco-test: 5.2.0 -> 5.3.0
* [`35d1b354`](https://github.com/NixOS/nixpkgs/commit/35d1b354425fed266e986313d4ecd32573785119) iosevka-bin: 17.0.2 -> 17.0.4
* [`f97f850c`](https://github.com/NixOS/nixpkgs/commit/f97f850c8abc18e618dab2f64410106f7b4fd32d) python310Packages.cairosvg: 2.5.2 -> 2.6.0
* [`185874df`](https://github.com/NixOS/nixpkgs/commit/185874df63be2dec1988f652b2bed7e4b104d431) nixos/qt: set QT_PLUGIN_PATH and QML2_IMPORT_PATH when enabled
* [`ecd5af38`](https://github.com/NixOS/nixpkgs/commit/ecd5af382537cc104cfeefaf96d25114e2bd6d5c) ruff: 0.0.222 -> 0.0.223
* [`cd18384f`](https://github.com/NixOS/nixpkgs/commit/cd18384f4920c11630ad6cb21665826eb35f620c) seaweedfs: 3.39 -> 3.40
* [`d7989b43`](https://github.com/NixOS/nixpkgs/commit/d7989b431b747a486ea3c317ee3eb747268a60c9) lightningcss: 0.17.1 → 0.18.0
* [`95ad6910`](https://github.com/NixOS/nixpkgs/commit/95ad6910ba5778f6ba6fbe95f99d1cbc610ba470) difftastic: 0.41.0 -> 0.42.0
* [`ff731153`](https://github.com/NixOS/nixpkgs/commit/ff731153e2b81d6a0c7de766c1ddd8deed25b49a) senpai: unstable-2022-12-02 → unstable-2023-01-03
* [`6b545991`](https://github.com/NixOS/nixpkgs/commit/6b545991b9f27489c550f9c1c602ab879fd18548) unpoller: 2.4.1 -> 2.7.10
* [`eb26a9d0`](https://github.com/NixOS/nixpkgs/commit/eb26a9d07260676b8b5b389e188cd23e822f908c) nanomq: 0.14.8 → 0.15.1
* [`50196461`](https://github.com/NixOS/nixpkgs/commit/5019646151f20779c70df923d41b79025eddc2a9) ferium: 4.3.3 -> 4.3.4
* [`e9b97a64`](https://github.com/NixOS/nixpkgs/commit/e9b97a64cf02247d90ab55415c67b8dfff267eca) convco: 0.3.12 -> 0.3.14
* [`9ae901cc`](https://github.com/NixOS/nixpkgs/commit/9ae901cc806462f8ccc97fe2d0e4a3da13bafeb1) tor: 0.4.7.12 -> 0.4.7.13
* [`27463cf1`](https://github.com/NixOS/nixpkgs/commit/27463cf1d52f7a6c7c64c77d27cf14d88555bf7e) tinygo: 0.25.0 -> 0.26.0
* [`936ea663`](https://github.com/NixOS/nixpkgs/commit/936ea6635fe71175490c6df165167451b8bfcc69) ogre: 13.5.3 -> 13.6.0
* [`54d22011`](https://github.com/NixOS/nixpkgs/commit/54d220114a04b583bcfddeba6283c914ca2ae605) cargo-llvm-cov: 0.5.8 -> 0.5.9
* [`04aca1a8`](https://github.com/NixOS/nixpkgs/commit/04aca1a89ab2e73f1935390e5e517313426c5c68) tlsx: 1.0.3 -> 1.0.4
* [`392bc0cf`](https://github.com/NixOS/nixpkgs/commit/392bc0cfb741f05e8fcdfea9aaec7416208f7e51) httpx: 1.2.4 -> 1.2.6
* [`52365627`](https://github.com/NixOS/nixpkgs/commit/52365627209c8ab8a4dc8cd2733eabd83ecb6e1b) Add nat-418 to maintainers list
* [`9fd7879b`](https://github.com/NixOS/nixpkgs/commit/9fd7879b484ab71b4636b242d7a1ad98816feb12) crc: 2.11.0 -> 2.12.0
* [`53a40eea`](https://github.com/NixOS/nixpkgs/commit/53a40eeab1f5121f9f725a0119bb1fc960a3d824) deno: 1.29.2 -> 1.29.3
* [`f59b2fbc`](https://github.com/NixOS/nixpkgs/commit/f59b2fbc630f6c3c930ab3b963858c368b56bf08) tcpflow: broaden platforms to unix
* [`c590d510`](https://github.com/NixOS/nixpkgs/commit/c590d510379f99c6037c0657e38962f89a84ed92) ceph: comment where to find python dependencies
* [`0282b0b2`](https://github.com/NixOS/nixpkgs/commit/0282b0b2bccf28f7bc74763d675cc814c962e4a5) gnome.nautilus: 43.1 → 43.2
* [`fda80204`](https://github.com/NixOS/nixpkgs/commit/fda802047655433519a4f12427ff8f8c32c6f1b7) nheko: 0.11.0 -> 0.11.1
* [`5e2eff69`](https://github.com/NixOS/nixpkgs/commit/5e2eff698439e5f28961ca29683ba1a8de0af8be) toybox: fix Libsystem inconsistency properly
* [`dc047d18`](https://github.com/NixOS/nixpkgs/commit/dc047d18bb78ed96eb3ba10df321674cc22bc8de) maintainers: add suominen
* [`c98d0946`](https://github.com/NixOS/nixpkgs/commit/c98d09461e3781b633d0c1edca51d5cddced6c0b) colorless: init at 109
* [`51215b4c`](https://github.com/NixOS/nixpkgs/commit/51215b4c3780f8fcf9438bd1aa7fc4a524015a8f) gitlab: 15.7.2 -> 15.7.3 ([nixos/nixpkgs⁠#210289](https://togithub.com/nixos/nixpkgs/issues/210289))
* [`18e85cef`](https://github.com/NixOS/nixpkgs/commit/18e85ceffe00698d4e00817ceb3a53a1c989abb4) python310Packages.pyro-ppl: 1.8.3 -> 1.8.4
* [`e2769890`](https://github.com/NixOS/nixpkgs/commit/e2769890ebf43be7b6f269e2f419b516456a6221) mangal: 4.0.5 -> 4.0.6
* [`e583172f`](https://github.com/NixOS/nixpkgs/commit/e583172fcb0ba144bad69ff47db18a5282c7cd86) toybox: small refactor
* [`27e1c72b`](https://github.com/NixOS/nixpkgs/commit/27e1c72be0313406208725e2af80bb7ad140acef) mark: 8.4 -> 8.6
* [`a5571181`](https://github.com/NixOS/nixpkgs/commit/a5571181be742ff91d72e15f0e9b088bb33863ae) komga: 0.157.5 -> 0.158.0
* [`ba00b146`](https://github.com/NixOS/nixpkgs/commit/ba00b146c123523d96261262695e55b8deaf654a) pocketbase: 0.11.0 -> 0.11.2
* [`2cae7169`](https://github.com/NixOS/nixpkgs/commit/2cae716942d95798fc21f31f1ec6eb91393d029f) monetdb: 11.45.7 -> 11.45.11
* [`4dbc2fe8`](https://github.com/NixOS/nixpkgs/commit/4dbc2fe873f24222304a620764bcc2e7bb56f3ff) nixos/syncthing: point out pitfalls with extraOptions ([nixos/nixpkgs⁠#210208](https://togithub.com/nixos/nixpkgs/issues/210208))
* [`8b3aad8e`](https://github.com/NixOS/nixpkgs/commit/8b3aad8e14146557df2223af55fc909a8b8d6ca2) python310Packages.rq: 1.11.1 -> 1.12.0
* [`c51dd423`](https://github.com/NixOS/nixpkgs/commit/c51dd423118cb4c85b7682cbae2f27188aeb11bc) nixos/wordpress: add settings option
* [`22827931`](https://github.com/NixOS/nixpkgs/commit/22827931f11136e4d2bf63ddc752c5e16c232f26) mediainfo: 22.06 -> 22.12
* [`3ed01b0d`](https://github.com/NixOS/nixpkgs/commit/3ed01b0ddadeb1346d7c0db28575b0904be59b1b) python310Packages.rq: add changelog to meta
* [`ff10c881`](https://github.com/NixOS/nixpkgs/commit/ff10c88195c495c9d56bdfaf51d487ff6c28ae6c) mautrix-whatsapp: 0.8.0 -> 0.8.1
* [`cc51fd43`](https://github.com/NixOS/nixpkgs/commit/cc51fd4319a5277d9fc0633288f61eb6ddde278f) python310Packages.openerz-api: add changelog to meta
* [`e7fa123f`](https://github.com/NixOS/nixpkgs/commit/e7fa123fdfe05d5c7a6c639671ed8b066df17295) python310Packages.openerz-api: 0.1.0 -> 0.2.0
* [`1a44669e`](https://github.com/NixOS/nixpkgs/commit/1a44669ef43a42b5caf7ec07c64463e3e92cb919) zotero: 6.0.18 -> 6.0.20 ([nixos/nixpkgs⁠#210142](https://togithub.com/nixos/nixpkgs/issues/210142))
* [`22a8cf0c`](https://github.com/NixOS/nixpkgs/commit/22a8cf0c28d536294d55049923575ce94bb39359) nixos/lxc-container: fix compatibility with systemd-nspawn
* [`721b6efa`](https://github.com/NixOS/nixpkgs/commit/721b6efa57eaa5e935f48022c87c2670fe4dd42a) python310Packages.prefixed: 0.5.0 -> 0.6.0
* [`2bb560b3`](https://github.com/NixOS/nixpkgs/commit/2bb560b3672cea2fb9eef9f0d4c063cadcf9b368) gmrender-resurrect: Add gmediarender service
* [`18174bdf`](https://github.com/NixOS/nixpkgs/commit/18174bdf86fb3cec34cc7654525cfb9e3f819cd6) cargo-generate: 0.17.4 -> 0.17.5
* [`2de90e2e`](https://github.com/NixOS/nixpkgs/commit/2de90e2e841f15ed1ee7556a36d2fbb6dae540d4) umurmur: fix build with openssl_3
* [`7c1096ab`](https://github.com/NixOS/nixpkgs/commit/7c1096ab995f8a75b794b1f4ac841ea6caa7a120) rsync: fix build with musl
* [`f46ee73b`](https://github.com/NixOS/nixpkgs/commit/f46ee73ba6851e458dedc78e3f0fe2c6eb099697) dracut: init at 059
* [`5a01086b`](https://github.com/NixOS/nixpkgs/commit/5a01086b121e9cd57d3e818e752372ca9bd6782d) eaglemode: restore build & install hooks, add .desktop file
* [`c9e98331`](https://github.com/NixOS/nixpkgs/commit/c9e983314c4036aad2922ebb443ebd6b36f5e88e) couchdb: 3.2.2 -> 3.3.1
* [`fee3da68`](https://github.com/NixOS/nixpkgs/commit/fee3da6847d29581f50a0be7094ca14625a634f6) erlang: set version as latest
* [`9b8d8f91`](https://github.com/NixOS/nixpkgs/commit/9b8d8f91db13946c71a3e4aa55da815f37a7b141) ejabberd: pin erlang to erlangR24
* [`163dc393`](https://github.com/NixOS/nixpkgs/commit/163dc3937965c9f771e4e4282ebd20a6dfe69195) erlang-ls: fix test for erlangR25+
* [`add94b83`](https://github.com/NixOS/nixpkgs/commit/add94b83b14a18f6178123d1ba8e6b6396fbea0a) kappanhang: restrict platforms to linux-only
* [`2a1b43ef`](https://github.com/NixOS/nixpkgs/commit/2a1b43ef285dd426fbd0689e56640a90fc4b1546) octoprint: fix build by relaxing constrain
* [`a181c29f`](https://github.com/NixOS/nixpkgs/commit/a181c29f9189ff421c2757524bed20cfb9f5e3ad) nagelfar: init at 1.3.3
* [`8e35002b`](https://github.com/NixOS/nixpkgs/commit/8e35002bc2be4e76d6056d35b3932b4fd9bcdc77) make-bootstrap-tools.nix: don't pull in pkgs.glibc in test ([nixos/nixpkgs⁠#210038](https://togithub.com/nixos/nixpkgs/issues/210038))
* [`943c7599`](https://github.com/NixOS/nixpkgs/commit/943c7599abad6d7ea076f89fd1f49c88cf3649d3) python310Packages.py-sonic: 0.7.9 -> 0.8.0
* [`eaec6380`](https://github.com/NixOS/nixpkgs/commit/eaec6380804bab7700fb56df4d3b5bd4881e6e69) pgadmin: fix build
* [`497c7f26`](https://github.com/NixOS/nixpkgs/commit/497c7f26aaf93a2f97d8d47b30f8416ddef8473f) socat: 1.7.4.3 -> 1.7.4.4
* [`3a150b75`](https://github.com/NixOS/nixpkgs/commit/3a150b7562fa255164cc1bc0344bb664a1b4485d) kitty: unbreak on `x86_64-darwin`
* [`c47f38e9`](https://github.com/NixOS/nixpkgs/commit/c47f38e91e802fce495b043cd559f4d630fa6f10) python310Packages.pontos: 23.1.0 -> 23.1.1
* [`67548d60`](https://github.com/NixOS/nixpkgs/commit/67548d607d6ae5cc1b716e5da12de63dc0d85f30) ocaml-ng.ocamlPackages_4_0[2-5].ocaml: unbreak on aarch64-linux
* [`fe91cc49`](https://github.com/NixOS/nixpkgs/commit/fe91cc497de796c8f21711d4ae3239e20ab76823) dot-http: remove at 0.2.0
* [`05a0da1b`](https://github.com/NixOS/nixpkgs/commit/05a0da1bc71211130a47e799a5b00ca18ac13625) firefox-unwrapped: 108.0.2 -> 109.0
* [`30320396`](https://github.com/NixOS/nixpkgs/commit/30320396f12db1bfbe6e25579f09977f2dbfca11) firefox-bin-unwrapped: 108.0.2 -> 109.0
* [`5cd6108b`](https://github.com/NixOS/nixpkgs/commit/5cd6108b145d2d131f179327bc3484b46718ba98) firefox-esr-unwrapped: 102.6.0esr -> 102.7.0esr
* [`ca3e08f3`](https://github.com/NixOS/nixpkgs/commit/ca3e08f3bc94546044cfa68da350687d50c71d31) python3.pkgs.sphinxcontrib-openapi: switch back to upstream
* [`96ec8c76`](https://github.com/NixOS/nixpkgs/commit/96ec8c7623f35840fbbcd1ee6581cfc73b059530) nixos/documentation.man.mandb: Add skipPackages option, and include nixos-version
* [`3f0acfda`](https://github.com/NixOS/nixpkgs/commit/3f0acfdab32500384fdd06a2f6f9da69ed560286) SDL_gfx: propagate SDL to -dev outputs
* [`eb37ec00`](https://github.com/NixOS/nixpkgs/commit/eb37ec00ff77bda495fd2d2f8e4580a3f59a909f) gnome-epub-thumbnailer: init at 1.7
* [`e24b481e`](https://github.com/NixOS/nixpkgs/commit/e24b481e0a29f76d53c9962a48b2ab4a88498f00) svtplay-dl: 4.17 -> 4.18
* [`87a0c949`](https://github.com/NixOS/nixpkgs/commit/87a0c9490d0c97f1dd40454b47a416d7477320ff) nixos/swap: fix creation on BTRFS and refactor assertions
* [`eecb6c2b`](https://github.com/NixOS/nixpkgs/commit/eecb6c2bd82e7b2db3cc91c2cd0fbeddaa78eced) nixos/tests/swap-file-btrfs: init
* [`af89d3a2`](https://github.com/NixOS/nixpkgs/commit/af89d3a2be6f70edb187dd817377d6c4360134fa) 78 fonts: Fix build after [nixos/nixpkgs⁠#173430](https://togithub.com/nixos/nixpkgs/issues/173430) changed postFetch semantics
* [`5b93a22d`](https://github.com/NixOS/nixpkgs/commit/5b93a22d90d649fd6a01f5a95c0a412242247aec) Update pkgs/development/libraries/SDL_gfx/default.nix
* [`eef1f709`](https://github.com/NixOS/nixpkgs/commit/eef1f70919005ee80f396b546a56351fe0ad8fe3) nixos/wiki-js: Add git and openssh to enable git backups.
* [`33b2ad57`](https://github.com/NixOS/nixpkgs/commit/33b2ad57c889f706b753932062d6392f57558500) openiscsi: 2.1.7 -> 2.1.8
* [`2dedd1b7`](https://github.com/NixOS/nixpkgs/commit/2dedd1b74305b00b7bf9a1c25789a569b9dba2e1) gsmartcontrol: 1.1.3 -> 1.1.4
* [`c93ba40e`](https://github.com/NixOS/nixpkgs/commit/c93ba40e1cab61209fca5731be7359008753d050) python310Packages.whois: 0.9.22 -> 0.9.23
* [`a862d893`](https://github.com/NixOS/nixpkgs/commit/a862d89303f2bbc72d1aa0b54bbbfc4e51e9974e) julia_18-bin: add darwin support
* [`751c42b6`](https://github.com/NixOS/nixpkgs/commit/751c42b62b7d9d01171832dc4f7fd5977bc3d649) pagsuite: fetchzip -> fetchurl
* [`e8efcbac`](https://github.com/NixOS/nixpkgs/commit/e8efcbaca7cbb9103b4d8cb573cd0a6eaaa991b7) kodi: properly wrap kodi-send binary
* [`f5cbe5d8`](https://github.com/NixOS/nixpkgs/commit/f5cbe5d8032b9b39bbe38761e2d9eadf7d25c4ae) libunwind: broaden platforms
* [`cbb71553`](https://github.com/NixOS/nixpkgs/commit/cbb715535fe7e5b7d9874cd26e0dc6a454cc94b9) cinnamon.cinnamon-common: 5.6.6 -> 5.6.7
* [`76b15840`](https://github.com/NixOS/nixpkgs/commit/76b158404e1034ffcb9f1fc4c63ecac9bc242d83) rabbitmq-server: 3.10.8 -> 3.11.6
* [`988c7c16`](https://github.com/NixOS/nixpkgs/commit/988c7c162354c2c371586d8a5d1f7143ed01cbe9) gpick: 0.2.6 -> 0.3
* [`802c7a0c`](https://github.com/NixOS/nixpkgs/commit/802c7a0cafcef59b45b7fd7c2ebd960816245347) gtkspell2: Build with enchant2
* [`7e0a72ca`](https://github.com/NixOS/nixpkgs/commit/7e0a72ca9f2d93cbaf3995eba4bc813f4c19afbc) ruff: 0.0.223 -> 0.0.224
* [`899a0d04`](https://github.com/NixOS/nixpkgs/commit/899a0d045ed2576d64cafeed9b171ca300fda690) python310Packages.gtts: 2.3.0 -> 2.3.1
* [`34f5e5ea`](https://github.com/NixOS/nixpkgs/commit/34f5e5ea791a55e68f95494df943f4484f8d3ff0) resholve: 0.8.4 -> 0.8.5; update README
* [`c53db95d`](https://github.com/NixOS/nixpkgs/commit/c53db95d253182b6d3c160ad18ce8aeb73fdb786) mir: init at 2.11.0
* [`820f9e49`](https://github.com/NixOS/nixpkgs/commit/820f9e49d157dfdbfeda8f46c2a4ec311d6f0cee) terraform-providers.mongodbatlas: 1.6.1 → 1.7.0
* [`33effca7`](https://github.com/NixOS/nixpkgs/commit/33effca71a42bb12df53a886ca9662bf3c9a670f) terraform-providers.spotinst: 1.91.0 → 1.92.0
* [`c8976c70`](https://github.com/NixOS/nixpkgs/commit/c8976c70ff5ae8734c9df456718cfe00c69a0381) terraform-providers.ucloud: 1.33.0 → 1.34.0
* [`aca10100`](https://github.com/NixOS/nixpkgs/commit/aca101006cb1ab2cf31c54c5edcf40421c02c279) python310Packages.robotframework: 6.0.1 -> 6.0.2
* [`608528af`](https://github.com/NixOS/nixpkgs/commit/608528afe6cde19f8aad7aa7308d027b16131994) libvirt: 8.10.0 -> 9.0.0
* [`9f911f6e`](https://github.com/NixOS/nixpkgs/commit/9f911f6e80055340957d8bc3770a4d1ef15443dd) python310Packages.jaraco-test: add changelog to meta
* [`cfe94040`](https://github.com/NixOS/nixpkgs/commit/cfe940406eedcb9827a461f94083688dfacb2978) python310Packages.txaio: add changelog to meta
* [`73ca9d5f`](https://github.com/NixOS/nixpkgs/commit/73ca9d5f201110a91c92d5592f59f6904582f6dc) python310Packages.txaio: 22.2.1 -> 23.1.1
* [`c52ffef3`](https://github.com/NixOS/nixpkgs/commit/c52ffef313daddf0ed331fd37b04f6a295a39e67) python310Packages.xkbcommon: 0.4 -> 0.8
* [`a51aa50d`](https://github.com/NixOS/nixpkgs/commit/a51aa50dfc36404b8f9ea1571f9798df444efaea) python310Packages.myfitnesspal: 2.0.0 -> 2.0.1
* [`c6d416c1`](https://github.com/NixOS/nixpkgs/commit/c6d416c1e360363e0317e1a93938c9f1d375966f) python310Packages.eth-typing: add changelog to meta
* [`81aef233`](https://github.com/NixOS/nixpkgs/commit/81aef2338a3834f4d0071978dbc114497ec56a7e) ocamlPackages.tls: 0.15.3 → 0.15.4
* [`5c78e494`](https://github.com/NixOS/nixpkgs/commit/5c78e494a8c5d3b6601b20ffd8a61dd9186966a3) pythonPackages.nbxmpp: 4.0.0 → 4.0.1
* [`5b2b0866`](https://github.com/NixOS/nixpkgs/commit/5b2b0866d059739c2e2a5df7e9bcd75a533fd421) gajim: 1.6.0 → 1.6.1
* [`7f2e083d`](https://github.com/NixOS/nixpkgs/commit/7f2e083d7a1cde20571cadd9a5a7e89d13d5e8bb) python310Packages.eth-typing: 3.1.0 -> 3.2.0
* [`0f9165d8`](https://github.com/NixOS/nixpkgs/commit/0f9165d8b6edc2c079e4f388be06c58d6683d23f) k3s: 1.25.3+k3s1 -> 1.26.0+k3s2
* [`4421a037`](https://github.com/NixOS/nixpkgs/commit/4421a0371ee5aa6e8c76dfd99f25d1ee5887e0c6) n8n: 0.210.2 -> 0.211.1
* [`a2dd61c9`](https://github.com/NixOS/nixpkgs/commit/a2dd61c98fe9c2fb9b85e909e173a4fe5a37435d) python310Packages.azure-synapse-artifacts: 0.14.0 -> 0.15.0
* [`a0766dc4`](https://github.com/NixOS/nixpkgs/commit/a0766dc4042dc577a35e3d99355cb94c5d37f000) python310Packages.google-cloud-secret-manager: 2.14.0 -> 2.15.0
* [`95ceb0ea`](https://github.com/NixOS/nixpkgs/commit/95ceb0ea887725e46977a6e819eeac1e76048699) python310Packages.browser-cookie3: 0.16.3 -> 0.16.5
* [`0bc03fea`](https://github.com/NixOS/nixpkgs/commit/0bc03feabc9674e486de33c4e72a93967e995d2c) python310Packages.azure-mgmt-redhatopenshift: 1.1.0 -> 1.2.0
* [`6efdd8b4`](https://github.com/NixOS/nixpkgs/commit/6efdd8b4835b913105f093d77775da73f9aba9a6) php.extensions.enchant: use enchant2
* [`7305aa4e`](https://github.com/NixOS/nixpkgs/commit/7305aa4e4877d396d3d409766baff79bc8abb764) vscode-utils: expose `toExtensionJson`
* [`49daadf0`](https://github.com/NixOS/nixpkgs/commit/49daadf0235eca9a0f0c057c0e582b5e22a5206e) python3Packages.pygeos: fix version 0.14 build
* [`cd4f1a1d`](https://github.com/NixOS/nixpkgs/commit/cd4f1a1df502f10a8494c5305121b1b9c4d80f63) nixos-install: only mount if root
* [`b77c7389`](https://github.com/NixOS/nixpkgs/commit/b77c7389f24270015737ab0b707efc24681e04f7) snowflake: 2.4.2 -> 2.4.3
* [`ef5f4cfd`](https://github.com/NixOS/nixpkgs/commit/ef5f4cfd2e9ffddcd684a85e40dcfa79ff6fe758) nextcloud24: 24.0.8 -> 24.0.9
* [`ff2fd5b4`](https://github.com/NixOS/nixpkgs/commit/ff2fd5b4d8c5eb8084126b8b10121f8577c3cd8b) nextcloud25: 25.0.2 -> 25.0.3
* [`4a039b67`](https://github.com/NixOS/nixpkgs/commit/4a039b672990d374069d551ee0a551f53c7cb9b4) python310Packages.pytibber: 0.26.8 -> 0.26.9
* [`eba97aa5`](https://github.com/NixOS/nixpkgs/commit/eba97aa5b107bb71791c98520221880cc726ffcf) tinygltf: 2.8.0 -> 2.8.2
* [`bd8533f2`](https://github.com/NixOS/nixpkgs/commit/bd8533f20201b99accaf99d197599fe1176d048e) signaldctl: init at 0.6.1
* [`a52714f6`](https://github.com/NixOS/nixpkgs/commit/a52714f65680a16cad805c362ff24d25a694fad8) python310Packages.dulwich: 0.20.50 -> 0.21.0
* [`34ad8447`](https://github.com/NixOS/nixpkgs/commit/34ad8447c3d8bc4609289ce0d7686491d2a54c38) nixos: systemd: add systemd.user.tmpfiles
* [`eadb6959`](https://github.com/NixOS/nixpkgs/commit/eadb69597733d7ecba20c2620bb22246ce35af72) awscli2: 2.9.13 -> 2.9.15
* [`8ac155a3`](https://github.com/NixOS/nixpkgs/commit/8ac155a3aa1a1387266494e3e11a22d0fbb6b74c) llvmPackages_git: fix cross eval
* [`27bcfe5f`](https://github.com/NixOS/nixpkgs/commit/27bcfe5f6ec6d424bfe1ef5bf818fd85c438fc54) deno: 1.29.3 -> 1.29.4
* [`111ef200`](https://github.com/NixOS/nixpkgs/commit/111ef20009c1faf39819b1dd2a61324cc569b811) python3Packages.pygeos: add changelog to meta
* [`037d524f`](https://github.com/NixOS/nixpkgs/commit/037d524fbd156be73069c0bdf11d37d944a91e7e) python310Packages.browser-cookie3: add changelog to meta
* [`d126d172`](https://github.com/NixOS/nixpkgs/commit/d126d1729872f0b758b198a63a98f8943293951a) cni-plugins: 1.1.1 -> 1.2.0
* [`777af4cd`](https://github.com/NixOS/nixpkgs/commit/777af4cd29b58ef9b78480660796226716280c10) librewolf-unwrapped: 108.0.2-1 -> 109.0-1
* [`d0c5054f`](https://github.com/NixOS/nixpkgs/commit/d0c5054f9193f74c86f9c6337c25ee9c84cc8f91) hugo: 0.109.0 -> 0.110.0
* [`159f042d`](https://github.com/NixOS/nixpkgs/commit/159f042d3829df0c026bef6c28f1962b0a42b37d) deno: add some simple tests
* [`ec2ccd96`](https://github.com/NixOS/nixpkgs/commit/ec2ccd96fb5ad3c58939704abe4b452978cf8ba5) oh-my-zsh: 2023-01-09 -> 2023-01-17
* [`94645872`](https://github.com/NixOS/nixpkgs/commit/94645872d18ef67e88f8faa817f45588facb2efc) p4c: add myself as maintainer and add changelog
* [`40b624cc`](https://github.com/NixOS/nixpkgs/commit/40b624cc51b2cce1bfe4bc3754f983a20ab37401) arduino-cli: 0.28.0 -> 0.29.0
* [`496db77f`](https://github.com/NixOS/nixpkgs/commit/496db77f2be6f89036fb07652ce0fa52add8bd04) resgate: init at 1.7.5
* [`20cd94c6`](https://github.com/NixOS/nixpkgs/commit/20cd94c6aab39ecd8aabe26fc76fcf38188344c9) arduino-cli: Add meta.changelog
* [`36699e98`](https://github.com/NixOS/nixpkgs/commit/36699e98e417593eb7f90efd5ea87bc517caf413) python3Packages.awkward: 2.0.4 -> 2.0.5 ([nixos/nixpkgs⁠#209498](https://togithub.com/nixos/nixpkgs/issues/209498))
* [`0ac476fa`](https://github.com/NixOS/nixpkgs/commit/0ac476fae0ecd642d9a2d8180b9a601cf0d0b077) libfabric: resort inputs
* [`f928257a`](https://github.com/NixOS/nixpkgs/commit/f928257a857a6a196a7e8ee82b52b8e8fed3a66f) thonny: 4.0.1 -> 4.0.2
* [`e0545dc6`](https://github.com/NixOS/nixpkgs/commit/e0545dc624dfbd34477be4b0b8f0abda61da5be6) python310Packages.ttp: skip failing test
* [`fcc8ff7c`](https://github.com/NixOS/nixpkgs/commit/fcc8ff7cc271c9652623dae2a9fcd1ba49232b57) python3Packages.scikits-odes: 2.6.5 -> 2.7.0
* [`b6b55b60`](https://github.com/NixOS/nixpkgs/commit/b6b55b60a811d7c9a8fe6da917de7e44963bc7f8) firejail: 0.9.70 -> 0.9.72
* [`7cbd8bcb`](https://github.com/NixOS/nixpkgs/commit/7cbd8bcb169758caac086e490d9515bdcb721c42) python310Packages.azure-mgmt-botservice: 1.0.0 -> 2.0.0
* [`45f6453b`](https://github.com/NixOS/nixpkgs/commit/45f6453b678d154486993f9aa4bf664a34aa60f3) starlark: unstable-2022-08-17 -> unstable-2023-01-12
* [`b9b0d326`](https://github.com/NixOS/nixpkgs/commit/b9b0d3260e699de1590077812ffed6f146019ba0) matrix-synapse: 1.74.0 -> 1.75.0
* [`2f994a85`](https://github.com/NixOS/nixpkgs/commit/2f994a85e102d29f603f06c7dc86fce0bb06fe21) qq: remove GTK_IM_MODULE_FILE prefix and add glib to buildInputs to fix input-method not works
* [`9f5fc1ba`](https://github.com/NixOS/nixpkgs/commit/9f5fc1ba37ae05bbe47ae6c1f5d9ed2f03f40306) tidalapi: init at 0.7.0
* [`84850643`](https://github.com/NixOS/nixpkgs/commit/848506435ed8c9111047eb357e0dedb0ac10b798) monado: unstable-2022-05-28 -> unstable-2023-01-14
* [`9b04b1d9`](https://github.com/NixOS/nixpkgs/commit/9b04b1d98b4a05628c414ce8028a84f9a42a3b32) eventstore: 22.6.0 -> 22.10.0
* [`08e378f0`](https://github.com/NixOS/nixpkgs/commit/08e378f0d43d01fc5ee19d52a732a03a82500ba1) buildDotnetModule: proper escaping of disabledTests
* [`f0f2c6be`](https://github.com/NixOS/nixpkgs/commit/f0f2c6bec922104a80764226a38e38c432597030) nixos: systemd: systemd.user.tmpfiles.users add default
* [`679af8b5`](https://github.com/NixOS/nixpkgs/commit/679af8b5724b997699a3d25875ca6396b0376fb9) eris-go: init at 20230114
* [`f851f25b`](https://github.com/NixOS/nixpkgs/commit/f851f25ba8185d4878562c7edfaf43dba41a6e66) cloud-hypervisor: 28.1 -> 29.0
* [`12249923`](https://github.com/NixOS/nixpkgs/commit/122499234b03facb535358e0ed4d95f971413224) shotgun: fix build, add figsoda as a maintainer
* [`08e2d7d1`](https://github.com/NixOS/nixpkgs/commit/08e2d7d1470197cc504c970ef7ddefd45f935194) photoprism: use buildNpmPackage for frontend
* [`c766d9dd`](https://github.com/NixOS/nixpkgs/commit/c766d9dd8dad7f7913dc91afd3b020cc569dc61f) dogdns: fix build, add figsoda as a maintainer
* [`500f3b94`](https://github.com/NixOS/nixpkgs/commit/500f3b94c3f033bf7bd07c0c675b62df8e30828b) mopidy-tidal: init at 0.3.2
* [`bacb53e6`](https://github.com/NixOS/nixpkgs/commit/bacb53e6f9af8e6689d0c311ab090d2e8410146e) xfce.xfce4-screenshooter: 1.10.2 -> 1.10.3
* [`ad10ad95`](https://github.com/NixOS/nixpkgs/commit/ad10ad95192014fc65e339c76dfd4ee52b03c260) tests.kernel-config: fix
* [`44425dc5`](https://github.com/NixOS/nixpkgs/commit/44425dc5ab5dc22559582dfdee1c537630e9b0c9) tests.kernel-config: remove test that wasn't being run
* [`3b1880dd`](https://github.com/NixOS/nixpkgs/commit/3b1880dd14ec2190df87888aad1ea19eb42fde09) kitty: Fix clone-in-kitty not working on bash >= 5.2
* [`2132e1d3`](https://github.com/NixOS/nixpkgs/commit/2132e1d35fbb96217174ef5de3a68de4e55c9b48) yabridge: 4.0.2 -> 5.0.3
* [`29ef9cd1`](https://github.com/NixOS/nixpkgs/commit/29ef9cd1ca2947be5c45cf0c8e9a452e61ee7d9b) pyhon3Packages.deal: fix build by disabling test
* [`40197595`](https://github.com/NixOS/nixpkgs/commit/40197595ce5f18e36c69a13925679971d5ec20db) test.testers: fix getAllOutputNames not found
* [`b9a3871c`](https://github.com/NixOS/nixpkgs/commit/b9a3871c3dd056906ceb405c38b9871d964d43f8) bwidget: 1.9.14 -> 1.9.16
* [`875a3567`](https://github.com/NixOS/nixpkgs/commit/875a3567e01cf1e438de2015d3fbba475cfb04a7) binaryen: 109 -> 111
* [`275bb9b5`](https://github.com/NixOS/nixpkgs/commit/275bb9b54493a116ed4ad0f7d84861a15fdbda6a) emscripten: backport support for binaryen 111
* [`3f3ca2d9`](https://github.com/NixOS/nixpkgs/commit/3f3ca2d90dba5431f9e573ec04c005c233a8887f) tests.testers.testBuildFailure.helloDoesNotFail: fix confusing output
* [`52c3f58b`](https://github.com/NixOS/nixpkgs/commit/52c3f58bad18601cee8bbef1fe1cb78f5c305c4e) feat: 1.7.1
* [`cc1abe35`](https://github.com/NixOS/nixpkgs/commit/cc1abe35873737270994454f102d1a5212aecf0e) ripasso-cursive: 0.5.2 -> 0.6.2
* [`7ee985e5`](https://github.com/NixOS/nixpkgs/commit/7ee985e5a26c751fc79aad77527e48991bb0d7c6) skalibs: 2.12.0.1 -> 2.13.0.0
* [`2bcc676d`](https://github.com/NixOS/nixpkgs/commit/2bcc676d412baf35f3be374429e7d8a45093f724) execline: 2.9.0.1 -> 2.9.1.0
* [`f6bae8bf`](https://github.com/NixOS/nixpkgs/commit/f6bae8bfd2da1510b9991b862edb60862bd711b0) s6: 2.11.1.2 -> 2.11.2.0
* [`4cbf1d8d`](https://github.com/NixOS/nixpkgs/commit/4cbf1d8dbc4db792ae207a729064a15b36185bc4) nsss: 0.2.0.1 -> 0.2.0.2
* [`550b7f36`](https://github.com/NixOS/nixpkgs/commit/550b7f36fa30500607973033baf0ffee553244ff) utmps: 0.1.2.0 -> 0.1.2.1
* [`737440fa`](https://github.com/NixOS/nixpkgs/commit/737440faeac484d0c65664cfc08494485c097dc1) s6-rc: 0.5.3.2 -> 0.5.3.3
* [`9dc5b78f`](https://github.com/NixOS/nixpkgs/commit/9dc5b78fabb0f1a5da0985c4e31ec0e03ea32ada) s6-linux-init: 1.0.8.0 -> 1.0.8.1
* [`58ba795c`](https://github.com/NixOS/nixpkgs/commit/58ba795c6ed7e2745995d8c8652531961cc84e3f) s6-portable-utils: 2.2.5.0 -> 2.2.5.1
* [`b7ed7391`](https://github.com/NixOS/nixpkgs/commit/b7ed739100e18a50df53c06ec0ac859738779e41) s6-linux-utils: 2.6.0.0 -> 2.6.0.1
* [`8133548d`](https://github.com/NixOS/nixpkgs/commit/8133548de230c41f7640c7295d19665bb43ed54d) s6-dns: 2.3.5.4 -> 2.3.5.5
* [`94fc8c5f`](https://github.com/NixOS/nixpkgs/commit/94fc8c5f30be045b81ec3ef091fc73bd8286127f) s6-networking: 2.5.1.1 -> 2.5.1.2
* [`5c9a5d0b`](https://github.com/NixOS/nixpkgs/commit/5c9a5d0bc316165601cd12d7b98c9f87b642d0d6) mdevd: 0.1.5.2 -> 0.1.6.1
* [`3484f0ba`](https://github.com/NixOS/nixpkgs/commit/3484f0babf32ba9259fd4dce2adb6a7cf89638ae) s6-man-pages: 2.11.1.1.1 -> 2.11.2.0.1
* [`5c33e2aa`](https://github.com/NixOS/nixpkgs/commit/5c33e2aaa9f3dc593735c384ebc8de3235357c89) s6-networking-manpages: 2.5.1.1.1 -> 2.5.1.2.1
* [`915214b0`](https://github.com/NixOS/nixpkgs/commit/915214b03bb59892d5b3f2b3624531d23eeb201f) s6-portable-utils-manpages: 2.2.5.0.1 -> 2.2.5.1.1
* [`3b215117`](https://github.com/NixOS/nixpkgs/commit/3b215117a2ea4350ad8f2ae4cb99bf38c9ed86da) execline: man pages: 2.9.0.0.1 -> 2.9.1.0.1
* [`1d84dbf0`](https://github.com/NixOS/nixpkgs/commit/1d84dbf0824c3b8882456106550513dc5ee2087d) yark: init at 1.2.3
* [`d843eab3`](https://github.com/NixOS/nixpkgs/commit/d843eab3078f53001be3e1eb4460959d00294f45) ArchiSteamFarm: 5.4.0.3 -> 5.4.1.11
* [`f1bb9471`](https://github.com/NixOS/nixpkgs/commit/f1bb94710d436824720b2ad31319e799ac166c8a) iterm2: 3.4.18 → 3.4.19
* [`29dfae7f`](https://github.com/NixOS/nixpkgs/commit/29dfae7f7b1b39bebb654c9af0876f32411a2564) libcue: update homepage
* [`39ca460d`](https://github.com/NixOS/nixpkgs/commit/39ca460d26bef32fe010f49e6a18fb511e060b06) libcue: clarify license
* [`11e5444b`](https://github.com/NixOS/nixpkgs/commit/11e5444ba52b7f4f71c0ef10080fb0cc0a83f57b) libcue: broaden platforms
* [`ba3db3e4`](https://github.com/NixOS/nixpkgs/commit/ba3db3e4733416b9d1a3b08ebfd31bdfc693e7c9) zerotierone: add -lgcc to NIX_LDFLAGS
* [`bf7b3baa`](https://github.com/NixOS/nixpkgs/commit/bf7b3baacdc918deded12334f1a919a1394498b3) gitea: 1.18.0 -> 1.18.1
* [`3597e7e5`](https://github.com/NixOS/nixpkgs/commit/3597e7e518b2a1c8f0ce3a2324e7fab687194f9f) fix(darwin): use sdk 11
* [`f8f49698`](https://github.com/NixOS/nixpkgs/commit/f8f49698283ffa60d35613f375cae89e9d15601d) ugrep: 3.9.4 -> 3.9.5
* [`b6e3185a`](https://github.com/NixOS/nixpkgs/commit/b6e3185a5db5e4e231cbfaf8a500bbb4ce44afd5) miniupnpc: drop obsolete FreeBSD patch
* [`cdd8bd07`](https://github.com/NixOS/nixpkgs/commit/cdd8bd07994bb00d6e08ff26ab71eba03249eec1) fzf: 0.35.1 -> 0.36.0
* [`bc7386de`](https://github.com/NixOS/nixpkgs/commit/bc7386def270088ea11b6f6170bd60d948cd7ce1) liferea: 1.14-RC3 -> 1.14.0
* [`4d49da62`](https://github.com/NixOS/nixpkgs/commit/4d49da629f70db4d11eb4d993685f1a8d9bb5c30) Revert "pythonPackages.nbxmpp: 4.0.0 → 4.0.1; gajim: 1.6.0 → 1.6.1"
* [`64c7c5df`](https://github.com/NixOS/nixpkgs/commit/64c7c5df40f85279cb9f50d0f4b465fb719a97e9) python3Packages.catppuccin: init at 1.1.1
* [`ec57cb61`](https://github.com/NixOS/nixpkgs/commit/ec57cb615bd61f6388455923563a94ec76ba4027) bazel_6: 6.0.0-pre.20220720.3 -> 6.0.0
* [`db0f039c`](https://github.com/NixOS/nixpkgs/commit/db0f039c7904d3762dad7352bb3e539539293a29) the-way: 0.18.0 -> 0.19.0
* [`4376bafd`](https://github.com/NixOS/nixpkgs/commit/4376bafd1e52b738b4d2b5ab136f2d68b969a81c) nuclei: 2.8.6 -> 2.8.7
* [`2e7c15c7`](https://github.com/NixOS/nixpkgs/commit/2e7c15c76fbd4aa74e659e6b0759e224d4d5c467) fcitx5-anthy: init at 5.0.13
* [`415504e8`](https://github.com/NixOS/nixpkgs/commit/415504e8679960580660f220249ce0c2878fe95d) lib/tests/release.nix: Make nix a parameter + strictDeps
* [`d8047358`](https://github.com/NixOS/nixpkgs/commit/d804735878ad86e05cafe6b051c7bf4fafca0991) ursadb: 1.5.0 -> 1.5.1
* [`2d6975e8`](https://github.com/NixOS/nixpkgs/commit/2d6975e8f20cd4efaf5e3757676f7f726f989dd5) step-cli: 0.23.0 -> 0.23.1
* [`86470064`](https://github.com/NixOS/nixpkgs/commit/86470064922b18e7e6245a2e3afe54d6a5409906) rustPlatform.importCargoLock: pass allRefs to builtins.fetchGit ([nixos/nixpkgs⁠#211298](https://togithub.com/nixos/nixpkgs/issues/211298))
* [`867504bf`](https://github.com/NixOS/nixpkgs/commit/867504bff8bcbb1f32f000f40edade1a2a784704) gotestsum: 1.8.2 -> 1.9.0
* [`c8b20e1c`](https://github.com/NixOS/nixpkgs/commit/c8b20e1c4168642f9fc92fb8d7fa465eb7a18c5c) apk-tools: don't pin to openssl_1_1
* [`766b04b1`](https://github.com/NixOS/nixpkgs/commit/766b04b1188922236c95c142836900f64da3c756) datree: 1.8.12 -> 1.8.14
* [`776e0f60`](https://github.com/NixOS/nixpkgs/commit/776e0f600a84eb78d1429a637435fe40fb7755d6) termusic: 0.7.7 -> 0.7.8
* [`c35354ec`](https://github.com/NixOS/nixpkgs/commit/c35354ecb2e821eeab66eb6aafb8829ca1947cb3) yq-go: 4.30.6 -> 4.30.8
* [`e969b9fe`](https://github.com/NixOS/nixpkgs/commit/e969b9fef228b8735cd087163929ecd1fe6c0c31) nixpacks: 1.1.0 -> 1.1.1
* [`3bf0de1e`](https://github.com/NixOS/nixpkgs/commit/3bf0de1ee9f850a00945c3b88eb222e9a07677d7) fastly: 4.6.1 -> 4.6.2
* [`4b228435`](https://github.com/NixOS/nixpkgs/commit/4b228435a2e6db87f85799321bc81bed1a80c615) okteto: 2.11.0 -> 2.11.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
