### PR TITLE
niv zsh-completions: update 1204f451 -> dd686f35

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "1204f45161b0e53a275f6226d0cfbc71c176ad38",
-        "sha256": "16aq5y38rba1lh9261435pl9qh1virldm51kz4bx24yqb5mpy1sg",
+        "rev": "dd686f35d1314f9cfcf20fa13ac7bb33b1d424e1",
+        "sha256": "1pra64610k0a7g4m6sfrpa6rihs1y95qg3l2pvvkvsxqjlyydqij",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/1204f45161b0e53a275f6226d0cfbc71c176ad38.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/dd686f35d1314f9cfcf20fa13ac7bb33b1d424e1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@1204f451...dd686f35](https://github.com/zsh-users/zsh-completions/compare/1204f45161b0e53a275f6226d0cfbc71c176ad38...dd686f35d1314f9cfcf20fa13ac7bb33b1d424e1)

* [`865fd86d`](https://github.com/zsh-users/zsh-completions/commit/865fd86d2ea724e5065d62b1ef3cf17995e3404f) add phx.gen.auth
