### PR TITLE
niv devenv: update 66b895f6 -> 96844436

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "66b895f6643912b25ae4be359b3839f3b2aa794a",
-        "sha256": "0xzi1svzm8bw9hac2ixcxb228krfadqry2p44wqmvnd11g7m71ds",
+        "rev": "9684443646e044f08e72765642ea9d3cef78445e",
+        "sha256": "15n0j9468v260fn7vy6czps6f9qc0xxh8mlja00gb8k4m6wkhacn",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/66b895f6643912b25ae4be359b3839f3b2aa794a.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/9684443646e044f08e72765642ea9d3cef78445e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@66b895f6...96844436](https://github.com/cachix/devenv/compare/66b895f6643912b25ae4be359b3839f3b2aa794a...9684443646e044f08e72765642ea9d3cef78445e)

* [`7ba71022`](https://github.com/cachix/devenv/commit/7ba710226c933e176c66355c001ff5997468df6d) feat: add couchdb as a new service
* [`5e4f95dc`](https://github.com/cachix/devenv/commit/5e4f95dcd24a544439559cec325d6636d90a7cbb) fix: remove unused imports on couchdb
* [`bb73dccf`](https://github.com/cachix/devenv/commit/bb73dccff6067fcc6c64ef4778fd9c4cd401febc) docs: couchdb example
* [`fc93ee80`](https://github.com/cachix/devenv/commit/fc93ee80b45d51d750e40f4a23400f566eccbdc3) refactor: change the config file to a unique settings option
* [`345e087d`](https://github.com/cachix/devenv/commit/345e087d7ba820f698379724b28e4d739bf8f4ee) remvoe startscript from packages
* [`3b70b8a6`](https://github.com/cachix/devenv/commit/3b70b8a6470ce3ce9caca22b57af95ca72813df3) add settings data types
* [`b3fa7611`](https://github.com/cachix/devenv/commit/b3fa761118cd377e4aea62f570c3ff095181ec14) add options description
* [`1c1d33c5`](https://github.com/cachix/devenv/commit/1c1d33c5c15ee8d7efcacc2f5d75756932a6e14b) Do not escape strings for process-compose env vars
* [`a16c6bce`](https://github.com/cachix/devenv/commit/a16c6bce829d90e3830abf3d149c9386082c625c) Postgres + Process-compose: faster shutdown + restart on failure
* [`c99b424c`](https://github.com/cachix/devenv/commit/c99b424cc868392df845b1d3cd52d254092f3c63) fix: doc generation
* [`2b3c0d56`](https://github.com/cachix/devenv/commit/2b3c0d566ceea54ce4f3558bb376df6e93ccb922) Auto generate docs/reference/options.md
* [`4125e1d0`](https://github.com/cachix/devenv/commit/4125e1d0bb196b704593352c19cb9210d0f03687) Fix typo
* [`98451097`](https://github.com/cachix/devenv/commit/984510974e308d464d473c9ff2a8a1483b8cd116) feat: Add Ansible support
* [`1aa3dbbf`](https://github.com/cachix/devenv/commit/1aa3dbbf745f50e77aadc016d124fed3ca2dc9be) Auto generate docs/reference/options.md
* [`cbff56d4`](https://github.com/cachix/devenv/commit/cbff56d49bd961a4518e1e5caef2fbf7d4f62c2a) feat(go): use correct go version for tools
* [`d0c5490b`](https://github.com/cachix/devenv/commit/d0c5490bc6d87b408f647dd6babcbb97160b4c93) chore(deps): bump cachix/install-nix-action from 18 to 19
