### PR TITLE
niv devenv: update c9ff5bd4 -> dc301339

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c9ff5bd489ca36a526e46440fec4d10a87988363",
-        "sha256": "0v0pfngb5a25zajdcbi11jzsv6hbr3nzqwgy1pdb5rzkbx0amhdv",
+        "rev": "dc301339a475b05e84edeb92b0ac581bd2eea4b2",
+        "sha256": "1wc9kj6hz694v0xf3cjcbl52yxpy5cbycq7qvx0hi0lj4j7g2zdi",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/c9ff5bd489ca36a526e46440fec4d10a87988363.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/dc301339a475b05e84edeb92b0ac581bd2eea4b2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@c9ff5bd4...dc301339](https://github.com/cachix/devenv/compare/c9ff5bd489ca36a526e46440fec4d10a87988363...dc301339a475b05e84edeb92b0ac581bd2eea4b2)

* [`140e5040`](https://github.com/cachix/devenv/commit/140e5040620d62824a04e51d75f3c6e2779f6f96) flake: use packages.default instead of defaultPackage
* [`4bb50d04`](https://github.com/cachix/devenv/commit/4bb50d045a47c408b154fab36c6c737a6d692769) .envrc: use own devenv and direnvrc
* [`dc301339`](https://github.com/cachix/devenv/commit/dc301339a475b05e84edeb92b0ac581bd2eea4b2) fix [cachix/devenv⁠#515](https://togithub.com/cachix/devenv/issues/515): apply locales if not null
