### PR TITLE
niv nixpkgs: update 1f8ac70d -> a4dd572d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1f8ac70db85189f2e58bc93259ab06b703d393ea",
-        "sha256": "055khd7ypqp69h4959yys49mpxzw92j5k53zrf53hyq1k25xryn0",
+        "rev": "a4dd572de1b524c9d2187b815c85dd20a09b6f4a",
+        "sha256": "1zcaih61s4mcmk8z21sqd0d84b9cq7md9w0mb7pv5sg9c9nb8fwl",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/1f8ac70db85189f2e58bc93259ab06b703d393ea.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a4dd572de1b524c9d2187b815c85dd20a09b6f4a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@1f8ac70d...a4dd572d](https://github.com/nixos/nixpkgs/compare/1f8ac70db85189f2e58bc93259ab06b703d393ea...a4dd572de1b524c9d2187b815c85dd20a09b6f4a)

* [`ec952cb4`](https://github.com/NixOS/nixpkgs/commit/ec952cb4ba22e9d85543d7c1a3c7c9a73d08de32) jl: Use derivation from haskellPackages
* [`2c241721`](https://github.com/NixOS/nixpkgs/commit/2c241721b18af3d91b9d7a4a08a869758ccf8ae8) libshout: 2.4.5 -> 2.4.6
* [`17659bb4`](https://github.com/NixOS/nixpkgs/commit/17659bb4ccbdf2cc4d0f8a9d696478b1f4580c40) shadowsocks-v2ray-plugin: 1.3.1 -> 1.3.2
* [`663747d7`](https://github.com/NixOS/nixpkgs/commit/663747d701278493a856e04a8ae1a10aad6b5c44) tpm2-abrmd: 2.4.1 -> 3.0.0
* [`b43f5f88`](https://github.com/NixOS/nixpkgs/commit/b43f5f88dc3b3e0f12ce448b2e8add4cf5ed0a4e) mdbook-admonish: 1.7.0 -> 1.8.0
* [`d060289f`](https://github.com/NixOS/nixpkgs/commit/d060289faeed9d3a0f38545f1dab1ecc39e7deef) mdbook-admonish: add Frostman to maintainers
* [`9c14449a`](https://github.com/NixOS/nixpkgs/commit/9c14449a5b9c3f14a70413d5d1c3c639ea664677) maintainers: add cathalmullan
* [`b8a35e8f`](https://github.com/NixOS/nixpkgs/commit/b8a35e8f8b97a89016120bff81a47a8f530a213c) python3Packages.show-in-file-manager: init at 1.1.4
* [`f01831ad`](https://github.com/NixOS/nixpkgs/commit/f01831ad50beeeac8f8c0c814139da2ebce435bd) python3Packages.pyheif: init at 0.7.1
* [`494f5ba9`](https://github.com/NixOS/nixpkgs/commit/494f5ba9514658ebb36eb4ba461a4fb723ea94c3) quartz-wm: --enable-xplugin-dock-support
* [`0a55054b`](https://github.com/NixOS/nixpkgs/commit/0a55054b160a05fd2e50ed96b1abd701c4e9b194) xorg.xorgserver: 1.18.4 -> 1.20.14 on Darwin (still broken)
* [`32c3b698`](https://github.com/NixOS/nixpkgs/commit/32c3b6983b68e0f4c20c24ca6fa7aa2305493a39) neon: 0.32.3 -> 0.32.4
* [`632584f5`](https://github.com/NixOS/nixpkgs/commit/632584f5bd7a54c4b9fca4445fe42c5b57c43dbd) rbspy: 0.12.1 -> 0.15.0
* [`955bbec0`](https://github.com/NixOS/nixpkgs/commit/955bbec005a9a405bca543e40fdb321998d3ad59) mdbook-admonish: remove unused fetchpatch from inputs
* [`907fe256`](https://github.com/NixOS/nixpkgs/commit/907fe2560108568a53a7144989a1201bc2c798c0) libwps: 0.4.12 -> 0.4.13
* [`6abbc7f9`](https://github.com/NixOS/nixpkgs/commit/6abbc7f98edef876761089dbc6778efa07d9af8f) latex2html: 2022.2 -> 2023
* [`bff126ff`](https://github.com/NixOS/nixpkgs/commit/bff126ffbc49f1c1e08dc9c622081652a6a6e86d) stdenv.mkDerivation: Make overrideAttrs overridable
* [`22f8bde7`](https://github.com/NixOS/nixpkgs/commit/22f8bde78b21057da30afeecf805fc8a876c914b) python310Packages.qdldl: 0.1.5.post2 -> 0.1.5.post3
* [`bd333976`](https://github.com/NixOS/nixpkgs/commit/bd3339760712b546be4c1d79b17f4e1476debbb5) hdf5: 1.12.2 -> 1.14.0
* [`5b2f597b`](https://github.com/NixOS/nixpkgs/commit/5b2f597b116d56104d45c35587920323ed2a5666) lib.extendDerivation: Fix interaction between output selection and overrideAttrs
* [`b460751e`](https://github.com/NixOS/nixpkgs/commit/b460751e79a2a1591740a5debe02eebfee62c70e) python310Packages.portalocker: 2.6.0 -> 2.7.0
* [`b94fa2c2`](https://github.com/NixOS/nixpkgs/commit/b94fa2c25315d2086cb4c50716598ffa65363593) python-packages-base: use extends instead of //
* [`9c0ac569`](https://github.com/NixOS/nixpkgs/commit/9c0ac5691c5c8e8902fe5a93599b07e3f21464aa) tests.overriding: init
* [`6f28b212`](https://github.com/NixOS/nixpkgs/commit/6f28b21298b66c3cfc121c0ec0d97b3da2105581) python310Packages.xarray-einstats: 0.4.0 -> 0.5.1
* [`42fc3500`](https://github.com/NixOS/nixpkgs/commit/42fc350000b31d67ff4da14a8c5ac319310dd11b) libimagequant: 2.17.0 -> 4.1.0
* [`8c4cb4ae`](https://github.com/NixOS/nixpkgs/commit/8c4cb4ae3187593e84e6237f88030b2b0a656216) libimagequant: add pillow as reverse dependency to passthru.tests
* [`b4006657`](https://github.com/NixOS/nixpkgs/commit/b4006657621a3a1d9189334a06ebbdef74433b71) python3.pkgs.tensorflow-bin: 2.9.3 -> 2.11.0
* [`684b3ea2`](https://github.com/NixOS/nixpkgs/commit/684b3ea2478f71ee40b23c4be0be35af10f07aa5) rapid-photo-downloader: 0.9.18 -> 0.9.34
* [`525e514b`](https://github.com/NixOS/nixpkgs/commit/525e514bfb21884b9cae67ac91fa10d3f177d358) gitlab-pages: 1.62.0 -> 15.7.3
* [`7cbb0b70`](https://github.com/NixOS/nixpkgs/commit/7cbb0b7098e9edb761b91b2878274c56b5215c37) python310Packages.ujson: 5.6.0 -> 5.7.0
* [`9b0ba273`](https://github.com/NixOS/nixpkgs/commit/9b0ba273bfa4c2900bf0f4acea30eaa51c5c2f38) python310Packages.cryptography: 38.0.4 -> 39.0.0
* [`251d1f77`](https://github.com/NixOS/nixpkgs/commit/251d1f770923b12653f5da4f529867248ea9228e) rdkafka: 1.9.2 -> 2.0.2
* [`a0f4e874`](https://github.com/NixOS/nixpkgs/commit/a0f4e8746d15683d75e590b08334df7faf4c7621) tests.overriding: add repeatedOverrides-pname, repeatedOverrides-entangled-pname
* [`d4d75b86`](https://github.com/NixOS/nixpkgs/commit/d4d75b86d2d93be281501ea231d5662fcbba9cd7) yder: 1.4.17 -> 1.4.19
* [`c9ecfe7e`](https://github.com/NixOS/nixpkgs/commit/c9ecfe7edac67bf1989d3b86c0a3bf65628fe6ac) python310Packages.pycryptodome: 3.16.0 -> 3.17.0
* [`7039d66a`](https://github.com/NixOS/nixpkgs/commit/7039d66a59180c4d930341568bb6da3845d72380) hidapi: 0.12.0 -> 0.13.1
* [`ad068a81`](https://github.com/NixOS/nixpkgs/commit/ad068a815c9be0458b0364642667c3327fd4cd89) python3Packages.hidapi: 0.12.0.post2 -> 0.13.1
* [`6ee589b3`](https://github.com/NixOS/nixpkgs/commit/6ee589b39a90f7f301953281184b816ffddeb3af) libopenmpt: 0.6.6 -> 0.6.8
* [`4ccd49d2`](https://github.com/NixOS/nixpkgs/commit/4ccd49d249807696744c17f11b38a4d3224f0e3a) python310Packages.watchdog: 2.2.0 -> 2.2.1
* [`d9f45ec9`](https://github.com/NixOS/nixpkgs/commit/d9f45ec99e87647d72fef9af1fada62023cfc581) cmocka: enable tests and set broken for static
* [`6668f9ae`](https://github.com/NixOS/nixpkgs/commit/6668f9ae8cb13711c8ab441a65599ec589148fdc) moltenvk: 1.2.1 -> 1.2.2
* [`67751b27`](https://github.com/NixOS/nixpkgs/commit/67751b2737f37d97599ab31180484d5e05447119) qt5.wrapQtAppsHook: fix interaction with strictDeps
* [`7abd1449`](https://github.com/NixOS/nixpkgs/commit/7abd144913c65a637d3d17a700dd0fb5c422d136) treewide: update darwin sdk hashes
* [`b39c23d2`](https://github.com/NixOS/nixpkgs/commit/b39c23d283248eb5e668c7347ef752da3070645b) libde265: 1.0.10 -> 1.0.11
* [`5bbc0c88`](https://github.com/NixOS/nixpkgs/commit/5bbc0c88919ebe87b611c39ac1b2262e871c4ca5) python3Packages.pillow: 9.3.0 -> 9.4.0
* [`e0e87e36`](https://github.com/NixOS/nixpkgs/commit/e0e87e36c6b54096fedfaddf8af5e129429c221a) networkmanager: 1.40.6 → 1.40.12
* [`746e2b1f`](https://github.com/NixOS/nixpkgs/commit/746e2b1fc46c8fe5f58918518b228514133f570d) glib: 2.74.3 → 2.74.5
* [`ab1de37e`](https://github.com/NixOS/nixpkgs/commit/ab1de37ebc0950ae9713eb00b8ee689b9c0c3fad) libwacom: 2.4.0 -> 2.6.0
* [`bf928e55`](https://github.com/NixOS/nixpkgs/commit/bf928e557940be4e10042b1a82d9dcce1776f6ba) libinput: 1.21.0 → 1.22.1
* [`a1e8dfcd`](https://github.com/NixOS/nixpkgs/commit/a1e8dfcdf477f3458902a03019b12033437ec7e3) libmbim: 1.26.4 → 1.28.2
* [`4dbac40f`](https://github.com/NixOS/nixpkgs/commit/4dbac40f65f70f67bbe37346febfcb430e652098) musikcube: activate portaudio, pipewire, sndio, core audio plugins
* [`2f6d2e99`](https://github.com/NixOS/nixpkgs/commit/2f6d2e99866cb816f2b401596996021d20048bf9) musikcube: order dependencies A-Z
* [`57af6a6e`](https://github.com/NixOS/nixpkgs/commit/57af6a6e7d3a1a229dfe2e5ee7e5e59547b8e345) libqmi: 1.30.8 → 1.32.2
* [`233dac29`](https://github.com/NixOS/nixpkgs/commit/233dac2934f685e87e3f9a6480c3b66027c069b2) modemmanager: 1.18.12 → 1.20.4
* [`fa7a52b9`](https://github.com/NixOS/nixpkgs/commit/fa7a52b9a90fb03367d2a6395ebff988ddd8fd73) python3Packages.pyopenssl: 22.1.0 -> 23.0.0
* [`327876fb`](https://github.com/NixOS/nixpkgs/commit/327876fb7ae632a71b0c6d446944df78506f0043) xorg.xorgserver: remove 1.18 compat
* [`69b3d7ef`](https://github.com/NixOS/nixpkgs/commit/69b3d7ef23a4ba24353a11e4fea3ad18383aa0a4) python3.pkgs.typeguard: build offline documentation
* [`f08158b0`](https://github.com/NixOS/nixpkgs/commit/f08158b03d2406dbcd5454fedc70ea09ccbc7146) doxygen: 1.9.5 -> 1.9.6
* [`ab04f477`](https://github.com/NixOS/nixpkgs/commit/ab04f4777b5e0fca66e2ebd51cc23eb7848b8269) boost: add zstd and lzma support
* [`7673d2be`](https://github.com/NixOS/nixpkgs/commit/7673d2be9094aa528355d9add56d84fdb19ebdb5) gi-docgen: 2022.2 → 2023.1
* [`66482fad`](https://github.com/NixOS/nixpkgs/commit/66482fadd25555963f7d4170ac182bc43581521b) fscrypt-experimental: 0.3.3 -> 0.3.4
* [`2142bc8d`](https://github.com/NixOS/nixpkgs/commit/2142bc8d338fcaa05c739016349d1acce4f4c836) systemd: don't reference build bash
* [`1db24221`](https://github.com/NixOS/nixpkgs/commit/1db242213092dc1ba1038edbe0bb5660d0fb5e00) systemd: disallowedReferences nativeBuildInputs
* [`42a4f2fd`](https://github.com/NixOS/nixpkgs/commit/42a4f2fd0ae92e2e27a1b8902931cbd2e4b88f8c) ruby: fix default CC not beeing set
* [`c62f7d24`](https://github.com/NixOS/nixpkgs/commit/c62f7d24578eec4db720a35cab8afdd4f9b0e287) openjdk8: 352-ga -> 362-ga
* [`c1c6d732`](https://github.com/NixOS/nixpkgs/commit/c1c6d7325cd2263c4e926a478ca79a3df77f36f2) openjdk11: 11.0.17+8 -> 11.0.18+10
* [`61de80e4`](https://github.com/NixOS/nixpkgs/commit/61de80e49901ba60f1d3c4c587b17fb77964102c) openjfx11: 11.0.17+1 -> 11.0.18+1
* [`3daee4c5`](https://github.com/NixOS/nixpkgs/commit/3daee4c5ee3d115a8b1951d771272da4353f55d4) meson: cleanup after https://github.com/NixOS/nixpkgs/pull/214046
* [`9b65aebf`](https://github.com/NixOS/nixpkgs/commit/9b65aebff1b513614038e7da3f6ed1235905dd8a) python310Packages.types-toml: 0.10.8.1 -> 0.10.8.2
* [`42d51f71`](https://github.com/NixOS/nixpkgs/commit/42d51f710a0055ae3973faa308c68583fb0567d4) openjdk17: 17.0.5+8 -> 17.0.6+10
* [`a8c155e0`](https://github.com/NixOS/nixpkgs/commit/a8c155e0f66ec9f11df5e8331480274160b8feff) openjfx17: 17.0.5+1 -> 17.0.6+3
* [`c8003150`](https://github.com/NixOS/nixpkgs/commit/c80031505ee15c468449f8017ac3795672c40cf2) roc-toolkit: split output
* [`1c7f726a`](https://github.com/NixOS/nixpkgs/commit/1c7f726a653ae006f6b747e5e42f7f308baf8936) glslang: 1.3.236.0 -> 1.3.239.0
* [`88847203`](https://github.com/NixOS/nixpkgs/commit/88847203be34c9689b4574da8b632ae7e06bff76) spirv-headers: 1.3.236.0 -> 1.3.239.0
* [`29e6668a`](https://github.com/NixOS/nixpkgs/commit/29e6668a9f5b96485037de94c483791732ef45b2) vulkan-headers: 1.3.236.0 -> 1.3.239.0
* [`b4022291`](https://github.com/NixOS/nixpkgs/commit/b4022291777ffe3f207740f2bf4b862edb7f403b) vulkan-loader: 1.3.236.0 -> 1.3.239.0
* [`9102bfdd`](https://github.com/NixOS/nixpkgs/commit/9102bfddb581f2f49f2fd9efd7fcdd57edc822ab) spirv-tools: 1.3.236.0 -> 1.3.239.0
* [`df3b29de`](https://github.com/NixOS/nixpkgs/commit/df3b29de7e70da4b2996f0263fe37e8541c30347) vulkan-validation-layers: 1.3.236.0 -> 1.3.239.0
* [`51b8f73d`](https://github.com/NixOS/nixpkgs/commit/51b8f73d57cbe1c6d6bace0d6dcd53e6547b4503) vulkan-extension-layer: 1.3.236.0 -> 1.3.239.0
* [`c171fe67`](https://github.com/NixOS/nixpkgs/commit/c171fe67c3b719fd4b99c461379ae6c90ae86d1b) vulkan-tools: 1.3.236.0 -> 1.3.239.0
* [`7a5a9bbf`](https://github.com/NixOS/nixpkgs/commit/7a5a9bbf9e11c47f39f9a9e8011159f598d2330d) vulkan-tools-lunarg: 1.3.236.0 -> 1.3.239.0
* [`44a1fb1b`](https://github.com/NixOS/nixpkgs/commit/44a1fb1b9c9daa2a6086b79ca5d70f01eb399230) spirv-cross: 1.3.236.0 -> 1.3.239.0
* [`7cf72768`](https://github.com/NixOS/nixpkgs/commit/7cf72768c0a19efbf561f3838c6afdee6e7821fd) glslang: revert AppleClang linker option
* [`be82be97`](https://github.com/NixOS/nixpkgs/commit/be82be97753b98d6989e2d7823d3f0d30ee82b53) vk-bootstrap: 0.6 -> 0.7
* [`3010a420`](https://github.com/NixOS/nixpkgs/commit/3010a420d6d86028d47360b55a11453ca027922f) python310Packages.s3fs: 2022.11.0 -> 2023.1.0
* [`9be0f13a`](https://github.com/NixOS/nixpkgs/commit/9be0f13abaa0d1d4cf039bc76eff21daee6c983b) pipewire: fix pipewire-rs builds
* [`89b1bf06`](https://github.com/NixOS/nixpkgs/commit/89b1bf06dfed5c64c2b1df1904440c5707cdc39d) openjdk19: 19.0.1+10 -> 19.0.2+7
* [`0685060f`](https://github.com/NixOS/nixpkgs/commit/0685060feb087e8ebbd415bb5c79fba702ba0f22) openjfx19: 19+11 -> 19.0.2.1+1
* [`33ec6774`](https://github.com/NixOS/nixpkgs/commit/33ec6774e90fd6a8307e2bd91e525a80e163b05b) re2: 2022-12-01 -> 2023-02-01
* [`8c24528b`](https://github.com/NixOS/nixpkgs/commit/8c24528b11f618c28344f8fe2736a0b2f78a129c) xorg.fontutil: 1.3.1 -> 1.3.3
* [`70599398`](https://github.com/NixOS/nixpkgs/commit/70599398d826bf967f9d69042cfab1e198595453) ninja: fix cross compilation
* [`640c1023`](https://github.com/NixOS/nixpkgs/commit/640c102321b244edb0b2156cd27ecb16620bd19c) openjfx11: add with{Media,Webkit} options
* [`976849f2`](https://github.com/NixOS/nixpkgs/commit/976849f2e693549ce96a65ae75c5a3c03e5742fb) openjfx11: remove unnecessary NIX_CFLAGS_COMPILE options
* [`45d33909`](https://github.com/NixOS/nixpkgs/commit/45d339096f07cfa283d4b4034291d20f3582a7dd) openjfx11: remove gtk2
* [`39022732`](https://github.com/NixOS/nixpkgs/commit/390227326d789f54cb699cde172dea223dd24e9b) openjfx15: add with{Media,Webkit} options
* [`a7647905`](https://github.com/NixOS/nixpkgs/commit/a76479057a7ad8ffdab37f7a39d118525e805a22) openjfx15: remove gtk2
* [`d7c4a9bf`](https://github.com/NixOS/nixpkgs/commit/d7c4a9bf931b7b6d3dfdc563e23fc260987f2ee7) openjfx17: add with{Media,Webkit} options
* [`c6323fe2`](https://github.com/NixOS/nixpkgs/commit/c6323fe2587ec5e1ecacab433717bb648e926e58) openjfx17: remove gtk2
* [`1caf19b8`](https://github.com/NixOS/nixpkgs/commit/1caf19b8e047cb567a17404879b467ded7adb5fe) openjfx19: add with{Media,Webkit} options
* [`a41cfc36`](https://github.com/NixOS/nixpkgs/commit/a41cfc36f5f52e6f348730deb51644bca4b54046) openjfx19: remove gtk2
* [`c5177444`](https://github.com/NixOS/nixpkgs/commit/c51774444c97a349c4e10ed7e5100f5d33c5b968) openjdk11: disable JavaFX by default
* [`368a7a02`](https://github.com/NixOS/nixpkgs/commit/368a7a02859b6f00e72c6fe291bc7d281abad8a4) openjdk12: disable JavaFX by default
* [`3db2a9d2`](https://github.com/NixOS/nixpkgs/commit/3db2a9d2d39251f4c2ed05afd30f9235537ab7be) openjdk13: disable JavaFX by default
* [`0ff24434`](https://github.com/NixOS/nixpkgs/commit/0ff244342e357614d0e810a0866adb4101a581ed) openjdk14: disable JavaFX by default
* [`4161997c`](https://github.com/NixOS/nixpkgs/commit/4161997c71a4b7a957a3c3999166dd28d8f0c55d) openjdk15: disable JavaFX by default
* [`644ec84b`](https://github.com/NixOS/nixpkgs/commit/644ec84b74046d9939bf8572bb589d7bffd08758) openjdk16: disable JavaFX by default
* [`83a10248`](https://github.com/NixOS/nixpkgs/commit/83a10248e3e6a734c71f326f9e4842dffbe55907) openjdk17: disable JavaFX by default
* [`6ba603bc`](https://github.com/NixOS/nixpkgs/commit/6ba603bcc9cfe1f959651f6d048fca2b2edb36a1) openjdk18: disable JavaFX by default
* [`ce6bc62d`](https://github.com/NixOS/nixpkgs/commit/ce6bc62d4807157a58300d8f4872dd7e46653169) openjdk19: disable JavaFX by default
* [`ad11f9c9`](https://github.com/NixOS/nixpkgs/commit/ad11f9c9ab4041a56cafa21da7e2e2d588da7cf5) bisq-desktop: enable JavaFX
* [`3be06e76`](https://github.com/NixOS/nixpkgs/commit/3be06e76e3193cc34516aa3eba2cf8b6bc19a609) pdfsam-basic: enable JavaFX
* [`e5f214ff`](https://github.com/NixOS/nixpkgs/commit/e5f214ff21be5c5f722d11088a5437f42f0e82dc) doc: document openjdk changes
* [`a42fdc6a`](https://github.com/NixOS/nixpkgs/commit/a42fdc6aa91e23a1d0a1ac7b9ffa2817a3a28c3c) openjfx19: expose it to all-packages.nix
* [`5de3af2d`](https://github.com/NixOS/nixpkgs/commit/5de3af2d1d12fc18ba00de515a21bdf13958efb2) genxword: remove obsolete gobject-introspection build input
* [`736acf66`](https://github.com/NixOS/nixpkgs/commit/736acf668f15e264180911ff89ed1aaf5e76150c) udiskie: remove obsolete gobject-introspection build input
* [`db96503b`](https://github.com/NixOS/nixpkgs/commit/db96503b4e7869faad4775c76ab0586a02d6cfc7) autokey: remove obsolete gobject-introspection build input
* [`7e5ee093`](https://github.com/NixOS/nixpkgs/commit/7e5ee093664ddd2d5a51fbf3fc1a6d1270161f80) terminator: remove obsolete gobject-introspection build input
* [`781b5f6a`](https://github.com/NixOS/nixpkgs/commit/781b5f6a29c20eb61d5d3560bfa7f05768ad759d) accountsservice: remove obsolete gobject-introspection build input
* [`9c6bce87`](https://github.com/NixOS/nixpkgs/commit/9c6bce8748d5929e37023ce319742e9bbd1d6421) gjs: remove obsolete gobject-introspection build input
* [`0a62fb98`](https://github.com/NixOS/nixpkgs/commit/0a62fb98de10b01cc32f43c66ab0019d15c05b3b) libgudev: remove obsolete gobject-introspection build input
* [`71a5e14e`](https://github.com/NixOS/nixpkgs/commit/71a5e14eb3c9afaa60248990a01ca8f413d8ff85) libical: remove obsolete gobject-introspection build input
* [`8f8a6ebd`](https://github.com/NixOS/nixpkgs/commit/8f8a6ebd1465c5495bc6a932cb3f2df2a07132bb) libmanette: remove obsolete gobject-introspection build input
* [`6ae50e12`](https://github.com/NixOS/nixpkgs/commit/6ae50e12eec367cf0deeb47aefb63b0a4eb42fe9) libnotify: remove obsolete gobject-introspection build input
* [`61f99208`](https://github.com/NixOS/nixpkgs/commit/61f9920880237002a03c7be39dec58b0ebb9d458) libqrtr-glib: remove obsolete gobject-introspection build input
* [`883eeac4`](https://github.com/NixOS/nixpkgs/commit/883eeac4ec71880766f9bfacc042e3d910b95820) librsvg: remove obsolete gobject-introspection build input
* [`f7af1769`](https://github.com/NixOS/nixpkgs/commit/f7af17693e6cc56ec59d9ef771b855d87cb0aeec) libsecret: remove obsolete gobject-introspection build input
* [`fcda6023`](https://github.com/NixOS/nixpkgs/commit/fcda6023e277f186f5dd34c6f2eeba3c7d34520a) libvirt-glib: remove obsolete gobject-introspection build input
* [`c4dc6ca6`](https://github.com/NixOS/nixpkgs/commit/c4dc6ca63561e6d9b70ab093e5cd685dfe0c97e2) polkit: remove obsolete gobject-introspection build input
* [`583a3c8b`](https://github.com/NixOS/nixpkgs/commit/583a3c8b2a764247101495d3ecf7427314850bc8) umockdev: remove obsolete gobject-introspection build input
* [`448dde20`](https://github.com/NixOS/nixpkgs/commit/448dde20b1eefda05c668b18b03b157a20ff916e) gpsd: remove obsolete gobject-introspection build input
* [`309e4dc8`](https://github.com/NixOS/nixpkgs/commit/309e4dc8b99f9648c125ffde1430578674602c11) python3.pkgs.pygobject: remove obsolete gobject-introspection build input
* [`8e092324`](https://github.com/NixOS/nixpkgs/commit/8e09232439b7936706b753309a1e6592a83a024a) libbsd: 0.11.6 -> 0.11.7
* [`0807fca4`](https://github.com/NixOS/nixpkgs/commit/0807fca47e29e6de510721bc1164f9f9ee3d774c) libxml2: restrict Python support in cross builds
* [`07d19858`](https://github.com/NixOS/nixpkgs/commit/07d19858228e1882f93465bc9986c2598bf86939) harfbuzz: re-disable introspection when not available
* [`c5b8ba38`](https://github.com/NixOS/nixpkgs/commit/c5b8ba3891f7fa870eea736b8a7279a823a28ff5) harfbuzz: broaden platforms
* [`697e78ba`](https://github.com/NixOS/nixpkgs/commit/697e78baaf6089a7c713f64d55374f74b00a54e2) pango: re-disable introspection when not available
* [`da2dfc91`](https://github.com/NixOS/nixpkgs/commit/da2dfc91fdcaf1af37f6edbe9bab63988a264269) pango: broaden platforms
* [`d3edbcdb`](https://github.com/NixOS/nixpkgs/commit/d3edbcdb7af2857ac7d268b21a32edd3a02b31bc) maturin: 0.14.5 -> 0.14.12
* [`5445b924`](https://github.com/NixOS/nixpkgs/commit/5445b924f87fd03f4840f4a9f9be4826c0d8eb40) doxygen: depend on libiconv unconditionally
* [`5eca7873`](https://github.com/NixOS/nixpkgs/commit/5eca7873b9cf9cba959a4bb8e87bd247b9e3a812) chez-racket: support many more platforms
* [`aa01f2c1`](https://github.com/NixOS/nixpkgs/commit/aa01f2c1d08437872ec4c9acf4893fa06c1b0014) chez-racket: depend on libiconv unconditionally
* [`3404d6b0`](https://github.com/NixOS/nixpkgs/commit/3404d6b0f764b640d0c5a3d59a496039e914f8c3) openjpeg: move jpylizer to nativeCheckInputs
* [`f672b49a`](https://github.com/NixOS/nixpkgs/commit/f672b49afc8a2ba00af1d382d85a2afc1be30fbb) libdrm: fix build for FreeBSD
* [`37bbc00a`](https://github.com/NixOS/nixpkgs/commit/37bbc00aee3f4a07e4b3b5e50bef0d58d603c039) nixosTests.google-oslogin: fix tests, provide group mock endpoint
* [`43ad4f2e`](https://github.com/NixOS/nixpkgs/commit/43ad4f2ef0256f118164d750eb215d01992cbd48) openjpeg: fix tests
* [`9e0c9db6`](https://github.com/NixOS/nixpkgs/commit/9e0c9db6c218b581bfe26187e732dd5caf6824bf) vim: 9.0.0609 -> 9.0.1275
* [`afef6588`](https://github.com/NixOS/nixpkgs/commit/afef6588e250aca603c7e80349678504e229d5e0) stdenv/setup.sh: Allow NIX_ATTRS_{JSON,SH}_FILE to be set correctly by Nix
* [`a7ba7b6d`](https://github.com/NixOS/nixpkgs/commit/a7ba7b6d01958b31c15cc530b8a6a19ad3185067) Revert "Revert Merge [nixos/nixpkgs⁠#214786](https://togithub.com/nixos/nixpkgs/issues/214786): libvmaf: fix build for BSD"
* [`421acf10`](https://github.com/NixOS/nixpkgs/commit/421acf1022541abcbc167c17a38b4cf2e9bd26e3) buildGo{Module,Package}: respect nix hardening flags when setting buildmode
* [`3cb38595`](https://github.com/NixOS/nixpkgs/commit/3cb385953bcdd0dc8676efd5dd28c520457ca549) mimir: add package override
* [`ff58d280`](https://github.com/NixOS/nixpkgs/commit/ff58d2801cff7bc6885559fda1de65cf6e267faf) isocodes: fix cross to non-Python platforms
* [`40d92d3b`](https://github.com/NixOS/nixpkgs/commit/40d92d3be5f049f2667a986af139a81fa92bf0e3) isocodes: enable parallel building
* [`e1739b19`](https://github.com/NixOS/nixpkgs/commit/e1739b19ca8c7170bf12358e8bba832dd5f93fa4) pdfsam-basic: Fix jdk override
* [`fa0633e7`](https://github.com/NixOS/nixpkgs/commit/fa0633e7faac4be522850c55854683db71ef6d8f) libvisual: pull upstream fix for pkg-config SDL1 discovery
* [`b89799ac`](https://github.com/NixOS/nixpkgs/commit/b89799acf0ac697a07256407caa9e119ac8b4e0d) systemd: fix build when withResolved=false and withImportd=true
* [`ffeb8432`](https://github.com/NixOS/nixpkgs/commit/ffeb843237e38dcf16c7a3caacc5a0e5d90320ca) pmdk: removed
* [`8e8822c8`](https://github.com/NixOS/nixpkgs/commit/8e8822c87271307ad42825b72b04c580c1f16e01) mariadb: remove pmdk; make Numa optional
* [`113cdbd2`](https://github.com/NixOS/nixpkgs/commit/113cdbd29d6b90bf430a0e32364cd9ed8775d25f) fstar: use proper z3 version and build .checked files
* [`7d9ab620`](https://github.com/NixOS/nixpkgs/commit/7d9ab620deba7c976951501dac07c213e58dee70) util-linux: install completion
* [`84e37a10`](https://github.com/NixOS/nixpkgs/commit/84e37a10ec32b70c0e1a74fb3e5a837f6e7d74ab) stdenv: allow propagating propagated dependencies separately from the
* [`9a9c42e1`](https://github.com/NixOS/nixpkgs/commit/9a9c42e19f0e520d06ee08c68cb050e3d698f3d6) makeSetupHook: support depsTargetTargetPropagated
* [`8be7ab60`](https://github.com/NixOS/nixpkgs/commit/8be7ab60b17f772b88358a8f1b6aeedd3306b13a) wrapGAppsHook: make it work with strictDeps
* [`4e3dcf36`](https://github.com/NixOS/nixpkgs/commit/4e3dcf364ed477075baea851fba264a20e47bb20) treewide: makeSetupHook deps -> propagatedBuildInputs
* [`8f171925`](https://github.com/NixOS/nixpkgs/commit/8f171925b3a0edbdc6611eef50eb07ef991fc7a6) makeSetupHook: deprecate deps argument
* [`680309fc`](https://github.com/NixOS/nixpkgs/commit/680309fc9ca3cfe06e02509134427215f1079310) add docs for makeSetupHook
* [`c585e1ed`](https://github.com/NixOS/nixpkgs/commit/c585e1ed0d8685a5eb597265c761406944df2fbd) python38Packages.yaramod: init at 3.12.2
* [`1d71a154`](https://github.com/NixOS/nixpkgs/commit/1d71a154a24ed32615ba31f97dd6afc780bd3231) python310Packages.sphinx-rtd-theme: 1.1.1 -> 1.2.0
* [`99eda60c`](https://github.com/NixOS/nixpkgs/commit/99eda60ce6e7ba4e335e4f23c60259bffe2db4df) neon: 0.32.4 -> 0.32.5
* [`9b23f8ed`](https://github.com/NixOS/nixpkgs/commit/9b23f8ed3bfad1e3f7027be98ac8ee7a0bcdb912) sysstat: 12.6.1 -> 12.6.2
* [`476d2bc6`](https://github.com/NixOS/nixpkgs/commit/476d2bc651b7b565fd6cfe872159c300acbb2d03) libptytty: fix musl and static
* [`a83c4274`](https://github.com/NixOS/nixpkgs/commit/a83c427483fd701c49daac19dde9b2965ad60acd) portaudio: build with jack support
* [`ac49f34f`](https://github.com/NixOS/nixpkgs/commit/ac49f34fe85a02110ba38ccd8798207e52ea150a) llvmPackages_rocm.llvm: 5.4.2 -> 5.4.3
* [`616d1877`](https://github.com/NixOS/nixpkgs/commit/616d1877e39d516d32a3379c197d67d712388072) mariadb: make withNuma unrelated to withEmbedded
* [`d5f88d5d`](https://github.com/NixOS/nixpkgs/commit/d5f88d5d1cc6c5fdcb892b2fe58b436facd6c78a) hwdata: 0.366 -> 0.367
* [`1f6d0b60`](https://github.com/NixOS/nixpkgs/commit/1f6d0b6016debe137e7648532c50d74fd3b4a33c) python310Packages.cryptography: 39.0.0 -> 39.0.1
* [`43ce59c6`](https://github.com/NixOS/nixpkgs/commit/43ce59c656ee25643335da4729110ea817bafa5e) ustream-ssl*: init at unstable-2022-12-08
* [`9b31147b`](https://github.com/NixOS/nixpkgs/commit/9b31147be92551e14c3b906f45096d6c7961e6ff) nixos/tests/systemd-initrd-vconsole: init new test for console.earlySetup
* [`e0fbf349`](https://github.com/NixOS/nixpkgs/commit/e0fbf34964af9eaa3e68204e14137ad9a49b640c) libubox: add ssl flavours
* [`f3ba738b`](https://github.com/NixOS/nixpkgs/commit/f3ba738bfe13f22543ea4d69f874c2b220eacb4f) libnl-tiny: init at unstable-2022-12-13
* [`965ceade`](https://github.com/NixOS/nixpkgs/commit/965ceadeb5e87eb851953733f2d450b57b5b79c5) uclient-fetch: init at unstable-2022-02-24
* [`18d1c014`](https://github.com/NixOS/nixpkgs/commit/18d1c014bfa4c92d20c0a2dd8ff47c0f2cddbb06) file: fix identification of pyzip files
* [`92e6b205`](https://github.com/NixOS/nixpkgs/commit/92e6b205ed8b823e2d832cde5928239c4466e7f7) strip-nondeterminism: 1.13.0 -> 1.13.1
* [`fc334fd7`](https://github.com/NixOS/nixpkgs/commit/fc334fd76c2700cb165f7a1bc394415ebb55fd7e) zsh-prezto: unstable-2023-01-12 -> unstable-2023-01-31
* [`aef5ef01`](https://github.com/NixOS/nixpkgs/commit/aef5ef01089eb39c4abea5d1cf05866a57cc444a) discourse: Reformat function arguments
* [`8fb5bab7`](https://github.com/NixOS/nixpkgs/commit/8fb5bab784b274d37a11668b6b85c756ab044ef1) discourse: 2.9.0.beta14 -> 3.1.0.beta2
* [`0dcc8c9a`](https://github.com/NixOS/nixpkgs/commit/0dcc8c9adb13d4a73e90be4d9ee16b6e0dd308ca) discourse: Update plugins
* [`5757259e`](https://github.com/NixOS/nixpkgs/commit/5757259eeeee5b767081bfbad66ad627cb261ef8) discourse.tests: nodes.discourse.config -> nodes.discourse
* [`ca6aa073`](https://github.com/NixOS/nixpkgs/commit/ca6aa0730465ad871a2abc3bf696a01893fc62fc) discourse: Document how to update
* [`b15ffddd`](https://github.com/NixOS/nixpkgs/commit/b15ffddd9cbbda2848bc7820e0f552713f6a4a74) pdm: 2.3.4 -> 2.4.3
* [`5bc96030`](https://github.com/NixOS/nixpkgs/commit/5bc96030b03cf1199899b07a04c2076dcd1d75ff) rustc: 1.67.0 -> 1.67.1
* [`0d41f3a1`](https://github.com/NixOS/nixpkgs/commit/0d41f3a17430627960ce0b65ad937cd5eb00b55e) joplin-desktop: 2.9.17 -> 2.10.4
* [`54a67709`](https://github.com/NixOS/nixpkgs/commit/54a6770929746d4e836cd8ce3cd081bde45bd9da) libsecret: fix non-deterministic fail of test-collection
* [`83c770cf`](https://github.com/NixOS/nixpkgs/commit/83c770cf530fb0baf9d58709bf795f7f40c8110b) _5etools: init at 1.175.2
* [`32693f33`](https://github.com/NixOS/nixpkgs/commit/32693f33a2b0636985e09a7bc91680704f062007) zstd: 1.5.2 -> 1.5.4
* [`1b48e26a`](https://github.com/NixOS/nixpkgs/commit/1b48e26a61b0df7e3e8d16d75d46909eaca4c49b) python310Packages.dnspython: add changelog to meta
* [`240a2d51`](https://github.com/NixOS/nixpkgs/commit/240a2d51eff17b9ea5b3ce342697ff47bdd6c84c) python310Packages.dnspython: 2.2.1 -> 2.3.0
* [`df6cdf02`](https://github.com/NixOS/nixpkgs/commit/df6cdf026fa15e5c648357d320cfdc5b7309819d) python310Packages.eventlet: 0.33.1 -> 0.33.3
* [`d607d078`](https://github.com/NixOS/nixpkgs/commit/d607d078e2909bba90f6eafb0795d8df1f5d06f2) rust-bindgen: 0.63.0 -> 0.64.0
* [`400212a9`](https://github.com/NixOS/nixpkgs/commit/400212a90295e9de7a349adc9a4b43c3320cf984) python3Packages.flit-scm: Fix src hash
* [`bc8cfa18`](https://github.com/NixOS/nixpkgs/commit/bc8cfa181b63e2712c9e5d016e7b52007454c32f) nss_esr: 3.79.3 -> 3.79.4
* [`48c2d328`](https://github.com/NixOS/nixpkgs/commit/48c2d3284a166b3b852a4398a177fe3075cb3902) mailman: 3.3.5 -> 3.3.8 supports latest sqlalchemy
* [`b881ca45`](https://github.com/NixOS/nixpkgs/commit/b881ca4548bb3f98d801d2085349d2c5c27b7d5d) autocorrect: init at 2.6.2
* [`a94804c4`](https://github.com/NixOS/nixpkgs/commit/a94804c4510b1566695895b24cbda7418b9071ff) python39: Move out of sources attrset
* [`f228b936`](https://github.com/NixOS/nixpkgs/commit/f228b9368b4c65775eb25dbb866fd5bba2ad3800) python310: 3.10.9 -> 3.10.10
* [`f0b8e029`](https://github.com/NixOS/nixpkgs/commit/f0b8e02958c5bec7aff2da38d62e9de7a673a49b) python311: 3.11.1 -> 3.11.2
* [`ee90eca1`](https://github.com/NixOS/nixpkgs/commit/ee90eca180f2c42afc3b2365ec47e7bc9d90ace5) cpython: Migrate sha256 occurences to hash
* [`20c723dd`](https://github.com/NixOS/nixpkgs/commit/20c723dd070792a0e6b56df0e7b173975867ddb3) python3.tests.condaExamplePackage: Exclude on non-linux
* [`a48dcc5d`](https://github.com/NixOS/nixpkgs/commit/a48dcc5da17e1507549770fdc525aa1bcbc1241e) python310Packages.asgiref: Fix tests on darwin
* [`f75329f0`](https://github.com/NixOS/nixpkgs/commit/f75329f0bcacebacfdd631fd588eed6419f0ba1c) python310Packages.ephemeral-port-reserve: Fix tests on darwin
* [`d704ee72`](https://github.com/NixOS/nixpkgs/commit/d704ee72c939d6a30dcd1c92bacca2413dbc90fa) python3.tests.nixenv-virtualenv: Fix on darwin
* [`ef0e55f2`](https://github.com/NixOS/nixpkgs/commit/ef0e55f22b6e4f4915f39185254d026d2e541147) maturin: 0.14.12 -> 0.14.13
* [`4422fe05`](https://github.com/NixOS/nixpkgs/commit/4422fe05ed938c5ce6ba11390dc7de93e8ee1357) streamlit: 1.16.0 -> 1.18.1
* [`2bace3c8`](https://github.com/NixOS/nixpkgs/commit/2bace3c824adb82315eb6617df42d244793e959c) palemoon-bin: init at 32.0.0
* [`2e4bc823`](https://github.com/NixOS/nixpkgs/commit/2e4bc8230fdc5900282b1a42f70361a564a22d5e) ghidra: 10.2.2 -> 10.2.3
* [`29226cfe`](https://github.com/NixOS/nixpkgs/commit/29226cfea74decf332dc019037c3e269eb06a752) python310Packages.eventlet: disable test_fork_after_monkey_patch test all the time
* [`66f6a849`](https://github.com/NixOS/nixpkgs/commit/66f6a849040005375f9b9c3e20b7bcb9dca60656) darwin.apple_sdk.frameworks.IOKit: fix on x86_64-darwin
* [`c8d7452c`](https://github.com/NixOS/nixpkgs/commit/c8d7452cedaca6f50e2dd846ac6d41ac8ad268f8) python310Packages.pytest-forked: 1.4.0 -> 1.6.0
* [`410d64db`](https://github.com/NixOS/nixpkgs/commit/410d64db35fe9e45f7d6a684fc368554761f6331) mesa: 22.3.4 -> 22.3.5
* [`f4e9ffe7`](https://github.com/NixOS/nixpkgs/commit/f4e9ffe7cba02a7491d9742e1a9396bc525a9d30) nss: fix build parallelism
* [`b4f74e33`](https://github.com/NixOS/nixpkgs/commit/b4f74e334eb4b675af6ebc6b3ae26c96e945da40) python2: fix eval
* [`3d695ad7`](https://github.com/NixOS/nixpkgs/commit/3d695ad7a256ef92b60b80b18662f43bddc8473d) libressl_3_6: 3.6.1 -> 3.6.2
* [`cae86017`](https://github.com/NixOS/nixpkgs/commit/cae86017b1e51d60c828b0cbcae9b52104dddde1) libressl_3_5: 3.5.3 -> 3.5.4
* [`938a52f6`](https://github.com/NixOS/nixpkgs/commit/938a52f603f1a545319441832441fb40820a7953) gtest: ensure C++17 support for aarch64 ([nixos/nixpkgs⁠#215767](https://togithub.com/nixos/nixpkgs/issues/215767))
* [`8abe7fd0`](https://github.com/NixOS/nixpkgs/commit/8abe7fd0758363056729cf70836bb58922d80eea) dde-polkit-agent: init at 5.5.22
* [`76ac6931`](https://github.com/NixOS/nixpkgs/commit/76ac693197f2114b27684ff12a95605362eb9e73) dpa-ext-gnomekeyring: init at 5.0.11
* [`4bcab74b`](https://github.com/NixOS/nixpkgs/commit/4bcab74b94c14e608d517dd626a8fbe6c29b9064) libinput: don't try to create /etc in build
* [`9fc6149d`](https://github.com/NixOS/nixpkgs/commit/9fc6149defc78ed3b459194b9acb7d53ace95aa3) python310Packages.django_4: 4.1.6 -> 4.1.7
* [`2e759a9a`](https://github.com/NixOS/nixpkgs/commit/2e759a9a92e4085582ba063f1625a8e948c25d80) file: backport another regression fix
* [`bb41e2b5`](https://github.com/NixOS/nixpkgs/commit/bb41e2b58b5d1e632564f0366397aee836c1f2de) Revert "python3Packages.patool: local backport of `file` regression fix"
* [`cb8d827b`](https://github.com/NixOS/nixpkgs/commit/cb8d827b9a4c1863c37c0b124f78da93b3b5cb05) libressl_3_4: add knownVulnerabilities
* [`b958f017`](https://github.com/NixOS/nixpkgs/commit/b958f017b7f27de0064cbc3e1a16e2020f2acce3) libressl_3_4: backport security fix
* [`0442267e`](https://github.com/NixOS/nixpkgs/commit/0442267e821a573737ec9a858ad3551bb144fb93) gnutls: 3.7.8 -> 3.8.0
* [`0cedc3de`](https://github.com/NixOS/nixpkgs/commit/0cedc3dedfacb410783ed767961356616bed9fa1) gnutls: drop the withSecurity option
* [`9df97ae0`](https://github.com/NixOS/nixpkgs/commit/9df97ae05a7be4caf332cc2aef293955c79482a9) harfbuzz: 6.0.0 -> 7.0.0
* [`ac34fdfd`](https://github.com/NixOS/nixpkgs/commit/ac34fdfd472d67302bf6f0dd6fca57b567d9caae) git: 2.39.1 -> 2.39.2
* [`4a816703`](https://github.com/NixOS/nixpkgs/commit/4a816703fd5de49b05c5fc9faa71818eb8fe9711) python310Packages.django_3: 3.2.17 -> 3.2.18
* [`e3a10a12`](https://github.com/NixOS/nixpkgs/commit/e3a10a12c7731479b3539fc8a81d9d61f547a4fa) rustPlatform.cargoSetupHook: improve cargoHash instructions
* [`a57fd65b`](https://github.com/NixOS/nixpkgs/commit/a57fd65b7bd074e5fe19f95e8d58a0ed6ea1867d) libX11: 1.8.3 -> 1.8.4
* [`73a534c8`](https://github.com/NixOS/nixpkgs/commit/73a534c880661d918240d16eb65ad5f1a55bf02b) modemmanager: fix build
* [`3cf92a87`](https://github.com/NixOS/nixpkgs/commit/3cf92a8760f7c20edc0b6fc45174cdf3a3cd86f0) libdeflate: 1.8 -> 1.17
* [`93aba2c9`](https://github.com/NixOS/nixpkgs/commit/93aba2c96d34e84e543ed608b3e1b7322a4bc783) 2048-cli: init at 0.9.1
* [`f445f928`](https://github.com/NixOS/nixpkgs/commit/f445f928f4edd24ceffab951ba013b66e7d7ad23) 2048-cli: 0.9.1 -> unstable-2019-12-10
* [`024cab59`](https://github.com/NixOS/nixpkgs/commit/024cab5905e49bb16bbdeae315580e920e726c30) gavin-bc: init at 6.2.4
* [`98157f13`](https://github.com/NixOS/nixpkgs/commit/98157f131dac8d56997673abd69d9f154d35e00e) gavin-bc: mark as broken on Darwin
* [`d37bd519`](https://github.com/NixOS/nixpkgs/commit/d37bd519ba0dffd075dfd4b67b5caec0d020ef0f) gavin-bc: enable extra options
* [`2a97c0d9`](https://github.com/NixOS/nixpkgs/commit/2a97c0d985791d4d3edce9d8432db983a6905203) nixos/hardware: add support for qmk keyboards
* [`7dc0f77e`](https://github.com/NixOS/nixpkgs/commit/7dc0f77ecf41ae952d7e8ed4830048125721c414) nixos/hardware: clean up "with lib;" for keyboards
* [`8ea81a94`](https://github.com/NixOS/nixpkgs/commit/8ea81a949a8a408cc901ccef5af06d4cf4109e24) curl: 7.87.0 -> 7.88.0
* [`5a2d41f7`](https://github.com/NixOS/nixpkgs/commit/5a2d41f70c4b9b82114ba287a61bd8f4e91ac165) python3Packages.reproject: 0.9.1 -> 0.10.0
* [`ff5fd91d`](https://github.com/NixOS/nixpkgs/commit/ff5fd91d043837abc3836a4b3978639be76e2fe2) python310Packages.awswrangler: relax pyarrow dependency
* [`5cf311c0`](https://github.com/NixOS/nixpkgs/commit/5cf311c0363fc0ff4cd8c3e1f47332480c664918) nixos/unbound: make stateDir writable
* [`90698f7c`](https://github.com/NixOS/nixpkgs/commit/90698f7c7063ab22b0cec1c49847dd0ff8d27db1) asterisk-module-sccp: 4.3.4 -> 4.3.5
* [`2a603a41`](https://github.com/NixOS/nixpkgs/commit/2a603a41a5cc32207e5983c4a28b7bf8c43b2daf) go_1_19: 1.19.5 -> 1.19.6
* [`74f6aaae`](https://github.com/NixOS/nixpkgs/commit/74f6aaae4a621d5b20fa61b3d99345c7c221dedb) curl: add patch for the HTTP/2 issue
* [`aac6e9c0`](https://github.com/NixOS/nixpkgs/commit/aac6e9c078e4772dc70c86ed33b38960a78abfe5) ccal: init at 2.5.3
* [`f908963c`](https://github.com/NixOS/nixpkgs/commit/f908963cd09d0dbb19d2528a6cb79bb46e0b3523) python310Packages.ansible-later: 3.1.0 -> 3.2.0
* [`02e1012c`](https://github.com/NixOS/nixpkgs/commit/02e1012cae21c4f162cf96c6460b3f5d333d2dc4) vttest: 20221229 -> 20230201
* [`35681340`](https://github.com/NixOS/nixpkgs/commit/35681340d18d3f3dd4d399adc1369f8a0eb004c3) Revert "love: 0.10.2 -> 11.4"
* [`fe18efc3`](https://github.com/NixOS/nixpkgs/commit/fe18efc37b8c7b8d362c23bb559f9bd4cbb1fc1d) mrrescue: fix path to love game file
* [`5dc4dfb4`](https://github.com/NixOS/nixpkgs/commit/5dc4dfb42222b1db97f1b105e4c8b30217e2c762) love: make love_11 the default
* [`c6dcda71`](https://github.com/NixOS/nixpkgs/commit/c6dcda71cb695d0e072de7fb2f2004b929f64dc4) curl: add yet another patch for the same issue
* [`32e59366`](https://github.com/NixOS/nixpkgs/commit/32e59366dbc261fd8c08f8fcc8e6433273ef3b1d) mariadb: add more precise EOLs + link
* [`351e8a51`](https://github.com/NixOS/nixpkgs/commit/351e8a51c490befe7d623a0c178b0b9aa928c439) mariadb_1011: init at 10.11.2
* [`1978d0ff`](https://github.com/NixOS/nixpkgs/commit/1978d0ff6f74adadaed6a6aa58089428b181aa9b) libmysqlconnectorcpp: 8.0.31 -> 8.0.32
* [`ff494a0c`](https://github.com/NixOS/nixpkgs/commit/ff494a0c1b2c6d841514122450397ea42efbbd00) helix: add desktop item and icon
* [`84f012d5`](https://github.com/NixOS/nixpkgs/commit/84f012d56cf66535425aa6bbdead32f78aa7be4f) lombok: 1.18.24 -> 1.18.26
* [`9f79456f`](https://github.com/NixOS/nixpkgs/commit/9f79456f9078a0c6401404888efa972e15408de7) vscode-extensions.matthewpi.caddyfile-support: init at 0.2.4
* [`8de374b1`](https://github.com/NixOS/nixpkgs/commit/8de374b132bd577556ee990e168cfe3716fc5efb) morgen: 2.6.4 -> 2.6.6
* [`f90fc782`](https://github.com/NixOS/nixpkgs/commit/f90fc78221e955f8006be5e060633d35801b6f79) python310Packages:flask-sqlalchemy: add changelog to meta
* [`83c82021`](https://github.com/NixOS/nixpkgs/commit/83c82021cd6de9244c8419dcfbebb0a69eb707ee) python310Packages.flask-sqlalchemy: 3.0.2 -> 3.0.3
* [`8e8b1619`](https://github.com/NixOS/nixpkgs/commit/8e8b161929cf08f0dbef911a0d8a3399b6f063ff) python310Packages.sqlalchemy-continuum: disable failing test
* [`bda4edd5`](https://github.com/NixOS/nixpkgs/commit/bda4edd5be336924b8fe29fa662cd3215cb21d41) python310Packages.trimesh: 3.19.3 -> 3.20.0
* [`5a2d66c8`](https://github.com/NixOS/nixpkgs/commit/5a2d66c88322d07e592751172b798267e4e266e6) deepin-wallpapers: init at 1.7.10
* [`5e0646d8`](https://github.com/NixOS/nixpkgs/commit/5e0646d8dbf265677b221715d40152d39e889246) squawk: 0.20.0 -> 0.21.0
* [`f66b2173`](https://github.com/NixOS/nixpkgs/commit/f66b21731df425ab1d8b42f632b53bf0e370f19f) python310Packages.datashader: 0.14.3 -> 0.14.4
* [`0faf4834`](https://github.com/NixOS/nixpkgs/commit/0faf4834e91ddb66a92ec3ace34f90773f89235a) python310Packages.radish-bdd: 0.14.2 -> 0.15.0
* [`c48011ec`](https://github.com/NixOS/nixpkgs/commit/c48011ec4672ee7781227eddf866e7618043304c) jellyfin-mpv-shim: 2.3.1 -> 2.4.2
* [`218b2819`](https://github.com/NixOS/nixpkgs/commit/218b28191ae3de4da69a3d932cbd847d0810616c) pipewire: 0.3.65 -> 0.3.66
* [`02825ae1`](https://github.com/NixOS/nixpkgs/commit/02825ae100a261e72ff9b1024acdaacf4c0663eb) python310Packages.weasyprint: 57.2 -> 58.0
* [`b1611627`](https://github.com/NixOS/nixpkgs/commit/b16116276c6a6a95564bc6d24ac1c7fe0d849fcf) kaniko: init at 1.9.1
* [`64076a98`](https://github.com/NixOS/nixpkgs/commit/64076a9875f7802cff49083e2f5e5779268ad5e0) directx-shader-compiler: build with gcc11 for i686
* [`33ed801e`](https://github.com/NixOS/nixpkgs/commit/33ed801e7385772d9e71f2df33cc60709711259e) rubyPackages.eventmachine: fix darwin build
* [`f3d988fc`](https://github.com/NixOS/nixpkgs/commit/f3d988fccd8af9f80cbadaec8308439a7b6d517c) python310Packages.kubernetes: 25.3.0 -> 26.1.0
* [`8467c637`](https://github.com/NixOS/nixpkgs/commit/8467c637493595a2023a1285100c7636c89f9217) flashrom: use a udev uaccess tag instead of introducing a custom flashrom group
* [`af9f449f`](https://github.com/NixOS/nixpkgs/commit/af9f449fc19fe3dc2a4832032c9414c5e2fc478d) appflowy: 0.0.9 -> 0.1.0
* [`4dc28559`](https://github.com/NixOS/nixpkgs/commit/4dc28559924cd13be1a7b6d8b0f7ce526f7c3205) python310Packages.python-lz4: add changelog to meta
* [`82799537`](https://github.com/NixOS/nixpkgs/commit/827995378da3eee0f783c36de36cbed6cda2ca65) python310Packages.databricks-sql-connector: add changelog to meta
* [`1555f8d5`](https://github.com/NixOS/nixpkgs/commit/1555f8d5340b034d76adb2dc412ee4ee05f69286) python310Packages.python-lz4: 4.3.1 -> 4.3.2
* [`644fd982`](https://github.com/NixOS/nixpkgs/commit/644fd982a92f6d5924f6797e6ba68dacb804c69b) python310Packages.databricks-sql-connector: 2.2.1 -> 2.3.0
* [`d57bfa7e`](https://github.com/NixOS/nixpkgs/commit/d57bfa7e1eb43d4c0c7578c2d66957b5cc9fb2c4) heimer: 3.6.4 -> 3.7.0
* [`7ae4cc2a`](https://github.com/NixOS/nixpkgs/commit/7ae4cc2a21b155518bd57e899d17687efa656c39) edencommon: 2023.01.30.00 -> 2023.02.13.00
* [`96898355`](https://github.com/NixOS/nixpkgs/commit/968983558f682e302e93fb1f7392f3db0b4ac95c) python310Packages.azure-mgmt-cognitiveservices: 13.3.0 -> 13.4.0
* [`949b1df7`](https://github.com/NixOS/nixpkgs/commit/949b1df785df8b7db59e780c49d9f1abb56c2b3c) nixos/tailscale: fix config priority conflict
* [`6a9fdab4`](https://github.com/NixOS/nixpkgs/commit/6a9fdab47e59a759b2c07d897572964cef201c2d) python310Packages.iminuit: 2.19.0 -> 2.20.0
* [`51d0e4e9`](https://github.com/NixOS/nixpkgs/commit/51d0e4e9225eeb688250039c1c9a1484cd8b6d15) python310Packages.python-manilaclient: 4.2.0 -> 4.3.0
* [`1c26aaab`](https://github.com/NixOS/nixpkgs/commit/1c26aaab3a2f674f5bdb47fcb249d06e36321ef9) base16-schemes: init at unstable-2022-12-16
* [`7df36e5a`](https://github.com/NixOS/nixpkgs/commit/7df36e5addf6b20df1ba4fc0fa778457576f4c27) openssh_hpn: 9.1p1 -> 9.2p1
* [`2dbe0d32`](https://github.com/NixOS/nixpkgs/commit/2dbe0d321b728b13d82007fdb5e565353c6de8ed) python310Packages.adjusttext: 0.7.3.1 -> 0.8.0
* [`805ba10e`](https://github.com/NixOS/nixpkgs/commit/805ba10ecbfbd617fad87d90d5169e798c9e935f) Revert "libvisual: disable building examples when cross compiling"
* [`482dfddc`](https://github.com/NixOS/nixpkgs/commit/482dfddc233f5aecefbdb8f5d50cfc3f5fbdae36) thrift: 0.17.0 -> 0.18.0
* [`ca2ce987`](https://github.com/NixOS/nixpkgs/commit/ca2ce98720afc154a78c8e47d441c28ac42be864) steam-fhs: remove deprecated options
* [`388f6fb6`](https://github.com/NixOS/nixpkgs/commit/388f6fb60d8f330e45601ab51491eaa6416e49f3) python310Packages.azure-mgmt-reservations: 2.1.0 -> 2.2.0
* [`ad815aeb`](https://github.com/NixOS/nixpkgs/commit/ad815aebfbfe1415ff6436521d545029c803c3fb) steam: cleanup
* [`720a248b`](https://github.com/NixOS/nixpkgs/commit/720a248b4479e7748e942fe1b28d3684bd5baaff) python310Packages.aiohttp: Make failing tests non-strict
* [`8780d854`](https://github.com/NixOS/nixpkgs/commit/8780d8542d3b6a7de43f1a92c2fcc64352355069) ruby_3_0: fix build on darwin
* [`a62d4446`](https://github.com/NixOS/nixpkgs/commit/a62d444697933940052260f1fe86ace6df52c14b) steam-small: init
* [`6c7d4d4f`](https://github.com/NixOS/nixpkgs/commit/6c7d4d4f9d4fe9bff6264890e4c3e09e96591305) lib/options: update showOption comment
* [`acde7b8e`](https://github.com/NixOS/nixpkgs/commit/acde7b8e9f137a8a0274853e826228ecceeb343b) sasutils: 0.3.13 -> 0.4.0
* [`4f3353c7`](https://github.com/NixOS/nixpkgs/commit/4f3353c775c40dd7fbfb6718ef0175c13d731227) miriway: unstable-2022-12-18 -> unstable-2023-02-18
* [`85c48a38`](https://github.com/NixOS/nixpkgs/commit/85c48a38b458aaf53867609a75abe63ef1cbe047) Revert "transmission: use openssl_legacy"
* [`b2a74bc0`](https://github.com/NixOS/nixpkgs/commit/b2a74bc0ab17f32532318e80b32e0759583a287a) tests/miriway: Refer to upstream issue about keyboard problem
* [`0de3431e`](https://github.com/NixOS/nixpkgs/commit/0de3431e303e372e509f37479e856c23de6ecc18) tests/miriway: Explicitly enable X11 for XWayland testing
* [`f305cd10`](https://github.com/NixOS/nixpkgs/commit/f305cd1098cdd90228620f9886ca733da327fa0a) gnomeExtensions.EasyScreenCast: 1.4.0 -> 1.7.0
* [`cc4e610b`](https://github.com/NixOS/nixpkgs/commit/cc4e610ba9ff3e3abb7522bf8b4b877c7cd588e7) go-cve-search: 0.1.3 -> 0.1.4
* [`d768db18`](https://github.com/NixOS/nixpkgs/commit/d768db189f6def6238ef3a7aae27dd6cc0c932fe) i2pd: 2.45.1 -> 2.46.0
* [`ba333178`](https://github.com/NixOS/nixpkgs/commit/ba333178e7fde383d56a8fee6b1e251147f70739) python310Packages.oslo-context: 5.0.0 -> 5.1.0
* [`a3cad255`](https://github.com/NixOS/nixpkgs/commit/a3cad255d864d9e041fcfddb094b452172dffdf2) discord: 0.0.24 -> 0.0.25
* [`45cb6c1f`](https://github.com/NixOS/nixpkgs/commit/45cb6c1fa3f2a7bfe1dd4d1b46b344077c9ed98a) libdeflate: fix darwin build
* [`efe1c91c`](https://github.com/NixOS/nixpkgs/commit/efe1c91cc1d68025c5d6bfebb408b722fddc2d66) jami: 20221220.0956.79e1207 -> 20230206.0
* [`4e59c7b2`](https://github.com/NixOS/nixpkgs/commit/4e59c7b2b6e0f0d5fde71449619a7e911c6595a3) python310Packages.ipympl: 0.9.2 -> 0.9.3
* [`9156d02e`](https://github.com/NixOS/nixpkgs/commit/9156d02e924661d9f5c574fe33cb940c5ebbf692) waydroid: fix icon, shell and iptables
* [`e20d1c56`](https://github.com/NixOS/nixpkgs/commit/e20d1c56cf25bd041b2b3ade4dca26e7f58cdbfc) python310Packages.mcstatus: 10.0.1 -> 10.0.2
* [`a0f8ef40`](https://github.com/NixOS/nixpkgs/commit/a0f8ef409ac6186b84dc593c9c00318724eff5c2) python-language-server: remove
* [`54e37e1a`](https://github.com/NixOS/nixpkgs/commit/54e37e1a1d05226761bfc604db8da15b70ea5097) freerdpUnstable: 2.9.0 -> 2.10.0
* [`4813c90d`](https://github.com/NixOS/nixpkgs/commit/4813c90dcf8398fcb38ba40e8ee640205b3ec928) nchat: init at 3.17
* [`8c616c69`](https://github.com/NixOS/nixpkgs/commit/8c616c699cd31011a6ca44921f335d5568be74ba) goffice: 0.10.54 → 0.10.55
* [`f71ede16`](https://github.com/NixOS/nixpkgs/commit/f71ede1693c9a1021b3f8abe6fea4903921337b3) gnumeric: 1.12.54 → 1.12.55
* [`986a6c6e`](https://github.com/NixOS/nixpkgs/commit/986a6c6e16cf304bbc3e7873207da02607f65332) ocamlPackages.paf: 0.3.0 → 0.4.0
* [`cbcd0166`](https://github.com/NixOS/nixpkgs/commit/cbcd016672a1a3101d7cdf8d199a07eb99729835) libisds: avoid build failure after curl update
* [`e8f21cba`](https://github.com/NixOS/nixpkgs/commit/e8f21cbac9ac2ab0020c7a51564f0f5b556f73d3) cinnamon.warpinator: 1.4.4 -> 1.4.5
* [`09268314`](https://github.com/NixOS/nixpkgs/commit/09268314d27c1b4bcbaa9bcdf944d311fc7d697a) aravis: 0.8.24 -> 0.8.26
* [`9a0c8c5c`](https://github.com/NixOS/nixpkgs/commit/9a0c8c5c4445533bb143d31dc1405b806042b3e8) clash-geoip: 20230112 -> 20230212
* [`b8701174`](https://github.com/NixOS/nixpkgs/commit/b8701174d480381223c582cb8b449b6ed612a8ad) amdvlk: 2022.Q4.4 → 2023.Q1.2
* [`1e75de33`](https://github.com/NixOS/nixpkgs/commit/1e75de336c3eca39b23d55ca696528c0c0a16a37) nixos/mbpfan: add aggressive option
* [`e9f759c8`](https://github.com/NixOS/nixpkgs/commit/e9f759c8257680e2430481cb2cce83b5a6d5f315) element-{web,desktop}: 1.11.22 -> 1.11.23
* [`8239d1fd`](https://github.com/NixOS/nixpkgs/commit/8239d1fde5407c7530d95c22c8206f5b552248d1) domoticz: 2022.2 -> 2023.1
* [`7ea75aa6`](https://github.com/NixOS/nixpkgs/commit/7ea75aa672527ba9f4623955a0d1d4fccf759de3) diswall: 0.3.0 -> 0.3.1
* [`d076d05d`](https://github.com/NixOS/nixpkgs/commit/d076d05deb328757db814b421ce294b405577cf5) icinga2: 2.13.6 -> 2.13.7
* [`0e92f9eb`](https://github.com/NixOS/nixpkgs/commit/0e92f9ebceddcea2f9243cd17abc46ac99745c57) python311Packages.boltons: add changelog to meta
* [`fff94b11`](https://github.com/NixOS/nixpkgs/commit/fff94b111d928c0f03f6c4a5da0a6ebeada37e05) python311Packages.boltons: disable failing test on Python 3.11
* [`17146a57`](https://github.com/NixOS/nixpkgs/commit/17146a573627175f1f1fe34faeb0d832c22ace59) python310Packages.huggingface-hub: 0.11.1 -> 0.12.1
* [`3a11d629`](https://github.com/NixOS/nixpkgs/commit/3a11d629f09b68433643dc4bcdd1ff7045dcc00a) linux_xanmod_latest: 6.1.7 -> 6.1.12
* [`d575718c`](https://github.com/NixOS/nixpkgs/commit/d575718cc35456aab00fd6ea25c5f6a1038f9c2f) python311Packages.datadog: add changelog to meta
* [`734f3226`](https://github.com/NixOS/nixpkgs/commit/734f322686694ee0a43ece28954394c3b355ed98) python311Packages.datadog: disable on unsupported Python releases
* [`c3bf65df`](https://github.com/NixOS/nixpkgs/commit/c3bf65df673ad1bd7141b87af6d528bf5d027266)  ocaml: remove spaceTimeSupport after 4.12
* [`0f701851`](https://github.com/NixOS/nixpkgs/commit/0f701851358739d8703ba4dcc29b6ef339f24203) caddy: install man pages
* [`3a574538`](https://github.com/NixOS/nixpkgs/commit/3a574538ee8e600f2bd3498af6cfa883af304894) caddy: add shell completions for fish
* [`145d1f37`](https://github.com/NixOS/nixpkgs/commit/145d1f379db37559a09870fc1d28537dc0651062) python311Packages.datadog: disable failing tests on Python 3.11
* [`6ea702f2`](https://github.com/NixOS/nixpkgs/commit/6ea702f2a01e25ddec443736146b736d6aee9b69) cimg: Add gmic and gmic-qt to passthru.tests
* [`a0796065`](https://github.com/NixOS/nixpkgs/commit/a07960652c65883166b7d6ad4da625ffcbea8484) gmic: Add gmic-qt to passthru.tests
* [`c4d80af5`](https://github.com/NixOS/nixpkgs/commit/c4d80af5bd57db5c10a992ea8d7b6b4acdd557b3) gmic: fix update script
* [`8e9e60c4`](https://github.com/NixOS/nixpkgs/commit/8e9e60c483665fb523554dc2e9eeed34d1c2f8c3) gmic: 3.2.0 → 3.2.1
* [`02be63fa`](https://github.com/NixOS/nixpkgs/commit/02be63faedcd2e6283ece368bb8d248c657aeb26) gmic-qt: add update script
* [`24f2c744`](https://github.com/NixOS/nixpkgs/commit/24f2c744c71b024adedea79421ef8ec5027dfb21) gmic-qt: 3.2.0 → 3.2.1
* [`d7bf4cb9`](https://github.com/NixOS/nixpkgs/commit/d7bf4cb9020d0c369fc67f559b5a31bae0619172) python311Packages.glom: add changelog to meta
* [`13b94f18`](https://github.com/NixOS/nixpkgs/commit/13b94f186cbe94b43793a14b7c0d681f928a0efe) keynav: update
* [`f1e1feed`](https://github.com/NixOS/nixpkgs/commit/f1e1feedac3673a27a3893693bf76f2d613931ea) python311Packages.glom: disable failing tests on Python 3.11
* [`fdfb7f36`](https://github.com/NixOS/nixpkgs/commit/fdfb7f360706f652e1c48433acb1ddfc12ddbaf2) python310Packages.dinghy: add changelog to meta
* [`d4f730ee`](https://github.com/NixOS/nixpkgs/commit/d4f730eea658d6aae88e6451d380bbd910b36ee3) python311Packages.eliot: switch to pytestCheckHook
* [`cfd6efaf`](https://github.com/NixOS/nixpkgs/commit/cfd6efafc8de39f37cee550f086bc99af76d0bb8) python310Packages.pyomo: 6.4.4 -> 6.5.0
* [`402b1ebd`](https://github.com/NixOS/nixpkgs/commit/402b1ebdcc6e9ecec91a384cfa1598aa89d362cc) pkgsStatic.slstatus: fix build
* [`a6cf80bb`](https://github.com/NixOS/nixpkgs/commit/a6cf80bb508e34389cd4d8977b88bf7130c60009) ffcast: Fix ffmpeg dependency for screenshot
* [`d6dd12a2`](https://github.com/NixOS/nixpkgs/commit/d6dd12a2c95d2865e78e34ec447400b55abc9407) python311Packages.gradient_statsd: add missing inputs
* [`f41ee288`](https://github.com/NixOS/nixpkgs/commit/f41ee288c14513ceb66770e40a43390a57cd7500) python310Packages.phonenumbers: 8.13.3 -> 8.13.6
* [`aebdd631`](https://github.com/NixOS/nixpkgs/commit/aebdd631d1395bb43e0f989be26ae397f9d98186) python310Packages.mypy-boto3-builder: 7.12.3 -> 7.12.4
* [`64ec496e`](https://github.com/NixOS/nixpkgs/commit/64ec496e2c55d7639f6b228e27ac4f3c8feeb117) python310Packages.phonenumbers: add changelog to meta
* [`743bd1f2`](https://github.com/NixOS/nixpkgs/commit/743bd1f29fb0c2aeeb8e756f23f44a51e4de3596) linux: fix-build on i686
* [`43386c39`](https://github.com/NixOS/nixpkgs/commit/43386c395d585dc1c03c7d4a06ca61401428aa68) python310Packages.types-psutil: 5.9.5.5 -> 5.9.5.7
* [`0a2dd8fb`](https://github.com/NixOS/nixpkgs/commit/0a2dd8fb201118549841c98edd1d84bf33a1cf8f) python310Packages.testcontainers: 3.7.0 -> 3.7.1
* [`bfac2d00`](https://github.com/NixOS/nixpkgs/commit/bfac2d0034f395a8dbcd7eabe633e68757c3f1c9) treewide:replace http by https when https is a permanent redirection
* [`17d9434c`](https://github.com/NixOS/nixpkgs/commit/17d9434c6f7a631b0a707e75af43199068c2d1d8) python310Packages.restview: add changelog to meta
* [`0382f94f`](https://github.com/NixOS/nixpkgs/commit/0382f94f0463af1d322b0f29007497c04c15d493) python310Packages.qiling: add changelog to emta
* [`e00fa961`](https://github.com/NixOS/nixpkgs/commit/e00fa961ed33e59510854b1c89c90d2fd62efcd4) gmic-qt: Add gimp plug-in to passthru.tests
* [`63e4a922`](https://github.com/NixOS/nixpkgs/commit/63e4a922175abf5f7d5087225bc046b0177348f5) gmic-qt: Mark as broken
* [`4624ec9f`](https://github.com/NixOS/nixpkgs/commit/4624ec9f3e4280d2e052cfbbe2e18fb681424414) maintainers: add cbrewster
* [`10b858a0`](https://github.com/NixOS/nixpkgs/commit/10b858a0222157b5bccf8b8d096997a3c4e017fb) appdaemon: 4.0.8 -> 4.2.1
* [`3f8ad50f`](https://github.com/NixOS/nixpkgs/commit/3f8ad50f9afc077784c260f0e3c948c926f0d402) build-support/vm/deb/deb-closure: quote generated urls
* [`d3b783f2`](https://github.com/NixOS/nixpkgs/commit/d3b783f29b7666dff6a4b33eb134c01d0e93b90d) commix: 3.6 -> 3.7
* [`2cf29e46`](https://github.com/NixOS/nixpkgs/commit/2cf29e463524e46d0aa34f3aac26bd628ef1166f) mfoc-hardnested: init at unstable-2021-08-14
* [`e3926b70`](https://github.com/NixOS/nixpkgs/commit/e3926b7046e45ac29f20802637e9a51273cb0771) python310Packages.ansible-lint: 6.13.0 -> 6.13.1
* [`7addad2d`](https://github.com/NixOS/nixpkgs/commit/7addad2d7c3b302beca4474a2902fb6b0ee2934e) shadowsocks-rust: fixup after https://github.com/NixOS/nixpkgs/pull/214126
* [`be4d5cb0`](https://github.com/NixOS/nixpkgs/commit/be4d5cb0edd434d9522b9acd57f6118e6f762c58) python310Packages.dvc-render: 0.0.17 -> 0.2.0
* [`412c90af`](https://github.com/NixOS/nixpkgs/commit/412c90af392047b93284b725744bb5509c153bf6) nwg-panel: 0.7.16 -> 0.7.17
* [`10e3e7cc`](https://github.com/NixOS/nixpkgs/commit/10e3e7ccb93de15a9f5ea9851a04b45d5091b82c) python310Packages.azure-mgmt-kusto: 3.0.0 -> 3.1.0
* [`50bfecb5`](https://github.com/NixOS/nixpkgs/commit/50bfecb5bc311222c2e7acdbeb94a85710755d1a) streamlink: 5.2.1 -> 5.3.0
* [`9c87dcbf`](https://github.com/NixOS/nixpkgs/commit/9c87dcbf85069c5a94325c0eec52623f77689353) maintainers: fix incorrect Matrix for toastal
* [`654cc11a`](https://github.com/NixOS/nixpkgs/commit/654cc11a5f4c19bc9f0a719b02f8e08e5b4efc60) git-machete: 3.15.0 -> 3.15.2
* [`434bb4d0`](https://github.com/NixOS/nixpkgs/commit/434bb4d090db77c495c1bb2bcf9bb97447b42b0a) librtlsdr: remove
* [`af260c1e`](https://github.com/NixOS/nixpkgs/commit/af260c1e5a5d9dc0fa046343f2151e0fe743495c) wezterm: fix build against rust 1.67, remove outdated checkFlags
* [`c90dcc73`](https://github.com/NixOS/nixpkgs/commit/c90dcc73273387b152e7d3cf1a50abec00c3204b) rustc: add ripgrep and wezterm to passthru.tests
* [`8be63c2f`](https://github.com/NixOS/nixpkgs/commit/8be63c2f948c7329faba3becb39f7bf31f5082bb) wezterm: cleanup meta, format
* [`759bd7b2`](https://github.com/NixOS/nixpkgs/commit/759bd7b26f363f4701cb9a44da578fcf4676f103) clippy: fix on darwin
* [`fd5fa383`](https://github.com/NixOS/nixpkgs/commit/fd5fa383fe79a0582100a26fa223a9099d5bac7e) clippy: drop rustc from buildInputs
* [`f08437ed`](https://github.com/NixOS/nixpkgs/commit/f08437edcb9249eb7bd9f9ebe11982ac5dbf655c) clippy: add rust team to maintainers
* [`20539ac2`](https://github.com/NixOS/nixpkgs/commit/20539ac23d38ef257b5db8d199ad1eb17f25b2f1) prefetch-npm-deps: add nix to PATH
* [`f70068f8`](https://github.com/NixOS/nixpkgs/commit/f70068f86dfb78408ceeff3d2595dbfcddba2643) python310Packages.python-novaclient: 18.2.0 -> 18.3.0
* [`10803b96`](https://github.com/NixOS/nixpkgs/commit/10803b968b2be9cfbf3137904908c80057fcc728) unison: 2.52.1 -> 2.53.0
* [`1fe9b33a`](https://github.com/NixOS/nixpkgs/commit/1fe9b33a8fefca1b222281c85393ea05d8eb48e8) python310Packages.flake8-bugbear: 23.1.20 -> 23.2.13
* [`ced929a2`](https://github.com/NixOS/nixpkgs/commit/ced929a2d02672e23f5c528829b9b99988476c16) nixos/tests: add test for luksroot and initrd keymaps ([nixos/nixpkgs⁠#189725](https://togithub.com/nixos/nixpkgs/issues/189725))
* [`37cc718b`](https://github.com/NixOS/nixpkgs/commit/37cc718bf9a3dc1c2251906650e04a2d3564ca57) liburing: backport portability fixes ([nixos/nixpkgs⁠#216975](https://togithub.com/nixos/nixpkgs/issues/216975))
* [`91cfaa25`](https://github.com/NixOS/nixpkgs/commit/91cfaa255c6ee4df0234294035346abffbb4cdd3) ppp: add ppp_defs.h shim for musl
* [`ab28fd01`](https://github.com/NixOS/nixpkgs/commit/ab28fd0173ba84e355118e4761c1acb900654369) clucene_core_2: fix build with musl and gcc>=11 ([nixos/nixpkgs⁠#217146](https://togithub.com/nixos/nixpkgs/issues/217146))
* [`68787dcc`](https://github.com/NixOS/nixpkgs/commit/68787dccb0e068e617a063cb939edda060391d58) python310Packages.python-cinderclient: 9.2.0 -> 9.3.0
* [`a3a92e39`](https://github.com/NixOS/nixpkgs/commit/a3a92e390132607721ecb77250488bbc16ad1b49) python310Packages.ipydatawidgets: 4.3.2 -> 4.3.3
* [`a0343b26`](https://github.com/NixOS/nixpkgs/commit/a0343b268a128abb3d3a0788b3b4f2cfc5d00005) python310Packages.first: add changelog to meta
* [`c1cf1216`](https://github.com/NixOS/nixpkgs/commit/c1cf12166281741e877e4c33f2c9f6c440ef3ae4) python310Packages.first: add pythonImportsCheck
* [`93218068`](https://github.com/NixOS/nixpkgs/commit/93218068b2620cee8afcdb28bdf05dfa5a03c1cd) wiki-js: 2.5.296 -> 2.5.297
* [`7be7a41d`](https://github.com/NixOS/nixpkgs/commit/7be7a41d47196da7b72db0b00acdcf2d3a433b3f) python310Packages.pytest-check: 1.3.0 -> 2.1.4
* [`09785415`](https://github.com/NixOS/nixpkgs/commit/0978541585d2c9fec1bbdc46df3d3633f0c09565) python310Packages.overrides: init at 7.3.1
* [`51094d7c`](https://github.com/NixOS/nixpkgs/commit/51094d7cf348e96852cd0c88c1a68918f8f9d261) nvc: 1.8.1 -> 1.8.2
* [`b11de88b`](https://github.com/NixOS/nixpkgs/commit/b11de88b221ed5fce626b0ff0562635273894fec) ovftool: 4.4.1-16812187 -> 4.5.0-20459872
* [`5e6a7aab`](https://github.com/NixOS/nixpkgs/commit/5e6a7aab54dc26cfc8f2c14867f04972eb3b6fe5) .editorconfig: exempt test OVA files packaged with ovftool
* [`e0400686`](https://github.com/NixOS/nixpkgs/commit/e04006869b09a3beb45fb7825282a043a6bedd82) python310Packages.python-fx: init at 0.2.0
* [`2da2df38`](https://github.com/NixOS/nixpkgs/commit/2da2df387370a860fb8aeb34c03485f12fb19d64) python310Packages.qiling: 1.4.4 -> 1.4.5
* [`25f5fe32`](https://github.com/NixOS/nixpkgs/commit/25f5fe3200056478564968d49c810d6df59275e8) iosevka-bin: 19.0.0 -> 19.0.1
* [`46d790b4`](https://github.com/NixOS/nixpkgs/commit/46d790b44bb41ce7379e49d19aec94f43222d024) python310Packages.quantities: 0.13.0 -> 0.14.1
* [`0b286bd6`](https://github.com/NixOS/nixpkgs/commit/0b286bd6ef4276af6e415dfa598ff6266056821f) ntfy-sh: 1.31.0 -> 2.0.1
* [`201a78e5`](https://github.com/NixOS/nixpkgs/commit/201a78e51cc1242343cb9dba05b4481fff60fb42) python310Packages.entrance: 1.1.17 -> 1.1.20
* [`430385ca`](https://github.com/NixOS/nixpkgs/commit/430385cad56869d1163bd4020dc5a59a4f633aec) ocamlPackages.simple-diff: init at 0.3
* [`65a2ffba`](https://github.com/NixOS/nixpkgs/commit/65a2ffba207a43c13ab8eff94986199bb90048f4) ligo: 0.59.0 -> 0.60.0
* [`72a48aaa`](https://github.com/NixOS/nixpkgs/commit/72a48aaacd4523fd7d5829cc549f6add32ec6cf6) v2ray-geoip: 202302160443 -> 202302200325
* [`38f63762`](https://github.com/NixOS/nixpkgs/commit/38f637624366ac5ed856eb36eb9c524aa615f03a) python310Packages.quantities: add changelog to meta
* [`dec690df`](https://github.com/NixOS/nixpkgs/commit/dec690df7fa58c88e3bd28d10b51c1aee4795c32) python310Packages.quantities: disable on unsupported Python releases
* [`bd189f47`](https://github.com/NixOS/nixpkgs/commit/bd189f478f4fa419611c90f88d494f0a85e37f25) python310Packages.neo: add changelog to meta
* [`2e75e17a`](https://github.com/NixOS/nixpkgs/commit/2e75e17a54dfcad2c23a0e01c0aa06f55fdf5bb0) python311Packages.neo: 0.11.1 -> 0.12.0
* [`e4b42071`](https://github.com/NixOS/nixpkgs/commit/e4b420716f8fd98dd54867662fb30872a002106b) python310Packages.quantities: add nativeBuildInputs
* [`522512e7`](https://github.com/NixOS/nixpkgs/commit/522512e7b46054645bba9deefb90547d47dbd149) linux: init 6.2
* [`f2445f30`](https://github.com/NixOS/nixpkgs/commit/f2445f305d1f889655388897ef7f60bd9c8a2b97) python310Packages.mcstatus: add changelog to meta
* [`f2a054c0`](https://github.com/NixOS/nixpkgs/commit/f2a054c03fce7c64a20085fa15495ae25709faba) go-cve-search: add changelog to meta
* [`8fab0b16`](https://github.com/NixOS/nixpkgs/commit/8fab0b16e2b2e37811188fa5d558b88128723849) domoticz: Add changelog
* [`3092bd8a`](https://github.com/NixOS/nixpkgs/commit/3092bd8a790e4b3950f70594d81dd93903a328e6) python310Packages.lupupy: 0.2.8 -> 0.3.0
* [`17a476a3`](https://github.com/NixOS/nixpkgs/commit/17a476a3a64acf23565af7af2f08bac56df2ab1e) python310Packages.yfinance: 0.2.11 -> 0.2.12
* [`5c458b42`](https://github.com/NixOS/nixpkgs/commit/5c458b422bfd4782cbead4470abcd2473414bd09) python310Packages.pyunifiprotect: 4.6.2 -> 4.7.0
* [`c80bfb40`](https://github.com/NixOS/nixpkgs/commit/c80bfb405221c7658a598744e617c762c7ab1972) python310Packages.aiohomekit: 2.5.0 -> 2.6.1
* [`4df8f9a2`](https://github.com/NixOS/nixpkgs/commit/4df8f9a2f82c85a8c2ef64362cef5a3cec695dbb) make-initrd-ng: support wrapped executables
* [`d01bc6f9`](https://github.com/NixOS/nixpkgs/commit/d01bc6f9cb7b0b1851fdd80ab45eaccc07e9730d) make-initrd-ng: document wrapped file behavior
* [`1fa1b58c`](https://github.com/NixOS/nixpkgs/commit/1fa1b58c2521cc8aa2e4eca41e1422df4724e199) nixos/console,nixos/systemd-initrd: remove now-unnecessary wrapped bin inclusions
* [`e83babd4`](https://github.com/NixOS/nixpkgs/commit/e83babd4939e26279da58cb9e448848bec5de8f7) nixos/tests/systemd-credentials-tpm2: Add tests for systemd credentials
* [`e12c2855`](https://github.com/NixOS/nixpkgs/commit/e12c28553181183686812f0c58e7464807e1008b) prospector: 1.8.4 -> 1.9.0
* [`a43dc018`](https://github.com/NixOS/nixpkgs/commit/a43dc01871b7e90d12113ec79a7b55d9f3b259ce) clash-meta: init at 1.14.2
* [`cb04c509`](https://github.com/NixOS/nixpkgs/commit/cb04c509120050091f85e0d8cd0179f1bd7f42db) gitea: 1.18.3 -> 1.18.4
* [`433e205e`](https://github.com/NixOS/nixpkgs/commit/433e205e25ae5d8e9e2dfa4f05c31faac67c3847) firefox-devedition-bin-unwrapped: 110.0b9 -> 111.0b3
* [`2167e43a`](https://github.com/NixOS/nixpkgs/commit/2167e43ab85037c587ddfa9b1a0823a8e849af80) czkawka: 5.0.2 -> 5.1.0
* [`859212e3`](https://github.com/NixOS/nixpkgs/commit/859212e303874ebbf0fafae1087c57c775daed9a) czkawka: add meta.changelog, use hash
* [`075bf797`](https://github.com/NixOS/nixpkgs/commit/075bf7974485c26d66406c2a790cc4f97a79b4bb) zine: 0.10.1 -> 0.11.0
* [`5455a9de`](https://github.com/NixOS/nixpkgs/commit/5455a9deb2d650f6d1d25c6095c30e74c06fdaa8) golangci-lint: 1.51.1 -> 1.51.2
* [`20c135b1`](https://github.com/NixOS/nixpkgs/commit/20c135b191fd84f556cc5eb37b8d9d683a580b1e) docs: borg expects --rsh, not -rsh
* [`eaf54489`](https://github.com/NixOS/nixpkgs/commit/eaf54489440729d4a84ee684898bbf059e9a7f1c)  cloudlog: add passthru update script
* [`e69c0d69`](https://github.com/NixOS/nixpkgs/commit/e69c0d6910fb3299095914f54843a1083f61c0bf)  cloudlog: 2.3.3. -> 2.4
* [`0fae3035`](https://github.com/NixOS/nixpkgs/commit/0fae3035a1910b6bdbc35a5359f589f08ffc566e) lilypond: 2.24.0 -> 2.24.1
* [`ba3f159c`](https://github.com/NixOS/nixpkgs/commit/ba3f159cc8261160511b0c7f42446b7d3a66de1b) nixos/tests/home-assistant: Overhaul and refactor
* [`3fa7dc20`](https://github.com/NixOS/nixpkgs/commit/3fa7dc206a54265f04fc2ea2afd1cf1cdb650c83) home-assistant: Stop exposing component & package files
* [`e01ccd62`](https://github.com/NixOS/nixpkgs/commit/e01ccd6245fe1fe34aa49aa48fe3d53e3b013c20) home-assistant: Inject extra dependencies through PYTHONPATH
* [`9bf8744a`](https://github.com/NixOS/nixpkgs/commit/9bf8744a732fad91482a66c28c5462a683be727c) nixos/tests/home-assistant: Check dependencies arrive in the PYTHONPATH
* [`f98462a2`](https://github.com/NixOS/nixpkgs/commit/f98462a27d097f1b8397ed07ca545b26009bf6c9) nixos/tests/home-assistant: Resolve deprecation warning
* [`143f3098`](https://github.com/NixOS/nixpkgs/commit/143f30987c07bedd593fa2de846b1ebb5d98980c) polypane: 10.0.1 -> 13.0.2
* [`a3c9f191`](https://github.com/NixOS/nixpkgs/commit/a3c9f191bf4e951f65d3dddfa5c353eb5efb8dce) python310Packages.yalexs: 1.2.6 -> 1.2.8
* [`d83759c1`](https://github.com/NixOS/nixpkgs/commit/d83759c1af2448a927b45660f02f23452597adf3) python3Packages.screed: 1.1.1 -> 1.1.2
* [`82b31b53`](https://github.com/NixOS/nixpkgs/commit/82b31b530d24995c823338a8799edadbccf7bc8c) foxitreader: drop
* [`bb7490c7`](https://github.com/NixOS/nixpkgs/commit/bb7490c76b38a96ab56a7b4808e7210daa7d1acd) chatty: 0.7.0_rc5 -> 0.7.0
* [`09e298dc`](https://github.com/NixOS/nixpkgs/commit/09e298dc8ef984f8b604bf74e26794c4018aec10) ibus: build without dbus-launch
* [`c8d94feb`](https://github.com/NixOS/nixpkgs/commit/c8d94febd7f6869eae615afe4fea077d2fbf206c) python310Packages.yalexs: add changelog to meta
* [`a7d95c38`](https://github.com/NixOS/nixpkgs/commit/a7d95c3874d3dd7dc773cdac9a61d2ff1106e250) python310Packages.yalexs: update disabled
* [`b5c3d554`](https://github.com/NixOS/nixpkgs/commit/b5c3d554f58bb07964870e414b5eee6c9eae7d1a) python310Packages.yalexs: remove asynctest
* [`7a76e0a1`](https://github.com/NixOS/nixpkgs/commit/7a76e0a1a83da876114841189f22fd29a72dec41) datree: 1.8.21 -> 1.8.24
* [`ec92fa54`](https://github.com/NixOS/nixpkgs/commit/ec92fa5402fa36ea1dd01217369e042fbf9f7502) ipxe: unstable-2023-01-25 -> unstable-2023-02-20
* [`4ca106a6`](https://github.com/NixOS/nixpkgs/commit/4ca106a6a033ad7acb13c27bf53b5476e8a443fe) tor-browser-bundle-bin: 11.5.8 -> 12.0.3
* [`dbd1ee56`](https://github.com/NixOS/nixpkgs/commit/dbd1ee56b1ad4219d9c2f5568bbac2e57b25f109) broot: 1.20.1 -> 1.20.2
* [`05946318`](https://github.com/NixOS/nixpkgs/commit/05946318dd3cc95d2e60ffd94097b908f08e140a) fldigi: 4.1.23 -> 4.1.25
* [`bfb63ef4`](https://github.com/NixOS/nixpkgs/commit/bfb63ef47f5a55939cf42d4e34e857f42ee9451a) vimPlugins.go-nvim: init at 2023-02-19
* [`4375ddbf`](https://github.com/NixOS/nixpkgs/commit/4375ddbf1fda94712fc6075769aaec66719547ae) cppcheck: 2.9.3 -> 2.10
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
