### PR TITLE
niv devenv: update 71f5c3c4 -> c9ff5bd4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "71f5c3c4344c9ef3d065de85386b5481c8f26abb",
-        "sha256": "1qn17rpha3is24jvxj6x60f51razlcp8agmj25j0067abib43ydx",
+        "rev": "c9ff5bd489ca36a526e46440fec4d10a87988363",
+        "sha256": "0v0pfngb5a25zajdcbi11jzsv6hbr3nzqwgy1pdb5rzkbx0amhdv",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/71f5c3c4344c9ef3d065de85386b5481c8f26abb.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/c9ff5bd489ca36a526e46440fec4d10a87988363.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@71f5c3c4...c9ff5bd4](https://github.com/cachix/devenv/compare/71f5c3c4344c9ef3d065de85386b5481c8f26abb...c9ff5bd489ca36a526e46440fec4d10a87988363)

* [`6fdb8842`](https://github.com/cachix/devenv/commit/6fdb88420c784d3084023100edb91e0db8e21400) Support pkgs.config.allowAliases
* [`5365808b`](https://github.com/cachix/devenv/commit/5365808bfa47de0e9690758090d2a6ef13bf14e8) go: Add $GOPATH/bin to PATH
* [`9617bf0f`](https://github.com/cachix/devenv/commit/9617bf0fb882caef7c47aee1c8c6b7a59a09bae0) remove instances of nixpkgs
