### PR TITLE
niv devenv: update d97ea8c7 -> 3f845b2a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d97ea8c7d91678683b321d93694ca805ac7978e0",
-        "sha256": "1yc3g24l77z4q6gqfh69296mbzhhq7b2c8w0s50hn35qpk6mx6vl",
+        "rev": "3f845b2aff58d0ae27d9777500fe0c80b837ffb2",
+        "sha256": "01j15lfvrgjmsbv75cdsgam520r7xrr2dxq2gbwxnp7qqzmny13v",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/d97ea8c7d91678683b321d93694ca805ac7978e0.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/3f845b2aff58d0ae27d9777500fe0c80b837ffb2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@d97ea8c7...3f845b2a](https://github.com/cachix/devenv/compare/d97ea8c7d91678683b321d93694ca805ac7978e0...3f845b2aff58d0ae27d9777500fe0c80b837ffb2)

* [`291cc4ed`](https://github.com/cachix/devenv/commit/291cc4ed68f045b4dcd3328d898a6f1e78241b7f) properly escape color codes to avoid long command lines wraping back on themselves
* [`b913671d`](https://github.com/cachix/devenv/commit/b913671d6b586a07bfec49cd2afd113332ad9315) update lock file
* [`1fe7cc77`](https://github.com/cachix/devenv/commit/1fe7cc7797d7f5997405c954023812778f11ed48) Set LOCALE_ARCHIVE if missing on non-NixOS hosts
* [`8d70fdfe`](https://github.com/cachix/devenv/commit/8d70fdfe8c1312d08adbaf2bb3e2db480f181923) feat(php): make php easier with services
* [`5b1cf022`](https://github.com/cachix/devenv/commit/5b1cf0225eb87ba81e87cb38d0f660a47cf39388) cli: use column from util-linux package
* [`2d47c9da`](https://github.com/cachix/devenv/commit/2d47c9da8e7d052a08842a82ad0c9ccbd1e520b3) fix basic example, fixes [cachix/devenv⁠#363](https://togithub.com/cachix/devenv/issues/363) ([cachix/devenv⁠#372](https://togithub.com/cachix/devenv/issues/372))
* [`0db0b87f`](https://github.com/cachix/devenv/commit/0db0b87f6cd9a705c862ce315e377e39731fbd53) Clean up workflow YAML formatting
* [`8cb5a808`](https://github.com/cachix/devenv/commit/8cb5a80833c843756e9b3a9c9c4c08285855fdff) Remove fixed todo comment
* [`07870330`](https://github.com/cachix/devenv/commit/0787033062e5eb4f5cdc572043cd306f6ca95ed8) Move example path overrides to CI
* [`dba7a96b`](https://github.com/cachix/devenv/commit/dba7a96b68a7e3cd2f4221019a3b99a2d83be46a) php: cleanup with the new options
* [`d95bce2c`](https://github.com/cachix/devenv/commit/d95bce2cf7b7c0281a293b53fce442972c3a9bd9) fix [cachix/devenv⁠#365](https://togithub.com/cachix/devenv/issues/365): exit early if devenv.nix is missing
* [`346d4956`](https://github.com/cachix/devenv/commit/346d49568b72b1889024d5f9569d777d83adb93f) Auto generate docs/reference/options.md
* [`a9bfd3ab`](https://github.com/cachix/devenv/commit/a9bfd3ab64864ead6381b8fa8a01d6ea8cf6c7e9) add TeX Live support
* [`206bca9c`](https://github.com/cachix/devenv/commit/206bca9cc1185314c9cc6060d44352dc31edbb9b) Auto generate docs/reference/options.md
* [`95a725bc`](https://github.com/cachix/devenv/commit/95a725bc11ace242fa1cb056b56200784cd0dd80) Auto generate examples/supported-languages/devenv.nix
* [`f0fb4726`](https://github.com/cachix/devenv/commit/f0fb47267b2859239e749d88d4cb8a6f4fd2f9ae) Expand the flake guide
* [`b4563487`](https://github.com/cachix/devenv/commit/b456348750ebdc2ff90a73c9243e1e7da6034561) docs: typos
* [`f91d0393`](https://github.com/cachix/devenv/commit/f91d03936f19e064b53e17994d3138bfbd46467f) Auto generate docs/reference/options.md
* [`bd5a7eff`](https://github.com/cachix/devenv/commit/bd5a7effc23c3242e19d11a505d1fb6fe169fa43) Allow the user to use a different version of OCaml
* [`702766ab`](https://github.com/cachix/devenv/commit/702766ab2eaaa5d6c383a22a294695366bc9bbb9) Auto generate docs/reference/options.md
* [`8ab746e2`](https://github.com/cachix/devenv/commit/8ab746e2812161830860157bdf98b809f0561776) raku.nix: fixed description to not break web documentation
* [`eac5eb12`](https://github.com/cachix/devenv/commit/eac5eb12eb42765f5f252972dc876d1f96b03dfe) Auto generate docs/reference/options.md
* [`cab5028b`](https://github.com/cachix/devenv/commit/cab5028b5414e8efd3d0218ccbecf0acc4bf97f0) info: make sections pluggable
* [`3b96a1d3`](https://github.com/cachix/devenv/commit/3b96a1d321a957ea04f5654cb8d85a9fbf0d10fd) getting-stated: accept flake config
* [`852f3a59`](https://github.com/cachix/devenv/commit/852f3a59ef9f384c24704e1c4f94d4b819104c2a) Auto generate docs/reference/options.md
* [`cf4d6a4c`](https://github.com/cachix/devenv/commit/cf4d6a4ccd212084d511cceed5ffd69063e74869) common-patterns: how to specify rosetta packages
* [`6acc06c3`](https://github.com/cachix/devenv/commit/6acc06c3315b4bb3a7357c2a327e784e71c98307) Delete unused file
* [`a65d8c31`](https://github.com/cachix/devenv/commit/a65d8c316ede30a050328b054fb7a076bfbff3b3) feat(go): allow configure go package
* [`16040125`](https://github.com/cachix/devenv/commit/16040125d0bd9e01ecf3fc129bd80afa4f4443fb) feat(go): add explict GOROOT to fix multiple go versions, fixes [cachix/devenv⁠#346](https://togithub.com/cachix/devenv/issues/346)
* [`16a90693`](https://github.com/cachix/devenv/commit/16a9069307f3f949fef6c95e62be89031c5e4982) feat(go): isolate go path from global go path, fixes [cachix/devenv⁠#389](https://togithub.com/cachix/devenv/issues/389)
* [`de77e238`](https://github.com/cachix/devenv/commit/de77e23877032d5ca1fdbf45ca3032a2e511492e) feat(go): install all required go packages for vscode-go
* [`5122d72c`](https://github.com/cachix/devenv/commit/5122d72cdc501d367b8619e45bb1cd39767c43a3) feat(go): add gopath to normal path
* [`3688aa05`](https://github.com/cachix/devenv/commit/3688aa055eb56f9bea3b9e796e14abb6a07f7cf9) remove version output of crystal
* [`f623bbc4`](https://github.com/cachix/devenv/commit/f623bbc43665fef680bdb9efd1abf26d57a8a00e) Auto generate docs/reference/options.md
* [`89f7ab12`](https://github.com/cachix/devenv/commit/89f7ab12a5056571d6f07e4f3e8d7436764505cf) overmind: specify root
* [`203e2e04`](https://github.com/cachix/devenv/commit/203e2e040ceb7e2874f0b1e540a2734a4952522f) fix poetry
* [`88a26d7c`](https://github.com/cachix/devenv/commit/88a26d7c98a80eddd930d9a297891b8c919ae903) ruby: add support for version and versionFile using nixpkgs-ruby
* [`f327f44a`](https://github.com/cachix/devenv/commit/f327f44a1c1374cc897e935a79ec34056fb4dfcd) examples/ruby: show usage of version and versionFile options
* [`f391d5d7`](https://github.com/cachix/devenv/commit/f391d5d73c4b42225e317a9e92a3a34ff7d260a4) Auto generate docs/reference/options.md
* [`fa30ee44`](https://github.com/cachix/devenv/commit/fa30ee4403c90611c822c81173c2aea9db23fa25) remove example lockfiles
* [`9d1e3dd3`](https://github.com/cachix/devenv/commit/9d1e3dd3edee220c311a10afe39b67fc559753c7) fix direnv test
* [`d85331d3`](https://github.com/cachix/devenv/commit/d85331d32964c876ea6d3371d3e43799226f2eb0) run examples on self-hosted runner
* [`961b2150`](https://github.com/cachix/devenv/commit/961b21507264950f481e263e135f78cfd4ebbbdb) fix process-compose
* [`e9091ffa`](https://github.com/cachix/devenv/commit/e9091ffadf286ea0488751f7e154019c71b9b626) Fix caddy
* [`2e57c2de`](https://github.com/cachix/devenv/commit/2e57c2de4069a299bf27eaff5b56cec6f7051328) more github self-hosted runners
* [`0c0fd6db`](https://github.com/cachix/devenv/commit/0c0fd6dbc5b27cba1704f74d9e7cc04284688da5) ignore devenv.lock for examples
* [`f10ff2f5`](https://github.com/cachix/devenv/commit/f10ff2f523b4b72da70b4538f4fa2803baafb03f) ci: --accept-config
* [`6625e90f`](https://github.com/cachix/devenv/commit/6625e90f6871e88527fb34f789062fed8bbe2af3) fix simple-remote example
* [`3f845b2a`](https://github.com/cachix/devenv/commit/3f845b2aff58d0ae27d9777500fe0c80b837ffb2) devenv init: hint the full option reference at the bottom
