### PR TITLE
niv nixpkgs: update fb020498 -> 3f113f8c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fb020498b83c223b6fca4b443c267bfc91087c64",
-        "sha256": "0lg1f0qak6xz0ij4n1wq970cp2mmwcv3lzdmyfyglgl5a2vb9d3k",
+        "rev": "3f113f8c53cddb2d95790b7ed8b20b61a195de6c",
+        "sha256": "0fggj2pz2a2md8gr1i0882cgz8lky6frmd7aka607k1i7jjbm91j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/fb020498b83c223b6fca4b443c267bfc91087c64.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/3f113f8c53cddb2d95790b7ed8b20b61a195de6c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@fb020498...3f113f8c](https://github.com/nixos/nixpkgs/compare/fb020498b83c223b6fca4b443c267bfc91087c64...3f113f8c53cddb2d95790b7ed8b20b61a195de6c)

* [`4822155d`](https://github.com/NixOS/nixpkgs/commit/4822155d49fba8bd8adec7212b6c71517b60e10e) nixos/hostapd: Remove blank default for cfg.interface
* [`8b7740d1`](https://github.com/NixOS/nixpkgs/commit/8b7740d1b2fc6f9e89bf405ba090e5931a8e8546) nixos/hostapd: Disable insecure TKIP by default
* [`5d012c4b`](https://github.com/NixOS/nixpkgs/commit/5d012c4bb21fa9bee9f34339f95ef8fffa052d56) nixos/hostapd: Enable 802.11n / 802.11ac by default
* [`ae1cb5ac`](https://github.com/NixOS/nixpkgs/commit/ae1cb5ac93f6808be688a1e056d1e58572018f8d) caf: 0.18.5 -> 0.18.6
* [`b376ec11`](https://github.com/NixOS/nixpkgs/commit/b376ec113b8bab7b4dbae054bd2805e501e1a6f0) home-assistant: fix packageOverrides ordering
* [`b601f9c0`](https://github.com/NixOS/nixpkgs/commit/b601f9c047d65982af248ce54327234f584916cb) usbredir: 0.12.0 -> 0.13.0
* [`6ec59165`](https://github.com/NixOS/nixpkgs/commit/6ec591652048ca89a17822ee4c0bcb1ec2d2745c) rlwrap: remove me as maintainer
* [`5da1db47`](https://github.com/NixOS/nixpkgs/commit/5da1db47bf1f4610e86bf744855fa40f937d5949) gnomeExtensions.tophat: patch missing dependency
* [`a2719e49`](https://github.com/NixOS/nixpkgs/commit/a2719e490d9dbdf922995da5f76e6f6a6c0e3d42) .github/ISSUE_TEMPLATE: Improvements
* [`3d17d6ff`](https://github.com/NixOS/nixpkgs/commit/3d17d6fff637cfadd6adb10adaf58bd8451fb90e) nixos/openvpn: added restartAfterSleep option
* [`8399ff1e`](https://github.com/NixOS/nixpkgs/commit/8399ff1e345f0b088f459b67c1dcc1aed00f70e6) nixos/openvpn: applied nixpkgs-fmt
* [`55070077`](https://github.com/NixOS/nixpkgs/commit/550700773091562a3e0db7e3599e8a6eed1eb105) Update .github/ISSUE_TEMPLATE/missing_documentation.md
* [`c926ca0a`](https://github.com/NixOS/nixpkgs/commit/c926ca0ae0de876403330e72af12b5379084d4da) snabb: 2022.10 -> 2022.12
* [`041910e6`](https://github.com/NixOS/nixpkgs/commit/041910e6859e2a26ced91cf45789385b968ef926) yquake2: 8.10 -> 8.20
* [`9e6d4662`](https://github.com/NixOS/nixpkgs/commit/9e6d466232c5f0ee0b661f14207077139662f93e) geekbench: 5.4.5 -> 5.4.6
* [`483c606a`](https://github.com/NixOS/nixpkgs/commit/483c606a948ee5e6123a3f400e6140caf5006d06) fixup! .github/ISSUE_TEMPLATE: Improvements
* [`b9ca555c`](https://github.com/NixOS/nixpkgs/commit/b9ca555cef8bda50bffb04f43202db1010d6ae90) ldapvi: fetch rev, fix version number
* [`1556f492`](https://github.com/NixOS/nixpkgs/commit/1556f4920ab56cf4bb684dd304ebab7a16e1b974) repro-get: init at 0.2.1
* [`7f8e2d85`](https://github.com/NixOS/nixpkgs/commit/7f8e2d8587fca5be759d46ff145f641db2105280) atomicparsley: 20210715.151551.e7ad03a -> 20221229.172126.d813aa6
* [`da47c1c2`](https://github.com/NixOS/nixpkgs/commit/da47c1c26a48bb8bb7f906aac42c311eae4792f6) zita-alsa-pcmi: 0.5.1 -> 0.6.1
* [`70c8d446`](https://github.com/NixOS/nixpkgs/commit/70c8d446a75cbb2bd0d468b2c5bec67e44f36fc5) aerc: 0.13.0 → 0.14.0
* [`7e98c597`](https://github.com/NixOS/nixpkgs/commit/7e98c597a1bbeb76da4267f2ddee0aa9475b1f9d) hotspot: 1.4.0 -> 1.4.1
* [`4068197a`](https://github.com/NixOS/nixpkgs/commit/4068197a9df2f46570cd4bb964beadc963dfa544) hotspot: add changelog to meta
* [`27513ed3`](https://github.com/NixOS/nixpkgs/commit/27513ed374ff36b7039ae7d594c85f28f49962ac) pynvml: Add patch for finding libnvidia-ml.so.1 on NixOS
* [`7650f5f8`](https://github.com/NixOS/nixpkgs/commit/7650f5f86f20fb37ac1fe4349ae72154d1e19638) template patch with addOpenGLRunpath
* [`42b3ad82`](https://github.com/NixOS/nixpkgs/commit/42b3ad82ccbccfcf8196ed89ce2be2fe96260618) callaudiod: 0.1.4 -> 0.1.7
* [`cd80df9e`](https://github.com/NixOS/nixpkgs/commit/cd80df9e8a68baeac061d1e4ca51aa628ca9cc1c) ldb: 2.3.0 -> 2.6.1
* [`300f427c`](https://github.com/NixOS/nixpkgs/commit/300f427c59c7699aa6e8ae238cbee93112d2df71) tdb: 1.4.6 -> 1.4.7
* [`0b1723cc`](https://github.com/NixOS/nixpkgs/commit/0b1723ccbf160f7e4dc0cb54798a599ca160267d) talloc: 2.3.3 -> 2.3.4
* [`a36d319f`](https://github.com/NixOS/nixpkgs/commit/a36d319f2d85aa7eec06051e6d5b524ad2e66781) tevent: 0.10.2 -> 0.13.0
* [`9b4cf108`](https://github.com/NixOS/nixpkgs/commit/9b4cf10855256ba9d78c04c28dc43b27a4b4acf4) samba: etc
* [`56807d09`](https://github.com/NixOS/nixpkgs/commit/56807d091770f18ccaada6bad4429060f4b59858) python310Packages.py3status: 3.47 -> 3.48
* [`cf5b8636`](https://github.com/NixOS/nixpkgs/commit/cf5b8636233e9e37ffa0cd0a7a0418564867cbbe) python310Packages.pypinyin: 0.47.1 -> 0.48.0
* [`5c4f6161`](https://github.com/NixOS/nixpkgs/commit/5c4f6161981917504c50b84864dcfd2f67dc037d) lib.path: Minor improvements
* [`eac25387`](https://github.com/NixOS/nixpkgs/commit/eac2538707ee6edd475cb40bfa2ec3d2c05c3ac0) lib.path.append: init
* [`06850637`](https://github.com/NixOS/nixpkgs/commit/0685063744f1550592546e7326bf90ecd7eeeed8) python310Packages.types-dateutil: 2.8.19.5 -> 2.8.19.6
* [`5612f555`](https://github.com/NixOS/nixpkgs/commit/5612f555c6508a366788b128d6f5b2b073de15f6) python310Packages.pyvmomi: 8.0.0.1.1 -> 8.0.0.1.2
* [`53729841`](https://github.com/NixOS/nixpkgs/commit/53729841e871a8604399dd003ce5a57491158eed) nixos/tests/cups-pdf: fix test with socket-activated cups
* [`8bdba2a2`](https://github.com/NixOS/nixpkgs/commit/8bdba2a2c0d66ae15a4914fc587a272a88cdea9e) buildbot: add badges plugin
* [`912fc670`](https://github.com/NixOS/nixpkgs/commit/912fc670f6dab8b7370430542c3afdf453d0417a) mariadb: use openssl_3 for 105
* [`3f5fcc6e`](https://github.com/NixOS/nixpkgs/commit/3f5fcc6eab9f05e374e8f93869d9d8ddff252ba0) mariadb_1010: init at 10.10.2
* [`3f94eff7`](https://github.com/NixOS/nixpkgs/commit/3f94eff79c7131c3bec8480a181a729bc7f8a8bd) vassal: set mainProgram
* [`60a23dd3`](https://github.com/NixOS/nixpkgs/commit/60a23dd32cf249a136aa7037fbe4035f28247196) vassal: add wrapGAppsHook
* [`75617407`](https://github.com/NixOS/nixpkgs/commit/75617407d29877ce877595e77f89e4a7317e6060) colima: use lima-bin on darwin for native macOS virtualization support
* [`e4541bcc`](https://github.com/NixOS/nixpkgs/commit/e4541bccd57496562b9f885c19a5ce9c009778b8) haskellPackages: stackage LTS 20.6 -> LTS 20.8
* [`c4d08113`](https://github.com/NixOS/nixpkgs/commit/c4d081132770679ff27ea4422e38526d9a524a55) all-cabal-hashes: 2023-01-12T12:18:29Z -> 2023-01-28T02:06:09Z
* [`0c439eaa`](https://github.com/NixOS/nixpkgs/commit/0c439eaa451dd19d6d35c627300d4a2e1ab10205) haskellPackages: regenerate package set based on current config
* [`bf5873ba`](https://github.com/NixOS/nixpkgs/commit/bf5873bad594846264266911e830de8ac1e6ce8b) leptonica: 1.82.0 -> 1.83.0
* [`a19c382d`](https://github.com/NixOS/nixpkgs/commit/a19c382df85074abfb782a1defddc7bd3f1fb9a5) include-what-you-use: 0.18 -> 0.19
* [`b573c6a1`](https://github.com/NixOS/nixpkgs/commit/b573c6a116bb743aef7556dba0a603bb6e11608d) jbig2enc: 0.28 -> 0.29
* [`24afb012`](https://github.com/NixOS/nixpkgs/commit/24afb0125d512944f6b7238a3f37785448e0f057) jbig2enc: move to pkgs/development/libraries
* [`3b77f6c3`](https://github.com/NixOS/nixpkgs/commit/3b77f6c31be895c12b1938d06ee052da2463b3d7) tesseract4: 4.1.1 -> 4.1.3
* [`c6233099`](https://github.com/NixOS/nixpkgs/commit/c623309976b707a9c6e8c02b566f4239779ce4ac) tesseract: 3.05.00 -> 3.05.02
* [`4cf2e4c2`](https://github.com/NixOS/nixpkgs/commit/4cf2e4c26ee3f9ede0421aaa6b2dd7660674b5f3) haskellPackages.bytepatch: unmark broken
* [`b5292b3e`](https://github.com/NixOS/nixpkgs/commit/b5292b3eedddb37aa8c2d6eeb5eaa1e7caa49373) slack: fix verbose logs
* [`7d6ecd05`](https://github.com/NixOS/nixpkgs/commit/7d6ecd0573cb089e574d8357358bddbfc62ee454) ccextractor: fix build with leptonica 1.83
* [`96aa0e21`](https://github.com/NixOS/nixpkgs/commit/96aa0e21406fe7e1efb4c197ccfe2b7b11acde2e) python3Packages.tesserocr: fix build with leptonica 1.83
* [`96a95c40`](https://github.com/NixOS/nixpkgs/commit/96a95c408ea4b295de46224c4c920a4f414c5b6f) qt-box-editor: unstable-2019-07-12 -> unstable-2019-07-14, fix build with leptonica 1.83
* [`3caa473d`](https://github.com/NixOS/nixpkgs/commit/3caa473dcf37346ef0f4ac00eba2b74765077c47) vobsub2srt: fix build with tesseract 3.05.02
* [`2e2bd8b4`](https://github.com/NixOS/nixpkgs/commit/2e2bd8b4f50d97e0a6d30deb9beb7b420d36a20b) xcode: add missing versions
* [`54614fa1`](https://github.com/NixOS/nixpkgs/commit/54614fa1c017ec43bb22b88feb745130cdf5d47c) xcode: update hashes to SRI for consistency
* [`a6755064`](https://github.com/NixOS/nixpkgs/commit/a6755064e6033d83d540232a20df8e1e6049b577) all-cabal-hashes: 2023-01-28T02:06:09Z -> 2023-01-29T01:30:53Z
* [`00e91ba5`](https://github.com/NixOS/nixpkgs/commit/00e91ba5318cf568302fcaaca0bfbf16d3f3887e) haskellPackages: regenerate package set based on current config
* [`c4d46081`](https://github.com/NixOS/nixpkgs/commit/c4d460810e6ff1c98c5643c5f9ee804ce18a1e17) haskellPackages: mark some broken packages as not broken
* [`e92ea6d4`](https://github.com/NixOS/nixpkgs/commit/e92ea6d48dba7a0ff2c765d1eaefd31200f90ddb) haskellPackages: Fix eval by bumping pinned versions
* [`3ead6d03`](https://github.com/NixOS/nixpkgs/commit/3ead6d03227e5ee55efc0b43d622204702b205bf) haskellPackages: regenerate package set based on current config
* [`7e9f2557`](https://github.com/NixOS/nixpkgs/commit/7e9f255717d06410596d79a776f016b3e51bf60a) nwg-panel: 0.7.11 -> 0.7.16
* [`e75161f4`](https://github.com/NixOS/nixpkgs/commit/e75161f4ba591199af1a7bd8fac3d77115b267a1) colima: add comment on why we use lima-bin on darwin
* [`3988efd7`](https://github.com/NixOS/nixpkgs/commit/3988efd73f74a4c30d0fac0a926e46ba1b2905ee) haskellPackages.ghcide: Drop maintainership
* [`3b23105b`](https://github.com/NixOS/nixpkgs/commit/3b23105b0bf9e42e26389ee17d843dedc4f9c6d8) haskellPackages.clay: Fix build and make maralorn maintainer
* [`8298122f`](https://github.com/NixOS/nixpkgs/commit/8298122fcb0773eac4a73f0f1fdaef60bbc6680c) haskellPackages.graphql-client: Fix build and make maralorn maintainer
* [`0ff0d08f`](https://github.com/NixOS/nixpkgs/commit/0ff0d08f690a17a6b3ebdc58709989e3f31a4b8b) haskellPackages.streamly-bytestring: Fix build and make maralorn maintainer
* [`6af08442`](https://github.com/NixOS/nixpkgs/commit/6af08442d676440e6495b310871abe3067128809) haskellPackages.pandoc-{cli,crossref}: Make maralorn maintainer
* [`4be2c3ac`](https://github.com/NixOS/nixpkgs/commit/4be2c3acd51fe2785be278b59195def0dbd8834e) haskellPackages: ignore maintainers without email
* [`597e558b`](https://github.com/NixOS/nixpkgs/commit/597e558b144f03d1660b6426b04faac79e5fba86) maintainers: add tehmatt
* [`a6b406e5`](https://github.com/NixOS/nixpkgs/commit/a6b406e5afedfd217ae44305e199e1dc3fca4dc3) flac2all: init at version 5.1
* [`a06fdc80`](https://github.com/NixOS/nixpkgs/commit/a06fdc80222787342da45c4431bb359e0e01ad1d) bundlewrap: fix runtime deps
* [`d9f07dce`](https://github.com/NixOS/nixpkgs/commit/d9f07dcee585db581688a72d3bcbea2b15794836) nixos/envfs: use configured environment.usrbinenv and environment.binsh
* [`7a70efc3`](https://github.com/NixOS/nixpkgs/commit/7a70efc3e57bc7d5cf6609b7aca127f2c4cf1b08) haskellPackages.hopenssl: link against openssl 3.0
* [`3ecdb69d`](https://github.com/NixOS/nixpkgs/commit/3ecdb69dd654f587b21154190ded65e507c0d197) haskellPackages.FailT: remove broken flag
* [`a16864e2`](https://github.com/NixOS/nixpkgs/commit/a16864e2bfd4c89677e539ff17a325d5785f98cc) git-annex: update sha256 for 10.20230126
* [`14974985`](https://github.com/NixOS/nixpkgs/commit/1497498503e3578418ff93de4180ca00f5ca900a) alice-tools,alice-tools-qt5,alice-tools-qt6: init at 0.12.1
* [`7562d276`](https://github.com/NixOS/nixpkgs/commit/7562d276f85b1098e845baf41aad9fbb605330b1) gitoxide: 0.19.0 -> 0.20.0
* [`98f36b2d`](https://github.com/NixOS/nixpkgs/commit/98f36b2d744c02c844200cc0624ba5bc226660e5) ocamlPackages.dune_3: enable for OCaml < 4.08
* [`62a2cfe3`](https://github.com/NixOS/nixpkgs/commit/62a2cfe3636c69ba81c1aea16a473abad15dab30) ocamlPackages.checkseum: use Dune 3
* [`390bbcce`](https://github.com/NixOS/nixpkgs/commit/390bbccee0fd3f0aed6ffbc01e3dca5f03f47fe9) arrow-cpp: 9.0.0 -> 10.0.1
* [`73b8f458`](https://github.com/NixOS/nixpkgs/commit/73b8f458eb816ec2cf9b45914dd0f6dd130d3ad3) python3Packages.pyarrow: 9.0.0 -> 10.0.1
* [`c446fa92`](https://github.com/NixOS/nixpkgs/commit/c446fa92113097692df7f9b75a0398340d17fbb7) python3Packages.pyarrow: ignore cython compilation test on darwin
* [`1f6cebf0`](https://github.com/NixOS/nixpkgs/commit/1f6cebf05cf6a5ed23c801645b62c7051957996b) thrift: propagate interface dependencies
* [`d0fd4b41`](https://github.com/NixOS/nixpkgs/commit/d0fd4b418e421ebe5ab77701a3fe87920e63721b) arrow-cpp: 10.0.1 -> 11.0.0
* [`806e263d`](https://github.com/NixOS/nixpkgs/commit/806e263d6a5bf96e5510ded7889b7053c9e5ee94) php81: 8.1.14 -> 8.1.15
* [`fb528f22`](https://github.com/NixOS/nixpkgs/commit/fb528f223756943730e12476127dad963cda3d5f) php82: 8.2.1 -> 8.2.2
* [`c8bb1b66`](https://github.com/NixOS/nixpkgs/commit/c8bb1b66fd21c1d8d37ec8a177d01a7512a30a22) handbrake: 1.5.1 -> 1.6.1
* [`6c432054`](https://github.com/NixOS/nixpkgs/commit/6c43205441353a01e778c9270896c05dc1a817b8) arrow-cpp: mark as broken on aarch64-linux
* [`0ec33e6d`](https://github.com/NixOS/nixpkgs/commit/0ec33e6d27edcf4e1642a0f153d410605280aee8) folly: 2022.11.28.00 -> 2023.01.30.00
* [`cbff6c4b`](https://github.com/NixOS/nixpkgs/commit/cbff6c4b513f726a7e5109cad01c1d76dd349862) mozillavpn: 2.12.0 → 2.13.0
* [`7ffa6e7d`](https://github.com/NixOS/nixpkgs/commit/7ffa6e7d5d067e968d13386262a4c79d61ab3add) vscode-extensions.streetsidesoftware.code-spell-checker: 2.15.0 -> 2.16.0
* [`33dfee8c`](https://github.com/NixOS/nixpkgs/commit/33dfee8c9b47b445060f5ec5dd50c71d51f751a0) deepin-desktop-base: init at 2022.03.07
* [`a0b05699`](https://github.com/NixOS/nixpkgs/commit/a0b05699ae315a04de4db09f8087b5b083357300) haskell.packages.ghc92.weeder: pin to supported 2.4.* versions
* [`77d65a56`](https://github.com/NixOS/nixpkgs/commit/77d65a56a9ad9ba9e4b22faa7f44ff1a86fd5e86) haskell-language-server: fix
* [`c0d9f21f`](https://github.com/NixOS/nixpkgs/commit/c0d9f21f50a90a5706214c09760a3ae9abfcfcf0) nixos/cockpit: init
* [`f772d2e6`](https://github.com/NixOS/nixpkgs/commit/f772d2e69b45e26df86e9c68508093b00d24e389) cockpit: init at 284
* [`1ef7b45f`](https://github.com/NixOS/nixpkgs/commit/1ef7b45ffb7d9f4ab5623a8c985ad9d247acde70) nixos/cockpit: add nixos test
* [`ac7b8b85`](https://github.com/NixOS/nixpkgs/commit/ac7b8b85ab92021f09aef5563a076bb7831fc468) lib3mf: fix include paths in pkg-config file
* [`2d5a1864`](https://github.com/NixOS/nixpkgs/commit/2d5a1864d1d1b884dd220ff2c271128dee7b9aae) pgpool: 4.4.1 -> 4.4.2
* [`99631874`](https://github.com/NixOS/nixpkgs/commit/9963187479418ab259e19ab1556229fa1447cd15) pgagroal: init at 1.5.1
* [`cd6a9847`](https://github.com/NixOS/nixpkgs/commit/cd6a9847364138fb4735a8c9324931bec0ac543b) monetdb: 11.45.11 -> 11.45.13
* [`732cfc79`](https://github.com/NixOS/nixpkgs/commit/732cfc79473d57728e16dd71c5d80c7b7aaf9897) go-lib: init at 5.8.27
* [`ea000987`](https://github.com/NixOS/nixpkgs/commit/ea00098756a2e2504ddee623c9849ce28ff04c42) go-gir-generator: init at 2.2.0
* [`cb3c1593`](https://github.com/NixOS/nixpkgs/commit/cb3c159314b371afd48b153bcd6c0fa7f98f903d) go-dbus-factory: init at 1.10.23
* [`c700cb7b`](https://github.com/NixOS/nixpkgs/commit/c700cb7b5efae55f46a9c70376f08861e5e1fec1) deepin-gettext-tools: init at 1.0.10
* [`dc0b7016`](https://github.com/NixOS/nixpkgs/commit/dc0b701631888d5e08d5696c8343b15db40fa0a9) deepin-pw-check: init at 5.1.17
* [`1dac9db7`](https://github.com/NixOS/nixpkgs/commit/1dac9db7fd426ee3f21dc1eb6850662091ac0892) python3Packages.sphinxcontrib-youtube: init at 1.2.0
* [`cfc77dc4`](https://github.com/NixOS/nixpkgs/commit/cfc77dc41003c7c0abe820fc4c18a7492012f1df) pgadmin4: 6.18 -> 6.19
* [`7dc8f2ab`](https://github.com/NixOS/nixpkgs/commit/7dc8f2ab9fc712a6cde1ac4b12f9e4677d225e1b) evolutionWithPlugins: wrap with evolution schema
* [`87b4173d`](https://github.com/NixOS/nixpkgs/commit/87b4173defe9e658149c9e1e0053ea6f37676963) python310Packages.flask-babel: 3.0.0 -> 3.0.1
* [`20d02d7b`](https://github.com/NixOS/nixpkgs/commit/20d02d7bfb04789af2287f5890494249120cb5a1) python3Packages.aiodocker: init at unstable-2022-01-20
* [`3364a1c1`](https://github.com/NixOS/nixpkgs/commit/3364a1c1a1f7f394e2de48c424f3e95af71ee3f8) k3b: use cdrecord from cdrtools rather than cdrkit
* [`3dcde1c3`](https://github.com/NixOS/nixpkgs/commit/3dcde1c342e613853087bc35d66fd4a769cc3f06) zlib: Use `finalAttrs` instead of `rec`
* [`6e4a1b18`](https://github.com/NixOS/nixpkgs/commit/6e4a1b18d995605b95365387d3752e279a2c2ccc) meta.pkgConfigModules: Init convention
* [`7da24b9b`](https://github.com/NixOS/nixpkgs/commit/7da24b9bbd09979bd0c31a90b027422321643dd6) python310Packages.ome-zarr: init at 0.6.1
* [`36fb0ebe`](https://github.com/NixOS/nixpkgs/commit/36fb0ebeefbd5ccb1b29b0d5a10cc96c6239f3e9) python310Packages.deep-translator: 1.9.2 -> 1.9.3
* [`ced105b0`](https://github.com/NixOS/nixpkgs/commit/ced105b058ebba774f3ad2d1a151b79f1b92c624) python310Packages.formulae: init at 0.3.4
* [`6015dbe7`](https://github.com/NixOS/nixpkgs/commit/6015dbe73185fe7cebd7b365d1bcc2941a361733) python310Packages.bambi: init at 0.9.3
* [`b2c5d344`](https://github.com/NixOS/nixpkgs/commit/b2c5d3449b47d654aaf3b93d34f53651445d77fc) haskellPackages: propagate platform meta values where necessary
* [`66532182`](https://github.com/NixOS/nixpkgs/commit/66532182f511ac0e080791aa712f468d023cf3c9) kotlin: 1.8.0 -> 1.8.10
* [`31b324c0`](https://github.com/NixOS/nixpkgs/commit/31b324c027bb6aa4cd6943dcb2c9694f1e17e34c) filtron: use buildGoModule
* [`3d262210`](https://github.com/NixOS/nixpkgs/commit/3d2622108264a9d4f96b9bc2bf7013e6fbacc5b4) nixos/zram: use zram-generator
* [`989b9901`](https://github.com/NixOS/nixpkgs/commit/989b9901dc7d1d72f1591d05c3cef074798eb896) nixos/zram: add release note about the switch to zram-generator
* [`6bb4f0f1`](https://github.com/NixOS/nixpkgs/commit/6bb4f0f10318be2111625f3d880a969cde97d1ed) emacs: use mkDerivation with finalAttrs
* [`2281f414`](https://github.com/NixOS/nixpkgs/commit/2281f414eaf16bac1e7887abb72ae36b1393a908) airwindows-lv2: 14.0 -> 16.0
* [`3cb6f8db`](https://github.com/NixOS/nixpkgs/commit/3cb6f8db35b63ed356f29d2033052fc92ae575f8) hackrf: 2022.09.1 -> 2023.01.1
* [`63862f4a`](https://github.com/NixOS/nixpkgs/commit/63862f4a66c19edc38280c51386513f5cee30afc) haskell.packages.ghc94.X11-xft: automate workaround for cabal[nixos/nixpkgs⁠#8455](https://togithub.com/nixos/nixpkgs/issues/8455)
* [`962633e4`](https://github.com/NixOS/nixpkgs/commit/962633e4d16c3a268f1e48e509a156cc33ba99ef) haskell.packages.ghc94.gtk2hs-buildtools: gtk2hs setup hook broken for ghc-9.4.4
* [`ef3a8f19`](https://github.com/NixOS/nixpkgs/commit/ef3a8f19ac1ce48907ebee72da6550f6e3d6454a) haskell.packages.ghc94.{glib,cairo,pango}: apply cabal[nixos/nixpkgs⁠#8455](https://togithub.com/nixos/nixpkgs/issues/8455) fix
* [`83f8025e`](https://github.com/NixOS/nixpkgs/commit/83f8025e543f01616ffb49efb401c565e815b3bb) haskellPackages.hslua-list: unmark as broken
* [`7197d459`](https://github.com/NixOS/nixpkgs/commit/7197d45919af9bf6b87b1c87198aaf0fe87504fc) etebase-server: fix optional dependencies
* [`e1f1b500`](https://github.com/NixOS/nixpkgs/commit/e1f1b50085cc2cf8258c2dafadfcc6ba70f0ce77) intel-media-sdk: 22.6.5 -> 23.1.0
* [`d397b090`](https://github.com/NixOS/nixpkgs/commit/d397b090626b21a2f84aa594d6e550479bf1b09d) virt-viewer: disable ovirtSupport
* [`910f9431`](https://github.com/NixOS/nixpkgs/commit/910f943116daa99143ffec26785e2fa41fd68249) virt-viewer: cleanup
* [`81b57078`](https://github.com/NixOS/nixpkgs/commit/81b570789390c69f1216044aeb5badd82d767c0a) virt-viewer: use regular spice-gtk
* [`d8ed5557`](https://github.com/NixOS/nixpkgs/commit/d8ed555748b01c4d6ba3cf23b2db6232e77c7d2a) libgovirt: 0.3.8 -> 0.3.9
* [`bfd33259`](https://github.com/NixOS/nixpkgs/commit/bfd3325932e0baef86758bb4252ca67b427c2492) haskell.packages.ghc94.libmpd: needs a jailbreak to succeed
* [`f0a4d983`](https://github.com/NixOS/nixpkgs/commit/f0a4d9833312215b4721ce2be9ff7e17b9e54616) haskell.packages.ghc94.ormolu: use latest version for ghc-9.4.x
* [`20f68e74`](https://github.com/NixOS/nixpkgs/commit/20f68e74e8a24ebace34351ea693b7cb5fc4f4e9) haskell.packages.ghc94.haskell-language-server: update list of supported plugins
* [`67ebd811`](https://github.com/NixOS/nixpkgs/commit/67ebd8112558b7e15e0583a06860a6becceaf95b) iosevka: fix Darwin build
* [`6dd324df`](https://github.com/NixOS/nixpkgs/commit/6dd324df0dd0da79fd58a4ae6f9ec2605e5745df) iosevka: remove superfluous inputs
* [`25ae7df3`](https://github.com/NixOS/nixpkgs/commit/25ae7df30eec92db8cfddaae9bdda45c070308a9) samba: 4.17.4 -> 4.17.5
* [`7a28048a`](https://github.com/NixOS/nixpkgs/commit/7a28048a7f7e4e7b3d2bdb648ea6367fbe40b8e9) python310Packages.deep-translator: add changelog to meta
* [`a22898bc`](https://github.com/NixOS/nixpkgs/commit/a22898bc378b5594541d029c5d1de81196f70832) icingaweb2: 2.11.3 -> 2.11.4
* [`513a2d1e`](https://github.com/NixOS/nixpkgs/commit/513a2d1e9a03690ca4d40de97677f7c2e66acdb9) apr: 1.7.0 -> 1.7.2
* [`3b3b4874`](https://github.com/NixOS/nixpkgs/commit/3b3b4874360314a5c353da8a5af73afe924e7b94) ocamlPackages.rusage: init at 1.0.0
* [`b93d92a3`](https://github.com/NixOS/nixpkgs/commit/b93d92a3d4cf79b37ff38bbdb244d3bb12a1dc00) ocamlPackages.irmin: 3.4.1 → 3.5.1
* [`cbc76260`](https://github.com/NixOS/nixpkgs/commit/cbc76260f72171db241317e782607b37630faa8b) doc: add section on swift
* [`f87e3de0`](https://github.com/NixOS/nixpkgs/commit/f87e3de07d62c5811a6392141110f2139bd4b8b0) python310Packages.snowflake-connector-python: 2.9.0 -> 3.0.0
* [`0a3288e1`](https://github.com/NixOS/nixpkgs/commit/0a3288e167a63e828ab636a1e60cc930fee29a65) heroic: 2.5.2 -> 2.6.1
* [`90581c97`](https://github.com/NixOS/nixpkgs/commit/90581c977ff1dc2442a79fd9d173ae1e307f6e53) nixos/nebula: don't run as root; support relays
* [`d02d50f5`](https://github.com/NixOS/nixpkgs/commit/d02d50f5d00f0f2b279ab73084c5ac1061cb2ee1) nebula: add passthru test
* [`9d649fd7`](https://github.com/NixOS/nixpkgs/commit/9d649fd78c30944dfe12b80bb55f8b4a9de567ed) nixos/nebula: add tests for relays; clean up nebula passthru test
* [`e99f342f`](https://github.com/NixOS/nixpkgs/commit/e99f342f1166b33c0cbabc68037a7da3fa2f5478) nixos/nebula: harden systemd unit
* [`eeb37db7`](https://github.com/NixOS/nixpkgs/commit/eeb37db7cff2c864df9a1d61349433d92ab65254) nixos/nebula: rename test nodes to be more descriptive
* [`96e3c9c3`](https://github.com/NixOS/nixpkgs/commit/96e3c9c3923e2c8866a497896bf2be3433fe6202) nixos/nebula: fix potential address collision in tests
* [`9dabedf8`](https://github.com/NixOS/nixpkgs/commit/9dabedf841f71ca63d4bd96d47d9d186647a5d84) mattermost: 7.5.2 -> 7.7.1
* [`87d7ea2f`](https://github.com/NixOS/nixpkgs/commit/87d7ea2f6ae89461cc5e515338b8642cc1bf3d90) s2n-tls: 1.3.34 -> 1.3.35
* [`887c2c0f`](https://github.com/NixOS/nixpkgs/commit/887c2c0f6f361f69866ffcf64b8df9d82574b674) ansible-lint: 6.11.0 -> 6.12.1
* [`ccc0fbca`](https://github.com/NixOS/nixpkgs/commit/ccc0fbca35d9535c2064aa2745bbba4b153d1e35) step-ca: 0.23.1 -> 0.23.2
* [`8efe3726`](https://github.com/NixOS/nixpkgs/commit/8efe372663709996e5f92c8029faa54ce006464a) solc-select: 1.0.2 -> 1.0.3
* [`2aa3458b`](https://github.com/NixOS/nixpkgs/commit/2aa3458bf4d118ae83c9915f246d73d0d0552fb6) libmediainfo: 22.06 -> 22.12
* [`7e0126da`](https://github.com/NixOS/nixpkgs/commit/7e0126da2cb15258fa2ba0f6056948a30ead56dc) mc: add x11Support option
* [`0556ca0f`](https://github.com/NixOS/nixpkgs/commit/0556ca0f88a30006a3833c3c675db4677c978d5b) mc: update postPatch phase
* [`d08e2fa8`](https://github.com/NixOS/nixpkgs/commit/d08e2fa87c689e2dc6796264d505b7a910c787e9) yatas: init at 1.3.3
* [`fa59d8e4`](https://github.com/NixOS/nixpkgs/commit/fa59d8e45cbf5acce6dfcea7fa464633c072402b) cobra-cli: fix the build
* [`686eda48`](https://github.com/NixOS/nixpkgs/commit/686eda481722be84eabea3fc9c72cb9dea39e6a0) nixos/no-x-libs: add mc
* [`6378836b`](https://github.com/NixOS/nixpkgs/commit/6378836bc1dee6bbe657de8468aeee216f4cffb8) python310Packages.aiohttp-jinja2: 1.5 -> 1.5.1
* [`06a37916`](https://github.com/NixOS/nixpkgs/commit/06a3791603d04bd5ca76ff72b40a405e6db291e0) colima: make lima derivation configurable
* [`18c0c488`](https://github.com/NixOS/nixpkgs/commit/18c0c48857f550e3b85bc51390593f1c0a4aa2bd) haskellPackages.mkDerivation: buildPkgDb: use haskellCompilerName
* [`a9b8a272`](https://github.com/NixOS/nixpkgs/commit/a9b8a272ea8c9ce1a13dd49af679ebc2b31626bd) haskellPackages.mkDerivation: refactor libdir calculation
* [`f45f7cb3`](https://github.com/NixOS/nixpkgs/commit/f45f7cb3e0f70279f6752ddef2ad4011c8e29cdc) haskellPackages: support hadrian libdir layout
* [`53180381`](https://github.com/NixOS/nixpkgs/commit/5318038186d0a83371d66ecfcc5732b109d2f2c8) haskellPackages.ghcWithPackages: fix whitespace alignment
* [`902701c0`](https://github.com/NixOS/nixpkgs/commit/902701c0cfe4727dd21a457cbece7dfd7f859a48) haskell.compiler.ghc924Binary: tag bindists built using hadrian
* [`36005f52`](https://github.com/NixOS/nixpkgs/commit/36005f52b82650de38318ef295120ecdbdc54226) haskell.compiler.ghc8102Binary: tag bindists built using hadrian
* [`328d6f84`](https://github.com/NixOS/nixpkgs/commit/328d6f84992c24a62e59f42bd8ec32cd42f3225e) haskell.compiler.ghc8107Binary: tag bindists built using hadrian
* [`eedda7e8`](https://github.com/NixOS/nixpkgs/commit/eedda7e8d87639c6ba65d0c177bbc5266a5fc790) rust-analyzer-unwrapped: 2023-01-23 -> 2023-01-30
* [`224c0b6c`](https://github.com/NixOS/nixpkgs/commit/224c0b6c15b85f552ef31a6964899f189a2d1747) partclone: 0.3.22 -> 0.3.23
* [`0fd2901e`](https://github.com/NixOS/nixpkgs/commit/0fd2901e31614a80cb5ba309ab4d5f656d8f533b) varscan: 2.4.4 -> 2.4.5
* [`2d9ce2b1`](https://github.com/NixOS/nixpkgs/commit/2d9ce2b132c83c329b207ddc28f0611b7cbd6bd9) jackett: 0.20.2782 -> 0.20.2916
* [`199418b9`](https://github.com/NixOS/nixpkgs/commit/199418b9f80743a7d55fa8315758bd74b2a67e6e) python310Packages.fakeredis: 2.6.0 -> 2.7.1
* [`e4730619`](https://github.com/NixOS/nixpkgs/commit/e47306199f4d758c4c7e85da761537710ea17f08) python310Packages.rpi-gpio2: 0.3.0a3 -> 0.4.0
* [`aac2ad65`](https://github.com/NixOS/nixpkgs/commit/aac2ad65e39d7762104303cd0e4149c6d358a9a2) python310Packages.arcam-fmj: 1.1.0 -> 1.2.0
* [`65ef7b3f`](https://github.com/NixOS/nixpkgs/commit/65ef7b3f80ab432dfdd0abee727e2986a2f4a350) maintainers: add sharzy
* [`72bce6ef`](https://github.com/NixOS/nixpkgs/commit/72bce6efa49d09988f61fa804cb2fc418e569b3f) rpcs3: 0.0.26-14637-c471120a8 -> 0.0.26-14684-8652b7d35
* [`3aa43022`](https://github.com/NixOS/nixpkgs/commit/3aa43022230548e9c8d99d238ddbe1c04edf2d8f) librewolf: 109.0-1 -> 109.0.1-2
* [`b4e8cdcc`](https://github.com/NixOS/nixpkgs/commit/b4e8cdcc0de877b7524985b748a72d848c7b5b36) openttd: 12.2 -> 13.0
* [`a1abd931`](https://github.com/NixOS/nixpkgs/commit/a1abd931fe62d40bf65d9192e43128c248dd37ea) openttd-jgrpp: 0.47.1 -> 0.50.3
* [`faeefbe1`](https://github.com/NixOS/nixpkgs/commit/faeefbe1b9931eb8f36e8f0638ba9a30088861d0) flare-signal: init at 0.6.0
* [`40ced660`](https://github.com/NixOS/nixpkgs/commit/40ced660aa32dc4504803e2b352087fedd3f43b2) sharedown: 5.1.0 -> 5.2.2
* [`4adc2fdb`](https://github.com/NixOS/nixpkgs/commit/4adc2fdb95e859153078c389ecbc7dc34c3bd8ad) python310Packages.mitmproxy-wireguard: fix darwin build
* [`0ef15ea8`](https://github.com/NixOS/nixpkgs/commit/0ef15ea8721103ea3d078ade691ece1a5a888a28) python310Packages.hahomematic: 2023.2.1.1 -> 2023.2.5
* [`5dc979f6`](https://github.com/NixOS/nixpkgs/commit/5dc979f6f222c0040aeb5b56b585019e5aa8abf7) argocd-vault-plugin: init at 1.13.1
* [`4b11a358`](https://github.com/NixOS/nixpkgs/commit/4b11a358e3129a71616210f1b8d39ac1dcd4d166) python310Packages.bimmer-connected: 0.12.0 -> 0.12.1
* [`eecccb42`](https://github.com/NixOS/nixpkgs/commit/eecccb4262a6a6459bdb449f5b4bbc8878d5124c) awscli2: 2.9.19 -> 2.9.21
* [`5ecb98d7`](https://github.com/NixOS/nixpkgs/commit/5ecb98d73100e7b70937540355e58ab4417be133) python310Packages.greeclimate: 1.4.0 -> 1.4.1
* [`0cb9271b`](https://github.com/NixOS/nixpkgs/commit/0cb9271b71eaf27354dc5879c5d5601357d7fc25) zed: set version, clean up
* [`a28d99d9`](https://github.com/NixOS/nixpkgs/commit/a28d99d9bdb043ff9ff9c1c6857dad02dd2e4a57) zq: drop
* [`d1dc61f1`](https://github.com/NixOS/nixpkgs/commit/d1dc61f145d1826737e40907e3c02e05965e1987) kbibtex: 0.9.2 -> 0.9.3.1
* [`3aa003ad`](https://github.com/NixOS/nixpkgs/commit/3aa003ad21fec641a0ee1b4b55b40dfb90a03b11) plasma5Packages.plasmaMobileGear: 22.11 -> 23.01.0
* [`008469a6`](https://github.com/NixOS/nixpkgs/commit/008469a60095f493d12f529ac60098dde0532758) tokodon: 22.11.2 -> 23.01.0
* [`04cc8760`](https://github.com/NixOS/nixpkgs/commit/04cc8760beb617588c9bc5bb68797f01c7715206) freeswitch: unpin openssl_1_1
* [`7a0b564c`](https://github.com/NixOS/nixpkgs/commit/7a0b564c30bdbc8db0096c2b3bc033dd5f7e5fd1) clickable: 7.4.0 -> 7.11.0
* [`b35ef7fd`](https://github.com/NixOS/nixpkgs/commit/b35ef7fdb64f5edc921315003099a8b1a3d993d5) firmware-manager: unpin openssl_1_1
* [`3adf8bdf`](https://github.com/NixOS/nixpkgs/commit/3adf8bdfb27b537a360d394914b6e97c70cd87cc) deepin-draw: init at 5.11.4
* [`992a67b8`](https://github.com/NixOS/nixpkgs/commit/992a67b8397229f0132b213fd2b31a0b9ed91f99) python310Packages.google-cloud-speech: 2.17.1 -> 2.17.3
* [`6fc81eb7`](https://github.com/NixOS/nixpkgs/commit/6fc81eb754e4ac2b87b3524f1c04740cce6c55ab) gdu: 5.21.1 -> 5.22.0
* [`ac500cdd`](https://github.com/NixOS/nixpkgs/commit/ac500cdd0baca97e5e7ef9e239007d2fd63f8fdd) deepin-image-viewer: init at 5.9.4
* [`98d5b0c3`](https://github.com/NixOS/nixpkgs/commit/98d5b0c319df294115d92c4e70c7d3d3ae8de407) deepin-album: init at 5.10.9
* [`2cf940e6`](https://github.com/NixOS/nixpkgs/commit/2cf940e66cf6b5be9fabb28358506b47dcf590cc) deepin-picker: init at 5.0.28
* [`13351c3d`](https://github.com/NixOS/nixpkgs/commit/13351c3d9ec7fb5fd2db5d3caf8386e885ac99ba) python310Packages.aioconsole: 0.5.1 -> 0.6.0
* [`8d4ebc8e`](https://github.com/NixOS/nixpkgs/commit/8d4ebc8e5db726e5e431e6f84d5e1b684c8d25f8) python310Packages.aioconsole: fix tests on Darwin
* [`64f21e16`](https://github.com/NixOS/nixpkgs/commit/64f21e162080aac06a69e7fe4c123329927ac2fe) circt: init at 1.29.0
* [`1356bf09`](https://github.com/NixOS/nixpkgs/commit/1356bf091f81c31e102196217f3016b0eb373c77) python310Packages.piccata: 2.0.0 -> 2.0.2
* [`5bf5db8e`](https://github.com/NixOS/nixpkgs/commit/5bf5db8ef8cd4faff6cc808f4502e1282156274b) python310Packages.duecredit: 0.9.1 -> 0.9.2
* [`2bbc46b2`](https://github.com/NixOS/nixpkgs/commit/2bbc46b29169af6529f7d27f264d68023a582dfd) python310Packages.apycula: 0.6.2 -> 0.7
* [`c114f447`](https://github.com/NixOS/nixpkgs/commit/c114f447eca95fb29ca3c5404d55efcb319ca3d1) python310Packages.pyodbc: add unixODBC to nativeBuildInputs
* [`8030c645`](https://github.com/NixOS/nixpkgs/commit/8030c64577a7973d07537e2bb446c14ccedaa14c) Revert Merge [nixos/nixpkgs⁠#214786](https://togithub.com/nixos/nixpkgs/issues/214786): libvmaf: fix build for BSD
* [`9b0d7211`](https://github.com/NixOS/nixpkgs/commit/9b0d72118de0dbf0eac418aa9f1ff9c13960dd02) python310Packages.whois: 0.9.26 -> 0.9.27
* [`c2300ed0`](https://github.com/NixOS/nixpkgs/commit/c2300ed0cba8fa7c3d77f6ab01914bea27316454) bibtex-tidy: init at 1.8.5
* [`3ae9f673`](https://github.com/NixOS/nixpkgs/commit/3ae9f6738caaefadf0df15a102ab108a579d83b0) forgejo: add `passthru.updateScript`
* [`e72e3101`](https://github.com/NixOS/nixpkgs/commit/e72e3101421567821b0ad300efa31658e8a41907) forgejo: 1.18.2-1 -> 1.18.3-0
* [`29464cd1`](https://github.com/NixOS/nixpkgs/commit/29464cd170b7c15057a0fdad09c347354af27005) racket: wrap with LOCALE_ARCHIVE iff Linux
* [`4c0adb98`](https://github.com/NixOS/nixpkgs/commit/4c0adb982862d1b6c398ebf2d36d488044e6e001) numix-icon-theme-square: 23.01.29 -> 23.02.05
* [`c7fcab25`](https://github.com/NixOS/nixpkgs/commit/c7fcab255a8ad16431f5d9ffe294e5604cb4fac8) python310Packages.google-cloud-container: 2.17.1 -> 2.17.2
* [`d1939fbe`](https://github.com/NixOS/nixpkgs/commit/d1939fbea120c4e81fd4b499abbd0ed775ffda83) ocamlPackages.rosetta: use Dune 3
* [`faf43fdb`](https://github.com/NixOS/nixpkgs/commit/faf43fdbb30981789729e1932b05f3f55949b696) ocamlPackages.uuuu: fix tests
* [`a3c897fe`](https://github.com/NixOS/nixpkgs/commit/a3c897fe344b2070d9b28e1bff68cdc179561f55) python310Packages.elementpath: 3.0.2 -> 4.0.1
* [`d37ecf35`](https://github.com/NixOS/nixpkgs/commit/d37ecf352381855098bbc295cff4895b96012b8e) oh-my-zsh: 2023-02-02 -> 2023-02-05
* [`8b031cac`](https://github.com/NixOS/nixpkgs/commit/8b031cac44ae8fb02b6017863aeefe727806ad41) podman: 4.3.1 -> 4.4.0
* [`3a0046c1`](https://github.com/NixOS/nixpkgs/commit/3a0046c12be4754d6c23376cca618f123051dd50) python311Packages.deepdiff: 6.2.1 -> 6.2.3
* [`acb76745`](https://github.com/NixOS/nixpkgs/commit/acb76745469d0352b7463f29c37aadb180320e45) babashka: 1.1.172 -> 1.1.173
* [`86704e93`](https://github.com/NixOS/nixpkgs/commit/86704e93187a0eeafe111fa28c9930674bdd3d66) invidious: unstable-2023-01-26 -> unstable-2023-02-02
* [`f7742de2`](https://github.com/NixOS/nixpkgs/commit/f7742de26975ba7d3ddb2780bbca53aede5159eb) python310Packages.screenlogicpy: 0.6.4 -> 0.7.0
* [`8f7fb664`](https://github.com/NixOS/nixpkgs/commit/8f7fb664f984ea18eaec869f75fd5c3ada6f4c0d) rime-cli: init at 0.0.3
* [`c3394e26`](https://github.com/NixOS/nixpkgs/commit/c3394e2617984e77d66152cc454fe43e71622129) python3Packages.humanize: 4.5.0 -> 4.6.0
* [`e29c75be`](https://github.com/NixOS/nixpkgs/commit/e29c75becc59a7065be68ab8c6d53cb19c353546) toot: 0.33.1 -> 0.34.0
* [`6d6a34b4`](https://github.com/NixOS/nixpkgs/commit/6d6a34b428a0dddea47b7d964928eb4a27764221) python310Packages.peaqevcore: 11.0.4 -> 11.1.2
* [`e6c9bc50`](https://github.com/NixOS/nixpkgs/commit/e6c9bc50172c4bf94531b1886f9fcf43aba3c803) yj: 5.0.0 -> 5.1.0
* [`c9222e23`](https://github.com/NixOS/nixpkgs/commit/c9222e23a9187e9345718c2fff5b4ea907f022e0) vieb: add update script
* [`9ccff9c1`](https://github.com/NixOS/nixpkgs/commit/9ccff9c18fc0833b3b67104cd883378ff78bc506) vieb: 9.5.0 -> 9.5.1
* [`1710a35f`](https://github.com/NixOS/nixpkgs/commit/1710a35f780713101e0020f65a5a7e28abe9df84) musikcube: 0.99.4 -> 0.99.5
* [`7d7b4262`](https://github.com/NixOS/nixpkgs/commit/7d7b4262cf44d3613f0633f9b5a15eb6dcca9a1e) linux: 4.14.304 -> 4.14.305
* [`7ac11283`](https://github.com/NixOS/nixpkgs/commit/7ac11283d523023e9d154c7b82b5dc793e4213f4) linux: 4.19.271 -> 4.19.272
* [`27b622c9`](https://github.com/NixOS/nixpkgs/commit/27b622c925ff83db7a68a19b4f618af101193273) linux: 5.10.166 -> 5.10.167
* [`7b1db085`](https://github.com/NixOS/nixpkgs/commit/7b1db0858c281a4fdea963178a5c52c50040deac) linux: 5.15.91 -> 5.15.92
* [`4b68d39f`](https://github.com/NixOS/nixpkgs/commit/4b68d39f3d3d290b9653070e08ba586564a845a9) linux: 5.4.230 -> 5.4.231
* [`db732d0b`](https://github.com/NixOS/nixpkgs/commit/db732d0bbede358fdf46c0133d089507abf6c32b) linux: 6.1.9 -> 6.1.10
* [`56bbb131`](https://github.com/NixOS/nixpkgs/commit/56bbb13161d6799df50898574d312d3a72bde9e8) linux_latest-libre: 19027 -> 19044
* [`6f5b6b79`](https://github.com/NixOS/nixpkgs/commit/6f5b6b7916e169cbaf0ea5b1aacf4a213215eccf) linux/hardened/patches/5.10: 5.10.165-hardened1 -> 5.10.166-hardened1
* [`34a45dce`](https://github.com/NixOS/nixpkgs/commit/34a45dcebf19bb133c3fadb6332042961e185ce9) linux/hardened/patches/5.15: 5.15.90-hardened1 -> 5.15.91-hardened1
* [`4f706834`](https://github.com/NixOS/nixpkgs/commit/4f706834c9f207eeeb6bbcbeafb1fd7b57f9c16f) sharing: init at 1.2.2
* [`b0e773ad`](https://github.com/NixOS/nixpkgs/commit/b0e773addea36d76de4ec077d303eff409067731) nixos/sharing: init
* [`4e7f20ad`](https://github.com/NixOS/nixpkgs/commit/4e7f20ade9b036e43df103192312ce5b4740d69c) nixos/prometheus-pihole-exporter: update configuration options
* [`75408b9e`](https://github.com/NixOS/nixpkgs/commit/75408b9e33df54823214783207f1707b835e7511) python310Packages.pydmd: 0.4.0.post2301 -> 0.4.0.post2302
* [`fac73552`](https://github.com/NixOS/nixpkgs/commit/fac7355203dec925887f79b61e0d1971b0880b17) wesnoth: 1.16.7 -> 1.16.8
* [`d404c169`](https://github.com/NixOS/nixpkgs/commit/d404c169c348a543fb923069f2347c0165d71ea5) obs-studio-plugins.obs-vaapi: 0.1.0 -> 0.2.0
* [`9d661624`](https://github.com/NixOS/nixpkgs/commit/9d661624b4b45fc31b0109a2b4f43e5c206b8edd) erdtree: init at 1.0.0
* [`e71c6dae`](https://github.com/NixOS/nixpkgs/commit/e71c6dae8aaf6e58819537535fad87fda0476616) yubihsm-shell: 2.3.2 -> 2.4.0
* [`bdf2e8b0`](https://github.com/NixOS/nixpkgs/commit/bdf2e8b01230b8fbb8cce9f5ff4cdf492641d43a) python310Packages.plugwise: 0.27.5 -> 0.27.6
* [`07e52946`](https://github.com/NixOS/nixpkgs/commit/07e5294689beade0a02578445179a4ab187acf4c) watchmate: 0.3.0 -> 0.4.0
* [`48a5e582`](https://github.com/NixOS/nixpkgs/commit/48a5e582759730fefa12e8bcd503ade57f57f7af) perlPackages.CryptOpenSSLRSA: unpin openssl_1_1
* [`b1bb9bb6`](https://github.com/NixOS/nixpkgs/commit/b1bb9bb6c8a378dec6317c20281fd04b060016f2) treewide: fix backwards smart apostrophes
* [`7e82811d`](https://github.com/NixOS/nixpkgs/commit/7e82811db2fb1dc3b59adf9f4816b9e341732f30) ecwolf: 1.4.0 -> 1.4.1
* [`e8956651`](https://github.com/NixOS/nixpkgs/commit/e8956651342858700cd42da3879e92ab7db107ef) wiki-js: 2.5.295 -> 2.5.296
* [`8e374f7c`](https://github.com/NixOS/nixpkgs/commit/8e374f7c687d78f25ed03d908f38334fbf41bf39) frescobaldi: 3.1.3 -> 3.2
* [`fe6c577c`](https://github.com/NixOS/nixpkgs/commit/fe6c577c412cc91765f0cb2fbb6e155bf5be290f) swaylock: 1.7 -> 1.7.2
* [`a8e609a3`](https://github.com/NixOS/nixpkgs/commit/a8e609a399c475b893187c6cb105520463116272) auto-multiple-choice: change default module dir (fix [nixos/nixpkgs⁠#214724](https://togithub.com/nixos/nixpkgs/issues/214724))
* [`d1c3c776`](https://github.com/NixOS/nixpkgs/commit/d1c3c776b6b54804fdc1f1e940cb057df00cb7f2) rmsd: init at 1.5.1
* [`80dbfee3`](https://github.com/NixOS/nixpkgs/commit/80dbfee3149309a3d517686e294c621d7feded63) python310Packages.bellows: 0.34.7 -> 0.34.8
* [`daa795fe`](https://github.com/NixOS/nixpkgs/commit/daa795fef97147df88c4954b5c5b8cfd29b53d2d) klipper: unstable-2023-01-07 -> unstable-2023-02-03
* [`8fd3e5e3`](https://github.com/NixOS/nixpkgs/commit/8fd3e5e331741955901e29f98fdf50015e1f6ae7) ecwolf: add darwin support
* [`fd3dc830`](https://github.com/NixOS/nixpkgs/commit/fd3dc830465c709929592e7e76c210de0a6ebc47) ham: 2020-09-09 -> 2022-10-26
* [`d5018c2c`](https://github.com/NixOS/nixpkgs/commit/d5018c2ce262d000e8553f3282ff922730da9cf4) python310Packages.getmac: 0.9.1 -> 0.9.2
* [`eef6eda0`](https://github.com/NixOS/nixpkgs/commit/eef6eda0f8c40ce4ce7bbbbf489248a5a0a6b9d8) amarok: clean-up unused arguments
* [`f1b553de`](https://github.com/NixOS/nixpkgs/commit/f1b553de8e22610c61838c6206df68d783ef81f5) wxmacmolplt: init at 7.7.2
* [`2051d472`](https://github.com/NixOS/nixpkgs/commit/2051d47229cd9329297eb1f6a689b23cf9d4a80a) mopac: init at 22.0.6
* [`06e02272`](https://github.com/NixOS/nixpkgs/commit/06e02272040ebeaa11ccea7efae94764cd33513f) linuxKernel.kernels.linux_zen: 6.1.9-zen1 -> 6.1.10-zen1
* [`789fe86e`](https://github.com/NixOS/nixpkgs/commit/789fe86ea7b45939106ebf7b5c042783ec10698f) linuxKernel.kernels.linux_lqx: 6.1.9-lqx1 -> 6.1.10-lqx1
* [`d4dafcbb`](https://github.com/NixOS/nixpkgs/commit/d4dafcbb896746d473e87da32d3937992b531aaa) geckodriver: 0.32.0 -> 0.32.1
* [`8116f965`](https://github.com/NixOS/nixpkgs/commit/8116f9653cc82c62aa5ca98fe2b232c40cf6ca58) privacyidea: 3.7.4 -> 3.8
* [`f6c8d04d`](https://github.com/NixOS/nixpkgs/commit/f6c8d04d11fe58b52844a626c87575e0c2e09c34) nixos/privacyidea: fix db uri
* [`ffd4bf73`](https://github.com/NixOS/nixpkgs/commit/ffd4bf730f81d0d56e8549a3fb0790148963416b) privacyidea: fix hash
* [`35840330`](https://github.com/NixOS/nixpkgs/commit/35840330133dd0746ab2f4c6abb97bceace30e83) pdns-recursor: 4.8.1 -> 4.8.2
* [`610af777`](https://github.com/NixOS/nixpkgs/commit/610af7778b04ebfe3c8ed715cc2b77af30c17304) bambootracker: 0.6.0 -> 0.6.1
* [`f1db792d`](https://github.com/NixOS/nixpkgs/commit/f1db792d8a5866a929329fb93cec66b82ff6d6fd) bambootracker-qt6: init at 0.6.1
* [`f4c1ef09`](https://github.com/NixOS/nixpkgs/commit/f4c1ef09d8bb2754acab930528853125832def9b) freshrss: fix `passthru.tests`
* [`d6128620`](https://github.com/NixOS/nixpkgs/commit/d61286201d37c7b2d44be7745d6dae241ccc95b9) python310Packages.cmsis-pack-manager: 0.5.1 -> 0.4.0
* [`de3d46fa`](https://github.com/NixOS/nixpkgs/commit/de3d46fa52cf0d8776ab1533f6492ea290936ed5) stress-ng: 0.15.01 -> 0.15.03
* [`73599b38`](https://github.com/NixOS/nixpkgs/commit/73599b389c1f19de6474a0dffaa61824de27fadf) coq: remove undefined attribute `ocamlPropagatedNativeBuildInputs` in `passthru`
* [`cd10a33b`](https://github.com/NixOS/nixpkgs/commit/cd10a33b63dcb543953d86a4a3a2104379cfc8ac) qt6.qtbase: fix regression
* [`9d4fdb96`](https://github.com/NixOS/nixpkgs/commit/9d4fdb9685729c49a047535a8a2c8001a66d5a91) nixos/roundcube: fixed nginx configuration
* [`c6007f7c`](https://github.com/NixOS/nixpkgs/commit/c6007f7c61510c6c30eaa49be9f3331b3e280543) maintainers: add vamega
* [`dedb550c`](https://github.com/NixOS/nixpkgs/commit/dedb550ce642e09341fcead3e8960c4f948752c6) bencode-py: init at 4.0.0
* [`4611ffe6`](https://github.com/NixOS/nixpkgs/commit/4611ffe60faa985b90414be6b4e54d9084035f87) proxysql: 2.4.5 -> 2.4.6
* [`f87cac22`](https://github.com/NixOS/nixpkgs/commit/f87cac221fc7bff1af0b563073ae59f7764215c8) proxysql: fix build
* [`2e6581f9`](https://github.com/NixOS/nixpkgs/commit/2e6581f905562b4bd709703bbaed76aae7a045c0) proxysql: 2.4.6 -> 2.5.0
* [`64c4077f`](https://github.com/NixOS/nixpkgs/commit/64c4077f92dc27b8796739af6b802572e2cc0c7f) timescaledb: 2.9.2 -> 2.9.3
* [`179f987d`](https://github.com/NixOS/nixpkgs/commit/179f987de7e2c44bb07b87dc8b5373b134bfa277) xchm: 1.33 -> 1.35
* [`fe6ab315`](https://github.com/NixOS/nixpkgs/commit/fe6ab31520740494da524df4464649d6dfd48381) tbls: 1.60.0 -> 1.61.0
* [`6ee7b97e`](https://github.com/NixOS/nixpkgs/commit/6ee7b97efea6905a5f414c14be0cb5baeff49ecf) dua: 2.19.0 -> 2.19.1
* [`9e436141`](https://github.com/NixOS/nixpkgs/commit/9e4361412af7ab83ba40a13886dcc698c641669b) pdfsam-basic: 4.3.4 -> 5.0.2
* [`7c193be7`](https://github.com/NixOS/nixpkgs/commit/7c193be7f389474514be260fe7b2f8077cc22df5) simple-mtpfs: init at 0.4.0
* [`aa5b7e45`](https://github.com/NixOS/nixpkgs/commit/aa5b7e4571619199510e0d86c1a02562bf6e493b) openvscode-server: 1.74.3 -> 1.75.0
* [`349748a7`](https://github.com/NixOS/nixpkgs/commit/349748a7e19f0792fd8baf5c5d930ca03d445bc9) portfolio: 0.60.2 -> 0.61.0
* [`8a1ff26d`](https://github.com/NixOS/nixpkgs/commit/8a1ff26db46df02c7606dd854c0878575acf5da9) breath-theme: init at unstable-2022-12-22
* [`e2402814`](https://github.com/NixOS/nixpkgs/commit/e24028141f278590407dd5389330f23d01c89cff) qdmr: fixup
* [`918c22bd`](https://github.com/NixOS/nixpkgs/commit/918c22bd5f2a754542a115c2d1178adf830abd12) privacyidea: fix build
* [`e7e447a1`](https://github.com/NixOS/nixpkgs/commit/e7e447a185483de1126d1dc92253db6eb8d420ce) meilisearch: 0.30.5 -> 1.0.0
* [`7c4abbf8`](https://github.com/NixOS/nixpkgs/commit/7c4abbf80e1471d7844aae825f6d1015ce315a48) lib.lists: add `replicate`
* [`66444200`](https://github.com/NixOS/nixpkgs/commit/66444200f4946c6ca30f2fb138358f668ec71521) metricbeat7: fix `passthru.tests`
* [`7ae6bfb6`](https://github.com/NixOS/nixpkgs/commit/7ae6bfb6a12fce586392e85e7b6778e8b576a911) python310Packages.pymemcache: disable broken test on 32-bit platforms
* [`cd3c4f00`](https://github.com/NixOS/nixpkgs/commit/cd3c4f00f7f6d7cf29dc4de2733b52f5c6e86d34) terraform-providers.gandi: 2.2.2 -> 2.2.3 ([nixos/nixpkgs⁠#214956](https://togithub.com/nixos/nixpkgs/issues/214956))
* [`eceae845`](https://github.com/NixOS/nixpkgs/commit/eceae845cdd56e064195475fa21abf6592ebd95a) darwin.openwith: init at unstable-2022-10-28
* [`3feeedb5`](https://github.com/NixOS/nixpkgs/commit/3feeedb5e2dd1a21bbbf72bdbca58c86b229f882) buildGoModule: make the vendor fetcher error if it is empty
* [`3ed6f9d6`](https://github.com/NixOS/nixpkgs/commit/3ed6f9d67932847523909460b96241a153c4b3f7) vimPlugins.vim-hexokinase: remove empty go vendor hash
* [`6879bec5`](https://github.com/NixOS/nixpkgs/commit/6879bec5175b517daedbfba503fe1c74a53b0425) evmdis: remove empty go vendor hash
* [`c4fff891`](https://github.com/NixOS/nixpkgs/commit/c4fff89150ced57dfcf87671eece38a82ba55ba8) statik: remove empty go vendor hash
* [`a83fd920`](https://github.com/NixOS/nixpkgs/commit/a83fd920d8088921512ba1f44dbdcebab957c1b8) phylactery: remove empty go vendor hash
* [`047202f1`](https://github.com/NixOS/nixpkgs/commit/047202f1e13dd42da28ab56349179d8dfeace3c7) lnch: remove empty go vendor hash
* [`e1e68ae0`](https://github.com/NixOS/nixpkgs/commit/e1e68ae08b5e8c0373f8dc6d4590435d1a630c29) conmon: 2.1.5 -> 2.1.6
* [`38e3d218`](https://github.com/NixOS/nixpkgs/commit/38e3d2182426f57256f68b6409705c1b5eb04b8b) stacks: 2.60 -> 2.62
* [`251d9a37`](https://github.com/NixOS/nixpkgs/commit/251d9a370748a11f281952c6ca12b88c04a4e0b7) buildah: 1.28.2 -> 1.29.0
* [`acf0a7d9`](https://github.com/NixOS/nixpkgs/commit/acf0a7d9fdd2bf63328b795e49db750ac52dc442) nix-init: 0.1.0 -> 0.1.1
* [`7767f842`](https://github.com/NixOS/nixpkgs/commit/7767f842c4cba5a9c556f14d3777ac2d6e1bf61b) ssldump: 1.5 -> 1.6 ([nixos/nixpkgs⁠#214992](https://togithub.com/nixos/nixpkgs/issues/214992))
* [`307918ba`](https://github.com/NixOS/nixpkgs/commit/307918ba5e1f9792794a4fabff45a29a5bfa816f) python310Packages.bitarray: 2.6.1 -> 2.7.0
* [`fd6c5273`](https://github.com/NixOS/nixpkgs/commit/fd6c52733b95ee8aff5cc6f18e1c8df17a5ea809) mycli: skip broken test
* [`6fe61041`](https://github.com/NixOS/nixpkgs/commit/6fe61041dc03d0347325e95fb9214b43b0a9fc77) pv-migrate: init at 1.0.1 ([nixos/nixpkgs⁠#210373](https://togithub.com/nixos/nixpkgs/issues/210373))
* [`80e2e282`](https://github.com/NixOS/nixpkgs/commit/80e2e282c0e4b60f5d4645e34feffd810dcd8065) maintainers: add sno2wman
* [`a2cc6437`](https://github.com/NixOS/nixpkgs/commit/a2cc64378f15cccf46ea95a5f304e1301e0d2335) sftpgo: 2.4.3 -> 2.4.4
* [`f329e5f5`](https://github.com/NixOS/nixpkgs/commit/f329e5f50682ce27e66490567881bb1e146b04ed) wasmtime: 4.0.0 -> 5.0.0
* [`4bd50031`](https://github.com/NixOS/nixpkgs/commit/4bd500317e0ff99d8dc0bbdcf18c87dcb4ad3916) iosevka-bin: 17.1.0 -> 18.0.0
* [`f8a7e5cf`](https://github.com/NixOS/nixpkgs/commit/f8a7e5cf2b8a21d19b079a100c94771b72b7bdee) yamlfmt: init at 0.7.1
* [`6a1c0b75`](https://github.com/NixOS/nixpkgs/commit/6a1c0b75e650c7b6c874e8848aaf93788d8dbcf4) kernelshark: 2.1.1 -> 2.2.0
* [`e3bec64e`](https://github.com/NixOS/nixpkgs/commit/e3bec64e7fef8a8389967700be2bdbbefa1cd355) phpExtensions.opcache: fix test environment for darwin
* [`89595c2d`](https://github.com/NixOS/nixpkgs/commit/89595c2d6327116f6168ddbacdf9c779447148ee) the-foundation: 1.5.0 -> 1.6.0
* [`91c5117c`](https://github.com/NixOS/nixpkgs/commit/91c5117c1b5d220ca6e5cebb3ab513fe647f6b43) prowlarr: 1.1.2.2453 -> 1.1.3.2521
* [`2da6994e`](https://github.com/NixOS/nixpkgs/commit/2da6994e17d885d953b2009f4c7ac56244cb813e) mapcache: 1.12.1 -> 1.14.0
* [`06eb99ff`](https://github.com/NixOS/nixpkgs/commit/06eb99ffa2a9933651b5116f888dec20a74b7b12) chromiumBeta: Fix the build
* [`bd351b76`](https://github.com/NixOS/nixpkgs/commit/bd351b76488279a36c77e0429ba45cd92ce25604) ruff: 0.0.241 -> 0.0.242
* [`c4269e49`](https://github.com/NixOS/nixpkgs/commit/c4269e49a680b375e6bf613f6d3b646502afb719) iptsd: correctly install udev rule and systemd service file
* [`96b055cb`](https://github.com/NixOS/nixpkgs/commit/96b055cbe734e2b99bb40adc42cbb3aefb444a6d) iptsd: 1.0.0 -> 1.0.1
* [`5cb68d16`](https://github.com/NixOS/nixpkgs/commit/5cb68d1645cd93bc51b91e4ca1ee1c1739a5a892) shotman: 0.3.0 -> 0.4.0
* [`6cdec6d1`](https://github.com/NixOS/nixpkgs/commit/6cdec6d1b8e5160cbb11eeb3821e6edaf38212f8) nixos/nginx: add comment about clearing Connection header ([nixos/nixpkgs⁠#214211](https://togithub.com/nixos/nixpkgs/issues/214211))
* [`3f5c9df6`](https://github.com/NixOS/nixpkgs/commit/3f5c9df6511c5e9ed4a6e5242be74bce12b18533) rPackages: added libiconv to darwin builds and removed redundant package level calls
* [`2a7130d1`](https://github.com/NixOS/nixpkgs/commit/2a7130d13a032093f5394ef0961842d1e1928789) nvidia: Reverse Prime Sync
* [`8ebfc5a4`](https://github.com/NixOS/nixpkgs/commit/8ebfc5a4a41901d0f426c821c028467cd3208467) sealcurses: 2022-05-18 → 2023-02-06
* [`3b25f6d7`](https://github.com/NixOS/nixpkgs/commit/3b25f6d75d2d00988e82beaf95abd82bd4b9b8e9) chromiumBeta: 110.0.5481.52 -> 110.0.5481.77
* [`003e6784`](https://github.com/NixOS/nixpkgs/commit/003e6784a113f6a8eae6f15a21f2ff1ecdcd7a7e) chromiumDev: 111.0.5562.0 -> 111.0.5563.8
* [`ddc5eecd`](https://github.com/NixOS/nixpkgs/commit/ddc5eecd7ae52cf1d911d02e75148448ecc6ff08) lagrange: 1.14.2 → 1.15.2
* [`87208cc7`](https://github.com/NixOS/nixpkgs/commit/87208cc7daf6542a9be4701a97db7a42d02ec951) mapcache: fix build on darwin
* [`ef5da70d`](https://github.com/NixOS/nixpkgs/commit/ef5da70d669321d482523ba64d331e7b09d6933b) services.openssh: rename several settings ([nixos/nixpkgs⁠#211991](https://togithub.com/nixos/nixpkgs/issues/211991))
* [`fdf6e37d`](https://github.com/NixOS/nixpkgs/commit/fdf6e37dc0cfbd4d1437ace3af0bddf5e609aa0b) advi: init at 2.0.0 ([nixos/nixpkgs⁠#214814](https://togithub.com/nixos/nixpkgs/issues/214814))
* [`413115bb`](https://github.com/NixOS/nixpkgs/commit/413115bb0da85ec4efcff17452e3b3b936654be1) rnote: 0.5.12 -> 0.5.13
* [`1adcc3be`](https://github.com/NixOS/nixpkgs/commit/1adcc3be90422309ccb0351eeda846017f8eb7af) tdesktop: 4.6.0 -> 4.6.1
* [`3299517e`](https://github.com/NixOS/nixpkgs/commit/3299517e6b24e3767496797ad63d41049c4ceff4) pipenv: 2022.11.25 -> 2023.2.4
* [`8e47596d`](https://github.com/NixOS/nixpkgs/commit/8e47596d38462320f889007d158470070b263d52) perlPackages.NetIPXS: init at 0.22
* [`aba3b5d8`](https://github.com/NixOS/nixpkgs/commit/aba3b5d8cd1772b3eba9f664a9087339567128ef) perlPackages.ZonemasterLDNS: 2.2.2 -> 3.1.0
* [`c216e896`](https://github.com/NixOS/nixpkgs/commit/c216e89616c9aac11f117004d26c390fa3ddbf86) perlPackages.ZonemasterEngine: 4.5.1 -> 4.6.1
* [`00f5c6f3`](https://github.com/NixOS/nixpkgs/commit/00f5c6f33218f99a1fcc9bb4aab375253700d551) perlPackages.ZonemasterCLI: 4.0.1 -> 5.0.1
* [`b6dcd6bd`](https://github.com/NixOS/nixpkgs/commit/b6dcd6bdc95111ec81820ae16a4de2bf4c66b01b) python310Packages.python-gvm: 22.9.1 -> 23.2.0
* [`063997be`](https://github.com/NixOS/nixpkgs/commit/063997be5064c5bca4994c9204c079ef0eae4ba5) imagemagick: 7.1.0-60 -> 7.1.0-61
* [`41e734a7`](https://github.com/NixOS/nixpkgs/commit/41e734a755cf8e1cbe2f9d33e26113dd32ee8ac0) python310Packages.meilisearch: 0.23.0 -> 0.24.0
* [`50e0012f`](https://github.com/NixOS/nixpkgs/commit/50e0012f9d576aed3765b0c540167513fa8c2fda) treewide: cleanup some unused bindings
* [`6ea7ec8a`](https://github.com/NixOS/nixpkgs/commit/6ea7ec8ac14b02f1b59a37aa0c13a7e3200e3ebb) dnscontrol: 3.25.0 -> 3.26.0
* [`67e898c1`](https://github.com/NixOS/nixpkgs/commit/67e898c12e0d70b19cd699cf87ef4890c0295bec) nng: 1.5.2 -> 1.6.0-prerelease and rPackages.nanonext dependency
* [`4e6f4f63`](https://github.com/NixOS/nixpkgs/commit/4e6f4f630a4995076283e8487efeb75e0a2aa7b9) drawio: 20.8.10 -> 20.8.16
* [`2d44668c`](https://github.com/NixOS/nixpkgs/commit/2d44668ce6af760c592d03cb18e7c3a30534c71a) phrase-cli: 2.6.5 -> 2.6.6
* [`e9cf3f79`](https://github.com/NixOS/nixpkgs/commit/e9cf3f794af3e89010fc23a9978c2f119d96baea) haskellPackages.hslua-core: skip tests for Musl
* [`341770d3`](https://github.com/NixOS/nixpkgs/commit/341770d3f1b7d78b6bff71e306567171187b48a8) nixos/zram: fix default swapDevices
* [`59e79c10`](https://github.com/NixOS/nixpkgs/commit/59e79c106d2aa9c83b3796a74dd47509c8ec9147) clifm: 1.9 -> 1.10
* [`0e2512a9`](https://github.com/NixOS/nixpkgs/commit/0e2512a9ff65bea06233945e1ee3250494845faa) mediaelch-qt6: 2.8.18 -> 2.10.0
* [`557a9c14`](https://github.com/NixOS/nixpkgs/commit/557a9c1492d3e7e1dbda5f6cb330dc5492cfd4ae) vassal: 3.6.10 -> 3.6.11
* [`91f3a79a`](https://github.com/NixOS/nixpkgs/commit/91f3a79a017ef6eeeec72e7f1ed7cc7d54477379) aravis: 0.8.22 -> 0.8.24
* [`a90c233d`](https://github.com/NixOS/nixpkgs/commit/a90c233d6ed372d468520fe252b8d317b89cd72b) evcc: 0.112.2 -> 0.112.5
* [`0b426cd8`](https://github.com/NixOS/nixpkgs/commit/0b426cd8e235f1e3ab1261ed5c064f766fca24db) nixos/pykms: rename systemd deprecated `MemoryLimit` to `MemoryMax`.
* [`c37fedf9`](https://github.com/NixOS/nixpkgs/commit/c37fedf985c2f9aa9a1e8c827c5f4314d421d550) verilator: 5.002 -> 5.006
* [`4946fa90`](https://github.com/NixOS/nixpkgs/commit/4946fa902d173a31b6d7196625903cdf5891897b) pandoc-katex: 0.1.10 -> 0.1.11
* [`01fecfaa`](https://github.com/NixOS/nixpkgs/commit/01fecfaa9b190681c7a20e3a3e315669b6226b46) python310Packages.xmlschema: 2.1.1 -> 2.2.0
* [`0e48bebe`](https://github.com/NixOS/nixpkgs/commit/0e48bebe62300c1ceea8d60cc6f494b9e0105033) touchegg: 2.0.15 -> 2.0.16
* [`0ada458c`](https://github.com/NixOS/nixpkgs/commit/0ada458c6827b528c9efcfb270cbc9282a46e873) ruff: 0.0.242 -> 0.0.243
* [`99d36b86`](https://github.com/NixOS/nixpkgs/commit/99d36b860d93df93c9938b4f95f5ef4863313464) steampipe: 0.18.3 -> 0.18.4
* [`b8e06daa`](https://github.com/NixOS/nixpkgs/commit/b8e06daabf43b13deecc257148b28dfa6dc6a7b6) python310Packages.volvooncall: 0.10.1 -> 0.10.2
* [`fb37015c`](https://github.com/NixOS/nixpkgs/commit/fb37015c452e75237b6879986bfd3e81ca96db6e) nixpacks: 1.1.1 -> 1.3.1
* [`3c3343ec`](https://github.com/NixOS/nixpkgs/commit/3c3343ec9db334099e2c8dfaa4c9052cbea22957) gnome-builder: 43.5 → 43.6
* [`025b08b5`](https://github.com/NixOS/nixpkgs/commit/025b08b580446ed27e4f5fe8e9fa914bddf02d49) protobuf3_21: don't build tests on 32-bit platforms
* [`31f57de7`](https://github.com/NixOS/nixpkgs/commit/31f57de7dd85b7575a01e20b0be2ae7b7fbd70df) devbox: 0.3.2 -> 0.3.3
* [`3c7e81d4`](https://github.com/NixOS/nixpkgs/commit/3c7e81d4254aa84f634fffd9052f9338c2aaa48b) nearcore: 1.30.0 -> 1.30.1
* [`61eaaa6b`](https://github.com/NixOS/nixpkgs/commit/61eaaa6b556fa2f19333221b05e79156dfddf565) moolicute: 1.00.1 -> 1.01.0
* [`b61b079b`](https://github.com/NixOS/nixpkgs/commit/b61b079b880a4bf4da6c4ef56f68cfb086c1e558) maintainers: add hughobrien
* [`3ac97f85`](https://github.com/NixOS/nixpkgs/commit/3ac97f85ff8b9a5351d67efbb80203b4e54a1276) moolticute: add hughobrien as maintainer
* [`527539fd`](https://github.com/NixOS/nixpkgs/commit/527539fd2d6a9bef8922b35069912391fd84a103) python310Packages.desktop-notifier: 3.4.2 -> 3.4.3
* [`dfc0ceec`](https://github.com/NixOS/nixpkgs/commit/dfc0ceece39e8d294c0661c24cbc49ca65d77c4d) sumneko-lua-language-server: 3.6.7 -> 3.6.10
* [`291887ff`](https://github.com/NixOS/nixpkgs/commit/291887ff6e0ac84488afa27641c894620dc50718) lua-language-server: rename from sumneko-lua-language-server
* [`8aee03fe`](https://github.com/NixOS/nixpkgs/commit/8aee03feff838c4b4264794bdab2c08622a2c1b8) deepin-image-viewer: fix build with libraw 0.21.1
* [`2e82629b`](https://github.com/NixOS/nixpkgs/commit/2e82629b56a10d9c07ae765b1f3dd615af6f8a0a) python310Packages.lupupy: 0.2.5 -> 0.2.7
* [`bf9771c9`](https://github.com/NixOS/nixpkgs/commit/bf9771c95fcf8241b9f2a6d00ccb3afe6ddd078c) python310Packages.pikepdf: 6.2.9 -> 7.0.0
* [`ab367c31`](https://github.com/NixOS/nixpkgs/commit/ab367c312c7c29fdac944a0d3ed8c796517f5b8e) eget: 1.3.1 -> 1.3.2
* [`e2b092fc`](https://github.com/NixOS/nixpkgs/commit/e2b092fc52c7d28a15241ae78bf10b7b66b4f405) Revert "rustPlatform.bindgenHook: use the same clang/libclang as rustc"
* [`1cedc22d`](https://github.com/NixOS/nixpkgs/commit/1cedc22d83c26028f5983d3e97f8010b6d00f1ca) shortwave: 3.1.0 -> 3.2.0
* [`70d75c24`](https://github.com/NixOS/nixpkgs/commit/70d75c24e41b82ee8ff9cd0d9e64115f67c7ff78) deepin-turbo: init at 0.0.6.3
* [`7082124d`](https://github.com/NixOS/nixpkgs/commit/7082124d63dd09b47a9623f9554d3c0e63900a54) setools: 4.4.0 -> 4.4.1
* [`3d034c27`](https://github.com/NixOS/nixpkgs/commit/3d034c279d5b28ba7025b7a397980341a219b4e2) terraform-providers.dns: 3.2.3 → 3.2.4
* [`d93725aa`](https://github.com/NixOS/nixpkgs/commit/d93725aad67cb1d02a6bca633a62a5b0a4c9505c) terraform-providers.google: 4.51.0 → 4.52.0
* [`20794e7c`](https://github.com/NixOS/nixpkgs/commit/20794e7c3827821f0ffa07ebd1532b9d2c746f92) terraform-providers.google-beta: 4.51.0 → 4.52.0
* [`458c1628`](https://github.com/NixOS/nixpkgs/commit/458c1628ee0a33af9439584f2cb4021366b63c33) fix logic
* [`fad8de6e`](https://github.com/NixOS/nixpkgs/commit/fad8de6ea191c4ce723d825bb7db6119cf8135ab) _1password-gui: 8.9.10 -> 8.9.14, 8.9.12-4.BETA -> 8.10.0-20.BETA
* [`68081ec1`](https://github.com/NixOS/nixpkgs/commit/68081ec1711eb3aee80d0d515a24fabfacd7944a) zulip: 5.9.4 → 5.9.5
* [`5462eb42`](https://github.com/NixOS/nixpkgs/commit/5462eb42ac3163d574cf6f50b52f0728b6fbce4d) python3Packages.soundfile: 0.10.3.post1 -> 0.11.0
* [`a6c1d83f`](https://github.com/NixOS/nixpkgs/commit/a6c1d83fd463f5d798cab557f473e655fd4567fb) lazygit: 0.36 -> 0.37.0
* [`8c60553e`](https://github.com/NixOS/nixpkgs/commit/8c60553edf36af246a57099bad4f4211a3550519) ocamlPackages.sqlite3: disable for OCaml < 4.12 & use Dune 3
* [`fc3ed53a`](https://github.com/NixOS/nixpkgs/commit/fc3ed53a2700d9af4a990e0336edccdb0347afcd) circt: fix darwin build
* [`f4ff5a59`](https://github.com/NixOS/nixpkgs/commit/f4ff5a5943f2178a868d9bcb7d661e9e194a92ef) lollypop: 1.4.35 -> 1.4.37
* [`5381c53a`](https://github.com/NixOS/nixpkgs/commit/5381c53ab12bd6adcef94b9829422b52e3d8de9e) anki-bin: 2.1.56 -> 2.1.57
* [`3d76922d`](https://github.com/NixOS/nixpkgs/commit/3d76922d2a2cd3644d9d0585d5fde4c54a2c0722) cudatext: 1.176.0 -> 1.183.0
* [`f2929eb9`](https://github.com/NixOS/nixpkgs/commit/f2929eb949dadce3c195fc67f742c0f56710976c) nixos/test-driver: drop logging from Machine.send_monitor_command
* [`067d688b`](https://github.com/NixOS/nixpkgs/commit/067d688b1687b731007ddfe58a399f466492efe4) nixos/test-driver: handle decoding errors in Machine.execute
* [`fe34d10e`](https://github.com/NixOS/nixpkgs/commit/fe34d10e57b76696738b3a4a4352480d4e0ffd2f) nixos/tests/gnupg: init
* [`e375feff`](https://github.com/NixOS/nixpkgs/commit/e375feffbefce4961fc6b97aef83e60f9ed0e705) gnupg: add NixOS tests to passthru
* [`e9920533`](https://github.com/NixOS/nixpkgs/commit/e992053340d076ae6099f0fdb386dc7fa44d5ee2) deno: 1.30.2 -> 1.30.3
* [`ccbedf58`](https://github.com/NixOS/nixpkgs/commit/ccbedf5829bbb54bd32a2edac3096e70a1d6c108) n8n: 0.214.0 -> 0.214.2
* [`d61f3ee3`](https://github.com/NixOS/nixpkgs/commit/d61f3ee353931a686a1d6a242d66d6fa4a515ace) python310Packages.django_treebeard: 4.6.0 -> 4.6.1
* [`f1d41d28`](https://github.com/NixOS/nixpkgs/commit/f1d41d287484f96a8e6f9c5a6eb88c7fa93b4ce3) pbpctrl: init at unstable-2023-02-07
* [`82a0b7d7`](https://github.com/NixOS/nixpkgs/commit/82a0b7d7df926b2b4411494dbfb0a92410213714) python311Packages.python-zbar: fix build since Py_SIZE is turned into a function
* [`e299ba0a`](https://github.com/NixOS/nixpkgs/commit/e299ba0a4292b36f09c9a24d0bf7078560b0355a) ipinfo: 2.10.0 -> 2.10.1
* [`c11c50b7`](https://github.com/NixOS/nixpkgs/commit/c11c50b70d33b4584acc2ab21edacf876f6edff8) spotify-player: 0.10.0 -> 0.11.1
* [`187b686f`](https://github.com/NixOS/nixpkgs/commit/187b686fb96e19e161500cf0abcd4dfc4fd5a293) sabnzbd: 3.7.1 -> 3.7.2
* [`acb81220`](https://github.com/NixOS/nixpkgs/commit/acb812207f184cfd3fe79a1730b6fbe92e2077b7) lib/licenses: add ecl20
* [`9b291471`](https://github.com/NixOS/nixpkgs/commit/9b291471540484134b54d6f23fd326dbba2ad8f2) wtwitch: 2.6.0 -> 2.6.1
* [`0079d432`](https://github.com/NixOS/nixpkgs/commit/0079d432758640d360f95048dc6658acbd742a57) nwchem: init at 7.0.2
* [`d65b2be4`](https://github.com/NixOS/nixpkgs/commit/d65b2be4e6e8d339b9331696cf70c67009864873) heroic: 2.6.1 -> 2.6.2
* [`98a61125`](https://github.com/NixOS/nixpkgs/commit/98a611259f2206d8c42a414d89494f6ae4aa0642) nix-eval-jobs: 2.12.1 -> 2.13.0
* [`fab09085`](https://github.com/NixOS/nixpkgs/commit/fab09085df1b60d6a0870c8a89ce26d5a4a708c2) doc/nixos: prefer the verb 'log in' ([nixos/nixpkgs⁠#214616](https://togithub.com/nixos/nixpkgs/issues/214616))
* [`64e33d69`](https://github.com/NixOS/nixpkgs/commit/64e33d695e9555b7eb43afa0f0355dfe927e385a) python310Packages.bluetooth-sensor-state-data: 1.6.0 -> 1.6.1
* [`0fdd8416`](https://github.com/NixOS/nixpkgs/commit/0fdd8416ebefe83efcf957c9f125a0711c715c70) python310Packages.bluemaestro-ble: 0.2.1 -> 0.2.3
* [`c7ae55ea`](https://github.com/NixOS/nixpkgs/commit/c7ae55ea146a724abadb2b62f3aad784c0b54063) python310Packages.pydeps: 1.11.0 -> 1.11.1
* [`7d6f5302`](https://github.com/NixOS/nixpkgs/commit/7d6f5302531275d7f20711da2875fe7da294895d) terrascan: 1.17.1 -> 1.18.0
* [`6cbed32d`](https://github.com/NixOS/nixpkgs/commit/6cbed32ddf358d978f9e5adc79a963b651eb0484) python310Packages.types-colorama: 0.4.15.5 -> 0.4.15.7
* [`96b73bcd`](https://github.com/NixOS/nixpkgs/commit/96b73bcdc5cc020ff3a9d926bda6739a054b129c) python310Packages.types-requests: 2.28.11.8 -> 2.28.11.11
* [`9c17022f`](https://github.com/NixOS/nixpkgs/commit/9c17022fde212e81abc4d822dbee27a0d157b30e) python310Packages.types-urllib3: 1.26.25.4 -> 1.26.25.5
* [`7ed23572`](https://github.com/NixOS/nixpkgs/commit/7ed2357267811eb50882b8853e94275ea0c4d89e) python310Packages.types-docutils: 0.19.1.2 -> 0.19.1.3
* [`21c2b0df`](https://github.com/NixOS/nixpkgs/commit/21c2b0df2e6e43358901444f523dcd3a34666127) httm: 0.20.4 -> 0.20.5
* [`58c9772b`](https://github.com/NixOS/nixpkgs/commit/58c9772bb79885caf42309d430363e09a9dcd9aa) jackett: 0.20.2916 -> 0.20.2986
* [`e92f95ae`](https://github.com/NixOS/nixpkgs/commit/e92f95ae36286451f4d306c6bc5b9001a029d09f) glooctl: 1.13.4 -> 1.13.5
* [`b9ca51f3`](https://github.com/NixOS/nixpkgs/commit/b9ca51f3c1e2b276586e15340d8f83bf8c379d7d) lxgw-neoxihei: 1.005 -> 1.006
* [`4f77f9a0`](https://github.com/NixOS/nixpkgs/commit/4f77f9a0f4e4c9c5c9d19cf9621b618ab4f39884) qgis-ltr: 3.22.15 -> 3.22.16
* [`f98c4eac`](https://github.com/NixOS/nixpkgs/commit/f98c4eac33a53652203b4196761aa29f92d7572b) doc/stdenv: fixup [nixos/nixpkgs⁠#212642](https://togithub.com/nixos/nixpkgs/issues/212642)
* [`ff167d81`](https://github.com/NixOS/nixpkgs/commit/ff167d8172c3cca60cb3be5a65ef85a93598f3ea) netdata-go.d.plugin: from 0.32.3 to 0.50.0
* [`f79ffab8`](https://github.com/NixOS/nixpkgs/commit/f79ffab8e43f867a36831dfc21da9df91800300b) unciv: 4.4.9 -> 4.4.11
* [`40ab60b3`](https://github.com/NixOS/nixpkgs/commit/40ab60b3179d9c688c87427ae011d0987f2399df) perlPackages.AppSqitch: 1.1.0 -> 1.3.1
* [`24e6cc41`](https://github.com/NixOS/nixpkgs/commit/24e6cc417e3067dd7e9a8b7d72d5614fbd6fd23d) perlPackages.TemplateToolkit: 3.009 → 3.101
* [`5952d4bc`](https://github.com/NixOS/nixpkgs/commit/5952d4bc10d394cdce31a581e67a52ee6533d66d) perlPackages.AppSqitch: add Template-Toolkit support
* [`6e7eaa31`](https://github.com/NixOS/nixpkgs/commit/6e7eaa312978e581a392c0d2c8eb4ba9fe759820) python310Packages.oralb-ble: 0.17.2 -> 0.17.4
* [`cb51e4ee`](https://github.com/NixOS/nixpkgs/commit/cb51e4eea43d96db06a2fffa3786dc73cea05a2f) python310Packages.thermopro-ble: 0.4.3 -> 0.4.5
* [`e6b61828`](https://github.com/NixOS/nixpkgs/commit/e6b61828e7a3cb032d2ad175e12f0e9285c4e340) python310Packages.xiaomi-ble: 0.15.0 -> 0.16.1
* [`23fff24e`](https://github.com/NixOS/nixpkgs/commit/23fff24ee773c1a338b4de53338f4a7a4e4e6cc5) python310Packages.tilt-ble: 0.2.3 -> 0.2.4
* [`db4c45d5`](https://github.com/NixOS/nixpkgs/commit/db4c45d50e402007579e06112b167bd1499c56d6) python310Packages.sensorpush-ble: 1.5.2 -> 1.5.5
* [`d10fb5c6`](https://github.com/NixOS/nixpkgs/commit/d10fb5c60415ec9cea28cfc1dbed26226d9cb4b7) python310Packages.sensorpro-ble: 0.5.1 -> 0.5.3
* [`6b92d2f4`](https://github.com/NixOS/nixpkgs/commit/6b92d2f403d522d2ff91036495a27839f1a93ba4) python311Packages.dvc-data: 0.36.2 -> 0.38.1
* [`73c0fd81`](https://github.com/NixOS/nixpkgs/commit/73c0fd813b6449a8ab73483c4c7f06fa4c3f07cd) python311Packages.sqltrie: 0.0.27 -> 0.0.28
* [`099a60d0`](https://github.com/NixOS/nixpkgs/commit/099a60d04e4fb75297c8013257cd2bd813445a60) python311Packages.dvc-objects: 0.19.0 -> 0.19.3
* [`a58df10a`](https://github.com/NixOS/nixpkgs/commit/a58df10aa82311588fa570e3727cc487d9731083) python310Packages.sensorpush-ble: add changelog to meta
* [`f903066b`](https://github.com/NixOS/nixpkgs/commit/f903066b4ea7dedde544f6674a8135f96a777558) python310Packages.tilt-ble: add changelog to meta
* [`5a5decd2`](https://github.com/NixOS/nixpkgs/commit/5a5decd2eb9a32276e7f5e0f8f0aff5bb69c6d36) doc: use `gitignoreSource`
* [`641b5ae1`](https://github.com/NixOS/nixpkgs/commit/641b5ae1f77bac3c94774f56716720a88cc7cd73) dnscrypt-proxy2: 2.1.3 -> 2.1.4
* [`f87b5083`](https://github.com/NixOS/nixpkgs/commit/f87b50832aefeae63709504c1efc2672bea23ef6) BeatSaberModManager: bump deps
* [`821a5fa3`](https://github.com/NixOS/nixpkgs/commit/821a5fa357f751e25e0fa75b8b90688fec067224) privacyidea: 3.8 -> 3.8.1
* [`7ce6fb77`](https://github.com/NixOS/nixpkgs/commit/7ce6fb77e88b6c8371f431faa40d91f7a60eff65) zimfw: 1.11.0 -> 1.11.1
* [`ecdd2b23`](https://github.com/NixOS/nixpkgs/commit/ecdd2b2310b345154a810f6c4e34fd5aebc7ef0c) codeowners: 1.1.1 -> 1.1.2
* [`7a3daed2`](https://github.com/NixOS/nixpkgs/commit/7a3daed2bd5670a24d21afb070305edf9231af50) vtm: 0.9.8q -> 0.9.8r
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
