### PR TITLE
niv doomemacs: update 8f6b045d -> 63586423

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "8f6b045dfdb6d00e5a324c3f9044dce773791502",
-        "sha256": "1fzgwxvj60dfjdgylibjbg407d1lb35269ykgy7jcjxdmmbfzl9b",
+        "rev": "63586423dab6248d6e5acfc68dc4324c15f05d83",
+        "sha256": "02czkc8vzr5jzgap79qpnxr823skd2ndw6x88m5rc4g63fsgdvr1",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/8f6b045dfdb6d00e5a324c3f9044dce773791502.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/63586423dab6248d6e5acfc68dc4324c15f05d83.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@8f6b045d...63586423](https://github.com/doomemacs/doomemacs/compare/8f6b045dfdb6d00e5a324c3f9044dce773791502...63586423dab6248d6e5acfc68dc4324c15f05d83)

* [`8be11ff4`](https://github.com/doomemacs/doomemacs/commit/8be11ff48cfd6f2212151f8abba6149a9f0e5364) fix(treemacs): ignore default popup rules
* [`78895d89`](https://github.com/doomemacs/doomemacs/commit/78895d89ee3947bcbbf25bed928d8bb6767e8b51) fix(csharp): csharp-tree-sitter-mode: void-function error in Emacs 29+
* [`0123dd16`](https://github.com/doomemacs/doomemacs/commit/0123dd1648695007ddec0a41e406624cec58224c) fix(tools): improve detection of available REPLs
* [`5daf800a`](https://github.com/doomemacs/doomemacs/commit/5daf800ae1d168719131a856d3468be1d7bd5d32) feat(tools): rework REPL selection UI
* [`ef525e61`](https://github.com/doomemacs/doomemacs/commit/ef525e6184f6fb671e94deffcd11e6039176e191) bump: :lang common-lisp
* [`8063b02a`](https://github.com/doomemacs/doomemacs/commit/8063b02a801c45a9754532b23e37d50e870d7c0f) feat(common-lisp): set custom repl opener
* [`d9f3d5c2`](https://github.com/doomemacs/doomemacs/commit/d9f3d5c2f14b27bec1f22402563a69d2f4f589da) fix(haskell): require `haskell-interactive-mode` when opening repl
* [`d9f18e60`](https://github.com/doomemacs/doomemacs/commit/d9f18e6040d5aa96245f93ccd864163c2eab82c0) fix(sh): eagerly load `sh-script` mode when opening a REPL
* [`719716cf`](https://github.com/doomemacs/doomemacs/commit/719716cf2049bef1fa46a159a5e2ce33301ec4d3) fix(clojure): eager localleader keybind
* [`81f5a8f0`](https://github.com/doomemacs/doomemacs/commit/81f5a8f052045afaa984db42bde7bdfcce16f417) fix(org): "No org-loaddefs.el file" errors
* [`7c7ee660`](https://github.com/doomemacs/doomemacs/commit/7c7ee6602cb66d6a82d852eb0f25f5889dd2ecf8) fix: update & simplify shell.nix
* [`adb125f4`](https://github.com/doomemacs/doomemacs/commit/adb125f41f49e5f3561091b3d1ea9209afec3dc0) fix(evil): persist evil state after mode changes
* [`f1f010ff`](https://github.com/doomemacs/doomemacs/commit/f1f010ff99c07eb8f1f0ae5d4753e70feaae035e) perf(rss): defer db compaction
* [`52129f04`](https://github.com/doomemacs/doomemacs/commit/52129f04bbe65d8fdafdec6691abc5d9a0882dfa) fix(direnv): envrc triggering in its own internal buffers
* [`8d578cad`](https://github.com/doomemacs/doomemacs/commit/8d578cad76bf833319fd05195038ccdf287e0427) fix: s/permenant-local/permanent-local
* [`63586423`](https://github.com/doomemacs/doomemacs/commit/63586423dab6248d6e5acfc68dc4324c15f05d83) release(modules): 23.03.0-dev
