### PR TITLE
niv nixpkgs: update d154f809 -> 4b1a1efe

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d154f809e9c3c47fee72186aa3ff6479403435d4",
-        "sha256": "11yc5jz3z7gw4yd5gbkcwshdgzbfabc5by8zfxjk1b0skywhxv4b",
+        "rev": "4b1a1efe99a7a8206544c0caae77eee43bb8db57",
+        "sha256": "0sbpacfi7z7gvp381irdvw50yv2d6w6x3af09p853y6qvnl4k10j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d154f809e9c3c47fee72186aa3ff6479403435d4.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4b1a1efe99a7a8206544c0caae77eee43bb8db57.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d154f809...4b1a1efe](https://github.com/nixos/nixpkgs/compare/d154f809e9c3c47fee72186aa3ff6479403435d4...4b1a1efe99a7a8206544c0caae77eee43bb8db57)

* [`037167ae`](https://github.com/NixOS/nixpkgs/commit/037167ae17fefe6b5dc86dc05f0dd168031c3c68) xf86videointel: Use the `crocus` and `iris` DRI drivers
* [`51ba2337`](https://github.com/NixOS/nixpkgs/commit/51ba23371779e1018fc89573f94ca414c09c4e61) pkgs/stdenv/linux: bootstrap-files for third (and final) mips ABI: n32
* [`efbeb1bb`](https://github.com/NixOS/nixpkgs/commit/efbeb1bb5e90ab3ca2d5184e446cea4fa97c29cb) prometheus-cpp: 1.0.1 -> 1.1.0
* [`57b09f29`](https://github.com/NixOS/nixpkgs/commit/57b09f29c6345f0ca701b79760dfd23443c3a982) vscode-extensions.jellyedwards.gitsweep: init at 0.0.15
* [`00ae655e`](https://github.com/NixOS/nixpkgs/commit/00ae655e639e620ee5dcfd6f1bd9ccb4e337eea1) btrbk: Use sudo or doas based on configuration
* [`3144b00d`](https://github.com/NixOS/nixpkgs/commit/3144b00d2486ca5d85098a688a76a5e945de411d) btrbk: add doas variant of module test
* [`9a848178`](https://github.com/NixOS/nixpkgs/commit/9a8481780b31e101dc941a3d619ce4803dc5d525) libsForQt515.solid: patch binary search paths
* [`a7ea3911`](https://github.com/NixOS/nixpkgs/commit/a7ea3911798120047beb25be107138a0c547dce2) swww: init at 0.5.0
* [`61840f71`](https://github.com/NixOS/nixpkgs/commit/61840f7181bc17f3c808fcae5acc656a2408ab7b) nixos/prometheus: Add new relabel_configs actions
* [`f88873d8`](https://github.com/NixOS/nixpkgs/commit/f88873d877d17617ed11a8f6aba49db9ae57cdbb) runelite: 2.1.5 -> 2.5.0
* [`2f8266e0`](https://github.com/NixOS/nixpkgs/commit/2f8266e02234a6a2e2ce2b939366e63b5369c278) sonic-pi: add updateScript
* [`5988ada8`](https://github.com/NixOS/nixpkgs/commit/5988ada8358cb66b5486889db22aba37caaf4f4c) sonic-pi: add ruby to nativeBuildInputs
* [`e7383a32`](https://github.com/NixOS/nixpkgs/commit/e7383a32e365371b9d62c30f16089687db7cb5d4) gitlab-pages: Maintain together with the rest of GitLab + add to...
* [`baf1f129`](https://github.com/NixOS/nixpkgs/commit/baf1f1293b289ce53d9b660465cd68e1a3e00b96) ruby: Fix withPackages on darwin with makeBinaryWrapper
* [`9fdd9729`](https://github.com/NixOS/nixpkgs/commit/9fdd97298b6b8b0a8385ada8b81d9d1d56ed7c34) nixos/java: add binfmt option
* [`dbd563b9`](https://github.com/NixOS/nixpkgs/commit/dbd563b9b8c20071075bcdd5912b99486b3fcfa3) nixos/gitlab: Improve support for GitLab Pages
* [`2d4f4e9b`](https://github.com/NixOS/nixpkgs/commit/2d4f4e9bdfdcc69ea19299150db5c26c7aa4e44a) nixos/gitlab: Handle secrets in GitLab Pages config
* [`44e5b418`](https://github.com/NixOS/nixpkgs/commit/44e5b41871ed5afdaa927e4bbf7c00362ebf54cb) lib/systems/parse: stop considering armv8a able to execute armv7l
* [`678eed32`](https://github.com/NixOS/nixpkgs/commit/678eed323ffd90117472cd432ebe85dddaff07f1) nixos/grub: Name initrd-secrets by system, not by initrd
* [`012434d4`](https://github.com/NixOS/nixpkgs/commit/012434d4815a7a3221c2f8b9568cb6285e810059) feedbackd: 0.0.1 -> 0.0.3
* [`6f63865c`](https://github.com/NixOS/nixpkgs/commit/6f63865cf470ce99b36bceacbefbb6886d05be51) dockerTools: Add minimal test case for [nixos/nixpkgs⁠#214434](https://togithub.com/nixos/nixpkgs/issues/214434)
* [`f4e4cac0`](https://github.com/NixOS/nixpkgs/commit/f4e4cac0c86f0e16aac773083aebbfc0e7daea43) dockerTools: Correctly unpack duplicate rootfs diffs
* [`9377f94a`](https://github.com/NixOS/nixpkgs/commit/9377f94ac5c69eaeca0a2a9d13a41ea7f41c0b7d) swww: v0.5.0 -> v0.7.0
* [`a124a517`](https://github.com/NixOS/nixpkgs/commit/a124a517b2e66078143beaae058e394aa5c1acc0) Update pkgs/tools/wayland/swww/default.nix
* [`2a5bf1fc`](https://github.com/NixOS/nixpkgs/commit/2a5bf1fcdfc8658678bc9305677dfa0fda907367) Update pkgs/tools/wayland/swww/default.nix
* [`2bf1fca5`](https://github.com/NixOS/nixpkgs/commit/2bf1fca5ac68b085bbc42f445731791cf5aa3b1b) Update pkgs/tools/wayland/swww/default.nix
* [`68f5e955`](https://github.com/NixOS/nixpkgs/commit/68f5e9554ffa3cfee31786f9a3013ebd8a7d8308) Add maintainers
* [`7c201f6b`](https://github.com/NixOS/nixpkgs/commit/7c201f6b53bf4acc77184d110cd2cfd72d065bae) Add whitespaces for readability.
* [`0566d27d`](https://github.com/NixOS/nixpkgs/commit/0566d27d03a7b9c285045f57004a6ba2c2613454) coder: fix web frontend building
* [`56ecab70`](https://github.com/NixOS/nixpkgs/commit/56ecab709a5a6e49049c0892a7cc59cfa22bdd98) nixos/coder: init module
* [`eb38ad04`](https://github.com/NixOS/nixpkgs/commit/eb38ad04efae0ebcd7217c4ccace3da0102d85af) dockerTools: ensure runAsRoot script not optimized away in test
* [`c66cabe3`](https://github.com/NixOS/nixpkgs/commit/c66cabe33ea1f969ef9562feeef0a015b83a60b1) dockerTools: use more familiar terminology to describe test image
* [`298c543e`](https://github.com/NixOS/nixpkgs/commit/298c543e55284a3be8e8785302883fb873e005af) dockerTools: Specify 'latest' tag for repeated layer test image
* [`84e04ccf`](https://github.com/NixOS/nixpkgs/commit/84e04ccf8570e9f8072486f7d750d326225c7117) dockerTools: Preprocess layers list before unpack to handle repeated layers
* [`c7fbd40f`](https://github.com/NixOS/nixpkgs/commit/c7fbd40fd152506057d84e3e656dd564164168d2) groff: Add enableIconv and enableLibuchardet option
* [`235d9e21`](https://github.com/NixOS/nixpkgs/commit/235d9e218736a7d930992e7297bef1182d69fd60) lib/licenses.nix: Add cc-by-nc-nd-30
* [`4efb17b5`](https://github.com/NixOS/nixpkgs/commit/4efb17b50b96b9058d646ecec8d632d69d3c9633) dendrite: 0.11.0 -> 0.11.1
* [`f0ddf281`](https://github.com/NixOS/nixpkgs/commit/f0ddf281c593b82a2bd11110e8147ba85a1de70c) sane-backends: 1.1.1 -> 1.2.1
* [`c845a281`](https://github.com/NixOS/nixpkgs/commit/c845a2815fac9fc3ad40a2095aa3d3d129616af1) cargo-pgx: add buildPgxExtension
* [`4e189d76`](https://github.com/NixOS/nixpkgs/commit/4e189d769bdfb7a220da5cd98413d63d5768489a) timescaledb-toolkit: init at 1.14.0
* [`9dc7a05a`](https://github.com/NixOS/nixpkgs/commit/9dc7a05a85a0b051d208f41ddca0f6cdb6e6ff06) cargo-pgx/timescaledb_toolkit: add nixos test
* [`5287f144`](https://github.com/NixOS/nixpkgs/commit/5287f1446fbb227f75f75c2ac5df59c9cd7ca4e6) Apply suggestions from code review
* [`3c486263`](https://github.com/NixOS/nixpkgs/commit/3c4862636fd6a29f69a7b43f82a3cf070a9c650d) linuxPackages.ipu6-drivers: init at 2023-01-17
* [`134e4a64`](https://github.com/NixOS/nixpkgs/commit/134e4a6473a032513c2bea03035342aacaf3f53d) ipu6-camera-bin: init at 2022-11-12
* [`4269391e`](https://github.com/NixOS/nixpkgs/commit/4269391e56b015472b8f238c1ae52442e168348f) ipu6-camera-hal: init at 2023-01-09
* [`c4c9f600`](https://github.com/NixOS/nixpkgs/commit/c4c9f600e7a09bb0044fc10ea3ae62a3c65b76b5) gst_all_1.icamerasrc: init at 202212109
* [`9b4f6d4d`](https://github.com/NixOS/nixpkgs/commit/9b4f6d4d9278632b1e6c28e83ed9764bd0387c43) linuxPackages.ivsc-driver: init at 2023-01-06
* [`6b338572`](https://github.com/NixOS/nixpkgs/commit/6b3385723874fc580a854701292a9a0c7ede4482) ivsc-firmware: init at 2022-11-02
* [`b38d6054`](https://github.com/NixOS/nixpkgs/commit/b38d6054d789ec8f12a11ed7c2107ce770be7a98) linuxPackages.ipu6-drivers: Reuse ivsc-driver source
* [`7d0299ea`](https://github.com/NixOS/nixpkgs/commit/7d0299eaf38e8e145fd6429d5f224bc9e64399d6) dotnet-sdk_6: 6.0.405 -> 6.0.406
* [`9b54e8ab`](https://github.com/NixOS/nixpkgs/commit/9b54e8abdef0ae7389c6fefa7ff2d27461950169) python3Packages.debugpy: lldb support
* [`bacfd9df`](https://github.com/NixOS/nixpkgs/commit/bacfd9df0915c8bb5c4b40234d9cd980196f2398) bitwig-studio: 4.4.6 -> 4.4.8
* [`ee89f8e1`](https://github.com/NixOS/nixpkgs/commit/ee89f8e1e558c2021a7bea8a7dd50b9521afb772) navidrome: 0.49.1 -> 0.49.3
* [`7a67b4c2`](https://github.com/NixOS/nixpkgs/commit/7a67b4c28ba8a303dc0ec20bddeaa077df6da165) fftwQuad: Fix build on Darwin by forcing gcc
* [`51417891`](https://github.com/NixOS/nixpkgs/commit/514178918f7f97a066911c0ce3fc2d41f550a934) 0.7.0 -> 0.7.2
* [`b3b79fc4`](https://github.com/NixOS/nixpkgs/commit/b3b79fc41eba5f31467bd5aa568ee52a5202ca7a) linuxPackages.systemtap: 4.5 -> 4.8
* [`0061f844`](https://github.com/NixOS/nixpkgs/commit/0061f844c9bbc993606eecd79243a07fb358443e) onlyoffice-documentserver: 7.3.0 -> 7.3.2
* [`72840a9f`](https://github.com/NixOS/nixpkgs/commit/72840a9f2f118c91f1421b8e8773fda576ea9114) peek: switch to ffmpeg-full
* [`fef1cfb0`](https://github.com/NixOS/nixpkgs/commit/fef1cfb05a1fa5596591058fe56fbb120b83d550) python3Packages.grpcio: Fix build parallelism
* [`f83f0f8d`](https://github.com/NixOS/nixpkgs/commit/f83f0f8dfaf0f7ec853597fa236340bc1873d315) python3Packages.mixins: init at 0.1.4
* [`e78dc938`](https://github.com/NixOS/nixpkgs/commit/e78dc938d81cc175f4af9da0d94771c39aa43cd5) nixos/qemu-vm: fix minor typo
* [`9f57a615`](https://github.com/NixOS/nixpkgs/commit/9f57a615e4f912c83d3f66d8e051c1b18b6ba2d3) nifi: 1.16.3 -> 1.20.0
* [`4d547243`](https://github.com/NixOS/nixpkgs/commit/4d547243a283353e7cb1c39fe76efa66f18ecf3c) signal-desktop: 6.5.1 -> 6.7.0, signal-desktop-beta: 6.6.0-beta.1 -> 6.8.0-beta.1
* [`2c7af955`](https://github.com/NixOS/nixpkgs/commit/2c7af95567179d59340bf54800642b851133dd3c) pre-commit: 2.20.0 -> 3.1.0
* [`4e9350b6`](https://github.com/NixOS/nixpkgs/commit/4e9350b673f59f47ad0eeffe5d4981a6e67e455b) BeatSaberModManager: 0.0.4 -> 0.0.5
* [`1e2257a4`](https://github.com/NixOS/nixpkgs/commit/1e2257a4584ee372ab772741e5546bed6244d591) maintainers: update lunik1's gpg key
* [`91294961`](https://github.com/NixOS/nixpkgs/commit/912949612371d0d6a26640992f13dfbec3c06711) libheif: 1.14.2 -> 1.15.1
* [`eddb6a1b`](https://github.com/NixOS/nixpkgs/commit/eddb6a1b6241303c0310993294662e9347a2435d) hunspell: fix spanish-language dictionaries
* [`b4ff692b`](https://github.com/NixOS/nixpkgs/commit/b4ff692b80a031fb0c9715208a4aca4398430fd9) orchis-theme: 2022-10-19 -> 2023-02-26
* [`ab0eeaaa`](https://github.com/NixOS/nixpkgs/commit/ab0eeaaa3687263741fcd5307587bd4be1902e48) github-runner: add update script
* [`b87b0dba`](https://github.com/NixOS/nixpkgs/commit/b87b0dba523ce77b07ed0a2967c12d6ded3a1d5b) github-runner: add `sourceProvenance` and `changelog` to `meta`
* [`2f813ae1`](https://github.com/NixOS/nixpkgs/commit/2f813ae18b27bd926595be2b9e9e7f7e696af193) github-runner: use `buildDotnetModule`
* [`b22b1f48`](https://github.com/NixOS/nixpkgs/commit/b22b1f4874a1614307b4efa8d5309301832685e4) github-runner: patch access to `.env` and `.path`
* [`137db830`](https://github.com/NixOS/nixpkgs/commit/137db83090cf371369a48111b3bd1c888288f19e) nixos/github-runners: use `Runner.Listener` directly for registration
* [`e8df83d4`](https://github.com/NixOS/nixpkgs/commit/e8df83d417a65f84914ee27da98b870c0e7d143c) nixos/tests/github-runner: init
* [`5a65a419`](https://github.com/NixOS/nixpkgs/commit/5a65a419627fa1746fac2d8b1a7219a47908e781) libre: use cmake for configurePhase
* [`67f93ae2`](https://github.com/NixOS/nixpkgs/commit/67f93ae299730480bd4a7bfd77a1b10322b682c6) librem: use cmake for configurePhase
* [`9a584068`](https://github.com/NixOS/nixpkgs/commit/9a584068b438be375dc258adbe010bdbdf70eab1) wakatime: 1.61.0 -> 1.68.1
* [`c4fc77a0`](https://github.com/NixOS/nixpkgs/commit/c4fc77a0c987f48f4927bbbbd295ed3ecafd94c0) python3Packages.qtile-extras: init at 0.22.1
* [`4c8b75ed`](https://github.com/NixOS/nixpkgs/commit/4c8b75ed9a4a2583b1b8f58745852d0f4fa49fcc) dotnetPackages.Nuget: 5.6.0.6489->6.3.1.1
* [`476b6f8d`](https://github.com/NixOS/nixpkgs/commit/476b6f8d6c69084280fa691fdd7b12109fe0534d) python310Packages.deid: init at 0.3.21
* [`067d00f7`](https://github.com/NixOS/nixpkgs/commit/067d00f76581ee21787c376e0d3b01bc9ccdf31b) bubblewrap: 0.7.0 -> 0.8.0
* [`476bb883`](https://github.com/NixOS/nixpkgs/commit/476bb8830866751e07edf015c78e00c0c951978f) nixos/atop: Don't choke if no existing atop logs
* [`f0a6216e`](https://github.com/NixOS/nixpkgs/commit/f0a6216eebb3a6693b111e2927e10f520f6c479a) mpv: enable swift support
* [`5b8e896d`](https://github.com/NixOS/nixpkgs/commit/5b8e896dbadd36fecc96dc77216517599c260ca7) mpv: Switch to apple_sdk_11_0 for darwin
* [`8a28ae85`](https://github.com/NixOS/nixpkgs/commit/8a28ae851dee5306de51352300fceb692bd9c389) mpv: Only enable swift support on aarch64-darwin
* [`0acc6df7`](https://github.com/NixOS/nixpkgs/commit/0acc6df7423fc042f29a0df8a3c39249b2e901e9) refactor: Add spacing around tests
* [`73981dd9`](https://github.com/NixOS/nixpkgs/commit/73981dd9c24d3b7529c12ea83c4d59c1377a2b99) feat: Create desktop item for `appimage-run`
* [`ef5dc1f9`](https://github.com/NixOS/nixpkgs/commit/ef5dc1f99490f24a6b367222fa590d8d91bca4c7) jid: Use buildGoModule
* [`4e0525a8`](https://github.com/NixOS/nixpkgs/commit/4e0525a8cdb370d31c1e1ba2641ad2a91fded57d) configuration.nix: suggest a command line program
* [`bee04d31`](https://github.com/NixOS/nixpkgs/commit/bee04d31577f4878e2d3824e354d1bf3bf300309) prisma-engines: 4.10.1 -> 4.11.0
* [`d5d8baa6`](https://github.com/NixOS/nixpkgs/commit/d5d8baa676aac635110fd9668738ef441c65d98a) nodePackages.prisma: 4.10.1 -> 4.11.0
* [`014eba88`](https://github.com/NixOS/nixpkgs/commit/014eba883e7d81771c9c8cb938618e5a3f35208d) buildDotnetModule: point fetch-deps at module's deps file by default
* [`929143c1`](https://github.com/NixOS/nixpkgs/commit/929143c14558140944c3beb392fbb084d8f9bd93) opensearch: 2.5.0 -> 2.6.0
* [`5cfd70fd`](https://github.com/NixOS/nixpkgs/commit/5cfd70fd4d6afabb89434c7a2ff0d116b030bbf9) opensearch: fix knn ml plugin
* [`3330e67e`](https://github.com/NixOS/nixpkgs/commit/3330e67e9718579df2d8e5ed933ec1e54651a3a9) python310Packages.dtlssocket: 0.1.12 -> 0.1.14
* [`39bb5f56`](https://github.com/NixOS/nixpkgs/commit/39bb5f56a10cdb4b222751c64e9ed583ae7e467b) zola: 0.16.1 -> 0.17.0
* [`2eb86f59`](https://github.com/NixOS/nixpkgs/commit/2eb86f590dd5590ce59e2be1456360e39d073a7b) zola: fix completions
* [`40575604`](https://github.com/NixOS/nixpkgs/commit/40575604eaaa1de4b90330bcd4c5dbf71a3d84dd) zola: 0.17.0 -> 0.17.1
* [`fe6b447c`](https://github.com/NixOS/nixpkgs/commit/fe6b447c430b23f508af608aff740e0c644297d7) ocamlPackages.elina: fixup build by using older make
* [`03bd6304`](https://github.com/NixOS/nixpkgs/commit/03bd63043fe664316f479fc0a548e903432fbb0f) deepin.dtkgui: don't propagate librsvg and freeimage
* [`118bdf25`](https://github.com/NixOS/nixpkgs/commit/118bdf25a6c572dd2fd29d10b1ae2e4d9a95b907) lib/modules: Allow an "anonymous" module with key in disabledModules
* [`00e61446`](https://github.com/NixOS/nixpkgs/commit/00e614468d4828bafeb2942b9a9055d9a1bbb0fd) evcc: 0.113.0 -> 0.114.0
* [`735b57d9`](https://github.com/NixOS/nixpkgs/commit/735b57d962bf61f5457f48e8d8e16da56ff1d88a) linuxPackages.tuxedo-keyboard: 3.1.1 -> 3.1.4
* [`ea0e64eb`](https://github.com/NixOS/nixpkgs/commit/ea0e64eb3fdf0f0ad477393060b7cc6f171ce86f) libvirt: 9.0.0 -> 9.1.0
* [`e7071b16`](https://github.com/NixOS/nixpkgs/commit/e7071b166934180cb2d9808568859b8595983423) stellar-core: 19.7.0 -> 19.8.0
* [`fae39600`](https://github.com/NixOS/nixpkgs/commit/fae39600ef84afac3c8570656198e7f9e0a3c30f) fossil: 2.20 -> 2.21
* [`d23e7b1b`](https://github.com/NixOS/nixpkgs/commit/d23e7b1be4e9c3a3135ca07045fb809278b5bf9d) ocamlPackages.elina: more precise meta.platforms
* [`688c4961`](https://github.com/NixOS/nixpkgs/commit/688c4961cf969df7a1ecc05dfd4f1932fda192dc) gnuplot: 5.4.5 -> 5.4.6
* [`ca44f048`](https://github.com/NixOS/nixpkgs/commit/ca44f0485c6135d1a1be5f9a3ac7ab1b18c24752) python310Packages.questionary: increase open files for testing
* [`c3c40d56`](https://github.com/NixOS/nixpkgs/commit/c3c40d562c254c260b959f513424db6fba3cb7e9) uhd: 4.1.0.5 -> 4.4.0.0
* [`22ee3640`](https://github.com/NixOS/nixpkgs/commit/22ee36406c6aebb2a4df228a932e48944e9eca72) volk: 2.5.0 -> 3.0.0
* [`35157ceb`](https://github.com/NixOS/nixpkgs/commit/35157ceba3d60f3338cdc6b4f0846444e037282d) pritunl-client: 1.3.3430.77 -> 1.3.3457.61
* [`5917a053`](https://github.com/NixOS/nixpkgs/commit/5917a053a75affb24979b3962411e704d15bf9c3) regreet: init at unstable-2023-02-27
* [`1a129dc6`](https://github.com/NixOS/nixpkgs/commit/1a129dc63f21026d029d43c5ff8cf5d77ef3238a) zfsUnstable: 2.1.10-unstable-2023-01-24 → 2.1.10-unstable-2023-03-02
* [`1bf8d63f`](https://github.com/NixOS/nixpkgs/commit/1bf8d63f8fe9b48225ed58a561b991bc4ba00398) openai-full: create variant that includes optional deps
* [`1023ebd4`](https://github.com/NixOS/nixpkgs/commit/1023ebd4a0c06d5dc3eaeb92f98412b444eb94f5) obsidian: 1.1.15 -> 1.1.16
* [`a48211c3`](https://github.com/NixOS/nixpkgs/commit/a48211c319dc9520dbabfd20bd2001f991fd898e) microsoft-edge: fix file picker and `subsituteInPlace`
* [`2c126112`](https://github.com/NixOS/nixpkgs/commit/2c1261127770f1886e49903742e4e989fdae6ad2) phoc: 0.21.1 -> 0.25.0
* [`2455dfab`](https://github.com/NixOS/nixpkgs/commit/2455dfab0da8bb2158d9c404ec13ccf42250ed3e) phosh: 0.23.0 -> 0.25.1
* [`a10d6761`](https://github.com/NixOS/nixpkgs/commit/a10d67619900daa500e010a3c68c1e7799c32eb8) llvm: tighten platforms
* [`7705b76c`](https://github.com/NixOS/nixpkgs/commit/7705b76cc1936920bccdedc0405b8a7dab641c08) xpra: 4.3.3 -> 4.4.3
* [`b7b7c43d`](https://github.com/NixOS/nixpkgs/commit/b7b7c43d5a9575201173cdf38659e4afc23cdaac) gnomeExtensions: auto-update
* [`94bbbb04`](https://github.com/NixOS/nixpkgs/commit/94bbbb047180b59ef6f25f4d89e7a12b5fc6db63) cudaPackages: point nvcc at a compatible -ccbin
* [`cf7fb1d0`](https://github.com/NixOS/nixpkgs/commit/cf7fb1d08f928f48725f15e595cbb84793278379) python3Packages.tensorflow: add cudaCapabilities argument
* [`79397957`](https://github.com/NixOS/nixpkgs/commit/79397957e876ef7fe6eccbcb58d23fb5c58f121c) cudaPackages.nccl: respect cudaCapabilities
* [`e3050112`](https://github.com/NixOS/nixpkgs/commit/e305011223c940a8dd661f64eb5cd5384c15ddbe) cudaPackages_12.nccl: fix new missing inputs
* [`d378cc6f`](https://github.com/NixOS/nixpkgs/commit/d378cc6fb23d67f3d9f86c39051f810c563789ca) opencv4: respect config.cudaCapabilities
* [`5f4bdbe6`](https://github.com/NixOS/nixpkgs/commit/5f4bdbe6c387bf740025581d94bbfba9a887c76f) python3Packages.tensorflow: fix `GLIBCXX_3.4.30' not found
* [`17248123`](https://github.com/NixOS/nixpkgs/commit/17248123b6ae01b89a25de730ea890276acd69b2) cudaPackages_12: use gcc12
* [`2b69d618`](https://github.com/NixOS/nixpkgs/commit/2b69d618c28bdcbc822843a534c2cb74542ec972) opencv3: respect config.cudaCapabilities
* [`c376c54f`](https://github.com/NixOS/nixpkgs/commit/c376c54f70b91c68f6f2ddc90838b57a82b12ecd) cudaPackages.cudatoolkit: refactor inheriting passthru.cc
* [`8bf5f5ac`](https://github.com/NixOS/nixpkgs/commit/8bf5f5ac893ff07406a3a1979d944c2a86cfc887) magma: use CMAKE_CUDA_ARCHITECTURES directly
* [`2100c492`](https://github.com/NixOS/nixpkgs/commit/2100c4926200b1ebbee032ad22113597195932f2) endless-sky:0.9.14 -> 0.9.16.1
* [`0ff1b6ed`](https://github.com/NixOS/nixpkgs/commit/0ff1b6ed70d13907a8d3d552fd90ac77d1b96bea) esptool: 4.5 -> 4.5.1
* [`fa8ecdce`](https://github.com/NixOS/nixpkgs/commit/fa8ecdced8888122a4ec14c8e652d350b2c97fd1) monocraft: 1.4 -> 2.4
* [`dd2b2769`](https://github.com/NixOS/nixpkgs/commit/dd2b27692e8a32316d263b938bddfa515eb2775a) magma: explain `cudaSupport ? true`
* [`0c25f5aa`](https://github.com/NixOS/nixpkgs/commit/0c25f5aa7ffb4ed9d4015fc273f51d08ff2a279b) cudaPackages.cudatoolkit: remove unused gcc argument
* [`ac64f07f`](https://github.com/NixOS/nixpkgs/commit/ac64f07f9c8b9bcc4a4b6d285146cd50473d6b5d) cudaPackages.cudaFlags: drop unused capabilitiesAndForward
* [`68648fa4`](https://github.com/NixOS/nixpkgs/commit/68648fa4c01e5b9f9b91cf0235652bbaec154926) darwin.apple_sdk_11_0.clang{12-15}Stdenv: init
* [`7a734f27`](https://github.com/NixOS/nixpkgs/commit/7a734f279523d08b5eec75a8a60d24438dbbe5cc) darwin.apple_sdk_11_0: code cleanup
* [`b7391c69`](https://github.com/NixOS/nixpkgs/commit/b7391c695b8c29e046445cc1953c7380ae36eb66) signalbackup-tools: unbreak on Darwin systems
* [`b373d299`](https://github.com/NixOS/nixpkgs/commit/b373d299bae89922f2bde5f351b90495b182daf2) docs/rust: improve docs for nightly usage
* [`fcc10ee9`](https://github.com/NixOS/nixpkgs/commit/fcc10ee9a4891ea20194fa8178d55786439fd73a) cargo-binutils: don't recommend nixpkgs-mozilla
* [`35081a77`](https://github.com/NixOS/nixpkgs/commit/35081a77d56c84bea79bc810a825179357d68658) cargo-llvm-cov: don't recommend nixpkgs-mozilla
* [`4f2d703d`](https://github.com/NixOS/nixpkgs/commit/4f2d703d91e958e79bd38254e5c8e09edcd5d583) ssm-session-manager-plugin: Build from source
* [`9c00800a`](https://github.com/NixOS/nixpkgs/commit/9c00800a68f2961e464240902407bcb27f53fa72) ssm-session-manager-plugin: 1.2.331.0 -> 1.2.398.0
* [`2c02d0ba`](https://github.com/NixOS/nixpkgs/commit/2c02d0ba11687d5ecca95ac33b1e9227f920ac3c) mongosh: 1.6.2 -> 1.8.0, use buildNpmPackage
* [`2a2831c9`](https://github.com/NixOS/nixpkgs/commit/2a2831c9e9f3b7f2d62373a3700a2c9c0862ea3d) ko: add developer-guy to maintainers list
* [`c777db77`](https://github.com/NixOS/nixpkgs/commit/c777db77a3e0aab5f406142fadc7ad43838b8d73) element-{web,desktop}: 1.11.23 -> 1.11.24
* [`6428223c`](https://github.com/NixOS/nixpkgs/commit/6428223c0ec203dc80716f100f89985bc4caafb2) cgreen: take maintenance
* [`abedfdd3`](https://github.com/NixOS/nixpkgs/commit/abedfdd3da6c1a301f23556f06936490e69c070a) maintainers: remove nichtsfrei
* [`fa06318a`](https://github.com/NixOS/nixpkgs/commit/fa06318a46c6110eb5395ffcb0270fca38da09f1) ndn-cxx: unpin openssl_1_1
* [`7e13b629`](https://github.com/NixOS/nixpkgs/commit/7e13b629c733ed7510c8d5fe3c77dce1316c1460) ndn-tools: unpin openssl_1_1
* [`a75ef43a`](https://github.com/NixOS/nixpkgs/commit/a75ef43adfb56aeefa78bfe29a4acb5154446efd) wireshark: format
* [`f1911fd8`](https://github.com/NixOS/nixpkgs/commit/f1911fd866d2ed05051c3b5cc20b459491f56d29) tutanota-desktop: 3.108.12 -> 3.110.0
* [`dede4a1d`](https://github.com/NixOS/nixpkgs/commit/dede4a1dadd5613f0f438180ef5a14c2a3e41887) pe-bear: 0.6.1 -> 0.6.5
* [`1616a0aa`](https://github.com/NixOS/nixpkgs/commit/1616a0aa4d4ffe8aa77fa90f9148960954b9c1f5) bazarr: 1.1.4 -> 1.2.0
* [`ddac6e04`](https://github.com/NixOS/nixpkgs/commit/ddac6e045f121a12541d9faf3842a5868b204358) wireshark: 4.0.3 -> 4.0.4
* [`55a25b0a`](https://github.com/NixOS/nixpkgs/commit/55a25b0acaa26956ac3e335711a603008ca6ab1a) wireshark: add more dependencies
* [`48eab73b`](https://github.com/NixOS/nixpkgs/commit/48eab73bb6145dc3e78325fc1bda679ba5c8645a) python310Packages.eradicate: update meta
* [`57e21e88`](https://github.com/NixOS/nixpkgs/commit/57e21e88b204c55eac1569807dd974741beffb5f) python310Packages.eradicate: disable on unsupported Python releases
* [`e1806091`](https://github.com/NixOS/nixpkgs/commit/e1806091d7374613c403414ae0debb58e6a7c814) python310Packages.eradicate: 2.1.0 -> 2.2.0
* [`353859c8`](https://github.com/NixOS/nixpkgs/commit/353859c8fb494a5c99ba61266605181347f0eb0a) python310Packages.bpycv: 0.2.43 -> 0.3.6
* [`71435991`](https://github.com/NixOS/nixpkgs/commit/71435991394209dc843eb6f99414ea8a75be491c) wpsoffice: 11.1.0.11664 -> 11.1.0.11691
* [`5248f534`](https://github.com/NixOS/nixpkgs/commit/5248f53462ad2004fa6d2128521844cc41d0b83e) vassal: 3.6.12 -> 3.6.13
* [`a3f3ede0`](https://github.com/NixOS/nixpkgs/commit/a3f3ede0cfd0a31d65637296cac21b7e28506e5d) ocamlPackages.ocaml-freestanding: mark as broken
* [`50e35e9b`](https://github.com/NixOS/nixpkgs/commit/50e35e9b6c8fbd2e84bf569bfb3c7dd9ab6a6329) obliv-c: migrate to OCaml 4.14
* [`cc4169d7`](https://github.com/NixOS/nixpkgs/commit/cc4169d737e092ef877cf8b8d9b940df849a7312) glsurf: migrate to OCaml 4.14
* [`3796e591`](https://github.com/NixOS/nixpkgs/commit/3796e5913698883eb2ef6d6cc6c797fd302a4bc4) vampire: unbreak on aarch64-linux
* [`f88ef28d`](https://github.com/NixOS/nixpkgs/commit/f88ef28dc9e8c732b9338571cd5b1bbd084ff268) maintainers: add apfelkuchen6
* [`d73f7fc6`](https://github.com/NixOS/nixpkgs/commit/d73f7fc6156c804dd325a5d2327a20bcfebb8caf) python3Packagages.python-musicpd: init at 0.8.0
* [`28eb4d04`](https://github.com/NixOS/nixpkgs/commit/28eb4d0456ac8aff043c499ec49a598f3f71206b) mpd-sima: init at 0.18.2
* [`919dd089`](https://github.com/NixOS/nixpkgs/commit/919dd0892c74a6cbca47000182909766d8380385) signalbackup-tools: 20230223-1 -> 20230304-3
* [`953d54f6`](https://github.com/NixOS/nixpkgs/commit/953d54f69117f4c79269e11f69ebafee5507d972) rust-analyzer: use nix-update-script
* [`4140f453`](https://github.com/NixOS/nixpkgs/commit/4140f453e932ccc92bef8fea370d6f88b6d09973) praat: 6.3.08 -> 6.3.09
* [`e10f9f1f`](https://github.com/NixOS/nixpkgs/commit/e10f9f1fbfb20acbf9b1643c7ec39e6d28bc2174) polkadot: 0.9.38 -> 0.9.39
* [`d008d899`](https://github.com/NixOS/nixpkgs/commit/d008d899ce44f8ce6f20442db157c96b5e31b096) shotman: 0.4.0 -> 0.4.1
* [`58306ceb`](https://github.com/NixOS/nixpkgs/commit/58306ceb17c8daea391a6bb888fc68b75fff0718) morgen: 2.6.6 -> 2.6.7
* [`72024b15`](https://github.com/NixOS/nixpkgs/commit/72024b159a71b057534ad2472f0c99f85407d4b5) tvm: 0.10.0 -> 0.11.0
* [`5424180b`](https://github.com/NixOS/nixpkgs/commit/5424180bc5d13d2b3707e572f5d410d67a02d582) nats-server: 2.9.14 -> 2.9.15
* [`46cdbdaa`](https://github.com/NixOS/nixpkgs/commit/46cdbdaa318325b42bbfb05e4a6db3d10b195864) linkerd_edge: 23.2.3 -> 23.3.1
* [`6ba0151a`](https://github.com/NixOS/nixpkgs/commit/6ba0151a846af3938196f830f7c128678a7ff89c) terragrunt: 0.44.0 -> 0.44.4
* [`a56529a9`](https://github.com/NixOS/nixpkgs/commit/a56529a95f30709bb7cc4d956d1a08961cf588d1) glsurf: fix runtime error
* [`7aa0bc3c`](https://github.com/NixOS/nixpkgs/commit/7aa0bc3c377d753c0964542eccd997aabaaf78a3) feedbackd: 0.0.3 -> 0.1.0
* [`3e45de22`](https://github.com/NixOS/nixpkgs/commit/3e45de22cda188da91528d8294047e73d0f8776f) acorn: 0.5.1 -> 0.6.0
* [`af81d879`](https://github.com/NixOS/nixpkgs/commit/af81d8794ec7f897accae7e07460b70b52cbd11e) unison: M4c -> M4h
* [`0f1483d1`](https://github.com/NixOS/nixpkgs/commit/0f1483d1a261a1f7f9a3ac109a16cdff68312db4) python310Packages.lineedit: init at 0.1.6
* [`b92e5657`](https://github.com/NixOS/nixpkgs/commit/b92e565723097a3425a0e2c7b47f30041085f940) python310Packages.s3fs: 2023.1.0 -> 2023.3.0
* [`d6a97b41`](https://github.com/NixOS/nixpkgs/commit/d6a97b41824b41af29ad19a11dea9b34270d7586) python310Packages.apispec: 6.0.2 -> 6.1.0
* [`f1e518e0`](https://github.com/NixOS/nixpkgs/commit/f1e518e06f4ac43238d376787c278d088758c986) bolt: 0.9.2 -> 0.9.5
* [`ca9f0682`](https://github.com/NixOS/nixpkgs/commit/ca9f0682fdbaf70454be9c1dd51250a0065233bd) nixos/systemd-boot: always use profile_path() for system closure paths
* [`73f2d007`](https://github.com/NixOS/nixpkgs/commit/73f2d0074aa039a40fd11ffcce6495568528c56e) python310Packages.rchitect: init at 0.3.40
* [`e730867d`](https://github.com/NixOS/nixpkgs/commit/e730867dc051f9f9f6bd0b641838a24b74cad4c8) python310Packages.radian: init at 0.6.4 and provide radianWrapper
* [`b2acf6bc`](https://github.com/NixOS/nixpkgs/commit/b2acf6bcd1d6b1615b40b3c8c01538d332eaf36a) thermald: 2.5.1 -> 2.5.2
* [`eadfa088`](https://github.com/NixOS/nixpkgs/commit/eadfa0886a1ab1e18aad53ba0103456abe7b0f3c) python310Packages.aiodiscover: 1.4.13 -> 1.4.14
* [`0e09eee2`](https://github.com/NixOS/nixpkgs/commit/0e09eee2c066791be7f17f53d1fc01457e4953ea) hikari: 2.3.2 -> 2.3.3
* [`da590309`](https://github.com/NixOS/nixpkgs/commit/da59030939a95114cf38cd589da4a7f5f7ca8b74) python310Packages.aiodiscover: add changelog to meta
* [`32907346`](https://github.com/NixOS/nixpkgs/commit/3290734615c91f490550d8336e4cf14d897b2027) pkgsStatic.iproute2: fix build (disable shared libraries)
* [`44172b3c`](https://github.com/NixOS/nixpkgs/commit/44172b3c66ded6942aea293c09d5437117956f3b) udict: init at 0.1.2
* [`8caf109c`](https://github.com/NixOS/nixpkgs/commit/8caf109c28ba10ab9ea71bd57a18c06451c9a8f3) carapace: 0.21.0 -> 0.22.0
* [`78c57b6c`](https://github.com/NixOS/nixpkgs/commit/78c57b6c1cd31b0a0a8e1e527893e150e26bb48b) neil: 0.1.47 -> 0.1.55
* [`38ba8261`](https://github.com/NixOS/nixpkgs/commit/38ba8261dd85015f007c7534a6a6074df11b1484) simdjson: 3.1.2 -> 3.1.3
* [`04082197`](https://github.com/NixOS/nixpkgs/commit/040821978dc5c2f26ce5c322b37b1ec363f0720d) squid: 5.7 -> 5.8
* [`9a23d3c8`](https://github.com/NixOS/nixpkgs/commit/9a23d3c8cd0387379380b3f082e46f7e4bf71ea4) pcloud: 1.10.1 -> 1.11.0
* [`c299df8d`](https://github.com/NixOS/nixpkgs/commit/c299df8dec7cff18d1d696047339d4ebb286aea6) openseachest: 22.07 -> 23.03
* [`3c4b76f4`](https://github.com/NixOS/nixpkgs/commit/3c4b76f46e2a7301b516df31d6024782eba9ba07) katawa-shoujo: init at 1.3.1
* [`877d7078`](https://github.com/NixOS/nixpkgs/commit/877d70784585dee16fa6a758b5d719aaf607fc0f) oven-media-engine: 0.15.0 -> 0.15.1
* [`35388553`](https://github.com/NixOS/nixpkgs/commit/353885536c7c82e119e486e3bcc7ff6fecaca2a4) drawterm: unstable-2021-10-02 -> unstable-2023-03-05
* [`a18b27a3`](https://github.com/NixOS/nixpkgs/commit/a18b27a3f62c72da3c5a1ba6b75c6a188e9b0376) libdeltachat: 1.110.0 -> 1.111.0
* [`783dd8d4`](https://github.com/NixOS/nixpkgs/commit/783dd8d4fe4702b6d1cc0e5d539337eab29237d3) awscli2: 2.10.4 -> 2.11.0
* [`1360d4cc`](https://github.com/NixOS/nixpkgs/commit/1360d4cc5133bf700044e6d343169d289143a183) zig: build offline documentation
* [`786bf693`](https://github.com/NixOS/nixpkgs/commit/786bf693bae56d7ee705e809c4ab2d4244cdca36) argocd: 2.6.2 -> 2.6.3
* [`5050b9c4`](https://github.com/NixOS/nixpkgs/commit/5050b9c48fd2fc920963c607831dba2047bd81fd) holochain-launcher: 0.9.0 -> 0.9.1
* [`3d173e96`](https://github.com/NixOS/nixpkgs/commit/3d173e9635eb413cf1cf4744b02de6551e342718) xborders: init at 3.4
* [`0f2d8460`](https://github.com/NixOS/nixpkgs/commit/0f2d84601c1f93fa311940fdde6adb8854e244e1) komga: 0.161.0 -> 0.162.0
* [`c0a41e92`](https://github.com/NixOS/nixpkgs/commit/c0a41e924b33d6e05b807f2f7816814d91b028d8) blaze: 3.8.1 -> 3.8.2
* [`8e3984de`](https://github.com/NixOS/nixpkgs/commit/8e3984de4c7334e0d6077e834b7e0212c7e9d585) avalanchego: 1.9.9 -> 1.9.10
* [`2b814394`](https://github.com/NixOS/nixpkgs/commit/2b814394c8846365598348f00c5b93cfa911b5ad) rpi-imager: 1.7.3 -> 1.7.4
* [`2bd6fc16`](https://github.com/NixOS/nixpkgs/commit/2bd6fc164cf473bd1d3b03a725169c8369fc217b) ntfy-sh: 2.1.1 -> 2.1.2
* [`1ae55a93`](https://github.com/NixOS/nixpkgs/commit/1ae55a93f8a23610fb1b729458567198eb03b49f) coreth: 0.11.7 -> 0.11.8
* [`1e45fc39`](https://github.com/NixOS/nixpkgs/commit/1e45fc393bf819cf2f211c9ea237283246465d97) chromiumDev: 112.0.5596.2 -> 112.0.5615.12
* [`33c3687d`](https://github.com/NixOS/nixpkgs/commit/33c3687d221b4be03e9a891636d8c25401c3317b) vscodium: 1.75.0.23033 -> 1.76.0.23062
* [`1c696382`](https://github.com/NixOS/nixpkgs/commit/1c696382ae5e3eb31f689c55ffd15ff1087f1315) autorestic: 1.7.5 -> 1.7.6
* [`fbaaa34c`](https://github.com/NixOS/nixpkgs/commit/fbaaa34c7a1b3f4d7923a987ab3946326e225227) fetchmail: 6.4.36 -> 6.4.37
* [`fddd8787`](https://github.com/NixOS/nixpkgs/commit/fddd8787d374141fbbb45ed68debba11483450b7) openfortivpn: 1.19.0 -> 1.20.1
* [`43750863`](https://github.com/NixOS/nixpkgs/commit/437508639df090459b1a9f1871ab7966913687b7) cemu: 2.0-26 -> 2.0-28
* [`50f8a89d`](https://github.com/NixOS/nixpkgs/commit/50f8a89d699d9e3e2ec2fa8491436b396f0c834e) exfat: 1.3.0 -> 1.4.0
* [`5dda1cbe`](https://github.com/NixOS/nixpkgs/commit/5dda1cbe9549cdf25c4ac70df5d7b230a613fbc3) grapejuice: 7.2.1 -> 7.8.3
* [`cda984b5`](https://github.com/NixOS/nixpkgs/commit/cda984b5ec21de133374025cffe9cbf548d839bd) kics: 1.6.10 -> 1.6.11
* [`6f10ea96`](https://github.com/NixOS/nixpkgs/commit/6f10ea96ec9149ef88cf0bd689efbca6e812c314) deltachat-desktop: remove old patch
* [`5e5d6e16`](https://github.com/NixOS/nixpkgs/commit/5e5d6e16ed90c73684b8426c7ca2567c7f1538fd) python310Packages.deltachat: inherit meta from libdeltachat
* [`823e822a`](https://github.com/NixOS/nixpkgs/commit/823e822aeec15abad61d2b56ee2bf8130a9e34d4) mdbook: 0.4.26 -> 0.4.28
* [`1fc18708`](https://github.com/NixOS/nixpkgs/commit/1fc187089b742fb79f07d88ede3b9939281ce3ba) ares-rs: init at 0.9.0
* [`1a79103b`](https://github.com/NixOS/nixpkgs/commit/1a79103b2b4fc48e07347f188ec2d68023c635ac) rauc: 1.8 -> 1.9
* [`a7cfc9af`](https://github.com/NixOS/nixpkgs/commit/a7cfc9afdf51ebcb571f463847c0ac8cae2cd0e2) python310Packages.ospd: add changelog to meta
* [`23dec20d`](https://github.com/NixOS/nixpkgs/commit/23dec20de6262748af0492e26cdbe86a8dcf7840) ospd-openvas: init at 22.4.6
* [`521fb3f6`](https://github.com/NixOS/nixpkgs/commit/521fb3f6a67fb10722fe5e6abe036c54f2eb6137) gvm-libs: add changelog to meta
* [`a97d17a4`](https://github.com/NixOS/nixpkgs/commit/a97d17a444c2fb22839418c564d7502a9ba6de91) gvm-libs: 21.4.4 -> 22.4.4
* [`ede665f2`](https://github.com/NixOS/nixpkgs/commit/ede665f2ef01f54831624a413030f7b6cb0ba661) miopengemm: 5.4.2 -> 5.4.3
* [`d4b88e4d`](https://github.com/NixOS/nixpkgs/commit/d4b88e4d15100cbd70bfaabe0a8b9f97e694d25c) python310Packages.kaggle: 1.5.12 -> 1.5.13
* [`b9c88ad0`](https://github.com/NixOS/nixpkgs/commit/b9c88ad0a09144667147b19c29f4187052820690) python310Packages.google-cloud-error-reporting: 1.8.2 -> 1.9.0
* [`626cc1f3`](https://github.com/NixOS/nixpkgs/commit/626cc1f3e645d8b3815d27c4bef8210c651aa680) firefox-beta-bin-unwrapped: 111.0b6 -> 111.0b8
* [`1d79811a`](https://github.com/NixOS/nixpkgs/commit/1d79811a4211ad6f1b9f9f2b4279145ec531f92c) wine: fix build failure on Darwin
* [`be7a05a7`](https://github.com/NixOS/nixpkgs/commit/be7a05a70f46bdbb072c25535fb576198b409651) brev-cli: 0.6.207 -> 0.6.208
* [`8fdababc`](https://github.com/NixOS/nixpkgs/commit/8fdababce4969d18f9d86664fa5dc292dd16a883) android-udev-rules: 20230104 -> 20230303
* [`c9babe3f`](https://github.com/NixOS/nixpkgs/commit/c9babe3fc1a435e2f36e3b8f0af89ff489757f7f) xd: 0.4.2 -> 0.4.4
* [`f8ae1e7f`](https://github.com/NixOS/nixpkgs/commit/f8ae1e7fe9934d335ee7886f1f8e583213c47fbe) lxgw-neoxihei: 1.006 -> 1.007
* [`9780b8e2`](https://github.com/NixOS/nixpkgs/commit/9780b8e2673dfd01279e4147f410887b93f3e032) ginkgo: fix darwin build
* [`d6d742cf`](https://github.com/NixOS/nixpkgs/commit/d6d742cf89e417cef066a30284a1e94ac44aeb9d) rnote: 0.5.14 -> 0.5.16
* [`5765d33f`](https://github.com/NixOS/nixpkgs/commit/5765d33f3540e12d7864dc3a155b8332a8dc0ec4) binutils: fix MinGW link failures with import libs
* [`8c7e78ad`](https://github.com/NixOS/nixpkgs/commit/8c7e78ad9d29610e57c394d06aa4e8dda1914ea0) jfrog-cli: 2.34.2 -> 2.34.6
* [`22cea184`](https://github.com/NixOS/nixpkgs/commit/22cea1844af6a6b88d97c8997c67fb6bf6be619e) litecoin: 0.21.2.1 -> 0.21.2.2
* [`782f4c77`](https://github.com/NixOS/nixpkgs/commit/782f4c779a1aec781fe2747f809964f9b6c0895f) cloud-hypervisor: 29.0 -> 30.0
* [`684306b2`](https://github.com/NixOS/nixpkgs/commit/684306b246d05168e42425a3610df7e2c4d51fcd) ocamlPackages.sedlex: 3.0 -> 3.1
* [`cb1e91e6`](https://github.com/NixOS/nixpkgs/commit/cb1e91e66189bf780930058a668a95097f3d2daf) python310Packages.iminuit: 2.20.0 -> 2.21.0
* [`1d503d2c`](https://github.com/NixOS/nixpkgs/commit/1d503d2c17eb26ddee3d915047388600ece49ae6) mkgmap: 4905 -> 4906
* [`915bc5fb`](https://github.com/NixOS/nixpkgs/commit/915bc5fb1de4f6e1798586d0f7f9e470f2647aee) podman-tui: 0.7.0 -> 0.9.0
* [`c52aa746`](https://github.com/NixOS/nixpkgs/commit/c52aa746e12733647ea47d9d2a1dd35fa02d8670) vscode-extensions.streetsidesoftware.code-spell-checker: 2.18.0 -> 2.19.0
* [`cd20e3b8`](https://github.com/NixOS/nixpkgs/commit/cd20e3b85e7fd8c5a3f303634022d7f794ac292b) colima: patch `sw_vers` on darwin
* [`c5d748d6`](https://github.com/NixOS/nixpkgs/commit/c5d748d650139e4b86248ab80c0e490d13561191) bgpq4: 1.8 -> 1.9
* [`6ea505ee`](https://github.com/NixOS/nixpkgs/commit/6ea505ee4ea6a148132f7b4fd93f8d36aa1b25b0) mesa: enable vulkan intel drivers on 32bit
* [`d23c04cd`](https://github.com/NixOS/nixpkgs/commit/d23c04cdbd5460ae548803bb10fd04b9da4037a0) colima: build and test all packages
* [`cb363523`](https://github.com/NixOS/nixpkgs/commit/cb363523dad54f575dae55d245d73018712a6f7f) gitlab: 15.8.3 -> 15.8.4 ([nixos/nixpkgs⁠#219406](https://togithub.com/nixos/nixpkgs/issues/219406))
* [`68553d6e`](https://github.com/NixOS/nixpkgs/commit/68553d6e23935cb1b2ec4192208e3c8bb2b95fc3) duckdb: 0.7.0 -> 0.7.1
* [`e6c8a2f3`](https://github.com/NixOS/nixpkgs/commit/e6c8a2f3e340cbf7dbecfd5c66baf716b212a139) linuxPackages_latest.jool: fix build ([nixos/nixpkgs⁠#219138](https://togithub.com/nixos/nixpkgs/issues/219138))
* [`358ca90b`](https://github.com/NixOS/nixpkgs/commit/358ca90b5f2e1e9a7263e8b4690d131d214c504b) luaPackages: adding several neovim plugins
* [`332073ba`](https://github.com/NixOS/nixpkgs/commit/332073ba4277f8643362ccfc6f20b0050549a4b9) colima: add darwin tools to native build inputs
* [`bf864baa`](https://github.com/NixOS/nixpkgs/commit/bf864baaa28514dbd4714fcfeb5714e7f3af4343) python310Packages.django-ipware: 4.0.2 -> 5.0.0
* [`b5f0fdc3`](https://github.com/NixOS/nixpkgs/commit/b5f0fdc371c33207144bf0b4b8de26c3fb613076) workflows/backport: Copy security label in backport PRs
* [`4caf0ce0`](https://github.com/NixOS/nixpkgs/commit/4caf0ce0e266f5a6ca9be701e307d2872d45dcfd) n8n: 0.215.1 -> 0.218.0
* [`31959695`](https://github.com/NixOS/nixpkgs/commit/3195969509c0569a6371a345738454e7c9191540) vimPlugins: update
* [`66fa5d30`](https://github.com/NixOS/nixpkgs/commit/66fa5d3036f1fafa9d58c379f34e881a8250e91b) vimPlugins.nvim-treesitter: update grammars
* [`7e4e8b9e`](https://github.com/NixOS/nixpkgs/commit/7e4e8b9e3cd28ab7b29c16a747ff16da47f2d52a) gitRepo: 2.31 -> 2.32
* [`15ada3ac`](https://github.com/NixOS/nixpkgs/commit/15ada3ac044e169d601929e493077dee17b8f65b) pantheon.elementary-files: 6.2.2 -> 6.3.0
* [`11d60255`](https://github.com/NixOS/nixpkgs/commit/11d602559bbf8eb3101957c04800eaa0aacfa974) python310Packages.tplink-omada-client: 1.1.0 -> 1.1.1
* [`14632246`](https://github.com/NixOS/nixpkgs/commit/146322465ff2996ad5143f13e10d6cd5ab23c52a) python310Packages.tplink-omada-client: add changelog to meta
* [`663f1739`](https://github.com/NixOS/nixpkgs/commit/663f17398c1820feaa192a523907ba294fe21319) python310Packages.screenlogicpy: 0.7.2 -> 0.8.0
* [`c15f803d`](https://github.com/NixOS/nixpkgs/commit/c15f803d8e729a0963d207f61826fb75ec1c8d02) python310Packages.scikit-survival: 0.19.0.post1 -> 0.20.0
* [`9e6c5da7`](https://github.com/NixOS/nixpkgs/commit/9e6c5da715c721429f308d1ae7de8665b53c86dc) python310Packages.caio: 0.9.11 -> 0.9.12
* [`62821edd`](https://github.com/NixOS/nixpkgs/commit/62821edd2e685be68ece5dd50af4b493a4fa9dba) This PR sets default SPARK_HOME and JAVA_HOME for R's sparklyr package using a patch in .onload. Preset value take precedence. SPARK_HOME points to python3Packages.pyspark rather than pkgs.spark because the former is actively maintained.
* [`ad920652`](https://github.com/NixOS/nixpkgs/commit/ad9206529272709d983822f7661bcc8b2ab343c8) element-{web,desktop}: hack to make ofborg maintainer pings work again
* [`41020c32`](https://github.com/NixOS/nixpkgs/commit/41020c3241acbdd15e0c3e9ad947826abc8638b6) bind: avoid tests on aarch64-linux for now
* [`b6cc2f29`](https://github.com/NixOS/nixpkgs/commit/b6cc2f2979a19ec2983cef156d5d44b2fe0e545f) element-desktop: electron_22 -> electron_23 ([nixos/nixpkgs⁠#219823](https://togithub.com/nixos/nixpkgs/issues/219823))
* [`2d1959e4`](https://github.com/NixOS/nixpkgs/commit/2d1959e4451ba8920d4cf2c38cbdd002fc51eb37) libqalculate, qalculate-gtk: 4.5.1 -> 4.6.0
* [`ba0b8cd1`](https://github.com/NixOS/nixpkgs/commit/ba0b8cd1051da6499a3fb4adffc25b5dda1f7149) python310Packages.exchangelib: 4.7.6 -> 4.9.0
* [`f8560b60`](https://github.com/NixOS/nixpkgs/commit/f8560b606d8bccadce7643de99bbbff3dba2fbae) python310Packages.google-cloud-iot: 2.8.1 -> 2.9.0
* [`45b97fbf`](https://github.com/NixOS/nixpkgs/commit/45b97fbf3c90dbc017c6a181bcbc8764f141084a) python310Packages.exchangelib: add changelog to meta
* [`97a25540`](https://github.com/NixOS/nixpkgs/commit/97a2554073bc9aca7faf0bdf39c2f392f55d1ca0) ponyc: fix build
* [`4056bd51`](https://github.com/NixOS/nixpkgs/commit/4056bd515fcf848a63c3e009c078f51f06b1cd07) mnemosyne: fix build on darwin
* [`fce04513`](https://github.com/NixOS/nixpkgs/commit/fce04513bdbd1befff2fb9d79606472ebc6818d5) python310Packages.yattag: 1.15.0 -> 1.15.1
* [`c37be28c`](https://github.com/NixOS/nixpkgs/commit/c37be28c5ce35a9ce27f282aad7b3ee5b00dd7af) python310Packages.yattag: update meta
* [`a22c1ad4`](https://github.com/NixOS/nixpkgs/commit/a22c1ad4658695d83a0c2511e86dc4703abf24e7) python310Packages.yattag: disable on unsupported Python releases
* [`2cb1fddb`](https://github.com/NixOS/nixpkgs/commit/2cb1fddb1741b6c9a7e194bc1c628cb930ba454f) python310Packages.yattag: add pythonImportsCheck
* [`37cb8972`](https://github.com/NixOS/nixpkgs/commit/37cb89729485c70a324076b465f10a019733d629) ddnet: 16.7.2 -> 16.8
* [`0385eec0`](https://github.com/NixOS/nixpkgs/commit/0385eec0567ba6b52c45fe4d7d66736ad84b44a9) rust-analyzer-unwrapped: 2023-02-27 -> 2023-03-06
* [`740395e1`](https://github.com/NixOS/nixpkgs/commit/740395e1d38f2b6201acc69c3de95a1805158425) cachix: 1.2 -> 1.3
* [`4b23fea8`](https://github.com/NixOS/nixpkgs/commit/4b23fea83c5fa2941d8fa8a59cfd04afa040db3d) pokefinder: Add `qtwayland` for Linux
* [`fcc9c904`](https://github.com/NixOS/nixpkgs/commit/fcc9c904caab87f83779eca73a21e226ab54f06f) xorg.xorgserver: fixup build on *-darwin
* [`8cbb9b0c`](https://github.com/NixOS/nixpkgs/commit/8cbb9b0caa0f682c4aa437f87ed5fac935f8b4fe) python310Packages.vertica-python: 1.3.0 -> 1.3.1
* [`a6ad4d51`](https://github.com/NixOS/nixpkgs/commit/a6ad4d5146fdb18c504102e45c842a667eb40d41) python310Packages.django-ipware: add changelog to meta
* [`2d91c09a`](https://github.com/NixOS/nixpkgs/commit/2d91c09a03dcde05ab350e8e7849f55dd3bc97a6) python310Packages.django-ipware: disable on unsupported Python releases
* [`1bf51415`](https://github.com/NixOS/nixpkgs/commit/1bf51415baa7bcbeca221a702441694e9a5b2b7b) ocamlPackages.camlimages_4_2_4: remove broken
* [`d934806f`](https://github.com/NixOS/nixpkgs/commit/d934806f6201e1749f98d47611dbf90d5fcdc0e7) omake: 0.10.5 → 0.10.6
* [`8ba93b07`](https://github.com/NixOS/nixpkgs/commit/8ba93b07f9cc5533070c9df076b727ee2178d071) python310Packages.aliyun-python-sdk-iot: 8.51.0 -> 8.52.0
* [`b5ee3bef`](https://github.com/NixOS/nixpkgs/commit/b5ee3bef18cd0f14268d04f7092f7c3b59538fad) spicy-parser-generator: 1.5.3 -> 1.7.0
* [`186e71a9`](https://github.com/NixOS/nixpkgs/commit/186e71a9aba60e6f0b5dc4193231ce6bc5c407a2) zeek: 5.1.2 -> 5.2.0
* [`eabc31b9`](https://github.com/NixOS/nixpkgs/commit/eabc31b9b927a8053434af87d25d69a665bc3ba4) hcl2json: 0.3.4 -> 0.5.0
* [`9687cb67`](https://github.com/NixOS/nixpkgs/commit/9687cb670bb87129e3ed4e3dcc90955b06bc1861) fselect: 0.8.1 -> 0.8.2
* [`5f60ed18`](https://github.com/NixOS/nixpkgs/commit/5f60ed186f842d4818de7a6615ad64dbc1c56294) kubelogin-oidc: 1.26.0 -> 1.27.0
* [`9e88cf2c`](https://github.com/NixOS/nixpkgs/commit/9e88cf2c9eec4a91ab6114cbf446930f65ed9e36) xorg.xf86videosuncg6: 1.1.2 -> 1.1.3
* [`46f6c447`](https://github.com/NixOS/nixpkgs/commit/46f6c447aa6ce45a68dd89864377a1a8d5d0362e) xorg.xf86videosunffb: 1.2.2 -> 1.2.3
* [`be4adf56`](https://github.com/NixOS/nixpkgs/commit/be4adf566821cc44298eb6c9eec0be51ec4f277d) xorg.xf86videosunleo: 1.2.2 -> 1.2.3
* [`7a550f8b`](https://github.com/NixOS/nixpkgs/commit/7a550f8b8d26a7036dd0e1d4215c95de4e8f01dd) xorg.xf86videotrident: 1.3.8 -> 1.4.0
* [`cfc997d8`](https://github.com/NixOS/nixpkgs/commit/cfc997d86de27d2df7c10a0130a956a5946ec639) xorg.xf86videoqxl: 0.1.5 -> 0.1.6
* [`24489274`](https://github.com/NixOS/nixpkgs/commit/2448927413e25f0f000d2f8ac4468436c6ee75aa) python310Packages.aioconsole: 0.6.0 -> 0.6.1
* [`3af39763`](https://github.com/NixOS/nixpkgs/commit/3af397636d07d949148e610c278060c7c0c8fb96) evcc: 0.114.0 -> 0.114.1
* [`a479ff1e`](https://github.com/NixOS/nixpkgs/commit/a479ff1ec5427acc7d4cb5cfd0dde8204ae14e21) sapling: 0.2.20230124-180750-hf8cd450a -> 0.2.20230228-144002-h9440b05e
* [`1eb6f7ea`](https://github.com/NixOS/nixpkgs/commit/1eb6f7eaabb3ea59195f151c6aee6acdee6ed804) trealla: only put valgrind in checkInputs if not darwin
* [`014968da`](https://github.com/NixOS/nixpkgs/commit/014968da10a43bf9c4547cfc7ee63be5c7476398) Update pkgs/development/interpreters/trealla/default.nix
* [`1511944c`](https://github.com/NixOS/nixpkgs/commit/1511944c6f4e5b2b86c751c8b8072beb8d69ac5b) treesheets: unstable-2023-02-25 -> unstable-2023-03-05
* [`a4384ecf`](https://github.com/NixOS/nixpkgs/commit/a4384ecfb23b72e8e37103df64aee9bcae0d53ef) llpp: 33 -> 41
* [`a6462d10`](https://github.com/NixOS/nixpkgs/commit/a6462d104a8d7004df933c892c9cf2d42c48ee97) iosevka-bin: 19.0.1 -> 20.0.0
* [`9ba06d5e`](https://github.com/NixOS/nixpkgs/commit/9ba06d5e2ff3eda353e2968cf2635873d8d6ed39) duden: init at 0.18.0
* [`14622349`](https://github.com/NixOS/nixpkgs/commit/14622349154c73938ac2b385be92518235e92a0d) hue-plus: init at 1.4.5
* [`67b2ca1b`](https://github.com/NixOS/nixpkgs/commit/67b2ca1b16f1c0d377cc3f71cf9022973cd5b13f) doppler: 3.55.0 -> 3.56.0
* [`6e060c01`](https://github.com/NixOS/nixpkgs/commit/6e060c01b8a5e85ccfc5dadaef9ffe5a1332f1ab) matrix-appservice-slack: 2.0.2 -> 2.1.0
* [`8119ccf4`](https://github.com/NixOS/nixpkgs/commit/8119ccf40044c1a8fc6a885e3f99c7bcf35ff021) conform: 0.1.0-alpha.26 -> 0.1.0-alpha.27
* [`9b985ffb`](https://github.com/NixOS/nixpkgs/commit/9b985ffb118dc36281b728570c1bc77ca4bd9ef4) weidu: patch against OCaml 4.14
* [`d61ab745`](https://github.com/NixOS/nixpkgs/commit/d61ab7452c9652b0b6051f1a2a9f7da38d67dceb) mldonkey: migrate to OCaml 4.14
* [`883997cb`](https://github.com/NixOS/nixpkgs/commit/883997cb3af6825772ab4d4d38e78109c241c53d) erdtree: 1.1.0 -> 1.2.0
* [`f255a7eb`](https://github.com/NixOS/nixpkgs/commit/f255a7ebc3924deb487a08ba881921859ac456fa) grpc-gateway: 2.15.1 -> 2.15.2
* [`a119b197`](https://github.com/NixOS/nixpkgs/commit/a119b197e068a518dc6f4d048b9166b520c94b6f) grafana-loki: 2.7.1 -> 2.7.4
* [`a233af68`](https://github.com/NixOS/nixpkgs/commit/a233af68773ab7dbf6157a612ae0eaed02abe98c) android-tools: 33.0.3p2 -> 34.0.0
* [`983d0143`](https://github.com/NixOS/nixpkgs/commit/983d0143d07d494d10cb7368d18852aa815fb3f5) autorestic: 1.7.6 -> 1.7.7
* [`319cc6ca`](https://github.com/NixOS/nixpkgs/commit/319cc6ca3534ee6956bae42be85d7518f278cd02) chromium{Beta,Dev}: Switch to LLVM 15
* [`ba9cceac`](https://github.com/NixOS/nixpkgs/commit/ba9cceac7a142bf30ce892fc417f3f3a835caf78) arkade: 0.9.2 -> 0.9.3
* [`6b52f888`](https://github.com/NixOS/nixpkgs/commit/6b52f88815a5a539e940fdb191c480aded2a400a) ocaml-ng.ocamlPackages_4_14_unsafe_string: init
* [`da3dacd0`](https://github.com/NixOS/nixpkgs/commit/da3dacd0e6c3a2002cf124e9c30f588859aaf1a5) treewide: use ocaml-ng.ocamlPackages_4_14_unsafe_string
* [`3d70562d`](https://github.com/NixOS/nixpkgs/commit/3d70562dfd2253df3c1ae1731af3f8dfba5b88b0) leo2: add darwin support
* [`28b5084f`](https://github.com/NixOS/nixpkgs/commit/28b5084f40662c15e4d2546dbaa5664876de9298) statverif: add darwin support
* [`0d8cfbd0`](https://github.com/NixOS/nixpkgs/commit/0d8cfbd06cd277453e48ec44458d41c57c210d24) monotoneViz: migrate to OCaml 4.14
* [`6185e429`](https://github.com/NixOS/nixpkgs/commit/6185e429a66b5360db976a604cece6cc731dbe36) wyrd: migrate to OCaml 4.14
* [`3966519d`](https://github.com/NixOS/nixpkgs/commit/3966519d12be2fb3fded3420f1cc82d681b17b5d) libreoffice: wrapper.nix rewrite
* [`bf98b333`](https://github.com/NixOS/nixpkgs/commit/bf98b333ee4ca6b0ea3140bb5fe5e14910863caa) torq: 0.18.17 -> 0.18.19
* [`22561466`](https://github.com/NixOS/nixpkgs/commit/22561466b0d5fb333d0a065f4b70553d69f56348) aws-c-io: 0.13.15 -> 0.13.18
* [`16818343`](https://github.com/NixOS/nixpkgs/commit/16818343f11972ed7f591080992ba146790cc2f1) maintainers: add apfelkuchen6
* [`481f02f7`](https://github.com/NixOS/nixpkgs/commit/481f02f7dd1b21ddfc363ec30b99fcfac04deaec) mpv: allow scripts to add wrapper args
* [`219a017c`](https://github.com/NixOS/nixpkgs/commit/219a017ce41a7b92746473f111b620850890c23b) dotnet-sdk_7: 7.0.102 -> 7.0.201
* [`e7c8662c`](https://github.com/NixOS/nixpkgs/commit/e7c8662c07e4caa2da07b8e58c7d779f29905b82) BeatSaberModManager: Update nuget dependencies
* [`72123b64`](https://github.com/NixOS/nixpkgs/commit/72123b64d423a4e7c511c91c1b82074cd40e8a4d) goreleaser: 1.15.2 -> 1.16.0
* [`1694afe2`](https://github.com/NixOS/nixpkgs/commit/1694afe2370f28a4c2cc393d3cf8fcbf58254af9) cpm-cmake: 0.38.0 -> 0.38.1
* [`26622690`](https://github.com/NixOS/nixpkgs/commit/266226903f343f867d1d217cab2b8e56f4fdefdc) python310Packages.doorbirdpy: 2.2.1 -> 2.2.2
* [`9ae79a46`](https://github.com/NixOS/nixpkgs/commit/9ae79a46f8b2497f0ea35da3ab3cb475c4283a5b) bacon: 2.6.1 -> 2.6.2
* [`a3dfcb57`](https://github.com/NixOS/nixpkgs/commit/a3dfcb57c2b727f3b307f370a27f1f6255ca7813) kbs2: 0.7.1 -> 0.7.2
* [`be1d82d5`](https://github.com/NixOS/nixpkgs/commit/be1d82d5ca6c3e80442d91b1a45af66776326495) python310Packages.openapi-schema-validator: 0.3.4 -> 0.4.3
* [`f1479a8e`](https://github.com/NixOS/nixpkgs/commit/f1479a8e9ff0c57a4d90b7ea1a86777be152330c) python310Packages.openapi-spec-validator: 0.5.1 -> 0.5.5
* [`9ca5356d`](https://github.com/NixOS/nixpkgs/commit/9ca5356d8d4475a12e9ad4d3d611fddbc02d4aa6) python310Packages.openapi-core: 0.16.6 -> 0.17.0
* [`6f7d6eba`](https://github.com/NixOS/nixpkgs/commit/6f7d6eba8f310a14f50050d6240497c5b041ad90) uacme: 1.7.3 -> 1.7.4
* [`68852fbe`](https://github.com/NixOS/nixpkgs/commit/68852fbe7c5714761fba83fe0c75afaf1902850a) oh-my-zsh: 2023-03-04 -> 2023-03-06
* [`2689297c`](https://github.com/NixOS/nixpkgs/commit/2689297c50e2041d7f1846580f6bd4d784cd45f9) rustpython: 2022-10-11 -> 0.2.0
* [`1846e296`](https://github.com/NixOS/nixpkgs/commit/1846e296de59daa169d9fd703445bbc5c942c885) mcfly: 0.7.1 -> 0.8.0
* [`851e7062`](https://github.com/NixOS/nixpkgs/commit/851e70627a9c4c22dd77bc182b5d1feda59ceea3) python310Packages.evtx: fix build on darwin
* [`bb5edc48`](https://github.com/NixOS/nixpkgs/commit/bb5edc482e691dbf9d0a28348684b2af611c6711) rustpython: fix build on aarch64-linux
* [`7e29e1b2`](https://github.com/NixOS/nixpkgs/commit/7e29e1b2c2cb2adb79783f2393553fbfd52175c5) postgresqlPackages.timescaledb: 2.10.0 -> 2.10.1
* [`ea593627`](https://github.com/NixOS/nixpkgs/commit/ea593627b9df5925f6a9c78698daedbaf2536753) python310Packages.pydata-sphinx-theme: 0.13.0 -> 0.13.1
* [`f6546a76`](https://github.com/NixOS/nixpkgs/commit/f6546a76559371bd690c30e4c4db8f898704ac31) python310Packages.jupyter-book: 0.14.0 -> 0.15.0
* [`fc9ceeba`](https://github.com/NixOS/nixpkgs/commit/fc9ceeba82d0f5c0b4be97ee333e58c41b7ab67d) brakeman: 5.4.0 -> 5.4.1
* [`95ae3fc8`](https://github.com/NixOS/nixpkgs/commit/95ae3fc851b46a1507f139a6def751f51cde086a) signalbackup-tools: 20230304-3 -> 20230305
* [`64967029`](https://github.com/NixOS/nixpkgs/commit/649670296e729ac4a9c6667fcb172ae24a939ff2) opencv2: add darwin dependencies
* [`f5d33bf1`](https://github.com/NixOS/nixpkgs/commit/f5d33bf1f62627d1f8032bc309d9e069fd0b13d0) terraform-providers.checkly: 1.6.3 → 1.6.4
* [`60894658`](https://github.com/NixOS/nixpkgs/commit/608946580f5eebd38bc2124a4418ef1ba44c0c2e) terraform-providers.dnsimple: 0.16.1 → 0.16.2
* [`4a968ef9`](https://github.com/NixOS/nixpkgs/commit/4a968ef9be13181f672d0bd0f95a1d6ed72c00fd) terraform-providers.external: 2.2.3 → 2.3.1
* [`24b1c515`](https://github.com/NixOS/nixpkgs/commit/24b1c515d10ba833fe3ec9954cf88953d42c5bbb) terraform-providers.google: 4.55.0 → 4.56.0
* [`63e53c25`](https://github.com/NixOS/nixpkgs/commit/63e53c25af0717bb2d19d35fc1a0267098bbed10) terraform-providers.google-beta: 4.55.0 → 4.56.0
* [`e9a108bb`](https://github.com/NixOS/nixpkgs/commit/e9a108bb8cb71af191e094a307310db9bc550e8d) terraform-providers.keycloak: 4.1.0 → 4.2.0
* [`4aee971d`](https://github.com/NixOS/nixpkgs/commit/4aee971db19c5df4aa4e9cee7d24ec4ef90e0364) terraform-providers.aws: 4.57.0 → 4.57.1
* [`70073985`](https://github.com/NixOS/nixpkgs/commit/70073985ae856f777639a4742943f48b317d7799) nixos/gemstash: init module
* [`b5a69971`](https://github.com/NixOS/nixpkgs/commit/b5a6997194937e3428daee359d89db84c9f64f11) flyctl: 0.0.475 -> 0.0.476
* [`a7f90a36`](https://github.com/NixOS/nixpkgs/commit/a7f90a36f103ea24f8766de766d3bc72a72c92bf) vector: 0.28.0 -> 0.28.1
* [`24af7f35`](https://github.com/NixOS/nixpkgs/commit/24af7f357fca0cfd7b596ed7ebf04a3e8a0ee37b) byacc: 20221229 -> 20230219
* [`d0879528`](https://github.com/NixOS/nixpkgs/commit/d0879528a63d927b4d571ed9242b8ab9b7f2fda8) Patch hercules-ci-agent to support cachix 1.3
* [`14af7c5a`](https://github.com/NixOS/nixpkgs/commit/14af7c5a37dcb5c09e13b458ca54a794b8641df2) directx-shader-compiler: 1.7.2212 -> 1.7.2212.1
* [`d966df07`](https://github.com/NixOS/nixpkgs/commit/d966df07bf7846a471ee1186c7039e1ca91f9080) pulumi: 3.55.0 -> 3.56.0
* [`46b4fad0`](https://github.com/NixOS/nixpkgs/commit/46b4fad03e60e68a728ace81aaf8db2b6af7d31a) conftest: 0.39.1 -> 0.39.2
* [`09b38d10`](https://github.com/NixOS/nixpkgs/commit/09b38d10cc0930fc1005e703cd26c99f5b5d55c6) libfabric: 1.17.0 -> 1.17.1
* [`3e79b30f`](https://github.com/NixOS/nixpkgs/commit/3e79b30f642ccaf6b3f25c851ada5b34d94f42ed) browserpass: 3.0.10 -> 3.1.0
* [`9550348c`](https://github.com/NixOS/nixpkgs/commit/9550348c1aea20ecf2a10a4d725bc5c30c8452e3) ocamlPackages.{arp,ethernet,tcpip}: some cleaning
* [`7fa20e70`](https://github.com/NixOS/nixpkgs/commit/7fa20e70ea7e1c98e8f6ae1d90564d1d0444e4f2) ocamlPackages.mirage-stack: 2.2.0 → 4.0.0
* [`b13286ad`](https://github.com/NixOS/nixpkgs/commit/b13286ad0271612bcc0e7bb198da42b37bc2eaf5) ocamlPackages.mirage-protocols: 5.0.0 → 8.0.0
* [`42441152`](https://github.com/NixOS/nixpkgs/commit/42441152b4bc50d8b92f59b03ddba55c5a02317a) python310Packages.peaqevcore: 12.2.6 -> 12.2.7
* [`b879ef25`](https://github.com/NixOS/nixpkgs/commit/b879ef25813dff5803fdbb1423d1aa0d014ad0ed) python310Packages.aioesphomeapi: 13.4.1 -> 13.5.0
* [`a3dcdef4`](https://github.com/NixOS/nixpkgs/commit/a3dcdef4a78b4a459fd0aa06d99ad82623826131) chezmoi: 2.31.0 -> 2.31.1
* [`1f1271bd`](https://github.com/NixOS/nixpkgs/commit/1f1271bd764e3732666c1bc389aec7089f293bdc) gitsign: add developer-guy to maintainers list
* [`bb26db7d`](https://github.com/NixOS/nixpkgs/commit/bb26db7dd930499c3a759623ee05473953094cfd) python310Packages.nestedtext: add changelog to meta
* [`49a67605`](https://github.com/NixOS/nixpkgs/commit/49a676052101f4b2206a2b559181ab6050c0eac4) python310Packages.nestedtext: equalize
* [`dba4f381`](https://github.com/NixOS/nixpkgs/commit/dba4f3816648b2a1a53df0b7b4ad23619d97e7f7) python310Packages.nestedtext: disable on unsupported Python releases
* [`6509273d`](https://github.com/NixOS/nixpkgs/commit/6509273d853b8d0b3d90fe5edfd43397525b1753) python310Packages.nestedtext: 1.2 -> 3.5
* [`cab5d3d7`](https://github.com/NixOS/nixpkgs/commit/cab5d3d75b6488ce5614b7e4fd074f74919a4363) circleci-cli: 0.1.23667 -> 0.1.23816
* [`9978ed0d`](https://github.com/NixOS/nixpkgs/commit/9978ed0d20b8f899c3d08a30089c0c3310359262) elmPackages.*: Semi automated update
* [`d6630686`](https://github.com/NixOS/nixpkgs/commit/d6630686893dc78f4d2ab908d845cae131443224) python310Packages.parametrize-from-file: disable failing test
* [`a0abef4a`](https://github.com/NixOS/nixpkgs/commit/a0abef4ae64d2c2161c1fa21ac7a6c222b6caf7f) python310Packages.google-cloud-websecurityscanner: 1.11.1 -> 1.12.0
* [`2a68c63f`](https://github.com/NixOS/nixpkgs/commit/2a68c63fc6c89ee7b9039e63cb612eea9dbc0c01) stunnel: 5.67 -> 5.69
* [`546adc67`](https://github.com/NixOS/nixpkgs/commit/546adc67e70ce0b1aa6a34ad2ccc0238548320ed) organicmaps: 2023.01.25-3 -> 2023.03.05-5
* [`fd296e5d`](https://github.com/NixOS/nixpkgs/commit/fd296e5d4d0649390bae0ec26a680f2db3f3861e) colima: 0.5.2 -> 0.5.3
* [`f59d3afc`](https://github.com/NixOS/nixpkgs/commit/f59d3afcd5e0d0e7e763155254b89ef115ecb654) organicmaps: add updateScript
* [`0fd67b46`](https://github.com/NixOS/nixpkgs/commit/0fd67b467ad31cb7af901989df3e5e4a59f9e91d) gobgp: 3.11.0 -> 3.12.0
* [`329e37ab`](https://github.com/NixOS/nixpkgs/commit/329e37ab4c2db9065900e14ce96b286076f0219a) d2: 0.2.2 -> 0.2.3
* [`106f543e`](https://github.com/NixOS/nixpkgs/commit/106f543e505af38b360748388cbb0e1e0adb9637) zellij: 0.34.4 -> 0.35.1
* [`5fc58a9c`](https://github.com/NixOS/nixpkgs/commit/5fc58a9cb4370cf4cecbbeeaf101211beee8b61e) jimtcl: 0.81 -> 0.82
* [`dc45d4e5`](https://github.com/NixOS/nixpkgs/commit/dc45d4e5a7d69b364c7623637d168f97fd6cfa12) cplay-ng: 5.1.0 -> 5.2.0
* [`705ee06f`](https://github.com/NixOS/nixpkgs/commit/705ee06f10d55a7b1f61b859be81a47b583df033) dillong: add meta.mainProgram
* [`79394475`](https://github.com/NixOS/nixpkgs/commit/7939447527bf256129c8b44883f31edb261de165) Update pkgs/development/r-modules/default.nix
* [`49878856`](https://github.com/NixOS/nixpkgs/commit/49878856e6cde3ae674f470da407e3bde2f55c9d) https://github.com/NixOS/nixpkgs/pull/188334#issuecomment-1445425412
* [`27375af8`](https://github.com/NixOS/nixpkgs/commit/27375af8c3a4b2adb696075d424e6635b21fce24) flyctl: 0.0.476 -> 0.0.477
* [`4830391e`](https://github.com/NixOS/nixpkgs/commit/4830391e718434341699eada1637aa8261297a6a) youtube-tui: init at 0.7.0
* [`74bbf74f`](https://github.com/NixOS/nixpkgs/commit/74bbf74fc935b549127d8d65600c58c31698249f) maintainers: add Ruixi-rebirth
* [`e34328aa`](https://github.com/NixOS/nixpkgs/commit/e34328aa3a0949f955ee96317c3bcf70f5c5ec07) netcoredbg: 2.0.0-895 -> 2.2.0-961
* [`c0a2b57e`](https://github.com/NixOS/nixpkgs/commit/c0a2b57e200e41f4b33af9e2f14a4b861c88811d) maintainers: add konradmalik
* [`62a0d2eb`](https://github.com/NixOS/nixpkgs/commit/62a0d2eb9fcb81a94e1652d4a0d2a4c47a3059cd) ginkgo: 2.8.4 -> 2.9.0
* [`253cdabf`](https://github.com/NixOS/nixpkgs/commit/253cdabfb6271fdfa855cbc120db1bee4d73998b) git-branchless: 0.6.0 -> 0.7.0
* [`561ec56a`](https://github.com/NixOS/nixpkgs/commit/561ec56a304e3d707da6a7f842cc2158fcefae12) acr: refactor
* [`6713a092`](https://github.com/NixOS/nixpkgs/commit/6713a092915702c8d45a5b22f8f752ca6eea89c8) flyctl: 0.0.476 -> 0.0.477
* [`c3982aae`](https://github.com/NixOS/nixpkgs/commit/c3982aae4e4af665e3fdd7d42d04752a2f378db8) forkstat: 0.03.00 -> 0.03.01
* [`4839388d`](https://github.com/NixOS/nixpkgs/commit/4839388d2b95d909f53236e2d8f899aa811ba76a) byacc: refactor
* [`20b50b7a`](https://github.com/NixOS/nixpkgs/commit/20b50b7a8f853f209421c8951617b376e2e819b5) jabref: 5.7 -> 5.9
* [`43f2c5ef`](https://github.com/NixOS/nixpkgs/commit/43f2c5ef663ade65f947ef3f83b76da50590f0f6) teleport: 12.0.2 -> 12.1.0
* [`6f3e07ed`](https://github.com/NixOS/nixpkgs/commit/6f3e07edfafe126902643cb7cafee89692091e89) python310Packages.google-cloud-spanner: 3.27.1 -> 3.28.0
* [`80380122`](https://github.com/NixOS/nixpkgs/commit/803801225594149d8b4f3836acd57fca4d366816) janet: 1.26.0 -> 1.27.0
* [`3032954d`](https://github.com/NixOS/nixpkgs/commit/3032954df3660ea74c72e69b42ecb97606c290ad) python310Packages.snapcast: 2.3.1 -> 2.3.2
* [`ae3b83c8`](https://github.com/NixOS/nixpkgs/commit/ae3b83c809f5ef9140c597b3d18896c02a5dcd25) hugo: 0.111.1 -> 0.111.2
* [`27eab436`](https://github.com/NixOS/nixpkgs/commit/27eab436bd6c9bb50bf48e9c4587bdf135ec3fdd) nixos/tests/hostname.nix: nixpkgs-fmt
* [`5566961d`](https://github.com/NixOS/nixpkgs/commit/5566961d2e43a688b0892fafe6c0f65aea1bf6b5) nixosTests.hostname: stop using deprecated nodes.machine.config
* [`ddf52e63`](https://github.com/NixOS/nixpkgs/commit/ddf52e637ced39a041cb70c95c30c4fe2095608c) gopsuinfo: 0.1.2 -> 0.1.3
* [`10684ae9`](https://github.com/NixOS/nixpkgs/commit/10684ae9c4362edf2b469548d7315b1b2584af7e) python3Packages.nix-prefetch-github: 6.0.0 -> 6.0.1
* [`525aff3a`](https://github.com/NixOS/nixpkgs/commit/525aff3ab33ab996d3532a45ec5478295c55a169) elisp-packages/manual-packages.nix: use self-scoped callPackage
* [`2acbdc41`](https://github.com/NixOS/nixpkgs/commit/2acbdc41e9c7ba55d2d876ab15039ce49e13bf8d) ffado: 2.4.3 -> 2.4.7
* [`9cb0772d`](https://github.com/NixOS/nixpkgs/commit/9cb0772d436dd64f319643d1f0b78076237ed82a) calcure: init at 2.8.2
* [`66b05cfb`](https://github.com/NixOS/nixpkgs/commit/66b05cfb9a00cfd8ec246e9591d5afbea7adca2e) dbmate: 1.16.2 -> 2.0.1
* [`23e0077d`](https://github.com/NixOS/nixpkgs/commit/23e0077d3653757c405a848d07ddbd37507a7ece) fizz: 2023.02.27.00 -> 2023.03.06.00
* [`f78d3c7d`](https://github.com/NixOS/nixpkgs/commit/f78d3c7d5f671fb2917e5212a20daab099cdbb05) jql: 5.1.6 -> 5.1.7
* [`1af3c49d`](https://github.com/NixOS/nixpkgs/commit/1af3c49d48ee8575dbe47994ef8ec55a6415d876) clojure: 1.11.1.1237 -> 1.11.1.1252
* [`2ca73535`](https://github.com/NixOS/nixpkgs/commit/2ca73535423e4252803b41d843ef59309658af49) linuxPackages.tuxedo-keyboard: 3.1.1 -> 3.1.4
* [`35ca4727`](https://github.com/NixOS/nixpkgs/commit/35ca4727fbf3cedef60681f23f5384aa8e758998) python310Packages.slack-sdk: 3.20.0 -> 3.20.1
* [`6d8041b0`](https://github.com/NixOS/nixpkgs/commit/6d8041b0532c8b51a93f68c9737feecbb195d32a) writeShellApplication: Prefer lib.getExe over unwrapped ShellChecked
* [`0ba1c25b`](https://github.com/NixOS/nixpkgs/commit/0ba1c25b620047a8c05cccce308fcb76c25c1780) python310Packages.hvac: 1.0.2 -> 1.1.0
* [`04a5d95d`](https://github.com/NixOS/nixpkgs/commit/04a5d95dbf13ed3776edc7c24927cf76975f37aa) maintainers: add milran
* [`42cda97c`](https://github.com/NixOS/nixpkgs/commit/42cda97c500b54ad2e8617d515cc198a027dceaa) gqlgenc: init at 0.11.3
* [`5b9628a9`](https://github.com/NixOS/nixpkgs/commit/5b9628a9ed381e34171c88cd8f17f1b6b7614dcc) teleport: add justinas to maintainers
* [`701a8387`](https://github.com/NixOS/nixpkgs/commit/701a838718504aa719de3913be0530c35b83da36) teleport: add arianvp to maintainers
* [`1f2cf28a`](https://github.com/NixOS/nixpkgs/commit/1f2cf28aa96e39f23abd7fa367273f9800f87521) algolia-cli: 1.3.0 -> 1.3.1
* [`73f2f4c6`](https://github.com/NixOS/nixpkgs/commit/73f2f4c6a8d503c5f179a84162a2eda151a93874) freac: 1.1.6 -> 1.1.7
* [`af13b8f8`](https://github.com/NixOS/nixpkgs/commit/af13b8f8523a6c2f74a207210f30d8c9f54ec3cd) boca: 1.0.6a -> 1.0.7
* [`19f0a78c`](https://github.com/NixOS/nixpkgs/commit/19f0a78c195223e7021ff4d16bad71c6f4cb981d) mpvScripts.uosc: init at 4.6.0
* [`b85c1e31`](https://github.com/NixOS/nixpkgs/commit/b85c1e319e28161044e0ca1a33cdb69310d1e93f) node2nix: pull in patch to fix bin scripts with crlf line-endings
* [`0835e5a1`](https://github.com/NixOS/nixpkgs/commit/0835e5a189bf0ae676ccfd91afaf0e6c39c65b28) nodePackages: regen only node-env
* [`27688662`](https://github.com/NixOS/nixpkgs/commit/2768866261ee21659edc6427f66d5b5b0f613752) nixosTests.pantheon: ensure the password box is focused when login
* [`94ce5a87`](https://github.com/NixOS/nixpkgs/commit/94ce5a875a001d285537a8757fd6e63d6b3f93f3) pkgs/tools/wayland: enable strictDeps
* [`47ace7b0`](https://github.com/NixOS/nixpkgs/commit/47ace7b0af442b2e6bdb8728330622c7dbc81499) pkgs/tools/nix: enable strictDeps
* [`9bfeb0d7`](https://github.com/NixOS/nixpkgs/commit/9bfeb0d751e7bbffb3d078f6a87804dd26ceae19) checkip: 0.44.2 -> 0.45.1
* [`5eb5d881`](https://github.com/NixOS/nixpkgs/commit/5eb5d881a49ce1eeecf24dc501efead1f70fc620) nixos/nginx: add defaultMimeTypes option
* [`3e38add9`](https://github.com/NixOS/nixpkgs/commit/3e38add9b06f92e0508acd7013bd4e15c388bd8a) maintainers: add connorbaker
* [`518ee5c9`](https://github.com/NixOS/nixpkgs/commit/518ee5c99bb9980deeaf2db102bf7abca901ad8b) zine: 0.11.1 -> 0.12.0
* [`2ba99961`](https://github.com/NixOS/nixpkgs/commit/2ba999615a0a558660a4eb00d42704566223264d) psql2csv: init at 0.12
* [`d8831d92`](https://github.com/NixOS/nixpkgs/commit/d8831d9224687aeb8e5b49ec7d626c94fa61d2e3) somebar: 1.0.0 -> 1.0.3
* [`2f430da1`](https://github.com/NixOS/nixpkgs/commit/2f430da1c6aaeb4306427b77f139f53dcd729e08) Replacing MRAN mirror with posit
* [`22cf9cd0`](https://github.com/NixOS/nixpkgs/commit/22cf9cd0112c9765d99226e38bdce9b7d82fba7d) sfeed: 1.6 -> 1.7
* [`de1f8d6b`](https://github.com/NixOS/nixpkgs/commit/de1f8d6bd89b43d0cd09ee13c94e5c60736b8333) maestro: 1.23.0 -> 1.24.0
* [`02cd0a5d`](https://github.com/NixOS/nixpkgs/commit/02cd0a5dfcb99b162791bade2d2888c8187a6a92) sherpa: 2.2.13 -> 2.2.14 ([nixos/nixpkgs⁠#220016](https://togithub.com/nixos/nixpkgs/issues/220016))
* [`27684f88`](https://github.com/NixOS/nixpkgs/commit/27684f8832048988eecdced28f3879db396a9b7e) mindustry: 141.2 -> 142
* [`acf1389e`](https://github.com/NixOS/nixpkgs/commit/acf1389e2fbc757cbcd731bf1c26a1ef940b2e0f) goreleaser: add caarlos0 to maintainers list
* [`a76b5ced`](https://github.com/NixOS/nixpkgs/commit/a76b5ced8b75f6b3767d6a0349abc5a8b5efb777) goreleaser: add developer-guy to maintainers list
* [`25939765`](https://github.com/NixOS/nixpkgs/commit/25939765180ed716662ed2c441ebe2506202cd8b) csdr: 0.18.0 -> 0.18.1
* [`7e1bcf5f`](https://github.com/NixOS/nixpkgs/commit/7e1bcf5f38a361828604e68efc98825ee0e060c2) glooctl: 1.13.8 -> 1.13.9
* [`0c370aab`](https://github.com/NixOS/nixpkgs/commit/0c370aab6450244197fcd08814a42cdf560ea973) aws-sso-cli: 1.9.9 -> 1.9.10
* [`937e716d`](https://github.com/NixOS/nixpkgs/commit/937e716d4ea11874fdd6381ced8a93f42f4d7273) python3Packages.sphinxext-opengraph: 0.7.5 -> 0.8.1
* [`8460c8b1`](https://github.com/NixOS/nixpkgs/commit/8460c8b124a00c603ccf1786e1a7d19d58874790) tlaps: migrate to OCaml 4.14
* [`0a11517a`](https://github.com/NixOS/nixpkgs/commit/0a11517a84f5eab2e7d4ef5219325f20cc52653f) act: 0.2.42 -> 0.2.43
* [`985e04ac`](https://github.com/NixOS/nixpkgs/commit/985e04ac1b00e59cc927e42812576845c10c2e78) maintainers: add kirillrdy
* [`72d7d2e9`](https://github.com/NixOS/nixpkgs/commit/72d7d2e9cc08bd38fec8cd96fe1bb0b743e87f2d) awsebcli: add kirillrdy as maintainer
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
