### PR TITLE
niv devenv: update 3f845b2a -> 66b895f6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "3f845b2aff58d0ae27d9777500fe0c80b837ffb2",
-        "sha256": "01j15lfvrgjmsbv75cdsgam520r7xrr2dxq2gbwxnp7qqzmny13v",
+        "rev": "66b895f6643912b25ae4be359b3839f3b2aa794a",
+        "sha256": "0xzi1svzm8bw9hac2ixcxb228krfadqry2p44wqmvnd11g7m71ds",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/3f845b2aff58d0ae27d9777500fe0c80b837ffb2.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/66b895f6643912b25ae4be359b3839f3b2aa794a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@3f845b2a...66b895f6](https://github.com/cachix/devenv/compare/3f845b2aff58d0ae27d9777500fe0c80b837ffb2...66b895f6643912b25ae4be359b3839f3b2aa794a)

* [`a69e33c3`](https://github.com/cachix/devenv/commit/a69e33c3913b2f00c6aab0e1a24ee6f098421eb2) Init Cassandra service
* [`66c44908`](https://github.com/cachix/devenv/commit/66c44908d1fc12d0c64661a2ff777f89a415b3ee) Do not create JVM_OPTS as a global env var
* [`77ee22cd`](https://github.com/cachix/devenv/commit/77ee22cd6af600915d8b49ba25b27db3ad1dddce) add ability to define assertions
* [`584d63e9`](https://github.com/cachix/devenv/commit/584d63e93a841148f75b3b9ec2cfed2ed08c760f) Add a Matrix room
* [`3226fac0`](https://github.com/cachix/devenv/commit/3226fac08e17d0c0956fa54e4d75ef0c70cfcfeb) Get Cassandra 3.x working
* [`a2d15ebe`](https://github.com/cachix/devenv/commit/a2d15ebec595a8d2975dcfffd7d22438acfd0efa) fixes [cachix/devenv⁠#409](https://togithub.com/cachix/devenv/issues/409)
* [`1d4617ce`](https://github.com/cachix/devenv/commit/1d4617cef98d9526817dd006630d08acfcf2d6a4) bump nix and improve gc command output
* [`cfadf774`](https://github.com/cachix/devenv/commit/cfadf774c937c642fcc61f391808a00ebe60222b) Auto generate docs/reference/options.md
* [`be05d19c`](https://github.com/cachix/devenv/commit/be05d19cdca75518f34c7bdfbc029f2eb7c931de) Default to Cassandra 4
* [`e0ea1237`](https://github.com/cachix/devenv/commit/e0ea12378e302af0cc6f69b395d3d9943aaf3416) bump install-nix-action
* [`866b156b`](https://github.com/cachix/devenv/commit/866b156b10a7bb6ff8006c63ee09963e2a5f0bcf) Fix python install
* [`532f581a`](https://github.com/cachix/devenv/commit/532f581a29590f785a6561525154c4789aefc0cb) Auto generate docs/reference/options.md
* [`5d2e75a6`](https://github.com/cachix/devenv/commit/5d2e75a6e7c4d117c1674ca6c518939728255aed) ruby: assert version and versionFile not both set at once
* [`b91a1157`](https://github.com/cachix/devenv/commit/b91a1157158a46fa7b33b195a1582b46446a9028) assertions: format multiline messages with indentation
* [`46cc0daa`](https://github.com/cachix/devenv/commit/46cc0daa0fd4f67a361d426ea8e235944641b61f) fix: process-compose invokation (use values from config as defaults)
* [`057b1c01`](https://github.com/cachix/devenv/commit/057b1c019ae27a4cfd5eef37b88a7b20b8ba8bef) python: move venv and poetry scripts to separate files
* [`22adea33`](https://github.com/cachix/devenv/commit/22adea33daf57df14debc6cf6bc55b9db1ddfad5) python: rebuild venv when devenv-profile is updated
* [`9590d815`](https://github.com/cachix/devenv/commit/9590d815a059dfc1dc1a483ddcb21352e472e854) python: always refer to the poetry executable from devenv
* [`66b895f6`](https://github.com/cachix/devenv/commit/66b895f6643912b25ae4be359b3839f3b2aa794a) Auto generate docs/reference/options.md
