### PR TITLE
niv powerlevel10k: update cb9788b1 -> b474978b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "cb9788b12a1fade6be631ad905928f9a5f7eb03f",
-        "sha256": "1hk3rw4vn6dbh3vx0j7i47izw29i9w9zs76rwl4jnq6bs50l6mms",
+        "rev": "b474978b2e9435c10ca66f8281352ebc825264f4",
+        "sha256": "18nn7cgnsx7ndrdnyxkz339v48a564j0hkhxipdvkcv6gp7v73fa",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/cb9788b12a1fade6be631ad905928f9a5f7eb03f.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/b474978b2e9435c10ca66f8281352ebc825264f4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@cb9788b1...b474978b](https://github.com/romkatv/powerlevel10k/compare/cb9788b12a1fade6be631ad905928f9a5f7eb03f...b474978b2e9435c10ca66f8281352ebc825264f4)

* [`614a6ed1`](https://github.com/romkatv/powerlevel10k/commit/614a6ed1ca8bcad6a5960457c6cd3acd15bc0456) display nix_shell if path contains /nix/store/* ([romkatv/powerlevel10k⁠#2246](https://togithub.com/romkatv/powerlevel10k/issues/2246))
* [`f02b8d36`](https://github.com/romkatv/powerlevel10k/commit/f02b8d365baae5336a5399256739930fa323f3f1) add POWERLEVEL9K_MODE=nerdfont-v3 ([romkatv/powerlevel10k⁠#2217](https://togithub.com/romkatv/powerlevel10k/issues/2217))
* [`ec1702ca`](https://github.com/romkatv/powerlevel10k/commit/ec1702caf1c61d8b2a04658857c1c526aa989901) nerdfonts-v3: add icons for artix and void linux ([romkatv/powerlevel10k⁠#2033](https://togithub.com/romkatv/powerlevel10k/issues/2033))
* [`6b50e091`](https://github.com/romkatv/powerlevel10k/commit/6b50e0918b66d390891b585a9d38463e04d22fab) nerdfonts-v3: use the kubernetes logo as a kubernetes icon ([romkatv/powerlevel10k⁠#2184](https://togithub.com/romkatv/powerlevel10k/issues/2184))
* [`6c82236d`](https://github.com/romkatv/powerlevel10k/commit/6c82236d6ff803b928a8935ea48318940a17425c) nerdfonts-v3: add an icon for EndevourOS ([romkatv/powerlevel10k⁠#1933](https://togithub.com/romkatv/powerlevel10k/issues/1933))
* [`6314edf3`](https://github.com/romkatv/powerlevel10k/commit/6314edf35c2529179449a12d24071803b1eaa029) wizard: rename capability "arrow" to "quotes"
* [`d031df75`](https://github.com/romkatv/powerlevel10k/commit/d031df752b6c5a8c7f4e2bb33b23af01a559ff2e) wizard: detect POWERLEVEL9K_MODE=nerdfont-v3
* [`81673836`](https://github.com/romkatv/powerlevel10k/commit/8167383665ff5def22670229a0eb4186aa05a361) wizard bug fix: offer advanced powerline options when using nerdfont-v3
* [`b474978b`](https://github.com/romkatv/powerlevel10k/commit/b474978b2e9435c10ca66f8281352ebc825264f4) wizard: prefer POWERLEVEL9K_MODE=nerdfont-complete over nerdfont-v3
