### PR TITLE
niv nixpkgs: update 3f113f8c -> 1f8ac70d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f113f8c53cddb2d95790b7ed8b20b61a195de6c",
-        "sha256": "0fggj2pz2a2md8gr1i0882cgz8lky6frmd7aka607k1i7jjbm91j",
+        "rev": "1f8ac70db85189f2e58bc93259ab06b703d393ea",
+        "sha256": "055khd7ypqp69h4959yys49mpxzw92j5k53zrf53hyq1k25xryn0",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/3f113f8c53cddb2d95790b7ed8b20b61a195de6c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/1f8ac70db85189f2e58bc93259ab06b703d393ea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@3f113f8c...1f8ac70d](https://github.com/nixos/nixpkgs/compare/3f113f8c53cddb2d95790b7ed8b20b61a195de6c...1f8ac70db85189f2e58bc93259ab06b703d393ea)

* [`12755ecd`](https://github.com/NixOS/nixpkgs/commit/12755ecdd522b502048c5b915cae1241778feabf) nixos/docker: load more required kernel modules
* [`26dbf446`](https://github.com/NixOS/nixpkgs/commit/26dbf446cf3bd2da334d7384512a9b97839545cb) Change clickhouse's module conf directory to permit overrides
* [`3278ce10`](https://github.com/NixOS/nixpkgs/commit/3278ce100b61226f475fb222efcd11cbda81bf1c) sslscan: enable TLS compression check
* [`8976fa4e`](https://github.com/NixOS/nixpkgs/commit/8976fa4e8a3256ddae3108fd7aa07efdbc8c4791) alsa-lib: 1.2.7.2 -> 1.2.8
* [`e81b87f2`](https://github.com/NixOS/nixpkgs/commit/e81b87f29390ddcc9bd3020d3eea96972246b25d) alsa-ucm-conf: 1.2.7.1 -> 1.2.8
* [`c5ec1baa`](https://github.com/NixOS/nixpkgs/commit/c5ec1baa8f23c91640c1e2c40170e66ef5597ee2) nasin-nanpa: init at 2.5.1
* [`75fae935`](https://github.com/NixOS/nixpkgs/commit/75fae935dc081f86bd0fff64d2b54fc7138117bb) protonup-qt: init at 2.7.4
* [`4add2dd5`](https://github.com/NixOS/nixpkgs/commit/4add2dd5c64f1c65284b3aa1c57f9508a6d85f0e) hunspell-dict-tok: init at 20220829
* [`fc2812a1`](https://github.com/NixOS/nixpkgs/commit/fc2812a1f8a2b74ce0ab9a36912e9298b2027bfe) nest: init at 3.3
* [`cbed6a64`](https://github.com/NixOS/nixpkgs/commit/cbed6a640f9d1aeb7621a8048e6245cafaca2568) ikiwiki: fix broken test for gitSupport
* [`0675daec`](https://github.com/NixOS/nixpkgs/commit/0675daec05c627b78aeca610f345738a11a77f07) ikiwiki: add ikiwiki-full
* [`18d6f135`](https://github.com/NixOS/nixpkgs/commit/18d6f13520878b2b7f2fdc9b57b21b2ad925c38a) python3Packages.brian2: init at 2.5.1
* [`7b664c15`](https://github.com/NixOS/nixpkgs/commit/7b664c15c1f750f41e13ff93e8f0319b88ab79bf) moonraker: unstable-2022-04-23 -> unstable-2022-11-18
* [`ce86df4a`](https://github.com/NixOS/nixpkgs/commit/ce86df4a2164c568e73f866eca0174f4ac121d0e) nixos/moonraker: Add zhaofengli as maintainer
* [`76583721`](https://github.com/NixOS/nixpkgs/commit/76583721855538f906f451d5711fa65729975299) nixos/moonraker: Pass -d (data-path) to moonraker
* [`7856ac79`](https://github.com/NixOS/nixpkgs/commit/7856ac79ac9edc10078986aba25e2271076f3645) nixos/moonraker: Deprecate configDir
* [`9411ea92`](https://github.com/NixOS/nixpkgs/commit/9411ea9214a23fda8ad17fbe2386dbdec4545457) nixos/moonraker: Remove database_path
* [`38508169`](https://github.com/NixOS/nixpkgs/commit/385081693ecd71bed8d4352cd45457819abbcad9) nixos/moonraker: Don't allow Moonraker to validate its systemd service
* [`52ea7387`](https://github.com/NixOS/nixpkgs/commit/52ea73876b4e705657f549a081d2ff073ebbe94c) quisk: 4.1.73 -> 4.2.12
* [`c5923af9`](https://github.com/NixOS/nixpkgs/commit/c5923af98669282886140478c6d83ddcdcf77a42) lib/systems/architectures: expand inferiors
* [`03b2a82c`](https://github.com/NixOS/nixpkgs/commit/03b2a82ca9014f0d047c7167c4fa5e402ad06b8c) runInLinuxVM: fix on musl
* [`272bb3df`](https://github.com/NixOS/nixpkgs/commit/272bb3dfa6bfdc07d0e2ca813bc6963a65206044) pkg-config: prepend added flags
* [`030b1aae`](https://github.com/NixOS/nixpkgs/commit/030b1aae17a7c520ae648fa9e8c3621889d04014) scorecard: 4.8.0 -> 4.10.2
* [`4fe0d5ed`](https://github.com/NixOS/nixpkgs/commit/4fe0d5ed5d29a5f0d717dec973a64682c2edae1e) libgpg-error: 1.45 -> 1.46
* [`2d44dc96`](https://github.com/NixOS/nixpkgs/commit/2d44dc9643c28346ea5b22561869d04a62a80be0) libassuan: Use automatically detected libgpg-error
* [`d3b076da`](https://github.com/NixOS/nixpkgs/commit/d3b076da3890aa212889226519d7d19760e64690) gnupg: 2.3.7 -> 2.4.0
* [`05e6f8e3`](https://github.com/NixOS/nixpkgs/commit/05e6f8e36f0afaa8c5f0f66eeba4b61afa324058) systemd: use gnupg.override instead of callPackage
* [`e6b4e45a`](https://github.com/NixOS/nixpkgs/commit/e6b4e45a2f5da22ccca528c6a53f61da106884cf) libfaketime: 0.9.9 -> 0.9.10
* [`82c61839`](https://github.com/NixOS/nixpkgs/commit/82c61839aadda88a657fbf9aac67514ae4b67b0e) ethtool: 6.0 -> 6.1
* [`5bf53688`](https://github.com/NixOS/nixpkgs/commit/5bf53688d62ab6e8d080f6c395077b01a0804425) webex: 42.10.0.24000 → 42.12.0.24485
* [`1151fafb`](https://github.com/NixOS/nixpkgs/commit/1151fafbd861ce923fe17b81b8d1412261ed7a06) libpsl: 0.21.1 -> 0.21.2
* [`3c22923e`](https://github.com/NixOS/nixpkgs/commit/3c22923e0ae36754438c71be8db5f44402f773fb) ioquake3: install binaries into $out/bin
* [`f1e48efe`](https://github.com/NixOS/nixpkgs/commit/f1e48efea82b01575345adfc61a60b9a8423db89) ioquake3: unstable-2021-07-20 -> unstable-2022-11-24
* [`d2dcc7a1`](https://github.com/NixOS/nixpkgs/commit/d2dcc7a1695d9afee3e181b5fa116999459f8cd6) nixos/parsedmarc: fix Grafana provisioning
* [`41f621c6`](https://github.com/NixOS/nixpkgs/commit/41f621c6177f4e3e963049450f54fb112b7785d8) waf: 2.0.24 -> 2.0.25
* [`432d4af3`](https://github.com/NixOS/nixpkgs/commit/432d4af37c66805c4df8c563fb3b2aa7aac96fa7) mpg123: 1.29.3 -> 1.31.1
* [`83af9206`](https://github.com/NixOS/nixpkgs/commit/83af920687a9ae0d3834771d87c1820b919f4e72)  libglvnd: 1.5.0 -> 1.6.0
* [`2a60c419`](https://github.com/NixOS/nixpkgs/commit/2a60c419103e2ba5893441c03d7b2631bb7736eb) hwdata: 0.364 -> 0.366
* [`fb49d81b`](https://github.com/NixOS/nixpkgs/commit/fb49d81b2541bd06fbaef6f516906381e7356947) linux: enable ACPI_FPDT, ACPI_HMAT, ACPI_APEI, ACPI_APEI_GHES, ACPI_DPTF
* [`ddd340c5`](https://github.com/NixOS/nixpkgs/commit/ddd340c59b94f8f89a1ff531531333055c90ea59) opencv4: added accuracy and performance tests
* [`66efeba6`](https://github.com/NixOS/nixpkgs/commit/66efeba6775c493bf264e8652481042d22ad35d1) opencv4: using blas provider, fixed multi-threading conflict between opencv and openblas
* [`672965cd`](https://github.com/NixOS/nixpkgs/commit/672965cd6df363aa40a68b1c4ff7d62e55c2ca26) hunspell: 1.7.1 -> 1.7.2
* [`fd06c8fc`](https://github.com/NixOS/nixpkgs/commit/fd06c8fc9f497975bac50a8f3188fcb9a3a40477) nixos/systemd-initrd: allow symlink into when checking for `/prepare-root`
* [`221ef67e`](https://github.com/NixOS/nixpkgs/commit/221ef67e1c12f3c374ec0737445e1a62fa6f6806) kernel: add deterministic-uname to moduleBuildDependencies
* [`0f95e269`](https://github.com/NixOS/nixpkgs/commit/0f95e269940ffe3b897665326a1f1455eab1bd56) newt: 0.52.21 -> 0.52.23
* [`6982f3b3`](https://github.com/NixOS/nixpkgs/commit/6982f3b3540f2555cf85258f959dff9ecb9c19c4) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.6.1 -> 1.6.4
* [`dce177b0`](https://github.com/NixOS/nixpkgs/commit/dce177b067b0a98245421b698cc176ab5f790db6) python310Packages.coconut: 2.1.1 -> 2.2.0
* [`112a1cff`](https://github.com/NixOS/nixpkgs/commit/112a1cffabce7afb9fed5da89a87a80f50854c24) python310Packages.inquirer: 3.1.1 -> 3.1.2
* [`187e4348`](https://github.com/NixOS/nixpkgs/commit/187e43489b5f4cbe319305cae9ca1acda01216f1) python310Packages.inquirer: add changelog to meta
* [`828487c5`](https://github.com/NixOS/nixpkgs/commit/828487c551a797ca2491fb2dd8f78ddc0a54bb1b) ruby_2_7: 2.7.6 -> 2.7.7
* [`0f9f6693`](https://github.com/NixOS/nixpkgs/commit/0f9f669328ca2dbda36b96746f41f58f9be90aa6) ruby_3_0: 3.0.4 -> 3.0.5
* [`8f947e41`](https://github.com/NixOS/nixpkgs/commit/8f947e417ff684965bd0156c8a444b389ab9310e) pkgsCross.wasi32.pkgsBuildTarget.llvm_{{5,12},git}: disable gold plugin on wasi
* [`d72176e6`](https://github.com/NixOS/nixpkgs/commit/d72176e68222c87173c787157ff4b7ae63ddf6ff) pahole: 1.24 -> 1.24-unstable-2022-11-24
* [`30d0abd5`](https://github.com/NixOS/nixpkgs/commit/30d0abd503c4eaac155910acfdb40e765ced3af5) python310Packages.pytz: 2022.7 -> 2022.7.1
* [`5f0b4eb0`](https://github.com/NixOS/nixpkgs/commit/5f0b4eb01ed5857d87dd516004f7806e65c9a01b) meson: patch bash completion file to access python3
* [`610256a6`](https://github.com/NixOS/nixpkgs/commit/610256a6c33432ea51c4df67dc1c040fd7873e83) meson.src: use hash instead of sha256 as its input parameter
* [`913dcab3`](https://github.com/NixOS/nixpkgs/commit/913dcab3b357c174253752cc206cb1bdcff0732b) python310Packages.cython: 0.29.32 -> 0.29.33
* [`abb7ce53`](https://github.com/NixOS/nixpkgs/commit/abb7ce53d7456108aaaa9ba459bb0467b1e4249a) python310Packages.hatch-requirements-txt: add hatchling to nativeBuildInputs
* [`020eb79d`](https://github.com/NixOS/nixpkgs/commit/020eb79d627550160864631e869c48ad67ecbe02) python3Packages.scipy: schedule as big-parallel on Hydra
* [`85066449`](https://github.com/NixOS/nixpkgs/commit/8506644905a7c78329953df7e8b4da255a53b5fc) python310Packages.cvxpy: 1.2.3 -> 1.3.0
* [`6f87cb2b`](https://github.com/NixOS/nixpkgs/commit/6f87cb2be9402cea86781dc93327181c6a2c98a6) gxplugins-lv2: 0.9 -> 1.0
* [`3487488f`](https://github.com/NixOS/nixpkgs/commit/3487488f62e7532104d9741c34c5f5b2236c02e7) file: 5.43 -> 5.44
* [`658c788b`](https://github.com/NixOS/nixpkgs/commit/658c788bc7de1036ad873e8f014d6acd04cb451c) go: Add patches to support Sv57 addressing on riscv64
* [`9af87363`](https://github.com/NixOS/nixpkgs/commit/9af87363f04d05cbde52498f8d77bb46e7832d32) libssh: 0.10.0 -> 0.10.4
* [`12d77fc4`](https://github.com/NixOS/nixpkgs/commit/12d77fc4b6acced68f0caf951c71402c8b15b65f) mpg123: 1.31.1 -> 1.31.2
* [`b58f89b2`](https://github.com/NixOS/nixpkgs/commit/b58f89b2f3b4ff1ac9120d4c5775d09019346a4c) ed: 1.18 -> 1.19
* [`30e48922`](https://github.com/NixOS/nixpkgs/commit/30e489228bb1d19ac01502df19ba957a75b6ac65) xorg.xset: 1.2.4 -> 1.2.5
* [`452c4de3`](https://github.com/NixOS/nixpkgs/commit/452c4de3fb4d296b925d1e366489d6540c2a1b2a) gperf: enable parallel building
* [`6e3bff61`](https://github.com/NixOS/nixpkgs/commit/6e3bff617fa22d2e1e7265ff69e9cb00f77b46a7) treewide: remove replacements of '$(shell uname -r)' with '${kernel.modDirVersion}'
* [`3a8d15be`](https://github.com/NixOS/nixpkgs/commit/3a8d15be543dd3c95913bde4d34968108c9720a6) python3Packages.sqlglot: 6.0.7 -> 10.5.2
* [`141cbae9`](https://github.com/NixOS/nixpkgs/commit/141cbae9d81cf9e7090868e9750b6ea934fe2e7e) python3Packages.proto-plus: 1.22.1 -> 1.22.2
* [`b73025e1`](https://github.com/NixOS/nixpkgs/commit/b73025e14c7e8738ec3baa9db71efa0044ec7b35) python311Packages.pyarrow: disable failing fs repr tests on py311
* [`c8df8dab`](https://github.com/NixOS/nixpkgs/commit/c8df8dab6be0e4f32cd8723c94619ecda0b39ff4) python3Packages.datafusion: 0.4.0 -> 0.7.0
* [`c1205e4c`](https://github.com/NixOS/nixpkgs/commit/c1205e4c48ea296be3c4744d2d2144d40dbcaee1) python3Packages.ibis-framework: 3.2.0 -> 4.0.0
* [`1b8fd7e7`](https://github.com/NixOS/nixpkgs/commit/1b8fd7e773fa23df0ec40b8b910a2e44303ce248) libcamera: split output
* [`22c7e514`](https://github.com/NixOS/nixpkgs/commit/22c7e514916a57b685aabf695aff8324d2a5ef9b) lsp-plugins: split outputs and fix indendation
* [`270625cd`](https://github.com/NixOS/nixpkgs/commit/270625cd92661068963993c74ce24682832a431d) calf: split outputs
* [`0ffa8f6b`](https://github.com/NixOS/nixpkgs/commit/0ffa8f6b9ed01d3e621da7866a9c23f409540b76) xorg.libXt: move share/doc to devdoc
* [`ce2eb078`](https://github.com/NixOS/nixpkgs/commit/ce2eb078d6804bb772f7b51b7fcf9270e70e2682) help2man: 1.49.2 -> 1.49.3, little cleanups
* [`de5c3cb8`](https://github.com/NixOS/nixpkgs/commit/de5c3cb8ca5e64943c7e205983702403eacbfbb2) tcpdump: 4.99.1 -> 4.99.3
* [`efbac5a2`](https://github.com/NixOS/nixpkgs/commit/efbac5a249e9176dbdd3a58fb6477935c1931447) xidel: 0.9.8 -> unstable-2022-11-01
* [`2f8e6f3d`](https://github.com/NixOS/nixpkgs/commit/2f8e6f3d33d73190ac8bebb4b4c94bfdf59c904d) gtest: ensure C++17 support ([nixos/nixpkgs⁠#207338](https://togithub.com/nixos/nixpkgs/issues/207338))
* [`1a13817d`](https://github.com/NixOS/nixpkgs/commit/1a13817d320af5f7e22327c2d3f98d2ef9df4b68) xorg.libX11: 1.8.1 -> 1.8.3
* [`5dbe61b2`](https://github.com/NixOS/nixpkgs/commit/5dbe61b225f792a860ea94fb7102364e8273d472) wildmidi: 0.4.4 -> 0.4.5
* [`c040a98a`](https://github.com/NixOS/nixpkgs/commit/c040a98a33b29ba58571702e606c322c22dd15ad) libuv: expand the steaming pile of unsandboxable tests
* [`12d2821b`](https://github.com/NixOS/nixpkgs/commit/12d2821bf56be27d33b90f109220a342a11828ca) treewide: remove -ldl linker flags
* [`e049b859`](https://github.com/NixOS/nixpkgs/commit/e049b8591006db58f34d41a490725a510191a238) bash: apply static fix unconditionally
* [`dfd70016`](https://github.com/NixOS/nixpkgs/commit/dfd70016472355bdaf75cbf49480fcf6fdf46218) harfbuzzFull: dont create dangling symlink
* [`cfb543a5`](https://github.com/NixOS/nixpkgs/commit/cfb543a53219ac607f930adcdb34cde001b27767) make-symlinks-relative: run on all outputs
* [`f81ab570`](https://github.com/NixOS/nixpkgs/commit/f81ab570496e459ec0bd9ef6c9ec8ca88f1fd5dd) libunistring: enableParallelChecking = false
* [`d62bfb19`](https://github.com/NixOS/nixpkgs/commit/d62bfb194d3fd4196298ec7df5e158dd22028c26) nodejs: Fix build on RISC-V
* [`cc69ffa1`](https://github.com/NixOS/nixpkgs/commit/cc69ffa15cc79114f3ca56323a80044b29ec272a) python310Packages.wheel: 0.37.1 -> 0.38.4
* [`1616b30d`](https://github.com/NixOS/nixpkgs/commit/1616b30dce6cebd8c74ac9f118c773b7ede23105) lsof: 4.96.5 -> 4.98.0
* [`eb620ff9`](https://github.com/NixOS/nixpkgs/commit/eb620ff9f79d39903a1f222ad5fbfc72f4f6f161) libredirect: add more wrappers
* [`5ac9fcfc`](https://github.com/NixOS/nixpkgs/commit/5ac9fcfc60a73d68b226ee01e00d6332fdbc761c) dejagnu: fix target passing for 'runtest' wrapper
* [`32b599ec`](https://github.com/NixOS/nixpkgs/commit/32b599ecfa3eed0546c309b96da402c493eb173c) btrfs-progs: 6.1.2 -> 6.1.3
* [`3e1fdaf2`](https://github.com/NixOS/nixpkgs/commit/3e1fdaf2e5d9f13fa0d5b08e866201173ef70b98) nixos/nextcloud: fix typo in option description
* [`333ffb5d`](https://github.com/NixOS/nixpkgs/commit/333ffb5d4ac5442b1204f7056b10ce342ec2f81f) meson: 0.64.1 -> 1.0.0
* [`022c01aa`](https://github.com/NixOS/nixpkgs/commit/022c01aa39f1df76eab961967ce48bdcbfe16684) meson: run project tests
* [`9d9eceb7`](https://github.com/NixOS/nixpkgs/commit/9d9eceb7e001bb951a8cd448b763ee88bd728b43) tcl.tclPackageHook: add dontWrapTclBinaries parameter
* [`48125f1e`](https://github.com/NixOS/nixpkgs/commit/48125f1ee926060577789d47d09d3800455bce07) poke: use dontWrapTclBinaries
* [`7f0ebaec`](https://github.com/NixOS/nixpkgs/commit/7f0ebaecd107960cce9fc8e15ec73a0ef71de816) pikchr: enable tcl support
* [`2e03c5e8`](https://github.com/NixOS/nixpkgs/commit/2e03c5e81dd265271234695a4b09cc9ed12e8bff) openrgb-plugin-hardwaresync: init at 0.8
* [`1f884807`](https://github.com/NixOS/nixpkgs/commit/1f88480755058f929995b167d318cdbf5da89d86) python310Packages.chart-studio: 5.11.0 -> 5.13.0
* [`f1df7a97`](https://github.com/NixOS/nixpkgs/commit/f1df7a9788bff637448248abb236ab532ce15756) libepoxy: fix build without x11 support
* [`3d9ac1fa`](https://github.com/NixOS/nixpkgs/commit/3d9ac1fa805ddd033bd51c59e2ce2d554b150661) libdatrie: depend on libiconv unconditionally
* [`2cfe8451`](https://github.com/NixOS/nixpkgs/commit/2cfe8451edf8be486db1af7d46b4e864f2c3c370) libredirect: add tests for new wrappers
* [`74333f09`](https://github.com/NixOS/nixpkgs/commit/74333f09547e6a497ef84fd6c3178a10262682a6) libvisual: 0.4.0 -> 0.4.1
* [`dcb1b49b`](https://github.com/NixOS/nixpkgs/commit/dcb1b49be6864d21da07ad41559d3b08967e2232) libkrb5: fix BSD cross-compilation
* [`9aac1343`](https://github.com/NixOS/nixpkgs/commit/9aac134336f7596d8d2f7bb1a6f141673776a5db) openrgb: add withPlugins
* [`9e01b532`](https://github.com/NixOS/nixpkgs/commit/9e01b53234f2a242a51c7fb7f598121f1092cdcf) openrgb-with-all-plugins: init
* [`4fc9f2e8`](https://github.com/NixOS/nixpkgs/commit/4fc9f2e86b3fd1d6604cc2f65c7c18466d7c37cf) ffmpeg: merge with ffmpeg-full
* [`89d172bb`](https://github.com/NixOS/nixpkgs/commit/89d172bbcc45fcc20ccf6485722f706a7e3334e4) jami: use regular ffmpeg_5
* [`79466c48`](https://github.com/NixOS/nixpkgs/commit/79466c48bcf1ac8b336f3d39a6cf470cfbaccd53) handbrake: disable sdl2 in custom ffmpeg
* [`cb7cb270`](https://github.com/NixOS/nixpkgs/commit/cb7cb27083ff852a1218a114fbf74817195d49ac) libuv: fix musl libc dlerror test expectation
* [`6515a7ac`](https://github.com/NixOS/nixpkgs/commit/6515a7acd54d71b5a1272564d01699a9aa754cf2) opusfile: apply patch for CVE-2022-47021
* [`e1ef521c`](https://github.com/NixOS/nixpkgs/commit/e1ef521cffc21c8161582b439789c2377b67f428) binutils: 2.39 -> 2.40
* [`232cdbf7`](https://github.com/NixOS/nixpkgs/commit/232cdbf7485e827a7d933970ec327928f8ece6ca) python310Packages.nunavut: 1.9.0 -> 2.0.0
* [`cb572732`](https://github.com/NixOS/nixpkgs/commit/cb5727323607dd9cc1fa12a8147ce21389df6599) stdenv: gcc_11 → gcc_12
* [`713db8d8`](https://github.com/NixOS/nixpkgs/commit/713db8d8f85412a9efde7539d8ebfeb5255ddb0b) linux/hardened: make GCC_STRUCTLEAK optional since it isn't an option
* [`99c7bd73`](https://github.com/NixOS/nixpkgs/commit/99c7bd7302ac33443a0cf4ec752cc0988f84eb73) unittest-cpp: add gcc12 patch
* [`41392070`](https://github.com/NixOS/nixpkgs/commit/413920705ea959afcc19ef99524f1e9a6519640b) tg_owt: add gcc12 patch
* [`0cf5d85f`](https://github.com/NixOS/nixpkgs/commit/0cf5d85f0cc52353b5cf1f0dd714e5d02855335e) treewide: add gcc12 flags
* [`5fddee71`](https://github.com/NixOS/nixpkgs/commit/5fddee717e35f045e1b59f6d35e9180223031b87) vte: change stdenv override to only aarch64-linux
* [`b3195fa1`](https://github.com/NixOS/nixpkgs/commit/b3195fa1aff668f3754d00b5b39953c5dbe10f52) clucene_core_2: add arch patch for missing include
* [`5328e138`](https://github.com/NixOS/nixpkgs/commit/5328e1384a6e15215d061e41be41bfb6edfaa801) nixosTests.systemd-cryptenroll: mark as not broken
* [`809f21a3`](https://github.com/NixOS/nixpkgs/commit/809f21a32f3f92c349be781f75c6459dd29902c3) cmake: 3.24.3 -> 3.25.1
* [`119726d9`](https://github.com/NixOS/nixpkgs/commit/119726d93a5f1a0bee3c45baad5d484a696750a6) xorg.bdftopcf: 1.1 -> 1.1.1
* [`2ba48bd1`](https://github.com/NixOS/nixpkgs/commit/2ba48bd164a569c31b051eb7fed531d41f3bafe4) libde265: 1.0.9 -> 1.0.10
* [`6b832b53`](https://github.com/NixOS/nixpkgs/commit/6b832b53320bbecd556804dff270ad50a3ee122d) build-support/cc-wrapper: revert "pass in non-existent --sysroot= to untangle from libc"
* [`5d837b28`](https://github.com/NixOS/nixpkgs/commit/5d837b280eb118aa87e34214ef56526b025250b9) wimboot: revert "fix build by fixing -idirafter ordering"
* [`e2e400e2`](https://github.com/NixOS/nixpkgs/commit/e2e400e26726b8b74c1685dbc2a282559d8ff77d) dmd: revert "set --sysroot=/ to avoid cc-wrapper value"
* [`25206ed9`](https://github.com/NixOS/nixpkgs/commit/25206ed9a89083889f386f8cd3c5a5a2611a5301) ubootTools: revert "fix build by fixing -idirafter ordering"
* [`58ddf90b`](https://github.com/NixOS/nixpkgs/commit/58ddf90bfa080e4a1c0ddda7435dfe4d9931a0a7) ipxe: revert "fix build by fixing -idirafter ordering"
* [`3f9fe5c1`](https://github.com/NixOS/nixpkgs/commit/3f9fe5c15fcf12c5f6b512f9d5f8234c890ead28) mesa: revert "fix build"
* [`183939da`](https://github.com/NixOS/nixpkgs/commit/183939da54831b11f389d9863a0e5b41aaf1ddc5) improve error when srcs is used with directories with the same post-hash name
* [`0a8262f9`](https://github.com/NixOS/nixpkgs/commit/0a8262f943481e6c956f8cf20a1a39d3618687bc) groff: add missing bison dependency for Clang
* [`c9a88f96`](https://github.com/NixOS/nixpkgs/commit/c9a88f969dfca9a6d0fa5581be55a6c29ef677c5) bash: add debug info
* [`202f1529`](https://github.com/NixOS/nixpkgs/commit/202f1529c3abf1c0b7dfee1faec8b7a8e7ea4fb8) xorg.lndir: 1.0.3 -> 1.0.4
* [`196ce767`](https://github.com/NixOS/nixpkgs/commit/196ce767035e102bf3863a4957d9c4cf520278bc) systemd: 252.4 -> 252.5
* [`900d7d6d`](https://github.com/NixOS/nixpkgs/commit/900d7d6d40fb6c9443baba69f78c8031eed07ba5) valgrind-light: fix build for ELFv2 PowerPC BE
* [`a6441df4`](https://github.com/NixOS/nixpkgs/commit/a6441df4d885f302b5b310d7b41cad56eabbfbd1) libvterm-neovim: 0.3 -> 0.3.1
* [`453c3b7b`](https://github.com/NixOS/nixpkgs/commit/453c3b7b916794a0023f0abad3e3387e5ad4b15e) libraw: 0.20.2.p2 -> 0.21.1
* [`b24c90dd`](https://github.com/NixOS/nixpkgs/commit/b24c90dd3fb90f6c29ea299c606f2e25416df539) libraw_unstable: remove
* [`68e2afd4`](https://github.com/NixOS/nixpkgs/commit/68e2afd480150e2b10eeac2eab6f420ea4e7ca33) python310Packages.selenium: 4.7.0 -> 4.8.0
* [`f386825f`](https://github.com/NixOS/nixpkgs/commit/f386825fa23a7b1e67e0c93e82bcbd318da03c86) tbb: split output
* [`092c2b3d`](https://github.com/NixOS/nixpkgs/commit/092c2b3dead3f7fcfd6cee084a4061312fbd7f63) gsl: split output
* [`c0548dd6`](https://github.com/NixOS/nixpkgs/commit/c0548dd6ab64da818e56b4749a5ba4be4279d77a) python310Packages.cvxopt: use lib.getX
* [`37dede42`](https://github.com/NixOS/nixpkgs/commit/37dede4296eded2800bc324c1110e8848ad78f9d) octopus: use lib.getX
* [`51acc624`](https://github.com/NixOS/nixpkgs/commit/51acc6245e5995c06c1304741263a8b954192e70) stdenv: don't include drvs in disallowedRefs as build-time deps.
* [`c86f20cb`](https://github.com/NixOS/nixpkgs/commit/c86f20cb4840c3a0e3a7c6988f76f428a89dbe8f) libtiff: apply patch for CVE-2022-48281
* [`06667ffd`](https://github.com/NixOS/nixpkgs/commit/06667ffdc8d6d07e1c8ba53fb8e719d682dd5e16) libcbor: 0.10.0 -> unstable-2023-01-29
* [`b9a9dfc3`](https://github.com/NixOS/nixpkgs/commit/b9a9dfc3d4596825d98bb87b7f488ff1a5d765f1) binutils: consolidate plugin-api.h support in a single
* [`63f869f5`](https://github.com/NixOS/nixpkgs/commit/63f869f5ff10b570fcf3a0d002a7aa25938f6f9f) rustc: 1.66.1 -> 1.67.0
* [`ede7b1d9`](https://github.com/NixOS/nixpkgs/commit/ede7b1d98a01cd25c05f30c215afc063bd62706b) Revert "rustc: add note about libiconv dependency"
* [`e608e04f`](https://github.com/NixOS/nixpkgs/commit/e608e04f3c5d1db8f583eb053ad7d6b6aca80ae4) puddletag: fix wrapping
* [`266eafad`](https://github.com/NixOS/nixpkgs/commit/266eafadc01d98b4c2046b136a4edeb78a68c647) git-credential-keepassxc: 0.11.0 -> 0.12.0
* [`4be79e35`](https://github.com/NixOS/nixpkgs/commit/4be79e3516bfca264c2de2e776aa1ee51e115666) xorg.fontalias: 1.0.3 -> 1.0.4
* [`ed5afe8b`](https://github.com/NixOS/nixpkgs/commit/ed5afe8b9d0ecce300aa55ceda1db7a992ddd9bd) ppp: disable IPX on musl
* [`e8d71d70`](https://github.com/NixOS/nixpkgs/commit/e8d71d70cea05c5d17d8eda9aa2e49ffbb603139) treewide: data: convert to stdenvNoCC.mkDerivation
* [`e86b3bbf`](https://github.com/NixOS/nixpkgs/commit/e86b3bbf2c88046e6d81efbca00fea0b3143e557) binutils: symlink libraries and headers for "target" to lib/ and include/
* [`726597c1`](https://github.com/NixOS/nixpkgs/commit/726597c1a7d8bae7db3c065b2de6cfb148210452) binutils: re-enable plugins support for wasi target
* [`b73942bc`](https://github.com/NixOS/nixpkgs/commit/b73942bc8e5bf4830ef11a285e62d07772f8fbbb) binutils: advertise binutils plugin API on darwin, it should just work
* [`9bc4f340`](https://github.com/NixOS/nixpkgs/commit/9bc4f340349d6d116579fd04dce7d3d2bf3a420c) cargo: move cert info to fetch-cargo-tarball
* [`c6d20346`](https://github.com/NixOS/nixpkgs/commit/c6d203467aa1a68fc3419bef7402d7d27ce924b3) buildRustPackage: drop cacert
* [`91be301b`](https://github.com/NixOS/nixpkgs/commit/91be301b1356cb0ce48b7c7c420a1de41b9c6a54) pipewire: enable strictDeps
* [`981e6981`](https://github.com/NixOS/nixpkgs/commit/981e6981e184abc9ac6774524065e16f0cd2c932) python3Packages.pytest-rerunfailures: 10.3 → 11.0
* [`b8b5fc14`](https://github.com/NixOS/nixpkgs/commit/b8b5fc1463033d7d4aadefafc7f2b091d8415382) gcc: revert "provide both native and cross forms of gcc.libs libraries"
* [`d3e48e9f`](https://github.com/NixOS/nixpkgs/commit/d3e48e9f1bfa05080a00156e8ea709e0cfc11f72) python3Packages.django_3: 3.2.16 -> 3.2.17
* [`6930b5bd`](https://github.com/NixOS/nixpkgs/commit/6930b5bda8431f2cdb12fecdb26d9d12bec7c4cf) lyx, rr, linuxPackgaes.systemtap: fixup build with gcc12
* [`88a42ba3`](https://github.com/NixOS/nixpkgs/commit/88a42ba309f4425f9c131c9c920cfaf67e956696) rustc: apply patch to fix thin archive reading
* [`3aa7b72b`](https://github.com/NixOS/nixpkgs/commit/3aa7b72b5e1174ba68d38fc466b1743118be265c) python3Packages.build: Fix build after pytest-rerunfailures update
* [`ad3ab4fc`](https://github.com/NixOS/nixpkgs/commit/ad3ab4fcff3a1aa197e79b1016f9dafd2a20f9af) python310Packages.python-magic: fix tests
* [`14d9512d`](https://github.com/NixOS/nixpkgs/commit/14d9512d60fc759fa9295cee33e03c03af85f1cf) Revert "libassuan: Use automatically detected libgpg-error"
* [`a26fc6a7`](https://github.com/NixOS/nixpkgs/commit/a26fc6a7299dd31aeac83edc950cdc7a2dca9b78) libassuan: explain why we set libgpg-error prefix
* [`9ac97a79`](https://github.com/NixOS/nixpkgs/commit/9ac97a794f45aeba55942174e069df1995caab28) meson: fix checks on darwin
* [`b5724354`](https://github.com/NixOS/nixpkgs/commit/b5724354b7345329d5ba3aba04223a5655dc9304) python310Packages.pytest-httpserver: Fix tests on darwin
* [`42f462e3`](https://github.com/NixOS/nixpkgs/commit/42f462e38724e66c4e6603bd3efdf89c40031ec9) v2raya: make code more readable
* [`e78f2115`](https://github.com/NixOS/nixpkgs/commit/e78f2115bf0c1c2f238bf918ed368fcf633da862) v2raya: v2rayA should start after nftables
* [`839b6b5e`](https://github.com/NixOS/nixpkgs/commit/839b6b5e2072967e82ebd347f6d563f4e68ab646) seahorse: add gpg 2.4.0 patch from upstream
* [`6f4215eb`](https://github.com/NixOS/nixpkgs/commit/6f4215eb87f2aa9b6fa33023b3fd5923e34e9a0d) dbus_cplusplus: fix build with gcc12 by another patch
* [`ae7d9a3f`](https://github.com/NixOS/nixpkgs/commit/ae7d9a3fe7a11918c29f3b7b94f89300170bd6e7) gegl: patch to build after libraw update
* [`ad1bdf4e`](https://github.com/NixOS/nixpkgs/commit/ad1bdf4e77f65d659e2f0427d958ef1b8727c705) v8, openbabel: fixup build with gcc12
* [`9bccea53`](https://github.com/NixOS/nixpkgs/commit/9bccea539c4aaae559d43c64e1cd2e311725f6f0) mesa: build Intel drivers on i686
* [`68b17279`](https://github.com/NixOS/nixpkgs/commit/68b17279079c4b7b37ce18ecdac33ecf2fd1e037) anbox, arc_unpacker: fix build after defaulting to gcc12
* [`0c19bf42`](https://github.com/NixOS/nixpkgs/commit/0c19bf42285e252ffce1c6b289d4b168aa855d36) openbabel2: fixup build with gcc12
* [`29be15b7`](https://github.com/NixOS/nixpkgs/commit/29be15b7f66743439b68ed98140b4824ac074505) krita: 5.1.4 -> 5.1.5
* [`e2d48792`](https://github.com/NixOS/nixpkgs/commit/e2d48792c503b6baea2d860492963a18946d1259) qt5/qtwebengine: 5.15.11 -> 5.15.12
* [`a25786f7`](https://github.com/NixOS/nixpkgs/commit/a25786f76f1020096fa58bbbebafeeb1a0ca6b76) qt5/qtwebengine: pick patch to fix build with gcc 12
* [`7d113c2f`](https://github.com/NixOS/nixpkgs/commit/7d113c2fe550bfcd164996fcc3a396c62315301a) rmfuse: don't use poetry2nix
* [`1735bedf`](https://github.com/NixOS/nixpkgs/commit/1735bedf66e2eb062dd793a1d72184d3f2f4f992) nss_wrapper: 1.1.12 -> 1.1.15
* [`dc163892`](https://github.com/NixOS/nixpkgs/commit/dc1638927e41e8bb45dbc98d5560f76e6d88715e) gcc10StdenvCompat: fix the intended logic
* [`8627b384`](https://github.com/NixOS/nixpkgs/commit/8627b384af3f88c20ca08c50a01fa27a241d637a) treewide: gcc11Stdenv on x86_64-linux -> gcc12Stdenv
* [`7677b9af`](https://github.com/NixOS/nixpkgs/commit/7677b9afd0b56d09ab6026fb484ce8e5b13b7ce4) libcryptui: accept gnupg 2.4
* [`c2fb9453`](https://github.com/NixOS/nixpkgs/commit/c2fb9453ab5e8dac128ac042f42e716252d763ec) idsk, indi-full: more gcc12 fixups
* [`44cb0052`](https://github.com/NixOS/nixpkgs/commit/44cb005294e79bca38d4d8490bbde0044a0043b1) furnace, boringssl, gloox, xorg.xf86videovmware: gcc12 fixups
* [`93f577ae`](https://github.com/NixOS/nixpkgs/commit/93f577aed89f0841c351ea384ece11c67c734ee5) python2Packages.wheel: keep 0.37.1 for python2 since 0.38 dropped support
* [`555f3008`](https://github.com/NixOS/nixpkgs/commit/555f300879332a5989c1130b8e78bf8bdbac20ea) treewide: another round of gcc12 fixups
* [`6190ed02`](https://github.com/NixOS/nixpkgs/commit/6190ed026ca52bd74ede412bda19552f5851df0d) hdrmerge: fix build with updated libraw
* [`cfc05628`](https://github.com/NixOS/nixpkgs/commit/cfc056287cb29a7bc434f0a2334b149f6a057094) treewide: another round of gcc12 fixups
* [`62928668`](https://github.com/NixOS/nixpkgs/commit/62928668a8562dfc910ce5d5b21cdaff8366ad06) nixos/no-x-libs: add vim-full
* [`5e1e6101`](https://github.com/NixOS/nixpkgs/commit/5e1e6101ad865a568005348bf41485534e3a0e41) libsForQt5.maplibre-gl-native: fix evaluation
* [`9034e45a`](https://github.com/NixOS/nixpkgs/commit/9034e45a784f9a72b26dafe70648e03e0bff16b7) ceph: fix build with gcc 12
* [`111958c0`](https://github.com/NixOS/nixpkgs/commit/111958c02a8fb2f24458a3fb1f997dd8512cb5f9) python3Packages.torch: fix build with gcc 12
* [`86e33692`](https://github.com/NixOS/nixpkgs/commit/86e33692cc9f308ab672cd05845a3c91e78540a4) ndn-cxx: 0.7.1 -> 0.8.1
* [`c1ab1549`](https://github.com/NixOS/nixpkgs/commit/c1ab15495e72643b205887db388746f5994901aa) ndn-tools: 0.7.0 -> 22.12
* [`c09e42d3`](https://github.com/NixOS/nixpkgs/commit/c09e42d337ebd3052840bc630b029ec2a1063074) python3Packages.torch: conditionalize -Wno-error={maybe-,}uninitialized on GNU stdenv
* [`ac2d27b1`](https://github.com/NixOS/nixpkgs/commit/ac2d27b1c27eeed834652bed2b0cd30fbfe2e84e) openrgb-plugin-effects: init at 0.8
* [`07c6e6b2`](https://github.com/NixOS/nixpkgs/commit/07c6e6b2b848a42198494b77df0521eabd61c5eb) libredirect: fix build on musl libc
* [`2f14f5d5`](https://github.com/NixOS/nixpkgs/commit/2f14f5d561cb1cb5f8f95902a37568c9c350c1b1) python310Packages.jaxopt: init at 0.5.5
* [`20f49fa1`](https://github.com/NixOS/nixpkgs/commit/20f49fa10b8d28c581a1cf125de12e5bbf47840a) python310Packages.blackjax: init at 0.9.6
* [`36acad3d`](https://github.com/NixOS/nixpkgs/commit/36acad3daf6fa6cc32fed4641eaf7e36984f055b) python310Packages.bambi: enable more tests
* [`3fb9672b`](https://github.com/NixOS/nixpkgs/commit/3fb9672b71c61854fbdddfc8be9c7159d1c1ea55) vips: Switch to Meson
* [`152204b0`](https://github.com/NixOS/nixpkgs/commit/152204b08cf68bc4f84152e12dddf5b061fea7d4) vips: 8.13.3 -> 8.14.1
* [`b872c2ad`](https://github.com/NixOS/nixpkgs/commit/b872c2ad6ada8a23e4814fc26fab9f2de3243bfd) vips: don't build gtk_doc on Darwin
* [`1de7179b`](https://github.com/NixOS/nixpkgs/commit/1de7179b424a328a534f09184a7f65f2e3882b90) imaginary: fix tests on Darwin
* [`7f41ad6c`](https://github.com/NixOS/nixpkgs/commit/7f41ad6c6c2f5859e167ed3123e44af5e0073656) xorg.xorgserver: patch CVE-2023-0494
* [`e968d033`](https://github.com/NixOS/nixpkgs/commit/e968d033212ad82743a536189e84ea857762e7ae) ffmpeg_4: enable avresample again
* [`ec0275c6`](https://github.com/NixOS/nixpkgs/commit/ec0275c684ac706725102dd1082bbccb6c52db4b) ffmpeg-full: remove dead file
* [`6bfd49ed`](https://github.com/NixOS/nixpkgs/commit/6bfd49ed80adb85e377aa26e1f13c94d25575b1f) Merge [nixos/nixpkgs⁠#214387](https://togithub.com/nixos/nixpkgs/issues/214387): pipewire: fix pipewire-rs builds
* [`15cf84fe`](https://github.com/NixOS/nixpkgs/commit/15cf84feea87949eb01b9b6e631246fe6991cd3a) openssl: 3.0.7 -> 3.0.8
* [`faa4d60e`](https://github.com/NixOS/nixpkgs/commit/faa4d60e7fab7386ec9081364db8dbe92aca2fc4) openssl_1_1: 1.1.1s -> 1.1.1t
* [`79a30130`](https://github.com/NixOS/nixpkgs/commit/79a301305be732d1bc294dcc18126f14f7ef5581) nginx: remove with lib over entire file
* [`059bd435`](https://github.com/NixOS/nixpkgs/commit/059bd435463f63f131c2a2d5f431198443ab0913) make-derivation.nix: Support inputDerivation on disallowedReferences
* [`b3a27afb`](https://github.com/NixOS/nixpkgs/commit/b3a27afb7c6d48a78ee2b1877f1fc83108d509dc) binfmt: Don't create invalid service with no registrations
* [`35b5c598`](https://github.com/NixOS/nixpkgs/commit/35b5c598f10c88b9a2ac571c477586bd2fd0feba) deepin-reader: init at 5.10.28
* [`14edf27b`](https://github.com/NixOS/nixpkgs/commit/14edf27b25d929459c371b2a7fc5167ab5fa497d) python310Packages.grad-cam: init at 1.4.6
* [`6056eaaa`](https://github.com/NixOS/nixpkgs/commit/6056eaaa8b38474920016a795cc3db0f0cc4a04e) rustc: apply patch to fix delay_span_bug ICE
* [`ef5aa34f`](https://github.com/NixOS/nixpkgs/commit/ef5aa34f4c3a5b694c35dac51f0bfc37c486d978) glslviewer, tab: fixup build with gcc12
* [`e4ee01e1`](https://github.com/NixOS/nixpkgs/commit/e4ee01e156933d401f8dc2eea33172053b73cd20) mariadb_104: 10.4.27 -> 10.4.28
* [`c4ee903b`](https://github.com/NixOS/nixpkgs/commit/c4ee903b0f533687c22dfe5c2c06fe153677c72a) mariadb_105: 10.5.18 -> 10.5.19
* [`1f1880da`](https://github.com/NixOS/nixpkgs/commit/1f1880da69b12eeb8e522d014295a7fa3ec3c164) mariadb_106: 10.6.11 -> 10.6.12
* [`10e9377d`](https://github.com/NixOS/nixpkgs/commit/10e9377d73953e5c7b6ebf83dd86f754e6010146) mariadb_108: 10.8.6 -> 10.8.7
* [`62e13904`](https://github.com/NixOS/nixpkgs/commit/62e139047b8b8912802197e034a272c03bff05d4) mariadb_109: 10.9.4 -> 10.9.5
* [`bfe3e5fc`](https://github.com/NixOS/nixpkgs/commit/bfe3e5fc15494afbc0d5bd6ce681783de4846926) mariadb_1010: 10.10.2 -> 10.10.3
* [`61d2d6ed`](https://github.com/NixOS/nixpkgs/commit/61d2d6ed26434f9a1572165673776b09832ab40a) python311Packages.cot: skip failing tests
* [`857052b1`](https://github.com/NixOS/nixpkgs/commit/857052b13a9ae808c9a5926e569c32fd20aff99c) libubox: unstable-2021-03-09 -> unstable-2023-01-03
* [`5a1ba628`](https://github.com/NixOS/nixpkgs/commit/5a1ba628417ce5f6151bea3f37351d8e68383252) onlyoffice: allow ExecStartPre additions
* [`e6e02bc9`](https://github.com/NixOS/nixpkgs/commit/e6e02bc9c21aeedb9c70893e5d0b9f68a7b05997) dde-api: init at 5.5.32
* [`2d30754d`](https://github.com/NixOS/nixpkgs/commit/2d30754df3e98a72f1080fa0e5a2f590fa28cd9a) kubernetes-helmPlugins.helm-diff: 3.5.0 -> 3.6.0
* [`f70071e4`](https://github.com/NixOS/nixpkgs/commit/f70071e41da960a1d68d3cef0cb1e2e4d0d93fbf) qemu: fix cross compilation, again
* [`08e6d08a`](https://github.com/NixOS/nixpkgs/commit/08e6d08acea8ac91619c5be4223d44e49f6476a7) qemu: Remove --cpu= flag
* [`8aee83b4`](https://github.com/NixOS/nixpkgs/commit/8aee83b4afd3366640012a88b1405f7e2f7e6932) postgresql_11: 11.18 -> 11.19
* [`0304c27c`](https://github.com/NixOS/nixpkgs/commit/0304c27c111a74f70a996a1a14db5427e6ef2b92) postgresql_12: 12.13 -> 12.14
* [`b908126e`](https://github.com/NixOS/nixpkgs/commit/b908126eaab35daf8bd5609e4560031419d21b57) postgresql_13: 13.9 -> 13.10
* [`894c6a57`](https://github.com/NixOS/nixpkgs/commit/894c6a5756e66a731a14b6f4c4741fcdc4d061d9) postgresql_14: 14.6 -> 14.7
* [`940b7d4e`](https://github.com/NixOS/nixpkgs/commit/940b7d4ee1a1008881f044cdf2986b817c753c42) postgresql_15: 15.1 -> 15.2
* [`5cbeee05`](https://github.com/NixOS/nixpkgs/commit/5cbeee05f3c05c6049ab24b8ab083c328d91a94b) python310Packages.types-protobuf: 4.21.0.2 -> 4.21.0.5
* [`4e51b4a5`](https://github.com/NixOS/nixpkgs/commit/4e51b4a5cbff4beaf0b88ed860ce675cd35b4cf2) graalvm*-ce: refactor derivation to be stand-alone
* [`256195c0`](https://github.com/NixOS/nixpkgs/commit/256195c07a7d4c191d0435919bb9c1f575b09339) native-image-installable-svm: init at 22.3.0
* [`58bfc885`](https://github.com/NixOS/nixpkgs/commit/58bfc885bf1ba5895f163971b1eb5fbcbdc0ff96) native-image-installable-svm: move it to its own file
* [`4f3ede68`](https://github.com/NixOS/nixpkgs/commit/4f3ede68973fdc1635ad8799831076d2708e1ef8) buildGraalvm: add passthru
* [`daf668db`](https://github.com/NixOS/nixpkgs/commit/daf668db55c2d756f37dbb981bfec986132d7710) mkGraal: remove
* [`6b60a4fc`](https://github.com/NixOS/nixpkgs/commit/6b60a4fc50505b09d0b72d85cce6538d640aeb22) buildGraalvmProduct: document phase behavior
* [`68e6010e`](https://github.com/NixOS/nixpkgs/commit/68e6010e81f0d36b7a861ae17c42cbe7b576aec3) native-image-installable-svm: add useMusl option back
* [`78c9e8b7`](https://github.com/NixOS/nixpkgs/commit/78c9e8b76e129fdfe3693dbaebca43b5445ed3c2) graalvm*-ce: remove unneeded params
* [`7893a8f7`](https://github.com/NixOS/nixpkgs/commit/7893a8f78fbea7dbca89268c4af14eb8a99d74d4) chromiumBeta: 110.0.5481.77 -> 111.0.5563.19
* [`0b6052b8`](https://github.com/NixOS/nixpkgs/commit/0b6052b8b07bf8537f0e854ec5e81b343342ecdd) graalvm*-ce: re-added darwin support
* [`1da6843f`](https://github.com/NixOS/nixpkgs/commit/1da6843f1b5b47ecc6857caafdeb025bd39a14f5) buildGraalvm: do not add products inputs
* [`0c7f039b`](https://github.com/NixOS/nixpkgs/commit/0c7f039bad78d09982ad242496a1ee4494a2bdc9) maintainers/team-list: create graalvm-ce team
* [`ed6d3de8`](https://github.com/NixOS/nixpkgs/commit/ed6d3de823c9e4e2f455546ee4848e2943e3a303) add maintainer: heyimnova
* [`52a153aa`](https://github.com/NixOS/nixpkgs/commit/52a153aae20d999854d7ece49b865e95b929e490) k3s: test all versions
* [`571de380`](https://github.com/NixOS/nixpkgs/commit/571de3804ff764e3b37a578853e83589fa4f552b) maintainers: add rvnstn
* [`bae9dc42`](https://github.com/NixOS/nixpkgs/commit/bae9dc42dcdfcc6fedae1a6c8a4dc423b6fadfed) river: 0.2.3 -> 0.2.4
* [`4ed059d0`](https://github.com/NixOS/nixpkgs/commit/4ed059d041c25cc2d933620d3a27d74dfa7ccb97) vmTools: update debian versions
* [`53cd64ce`](https://github.com/NixOS/nixpkgs/commit/53cd64ce18c415dbf47e16c69f8e412e40f731f1) pyside2: Add qt3d to buildInputs
* [`6f7a553d`](https://github.com/NixOS/nixpkgs/commit/6f7a553d0a3c3dd59a4203afe97cf8e45a734afa) maintainers: add andrewsmith
* [`e186a328`](https://github.com/NixOS/nixpkgs/commit/e186a328e4de5ffd62835982098b5d192068d8c1) zstd: add some key reverse-dependencies to passthru.tests
* [`b0f5cb08`](https://github.com/NixOS/nixpkgs/commit/b0f5cb08bf1f2f7d5a4c659bdd451b904cf7250e) pyside2: Disable on Python 3.11 or later
* [`37e3c5d0`](https://github.com/NixOS/nixpkgs/commit/37e3c5d085832c8fa44f2a5c397ab9f71f6b78cc) tengine: 2.3.4 -> 2.4.0
* [`79c2eced`](https://github.com/NixOS/nixpkgs/commit/79c2eceda8d622e0b707f0c20a1dcff72b4e83bb) graalvm*-ce: 22.3.0 -> 22.3.1, migrate upgrade script to sh
* [`6704d4f4`](https://github.com/NixOS/nixpkgs/commit/6704d4f4e4d2af442a4b76a6011f660fb115eb91) bbin: inherit graalvmDrv from babashka
* [`9788650f`](https://github.com/NixOS/nixpkgs/commit/9788650f521f1c4c07edd5f364ed1c51b970f554) buildFHSUserEnv: fix permissions on /tmp/.X11-unix
* [`3dc2e4d0`](https://github.com/NixOS/nixpkgs/commit/3dc2e4d016178ccbac480f98a33f40bd27806a46) python310Packages.oslo-log: 5.0.2 -> 5.1.0
* [`a88d103b`](https://github.com/NixOS/nixpkgs/commit/a88d103bfcf52561b74ee8d23647ef6886664df1) python3Packages.isort: 5.11.4 → 5.12.0
* [`ede042f5`](https://github.com/NixOS/nixpkgs/commit/ede042f54dbc9dbfdb846b7203c5f23e5a5d17e4) nnpdf: 4.0.4 -> 4.0.6
* [`34ccf74c`](https://github.com/NixOS/nixpkgs/commit/34ccf74c23cdcf6013c841a2575ebb8c12875680) python3Packages.n3fit: init at 4.0
* [`95b08561`](https://github.com/NixOS/nixpkgs/commit/95b0856179ba4ac8ef21a5d82b34f6b97c17dd43) python310Packages.playwright: set meta.platforms
* [`98c1d7eb`](https://github.com/NixOS/nixpkgs/commit/98c1d7eb6747db65eab6c8112d35f618141f8079) awscli2: 2.9.21 -> 2.9.23
* [`a6081aed`](https://github.com/NixOS/nixpkgs/commit/a6081aedf809e850b5b9eadaa0565ce968df3a72) python310Packages.clustershell: 1.9 -> 1.9.1
* [`4ea38729`](https://github.com/NixOS/nixpkgs/commit/4ea38729b3e9e7b1738ed433971a099d2b14ebbc) python310Packages.iminuit: 2.18.0 -> 2.19.0
* [`e86de241`](https://github.com/NixOS/nixpkgs/commit/e86de2417f557e0d84532e82cb057ae416818baa) rust-analyzer-unwrapped: 2023-01-30 -> 2023-02-06
* [`a907adf7`](https://github.com/NixOS/nixpkgs/commit/a907adf7a57f76957b00864bc3bf98f806a08190) haskellPackages: stackage LTS 20.8 -> LTS 20.11
* [`17b0cf6f`](https://github.com/NixOS/nixpkgs/commit/17b0cf6fb5078348e576bc8de45dae9f6553252b) all-cabal-hashes: 2023-01-29T01:30:53Z -> 2023-02-11T16:57:22Z
* [`7343f763`](https://github.com/NixOS/nixpkgs/commit/7343f7630c9d7211c98f0c043f380a9037b69252) haskellPackages: regenerate package set based on current config
* [`56369405`](https://github.com/NixOS/nixpkgs/commit/5636940545b6fae90f589d385113866d1140976e) commitizen: 2.41.0 -> 2.42.0
* [`c976bd78`](https://github.com/NixOS/nixpkgs/commit/c976bd78844756f1fec76e5573319077c6bcf70a) python310Packages.oslo-serialization: 5.0.0 -> 5.1.0
* [`b512908f`](https://github.com/NixOS/nixpkgs/commit/b512908f99b5bdadd5f666f23220a82b4a672a44) python310Packages.drf-yasg: 1.21.4 -> 1.21.5
* [`c13f9fbd`](https://github.com/NixOS/nixpkgs/commit/c13f9fbd5d365a786045bdebb3a17bcbb2ac0d1d) python310Package.pygatt: fix cross compilation
* [`7d6df80d`](https://github.com/NixOS/nixpkgs/commit/7d6df80d0b803572836d9ec5aeff713b1509d9be) dos2unix: 7.4.3 -> 7.4.4
* [`28d9074c`](https://github.com/NixOS/nixpkgs/commit/28d9074cc6540921d5bc736f9fac89a42e87b64e) vdr-text2skin: fix src
* [`0214f60b`](https://github.com/NixOS/nixpkgs/commit/0214f60bef5aa2efee162c2732da53a017a7fa9c) vdr-softhddevice: 1.9.3 -> 1.9.7
* [`9a2ebddd`](https://github.com/NixOS/nixpkgs/commit/9a2ebdddca44e4d614945027b504089d0e8d57fd) vdr-markad: 3.0.26 -> 3.1.1
* [`b653bbb7`](https://github.com/NixOS/nixpkgs/commit/b653bbb783307b1a3791b52a1e5d7fac16d4f9d6) vdr-epgsearch: 2.4.1 -> 2.4.2
* [`6be95b12`](https://github.com/NixOS/nixpkgs/commit/6be95b12b2375fe25eee4c8af6099e79d875f363) vdr-vnsiserver: 1.8.1 -> 1.8.3
* [`3f026221`](https://github.com/NixOS/nixpkgs/commit/3f02622151322fbf297a07e9ab37ba085dcf7ad8) vdrPlugins: fix name in function mkPlugin
* [`1ef4899f`](https://github.com/NixOS/nixpkgs/commit/1ef4899f72e74c916bb3eb736c481873a7908fc1) kustomize-sops: 4.0.0 -> 4.1.0
* [`b5fa1434`](https://github.com/NixOS/nixpkgs/commit/b5fa1434696c86576da1462db2d005ea2e93501d) frp: 0.46.1 -> 0.47.0
* [`646b0206`](https://github.com/NixOS/nixpkgs/commit/646b020606a696742569b58dc652e0003fbc7836) pluto: 5.12.0 -> 5.13.3
* [`2dd58d64`](https://github.com/NixOS/nixpkgs/commit/2dd58d648775b7efb1b5d09ca47fa61a1250a92c) flatpak: 1.14.1 → 1.14.2
* [`01de4144`](https://github.com/NixOS/nixpkgs/commit/01de41442640c3affb3803f7be43ee19b519a39d) syncthing-discovery: 1.23.0 -> 1.23.1
* [`d0041050`](https://github.com/NixOS/nixpkgs/commit/d004105003d6336b0b0afcecf2210e866c029245) nixos-render-docs: print exception trees by __cause__
* [`ad2b150a`](https://github.com/NixOS/nixpkgs/commit/ad2b150af78f260f9b1caee0f4d3d877af78c121) nixos-render-docs: use Mapping for options converter
* [`d30da4d9`](https://github.com/NixOS/nixpkgs/commit/d30da4d9cd20f18b08d51fc28b20b4bbd2aa2a64) nixos-render-docs: add support for <part>
* [`9977f997`](https://github.com/NixOS/nixpkgs/commit/9977f997400309871a82fcb4b6255b3bdd8dbc41) nixos/manual: inline man-configuration.xml
* [`ef413e3e`](https://github.com/NixOS/nixpkgs/commit/ef413e3eac947507ae1dc62dc365d225c30f4bbf) nixos/manual: split manpages-combined from manual-combined
* [`8b7f0e55`](https://github.com/NixOS/nixpkgs/commit/8b7f0e559ad9419815d0a4c8d231e2bf464c0ad2) nixos/manual: clean up default.nix a bit
* [`76a47699`](https://github.com/NixOS/nixpkgs/commit/76a476994ca61153399ad1675fdeb714daf4b2d6) python310Packages.pefile: add changelog to meta
* [`989dfc7c`](https://github.com/NixOS/nixpkgs/commit/989dfc7c2eef1c5e962dba4345fe2938e42e1d58) python310Packages.pefile: 2022.5.30 -> 2023.2.7
* [`80bce711`](https://github.com/NixOS/nixpkgs/commit/80bce711c372b85ba1f1f75ae110ed3b1d1cf280) wxGTK32: 3.2.1 -> 3.2.2
* [`56a249d3`](https://github.com/NixOS/nixpkgs/commit/56a249d31f3bf0276681ccbb295144063b469e2e) python310Packages.limnoria: 2023.1.12 -> 2023.1.28
* [`1229e735`](https://github.com/NixOS/nixpkgs/commit/1229e735ac51dbe79724f7648655a2089c9c67b9) nixos-render-docs: add structural includes, use for manual
* [`f9c43e87`](https://github.com/NixOS/nixpkgs/commit/f9c43e87acb3f2c724ceab1dffbcbb04e47b6f80) python310Packages.ciscoconfparse: add changelog to meta
* [`9a1e9d42`](https://github.com/NixOS/nixpkgs/commit/9a1e9d423afea66e56f6c0d011ea07e8b33c3a7f) python310Packages.deprecat: init at 2.1.1
* [`2db8ff4f`](https://github.com/NixOS/nixpkgs/commit/2db8ff4f424abf54ecf6f74896a59736c414adb9) python310Packages.ciscoconfparse: 1.6.50 -> 1.7.15
* [`25e334fc`](https://github.com/NixOS/nixpkgs/commit/25e334fc0430a1cec8acb5385ebcfef233362b91) python310Packages.primer3: 0.6.1 -> 1.0.0
* [`b5ace1ff`](https://github.com/NixOS/nixpkgs/commit/b5ace1ffc029c4fea5ab2344c0a77e459b3df4ed) furnace, tvheadend: more fallout from gcc upgrade
* [`bfc6975c`](https://github.com/NixOS/nixpkgs/commit/bfc6975cbc399cac0719b9305a8ac0fedb957aca) nixos/manual: remove holdovers from docbook times
* [`d381e51f`](https://github.com/NixOS/nixpkgs/commit/d381e51fb567e23039f17fdf28576dd6b341911d) binutils: try to move headers around only when --host/--target differ ([nixos/nixpkgs⁠#215989](https://togithub.com/nixos/nixpkgs/issues/215989))
* [`65e774e2`](https://github.com/NixOS/nixpkgs/commit/65e774e2a4002b762aa576ba1d0f0ed71298c86d) agda: fix passthru
* [`57145917`](https://github.com/NixOS/nixpkgs/commit/571459175404aa43de4db2c6d9049204700b957f) ddrescue: 1.26 -> 1.27
* [`af9ab543`](https://github.com/NixOS/nixpkgs/commit/af9ab54357371cde8ce7afd458738dfb4e401731) evolution: 3.46.3 → 3.46.4
* [`549d7f90`](https://github.com/NixOS/nixpkgs/commit/549d7f905ecda05d3dbb6765e77f490c83be140a) evolution-data-server: 3.46.3 → 3.46.4
* [`1543d46a`](https://github.com/NixOS/nixpkgs/commit/1543d46a89571e41d377f35c1bd74288a0581d81) evolution-ews: 3.46.3 → 3.46.4
* [`b75c6c70`](https://github.com/NixOS/nixpkgs/commit/b75c6c70bdca991cd0c4f4a700899bd9b2480bc7) gnome.gnome-software: 43.3 → 43.4
* [`d0fa8c16`](https://github.com/NixOS/nixpkgs/commit/d0fa8c16b69f35a4e7d8e246681747a9f25dccaa) pico-sdk: 1.4.0 -> 1.5.0
* [`542c88f8`](https://github.com/NixOS/nixpkgs/commit/542c88f871e7a443aaf32dea6ecbb21c5493d127) graalvm*-ce: remove old sources file
* [`c181fb98`](https://github.com/NixOS/nixpkgs/commit/c181fb980739d08d5ceceaef78ecb2d3303eacde) picotool: 1.1.0 -> 1.1.1
* [`dd363844`](https://github.com/NixOS/nixpkgs/commit/dd363844d277284af4e64d58a52dd702419b2329) picotool: remove installPhase
* [`b83f032f`](https://github.com/NixOS/nixpkgs/commit/b83f032ffcbc6b1b9f412d50b7a6ba3cfe471d0a) gcc/11: apply upstream fix 103910 so openjdk builds
* [`07942cdb`](https://github.com/NixOS/nixpkgs/commit/07942cdbdf40df390eb29ddf3f8f0264deb9623e) setup-hooks/reproducible-builds.sh: NIX_OUTPATH_USED_AS_RANDOM_SEED
* [`359896bd`](https://github.com/NixOS/nixpkgs/commit/359896bd1bcab22e14f8e26c098831c8844a8d4f) ipset: 7.15 -> 7.17
* [`a81a9cbf`](https://github.com/NixOS/nixpkgs/commit/a81a9cbf1226039ab9dc5d410be36a415cd4fbe7) openconnect: disable useDefaultExternalBrowser when cross
* [`ddbc1eb4`](https://github.com/NixOS/nixpkgs/commit/ddbc1eb4c2021ab0ffe49dfdeb371f7aa1149bcf) darkman: 1.4.0 -> 1.5.4
* [`21f8a7ca`](https://github.com/NixOS/nixpkgs/commit/21f8a7ca845533d8be50d877de768f72067822a3) mutt: assert relations between configuration options
* [`771e7050`](https://github.com/NixOS/nixpkgs/commit/771e70507bb0df402049fc39955da0985e7e8c49) prowlarr: 1.1.3.2521 -> 1.2.0.2583
* [`15f0d4cc`](https://github.com/NixOS/nixpkgs/commit/15f0d4ccd57e88ccadbaa92582f23c25e81fa9e1) ethtool: apply upstream diff to fix build on musl ([nixos/nixpkgs⁠#216011](https://togithub.com/nixos/nixpkgs/issues/216011))
* [`d2e047f1`](https://github.com/NixOS/nixpkgs/commit/d2e047f112b459dc2ded9923c388370c893520ae) graalvm-ce: add it to all-packages pointing to graalvm11-ce
* [`a2dc4ed8`](https://github.com/NixOS/nixpkgs/commit/a2dc4ed8dbc8608b012baacbe574dec6e6cb88b5) linkerd_edge: 23.1.2 -> 23.2.1
* [`3c881d48`](https://github.com/NixOS/nixpkgs/commit/3c881d4887a5ebcedb9441215f290106605b1ad7) sway: 1.8 -> 1.8.1
* [`f24ea245`](https://github.com/NixOS/nixpkgs/commit/f24ea2456e6db912d0bb9a09f3db5fb3b80afe62) jpegoptim: 1.5.1 -> 1.5.2
* [`d2128e82`](https://github.com/NixOS/nixpkgs/commit/d2128e82eeb1ace7c424a86e035ac9b1ad8451f2) repro-get: 0.2.1 -> 0.3.0
* [`596ef34e`](https://github.com/NixOS/nixpkgs/commit/596ef34e284f6df07c9647c106584469bc7cb9dd) jbang: 0.102.0 -> 0.103.0
* [`d1dd7f8a`](https://github.com/NixOS/nixpkgs/commit/d1dd7f8a8de510c5d67964b8fd67975dc2627579) hilbish: 2.0.1 -> 2.1.0
* [`6ab66c74`](https://github.com/NixOS/nixpkgs/commit/6ab66c744ffaf54951a2054f20501fc312a8d02e) imagemagick: 7.1.0-61 -> 7.1.0-62
* [`db348eb0`](https://github.com/NixOS/nixpkgs/commit/db348eb0d638ff0297411132061de10cc9ad43bf) inormalize/minc-widgets/gimp-plugins: use pname & version
* [`31ec341b`](https://github.com/NixOS/nixpkgs/commit/31ec341b3c51bfc17ced17f80cc2e837cf82a4b7) vimPlugins: update
* [`667b12fb`](https://github.com/NixOS/nixpkgs/commit/667b12fbcdc99ae44d077b455bede7a3450b6fa2) vimPlugins.telescope-undo-nvim: init at 2023-01-29
* [`d9cebc9d`](https://github.com/NixOS/nixpkgs/commit/d9cebc9d9ed50460158a9ed046974308fd24b0b1) vimPlugins.nvim-treesitter: update grammars
* [`b792e544`](https://github.com/NixOS/nixpkgs/commit/b792e5449534d8e706497af4bfe94b353de6b9a8) vimPlugins.vim-clap: fix cargoSha256
* [`a003cf03`](https://github.com/NixOS/nixpkgs/commit/a003cf0367cdb460a76316802f3fa1d9c4d1f248) haskellPackages.persistent-sqlite: disable tests
* [`cb32d702`](https://github.com/NixOS/nixpkgs/commit/cb32d70250e9ab6fafca08023389c6f9b9e65864) python310Packages.rapt-ble: init at 0.1.0
* [`da915b8b`](https://github.com/NixOS/nixpkgs/commit/da915b8bdc574ba241725e0884ef7734973abcb6) iosevka-bin: 18.0.0 -> 19.0.0
* [`1280a27b`](https://github.com/NixOS/nixpkgs/commit/1280a27bbd5d48a6b3b015ef5ad1d229f41faa12) python3.pkgs.lightning: drop
* [`fe5d8a3f`](https://github.com/NixOS/nixpkgs/commit/fe5d8a3fb7fa154f85a6a5b593741da1a6d3c44b) structorizer: init at 3.32-11
* [`5ba7fac7`](https://github.com/NixOS/nixpkgs/commit/5ba7fac716ba49bf41b154e7d15a9e10fc0ab007) burpsuite: 2022.12.7 -> 2023.1.2
* [`08834266`](https://github.com/NixOS/nixpkgs/commit/08834266e1f49e824a2057f1c7b6eb06d8409a68) opencryptoki: 3.8.2 -> 3.19.0
* [`5af91852`](https://github.com/NixOS/nixpkgs/commit/5af91852b822d5129bd98276c0bf52d93587548f) xray: 1.7.2 -> 1.7.5
* [`352b7c0a`](https://github.com/NixOS/nixpkgs/commit/352b7c0a1485a8e43996397d3547d13ae27e956f) httm: 0.20.5 -> 0.21.0
* [`2aa0edd9`](https://github.com/NixOS/nixpkgs/commit/2aa0edd9ca295d3043ad663382d47a4b5fdf2e6e) httm: 0.21.0 -> 0.21.1
* [`d9cf62f0`](https://github.com/NixOS/nixpkgs/commit/d9cf62f01235ebb2af046eaaff786f64e5f82685) wgpu-utils: 0.15.0 -> 0.15.1
* [`3953ad2e`](https://github.com/NixOS/nixpkgs/commit/3953ad2e6b668b25c2f56ba739c5fb9e314e993a) python3Packages.screed: init at 1.1.1
* [`105c76e7`](https://github.com/NixOS/nixpkgs/commit/105c76e711cbdbf5f615ce37f702cb37228f3bc1) maintainers: add luizirber
* [`0620523d`](https://github.com/NixOS/nixpkgs/commit/0620523d943c60528e7a9ffbc0e5e9cfe868ffda) vsmtp: 2.1.0 -> 2.1.1
* [`4dfbbc07`](https://github.com/NixOS/nixpkgs/commit/4dfbbc07f592e78039d5f51fc3ca668d3dc127cc) example-robot-data: 4.0.3 -> 4.0.4
* [`bf9ab610`](https://github.com/NixOS/nixpkgs/commit/bf9ab6107e996c7937965244189ff849735de90a) python311.pkgs.nipy: fix build
* [`961892a0`](https://github.com/NixOS/nixpkgs/commit/961892a085caa26beaf5e571433dc3a934b69718) recoll: wrap some input handlers with extra deps
* [`df71f8b2`](https://github.com/NixOS/nixpkgs/commit/df71f8b2a8a8a22a5fca52fc14d95c648781f79f) kanata: 1.1.0 -> 1.2.0
* [`51b444c7`](https://github.com/NixOS/nixpkgs/commit/51b444c7c9b80be13473eaa45ddd7dd22703a392) git-trim: fix build on darwin
* [`ceab3fb5`](https://github.com/NixOS/nixpkgs/commit/ceab3fb5f4ae430845e93c457b5353dc8b019e2b) noti: 3.6.0 -> 3.7.0
* [`af90082c`](https://github.com/NixOS/nixpkgs/commit/af90082c6130624f0c2e45d602e40f47bb445396) esbuild: 0.17.7 -> 0.17.8
* [`b5538baf`](https://github.com/NixOS/nixpkgs/commit/b5538baf6e471b4b9a8c6a51dfe3f3e1659dfc05) clhep: 2.4.6.3 -> 2.4.6.4
* [`d05b9499`](https://github.com/NixOS/nixpkgs/commit/d05b9499061d16245aae6693a7d66cbf93459bc5) python310Packages.awswrangler: don't use SPARQLWrapper alias
* [`080f42af`](https://github.com/NixOS/nixpkgs/commit/080f42af5cf79c6a9446642565c79ee48f530d0c) python310Packages.google-cloud-container: 2.17.2 -> 2.17.3
* [`8cb1591b`](https://github.com/NixOS/nixpkgs/commit/8cb1591beab1e4b95a089ffc6f7d74ef761bd724) python310Packages.ansible-doctor: 1.4.8 -> 2.0.0
* [`0d48da7e`](https://github.com/NixOS/nixpkgs/commit/0d48da7e29148184fcb8372a1fd76a92d08ebd06) python310Packages.vowpalwabbit: 9.6.0 -> 9.7.0
* [`1995db3b`](https://github.com/NixOS/nixpkgs/commit/1995db3be345620685d143fe378b62d430fcd5cf) rocm-device-libs: 5.4.2 -> 5.4.3
* [`9435a8f4`](https://github.com/NixOS/nixpkgs/commit/9435a8f48e37ea494b01330c3443f77a66bdc5e5) ocaml-top: 1.2.0-rc → 1.2.0
* [`d4b39b85`](https://github.com/NixOS/nixpkgs/commit/d4b39b856994ce05e657d5f7a3e48c83c0754f78) python310Packages.uhi: init at 0.3.3
* [`0fe08544`](https://github.com/NixOS/nixpkgs/commit/0fe08544fc548ddf922004e9268c9cc389939857) python310Packages.histoprint: init at 2.4.0
* [`e939aafb`](https://github.com/NixOS/nixpkgs/commit/e939aafb986d8e8c996e0b049ffdd3f69a9c24f1) python310Packages.hist: init at 2.6.3
* [`e8b67bd8`](https://github.com/NixOS/nixpkgs/commit/e8b67bd87cbbefebda0cee68728c67da0fe91b6c) sapling: 0.2.20221222-152408-ha6a66d09 -> 0.2.20230124-180750-hf8cd450a
* [`be4000d5`](https://github.com/NixOS/nixpkgs/commit/be4000d572ea9d384d9b705242298779fe6fb9ef) python310Packages.python-utils: 3.4.5 -> 3.5.2
* [`a9898979`](https://github.com/NixOS/nixpkgs/commit/a9898979dde654944719267cef74b1aa7777147f) python310Packages.python-utils: fix build on darwin
* [`04b686d4`](https://github.com/NixOS/nixpkgs/commit/04b686d4d61ad45146212818601763a931d572da) python310Packages.holoviews: 1.15.3 -> 1.15.4
* [`f0a6595f`](https://github.com/NixOS/nixpkgs/commit/f0a6595fe5bebfa033c0fc1fc91d85d5f5f5c2cd) k3s: add passthru.tests to all derivations
* [`6e9ce51d`](https://github.com/NixOS/nixpkgs/commit/6e9ce51dcea5bc070ef9f42aad3ef638c88d1877) vscode-extensions.eamodio.gitlens: 2022.12.604 -> 2023.2.1204
* [`48293adf`](https://github.com/NixOS/nixpkgs/commit/48293adfc53a1cb59ae854844d2847353f3c40dd) python310Packages.moat-ble: add changelog to meta
* [`822f076d`](https://github.com/NixOS/nixpkgs/commit/822f076daf05d4070b3ac7cb85b88e6e77b8a2bf) python310Packages.kegtron-ble: add changelog to meta
* [`12343b9c`](https://github.com/NixOS/nixpkgs/commit/12343b9cae3e709645f9c32c9d1e82d0c245157f) python310Packages.qingping-ble: add changelog to meta
* [`e07fc2f4`](https://github.com/NixOS/nixpkgs/commit/e07fc2f4eb41ada4d228f17fcd2d8b4552572a37) python310Packages.thermopro-ble: add changelog to meta
* [`b5cdf350`](https://github.com/NixOS/nixpkgs/commit/b5cdf35097603c6c82552bfce3b017b1d934301a) python310Packages.led-ble: add changelog to meta
* [`8867f889`](https://github.com/NixOS/nixpkgs/commit/8867f889a36a41c755aa72bd5e36bede6a590798) python310Packages.pc-ble-driver-py: add changelog to meta
* [`9ed5745d`](https://github.com/NixOS/nixpkgs/commit/9ed5745d1250276ccd1fe681022bac36c2aaf521) python310Packages.inkbird-ble: add changelog to meta
* [`8377d07b`](https://github.com/NixOS/nixpkgs/commit/8377d07b258f8e81b6b884a088e47842c57812c1) python310Packages.ibeacon-ble: add changelog to meta
* [`5ee9d70e`](https://github.com/NixOS/nixpkgs/commit/5ee9d70e01ddca7bcfbf8a1179f7e5d1a3390671) python310Packages.atc-ble: add changelog to meta
* [`92c27f38`](https://github.com/NixOS/nixpkgs/commit/92c27f38dc1e2b1e0ae1a3fa8f88913ab085a81e) python310Packages.sensorpro-ble: update rev
* [`106785ff`](https://github.com/NixOS/nixpkgs/commit/106785ff1c3fe493f77f3e373e021169438f2516) python310Packages.airthings-ble: add changelog to meta
* [`fdbf633c`](https://github.com/NixOS/nixpkgs/commit/fdbf633c4851ed0750ec54dedcb0b3be2639c31f) python310Packages.rapt-ble: add changelog to meta
* [`a1e6a37f`](https://github.com/NixOS/nixpkgs/commit/a1e6a37fcd472c9356cfa1c21d3b027375c1f64a) regextester: 1.0.1 -> 1.1.1
* [`49a06c00`](https://github.com/NixOS/nixpkgs/commit/49a06c00057ca9db11f0f5ab524db88f836481bf) python310Packages.check-manifest: add changelog to meta
* [`67a00c20`](https://github.com/NixOS/nixpkgs/commit/67a00c202463acfef373b9a22d4e65a7174290ab) python310Packages.check-manifest: 0.48 -> 0.49
* [`3f794e72`](https://github.com/NixOS/nixpkgs/commit/3f794e72d1a0ae5772119bc25b890f2068a326f3) prometheus-artifactory-exporter: 1.11.0 -> 1.12.0
* [`c4a8d973`](https://github.com/NixOS/nixpkgs/commit/c4a8d9735c490f5e06111fc7844982338615c86e) maintainers: Update email for Zimmi48
* [`87cb243d`](https://github.com/NixOS/nixpkgs/commit/87cb243dcb74cdb27e1d52023d3b2b3e338834ae) python3Packages.python-mpv-jsonipc: 1.1.11 -> 1.1.14
* [`b84ac254`](https://github.com/NixOS/nixpkgs/commit/b84ac25469743d433553d2037b9c60759b4f1c43) jellyfin-mpv-shim: 2.2.0 -> 2.3.1
* [`0fb0adfe`](https://github.com/NixOS/nixpkgs/commit/0fb0adfe7b5f7ab124a09343736ff70c4e0518cf) enc: init at 1.1.0
* [`607a2f9e`](https://github.com/NixOS/nixpkgs/commit/607a2f9e420453889695628dfb4e89c54929648f) sunpaper: 2022-04-01 -> 2.0
* [`60838304`](https://github.com/NixOS/nixpkgs/commit/60838304dd8fc5c99995b7ef2488a738ef477189) signald: 0.23.0 -> 0.23.2
* [`832acbd7`](https://github.com/NixOS/nixpkgs/commit/832acbd7434c69b6c602251240d61b6a754ba17e) python311.pkgs.validobj: disable
* [`eed13265`](https://github.com/NixOS/nixpkgs/commit/eed132659295ddc06e81305f1644ecd68bab2ed1) tree-sitter: fix src value
* [`116872ae`](https://github.com/NixOS/nixpkgs/commit/116872aedda426b0bd1633e3e9c9328fea5e7351) nixos/gitlab-runner: fix shell syntax preventing build
* [`5596aefd`](https://github.com/NixOS/nixpkgs/commit/5596aefd05f97183bcca7c3d053b084a048e85dd) ferretdb: 0.9.0 -> 0.9.1
* [`afbdf8c5`](https://github.com/NixOS/nixpkgs/commit/afbdf8c54d71c819f5e7f61cf3cdd492be2dcbdf) cosmoc: drop
* [`e9be28eb`](https://github.com/NixOS/nixpkgs/commit/e9be28ebacfd89a9123d3cc716493fd73479790e) cosmocc: init at 2.2
* [`f60c069a`](https://github.com/NixOS/nixpkgs/commit/f60c069a2b56d1e088d54f752cd1c681a5962eaa) jellyfin-media-player: 1.7.1 -> 1.8.1
* [`58ad16c2`](https://github.com/NixOS/nixpkgs/commit/58ad16c22e30209fdc292a3fcc5e5459e290b250) libreddit: 0.29.1 -> 0.29.2
* [`5414b4fc`](https://github.com/NixOS/nixpkgs/commit/5414b4fcd2fab250aeff5723bd302422329b5693) uptime-kuma: 1.19.6 -> 1.20.0
* [`b2747781`](https://github.com/NixOS/nixpkgs/commit/b274778192ef2d21da3ff281d773fa5908a20dbc) haruna: 0.10.2 -> 0.10.3
* [`d990d1ea`](https://github.com/NixOS/nixpkgs/commit/d990d1ea881a3cf1226ab4dbbf612bc7a01c9c79) python311.pkgs.collections-extended: disable
* [`3dfbe2b6`](https://github.com/NixOS/nixpkgs/commit/3dfbe2b6a31b01f9bb4ab6e1a84c6ebf505dddfd) maintainers/haskell/test-configurations.nix: support ghcHEAD
* [`e2d5eeee`](https://github.com/NixOS/nixpkgs/commit/e2d5eeeee0aa5159db1afdb7ef8d13fea2e9f703) maintainers: add CardboardTurkey
* [`8c9a8fa6`](https://github.com/NixOS/nixpkgs/commit/8c9a8fa6e37b7f4c941362a9190ba251d712788c) torq: copy frontend instead of linking
* [`bb62992d`](https://github.com/NixOS/nixpkgs/commit/bb62992d4e3a50d590c27c8bbdc480b63b35f20a) torq: 0.17.3 -> 0.18.17
* [`3af4729a`](https://github.com/NixOS/nixpkgs/commit/3af4729a3291de4f35df7af986f8a4fc52589f8f) python3.pkgs.certomancer: 0.8.2 -> 0.9.1
* [`9bbface3`](https://github.com/NixOS/nixpkgs/commit/9bbface354c0c7e387f26966a0d38e6985313844) maintainers: add garaiza-93
* [`432c3ab5`](https://github.com/NixOS/nixpkgs/commit/432c3ab524b1b31b392f176a75b85da3f86ff5ca) haskellPackages.persistent-postgresql: disable broken tests
* [`a098dc81`](https://github.com/NixOS/nixpkgs/commit/a098dc81ae2107a7c911783c65bca9de8cbe08ce) helvum: 0.3.4 -> 0.4.0
* [`a9237c3a`](https://github.com/NixOS/nixpkgs/commit/a9237c3a605ff641fe7986d1c00b5faf87324f7d) Revert "irr1: add meta.changelog"
* [`78aa32e7`](https://github.com/NixOS/nixpkgs/commit/78aa32e76e2e7e1c15a2353d9df0f62360a33781) Revert "dosbox-staging: add meta.changelog"
* [`4f7c02e8`](https://github.com/NixOS/nixpkgs/commit/4f7c02e890f8c04f734220801797ef5cdfa75161) haskellPackages.sensei: use fsnotify 0.4 and tame hspec-contrib
* [`75cdc109`](https://github.com/NixOS/nixpkgs/commit/75cdc109f0462ec83af02cb8c458a239dcb8f5db) haskellPackages.ghc: 9.2.4 -> 9.2.6
* [`8e27e6d8`](https://github.com/NixOS/nixpkgs/commit/8e27e6d83f690511ba6fcc88e922c5f2ee9a64da) kluctl: 2.18.4 -> 2.19.0
* [`c23273af`](https://github.com/NixOS/nixpkgs/commit/c23273af54eecd78f5edf758e6ea401e839c844b) lua-language-server: 3.6.10 -> 3.6.11
* [`e13d49d6`](https://github.com/NixOS/nixpkgs/commit/e13d49d686aaa6a582c8b8c76fa1b3032d80c83e) wgo: init at 0.5.1
* [`205293d8`](https://github.com/NixOS/nixpkgs/commit/205293d8a97e10576119f1424e87382ab82c888c) hidapi: Add `meta.pkgConfigModules` and test
* [`dc327861`](https://github.com/NixOS/nixpkgs/commit/dc3278615ec0cf70bc0e6c42e01a88130f5500f9) imlib2: Add `meta.pkgConfigModules` and test
* [`c733f0bf`](https://github.com/NixOS/nixpkgs/commit/c733f0bf8ad39186b9d14d4fb4d0bc1394b93940) jack: Add `meta.pkgConfigModules` and test
* [`b7e9a15a`](https://github.com/NixOS/nixpkgs/commit/b7e9a15ab9eaf13cc2b39879ab741c7ac6104d80) webkitgtk: Add `meta.pkgConfigModules` and test
* [`3f8b1578`](https://github.com/NixOS/nixpkgs/commit/3f8b15788f73b33ca1d08cd3a4e6eca8f8a9e283) liblapack: Add `meta.pkgConfigModules` and test
* [`ee2fd1e5`](https://github.com/NixOS/nixpkgs/commit/ee2fd1e5108433cc5bba3d0bc9d7667ed1346014) R: Add `meta.pkgConfigModules` and test
* [`79631365`](https://github.com/NixOS/nixpkgs/commit/796313656cd9b5e2d0915f89f41c129d3f58f193) ffmpeg: Add `meta.pkgConfigModules` and test
* [`bbed2700`](https://github.com/NixOS/nixpkgs/commit/bbed27008402bb2331e45edaac8a9d7830399ced) libb2: Add `meta.pkgConfigModules` and test
* [`d488c432`](https://github.com/NixOS/nixpkgs/commit/d488c432fb8dec5b5eaa264bd20e735313bfdf1c) brotli: Add `meta.pkgConfigModules` and test
* [`d0e78671`](https://github.com/NixOS/nixpkgs/commit/d0e7867130f192a17c63d93ee47dc1e5d077d781) openssl: Add `meta.pkgConfigModules` and test
* [`fd34bbb0`](https://github.com/NixOS/nixpkgs/commit/fd34bbb0adccf16d34d4b758ac5868cb2f43f2e3) icu: Add `meta.pkgConfigModules` and test
* [`a554e68a`](https://github.com/NixOS/nixpkgs/commit/a554e68a1cabed627ffd3e31b1e89fc0d7c94295) hoard: 1.3.0 -> 1.3.1
* [`4ec05165`](https://github.com/NixOS/nixpkgs/commit/4ec05165a3afb988fc82aadd017fd2539e96e1a4) wxGTK32: 3.2.2 -> 3.2.2.1
* [`98380ca5`](https://github.com/NixOS/nixpkgs/commit/98380ca5d12ea8b2b63060b839031675b1e436d5) mdbook-katex: 0.3.7 -> 0.3.8
* [`c1cf9a0f`](https://github.com/NixOS/nixpkgs/commit/c1cf9a0fe63637dbe9b4c65896feb140079c05aa) python310Packages.aioesphomeapi: 13.2.0 -> 13.3.1
* [`a3526481`](https://github.com/NixOS/nixpkgs/commit/a3526481a6617daa2fb38a7285a2356ea66d3260) python310Packages.oralb-ble: 0.17.4 -> 0.17.5
* [`18a3b21d`](https://github.com/NixOS/nixpkgs/commit/18a3b21de225ac26ec1beed1fbd8fcefcc956923) python310Packages.xiaomi-ble: 0.16.1 -> 0.16.3
* [`22b11b3b`](https://github.com/NixOS/nixpkgs/commit/22b11b3bb82810fd58f6347cd18757f95c0f332c) python310Packages.yalexs-ble: 1.12.8 -> 1.12.12
* [`b421e2a0`](https://github.com/NixOS/nixpkgs/commit/b421e2a0a3998939d9cdba2f791a253a2f10a570) home-assistant: 2023.2.3 -> 2023.2.4
* [`1069dbc6`](https://github.com/NixOS/nixpkgs/commit/1069dbc604de80eccfdd2f19b3ecc7e6311b45bc) python310Packages.raincloudy: Fix build
* [`032b2cf7`](https://github.com/NixOS/nixpkgs/commit/032b2cf74af9098f60c23ca2154209d1782bb91b) python3.pkgs.quantiphy: 2.18 -> 2.19
* [`70fb5ec4`](https://github.com/NixOS/nixpkgs/commit/70fb5ec4cb8c5acac048cec7a593830b2feb6b75) python310Packages.aio-geojson-generic-client: drop asynctest
* [`475b5144`](https://github.com/NixOS/nixpkgs/commit/475b5144fb374454b07c483dc7b05686102561fe) maintainers: Fix github account names/ids
* [`a6318970`](https://github.com/NixOS/nixpkgs/commit/a63189702073db9079b0db765253de92a1b232ce) python310Packages.aio-geojson-usgs-earthquakes: drop asynctest
* [`0eed8951`](https://github.com/NixOS/nixpkgs/commit/0eed8951acec06e303ddfcf5e8150d0483514d43) cargo-semver-checks: 0.17.1 -> 0.18.0
* [`35ea0592`](https://github.com/NixOS/nixpkgs/commit/35ea05920e449935c383deaa713987a895b89f38) whitesur-gtk-theme: 2022-10-27 -> 2023-02-07
* [`c73f3cf9`](https://github.com/NixOS/nixpkgs/commit/c73f3cf9276f742f4cd65aee51953553b4732838) xwayland: enable libunwind
* [`3b1f5860`](https://github.com/NixOS/nixpkgs/commit/3b1f5860ba4baed7b141c21f650de76deb7760fb) liburing: 2.2 -> 2.3
* [`a61f3328`](https://github.com/NixOS/nixpkgs/commit/a61f33281581ccd06b7a37ca1a5abde7b916e7c1) python311Packages.asyncio-dgram: disable failing test
* [`11867c6e`](https://github.com/NixOS/nixpkgs/commit/11867c6ee3a6833109d640ae77a6a78d7409a7ce) wordpressPackages.themes.geist: init 2.0.3
* [`85cdc2a7`](https://github.com/NixOS/nixpkgs/commit/85cdc2a7ff3d2583f2a0ceafd638b50a96007e8a) qdmr: fix eval with aliases disabled
* [`6965ac6c`](https://github.com/NixOS/nixpkgs/commit/6965ac6ccecb23e1120aad8fdb67fdcd89a0bc9f) rubyPackages.mail: init at 2.8.1
* [`e2357870`](https://github.com/NixOS/nixpkgs/commit/e23578703ad5d57bfa1c48db341348e5cdd25b1b) rubyPackages: update
* [`59db4617`](https://github.com/NixOS/nixpkgs/commit/59db4617e5bd17f73384bed7a6de199ea527f461) nix-index: 0.1.4 -> 0.1.5
* [`354bf3f2`](https://github.com/NixOS/nixpkgs/commit/354bf3f208d402857c75190afc67e1de516ddabc) pspg: 5.7.2 -> 5.7.3
* [`f3648fbd`](https://github.com/NixOS/nixpkgs/commit/f3648fbddfe3484b3c0db73163dc08c8954fa091) pspg: 5.7.3 -> 5.7.4
* [`7d13ae28`](https://github.com/NixOS/nixpkgs/commit/7d13ae285193734b10bfbf7ceec584da0bbc2345) pspg: install manpage
* [`6a26f81a`](https://github.com/NixOS/nixpkgs/commit/6a26f81ad761da8c95f462b50e87488b7454c8e8) mdbook-pdf: 0.1.4 -> 0.1.5
* [`c7ddec6e`](https://github.com/NixOS/nixpkgs/commit/c7ddec6e176d19ec2d6369806e6b42ef63606ce1) gopass: 1.15.3 → 1.15.4
* [`99b2bfa5`](https://github.com/NixOS/nixpkgs/commit/99b2bfa51d80ed8628709442725adc575237f01a) git-credential-gopass: 1.15.3 → 1.15.4
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
