### PR TITLE
niv devenv: update dc301339 -> e639583e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "dc301339a475b05e84edeb92b0ac581bd2eea4b2",
-        "sha256": "1wc9kj6hz694v0xf3cjcbl52yxpy5cbycq7qvx0hi0lj4j7g2zdi",
+        "rev": "e639583e5974e1d0f58ac110356f7f182d6f6004",
+        "sha256": "0j3azcczca5jw4rfmgigy22grrvksdzvnhpkr3iqg8vf789jh151",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/dc301339a475b05e84edeb92b0ac581bd2eea4b2.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/e639583e5974e1d0f58ac110356f7f182d6f6004.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@dc301339...e639583e](https://github.com/cachix/devenv/compare/dc301339a475b05e84edeb92b0ac581bd2eea4b2...e639583e5974e1d0f58ac110356f7f182d6f6004)

* [`c8541f6d`](https://github.com/cachix/devenv/commit/c8541f6de6ff444aac0e032c4c3b0eae48e6d106) fix: hanging direnv
* [`8cc5d087`](https://github.com/cachix/devenv/commit/8cc5d087c1b2489468df90de83ed9a36e5362f5e) feat: add opensearch options
* [`966b1e2d`](https://github.com/cachix/devenv/commit/966b1e2d72c2d48be928dc12737fdadcd907e8df) add script to build docs on cloudflare
* [`6c23467c`](https://github.com/cachix/devenv/commit/6c23467c91f97999be1235253779feecf7ede9e8) upgrade mkdocs-material-insiders
* [`3e33d80b`](https://github.com/cachix/devenv/commit/3e33d80b1f067f0558e67a4ec656697f49e64037) Auto generate docs/reference/options.md
* [`576b3f02`](https://github.com/cachix/devenv/commit/576b3f02dc1df6f3dbaa6acbc46f2eabf5bbc9ca) docs: don't escape docs in reference
