### PR TITLE
niv zsh-completions: update 98ea8e68 -> 820aaba9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "98ea8e685c1a9630a21b39a1596cb94794d1cb3c",
-        "sha256": "1dqzva9mr1i4icr58gcilw7y6r8bsk35b0adh5x38kacgd9kvp2s",
+        "rev": "820aaba911fce0594bf17f0e9a82092a6af7810e",
+        "sha256": "0cvz5cyzd34mr7pvhasb3bq6260mr89mh3iwx0p068mhs9sy73k7",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/98ea8e685c1a9630a21b39a1596cb94794d1cb3c.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/820aaba911fce0594bf17f0e9a82092a6af7810e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@98ea8e68...820aaba9](https://github.com/zsh-users/zsh-completions/compare/98ea8e685c1a9630a21b39a1596cb94794d1cb3c...820aaba911fce0594bf17f0e9a82092a6af7810e)

* [`c20d6e92`](https://github.com/zsh-users/zsh-completions/commit/c20d6e921214412f71b1ef8901078f39b0f545d3) updated _bitcoin-cli to match bitcoind v24.1rc1
* [`cd3b8a46`](https://github.com/zsh-users/zsh-completions/commit/cd3b8a4657b68b4e4b005ad6bc8d1ae74d54adbc) Update src/_bitcoin-cli
* [`889db4f8`](https://github.com/zsh-users/zsh-completions/commit/889db4f8f69ad6278f9b0509915221f0017ccb14) Update src/_bitcoin-cli
