### PR TITLE
niv devenv: update e639583e -> 5f7f76fc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e639583e5974e1d0f58ac110356f7f182d6f6004",
-        "sha256": "0j3azcczca5jw4rfmgigy22grrvksdzvnhpkr3iqg8vf789jh151",
+        "rev": "5f7f76fcb3fc2c4ac7923e8d6de0e5c7993b77a4",
+        "sha256": "0zl7xn0c1879zhm3i9cwckp1jlaxafibcgynwlws8naxnqxn1nj9",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/e639583e5974e1d0f58ac110356f7f182d6f6004.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/5f7f76fcb3fc2c4ac7923e8d6de0e5c7993b77a4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@e639583e...5f7f76fc](https://github.com/cachix/devenv/compare/e639583e5974e1d0f58ac110356f7f182d6f6004...5f7f76fcb3fc2c4ac7923e8d6de0e5c7993b77a4)

* [`b2f0e197`](https://github.com/cachix/devenv/commit/b2f0e197d56fddddb8477a23bf6b03a1bd784f16) python: only write POETRY_CHECKSUM_FILE when poetry install succeeds
* [`776d51ba`](https://github.com/cachix/devenv/commit/776d51baa939dbd2af18e07a82493e70cc6bac2d) python: poetry: create virtualenv using poetry
* [`90cbc14b`](https://github.com/cachix/devenv/commit/90cbc14b26d775e3f06354c73a84f7c34680a657) python: poetry: always use pkgs.poetry
* [`fecbe8c3`](https://github.com/cachix/devenv/commit/fecbe8c319bf4edd414aca6c53fa09d8cb3f474f) python: venv: use .venv instead of .devenv/state/venv
* [`adfd129b`](https://github.com/cachix/devenv/commit/adfd129b6b77423a248f7b8e47d7698705a9f4fa) python: extract venv path into variable
* [`b4c0e1ce`](https://github.com/cachix/devenv/commit/b4c0e1ced2d18549ec03607524d2192756db5b5b) python: move venv to DEVENV_STATE
* [`b992aa27`](https://github.com/cachix/devenv/commit/b992aa273a1cf5a7db5a37a4080173821aee6089) docs: fix example for overlays
* [`86ba8df8`](https://github.com/cachix/devenv/commit/86ba8df8d4bd3b7cfa417b4865a78200009b1096) Auto generate docs/reference/options.md
* [`62773b87`](https://github.com/cachix/devenv/commit/62773b870223a136670218291ec971f5eb5d335d) templates: use nix-systems to handle defaults systems
* [`5f7f76fc`](https://github.com/cachix/devenv/commit/5f7f76fcb3fc2c4ac7923e8d6de0e5c7993b77a4) templates: remove unneeded line
