### PR TITLE
niv devenv: update b454e31b -> c388b8c5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b454e31b73e1ce987e721e0a7a43044253d6b91a",
-        "sha256": "1b9za2xx5rj82m442sr0db6aisyc0x17b4s8yh7n55fikqlzng55",
+        "rev": "c388b8c57116a71174d26b09c0c38b4b6b5bac3a",
+        "sha256": "0qyyc7pfl4kh77daqqpq7762hzwlpvgkwyizz5x4b76hmv4gll9h",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/b454e31b73e1ce987e721e0a7a43044253d6b91a.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/c388b8c57116a71174d26b09c0c38b4b6b5bac3a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@b454e31b...c388b8c5](https://github.com/cachix/devenv/compare/b454e31b73e1ce987e721e0a7a43044253d6b91a...c388b8c57116a71174d26b09c0c38b4b6b5bac3a)

* [`4e5a2d53`](https://github.com/cachix/devenv/commit/4e5a2d53335c5858200715a7c56e648ee6ceb551) mysql: default to pkgs.mariadb
* [`79a3a362`](https://github.com/cachix/devenv/commit/79a3a362aed482c15e2c7fb3aea2af328da884ab) python: use explicit binaries for python and poetry
* [`bc55aa99`](https://github.com/cachix/devenv/commit/bc55aa99b158ec5181b5830793baec6b354ae4a0) python: poetry: avoid creating venv symlink inside .venv
* [`f2898b44`](https://github.com/cachix/devenv/commit/f2898b44a84eb71dcce9eb6024629a1182cede17) python: use explicit packages for other commands as well
* [`d11d8db6`](https://github.com/cachix/devenv/commit/d11d8db6ac90c28d7785dc2e192e6e147307ac19) python: poetry: unset VIRTUAL_ENV
* [`1edf1abf`](https://github.com/cachix/devenv/commit/1edf1abf54ad1001f3e3082fe0fa11847c164d10) devenv: add debug option
* [`83f5e60d`](https://github.com/cachix/devenv/commit/83f5e60d99946d09e1ed2b7307937d039632b3d4) devenv: run debug statement earlier (in shellHook instead of enterShell)
* [`c37232d9`](https://github.com/cachix/devenv/commit/c37232d974f8301cfa85bb293ea748fe5a6e6c5c) Auto generate docs/reference/options.md
* [`47eb4d1f`](https://github.com/cachix/devenv/commit/47eb4d1f12a9209913a485f9df945c2a404a918a) ci: don't fail fast
* [`75b18d27`](https://github.com/cachix/devenv/commit/75b18d276b66719bd4e6730dc56c8d39bdcbde59) python: evaluate $DEVENV_PROFILE at runtime instead of in nix
* [`20eaca2e`](https://github.com/cachix/devenv/commit/20eaca2e7002684e3bc87766476f3b77e93d2c78) Auto generate docs/reference/options.md
* [`3e305406`](https://github.com/cachix/devenv/commit/3e3054069c094ae680417bb1d40e2902ca30dcc1) fix error when devenv ci in devcontainer
* [`cdb3b2f6`](https://github.com/cachix/devenv/commit/cdb3b2f6b358419f0159ae89970e9951f54f0b7b) show error when devenv is not run in impure mode
* [`53ab1fe3`](https://github.com/cachix/devenv/commit/53ab1fe3281d44489874b87d2c91a2ab99e558b3) run tests with --impure
* [`1bedd90b`](https://github.com/cachix/devenv/commit/1bedd90b2599b533f3712d7650c3a17566bb3234) update documentation to use Nix's --impure
* [`85fd091c`](https://github.com/cachix/devenv/commit/85fd091ce8634328806e803dd2c85d3f62d89d78) mkNakedShell: use pkgs.stdenv.system instead of pkgs.system
* [`51eedd76`](https://github.com/cachix/devenv/commit/51eedd761a0e398abd20fbd9f7b341c0824e0372) test explicitly for failing nix-develop in pure mode
* [`3f0ac71e`](https://github.com/cachix/devenv/commit/3f0ac71e8585e0f1b101d4748dcaea0dc971e7a6) devenv: use explicit Nix packages for all external commands
* [`a4c0c7db`](https://github.com/cachix/devenv/commit/a4c0c7db0140ed10befb786cc596f2aeae8c63f6) devenv: pass nix package instead of input
* [`b31d1ffe`](https://github.com/cachix/devenv/commit/b31d1ffed36e95487b9489ac11f55b85f213fed7) devenv: refer to Nix package like other packages
* [`49fdde4c`](https://github.com/cachix/devenv/commit/49fdde4cf0e39388c692eb32b92df2235bc4143a) devenv: refer to devenv-yaml package like other packages
* [`aa1cb61c`](https://github.com/cachix/devenv/commit/aa1cb61c828e0d886ec064da6d91d7c15e839dd2) devenv: use explicit bash packages
* [`cafbb3f1`](https://github.com/cachix/devenv/commit/cafbb3f105d7cc196810bb7aba78ef1845cdbaac) keep the original call signature of src/devenv.nix
* [`f0ad477a`](https://github.com/cachix/devenv/commit/f0ad477af0c36623ac696c12573ee6f50be02632) generate docs using --impure
* [`b16a73a8`](https://github.com/cachix/devenv/commit/b16a73a81b7ea4c9f13a1eb202a6fc99b9973434) Fixed wrong url example
* [`dc815e3b`](https://github.com/cachix/devenv/commit/dc815e3b0907602aa598c8a2f0540d94ba55bdd4) Auto generate docs/reference/options.md
* [`88ff644e`](https://github.com/cachix/devenv/commit/88ff644eb484447ff36b171f8f9ba4268f883474) fix cloudflare pages
