### PR TITLE
niv nixpkgs: update 53dad94e -> 328636ca

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
-        "sha256": "03knsdlm2f4hd46y100vcii07xsa95rdk3b1i2jh8rj3pjm4hlzl",
+        "rev": "328636cafa83bcdf08b2a4f4e6b7fbcbe4ec56b3",
+        "sha256": "16bzv763l44rfhmv47qlgckcv4cz7n9j3dnp43lg1k0jxxzvbcqs",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/53dad94e874c9586e71decf82d972dfb640ef044.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/328636cafa83bcdf08b2a4f4e6b7fbcbe4ec56b3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@53dad94e...328636ca](https://github.com/nixos/nixpkgs/compare/53dad94e874c9586e71decf82d972dfb640ef044...328636cafa83bcdf08b2a4f4e6b7fbcbe4ec56b3)

* [`a115a707`](https://github.com/NixOS/nixpkgs/commit/a115a70781af17eab1d3f366d1a08b9fa529cdac) fluentd: Add fluent-plugin-concat at 2.5.0
* [`2e15ff35`](https://github.com/NixOS/nixpkgs/commit/2e15ff35630f5a27c8044dab8eadad6bcf3f34fe) fluentd: Link NixOS test
* [`368b64a4`](https://github.com/NixOS/nixpkgs/commit/368b64a478d46de6f172344aa3657be53107e727) ox-rss: init at version 20230129
* [`0467444d`](https://github.com/NixOS/nixpkgs/commit/0467444d968a3b54277b89abc394c1ff0521663c) lisp-modules: remove both current implementations
* [`7a1ccaa9`](https://github.com/NixOS/nixpkgs/commit/7a1ccaa997e76d0404a962c0f8c89aab4ce61882) lisp-modules: Add manual section
* [`6c96e30a`](https://github.com/NixOS/nixpkgs/commit/6c96e30a3a0427b58b4a9c328f6df33cd934b311) clasp: remove
* [`a43b5237`](https://github.com/NixOS/nixpkgs/commit/a43b5237ed160881191e6f5872b8501258f2eea9) clasp: init at 2.2.0
* [`04c276ac`](https://github.com/NixOS/nixpkgs/commit/04c276ac9c34ef9df9e2caff61b9252f09f5eb6b) asdf_3_3: init at 3.3.6
* [`9e860e41`](https://github.com/NixOS/nixpkgs/commit/9e860e41eb29670601c7d5b8a2dcb536f968d476) lisp-modules: init
* [`5a3c528c`](https://github.com/NixOS/nixpkgs/commit/5a3c528ccef74589d9fd6f705cbe038f76cc0b28) lisp-modules: wrap lisps
* [`e141ed83`](https://github.com/NixOS/nixpkgs/commit/e141ed831269e5670a6114c6d9878fe9b8f8e153) stumpwm: fix after major changes to lisp-modules
* [`03ef1b25`](https://github.com/NixOS/nixpkgs/commit/03ef1b250a95abb505a07281c9e52643aa720942) nyxt: fix after major changes to lisp-modules
* [`254765f3`](https://github.com/NixOS/nixpkgs/commit/254765f3d253d1f03bbfc07baae7af483e8c2b98) lisp-modules: make spec.flags a list of strings
* [`5f2e4cf4`](https://github.com/NixOS/nixpkgs/commit/5f2e4cf4bef01e1ab05c70c15d2960f48764fe03) sbclPackages.hu_dot_dwim_dot_graphviz: fix build
* [`092acca8`](https://github.com/NixOS/nixpkgs/commit/092acca8b3b645be5261592d29aad77736e2d606) lisp-modules: make ql-import.lisp automatically pull the latest Quicklisp dist
* [`efe90254`](https://github.com/NixOS/nixpkgs/commit/efe902542a1a4e514e7d3c075c6f671594e9e68e) sbclPackages.cl-gtk4: update to tip of trunk
* [`a0bdaf34`](https://github.com/NixOS/nixpkgs/commit/a0bdaf345b4e38eabc7d6df8f48c440323b4b373) lisp-modules: replace "_" in package names with "__" for reversibility
* [`653ba458`](https://github.com/NixOS/nixpkgs/commit/653ba458347e33ce31fce1c7402678bcdb5bed87) sbclPackages.math: fix build
* [`84eea85a`](https://github.com/NixOS/nixpkgs/commit/84eea85ad99ac2dd4c30d22dc32004888ea73b03) lisp-modules: use wrapLisp to wrap Lisps
* [`e758d73e`](https://github.com/NixOS/nixpkgs/commit/e758d73e0127bafd7947eda9775820ca53567c77) clpm: fix eval
* [`dae0dca5`](https://github.com/NixOS/nixpkgs/commit/dae0dca5d1c9ad4150b91c55c5f4b54430b1413c) lisp-modules: second version of wrapLisp
* [`59ba175a`](https://github.com/NixOS/nixpkgs/commit/59ba175a2beb4f41651da9e33539ad35fd07a51b) gladtex: init at unstable-2023-01-22
* [`875626cf`](https://github.com/NixOS/nixpkgs/commit/875626cf077617c0646699c521e62c2ab01003b0) python310Packages.phonenumbers: 8.13.6 -> 8.13.7
* [`c2c55f19`](https://github.com/NixOS/nixpkgs/commit/c2c55f1969974621cb806aa5beb9f85eebe96082) lisp-modules: wrap cmucl_binary, gcl and mkcl
* [`97ec9764`](https://github.com/NixOS/nixpkgs/commit/97ec9764a4c2a23eef5c505183c858a3ae80606c) clasp-common-lisp: fix eval
* [`bf643838`](https://github.com/NixOS/nixpkgs/commit/bf643838f356cb6dcccda204f02bbcd0eb8bd01a) lisp-modules: fix typos
* [`819d1d78`](https://github.com/NixOS/nixpkgs/commit/819d1d78e3efacf0be2e6b9097f5e8566ba34688) lisp-modules: use meta.mainProgram before pname
* [`e81872b9`](https://github.com/NixOS/nixpkgs/commit/e81872b9f437de3a1d3cb91fc44a329cd88f450f) Set PHP_INI_SCAN_DIR only if not set
* [`fdabf619`](https://github.com/NixOS/nixpkgs/commit/fdabf61974bbcc9c3763ed5ccef9e641fe983114) lisp-modules: manual: add self links
* [`87517642`](https://github.com/NixOS/nixpkgs/commit/8751764236e5d85cc394652288cda7a63fe78f94) lib/modules: better error for invalid option declarations
* [`bd0ec2e6`](https://github.com/NixOS/nixpkgs/commit/bd0ec2e61b2a3163f751aabd3df4827753a755d5) python310Packages.bc-detect-secrets: 1.4.14 -> 1.4.15
* [`c2d2e827`](https://github.com/NixOS/nixpkgs/commit/c2d2e8272acad408deb0c66a7b03d67b9f602dfe) lisp-modules: remove left over "..." in argument lists
* [`6e8b45e4`](https://github.com/NixOS/nixpkgs/commit/6e8b45e49f3029d99ab4aa7eef8819d0c5b7b410) clasp-common-lisp: fix eval
* [`0c26e885`](https://github.com/NixOS/nixpkgs/commit/0c26e885332981dce64a16ec735a70e2a297ef42) hydra_unstable: 2022-12-23 -> 2023-03-27
* [`218b8ac2`](https://github.com/NixOS/nixpkgs/commit/218b8ac2a90f021c3f44c1dfd5a5264d384b873d) clpm: fix build
* [`788df545`](https://github.com/NixOS/nixpkgs/commit/788df5456baac036c9acc1bcb34be02914e4f7c6) kicad: 7.0.0 -> 7.0.1
* [`d8020e1e`](https://github.com/NixOS/nixpkgs/commit/d8020e1e17ef13b5bcc5aaad3d8d3e77edccd9c4) kicad: remove withOCC and more cmakeFlags cleanup
* [`7f3a0871`](https://github.com/NixOS/nixpkgs/commit/7f3a08710a6b50ea53ddaa1fe77cefcc894fc793) kicad: add requests runtime dependency
* [`7dc1d42e`](https://github.com/NixOS/nixpkgs/commit/7dc1d42ee1ce9f2975a5f9e92cc20c6972c85459) budgie.budgie-desktop: init at 10.7.1
* [`db9b8f62`](https://github.com/NixOS/nixpkgs/commit/db9b8f62b87466a08f0d92df2677db9849ddd025) budgie.budgie-desktop-view: init at 1.2.1
* [`1e071285`](https://github.com/NixOS/nixpkgs/commit/1e0712859ecc43b032783d15e2528c192e776c82) pptp: rework packaging, fix cross compilation
* [`40ee8d66`](https://github.com/NixOS/nixpkgs/commit/40ee8d66cd703e44eae0e26752ac3207a6140ec2) nvidia-container-toolkit: 1.5.0 -> 1.9.0
* [`6d097e33`](https://github.com/NixOS/nixpkgs/commit/6d097e33856c8359274dab4c07ee376a593cc51a) xwayland 22.1.8 -> 23.1.1
* [`4f0de946`](https://github.com/NixOS/nixpkgs/commit/4f0de9463ab4e87eca136e8320480dcf10031acf) kicad-unstable: 2023-02-14 -> 2023-03-29
* [`23849267`](https://github.com/NixOS/nixpkgs/commit/23849267ee0f3c84aa36f644d3d279b280e9f647) kicad-unstable: fix ngspice tests
* [`961e6fba`](https://github.com/NixOS/nixpkgs/commit/961e6fbadb6c0ab87294ffcac3de7cf05f569987) alpine: 2.25 -> 2.26
* [`3d6a8c2e`](https://github.com/NixOS/nixpkgs/commit/3d6a8c2ea5acf343b380daa5d19bc2b9fd1bbe8c) mongoose: 2.0.4 -> 3.0.4
* [`d8cd324e`](https://github.com/NixOS/nixpkgs/commit/d8cd324e3c2b1b6b1259403beb3a02de2cc51440) python310Packages.cython_3: 3.0.0a11 -> 3.0.0b2
* [`cc1f7504`](https://github.com/NixOS/nixpkgs/commit/cc1f75044bc97dd832d4c33f991d74fba1d403ef) python310Packages.rapidfuzz: 2.13.7 -> 2.14.0
* [`d857988d`](https://github.com/NixOS/nixpkgs/commit/d857988d21be667385c3841f0ce7df7c9ec153fb) anki-bin: add commandLineArgs to package arguments
* [`5f2678d7`](https://github.com/NixOS/nixpkgs/commit/5f2678d7d3dff2956b53fcd69c8dd22ac39e8521) Update pkgs/games/anki/bin.nix
* [`052d5893`](https://github.com/NixOS/nixpkgs/commit/052d58934700a81b270edc148c76e50e8ce90956) Update pkgs/games/anki/bin.nix
* [`ed4aff0e`](https://github.com/NixOS/nixpkgs/commit/ed4aff0eaf94af48723e914515f731c4aa512ac1) python310Packages.miniaudio: 1.55 -> 1.56
* [`fa0d4b17`](https://github.com/NixOS/nixpkgs/commit/fa0d4b174e8b2ca211959141a5b1f67cd20972aa) python310Packages.miniaudio: unvendor miniaudio
* [`a6f9bcf8`](https://github.com/NixOS/nixpkgs/commit/a6f9bcf863fc11e68b74cfb58cf1353be6c552d2) miniaudio: 0.11.11 -> 0.11.14
* [`e48d50d2`](https://github.com/NixOS/nixpkgs/commit/e48d50d23b4f9819827db21d5e8bb4446fc7dc91) python310Packages.django-auth-ldap: 4.1.0 -> 4.2.0
* [`59ef8c5a`](https://github.com/NixOS/nixpkgs/commit/59ef8c5a199a6ea8c9269d607fb31954e2396671) zsv: 0.3.5-alpha -> 0.3.6-alpha
* [`fb143012`](https://github.com/NixOS/nixpkgs/commit/fb14301291adfd9bc67d4de9a1deb8340afa73ec) mariadb-galera: 26.4.13 -> 26.4.14
* [`cfc3d04a`](https://github.com/NixOS/nixpkgs/commit/cfc3d04a275b41b84292c77bd1a9d3eee27897da) python310Packages.ansible-doctor: 2.0.2 -> 2.0.3
* [`7ccb7b1d`](https://github.com/NixOS/nixpkgs/commit/7ccb7b1d33ee13b98c539d8f8c5d10831cda6802) wine{Unstable,Staging}: 8.3 -> 8.5
* [`ce7c7b33`](https://github.com/NixOS/nixpkgs/commit/ce7c7b3312980973566cb477147a21919966d7e5) invidious: unstable-2023-03-15 -> unstable-2023-03-31
* [`1c9ad3ec`](https://github.com/NixOS/nixpkgs/commit/1c9ad3ec47cd529d0681f602d4337cd91d57fd75) budgie.budgie-control-center: init at 1.2.0
* [`946e7256`](https://github.com/NixOS/nixpkgs/commit/946e725671c7fdaee8913727a8aeef6c065671d9) budgie.budgie-backgrounds: init at 0.1
* [`297cfa71`](https://github.com/NixOS/nixpkgs/commit/297cfa71e64a53016f17d4aedf8b312843200b7c) budgie.budgie-gsettings-overrides: init
* [`424a6ccd`](https://github.com/NixOS/nixpkgs/commit/424a6ccd2b805c711ece5bb924314d1a548736a1) gnome.gnome-session: Make support for GNOME Shell optional
* [`50198ac1`](https://github.com/NixOS/nixpkgs/commit/50198ac1f8d6b54ccb4a619b14ade0fdfe601219) nixos/budgie: init
* [`bdc00026`](https://github.com/NixOS/nixpkgs/commit/bdc000263ae994f6d96a6bde7d63805f1e4f818b) lisp-modules: add back the two current implementations
* [`71a3a77c`](https://github.com/NixOS/nixpkgs/commit/71a3a77c2a97b7aadf35b4c9b0e066bb96fec56c) qrcp: 0.9.1 -> 0.10.0
* [`c7117a1e`](https://github.com/NixOS/nixpkgs/commit/c7117a1e192836afed90f424f38ed00591d26c4f) ocamlPackages.bwd: 2.0.0 → 4.0.0
* [`0d7be800`](https://github.com/NixOS/nixpkgs/commit/0d7be800f78e91a19c7218257885260bb558c097) ocamlPackages.algaeff: init at 0.2.1
* [`da841326`](https://github.com/NixOS/nixpkgs/commit/da8413266703b3b3df1a9ba3014b4d9b907f3836) ocamlPackages.yuujinchou: 2.0.0 → 4.0.0
* [`8218e8b4`](https://github.com/NixOS/nixpkgs/commit/8218e8b45716c86790ea4aabf3545e4bef7a82b2) libreoffice: generate-*-srcs.py Remove export prefix
* [`272f3d39`](https://github.com/NixOS/nixpkgs/commit/272f3d39144149a7adc62873ed21f09da9c8f2e9) libreoffice-fresh: 7.4.2.3 -> 7.5.2.1
* [`c613b68e`](https://github.com/NixOS/nixpkgs/commit/c613b68e4ce0ce94393e0b1886123348665d8961) libreoffice-still: 7.3.7.2 -> 7.4.6.2
* [`e0b64b3a`](https://github.com/NixOS/nixpkgs/commit/e0b64b3a8226c5f6ca588f2081793528357f59f2) libreoffice: Remove failing test
* [`699d543e`](https://github.com/NixOS/nixpkgs/commit/699d543e9ef64d3a6c5819dc19b6495762122a09) libreoffice.unwrapped: Remove $dev output
* [`2531b252`](https://github.com/NixOS/nixpkgs/commit/2531b2520733b89ae02299722381755b23d798ba) kubectl-view-allocations: init at 0.16.3
* [`0c782640`](https://github.com/NixOS/nixpkgs/commit/0c782640ee2875d44c7c4e7b124a4e27327d97ff) lisp-modules: deprecate the two current implementations in comments
* [`2b180f79`](https://github.com/NixOS/nixpkgs/commit/2b180f796a983d3cd8dbb5d39610175eba60de78) lisp-modules: add release note about the new manual and the interface
* [`3865ffaf`](https://github.com/NixOS/nixpkgs/commit/3865ffaf69bdfc9729814b7b85a938c43ec996c4) dbmate: 2.1.0 -> 2.2.0
* [`cc84572e`](https://github.com/NixOS/nixpkgs/commit/cc84572e3479634234c8f836c8df0e6e8720cd19) python310Packages.gtfs-realtime-bindings: 0.0.7 -> 1.0.0
* [`e929a998`](https://github.com/NixOS/nixpkgs/commit/e929a99848b67822e69522d6895c91688c2b7cca) writeShellApplication: allow substitutions and remote building.
* [`034e4b47`](https://github.com/NixOS/nixpkgs/commit/034e4b471e54f9c338511f5504be5424e71d808a) open-policy-agent: v0.50.2 -> v0.51.0
* [`f59ca237`](https://github.com/NixOS/nixpkgs/commit/f59ca237efa09d492e2eca1a206c758f0099e870) cargo: remove retrry from meta.maintainers
* [`c0dcb5c2`](https://github.com/NixOS/nixpkgs/commit/c0dcb5c24ad1faa671c90c017ef9f9df88defd32) nixos/tests/budgie: init
* [`ce6f0af9`](https://github.com/NixOS/nixpkgs/commit/ce6f0af95432a45a47e63ef0719c6acd30d5b4e1) nixos/doc: add release note for Budgie Desktop
* [`0b4c7a3d`](https://github.com/NixOS/nixpkgs/commit/0b4c7a3d4103829e4da3e90066e4d2bd5a514895) vsmtp: 2.1.1 -> 2.2.1
* [`ef5f86f5`](https://github.com/NixOS/nixpkgs/commit/ef5f86f54d715b373bc561d90ff0f545a33394f7) colloid-gtk-theme: 2022-07-18 -> 2022.11.11
* [`fe8bfad4`](https://github.com/NixOS/nixpkgs/commit/fe8bfad4d333aed153baa72e8687a3304533523a) material-design-icons: 7.1.96 -> 7.2.96
* [`dedf1dae`](https://github.com/NixOS/nixpkgs/commit/dedf1dae04ceaa9378be2c97a8dfa96d57cd7592) cargo-tally: 1.0.24 -> 1.0.25
* [`c72db554`](https://github.com/NixOS/nixpkgs/commit/c72db554827b011af96c6c557eb084438c9aeba9) gvm-libs: 22.4.4 -> 22.4.5
* [`7e8c4c21`](https://github.com/NixOS/nixpkgs/commit/7e8c4c21fcb1c467eb4017ebfe5f37b9883b9bc8) halp: 0.1.4 -> 0.1.5
* [`814e89e9`](https://github.com/NixOS/nixpkgs/commit/814e89e997dbe954fc3f99ece87064af588b3a3c) cargo-expand: 1.0.46 -> 1.0.47
* [`b6310129`](https://github.com/NixOS/nixpkgs/commit/b6310129f4dcc1ee3dfb5af2aeb3ee8337a182d4) cargo-llvm-lines: 0.4.25 -> 0.4.26
* [`cddb4a24`](https://github.com/NixOS/nixpkgs/commit/cddb4a24bab4095949292f9f009ca9b35f16557a) blast-bin: init at 2.13.0
* [`6431dfbe`](https://github.com/NixOS/nixpkgs/commit/6431dfbe0faac50e079d7b87a215ad24b046b32b) libreoffice-fresh: 7.5.2.1 - > 7.5.2.2
* [`c88b4de5`](https://github.com/NixOS/nixpkgs/commit/c88b4de5358dff3edaf0f8bedc377090bfd5a3aa) imagemagick: 7.1.1-5 -> 7.1.1-6
* [`c6049e94`](https://github.com/NixOS/nixpkgs/commit/c6049e9403822df3cb2cd8485fada1dc4c547f00) ocamlPackages.ctypes: 0.20.1 → 0.20.2
* [`9cffa291`](https://github.com/NixOS/nixpkgs/commit/9cffa291d5f8c189220c6dd3d1c34ad21fb18b36) python310Packages.pipdeptree: 2.5.0 -> 2.7.0
* [`6264caf7`](https://github.com/NixOS/nixpkgs/commit/6264caf76f49aa024c003675dbec2b4ea8548847) fava: 1.24 -> 1.24.3
* [`71c95adf`](https://github.com/NixOS/nixpkgs/commit/71c95adf30bea8e400aaf2b8c567db587d7de7e7) ntfy-sh: 2.1.2 -> 2.3.1
* [`c25ae561`](https://github.com/NixOS/nixpkgs/commit/c25ae56166ef926ac4eb5a16e29debbd68818165) seaweedfs: 3.44 -> 3.45
* [`1010c175`](https://github.com/NixOS/nixpkgs/commit/1010c17591db2553d4954cc6a143169604f150e4) python3Packages.tensorflow: remove @⁠jyp from `meta.maintainers`
* [`fb372a28`](https://github.com/NixOS/nixpkgs/commit/fb372a28d899a9d79def6debd0b081b3ce7314c8) libviperfx: mark meta.sourceProvenance
* [`a476a6dc`](https://github.com/NixOS/nixpkgs/commit/a476a6dc8d45edda1820c021708dc4bbb9bdac36) wpsoffice: mark meta.sourceProvenance
* [`b5582882`](https://github.com/NixOS/nixpkgs/commit/b55828826a772fac905357c2b0e3250e421b650a) hyprland: wayland-scanner should be nativeBuildInputs
* [`04124990`](https://github.com/NixOS/nixpkgs/commit/04124990ffc5149b6d64ee29f53662347a32863c) maude: 3.1 -> 3.3
* [`82ebf4df`](https://github.com/NixOS/nixpkgs/commit/82ebf4dfae38cb30845263371cf536e68c6af1c9) linux_testing: 6.3-rc1 -> 6.3-rc5
* [`4ad85a5c`](https://github.com/NixOS/nixpkgs/commit/4ad85a5c107fbe0bc3e7c589f5b0905f800534c9) scalp: update mirror link
* [`fe39b694`](https://github.com/NixOS/nixpkgs/commit/fe39b694d24ac2016e1163878f4761dbcd43ffc3) socklog: mark not broken on darwin
* [`8fd99e12`](https://github.com/NixOS/nixpkgs/commit/8fd99e12128381ee4efdc1c13e09f2e41795c500) python3Packages.jiwer: init at 3.0.1
* [`83c023b4`](https://github.com/NixOS/nixpkgs/commit/83c023b45351198f56ed85eb653c6b3daf6604d4) maintainers: remove retrry
* [`e0205290`](https://github.com/NixOS/nixpkgs/commit/e0205290f5319e219401a6ecbc5d42ac3e93112a) go-ethereum: 1.10.26 -> 1.11.5
* [`85a56caa`](https://github.com/NixOS/nixpkgs/commit/85a56caaa09c3a0bc2911f0360b4b2bca2fd343b) chroma: 2.4.0 -> 2.7.0
* [`f7973430`](https://github.com/NixOS/nixpkgs/commit/f797343034ee289e7366e0358b6a27f1fcf7ad50) mutagen: not broken on darwin
* [`a397c5c1`](https://github.com/NixOS/nixpkgs/commit/a397c5c1bfb81c11d0095fe142b0bd63e1fd95dd) home-manager: 2022-10-25 -> 2023-04-02
* [`e00db8e1`](https://github.com/NixOS/nixpkgs/commit/e00db8e1fe3b0553e433133af4ba4bfd358cab16) fishPlugins.fzf-fish: 9.3 -> 9.7
* [`f95d6c4c`](https://github.com/NixOS/nixpkgs/commit/f95d6c4cc2dba9fa77044d644668ef6847353c60) fishPlugins.fzf-fish: add natsukium to maintainers
* [`2adfe800`](https://github.com/NixOS/nixpkgs/commit/2adfe800bd3b2f2171739fe7f5878fdafcd0d01f) klipper-estimator: init at 3.2.1
* [`00309569`](https://github.com/NixOS/nixpkgs/commit/0030956979fc9054322bcb03d26f6bb186ffacda) linuxPackages.apfs: 0.3.0 -> 0.3.1
* [`0b0cc93e`](https://github.com/NixOS/nixpkgs/commit/0b0cc93e79e2699700f44415eb2fa498db3be6b2) remove myself (erictapen) from packages which I don't use anymore
* [`4da422e2`](https://github.com/NixOS/nixpkgs/commit/4da422e269c3af48f0213689da26ac14e5f2c23d) scream: fix dependencies for `jackSupport`
* [`8b601a11`](https://github.com/NixOS/nixpkgs/commit/8b601a118f40349c5507a0dee8366d0e32d6252c) scream: optional `pcapSupport`
* [`402800cf`](https://github.com/NixOS/nixpkgs/commit/402800cf05195cc449704f28c0276aca50edd04a) roon-server: 2.0-1234 -> 2.0-1244
* [`4b621009`](https://github.com/NixOS/nixpkgs/commit/4b6210095f2fc5dab6a9319c7b28a93eba5b8a4d) python310Packages.xiaomi-ble: 0.16.4 -> 0.17.0
* [`3bd29fe7`](https://github.com/NixOS/nixpkgs/commit/3bd29fe7504735a7790ad2ed130890ad2c3418ca) dnstwist: 20221213 -> 20230402
* [`205fa27e`](https://github.com/NixOS/nixpkgs/commit/205fa27e47f81d19cda764b19544fd4ce5a887f7) cdecrypt: init at 4.8
* [`30d1f10b`](https://github.com/NixOS/nixpkgs/commit/30d1f10b2d4831970c0dbb1d1e5588d3dc4caa99) python310Packages.shtab: 1.5.8 -> 1.6.0
* [`d10dffeb`](https://github.com/NixOS/nixpkgs/commit/d10dffebb213847cc50065a6c9701a949308e041) python310Packages.python-gvm: 23.2.0 -> 23.4.0
* [`22855521`](https://github.com/NixOS/nixpkgs/commit/22855521b77ede16d69bbe04d1cb7cbee578a080) python310Packages.msgspec: 0.13.1 -> 0.14.0
* [`057ca085`](https://github.com/NixOS/nixpkgs/commit/057ca085321d1ccefaa4c6f4ae885ba4dba85642) python310Packages.mkdocstrings-python: 0.8.3 -> 0.9.0
* [`d2b00b0f`](https://github.com/NixOS/nixpkgs/commit/d2b00b0f55702aca18e65be77857adabf2c3553c) python310Packages.meilisearch: 0.25.0 -> 0.26.0
* [`a320db8d`](https://github.com/NixOS/nixpkgs/commit/a320db8d294eca7e14087e83677d4bf6808386f4) python310Packages.griffe: 0.25.5 -> 0.26.0
* [`6c9c6208`](https://github.com/NixOS/nixpkgs/commit/6c9c6208970b26927aaadca0aa991eb0b8a46d90) python310Packages.google-cloud-bigquery-logging: 1.2.0 -> 1.2.1
* [`5151d757`](https://github.com/NixOS/nixpkgs/commit/5151d75738784ee1c1a174948626d922a58953b6) python310Packages.fastapi-mail: 1.2.6 -> 1.2.7
* [`6de4b340`](https://github.com/NixOS/nixpkgs/commit/6de4b3404f80a2ea0ee357d0ad1c1fb85e95b28e) python310Packages.faraday-plugins: 1.10.0 -> 1.11.0
* [`7ef9ebc2`](https://github.com/NixOS/nixpkgs/commit/7ef9ebc27baf1002d2d6fbbf3bbce9387383d676) python310Packages.easyenergy: 0.2.3 -> 0.3.0
* [`8c119d26`](https://github.com/NixOS/nixpkgs/commit/8c119d2641a390d8eab2dfe87db57023a0cddff1) python310Packages.adafruit-platformdetect: 3.42.0 -> 3.43.0
* [`6cf5d549`](https://github.com/NixOS/nixpkgs/commit/6cf5d549fe1141250cf4df7ab3f3697ea984b4dc) nimble-unwrapped: Add missing Security framework buildInput
* [`47efd9d5`](https://github.com/NixOS/nixpkgs/commit/47efd9d5700a89b9e7258a332c45432656829243) python310Packages.aiocoap: 0.4.5 -> 0.4.7
* [`3a864570`](https://github.com/NixOS/nixpkgs/commit/3a864570ba808663ea7d7072d6fe9aea93baeeb3) gotestwaf: 0.3.1 -> 0.4.0
* [`dd2afe68`](https://github.com/NixOS/nixpkgs/commit/dd2afe681227be4b98f06cf603b11b310c440bef) gotestwaf: fix version self-reporting
* [`1b5ba6d5`](https://github.com/NixOS/nixpkgs/commit/1b5ba6d5bd22ae637b30013fd016900b8a49e94e) emacs.pkgs.jinx: build .so file
* [`a7ff41de`](https://github.com/NixOS/nixpkgs/commit/a7ff41dedb92c16061f0bee624c1ee577606a7c0) ddnet: 16.8 -> 16.9
* [`fcf6c6eb`](https://github.com/NixOS/nixpkgs/commit/fcf6c6eb394513fc238490e2aabaebfc8bed28fb) freenet: fix build by pinning gradle_7
* [`f8f13b50`](https://github.com/NixOS/nixpkgs/commit/f8f13b5059c9bdcc0b318941034c4a602d63a072) helix: 22.11 -> 23.03
* [`069b4772`](https://github.com/NixOS/nixpkgs/commit/069b47722b3b2976e88526420a3735a028d155ae) python310Packages.peaqevcore: 13.4.14 -> 13.4.15
* [`0d4a1f29`](https://github.com/NixOS/nixpkgs/commit/0d4a1f299be2622d84fdd312b2d7d23d382b6327) python310Packages.peaqevcore: 13.4.15 -> 15.0.2
* [`f864bb2b`](https://github.com/NixOS/nixpkgs/commit/f864bb2b1176cc363dd55f7d0b6139b4a7fa3a02) regreet: unstable-2023-03-19 -> 0.1.0
* [`a001b446`](https://github.com/NixOS/nixpkgs/commit/a001b446a25be51c5f0cf054c190334c53b77da2) poetry: 1.4.1 -> 1.4.2
* [`c10f918f`](https://github.com/NixOS/nixpkgs/commit/c10f918f3dd01b7dbe7dacc81830295026c0557e) maintainers/team-list: drop lnl7 from rust maintainer list
* [`ccbe18bb`](https://github.com/NixOS/nixpkgs/commit/ccbe18bbf718c06a27c0b1c5d6cce9ed503a2462) meilisearch: 1.0.2 -> 1.1.0
* [`5da3f9d6`](https://github.com/NixOS/nixpkgs/commit/5da3f9d63615916de5fddc7fe3c4d1b327746ed4) libdeltachat: 1.112.4 -> 1.112.5
* [`c8613122`](https://github.com/NixOS/nixpkgs/commit/c8613122a080456ae6a134cdaed2464a7faad309) Remove maintainer from `tools/typesetting/htmldoc`
* [`ce2fcc00`](https://github.com/NixOS/nixpkgs/commit/ce2fcc00e0abbb8ad85ceb6d7cd897d4782efd7b) Remove maintainer from `maintainer-list.nix`
* [`5c5dc433`](https://github.com/NixOS/nixpkgs/commit/5c5dc43305f18857eb6b32ab165dc795f359716f) python310Packages.psycopg: fix build with Cython 3.0.0b1
* [`230939de`](https://github.com/NixOS/nixpkgs/commit/230939de785c26295fc038c04e5672b94d0fef24) python311Packages.psycopg: Propagate typing-extensions unconditionally
* [`a182101a`](https://github.com/NixOS/nixpkgs/commit/a182101ae7dd15e8e79f046a2a7579540c88efed) lisp-modules: don't use mysql-client alias
* [`f60d291f`](https://github.com/NixOS/nixpkgs/commit/f60d291f64d4e722c582bbe060b6a664a8ab35fb) lisp-modules: don't use mysql alias
* [`82aeb5ec`](https://github.com/NixOS/nixpkgs/commit/82aeb5ec4094859b7c29f099dd12d8373983d45e) abcmidi: 2023.03.15 -> 2023.03.24
* [`dcf9f37a`](https://github.com/NixOS/nixpkgs/commit/dcf9f37aef4143eb2b89c561150b4117598ff0a5) celeste: 0.4.6 -> 0.5.2
* [`98d21463`](https://github.com/NixOS/nixpkgs/commit/98d2146331f49640ebb3e852e78cca0aa023e020) beancount-language-server: 1.3.0 -> 1.3.1
* [`2cc4e028`](https://github.com/NixOS/nixpkgs/commit/2cc4e028292753cba509edf1f3841ce2096928a9) python3Packages.cyclonedx-python-lib: 3.1.5 -> 4.0.0
* [`bde478a5`](https://github.com/NixOS/nixpkgs/commit/bde478a52f239ae334fb8e99b694e0555ec00f2b) discord: remove maintainer ([nixos/nixpkgs⁠#224577](https://togithub.com/nixos/nixpkgs/issues/224577))
* [`9ddfa473`](https://github.com/NixOS/nixpkgs/commit/9ddfa473f5fc3e2dc24dfdb141bb333a30c932c6) proteus: init at 1.2 ([nixos/nixpkgs⁠#224221](https://togithub.com/nixos/nixpkgs/issues/224221))
* [`1e02fa2d`](https://github.com/NixOS/nixpkgs/commit/1e02fa2d81fa6d7c4384bc0672a7648ce2f1050b) ocamlPackages.jsonm: 1.0.1 → 1.0.2
* [`d9c613d7`](https://github.com/NixOS/nixpkgs/commit/d9c613d746e0b88ec9afc558368dd5422aff8448) mediawiki: add support for postgresql
* [`955503e4`](https://github.com/NixOS/nixpkgs/commit/955503e407f074daf23ecf605b4c0544242d3771) vimv-rs: 1.7.7 -> 1.8.0
* [`09a6672b`](https://github.com/NixOS/nixpkgs/commit/09a6672bbfc240b6154474b135ba583c929859e4) elasticsearch6*: remove
* [`76ad0b1b`](https://github.com/NixOS/nixpkgs/commit/76ad0b1b7db9fd4cb62a176caa1e47a5b5671b33) logstash6*: remove
* [`426fbcb5`](https://github.com/NixOS/nixpkgs/commit/426fbcb5a6f110b4bc76a5cd2818e5254dbef8ba) *beat6: remove
* [`3acb3d73`](https://github.com/NixOS/nixpkgs/commit/3acb3d73ae12e38dc69909b23efa36918232bd87) elasticsearch-oss: remove
* [`8b4505a8`](https://github.com/NixOS/nixpkgs/commit/8b4505a841c83cd4112a475d4e334d0404dda6d2) nixos/rl-2305: mention elk6 removal
* [`4c874b81`](https://github.com/NixOS/nixpkgs/commit/4c874b81b59da9ca1702365354e0fd922154994f) skopeo: 1.11.1 --> 1.11.2
* [`0b7f8761`](https://github.com/NixOS/nixpkgs/commit/0b7f87614bcf9882b46a3df538c357eba6517f73) skopeo: add developer-guy to maintainers list
* [`7d6f837b`](https://github.com/NixOS/nixpkgs/commit/7d6f837b80a6b7714d51357ad7fa07a1cca3e25b) harmonia: 0.6.0 -> 0.6.1
* [`a1510d8f`](https://github.com/NixOS/nixpkgs/commit/a1510d8fa4433b5daa143abdeee7e72d85ebc382) terraform-providers.cloudfoundry: 0.50.6 → 0.50.7
* [`1afb9035`](https://github.com/NixOS/nixpkgs/commit/1afb9035e9856de028eae94f3b48b6c69783c8e6) terraform-providers.cloudamqp: 1.24.2 → 1.25.0
* [`17a7c500`](https://github.com/NixOS/nixpkgs/commit/17a7c5008287fca629d222b85b0a6e654a1362f7) terraform-providers.github: 5.18.3 → 5.19.0
* [`bef20f18`](https://github.com/NixOS/nixpkgs/commit/bef20f18bf1b64fa7b95ec8393b12e4bde673883) terraform-providers.scaleway: 2.14.1 → 2.15.0
* [`e7cd1fd2`](https://github.com/NixOS/nixpkgs/commit/e7cd1fd2747d0aef6ea409117c5ad0656d26c6ea) terraform-providers.snowflake: 0.60.0 → 0.61.0
* [`eb423a40`](https://github.com/NixOS/nixpkgs/commit/eb423a400e1013af3c8c73ad504edae675870506) terraform-providers.vultr: 2.12.1 → 2.13.0
* [`21131995`](https://github.com/NixOS/nixpkgs/commit/21131995d9c949758ec4e37ff590a3cd3d9a0ce1) coqPackages.serapi: 8.16.0+0.16.3 -> 8.17.0+0.17.0
* [`6462ef85`](https://github.com/NixOS/nixpkgs/commit/6462ef85d8caefd4a27a09164c53017241547214) coqPackages.coq-lsp: 0.1.6.1 for Coq 8.17
