### PR TITLE
niv spacemacs: update 5b8a25a6 -> a529b0bf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": "http://spacemacs.org",
         "owner": "syl20bnr",
         "repo": "spacemacs",
-        "rev": "5b8a25a6b7cb9f070852144fc71824b1e01a5711",
-        "sha256": "0iibnmpv6lwkj5ckpw2fgs8r0gxirlkryqn6l5fazvpycfhgs05b",
+        "rev": "a529b0bfa8fb04c368e6d57059929806b9722e2f",
+        "sha256": "1yw16yhyh4gd1cr117b0dkf2bbhc19yni9b615zijiw8p7lq7src",
         "type": "tarball",
-        "url": "https://github.com/syl20bnr/spacemacs/archive/5b8a25a6b7cb9f070852144fc71824b1e01a5711.tar.gz",
+        "url": "https://github.com/syl20bnr/spacemacs/archive/a529b0bfa8fb04c368e6d57059929806b9722e2f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unar": {


### PR DESCRIPTION
## Changelog for spacemacs:
Branch: develop
Commits: [syl20bnr/spacemacs@5b8a25a6...a529b0bf](https://github.com/syl20bnr/spacemacs/compare/5b8a25a6b7cb9f070852144fc71824b1e01a5711...a529b0bfa8fb04c368e6d57059929806b9722e2f)

* [`cf021951`](https://github.com/syl20bnr/spacemacs/commit/cf021951b73fc0c2b7af1368fa0339f3515e4101) fix(spacemacs-buffer): replace y-or-n question by a warning
* [`f3f0d6e6`](https://github.com/syl20bnr/spacemacs/commit/f3f0d6e6da07ee3fa9c2f47c124500662aad50ac) [bot] built_in_updates ([syl20bnr/spacemacs⁠#15910](https://togithub.com/syl20bnr/spacemacs/issues/15910))
* [`b586fbc2`](https://github.com/syl20bnr/spacemacs/commit/b586fbc2b5c6a9894dfe53da129d374f1b956e9f) do not filter away all recent files when org-directory is not set ([syl20bnr/spacemacs⁠#15923](https://togithub.com/syl20bnr/spacemacs/issues/15923))
* [`5e284e30`](https://github.com/syl20bnr/spacemacs/commit/5e284e3089211b3e6fcf46de711efd4f1e3740c3) [bot] "built_in_updates" Sat Feb 18 23:49:37 UTC 2023 ([syl20bnr/spacemacs⁠#15924](https://togithub.com/syl20bnr/spacemacs/issues/15924))
* [`00bae656`](https://github.com/syl20bnr/spacemacs/commit/00bae656b56e051c84735a760fe108966e2ec802) Fix face warnings by using unspecified instead of nil ([syl20bnr/spacemacs⁠#15898](https://togithub.com/syl20bnr/spacemacs/issues/15898))
* [`821bd9cc`](https://github.com/syl20bnr/spacemacs/commit/821bd9cc683575af0996c8e2b3e42452bb9c684a) [nixos] Fix nixos-format-on-save for newer nixos-mode
* [`7231bdde`](https://github.com/syl20bnr/spacemacs/commit/7231bdde0ecf79b15e45b0750e743b0ecb24497c) csharp: stop using csharp-mode package in emacs 29
* [`70acc4d1`](https://github.com/syl20bnr/spacemacs/commit/70acc4d1776098d8bce6648402b76e42641652d5) Typescript minor improvements ([syl20bnr/spacemacs⁠#15920](https://togithub.com/syl20bnr/spacemacs/issues/15920))
* [`5600e4f1`](https://github.com/syl20bnr/spacemacs/commit/5600e4f1e44a67cc3c6eb3fa053651e821b4685d) evil: support auto-adjusting evil-shift-width in go-mode ([syl20bnr/spacemacs⁠#15927](https://togithub.com/syl20bnr/spacemacs/issues/15927))
* [`a529b0bf`](https://github.com/syl20bnr/spacemacs/commit/a529b0bfa8fb04c368e6d57059929806b9722e2f) Correct the documented lsp-use-lsp-ui default value to `t` ([syl20bnr/spacemacs⁠#15937](https://togithub.com/syl20bnr/spacemacs/issues/15937))
