### PR TITLE
niv nixpkgs: update 328636ca -> 4f360a29

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "328636cafa83bcdf08b2a4f4e6b7fbcbe4ec56b3",
-        "sha256": "16bzv763l44rfhmv47qlgckcv4cz7n9j3dnp43lg1k0jxxzvbcqs",
+        "rev": "4f360a2944af5a027b229f3e643e03d40b4c9c7e",
+        "sha256": "06c9y1nwnbp6bfq08yvx93nwn1zn24yqhyxpf0bx9qfrb8xy9il9",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/328636cafa83bcdf08b2a4f4e6b7fbcbe4ec56b3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4f360a2944af5a027b229f3e643e03d40b4c9c7e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@328636ca...4f360a29](https://github.com/nixos/nixpkgs/compare/328636cafa83bcdf08b2a4f4e6b7fbcbe4ec56b3...4f360a2944af5a027b229f3e643e03d40b4c9c7e)

* [`8dd82f3f`](https://github.com/NixOS/nixpkgs/commit/8dd82f3f41928d7663b3a61ddeba87c44852adc5) zabbix: Support for 6.0
* [`a4fc9696`](https://github.com/NixOS/nixpkgs/commit/a4fc9696dafc7f3b67b34979195c561d7ab6b9f2) zabbix: move vendorSha256 to versions.nix
* [`6c8f8293`](https://github.com/NixOS/nixpkgs/commit/6c8f82937fb433065945faa545883714677a7b4e) librewolf: build with `MOZ_REQUIRE_SIGNING = ""`
* [`69b41f98`](https://github.com/NixOS/nixpkgs/commit/69b41f98809c7a3bfe79dae28c31917927ee9f64) pfstools: fix netpbm inclusion
* [`b639a8c6`](https://github.com/NixOS/nixpkgs/commit/b639a8c6a6d02c2694318c1e8841f83388ebc6c5) qt6.qtdeclarative: build qmlls
* [`3c70b00f`](https://github.com/NixOS/nixpkgs/commit/3c70b00f18e907547a7e7e118cc2e55d1509a8e0) nailgun: split into client and server
* [`80d3f484`](https://github.com/NixOS/nixpkgs/commit/80d3f4849cb34004b8eb6536b561552092e1304e) maintainers: add arian-d
* [`e90acad3`](https://github.com/NixOS/nixpkgs/commit/e90acad35f33b883b6627ec28998fe883e303b02) python310Packages.aioresponses: don't depend on asynctest
* [`8225d6db`](https://github.com/NixOS/nixpkgs/commit/8225d6db3a7921893c212ae2d93e657483cd74cb) smokeping: fix css and js symlink
* [`6a6349cc`](https://github.com/NixOS/nixpkgs/commit/6a6349cc338df56f6d7092382ba22338f1077f03) nixos/tests/libreswan: attempt to fix flakiness
* [`93dd7ceb`](https://github.com/NixOS/nixpkgs/commit/93dd7ceb13878a626275636ed3a32df3dc5b0021) libreswan: fix yet another path
* [`e4a5147c`](https://github.com/NixOS/nixpkgs/commit/e4a5147cf83fd571a603bda27ed0e8db0209eff5) gbforth: init at unstable-2023-03-02
* [`9435abca`](https://github.com/NixOS/nixpkgs/commit/9435abcaee6e68ba746deef96bde5846e0abe46e) Expose the buildTensorRTPackage function.
* [`a411a116`](https://github.com/NixOS/nixpkgs/commit/a411a116a5d91a8d7ce260a05fe48142366138e4) openafs: Fix configure option; Add tools
* [`40a091cd`](https://github.com/NixOS/nixpkgs/commit/40a091cdd682940767cc09624de85c9b3f25164a) syncplay: fix xcb plugin issue
* [`99bc90e3`](https://github.com/NixOS/nixpkgs/commit/99bc90e3019cd79de82b41481fe1cc2ef4900caa) lib.strings: Deprecate path prefix/suffix/infix arguments
* [`5e8b9de7`](https://github.com/NixOS/nixpkgs/commit/5e8b9de7285497e4ef749eb9c55916dd26fecb88) lib.strings.normalizePath: Deprecate for path values
* [`61012f6d`](https://github.com/NixOS/nixpkgs/commit/61012f6daf61e2cca664c333453a8b868908dc97) lib.strings.remove{Prefix,Suffix}: Deprecate for path prefix/suffix arguments
* [`2c19718b`](https://github.com/NixOS/nixpkgs/commit/2c19718beed29f1b627a3a143653487318d6511c) dendrite: 0.11.0 -> 0.12.0
* [`c6e871f6`](https://github.com/NixOS/nixpkgs/commit/c6e871f634db9f868eb95662fc33ef9a94ce2c65) newlib: improve the nano version
* [`b34aec22`](https://github.com/NixOS/nixpkgs/commit/b34aec224d234a75adada4afd29326ac71842b97) material-color-utilities-python: init at 0.1.5
* [`8ff27f66`](https://github.com/NixOS/nixpkgs/commit/8ff27f6602c1fcbddbb327fde36460efa01d1dc8) libpg_query: also build shared library
* [`4306baba`](https://github.com/NixOS/nixpkgs/commit/4306baba86a189851b2bd40a944bb39f236abab0) chefdk: remove due to being deprecated upstream by Chef Workstation
* [`13e3b51c`](https://github.com/NixOS/nixpkgs/commit/13e3b51c998383df221e8c489a3c8192dff50297) newlib: sync configure flags with upstream
* [`116dd693`](https://github.com/NixOS/nixpkgs/commit/116dd693ca46b6bff0f44c714a94175d0e5b6b88) newlib: 4.1.0 -> 4.3.0.20230120
* [`eca3d38d`](https://github.com/NixOS/nixpkgs/commit/eca3d38d188dd9d9ebb60a502ba42a6ca92d550d) newlib: add meta
* [`d7d6d905`](https://github.com/NixOS/nixpkgs/commit/d7d6d9051b2f972ab251723d6591fbd2c28cb1a2) python310Packages.timm: update github repo owner
* [`db18f349`](https://github.com/NixOS/nixpkgs/commit/db18f3498e3053a1d4c4a274856041ac0f16e3a0) python3Packages.rustworkx: init at 0.12.1
* [`ba0a1611`](https://github.com/NixOS/nixpkgs/commit/ba0a1611fcd67b826eaa8f7dc238105aec93d3c7) nixos/nginx: fix warning about duplicate mime entry
* [`a9cbb206`](https://github.com/NixOS/nixpkgs/commit/a9cbb20640a2a95aea41b449fbf06f2073ddacff) maintainers: add mathiassven
* [`6f81910b`](https://github.com/NixOS/nixpkgs/commit/6f81910b71906a979580ffd33b51b5fc704aa9d2) python310Packages.django-compression-middleware: 0.4.2 → 0.5.0
* [`99f96687`](https://github.com/NixOS/nixpkgs/commit/99f9668726e337caa646734c88507538ec6455bf) yuview: 2.12.1 -> 2.13
* [`0f57b4bd`](https://github.com/NixOS/nixpkgs/commit/0f57b4bd736cbb3237e2b221d4fcbb742d24b527) fetchMavenArtifact: deprecate phases & use pname+version
* [`15eecb31`](https://github.com/NixOS/nixpkgs/commit/15eecb3144e9d77c24e5ac29f7169080733af43d) osu-lazer-bin: 2023.305.0 -> 2023.326.1
* [`672aaa57`](https://github.com/NixOS/nixpkgs/commit/672aaa57f2a206988a6a479da87764e75f4dfa1b) osu-lazer: 2023.305.0 -> 2023.326.1
* [`f6957645`](https://github.com/NixOS/nixpkgs/commit/f6957645b54171ddbc400629490ba68dcb80acd4) libpg_query: enable tests
* [`d505646d`](https://github.com/NixOS/nixpkgs/commit/d505646da5516457d258f88e76f02852e221bc03) python310Packages.tree-sitter: init at 0.20.1
* [`98ef4e4f`](https://github.com/NixOS/nixpkgs/commit/98ef4e4fc9d0638c17a5294ae2a4b1d2d370125d) tor-browser-bundle-bin: add missing control auth variables
* [`982cecf9`](https://github.com/NixOS/nixpkgs/commit/982cecf911134e7642489508907bcdf46efc8544) tuckr: 0.7.1 -> 0.8.0
* [`aa7e8209`](https://github.com/NixOS/nixpkgs/commit/aa7e8209348c4d7a79fb105288205a8c9fba0407) zabbix60: 6.0.9 -> 6.0.14
* [`85f74d19`](https://github.com/NixOS/nixpkgs/commit/85f74d19ef2cd9bbfa5484fae49777c445665f86) zabbix50: 5.0.19 -> 5.0.33
* [`34eb88e5`](https://github.com/NixOS/nixpkgs/commit/34eb88e5c23454eb8b707e63a2c77277b8764c55) zabbix40: 4.0.37 -> 4.0.44
* [`ed513f71`](https://github.com/NixOS/nixpkgs/commit/ed513f71d7d54de71ecf58f95eacc5eb1963256f) zabbix: agent2 is not supported for v4
* [`9d4439bb`](https://github.com/NixOS/nixpkgs/commit/9d4439bb63060a32a1c035419af2997c95133c97) zabbix: set default zabbix version to v6
* [`deab2b3b`](https://github.com/NixOS/nixpkgs/commit/deab2b3bf768fc6158142e4d59e20ef016197438) nixos/auto-cpufreq: Add configuration support.
* [`fb0b48d3`](https://github.com/NixOS/nixpkgs/commit/fb0b48d3af008ab589b38f578d8894c6956d0c6b) enchant: explicitly enable required providers
* [`7550a20a`](https://github.com/NixOS/nixpkgs/commit/7550a20a4562d6db134cee25a78173fe0e31168f) nuspell: provide icu for dependent packages
* [`675111e5`](https://github.com/NixOS/nixpkgs/commit/675111e5acee20c48dbadb34b9bdde676d20d337) patchelfUnstable: unstable-2023-03-18 -> unstable-2023-03-27
* [`1ba9b851`](https://github.com/NixOS/nixpkgs/commit/1ba9b8517a8938ad40136a9a842dfa99f60dcc6a) haskellPackages: stackage LTS 20.14 -> LTS 20.16
* [`0ba1bbe6`](https://github.com/NixOS/nixpkgs/commit/0ba1bbe64ea9a11463967ffe62bea42ea00e3c07) all-cabal-hashes: 2023-03-13T08:59:39Z -> 2023-03-30T00:19:14Z
* [`80bdc110`](https://github.com/NixOS/nixpkgs/commit/80bdc110a0366bd024394c5bb67bf4ab91569e9a) haskellPackages: regenerate package set based on current config
* [`bdd538ff`](https://github.com/NixOS/nixpkgs/commit/bdd538ff0316586b0b5e3edfdd87f0ec949f2e8a) haskell.packages.ghc944.lens: 5.2.1 -> 5.2.2
* [`9283ba9f`](https://github.com/NixOS/nixpkgs/commit/9283ba9fbb07b18802bd67b1ede5a3602b0c57d5) haskell.packages.ghc944.http-api-data: 0.5 -> 0.5.1
* [`f90d9744`](https://github.com/NixOS/nixpkgs/commit/f90d9744810869a6c9a3883e10e164644b110af5) haskell.packages.ghc944.tasty-hedgehog: 1.4.0.0 -> 1.4.0.1
* [`c69399d4`](https://github.com/NixOS/nixpkgs/commit/c69399d4fd83ab0d4e4ecb98e7cb1d00f0dc5b63) cachix: remove source override
* [`43519156`](https://github.com/NixOS/nixpkgs/commit/435191569622eb8dccc36e5f474dacc4d4610770) haskell.packages.ghc944.ghc-exactprint: pin to 1.6.1.1
* [`a34c185e`](https://github.com/NixOS/nixpkgs/commit/a34c185ea4691a8744a7e118492d272e3cde4e6c) flow: 0.193.0 -> 0.203.1
* [`b427649a`](https://github.com/NixOS/nixpkgs/commit/b427649abd62499b2b7f106fc7840d0445ddf5a1) ledger: 3.3.1 -> 3.3.2
* [`dc532b18`](https://github.com/NixOS/nixpkgs/commit/dc532b18f2d7ffd8e4aad708c60a3e1b996f818e) haskell.packages.ghc96: fix some overrides for ghc96
* [`cd111f45`](https://github.com/NixOS/nixpkgs/commit/cd111f458f4db5ca5ef6c1316c3fa6fc12b241a8) haskell.packages.ghc944.fourmolu_0_11_0_0: unbreak
* [`79fe155d`](https://github.com/NixOS/nixpkgs/commit/79fe155d0584502884738096a8d1f94646d722b3) libpg_query: prefer setting checkTarget to overriding checkPhase
* [`bcd59cec`](https://github.com/NixOS/nixpkgs/commit/bcd59cec7b03786c0173f3b41d3623d6186cabfa) maintainers: add colamaroro
* [`4ea3cb47`](https://github.com/NixOS/nixpkgs/commit/4ea3cb472bdaf3efd14770a1823235c74b06c959) flare: 1.13.04 -> 1.14
* [`86361b57`](https://github.com/NixOS/nixpkgs/commit/86361b5767e678f72c5356acaa6ab0c1ffa53209) prismlauncher: add support for GameMode
* [`26773687`](https://github.com/NixOS/nixpkgs/commit/26773687e155a68ecafb8a333a660f7e339347ce) ndpi: add changelog to meta
* [`a9c29a7a`](https://github.com/NixOS/nixpkgs/commit/a9c29a7af72e8f7ea1f193a52d60431a9a1aed09) ndpi: 4.2 -> 4.6
* [`0d88b0da`](https://github.com/NixOS/nixpkgs/commit/0d88b0dac68abc0e9ebc4fb36a6fecbe818d3c5f) ntopng: add changelog to meta
* [`31cb9b08`](https://github.com/NixOS/nixpkgs/commit/31cb9b08409ea3d4c0fc0eaaaa2af600bc8eb9fa) ntopng: 5.2.1 -> 5.6
* [`b6ecc4fe`](https://github.com/NixOS/nixpkgs/commit/b6ecc4fec128fbd001ee587eb518a014b977cc95) tracy: fix build on macos (fixes [nixos/nixpkgs⁠#223469](https://togithub.com/nixos/nixpkgs/issues/223469))
* [`6ae3b95f`](https://github.com/NixOS/nixpkgs/commit/6ae3b95f56fa98c3ac145212969906b84b02fbf4) tcsh: fix cross compilation
* [`18f4e2dc`](https://github.com/NixOS/nixpkgs/commit/18f4e2dc98292f213f0cb698f98315c7820e3b62) tcsh: drop outdated patch for musl
* [`b88b470a`](https://github.com/NixOS/nixpkgs/commit/b88b470abb1bbd9dd74c750c798b367b0d367501) deepin.deepin-pdfium: init at 1.0.1
* [`5300e070`](https://github.com/NixOS/nixpkgs/commit/5300e0701f335e5635229de8d3362b20004bfe56) fuzzel: 1.8.2 -> 1.9.1
* [`58aec3d1`](https://github.com/NixOS/nixpkgs/commit/58aec3d12a98a3723df599ff0dcd5af441d9fc94) haskellPackages.openai-hs: Fix build by disabling tests
* [`69ba0b6c`](https://github.com/NixOS/nixpkgs/commit/69ba0b6ca3ef53723d9a4de0ea0db5582504943b) all-cabal-hashes: 2023-03-30T00:19:14Z -> 2023-03-31T20:07:10Z
* [`56b81893`](https://github.com/NixOS/nixpkgs/commit/56b81893ea6513800b24b8b1924db53e7f30aa73) haskellPackages: regenerate package set based on current config
* [`c28c72a2`](https://github.com/NixOS/nixpkgs/commit/c28c72a2b30a346b0d63cbb0c6f77a6b267733f4) driftnet: 1.4.0 -> 1.5.0
* [`292f22ce`](https://github.com/NixOS/nixpkgs/commit/292f22ce7f78d4bb2adb3a1baa9ecbd948bdffb5) python310Packages.jupyterlab: 3.6.1 -> 3.6.3
* [`7ec7922b`](https://github.com/NixOS/nixpkgs/commit/7ec7922b04f6775b2fb3416fd85cea26e7480f81) nixos/tests/nginx: update test script
* [`8a289bcc`](https://github.com/NixOS/nixpkgs/commit/8a289bcc79950439935b830eaf7f1a533f124254) nixos/nginx: enable multiple proxyCachePath support
* [`b2aabfd2`](https://github.com/NixOS/nixpkgs/commit/b2aabfd21642be5b8b28c19bc4d517b40644b34c) haskellPackages.haskell-language-server: Reorganize overrides
* [`0b39ed44`](https://github.com/NixOS/nixpkgs/commit/0b39ed44dd08d37a9364cd39bc20f097c1fb07b7) carapace: add ldflags for version
* [`5a6fc17b`](https://github.com/NixOS/nixpkgs/commit/5a6fc17bd4e5939d6ae9509cfe65a205293ee055) python3Packages.furo: 2022.12.7 -> 2023.3.27
* [`b53a03a1`](https://github.com/NixOS/nixpkgs/commit/b53a03a13236c391bfba6c653bd6df5cabc26810) wf-config: update
* [`790f3ca1`](https://github.com/NixOS/nixpkgs/commit/790f3ca188e51b60c89a8eac96e5e06e1c0062f3) wayfire: 0.7.2 -> 0.7.5
* [`2c98c9d3`](https://github.com/NixOS/nixpkgs/commit/2c98c9d34ad887026e3832bee535f6fa88e17492) wf-shell: update
* [`a852c365`](https://github.com/NixOS/nixpkgs/commit/a852c3656ac6b91376dbb7339157d3948409e680) wcm: 0.7.0 -> 0.7.5
* [`d20c12ec`](https://github.com/NixOS/nixpkgs/commit/d20c12ec43f2e0d3e8238171856d93ec0be32533) qtcreator-qt6: init at 9.0.2
* [`e4246ae1`](https://github.com/NixOS/nixpkgs/commit/e4246ae1e7f78b7087dce9c9da10d28d3725025f) {ibus,fcitx5}-rime: Refactor RIME data support
* [`733af06a`](https://github.com/NixOS/nixpkgs/commit/733af06a07d74f4e089e03629ae92dc42ad5e893) mucommander: 1.1.0-1 -> 1.2.0-1
* [`4e223a3b`](https://github.com/NixOS/nixpkgs/commit/4e223a3b68092f2917578e3aba703aee1cecac04) clutter-gst: enable strictDeps
* [`52306ecc`](https://github.com/NixOS/nixpkgs/commit/52306ecc2687ce97652f0853a2709fd7d1502f28) amtk: enable strictDeps
* [`9de6ea60`](https://github.com/NixOS/nixpkgs/commit/9de6ea604b1e3fdd4d958c29f875f3632e498b51) libcloudproviders: enable strictDeps
* [`ceb7b207`](https://github.com/NixOS/nixpkgs/commit/ceb7b207235d51e5ddf532a9ef085b0e233758b9) gucharmap: enable strictDeps
* [`729c8406`](https://github.com/NixOS/nixpkgs/commit/729c8406c995166a9352c4e018f86f95047486fd) uhttpmock: enable strictDeps
* [`e6b244b4`](https://github.com/NixOS/nixpkgs/commit/e6b244b41d37003eb687841ab32d3a9c9ba41e9b) tepl: enable strictDeps
* [`e8d9eb71`](https://github.com/NixOS/nixpkgs/commit/e8d9eb71f67c9d1995ef14c8bf005865c944fa6d) gmime2,gmime3: fix cross by copying iconv-detect.h from void-packages
* [`928c439e`](https://github.com/NixOS/nixpkgs/commit/928c439ec256e9f1f2319433138079525bc04ec7) librest_1_0: fix cross
* [`ef0e28c6`](https://github.com/NixOS/nixpkgs/commit/ef0e28c60a469b4366e0894a6f048ffb7517e475) telepathy-glib: enable strictDeps
* [`763b4576`](https://github.com/NixOS/nixpkgs/commit/763b4576012ecc50d85470689927214a928a3759) docker-credential-gcr: 2.1.7 -> 2.1.8
* [`03515759`](https://github.com/NixOS/nixpkgs/commit/03515759a3dd777d39c0d3f55cc140a74255b464) ryujinx: 1.1.687 -> 1.1.692
* [`1b3f8f6b`](https://github.com/NixOS/nixpkgs/commit/1b3f8f6b9c98065d8ef47f52302db6a3902fa541) dex-oidc: 2.35.3 -> 2.36.0
* [`99efd16b`](https://github.com/NixOS/nixpkgs/commit/99efd16bbde86dcae8f368d18ed7d9c1ccbbbda6) renderdoc: 1.25 -> 1.26
* [`3bac29ba`](https://github.com/NixOS/nixpkgs/commit/3bac29ba106086b96a82267f7beee86ffea319a4) coin-utils: init at 2.11.6
* [`daa4d3a3`](https://github.com/NixOS/nixpkgs/commit/daa4d3a33106e2b29d16b4af19a3172eec26c4fc) osi: 0.108.6 -> 0.108.7
* [`1718fc0b`](https://github.com/NixOS/nixpkgs/commit/1718fc0b044d8085c8acb40617757f6d886b48ac) clp: 1.17.6 -> 1.17.7
* [`8afcf3e3`](https://github.com/NixOS/nixpkgs/commit/8afcf3e3493abea7d67bc51c49702e33b951314b) fluidd: 1.23.3 -> 1.23.4
* [`cf34226d`](https://github.com/NixOS/nixpkgs/commit/cf34226d3f1285efaf771ff8e4653440ca87e3e8) exploitdb: 2023-04-01 -> 2023-04-02
* [`7b3e5b00`](https://github.com/NixOS/nixpkgs/commit/7b3e5b002e602d4344cc65ed060bad1cb5e2e1f3) gtksourceview5: fix cross
* [`a0405f0a`](https://github.com/NixOS/nixpkgs/commit/a0405f0aa64994236abdf558ba7739df9dbe2391) teleport: 12.1.0 -> 12.1.5
* [`80aa0693`](https://github.com/NixOS/nixpkgs/commit/80aa06932fefb0926e437d76be0ec08e0f4bea52) haskellPackages: Configure to add cachix < 1.4
* [`800bac08`](https://github.com/NixOS/nixpkgs/commit/800bac085efe6d9a5115fc6b7d7d4ca2557b7607) haskellPackages: regenerate package set based on current config
* [`c2b25291`](https://github.com/NixOS/nixpkgs/commit/c2b2529148877de0e6b41a0cd92745bf0ebc2432) haskellPackages.cachix_1_3_3: configure
* [`a13a44f7`](https://github.com/NixOS/nixpkgs/commit/a13a44f78140270528dc872a39225555a95ed9f6) haskellPackages.hercules-ci-agent: Use cachix 1.3
* [`eb16b4ff`](https://github.com/NixOS/nixpkgs/commit/eb16b4ff4b64c361f28af9bee6ecfae91d20727a) arkade: 0.9.5 -> 0.9.6
* [`3524ecfe`](https://github.com/NixOS/nixpkgs/commit/3524ecfed257fa1e70cfcc5349dd74df91b13866) d2: 0.2.6 -> 0.3.0
* [`57d6b684`](https://github.com/NixOS/nixpkgs/commit/57d6b68435666e56a6f81ec3fa2c2ffdea150f9c) ansifilter: 2.18 -> 2.19
* [`aa945d4c`](https://github.com/NixOS/nixpkgs/commit/aa945d4c2264f88323bc03d3af102d668e7b73cd) wakapi: 2.6.2 -> 2.7.0
* [`9323b20b`](https://github.com/NixOS/nixpkgs/commit/9323b20bf9154fa7cbe1ee783959321928096445) osu-lazer: 2023.326.1 -> 2023.403.0
* [`2ab282a4`](https://github.com/NixOS/nixpkgs/commit/2ab282a458327a750f378dd15567049b61af467d) osu-lazer-bin: 2023.326.1 -> 2023.403.0
* [`3753dfe6`](https://github.com/NixOS/nixpkgs/commit/3753dfe6a9d6c325e53622baf26202f5bc48a08e) network_cmds: unconditionally exclude Unbound
* [`bf89df42`](https://github.com/NixOS/nixpkgs/commit/bf89df428deebde99c5218caac196610b8ce6b74) maintainers: add mwdomino
* [`4b2d66b7`](https://github.com/NixOS/nixpkgs/commit/4b2d66b7be5273ddbd26cece8433980b34cb8d5c) aichat: init at 0.8.0
* [`64ff8009`](https://github.com/NixOS/nixpkgs/commit/64ff80092ff5a91c227136b5ada4b69e339887f3) osu-lazer-bin: 2023.403.0 -> 2023.403.1
* [`e6510786`](https://github.com/NixOS/nixpkgs/commit/e65107868e619ed62e2e065aa2054dbd87dbe427) osu-lazer: 2023.403.0 -> 2023.403.1
* [`f2bb0266`](https://github.com/NixOS/nixpkgs/commit/f2bb0266c1f14f077aed5659fa1f1ed3c386a74c) nixops_unstable: mark cryptography insecure
* [`05fc4507`](https://github.com/NixOS/nixpkgs/commit/05fc4507389b5431e5accd9bdb17ba03ef73b7ef) python310Packages.tensorflow: mark insecure
* [`d7b8a4e4`](https://github.com/NixOS/nixpkgs/commit/d7b8a4e44601121e0773f2aed2406fc231cc8f59) UTM: fix meta.mainProgram field
* [`93cd4b43`](https://github.com/NixOS/nixpkgs/commit/93cd4b43c19e8403aa3f7d9816ead5bf274f6ca4) all-cabal-hashes: 2023-03-31T20:07:10Z -> 2023-04-03T07:13:26Z
* [`e8215cb4`](https://github.com/NixOS/nixpkgs/commit/e8215cb4f54f03d068888ef8cc3d61e170dbd810) haskellPackages: regenerate package set based on current config
* [`788c8a63`](https://github.com/NixOS/nixpkgs/commit/788c8a630a3bb67da70e4a6b6cec3db212495727) deepin.util-dfm: init at 1.2.7
* [`637bbe55`](https://github.com/NixOS/nixpkgs/commit/637bbe5529609b9c261cadaa6981440f8f9a1756) haskellPackages.haskell-language-server: Fix build for version 1.10
* [`9554582b`](https://github.com/NixOS/nixpkgs/commit/9554582b341104529ffc8baaaa8955635636420e) nginxMainline: 1.23.3 -> 1.23.4
* [`b7cb7432`](https://github.com/NixOS/nixpkgs/commit/b7cb74322c663479e5b2382bd88978a5e61b59a1) fetchhg: allow specifying (sri) hash
* [`8be794b1`](https://github.com/NixOS/nixpkgs/commit/8be794b197fd5e9146aeb2903044121f362b70fe) nginx: sha256 -> hash
* [`eae93980`](https://github.com/NixOS/nixpkgs/commit/eae9398010a6fd99971cd8047538186b8c0f3276) clp: Change license to epl20
* [`55fae22f`](https://github.com/NixOS/nixpkgs/commit/55fae22f98c2fa0d83cf773045fc0452f705e1d4) osi: Change license to epl20
* [`0ba7f768`](https://github.com/NixOS/nixpkgs/commit/0ba7f7688dbdabbfb508aaf961cba20a6c852d7c) haskell.packages.ghc{810,90}.haskell-language-server: Fix build with jailbreak
* [`27147190`](https://github.com/NixOS/nixpkgs/commit/2714719012aa1c57b75236f19a01effc92d53754) potreeconverter: symlink resources dir to $out
* [`b173c1c6`](https://github.com/NixOS/nixpkgs/commit/b173c1c6e2257ec2bb44ab70dc49ddacf697552f) potreeconverter: stop copy operation from inheriting permissions from store
* [`c332cf0e`](https://github.com/NixOS/nixpkgs/commit/c332cf0e1d95fa2adbf12acacbe24b809cae281a) potreeconverter: unstable-2022-08-04 -> unstable-2023-02-27
* [`4e72d111`](https://github.com/NixOS/nixpkgs/commit/4e72d111e92555e993dff69c6f230246c6ce1795) raspa: init at 2.0.47 and add tests
* [`6ce53a27`](https://github.com/NixOS/nixpkgs/commit/6ce53a279b0e3076aa4b50d0b53ad1d7c95b32e2) jacoco: 0.8.8 -> 0.8.9
* [`5ddf8ec5`](https://github.com/NixOS/nixpkgs/commit/5ddf8ec5a8ba62f5e117a7700946f56e711a9618) haskell.packages.ghc94.haskell-language-server: Fix build
* [`f8ca8c03`](https://github.com/NixOS/nixpkgs/commit/f8ca8c031bcefb5823803582dddec1387e582a97) haskell.packages.ghc96.haskell-language-server: Fix build
* [`0ee5c233`](https://github.com/NixOS/nixpkgs/commit/0ee5c23301ce1573cf524e063c7c6483e3581cf6) python3.pkgs.pydevtool: init at 0.3.0
* [`e505ffd2`](https://github.com/NixOS/nixpkgs/commit/e505ffd2512844f36da45bb129555f831e34fe58) llvmPackages_git: apply [nixos/nixpkgs⁠#190936](https://togithub.com/nixos/nixpkgs/issues/190936) (fix pkgsStatic LLVM build)
* [`2c65676e`](https://github.com/NixOS/nixpkgs/commit/2c65676e876ef3cd1f3faab225b6f6916f73323b) UTM: use makeWrapper to link UTM into bin/
* [`824c9ac5`](https://github.com/NixOS/nixpkgs/commit/824c9ac5c977ed67c20b9fae7e16c50d124dd55c) nix-prefetch-docker: handle overrides correctly
* [`c9deaf22`](https://github.com/NixOS/nixpkgs/commit/c9deaf22c435861510396314f4b30f446c4e1f6b) python310Packages.tensorflow-bin: mark insecure
* [`941a35b7`](https://github.com/NixOS/nixpkgs/commit/941a35b7ea165f3ef2d690a611226b43e8c843d5) nil: 2023-03-11 -> 2023-04-03
* [`81798fe4`](https://github.com/NixOS/nixpkgs/commit/81798fe4f48633eb5e8d11bde1cb3c15fe80840d) elmPackages.lamdera: 1.0.1 -> 1.1.0
* [`130219aa`](https://github.com/NixOS/nixpkgs/commit/130219aa1957033cdaada05f0e6c5531d3ec37c0) python310Packages.iocextract: init at 1.15.1
* [`42495043`](https://github.com/NixOS/nixpkgs/commit/4249504385852e1e53df9bd4fe0f97dcbbb4e050) lutris: remove wine dependency
* [`c5f2c2c1`](https://github.com/NixOS/nixpkgs/commit/c5f2c2c17e844b6053a604ac6130097e224ddb06) k3s_1_23: drop deprecated k3s version
* [`cebe5de8`](https://github.com/NixOS/nixpkgs/commit/cebe5de8aff7c8de800a8c8636b339e11ba695bc) python3.pkgs.pyarrow: fix build
* [`0521683e`](https://github.com/NixOS/nixpkgs/commit/0521683ef252c48b310d0779559f2081f26538ab) pscale: 0.133.0 -> 0.134.0
* [`128fcd62`](https://github.com/NixOS/nixpkgs/commit/128fcd6264bcd510188aa1cc367ab784385ca9b7) python310Packages.ancp-bids: init at 0.2.1
* [`9a15cdc3`](https://github.com/NixOS/nixpkgs/commit/9a15cdc3901b50df9e78e82c9db60fab172dd525) wsjtx: 2.5.4 -> 2.6.1
* [`baee1005`](https://github.com/NixOS/nixpkgs/commit/baee1005c9d5cf320d52be41e9ad905b2de7397b) tdesktop: 4.6.5 -> 4.7.1
* [`b6641c22`](https://github.com/NixOS/nixpkgs/commit/b6641c2209354eb38d1f52c74cf89296cd0553a0) tdesktop: override glibmm_2_68 to version 2.76.0
* [`b033a361`](https://github.com/NixOS/nixpkgs/commit/b033a3614995a2f140c7e3dc7e1c338eb2fed95c) valent: unstable-2023-03-02 -> unstable-2023-03-31
* [`f4b0afe9`](https://github.com/NixOS/nixpkgs/commit/f4b0afe9f56ced1adce1f6bc65c91e0fc880c6c3) pre-commit: 3.1.0 -> 3.2.1
* [`f96d3b9b`](https://github.com/NixOS/nixpkgs/commit/f96d3b9bca8ca466688db170996a3f3eef85a7bc) uhk-agent: 2.1.1 -> 2.1.2
* [`c28cde3a`](https://github.com/NixOS/nixpkgs/commit/c28cde3aacc920375e86adcc40d75dfb0e5c9d78) zigbee2mqtt: 1.30.2 -> 1.30.3
* [`24aff837`](https://github.com/NixOS/nixpkgs/commit/24aff837bd92cd9dfc5548d712c6d46ac8727413) tracy: update from 0.9 to 0.9.1
* [`b4fe08d2`](https://github.com/NixOS/nixpkgs/commit/b4fe08d2d67ab0cbefe157d640ff0ebc75c644ca) tracy: Remove UniformTypeIdentifiers depending on SDK
* [`01ceca76`](https://github.com/NixOS/nixpkgs/commit/01ceca76ac21b5df4196f2d0d029b932b16846ff) zeal: 0.6.20221022 -> 0.6.1.20230320
* [`46ab8008`](https://github.com/NixOS/nixpkgs/commit/46ab8008a3255902b579b1bc72dacb1966a279d8) tqsl: 2.5.9 -> 2.6.5
* [`b9e93192`](https://github.com/NixOS/nixpkgs/commit/b9e9319236b0744d6b4ebe919caac8015db16657) git-gone: 0.4.3 -> 0.5.0
* [`34adc9e4`](https://github.com/NixOS/nixpkgs/commit/34adc9e4e30210200c322bae2965faa5c35a86de) millet: 0.8.6 -> 0.8.7
* [`adcbb9f5`](https://github.com/NixOS/nixpkgs/commit/adcbb9f514e42f37bdb30f865616d247152d8d84) blesh: 2022-07-29 -> 0.3.4
* [`09b49938`](https://github.com/NixOS/nixpkgs/commit/09b49938e548edfea863b443e5fb0fdd248174cc) actionlint: 1.6.23 -> 1.6.24
* [`0e2804eb`](https://github.com/NixOS/nixpkgs/commit/0e2804eb3ed5708bbf2910ed673b147cf95b74bf) arti: 1.1.2 -> 1.1.3
* [`2593f5e0`](https://github.com/NixOS/nixpkgs/commit/2593f5e033501ad7cb07ebab43bb33b4801959be) chatgpt-cli: 0.6.0-beta -> 1.0.2
* [`0783b500`](https://github.com/NixOS/nixpkgs/commit/0783b500fc9db4b1af8c121e41c39fe6c5198e98) railway: 3.0.18 -> 3.0.19
* [`471ca583`](https://github.com/NixOS/nixpkgs/commit/471ca58383dd662cb90e85ab51ea559a7b93fba6) minizinc: 2.7.0 -> 2.7.1
* [`6789f0bb`](https://github.com/NixOS/nixpkgs/commit/6789f0bb62dd744d456dbb47f2878b7d5e75a630) pritunl-client: 1.3.3477.58 -> 1.3.3484.2
* [`d442ebf9`](https://github.com/NixOS/nixpkgs/commit/d442ebf9f820a9d29033bc21d24f80b2fc927db5) spicedb: 1.17.0 -> 1.19.0
* [`1e54b37c`](https://github.com/NixOS/nixpkgs/commit/1e54b37c8d88b6edd543177a895cb01a241c734a) wasabiwallet: 2.0.2.2 -> 2.0.3
* [`a6028bae`](https://github.com/NixOS/nixpkgs/commit/a6028bae0341b528c805651e864d1b9394ddde9a) netbird: 0.14.4 -> 0.14.6
* [`85e22318`](https://github.com/NixOS/nixpkgs/commit/85e2231832a1cc10bebeb1ebae0b4d5541397738) tandoor-recipes: fix build
* [`36aa2c86`](https://github.com/NixOS/nixpkgs/commit/36aa2c864bbb0a641f5cdcfcb780dbe5d7854722) faudio: 23.03 -> 23.04
* [`d8548211`](https://github.com/NixOS/nixpkgs/commit/d85482117b5d91de773afee13219ecc0b91ffb0e) vitess: 16.0.0 -> 16.0.1
* [`0e79b157`](https://github.com/NixOS/nixpkgs/commit/0e79b157e14be99675e111b1cecb689bf9e07dd6) checkov: 2.3.96 -> 2.3.150
* [`33c156c3`](https://github.com/NixOS/nixpkgs/commit/33c156c32e08b2e772008cb29b394f277563e9a7) vimPlugins.blamer-nvim: init at 2021-11-17
* [`1e36c703`](https://github.com/NixOS/nixpkgs/commit/1e36c703b14366c0f4cabfd60d2f9884f330a812) spotify: 1.1.84.716.gc5f8b819 -> 1.1.99.878.g1e4ccc6e
* [`b5872242`](https://github.com/NixOS/nixpkgs/commit/b5872242a60774a96953d04695d74956889fb3be) spotify: Add support for `NIXOS_OZONE_WL`
* [`2a36db55`](https://github.com/NixOS/nixpkgs/commit/2a36db554b1fa7ceaf273a02cb11ed5fde49eaf0) knot-dns: 3.2.5 -> 3.2.6
* [`9e104018`](https://github.com/NixOS/nixpkgs/commit/9e1040188af5d54a2e6e1f17cfa899535bcdd774) ngtcp2-gnutls: 0.13.0 -> 0.13.1
* [`3d3b0c27`](https://github.com/NixOS/nixpkgs/commit/3d3b0c27d1cc09d32154529817338b2ead7298d6) cargo-llvm-cov: 0.5.11 -> 0.5.13
* [`1f874da9`](https://github.com/NixOS/nixpkgs/commit/1f874da97bae36f8594f1a839cd265113d097de1) vimPlugins.vim-wakatime: fix build as vim plugin
* [`bc4b08ac`](https://github.com/NixOS/nixpkgs/commit/bc4b08acbe7f40ecdf0cabb90d8833092e6c233d) netbox: 3.3.9 -> 3.4.1
* [`2cb6dc90`](https://github.com/NixOS/nixpkgs/commit/2cb6dc90acfa16a37c055f6786de06a031f12326) formats.pythonVars: init
* [`36a550c6`](https://github.com/NixOS/nixpkgs/commit/36a550c6f9fd5b7a2300c3b9d4d1b698858fe18d) nixos/netbox: RFC42-style options
* [`94976398`](https://github.com/NixOS/nixpkgs/commit/949763988a53fa6155087c436eaf295495b1105a) nixos/tests/netbox: test through proxy, REST API, GraphQL, LDAP integration
* [`70e95c69`](https://github.com/NixOS/nixpkgs/commit/70e95c699a21cfa453441fbe939672d50a4926aa) nixos/doc: add release notes for NetBox changes
* [`52f3031f`](https://github.com/NixOS/nixpkgs/commit/52f3031f23ee770c986307ce0577c7feb5812474) netbox: 3.4.1 -> 3.4.2
* [`eeb17fca`](https://github.com/NixOS/nixpkgs/commit/eeb17fca1c436efbf05609f0050a868e737dca6b) netbox: 3.4.2 -> 3.4.3
* [`8dbfb9e2`](https://github.com/NixOS/nixpkgs/commit/8dbfb9e263b80ac3ca83896a2305a0e5f82ece5c) netbox: 3.4.3 -> 3.4.5
* [`6e054138`](https://github.com/NixOS/nixpkgs/commit/6e054138b05670b2285ec815be44ef683e9bc1da) netbox: 3.4.5 -> 3.4.6
* [`78eb4d64`](https://github.com/NixOS/nixpkgs/commit/78eb4d64e70b95389670f24d8b00631db00653b3) netbox_3_3: init
* [`c1081bf2`](https://github.com/NixOS/nixpkgs/commit/c1081bf20b18c1e004ca063dba108cfd824c7da1) netbox: 3.4.6 -> 3.4.7
* [`03497d4a`](https://github.com/NixOS/nixpkgs/commit/03497d4ab4c6dc383130d83ba5a469f58379692b) netbox: introduce common function for generic packages, mark 3.3.9 EOL
* [`e965c5cc`](https://github.com/NixOS/nixpkgs/commit/e965c5cc5f9b6d39f118f939fe8fa7024178a621) netbox_3_3: 3.3.9 -> 3.3.10
* [`4a25cc47`](https://github.com/NixOS/nixpkgs/commit/4a25cc47534d8f66eb3a643e03bc6f9694b6518f) trufflehog: 3.31.2 -> 3.31.3
* [`0221a9ba`](https://github.com/NixOS/nixpkgs/commit/0221a9ba5beb8dfbd8f520759e68e60a543d0e14) tts: Run tests in passthru
* [`f7310b56`](https://github.com/NixOS/nixpkgs/commit/f7310b567d553f8171d2f588b45b446c7b9b51d5) ipget: 0.9.1 -> 0.9.2
* [`04e8e101`](https://github.com/NixOS/nixpkgs/commit/04e8e1010434c02f59dbf5be5ec35764c5fa8ed7) mediawiki: 1.39.2 -> 1.39.3
* [`bfdf33d1`](https://github.com/NixOS/nixpkgs/commit/bfdf33d13e467d524d96aa3b6e0211b34ac81e25) qownnotes: 23.2.4 -> 23.4.0
* [`47428f1a`](https://github.com/NixOS/nixpkgs/commit/47428f1a16d4c35ab712c67529110412ca97a556) mediawiki: Expose test variants individually
* [`f5f0feca`](https://github.com/NixOS/nixpkgs/commit/f5f0feca54fbd8840403de84caa386c96d47e144) python310Packages.bc-detect-secrets: 1.4.15 -> 1.4.16
* [`344ebdf2`](https://github.com/NixOS/nixpkgs/commit/344ebdf2e4ee1b62e7bd59fcc142bc313499308e) python310Packages.fakeredis: 2.10.2 -> 2.10.3
* [`b46f7fb4`](https://github.com/NixOS/nixpkgs/commit/b46f7fb47ca16eb44ccf715c261ca6979ad247de) sing-box: 1.2.1 -> 1.2.2
* [`acd90cdb`](https://github.com/NixOS/nixpkgs/commit/acd90cdb0716e1d7bbee72d35120f23310bf2069) mozart: use llvmPackages_8 instead of llvmPackages_5
* [`fd9c4cdb`](https://github.com/NixOS/nixpkgs/commit/fd9c4cdb2453aa638414a6a44c783a8c96bfb2e2) python310Packages.textnets: 0.8.7 -> 0.8.8
* [`2f27b9cb`](https://github.com/NixOS/nixpkgs/commit/2f27b9cb0ced564c66ed16a18de271518b966acd) qgis-ltr: 3.22.16 -> 3.28.5
* [`ee9df2c1`](https://github.com/NixOS/nixpkgs/commit/ee9df2c1a838f2f6905dd34d03b36926c55929e2) vulkan-headers: add update script
* [`00aab451`](https://github.com/NixOS/nixpkgs/commit/00aab4510243df735824d004a9fe569787dd57dc) mozart: Simplify build thanks to the new sources format
* [`6dcb25a0`](https://github.com/NixOS/nixpkgs/commit/6dcb25a078b70db9e88f5e4ada8bdb1784d4bc20) license-scanner: init at 0.10.0
* [`5ac23f93`](https://github.com/NixOS/nixpkgs/commit/5ac23f930cc5aeadc48e4d5827b645cf14ecdcfe) python310Packages.lupa: 1.14.1 -> 2.0
* [`9ca9baab`](https://github.com/NixOS/nixpkgs/commit/9ca9baab512ca0bddd64029d55beafa93c85c988) python310Packages.lupa: add changelog to meta
* [`a3221987`](https://github.com/NixOS/nixpkgs/commit/a32219871ee0044f8cf033fbeb9506304deb9867) python310Packages.lupa: disable on unsupported Python releases
* [`47c38620`](https://github.com/NixOS/nixpkgs/commit/47c386205d2cbebb6f6b2b4874a7bdc4a589e4ef) restinio: refactor
* [`d273fa8b`](https://github.com/NixOS/nixpkgs/commit/d273fa8bb6e90fe98deb10323a909b7fcb9e5d78) python3.pkgs.picobox: 2.2.0 -> 3.0.0
* [`85977002`](https://github.com/NixOS/nixpkgs/commit/8597700299b29e28944dcf8e25e142abe6a62b27) rml: use prefixKey
* [`a143b6f4`](https://github.com/NixOS/nixpkgs/commit/a143b6f42494c1f1e9dbf446ebcf53741d1d3b95) gptcommit: 0.1.15 -> 0.5.6
* [`14fe853a`](https://github.com/NixOS/nixpkgs/commit/14fe853aff518cede0e8e6cb1c313810d701a905) aaaaxy: 1.3.372 -> 1.3.421
* [`f5f4a50d`](https://github.com/NixOS/nixpkgs/commit/f5f4a50de5e55a84c1b353b92c4c46aeb0bd5288) libcef: remove i686-linux from platforms
* [`2b21a945`](https://github.com/NixOS/nixpkgs/commit/2b21a945d997dbd79248d290a043f471ccdfffd7) vimPlugins.autosave-nvim: init at 2022-10-13
* [`46016871`](https://github.com/NixOS/nixpkgs/commit/460168712363202aaecc2bf608598f1a8957e43d) buildFishPlugin: check if any .fish file exists in source
* [`1f6987ce`](https://github.com/NixOS/nixpkgs/commit/1f6987ce7e4a1c88d3b38ff568a81822ed2c27e9) fishPlugins.forgit: unstable-2022-10-14 -> 23.04.0
* [`3f1bafb6`](https://github.com/NixOS/nixpkgs/commit/3f1bafb686905c1e97a7762c13ebd925d0c03b74) plasma: 5.27.3 -> 5.27.4(.1)
* [`bf48945e`](https://github.com/NixOS/nixpkgs/commit/bf48945e2ea30233f075854d960b748b70b26847) ttdl: 3.7.0 -> 3.7.1
* [`a3cff1f0`](https://github.com/NixOS/nixpkgs/commit/a3cff1f0527ba7a5be7ac7a802002c3dab267a94) solc: 0.8.13 -> 0.8.19 ([nixos/nixpkgs⁠#219240](https://togithub.com/nixos/nixpkgs/issues/219240))
* [`3766708e`](https://github.com/NixOS/nixpkgs/commit/3766708eac355421461c55a6a7b2d73038715bae) butane: 0.17.0 -> 0.18.0
* [`d02bedbe`](https://github.com/NixOS/nixpkgs/commit/d02bedbe289de759c86ebed542dbe4e175e2b987) chickenPackages_5: overhaul ecosystem
* [`3545373f`](https://github.com/NixOS/nixpkgs/commit/3545373f306600c20874ccb8d4c79071e0aec6f8) maintainers: add konst-aa
* [`ca0335c0`](https://github.com/NixOS/nixpkgs/commit/ca0335c064e5cc5fd643be34e427c297da91f75a) chickenPackages_5: Remove ocaml dependency, switch to TOML
* [`44fc252d`](https://github.com/NixOS/nixpkgs/commit/44fc252df914ea1ca32af4bfb3ad327a489e2824) signalbackup-tools: 20230329 -> 20230404
* [`cc758eea`](https://github.com/NixOS/nixpkgs/commit/cc758eea86da2fd6167578034ebf0ba0e8cb7762) cinny-desktop: 2.2.4 -> 2.2.6
* [`e507ac4b`](https://github.com/NixOS/nixpkgs/commit/e507ac4bdb0d81711900f6c9eefa78ebc28327f4) sysdig: also update driver
* [`8b663f50`](https://github.com/NixOS/nixpkgs/commit/8b663f501c328bd8eb03f5177a60d18695d80c9b) cinny-desktop: update license (mit -> agpl3Only)
* [`cd1e297b`](https://github.com/NixOS/nixpkgs/commit/cd1e297b9327ff3242227264977e4bea2b747d81) dune_3: 3.7.0 -> 3.7.1
* [`81ce33c7`](https://github.com/NixOS/nixpkgs/commit/81ce33c7ed921ddfa4d6a1f8afdaee72aa58fba3) sniffnet: 1.1.2 -> 1.1.3
* [`92dd06ae`](https://github.com/NixOS/nixpkgs/commit/92dd06ae1d8d710250b644bd776bb4f174044a39) nu_scripts: init at unstable-2023-03-16
* [`947007c1`](https://github.com/NixOS/nixpkgs/commit/947007c1c4b81e3a4649956982fa6ca646a5f2b1) sentry-native: 0.6.0 -> 0.6.1
* [`2831eb0a`](https://github.com/NixOS/nixpkgs/commit/2831eb0a083a08ccc76ae9b3727db66cb16b46ad) tbls: 1.63.0 -> 1.64.0
* [`3ec7b3b9`](https://github.com/NixOS/nixpkgs/commit/3ec7b3b91f7854bed5490c969a234c11b82a27fd) python310Packages.notus-scanner: unstable-2021-09-05 -> 22.4.5
* [`162ca510`](https://github.com/NixOS/nixpkgs/commit/162ca510540b7b1a599ae0ef88d45c32a8f45b8d) scraper: 0.15.0 -> 0.16.0
* [`246567a3`](https://github.com/NixOS/nixpkgs/commit/246567a3ad88e3119c2001e2fe78be233474cde0) josm: 18678 -> 18700
* [`4a9c7011`](https://github.com/NixOS/nixpkgs/commit/4a9c7011a18c90d9dee37fd1a994ac76a91de928) gh: 2.25.1 -> 2.26.0
* [`53c20eae`](https://github.com/NixOS/nixpkgs/commit/53c20eae380f5fbb820ddd67ad30feab6deca2d4) Revert "bind: remove hard-coded `allow-query` config setting"
* [`e91de945`](https://github.com/NixOS/nixpkgs/commit/e91de945b92910665bd8a25884cc73dc0f67c59c) python310Packages.archinfo: 9.2.44 -> 9.2.45
* [`591ba97f`](https://github.com/NixOS/nixpkgs/commit/591ba97f6584c91bf2487bde139d07c2b2372a73) python310Packages.ailment: 9.2.44 -> 9.2.45
* [`69b9de33`](https://github.com/NixOS/nixpkgs/commit/69b9de334d88a6e3c33f78cb3d4568d0399da988) python310Packages.pyvex: 9.2.44 -> 9.2.45
* [`7b62888f`](https://github.com/NixOS/nixpkgs/commit/7b62888f814cabb2e663b5c35092c497e83bef23) python310Packages.claripy: 9.2.44 -> 9.2.45
* [`18f154b2`](https://github.com/NixOS/nixpkgs/commit/18f154b27d737a0159920b9bdf4b555c05275177) python310Packages.cle: 9.2.44 -> 9.2.45
* [`44b291cb`](https://github.com/NixOS/nixpkgs/commit/44b291cbec8864062869cb14d2bb27d1e6a891b3) python310Packages.angr: 9.2.44 -> 9.2.45
* [`ec8cbfef`](https://github.com/NixOS/nixpkgs/commit/ec8cbfef443f1bfc9868f8039eefc259133b4aec) grype: 0.60.0 -> 0.61.0
* [`1e7ac24e`](https://github.com/NixOS/nixpkgs/commit/1e7ac24e9d4d2d93345370c0fce0f905313028bb) python310Packages.types-requests: 2.28.11.16 -> 2.28.11.17
* [`c5012f14`](https://github.com/NixOS/nixpkgs/commit/c5012f145ae48bd3e49418b6332ccacf2cafbc22) python310Packages.mwdblib: 4.3.1 -> 4.4.0
* [`8586e6c2`](https://github.com/NixOS/nixpkgs/commit/8586e6c26aa542d4a797520719c9e222ce2d4a8a) pipe-rename: 1.6.1 -> 1.6.2
* [`1d187379`](https://github.com/NixOS/nixpkgs/commit/1d18737910491b629b6912b3af094eaae305b661) python310Packages.mwdblib: add changelog to meta
* [`54cb3a75`](https://github.com/NixOS/nixpkgs/commit/54cb3a75a9a2f8e99f417b817f3301ff5a400ee7) vimv-rs: 1.8.0 -> 2.0.0
* [`4c40162c`](https://github.com/NixOS/nixpkgs/commit/4c40162cb5a4317df6250308c93761cc29d09c40) clusterctl: 1.4.0 -> 1.4.1
* [`6df3f671`](https://github.com/NixOS/nixpkgs/commit/6df3f671385b427a249efac7b0c8f323b8a35805) python310Packages.goodwe: 0.2.30 -> 0.2.31
* [`88297afc`](https://github.com/NixOS/nixpkgs/commit/88297afce09af0563c583dcb48a452336ebaf6a8) chromiumDev: 113.0.5672.12 -> 113.0.5672.24
* [`b830360c`](https://github.com/NixOS/nixpkgs/commit/b830360c9fa98d578c34fcf7b711f8babe21df77) chromium: 111.0.5563.146 -> 112.0.5615.49
* [`07137979`](https://github.com/NixOS/nixpkgs/commit/07137979536870707f4170325323118e7eab1170) python310Packages.pychromecast: 13.0.6 -> 13.0.7
* [`4b7d7154`](https://github.com/NixOS/nixpkgs/commit/4b7d7154cded6481e82af8728cac731c98f226d0) nushell: 0.77.1 -> 0.78.0
* [`dc2c96df`](https://github.com/NixOS/nixpkgs/commit/dc2c96df1d5ee5da69f16b4b3f3f88eb010c63e3) gmic: 3.2.2 -> 3.2.3
* [`b3c599eb`](https://github.com/NixOS/nixpkgs/commit/b3c599ebb62ec6a637ecf13370a1c8e14560e84b) cimg: 3.2.2 -> 3.2.3
* [`0bb82916`](https://github.com/NixOS/nixpkgs/commit/0bb829166035c9559851a96c813a21aa4be54c42) gmic-qt: 3.2.2 -> 3.2.3
* [`6dba375c`](https://github.com/NixOS/nixpkgs/commit/6dba375c3c3cbed024b39d28fd4611db03654f27) ventoy-bin-full: 1.0.89 -> 1.0.90
* [`c15de994`](https://github.com/NixOS/nixpkgs/commit/c15de9948fa65c366ac8ed323244694325ce0fc7) python3Packages.meraki: init at 1.30.0
* [`8059809f`](https://github.com/NixOS/nixpkgs/commit/8059809feae52730f2c6bbf652666330e5ec91ae) typst: 23-03-28 -> 0.1
* [`6d1ee759`](https://github.com/NixOS/nixpkgs/commit/6d1ee759c673c7b5df2747c288bd2d7229c0d688) lux: 0.17.0 -> 0.17.2
* [`7a170a54`](https://github.com/NixOS/nixpkgs/commit/7a170a54d33381d504bdf510c2dfb7639995fcff) maintainers: remove candyc1oud
* [`7884a01e`](https://github.com/NixOS/nixpkgs/commit/7884a01ebfed4b4ee8abc39113d1417665b9b05a) gh: 2.26.0 -> 2.26.1
* [`14113cb0`](https://github.com/NixOS/nixpkgs/commit/14113cb0d0cfeaf7034f2cf237be55affefb5806) bzip3: 1.2.3 -> 1.3.0
* [`e7e93bd7`](https://github.com/NixOS/nixpkgs/commit/e7e93bd709044a98116f127bd820e76a227a5c6b) docs/rust: prefer `ln -s` over `cp`
* [`f42b9fd7`](https://github.com/NixOS/nixpkgs/commit/f42b9fd74544bfcbabef8a8efd8ea388741cff0e) maintainers/scripts/update.nix: Remove unicode from message and comply with CONTRIBUTING.md
* [`2f90dc20`](https://github.com/NixOS/nixpkgs/commit/2f90dc20b9e2e15ec5fe5aca9e904774f7c88cc0) zfxtop: 0.3.0 -> 0.3.2
* [`3095200a`](https://github.com/NixOS/nixpkgs/commit/3095200a3efae7967df0bc331e4df1112df3d325) python310Packages.pygmt: 0.8.0 -> 0.9.0
* [`fb85a157`](https://github.com/NixOS/nixpkgs/commit/fb85a157c63dad94f8d3b5702119498b99ededb8) pantheon.gala: 7.0.1 -> 7.0.2
* [`d96029d5`](https://github.com/NixOS/nixpkgs/commit/d96029d5b5b0661c3389dacd4cce4adf82d141f7) pantheon.switchboard-plug-onlineaccounts: 6.5.1 -> 6.5.2
* [`3296a5dc`](https://github.com/NixOS/nixpkgs/commit/3296a5dc5fdf39886669b31b60c91160751458b6) pantheon.sideload: 6.1.0 -> 6.2.0
* [`16c33c9c`](https://github.com/NixOS/nixpkgs/commit/16c33c9c991eacf3bd265aa3f274cefae50cb289) vimPlugins: update
* [`4a9463d5`](https://github.com/NixOS/nixpkgs/commit/4a9463d51ccd7e21eecf80316481ed2fff2ae9b0) pantheon.elementary-terminal: 6.1.1 -> 6.1.2
* [`bad81075`](https://github.com/NixOS/nixpkgs/commit/bad81075ea8f345b6d51af181b05aca9c0e2f387) vimPlugins: resolve github repository redirects
* [`31de9b13`](https://github.com/NixOS/nixpkgs/commit/31de9b134e5abd7955b787550a7aba66dac8e6d4) vimPlugins.telescope-zf-native-nvim: init at 2023-03-15
* [`ad890a81`](https://github.com/NixOS/nixpkgs/commit/ad890a81d7236e0de151ef90a153eff8d2c166bf) vimPlugins.nvim-treesitter: update grammars
* [`171558b9`](https://github.com/NixOS/nixpkgs/commit/171558b99d473150fa19a3cec352a53e5cefc5bd) celluloid: 0.24 -> 0.25
* [`9764060c`](https://github.com/NixOS/nixpkgs/commit/9764060cf954d2233f5fc84531ad98094d8d7078) labwc: 0.6.1 -> 0.6.2
* [`d42cca51`](https://github.com/NixOS/nixpkgs/commit/d42cca51d7cba60393426d7e3caa2ba5510f3a2a) Add maintainer
* [`bb4cec38`](https://github.com/NixOS/nixpkgs/commit/bb4cec38222882b0ba4f84e8eca3a2c369b7782b) polar-bookshelf1: init at 1.100.14
* [`f8e7efd9`](https://github.com/NixOS/nixpkgs/commit/f8e7efd9745c2146e7844428a747e05d8bbde77f) python310Packages.docstring-to-markdown: 0.11 -> 0.12
* [`03dc88e1`](https://github.com/NixOS/nixpkgs/commit/03dc88e1f9860c638721bd38ee1879d803046e68) ruff: 0.0.260 -> 0.0.261
* [`6cfe7a88`](https://github.com/NixOS/nixpkgs/commit/6cfe7a889f9cd2d207c7ea4e468db89a5b241ca9) otpclient: 3.1.5 -> 3.1.6
* [`e4f9d4f6`](https://github.com/NixOS/nixpkgs/commit/e4f9d4f62cb05cffaab1b1f27e57377432f927fd) nixos/manual: fix cross-compilation
* [`440b4de5`](https://github.com/NixOS/nixpkgs/commit/440b4de588d950e7fcf7add3b049fb209f097367) buildBazelPackage: support multiple targets
* [`563f4ede`](https://github.com/NixOS/nixpkgs/commit/563f4edea598063b874489688a6c885c6f4567ce) scalr-cli: 0.14.5 -> 0.15.1
* [`17af0c2e`](https://github.com/NixOS/nixpkgs/commit/17af0c2ea3e70c04d4cbfd601b25afa51e96733a) media-downloader: 2.9.0 -> 3.1.0
* [`6693a96f`](https://github.com/NixOS/nixpkgs/commit/6693a96f339ee0ca31348d92759c32dc1e16ae5d) opentelemetry-collector: 0.71.0 -> 0.74.0
* [`3e6b47a0`](https://github.com/NixOS/nixpkgs/commit/3e6b47a0073ec41e6b89f25f5c407a51d7920f9f) rPackages: switch to official CRAN mirrors
* [`bb87f243`](https://github.com/NixOS/nixpkgs/commit/bb87f24392803cff42f4a2151ddc47a16ac9f854) rPackages: regenerate CRAN hashes
* [`378d0672`](https://github.com/NixOS/nixpkgs/commit/378d067213496a48767c8c4f4ad9d44dfc2b800c) usql: 0.13.12 -> 0.14.0
* [`b28d542a`](https://github.com/NixOS/nixpkgs/commit/b28d542a1686a3472d650d80140db904a68beca9) numix-icon-theme-square: 23.03.19 -> 23.04.05
* [`2620a7fa`](https://github.com/NixOS/nixpkgs/commit/2620a7fa06475cfa11bbf9c257491338dbcfa2ba) cloud-nuke:  0.27.1 -> 0.29.0
* [`1c379d5a`](https://github.com/NixOS/nixpkgs/commit/1c379d5a8595324315a6307beda861218587eb00) ncspot: 0.13.0 -> 0.13.1
* [`81eed480`](https://github.com/NixOS/nixpkgs/commit/81eed48040289e2a5f654a2b2edf13c939c505ec) python310Packages.approvaltests: 8.2.0 -> 8.2.5
* [`ba13f46f`](https://github.com/NixOS/nixpkgs/commit/ba13f46fc4821041179341a29ea2b9edcbae99e4) python310Packages.internetarchive: 3.3.0 -> 3.4.0
* [`3f11c2fc`](https://github.com/NixOS/nixpkgs/commit/3f11c2fc18c93b26019fd6be963ab21248908fd9) flexget: 3.5.33 -> 3.5.36
* [`3bb23bd8`](https://github.com/NixOS/nixpkgs/commit/3bb23bd81a994b0a4886aa5499f955a2e3c82f82) postgresqlPackages.plv8: 3.1.4 -> 3.1.5
* [`1732bce8`](https://github.com/NixOS/nixpkgs/commit/1732bce8ac6065859c3b2fb2a3e7968f5f3e5330) oh-my-posh: 14.22.0 -> 14.27.0
* [`94a43ef8`](https://github.com/NixOS/nixpkgs/commit/94a43ef878363525c920c39088d7a09808970be1) python310Packages.nvchecker: 2.10 -> 2.11
* [`4d39b37f`](https://github.com/NixOS/nixpkgs/commit/4d39b37f6b5a242063a57fad8a5a56c34098f087) docker-slim: 1.40.0 -> 1.40.1
* [`4a65e9f6`](https://github.com/NixOS/nixpkgs/commit/4a65e9f64e53fdca6eed31adba836717a11247d2) go_1_19: 1.19.7 -> 1.19.8
* [`caa9102e`](https://github.com/NixOS/nixpkgs/commit/caa9102e5bca18efd8c9aacaf3fcd0d718f6fb2d) terraform-providers.aci: 2.6.1 → 2.7.0
* [`68cd1172`](https://github.com/NixOS/nixpkgs/commit/68cd1172a99be45df412ea9bab168cc9c9a6dc5b) terraform-providers.baiducloud: 1.19.5 → 1.19.6
* [`08f8ec0d`](https://github.com/NixOS/nixpkgs/commit/08f8ec0d873fbc08da8ac90d2d217c57cbc060cf) terraform-providers.bitbucket: 2.30.2 → 2.31.0
* [`6547c9db`](https://github.com/NixOS/nixpkgs/commit/6547c9dba2f0ecbbfd009e8614c406795659953e) terraform-providers.cloudflare: 4.2.0 → 4.3.0
* [`67be4042`](https://github.com/NixOS/nixpkgs/commit/67be4042545c723cf4d903fb56bcca5255697bae) terraform-providers.github: 5.19.0 → 5.20.0
* [`6dea81e8`](https://github.com/NixOS/nixpkgs/commit/6dea81e897b4c9daa67032d9d43a45b94e205cb2) terraform-providers.google: 4.59.0 → 4.60.0
* [`60863fe6`](https://github.com/NixOS/nixpkgs/commit/60863fe66a37c9cf735427066a77eb8d718ff527) terraform-providers.google-beta: 4.59.0 → 4.60.0
* [`5d023ade`](https://github.com/NixOS/nixpkgs/commit/5d023ade0d034dbb86adc6302f092cd6b0977542) terraform-providers.scaleway: 2.15.0 → 2.16.0
* [`6c66419a`](https://github.com/NixOS/nixpkgs/commit/6c66419a9aa7ba0aa5b8c4c667c80d88671e1de4) terraform-providers.tailscale: 0.13.6 → 0.13.7
* [`9c8ff8b4`](https://github.com/NixOS/nixpkgs/commit/9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e) terraform-providers.thunder: 1.1.0 → 1.2.0
* [`3f6146e5`](https://github.com/NixOS/nixpkgs/commit/3f6146e5ca9e7dcd1f83c4140a9298d50b5cdf07) ocamlPackages.rdbg: 1.196.12 → 1.199.0
* [`cbc30e4b`](https://github.com/NixOS/nixpkgs/commit/cbc30e4bbc341f1538bc87d7016cacd22eaede2f) stack: make sure to pin the hpack version to 0.35.0 to match upstream
* [`533016a5`](https://github.com/NixOS/nixpkgs/commit/533016a5faf71ed0a388b7c53d9c92c95e01defa) python310Packages.db-dtypes: 1.0.5 -> 1.1.1
* [`64a9e244`](https://github.com/NixOS/nixpkgs/commit/64a9e244cddffad3151ad7e2e4c98ea840c933fd) maintainers/teams: set githubTeams for golang
* [`f3e62ad4`](https://github.com/NixOS/nixpkgs/commit/f3e62ad4e426c676896fe091cefac2ba793dc809) maintainers/teams: set githubTeams for rust
* [`20044799`](https://github.com/NixOS/nixpkgs/commit/20044799c06374ef1e16139940bd3b145496b4bc) bundix: 2.5.1 -> 2.5.2
* [`ed6a9ec8`](https://github.com/NixOS/nixpkgs/commit/ed6a9ec8fee0e8b94a0058637f3bbb9560fa9da6) vifm: 0.12.1 -> 0.13
* [`bd54a904`](https://github.com/NixOS/nixpkgs/commit/bd54a9047d7d36463aa3ccfd29d28b848a67dc4d) tamarin-prover: Allow compiling with maude-3.3
* [`b6bc7b2d`](https://github.com/NixOS/nixpkgs/commit/b6bc7b2d79385520ddc70b118b902f5bb9da1667) python310Packages.nitime: 0.9 -> 0.10.1
* [`982eab30`](https://github.com/NixOS/nixpkgs/commit/982eab30dac3032d56a6cc3340dee7bc6a0eab79) haskellPackages.git-annex: Correct hash after version bump
* [`9100134b`](https://github.com/NixOS/nixpkgs/commit/9100134ba9902515c6d26f8ac03f1605e29fa405) ocamlPackages.caqti: use Dune 3
* [`cdf5720a`](https://github.com/NixOS/nixpkgs/commit/cdf5720ae27e3165412b62886b12d012cbd692ae) ocamlPackages.uri: use Dune 3
* [`7979b4c7`](https://github.com/NixOS/nixpkgs/commit/7979b4c793ab5b93d5910ed877dde3ac731cb8be) ocamlPackages.stringext: use Dune 3
* [`8787829c`](https://github.com/NixOS/nixpkgs/commit/8787829c48a602a239182c0a4d0510109579fd47) ocamlPackages.qtest: use Dune 3
* [`1c09f02c`](https://github.com/NixOS/nixpkgs/commit/1c09f02cc679cbab38c15f29ed235b00668586b1) ocamlPackages.syslog-message: use Dune 3
* [`543d5310`](https://github.com/NixOS/nixpkgs/commit/543d53100e992fc6f894b2dc5d06ec65734f3be4) ocamlPackages.iter: use Dune 3
* [`eee0652b`](https://github.com/NixOS/nixpkgs/commit/eee0652b6b558cec01d7fb1490f4a520f08c246f) ocamlPackages.pratter: use Dune 3
* [`f80bf9ab`](https://github.com/NixOS/nixpkgs/commit/f80bf9ab05b5abb4f0664ae53720396afabc2560) ocamlPackages.qcheck: fix for OCaml ≥ 5.0
* [`3bd7ee3b`](https://github.com/NixOS/nixpkgs/commit/3bd7ee3b835bd075fe74fcc94711c0ad0eaf1e24) python310Packages.appthreat-vulnerability-db: 5.0.1 -> 5.0.3
* [`3ac2acfe`](https://github.com/NixOS/nixpkgs/commit/3ac2acfe88c35d9b063b400f5114af0d136b06ad) python310Packages.pygmt: add changelog to meta
* [`4fc52a4a`](https://github.com/NixOS/nixpkgs/commit/4fc52a4ab92bd25dba2ea0fa26a0974fc91bcd06) python310Packages.pygmt: update disabled
* [`92376558`](https://github.com/NixOS/nixpkgs/commit/92376558f6837bd05834bfdaaa747574c3c99069) python310Packages.pygmt: equalize
* [`325cb4e4`](https://github.com/NixOS/nixpkgs/commit/325cb4e48350e5129facdb2de34c1f111fff28b0) jcli: 0.0.41 -> 0.0.42
* [`5fd7c964`](https://github.com/NixOS/nixpkgs/commit/5fd7c9645e9877a0babe1230ff3a8d79ab3ad13f) haskellPackages.gi-soup: 3.0.2 -> 2.4.28
* [`bde97630`](https://github.com/NixOS/nixpkgs/commit/bde97630f2dbc068259db1fe274f1a3aa0d95e91) kubergrunt: 0.10.1 -> 0.11.1
* [`d7c630ca`](https://github.com/NixOS/nixpkgs/commit/d7c630ca17a9657a7c9d994a3ab65b279d6061e5) maintainers/haskell/update-stackage.sh: Strip out with-compiler from stackage config
* [`3173a116`](https://github.com/NixOS/nixpkgs/commit/3173a1163602f85df6220cdd8d8ea8588c6670ba) haskellPackages: formatting
* [`391e94a9`](https://github.com/NixOS/nixpkgs/commit/391e94a986322a002a084574ccf2fd73814872b1) haskellPackages: regenerate hackage-packages
* [`2941e14f`](https://github.com/NixOS/nixpkgs/commit/2941e14f607fddc9a221f6833c229e069b8ce6e0) cpp-utilities: 5.21.0 -> 5.22.0
* [`34e99591`](https://github.com/NixOS/nixpkgs/commit/34e995914c04d54680ff99fb1755825fc79aaa56) libsForQt5.qtutilities: 6.11.0 -> 6.12.0
* [`ca6c0e3b`](https://github.com/NixOS/nixpkgs/commit/ca6c0e3b87ebea84009a9bf8e3882e95c7ad1326) darwin: recurseIntoAttrs
* [`19b62c5b`](https://github.com/NixOS/nixpkgs/commit/19b62c5b4b93203bb356664ed02dcfb17df69e05) unciv: 4.5.13 -> 4.5.15
* [`89911c1b`](https://github.com/NixOS/nixpkgs/commit/89911c1b6d0a579a5b90f304523b0c064eeaea07) viceroy: 0.4.1 -> 0.4.2
* [`0d25d60b`](https://github.com/NixOS/nixpkgs/commit/0d25d60b63197fb8056fafe57dea5c45ce3ca2d7) gobgp: 3.12.0 -> 3.13.0
* [`134c32d7`](https://github.com/NixOS/nixpkgs/commit/134c32d770297081d2dcde06c2a6a4deafc87c00) gnome.eog: unbreak on darwin
* [`5804b7fb`](https://github.com/NixOS/nixpkgs/commit/5804b7fb5fa07ac9b3720a19aa207edfb1521133) vscodium: 1.76.2.23074 -> 1.77.0.23093
* [`ce7730aa`](https://github.com/NixOS/nixpkgs/commit/ce7730aa87b97b1ee92c7651de420bd293c0e32e) mastodon: 4.1.1 -> 4.1.2
* [`27f407b4`](https://github.com/NixOS/nixpkgs/commit/27f407b4bbaf29a3c5b9daa0a69f01bb9659e74c) tracee: 0.11.0 -> 0.13.0
* [`0e681fb6`](https://github.com/NixOS/nixpkgs/commit/0e681fb60086300ee42b76df4e53be3e45fa9ba0) matrix-hookshot: 3.0.1 -> 3.2.0
* [`1ee2c5c9`](https://github.com/NixOS/nixpkgs/commit/1ee2c5c9ebf564f88d6bbc26bd8d2dd376106b6a) buildBazelPackage: allow buildAttrs and fetchAttrs to override inherited attrs
* [`4d25991c`](https://github.com/NixOS/nixpkgs/commit/4d25991c98d3629053e65cd61d761e4b7a88eed2) tuba: 0.1.0 -> 0.2.0
* [`dd24376b`](https://github.com/NixOS/nixpkgs/commit/dd24376b8529b2577aaead35a1e3dd2f9e52be4b) linux_xanmod: 6.1.20 -> 6.1.22
* [`68618ee1`](https://github.com/NixOS/nixpkgs/commit/68618ee152faf3badf3a581b773caaf36f369fff) linux_xanmod: 6.2.7 -> 6.2.9
* [`7116dd2f`](https://github.com/NixOS/nixpkgs/commit/7116dd2fe7957ea40f58ec904563d08922876ccc) linja-sike: init at 5.0 ([nixos/nixpkgs⁠#194819](https://togithub.com/nixos/nixpkgs/issues/194819))
* [`2e601f71`](https://github.com/NixOS/nixpkgs/commit/2e601f71d7debe7814971efac7dbab725a7b072d) brlcad: init at 7.34.0
* [`2b8d42a7`](https://github.com/NixOS/nixpkgs/commit/2b8d42a720c016426c52500701d10b0930d215c7) uptime-kuma: 1.20.0 -> 1.21.2
* [`7fae5a80`](https://github.com/NixOS/nixpkgs/commit/7fae5a802b4aac751c41a404c44c9f550e8bfe5c) gcc-arm-embedded: fix arm-none-eabi-gdb error
* [`d7eabb37`](https://github.com/NixOS/nixpkgs/commit/d7eabb378151db123706a24b170d7e783b35f80a) gcc-arm-embedded: add myself to maintainers
* [`2ce47167`](https://github.com/NixOS/nixpkgs/commit/2ce47167bc264eb598a0cd03848603a73d6b8b07) maintainers: add jedsek
* [`c5a3aeba`](https://github.com/NixOS/nixpkgs/commit/c5a3aeba6fe5bd254334aa3119902d7c2487b110) bilibili: init at 1.9.2-1
* [`bcf7befe`](https://github.com/NixOS/nixpkgs/commit/bcf7befedfe5f7509a50e581531b6185b7aa52a0) lispPackages: dont recurse into attrs
* [`7f3ea269`](https://github.com/NixOS/nixpkgs/commit/7f3ea2699445c51f02b373ec88e13adf80d0d15d) zoom-us: 5.14.0.1720 -> 5.14.2.2046
* [`3d6ae762`](https://github.com/NixOS/nixpkgs/commit/3d6ae762e772ee84d801bb7e58f6e34c27d91505) snes9x-gtk: 1.62.1 -> 1.62.3
* [`9de75c8b`](https://github.com/NixOS/nixpkgs/commit/9de75c8bbead82764554823312182307d014f1d2) nixos/smokeping: use /etc/smokeping.conf
* [`8fcdc3f6`](https://github.com/NixOS/nixpkgs/commit/8fcdc3f62c1c39d0a790b33f4613207d299b3b66) varscan: 2.4.5 -> 2.4.6
* [`d179bf5a`](https://github.com/NixOS/nixpkgs/commit/d179bf5a96a57a68dcca548c992b5e9b5ee5818f) gptfdisk: Backport upstream fix for popt 1.19
* [`cc2a49fc`](https://github.com/NixOS/nixpkgs/commit/cc2a49fc3afd31666d9b11842adcc1fb1b4fbe16) crispyDoom: 5.12.0 -> 6.0
* [`44b62979`](https://github.com/NixOS/nixpkgs/commit/44b62979c7406c313bdbef249e0e53d05a7fac13) lisp-modules: reduce number of packages build on Hydra
* [`01051d8e`](https://github.com/NixOS/nixpkgs/commit/01051d8eb6f5396f3c9e0819b7dc0a6c21e2a3a4) fheroes2: include desktop entry
* [`dbd2e951`](https://github.com/NixOS/nixpkgs/commit/dbd2e9514884e88772da40fb3dcf46be65db5a6f) mtools: add update script
* [`af4d85ba`](https://github.com/NixOS/nixpkgs/commit/af4d85ba89438a88d69e41729222ef427f051623) mtools: 4.0.42 -> 4.0.43
* [`18cc1ed2`](https://github.com/NixOS/nixpkgs/commit/18cc1ed2dc3bc913ffc34ca4f4d15e6115b2117a) python3Packages.glad2: init at 2.0.3
* [`dcf37bae`](https://github.com/NixOS/nixpkgs/commit/dcf37baee75e2949f7d6043e52bab24f634ade92) libdovi: init at 3.1.2
* [`7fa28593`](https://github.com/NixOS/nixpkgs/commit/7fa285932c9b17ab27677b8bbcad432cc2c9ff44) clasp-common-lisp: set correct platforms
* [`be6fee99`](https://github.com/NixOS/nixpkgs/commit/be6fee999e77b9ff1d1814c18c9a4f2831754471) gir-rs: unstable-2021-11-21 -> 0.17.1
* [`b29b7e2b`](https://github.com/NixOS/nixpkgs/commit/b29b7e2bd5b3007fa5056c141dc68542787a8459) vultr-cli: 2.15.0 -> 2.16.2
* [`2e431183`](https://github.com/NixOS/nixpkgs/commit/2e4311834db93d625c7f7ab82983ee09781aa975) vultr-cli: enable tests
* [`8c5b8838`](https://github.com/NixOS/nixpkgs/commit/8c5b8838e693b16e0337a630ae419ce468bf7f25) adguardhome: 0.107.26 -> 0.107.27
* [`fb8e6e65`](https://github.com/NixOS/nixpkgs/commit/fb8e6e65b5d275a76f735d216586dbb4c12d1d9a) treesheets: unstable-2023-03-18 -> unstable-2023-04-04
* [`64953434`](https://github.com/NixOS/nixpkgs/commit/64953434f2a34fa81f71989a1187e63a4ea0dbae) matcha-gtk-theme: 2022-11-15 -> 2023-04-03
* [`6817b72c`](https://github.com/NixOS/nixpkgs/commit/6817b72ca3cdb8e5edd9ff84a1dc549de1c683f3) lisp-modules: set maintainers to the lisp team
* [`644fbbe0`](https://github.com/NixOS/nixpkgs/commit/644fbbe01f592cad1a5ade1f0dd561dfb06a3b4a) python310Packages.aiounifi: 44 -> 45
* [`c418d8fc`](https://github.com/NixOS/nixpkgs/commit/c418d8fc477535acf374ff55399df007bc2db7c9) home-assistant.intents: 2023.2.28 -> 2023.3.29
* [`0686d18e`](https://github.com/NixOS/nixpkgs/commit/0686d18e412ad15228cfb1c47a9e59da8ed3403b) python310Packages.python-matter-server: 3.1.0 -> 3.2.0
* [`8ab71fc1`](https://github.com/NixOS/nixpkgs/commit/8ab71fc1ca92d0c78b892d4741a4d67d5cda12e5) python310Packages.aioesphomeapi: 13.6.0 -> 13.6.1
* [`0e578bb9`](https://github.com/NixOS/nixpkgs/commit/0e578bb9f1f9ee4c8a0188fed6c2b2d2c9504b98) python310Packages.zeroconf: 0.47.4 -> 0.54.0
* [`4b3b94f7`](https://github.com/NixOS/nixpkgs/commit/4b3b94f7e7cf7a8b4166b2e4963765f622111651) python310Packages.aiohomekit: 2.6.2 -> 2.6.3
* [`1e6bece5`](https://github.com/NixOS/nixpkgs/commit/1e6bece50a818e70d085613e7ad79e66892b0b78) python310Packages.aiounifi: 45 -> 46
* [`99669d80`](https://github.com/NixOS/nixpkgs/commit/99669d80e0a52e68a960a40f5feae73f35575857) python310Packages.zigpy: 0.53.2 -> 0.54.0
* [`b30122ea`](https://github.com/NixOS/nixpkgs/commit/b30122ea488f90d0c9b0691bc2d9eacbbfd77814) python310Packages.zigpy-deconz: 0.19.2 -> 0.20.0
* [`908d96fe`](https://github.com/NixOS/nixpkgs/commit/908d96fe1b95d94778bee09bfe0132fd4c4f2396) libplacebo: 4.208.0 -> 5.264.1
* [`c7b67c20`](https://github.com/NixOS/nixpkgs/commit/c7b67c200a78547cc701e57d2e16cb135e2efd29) python310Packages.zigpy-xbee: 0.16.2 -> 0.17.0
* [`cb009244`](https://github.com/NixOS/nixpkgs/commit/cb0092447583d7f40ea3b7e7c51245692ee8f68a) python310Packages.bellows: 0.34.10 -> 0.35.0
* [`cc436454`](https://github.com/NixOS/nixpkgs/commit/cc436454039214c7de85f7a5d32d18665560e4b4) python310Packages.bimmer-connected: 0.13.0 -> 0.13.1
* [`d172c39e`](https://github.com/NixOS/nixpkgs/commit/d172c39ed608044236d45265d94fa3c0722b2ec1) python310Packages.bleak: 0.19.5 -> 0.20.1
* [`c0dc48a7`](https://github.com/NixOS/nixpkgs/commit/c0dc48a7853182d30308ff88b1489924ff930a60) python310Packages.bleak-retry-connector: 3.0.0 -> 3.0.2
* [`3022763e`](https://github.com/NixOS/nixpkgs/commit/3022763e9a2080c78edbb13eed7ee3aee057e3bd) python310Packages.brother: 2.2.0 -> 2.3.0
* [`7912db4e`](https://github.com/NixOS/nixpkgs/commit/7912db4e3275c683c01244fe6f4e33ab9c068099) python310Packages.env-canada: 0.5.29 -> 0.5.30
* [`58df385d`](https://github.com/NixOS/nixpkgs/commit/58df385d576aed30335a125cf189f4a555172353) python310Packages.hass-nabucasa: 0.61.0 -> 0.61.1
* [`4620b234`](https://github.com/NixOS/nixpkgs/commit/4620b234fe932343343590c4ac6193cbd90246f7) python310Packages.hass-nabucasa: add changelog to meta
* [`096b9f83`](https://github.com/NixOS/nixpkgs/commit/096b9f83b50388718f5dd0de7686184142080ecc) python310Packages.hass-nabucasa: disable on unsupported Python releases
* [`2bb1ae36`](https://github.com/NixOS/nixpkgs/commit/2bb1ae361f89f0a13fd66a66b322e791d17d5c88) python310Packages.nitime: minor maintenance
* [`d980c31d`](https://github.com/NixOS/nixpkgs/commit/d980c31db45fc73769918c248e16e48cd7f592ba) python310Packages.ical: 4.2.9 -> 4.5.3
* [`eba74228`](https://github.com/NixOS/nixpkgs/commit/eba74228545447d20c0cef3a9b1d29ce2259c59f) Revert "python3Packages.ical: drop a test failing since tzdata-2022g"
* [`be4e3cc8`](https://github.com/NixOS/nixpkgs/commit/be4e3cc897b89fd04d9471bbd2acf22eb10de51f) python310Packages.insteon-frontend-home-assistant: 0.3.3 -> 0.3.4
* [`bfa6b914`](https://github.com/NixOS/nixpkgs/commit/bfa6b914c3cb8a0d1d40f728896ff1eec649772f) python310Packages.onvif-zeep-async: 1.2.2 -> 1.2.3
* [`04429393`](https://github.com/NixOS/nixpkgs/commit/04429393da275a10034a10d608ba2dc93e073189) python310Packages.pyinsteon: 1.3.4 -> 1.4.1
* [`f055adb7`](https://github.com/NixOS/nixpkgs/commit/f055adb7a0941bda674bc2f5cf32f74c02cb4b3a) python310Packages.wled: 0.15.0 -> 0.16.0
* [`5c09f561`](https://github.com/NixOS/nixpkgs/commit/5c09f561102440dc18e5db0473d1f4ebcc3fc5df) python310Packages.wled: add changelog to meta
* [`da6f3042`](https://github.com/NixOS/nixpkgs/commit/da6f3042c97a353b01d26947178dc282c405f383) blender: add aarch64-linux support ([nixos/nixpkgs⁠#224771](https://togithub.com/nixos/nixpkgs/issues/224771))
* [`3f943f75`](https://github.com/NixOS/nixpkgs/commit/3f943f754eb082777b1202d7d7bea93adfe0397f) python310Packages.zwave-js-server-python: 0.46.0 -> 0.47.3
* [`85382d5b`](https://github.com/NixOS/nixpkgs/commit/85382d5b6848889dff5a721ee21d3edea4947fe7) jenkins: 2.387.1 -> 2.387.2
* [`5df7aa01`](https://github.com/NixOS/nixpkgs/commit/5df7aa01ed07195d3d41bc6ab13a17a29dae4e82) python310Packages.snitun: 0.33.0 -> 0.34.0
* [`e56a6c94`](https://github.com/NixOS/nixpkgs/commit/e56a6c94c6672ebcd68db2e211e78c784a47329c) python310Packages.hass-nabucasa: 0.61.1 -> 0.64.0
* [`88ea1aca`](https://github.com/NixOS/nixpkgs/commit/88ea1acabef8a95da8bfdb314d75830aff8cadfa) python310Packages.spacy-transformers: relax deps
* [`f3a038c8`](https://github.com/NixOS/nixpkgs/commit/f3a038c827ebdd3ebd50851e2af6510b0ec461f9) cmark-gfm: 0.29.0.gfm.9 -> 0.29.0.gfm.10
* [`ca3b8758`](https://github.com/NixOS/nixpkgs/commit/ca3b8758aba7ea31fb5a57454334f74c92b6cc9f) zef: 0.18.1 -> 0.18.2
* [`76f74c22`](https://github.com/NixOS/nixpkgs/commit/76f74c2203e98cecfab47df4c0ad8982bc3cf203) python310Packages.zigpy-znp: 0.9.3 -> 0.10.0
* [`2f4865a5`](https://github.com/NixOS/nixpkgs/commit/2f4865a51a07770fe68d33e0ba57f5b0b45bcfde) conftest: 0.40.0 -> 0.41.0
* [`0dd0b210`](https://github.com/NixOS/nixpkgs/commit/0dd0b2103a25d2068462895faa852d535666a977) forgejo: use "predictable URLs" as src
* [`9f1a1b93`](https://github.com/NixOS/nixpkgs/commit/9f1a1b9373cb1fe754bbcd318a1789ec1f691398) forgejo: 1.19.0-2 -> 1.19.0-3
* [`f4d36c53`](https://github.com/NixOS/nixpkgs/commit/f4d36c53a711a5e0096b567928366a9b8b33bfe6) interactsh: 1.1.0 -> 1.1.2
* [`c844e3d3`](https://github.com/NixOS/nixpkgs/commit/c844e3d3c1a46915d09be9cfb6fe02f0707d807c) rust-script: 0.23.0 -> 0.24.0
* [`87880509`](https://github.com/NixOS/nixpkgs/commit/87880509322e0b4e46598a34e59b4902dd6fbdf5) iaito: 5.8.2 -> 5.8.4
* [`6726464b`](https://github.com/NixOS/nixpkgs/commit/6726464b6a64e6f4d836efec8f3a8ce023085953) python312: 3.12.0a6 -> 3.12.0a7
* [`12a6b43b`](https://github.com/NixOS/nixpkgs/commit/12a6b43b0c127787a2e5e35df2e7b82f152aec61) flexget: pin transmission-rpc version to fix compatibility issue
* [`1e67c00b`](https://github.com/NixOS/nixpkgs/commit/1e67c00b61d8f4098b25a13377ba0f055b6a0620) enumer: 1.5.7 -> 1.5.8
* [`6b615f3c`](https://github.com/NixOS/nixpkgs/commit/6b615f3ca5d133ef62b48bfb7ce14f79a6945ee4) evcc: 0.114.1 -> 0.115.0
* [`476fde08`](https://github.com/NixOS/nixpkgs/commit/476fde08afe6fe0541d35b0a564200079209bf03) default-crate-overrides.nix: prost-build needs protobuf
* [`63d9771d`](https://github.com/NixOS/nixpkgs/commit/63d9771dc44b8c842b84934c7d9d8a76c72d855e) openocd: enableParallelBuilding=true
* [`b508af56`](https://github.com/NixOS/nixpkgs/commit/b508af56273c5e9fd97bd2849804e2abe1edc649) tracy: Fix compilation for 0.9.1
* [`3494b90a`](https://github.com/NixOS/nixpkgs/commit/3494b90af4083346a0fe1cf3bcbd931da4aaeb08) python310Packages.pontos: 23.3.6 -> 23.4.0
* [`ae16ad59`](https://github.com/NixOS/nixpkgs/commit/ae16ad59dd42484b1bf116bfc3a811cb1d3932e2) streamripper: fix cross compilation
* [`14604986`](https://github.com/NixOS/nixpkgs/commit/14604986ad7794de7f82b9620600214555a42a4a) linux-kernels: linux_mptcp_95 was deprecated in aliases.nix and does not exist in packages anymore. While attribute-missing-errors are aborting, throw can be caught with tryEval.
* [`924672cc`](https://github.com/NixOS/nixpkgs/commit/924672cc026b4b8078085b027f0740c0dc838d2e) python310Packages.peaqevcore: 15.0.2 -> 15.1.1
* [`b446d147`](https://github.com/NixOS/nixpkgs/commit/b446d147682747c5cdd4bea7291642ba91da408d) python310Packages.asyncwhois: 1.0.4 -> 1.0.5
* [`3e6210d2`](https://github.com/NixOS/nixpkgs/commit/3e6210d2a5aa6cb3a100604c69df25deb583c06f) firefox: take makeBinaryWrapper from buildPackages
* [`0963a3a3`](https://github.com/NixOS/nixpkgs/commit/0963a3a36b9d08e7b8e046c9642aaeb17422e8f4) rPackages: CRAN and BioC update
* [`cfeceb35`](https://github.com/NixOS/nixpkgs/commit/cfeceb35bce088800fae11ef8217dd58ffe0c584) python310Packages.mitmproxy-wireguard: 0.1.21 -> 0.1.23
* [`94b40204`](https://github.com/NixOS/nixpkgs/commit/94b402045d8ff363f394bfa27b10755b90e6b92a) nixos/home-assistant: fix infinite recursion when derivations are used in config
* [`96e569cb`](https://github.com/NixOS/nixpkgs/commit/96e569cb29daa8dbcec62d4c6f947d40fd4a8a76) citra: nightly 1765 -> 1873, canary 2146 -> 2440 ([nixos/nixpkgs⁠#224337](https://togithub.com/nixos/nixpkgs/issues/224337))
* [`dbad09df`](https://github.com/NixOS/nixpkgs/commit/dbad09df4491a3d3c093f6d7af204ea1c992c301) vscode: 1.77.0 -> 1.77.1
* [`bc0e5c12`](https://github.com/NixOS/nixpkgs/commit/bc0e5c1205626614288a9187b854ec93982afbc2) poetry2nix: 1.40.1 -> 1.41.0
* [`323cb306`](https://github.com/NixOS/nixpkgs/commit/323cb306555e17fb0934402a92921a1b29116968) pantheon.elementary-files: 6.3.0 -> 6.3.1
* [`488dd695`](https://github.com/NixOS/nixpkgs/commit/488dd695092662c4cdeab089ae2407bbc5b13724) argc: 0.15.1 -> 1.0.0
* [`f8ee0612`](https://github.com/NixOS/nixpkgs/commit/f8ee061247b365a98322c102c5bfd900395a826c) buildBazelPackage: fix difference between linux and darwin deps
* [`1460742e`](https://github.com/NixOS/nixpkgs/commit/1460742e0b0128e833fac1ca784c4a64c2bac525) budgie.budgie-backgrounds: 0.1 -> 1.0
* [`f6e6b942`](https://github.com/NixOS/nixpkgs/commit/f6e6b942e345c7e373c1997247ac5abde97b190f) libdeltachat: 1.112.5 -> 1.112.6
* [`d314be66`](https://github.com/NixOS/nixpkgs/commit/d314be66d67ecded018119593bef0a3e4d0f86cd) antiword: fix cross compilation
* [`0e4477c9`](https://github.com/NixOS/nixpkgs/commit/0e4477c9137032b7c195dbc280bed02b8e5ec54a) python310Packages.docformatter: 1.5.1 -> 1.6.0
* [`f8c70505`](https://github.com/NixOS/nixpkgs/commit/f8c705059f9820093d753157a7488a3c446f8d77) gnome-extensions-cli: init at 0.9.5
* [`84c63f9e`](https://github.com/NixOS/nixpkgs/commit/84c63f9e2f012ef403552c0fa61830a98f53b0bc) squeezelite: add passthru.updateScript
* [`e23e82ab`](https://github.com/NixOS/nixpkgs/commit/e23e82abcf743d4000cd267ba7c0b239f6a67ff2) squeezelite: 1.9.9.1419 -> 1.9.9.1428
* [`89465169`](https://github.com/NixOS/nixpkgs/commit/8946516985cbb402e838b52412cec2b59c2603b9) librem: fix cross compilation
* [`6bd07dbe`](https://github.com/NixOS/nixpkgs/commit/6bd07dbee1d98157529c114200daac625ffd9338) git-absorb: 0.6.9 -> 0.6.10
* [`49c4e680`](https://github.com/NixOS/nixpkgs/commit/49c4e680534b5b48f6c0e38d0a2e5af5710d0c57) twilio-cli: 5.5.0 -> 5.6.0
* [`fb21d123`](https://github.com/NixOS/nixpkgs/commit/fb21d12350166a7f70a6cbb2cacf0563eb832e4a) terraform-providers.google: 4.60.0 -> 4.60.1
* [`71028c60`](https://github.com/NixOS/nixpkgs/commit/71028c602abec6387c11d66b0ba05e25e49eb721) terraform-providers.google-beta: 4.60.0 -> 4.60.1
* [`69f7ad76`](https://github.com/NixOS/nixpkgs/commit/69f7ad76ac3f6b69a7b2316399c258b417a6f6a3) terraform-providers.newrelic: 3.20.0 -> 3.20.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
