### PR TITLE
niv home-manager: update ec94ad91 -> 15dcd096

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "knl",
         "repo": "home-manager",
-        "rev": "ec94ad9198dbb7f6632ea24647003044358d131b",
-        "sha256": "0nb8fjdsi9hw1g9p6h7qi6rk7q221z8zp53rhbvgwnpkvw5xvg93",
+        "rev": "15dcd096762f884d06088b31f35310e606f76549",
+        "sha256": "0h8rf83qm8kp81lpx7h95q80mhfwjihrw9clxv7s9vl32sn9b4j2",
         "type": "tarball",
-        "url": "https://github.com/knl/home-manager/archive/ec94ad9198dbb7f6632ea24647003044358d131b.tar.gz",
+        "url": "https://github.com/knl/home-manager/archive/15dcd096762f884d06088b31f35310e606f76549.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: unbroken
Commits: [knl/home-manager@ec94ad91...15dcd096](https://github.com/knl/home-manager/compare/ec94ad9198dbb7f6632ea24647003044358d131b...15dcd096762f884d06088b31f35310e606f76549)

* [`7efca2ca`](https://github.com/knl/home-manager/commit/7efca2ca18062791cbaa838f4d3e23d629bb1473) files: allow disabling creation of a file
* [`8f39c67c`](https://github.com/knl/home-manager/commit/8f39c67c4c87c137f33858123abadf70e4f00e76) ci: bump DeterminateSystems/update-flake-lock from 15 to 16
* [`bb4b25b3`](https://github.com/knl/home-manager/commit/bb4b25b302dbf0f527f190461b080b5262871756) bash: format using nixfmt
* [`08a778d8`](https://github.com/knl/home-manager/commit/08a778d80308353f4f65c9dcd3790b5da02d6306) papis: add module
* [`69696fe5`](https://github.com/knl/home-manager/commit/69696fe53940562a047bf2ec675cc1dcd1bc09b3) wlogout: add module ([knl/home-manager⁠#3629](https://togithub.com/knl/home-manager/issues/3629))
* [`1c6f3054`](https://github.com/knl/home-manager/commit/1c6f3054ca36466a45972bf163fa934c33d69a15) rbenv: add module
* [`1d94de56`](https://github.com/knl/home-manager/commit/1d94de5604935591494eeb6ea80bc34ac84a9f23) pass-secret-service: various improvements
* [`782cb855`](https://github.com/knl/home-manager/commit/782cb855b2f23c485011a196c593e2d7e4fce746) home-manager: edit `homeManagerConfiguration` err ([knl/home-manager⁠#3632](https://togithub.com/knl/home-manager/issues/3632))
* [`2f62da98`](https://github.com/knl/home-manager/commit/2f62da9837f6f38c329c9d763df2fc152a97a49b) git: unset `pager` while using difftastic ([knl/home-manager⁠#3633](https://togithub.com/knl/home-manager/issues/3633))
* [`4a958524`](https://github.com/knl/home-manager/commit/4a958524903e6019f5f69a23e0c0f16e5af01eb0) flake.lock: Update ([knl/home-manager⁠#3619](https://togithub.com/knl/home-manager/issues/3619))
* [`d1c7730b`](https://github.com/knl/home-manager/commit/d1c7730bb707bf8124d997952f7babd2a281ae68) services.autorandr: add module
* [`e2c1756e`](https://github.com/knl/home-manager/commit/e2c1756e3ae001ca8696912016dd31cb1503ccf3) mbsync: make passwordCommand escaping consistent ([knl/home-manager⁠#3630](https://togithub.com/knl/home-manager/issues/3630))
* [`2ffc6d64`](https://github.com/knl/home-manager/commit/2ffc6d64961cb46d58d80fc344795837d6f227c2) tmux: mouse support ([knl/home-manager⁠#3642](https://togithub.com/knl/home-manager/issues/3642))
* [`e716961d`](https://github.com/knl/home-manager/commit/e716961d780b70295076f1b16f9174ea31273f2a) modules: java: fix setting JAVA_HOME ([knl/home-manager⁠#3638](https://togithub.com/knl/home-manager/issues/3638))
* [`ffc022b6`](https://github.com/knl/home-manager/commit/ffc022b6a7fcd8ae1d9310dc1713257f0aaf5f8e) vim-vint: add module ([knl/home-manager⁠#3604](https://togithub.com/knl/home-manager/issues/3604))
* [`ca69be93`](https://github.com/knl/home-manager/commit/ca69be9335def2e31525ea0dc7abd5062700f5ab) borgmatic: Do not inhibit idle in service ([knl/home-manager⁠#3637](https://togithub.com/knl/home-manager/issues/3637))
* [`6d2ba465`](https://github.com/knl/home-manager/commit/6d2ba4654d6fc7f7eac504938316889058b1fe0a) home-manager: pass --refresh to nix ([knl/home-manager⁠#3624](https://togithub.com/knl/home-manager/issues/3624))
* [`e3f28ddb`](https://github.com/knl/home-manager/commit/e3f28ddb0dc270819b0a4b5563ca34bdc995721d) tmux: fix secureSocket environment variable ([knl/home-manager⁠#3593](https://togithub.com/knl/home-manager/issues/3593))
* [`9f4268e6`](https://github.com/knl/home-manager/commit/9f4268e6b630497e289b18473775dff9c2d6635d) firefox: support passing any json value to settings ([knl/home-manager⁠#3580](https://togithub.com/knl/home-manager/issues/3580))
* [`9621e9ab`](https://github.com/knl/home-manager/commit/9621e9ab80a038cd11c7cfcae4df46a59d62b16a) programs.neovim: add extraLuaConfig ([knl/home-manager⁠#3639](https://togithub.com/knl/home-manager/issues/3639))
* [`c43d4a3d`](https://github.com/knl/home-manager/commit/c43d4a3d6d9ef8ddbe2438362f5c775b4186000b) firefox: manage add-ons per-profile
* [`b70362bf`](https://github.com/knl/home-manager/commit/b70362bf9bdefcf1042af3848f7311171b07a7cc) nix: fix package assertion
* [`d6b1d426`](https://github.com/knl/home-manager/commit/d6b1d426826a437b9da00a1197837e690e4bc8e1) activation-init.sh: remove shebang, execute bit
* [`17dc5939`](https://github.com/knl/home-manager/commit/17dc5939309bb24c02133d67341fe9a791523c6f) modules: add platform assertions
* [`edb36453`](https://github.com/knl/home-manager/commit/edb364538383a54528ef485e182ee4105ebda532) systemd: remove platform assertion
* [`7529a267`](https://github.com/knl/home-manager/commit/7529a2674a34309bec6117df3a6c0b4906b2c313) scmpuff: clean up tests
* [`02ac6675`](https://github.com/knl/home-manager/commit/02ac66755701f65bfebf7f3feb73030ae66a4f49) docs: bump nmd
* [`6d95d98b`](https://github.com/knl/home-manager/commit/6d95d98b6b4876c9ab589327331196b2893581c5) xsuspender: fix typo that made debug option a noop ([knl/home-manager⁠#3653](https://togithub.com/knl/home-manager/issues/3653))
* [`d7a5a28f`](https://github.com/knl/home-manager/commit/d7a5a28fc30d7576061ccfdd3e8382e7ab56ce19) vscode: add extensions.json file in extensions dir ([knl/home-manager⁠#3588](https://togithub.com/knl/home-manager/issues/3588))
* [`e631d78d`](https://github.com/knl/home-manager/commit/e631d78ddfbf808fd1cfc4d79039a1b3acda5bed) vscode: fix erroneous application of lib.optional ([knl/home-manager⁠#3655](https://togithub.com/knl/home-manager/issues/3655))
* [`1232d0e1`](https://github.com/knl/home-manager/commit/1232d0e13305f462a5a7c29584f50eb232cc4ba0) Revert "mbsync: make passwordCommand escaping consistent" ([knl/home-manager⁠#3657](https://togithub.com/knl/home-manager/issues/3657))
* [`2dce7f1a`](https://github.com/knl/home-manager/commit/2dce7f1a55e785a22d61668516df62899278c9e4) tests: fix formatting (tab -> spaces) ([knl/home-manager⁠#3660](https://togithub.com/knl/home-manager/issues/3660))
* [`da72e6fc`](https://github.com/knl/home-manager/commit/da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5) keychain: add nushell integration
* [`5ffb0f1f`](https://github.com/knl/home-manager/commit/5ffb0f1f818ff0d435b16a4934a24c6277d3fde7) tests: fix gnupg stub ([knl/home-manager⁠#3685](https://togithub.com/knl/home-manager/issues/3685))
* [`81f16a1e`](https://github.com/knl/home-manager/commit/81f16a1e3c07bc3dffb9733f4ce5a344bf5b4c43) prezto: add missing use of yesNo
* [`9e9a0e43`](https://github.com/knl/home-manager/commit/9e9a0e43fe6b5e47d77da1dd14b26d9b0326cb5d) owncloud-client: add package option
* [`aa4c6850`](https://github.com/knl/home-manager/commit/aa4c685096b68f2d5efe5d9a63e5ce42a882af53) Translate using Weblate (Portuguese)
* [`bdcd1bde`](https://github.com/knl/home-manager/commit/bdcd1bde4e50466ebb9cd6c74e0adb5959014b76) Add translation using Weblate (Portuguese)
* [`ae6f1895`](https://github.com/knl/home-manager/commit/ae6f1895d561aa58f0c8f2bcb95100b5ce05ea18) Translate using Weblate (Portuguese)
* [`6ea50104`](https://github.com/knl/home-manager/commit/6ea501044b52fb98f9e37a5b4f79dc5de74c6c5c) ci: bump cachix/install-nix-action from 18 to 19
* [`ebb21e1b`](https://github.com/knl/home-manager/commit/ebb21e1bf6b921a60ee314c4246785b61f5ecbf2) direnv: nushell integration should not be read only
* [`72ce74d3`](https://github.com/knl/home-manager/commit/72ce74d3eae78a6b31538ea7ebe0c1fcf4a10f7a) qt: auto-detect style package from name ([knl/home-manager⁠#3692](https://togithub.com/knl/home-manager/issues/3692))
* [`5e889b38`](https://github.com/knl/home-manager/commit/5e889b385c43a8a72ada5ebc4888bbebb129b438) mpd-mpris: add module
* [`c7c69ec4`](https://github.com/knl/home-manager/commit/c7c69ec40543d5c088abf0af816aff7b738ccaa2) launchd: fix example of StartCalendarInterval
* [`564b82b3`](https://github.com/knl/home-manager/commit/564b82b3542026e7fb5d0da16c56ae3e40e5c9dd) firefox: fix search options without a default engine
* [`4295fdfa`](https://github.com/knl/home-manager/commit/4295fdfa6b0005c32f2e1f0b732faf5810c1bc7f) avizo: add module
* [`664945b3`](https://github.com/knl/home-manager/commit/664945b3e09b4551c4e63e16efebd493cf5eac74) starship: Use mkEnableOption ([knl/home-manager⁠#3701](https://togithub.com/knl/home-manager/issues/3701))
* [`693d76ee`](https://github.com/knl/home-manager/commit/693d76eeb84124cc3110793ff127aeab3832f95c) programs.gpg: update references to respective manpages ([knl/home-manager⁠#3648](https://togithub.com/knl/home-manager/issues/3648))
* [`7b6e5071`](https://github.com/knl/home-manager/commit/7b6e5071518c726b9e9371bbfc8bb9beb81f50b9) docs: slight improvement of Flake documentation
* [`d68cd7f7`](https://github.com/knl/home-manager/commit/d68cd7f7df34331b46ac8a9bca79aa13117b4bfb) flake: avoid recursive set
* [`fc3432ba`](https://github.com/knl/home-manager/commit/fc3432bac27d0dd3ffd8625d2724c41f86b8ad10) home-manager: make `--version` report 23.05-pre
* [`bf76afbb`](https://github.com/knl/home-manager/commit/bf76afbb06b77237507b5279d0d555e05b5cc7f7) Set the SHELL environment variable for keychain in .xsession ([knl/home-manager⁠#3695](https://togithub.com/knl/home-manager/issues/3695))
* [`635bbcdd`](https://github.com/knl/home-manager/commit/635bbcdd6f8e11799f31d004f933fdb9cd3fff5d) modules/git: make options passed to `less(1)` for `diff-so-fancy` configurable ([knl/home-manager⁠#3704](https://togithub.com/knl/home-manager/issues/3704))
* [`ab7c8f4a`](https://github.com/knl/home-manager/commit/ab7c8f4a8427bfcaf01a46bab974298cc27bc1f5) modules/redshift-gammastep: install package into the profile ([knl/home-manager⁠#3710](https://togithub.com/knl/home-manager/issues/3710))
* [`305daba4`](https://github.com/knl/home-manager/commit/305daba44a9df57738cffc67c08129005a25579a) aerc: update auth mechanisms ([knl/home-manager⁠#3714](https://togithub.com/knl/home-manager/issues/3714))
* [`4bac3418`](https://github.com/knl/home-manager/commit/4bac34186886f8d484791702f32ec371f8c7a81e) `exa`: add more options ([knl/home-manager⁠#3505](https://togithub.com/knl/home-manager/issues/3505))
* [`9438e56a`](https://github.com/knl/home-manager/commit/9438e56a7b7df5e02091027dccdd8d86768f1a2d) .github: pin nix 2.13 in workflows ([knl/home-manager⁠#3720](https://togithub.com/knl/home-manager/issues/3720))
* [`ddcbf676`](https://github.com/knl/home-manager/commit/ddcbf676ba422ae3dc0c386bc5001acbebbf0b0d) specialization: fix `name` conflict inside NixOS module ([knl/home-manager⁠#3718](https://togithub.com/knl/home-manager/issues/3718))
* [`ef7d3165`](https://github.com/knl/home-manager/commit/ef7d316578367ed7732a21eede6c79546a36124f) exa: always configure `exa` alias ([knl/home-manager⁠#3721](https://togithub.com/knl/home-manager/issues/3721))
* [`f8077880`](https://github.com/knl/home-manager/commit/f8077880359b72bbd290ee216b105f200a6f7cc7) docs: add chapter on 3rd-party extensions
* [`db1c2262`](https://github.com/knl/home-manager/commit/db1c22626ad1058834f043eae7d80bbf2a8e1532) mako: programs.mako -> services.mako ([knl/home-manager⁠#3265](https://togithub.com/knl/home-manager/issues/3265))
* [`547a3bc8`](https://github.com/knl/home-manager/commit/547a3bc8d464cb2a22e4cf0dbbb746f8c654151a) git: allow tags to be unsigned when signing.signByDefault=true ([knl/home-manager⁠#3479](https://togithub.com/knl/home-manager/issues/3479))
* [`b9e3a298`](https://github.com/knl/home-manager/commit/b9e3a29864798d55ec1d6579ab97876bb1ee9664) recoll: fix generation of string lists
* [`3c18113b`](https://github.com/knl/home-manager/commit/3c18113bd768ae925b383867d1821563391ecab6) mpd: add `extraArgs` ([knl/home-manager⁠#3735](https://togithub.com/knl/home-manager/issues/3735))
* [`68ba5957`](https://github.com/knl/home-manager/commit/68ba59578352815ac372b17fb3df9db39afb1407) xfconf: fix dbus may not be started in the startup of NixOS. ([knl/home-manager⁠#3707](https://togithub.com/knl/home-manager/issues/3707))
* [`e314f6cf`](https://github.com/knl/home-manager/commit/e314f6cf211e480ab8fa101a017e593a9bb9f21b) broot: remove unnecessary IFD
* [`04d6cad6`](https://github.com/knl/home-manager/commit/04d6cad67557512452decbfe888c68fa11338a96) flake.lock: Update ([knl/home-manager⁠#3654](https://togithub.com/knl/home-manager/issues/3654))
* [`defd16c5`](https://github.com/knl/home-manager/commit/defd16c5d5b271ff6cd7f72a108f711ebf31c936) Translate using Weblate (Japanese)
* [`0f3dfc16`](https://github.com/knl/home-manager/commit/0f3dfc16d0e62f568bf08056de1a37832e900c32) home-manager: fix nix-env uninstall command
* [`f6981648`](https://github.com/knl/home-manager/commit/f69816489d5bcd1329c50fb4a7035a9a9dc19a3b) home-manager: handle missing per-user profiles directory
* [`36999b8d`](https://github.com/knl/home-manager/commit/36999b8d19eb6eebb41983ef017d7e0095316af2) docs: simplify flake-specific instructions in the documentation ([knl/home-manager⁠#3737](https://togithub.com/knl/home-manager/issues/3737))
* [`fce9dbfe`](https://github.com/knl/home-manager/commit/fce9dbfeb4fa0b0878cf4ebd375d4f2b5acc87b0) lib: add generator for KDL
* [`c03d1e75`](https://github.com/knl/home-manager/commit/c03d1e75a1e5e10384e2836cdd6537a4e94be89a) zellij: switch config lang from yaml to kdl for 0.32.0
* [`7224d7c5`](https://github.com/knl/home-manager/commit/7224d7c54c5fc74cdf60b208af6148ed3295aa32) zellij: fix typo
* [`bf5712c5`](https://github.com/knl/home-manager/commit/bf5712c5865e543fb3f4796511d4cf51efd841b1) home-manager: slightly expand option description
* [`a410f8d6`](https://github.com/knl/home-manager/commit/a410f8d658d16e65ecd166ef672e01661aef9a99) Translate using Weblate (Norwegian Bokmål)
* [`9a8e3ad2`](https://github.com/knl/home-manager/commit/9a8e3ad21aa321122ae360fb076e5f8737d6429a) Update translation files
* [`564aea1c`](https://github.com/knl/home-manager/commit/564aea1c4331c003eb7c8ac6e0593ad75473964b) Translate using Weblate (Ukrainian)
* [`609bc04c`](https://github.com/knl/home-manager/commit/609bc04c21ae4117d524a72357b55189df7b0235) Translate using Weblate (Swedish)
* [`4bc153e9`](https://github.com/knl/home-manager/commit/4bc153e9c83525f23ead72c72c5574967f4f010d) Translate using Weblate (Spanish)
* [`7783e1b9`](https://github.com/knl/home-manager/commit/7783e1b949f84d8d7a1c2e146f2bfa504b7f41db) Add translation using Weblate (Ukrainian)
* [`dd6c5acd`](https://github.com/knl/home-manager/commit/dd6c5acd86e8a05b7dde00c8149c522fa6312c2e) Translate using Weblate (Ukrainian)
* [`118a9f79`](https://github.com/knl/home-manager/commit/118a9f79fd45748ec4a7c9dd17e04aec08e0d070) Translate using Weblate (Japanese)
* [`7fe539df`](https://github.com/knl/home-manager/commit/7fe539dfbba8a158a455b54697d1bd7e97b37c60) Fix path to Kitty theme files ([knl/home-manager⁠#3764](https://togithub.com/knl/home-manager/issues/3764))
* [`24c1a633`](https://github.com/knl/home-manager/commit/24c1a6335e3da6a3ecf82f33ac50c2ad66aee346) vscode: add options for global and user snippets ([knl/home-manager⁠#3765](https://togithub.com/knl/home-manager/issues/3765))
* [`8d2b8985`](https://github.com/knl/home-manager/commit/8d2b898532849ba0726b546a2ba52e0d2e5c2501) docs: update description of uninstall command
* [`da15dd1f`](https://github.com/knl/home-manager/commit/da15dd1f274d5de616f1dfd77a262d833b0726c9) docs: minor typographic improvement in release note
* [`cae54dc4`](https://github.com/knl/home-manager/commit/cae54dc45c0d61c99c1dc8b04bc42f36c76f9771) home-manager: change default configuration home
* [`2fa7d286`](https://github.com/knl/home-manager/commit/2fa7d2869951a4c90d6cac4c7587f2d37a8d55dc) Translate using Weblate (Korean)
* [`af4e1af1`](https://github.com/knl/home-manager/commit/af4e1af1ae207f1dea4ad4ed5cc47f635a03de03) Update translation files
* [`215af625`](https://github.com/knl/home-manager/commit/215af6252d939a936b41dbd85e94d22e874ad990) atuin: add disable key options ([knl/home-manager⁠#3754](https://togithub.com/knl/home-manager/issues/3754))
* [`5b798e2b`](https://github.com/knl/home-manager/commit/5b798e2b99c64b5f9f533ef75663b7a3e3725d96) Translate using Weblate (Swedish)
* [`85196310`](https://github.com/knl/home-manager/commit/85196310e1aceb1d91ff4fb5ac5cd6e1f630a66a) Translate using Weblate (Spanish)
* [`2bd74d92`](https://github.com/knl/home-manager/commit/2bd74d92bc7345f323ebcbfeb631d5cf4067ed8e) ci: bump DeterminateSystems/update-flake-lock from 16 to 17
* [`95201931`](https://github.com/knl/home-manager/commit/95201931f2e733705296d1d779e70793deaeb909) qutebrowser: allow for specifying multiple commands in bindings ([knl/home-manager⁠#3322](https://togithub.com/knl/home-manager/issues/3322))
* [`c8cb60b8`](https://github.com/knl/home-manager/commit/c8cb60b8a15c90b2bbc416c182532620602edb48) home-manager: add `init` command to main tool
* [`5e94669f`](https://github.com/knl/home-manager/commit/5e94669f8ea8d697b1a00b916b2a86909f8c4ff5) home.pointerCursor: set common XCURSOR_* environment variables by default ([knl/home-manager⁠#3663](https://togithub.com/knl/home-manager/issues/3663))
* [`b832390d`](https://github.com/knl/home-manager/commit/b832390db376fbbf44115904cfab6680fb42e076) i3status-rust: update it to handle 0.30.x releases ([knl/home-manager⁠#3773](https://togithub.com/knl/home-manager/issues/3773))
* [`c7231c06`](https://github.com/knl/home-manager/commit/c7231c06e97170f7834922af698bca4ea3016753) starship: condition nushell integration on nushell 0.73+ ([knl/home-manager⁠#3776](https://togithub.com/knl/home-manager/issues/3776))
* [`62cc5d81`](https://github.com/knl/home-manager/commit/62cc5d815cfa288afe5f82b732ad727f2809fef9) .github: bump install-nix-action ([knl/home-manager⁠#3723](https://togithub.com/knl/home-manager/issues/3723))
* [`3239e0b4`](https://github.com/knl/home-manager/commit/3239e0b40f242f47bf6c0c37b2fd35ab3e76e370) Revert "starship: condition nushell integration on nushell 0.73+" ([knl/home-manager⁠#3778](https://togithub.com/knl/home-manager/issues/3778))
* [`bcc417b8`](https://github.com/knl/home-manager/commit/bcc417b80f3bef3e0cf21160850525d8a03387e6) exa: removed stale comment ([knl/home-manager⁠#3789](https://togithub.com/knl/home-manager/issues/3789))
* [`1b8bf5c3`](https://github.com/knl/home-manager/commit/1b8bf5c3270386a1b6850bd77d79dbdbaf0d7a7c) home-manager: avoid stray error message
* [`7217ca16`](https://github.com/knl/home-manager/commit/7217ca165b33ab3e002cc7a79ce16fd1a1500ff1) Update translation files
* [`69bf0fed`](https://github.com/knl/home-manager/commit/69bf0fedbe1d0cd80946d23e762fea78761e6018) Translate using Weblate (Swedish)
* [`abc8378e`](https://github.com/knl/home-manager/commit/abc8378e213e62c500047d923266f9b20ca1c181) Translate using Weblate (Spanish)
* [`c509a7d5`](https://github.com/knl/home-manager/commit/c509a7d5ff58ee91e73246bf8b9af5308339cc00) Translate using Weblate (Ukrainian)
* [`7720f200`](https://github.com/knl/home-manager/commit/7720f200ea3eb9ad21646354afac0644dd011ca6) home-manager: make generated home.nix more helpful
* [`2bf15d38`](https://github.com/knl/home-manager/commit/2bf15d3835030906e727abd0e1533b98a4fb916c) docs: reference Stylix in 3rd-party extensions
* [`2ddd4e15`](https://github.com/knl/home-manager/commit/2ddd4e151d6d4ac56bb1c93f4b15b22dd2d9d0d5) borgmatic: change type of extraConfigOption
* [`a8f5ca23`](https://github.com/knl/home-manager/commit/a8f5ca239f8f17ba68e75f97ba995f93c3f1a04b) borgmatic: optionally exclude HM symlinks from backup
* [`e386ec64`](https://github.com/knl/home-manager/commit/e386ec640e16dc91120977285cb8c72c77078164) mpv: add scriptOpts option, fix tests ([knl/home-manager⁠#3491](https://togithub.com/knl/home-manager/issues/3491))
* [`e60080dd`](https://github.com/knl/home-manager/commit/e60080ddfb45f6e667d8cac3ca20922ddbaf4e5b) listenbrainz-mpd: add module
* [`486ba3de`](https://github.com/knl/home-manager/commit/486ba3de4ecca3ef8371c20b0c53866d61e97dbd) copyq: add module
* [`c6a7bc90`](https://github.com/knl/home-manager/commit/c6a7bc90cab372977e76f8fa1090ee984b99de12) zathura: add documentation for mode-specific mappings ([knl/home-manager⁠#3797](https://togithub.com/knl/home-manager/issues/3797))
* [`363c46b2`](https://github.com/knl/home-manager/commit/363c46b2480f1b73ec37cf68caac61f5daa82a2e) programs/alot: make Sent and Drafts folder optional ([knl/home-manager⁠#3798](https://togithub.com/knl/home-manager/issues/3798))
* [`db37c537`](https://github.com/knl/home-manager/commit/db37c537603d1d45d022cc0666ad45197455b364) docs: bump nmd
* [`a34aaad2`](https://github.com/knl/home-manager/commit/a34aaad2ae159b66306ced0cbfa1eefac8c4343e) gpg: fix URL of key in test case
* [`2f8d24b7`](https://github.com/knl/home-manager/commit/2f8d24b7f57fdd404defe84626b08f3318612f8c) zoxide: enable nushell integration
* [`885a504f`](https://github.com/knl/home-manager/commit/885a504f80227b98d137a84a888bf7faa36d00dc) syncthing: add Darwin support
* [`3ace6a31`](https://github.com/knl/home-manager/commit/3ace6a31dd859710e7b7666a9d456b611f9376dc) im/fcitx: drop as fcitx 4 has been removed from nixpkgs ([knl/home-manager⁠#3804](https://togithub.com/knl/home-manager/issues/3804))
* [`99680311`](https://github.com/knl/home-manager/commit/99680311f1d94632e75da1b8f78091220684b4bf) hstr: add module
* [`225d1fb7`](https://github.com/knl/home-manager/commit/225d1fb77e6c9f9be1ffd65c8e5eb9cf583aa698) hstr: fix sorting in CODEOWNERS
* [`d80bf24d`](https://github.com/knl/home-manager/commit/d80bf24dab1c1abb3c36e6e28cd30d27599a9620) home-manager: error out when showing news in flake
* [`2acea865`](https://github.com/knl/home-manager/commit/2acea86583ba10b67b36db135c94d6df1ae41d55) launchd: make Launch Agents config a freeform setting
* [`da325265`](https://github.com/knl/home-manager/commit/da325265b72b338647720b33df23d775aa73825d) launchd: sync option definition with nix-darwin
* [`deb2f59b`](https://github.com/knl/home-manager/commit/deb2f59b5c1fd11bec00600517ba7f51984c3090) programs.neovim: link packpath dir in XDG_DATA_HOME ([knl/home-manager⁠#3717](https://togithub.com/knl/home-manager/issues/3717))
* [`765e4007`](https://github.com/knl/home-manager/commit/765e4007b6f9f111469a25d1df6540e8e0ca73a6) nixpkgs: fix semicolon and list layout in docs ([knl/home-manager⁠#3813](https://togithub.com/knl/home-manager/issues/3813))
* [`0e065e1b`](https://github.com/knl/home-manager/commit/0e065e1b6f0776ebbacea9dcbc977af7bc9eddc0) Revert "programs.neovim: link packpath dir in XDG_DATA_HOME ([knl/home-manager⁠#3717](https://togithub.com/knl/home-manager/issues/3717))" ([knl/home-manager⁠#3817](https://togithub.com/knl/home-manager/issues/3817))
* [`d3fd3b9d`](https://github.com/knl/home-manager/commit/d3fd3b9d697697563905575665de129938a213a0) docs: bump nmd
* [`67b97020`](https://github.com/knl/home-manager/commit/67b97020b6970d39b4126a7870063d11337ecb80) copyq: support xwayland
* [`ddd8866c`](https://github.com/knl/home-manager/commit/ddd8866c0306c48f465e7f48432e6f1ecd1da7f8) dconf: disable on darwin
* [`6c76fb5b`](https://github.com/knl/home-manager/commit/6c76fb5b125232048458c50dfe600dc7380177c3) maintainers: rename houstdav000 → cyntheticfox ([knl/home-manager⁠#3838](https://togithub.com/knl/home-manager/issues/3838))
* [`ccf650bb`](https://github.com/knl/home-manager/commit/ccf650bb5badcf48054cf77f74ac85ea87c6f84c) man: use cfg when possible
* [`a5fe7bf7`](https://github.com/knl/home-manager/commit/a5fe7bf73ce0c2cc5d7497ec9bef63e94912232f) Translate using Weblate (Japanese)
* [`24f60622`](https://github.com/knl/home-manager/commit/24f60622a7ca9e424ff4be41c4ac49f1a9385570) flake.lock: Update
* [`eefb3793`](https://github.com/knl/home-manager/commit/eefb37938639739251acd4bb68ecdaf7de2a13b5) ci: bump DeterminateSystems/update-flake-lock from 17 to 18
* [`ec06f419`](https://github.com/knl/home-manager/commit/ec06f419af79207b33d797064dfb3fc9dbe1df4a) xdg-desktop-entries: make `exec` default to null ([knl/home-manager⁠#3827](https://togithub.com/knl/home-manager/issues/3827))
* [`440faf5a`](https://github.com/knl/home-manager/commit/440faf5ae472657ef2d8cc7756d77b6ab0ace68d) flake.lock: Update
* [`93f5cb24`](https://github.com/knl/home-manager/commit/93f5cb2482dd20e57eb8ca6c819cdad9738f98a0) home-manager: migrate profiles to nix state directory
* [`4e79c6a4`](https://github.com/knl/home-manager/commit/4e79c6a414ce59fd1a53ab77899c77ab87774e6b) ci: bump DeterminateSystems/update-flake-lock from 18 to 19
* [`013948dd`](https://github.com/knl/home-manager/commit/013948ddf6576bbc02629e9b78e87b1364cd3dcf) home-cursor: follow xdg spec for icons folder ([knl/home-manager⁠#3851](https://togithub.com/knl/home-manager/issues/3851))
* [`6e57fc47`](https://github.com/knl/home-manager/commit/6e57fc470508ae65caf59b8de391cdaafc88b1de) home-manager: add some i18n context
* [`28698126`](https://github.com/knl/home-manager/commit/28698126bd825aff21cae9ffd15cf83e169051b0) thunderbird: add userChrome and userContent options
* [`fe1e2dee`](https://github.com/knl/home-manager/commit/fe1e2dee1955f130830536403c7564f4afc6edc0) home-manager: make sure Nix profiles path exists
* [`8631c044`](https://github.com/knl/home-manager/commit/8631c0441614587a10c9e10372f85561211a4bb8) home-manager: ignore errors when creating the profiles path
* [`af8a80c4`](https://github.com/knl/home-manager/commit/af8a80c4ce46dceff40491899d6587c0534e8501) Add translation using Weblate (Romanian)
* [`916b7a54`](https://github.com/knl/home-manager/commit/916b7a545d9e9f9270a821c6c5602082769d7e62) Add translation using Weblate (Romanian)
* [`b10e3ee4`](https://github.com/knl/home-manager/commit/b10e3ee4ad905f0dd7c3cfbd851ffac7ef74ad21) Translate using Weblate (Dutch)
* [`9481677f`](https://github.com/knl/home-manager/commit/9481677f34a4695d175d0afa58cf6b3020cd0d49) Update translation files
* [`49a3eff1`](https://github.com/knl/home-manager/commit/49a3eff14683a4a6f2f5cd1297a7bc37e8f579f0) Translate using Weblate (Italian)
* [`61f5c219`](https://github.com/knl/home-manager/commit/61f5c2196fa61868d905b2533aef5d91c2a55612) Translate using Weblate (Spanish)
* [`d53b9b39`](https://github.com/knl/home-manager/commit/d53b9b39b222b538b3f7953f3116e3715c64554d) Translate using Weblate (Japanese)
* [`48aa5429`](https://github.com/knl/home-manager/commit/48aa5429cc41dfb36fdfb2e49c1cff63aefe58a1) Update translation files
* [`5cdaa298`](https://github.com/knl/home-manager/commit/5cdaa2982c0e36332ec1d2bbc5908c114a7a3736) Translate using Weblate (Ukrainian)
* [`17198cf5`](https://github.com/knl/home-manager/commit/17198cf5ae27af5b647c7dac58d935a7d0dbd189) flake.nix: get rid of flake-utils
* [`75f4f362`](https://github.com/knl/home-manager/commit/75f4f362e1b5ebdc4076fcbdb4188b4fd736187c) git-sync: fix test
* [`2df3d5d3`](https://github.com/knl/home-manager/commit/2df3d5d39c5ef3a4eebe80d478d75c9e20d5c820) swaylock: add enable and package option
* [`40ebb621`](https://github.com/knl/home-manager/commit/40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad) swaylock: add platform assertion
* [`21ca88f3`](https://github.com/knl/home-manager/commit/21ca88f3a98f15e4791c82697745e3698ad883d8) flake.lock: Update
* [`d1d0ee37`](https://github.com/knl/home-manager/commit/d1d0ee37c315537cdcadbcf0f773694e9da0605d) home-manager: ignore errors from notify-send
* [`68eaf4b5`](https://github.com/knl/home-manager/commit/68eaf4b577cfa8024fb910a1ce7d60385044f798) i3-sway: add option trayPadding (tray_padding) for bars ([knl/home-manager⁠#3829](https://togithub.com/knl/home-manager/issues/3829))
* [`53bd74f7`](https://github.com/knl/home-manager/commit/53bd74f786934997e7f6a5ed9741b226e511e508) copyq: fix typo in documentation
* [`ae79840b`](https://github.com/knl/home-manager/commit/ae79840bc756e97f9750fc70448ae0efc1b8dcc3) doc: replace invalid link ([knl/home-manager⁠#3881](https://togithub.com/knl/home-manager/issues/3881))
* [`cd690d20`](https://github.com/knl/home-manager/commit/cd690d202176c251f2a5ed31b621937f8a95268d) lazygit: use xdg.configHome on Darwin
* [`e17e5e4f`](https://github.com/knl/home-manager/commit/e17e5e4f48116763e7c544147cd5d27f94a63623) bottom: use xdg.configHome on Darwin
* [`6db559da`](https://github.com/knl/home-manager/commit/6db559daa952833fb16bd52c5ae24e1c4fffd488) thunderbird: add extraConfig option
* [`58b8685e`](https://github.com/knl/home-manager/commit/58b8685e47ce54b298c40aff7877ea9b875de0e6) nushell: add shellAliases option
* [`fa980cc9`](https://github.com/knl/home-manager/commit/fa980cc98529111c7aad713574d307e9b4f3e5ed) batsignal: add module
* [`2dcb61d3`](https://github.com/knl/home-manager/commit/2dcb61d396b45f10d9e0621a7358b361f94323ff) atuin: enable nushell integration
* [`cd572373`](https://github.com/knl/home-manager/commit/cd5723734acbffa63e11a69cf6767f8ef69f6517) rofi: skip override if there are no plugins ([knl/home-manager⁠#3885](https://togithub.com/knl/home-manager/issues/3885))
* [`aa03c8a4`](https://github.com/knl/home-manager/commit/aa03c8a429902dbaf15b3395f8cefc5a4b83f7f7) bat: rebuild caches during activation
