### PR TITLE
niv nixpkgs: update f405ff3e -> f48a45c8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f405ff3e78fd4ee0cb688ee1971e7e34368c386c",
-        "sha256": "04sahwczy62jp67c2dngabfyb3pgq8jsxw6c4gbcacci3kxr8abn",
+        "rev": "f48a45c883479a078543fafdb2a66e4f06656d66",
+        "sha256": "11329ll3w4vhxq9yp5mg5nnpjihk8gpkwjlrg3gkri0w1h1jrbdp",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f405ff3e78fd4ee0cb688ee1971e7e34368c386c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f48a45c883479a078543fafdb2a66e4f06656d66.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f405ff3e...f48a45c8](https://github.com/nixos/nixpkgs/compare/f405ff3e78fd4ee0cb688ee1971e7e34368c386c...f48a45c883479a078543fafdb2a66e4f06656d66)

* [`3f11515a`](https://github.com/NixOS/nixpkgs/commit/3f11515a260bc195637d0c3817815eb28e6cf996) units: fix build with enableCurrenciesUpdater=false; pythonPackages=null;
* [`bab4cdd4`](https://github.com/NixOS/nixpkgs/commit/bab4cdd43a2497dd0fa6303b7f9cc00380e1c185) fetchgit: Remove comment regarding path needing to be a string
* [`eea95ff4`](https://github.com/NixOS/nixpkgs/commit/eea95ff4daff7cbf84f2f5400a6ba8efe36ab045) guile: add extensions search path to setup hook
* [`15ebd7cc`](https://github.com/NixOS/nixpkgs/commit/15ebd7cc3d7b3463c144d549ff5137259276d352) mu: enable AOT native-comp for emacs lisp
* [`f1bce905`](https://github.com/NixOS/nixpkgs/commit/f1bce90517a2a24eb77937ad5701462c2c543c7f) default-crate-overrides.nix: add gtk-sys (gtk3)
* [`220be665`](https://github.com/NixOS/nixpkgs/commit/220be6650e7da168582b379e88e5332a20819b3e) catppuccin-kde: unstable-2022-11-26 -> 0.2.2
* [`8d0dd4c8`](https://github.com/NixOS/nixpkgs/commit/8d0dd4c886714bbd8b9e5912145b47e9cb1ef016) supercollider: add changelog
* [`8c8524bc`](https://github.com/NixOS/nixpkgs/commit/8c8524bc9a95f9a0ba7691b097804f928781d162) buildDotnetModule: fix sandboxed builds on darwin
* [`0351445e`](https://github.com/NixOS/nixpkgs/commit/0351445e249c0453efd6450e5f0fa3b3583e9d24) z3: 4.8.15 -> 4.8.17
* [`0aaea9cd`](https://github.com/NixOS/nixpkgs/commit/0aaea9cda209fd5c4cf7bff442cf4a5cb3a9415b) rectangle: 0.59 -> 0.67
* [`3266f88f`](https://github.com/NixOS/nixpkgs/commit/3266f88f3dd3bcfca231ddc6c95a5da702792756) asterisk: add sub-package with ldap support
* [`1bfefc7b`](https://github.com/NixOS/nixpkgs/commit/1bfefc7b43cb397a34ecce9b02dd0f6b146a5e16) asterisk: autoformat default.nix
* [`f126a1dd`](https://github.com/NixOS/nixpkgs/commit/f126a1dd14a07d37ef51a3dfd7f460a6681233bf) i3lock-fancy-rapid: 2019-10-09 -> unstable-2021-04-21
* [`5e30b82d`](https://github.com/NixOS/nixpkgs/commit/5e30b82dabf0bf6a8212c7e44f13336589f09a34) micropad: 4.2.0 -> 4.2.1
* [`d5b9f6cc`](https://github.com/NixOS/nixpkgs/commit/d5b9f6cc5a356201a65e05b5050480aef6d651b2) python310Packages.pysigma: 0.9.4 -> 0.9.5
* [`722d963e`](https://github.com/NixOS/nixpkgs/commit/722d963ef287f2469133f6677b0d3e25ae4e2ede) owl-compositor: init at unstable-2021-11-10
* [`10a80d40`](https://github.com/NixOS/nixpkgs/commit/10a80d4086d02daa4c090723dcdb632be18b5835) python310Packages.ttp-templates: 0.3.2 -> 0.3.4
* [`6b58973b`](https://github.com/NixOS/nixpkgs/commit/6b58973b393bdcdbb2d4b7e9ad093dfb17686fb2) maintainers: add aplund as maintainer
* [`d21fe9c9`](https://github.com/NixOS/nixpkgs/commit/d21fe9c912f2e28cfb586a56b92ba48e75a47db0) coyim: 0.4 -> 0.4.1
* [`4f3687cd`](https://github.com/NixOS/nixpkgs/commit/4f3687cd3d03e0c0a81d8a82fd87c5c73ad1c2a2) google-cloud-sdk: 408.0.1 -> 424.0.0
* [`55aab11e`](https://github.com/NixOS/nixpkgs/commit/55aab11e91b69b9251c75ac9d0dc1da969d1b2fb) parallel: 20230222 -> 20230322
* [`ec6f63da`](https://github.com/NixOS/nixpkgs/commit/ec6f63dae7982f3d83b792afa0d8a88ac754a0ac) libsForQt5.qtpositioning: init at 5.15.2
* [`81a6a27b`](https://github.com/NixOS/nixpkgs/commit/81a6a27b15d2c2b9e58f43b458f909693c1b1844) icingaweb2-ipl: 0.10.1 -> 0.11.0
* [`8dbd0051`](https://github.com/NixOS/nixpkgs/commit/8dbd0051aed8227b5e9efd8b0fa90a34f427edfa) bees: 0.8 -> 0.9.3
* [`75fed51e`](https://github.com/NixOS/nixpkgs/commit/75fed51e185811cf41126030532cc1d3f61633bf) llvmPackages_git: apply [nixos/nixpkgs⁠#205355](https://togithub.com/nixos/nixpkgs/issues/205355) (disable libpfm on non-Linux)
* [`61b348f0`](https://github.com/NixOS/nixpkgs/commit/61b348f0c6b934ff944c684277c351ba3aa23bb7) llvmPackages_git.openmp: apply [nixos/nixpkgs⁠#197674](https://togithub.com/nixos/nixpkgs/issues/197674) (fix cross compile)
* [`2b155e11`](https://github.com/NixOS/nixpkgs/commit/2b155e1198ed92587059ff8cc29d2994220dca8a) nixos/moodle: use PHP 8.1
* [`32f10b45`](https://github.com/NixOS/nixpkgs/commit/32f10b45f8458a495a5d96a7c3f06fc3a02d1fa7) fishPlugins.wakatime-fish: init at 0.0.3
* [`39943196`](https://github.com/NixOS/nixpkgs/commit/39943196e5751257a9b31e763821a8fd8b110d52) CODEOWNERS: add RaitoBezarius to llvm tree
* [`e5d66059`](https://github.com/NixOS/nixpkgs/commit/e5d66059d9f3fda50823f41b2013d3008d53a620) apptainer: 1.1.5 -> 1.1.7, singularity: 3.10.4 -> 3.11.1
* [`1f32cee4`](https://github.com/NixOS/nixpkgs/commit/1f32cee4d41d5602efa74600a6d1146887494bd7) apptainer, singularity: add passthru.tests.image-hello-cowsay
* [`532911e9`](https://github.com/NixOS/nixpkgs/commit/532911e9aeec2ca4c64496361bc1cfe9bc3acab0) pjsip: use finalAttrs in mkDerivation
* [`c32dd072`](https://github.com/NixOS/nixpkgs/commit/c32dd072f0f6fc8e00b3d926fbe4a3f32ba529ab) pjsip: add version and pkg-config tests
* [`072cd2ab`](https://github.com/NixOS/nixpkgs/commit/072cd2ab7a15b7fd475deaf5bb63405d351b82c2) pjsip: fix pjsua executable compatiblity with darwin
* [`8da0c399`](https://github.com/NixOS/nixpkgs/commit/8da0c399033cca9aa9203f23b6d67003fc4609d8) maintainers: add oddlama
* [`18d9f16d`](https://github.com/NixOS/nixpkgs/commit/18d9f16d0a068ab3830c79bc95d83e881f5b9c31) llvmPackages_git.libcxx: updates from LLVM15
* [`2e453ee5`](https://github.com/NixOS/nixpkgs/commit/2e453ee51beff39ae1904807a973237451aea863) llvmPackages_git.libcxxabi: fix cycles that arise when `stdenv` is the LLVM stdenv
* [`5fbf2cd1`](https://github.com/NixOS/nixpkgs/commit/5fbf2cd1a04a4e7a6ef34bb359e4d02cb334a165) llvmPackages_git: apply [nixos/nixpkgs⁠#211230](https://togithub.com/nixos/nixpkgs/issues/211230) to llvmPackages_git
* [`92bf9338`](https://github.com/NixOS/nixpkgs/commit/92bf9338909d29b8e85a1bd426e15efbc4c87226) llvmPackages_git.libcxx: remove `preInstall` phase for Darwin
* [`8df62ec4`](https://github.com/NixOS/nixpkgs/commit/8df62ec46c2871e8e2ae3dc0ac7954f91c0b30b6) nixos/esphome: init module
* [`a51ac639`](https://github.com/NixOS/nixpkgs/commit/a51ac639c0e9394de23bfbd19c5fe9958d4f2370) maintainers: add kindrowboat
* [`491667f8`](https://github.com/NixOS/nixpkgs/commit/491667f8a95d89d3401bd9cfa99021cf7a7eb7b5) dante: autoreconfHook unconditionally
* [`f6e7fccf`](https://github.com/NixOS/nixpkgs/commit/f6e7fccfa6b22fb8928fd1c3cf8401f7fef17e11) apptainer, singularity: unify the PATH prefix to defaultPath and wrapProgram
* [`e1e2ca8c`](https://github.com/NixOS/nixpkgs/commit/e1e2ca8cd194ca89cf03cd810d55e3c00ab97b38) pdfgrep: partially fix cross
* [`327b0cff`](https://github.com/NixOS/nixpkgs/commit/327b0cff7aedc20a148d245b1182f43800acc1f5) treewide: use more lib.optionalString
* [`052463fa`](https://github.com/NixOS/nixpkgs/commit/052463fa20757074f8e7ac6e41d91a4ac5caceca) python310Packages.google-api-python-client: 2.83.0 -> 2.84.0
* [`c2fb621e`](https://github.com/NixOS/nixpkgs/commit/c2fb621ea6ce43e98bf1acae7eb437ab3497c685) maintainers: add ivanmoreau
* [`02c1d132`](https://github.com/NixOS/nixpkgs/commit/02c1d132478b5e479d5e5d13b26f5ef77fee72d5) factorio: 1.1.77 -> 1.1.80
* [`722948a9`](https://github.com/NixOS/nixpkgs/commit/722948a9429d89c7661d9fec89128ba9eae6eb54) singularity, apptainer: adjust dependencies
* [`e7997ece`](https://github.com/NixOS/nixpkgs/commit/e7997ece6ec632512e534ef8a79b9988e06a1160) kstars: 3.6.3 -> 3.6.4
* [`f7050cc8`](https://github.com/NixOS/nixpkgs/commit/f7050cc88c479dc137f7b5c02f5012488ca02352) octoprint.plugins: use callPackage
* [`b598fea8`](https://github.com/NixOS/nixpkgs/commit/b598fea8d26e5ab4b7c6c6df0d8877a8605c0339) octoprint.tests.plugins.abl-expert: use fetchFromGitLab
* [`d779fd87`](https://github.com/NixOS/nixpkgs/commit/d779fd8706dc7512730ddca4f4927c51e566f634) octoprint.plugins.themeify: fix hash
* [`d89fe682`](https://github.com/NixOS/nixpkgs/commit/d89fe68254e49401d8b7ae490c35a4158998f864) octoprint.plugins.octolabse: 0.4.1 -> 0.4.2, mark broken
* [`f6284134`](https://github.com/NixOS/nixpkgs/commit/f62841340719ac6199c3a91b29236bb916aa2a59) g810-led: init at 0.4.3
* [`1200d893`](https://github.com/NixOS/nixpkgs/commit/1200d893f8b22e9d4bbcf38b0ce72bcc23e2889e) fcft: add zlib license to list
* [`9810382a`](https://github.com/NixOS/nixpkgs/commit/9810382a6c474ba358e9db2761cee794ca7fc92c) geckodriver: 0.32.2 -> 0.33.0
* [`bf893d1b`](https://github.com/NixOS/nixpkgs/commit/bf893d1b9e656f32024dd96e229f0b4a62642af2) python3Packages.unearth: 0.7.2 -> 0.9.0
* [`92644bbe`](https://github.com/NixOS/nixpkgs/commit/92644bbe5baa0b3223123d9db0f119276993a25f) discord: add text-to-speech
* [`0cd484f4`](https://github.com/NixOS/nixpkgs/commit/0cd484f41331a6b911511469a7ee2f3e1f72091f) aws-c-sdkutils: 0.1.7 -> 0.1.8
* [`87865f3c`](https://github.com/NixOS/nixpkgs/commit/87865f3c8d5cdfbd28a05840c0f9ff19b92edba4) netmaker-full: 0.17.1 -> 0.18.5
* [`d6e64781`](https://github.com/NixOS/nixpkgs/commit/d6e64781367b1149bf8e14f670725f5991b17e3d) octoprint: normalize pnames and attrs
* [`8d91dcbf`](https://github.com/NixOS/nixpkgs/commit/8d91dcbfe000a08d3c3a229781482ad5f0dfda88) pdm: 2.4.6 -> 2.5.1
* [`39c62c37`](https://github.com/NixOS/nixpkgs/commit/39c62c37d962b93dd1d883a9f66eefe7f113981d) aws-c-auth: 0.6.22 -> 0.6.26
* [`9f8c7fde`](https://github.com/NixOS/nixpkgs/commit/9f8c7fde98ef17542325adb56fae5149aafe19d2) aws-c-common: 0.8.9 -> 0.8.15
* [`f46c7320`](https://github.com/NixOS/nixpkgs/commit/f46c7320d62170a7823e2c0ce670d2849066c50c) aws-c-event-stream: 0.2.18 -> 0.2.20
* [`247f7b18`](https://github.com/NixOS/nixpkgs/commit/247f7b18e15ed200931a40de5f3f2575753144f8) aws-c-http: 0.7.3 -> 0.7.6
* [`5fff14c5`](https://github.com/NixOS/nixpkgs/commit/5fff14c527ffb6416b67e5d309319f268e9a05df) aws-c-mqtt: 0.8.4 -> 0.8.8
* [`fd493aee`](https://github.com/NixOS/nixpkgs/commit/fd493aee17a61f05aaa4241dfc27c78b5e36a9ac) aws-c-s3: 0.2.2 -> 0.2.8
* [`98992578`](https://github.com/NixOS/nixpkgs/commit/98992578f72ab9982c728dd239125762f465cb20) aws-c-io: 0.13.18 -> 0.13.19
* [`ffd01fe9`](https://github.com/NixOS/nixpkgs/commit/ffd01fe9e1ec389dc255c75356a9149c7e99baaf) aws-crt-cpp: 0.18.9 -> 0.19.8
* [`4a398303`](https://github.com/NixOS/nixpkgs/commit/4a398303318f3be670f78832f3bc05f57356c400) aws-sdk-cpp: 1.9.294 -> 1.11.37
* [`f221a662`](https://github.com/NixOS/nixpkgs/commit/f221a6628600d258156a22b51da41cf976e47012) nix: use old aws-sdk-cpp for old nix
* [`46e32697`](https://github.com/NixOS/nixpkgs/commit/46e326973d603fe90975b62549385401213e608a) python310Packages.asf-search: 6.2.0 -> 6.3.1
* [`4d41c937`](https://github.com/NixOS/nixpkgs/commit/4d41c9374502b1f666ad7b0db3ec97a7c1492d46) osl: 1.11.17.0 -> 1.12.11.0
* [`86526d70`](https://github.com/NixOS/nixpkgs/commit/86526d707acef0d854d4f35dcd9b0b2b4dbbb8d8) octoprint: test plugins with ofborg
* [`26214bb8`](https://github.com/NixOS/nixpkgs/commit/26214bb8887b44132615a5c4b634125301f3935d) ocamlPackages.class_group_vdf: Bump MACOSX_DEPLOYMENT_TARGET to fix build
* [`053afa80`](https://github.com/NixOS/nixpkgs/commit/053afa8036b68ee9f7a485e6f9d942af49b32c59) astc-encoder: 4.3.1 -> 4.4.0
* [`e9315ee2`](https://github.com/NixOS/nixpkgs/commit/e9315ee2b220e8b46f8e5355eb5a279a6cc898fc) mindustry: 142 -> 143.1
* [`b5235e8d`](https://github.com/NixOS/nixpkgs/commit/b5235e8d6e0c21487c5fe38c6616158063af9851) fedigroups: 0.4.4 -> 0.4.5
* [`121dfc18`](https://github.com/NixOS/nixpkgs/commit/121dfc185a23113173e653cd538f80ff9171f3c3) rtsp-simple-server: 0.21.6 -> 0.22.0
* [`bbb33138`](https://github.com/NixOS/nixpkgs/commit/bbb33138ffb288032278ff4c1f6dbd1520053324) sundials: 6.5.0 -> 6.5.1
* [`af0fc321`](https://github.com/NixOS/nixpkgs/commit/af0fc32127e229f35b235e5bd73d5fd34e6b8a5e) perlPackages: use makeScopeWithSplicing
* [`71983a6e`](https://github.com/NixOS/nixpkgs/commit/71983a6eb5cdf0755d80d8197f52f52b0a5d3f9f) systemd-initrd: Don't use SYSTEMD_SULOGIN_FORCE
* [`fef26d88`](https://github.com/NixOS/nixpkgs/commit/fef26d88e20cc4045768071421bf495871506b7a) systemd-initrd: Support secrets when boot loader doesn't
* [`762b69f2`](https://github.com/NixOS/nixpkgs/commit/762b69f2ff4a7e843a7e9690a0bed741f229229d) systemd-initrd: Fix up root directory mode
* [`20559ae2`](https://github.com/NixOS/nixpkgs/commit/20559ae2863ba0554df5a7cfcea21955ed406dee) playwright: 1.27.1 -> 1.30.0
* [`dd16761a`](https://github.com/NixOS/nixpkgs/commit/dd16761a2b8c15321bf22f89884c9def72a8e584) playwright: remove firefox support
* [`13a46443`](https://github.com/NixOS/nixpkgs/commit/13a464432548c18924e8a1183209e61050d9f10d) playwright: 1.30.0 -> 1.31.1
* [`d9263322`](https://github.com/NixOS/nixpkgs/commit/d92633226f5c4aa8f5c8e875e664cef54b2849f9) alice-tools,alice-tools-qt5,alice-tools-qt6: 0.12.1 -> 0.13.0
* [`82c8852b`](https://github.com/NixOS/nixpkgs/commit/82c8852b6f60e838d50dcd1b1add6d6aa61e8a6e) alice-tools,alice-tools-qt5,alice-tools-qt6: Add version test
* [`504849a7`](https://github.com/NixOS/nixpkgs/commit/504849a7bb581207756d5767d55213ee422281ce) rtsp-simple-server: rebrand as mediamtx
* [`197ed8e7`](https://github.com/NixOS/nixpkgs/commit/197ed8e75df56e5bb9776cda3c04c72a8c939a66) mediamtx: Remove doronbehar from maintenance.
* [`f1dffc4f`](https://github.com/NixOS/nixpkgs/commit/f1dffc4fd4643b136bda328afce2523767837e01) openvpn3: 19_beta -> 20
* [`664d9fd9`](https://github.com/NixOS/nixpkgs/commit/664d9fd9a252569075f21f2b7d13463466d9ae8c) alice-tools-qt6: Fix Qt tool detection on Darwin
* [`a56b0af5`](https://github.com/NixOS/nixpkgs/commit/a56b0af5ff980f795b223bac9a03dcf8460ca5aa) maintainers: add ne9z
* [`dd456244`](https://github.com/NixOS/nixpkgs/commit/dd4562447dabdd9b94e8c0a0a7a2e65bbdbd65ca) ArchiSteamFarm: 5.4.3.2 -> 5.4.4.5
* [`e70b42bf`](https://github.com/NixOS/nixpkgs/commit/e70b42bf612e65693c95fab37ff0de725858ed8e) systemd-initrd: Add users and groups with static IDs.
* [`6032e005`](https://github.com/NixOS/nixpkgs/commit/6032e00504291bfe6b9b6b5e6b03417859722de4) nixos/tests/aaaaxy: init
* [`69200947`](https://github.com/NixOS/nixpkgs/commit/69200947a9bd65bb6c5d7f48202cd6b2a535b2b0) supercollider: 3.12.2 → 3.13.0
* [`070aa0e7`](https://github.com/NixOS/nixpkgs/commit/070aa0e77ee24557e4d552a4aced88446bb4679e) all-cabal-hashes: 2023-04-07T21:49:23Z -> 2023-04-13T09:45:26Z
* [`be1ad341`](https://github.com/NixOS/nixpkgs/commit/be1ad3419a740a71dfa1d540553a4a85e7df7ce6) haskellPackages: regenerate package set based on current config
* [`35c00c63`](https://github.com/NixOS/nixpkgs/commit/35c00c639a2addcb3553437062fe8ced8ccf16d8) haskellPackages.hackage-db: 2.1.2 -> 2.1.3
* [`b44a2993`](https://github.com/NixOS/nixpkgs/commit/b44a299381f3ce9faeb9f6cc41cda454d02335ed) mullvad-browser: init at 12.0.4
* [`b2cee6f4`](https://github.com/NixOS/nixpkgs/commit/b2cee6f4865d5d56c03f054968dbc30a356838d8) python3Packages.ipywidgets: 8.0.4 -> 8.0.6
* [`2654e263`](https://github.com/NixOS/nixpkgs/commit/2654e2635a378afe11e704fbdebcce03309e59ca) python3Packages.jupyterlab-widgets: 3.0.5 -> 3.0.7
* [`6b259302`](https://github.com/NixOS/nixpkgs/commit/6b259302c14ebe5bb57dd9d88a30cbb6c6b86863) python3Packages.widgetsnbextension: 4.0.5 -> 4.0.7
* [`ace4fa3d`](https://github.com/NixOS/nixpkgs/commit/ace4fa3d1f20da2ace54504226d999f633556930) swayfx: init at 0.2
* [`cd1e7609`](https://github.com/NixOS/nixpkgs/commit/cd1e76095a283d980cea92e10f9f84caeea413e5) gnome-common: Remove superfluous patch
* [`96db3a90`](https://github.com/NixOS/nixpkgs/commit/96db3a90edb2f2c65ad9d1572c1246e0206b45c5) cogl+gtk: Avoid depending on GNOME Bugzilla server
* [`e9944eae`](https://github.com/NixOS/nixpkgs/commit/e9944eaecce1272e79373b89a422254aa7b3d50a) python3Packages.comm: 0.1.2 -> 0.1.3
* [`058dc0f6`](https://github.com/NixOS/nixpkgs/commit/058dc0f6dfdf2f9147dc8bf194d2046404b3dd03) sage: replace ipywidgets workaround by update patches
* [`2c97ab29`](https://github.com/NixOS/nixpkgs/commit/2c97ab29dff951e3af6d7617a64946e6676062d7) haskellPackages.eventlog2html: fix build
* [`8ddb1338`](https://github.com/NixOS/nixpkgs/commit/8ddb133890df988b5fb5367e5c48565217199c6a) haskellPackages: regenerate package set based on current config
* [`432cd8cf`](https://github.com/NixOS/nixpkgs/commit/432cd8cfae04221330411d10f58815da9f7be2a7) nodePackages: update
* [`a2510be0`](https://github.com/NixOS/nixpkgs/commit/a2510be0229941d186bcdcfd97af948355e96410) nodePackages.diff2html-cli: init at 5.2.9
* [`c97834ad`](https://github.com/NixOS/nixpkgs/commit/c97834adb5187927908c3e6c9a777687fb957223) libcifpp: 4.2.2 -> 5.0.8
* [`28bc96ee`](https://github.com/NixOS/nixpkgs/commit/28bc96eeca8a407977c11e4d3979c956cba2a532) libmcfp: init at 1.2.3
* [`62943901`](https://github.com/NixOS/nixpkgs/commit/62943901ddf728729e6c624ff22250d80fb9f0ac) dssp: 4.0.5 -> 4.2.2.1
* [`1220b75c`](https://github.com/NixOS/nixpkgs/commit/1220b75c47110cff68f836be16045b8a78be646f) bitwig-studio: 4.4.8 -> 4.4.10
* [`0dfc5c14`](https://github.com/NixOS/nixpkgs/commit/0dfc5c14d74a70818f5171d1f16df05875d2a59d) nixos/multipass: don't start until online
* [`0afe48b3`](https://github.com/NixOS/nixpkgs/commit/0afe48b3323af2a05f753e747f000a0118ef26a3) lisp-modules.mcclim: fix build failure
* [`f6b48239`](https://github.com/NixOS/nixpkgs/commit/f6b48239e43284fb39941897db633abcc2d80d52) lisp-modules.mcclim-layouts: fix build
* [`3bce72b7`](https://github.com/NixOS/nixpkgs/commit/3bce72b7e950a9840be42bc376afed54cd347ad6) lisp-modules.polyclot: init from trunk
* [`1c5ca89f`](https://github.com/NixOS/nixpkgs/commit/1c5ca89f42e6cc17815f8e10585c8f862172158e) nixos/lorri: install direnv
* [`88f4f0f3`](https://github.com/NixOS/nixpkgs/commit/88f4f0f3759120538ec0c6e4ff0e2b8ec2073f65) zookeeper: 3.6.3 -> 3.7.1
* [`b79286ea`](https://github.com/NixOS/nixpkgs/commit/b79286ea28bd91de5d7b734fc26eddb6560324df) maintainers/haskell/upload-package-list: support 3.10 config dir
* [`c4e4e529`](https://github.com/NixOS/nixpkgs/commit/c4e4e5294bce81b1b358c53930ca714ae128aa51) mbrola: split derivation for bin and data files
* [`dfc599c7`](https://github.com/NixOS/nixpkgs/commit/dfc599c71ae1a0730dcb37477f257bf882fdc005) tor-browser-bundle-bin: fix IPC socket issue
* [`880d99b2`](https://github.com/NixOS/nixpkgs/commit/880d99b259b502f936d98a2f884ab85fa889a1b8) jetbrains: 2022.3.2 -> 2023.1.1
* [`1ef6ddb2`](https://github.com/NixOS/nixpkgs/commit/1ef6ddb2fc8895046c42c64a0a6d8fa531e89c56) mullvad-vpn: 2023.2 -> 2023.3
* [`ea704b79`](https://github.com/NixOS/nixpkgs/commit/ea704b798f94a03886c28c65755739f1e126476a) grpc: 1.53.0 -> 1.54.0
* [`2400c6bd`](https://github.com/NixOS/nixpkgs/commit/2400c6bdb20f5b09e698c797ee07cfc090c744f9) Bump pop-shell
* [`a604287f`](https://github.com/NixOS/nixpkgs/commit/a604287fbe5e6c04bcf4b6380567c300d9fe3829) streamlit: 1.18.1 -> 1.21.0
* [`00d55625`](https://github.com/NixOS/nixpkgs/commit/00d556255c2d8a4224856834d0dc9c872c282b9a) aptdec: format
* [`53ada238`](https://github.com/NixOS/nixpkgs/commit/53ada2386837aee422ce1bd91550161185929b7b) aptdec: unstable-2022-05-18 -> 1.8.0
* [`540b9615`](https://github.com/NixOS/nixpkgs/commit/540b961504cab72d21a4e34da80c8097f4c6c75f) sgp4: unstable-2021-01-11 -> unstable-2022-11-13
* [`4c0970c2`](https://github.com/NixOS/nixpkgs/commit/4c0970c21684b31da57b608400d885d685e6e58e) xgboost: 1.7.4 -> 1.7.5
* [`87e450cb`](https://github.com/NixOS/nixpkgs/commit/87e450cbbc53e657760aa0066ca122af3494b124) gparted: 1.4.0 -> 1.5.0
* [`a8921b81`](https://github.com/NixOS/nixpkgs/commit/a8921b81fe4f9793b79b87014427d3fe3f37751f) sdrangel: fix apt demodulator, satellite tracker and cleanup
* [`312b3856`](https://github.com/NixOS/nixpkgs/commit/312b3856e8dda36ddbea7d8465f89d01bfaee530) mpvScripts.uosc: 4.6.0 -> 4.7.0
* [`47962955`](https://github.com/NixOS/nixpkgs/commit/479629550084d43fda03ed4f6c41e7c22698d11a) python310Packages.crate: 0.30.0 -> 0.31.0
* [`90e2c6f5`](https://github.com/NixOS/nixpkgs/commit/90e2c6f57031509e84a5dab38578a78499af5223) cups-brother-hll3230cdw: init at version 1.0.2
* [`f6c88027`](https://github.com/NixOS/nixpkgs/commit/f6c880275845717a41ffdfa22910b5104f0651c2) kalker: 2.0.0 -> 2.0.3, add figsoda as a maintainer
* [`e8512ca2`](https://github.com/NixOS/nixpkgs/commit/e8512ca23fc113d953f175f166bcfda9f69e478c) crystal: 1.7 -> 1.8
* [`2f319381`](https://github.com/NixOS/nixpkgs/commit/2f319381f5720f1986ed06f3da6a5771f2482afc) fastlane: 2.212.1 -> 2.212.2
* [`aaae9895`](https://github.com/NixOS/nixpkgs/commit/aaae98955fbec5d355b5080dfa5871c26d2a7418) enchant: 2.3.3 → 2.3.4
* [`92283e00`](https://github.com/NixOS/nixpkgs/commit/92283e00bdb7d84a4ec5fcb4ef5e277d1624f7e0) ferdium: 6.2.4 -> 6.2.6
* [`af12a002`](https://github.com/NixOS/nixpkgs/commit/af12a002c7be039c7de96d0dd62ef019e3353a0c) ipopt: 3.14.11 -> 3.14.12
* [`ae1b4659`](https://github.com/NixOS/nixpkgs/commit/ae1b465987dcf9fb85d6c428e81d513983d59bc5) ferdium: add update script
* [`05f87ea0`](https://github.com/NixOS/nixpkgs/commit/05f87ea0ee0a90436202a885a3687525d0bcfec0) openapi-generator-cli: 6.4.0 -> 6.5.0
* [`db5f683c`](https://github.com/NixOS/nixpkgs/commit/db5f683c7d227c98b109fe7e7fd796dfcf9a4b05) gcompris: 3.1 -> 3.2
* [`73664db7`](https://github.com/NixOS/nixpkgs/commit/73664db7fa39cd811e87d0e0703464f097ae639d) janus-gateway: 1.1.2 -> 1.1.3
* [`2dd10bd4`](https://github.com/NixOS/nixpkgs/commit/2dd10bd4eba637bdeed723c1648e99a6a38d63ce) janus-gateway: add changelog to meta
* [`d7136312`](https://github.com/NixOS/nixpkgs/commit/d713631265fdbf66c88723e8a54cb1c81c0984e8) monica: init at 4.0.0
* [`33a7f368`](https://github.com/NixOS/nixpkgs/commit/33a7f368b40cddbd623db0e40c011be499b6c63f) nixos/monica: init
* [`32d3f6a2`](https://github.com/NixOS/nixpkgs/commit/32d3f6a2d84f13c5680f90e917e9e35d18f53e55) nixos/release-notes: add services.monica
* [`4ec6e2ef`](https://github.com/NixOS/nixpkgs/commit/4ec6e2efb3f1de76ba8dc36898b3b3841d0cbdbf) lilypond-unstable: 2.25.1 -> 2.25.3
* [`424e5ca7`](https://github.com/NixOS/nixpkgs/commit/424e5ca7c99f5a4c08f8480bc3be395181ec827a) xcbuild: add ProductBuildVersion
* [`22f7ec86`](https://github.com/NixOS/nixpkgs/commit/22f7ec86372cf2b423e7b538bd5160a6e9e5e3d3) python3Packages.parsy: 1.4.0 -> 2.1
* [`526e199b`](https://github.com/NixOS/nixpkgs/commit/526e199b565fc233c040e9909d5ec0da3967573c) python3Packages.parsy: add changelog to meta
* [`9ce159fd`](https://github.com/NixOS/nixpkgs/commit/9ce159fd735fa7b24f33801e25489582c0512786) evcc: 0.116.0 -> 0.116.2
* [`02bb6b0d`](https://github.com/NixOS/nixpkgs/commit/02bb6b0d2d634d055529b54a412ec805471fa6ec) ogre: 13.6.3 -> 13.6.4
* [`4bbe0906`](https://github.com/NixOS/nixpkgs/commit/4bbe09068aefe0381e611e1928f08881bd94b05b) nixos/pufferpanel: init
* [`063d0aea`](https://github.com/NixOS/nixpkgs/commit/063d0aea24cd9bbaa3c8a283cdacf7371b274b4e) iosevka: 22.0.0 → 22.0.2
* [`bdc7b7ce`](https://github.com/NixOS/nixpkgs/commit/bdc7b7cee9c3dc427940fc232cc5d693133cad9e) jumpy: 0.6.0 -> 0.6.1
* [`3764529e`](https://github.com/NixOS/nixpkgs/commit/3764529e05e4f1a460cda3142b7763015bec79e8) activemq: 5.17.3 -> 5.18.1
* [`7cb94d7c`](https://github.com/NixOS/nixpkgs/commit/7cb94d7c11091d1cb7c56fdbfb8616291432bb40) python3Packages.pydruid: init at 0.6.5
* [`8b0d32ba`](https://github.com/NixOS/nixpkgs/commit/8b0d32ba68c39fa8739fff6415af868574d8d17a) python310Packages.hahomematic: 2023.3.1 -> 2023.4.0
* [`8792ed32`](https://github.com/NixOS/nixpkgs/commit/8792ed32bb8f8c88449713cb6720ff6e59ddcbe2) python310Packages.peaqevcore: 15.2.8 -> 15.3.1
* [`01353a1e`](https://github.com/NixOS/nixpkgs/commit/01353a1ee12f0f98f1bd4f5a8dd6eafc84a57dd6) python3Packages.sphinxext-opengraph: 0.8.1 -> 0.8.2
* [`c62a52ff`](https://github.com/NixOS/nixpkgs/commit/c62a52ff59d409478d4d8269a591222b4e15c029) python310Packages.tplink-omada-client: 1.1.5 -> 1.2.3
* [`09bd8199`](https://github.com/NixOS/nixpkgs/commit/09bd819958fdf81810819d1303e038593bbabcc5) qt6: 6.4.3 -> 6.5.0
* [`bb6f287d`](https://github.com/NixOS/nixpkgs/commit/bb6f287d936f27cad2539415d0746de941ee14be) qt6.qtbase: refresh patches
* [`52703c42`](https://github.com/NixOS/nixpkgs/commit/52703c427ebbd561695106d4ffb7558dead8f503) qt6: move mkspecs/modules to dev output
* [`4769460f`](https://github.com/NixOS/nixpkgs/commit/4769460fb3cddb5c02ab78cb611658e845c89d60) qt6.qtlocation: init at 6.5.0
* [`5e316e49`](https://github.com/NixOS/nixpkgs/commit/5e316e49ddd41b040ec3068151a06da797823533) qt6.qtquickeffectmaker: init at 6.5.0
* [`4171299e`](https://github.com/NixOS/nixpkgs/commit/4171299ee95b628b5672b39d4b072347092a11cc) qt6.qtgrpc: init at 6.5.0
* [`6d7ec3e4`](https://github.com/NixOS/nixpkgs/commit/6d7ec3e49860a024ecc75bfb2e6b9912cf37be94) qt6.full: add missing modules
* [`e15575e3`](https://github.com/NixOS/nixpkgs/commit/e15575e3ad381b098bf74239fb096a0246337f0b) copyq: 7.0.0 -> unstable-2023-04-14
* [`6e856153`](https://github.com/NixOS/nixpkgs/commit/6e8561539eea62d2f9c2327be1d6eda6c7672ebe) zeal-qt6: fix build with qt 6.5
* [`fca522b5`](https://github.com/NixOS/nixpkgs/commit/fca522b53865fb9d890e0b5958a3120fff67e566) qt6.qtbase: set strictDeps, remove python3 from buildInputs to reduce closure size
* [`b4026106`](https://github.com/NixOS/nixpkgs/commit/b4026106f793c500313cd29595b86d949c94f2ad) jami: add patch to fix annotations in bin/dbus/cx.ring.Ring.CallManager.xml
* [`d0565d40`](https://github.com/NixOS/nixpkgs/commit/d0565d403eae66e22a993cfa0d09494a8239253e) texworks: add patch to fix build with qt 6.5
* [`19f2603c`](https://github.com/NixOS/nixpkgs/commit/19f2603c1c1780abf02af433adaa146bae2a3fdd) mediaelch: add patch to fix build with qt 6.5
* [`cfbe0f13`](https://github.com/NixOS/nixpkgs/commit/cfbe0f13ce5594675b61d7f42f6dfd2340a30485) python3Packages.ducc0: 0.28.0 -> 0.29.0
* [`349cdce3`](https://github.com/NixOS/nixpkgs/commit/349cdce31e42b0388e139758e9542037c9ae7d6e) haskellPackages.jsaddle-webkit2gtk: Apply patch for webkit 2.40 compat
* [`f7eee945`](https://github.com/NixOS/nixpkgs/commit/f7eee9453835e5effc4fb02a31a2b89b677198e3) haskellPackages: Remove trailing whitespace
* [`6d1315c8`](https://github.com/NixOS/nixpkgs/commit/6d1315c89653242e53d3ad98608af17388311491) python3.pkgs.django-parler: init at 2.3
* [`e4a9fe6c`](https://github.com/NixOS/nixpkgs/commit/e4a9fe6cb236e2e5c74f2f0c4d710a64a750ef6d) python3.pkgs.django-scheduler: init at 0.10.1
* [`a373f763`](https://github.com/NixOS/nixpkgs/commit/a373f76301cb87598ffe9bdbd5323a0d82edb572) cloudflare-warp: fix build
* [`ecb528d6`](https://github.com/NixOS/nixpkgs/commit/ecb528d66387f2193bc8c0efcfb713c7ee3f4db4) feed2imap-go: init at 1.6.0
* [`ad7996ab`](https://github.com/NixOS/nixpkgs/commit/ad7996abce1894cd3c6cd46eb0b5bf3036753e43) apfsprogs: link to apfs NixOS test
* [`a8370201`](https://github.com/NixOS/nixpkgs/commit/a837020120f58d3ef446a84014a34a7611274e33) apfsprogs: unstable-2022-10-15 -> unstable-2023-03-21
* [`1a41d761`](https://github.com/NixOS/nixpkgs/commit/1a41d76159d8cd81bc7dbdee35a93d15fa2b5f50) maintainers: Add FlafyDev and NotAShelf
* [`af0ce076`](https://github.com/NixOS/nixpkgs/commit/af0ce076612bd4b2c3ff4fa3279dafdaa5c5b44a) lxqt.liblxqt: 1.2.0 -> 1.3.0
* [`97271f59`](https://github.com/NixOS/nixpkgs/commit/97271f5991e0c785044d8ec9405607cc73300380) lxqt.libqtxdg: 3.10.0 -> 3.11.0
* [`2e4a8e63`](https://github.com/NixOS/nixpkgs/commit/2e4a8e6376f0ad45ec226da2294b17a73c379035) lxqt.libfm-qt: 1.2.1 -> 1.3.0
* [`bf17d531`](https://github.com/NixOS/nixpkgs/commit/bf17d531b91f728b9720e9e4e0c9d2a5e3536e5b) lxqt.lximage-qt: 1.2.0 -> 1.3.0
* [`96412f3b`](https://github.com/NixOS/nixpkgs/commit/96412f3bb89f442d8667762297ca15f2446a3d14) lxqt.lxqt-about: 1.2.0 -> 1.3.0
* [`6182cbb4`](https://github.com/NixOS/nixpkgs/commit/6182cbb4b3be85e8d8a74aacf6b415ffd7aa38f9) lxqt.lxqt-admin: 1.2.0 -> 1.3.0
* [`49df77a3`](https://github.com/NixOS/nixpkgs/commit/49df77a302dc9aab38d78d60a3d769365fce6c9d) lxqt.lxqt-archiver: 0.7.0 -> 0.8.0
* [`cbd9ef69`](https://github.com/NixOS/nixpkgs/commit/cbd9ef69beb0dfe480ae49c75630143836a23223) consul-template: 0.30.0 -> 0.31.0
* [`52eac4e1`](https://github.com/NixOS/nixpkgs/commit/52eac4e1d5c65acab1bad61b03a3623f9fdc4b04) eclipses: 2022-12 -> 2023-03
* [`c7af6d1e`](https://github.com/NixOS/nixpkgs/commit/c7af6d1e95ddb30a7222591bffa9fb15ded0f404) xdg-desktop-portal-wlr: 0.6.0 -> 0.7.0
* [`670a6325`](https://github.com/NixOS/nixpkgs/commit/670a6325291962dd852679273f60501fe81490a0) powertop: change substitute for xset
* [`2dac5440`](https://github.com/NixOS/nixpkgs/commit/2dac5440f1592700ecc1628bbdd97ec4c3321529) emblem: 1.1.0 -> 1.2.0, increase platform support, add figsoda as a maintainer
* [`7a40725f`](https://github.com/NixOS/nixpkgs/commit/7a40725f9eb291bb11a46122d93faeb661e536d6) mautrix-whatsapp: 0.8.3 -> 0.8.4
* [`d3c6336d`](https://github.com/NixOS/nixpkgs/commit/d3c6336d0bc8e4f7ddb175697f74497191572193) scriv: 1.2.1 -> 1.3.1
* [`fcd60db2`](https://github.com/NixOS/nixpkgs/commit/fcd60db24f1c7781e4a1aa51c9ae35cdabded5d8) vintagestory: 1.17.10 -> 1.17.11
* [`ec5ee07b`](https://github.com/NixOS/nixpkgs/commit/ec5ee07b1b29070475284ada1eee05ec5b7ad821) teams-for-linux: 1.0.59 -> 1.0.65
* [`eea5ebb1`](https://github.com/NixOS/nixpkgs/commit/eea5ebb173ec55f9761534b5be8e6ebd58ee64d4) webcord: 4.1.1 -> 4.2.0
* [`fd944e15`](https://github.com/NixOS/nixpkgs/commit/fd944e15874106760243d5d327e3ba4b8b670cd4) steampipe: 0.19.3 -> 0.19.4
* [`6c15c20d`](https://github.com/NixOS/nixpkgs/commit/6c15c20d94bbd454bdc7c8e7e8b58779409fe9ff) teams-for-linux: add hack fix for wayland screen-sharing
* [`8050381a`](https://github.com/NixOS/nixpkgs/commit/8050381a438cf3a35ff0260c08e6c137dbfafaa8) elasticsearch: bump version, adjust sha256, drop esversion 6.8.21 support
* [`4ca39268`](https://github.com/NixOS/nixpkgs/commit/4ca392680814488ec19a4b8ce97b8c7365dc4fca) python310Packages.sentencepiece: 0.1.97 -> 0.1.98
* [`4f4ed386`](https://github.com/NixOS/nixpkgs/commit/4f4ed3864bc0b7f4b1ebdba02c6b059bb15c7d09) stern: 1.24.0 -> 1.25.0
* [`a6323587`](https://github.com/NixOS/nixpkgs/commit/a63235871017932b07714e807166726e6084aaa3) libxisf: init at 0.2.3
* [`73c5e2a5`](https://github.com/NixOS/nixpkgs/commit/73c5e2a5c5eeff3fc46b54264b0ef1af4a304f69) sq: 0.25.1 -> 0.33.0
* [`cc768325`](https://github.com/NixOS/nixpkgs/commit/cc7683256548beb06bb5546660180d9a74646241) exploitdb: 2023-04-13 -> 2023-04-15
* [`e7dac23c`](https://github.com/NixOS/nixpkgs/commit/e7dac23ca45cd1a1c6834a3525f87c6a5489f1a8) checkSSLCert: 2.62.0 -> 2.64.0
* [`78154339`](https://github.com/NixOS/nixpkgs/commit/781543392bb172f9265537335758078e15b21e22) wthrr: init at 1.0.1
* [`66e85ab9`](https://github.com/NixOS/nixpkgs/commit/66e85ab988349b8f6a5b015d55202d8a9d0913e2) rav1e: 0.6.3 -> 0.6.4
* [`ec1631a0`](https://github.com/NixOS/nixpkgs/commit/ec1631a06f864c5303c86f63862e5bc3c4ee3e67) uhd: fix cross
* [`9aa3e69c`](https://github.com/NixOS/nixpkgs/commit/9aa3e69c99a99bad659e51ab18a179ca3eefa778) yosys/plugins/ghdl.nix: fix build
* [`d8b461be`](https://github.com/NixOS/nixpkgs/commit/d8b461be9594a2ca1fc023d82dadd09be85ef2ad) postman: fix notarization failure on macOS 13
* [`9d7a0555`](https://github.com/NixOS/nixpkgs/commit/9d7a0555aa8d8a993b01018ab08fc1e34c527408) shards_0_17: 0.17.2 -> 0.17.3
* [`06b09a50`](https://github.com/NixOS/nixpkgs/commit/06b09a500e5450423b0bab6f914e62f56f37bbaf) python311Packages.devito: 4.8.0 -> 4.8.1
* [`fe14ed3c`](https://github.com/NixOS/nixpkgs/commit/fe14ed3c7a86890c80572903efccb4d89883c0af) cpu-x: 4.5.2 -> 4.5.3
* [`952e23ab`](https://github.com/NixOS/nixpkgs/commit/952e23abcf188b59aa326ea9990bd0dd65682e79) libmodsecurity: 3.0.8 -> 3.0.9
* [`beb3583b`](https://github.com/NixOS/nixpkgs/commit/beb3583b7716a453b54310a703367b114e3ab05e) chirp: use wrapGAppsHook to fix file manager crash
* [`dbf179da`](https://github.com/NixOS/nixpkgs/commit/dbf179da7ebfb604911e29d6c2a1f1095d2d216f) python310Packages.django-stubs-ext: 0.7.0 -> 0.8.0
* [`afec2906`](https://github.com/NixOS/nixpkgs/commit/afec2906ea9bf688dd8403b84e4f3c87011c0c0c) pam_u2f: 1.2.1 -> 1.3.0
* [`3c498a22`](https://github.com/NixOS/nixpkgs/commit/3c498a2216fe5992cd3a5e65330e5f06b1ebc2fd) ustreamer: 5.36 -> 5.37
* [`df496ea6`](https://github.com/NixOS/nixpkgs/commit/df496ea67e2a9e3e09b4c3c5394a38ef946b6923) sketchybar: fix build
* [`c806a5c1`](https://github.com/NixOS/nixpkgs/commit/c806a5c1219662309f50f191d14b73ec288f0fce) gtkwave: 3.3.114 -> 3.3.115
* [`4a831cda`](https://github.com/NixOS/nixpkgs/commit/4a831cda4a208a54bdb49d6814a0f8fa53c18c68) sketchybar: 2.14.1 -> 2.14.4
* [`d0e4b839`](https://github.com/NixOS/nixpkgs/commit/d0e4b839a81d26339afe6677ec285f01fa9b0197) spotify-unwrapped: add macOS builds
* [`7cddde92`](https://github.com/NixOS/nixpkgs/commit/7cddde921877e2019b4b9968d445356134b082d6) spotify: remove `mudri` as a maintainer
* [`50745087`](https://github.com/NixOS/nixpkgs/commit/50745087beaaea2eb8bb234d392152784193f0b3) python310Packages.dkimpy: 1.1.1 -> 1.1.2
* [`52b5056e`](https://github.com/NixOS/nixpkgs/commit/52b5056e096ec5159a4d9d7db2f561e6816739bf) vgmplay-libvgm: unstable-2022-03-17 -> unstable-2023-04-12
* [`c8c09014`](https://github.com/NixOS/nixpkgs/commit/c8c0901412f7030f999ba32f5bfa6e70fc53934c) ocamlPackages.ppx_tools_versioned: use Dune 3
* [`244c5561`](https://github.com/NixOS/nixpkgs/commit/244c5561fb36ee1b10285aec4fbf14917646df06) ocamlPackages.hack_parallel: use Dune 3
* [`0939a960`](https://github.com/NixOS/nixpkgs/commit/0939a9604db7f77186505833ddf327649a944ba8) ocamlPackages.ocaml-migrate-parsetree: use Dune 3
* [`bf8dc7ed`](https://github.com/NixOS/nixpkgs/commit/bf8dc7ed769798c06d585ba22bf8014d24ebefef) jasmin-compiler: 2022.09.0 → 2022.09.2
* [`61662955`](https://github.com/NixOS/nixpkgs/commit/616629559c104d2c02c1648ad946d20465a19cc2) seaweedfs: 3.45 -> 3.46
* [`55c89ba0`](https://github.com/NixOS/nixpkgs/commit/55c89ba02b2ae39434d6514145b240a75f1b4b83) python310Packages.azure-eventgrid: 4.9.1 -> 4.10.0
* [`b9157c11`](https://github.com/NixOS/nixpkgs/commit/b9157c11a51dc8bf2a9fce81542c4ab84953d24a) python310Packages.pysigma-backend-elasticsearch: 0.2.0 -> 1.0.1
* [`2f852c48`](https://github.com/NixOS/nixpkgs/commit/2f852c48ca80e65abc4484d577d2ad22d34c4a99) python310Packages.pysigma-backend-opensearch: 0.1.6 -> 0.1.6
* [`5586e0dd`](https://github.com/NixOS/nixpkgs/commit/5586e0dd1433e8712fcc5f04f422bf540f686827) python310Packages.pysigma: 0.9.5 -> 0.9.6
* [`a8a94887`](https://github.com/NixOS/nixpkgs/commit/a8a948870445f0be77983b5ced7738c5df793a1c) ots: init at 0.2.0
* [`e7a73d03`](https://github.com/NixOS/nixpkgs/commit/e7a73d03f5adc6c7c259978035d8158b2c473329) sigma-cli: 0.5.3 -> 0.7.2
* [`29e1d4e7`](https://github.com/NixOS/nixpkgs/commit/29e1d4e77c8f1d37d0d224060520b4e42076c7ca) python310Packages.pyfibaro: 0.6.9 -> 0.7.0
* [`6d277318`](https://github.com/NixOS/nixpkgs/commit/6d2773189f7db4ba87869e0a249ae0e7220adda6) python310Packages.pylaunches: 1.3.0 -> 1.4.0
* [`0c88ed25`](https://github.com/NixOS/nixpkgs/commit/0c88ed25e0eab5b272af73ed2d2127056d4d94dd) deepin.dde-calendar: disable unit testing
* [`80d27a63`](https://github.com/NixOS/nixpkgs/commit/80d27a6317347302672ae6c7d5cf19ee379d3ce5) deepin.util-dfm: 1.2.7 -> 1.2.8
* [`9b5533a3`](https://github.com/NixOS/nixpkgs/commit/9b5533a3be9057f6d1c0336c5ddb9e0be89c1f3d) php81: 8.1.17 -> 8.1.18
* [`1cc5062c`](https://github.com/NixOS/nixpkgs/commit/1cc5062cb50d4098375be7a9cbee0e67015aa0fd) deepin.dde-file-manager: 6.0.13 -> 6.0.14
* [`b3846242`](https://github.com/NixOS/nixpkgs/commit/b384624244ce0dd49b9c67baf6dd2d5458f82d64) php82: 8.2.4 -> 8.2.5
* [`23e78ca2`](https://github.com/NixOS/nixpkgs/commit/23e78ca2fc0ffc708bc49e8c4db9f062502c8970) jmol: 16.1.3 -> 16.1.9
* [`be06a2b9`](https://github.com/NixOS/nixpkgs/commit/be06a2b91ce327c50757b4d4b08129ffc168a80b) mesa-demos: fix cross compilation
* [`02bb7124`](https://github.com/NixOS/nixpkgs/commit/02bb71243f0dcfdc79c2bb50b4a3606e1ab1cb42) python310Packages.mautrix: 0.19.9 -> 0.19.11
* [`1ab15c48`](https://github.com/NixOS/nixpkgs/commit/1ab15c4859c2fe639d935efc1cbcc7ce6b9556dc) python310Packages.python-manilaclient: 4.3.0 -> 4.4.0
* [`41d524d5`](https://github.com/NixOS/nixpkgs/commit/41d524d5be2b14bd4cc40a4914a7dfb864aa1c6c) v2ray-geoip: 202304060040 -> 202304130041
* [`71266bac`](https://github.com/NixOS/nixpkgs/commit/71266bac032cb80172b201ffd2b15c127c2e2872) firefox-beta-bin-unwrapped: 113.0b3 -> 113.0b4
* [`4cee616f`](https://github.com/NixOS/nixpkgs/commit/4cee616fa8e6606625608202de89a9c49172ff2c) firefox-devedition-bin-unwrapped: 113.0b3 -> 113.0b4
* [`05564cec`](https://github.com/NixOS/nixpkgs/commit/05564ceca772fce89070d81aaf3b9452d2dc86da) ipe: 7.2.24 -> 7.2.26
* [`9c876916`](https://github.com/NixOS/nixpkgs/commit/9c876916b1a7e7f2dfeec5f6a64302e7d05f0a14) firefox-devedition-unwrapped: 113.0b3 -> 113.0b4
* [`37e60911`](https://github.com/NixOS/nixpkgs/commit/37e609113cf03bb61cf984fc457e94aa456acc57) deepin.deepin-terminal: 5.9.40 -> 6.0.5
* [`bb724fcf`](https://github.com/NixOS/nixpkgs/commit/bb724fcfb1610a1bc78a0f15b5431ec55f218638) dnscontrol: 3.30.0 -> 3.31.0
* [`b72b8eff`](https://github.com/NixOS/nixpkgs/commit/b72b8eff54718a3c638bedb216ba77e4099e4e82) firefox-beta-unwrapped: 113.0b3 -> 113.0b4
* [`c9eada43`](https://github.com/NixOS/nixpkgs/commit/c9eada434c2101cf9507438198ebad31a899a471) python310Packages.apycula: 0.7 -> 0.8
* [`635b128c`](https://github.com/NixOS/nixpkgs/commit/635b128ca3b5755ea65205c89a5135d022fed62f) maintainers: add lx
* [`a14d424d`](https://github.com/NixOS/nixpkgs/commit/a14d424d8512c8fa488019ff574422de50ac703d) wgautomesh: init at 0.1.0
* [`a727a3d6`](https://github.com/NixOS/nixpkgs/commit/a727a3d6769ea064d00b24883fc08535db195f1a) nixos/wgautomesh: init at 0.1.0
* [`71104175`](https://github.com/NixOS/nixpkgs/commit/711041757168b239548041e4ecab29f392cec5bd) signal-desktop: v6.10.1 -> v6.14.0
* [`6036c991`](https://github.com/NixOS/nixpkgs/commit/6036c9910617bf470ff280779681285678bc0208) signal-desktop-beta: v6.11.0-beta.2 -> v6.15.0-beta.1
* [`f8700b4f`](https://github.com/NixOS/nixpkgs/commit/f8700b4f1674288c61c0053da50159add405eb34) python310Packages.onvif-zeep-async: 1.2.5 -> 1.2.11
* [`7616253b`](https://github.com/NixOS/nixpkgs/commit/7616253bac1cf55b5b8845e66bad87edbbdf25e4) sqlfluff: 2.0.4 -> 2.0.5
* [`e2a237d6`](https://github.com/NixOS/nixpkgs/commit/e2a237d6f9c903be392be159e617027874e05490) fastnetmon-advanced: 2.0.335 -> 2.0.336 ([nixos/nixpkgs⁠#226602](https://togithub.com/nixos/nixpkgs/issues/226602))
* [`376fc84b`](https://github.com/NixOS/nixpkgs/commit/376fc84bbc14306712b4fa0ded62ab5ec56dd43c) clickhouse: 22.8.11.15 -> 22.8.16.32 ([nixos/nixpkgs⁠#226603](https://togithub.com/nixos/nixpkgs/issues/226603))
* [`e21be863`](https://github.com/NixOS/nixpkgs/commit/e21be86383a4019d3840fc0011956ed44d4e110d) python310Packages.pyunifiprotect: 4.7.0 -> 4.8.1
* [`9c99a7da`](https://github.com/NixOS/nixpkgs/commit/9c99a7dadc94f41f63c50e41c95319c0b8f4eeaa) androidStudioPackages.stable: 2022.1.1.20 -> 2022.2.1.18
* [`7081da42`](https://github.com/NixOS/nixpkgs/commit/7081da42c68f57bc605a723e1720c2e5d157b04a) atuin: 14.0.0 -> 14.0.1 ([nixos/nixpkgs⁠#226495](https://togithub.com/nixos/nixpkgs/issues/226495))
* [`d1f57357`](https://github.com/NixOS/nixpkgs/commit/d1f57357449c312491b6a957558b7a34655f80a0) linux_testing: 6.3-rc6 -> 6.3-rc7
* [`15e8ee51`](https://github.com/NixOS/nixpkgs/commit/15e8ee51d47ff4a57ee7ceb92d7b7924e7f550b3) zerotierone: 1.10.3 -> 1.10.6 ([nixos/nixpkgs⁠#224992](https://togithub.com/nixos/nixpkgs/issues/224992))
* [`9678498e`](https://github.com/NixOS/nixpkgs/commit/9678498e45d84cd79d09055f25a4882a35fc80a0) maintainers: add ionutnechita
* [`fed6621d`](https://github.com/NixOS/nixpkgs/commit/fed6621deb2c70ec3d69c337157edef4e626d163) yandex-browser: 22.9.1.1110-1 -> 23.3.1.906-1
* [`7607b322`](https://github.com/NixOS/nixpkgs/commit/7607b322f7558e3d5a9fe3d30864c12f6ed37db2) python3.pkgs.pytomlpp: 1.0.6 -> 1.0.13
* [`ec50349c`](https://github.com/NixOS/nixpkgs/commit/ec50349c2b1cffbd305f86c04ec416013720b6d9) vscode-extensions.contextmapper.context-mapper-vscode-extension: init at 6.7.0
* [`b1fde22c`](https://github.com/NixOS/nixpkgs/commit/b1fde22c3b315ba78eb3101d14f9d501ddd86674) python310Packages.pytelegrambotapi: 4.10.0 -> 4.11.0
* [`dd8daa40`](https://github.com/NixOS/nixpkgs/commit/dd8daa40094d77da09053888f8ae1b98a5a50387) python310Packages.pydrive2: 1.15.1 -> 1.15.3
* [`757b6381`](https://github.com/NixOS/nixpkgs/commit/757b6381ec238148d9a8a6c1aeec3240981b513c) yaru-theme: 22.10.3 -> 23.04.4
* [`1ee86f28`](https://github.com/NixOS/nixpkgs/commit/1ee86f28c7e3499c8e83ef8ab280ab05486b1ee8) nixos-shell: add jq dependency
* [`96a2c646`](https://github.com/NixOS/nixpkgs/commit/96a2c646ec40121679942bf58c44858e2669abff) secp256k1: 0.3.0 -> 0.3.1
* [`9a4f0d77`](https://github.com/NixOS/nixpkgs/commit/9a4f0d773b5a119e542b96897e3b4ed37093c882) python310Packages.monty: 2022.9.9 -> 2023.4.10
* [`45c1aabe`](https://github.com/NixOS/nixpkgs/commit/45c1aabe9472a2570b07496bdc82868ec958785c) yed: 3.22 -> 3.23.1
* [`5bf1f8fd`](https://github.com/NixOS/nixpkgs/commit/5bf1f8fd50d57e285c6b495e9c63ff03d5f52a6f) emacs.pkgs.sqlite3: build .so file
* [`ec826f33`](https://github.com/NixOS/nixpkgs/commit/ec826f33852f2226b907291fe5a60d5a5e0b86c2) vscode-extensions.kahole.magit: 0.6.39 → 0.6.40
* [`642deff3`](https://github.com/NixOS/nixpkgs/commit/642deff3214b8515758d1310616b61434ab747fa) python310Packages.google-cloud-bigquery: 3.7.0 -> 3.9.0
* [`834c6bf7`](https://github.com/NixOS/nixpkgs/commit/834c6bf77768a038b430ae4ea354994da584d354) libqalculate, qalculate-gtk, qalculate-qt: 4.6.0 -> 4.6.1
* [`3365aa18`](https://github.com/NixOS/nixpkgs/commit/3365aa18ebd795656bab7d9c5700a5341b5a42d3) ocamlPackages.cohttp*: 5.0.0 -> 5.1.0
* [`56315519`](https://github.com/NixOS/nixpkgs/commit/56315519c95b5f598f933127d1e087be08bb48d1) maintainers: add onedragon
* [`79d5a539`](https://github.com/NixOS/nixpkgs/commit/79d5a53953b33598f9b29fef6ca296f5f8597b09) realvnc-vnc-viewer: 6.22.515 -> 7.1.0
* [`d8ad536c`](https://github.com/NixOS/nixpkgs/commit/d8ad536c627854463ee612ef2c2cdb97302ba2e7) miniserve: 0.23.0 -> 0.23.1
* [`c48074a3`](https://github.com/NixOS/nixpkgs/commit/c48074a352986ce2fcf88aa538918d67d17187ca) python310Packages.pydeps: 1.11.2 -> 1.12.1
* [`d9d363bf`](https://github.com/NixOS/nixpkgs/commit/d9d363bf3ca67cd01383e71593c857ec9da7526c) nixpkgs-hammering: unstable-2022-11-15 -> unstable-2023-03-09
* [`92aae37b`](https://github.com/NixOS/nixpkgs/commit/92aae37bc958e6aa3e2ee000ae84799332bdfa30) python310Packages.social-auth-app-django: 5.1.0 -> 5.2.0
* [`2b01a3b4`](https://github.com/NixOS/nixpkgs/commit/2b01a3b4771dc08003dbfd679ff649e921161b48) python310Packages.python-gitlab: 3.13.0 -> 3.14.0
* [`4a239294`](https://github.com/NixOS/nixpkgs/commit/4a239294b2f613be6808d4f79472abaaa28d9c00) git-ignore: 1.2.0 -> 1.2.2
* [`bc07f0ac`](https://github.com/NixOS/nixpkgs/commit/bc07f0ac318f53753aca2efc8e568d0b8ec77d22) borgmatic: fix timer wantedBy
* [`990899a3`](https://github.com/NixOS/nixpkgs/commit/990899a387fc61610859fb58bc51b6832bba8b57) obsidian: use electron-24 which is not EOL
* [`6eaaabf1`](https://github.com/NixOS/nixpkgs/commit/6eaaabf15fcd37181c61b6422123ff90a9e55bf3) teams-for-linux: fix notification sounds when which isn't in PATH
* [`f9e2f37a`](https://github.com/NixOS/nixpkgs/commit/f9e2f37ac8dd02c1acad4cc59c49364220b3202f) jackett: 0.20.3846 -> 0.20.3920
* [`f63627aa`](https://github.com/NixOS/nixpkgs/commit/f63627aaafb38eda3ab70404478495baa9c969e9) imagemagick: 7.1.1-6 -> 7.1.1-7
* [`1bcbcfb3`](https://github.com/NixOS/nixpkgs/commit/1bcbcfb362bec95aa0f100a5e7fe5664a5772c8e) libsForQt5.qtstyleplugin-kvantum: 1.0.9 -> 1.0.10
* [`de9b7f2e`](https://github.com/NixOS/nixpkgs/commit/de9b7f2e5d236907afeff351c9e4e3d9b916bf76) ocamlPackages.dates_calc: init at 0.0.4
* [`dfbcd782`](https://github.com/NixOS/nixpkgs/commit/dfbcd782b3ad78ab1fd38b6a6194834014080834) ocamlPackages.ppx_monad: init at 0.2.0
* [`afa89ff7`](https://github.com/NixOS/nixpkgs/commit/afa89ff7428668a42e921193aa68cb4b3eb9e583) python310Packages.pyspark: 3.3.2 -> 3.4.0
* [`c34918a1`](https://github.com/NixOS/nixpkgs/commit/c34918a1c2f0ee56d2a1f84a65e407696cbccab2) freeswitch: remove misuzu as maintainer
* [`20dde675`](https://github.com/NixOS/nixpkgs/commit/20dde675235e1e58f08f1175fcb6d7e4bf49fa58) pulsar: 1.103.0 -> 1.104.0
* [`7cdd1f3e`](https://github.com/NixOS/nixpkgs/commit/7cdd1f3ebf9974aa402d2f6fe11670a1e7e138c1) libnvme: fix cross
* [`2ef748c8`](https://github.com/NixOS/nixpkgs/commit/2ef748c8de50bdcaf0f244f312ad99e582ed5dbc) waynergy: 0.0.15 -> 0.0.16
* [`dc60c10a`](https://github.com/NixOS/nixpkgs/commit/dc60c10a1102be3fd4adeb6eea3e6e1285a43f4d) cargo-release: 0.24.9 -> 0.24.10
* [`270107e9`](https://github.com/NixOS/nixpkgs/commit/270107e9da5c6074574a2a154c029f229804d036) mmc-utils: unstable-2023-02-09 -> unstable-2023-04-17
* [`bda7e117`](https://github.com/NixOS/nixpkgs/commit/bda7e117c52d628d91e604482633a193993c41e1) lxqt.lxqt-build-tools: 0.12.0 -> 0.13.0
* [`9c86a46a`](https://github.com/NixOS/nixpkgs/commit/9c86a46a8689f8d3ad807c1fa6292c5ed8b6c0ee) lxqt.lxqt-config: 1.2.0 -> 1.3.0
* [`83762543`](https://github.com/NixOS/nixpkgs/commit/83762543e5eb0f944ec6525c438fcc1645e9e968) lxqt.lxqt-globalkeys: 1.2.0 -> 1.3.0
* [`ef0c5333`](https://github.com/NixOS/nixpkgs/commit/ef0c5333abc3ee148c9ca111f692d4f67b636749) lxqt.lxqt-notificationd: 1.2.0 -> 1.3.0
* [`47e18213`](https://github.com/NixOS/nixpkgs/commit/47e182132aa25d5373bb92f1dbb510cdd18d1810) lxqt.lxqt-openssh-askpass: 1.2.0 -> 1.3.0
* [`7ad834fb`](https://github.com/NixOS/nixpkgs/commit/7ad834fb3e2476c3e58c65f2e8d29439092b2061) lxqt.lxqt-panel: 1.2.1 -> 1.3.0
* [`b353525e`](https://github.com/NixOS/nixpkgs/commit/b353525e5e2c1ac787bba2937f4e2f9742d17697) lxqt.lxqt-policykit: 1.2.0 -> 1.3.0
* [`b2be78e4`](https://github.com/NixOS/nixpkgs/commit/b2be78e4de23c35ad87f48e0b9468805566cf4a0) lxqt.lxqt-powermanagement: 1.2.0 -> 1.3.0
* [`b17234ba`](https://github.com/NixOS/nixpkgs/commit/b17234baba6bc3f740b53623f2f621b1d96ac827) lxqt.lxqt-qtplugin: 1.2.0 -> 1.3.0
* [`90512d55`](https://github.com/NixOS/nixpkgs/commit/90512d552e4f09addb0a74069c7eea0b74493a55) lxqt.lxqt-runner: 1.2.0 -> 1.3.0
* [`db0c6cf3`](https://github.com/NixOS/nixpkgs/commit/db0c6cf3b5d6974170950bcbd807c8ffcf13ff04) lxqt.lxqt-session: 1.2.0 -> 1.3.0
* [`0a0781d4`](https://github.com/NixOS/nixpkgs/commit/0a0781d4e17909d6868ef70f8d3be71aeefb94b4) lxqt.lxqt-sudo: 1.2.0 -> 1.3.0
* [`620425ed`](https://github.com/NixOS/nixpkgs/commit/620425edad0608f422bfc66b90a5d174b0a62f0b) lxqt.lxqt-themes: 1.2.0 -> 1.3.0
* [`26bf7bbe`](https://github.com/NixOS/nixpkgs/commit/26bf7bbe84d0a3418d15d5a27d22400db4b27aea) lxqt.pavucontrol-qt: 1.2.0 -> 1.3.0
* [`0a4206a5`](https://github.com/NixOS/nixpkgs/commit/0a4206a51b386e5cda731e8ac78d76ad924c7125) ocamlPackages.uring: init at 0.5
* [`b2b767fc`](https://github.com/NixOS/nixpkgs/commit/b2b767fcffd44ec8da2f2a0041de447c5f5edc70) lxqt.pcmanfm-qt: 1.2.1 -> 1.3.0
* [`9fbb59ef`](https://github.com/NixOS/nixpkgs/commit/9fbb59ef0fa0a98c0bbe068c2884eb4a6e37c8ed) lxqt.qps: 2.6.0 -> 2.7.0
* [`8e787d04`](https://github.com/NixOS/nixpkgs/commit/8e787d0460684d8bfce42cfbf7b2da0b3471e73e) lxqt.qterminal: 1.2.0 -> 1.3.0
* [`b38a3f20`](https://github.com/NixOS/nixpkgs/commit/b38a3f2037bd07af9efb05260cbca468ab41f265) lxqt.qtermwidget: 1.2.0 -> 1.3.0
* [`a4295d62`](https://github.com/NixOS/nixpkgs/commit/a4295d62cfb678a1eb1010d188a57d3b7bdf9720) lxqt.qtxdg-tools: 3.10.0 -> 3.11.0
* [`73c9e3a6`](https://github.com/NixOS/nixpkgs/commit/73c9e3a66e9be4ddcda974cecf1c524bc109cfbb) lxqt.screengrab: 2.5.0 -> 2.6.0
* [`6da3d3a4`](https://github.com/NixOS/nixpkgs/commit/6da3d3a400a0e0bbccc4dcc20862e0211cd3a6e3) lxqt.xdg-desktop-portal-lxqt: 0.3.0 -> 0.4.0
* [`f399f5e1`](https://github.com/NixOS/nixpkgs/commit/f399f5e1b1716d5b912acd361187d7eaedfab258) mmctl: 7.5.2 -> 7.10.0
* [`24a451a1`](https://github.com/NixOS/nixpkgs/commit/24a451a1db9ebb3f63365346f66d10863b7c88f9) cypress: 10.10.0 -> 12.9.0
* [`d8cd4e60`](https://github.com/NixOS/nixpkgs/commit/d8cd4e60d1f8bbdd5cb2be79901474e15c11b6b4) honggfuzz: install libraries, too
* [`962d920b`](https://github.com/NixOS/nixpkgs/commit/962d920b8dff4607dd27d33c36c88e4882f62a96) honggfuzz: enable on aarch64-linux
* [`9c8a86d5`](https://github.com/NixOS/nixpkgs/commit/9c8a86d52f66d64cb5d268398fd5269a3cbb024b) Revert "uhd: fix cross"
* [`3697ccb4`](https://github.com/NixOS/nixpkgs/commit/3697ccb4b1444c1cd4259da5bb875308b091488b) uhd: Remove neon.patch not applying anymore
* [`be4ae4fb`](https://github.com/NixOS/nixpkgs/commit/be4ae4fbfdbb44c44e74cc01b35739aecd56cf35) uhd: Remove unused enableSim flag
* [`25665063`](https://github.com/NixOS/nixpkgs/commit/25665063b9077c9cdc6db1549ebb3d3ae070b892) uhd: Add a buildPackages pythonEnv for nativeBuildInputs
* [`2f35bf5d`](https://github.com/NixOS/nixpkgs/commit/2f35bf5d34e6bb40b21ce8009c54a0af0b984f36) octaveFull: 8.1.0 -> 8.2.0
* [`fb13118f`](https://github.com/NixOS/nixpkgs/commit/fb13118f4bdf15850909aab93b63612e0b4f7902) kapp: 0.54.1 -> 0.55.0
* [`efde50d9`](https://github.com/NixOS/nixpkgs/commit/efde50d9f5678a3e21855df775ff13bc9323f624) nixos/plausible: add package option
* [`37a45abb`](https://github.com/NixOS/nixpkgs/commit/37a45abb280e266b161a1b1f37d72ebd4c48ca48) circup: 1.1.4 -> 1.2.1
* [`ad0c509f`](https://github.com/NixOS/nixpkgs/commit/ad0c509f731c0f51f58f25a3d9d099cb1c634b93) pipes-rs: 1.6.0 -> 1.6.1
* [`1ae613f4`](https://github.com/NixOS/nixpkgs/commit/1ae613f4b8ff15cdf021cb7c65f808618e6de4c9) peep: 0.1.4-post.2021-08-17 -> 0.1.6
* [`8d2ffe08`](https://github.com/NixOS/nixpkgs/commit/8d2ffe08c4d015164d0d87c98187cdcd0fb16e01) fx: 24.0.0 -> 24.1.0
* [`4917dc75`](https://github.com/NixOS/nixpkgs/commit/4917dc751ccc14daf238294dfc0ac862a28ceea1) llvmPackages_git.llvm: add checks for the LLVM version
* [`a77eef2b`](https://github.com/NixOS/nixpkgs/commit/a77eef2bb9970e9fd911c834cba6d22e1261d07b) llvmPackages_git: expose the release information and monorepo source as overridable args
* [`98182aec`](https://github.com/NixOS/nixpkgs/commit/98182aec04aa1d429db5b4fe1c16a057e13306d3) llvmPackages_git: unstable-2022-26-07 → 15.0.7
* [`175c646b`](https://github.com/NixOS/nixpkgs/commit/175c646b8a734107f6ae034a528d59711f5601eb) texlive.bin.xindy: add perl to buildInputs to fix shebang ([nixos/nixpkgs⁠#226530](https://togithub.com/nixos/nixpkgs/issues/226530))
* [`e94f9d0d`](https://github.com/NixOS/nixpkgs/commit/e94f9d0d4cabb2f1e3baf2d5fc1efa66539a226a) ima-evm-utils: 1.4 -> 1.5
* [`9941f145`](https://github.com/NixOS/nixpkgs/commit/9941f1457d010a2e3c4cfd88fd298b8374bf1953) python310Packages.env-canada: 0.5.32 -> 0.5.33
* [`58c1630f`](https://github.com/NixOS/nixpkgs/commit/58c1630f2ca1bed1de26641601c96ac6afc82a38) firefox-bin-unwrapped: 112.0 -> 112.0.1
* [`4463a6c2`](https://github.com/NixOS/nixpkgs/commit/4463a6c2c42821ef1f7965f1a500c98861303cf4) octavePackages.ltfat: update source URL
* [`38401aed`](https://github.com/NixOS/nixpkgs/commit/38401aed72cb7f57046ebe9a9529adcd7affe190) treewide: remove file-wide `with rustPlatform;`s
* [`a5c08404`](https://github.com/NixOS/nixpkgs/commit/a5c08404835b908ad98b6a20756b614f5910ce1c) python310Packages.reolink-aio: 0.5.12 -> 0.5.13
* [`08719002`](https://github.com/NixOS/nixpkgs/commit/08719002ced8fd9dada776d849f649d61a454ee1) python310Packages.aioruuvigateway: 0.0.2 -> 0.1.0
* [`8037aa17`](https://github.com/NixOS/nixpkgs/commit/8037aa171d78c1d580035b9c71d7f6d4cab86ec1) python310Packages.trytond: 6.6.5 -> 6.6.7
* [`db457e87`](https://github.com/NixOS/nixpkgs/commit/db457e873a62c1707190a5929824ce5ddb15b942) mtpfs: drop explicit overrides for libmad and libid3tag
* [`dd392d7c`](https://github.com/NixOS/nixpkgs/commit/dd392d7c7694c762812f84b4d0a3ba8157ac8a73) systemd-initrd: networkd
* [`748f1329`](https://github.com/NixOS/nixpkgs/commit/748f1329fcee7db22be526677089719a5276ba30) systemd-initrd: Automatically configure networking.interfaces
* [`0698a1cf`](https://github.com/NixOS/nixpkgs/commit/0698a1cf04392a24f740b4b5e16c5bd33642b6df) systemd-initrd: sshd
* [`834ec135`](https://github.com/NixOS/nixpkgs/commit/834ec135ce71cdc93aba9e98cf67f42e41502f32) systemd-initrd: OpenVPN
* [`85982346`](https://github.com/NixOS/nixpkgs/commit/85982346510230f7bfe1aeabfa2f9382c8192ad8) systemd-initrd: dbus
* [`3cb9534d`](https://github.com/NixOS/nixpkgs/commit/3cb9534df64937f3425dbc0f63749cc83276791a) systemd-initrd: Flush networkd
* [`cd439c64`](https://github.com/NixOS/nixpkgs/commit/cd439c64b0abe18e7fe8982b9387c67e31354e74) octavePackages.stk: update source URL
* [`3e565ed6`](https://github.com/NixOS/nixpkgs/commit/3e565ed6b0d8901e8a9e5d091460ea1bdf934e83) python310Packages.invocations: 2.6.0 -> 3.0.1
* [`d8ac0784`](https://github.com/NixOS/nixpkgs/commit/d8ac078493a6e443786e1204b1edf329d8c3e751) octavePackages.ltfat: remove old syntax-error.patch
* [`0f2e3635`](https://github.com/NixOS/nixpkgs/commit/0f2e3635c5c8d82fda0319f23ed6b3b3d939f874) haskellPackages: mark builds failing on hydra as broken
* [`aac197ee`](https://github.com/NixOS/nixpkgs/commit/aac197ee00feae0f9e46310c394553c0279fd5a2) redis: 7.0.10 -> 7.0.11
* [`50bf9252`](https://github.com/NixOS/nixpkgs/commit/50bf9252cc6d70f7532cc3a7be75311e2d913772) gnomeExtensions.dash-to-dock v79 -> v80
* [`cb2d5a2f`](https://github.com/NixOS/nixpkgs/commit/cb2d5a2fa9f2fa6dd2a619fc3be3e2de21a6a2f4) gdbHostCpuOnly: init ([nixos/nixpkgs⁠#226134](https://togithub.com/nixos/nixpkgs/issues/226134))
* [`9b233b8f`](https://github.com/NixOS/nixpkgs/commit/9b233b8fd3a870042beb8f1493ea84bf0fc96d04) rofi-emoji: 3.1.0 -> 3.2.0
* [`7f0e7444`](https://github.com/NixOS/nixpkgs/commit/7f0e744480f2aec5ea22faebcf6ad142fc1bead1) python310Packages.pylacrosse: patch version
* [`2c544dbb`](https://github.com/NixOS/nixpkgs/commit/2c544dbb850d2c2843c6d80f6b072d773d79e212) haskellPackages.ghc-debug-brick: Fix build
* [`34dbbdd6`](https://github.com/NixOS/nixpkgs/commit/34dbbdd6ebd9d029166dd5a31a7412132f134633) haskellPackages: Add myself as maintainer for some packages
* [`ce8e0c72`](https://github.com/NixOS/nixpkgs/commit/ce8e0c72d5f879ea5977e52fb1c8e25185f3953d) libmad: add some key reverse dependencies to passthru.tests
* [`78b36858`](https://github.com/NixOS/nixpkgs/commit/78b36858834236df0d1bfab693fd20ee559c0f0f) pahole: 1.24-unstable-2023-03-02 -> 1.25
* [`96cbb174`](https://github.com/NixOS/nixpkgs/commit/96cbb1743f22de91d39a4839512586eb7917dd3b) ucg: cosmetical rewrite
* [`a5df3bfe`](https://github.com/NixOS/nixpkgs/commit/a5df3bfe1fe071a434d1a6c19396b934eb4286c7) ucg: 2019-02-25 -> 2022-09-03
* [`4df48038`](https://github.com/NixOS/nixpkgs/commit/4df48038a44e9f3a3da8e9b42ca182726b743de4) ucg: mark as broken on Darwin
* [`2e7a27e6`](https://github.com/NixOS/nixpkgs/commit/2e7a27e66b07e44f09c04e197e853dc60d6a14df) pkgsi686Linux.openexr_3: enforce SSE arithmetics (instead of x87)
* [`97869416`](https://github.com/NixOS/nixpkgs/commit/978694162abfbad459b6ce3dc88fd38aa0ee06c3) haskellPackages.wiringPi: Add wiringpi as a dependency on aarch
* [`0ab0cbb2`](https://github.com/NixOS/nixpkgs/commit/0ab0cbb25aad456e6dd18c447746a5bfcad27edd) python3Packages.jaxlib-bin: 0.3.22 -> 0.4.4
* [`a6c0e4d2`](https://github.com/NixOS/nixpkgs/commit/a6c0e4d21c0450ed59759c2605c82d4584a08768) python3Packages.jax: 0.4.1 -> 0.4.5 and fix aarch64-darwin build
* [`8d0a8a87`](https://github.com/NixOS/nixpkgs/commit/8d0a8a874afcbbac0d14566baef2380eebd8b712) exodus: 23.3.13 -> 23.4.10
* [`d330ef32`](https://github.com/NixOS/nixpkgs/commit/d330ef3206e8ebe2093647f90dd608b61548833a) argo: 3.4.5 -> 3.4.7
* [`e1f004d9`](https://github.com/NixOS/nixpkgs/commit/e1f004d9c5306607f3e6a0451ac4f2416464e24a) systeroid: 0.3.1 -> 0.3.2
* [`11687d06`](https://github.com/NixOS/nixpkgs/commit/11687d0609719a8904a7863b33a0ac67af7ca5f7) python3Packages.jaxlib: 0.3.22 -> 0.4.4
* [`229fb0c0`](https://github.com/NixOS/nixpkgs/commit/229fb0c066610346150a754325f65e61018ea61f) envsubst: 1.2.0 -> 1.4.2
* [`feede794`](https://github.com/NixOS/nixpkgs/commit/feede7944493802f82aadbad045654c92e7fac1e) gopass: 1.15.4 -> 1.15.5
* [`f21e8bbf`](https://github.com/NixOS/nixpkgs/commit/f21e8bbfcaecf54594ca2b2915adde2c112ea1a1) chezmoi: 2.33.0 -> 2.33.1
* [`93f0ca1a`](https://github.com/NixOS/nixpkgs/commit/93f0ca1ab6993852135086b794a3fc4f584ee965) cudatext: 1.190.1 -> 1.191.0
* [`86b0fd9f`](https://github.com/NixOS/nixpkgs/commit/86b0fd9fd726b851a3afb35af3925df10f2e388d) coreth: 0.11.9 -> 0.12.0
* [`3696d5e7`](https://github.com/NixOS/nixpkgs/commit/3696d5e76f895a368b02b6ae94515261b972f4b3) auth0-cli: 0.13.1 -> 1.0.0
* [`3d16049d`](https://github.com/NixOS/nixpkgs/commit/3d16049d6c348772f45567ab3c17ff6706baf628) flannel: 0.20.2 -> 0.21.4
* [`2f81686e`](https://github.com/NixOS/nixpkgs/commit/2f81686ec826ec91bc19200af30b5494030646c7) router: init at 1.15.0
* [`77aa927a`](https://github.com/NixOS/nixpkgs/commit/77aa927abcc77c0e124b6ddee69356f8012c2d36) air: 1.42.0 -> 1.43.0
* [`8e77d667`](https://github.com/NixOS/nixpkgs/commit/8e77d66778bca5d5ebb1ff329d5a971e894089de) azure-static-sites-client: 1.0.022431 -> 1.0.022851
* [`fde45da1`](https://github.com/NixOS/nixpkgs/commit/fde45da1fdd7919371b6d2918756e5e462f9c2de) imgproxy: 3.14.0 -> 3.15.0
* [`df24f905`](https://github.com/NixOS/nixpkgs/commit/df24f90584734a76ae47f527c17de708cc03025c) ghorg: 1.9.1 -> 1.9.4
* [`cd20b877`](https://github.com/NixOS/nixpkgs/commit/cd20b877c637ec61bf54cc480d18f5b67c4f2ca1) ergo: 5.0.7 -> 5.0.8
* [`4e642a1a`](https://github.com/NixOS/nixpkgs/commit/4e642a1af2b1f62fa2fa6981050a10fd69e8a714) airwindows-lv2: 16.0 -> 18.0
* [`406ff6a7`](https://github.com/NixOS/nixpkgs/commit/406ff6a75dc020e3634235fdd113fc7f65246a70) faas-cli: 0.15.9 -> 0.16.3
* [`bb674c65`](https://github.com/NixOS/nixpkgs/commit/bb674c654f3e1e7ec0b58f6bbcb78ac98a80024c) algolia-cli: 1.3.2 -> 1.3.4
* [`df620d7d`](https://github.com/NixOS/nixpkgs/commit/df620d7d666801709843161f3808440ac718f041) codeql: 2.12.5 -> 2.12.6
* [`d9901137`](https://github.com/NixOS/nixpkgs/commit/d9901137f76441b0d74774d6352d4c43f8a438f7) cmctl: 1.11.0 -> 1.11.1
* [`7b2ad71a`](https://github.com/NixOS/nixpkgs/commit/7b2ad71a821f8bfb7cfba9c0e472e41a65476bda) kodiPackages.pvr-hts: 20.6.0 -> 20.6.2
* [`1fbdaa0e`](https://github.com/NixOS/nixpkgs/commit/1fbdaa0e43620289495d136a73745a8a461e77a1) go-jsonnet: 0.19.1 -> 0.20.0
* [`3f3c2747`](https://github.com/NixOS/nixpkgs/commit/3f3c2747ce9c122d93edd394ebc4aa29bcb7bba4) clash: 1.15.0 -> 1.15.1
* [`babf0983`](https://github.com/NixOS/nixpkgs/commit/babf09839cfd263f2d4631b8eb207e85d4452921) libsForQt5.libqglviewer: 2.8.0 -> 2.9.1
* [`338611e7`](https://github.com/NixOS/nixpkgs/commit/338611e7663c010494780f84e08e2420bb895560) stratisd: 3.5.2 -> 3.5.3
* [`f03dba5d`](https://github.com/NixOS/nixpkgs/commit/f03dba5d676b2dbd0ff46147c982b49884f389cf) python3Packages.meraki: 1.30.0 -> 1.32.1
* [`788fa2fe`](https://github.com/NixOS/nixpkgs/commit/788fa2feda53a5e715aa4df124cb36d90e56e701) pipes-rs: update license
* [`1df6c2d1`](https://github.com/NixOS/nixpkgs/commit/1df6c2d1488517d3b893d2c7e38513df96f1303b) havoc: 0.4.0 -> 0.5.0
* [`a76693ef`](https://github.com/NixOS/nixpkgs/commit/a76693efa3ab032263c3fbbe267d28547f6e30bb) terragrunt: 0.45.0 -> 0.45.2
* [`4f847cfe`](https://github.com/NixOS/nixpkgs/commit/4f847cfeff3b9b61f5043f878b69ea0c0866e7e8) numix-icon-theme-circle: 23.03.19 -> 23.04.05
* [`715bc56b`](https://github.com/NixOS/nixpkgs/commit/715bc56b080974f2be2bd985a0b96c95cefb3c05) abiword: fix cross
* [`10d06c61`](https://github.com/NixOS/nixpkgs/commit/10d06c610fb80e724a53599b87a831f63b927866) abiword: set strictDeps=true
* [`df24febd`](https://github.com/NixOS/nixpkgs/commit/df24febd83fa458533748d61fc51c857ff29dbaa) vscodium: 1.77.1.23095 -> 1.77.3.23102
* [`9d228c10`](https://github.com/NixOS/nixpkgs/commit/9d228c10ba1d25c37abfa82a497f34d188fd7359) fulcrum: 1.9.0 -> 1.9.1
* [`3e9f8080`](https://github.com/NixOS/nixpkgs/commit/3e9f808073774e9bad6882501fd565522167e941) fwts: 23.01.00 -> 23.03.00
* [`69d506aa`](https://github.com/NixOS/nixpkgs/commit/69d506aad2ef61dbdba24719126544fc1f0b40ce) capnproto: 0.10.3 -> 0.10.4
* [`f88eb92f`](https://github.com/NixOS/nixpkgs/commit/f88eb92ff9cee37efada430c33311673814c8360) platformio: Don't link udev rules into a subdirectory
* [`70ddbe7a`](https://github.com/NixOS/nixpkgs/commit/70ddbe7ace9efaa5511d6d3a485f7ba69697f078) terraform-providers.azuread: 2.37.0 -> 2.37.1
* [`c335883b`](https://github.com/NixOS/nixpkgs/commit/c335883b49db3b62b0658fdd9b0278cd1527723d) terraform-providers.google: 4.61.0 -> 4.62.0
* [`48b8f87d`](https://github.com/NixOS/nixpkgs/commit/48b8f87d8cc9b58b2c29395f26f8b0a70be6a1cf) terraform-providers.google-beta: 4.61.0 -> 4.62.0
* [`6c1b3d79`](https://github.com/NixOS/nixpkgs/commit/6c1b3d79173d84a1ee34da69527bbbd71e7cc4dc) terraform-providers.grafana: 1.37.1 -> 1.37.2
* [`a55f1a9e`](https://github.com/NixOS/nixpkgs/commit/a55f1a9e97a634ba97029de2ba1ab2bc55555d6c) terraform-providers.okta: 3.45.0 -> 3.46.0
* [`22eace22`](https://github.com/NixOS/nixpkgs/commit/22eace2276747c34272fd73d956eae8bce5c4237) terraform-providers.pagerduty: 2.14.1 -> 2.14.2
* [`767714eb`](https://github.com/NixOS/nixpkgs/commit/767714eb50c9d08f33f7907b60661dd3c96f73b4) terraform-providers.ucloud: 1.35.1 -> 1.36.0
* [`1e2c3e2e`](https://github.com/NixOS/nixpkgs/commit/1e2c3e2e130e3c70187f0f49d86cd9ee0b1cffc0) terraform-providers.vault: 3.14.0 -> 3.15.0
* [`53b6e1a3`](https://github.com/NixOS/nixpkgs/commit/53b6e1a3c5ad2d42bd97f8a108bdb275954bf38b) rustc: fix >=1.68 host!=build
* [`86eee743`](https://github.com/NixOS/nixpkgs/commit/86eee743e1ce3dcdd713c422dddee42ef5b9a6bd) eksctl: 0.136.0 -> 0.137.0
* [`e54774d2`](https://github.com/NixOS/nixpkgs/commit/e54774d2888bee483338121c5b11fc921855c4fc) cloudlist: 1.0.1 -> 1.0.3
* [`bccf1dc6`](https://github.com/NixOS/nixpkgs/commit/bccf1dc63bc9b0d6cae74bb0bab5216e5d00448d) ecs-agent: 1.67.2 -> 1.70.1
* [`7b1a2d29`](https://github.com/NixOS/nixpkgs/commit/7b1a2d29f41a7ca641febc68be55187cb7ae90cf) clair: 4.6.0 -> 4.6.1
* [`1935d4b5`](https://github.com/NixOS/nixpkgs/commit/1935d4b5cb805660ff19f5933fbb3cfff110b78d) flyctl: 0.0.509 -> 0.0.522
* [`e2584d57`](https://github.com/NixOS/nixpkgs/commit/e2584d57d6a54532b7027123756649997d6f78e1) exportarr: 1.2.6 -> 1.3.1
* [`ace8bb45`](https://github.com/NixOS/nixpkgs/commit/ace8bb45603e8aa8676479f6916cbed58c84d243) cargo-update: 12.0.0 -> 13.0.1
* [`6f46ad9e`](https://github.com/NixOS/nixpkgs/commit/6f46ad9e7c342a6193bac66eaac18e444454b7dc) gsl-lite: 0.40.0 -> 0.41.0
* [`fd39f5bb`](https://github.com/NixOS/nixpkgs/commit/fd39f5bb6743feab0d38b69d884bab2a87c26925) frugal: 3.16.15 -> 3.16.18
* [`abe36864`](https://github.com/NixOS/nixpkgs/commit/abe36864e64cb1aebaab3da56650b2d72fff052b) holochain-launcher: 0.9.3 -> 0.9.4
* [`f3f33456`](https://github.com/NixOS/nixpkgs/commit/f3f33456091dce36dba05b8bcb842ba0ef2db593) ctlptl: 0.8.17 -> 0.8.18
* [`9d025b89`](https://github.com/NixOS/nixpkgs/commit/9d025b891643cbac114ecc9c9c97552a81bcfd93) pahole: add `nixosTests.bpf` to `passthru.tests`
* [`49c494be`](https://github.com/NixOS/nixpkgs/commit/49c494be20e172979d16245bb77bca41e4858dc6) ddosify: 0.15.4 -> 0.16.2
* [`f20115d2`](https://github.com/NixOS/nixpkgs/commit/f20115d27df7e71183fd54f896ee08a4319414e1) gnomeExtensions.arcmenu: 43 -> 44
* [`50ce88d4`](https://github.com/NixOS/nixpkgs/commit/50ce88d4ae0920ae4e0ac219774051c211a866a7) ocamlPackages.mdx: 2.2.1 → 2.3.0
* [`cd1961c7`](https://github.com/NixOS/nixpkgs/commit/cd1961c70bc6366ff7b9dc75eb9f5d2d502648b7) bazel-gazelle: 0.28.0 -> 0.30.0
* [`cd2bd78e`](https://github.com/NixOS/nixpkgs/commit/cd2bd78ea5c919000c571c72f412ddc632787d16) librewolf: 112.0-1 -> 112.0.1-1
* [`7e0ad3d9`](https://github.com/NixOS/nixpkgs/commit/7e0ad3d95e732a18721751118c20a22acddba054) maintainers: Add mslingsby
* [`28b1c0c0`](https://github.com/NixOS/nixpkgs/commit/28b1c0c057b82113860878e14930e7f5f6f00a81) python310packages.bytewax: init at 0.15.1
* [`5bbb301b`](https://github.com/NixOS/nixpkgs/commit/5bbb301be2b91eee486949389abe254bc6643bbb) ocamlPackages.bdd: init at unstable-2022-07-14
* [`bc35d8dc`](https://github.com/NixOS/nixpkgs/commit/bc35d8dce2d9bef43938a1f3c00a75ca3f25b49a) python310Packages.aqualogic: 3.3 -> 3.4
* [`e9dadae2`](https://github.com/NixOS/nixpkgs/commit/e9dadae2c6487e02cf791348dad522cd65df0b33) python310Packages.mcstatus: 10.0.2 -> 10.0.3
* [`d3648861`](https://github.com/NixOS/nixpkgs/commit/d3648861353cf50fa8e315c4b2998ac1dbb92858) python310Packages.meraki: add changelog to meta
* [`a89ddac4`](https://github.com/NixOS/nixpkgs/commit/a89ddac47116e9bacb966ff24ec26ac382a71da8) infisical: init at 0.3.7
* [`d260cae0`](https://github.com/NixOS/nixpkgs/commit/d260cae0621216de05d521f9b300557da4273045) goconvey: 1.7.2 -> 1.8.0
* [`30e6684f`](https://github.com/NixOS/nixpkgs/commit/30e6684f98f6697a12b54a3f9b114af19a766ad9) diffuse: 0.8.1 -> 0.8.2
* [`54a682e1`](https://github.com/NixOS/nixpkgs/commit/54a682e11929364163447d611954d0f57ec17d40) delve: 1.20.1 -> 1.20.2
* [`5397643a`](https://github.com/NixOS/nixpkgs/commit/5397643a99f7253f1ac1f0814c38e8c0e067ed48) xfce.tumbler: 4.18.0 -> 4.18.1
* [`d87b3d84`](https://github.com/NixOS/nixpkgs/commit/d87b3d847a4a1c2ab50188d29eca86dc45ac02af) xfce.xfconf: 4.18.0 -> 4.18.1
* [`d9f622af`](https://github.com/NixOS/nixpkgs/commit/d9f622af3386887b917e44d30cbd1096c6ece87b) cloudfox: 1.10.2 -> 1.10.3
* [`792d9fc5`](https://github.com/NixOS/nixpkgs/commit/792d9fc5c902c5f3318d66d4b2bf41475088d548) suricata: 6.0.10 -> 6.0.11
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
