### PR TITLE
niv emacs-overlay: update fc341b52 -> f5689d4d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fc341b52fe5837ef313cfe79eea7e2a05b6efffa",
-        "sha256": "1s4kh044jx4890zzfv7lbf2r5z86alha592bkcj6fhzs8ml3w32w",
+        "rev": "f5689d4d9a0d1c4dd8fee769d137daec0f02dc4a",
+        "sha256": "1gcm3vlkzrrbzzqzhvlfydhy842rc7arm1lwqgf4yyh0f6j4axpx",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/fc341b52fe5837ef313cfe79eea7e2a05b6efffa.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/f5689d4d9a0d1c4dd8fee769d137daec0f02dc4a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@fc341b52...f5689d4d](https://github.com/nix-community/emacs-overlay/compare/fc341b52fe5837ef313cfe79eea7e2a05b6efffa...f5689d4d9a0d1c4dd8fee769d137daec0f02dc4a)

* [`868a2b03`](https://github.com/nix-community/emacs-overlay/commit/868a2b036b1cc5a599cb8739fb8c6b696f455b39) Updated repos/melpa
* [`6beae892`](https://github.com/nix-community/emacs-overlay/commit/6beae892f03b0a963ecb924e4ae0120bc6d44639) Updated repos/elpa
* [`8a9a42e2`](https://github.com/nix-community/emacs-overlay/commit/8a9a42e253f48177f5f5e4dbb2745cbb17d7f023) Updated repos/emacs
* [`72cf8e98`](https://github.com/nix-community/emacs-overlay/commit/72cf8e98a2ba74e34098cd6f7cf6c15044198aaa) Updated repos/melpa
* [`b537e3cb`](https://github.com/nix-community/emacs-overlay/commit/b537e3cba7307729bf80cdc8ef2b176727cbb645) Updated repos/nongnu
* [`5425bafa`](https://github.com/nix-community/emacs-overlay/commit/5425bafa8a38e8c32198def4e07fed8cf68dcc98) Updated repos/elpa
* [`4a14e8f7`](https://github.com/nix-community/emacs-overlay/commit/4a14e8f79e91636cdfc4cecc3f12cdc4cfe57a60) Updated repos/melpa
* [`e8fbc3e6`](https://github.com/nix-community/emacs-overlay/commit/e8fbc3e6d55c221e489f96e8dd2c33d76d53934a) Updated repos/emacs
* [`d85438fe`](https://github.com/nix-community/emacs-overlay/commit/d85438fe16bfef13004bc90a50661d0c74252970) Updated repos/melpa
* [`1a3f5d63`](https://github.com/nix-community/emacs-overlay/commit/1a3f5d633ea962194f8ef7a2be8a592cae303040) Updated repos/emacs
* [`a488b1a6`](https://github.com/nix-community/emacs-overlay/commit/a488b1a67be14ce00e26e580e10b7bcb67e4b46d) Updated repos/melpa
* [`5cab6df9`](https://github.com/nix-community/emacs-overlay/commit/5cab6df93a5eccccbee9613bb25b85296f15e03c) Updated repos/elpa
* [`40948df7`](https://github.com/nix-community/emacs-overlay/commit/40948df73aec8b6cf0c6ff24af619e86f3ad8522) Updated repos/emacs
* [`9066f92a`](https://github.com/nix-community/emacs-overlay/commit/9066f92a2f6334de8977240e221278aba8037d7a) Updated repos/melpa
* [`a2e8ecc3`](https://github.com/nix-community/emacs-overlay/commit/a2e8ecc377a751d4a5019f6b2d20ab350ece7e47) Updated repos/emacs
* [`e59c5c21`](https://github.com/nix-community/emacs-overlay/commit/e59c5c21e96e7b4da8e877446e98ae89120fe9dd) Updated repos/melpa
* [`2f6595fe`](https://github.com/nix-community/emacs-overlay/commit/2f6595feecd8a5b12068eacbfbaefc02c42c25bd) Updated repos/nongnu
* [`a458da4b`](https://github.com/nix-community/emacs-overlay/commit/a458da4b6b21eb5963438d305b216b7a4921f19a) Updated repos/melpa
* [`f407ec92`](https://github.com/nix-community/emacs-overlay/commit/f407ec929d970eba7f726f7a5f35c09f7d9431dd) Updated repos/elpa
* [`2a5e1789`](https://github.com/nix-community/emacs-overlay/commit/2a5e17891943beba3403e33d10080d0ab256a015) Updated repos/emacs
* [`f31b9a13`](https://github.com/nix-community/emacs-overlay/commit/f31b9a13f881c0e8bc844fa8273daef2128f9510) Updated repos/melpa
* [`699dd6e9`](https://github.com/nix-community/emacs-overlay/commit/699dd6e9999e3977490eb75490f1fa155fa5c319) Remove special casing for nongnuPackages
* [`02dd2126`](https://github.com/nix-community/emacs-overlay/commit/02dd212638014b3c856b11e457ba87119cdc9522) Updated repos/melpa
* [`b14ac8cc`](https://github.com/nix-community/emacs-overlay/commit/b14ac8cc285517482b2fd8e20db355a3980f59f0) Updated repos/melpa
* [`48690025`](https://github.com/nix-community/emacs-overlay/commit/48690025fe8ff4071b444fd001baf9b8078d7095) Updated repos/elpa
* [`262f18ee`](https://github.com/nix-community/emacs-overlay/commit/262f18ee0e366382f55ed3ed2d3d87f29627287b) Updated repos/emacs
* [`60bd8884`](https://github.com/nix-community/emacs-overlay/commit/60bd8884098f51d652ccea942456abf770b84b48) Updated repos/melpa
* [`1114c22a`](https://github.com/nix-community/emacs-overlay/commit/1114c22aeb13c1c2344f237ec57bf155c9fc1a8f) Updated repos/nongnu
* [`9974b66e`](https://github.com/nix-community/emacs-overlay/commit/9974b66ebe46235d583d8724c0ab2ed2b3acf395) Add nixpkgs input and create lock file
* [`e6679463`](https://github.com/nix-community/emacs-overlay/commit/e66794634ab3a380ffecc9275c8bf28380f61ff5) Updated repos/emacs
* [`4de9f486`](https://github.com/nix-community/emacs-overlay/commit/4de9f486cff63cc6508d425da10e2ed32fde8c55) Updated repos/melpa
* [`6d8a2ba3`](https://github.com/nix-community/emacs-overlay/commit/6d8a2ba38e84e0491c3d5a3d014a0dcdb7fdb31d) Updated repos/elpa
* [`800685a0`](https://github.com/nix-community/emacs-overlay/commit/800685a0ad5dfa94d6e3fffb5ffa1a208ad8c76a) Updated repos/melpa
* [`91c70283`](https://github.com/nix-community/emacs-overlay/commit/91c70283d216e46d591652ea6139749c0b1b292b) Updated repos/emacs
* [`3f8a6e83`](https://github.com/nix-community/emacs-overlay/commit/3f8a6e839a1574631e135a34c53e5e58ae81bd8e) Updated repos/melpa
* [`39ae8f18`](https://github.com/nix-community/emacs-overlay/commit/39ae8f186f5334f4ff69126ae933745b9f937658) Updated repos/emacs
* [`64730859`](https://github.com/nix-community/emacs-overlay/commit/64730859c8decadbbc7f9b133af438306c441c3f) Updated repos/melpa
* [`0856ec24`](https://github.com/nix-community/emacs-overlay/commit/0856ec24f3bef9d778dbc7513d32c7db17301ecc) Updated repos/elpa
* [`0626733c`](https://github.com/nix-community/emacs-overlay/commit/0626733cfc6acdadd3a2685063d7100c25b23b1e) Updated repos/emacs
* [`42fdbe13`](https://github.com/nix-community/emacs-overlay/commit/42fdbe1322a4d9bdafa68b9ec94f477994d7b919) Updated repos/melpa
* [`c5f01edf`](https://github.com/nix-community/emacs-overlay/commit/c5f01edf49f54bfce90cd978121b496b51dbd886) Updated repos/emacs
* [`aad52b34`](https://github.com/nix-community/emacs-overlay/commit/aad52b340375a4dd8e4916306c0cdd52caacd725) Updated repos/melpa
* [`b63cf575`](https://github.com/nix-community/emacs-overlay/commit/b63cf575927c768ad4dbc4a70f64201e59cf3da6) Updated repos/nongnu
* [`23513ddc`](https://github.com/nix-community/emacs-overlay/commit/23513ddc6941b1c6bd2dac46451e79d3237801ae) Updated repos/emacs
* [`b7102ef6`](https://github.com/nix-community/emacs-overlay/commit/b7102ef6e2389ef88c91b6f87fe2b981c0ecc567) Updated repos/melpa
* [`5b44d966`](https://github.com/nix-community/emacs-overlay/commit/5b44d966a3d3de78bd652c86542805f267d25537) Updated repos/elpa
* [`b162e43f`](https://github.com/nix-community/emacs-overlay/commit/b162e43fe6e4608560bc7f9ebfd125e6c8b0107c) Updated repos/emacs
* [`f3f76b7b`](https://github.com/nix-community/emacs-overlay/commit/f3f76b7ba1359b070df55ae2c80c18d662fbd71f) Updated repos/melpa
* [`31042303`](https://github.com/nix-community/emacs-overlay/commit/31042303652c6264589a63a59f3cfeddf0701ca3) Updated repos/elpa
* [`9ae9e7ec`](https://github.com/nix-community/emacs-overlay/commit/9ae9e7ec7d674bd8a7d16e1a7bfd57564a61a7f6) Updated repos/emacs
* [`5a1c44b7`](https://github.com/nix-community/emacs-overlay/commit/5a1c44b73d0b0c22559679073e901b793471861c) Updated repos/melpa
* [`c12e6782`](https://github.com/nix-community/emacs-overlay/commit/c12e6782e78b831afe482daabf0d418bdd6a8c2d) Updated repos/nongnu
* [`e12bebac`](https://github.com/nix-community/emacs-overlay/commit/e12bebac0fcd6f882aecd4053207031103bb911f) Updated repos/emacs
* [`e98ec0df`](https://github.com/nix-community/emacs-overlay/commit/e98ec0df74dbb00225850b7090b0fe59f12d9b01) Updated repos/melpa
* [`6bfbd4bc`](https://github.com/nix-community/emacs-overlay/commit/6bfbd4bcaed62bf7f1a74343949094c4ea75348f) Updated repos/elpa
* [`c265dd3a`](https://github.com/nix-community/emacs-overlay/commit/c265dd3ae69a888d817b222ae34e6cae39ab59de) Updated repos/emacs
* [`5959aa48`](https://github.com/nix-community/emacs-overlay/commit/5959aa48e3406a4f74281e7dc6136460d0a55a2b) Updated repos/melpa
* [`7f6e264e`](https://github.com/nix-community/emacs-overlay/commit/7f6e264e13f11b263db626b7210f3b603af08ec9) Updated repos/elpa
* [`311eeac7`](https://github.com/nix-community/emacs-overlay/commit/311eeac77b110462c1f80c93c1cc2f444689d53c) Updated repos/emacs
* [`455cefa9`](https://github.com/nix-community/emacs-overlay/commit/455cefa9eabee05a6a8ea55654d2f87dfb93a879) Updated repos/melpa
* [`d0d9310e`](https://github.com/nix-community/emacs-overlay/commit/d0d9310e383f25872db7dea6a2b60dbc13db9ee4) Updated repos/melpa
* [`c02cfe11`](https://github.com/nix-community/emacs-overlay/commit/c02cfe11649018c3e31c8c4a4d91233b1e62d487) Updated repos/melpa
* [`0968c208`](https://github.com/nix-community/emacs-overlay/commit/0968c2084c7b59c591bcd55617ffc491fe9401c9) Updated repos/elpa
* [`156c8a3e`](https://github.com/nix-community/emacs-overlay/commit/156c8a3e833726d7411625d7b45fcffa6ad79e18) Updated repos/emacs
* [`8365523d`](https://github.com/nix-community/emacs-overlay/commit/8365523d10c9fca0a232e5dfaaad783bf34ecf02) Updated repos/melpa
* [`1c782619`](https://github.com/nix-community/emacs-overlay/commit/1c78261981f409b60a23d8c246f6508bf1d6834b) Updated repos/elpa
* [`b39095ca`](https://github.com/nix-community/emacs-overlay/commit/b39095ca053853c7d00685e2c9172348e79e7c49) Updated repos/emacs
* [`fa7dedfa`](https://github.com/nix-community/emacs-overlay/commit/fa7dedfa5e1171a76ff78a1260064e1b20ec93bb) Updated repos/melpa
* [`ebc21994`](https://github.com/nix-community/emacs-overlay/commit/ebc21994026b61967b55556d8215a613a1bc9a41) Updated repos/elpa
* [`87283bd5`](https://github.com/nix-community/emacs-overlay/commit/87283bd5f4e015177c8d5b91ca867f60a7575c8b) Updated repos/emacs
* [`ad839f83`](https://github.com/nix-community/emacs-overlay/commit/ad839f83ca7ceb0f5f0b301da847366ecf57ef49) Updated repos/melpa
* [`47615873`](https://github.com/nix-community/emacs-overlay/commit/4761587385f90d4c4442dfe58a38b554d41a8e70) Updated repos/emacs
* [`11f1b755`](https://github.com/nix-community/emacs-overlay/commit/11f1b755fb5b78d7af074fcffe7dfcced082305d) Updated repos/melpa
* [`e989f32e`](https://github.com/nix-community/emacs-overlay/commit/e989f32e7b5c61fef125eaf5a54dd80a144287b0) Updated repos/emacs
* [`ccc0a519`](https://github.com/nix-community/emacs-overlay/commit/ccc0a51900aac43bd59743cb3fdccd76eb5e68d6) Updated repos/melpa
* [`8bf1584f`](https://github.com/nix-community/emacs-overlay/commit/8bf1584f2569a2c252d8d7d577a1c20652a75f93) Updated repos/emacs
* [`1c84fffb`](https://github.com/nix-community/emacs-overlay/commit/1c84fffbf6214e002bd90bee9a1e4c7f3845f6c2) Updated repos/melpa
* [`cfc908b1`](https://github.com/nix-community/emacs-overlay/commit/cfc908b14fda2b7065e9841382ca82024791cc05) Updated repos/nongnu
* [`5bd6b435`](https://github.com/nix-community/emacs-overlay/commit/5bd6b435915e95101a2400fa552e4f6f282e74b6) Add tree-sitter-html
* [`57455eac`](https://github.com/nix-community/emacs-overlay/commit/57455eacf1239a4b1842c05c33faeaa458aa11f9) Updated repos/emacs
* [`93d97996`](https://github.com/nix-community/emacs-overlay/commit/93d9799629140618a9b18930fd3e3d3d5b5fe452) Updated repos/melpa
* [`3d15610c`](https://github.com/nix-community/emacs-overlay/commit/3d15610ce2f935b715de2afe1b4bad38f25e34da) Updated repos/emacs
* [`69067d7a`](https://github.com/nix-community/emacs-overlay/commit/69067d7a328f6e8542aefcdb440bb898cbdfd8a7) Updated repos/melpa
* [`9576aced`](https://github.com/nix-community/emacs-overlay/commit/9576acedb5e242be13741475bd0df81abbed958f) Updated repos/emacs
* [`184ae9c3`](https://github.com/nix-community/emacs-overlay/commit/184ae9c371a6251564e0b07391f7e9aaf310f002) Updated repos/melpa
* [`50771a21`](https://github.com/nix-community/emacs-overlay/commit/50771a213ea23c0ad1de68d8eaa2e3734ff05223) Updated repos/melpa
* [`eebaab5f`](https://github.com/nix-community/emacs-overlay/commit/eebaab5f383cc523aacfc976c195bac7d31e3441) Updated repos/elpa
* [`92524fd2`](https://github.com/nix-community/emacs-overlay/commit/92524fd243f9a1f7c25215458787995dade10ec7) Updated repos/emacs
* [`fa16809c`](https://github.com/nix-community/emacs-overlay/commit/fa16809cea4b20dd786f70c18f2b9007e3dc763c) Updated repos/melpa
* [`9bf1cacc`](https://github.com/nix-community/emacs-overlay/commit/9bf1cacc38c1d03ae379e1b008c52f2d999e7a8d) Updated repos/nongnu
* [`100c28bd`](https://github.com/nix-community/emacs-overlay/commit/100c28bd32ecf838f85939cad5b62b5969c41821) Updated repos/melpa
* [`908646b9`](https://github.com/nix-community/emacs-overlay/commit/908646b952e01a03b292cdda646e81b5ced87aa9) Updated repos/nongnu
* [`1d412618`](https://github.com/nix-community/emacs-overlay/commit/1d412618e106acf88e5b50a275c62206512888ca) Updated repos/emacs
* [`5ceb5ddb`](https://github.com/nix-community/emacs-overlay/commit/5ceb5ddbdba19411bf9cd201a532bbbd03fb538b) Updated repos/melpa
* [`4c7a22c0`](https://github.com/nix-community/emacs-overlay/commit/4c7a22c05b1380808391b6bf43688a44bbfb7353) Updated repos/nongnu
* [`b4f5a551`](https://github.com/nix-community/emacs-overlay/commit/b4f5a551558f272382a85bff003ebe34957faec5) Updated repos/elpa
* [`c953dd08`](https://github.com/nix-community/emacs-overlay/commit/c953dd08d06a3aab40b8f1d0b6b0ee431f57b1d3) Updated repos/emacs
* [`274a6049`](https://github.com/nix-community/emacs-overlay/commit/274a6049a74c67f6105da9ea1b522d104eaf92dc) Updated repos/melpa
* [`10b235ad`](https://github.com/nix-community/emacs-overlay/commit/10b235ada45ae980b2c8e72d1d1dd8cc70cc3d59) Updated repos/elpa
* [`eb9b7140`](https://github.com/nix-community/emacs-overlay/commit/eb9b71408585443276d52131a4d29a428edb44f7) Updated repos/emacs
* [`2164c881`](https://github.com/nix-community/emacs-overlay/commit/2164c8819a19ab33b280ca0c0575bd5a17829b7c) Updated repos/melpa
* [`eb3b8c69`](https://github.com/nix-community/emacs-overlay/commit/eb3b8c69fdc10e44090b7dde8bf83bd9651329c7) Updated repos/melpa
* [`d5316379`](https://github.com/nix-community/emacs-overlay/commit/d53163791c6c6fdb0132339f0fca01a3593ece87) Updated repos/melpa
* [`05b466b9`](https://github.com/nix-community/emacs-overlay/commit/05b466b981a7b2d559a441927c1f660a6752a025) Updated repos/elpa
* [`15f7310f`](https://github.com/nix-community/emacs-overlay/commit/15f7310fafeb01d9e574c49037105d2aaf46ae4c) Updated repos/emacs
* [`53018b60`](https://github.com/nix-community/emacs-overlay/commit/53018b60fc15aaac1722031e50b043883b74fcd0) Updated repos/melpa
* [`f38bcebf`](https://github.com/nix-community/emacs-overlay/commit/f38bcebf77442ae05f37c67a7ce93f9135ce5af5) Updated repos/elpa
* [`be2e9cae`](https://github.com/nix-community/emacs-overlay/commit/be2e9caec9ec4aae477e59af4bc9e38999e4f1f4) Updated repos/melpa
* [`9b18e0da`](https://github.com/nix-community/emacs-overlay/commit/9b18e0da77742c239523b0bd284647aa71b3005e) Updated repos/elpa
* [`7970ed08`](https://github.com/nix-community/emacs-overlay/commit/7970ed0829678eefa33309fb22149ad9615c69f1) Updated repos/emacs
* [`f0c91f45`](https://github.com/nix-community/emacs-overlay/commit/f0c91f4589afa6581c4c63cf909c8be68e55465b) Updated repos/melpa
* [`c485a42c`](https://github.com/nix-community/emacs-overlay/commit/c485a42c9cba41b96ba216812e6d739c2f716009) Updated repos/melpa
* [`6b44cc8a`](https://github.com/nix-community/emacs-overlay/commit/6b44cc8a441bed3796e6ddc984745fcdeaba8aa4) Updated repos/nongnu
* [`167eb388`](https://github.com/nix-community/emacs-overlay/commit/167eb3887a0774c2bbf33d679c05919298dfe343) Updated repos/elpa
* [`4506c1f3`](https://github.com/nix-community/emacs-overlay/commit/4506c1f3a966518bb3cd2a114ecdffb0e4eca960) Updated repos/emacs
* [`acff9f41`](https://github.com/nix-community/emacs-overlay/commit/acff9f41c4962704acb8008e5ff5b90a43cf7758) Updated repos/melpa
* [`1c93656f`](https://github.com/nix-community/emacs-overlay/commit/1c93656f259af0ceb5738aecd67e3c1ee25e7a3a) Updated repos/elpa
* [`f0c737fa`](https://github.com/nix-community/emacs-overlay/commit/f0c737faf06880ea4162202a4cfc259d7d971b12) Updated repos/emacs
* [`0de52764`](https://github.com/nix-community/emacs-overlay/commit/0de52764b28fd1c0aaa9567203a62426957fb38b) Updated repos/melpa
* [`c736159b`](https://github.com/nix-community/emacs-overlay/commit/c736159b77febee492e6262c8b65a3c52e6dc291) Updated repos/melpa
* [`3dcc6a53`](https://github.com/nix-community/emacs-overlay/commit/3dcc6a53b8f7e576ef8b6676c557cf13b8d2c4e7) Updated repos/elpa
* [`9cbe5238`](https://github.com/nix-community/emacs-overlay/commit/9cbe523889c79e9ba0ab61c02e68a7297f206fc3) Updated repos/emacs
* [`1e9e9e62`](https://github.com/nix-community/emacs-overlay/commit/1e9e9e62a5a37c262b4f31ee8cc97d40894d1874) Updated repos/melpa
* [`0ce6f349`](https://github.com/nix-community/emacs-overlay/commit/0ce6f349ab23a420490a23b1f331e14e709d9c0a) Updated repos/elpa
* [`c577999f`](https://github.com/nix-community/emacs-overlay/commit/c577999f68405386c9c81a5cf5d75ebbe5ebe640) Updated repos/emacs
* [`d2d7a3c5`](https://github.com/nix-community/emacs-overlay/commit/d2d7a3c5eb96fa6ca486b3adc0694295aedef6c7) Updated repos/melpa
* [`fa8e052d`](https://github.com/nix-community/emacs-overlay/commit/fa8e052d22b0cb283ba6656559c62e2cb2fe049e) Updated repos/emacs
* [`c595b26b`](https://github.com/nix-community/emacs-overlay/commit/c595b26be85c85c352ac3f058f2726686ca3a1ee) Updated repos/melpa
* [`4e3f717b`](https://github.com/nix-community/emacs-overlay/commit/4e3f717b95d4acaa0afb82a3ae2292e75524efdb) Updated repos/elpa
* [`ec0f7cfd`](https://github.com/nix-community/emacs-overlay/commit/ec0f7cfdd66b4c8849ce2dbdad953d8090132155) Updated repos/emacs
* [`8e79aca6`](https://github.com/nix-community/emacs-overlay/commit/8e79aca6bcc85a0b5d9e6c86d2bc9e16aecffd4b) Updated repos/melpa
* [`d1ea6872`](https://github.com/nix-community/emacs-overlay/commit/d1ea6872b199edc680917a7248b596e532297538) Updated repos/nongnu
* [`e805bcc2`](https://github.com/nix-community/emacs-overlay/commit/e805bcc20a956215d70bb2d44032d4d4d6fcfdcd) Updated repos/elpa
* [`64851c8f`](https://github.com/nix-community/emacs-overlay/commit/64851c8f5701cd00995d27f6a018395fdaa86ba3) Updated repos/emacs
* [`a1ba95fe`](https://github.com/nix-community/emacs-overlay/commit/a1ba95fe5dc8b7dd493f86a5a3cbf0e4385a03c7) Updated repos/melpa
* [`c67c5bfa`](https://github.com/nix-community/emacs-overlay/commit/c67c5bfa005e083875d5b25bf96ffd24885985d4) Updated repos/nongnu
* [`21b24958`](https://github.com/nix-community/emacs-overlay/commit/21b24958c1b60ebfa5a761ba2301686ee4784e0c) Updated repos/emacs
* [`d23a3449`](https://github.com/nix-community/emacs-overlay/commit/d23a3449c8f26fb264402d3f7fb3fc7064b70e07) Updated repos/melpa
* [`34e85ada`](https://github.com/nix-community/emacs-overlay/commit/34e85ada035c5a6851b09af573c12589a4f3953b) Updated repos/elpa
* [`c3eaa953`](https://github.com/nix-community/emacs-overlay/commit/c3eaa953604bf08cd7c8bca88d29c216976f5d27) Updated repos/emacs
* [`1d2409ef`](https://github.com/nix-community/emacs-overlay/commit/1d2409effbdebad47fb887ff6305f3da1fea5965) Updated repos/melpa
* [`41530312`](https://github.com/nix-community/emacs-overlay/commit/4153031275d1db12a40e6882b09a8e5dfafa1f36) Updated repos/elpa
* [`db19c252`](https://github.com/nix-community/emacs-overlay/commit/db19c25226deb094871cc4d1944cf24dd74730f0) Updated repos/melpa
* [`ee1f91d5`](https://github.com/nix-community/emacs-overlay/commit/ee1f91d538ac4c09eb7f7c007846f6bef1950a41) Updated repos/emacs
* [`ffab139d`](https://github.com/nix-community/emacs-overlay/commit/ffab139d704bdec0c1d894f667c0fb9fe6261b80) Updated repos/melpa
* [`f40b555b`](https://github.com/nix-community/emacs-overlay/commit/f40b555b6d0c68dad9a149c3e71e7b7733883634) Updated repos/elpa
* [`917df605`](https://github.com/nix-community/emacs-overlay/commit/917df605c7218b7d306d4194d967ba58bc24fa7e) Updated repos/emacs
* [`5c7ac97e`](https://github.com/nix-community/emacs-overlay/commit/5c7ac97e616c6d162c086d417a221831fd871ef3) Updated repos/melpa
* [`a649a39e`](https://github.com/nix-community/emacs-overlay/commit/a649a39e3d83f4fa5ce419546d3ab9caab00fe71) Updated repos/elpa
* [`c55f90ec`](https://github.com/nix-community/emacs-overlay/commit/c55f90ec11c6bab025ed06b5e229aa42f095b9b6) Updated repos/emacs
* [`9e19d1aa`](https://github.com/nix-community/emacs-overlay/commit/9e19d1aa6f9e87201108a54ece57ab4841655172) Updated repos/melpa
* [`3c0026d5`](https://github.com/nix-community/emacs-overlay/commit/3c0026d5a370c205d53ecfc5c0e5a3e71b36eb23) Updated repos/nongnu
* [`ce3b8f02`](https://github.com/nix-community/emacs-overlay/commit/ce3b8f023873cc77e8953143d101e8baf1bd9c8c) Updated repos/emacs
* [`2b15bcc8`](https://github.com/nix-community/emacs-overlay/commit/2b15bcc895fbb78f6eab189f2cf03f576d376a62) Updated repos/melpa
* [`c1134426`](https://github.com/nix-community/emacs-overlay/commit/c113442689b39fc1ad029b21512642fccc87ff74) Updated repos/elpa
* [`f5689d4d`](https://github.com/nix-community/emacs-overlay/commit/f5689d4d9a0d1c4dd8fee769d137daec0f02dc4a) Updated repos/melpa
