### PR TITLE
niv zsh-completions: update 3e3e2f97 -> 828fe2bd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "3e3e2f97f2ff1b996092cf582e8eba33b46b8409",
-        "sha256": "1yhg610adw65ngqz21imkc4ir8868givnmq77ncjawisibn4v9s5",
+        "rev": "828fe2bd3c67123263fc8a8cadebae92e10a2224",
+        "sha256": "1imjkjp6i0xs7gkvagfaikvizqlmd9j1jnqk54ihg9i11mnr60cw",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/3e3e2f97f2ff1b996092cf582e8eba33b46b8409.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/828fe2bd3c67123263fc8a8cadebae92e10a2224.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@3e3e2f97...828fe2bd](https://github.com/zsh-users/zsh-completions/compare/3e3e2f97f2ff1b996092cf582e8eba33b46b8409...828fe2bd3c67123263fc8a8cadebae92e10a2224)

* [`b07000ca`](https://github.com/zsh-users/zsh-completions/commit/b07000ca5f8b41a64c725bce7f3f0262fc05c886) Update include-what-you-use completion
* [`e936451b`](https://github.com/zsh-users/zsh-completions/commit/e936451b03fd58cb3ae1f0e81c5c0230ee81b9b8) tmuxp: fix using workspace dirs other than ~/.tmuxp
