### PR TITLE
niv zsh-completions: update 828fe2bd -> 86d55972

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "828fe2bd3c67123263fc8a8cadebae92e10a2224",
-        "sha256": "1imjkjp6i0xs7gkvagfaikvizqlmd9j1jnqk54ihg9i11mnr60cw",
+        "rev": "86d55972f5cb65d545389fe0306e617b68328982",
+        "sha256": "1whg0v2n37qab4rmh58pmzhi066ryd9y8s8pm703k01hbx2kj5w0",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/828fe2bd3c67123263fc8a8cadebae92e10a2224.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/86d55972f5cb65d545389fe0306e617b68328982.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@828fe2bd...86d55972](https://github.com/zsh-users/zsh-completions/compare/828fe2bd3c67123263fc8a8cadebae92e10a2224...86d55972f5cb65d545389fe0306e617b68328982)

* [`a2c3a972`](https://github.com/zsh-users/zsh-completions/commit/a2c3a97252bbcee158822152a62b4b80b695cf1d) tmuxp: fix xdg dir checked
