### PR TITLE
niv devenv: update 818abeae -> c5519d64

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "818abeae2dd2f4911839a079e5c8934fee160a60",
-        "sha256": "1g151mc2hm5yr72rq0rbcp7ajbxnyfcsrqvp5gygm77kgf2harny",
+        "rev": "c5519d64b6bbf59be0d37a26a801a2e9430bcb3f",
+        "sha256": "1l6h3p2ax4cf5lvaj81wxj492kcs1dwvj9bc422nnahjawjb38rm",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/818abeae2dd2f4911839a079e5c8934fee160a60.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/c5519d64b6bbf59be0d37a26a801a2e9430bcb3f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@818abeae...c5519d64](https://github.com/cachix/devenv/compare/818abeae2dd2f4911839a079e5c8934fee160a60...c5519d64b6bbf59be0d37a26a801a2e9430bcb3f)

* [`778acc77`](https://github.com/cachix/devenv/commit/778acc77fd8b51e7bf5e076fc1d9d91a0450140f) languages/python: add virtual environment option
* [`2e7b5d18`](https://github.com/cachix/devenv/commit/2e7b5d184c451cdc6cbc4a3a83077aa6ad265634) hostctl: init module
* [`d5380dee`](https://github.com/cachix/devenv/commit/d5380dee56a9a62860e56afbe87995669ec5245e) hostctl: remove options prefix
* [`2e473b3f`](https://github.com/cachix/devenv/commit/2e473b3f487f820cb3c5a72cb311f079a25ac1f0) hostctl: set a unique profile name
* [`a072c3a9`](https://github.com/cachix/devenv/commit/a072c3a96829bd087cbc55fb6a9974f2aac05419) add beforeUp and afterUp
* [`7ddbf58d`](https://github.com/cachix/devenv/commit/7ddbf58d822761e9e07619c0279e8aded9c5410c) hostctl: rename option
* [`1f575614`](https://github.com/cachix/devenv/commit/1f575614f47997a0e9390dbfda1a5feaba87d73e) Update src/modules/integrations/hostctl.nix
* [`23f28bec`](https://github.com/cachix/devenv/commit/23f28becabcf6f333f68f63044cf50785169a159) Update hostctl.nix
* [`0960585a`](https://github.com/cachix/devenv/commit/0960585a7221e6ede718cc9a2c2eade7ce75c229) Auto generate docs/reference/options.md
* [`4054e137`](https://github.com/cachix/devenv/commit/4054e137f9af4514b1fb0d79fa18634c922cc647) services/minio: add ensureBuckets
* [`91fa7d31`](https://github.com/cachix/devenv/commit/91fa7d31ff642189989a765bccf1b8f7a7948572) services/minio: rename option
* [`f011145d`](https://github.com/cachix/devenv/commit/f011145d04c70d563b83e0b1f70d6c3fcf146a28) Auto generate docs/reference/options.md
* [`36f07b03`](https://github.com/cachix/devenv/commit/36f07b03d4818fa6362f02554d2efe2b8374db76) allow flakes to be used for imports
* [`02737dd5`](https://github.com/cachix/devenv/commit/02737dd5cb9084ce86115bab5511ffa1e4a54c6f) build pull requests also for aarch64-darwin
* [`433324c4`](https://github.com/cachix/devenv/commit/433324c452ca81d05ad8399cbaec6b29abdc6f21) 22.05 -> 22.11
* [`22c4765d`](https://github.com/cachix/devenv/commit/22c4765d832b293d51abde2bfc06710d4dc3520b) languages/python: only create venv if not exist
* [`b6c6d576`](https://github.com/cachix/devenv/commit/b6c6d5761ba74aee92317a0d6cb8999195157952) scala: allow picking the scala base and override jre
* [`6bb95f8e`](https://github.com/cachix/devenv/commit/6bb95f8ea0c2d5e84b4bc82f09d3cd49afd926df) Auto generate docs/reference/options.md
* [`7c5a989f`](https://github.com/cachix/devenv/commit/7c5a989fb3dfd15a609d701a222d7f3ed1c2f1aa) Auto generate docs/reference/options.md
* [`d791e69e`](https://github.com/cachix/devenv/commit/d791e69ebd232b03f3188e423e7837156770505d) docs: add github actions snippet
* [`6020f138`](https://github.com/cachix/devenv/commit/6020f13802f73425c54180081a4845013f033546) typo
* [`e1590f78`](https://github.com/cachix/devenv/commit/e1590f7826ab96702a492aba19eb03433e99e7c9) scala: make scala-cli optional if jdk is too old
* [`8bc83de4`](https://github.com/cachix/devenv/commit/8bc83de411910ec5ed9759f8478c49639326e5f0) processes: quote env vars
* [`e68fc676`](https://github.com/cachix/devenv/commit/e68fc67662890375d10f64f08820eddf9901be1d) User can specify SQL to run during initialization
* [`c5519d64`](https://github.com/cachix/devenv/commit/c5519d64b6bbf59be0d37a26a801a2e9430bcb3f) Auto generate docs/reference/options.md
