### PR TITLE
niv devenv: update 2e20275b -> d97ea8c7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2e20275b01464345c35d2aa42f8405fd8685a6e4",
-        "sha256": "1by2s84js48wn54d9fkig8rnr2paw7m6xkdsi21i9dfzdiinaqxx",
+        "rev": "d97ea8c7d91678683b321d93694ca805ac7978e0",
+        "sha256": "1yc3g24l77z4q6gqfh69296mbzhhq7b2c8w0s50hn35qpk6mx6vl",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/2e20275b01464345c35d2aa42f8405fd8685a6e4.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/d97ea8c7d91678683b321d93694ca805ac7978e0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@2e20275b...d97ea8c7](https://github.com/cachix/devenv/compare/2e20275b01464345c35d2aa42f8405fd8685a6e4...d97ea8c7d91678683b321d93694ca805ac7978e0)

* [`cc5bae4b`](https://github.com/cachix/devenv/commit/cc5bae4b882e66e08ba018cec4c2ade5e7d425d7) Add Julia support
* [`2025222e`](https://github.com/cachix/devenv/commit/2025222e7ef940d8402393afa8e026f9091fa86b) Add Racket support
* [`a7250a64`](https://github.com/cachix/devenv/commit/a7250a641816619e96a2e23865457b719087393e) Add example for Racket
* [`1a2ed126`](https://github.com/cachix/devenv/commit/1a2ed1268b51be506383d3da1285ff25dd3939ad) fix: mysql starting with empty folder
* [`3e077dc0`](https://github.com/cachix/devenv/commit/3e077dc06a5b15a7dc028f3af3361e32002a831b) bump supported-languages deps
* [`1447b6c2`](https://github.com/cachix/devenv/commit/1447b6c2a5f36aca4ac8540da9f0d53e62240f13) Add Dart language
* [`7006d98d`](https://github.com/cachix/devenv/commit/7006d98db8b2338ee0eaa897d8c88888e9e40da7) Auto generate docs/reference/options.md
* [`002e3d68`](https://github.com/cachix/devenv/commit/002e3d68e6ce4a7b170e4d46f75519006427f6c4) Auto generate examples/supported-languages/devenv.nix
* [`903c895a`](https://github.com/cachix/devenv/commit/903c895a8adb14f0cda0554b864ec2eb1f703e1c) Fix direnv with strict_env enabled
* [`a43eb4df`](https://github.com/cachix/devenv/commit/a43eb4df64302020db1f213931f2ca3988419dac) Auto generate docs/reference/options.md
* [`3e726dd0`](https://github.com/cachix/devenv/commit/3e726dd0709ef3fe32bbfa1e7452385721b0fd81) Auto generate examples/supported-languages/devenv.nix
* [`fa21391d`](https://github.com/cachix/devenv/commit/fa21391dff848da058daaa119c9a5ba930076d3c) Auto generate docs/reference/options.md
* [`06004e5b`](https://github.com/cachix/devenv/commit/06004e5b486e85409f49b7ad55301ba4750d9392) Auto generate examples/supported-languages/devenv.nix
* [`727f8939`](https://github.com/cachix/devenv/commit/727f89395cbb3497dbe62353e0934782ae726c19) feat: make composer optional
* [`1aacdbe7`](https://github.com/cachix/devenv/commit/1aacdbe7f9c1c0b78e1ffaa311e112e8781b021e) feat(php): allow disabling composer
* [`be66db90`](https://github.com/cachix/devenv/commit/be66db907825912f1afaad231f851ef5556347bb) feat(php): get rid of usage of global tmp dir
* [`7337bf6a`](https://github.com/cachix/devenv/commit/7337bf6a3ee9a09b2a34ca05dda0682236dbae18) added GNU Awk language support
* [`c50a6d9d`](https://github.com/cachix/devenv/commit/c50a6d9d18348530ce3312111f97056c974d0987) cli: suppress dirty git repository warnings
* [`8270bc26`](https://github.com/cachix/devenv/commit/8270bc2683989fc7487abef9c5b6f5373e03324d) Add a failing test for direnv in strict mode
* [`557cc7f3`](https://github.com/cachix/devenv/commit/557cc7f31c8cb81912cf21db56196c54e2a12827) Update the 'simple' example to fix failing direnv test
* [`e1a8b96b`](https://github.com/cachix/devenv/commit/e1a8b96badd53b7a0c9a99257fc4eafcc787a39d) Fix more unbound variables
* [`ea002aae`](https://github.com/cachix/devenv/commit/ea002aae068363b86c165151dd471116d11eab00) bump deps
* [`a34cfc9a`](https://github.com/cachix/devenv/commit/a34cfc9a5283911f0db52bb272591381910cb675) Auto generate docs/reference/options.md
* [`4135d30c`](https://github.com/cachix/devenv/commit/4135d30cc5487572b60258281d51ecdfddaaeee6) 0.5.1
* [`baaf3eba`](https://github.com/cachix/devenv/commit/baaf3ebae4b8e49876e17d5052fd0a47120fa1a6) Auto generate docs/reference/options.md
* [`a862d75b`](https://github.com/cachix/devenv/commit/a862d75b6412a12a06216bda556cc3301aca7327) Fix shell evaluation when devenv installed is newer
* [`e0688a63`](https://github.com/cachix/devenv/commit/e0688a630eddfd149c01c00d8ca1e560a05c366b) docs: unpack mdDoc
* [`6b45ce19`](https://github.com/cachix/devenv/commit/6b45ce19da285766b90a26ce402982b89ccb015c) docs: remove mdDoc
* [`a2d8028e`](https://github.com/cachix/devenv/commit/a2d8028e2cd6398f4bb3d67b9622fb2570f31c29) docs: convert docbook descriptions to markdown
* [`b9988c9f`](https://github.com/cachix/devenv/commit/b9988c9fbaef43d31f8570e172ee1385f618883d) docs: fix links
* [`91c77323`](https://github.com/cachix/devenv/commit/91c77323df5b8597ab3f44c3c319d2516aec7cb8) Auto generate docs/reference/options.md
* [`755670d4`](https://github.com/cachix/devenv/commit/755670d41ba697224a074c6ec97bb36cdaa668c6) bump simple example
* [`1543a0d8`](https://github.com/cachix/devenv/commit/1543a0d85c25e9e91ab269f577134927c525f8bd) Fix use of deprecated config.mysql
* [`d41123a8`](https://github.com/cachix/devenv/commit/d41123a8bafb428e6be32abbb70815bf7cc47ff3) starship: fix setting a custom config
* [`0fbf9c57`](https://github.com/cachix/devenv/commit/0fbf9c57465a7d591f615e94fe4bbdbb8370651d) add version to the derivation
* [`d9cc57d8`](https://github.com/cachix/devenv/commit/d9cc57d86d03ba5f83f6193be5e74585f617bf4b) Revert "add version to the derivation"
* [`181ffc93`](https://github.com/cachix/devenv/commit/181ffc9327102f4246579422b118128d04df5d58) Auto generate docs/reference/options.md
* [`f651ec93`](https://github.com/cachix/devenv/commit/f651ec93c9793f553ce8b476b2073cfb60a57194) search: unpack Nix types when generating the options
* [`629c39d8`](https://github.com/cachix/devenv/commit/629c39d858cf8312fd3d1d60b8d0bfe3059e3b8b) added: language support for raku
* [`77474fc9`](https://github.com/cachix/devenv/commit/77474fc99c8c858e4fcdaebe063dfffc5d4a1885) raku.nix: neatly formatted description
* [`6fe685c7`](https://github.com/cachix/devenv/commit/6fe685c740440c8a0e0ac70903f48f8ded73697a) raku.nix: fixed attribute
* [`67a22058`](https://github.com/cachix/devenv/commit/67a2205869f5d1bfb7a103cae5fb9433cafa19d6) Auto generate docs/reference/options.md
* [`2c0c2f1d`](https://github.com/cachix/devenv/commit/2c0c2f1d3a0b2166bc898c785a54ebce98cecafe) Auto generate examples/supported-languages/devenv.nix
* [`1031ca13`](https://github.com/cachix/devenv/commit/1031ca13cf4da7dcbc73a1c9054fbdca661424e8) php: make composer as package
* [`77c9fb12`](https://github.com/cachix/devenv/commit/77c9fb12e5bcca0b99e2921ee44faafd6004ccb5) Auto generate docs/reference/options.md
* [`91c1900f`](https://github.com/cachix/devenv/commit/91c1900fd90a03d8b63e12d6555b6c7b6848cb58) Auto generate examples/supported-languages/devenv.nix
* [`6ea4e833`](https://github.com/cachix/devenv/commit/6ea4e83337da0e1bebc660bfb27c0c63af5aecc6) add Swift language support
* [`6fda9a6c`](https://github.com/cachix/devenv/commit/6fda9a6c3d10d67278c616af3a1e2dbfa49dcd4a) doc: edit files-and-variables
* [`b909f5d6`](https://github.com/cachix/devenv/commit/b909f5d6fa2418a1429b63b48c22173c716f48df) Auto generate docs/reference/options.md
* [`664e94b5`](https://github.com/cachix/devenv/commit/664e94b53d45a809902ecdcea7873fa6071d10d9) Auto generate examples/supported-languages/devenv.nix
* [`ebaf449f`](https://github.com/cachix/devenv/commit/ebaf449fe0746882e27e869af749da8cb706839d) bump cachix/install-nix-action
* [`4d099c41`](https://github.com/cachix/devenv/commit/4d099c41cad548d10166e504dcbabb5c2185f9a7) feat(php): add first class phps support
* [`665ec536`](https://github.com/cachix/devenv/commit/665ec5367a8cc2116b1edbfa3a5d7668c7e958be) docs/getting-started: use latest branch instead of tag
* [`b7c9d1f0`](https://github.com/cachix/devenv/commit/b7c9d1f0a4ecac7117dd726e9c2179a074faff5d) feat(php): simplify code
* [`d97ea8c7`](https://github.com/cachix/devenv/commit/d97ea8c7d91678683b321d93694ca805ac7978e0) Auto generate docs/reference/options.md
