### PR TITLE
niv doomemacs: update ce6be8c1 -> 4e105a95

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ce6be8c1b177551231979a9eaa949bf83a601885",
-        "sha256": "064ffwy4pc98lp9kdwm30n8x7lz571yvsmkby37q3z9c7wfkc430",
+        "rev": "4e105a95af9c4c7e86471e5566eb7a5ff776ec92",
+        "sha256": "03m5r0xirbkc0wgj07lr5s0f6g83fqi9gq900lcl0lsgrlhh5aaz",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/ce6be8c1b177551231979a9eaa949bf83a601885.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/4e105a95af9c4c7e86471e5566eb7a5ff776ec92.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@ce6be8c1...4e105a95](https://github.com/doomemacs/doomemacs/compare/ce6be8c1b177551231979a9eaa949bf83a601885...4e105a95af9c4c7e86471e5566eb7a5ff776ec92)

* [`18da873a`](https://github.com/doomemacs/doomemacs/commit/18da873a8c64aaa21d6587051f4ee5e19b1c1cd3) refactor(cli): mkdir and log to doom-state-dir
* [`9350b44d`](https://github.com/doomemacs/doomemacs/commit/9350b44dc067f255bb7d300ab347e1251829edb0) feat(undo): add vundo
* [`0eff40c5`](https://github.com/doomemacs/doomemacs/commit/0eff40c552455f1923954bc9b68925b214ebd24f) feat(lookup): add sourcegraph provider
* [`cb6b065b`](https://github.com/doomemacs/doomemacs/commit/cb6b065b87397302aa59ddc4ce7447ed801c6460) fix(evil): embrace: escaped pairs in first org buffer
* [`51282807`](https://github.com/doomemacs/doomemacs/commit/512828078f03727d57d1bcdb0c3d7f15baa1c23c) bump: :emacs undo
* [`3ce89731`](https://github.com/doomemacs/doomemacs/commit/3ce89731b6c13eab8f0edc57cebbacd93cac69f3) docs(undo): add vundo
* [`e5dbd4e8`](https://github.com/doomemacs/doomemacs/commit/e5dbd4e8b1c14a608cad36b3cbff88db3228f42c) bump: :completion vertico compat
* [`1a016207`](https://github.com/doomemacs/doomemacs/commit/1a01620705ed5883bf6cdcdb3107d228768ccc0c) fix(unicode): don't unset `doom-unicode-font`
* [`890f200b`](https://github.com/doomemacs/doomemacs/commit/890f200b41f24f6115508799214ab99cb9059776) feat(vertico): bind C-h/C-l to enter-or-preview/move up
* [`221e75e7`](https://github.com/doomemacs/doomemacs/commit/221e75e7391a4c613d089a5ac7d98f0011bc03d0) refactor!(elixir): remove alchemist
* [`1d7dd915`](https://github.com/doomemacs/doomemacs/commit/1d7dd915ab306e917cd33fa5d285636c0754e31b) fix(unicode): show remapping progress at startup
* [`09f602b3`](https://github.com/doomemacs/doomemacs/commit/09f602b3426c22a701a5627f66535d033b817257) fix(unicode): unicode-fonts remapping for daemon
* [`bab4c921`](https://github.com/doomemacs/doomemacs/commit/bab4c921c88a158043d68aa0bcb63323820aadea) tweak(vc): smerge-next -> smerge-vc-next-conflict
* [`4e105a95`](https://github.com/doomemacs/doomemacs/commit/4e105a95af9c4c7e86471e5566eb7a5ff776ec92) refactor(vertico): take evil keybinds from :config default
