### PR TITLE
niv niv: update 689d0e55 -> ecabfde8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "689d0e5539eddd0b0f566aee7bb18629eee7df74",
-        "sha256": "1rld3lk42l6b01f2gcrhq8qm9vry1awmfl29zmpiqda9dy89vbx0",
+        "rev": "ecabfde837ccfb392ccca235f96bfcf4bb8ab186",
+        "sha256": "1aij19grvzbxj0dal49bsnhq1lc23nrglv6p0f00gwznl6109snj",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/689d0e5539eddd0b0f566aee7bb18629eee7df74.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/ecabfde837ccfb392ccca235f96bfcf4bb8ab186.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@689d0e55...ecabfde8](https://github.com/nmattia/niv/compare/689d0e5539eddd0b0f566aee7bb18629eee7df74...ecabfde837ccfb392ccca235f96bfcf4bb8ab186)

* [`d13000fc`](https://github.com/nmattia/niv/commit/d13000fcea6fd63c6ec15ec1104137053b2b4fc4) fix: Bump cachix install action
* [`40482f05`](https://github.com/nmattia/niv/commit/40482f05b527a250e02e00e31f45b03763a8d878) feat: Configure Dependabot for GitHub Actions
* [`320689d7`](https://github.com/nmattia/niv/commit/320689d737d2c3dc325af1e5942ade5443e3206a) Bump cachix/cachix-action from 10 to 12
* [`de5a4e7d`](https://github.com/nmattia/niv/commit/de5a4e7d0184b6a852a6f23917d6f57b9622e796) Update devshell ([nmattia/niv⁠#367](https://togithub.com/nmattia/niv/issues/367))
* [`f275964b`](https://github.com/nmattia/niv/commit/f275964bb0ffae1ddaddd53ec19dfceef9cc90ba) refactor: statix recommendations ([nmattia/niv⁠#363](https://togithub.com/nmattia/niv/issues/363))
* [`ecabfde8`](https://github.com/nmattia/niv/commit/ecabfde837ccfb392ccca235f96bfcf4bb8ab186) Release 0.2.22
