### PR TITLE
niv nixpkgs: update d241b996 -> 53dad94e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d241b99697eedd2caa1a6685cb76a0cbbd7054ee",
-        "sha256": "1qrx0ifxyvd9v98gsbwhf891rlk9jiv89j9jrfbs40csmwy7xhag",
+        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
+        "sha256": "03knsdlm2f4hd46y100vcii07xsa95rdk3b1i2jh8rj3pjm4hlzl",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d241b99697eedd2caa1a6685cb76a0cbbd7054ee.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/53dad94e874c9586e71decf82d972dfb640ef044.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d241b996...53dad94e](https://github.com/nixos/nixpkgs/compare/d241b99697eedd2caa1a6685cb76a0cbbd7054ee...53dad94e874c9586e71decf82d972dfb640ef044)

* [`ccc841f2`](https://github.com/NixOS/nixpkgs/commit/ccc841f2d31a7b0563c7277628081db56d82de8d) nimraylib-now: init at 0.15.0
* [`0df169a6`](https://github.com/NixOS/nixpkgs/commit/0df169a62a587a93f7231361cfe6897af85bf4c3) sosreport: 4.3 -> 4.4
* [`73a0dfb4`](https://github.com/NixOS/nixpkgs/commit/73a0dfb4498d68b5989fac8f12318c1d9dbd5bf1) pythonPackages.boa-api: init at 0.1.14
* [`68ef099f`](https://github.com/NixOS/nixpkgs/commit/68ef099f53431b44ddc965cce7b0801a3ae94a43) processing: 3 -> 4.0.1
* [`02641062`](https://github.com/NixOS/nixpkgs/commit/02641062d16b84b74c708fb99041b0421253759f) quarto: allow overriding extra R and Python packages
* [`da9be96e`](https://github.com/NixOS/nixpkgs/commit/da9be96e07ec05a6ea484295cf58af80ac6e36d3) tone: init at 0.1.3
* [`1aab9c28`](https://github.com/NixOS/nixpkgs/commit/1aab9c281faeffaa25b5c8f60bbb57836f3c1ff9) golden-cheetah: add AppImage derivation
* [`9cb1ca6d`](https://github.com/NixOS/nixpkgs/commit/9cb1ca6d71c2e3a04660509349556cbc78bfcd93) rocfft: fix propagatedBuildInputs typo
* [`4af7dad6`](https://github.com/NixOS/nixpkgs/commit/4af7dad6255d8a61eb31bc60702df467e91a65ee) rocfft: split base outputs for hydra
* [`5856247c`](https://github.com/NixOS/nixpkgs/commit/5856247cfce6d935580f899858090fe5ff743942) snekim: init at 1.2.0
* [`93e9aac7`](https://github.com/NixOS/nixpkgs/commit/93e9aac7dc26af7bde133dc1861bfabfd597c577) androidenv: fix autopatching toolchains
* [`39fab30f`](https://github.com/NixOS/nixpkgs/commit/39fab30f55265c95c97dc910e8319548bb6df7cf) jna: 4.5.2 -> 5.13.0
* [`c37e12ca`](https://github.com/NixOS/nixpkgs/commit/c37e12ca1ac8c1ab374a9b586a444116f4e33be6) audiobookshelf: init at 2.2.15
* [`94fc16e6`](https://github.com/NixOS/nixpkgs/commit/94fc16e6f34049020daa4dd59e812e3f69c420c8) clipboard-jh: init at 0.3.2
* [`408a877c`](https://github.com/NixOS/nixpkgs/commit/408a877c20382e57e39817aba88e1dc67af8e043) dracula-theme: 3.0 -> 4.0.0
* [`be8868e9`](https://github.com/NixOS/nixpkgs/commit/be8868e936a7ebf2951301fd77c5fd9fe584352b) coreboot-configurator: 2022-08-22 -> 2023-01-17, use pkexec instead of sudo.
* [`4a622549`](https://github.com/NixOS/nixpkgs/commit/4a622549c7f8235ff182ea0f6ea97b273685d303) Resolve pkexec from PATH by default.
* [`3b8e8956`](https://github.com/NixOS/nixpkgs/commit/3b8e89569b430dfda49fb37d8896338046c84124) paleta: init at 0.3.1
* [`b76ce89d`](https://github.com/NixOS/nixpkgs/commit/b76ce89dfcf42b4ea015f8e794dbf9ada8a05cc4) buildDotnetModule: add support for args with spaces in makeWrapperArgs
* [`b32ee446`](https://github.com/NixOS/nixpkgs/commit/b32ee446ee9a571668166a8b9561f02855d32bf9) gradle: add 8
* [`23ee7693`](https://github.com/NixOS/nixpkgs/commit/23ee7693587b2aac2b633012290f2bc400fdc8b3) buildFHSUserEnv: add version arg
* [`81d23b8d`](https://github.com/NixOS/nixpkgs/commit/81d23b8d3a022b5a74c9944a96e916c7f156382d) buildFHSUserEnv: rewrite not isNull check
* [`e069b686`](https://github.com/NixOS/nixpkgs/commit/e069b686bb5d56fecfc5be24f049bcfce81b74ca) h3_4: init at 4.1.0
* [`908a8f3e`](https://github.com/NixOS/nixpkgs/commit/908a8f3e4ef0dd9a5905bca06c3e6b3fd2b61757) h3: add marsam to maintainers
* [`16e4a92e`](https://github.com/NixOS/nixpkgs/commit/16e4a92e0de44af134e76ffbd80029eed201f2a7) pcsc-safenet: 10.0.37 -> 10.8.28
* [`f004e977`](https://github.com/NixOS/nixpkgs/commit/f004e9779a24cbf09828d709f23ffa09c4b43df0) quick-lint-js: 2.11.0 -> 2.12.0
* [`1b0cd6bc`](https://github.com/NixOS/nixpkgs/commit/1b0cd6bcdaa4d591b9ccf0de620eafe04544bd83) grub2: Pull upstream patches for flicker-free boot
* [`1649603f`](https://github.com/NixOS/nixpkgs/commit/1649603f9f7625673a4dbbd298ef8be4f572f2ae) gutenprint: enable strictDeps
* [`bbdaa58a`](https://github.com/NixOS/nixpkgs/commit/bbdaa58a5bd86e607fd294597161db0ed4aa801c) obex-data-server: enable strictDeps
* [`baa5974a`](https://github.com/NixOS/nixpkgs/commit/baa5974a37e6c52ed537b2076b2b89e255ed3f29) open-vm-tools: 12.1.5 -> 12.2.0
* [`d86c8974`](https://github.com/NixOS/nixpkgs/commit/d86c897423d8a5416d5a02b66468407edf36cf9e) p2pool: 2.7 -> 3.1
* [`bc833b35`](https://github.com/NixOS/nixpkgs/commit/bc833b3521767028fcbb80d150ad845fd7b0bd18) haskellPackages: stackage LTS 20.12 -> LTS 20.14
* [`b645a1d8`](https://github.com/NixOS/nixpkgs/commit/b645a1d84a95c48d33de712a6ce58d7acd0aa7e0) all-cabal-hashes: 2023-03-01T16:43:25Z -> 2023-03-13T08:59:39Z
* [`df547d23`](https://github.com/NixOS/nixpkgs/commit/df547d23fb5424d3513c4bfbfd64626a4a006095) haskellPackages: regenerate package set based on current config
* [`196e9745`](https://github.com/NixOS/nixpkgs/commit/196e9745e3b721fe79b5c4ede67c0c92e7076cba) fishPlugins.fzf: init at unstable-2021-05-12
* [`aec78577`](https://github.com/NixOS/nixpkgs/commit/aec7857745a074361cbb2b6d20aff9e7181a026a) fishPlugins.humantime-fish: init at unstable-2022-04-08
* [`6b558b3d`](https://github.com/NixOS/nixpkgs/commit/6b558b3df926f84f87b246e33742d47a5d2b5f02) fishPlugins.z: init at unstable-2022-04-08
* [`fe1d5a77`](https://github.com/NixOS/nixpkgs/commit/fe1d5a77200f71018a78008a1f8f36e9526a3b07) fishPlugins.bobthefish: init at unstable-2022-08-02
* [`48eb49b8`](https://github.com/NixOS/nixpkgs/commit/48eb49b8ba5b004db34c826f28692c2041367d3e) fishPlugins.bobthefisher: init at unstable-2023-03-09
* [`6e99f2ee`](https://github.com/NixOS/nixpkgs/commit/6e99f2eecc2d272292dc2aa28f376a13ddb3f29d) cachix: remove no longer needed src override & patch
* [`f7d99b7d`](https://github.com/NixOS/nixpkgs/commit/f7d99b7da8c3bc2f0f2568977bf29ed7bf37d1ff) cachix,hercules-ci-{agent,cnix-expr,cnix-store}: bump nix pin to 2_14
* [`690740bd`](https://github.com/NixOS/nixpkgs/commit/690740bd3b74919512fb964a28083af4a27471da) haskellPackages.tomland: unbreak
* [`0d04028e`](https://github.com/NixOS/nixpkgs/commit/0d04028e661f1b62f6321d6aef5bda442e8bfeaa) github-copilot-cli: init at version 0.1.21
* [`f5b75488`](https://github.com/NixOS/nixpkgs/commit/f5b754881dd9b8554e313fcbca6dc5885b63a994) bind: remove hard-coded `allow-query` config file entry, so it can be customized via `extraConfig`
* [`b12beeb2`](https://github.com/NixOS/nixpkgs/commit/b12beeb2bafd63a365711304b554c095a529a3ff) gammaray: init at 2.11.3
* [`38d703bd`](https://github.com/NixOS/nixpkgs/commit/38d703bdb743363e57749c26e87e1008e9777a86) haskellPackages.Cabal_3_10_1_0: build with matching of Cabal-syntax
* [`e4f591ea`](https://github.com/NixOS/nixpkgs/commit/e4f591eae9293974bf381caa0f6bc12bd328d86d) haskellPackages.Cabal{,-syntax}_3_8_1_0: keep
* [`e9b906ef`](https://github.com/NixOS/nixpkgs/commit/e9b906ef3490dc667f605684b85821c07a96ad26) dt-schema: 2022.1 -> 2022.12
* [`76c79662`](https://github.com/NixOS/nixpkgs/commit/76c796628de6e7150942a6e7d739f011d56da1cb) edl: init at unstable-2022-09-07
* [`4d3bb49e`](https://github.com/NixOS/nixpkgs/commit/4d3bb49e8f7376d4db8688f6a803a4cc1840bab3) ariang: init 1.3.3
* [`22d7930c`](https://github.com/NixOS/nixpkgs/commit/22d7930c643dad6979e1145feeab734cb4a3e9c8) dash: 0.5.11.5 -> 0.5.12
* [`07673d91`](https://github.com/NixOS/nixpkgs/commit/07673d91cddd437e602dd6dd5d1ba4f2c83e9711) haskell.packages.ghc92.th-desugar: use stackage prescribed version
* [`6dae8a83`](https://github.com/NixOS/nixpkgs/commit/6dae8a83111e77b1d2cc2c902db059534eec035f) haskell.packages.ghc94.ghc-lib*: retain GHC 9.4 versions
* [`eabab539`](https://github.com/NixOS/nixpkgs/commit/eabab5397e8041c121c33cccb68d1556d3dda2e7) haskell.packages.ghc94.th-desugar: 1.14 -> 1.15
* [`a8073117`](https://github.com/NixOS/nixpkgs/commit/a80731175fb8d424f62c23f76970fac395b337a3) haskellPackages.haskell-gi: drop obsolete override
* [`beafc737`](https://github.com/NixOS/nixpkgs/commit/beafc73774e756ccba5d3fc5baf2951e1de35300) haskellPackages.hspec*: reflect 2.10.9 -> 2.10.10
* [`1a9ab74f`](https://github.com/NixOS/nixpkgs/commit/1a9ab74f66ef1697e7e590c5eab4b941b4f8bfdf) haskellPackages.haddock-cheatsheet: unbreak
* [`2ef27ee3`](https://github.com/NixOS/nixpkgs/commit/2ef27ee3499f8c20173ac405e57e93313af8a9ed) python310Packages.soxr: 0.3.3 -> 0.3.4
* [`c1e8756b`](https://github.com/NixOS/nixpkgs/commit/c1e8756b56ce725f9c7c4cfa203bd4cee8c3594b) python310Packages.chex: Propagate cloudpickle
* [`93482590`](https://github.com/NixOS/nixpkgs/commit/93482590c103c06625b26bd5dd315b5b3d0df014) clash: 1.13.0 -> 1.14.0
* [`8da8071e`](https://github.com/NixOS/nixpkgs/commit/8da8071e37a392a1548f3ad503f3ca8092b855dd) glucose: 4.1 -> 4.2.1
* [`3ce5834b`](https://github.com/NixOS/nixpkgs/commit/3ce5834b3eed2fcd5bd291af62592d081aeb034f) haskell.packages.ghc94.indexed-traversable*: drop obsolete overrides
* [`94b31d8f`](https://github.com/NixOS/nixpkgs/commit/94b31d8f487bdc752e782a0378579907666d8b29) haskell.packages.ghc96.cabal-install: make work
* [`a1c16a79`](https://github.com/NixOS/nixpkgs/commit/a1c16a7909ed8ba0f224a3137ae111048c813987) haskell.packages.ghc94.generically: supply base-orphans
* [`7be4e628`](https://github.com/NixOS/nixpkgs/commit/7be4e628555fe3ee4f45170a497a1d53e81adf9b) release-haskell.nix: test weeder with GHC 9.4
* [`a50dd13c`](https://github.com/NixOS/nixpkgs/commit/a50dd13c92035097bd4d6983c74e3f345fdc4834) haskell.packages.ghc94.aeson: drop obsolete jailbreak
* [`8dda93a2`](https://github.com/NixOS/nixpkgs/commit/8dda93a2ce7827e9868db12413b3a6d28048f5fa) haskell.packages.ghc96.ghc-lib*: pick appropriate versions
* [`84c43d4e`](https://github.com/NixOS/nixpkgs/commit/84c43d4e70b4453b75de0743fc039ca38d2548a3) release-haskell.nix: test GHC 9.6 package set
* [`2ea51885`](https://github.com/NixOS/nixpkgs/commit/2ea51885809634912c9c9f5f78e1f1b81964562f) chirp: unstable-2022-12-07 -> unstable-2023-03-15
* [`fcb4e6e1`](https://github.com/NixOS/nixpkgs/commit/fcb4e6e189eee90faa07d9d1a35902188ff43182) mudlet: 4.16.0 -> 4.17.0
* [`4313c92b`](https://github.com/NixOS/nixpkgs/commit/4313c92b31fbd16549737111239873a525c5fdc9) haskell.packages.ghc94.ghc: 9.4.2 -> 9.4.4
* [`f9e50cf7`](https://github.com/NixOS/nixpkgs/commit/f9e50cf70f32a1fe6729a75b2ac5b3c1a078bc0a) haskell.packages.ghc94.cabal-install: make work
* [`e09625fc`](https://github.com/NixOS/nixpkgs/commit/e09625fc2bb3688d0e6872330ce2953b00681e9f) release-haskell.nix: test Cabal-syntax >= 3.8 as well
* [`cb558fa1`](https://github.com/NixOS/nixpkgs/commit/cb558fa1e95c6595eaf9880f9afbf8871bc269e6) clolcat: init at 1.1
* [`c3ab41d5`](https://github.com/NixOS/nixpkgs/commit/c3ab41d59273e5c4283213c745ffdbe09f6f974c) armadillo: 11.4.3 -> 12.0.1
* [`fae83110`](https://github.com/NixOS/nixpkgs/commit/fae831109185e5a2d0d78f1c7c62b36185b0657e) qtile: fix pulsevolume widget
* [`edc62383`](https://github.com/NixOS/nixpkgs/commit/edc62383e460f56f1050d65d20d578b8dca631b2) qtile: add myself as maintainer
* [`1addf91b`](https://github.com/NixOS/nixpkgs/commit/1addf91b0b24b8c8556bf5c484a7382f6fd4a6e8) qtile: add more options and expose unwrapped package
* [`8d3f59cd`](https://github.com/NixOS/nixpkgs/commit/8d3f59cd55f8f659f0d3959e5bbd193a6249e4af) ultrablue-server: init at unstable-2023-01-25
* [`4f9339f6`](https://github.com/NixOS/nixpkgs/commit/4f9339f6c4564ba618bde6f5d3097757635fa0d6) deepin.dde-control-center: init at 5.6.3
* [`4d5b2745`](https://github.com/NixOS/nixpkgs/commit/4d5b27458b0db7fb95ba0a3e03ea9d8f65b74049) python3Packages.azure-mgmt-frontdoor: init at 1.0.1
* [`1153bb88`](https://github.com/NixOS/nixpkgs/commit/1153bb884e199dca10e2c4714b7e70c62214542b) python3Packages.django-pattern-library: init at 1.0.0
* [`5c618b25`](https://github.com/NixOS/nixpkgs/commit/5c618b25974dbaf3f381a1efa4d52e7b28453b2f) python3Packages.draftjs-exporter: init at 2.1.7
* [`11019dc2`](https://github.com/NixOS/nixpkgs/commit/11019dc245a39faedebefd2137945716d3667c09) python3Packages.l18n: init at 2021.3
* [`1f094cd8`](https://github.com/NixOS/nixpkgs/commit/1f094cd8e38765b8daffd22e1039fe8199559097) python3Packages.permissionedforms: init at 0.1
* [`640cfc04`](https://github.com/NixOS/nixpkgs/commit/640cfc04ee9634e3b9bd22cd4a4b800b6a0dc5b0) python3Packages.telepath: init at 0.3
* [`6480e5cd`](https://github.com/NixOS/nixpkgs/commit/6480e5cd8d74725ab8b1af39ed975e118a42f8c9) geos: 3.11.1 -> 3.11.2
* [`61ddac6d`](https://github.com/NixOS/nixpkgs/commit/61ddac6d5eb80bac668744c5547b717a2d4e9ad7) python3Packages.wagtail-factories: init at 4.0.0
* [`5f25c053`](https://github.com/NixOS/nixpkgs/commit/5f25c053fabe0d60aba59f34984f97a8e21a3eae) python3Packages.wagtail-localize: init at 1.5
* [`b6629ca2`](https://github.com/NixOS/nixpkgs/commit/b6629ca286230b808fdcf287109cf324e99ec7d6) python3Packages.wagtail: init at 4.2
* [`f73d0e30`](https://github.com/NixOS/nixpkgs/commit/f73d0e3084aa5b56ccdab416f61e008170e4aaeb) fix cachix build
* [`600fd969`](https://github.com/NixOS/nixpkgs/commit/600fd969f6d317524f4e859824f577663d795d15) haskell.packages.ghc94.weeder: don't test on aarch64
* [`0cce97d6`](https://github.com/NixOS/nixpkgs/commit/0cce97d64ecdd009381c4464d82a7cbd1f547068) haskell.packages.*.vector: clean up and unify overrides, run tests
* [`6634553e`](https://github.com/NixOS/nixpkgs/commit/6634553e48f47185056d6646784a5f8fd329b1fe) haskell.packages.ghc94.cborg: resolve duplicate overlay entry
* [`6c96cf3d`](https://github.com/NixOS/nixpkgs/commit/6c96cf3d29f3b169b768a27ed2de14d7b86852c8) cogl: Add missing patch decompression
* [`93d9358c`](https://github.com/NixOS/nixpkgs/commit/93d9358ca35608ba084d7f86488ff1025003960c) maintainers: Add vinnymeller
* [`00b5e395`](https://github.com/NixOS/nixpkgs/commit/00b5e39534f0263802b4778bdc61b6a1f1c7410c) jcli: init at 0.0.41
* [`2cc14533`](https://github.com/NixOS/nixpkgs/commit/2cc1453302cbf31107ad56076314609b375e2002) crc: 2.14.0 -> 2.15.0
* [`eeeed328`](https://github.com/NixOS/nixpkgs/commit/eeeed328b40e7b3b5cf6ae6004e2fa85527946a5) crc: fix `update.sh` not updating git hash
* [`25ae2724`](https://github.com/NixOS/nixpkgs/commit/25ae2724974bca2b7d1ba0cb5772f57ac63673f7) haskell.packages.ghc94.cborg: unrestrict platforms
* [`31acb374`](https://github.com/NixOS/nixpkgs/commit/31acb3746d8d99b9b9ba81223c3b1b1912882550) python3Packages.rasterio: 1.3.5 -> 1.3.6
* [`49d835a2`](https://github.com/NixOS/nixpkgs/commit/49d835a29f6b4f033aaa2a6fb303bda422e28650) haskell.packages.ghc92.cabal-install: get to work
* [`205fbe97`](https://github.com/NixOS/nixpkgs/commit/205fbe972c620f27283a69a29e7e81e9d693a210) maintainers: add ettom
* [`f163a047`](https://github.com/NixOS/nixpkgs/commit/f163a047f593ab31a81e24fb68a72a162d39500a) zeyple: init at cc125b7
* [`a375b000`](https://github.com/NixOS/nixpkgs/commit/a375b000a673b6b5bb80c43f5d561c67c9bd3cdc) nixos/zeyple: init
* [`b73979f0`](https://github.com/NixOS/nixpkgs/commit/b73979f09bb6d8700c9c9214fd91939c92dcbc74) openssh: 9.2p1 -> 9.3p1
* [`53d9b6db`](https://github.com/NixOS/nixpkgs/commit/53d9b6db122334dc92daa62527bddea3947aaf32) openssh_*: Add knownVulnerabilities
* [`fc9d82a3`](https://github.com/NixOS/nixpkgs/commit/fc9d82a33533b2851da368cc4da735ab49bfa9fa) zola: 0.17.1 -> 0.17.2
* [`f2b3bed8`](https://github.com/NixOS/nixpkgs/commit/f2b3bed84721d3688de8de206a691fa34944c752) matrix-synapse: fix signing key path in fix-permissions script
* [`8da60f20`](https://github.com/NixOS/nixpkgs/commit/8da60f204ffc26b6ac59b39568071fa4e3276412) syncthing: apply autoSignDarwinBinariesHook
* [`fbda432e`](https://github.com/NixOS/nixpkgs/commit/fbda432ee5668d9d9facfc94e692c514fbd63dd5) tiv: add imagemagick to path
* [`dec6a6d9`](https://github.com/NixOS/nixpkgs/commit/dec6a6d91a07e8c16f2c83b7ff7af8d3cf81aaea) deepin.deepin-clone: init at 5.0.11
* [`545c0c31`](https://github.com/NixOS/nixpkgs/commit/545c0c31daf06a4e3c5f8f52dbbfed0d1bae28d4) maintainers: eken
* [`c4c109f8`](https://github.com/NixOS/nixpkgs/commit/c4c109f8215ee52e08eb65aba4f4833e14b1b476) wmenu: init at 0.1.2
* [`14a55e86`](https://github.com/NixOS/nixpkgs/commit/14a55e86420ee9a5ed75949edc66d063bc6bceec) via: 2.1.0 -> 3.0.0
* [`c4b7a143`](https://github.com/NixOS/nixpkgs/commit/c4b7a1439f905090faf0173d7288925e076bbc11) microsoft-edge: 107.0.1418.52 -> 111.0.1661.44
* [`70b7d001`](https://github.com/NixOS/nixpkgs/commit/70b7d001178c0ea218fdc46c5922f8ef332f328c) gnome-frog: 1.2.0 -> 1.3.0
* [`91c2c00a`](https://github.com/NixOS/nixpkgs/commit/91c2c00aad7d60baa0de4d20edc203615a539ba5) sumo: 1.15.0 -> 1.16.0
* [`e2f247c3`](https://github.com/NixOS/nixpkgs/commit/e2f247c39e6d00073945909a3b1047a16a2f8046) haskellPackages.hermes-json_0_2_0_1: generate package
* [`3009eda9`](https://github.com/NixOS/nixpkgs/commit/3009eda91b99771947fb4c983455c89ee58270ff) nix-output-monitor: use hermes-json-0.2.0.1
* [`7f663abb`](https://github.com/NixOS/nixpkgs/commit/7f663abbc28d126dd573d49ec1e7c122dd7d93db) haskellPackages.goldplate: make executable available for tests
* [`521f6aec`](https://github.com/NixOS/nixpkgs/commit/521f6aec443fb8e7b96a7f23b1c8f1637ce1b30a) haskellPackages.hspec-api: downgrade to match hspec
* [`1d31b69c`](https://github.com/NixOS/nixpkgs/commit/1d31b69cddb893e18a76908f9e57b39f344113d4) linux-kernels/linuxConfig: add kernelPatches
* [`ef9c99a0`](https://github.com/NixOS/nixpkgs/commit/ef9c99a035aea4b828324abe686210460a8cfd9e) nixos/kubo: add QUICv1 and WebTransport to Addresses.Swarm list
* [`2235dd46`](https://github.com/NixOS/nixpkgs/commit/2235dd4616b3e228e9811ebc6892c08b6a97f500) kubo: 0.18.1 -> 0.19.0
* [`319f623d`](https://github.com/NixOS/nixpkgs/commit/319f623d417867171b5abe7980c2930218a976c6) honk: 0.9.8 -> 0.9.91
* [`b2fe4102`](https://github.com/NixOS/nixpkgs/commit/b2fe4102fddc46d80e40f45c0582e835d1397903) haskellPackages: mark builds failing on hydra as broken
* [`3dade082`](https://github.com/NixOS/nixpkgs/commit/3dade082a18fbd36b3ba85b398bab1dcb8cac41b) exodus: 22.8.12 -> 23.3.13
* [`ba783d48`](https://github.com/NixOS/nixpkgs/commit/ba783d488784ae1ad28a821aedf33015931874c0) protonmail-bridge: 3.0.18 -> 3.0.21
* [`b5f7d9c3`](https://github.com/NixOS/nixpkgs/commit/b5f7d9c3ae2600cd689964ebf8488815d80a80e7) flink: 1.14.4 -> 1.17.0
* [`46344c77`](https://github.com/NixOS/nixpkgs/commit/46344c77b3d313d9c5e1a7a7053836de9935ee7f) nixos/proxychains: add package option
* [`177b6a4b`](https://github.com/NixOS/nixpkgs/commit/177b6a4bc3f9bb2685566bac7c5e199070bc62a2) cloudlog: remove import-from-derivation in config
* [`16476ccd`](https://github.com/NixOS/nixpkgs/commit/16476ccdce65478f64864e5bc4c6320f1cd32a09) haskellPackages.hs-swisstable-hashtables-class: only build on x86_64
* [`f430566c`](https://github.com/NixOS/nixpkgs/commit/f430566c57413ea0be1ad562c40d09b36562dd20) haskellPackages: add comments to release-haskell.nix
* [`0d364a01`](https://github.com/NixOS/nixpkgs/commit/0d364a0117111c1677f0685a9ec3cca38d9608b3) haskellPackages: small formatting fix to versionedCompilerJobs in release-haskell.nix
* [`4a736e5e`](https://github.com/NixOS/nixpkgs/commit/4a736e5ede53881ed86078e8a31301ba0a62057f) haskellPackages: small refactoring and comments to versionedCompilerJobs in release-haskell.nix
* [`105e326f`](https://github.com/NixOS/nixpkgs/commit/105e326f5fb9d8220c88775561053796e991b86a) haskellPackages: make sure versionedCompilerJobs doesn't try running on platforms ghc does not support
* [`ac9174a5`](https://github.com/NixOS/nixpkgs/commit/ac9174a548614ba96852812aeb232080b62f13af) aliases: document avoiding them within nixpkgs better
* [`4f7f469c`](https://github.com/NixOS/nixpkgs/commit/4f7f469c8257e136f24bbd2f079e8507790eca57) timescaledb: Fixed the licensing for the timescaledb package to be split into TSL (Timescale Community License) and Apache 2.0 components.
* [`91f99f14`](https://github.com/NixOS/nixpkgs/commit/91f99f14ff83b3c2ca0c90c29ada3b030127152d) linuxPackages.nvidia_x11: add support for zstd compression
* [`c3ce7112`](https://github.com/NixOS/nixpkgs/commit/c3ce711249cb09e3558468e3d0e33d5870affe65) nixos/nvidia: re-enable IBT for newer drivers
* [`37842ec1`](https://github.com/NixOS/nixpkgs/commit/37842ec1a4e67425f646366e07448a53bcedd434) vivaldi: Fix X11 video / Vulkan hardware acceleration
* [`070c3a15`](https://github.com/NixOS/nixpkgs/commit/070c3a155fb4a6f0f2c7c7f72d2ae5d534b6271f) linuxPackages.nvidia_x11_beta: 525.89.02 -> 530.30.02
* [`90c44c95`](https://github.com/NixOS/nixpkgs/commit/90c44c959814b11009fe3abb33344fa6f5e6d290) linuxPackages.nvidia_x11: 525.89.02 -> 530.41.03
* [`3aea75b8`](https://github.com/NixOS/nixpkgs/commit/3aea75b8fc82e416d8146a6b3d6338395c2dfbd9) haskellPackages: fix indentiation in hydra-report.hs
* [`265a3a3b`](https://github.com/NixOS/nixpkgs/commit/265a3a3b1581f0d7825e04d772d2f34e490745db) haskellPackages: add types and some formatting to hydra-report.hs
* [`133dcda4`](https://github.com/NixOS/nixpkgs/commit/133dcda49227a4ddfab2eafc975688e734360219) go-containerregistry: 0.11.0 -> 0.14.0
* [`f01d7a52`](https://github.com/NixOS/nixpkgs/commit/f01d7a521204db43fc0da4165f081e90c207980d) vivaldi: Fix fontconfig
* [`e8c9c38d`](https://github.com/NixOS/nixpkgs/commit/e8c9c38ddedfa7361fb85d19e236a0b2d108f51d) wsdd: add man
* [`376345c7`](https://github.com/NixOS/nixpkgs/commit/376345c705ab9dfaf68cfcba68648d9c1aa71b4b) wsdd: 0.7.0 -> 0.7.1
* [`5073b8c3`](https://github.com/NixOS/nixpkgs/commit/5073b8c39ce15e1ff381d4352f44a5cd1317d916) firefox-devedition-bin-unwrapped: 112.0b5 -> 112.0b6
* [`cb619a09`](https://github.com/NixOS/nixpkgs/commit/cb619a09e024e7d16523422091d7027826f9678b) pythonPackages.pyrr: 0.10.3 -> unstable-2022-07-22
* [`f31c0d7f`](https://github.com/NixOS/nixpkgs/commit/f31c0d7f9e03b911d225eec1021b9b1573882c6f) python310Packages.trimesh: 3.20.2 -> 3.21.0
* [`f50a1657`](https://github.com/NixOS/nixpkgs/commit/f50a1657dede88134b9289651d81d4c54b9c1d25) vips: 8.14.1 -> 8.14.2
* [`2a3b9026`](https://github.com/NixOS/nixpkgs/commit/2a3b9026be919c50fe4bb201f6c45595b7790baa) unison: 2.53.0 -> 2.53.2
* [`d7282c90`](https://github.com/NixOS/nixpkgs/commit/d7282c901d68286717db16d64f5605725a4bf491) snappymail: 2.26.4 -> 2.27.2
* [`07b7e795`](https://github.com/NixOS/nixpkgs/commit/07b7e7950206791b4fc5c74a804fccbb07b5e959) viceroy: 0.4.0 -> 0.4.1
* [`d60cc037`](https://github.com/NixOS/nixpkgs/commit/d60cc03705f4aeb956285b79fe088b153bdd3875) twilio-cli: 5.4.2 -> 5.5.0
* [`bb270775`](https://github.com/NixOS/nixpkgs/commit/bb270775f2dc80e6fba3984d641415adbe58393b) cvc5: 1.0.4 -> 1.0.5
* [`df59c898`](https://github.com/NixOS/nixpkgs/commit/df59c8988be65b8621cc0a79e1452a173d4fd1a4) hubstaff: 1.6.12-da9418f3 -> 1.6.13-269829b4
* [`a47f4123`](https://github.com/NixOS/nixpkgs/commit/a47f412366cc6a8966185c8ff61e6b1fe43cef05) python310Packages.dyn: 1.8.1 -> 1.8.6
* [`8c061165`](https://github.com/NixOS/nixpkgs/commit/8c061165c32433732bc6c43b6e3a821ccada7a99) python310Packages.plaid-python: 11.6.0 -> 12.0.0
* [`f03bd2b7`](https://github.com/NixOS/nixpkgs/commit/f03bd2b70ea264b0e15fab27351a7234b91e042e) livepeer: mark not broken on darwin
* [`237510b1`](https://github.com/NixOS/nixpkgs/commit/237510b1128015636e2c57b9a21af6da6df09721) jbang: 0.104.0 -> 0.105.1
* [`69cc4d0c`](https://github.com/NixOS/nixpkgs/commit/69cc4d0ce8c5b6fc8d2401557aa436363cab5b5b) python310Packages.trimesh: 3.21.0 -> 3.21.2
* [`231ecef5`](https://github.com/NixOS/nixpkgs/commit/231ecef5a919284dacdaf1b57dfbe3ce8e4a045b) twilio-cli: fix tests.version
* [`a99a07b1`](https://github.com/NixOS/nixpkgs/commit/a99a07b1a611b863c03b8db99a5d292f1fd100a7) python310Packages.trimesh: set format to "pyproject"
* [`4d164b7d`](https://github.com/NixOS/nixpkgs/commit/4d164b7d1c7a3490cc9e7d574572fb2bf5107f81) python310Packages.myst-nb: fix build
* [`d4f55d10`](https://github.com/NixOS/nixpkgs/commit/d4f55d1005d782a8c174da2f2c084e55266f59d0) twilio-cli: changelog url
* [`96200c5e`](https://github.com/NixOS/nixpkgs/commit/96200c5e43b108748568e87e2e844066229b083e) python310Packages.trimesh: execute minimal test
* [`538ab435`](https://github.com/NixOS/nixpkgs/commit/538ab435ae06a42fa6bc9d1086ff6ff00b431d24) esbuild: 0.17.13 -> 0.17.14
* [`01e08cba`](https://github.com/NixOS/nixpkgs/commit/01e08cbafbca3e150bd41609b573c98bf1f85bee) millet: 0.8.3 -> 0.8.6
* [`1c313584`](https://github.com/NixOS/nixpkgs/commit/1c313584cc51607840d5e54d4a51bd0a266049f1) katana: 0.0.3 -> 1.0.0
* [`6afaad64`](https://github.com/NixOS/nixpkgs/commit/6afaad64ebe209afd541fb225e8700fdbb20ba71) git-stack: 0.10.12 -> 0.10.14
* [`7ca5b504`](https://github.com/NixOS/nixpkgs/commit/7ca5b50432a833fc66cfa6f2594671bfab9701d7) dump1090: mark working on darwin
* [`f7c66bf8`](https://github.com/NixOS/nixpkgs/commit/f7c66bf8eaf6b754b64acf68d405984aa28f72d4) xgalagapp: init at 0.9
* [`fdf38b8a`](https://github.com/NixOS/nixpkgs/commit/fdf38b8a0301806498c1a80c171c66b9d1050408) cyberchef: 9.55.0 -> 10.2.0
* [`c574a8c3`](https://github.com/NixOS/nixpkgs/commit/c574a8c37ee12ddbbb4477544b57ca2c7a5e2536) haskellPackages: add a little documentation to hydra-report.hs
* [`28f22d86`](https://github.com/NixOS/nixpkgs/commit/28f22d86d7b26e7923ce3465c4978ba3546c5b74) haskellPackages: slight refactoring of hydra-report.hs
* [`50e860b9`](https://github.com/NixOS/nixpkgs/commit/50e860b91ebcdbc71b94f3ceeb7542e28ae12d29) xdg-desktop-portal-kde: fix missing runtime dependency
* [`ffd0990a`](https://github.com/NixOS/nixpkgs/commit/ffd0990ad12ed766686d476a3d68d4030141d173) mako: add jq and systemd to PATH of makoctl
* [`b2af201c`](https://github.com/NixOS/nixpkgs/commit/b2af201c0e70b28d59e26becd18b3095dc7f9636) haskellPackages: add newtype for JobName in hydra-report.hs
* [`9a1bef21`](https://github.com/NixOS/nixpkgs/commit/9a1bef21ef0e782595862ba39c25dcd82ff2b54b) trino-cli: 403 -> 410
* [`19b43593`](https://github.com/NixOS/nixpkgs/commit/19b435931aa311acd115fe7f104685070f408c10) ocamlPackages.mirage-block-ramdisk: use Dune 3
* [`bec9dd54`](https://github.com/NixOS/nixpkgs/commit/bec9dd54c60c4d36caaed0d7ff84e68d38783c05) ocamlPackages.mirage-block-unix: use Dune 3
* [`01f457d3`](https://github.com/NixOS/nixpkgs/commit/01f457d3280a1cd94fd18ce186eb41ba1b2bfbc1) ocamlPackages.mirage-block: 3.0.0 → 3.0.2
* [`5475dfc1`](https://github.com/NixOS/nixpkgs/commit/5475dfc18d95153fdfda20ac6dc005bade7ce718) apacheHttpd: 2.4.55 -> 2.4.56
* [`dd557d36`](https://github.com/NixOS/nixpkgs/commit/dd557d36371e7b1d719f72ad25c825a517a4f484) ack: 3.6.0 -> 3.7.0
* [`d752b1a8`](https://github.com/NixOS/nixpkgs/commit/d752b1a8c5bc0e3e5ef8926d4765c9f22a5c067c) alacritty: 0.11.0 -> 0.12.0
* [`d2593b56`](https://github.com/NixOS/nixpkgs/commit/d2593b5650e39252c040da732d3424d871234145) alfaview: 8.58.2 -> 8.65.0
* [`1b4f8f9b`](https://github.com/NixOS/nixpkgs/commit/1b4f8f9b16050ad0d14eda81f798036d8fc918e5) netpbm: 11.1.0 -> 11.2.0
* [`60ecb0a5`](https://github.com/NixOS/nixpkgs/commit/60ecb0a52e1918d45678af973adf9bdfddcc934e) prusa-slicer: 2.5.0 -> 2.5.1
* [`19b56763`](https://github.com/NixOS/nixpkgs/commit/19b567636119e6dac41a770370bd5e58a60c8f59) haskellPackages: add newtype for PkgName and PkgSet in hydra-report.hs
* [`2cb2ee96`](https://github.com/NixOS/nixpkgs/commit/2cb2ee963019b3cfd381683343a81ec21077384a) ginac: 1.8.5 -> 1.8.6
* [`d0be03cc`](https://github.com/NixOS/nixpkgs/commit/d0be03cc91995aa1a99a5d07d49e7de1061355fc) arkade: 0.9.4 -> 0.9.5
* [`6aab31bf`](https://github.com/NixOS/nixpkgs/commit/6aab31bf5027043e2a3c7b676cec7ee46033bc50) booster: 0.9 -> 0.10
* [`322dda51`](https://github.com/NixOS/nixpkgs/commit/322dda5148212661366ce3657be56138996e3b87) weather: 2.4.2 -> 2.4.4
* [`7cbb2be5`](https://github.com/NixOS/nixpkgs/commit/7cbb2be5082c3fc696ae0e2f1aff2e52f55682d4) datovka: 4.21.1 -> 4.22.0
* [`7de0aead`](https://github.com/NixOS/nixpkgs/commit/7de0aeade4db1c46cb2767bc64418eff51f44f6c) ckbcomp: 1.217 -> 1.218
* [`e05175a7`](https://github.com/NixOS/nixpkgs/commit/e05175a7c9578559305fd5471aa5e749ee72b6d9) ostree: 2023.1 -> 2023.2
* [`8b7f79be`](https://github.com/NixOS/nixpkgs/commit/8b7f79be5c17603ad59d99064e4cdfe989fd4ffd) setbfree: 0.8.11 -> 0.8.12
* [`d0b5d7f9`](https://github.com/NixOS/nixpkgs/commit/d0b5d7f95cb68f941be6e86a0bdc9647b6f2f4b3) mydumper: 0.13.1-1 -> 0.14.1-1
* [`42aa7965`](https://github.com/NixOS/nixpkgs/commit/42aa7965621f2e044ee2fcfa3eff3e8aa699123b) osm2pgsql: unpin from fmt_8
* [`793bd718`](https://github.com/NixOS/nixpkgs/commit/793bd718629e5974bb2e85558bb9186a1340af0e) dab_lib: unstable-2021-12-28 -> unstable-2023-03-25
* [`afeb7db8`](https://github.com/NixOS/nixpkgs/commit/afeb7db834b3e32e397296a77ee71695f7173118) python310Packages.zeroc-ice: 3.7.8.2 -> 3.7.9
* [`f463bda4`](https://github.com/NixOS/nixpkgs/commit/f463bda48dd02e7f5401bc9a5de84a53d0df1e50) protoc-gen-validate: 0.9.1 -> 0.10.1
* [`ddfbf234`](https://github.com/NixOS/nixpkgs/commit/ddfbf234cede27e482894c7b202fd0d95393081f) fizz: 2023.03.06.00 -> 2023.03.20.00
* [`c6de147d`](https://github.com/NixOS/nixpkgs/commit/c6de147d1325d55ba2ed39ad557b85f4afd51d0a) fizz: add changelog to meta
* [`c62b815b`](https://github.com/NixOS/nixpkgs/commit/c62b815bc4ae6937e13bfee4399e3af6aacd4b6d) adw-gtk3: support all unix platforms
* [`e93eeb6c`](https://github.com/NixOS/nixpkgs/commit/e93eeb6c8230ad1e9d8f75e231b8d626adf27fe8) python310Packages.datadog: 0.44.0 -> 0.45.0
* [`11b3e643`](https://github.com/NixOS/nixpkgs/commit/11b3e643de14be40a6a8cf07281e77424acc734b) xfce.xfce4-clipman-plugin: 1.6.2 -> 1.6.3
* [`b5e8c476`](https://github.com/NixOS/nixpkgs/commit/b5e8c47696600a719a14a83f870e906d5458c193) python310Packages.pydy: 0.6.0 -> 0.7.1
* [`e564c700`](https://github.com/NixOS/nixpkgs/commit/e564c700cc47c62a6b328dc844512d1fbd7176df) redmine: Update outstanding Gemfile to latest stable release
* [`eb7fd31c`](https://github.com/NixOS/nixpkgs/commit/eb7fd31ca062c57e20564380eac5167c3da9ad1b) altair: 5.0.17 -> 5.0.19
* [`619fbfc0`](https://github.com/NixOS/nixpkgs/commit/619fbfc06972b4ba1a2b8174e1cdcaf9b6b16e5c) pscale: 0.130.0 -> 0.133.0
* [`aa9f2afe`](https://github.com/NixOS/nixpkgs/commit/aa9f2afec4f0e383a5fe3d250112e72162da38c9) phrase-cli: 2.7.0 -> 2.8.0
* [`f4b0e86c`](https://github.com/NixOS/nixpkgs/commit/f4b0e86c9386a90a8099b34464bae17f248af1c8) svlint: 0.6.1 -> 0.7.1
* [`0fa75a6f`](https://github.com/NixOS/nixpkgs/commit/0fa75a6ff5dc38ca22978433974c1d45e4876358) cf-terraforming: 0.10.0 -> 0.11.0
* [`c3966c2d`](https://github.com/NixOS/nixpkgs/commit/c3966c2d35b14e4ed90723724f986183ba9c68ee) freedv: 1.8.7 -> 1.8.8
* [`a715e773`](https://github.com/NixOS/nixpkgs/commit/a715e773cceaf2cdf28e9aaa4c9298a8821feaf4) xmrig-mo: 6.19.0-mo1 -> 6.19.1-mo1
* [`21832bd5`](https://github.com/NixOS/nixpkgs/commit/21832bd52db3871501488777a6c2b98c63c0133a) kubernetes-metrics-server: 0.6.2 -> 0.6.3
* [`5265db59`](https://github.com/NixOS/nixpkgs/commit/5265db5915c146d8d78184519688dbc8034ef339) argocd-vault-plugin: 1.13.1 -> 1.14.0
* [`460dec94`](https://github.com/NixOS/nixpkgs/commit/460dec94b1592e8ea2d21f268de247b5de5228f3) ocamlPackages.tsdl-ttf: 0.3.2 → 0.5
* [`4d5d4665`](https://github.com/NixOS/nixpkgs/commit/4d5d4665ca028aca6919bdebc05947ebb6dd9c63) ocamlPackages.tsdl-mixer: 0.3.2 → 0.5
* [`1c30d5e3`](https://github.com/NixOS/nixpkgs/commit/1c30d5e3146b51b8bd08f9335b57a4ba02ec5bd5) ocamlPackages.tsdl-image: 0.3.2 → 0.5
* [`a49c9701`](https://github.com/NixOS/nixpkgs/commit/a49c9701e83bd96ca6ea2e04dcbb718b6d650c30) ocamlPackages.tsdl: 0.9.9 → 1.0.0
* [`d2e946e2`](https://github.com/NixOS/nixpkgs/commit/d2e946e21ad876c4a4808473386fd2845f51e554) sqlcmd: 0.15.3 -> 0.15.4
* [`1c415839`](https://github.com/NixOS/nixpkgs/commit/1c41583945c03f0d5d2bf0919dc802c628754274) vala-language-server: 0.48.5 -> 0.48.7
* [`51a1a188`](https://github.com/NixOS/nixpkgs/commit/51a1a188719c9f5910681e4cd39601ad31edde96) tmux-mem-cpu-load: 3.6.1 -> 3.6.2
* [`647ac3f5`](https://github.com/NixOS/nixpkgs/commit/647ac3f5a46fc8e8c3853edbf003543ef929884e) osinfo-db: 20221130 -> 20230308
* [`56376c51`](https://github.com/NixOS/nixpkgs/commit/56376c515a7bb0d1b7f42ff69ab006f87458de8b) redpanda: 23.1.1 -> 23.1.3
* [`bd9bb50a`](https://github.com/NixOS/nixpkgs/commit/bd9bb50ad22102b92e3a6e2231343a6550c7fc62) haskellPackages: remove error about outstanding jobs on aarch64-darwin in hydra-report.hs
* [`35295aed`](https://github.com/NixOS/nixpkgs/commit/35295aed71ed588fb3b998110ab89e072aac731f) haskellPackages: in hydra-report.hs, split Linux and Darwin build failures
* [`4d0c6652`](https://github.com/NixOS/nixpkgs/commit/4d0c66529b67219fadd720778a921ab3f68efc94) src: 1.29 -> 1.31
* [`7f6bfd8f`](https://github.com/NixOS/nixpkgs/commit/7f6bfd8f3879f070ec6b77209efe73c54e210264) argocd: 2.6.5 -> 2.6.7
* [`f757e6cc`](https://github.com/NixOS/nixpkgs/commit/f757e6cc0afcb5162445cdd3a9aa1bc70239e168) rustls-ffi: init at 0.9.2
* [`43f7cc0d`](https://github.com/NixOS/nixpkgs/commit/43f7cc0df7c2e4564da45b4463e63aa3e9264e52) dotnet-sdk_3: remove
* [`3b0d74bc`](https://github.com/NixOS/nixpkgs/commit/3b0d74bccc8af16296c1f637d7e55c8ba0c23d60) maintainers: add panda2134
* [`3257a92f`](https://github.com/NixOS/nixpkgs/commit/3257a92f244ed8811f9fd64412583477d1325737) mutt: 2.2.9 -> 2.2.10
* [`0da40725`](https://github.com/NixOS/nixpkgs/commit/0da407258286793d3c1189b2b0ef496063acac4d) llvmPackages_git.llvm: run the tests on macOS
* [`a2cb09e3`](https://github.com/NixOS/nixpkgs/commit/a2cb09e3047759070fc29c1abd70d3b8cc35ef91) katana: add changelog to meta
* [`5d315417`](https://github.com/NixOS/nixpkgs/commit/5d315417f20eb31842cf524bc480f3429adb9d3f) cyberchef: add changelog to meta
* [`ef989867`](https://github.com/NixOS/nixpkgs/commit/ef989867aeb6acd08dcd40c132d33f80ce088a3d) exploitdb: 2023-03-25 -> 2023-03-26
* [`4bd4a8d4`](https://github.com/NixOS/nixpkgs/commit/4bd4a8d462132e38417d2aaf9a1f98c2d1babd51) python310Packages.lightwave2: 0.8.21 -> 0.8.22
* [`422b0ff9`](https://github.com/NixOS/nixpkgs/commit/422b0ff93b3d72b366f7473766dbbbd0fa665e47) steam: use writeShellScript
* [`192c3ecd`](https://github.com/NixOS/nixpkgs/commit/192c3ecd4bcc317c3d8868d3c944a75de0dee32e) buildFHSEnvBubblewrap: allow deeper introspection via passthru
* [`47315987`](https://github.com/NixOS/nixpkgs/commit/473159871236e584af08386ed408aef30102395c) nixos/steam: always apply extraLibraries and make them additive
* [`1f27e0b7`](https://github.com/NixOS/nixpkgs/commit/1f27e0b77a63fd243ab40dfce22edf106424faea) steam: add extraEnv option
* [`230d5060`](https://github.com/NixOS/nixpkgs/commit/230d506073fffd12051fc30c184fb5dd6f2a1864) netbox: workaround to allow python packageOverrides
* [`ea5208f0`](https://github.com/NixOS/nixpkgs/commit/ea5208f0e5fdf1b0343a207847e27fb37b62af92) python310Packages.zha-quirks: remove asynctest
* [`8a619cd5`](https://github.com/NixOS/nixpkgs/commit/8a619cd583a1d259d4814469d4418bdbb161c1f3) subtitleedit: 3.6.11 -> 3.6.12
* [`3f9a9ad9`](https://github.com/NixOS/nixpkgs/commit/3f9a9ad9f27bb6c82485cee964da4b05def00f78) llvmPackages_git.llvm: adjust a path, skip an xfail test on darwin
* [`761552c4`](https://github.com/NixOS/nixpkgs/commit/761552c4c30d714cec66422eaf032df025ddc6f9) prometheus-postgres-exporter: 0.11.1 -> 0.12.0
* [`83979742`](https://github.com/NixOS/nixpkgs/commit/83979742992859f01a78adc19ff47a4f1c4c6567) hugin: add wrapGAppsHook
* [`c239772e`](https://github.com/NixOS/nixpkgs/commit/c239772ef27312876e585f8610de52883886e2e2) nerdfix: init at 0.1.0
* [`430b8f07`](https://github.com/NixOS/nixpkgs/commit/430b8f07b5fa5681e47f96970e9b380ce6a34b17) sleep-on-lan: init at 1.1.1
* [`21d74253`](https://github.com/NixOS/nixpkgs/commit/21d74253b94fb83e5aa77295e83981d49b245d22) chromiumDev: 113.0.5653.0 -> 113.0.5668.0
* [`e4277a6c`](https://github.com/NixOS/nixpkgs/commit/e4277a6cf1bd8255fd3fb6f2898a4449061fd31c) python310Packages.asyncpg: use pytestCheckHook
* [`5c7757b1`](https://github.com/NixOS/nixpkgs/commit/5c7757b10b1347c23d141a5a0c5672a81f48fda7) microbin: 1.1.0 -> 1.2.1, add figsoda as a maintainer
* [`1faef680`](https://github.com/NixOS/nixpkgs/commit/1faef68068582fd43fefcd8149a95707bfea5015) maintainers: add mynacol
* [`eb123f6e`](https://github.com/NixOS/nixpkgs/commit/eb123f6e7c8860a30e9ef8ad88f4f3df264890ad) typst: 22-03-21-2 -> 23-03-21-2
* [`de508898`](https://github.com/NixOS/nixpkgs/commit/de5088984835d244a2a02da82f675c77adfb0c7b) leanify: init at unstable-2022-12-04
* [`82427c93`](https://github.com/NixOS/nixpkgs/commit/82427c93fe40596a482a279d32529a5e2a8711c9) hip: 5.4.3 -> 5.4.4
* [`ff75d77c`](https://github.com/NixOS/nixpkgs/commit/ff75d77c5d6803123568981d0413606f58252a53) golangci-lint: 1.52.1 -> 1.52.2
* [`3f977c13`](https://github.com/NixOS/nixpkgs/commit/3f977c13dd35ad9729c237addc5f9d67898023ed) leanify: mark darwin as broken
* [`d7887373`](https://github.com/NixOS/nixpkgs/commit/d7887373fe0731719365831cd254c1e5948307d3) keyleds: init at 2022-07-03
* [`744cfdaf`](https://github.com/NixOS/nixpkgs/commit/744cfdaf11096ae724e920107229d2ca59dafea8) yq-go: 4.32.2 -> 4.33.1
* [`40c8ceba`](https://github.com/NixOS/nixpkgs/commit/40c8cebade44d2874453ed992a7ec2d50123a34d) nixos/synapse: Fix incorrect module path after it was moved
* [`d5929d7a`](https://github.com/NixOS/nixpkgs/commit/d5929d7a82d4836baf2377b4f3d3481a98dbe06a) btrbk: 0.32.5 -> 0.32.6
* [`c3005373`](https://github.com/NixOS/nixpkgs/commit/c300537363c80956048b1778d441b7d058a94b3d) dnscontrol: 3.29.0 -> 3.29.1
* [`8c238320`](https://github.com/NixOS/nixpkgs/commit/8c238320ef24013df837232591d9f0154e756382) haskellPackages: mark builds failing on hydra as broken
* [`88e877fe`](https://github.com/NixOS/nixpkgs/commit/88e877fe1c764a55db4cc361fefc5d950c601807) haskellPackages.ffmpeg-light: force use of ffmpeg-4
* [`55024cd3`](https://github.com/NixOS/nixpkgs/commit/55024cd307e4400463d64bc63b93d1cacfad7459) podman-desktop: init at 0.12.0
* [`11df7afe`](https://github.com/NixOS/nixpkgs/commit/11df7afec3b2ad591af7bbd41c21eea308725569) sing-box: 1.2.0 -> 1.2.1
* [`21877e10`](https://github.com/NixOS/nixpkgs/commit/21877e107c3be158c957d84403b0a103c095753e) sing-box: add updateScript
* [`2c467644`](https://github.com/NixOS/nixpkgs/commit/2c4676444a26872ab48905c46f66e18f45847c97) newsboat: 2.30.1 -> 2.31
* [`71d37d85`](https://github.com/NixOS/nixpkgs/commit/71d37d8535798cfec0311815bb34fc098e77855e) libnitrokey: init at 3.8
* [`771d3963`](https://github.com/NixOS/nixpkgs/commit/771d39638bc45280dadabdbf2734024b5843681e) nitrokey-udev-rules: replace with libnitrokey
* [`db12fced`](https://github.com/NixOS/nixpkgs/commit/db12fcedef38fead8a86c2e7b5fb276330b91c12) qmplay2: 22.08.21 -> 23.02.05
* [`59cf5102`](https://github.com/NixOS/nixpkgs/commit/59cf5102f01f0f6aa368a9ba82202edca86a1845) onlyoffice-bin: fix icon location
* [`71b10457`](https://github.com/NixOS/nixpkgs/commit/71b10457885cf0c9177ac9b833361b11f2fb7a3c) openvscode-server: 1.75.0 -> 1.76.2
* [`ae3ac99d`](https://github.com/NixOS/nixpkgs/commit/ae3ac99d579b4d881813e7c94542123efec95d7e) exhaustive: init at 0.10.0
* [`2799851a`](https://github.com/NixOS/nixpkgs/commit/2799851afb30ac641bd33dfa0118d3bc5b033fad) rsonpath: init at 0.3.2
* [`596b7126`](https://github.com/NixOS/nixpkgs/commit/596b7126582e6592c447536d65abaac8b4c2c3aa) mill: 0.10.11 -> 0.10.12
* [`a574b814`](https://github.com/NixOS/nixpkgs/commit/a574b81449ac15cc619053dbf095e67192712a4a) eartag: 0.3.2 -> 0.3.3
* [`822ae3e8`](https://github.com/NixOS/nixpkgs/commit/822ae3e89125fb2f709a237435713b020b00ab37) nvidia-vaapi-driver: add `-Wno-error`
* [`88076399`](https://github.com/NixOS/nixpkgs/commit/88076399f496666119828d1fa7d8cd82cd0a3d18) gtk-server: 2.4.5 -> 2.4.6
* [`9c7e5c7c`](https://github.com/NixOS/nixpkgs/commit/9c7e5c7c532d88f194a96d7711c580b363e556b4) python3Packages.pymoo: 0.6.0 -> 0.6.0.1 ([nixos/nixpkgs⁠#223332](https://togithub.com/nixos/nixpkgs/issues/223332))
* [`e541cff5`](https://github.com/NixOS/nixpkgs/commit/e541cff5de9f58923f2c41ba2116bc5445e8f0d0) eksctl: 0.134.0 -> 0.135.0
* [`0bd1408d`](https://github.com/NixOS/nixpkgs/commit/0bd1408dfe17712e9896dedec45e57548f347339) ocamlPackages: fix eval
* [`158d6034`](https://github.com/NixOS/nixpkgs/commit/158d603401ad885c2f8275861133cc3999a7f0e8) steampipe: 0.19.2 -> 0.19.3
* [`3b865634`](https://github.com/NixOS/nixpkgs/commit/3b8656349258ff70c03e1bde168a962059ef6297) mpd-mpris: 0.3.1 -> 0.4.0
* [`68345e8e`](https://github.com/NixOS/nixpkgs/commit/68345e8e571e11036a7dc62bb499b2a46004b479) python310Packages.asyncpg: add changelog to meta
* [`dec9899d`](https://github.com/NixOS/nixpkgs/commit/dec9899d8ec039633d75b14ac3c925120557e931) python310Packages.dvc-objects: 0.20.0 -> 0.21.1
* [`f70568dd`](https://github.com/NixOS/nixpkgs/commit/f70568dd6d3babc3749796acc9ec58c7fcabf71c) qovery-cli: 0.54.0 -> 0.55.0
* [`111ff168`](https://github.com/NixOS/nixpkgs/commit/111ff168c9b0dbdd8624a85f5d11632fc2da8848) amass: 3.22.1 -> 3.22.2
* [`bb82199e`](https://github.com/NixOS/nixpkgs/commit/bb82199ebebf26c262712daaa90f2a3f53777d41) python310Packages.yalexs-ble: 2.1.6 -> 2.1.10
* [`bc80e23d`](https://github.com/NixOS/nixpkgs/commit/bc80e23d048ec46e224352e530b6a86ecd03d547) python310Packages.pydeconz: 110 -> 111
* [`7d7f8be0`](https://github.com/NixOS/nixpkgs/commit/7d7f8be0b776dd3f55fb16c2fa939fa2e1e25a68) python310Packages.niapy: 2.0.4 -> 2.0.5
* [`1b691903`](https://github.com/NixOS/nixpkgs/commit/1b6919037c1e5c7449901657a22a84fb9726b94e) python310Packages.hahomematic: 2023.2.11 -> 2023.3.0
* [`4ec16be0`](https://github.com/NixOS/nixpkgs/commit/4ec16be06c59f3cbfeca9b5328b8cbcaabab418c) python310Packages.types-python-dateutil: 2.8.19.8 -> 2.8.19.10
* [`fc3357f6`](https://github.com/NixOS/nixpkgs/commit/fc3357f6b69e0317e336620f4670818b2a1e6c75) python310Packages.types-pytz: 2022.7.1.2 -> 2023.2.0.0
* [`98615cb6`](https://github.com/NixOS/nixpkgs/commit/98615cb6dc585f3e1b4363dc6fcfe653c8aea016) python310Packages.types-urllib3: 1.26.25.8 -> 1.26.25.9
* [`31c05a52`](https://github.com/NixOS/nixpkgs/commit/31c05a5230806ee99f4946ca794be36a3bcc6b5b) python310Packages.aioesphomeapi: 13.5.1 -> 13.6.0
* [`45003ac1`](https://github.com/NixOS/nixpkgs/commit/45003ac138216f681f3a6d23e790c8c3c3a6e847) yewtube: 2.10.1 -> 2.10.2
* [`a188ce34`](https://github.com/NixOS/nixpkgs/commit/a188ce34366863de551a5721525a52a0aa38612a) python310Packages.pyzerproc: remove asynctest
* [`399396ec`](https://github.com/NixOS/nixpkgs/commit/399396ec833c96ede55a0bd91c4826bce1752897) python310Packages.scikit-hep-testdata: 0.4.28 -> 0.4.30
* [`147e04f2`](https://github.com/NixOS/nixpkgs/commit/147e04f2c892ba12f90ee5ece40832229f98cce9) wezterm: 20230320-124340-559cb7b0 -> 20230326-111934-3666303c
* [`76694fde`](https://github.com/NixOS/nixpkgs/commit/76694fdeb3fc6e4f975cbf621df6b332b61ae35e) prl-tools: refactor
* [`9b60eef4`](https://github.com/NixOS/nixpkgs/commit/9b60eef4bdcb63b0a51e260d6fec79ff53f9d67b) authelia: move module under security and minor fixes
* [`830b112e`](https://github.com/NixOS/nixpkgs/commit/830b112ebb5cdd5bb4c6e39f2af955a3f8f01762) librewolf-unwrapped: 111.0-3 -> 111.0.1-1
* [`855b6e2a`](https://github.com/NixOS/nixpkgs/commit/855b6e2ad0e08fa92956f3f9f7de0a5fc5c794ee) nim-unwrapped: Add missing Security framework buildInput
* [`8a2c93e5`](https://github.com/NixOS/nixpkgs/commit/8a2c93e5b80ae8e93115628dff4a423a2ca395b7) xfsprogs: 6.1.1 -> 6.2.0
* [`0b7ad90f`](https://github.com/NixOS/nixpkgs/commit/0b7ad90fb51198a8c3d6622f9400f68f5b068f9c) python310Packages.python-telegram-bot: 20.1 -> 20.2
* [`5ad0e539`](https://github.com/NixOS/nixpkgs/commit/5ad0e539169d07ddde4fae2409fe131889bfafd7) cppcodec: init at 0.2
* [`26450794`](https://github.com/NixOS/nixpkgs/commit/2645079477a9412bd25716b2605cadad294ed02a) nitrokey-app: use system libnitrokey and cppcodec
* [`e9c1dac2`](https://github.com/NixOS/nixpkgs/commit/e9c1dac2ab807e180cfbf5652872ba6410ed9b36) haskellPackages.cabal-install.scope.vector: don't pull in doctest
* [`bc319601`](https://github.com/NixOS/nixpkgs/commit/bc3196013a3ffa4daa9b172063d0293a39bde295) sccache: 0.4.0 -> 0.4.1
* [`7a90c445`](https://github.com/NixOS/nixpkgs/commit/7a90c445f2a7f91307c339021e10cb6296a55b74) go2tv: 1.14.0 -> 1.14.1
* [`20659b83`](https://github.com/NixOS/nixpkgs/commit/20659b83308a02fcf043982f6274bddec69c853c) python310Packages.google-cloud-spanner: 3.28.0 -> 3.29.0
* [`e20cbb49`](https://github.com/NixOS/nixpkgs/commit/e20cbb498d937fbcfdf0f2804bb396db26b8c4c4) texlab: 5.4.0 -> 5.4.1
* [`5f29c19f`](https://github.com/NixOS/nixpkgs/commit/5f29c19fab334e8ac2c0cae8c245207ff60bf397) vulkan-cts: 1.3.5.0 -> 1.3.5.1
* [`6cbbc163`](https://github.com/NixOS/nixpkgs/commit/6cbbc163798888916ec28e6a3ef75d58373739cb) tasktimer: add caarlos0 to maintainers list
* [`403affda`](https://github.com/NixOS/nixpkgs/commit/403affdafec92e24078b4b8ce9e13f8b66f31022) domain-exporter: add caarlos0 to maintainer list
* [`bc805499`](https://github.com/NixOS/nixpkgs/commit/bc805499d9aef332715154581f94ef24fa35f81c) timer: add caarlos0 to maintainers list
* [`93baaff4`](https://github.com/NixOS/nixpkgs/commit/93baaff43466512c424911fcad7a49ee695c560a) nfpm: add caarlos0 to maintainers list
* [`bae4239b`](https://github.com/NixOS/nixpkgs/commit/bae4239b72d0e5ced19b5ef899edc7baca505136) mongodb: Stop overriding -march and -mtune on <5.0.
* [`098589a3`](https://github.com/NixOS/nixpkgs/commit/098589a3cc76a976cb8e7a3d395d0823784389ea) vokoscreen-ng: enable pipewire screen record
* [`a601e659`](https://github.com/NixOS/nixpkgs/commit/a601e6596788dc6365b17bd7d956995eeac1d3ce) coqPackages_8_17.stdpp: init at 1.8.0
* [`44780192`](https://github.com/NixOS/nixpkgs/commit/4478019214283d60518162c70ecf8e337520e18b) urbit: 1.22 -> 2.0
* [`a3983c88`](https://github.com/NixOS/nixpkgs/commit/a3983c8856895190bcfc5f6b59f2f279059de1a3) gitlab: 15.9.3 -> 15.10.0 ([nixos/nixpkgs⁠#223367](https://togithub.com/nixos/nixpkgs/issues/223367))
* [`64a4de85`](https://github.com/NixOS/nixpkgs/commit/64a4de856877a32e4f8f4863101e2cbbfdc6b62b) zfsUnstable: make it compatible again with 6.2.8 and potentially 6.3
* [`56fa7ab0`](https://github.com/NixOS/nixpkgs/commit/56fa7ab066165a2eb6274a0ab423b518e3e115b4) nixos/tests/zfs: add zfsUnstable test for systemd-stage 1
* [`e88df924`](https://github.com/NixOS/nixpkgs/commit/e88df924a0aa860b5042f2d14c177945ebaf78a8) libtorch-bin: 1.13.1 -> 2.0.0
* [`c42fe31f`](https://github.com/NixOS/nixpkgs/commit/c42fe31f1e442bc426e33cbb5dccfb2b7b0ac029) nitrokey-app: add panicgh to maintainers
* [`28c08a22`](https://github.com/NixOS/nixpkgs/commit/28c08a222e13bf9533e3f92fb54af08c1658a509) nfpm: add man and completions
* [`e81d3ea1`](https://github.com/NixOS/nixpkgs/commit/e81d3ea1b86b16b190d2e784c226916129af4ad0) goreleaser: install completions and manpages
* [`7159363f`](https://github.com/NixOS/nixpkgs/commit/7159363f5172a53286678ea84693570d3b35a9db) linuxPackages.nvidia_x11_legacy340: Fix build on 6.1
* [`406e24aa`](https://github.com/NixOS/nixpkgs/commit/406e24aa197caad8ecb1e417615761520a8b928b) corrscope: 0.8.0 -> 0.8.1
* [`decad3f2`](https://github.com/NixOS/nixpkgs/commit/decad3f23c29fa7046da80fa3de5ec2af69dd639) vscode-extensions.github: split up for consistency
* [`09adaec7`](https://github.com/NixOS/nixpkgs/commit/09adaec7c13bfe06e22c0d151c2a72901585d13e) vscode-extensions.coenraads.bracket-pair-colorizer: remove
* [`9c73895c`](https://github.com/NixOS/nixpkgs/commit/9c73895c06e460c4beaa9578e3a9136f737abfd8) vscode-extensions.coenraads.bracket-pair-colorizer-2: remove
* [`359124ad`](https://github.com/NixOS/nixpkgs/commit/359124ad033209aca919cc0fa51693cf42ea207f) vscode-extensions.faustinoaq.lex-flex-yacc-bison: remove
* [`e8888cfd`](https://github.com/NixOS/nixpkgs/commit/e8888cfda14e16c649cd6ab27d50df21c2c7f25a) vscode-extensions.msjsdiag.debugger-for-chrome: remove
* [`4dcef4d9`](https://github.com/NixOS/nixpkgs/commit/4dcef4d9c91bd14990b154a4d52faf6fbfa66709) vscode-extensions.silvenon.mdx: remove
* [`aed90711`](https://github.com/NixOS/nixpkgs/commit/aed907112c7108a25ff9a7bb9a29e9205217ae64) pcsc-safenet: switch from fetchurl to fetchzip
* [`8b5a5c29`](https://github.com/NixOS/nixpkgs/commit/8b5a5c29f7ed0ab739b8581518ba9aabd2b74ffd) pcsc-safenet: add comments documenting library symlink munging
* [`a761d073`](https://github.com/NixOS/nixpkgs/commit/a761d073ca9caaf226125cab1cdad34c716c6e3d) vscode-extensions.jpoinssonnier.vscode-styled-components: move to styled-components.vscode-styled-components, 1.4.1 -> 1.7.6
* [`32a11f9c`](https://github.com/NixOS/nixpkgs/commit/32a11f9cf16c37f2b6d030447df253cafe5af7f5) vscode-extensions.matklad.rust-analyzer: move to alias section
* [`5cfaf84a`](https://github.com/NixOS/nixpkgs/commit/5cfaf84ab6266931c7a43c32c4ce7fda2ce53cfe) vscode-extensions: restore alphabetical order
* [`c3fe41dd`](https://github.com/NixOS/nixpkgs/commit/c3fe41dd0a4fd7002de4e821e09a75cc1ca97209) python310Packages.btest: init at 1.0
* [`29d380aa`](https://github.com/NixOS/nixpkgs/commit/29d380aa2f270724f68d6ca163589e1adcd1471a) zkg: init at 2.13.0
* [`bfee95c1`](https://github.com/NixOS/nixpkgs/commit/bfee95c1a12b46ec247b53b18a94d6404708155e) python310Packages.reolink-aio: 0.5.6 -> 0.5.7
* [`6e8f5201`](https://github.com/NixOS/nixpkgs/commit/6e8f5201e547bd7bba53a3c5650096ccf2671b7a) python310Packages.yalexs-ble: 2.1.10 -> 2.1.12
* [`c29ca670`](https://github.com/NixOS/nixpkgs/commit/c29ca6704dfd562e22bc60ad3d650d753f4bb22f) mattermost: add environmentFile option to allow declarative secrets
* [`87d4e177`](https://github.com/NixOS/nixpkgs/commit/87d4e177760993d588d7a89aa9935c723945138c) maintainers/team-list: add asymmetric to docs
* [`fc69cf51`](https://github.com/NixOS/nixpkgs/commit/fc69cf51a5b028acb426d372de3f1be9377e2bba) libowfat: 0.32 -> 0.33
* [`816a6f60`](https://github.com/NixOS/nixpkgs/commit/816a6f60d409a979afff51eb77be4bad6dc650ce) opentracker: 2018-05-26 -> 2021-08-23
* [`9218f1a0`](https://github.com/NixOS/nixpkgs/commit/9218f1a00cd3f54fac797095dbddc486683d820e) Revert "buildLuaPackage: throw instead of marking as broken package"
* [`af412536`](https://github.com/NixOS/nixpkgs/commit/af412536e82666f44f3e4bf0d15d19606fe40732) mongodb-4_4: 4.4.13 -> 4.4.19
* [`e6854e7d`](https://github.com/NixOS/nixpkgs/commit/e6854e7d3aa342705b870d5ccf76e210a0eaeb65) garage: fix missing stateVersion and default pkg
* [`2e6a5a6a`](https://github.com/NixOS/nixpkgs/commit/2e6a5a6ad216faaf53435f236dcf5d99dd961207) haskell.packages.ghc96.memory: bump version
* [`bbc633e5`](https://github.com/NixOS/nixpkgs/commit/bbc633e5fe1566e98315ae664e95083aaa64d17d) haskell.packages.ghc96.parallel: bump version
* [`b9afffd1`](https://github.com/NixOS/nixpkgs/commit/b9afffd107bb47fefde3ecccd10501de19b3441b) haskell.packages.ghc96.foundation: add build patch
* [`c7f5ccae`](https://github.com/NixOS/nixpkgs/commit/c7f5ccaef9fb0bcb992797a88b9811d090aff14f) vscode-extensions: lowercase remaining extension names
* [`6d58c522`](https://github.com/NixOS/nixpkgs/commit/6d58c5221aa7a4a3a81ca277f9957708861f5be7) omnisharp-roslyn: use dotnet from PATH
* [`052bb414`](https://github.com/NixOS/nixpkgs/commit/052bb41410760535a5360cbb591cb54d538c2bcd) doc: assign ids to many headings
* [`11df6574`](https://github.com/NixOS/nixpkgs/commit/11df65743da95d6153c6c048dbc9596e47871fa6) vscode-extensions: simplify how aliases are specified
* [`2dd94107`](https://github.com/NixOS/nixpkgs/commit/2dd94107bc137e614ee0cd69a566dab3dfe11aef) vimPlugins: update
* [`110564e9`](https://github.com/NixOS/nixpkgs/commit/110564e99d4712f6b41449baa9b9dbce26239d55) vimPlugins.nvim-treesitter: update grammars
* [`733e7c52`](https://github.com/NixOS/nixpkgs/commit/733e7c52c2f9ef8e083b7442a85e4e7711b37b89) calcmysky: 0.2.1 -> unstable-203-02-11
* [`d19f5ded`](https://github.com/NixOS/nixpkgs/commit/d19f5dedec60d27391fcadfeb61c4bcae07bf5b0) stellarium: 1.2 -> 23.1
* [`a727dbe8`](https://github.com/NixOS/nixpkgs/commit/a727dbe8ebf1c36b0b799b9d4387afd6d4e8b52d) mozillavpn: 2.13.1 → 2.14.0
* [`821e8d08`](https://github.com/NixOS/nixpkgs/commit/821e8d088453fac66705967b0aebda37aea61ea7) python3Packages.apache-beam: fix build
* [`e946e982`](https://github.com/NixOS/nixpkgs/commit/e946e982a776d6b41dee28becd1ea106596989dd) awscli2: 2.11.4 -> 2.11.6
* [`6c2c9cfb`](https://github.com/NixOS/nixpkgs/commit/6c2c9cfb04e0c767497fe280b83ce379a8b74801) svdtools: 0.2.8 -> 0.3.0
* [`dba111b7`](https://github.com/NixOS/nixpkgs/commit/dba111b7c88c55751c8694146972131d12abd453) palemoon: 32.0.1 -> 32.1.0
* [`a426ae8e`](https://github.com/NixOS/nixpkgs/commit/a426ae8eeace721beee83ee0cd17de9832ba08f4) iotas: 0.1.9 -> 0.1.11
* [`97971ca2`](https://github.com/NixOS/nixpkgs/commit/97971ca20d86e827b9dc42c01c1fa090d4a7b79f) maintainers: Add stepech
* [`b81f7d15`](https://github.com/NixOS/nixpkgs/commit/b81f7d15f1b9bc6074e36e111505a1cc5fd3a2ff) lemmy: 0.17.1 -> 0.17.2
* [`e251ece2`](https://github.com/NixOS/nixpkgs/commit/e251ece266c5d59ef8c5df98feb629a26a35a14d) espeak-ng: Add alsa-plugins path to ALSA_PLUGIN_DIR
* [`3965ba97`](https://github.com/NixOS/nixpkgs/commit/3965ba97fc6389ecdd1eff81190f3119275a83e9) python310Packages.packageurl-python: 0.10.4 -> 0.11.1
* [`5cd8f349`](https://github.com/NixOS/nixpkgs/commit/5cd8f3499c45912a534fa2903f29b9d1873f43ac) python310Packages.zope-cachedescriptors: 4.4 -> 5.0
* [`9c463813`](https://github.com/NixOS/nixpkgs/commit/9c463813caa836df96bc7e99195c411ba1cd6afa) python310Packages.google-cloud-tasks: 2.13.0 -> 2.13.1
* [`45615f78`](https://github.com/NixOS/nixpkgs/commit/45615f788d42bb238fcd3ff2befc60bed292f6ca) python310Packages.pytaglib: 1.5.0-1 -> 2.0.0
* [`c4f42f79`](https://github.com/NixOS/nixpkgs/commit/c4f42f7964c7d4bffac07b64a5caf3c1603b1e36) python310Packages.json-stream: 2.2.0 -> 2.2.1
* [`25e44caf`](https://github.com/NixOS/nixpkgs/commit/25e44caf2f54c1b73e4f22592820e002cd5ca975) vmware-workstation: add libxcrypt-legacy
* [`49ca2435`](https://github.com/NixOS/nixpkgs/commit/49ca24350c28656ba87344e8e771a24b067d813e) python310Packages.tern: 2.11.0 -> 2.12.0
* [`19746a83`](https://github.com/NixOS/nixpkgs/commit/19746a83aa3b3936fbb2e55fd53c7408bfec1da9) discord-ptb: 0.0.39 -> 0.0.41
* [`a7cf2875`](https://github.com/NixOS/nixpkgs/commit/a7cf2875838aec3963ada43436039b776ce108b2) comrak: 0.16.0 -> 0.17.1
* [`4cd7d863`](https://github.com/NixOS/nixpkgs/commit/4cd7d8634dfbfe237d2ede2ae0da882ab2829efe) nixpacks: 1.5.1 -> 1.6.0
* [`e700b7ab`](https://github.com/NixOS/nixpkgs/commit/e700b7ab98d9fe1385b8dec2fd2120a18601c142) ctpv: 1.0 -> 1.1
* [`b0a7c437`](https://github.com/NixOS/nixpkgs/commit/b0a7c437a215afe12b1ea9760f0af958c59028cf) holochain-launcher: 0.9.2 -> 0.9.3
* [`8932f6b0`](https://github.com/NixOS/nixpkgs/commit/8932f6b0b4879181ee9006b198170bdb645a4fd2) svls: 0.2.7 -> 0.2.8
* [`14ddd89f`](https://github.com/NixOS/nixpkgs/commit/14ddd89f4c3078b6bef983a0e3f25d8a3d73de46) datree: 1.8.45 -> 1.8.46
* [`f2deff90`](https://github.com/NixOS/nixpkgs/commit/f2deff906250349120f228dc678b051734cc8e39) terraform-providers.buildkite: 0.11.1 → 0.12.1
* [`668e6b81`](https://github.com/NixOS/nixpkgs/commit/668e6b8183de6acb6972ffda458ba3ebcf497c0a) terraform-providers.argocd: 5.0.0 → 5.0.1
* [`0bfce557`](https://github.com/NixOS/nixpkgs/commit/0bfce55798f268c614aafc129fcb1a94241b33e4) terraform-providers.fastly: 4.1.0 → 4.1.1
* [`9f75cd07`](https://github.com/NixOS/nixpkgs/commit/9f75cd079cf280ac6e374c4f72360a19331a0c93) grpc: 1.52.1 -> 1.53.0
* [`7b007a32`](https://github.com/NixOS/nixpkgs/commit/7b007a320753a3fe316170b84b95c9ff82df2dd4) python310Packages.grpcio-tools: 1.52.0 -> 1.53.0
* [`17e84461`](https://github.com/NixOS/nixpkgs/commit/17e8446138d3c1f4c6a8cc7c364c12832533cf93) rbw: 1.7.0 -> 1.7.1
* [`ac7d68bc`](https://github.com/NixOS/nixpkgs/commit/ac7d68bc8a63cef1a56f14de96c3db3fe2065f86) python310Packages.grpcio-status: 1.52.0 -> 1.53.0
* [`e935eb83`](https://github.com/NixOS/nixpkgs/commit/e935eb83651547f193d9f789a5aae3c92766ebf4) brook: 20230401 -> 20230404
* [`3b3cc657`](https://github.com/NixOS/nixpkgs/commit/3b3cc657012f64c336f23a4ae5010a4246667485) primecount: 7.6 -> 7.7
* [`a01d310e`](https://github.com/NixOS/nixpkgs/commit/a01d310e2ca8a802e4052135d28b44b8d1fcc0ca) python310Packages.nextcloudmonitor: 1.3.0 -> 1.4.0
* [`20fc1f47`](https://github.com/NixOS/nixpkgs/commit/20fc1f47aa412f044dd5a7a1a044f030e6e60b9b) dontgo403: 0.5 -> 0.8.1
* [`ebeb85bf`](https://github.com/NixOS/nixpkgs/commit/ebeb85bf32c7bc6577bf2fb393a918ab7968ae3d) symfony-cli: 5.5.1 -> 5.5.2
* [`b5173ecc`](https://github.com/NixOS/nixpkgs/commit/b5173ecce0b4dd08bf8fb38ce232e0361aaa74a9) fbthrift: 2023.02.20.00 -> 2023.03.20.00
* [`49e3f4fe`](https://github.com/NixOS/nixpkgs/commit/49e3f4fe0c927b128d1471bbbc8035657dde17c3) memcached: 1.6.18 -> 1.6.19
* [`8fe1ea49`](https://github.com/NixOS/nixpkgs/commit/8fe1ea496b24338f61032e4caa7f981626d24d4b) coq: 8.16.1 -> 8.17.0
* [`a5bfcaf6`](https://github.com/NixOS/nixpkgs/commit/a5bfcaf6f1dc5151e0b887ac1bd650400c4f2f33) avfs: 1.1.4 -> 1.1.5
* [`c26e9c8e`](https://github.com/NixOS/nixpkgs/commit/c26e9c8ee2e8fcc98a6f8cfaadc0831d40698a05) python310Packages.pytaglib: add changelog to meta
* [`8066817e`](https://github.com/NixOS/nixpkgs/commit/8066817ecc0d44859733883c52d82fa5175137bb) python310Packages.pytaglib: disable on unsupported Python releases
* [`50a63ac9`](https://github.com/NixOS/nixpkgs/commit/50a63ac98d1063e57dff5f7d743ce546777431d9) python310Packages.packageurl-python: add changelog to meta
* [`cfc14296`](https://github.com/NixOS/nixpkgs/commit/cfc14296519ec87ad68f122de1a04ce6f7ce0f49) python310Packages.packageurl-python: update disabled
* [`1767ac74`](https://github.com/NixOS/nixpkgs/commit/1767ac74ea4ddbc144524d934df06430dd9d0ba6) python310Packages.plugwise: 0.27.7 -> 0.27.9
* [`fb57c89c`](https://github.com/NixOS/nixpkgs/commit/fb57c89c92c3e6c7a8741301947ad53b99bbf7f3) python310Packages.pydeps: 1.11.1 -> 1.11.2
* [`c4138344`](https://github.com/NixOS/nixpkgs/commit/c4138344572780d01bd040cccf32d6afeb2bb505) python310Packages.python-bsblan: 0.5.9 -> 0.5.10
* [`bd2a2628`](https://github.com/NixOS/nixpkgs/commit/bd2a2628c584982d4be45c32757e7b98fb603a45) python310Packages.types-colorama: 0.4.15.8 -> 0.4.15.9
* [`42d79d1c`](https://github.com/NixOS/nixpkgs/commit/42d79d1cb86f472633682d53bf8d2fc2e1799213) python310Packages.aiodiscover: 1.4.14 -> 1.4.15
* [`4d862ad6`](https://github.com/NixOS/nixpkgs/commit/4d862ad620ebf1b5d00d7b70dc158e82fed300f5) exploitdb: 2023-03-26 -> 2023-03-28
* [`6d0c84a9`](https://github.com/NixOS/nixpkgs/commit/6d0c84a94e777f216823af82b1112c7c30352279) wakatime: 1.68.3 -> 1.70.0
* [`37d68dd8`](https://github.com/NixOS/nixpkgs/commit/37d68dd8e76fa0d1d6e075697c0104882b23983b) ocamlPackages.pcap-format: 0.5.2 → 0.6.0
* [`6b9fe979`](https://github.com/NixOS/nixpkgs/commit/6b9fe979f4122972403278be0b661e54954572ad) trufflehog: 3.29.1 -> 3.30.0
* [`4e6d3feb`](https://github.com/NixOS/nixpkgs/commit/4e6d3feb566667b6d8df6ab5bfbf7ca91da19dbb) python310Packages.asyncua: add changelog to meta
* [`03d50d87`](https://github.com/NixOS/nixpkgs/commit/03d50d87c785b658ef0427bbaab43db02556e78b) podman: 4.4.3 -> 4.4.4
* [`55aa1f19`](https://github.com/NixOS/nixpkgs/commit/55aa1f199b8a0dcfa8efacae9898e820d89498c2) btrfs-progs: 6.2.1 -> 6.2.2
* [`025027cb`](https://github.com/NixOS/nixpkgs/commit/025027cb010bdeeb0ca070d222857a5a8abc3d82) python310Packages.asyncua: remove asynctest
* [`f8d959f8`](https://github.com/NixOS/nixpkgs/commit/f8d959f86c9ffd4f8a2ef805bb1ffb87400804f4) btrfs-progs: update meta
* [`bc6f8b1a`](https://github.com/NixOS/nixpkgs/commit/bc6f8b1a2e0ba3d9e3e5d147164a84321f770620) firefox-beta-unwrapped: 112.0b6 -> 112.0b7
* [`fb4c7036`](https://github.com/NixOS/nixpkgs/commit/fb4c70366b3c429b7b00eb9d1ab306574dbd74dc) firefox-devedition-unwrapped: 112.0b6 -> 112.0b7
* [`2b8a3cc0`](https://github.com/NixOS/nixpkgs/commit/2b8a3cc07ffa8b5fce1a5c8dbf57c00cd6866204) logseq: 0.8.18 -> 0.9.0
* [`3bbc5378`](https://github.com/NixOS/nixpkgs/commit/3bbc53783fc9accce939e654a2f386a9974a0f79) python3Packages.piano-transcription-inference: Fix run against librosa 0.10.0
* [`4212b269`](https://github.com/NixOS/nixpkgs/commit/4212b26928112c4d669f3fbb2a6ed87927a552dc) python310Packages.azure-mgmt-containerservice: 21.2.0 -> 22.0.0
* [`0d401aba`](https://github.com/NixOS/nixpkgs/commit/0d401abaef820943cd76f64b4f0e329b944a8b6c) python310Packages.garminconnect: 0.1.54 -> 0.1.55
* [`92fc688d`](https://github.com/NixOS/nixpkgs/commit/92fc688db9a56c0c04d42ff8c76441bd10e06d15) python310Packages.goodwe: 0.2.28 -> 0.2.29
* [`097c19b9`](https://github.com/NixOS/nixpkgs/commit/097c19b9b01f3258609f77f3951089385ea3cefa) python310packages.bellows: remove asnyctest
* [`982ea429`](https://github.com/NixOS/nixpkgs/commit/982ea4295b10fc40bc3df5c2d003e9fb94f97081) NixOS/opengl: Use the default Mesa package by default.
* [`81566fa8`](https://github.com/NixOS/nixpkgs/commit/81566fa8cd4f982989ee2a373d83004400e5e748) python310Packages.zigpy: remove asynctest
* [`5a775d7c`](https://github.com/NixOS/nixpkgs/commit/5a775d7cb520ebb0e1baeb35d5228e532b8db481) ocamlPackages.git: 3.12.0 -> 3.13.0 ([nixos/nixpkgs⁠#223522](https://togithub.com/nixos/nixpkgs/issues/223522))
* [`b3b75dc9`](https://github.com/NixOS/nixpkgs/commit/b3b75dc9805de6238b204171bc8549068e00a165) ocamlPackages.mirage-random-test: use Dune 3
* [`b28fd0e9`](https://github.com/NixOS/nixpkgs/commit/b28fd0e903f05211f76df8ce69011b951f2e18de) ocamlPackages.mirage-random: use Dune 3
* [`5accdae4`](https://github.com/NixOS/nixpkgs/commit/5accdae43a011d68bf33d02c821f4d02e6d0ab8a) ocamlPackages.mirage-channel: use Dune 3
* [`ad6bb1a8`](https://github.com/NixOS/nixpkgs/commit/ad6bb1a8169b30c31eeac884b4904c8e66935460) ocamlPackages.callipyge: use Dune 3
* [`7da5c6a3`](https://github.com/NixOS/nixpkgs/commit/7da5c6a3038aa0e2134cfcd9e1a8490115b81201) ocamlPackages.eqaf: use Dune 3
* [`8fdf8ee8`](https://github.com/NixOS/nixpkgs/commit/8fdf8ee81c9948cf591a16bf1572cfcd21ec9049) ocamlPackages.mirage-console: use Dune 3
* [`33eff164`](https://github.com/NixOS/nixpkgs/commit/33eff1646629b977e373ef4d486c6862974080a6) ocamlPackages.vchan: use Dune 3
* [`aeb92620`](https://github.com/NixOS/nixpkgs/commit/aeb9262087a4312b9cfea0c3cbaaddb4f333b62a) ocamlPackages.xenstore: use Dune 3
* [`1bf4036f`](https://github.com/NixOS/nixpkgs/commit/1bf4036f3c25ba8f8e0112d4944dad8dc7820204) ocamlPackages.io-page: use Dune 3
* [`4f2c5e88`](https://github.com/NixOS/nixpkgs/commit/4f2c5e880d4f76cdbbf3f55cca952a4220d62e06) ocamlPackages.mirage-flow: use Dune 3
* [`78be8391`](https://github.com/NixOS/nixpkgs/commit/78be8391f7db1778e7d2c18070a878e7a78a2f60) ocamlPackages.asn1-combinators: use Dune 3
* [`23e5b45f`](https://github.com/NixOS/nixpkgs/commit/23e5b45f189af8cd47b143612d0b90d1eea8ba84) ocamlPackages.randomconv: use Dune 3
* [`0e0155ed`](https://github.com/NixOS/nixpkgs/commit/0e0155ed964cef8aa20cd9f797fa1981c94c0f81) ocamlPackages.dbf: use Dune 3
* [`6134a755`](https://github.com/NixOS/nixpkgs/commit/6134a755daac37db021eed103db693e3fe3b701c) ocamlPackages.wayland: use Dune 3
* [`cb68c76b`](https://github.com/NixOS/nixpkgs/commit/cb68c76b8e2843d357ee336569d1f178312a2255) ocamlPackages.cstruct: 6.1.1 → 6.2.0
* [`f0a09cc1`](https://github.com/NixOS/nixpkgs/commit/f0a09cc1658c000790f9becf3dc7fd7c55e18948) chatgpt-cli: init at 0.6.0-beta
* [`52d11199`](https://github.com/NixOS/nixpkgs/commit/52d111998fc42267d0c5c468fb086121a99dfa5c) fcitx5: 5.0.22 -> 5.0.23
* [`1139cea5`](https://github.com/NixOS/nixpkgs/commit/1139cea54204b0d9ec29a2805628ba3bceb2b67b) gum: 0.8.0 -> 0.10.0
* [`6be98b2a`](https://github.com/NixOS/nixpkgs/commit/6be98b2a3379e716b6d933a4968f844baf558ec0) ferretdb: 0.9.3 -> 0.9.4
* [`ded33fd5`](https://github.com/NixOS/nixpkgs/commit/ded33fd591a466a8b1829b00e69ab7ad99e70a02) jackett: 0.20.3670 -> 0.20.3689
* [`a76bd96e`](https://github.com/NixOS/nixpkgs/commit/a76bd96e4bfa869fd51310574490ff6e2659685a) nixos/malloc: set vm.max_map_count when using graphene-hardened
* [`97e9bfa7`](https://github.com/NixOS/nixpkgs/commit/97e9bfa750192d65140ccf48b4d1db48800c5760) octave: 7.3.0 -> 8.1.0
* [`5af358e1`](https://github.com/NixOS/nixpkgs/commit/5af358e19362b7cf98182a49cc2d3197f13be701) checkstyle: 10.9.2 -> 10.9.3
* [`46293d2b`](https://github.com/NixOS/nixpkgs/commit/46293d2b9a208349ec3d7f282142873dff1e2e7e) octave.pkgs: Update all with script
* [`a0849883`](https://github.com/NixOS/nixpkgs/commit/a0849883432b75507153db90ce999ebb41308f5d) dagger: 0.4.1 -> 0.4.2
* [`a3afe188`](https://github.com/NixOS/nixpkgs/commit/a3afe1883609dc0e5c8a3659999c09476f79a70b) coreth: 0.11.8 -> 0.11.9
* [`124736ba`](https://github.com/NixOS/nixpkgs/commit/124736ba6cc017a75a51e7d37625f7f91f893e98) docker-credential-gcr: 2.1.6 -> 2.1.7
* [`06f72bd1`](https://github.com/NixOS/nixpkgs/commit/06f72bd18a0f666faec4bb7b75ae8d28aa9a8e4f) quarto: 1.2.335 -> 1.2.475
* [`85613c34`](https://github.com/NixOS/nixpkgs/commit/85613c34bb80eff6fcfadb86ab1dda5a1707a293) firectl: unstable-2022-07-12 -> 0.2.0
* [`5a4cfac5`](https://github.com/NixOS/nixpkgs/commit/5a4cfac5ecdd2e56efe3596dfbb35caee9fe46b2) llvmPackages_git.llvm: fix the tests on `x86_64-darwin`
* [`c492acd8`](https://github.com/NixOS/nixpkgs/commit/c492acd865a2b5347de5257273bb5961b3daa11e) protonmail-bridge: rename back the binary to protonmail-bridge
* [`dbf278b9`](https://github.com/NixOS/nixpkgs/commit/dbf278b976e3f2a8a3d100fa4ec897f537d65563) karabiner-elements: Add updateScript
* [`935a1edc`](https://github.com/NixOS/nixpkgs/commit/935a1edcc3903598e90e77fda7d5cf1fe61e8d1f) karabiner-elements: 14.8.0 -> 14.11.0
* [`236410c7`](https://github.com/NixOS/nixpkgs/commit/236410c7a63fd2d521c72094ceff39523900aaa2) bluespec: 2022.1 -> 2023.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
