### PR TITLE
niv devenv: update 96844436 -> 8e047801

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "9684443646e044f08e72765642ea9d3cef78445e",
-        "sha256": "15n0j9468v260fn7vy6czps6f9qc0xxh8mlja00gb8k4m6wkhacn",
+        "rev": "8e0478018a410f47d947b4c16de0927170f226bf",
+        "sha256": "0v9nin4pg8bcd6lyvkhqx68mbv0q1hyi2gp00rqicxnzd600fslv",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/9684443646e044f08e72765642ea9d3cef78445e.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/8e0478018a410f47d947b4c16de0927170f226bf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@96844436...8e047801](https://github.com/cachix/devenv/compare/9684443646e044f08e72765642ea9d3cef78445e...8e0478018a410f47d947b4c16de0927170f226bf)

* [`9de5bd8f`](https://github.com/cachix/devenv/commit/9de5bd8fe2291ef04643a30ccd2521bc37dacae2) Support unfree attribute in devenv.yaml
* [`17111e2a`](https://github.com/cachix/devenv/commit/17111e2a7fc44d8d9be2c977e4566782a4f2bec6) Allow wiring up overlays
* [`4430eb1f`](https://github.com/cachix/devenv/commit/4430eb1fb91e2e7716a2ea3f01f9a61eeb09e593) add an example for overlays
* [`b0f22d76`](https://github.com/cachix/devenv/commit/b0f22d7662aa7c443f8d3ea4f4eeb8f7658e973f) Validate devenv.yaml schema and move overlays to inputs
* [`eb7eb2ce`](https://github.com/cachix/devenv/commit/eb7eb2ce67832236dd03f804f5d7f5ceecf597d2) raku.nix: fixed description to not break web documentation
* [`3a86f301`](https://github.com/cachix/devenv/commit/3a86f30128ca1cc134353c7040109be8173a7a67) Auto generate docs/reference/options.md
* [`00c8dc4c`](https://github.com/cachix/devenv/commit/00c8dc4ccf5a648c400432c44a14d69cbb9ed1c2) add devenv specific direnv integration
* [`b6fdef59`](https://github.com/cachix/devenv/commit/b6fdef59e0693f5dbdaae58184bce78651ecce11) use devenv-direnv
* [`a0e1ad3c`](https://github.com/cachix/devenv/commit/a0e1ad3c2efba452cf14d701ed6fb6a00618b26b) write down also the imports as CSV
* [`e5dd4d8c`](https://github.com/cachix/devenv/commit/e5dd4d8c6a57aa6c4c8e68414f516f2c86cdc9b5) Update direnvrc
* [`785f6c73`](https://github.com/cachix/devenv/commit/785f6c731317a627e28bc90f6e61ecf9e8d9e2bf) Update src/devenv-yaml.nix
* [`55d1428f`](https://github.com/cachix/devenv/commit/55d1428fa11e3c4256e5a52a41bbc15f02d6287f) Added mkcert as integration
* [`c71c96cc`](https://github.com/cachix/devenv/commit/c71c96ccefb2c04202384123827cc794fa4e66fd) correct hostctl integration
* [`f9fe71f2`](https://github.com/cachix/devenv/commit/f9fe71f2bcad655445502853d7bf64ab5352aadf) added a complete mkcert example
* [`78d20ff9`](https://github.com/cachix/devenv/commit/78d20ff938732dd20431c398a74adac57b5f99c6) added a fallback for the hostctl hosts option
* [`a01eca89`](https://github.com/cachix/devenv/commit/a01eca891176a159715a112dcc9e0814563fa459) Update src/devenv-yaml.nix
* [`580d2c25`](https://github.com/cachix/devenv/commit/580d2c2576bfc9413e741e77e35be888052571c1) revert hostctl config changes
* [`d93bcc38`](https://github.com/cachix/devenv/commit/d93bcc38bf6313b43a64170dcc640ca53e122c53) rename certificates option
* [`99800678`](https://github.com/cachix/devenv/commit/99800678a4a4baf082a2aeea04098315fc63414d) remove wildcard from example
* [`670b9838`](https://github.com/cachix/devenv/commit/670b9838ca701eae22a59d9d72480f0e6c5cce5b) Add wildcard domain to option example
* [`9698a12a`](https://github.com/cachix/devenv/commit/9698a12a9ce04cd5c554c4e4066dd9e25423b9ae) Update src/devenv-yaml.nix
* [`5c1daec7`](https://github.com/cachix/devenv/commit/5c1daec7be65aa403b58f74ca07de064229ee443) Auto generate docs/reference/options.md
* [`ae8f9401`](https://github.com/cachix/devenv/commit/ae8f94010dde5d4dc01b793ba0f541bdb1361c2b) docs/github-actions: use devenv version 0.5.1
* [`61250a0c`](https://github.com/cachix/devenv/commit/61250a0cdbeb75c60cfd27b60edb5026bd1fe74b) chore(deps): bump cachix/install-nix-action from 19 to 20
* [`ac800694`](https://github.com/cachix/devenv/commit/ac800694e1479aca9bceb20ae63d716a1c031edb) ignore documentation warnings for now
* [`43442e53`](https://github.com/cachix/devenv/commit/43442e5385fd547780181d93db0203d5c2a5587d) Make it easy to create containers out of the environment.
* [`a8cfd5aa`](https://github.com/cachix/devenv/commit/a8cfd5aaec6e0b8bccaca05c954beea4d3a4ed45) format
* [`983f9b68`](https://github.com/cachix/devenv/commit/983f9b68444ed5385337977ea62ed511d42113ef) Update docs/containers.md
* [`42773ac2`](https://github.com/cachix/devenv/commit/42773ac24a9fef3874619a92a0e506745dde0bcb) Auto generate docs/reference/options.md
* [`8c824ea9`](https://github.com/cachix/devenv/commit/8c824ea953c31c4a298dc2ea5dea99beb916b7e6) bump direnv integration
* [`50606d49`](https://github.com/cachix/devenv/commit/50606d496cf82324572c081192fbda869b9b155f) fix --help
* [`68e8b874`](https://github.com/cachix/devenv/commit/68e8b874b6c0ceb833309140463012458c543c41) fix link
* [`784e68a4`](https://github.com/cachix/devenv/commit/784e68a416e029679d7c76b212b4eaa107951903) Auto generate docs/reference/options.md
* [`90007a94`](https://github.com/cachix/devenv/commit/90007a9418288951b159d793435c9aa801388532) v0.6 release post
* [`2cae5ec8`](https://github.com/cachix/devenv/commit/2cae5ec87e6111aec5e46b2137fb8ab4a75b5960) v0.6
* [`25196b56`](https://github.com/cachix/devenv/commit/25196b56aadcfcce1d4546783caa936c1876efd0) Auto generate docs/reference/options.md
* [`ab2222ff`](https://github.com/cachix/devenv/commit/ab2222ffb1613500c0f2a96a81f1c9eead17a05a) v0.6 post: rename subsection
* [`7976b7ac`](https://github.com/cachix/devenv/commit/7976b7ac200680419c0b83e2a49579de8b1b111d) Auto generate docs/reference/options.md
* [`6fa448dd`](https://github.com/cachix/devenv/commit/6fa448dd3933d18cd3f3e39c42ffea13fb803e5d) Fix indentation in the devenv script
* [`8489b4d9`](https://github.com/cachix/devenv/commit/8489b4d98c0144a4d58a51ab5a857fede4c45f42) Auto generate docs/reference/options.md
* [`4e7a5573`](https://github.com/cachix/devenv/commit/4e7a557381fc4fecee88fbeac17fdc0e6e9f83ca) test devenv against zsh/fish
* [`8f7ea93f`](https://github.com/cachix/devenv/commit/8f7ea93f0fd9b4aea9d53def7cc6b12ef172008f) Enable the escapeall pymdown extension
* [`7b84c367`](https://github.com/cachix/devenv/commit/7b84c36743458ceadd6d21f96a94950f4f7f5569) Fix links to source in reference docs
* [`ef6d9eff`](https://github.com/cachix/devenv/commit/ef6d9eff24d7879c7d0614c19afec32fc85c6a8c) Ignore .direnv folder for cached builds
* [`2660787f`](https://github.com/cachix/devenv/commit/2660787f68809fd94d7de5b01e4f6a643bda23c4) Remove override from process-compose config as it's not supported
* [`93796e5d`](https://github.com/cachix/devenv/commit/93796e5dbfd77bcc05eb133879c3a80643b8769c) Auto generate docs/reference/options.md
* [`45d8a5ed`](https://github.com/cachix/devenv/commit/45d8a5ed23ef8ae5bf2b9c4ea928eafa736c94f2) Fix echo output of update command when using an old devenv.lock
* [`e3880e0c`](https://github.com/cachix/devenv/commit/e3880e0cf22af6861b968fe702bd3defe9a19eae) add ccls to languages/c
* [`c6a9df32`](https://github.com/cachix/devenv/commit/c6a9df32ab36bb9b8e9b3419a07ee66652bc5ca6) add ccls to languages/cplusplus
* [`6341248d`](https://github.com/cachix/devenv/commit/6341248dd29ef2a9628d04ac7ee7a8099be7c00b) fix search, add a test
* [`2e76ef33`](https://github.com/cachix/devenv/commit/2e76ef337843a0f80d7ca74dc852eabdab183d12) doc: emphaize the new section
* [`1d7cf3d4`](https://github.com/cachix/devenv/commit/1d7cf3d43fc610af6d4139739b00f34476350e3f) Auto generate docs/reference/options.md
* [`9e44e0e8`](https://github.com/cachix/devenv/commit/9e44e0e8c0254d97a532eef9d554a9b9fcbef10b) typo
* [`7ea6436d`](https://github.com/cachix/devenv/commit/7ea6436dab00a0697997e697fbb0d17787827ce1) v0.6.1
* [`5c601fe0`](https://github.com/cachix/devenv/commit/5c601fe04d1d1099e1c54eb5df6544b03b2c1552) Auto generate docs/reference/options.md
* [`84b23cfe`](https://github.com/cachix/devenv/commit/84b23cfefad17ecfd54d653ddbd7c9d27dd74081) fix allowUnfree and add a test
* [`d1f7b48e`](https://github.com/cachix/devenv/commit/d1f7b48e35e6dee421cfd0f51481d17f77586997) direnvrc: when loading the environment fails, exit with 1
* [`29648069`](https://github.com/cachix/devenv/commit/296480692d1e570ae3a479c31692b918b553545a) update .envrc
* [`6455f319`](https://github.com/cachix/devenv/commit/6455f319fc90e0be2071327093c5458f9afc61bf) v0.6.2
* [`8e047801`](https://github.com/cachix/devenv/commit/8e0478018a410f47d947b4c16de0927170f226bf) Auto generate docs/reference/options.md
