### PR TITLE
niv nixpkgs: update fc8a1965 -> fd5d1c8e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fc8a1965d0aefd9d329adc6f4b6ac7e613d3b4cc",
-        "sha256": "1kd5g5lq3z5w7a9vd02vixach3qxjr8zvc2nd3vkm08anxwbc9c8",
+        "rev": "d241b99697eedd2caa1a6685cb76a0cbbd7054ee",
+        "sha256": "1qrx0ifxyvd9v98gsbwhf891rlk9jiv89j9jrfbs40csmwy7xhag",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/fc8a1965d0aefd9d329adc6f4b6ac7e613d3b4cc.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d241b99697eedd2caa1a6685cb76a0cbbd7054ee.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@fc8a1965...d241b996](https://github.com/nixos/nixpkgs/compare/fc8a1965d0aefd9d329adc6f4b6ac7e613d3b4cc...d241b99697eedd2caa1a6685cb76a0cbbd7054ee)

* [`41bb8eb3`](https://github.com/NixOS/nixpkgs/commit/41bb8eb30644c4a69156e914fb888916c88f6e81) leftwm: fix to also patchelf lefthk-worker
* [`a9f7dd99`](https://github.com/NixOS/nixpkgs/commit/a9f7dd99638c82035ac3703256cca1a336f0def0) or-tools: add darwin support
* [`9bfd85bf`](https://github.com/NixOS/nixpkgs/commit/9bfd85bf3373b9481b03c6d9178bc0df2d8b2b2d) prepare v0.6.2
* [`1c13a261`](https://github.com/NixOS/nixpkgs/commit/1c13a261cf0d29e5fe20e39d83ce7c5509cde4fe) stuntrally: 2.6.2 -> 2.7
* [`59296fbb`](https://github.com/NixOS/nixpkgs/commit/59296fbbc36a51892dbe03f5663ee92de20dd494) Assert that fish configuration is enabled if any user has fish as their shell.
* [`631b7f6f`](https://github.com/NixOS/nixpkgs/commit/631b7f6f882b05c2a5c35f088bfdd99ebbcbf1f3) Add support for the other shells
* [`9b3b562f`](https://github.com/NixOS/nixpkgs/commit/9b3b562ff59257ad5deb8b4a7f4d399f0029ebdd) patchelfStable: 0.15.0 -> 0.17.2
* [`0a8e692d`](https://github.com/NixOS/nixpkgs/commit/0a8e692d29816ecd06e3e25034a0b52fe037ceb0) stdenv: show supported and requested platforms when check meta fails
* [`7a7ff877`](https://github.com/NixOS/nixpkgs/commit/7a7ff877b78e4f602a3aa8d3704bfd68caefb5de) nixos/podman: remove unused mkMerge
* [`42d3c208`](https://github.com/NixOS/nixpkgs/commit/42d3c2083fe985218c004f9bbb96382d995df0da) bump v0.7.0
* [`7d403873`](https://github.com/NixOS/nixpkgs/commit/7d403873242bd14be9ebda1c4f821615fe5f372d) himalaya: adjust todo comment about cargo test flags
* [`4ee9acb3`](https://github.com/NixOS/nixpkgs/commit/4ee9acb309665a7bf7661c596b33aff74286638a) python310Packages.etcd: cleanup patchPhase overwrite, update meta
* [`12db8314`](https://github.com/NixOS/nixpkgs/commit/12db8314d734f9fbb2dc58dfe73c1b3410599b29) fail2ban: 0.11.2 -> 1.0.2
* [`4fe7937e`](https://github.com/NixOS/nixpkgs/commit/4fe7937e96510ce0f2a7252ff73e3d3143f6c0ee) himalaya: bump v0.7.1
* [`c4c6a608`](https://github.com/NixOS/nixpkgs/commit/c4c6a6082b47203dba648ffc02e1aa1c4f2a7188) make himalaya-vim derivation use versions to reduce breaking changes
* [`f645f1ce`](https://github.com/NixOS/nixpkgs/commit/f645f1ce98ac0ebdb63b1efd194dee21393f00a7) himalaya: revert formatting
* [`c714a76c`](https://github.com/NixOS/nixpkgs/commit/c714a76c0427262fdc99b2d0dfd0b1509178128f) chromium: fix vulkan linking
* [`06d21e86`](https://github.com/NixOS/nixpkgs/commit/06d21e8659ddb58ee1bcde88610ad7f3a2a7e2f4) himalaya: add args to manage cargo features
* [`bb55ac4f`](https://github.com/NixOS/nixpkgs/commit/bb55ac4f61480e4b8fa9e8117671e82a47e580c9) badwolf: init at 1.2.2
* [`69978dcb`](https://github.com/NixOS/nixpkgs/commit/69978dcb2ac037329999747b9105b91031b30084) remove useless cargo test flags
* [`2a1b1ea1`](https://github.com/NixOS/nixpkgs/commit/2a1b1ea1d6b5645f85b0fbef8294c52f79e45776) noisetorch: 0.12.0 -> 0.12.2, remove meta.{insecure,knownVulnerabilities}
* [`9b2e2e80`](https://github.com/NixOS/nixpkgs/commit/9b2e2e8006fc478050f7e6fcd5797d38bd8e07f1) nixos/yggdrasil: nixpkgs-fmt
* [`78ac8123`](https://github.com/NixOS/nixpkgs/commit/78ac8123569ae95e5967137d7fb97049b03ad69c) nixos/yggdrasil: fix configFile option
* [`cf8b1fb8`](https://github.com/NixOS/nixpkgs/commit/cf8b1fb85ecf75b836b881dc5a50dd1f88926d2a) nixos/yggdrasil: support HJSON files as configFile
* [`8bc615d0`](https://github.com/NixOS/nixpkgs/commit/8bc615d0e089f302f787a115f907105a367f0300) nixos/yggdrasil: correct documentation
* [`87ffe8dd`](https://github.com/NixOS/nixpkgs/commit/87ffe8dd8836dd3fb388a920be3657ce87070ee7) Allow overriding features
* [`5e5a84b1`](https://github.com/NixOS/nixpkgs/commit/5e5a84b193f66427d215fd1af2b2fd2400a5c84c) nixos/nginx: add recommendedZstdSettings
* [`e31461ff`](https://github.com/NixOS/nixpkgs/commit/e31461fff1d71e13ed5749b810dd5bac28fbf9d2) nginx.modules.zstd: init
* [`e2822bee`](https://github.com/NixOS/nixpkgs/commit/e2822bee39d39e1409731d9763de54f5056a33ac) libcef: 100.0.24 -> 110.0.27
* [`6323dc43`](https://github.com/NixOS/nixpkgs/commit/6323dc433f93741ba1ab8e927320638627fd540b) rubygems: 3.3.20 -> 3.4.7
* [`2f227890`](https://github.com/NixOS/nixpkgs/commit/2f22789063096c2690c3310f487f3a799ed09f87) rvm-patchsets: drop
* [`52ffebb7`](https://github.com/NixOS/nixpkgs/commit/52ffebb7a7a6fb1ad2d64e8099451d0cbb281e68) ruby: add strictDeps
* [`fec0d779`](https://github.com/NixOS/nixpkgs/commit/fec0d7798d3016e6b6abff542eaeb8c9013829cc) ruby_3_1: 3.1.2 -> 3.1.3
* [`0ce320c9`](https://github.com/NixOS/nixpkgs/commit/0ce320c93328bd400a9727bd8c643fc8adff1997) ruby_3_2: init at 3.2.1
* [`188e51d0`](https://github.com/NixOS/nixpkgs/commit/188e51d08cea930f3f7956167f22e36255f941e8) ruby_3_2: build with YJIT support by default
* [`c3547bc6`](https://github.com/NixOS/nixpkgs/commit/c3547bc6ebce55124a5c9a53c81686efbdd7a957) gcc/{11,12}: update buildFlags for `--disable-bootstrap` case
* [`71abb2c0`](https://github.com/NixOS/nixpkgs/commit/71abb2c0854a20dc68c31e818b7be781cf365cc8) multiple-outputs.sh: Allow `var` as an output name
* [`6e91cb04`](https://github.com/NixOS/nixpkgs/commit/6e91cb046e210ff2a33ba3f8b597050c350a5301) multiple-outputs.sh: Do not leak `_var` variable from _assignFirst
* [`c8b70482`](https://github.com/NixOS/nixpkgs/commit/c8b7048233f84c62ece9212888578f16a93ad1b3) multiple-outputs.sh: Make _assignFirst message more accurate
* [`69cf5181`](https://github.com/NixOS/nixpkgs/commit/69cf5181c31c691e9fb225ada9a33f54208d914b) stdenv/generic/setup.sh: enable parallel installs by default
* [`8a99bbab`](https://github.com/NixOS/nixpkgs/commit/8a99bbab4478b1a3ecb21916b856ea0955fc7449) net-snmp: disable install parallelism
* [`0026b4a0`](https://github.com/NixOS/nixpkgs/commit/0026b4a08718af34f59e90ffc3257960e27a3f7e) xfsprogs: disable install parallelism
* [`82c5a2b6`](https://github.com/NixOS/nixpkgs/commit/82c5a2b62eed1ab585eeb2694b6327ccf09c423b) sssd: disable parallel installs
* [`060baa5e`](https://github.com/NixOS/nixpkgs/commit/060baa5e1c412201f0ac0748021c794deb5788ac) libre: enableParallelBuilding=true
* [`258e046c`](https://github.com/NixOS/nixpkgs/commit/258e046c4279b09c5fa6601ff6091b302362a417) librem: enableParallelBuilding=true
* [`4fff5905`](https://github.com/NixOS/nixpkgs/commit/4fff590562e9c767493eedcae18b5219e716da4c) baresip: enableParallelBuilding=true
* [`1682265d`](https://github.com/NixOS/nixpkgs/commit/1682265db7feb0720277802902a85b6fcca27e2c) baresip: use cmake for configurePhase, fixes cross
* [`1320cb81`](https://github.com/NixOS/nixpkgs/commit/1320cb8157dff844e102106e727588fdd6e1fa20) tdesktop: add patch to disable custom URL scheme registration
* [`0eff3677`](https://github.com/NixOS/nixpkgs/commit/0eff36777f31547b0e857bfcfded8295f729442d) catch2_3: 3.3.1 -> 3.3.2
* [`3193ea68`](https://github.com/NixOS/nixpkgs/commit/3193ea682eb5251691220f2d6dade6d48fc2043b) openblas: Fix include path in generated .pc file
* [`86053e5e`](https://github.com/NixOS/nixpkgs/commit/86053e5ec2c1ed023e543cf753922a989055fc1c) dgraph: use --prefix to prefix PATH 
* [`3a449d02`](https://github.com/NixOS/nixpkgs/commit/3a449d02b9551a8fd1c7b7e64e479db89df6d8f1) lingot: Add fftwFloat for faster fft
* [`6e422a0f`](https://github.com/NixOS/nixpkgs/commit/6e422a0fbaca1d8be112f606edcf8a48fbe0eb2f) tests.stdenv.outputs-no-out: cause less rebuilds
* [`a4e1cf6d`](https://github.com/NixOS/nixpkgs/commit/a4e1cf6d13004d19957bbecdf0d3940d4708460d) tests.stdenv.outputs-no-out: update expectedMsg
* [`ea80b392`](https://github.com/NixOS/nixpkgs/commit/ea80b3925f202dc49d258d07838ff813779824d9) subversion: disable parallel installs
* [`7b8d8627`](https://github.com/NixOS/nixpkgs/commit/7b8d86277d08ddaf071eb54c9b6c5d94531b02be) ocaml: disable parallel installs
* [`dfc95e08`](https://github.com/NixOS/nixpkgs/commit/dfc95e08f5c0376a896741327afc4f6dab8647e7) libwpe: 1.14.0 -> 1.14.1
* [`51b39d7b`](https://github.com/NixOS/nixpkgs/commit/51b39d7b8b6ea9a4faecf761ad692114f19294b5) eresi: disable parallel installs
* [`915a1920`](https://github.com/NixOS/nixpkgs/commit/915a1920232aa1447d2804e3f04c91e933d680b1) ncurses: enable strictDeps
* [`2c8cfc60`](https://github.com/NixOS/nixpkgs/commit/2c8cfc60c63b5f3a27d8f141020fa36f46e83d56) readline: enable strictDeps
* [`92b9dce6`](https://github.com/NixOS/nixpkgs/commit/92b9dce61b89475164f82f5fa070afd409a9294d) tracker: enable strictDeps
* [`78367e1b`](https://github.com/NixOS/nixpkgs/commit/78367e1bffa0fe7d60472d5367b65cc1e3bfeda8) networkmanager: 1.40.12 -> 1.40.16
* [`9c72ea87`](https://github.com/NixOS/nixpkgs/commit/9c72ea872567c9d92ed0cad1be88726f3e461f97) multiple-outputs.sh: silence 'rmdir: failed to remove ... Directory not empty'
* [`b3d8d75d`](https://github.com/NixOS/nixpkgs/commit/b3d8d75db86efe821d80f86d986d3c7808fa11aa) s9fes: disable install parallelism
* [`f37d97b7`](https://github.com/NixOS/nixpkgs/commit/f37d97b7a09ba749617ba6a7b0342712554e0bf4) libbacktrace: clean up
* [`9cc45e19`](https://github.com/NixOS/nixpkgs/commit/9cc45e195f4ea9d972bd7dd1dae904a32c365bfc) libbacktrace: unstable-2020-05-13 → unstable-2022-12-16
* [`14c5fae1`](https://github.com/NixOS/nixpkgs/commit/14c5fae1cbde7f4eddb95bccf4535b211963217e) libbacktrace: Enable tests
* [`1e038482`](https://github.com/NixOS/nixpkgs/commit/1e0384829d14e4eb186dc71f9b6df249508a9df1) libbacktrace: Add support for NIX_DEBUG_INFO_DIRS
* [`d3b862c4`](https://github.com/NixOS/nixpkgs/commit/d3b862c457039208bd98f61cf6730dd87c0fee36) libpcap: 1.10.1 -> 1.10.3
* [`b6388ae3`](https://github.com/NixOS/nixpkgs/commit/b6388ae3ee77d7fd38dbcba94414fd735a9292e6) lutris: Include libnghttp2 in the FHS.
* [`575fddf2`](https://github.com/NixOS/nixpkgs/commit/575fddf25b672b8ed5d5294ab10a8a22d579bc3b) systemd: 252.5 -> 253
* [`f7ce1d22`](https://github.com/NixOS/nixpkgs/commit/f7ce1d22ebbeeff8784fbdff8d5dd52454fd917a) systemd: 253 -> 253.1
* [`d2837a9c`](https://github.com/NixOS/nixpkgs/commit/d2837a9cb3d11187e12db193becffe4cb7c8d1ad) nixos/systemd-initrd: create the /tmp mount point in the initrd
* [`9b8a0e5f`](https://github.com/NixOS/nixpkgs/commit/9b8a0e5f7ae4bed2b39d0595a2defef1edd8bcb0) python3.pkgs.pynacl: build offline documentation
* [`c541bf5e`](https://github.com/NixOS/nixpkgs/commit/c541bf5ee65f8d6ca44f43b2f361df8e17ca44fc) networkmanager: 1.40.16 -> 1.42.2
* [`764dd10a`](https://github.com/NixOS/nixpkgs/commit/764dd10ac0d7700d065571c438953a12aea84cf3) iproute2: 6.1.0 -> 6.2.0
* [`9c64da6e`](https://github.com/NixOS/nixpkgs/commit/9c64da6ed40c9de48c17d4742318e2389e276126) modemmanager: 1.20.4 -> 1.20.6
* [`83f65146`](https://github.com/NixOS/nixpkgs/commit/83f65146ab1d5d55548d1dbe87a93d9ee8081ee0) nixos/systemd: systemd-growfs* units are real files now
* [`18b4f46c`](https://github.com/NixOS/nixpkgs/commit/18b4f46cb6f84092e0a19264e30b0f83c7c73129) bundler: 2.4.6 -> 2.4.7
* [`7df4387e`](https://github.com/NixOS/nixpkgs/commit/7df4387ebdc9f5293fad04480391e8743c312a3b) gcc: do not install sys-include headers for cross-compilers.
* [`c68f2c93`](https://github.com/NixOS/nixpkgs/commit/c68f2c937a2aedbc182bab4c9dbbdc8830256f62) libopenmpt: 0.6.8 -> 0.6.9
* [`740ab712`](https://github.com/NixOS/nixpkgs/commit/740ab71253c1e052422925355252654078848e94) liburcu: 0.13.2 -> 0.14.0
* [`4a3699c0`](https://github.com/NixOS/nixpkgs/commit/4a3699c08b5184eaf6576e3de105e66d68fcd252) cargo-auditable: 0.6.0 -> 0.6.1
* [`aaa11f72`](https://github.com/NixOS/nixpkgs/commit/aaa11f72106e7c8bc5716f813bf5f96a8421a9ea) ruby: add rubygems to expression passthru
* [`708dcbce`](https://github.com/NixOS/nixpkgs/commit/708dcbce926fdfb40a08ff625148fe11b6fe601d) nodejs-18_x: 18.14.2 -> 18.15.0
* [`35d43b45`](https://github.com/NixOS/nixpkgs/commit/35d43b45f7419c6db6f6aa49e9da376befd31606) ruby.rubygems: 3.4.7 -> 3.4.8
* [`7590ada9`](https://github.com/NixOS/nixpkgs/commit/7590ada96f561c77b9c5b9e564ab684b9eb34d97) liburcu: add changelog to meta
* [`49000d52`](https://github.com/NixOS/nixpkgs/commit/49000d52e01fd1caf6490f8148bd270c3563a4f9) vpnc: disable install parallelism
* [`af189bd3`](https://github.com/NixOS/nixpkgs/commit/af189bd3de5da15b5fc0baf23c84aacd7192a848) spandsp: fix cross compilation
* [`6b0e0967`](https://github.com/NixOS/nixpkgs/commit/6b0e09670d4b0edb7ac3d24503a2a9a5a081dc5a) https://github.com/NixOS/nixpkgs/pull/218477#discussion_r1118125573
* [`8a05f77b`](https://github.com/NixOS/nixpkgs/commit/8a05f77b5d4d8422624828f9744daee1b9b213d4) https://github.com/NixOS/nixpkgs/pull/217995#pullrequestreview-1318620540
* [`1e5a594e`](https://github.com/NixOS/nixpkgs/commit/1e5a594e686f5154b706dfab68550f9f3bde675e) spandsp: enableParallelBuilding = true
* [`d6619542`](https://github.com/NixOS/nixpkgs/commit/d6619542978324e80eb949721f4749955034540a) outline: 0.67.2 -> 0.68.1
* [`3e5f408e`](https://github.com/NixOS/nixpkgs/commit/3e5f408e735ad492319e72a158f5815523fc7adf) isabelle: add aarch64-linux support
* [`0070f29a`](https://github.com/NixOS/nixpkgs/commit/0070f29a1327858c5ca976f341496b86597e5c2d) dnsmasq: 2.88 -> 2.89
* [`38daa6bb`](https://github.com/NixOS/nixpkgs/commit/38daa6bb44d8f9a3d1442c9f334ae5a38c6c86d8) python3Packages.appnope: Make available on non-Darwin, styling, update homepage
* [`9eb7621c`](https://github.com/NixOS/nixpkgs/commit/9eb7621cbb8d0ae7a140c9516f99c6cbdc844095) libmbim: 1.28.2 -> 1.28.4
* [`a8da8df2`](https://github.com/NixOS/nixpkgs/commit/a8da8df295b9468f2ab34bf237b70ab49cd61e64) libmbim: add changelog to meta
* [`fe201024`](https://github.com/NixOS/nixpkgs/commit/fe201024e97fd7e5a852373e5a950883947217bc) systemd: make libidn2 optional
* [`d37221dd`](https://github.com/NixOS/nixpkgs/commit/d37221dd4b2b8497d3144b0313e9c1ca25df50bb) systemd: make libacl optional
* [`86aff5f3`](https://github.com/NixOS/nixpkgs/commit/86aff5f32fe9cb44730d839c168af6c5b0b317ed) systemd: make libaudit optional
* [`2d17a968`](https://github.com/NixOS/nixpkgs/commit/2d17a968053a968667457f06971577fe002385c0) systemd: make PAM integration optional
* [`3be2b599`](https://github.com/NixOS/nixpkgs/commit/3be2b599651b3d7ed39ec52df25915a9b7a39218) systemd: optional kmod integration
* [`38bdc13b`](https://github.com/NixOS/nixpkgs/commit/38bdc13b6dae2c99a83f389639fee44bf2d3e766) systemd: disable dependencies for minimal build
* [`2d29fbd4`](https://github.com/NixOS/nixpkgs/commit/2d29fbd4b6ec03b53d63dc126ce27f7e45e083bf) sphinx-rtd-theme: fix missing docutils for cross compilation
* [`2b168ba3`](https://github.com/NixOS/nixpkgs/commit/2b168ba3f064beeb908031bb765a33b806d6c77f) headscale: rename oidc.client_secret_file to oidc.client_secret_path
* [`dbdebe12`](https://github.com/NixOS/nixpkgs/commit/dbdebe125f049c0baf844e09fb57497ddf3d7084) pandoc: remove reference to warp
* [`c0c01af3`](https://github.com/NixOS/nixpkgs/commit/c0c01af367f0c8962b3bad15f5557eb34b2a25fd) consul: 1.15.0 -> 1.15.1
* [`98ebcd28`](https://github.com/NixOS/nixpkgs/commit/98ebcd28e1235ddb4ee127a8e96310e554afdc13) compiler-rt: fix build on ARMv6
* [`8fc5d9f3`](https://github.com/NixOS/nixpkgs/commit/8fc5d9f3b06fa0890d212edd57ebc15af8d4b8bb) python310Packages.more-itertools: 9.0.0 -> 9.1.0
* [`aa0d89d5`](https://github.com/NixOS/nixpkgs/commit/aa0d89d55ab2b26974d338c98848db3577bca903) lcms2: 2.13.1 -> 2.15
* [`68cd5bdc`](https://github.com/NixOS/nixpkgs/commit/68cd5bdc83d0e2c77895a1e6747e0db6cc291019) systemdStage1: disable PAM
* [`57ecdd6a`](https://github.com/NixOS/nixpkgs/commit/57ecdd6abdcb5bfc250785b2640ec943104e0401) ruby: fix cross compilation
* [`e5b072ec`](https://github.com/NixOS/nixpkgs/commit/e5b072eca165430efc4d7a179011a42aab4470a2) nixos/iso-image: add an option to disable BIOS boot
* [`905be9f8`](https://github.com/NixOS/nixpkgs/commit/905be9f8c5d0bcc95dbd26f9d5a53f61c48d9798) nixos/iso-image: s/efi/EFI in documentation
* [`61516301`](https://github.com/NixOS/nixpkgs/commit/61516301fd4f96373b02655a912bea0e09c8f70a) python310Packages.nextcloudmonitor: 1.2.0 -> 1.3.0
* [`a16f3e6b`](https://github.com/NixOS/nixpkgs/commit/a16f3e6b3801ee0531497b3991d33860bb56487b) cmake: 3.25.2 -> 3.25.3
* [`04cc3ff7`](https://github.com/NixOS/nixpkgs/commit/04cc3ff7d334fe5f064071e05990949e11f8aa88) asymptote: disable install parallelism
* [`03be09d5`](https://github.com/NixOS/nixpkgs/commit/03be09d5181b43ffcf0c6085d795d9fad3d5f515) gretl: disable install parallelism
* [`41ddcc38`](https://github.com/NixOS/nixpkgs/commit/41ddcc3898962edda8e49032d235d7edc47e31ee) qsynth: disable install parallelism
* [`91e20f10`](https://github.com/NixOS/nixpkgs/commit/91e20f108149be118c166eed2a4db44ca124d05b) solanum: disable install parallelism
* [`ed1bc2f7`](https://github.com/NixOS/nixpkgs/commit/ed1bc2f7b726183a07fb67106f47fb218f01d9e0) libimagequant: 4.1.0 -> 4.1.1
* [`88cbe74d`](https://github.com/NixOS/nixpkgs/commit/88cbe74d05cac6e037e934ee7fbe8b1f0d164f25) spandsp: refactor
* [`b27cf6ac`](https://github.com/NixOS/nixpkgs/commit/b27cf6ace4e687b073d05a8f397a9c944e5ee967) llvm_14,llvmPackages_git.llvm: enable polly by default
* [`c5f75817`](https://github.com/NixOS/nixpkgs/commit/c5f758174b1cd78402dbf32511c4b9532a4bc1ae) clang: drop the C++ std version `-DCMAKE_CXX_FLAG`
* [`c1a2a95a`](https://github.com/NixOS/nixpkgs/commit/c1a2a95aacd4a5c4b5fd278b31977b09d758b259) ruby_3_1,ruby_3_0,ruby_2_7: allow enabling dtrace support on linux
* [`3816765e`](https://github.com/NixOS/nixpkgs/commit/3816765e472a98482e26d0831a84d3b27cb56db8) llvm: add in a missing check dep
* [`0fd04a59`](https://github.com/NixOS/nixpkgs/commit/0fd04a591802cb92a244528eb1c65d68417df55d) llvmPackages.compiler-rt: enable libclang_rt.profile-....a build
* [`a6e176c5`](https://github.com/NixOS/nixpkgs/commit/a6e176c5b2ec099739a23ff9fe3df3e34e2c1a77) ArchiSteamFarm: choose correct framework instead of patching
* [`d23059ce`](https://github.com/NixOS/nixpkgs/commit/d23059ce150f9dc4fbb1694bbcf1ef7199c1cc40) bundler: 2.4.7 -> 2.4.8
* [`925510b3`](https://github.com/NixOS/nixpkgs/commit/925510b397b2fa27d44109ac4704a9a354e34e79) w3m: 0.5.3+git20220429 -> 0.5.3+git20230121
* [`65da8d4f`](https://github.com/NixOS/nixpkgs/commit/65da8d4f29157068df5da784b3d39158bdb6495f) nix: dedupe fix-requires-non-existing-output patch
* [`adafbeff`](https://github.com/NixOS/nixpkgs/commit/adafbeff4ad01e21b9d1b39f072298978c08aa6c) nixos/restic: generalize cache configuration
* [`279a5e27`](https://github.com/NixOS/nixpkgs/commit/279a5e27d0a5fbe61e1dd30c3658408fb93732ae) python3Packages.myst-parser: 0.19.1 -> 1.0.0
* [`8e8be880`](https://github.com/NixOS/nixpkgs/commit/8e8be88067fc568d81f88ad6a93fd03218d9ca60) SDL2: 2.26.3 -> 2.26.4
* [`490e77ce`](https://github.com/NixOS/nixpkgs/commit/490e77ce0aca322268bd64c3508e26be2fc784f1) SDL2: add superherointj as maintainer
* [`4ffa52eb`](https://github.com/NixOS/nixpkgs/commit/4ffa52ebdf80bb217929ab94148a8021d58cb4fa) llvmPackages_git.libcxx: use clang from git instead of the stdenv's compiler
* [`011c454a`](https://github.com/NixOS/nixpkgs/commit/011c454a6d55e729b59532fa93109596d3fe9721) libedit: 20210910-3.1 -> 20221030-3.1
* [`2d2aa463`](https://github.com/NixOS/nixpkgs/commit/2d2aa463ddfa74f12e8982e9febcdb1972b7a99c) build-rust-package: call sysroot/src with the expected lib parameter
* [`87837a5f`](https://github.com/NixOS/nixpkgs/commit/87837a5fcf7dd9c58bb80f15a8f046a2abc8a4c8) build-support/rust/sysroot: update Cargo.lock
* [`63c8961f`](https://github.com/NixOS/nixpkgs/commit/63c8961f8b144ca40314909330f7759d1fa7e530) build-support/rust/sysroot: let cargo-src crate become no_std
* [`9d1aafcd`](https://github.com/NixOS/nixpkgs/commit/9d1aafcdeb074c5ad8b6780f9474f9cced901388) build-support/rust: allow cross-compiling the sysroot
* [`94c7bf57`](https://github.com/NixOS/nixpkgs/commit/94c7bf576a44829a676fb172bfceaefff4eb90f0) separate-debug-info.sh: succeed when output does not contain elf files
* [`6ab299b3`](https://github.com/NixOS/nixpkgs/commit/6ab299b3a36c656065d92cab3385a29e43404879) openjdk: port to gnumake-4.4.1
* [`544ef313`](https://github.com/NixOS/nixpkgs/commit/544ef3138a7f383a260f421eb7999dd917a0c414) openjdk: port to gnumake-4.4.1
* [`7b53fc52`](https://github.com/NixOS/nixpkgs/commit/7b53fc52419ec55419853c324cfad7d1dfac79ec) openjdk11: port to gnumake-4.4.1
* [`bec77874`](https://github.com/NixOS/nixpkgs/commit/bec778740ca0ccbc57ab7ac171a6423f563f7217) gnumake44: revert "reintrocude older 4.4 version for openjdk"
* [`91dd01a3`](https://github.com/NixOS/nixpkgs/commit/91dd01a3065dbf60df1725681899b02afa444f18) systemd: disable the ukify tool
* [`1f9c5a4a`](https://github.com/NixOS/nixpkgs/commit/1f9c5a4aea27022d0412bce65bb43c293fac1608) metals: 0.11.10 -> 0.11.11
* [`928c8115`](https://github.com/NixOS/nixpkgs/commit/928c8115ba60d54ec36b3f11a364ff81b0ad066c) nixos/starship: add interactiveOnly option
* [`4e300e07`](https://github.com/NixOS/nixpkgs/commit/4e300e071b97e1e3a6ba4d856cc65e5386366f6f) libxcrypt: Build only with strong hashes
* [`0d7cd666`](https://github.com/NixOS/nixpkgs/commit/0d7cd666520621ebb3f2fb0e590064e8621e249e) nixos/users-groups: Update password scheme validation
* [`909f394f`](https://github.com/NixOS/nixpkgs/commit/909f394f28c637a6d5a269d893b77e095b2812eb) pam: Make libxcrypt a non-optional dependency
* [`4472cf44`](https://github.com/NixOS/nixpkgs/commit/4472cf44eba4991e46904c588e07dfe8e6fcceb8) treewide: Make yescrypt the default algorithm for pam_unix.so
* [`8e2e741a`](https://github.com/NixOS/nixpkgs/commit/8e2e741ab5bdea119a34013b1387eb3f281841cb) zsh: set environment variables in zshenv instead of zprofile
* [`051b74fe`](https://github.com/NixOS/nixpkgs/commit/051b74fe7d7398c24fee4d703bd1e32a88b68393) nixos/fcitx: deprecated, and suggestions to use fcitx5 instead
* [`4e8ad00a`](https://github.com/NixOS/nixpkgs/commit/4e8ad00ae81e70f4e4db7dfc7e67d9c853f0d6b6) fcitx: remove packages and update documentations and aliases to fcitx5
* [`6d951523`](https://github.com/NixOS/nixpkgs/commit/6d951523ad424c077d60bcd57e9a53bc9dd56e5d) mlterm: update fcitx dependency to fcitx5
* [`f95c20d7`](https://github.com/NixOS/nixpkgs/commit/f95c20d77d5275a0fe4d2809bbb6e10d5492b93f) nixos/fcitx5: init tests
* [`23f23a89`](https://github.com/NixOS/nixpkgs/commit/23f23a89b325b06e3f7ff6c0a45e06271db49ead) fftw: enable optimizations unconditionally and build with mtune=generic
* [`a9b7d738`](https://github.com/NixOS/nixpkgs/commit/a9b7d738fc1437f8d796607ed31093921685b2b4) Revert "python3Packages.babel: revert test fixes for now"
* [`a8e44411`](https://github.com/NixOS/nixpkgs/commit/a8e44411d65222b0af2ec3d1b641e7f1b82eb87d) sparrow: 1.7.1 -> 1.7.3
* [`eb561a3a`](https://github.com/NixOS/nixpkgs/commit/eb561a3af2ba2c5fc6f9abb6dcf38beb348663ca) sparrow: enable JavaFX
* [`4d8df72e`](https://github.com/NixOS/nixpkgs/commit/4d8df72e93261fd31157b74eb44bf8441f04547c) xmlbeans: 5.0.2-20211014 -> 5.1.1-20220819, remove myself as maintainer
* [`fab17d21`](https://github.com/NixOS/nixpkgs/commit/fab17d210d14e11adba8255cc0767cec0ff9e6b8) gtk2: read configuration from /etc/gtk-2.0/gtkrc
* [`b830681b`](https://github.com/NixOS/nixpkgs/commit/b830681bfbf1058e2893411a3a8e0a448f3f82cf) python310Packages.sqlalchemy: 2.0.4 -> 2.0.6
* [`e4959cfe`](https://github.com/NixOS/nixpkgs/commit/e4959cfe9788ccc641250580d4b26af6e68aed6d) unityhub: 2.3.2 -> 3.4.1
* [`0cf4dddb`](https://github.com/NixOS/nixpkgs/commit/0cf4dddbc0bdc3e79a05818f5afececb7e283aa8) magma: fix [nixos/nixpkgs⁠#220343](https://togithub.com/nixos/nixpkgs/issues/220343) and separate CUDA build/run-time dependencies
* [`711e9cfd`](https://github.com/NixOS/nixpkgs/commit/711e9cfd493296681b84147a650972ea78e948c4) ffmpeg: ffmpeg_4 → ffmpeg_5
* [`9bd25064`](https://github.com/NixOS/nixpkgs/commit/9bd2506458ea053ccbcde6e622d7cec9993d8f36) treewide: make ffmpeg_4-dependant packages depend on ffmpeg_4
* [`f8264a5b`](https://github.com/NixOS/nixpkgs/commit/f8264a5b1e7832d93d8a22816f5133ff891724b6) tree-wide: mark broken packages as such
* [`a3d10c67`](https://github.com/NixOS/nixpkgs/commit/a3d10c676f813f6393e38c4bbe01b640fb791947) sqlite: 3.41.0 -> 3.41.1
* [`107df2f7`](https://github.com/NixOS/nixpkgs/commit/107df2f7c20b5ef6fa5b17ea09f0cbc837f7ca83) s2n-tls: 1.3.37 -> 1.3.38
* [`b0cd9107`](https://github.com/NixOS/nixpkgs/commit/b0cd9107fc036ff503b9556a28150a88bb4bb127) s2n-tls: 1.3.38 -> 1.3.39
* [`3e331bf5`](https://github.com/NixOS/nixpkgs/commit/3e331bf5b3978e68597a320d55712e8f75196dad) directx-headers: 1.608.2 -> 1.608.2b
* [`ef695215`](https://github.com/NixOS/nixpkgs/commit/ef6952158cb5b31d1505f217d9fa0f55e4999120) tinycompress: init at 1.2.8
* [`6ff293ec`](https://github.com/NixOS/nixpkgs/commit/6ff293ecbc181c2339a085ed615d1a50727cc7a3) pipewire: enable compress-offload
* [`b8ac3f9a`](https://github.com/NixOS/nixpkgs/commit/b8ac3f9a93cac7a54aafc366f221b372dd59b463) pipewire: 0.3.66 -> 0.3.67
* [`1fab8692`](https://github.com/NixOS/nixpkgs/commit/1fab86929f7df5cdd60bcf65b4c78f4058777a03) nixos/pipewire: spring cleaning
* [`c3a42a04`](https://github.com/NixOS/nixpkgs/commit/c3a42a047cfe7d645fcf63b8cba04336bf3041ea) snappy: 1.1.9 -> 1.1.10
* [`5eff9f19`](https://github.com/NixOS/nixpkgs/commit/5eff9f19408717e3d330fd0f97961cddf8ac23b6) R: 4.2.2 -> 4.2.3
* [`17ea9488`](https://github.com/NixOS/nixpkgs/commit/17ea94881f78ff37d0123bc67ee82471d6d014ca) octavePackages: add automatic updating script based on Python's
* [`be699cf0`](https://github.com/NixOS/nixpkgs/commit/be699cf06b37f1ec9e5a22b7b3273ea15827d445) octavePackages: run update script on all packages
* [`5b5e4182`](https://github.com/NixOS/nixpkgs/commit/5b5e4182cb24a01eaa5204001284fc6b2eac4ae6) proxysql: 2.5.0 -> 2.5.1
* [`9196dbce`](https://github.com/NixOS/nixpkgs/commit/9196dbce78a73d7cc5a8d1dc4d8b8be72493945d) whatsapp-for-linux: 1.3.1 -> 1.6.1
* [`cc2738c7`](https://github.com/NixOS/nixpkgs/commit/cc2738c71ad454dba35cb8c33c4fce2481e344e7) swift: reduce closure size of swift-lib
* [`39620ace`](https://github.com/NixOS/nixpkgs/commit/39620acea8d86488e8ecb37424643ff94c5ea0a3) vim: 9.0.1369 -> 9.0.1403
* [`60002cab`](https://github.com/NixOS/nixpkgs/commit/60002cabc02d22e8ee3f1718c1217684134d5178) aaaaxy: init at 1.3.372
* [`590ccae1`](https://github.com/NixOS/nixpkgs/commit/590ccae1f848eef59f8984e98348208eb69cffe1) nixos/networkd: add L2TP options
* [`28ddd570`](https://github.com/NixOS/nixpkgs/commit/28ddd570f70dd9fe160260672ebf687abc5f2585) nixos/networkd: add Bridge options
* [`d646f7c7`](https://github.com/NixOS/nixpkgs/commit/d646f7c7f2b69ef4d085f79f7805098b80dc8467) nixos/networkd: add BridgeFDB options
* [`ae15b86d`](https://github.com/NixOS/nixpkgs/commit/ae15b86d4d81ffa3824528f4316c1b5f4ad640d3) nixos/networkd: add BridgeMDB option
* [`a7724b8f`](https://github.com/NixOS/nixpkgs/commit/a7724b8f9177026c4635740812e2b8e291137d0e) nixos/networkd: add LLDP options
* [`df149537`](https://github.com/NixOS/nixpkgs/commit/df14953724481b185161aa16c6e154bc04445eb0) nixos/networkd: add CAN options
* [`09e745c7`](https://github.com/NixOS/nixpkgs/commit/09e745c78405cbd906f8f39cc89376f9f29db1c3) nixos/networkd: add IPoIB options
* [`b08e5be9`](https://github.com/NixOS/nixpkgs/commit/b08e5be98d9eed403a2f334f2459da909114c002) nixos/networkd: add QDisc options
* [`55cd970d`](https://github.com/NixOS/nixpkgs/commit/55cd970d739f6c0cc60f846aa826e05e322b9559) nixos/networkd: add NetworkEmulator options
* [`d6303532`](https://github.com/NixOS/nixpkgs/commit/d63035329e6c7c07bf5cd3c4e06f4b8d2e71653f) nixos/networkd: add TokenBucketFilter options
* [`2784862e`](https://github.com/NixOS/nixpkgs/commit/2784862e410bd07b562e6f537d6ff756fffa66ba) nixos/networkd: add PIE options
* [`872a4823`](https://github.com/NixOS/nixpkgs/commit/872a4823cf3fdaca4d6bc6c13868ffe8a8097026) nixos/networkd: add FlowQueuePIE options
* [`736650cc`](https://github.com/NixOS/nixpkgs/commit/736650ccf144850bc47587de620ae13efc88cb39) nixos/networkd: add StochasticFairBlue options
* [`51689e86`](https://github.com/NixOS/nixpkgs/commit/51689e86b99ca43b14e5aa307b5e453aa0cb7ae3) nixos/networkd: add StochasticFairnessQueueing options
* [`f2ca28f6`](https://github.com/NixOS/nixpkgs/commit/f2ca28f6585a3ecad3032e8057ea606402a86e93) nixos/networkd: add PFIFO options
* [`d9e1963a`](https://github.com/NixOS/nixpkgs/commit/d9e1963a158f38b95a21171a0ed400a2c2575b7a) nixos/networkd: add BFIFO options
* [`f75ec30f`](https://github.com/NixOS/nixpkgs/commit/f75ec30feea0d0e0f1bddcf07cfa89dea795b5d3) nixos/networkd: add PFIFOHeadDrop options
* [`7a6cae0e`](https://github.com/NixOS/nixpkgs/commit/7a6cae0e155ec8952fcaa0add1b6f6d712e8d721) nixos/networkd: add PFIFOFast options
* [`72810855`](https://github.com/NixOS/nixpkgs/commit/728108555e0d21b7fb0d5f4884e7b893e746adb0) nixos/networkd: add CAKE options
* [`49df6bc6`](https://github.com/NixOS/nixpkgs/commit/49df6bc66997d29d1addb0424a898c745082fe40) nixos/networkd: add ControlledDelay options
* [`0d06e859`](https://github.com/NixOS/nixpkgs/commit/0d06e8599699ef5629995a6ce46329baa2f3abad) nixos/networkd: add DeficitRoundRobinScheduler options
* [`3cde7aaa`](https://github.com/NixOS/nixpkgs/commit/3cde7aaa36a3089f7881c9f65e7c37bf65f9177d) nixos/networkd: add DeficitRoundRobinSchedulerClass options
* [`ca496f87`](https://github.com/NixOS/nixpkgs/commit/ca496f87548eb194280d2a3a4489380b94d088eb) nixos/networkd: add EnhancedTransmissionSelection options
* [`5b5c79c6`](https://github.com/NixOS/nixpkgs/commit/5b5c79c6a0c94586cc392a1a476397b44912e820) nixos/networkd: add GenericRandomEarlyDetection options
* [`dbc14e5a`](https://github.com/NixOS/nixpkgs/commit/dbc14e5a441beebc3c01b60f22e1f3cadf2acdad) nixos/networkd: add FairQueueingControlledDelay options
* [`cf470ebd`](https://github.com/NixOS/nixpkgs/commit/cf470ebd88c4b9e8d4b7ae875ffaebbef6b2b02e) nixos/networkd: add FairQueueing options
* [`29e54519`](https://github.com/NixOS/nixpkgs/commit/29e54519636578683070f9c778ac207fedf1e56a) nixos/networkd: add TrivialLinkEqualizer options
* [`24df07c7`](https://github.com/NixOS/nixpkgs/commit/24df07c786d0818731af5a3056b786ba83731dab) nixos/networkd: add HierarchyTokenBucket options
* [`88d99a36`](https://github.com/NixOS/nixpkgs/commit/88d99a36305d9387383baf7eb88c86e02541f703) nixos/networkd: add HierarchyTokenBucketClass options
* [`493ed754`](https://github.com/NixOS/nixpkgs/commit/493ed754187177260848764e3a0c5ea5515984e3) nixos/networkd: add HeavyHitterFilter options
* [`fde806d5`](https://github.com/NixOS/nixpkgs/commit/fde806d5a5b07f98dde0eb03be56814baae1131e) nixos/networkd: add QuickFairQueueing options
* [`cd650b3f`](https://github.com/NixOS/nixpkgs/commit/cd650b3fa303a88e6ab842dd110871b50d0bd9d1) nixos/networkd: add QuickFairQueueingClass options
* [`0ddfb0a5`](https://github.com/NixOS/nixpkgs/commit/0ddfb0a5dfc45a495bf862fe90a630325efecb32) nixos/networkd: add BridgeVLAN options
* [`4ddd5e48`](https://github.com/NixOS/nixpkgs/commit/4ddd5e48b7007128e8abe32fee65e4fdd708ef67) python310Packages.etils: 1.0.0 -> 1.1.0
* [`62501a21`](https://github.com/NixOS/nixpkgs/commit/62501a21e890f9b62cf2095d4ab0601ce7820ec5) python310Packages.testcontainers: fix build
* [`79700ec6`](https://github.com/NixOS/nixpkgs/commit/79700ec6ed926fd1db76fec445d6d6c7d3ea83cf) python310Packages.tables: remove cython from requirements.txt
* [`f6b69b23`](https://github.com/NixOS/nixpkgs/commit/f6b69b23c91ffc05b8a69162a4f68e9625ecca6d) python310Packages.blosc2: remove pytest from runtime-requirements.txt
* [`1c1e0891`](https://github.com/NixOS/nixpkgs/commit/1c1e0891cc5d7a013370f9480a8e99ed501f82f1) python310Packages.scooby: fix build
* [`8dd30155`](https://github.com/NixOS/nixpkgs/commit/8dd301559ab120f96aec2a2a66164bfdb0d5fbed) ruby: disable parallel install
* [`48f48c31`](https://github.com/NixOS/nixpkgs/commit/48f48c3101615e78fc28378ad818291c1ee8252a) mesa: build dri for arm
* [`0c0c6908`](https://github.com/NixOS/nixpkgs/commit/0c0c6908b9ccc81350f86640dc07ad78981431a1) rPackages: CRAN and BioC update
* [`a10887cb`](https://github.com/NixOS/nixpkgs/commit/a10887cb3fd7087c006b91197b6eb2b8730eebeb) rPackages.purrr: patch configure shebang
* [`c4ce6f0b`](https://github.com/NixOS/nixpkgs/commit/c4ce6f0bfa832a242bed666ee49bea164a5d96f9) asls: drop
* [`ef0e4e67`](https://github.com/NixOS/nixpkgs/commit/ef0e4e67ccf4e4838d7eb8a5e42e0b511a15500c) python310Packages.json-stream-rs-tokenizer: 0.4.13 -> 0.4.16
* [`20fe8b28`](https://github.com/NixOS/nixpkgs/commit/20fe8b2871b3d53e3443d8e2a8f661fe0d46f3e9) python310Packages.passlib: libxcrypt related failures also affect linux
* [`a6b712f8`](https://github.com/NixOS/nixpkgs/commit/a6b712f8a4c09071246fe2d8c4def6948d1f61d9) nixos-generate-config: fix invalid sample config
* [`fa52143c`](https://github.com/NixOS/nixpkgs/commit/fa52143cffb35ce6ba5ffdfeaa0fcb2056137885) python3Packages.pdoc: 12.3.1 -> 13.0.0
* [`9a89bf96`](https://github.com/NixOS/nixpkgs/commit/9a89bf966930abf3e05139332b039f6e9dbc34ca) python310Packages.pytest-twisted: 1.13.2 -> 1.14.0
* [`f3347106`](https://github.com/NixOS/nixpkgs/commit/f3347106dd4bf2f4d97e329d7aa12a01babfdb76) lxd: 5.11 -> 5.12
* [`ad33f180`](https://github.com/NixOS/nixpkgs/commit/ad33f1800f2b2352d74ead11af39a0297875071e) rake: 12.3.2 -> 13.0.6
* [`78877052`](https://github.com/NixOS/nixpkgs/commit/78877052dcd5865fa346f345badd230a2eb42fee) jdom: 1.0 -> 2.0.6.1
* [`d2b28763`](https://github.com/NixOS/nixpkgs/commit/d2b2876373efd862748a92c7fe952ffb708dfd3f) xorg.libXvMC: 1.0.12 -> 1.0.13
* [`12a7c7e6`](https://github.com/NixOS/nixpkgs/commit/12a7c7e68b335d2ad7c5514a7622e9aea224eeea) deepin.deepin-shortcut-viewer: init at 5.0.7
* [`17dcb692`](https://github.com/NixOS/nixpkgs/commit/17dcb69237457e78cfb7e2f8a13d99e315ea3f05) python310Packages.twisted: Disable tests using legacy algos from crypt
* [`8668d96c`](https://github.com/NixOS/nixpkgs/commit/8668d96c28e3fbda92eac6dc212b1393ef97d9da) nixos/wireshark: set the correct capabilities
* [`94f0ae85`](https://github.com/NixOS/nixpkgs/commit/94f0ae85e1232261a88bb3509ababe7028d3f232) python310Packages.passlib: Disable tests for unsupported algorithms
* [`3e531b41`](https://github.com/NixOS/nixpkgs/commit/3e531b418e1aa5d60cee4d316334b43cdef5e2e9) firefox-beta-bin-unwrapped: 112.0b2 -> 112.0b3
* [`476d7536`](https://github.com/NixOS/nixpkgs/commit/476d75361354d7a011ead601787fef95eebfeb74) python310Packages.y-py: Fix build on darwin
* [`18c90897`](https://github.com/NixOS/nixpkgs/commit/18c9089744ca00b1b00ff61a02cc43ad259c907e) matrix-synapse.tools.synadm: 0.38 -> 0.40
* [`dc937802`](https://github.com/NixOS/nixpkgs/commit/dc937802ba1d00a0ff9211a73934bd0d788221ef) dnscontrol: 3.27.2 -> 3.28.0
* [`4bdbae5a`](https://github.com/NixOS/nixpkgs/commit/4bdbae5ad13b0c8c98232ebb70a288815ef5f012) cc-wrapper: wrap `cpp` for cross lust like to native
* [`0d44f838`](https://github.com/NixOS/nixpkgs/commit/0d44f838ca622cd967d86c16aa429dcfa2c289c7) gatk: 4.3.0.0 -> 4.4.0.0
* [`96100e76`](https://github.com/NixOS/nixpkgs/commit/96100e7675f96c90b4f1124a77f86e87d7a251ee) passage: add missing dependency on tree(1)
* [`3eea810b`](https://github.com/NixOS/nixpkgs/commit/3eea810b5e4ff0226d0f4d7c072918866247d72b) Update to latest versions: pdfstudio2022.2.2, pdfstudio2021.2.1, pdfstudioviewer2022.2.2
* [`8f1d05d9`](https://github.com/NixOS/nixpkgs/commit/8f1d05d958c705f0361b7c69648627b4dabf4783) veracrypt: add wrapGAppsHook
* [`8f681143`](https://github.com/NixOS/nixpkgs/commit/8f6811433b65def7728267f31a84786cf1f0de22) discord-canary: 0.0.149 -> 0.0.150
* [`4e0ac3aa`](https://github.com/NixOS/nixpkgs/commit/4e0ac3aabc5830420f7fb41b08f35e0035676830) librewolf-unwrapped: 111.0-2 -> 111.0-3
* [`a160a8be`](https://github.com/NixOS/nixpkgs/commit/a160a8be02e7658add24c7cabbad876e1016ff54) python310Packages.anyascii: 0.3.1 -> 0.3.2
* [`c54a718a`](https://github.com/NixOS/nixpkgs/commit/c54a718a9f5aad5386d9155b3836ba54eb0514fc) docker-buildx: 0.9.1 -> 0.10.4
* [`4d5c24f7`](https://github.com/NixOS/nixpkgs/commit/4d5c24f72d5d9513edd0f68b52c7ab521029368f) docker-buildx: add developer-guy to maintainers list
* [`ab234dc5`](https://github.com/NixOS/nixpkgs/commit/ab234dc5e9e9ff7b02ac05fd778bfab3ad33d1fd) docker-buildx: doCheck false
* [`d75cff2e`](https://github.com/NixOS/nixpkgs/commit/d75cff2ee3bb6d91c818d43d1ba7603bb6dacd59) linuxManualConfig: don't build inside source tree
* [`75e6d945`](https://github.com/NixOS/nixpkgs/commit/75e6d945b8f292621ba2c43fdb3b66d690c47f80) python3Packages.mautrix: 0.19.4 -> 0.19.5
* [`f3269c39`](https://github.com/NixOS/nixpkgs/commit/f3269c396e760622c114f070265c448d13fa8dca) python3Packages.mautrix: 0.19.5 -> 0.19.6
* [`e608077c`](https://github.com/NixOS/nixpkgs/commit/e608077c090e17ea8b3de13c81bc2a99470bd4e2) woodpecker-pipeline-transform: init at 0.1.1
* [`efd23ff1`](https://github.com/NixOS/nixpkgs/commit/efd23ff1c8f0cebc4aa41f08815d71a0a2556d48) nixos/gdk-pixbuf: move GDK_PIXBUF_MODULE_FILE to sessionVariables
* [`7f079e02`](https://github.com/NixOS/nixpkgs/commit/7f079e028ea94fc939826a2df86b0401fbc8ccce) discord: 0.0.264 -> 0.0.273
* [`aacbb6d0`](https://github.com/NixOS/nixpkgs/commit/aacbb6d021d617881630c27088f311a5bc0e2145) tiny-cuda-nn: init 1.6
* [`114bccda`](https://github.com/NixOS/nixpkgs/commit/114bccdafa4fa326f3658e475b1dc0463fe88d51) emacs: use held back patchelf_0_15 to avoid upstream bug
* [`72dd6af7`](https://github.com/NixOS/nixpkgs/commit/72dd6af7ac52ac257aa523afe7e61a5484f30d9d) firefox-devedition-bin-unwrapped: 112.0b1 -> 112.0b3
* [`9203d2c6`](https://github.com/NixOS/nixpkgs/commit/9203d2c69b7f1351d9d763994e434535c0142ed5) klipper: unstable-2023-02-20 -> unstable-2023-03-15
* [`aeece9d9`](https://github.com/NixOS/nixpkgs/commit/aeece9d990e43477804a76107cac6f9d1fdf9854) maintainers: add martinramm
* [`b668e7df`](https://github.com/NixOS/nixpkgs/commit/b668e7df42b5093c7b1f116dd57255846976ad08) benthos: 4.12.1 -> 4.13.0
* [`e2871a59`](https://github.com/NixOS/nixpkgs/commit/e2871a593c24da5e521a57901c8c703efa0e7893) mfc5890cnlpr: init at 1.1.2-2
* [`bc066c95`](https://github.com/NixOS/nixpkgs/commit/bc066c95134f04118d1c96a7a2e0f080a3268862) bigloo: mark darwin aarch64 as broken
* [`b1fec2a5`](https://github.com/NixOS/nixpkgs/commit/b1fec2a5747ecf7aebdd2cea812bc13ae963fef7) python3Packages.torchvision: switch to backendStdenv.cc from cudatoolkit.cc
* [`713eeaa6`](https://github.com/NixOS/nixpkgs/commit/713eeaa68af2272de6b42fa9742d5a5f4315b398) clash-verge: 1.2.3 -> 1.3.0
* [`e85ed323`](https://github.com/NixOS/nixpkgs/commit/e85ed3236b7103e51f8c30a542e522025d654993) python310Packages.m2crypto: fix darwin build
* [`924aef28`](https://github.com/NixOS/nixpkgs/commit/924aef28c03453a3a894dd6bd7f8d561b0500efa) ltex-ls: 15.2.0 -> 16.0.0
* [`cbe5191d`](https://github.com/NixOS/nixpkgs/commit/cbe5191d8bf70f8b524e5772853695b0b83f1af4) guardian-agent: mark broken on darwin
* [`00ebbf5b`](https://github.com/NixOS/nixpkgs/commit/00ebbf5bd136319951d3ba8b85d06bda6648180c) gforth: mark as broken on darwin aarch64
* [`cc011846`](https://github.com/NixOS/nixpkgs/commit/cc0118467198f76087e7e5ced2168dde080094ea) ipxe: unstable-2023-03-07 -> unstable-2023-03-15
* [`a9d6317e`](https://github.com/NixOS/nixpkgs/commit/a9d6317eef09ae1fdc278d6f2edb643963586ae1) gcc-arm-embedded: meta.sourceProvenance = binaryNativeCode
* [`f05c5da8`](https://github.com/NixOS/nixpkgs/commit/f05c5da8e0a5ebdfeaeaf9838a5a47d41d543f91) ocamlPackages.ppx_cstubs: use Dune 3
* [`79fa97ca`](https://github.com/NixOS/nixpkgs/commit/79fa97caa3e61f4793744b7148d5bdac01f0aa4e) ocamlPackages.containers: 3.10 → 3.11
* [`91faebb5`](https://github.com/NixOS/nixpkgs/commit/91faebb585c5c0c5efbc32440a512e26c127a279) minio: 2023-02-27T18-10-45Z -> 2023-03-13T19-46-17Z
* [`cc6ef4ea`](https://github.com/NixOS/nixpkgs/commit/cc6ef4ea2a55cf96f63c85814c854dde47dab2e7) nvidia-vaapi-driver: 0.0.8 -> 0.0.9
* [`20d11966`](https://github.com/NixOS/nixpkgs/commit/20d11966ed9919cfe01846cec55f8870e602d91b) linux_xanmod_latest: 6.2.3 -> 6.2.7
* [`d8395b12`](https://github.com/NixOS/nixpkgs/commit/d8395b127678d1a5b16d916549f98e2476650344) linux_xanmod: 6.1.16 -> 6.1.20
* [`4ed9586e`](https://github.com/NixOS/nixpkgs/commit/4ed9586edf8a986470086ff4330ae2b0327f1e2b) treesheets: unstable-2023-03-07 -> unstable-2023-03-18
* [`2ed89e14`](https://github.com/NixOS/nixpkgs/commit/2ed89e14db64ee154a6944cb41accbea87ca8167) ssm-session-manager-plugin: 1.2.398.0 -> 1.2.463.0
* [`7df61306`](https://github.com/NixOS/nixpkgs/commit/7df61306fb9fd6ddcb948e69bba27cb6d3f8b813) lgogdownloader: 3.9 -> 3.10
* [`d808cc14`](https://github.com/NixOS/nixpkgs/commit/d808cc1420f6d72e2d8e78c6dbd3947e44791c71) qutebrowser-qt6: unstable-2022-09-16 -> unstable-2023-03-19
* [`39ee9df4`](https://github.com/NixOS/nixpkgs/commit/39ee9df4329fc7cd49ea41ccb08d71f9c5460e29) xfce.xfce4-screensaver: 4.16.0 -> 4.18.0
* [`7461adb6`](https://github.com/NixOS/nixpkgs/commit/7461adb605437c8cc4d0cf0e42eb1aeb968daa06) xfce.thunar-archive-plugin: 0.4.0 -> 0.5.0
* [`802ed4b2`](https://github.com/NixOS/nixpkgs/commit/802ed4b27a7dcb3784eb35c04724931872cf619a) xfce.thunar-media-tags-plugin: 0.3.0 -> 0.4.0
* [`4062f28a`](https://github.com/NixOS/nixpkgs/commit/4062f28a76380f8dd88371c772948b977e024cb1) baget: remove due to upstream being unmaintained
* [`58bcff71`](https://github.com/NixOS/nixpkgs/commit/58bcff71bb1fbafa3471d2f386d19e19bb6df7a9) xfce.xfce4-notes-plugin: 1.9.0 -> 1.10.0
* [`5bb320c5`](https://github.com/NixOS/nixpkgs/commit/5bb320c54774b0742b98322dcfd5849d77db07c5) gitkraken: 9.1.1 -> 9.2.1
* [`4b56d3aa`](https://github.com/NixOS/nixpkgs/commit/4b56d3aa5076a07472661f12367c13f426de44dd) cloudhunter: init at 0.7.0
* [`06c3871c`](https://github.com/NixOS/nixpkgs/commit/06c3871c81c8515c2fe2084ee2ac28498d70cdca) python310Packages.dash: 2.8.1 -> 2.9.1
* [`fb05346f`](https://github.com/NixOS/nixpkgs/commit/fb05346f21b23f0dcaf26756ec6d67e7fde45653) xfce.xfce4-windowck-plugin: 0.5.0 -> 0.5.1
* [`416474b0`](https://github.com/NixOS/nixpkgs/commit/416474b069ad82369f0635da754d7e1ae72a9acd) phpunit: 10.0.14 -> 10.0.16
* [`af4e12ad`](https://github.com/NixOS/nixpkgs/commit/af4e12adb785c10892c61a1244bf86694c82782d) subsurface: add dependencies for transports
* [`cceff04c`](https://github.com/NixOS/nixpkgs/commit/cceff04ce9c2c4cc3eab27a10dd220cc5c381b3d) mongodb-4_2: 4.2.19 -> 4.2.24
* [`005aff9d`](https://github.com/NixOS/nixpkgs/commit/005aff9d84da2704e5bb68db0fd3be057ed360f9) urn-timer: switch to maintained fork, unstable-2017-08-20 -> unstable-2023-03-18
* [`86a8d80a`](https://github.com/NixOS/nixpkgs/commit/86a8d80a9d34f31691a3fe19ba5e9ec8e788300a) hydroxide: 0.2.24 -> 0.2.25
* [`212a2495`](https://github.com/NixOS/nixpkgs/commit/212a24952c2fed0bfc3306e1927e6e351feee510) xdp-tools: 1.2.9 -> 1.3.1
* [`8910b1e1`](https://github.com/NixOS/nixpkgs/commit/8910b1e180e1aa3451e6e9d0dc4f72b39cee2353) yoshimi: 2.2.2.1 -> 2.2.3
* [`a4b46044`](https://github.com/NixOS/nixpkgs/commit/a4b46044bacdeb8eb43a0c3cd1146538dfae425d) atlassian-jira: 9.4.0 -> 9.6.0
* [`26ff0e4a`](https://github.com/NixOS/nixpkgs/commit/26ff0e4a27e9a6c23d4aba5eb180f397f21cf6ae) dotnet-sdk_7: 7.0.201 -> 7.0.202
* [`d093086a`](https://github.com/NixOS/nixpkgs/commit/d093086a2b20a4b2183e85ee86d663f54dcebfef) buildDotnetModule: add support for using combinePackages as dotnet-sdk
* [`3e04ba2c`](https://github.com/NixOS/nixpkgs/commit/3e04ba2c1d134acedfe3ba1632b56a1b01ef2965) BeatSaberModManager: regenerate deps, remove add-runtime-identifier.patch
* [`211a9638`](https://github.com/NixOS/nixpkgs/commit/211a963855e0d6716d40babc4ded8f7aa707d401) tsm-client: 8.1.17.0 -> 8.1.17.2
* [`e2d05277`](https://github.com/NixOS/nixpkgs/commit/e2d052776030d4f822c40762cf04e18fe4cb30f3) golden-cheetah: 3.6-RC3 -> 3.6RC4
* [`e955f24c`](https://github.com/NixOS/nixpkgs/commit/e955f24cb4913d0e7ceb4f21f3920f10abb20cb0) mdcat: 1.1.0 -> 1.1.1
* [`ff68cad0`](https://github.com/NixOS/nixpkgs/commit/ff68cad0728e4aae10033b7b63db866e77c9049f) git-ps-rs: init at version 6.5.0
* [`b7ca098c`](https://github.com/NixOS/nixpkgs/commit/b7ca098c7bb10a3866d7d359e4e09a10692afc1c) python310Packages.aiocontextvars: drop useless pytest-runner
* [`dc5ffba5`](https://github.com/NixOS/nixpkgs/commit/dc5ffba52d2adae602086770c9521d7d6d7397b5) nixos/portunus: fix portunus not only listening on localhost
* [`dbf0e8a1`](https://github.com/NixOS/nixpkgs/commit/dbf0e8a18a4a62c49ad0ec1b269505d913658e5e) python310Packages.aardwolf: 0.2.1 -> 0.2.7
* [`0bac6b83`](https://github.com/NixOS/nixpkgs/commit/0bac6b837b72fcf342abba52646942b1419c5966) perl534Packages.Wx: migrate to wxGTK32
* [`982e914e`](https://github.com/NixOS/nixpkgs/commit/982e914e5786dbbd4935e244c010f5d8994f6eeb) mongodb: Mark anything older than 6.0 broken on aarch64-darwin
* [`abd627f6`](https://github.com/NixOS/nixpkgs/commit/abd627f685163e3c6e7b8f3856759d61d574fe88) python310Packages.pymodbus: remove asynctest
* [`caf91510`](https://github.com/NixOS/nixpkgs/commit/caf91510609fc82a239c91bb153ae6f98fd9d4f7) python3Packages.pywebview: add bottle to dependencies
* [`5d5b794e`](https://github.com/NixOS/nixpkgs/commit/5d5b794e10fb255aff04d2d8daa94702387a6226) musescore: 4.0.1 -> 4.0.2
* [`084fd533`](https://github.com/NixOS/nixpkgs/commit/084fd533740d946f783778b3d9931c600b976422) mongodb-4_2: Add cache alignment fix for aarch64
* [`8e08e348`](https://github.com/NixOS/nixpkgs/commit/8e08e348aae65b19ebf201a3a0269f374ae24691) sniproxy: 0.6.0 -> 0.6.1
* [`bab87b45`](https://github.com/NixOS/nixpkgs/commit/bab87b45674c11e4094f4b1490bc16326f00bf35) sniproxy: add raitobezarius as maintainer
* [`f83d8d46`](https://github.com/NixOS/nixpkgs/commit/f83d8d46cb19db5eaafe8434411d8d2e54d301c2) sniproxy: render homepage visible in the nix expression
* [`045cf7df`](https://github.com/NixOS/nixpkgs/commit/045cf7df320db3aa447b7de37454800087d285e6) ocaml: re-establish alphabetical order to top-level
* [`7de3f08c`](https://github.com/NixOS/nixpkgs/commit/7de3f08ce38aca9fddb5db7bcb7741fd389be9ef) linuxManualConfig: unpack directly into $dev
* [`41f788b1`](https://github.com/NixOS/nixpkgs/commit/41f788b1217b05d8661ebb77bfc9d9f3f65b5dd2) linuxManualConfig: use the default make target
* [`e3a689d9`](https://github.com/NixOS/nixpkgs/commit/e3a689d97cb2ca7743d156ebc0b25039d6e84b65) chromiumBeta: 112.0.5615.20 -> 112.0.5615.29
* [`c2ecaab4`](https://github.com/NixOS/nixpkgs/commit/c2ecaab4eed9685171143954a33542c7da1b07c0) chromiumDev: 113.0.5638.0 -> 113.0.5653.0
* [`aacfc095`](https://github.com/NixOS/nixpkgs/commit/aacfc0950b84657b32ebb4106e21eef4db8e626b) regreet: 2023-02-27 -> 2023-03-19
* [`692c28ec`](https://github.com/NixOS/nixpkgs/commit/692c28ec10f0ddbf043d6c70720a62e7293d4833) nixos/regreet: init
* [`69dfa612`](https://github.com/NixOS/nixpkgs/commit/69dfa612cc27b3495b766239dec31facb1df66b9) python310Packages.subliminal: enable tests
* [`d57568fc`](https://github.com/NixOS/nixpkgs/commit/d57568fcad7e3a9364850cb1c25d7a34693c02d5) linuxManualConfig: install GDB scripts
* [`a10f3197`](https://github.com/NixOS/nixpkgs/commit/a10f3197fc893c98a74ae3bb3610b95559951e7f) systemd-lib: fix building -.slice (root slice)
* [`cdc33cdb`](https://github.com/NixOS/nixpkgs/commit/cdc33cdb0e0119c62b74efb3357e7bac26d90851) mkvtoolnix: fix build on darwin
* [`463a1de8`](https://github.com/NixOS/nixpkgs/commit/463a1de84c5a8258aa2c21d83457e2ee6803be7f) postman: 9.31.0 -> 10.12.0
* [`097f9e6c`](https://github.com/NixOS/nixpkgs/commit/097f9e6c1e24fb101f310f260624fa951a06ce62) skippy-xd: richardgv/skippy-xd unstable-2023-03-10 -> dreamcat4 0.6.0
* [`b4744bf2`](https://github.com/NixOS/nixpkgs/commit/b4744bf28bac0c7609e694a0b6adaa7c9770bb14) xfce.xfce4-xkb-plugin: 0.8.2 -> 0.8.3
* [`3e82573d`](https://github.com/NixOS/nixpkgs/commit/3e82573de08a68090657afeed57bae74019db0d6) tonelib-gfx: 4.7.5 -> 4.7.8
* [`68ce9279`](https://github.com/NixOS/nixpkgs/commit/68ce92797a1077bb6be0959191816574a86fc6ad) tonelib-jam: 4.7.5 -> 4.7.8
* [`1dd90bcd`](https://github.com/NixOS/nixpkgs/commit/1dd90bcd9b2f3916aa3f08b89b795e281740f4d5) tonelib-metal: 1.1.0 -> 1.2.6
* [`407d5232`](https://github.com/NixOS/nixpkgs/commit/407d5232a4ce48b73d37a7633b3105cf34769d99) tmux-xpanes: 4.1.3 -> 4.1.4
* [`90cc287d`](https://github.com/NixOS/nixpkgs/commit/90cc287d6e2d9a9f02d8edbf5f8b2cac6006e939) slsa-verifier: 2.0.1 -> 2.1.0
* [`c0baa0dd`](https://github.com/NixOS/nixpkgs/commit/c0baa0ddf2f25bbad3011de14fb392d83162c551) wit-bindgen: init at 0.4.0
* [`76b5525a`](https://github.com/NixOS/nixpkgs/commit/76b5525a6d91ef7b4394b78d795ad6dcb1408d88) shot-scraper: init at 1.1.1
* [`474b2cf0`](https://github.com/NixOS/nixpkgs/commit/474b2cf0aa2a79dcd97f526e7d4332afa7ced384) argc: 0.14.0 -> 0.15.0
* [`fa871f9f`](https://github.com/NixOS/nixpkgs/commit/fa871f9f5a01f9d0b1dd5bb66a84df3f5f2a0e78) python310Packages.tesserocr: 2.5.2 -> 2.6.0
* [`6077061b`](https://github.com/NixOS/nixpkgs/commit/6077061bb563603bdecc389462980cf5fdb77e5b) python310Packages.rst2pdf: 0.99 -> 0.100
* [`999d1ddd`](https://github.com/NixOS/nixpkgs/commit/999d1ddd21b66f656e3f60b9b7133586e8508bac) millet: 0.8.1 -> 0.8.3
* [`92f8db87`](https://github.com/NixOS/nixpkgs/commit/92f8db870c60bba1acdf2b469ed70a91e47851bf) redis: 7.0.9 -> 7.0.10
* [`2ae0a53e`](https://github.com/NixOS/nixpkgs/commit/2ae0a53efc7d01d8b98d16adecae94b3691edd60) rst2pdf: add top level alias
* [`30356d7a`](https://github.com/NixOS/nixpkgs/commit/30356d7a9e74359e8403a9239615a02d8503216a) python310Packages.py-synologydsm-api: 2.1.4 -> 2.2.0
* [`c6f12253`](https://github.com/NixOS/nixpkgs/commit/c6f122539fc22ca4f74d7ce3c7b4aea7ba7101c3) kodi: 20.0 -> 20.1
* [`edf81049`](https://github.com/NixOS/nixpkgs/commit/edf81049b1e89ed31f17722429e77fcba87f31c3) ocaml-ng.ocamlPackages_4_01_0.csv: remove at 1.5
* [`832ce14a`](https://github.com/NixOS/nixpkgs/commit/832ce14a2103077ce137b2b6808636a656d7777c) ocamlPackages.csv: fix for OCaml ≥ 5.0
* [`d12785c4`](https://github.com/NixOS/nixpkgs/commit/d12785c43c4263fb68c47b8cd127af56268d8c6b) python310Packages.peaqevcore: 13.2.2 -> 13.2.3
* [`7a4961ed`](https://github.com/NixOS/nixpkgs/commit/7a4961ed2bdc1d6b7e61692b6e6599150b44cb60) python3Packages.wxPython_4_{0,1}: drop
* [`cb8c832a`](https://github.com/NixOS/nixpkgs/commit/cb8c832a0b71ae80195a613f4bdfafd012ec5d63) vimPlugins: update
* [`85c1280f`](https://github.com/NixOS/nixpkgs/commit/85c1280f0e3c5ff1cb6a47e051b4481e22c1f67d) vimPlugins.magma-nvim-goose: init at 2023-03-13
* [`6f224970`](https://github.com/NixOS/nixpkgs/commit/6f2249708e0f75b5f47434fd579c03f126f14614) vimPlugins.netman-nvim: init at 2023-03-03
* [`b1e462ca`](https://github.com/NixOS/nixpkgs/commit/b1e462cad7027ed2713cdbcf0f458baae2f06210) vimPlugins.mark-radar-nvim: init at 2021-06-22
* [`fd694a1b`](https://github.com/NixOS/nixpkgs/commit/fd694a1b14b4b8cd2d3ebde85159d2c72833139f) vimPlugins.intellitab-nvim: init at 2021-11-13
* [`9c89e9a8`](https://github.com/NixOS/nixpkgs/commit/9c89e9a8c9fe671a3abb1cc12fec47393543fb4b) vimPlugins.nvim-treesitter: update grammars
* [`20c4346a`](https://github.com/NixOS/nixpkgs/commit/20c4346aad8cc0589e116c9d8e784f494086fbe9) python310Packages.teslajsonpy: 3.7.2 -> 3.7.4
* [`910b639b`](https://github.com/NixOS/nixpkgs/commit/910b639bff3d2d7cac4e7095ef545bb41a3a8dec) shot-scraper: add changelog to meta
* [`d88a7684`](https://github.com/NixOS/nixpkgs/commit/d88a768439adba886d2dce7059cc99ee07fc7b2a) python310Packages.blebox-uniapi: remove asynctest
* [`ed4ce166`](https://github.com/NixOS/nixpkgs/commit/ed4ce16637968970b529b61e354b1c3ae0d58993) supergfxd: add missing kmod to PATH
* [`1ab4dd7e`](https://github.com/NixOS/nixpkgs/commit/1ab4dd7eb6013d82297c279760dd5166341d4400) python310Packages.strenum: 0.4.9 -> 0.4.10
* [`a06e5ea3`](https://github.com/NixOS/nixpkgs/commit/a06e5ea36566fd4e7dcf7477402b6497fa17417f) sysdig: 0.30.2 -> 0.31.3
* [`e5a1b49f`](https://github.com/NixOS/nixpkgs/commit/e5a1b49f5f504ee6f2813a6e13586dfe7af8b4d5) python310Packages.bluetooth-adapters: 0.15.2 -> 0.15.3
* [`5a3f283a`](https://github.com/NixOS/nixpkgs/commit/5a3f283ab9d510d24ac7a3a5d86af8b28ec9dffa) lcms: default to lcms2
* [`cea14e1d`](https://github.com/NixOS/nixpkgs/commit/cea14e1d8dcbbe59b9ed68cf9504222e6b6ef878) kops: drop 1.23
* [`1d28868d`](https://github.com/NixOS/nixpkgs/commit/1d28868d3da1a15c4d750c13618083267a362440) kops: 1.24.3 -> 1.24.5
* [`c7834ab0`](https://github.com/NixOS/nixpkgs/commit/c7834ab085028622c1fc5447c1a7915b4913694e) kops: 1.25.3 -> 1.25.4
* [`a37accb1`](https://github.com/NixOS/nixpkgs/commit/a37accb136b0263e54b8a38e184c70d5c853b7c6) kops: 1.25.4 -> 1.26.2
* [`b762d1dd`](https://github.com/NixOS/nixpkgs/commit/b762d1ddbcbd576176723a616a752e02f63e3724) numix-icon-theme-circle: 23.03.04 -> 23.03.19
* [`a3f338ef`](https://github.com/NixOS/nixpkgs/commit/a3f338ef5f0031b0748557bf7228cec9ad0202dc) _389-ds-base: disable parallel installing
* [`57a72706`](https://github.com/NixOS/nixpkgs/commit/57a727064266c570de636220f2f06fe859719687) gitea: create static gzip and brotli files
* [`6b9d81b9`](https://github.com/NixOS/nixpkgs/commit/6b9d81b953b1dd6df343d404b322cdf72bd10e10) forgejo: create static gzip and brotli files
* [`5081f9dc`](https://github.com/NixOS/nixpkgs/commit/5081f9dc05800d59f2ad16c345a62047bc02d59d) signal-desktop: disable wayland for now
* [`9666d43d`](https://github.com/NixOS/nixpkgs/commit/9666d43d40b7688718df4303ca338a84ea900d6f) dovecot: avoid testing DES-encrypted passwords
* [`f3dd69a4`](https://github.com/NixOS/nixpkgs/commit/f3dd69a480b26f9743780030132d19268fde19f3) python310Packages.pyscreenshot: 3.0 -> 3.1
* [`36b0252c`](https://github.com/NixOS/nixpkgs/commit/36b0252c0e55f0952684a03be701197fad4c3e21) got: 0.83 -> 0.86
* [`ec9655c0`](https://github.com/NixOS/nixpkgs/commit/ec9655c09b4b41a6952b6ac9265a06aed71c9876) vscode-extensions: move underscore-prefixed extension identifiers to quoted ones
* [`dc82424c`](https://github.com/NixOS/nixpkgs/commit/dc82424c06a297662729b83be942e6c352779b63) open-stage-control: fix src hash
* [`c9f87ea4`](https://github.com/NixOS/nixpkgs/commit/c9f87ea4d2b8102f7d749cd13525f797caa90441) geant4: 11.0.3 -> 11.0.4
* [`65de6e9e`](https://github.com/NixOS/nixpkgs/commit/65de6e9ee772510a5cbe39ecdd0ca012ce9dd4df) ttop: 0.8.6 -> 1.0.1
* [`89b4b811`](https://github.com/NixOS/nixpkgs/commit/89b4b811419f1f293a738958e75898112c54f41c) vscode-extensions.genieai.chatgpt-vscode: init at 0.0.2
* [`6ba2ffa0`](https://github.com/NixOS/nixpkgs/commit/6ba2ffa05c3be99787fd5c4a2a05e7717bbcf168) linux_4_19_hardened: mark broken on x86_64
* [`8c719d58`](https://github.com/NixOS/nixpkgs/commit/8c719d58e19838a605bd1bb634602fc0996087f6) linux_4_14_hardened: mark broken
* [`cdd6211a`](https://github.com/NixOS/nixpkgs/commit/cdd6211abba5bc20248fd16da8f1da6af2fcdee0) linux_testing_bcachefs: fix meta
* [`663caaa6`](https://github.com/NixOS/nixpkgs/commit/663caaa684c07484b6fa63df882db237cfc903e6) linux_testing_bcachefs: mark broken on aarch64
* [`32abfcc9`](https://github.com/NixOS/nixpkgs/commit/32abfcc92306345b124aa2201d337d5c6f2a7469) build(deps): bump cachix/install-nix-action from 19 to 20
* [`4678ba64`](https://github.com/NixOS/nixpkgs/commit/4678ba645491c24597e9b75eddd83fd65f0832e6) linuxKernel.kernels.linux_zen: 6.2.6-zen1 -> 6.2.7-zen1
* [`b64eb5bb`](https://github.com/NixOS/nixpkgs/commit/b64eb5bbbf3ee58a84bd426f85da15c6ae020e1e) limesurvey: 3.27.33+220125 -> 5.6.9+230306
* [`acde26c9`](https://github.com/NixOS/nixpkgs/commit/acde26c95a126acc3036d0ffab58da98e570216b) linuxKernel.kernels.linux_lqx: 6.2.6-lqx1 -> 6.2.7-lqx1
* [`90116fa8`](https://github.com/NixOS/nixpkgs/commit/90116fa82f56467620762e1aaf1f4501eeeadc42) argc: 0.15.0 -> 0.15.1
* [`6715882c`](https://github.com/NixOS/nixpkgs/commit/6715882cb7a82eea378646eb2c4b02f698fbc88c) cargo-about: 0.5.4 -> 0.5.5
* [`a70114f1`](https://github.com/NixOS/nixpkgs/commit/a70114f1b7b9410aa20abca49708d94825a7415f) maintainers: add kranuarg7
* [`bc6e8aba`](https://github.com/NixOS/nixpkgs/commit/bc6e8aba91c55ad20dabf732974d63b2168e3361) liblinear: 2.43 -> 2.46
* [`ca226caf`](https://github.com/NixOS/nixpkgs/commit/ca226cafce2081eed6525674d3c2b1570d2ceae7) gpu-viewer: init at 2.26
* [`96c5fc94`](https://github.com/NixOS/nixpkgs/commit/96c5fc940c78a9fee1455249e341b37223cdeee6) sniffnet: replace libGL with vulkan-loader
* [`5c5f7103`](https://github.com/NixOS/nixpkgs/commit/5c5f710388f0d94a222c91c79c0c812d2b65fdde) gitea: 1.18.5 -> 1.19.0
* [`7ebafc91`](https://github.com/NixOS/nixpkgs/commit/7ebafc91abe22556231ea59fb8fcf805b20c844f) hello-wayland: unstable-2020-07-27 -> unstable-2023-03-16
* [`238d4c33`](https://github.com/NixOS/nixpkgs/commit/238d4c33349143212f7ae925750ac09e8633463f) b4: 0.12.1 -> 0.12.2
* [`f129d39c`](https://github.com/NixOS/nixpkgs/commit/f129d39c779f090a2ee1e284f479e1450e767458) nix-init: 0.1.1 -> 0.2.0
* [`e32f3c7e`](https://github.com/NixOS/nixpkgs/commit/e32f3c7ea9b3ae7cc4d1447fe917d2d96eba3587) vimPlugins: update
* [`f58a0dc2`](https://github.com/NixOS/nixpkgs/commit/f58a0dc2d4450b95ea1fd79f366388a0ccd58ddd) vimPlugins.openscad-nvim: init at 2022-04-15
* [`068c6de7`](https://github.com/NixOS/nixpkgs/commit/068c6de7f6f6658219a846e835cba1f9bf18e591) vimPlugins.nvim-treesitter: update grammars
* [`52162c69`](https://github.com/NixOS/nixpkgs/commit/52162c69e574c6b1cefe7cba99bc1a02d5ba8bd4) git-open: 2.1.0 -> 3.0.0, drop inactive maintainer, remove git from the wrapper
* [`1907fe8d`](https://github.com/NixOS/nixpkgs/commit/1907fe8d2558649df796ab40553b23aad2a7f911) tor-browser-bundle-bin: 12.0.3 -> 12.0.4
* [`656709bc`](https://github.com/NixOS/nixpkgs/commit/656709bceb2d9f86c5b971f0ec53bbfbac0de543) pkgsMusl.xterm: fix build ([nixos/nixpkgs⁠#220731](https://togithub.com/nixos/nixpkgs/issues/220731))
* [`8aa9c822`](https://github.com/NixOS/nixpkgs/commit/8aa9c82256e957b98e3057f245a32f105db7d31a) vscode-extensions.streetsidesoftware.code-spell-checker: 2.19.0 -> 2.20.3
* [`34d5d644`](https://github.com/NixOS/nixpkgs/commit/34d5d6445eb42feec12cfd0a05de8dc65b2390d8) python310Packages.zeroconf: 0.47.3 -> 0.47.4
* [`24976f38`](https://github.com/NixOS/nixpkgs/commit/24976f3816158497b7a137d011907fec3fb13a59) openbox: Apply crash fix for GLib 2.76
* [`c7a96220`](https://github.com/NixOS/nixpkgs/commit/c7a96220a3b94a6b6dfdbd42c3957b7e90f3621d) python310Packages.aiomusiccast: 0.14.7 -> 0.14.8
* [`a92ddfb5`](https://github.com/NixOS/nixpkgs/commit/a92ddfb549058b6c0b7480d7c2dacd91fc8e06a0) sidplayfp: 2.4.0 -> 2.4.1
* [`0de90269`](https://github.com/NixOS/nixpkgs/commit/0de9026953c195a29681ddba7526faf652271a27) miriway: unstable-2023-02-18 -> unstable-2023-03-17
* [`c1f45a9a`](https://github.com/NixOS/nixpkgs/commit/c1f45a9ae60ee12657705dbe43ed34f42aa3dbbc) open-watcom-v2-unwrapped: unstable-2023-01-30 -> unstable-2023-03-20
* [`0810a6e0`](https://github.com/NixOS/nixpkgs/commit/0810a6e018ee759de935e25a330f7710f2c4ca9c) nixos/prometheus.alertmanagerIrcRelay: init
* [`93beb1e9`](https://github.com/NixOS/nixpkgs/commit/93beb1e9169c7087bd2d51885abd22f8759b9a6e) haxe_3_2, haxe_3_4: drop
* [`ce15577a`](https://github.com/NixOS/nixpkgs/commit/ce15577ab4d047802e0dbf12c99e09adf21184d4) Revert "Merge [nixos/nixpkgs⁠#211691](https://togithub.com/nixos/nixpkgs/issues/211691): patchelfStable: 0.15.0 -> 0.17.2"
* [`df0d3e3e`](https://github.com/NixOS/nixpkgs/commit/df0d3e3ea1a579aa994327a4c69b7f742e3ece63) Revert "Merge [nixos/nixpkgs⁠#221900](https://togithub.com/nixos/nixpkgs/issues/221900): emacs: use patchelf_0_15 to avoid upstream bug"
* [`7cee2ad5`](https://github.com/NixOS/nixpkgs/commit/7cee2ad598c1c4437b6f578cd75722853784d2b1) hplip: fix broken/hardcoded paths in .desktop files
* [`5a35e7ea`](https://github.com/NixOS/nixpkgs/commit/5a35e7ea4aa482075316a5a2fd1cea0e9dbfbae3) nixpkgs-review: 2.8.0 -> 2.9.0
* [`97d4b225`](https://github.com/NixOS/nixpkgs/commit/97d4b225da9ed7bae07d148a4895b03844437d0b) polkit: move test-only deps to nativeCheckInputs
* [`9180097c`](https://github.com/NixOS/nixpkgs/commit/9180097c41486bed157f73327be0ba772b21e659) sonarr: 3.0.9.1549 -> 3.0.10.1567
* [`72f784db`](https://github.com/NixOS/nixpkgs/commit/72f784dbbe5511cb2433a369212212e56a7d9c72) balena-cli: fix linux binary with patchelf
* [`280f1449`](https://github.com/NixOS/nixpkgs/commit/280f14490eeff5285e9f5e79b81869ce720546db) curl: 7.88.1 -> 8.0.1
* [`603cae07`](https://github.com/NixOS/nixpkgs/commit/603cae0768edf341d75708f881f73abd04d8646d) curl: Fix passthru tests evaluation
* [`466240f8`](https://github.com/NixOS/nixpkgs/commit/466240f8cbe39cbeb6d02d2a2039297e348e1a4e) osu-lazer-bin: 2023.301.0 -> 2023.305.0
* [`2c5b18dc`](https://github.com/NixOS/nixpkgs/commit/2c5b18dc0b33164a928e6830b69659e58d143d4d) osu-lazer: 2023.301.0 -> 2023.305.0
* [`2b37a482`](https://github.com/NixOS/nixpkgs/commit/2b37a4822c57187c5fe50bc7480108571da7be7a) osu-lazer-bin: adding support for darwin systems
* [`a22e80f5`](https://github.com/NixOS/nixpkgs/commit/a22e80f516cee794083fa6e83c32e1222d934371)  ledger-live-desktop: 2.54.0 -> 2.55.0 
* [`d3eda58a`](https://github.com/NixOS/nixpkgs/commit/d3eda58a2d9188020b78772e28138bdcd4d9927a) cppcheck: enable strictDeps
* [`0112d0bd`](https://github.com/NixOS/nixpkgs/commit/0112d0bdfa02c635c341cb09264648ef8a935700) hyprpicker: Fix eval with aliases disabled
* [`2676c648`](https://github.com/NixOS/nixpkgs/commit/2676c648eaa25553d4c89ec4042ce0813d350eb1) fastnetmon-advanced: init at 2.0.335 ([nixos/nixpkgs⁠#218609](https://togithub.com/nixos/nixpkgs/issues/218609))
* [`6d2eaecc`](https://github.com/NixOS/nixpkgs/commit/6d2eaecc8c29c54705d0f69db186c278e423b5a7) gollum: 5.3.0 -> 5.3.1
* [`424c98bf`](https://github.com/NixOS/nixpkgs/commit/424c98bf7852bdf208bc19068e98b0d7ba6c9aea) nixos/gollum: fix deprecation warning
* [`2af44e35`](https://github.com/NixOS/nixpkgs/commit/2af44e355256e7a9d7377acfd4aeb3153dbffd81) watchman: add version to binary
* [`783acd81`](https://github.com/NixOS/nixpkgs/commit/783acd81236e0a5b04f6ffe0a0217edcf4ed6aef) xonotic: fix libraries not found error
* [`e0371f9d`](https://github.com/NixOS/nixpkgs/commit/e0371f9d20bc08b2ac72813e83d1e678442bd30e) mastodon: 4.1.0 -> 4.1.1
* [`27cbc356`](https://github.com/NixOS/nixpkgs/commit/27cbc35640f72aa5546fed0a72f09e778911a22a) codeql: make substitution include the aarch path
* [`36abb0e5`](https://github.com/NixOS/nixpkgs/commit/36abb0e53b987661fd916885e34ca2a2ea7613ae) dart: add update script
* [`94c11d33`](https://github.com/NixOS/nixpkgs/commit/94c11d33343df7772a83388bc0c4f5fb7da8559f) kubectl-gadget: init at 0.14.0
* [`ee71bbc2`](https://github.com/NixOS/nixpkgs/commit/ee71bbc2f7eeffccd422011c5e4dd503a8feebcb) libsvm: 3.25 -> 3.31
* [`48be87c5`](https://github.com/NixOS/nixpkgs/commit/48be87c5543799f397ad952355eee9d9094bad02) erdtree: 1.3.0 -> 1.6.0, add figsoda as a maintainer
* [`336e5cc1`](https://github.com/NixOS/nixpkgs/commit/336e5cc12618d4dc8ff178e750350fda22357927) seaweedfs: 3.43 -> 3.44
* [`e12230e7`](https://github.com/NixOS/nixpkgs/commit/e12230e71628a460bf82a8477242280868efe799) why3: 1.5.1 → 1.6.0; ocamlPackages.lambdapi: 2.2.1 → 2.3.1 ([nixos/nixpkgs⁠#220986](https://togithub.com/nixos/nixpkgs/issues/220986))
* [`c24515de`](https://github.com/NixOS/nixpkgs/commit/c24515de8fa7f78b50a578df15b67982a39b6cf0) firebird-emu: 1.5 -> 1.6
* [`88c4a670`](https://github.com/NixOS/nixpkgs/commit/88c4a670e65b01dd98ed054f70147fb7fd744daf) slimserver: remove phile314 as maintainer
* [`f01862e2`](https://github.com/NixOS/nixpkgs/commit/f01862e271cac854e8e90eb9c6a273a1035901e0) gitea.data-compressed: improve drv name
* [`f2f7589c`](https://github.com/NixOS/nixpkgs/commit/f2f7589c1c1dbf6c7905a711cf914cb1d320ab06) maintainers: add dylanmtaylor
* [`6599eca8`](https://github.com/NixOS/nixpkgs/commit/6599eca8717fa84fde54ebf8f0bed44a17cbf3e5) scalr-cli: init at 0.14.5
* [`d2629daf`](https://github.com/NixOS/nixpkgs/commit/d2629daf0d6def4c8828f20225d187dd7c9c4445) php.packages.composer: 2.5.1 -> 2.5.4
* [`a5c90b89`](https://github.com/NixOS/nixpkgs/commit/a5c90b896d479d4247117fb01bf53bcfee8507d9) php81: 8.1.16 -> 8.1.17
* [`64362896`](https://github.com/NixOS/nixpkgs/commit/64362896c88f761a30d4012151e410e1765fbc66) php82: 8.2.3 -> 8.2.4
* [`bca2472c`](https://github.com/NixOS/nixpkgs/commit/bca2472c1e9826513da1c7c39546c2c273f2008c) wails: 2.4.0 -> 2.4.1
* [`1f24ebb4`](https://github.com/NixOS/nixpkgs/commit/1f24ebb428c036ebc01b9da6b106b79f93957d6d) elixir-ls: rename elixir_ls to elixir-ls
* [`d5f74b29`](https://github.com/NixOS/nixpkgs/commit/d5f74b29987affbbe8c7d71c52e7774f89ad1c38) naabu: 2.1.3 -> 2.1.4
* [`3f9ad8bf`](https://github.com/NixOS/nixpkgs/commit/3f9ad8bfe2af6327130726d739fcd9b46a63a08b) maintainers: add atkrad
* [`1de4691d`](https://github.com/NixOS/nixpkgs/commit/1de4691d3cfde7210b939391ac65ff1bbd0fbde2) or-tools: fix checkPhase issues
* [`41135131`](https://github.com/NixOS/nixpkgs/commit/41135131a4cfdd70e906f0983632096c780e4cb2) gh: 2.24.3 -> 2.25.0
* [`cd3ffbdf`](https://github.com/NixOS/nixpkgs/commit/cd3ffbdfe6869c35c483bc7cec348e8d5365c2b3) nixos/zram: add writebackDevice option and corresponding test
* [`68d28d94`](https://github.com/NixOS/nixpkgs/commit/68d28d948467458b64f9021803e127d394395251) havoc: mark as broken on darwin
* [`0c64c8d5`](https://github.com/NixOS/nixpkgs/commit/0c64c8d545af02ccfefe574a3e637346422ae8e1) libkrunfw: 3.9.0 -> 3.10.0
* [`5e00adf7`](https://github.com/NixOS/nixpkgs/commit/5e00adf7f8c76ce674003e134dcbf28ddcd75016) libkrun: 1.5.0 -> 1.5.1
* [`d1156e3c`](https://github.com/NixOS/nixpkgs/commit/d1156e3ca9f05f1733d7dc3f650512727b0a1571) v2ray-domain-list-community: 20230311145412 -> 20230320093818
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
