### PR TITLE
niv nixpkgs: update 9d801f40 -> 8afc5921

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d801f40e6f7a46fe47204547cd286ba20f354dc",
-        "sha256": "1g80dwgzpib8fja7zz4scvqlyas1wr3bds4l9hqhiqjq5k7k937k",
+        "rev": "8afc5921f9efd3621c828949ae8741559fedb4e9",
+        "sha256": "119hpja8r4v24zxwiscssl9ylrsqcglp5q4nrbxqpjwjsnhhx6mb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/9d801f40e6f7a46fe47204547cd286ba20f354dc.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8afc5921f9efd3621c828949ae8741559fedb4e9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@9d801f40...8afc5921](https://github.com/nixos/nixpkgs/compare/9d801f40e6f7a46fe47204547cd286ba20f354dc...8afc5921f9efd3621c828949ae8741559fedb4e9)

* [`b57e7944`](https://github.com/NixOS/nixpkgs/commit/b57e7944b8bbe7ee6b136efcd97c10d74b052a36) transcribe: install icon, desktop and mime types
* [`c49a70ff`](https://github.com/NixOS/nixpkgs/commit/c49a70ffff40a59997c05658e2dc4cba2e4e2d3c) ocamlPackages.ctypes: 0.20.0 -> 0.20.1
* [`10429e43`](https://github.com/NixOS/nixpkgs/commit/10429e4328f9b0c2bdce151eff63ef5e41b5eb98) potreeconverter: init at unstable-2022-08-04
* [`9aa9450e`](https://github.com/NixOS/nixpkgs/commit/9aa9450e4ca99a855966aa460eeb8fbc17f7299f) sm64ex-coop: 0.pre+date=2022-05-14 -> 0.pre+date=2022-08-05, cleanup
* [`9044d9d0`](https://github.com/NixOS/nixpkgs/commit/9044d9d00f4000eee3a5195916ac8228c11f97b6) qv2ray: 2.7.0 -> unstable-2022-09-25
* [`4c65cfcf`](https://github.com/NixOS/nixpkgs/commit/4c65cfcf285e25a6d96925b0ec07b0457537bf59) ksmbd-tools: 3.4.5 -> 3.4.6
* [`59957c54`](https://github.com/NixOS/nixpkgs/commit/59957c54b45bde06a179b9a596d003c50bec88f2) mavproxy: 1.8.57 -> 1.8.59
* [`5386e774`](https://github.com/NixOS/nixpkgs/commit/5386e77490c31c67a49a3395b0a3e3d18369a4a7) tvm: 0.9.0 -> 0.10.0
* [`beb95747`](https://github.com/NixOS/nixpkgs/commit/beb95747bb40edcaefdbdcbab9d1c353076e475b) fulcio: 0.6.0 -> 1.0.0
* [`018c1658`](https://github.com/NixOS/nixpkgs/commit/018c1658d0700dedc883d376c3a626f1849d97fa) starboard: 0.15.10 -> 0.15.11
* [`2b433fd3`](https://github.com/NixOS/nixpkgs/commit/2b433fd380cf9e7264d450220c38c731f18c2a9d) ceph-csi: 3.7.1 -> 3.7.2
* [`e0532dd8`](https://github.com/NixOS/nixpkgs/commit/e0532dd87c099ddfe20c53c8a2bc860ab6f90355) ocamlPackages.carton: Tests require getconf
* [`b7b567d3`](https://github.com/NixOS/nixpkgs/commit/b7b567d302cf63339220dcd784971161d7a47cf5) sharedown: 5.0.2 -> 5.1.0
* [`358b3e70`](https://github.com/NixOS/nixpkgs/commit/358b3e70b3c5dbef80c1a6b44d8dccdafa947552) levant: 0.3.1 -> 0.3.2
* [`9898a043`](https://github.com/NixOS/nixpkgs/commit/9898a043196f1bc6ecc671a8bb1768e0ee636e8d) xmrig-mo: 6.18.0-mo1 -> 6.18.1-mo1
* [`f043865f`](https://github.com/NixOS/nixpkgs/commit/f043865fc3bd5a65df0637150d6af4a7cd172bef) ddnet: 16.4 -> 16.5
* [`9c89d9e1`](https://github.com/NixOS/nixpkgs/commit/9c89d9e1fe8d32c2f91c75e9ae3f75da322b125c) ddnet: remove unneeded cmakeFlags
* [`e62ea07d`](https://github.com/NixOS/nixpkgs/commit/e62ea07dfe3961c33f2cf60f6614de6f9b9b537d) igmpproxy: 0.3 -> 0.4
* [`3a97df3b`](https://github.com/NixOS/nixpkgs/commit/3a97df3b573371a9824594fa7a6d52c81be286ec) proxmark3-rrg: 4.14831 -> 4.15864
* [`18bdd5dd`](https://github.com/NixOS/nixpkgs/commit/18bdd5ddbc1496d5cc525e9883ce3a76e31030cd) maintainers: add pongo1231
* [`dd9d6a0d`](https://github.com/NixOS/nixpkgs/commit/dd9d6a0dc91e8d1463dfd34cf587a741bf5520b5) duo-unix: 1.12.1 -> 2.0.0
* [`5f8fd0ae`](https://github.com/NixOS/nixpkgs/commit/5f8fd0aee5207707ee693952bd016afe161eec51) guile-sdl2: 0.7.0 -> 0.8.0
* [`af07c21e`](https://github.com/NixOS/nixpkgs/commit/af07c21e647eb3db2ace1c0f3fa7f8f27c7dd711) goa: 3.10.0 -> 3.10.2
* [`04576575`](https://github.com/NixOS/nixpkgs/commit/04576575657eeb14fb29451ca31ee88afc81d81d) libwhich: 1.1.0 -> 1.2.0
* [`947aab9c`](https://github.com/NixOS/nixpkgs/commit/947aab9cbd63bfb59f129c24f54339cf3b931697) vcluster: 0.12.2 -> 0.12.3
* [`9b58e5e7`](https://github.com/NixOS/nixpkgs/commit/9b58e5e7732ffe3f6904d5540dbd4d87622102db) xl2tpd: 1.3.17 -> 1.3.18
* [`7ec4378b`](https://github.com/NixOS/nixpkgs/commit/7ec4378b73ff742bbe1e930a24cb47f7b7e1d5f2) gretl: 2022b -> 2022c
* [`7c4d5c3e`](https://github.com/NixOS/nixpkgs/commit/7c4d5c3e35839fc2f69fb8f73745bc80daf6bd88) matterircd: 0.25.1 -> 0.26.1
* [`d77a5816`](https://github.com/NixOS/nixpkgs/commit/d77a58165e09f2ef8d5578ce837c12ddb0120ab5) lyra: 1.6 -> 1.6.1
* [`6660854a`](https://github.com/NixOS/nixpkgs/commit/6660854ac93a2d9aeccd1e03e6c489fc77005a5f) convimg: 8.10.2 -> 9.0
* [`8ad4b1c6`](https://github.com/NixOS/nixpkgs/commit/8ad4b1c66cc99eb570ede29bbe9a9ce78a7728d2) mmc-utils: unstable-2022-09-27 -> unstable-2022-11-09
* [`3743e020`](https://github.com/NixOS/nixpkgs/commit/3743e020d17c5c98c125a84fd865dc07e83e0da8) flex-ncat: 0.1-20221007.1 -> 0.1-20221109.1
* [`d61793a3`](https://github.com/NixOS/nixpkgs/commit/d61793a3d70ec2318dc2b8ce93cb22f9ca90302b) confluent-platform: 7.2.1 -> 7.3.0
* [`c13a9ce2`](https://github.com/NixOS/nixpkgs/commit/c13a9ce21842a18052de7954a0c11086033203c5) headphones: 0.6.0-beta.5 -> 0.6.0
* [`da4686fe`](https://github.com/NixOS/nixpkgs/commit/da4686fe49d451d62058f560b65f1480b65b29bc) writefreely: 0.13.1 -> 0.13.2
* [`3b07d6b7`](https://github.com/NixOS/nixpkgs/commit/3b07d6b7280ddbd3b20236370de021b025488a69) alembic: 1.8.3 -> 1.8.4
* [`899d0b6b`](https://github.com/NixOS/nixpkgs/commit/899d0b6b09f0cb4b5b4c3ed897b5f485ae5d1459) chafa: 1.12.3 -> 1.12.4
* [`c58a3b82`](https://github.com/NixOS/nixpkgs/commit/c58a3b82cfc0c2dfbde67471dd9f14b720a20e9e) p3x-onenote: 2020.10.111 -> 2022.10.117
* [`c03413b1`](https://github.com/NixOS/nixpkgs/commit/c03413b11d26cb235958bf18cdfc1d736e8fabf3) ablog: 0.10.29 -> 0.10.33
* [`0c621bc4`](https://github.com/NixOS/nixpkgs/commit/0c621bc41b0e44570235bcf88673bff77752a466) linode-cli: 5.25.0 -> 5.26.1
* [`1c76a4a9`](https://github.com/NixOS/nixpkgs/commit/1c76a4a915de8c92261afa968c218279bcea35dd) sasutils: 0.3.12 -> 0.3.13
* [`e95eaa95`](https://github.com/NixOS/nixpkgs/commit/e95eaa9583b3ae8df48e6834aae2a018731a2baf) clight: 4.8 -> 4.9
* [`357d12c3`](https://github.com/NixOS/nixpkgs/commit/357d12c3376801f1ff64872daf89491c43c669bd) clightd: 5.6 -> 5.7
* [`c648280b`](https://github.com/NixOS/nixpkgs/commit/c648280b674c83b014a5f7363eba27956a9a27d3) python3Packages.pywick: mark broken due to missing dependencies
* [`2be34138`](https://github.com/NixOS/nixpkgs/commit/2be34138b7ea3ec8c1e604bc6dded069425d3014) system76-keyboard-configurator: 1.2.0 -> 1.3.0
* [`6399ed7b`](https://github.com/NixOS/nixpkgs/commit/6399ed7b5540d8bfe8f6035ddd554924bb35709f) tsduck: disable tests failing in sandbox
* [`5aaf1c28`](https://github.com/NixOS/nixpkgs/commit/5aaf1c286d7328d9497468e39eb192551b336601) apktool: 2.6.1 -> 2.7.0
* [`f797afbc`](https://github.com/NixOS/nixpkgs/commit/f797afbc26ae566604fd210845e8ec34b4c637eb) cider: 1.5.7 -> 1.6.0
* [`ecff9400`](https://github.com/NixOS/nixpkgs/commit/ecff940084427ea47c58c512962259f8a897e441) mautrix-signal: 0.4.1 -> 0.4.2
* [`0683de6b`](https://github.com/NixOS/nixpkgs/commit/0683de6bc3fec1a37b0753981bc923129cf2e3dd) openttd-nml: 0.7.0 -> 0.7.1
* [`3587d688`](https://github.com/NixOS/nixpkgs/commit/3587d6881d59ef58262acada598e0fb1cde0e9ed) imgurbash2: 3.2 -> 3.3
* [`cb01b233`](https://github.com/NixOS/nixpkgs/commit/cb01b2339e6f7d2064e13e81cb85f0a45e8d7df4) ledger2beancount: 2.6 -> 2.7
* [`31ee0083`](https://github.com/NixOS/nixpkgs/commit/31ee0083e056f985724a5109b97c72922524574e) moolticute: 0.55.0 -> 1.00.1
* [`47d8482d`](https://github.com/NixOS/nixpkgs/commit/47d8482d3965aec965177efa717d3799e4bf5940) ryzenadj: 0.11.1 -> 0.12.0
* [`e8c45fa6`](https://github.com/NixOS/nixpkgs/commit/e8c45fa6469579a23c898c65b67cc570d8cf8eab) stellar-core: 19.4.0 -> 19.6.0
* [`70227a2b`](https://github.com/NixOS/nixpkgs/commit/70227a2bc73b65a3f2e095d4f6d80030eea4446d) tilt: 0.30.9 -> 0.30.13
* [`b601531b`](https://github.com/NixOS/nixpkgs/commit/b601531bd5a63aaee240793958753bdbefe3ade8) tofi: 0.7.0 -> 0.8.1
* [`75fcc792`](https://github.com/NixOS/nixpkgs/commit/75fcc792f7c67556d05e3a434547e6fba865ce26) upterm: 0.9.0 -> 0.10.0
* [`f7d7b00d`](https://github.com/NixOS/nixpkgs/commit/f7d7b00db455e1c6caa437e7ac14cd4fad307a35) easeprobe: 1.9.0 -> 2.0.0
* [`b2be70d8`](https://github.com/NixOS/nixpkgs/commit/b2be70d8ecfabbd751b866af6f7624a933a952dc) eventstat: 0.04.13 -> 0.05.00
* [`b2fb7f31`](https://github.com/NixOS/nixpkgs/commit/b2fb7f31e8fe51916502699538a336d3a6a33ff1) matrix-synapse-tools.synadm: 0.37.1 -> 0.38
* [`1dcc1a0d`](https://github.com/NixOS/nixpkgs/commit/1dcc1a0dfa23f0784af50e891697ca4ee2459dc1) norouter: 0.6.4 -> 0.6.5
* [`52c5fa4b`](https://github.com/NixOS/nixpkgs/commit/52c5fa4bd3e2f2b174cc69ef1c40eec9bb9913b5) postfixadmin: 3.3.11 -> 3.3.13
* [`bfd1c45e`](https://github.com/NixOS/nixpkgs/commit/bfd1c45e54bd9823b083c10537cf677462fc2c28) nixos/hardware/device-tree: fix application of overlays
* [`d68f54c1`](https://github.com/NixOS/nixpkgs/commit/d68f54c1473fa3537a9f9d8f5d71cef0c6630681) sssd: 2.8.1 -> 2.8.2
* [`f2f5ecb7`](https://github.com/NixOS/nixpkgs/commit/f2f5ecb76bf72975390130f661768b4d40ad753c) temporalite: 0.2.0 -> 0.3.0
* [`66049fde`](https://github.com/NixOS/nixpkgs/commit/66049fdec2fa1afd9ba2f44acc79d667a13bca03) audiowaveform: 1.6.0 -> 1.7.0
* [`9d04c2cd`](https://github.com/NixOS/nixpkgs/commit/9d04c2cdb03f54a55a500dccb88b0ea412f0afa4) dyncall: 1.3 -> 1.4
* [`8570864b`](https://github.com/NixOS/nixpkgs/commit/8570864ba0b9585a4b36e7e5d091450e72208bd9) python3Packages.jpylyzer: skip test_testfiles by default
* [`feee7e03`](https://github.com/NixOS/nixpkgs/commit/feee7e0357a74ab0510b2d113a3bdede1d509759) trust-dns: init at 0.22.0
* [`82d9fb7d`](https://github.com/NixOS/nixpkgs/commit/82d9fb7d15a819590a07bc5cfa62fd1755500f7f) grandorgue: 3.9.0-1 -> 3.9.4-1
* [`a53b77bf`](https://github.com/NixOS/nixpkgs/commit/a53b77bf60fabb5a86586f396bc7e1a95d10f542) android-tools: 33.0.3p1 -> 33.0.3p2
* [`f969c61a`](https://github.com/NixOS/nixpkgs/commit/f969c61a95e8f390f952ea4b67d15eeb922daaa0) roswell: 22.12.14.112 -> 22.12.14.113
* [`f163ec78`](https://github.com/NixOS/nixpkgs/commit/f163ec78a3dd54cfd69e407dfe016ae053ed9ed5) MIDIVisualizer: 6.5 -> 7.0
* [`77ff6243`](https://github.com/NixOS/nixpkgs/commit/77ff62438226498540dafe681e13cc8ef1551c8c) throttled: 0.9.2 -> 0.10.0
* [`211a27df`](https://github.com/NixOS/nixpkgs/commit/211a27df4b85940be905d53d65c3983d907476d4) linuxPackages.rtl8189es: 2022-08-30 -> 2022-10-30
* [`4f675561`](https://github.com/NixOS/nixpkgs/commit/4f67556113644a04d9b60094bcb396fcbd83cd52) lima: 0.13.0 -> 0.14.1
* [`d499bc24`](https://github.com/NixOS/nixpkgs/commit/d499bc244735c776305ac0658b2539f979313f5f) tandem-aligner: init at unstable-2022-09-17
* [`946dd76d`](https://github.com/NixOS/nixpkgs/commit/946dd76d6ddc4bd1a77c746ff4b85ffe1c1c27ce) ecs-agent: 1.66.2 -> 1.67.2
* [`dc05102a`](https://github.com/NixOS/nixpkgs/commit/dc05102a83562c077518e9758c0f97851b887883) add _output cleaning before build
* [`1a5fda5f`](https://github.com/NixOS/nixpkgs/commit/1a5fda5f2b8dae7917ec323b81ccae92910fdd9e) remove rm, add --force to codesign
* [`470662f5`](https://github.com/NixOS/nixpkgs/commit/470662f51b04519cb0d54eac378d22f3c48668fe) fast-downward: 22.06.1 -> 22.12.0
* [`169f6939`](https://github.com/NixOS/nixpkgs/commit/169f6939cb3b7908065d56547fa1fe057827e3f6) garble: 0.7.2 -> 0.8.0
* [`b8ea81f0`](https://github.com/NixOS/nixpkgs/commit/b8ea81f0baf76d5fc685a522a70c22dee6be4fd2) calls: 43.0 -> 43.2
* [`788a5c31`](https://github.com/NixOS/nixpkgs/commit/788a5c31da627258a538b1d7feee7ba61b666c3b) Combine `substituteInPlace` on `Makefile`
* [`5eee8453`](https://github.com/NixOS/nixpkgs/commit/5eee84537197f12e976d3d38744d88936b3f7bf8) maintainers: add thled
* [`1e72eb27`](https://github.com/NixOS/nixpkgs/commit/1e72eb2712011bdcd7fe75f597c7b54a5643934a) uair: init at 0.4.0
* [`543fe428`](https://github.com/NixOS/nixpkgs/commit/543fe428d29e14055975d1e19f63dc3e4c084f72) davinci-resolve: fix when QT_PLUGIN_PATH already exists in the env
* [`1018df45`](https://github.com/NixOS/nixpkgs/commit/1018df456cc8f031f4c78b65d3971f4ecaef088c) fstar: remove unnecessary store path & build artifacts
* [`33ae410a`](https://github.com/NixOS/nixpkgs/commit/33ae410afa566931c5f86110118f00c4967dda86) virtio_vmmci 0.4.0 -> 0.5.0
* [`5dfd3145`](https://github.com/NixOS/nixpkgs/commit/5dfd314513703b4d127ab56734f93eea2ddbec24) kubelogin: 0.0.24 -> 0.0.25
* [`22cc969c`](https://github.com/NixOS/nixpkgs/commit/22cc969c3164ac732834493cc42d027cfd2cb976) yad: 12.1 -> 12.3
* [`2e299d2a`](https://github.com/NixOS/nixpkgs/commit/2e299d2ae6e14b9d08ff4a4eb0be7ad78077b145) slint-lsp: 0.3.0 -> 0.3.3
* [`c7e56f30`](https://github.com/NixOS/nixpkgs/commit/c7e56f306cf57c16fc6fce0df2243debf4f4dbce) page: 4.4.0 -> 4.6.0
* [`0eb2db21`](https://github.com/NixOS/nixpkgs/commit/0eb2db2162126eae57ec49efa992aed3a148ad5e) python310Packages.flowlogs_reader: 3.2.0 -> 4.0.0
* [`a72c69e4`](https://github.com/NixOS/nixpkgs/commit/a72c69e4ed6966ebbafbacd6eb4e58bdb99003a1) wasabiwallet: 2.0.2 -> 2.0.2.1
* [`d4dc5b1f`](https://github.com/NixOS/nixpkgs/commit/d4dc5b1fff966a38010c28d052cd6732547cce5d) meshcentral: 1.1.0 -> 1.1.2
* [`5659f178`](https://github.com/NixOS/nixpkgs/commit/5659f17812fa53f8ef16f68b1b351cfe2c0b6a3d) sigil: 1.9.10 -> 1.9.20
* [`6d459593`](https://github.com/NixOS/nixpkgs/commit/6d459593981584dd15de4f061b56d35d2d62f577) distrobox: 1.4.1 -> 1.4.2.1
* [`00977f8d`](https://github.com/NixOS/nixpkgs/commit/00977f8dcf4f3ca1eeb6dd918ae99a7004d5b96b) neil: 0.1.45 -> 0.1.47
* [`c5a43a4a`](https://github.com/NixOS/nixpkgs/commit/c5a43a4aa03fdc9196cb2c68ac66ea0db0a5123d) obs-studio-plugins.obs-move-transition: 2.7.1 -> 2.8.0
* [`45703707`](https://github.com/NixOS/nixpkgs/commit/45703707c789ab709213b6851772ad29e480b715) vxl: 3.3.2 -> 3.5.0
* [`64862b65`](https://github.com/NixOS/nixpkgs/commit/64862b650b387d98a0eeb35308211a770bcfdd72) ocamlPackages.optint: 0.2.0 -> 0.3.0
* [`40c87714`](https://github.com/NixOS/nixpkgs/commit/40c877143d4d5a91bd95440253ecc86421cf3092) maintainers: add lorenz
* [`d5d3e334`](https://github.com/NixOS/nixpkgs/commit/d5d3e334ad39522f4edeedd87f064043a4234dea) dolbybcsoftwaredecode: init at april-2018
* [`c87222c7`](https://github.com/NixOS/nixpkgs/commit/c87222c7ea73ba0de302e7c619b03ca071b04c67) dotenv-linter: 3.2.0 -> 3.3.0
* [`5fd24928`](https://github.com/NixOS/nixpkgs/commit/5fd24928adff31d44681d643cb9b5c4f8fc9ea29) ovito: 3.7.7 -> 3.7.11
* [`10276b90`](https://github.com/NixOS/nixpkgs/commit/10276b9037028c9fa047e10c88c5060fb267bf7c) elinks: 0.15.1 -> 0.16.0 (fixes [nixos/nixpkgs⁠#207718](https://togithub.com/nixos/nixpkgs/issues/207718))
* [`a9ef8bb2`](https://github.com/NixOS/nixpkgs/commit/a9ef8bb2925352031df95f76f2e7ec8eff08df3c) leafpad: 0.8.18.1 -> 0.8.19
* [`9344a238`](https://github.com/NixOS/nixpkgs/commit/9344a238f7e0dbbfa5d6e5eb911d273c9343bcce) swagger-codegen3: 3.0.35 -> 3.0.36
* [`5bab98b5`](https://github.com/NixOS/nixpkgs/commit/5bab98b5b1d71c640afd41f3ec47bb0865477acd) simpleitk: 2.1.1.2 -> 2.2.1
* [`545fddfa`](https://github.com/NixOS/nixpkgs/commit/545fddfa45fe137f82938bef37984fb94008f5d2) batsignal: 1.6.2 -> 1.6.4
* [`fa65a5e2`](https://github.com/NixOS/nixpkgs/commit/fa65a5e2a6b2cb42e3d3707a630fb9d1c75a6b50) lima: 0.14.2
* [`65220480`](https://github.com/NixOS/nixpkgs/commit/652204808d4476dbdd0acc6e1210d09feb3b1cf1) hamlib_4: 4.4 -> 4.5.2
* [`7066d039`](https://github.com/NixOS/nixpkgs/commit/7066d039cf1bdcd83c25e0058bf5e63258b96d25) fishPlugins.puffer: init at unstable-2022-10-07
* [`37197dee`](https://github.com/NixOS/nixpkgs/commit/37197dee16f6310502f95a3a47f122af275d70df) bear: 3.0.20 -> 3.0.21
* [`199b12ad`](https://github.com/NixOS/nixpkgs/commit/199b12ad3d69e2445ed2fbd53ad705d5e143e4ef) netpbm: 11.0.2 -> 11.1.0
* [`4153a157`](https://github.com/NixOS/nixpkgs/commit/4153a15706fc0616f5cde0a80b777b33ff23d4a7) kubedb-cli: 0.29.0 -> 0.30.0
* [`bf2aea45`](https://github.com/NixOS/nixpkgs/commit/bf2aea451eec5d963ad6b2e7545603ff443a1563) pgweb: 0.11.12 -> 0.13.1
* [`7cec36f3`](https://github.com/NixOS/nixpkgs/commit/7cec36f3551c27f8270da00ecba696fd5533fa7e) ocamlPackages.cairo2: 0.6.2 -> 0.6.4
* [`b7ebd1f8`](https://github.com/NixOS/nixpkgs/commit/b7ebd1f8972425787e0ba6567f69b9bd7db79356) vanilla-dmz: Expose themes under DMZ-{White,Black} names
* [`66141592`](https://github.com/NixOS/nixpkgs/commit/661415920c027c1f8380744498709520206f81a1) inklecate: 1.0.0 -> 1.1.1
* [`1d56f75f`](https://github.com/NixOS/nixpkgs/commit/1d56f75f94434eb5751275beb7efbf4b3ac39d8c) chatterino2: 2.3.5 -> 2.4.0
* [`8bed6282`](https://github.com/NixOS/nixpkgs/commit/8bed62821cd942d9ff1dbeb0395cba9f6241f1e0) nzbhydra2: 3.14.2 -> 4.7.6
* [`34c3093c`](https://github.com/NixOS/nixpkgs/commit/34c3093c20793e261f6ebef1c4b8a358013670d9) python310Packages.recoll: 1.33.2 -> 1.33.4
* [`1f4feb7c`](https://github.com/NixOS/nixpkgs/commit/1f4feb7c6f2bb7d257e860b2d8413a746fbe50c8) avr-gcc: fix build on Darwin
* [`43876e71`](https://github.com/NixOS/nixpkgs/commit/43876e7128ca0228bf1e270fdfd6fda5a6ed4de3) eiciel: 0.10.0-rc2 -> 0.10.0
* [`b8abee82`](https://github.com/NixOS/nixpkgs/commit/b8abee82d678064c0fe50b94f08ab143c4a19e07) evmdis: 2018-03-23 -> unstable-2022-05-09
* [`89bdfaa0`](https://github.com/NixOS/nixpkgs/commit/89bdfaa08cd1ebd6892841d08fe86b87b85029d6) rose-pine-gtk: unstable-2021-02-22 -> unstable-2022-09-01
* [`f18cbacc`](https://github.com/NixOS/nixpkgs/commit/f18cbacce4909f4726ecf52deae3efe0fc797edb) maintainers: add the-argus
* [`0d1d1250`](https://github.com/NixOS/nixpkgs/commit/0d1d1250338f28da06b21aada80f6f734d2e99c2) rose-pine-gtk: add the-argus as a maintainer
* [`99a82dd3`](https://github.com/NixOS/nixpkgs/commit/99a82dd360635933294b9b1b09106983b3d284f9) rose-pine-gtk: format
* [`6043e3af`](https://github.com/NixOS/nixpkgs/commit/6043e3af4ec34a42d1f45620527eb3081e5b564a) ocamlPackages.findlib: detect conflicts of version early
* [`26fff39e`](https://github.com/NixOS/nixpkgs/commit/26fff39e4f5bd4c4ccde1397aa92532fe4d3f95b) python310Packages.recoll: add changelog to meta
* [`e3055f11`](https://github.com/NixOS/nixpkgs/commit/e3055f11d631fd14a65d248f151974365124ba91) python3Packages.dicom-numpy: init at 0.6.3
* [`1d1ed8fb`](https://github.com/NixOS/nixpkgs/commit/1d1ed8fbb244fe3d242ebd3d2ad4e647235719eb) webcord: init at 4.1.1
* [`b2a8b1a4`](https://github.com/NixOS/nixpkgs/commit/b2a8b1a48cbbd07d1f9ee374765cc76ce89b2fd5) legendary-gl: 0.20.31 -> 0.20.32
* [`a18a6a19`](https://github.com/NixOS/nixpkgs/commit/a18a6a19fa086d92eb6f08192bd8447f674d3088) vttest: 20221111 -> 20221229
* [`6f3fc819`](https://github.com/NixOS/nixpkgs/commit/6f3fc8199aba09a1260afa75987be9599369bcb7) squirrel-sql: 4.4.0 -> 4.5.1
* [`f53e2506`](https://github.com/NixOS/nixpkgs/commit/f53e25064015506788f4d8d54e619e5d536be464) last-resort: 14.000 -> 15.000
* [`1f1eba99`](https://github.com/NixOS/nixpkgs/commit/1f1eba997ef3b5cf752595fc8836107a934fb7ce) openwsman: 2.7.1 -> 2.7.2
* [`7e645125`](https://github.com/NixOS/nixpkgs/commit/7e645125e96d880a8b2f34f8ac4e7acbb5522702) rare: relax legendary-gl
* [`72205463`](https://github.com/NixOS/nixpkgs/commit/722054637aa2834b06fae3fc4d2f48a7019505f9) python39Packages.pyopengl-accelerate: 3.1.5 -> 3.1.6
* [`f0ebe533`](https://github.com/NixOS/nixpkgs/commit/f0ebe533a322bb91cd5a105cee98708e42670b50) mailman-hyperkitty: 1.2.0 -> 1.2.1
* [`0521f301`](https://github.com/NixOS/nixpkgs/commit/0521f3013fe9afb139bbd5c2ef704446bdc57493) tcpreplay: 4.4.2 -> 4.4.3
* [`c70c515e`](https://github.com/NixOS/nixpkgs/commit/c70c515ed1f7f380a4289c2d0471656fb9c8d69e) python310Packages.sphinxext-opengraph: 0.7.4 -> 0.7.5
* [`b12c140d`](https://github.com/NixOS/nixpkgs/commit/b12c140dd98bf47bf3a91007021770f73f5f397b) python310Packages.yattag: 1.14.0 -> 1.15.0
* [`72b82f86`](https://github.com/NixOS/nixpkgs/commit/72b82f86d4bf448c130da5980fd872a02319bd83) backintime: 1.3.2 -> 1.3.3
* [`c6313c6a`](https://github.com/NixOS/nixpkgs/commit/c6313c6a082749f70f5eb83c026960ce8abe25c2) sublime-merge-dev: 2078 -> 2081
* [`029c0a92`](https://github.com/NixOS/nixpkgs/commit/029c0a92881a9c8ca38c58c370f4934e7104aa6a) squeezelite: add gpio support
* [`7dc9a930`](https://github.com/NixOS/nixpkgs/commit/7dc9a9300e94b040f29e5a0f9e741af74bfe5eab) p4c: 1.2.3.2 -> 1.2.3.5
* [`deead5cc`](https://github.com/NixOS/nixpkgs/commit/deead5ccfa24e8f48802414acaaf04beda0f19af) wgnord: init at 0.1.10
* [`c5c910c9`](https://github.com/NixOS/nixpkgs/commit/c5c910c959d492a232997960628e9d8f86abcb4c) remnote: 1.7.6 -> 1.8.52
* [`5d0b499b`](https://github.com/NixOS/nixpkgs/commit/5d0b499bb57e4b60ca62ecd08c3966868c084542) squashfs-tools-ng: 1.1.4 -> 1.2.0
* [`495c294f`](https://github.com/NixOS/nixpkgs/commit/495c294fae28ba842448239eaf4931c20eec17d1) cli11: 2.3.0 -> 2.3.2
* [`cf74134f`](https://github.com/NixOS/nixpkgs/commit/cf74134f1db0381aa680373974bb1991215c37b4) pure-prompt: 1.20.4 -> 1.21.0
* [`1007dac3`](https://github.com/NixOS/nixpkgs/commit/1007dac35f8ec8996cbc8fce36fd218240b79cf4) jftui: 0.6.1 -> 0.6.2
* [`3ca4c0e0`](https://github.com/NixOS/nixpkgs/commit/3ca4c0e0ddec3f82d1ca6455073ee11373ebac54) azpainter: 3.0.4 → 3.0.6
* [`6e13168f`](https://github.com/NixOS/nixpkgs/commit/6e13168f479f7e840a2434dc2e2520c031fa285f) simavr: fix build on Darwin
* [`3592793e`](https://github.com/NixOS/nixpkgs/commit/3592793ebfa628c412f9c3b6bac3a5897a8bfbac) python310Packages.tika: 1.24 -> 2.6.0
* [`212c3f86`](https://github.com/NixOS/nixpkgs/commit/212c3f86d003a5f6dbae0964c9d95d6b4c1a588f) wsmancli: 2.6.0 -> 2.6.2
* [`dae8d901`](https://github.com/NixOS/nixpkgs/commit/dae8d901a554b8edd63d457ff255119f451a4a2a) fluidd: 1.21.1 -> 1.23.0
* [`8bb6cdb1`](https://github.com/NixOS/nixpkgs/commit/8bb6cdb1564ce061ee20a4eb9e7cc426f18f8df3) ceres-solver: 2.0.0 -> 2.1.0
* [`86c35695`](https://github.com/NixOS/nixpkgs/commit/86c356958133f544901078338d884413e97010b0) rtl88xxau-aircrack: 37e27f -> ee2997
* [`a71ea2fb`](https://github.com/NixOS/nixpkgs/commit/a71ea2fbd9b30a115d83751337ff994a144f909c) kuttl: 0.14.0 -> 0.15.0
* [`a402e361`](https://github.com/NixOS/nixpkgs/commit/a402e361364cf5e23ec910775758d37c19d5b246) tartube-yt-dlp: 2.4.093 -> 2.4.221
* [`4f792dce`](https://github.com/NixOS/nixpkgs/commit/4f792dcec48aa06209a5b2c95518eda8d2d53e0d) bisq-desktop: update updater script
* [`2f5f8fdd`](https://github.com/NixOS/nixpkgs/commit/2f5f8fdd1316081a3ba7fe044d065872b838e594) bisq-desktop: 1.9.8 -> 1.9.9
* [`99639b32`](https://github.com/NixOS/nixpkgs/commit/99639b329f0ef67dc531f8858c34006da2cae8ed) circumflex: 2.6 -> 2.8
* [`fd68cf54`](https://github.com/NixOS/nixpkgs/commit/fd68cf5448198e22157a921024123a5e8552a83a) python310Packages.python-vipaccess: 0.14 -> 0.14.1
* [`07584906`](https://github.com/NixOS/nixpkgs/commit/07584906a4342d6d64d758e9bc56b11eb0259a1d) wails: 2.2.0 -> 2.3.1
* [`346b939a`](https://github.com/NixOS/nixpkgs/commit/346b939a095793430d847f9dfc5d136bba982936) lib/licenses add Fair license
* [`7df27f13`](https://github.com/NixOS/nixpkgs/commit/7df27f13ee4177ebd2ee59a7ca89306addbfa63e) maintainers: Add loveisgrief
* [`72d43ddf`](https://github.com/NixOS/nixpkgs/commit/72d43ddf528026416c84a7acf08c2922e9ce1e51) zxfer: init at 1.1.7
* [`3cff1da8`](https://github.com/NixOS/nixpkgs/commit/3cff1da83480ee70413ff2339d56ee9327fc58b1) aaxtomp3: use resholve not PATH
* [`e802b005`](https://github.com/NixOS/nixpkgs/commit/e802b00547cb0038478157e910a0b99fc703698a) dotnet-sdk_7.0: 7.0.101 -> 7.0.102
* [`cac5e045`](https://github.com/NixOS/nixpkgs/commit/cac5e045dc300d630b28396062f7f470ade130d8) cbqn: tie outputs for library to library config option
* [`cde181e8`](https://github.com/NixOS/nixpkgs/commit/cde181e81bfad54ef03721e1e57361c177c816ad) redis-plus-plus: 1.3.5 -> 1.3.7
* [`9f54342b`](https://github.com/NixOS/nixpkgs/commit/9f54342b153d45f7f525acaa187f669e44e8d505) libgbinder: 1.1.26 -> 1.1.31
* [`629ec458`](https://github.com/NixOS/nixpkgs/commit/629ec4589379193bc89a2ab5c874a2fb49cac87e) siril: 1.0.5 -> 1.0.6
* [`ed614a4e`](https://github.com/NixOS/nixpkgs/commit/ed614a4ebccc1bcbea607dd89aa5c21d6f50efd7) papermc: 1.19.2r131 -> 1.19.3r375
* [`0e9cb9fc`](https://github.com/NixOS/nixpkgs/commit/0e9cb9fcfda189bde0cd6bbd47773b5e7b041e3d) nixos/dhcpcd: don't solicit or accept ipv6 router advertisements if use static addresses
* [`4689b731`](https://github.com/NixOS/nixpkgs/commit/4689b731f5f8e8d1236628282ed6c3810d765b74) haskellPackages: stackage LTS 20.5 -> LTS 20.6
* [`4740be3a`](https://github.com/NixOS/nixpkgs/commit/4740be3a886f59d983a994bba0c6cf1afcbc3fb3) all-cabal-hashes: 2023-01-08T15:35:40Z -> 2023-01-12T12:18:29Z
* [`d2e61940`](https://github.com/NixOS/nixpkgs/commit/d2e61940846eaa7ff62abfea1e4add088be12dd9) haskellPackages: regenerate package set based on current config
* [`865a8f28`](https://github.com/NixOS/nixpkgs/commit/865a8f2861f2bd2dadd474fc489aae86f4ffe066) haskellPackages.binrep: unmark broken
* [`b4f681d5`](https://github.com/NixOS/nixpkgs/commit/b4f681d5d004fccb399fe4eb7bf00b8b0cef667e) maintainers: add raehik
* [`c99c1751`](https://github.com/NixOS/nixpkgs/commit/c99c1751cc80cc47cc75cfb3eb5ac46b9a4e5d9e) haskellPackages: add raehik as maintainer for own pkgs
* [`02cbec61`](https://github.com/NixOS/nixpkgs/commit/02cbec616aa7b7cafe3b76a39031c0c74c07106a) haskellPackages.xcffib: remove stale broken flag
* [`181e0e91`](https://github.com/NixOS/nixpkgs/commit/181e0e91ba9f1d57d608d8b0e95278fbc14c9711) androidenv: generate package.xml in packages' directory
* [`5a3c4c79`](https://github.com/NixOS/nixpkgs/commit/5a3c4c79a4d6bd643a8a11d98005fd5f3750d1be) prometheus-artifactory-exporter: 1.10.0 -> 1.11.0
* [`9a13c551`](https://github.com/NixOS/nixpkgs/commit/9a13c5514c920a9b86714047f28f44e2d0f63f19) nixos/activemq: deprecate phases
* [`7ead7826`](https://github.com/NixOS/nixpkgs/commit/7ead78268f1ec9559d6674416296efed78040611) brave: 1.46.144 -> 1.47.171
* [`d208683c`](https://github.com/NixOS/nixpkgs/commit/d208683cdf5f0b4ee2472c0d5cd5596f4e7e20f4) hyper: 3.3.0 -> 3.4.1
* [`18fd604c`](https://github.com/NixOS/nixpkgs/commit/18fd604cf09d7aa86f1730b7b074e586ccc43f4e) sooperlooper: 1.7.4 -> 1.7.8
* [`910d7035`](https://github.com/NixOS/nixpkgs/commit/910d7035d79aad8879bf76103fecc2de1f5b97c3) maintainers: add deepin team
* [`f2ab2d55`](https://github.com/NixOS/nixpkgs/commit/f2ab2d558c274ba37f278c87baa843bd28ed5328) aliases.nix: remove aliases of deepin
* [`099caac0`](https://github.com/NixOS/nixpkgs/commit/099caac0a827e3b0a20521728653dd77d80a362b) nixos/modules/rename: dont set deepin as a removed module
* [`ab43cc69`](https://github.com/NixOS/nixpkgs/commit/ab43cc69fa5621c7f728ee0a58ce88d226ac61f4) rose-pine-gtk: squash variants into one package
* [`e02cd8e9`](https://github.com/NixOS/nixpkgs/commit/e02cd8e9286fbbf27afefbc6032b4f035cca242d) rose-pine-gtk: format
* [`6e6fcce2`](https://github.com/NixOS/nixpkgs/commit/6e6fcce2f9b82e4d495707519139a566ac15fdd6) androidStudioPackages.stable: 2021.3.1.17 -> 2022.1.1.19
* [`cf8621d2`](https://github.com/NixOS/nixpkgs/commit/cf8621d287db822eb22c0ded651455474ee1c0d4) gridtracker: 1.22.1226 -> 1.23.0110
* [`cc4de1aa`](https://github.com/NixOS/nixpkgs/commit/cc4de1aa3ad39c480e111113aec48da2e7c24e8d) nixos-rebuild: Allow local builds when --target-host is used again
* [`0613ff08`](https://github.com/NixOS/nixpkgs/commit/0613ff085e246914245614d2abf1df535e08450d) python310Packages.zigpy: 0.53.0 -> 0.53.1
* [`48043e4c`](https://github.com/NixOS/nixpkgs/commit/48043e4cb1bd78e3ddbb2660b9812bb3600948bc) mdbook-open-on-gh: 2.2.0 -> 2.3.0
* [`268feffc`](https://github.com/NixOS/nixpkgs/commit/268feffcaac9f5fa37d4be7d64d43d32e2088170) simple-dlna-browser: Add new package
* [`3b2399bf`](https://github.com/NixOS/nixpkgs/commit/3b2399bf26acc7ba9dd209286fb6824070371a8d) python3Packages.graphite-web: switch to github source
* [`670f603a`](https://github.com/NixOS/nixpkgs/commit/670f603a2d6601a76af1ab6317bf73449171a7ed) python3Packages.graphite-web: add patches for CVE-2022-4730, CVE-2022-4729 & CVE-2022-4728
* [`760d26e1`](https://github.com/NixOS/nixpkgs/commit/760d26e16dc42b02be93d09e33aa74085bf5a720) python3Packages.graphite-web: remove whitenoise
* [`5ccffc22`](https://github.com/NixOS/nixpkgs/commit/5ccffc22c9688c7383ee79eb9b8868621b416fce) python3Packages.graphite-web: enable tests
* [`890bf782`](https://github.com/NixOS/nixpkgs/commit/890bf782f3c059bf9305f12b00507d56fb3e134b) python3Packages.graphite-web: unmark as broken on aarch64 and darwin
* [`85dc9e85`](https://github.com/NixOS/nixpkgs/commit/85dc9e8544749aefe35eb58cdbd561fbd164d2d2) qcad: 3.27.6.11 -> 3.27.8.7
* [`44f51f1f`](https://github.com/NixOS/nixpkgs/commit/44f51f1f0945d1de69794dc7d3a388d307e9d652) haskellPackages.purebred-email: Add maralorn as maintainer
* [`a1b357d3`](https://github.com/NixOS/nixpkgs/commit/a1b357d321bdea614331242301e8d69c6099cc28) libamqpcpp: 4.3.18 -> 4.3.19
* [`92dca3d3`](https://github.com/NixOS/nixpkgs/commit/92dca3d39f1ab3db606f1869baf658bc8b292013) micronaut: 3.7.4 -> 3.8.1
* [`40208098`](https://github.com/NixOS/nixpkgs/commit/40208098d2cf7ef3706a7f68ffdef7046eb2d001) klayout: 0.27.11 -> 0.28.3
* [`de45d7fd`](https://github.com/NixOS/nixpkgs/commit/de45d7fd527fe44d79412a71b522b08c467bfe7e) libzen: 0.4.39 -> 0.4.40
* [`2d639cc4`](https://github.com/NixOS/nixpkgs/commit/2d639cc4219699e3966cbdbe85dd452de360b3f5) ode: 0.16.2 -> 0.16.3
* [`26ce043b`](https://github.com/NixOS/nixpkgs/commit/26ce043bbf354d7fc8c6f0b910225a5683be2b78) nordzy-icon-theme: 1.7.6 -> 1.8.1
* [`ddb7ece9`](https://github.com/NixOS/nixpkgs/commit/ddb7ece95a1b6fa9e0879a1c74010849c9a1517b) grafana-image-renderer: 3.6.1 -> 3.6.3
* [`5a9ca133`](https://github.com/NixOS/nixpkgs/commit/5a9ca13318501b66a88778509bb280e4a671ebf5) nco: 5.0.6 -> 5.1.4
* [`fc65d6e6`](https://github.com/NixOS/nixpkgs/commit/fc65d6e66e13c9a3251b4f511138f92de8b381ae) star: 2.7.10a -> 2.7.10b
* [`8aac051f`](https://github.com/NixOS/nixpkgs/commit/8aac051f844abbe34c0b53f44a733f79bf4893f4) libargs: 6.4.4 -> 6.4.6
* [`bd4aede8`](https://github.com/NixOS/nixpkgs/commit/bd4aede85c5f7d4a1e73279c43fea73e00060092) frp: 0.45.0 -> 0.46.1
* [`56ab6089`](https://github.com/NixOS/nixpkgs/commit/56ab60896aa96001c0ca21ce27e02e08d485cf58) openhantek6022: 3.3.1 -> 3.3.2.1
* [`82e33443`](https://github.com/NixOS/nixpkgs/commit/82e33443c9cf7290f1eed74c16814ad9f92379c8) opcr-policy: 0.1.43 -> 0.1.47
* [`99bee15d`](https://github.com/NixOS/nixpkgs/commit/99bee15d83e2ecdd38c48894f1582b5af0751757) partclone: 0.3.21 -> 0.3.22
* [`f2c75f06`](https://github.com/NixOS/nixpkgs/commit/f2c75f068dadba11c6f0dc74347ad79448843942) avalanchego: init at 1.9.7
* [`458e6c90`](https://github.com/NixOS/nixpkgs/commit/458e6c90b093920ab612c7b19e1dee8c9f327d81) python310Packages.google-cloud-bigtable: 2.14.1 -> 2.15.0
* [`578e8841`](https://github.com/NixOS/nixpkgs/commit/578e88414a680c96ce4b808427c9e89d1692d8ce) libdigidocpp: 3.14.11 -> 3.14.12
* [`72e09e90`](https://github.com/NixOS/nixpkgs/commit/72e09e90547d4597750025b4a975ba9e308e8ab2) libucl: 0.8.1 -> 0.8.2
* [`26cc7bf3`](https://github.com/NixOS/nixpkgs/commit/26cc7bf3854af6887c1887597a15d0ff253421ba) openasar: unstable-2022-12-11 -> unstable-2023-01-13
* [`a69f2fc7`](https://github.com/NixOS/nixpkgs/commit/a69f2fc78ca1ed6a760363a00bf36216ba9e656e) guile-ssh: 0.16.0 -> 0.16.2
* [`face67b3`](https://github.com/NixOS/nixpkgs/commit/face67b312e0251ae610d5984b2362cd1633a069) xfe: 1.44 -> 1.45
* [`e3fe978b`](https://github.com/NixOS/nixpkgs/commit/e3fe978bdfd5bd8b94193bdd30d99a3a851d2faa) gerbera: 1.11.0 -> 1.12.1
* [`af3e04d3`](https://github.com/NixOS/nixpkgs/commit/af3e04d3f646ae7d715d5c0689f1fcd85737a2ca) ghc.withPackages: set preferLocalBuild in the correct place
* [`76f0ebe8`](https://github.com/NixOS/nixpkgs/commit/76f0ebe821f122cc0eedc4f988f0453f37ee3631) python310Packages.rns: 0.4.6 -> 0.4.7
* [`10dba7bf`](https://github.com/NixOS/nixpkgs/commit/10dba7bf5261d01f3a578fd9d8836ac90a64f65d) python310Packages.lxmf: 0.2.8 -> 0.2.9
* [`6a038423`](https://github.com/NixOS/nixpkgs/commit/6a038423b6467e92cf90550e493820e0aeeca8e4) python310Packages.nomadnet: 0.3.1 -> 0.3.2
* [`3e0afdc5`](https://github.com/NixOS/nixpkgs/commit/3e0afdc5968114f1fc9f8c34b5d3364703e3c2c7) bencoder: init at 0.2.0
* [`78eb8d67`](https://github.com/NixOS/nixpkgs/commit/78eb8d67272ee8d303fccd85e2d915c09b314542) gazelle-origin: init at 3.0.0
* [`9fac1164`](https://github.com/NixOS/nixpkgs/commit/9fac1164cceed2c3b53e1e6e0317b58d032c2b3d) python310Packages.types-pytz: 2022.7.0.0 -> 2022.7.1.0
* [`15796c4e`](https://github.com/NixOS/nixpkgs/commit/15796c4ed9d9479a612d927116fa5e251c47dda0) lastpass-cli: 1.3.3 -> 1.3.4
* [`fef1559b`](https://github.com/NixOS/nixpkgs/commit/fef1559b0568b31378c8ad7809f901a57bbb8fae) nixos/mastodon: Add the ability to pass environment files
* [`f44a536c`](https://github.com/NixOS/nixpkgs/commit/f44a536cf0ce7497106246492226f9ded4b02c4a) i2pd: 2.44.0 -> 2.45.1
* [`69843317`](https://github.com/NixOS/nixpkgs/commit/6984331709ceaf9f3fbe1c40fb59849feff8f586) dragonfly-reverb: 3.2.7 -> 3.2.8
* [`e556438e`](https://github.com/NixOS/nixpkgs/commit/e556438e1cf5ec260258c955ed4472afb388d08d) driftctl: 0.38.1 -> 0.38.2
* [`cc3b636d`](https://github.com/NixOS/nixpkgs/commit/cc3b636db3186a0fedaded60218aa8aeb81f8fe8) python3Packages.pscript: 0.7.6 -> 0.7.7
* [`a7f6a929`](https://github.com/NixOS/nixpkgs/commit/a7f6a9293a2d0ad475ae14b5c598c87dd9bb47a8) minissdpd: 1.5.20180223 -> 1.6.0
* [`42eaaafa`](https://github.com/NixOS/nixpkgs/commit/42eaaafa63c963161f3210fa6c873d80886af254) python3Packages.pscript: add changelog to meta
* [`ed883448`](https://github.com/NixOS/nixpkgs/commit/ed8834484642abebfcbfdb5e28458644c206679a) libtar: apply patches for CVE-2021-33640, CVE-2021-33643, CVE-2021-33644, CVE-2021-33645 and CVE-2021-33646
* [`a1654f8b`](https://github.com/NixOS/nixpkgs/commit/a1654f8b871ca420326ca535023e3aae8f3ef391) python310Packages.pook: 1.1.0 -> 1.1.1
* [`c68f4747`](https://github.com/NixOS/nixpkgs/commit/c68f4747c48cfb8239b44732d7afaaf4b197296b) pulumi-bin: 3.49.0 -> 3.51.1
* [`727491cd`](https://github.com/NixOS/nixpkgs/commit/727491cd957632ae9dc0449f3600999b40a8a61a) ghc.withPackages: install documentation to -with-packages output
* [`d5efe894`](https://github.com/NixOS/nixpkgs/commit/d5efe89452bceea4b4470ccad423db052548a15c) vkdt: separate buildInputs and add wayland package
* [`75eef608`](https://github.com/NixOS/nixpkgs/commit/75eef6086cf1ed328dcf56bb67bccc991aad1fae) python310Packages.pydicom: 2.3.0 -> 2.3.1
* [`ef9c65fa`](https://github.com/NixOS/nixpkgs/commit/ef9c65fa435fafa571c1ef17f473913d456be2a8) python310Packages.dipy: 1.4.1 -> 1.5.0
* [`e2f0a974`](https://github.com/NixOS/nixpkgs/commit/e2f0a97456e925952406ce770b3ad9afbd7744e3) pmd: 6.49.0 -> 6.53.0
* [`2ac3bf73`](https://github.com/NixOS/nixpkgs/commit/2ac3bf735a25a585982fbd76b384b6ec41fb3dcd) tdlib: 1.8.8 → 1.8.10
* [`358bae31`](https://github.com/NixOS/nixpkgs/commit/358bae310f019e8ad2c7d49a63445e2e6d642d9f) haskell.packages.ghcHEAD.xhtml: now available for cross compilers
* [`a6667917`](https://github.com/NixOS/nixpkgs/commit/a6667917a1ea34189d55371b09d5d1d6a8775c3f) haskellPackages.brick-skylighting: remove stale broken flag
* [`3ccbb8cf`](https://github.com/NixOS/nixpkgs/commit/3ccbb8cffac0a64a9d557d77432f092f32a46423) super-productivity: 7.12.0 -> 7.12.1
* [`f133968d`](https://github.com/NixOS/nixpkgs/commit/f133968d2c080e96dab2d5c1ae206cc95837eb76) updated MKL to 2023.0.0
* [`a2244cd5`](https://github.com/NixOS/nixpkgs/commit/a2244cd5dde9f0d07e086328c5aacd1e11d24c34) vassal: 3.6.7 -> 3.6.10
* [`7641901f`](https://github.com/NixOS/nixpkgs/commit/7641901f0acda84cfd1f9c8da03ad8b10edb0640) xplr: 0.20.1 -> 0.20.2
* [`3fb5bbd0`](https://github.com/NixOS/nixpkgs/commit/3fb5bbd0a7d3b3ec189c9286c360b90228c27b4e) ginac: 1.8.4 -> 1.8.5
* [`399961ec`](https://github.com/NixOS/nixpkgs/commit/399961eccbbfffbf5686af8eece48dfda0f82588) forkstat: 0.02.17 -> 0.03.00
* [`23464601`](https://github.com/NixOS/nixpkgs/commit/23464601e2bfbe0d0eb04dbbc45cc37cf107f383) rymdport: 3.2.0 -> 3.3.0
* [`d269d792`](https://github.com/NixOS/nixpkgs/commit/d269d79261f605d1f1dbec27dc5929cbc2dd6a14) last: 1411 -> 1422
* [`c4965721`](https://github.com/NixOS/nixpkgs/commit/c4965721557b3263cf9aadb4a53946f8764725d2) rsnapshot: 1.4.4 -> 1.4.5
* [`dde298c1`](https://github.com/NixOS/nixpkgs/commit/dde298c12623af9e1b84a0459fb0c2de73cda7dd) python37: remove leftover files
* [`1d2d6b46`](https://github.com/NixOS/nixpkgs/commit/1d2d6b46833a56119e202f1b2691b677629727df) macvim: use python3 instead of python37
* [`c5e7638d`](https://github.com/NixOS/nixpkgs/commit/c5e7638d1ce10ef4433fc8a192358533197f43ad) maintainers: add kidsan
* [`bd4ab5e1`](https://github.com/NixOS/nixpkgs/commit/bd4ab5e17c48c520649dd9972660bd69b475df36) kord: init at 0.4.2
* [`f9743eeb`](https://github.com/NixOS/nixpkgs/commit/f9743eebe285fc2ce6df4f2b27209bd0e9aefdeb) pyradio: 0.8.9.32 -> 0.8.9.36
* [`c5ddc808`](https://github.com/NixOS/nixpkgs/commit/c5ddc80848c6721c1764fabdd692a457c91d8585) python310Packages.dpath: 2.1.3 -> 2.1.4
* [`896eae0b`](https://github.com/NixOS/nixpkgs/commit/896eae0bb70ea978cb81fe03019b61b0fad30831) python310Packages.lxmf: 0.2.8 -> 0.2.9
* [`8575ba2a`](https://github.com/NixOS/nixpkgs/commit/8575ba2ab270f0c13f06fc91b4088cc33537dd0d) gensio: 2.5.5 -> 2.6.2
* [`ebf3a404`](https://github.com/NixOS/nixpkgs/commit/ebf3a404f6bcacbabb81cb141ad614bcd52752b1) gmnisrv: don't pin to openssl_1_1
* [`64165b05`](https://github.com/NixOS/nixpkgs/commit/64165b053d977c705aeac3358c7b9bdc761c719b) python310Packages.atlassian-python-api: 3.32.0 -> 3.32.2
* [`1b89ef3a`](https://github.com/NixOS/nixpkgs/commit/1b89ef3acc73d8698171aac0e253d2d6eeac94b0) performous: 1.1 -> 1.2.0
* [`c035bfc5`](https://github.com/NixOS/nixpkgs/commit/c035bfc5288201d8ffaaa1547bac5041bbbf058b) nixVersions.nix_{2_3,2_10,2_11,2_12}: add monitorfdhup patch
* [`1fe99675`](https://github.com/NixOS/nixpkgs/commit/1fe996757b492eaa0af0fe7076c764e7b305e80e) rednotebook: 2.29 -> 2.29.3
* [`eb290d87`](https://github.com/NixOS/nixpkgs/commit/eb290d87d3bc06f763b4455341606509b7b845eb) gradle_4: remove
* [`ce3a7f8d`](https://github.com/NixOS/nixpkgs/commit/ce3a7f8d88d30f8047696326e5a3c58c9d187e8f) gradle_5: remove
* [`bf370f6f`](https://github.com/NixOS/nixpkgs/commit/bf370f6f985ca7732fe8925ee13539da03a7a6f8) intel-media-sdk: 22.5.4 -> 22.6.5
* [`15bfeddd`](https://github.com/NixOS/nixpkgs/commit/15bfeddda5586f9757226c552a08161e5321ce5c) air: 1.40.4 -> 1.41.0
* [`26f9d69a`](https://github.com/NixOS/nixpkgs/commit/26f9d69af3b1973125d38c03665e8bd8cf7537d7) openai-whisper: unstable-2022-09-30 -> 20230117
* [`cd5e3e32`](https://github.com/NixOS/nixpkgs/commit/cd5e3e324afe790aa75fdc53ca2515bbc3a7a7dd) vault-medusa: 0.3.6 -> 0.4.1
* [`078f08db`](https://github.com/NixOS/nixpkgs/commit/078f08dbba3eed7bc9a4ebf9c017197bd98fd3aa) automatic-timezoned: 1.0.55 -> 1.0.57
* [`d67f3310`](https://github.com/NixOS/nixpkgs/commit/d67f331026f455544706a3621d586f661ec58527) python310Packages.mt-940: 4.27.0 -> 4.28.0
* [`789b55c6`](https://github.com/NixOS/nixpkgs/commit/789b55c683a7ac3afe7f8d177bf04210dfd9261e) python310Packages.trimesh: 3.18.0 -> 3.18.1
* [`3efc6952`](https://github.com/NixOS/nixpkgs/commit/3efc69523fdb04250a3472a13737b826b206eea7) wesnoth: 1.16.6 -> 1.16.7
* [`d59eb2ff`](https://github.com/NixOS/nixpkgs/commit/d59eb2ffba25b5132651a5c8f0589d2690637cd2) libunibreak: 5.0 -> 5.1
* [`4b22955e`](https://github.com/NixOS/nixpkgs/commit/4b22955eb618f51cb5a914c092eeeb2473e9b5e3) spicedb-zed: 0.7.5 -> 0.8.0
* [`119fb25f`](https://github.com/NixOS/nixpkgs/commit/119fb25fbf47d897bc110014a247ea65081910c7) python310Packages.aioesphomeapi: 13.0.4 -> 13.1.0
* [`9d96632a`](https://github.com/NixOS/nixpkgs/commit/9d96632af11ba64431472bbca4d9ee36d91d4319) karlender: 0.8.0 -> 0.9.0
* [`8a9e4179`](https://github.com/NixOS/nixpkgs/commit/8a9e4179f24db92fec57ca93c76aa7144e457d6d) kanboard: 1.2.25 -> 1.2.26
* [`ecc0572e`](https://github.com/NixOS/nixpkgs/commit/ecc0572ed99cff53e5136d75924e41c7e3bd82f6) vexctl: 0.0.2 -> 0.1.0
* [`39cf6bea`](https://github.com/NixOS/nixpkgs/commit/39cf6beaf0f1f79619756d736654aaed23588d06) memcached: 1.6.17 -> 1.6.18
* [`6caaaeff`](https://github.com/NixOS/nixpkgs/commit/6caaaeff07183b8479cd796a2be2e1cf70716b0a) BeatSaberModManager: bump deps
* [`20c25e37`](https://github.com/NixOS/nixpkgs/commit/20c25e3794187bbd94da2dbc0455a3a28d1361ca) openai: 0.25.0 -> 0.26.1
* [`1c2523b7`](https://github.com/NixOS/nixpkgs/commit/1c2523b7498556253d65c4684a11bf421a60ae42) treewide: fonts: reduce unneeded fetchzips
* [`27b09ea4`](https://github.com/NixOS/nixpkgs/commit/27b09ea44a1235aec808ea257eb9a7a2dfc2c129) sdrangel: 7.8.5 -> 7.8.6
* [`de77669d`](https://github.com/NixOS/nixpkgs/commit/de77669d29431c3399577f37e2d814cc05ba8752) prospector: 1.8.3 -> 1.8.4
* [`0b4b7586`](https://github.com/NixOS/nixpkgs/commit/0b4b7586f1e9bb78d5e1f9ec2e09594fd1557229) ocamlPackages.piaf: use Dune 3
* [`f02cba5d`](https://github.com/NixOS/nixpkgs/commit/f02cba5d2f454d315c30a4375732ce722101cbcd) civo: 1.0.41 -> 1.0.45
* [`d1b048bb`](https://github.com/NixOS/nixpkgs/commit/d1b048bb27bbbfd6145e7311d7ded9284f100a19) faircamp: unstable-2022-10-08 -> unstable-2022-12-28
* [`2f95d02f`](https://github.com/NixOS/nixpkgs/commit/2f95d02f3df75c27c3f76176c35f0ed425bf9af6) domination: 1.2.5 -> 1.2.7
* [`d529678f`](https://github.com/NixOS/nixpkgs/commit/d529678ff892c624610a504675940be6fe35b113) vscode-extensions.dbaeumer.vscode-eslint: add metadata
* [`867bc25c`](https://github.com/NixOS/nixpkgs/commit/867bc25c5f3efc686d50980c6a47dd6782b4fd2f) exempi: update homepage
* [`d95feb43`](https://github.com/NixOS/nixpkgs/commit/d95feb435fc307f453bb5f2c6e7f4288ec85f2b3) exempi: remove unused fetchpatch input
* [`494cbda1`](https://github.com/NixOS/nixpkgs/commit/494cbda1bbec68208444adbe1c7140e958097c5c) exempi: enable parallel building
* [`1c272b10`](https://github.com/NixOS/nixpkgs/commit/1c272b106b66baea9dd8ef7cc2c541dd38373657) xrdp: 0.9.9 -> 0.9.21, xorgxrdp: 0.2.9 -> 0.9.19
* [`a65b2f2f`](https://github.com/NixOS/nixpkgs/commit/a65b2f2f3a9d097cc90f68412be9a2e3441045ba) python310Packages.opytimark: fix pname
* [`2dd0b25e`](https://github.com/NixOS/nixpkgs/commit/2dd0b25e164946e597c1f8a1309d73f1bff03f53) gmic: 3.1.6 → 3.2.0
* [`5054a306`](https://github.com/NixOS/nixpkgs/commit/5054a306323053e33143323d23cb025266c4bc2b) licensor: fix tests, this time in a longterm way
* [`e4d981e9`](https://github.com/NixOS/nixpkgs/commit/e4d981e97fa0e4eb0f26cc2ac4d340c771f28f88) cf-terraforming: 0.8.8 -> 0.9.0
* [`cec45b0a`](https://github.com/NixOS/nixpkgs/commit/cec45b0a1ce9b9dc03ee762fbc3ed636ed83ccbc) elixir-ls: 0.12.0 -> 0.13.0
* [`0d9917d1`](https://github.com/NixOS/nixpkgs/commit/0d9917d16b1ea60f8944eb22ce4b6a468c5461b1) wakatime: 1.60.1 -> 1.61.0
* [`ac5c59f0`](https://github.com/NixOS/nixpkgs/commit/ac5c59f0b210b24a3f5a09d03c1d013877090bc5) AusweisApp2: 1.26.1 -> 1.26.2
* [`78a633d1`](https://github.com/NixOS/nixpkgs/commit/78a633d165dbbfc04079093872710387b28fa5c4) ntbtls: 0.2.0 -> 0.3.1
* [`e7c35428`](https://github.com/NixOS/nixpkgs/commit/e7c3542806350832c10d5c51d158ac36b9b4f905) xray: 1.7.0 -> 1.7.2
* [`1f7c5db1`](https://github.com/NixOS/nixpkgs/commit/1f7c5db15d23a8c5ac6a03a6c9eb4f5b71569e0e) dasel: 2.1.0 -> 2.1.1
* [`d12040e8`](https://github.com/NixOS/nixpkgs/commit/d12040e85829bf0c4afbb694449283cf6941650b) nixos/tests/systemd-boot: fix update test
* [`373efbda`](https://github.com/NixOS/nixpkgs/commit/373efbda6425dae7875efc98339cc18af3c254f4) limitcpu: 2.7 -> 2.8
* [`83eb035e`](https://github.com/NixOS/nixpkgs/commit/83eb035ef93bad74d4c98de5b4bbe08ebae4fee7) pg_activity: 3.0.1 -> 3.0.3
* [`8736edfd`](https://github.com/NixOS/nixpkgs/commit/8736edfd9547b2f5807c4fa7d780fcc2fef87088) nixos/qemu-vm: fix useBootLoader builds on aarch64-linux
* [`29585f1e`](https://github.com/NixOS/nixpkgs/commit/29585f1ea0a03863b033547b50c38b53e5cbb3ea) moodle: 4.0.5 -> 4.1.1
* [`939d238c`](https://github.com/NixOS/nixpkgs/commit/939d238cd792b764fc978a5878a203d3934ee2c2) elfutils: Disable failing test on RISC-V
* [`ddc5d34f`](https://github.com/NixOS/nixpkgs/commit/ddc5d34f6126c7029d6aa876eac29e2aed0ee0e4) nixos/tests/systemd-boot: only patch systemd-boot during update test
* [`8f2babd0`](https://github.com/NixOS/nixpkgs/commit/8f2babd0326e57dc01a22bdccec376dcc7ca3ed3) nixos/systemd-boot: pass EFI variable flags during update too
* [`b17e22ec`](https://github.com/NixOS/nixpkgs/commit/b17e22ec52f0f0e498bbf16763d94d17fb095789) ocamlPackages.secp256k1: 0.4.1 → 0.4.4
* [`6dd6c2b7`](https://github.com/NixOS/nixpkgs/commit/6dd6c2b7b30a112592f194e6ed0e6a3669215132) material-design-icons: convert to `stdenvNoCC.mkDerivation`
* [`a5bcee65`](https://github.com/NixOS/nixpkgs/commit/a5bcee65171cf1f9b77ab9857cb6c14cdf98cc9a) material-design-icons: 7.0.96 -> 7.1.96
* [`aedca364`](https://github.com/NixOS/nixpkgs/commit/aedca364f913021a0b84ab678754adcd6ee495c8) material-design-icons: add PlayerNameHere as maintainer
* [`c7293b68`](https://github.com/NixOS/nixpkgs/commit/c7293b6840b58cc8c70d041a36eec4e6382bf2dd) nwg-bar: unstable-2021-09-23 -> 0.1.0
* [`2dfc86b8`](https://github.com/NixOS/nixpkgs/commit/2dfc86b8380edf8f8d00c8e25508b565708d6a89) nixos/modprobe: fix typo in boot.modprobeConfig.enable documentation
* [`5fba9844`](https://github.com/NixOS/nixpkgs/commit/5fba98444bb250effe594791127f1eb349cdbcbf) gmic-qt: 3.1.6 → 3.2.0
* [`21f36c2a`](https://github.com/NixOS/nixpkgs/commit/21f36c2a2e92e2982d080207995ddee825a413f5) gprojector: 3.0.4 -> 3.0.6
* [`f45ec100`](https://github.com/NixOS/nixpkgs/commit/f45ec100716ed2393b045d950e0756ec450c8a80) maintainers: update alyaeanyx
* [`7d7fe885`](https://github.com/NixOS/nixpkgs/commit/7d7fe8858844db7751df42fdb32a82af1ed5751a) jackett: 0.20.2608 -> 0.20.2679
* [`c0fff22e`](https://github.com/NixOS/nixpkgs/commit/c0fff22e52c323ab4ab32a710a78aa058d404421) pscale: 0.125.0 -> 0.127.0
* [`c6d66963`](https://github.com/NixOS/nixpkgs/commit/c6d66963de8bce8ac945a381b0a38ee043d65460) libvgm: unstable-2022-11-25 -> unstable-2023-01-18
* [`e550b2c9`](https://github.com/NixOS/nixpkgs/commit/e550b2c9c8166f053c71361db52130362325fb6d) unciv: 4.3.1 -> 4.4.3
* [`51577b30`](https://github.com/NixOS/nixpkgs/commit/51577b3025fd7ee821713c21ccebb534a1959a67) vtm: 0.9.8l -> 0.9.8n
* [`49d71d09`](https://github.com/NixOS/nixpkgs/commit/49d71d095482c25d5bcf8567d7420dd44b32558c) python310Packages.limnoria: 2022.11.10 -> 2023.1.12
* [`1a9ef11a`](https://github.com/NixOS/nixpkgs/commit/1a9ef11a8cc5ee3b115ae99f20f94bb47a6040de) kics: 1.6.7 -> 1.6.8
* [`18336a35`](https://github.com/NixOS/nixpkgs/commit/18336a3538c1d9538bbc881060a4988a05951c3f) python310Packages.openapi-core: 0.16.4 -> 0.16.5
* [`b794299b`](https://github.com/NixOS/nixpkgs/commit/b794299b112c738d6796eea34f4bedd1df619a8a) pinniped: 0.20.0 -> 0.22.0
* [`3fe5a73b`](https://github.com/NixOS/nixpkgs/commit/3fe5a73b2898d86ccbf856622bfc35da9f0da206) androidStudioPackages.beta: 2022.1.1.12 -> 2022.2.1.12
* [`5599a8a7`](https://github.com/NixOS/nixpkgs/commit/5599a8a72f88093b8f252ef8a805a04b852be2aa) androidStudioPackages.canary: 2022.2.1.2 -> 2023.3.1.1
* [`38d9d6a6`](https://github.com/NixOS/nixpkgs/commit/38d9d6a6714b6fb394be58f7049aa572a376a37d) echidna: 2.0.4 -> 2.0.5
* [`aeb8fd12`](https://github.com/NixOS/nixpkgs/commit/aeb8fd1296eeb3d46d9c46ba5f127dc2beea7970) ecwolf: replace fetchurl with fetchFromBitbucket
* [`d0d65bad`](https://github.com/NixOS/nixpkgs/commit/d0d65badfcb971d606e3982afb000a316214e46d) ecwolf: 1.3.3 -> 1.4.0
* [`1e403c6c`](https://github.com/NixOS/nixpkgs/commit/1e403c6c0e14171951d1042f2afa6b157a830b09) phrase-cli: 2.6.2 -> 2.6.4
* [`12cb0629`](https://github.com/NixOS/nixpkgs/commit/12cb062985575535fd4d6514cbce74b1f086bc29) zfs: 2.1.7 → 2.1.8
* [`b88bf50e`](https://github.com/NixOS/nixpkgs/commit/b88bf50e11d912247f018373bddd1ec5bfabc7b6) neo4j-desktop: 1.4.12 -> 1.5.6
* [`dc9e0d81`](https://github.com/NixOS/nixpkgs/commit/dc9e0d81350937c8b68844581db6570fb8f72c09) mackerel-agent: 0.73.1 -> 0.74.1
* [`76fb7480`](https://github.com/NixOS/nixpkgs/commit/76fb7480de6d5cd5995b0b5da1e7e19e4db010a9) buildbot: fix tests
* [`d64b3009`](https://github.com/NixOS/nixpkgs/commit/d64b30098b10a1e19ecb90b15c050cc949ffffad) libpcap: added support for rpcapd
* [`54626a9b`](https://github.com/NixOS/nixpkgs/commit/54626a9b527f31f5e926cc53b9579b071607da62) mc: 4.8.28 -> 4.8.29
* [`00db6063`](https://github.com/NixOS/nixpkgs/commit/00db60632d2c95a52f1001b41bc923a1bf47ce50) getmail6: 6.18.11 -> 6.18.12
* [`4f61c925`](https://github.com/NixOS/nixpkgs/commit/4f61c925d7a3fde4bd6626ba57d874ae8c7b241d) python310Packages.scripttest: little cleanup, update homepage
* [`2660299f`](https://github.com/NixOS/nixpkgs/commit/2660299f54698b7bd8e8cb11809d45c5377377c9) bowtie2: 2.4.5 -> 2.5.1
* [`046f822d`](https://github.com/NixOS/nixpkgs/commit/046f822dd5fa612031b79209cb1cee0efddd5850) home-assistant: 2023.1.5 -> 2023.1.6
* [`4dcb03a5`](https://github.com/NixOS/nixpkgs/commit/4dcb03a5c32a90dbef83094183ef52e0580dfd22) treewide: remove global with lib; statements in pkgs/coq-modules
* [`6ae435a0`](https://github.com/NixOS/nixpkgs/commit/6ae435a0faebec77828b0f7cd154ed2cd0a2d936) python310Packages.pytorch-metric-learning: 1.6.3 -> 1.7.2
* [`e9331891`](https://github.com/NixOS/nixpkgs/commit/e9331891f2cc9dcaf574a40bded86a859b64d8fd) nuraft: 1.3.0 -> 2.1.0
* [`a2f9ee02`](https://github.com/NixOS/nixpkgs/commit/a2f9ee028e660a038faef20e959d3dd835968736) cargo-careful: init at 0.2.4
* [`5037415b`](https://github.com/NixOS/nixpkgs/commit/5037415bf66351403b72d619804956df945ac731) simgear: 2020.3.14 -> 2020.3.17
* [`2dbb06e2`](https://github.com/NixOS/nixpkgs/commit/2dbb06e267e5b4e657ca71df8363cc0ab3396423) fmt: fmt_7 -> fmt_9
* [`8c11effe`](https://github.com/NixOS/nixpkgs/commit/8c11effee2cb3fdece23a5d28147156647f55963) treewide: pin to fmt_7
* [`6a1bfe65`](https://github.com/NixOS/nixpkgs/commit/6a1bfe659cde6a436c0408ac27d994b127eae01d) treewide: unpin fmt_7, use latest fmt where possible
* [`bca50871`](https://github.com/NixOS/nixpkgs/commit/bca50871099f6dcd84a1ce5027ce2057e02f1df7) dolphin-emu-primehack: pin fmt_7 -> fmt_8
* [`9e570e9c`](https://github.com/NixOS/nixpkgs/commit/9e570e9ceab6c78b8e48356f5c2dc0e09f4226d0) osm2pgsql: pin fmt_7 -> fmt_8
* [`d2eac42a`](https://github.com/NixOS/nixpkgs/commit/d2eac42a6f2ff122725b5bf9aed0a70002cdb9ab) kompute: pin fmt_7 -> fmt_8
* [`44c6d3cc`](https://github.com/NixOS/nixpkgs/commit/44c6d3cc10b6a7caae885f8ee5dc9465fcc4880f) openimageio: pin fmt_7 -> fmt_8
* [`b9bf4d53`](https://github.com/NixOS/nixpkgs/commit/b9bf4d5378762acfe7367fa4fef7b61d1f479596) ceph: pin fmt_7 -> fmt_8
* [`fb9496a5`](https://github.com/NixOS/nixpkgs/commit/fb9496a58fa963aa53c18a1b318e522ddb38b8a5) fmt_7: remove unused pkg
* [`185ea78a`](https://github.com/NixOS/nixpkgs/commit/185ea78a2a0e6e6ed4128773d93cb698e162e6d6) satysfi: rewrite with buildDunePackage
* [`6f7decf6`](https://github.com/NixOS/nixpkgs/commit/6f7decf60b3241c7b142d6ce59c7db1115413bad) freedv: 1.8.6 -> 1.8.7
* [`5a79781d`](https://github.com/NixOS/nixpkgs/commit/5a79781dc6db305055b2c348e9d47a5fb6b0af5d) nimPackages.asynctools: init at 2021-07-06
* [`a7faa78c`](https://github.com/NixOS/nixpkgs/commit/a7faa78c011baf18d709ca2d5537deade7fc9940) millet: 0.7.0 -> 0.7.4
* [`a11ea1e4`](https://github.com/NixOS/nixpkgs/commit/a11ea1e408f48efe7f4fd6386ed0f481ea0a06f1) nimlsp: 0.4.1 -> 0.4.3
* [`4b1bd2ce`](https://github.com/NixOS/nixpkgs/commit/4b1bd2ce87a3739d26dbfb759dc3506370be69be) swaylock-effects: 1.6.10 -> 1.6.11
* [`96f9166f`](https://github.com/NixOS/nixpkgs/commit/96f9166f68878087b27b4c10ae1d67e491024e51) pachyderm: 2.4.2 -> 2.4.4
* [`b92f2042`](https://github.com/NixOS/nixpkgs/commit/b92f2042a008218f614b4910dbaa9d700bd45da8) rose-pine-gtk: remove reference to nonexistent variable variant
* [`4efd9c44`](https://github.com/NixOS/nixpkgs/commit/4efd9c440b9b2cc5e74e4e1721c01afc908b8bdc) postfix: add trivial updater
* [`9bc59980`](https://github.com/NixOS/nixpkgs/commit/9bc59980ab7cc5bfed425489260e6bebc0a1dc59) postfix: 3.7.3 -> 3.7.4
* [`8e228cb5`](https://github.com/NixOS/nixpkgs/commit/8e228cb51defa02fc70164a0eb353a171caa2914) qownnotes: 23.1.0 -> 23.1.1
* [`b0c69069`](https://github.com/NixOS/nixpkgs/commit/b0c69069f15677e939423465cc3040f88612efef) filezilla: 3.61.0 -> 3.62.2
* [`284c315a`](https://github.com/NixOS/nixpkgs/commit/284c315a62f249dab98a24498fe697436524c0bd) buildVscodeExtension: fix passthru
* [`4e91b837`](https://github.com/NixOS/nixpkgs/commit/4e91b837f2d71b250ee5d44ea9d3e5f1804e71b1) aileron: migrate to stdenvNoCC, fix download link
* [`616a0880`](https://github.com/NixOS/nixpkgs/commit/616a088011d981f09512ab98cc7c6e7c97699676) vegur: migrate to stdenvNoCC, use upstream download link
* [`3e68671e`](https://github.com/NixOS/nixpkgs/commit/3e68671ed0b6599776a2f54926942f927905fd4f) f5_6: migrate to stdenvNoCC, fix download link
* [`b3f58e84`](https://github.com/NixOS/nixpkgs/commit/b3f58e84f5934d94f393b5d2f212a1a352ebded4) tenderness: migrate to stdenvNoCC, fix download link
* [`50b0534b`](https://github.com/NixOS/nixpkgs/commit/50b0534bdcb2dffe6dd1e4a1c95a8a121ab59e56) medio: migrate to stdenvNoCC, fix download link
* [`2734632d`](https://github.com/NixOS/nixpkgs/commit/2734632de8c8ec154045ae495840dd04453d17c1) ferrum: migrate to stdenvNoCC, fix download link
* [`4a66f56a`](https://github.com/NixOS/nixpkgs/commit/4a66f56a79119929cf27383f4f02a046a4d86618) seshat: migrate to stdenvNoCC, fix download link
* [`4e477329`](https://github.com/NixOS/nixpkgs/commit/4e477329a935ce239fd3ce0d7fb2c762e1ec4efd) penna: migrate to stdenvNoCC, fix download link
* [`655b5218`](https://github.com/NixOS/nixpkgs/commit/655b521833ec1c4e865b4a72ae8cf73996db899d) eunomia: migrate to stdenvNoCC, fix download link
* [`42482091`](https://github.com/NixOS/nixpkgs/commit/424820916f845aee13d90a854fb7e8efd7587f71) route159: migrate to stdenvNoCC, fix download link
* [`16771e67`](https://github.com/NixOS/nixpkgs/commit/16771e67198afa9eae16af432444d85622d5fd38) f1_8: init at 1.101
* [`aec80ead`](https://github.com/NixOS/nixpkgs/commit/aec80eadbbac531179e0ead4bd44c0e0875354d9) nacelle: init at 1.00
* [`8ba1b2e7`](https://github.com/NixOS/nixpkgs/commit/8ba1b2e722279b5e97f600766b6811f4d27d19f2) melete: init at 0.200
* [`105d75cc`](https://github.com/NixOS/nixpkgs/commit/105d75cc087d977c120b4a7e068abc1afafbe482) fa_1: init at 0.100
* [`53c79444`](https://github.com/NixOS/nixpkgs/commit/53c79444291fca3240fe6ea3a4dd1e8267f2ce09) dotcolon-fonts: init collection
* [`e75c36d0`](https://github.com/NixOS/nixpkgs/commit/e75c36d0557a0631a91ebb0be72da20da1a4aefb) haskellPackages.ghcWithPackages: suppport ghcs without doc output
* [`6f3f88ec`](https://github.com/NixOS/nixpkgs/commit/6f3f88ec480e713321503d3a9ccb8afec71ae97a) linuxPackages.zenpower: unstable-2022-04-13 -> unstable-2022-11-04
* [`d0206d0d`](https://github.com/NixOS/nixpkgs/commit/d0206d0de07e14b4d62094fe05b821b0610e2ce2) pythonPackages.pynmea2: 1.18.0 -> 1.19.0
* [`2166bf1b`](https://github.com/NixOS/nixpkgs/commit/2166bf1bfe6db53e9052d4f96c952e036eb7ca25) sambamba: 0.8.2 -> 1.0.0
* [`bac43d3b`](https://github.com/NixOS/nixpkgs/commit/bac43d3b64026317c4e6f6d0e995c46de7acf6ca) haskell.packages.ghcHEAD: mv configuration-ghc-{head,9.8.x}.nix
* [`e8e64dc6`](https://github.com/NixOS/nixpkgs/commit/e8e64dc6ed8f269ab97fa8ab8f0e3102d1296595) haskellPackages.sfnt2woff: fix build
* [`e6c17d88`](https://github.com/NixOS/nixpkgs/commit/e6c17d8808efec0eb8a4aa28d75a8142f00d6b4d) zziplib: broaden platforms
* [`aa7627a1`](https://github.com/NixOS/nixpkgs/commit/aa7627a19f1cc46de098ca0e0c598790908f50a0) gperftools: broaden platforms
* [`31f09f76`](https://github.com/NixOS/nixpkgs/commit/31f09f7643da2267f0781793d37e9f7df595d515) session-desktop: 1.10.3 -> 1.10.4
* [`b3116255`](https://github.com/NixOS/nixpkgs/commit/b31162552614968eaad5668f35a4d969780e5183) httrack: depend on libiconv unconditionally
* [`6ae3e769`](https://github.com/NixOS/nixpkgs/commit/6ae3e7695e27a4f7afb1d2017f5967d5e82f4c00) nixos/virtualisation: add option for explicitly named network interfaces
* [`58e4c263`](https://github.com/NixOS/nixpkgs/commit/58e4c2638c2e8988892ad4ef5d7a3b0cd7052477) omnisharp-roslyn: 1.39.2 -> 1.39.4
* [`4d97d477`](https://github.com/NixOS/nixpkgs/commit/4d97d4772ebe86d807063169068049b005d36fa8) python310Packages.pyunifiprotect: 4.6.1 -> 4.6.2
* [`603239b8`](https://github.com/NixOS/nixpkgs/commit/603239b8a022094e97ec873842ce2fe01bdc47a3) godot_4: 4.0-beta10 -> 4.0-beta14
* [`fbb694c1`](https://github.com/NixOS/nixpkgs/commit/fbb694c1b5ba57f061e949b913ad72cfa3cce1e8) apx: init at 1.4.2
* [`815282d1`](https://github.com/NixOS/nixpkgs/commit/815282d1c0308de5bcc59d84b4a0ee97403271df) fwupd: 1.8.4 -> 1.8.9
* [`87cda273`](https://github.com/NixOS/nixpkgs/commit/87cda273e5e865df53eb3c2130f904bb91d43123) python310Packages.pycaption: 2.1.0 -> 2.1.1
* [`192698a4`](https://github.com/NixOS/nixpkgs/commit/192698a4e9ddd7e92e4fb7834d861c049f845979) python310Packages.env-canada: add changelog to meta
* [`56df8494`](https://github.com/NixOS/nixpkgs/commit/56df8494914ab2d171736d5d113ebe073269524d) python310Packages.env-canada: 0.5.25 -> 0.5.26
* [`0f2b75bc`](https://github.com/NixOS/nixpkgs/commit/0f2b75bc9d1a0ca001bdfccf2390f2bcb8cfc1b5) syft: 0.62.3 -> 0.66.2
* [`38bc80cb`](https://github.com/NixOS/nixpkgs/commit/38bc80cb5a16106d7789c9bb4a84e8515dd28594) maintainers: add novenary
* [`eaed2336`](https://github.com/NixOS/nixpkgs/commit/eaed23363a66bef2a164face57c6fd93b4a8560e) cdxgen: init at 6.0.14
* [`6803ef06`](https://github.com/NixOS/nixpkgs/commit/6803ef067fe6b669d9c6db0ca017cec6ec344be7) lazpaint: 7.1.5 -> 7.2.2
* [`f050ae86`](https://github.com/NixOS/nixpkgs/commit/f050ae86cc88baa49ee466c36f36e8401cf15c5b) ruff: 0.0.228 -> 0.0.230
* [`b29703a4`](https://github.com/NixOS/nixpkgs/commit/b29703a4b12ca93395f6a4c95770ad92bac06960) python310Packages.tinydb: 4.7.0 -> 4.7.1
* [`1109b9d6`](https://github.com/NixOS/nixpkgs/commit/1109b9d6860afbefc8683f5107c2b0fb619b982d) python310Packages.python-bsblan: add changelog to meta
* [`707a15f5`](https://github.com/NixOS/nixpkgs/commit/707a15f5735dec32773a32e0f7d217d24dfd873e) python310Packages.python-bsblan: 0.5.8 -> 0.5.9
* [`b533ff3d`](https://github.com/NixOS/nixpkgs/commit/b533ff3d01cfc7dd22a7ead3c73f5929dd55675f) flyway: 9.7.0 -> 9.12.0
* [`be622593`](https://github.com/NixOS/nixpkgs/commit/be62259393a3cff405b9d84015f1a60d9150b355) libcIconv: rename from glibcIconv
* [`b19185fd`](https://github.com/NixOS/nixpkgs/commit/b19185fdb2a5ffbbdb5689ef5ee30d17d208e217) libiconv: use libc header on NetBSD
* [`fc0c3f53`](https://github.com/NixOS/nixpkgs/commit/fc0c3f538258b2973f46b50098a99bcc14779843) rose-pine-gtk: use nixpkgs-fmt, NoCC, and update icon cache
* [`feaf1a72`](https://github.com/NixOS/nixpkgs/commit/feaf1a72bc088afc0aec83f1e1a1a503c60303e1) htop: enable extra features
* [`ab9efae9`](https://github.com/NixOS/nixpkgs/commit/ab9efae911964d48812d1310d8f23fc0fde70acf) python310Packages.pylsp-mypy: 0.6.4 -> 0.6.5
* [`9fd918d0`](https://github.com/NixOS/nixpkgs/commit/9fd918d07a7be106c2909b086633f8a8a0a290dc) bottom: 0.7.1 -> 0.8.0
* [`1310cc0a`](https://github.com/NixOS/nixpkgs/commit/1310cc0ad72bddea49ed7ed199e1390a1d27cad0) ergo: 5.0.3 -> 5.0.6
* [`e368c708`](https://github.com/NixOS/nixpkgs/commit/e368c70817cee56bd87a1d8dcc7fd44454e499aa) openvpn_24: remove
* [`ee00af7a`](https://github.com/NixOS/nixpkgs/commit/ee00af7a32def3d4d9b3e8d7f7f74e053432b9db) attrsets: clarify that mapAttrs maps over *leaf* attrs
* [`2e49ab33`](https://github.com/NixOS/nixpkgs/commit/2e49ab3319a5e3cfdb0921cf513f89cff33e48bb) zsnes2: init at 2.0.10
* [`af49c8f6`](https://github.com/NixOS/nixpkgs/commit/af49c8f6718c199012069e39afa109c71127e1bb) python310Packages.reikna: 0.7.6 -> 0.8.0
* [`e83911bd`](https://github.com/NixOS/nixpkgs/commit/e83911bd90ca08959c561d86dcd241877111f305) setconf: init at 0.7.7
* [`9f370f0f`](https://github.com/NixOS/nixpkgs/commit/9f370f0f74d2db2cf64c10ca7fa6f45fa6f1bd38) cargo-bisect-rustc: unpin openssl_1_1
* [`f6d98679`](https://github.com/NixOS/nixpkgs/commit/f6d98679bb2fa6f65f1783e3488f2d615500df98) cliscord: unpin openssl_1_1
* [`93da9ccc`](https://github.com/NixOS/nixpkgs/commit/93da9cccfacd6b94b0d0bcbe55a8d44c0d2aaf8c) journaldriver: unpin openssl_1_1
* [`f85005c8`](https://github.com/NixOS/nixpkgs/commit/f85005c85e0d7daee4afe82eac73a7da7b856f6d) git-trim: unpin openssl_1_1
* [`284370ec`](https://github.com/NixOS/nixpkgs/commit/284370ecf074a5b1b9efaca9952864ad3d4c80b8) shotwell: remove unused libchamplain dependency
* [`a4e6fbc3`](https://github.com/NixOS/nixpkgs/commit/a4e6fbc3bf980af29c99f969106e8c34c1ebb687) gnome.empathy: drop
* [`a7f3447f`](https://github.com/NixOS/nixpkgs/commit/a7f3447fbbca8ec524801bfaf512a74ee170996e) armcord: fix gsettings crash when selecting file
* [`3c9db360`](https://github.com/NixOS/nixpkgs/commit/3c9db360007ac503a76fb640098e8607a0cca198) rapidjson: fix cross compilation, cleanup checkPhase
* [`5b5ace4f`](https://github.com/NixOS/nixpkgs/commit/5b5ace4f17fa4eb790a84f883637713aea837382) bundler: 2.4.4 -> 2.4.5
* [`109d610f`](https://github.com/NixOS/nixpkgs/commit/109d610f48744f410d78281cc9b9ed1b91c9aa4e) terraform-providers.gitlab: 15.7.1 → 15.8.0
* [`9a1a1f1f`](https://github.com/NixOS/nixpkgs/commit/9a1a1f1faa9edc7548dabd3727576609673b60c7) yubioath-flutter: flutter itself should not be in the closure for yubioath-flutter
* [`00a65532`](https://github.com/NixOS/nixpkgs/commit/00a6553266333d01236d4ebeaf769a1802c4e85a) nixos/gnome-documents: remove
* [`0aeadf53`](https://github.com/NixOS/nixpkgs/commit/0aeadf53d3e4f7c8517db77479dc16ec059e5269) p2pool: 2.4 -> 2.7
* [`1b00e5af`](https://github.com/NixOS/nixpkgs/commit/1b00e5af2fdff56affeb1f2c00db5b035c08fdcc) waydroid: Add missing ambiant dependencies
* [`35e3d673`](https://github.com/NixOS/nixpkgs/commit/35e3d673c48851adc1e97e27f676a9a9fc110307) cargo-zigbuild: 0.14.3 -> 0.14.5
* [`20a1663e`](https://github.com/NixOS/nixpkgs/commit/20a1663e048047fd94f73a64157cec650c2906c1) fava: loosen cheroot version requirement
* [`53bb93d0`](https://github.com/NixOS/nixpkgs/commit/53bb93d08bc75a0a7b32be9ffed32202f7469e08) babashka: 1.0.169 -> 1.0.170
* [`290892dd`](https://github.com/NixOS/nixpkgs/commit/290892ddba7468398b6a0bf77ce29b8a00b7cd53) Revert "jdupes: 1.21.0 -> 1.21.1"
* [`8145499e`](https://github.com/NixOS/nixpkgs/commit/8145499e9c4186256ff20007643e49f02a8264a6) ocamlPackages.lutils: 1.51.2 → 1.54.1
* [`ce563f61`](https://github.com/NixOS/nixpkgs/commit/ce563f610557f4e2659c9b3a567bbf46116736bf) gitprompt-rs: init at 0.3.0
* [`e3374aff`](https://github.com/NixOS/nixpkgs/commit/e3374aff8a747472bafe7cfab2116f362f852590) manifest-tool: init at v2.0.6
* [`d6be2359`](https://github.com/NixOS/nixpkgs/commit/d6be2359f2b5d3ff4851c0f4cc26f88347b9c4fc) invidious: unstable-2023-01-10 -> unstable-2023-01-22
* [`0fbdf6da`](https://github.com/NixOS/nixpkgs/commit/0fbdf6daae8d905f8fe70db512ed1bf6f7e48981) httm: 0.19.2 -> 0.19.3
* [`d776f4ed`](https://github.com/NixOS/nixpkgs/commit/d776f4ed22e9e1aa2ff73f826a33cf42ceadf52e) relic: 7.5.3 -> 7.5.4
* [`2c5768fe`](https://github.com/NixOS/nixpkgs/commit/2c5768fe8fbed772548f63165ee58f7bd94dbfce) manifest-tool: add static binary support
* [`6f51b183`](https://github.com/NixOS/nixpkgs/commit/6f51b1834ab5c3227473efd6f7044e75121aca6a) operator-sdk: build all binaries
* [`6e873de5`](https://github.com/NixOS/nixpkgs/commit/6e873de5b87e33043c02c2f77291c167e09be829) monitor: 0.14.0 -> 0.15.0
* [`24bb925e`](https://github.com/NixOS/nixpkgs/commit/24bb925ebcfe5b2feeea3ebb14f7da603a3588b5) komga: 0.158.0 -> 0.160.0
* [`3bbf5450`](https://github.com/NixOS/nixpkgs/commit/3bbf545034ea2a5e18c90931bed0e732d121475f) copilot-cli: 1.24.0 -> 1.25.0
* [`5fa6306f`](https://github.com/NixOS/nixpkgs/commit/5fa6306fd5690439a3b8358e3cfd11c6d4341b50) pocketbase: 0.11.2 -> 0.11.3
* [`151b86ad`](https://github.com/NixOS/nixpkgs/commit/151b86ad6ab7e2161b2da2c599441ac3024422a3) jellyfin-web: 10.8.8 -> 10.8.9
* [`575f56d8`](https://github.com/NixOS/nixpkgs/commit/575f56d82cdb3773b72a5f8e09ad8472cf4a3ddc) jellyfin: 10.8.8 -> 10.8.9
* [`5cdaf596`](https://github.com/NixOS/nixpkgs/commit/5cdaf596e5eb3488e9a721bd6bdf01f9cba8ec10) open-policy-agent: 0.47.4 -> 0.48.0
* [`c89e19ee`](https://github.com/NixOS/nixpkgs/commit/c89e19eefed61f165b83eab32c59c046b8099a04) peering-manager: 1.7.3 -> 1.7.4
* [`48665a41`](https://github.com/NixOS/nixpkgs/commit/48665a415038e5e04d8bef71c447e60077dba501) linux_6_0: drop
* [`1535f597`](https://github.com/NixOS/nixpkgs/commit/1535f5974aca2ba1099ea22c03a0b9aa8b683349) level-zero: 1.8.12 -> 1.9.4
* [`544df362`](https://github.com/NixOS/nixpkgs/commit/544df362deeaf539bb7b4a4f37b8f7a5b8579b52) intel-compute-runtime: add a patch to fix typo
* [`285bba82`](https://github.com/NixOS/nixpkgs/commit/285bba82f6c393b89911b49538bdf411646186e7) crowdin-cli: 3.9.1 -> 3.9.3
* [`8dda3f4a`](https://github.com/NixOS/nixpkgs/commit/8dda3f4a5207996b8ba60dee48d53ec2983f4187) python3Packages.pyrainbird: 1.1.0 -> 1.1.1
* [`e3ce8178`](https://github.com/NixOS/nixpkgs/commit/e3ce81781cf98872b3605d46bc65092db06418db) home-assistant: 2023.1.6 -> 2023.1.7
* [`6262935d`](https://github.com/NixOS/nixpkgs/commit/6262935d09f683335d35bbc6413f1fffb50bd5ac) fzf: fix failing test on 32-bit platforms
* [`27a557db`](https://github.com/NixOS/nixpkgs/commit/27a557db61565fdf67bfe0a29f8d1518b3565b01) git-machete: 3.14.2 -> 3.14.3
* [`86d0c9f6`](https://github.com/NixOS/nixpkgs/commit/86d0c9f603d20db3522a2ee2ae2d208723019097) forgejo: 1.18.2-0 -> 1.18.2-1
* [`d000c1d1`](https://github.com/NixOS/nixpkgs/commit/d000c1d19de0045cba1c120117f3c2548b713d57) werf: 1.2.195 -> 1.2.197
* [`406cf637`](https://github.com/NixOS/nixpkgs/commit/406cf6373f2afb2cddd990361895d40e1afdb42d) er-patcher: 1.06-2 -> 1.06-3
* [`e7ad4296`](https://github.com/NixOS/nixpkgs/commit/e7ad4296d6e7d7de68dd5689cdd8b2d4b6801b44) maintainers: add jboy
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
