### PR TITLE
niv nixpkgs: update 4f360a29 -> f405ff3e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4f360a2944af5a027b229f3e643e03d40b4c9c7e",
-        "sha256": "06c9y1nwnbp6bfq08yvx93nwn1zn24yqhyxpf0bx9qfrb8xy9il9",
+        "rev": "f405ff3e78fd4ee0cb688ee1971e7e34368c386c",
+        "sha256": "04sahwczy62jp67c2dngabfyb3pgq8jsxw6c4gbcacci3kxr8abn",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4f360a2944af5a027b229f3e643e03d40b4c9c7e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f405ff3e78fd4ee0cb688ee1971e7e34368c386c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4f360a29...f405ff3e](https://github.com/nixos/nixpkgs/compare/4f360a2944af5a027b229f3e643e03d40b4c9c7e...f405ff3e78fd4ee0cb688ee1971e7e34368c386c)

* [`daa77caf`](https://github.com/NixOS/nixpkgs/commit/daa77caf9bf660c52858772d8aa4cf9ab08ffe92) cc-wrapper: disable response files for ccache
* [`6139d826`](https://github.com/NixOS/nixpkgs/commit/6139d826a9cdc3b4598df85390755360283c746f) maintainers: add hacker1024
* [`95c0be4c`](https://github.com/NixOS/nixpkgs/commit/95c0be4c667a2c3a4e160e91a0a30798128345c3) libpff: init at 20211114
* [`b03e59d4`](https://github.com/NixOS/nixpkgs/commit/b03e59d4c08c00f0f66296db3eecd299c0c976d8) grub2_full: turn into alias
* [`f4140ff0`](https://github.com/NixOS/nixpkgs/commit/f4140ff0157fa7d8e3bcc53eb895f0d70a3e4224) orthorobot: repair and cleanup
* [`7e79c2ff`](https://github.com/NixOS/nixpkgs/commit/7e79c2ff7585bef771449f895488d792cc6b435c) maintainers: add kazenyuk
* [`265bb9eb`](https://github.com/NixOS/nixpkgs/commit/265bb9ebd0ca3365632ed5e0b645b4017d2d6256) hyperion-ng: 2.0.12 -> 2.0.14, unbreak
* [`f6b4a177`](https://github.com/NixOS/nixpkgs/commit/f6b4a177c8553e14f4d7a306bf3b5d426890be84) SDL2-net: 2.0.1 -> 2.2.0
* [`e151c437`](https://github.com/NixOS/nixpkgs/commit/e151c437684a74f8412ceeb13a30e502b8cf38a7) vimPlugins.nvim-treesitter.grammarToPlugin: init
* [`09726de8`](https://github.com/NixOS/nixpkgs/commit/09726de8632708408fa8edafc5c7f11f859500c6) unicurses: init at 2.1.3
* [`0092b9bc`](https://github.com/NixOS/nixpkgs/commit/0092b9bc72e7ba27b9ce2578d27fd5b7915aa4a0) tuifimanager: init at 2.3.4
* [`d945687c`](https://github.com/NixOS/nixpkgs/commit/d945687cf606e155080d1035d17bc10c3cf0d9ae) lv_img_conv: init at 0.4.0
* [`be57fca5`](https://github.com/NixOS/nixpkgs/commit/be57fca54a5b728171d2cb17be9118c2897246dc) maintainers: add felixalbrigtsen
* [`07006967`](https://github.com/NixOS/nixpkgs/commit/070069676ea175ae3171998ef90565d1b459616d) phetch: init at 1.2.0
* [`d0e80df0`](https://github.com/NixOS/nixpkgs/commit/d0e80df0dc89176080bad5c274db7a4b53085b59) cc-wrapper: replace "-isystem" by "-cxx-isystem" for c++ header
* [`27dddbfc`](https://github.com/NixOS/nixpkgs/commit/27dddbfc224bde13dd7a2809d258798dc87ad727) cc-wrapper: add the '-xc++' and `-x*-header` case to the wrapper
* [`a18367ea`](https://github.com/NixOS/nixpkgs/commit/a18367ea2ccaad1cd30125c7c659a546086b44e9) clang-tools: support -cxx-isystem flag
* [`ee2b2cef`](https://github.com/NixOS/nixpkgs/commit/ee2b2cef35f4c555360e560bb62b689af80fa5ca) cc-wrapper: add -cxx-isystem to libcxx-cxxflags instead of libc-cflags
* [`b59d61aa`](https://github.com/NixOS/nixpkgs/commit/b59d61aa489b3ae6a08cfe5b7684068b644d26f1) cc-wrapper: revert change to `-isystem`
* [`39341af6`](https://github.com/NixOS/nixpkgs/commit/39341af6b0e79563211d643ed388ea5e3d7587cd) papermc: allow version override
* [`96c41775`](https://github.com/NixOS/nixpkgs/commit/96c41775f0441b8ec553cb9f05be939caa098fc2) image_optim: add oxipng, fix optional workers
* [`c6324f8b`](https://github.com/NixOS/nixpkgs/commit/c6324f8b63cbd33ac685b5b43453770c7e38d9a8) image_optim: 0.31.1 -> 0.31.3
* [`f393974f`](https://github.com/NixOS/nixpkgs/commit/f393974f54f1f751e7b9b12cda9e0f905c0caaac) libomxil-bellagio: Fix -Wstringop-truncation for GCC 12
* [`8ec36277`](https://github.com/NixOS/nixpkgs/commit/8ec3627796ecc899e6f47f5bf3c3220856ead9c5) tree-sitter: Add solidity, update grammars
* [`c10bdd23`](https://github.com/NixOS/nixpkgs/commit/c10bdd233c4bc96b5232fabb8a79540563969d44) notable: add seccomp-fix for AppImage
* [`fa9659e0`](https://github.com/NixOS/nixpkgs/commit/fa9659e0defbdab1693e708a8063403f826f931c) qt-5/hooks/fix-qt-builtin-paths.sh: do not hardcode output paths
* [`5ef40489`](https://github.com/NixOS/nixpkgs/commit/5ef40489a99e9418a91be22ac6061857b429d7cd) nixos-bgrt-plymouth: init at unstable-2023-03-10
* [`690e76e0`](https://github.com/NixOS/nixpkgs/commit/690e76e0632ae237432ec86823094e350fa96f5c) gotop: fix build on Darwin
* [`72094bce`](https://github.com/NixOS/nixpkgs/commit/72094bce6397820ae517045d2a290c842d48e253) supercolliderPlugins.sc3-plugins: 3.11.1 → 3.13.0
* [`84e212d2`](https://github.com/NixOS/nixpkgs/commit/84e212d2f2a37ec7861c4d53b93f6a31c07e737b) jellyfin-media-player: 1.8.1 -> 1.9.0
* [`a418cae4`](https://github.com/NixOS/nixpkgs/commit/a418cae499fe92ab526bbdce807a6a3ebe5b8323) opencv: misc CUDA-related updates and fixes; add enableLto
* [`1021a7d9`](https://github.com/NixOS/nixpkgs/commit/1021a7d928208470082f10b43853e55c218a66ce) nixos/ddclient: fix permissions warning
* [`470e6130`](https://github.com/NixOS/nixpkgs/commit/470e6130b347c5aabc63cd6600ba78fa909e8e2a) rust: fix overriding rust flags on musl
* [`32c7999a`](https://github.com/NixOS/nixpkgs/commit/32c7999a105014af5f73188338a6f9cc0c59f344) dbus: 1.14.4 -> 1.14.6
* [`8968bb87`](https://github.com/NixOS/nixpkgs/commit/8968bb87e2cf900c3a16c61d0d8a3118627cd61a) python-yubico: init at 1.3.2
* [`d9587d35`](https://github.com/NixOS/nixpkgs/commit/d9587d35f40f79a0ef9a4b6889e4a8762e0d4c32) lesscpy: init at 0.13.0
* [`8a68c2bd`](https://github.com/NixOS/nixpkgs/commit/8a68c2bdcc62ba1cc370ec32cc2c6f10e24a2422) dogtag-pki: init at 11.2.1
* [`6d33f53f`](https://github.com/NixOS/nixpkgs/commit/6d33f53fa638617b5b1d4818d2a579ca10226881) krb5: add libverto as dependency
* [`da470200`](https://github.com/NixOS/nixpkgs/commit/da470200dfef09ce0a280c0af9a4fecb855c22eb) freeipa: init at 4.10.1
* [`6d299334`](https://github.com/NixOS/nixpkgs/commit/6d299334b0ca99f91890c8396d6ed73839535ec4) nixos/freeipa: init
* [`48dc4386`](https://github.com/NixOS/nixpkgs/commit/48dc4386a44ca2f3aa7524baf0be1a631144c320) rustPlatform.importCargoLock: support extra registries
* [`675dec9f`](https://github.com/NixOS/nixpkgs/commit/675dec9f7ce2c1ef232549ac3bd598835c96eb0f) zap: Fix configuration persistence
* [`cd169311`](https://github.com/NixOS/nixpkgs/commit/cd16931110f1e5647308c338454eab030a66c791) opencv: use cudaPackages.backendStdenv.cc instead of cudaPackages.cudatoolkit.cc
* [`d8c3f083`](https://github.com/NixOS/nixpkgs/commit/d8c3f083a1c1e35318fc58631d2c8038804fd49c) libidn2: 2.3.2 -> 2.3.4
* [`0ebe5103`](https://github.com/NixOS/nixpkgs/commit/0ebe51030f2a4482b2cc6b07fc0be1ba86d484a9) cc-wrapper: make $tool-prefixed `cpp` wrapping unconditional
* [`7f90949f`](https://github.com/NixOS/nixpkgs/commit/7f90949f1e0bf2cac5629098a8fc203ebcc2ad24) apple_sdk_11_0: script to generate frameworks.nix
* [`b9e6d1db`](https://github.com/NixOS/nixpkgs/commit/b9e6d1dbc0606c39932eca1c2a697e7581261c06) apple_sdk_11_0: generate frameworks.nix
* [`0c3aaf3e`](https://github.com/NixOS/nixpkgs/commit/0c3aaf3e6c1256bea584d7e8289cd96d3b21866f) apple_sdk_11_0: fix circular framework references
* [`a0537d63`](https://github.com/NixOS/nixpkgs/commit/a0537d633fdbd90f26808df5ca0a890cb4d6ebdf) apple_sdk_11_0: simplify SDK unpacking
* [`9f43a527`](https://github.com/NixOS/nixpkgs/commit/9f43a5273f86751410f108e32dc37e6b16969c8b) python3Packages.tensorflow: use default patchelf as it got the fixes
* [`6d96f0b9`](https://github.com/NixOS/nixpkgs/commit/6d96f0b9b94896dddc401260521a3fa681b84f9e) lv2: 1.18.2 -> 1.18.10
* [`916dba87`](https://github.com/NixOS/nixpkgs/commit/916dba8790619ad3002ab489a32f44070e44152d) bpftools: 5.19.12 -> 6.2; sync with linuxHeaders
* [`018143e3`](https://github.com/NixOS/nixpkgs/commit/018143e394a220479cdd9d48557d2d0e3f87a085) python3Packages.types-pyopenssl: init at 23.0.0.4
* [`b237f5b6`](https://github.com/NixOS/nixpkgs/commit/b237f5b63756203e07e34a241610d5b86dabbe33) qt5: make overriding separatedebuginfo useful
* [`8f454232`](https://github.com/NixOS/nixpkgs/commit/8f45423217c07a3df6ad49c875f06a56eaede2a5) libpcap: build with libnl
* [`a5d95ac5`](https://github.com/NixOS/nixpkgs/commit/a5d95ac5fca37482f55feb0870c9ed6b1b9bb4b4) nixos/tmp: move /tmp options under boot.tmp
* [`c8ddde75`](https://github.com/NixOS/nixpkgs/commit/c8ddde75f78d3b00c941bf14fa686ddf99c9b9e1) python310Packages.pybind11: 2.10.3 -> 2.10.4
* [`b4523c91`](https://github.com/NixOS/nixpkgs/commit/b4523c91011a0638a3cd457abb706b986ccdbabf) ed: cleanup, format
* [`1d9429fa`](https://github.com/NixOS/nixpkgs/commit/1d9429faa0c864cae4e4f366818d47b18c32234e) polkit: move test-only deps to nativeCheckInputs
* [`3a5de0e7`](https://github.com/NixOS/nixpkgs/commit/3a5de0e7258d249a36fc29f0bb2a55f40b211a45) nixos/tmp: add a note to useTmpfs on potential issues
* [`10aecede`](https://github.com/NixOS/nixpkgs/commit/10aecedee1d3e2a7f8fa808b29478fdc03684395) pythonPackages.certbot: 2.3.0 -> 2.4.0
* [`e2825fb1`](https://github.com/NixOS/nixpkgs/commit/e2825fb1b5ea01c320b5ffd3ccd4836864f076bb) rustPlatform.importCargoLock: improved semantics for 'extraRegistries' option
* [`dd922563`](https://github.com/NixOS/nixpkgs/commit/dd922563afb0370d82e8141dca1e7691c92f96f1) mpg123: add lib-only derivation not depending on sound servers
* [`9f6d48ae`](https://github.com/NixOS/nixpkgs/commit/9f6d48ae2ec27b35bb8bd656ba8b1c22e7da196e) libsndfile: enable MP3 support
* [`1b80b556`](https://github.com/NixOS/nixpkgs/commit/1b80b55648e705c8c6034b39dad67b6940289d1d) libsndfile: 1.1.0 -> 1.2.0
* [`6477516d`](https://github.com/NixOS/nixpkgs/commit/6477516d6d5d6a25e975d88ac8ed2405e6b846c4) libsndfile: link sndfile-play with ALSA on GNU/Linux
* [`c0bb90b4`](https://github.com/NixOS/nixpkgs/commit/c0bb90b44097b831da4268f321898e34f0781e93) bundler: 2.4.8 -> 2.4.9
* [`bcdb108d`](https://github.com/NixOS/nixpkgs/commit/bcdb108d06045852c306ab166ffe3bedebb5c4f5) unbound: enable parallel building
* [`d5a1ebd6`](https://github.com/NixOS/nixpkgs/commit/d5a1ebd648d7be1e8d58a9b3bcdecbea25abcfea) libnftnl: 1.2.4 -> 1.2.5
* [`b17e280a`](https://github.com/NixOS/nixpkgs/commit/b17e280afe75308fc94a4310cad1570ebc60e549) nftables: 1.0.6 -> 1.0.7
* [`eee96956`](https://github.com/NixOS/nixpkgs/commit/eee96956f821a921910792d59f69a1919341eb32) lvm2: 2.03.19 -> 2.03.20
* [`98df16e2`](https://github.com/NixOS/nixpkgs/commit/98df16e2417ddfc1ae12a43bd90b47f6e2e5e2e5) katago: 1.11.0 -> 1.12.4
* [`5113be65`](https://github.com/NixOS/nixpkgs/commit/5113be6584810b63ae9be37f3d887bc09e7c1334) teams-for-linux: add updateScript
* [`c98c72df`](https://github.com/NixOS/nixpkgs/commit/c98c72df26b3ed2c79757a1427d39857bc2bd07f) gpgme: 1.18.0 -> 1.19.0
* [`a439e85b`](https://github.com/NixOS/nixpkgs/commit/a439e85b7a1c2f2f71f8c461a1e6cad6631606a7) xz: 5.4.1 -> 5.4.2
* [`cfde0671`](https://github.com/NixOS/nixpkgs/commit/cfde0671b9d7e52e4bd286f3e60f9d1bd8c696ca) nsnake: init at 3.0.1
* [`ab3044b4`](https://github.com/NixOS/nixpkgs/commit/ab3044b4536b70bda8686649bc300c42f25517b7) libgcrypt: 1.5.6 -> 1.8.10
* [`858391df`](https://github.com/NixOS/nixpkgs/commit/858391dfad508a2f1b80e571802c40813baa285f) gnupg: Add LTS version 2.2.41
* [`530ebd6c`](https://github.com/NixOS/nixpkgs/commit/530ebd6c0ddca9f228e1322d88957e392e6eae77) gnupg: Remove patch for code that is disabled upstream
* [`3e665614`](https://github.com/NixOS/nixpkgs/commit/3e66561470ed54b54d6c27c7c456dca114636347) libomxil-bellagio: explain the compiler warning better
* [`31bc4ea6`](https://github.com/NixOS/nixpkgs/commit/31bc4ea688643894bbf6463bddbd7599b796cd11) python3Packages.psutil: Skip another test with a build impurity
* [`d0dc53e8`](https://github.com/NixOS/nixpkgs/commit/d0dc53e858a90a95cda5b011c7eb817d9f536d95) tzdata: 2022g -> 2023a
* [`66c8fcb3`](https://github.com/NixOS/nixpkgs/commit/66c8fcb314cd202d57f8fb1e0f4ad1a7ca89192c) iana-etc: 20221107 -> 20230316
* [`9d719e19`](https://github.com/NixOS/nixpkgs/commit/9d719e198c6a6a5b9a2d5f02b3b41660f79610ff) python310Packages.markdown: 3.4.1 -> 3.4.3
* [`dcc57617`](https://github.com/NixOS/nixpkgs/commit/dcc576176cd23d4ae1e37d31bba260484ecea05d) buildGo{Module,Package}: fix precedence for or operator
* [`f0c809ad`](https://github.com/NixOS/nixpkgs/commit/f0c809adfd6635c1ddace0ea259127c137cd1a9e) tzdata: 2023a -> 2023b
* [`49b3864f`](https://github.com/NixOS/nixpkgs/commit/49b3864f656a8bd22f6842b0883b43ca1fbf0c2c) libvmaf: add xxd to nativeBuildInputs
* [`39fb426d`](https://github.com/NixOS/nixpkgs/commit/39fb426da55f30b021844f0e8bddd5f2ffb76b8e) itk: enable SimpleITKFilters; minor refactor
* [`9e182deb`](https://github.com/NixOS/nixpkgs/commit/9e182deb290b2602dc86630810818d5e0e4ae9dd) simpleitk: collapse `out` and `dev` outputs
* [`157285ff`](https://github.com/NixOS/nixpkgs/commit/157285ffee5174defc6302288afe8210b1479f2d) python310Packages.simpleitk: init at 2.2.1
* [`6ee34a43`](https://github.com/NixOS/nixpkgs/commit/6ee34a43765fb47a66b9b49fce9a9ec99d25c747) oras: 0.16.0 -> 1.0.0
* [`ac397b15`](https://github.com/NixOS/nixpkgs/commit/ac397b1542f794e2c16d6ba5b8e1dff6b06dfe5d) oras: add developer-guy to maintainers list
* [`deb1d7ac`](https://github.com/NixOS/nixpkgs/commit/deb1d7ac1ed8475d8dd1d1accf045203bfb4ee58) ceph: 16.2.10 -> 17.2.5
* [`adb0c356`](https://github.com/NixOS/nixpkgs/commit/adb0c3560b93e5390825a03147a44383dd54050e) nixos/tests/ceph*: Enable on aarch64-linux
* [`601447fc`](https://github.com/NixOS/nixpkgs/commit/601447fcb728d3322d9322ccdde5529d7798ca68) libgit2: 1.6.2 -> 1.6.3
* [`14006c61`](https://github.com/NixOS/nixpkgs/commit/14006c6195b08f07f44923b61ab51b3d9b5e7227) bpftools: add debug info
* [`8e40747e`](https://github.com/NixOS/nixpkgs/commit/8e40747e62943327c390fb8f7e4a3988d9e6e1cd) perl536Packages.Po4a: remove texlive dependency
* [`5cb6d765`](https://github.com/NixOS/nixpkgs/commit/5cb6d7653a7b1701a339716a29da9145840a4345) libdeflate: 1.17 -> 1.18
* [`8c890897`](https://github.com/NixOS/nixpkgs/commit/8c890897b5622031f57ade840f200249730e2f7a) sratom: 0.6.8 -> 0.6.14
* [`e9f8bfcd`](https://github.com/NixOS/nixpkgs/commit/e9f8bfcdf23fbd35f956bc0c376076b629a9532d) mesa: default to 23.0.1
* [`e31ac722`](https://github.com/NixOS/nixpkgs/commit/e31ac7227e68934c80a8219c8f617d66539241d0) libmicrohttpd: Apply patch for CVE-2023-27371
* [`7de760af`](https://github.com/NixOS/nixpkgs/commit/7de760af6ce9e2df89b738f0c8ca3639da231119) libmbim: support cross
* [`7da7a46b`](https://github.com/NixOS/nixpkgs/commit/7da7a46bce728f08a87e6163ac99ad6d930dd69d) python310Packages.pytz: 2022.7.1 -> 2023.2
* [`70c40261`](https://github.com/NixOS/nixpkgs/commit/70c40261bed0c1c5b432eb5f5f604e4cfef74053) roc-toolkit: 0.2.1 -> 0.2.3
* [`dda92df9`](https://github.com/NixOS/nixpkgs/commit/dda92df9c0ffd7dd9d994158a7f46ccdfb32e9e1) wayland: build libraries on darwin
* [`20e24e42`](https://github.com/NixOS/nixpkgs/commit/20e24e42d4745d2b81423e3eeaae8acc0d4fa120) rustc: 1.67.1 -> 1.68.0
* [`370040c2`](https://github.com/NixOS/nixpkgs/commit/370040c2f1b9504b9506ac0d4253cfc4e7b397aa) rustc: 1.68.0 -> 1.68.1
* [`91c36201`](https://github.com/NixOS/nixpkgs/commit/91c36201aa02ea8495747624e3b6b321c4a94f74) rustfmt: fix build for 1.68
* [`9861cf4a`](https://github.com/NixOS/nixpkgs/commit/9861cf4a7f5f39f82878c7669232eb68eadf7f78) rustPlatform.fetchCargoTarball: use sparse protocol for crates.io
* [`9d634c7d`](https://github.com/NixOS/nixpkgs/commit/9d634c7dec4d3257f4c5c923daf8f5a348909e35) python310Packages.jsonschema-spec: 0.1.3 -> 0.1.4
* [`0be8a34f`](https://github.com/NixOS/nixpkgs/commit/0be8a34fa9be1f8750b971b71c400e58ab47e139) gssdp: enable introspection on cross builds
* [`80183144`](https://github.com/NixOS/nixpkgs/commit/8018314491598b2eaa0ac2b4307694f2f70b1fed) gupnp: enable introspection on cross builds
* [`63793f51`](https://github.com/NixOS/nixpkgs/commit/63793f516e5164eace848e37e4852a3d33e71f93) gssdp_1_6: support cross compilation
* [`d20bb7f9`](https://github.com/NixOS/nixpkgs/commit/d20bb7f9be205bfbaa93bd3356db2f5ffef78e65) gupnp_1_6: support cross compilation
* [`167f4e93`](https://github.com/NixOS/nixpkgs/commit/167f4e9363478ab4dc606438bc127293d3b4b312) python310Packages.bcrypt: 4.0.0 -> 4.0.1
* [`19e807bd`](https://github.com/NixOS/nixpkgs/commit/19e807bd2c00229700a3e6149636591112693f21) python310Packages.sphinx-autodoc-typehints: 1.23.4 -> 1.22
* [`78d55e8a`](https://github.com/NixOS/nixpkgs/commit/78d55e8a893f57c836da4570e82517ec14d7df41) python310Packages.pytest-xdist: 3.2.0 -> 3.2.1
* [`201d4b7c`](https://github.com/NixOS/nixpkgs/commit/201d4b7c5c106affaba32a3b0138aa81b1a8b037) rustPlatform.buildRustPackage: make auditable the default
* [`a77bce6c`](https://github.com/NixOS/nixpkgs/commit/a77bce6c1a1b07fcb37d43d5fa2c78df952826f8) lua*Packages: fix the default namePrefix as intended
* [`5fb0535e`](https://github.com/NixOS/nixpkgs/commit/5fb0535e036861b3c485b010d90d970aa7003b6e) libelf: disable parallel installs
* [`de09232a`](https://github.com/NixOS/nixpkgs/commit/de09232a2e2c596ae147b952d2f72567e4160eea) python3.pkgs.expiring-dict: init at 1.1.0
* [`86bc7e3b`](https://github.com/NixOS/nixpkgs/commit/86bc7e3b93b5524132206826725dd855668e692e) unifi-protect-backup: 0.8.8 -> 0.9.0
* [`c8217d6b`](https://github.com/NixOS/nixpkgs/commit/c8217d6ba47c3552f89ac5aed33d4d3fc04485e8) mesa: remove libgrl.a
* [`0bfa2fab`](https://github.com/NixOS/nixpkgs/commit/0bfa2fabb7954da499656407a6e612b93dae445d) Revert "tzdata: 2023a -> 2023b"
* [`221f2fe6`](https://github.com/NixOS/nixpkgs/commit/221f2fe6938fec92700e3577419d442e58b4a21f) at-spi2-core: fix support for dbus-broker
* [`56728f63`](https://github.com/NixOS/nixpkgs/commit/56728f632b90bfff5162a16e4c2457b42ad6f0f9) libGL: complete meta, get version from correct package
* [`2865b8f2`](https://github.com/NixOS/nixpkgs/commit/2865b8f2a320daad30021e39df3f3d70f1af4d76) udisks: backport patch for crash on exit
* [`bb9e6554`](https://github.com/NixOS/nixpkgs/commit/bb9e65549fe4a54def429a34123e7c98f489421c) python310Packages.typeguard: move setuptools-scm to correct input, add empty meta.maintainers, misc cleanup
* [`b30b9fda`](https://github.com/NixOS/nixpkgs/commit/b30b9fda485b2b9701172369f6c84830a3ab845c) maintainer: add pyxels
* [`b44b55f8`](https://github.com/NixOS/nixpkgs/commit/b44b55f80396562cb30e8ec4a57a33c0dd4f5fb0) esphome: 2023.3.1 -> 2023.3.2
* [`f1d94e36`](https://github.com/NixOS/nixpkgs/commit/f1d94e365ab9e2d6bd0b70bf9845395774a6e483) colloid-icon-theme: 2023-01-08 -> 2023-03-28
* [`e7f6684c`](https://github.com/NixOS/nixpkgs/commit/e7f6684c4fa6c55e176999bcd6f6d65e2da157d4) python310Packages.orjson: 3.8.6 -> 3.8.9
* [`45b1d4d2`](https://github.com/NixOS/nixpkgs/commit/45b1d4d2926c19f8a3d2a91f6324071cb03ce9b1) rustc: 1.68.1 -> 1.68.2
* [`4cb59fe2`](https://github.com/NixOS/nixpkgs/commit/4cb59fe2e32a24ca9c2952bfc22ca4f37c038224) rustc: remove unused inputs
* [`b42ee8b8`](https://github.com/NixOS/nixpkgs/commit/b42ee8b81746a38599148998aae69622189716ed) glibc: 2.35-224 -> 2.37-8
* [`b2a1ac4e`](https://github.com/NixOS/nixpkgs/commit/b2a1ac4e9935fd4eed863156c2e117496b12a4cc) gcc11: fix build w/glibc-2.36
* [`019f605c`](https://github.com/NixOS/nixpkgs/commit/019f605cd74e7476685195d3957f7066cff19e0a) gcc: exclude malformed `sys/mount.h` from fixed headers directory
* [`b0265aad`](https://github.com/NixOS/nixpkgs/commit/b0265aadac2813d5e86605f9ff7da141ca9e4bb2) gcc10: fix build w/glibc-2.36
* [`531a1965`](https://github.com/NixOS/nixpkgs/commit/531a1965de56e293c9f1533a33b3128476d4cb11) gcc9: fix build w/glibc-2.36
* [`b0d673c7`](https://github.com/NixOS/nixpkgs/commit/b0d673c7943a6c1231d478cbd095ea3f96692706) gcc8: fix build w/glibc-2.36
* [`0ed55ff3`](https://github.com/NixOS/nixpkgs/commit/0ed55ff3cafe526eba49700f98510f1fcf837f6b) gcc7: fix build w/glibc-2.36
* [`9bb6dc1b`](https://github.com/NixOS/nixpkgs/commit/9bb6dc1bc3cffbabc78f8df337d241f070604590) gcc6: fix build w/glibc-2.36
* [`2a2cd02c`](https://github.com/NixOS/nixpkgs/commit/2a2cd02cb650300010b74e1de92def52e36e9d13) gcc49: fix build w/glibc-2.36
* [`1e33e850`](https://github.com/NixOS/nixpkgs/commit/1e33e8506313d84a12c0cab7dd2291d47112adc6) libcdio: fix build w/glibc-2.36
* [`7f06aa70`](https://github.com/NixOS/nixpkgs/commit/7f06aa700a6dd875dcfbd23165dc132747877596) lxc: fix build w/glibc-2.36
* [`ea13def9`](https://github.com/NixOS/nixpkgs/commit/ea13def9b9a89a64aceb1015ab840d4b612ad030) criu: fix build w/glibc-2.36
* [`2768c81a`](https://github.com/NixOS/nixpkgs/commit/2768c81adc9d49737162d8c2bef3f3abd1f43f83) spdk: fix build w/glibc-2.36
* [`c5aabf63`](https://github.com/NixOS/nixpkgs/commit/c5aabf639225d30989c2e5c072f118f990e84196) distrobuilder: fix build w/glibc-2.36
* [`5f0b5cc1`](https://github.com/NixOS/nixpkgs/commit/5f0b5cc16e7ce444f72b4c1fba0fc772140d9791) lxcfs: fix build w/glibc-2.36
* [`7046f09f`](https://github.com/NixOS/nixpkgs/commit/7046f09fe464d6959209793e48d987635f4da156) xorg.xdm: fix build w/glibc-2.36
* [`89fda21f`](https://github.com/NixOS/nixpkgs/commit/89fda21faeccce95f523e3b1c20327a137c83014) gccgo6: fix build w/glibc-2.36
* [`667fac1b`](https://github.com/NixOS/nixpkgs/commit/667fac1b4e25ea36077bb3e1207f5ab5b8b5233f) nixos/doc: mention glibc update in release notes
* [`047f379d`](https://github.com/NixOS/nixpkgs/commit/047f379d38c64fc125b65602fb530c3fb9ce4b15) glibc: use patch from ArchLinux to re-enable DT_HASH
* [`907bd492`](https://github.com/NixOS/nixpkgs/commit/907bd4927b7f11d715249729ea055dd64eb60f91) nixos/clash-verge: init module
* [`e6f19ea4`](https://github.com/NixOS/nixpkgs/commit/e6f19ea4295df7d4a05c1c122962309f5e6fca70) writeTextFile: chmod before checkPhase
* [`05a12887`](https://github.com/NixOS/nixpkgs/commit/05a128875aa9da69a2e868e10cdd58c482701c49) maintainers: add lillycham
* [`0d601b53`](https://github.com/NixOS/nixpkgs/commit/0d601b53c776a0447ffa8859f6133e857df01234) python3Packages.testpath: fix build reproducibility
* [`83cb871d`](https://github.com/NixOS/nixpkgs/commit/83cb871d8b40a78c4b4a541fc8c69056b77d96e4) bundler: 2.4.9 -> 2.4.10
* [`952a8a21`](https://github.com/NixOS/nixpkgs/commit/952a8a21ceceb563db3a38865f2089ae8c0ff323) maturin: 0.14.15 -> 0.14.16
* [`d04eae79`](https://github.com/NixOS/nixpkgs/commit/d04eae79c983f73705ed06faface7344849e8a38) sqlite: 3.41.1 -> 3.41.2
* [`2cfc128c`](https://github.com/NixOS/nixpkgs/commit/2cfc128ca307cb24ed66b23d0d2543edcb6b1c7b) nanovna-saver: 0.5.4 -> 0.6.0
* [`aa42083d`](https://github.com/NixOS/nixpkgs/commit/aa42083d7ebbc975a79f196f64fa2626d67cdd3c) tk: propagate frameworks
* [`a9bd9087`](https://github.com/NixOS/nixpkgs/commit/a9bd908709826ef1d1319cb4001a8088e97ab5bb) systemd: 253.1 -> 253.2
* [`61781324`](https://github.com/NixOS/nixpkgs/commit/617813243c052e0b9e8ae57362de234523d61524) systemd: fix ukify script
* [`dd6de392`](https://github.com/NixOS/nixpkgs/commit/dd6de392b3f7194765259084f2b7a2e6ea8bdd06) dapr-cli: 1.8.1 -> 1.10.0
* [`e75df8cd`](https://github.com/NixOS/nixpkgs/commit/e75df8cd4eeda63ea9b9c9407727c3e9cf7af748) meshoptimizer: init at unstable-2023-03-22
* [`7fe340e4`](https://github.com/NixOS/nixpkgs/commit/7fe340e404b82e7890686e2a14990c465d06e797) postman: patchelf chrome_crashpad_handler
* [`92b434f8`](https://github.com/NixOS/nixpkgs/commit/92b434f89b2efbd746d5dee907ac57714be5b2e5) freeipa: use 'pkg-config' instead of 'pkgconfig' alias
* [`562fc67a`](https://github.com/NixOS/nixpkgs/commit/562fc67aff9d30376e6b37379204f8dddab108ee) python3Packages.dogtag-pki: use 'python-ldap', not an 'ldap' alias
* [`2869364b`](https://github.com/NixOS/nixpkgs/commit/2869364b9b23f5ae0c284e670cd69a9aa42b38c4) matrix-sdk-crypto-nodejs: 0.1.0-beta.2 -> 0.1.0-beta.3
* [`53a63959`](https://github.com/NixOS/nixpkgs/commit/53a639594f138e9eb86759457c8a93a776a99441) matrix-sdk-crypto-nodejs: convert cargoDeps to importCargoLock
* [`6831ac72`](https://github.com/NixOS/nixpkgs/commit/6831ac7257c060d1abf6f1dc297c8508fe845808) gotraceui: init at 0.1.0
* [`480df9b4`](https://github.com/NixOS/nixpkgs/commit/480df9b4daab735b9ecc15f1829d1aeffbbde3a0) tzdata: 2023a -> 2023c
* [`7c0d0c1a`](https://github.com/NixOS/nixpkgs/commit/7c0d0c1aaaeb3cdd8813af2b3ebb766fd6d50404) linuxPackages.nvidia_x11_vulkan_beta: 525.47.11 -> 525.47.18
* [`5df6db95`](https://github.com/NixOS/nixpkgs/commit/5df6db9577b1c15f57c8278e60b666e4d9b2af81) latte-dock: unstable-2022-09-06 -> unstable-2023-03-31
* [`b459da31`](https://github.com/NixOS/nixpkgs/commit/b459da3172f2546e6867bee886d03d7a8a80d297) texlive.bin.core: avoid unnecessary dependency on texlinks ([nixos/nixpkgs⁠#222323](https://togithub.com/nixos/nixpkgs/issues/222323))
* [`121fddc9`](https://github.com/NixOS/nixpkgs/commit/121fddc901f2c81ee12b056def74d1e7a5fbd419) nixos/proxmox-image: don't assume virtio0 is using local-lvm storage
* [`ca228108`](https://github.com/NixOS/nixpkgs/commit/ca228108559b05a6f3a7a3d0422cc7c7a573b1f8) manrope: 3 -> 4.505
* [`c56d5b4e`](https://github.com/NixOS/nixpkgs/commit/c56d5b4ec4d50a7199658a159a6f1a1bc499836a) manrope: update homepage
* [`8d8dd6fd`](https://github.com/NixOS/nixpkgs/commit/8d8dd6fdbf6406c82faee1b3293a0b491b3b3751) platformio: make multi-output
* [`fcbc5d74`](https://github.com/NixOS/nixpkgs/commit/fcbc5d74e73dbac4d2bb28c628a09630561b52d1) platformio-core: move src & version to main expression
* [`bd3361bc`](https://github.com/NixOS/nixpkgs/commit/bd3361bcfb3332ed8209a748c350532195267ef0) platformio: ensure coherent python interpreter with platformio-core
* [`cea8b33d`](https://github.com/NixOS/nixpkgs/commit/cea8b33d31ed8ca361e6e9573f16b8d233fbc729) gamemode: fix build w/ glibc-2.36
* [`26495c83`](https://github.com/NixOS/nixpkgs/commit/26495c833ffb8d9a72def3a890d15948b99d1872) qemu: fix build w/ glibc-2.37
* [`9fdf7027`](https://github.com/NixOS/nixpkgs/commit/9fdf7027cc200665da40e6a7d51b8299e70fdf30) nixos/zsh: allow fqdn hostname output
* [`f08a0299`](https://github.com/NixOS/nixpkgs/commit/f08a02991b6e478f069ee8ef46dabb51a2ba7062) mailutils: fix testsuite failure caused by unsupported weak hashes
* [`99399792`](https://github.com/NixOS/nixpkgs/commit/99399792e99caa50eb2b7a68327e9816b44fef94) python310Packages.aenum: 3.1.11 -> 3.1.12
* [`fce7bf97`](https://github.com/NixOS/nixpkgs/commit/fce7bf97d85025d79c8b0c9cfe4931476958d1f3) maintainers: add kylehendricks
* [`fea33a10`](https://github.com/NixOS/nixpkgs/commit/fea33a101ee59d5a42db51646719e46b56c19aa7) blocky: 0.20 -> 0.21
* [`6f6e74d2`](https://github.com/NixOS/nixpkgs/commit/6f6e74d2555372a6d2f722503c1a8bd8add152c7) clash-meta: 1.14.2 -> 1.14.3
* [`a8ee4e3c`](https://github.com/NixOS/nixpkgs/commit/a8ee4e3ce491887583fd0b594e8197505a4256bc) python310Packages.google-auth: 2.16.1 -> 2.17.1
* [`74207b79`](https://github.com/NixOS/nixpkgs/commit/74207b79f05fe0f067528c7fd3c7c8fd60128939) curl: add support for Rustls backend
* [`3b49fb2a`](https://github.com/NixOS/nixpkgs/commit/3b49fb2ab6ebb157daa45c3cd9633d55aed3a457) trivial-builders/test/references.nix: fix eval
* [`41027144`](https://github.com/NixOS/nixpkgs/commit/410271448ca70e68ce013f6f10935d5a76ff6a9a) test-defaultPkgConfigPackages.nix: filter out recurseForDerivations
* [`39c7885c`](https://github.com/NixOS/nixpkgs/commit/39c7885cd90ebca1541a1e0b1a26b7d44238d986) cc-wrapper: if isClang, add -L${gccForLibs.libgcc}/lib
* [`87225ff5`](https://github.com/NixOS/nixpkgs/commit/87225ff54dd632653480a68cb4223eb24d972d35) ccache-links: inherit version to keep cc-wrapper happy
* [`70d34589`](https://github.com/NixOS/nixpkgs/commit/70d34589bd7b890afc1eeafa0eb739fbf6676df0) stdenv/linux: factor out commonGccOverrides
* [`fdd49f1b`](https://github.com/NixOS/nixpkgs/commit/fdd49f1bcd8a7f0b5e29f550d698b2abe5c540cd) gcc/{11,12}: use lib.pipe
* [`889acff7`](https://github.com/NixOS/nixpkgs/commit/889acff738f118d2fdfb6304cf3348da3e9d4224) portfolio: 0.61.4 -> 0.62.0
* [`a66723d4`](https://github.com/NixOS/nixpkgs/commit/a66723d4bf4f66e5725b48eb64def872185eb3bf) auto-multiple-choice: create pkgs fixpoint for texlive using mkDerivation
* [`6b2b9a0d`](https://github.com/NixOS/nixpkgs/commit/6b2b9a0de3f6d740d141ae3ffdf2a25ad598adf1) eukleides: create pkgs fixpoint for texlive using mkDerivation
* [`2f7daea6`](https://github.com/NixOS/nixpkgs/commit/2f7daea6031264ee98757fab25e68b7a66931f73) mftrace: create pkgs fixpoint for texlive using mkDerivation
* [`4213fc7c`](https://github.com/NixOS/nixpkgs/commit/4213fc7cde89d8508f27bd683f4047a462ee9652) sasview: fix build
* [`4319e1ce`](https://github.com/NixOS/nixpkgs/commit/4319e1ceb24d014b125f05e18f6a4bccec792e87) noweb: create pkgs fixpoint for texlive using mkDerivation
* [`2020863f`](https://github.com/NixOS/nixpkgs/commit/2020863f242ecdd0c6bf271da24a07f73fe18492) sagetex: create pkgs fixpoint for texlive using mkDerivation
* [`240cc599`](https://github.com/NixOS/nixpkgs/commit/240cc5994224b2ed8403feb5f8a05aea38121df3) texlive.combine: move dependencies to attribute tlDeps, resolve them with genericClosure
* [`59661daf`](https://github.com/NixOS/nixpkgs/commit/59661dafb04b95b4e6d5933bfa2332949de46bbe) texlive.combine: remove lib.unique in generating language and format configuration
* [`57b2634a`](https://github.com/NixOS/nixpkgs/commit/57b2634ac1242bd8d34b6c78396b217c65418755) texlive.combine: document how to create custom packages with pkgs and tlDeps attributes
* [`acb02e2f`](https://github.com/NixOS/nixpkgs/commit/acb02e2fab3b84601288af4524582f4049248a9b) eukleides: move texlive dependencies to tlDeps
* [`35b698d0`](https://github.com/NixOS/nixpkgs/commit/35b698d0b2194038d0a2f279347053e5a10ea1fb) mftrace: move texlive dependencies to tlDeps
* [`eb0f101b`](https://github.com/NixOS/nixpkgs/commit/eb0f101b8aa0b704e103164699350fd3914c298c) gasket: init at 1.0-18
* [`5fbdef57`](https://github.com/NixOS/nixpkgs/commit/5fbdef572082948ca9c4aefffb9d09dbd50aedb8) python3Packages.lightgbm: add GPU support
* [`64987000`](https://github.com/NixOS/nixpkgs/commit/64987000708d5ba7152aa3585f780f367af5902f) python310Packages.cython: 0.29.33 -> 0.29.34
* [`c8ece551`](https://github.com/NixOS/nixpkgs/commit/c8ece5516e7e0734842039913fa404ea0836f69b) python310Packages.cython: Force regeneration of generated code in sdists
* [`7553d0fe`](https://github.com/NixOS/nixpkgs/commit/7553d0fe29801938bcb280bb324b579ef9016aea) stdenv: Nix-driven bootstrap of gcc
* [`c6bd37a6`](https://github.com/NixOS/nixpkgs/commit/c6bd37a69160e7e436d9b8fba1ff12d0678ccf1a) make-bootstrap-tools.nix: ship libisl.so
* [`86ca0faf`](https://github.com/NixOS/nixpkgs/commit/86ca0faff759bb28901079e643c55c3f6a4ea47d) make-bootstrap-tools.nix: cp libgcc_s without -d
* [`d7fe0a55`](https://github.com/NixOS/nixpkgs/commit/d7fe0a5548413fedb2c23d8b7d9864c99350e226) make-bootstrap-tools.nix: use a patchelf built with -static-{libgcc,libstdc++}
* [`fed2300b`](https://github.com/NixOS/nixpkgs/commit/fed2300bea5e0451c6fe55535f0a8f471a5d8c35) unpack-bootstrap-tools.sh: patchelf libgcc_s.so.1
* [`96588eb3`](https://github.com/NixOS/nixpkgs/commit/96588eb3de55931e8b92a4f78f44342598f7ed5c) gcc: add common/checksum.nix
* [`5f57c2e0`](https://github.com/NixOS/nixpkgs/commit/5f57c2e0f97a83bf5691ac3a29da6ef9b44535c4) pkgs/test/stdenv/default.nix: add gcc-stageCompare
* [`6c209e86`](https://github.com/NixOS/nixpkgs/commit/6c209e862e18d6a9d103a80d5fa2443f4e47163e) emacs: path fixes resulting from libgccjit changes
* [`42ca62eb`](https://github.com/NixOS/nixpkgs/commit/42ca62eb014f3f55a5d3d23c73bacb1e79bad64e) sunshine: add updater script
* [`1fd08a86`](https://github.com/NixOS/nixpkgs/commit/1fd08a866e6c83decd019008b1e35f8c97c916a4) sherlock:  0.14.0 -> 0.14.3
* [`53e6dfce`](https://github.com/NixOS/nixpkgs/commit/53e6dfce424172c38a348eddf533918d2c65fe74) maintainers: add jfvillablanca
* [`f8dca33e`](https://github.com/NixOS/nixpkgs/commit/f8dca33e50eda25b56d9d4648cc8e901ffa5909c) onagre: init at 1.0.0-alpha.0
* [`d2813d50`](https://github.com/NixOS/nixpkgs/commit/d2813d505e844753cd15e54942e93ae3f73d0af4) iptables: 1.8.8 -> 1.8.9
* [`2ef1e26e`](https://github.com/NixOS/nixpkgs/commit/2ef1e26ea5cdcf6a4e1ee522b1993308744e7c26) pkgsStatic.iptables: fix build
* [`4f215221`](https://github.com/NixOS/nixpkgs/commit/4f2152215a66ff7764ada6da0de3fd174ba1f654) nixos/gitit: remove
* [`6cc536eb`](https://github.com/NixOS/nixpkgs/commit/6cc536eb1d45960ba6ce4244945f35c843a1d1ec) vulkan-headers: 1.3.239.0 -> 1.3.243.0
* [`6e5af0ea`](https://github.com/NixOS/nixpkgs/commit/6e5af0ea427789e9ea9eac7df0ea25b982acb79e) spirv-headers: 1.3.239.0 -> 1.3.243.0
* [`fae495c3`](https://github.com/NixOS/nixpkgs/commit/fae495c37da6decfc659f6a081fa5144e046b860) glslang: 1.3.239.0 -> 1.3.243.0
* [`f1a6b703`](https://github.com/NixOS/nixpkgs/commit/f1a6b703bb208c343860572cf7bdc6c736414a6d) vulkan-loader: 1.3.239.0 -> 1.3.243.0
* [`4805fe6c`](https://github.com/NixOS/nixpkgs/commit/4805fe6c0a5bcf6085a92be1cb82e973d644496a) spirv-tools: 1.3.239.0 -> 1.3.243.0
* [`0bd070e1`](https://github.com/NixOS/nixpkgs/commit/0bd070e1bcccf6460aef911e6f6cdefb4d4c6452) spirv-cross: 1.3.239.0 -> 1.3.243.0
* [`eb5a415e`](https://github.com/NixOS/nixpkgs/commit/eb5a415e1ce936f8499e88700da95fa01e624200) vulkan-validation-layers: 1.3.239.0 -> 1.3.243.0
* [`5481d74a`](https://github.com/NixOS/nixpkgs/commit/5481d74a296dfb51f75aa1c9841348d02d279ae9) vulkan-tools: 1.3.239.0 -> 1.3.243.0
* [`275bfd93`](https://github.com/NixOS/nixpkgs/commit/275bfd93eaf5e00bf42bab0038f162b85fe80aaa) vulkan-tools-lunarg: 1.3.239.0 -> 1.3.243.0
* [`e3ee688b`](https://github.com/NixOS/nixpkgs/commit/e3ee688b5d47d1547dff9e68c1e957c89d9be0af) vulkan-extension-layer: 1.3.239.0 -> 1.3.243.0
* [`a9196218`](https://github.com/NixOS/nixpkgs/commit/a9196218c916b6215d61730c5c0e0eaa5a00a114) moltenvk: 1.2.2 -> 1.2.3
* [`188573bf`](https://github.com/NixOS/nixpkgs/commit/188573bf932186dc1aedf4419cc9f1edc0de42ab) nixos/roundcube: use PHP 8.1
* [`76973ae3`](https://github.com/NixOS/nixpkgs/commit/76973ae3b30a88ea415f27ff53809ab8f452e2ec) qt5: regularly scheduled patchset update
* [`8a339bb8`](https://github.com/NixOS/nixpkgs/commit/8a339bb874ef98fec364e5362e8d055b999dd1d0) python310Packages.aiomisc: 16.3.15 -> 17.0.8
* [`d4bb2b1f`](https://github.com/NixOS/nixpkgs/commit/d4bb2b1f4f93665d783eff5ad0a8c42a6baae495) python310Packages.aiomisc: add changelog to meta
* [`7206f1d0`](https://github.com/NixOS/nixpkgs/commit/7206f1d01f25afa34e4e2963c3bf3f6cecc34638) python310Packages.aiomisc-pytest: init at 1.1.1
* [`2f29aa5f`](https://github.com/NixOS/nixpkgs/commit/2f29aa5f4ad2859a720cd4bd34a89507301a3ecb) python310Packages.caio: add missing input
* [`61913091`](https://github.com/NixOS/nixpkgs/commit/61913091143cb304b3ea2e6cd67ec60488e7d4d6) python310Packages.aiofile: 3.8.0 -> 3.8.5
* [`e8828da0`](https://github.com/NixOS/nixpkgs/commit/e8828da0421d7ba1e0c5f9b6a293aa05101efb0d) awscli2: allow composible python packageOverrides
* [`39b16d6b`](https://github.com/NixOS/nixpkgs/commit/39b16d6b3c79257312c85d81e63bd925b25681a6) python310Packages.time-machine: 2.8.2 -> 2.9.0
* [`b7302141`](https://github.com/NixOS/nixpkgs/commit/b730214152e773871fd1d6ed922dd4d20d2717bf) pkgsCross.musl64.go: fix build
* [`34464d60`](https://github.com/NixOS/nixpkgs/commit/34464d6044271c431133f0e9ce064b7bc79c9868) nixos/go-neb: Replace PermissionsStartOnly with executable prefix
* [`ba040c9d`](https://github.com/NixOS/nixpkgs/commit/ba040c9d85cf106a3b9d81fa95314d7abaae18b9) python310Packages.asgiref: 3.5.2 -> 3.6.0
* [`58af20bd`](https://github.com/NixOS/nixpkgs/commit/58af20bd05b6f1258505a4213ba9782f30bfbf2e) elasticsearchPlugins: add analysis-kuromoji plugin
* [`4a269e1a`](https://github.com/NixOS/nixpkgs/commit/4a269e1afa72e97aeef00b3eae729a61d31a1180) python310Packages.django_4: 4.1.7 -> 4.2
* [`6f50798d`](https://github.com/NixOS/nixpkgs/commit/6f50798d26b1e6c486fae4a4a99ff40ee156a06d) python310Packages.social-auth-core: 4.3.0 -> 4.4.1
* [`7109d10a`](https://github.com/NixOS/nixpkgs/commit/7109d10aab33a36571737977ef48ac99c050453b) python310Packages.django_4: enable tests on linux
* [`8bf066a0`](https://github.com/NixOS/nixpkgs/commit/8bf066a0f7c977b47caaa8c8da14a19e5cfe8f89) python310Packages.channels: Provide async-timeout in checkPhase
* [`3c473994`](https://github.com/NixOS/nixpkgs/commit/3c473994371cb7238e1293c87a9b4ab63bce8033) python310Packages.pytest-httpbin: Fix tests on darwin
* [`83869668`](https://github.com/NixOS/nixpkgs/commit/838696680d2c3d50d3a5059b225de998a417ad25) python310Packages.httpcore: Fix tests on darwin
* [`47905eee`](https://github.com/NixOS/nixpkgs/commit/47905eee941c7fceb8af5494f27c4b7a0eef3c4f) python310Packages.jedi: Pin tests to django_3
* [`0c3231e5`](https://github.com/NixOS/nixpkgs/commit/0c3231e556541839a5c3f70a0efd098fe7c2586e) freeipa: Don't use alias for python-ldap
* [`8eb04f9c`](https://github.com/NixOS/nixpkgs/commit/8eb04f9c231e29fe7bb020d3ece32c2acd0077ba) organicmaps: 2023.03.05-5 -> 2023.04.02-7
* [`3aa92164`](https://github.com/NixOS/nixpkgs/commit/3aa92164e665b21ad0a2ffd178565b70d9c83b9d) libdeflate: add meta.changelog
* [`2638fb72`](https://github.com/NixOS/nixpkgs/commit/2638fb722ec78b51695b6be2aa5affef97263c4c) systemd-boot-builder only ignores OSError "invalid argument"
* [`41d78215`](https://github.com/NixOS/nixpkgs/commit/41d7821552c21a4bcdc2743eb6f4d4c08ca6c68a) openseachest: 23.03 -> 23.03.1
* [`32d6a1d1`](https://github.com/NixOS/nixpkgs/commit/32d6a1d1dbb8aed958fcfe237fbcbf7b6463c1ff) harfbuzz: 7.0.1 -> 7.1.0
* [`7dd900af`](https://github.com/NixOS/nixpkgs/commit/7dd900af6f7a4cee31500d04910ff57f7104b56e) python3Packages.pytest-rerunfailures: 11.1.1 → 11.1.2
* [`2d7a5442`](https://github.com/NixOS/nixpkgs/commit/2d7a54427c88959933bfec2fb8f478966d67500b) xorg.libpciaccess: fix pci.ids lookups at runtime
* [`685febb5`](https://github.com/NixOS/nixpkgs/commit/685febb5e616805284ae931ffe86b112f584ccef) alterx: init at 0.0.1
* [`21c659d5`](https://github.com/NixOS/nixpkgs/commit/21c659d543f764a3274a10cc5ffd4e0603df6a1e) javaPackages.compiler.openjdk15: fix eval
* [`68ee8c7d`](https://github.com/NixOS/nixpkgs/commit/68ee8c7d393071f42efdc8c6d10ea2bfd600ffe2) python310Packages.distlib: remove unnecessary and unreproducible exe's
* [`941b891e`](https://github.com/NixOS/nixpkgs/commit/941b891e26b6ed692fc8b0296187e075af9514bc) tsm-client: use `libxcrypt-legacy` to fix build
* [`912f162c`](https://github.com/NixOS/nixpkgs/commit/912f162cbcabe02d533b920a5260957b35f66941) python310Packages.openai: 0.27.2 -> 0.27.4
* [`f7a9697f`](https://github.com/NixOS/nixpkgs/commit/f7a9697f1beee2e1067552bdd21b4340147acff7) Add self (ashleyghooper) to nixpkgs maintainers
* [`e8d059eb`](https://github.com/NixOS/nixpkgs/commit/e8d059ebd0d194cb7193aa42d16abdbd9db49016) prometheus-nut-exporter: 2.5.3 -> 3.0.0
* [`9d5d0749`](https://github.com/NixOS/nixpkgs/commit/9d5d0749e9b9b58129a88f6e55314be1f8db0993) mergerfs: 2.34.1 -> 2.35.1
* [`f36ed3c4`](https://github.com/NixOS/nixpkgs/commit/f36ed3c45330be5765d5c42371246d8872c9f55f) python3Packages.testpath: fixup optional -> optionalString
* [`3e4e464b`](https://github.com/NixOS/nixpkgs/commit/3e4e464b647d2ef5962d1c4dbef5473578ec3bfa) maintainers: add zahrun
* [`d763075d`](https://github.com/NixOS/nixpkgs/commit/d763075d5e576677badc92cc881aff4ea02f0591) obs-backgroundremoval: reinit at 0.5.16
* [`573a4769`](https://github.com/NixOS/nixpkgs/commit/573a47691ef07f9132240e5a008a8e73e4b957cf) vscode-extensions: link to proper name instead of throwing
* [`86d052f7`](https://github.com/NixOS/nixpkgs/commit/86d052f7d44af5a193d99ac84f1bc3828fcfbd43) kind: 0.17.0 -> 0.18.0
* [`416d51a2`](https://github.com/NixOS/nixpkgs/commit/416d51a21c51a369492ba302e915b39ad57c408e) go_1_20: 1.20.2 -> 1.20.3
* [`3542a6c6`](https://github.com/NixOS/nixpkgs/commit/3542a6c628ba7e6b80fb389dfa6f83b163e24db9) swagger-codegen: 2.4.19 -> 2.4.31
* [`fcb0ec3f`](https://github.com/NixOS/nixpkgs/commit/fcb0ec3f59d526e3e5836f6f7e4b4385cae3fa6d) xmp: add Darwin support
* [`acebe7b9`](https://github.com/NixOS/nixpkgs/commit/acebe7b96a4757579d45fb40b6048f2e42b383ab) python310Packages.transformers: 4.26.1 -> 4.27.4
* [`c2e14a73`](https://github.com/NixOS/nixpkgs/commit/c2e14a73e664626c74537fc5dffba84069d50418) xgcc: avoid libc.so mix between gcc and binutils-ld linker plugin
* [`3719fd8f`](https://github.com/NixOS/nixpkgs/commit/3719fd8f3451cc3c465fc268bc8bba506bf645f4) nordzy-icon-theme: 1.8.1 -> 1.8.4
* [`da5f04dd`](https://github.com/NixOS/nixpkgs/commit/da5f04dd9eed43128f4e0b4283513304ad27ea82) qt5/qtwayland: drop merged patch
* [`5451b89b`](https://github.com/NixOS/nixpkgs/commit/5451b89b28b707ea8970d8a303512e624c36628e) ankisyncd: use bundled anki version
* [`b1242bc5`](https://github.com/NixOS/nixpkgs/commit/b1242bc59c436f7e8edeb57396823d16153352bc) chatblade: init at 0.2.1
* [`bff6885e`](https://github.com/NixOS/nixpkgs/commit/bff6885e60056a7da52211dd148a01fbfafb1e42) foot: 1.13.1 -> 1.14.0
* [`6707fa40`](https://github.com/NixOS/nixpkgs/commit/6707fa40560a8244daf3bc1f79a1d38a5524c557) llvmPackages_git.compiler-rt: fixes for Darwin
* [`fca76c58`](https://github.com/NixOS/nixpkgs/commit/fca76c5810d331a3d6b2f268b6cca75b8498b016) tsm-client: fix absolute symlinks, drop openssl dependency
* [`ad2b7006`](https://github.com/NixOS/nixpkgs/commit/ad2b70061fc05a5b83232bf55572ac8c1014bbdc) nixos/tsm-client: use `lib.concatLines`
* [`19be5ac0`](https://github.com/NixOS/nixpkgs/commit/19be5ac0119740b050ddcfd8608691ebf65abf9e) mesa: fix zink by patching RPATH so it finds libvulkan.so
* [`4edf9b11`](https://github.com/NixOS/nixpkgs/commit/4edf9b117c61e4eabaedea21dd87283fa76f67e5) raycast: 1.49.0 -> 1.49.2
* [`da35fafa`](https://github.com/NixOS/nixpkgs/commit/da35fafa08de9a118a51b92cc8d0644e1afe2a5f) chickenPackages: Introduce overrides
* [`e97b960c`](https://github.com/NixOS/nixpkgs/commit/e97b960c4e9b31c5983355543e84eff7441a6038) u-Boot: add Orange Pi 3 support
* [`8353c2cc`](https://github.com/NixOS/nixpkgs/commit/8353c2cc9ce6ca2f049ee488dc8a37d9d0c0a7a5) wayland: hotfix
* [`11fc0363`](https://github.com/NixOS/nixpkgs/commit/11fc036357c11d5a09d1a8e93c6a62c604febab1) wl-clipboard: add darwin support
* [`476edc50`](https://github.com/NixOS/nixpkgs/commit/476edc5035a760e8805591b82e4696e431bb3b30) vscode-extensions.equinusocio.vsc-material-theme: init 33.8.0
* [`8e5ee715`](https://github.com/NixOS/nixpkgs/commit/8e5ee715d12efa8fe3d1071d83c141a6a03d328a) glib: 2.74.5 → 2.75.3
* [`589437f4`](https://github.com/NixOS/nixpkgs/commit/589437f4461ae8e9c97ca3d6d8b3833551b3a2a0) glib-networking: 2.74.0 → 2.76.beta
* [`7e6f9d80`](https://github.com/NixOS/nixpkgs/commit/7e6f9d80f47176e2554c70d272b9a605b31018e8) gjs: 1.74.2 → 1.75.2
* [`5e5ae463`](https://github.com/NixOS/nixpkgs/commit/5e5ae463edcaa00697cf77c859a5fc3d6aa0d26c) glibmm_2_68: 2.74.0 → 2.75.0
* [`2a9d7ea3`](https://github.com/NixOS/nixpkgs/commit/2a9d7ea3a938c4644c8913e993fada2f5f5c73a5) at-spi2-core: 2.46.0 → 2.47.1
* [`75723a05`](https://github.com/NixOS/nixpkgs/commit/75723a05c555e42aa04aaa47afbd8418fb735321) gobject-introspection: 1.74.0 → 1.75.6
* [`00bb9411`](https://github.com/NixOS/nixpkgs/commit/00bb94119d421dfc088df131f6e1657d5e2503fb) gsettings-desktop-schemas: 43.0 → 44.beta
* [`58e81cd3`](https://github.com/NixOS/nixpkgs/commit/58e81cd39cc8763b0fae9decb9aa5e47822ab5fe) pango: 1.50.12 → 1.50.13
* [`297dedf2`](https://github.com/NixOS/nixpkgs/commit/297dedf249649cdce5ca57cfa63c8e5f019a0976) python3.pkgs.pygobject3: 3.42.2 → 3.43.1
* [`8695577e`](https://github.com/NixOS/nixpkgs/commit/8695577e7d433d049e660d55e2e9ec05d0c79f49) gtksourceview5: 5.6.2 → 5.7.1
* [`2b4ca2d2`](https://github.com/NixOS/nixpkgs/commit/2b4ca2d2836a2ba11187887f12b793ebaa316eeb) gtk4: 4.8.3 → 4.9.4
* [`d7301106`](https://github.com/NixOS/nixpkgs/commit/d7301106aab77ef4ef94a8fa22d182b7874f0159) gtkmm4: 4.8.0 → 4.9.3
* [`f2832b96`](https://github.com/NixOS/nixpkgs/commit/f2832b96bad2725292b521b06fab98dd191c1af3) libadwaita: 1.2.3 → 1.3.beta
* [`4532de29`](https://github.com/NixOS/nixpkgs/commit/4532de29b317af07d09b502a18f7179251df160c) libgtop: 2.40.0 → 2.41.1
* [`6932fd0c`](https://github.com/NixOS/nixpkgs/commit/6932fd0cca5863c05601af601a5511a733c485ff) libpanel: 1.0.2 → 1.1.1
* [`602bf4d7`](https://github.com/NixOS/nixpkgs/commit/602bf4d73d5fefc11fea644f388973b723c729c4) libnotify: 0.8.1 → 0.8.2
* [`5c22534b`](https://github.com/NixOS/nixpkgs/commit/5c22534bea5df2752a5edc7f72c0921a559b6244) libsoup_3: 3.2.2 → 3.3.1
* [`a71df7fa`](https://github.com/NixOS/nixpkgs/commit/a71df7fa5c537889699ae8cfca86aa8a8666ba68) tracker: 3.4.2 → 3.5.0.beta
* [`362115f1`](https://github.com/NixOS/nixpkgs/commit/362115f1496866d5cc69af5ab82e5017176e5030) tracker-miners: 3.4.3 → 3.5.0.beta
* [`36e22722`](https://github.com/NixOS/nixpkgs/commit/36e22722f202492484258ab566ac9999f9242fd6) vte: 0.70.3 → 0.71.92
* [`97097030`](https://github.com/NixOS/nixpkgs/commit/970970308a6d1cc6d7041e88a885cd565b381e80) gnome-desktop: 43.2 → 44.beta
* [`5d67de42`](https://github.com/NixOS/nixpkgs/commit/5d67de42cfd2ba35bc7dc3004b2c25df37062637) gnome.adwaita-icon-theme: 43 → 44.beta
* [`094ea8f5`](https://github.com/NixOS/nixpkgs/commit/094ea8f534e9b0374c090463901314f30db4d059) xdg-desktop-portal-gnome: 43.1 → 44.beta
* [`8fe5ceac`](https://github.com/NixOS/nixpkgs/commit/8fe5ceac2154ff1d45843f64fc60bfad761be501) d-spy: 1.4.0 → 1.5.0
* [`7943b76b`](https://github.com/NixOS/nixpkgs/commit/7943b76b91098ad67d8fa8dbd94287a7713cb901) baobab: 43.0 → 44.beta
* [`53acb69b`](https://github.com/NixOS/nixpkgs/commit/53acb69b1c010ab942e22ee93d7e68e4a929717e) epiphany: 43.1 → 44.beta
* [`a788a546`](https://github.com/NixOS/nixpkgs/commit/a788a54676b73b2080acf7334728a6e855600260) evolution: 3.46.4 → 3.47.2
* [`e6f15038`](https://github.com/NixOS/nixpkgs/commit/e6f150382b4196f2484addbe5a1a8677d2c0254d) gnome.eog: 43.2 → 44.beta
* [`acbe0709`](https://github.com/NixOS/nixpkgs/commit/acbe0709821d1c857802f3f2f1be5c8cdc315c2a) gnome.ghex: 43.1 → 44.beta
* [`33c52f8e`](https://github.com/NixOS/nixpkgs/commit/33c52f8e3fcb570e68bec77353f2aee95fce77ae) gnome.gnome-boxes: 43.3 → 44.beta.1
* [`e5e99f60`](https://github.com/NixOS/nixpkgs/commit/e5e99f609afdd629965023314d956d07f83a7972) gnome.gnome-calendar: 43.1 → 44.beta
* [`d9a45ba4`](https://github.com/NixOS/nixpkgs/commit/d9a45ba4f3374b0fa34d04ffffd7c1ac0bbd4cd0) gnome.gnome-calculator: 43.0.1 → 44.beta
* [`ab892c8e`](https://github.com/NixOS/nixpkgs/commit/ab892c8e6e196a068be76de8a054cda74ad66d50) gnome.gnome-characters: 43.1 → 44.beta
* [`25b67275`](https://github.com/NixOS/nixpkgs/commit/25b67275d00c453b510bb8757b0dd476e209083f) gnome.gnome-clocks: 43.0 → 44.beta
* [`3a7fed34`](https://github.com/NixOS/nixpkgs/commit/3a7fed34bd09cd73e553fb6ab215c7896be6d2bd) gnome.gnome-contacts: 43.1 → 44.beta
* [`520d05be`](https://github.com/NixOS/nixpkgs/commit/520d05be7c6693f6c5f20715d6cbcf29715ec037) gnome.gnome-disk-utility: 43.0 → 44.beta
* [`4da0e953`](https://github.com/NixOS/nixpkgs/commit/4da0e953c370e7a220c2e2b615fbb7fe09b7ffc9) gnome.gnome-control-center: 43.4.1 → 44.beta
* [`d0fd1d4f`](https://github.com/NixOS/nixpkgs/commit/d0fd1d4f1f2152ab7d37e96c2b6230443d996c72) gnome.gnome-backgrounds: 43.1 → 44.beta
* [`5279ddec`](https://github.com/NixOS/nixpkgs/commit/5279ddeccc160525c22144670a0c9efc7cd8b0ea) gnome.gnome-font-viewer: 43.0 → 44.beta
* [`d56dce12`](https://github.com/NixOS/nixpkgs/commit/d56dce12f3fa9f8cf57bf3be5dc0a143ff87e48f) gnome.gnome-initial-setup: 43.2 → 44.beta
* [`b566758d`](https://github.com/NixOS/nixpkgs/commit/b566758d86700cbd8b40a19b41fb8a0bf3f31ba1) gnome.gnome-maps: 43.4 → 44.beta
* [`008a5ebb`](https://github.com/NixOS/nixpkgs/commit/008a5ebb1d308bc9956b1e9b3f12d3ad32c6cc16) gnome.gnome-music: 42.1 → 44.beta
* [`e6c58074`](https://github.com/NixOS/nixpkgs/commit/e6c58074b3131d2c1da7ddc240c3669117524a92) gnome.gnome-panel: 3.46.0 → 3.47.1
* [`c1358976`](https://github.com/NixOS/nixpkgs/commit/c13589761e740f84143b8a03342c2682a9e57ade) gnome.gnome-remote-desktop: 43.3 → 44.alpha
* [`d004cccb`](https://github.com/NixOS/nixpkgs/commit/d004cccbc82fc79c068035c8e5278f145d402d74) gnome.gnome-settings-daemon: 43.0 → 44.beta
* [`448e4372`](https://github.com/NixOS/nixpkgs/commit/448e43729540f3fa9a29d3686080f5af9c5ecf6c) gnome.mutter: 43.3 → 44.beta
* [`3cf1ccdc`](https://github.com/NixOS/nixpkgs/commit/3cf1ccdca4baace2ac6953b0f27f5d8c6eb880f7) gnome.gnome-shell: 43.3 → 44.beta
* [`f1e3ab20`](https://github.com/NixOS/nixpkgs/commit/f1e3ab20d9e4914f9b3e929aab664eccbc04a40d) gnome.gnome-shell-extensions: 43.1 → 44.beta
* [`17754118`](https://github.com/NixOS/nixpkgs/commit/17754118a95c869623d724201eccc31cb7a40758) gnome.gnome-software: 43.4 → 44.beta
* [`fdf5e4bc`](https://github.com/NixOS/nixpkgs/commit/fdf5e4bc837e614d3f655e4d243fcd0a0df2e0ea) gnome.gnome-sudoku: 43.1 → 44.beta
* [`3c9c0833`](https://github.com/NixOS/nixpkgs/commit/3c9c083309f6f0a3770cfcf8ba45f362bb8721db) gnome.gnome-system-monitor: 42.0 → 44.beta
* [`a47b88d7`](https://github.com/NixOS/nixpkgs/commit/a47b88d7663e96c4a7af3713dd3d391210ca10f6) gnome.gnome-weather: 43.0 → 44.beta
* [`37412b86`](https://github.com/NixOS/nixpkgs/commit/37412b864630a871dd374153ac5d1e5f6e648a6a) gnome.nautilus: 43.2 → 44.beta
* [`91847b3c`](https://github.com/NixOS/nixpkgs/commit/91847b3c94ea05d7d6d691066dc6ae549b2f17f5) gnome-console: 43.0 → 44.beta
* [`7f0f298f`](https://github.com/NixOS/nixpkgs/commit/7f0f298f4f48d0e0b0b0a69a1a6252c02e763360) gnome.zenity: 3.44.0 → 3.90.0
* [`ffa5d059`](https://github.com/NixOS/nixpkgs/commit/ffa5d0597f1f8b248629ac9c5bd5944dafbc552e) gnome-connections: 43.0 → 44.beta
* [`a67dd08a`](https://github.com/NixOS/nixpkgs/commit/a67dd08a66d7c4fe18652c52048a1e621cb6f677) gnome-builder: 43.6 → 44.beta
* [`a22bd5f0`](https://github.com/NixOS/nixpkgs/commit/a22bd5f0d4f09a7cbbc21a78f3e687905f4fd768) gnome-text-editor: 43.2 → 44.beta
* [`32bf3e9f`](https://github.com/NixOS/nixpkgs/commit/32bf3e9f99bac446cb64d3a0b7d993e24bfbd93d) gtk-frdp: unstable-2022-04-11 → unstable-2023-02-11
* [`971dd3a7`](https://github.com/NixOS/nixpkgs/commit/971dd3a75265b617cf04d0789605ffb4c87a0db5) evolution-data-server: 3.46.4 → 3.47.2
* [`ee55ba50`](https://github.com/NixOS/nixpkgs/commit/ee55ba505ddb82bb28a7e1c6ea17104bc3eeaabe) webkitgtk: 2.38.5 → 2.39.90
* [`0f4129cc`](https://github.com/NixOS/nixpkgs/commit/0f4129cc5a17989e84fc0af8c01091a4524df258) webkitgtk_6_0: init, webkitgtk_5_0: drop
* [`f1e4f33a`](https://github.com/NixOS/nixpkgs/commit/f1e4f33ad8a9df07b5870e9d4e07f46c4cd50ac0) libdex: init at 0.1.0
* [`4a8fff88`](https://github.com/NixOS/nixpkgs/commit/4a8fff88fc0a5651f346762c2e1993f21d388572) gnome-online-accounts: 3.46.0 → 3.47.1
* [`3b9d20a5`](https://github.com/NixOS/nixpkgs/commit/3b9d20a5116b7d37581c4baedc6b160863484b18) epiphany: 44.beta → 44.rc
* [`48d92a5e`](https://github.com/NixOS/nixpkgs/commit/48d92a5e9a47c1e392b4f6248944dbe95e0b6bea) evolution: 3.47.2 → 3.47.3
* [`ceeb9f39`](https://github.com/NixOS/nixpkgs/commit/ceeb9f39db4030a500a6855ba6c6e1395d4864c6) glib: 2.75.3 → 2.75.4
* [`7cd1411f`](https://github.com/NixOS/nixpkgs/commit/7cd1411f4eaa625dd416d6bbfc826226461a5699) gnome.gnome-calculator: 44.beta → 44.rc
* [`805156c7`](https://github.com/NixOS/nixpkgs/commit/805156c76d9b88b4622950882075c9c38824a5ef) gnome.gnome-initial-setup: 44.beta → 44.rc
* [`50c1ec94`](https://github.com/NixOS/nixpkgs/commit/50c1ec94b677d33ad8ef3d438803f5ada2593985) gnome.gnome-disk-utility: 44.beta → 44.rc
* [`efbb92a5`](https://github.com/NixOS/nixpkgs/commit/efbb92a582e83b322ea11db92bec2498bff57cd9) gnome.gnome-maps: 44.beta → 44.rc
* [`129f2ff5`](https://github.com/NixOS/nixpkgs/commit/129f2ff5de0af99218e24ad245917376b73d9b17) gnome.gnome-software: 44.beta → 44.rc
* [`9aae7ce5`](https://github.com/NixOS/nixpkgs/commit/9aae7ce5d43a7de45b5416a91fcdcc9c889b4ea8) gnome.gnome-system-monitor: 44.beta → 44.rc
* [`75221eaf`](https://github.com/NixOS/nixpkgs/commit/75221eafd291ae668a95b1671a8caffcf457fe0d) gtk-frdp: unstable-2023-02-11 → unstable-2023-03-03
* [`6d4256f8`](https://github.com/NixOS/nixpkgs/commit/6d4256f849ae41f0ca50590fc76a31cc4be50737) gnome-connections: 44.beta → 44.rc
* [`4f5e2fa3`](https://github.com/NixOS/nixpkgs/commit/4f5e2fa3c86b5622c5f739216dd73c7936917784) gnome-builder: 44.beta → 44.rc
* [`99edcdf8`](https://github.com/NixOS/nixpkgs/commit/99edcdf872e624f61b3cd1ba3a3ecfece81577cd) gnome-text-editor: 44.beta → 44.rc
* [`ce0edfa1`](https://github.com/NixOS/nixpkgs/commit/ce0edfa17c2bee600fce941fe5cfb04570aad9e9) gtksourceview5: 5.7.1 → 5.7.2
* [`68683eca`](https://github.com/NixOS/nixpkgs/commit/68683ecaea44f4123c1abef78d7a0fd916550913) gtk3: 3.24.36 → 3.24.37
* [`6267cbe7`](https://github.com/NixOS/nixpkgs/commit/6267cbe792d498e8ef4f96fe18fc2445cc16d0ad) jsonrpc-glib: 3.42.0 → 3.43.0
* [`f19f5d0a`](https://github.com/NixOS/nixpkgs/commit/f19f5d0a2745db63ebd6629ec34b5dd958a5836d) libpanel: 1.1.1 → 1.1.2
* [`bb07a5bc`](https://github.com/NixOS/nixpkgs/commit/bb07a5bced64886877aa01ba71b843679cc71ea8) pango: 1.50.13 → 1.50.14
* [`a00aece4`](https://github.com/NixOS/nixpkgs/commit/a00aece4e47c0666765f22e48b0dd48dfd16ff54) template-glib: 3.36.0 → 3.36.1
* [`83d3c54e`](https://github.com/NixOS/nixpkgs/commit/83d3c54e7baf9b3a66667bb45f956839d5ca7c4c) gnome.hitori: 3.38.4 → 44.0
* [`da6fc447`](https://github.com/NixOS/nixpkgs/commit/da6fc4476a62603ac7dd086a71880f7028195aaa) evolution-data-server: 3.47.2 → 3.47.3
* [`1d846ea9`](https://github.com/NixOS/nixpkgs/commit/1d846ea9e51997eb3c8e9a3045989848a3cbee5d) gnome.gnome-terminal: Fix updateScript
* [`bf1fbb40`](https://github.com/NixOS/nixpkgs/commit/bf1fbb4026627aa00f2c1c40b5b0b64e9db94417) libdex: 0.1.0 → 0.1.1
* [`691a11e1`](https://github.com/NixOS/nixpkgs/commit/691a11e1b685ea02b27b4a1b669bf47aa8f4711b) at-spi2-core: 2.47.1 → 2.47.90
* [`d32f25d3`](https://github.com/NixOS/nixpkgs/commit/d32f25d3eb0861bab8bdaec52f5f00d3a13b6f80) tracker: 3.5.0.beta → 3.5.0.rc
* [`64142d12`](https://github.com/NixOS/nixpkgs/commit/64142d12b0e2c224fdd5b21f85f8085c696920d5) gtk4: 4.9.4 → 4.10.0
* [`ffb35e7c`](https://github.com/NixOS/nixpkgs/commit/ffb35e7cf522c4f5166da7a7efc0856152a32b1b) libadwaita: 1.3.beta → 1.3.rc
* [`a4b81997`](https://github.com/NixOS/nixpkgs/commit/a4b8199787cefb5c7a50bb1c65b37022558871e0) libhandy: 1.8.1 → 1.8.2
* [`90008d61`](https://github.com/NixOS/nixpkgs/commit/90008d6167555ef67a485ee5f7c13d0999fd2a8a) gcr_4: 4.0.0 → 4.1.0
* [`ec56e0de`](https://github.com/NixOS/nixpkgs/commit/ec56e0de065aaca346309158cd16032fa1d78b58) gjs: 1.75.2 → 1.75.90
* [`aba06997`](https://github.com/NixOS/nixpkgs/commit/aba06997280b216436b61d59447383cb97b01e9b) tracker-miners: 3.5.0.beta → 3.5.0.rc
* [`9795950f`](https://github.com/NixOS/nixpkgs/commit/9795950fbb25bcde0dabee93bfdbf04178edfeea) baobab: 44.beta → 44.rc
* [`c8dbf996`](https://github.com/NixOS/nixpkgs/commit/c8dbf99619c4b80b72ff9c85d047f2b21a6f22aa) folks: 0.15.5 → 0.15.6
* [`cc6084e9`](https://github.com/NixOS/nixpkgs/commit/cc6084e9e33ad7c1457249dd31cea5a63f1a1497) gnome.gdm: 43.0 → 44.rc
* [`a08f0520`](https://github.com/NixOS/nixpkgs/commit/a08f052050a75832a53b422d44861d0d0c2f9a69) gnome.gnome-clocks: 44.beta → 44.rc
* [`87bf736b`](https://github.com/NixOS/nixpkgs/commit/87bf736bd7c93b188df4e9c5643444a66cef6955) gnome.gnome-characters: 44.beta → 44.rc
* [`23bb1095`](https://github.com/NixOS/nixpkgs/commit/23bb1095723507eae188dbdecdfde9f7b32ce217) gnome.gnome-contacts: 44.beta → 44.rc
* [`b1187701`](https://github.com/NixOS/nixpkgs/commit/b11877010771cc4fc6a8f91156e3f6492dfe7673) gnome.gnome-font-viewer: 44.beta → 44.rc
* [`65865b1a`](https://github.com/NixOS/nixpkgs/commit/65865b1a1a0b687fb11a7b95409d6a97b75a1f44) gnome.gnome-music: 44.beta → 44.rc
* [`c682e73c`](https://github.com/NixOS/nixpkgs/commit/c682e73c1f231806ae8c6d003b7b2757c1bc557c) gnome.gnome-control-center: 44.beta → 44.rc
* [`2f8f7972`](https://github.com/NixOS/nixpkgs/commit/2f8f7972d5292e3068655e94e783a09d1b06427c) gnome.gnome-remote-desktop: 44.alpha → 44.rc
* [`9393e8eb`](https://github.com/NixOS/nixpkgs/commit/9393e8eb33e22708e0911f6c9a8415da8c0870c9) gnome.gnome-session: 43.0 → 44.rc
* [`3415f5ec`](https://github.com/NixOS/nixpkgs/commit/3415f5ecbf91381ff7fdad22cd01eaefbb127563) gnome.gnome-settings-daemon: 44.beta → 44.rc
* [`3795fc2f`](https://github.com/NixOS/nixpkgs/commit/3795fc2f52185644bf1f18e014a6d32988c1da97) gnome.gnome-weather: 44.beta → 44.rc
* [`d7b83599`](https://github.com/NixOS/nixpkgs/commit/d7b83599bf83431513a048f9ee90e2bd4896eb6f) gnome.nautilus: 44.beta → 44.rc
* [`4af2ecdd`](https://github.com/NixOS/nixpkgs/commit/4af2ecdddcbfdb73cd4428a2ab277339d2df3f4c) gnome-user-docs: 43.0 → 44.rc
* [`b42fecba`](https://github.com/NixOS/nixpkgs/commit/b42fecbae80a9d723e9405fb9ab2b9867a84a2f3) gnome.atomix: 3.34.0 → 44.rc
* [`75538754`](https://github.com/NixOS/nixpkgs/commit/755387543f459d6edc31595a98f8d998ffb7ccca) gnome.mutter: 44.beta → 44.rc
* [`b4187a6d`](https://github.com/NixOS/nixpkgs/commit/b4187a6dfd061e02d7d53a2716d037eab5f87ce0) vte: 0.71.92 → 0.71.99
* [`96439cfe`](https://github.com/NixOS/nixpkgs/commit/96439cfed09d07580cd38786ccb97fe817885c53) gnome.gnome-terminal: 3.47.0 → 3.47.99
* [`0c35dfcc`](https://github.com/NixOS/nixpkgs/commit/0c35dfccb99cb0592e2a93c7d7007aa831924910) gnome.gnome-shell: 44.beta → 44.rc
* [`f441c242`](https://github.com/NixOS/nixpkgs/commit/f441c242d2ea71e8f704f464030875f772eafe7a) desktop-file-utils: Support Desktop Entry Specification v1.5
* [`29fcc594`](https://github.com/NixOS/nixpkgs/commit/29fcc594834aca6c5c48eb8a8a0028473c1c44be) evince: 43.1 → 44.rc
* [`6a9a7646`](https://github.com/NixOS/nixpkgs/commit/6a9a7646f93e03495a3a8ab4044a54b6c8285901) gnome.ghex: 44.beta → 44.rc
* [`06ab7358`](https://github.com/NixOS/nixpkgs/commit/06ab7358ff9c77b8ccc2cb551d6201e1daed2e51) spice: 0.15.0 → 0.15.1
* [`1301ddbd`](https://github.com/NixOS/nixpkgs/commit/1301ddbd4e25e1258d8551164b51d4ac4f06dcea) spice-gtk: 0.41 → 0.42
* [`1877a875`](https://github.com/NixOS/nixpkgs/commit/1877a8750afe882458e8656f49a799e51fe1e4fc) gnome.gnome-boxes: 44.beta.1 → 44.rc
* [`09072ccd`](https://github.com/NixOS/nixpkgs/commit/09072ccd7a2dfcd3c631d79f61a21b9f780e18f6) gnome.gnome-calendar: 44.beta → 44.rc
* [`3f53eaac`](https://github.com/NixOS/nixpkgs/commit/3f53eaacd39d0e9e73dc2477e8c7a537d78c486b) gnome.gnome-shell-extensions: 44.beta → 44.rc
* [`bba15a64`](https://github.com/NixOS/nixpkgs/commit/bba15a64e454cfea9751a88dec38e94d1afc052b) gtkmm4: 4.9.3 → 4.10.0
* [`a33f4efd`](https://github.com/NixOS/nixpkgs/commit/a33f4efd55c300e7ffe40e43a9137d25de420e99) orca: 43.1 → 44.rc
* [`5113382a`](https://github.com/NixOS/nixpkgs/commit/5113382afe98a5a1ec7771468644ef6912480429) xdg-desktop-portal-gnome: 44.beta → 44.rc
* [`703500d5`](https://github.com/NixOS/nixpkgs/commit/703500d5fd6667680a08a90acb0d9168aae0aad3) glib: 2.75.4 → 2.76.0
* [`3863e0ff`](https://github.com/NixOS/nixpkgs/commit/3863e0ff0df7dab228716be01301cb3bf556e399) gnome.zenity: 3.90.0 → 3.91.0
* [`5871a211`](https://github.com/NixOS/nixpkgs/commit/5871a21187bdba01b93ea73bc3c63e9d3643f4b0) gnome-photos: 43.0 → 44.0
* [`992dffb5`](https://github.com/NixOS/nixpkgs/commit/992dffb5b1360da3bed235da08e309c310a4abac) abiword: clean up
* [`0d8905a0`](https://github.com/NixOS/nixpkgs/commit/0d8905a0562ac4c1053176b6983bd32935512eac) webkitgtk: 2.39.90 → 2.39.91
* [`8de8fc42`](https://github.com/NixOS/nixpkgs/commit/8de8fc42230bae261992998edb9c75de53d455f8) girara: 0.3.7 → 0.3.9
* [`b54f99dc`](https://github.com/NixOS/nixpkgs/commit/b54f99dc250dec5aecf5ac7f9342d190347ac917) glibmm_2_68: 2.75.0 → 2.76.0
* [`d4d54a4e`](https://github.com/NixOS/nixpkgs/commit/d4d54a4e266ecaf074bf8b63d02d00acbebbe401) glibmm: 2.66.5 → 2.66.6
* [`5c459460`](https://github.com/NixOS/nixpkgs/commit/5c45946077cba99733ec9f9bcd304a1fae23859b) gobject-introspection: 1.75.6 → 1.76.0
* [`71619a78`](https://github.com/NixOS/nixpkgs/commit/71619a7829a3f8cc7befd3d8deacc3761120bac0) gtk4: 4.10.0 → 4.10.1
* [`bc23e0c8`](https://github.com/NixOS/nixpkgs/commit/bc23e0c8b9b13e7116b5bfc40ce012a1e0688b80) gnome.gnome-calendar: 44.rc → 44.0
* [`0aae3716`](https://github.com/NixOS/nixpkgs/commit/0aae37164a1c1b4a4a2ebeb433c3e78c2f37af5f) gnome.gnome-software: 44.rc → 44.0
* [`b77aa344`](https://github.com/NixOS/nixpkgs/commit/b77aa34466854cd8dfd7f5ab26d2da9caa2635b3) feedbackd: Fix crash exposed by GLib 2.76
* [`fbec7d14`](https://github.com/NixOS/nixpkgs/commit/fbec7d146c8bea034f9bcc827e8efb54f7de7842) gvfs: 1.50.3 → 1.50.4
* [`40df9774`](https://github.com/NixOS/nixpkgs/commit/40df9774dcbeb91f5b287ac462a23df4ee5e3dca) libadwaita: 1.3.rc → 1.3.1
* [`c98f017a`](https://github.com/NixOS/nixpkgs/commit/c98f017a794e62b74ba69b2de6382aeb72670bd1) libsoup_3: 3.3.1 → 3.4.0
* [`742558fc`](https://github.com/NixOS/nixpkgs/commit/742558fc05857249e827501da8daa21ca168da52) glib-networking: 2.76.beta → 2.76.0
* [`1939066a`](https://github.com/NixOS/nixpkgs/commit/1939066a4282c7d785378c6673ced473952813b5) evolution-data-server: 3.47.3 → 3.48.0
* [`fda0e49d`](https://github.com/NixOS/nixpkgs/commit/fda0e49d011a68b8edd27ecea7d68085938fb1f8) d-spy: 1.5.0 → 1.6.0
* [`89f5891e`](https://github.com/NixOS/nixpkgs/commit/89f5891e166e73693d98c14c9dcdc0f80610b35c) epiphany: 44.rc → 44.0
* [`c410f1ee`](https://github.com/NixOS/nixpkgs/commit/c410f1ee0787a80bca3256dfa8cbf9d1f64b8ea8) evolution: 3.47.3 → 3.48.0
* [`8a0877d6`](https://github.com/NixOS/nixpkgs/commit/8a0877d6b42f8195afbb369ec5d2a2fd6568e219) gnome.gnome-autoar: 0.4.3 → 0.4.4
* [`365557dc`](https://github.com/NixOS/nixpkgs/commit/365557dc4bcac6a118cb5309e587e0994f0b51d0) gnome.gnome-boxes: 44.rc → 44.0
* [`63a3f11c`](https://github.com/NixOS/nixpkgs/commit/63a3f11c794b6d04e77fb4df11c8a1ae263e2ad6) gnome.gnome-chess: 43.1 → 43.2
* [`8e42e0d6`](https://github.com/NixOS/nixpkgs/commit/8e42e0d6b8a6b29b01cb95b5efc639b0087950a1) gnome.gnome-clocks: 44.rc → 44.0
* [`93492597`](https://github.com/NixOS/nixpkgs/commit/9349259753a301c5294ccc2c0b3fb572348fe04c) gnome.gnome-disk-utility: 44.rc → 44.0
* [`ad302fde`](https://github.com/NixOS/nixpkgs/commit/ad302fde3b1b4d18ea63150b4315ecb8086ada0d) gnome.gnome-initial-setup: 44.rc → 44.0
* [`22b0f6b4`](https://github.com/NixOS/nixpkgs/commit/22b0f6b4d320bfe77370c01af38c2aae72a21405) gnome.gnome-sudoku: 44.beta → 44.0
* [`83c0d6aa`](https://github.com/NixOS/nixpkgs/commit/83c0d6aa8dbde721c62dbf9e97992240001ca6b8) gnome.nautilus: 44.rc → 44.0
* [`5653c20e`](https://github.com/NixOS/nixpkgs/commit/5653c20e9a099b30c1ba5b7fc772e766efb36909) gnome.atomix: 44.rc → 44.0
* [`7c8e205b`](https://github.com/NixOS/nixpkgs/commit/7c8e205bae01c62611799567bef949f999dfc76d) gnome.gnome-calculator: 44.rc → 44.0
* [`4d579a33`](https://github.com/NixOS/nixpkgs/commit/4d579a337c16675b300fdee53b7579a97291fae9) gnome.gnome-system-monitor: 44.rc → 44.0
* [`6a4d4a4c`](https://github.com/NixOS/nixpkgs/commit/6a4d4a4c94f8d6f382e54540a6dcf461cd700868) gnome-online-accounts: 3.47.1 → 3.48.0
* [`946b3562`](https://github.com/NixOS/nixpkgs/commit/946b3562e30a21c6f35188a1015b4b088fc9c754) gtksourceview5: 5.7.2 → 5.8.0
* [`5c4ca3f9`](https://github.com/NixOS/nixpkgs/commit/5c4ca3f9ce4eb8697f53002c92634abb92068027) libpanel: 1.1.2 → 1.2.0
* [`1949813a`](https://github.com/NixOS/nixpkgs/commit/1949813ae35a9b730f5b1b69814d9d1502aceab1) libdex: 0.1.1 → 0.2.0
* [`82773150`](https://github.com/NixOS/nixpkgs/commit/82773150df3de49505977f24ea82d26c041fb71c) gnome-text-editor: 44.rc → 44.0
* [`e428d39a`](https://github.com/NixOS/nixpkgs/commit/e428d39af9192621a6ca2af835e84d27a9d507f9) evince: 44.rc → 44.0
* [`30885bf1`](https://github.com/NixOS/nixpkgs/commit/30885bf1dc97569d1a8fd05a6ae1df88f7b737e0) gjs: 1.75.90 → 1.76.0
* [`ecc3f7ce`](https://github.com/NixOS/nixpkgs/commit/ecc3f7ce4e9fa5b837b3849e079d3b2a175a6114) gnome.eog: 44.beta → 44.0
* [`1c66db00`](https://github.com/NixOS/nixpkgs/commit/1c66db00e2aca3ec4319ba851c176a76c49443d1) gnome.gnome-contacts: 44.rc → 44.0
* [`334391a4`](https://github.com/NixOS/nixpkgs/commit/334391a4c56de82bbb1f6bb02054d63994faad61) gnome.gnome-maps: 44.rc → 44.0
* [`f976d638`](https://github.com/NixOS/nixpkgs/commit/f976d638a3cc77f5476a332ce197bbffba8039cd) gnome.gnome-remote-desktop: 44.rc → 44.0
* [`3beee4dd`](https://github.com/NixOS/nixpkgs/commit/3beee4dd11167069998bb7367d4e376dad48a525) gnome-builder: 44.rc → 44.0
* [`7244b02f`](https://github.com/NixOS/nixpkgs/commit/7244b02ff8d8d895f9cbc0025d623b99b51c3c54) gnome-connections: 44.rc → 44.0
* [`d20c945e`](https://github.com/NixOS/nixpkgs/commit/d20c945e02bb414fd31d1c7f11b082df6d4a612e) gnome-user-docs: 44.rc → 44.0
* [`df1ef059`](https://github.com/NixOS/nixpkgs/commit/df1ef059cd6c31627bae0f23472e606bdc3cf01b) libpeas: 1.34.0 → 1.36.0
* [`51dbeb8d`](https://github.com/NixOS/nixpkgs/commit/51dbeb8d1e58258b9993e17c2f04e8d99593947d) gnome.gnome-terminal: 3.47.99 → 3.48.0
* [`305984ae`](https://github.com/NixOS/nixpkgs/commit/305984ae0774386179102c3ef5a3e35ce691da96) at-spi2-core: 2.47.90 → 2.48.0
* [`2bcd9e26`](https://github.com/NixOS/nixpkgs/commit/2bcd9e2658570df444143878958f6d6372e1c846) gnome-desktop: 44.beta → 44.0
* [`1a1e543c`](https://github.com/NixOS/nixpkgs/commit/1a1e543c7e55171b7dae9b95bc1994a9a8f36b3c) gsettings-desktop-schemas: 44.beta → 44.0
* [`91aee608`](https://github.com/NixOS/nixpkgs/commit/91aee608316b04d65c54ee2b191e557ee7c39917) jsonrpc-glib: 3.43.0 → 3.44.0
* [`781dce32`](https://github.com/NixOS/nixpkgs/commit/781dce32a9448ca45b63c183204259c87581c630) python3.pkgs.pygobject3: 3.43.1 → 3.44.0
* [`7d9863ea`](https://github.com/NixOS/nixpkgs/commit/7d9863eae24cf0aafcc56f7b21cea8e91810d5a2) sysprof: 3.46.0 → 3.48.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
