### PR TITLE
niv devenv: update c67a0fcf -> b454e31b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c67a0fcf40a384f955d21494cb6d72a562cf82cf",
-        "sha256": "0qymmz7hk205nl6labxdhqxq4sziycfyff1jnp8flcqrv6zj12bj",
+        "rev": "b454e31b73e1ce987e721e0a7a43044253d6b91a",
+        "sha256": "1b9za2xx5rj82m442sr0db6aisyc0x17b4s8yh7n55fikqlzng55",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/c67a0fcf40a384f955d21494cb6d72a562cf82cf.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/b454e31b73e1ce987e721e0a7a43044253d6b91a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@c67a0fcf...b454e31b](https://github.com/cachix/devenv/compare/c67a0fcf40a384f955d21494cb6d72a562cf82cf...b454e31b73e1ce987e721e0a7a43044253d6b91a)

* [`8184e7f1`](https://github.com/cachix/devenv/commit/8184e7f1b933ee8c9813401f00fd023dedd00308) add missing argument to container registry option
* [`b04fba86`](https://github.com/cachix/devenv/commit/b04fba8624bf74e42e01b368acc79c110a71a36a) python: automatic virtualenv activation for poetry
* [`74e2532d`](https://github.com/cachix/devenv/commit/74e2532dcf77f3a8d0201847d850ed448e97aea2) allow examples to have custom tests
* [`73df5124`](https://github.com/cachix/devenv/commit/73df5124ebfce40f7fc43ac850444bfc00957299) examples: python-venv: add test for correct python executable
* [`366afe7a`](https://github.com/cachix/devenv/commit/366afe7a5e433c141f52d555364be17e35466fb2) examples: ruby: add test
* [`ac410263`](https://github.com/cachix/devenv/commit/ac4102635a6abb5bb28fc744b391d1716cb10f4b) use date from coreutils
* [`bcad6abc`](https://github.com/cachix/devenv/commit/bcad6abc3de3298ad0bf3d49ebd03f8047ad5d83) Add -p option to redis rediness check
* [`4e838d44`](https://github.com/cachix/devenv/commit/4e838d443bea81f1c4fe743fce6cf4eb175cf9ca) Auto generate docs/reference/options.md
* [`e85b0812`](https://github.com/cachix/devenv/commit/e85b081229ca4d7d60c898afb24e36aeb5ecad8e) devenv: use poetry instead of requirements.txt
* [`92cc0642`](https://github.com/cachix/devenv/commit/92cc0642ca38474caae476b2736795e0e85404dc) examples: python-poetry: add test
* [`3139f8ae`](https://github.com/cachix/devenv/commit/3139f8ae792cfba5bf3dcf81c92fd8540bc328f5) add nginx service
* [`b454e31b`](https://github.com/cachix/devenv/commit/b454e31b73e1ce987e721e0a7a43044253d6b91a) Auto generate docs/reference/options.md
