### PR TITLE
niv devenv: update b97ca4bd -> 71f5c3c4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b97ca4bd581f0e2fb620f301cc417791f655f851",
-        "sha256": "192xn5lplq2anjc177ffq40j6zasm88diq825rlci5pac140hrfr",
+        "rev": "71f5c3c4344c9ef3d065de85386b5481c8f26abb",
+        "sha256": "1qn17rpha3is24jvxj6x60f51razlcp8agmj25j0067abib43ydx",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/b97ca4bd581f0e2fb620f301cc417791f655f851.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/71f5c3c4344c9ef3d065de85386b5481c8f26abb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@b97ca4bd...71f5c3c4](https://github.com/cachix/devenv/compare/b97ca4bd581f0e2fb620f301cc417791f655f851...71f5c3c4344c9ef3d065de85386b5481c8f26abb)

* [`28a4cf56`](https://github.com/cachix/devenv/commit/28a4cf56df69ae1ce2c95685c5a829cad17bd0db) refactor(dotnet): add package option and needed environment variables
* [`56ac2cbd`](https://github.com/cachix/devenv/commit/56ac2cbd24e7326a3bf1358ae03b9bf1929d8dae) use miliseconds when creating shell in case we launch two
* [`3f51664d`](https://github.com/cachix/devenv/commit/3f51664de1c04c558f8e4fdb6fa4b1115f5602f6) bump deps
* [`dae3c88a`](https://github.com/cachix/devenv/commit/dae3c88a5343d682efe2f9e725c3070d6fad9ad4) docs: clarify the defaults around GC
* [`82786d75`](https://github.com/cachix/devenv/commit/82786d75ac928b4a2b9ca485d07e55d46d918cfe) haskell: add package and haskell-language-server
* [`46a8de34`](https://github.com/cachix/devenv/commit/46a8de341cbc9bafce1886ded2b60aa976a242cc) Auto generate docs/reference/options.md
* [`eb1e3624`](https://github.com/cachix/devenv/commit/eb1e36249d0abf16726b8ac43442ef80bb2935fc) Fix two errors in Rosetta pattern
* [`bad196f4`](https://github.com/cachix/devenv/commit/bad196f49284da359671a7dbe57d71a65ffcc31d) flake.nix: Add lib.mkEval
* [`0fb39a64`](https://github.com/cachix/devenv/commit/0fb39a640bacf50f1435407cddd2f4669418f540) flake.nix: Add flakeModule
* [`4151b00c`](https://github.com/cachix/devenv/commit/4151b00c24e438b6b26e14be230109a577bad3ea) Don't shadow the flake devenv shim
* [`616b216a`](https://github.com/cachix/devenv/commit/616b216a1395adb76698caab3cecacfe17c622bd) flakeModule: Expose the containers as packages
* [`a285b5f9`](https://github.com/cachix/devenv/commit/a285b5f954b7c6ff9a2710a176a137975af9ada7) doc: add guide for flake.parts
* [`a9fbb6fd`](https://github.com/cachix/devenv/commit/a9fbb6fd9bdf3ad23dd64ebe443a7dc3b614648d) Auto generate docs/reference/options.md
* [`7d6c1b54`](https://github.com/cachix/devenv/commit/7d6c1b544209cfb7f849ef4435a2abb01a7b3a76) fix: improve mysql escaping
* [`4c09ade4`](https://github.com/cachix/devenv/commit/4c09ade404eaae55b5fd8dcc00604fcc0d1de7dd) build: update to 2.2.1
* [`0798695d`](https://github.com/cachix/devenv/commit/0798695d612aeaeb4c80bfac983e6b0ac165d7b7) feat(module): add varnish
* [`71f5c3c4`](https://github.com/cachix/devenv/commit/71f5c3c4344c9ef3d065de85386b5481c8f26abb) Auto generate docs/reference/options.md
