### PR TITLE
niv emacs-overlay: update c4ebde39 -> ff0f8af5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4ebde39c21d85c402e615db225b57b5e27ed1d9",
-        "sha256": "0jzyvy19c16pa6g64cb4kjb6jpklpqckl48amndb1vc3gsg9vjzw",
+        "rev": "ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6",
+        "sha256": "11ifgvbvjlymjcvg2b1cb16qcch7h19l373rb4wphm07p12k6ain",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/c4ebde39c21d85c402e615db225b57b5e27ed1d9.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@c4ebde39...ff0f8af5](https://github.com/nix-community/emacs-overlay/compare/c4ebde39c21d85c402e615db225b57b5e27ed1d9...ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6)

* [`8f19a025`](https://github.com/nix-community/emacs-overlay/commit/8f19a0251aa3f43de40b6f71d755b64c0b400c8b) flake: add nixConfig for build cache
* [`0ac6d8d8`](https://github.com/nix-community/emacs-overlay/commit/0ac6d8d8060786dfe53bdd725572ee5b020305d6) Updated repos/elpa
* [`5342ef6d`](https://github.com/nix-community/emacs-overlay/commit/5342ef6d94113aff959bd01da5707cbe81ee2b25) Updated repos/melpa
* [`cd9eebce`](https://github.com/nix-community/emacs-overlay/commit/cd9eebcef6b9c65e9ee94b3024348b625dcfdba4) Updated repos/melpa
* [`d7d53d72`](https://github.com/nix-community/emacs-overlay/commit/d7d53d728dc68d0fca4601b4e155e746ce274098) Updated repos/nongnu
* [`ff7ca8c1`](https://github.com/nix-community/emacs-overlay/commit/ff7ca8c14491c1e83d79381f2cbb49b86e648ecc) Updated repos/melpa
* [`fde7fa9b`](https://github.com/nix-community/emacs-overlay/commit/fde7fa9b5c44294f2d8f335897a2cc41cca14e47) Updated repos/melpa
* [`914b123b`](https://github.com/nix-community/emacs-overlay/commit/914b123b92a9692a1bb54d127033003dd272b9be) Updated repos/nongnu
* [`cbec347e`](https://github.com/nix-community/emacs-overlay/commit/cbec347e20757eed8911282ea9d1fdd8d5b4bc9b) Updated repos/melpa
* [`3c235db0`](https://github.com/nix-community/emacs-overlay/commit/3c235db06bb1493f39937e080447bf5bfac24f24) Updated repos/melpa
* [`93e9a14c`](https://github.com/nix-community/emacs-overlay/commit/93e9a14c4d59ad6481418f76f4e8353b7c6129d8) Updated repos/elpa
* [`bd28dc9f`](https://github.com/nix-community/emacs-overlay/commit/bd28dc9f3e62796191fa3ba277a7eab011e9f8af) Updated repos/melpa
* [`48c24461`](https://github.com/nix-community/emacs-overlay/commit/48c24461051f108c4dfdf4cdac54e6c5e3f479c3) Updated repos/nongnu
* [`dce15e40`](https://github.com/nix-community/emacs-overlay/commit/dce15e40f673c6ba58fc40a0a59587f19476b20b) Updated repos/melpa
* [`9ca0640a`](https://github.com/nix-community/emacs-overlay/commit/9ca0640a176587a3ebee10d84621bfb327761638) Updated repos/elpa
* [`ca95cddd`](https://github.com/nix-community/emacs-overlay/commit/ca95cddd3feec009600f570ccb05f27717c10fbb) Updated repos/melpa
* [`d7072d26`](https://github.com/nix-community/emacs-overlay/commit/d7072d2680c8f0f2fce6246a8d41da67dd179a6d) Updated repos/elpa
* [`e7032c47`](https://github.com/nix-community/emacs-overlay/commit/e7032c472f0223bb65a27cf3b38af5c935eba962) Updated repos/melpa
* [`6a2222bf`](https://github.com/nix-community/emacs-overlay/commit/6a2222bf037ac02d79f28c5455ec62adad699560) Updated repos/melpa
* [`39db4c58`](https://github.com/nix-community/emacs-overlay/commit/39db4c582a4935df06184da96d2315c01cd0613c) Updated repos/melpa
* [`cc8c7cbb`](https://github.com/nix-community/emacs-overlay/commit/cc8c7cbb74cdf2f409c061d2b82f7b4809d23b61) Updated repos/melpa
* [`dff7ec23`](https://github.com/nix-community/emacs-overlay/commit/dff7ec237601b36f8469e27cf8fdf451e1b04c74) Updated repos/nongnu
* [`bc29db7d`](https://github.com/nix-community/emacs-overlay/commit/bc29db7db64ef56207f42b4c654ecd1a06a60e84) Updated repos/melpa
* [`8d3390e6`](https://github.com/nix-community/emacs-overlay/commit/8d3390e69f6f850f33e7b70d2c7a4b83c5f69871) Updated repos/nongnu
* [`f8d8eb4b`](https://github.com/nix-community/emacs-overlay/commit/f8d8eb4ba39c78cbf20b5142b2cb4ec7e0e58b34) Updated repos/emacs
* [`cfcf2398`](https://github.com/nix-community/emacs-overlay/commit/cfcf2398c07242a3c3aa389cfb9efe703ad661db) Updated repos/melpa
* [`0c2be677`](https://github.com/nix-community/emacs-overlay/commit/0c2be677ba056c82936e07bced27e1e14d83559d) Updated repos/elpa
* [`0a85b8e4`](https://github.com/nix-community/emacs-overlay/commit/0a85b8e407611de0994496dda6bce15bf280c190) Updated repos/melpa
* [`976cd840`](https://github.com/nix-community/emacs-overlay/commit/976cd840f97149664bc826bbf2e3718d62fb019b) Updated repos/emacs
* [`3bf71846`](https://github.com/nix-community/emacs-overlay/commit/3bf718469779e993ae41f0acf437e3ac42e394f1) Updated repos/melpa
* [`38a4cd63`](https://github.com/nix-community/emacs-overlay/commit/38a4cd63e3cb6e7e044cd60282093a037f1ebd09) Updated repos/elpa
* [`2f631af1`](https://github.com/nix-community/emacs-overlay/commit/2f631af12a169c9d4b455c6e892a1fbe9c5b8a50) Updated repos/emacs
* [`9b6821c5`](https://github.com/nix-community/emacs-overlay/commit/9b6821c510a5ab2a8358b34b9e6b8303eddc3e38) Updated repos/melpa
* [`dd270ae6`](https://github.com/nix-community/emacs-overlay/commit/dd270ae65d57737567dc6a16e16ce934b59817bf) Updated repos/emacs
* [`d092f0b6`](https://github.com/nix-community/emacs-overlay/commit/d092f0b653985d6cb1d7c828ff2ac602a36b7e4e) Updated repos/melpa
* [`34bb46ef`](https://github.com/nix-community/emacs-overlay/commit/34bb46ef62a3069ac6cf8dca07cbfa1137822d20) Updated repos/melpa
* [`7e317b12`](https://github.com/nix-community/emacs-overlay/commit/7e317b12b7668d9f34807542717dae1bce21a242) Updated repos/emacs
* [`c89b34da`](https://github.com/nix-community/emacs-overlay/commit/c89b34da3461fe336dfed895d67d2b9d072a9b66) Updated repos/melpa
* [`444d1de5`](https://github.com/nix-community/emacs-overlay/commit/444d1de55d7cf3df7ceeb6509b562df8873c1bd9) Updated repos/emacs
* [`a24cd789`](https://github.com/nix-community/emacs-overlay/commit/a24cd78969ad2a9e369b559df8ce586a22b3442d) Updated repos/melpa
* [`1195f952`](https://github.com/nix-community/emacs-overlay/commit/1195f952f1d610244a4b1b8b0b9dbd13ef6d553c) Updated repos/melpa
* [`98667634`](https://github.com/nix-community/emacs-overlay/commit/986676341b4464f35a2e9bc4981fbc01a3c5079c) Updated repos/elpa
* [`ac2a503b`](https://github.com/nix-community/emacs-overlay/commit/ac2a503b226f57aa7650eeeb4bfd0dec7c8a4720) Updated repos/emacs
* [`9b666f4c`](https://github.com/nix-community/emacs-overlay/commit/9b666f4c6cc6702c010948a16d73f810a2774c48) Updated repos/melpa
* [`e8f69dc3`](https://github.com/nix-community/emacs-overlay/commit/e8f69dc387793aee0dc327b19fdcd2ecc77456f2) Updated repos/elpa
* [`33f81589`](https://github.com/nix-community/emacs-overlay/commit/33f81589f8959f4e0008a5743e9447548fa2d551) Updated repos/emacs
* [`48c44fe8`](https://github.com/nix-community/emacs-overlay/commit/48c44fe806d73dbe376be665250659cffaef3610) Updated repos/melpa
* [`5aef1631`](https://github.com/nix-community/emacs-overlay/commit/5aef16311ea92339e432e7bf8858f6dcff00468b) Updated repos/emacs
* [`20c47d24`](https://github.com/nix-community/emacs-overlay/commit/20c47d24ebe8fa16d4c2ac79286631cf92101781) Updated repos/melpa
* [`299d52f7`](https://github.com/nix-community/emacs-overlay/commit/299d52f738e576ab510e6c7007b11b0f5f392c36) Updated repos/elpa
* [`bef4a4b2`](https://github.com/nix-community/emacs-overlay/commit/bef4a4b28eec157d8d8b2718c8d0eeaa6f029458) Updated repos/emacs
* [`0a91697a`](https://github.com/nix-community/emacs-overlay/commit/0a91697aae6acefe1d5c9b3654ea273b53539380) Updated repos/melpa
* [`74d55aaa`](https://github.com/nix-community/emacs-overlay/commit/74d55aaacdad518fb96c4f70a535cc2804743c57) Updated repos/emacs
* [`ed643867`](https://github.com/nix-community/emacs-overlay/commit/ed6438672d7f9fcb2b11df7c0a626c24cc5f93d4) Updated repos/melpa
* [`a4eae3fc`](https://github.com/nix-community/emacs-overlay/commit/a4eae3fc578e0a008a15d04fe524231265bb27fa) Updated repos/emacs
* [`d25784b5`](https://github.com/nix-community/emacs-overlay/commit/d25784b571d9c45ba40ec09f749b6c19a863d253) Updated repos/melpa
* [`42223acc`](https://github.com/nix-community/emacs-overlay/commit/42223accdafd3e9803e2ce955c85903c86ab2b1b) Updated repos/nongnu
* [`583f06bf`](https://github.com/nix-community/emacs-overlay/commit/583f06bf5997648fedb8510faaa68f111c1775d6) Updated repos/elpa
* [`6185ec1e`](https://github.com/nix-community/emacs-overlay/commit/6185ec1e92adb153d0de3abc703149693d66a450) Updated repos/emacs
* [`334255ca`](https://github.com/nix-community/emacs-overlay/commit/334255cac589f8fac99d7cd584413971dc9debe1) Updated repos/melpa
* [`e28c8932`](https://github.com/nix-community/emacs-overlay/commit/e28c8932e5023d19dfb4ce260c88b9557f40e89b) Enable Emacs 29 features for emacsUnstable
* [`c1f6d037`](https://github.com/nix-community/emacs-overlay/commit/c1f6d037d039fb3b5ff4a8a62342d8ac5238b504) Update comment
* [`f73f92e0`](https://github.com/nix-community/emacs-overlay/commit/f73f92e01b6477dd56a628e251d265ee999f1afe) Fix issue link for bug-reference-prog-mode
* [`644ae3ce`](https://github.com/nix-community/emacs-overlay/commit/644ae3ce05ae9d42232bba9642d4eaa63bb062d3) Fix comment
* [`0030dec0`](https://github.com/nix-community/emacs-overlay/commit/0030dec0b386d7abd8425b93b0e47d90ebeb3d38) Updated repos/elpa
* [`acf157f5`](https://github.com/nix-community/emacs-overlay/commit/acf157f5400a62fd1506da20d257bcec07c040c7) Updated repos/emacs
* [`96fec8e6`](https://github.com/nix-community/emacs-overlay/commit/96fec8e6cdb99a7a40e5d8f7f7449d7fee6d441f) Updated repos/melpa
* [`d16c6c1f`](https://github.com/nix-community/emacs-overlay/commit/d16c6c1fb297d57aa4147e291ef06b650fa24061) Use overrideScope' for override
* [`63c896e1`](https://github.com/nix-community/emacs-overlay/commit/63c896e1efb1a75cb54523b79ddda02562b56bd5) Updated repos/emacs
* [`86ea3268`](https://github.com/nix-community/emacs-overlay/commit/86ea3268b55bb632de43a80a37501a3d05cdb224) Updated repos/melpa
* [`1a3221bb`](https://github.com/nix-community/emacs-overlay/commit/1a3221bb041067b0a4942af160d9c6d93e7596ac) Updated repos/elpa
* [`73ea60a2`](https://github.com/nix-community/emacs-overlay/commit/73ea60a234e4dabc5a9a48ac561ee9dcd974ea8d) Updated repos/emacs
* [`29ec9b44`](https://github.com/nix-community/emacs-overlay/commit/29ec9b4431916ca379eba7770577812e8610e372) Updated repos/melpa
* [`4cf48f29`](https://github.com/nix-community/emacs-overlay/commit/4cf48f29e6235612e5ccb3735b28aeedb02bdfb2) Updated repos/elpa
* [`f6e473f6`](https://github.com/nix-community/emacs-overlay/commit/f6e473f64a61d586b7f5cc01fac11834abf96934) Updated repos/emacs
* [`1be00f42`](https://github.com/nix-community/emacs-overlay/commit/1be00f42d07320f4fd0230172ceb27ec40330f53) Updated repos/melpa
* [`0a03d1f4`](https://github.com/nix-community/emacs-overlay/commit/0a03d1f4955feb875e3d9ebddd010b1b05f42905) Updated repos/emacs
* [`20f5ce4d`](https://github.com/nix-community/emacs-overlay/commit/20f5ce4dfacaf87234d6ab2b786dd008032edde1) Updated repos/melpa
* [`3655d150`](https://github.com/nix-community/emacs-overlay/commit/3655d1502e02bafa2668a74e511166ce5415c247) Updated repos/elpa
* [`00f31a3b`](https://github.com/nix-community/emacs-overlay/commit/00f31a3be2f8d42cddd61b9a4e858eb1feae63e5) Updated repos/emacs
* [`29a93f82`](https://github.com/nix-community/emacs-overlay/commit/29a93f82abd706561032c31ce59a0e94b3e7963f) Updated repos/melpa
* [`b1b45ec1`](https://github.com/nix-community/emacs-overlay/commit/b1b45ec1178f862c3b5d69b50821f0c5c11d582c) Add emacsUnstablePgtk
* [`527415f4`](https://github.com/nix-community/emacs-overlay/commit/527415f4fd8b77182b21a88aa28fb7e23ff07043) Updated repos/elpa
* [`62b1e465`](https://github.com/nix-community/emacs-overlay/commit/62b1e46588983fd567452c9da4f5bfa12dab9116) Updated repos/emacs
* [`29271109`](https://github.com/nix-community/emacs-overlay/commit/29271109bf6fb83f60b2b512e88ced787ca49994) Updated repos/melpa
* [`7606cc4b`](https://github.com/nix-community/emacs-overlay/commit/7606cc4b272b55d800c5b62adff217e5833db045) Updated repos/melpa
* [`c295a5c8`](https://github.com/nix-community/emacs-overlay/commit/c295a5c882c2d3a6039c0204657f3fef8da79ab4) Updated repos/elpa
* [`5fef114d`](https://github.com/nix-community/emacs-overlay/commit/5fef114d0a2bce6c2b1373f379889dd33cc9f22c) Updated repos/emacs
* [`fbe8bd5e`](https://github.com/nix-community/emacs-overlay/commit/fbe8bd5e0226b57911c1f30dc26e3bec57c2e1a4) Updated repos/melpa
* [`06801274`](https://github.com/nix-community/emacs-overlay/commit/06801274272a2dc641a696ac62245f2eaa806bf1) Updated repos/elpa
* [`3a5111ac`](https://github.com/nix-community/emacs-overlay/commit/3a5111ac08ab8bf76cb4127e0e2f19a54d2ab991) Updated repos/emacs
* [`42c6d740`](https://github.com/nix-community/emacs-overlay/commit/42c6d7402a34c5ce53dafd87906d865e10e76dbb) Updated repos/melpa
* [`660ddee3`](https://github.com/nix-community/emacs-overlay/commit/660ddee3c3280a08590e999b1d08af4b4fc82b6b) Updated repos/nongnu
* [`9ed40859`](https://github.com/nix-community/emacs-overlay/commit/9ed408593f084113877fb09b7869f55582bd2808) Updated repos/emacs
* [`c470756d`](https://github.com/nix-community/emacs-overlay/commit/c470756d69bc9195d0ddc1fcd70110376fc93473) Updated repos/melpa
* [`9fb7466c`](https://github.com/nix-community/emacs-overlay/commit/9fb7466c3fefc6332c7aef2f7fdb1667a47f3bfb) Updated repos/elpa
* [`12308581`](https://github.com/nix-community/emacs-overlay/commit/1230858106f7bc2ec6397e07ce09202fe1084b67) Updated repos/emacs
* [`abaa2799`](https://github.com/nix-community/emacs-overlay/commit/abaa27998067fe47f28ba75e43225481101a9607) Updated repos/melpa
* [`3575e7de`](https://github.com/nix-community/emacs-overlay/commit/3575e7def8673bb5560adc0b4331f43d7dbbe781) Updated repos/elpa
* [`e7ae8c04`](https://github.com/nix-community/emacs-overlay/commit/e7ae8c04fe3785459c87a4725c229bd4e421e5d0) Updated repos/emacs
* [`58fbc819`](https://github.com/nix-community/emacs-overlay/commit/58fbc819635daef829809f1e8d3e37961e5670a1) Updated repos/melpa
* [`8a5f05e1`](https://github.com/nix-community/emacs-overlay/commit/8a5f05e13f0254b5f85368b03cb5e9aeebc40474) Updated repos/nongnu
* [`0dfa1616`](https://github.com/nix-community/emacs-overlay/commit/0dfa16169942b7e524a353b07f8643d57524a6e6) Updated repos/melpa
* [`87d3eb48`](https://github.com/nix-community/emacs-overlay/commit/87d3eb48b7cdc4fa82b7bdc2b1e7964c82518c61) Path fixes resulting from libgccjit changes
* [`4e39df03`](https://github.com/nix-community/emacs-overlay/commit/4e39df0374084e3172c02bcfb65e2c654560c388) Updated repos/emacs
* [`f948eb91`](https://github.com/nix-community/emacs-overlay/commit/f948eb91ff33ead565b32d4e4e9cb17ab304c0b4) Updated repos/melpa
* [`d61f4d1c`](https://github.com/nix-community/emacs-overlay/commit/d61f4d1c25792acdde125a2b23141d2c7d357164) Updated repos/emacs
* [`7d7f080f`](https://github.com/nix-community/emacs-overlay/commit/7d7f080f81b042fc7de78c87c970dd2004082cc5) Updated repos/melpa
* [`ad75b205`](https://github.com/nix-community/emacs-overlay/commit/ad75b205105b81fd4f1847fcb28dcd366f3624b3) Updated repos/melpa
* [`065f390d`](https://github.com/nix-community/emacs-overlay/commit/065f390de7b37d86e014777cab64b6410498ecc8) Updated repos/elpa
* [`ddab5e54`](https://github.com/nix-community/emacs-overlay/commit/ddab5e5415830a4a680bfb17ef57849f425795b5) Updated repos/emacs
* [`dad2876c`](https://github.com/nix-community/emacs-overlay/commit/dad2876c31059cd5b32e9272864409a69a10e62e) Updated repos/melpa
* [`50c62e5f`](https://github.com/nix-community/emacs-overlay/commit/50c62e5f77a2aed1c6ae7e1779518a6177085a41) Updated repos/emacs
* [`00993d05`](https://github.com/nix-community/emacs-overlay/commit/00993d057b699a7a9921942d75eca18c191a19ad) Updated repos/melpa
* [`183e347a`](https://github.com/nix-community/emacs-overlay/commit/183e347a7e0f61bd68e3b4ae99901eac96330791) Updated repos/emacs
* [`12ba135e`](https://github.com/nix-community/emacs-overlay/commit/12ba135e863d25ffc3d80f05678ef7deacfd3689) Updated repos/melpa
* [`3b912580`](https://github.com/nix-community/emacs-overlay/commit/3b912580d054557e959d0b282fd12f5c473103f3) Updated repos/melpa
* [`cd22b696`](https://github.com/nix-community/emacs-overlay/commit/cd22b6969b0cd3113ae8b742a88e5f274524435e) Updated repos/elpa
* [`20248af9`](https://github.com/nix-community/emacs-overlay/commit/20248af9c7408b3bb5d5db892a586de3e760834d) Updated repos/emacs
* [`8c59dfc1`](https://github.com/nix-community/emacs-overlay/commit/8c59dfc130abf5bbc8609734b3da425fd5a7d1e7) Updated repos/emacs
* [`5ad38e37`](https://github.com/nix-community/emacs-overlay/commit/5ad38e37e0e76abdc95486c642013f54abba96c4) Updated repos/melpa
* [`02eea1bf`](https://github.com/nix-community/emacs-overlay/commit/02eea1bf04605ef02eba5363d3cd578170f2b610) Updated repos/nongnu
* [`5328b83d`](https://github.com/nix-community/emacs-overlay/commit/5328b83dd64512f94b73b0f1877c26048052a3c2) Updated repos/emacs
* [`7f4b9004`](https://github.com/nix-community/emacs-overlay/commit/7f4b90040296ed6faacbcd9933927852d020df75) Updated repos/melpa
* [`fffb5156`](https://github.com/nix-community/emacs-overlay/commit/fffb5156c35ab5dd1cf88d424ec6aa4a91b8ce97) Updated repos/emacs
* [`03d4bfb6`](https://github.com/nix-community/emacs-overlay/commit/03d4bfb6ac2c177d3f6a9d272547bfe2371cdf37) Updated repos/melpa
* [`a1c8cf91`](https://github.com/nix-community/emacs-overlay/commit/a1c8cf91d0735e15243e90d00d76702fd4e0a068) Updated repos/melpa
* [`fc0a9c42`](https://github.com/nix-community/emacs-overlay/commit/fc0a9c421f8b1533317bca59867c18244487534a) Updated repos/melpa
* [`23f50315`](https://github.com/nix-community/emacs-overlay/commit/23f5031575b1975ffaefeb55102cbf3f608d9e07) Updated repos/elpa
* [`43ac4bba`](https://github.com/nix-community/emacs-overlay/commit/43ac4bba4cd61cf0c8931fbda599b83e902468cf) Updated repos/emacs
* [`cbca5fd5`](https://github.com/nix-community/emacs-overlay/commit/cbca5fd577779cbb9228bcdc65474b8cdfe61a2e) Updated repos/melpa
* [`4e52b36e`](https://github.com/nix-community/emacs-overlay/commit/4e52b36ed3f08db0843e161a5f64343d8fb4b35a) Updated repos/melpa
* [`787f334a`](https://github.com/nix-community/emacs-overlay/commit/787f334aed9bb8c373e49a0b0f62da67ed982d22) Updated repos/emacs
* [`f86e3962`](https://github.com/nix-community/emacs-overlay/commit/f86e3962f7b01ffb470b08c0cf95b6ca85516432) Updated repos/melpa
* [`f6a45eb6`](https://github.com/nix-community/emacs-overlay/commit/f6a45eb6985e005444fa4ab45df9aaa1fe575e43) Updated repos/elpa
* [`f86c0588`](https://github.com/nix-community/emacs-overlay/commit/f86c0588c817445d3f617bf839c0810f597654df) Updated repos/emacs
* [`0892b847`](https://github.com/nix-community/emacs-overlay/commit/0892b847937031b70e71b8bbdb4ab6055985789e) Updated repos/melpa
* [`2d6d615f`](https://github.com/nix-community/emacs-overlay/commit/2d6d615f64e6789ca10f050d369f759bcfdf0058) Updated repos/emacs
* [`372c8287`](https://github.com/nix-community/emacs-overlay/commit/372c8287a251f2a4dc7a1929f6368ba78582c3a2) Updated repos/melpa
* [`44e9fd81`](https://github.com/nix-community/emacs-overlay/commit/44e9fd81f9be4893e03d10ef74d1ddb91646f27f) Updated repos/elpa
* [`b402d923`](https://github.com/nix-community/emacs-overlay/commit/b402d923f61f0f2d6740c3dfe4c8ba4776af17dd) Updated repos/emacs
* [`8130908e`](https://github.com/nix-community/emacs-overlay/commit/8130908eb877b81252a5e66a44e9a3bab42793c7) Updated repos/melpa
* [`8482e1be`](https://github.com/nix-community/emacs-overlay/commit/8482e1be6c012c2c8d98ec8a49c7e393b4d14dd2) Updated repos/emacs
* [`d72442b2`](https://github.com/nix-community/emacs-overlay/commit/d72442b2a1932963373e8bab80adfc6aad33c1b0) Updated repos/melpa
* [`4c0a35e8`](https://github.com/nix-community/emacs-overlay/commit/4c0a35e80513bd77fdf8291a820f8eea844be56c) Updated repos/melpa
* [`39c7507e`](https://github.com/nix-community/emacs-overlay/commit/39c7507e5b88a62b8fffde2712bc5ea40253b8e4) Updated repos/elpa
* [`1e9fb0a0`](https://github.com/nix-community/emacs-overlay/commit/1e9fb0a0913fac6f29307042fa08967c7ffd19bd) Updated repos/emacs
* [`2afeb059`](https://github.com/nix-community/emacs-overlay/commit/2afeb0596418d37aa3feb7203cc37a11c10c83fe) Updated repos/melpa
* [`e5e0b480`](https://github.com/nix-community/emacs-overlay/commit/e5e0b4800341c436ba1973593d4641e7f6cb52e7) Updated repos/melpa
* [`3b1a5a94`](https://github.com/nix-community/emacs-overlay/commit/3b1a5a9427c666f196aa7be5b8d4a5838e42a92a) Updated repos/melpa
* [`54173b7b`](https://github.com/nix-community/emacs-overlay/commit/54173b7b65053cb512649f5198f93dced3a7e6bf) Updated repos/emacs
* [`03e96559`](https://github.com/nix-community/emacs-overlay/commit/03e96559076a11e14932734b5bcb16fd3ef114f1) Updated repos/melpa
* [`f8a3a0e9`](https://github.com/nix-community/emacs-overlay/commit/f8a3a0e921822f24e15bf1b24e0de2a5b363f55c) Updated repos/elpa
* [`93f01504`](https://github.com/nix-community/emacs-overlay/commit/93f01504147484688a9170a099b04ea594590571) Updated repos/emacs
* [`052ee45a`](https://github.com/nix-community/emacs-overlay/commit/052ee45a317aaa5b24be093fbde3afb504c8f55d) Updated repos/melpa
* [`16ff6e6f`](https://github.com/nix-community/emacs-overlay/commit/16ff6e6f0d7dba1c4cf57ed4cab6d41c3447f23c) Updated repos/melpa
* [`b7c14a45`](https://github.com/nix-community/emacs-overlay/commit/b7c14a45ec924846f99ecf6da37daa5877dab937) Updated repos/emacs
* [`65ee69cd`](https://github.com/nix-community/emacs-overlay/commit/65ee69cd3f82450078247145f3b61e4a52e1ef7a) Updated repos/melpa
* [`e6f4f265`](https://github.com/nix-community/emacs-overlay/commit/e6f4f265d8f22f64ad94ea8de81cc39cdcfdc1f4) Updated repos/elpa
* [`fb1bd293`](https://github.com/nix-community/emacs-overlay/commit/fb1bd2938c21cc1b45d3a17ccf7780a6cd8eb229) Updated repos/emacs
* [`8a0c157d`](https://github.com/nix-community/emacs-overlay/commit/8a0c157d4d1795f181f5c82c85fcd041660630ee) Updated repos/melpa
* [`11328c7c`](https://github.com/nix-community/emacs-overlay/commit/11328c7c99e9b020b30b49536bd4eb62fef24e6f) Updated repos/melpa
* [`eb64b0a7`](https://github.com/nix-community/emacs-overlay/commit/eb64b0a78614ef64efe0e28ff23462db750c9af8) Updated repos/emacs
* [`00893eb4`](https://github.com/nix-community/emacs-overlay/commit/00893eb4a9a6b68404da1a954057abe1a4b500b5) Updated repos/melpa
* [`78ab22df`](https://github.com/nix-community/emacs-overlay/commit/78ab22dfae186ef31c2ecc7c9e44dd79997cf06c) Updated repos/elpa
* [`bae48bfe`](https://github.com/nix-community/emacs-overlay/commit/bae48bfe86c45919da81a9b915215160591d2d1b) Updated repos/melpa
* [`fda6743a`](https://github.com/nix-community/emacs-overlay/commit/fda6743a89b57e46e8ab46f9f2aa9d9e45914b1c) Updated repos/nongnu
* [`2f21bcd8`](https://github.com/nix-community/emacs-overlay/commit/2f21bcd8f4ed2ab8954b5a0a624c50aa6c5b056e) Updated repos/melpa
* [`c7245e66`](https://github.com/nix-community/emacs-overlay/commit/c7245e6677d32a8fcbce16cd074e66c51cd9e722) Updated repos/emacs
* [`a13f99c8`](https://github.com/nix-community/emacs-overlay/commit/a13f99c8a8fcaf2715ec75084b007eaab877c838) Updated repos/melpa
* [`74b94931`](https://github.com/nix-community/emacs-overlay/commit/74b949310a0112b7a080f61abea6d52de8047744) Updated repos/emacs
* [`b9f58617`](https://github.com/nix-community/emacs-overlay/commit/b9f58617837bb55201c526a8c37976d0ff25aebd) Updated repos/melpa
* [`39501a3c`](https://github.com/nix-community/emacs-overlay/commit/39501a3cf1e833c922e8ed70594c9741ce357c22) Updated repos/emacs
* [`23488bbc`](https://github.com/nix-community/emacs-overlay/commit/23488bbca5ea0012bafa2c75b88902b540ff9940) Updated repos/melpa
* [`7c6b30cc`](https://github.com/nix-community/emacs-overlay/commit/7c6b30ccd55db6ce49fb9377bd3cb3bf605df1b8) Updated repos/emacs
* [`8b3dc10f`](https://github.com/nix-community/emacs-overlay/commit/8b3dc10f7bb3a21853a9f085d7a20c1e57c814b8) Updated repos/melpa
* [`04ba1f5c`](https://github.com/nix-community/emacs-overlay/commit/04ba1f5cd05e83adf0948a7d97c9c4c419450fb0) Updated repos/emacs
* [`bc9ab6c1`](https://github.com/nix-community/emacs-overlay/commit/bc9ab6c16d0e56a8358c7e41b38711159d37b6b3) Updated repos/melpa
* [`60fe647b`](https://github.com/nix-community/emacs-overlay/commit/60fe647be71d6f433f4a8f9f22d7430bf0ef58a4) Updated repos/emacs
* [`80247cfc`](https://github.com/nix-community/emacs-overlay/commit/80247cfcaa45e07de7e7dc1536329ebaaea70382) Updated repos/elpa
* [`0489c1bb`](https://github.com/nix-community/emacs-overlay/commit/0489c1bbade20d3f95e2a96ba384bdc327ed9750) Updated repos/emacs
* [`550e5eed`](https://github.com/nix-community/emacs-overlay/commit/550e5eed7794258c7b2c95d8db6f1f6ba305aeab) Updated repos/emacs
* [`b04a264d`](https://github.com/nix-community/emacs-overlay/commit/b04a264d5f566ce27e1d62eeae3eabaaa8e942ef) Updated repos/nongnu
* [`038158de`](https://github.com/nix-community/emacs-overlay/commit/038158de4da32a280b1787d34c8f41a2a4cb6a5f) Updated repos/elpa
* [`405d1e75`](https://github.com/nix-community/emacs-overlay/commit/405d1e75811d96bb177dabfe6d813e921866b014) Updated repos/emacs
* [`e9e67599`](https://github.com/nix-community/emacs-overlay/commit/e9e67599cda6f57f37178fd33ccff86cc2c2d6c4) Updated repos/emacs
* [`0b6c10ab`](https://github.com/nix-community/emacs-overlay/commit/0b6c10ab19e79fd85c1bb3ea29c38eb5db464e0c) Updated repos/emacs
* [`ff0f8af5`](https://github.com/nix-community/emacs-overlay/commit/ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6) Updated repos/elpa
