### PR TITLE
niv nixpkgs: update 4b1a1efe -> fc8a1965

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4b1a1efe99a7a8206544c0caae77eee43bb8db57",
-        "sha256": "0sbpacfi7z7gvp381irdvw50yv2d6w6x3af09p853y6qvnl4k10j",
+        "rev": "fc8a1965d0aefd9d329adc6f4b6ac7e613d3b4cc",
+        "sha256": "1kd5g5lq3z5w7a9vd02vixach3qxjr8zvc2nd3vkm08anxwbc9c8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4b1a1efe99a7a8206544c0caae77eee43bb8db57.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/fc8a1965d0aefd9d329adc6f4b6ac7e613d3b4cc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4b1a1efe...fc8a1965](https://github.com/nixos/nixpkgs/compare/4b1a1efe99a7a8206544c0caae77eee43bb8db57...fc8a1965d0aefd9d329adc6f4b6ac7e613d3b4cc)

* [`e9ad0246`](https://github.com/NixOS/nixpkgs/commit/e9ad02461516d74b3e53c5fde55bd41f104dcad5) xen: move patches specific for 4.10
* [`2f40c464`](https://github.com/NixOS/nixpkgs/commit/2f40c4647b1bf46abded4136075ea47533906fcb) xen: upgrade to 4.15
* [`9591c917`](https://github.com/NixOS/nixpkgs/commit/9591c9170fd20966e6a5e6f108bc4d4f19fcd25d) xen: bump to 4.15.1
* [`93437909`](https://github.com/NixOS/nixpkgs/commit/93437909af24b6728e447ffbeaef7923f8814f3c) xen: patch 4.15 with XSA-386
* [`e6845699`](https://github.com/NixOS/nixpkgs/commit/e6845699549ef8474acb1361e8d2001e08442ead) libsForQt5.drumstick: 2.6.1 -> 2.7.0
* [`f82ceb1c`](https://github.com/NixOS/nixpkgs/commit/f82ceb1c489cf552e668e5a6411ae60a4a475fd6) python310Packages.dvc-http: init at 0.0.1
* [`64e5fe65`](https://github.com/NixOS/nixpkgs/commit/64e5fe651197f6c6f5fe9b8f40edd40b55dc1726) units: 2.21 -> 2.22
* [`60d6bd3f`](https://github.com/NixOS/nixpkgs/commit/60d6bd3fb3fa50a4048606dce36dd48a7bbe6664) bobcat: 5.10.01 -> 5.11.01
* [`b34a1d28`](https://github.com/NixOS/nixpkgs/commit/b34a1d28a4b8fd549e6236614bba8df491afa2e3) xsimd: 8.1.0 -> 9.0.1
* [`1a07eaa6`](https://github.com/NixOS/nixpkgs/commit/1a07eaa6dd7116dd9043f2e40317cb418fc7f3ac) llhttp: init at 8.1.0
* [`657ab5d8`](https://github.com/NixOS/nixpkgs/commit/657ab5d835d92453ebb5a935cd2c434e950b1846) libharu: 2.4.0 -> 2.4.3
* [`e497acaa`](https://github.com/NixOS/nixpkgs/commit/e497acaac7ddcb8db1f7d3feb3d4dabea680cc3a) zap: 2.11.1 -> 2.12.0
* [`13c2eb0e`](https://github.com/NixOS/nixpkgs/commit/13c2eb0eb334b300358aca2b75021e8ad066e992) xpra: Also add module paths to xorg-uinput.conf
* [`48f5a242`](https://github.com/NixOS/nixpkgs/commit/48f5a242db0fc36e76ce8cca130ca00b281641e2) fop: 2.7 -> 2.8
* [`99190a6e`](https://github.com/NixOS/nixpkgs/commit/99190a6e3e56e039babc7fae5f3878a4056d9920) nrfutil: 6.1.6 -> 6.1.7
* [`150a5d7e`](https://github.com/NixOS/nixpkgs/commit/150a5d7e6498483f81a98b76268b417d01920bca) libupnp: 1.14.14 -> 1.14.15
* [`853dd62b`](https://github.com/NixOS/nixpkgs/commit/853dd62b67236bcf194943e3c1b6892ea81421a5) libusb-compat-0_1: 0.1.7 -> 0.1.8
* [`4e2b7d7a`](https://github.com/NixOS/nixpkgs/commit/4e2b7d7a929ffa4a63328a71853dabd99ed403ca) qMasterPassword: back to qt5, qtstyleplugins missing in qt6
* [`1861ae19`](https://github.com/NixOS/nixpkgs/commit/1861ae19f5a0b34747ed19cbf683fd22a4db7558) bootstrap-studio: 6.0.1 -> 6.2.1
* [`efc80cec`](https://github.com/NixOS/nixpkgs/commit/efc80cecf649c04c06e912a08b12fb4f5ffaafc0) sumo: 1.9.2 -> 1.15.0
* [`3e445521`](https://github.com/NixOS/nixpkgs/commit/3e445521a75baa90829c7098a72e65bc7bd59c89) librepo: 1.14.5 -> 1.15.1
* [`ae55ff52`](https://github.com/NixOS/nixpkgs/commit/ae55ff528d90d4e66e0176afdd333f577b18add9) pcl: 1.12.0 -> 1.13.0
* [`1659f599`](https://github.com/NixOS/nixpkgs/commit/1659f599a38978506bb6006d155f6244c331b6e1) grml-zsh-config: 0.19.4 -> 0.19.5
* [`aee15b98`](https://github.com/NixOS/nixpkgs/commit/aee15b985a87f9385fc0dc7c1623780743e94721) libsForQt5.libqglviewer: 2.7.2 -> 2.8.0
* [`e7ece6ee`](https://github.com/NixOS/nixpkgs/commit/e7ece6eeddcc00aeb4acb3c89177d2c4f45b4a20) irccloud: 0.13.0 -> 0.16.0
* [`1f9b92b0`](https://github.com/NixOS/nixpkgs/commit/1f9b92b0e6f2dd073f1863d95fd6587448415214) fetchdarcs: fetch by commit hash
* [`67253945`](https://github.com/NixOS/nixpkgs/commit/67253945376ed8ac3dc166c5b3c469cd53deb4e9) maintainers: add cbleslie
* [`a8cfa9b5`](https://github.com/NixOS/nixpkgs/commit/a8cfa9b5a306f7ad0d1df1bed9a649530f6c78e8) monitorcontrol: init at 4.1.0
* [`d8b19108`](https://github.com/NixOS/nixpkgs/commit/d8b19108efad3992384606dd9afda5cadf195ea1) goku: 0.5.2 -> 0.6.0, fix deps, add aarch64
* [`1e620a4f`](https://github.com/NixOS/nixpkgs/commit/1e620a4f156227214d3b79d81c227187552a47e5) pynitrokey: 0.4.27 -> 0.4.30
* [`42548cff`](https://github.com/NixOS/nixpkgs/commit/42548cff3af1bbf231a906b2adb73b0226184a6a) python3Packages.tlv8: init at 0.10.0
* [`73d013b6`](https://github.com/NixOS/nixpkgs/commit/73d013b64e390b0b87629d6fb2d960ad795d0910) pynitrokey: 0.4.30 -> 0.4.31
* [`e7fd8488`](https://github.com/NixOS/nixpkgs/commit/e7fd84881224e0ff6c8f1b5d8b5bc99cc4a57ba1) pynitrokey: relax dep on spsdk
* [`0bc74963`](https://github.com/NixOS/nixpkgs/commit/0bc74963f09dc60aefb151d539402dcf5d2833b0) zoneminder: 1.36.28 -> 1.36.32
* [`4c64355f`](https://github.com/NixOS/nixpkgs/commit/4c64355fa3f48800ec36ef0b8c41dd5bcb895d6e) nixos/zoneminder: also run zmupdate "freshen" on start
* [`8093c136`](https://github.com/NixOS/nixpkgs/commit/8093c136a2fadb81a6bc629a33827ed4c39ed55e) nixos/zoneminder: requires `sysvsem` PHP extension
* [`86b48684`](https://github.com/NixOS/nixpkgs/commit/86b48684bb028e551bf6c876d0a0668532ea2f4f) nixos/zoneminder: automatically update Nix store path in config DB
* [`06166c8c`](https://github.com/NixOS/nixpkgs/commit/06166c8c7036fc2df964acd53c60fe0e3b8bcbb6) python3Packages.json-stream-rs-tokenizer: init at 0.4.13
* [`195600bc`](https://github.com/NixOS/nixpkgs/commit/195600bc7e7af3d62867f4729a67271d52148b5c) python3Packages.json-stream: 1.5.1 -> 2.1.1
* [`856ed630`](https://github.com/NixOS/nixpkgs/commit/856ed630b0331f5472d0558fa56cfc0420c6e75f) mercury: 22.01.3 -> 22.01.5
* [`ab1399db`](https://github.com/NixOS/nixpkgs/commit/ab1399db21cdcb56a0257bdfb451aeabbe2caa77) hydrus: 503 -> 504
* [`87e5f355`](https://github.com/NixOS/nixpkgs/commit/87e5f355234f2e10ebaa70af702a39647236d52a) hydrus: 504 -> 505b
* [`c31a31f1`](https://github.com/NixOS/nixpkgs/commit/c31a31f1692221013f6b7f831fa9c0c62ce228dd) hydrus: 505b -> 507
* [`bcdf1ccf`](https://github.com/NixOS/nixpkgs/commit/bcdf1ccfdd8637c9cee38bc32bbe7f3ecb899580) hydrus: 507 -> 508
* [`1a266392`](https://github.com/NixOS/nixpkgs/commit/1a266392410e45427df3a36dd85ce594e3d41fe0) hydrus: 508 -> 509
* [`2b08598b`](https://github.com/NixOS/nixpkgs/commit/2b08598b4a8ef3efdba405daee9e77a8a6c2d20a) pyqt6-charts: init at 6.4.0
* [`b94f337e`](https://github.com/NixOS/nixpkgs/commit/b94f337eee200767632ccfd264a83e6262d8f74f) hydrus: switch to qt6
* [`b0e228f8`](https://github.com/NixOS/nixpkgs/commit/b0e228f88dac5011a7eeb11f6f48d6c402b2d4bf) hydrus: 509 -> 510
* [`c29a4f91`](https://github.com/NixOS/nixpkgs/commit/c29a4f91d8b88fc0d9deb6028a67e739878aca55) hydrus: 510 -> 510a
* [`ef84d20b`](https://github.com/NixOS/nixpkgs/commit/ef84d20b3199552c4bbac62f4cb71b9bfe5fc61c) hydrus: 510a -> 511
* [`aa0b988d`](https://github.com/NixOS/nixpkgs/commit/aa0b988d7b08d7c2037040a08ab7fc33593ca416) hydrus: 511 -> 512
* [`f68e795c`](https://github.com/NixOS/nixpkgs/commit/f68e795cd5fc3dc1da7b3700ae6e513353eef455) hydrus: 512 -> 513
* [`e31dea3d`](https://github.com/NixOS/nixpkgs/commit/e31dea3d14e72a445db2c9b22f4ea005c36a5c85) python3Packages.parsimonious: disable benchmark tests that may fail
* [`143b5ed9`](https://github.com/NixOS/nixpkgs/commit/143b5ed9e0222eb92ec6d6b0f0025b6ada819775) zap: update version tag
* [`c29c5fee`](https://github.com/NixOS/nixpkgs/commit/c29c5fee10daeee8b37ee7d225dfeb8c6d33bf9d) libcerf: 2.1 -> 2.3
* [`b2b74c29`](https://github.com/NixOS/nixpkgs/commit/b2b74c29b62ba2c4d75f1992c1c904f36a2acf8b) suitesparse-graphblas: 7.2.0 -> 7.4.3
* [`7ffa701d`](https://github.com/NixOS/nixpkgs/commit/7ffa701d74f047b8a1dab6d1e7c39e714c9e1013) kernel: enable Terminus 16x32 font
* [`5bb65387`](https://github.com/NixOS/nixpkgs/commit/5bb65387bf4c33753c972371cf32e625ce450c47) console: support using in-kernel fonts
* [`3d453e2a`](https://github.com/NixOS/nixpkgs/commit/3d453e2aee3dc01b4c5cd95d99f94969aa80bd85) mkDerivation: add support for fortify3 hardening flag
* [`00aadf0b`](https://github.com/NixOS/nixpkgs/commit/00aadf0bf7013c4597156c3cd2dc10919f71ab2b) cc-wrapper: add support for fortify3 flag
* [`74ea4fe2`](https://github.com/NixOS/nixpkgs/commit/74ea4fe24fb8fe40732ca4f16a70de36ba01ff61) llvm*Packages.clang: mark hardeningUnsupportedFlags fortify3
* [`c09e1fa4`](https://github.com/NixOS/nixpkgs/commit/c09e1fa406f95abff9d6eab173629c61806bb661) gcc: mark hardeningUnsupportedFlags fortify3 for all but gcc 12
* [`63602988`](https://github.com/NixOS/nixpkgs/commit/636029883ad0a8cd89489cd40447e1d4096ab137) acl: disable fortify3 hardening
* [`4e49c5d2`](https://github.com/NixOS/nixpkgs/commit/4e49c5d2e3550e072a34aa2c761cb7beb82e1309) libffi: disable fortify3 hardening for tests
* [`e74c9e54`](https://github.com/NixOS/nixpkgs/commit/e74c9e5466c21e5848c6fd1cdefce936a5f9147b) hydrus: 513 -> 514
* [`f42366f7`](https://github.com/NixOS/nixpkgs/commit/f42366f7e82c8fa79b70f065733ff000c327cc8c) cotp: fix pname
* [`527f549d`](https://github.com/NixOS/nixpkgs/commit/527f549d60dc0c97800fc6474535bbb92b7b5088) xvfb-run: fix pname
* [`09520659`](https://github.com/NixOS/nixpkgs/commit/095206590818caaf72f8b462d865145045108c28) ocs-url: fix pname
* [`fb510e23`](https://github.com/NixOS/nixpkgs/commit/fb510e23129b279bda38cbadc4a0fde5672a0e55) blesh: fix pname
* [`2e600361`](https://github.com/NixOS/nixpkgs/commit/2e600361c1488c5999bda22b7edd4bf7244eea7b) apparmor-parser: fix pname
* [`92aa3caf`](https://github.com/NixOS/nixpkgs/commit/92aa3caf581ebc19fc8020a012cad2536a5baa8c) dxvk: fix pname
* [`c9cb4eb6`](https://github.com/NixOS/nixpkgs/commit/c9cb4eb6cae8e973ee668660ca986668371400ab) darkplaces: fix pname
* [`9e099726`](https://github.com/NixOS/nixpkgs/commit/9e099726e00386e59af8ad20df97b022ed582652) ta-lib: fix pname
* [`c1872396`](https://github.com/NixOS/nixpkgs/commit/c1872396f770c72c78a8766a564d4a00e4d64490) asmjit: fix pname
* [`b75f89de`](https://github.com/NixOS/nixpkgs/commit/b75f89de9430f096038bb14dfb9b49531dc19da2) readstat: fix pname
* [`6aae8e96`](https://github.com/NixOS/nixpkgs/commit/6aae8e96f8e7dcab196b8eccc39b83049ec92577) veryfasttree: fix pname
* [`e5c51680`](https://github.com/NixOS/nixpkgs/commit/e5c51680fdc2d9f877089b5c226ff158c4e5a77d) muscle: fix pname
* [`d4f0fe78`](https://github.com/NixOS/nixpkgs/commit/d4f0fe781124efb4b4d1ee91c06d765732ca7e2a) cloudlog: fix pname
* [`0ecbbd6e`](https://github.com/NixOS/nixpkgs/commit/0ecbbd6e5fd355c67b569dd56fc767b6e49d5802) cinny-desktop: fix pname
* [`c5221592`](https://github.com/NixOS/nixpkgs/commit/c522159213f7b975f294bd1fd3e935d972a97fd4) xmage: fix pname
* [`e64eb996`](https://github.com/NixOS/nixpkgs/commit/e64eb9960835da6f07eba9c1b344eda2125d5d42) vmm_clock: fix pname
* [`56c23687`](https://github.com/NixOS/nixpkgs/commit/56c23687eb7d3033ab848edc04d5dd9c52f6397d) siji: fix pname
* [`9a2a7ac4`](https://github.com/NixOS/nixpkgs/commit/9a2a7ac4da2af8b13259051f923ae762ee12932f) gossa: fix pname
* [`b615db99`](https://github.com/NixOS/nixpkgs/commit/b615db994bc714ceac6f3a3b48beacd8c015d7e4) freetds: 1.3.13 -> 1.3.17
* [`86f398df`](https://github.com/NixOS/nixpkgs/commit/86f398dfc4cf3a10f9c1c6aec67c20318cc7fb19) gdb: add system-wide configuration file
* [`b90cf061`](https://github.com/NixOS/nixpkgs/commit/b90cf0612e5963849d0dfe22e95debe834e9abde) nixos/atop: Remove upgraded logfiles if not replaced
* [`95c17b8e`](https://github.com/NixOS/nixpkgs/commit/95c17b8e72da5b9b668a6fa69cc6ee73151b8d8d) lout: 3.40 -> 3.42.2
* [`71206995`](https://github.com/NixOS/nixpkgs/commit/712069957d45cf87adb8184eb24dc8683e5084d5) python310Packages.email-validator: 1.3.0 -> 1.3.1
* [`218c7795`](https://github.com/NixOS/nixpkgs/commit/218c7795a669d577fc3ae79a571135e5f105793a) nixos/cgit: init
* [`45f06d97`](https://github.com/NixOS/nixpkgs/commit/45f06d9712bdd6ee8084065bbd0776d73982fd6e) nixos/cgit: add package option
* [`c09aa819`](https://github.com/NixOS/nixpkgs/commit/c09aa81965a6136f92a766ddf27a6684116350dc) jitsi-meet: 1.0.6644 -> 1.0.6943
* [`49874499`](https://github.com/NixOS/nixpkgs/commit/498744997a4fed7d386748cce7a2481d7c315d83) jitsi-meet-prosody: 1.0.6644 -> 1.0.6943
* [`06cfa144`](https://github.com/NixOS/nixpkgs/commit/06cfa144ce66c4029cb5991ecb7c9c08b545d01a) jicofo: 1.0-940 -> 1.0-987
* [`c57f9faa`](https://github.com/NixOS/nixpkgs/commit/c57f9faa2230c9f14eabf4a4fd61c60d4bf7a21f) jitsi-videobridge: 2.2-45-ge8b20f06 -> 2.2-69-gad606ca2
* [`9b061691`](https://github.com/NixOS/nixpkgs/commit/9b0616911d37ebffa572239b4305542aef766e45) jibri: 8.0-139-g7ab9aa2 -> 8.0-140-gccc7278
* [`adc59137`](https://github.com/NixOS/nixpkgs/commit/adc59137e9faaa25682767585dcc3b6eb28a0e71) nixos/jicofo: fix after update
* [`72e0ac1b`](https://github.com/NixOS/nixpkgs/commit/72e0ac1bb86f3d31be4337fbd5595d5d490a9160) ocamlPackages.findlib: explain how to bypass the dep conflict detection
* [`62957815`](https://github.com/NixOS/nixpkgs/commit/62957815336742f13840d936e5d37859912fd962) hydrus: 514 -> 515
* [`8ffa817b`](https://github.com/NixOS/nixpkgs/commit/8ffa817b6cb9966c9d8bfa7849dcf38e8910466c) libpipeline: 1.5.6 -> 1.5.7
* [`db79c7af`](https://github.com/NixOS/nixpkgs/commit/db79c7af37355976c059868e21c3237c35ab2a5e) srtp: 2.4.2 -> 2.5.0
* [`72cfabf2`](https://github.com/NixOS/nixpkgs/commit/72cfabf2222ed982db3c24b70aec750861561f50) mononoki: 1.3 -> 1.5
* [`3e152ec7`](https://github.com/NixOS/nixpkgs/commit/3e152ec76d105dbdbea4ab410b900154c353139c) fwts: 22.09.00 -> 23.01.00
* [`fdca54f1`](https://github.com/NixOS/nixpkgs/commit/fdca54f1a1b2db72f4e8730be95ed1ffcfb0b489) e2fsprogs: 1.46.5 -> 1.46.6
* [`a000076d`](https://github.com/NixOS/nixpkgs/commit/a000076d5817163ffb320b2531875c3a92b18677) texlive.combine: split static $TEXMFDIST into a separate derivation
* [`04313e12`](https://github.com/NixOS/nixpkgs/commit/04313e1238f0f0ccb8887fada8634a6f05cda845) masterpdfeditor: 5.8.70 -> 5.9.35
* [`988184ca`](https://github.com/NixOS/nixpkgs/commit/988184ca82a083eae130cc49e7240682fb0962e0) systemd-stage-1: managerEnvironment option
* [`1b394913`](https://github.com/NixOS/nixpkgs/commit/1b394913269a0b1086ebae1c0f30c3fa932a3ebb) systemd-stage-1: Use `x-initrd.mount` for better unit dependencies
* [`a0ba973e`](https://github.com/NixOS/nixpkgs/commit/a0ba973e1358333fdc9e05225fe5b3c31585804a) qemu-vm: Simplfiy systemd-initrd /nix/store mount units
* [`14b77582`](https://github.com/NixOS/nixpkgs/commit/14b77582da466c5d064db11ce7dbe67b8506362b) systemd-stage-1: fsck
* [`a0a0ce54`](https://github.com/NixOS/nixpkgs/commit/a0a0ce54a0e77e39c7dae987683cd7aef10d5549) hydrus: 515 -> 516
* [`82a0533e`](https://github.com/NixOS/nixpkgs/commit/82a0533e0a682a54a6dc973e2f5d5ace187de470) man-db: 2.11.1 -> 2.11.2
* [`4d036bf0`](https://github.com/NixOS/nixpkgs/commit/4d036bf0fc0b0033f2b7f380e0b6b3d93d8eeeda) gsm: 1.0.20 -> 1.0.22
* [`bf8f325a`](https://github.com/NixOS/nixpkgs/commit/bf8f325a11274c6076efe44c918408130cf5a88f) cracklib: 2.9.7 -> 2.9.8
* [`8f1c823a`](https://github.com/NixOS/nixpkgs/commit/8f1c823ab0c4662867144be8a0b7e80665789218) nixos/hbase: add thrift and rest servers
* [`1035e521`](https://github.com/NixOS/nixpkgs/commit/1035e52191efcc629ff676d1d8db20879b4ce629) hbase: 2.5.1 -> 2.5.3, 2.4.15 -> 2.4.16
* [`08e194a9`](https://github.com/NixOS/nixpkgs/commit/08e194a913109b421574adb53b3dd26238aa684d) xorg.libXxf86vm: 1.1.4 -> 1.1.5
* [`624b1ee5`](https://github.com/NixOS/nixpkgs/commit/624b1ee5605cecfc4fd47bb375861be9102802f7) serd: 0.30.10 -> 0.30.16
* [`487e2955`](https://github.com/NixOS/nixpkgs/commit/487e2955f8d0540d4230ba1a740d705d25a577c3) dumpnar: init at unstable-2023-01-01
* [`c3693fbf`](https://github.com/NixOS/nixpkgs/commit/c3693fbfd5a3f17db8be11cd3dba80481e7813c7) stdenvBootstrapTools: native aarch64-darwin build
* [`47cfb7f0`](https://github.com/NixOS/nixpkgs/commit/47cfb7f0906f3cb877aa9a9c348ca8709deec141) nut: 2.7.4 -> 2.8.0
* [`1c128e7c`](https://github.com/NixOS/nixpkgs/commit/1c128e7c73ab8bbf36561db244a73bb5a4534300) maintainers: add Zaechus
* [`e56053b3`](https://github.com/NixOS/nixpkgs/commit/e56053b343ebda445f863d2658e5980475971d8e) libunistring: 1.0 -> 1.1
* [`06184acf`](https://github.com/NixOS/nixpkgs/commit/06184acf6cabcf3010eac651620b312b5cc22ef4) xorg.xkbcomp: 1.4.5 -> 1.4.6
* [`21ec9064`](https://github.com/NixOS/nixpkgs/commit/21ec906463ea8f11abf3f9091ddd4c3276516e58) stdenv: aarch64-linux: gcc9 -> gcc12
* [`c70c3560`](https://github.com/NixOS/nixpkgs/commit/c70c35601a4396959bbef428dfcb703555f5a4ea) graphviz: 7.0.2 -> 7.1.0
* [`7c026bae`](https://github.com/NixOS/nixpkgs/commit/7c026bae62d29600b42359b370b620602e8c498e) stdenv: aarch64-linux: update the bootstrap tools (incl. busybox)
* [`0e50c09c`](https://github.com/NixOS/nixpkgs/commit/0e50c09cf4e572985022bf17a0305a197001fdaf) texinfo: Add version 7.0.2
* [`9aace434`](https://github.com/NixOS/nixpkgs/commit/9aace434084bb67d7adcbb0fc0919f0ed84b777e) texinfo: 6.8 -> 7.0.2
* [`1a2c2846`](https://github.com/NixOS/nixpkgs/commit/1a2c2846b0933b596c51e964acb8a45ab9a13691) lib.path.subpath.join: init
* [`d707691b`](https://github.com/NixOS/nixpkgs/commit/d707691b3574998bcd10028c1419ca6695e8713d) strip-nondeterminism: fix binary functioning on darwin
* [`4c13a04c`](https://github.com/NixOS/nixpkgs/commit/4c13a04cb2797fadf1984245df82d2ecc7eabb0d) libaom: 3.5.0 -> 3.6.0
* [`9d3bdfb8`](https://github.com/NixOS/nixpkgs/commit/9d3bdfb885dd04a449f27af0c74ec067dd99f8ff) freetype: 2.12.1 -> 2.13.0
* [`2c102088`](https://github.com/NixOS/nixpkgs/commit/2c102088fad9ff37acde22db4807240b93a05689) cryptsetup: 2.5.0 -> 2.6.1
* [`a5ea08f7`](https://github.com/NixOS/nixpkgs/commit/a5ea08f7f44ea7d288dcfa4941ff9f02e417a93f) openldap: 2.6.3 -> 2.6.4
* [`85b60c38`](https://github.com/NixOS/nixpkgs/commit/85b60c3849964ae43dc7a8819af1277097ae39f6) openldap: add passthru.tests
* [`3df3c930`](https://github.com/NixOS/nixpkgs/commit/3df3c930379d26b4c30493a3f4abab8e9d381155) nixosTests.openldap: fix deprecation warning
* [`3697ddea`](https://github.com/NixOS/nixpkgs/commit/3697ddeabe2c51a868a2b1d1f2626f7778d673b4) bintools-wrapper: wrap all 'ld.*'
* [`2f29e322`](https://github.com/NixOS/nixpkgs/commit/2f29e3223bc3bb6cc495565a22d06b3f40d98aca) hydrus: 516 -> 517
* [`4e3cf3e4`](https://github.com/NixOS/nixpkgs/commit/4e3cf3e4911a3edc1448184948a8632c035accf7) opencl-headers: 2022.09.30 -> 2023.02.06
* [`37fe1613`](https://github.com/NixOS/nixpkgs/commit/37fe1613cfd9bb3e7031d60b1b7316fee090b00e) gcc: expose --disable-bootstrap as disableBootstrap
* [`4a5f5d4f`](https://github.com/NixOS/nixpkgs/commit/4a5f5d4f97e923f87a3f22b90c5901505e89621a) libdrm: 2.4.114 -> 2.4.115
* [`152a7214`](https://github.com/NixOS/nixpkgs/commit/152a7214680c1c96bb4317a046179617be6c2fc1) gpgme: update patch to support Python 3.11
* [`731053d8`](https://github.com/NixOS/nixpkgs/commit/731053d8aa1624475779065ef17294c54af072e4) services.cachix-watch-store: fix description of compressionLevel
* [`b5abc3d0`](https://github.com/NixOS/nixpkgs/commit/b5abc3d0907c7c5d70479c60ff7f1cf262ead4c8) bintools-wrapper: dont wrap ld if it doesn't exist
* [`4d523d93`](https://github.com/NixOS/nixpkgs/commit/4d523d937d27933e64c4d8b475debcd096c15500) publicsuffix-list: unstable-2021-09-03 -> unstable-2023-02-16
* [`299a7bd3`](https://github.com/NixOS/nixpkgs/commit/299a7bd35e552fe6e444096658d7e9ebafb038af) stdenvAdapters: add useMoldLinker
* [`8c1ab28a`](https://github.com/NixOS/nixpkgs/commit/8c1ab28a62bd18660da2c1650779e315b7858242) xterm: 378 -> 379
* [`1443e640`](https://github.com/NixOS/nixpkgs/commit/1443e64050751ef9f47c15e75bc43d4e609a157b) plex-mpv-shim: 1.10.3 -> 1.11.0
* [`cadffcfe`](https://github.com/NixOS/nixpkgs/commit/cadffcfe5053c1cc73f2a56e12bd41b762b5b653) treewide: remove issue [nixos/nixpkgs⁠#56943](https://togithub.com/nixos/nixpkgs/issues/56943) workarounds
* [`7242c23f`](https://github.com/NixOS/nixpkgs/commit/7242c23f1207a074f87b966406da42ee439cb562) dogtail: remove issue 56943 workaround
* [`ab3ba31f`](https://github.com/NixOS/nixpkgs/commit/ab3ba31f1c9b3aff23b01e509335fd4042980196) curtail: dont propagate unnecessary packages
* [`c10b1e44`](https://github.com/NixOS/nixpkgs/commit/c10b1e44b815247204f8c7d59ce2f7becdcc41d6) touchosc: make updateScript more readable and robust
* [`c4e7fb10`](https://github.com/NixOS/nixpkgs/commit/c4e7fb103648a624ba4a55b0d3633585941e90fb) wrapGAppsHook: move dconf.lib to depsTargetTargetPropagated
* [`21686116`](https://github.com/NixOS/nixpkgs/commit/2168611677275aa5cfbf334fc0392e6a540986e6) wrapGAppsHook: run tests with strictDeps
* [`2c471e64`](https://github.com/NixOS/nixpkgs/commit/2c471e647963e8bf50934580fe38c5ea176c6b34) wrapGAppsHook: add gtk3 to depsTargetTargetPropagated
* [`792907e3`](https://github.com/NixOS/nixpkgs/commit/792907e3bf429784a42ca57805025f2737c98eed) patch-shebangs: handle env -S shebangs
* [`8876a5c9`](https://github.com/NixOS/nixpkgs/commit/8876a5c91faf35e37e08d647dd6e9ea9d4a4f79f) tests.stdenv: move patch-shebangs test
* [`883daacb`](https://github.com/NixOS/nixpkgs/commit/883daacbaaabbf826bffe9a414b06e1d935e3133) tests.stdenv: add hooks.patch-shebangs.split-string & tweak tests
* [`fa65b293`](https://github.com/NixOS/nixpkgs/commit/fa65b293a90390e25b7f4d94bbaf9d410140c9ee) cmake: 3.25.1 -> 3.25.2
* [`7637168d`](https://github.com/NixOS/nixpkgs/commit/7637168dd21b4ab0c64499ea20065b532ba11858) librsvg: withIntrospection when stdenv.hostPlatform.emulatorAvailable buildPackages
* [`d5b6b623`](https://github.com/NixOS/nixpkgs/commit/d5b6b6232c368279a48e8b6907a637b652d378ba) librsvg: create loaders.cache even when cross-compiling
* [`f488b617`](https://github.com/NixOS/nixpkgs/commit/f488b617ab41daaaa6bcae761a4fa92536d69a0e) setup-hooks/reproducible-builds.sh: NIX_OUTPATH_USED_AS_RANDOM_SEED (take 2) ([nixos/nixpkgs⁠#216967](https://togithub.com/nixos/nixpkgs/issues/216967))
* [`c83dc8d0`](https://github.com/NixOS/nixpkgs/commit/c83dc8d0505452818fb2913b0e7d469995b08223) ffmpeg: fix RUNPATH patching
* [`52378085`](https://github.com/NixOS/nixpkgs/commit/52378085d9ee93e5d9fb5e127d38e2bfdf8cabe7) ell: 0.55 -> 0.56
* [`6bd5976d`](https://github.com/NixOS/nixpkgs/commit/6bd5976d81ef0ae1e84fbf8fa6b999e964ea752a) iwd: 2.1 -> 2.3
* [`eb813a62`](https://github.com/NixOS/nixpkgs/commit/eb813a6203f9db174701b6026b2ad26094356e7d) python310Packages.apscheduler: Normalize attribute, pname and location
* [`7a2ddfb3`](https://github.com/NixOS/nixpkgs/commit/7a2ddfb354d1139ecebeb3517066cba1b7cc7a13) python310Packages.btrees: Normalize attribute name
* [`34ff0bd1`](https://github.com/NixOS/nixpkgs/commit/34ff0bd1b5da368ef0e0c2ff27f6066d1400810a) python310Packages.blinkstick: Normalize attribute name and pname
* [`0b0d92d8`](https://github.com/NixOS/nixpkgs/commit/0b0d92d893f36b96bee8097c72cc73291a5ea3a4) python310Packages.colanderalchemy: Normalize attribute and pname
* [`225dbad5`](https://github.com/NixOS/nixpkgs/commit/225dbad50b68f42853fc53510d78d3fa7e335269) python310Packages.commonmark: Normalize attribute name
* [`6325bb10`](https://github.com/NixOS/nixpkgs/commit/6325bb1019899b05968545b81d5ef73c778239cf) python310Packages.easyprocess: Normalize attribute and pname
* [`80192e20`](https://github.com/NixOS/nixpkgs/commit/80192e201a719247b78b27a8641b6567d7ba6d67) python310Packages.fabric: Normalize attribute name and dirname
* [`985f6384`](https://github.com/NixOS/nixpkgs/commit/985f638488d0a9490f4d4c1f63755e9b0ccf262d) python310Packages.formencode: Normalize attribute, pname and dirname
* [`b03e5a85`](https://github.com/NixOS/nixpkgs/commit/b03e5a85b238ee793bbdb1b12b854b6c6e6c96ba) python310Packages.geoip: Normalize attribute, pname, dirname
* [`2489cd9c`](https://github.com/NixOS/nixpkgs/commit/2489cd9c266849a72c42dc0a6fd1a751d647ff0b) python310Packages.htseq: Normalize attribute, pname, dirname
* [`5b1bb7e4`](https://github.com/NixOS/nixpkgs/commit/5b1bb7e42ac0746c277661f04096917693676d3f) python310Packages.jpype1: Normalize attribute, pname, dirname
* [`ee9b576f`](https://github.com/NixOS/nixpkgs/commit/ee9b576f25a6837683408fc7d6b0e085b5f69527) python310Packages.jaydebapi: Normalize attribute, pname, dirname
* [`acfd6f77`](https://github.com/NixOS/nixpkgs/commit/acfd6f7704fd75fff41446bc6dacd44d0956e7c4) python310Packages.kajiki: Normalize attribute name
* [`52d58e50`](https://github.com/NixOS/nixpkgs/commit/52d58e509a21785fee8079458eee08989ff5cfaf) python310Packages.logbook: Normalize attribute, pname, dirname
* [`0981423e`](https://github.com/NixOS/nixpkgs/commit/0981423ea1a6991121d004a74bca498df78ec062) python310Packages.mdp: Normalize attribute and pname
* [`9e7f9a40`](https://github.com/NixOS/nixpkgs/commit/9e7f9a402b3176d2a866b883f64878d196690792) python310Packages.mako: Normalize attribute, pname, dirname
* [`02c76246`](https://github.com/NixOS/nixpkgs/commit/02c7624618302b6a1f01454df14c1a866e8854be) python310Packages.nikola: Normalize attribute, pname, dirname
* [`743ad736`](https://github.com/NixOS/nixpkgs/commit/743ad736bb1ee87cfce2efd8b53af2be1360c117) python310Packages.nuitka: Normalize attribute & pname
* [`d1fb8a30`](https://github.com/NixOS/nixpkgs/commit/d1fb8a3019bdc7f1473f7aa06256e71215aecbf8) python310Packages.pmw: Normalize attribute, pname, dirname
* [`8a20c5e4`](https://github.com/NixOS/nixpkgs/commit/8a20c5e473af5bc8dbcceef3c044cdfbac69a63d) python310Packages.pweave: Normalize attribute & pname
* [`0deebc3b`](https://github.com/NixOS/nixpkgs/commit/0deebc3b247ec8e789d79815a56d258a3a81a6ab) python310Packages.pychromecast: Normalize attribute name
* [`574ec987`](https://github.com/NixOS/nixpkgs/commit/574ec98796bae02c0e5f1bbd5760c785084aa847) python310Packages.pygithub: Normalize attribute, pname, dirname
* [`0f7b057f`](https://github.com/NixOS/nixpkgs/commit/0f7b057fa35b0c7716a1a8e2752899369fbea1ed) python310Packages.pylti: Normalize attribute and pname
* [`9a18b57a`](https://github.com/NixOS/nixpkgs/commit/9a18b57a3b910a21244769364103ab57384bb1aa) python310Packages.pymvglive: Normalize attribute & pname
* [`5214e64a`](https://github.com/NixOS/nixpkgs/commit/5214e64a288d743c5c2ba84d6c1d10af7fc41d49) python310Packages.pyrss2gen: Normalize attribute & pname
* [`5b8f20d1`](https://github.com/NixOS/nixpkgs/commit/5b8f20d115b064285e85bc0d602b61fede27aba1) python310Packages.pystemmer: Normalize attribute & pname
* [`dd0c18a4`](https://github.com/NixOS/nixpkgs/commit/dd0c18a42475991a47ffa3c57b12febad21b57f3) python310Packages.pyvirtualdisplay: Normalize attribute, pname, dirname
* [`d0f1db1e`](https://github.com/NixOS/nixpkgs/commit/d0f1db1efd4bdd02db1a5508cb2c470be53a7ddb) python310Packages.pyro4: Normalize attribute name
* [`32b2d24d`](https://github.com/NixOS/nixpkgs/commit/32b2d24df44772ca37fb54a88ee12d9e22e49e14) python310Packages.pyro5: Normalize attribute name
* [`4b570085`](https://github.com/NixOS/nixpkgs/commit/4b57008582ae954a2aa784de4f68e5da78fe5a9c) python310Packages.quandl: Normalize attribute name
* [`daf490f1`](https://github.com/NixOS/nixpkgs/commit/daf490f1f9b5abd9ef9fe115e4d11a2b55a2ccbd) python310Packages.rtree: Normalize attribute and dirname
* [`71d6e216`](https://github.com/NixOS/nixpkgs/commit/71d6e2167088c53bcf5f29b09d639ffacf0ddb5c) python310Packages.theano: Normalize attribute, pname, dirname
* [`0347d27a`](https://github.com/NixOS/nixpkgs/commit/0347d27afa4e39511a48ac5b4e5aa91d4f1fa539) python310Packages.wsme: Normalize attribute, pname, dirname
* [`19697a0e`](https://github.com/NixOS/nixpkgs/commit/19697a0e67d76b0b87cf22f8cce4924b95a3b7de) python310Packages.xlsxwriter: Normalize attribute & dirname
* [`1a6bc9db`](https://github.com/NixOS/nixpkgs/commit/1a6bc9db7457d227d7f6d01b2edd0b4b1a198b41) python310Packages.yapsi: Normalize attribute & pname
* [`b70c51b2`](https://github.com/NixOS/nixpkgs/commit/b70c51b21866546f4348acd90ce6d298df8dcb4e) klipper: unstable-2023-02-03 -> unstable-2023-02-20
* [`b6c9118a`](https://github.com/NixOS/nixpkgs/commit/b6c9118a53558b6c141c77c5d0efac5fc595c09e) c-ares: 1.18.1 -> 1.19.0
* [`cdf6a423`](https://github.com/NixOS/nixpkgs/commit/cdf6a4230156ad23e16ce2eedcfd2a328365bdf6) diffutils: 3.8 -> 3.9
* [`6da9d0f3`](https://github.com/NixOS/nixpkgs/commit/6da9d0f34af9212af914ea0685e31952faec24e1) curl: 7.88.0 -> 7.88.1
* [`1475f90a`](https://github.com/NixOS/nixpkgs/commit/1475f90ab220f69cb06e16a33adb1f43de1875e2) libomxil-bellagio: fix stack overred
* [`436b0d9e`](https://github.com/NixOS/nixpkgs/commit/436b0d9e1f3e7dd74fc5f8726f54b35c1c5eb35f) cc-wrapper: fix inverted logic around fortify & fortify3 mutual exclusion
* [`6b6c06e5`](https://github.com/NixOS/nixpkgs/commit/6b6c06e5d725afeb7b6691d0e211b1f5844958a5) cc-wrapper: allow non-clang compilers to use gccForLibs codepath
* [`d7aad245`](https://github.com/NixOS/nixpkgs/commit/d7aad245314ef6b026707bf41c36461d450ef3ab) express [nixos/nixpkgs⁠#208478](https://togithub.com/nixos/nixpkgs/issues/208478) as assertions
* [`c2fc1acc`](https://github.com/NixOS/nixpkgs/commit/c2fc1acc8b1098f84702aa347dd459c469a94dce) python310Packages.cachetools: 5.2.1 -> 5.3.0
* [`37f7e1de`](https://github.com/NixOS/nixpkgs/commit/37f7e1de51413d282d5d083756fe0c1e9fd7faea) python310Packages.requests-cache: add changelog to meta
* [`8cc327ce`](https://github.com/NixOS/nixpkgs/commit/8cc327ce14c42f4216e0128cca29e725c2ace8cb) liblc3: 1.0.1 -> 1.0.2
* [`56ee0e9a`](https://github.com/NixOS/nixpkgs/commit/56ee0e9a090ef7dd50ffe5370793308869056ef0) python310Packages.requests-cache: 0.9.7 -> 0.9.8
* [`594f162c`](https://github.com/NixOS/nixpkgs/commit/594f162cdf97d6445654bacf9753ad3b59e0b82a) horizon-eda: switch from OCE to OCC
* [`7a8df1f0`](https://github.com/NixOS/nixpkgs/commit/7a8df1f02cc73642145e8e831a815c65f7e88dc5) libtiff: add patches for many related CVEs
* [`e7eb16af`](https://github.com/NixOS/nixpkgs/commit/e7eb16af3ebd2ab5557e894f840c61ee49da3448) lvm2: 2.03.18 -> 2.03.19
* [`b1849a18`](https://github.com/NixOS/nixpkgs/commit/b1849a18cf6daa98f0f10860dfd66da2a2f591fb) xdg-utils: patch xdg-open to correctly open files when using portal
* [`09fc9be1`](https://github.com/NixOS/nixpkgs/commit/09fc9be172fc1fee14f8a6c319b67fef7bdc3e5b) gdbgui: 0.15.0.1 -> 0.15.1.0
* [`4454f210`](https://github.com/NixOS/nixpkgs/commit/4454f21034fa1049162ea4f5665a8d95ae668123) cmocka: 1.1.5 -> 1.1.6
* [`1d7d07ca`](https://github.com/NixOS/nixpkgs/commit/1d7d07ca239ab5762edd5d6d7c96f0ed7e429e5d) lvm2: add more tests to passthru
* [`8d3141af`](https://github.com/NixOS/nixpkgs/commit/8d3141afdaf3f7b4f0990e538f9dbb03e10c8782) lvm2-2_02: remove
* [`90904c44`](https://github.com/NixOS/nixpkgs/commit/90904c440eb6b99cc18d073a490d92788ec96ad0) linuxManualConfig: remove obsolete comments
* [`f8116ec6`](https://github.com/NixOS/nixpkgs/commit/f8116ec6b425658abe173cb7119ca882e8ae776b) vala: 0.56.3 → 0.56.4
* [`48c598aa`](https://github.com/NixOS/nixpkgs/commit/48c598aafd370b66e726c743c744cd994b501028) linuxHeaders: 6.1 -> 6.2
* [`59e61093`](https://github.com/NixOS/nixpkgs/commit/59e6109377e101eb3c220f22ec94c781ad1059fc) hydrus: 517 -> 518
* [`24b07fc9`](https://github.com/NixOS/nixpkgs/commit/24b07fc9e5216d8ae22205c2f8c688e2738d8502) gcc/common: add disableGdbPlugin option
* [`852e9c27`](https://github.com/NixOS/nixpkgs/commit/852e9c27818b466d14ebff8f2ae1377bb09cd9e8) mesa: 22.3.5 -> 22.3.6
* [`ab3ec09c`](https://github.com/NixOS/nixpkgs/commit/ab3ec09c66554291363972aa8243ae910b84a17f) gdb: 12.1 -> 13.1
* [`3f08dd7e`](https://github.com/NixOS/nixpkgs/commit/3f08dd7eeed2d0919964ce37891e1dc74824e085) openboardview: 9.0.3 -> 9.95.0
* [`79484b17`](https://github.com/NixOS/nixpkgs/commit/79484b17078c06763dafd4dcaab67aebc129dfd9) bintools: Add response file support to `ld-wrapper` ([nixos/nixpkgs⁠#213831](https://togithub.com/nixos/nixpkgs/issues/213831))
* [`70963ca6`](https://github.com/NixOS/nixpkgs/commit/70963ca667e8e5f526c50c21f6ffab9d9e7142d1) hubstaff: 1.6.7-5c6fee47 -> 1.6.12-da9418f3
* [`86a0e46e`](https://github.com/NixOS/nixpkgs/commit/86a0e46ed4687f9a8ab8e1c38c7f0b926bf77d11) gcc: fix implication order in assertion
* [`a2eeadde`](https://github.com/NixOS/nixpkgs/commit/a2eeaddea212121f336872900635686462e1416a) nixos/nextcloud: support SSE-C for S3 primary storage
* [`4b9857d4`](https://github.com/NixOS/nixpkgs/commit/4b9857d413bf41d8e0036a4bee891621fc505127) calls: 43.2 -> 43.3
* [`2761539c`](https://github.com/NixOS/nixpkgs/commit/2761539c64360f8e05f9c9ed27fa640829c74d83) libsepol: 3.3 -> 3.5
* [`42fcb303`](https://github.com/NixOS/nixpkgs/commit/42fcb30330d5a9cabdc12095a71761ce2c865b32) python310Packages.kiwisolver: fix NIX_CFLAGS_COMPILE definition
* [`b41933a1`](https://github.com/NixOS/nixpkgs/commit/b41933a1be1ea0f9bddad4ef5eed6d0ed61a2510) bintools-wrapper: specify SHA1 as the `build-id` hash style explicitly
* [`d364ee8d`](https://github.com/NixOS/nixpkgs/commit/d364ee8d13c8889aa7a88c5ed87255915af8e45e) mkDerivation: do not disable `separateDebugInfo` on LLVM stdenvs
* [`45e58731`](https://github.com/NixOS/nixpkgs/commit/45e58731b8ad48d4ffc5c0086e98f4ab942efce1) firefox: remove the `separate-debug-info` workaround
* [`07064726`](https://github.com/NixOS/nixpkgs/commit/07064726bfbc5656a215a751e0aa819235f6c4a5) perlPackages.Po4a: enable strictDeps
* [`7f8c7073`](https://github.com/NixOS/nixpkgs/commit/7f8c70731206c8caf3afae3467be24ddd42df3e2) kmod: enable strictDeps
* [`4c506373`](https://github.com/NixOS/nixpkgs/commit/4c5063737ceb521e5d7e460a18054d40d85024b2) python310Packages.pytest-subtests: 0.9.0 -> 0.10.0
* [`3d6fc928`](https://github.com/NixOS/nixpkgs/commit/3d6fc9283518c14d722a1b90c3c4dffd64ef3af7) CuboCore.packages: 4.3.0 -> 4.4.0
* [`d5dc3d17`](https://github.com/NixOS/nixpkgs/commit/d5dc3d17f34094410c0abd9fe814c76463e0b8d2) rustc: re-enable parallel building
* [`eb2eafd2`](https://github.com/NixOS/nixpkgs/commit/eb2eafd2af7d466fb296e5716bdd0ec577de426d) clang_13,clang_14,clang_git: deduplicate patch
* [`1e26d333`](https://github.com/NixOS/nixpkgs/commit/1e26d33371a4a7238a644c49ddae49a4009c927f) clang_15: add nostdlibinc flag
* [`3e18607b`](https://github.com/NixOS/nixpkgs/commit/3e18607be38fe5294fc4773220f25452ce0b7f9f) rustPlatform.cargoSetupHook: dereference symlinks in cargoDeps
* [`7e4e6e8b`](https://github.com/NixOS/nixpkgs/commit/7e4e6e8bd7c6d5447d54d0730e59814c6412a73b) nixos/ec2: don't populate nonexistent metadata files
* [`5d56b258`](https://github.com/NixOS/nixpkgs/commit/5d56b258b6bdab16e4b943d811dcfd8fc34ef256) liblouis: enable strictDpes
* [`e9f7a65d`](https://github.com/NixOS/nixpkgs/commit/e9f7a65db8e7f2e14910122e68a8daaf3bd145eb) perlPackages.AlienLibxml2: enable strictDeps
* [`f05b5d40`](https://github.com/NixOS/nixpkgs/commit/f05b5d40549a27ad71c82aebe49639d353d33c10) stdenv: aarch64-linux: gcc9 -> gcc12
* [`c80fd665`](https://github.com/NixOS/nixpkgs/commit/c80fd6659ed8eeb24673e082b2959158592cdf13) python3Packages.pygments: 2.13.0 -> 2.14.0
* [`a9a46e57`](https://github.com/NixOS/nixpkgs/commit/a9a46e5770924bf171d875c53780f983bf294383) sphinx: disable tests that fail with pygments 2.14
* [`4ef98e72`](https://github.com/NixOS/nixpkgs/commit/4ef98e72006af7d42b6a6967c868ed05bf7bece9) python310Packages.rich: 13.0.0 -> 13.3.0
* [`2d2bf009`](https://github.com/NixOS/nixpkgs/commit/2d2bf009615700df155950317bb739f103c81585) python3Packages.pandas: break dependency cycle with hypothesis docs
* [`92004c8d`](https://github.com/NixOS/nixpkgs/commit/92004c8d619ea976aba03ad0c5f0be345645f97d) python3Packages.markdown-it-py: 2.1.0 -> 2.2.0
* [`f4c041be`](https://github.com/NixOS/nixpkgs/commit/f4c041be3eaa3577e626fe7c92a14c0e2d9d269c) python3Packages.textual: 0.10.1 -> 0.11.1
* [`95806059`](https://github.com/NixOS/nixpkgs/commit/95806059e1087dbbaa09e3001301f923d1393e9c) sqlite: 3.40.1 -> 3.41.0
* [`945ff62e`](https://github.com/NixOS/nixpkgs/commit/945ff62ef890ae475c4c77e1ef7d55a5c89a74c0) gnumake: 4.4 -> 4.4.1
* [`e731fba4`](https://github.com/NixOS/nixpkgs/commit/e731fba41489e3065dddccf64000564ae9cab5db) llvmPackages_git.compiler-rt: fix armv7l patch
* [`4040a6d1`](https://github.com/NixOS/nixpkgs/commit/4040a6d1314b770a4c38cd7979e6dd8fd779e3ad) llvmPackages_git.compiler-rt: fix Glibc build
* [`f388236a`](https://github.com/NixOS/nixpkgs/commit/f388236ab2b1c8b25220492e8774bdf3de69ce3f) python310Packages.sentry-sdk: 1.15.0 -> 1.16.0
* [`fe1c3385`](https://github.com/NixOS/nixpkgs/commit/fe1c3385105bea73a5ec55edd751ce6793a525bd) llvmPackages_git: expand the `NIX_BUILD_CORES` arg passed to lit at configure time
* [`60a2f641`](https://github.com/NixOS/nixpkgs/commit/60a2f64123da7b36d1355158afc7f690f27d54b5) llvmPackages_git: switch to using `ninja`
* [`f0426044`](https://github.com/NixOS/nixpkgs/commit/f04260448a6a71830911c38323ee95bb803ed78e) libgit2: 1.5.1 -> 1.6.1
* [`ea0dc2c5`](https://github.com/NixOS/nixpkgs/commit/ea0dc2c5eb7c462a657e336763b1754efe1e5661) nixos/avahi: add denyInterfaces option
* [`78649a67`](https://github.com/NixOS/nixpkgs/commit/78649a67abb664c6ee17433139d74a4345703ed3) SDL2: 2.24.2 -> 2.26.3
* [`b6b14fe0`](https://github.com/NixOS/nixpkgs/commit/b6b14fe05165cd38db41e37749e61ddeff8ece0e) libvpx: 1.12.0 -> 1.13.0
* [`fc9356c8`](https://github.com/NixOS/nixpkgs/commit/fc9356c8adbdb53ea5acf5a7d403e816aa4be1a0) go, buildGoModule, buildGoPackage: default to 1.20
* [`d9e39ec3`](https://github.com/NixOS/nixpkgs/commit/d9e39ec30a3bb0f1a2af641df6d20bc8632f8ced) python310Packages.influxdb-client: 1.36.0 -> 1.36.1
* [`ed209e62`](https://github.com/NixOS/nixpkgs/commit/ed209e627909e1034e6d2315497420ad648a32c9) clang_15: mark hardeningUnsupportedFlags fortify3
* [`6cc523ca`](https://github.com/NixOS/nixpkgs/commit/6cc523ca28008cf19c727e1ee84c3f6be51eabca) lld: build with 2M stack size
* [`1db7f30d`](https://github.com/NixOS/nixpkgs/commit/1db7f30d1f96bab9512029b16a427ec2c7e81432) lld: explain why we change the stack size on Musl
* [`2fffdddd`](https://github.com/NixOS/nixpkgs/commit/2fffdddd69a053a84eea19a19087b340b7761d65) apparmor: 3.1.2 -> 3.1.3
* [`5648b252`](https://github.com/NixOS/nixpkgs/commit/5648b252998033358685ddc987450b59bb6d8dfd) maintainers: change email, add matrix
* [`a3059850`](https://github.com/NixOS/nixpkgs/commit/a3059850c5d6b53975d85e00b879819e1e3585e3) zix: init at unstable-2023-02-13
* [`cd8c610f`](https://github.com/NixOS/nixpkgs/commit/cd8c610ff24805cfbf8e34912c18796bceea88c6) log4cplus: 2.0.8 -> 2.1.0
* [`ba21116c`](https://github.com/NixOS/nixpkgs/commit/ba21116cec210ccf6275ce3dea2106769f97dabc) jdt-language-server: 1.19.0 -> 1.20.0
* [`b9a585eb`](https://github.com/NixOS/nixpkgs/commit/b9a585ebd33104f5eb4cf186a8b6d81e1430cc9c) libwacom: run tests
* [`098644ac`](https://github.com/NixOS/nixpkgs/commit/098644ac619be8ecf74011ba4bbb356a0170db5e) libwacom: add meta.changelog
* [`7effb27f`](https://github.com/NixOS/nixpkgs/commit/7effb27febc7af40ab31d6b4a7ddc444fc3ad631) python311Packages.ipython: 8.4.0 -> 8.11.0
* [`5a11d74d`](https://github.com/NixOS/nixpkgs/commit/5a11d74d175a7983137e912a3a4cfe0da4aa40d6) libass: 0.16.0 -> 0.17.1
* [`4040da19`](https://github.com/NixOS/nixpkgs/commit/4040da1900d3c7c6e3a273a2b6fa94fdeb2dfe55) dav1d: 1.0.0 -> 1.1.0
* [`66e579a8`](https://github.com/NixOS/nixpkgs/commit/66e579a856509bb30af20e78bcf5a6fe0712729d) libjxl: 0.7.0 -> 0.8.1
* [`248ab0ee`](https://github.com/NixOS/nixpkgs/commit/248ab0ee57b7564326fbe1ac156a4ffc8f895b39) python311Packages.mdit-py-plugins: 0.3.3 -> 0.3.4
* [`e3c84efc`](https://github.com/NixOS/nixpkgs/commit/e3c84efc8ebd908b29b1be9f63db8139b3437608) deepin.deepin-terminal: 5.4.34 -> 5.9.40
* [`c94182cc`](https://github.com/NixOS/nixpkgs/commit/c94182ccf08d27b6424b4039985f50bec83c3dd9) python311Packages.markdown2: 2.4.1 -> 2.4.8
* [`b87e0810`](https://github.com/NixOS/nixpkgs/commit/b87e0810c7be07e6b50b7af04993cf06fc7cb62b) python311Packages.myst-parser: 0.18.1 -> 0.19.0
* [`e8b4c13b`](https://github.com/NixOS/nixpkgs/commit/e8b4c13b8d206f4b01e95499aa7425765a79513e) arrow-cpp: unbreak on aarch64-linux
* [`39a2b0b3`](https://github.com/NixOS/nixpkgs/commit/39a2b0b3bf1849354e033a8752e3eff484195ebc) rust: remove aarch64-linux workaround
* [`b7d8c463`](https://github.com/NixOS/nixpkgs/commit/b7d8c4630206d113c8cbe22d0ff80be5189a7655) haskellPackages.ghc: 9.2.6 -> 9.2.7
* [`499be580`](https://github.com/NixOS/nixpkgs/commit/499be5802684091917e14e6e320504d5c770b990) haskellPackages: stackage LTS 20.11 -> LTS 20.12
* [`a8abc9e5`](https://github.com/NixOS/nixpkgs/commit/a8abc9e550782b512a0ea20fcda3d10c72b65f64) all-cabal-hashes: 2023-02-19T09:15:19Z -> 2023-03-01T16:43:25Z
* [`bc6029b2`](https://github.com/NixOS/nixpkgs/commit/bc6029b2d1ecc649e9d8b8bab6c5d3c7167df04c) haskellPackages: regenerate package set based on current config
* [`50e7b4bf`](https://github.com/NixOS/nixpkgs/commit/50e7b4bfce7218d1700e3cc420d063ebfbfc04fe) haskellPackages.haskell-gi: use hackage2nix generated 0.26.3 expr
* [`ed65e11b`](https://github.com/NixOS/nixpkgs/commit/ed65e11bac2fde631de8b76a5dddef8aabef2761) haskellPackages.Cabal_3_8_1_0: drop obsolete override
* [`d8a62e20`](https://github.com/NixOS/nixpkgs/commit/d8a62e205d4c8f88147bd18068a65b5eba5364e4) keyutils: fix build for s390
* [`23cc5a59`](https://github.com/NixOS/nixpkgs/commit/23cc5a59dad17d651810f76b7f5f9937501cfdea) libcap: 2.66 -> 2.67
* [`fb66334e`](https://github.com/NixOS/nixpkgs/commit/fb66334ec2f9a7599e78862f7d810603d968a1cd) libfido2: 1.12.0 -> 1.13.0
* [`11b07d93`](https://github.com/NixOS/nixpkgs/commit/11b07d930ddab70c3a82234fe83ed5d649b2ac52) firefox, spidermonkey: remove NIX_LDFLAGS
* [`846ce0b7`](https://github.com/NixOS/nixpkgs/commit/846ce0b7fee4810c8e3dc5a8f21d67380b721c43) re2: 2023-02-01 -> 2023-03-01
* [`40f75224`](https://github.com/NixOS/nixpkgs/commit/40f7522469a53c959ae831e865a38b00a4e15da8) hwdata: 0.367 -> 0.368
* [`653d1f05`](https://github.com/NixOS/nixpkgs/commit/653d1f053463b85525e02afb7ee91b4b26d966e1) nixos/hbase: add examples for options
* [`50da886b`](https://github.com/NixOS/nixpkgs/commit/50da886be414335874ede07fc57ee19f9878c841) timeular: 4.8.0 -> 5.7.8
* [`cc541cb7`](https://github.com/NixOS/nixpkgs/commit/cc541cb750a3468fbc5a75ecd6ef8d9e7402e490) tbb: Split into tbb_2020_3 and tbb_2021_8
* [`b06ac37f`](https://github.com/NixOS/nixpkgs/commit/b06ac37f38c11ac800ae8d4a3b094baa6a60072e) llvmPackages*.clang_manpages: drop the sphinx `find_package` patch
* [`98ee15d1`](https://github.com/NixOS/nixpkgs/commit/98ee15d1920db3fd3f17e230d3339cee719f9476) ballerina: 2201.2.2 -> 2201.4.0
* [`5a86855e`](https://github.com/NixOS/nixpkgs/commit/5a86855e006de9420ed5b2f799900bbefb691e53) haskell.packages.*: reflect terminfo update for cross compilation
* [`74ff13b1`](https://github.com/NixOS/nixpkgs/commit/74ff13b12d2762c997ab418f39e81a3fdd909298) haskellPackages.espial: drop upstreamed patch
* [`21b99329`](https://github.com/NixOS/nixpkgs/commit/21b993296fbfd80543fbe14fa0ff6b093ba54502) haskellPackages: reflect haskelline 0.8.2 -> 0.8.2.1
* [`7f2ac905`](https://github.com/NixOS/nixpkgs/commit/7f2ac90596a220c22c28908f0e402d7b09a44951) haskell.packages.ghc94.primitive: 0.7.4.0 -> 0.8.0.0
* [`295066c4`](https://github.com/NixOS/nixpkgs/commit/295066c43d74b2ac73439dcc1d17639d2e55298b) haskell.packages.ghc94.aeson: 2.1.1.0 -> 2.1.2.1
* [`335f3cf3`](https://github.com/NixOS/nixpkgs/commit/335f3cf3906b77a5e0d73dc435b4177c1f50a67d) haskell.packages.ghc94.lens: 5.2 -> 5.2.1
* [`28e1929f`](https://github.com/NixOS/nixpkgs/commit/28e1929fb013cea5aad7ad3ed8daa1cb34a5fe84) git-annex: update sha256 for 10.20230227
* [`fa651582`](https://github.com/NixOS/nixpkgs/commit/fa651582867b2ebd01d87472febcf539996d8e6b) elmPackages.elm-format: reflect text 2.0.1 -> 2.0.2
* [`37d891ae`](https://github.com/NixOS/nixpkgs/commit/37d891aebf50d150a368870aee18e2a08612f2ec) python3Packages.myst-parser: 0.19.0 -> 0.19.1
* [`69b87ae0`](https://github.com/NixOS/nixpkgs/commit/69b87ae0ec53ab876263ce5bae4bc7fd9bf3aa4c) libsoup_3: re-disable introspection if no emulator
* [`7c643c33`](https://github.com/NixOS/nixpkgs/commit/7c643c33121fd54162f7e81c148b776e903c05d2) gsettings-desktop-schemas: re-disable introspection if no emulator
* [`8ea1ca27`](https://github.com/NixOS/nixpkgs/commit/8ea1ca271b3df191f8e0eef50ba03561fbca1f0d) at-spi2-core: re-disable introspection if no emulator
* [`430a9ba1`](https://github.com/NixOS/nixpkgs/commit/430a9ba1307f99ff364011915abe5d144e18b60f) gdk-pixbuf: re-disable introspection if no emulator
* [`ffb1b62b`](https://github.com/NixOS/nixpkgs/commit/ffb1b62b5f338a27232bac210c9dc22831f6d151) json-glib: re-disable introspection if no emulator
* [`e1bd8afb`](https://github.com/NixOS/nixpkgs/commit/e1bd8afb0794c0af1b35bcd623e0d9e88cf845b4) libsoup: re-disable introspection if no emulator
* [`5ecef164`](https://github.com/NixOS/nixpkgs/commit/5ecef164cb5c0edd7368f816812ca8d3f889e60b) libsecret: disable introspection if no emulator
* [`9144866b`](https://github.com/NixOS/nixpkgs/commit/9144866bb79628ffd0a92875474429664d70250f) libical: re-disable introspection if no emulator
* [`2654807c`](https://github.com/NixOS/nixpkgs/commit/2654807c757bc23c52863307775000535b8576bf) tracker: disable introspection if no emulator
* [`fef0a52d`](https://github.com/NixOS/nixpkgs/commit/fef0a52db9b674209e22162ff89f7602ba98c148) libmanette: disable introspection if no emulator
* [`52a479d0`](https://github.com/NixOS/nixpkgs/commit/52a479d024e6eba3ce7bc3178d3b53591d9a92ba) polkit: re-disable introspection if no emulator
* [`0913507b`](https://github.com/NixOS/nixpkgs/commit/0913507b1360c55a62f48a82b13314db001a1f3e) gtk3: re-disable introspection if no emulator
* [`79ded405`](https://github.com/NixOS/nixpkgs/commit/79ded405f861f480531f6c7718368a0f456a6572) libdiscid: 0.6.2 -> 0.6.3
* [`da01b17b`](https://github.com/NixOS/nixpkgs/commit/da01b17bec5caef41468a7b6b650d9d04e2c7083) libdiscid: 0.6.3 -> 0.6.4
* [`73665ef4`](https://github.com/NixOS/nixpkgs/commit/73665ef4e43f658edaff4421dd87ec7e19d02923) i3status-rust: 0.22.0 -> 0.30.4
* [`be702986`](https://github.com/NixOS/nixpkgs/commit/be702986e11e1c1d99099e7bd0af988248170995) harfbuzz: 7.0.0 -> 7.0.1
* [`ce7e3aa3`](https://github.com/NixOS/nixpkgs/commit/ce7e3aa3563e430309a042924e55720274a2ce42) semgrep: 1.0.0 -> 1.14.0
* [`c5a6d51a`](https://github.com/NixOS/nixpkgs/commit/c5a6d51ac1e82657882e8b236ce8e92dce44e046) yubihsm-connector: 3.0.2 -> 3.0.4
* [`d1949033`](https://github.com/NixOS/nixpkgs/commit/d19490339b900fff1de43876702964f3d41557ea) carla: 2.5.1 -> 2.5.3
* [`c0680473`](https://github.com/NixOS/nixpkgs/commit/c068047330d4c72cca53bf3a3d383bf8896bbcd0) carla: remove python3Packages and gtk2, gk3 assertions
* [`410971fc`](https://github.com/NixOS/nixpkgs/commit/410971fc3597ede8a23e829487847ad35641e69b) zrythm: 1.0.0-alpha.28.1.3 -> 1.0.0-beta.4.5.62
* [`f0371671`](https://github.com/NixOS/nixpkgs/commit/f03716715f663f1c45056b7df450cf1b7386181b) nixos/hidpi: Disable anti-aliasing
* [`b2366655`](https://github.com/NixOS/nixpkgs/commit/b2366655e2ee2b284f530509114bf873c1601973) nixos/hidpi: Disable font hinting
* [`e1220cf1`](https://github.com/NixOS/nixpkgs/commit/e1220cf121328e2f851a0a8458a2891d07361a60) nixos/hidpi: Don't set subpixel order
* [`fc65af6a`](https://github.com/NixOS/nixpkgs/commit/fc65af6a746ca0d9b219775655f8ed4c079caa99) nixos/hidpi: Minor refactor
* [`0367cc8b`](https://github.com/NixOS/nixpkgs/commit/0367cc8b5a7d4e6e62ca7c9f429f8a1901194297) nixos/profiles/base: remove duplicate systemPackages
* [`f86e1e9a`](https://github.com/NixOS/nixpkgs/commit/f86e1e9a79149c8ee295fb2d7fe958248c869931) nixos/tests/sgtpuzzles: init
* [`b2d84edd`](https://github.com/NixOS/nixpkgs/commit/b2d84edda8e62f576d9ab8dc677e5b46abf57313) chromaprint: remove boost dependency
* [`3e3367aa`](https://github.com/NixOS/nixpkgs/commit/3e3367aa6a18cf4ec4c79c21f36eec150b3d7939) nixos/profiles/base: remove duplicate and optimize fsPackages
* [`3ffb9301`](https://github.com/NixOS/nixpkgs/commit/3ffb93010142c57fc5810f8dc36b4d0f4601123b) viber: fix build with openssl
* [`379b94bd`](https://github.com/NixOS/nixpkgs/commit/379b94bdfaf4cc682e540e47c629fad64782a9d7) elfutils: 0.188 -> 0.189
* [`451c6321`](https://github.com/NixOS/nixpkgs/commit/451c63214766d3bb8d078620cff4dc74463c5bc8) python310Packages.setuptools: 65.0.3 -> 67.4.0
* [`eec8bd84`](https://github.com/NixOS/nixpkgs/commit/eec8bd84c0d849d537740d7d47a9daf8a7951114) python310Packages.pip: 22.3.1 -> 23.0.1
* [`3b6781a6`](https://github.com/NixOS/nixpkgs/commit/3b6781a68a946aa150abb70d74743ce0fdca7b91) python310Packages.build: 0.9.0 -> 0.10.0
* [`ecc65ff2`](https://github.com/NixOS/nixpkgs/commit/ecc65ff29c727b712912826357f7b321cc0a42f5) python310Packages.poetry-core: 1.4.0 -> 1.5.1
* [`cf5938f4`](https://github.com/NixOS/nixpkgs/commit/cf5938f4a6e7d0867a0c970abae1ff3e29fd5fea) python310Packages.pdm-pep517: 1.0.6 -> 1.1.2
* [`487342f0`](https://github.com/NixOS/nixpkgs/commit/487342f0e131d0ff962e5d0c9743983d1fb2ef00) python310Packages.pdm-backend: init at 2.0.2
* [`05f77ec9`](https://github.com/NixOS/nixpkgs/commit/05f77ec9773816aefc15c1aeedab0d9b9fcfd89f) python310Packages.pbr: 5.11.0 -> 5.11.1
* [`f9174cec`](https://github.com/NixOS/nixpkgs/commit/f9174cec15ee375cf88ea002a8e40ff577e27c1b) python310Packages.hatchling: 1.11.1 -> 1.13.0
* [`8b711e85`](https://github.com/NixOS/nixpkgs/commit/8b711e85571b3ccb400e07a7d807fe39f0016b4b) python310Packages.pytest: 7.2.0 -> 7.2.1
* [`13309dba`](https://github.com/NixOS/nixpkgs/commit/13309dba9acbac09a52e041cf8d39ba4dc4a4aff) python310Packages.hypothesis: 6.61.0 -> 6.68.2
* [`4a9ddc55`](https://github.com/NixOS/nixpkgs/commit/4a9ddc55152a37c0c41c6d46be813bfa59abb856) Revert "python3.pkgs.cryptography: use openssl_1_1"
* [`3f1c8de7`](https://github.com/NixOS/nixpkgs/commit/3f1c8de71113a1ff622550d336f40cdd8627b4d2) pythonPackages.flask: Move optional deps to passthru
* [`32283aa1`](https://github.com/NixOS/nixpkgs/commit/32283aa1de03fe3549e7f0c9052ca258d35e2a39) python310Packages.packaging: 21.3 -> 23.0, add SuperSandro2000 as maintainer
* [`664f1330`](https://github.com/NixOS/nixpkgs/commit/664f1330fbf81f4e1bdcad539a99ce45b07f6bdb) pypy3Packages.bootstrapped-pip: fix build
* [`07ff0b59`](https://github.com/NixOS/nixpkgs/commit/07ff0b59009c59e65695c0cdc4d0197910534391) sphinx: 5.3.0 -> 6.1.3
* [`2278f9eb`](https://github.com/NixOS/nixpkgs/commit/2278f9ebe2cc2595f20fb756b7a499699c4fe9c1) haskell.compiler: fix GHCs' user guide build with sphinx >= 6.0
* [`a054a24e`](https://github.com/NixOS/nixpkgs/commit/a054a24e0b14b4400925375f63fff1e6af90e6f8) python310Packages.sphinxcontrib-jquery: rename from sphinx-jquery
* [`cf3963a5`](https://github.com/NixOS/nixpkgs/commit/cf3963a5d40f0c402bb376b9bc0835a114b8e8a9) python310Packages.sphinxcontrib-jquery: Enable tests, update meta
* [`6449f679`](https://github.com/NixOS/nixpkgs/commit/6449f679ea1d0d246e63219ad0b655f8a33b7cc9) python310Packages.mutagen: Fix sphinx 6.0 compat
* [`3b5a2db8`](https://github.com/NixOS/nixpkgs/commit/3b5a2db8a6a33a753cf895eb2d1175502f4c9b2f) python310Packages.sphinx-rtd-theme: Replace sphinx-jquery alias
* [`10aa1789`](https://github.com/NixOS/nixpkgs/commit/10aa1789a9dcc7010ce68ebfe04c6fea10efed02) python310Packages.sphinxcontrib-autoapi: 2.0.0 -> 2.0.1
* [`b53d7821`](https://github.com/NixOS/nixpkgs/commit/b53d78210594bac731001a3c45f4f8778a8f4c2d) python310Packages.urllib3: 1.26.13 -> 1.26.14
* [`ed22deca`](https://github.com/NixOS/nixpkgs/commit/ed22deca23a5969b07b09d61aa5494d63fa0c8bb) python310Packages.splinter: 0.18.1 -> 0.19.0
* [`03b73034`](https://github.com/NixOS/nixpkgs/commit/03b73034edf273b72cfdf21bcb2b310ddedb02f1) python310Packages.pytest-xdist: 3.1.0 -> 3.2.0
* [`5a6143b6`](https://github.com/NixOS/nixpkgs/commit/5a6143b6639a9bb8ce1d11f221d247d861a0b440) python310Packages.aiohttp: 3.8.3 -> 3.8.4
* [`0d6e54e6`](https://github.com/NixOS/nixpkgs/commit/0d6e54e62917652176e2d874ca57712640473feb) python3.pkgs.scipy: 1.9.3 -> 1.10.1
* [`799bc1a7`](https://github.com/NixOS/nixpkgs/commit/799bc1a7fae3c57f92ab8082b8e52582521a6c5e) pymdown-extensions: 9.9 -> 9.9.2
* [`d667eefa`](https://github.com/NixOS/nixpkgs/commit/d667eefaeb24630b3beb8d2b67323bd563f7decb) mkdocs-material: 8.5.11 -> 9.0.1
* [`756aa845`](https://github.com/NixOS/nixpkgs/commit/756aa845b82acf5793c7a164fe5982e28d304ee2) python3Packages.absl-py: 1.3.0 -> 1.4.0
* [`04b4f0cc`](https://github.com/NixOS/nixpkgs/commit/04b4f0cc1480e33f9604fa03c65929fa9010e091) python3Packages.aeppl: 0.0.50 -> 0.1.2
* [`33118e3f`](https://github.com/NixOS/nixpkgs/commit/33118e3f1b2020abbdd4f0db8485257a1da53dba) python3Packages.aesara: 2.8.9 -> 2.8.12
* [`93cf4321`](https://github.com/NixOS/nixpkgs/commit/93cf4321f6a03627f8db11b94ece37d69ce49bb5) python3Packages.afdko: 3.9.2 -> 3.9.3
* [`88e12335`](https://github.com/NixOS/nixpkgs/commit/88e12335d4c21869c440c9c51a0a62e6eb934671) python3Packages.affine: 2.3.1 -> 2.4.0
* [`b87c096d`](https://github.com/NixOS/nixpkgs/commit/b87c096d1dd7b3f28c50c699f73e559e8e5d466d) python3Packages.aiohttp-socks: 0.7.1 -> 0.8.0
* [`2b607661`](https://github.com/NixOS/nixpkgs/commit/2b607661a026da461bf10052a3114da7ebf4a1ff) python3Packages.aiomisc: 16.3.15 -> 17.0.6
* [`76e65aa5`](https://github.com/NixOS/nixpkgs/commit/76e65aa51e40cdacd20208659ad07696c76f614e) python3Packages.aiomysensors: 0.3.5 -> 0.3.6
* [`e788053a`](https://github.com/NixOS/nixpkgs/commit/e788053aeae7be5055bb8a5a568e42bbf6e590db) python3Packages.aiosmtpd: 1.4.3 -> 1.4.4.post2
* [`357b828e`](https://github.com/NixOS/nixpkgs/commit/357b828ebb30f0007e44e5fef70e4a535b9a527e) python3Packages.alabaster: 0.7.12 -> 0.7.13
* [`1f8eaf75`](https://github.com/NixOS/nixpkgs/commit/1f8eaf759f69a512f25a2e3765296a10d3f96998) python3Packages.alembic: 1.9.1 -> 1.9.4
* [`3b8f6b5d`](https://github.com/NixOS/nixpkgs/commit/3b8f6b5d6b7e7bade9ee04cc88bf7badb04d050c) python3Packages.ale-py: 0.8.0 -> 0.8.1
* [`dd5fc9c6`](https://github.com/NixOS/nixpkgs/commit/dd5fc9c62aa3943aad2a9c4e44bf47a7ce2baf94) python3Packages.amazon_kclpy: 2.0.6 -> 2.1.1
* [`067b77f8`](https://github.com/NixOS/nixpkgs/commit/067b77f8f97473f313f647c80854c63ea0e7e489) python3Packages.apache-airflow: 2.5.0 -> 2.5.1
* [`b79d9ca1`](https://github.com/NixOS/nixpkgs/commit/b79d9ca1d1691379d19444987cdd977ddb756614) python3Packages.apprise: 1.2.1 -> 1.3.0
* [`d45f4299`](https://github.com/NixOS/nixpkgs/commit/d45f4299d19731d52caf6619db45db446d55ff82) python3Packages.apscheduler: 3.9.1.post1 -> 3.10.0
* [`c10568a1`](https://github.com/NixOS/nixpkgs/commit/c10568a10ae82cd503fd4c4bd354e28d5a454355) python3Packages.apsw: 3.40.0.0 -> 3.40.1.0
* [`06d6e8a0`](https://github.com/NixOS/nixpkgs/commit/06d6e8a0ffdeaba1c4614f7407661dc8ec678776) python3Packages.argh: 0.27.2 -> 0.28.1
* [`147a1944`](https://github.com/NixOS/nixpkgs/commit/147a1944e26d99b83e66effaa588f8cb1eb4b5ac) python3Packages.argparse-addons: 0.8.0 -> 0.12.0
* [`24734dd6`](https://github.com/NixOS/nixpkgs/commit/24734dd68e6bd8692b2a19e7bd2260cde2c7b16b) python3Packages.ariadne: 0.17.0 -> 0.18.1
* [`a455ac03`](https://github.com/NixOS/nixpkgs/commit/a455ac03e48ebefe8cd3ac36f220adfd2f226153) python3Packages.arviz: 0.14.0 -> 0.15.0
* [`21ea11a3`](https://github.com/NixOS/nixpkgs/commit/21ea11a368a7baace13aff6034d7b7d1a046bc8c) python3Packages.asana: 3.1.0 -> 3.1.1
* [`52e9c944`](https://github.com/NixOS/nixpkgs/commit/52e9c9440bd2aed817561fc00e0ca684f7411f10) python3Packages.asf-search: 6.0.2 -> 6.1.0
* [`bac097a6`](https://github.com/NixOS/nixpkgs/commit/bac097a66b497ca869ef3c3049dcc4c6ef636678) python3Packages.astroid: 2.12.13 -> 2.14.2
* [`9d89940b`](https://github.com/NixOS/nixpkgs/commit/9d89940b03a999448b591ea0985085f949f548e9) python3Packages.astropy: 5.2 -> 5.2.1
* [`9d470546`](https://github.com/NixOS/nixpkgs/commit/9d47054644f4211b43c049119ec9d7cf71ad1b07) python3Packages.atom: 0.8.2 -> 0.9.0
* [`bdbd6f84`](https://github.com/NixOS/nixpkgs/commit/bdbd6f842bfcb5ca84dccfb65e0e04bc851d31f0) python3Packages.auth0-python: 3.24.0 -> 4.0.0
* [`61922aa8`](https://github.com/NixOS/nixpkgs/commit/61922aa8645e8b1df6fcd289c7b02d273a3bae3b) python3Packages.autofaiss: 2.15.4 -> 2.15.5
* [`8733da2a`](https://github.com/NixOS/nixpkgs/commit/8733da2aff932f59e8147c19ccae0caba71e7f01) python3Packages.autoflake: 1.4 -> 2.0.1
* [`ab02382e`](https://github.com/NixOS/nixpkgs/commit/ab02382ed8d613949605bbf39a018c71621ddd36) python3Packages.awkward-cpp: 6 -> 9
* [`238acde5`](https://github.com/NixOS/nixpkgs/commit/238acde5dcbe54a161db74d1e8c927f80fde266b) python3Packages.awkward: 2.0.5 -> 2.0.8
* [`b73a3dea`](https://github.com/NixOS/nixpkgs/commit/b73a3dea9f2538aea4c6975e251e9bdca75075dd) python3Packages.aws-lambda-builders: 1.25.0 -> 1.27.0
* [`17a51ba6`](https://github.com/NixOS/nixpkgs/commit/17a51ba6267e76b57eb5a3a992e3ac15894bc07b) python3Packages.aws-sam-translator: 1.55.0 -> 1.60.1
* [`779b8f09`](https://github.com/NixOS/nixpkgs/commit/779b8f097bb9def4152a32888ba45db751df90d5) python3Packages.azure-storage-file-share: 12.10.1 -> 12.11.0
* [`1d04b328`](https://github.com/NixOS/nixpkgs/commit/1d04b32881c82c5ab7dec4db6e33124a8799c1ee) python3Packages.azure-storage-queue: 12.5.0 -> 12.6.0
* [`14b85dd8`](https://github.com/NixOS/nixpkgs/commit/14b85dd8be8dd89143ca1d6f9c59309a728da23f) python3Packages.bacpypes: 0.18.4 -> 0.18.6
* [`7090dc4b`](https://github.com/NixOS/nixpkgs/commit/7090dc4b052cf69c375354ac377ef936d8f70bc1) python3Packages.bambi: 0.9.3 -> 0.10.0
* [`edf2e794`](https://github.com/NixOS/nixpkgs/commit/edf2e79489aa14f39a812460790826080e9b245b) python3Packages.beautifulsoup4: 4.11.1 -> 4.11.2
* [`2706675b`](https://github.com/NixOS/nixpkgs/commit/2706675bcf0734e5733c94f55ed52ed83f5d1639) python3Packages.bidict: 0.22.0 -> 0.22.1
* [`740e11be`](https://github.com/NixOS/nixpkgs/commit/740e11be779e767038c8386474c22f94e70d0e54) python3Packages.bimmer-connected: 0.12.1 -> 0.13.0
* [`d3b702a5`](https://github.com/NixOS/nixpkgs/commit/d3b702a50308f7db5d9ff615b744d02432506149) python3Packages.bincopy: 17.14.0 -> 17.14.5
* [`0a3770a6`](https://github.com/NixOS/nixpkgs/commit/0a3770a643ec4c201ac63c7066a1bc682eb6a768) python3Packages.black: 22.12.0 -> 23.1.0
* [`536911eb`](https://github.com/NixOS/nixpkgs/commit/536911eb1e476f0c045b70e7c116c94066770307) python3Packages.bleach: 5.0.1 -> 6.0.0
* [`32dee093`](https://github.com/NixOS/nixpkgs/commit/32dee093c2f1431d27a4ccbad3b955ac276a3461) python3Packages.bleak-retry-connector: 2.13.1 -> 3.0.0
* [`a65fe285`](https://github.com/NixOS/nixpkgs/commit/a65fe285f04ae7f8cb918a414be0fe107383727d) python3Packages.blessed: 1.19.1 -> 1.20.0
* [`6616852b`](https://github.com/NixOS/nixpkgs/commit/6616852b1aedfa04fb639583d8710932fe4ac8ba) python3Packages.blis: 0.7.9 -> 0.9.1
* [`e40fbc57`](https://github.com/NixOS/nixpkgs/commit/e40fbc57f75bef18de25f772e4a466525ed7a09a) python3Packages.botocore: 1.29.40 -> 1.29.79
* [`dedda0d9`](https://github.com/NixOS/nixpkgs/commit/dedda0d9522d4d5210589f8182839965daf45d90) python3Packages.bottle: 0.12.23 -> 0.12.24
* [`d21a016e`](https://github.com/NixOS/nixpkgs/commit/d21a016ed8677e80dee71b6462758c14a7f064db) python3Packages.bundlewrap: 4.16.0 -> 4.17.0
* [`9f998933`](https://github.com/NixOS/nixpkgs/commit/9f998933606ea33fc2cfe0444d79b74da306a3a6) python3Packages.cachelib: 0.9.0 -> 0.10.2
* [`3626e308`](https://github.com/NixOS/nixpkgs/commit/3626e3084a65c2a36ab70420d9624d3449b1556b) python3Packages.catboost: 1.0.5 -> 1.1.1
* [`04fa0221`](https://github.com/NixOS/nixpkgs/commit/04fa022176dfb9fc445c904475a29108c009ffc8) python3Packages.certbot: 2.1.1 -> 2.3.0
* [`0235e5c4`](https://github.com/NixOS/nixpkgs/commit/0235e5c4e25e3f4b1776d513b49a53b7ae3c2199) python3Packages.cfn-lint: 0.72.5 -> 0.73.2
* [`dfaa3ecd`](https://github.com/NixOS/nixpkgs/commit/dfaa3ecdd9f33f436da156567fce93a801687c53) python3Packages.chart-studio: 5.13.0 -> 5.13.1
* [`ea768a4e`](https://github.com/NixOS/nixpkgs/commit/ea768a4e92417e816e6cd0590c26425ac6a1c70b) python3Packages.chex: 0.1.5 -> 0.1.6
* [`94e963c5`](https://github.com/NixOS/nixpkgs/commit/94e963c5c72738b0465e1525184afea8e17c274b) python3Packages.chia-rs: 0.2.0 -> 0.2.2
* [`8cfb457f`](https://github.com/NixOS/nixpkgs/commit/8cfb457f962ffa5232eaabb41d97892aafa4913d) python3Packages.cliff: 4.1.0 -> 4.2.0
* [`f3f8b847`](https://github.com/NixOS/nixpkgs/commit/f3f8b847868530b473c0f121f52dde73ee562729) python3Packages.cloudscraper: 1.2.68 -> 1.2.69
* [`4c2b5c30`](https://github.com/NixOS/nixpkgs/commit/4c2b5c30b6a037b7282d29cad76679bd1582a751) python3Packages.cmd2: 2.4.2 -> 2.4.3
* [`b0bbed75`](https://github.com/NixOS/nixpkgs/commit/b0bbed759827813d41930670f5a5f63decbde610) python3Packages.coinmetrics-api-client: 2022.11.14.16 -> 2023.2.23.0
* [`61a26b94`](https://github.com/NixOS/nixpkgs/commit/61a26b94716db9a675001aa5de58a52c0f7eba95) python3Packages.colander: 1.8.3 -> 2.0
* [`b7e94dba`](https://github.com/NixOS/nixpkgs/commit/b7e94dba9ec4abbf7cdd8fd8dccb0eef640491a7) python3Packages.commoncode: 31.0.0 -> 31.0.2
* [`afcfd7de`](https://github.com/NixOS/nixpkgs/commit/afcfd7de1b3c5f1480d095e3be6cc1edb00d3442) python3Packages.confluent-kafka: 1.9.2 -> 2.0.2
* [`030dc7c0`](https://github.com/NixOS/nixpkgs/commit/030dc7c0c006b200f0722bc857acee5893f00da7) python3Packages.contourpy: 1.0.6 -> 1.0.7
* [`1896e515`](https://github.com/NixOS/nixpkgs/commit/1896e5152cd4d680c2eaa0328afa0f5c48569d9c) python3Packages.coverage: 7.0.1 -> 7.2.1
* [`c5f6ac58`](https://github.com/NixOS/nixpkgs/commit/c5f6ac5836eb9a4f28f36f5ec17abfb047443c03) python3Packages.crate: 0.29.0 -> 0.30.0
* [`48c15f81`](https://github.com/NixOS/nixpkgs/commit/48c15f813807a7151a13ea455a87c37e2542d7a9) python3Packages.cryptolyzer: 0.8.2 -> 0.8.4
* [`6ae32c19`](https://github.com/NixOS/nixpkgs/commit/6ae32c196c631d997d69c7abf0618d7681b8a6c3) python3Packages.cryptoparser: 0.8.2 -> 0.8.4
* [`d7266fe4`](https://github.com/NixOS/nixpkgs/commit/d7266fe4fcb5da4e2a1010ac7961deeb18157e66) python3Packages.cx-freeze: 6.13.1 -> 6.14.4
* [`8680508e`](https://github.com/NixOS/nixpkgs/commit/8680508ead71b0952b16c12ea6b76ebbbc952353) python3Packages.dalle-mini: 0.1.1 -> 0.1.4
* [`42caad0a`](https://github.com/NixOS/nixpkgs/commit/42caad0ad061d5286c49e1af5b609784dffd1774) python3Packages.dash: 2.7.0 -> 2.8.1
* [`80de5609`](https://github.com/NixOS/nixpkgs/commit/80de560996ababa6948d99a910eb69cce31a5785) python3Packages.databricks-connect: 10.4.18 -> 11.3.6
* [`b1a77825`](https://github.com/NixOS/nixpkgs/commit/b1a77825236196a9003cddc2f76579bb13d3e366) python3Packages.databricks-sql-connector: 2.3.0 -> 2.4.0
* [`3088bb02`](https://github.com/NixOS/nixpkgs/commit/3088bb0295774f56bf108727952a48a419145e02) python3Packages.dbus-fast: 1.84.1 -> 1.84.2
* [`f1998432`](https://github.com/NixOS/nixpkgs/commit/f199843282ad8d830f711349a5ef3eb2fb44474d) python3Packages.dbus-python-client-gen: 0.8 -> 0.8.2
* [`22d35b87`](https://github.com/NixOS/nixpkgs/commit/22d35b87613809136103075bfe4bd523a57f7417) python3Packages.deep-translator: 1.9.3 -> 1.10.1
* [`d55d7c68`](https://github.com/NixOS/nixpkgs/commit/d55d7c68ae46c66a84da3305af1e9d9e4153db27) python3Packages.dict2xml: 1.7.2 -> 1.7.3
* [`a9070ea4`](https://github.com/NixOS/nixpkgs/commit/a9070ea4df25a61bd68ba0ee462842d0938fff3c) python3Packages.diff-cover: 7.3.0 -> 7.5.0
* [`5d28c89b`](https://github.com/NixOS/nixpkgs/commit/5d28c89bbb4928dc4e72d6595fdd248b6b6fd1af) python3Packages.distrax: 0.1.2 -> 0.1.3
* [`7ed40a27`](https://github.com/NixOS/nixpkgs/commit/7ed40a2746439129b036a3c8322a474e20352969) python3Packages.distributed: 2023.1.0 -> 2023.2.1
* [`d8c1a53f`](https://github.com/NixOS/nixpkgs/commit/d8c1a53f4de8b26a2f05bb6ab4e8855bfa9d29a8) python3Packages.django-compressor: 4.1 -> 4.3.1
* [`dc639eca`](https://github.com/NixOS/nixpkgs/commit/dc639ecac6974b78ed1af7b4dc786a14025381b2) python3Packages.django-crispy-forms: 1.14.0 -> 2.0
* [`b73681dc`](https://github.com/NixOS/nixpkgs/commit/b73681dc8f246e530a893bb9b3c44f54430c2f62) python3Packages.django-import-export: 2.8.0 -> 3.1.0
* [`5f16446a`](https://github.com/NixOS/nixpkgs/commit/5f16446a098ab5bc60c0a8b88c43f9593cb5048c) python3Packages.django-mailman3: 1.3.8 -> 1.3.9
* [`e954768a`](https://github.com/NixOS/nixpkgs/commit/e954768ab3594fe959b1de43dcbde48a718e4dc7) python3Packages.django-phonenumber-field: 6.4.0 -> 7.0.2
* [`8210334f`](https://github.com/NixOS/nixpkgs/commit/8210334f388319577dd3fbcdaec143f1093d454d) python3Packages.django-stubs: 1.13.1 -> 1.15.0
* [`29263bb0`](https://github.com/NixOS/nixpkgs/commit/29263bb064c2748fa5a30256ebbe419db291be05) python3Packages.django-versatileimagefield: 2.2 -> 3.0
* [`33c18bf3`](https://github.com/NixOS/nixpkgs/commit/33c18bf349a385574091a82d0e99e48c0ea63fc0) python3Packages.dj-rest-auth: 2.2.5 -> 3.0.0
* [`f4bb6c46`](https://github.com/NixOS/nixpkgs/commit/f4bb6c46a712a5232ed4c31fd2a6d85ce9b5117b) python3Packages.dvc-data: 0.40.3 -> 0.41.3
* [`d4700bd1`](https://github.com/NixOS/nixpkgs/commit/d4700bd12a6329ec26ddf7203939331597132131) python3Packages.dvclive: 1.3.0 -> 2.1.0
* [`cc4c971d`](https://github.com/NixOS/nixpkgs/commit/cc4c971d9dc0f137bde83218847eeefc01dddb69) python3Packages.dvc-objects: 0.19.3 -> 0.20.0
* [`75dcf915`](https://github.com/NixOS/nixpkgs/commit/75dcf915a22b01b026fae9a2fb3ed2fd7de2d96e) python3Packages.enaml: 0.15.2 -> 0.16.0
* [`a029159e`](https://github.com/NixOS/nixpkgs/commit/a029159e51322101647bb56fb6c53227235fdc13) python3Packages.etils: 0.9.0 -> 1.0.0
* [`22d99610`](https://github.com/NixOS/nixpkgs/commit/22d99610ac1b7c286b83896620add82c409a7520) python3Packages.ezyrb: 1.3.0.post2212 -> 1.3.0.post2302
* [`4fe7f2fb`](https://github.com/NixOS/nixpkgs/commit/4fe7f2fbbc829989cc34399959ff418c0277a2b9) python3Packages.fabric: 2.7.1 -> 3.0.0
* [`6e091eb4`](https://github.com/NixOS/nixpkgs/commit/6e091eb459a15474165f9475f7dfdc90f487cc5b) python3Packages.faker: 15.3.4 -> 17.3.0
* [`8f0a50bb`](https://github.com/NixOS/nixpkgs/commit/8f0a50bb60b46087c61cc54f3951c05aa3325105) python3Packages.fastapi: 0.88.0 -> 0.92.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
