### PR TITLE
niv spacemacs: update 9e3fc598 -> 5b8a25a6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "9e3fc598ad7f7c241b0d60cd3f165f4a34ecf4c2",
-        "sha256": "119fpnnb8j07m5hc9v5p0dwhpj2zw8qk5bdkp9acg6xfxc88m629",
+        "rev": "5b8a25a6b7cb9f070852144fc71824b1e01a5711",
+        "sha256": "0iibnmpv6lwkj5ckpw2fgs8r0gxirlkryqn6l5fazvpycfhgs05b",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/9e3fc598ad7f7c241b0d60cd3f165f4a34ecf4c2.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/5b8a25a6b7cb9f070852144fc71824b1e01a5711.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@9e3fc598...5b8a25a6](https://github.com/syl20bnr/spacemacs/compare/9e3fc598ad7f7c241b0d60cd3f165f4a34ecf4c2...5b8a25a6b7cb9f070852144fc71824b1e01a5711)

* [`7e852408`](https://github.com/syl20bnr/spacemacs/commit/7e8524086c4170934df1ced9856470e6348ce9d4) org-layer: Update to org 9.6.1, fixing broken install
* [`d08822c6`](https://github.com/syl20bnr/spacemacs/commit/d08822c6148cf7942ae3953c363257b9a7cc92ab) Fixing side effects of org version mismatch hotfix
* [`50825419`](https://github.com/syl20bnr/spacemacs/commit/50825419ab86983e0019c1142d548b0389c50c01) Remove the docker tramp obsolete warning ([syl20bnr/spacemacs⁠#15899](https://togithub.com/syl20bnr/spacemacs/issues/15899))
* [`58a52ae6`](https://github.com/syl20bnr/spacemacs/commit/58a52ae6ef6c573bb9731cfcf1b9fe95627b2cc9) [bot] "built_in_updates" Sun Jan 22 16:50:05 UTC 2023 ([syl20bnr/spacemacs⁠#15900](https://togithub.com/syl20bnr/spacemacs/issues/15900))
* [`2c549143`](https://github.com/syl20bnr/spacemacs/commit/2c5491437024b6b744cfe98ff49a84d5f79afc34) layers/+lang/python/funcs.el: Fix typo in flag ([syl20bnr/spacemacs⁠#15905](https://togithub.com/syl20bnr/spacemacs/issues/15905))
* [`91e2a4f3`](https://github.com/syl20bnr/spacemacs/commit/91e2a4f3969d58143516b57428d16915a500c520) Do not call org-agenda-files if org-mode is already loaded ([syl20bnr/spacemacs⁠#15908](https://togithub.com/syl20bnr/spacemacs/issues/15908))
* [`5b8a25a6`](https://github.com/syl20bnr/spacemacs/commit/5b8a25a6b7cb9f070852144fc71824b1e01a5711) Docker and Kubernetes layers fixes ([syl20bnr/spacemacs⁠#15906](https://togithub.com/syl20bnr/spacemacs/issues/15906))
