### PR TITLE
niv powerlevel10k: update fb1287fe -> c1b5b2c8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "fb1287fedbb877201572d164ba0bad5c9d375b4f",
-        "sha256": "00bdj2w1sjkk1xx3jmqx7jzw8hi0kpsgpjxpr7gniv1j9a6m2crs",
+        "rev": "c1b5b2c8aab51b2a5b0d29d078e3cb53bb4c46bb",
+        "sha256": "0f3qpqpvamhz2hkwf4rpr203rm8f1n2w02716dwmbm4qk3p2hhjp",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/fb1287fedbb877201572d164ba0bad5c9d375b4f.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/c1b5b2c8aab51b2a5b0d29d078e3cb53bb4c46bb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@fb1287fe...c1b5b2c8](https://github.com/romkatv/powerlevel10k/compare/fb1287fedbb877201572d164ba0bad5c9d375b4f...c1b5b2c8aab51b2a5b0d29d078e3cb53bb4c46bb)

* [`bab655fb`](https://github.com/romkatv/powerlevel10k/commit/bab655fb1f457de5ae5ad9f3c425a2e5186aa6b8) do not infer nix_shell from PATH unless POWERLEVEL9K_NIX_SHELL_INFER_FROM_PATH is set to true ([romkatv/powerlevel10k⁠#2246](https://togithub.com/romkatv/powerlevel10k/issues/2246))
* [`f27d192e`](https://github.com/romkatv/powerlevel10k/commit/f27d192eb20cbf9cf690a372f342110b7347c8d6) bump version
* [`954f38d5`](https://github.com/romkatv/powerlevel10k/commit/954f38d589212753e1c767f56b3a3fed9cfacfe2) use less surprising input for clock option
