### PR TITLE
niv devenv: update c5519d64 -> 2e20275b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c5519d64b6bbf59be0d37a26a801a2e9430bcb3f",
-        "sha256": "1l6h3p2ax4cf5lvaj81wxj492kcs1dwvj9bc422nnahjawjb38rm",
+        "rev": "2e20275b01464345c35d2aa42f8405fd8685a6e4",
+        "sha256": "1by2s84js48wn54d9fkig8rnr2paw7m6xkdsi21i9dfzdiinaqxx",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/c5519d64b6bbf59be0d37a26a801a2e9430bcb3f.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/2e20275b01464345c35d2aa42f8405fd8685a6e4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@c5519d64...2e20275b](https://github.com/cachix/devenv/compare/c5519d64b6bbf59be0d37a26a801a2e9430bcb3f...2e20275b01464345c35d2aa42f8405fd8685a6e4)

* [`dbb12e64`](https://github.com/cachix/devenv/commit/dbb12e6442997a5c126f8a3cf9168e3aae673d82) Files and variables language edit
* [`d3f28dd0`](https://github.com/cachix/devenv/commit/d3f28dd05d6f18b7f0ed45462cf3ff4bb54a9309) README.md proofread
* [`dfd9c485`](https://github.com/cachix/devenv/commit/dfd9c4857c4e4b910b4270c6a35af9f9ba824917) languages/python: add poetry support
* [`e64d04f1`](https://github.com/cachix/devenv/commit/e64d04f1662cf17c41391fb2c5f7cf418d1e9382) languages/python: warn about missing poetry.lock
* [`7a3083d7`](https://github.com/cachix/devenv/commit/7a3083d7d8882431ea7d451da5147eec5931f4f7) languages/python: avoid rerunning python install for same poetry.lock
* [`89dddf0f`](https://github.com/cachix/devenv/commit/89dddf0ffcbd3e3912d9b980322fa1521fdb909b) correct mariadb database and user handling
* [`13a072ce`](https://github.com/cachix/devenv/commit/13a072ce3424995aa7005c8ea702edac100fe906) remove unused char
* [`82508795`](https://github.com/cachix/devenv/commit/82508795e56f7cd8a243e3d2e8a2dc3b481bec5f) inputs.md language edit
* [`edb01439`](https://github.com/cachix/devenv/commit/edb014395e8836c211329666abd961bdea1240ad) Allow the user to use a different version of OCaml
* [`9b10d49c`](https://github.com/cachix/devenv/commit/9b10d49cb64877f50f55ac889f49ebdacf70c18b) Auto generate docs/reference/options.md
* [`df80bfec`](https://github.com/cachix/devenv/commit/df80bfecabf7948950301d7d6d991d3572bc15d8) Revert "Allow the user to use a different version of OCaml"
* [`6bde92ba`](https://github.com/cachix/devenv/commit/6bde92babf4c37e398a8769d1a668abed108f5c4) Auto generate docs/reference/options.md
* [`6a4e78b6`](https://github.com/cachix/devenv/commit/6a4e78b6af7aef298dfb82007a62686833e3a9e8) Auto generate docs/reference/options.md
* [`be487fa3`](https://github.com/cachix/devenv/commit/be487fa3e97656fb1f88e1b004591a2f6575033b) Scripts language edit
* [`5341c0b9`](https://github.com/cachix/devenv/commit/5341c0b9bbaf32c68557118566f2af05e5484831) Languages language edit
* [`92bfff6e`](https://github.com/cachix/devenv/commit/92bfff6e2a8aec0637df52ebd8d8f36ab0931f97) Packages language edit
* [`98e9da9f`](https://github.com/cachix/devenv/commit/98e9da9f71622e0c4014057fbd4839b89aa3097c) Pre-commit hooks language edit
* [`fba71833`](https://github.com/cachix/devenv/commit/fba71833e2c606287c4d6f0fb1d5e36057742a3f) (Re)add Crystal
* [`711bbbaa`](https://github.com/cachix/devenv/commit/711bbbaa58b435a23783bcfd0bd9ccbcf9de651d) Auto generate docs/reference/options.md
* [`6fc4534d`](https://github.com/cachix/devenv/commit/6fc4534dfc4ac6b8b5eba24565f137762ec04fd9) Auto generate examples/supported-languages/devenv.nix
* [`2e20275b`](https://github.com/cachix/devenv/commit/2e20275b01464345c35d2aa42f8405fd8685a6e4) rust: be able to find headers for darwin frameworks
