### PR TITLE
niv devenv: update 8e047801 -> b97ca4bd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "8e0478018a410f47d947b4c16de0927170f226bf",
-        "sha256": "0v9nin4pg8bcd6lyvkhqx68mbv0q1hyi2gp00rqicxnzd600fslv",
+        "rev": "b97ca4bd581f0e2fb620f301cc417791f655f851",
+        "sha256": "192xn5lplq2anjc177ffq40j6zasm88diq825rlci5pac140hrfr",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/8e0478018a410f47d947b4c16de0927170f226bf.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/b97ca4bd581f0e2fb620f301cc417791f655f851.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@8e047801...b97ca4bd](https://github.com/cachix/devenv/compare/8e0478018a410f47d947b4c16de0927170f226bf...b97ca4bd581f0e2fb620f301cc417791f655f851)

* [`dbb67882`](https://github.com/cachix/devenv/commit/dbb6788246f9a2b314a83066549b042ebede1396) Add terraform template
* [`f206e2fb`](https://github.com/cachix/devenv/commit/f206e2fb18f185b1597051b0cf0d69ce7311fac9) Add template to flake.nix
* [`39f92833`](https://github.com/cachix/devenv/commit/39f92833beaad1b813653b63b84b564e4fa6e57a) docs: clarify reinstallation
* [`b9e0ace8`](https://github.com/cachix/devenv/commit/b9e0ace80abd0ca5631ab5df7d6562ba9d8af50c) docs: link to fly.io example
* [`8b7ea765`](https://github.com/cachix/devenv/commit/8b7ea765f4aea91b00a82eb367d47fac7ccc113b) docs: strip colons from help text
* [`6dbb3777`](https://github.com/cachix/devenv/commit/6dbb37771a724dc92b900a429bcdd3f5a68f8de5) envrc: give explanation on failing devenv builds
* [`f471d8a9`](https://github.com/cachix/devenv/commit/f471d8a906a3dc1330abeea8550091abde5b46a8) docs: bump actions
* [`910271fe`](https://github.com/cachix/devenv/commit/910271fec39dc4513014ffec58c40ad172acf2c2) direnvrc: avoid exiting with code 1
* [`555f210e`](https://github.com/cachix/devenv/commit/555f210eb921f5dc1e179cdfe22f284d5f32eed9) direnvrc: use log_error for errors
* [`95f329d4`](https://github.com/cachix/devenv/commit/95f329d49a8a5289d31e0982652f7058a189bfca) direnvrc: avoid exit 1 when parsing devenv.yaml fails
* [`ca23892d`](https://github.com/cachix/devenv/commit/ca23892d8b9f788be8d1d358c673c8d0f9b4f68f) doc: fix flake example
* [`8bde3094`](https://github.com/cachix/devenv/commit/8bde30945460ace36293396fdc8ee8d584c05ba3) use util-linuxMinimal instead of util-linux for column
* [`524e6ac2`](https://github.com/cachix/devenv/commit/524e6ac2373b484cbe347d06d6262a21dd53b57f) python: allow venv to be used in recursive devenv
* [`be184a41`](https://github.com/cachix/devenv/commit/be184a4104405aaa0864f898e26a30d6dac052e9) doc: fix quotes in flake example
* [`cd1a085e`](https://github.com/cachix/devenv/commit/cd1a085e2bc8de888dfbfab855cd6cb530d6a8ed) fix: allow setting a non default timzone for mysql
* [`ae5a25de`](https://github.com/cachix/devenv/commit/ae5a25de70d7b2c29f74a8a128407f96392894f1) Auto generate docs/reference/options.md
* [`acac54b2`](https://github.com/cachix/devenv/commit/acac54b2775647597b1432856aa3a24dea43e3fd) docs: mention devenv is using Nix
* [`171ad829`](https://github.com/cachix/devenv/commit/171ad829af3bca61b1babf961153c088a50aa7aa) bump deps and always install python deps
* [`f665f6b0`](https://github.com/cachix/devenv/commit/f665f6b0db78abac8d06dc53873ba12acaba04b3) Auto generate docs/reference/options.md
* [`8a46d83b`](https://github.com/cachix/devenv/commit/8a46d83b463a213ce0741bce82f8f7d9df152a65) Update using-with-flakes.md
* [`0317938c`](https://github.com/cachix/devenv/commit/0317938c6256716436526f48cae0bcb96b485e8d) fix devcontainer and auto-configure devenv
* [`20b151e3`](https://github.com/cachix/devenv/commit/20b151e394d91c826057a82f5bdd4747f2f6b494) feat: allow to customize devcontainers
* [`a1e83a9c`](https://github.com/cachix/devenv/commit/a1e83a9c6b4ff203b31b16317d1d2c8dca2263a2) Update .devcontainer.json
* [`b19b7e9d`](https://github.com/cachix/devenv/commit/b19b7e9d657a6fa20179b855bd3e702b696ec4ba) Update devenv.nix
* [`cef15c1a`](https://github.com/cachix/devenv/commit/cef15c1a5a824a5ecb888a7beb8af647d2b76e91) Auto generate docs/reference/options.md
* [`39a1a553`](https://github.com/cachix/devenv/commit/39a1a553c399ac71ee1312a6fcdcb99b3e24be0c) send newsletter to the new emailing provider
* [`b3319069`](https://github.com/cachix/devenv/commit/b331906925f3ba23d67e461b14ed042c743259c4) fix newsletter action
* [`ab2d77fd`](https://github.com/cachix/devenv/commit/ab2d77fd8bd0f31c0c82ca066189e41f2627ffd4) newsletter: change submission url again
