### PR TITLE
niv powerlevel10k: update 0adbc141 -> a30145b0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0adbc1415bf1bad46a7fd111b39640d995294dad",
-        "sha256": "0i2f7442gndr1zg289zkyf3b9540hcypapz03xkzh8l7ap4i0207",
+        "rev": "a30145b0f82d06770e924e9eac064ed223a94e6b",
+        "sha256": "050zdvcpks5h8zx675q66zz2pphz1nd1cvbx9mhb4lmhphp5fxlf",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0adbc1415bf1bad46a7fd111b39640d995294dad.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/a30145b0f82d06770e924e9eac064ed223a94e6b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@0adbc141...a30145b0](https://github.com/romkatv/powerlevel10k/compare/0adbc1415bf1bad46a7fd111b39640d995294dad...a30145b0f82d06770e924e9eac064ed223a94e6b)

* [`e9e94a50`](https://github.com/romkatv/powerlevel10k/commit/e9e94a503a550b13b63a7528551a30dc5938c541) fix the default value of POWERLEVEL9K_VPN_IP_INTERFACE
* [`e7b2bb23`](https://github.com/romkatv/powerlevel10k/commit/e7b2bb2372c5c7060d35c0b7a710f3f01bd4593b) set POWERLEVEL9K_VPN_IP_INTERFACE to the same value as the default: this adds ZeroTier support
* [`a30145b0`](https://github.com/romkatv/powerlevel10k/commit/a30145b0f82d06770e924e9eac064ed223a94e6b) add an optional parameter to _p9k_upglob to pass glob qualifiers and use it in most cases to restrict globbing to files/directories/links/etc ([romkatv/powerlevel10k⁠#2175](https://togithub.com/romkatv/powerlevel10k/issues/2175))
