### PR TITLE
niv niv: update ecabfde8 -> 72255212

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "ecabfde837ccfb392ccca235f96bfcf4bb8ab186",
-        "sha256": "1aij19grvzbxj0dal49bsnhq1lc23nrglv6p0f00gwznl6109snj",
+        "rev": "7225521219f64df00de86c3b946a26f608f3b4dc",
+        "sha256": "04w9c06f70n0k9c4xhma4nfrkxxg7d039xd3v9dak8xd7avjb7v0",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/ecabfde837ccfb392ccca235f96bfcf4bb8ab186.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/7225521219f64df00de86c3b946a26f608f3b4dc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@ecabfde8...72255212](https://github.com/nmattia/niv/compare/ecabfde837ccfb392ccca235f96bfcf4bb8ab186...7225521219f64df00de86c3b946a26f608f3b4dc)

* [`72255212`](https://github.com/nmattia/niv/commit/7225521219f64df00de86c3b946a26f608f3b4dc) Update the default nixpkgs to a rolling release ([nmattia/niv⁠#369](https://togithub.com/nmattia/niv/issues/369))
