### PR TITLE
niv zsh-completions: update 86d55972 -> 4de5a8cc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "86d55972f5cb65d545389fe0306e617b68328982",
-        "sha256": "1whg0v2n37qab4rmh58pmzhi066ryd9y8s8pm703k01hbx2kj5w0",
+        "rev": "4de5a8cc6a5e4b9e2cea9afd7c0460aca874bac2",
+        "sha256": "1npqr7mkc4v7i2iic1qby9yfg3w4y0mxmf9imavhb3j0a6aqscm2",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/86d55972f5cb65d545389fe0306e617b68328982.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/4de5a8cc6a5e4b9e2cea9afd7c0460aca874bac2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@86d55972...4de5a8cc](https://github.com/zsh-users/zsh-completions/compare/86d55972f5cb65d545389fe0306e617b68328982...4de5a8cc6a5e4b9e2cea9afd7c0460aca874bac2)

* [`04a65a56`](https://github.com/zsh-users/zsh-completions/commit/04a65a56dea1a1ca943c41877cacc496375ed251) Implement 'flutter build target' completion
* [`7f2beb4f`](https://github.com/zsh-users/zsh-completions/commit/7f2beb4fd3d78dd506afdaf131abe040cc5147d8) Add neofetch
