### PR TITLE
niv emacs-overlay: update f5689d4d -> 545383bd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f5689d4d9a0d1c4dd8fee769d137daec0f02dc4a",
-        "sha256": "1gcm3vlkzrrbzzqzhvlfydhy842rc7arm1lwqgf4yyh0f6j4axpx",
+        "rev": "545383bd7de8e3f100356fea217698379d8f5c31",
+        "sha256": "0bkhjhh20wxq6qxvnfc7hfzin7j4waqm5wz346cmlzlfqy2rkd5i",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/f5689d4d9a0d1c4dd8fee769d137daec0f02dc4a.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/545383bd7de8e3f100356fea217698379d8f5c31.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@f5689d4d...545383bd](https://github.com/nix-community/emacs-overlay/compare/f5689d4d9a0d1c4dd8fee769d137daec0f02dc4a...545383bd7de8e3f100356fea217698379d8f5c31)

* [`93fa2b95`](https://github.com/nix-community/emacs-overlay/commit/93fa2b952d5e8e2298cbaea41ab2f6bcb72129a4) Updated repos/elpa
* [`eb87090c`](https://github.com/nix-community/emacs-overlay/commit/eb87090cbbf8442fe7b819022c2d3d276947a14c) Updated repos/melpa
* [`4c9e92d1`](https://github.com/nix-community/emacs-overlay/commit/4c9e92d154e474fcc91e37dd63985a6be94d7c5f) Updated repos/emacs
* [`d8710239`](https://github.com/nix-community/emacs-overlay/commit/d8710239637d59229781cbdc9f9dc292a9123e80) Updated repos/melpa
* [`dde3396d`](https://github.com/nix-community/emacs-overlay/commit/dde3396d92ad61a8c73c6a3b6c1bbb14a70c5e5e) Updated repos/nongnu
* [`4cabfe3a`](https://github.com/nix-community/emacs-overlay/commit/4cabfe3a98b11707c6bc03f12cc159bcc03857a0) Updated repos/elpa
* [`6bfbf908`](https://github.com/nix-community/emacs-overlay/commit/6bfbf90833b52f13946b332afa1c46bae56c2df2) Updated repos/melpa
* [`8f515d7f`](https://github.com/nix-community/emacs-overlay/commit/8f515d7f9a0ffd720c53b29beaf994b2c3b6193b) Updated repos/elpa
* [`f493f387`](https://github.com/nix-community/emacs-overlay/commit/f493f3870622604c0903ddc02c9879983e570b07) Updated repos/emacs
* [`e27c4761`](https://github.com/nix-community/emacs-overlay/commit/e27c4761fb5f1b19c5b25ae04ccfc6e2baceb6c9) Updated repos/melpa
* [`7276116f`](https://github.com/nix-community/emacs-overlay/commit/7276116feb26bf3fc2834709a2ea2f6ed738cc52) Updated repos/nongnu
* [`9641261d`](https://github.com/nix-community/emacs-overlay/commit/9641261d49ec2ae07e46317431b5bdd3afd394af) Updated repos/emacs
* [`d524102f`](https://github.com/nix-community/emacs-overlay/commit/d524102fb8d013a2c136ec09b51fb6fee886787c) Updated repos/melpa
* [`eedd527b`](https://github.com/nix-community/emacs-overlay/commit/eedd527b77067ad14cc295f278945ff8980196cf) Updated repos/elpa
* [`415ceab3`](https://github.com/nix-community/emacs-overlay/commit/415ceab3188cbf01679fded56c368892509aa184) Updated repos/emacs
* [`a0185772`](https://github.com/nix-community/emacs-overlay/commit/a018577287e390e01654a8b44d57d183a51b72b2) Updated repos/melpa
* [`27625286`](https://github.com/nix-community/emacs-overlay/commit/27625286ac637065286c1372d0eae66e3d16c146) Updated repos/melpa
* [`43c6ad70`](https://github.com/nix-community/emacs-overlay/commit/43c6ad70d8209ca65af056360a687e73c4166d05) Updated repos/emacs
* [`88dcf530`](https://github.com/nix-community/emacs-overlay/commit/88dcf53013b1f8f0a6a1766fc76ed181e0a6a8db) Updated repos/melpa
* [`c07791ce`](https://github.com/nix-community/emacs-overlay/commit/c07791ce9a407f6007842a1bfa5ccf7c037e317f) Updated repos/melpa
* [`3234e0e7`](https://github.com/nix-community/emacs-overlay/commit/3234e0e76bc5e8d4ade6b999bd037d7a6f4c4372) Updated repos/elpa
* [`0b567bc6`](https://github.com/nix-community/emacs-overlay/commit/0b567bc6ae7f9c39fef22a3f5de717f5860493db) Updated repos/emacs
* [`44cdc7a3`](https://github.com/nix-community/emacs-overlay/commit/44cdc7a37d1da2d7f6d27d602766bf2cdbf48ec3) Updated repos/melpa
* [`c48c8926`](https://github.com/nix-community/emacs-overlay/commit/c48c89261905dcf10c4824d531b0d8e5bb09ef8a) Updated repos/nongnu
* [`0d630ac0`](https://github.com/nix-community/emacs-overlay/commit/0d630ac0f6430797b885a86a6699e8c75093c513) Updated repos/melpa
* [`b481582f`](https://github.com/nix-community/emacs-overlay/commit/b481582f886a1589a5cf2b5912f51411dc2a32cb) Updated repos/emacs
* [`00fcdb0c`](https://github.com/nix-community/emacs-overlay/commit/00fcdb0c7f33f88bd8c84bff7f281f09b9985480) Updated repos/melpa
* [`362fd889`](https://github.com/nix-community/emacs-overlay/commit/362fd8897c86ef4e59e58ba733488df05b6a36d6) Updated repos/emacs
* [`48188e42`](https://github.com/nix-community/emacs-overlay/commit/48188e420b453dea7467f39a587e3a965c013815) Updated repos/melpa
* [`475c58ac`](https://github.com/nix-community/emacs-overlay/commit/475c58aca32b60826f2e9ac75b78006d5cecf6b5) Updated repos/melpa
* [`21539406`](https://github.com/nix-community/emacs-overlay/commit/215394062b3fc38d131fdf78725c1704e110ae19) allow tree-sitter grammars to be overridden
* [`2413b096`](https://github.com/nix-community/emacs-overlay/commit/2413b09697ce3273884e71f37c7e91c075dd5072) Updated repos/elpa
* [`5fd9ac22`](https://github.com/nix-community/emacs-overlay/commit/5fd9ac2245753d68d4f22739860889d37a0b71c3) Updated repos/emacs
* [`ea9cedde`](https://github.com/nix-community/emacs-overlay/commit/ea9ceddec99ab3c66017ab3104fb86863e26154a) Updated repos/melpa
* [`eab435bd`](https://github.com/nix-community/emacs-overlay/commit/eab435bdceac66ee1276173e7c3eab38aa0530cc) Updated repos/elpa
* [`cb76f25c`](https://github.com/nix-community/emacs-overlay/commit/cb76f25c777004ec105d2305f19f101ea846abb9) Updated repos/emacs
* [`8c20f1b7`](https://github.com/nix-community/emacs-overlay/commit/8c20f1b7fbed3744c5a4c46381781f14c1001269) Updated repos/melpa
* [`cf267241`](https://github.com/nix-community/emacs-overlay/commit/cf267241b56b425d20faed46ab8e16dd0434a663) Updated repos/melpa
* [`443cbd27`](https://github.com/nix-community/emacs-overlay/commit/443cbd27492b72b6568fee23974e0ee7f0d72ee3) Updated repos/melpa
* [`087f65ec`](https://github.com/nix-community/emacs-overlay/commit/087f65ecbc35a0b92389a217a1356494dcaeb9b4) Updated repos/elpa
* [`b46c1569`](https://github.com/nix-community/emacs-overlay/commit/b46c1569262843fe490663fa74f052f28b904bdb) Updated repos/emacs
* [`6020998b`](https://github.com/nix-community/emacs-overlay/commit/6020998bf96c71e24b628fa24721492266b66d5c) Updated repos/melpa
* [`ccd2eed0`](https://github.com/nix-community/emacs-overlay/commit/ccd2eed0dfea3511d38c99baa229200165d2b897) Updated repos/melpa
* [`913d3f9d`](https://github.com/nix-community/emacs-overlay/commit/913d3f9daf265d3e36b3820b2187b1d14f6cf589) Updated repos/elpa
* [`42ddff33`](https://github.com/nix-community/emacs-overlay/commit/42ddff336887c2dabc271a2a8c0336da1fba18f3) Updated repos/melpa
* [`ffeea040`](https://github.com/nix-community/emacs-overlay/commit/ffeea04060148f3f3907fd940dce0fb7b55b8bb3) Updated repos/elpa
* [`14d32596`](https://github.com/nix-community/emacs-overlay/commit/14d32596959c43802ce2eea26c1a8c9f751e3a13) Updated repos/emacs
* [`af05d7d8`](https://github.com/nix-community/emacs-overlay/commit/af05d7d8611d835111235890bf53bf1578153881) Updated repos/melpa
* [`d6123813`](https://github.com/nix-community/emacs-overlay/commit/d612381359e395796526040f4bfd3c469bb384a5) Updated repos/nongnu
* [`74ad8382`](https://github.com/nix-community/emacs-overlay/commit/74ad83821897f9c6a1f7aa55097479f99712c0e4) Updated repos/emacs
* [`9db1efe2`](https://github.com/nix-community/emacs-overlay/commit/9db1efe2aa74040b1f29210c2090022c1cf15f0f) Updated repos/melpa
* [`c1eb5198`](https://github.com/nix-community/emacs-overlay/commit/c1eb5198d74d4f3d3ca2522bf8e2a4d04f5688a9) Updated repos/nongnu
* [`3bf83d0c`](https://github.com/nix-community/emacs-overlay/commit/3bf83d0ca38be39b4d74e9ccc60fdc262c503883) Updated repos/elpa
* [`799a7d98`](https://github.com/nix-community/emacs-overlay/commit/799a7d981f2aad8dc6c702e5ec13d542a3d6c7af) Updated repos/emacs
* [`3a97f683`](https://github.com/nix-community/emacs-overlay/commit/3a97f6833b1416bbe1e832fdb2f136052e0ad2fd) Updated repos/melpa
* [`d9cfdfca`](https://github.com/nix-community/emacs-overlay/commit/d9cfdfcaeeddc5bf671c1c38ff46d0e2752b8fc2) Updated repos/elpa
* [`f79cf966`](https://github.com/nix-community/emacs-overlay/commit/f79cf966e065c871c53906c7536a793a054f3117) Updated repos/melpa
* [`0fe268a3`](https://github.com/nix-community/emacs-overlay/commit/0fe268a3b03ab9ef7a77363c64247030ee3902a7) Updated repos/nongnu
* [`c4cf66c3`](https://github.com/nix-community/emacs-overlay/commit/c4cf66c30122a0807d6dc91c5c8ec0ca650ecd24) Updated repos/emacs
* [`b70f136e`](https://github.com/nix-community/emacs-overlay/commit/b70f136e1c59d3733684d9bd9893d9153f810be3) Updated repos/melpa
* [`5efe1164`](https://github.com/nix-community/emacs-overlay/commit/5efe11646cbbd9c16c70cdf738104714252848b0) Updated repos/melpa
* [`71e56eeb`](https://github.com/nix-community/emacs-overlay/commit/71e56eeb054c4414de9b9de1482ca1bb780f9fc3) Updated repos/emacs
* [`b3aba0b7`](https://github.com/nix-community/emacs-overlay/commit/b3aba0b7082196d5f621267ff08b135f501073a2) Updated repos/melpa
* [`f7e1ecfa`](https://github.com/nix-community/emacs-overlay/commit/f7e1ecfac86dbb780449f3d5cf9d292df473cbee) Updated repos/nongnu
* [`4e14b32a`](https://github.com/nix-community/emacs-overlay/commit/4e14b32a700efeff5d15a5577fbca8d22e461795) Updated repos/emacs
* [`581072bb`](https://github.com/nix-community/emacs-overlay/commit/581072bb0d49768da9370056f7b6e7b761b5d8be) Updated repos/melpa
* [`e42a89b8`](https://github.com/nix-community/emacs-overlay/commit/e42a89b8223b01c50b41121e3b22164ac626ec06) Updated repos/melpa
* [`8960d6c7`](https://github.com/nix-community/emacs-overlay/commit/8960d6c78973d3ff733972474d770dc0c5bdfc7d) Updated repos/elpa
* [`8caf1c59`](https://github.com/nix-community/emacs-overlay/commit/8caf1c59131a246bb99fc93bea4bd6112509b38d) Updated repos/emacs
* [`928bc690`](https://github.com/nix-community/emacs-overlay/commit/928bc690506ebe43982fc896e30aff902f6dc784) Updated repos/melpa
* [`e725980d`](https://github.com/nix-community/emacs-overlay/commit/e725980d7fa44d2d7f4c93c348b9e14b2e3fb8a0) flake: Add `emacsPackagesFor`, `emacsWithPackages*` to `lib` output
* [`ef9967ba`](https://github.com/nix-community/emacs-overlay/commit/ef9967ba8bb412b38521150c445628e2823221ed) Updated repos/emacs
* [`b20d8af9`](https://github.com/nix-community/emacs-overlay/commit/b20d8af970870a47bd5462824a3b09b477dc774a) Updated repos/melpa
* [`8c7bcb6c`](https://github.com/nix-community/emacs-overlay/commit/8c7bcb6c7f20f90a94a06814fa70772345cd2e11) Updated repos/elpa
* [`ccf9eeb3`](https://github.com/nix-community/emacs-overlay/commit/ccf9eeb3b7653998f2359bd1a0334d5f760f5573) Updated repos/emacs
* [`b991fd49`](https://github.com/nix-community/emacs-overlay/commit/b991fd49bf64e4631f7e52d4af7a253f18c4e1e4) Updated repos/melpa
* [`5b908034`](https://github.com/nix-community/emacs-overlay/commit/5b908034d85f2f76fcc01953af2cb3405b9231e6) Updated repos/elpa
* [`6e752a15`](https://github.com/nix-community/emacs-overlay/commit/6e752a15496137308e732e5107a19a701f215a99) Updated repos/emacs
* [`242a703e`](https://github.com/nix-community/emacs-overlay/commit/242a703e80efb74f868cdcb54cd809ee03431665) Updated repos/melpa
* [`a68a3753`](https://github.com/nix-community/emacs-overlay/commit/a68a3753466c045db326a7f7b9a25b35a2935225) Updated repos/nongnu
* [`1fc9a171`](https://github.com/nix-community/emacs-overlay/commit/1fc9a1716a00967a14c12f3ead2fffdf63934f42) Updated repos/emacs
* [`25bc792c`](https://github.com/nix-community/emacs-overlay/commit/25bc792c9fe3ab354e7b51539b4da72ac821dde9) Updated repos/melpa
* [`74669061`](https://github.com/nix-community/emacs-overlay/commit/746690618d8e259949c97c8c04efc6c67b25b8ce) Updated repos/elpa
* [`d8c60bfb`](https://github.com/nix-community/emacs-overlay/commit/d8c60bfbaf71b57608744633346ec3f413257b7c) Updated repos/emacs
* [`558a102c`](https://github.com/nix-community/emacs-overlay/commit/558a102c165bdf22782cd8c5db2e0fb9578ddc0e) Updated repos/melpa
* [`2cb7ec2f`](https://github.com/nix-community/emacs-overlay/commit/2cb7ec2f6dc53efbbb817ec57a4d103e07a59656) flake.nix: cosmetics
* [`87ecbb91`](https://github.com/nix-community/emacs-overlay/commit/87ecbb91060cb6c9c69161b9abf4de924cefc99a) Updated repos/emacs
* [`09ebba15`](https://github.com/nix-community/emacs-overlay/commit/09ebba158540ba3171b5f319b71427b51db8794b) Updated repos/melpa
* [`8698300e`](https://github.com/nix-community/emacs-overlay/commit/8698300ee94b54337206b978c46ebcc1f9092de0) Updated repos/emacs
* [`dc9d1a2f`](https://github.com/nix-community/emacs-overlay/commit/dc9d1a2f5ccd547ea32f46313081827f05ec1dae) Updated repos/melpa
* [`d938b780`](https://github.com/nix-community/emacs-overlay/commit/d938b780a3d8072aeac0178c46121060079ff217) Updated repos/melpa
* [`46b97b3b`](https://github.com/nix-community/emacs-overlay/commit/46b97b3bcd0a5d484aa2a762e8dbfba39efda59c) Updated repos/elpa
* [`d982609e`](https://github.com/nix-community/emacs-overlay/commit/d982609e8317cea8666631f2e9c3d308f0dd95a1) Updated repos/emacs
* [`e24f948b`](https://github.com/nix-community/emacs-overlay/commit/e24f948ba5bcd5d8f4e6485a6e0102f2171541c7) Updated repos/melpa
* [`c16be6de`](https://github.com/nix-community/emacs-overlay/commit/c16be6de78ea878aedd0292aa5d4a1ee0a5da501) Updated repos/melpa
* [`a34159a5`](https://github.com/nix-community/emacs-overlay/commit/a34159a5b183b7e863370b2c3497e25d6cf1cccf) Updated repos/emacs
* [`8d9eaa57`](https://github.com/nix-community/emacs-overlay/commit/8d9eaa57b64e7fe74f29f4b7c6823a541bbf5556) Updated repos/melpa
* [`8a1a2144`](https://github.com/nix-community/emacs-overlay/commit/8a1a2144532deffd3d3e243f58dfece729765a68) Updated repos/elpa
* [`ae6bceed`](https://github.com/nix-community/emacs-overlay/commit/ae6bceed704bcb137364aa0793f7a3f696b9d285) Updated repos/emacs
* [`1046546c`](https://github.com/nix-community/emacs-overlay/commit/1046546c5d006fbe854e7944cd784b16e0d9494a) Updated repos/melpa
* [`20d632bc`](https://github.com/nix-community/emacs-overlay/commit/20d632bc23372128c39f35754806306c117b9009) Updated repos/emacs
* [`02b3e92f`](https://github.com/nix-community/emacs-overlay/commit/02b3e92fb3f23fba90c25820f9b1b8b6bfb555d0) Updated repos/melpa
* [`6a8a9e25`](https://github.com/nix-community/emacs-overlay/commit/6a8a9e252f54563d3f0207ec7c0df3b5c48f8a80) Updated repos/elpa
* [`a35caf05`](https://github.com/nix-community/emacs-overlay/commit/a35caf05221c71616925c114a2c85f07b41a9813) Updated repos/emacs
* [`fb1cdbb0`](https://github.com/nix-community/emacs-overlay/commit/fb1cdbb0a12d7f0e0e50022c405aca7c856dd233) Updated repos/melpa
* [`8e8c7ab6`](https://github.com/nix-community/emacs-overlay/commit/8e8c7ab6874c97b4d1c23a5a204b6743b40cee78) Updated repos/melpa
* [`79108ea2`](https://github.com/nix-community/emacs-overlay/commit/79108ea2e8bfa497cbecb18540dec7e79d2d1e14) Updated repos/emacs
* [`4bb9abd0`](https://github.com/nix-community/emacs-overlay/commit/4bb9abd04a46a7b52ff07af252204ca3ce6d337f) Updated repos/melpa
* [`f2965a16`](https://github.com/nix-community/emacs-overlay/commit/f2965a16bd6a3e78b62d010554c302e553f6af6e) Updated repos/elpa
* [`dd71d40e`](https://github.com/nix-community/emacs-overlay/commit/dd71d40e286752a97e808ccb37911c3a2b3a35e8) Updated repos/emacs
* [`391dca00`](https://github.com/nix-community/emacs-overlay/commit/391dca00f29463ab817865d778db4852099b7066) Updated repos/melpa
* [`424e98fb`](https://github.com/nix-community/emacs-overlay/commit/424e98fb8193af6d96cd8ba91adefb43b0c1c6eb) Updated repos/melpa
* [`3420e1ab`](https://github.com/nix-community/emacs-overlay/commit/3420e1ab815febd56f0b960d15b4c9aa58053b9f) Updated repos/nongnu
* [`df1be7cd`](https://github.com/nix-community/emacs-overlay/commit/df1be7cd6ddb3d4d7818e51abede310bdee99ad0) Updated repos/emacs
* [`cd34501a`](https://github.com/nix-community/emacs-overlay/commit/cd34501a9bcec341533c7131af77572456c100d8) Updated repos/melpa
* [`647872bf`](https://github.com/nix-community/emacs-overlay/commit/647872bf6698e0b4aeb6e0d48bc9d080ad9d1355) Updated repos/emacs
* [`ab0f3828`](https://github.com/nix-community/emacs-overlay/commit/ab0f3828a6305fe7fd8c4909e67c1c2107292486) Updated repos/melpa
* [`a880b28c`](https://github.com/nix-community/emacs-overlay/commit/a880b28c71dcc431656373821b0182aeab322408) Updated repos/elpa
* [`061e49c5`](https://github.com/nix-community/emacs-overlay/commit/061e49c50104a8478f9a24ee81c7ef62330f4281) Updated repos/emacs
* [`5b567bd4`](https://github.com/nix-community/emacs-overlay/commit/5b567bd46294ff2e30cd852e0239caebdf8e1676) Updated repos/melpa
* [`1b6e8ce7`](https://github.com/nix-community/emacs-overlay/commit/1b6e8ce7dd323d7e01fdc122a8b96042d2218750) Updated repos/emacs
* [`f417b108`](https://github.com/nix-community/emacs-overlay/commit/f417b108302f2faf18f60a367c70c135ba7b848c) Updated repos/melpa
* [`1729c790`](https://github.com/nix-community/emacs-overlay/commit/1729c7900f035100c954a1537733a8b0095f0d54) Updated repos/elpa
* [`8bf4496a`](https://github.com/nix-community/emacs-overlay/commit/8bf4496a7db1bcedfb75cbb02da2f33939ec50f9) Updated repos/emacs
* [`18a770f4`](https://github.com/nix-community/emacs-overlay/commit/18a770f432280e4c60bf6127f176ea5ca72ce2e6) Updated repos/melpa
* [`e5e098a2`](https://github.com/nix-community/emacs-overlay/commit/e5e098a2995867cac1eff1341467830d696a3a30) Updated repos/elpa
* [`afb7e353`](https://github.com/nix-community/emacs-overlay/commit/afb7e35394491a07e4ae0e7075ee5cc685b5754d) Updated repos/emacs
* [`bb11ce68`](https://github.com/nix-community/emacs-overlay/commit/bb11ce6818ed5975db9ea5d59f3d3a29d14a0c7a) Updated repos/melpa
* [`e0f50595`](https://github.com/nix-community/emacs-overlay/commit/e0f50595b9fdcda9713268969c08606952117c25) Updated repos/nongnu
* [`88b2e9ed`](https://github.com/nix-community/emacs-overlay/commit/88b2e9eda133e593558680ffb6262203db193ac4) Updated repos/melpa
* [`314f3322`](https://github.com/nix-community/emacs-overlay/commit/314f3322d49483ca44bcf185931d9387df6d0183) Updated repos/elpa
* [`5c52a909`](https://github.com/nix-community/emacs-overlay/commit/5c52a909636b29ed9c76399e95d61d9a5341d57f) Updated repos/emacs
* [`ea14c629`](https://github.com/nix-community/emacs-overlay/commit/ea14c62958d96e0f7cfead9d09e097b1891bf7c4) Updated repos/melpa
* [`e785b8ba`](https://github.com/nix-community/emacs-overlay/commit/e785b8ba6d1eac0cd3547fd454cd6ac32e55457b) Updated repos/elpa
* [`dafe925b`](https://github.com/nix-community/emacs-overlay/commit/dafe925b9744679b5b07ccb7164bb973ea43e882) Updated repos/emacs
* [`15de1559`](https://github.com/nix-community/emacs-overlay/commit/15de155944355203f78a9acec39644242731c3a1) Updated repos/melpa
* [`2b807c38`](https://github.com/nix-community/emacs-overlay/commit/2b807c388a5600d9f4e98f743306834de5dd03a5) Updated repos/melpa
* [`e767f356`](https://github.com/nix-community/emacs-overlay/commit/e767f356c3dd993856e4b69faee0de9775b26288) Updated repos/elpa
* [`c5ac8199`](https://github.com/nix-community/emacs-overlay/commit/c5ac81992c897be55c14ef069b1a5a1cd62586c2) Updated repos/emacs
* [`d7eeebd4`](https://github.com/nix-community/emacs-overlay/commit/d7eeebd439b52b77958eb3d8043f3262701ddee2) Updated repos/melpa
* [`567a8501`](https://github.com/nix-community/emacs-overlay/commit/567a85012dee105c4f9c83a8864f26530f276ef5) Updated repos/emacs
* [`aabdd358`](https://github.com/nix-community/emacs-overlay/commit/aabdd358238bb4247347d8f65ce50aff7da98820) Updated repos/melpa
* [`8279a14e`](https://github.com/nix-community/emacs-overlay/commit/8279a14edb0194ddb5d15dc1f7d752fee9fc8ce0) Updated repos/melpa
* [`6dfa3640`](https://github.com/nix-community/emacs-overlay/commit/6dfa3640d5f6bd231eba21dabbf0693f24fc6918) Updated repos/elpa
* [`1e323cfa`](https://github.com/nix-community/emacs-overlay/commit/1e323cfa281a684e6bf9174a55176ada2f002133) Updated repos/emacs
* [`15866c4a`](https://github.com/nix-community/emacs-overlay/commit/15866c4afca8ff59d9bef8c613bd5277c7d922ea) Updated repos/melpa
* [`3ee2017a`](https://github.com/nix-community/emacs-overlay/commit/3ee2017a7b5045b444cf73b556286707a1ab091c) Updated repos/emacs
* [`1e132a90`](https://github.com/nix-community/emacs-overlay/commit/1e132a90608e7cb9c874a65d0634027f309817e7) Updated repos/melpa
* [`148a59da`](https://github.com/nix-community/emacs-overlay/commit/148a59dade4c8bfade5a1d5e521713e7383f3ff5) Updated repos/emacs
* [`6c39228d`](https://github.com/nix-community/emacs-overlay/commit/6c39228d24c69ff0d52aedb8c9976bb796ebda2a) Updated repos/melpa
* [`c0fd73f7`](https://github.com/nix-community/emacs-overlay/commit/c0fd73f7486eb60fd971f0ab866de220d7727067) Updated repos/elpa
* [`50fd5e2a`](https://github.com/nix-community/emacs-overlay/commit/50fd5e2a3334bd3bea9cfdee3e7d66ae372cba76) Updated repos/emacs
* [`3d87b9b1`](https://github.com/nix-community/emacs-overlay/commit/3d87b9b13528cb0d38a5950690d040999ed0c590) Updated repos/melpa
* [`063c14fd`](https://github.com/nix-community/emacs-overlay/commit/063c14fd6db8460891a70da6450b351f1c38fe6a) Updated repos/emacs
* [`9f3f702c`](https://github.com/nix-community/emacs-overlay/commit/9f3f702cf91822b93a6b474f064bfe450e2d1478) Updated repos/melpa
* [`af3de875`](https://github.com/nix-community/emacs-overlay/commit/af3de875e31ea4814eadc537d6af6e68b34bb86a) Updated repos/emacs
* [`ef717aed`](https://github.com/nix-community/emacs-overlay/commit/ef717aed7e04c59930dda17f78a699ebce38f006) Updated repos/melpa
* [`5103b399`](https://github.com/nix-community/emacs-overlay/commit/5103b399cfe666ef9e874f3c184afbb15592d9a0) Updated repos/elpa
* [`7c411f56`](https://github.com/nix-community/emacs-overlay/commit/7c411f5678627786a1b9e78cd0816119d0809e21) Updated repos/emacs
* [`3fc77170`](https://github.com/nix-community/emacs-overlay/commit/3fc771708d511a1e43dda28202c00c1bc6310e17) Updated repos/melpa
* [`6411f650`](https://github.com/nix-community/emacs-overlay/commit/6411f650fff63eb3a8f9659f93cf09d8ef3055a7) Updated repos/elpa
* [`c40dfb15`](https://github.com/nix-community/emacs-overlay/commit/c40dfb15c8a46f5464513cd38deebf8efc723545) Updated repos/emacs
* [`1cc50999`](https://github.com/nix-community/emacs-overlay/commit/1cc50999c7e419f3e001c987d1bcc4060dbe2a7a) Updated repos/melpa
* [`d1e73fcb`](https://github.com/nix-community/emacs-overlay/commit/d1e73fcb8e45abaa402de149c2e678e03388e801) Updated repos/emacs
* [`582d0b3e`](https://github.com/nix-community/emacs-overlay/commit/582d0b3ee9d5b4978fd44d51a971d31d816bd250) Updated repos/elpa
* [`70921635`](https://github.com/nix-community/emacs-overlay/commit/709216359df430397a9021e3dc18b65979f2e665) Updated repos/emacs
* [`88e410d7`](https://github.com/nix-community/emacs-overlay/commit/88e410d7f1ddef554b40f66755626e5c883487d9) Updated repos/melpa
* [`81e49702`](https://github.com/nix-community/emacs-overlay/commit/81e4970219f25c2f093599805d2c35f88e29a4ed) Updated repos/emacs
* [`99dbfcd5`](https://github.com/nix-community/emacs-overlay/commit/99dbfcd50c81a1f33f3a3e4544504acc374f364f) Updated repos/melpa
* [`09925032`](https://github.com/nix-community/emacs-overlay/commit/0992503240151ed9bea2aa98162f9221532555d6) Updated repos/emacs
* [`3f5e4c79`](https://github.com/nix-community/emacs-overlay/commit/3f5e4c795311a0eaec5f7441f7a95ed22481354b) Updated repos/melpa
* [`cf7197e9`](https://github.com/nix-community/emacs-overlay/commit/cf7197e98baf93a3f03d074e10293d2b5a8cb2bb) Updated repos/emacs
* [`3b00ab8d`](https://github.com/nix-community/emacs-overlay/commit/3b00ab8d842fe59b08342e02ad90f8fef7ff5f7e) Updated repos/melpa
* [`1c5477b0`](https://github.com/nix-community/emacs-overlay/commit/1c5477b02968cd87edcf6aea0578799be2a4be19) Updated repos/emacs
* [`8f4f2c60`](https://github.com/nix-community/emacs-overlay/commit/8f4f2c6088719915e5e63f7114f66a797c21ff47) Updated repos/melpa
* [`9c01afae`](https://github.com/nix-community/emacs-overlay/commit/9c01afaeaac15df4fd7646995f2752718f6f21f0) Updated repos/emacs
* [`36750be6`](https://github.com/nix-community/emacs-overlay/commit/36750be6b0d855dc190a174a05a951ce26170a9a) Updated repos/melpa
* [`dc573075`](https://github.com/nix-community/emacs-overlay/commit/dc5730753762dc2f60a894395e96fec0fcd0bc10) Updated repos/elpa
* [`8cc87665`](https://github.com/nix-community/emacs-overlay/commit/8cc876653fcfb5265bc7b0d691c78afa145d4079) Updated repos/emacs
* [`9f2a5cf6`](https://github.com/nix-community/emacs-overlay/commit/9f2a5cf6737999431c1d433fd4ed15191d2fa38b) Updated repos/melpa
* [`953d044d`](https://github.com/nix-community/emacs-overlay/commit/953d044d600301ba223f1bf8eecedc8f00086e53) Updated repos/melpa
* [`6b78d95a`](https://github.com/nix-community/emacs-overlay/commit/6b78d95ab076292dc1bf181636787c2fd86e8158) Updated repos/emacs
* [`9093af7c`](https://github.com/nix-community/emacs-overlay/commit/9093af7c4f926936ac2324b64255c802f888bbf6) Updated repos/melpa
* [`a07e6124`](https://github.com/nix-community/emacs-overlay/commit/a07e612415ca3bca9f6fbb5106f294cc72eb5655) Updated repos/emacs
* [`e489ac3f`](https://github.com/nix-community/emacs-overlay/commit/e489ac3f5f94c71b759c5b6bbde15be29d873b7c) Updated repos/melpa
* [`06b7eac8`](https://github.com/nix-community/emacs-overlay/commit/06b7eac8861e935e0e9efac9da1430ed2efec3a2) Updated repos/elpa
* [`b9456115`](https://github.com/nix-community/emacs-overlay/commit/b945611546c53ee9ae900d0e31ddbd7e5b5b0605) Updated repos/emacs
* [`a229a3bc`](https://github.com/nix-community/emacs-overlay/commit/a229a3bc230c85cd33d81274daf315d419cf6dec) Updated repos/melpa
* [`98c42f25`](https://github.com/nix-community/emacs-overlay/commit/98c42f25739fe550de650bca1244b61cab168eae) Updated repos/nongnu
* [`4c10b550`](https://github.com/nix-community/emacs-overlay/commit/4c10b55096a7599182f4dc75bc407257f1a30581) Updated repos/emacs
* [`16481a01`](https://github.com/nix-community/emacs-overlay/commit/16481a0121af8d3024c4cdd74fc40ff521392479) Updated repos/melpa
* [`f7ff5f4b`](https://github.com/nix-community/emacs-overlay/commit/f7ff5f4b943bb190a8561dbd4ba567e420504ffb) Updated repos/emacs
* [`545383bd`](https://github.com/nix-community/emacs-overlay/commit/545383bd7de8e3f100356fea217698379d8f5c31) Updated repos/melpa
