### PR TITLE
niv doomemacs: update 63586423 -> ce6be8c1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "63586423dab6248d6e5acfc68dc4324c15f05d83",
-        "sha256": "02czkc8vzr5jzgap79qpnxr823skd2ndw6x88m5rc4g63fsgdvr1",
+        "rev": "ce6be8c1b177551231979a9eaa949bf83a601885",
+        "sha256": "064ffwy4pc98lp9kdwm30n8x7lz571yvsmkby37q3z9c7wfkc430",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/63586423dab6248d6e5acfc68dc4324c15f05d83.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/ce6be8c1b177551231979a9eaa949bf83a601885.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@63586423...ce6be8c1](https://github.com/doomemacs/doomemacs/compare/63586423dab6248d6e5acfc68dc4324c15f05d83...ce6be8c1b177551231979a9eaa949bf83a601885)

* [`61b799d0`](https://github.com/doomemacs/doomemacs/commit/61b799d0620fbf293107ba602c39f45c2031768a) fix: s/permanant-local/permanent-local
* [`d1141b14`](https://github.com/doomemacs/doomemacs/commit/d1141b14c15c46914551387560722269fac19d05) fix(org): org-flag -> org-fold, add spec argument
* [`bb60f5f6`](https://github.com/doomemacs/doomemacs/commit/bb60f5f6bc64d21c0e5f19b8e5a576d8479474e2) feat(common-lisp): add project loading and testing commands
* [`b66ad770`](https://github.com/doomemacs/doomemacs/commit/b66ad7703134d8a91e8ae1fab84af3bb90fcca03) feat(elm): add bindings for project compilation
* [`9d6a7b7d`](https://github.com/doomemacs/doomemacs/commit/9d6a7b7d4b52370eb6f3ede3171d3361d1f3ab1f) fix(clojure): load against the correct package
* [`e1c962cd`](https://github.com/doomemacs/doomemacs/commit/e1c962cdf9783d83602760170322b390d8d0e9fa) fix(parinfer): activate for `fennel-mode`
* [`22097b5a`](https://github.com/doomemacs/doomemacs/commit/22097b5a755a5b1d661e362a8441b61e37f777c9) fix(company): hook company-abort when +childframe enabled
* [`65b28350`](https://github.com/doomemacs/doomemacs/commit/65b283501a33c1c75ca9a9eac6e8a8098ee7f69c) docs(cli): assume ~/.config/emacs by default
* [`2764b6c2`](https://github.com/doomemacs/doomemacs/commit/2764b6c2824767e23373435f6a07c8f79db87a1a) bump: :lang ruby
* [`d883863b`](https://github.com/doomemacs/doomemacs/commit/d883863b91be123dec51a3b701a1381c286c9402) bump: :checkers spell
* [`0ecf69af`](https://github.com/doomemacs/doomemacs/commit/0ecf69afafabb58546fa4a727ff6fab3b586fd0c) fix(cli): increment __DOOMSTEP in elisp instead
* [`382058e1`](https://github.com/doomemacs/doomemacs/commit/382058e1e66014a9bb3d36579b2c116e26ed2107) fix(debug): doom-info: improve git error
* [`1af08011`](https://github.com/doomemacs/doomemacs/commit/1af08011df5944b393158d5e1311be928ae8b57f) fix(lib): doom/help-modules: omit nil in module list
* [`c157c39f`](https://github.com/doomemacs/doomemacs/commit/c157c39f4ac1126b40f14d4f7c42dc3eb95abb57) tweak(lookup): add internet archive & doom providers
* [`db2534aa`](https://github.com/doomemacs/doomemacs/commit/db2534aa2978e69a432f822b287e6148c49e8d75) fix(cli): convert __DOOMSTEP to string
* [`ce6be8c1`](https://github.com/doomemacs/doomemacs/commit/ce6be8c1b177551231979a9eaa949bf83a601885) fix(mu4e): Do not shadow `mu4e` arguments
