### PR TITLE
niv powerlevel10k: update a066b55f -> 0adbc141

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "a066b55f855c8e488d3ea9e26e861bdd5ecd4fe8",
-        "sha256": "0i0k5sk15ad8xldfnn49jkqj058x7fg0k6x1czlc62gsd1nz02ky",
+        "rev": "0adbc1415bf1bad46a7fd111b39640d995294dad",
+        "sha256": "0i2f7442gndr1zg289zkyf3b9540hcypapz03xkzh8l7ap4i0207",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/a066b55f855c8e488d3ea9e26e861bdd5ecd4fe8.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/0adbc1415bf1bad46a7fd111b39640d995294dad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@a066b55f...0adbc141](https://github.com/romkatv/powerlevel10k/compare/a066b55f855c8e488d3ea9e26e861bdd5ecd4fe8...0adbc1415bf1bad46a7fd111b39640d995294dad)

* [`d1b89dd3`](https://github.com/romkatv/powerlevel10k/commit/d1b89dd3813fca823afef323101faf71a9840d36) Update README.md
* [`b165fec0`](https://github.com/romkatv/powerlevel10k/commit/b165fec0ed971fc54c47a746eb15454c8c808eb6) Add AWS partitions support to EKS kubernetes cluster names
* [`21e89cb6`](https://github.com/romkatv/powerlevel10k/commit/21e89cb61d9ed240c1ddf6dd09ce306e7c9cf437) bust caches
* [`f03d917f`](https://github.com/romkatv/powerlevel10k/commit/f03d917fb0842e412748f284afba093aaeb01fc9) fix network interface detection on macos ([romkatv/powerlevel10k⁠#2170](https://togithub.com/romkatv/powerlevel10k/issues/2170))
* [`0adbc141`](https://github.com/romkatv/powerlevel10k/commit/0adbc1415bf1bad46a7fd111b39640d995294dad) fix a silly bug introduced in the last commit ([romkatv/powerlevel10k⁠#2170](https://togithub.com/romkatv/powerlevel10k/issues/2170))
