### PR TITLE
niv nixpkgs: update 8afc5921 -> fb020498

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8afc5921f9efd3621c828949ae8741559fedb4e9",
-        "sha256": "119hpja8r4v24zxwiscssl9ylrsqcglp5q4nrbxqpjwjsnhhx6mb",
+        "rev": "fb020498b83c223b6fca4b443c267bfc91087c64",
+        "sha256": "0lg1f0qak6xz0ij4n1wq970cp2mmwcv3lzdmyfyglgl5a2vb9d3k",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/8afc5921f9efd3621c828949ae8741559fedb4e9.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/fb020498b83c223b6fca4b443c267bfc91087c64.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@8afc5921...fb020498](https://github.com/nixos/nixpkgs/compare/8afc5921f9efd3621c828949ae8741559fedb4e9...fb020498b83c223b6fca4b443c267bfc91087c64)

* [`cd78ec13`](https://github.com/NixOS/nixpkgs/commit/cd78ec13ab828d0cda1e533e035c2d0948a9eaa4) nixos/lightdm: changed minimum-uid to 1000
* [`db74bf53`](https://github.com/NixOS/nixpkgs/commit/db74bf537556218e7fe48c03729b6ab9bff26b6c) nixos/users: isSystemUser below 1000 above 400
* [`75e76c44`](https://github.com/NixOS/nixpkgs/commit/75e76c44965edb274c72f0b84764eb2e09b8d862) unixODBC: 2.3.9 -> 2.3.11
* [`44785549`](https://github.com/NixOS/nixpkgs/commit/44785549a7a7d8c2de79773329c217b8c4c2b369) zabbix.proxy-sqlite: fix cross compilation by setting AR and RANLIB, and
* [`1ca18c81`](https://github.com/NixOS/nixpkgs/commit/1ca18c812488d22fce3c4594fa9dff0f8d9216e2) csound: use portaudio module on darwin
* [`a69d7240`](https://github.com/NixOS/nixpkgs/commit/a69d724050e993747a4316b7245439d32d1922c5) strongswanTNC: 5.9.7 -> 5.9.8
* [`ac864f6d`](https://github.com/NixOS/nixpkgs/commit/ac864f6d7c4642f0dbde4e8ee26350e989dd1ed6) strongswanNM: 5.9.7 -> 5.9.8
* [`d6945355`](https://github.com/NixOS/nixpkgs/commit/d69453559a25b05758d16508214c67c5edba0933) apple_sdk_11_0: install swift modules
* [`6a20451a`](https://github.com/NixOS/nixpkgs/commit/6a20451ac0af693a95dd071c1e525b06c04c0ceb) apple_sdk_11_0: Foundation depends on Combine
* [`e23a9770`](https://github.com/NixOS/nixpkgs/commit/e23a97700f4e5efcf85040693f2752408e67cccd) apple_sdk_11_0: Fix missing CoreVideo include
* [`6062fd08`](https://github.com/NixOS/nixpkgs/commit/6062fd0800952efac3b8a986215fe5f60d984b8b) apple_sdk_11_0: Add SwiftUI dependencies
* [`64e53896`](https://github.com/NixOS/nixpkgs/commit/64e5389634bad9ac9ad80f50533f7d73d3cf9a39) xcbuild: add JSON variant of SDKSettings
* [`2c2b799d`](https://github.com/NixOS/nixpkgs/commit/2c2b799dba29e6fca8fea3c3911a5291fff42b90) xcbuild: exit with error if --find fails
* [`8ed924c0`](https://github.com/NixOS/nixpkgs/commit/8ed924c07a72849dbca9eb4fb8f13e45dc0e0429) swift: compiler only build & darwin support
* [`3c54a5dc`](https://github.com/NixOS/nixpkgs/commit/3c54a5dce6119d1dab8838ca6766ea4e3d257e00) swiftPackages.Dispatch: 5.5 -> 5.7
* [`89f97908`](https://github.com/NixOS/nixpkgs/commit/89f979085894124912f152dc8db11076518e66ac) swiftPackages.Foundation: init at 5.7
* [`0b877d85`](https://github.com/NixOS/nixpkgs/commit/0b877d85e53de20a64e79e868bdcfff1ddac442a) swiftPackages.XCTest: init at 5.7
* [`4f082f52`](https://github.com/NixOS/nixpkgs/commit/4f082f522ee7da61ee94b354b26525c155176755) swiftpm2nix: init
* [`ece9224c`](https://github.com/NixOS/nixpkgs/commit/ece9224c8a6e9099306e8a0afc85d917e0f14066) swiftpm: init at 5.7
* [`dcb0eaf6`](https://github.com/NixOS/nixpkgs/commit/dcb0eaf66d3ad5f1826a8c6b629b6cb3afb42603) swift-driver: init at 5.7
* [`ce2dd8b8`](https://github.com/NixOS/nixpkgs/commit/ce2dd8b8de4d75b0ea381acb43976bbd4375efe9) sourcekit-lsp: init at 5.7
* [`d63aef6c`](https://github.com/NixOS/nixpkgs/commit/d63aef6c479021ebc0bcb67ea852bee0041d4474) swift-docc: init at 5.7
* [`7bd0044a`](https://github.com/NixOS/nixpkgs/commit/7bd0044abd5f703a015c256adb6c55925cf1c528) pokemonsay: unstable-2021-10-05 -> 1.0.0, fix tests, apply word-wrap patch
* [`84337ca5`](https://github.com/NixOS/nixpkgs/commit/84337ca5a4ffa473edf6a844f8230fa332744d48) maintainers: add samhug
* [`b254f540`](https://github.com/NixOS/nixpkgs/commit/b254f540ff266a06fdee16674982da826f3dfbb4) pop-launcher: init at 1.2.1
* [`cd108c68`](https://github.com/NixOS/nixpkgs/commit/cd108c688dae9f2a2e5127b9e09909fbd3f4a5b6) dnsdist: 1.7.2 -> 1.7.3
* [`bd99b3b8`](https://github.com/NixOS/nixpkgs/commit/bd99b3b8ff843f0859c27dea1cf7ad0cc9bc1753) nixos/plymouth: don't start Plymouth on config switch
* [`5e635986`](https://github.com/NixOS/nixpkgs/commit/5e635986cadb1cd12de8349b428878cf7122a9c6) nixos/plasma: leave `displayManager.setupCommands` alone
* [`0e08b082`](https://github.com/NixOS/nixpkgs/commit/0e08b082b894e987e89acb32b38f68f32f65c3d0) swiftpm: improve setup hook shell conditions
* [`449e2f1b`](https://github.com/NixOS/nixpkgs/commit/449e2f1b017b232118ceb85606fec294bae5b983) swift: track version in a central sources.nix
* [`9cb71639`](https://github.com/NixOS/nixpkgs/commit/9cb7163973209084290dae1f8c3d2520b427b94f) swiftpm2nix: reduce duplication in generated files
* [`7d559a3c`](https://github.com/NixOS/nixpkgs/commit/7d559a3cb38276bb809479cede72d01787a39f42) swiftPackages: update swiftpm2nix generated files
* [`a8f9977c`](https://github.com/NixOS/nixpkgs/commit/a8f9977c6f84ff55eb03b015da040acc6bc161f4) swiftpm: typo fixes
* [`aae35562`](https://github.com/NixOS/nixpkgs/commit/aae355626f804d662d1cc81e8880513ebb008e60) swiftpm: factor out cmake glue installation
* [`a4c8c87c`](https://github.com/NixOS/nixpkgs/commit/a4c8c87cb12a9f7b381d2cfe1d212b101c1c1453) swift: remove NIX_BUILD_TOP
* [`da15d447`](https://github.com/NixOS/nixpkgs/commit/da15d44729ab168497db3e751d2c358daae5ac66) swiftPackages.Foundation: add note about CF
* [`72ba2936`](https://github.com/NixOS/nixpkgs/commit/72ba29367503fe46b6e4237bcbea4c94f6101bbe) swift: remove internal wrapperParams arg
* [`a567024b`](https://github.com/NixOS/nixpkgs/commit/a567024b44e91099a7ce9ffcd377cf7350c00ffd) swift: add canary to verify no compiler dependency
* [`813c58da`](https://github.com/NixOS/nixpkgs/commit/813c58dab17bb3ea910bd5101db61191a6573f19) swiftPackages.Dispatch: fix linux build
* [`2b14eec4`](https://github.com/NixOS/nixpkgs/commit/2b14eec435ad7b4e7a3ca571458b176ef0367039) tabula: mark as broken
* [`461ae1ef`](https://github.com/NixOS/nixpkgs/commit/461ae1efb5e6f1432ff80b4a4f97ff0a4b6d5fa7) hdhomerun-config-gui: 20210224 -> 20221031
* [`1d61d168`](https://github.com/NixOS/nixpkgs/commit/1d61d168a6fe30eb42c02fff8a097a5c224c7ec9) nixos/bluetooth: add input and network service configs
* [`44319dc9`](https://github.com/NixOS/nixpkgs/commit/44319dc91185e3b67224572494b09ac5561b9203) nixos/openconnect: use alternative protocol
* [`ed0b8c26`](https://github.com/NixOS/nixpkgs/commit/ed0b8c26f127525a9ee66f895bdc894cdaa5d685) lib/strings: add `concatLines`
* [`01d84d1a`](https://github.com/NixOS/nixpkgs/commit/01d84d1aef9d7778883e9ca9e9d24decd66cd21f) sioyek: link binary on darwin
* [`e6f973ee`](https://github.com/NixOS/nixpkgs/commit/e6f973eeabff82c437c6adf8254227b073ffb5a7) matterbridge: only build main package
* [`58107eca`](https://github.com/NixOS/nixpkgs/commit/58107eca57653a3342e58b3909b36d0109467c01) libsForQt5.qca-qt5: 2.3.4 -> 2.3.5
* [`5629b8ab`](https://github.com/NixOS/nixpkgs/commit/5629b8aba1e3e4259b24a45c0f273c6e8542fbaf) poac: 0.4.1 -> 0.5.1
* [`a5b4e5b9`](https://github.com/NixOS/nixpkgs/commit/a5b4e5b9d64c577853487fa6dbf8f93c2a4cd0bf) xrootd: provide fuse support (xrootdfs) for Darwin
* [`16516fa2`](https://github.com/NixOS/nixpkgs/commit/16516fa2a72f9b0a90194bf6dd9c302a778e89fa) xrootd.passthru.tests: only add test-runner for Linux
* [`4f424907`](https://github.com/NixOS/nixpkgs/commit/4f424907226c783b9203c5cddcd0a5276980dc79) xrootd.passthru.test-xrdcp: init
* [`4346bbaa`](https://github.com/NixOS/nixpkgs/commit/4346bbaafae9e83ff7625827355c2bed5c27cde5) python3Packages.blis: 0.9.1 -> 0.7.9
* [`511f21df`](https://github.com/NixOS/nixpkgs/commit/511f21df7c821bea7aba86fd4062d5fed9af948d) darwin.apple_sdk_11_0: add Security dependency on xpc
* [`bee48024`](https://github.com/NixOS/nixpkgs/commit/bee480241329615b15a58c839c07ca65590e12e3) matrix-commander: set platforms to unix
* [`dc2a266a`](https://github.com/NixOS/nixpkgs/commit/dc2a266a80ede59e2e64dda7c739c109d290f2bb) lvm2: 2.03.17 -> 2.03.18
* [`80d77c3d`](https://github.com/NixOS/nixpkgs/commit/80d77c3d048350b8ca69e7a5da856d7a3871b547) llvmPackages_8.lldb: enable installCheckPhase, add message
* [`0a968846`](https://github.com/NixOS/nixpkgs/commit/0a968846e1db86e27a04a0f80df4b91622e98044) llvmPackages_9.lldb: enable installCheckPhase, add message
* [`44554bd9`](https://github.com/NixOS/nixpkgs/commit/44554bd94134bab63734ecbf44e3b355f1d2dc3d) llvmPackages_10.lldb: enable installCheckPhase, add message
* [`e4d24b71`](https://github.com/NixOS/nixpkgs/commit/e4d24b7187f61b6de8ffcf4f2b2a1304df36b108) llvmPackages_11.lldb: enable installCheckPhase, add message
* [`6346b158`](https://github.com/NixOS/nixpkgs/commit/6346b158ec599ce1b59bc5de9b616499f35abde7) llvmPackages_12.lldb: enable installCheckPhase, add message
* [`4ac8aa73`](https://github.com/NixOS/nixpkgs/commit/4ac8aa736e0175b0a847d9c15550eeb188b35325) llvmPackages_13.lldb: enable installCheckPhase, add message
* [`ebf37796`](https://github.com/NixOS/nixpkgs/commit/ebf3779600859c4154bfd451154bcaa101b88cfd) llvmPackages_14.lldb: enable installCheckPhase, add message
* [`74616a18`](https://github.com/NixOS/nixpkgs/commit/74616a18ab828ff01ff9c9b050974ffaa8b98862) llvmPackages_14.lldb: fix broken lua and python3 site-packages install dir
* [`d259884f`](https://github.com/NixOS/nixpkgs/commit/d259884f7d3588010e97bc0ca248b1ced86914e6) lsof: 4.96.4 -> 4.96.5
* [`5c90ea3f`](https://github.com/NixOS/nixpkgs/commit/5c90ea3fa6841484fffde6c04d04461a69ae7582) Add wayland support
* [`1aaf4302`](https://github.com/NixOS/nixpkgs/commit/1aaf43022fc002e59ad4a3971da4339ffdff83e1) postgresqlPackages.pgaudit: init at 1.7.0
* [`eaa0e349`](https://github.com/NixOS/nixpkgs/commit/eaa0e34921b5ed0081acbf5801aa5f90e81d461f) libcbor: 0.9.0 -> 0.10.0
* [`5732c263`](https://github.com/NixOS/nixpkgs/commit/5732c263b78cebd8b2ab9ee87703100b2528c97c) libcbor: add some key reverse dependencies to passthru.tests
* [`e3992325`](https://github.com/NixOS/nixpkgs/commit/e39923253d4078eb982a615d59345557d08547f8) libcbor: enable tests
* [`4def6d82`](https://github.com/NixOS/nixpkgs/commit/4def6d828bef775c58ac05d21bbea3ae45a24a67) fmtoy: unstable-2021-12-24 -> unstable-2022-12-23
* [`5101d61d`](https://github.com/NixOS/nixpkgs/commit/5101d61da4858be72265fa9b9c5cee0c649eb807) ncurses: 6.3-p20220507 -> 6.4
* [`ad9521e0`](https://github.com/NixOS/nixpkgs/commit/ad9521e07e188572fb64f4941b8eb770c7a7e20c) multipath-tools: 0.9.3 -> 0.9.4
* [`99b56a91`](https://github.com/NixOS/nixpkgs/commit/99b56a9139a6a125bc73afb8f3c30bba1a002148) gcc/builder.sh: drop dead RPATH clobbering code
* [`12cfea32`](https://github.com/NixOS/nixpkgs/commit/12cfea32f825c89200d279efae235d93b7be7ad7) secp256k1: unstable-2022-02-06 -> 0.2.0
* [`89d3fe87`](https://github.com/NixOS/nixpkgs/commit/89d3fe878c6a04bd2377900a7da4c3044983e368) gtk3: 3.24.35 -> 3.24.36
* [`b470a6b2`](https://github.com/NixOS/nixpkgs/commit/b470a6b21293d0fa29d35f7e7ac180c5b0311e87) linux/bootstrap-tools: move libstdc++ out of default library search path
* [`2c45428d`](https://github.com/NixOS/nixpkgs/commit/2c45428d83459d3a52f547529230465dc8a57688) krfb: add missing pipewire dependency
* [`2c931bd5`](https://github.com/NixOS/nixpkgs/commit/2c931bd5f404162c15de10dca8e476e5469b2994) gcc: provide both native and cross forms of gcc.libs libraries
* [`17fe63fa`](https://github.com/NixOS/nixpkgs/commit/17fe63faf9e31ce24f2bb8f0e24069d692d3e4d2) python3Packages.onnx: 1.12.0 -> 1.13.0
* [`314b0312`](https://github.com/NixOS/nixpkgs/commit/314b03125f348a2970b86dcf77d9dc8039c7a981) stdenv: don't fail installPhase on missing makefile
* [`6a61bcff`](https://github.com/NixOS/nixpkgs/commit/6a61bcff322778582dde975049de660b69834aaf) python310Packages.orjson: 3.8.2 -> 3.8.4
* [`92b12efa`](https://github.com/NixOS/nixpkgs/commit/92b12efa47a98adecc6903c40cb8a94a09c0b8a0) libva: 2.16.0 -> 2.17.0
* [`be71db89`](https://github.com/NixOS/nixpkgs/commit/be71db89eea41ae0aa1f1383e23891044e72ac86) libmpc: 1.2.1 -> 1.3.1
* [`83666885`](https://github.com/NixOS/nixpkgs/commit/83666885deffbe1a6c88e47444ac8ee3c53b5b45) fluidsynth: 2.3.0 -> 2.3.1
* [`ba11c6f1`](https://github.com/NixOS/nixpkgs/commit/ba11c6f123afdf19681de27b433ae25b0f2b95f1) setup-hooks/make-symlinks-relative.sh: match what other hooks do so
* [`0a3e68ba`](https://github.com/NixOS/nixpkgs/commit/0a3e68ba844bf17891c8702604b6149f556b447c) unzip: apply patch for CVE-2022-0529 and CVE-2022-0530
* [`6da32655`](https://github.com/NixOS/nixpkgs/commit/6da32655688c4fee4c8b7c09b220030738bbb885) box64: More platforms, dynarec option, hello test, extra maintainer
* [`c074d002`](https://github.com/NixOS/nixpkgs/commit/c074d002f1545b4c61e11d7f0acf0fe82d846588) alttpr-opentracker: 1.8.2 -> 1.8.5
* [`a566ac82`](https://github.com/NixOS/nixpkgs/commit/a566ac822c0f0d404e48bd109cb4ca8cefeeaa7a) harfbuzz: remove unnecessary gobject-introspection from buildInputs
* [`113ef8c4`](https://github.com/NixOS/nixpkgs/commit/113ef8c4aebf9d7368471441235b91e8027d5559) pango: remove unnecessary gobject-introspection from buildInputs
* [`ef641046`](https://github.com/NixOS/nixpkgs/commit/ef641046120f486d2b8709b3e01d91fabc589ead) gdk-pixbuf: remove obsolete gobject-introspection from buildInputs
* [`57c5eda1`](https://github.com/NixOS/nixpkgs/commit/57c5eda12e4d1413fc8a9d6fe98fe08acba277c3) json-glib: remove unnecessary gobject-introspection from buildInputs
* [`42d56e44`](https://github.com/NixOS/nixpkgs/commit/42d56e44f45218d39043132db8aa1489d5284110) libsoup: remove unnecessary gobject-introspection from buildInputs
* [`91acc7b9`](https://github.com/NixOS/nixpkgs/commit/91acc7b9d66fd2b894bec5d24d4b449cc7823a90) tracker: remove obsolete gobject-introspection from buildInputs
* [`80db8054`](https://github.com/NixOS/nixpkgs/commit/80db805444703faba338db58a94bcd18a0479fef) gtk3: remove obsolete gobject-introspection from buildInputs
* [`249a3ba5`](https://github.com/NixOS/nixpkgs/commit/249a3ba53b018bfb5ee6e7d939b440a773c0a008) pkgsStatic.wpa_supplicant: fix build
* [`ccc9c056`](https://github.com/NixOS/nixpkgs/commit/ccc9c0564792c3cb8586ba29c74cc02d3c06a78a) libcbor, pkgsi686Linux.libcbor: disable tests on 32-bit platforms
* [`1302f3bd`](https://github.com/NixOS/nixpkgs/commit/1302f3bd2780629a06778bd3162db9d33af6b9cf) apple-source-release: deprecate phases ([nixos/nixpkgs⁠#161535](https://togithub.com/nixos/nixpkgs/issues/161535))
* [`f742c6d4`](https://github.com/NixOS/nixpkgs/commit/f742c6d4436c26404f98c95568fd33763475dd8b) python311: fix cross compilation
* [`033ec059`](https://github.com/NixOS/nixpkgs/commit/033ec059603d268663c1fc0394f3268478033331) setup-hooks/strip.sh: redirect stdout to dev/null
* [`8c858761`](https://github.com/NixOS/nixpkgs/commit/8c858761baf06bff2fe547ee6784362919eaf7d5) python310Packages.rpy2: 3.5.6 -> 3.5.7
* [`0b7d7d82`](https://github.com/NixOS/nixpkgs/commit/0b7d7d828ddf604bdd8e07a3162cc6b6d7a84978) mpfr: 4.1.1 -> 4.2.0
* [`3e0c3c51`](https://github.com/NixOS/nixpkgs/commit/3e0c3c51a6d0949ca476f69782f3660bef23e0f5) python310Packages.nltk: 3.8 -> 3.8.1
* [`e5ac8de6`](https://github.com/NixOS/nixpkgs/commit/e5ac8de6efcf404dbbc2c4ae18d1df85f4bd56a2) maintainers: add janik
* [`68db144c`](https://github.com/NixOS/nixpkgs/commit/68db144c66854616978f0ee214dc53bf950d9e25) python310Packages.exceptiongroup: 1.0.4 -> 1.1.0
* [`b96c0110`](https://github.com/NixOS/nixpkgs/commit/b96c01108f7eb59ba6dd06a0a20b7dad11d98774) python310Packages.cachetools: add changelog to meta
* [`abf4c42e`](https://github.com/NixOS/nixpkgs/commit/abf4c42e783e2a46712f20ff2bdecd770ff45c2e) openconnect: add xdg-utils build dependency ([nixos/nixpkgs⁠#205543](https://togithub.com/nixos/nixpkgs/issues/205543))
* [`209611b2`](https://github.com/NixOS/nixpkgs/commit/209611b2e18e802752cad0c73c632530abd8d535) grafana-agent: add Darwin support
* [`35f0dcc5`](https://github.com/NixOS/nixpkgs/commit/35f0dcc5323a17021daf71c1a7487a085e8b2bab) tt-rss-theme-feedly: 2.10.0 -> 3.1.0
* [`5c298b8d`](https://github.com/NixOS/nixpkgs/commit/5c298b8d89ea825ce20c5193b198dfbfb64b8b8b) xterm: 377 -> 378
* [`8c80bd08`](https://github.com/NixOS/nixpkgs/commit/8c80bd08b7e39229947d55104d1871f5066437d9) build-support/cc-wrapper: pass in non-existent --sysroot= to untangle from libc
* [`8f0e753f`](https://github.com/NixOS/nixpkgs/commit/8f0e753f49de167e9ec21696e4170134dfe101c3) ngtcp2: 0.12.0 -> 0.12.1
* [`0060e4da`](https://github.com/NixOS/nixpkgs/commit/0060e4da37e5e49d73c256254d2ab67c8dfc2e35) python310Packages.cachetools: 5.2.0 -> 5.2.1
* [`6195c7b4`](https://github.com/NixOS/nixpkgs/commit/6195c7b47b7c21c6eb33979e381637a6e8afc1d3) libjxl: cherry-pick patch to fix tests
* [`74df5ad7`](https://github.com/NixOS/nixpkgs/commit/74df5ad72b7f5f28ce84520708c35a6877c66194) stdenv: build gettext only once
* [`4fc551f4`](https://github.com/NixOS/nixpkgs/commit/4fc551f4ddf0df178c34d6084afbfd118aa50168) qt6.qtbase: fix the libexecdir in the pkg-config config file
* [`eeb450e2`](https://github.com/NixOS/nixpkgs/commit/eeb450e20fcbeee1d10d341655e25e08c56458f0) nss: convert NIX_CFLAGS_COMPILE to a list
* [`3a41f834`](https://github.com/NixOS/nixpkgs/commit/3a41f834f0c389d0c93caadb4336ed45a32f1ce9) nss_esr: 3.79.2 -> 3.79.3
* [`11568e03`](https://github.com/NixOS/nixpkgs/commit/11568e033cd084bd7be1e4401bdf6d4c3174281c) qmk: Use pep517 based setuptools build
* [`a0bb02d3`](https://github.com/NixOS/nixpkgs/commit/a0bb02d34027368341884a07f3e5ffeee4162fec) gawk: unconditionally apply the patch to fix PIE linkage on musl
* [`88f36d26`](https://github.com/NixOS/nixpkgs/commit/88f36d2694840816f01ee1436867533669757437) gzip: make reproducible when GZIP_NO_TIMESTAMPS is set
* [`54513ae6`](https://github.com/NixOS/nixpkgs/commit/54513ae6d0becbcdbce1af9aeae357a382f74afb) roc-toolkit: guard optional libraries in buildInputs with their flags
* [`6aabf2f2`](https://github.com/NixOS/nixpkgs/commit/6aabf2f2d21f0cfc6604681f56eb654fc257ed30) roc-toolkit: add sox support
* [`8389dff3`](https://github.com/NixOS/nixpkgs/commit/8389dff3db12c660504ee6f7722e4c5a4082305a) go_1_19: 1.19.4 -> 1.19.5
* [`d9a7ea80`](https://github.com/NixOS/nixpkgs/commit/d9a7ea80533e34d02a0ed3154db95460c267759e) python3Packages.afdko: 3.9.0 -> 3.9.2
* [`97255b07`](https://github.com/NixOS/nixpkgs/commit/97255b0701c96a0aa8b9db11577d62410780d7f0) opera: 90.0.4480.84 -> 94.0.4606.54
* [`4900972f`](https://github.com/NixOS/nixpkgs/commit/4900972f9cd2eaea9871909b07af3e709baf1719) python310Packages.iteration-utilities: init at 0.11.0
* [`b38acd8b`](https://github.com/NixOS/nixpkgs/commit/b38acd8b9dd225055759762b0357b769fbb61372) python310Packages.jinja2-ansible-filters: init at 1.3.2
* [`b019c370`](https://github.com/NixOS/nixpkgs/commit/b019c370a7517dcdf88316dcf2fed52c63f8cd45) python310Packages.mkdocs-mermaid2-plugin: init at 0.6.0
* [`a3ff3462`](https://github.com/NixOS/nixpkgs/commit/a3ff34620d9cce0a5709ca6f64ebf8e1490b87dc) python310Packages.pyyaml-include: init at 1.3
* [`6a17f834`](https://github.com/NixOS/nixpkgs/commit/6a17f834d80d9e890de0d86992521fbdcec86717) copier: init at 7.0.1
* [`7d24dc44`](https://github.com/NixOS/nixpkgs/commit/7d24dc44d67541d50862026ab26231b1e3563e50) python310Packages.poetry-dynamic-versioning: disable tests
* [`58a501f3`](https://github.com/NixOS/nixpkgs/commit/58a501f399a4a4376990fd056816b41a979ace76) libxkbcommon: 1.4.1 -> 1.5.0
* [`1470ba5f`](https://github.com/NixOS/nixpkgs/commit/1470ba5fd113d3d054ad8a9156e065702dd3b6a5) unbound: 1.17.0 -> 1.17.1
* [`06ef4c17`](https://github.com/NixOS/nixpkgs/commit/06ef4c1740f600b715056caf4fd87cd34a6ce773) xbps: unpin openssl_1_1
* [`ce373ba2`](https://github.com/NixOS/nixpkgs/commit/ce373ba23471208cdbc0c7708d5570317160ed83) netbsd.libarch: init at 9.2
* [`0a77e09a`](https://github.com/NixOS/nixpkgs/commit/0a77e09a83e3c0aa51320ecb327a79d0898850db) netbsd.libpci: init at 9.2
* [`abdc781d`](https://github.com/NixOS/nixpkgs/commit/abdc781d4c41bb9cbbb68919980d7dff5db8fda8) xorg.libpciaccess: broaden platforms
* [`13d80683`](https://github.com/NixOS/nixpkgs/commit/13d80683544bae37716b6f16a7201935948b49c8) xorg.libpciaccess: fix build on NetBSD
* [`2ce5fca4`](https://github.com/NixOS/nixpkgs/commit/2ce5fca4ad0672efdc136bf0fdb4abc27fdb72bd) ydict: add mpg123 to PATH
* [`4cd69118`](https://github.com/NixOS/nixpkgs/commit/4cd69118d1307685c1555837ac2091ab2973711c) tinyxml-2: 6.0.0 -> 9.0.0
* [`2fd3e692`](https://github.com/NixOS/nixpkgs/commit/2fd3e6928e18720ca28970e729c5dcbe2b05fa89) vvvvvv: init at 2.3.6
* [`979a975d`](https://github.com/NixOS/nixpkgs/commit/979a975dbe0743037fdc190c51f51c83e3d59df8) pkg-config: use dontUnpack instead of no-op phase
* [`d4c1e368`](https://github.com/NixOS/nixpkgs/commit/d4c1e368e1ee945f75a2fb13e3166aa4d2f8c414) iputils: 20211215 -> 20221126
* [`4d32358b`](https://github.com/NixOS/nixpkgs/commit/4d32358bea2b91c5bd7b6962366c2a0d6b1c79e0) iputils: format with nixpkgs-fmt
* [`1cc47822`](https://github.com/NixOS/nixpkgs/commit/1cc478222ebedff16e6df69ee83a124a52d468b2) xz: 5.4.0 -> 5.4.1
* [`1d5a8a5e`](https://github.com/NixOS/nixpkgs/commit/1d5a8a5e43e56a7ca55e6d8515be2d85eb4dd95c) binutils: avoid texinfo dependency during bootstrap
* [`6becbd39`](https://github.com/NixOS/nixpkgs/commit/6becbd39707fbf8306b35af1828893eec0d03646) libtool: drop unused auto* dependencies
* [`58857196`](https://github.com/NixOS/nixpkgs/commit/58857196f10eb0553ad00e10d7cc6340b92f5d3a) stdenv: mark binutils-patchelfed ([nixos/nixpkgs⁠#209600](https://togithub.com/nixos/nixpkgs/issues/209600))
* [`76f5618e`](https://github.com/NixOS/nixpkgs/commit/76f5618e1e591bb54b4e84cd769bb8fb10fed49f) glibc: copy libgcc_s.so from .lib output if it exists
* [`7cd1c436`](https://github.com/NixOS/nixpkgs/commit/7cd1c436f53bf6a882be598e6f9df045196440a7) roc-toolkit: drop removed --disable-tests --disable-doc
* [`2089311c`](https://github.com/NixOS/nixpkgs/commit/2089311c6671bdd4c4abcb38504ad433cbb12125) libwebp: 1.2.4 -> 1.3.0
* [`f259f924`](https://github.com/NixOS/nixpkgs/commit/f259f924619d88996edc4bb5e34b955700d0fd03) sqlcl: 22.3.1 -> 22.4.0.342.1212
* [`69b181af`](https://github.com/NixOS/nixpkgs/commit/69b181af30d15948cfd7143dfd1d2d24f73b75d3) lzip: drop unused 'texinfo' input
* [`1c5020b6`](https://github.com/NixOS/nixpkgs/commit/1c5020b684b7f559b42194580f7eca1f88406cb8) asterisk: 16.29.0 -> 16.30.0, 18.15.0 -> 18.16.0, 19.7.0 -> 19.8.0, 20.0.0 -> 20.1.0
* [`6728277e`](https://github.com/NixOS/nixpkgs/commit/6728277e199c18b6e03bf123b84915743d1f2f23) libc: wipe out all references from copied libgcc_s.so.1
* [`e32aef5a`](https://github.com/NixOS/nixpkgs/commit/e32aef5aca347d3257b3bc13abbeb9afd791a84c) pkg: init at 1.19.0
* [`eaf77e7b`](https://github.com/NixOS/nixpkgs/commit/eaf77e7b0b3cd80c7eb154998b513149367452b9) freebsd.sed: init at 13.1.0
* [`49703346`](https://github.com/NixOS/nixpkgs/commit/497033467f27e1063cee82ec64105a6d7ea74070) make-bootstrap-tools: fix test to include libstdc++ -rpath
* [`57b9fc26`](https://github.com/NixOS/nixpkgs/commit/57b9fc2699b0158fb8c41a0578d414fcecce6a7c) python310Packages.future: 0.18.2 -> 0.18.3
* [`eff9653f`](https://github.com/NixOS/nixpkgs/commit/eff9653f947fe0580465092f25ac917f1a8a889f) python310Packages.requests: add changelog to meta
* [`619ac187`](https://github.com/NixOS/nixpkgs/commit/619ac1872146d6427ae20cb8ae23e4caf8105da9) python310Packages.requests: 2.28.1 -> 2.28.2
* [`471c4192`](https://github.com/NixOS/nixpkgs/commit/471c41923ad691ea7fb36fae1c888855d384337c) python310Packages.simplejson: add changelog to meta
* [`9a30cff7`](https://github.com/NixOS/nixpkgs/commit/9a30cff75c6025269604037b5ba13425efc5140b) python310Packages.simplejson: 3.18.0 -> 3.18.1
* [`d6d18979`](https://github.com/NixOS/nixpkgs/commit/d6d18979043b65685de9163743558ece2365d18f) gcc: Backport fix of GCC Issue 80431 from version 12
* [`8bda2c3a`](https://github.com/NixOS/nixpkgs/commit/8bda2c3acce520c835e471b81912174402f7d554) nix-info: fix error when no channel installed
* [`818d0f8c`](https://github.com/NixOS/nixpkgs/commit/818d0f8cf1aeec10c1370b5534c1393c4ced265b) auto-patchelf: don't resolve symlinks if basenames don't match
* [`57c8c6c3`](https://github.com/NixOS/nixpkgs/commit/57c8c6c3d2c9afec2a57433f0c06560e90724c4e) Revert "tsm-client: fix patching rpath with autoPatchelf"
* [`aaa55a83`](https://github.com/NixOS/nixpkgs/commit/aaa55a832d77efdb2d79890c514c5003635a73db) maple-font: 5.5 -> 6.1
* [`2c3e53a6`](https://github.com/NixOS/nixpkgs/commit/2c3e53a6cdcc92f0a2f9913c3363a1a42b871e41) eclipses.*: Enable on aarch64-linux
* [`079e593d`](https://github.com/NixOS/nixpkgs/commit/079e593d72fe43ee1c7ecf6834bb04da04c4c5ff) evdev-proto: init at 6.0
* [`44dcf453`](https://github.com/NixOS/nixpkgs/commit/44dcf4534276965c1767b79dc17d3636e80ccba3) mtdev: use HTTPS for homepage
* [`b994008c`](https://github.com/NixOS/nixpkgs/commit/b994008cbf32c291d5ae77768ed8e3c7deabb25f) mtdev: add FreeBSD support
* [`35a4ca4b`](https://github.com/NixOS/nixpkgs/commit/35a4ca4bde5aca6d29fc2c24704cb355f4fe95f5) python3.pkgs.hypothesis: build offline documentation
* [`7c76f38f`](https://github.com/NixOS/nixpkgs/commit/7c76f38f60eb055727a708e1970a0c9272a2c8c9) python3.pkgs.sphinx-codeautolink: init at 0.12.1
* [`ebf25261`](https://github.com/NixOS/nixpkgs/commit/ebf252618c531b082e5ec035db3e6f1a50bdad01) python3.pkgs.sphinx-hoverxref: init at 1.3.0
* [`fd7beb4b`](https://github.com/NixOS/nixpkgs/commit/fd7beb4b39e271131ba82c24b7ad6c72571e2b92) python3.pkgs.sphinx-jquery: init at 3.0.0
* [`3030245e`](https://github.com/NixOS/nixpkgs/commit/3030245e6da56ba3b73b7571fbd851a48418dd3e) python3.pkgs.sphinx-notfound-page: init at 0.8.3
* [`67c80d38`](https://github.com/NixOS/nixpkgs/commit/67c80d38125d9918716ec59863836fa68b19a443) python3.pkgs.sphinx-prompt: init at 1.5.0
* [`7fb944dd`](https://github.com/NixOS/nixpkgs/commit/7fb944dd29ef5b7065650f20457e7bd68c2a1241) python3.pkgs.sphinx-tabs: init at 3.4.1
* [`4e880e72`](https://github.com/NixOS/nixpkgs/commit/4e880e72409b49fc0d160cb206811dce04661db4) python3.pkgs.sphinx-version-warning: init at unstable-2019-08-10
* [`856f3a46`](https://github.com/NixOS/nixpkgs/commit/856f3a46b2f64d4481ced392e1ebc86f09551521) stdenv: drop remove unnecessary env var
* [`fe1c7a19`](https://github.com/NixOS/nixpkgs/commit/fe1c7a1945d462489af03ea88e56d46b1a721e53) treewide: remove usages of header and stopNest
* [`568d6fca`](https://github.com/NixOS/nixpkgs/commit/568d6fca33da46503b3b87ddec33aa5d3efa4894) systemd: fix tpm2 driver init
* [`231d0821`](https://github.com/NixOS/nixpkgs/commit/231d0821c798172f8070a0349076815806f0faf8) Revert "qt5.qt3d: override src to include submodules"
* [`0567815a`](https://github.com/NixOS/nixpkgs/commit/0567815a1199918c9d548fb91850d45bde711490) qt5: fetch submodules
* [`5d2dc462`](https://github.com/NixOS/nixpkgs/commit/5d2dc4626374b58cf9d66e65f6ac4a8db43763d6) qt5: update source hashes to include submodules
* [`2f3b572e`](https://github.com/NixOS/nixpkgs/commit/2f3b572ece870f009da57f3bc28de1e556ceb9ef) python310Packages.python-benedict: 0.28.0 -> 0.28.3
* [`0e8263ce`](https://github.com/NixOS/nixpkgs/commit/0e8263ce73cc3f78bd94b37db87fe47060761ce3) stdenv: fix SC2223
* [`0417f953`](https://github.com/NixOS/nixpkgs/commit/0417f953e2b46d37fd68704d7bb24181c9c03274) stdenv: fix SC2004 & SC2086
* [`4db439c5`](https://github.com/NixOS/nixpkgs/commit/4db439c5991dc1903efc167918b64cf852ba0fd5) stdenv: disable shellcheck rules
* [`e58785bf`](https://github.com/NixOS/nixpkgs/commit/e58785bf417dbb62611795a0187240600cc8685c) stdenv: disable shellcheck rule SC2048
* [`01d7f193`](https://github.com/NixOS/nixpkgs/commit/01d7f19346bc5de4508244b7b1dd23355d026899) multi-outputs.sh: Improve _assignFirst error message
* [`d16e068b`](https://github.com/NixOS/nixpkgs/commit/d16e068b146a8849c0aa42cc88cb8960b8047dca) testers.testBuildFailure: Fix
* [`ea1a841e`](https://github.com/NixOS/nixpkgs/commit/ea1a841e6f33cf0ad6aa52ecb4c45a5bd80aa2ce) lzip: drop no-op nativeBuildInputs = [ ]; assignment
* [`f2c27018`](https://github.com/NixOS/nixpkgs/commit/f2c27018f067d9e664c6bac5200f1ef980fc8a93) stdenv: fix SC2242
* [`e525ae1e`](https://github.com/NixOS/nixpkgs/commit/e525ae1e1e1a991d27346ef072b5efcfe9236cca) stdenv: disable shellcheck rule SC2068 & SC1091
* [`0efa1d86`](https://github.com/NixOS/nixpkgs/commit/0efa1d86bb4d818fd72f44c32802dbbe8f834a90) init: mdbook-pagetoc at v0.1.5
* [`596400e6`](https://github.com/NixOS/nixpkgs/commit/596400e60f1b232da52b9a91ed9ce99ec9f68b9b) maintainers: add ChaosAttractor
* [`b48c6ab6`](https://github.com/NixOS/nixpkgs/commit/b48c6ab66b77b25af31490ab089fa6ad750b0d72) yesplaymusic: init at 0.4.5
* [`9320c0ac`](https://github.com/NixOS/nixpkgs/commit/9320c0acf9f12782fa56c2660fcb6309826f66a8) elfutils: fix compile failure with latest curl (7.87.0)
* [`354cff2a`](https://github.com/NixOS/nixpkgs/commit/354cff2a4f774e53fdc5ce9876c7b24e963bb803) outline: 0.67.1 -> 0.67.2
* [`6c615f69`](https://github.com/NixOS/nixpkgs/commit/6c615f6957c1a36b2d173f9438d7b63fec9b5cf8) add rustc and cargo to the cross trunk
* [`c696a19b`](https://github.com/NixOS/nixpkgs/commit/c696a19bfa6789b7d9a65a1b035e5c403abae8c5) multiple-outputs.sh: Apply suggestions from code review
* [`f50df0ed`](https://github.com/NixOS/nixpkgs/commit/f50df0ed93abaaf0cb213f483f2121b787c9d040) git: 2.39.0 → 2.39.1
* [`ae696ae8`](https://github.com/NixOS/nixpkgs/commit/ae696ae8fa28984dc29cc9f1acf38abf22e8d5af) python3Packages.m2crypto: 0.36.0 -> 0.38.0
* [`68f1182b`](https://github.com/NixOS/nixpkgs/commit/68f1182b659a8ea57c78d8e94d74f803065cac24) stdenv: don't clobber useArray and type in {prepend,append}ToVar
* [`159e4dc5`](https://github.com/NixOS/nixpkgs/commit/159e4dc581e367f972b450e08b3689ddf1e662ed) python310Packages.pytest-benchmark: 3.4.1 -> 4.0.0 ([nixos/nixpkgs⁠#211015](https://togithub.com/nixos/nixpkgs/issues/211015))
* [`f00a7e7e`](https://github.com/NixOS/nixpkgs/commit/f00a7e7e27ab980c91f04aa7e276b3fbe64242d8) outline: fix email notifications
* [`92535dbc`](https://github.com/NixOS/nixpkgs/commit/92535dbc02b3ab4c04cf3e36c36aec92bb04aa37) giflib: patch to fix CVE-2022-28506
* [`a1dc7fcf`](https://github.com/NixOS/nixpkgs/commit/a1dc7fcf171c2a84df4a656c1e5e23bb01fd94b9) pkg-config: depend on libiconv unconditionally
* [`4ddfd5f7`](https://github.com/NixOS/nixpkgs/commit/4ddfd5f74d3e14582aec99d0cec48ff046ee358b) python310Packages.pybind11: 2.10.2 -> 2.10.3
* [`d450afc9`](https://github.com/NixOS/nixpkgs/commit/d450afc911598812d54cbac7e384a2bf4724f9ce) cargo-auditable-cargo-wrapper: Use writeShellScriptBin instead of writeShellApplication
* [`387e803f`](https://github.com/NixOS/nixpkgs/commit/387e803f3071c0ef35d919a85f8574dd11eb3d09) yewtube: init at 2.9.0
* [`e6f7cba3`](https://github.com/NixOS/nixpkgs/commit/e6f7cba33a64a89c76416041d2a614da40b33d93) mps-youtube: remove in favor of yewtube
* [`703b1c17`](https://github.com/NixOS/nixpkgs/commit/703b1c17a5f5777a93e4230d2b41fd66b6a57ad7) python3Packages.pafy: remove
* [`0ae87d51`](https://github.com/NixOS/nixpkgs/commit/0ae87d514f16312be03227c1030e155efa14e915) treewide: add names to all setup hooks
* [`1fc2a79e`](https://github.com/NixOS/nixpkgs/commit/1fc2a79ee1406371f3b38ada45340d04b2225c54) makeSetupHook: make "name" argument mandatory
* [`6d100408`](https://github.com/NixOS/nixpkgs/commit/6d1004086cd46b93780a0f1c417af7a0d9a716a7) python3Packages.flask-babel: 2.0.0 -> 3.0.0
* [`48958930`](https://github.com/NixOS/nixpkgs/commit/48958930e761e3a200e1fcbbcb3ddc4e43c51894) python3Packages.flaskbabel: Drop in favor of flask-babel
* [`596d123c`](https://github.com/NixOS/nixpkgs/commit/596d123cbb148271b0bbf85c6f48ceaf1f77a21f) pianoteq: fix fetchers
* [`f867378f`](https://github.com/NixOS/nixpkgs/commit/f867378f0872ebade7ac067e5fe5acae0e38424e) pianoteq.{stage-trial,standard-trial}: 7.5.4 -> 8.0.5
* [`8a496826`](https://github.com/NixOS/nixpkgs/commit/8a496826b03d424c411e8d0a1eadf5217b0b6d42) python310Packages.pylitterbot: 2023.1.1 -> 2023.1.2
* [`161c4dd2`](https://github.com/NixOS/nixpkgs/commit/161c4dd2ae61f97f0006bdba53abcc3284dda25e) wslu: supply default conf
* [`c7475c80`](https://github.com/NixOS/nixpkgs/commit/c7475c80e109b480894d641bc781a024628ec34d) libtheora: don't build examples
* [`4abd5f04`](https://github.com/NixOS/nixpkgs/commit/4abd5f04c6c0e5ee7dcbb1498e4a6d3dc01bb47d) wlcs: 1.4.0 -> 1.5.0, mark Linux-only
* [`447ca4bf`](https://github.com/NixOS/nixpkgs/commit/447ca4bf3b8ae3c7febd9e902752f87c5ba06203) treewide: migrate to nativeCheckInputs
* [`558821eb`](https://github.com/NixOS/nixpkgs/commit/558821eb1f896e6a26154bd5151dbc0aba17c86d) sofia_sip: 1.13.10 -> 1.13.12
* [`d29b1ecb`](https://github.com/NixOS/nixpkgs/commit/d29b1ecb89246c592ce53d8a8326358edec23ab0) make-bootstrap-tools.nix: fix for wrapped gzip
* [`c2ae0a0b`](https://github.com/NixOS/nixpkgs/commit/c2ae0a0b8fbf0d3e922b0368e31971d4a9101a02) python3Packages.nghttp2: fix build
* [`73e9c838`](https://github.com/NixOS/nixpkgs/commit/73e9c838f7eb270063d87d96a52c4b24f49a8c6d) miriway: init at unstable-2022-12-18
* [`b9d21ba9`](https://github.com/NixOS/nixpkgs/commit/b9d21ba9724c5adc2357535735c410d7bb8f584f) pidgin: 2.14.10 -> 2.14.12
* [`f4ae6b25`](https://github.com/NixOS/nixpkgs/commit/f4ae6b252d498b105f5ee39d5d55b6e7b9a88f9a) Revert "darwin.apple_sdk_11_0: add Security dependency on xpc"
* [`7220d26e`](https://github.com/NixOS/nixpkgs/commit/7220d26ed5d20cfbcbee81644fcdfc91932fcbb0) swift: bootstrap using system stdlib
* [`9fdb0765`](https://github.com/NixOS/nixpkgs/commit/9fdb076597f52e2edaf7aef84c284b2c81773105) libpsm2: 11.2.229 -> 11.2.230
* [`614aaaa3`](https://github.com/NixOS/nixpkgs/commit/614aaaa340928287120854766efc0a78df3e8300) nix-eval-jobs: 2.12.0 -> 2.12.1
* [`1ae2059a`](https://github.com/NixOS/nixpkgs/commit/1ae2059a34133265e17255e24ebd58ce1a3fa1a0) tts: drop dependency on umap-learn
* [`3bfc08b5`](https://github.com/NixOS/nixpkgs/commit/3bfc08b5c0290f338c2f2ad91217e4be5894afbf) maintainers: add serge_sans_paille
* [`c0dc2ef1`](https://github.com/NixOS/nixpkgs/commit/c0dc2ef1ff9ebd70faf9f8d259b397a3e2e256ed) nixos/rtorrent: make directory permissions configurable
* [`ad460ca4`](https://github.com/NixOS/nixpkgs/commit/ad460ca4f5cf750e208fce663377e94d2271c454) python310Packages.pysvn: 1.9.18 -> 1.9.20
* [`3f02898c`](https://github.com/NixOS/nixpkgs/commit/3f02898c9d1aeb9c01e06fffc7cdbc7d5bbc7ccf) jdt-language-server 1.17.0 -> 1.19.0
* [`e525b687`](https://github.com/NixOS/nixpkgs/commit/e525b687f43d724b617f1b7f0f6a04cbb9229aac) iconv: init (portable attribute for iconv(1))
* [`93711987`](https://github.com/NixOS/nixpkgs/commit/9371198770f8bab0d7fee20108b5593393704002) librevenge: 0.0.4 -> 0.0.5
* [`63dc4b38`](https://github.com/NixOS/nixpkgs/commit/63dc4b38f3cf1ce17f778270adfa1422b1863a5c) devserver: drop
* [`6a1f32b9`](https://github.com/NixOS/nixpkgs/commit/6a1f32b90dfac17401968c172821234b756b8d5d) coinlive: 0.2.1 -> 0.2.2
* [`0c560c85`](https://github.com/NixOS/nixpkgs/commit/0c560c854402bbc0336343e2fce1bba595a82f0b) tunnelto: 0.1.18 -> unstable-2022-09-25
* [`25405198`](https://github.com/NixOS/nixpkgs/commit/254051982bdc26c987cbdae9928968b1308b8f11) git-subset: drop
* [`d22575be`](https://github.com/NixOS/nixpkgs/commit/d22575be494d6aa5f69f8112af98e8d16f58c750) imag: drop
* [`03214405`](https://github.com/NixOS/nixpkgs/commit/03214405bbfb25e6a7168e98715afb19dcfa6dba) firmware-manager: 0.1.2 -> unstable-2022-12-09
* [`71034ab5`](https://github.com/NixOS/nixpkgs/commit/71034ab59226818c69992971f5d3eeb23c93ee93) finalfrontier: 0.9.4 -> unstable-2022-01-06
* [`3a1ec4f9`](https://github.com/NixOS/nixpkgs/commit/3a1ec4f986aea79ed6b6a0c6624748f8d598fa99) imagemagick: 7.1.0-57 -> 7.1.0-58
* [`b0b58266`](https://github.com/NixOS/nixpkgs/commit/b0b582660aef2c15e32c23ddb0ed4f7241279e2f) perlPackages.ImageMagick: 7.0.11-1 -> 7.0.11-3
* [`6108775d`](https://github.com/NixOS/nixpkgs/commit/6108775d2d5baf58ca323558528096b0a50bab7b) catch2_3: 3.2.1 -> 3.3.0
* [`b705896d`](https://github.com/NixOS/nixpkgs/commit/b705896d69deaefffe6f21b07c37cd0642c9e12d) openmvs: move binaries to correct location
* [`9adfe0b9`](https://github.com/NixOS/nixpkgs/commit/9adfe0b91af13a6696b4a267ab2008b96fee5d9f) libgit2: 1.5.0 -> 1.5.1
* [`0dcc6bc7`](https://github.com/NixOS/nixpkgs/commit/0dcc6bc710cb0a2a743b774e735c3974e04d4406) Add missing 'optional' packages
* [`eb98fefe`](https://github.com/NixOS/nixpkgs/commit/eb98fefe240aedc9a82898923c1260d9d2408fa1) build-rust-crate: handle ILP32 platforms correctly
* [`45e91634`](https://github.com/NixOS/nixpkgs/commit/45e91634e4d64dbc9c1449e9c91fd156e4f0576b) docker: 20.10.21 -> 20.10.23
* [`0c985033`](https://github.com/NixOS/nixpkgs/commit/0c9850330d3a99bba339964a5d1b38b9998d33a7) python310Packages.jaraco-context: add changelog to meta
* [`213e3d70`](https://github.com/NixOS/nixpkgs/commit/213e3d70b399df045534fd6b2a0f37e29ddf4e17) python310Packages.jaraco-context: 4.2.0 -> 4.3.0
* [`38072997`](https://github.com/NixOS/nixpkgs/commit/38072997c52862b4fb6aa42ccf1cf9001fa0edbc) firefox: option to enable speech synthesis
* [`78f357f1`](https://github.com/NixOS/nixpkgs/commit/78f357f134f2184ff4583ba82fd51c19fc40297c) nixos/kubo: make the configuration options idempotent
* [`e0f27aee`](https://github.com/NixOS/nixpkgs/commit/e0f27aee10d9678b143e24f39e6a5e7d04ff4044) vtk: 9.2.2 -> 9.2.5
* [`bf4959f1`](https://github.com/NixOS/nixpkgs/commit/bf4959f1a574dbeac46675da0eb351ed8f777f7f) mfcl8690cdwlpr: Make it installable on x86_64-linux
* [`4fbe3e45`](https://github.com/NixOS/nixpkgs/commit/4fbe3e450bb2b8a0d3cbc99d634f080ca8d57cef) awsebcli: fix up, requests and future dependencies
* [`146f9c8d`](https://github.com/NixOS/nixpkgs/commit/146f9c8de6e8c00f450cc0c01bb216c77a60720d)  globalprotect-openconnect: 1.4.8 -> 1.4.9
* [`0e31d244`](https://github.com/NixOS/nixpkgs/commit/0e31d244c414fae6fdb3edca8ebc4cb2d15e3475) use fetchurl instead
* [`464e87c4`](https://github.com/NixOS/nixpkgs/commit/464e87c40d8acfa9fa51199a42c1888d887e51c1) address comments
* [`5760604c`](https://github.com/NixOS/nixpkgs/commit/5760604c9d94cb2a290bf2d6f27c9c4ecbb29416) trilium-desktop: split desktop & server into two files
* [`739b153f`](https://github.com/NixOS/nixpkgs/commit/739b153f972a86003b3e5a4cf3cc43138ae9d1e7) trilium-desktop: add darwin64
* [`96726e8f`](https://github.com/NixOS/nixpkgs/commit/96726e8fb96181d1da32a2f7e49a83f58e0f6972) maintainers: add eliandoran
* [`93ad2ef1`](https://github.com/NixOS/nixpkgs/commit/93ad2ef195537e54c6310db00d07c2667bdb742d) trilium-{desktop,server}: add eliandoran to maintainers
* [`688d658a`](https://github.com/NixOS/nixpkgs/commit/688d658a9689194787f6df15b83daad7e78f20bc) nixos/wireless: fix failure on missing config file
* [`3e45994a`](https://github.com/NixOS/nixpkgs/commit/3e45994a3bd92be78891e869352cb5d9741b1046) nixos/make-options-doc: don't use inspect for optionsToDocbook
* [`ba1f5331`](https://github.com/NixOS/nixpkgs/commit/ba1f533134d230e4bc65d3f6072c63993e07228a) nixos/make-option-docs: wrap md parser+renderer into Converter
* [`6b677d91`](https://github.com/NixOS/nixpkgs/commit/6b677d91489589d7147292c1aaf5f5bea3c54f9d) nixos/make-options-doc: disable inline html
* [`de22a26b`](https://github.com/NixOS/nixpkgs/commit/de22a26b4c66fc27b0dbb1f48ed2082305c3de23) nixos/make-options-doc: render option types through md
* [`9ff98776`](https://github.com/NixOS/nixpkgs/commit/9ff987764cc40a55968b630d245bb8a6991378a7) nixos/make-options-doc: enable smartquotes and replacements
* [`8cc7194f`](https://github.com/NixOS/nixpkgs/commit/8cc7194fd0cbd29477468cd5ede36566d64da912) python310Packages.wasabi: 1.1.0 -> 1.1.1
* [`481e69b0`](https://github.com/NixOS/nixpkgs/commit/481e69b09a9dae6f92473921f8baef2e90bf942a) Add IOSocketSSL Dependency for ldaps access
* [`d04c58a1`](https://github.com/NixOS/nixpkgs/commit/d04c58a1c32c10f885a2fdef41b1f28dd009cbb9) dnscontrol: 3.24.0 -> 3.25.0
* [`f3354c2f`](https://github.com/NixOS/nixpkgs/commit/f3354c2f114264d9a13adaef42cd37d08a8c5912) maintainers: add phip1611
* [`d855d691`](https://github.com/NixOS/nixpkgs/commit/d855d691843f1124f2574973d6ccab5039d5c906) libheif: install gdk-pixbuf loader
* [`7f06dbef`](https://github.com/NixOS/nixpkgs/commit/7f06dbefa5e668389cb2379a2438406dcd2620aa) gnome.eog: Add heif support
* [`57daeabf`](https://github.com/NixOS/nixpkgs/commit/57daeabfa267c225c5e3de61cc6a6e15eb10b598) barman: 3.3.0 -> 3.4.0
* [`22ad974e`](https://github.com/NixOS/nixpkgs/commit/22ad974ea97a4459bb526189d2a33ec21a7cde74) python3Packages.objsize: init at 0.6.1
* [`ba97c12c`](https://github.com/NixOS/nixpkgs/commit/ba97c12cc9aa1836da401b89de442da27a0c147c) python310Packages.glean-parser: 6.4.0 -> 7.0.0
* [`550f0267`](https://github.com/NixOS/nixpkgs/commit/550f0267a882981867b36e6933f6a369cebf7456) docker-slim: 1.39.0 -> 1.40.0
* [`c74d8ff1`](https://github.com/NixOS/nixpkgs/commit/c74d8ff134da6bf60187788e8fd72757329b68f5) postgresqlPackages.pgvector: 0.3.2 -> 0.4.0
* [`4bd33d77`](https://github.com/NixOS/nixpkgs/commit/4bd33d773411d829ecf53f36fe0a9bd38620504f) pritunl-client: 1.3.3373.6 -> 1.3.3420.31
* [`8b3a31f9`](https://github.com/NixOS/nixpkgs/commit/8b3a31f923662bc3003be4943bc382c46136cb5f) ubootTools: fix build by fixing -idirafter ordering
* [`607af43f`](https://github.com/NixOS/nixpkgs/commit/607af43f1bb79d599ce229aac879d1e25f521d32) oh-my-zsh: 2023-01-17 -> 2023-01-26
* [`778419b9`](https://github.com/NixOS/nixpkgs/commit/778419b9e6e9d82d5801b382070a81169f5920ca) Revert "lib/meta.nix: platformMatch: allow predicate functions"
* [`7db68083`](https://github.com/NixOS/nixpkgs/commit/7db6808335f5307f94f0f49d73669e565f526f46) logseq: Fix publishing graph
* [`1690aa68`](https://github.com/NixOS/nixpkgs/commit/1690aa6858102c0986075f460f93d693c724327b) lib/meta.nix: allow patterns over entire platform, not just `.parsed`
* [`ea0bcf25`](https://github.com/NixOS/nixpkgs/commit/ea0bcf25053464a9f0483c3b2f411275de036e57) lib/systems/inspect.nix: add platformPatterns.isStatic
* [`a94114e7`](https://github.com/NixOS/nixpkgs/commit/a94114e70a761e346f36d4ebdef01da8fe53c778) systemd: use non-function pattern for badPlatforms
* [`586433bc`](https://github.com/NixOS/nixpkgs/commit/586433bc70ec8ae2540f51f4fe00e654b0645ae5) barman: add cahngelog to meta
* [`6f942d4a`](https://github.com/NixOS/nixpkgs/commit/6f942d4a17c11874c5d345ea3f872a0f54bce9bd) Update lib/meta.nix
* [`435618d9`](https://github.com/NixOS/nixpkgs/commit/435618d9b3d47f978d397a0ea2934b2b9e0b1dd6) Update lib/meta.nix
* [`009a3f18`](https://github.com/NixOS/nixpkgs/commit/009a3f1857a89c9f085b03e85410c0713a9d451f) Update lib/systems/inspect.nix
* [`9c0a3417`](https://github.com/NixOS/nixpkgs/commit/9c0a3417c8defd0b5f4b592659c88c978f8b36b6) Update lib/systems/inspect.nix
* [`1bf7beff`](https://github.com/NixOS/nixpkgs/commit/1bf7beff012075c0ae78efa35f05f0915eaa7d24) Revert "libfabric: resort inputs"
* [`c9ce56c0`](https://github.com/NixOS/nixpkgs/commit/c9ce56c0e389875f2e4b0f05586182128ec9c8c9) Revert "libfabric -> 1.17.0 and opx activation"
* [`63317d61`](https://github.com/NixOS/nixpkgs/commit/63317d61b9993e3979439ae313018859dcfb4733) goffice: 0.10.53 → 0.10.54
* [`edd316f2`](https://github.com/NixOS/nixpkgs/commit/edd316f2eac32ca76f0c665a1c70510960cc67e1) gnumeric: 1.12.53 → 1.12.54
* [`801d8877`](https://github.com/NixOS/nixpkgs/commit/801d887751a01eba5142fb212c75692308cb5aa9) fwupd: 1.8.9 -> 1.8.10
* [`9995bfa1`](https://github.com/NixOS/nixpkgs/commit/9995bfa17dcaa144b2dd00ce3a9aa8b541535608) python3.pkgs.remote-pdb: init at 2.1.0
* [`d0a7702b`](https://github.com/NixOS/nixpkgs/commit/d0a7702b8fbc078e83c40160d469f27a0dd9d5c1) fwupd: thunderbolt plugin only enabled upstream for x86.
* [`be6a2536`](https://github.com/NixOS/nixpkgs/commit/be6a25368f2189df579b02ab1198f9f55487d573) nixos-render-docs: init from optionsToDocbook.py
* [`986e48ca`](https://github.com/NixOS/nixpkgs/commit/986e48ca22857d4cb5f86df663e7fb2834cb63bd) nixos-render-docs: move escaping functions to new modules
* [`a4ec68a7`](https://github.com/NixOS/nixpkgs/commit/a4ec68a777d0a4e495231ace7925d1c11044637a) nixos-render-docs: move docbook renderer to docbook module
* [`5e37d9f2`](https://github.com/NixOS/nixpkgs/commit/5e37d9f29ef78ed4e291105682111d9ddf382bb0) nixos-render-docs: improve type annotations in docbook
* [`1016b727`](https://github.com/NixOS/nixpkgs/commit/1016b727a8b2b8d0cf5434276e5c06ff0ab64af8) nixos-render-docs: add Renderer base class
* [`c63a550e`](https://github.com/NixOS/nixpkgs/commit/c63a550e7b23c4de6eec39a5671a38f460c6b495) nixos-render-docs: don't use env for renderer state
* [`aa3fd286`](https://github.com/NixOS/nixpkgs/commit/aa3fd2865bbe878c12d8a4495526db280097fe5e) nixos-render-docs: move some options helpers to new module
* [`ccb58629`](https://github.com/NixOS/nixpkgs/commit/ccb586299d26ea22d8c064440888ede1065727f7) nixos-render-docs: move options conversion to options module
* [`e0596e09`](https://github.com/NixOS/nixpkgs/commit/e0596e0940389679df43b34b6f7a2ef9e935a0bb) nixos-render-docs: generalize option converter
* [`e8c5618b`](https://github.com/NixOS/nixpkgs/commit/e8c5618b67ca1bcbef436155ede3d3091790cc96) nixos-render-docs: add some better CLI infrastructure
* [`76050680`](https://github.com/NixOS/nixpkgs/commit/76050680009a73d7f0f8b64375cf99858f9c86b0) nixos-render-docs: add tip and caution admonitions
* [`c2e63839`](https://github.com/NixOS/nixpkgs/commit/c2e638391e14840572a56592dfbc3abe27ed31d2) nixos-render-docs: use only one container plugin instance
* [`41a5c3a9`](https://github.com/NixOS/nixpkgs/commit/41a5c3a93db9be764934d23157c303aadc94f72e) nixos-render-docs: prepare for plugins
* [`6829c6c3`](https://github.com/NixOS/nixpkgs/commit/6829c6c335945c7db95b61d0f88fe981e7c6bfb4) nixos-render-docs: add inline anchor plugin
* [`00a1b41c`](https://github.com/NixOS/nixpkgs/commit/00a1b41c3b5d61a4ce1ae862e691ea0cde8fd974) nixos-render-docs: add html comment plugins
* [`82d5698e`](https://github.com/NixOS/nixpkgs/commit/82d5698e228745db173adfa2868c35258ca171f7) nixos-render-docs: add headings and ordered lists
* [`8e3b2a4e`](https://github.com/NixOS/nixpkgs/commit/8e3b2a4eaae045354f0fcbf39b5d5575042eca18) nixos-render-docs: add heading id support
* [`4e2e950a`](https://github.com/NixOS/nixpkgs/commit/4e2e950ab11a67f5a6002668a0a2b3887ccfb059) nixos-render-docs: compact lists support
* [`8b8670db`](https://github.com/NixOS/nixpkgs/commit/8b8670db100efed03a979f7ec24c353f72c0bdbd) nixos-render-docs: add manual chapter rendering support
* [`0a6e6cf7`](https://github.com/NixOS/nixpkgs/commit/0a6e6cf7e698a6a08a62d8863e2c66b36d5db0d9) nixos/manual: render module chapters with nixos-render-docs
* [`f6647dfd`](https://github.com/NixOS/nixpkgs/commit/f6647dfd94567892da93f84ca5b958ba24d63336) rmlint: fix NIX_* environment propagations to scons
* [`abcad620`](https://github.com/NixOS/nixpkgs/commit/abcad620c630605e3f6a7978085b6c94aaacd2be) godot: fix NIX_* environment propagations to scons
* [`ba0365b7`](https://github.com/NixOS/nixpkgs/commit/ba0365b73056c347a8d0c2597d867a83b7410b7d) novnc: 1.3.0 -> 1.4.0
* [`6af5ac7b`](https://github.com/NixOS/nixpkgs/commit/6af5ac7ba5c6aa59d82ce5b7aa291366556a484e) deepin-icon-theme: init at 2021.11.24
* [`20a25fc2`](https://github.com/NixOS/nixpkgs/commit/20a25fc288d05df906bca383e57431aaed32bf66) deepin-gtk-theme: init at unstable-2022-07-26
* [`216ac3a5`](https://github.com/NixOS/nixpkgs/commit/216ac3a5e36b94edc02ec875cfacd67f949e9e5e) deepin-sound-theme: init at 15.10.6
* [`a9156a9c`](https://github.com/NixOS/nixpkgs/commit/a9156a9c2192b5ca181887ce771ae4fae0562e98) dde-account-faces: init at 1.0.12.1
* [`01c2d762`](https://github.com/NixOS/nixpkgs/commit/01c2d762f301734ac644e067c7cac56f96795c23) diamond: 2.0.15 -> 2.1.0
* [`abb2fde3`](https://github.com/NixOS/nixpkgs/commit/abb2fde32d4487241a3c934f31ed40ca1f333f89) openvscode-server: fix build
* [`78080737`](https://github.com/NixOS/nixpkgs/commit/780807370c9873f560d36a4683c7e59bbc1d6e04) hevea: fix nativeBuildInputs
* [`8696a5c9`](https://github.com/NixOS/nixpkgs/commit/8696a5c9609385cdbc3d1f3319221f5de216ca33) code-server: fix build
* [`04e42353`](https://github.com/NixOS/nixpkgs/commit/04e42353fcc486856e741e96c8575fba5d5d5ec4) twspace-crawler: init at 1.11.13
* [`a097897e`](https://github.com/NixOS/nixpkgs/commit/a097897e58471526549107a72caa1cf9e5b6bbba) hevea: update homepage
* [`0ac4b282`](https://github.com/NixOS/nixpkgs/commit/0ac4b2825cba5105a6f412c62a8f7ab615392b93) postgresqlPackages.plpgsql_check: 2.2.6 -> 2.3.0
* [`90a9fdf9`](https://github.com/NixOS/nixpkgs/commit/90a9fdf990ce6053cfeba28db09b762ae43bb816) algolia-cli: init at 1.2.1
* [`591cb875`](https://github.com/NixOS/nixpkgs/commit/591cb8756025362cd0bdd1e6cba047337db8bad6) cargo-watch: fix darwin build
* [`377fc986`](https://github.com/NixOS/nixpkgs/commit/377fc986f3630b590d5c9c836aa18b2ccf0d6137) python310Packages.ismartgate: 4.0.4 -> 5.0.0
* [`4763533c`](https://github.com/NixOS/nixpkgs/commit/4763533cca53e31eeb94778875b84b9440deac9e) build-support/cc-wrapper: add libstdc++fs into default library path for clang
* [`aea9b201`](https://github.com/NixOS/nixpkgs/commit/aea9b201cbbe9b04bfdf7b5b76f50f8fc9a86ed5) zig: rename to zig_0_9 to prepare for version 0.10
* [`db76c9e0`](https://github.com/NixOS/nixpkgs/commit/db76c9e04a75599c094d6ffccfcbf40c17004207) zig_0_10: init at 0.10.1
* [`a9e6a5c1`](https://github.com/NixOS/nixpkgs/commit/a9e6a5c1bc8223d77ca110b3d3987194803dcddf) ipxe: fix build by fixing -idirafter ordering
* [`1ad0b9a4`](https://github.com/NixOS/nixpkgs/commit/1ad0b9a4e301f06652e6d5e42fc1e4690fb9d831) wimboot: fix build by fixing -idirafter ordering
* [`33966f99`](https://github.com/NixOS/nixpkgs/commit/33966f99b37b746571260a018a40bd8733a3520f) rhvoice: fix NIX_* environment propagations to scons
* [`0447aa0a`](https://github.com/NixOS/nixpkgs/commit/0447aa0a0ca66afefc200862852e747d73b4d714) python310Packages.dacite: 1.7.0 -> 1.8.0
* [`2b5f71ee`](https://github.com/NixOS/nixpkgs/commit/2b5f71eed139c93470f0b1052772936d2ab761db) mesa: 22.3.3 -> 22.3.4
* [`1ea7e2bc`](https://github.com/NixOS/nixpkgs/commit/1ea7e2bc443e2acdfe7ae6327e7a93c1f0393d8e) xorg.libXpm: 3.5.13 -> 3.5.15
* [`7c73d1e0`](https://github.com/NixOS/nixpkgs/commit/7c73d1e0258453b7ee08305e284197f8a7f7940c) dmd: set --sysroot=/ to avoid cc-wrapper value
* [`386bd0d7`](https://github.com/NixOS/nixpkgs/commit/386bd0d7e920e0ce78cd69aeffecb2b0193d7da2) python310Packages.pathable: add changelog to meta
* [`e5bac261`](https://github.com/NixOS/nixpkgs/commit/e5bac261727fd679126661d3bbf1809e6f5a6552) python310Packages.dictpath: remove
* [`45eff20e`](https://github.com/NixOS/nixpkgs/commit/45eff20ea04bf83b995d53d716c168d0d1b129d7) python310Packages.fastavro: 1.7.0 -> 1.7.1
* [`eb799f36`](https://github.com/NixOS/nixpkgs/commit/eb799f365b3a42ad35f3347d2a7194fa826a2039) libclc: 14.0.6 -> 15.0.7
* [`f4a78e4b`](https://github.com/NixOS/nixpkgs/commit/f4a78e4b2cc3c00570a22792bc03c4dad507e241) mesa: fix build
* [`ea8fb54a`](https://github.com/NixOS/nixpkgs/commit/ea8fb54acb304c501d3f164c40c808651f927113) mesa: use LLVM 15, remove global spirv-translator override
* [`f416128e`](https://github.com/NixOS/nixpkgs/commit/f416128e90ac75bec060e8b9435fe9c38423c036) mesa: simplify opencl patch
* [`763094d2`](https://github.com/NixOS/nixpkgs/commit/763094d2347f69eec82d04932bceeae0b65a6d03) vscode-extensions.james-yu.latex-workshop: 9.4.4 -> 9.5.0
* [`03f7d36b`](https://github.com/NixOS/nixpkgs/commit/03f7d36b21f17bed02be3adb1b0619f9c741feca) vscode-extensions.vscodevim.vim: 1.24.1 -> 1.24.3
* [`cc6a12e6`](https://github.com/NixOS/nixpkgs/commit/cc6a12e6ecb168064d96982f8b732864bc506508) vscode-extensions.marp-team.marp-vscode: 1.5.0 -> 2.4.1
* [`82103fb6`](https://github.com/NixOS/nixpkgs/commit/82103fb6746ef7f66295ddbce17f4676621716ec) vscode-extensions.bierner.markdown-mermaid: 1.14.2 -> 1.17.4
* [`7efef84f`](https://github.com/NixOS/nixpkgs/commit/7efef84f2506929210506dd0a89451b9255c01b4) vscode-extensions.catppuccin.catppuccin-vsc: 2.2.1 -> 2.5.0
* [`c1aadcb9`](https://github.com/NixOS/nixpkgs/commit/c1aadcb9acc79e94e0a535efb3f3e05fea22b93e) fluxus: fix NIX_* environment propagations to scons
* [`6ed94004`](https://github.com/NixOS/nixpkgs/commit/6ed94004401d043b8d68cb8e2c67a86ff6166050) vkdt: 0.5.1 -> 0.5.3
* [`f1d4f49e`](https://github.com/NixOS/nixpkgs/commit/f1d4f49ef524b2fe0a95a415129a76950ea491d6) vscode-extensions.golang.go: 0.33.1 -> 0.37.1
* [`604b54a0`](https://github.com/NixOS/nixpkgs/commit/604b54a0a90d5c02fcde2ed2fe4bc3e6342c3952) vscode-extensions.jdinhlife.gruvbox: 1.5.1 -> 1.8.0
* [`678bcd52`](https://github.com/NixOS/nixpkgs/commit/678bcd522a8efefe0ebfb69e768e15c9841f7e23) mesa: add libzstd
* [`5074173a`](https://github.com/NixOS/nixpkgs/commit/5074173a5391bf67bdee59ac675eb38d4bfedeec) mesa: build intel-nullhw Vulkan layer
* [`07e13abf`](https://github.com/NixOS/nixpkgs/commit/07e13abffc27dc99625ab16537f8dfda39272556) directx-headers: init at 1.608.2
* [`17af0cdc`](https://github.com/NixOS/nixpkgs/commit/17af0cdc155f38bb3b14ffd5aff0169cd9a2947e) mesa: enable RT on Intel hardware
* [`96978011`](https://github.com/NixOS/nixpkgs/commit/96978011e6b6c6364f126773c5dcfeeb0827d7af) mesa: enable SPIR-V support for Clover
* [`677e5a1b`](https://github.com/NixOS/nixpkgs/commit/677e5a1b3a1c29066dfebb604b9e8c6998e031d5) mesa: clean up, allow building with dozen
* [`e7a2c65a`](https://github.com/NixOS/nixpkgs/commit/e7a2c65ab54f096546c9aad6ae2e4e29e61f2885) mesa: reorganize default driver list
* [`14e04064`](https://github.com/NixOS/nixpkgs/commit/14e04064d36a19662c602c07db66cf87e1f5636d) mesa: demote iris to x86_64 only
* [`b071fdb2`](https://github.com/NixOS/nixpkgs/commit/b071fdb268fdad2ea424f5914d895f3896c20b84) mesa: also demote anv
* [`f4f7c7d6`](https://github.com/NixOS/nixpkgs/commit/f4f7c7d6401f7f4ae3a9a7cf88d0e28d5390d71e) dwl: 0.3.1 -> 0.4
* [`cda2faeb`](https://github.com/NixOS/nixpkgs/commit/cda2faeb238f2fb942f3176314621fd5f3e98307) python310Packages.mat2: 0.13.1 -> 0.13.2
* [`3d031384`](https://github.com/NixOS/nixpkgs/commit/3d0313845640e075d01ebe2a0d84eef949bf09c2) gerrit: 3.6.2 -> 3.7.0
* [`16e9b550`](https://github.com/NixOS/nixpkgs/commit/16e9b550259092803b1d7fcf9f98863060c22862) dxvk: vendor `setup_dxvk.sh`
* [`403fe213`](https://github.com/NixOS/nixpkgs/commit/403fe21323e4d33021ef296d0057cdd08f6c3c17) dxvk: expose Windows derivations
* [`67a2ceab`](https://github.com/NixOS/nixpkgs/commit/67a2ceab6a9529413304cfe5ffed7c6383d88334) dxvk: add native Linux build
* [`81a86d07`](https://github.com/NixOS/nixpkgs/commit/81a86d07e6d9e237004461c2f8de256f4ed83e3e) dxvk: 2.0 -> 2.1
* [`c304f264`](https://github.com/NixOS/nixpkgs/commit/c304f2646c9877d99c74e7fed2591f2405c384d4) mesa: add udev dependency
* [`db09900a`](https://github.com/NixOS/nixpkgs/commit/db09900aa67055397d803a44247699049bc74fa8) python310Packages.opensearch-py: init at 2.1.1
* [`1b11f07b`](https://github.com/NixOS/nixpkgs/commit/1b11f07b5877e41ee17302b6356c49b13a4bc157) osm2pgsql: 1.7.2 → 1.8.0
* [`cef47da8`](https://github.com/NixOS/nixpkgs/commit/cef47da8e5136f07076ff2a63c6b61b2e9a409b9) Revert "nextcloud26: init at 26.0.0beta1"
* [`6d7f8a44`](https://github.com/NixOS/nixpkgs/commit/6d7f8a4464fadf786c39b8bc70940383d3389091) iosevka: 15.6.3 → 17.1.0
* [`3b4a63f2`](https://github.com/NixOS/nixpkgs/commit/3b4a63f224595a2cc5111d78255757b1fac61afa) karmor: 0.11.5 -> 0.11.6
* [`487550f2`](https://github.com/NixOS/nixpkgs/commit/487550f2e0cc8485b876f8590c595d11fd6421eb) tlsx: 1.0.4 -> 1.0.5
* [`c6e1c071`](https://github.com/NixOS/nixpkgs/commit/c6e1c071a024218901f3d11c7994141b493205d5) kustomize-sops: 3.1.0 -> 4.0.0
* [`573dfab1`](https://github.com/NixOS/nixpkgs/commit/573dfab12afb8b4ea429d967bb1fa38fa201cacf) ace: 7.0.10 -> 7.0.11
* [`5dc0149f`](https://github.com/NixOS/nixpkgs/commit/5dc0149fa21aebc516fa00a19a0fb25ce1692fba) flacon: 9.5.1 -> 10.0.0
* [`1aeadcbd`](https://github.com/NixOS/nixpkgs/commit/1aeadcbdc2d5bbf841bbea71858d74e48205e590) run: 0.9.1 -> 0.11.1
* [`de6e502f`](https://github.com/NixOS/nixpkgs/commit/de6e502f5e9e0ae9cb827ca44c1ec344aa97d68b) pipewire: 0.3.64 -> 0.3.65
* [`14b4f400`](https://github.com/NixOS/nixpkgs/commit/14b4f400346bd0057c98ad7c782a212c967d4da4) pipewire: backport minor fix
* [`8542aa18`](https://github.com/NixOS/nixpkgs/commit/8542aa185d825b9a567b5f6910d280852a4933eb) throttled: fix after recent update
* [`11d1b8b4`](https://github.com/NixOS/nixpkgs/commit/11d1b8b438b58cf05cc0da1b7347a191363e96b6) denaro: init at 2023.1.1
* [`5b28044d`](https://github.com/NixOS/nixpkgs/commit/5b28044de6355b77a4ede9e16d52c6c3d972386a) completely: init at 0.5.2
* [`7790eafb`](https://github.com/NixOS/nixpkgs/commit/7790eafbdcbc85a8e48912189400565dd039cb64) pkg-configPackages: init
* [`e93cfb25`](https://github.com/NixOS/nixpkgs/commit/e93cfb250b683f3ffd9adc957c14b5b3b2e108ae) tests.pkg-configPackages: Filter out unsupported packages
* [`04b06e83`](https://github.com/NixOS/nixpkgs/commit/04b06e83dc3438512896abdb38b7d6a8dd8adb26) tests.pkg-configPackages: Filter out broken packages
* [`b576b17f`](https://github.com/NixOS/nixpkgs/commit/b576b17fb00af05968a0ccaddf7ee63857d8d5e2) zlib: Add tests.pkg-configPackages
* [`2d4e78fb`](https://github.com/NixOS/nixpkgs/commit/2d4e78fb8bd3420d31879f5669160b1a62d47fb0) tests.pkg-configPackages: Copy meta attributes for licensing concerns
* [`75a70ff1`](https://github.com/NixOS/nixpkgs/commit/75a70ff129f6442ee8554470d71ce48fab00a527) pkg-configPackages: Fixes for darwin
* [`159ad20b`](https://github.com/NixOS/nixpkgs/commit/159ad20b894a9af2893cacfcca19fcec7f21fa06) doc: Add pkg-config section
* [`90fdbf5f`](https://github.com/NixOS/nixpkgs/commit/90fdbf5f394f3bb7d49992702157df7d93056055) Revert "zlib: Add tests.pkg-configPackages"
* [`a010129b`](https://github.com/NixOS/nixpkgs/commit/a010129bf87c2afcb2f60db410cc535fef299f8c) pkg-configPackages -> defaultPkgConfigPackages
* [`81a541e6`](https://github.com/NixOS/nixpkgs/commit/81a541e6b657cb6dd1943079da48a550b89b87ba) defaultPkgConfigPackages: Make it JSON
* [`09eb09b9`](https://github.com/NixOS/nixpkgs/commit/09eb09b9c50d4f44082a7843b1222bfbaa2d7887) pkg-config-data.json: Encode platform support
* [`811bf8ad`](https://github.com/NixOS/nixpkgs/commit/811bf8ade022b34148a5b71242ca1a713865c7fa) pkg-config-data.json: Add version
* [`3be7ea8c`](https://github.com/NixOS/nixpkgs/commit/3be7ea8c891b3209e92e961fe689649fb0333bcc) top-level/pkg-config: Make tests easy to find
* [`974d331e`](https://github.com/NixOS/nixpkgs/commit/974d331e14318ba27a37874763db0bf32162f1aa) pkg-config-data.json: Remove m and pthread
* [`73b810b1`](https://github.com/NixOS/nixpkgs/commit/73b810b140a31c3014002b806b6da9e877ec674e) shiori: 1.5.3 -> 1.5.4
* [`cebe2c42`](https://github.com/NixOS/nixpkgs/commit/cebe2c422b0798a50224a92238ecc578f3423ed0) python310Packages.qcs-api-client: add changelog to meta
* [`208f0fc6`](https://github.com/NixOS/nixpkgs/commit/208f0fc6ab2844d748b3779e435a6c74361ecc94) python310Packages.qcs-api-client: 0.21.2 -> 0.21.3
* [`c8e138a3`](https://github.com/NixOS/nixpkgs/commit/c8e138a344b947599c6c4f59b927e001c2f75cb8) python310Packages.pyquil: add chagnelog to meta
* [`987cce57`](https://github.com/NixOS/nixpkgs/commit/987cce570afab75ccd6f169b26675b79e3d781f7) mu: 1.8.13 -> 1.8.14
* [`37e48418`](https://github.com/NixOS/nixpkgs/commit/37e48418ac791959659ce98196b8db09adc8b0cb) python311Packages.qcs-api-client: disable tests on Python 3.11
* [`996f448a`](https://github.com/NixOS/nixpkgs/commit/996f448a1bf40948485bc451a6976036902a065c) python310Packages.pyquil: 3.3.2 -> 3.3.3
* [`f7059afc`](https://github.com/NixOS/nixpkgs/commit/f7059afcf864b1cf63b8270788addbce2bb583be) xfce.libxfce4util: 4.18.0 -> 4.18.1
* [`e8dd056b`](https://github.com/NixOS/nixpkgs/commit/e8dd056bfadc27b95176f73674e0a863d6309b72) xfce.thunar: 4.18.1 -> 4.18.3
* [`8f23070e`](https://github.com/NixOS/nixpkgs/commit/8f23070e1af9e79a41c134cf92cfc38b88c0a5c2) xfce.xfce4-datetime-plugin: 0.8.2 -> 0.8.3
* [`a8c1e3fa`](https://github.com/NixOS/nixpkgs/commit/a8c1e3fa17701e4a0837a228169f9d14668ebf27) xfce.xfce4-panel: 4.18.0 -> 4.18.1
* [`403be179`](https://github.com/NixOS/nixpkgs/commit/403be179ec09e37a252f32ba292aed2bbd3a8c8f) xfce.xfce4-taskmanager: odd minor release numbers are stable
* [`85c6464a`](https://github.com/NixOS/nixpkgs/commit/85c6464a2ab44ff2f54763341025c3445f27d4dd) xfce.xfce4-whiskermenu-plugin: 2.7.1 -> 2.7.2
* [`26057588`](https://github.com/NixOS/nixpkgs/commit/26057588ae44ffa34b34a7b202c909f110c03105) xfce.xfdesktop: 4.18.0 -> 4.18.1
* [`859f4aa1`](https://github.com/NixOS/nixpkgs/commit/859f4aa1722ce688f320586d0c90ce76d0bd2158) nixos/tests/grafana/provision: fix test
* [`18cc5e18`](https://github.com/NixOS/nixpkgs/commit/18cc5e1818f205ffa857eac684dedce10bce575f) ddcutil: 1.3.2 -> 1.4.1
* [`32576447`](https://github.com/NixOS/nixpkgs/commit/32576447c051c890d2be51b75036bc7a11667e91) cavalier: init at 2023.01.29
* [`6b4b96e6`](https://github.com/NixOS/nixpkgs/commit/6b4b96e68589414dee2724e14ebc352954c86616) craftos-pc: 2.6.6 -> 2.7.3
* [`fb8cf494`](https://github.com/NixOS/nixpkgs/commit/fb8cf494a107f4a899cc3fd2aee054317bd0336c) craftos-pc: Add tomodachi94 to maintainers
* [`4f8a5065`](https://github.com/NixOS/nixpkgs/commit/4f8a5065d73e7e9e5b5a0db922b99813f9c0c773) lib.systems.inspect.patterns.isEfi: remove "aarch64"
* [`366dfbf8`](https://github.com/NixOS/nixpkgs/commit/366dfbf8f6c8cc99ba759aef9ea6be97bc9e0a79) httm: 0.19.3 -> 0.20.0
* [`5c31d2d2`](https://github.com/NixOS/nixpkgs/commit/5c31d2d23bf2d70ac6c6f75df0ec5a9713500344) dxvk: improve description of `dxvk` derivation
* [`b24f64be`](https://github.com/NixOS/nixpkgs/commit/b24f64bef4c8cc814316f711fbb7f66477574c34) raft-canonical: 0.16.0 -> 0.17.1
* [`524a5128`](https://github.com/NixOS/nixpkgs/commit/524a512848a15e49c0e071d78d15ac8913ccf039) raft-canonical: add lxd as reverse dependency to passthru.tests
* [`2b449a12`](https://github.com/NixOS/nixpkgs/commit/2b449a128bf982e1f29d5623b3a75d815c3ac13a) dqlite: 1.13.0 -> 1.14.0
* [`9a8dd449`](https://github.com/NixOS/nixpkgs/commit/9a8dd44914aa7837776d66ddff3f7d8cb8f94cb7) dqlite: add lxd as reverse dependency to passthru.tests
* [`77f3d199`](https://github.com/NixOS/nixpkgs/commit/77f3d199e2cd2e736d748f5ab829066e1716cb90) process-compose: 0.29.7 -> 0.40.0
* [`b989419e`](https://github.com/NixOS/nixpkgs/commit/b989419ec1efae368af5bb999ac4067c634cc089) python310Packages.awscrt: 0.16.6 -> 0.16.8
* [`32b89d8c`](https://github.com/NixOS/nixpkgs/commit/32b89d8c5f886f163c11191b60339d22ac4cd87d) pax-utils: 1.3.6 -> 1.3.7
* [`06a60a56`](https://github.com/NixOS/nixpkgs/commit/06a60a56576f74d07074db5775e9ec23df1c1a97) python310Packages.airtouch4pyapi: 1.0.5 -> 1.0.8
* [`84747dae`](https://github.com/NixOS/nixpkgs/commit/84747dae9a7244d06ddf9374238771f53e57b3cf) imagemagick6: mark insecure
* [`b4720c3b`](https://github.com/NixOS/nixpkgs/commit/b4720c3bc1435ced76f7d318ecc6933f8bc35332) thedesk: 23.0.5 -> 24.0.7
* [`c9e98260`](https://github.com/NixOS/nixpkgs/commit/c9e98260148a046e397ac3b018b4a3ee9fe34ef5) flex-ndax: 0.2-20221007.1 -> 0.3-20230126.0
* [`cf46e1ae`](https://github.com/NixOS/nixpkgs/commit/cf46e1aedde4438bd15e05d6e5186228f4cb3e4a) drone-runner-ssh: init at unstable-2022-12-22
* [`24460ed8`](https://github.com/NixOS/nixpkgs/commit/24460ed802eda26a7a6300053df17b75444fff6e) cinelerra: unstable-2021-02-14 -> unstable-2023-01-29
* [`7f35c8b2`](https://github.com/NixOS/nixpkgs/commit/7f35c8b2ac51c9c93abaa4eaa23f4ac39e5db5a5) nixos/systemd/coredump: fix kernel.core_pattern truncation
* [`465b5127`](https://github.com/NixOS/nixpkgs/commit/465b51277703489e6ccadda049a1ee2e70833a83) resholve: 0.8.5 -> 0.9.0
* [`4bac8529`](https://github.com/NixOS/nixpkgs/commit/4bac8529efed76fa6461bb39cfc6b97ab84fa8da) marathi-cursive: 2.0 -> 2.1
* [`bd900722`](https://github.com/NixOS/nixpkgs/commit/bd9007229472cac18311a3e572278d501d15c717) drone: add website
* [`89a0a924`](https://github.com/NixOS/nixpkgs/commit/89a0a924743ec4b7de365ab1e03fc0520ecaa0a2) mpich: 4.0.3 -> 4.1
* [`e81afd88`](https://github.com/NixOS/nixpkgs/commit/e81afd887eff1be3648ed051ceced90792728ed7) python310Packages.getmac: 0.8.3 -> 0.9.1
* [`fb910900`](https://github.com/NixOS/nixpkgs/commit/fb9109003295e7e139172642716b9f9d69bd7d88) python310Packages.devpi-common: 3.7.1 -> 3.7.2
* [`6900c444`](https://github.com/NixOS/nixpkgs/commit/6900c444a7968ec5423530cb5988330354922c89) python310Packages.ffmpeg-progress-yield: 0.6.1 -> 0.7.0
* [`473ac969`](https://github.com/NixOS/nixpkgs/commit/473ac9692e09451ef6025e50ccfa19efe5ae69a9) lib.hydraJob: Tolerate null
* [`f192e96d`](https://github.com/NixOS/nixpkgs/commit/f192e96d0771a9c8fa8e8c73e6ef66af56a548f8) tests.defaultPkgConfigPackages: Add recurseIntoAttrs
* [`b6bec17e`](https://github.com/NixOS/nixpkgs/commit/b6bec17eb9b8f256151c396282ad76db255fff91) testers.hasPkgConfigModule: Extract and add tests, docs
* [`d8a21780`](https://github.com/NixOS/nixpkgs/commit/d8a217801e21d561e47a91ea60ec086397fc7466) defaultPkgConfigPackages: Add dontRecurseIntoAttrs
* [`e03dc541`](https://github.com/NixOS/nixpkgs/commit/e03dc5413303b7ebf3a3e8e01e2395adc1a8b041) pixinsight: remove qtwebkit
* [`61096171`](https://github.com/NixOS/nixpkgs/commit/6109617190bcd944636ab9b52f8d9741be8ac8d4) firefox-beta-bin-unwrapped: 110.0b5 -> 110.0b7
* [`b6a8a230`](https://github.com/NixOS/nixpkgs/commit/b6a8a230dbf737b656dba728131823e0653933d2) labwc: 0.6.0 -> 0.6.1
* [`259cc790`](https://github.com/NixOS/nixpkgs/commit/259cc7903c78d48d10c930b019bea049a5471884) nixos/roon-bridge: fix exec name
* [`aa49baac`](https://github.com/NixOS/nixpkgs/commit/aa49baac70e5ff48e43216b000766e014917c50b) python310Packages.moku: 2.5.1 -> 2.6.0
* [`b431ac2f`](https://github.com/NixOS/nixpkgs/commit/b431ac2fd98ac95f64c8fa28d16c4e4c2314541e) programmer-calculator: 2.2 -> 3.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
