### PR TITLE
niv powerlevel10k: update bbea8d2d -> dff735c2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "bbea8d2d06382f6f0001c9212da91a319076f06e",
-        "sha256": "1izmxgjcpmk5sywxnbjqa5n3593j1kp6h0ypkihzpfpdldzcd16m",
+        "rev": "dff735c26173183dc44864ae5d9aa4c1d74fe150",
+        "sha256": "0nwrsrbf7hghx5x82zskw7hslliyizk8fza7spqds8xsdbp0rdpm",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/bbea8d2d06382f6f0001c9212da91a319076f06e.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/dff735c26173183dc44864ae5d9aa4c1d74fe150.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@bbea8d2d...dff735c2](https://github.com/romkatv/powerlevel10k/compare/bbea8d2d06382f6f0001c9212da91a319076f06e...dff735c26173183dc44864ae5d9aa4c1d74fe150)

* [`630c1868`](https://github.com/romkatv/powerlevel10k/commit/630c1868df23bb3b62abf90d50e8801ca084b9d3) add POWERLEVEL9K_GITSTATUS_INIT_TIMEOUT_SEC
* [`dff735c2`](https://github.com/romkatv/powerlevel10k/commit/dff735c26173183dc44864ae5d9aa4c1d74fe150) increase the default value of POWERLEVEL9K_GITSTATUS_INIT_TIMEOUT_SEC from 5 to 10
