### PR TITLE
niv devenv: update 5f7f76fc -> c67a0fcf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "5f7f76fcb3fc2c4ac7923e8d6de0e5c7993b77a4",
-        "sha256": "0zl7xn0c1879zhm3i9cwckp1jlaxafibcgynwlws8naxnqxn1nj9",
+        "rev": "c67a0fcf40a384f955d21494cb6d72a562cf82cf",
+        "sha256": "0qymmz7hk205nl6labxdhqxq4sziycfyff1jnp8flcqrv6zj12bj",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/5f7f76fcb3fc2c4ac7923e8d6de0e5c7993b77a4.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/c67a0fcf40a384f955d21494cb6d72a562cf82cf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@5f7f76fc...c67a0fcf](https://github.com/cachix/devenv/compare/5f7f76fcb3fc2c4ac7923e8d6de0e5c7993b77a4...c67a0fcf40a384f955d21494cb6d72a562cf82cf)

* [`cbdef1f8`](https://github.com/cachix/devenv/commit/cbdef1f80c17594be7708f7db3e43c86d4c5b0ce) Bug report proofread
* [`b38a119d`](https://github.com/cachix/devenv/commit/b38a119dff2ba35014e3dea8be5d39c3b53a1a17) Using with flakes proofread
* [`0526e29b`](https://github.com/cachix/devenv/commit/0526e29bca1884f6d469544166b0627260623028) contributing.md language edit
* [`aa43bef0`](https://github.com/cachix/devenv/commit/aa43bef0316f8d612ded3b44cff7c0f014b57ac2) containers.md language edit
* [`15c693b4`](https://github.com/cachix/devenv/commit/15c693b49f527ff6a56b70cc0c2748592c680fca) roadmap.md language edit
* [`0932d6de`](https://github.com/cachix/devenv/commit/0932d6decf9221bbab83af208407535360c06f03) examples.md language edit
* [`9bdfc45a`](https://github.com/cachix/devenv/commit/9bdfc45a32cde73650ff3014f205de23f86dbd14) languages.md add title
* [`b2d04353`](https://github.com/cachix/devenv/commit/b2d04353ef16f51b03c6ec50f74a2aa649ef5f7a) processes.md add title
* [`d00e34ea`](https://github.com/cachix/devenv/commit/d00e34ea5d6c156a6fe202ee9db87f35c98bb728) Composing using imports add title
* [`4aeffcf0`](https://github.com/cachix/devenv/commit/4aeffcf0677f83836f3ec3a284b701b6512514b4) Garbage collection add title
* [`d10cbe5e`](https://github.com/cachix/devenv/commit/d10cbe5e3d13f3ee6d82a6cb0a8308da9624fa1c) GitHub Actions add title
* [`4f6b4dee`](https://github.com/cachix/devenv/commit/4f6b4dee418ad6d21c5d29a5fa4815f7f29d3087) feat(redis): Added readiness_probe using redis-cli
* [`7ca42d72`](https://github.com/cachix/devenv/commit/7ca42d725db7032056c9f10ae3942db64b703aa5) gitignore: add more defaults
* [`a9ccb464`](https://github.com/cachix/devenv/commit/a9ccb4648d5cf08db7920eaabf2afe897b8b2d92) pre-commit: inform about the config file
* [`0ce35c9f`](https://github.com/cachix/devenv/commit/0ce35c9f867583d6ac59bb540eb968e1b3ad823f) direnv: inform about the default directory
* [`c67a0fcf`](https://github.com/cachix/devenv/commit/c67a0fcf40a384f955d21494cb6d72a562cf82cf) mkcert: pin
