### PR TITLE
niv zsh-you-should-use: update 5b316f4a -> c062be91

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -252,10 +252,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "5b316f4af3ac90e044f386003aacdaa0ad606488",
-        "sha256": "192jb680f1sc5xpgzgccncsb98xa414aysprl52a0bsmd1slnyxs",
+        "rev": "c062be916d0307fd851023c7afdbf7894b6667b6",
+        "sha256": "1m3gm1475w9slp2yzbwlhkxmg3iw7whflkqp7r6013lwn09kqi5r",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/5b316f4af3ac90e044f386003aacdaa0ad606488.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/c062be916d0307fd851023c7afdbf7894b6667b6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@5b316f4a...c062be91](https://github.com/MichaelAquilina/zsh-you-should-use/compare/5b316f4af3ac90e044f386003aacdaa0ad606488...c062be916d0307fd851023c7afdbf7894b6667b6)

* [`16d0cfe9`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/16d0cfe9182327acecede3ccc2ece83f2be1d6af) Improve oh-my-zsh installation instructions
* [`e23c7d74`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/e23c7d74378debd440669b08fa5545fa9f4d6ac3) Fix syntax
* [`3cb8b78f`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/3cb8b78fbef3ffd4f286e5a233742c5b75295279) build: Add pygments to lint job
