### PR TITLE
niv nixpkgs: update f48a45c8 -> c8d358b3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f48a45c883479a078543fafdb2a66e4f06656d66",
-        "sha256": "11329ll3w4vhxq9yp5mg5nnpjihk8gpkwjlrg3gkri0w1h1jrbdp",
+        "rev": "c8d358b3ade1ba08a945c794b797df3c01f9cbab",
+        "sha256": "0lslq6d3y5g816jzp4w7sbk5qwq733nbizdn2rpkh9rhzzixxwrk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f48a45c883479a078543fafdb2a66e4f06656d66.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c8d358b3ade1ba08a945c794b797df3c01f9cbab.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f48a45c8...c8d358b3](https://github.com/nixos/nixpkgs/compare/f48a45c883479a078543fafdb2a66e4f06656d66...c8d358b3ade1ba08a945c794b797df3c01f9cbab)

* [`343f7f8f`](https://github.com/NixOS/nixpkgs/commit/343f7f8f07dcb376cf05658f6e80e3826ef6a470) mopidy-somafm: 2.0.0 -> 2.0.2
* [`66810822`](https://github.com/NixOS/nixpkgs/commit/66810822f941e94340f87eba3ff78efcc3a7f5b6) lib/systems/inspect.nix: explanatory comment
* [`32ac8745`](https://github.com/NixOS/nixpkgs/commit/32ac87459e003f6f323c4f3e0087c92a931abb70) flutter: Add dependencies for Linux desktop compilation
* [`7fd5a333`](https://github.com/NixOS/nixpkgs/commit/7fd5a33393a196d12769d5d10cd5972ac2d68d93) flutter: Move runtime libraries out of FHS using LD_LIBRARY_PATH
* [`c6b044c1`](https://github.com/NixOS/nixpkgs/commit/c6b044c101523efbe699373fdf449fdd60390cf4) flutter: Use RPATH and CFLAGS to remove Linux desktop compilation and runtime FHS dependency
* [`ea48c7c9`](https://github.com/NixOS/nixpkgs/commit/ea48c7c9b68add8b1b7f8a8926d9fec3df12301f) flutter: Modularize unwrapped, wrapped, and FHS components
* [`e2adc5d8`](https://github.com/NixOS/nixpkgs/commit/e2adc5d8997a8a63cd3e69d9ac21b94a34c7f536) flutter: Only enable Linux desktop support by default on Linux
* [`e4df8739`](https://github.com/NixOS/nixpkgs/commit/e4df8739b7dc5d2b327669aa3edeff6f2be32c05) flutter: Implement mkFlutter function using barebones FHS environment
* [`b180cb46`](https://github.com/NixOS/nixpkgs/commit/b180cb467bbf3b4ec8f8f488647753081f3af72a) flutter.mkFlutterApp: Use wrapped Flutter package during build
* [`43d1e2eb`](https://github.com/NixOS/nixpkgs/commit/43d1e2ebf49cfb1b96c9ec82c0de3dd6b2b3935c) flutter.mkFlutterApp: Don't use .packages
* [`9c6c81dc`](https://github.com/NixOS/nixpkgs/commit/9c6c81dc4914cc40db32f2ebd351b80f0f9e6576) flutter: Add fake SDK derivation
* [`8fbe036f`](https://github.com/NixOS/nixpkgs/commit/8fbe036fb2bf56ac5f1195a1c68d7a1641931ddf) mercury: use jdk_headless to allow non-gui builds
* [`fd465528`](https://github.com/NixOS/nixpkgs/commit/fd46552867e2ce5fdb27a1c8fb27deea227c9050) flutter: Add libdeflate to build environment
* [`1d547bae`](https://github.com/NixOS/nixpkgs/commit/1d547baee0f502f91a67153ee3a9355d0eb31c61) flutter: Do not rely on pkg-config setup hook to build search path
* [`240d9bdf`](https://github.com/NixOS/nixpkgs/commit/240d9bdf436a460dab587a0ff391d5029c1f8fb4) flutter: Properly set linker flags in wrapper
* [`aa33cb99`](https://github.com/NixOS/nixpkgs/commit/aa33cb995640cf2dcc4ff8751125fa92f4c742d1) flutter: Reorganize the wrapper code
* [`341fa709`](https://github.com/NixOS/nixpkgs/commit/341fa709ffca3d4c850e64bbbaec5d2a93c234fb) flutter: Redesign wrapping architecture
* [`5c14005e`](https://github.com/NixOS/nixpkgs/commit/5c14005e00044516c3005d9a4775480bfb5c24ab) python310Packages.pytest-aio: 1.4.1 -> 1.5.0
* [`b782e77d`](https://github.com/NixOS/nixpkgs/commit/b782e77de006e0683b9c9805a209a119eb854448) python310Packages.pytest-aio: add changelog to meta
* [`da46337f`](https://github.com/NixOS/nixpkgs/commit/da46337f0e25190ce1a51986f1cf401227bc59b1) crystfel: enable aarch64-* and external filter plugins on Darwin
* [`3c9e3937`](https://github.com/NixOS/nixpkgs/commit/3c9e3937c00a89c2587ba09fa8c8c88dcc7f7dc9) maintainers: change StillerHarpo
* [`d980b918`](https://github.com/NixOS/nixpkgs/commit/d980b918663ff2e21b1ad77950d1fd0c30c6a27a) crystfel: review fixes
* [`9897255a`](https://github.com/NixOS/nixpkgs/commit/9897255a21aecbfb4f098d7f1d22363b7dcc56b2) portal: init at 1.2.2
* [`820dc2a5`](https://github.com/NixOS/nixpkgs/commit/820dc2a56057bcc396dbddbff6be91e1cec73f6f) git: also patch the ls command for git-core scripts
* [`6ed55eaa`](https://github.com/NixOS/nixpkgs/commit/6ed55eaa191146ffda72cda307ef86a2aef2cd06) framesh: 0.5.0 -> 0.6.2
* [`f4339002`](https://github.com/NixOS/nixpkgs/commit/f43390024ce7bf53688ad68fbc74b6aeccbc9687) crystfel: more review fixes
* [`a02ac1d2`](https://github.com/NixOS/nixpkgs/commit/a02ac1d2e8cf76931a1344b6eed75bc0491aad14) fontforge: 20220308 -> 20230101
* [`10689827`](https://github.com/NixOS/nixpkgs/commit/1068982713a0f3b8ab98f251d1e1dd873f458ac2) libjxl: add patch to fix build with gcc for RISC-V
* [`138983c6`](https://github.com/NixOS/nixpkgs/commit/138983c60019183a6f0cb96623f44032f8b51b37) xp-pen-deco-01-v2-driver: 3.2.3 -> 3.3.9
* [`1a83976e`](https://github.com/NixOS/nixpkgs/commit/1a83976e30e4c7fd65a88250c61939b21994faf2) libhwy: 1.0.2 -> 1.0.4
* [`5ba86e5e`](https://github.com/NixOS/nixpkgs/commit/5ba86e5ea606cca3a310a751ed851543558bb272) libtiff: format expression with nixpkgs-fmt
* [`878a3ff9`](https://github.com/NixOS/nixpkgs/commit/878a3ff9c6ce183e29c0a9f66c44707b3d54d6c5) libtiff: adjust expression format (propagatedBuildInputs part)
* [`6a60f11b`](https://github.com/NixOS/nixpkgs/commit/6a60f11bfa4a20a5487b90cd3cce3a43274c8e68) libtiff: move libdeflate into propagatedBuildInputs
* [`eb3cb597`](https://github.com/NixOS/nixpkgs/commit/eb3cb597c3a234be8085f49ff4d01fc872eb0cf0) openjpeg: remove libdeflate from buildInputs
* [`b48f6118`](https://github.com/NixOS/nixpkgs/commit/b48f6118c489beda224223dc66589195b387a9d0) desktopToDarwinBundle: Return at most 1 literal match from desktop file
* [`8e02449e`](https://github.com/NixOS/nixpkgs/commit/8e02449edb14d316bc7b4fdbc42077a9294ca90a) texinfo: 7.0.2 -> 7.0.3
* [`d8de50d5`](https://github.com/NixOS/nixpkgs/commit/d8de50d5ddc686580d717cac9da290defadc56ad) gst-plugins-base: enable graphene and re-enable gstgl on aarch64-darwin
* [`4ff7d99a`](https://github.com/NixOS/nixpkgs/commit/4ff7d99a6a4f978c7c2a704406380ee7febcd59b) gst-plugins-bad: add cocoa for darwin
* [`8bbb9ca1`](https://github.com/NixOS/nixpkgs/commit/8bbb9ca13d1ecd1ff7ba7e7e237870b2c6467cdc) gtk4: build media-gstreamer on aarch64-darwin
* [`02ef0aab`](https://github.com/NixOS/nixpkgs/commit/02ef0aabda277d5dcc89942a27e335aca2f001f8) squashfsTools: 4.5.1 -> 4.6
* [`f9ce8370`](https://github.com/NixOS/nixpkgs/commit/f9ce837059897e692bd7d31a7e1329f9af7ce254) squashfsTools: 4.6 -> 4.6.1
* [`5a649004`](https://github.com/NixOS/nixpkgs/commit/5a6490040c1fff29f94cf3a6a80bc07709836046) linux: fix error with IR remotes
* [`15399cff`](https://github.com/NixOS/nixpkgs/commit/15399cff6d678b035e1b2b97542203f641bb8f42) gsocket: 1.4.39 -> 1.4.40
* [`d9a07bcd`](https://github.com/NixOS/nixpkgs/commit/d9a07bcd41135f2b9653ba934fc5867856196f78) desktopToDarwinBundle: Add debug outputs for icon conversion
* [`f78175ad`](https://github.com/NixOS/nixpkgs/commit/f78175ad35e0fa7eb5183b756cfa988b783fed77) desktopToDarwinBundle: Fix icon selection algorithm
* [`4c135f04`](https://github.com/NixOS/nixpkgs/commit/4c135f04bd291a79a8ed4c8fc25c1b9a76df0e63) twitter-color-emoji: 14.0.2 -> 14.1.2
* [`8826b550`](https://github.com/NixOS/nixpkgs/commit/8826b550a0d519c9adfd5d024ec8557170d34dc5) ruby: update default version to `ruby_3_1`
* [`d951601e`](https://github.com/NixOS/nixpkgs/commit/d951601ea753b574bf7d37eb6b78b4200ad84ae8) libinput: 1.22.1 -> 1.23.0
* [`3c78f8bb`](https://github.com/NixOS/nixpkgs/commit/3c78f8bbaf49e7b926c4eb2866f926725d1135ac) foundationdb: remove unused branch parameter to cmakeBuild
* [`f5f5051d`](https://github.com/NixOS/nixpkgs/commit/f5f5051d816e6d2e9523ca47649de4e37e0cabe7) foundationdb: don't set CMAKE_BUILD_TYPE
* [`2f3759f4`](https://github.com/NixOS/nixpkgs/commit/2f3759f4ff06ae7c7df8f465c3fef28537081f14) foundationdb: remove unused with builtins
* [`b9a6bd81`](https://github.com/NixOS/nixpkgs/commit/b9a6bd815a5f2d8db82d0995086d7b4523b39e16) foundationdb: remove seemingly no longer needed patching of fdb_install
* [`79c547bb`](https://github.com/NixOS/nixpkgs/commit/79c547bb97e9b5a2d2565c0549d821c50b358156) foundationdb: add pkg-config to help find libraries
* [`6fc2ba03`](https://github.com/NixOS/nixpkgs/commit/6fc2ba036ab77c647ea897b2aa26d38d540c4046) foundationdb: add 7.1.26
* [`73ca83e9`](https://github.com/NixOS/nixpkgs/commit/73ca83e965a2036ea0a17681273c040ed4aff99a) foundationdb: build on aarch64-linux
* [`71e8e214`](https://github.com/NixOS/nixpkgs/commit/71e8e2148d920ba6a1db6f64e94cf135620c4923) python310Packages.accelerate: init at 0.18.0
* [`712adfbb`](https://github.com/NixOS/nixpkgs/commit/712adfbb27f3369b18adee28a6e0939833d8ec31) obs-studio-plugins.obs-teleport: init at 0.6.5
* [`e4f3b21d`](https://github.com/NixOS/nixpkgs/commit/e4f3b21d4d2e7f0d74df878d98f2f49a47533535) python310Packages.peft: init at 0.2.0
* [`6a2295a8`](https://github.com/NixOS/nixpkgs/commit/6a2295a80a4ec98dfe4a1603660d27ddf16357f2) libcbor: enable strictDeps
* [`e89356a9`](https://github.com/NixOS/nixpkgs/commit/e89356a9b70f27a4bad87e54b974237649acf6f0) maintainers: add indexyz
* [`59d2de73`](https://github.com/NixOS/nixpkgs/commit/59d2de73ede277f614313a3200caeeb1358608dc) ffmpeg: add libplacebo
* [`b5d052d4`](https://github.com/NixOS/nixpkgs/commit/b5d052d438df99d5a80e7c126551656d5ba74f75) git: fix in completion scripts references to environment utils
* [`79d78413`](https://github.com/NixOS/nixpkgs/commit/79d784131a9e3dc479f29ad68a1fb79b55d3e45c) fluidsynth: 2.3.1 -> 2.3.2
* [`112150ec`](https://github.com/NixOS/nixpkgs/commit/112150ec70f1846a88301ef085dbb933ee8968c5) setup-hooks/strip.sh: preserve file dates
* [`5241ee98`](https://github.com/NixOS/nixpkgs/commit/5241ee98da2bf7d50f4e3c05742aa9d0bc41b3d6) directfb: make reproducible
* [`72e952ef`](https://github.com/NixOS/nixpkgs/commit/72e952ef3a2517703300e86bdcdecb1b63f01e95) zstd: 1.5.4 → 1.5.5
* [`7d5b7ff8`](https://github.com/NixOS/nixpkgs/commit/7d5b7ff8ae27c11286726bb8c5f55357932e234b) gpgme: enableParallelBuilding=true
* [`7f7138e8`](https://github.com/NixOS/nixpkgs/commit/7f7138e85646b6925265143ccd6fa4ab506d1d2c) gnu-config: 2021-01-25 -> 2023-01-21
* [`f36f6472`](https://github.com/NixOS/nixpkgs/commit/f36f64723d8ade5059494c5d8ca8da58af12308f) python310: 3.10.10 -> 3.10.11
* [`5a5994d2`](https://github.com/NixOS/nixpkgs/commit/5a5994d2adb7d55818fcffd8febcf8e83f45fb9e) python310Packages.cryptography: 39.0.1 -> 40.0.1
* [`51fdf00e`](https://github.com/NixOS/nixpkgs/commit/51fdf00ecb4a95a14308d73814f678120705ed53) nixos/grafana: fix assertions leaking into YAML
* [`9eafe431`](https://github.com/NixOS/nixpkgs/commit/9eafe4319c247d3211c6c0783bb59003357f6064) gnulib: add gnulib-longdouble-redirect.patch
* [`1fa5ff7d`](https://github.com/NixOS/nixpkgs/commit/1fa5ff7d5d126e3a9d43781483af2edf6c4833d0) gnused: apply gnulib.passthru.longdouble-redirect-patch
* [`810c6c38`](https://github.com/NixOS/nixpkgs/commit/810c6c387ba97d726cb61999a9f474b7f62a1e7f) gettext: apply gnulib.passthru.longdouble-redirect-patch
* [`5d64ebd9`](https://github.com/NixOS/nixpkgs/commit/5d64ebd9366a81dc00cd80209cedd05848cf3dcc) texinfo: apply gnulib.passthru.longdouble-redirect-patch
* [`cee9981b`](https://github.com/NixOS/nixpkgs/commit/cee9981b32cddb028bb05738fdea93be13301271) mpfr: add --disable-decimal-float
* [`e2d44f67`](https://github.com/NixOS/nixpkgs/commit/e2d44f67370bbb497804efbf9c7bc0bfedd1adcd) libpipeline: apply gnulib.passthru.longdouble-redirect-patch
* [`52cf8fea`](https://github.com/NixOS/nixpkgs/commit/52cf8fea4fefeb990d72d2159ce42cf7cf94dd2f) libpipeline: 1.5.4 -> 1.5.6
* [`40f73002`](https://github.com/NixOS/nixpkgs/commit/40f7300227019403d00965fc37709149ba4eadca) gcc: if isPower64 && !isMusl use --with-long-double-format=ieee
* [`aeae5ca5`](https://github.com/NixOS/nixpkgs/commit/aeae5ca56212e800a86aef237e6500c452fce5a9) Revert "goffice: disable tests on powerpc64le"
* [`c5a4cc83`](https://github.com/NixOS/nixpkgs/commit/c5a4cc839601e0adafca2eb6cd18858f064e7c06) glibc: suppress warning about IEEE-standard long double
* [`29b39530`](https://github.com/NixOS/nixpkgs/commit/29b395309fbd55626087ed60e319aa86e5b70264) gcc: make --with-long-double-format configurable by targetPlatform.gcc
* [`deda18ba`](https://github.com/NixOS/nixpkgs/commit/deda18bae8a38ec76c9366e227e3a2b8610ad697) gcc: only pass --with-long-double-format if gcc allows it
* [`0ce0096e`](https://github.com/NixOS/nixpkgs/commit/0ce0096e8f6c01c554b072144aa30af1e74bfbb3) drop gnused gnulib.passthru.longdouble-redirect-patch
* [`cbb4c1eb`](https://github.com/NixOS/nixpkgs/commit/cbb4c1eb7b3e0fd1b27425aadb473d8a7fd349ad) python311: 3.11.2 -> 3.11.3
* [`f53c72b6`](https://github.com/NixOS/nixpkgs/commit/f53c72b60f00135d905b53e74e9522cecc583fc3) python310Packages.sqlalchemy: 2.0.6 -> 2.0.9
* [`5ebc2728`](https://github.com/NixOS/nixpkgs/commit/5ebc272859cf1f07214329e4b6c0659aa97d39ce) python310Packages.sqlalchemy: Fix optional dependency references
* [`4167c068`](https://github.com/NixOS/nixpkgs/commit/4167c06818aaeff8f3e49813c7d3e9872149b23c) python310Packages.pytest-xdist: 3.2.0 -> 3.2.1
* [`70001eb1`](https://github.com/NixOS/nixpkgs/commit/70001eb101e5f9b82a63b5305a108c7c44e531f0) texlive.bin.core: fix cross compilation
* [`089675b3`](https://github.com/NixOS/nixpkgs/commit/089675b38b037312394271a2dd75fceec82ececc) texlive.bin.core-big: fix cross compilation
* [`2abf285e`](https://github.com/NixOS/nixpkgs/commit/2abf285e2be0810c49bd8e5834fe34298bf83c26) stdenv/linux: add is{From,BuiltBy} assertions for patchelf
* [`1847b1bc`](https://github.com/NixOS/nixpkgs/commit/1847b1bc153c1f128c4b37447b4bbb48875b72e3) stdenv/linux: fix patchelf confusion
* [`43bfba1d`](https://github.com/NixOS/nixpkgs/commit/43bfba1dcc96a18c00684a2b7cc0d4d4aef97ed8) xorg.xcbutil{,errors,image,keysyms,renderutil,wm}: update to 2023 April
* [`542fbce5`](https://github.com/NixOS/nixpkgs/commit/542fbce556010e1605eae91c1524eb09ac53c774) mpg123: 1.31.2 -> 1.31.3
* [`7d2235a9`](https://github.com/NixOS/nixpkgs/commit/7d2235a9ca7294d9df4602f3fed751a3f9029861) systemdMinimal: re-enable kmod integration
* [`fd3641ec`](https://github.com/NixOS/nixpkgs/commit/fd3641ec26038e0f23260a7ae3c20f9d412a0f7a) mrustc: 0.9 -> 0.10
* [`d65445f5`](https://github.com/NixOS/nixpkgs/commit/d65445f5b241e87cd7fed8925eb8adb90735e286) python310Packages.aiohttp: speed test up with pytest-xdist
* [`d440fe3c`](https://github.com/NixOS/nixpkgs/commit/d440fe3cc1b0ece187f620eacc42bd150ad8bee1) python310Packages.anyio: speed test up with pytest-xdist
* [`1efae9a8`](https://github.com/NixOS/nixpkgs/commit/1efae9a8ec5e2bddae6257a89c0b33384d7aaad3) python310Packages.passlib: speed test up with pytest-xdist
* [`71efa695`](https://github.com/NixOS/nixpkgs/commit/71efa6959371ac561a229cc5d916b37e2a250918) systemd: 253.2 -> 253.3
* [`3e68a278`](https://github.com/NixOS/nixpkgs/commit/3e68a27822eb3e2a27282e32289a13f5b988c08d) prefetch-npm-deps: refactor
* [`7e247e6f`](https://github.com/NixOS/nixpkgs/commit/7e247e6fecdb539911ddc7fafdbcf6db18506b84) prefetch-npm-deps: download dev deps for git deps with install scripts
* [`e1d64c19`](https://github.com/NixOS/nixpkgs/commit/e1d64c19411e38790765338ac0e68f290f43bbe2) prefetch-npm-deps: throw better error when unsupported git service is used
* [`faa3de1b`](https://github.com/NixOS/nixpkgs/commit/faa3de1bf57a78e8df814e06f05c0b7e038656b7) prefetch-npm-deps: fix clippy lint
* [`a7391ddb`](https://github.com/NixOS/nixpkgs/commit/a7391ddbe6c7403f6537020b0f143a267b6e41a0) mongosh: fix hash now that all git deps are fetched
* [`ae08ff7b`](https://github.com/NixOS/nixpkgs/commit/ae08ff7b7172d3d99c95fb94b79489c39b3db78b) xcodeenv: allow versions higher than specified
* [`353c3809`](https://github.com/NixOS/nixpkgs/commit/353c38092a3135ef26285d0c5e91c16dda32e4fe) texlive/bin: remove unnecessary parentheses
* [`13b1c601`](https://github.com/NixOS/nixpkgs/commit/13b1c60144d9d208e88081c202009dd948e68f7a) python310Packages.pyopenssl: 23.0.0 -> 23.1.1
* [`e22e3f4c`](https://github.com/NixOS/nixpkgs/commit/e22e3f4c62340456ab84d285422ff87f10591524) bitwarden: 2023.2.0 -> 2023.3.2
* [`6fc841cf`](https://github.com/NixOS/nixpkgs/commit/6fc841cf75467c6082c221036a59d5930a2063b1) python310Packages.qcs-api-client: 0.21.3 -> 0.21.4
* [`e9300b3a`](https://github.com/NixOS/nixpkgs/commit/e9300b3a3c46ddd36e2b97bdd4f77dfbc19637aa) grab-site: Don't use override on sqlalchemy fetcher
* [`0f31e9d9`](https://github.com/NixOS/nixpkgs/commit/0f31e9d9322812245d9818857a59ca328455a0fc) privacyidea: Don't use override on sqlalchemy fetcher
* [`c708069c`](https://github.com/NixOS/nixpkgs/commit/c708069ce5ab7e447a7cf428a56c829f961a4d0f) pgadmin: Don't use override on sqlalchemy fetcher
* [`1e87c653`](https://github.com/NixOS/nixpkgs/commit/1e87c6534aac0bd00b95459c16348fd4c94b0c77) python3Packages.matplotlib: fix Tk
* [`d616b23b`](https://github.com/NixOS/nixpkgs/commit/d616b23b9fa64c5e6965c5fe8b3c460c0519d4f3) qt5: 5.15.8 -> 5.15.9
* [`8e166f4a`](https://github.com/NixOS/nixpkgs/commit/8e166f4acdcaf46142d967df103780e0a2ffd9a6) qtwebengine: 5.15.12 -> 5.15.13
* [`1e707213`](https://github.com/NixOS/nixpkgs/commit/1e70721319856d35a86c021cd6620a52facc72a5) Use clickable homepages on packages which are changed in [nixos/nixpkgs⁠#225362](https://togithub.com/nixos/nixpkgs/issues/225362)
* [`ea67874c`](https://github.com/NixOS/nixpkgs/commit/ea67874c07959f79e63752510453257173750277) sbcl: 2.3.0 -> 2.3.2
* [`f4608856`](https://github.com/NixOS/nixpkgs/commit/f4608856947e483a0a28fda372a451b6681f20de) SDL2: don't propagate headers-only packages via RUNPATH
* [`2919970c`](https://github.com/NixOS/nixpkgs/commit/2919970c22b6399e074d063be6e8554df0708529) pypy3Packages.nose: Mark broken
* [`7373272e`](https://github.com/NixOS/nixpkgs/commit/7373272e86e16a0e26f50453dcbb340639bd9eb8) python310Packages.flaky: Drop nose tests
* [`0e3b6c56`](https://github.com/NixOS/nixpkgs/commit/0e3b6c5634f310d50c275ca16dd866f32d330ca8) pypy3Packages.virtualenv: Disable failing tests
* [`57c8befe`](https://github.com/NixOS/nixpkgs/commit/57c8befec1c67c3a7329cf48222f2a06086161b7) pypy3Packages.hypothesis: Fix tests by providing tzdata
* [`f2fcc1fc`](https://github.com/NixOS/nixpkgs/commit/f2fcc1fc25f39a36585e05863550e6cf64c8b034) pypy3Packages.yapf: Disable tests
* [`b7bad825`](https://github.com/NixOS/nixpkgs/commit/b7bad825f74733ccc393707364f491be6f5b09fa) elfutils: enable debuginfod support
* [`23dfa9c2`](https://github.com/NixOS/nixpkgs/commit/23dfa9c2f994d8f9dde1be8d9fe75fd95e1a14f7) fluxcd: 0.41.2 -> 2.0.0-rc.1
* [`087d5081`](https://github.com/NixOS/nixpkgs/commit/087d508123e93c95e756b88ea70754e599a3b2bb) egl-wayland: depend on libdrm instead of mesa
* [`84822c43`](https://github.com/NixOS/nixpkgs/commit/84822c43fcf6787f3680868d6f63e80b69244fbe) gcc: drop include-fixed/bits/statx.h
* [`7d5831a2`](https://github.com/NixOS/nixpkgs/commit/7d5831a25131080e1afc86872ea1c6e3cdcf00a2) python310Packages.aioquic: Fix build with pyopenssl>22 and on darwin
* [`6bf78d8d`](https://github.com/NixOS/nixpkgs/commit/6bf78d8d3d07a77c043b68f3795a250257a23b21) mkYarnPackage: fix uncopied resolutions field
* [`6507c049`](https://github.com/NixOS/nixpkgs/commit/6507c049fd89fd2fb32ee76ba2e42dc247a4f585) gnupg: look for system wide config files at /etc/gnupg/* rather than in the nix store
* [`20c5fe63`](https://github.com/NixOS/nixpkgs/commit/20c5fe6341153d0cfdb1ab6316160873dd526e34) ruby-modules: add jekyll-archives, jekyll-spaceship
* [`fcbf9c64`](https://github.com/NixOS/nixpkgs/commit/fcbf9c6415e9936475d05e6f1090793367b0f2ff) patch-ppd-files: use `meta` and `passthru` directly
* [`414ea018`](https://github.com/NixOS/nixpkgs/commit/414ea01831c08f936959984336ceb82aa7e2519d) python310Packages.dicomweb-client: init at 0.59.1
* [`fd004f17`](https://github.com/NixOS/nixpkgs/commit/fd004f17adfb9b44b19858ade03eae561c7f724c) Revert "python310Packages.kaldi-active-grammar: fixup build"
* [`b1d4dfdd`](https://github.com/NixOS/nixpkgs/commit/b1d4dfddaf961fe8eab1207fb840fe9a67a3b72d) Revert "julia{18,19,}: fix build by a temporary hack"
* [`88fc2266`](https://github.com/NixOS/nixpkgs/commit/88fc226615153f73e951279063637fc5ab8ef4ba) Revert "python3Packages.scikit-learn: hack-fix missing libstdc++"
* [`f06ab170`](https://github.com/NixOS/nixpkgs/commit/f06ab170fae68622dbfd254aac094fb13b0cfcaa) gcc: never disableBootstrap for gfortran
* [`de8ce81f`](https://github.com/NixOS/nixpkgs/commit/de8ce81ff28dea6298527043150218969ea47f9d) cc-wrapper: deunify clang/gcc treatment of -isystem
* [`19d48a92`](https://github.com/NixOS/nixpkgs/commit/19d48a925778a524a970ca06cabc45ade3f82474) doc/stdenv/meta.chapter.md: explain difference between broken and badPlatforms
* [`3d871064`](https://github.com/NixOS/nixpkgs/commit/3d8710643d31d820709b79be37750a863aef34ad) libwebp: fix MFSA-TMP-2023-0001
* [`0afc44be`](https://github.com/NixOS/nixpkgs/commit/0afc44be9a2b6d712f6a4e0f5381403cc8c10ffc) ghostscript: 9.56.1 -> 10.01.1
* [`a0878852`](https://github.com/NixOS/nixpkgs/commit/a0878852ff60e2deacb3c2b6cee8ddaacc94b6d3) ghostscript: add some key reverse-dependencies to passthru.tests
* [`b0b23853`](https://github.com/NixOS/nixpkgs/commit/b0b2385325352398b563a0f65f3428e3d64f38b4) rustc: reapply re-erased-regions-are-local patch
* [`50c40a8f`](https://github.com/NixOS/nixpkgs/commit/50c40a8f6ab80600cf095855ecd7aa972cb6eac3) audit: 2.8.5 -> 3.1
* [`e8ce8afd`](https://github.com/NixOS/nixpkgs/commit/e8ce8afd5570ba78a89fadac6d03fc3ba5d11dfa) write-qt-apps-hook.sh: use make-binary-wrapper for significant speedups
* [`7840f205`](https://github.com/NixOS/nixpkgs/commit/7840f2055a183e93ac69e73b5fc63fcfa9c47a18) flutter: Create the flutter derivation with callPackage alone
* [`15e2a735`](https://github.com/NixOS/nixpkgs/commit/15e2a735f817d77f06139cd99ce52b3ec5272ccb) Revert "cc-wrapper: add optional temporary hack for -B"
* [`6f8a69ee`](https://github.com/NixOS/nixpkgs/commit/6f8a69ee313ada39e9b7c3136d011df4bb1d406c) Revert "llvmPackages_13.compiler-rt-libc: also apply tmp hack"
* [`7f8f688e`](https://github.com/NixOS/nixpkgs/commit/7f8f688ef3d340c50ac47445081ffa1c69449c0c) python3Packages.pybind11: fix cross-compilation with setup hook
* [`4039dbd3`](https://github.com/NixOS/nixpkgs/commit/4039dbd3ddbad55734d98430a581c91506587cd7) python3Packages.protobuf: avoid build platform references
* [`1d5e5ca5`](https://github.com/NixOS/nixpkgs/commit/1d5e5ca56d1f6019b8a7dcc5b66a78e767e5276e) or-tools: fix cross-compilation
* [`bcf58d91`](https://github.com/NixOS/nixpkgs/commit/bcf58d9125926e68af5b3eb3f6e85a75cfbfe206) ghostscript.tests.test-corpus-render: unstable-2020-02-19 -> unstable-2022-12-01
* [`edcec44c`](https://github.com/NixOS/nixpkgs/commit/edcec44cc191fb6281e12538abe34534be88c056) libqmi: don't build manuals when cross compiling
* [`90588d5e`](https://github.com/NixOS/nixpkgs/commit/90588d5e850c06e713ac3377c6ee1851ec578422) pam_mount: move perl into nativeBuildInputs to support cross compilation
* [`aae28d05`](https://github.com/NixOS/nixpkgs/commit/aae28d05fe8acc8bfe4a8ccfb05ac5088db3a508) nodejs-18_x: 18.15.0 -> 18.16.0
* [`a3feceff`](https://github.com/NixOS/nixpkgs/commit/a3fecefff9aa2f6da75861f2f7aabe52692d7389) figma-agent: init at 0.2.7
* [`40074520`](https://github.com/NixOS/nixpkgs/commit/40074520d171d4b2f468db3ba26a9079892a7146) libxml2: 2.10.3 → 2.10.4
* [`ed3f60f8`](https://github.com/NixOS/nixpkgs/commit/ed3f60f8f84cd2cd07c0266eac06f8c55addd0d7) serf: support cross compilation
* [`d9d13d89`](https://github.com/NixOS/nixpkgs/commit/d9d13d89811a5f4c6e4728b87daa0d8dc722c0bf) subversion: support cross compilation
* [`cda91ab2`](https://github.com/NixOS/nixpkgs/commit/cda91ab26974f5848ec919142855872695b1f994) flutter: Add cache output and preload pub cache when necessary
* [`65708c33`](https://github.com/NixOS/nixpkgs/commit/65708c3360e6b2a01f42d2784f36983908e2c706) flutter: Don't delete SDK artifacts
* [`94a34aad`](https://github.com/NixOS/nixpkgs/commit/94a34aadf6d3f7a78cad181a555d4d162a7e7914) flutter: Use autoPatchelfHook for SDK artifacts
* [`9e33e355`](https://github.com/NixOS/nixpkgs/commit/9e33e35589ac026ba535c8d8e68a6e66beeac048) flutter: Add zlib to the linker search path
* [`e5529593`](https://github.com/NixOS/nixpkgs/commit/e5529593957fae3006388b08826651ec9993af1e) flutter: Remove the FHS wrapper
* [`d6ce0daf`](https://github.com/NixOS/nixpkgs/commit/d6ce0dafcfccbd2c93c3af9428671384deeb05b8) flutter: Don't use an external artifact cache
* [`9497627b`](https://github.com/NixOS/nixpkgs/commit/9497627b15ce079b0fb89fff46220bfbdfd3b510) flutter: Don't try to update the immutable artifact cache
* [`7f01352e`](https://github.com/NixOS/nixpkgs/commit/7f01352e6513ea425d8ed026445f24f7234a8502) flutter: Don't preserve prebuilt SDK asset file permissions
* [`aa9079c6`](https://github.com/NixOS/nixpkgs/commit/aa9079c678a76354c829d4821e35776db67084ba) flutter: Remove prebuilt dependencies from the wrapper
* [`0f284863`](https://github.com/NixOS/nixpkgs/commit/0f2848638fef6e708b9488ee7badb3899fa3ab27) flutter: 3.3.3 -> 3.7.11
* [`5777f1a1`](https://github.com/NixOS/nixpkgs/commit/5777f1a122a07e0b63d1eb2dcdb17a7b7d31d196) flutter: Don't check executable locations in doctor
* [`5a7558f2`](https://github.com/NixOS/nixpkgs/commit/5a7558f2b034d8794ffde3c85e5c33b78d5a8131) biodbhts : init at 3.01
* [`88b308c1`](https://github.com/NixOS/nixpkgs/commit/88b308c1323897b2747cf4593fbaf9cd9aa95f36) maintainers: add FlafyDev
* [`bc6e36af`](https://github.com/NixOS/nixpkgs/commit/bc6e36afdcdba1a58814de7ea87306e2c8b4f8c1) maintainers: add hacker1024
* [`4df7d07a`](https://github.com/NixOS/nixpkgs/commit/4df7d07ab1d829c16e4aa36a012b161825b717d9) flutter: Remove stray dollar sign from name string
* [`f3aac6e6`](https://github.com/NixOS/nixpkgs/commit/f3aac6e61e6711908073d5eeb6adf2d445f81ccf) flutter: Add FlafyDev, gilice, and hacker1024 as maintainers
* [`4196ddbe`](https://github.com/NixOS/nixpkgs/commit/4196ddbeb5f1c1f6134a2dfef771c9777be87e86) flutter: Add git and which to PATH
* [`6d50bcc4`](https://github.com/NixOS/nixpkgs/commit/6d50bcc4876261de18720e6a867ae959d31018d1) mkFlutterApp: Deduplicate build environment setup
* [`04e7ced7`](https://github.com/NixOS/nixpkgs/commit/04e7ced7e2ff2013dc6b6fa777e05c76352c0f24) mkFlutterApp: Don't fetch prebuilt artifacts
* [`c59ce54f`](https://github.com/NixOS/nixpkgs/commit/c59ce54f1d19be4f1f69652b46de72116b1928ed) flutter: Add mkFlutterApp as a passthru attribute
* [`13bbb361`](https://github.com/NixOS/nixpkgs/commit/13bbb361325433e0c8d23ec4b4db74a7eef1961b) flutter: Move makeWrapper to nativeBuildInputs in wrapper
* [`cedcb0b7`](https://github.com/NixOS/nixpkgs/commit/cedcb0b7729390eb6dc3c32734a58485d2b090ea) flutter: Rename "self" to "unwrapped" in main derivation
* [`8f9aa6b1`](https://github.com/NixOS/nixpkgs/commit/8f9aa6b18befaa6bd6f5cb1a328a9528bc4bd761) flutter.mkFlutterApp: Don't use autoPatchelf on package cache
* [`f7e3c19c`](https://github.com/NixOS/nixpkgs/commit/f7e3c19cc8b34f17bd822bf328687b913c1534ad) flutter.mkFlutterApp: Don't vendor arbitrary configuration files
* [`b612fe36`](https://github.com/NixOS/nixpkgs/commit/b612fe36b2bb3b5c5e625cf66e959c447e5dd0a1) autoPatchelfHook: add appendRunpaths argument
* [`97870fb6`](https://github.com/NixOS/nixpkgs/commit/97870fb60c2d045d8e92df3f5afd74d6ea0c2f5c) cudaPackages: append $ORIGIN to runtime paths
* [`30caca08`](https://github.com/NixOS/nixpkgs/commit/30caca083912d28bcb9cd6f62e505a59afc9cf5d) flutter.mkFlutterApp: Add Git to nativeBuildInputs
* [`e396a4ec`](https://github.com/NixOS/nixpkgs/commit/e396a4ec1f9a484e95eb685e0d877869b5edb753) rocdbgapi: fix build
* [`6be78e28`](https://github.com/NixOS/nixpkgs/commit/6be78e28b446703b80e83724b3cf14c44b9bbca7) libgcrypt: 1.5.6 -> 1.8.10
* [`6f635e39`](https://github.com/NixOS/nixpkgs/commit/6f635e39af3e6ac03db4032258b28666e103051e) gnupg: Add LTS version 2.2.41
* [`f92d7c3a`](https://github.com/NixOS/nixpkgs/commit/f92d7c3a205d2674f65d0afade55513f9aeabd7a) gnupg: Remove patch for code that is disabled upstream
* [`dcf20a0c`](https://github.com/NixOS/nixpkgs/commit/dcf20a0c2348cec9e56314354df3f53ef1c5237d) systemd: reflow patches, remove whitespace error in Fix-hwdb-paths.patch
* [`99910f07`](https://github.com/NixOS/nixpkgs/commit/99910f07fb677c46823258eb38168409095f8910) libde265: add patches for CVE-2023-27102 & CVE-2023-27103
* [`95e44ea6`](https://github.com/NixOS/nixpkgs/commit/95e44ea66827853dae277e6974e17842869d0288) libde265: add tests.test-corpus-decode
* [`18f1be70`](https://github.com/NixOS/nixpkgs/commit/18f1be707120b0bb5e2ddfb5058bc8d3c16f18cb) openssl: remove run-time dependency of perl due to c_rehash
* [`7b45dfa9`](https://github.com/NixOS/nixpkgs/commit/7b45dfa9415fdcec6ba72ccafc6705caaad9d238) quictls: remove run-time dependency of perl due to c_rehash
* [`1b2cac51`](https://github.com/NixOS/nixpkgs/commit/1b2cac51b2941b7e5bee2c10ce10de3f0fb7dc71) flutter: Use existing libdeflate derivation
* [`7e12e3af`](https://github.com/NixOS/nixpkgs/commit/7e12e3afaa335816baa2eeb1683787fbd22a3372) flutter.mkFlutterApp: Remove the target architecture from the dependency derivation name
* [`b16e344f`](https://github.com/NixOS/nixpkgs/commit/b16e344fae5aedeed4ce66e8f54bb60e6aacb0f7) flutter: Remove --no-version-check from the immutable wrapper
* [`c1e956e0`](https://github.com/NixOS/nixpkgs/commit/c1e956e0a9a6fbd955fb4f24318a1adefc5efb8c) cc-wrapper: deunify clang/gcc handling of `-B` flag
* [`2ce3cb41`](https://github.com/NixOS/nixpkgs/commit/2ce3cb412e58ecb4cbd8011ea7ebcde0f6a31c3e) slsa-verifier: 2.1.0 -> 2.2.0
* [`ecbbd310`](https://github.com/NixOS/nixpkgs/commit/ecbbd3104f536083ae52bca1c6e9262b17ed79ff) rustc: put targetPrefix in pname
* [`36c8e500`](https://github.com/NixOS/nixpkgs/commit/36c8e5004689b7d7a89bfc5ebd662f6cd86f4c45) lunatask: init at version 1.6.4
* [`c3797393`](https://github.com/NixOS/nixpkgs/commit/c3797393b70ce507aa47abb2f742bbb355e2c398) flutter: Use fetchzip instead of fetchurl for source downloads
* [`62e50080`](https://github.com/NixOS/nixpkgs/commit/62e50080f39560183c57aa184bf03e47a341444c) flutter: Download engine artifacts individually
* [`e78f08fa`](https://github.com/NixOS/nixpkgs/commit/e78f08fa212580e2a8509ff8fb3587d1e2413aec) nixos/dokuwiki: Finally remove extraConfig
* [`cc55cd6a`](https://github.com/NixOS/nixpkgs/commit/cc55cd6ab74b32d0cf5a3cc7da87f82773a5bc66) nixos/dokuwiki: Mark last descriptions as md
* [`fdce3f30`](https://github.com/NixOS/nixpkgs/commit/fdce3f30c4bde2ed4f7bef3f65f5dfc2a673f0ff) flutter.mkFlutterApp: Don't hash more unstable files
* [`4e0210b7`](https://github.com/NixOS/nixpkgs/commit/4e0210b76d8e9e69cf901b37cb53f55ff7e022c5) systemd: re-do fsck patch
* [`16ee1b18`](https://github.com/NixOS/nixpkgs/commit/16ee1b18a485568a7c7164e6348f58768338ae2a) systemd: re-introduce hostnamed-localed-timedated-disable-methods-that-cha.patch
* [`4d057d14`](https://github.com/NixOS/nixpkgs/commit/4d057d14ba766b516d8f585b66dbfe8c00cd0d53) ledfx: init at 2.0.64
* [`75925de9`](https://github.com/NixOS/nixpkgs/commit/75925de96941686e8b41a526c926152be4678694) maintainers: add elesiuta
* [`a4eebda6`](https://github.com/NixOS/nixpkgs/commit/a4eebda62e3eb8b08a9ca9f4fe1e73f44436f967) picosnitch: init at 0.12.0
* [`acfed642`](https://github.com/NixOS/nixpkgs/commit/acfed642249887ce8b5a0401e0bfcdb864622a06) nixos/picosnitch: init
* [`a890a9ca`](https://github.com/NixOS/nixpkgs/commit/a890a9cadf6385e8f82b6eddeea925f9bbb999ce) ruby: rubygems 3.4.8 -> 3.4.12
* [`2b026ef5`](https://github.com/NixOS/nixpkgs/commit/2b026ef5dd34e9b7be8c1859c944d90cd4944543) bundler: 2.4.10 -> 2.4.12
* [`a5aa3798`](https://github.com/NixOS/nixpkgs/commit/a5aa37989156c23be3bed2c8da33f28427845caa) gitlab: use Ruby 2.7
* [`bc95b984`](https://github.com/NixOS/nixpkgs/commit/bc95b98495fe5310ffa9e122af0b83aae0690eef) nawk: unstable-2021-02-15 -> 20220122
* [`bd80d99a`](https://github.com/NixOS/nixpkgs/commit/bd80d99a616f37bbf4928b574e5c106a70047932) galene: add erdnaxe as maintainer
* [`4be94ba4`](https://github.com/NixOS/nixpkgs/commit/4be94ba44b43a661a55d19e8a9e77030d3424ee6) galene: 0.6.1 -> 0.7.0
* [`8c2f6a1d`](https://github.com/NixOS/nixpkgs/commit/8c2f6a1d9e21236251dfde2e9ae0a23ab9266e38) dokuwiki: 2022-07-31a -> 2023-04-04
* [`3d9103c3`](https://github.com/NixOS/nixpkgs/commit/3d9103c362d47b7730fb7ff3ef7d0e7f9c5356fc) tcpdump: 4.99.3 -> 4.99.4
* [`97ae1aaa`](https://github.com/NixOS/nixpkgs/commit/97ae1aaa88203a41a12e256b27d4b11c3addf134) libpcap: 1.10.3 -> 1.10.4
* [`b187edb8`](https://github.com/NixOS/nixpkgs/commit/b187edb802c25abd103aa71eb7f00663e25333d4) flutter: Pass through the version attribute in the wrapper
* [`62b7d500`](https://github.com/NixOS/nixpkgs/commit/62b7d500163736131ff1c8c4dd7f09c712e62a87) libmodplug: split headers to "dev" output
* [`c3a87421`](https://github.com/NixOS/nixpkgs/commit/c3a87421ae381ee68cd8f64f0be29616df8bdb25) flutter: Don't tarball the package cache
* [`f00f918e`](https://github.com/NixOS/nixpkgs/commit/f00f918e274bcba8e2265f97cf472bb7fa981d51) flutter: Remove cached Git package Git directories
* [`607a57d4`](https://github.com/NixOS/nixpkgs/commit/607a57d48e9f2f61fdb93f4f76310536b0a38273) flutter.mkFlutterApp: Rename to flutter.buildFlutterApplication
* [`86ce1865`](https://github.com/NixOS/nixpkgs/commit/86ce1865b6f5617e7f15643c03238735e81e109c) Revert "grafana: skip a test that started failing"
* [`f3ec1208`](https://github.com/NixOS/nixpkgs/commit/f3ec1208820ecd1a6509fe79629535abbf44bd82) grafana: fix a test by upstream patch
* [`3c5a37ff`](https://github.com/NixOS/nixpkgs/commit/3c5a37ff77efe386b2d812aa9c24dc82ef7a34db) directx-headers: 1.608.2b -> 1.610.0
* [`915a6779`](https://github.com/NixOS/nixpkgs/commit/915a6779fc28fe545a3393e2db1fccfc40d40380) flutter.buildFlutterApplication: Refactor dependency setup as a standalone derivation with an output hook
* [`4e68ee32`](https://github.com/NixOS/nixpkgs/commit/4e68ee327e38541f0edf4d1d8d757f5ca914a055) flutter.buildFlutterApplication: Add an explanation when a pubspec mismatch occurs
* [`d2ab3412`](https://github.com/NixOS/nixpkgs/commit/d2ab34122d2f0b103a91d9ab05f327b09d3090b9) dart.fetch-dart-deps: Remove stray comment from the dependency derivation
* [`88275ca6`](https://github.com/NixOS/nixpkgs/commit/88275ca6d6ceeaecfc9c7d1a313c198bb888d287) flutter.buildFlutterApplication: Allow using a custom pubspec.lock
* [`b1aa0545`](https://github.com/NixOS/nixpkgs/commit/b1aa0545c8920d04d731a46ed56fe43a5f33a04d) pipewire: 0.3.68 -> 0.3.69
* [`b5f0c482`](https://github.com/NixOS/nixpkgs/commit/b5f0c482a9764ded391c50dfdfa341dc24e6e08d) pipewire: backport hotfix patch
* [`0e5db63d`](https://github.com/NixOS/nixpkgs/commit/0e5db63dc3a1ba3b434b993536c508b69e9a63b8) dart.fetch-dart-deps: Don't delete .git/pub-packages
* [`65631597`](https://github.com/NixOS/nixpkgs/commit/65631597c1be82bea68fc7b83aecc604fe5f6b14) yubioauth-flutter: Update vendor hash for new pubspec.lock handling
* [`396938b6`](https://github.com/NixOS/nixpkgs/commit/396938b6de7a40a1a9d8f0d07e0d0d3206e750f9) firmware-updater: Add a pubspec.lock
* [`5fa3b410`](https://github.com/NixOS/nixpkgs/commit/5fa3b41041212a468e50b9b36256b3fc74d91ea8) dart.fetch-dart-deps: Verify the pubspec.lock as well as pubspec.yaml
* [`643b62c8`](https://github.com/NixOS/nixpkgs/commit/643b62c8f14c8685c9be273991d9e568ba02b6bf) dart.fetch-dart-deps: Don't allow overriding the deps derivation name
* [`075f50f2`](https://github.com/NixOS/nixpkgs/commit/075f50f2d167affaefe3783dc21922a8288f4247) dart.fetch-dart-deps: Compress the generated pubspec.lock file
* [`1f7eab1c`](https://github.com/NixOS/nixpkgs/commit/1f7eab1c3845f873352a997d947673c2beb05f2d) dart.fetch-dart-deps: Fix invalid syntax in pubspec validation statement
* [`e279eef0`](https://github.com/NixOS/nixpkgs/commit/e279eef0b3d99158a476c2c9e0b70896934a7b54) git: 2.39.2 -> 2.40.0
* [`057da896`](https://github.com/NixOS/nixpkgs/commit/057da8964d5843fbf3b72d270a986c59b22eb51a) libfprint-2-tod1-goodix-550a: init at 0.0.9
* [`1dbdadc2`](https://github.com/NixOS/nixpkgs/commit/1dbdadc26a1eba87194cd88c3bbb38ce51969c90) maintainers: add utkarshgupta137
* [`6024b587`](https://github.com/NixOS/nixpkgs/commit/6024b58745f465b1cb3db3dd9248c9ee93fff0f3) deadbeef: 1.9.4 -> 1.9.5
* [`04d62873`](https://github.com/NixOS/nixpkgs/commit/04d6287399338b864d068c486808d9070f4f5847) deadbeefPlugins.mpris2: 1.14 -> 1.16
* [`f35c2b0b`](https://github.com/NixOS/nixpkgs/commit/f35c2b0b921bf53a51d1531df82dfb1690c2a50d) Apply suggestions from code review
* [`5a5435de`](https://github.com/NixOS/nixpkgs/commit/5a5435dea652265c52cf12be864d798d8682e29a) flutter.buildFlutterApplication: Add flutterBuildFlags argument
* [`1e803e76`](https://github.com/NixOS/nixpkgs/commit/1e803e76610da5ee45a9087c5ab4d38133fb52e5) libdecor: move headers out to "dev" output
* [`617525dd`](https://github.com/NixOS/nixpkgs/commit/617525dd31799e8b87ade9cb076575af87b7ee38) audiofile: move headers and mand to "dev" and "man" outputs
* [`eefb6703`](https://github.com/NixOS/nixpkgs/commit/eefb67036f600783ef1284a6b1f635cc9ec6208b) flutter.buildFlutterApplication: Move debugging symbols into another output
* [`03bbaa4d`](https://github.com/NixOS/nixpkgs/commit/03bbaa4d854bc67dbf1a154ee3439bfc67a7d5a3) libinput: add .meta.changelog
* [`a9709b3d`](https://github.com/NixOS/nixpkgs/commit/a9709b3d9d99e76111e0410cca97038d4abd16f8) mesa: have one attribute per major version
* [`62b9ccf8`](https://github.com/NixOS/nixpkgs/commit/62b9ccf838c371ddc7ded9a6b46cfa7b70ee2ea3) mesa_23_0: 23.0.1 -> 23.0.2, drop merged patch
* [`bbfc7911`](https://github.com/NixOS/nixpkgs/commit/bbfc7911d3e5bbc1a4abb59fbc73b3059df4a705) flutter.buildFlutterApplication: Supply runtime dependencies
* [`83907067`](https://github.com/NixOS/nixpkgs/commit/839070670e7a32d2785ca590a4a4bd28ec183918) cen64: unstable-2021-03-12 -> unstable-2022-10-02
* [`cffe87b9`](https://github.com/NixOS/nixpkgs/commit/cffe87b9f509e0dfe7aeedff950dcc74ceca785a) gpxsee: 12.2 → 12.4
* [`c3fa78ba`](https://github.com/NixOS/nixpkgs/commit/c3fa78ba8b1820202106dab9255fdb6a590ec28b) celt: split headers to "dev" output
* [`752e62b4`](https://github.com/NixOS/nixpkgs/commit/752e62b453bf2ab7ce61dcd85f441b978963cb65) ldacbt: split headers to "dev" output
* [`17cb291d`](https://github.com/NixOS/nixpkgs/commit/17cb291df1d84b89e4aba1fc085333038c9736c3) flutter: Allow adding extra dependencies to the wrapper
* [`b68a185b`](https://github.com/NixOS/nixpkgs/commit/b68a185b0f6276340fa5aaf2d572c48d0e25a841) dart.fetch-dart-deps: Expose the package cache files through passthru
* [`4f5dd08f`](https://github.com/NixOS/nixpkgs/commit/4f5dd08fe8a8bf81f636074a99dd4264faf017bb) dart.fetch-dart-deps: Add hook runtime dependencies
* [`87f809e0`](https://github.com/NixOS/nixpkgs/commit/87f809e0c6556126489d5340d8b3d71c4f85f0f1) dart.list-dart-deps: Add list-dart-deps function
* [`1a828c71`](https://github.com/NixOS/nixpkgs/commit/1a828c711aed776f2698ff3249c7b9a74d1a61aa) python3Packages.dbus-deviation: init at 0.6.1
* [`935974da`](https://github.com/NixOS/nixpkgs/commit/935974daa05eeedd4009e2971196650d0de9afd7) python3Packages.wheezy-template: init at 3.1.0
* [`188be504`](https://github.com/NixOS/nixpkgs/commit/188be504d7bf6fb8a3743a2d5e2aafe0d0a81805) hotdoc: init at 0.13.7
* [`41baeb5a`](https://github.com/NixOS/nixpkgs/commit/41baeb5a9baa70925a25c7a6f834fb29ad7ce789) libnice: 0.1.18 -> 0.1.21
* [`4b859ee8`](https://github.com/NixOS/nixpkgs/commit/4b859ee802bb5a85ca2a8fdb2397325ca874e90a) gst_all_1.gstreamer: 1.20.3 -> 1.22.2
* [`3028bf5e`](https://github.com/NixOS/nixpkgs/commit/3028bf5ea303fb04ae29c74b9aea5848e260c668) gst_all_1.gst-plugins-good: 1.20.3 -> 1.22.2
* [`f03d8ba1`](https://github.com/NixOS/nixpkgs/commit/f03d8ba1e1932d35564b9d46811426392371a28c) gst_all_1.gst-plugins-bad: 1.20.3 -> 1.22.2
* [`a315e096`](https://github.com/NixOS/nixpkgs/commit/a315e09637f99babd6811750a715002c52c530a9) gst_all_1.gst-plugins-ugly: 1.20.3 -> 1.22.2
* [`26a54eba`](https://github.com/NixOS/nixpkgs/commit/26a54eba11ab4e6c88a33a681590c3dc04a5acce) gst_all_1.gst-libav: 1.20.3 -> 1.22.2
* [`50b8c274`](https://github.com/NixOS/nixpkgs/commit/50b8c274eaadacc6177ec47c76fc6fd9159d0b4d) gst_all_1.gst-vaapi: 1.20.3 -> 1.22.2
* [`79e42f53`](https://github.com/NixOS/nixpkgs/commit/79e42f53c26b4b83c5ae6d364aa25ae94194bff3) gst_all_1.gst-devtools: 1.20.3 -> 1.22.2
* [`782969f5`](https://github.com/NixOS/nixpkgs/commit/782969f5d6ee61f463c3da5e755fcc1e18c3e25f) gst_all_1.gst-rtsp-server: 1.20.3 -> 1.22.2
* [`46bf2c47`](https://github.com/NixOS/nixpkgs/commit/46bf2c47f0ecc9b9a9ff305ee3a116cb71e42317) gst_all_1.gst-editing-services: 1.20.3 -> 1.22.2
* [`256b64df`](https://github.com/NixOS/nixpkgs/commit/256b64dfa8a17507d19f28a6739a3212ce8f61ac) python3Packages.gst-python: 1.20.0 -> 1.22.2
* [`329c494d`](https://github.com/NixOS/nixpkgs/commit/329c494d0c9e5983da84d5230a00c325b932f79c) flutter.buildFlutterApplication: Allow overriding configuration attributes
* [`0495725a`](https://github.com/NixOS/nixpkgs/commit/0495725a1f8e9df1ac3996459a9bb82305e69242) flutter.buildFlutterApplication: Introduce a package override repository
* [`e0caa914`](https://github.com/NixOS/nixpkgs/commit/e0caa91427d6d06e86f6a812accdf073f77b3a1a) at-spi2-core: use availableOn
* [`dab72ecb`](https://github.com/NixOS/nixpkgs/commit/dab72ecb03bca34d41723b6a02a47f88d2da77ad) mrustc: Remove obsolete patches
* [`3c00d2ee`](https://github.com/NixOS/nixpkgs/commit/3c00d2ee2bbe3e04dcace7fec9ae3e100f68f138) mrustc-bootstrap: Fix linker error caused by libstdc++ version mismatch
* [`70455de7`](https://github.com/NixOS/nixpkgs/commit/70455de76d1564a711d1d16caf3ef66063340641) mrustc-bootstrap: Recompile minicargo
* [`9faa0704`](https://github.com/NixOS/nixpkgs/commit/9faa070404d743c3d2ab61f2bc2a5555b053c2cf) mrustc-bootstrap: Document workarounds
* [`12d021c5`](https://github.com/NixOS/nixpkgs/commit/12d021c5552ad88c17d333b373b006a0c1ba523e) tutanota-desktop: add missing library
* [`342ff8c1`](https://github.com/NixOS/nixpkgs/commit/342ff8c1f1eee9b7add7fd80f2ff1af32778ada1) armadillo: 12.0.1 -> 12.2.0
* [`37e93f7c`](https://github.com/NixOS/nixpkgs/commit/37e93f7c3b9c98eef13733f2a558194db2d1b0f6) flutter.buildFlutterApplication: Supply package metadata to overrides
* [`83fa1295`](https://github.com/NixOS/nixpkgs/commit/83fa1295bf9d964a7750956244f0d741cca31298) liblc3: split headers to "dev" output
* [`b8932332`](https://github.com/NixOS/nixpkgs/commit/b89323329c60a09936d76b9c6fad669b3b5da0a2) hdf5: fix dev output, remove refs to /build from compiler wrappers
* [`4fbc3190`](https://github.com/NixOS/nixpkgs/commit/4fbc3190f50754fbf59a5421c6262dc6e92126d6) hdf: enable parallel builds
* [`1030709e`](https://github.com/NixOS/nixpkgs/commit/1030709e0f22b40e84a1ba2913d38bf917a25192) hdf5: add maintainer markuskowa
* [`9f898cbf`](https://github.com/NixOS/nixpkgs/commit/9f898cbfa7d9f2f0050e2291099b7b41c104a526) python310Packages.anyio: Disable failing tests
* [`812b738e`](https://github.com/NixOS/nixpkgs/commit/812b738e2c03ae74a222f4d3a580137dead3de6b) fbterm: update and use debian-maintained version
* [`ac1b5deb`](https://github.com/NixOS/nixpkgs/commit/ac1b5deba339478394fd4f8d0450116b757ce12c) saleae-logic-2: Fix "Error Connecting to Socket"
* [`0fc68550`](https://github.com/NixOS/nixpkgs/commit/0fc68550d179aa57b06c3c83279b6469ba9fc93f) saleae-logic-2: 2.4.6 -> 2.4.7
* [`9f32e0df`](https://github.com/NixOS/nixpkgs/commit/9f32e0df8401800ca4501b413b82a0ca2ddadfaf) libva: fix finding wayland when cross compiling
* [`4705a06c`](https://github.com/NixOS/nixpkgs/commit/4705a06cc0fb76689167ed1d02dc3e106bfeadc4) gst_all_1: re-disable docs for cross
* [`53feaedd`](https://github.com/NixOS/nixpkgs/commit/53feaedd8b567d52fea0239ff95eb312424ae067) python3.pkgs.mmcv: init at 1.7.1
* [`c9130993`](https://github.com/NixOS/nixpkgs/commit/c9130993d5ebba175774b97b5a25ebffdf82d96f) hotdoc: fix failing test on darwin
* [`f2ca6788`](https://github.com/NixOS/nixpkgs/commit/f2ca6788911a1a160089a0575bdfa4170c4e4f83) python3Packages.tokenizers: 0.12.1 -> 0.13.3
* [`c65c7ae5`](https://github.com/NixOS/nixpkgs/commit/c65c7ae5f06442083a9d2fcc1c8296086c8be73d) pipewire: 0.3.69 -> 0.3.70
* [`d7e04434`](https://github.com/NixOS/nixpkgs/commit/d7e04434ce37b02cb158be35fade55666c4424f8) SDL2: default drmSupport to false
* [`39e2454c`](https://github.com/NixOS/nixpkgs/commit/39e2454c1408209caba27a8770e59c66d7ae3a99) gnutls: remove Guile bindings
* [`7a86a7f9`](https://github.com/NixOS/nixpkgs/commit/7a86a7f9edb07a5f8e5025acbac44a87223281f7) nixos/tests/pipewire: don't enable pipewire in test VM
* [`c3ee84f5`](https://github.com/NixOS/nixpkgs/commit/c3ee84f573715ead89056411c699f32995ceb35d) all-cabal-hashes: 2023-04-18T09:14:41Z -> 2023-04-20T12:48:01Z
* [`09055b55`](https://github.com/NixOS/nixpkgs/commit/09055b5598a5efaf40060a55811191653a2cd799) haskellPackages: regenerate package set based on current config
* [`63c3703d`](https://github.com/NixOS/nixpkgs/commit/63c3703dedfdf66a8e7fa704ddef6d3d8699e350) lighthouse: 3.5.1 -> 4.1.0
* [`2aa2d2d5`](https://github.com/NixOS/nixpkgs/commit/2aa2d2d5c280c6bf2f29aab42acc47311501e1c0) redpanda: 23.1.6 -> 23.1.7
* [`105933e2`](https://github.com/NixOS/nixpkgs/commit/105933e2fcb64f15fa4bbd35b36e4b385fe38d29) haskellPackages.matterhorn: remove obsolete overrides
* [`0bd7d2db`](https://github.com/NixOS/nixpkgs/commit/0bd7d2dbedc23a8e2852209701622b06e0e446b0) haskellPackages.storablevector: jailbreak to fix tests
* [`e30dafc0`](https://github.com/NixOS/nixpkgs/commit/e30dafc09bd4df9b27dac77c3655f4d5836915e9) nixos: add module for GameScope
* [`1150cc09`](https://github.com/NixOS/nixpkgs/commit/1150cc09b70d6ac506e40cda0ee2f0318b5b00cd) oven-media-engine: 0.15.8 -> 0.15.9
* [`b7a60b61`](https://github.com/NixOS/nixpkgs/commit/b7a60b612f654735fa4d2d16d242acb2d2a11d10) shaarli: 0.12.1 -> 0.12.2
* [`52cb2d2c`](https://github.com/NixOS/nixpkgs/commit/52cb2d2cdd436834d0bb5b62d2c73038ad1b1650) cemu: 2.0-32 -> 2.0-36
* [`9d0c680b`](https://github.com/NixOS/nixpkgs/commit/9d0c680b080640f624a8a62d6afe2ab94fb0e787) php80Extensions.blackfire: 1.86.6 -> 1.86.8
* [`a9f4dfc8`](https://github.com/NixOS/nixpkgs/commit/a9f4dfc8950b7e98a395c34cb9a9562664740ffc) linux_xanmod_latest: 6.2.11 -> 6.2.12
* [`40a5c0a0`](https://github.com/NixOS/nixpkgs/commit/40a5c0a05841641225c8e77bb5eae0ca23d67898) linux_xanmod: 6.1.24 -> 6.1.25
* [`8c49f09b`](https://github.com/NixOS/nixpkgs/commit/8c49f09be2e5a62ff005103e5eb7faee7f991200) resilio-sync: fix build with libxcrypt and use autoPatchelfHook
* [`34122f73`](https://github.com/NixOS/nixpkgs/commit/34122f7321d2abe79b6ca1086b02354495888563) ocamlPackages.ocamlmod: disable for OCaml ≥ 5.0
* [`d3db6fe0`](https://github.com/NixOS/nixpkgs/commit/d3db6fe015712bba507f363551d3bf6ded16b5db) ocamlPackages.ocaml_oasis: 0.4.10 → 0.4.11
* [`23caceb5`](https://github.com/NixOS/nixpkgs/commit/23caceb5571ceac44de6b1396cf132c61e31e3ae) maintainers: add tcheronneau
* [`17e8a70e`](https://github.com/NixOS/nixpkgs/commit/17e8a70e529d9e51c4a7ec57f30b755d6b9549b5) maude: update from version 3.3 to 3.3.1
* [`b9f335aa`](https://github.com/NixOS/nixpkgs/commit/b9f335aa6aecff305088a1cb52a01dbc9069c832) maude: try what happens when we re-enable parallel building
* [`e3421f59`](https://github.com/NixOS/nixpkgs/commit/e3421f59c7f7b2695345ace1aaf433f3e97e5b8f) python310Packages.xml2rfc: 3.17.0 -> 3.17.1
* [`6ab1860f`](https://github.com/NixOS/nixpkgs/commit/6ab1860ffdf268bdccbccb8358aa73065fdbcc50) python310Packages.pyamg: 4.2.3 -> 5.0.0
* [`77af1018`](https://github.com/NixOS/nixpkgs/commit/77af1018937b2f6af8d4a12a44d59f05241c1b0e) fluidsynth: fix darwin build for 2.3.2
* [`0506c319`](https://github.com/NixOS/nixpkgs/commit/0506c31972a96534a08c5a38ba641480c9dbda12) besu: 22.10.3 -> 23.1.2
* [`e3f3b9c7`](https://github.com/NixOS/nixpkgs/commit/e3f3b9c7e4f950983fc6df68e7ef514157cdb160) haskellPackages: remove packages from broken.yaml that are maintained by me
* [`93357bed`](https://github.com/NixOS/nixpkgs/commit/93357bed06924dd537c859b60f9832763e19e61a) chromium: use versionhistory.googleapis.com over omahaproxy.appspot.com
* [`7b9110eb`](https://github.com/NixOS/nixpkgs/commit/7b9110eba41fdf7a4b6c0aa75161a5a70959c39f) llvm: use versionhistory.googleapis.com over omahaproxy.appspot.com
* [`ab757c51`](https://github.com/NixOS/nixpkgs/commit/ab757c51f506569117009610c6e283d19d9007ec) ungoogled-chromium: update repo links to ungoogled-software organisation
* [`81a44e02`](https://github.com/NixOS/nixpkgs/commit/81a44e02bc385f1a0163d065299998fd681cff4d) ungoogled-chromium: Only use linux stable tags
* [`d40d00ef`](https://github.com/NixOS/nixpkgs/commit/d40d00efea5c587e755bcbffa0ee4e96616cd692) libwpe-fdo: 1.14.0 → 1.14.2
* [`73ef9868`](https://github.com/NixOS/nixpkgs/commit/73ef9868cfac99fcd8e4a840e43c29faaeafb23b) webkitgtk: 2.40.0 → 2.40.1
* [`51f097f8`](https://github.com/NixOS/nixpkgs/commit/51f097f853d6423387b18a889dfcf2c7606b0852) python3Packages.tensorflow: update darwin x86_64 deps hash
* [`45ec842b`](https://github.com/NixOS/nixpkgs/commit/45ec842b0bdd0f4d6cd93df49b1d25531a792bc9) maintainers: add thielema
* [`5d91d02f`](https://github.com/NixOS/nixpkgs/commit/5d91d02fc4cd09457c3bb0f9928ff64dac36b062) haskellPackages: add thielema as maintainer to configuration-hackage2nix/main.yaml
* [`3e7b7602`](https://github.com/NixOS/nixpkgs/commit/3e7b76025df2e0cb52cbbde57102734aec16a272) haskellPackages: regenerate package set based on current config
* [`be90a197`](https://github.com/NixOS/nixpkgs/commit/be90a19796785e4b9c4958e18acc06d68d26e49a) visualvm: 2.1.5 -> 2.1.6
* [`3a14846e`](https://github.com/NixOS/nixpkgs/commit/3a14846ec7b0079b7b63e7799d606a6415692acd) celestia: 1.6.2.2 -> 1.6.3
* [`375079d2`](https://github.com/NixOS/nixpkgs/commit/375079d28c048e8478f49917dca068e88a373a02) nixos/budgie: Make default backgrounds available in Budgie Control Center
* [`65b4919c`](https://github.com/NixOS/nixpkgs/commit/65b4919c4964fc163fbd1fb6f55066e8780e552a) budgie.budgie-gsettings-schemas: Update default settings
* [`0c03318f`](https://github.com/NixOS/nixpkgs/commit/0c03318f28e05b635becab48dee61a286d99c648) spire: 1.6.1 -> 1.6.3
* [`26b3ecb5`](https://github.com/NixOS/nixpkgs/commit/26b3ecb50a1182285c85a0a26dc314b4d5c1354b) python310Packages.safetensors: init at 0.3.0
* [`29d3baf2`](https://github.com/NixOS/nixpkgs/commit/29d3baf23c779ad7c0fcc98e5e6b7f190ccd0a00) python310Packages.mdit-py-plugins: 0.3.4 -> 0.3.5
* [`93a5256e`](https://github.com/NixOS/nixpkgs/commit/93a5256e22aada4d32efcca6806ae66ffe65751f) python310Packages.mdit-py-plugins: add changelog to meta
* [`f510a301`](https://github.com/NixOS/nixpkgs/commit/f510a301579a0c7beb953c53dd682f92ee73535e) librewolf-unwrapped: 112.0.1-1 -> 112.0.1-2
* [`4e54419a`](https://github.com/NixOS/nixpkgs/commit/4e54419a02ea282d3db5aa92b10a70c5e4e5ec34) python310Packages.timetagger: 23.2.1 -> 23.4.1
* [`c21df8ad`](https://github.com/NixOS/nixpkgs/commit/c21df8adba2ef620124ff64c434256e85862b253) kics: 1.6.13 -> 1.6.14
* [`b8b706b0`](https://github.com/NixOS/nixpkgs/commit/b8b706b0708e7c61b7dd715f0fab9bd7b9e627c7) python3Packages.uamqp: use github source, unpin openssl_1_1, enable tests
* [`6a08f73f`](https://github.com/NixOS/nixpkgs/commit/6a08f73f63a48ed9bee41734611bdda241b28432) fluidd: 1.23.4 -> 1.23.5
* [`742f798f`](https://github.com/NixOS/nixpkgs/commit/742f798f31c1928acacf97267dacd717a8f2f949) postfix: 3.7.4 -> 3.8.0
* [`e5b55e5b`](https://github.com/NixOS/nixpkgs/commit/e5b55e5b549d21bc217fbc87d1175e36906584aa) coin-utils: 2.11.6 -> 2.11.8
* [`fa0a071b`](https://github.com/NixOS/nixpkgs/commit/fa0a071b2eefc38727e5304e19aafe311f85b793) haskellPackages: add buildExamples Cabal flag to audacity, med-module, spreadsheet
* [`3fd9285a`](https://github.com/NixOS/nixpkgs/commit/3fd9285a6367756f99fcfaccc6be0d499748a50e) haskellPackages.wiringPi: unsupported on aarch64-darwin
* [`0d30892a`](https://github.com/NixOS/nixpkgs/commit/0d30892a916d4df5d45b7bfad015dff4299b8f0e) haskellPackages.dhall-nix(pkgs)?: Fix build by pinning to stackage compatible versions
* [`83bccf9f`](https://github.com/NixOS/nixpkgs/commit/83bccf9f83585daa8733a327654b9ba8b778ebfa) gocd-server: 22.2.0 -> 23.1.0
* [`83f57df7`](https://github.com/NixOS/nixpkgs/commit/83f57df79dd7d94311f13455558477ee0e5def4e) gocd-agent: 22.2.0 -> 23.1.0
* [`526662e0`](https://github.com/NixOS/nixpkgs/commit/526662e0d08bbb4e3606a305ba200983eb2efa10) links2: 2.28 -> 2.29
* [`5e89f704`](https://github.com/NixOS/nixpkgs/commit/5e89f7044484b0e86fe06637fe5d187ea32e169f) telegram-desktop: 4.7.1 -> 4.8.0
* [`86bb552b`](https://github.com/NixOS/nixpkgs/commit/86bb552bfbc90e544072b22d27486cc3bf258d01) haskellPackages: Regenerate with transitive-fixed packages
* [`a9c8570a`](https://github.com/NixOS/nixpkgs/commit/a9c8570af48006685d46582d8a372cbfcf2275c4) haskell.packages.text-time: remove broken attribute
* [`e7eb209f`](https://github.com/NixOS/nixpkgs/commit/e7eb209fed6d400bab258baece1c6f6f50e14eea) stdenv: avoid -p flag for strip when boostrapping x86_64-darwin
* [`9f05297d`](https://github.com/NixOS/nixpkgs/commit/9f05297dc8875baeeeb8160b60f120affc259f2c) flutter.buildFlutterApplication: Manually supply the dependency list
* [`09de6885`](https://github.com/NixOS/nixpkgs/commit/09de6885112ec46a451ee0782ec94fa0b760bea0) haskell.packages.ghc96.newtype-generics: relax base bound
* [`e648525f`](https://github.com/NixOS/nixpkgs/commit/e648525ff310d59278aa65b82b22c4af0222df88) haskellPackages: Restricte alsa packages to linux
* [`89bb0ed9`](https://github.com/NixOS/nixpkgs/commit/89bb0ed91bd5ed327ce0c9bd745921fdf4bad097) flutter.buildFlutterApplication: Add an option to generate the dependency list with IFD
* [`b1472294`](https://github.com/NixOS/nixpkgs/commit/b14722944481d6ad05e4e020a96202e810fb1836) haskell.packages.ghc96.hourglass: pull test fix
* [`216f0b7c`](https://github.com/NixOS/nixpkgs/commit/216f0b7c2986b5ec4f54c6a91921b28902fb25b6) haskell.packages.ghc96.hedgehog: distribute v1.2
* [`47fc9242`](https://github.com/NixOS/nixpkgs/commit/47fc92421bcfb4c498e2a4b22b3c950d02dc7c70) haskell.packages.ghc96.http-api-data: distribute v0.5.1
* [`a0816808`](https://github.com/NixOS/nixpkgs/commit/a08168088124f93a03bbc10cac2b998c7f773ed3) komikku: 1.18.0 -> 1.19.0
* [`549c1a62`](https://github.com/NixOS/nixpkgs/commit/549c1a62fee6c05b6c5ebaad6decfb933b52ffd4) maintainers: add anpin
* [`3efea7f0`](https://github.com/NixOS/nixpkgs/commit/3efea7f0eacb27b940d5d3e930246bd37eb1cca0) postgresqlPackages.promscale_extension: init at 0.8.0
* [`4e6ddd0c`](https://github.com/NixOS/nixpkgs/commit/4e6ddd0c15d65bcd5bdc36bac7a6e51b64b39061) promscale: 0.10.0 -> 0.17.0
* [`08ddf6f0`](https://github.com/NixOS/nixpkgs/commit/08ddf6f0e3ce657dcd1d579796297af2b32b578d) nixosTests.promscale: add tests for promscale_extension
* [`039b9d39`](https://github.com/NixOS/nixpkgs/commit/039b9d39888509efc001d1abf8cd6f0bd3caae12) haskell.packages.ghc96.turtle: distribute v1.6.1
* [`fb8d2dda`](https://github.com/NixOS/nixpkgs/commit/fb8d2ddabbbe86f424b399c7476efb40e5cfc5b7) all-cabal-hashes: 2023-04-20T12:48:01Z -> 2023-04-22T18:19:29Z
* [`1ff2b20a`](https://github.com/NixOS/nixpkgs/commit/1ff2b20a7a6ce576e099cb91adee070e2131bacc) haskellPackages: regenerate package set based on current config
* [`c4b05347`](https://github.com/NixOS/nixpkgs/commit/c4b05347015db3eb8ad2f6f67e5b6f5308c3c9f0) texlive: use version info from tlpdb instead of hardcoding
* [`671f7556`](https://github.com/NixOS/nixpkgs/commit/671f7556b2363b18c4bea0777a6a344e1eb4ce3a) texlive.texdoc: add tlpdb revision to version
* [`ec669aba`](https://github.com/NixOS/nixpkgs/commit/ec669ababf278d7eac378b7665e777f8f0e2ba22) dnscontrol: 3.31.1 -> 3.31.2
* [`cf122f34`](https://github.com/NixOS/nixpkgs/commit/cf122f34ddb6cc7912229d295b1da1cb6e613229) vim: Actually disable parallelism in install
* [`ef8559d3`](https://github.com/NixOS/nixpkgs/commit/ef8559d3f4c4f69b6196ceeffb853a9dde82c9de) haskell.packages.ghc96.cborg-json: allow base-4.18
* [`e08455e3`](https://github.com/NixOS/nixpkgs/commit/e08455e3d6dce4792c5473949100411e62bfd396) haskell.packages.ghc96.serialise: allow base-4.18
* [`49257602`](https://github.com/NixOS/nixpkgs/commit/4925760232120dc8bc26f733a692f685b86ee108) haskell.packages.ghc96: uses jailbreakForCurrentVersion
* [`22c5bd85`](https://github.com/NixOS/nixpkgs/commit/22c5bd85d8478e24874ff2b80875506f5c3711a6) Partially revert "haskell.packages.ghc96: uses jailbreakForCurrentVersion"
* [`458807f4`](https://github.com/NixOS/nixpkgs/commit/458807f454d7979e7d6385eac215c0c2cb7902c0) github-desktop: support ozone
* [`32a72172`](https://github.com/NixOS/nixpkgs/commit/32a7217281ff3b4f3c08457213ef33ce7facbd3e) haskellPackages.audacity: Add executableHaskellDepends for examples
* [`10a92504`](https://github.com/NixOS/nixpkgs/commit/10a925042587729fa4265afc342098ccd4200497) haskellPackages.spreadsheet: Add executableHaskellDepends for examples
* [`79963036`](https://github.com/NixOS/nixpkgs/commit/799630369ab3d831415e4e7419646631991cb7cf) haskellPackages.comfort-fttw: Pin to fixed version
* [`59f65414`](https://github.com/NixOS/nixpkgs/commit/59f654146c9a4f0bea4588d6912429153fab8d42) haskellPackages.hspec*: Update overrides
* [`ec4d9834`](https://github.com/NixOS/nixpkgs/commit/ec4d9834ce4e7859adfec2cc92eff3c6f1dbbbef) haskellPackages.twirl: Unsupported on darwin
* [`e733063e`](https://github.com/NixOS/nixpkgs/commit/e733063e6d17b5e8f5af2c266f80184d0af5d880) mathgl: init at 8.0.1
* [`c3e9a943`](https://github.com/NixOS/nixpkgs/commit/c3e9a94359522691d47b60b0df972c09babe237d) libadwaita: 1.3.1 -> 1.3.2
* [`8af51c36`](https://github.com/NixOS/nixpkgs/commit/8af51c362856f71ebafa89229bf59bff848cd933) workcraft: 3.3.9 -> 3.4.0
* [`03e187d7`](https://github.com/NixOS/nixpkgs/commit/03e187d7f10d3665e9676418e06ae4b6cca65b8c) mandelbulber: 2.28 -> 2.29
* [`efe1e848`](https://github.com/NixOS/nixpkgs/commit/efe1e848e7a657c2a77163b34b59d6c73b007735) libcef: 111.2.6 -> 112.3.0
* [`d9cb65a2`](https://github.com/NixOS/nixpkgs/commit/d9cb65a263c841c0c84b81cdc7c4533547eea557) wf-config: fix cross
* [`c32e5d3a`](https://github.com/NixOS/nixpkgs/commit/c32e5d3afbe9505219585b908bd20e6b55dbac24) wayfire: fix cross
* [`1ef54d4a`](https://github.com/NixOS/nixpkgs/commit/1ef54d4a89e3adbf22e73dcf55f677a0483662a4) lcm: 1.4.0 -> 1.5.0
* [`c552ebbc`](https://github.com/NixOS/nixpkgs/commit/c552ebbca826b00f2b7286bf09efa8be3ab5d1db) amdvlk: 2023.Q1.3 -> 2023.Q2.1
* [`a4875b8a`](https://github.com/NixOS/nixpkgs/commit/a4875b8af02e5fb0333020e438661a7bbf31c94b) umockdev: 0.17.16 -> 0.17.17
* [`7e535988`](https://github.com/NixOS/nixpkgs/commit/7e53598823416e2feb0c4fdc645e7692b8453b5d) flutter: 3.7.11 -> 3.7.12
* [`ae0aff84`](https://github.com/NixOS/nixpkgs/commit/ae0aff848fce2a672919bedffbe04f85bfed13b6) flutter: Throw a useful message when there are missing artifact hashes
* [`552e3fe4`](https://github.com/NixOS/nixpkgs/commit/552e3fe49817599c2127a8ab32b72b8e6bf9f724) flutter: Don't use IFD to read the engine version
* [`e5aabf05`](https://github.com/NixOS/nixpkgs/commit/e5aabf059e02038674b09b8c161bac2fcbf8823d) Merge [nixos/nixpkgs⁠#227471](https://togithub.com/nixos/nixpkgs/issues/227471): texinfo: apply gnulib patch only to version 6.7
* [`e057b849`](https://github.com/NixOS/nixpkgs/commit/e057b8492aa5985c38222e60d19cadf653e1d087) libreoffice*: drop test which regressed on libxml2 update
* [`8ee58612`](https://github.com/NixOS/nixpkgs/commit/8ee586120177ea66d2b6d69e69373af08a9d9c5c) tiled: 1.10.0 -> 1.10.1
* [`690e5bf2`](https://github.com/NixOS/nixpkgs/commit/690e5bf26a0ff837a438bd62232f0705c5b2b1f7) python310Packages.tinycss: update meta
* [`b49aa422`](https://github.com/NixOS/nixpkgs/commit/b49aa4221b330db57f08936b1dfac88f38f8b712) python310Packages.tinycss: disable on unsupported Python releases
* [`cf197c7d`](https://github.com/NixOS/nixpkgs/commit/cf197c7d49f669d88b3919f72bf9998ca00b70f2) python310Packages.tinycss: add pythonImportsCheck
* [`4d3cf986`](https://github.com/NixOS/nixpkgs/commit/4d3cf98691b3a4ba7fd52669420db81781d9875e) python311Packages.tenacity: 8.2.1 -> 8.2.2
* [`e4b66fa1`](https://github.com/NixOS/nixpkgs/commit/e4b66fa1a121aa9fb9121e0606918f047cd041a2) maintainers/scripts/haskell: Integrate transitive-broken into regeneration script
* [`0e191c7e`](https://github.com/NixOS/nixpkgs/commit/0e191c7ec12e5af4041c2c5cba1a3ab52f3a17ae) promscale_extension: fixed cargoPatch
* [`16865b95`](https://github.com/NixOS/nixpkgs/commit/16865b959fbcea2769c02ea864c51414fa4f50b8) gtk4: 4.10.1 → 4.10.3
* [`a89f0a0e`](https://github.com/NixOS/nixpkgs/commit/a89f0a0e0734b33e2d153f5e6c5099dfd9223eb1) deepin.deepin-kwin: init at 5.24.3-deepin.1.9
* [`952dceb8`](https://github.com/NixOS/nixpkgs/commit/952dceb87b2ebf6ba011ac029b138b2c482b9202) deepin.dde-kwin: init at 5.6.5
* [`78e4a5a4`](https://github.com/NixOS/nixpkgs/commit/78e4a5a474b639eacdda7dd21e75d7f197e77c78) terminus_font: reliably generate fontdir
* [`12c4aafc`](https://github.com/NixOS/nixpkgs/commit/12c4aafccb1a310a0b3855eaebcdf7ac37862ce4) python310Packages.eigenpy: 2.9.2 -> 3.0.0
* [`2af4a9bc`](https://github.com/NixOS/nixpkgs/commit/2af4a9bc09bccb74cda5eefb98193b4bbbb0eba5) nixos/roundcube: fix PostgreSQL password
* [`279eeae1`](https://github.com/NixOS/nixpkgs/commit/279eeae178543bfd0a8b5f04793f586699f64555) nixos/roundcube: fix roundcube-setup start
* [`78fb35ce`](https://github.com/NixOS/nixpkgs/commit/78fb35ce39b9f4db45999457c170f65ed153f3eb) nixos/roundcube: extend documentation for passwordFile
* [`ab513057`](https://github.com/NixOS/nixpkgs/commit/ab51305750a12d678b841f939a0ac26d2ada57b9) snapmaker-luban: 4.7.2 -> 4.7.3
* [`4a651cac`](https://github.com/NixOS/nixpkgs/commit/4a651cac38ffb8d3064ecb6b6315c0db5e037dc6) nats-streaming-server: 0.24.6 -> 0.25.4
* [`213752fd`](https://github.com/NixOS/nixpkgs/commit/213752fd01a2c0fb32c02285c3ebbcd692e04fca) ergo: 5.0.8 -> 5.0.9
* [`13c90a1b`](https://github.com/NixOS/nixpkgs/commit/13c90a1bfed55320d2f8e7e89da82f7edfa53d3b) zine: 0.13.0 -> 0.14.0
* [`043340c0`](https://github.com/NixOS/nixpkgs/commit/043340c046f56a92cff8407aa1de63b53e0ab71c) budgie.budgie-analogue-clock-applet: init at 2.0
* [`2a789314`](https://github.com/NixOS/nixpkgs/commit/2a789314349583bb3ad0fb98e88dee972ade6b3f) budgie.budgie-desktop-with-plugins: init
* [`3c0f50b2`](https://github.com/NixOS/nixpkgs/commit/3c0f50b28c2f1c222211176493f1c96235b12330) nixos/budgie: Add services.xserver.desktopManager.budgie.extraPlugins option
* [`45d0a21c`](https://github.com/NixOS/nixpkgs/commit/45d0a21ce60a3a7b9a80a514b17496bd40d01a96) nixos/tests/budgie: Add budgie-analogue-clock-applet
* [`c58c844b`](https://github.com/NixOS/nixpkgs/commit/c58c844b364a776b3251c1725afa597c1e199a96) nix-init: 0.2.1 -> 0.2.2
* [`c1c98d9c`](https://github.com/NixOS/nixpkgs/commit/c1c98d9cc805ab2992b13a1c0b4b15fad400a976) python3Packages.wagtail: 4.2 -> 4.2.2
* [`29f8a52d`](https://github.com/NixOS/nixpkgs/commit/29f8a52d9fa98dcb7ca9a633f4e57af23e77d3db) aiac: Init at 2.2.0
* [`bfc30718`](https://github.com/NixOS/nixpkgs/commit/bfc307189f15407b78f0034251c74cb109804eb3) wike: 1.7.1 -> 2.0.1
* [`f1eb2df8`](https://github.com/NixOS/nixpkgs/commit/f1eb2df82ef910afe2c882475a32c3cf5e1789be) python310Packages.codecov: 2.1.12 -> 2.1.13
* [`c5d83918`](https://github.com/NixOS/nixpkgs/commit/c5d839180a5c70c72f08ab44f22bef4ce6cad3f6) ntirpc: 4.3 -> 5.0
* [`862488f4`](https://github.com/NixOS/nixpkgs/commit/862488f4591286e6287bd0059bb8278c7a370590) nfs-ganesha: 4.4 -> 5.0
* [`15ebfa7b`](https://github.com/NixOS/nixpkgs/commit/15ebfa7be78d3390364b550ccbf1c55a09f4cfa4) vim: Harden build against ex and other tools being missing
* [`77fb04d8`](https://github.com/NixOS/nixpkgs/commit/77fb04d83ec2323a81e3319799979203ad877481) haskellPackages.gtk: refactor configuration-nix
* [`355cb4ce`](https://github.com/NixOS/nixpkgs/commit/355cb4ce6bbc3f6f238b8a92d61332b2bec753a5) haskellPackages.gio: fix build
* [`0313eb47`](https://github.com/NixOS/nixpkgs/commit/0313eb47958693e965f1fe33aaefd522e06ac08e) blender: patch removed numpy attribute
* [`83d4fa46`](https://github.com/NixOS/nixpkgs/commit/83d4fa464aa8e6de17119694faa5578590bc5e70) texlab: 5.4.1 -> 5.4.2
* [`646872b2`](https://github.com/NixOS/nixpkgs/commit/646872b228ac8ef00b3923d90993b381a4bf18b7) texlab: 5.4.2 -> 5.5.0
* [`9d5dba71`](https://github.com/NixOS/nixpkgs/commit/9d5dba717041400aececbb86b46896cd18d8b84d) nixos/roundcube: read only first line of password file
* [`6cc2ab02`](https://github.com/NixOS/nixpkgs/commit/6cc2ab022a2df93d898ef6434ca02cd78f1d5bf5) gromacs: 2023 -> 2023.1
* [`3aa6004a`](https://github.com/NixOS/nixpkgs/commit/3aa6004a884b6308f204728fa157e9d2081cd153) haskell.packages.ghc961.{aeson,singleton-bool,unliftio-core,lukko,lucid}:
* [`94add426`](https://github.com/NixOS/nixpkgs/commit/94add426514aab7e9c9dd39e5631f5a49a8c8722) octopus: 12.1 -> 12.2
* [`4a0f7c97`](https://github.com/NixOS/nixpkgs/commit/4a0f7c97d986f7de6450d1813fc4668f6cd27e60) python310Packages.forecast-solar: 2.3.0 -> 3.0.0
* [`66504778`](https://github.com/NixOS/nixpkgs/commit/66504778ce157db536f70274d1dadc7f8a576a11) rye: init at unstable-2023-04-23
* [`3c108bd5`](https://github.com/NixOS/nixpkgs/commit/3c108bd5d84ce59d4cb94996547e4034ccb11aa7) haskell.packages.ghc961.singleton-bool: Remove useless assert
* [`e7ec5e11`](https://github.com/NixOS/nixpkgs/commit/e7ec5e110c85fcffb5d920a7fb538bb6c0318069) haskellPackages.gtk: fix build
* [`9605ca48`](https://github.com/NixOS/nixpkgs/commit/9605ca4834edd44efe423ec81ec1c0f89829cd2f) ledger-live-desktop: 2.55.0->2.57.0
* [`0df5257b`](https://github.com/NixOS/nixpkgs/commit/0df5257b8217dcbd43b195cc25e9fbc309017487) nixos/qemu-vm: introduce `virtualisation.mountHostNixStore` option
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
