### PR TITLE
niv zsh-completions: update dd686f35 -> 3e3e2f97

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "dd686f35d1314f9cfcf20fa13ac7bb33b1d424e1",
-        "sha256": "1pra64610k0a7g4m6sfrpa6rihs1y95qg3l2pvvkvsxqjlyydqij",
+        "rev": "3e3e2f97f2ff1b996092cf582e8eba33b46b8409",
+        "sha256": "1yhg610adw65ngqz21imkc4ir8868givnmq77ncjawisibn4v9s5",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/dd686f35d1314f9cfcf20fa13ac7bb33b1d424e1.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/3e3e2f97f2ff1b996092cf582e8eba33b46b8409.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@dd686f35...3e3e2f97](https://github.com/zsh-users/zsh-completions/compare/dd686f35d1314f9cfcf20fa13ac7bb33b1d424e1...3e3e2f97f2ff1b996092cf582e8eba33b46b8409)

* [`4f5a896b`](https://github.com/zsh-users/zsh-completions/commit/4f5a896b96cecf48b83d4b17c0c3ff752f6b1ca6) Add networkQuality completion
* [`14817f4f`](https://github.com/zsh-users/zsh-completions/commit/14817f4f11b30da24026e3580c8bd00ca93aab11) Update flutter completion for version 3.7
* [`e9191ffa`](https://github.com/zsh-users/zsh-completions/commit/e9191ffa9532ea6238a88dd7a5bbb300c151d3a2) Implement flutter pub sub command completions
