### PR TITLE
niv fast-syntax-highlighting: update 371591a7 -> 13d7b4e6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "371591a7b6f0f3c9501c52a7b566addbfd804d09",
-        "sha256": "125kp7rzq9yf565h6crkr8fyvrz867jjwlx0w2dbhas9p1id978l",
+        "rev": "13d7b4e63468307b6dcb2dadf6150818f242cbff",
+        "sha256": "0ghzqg1xfvqh9z23aga7aafrpxbp9bpy1r8vk4avi6b80p3iwsq2",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/371591a7b6f0f3c9501c52a7b566addbfd804d09.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/13d7b4e63468307b6dcb2dadf6150818f242cbff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@371591a7...13d7b4e6](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/371591a7b6f0f3c9501c52a7b566addbfd804d09...13d7b4e63468307b6dcb2dadf6150818f242cbff)

* [`13d7b4e6`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/13d7b4e63468307b6dcb2dadf6150818f242cbff) add support for `goawk` ([zdharma-continuum/fast-syntax-highlighting⁠#51](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/51))
