### PR TITLE
niv zsh-completions: update 4de5a8cc -> 98ea8e68

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "4de5a8cc6a5e4b9e2cea9afd7c0460aca874bac2",
-        "sha256": "1npqr7mkc4v7i2iic1qby9yfg3w4y0mxmf9imavhb3j0a6aqscm2",
+        "rev": "98ea8e685c1a9630a21b39a1596cb94794d1cb3c",
+        "sha256": "1dqzva9mr1i4icr58gcilw7y6r8bsk35b0adh5x38kacgd9kvp2s",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/4de5a8cc6a5e4b9e2cea9afd7c0460aca874bac2.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/98ea8e685c1a9630a21b39a1596cb94794d1cb3c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@4de5a8cc...98ea8e68](https://github.com/zsh-users/zsh-completions/compare/4de5a8cc6a5e4b9e2cea9afd7c0460aca874bac2...98ea8e685c1a9630a21b39a1596cb94794d1cb3c)

* [`348187fa`](https://github.com/zsh-users/zsh-completions/commit/348187fac28d5fbdb3a3e4ac66ab74cf36bc11b5) Fix `--ostype` argument of `vboxmanage createvm` command
* [`b030b22f`](https://github.com/zsh-users/zsh-completions/commit/b030b22f6423ddc69805e128d3a338b4aa2e2681) Fix misleading description for `vboxmanage --ostype` values
* [`9fa28bec`](https://github.com/zsh-users/zsh-completions/commit/9fa28becbaad71ef25675f64eb6c19b2351faf86) Fixed `vboxmanage closemedium` redundant parameters completion:
* [`234e5d3e`](https://github.com/zsh-users/zsh-completions/commit/234e5d3e6126b334c1af220ea3b14c4586c2c659) Fix `vboxmanage` medium-related commands parameters:
* [`ddb66cf1`](https://github.com/zsh-users/zsh-completions/commit/ddb66cf14c992e2cf336564fc9c93f0fa0f613bf) Update node.js completion for version 19.7.0
* [`40ae92e1`](https://github.com/zsh-users/zsh-completions/commit/40ae92e11289b42704f577ca6e47b306dd8bb670) Update conan completion and refactoring
