### PR TITLE
niv fast-syntax-highlighting: update 5521b083 -> 371591a7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "5521b083f8979ad40be2137d7a46bfa51c8d666a",
-        "sha256": "0ki5dl3gvmcl1kr9smx0949303dxzwadz7r4abj7ivj3284xxk44",
+        "rev": "371591a7b6f0f3c9501c52a7b566addbfd804d09",
+        "sha256": "125kp7rzq9yf565h6crkr8fyvrz867jjwlx0w2dbhas9p1id978l",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/5521b083f8979ad40be2137d7a46bfa51c8d666a.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/371591a7b6f0f3c9501c52a7b566addbfd804d09.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@5521b083...371591a7](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/5521b083f8979ad40be2137d7a46bfa51c8d666a...371591a7b6f0f3c9501c52a7b566addbfd804d09)

* [`371591a7`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/371591a7b6f0f3c9501c52a7b566addbfd804d09) avoid errors unbound variables and unset parameters ([zdharma-continuum/fast-syntax-highlighting⁠#50](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/50))
