### PR TITLE
niv powerlevel10k: update c1b5b2c8 -> bbea8d2d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "c1b5b2c8aab51b2a5b0d29d078e3cb53bb4c46bb",
-        "sha256": "0f3qpqpvamhz2hkwf4rpr203rm8f1n2w02716dwmbm4qk3p2hhjp",
+        "rev": "bbea8d2d06382f6f0001c9212da91a319076f06e",
+        "sha256": "1izmxgjcpmk5sywxnbjqa5n3593j1kp6h0ypkihzpfpdldzcd16m",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/c1b5b2c8aab51b2a5b0d29d078e3cb53bb4c46bb.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/bbea8d2d06382f6f0001c9212da91a319076f06e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@c1b5b2c8...bbea8d2d](https://github.com/romkatv/powerlevel10k/compare/c1b5b2c8aab51b2a5b0d29d078e3cb53bb4c46bb...bbea8d2d06382f6f0001c9212da91a319076f06e)

* [`045f006c`](https://github.com/romkatv/powerlevel10k/commit/045f006c50d782a6d3acbd8a07d1595322ff7e43) correctly resolve node_version when using nodenv ([romkatv/powerlevel10k⁠#2268](https://togithub.com/romkatv/powerlevel10k/issues/2268))
* [`94c4428d`](https://github.com/romkatv/powerlevel10k/commit/94c4428ddc9aab97aeaf1c7fffe2f13cdcd1b8bb) added icon for kali linux
* [`bbea8d2d`](https://github.com/romkatv/powerlevel10k/commit/bbea8d2d06382f6f0001c9212da91a319076f06e) use U+F327 (Kali Linux logo) only with POWERLEVEL9K_MODE=nerdfont-v3 ([romkatv/powerlevel10k⁠#2281](https://togithub.com/romkatv/powerlevel10k/issues/2281))
