### PR TITLE
niv nixpkgs: update c8d358b3 -> 055a2f47

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c8d358b3ade1ba08a945c794b797df3c01f9cbab",
-        "sha256": "0lslq6d3y5g816jzp4w7sbk5qwq733nbizdn2rpkh9rhzzixxwrk",
+        "rev": "055a2f470bced98bb34a5d94b775c410e1594cc2",
+        "sha256": "1x932hnirdk9vmfwdnk73rahmy8hsm6g2zkmxpyw108gca3788jm",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c8d358b3ade1ba08a945c794b797df3c01f9cbab.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/055a2f470bced98bb34a5d94b775c410e1594cc2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c8d358b3...055a2f47](https://github.com/nixos/nixpkgs/compare/c8d358b3ade1ba08a945c794b797df3c01f9cbab...055a2f470bced98bb34a5d94b775c410e1594cc2)

* [`804dc945`](https://github.com/NixOS/nixpkgs/commit/804dc945940ba1bb75994f49d6cd6397b94eb596) neovim-unwrapped: add debug output
* [`8f57ffce`](https://github.com/NixOS/nixpkgs/commit/8f57ffce3dc9a69ef168f5ba221c1602c0809e81) libuv: add debug output
* [`833bd514`](https://github.com/NixOS/nixpkgs/commit/833bd514a247269d9e4896edc43b3e14f50105b0) dehydrated: apply nixpkgs-fmt
* [`1e1a1e0e`](https://github.com/NixOS/nixpkgs/commit/1e1a1e0e853da0d66285398d85fc5b4cdb7f72c6) dehydrated: add missing dependency hexdump
* [`ea490bab`](https://github.com/NixOS/nixpkgs/commit/ea490bab62043401941fcd95459e7a5cf8ce9d32) maintainers: add shhht
* [`6b6f3f18`](https://github.com/NixOS/nixpkgs/commit/6b6f3f188c1e8a070ff608fed4a711620dd96a8d) buildMozillaMach: passthru application, extraPatches to be later used by betterbird package
* [`d3b4a6ee`](https://github.com/NixOS/nixpkgs/commit/d3b4a6ee385c2d4aa332855a7dda7f3073932f19) mainsail: init at 2.4.1
* [`d2c34a85`](https://github.com/NixOS/nixpkgs/commit/d2c34a858330ae01a9424be3293ddee66fe6a0e7) maintainers: add slwst
* [`d8747030`](https://github.com/NixOS/nixpkgs/commit/d8747030598e9072b381a96d90a708b9599aac4f) adi1090x-plymouth-themes: init at unstable-2020-12-28
* [`03ceb367`](https://github.com/NixOS/nixpkgs/commit/03ceb367b77c88d99d31af840b15b06b1ee44428) lib.toPlist: support for path values
* [`5a23a24b`](https://github.com/NixOS/nixpkgs/commit/5a23a24ba275ca78d9f1e0d1dfdb7757a720707d) nixos/grub-install: don't rely on shell to run commands
* [`63a8c43d`](https://github.com/NixOS/nixpkgs/commit/63a8c43d0954cf290aa18ae92738a76f8758d463) lib.toPlist: basic test coverage
* [`d9c92360`](https://github.com/NixOS/nixpkgs/commit/d9c92360a8454c6735b0a53e49fdedaa69862162) nixos/install-grub: stop using bare file handles for readFile/WriteFile
* [`e932e984`](https://github.com/NixOS/nixpkgs/commit/e932e98437ea9184365233bad439860c795f65a1) lib.toPlist: keep test output in external files for their tab indents
* [`38f35cf7`](https://github.com/NixOS/nixpkgs/commit/38f35cf7b0beb6adfefcecf0fa5414fd4f4aa628) firefox: remove unused rec
* [`f382bf1d`](https://github.com/NixOS/nixpkgs/commit/f382bf1d802a6622b2d6f51f782fd4f8511b2528) thunderbird: allow overwriting wrapped binary
* [`ea750901`](https://github.com/NixOS/nixpkgs/commit/ea750901e2c45de0e2944cb125fa8a1cb64cbc56) betterbird: init at 102.8.0-bb30
* [`aa69dbd0`](https://github.com/NixOS/nixpkgs/commit/aa69dbd08b992d9ec748cead6d0ee525c518d674) PyQt5: fix check for QtConnectivity
* [`879fa969`](https://github.com/NixOS/nixpkgs/commit/879fa969fed2a67acfc06c367ad40b2be98ae7f8) PyQt5: enable parallel building
* [`9709a912`](https://github.com/NixOS/nixpkgs/commit/9709a912b18763fc2aad3db3f0343c5a777bd49d) PyQt6: enable parallel building conditionally
* [`a2d23744`](https://github.com/NixOS/nixpkgs/commit/a2d23744fe09b70182b9f59ed28d19fca56cbebe) vcv-rack 2.2.1 -> 2.3.0
* [`048bf22a`](https://github.com/NixOS/nixpkgs/commit/048bf22a4c1281999528df0ac72a22d4d6fa4e96) tcl, tk: 8.6.11 -> 8.6.13
* [`80b00d8d`](https://github.com/NixOS/nixpkgs/commit/80b00d8db6f5b9854d82456be26b14d886c4dfa7) team-list: add cuda team
* [`c690aac0`](https://github.com/NixOS/nixpkgs/commit/c690aac0c68c75288af21f339c3c6762bbad7324) cudaPackages: add teams.cuda to maintainers
* [`e935fa19`](https://github.com/NixOS/nixpkgs/commit/e935fa1951e1fef2798365276a056b7dcaa0b118) ffmpeg: add tensorflow dnn backend support
* [`73e0ef7f`](https://github.com/NixOS/nixpkgs/commit/73e0ef7fcf7c520f6916ca8184323f611d729537) prometheus-cloudflare-exporter: init at 0.0.14
* [`f391ca70`](https://github.com/NixOS/nixpkgs/commit/f391ca709efc0329a7c64f707d3cd0f9ee5a2559) vagrant: 2.2.19 -> 2.3.4
* [`e77295ab`](https://github.com/NixOS/nixpkgs/commit/e77295ab8ac9e636741f84391777b21d1648eb1c) wordpress: added ro_RO language + updated plugins,themes and languages
* [`3c789e13`](https://github.com/NixOS/nixpkgs/commit/3c789e1349609fe7a0b80341559a5ba1130a0142) speedtest-exporter: resolve let in, format
* [`2c627d9c`](https://github.com/NixOS/nixpkgs/commit/2c627d9c702202d75746fd45045d20008bf7ed86) llvmPackages_16: init
* [`3c76624c`](https://github.com/NixOS/nixpkgs/commit/3c76624c7037a3bbc4c0f49366143067fac864a3) nixos/fzf: add ohMyZsh integration
* [`dc61a2fe`](https://github.com/NixOS/nixpkgs/commit/dc61a2fe6c25bd325024b25dd6af5c5074bb85fd) fix: virtualbox: make alsa as audio backend working
* [`8604beb4`](https://github.com/NixOS/nixpkgs/commit/8604beb4191e31120bb9a4099703995815f9d83d) kbd: split headers to "dev" output
* [`22e6b372`](https://github.com/NixOS/nixpkgs/commit/22e6b372f22b3271663e75ae43cd020bcede24cf) fluidsynth: move headers out to "dev" output, mans to "man"
* [`d56125cf`](https://github.com/NixOS/nixpkgs/commit/d56125cfba7f9992a12c85820e35e58c875f495f) fribidi: move headers out to "dev" output
* [`434bdafb`](https://github.com/NixOS/nixpkgs/commit/434bdafb956ceb51116a5bd80d8565bb72f0fc2c) SDL2_net: move headers to "dev" output
* [`31390931`](https://github.com/NixOS/nixpkgs/commit/31390931677a7f8fa69825687bc375da0fb33afc) liburcu: move headers to "dev" and docs to "doc"
* [`e4af1f26`](https://github.com/NixOS/nixpkgs/commit/e4af1f260b95487df2f93187d75874c44eb6fee3) gnomeExtensions.valent: init at unstable-2023-03-18
* [`b084afd4`](https://github.com/NixOS/nixpkgs/commit/b084afd456e951c3d1b4e56456f14a4cb234f767) libgpg-error: 1.46 -> 1.47
* [`e86bbf38`](https://github.com/NixOS/nixpkgs/commit/e86bbf38ce149ce203882bbca24264ed540fc2a7) file: move headers and mans to "dev" and "man" outputs
* [`8b92fc3a`](https://github.com/NixOS/nixpkgs/commit/8b92fc3a868ab27b8d630b82aa1524363f46a22c) colloid-gtk-theme: 2022.11.11 -> 2023.04.11
* [`89f78e90`](https://github.com/NixOS/nixpkgs/commit/89f78e90d37e7bdd2dd9fe4b64e2852aebda2667) fdk_aac: split headers to "dev" output
* [`720628bb`](https://github.com/NixOS/nixpkgs/commit/720628bb7ff4f091995d78058271e8a9cd85b8fa) libcanberra: split headers to "dev" output
* [`c8fe3df4`](https://github.com/NixOS/nixpkgs/commit/c8fe3df4ec5140f101fbbbb69d744e83694858ca) emacsPackages.wat-mode: init at unstable-2022-07-13
* [`690583b3`](https://github.com/NixOS/nixpkgs/commit/690583b348cd270fc11acbfb3ae265befee4af65) libuv: split headers to "dev" output
* [`3fa2b905`](https://github.com/NixOS/nixpkgs/commit/3fa2b9059d65c1dca7c73ebcc1718bd129a07c1a) libmad: split headers to "dev" output
* [`599712cb`](https://github.com/NixOS/nixpkgs/commit/599712cbc6787d78f72b54379db95a768e448d3f) wavpack: split headers to "dev" output (and "doc", "man" while at it)
* [`cbb56d49`](https://github.com/NixOS/nixpkgs/commit/cbb56d496069cc17ff55e11fd3a7f4b94116f503) libfreeaptx: split headers to "dev" output
* [`c80513bf`](https://github.com/NixOS/nixpkgs/commit/c80513bf07518488aba593f8fbbbb4bfbbe25eaa) libmysofa: split headers to "dev" output
* [`1f3fda94`](https://github.com/NixOS/nixpkgs/commit/1f3fda9457547e07639bdbaabfa722ed09c9dd06) avahi: split headers to "dev" output
* [`887afd30`](https://github.com/NixOS/nixpkgs/commit/887afd30123fc7d7681a042e581e32546c120577) SDL2: 2.26.4 -> 2.26.5
* [`0f4f1a6f`](https://github.com/NixOS/nixpkgs/commit/0f4f1a6f9724a3399fab01c4a93d831016c73bb3) libgcrypt: 1.10.1 -> 1.10.2
* [`5db6008a`](https://github.com/NixOS/nixpkgs/commit/5db6008a2d1d00db7596c64e3b6293e5f0bb6281) tpm2-tss: split headers to "dev" output (and "man" while at it)
* [`5a5021f2`](https://github.com/NixOS/nixpkgs/commit/5a5021f2596acc159f22dca159b03b0f22e16836) libopenmpt: 0.6.9 -> 0.6.10
* [`59e41fe8`](https://github.com/NixOS/nixpkgs/commit/59e41fe872bc2b0037021cd82f2cc9c28bad74d4) maintainers: add laurent-f1z1
* [`3e35548a`](https://github.com/NixOS/nixpkgs/commit/3e35548a9bc7b11e96113f863f4091768700b998) python310Packages.watchdog: 2.3.0 -> 2.3.1
* [`15f4972e`](https://github.com/NixOS/nixpkgs/commit/15f4972e883573768a2777afcfa6321a296411dd) hwdata: 0.368 -> 0.369
* [`baf549a9`](https://github.com/NixOS/nixpkgs/commit/baf549a9a19d2d080402e73093844f0aa35493bb) mysql-shell: 8.0.32 -> 8.0.33
* [`587f267c`](https://github.com/NixOS/nixpkgs/commit/587f267c7d99c1ea9049ad04339f9ec3aa2f7ff9) codeberg-pages: init at v4.6.2
* [`56a07ba9`](https://github.com/NixOS/nixpkgs/commit/56a07ba986de50006d24792615ee8609342c0354) update-python-libraries: escape vars in regexes
* [`2e77eb81`](https://github.com/NixOS/nixpkgs/commit/2e77eb8190809acb24953ddc7806fec80fa977e3) clang_15: fix build!=(host==target) cross compilation
* [`2baf839f`](https://github.com/NixOS/nixpkgs/commit/2baf839f53e7c38f2b97cc5832e3caed930f88ee) wayland: 1.21.0 -> 1.22.0
* [`9a075406`](https://github.com/NixOS/nixpkgs/commit/9a0754061262b3bd5bdc56ddb5dd971f9245b112) meson: 1.0.0 -> 1.1.0
* [`084a9e08`](https://github.com/NixOS/nixpkgs/commit/084a9e0885dfc3a1a20e4934f20f3e144eadbd4a) fwupd,power-profiles-daemon: remove pkexec hack
* [`f311f47d`](https://github.com/NixOS/nixpkgs/commit/f311f47d63e23b683f819d516cfd12b4d874061a) python310Packages.pyxattr: 0.8.0 -> 0.8.1
* [`22c0f2bc`](https://github.com/NixOS/nixpkgs/commit/22c0f2bca0d9a6a0dd10a035df1e205343db5401) intel-media-driver: 22.6.4 -> 23.1.6
* [`72a7fb85`](https://github.com/NixOS/nixpkgs/commit/72a7fb85f9a7b35d3f6556f57de883ce3e3e629d) intel-gmmlib: 22.3.4 -> 22.3.5
* [`e3401d3a`](https://github.com/NixOS/nixpkgs/commit/e3401d3a508089371697e72994c816a3a9aca583) libva: 2.17.0 -> 2.18.0
* [`e3c880ed`](https://github.com/NixOS/nixpkgs/commit/e3c880edb8b1a982662864f669c2db599493005f) libva: 2.17.1 -> 2.18.0
* [`79a85d3c`](https://github.com/NixOS/nixpkgs/commit/79a85d3ce548122577aaf9f779e07ec4cba6faca) neovim: bundle treesitter parsers
* [`01e24691`](https://github.com/NixOS/nixpkgs/commit/01e24691420eba01be1ad9edad3ebbeded1e36b5) kexec-tools: 2.0.25 -> 2.0.26
* [`0131a9a6`](https://github.com/NixOS/nixpkgs/commit/0131a9a6b0d4587968b848008e7e7be2b7d8964d) libgit2: 1.6.3 -> 1.6.4
* [`fda9058a`](https://github.com/NixOS/nixpkgs/commit/fda9058affd73baa6379743da7a4b463b12849b4) libqmi: widen cross support using emulation
* [`4200374b`](https://github.com/NixOS/nixpkgs/commit/4200374b140c2daed07c3766d1049c931bdcdc06) xf86_input_wacom: 1.1.0 -> 1.2.0
* [`5dc40634`](https://github.com/NixOS/nixpkgs/commit/5dc40634877e96639e1bf6c575231a18afdd8548) weechatScripts.wee-slack: 2.9.0 -> 2.9.1
* [`149b6c58`](https://github.com/NixOS/nixpkgs/commit/149b6c5859abff8731bf5f9dd56e1052a0f52bc4) lvm2: 2.03.20 -> 2.03.21
* [`831f3942`](https://github.com/NixOS/nixpkgs/commit/831f394239f37ecd6b6cdd5dc7b9d6767abc1393) egl-wayland: backport wayland protocol fix
* [`25a7e7d9`](https://github.com/NixOS/nixpkgs/commit/25a7e7d93416fc45817aec9fe63331eaa0d4a5cc) libdecor: 0.1.0 -> 0.1.1
* [`fcde5da6`](https://github.com/NixOS/nixpkgs/commit/fcde5da649b19e2887e855399ada005e40b4c105) libdecor: disable unused demo
* [`ad25ec8e`](https://github.com/NixOS/nixpkgs/commit/ad25ec8ecbbb2c4eea92bb250052b09fcd4adaf9) python310Packages.pydantic: Expose optional dependencies
* [`0cebfbc8`](https://github.com/NixOS/nixpkgs/commit/0cebfbc80e94de86066f7d38edbbc257d45149f0) python310Packages.pydantic: 1.10.5 -> 1.10.7
* [`b5459a2c`](https://github.com/NixOS/nixpkgs/commit/b5459a2c060e8a0f49767f301f27887b648e58ab) python310Packages.pydantic-scim: init at 0.0.7
* [`5f196882`](https://github.com/NixOS/nixpkgs/commit/5f196882beff689c87d34b9a70ba4cc1dfea3c53) python311Packages.fastapi: Fix build
* [`02a0c74e`](https://github.com/NixOS/nixpkgs/commit/02a0c74e97194edc557e1945a188b2e8cad73dd3) texinfo: apply gnulib patch only to version 6.7
* [`0fce0749`](https://github.com/NixOS/nixpkgs/commit/0fce0749b5463497f7d8c42fa4d889d4c6cff3e2) nixos/udev: Fix hwdb conflict handling; build with systemdb-hwdb
* [`85b1f14a`](https://github.com/NixOS/nixpkgs/commit/85b1f14a550fff7d6b79ab957b0c33a6fb88775d) gpgme: 1.19.0 -> 1.20.0
* [`80f3868f`](https://github.com/NixOS/nixpkgs/commit/80f3868fc82d8ddb77bdc845c384e07d12ca18a0) ktlint: 0.48.2 -> 0.49.0
* [`655b1cab`](https://github.com/NixOS/nixpkgs/commit/655b1cabfcb3511ff6f1152725d6e0e637d0588a) faust: make faust2sc available
* [`f4c3ef8b`](https://github.com/NixOS/nixpkgs/commit/f4c3ef8b1e00f0b7cf934be0cb175e02931f75bd) libmpg123: move headers out to "dev" output, mans to "man"
* [`06017ebd`](https://github.com/NixOS/nixpkgs/commit/06017ebd5563b36b38a2964da97858da49a15ac9) python310Packages.transmission-rpc: Update dependencies
* [`d5295e6c`](https://github.com/NixOS/nixpkgs/commit/d5295e6c9df3eb4540f40ca774424b45d122e4f0) python310Packages.pygit2: 1.11.1 -> 1.12.0
* [`c3c75f12`](https://github.com/NixOS/nixpkgs/commit/c3c75f129cff1e6733b00fc164317476975279aa) plasma5Packages.extra-cmake-modules: set bundledir on darwin
* [`a205795c`](https://github.com/NixOS/nixpkgs/commit/a205795c8a8be87904dc687ea64c271848dc8af0) treewide: Make some fetchers overridable
* [`081c90ff`](https://github.com/NixOS/nixpkgs/commit/081c90ff3bfb1212a751122b97bcb99210972e52) rustc: 1.68.2 -> 1.69.0
* [`69847c62`](https://github.com/NixOS/nixpkgs/commit/69847c62129a8c90984b877ee433df9b16227c25) Revert "python3Packages.pythonocc-core: 7.6.2 -> 7.7.0"
* [`ab829c1b`](https://github.com/NixOS/nixpkgs/commit/ab829c1b66512448e510edab0b4f5172b2118724) python3Packages.enamlx: fix build
* [`da2aa5a0`](https://github.com/NixOS/nixpkgs/commit/da2aa5a0db476cdf76acdf101f48173821138264) eglexternalplatform: init at 1.1
* [`9156daa5`](https://github.com/NixOS/nixpkgs/commit/9156daa547086435dadc55ed78bb0d1a85a03a6c) setup-hooks/separate-debug-info.sh: make deterministic
* [`e2ef5b81`](https://github.com/NixOS/nixpkgs/commit/e2ef5b81fb470eded7c53c2863b8dbbb4172c40c) egl-wayland: Remove includedir from pkg-config file
* [`0551be29`](https://github.com/NixOS/nixpkgs/commit/0551be29ec2686932854c8e53d1ab2328af39021) pianoteq: fix fetchers
* [`ee193797`](https://github.com/NixOS/nixpkgs/commit/ee19379700c41c880ac6a79d25848dde6487c025) pianoteq.{stage-trial,standard-trial}: 8.0.5 -> 8.0.8
* [`7e5cc4d3`](https://github.com/NixOS/nixpkgs/commit/7e5cc4d3ce9721fb3de0cd4535e17d43b06f9b53) timidity: drop unused NIX_LDFLAGS override
* [`618fdb19`](https://github.com/NixOS/nixpkgs/commit/618fdb19513c40dddf8394e2c8265713305968cf) vscode-extensions.llvm-vs-code-extensions.vscode-clangd: 0.1.23 -> 0.1.24
* [`25f8a3f2`](https://github.com/NixOS/nixpkgs/commit/25f8a3f2763ac89f5124176627b22181d883a053) lua.lib: use toLua in generateLuarocksConfig
* [`ade7ee78`](https://github.com/NixOS/nixpkgs/commit/ade7ee78c683959d14f09a77ac89c97cb03934fe) iosevka: 22.0.2 → 22.1.0
* [`bbd604ab`](https://github.com/NixOS/nixpkgs/commit/bbd604ab1de6a2f4c400db38e8e992854e2700c3) polyphone: drop redundant INCLUDEPATH to libjack2
* [`b83ad894`](https://github.com/NixOS/nixpkgs/commit/b83ad894b9c0665336fe5290702e995005d7fe90) mir: 2.12.1 -> 2.13.0
* [`4042fa83`](https://github.com/NixOS/nixpkgs/commit/4042fa838a9573f3f482b36f5edb51b1ed51f647) arduino-cli: 0.31.0 -> 0.32.2
* [`6633151d`](https://github.com/NixOS/nixpkgs/commit/6633151db3de14c3d2f1762876292e7d1585338a) palemoon-bin: 32.1.0 -> 32.1.1
* [`90d6866b`](https://github.com/NixOS/nixpkgs/commit/90d6866b78cde026f9644befb534e871d372e1a5) glib: 2.76.1 → 2.76.2
* [`f02b45b5`](https://github.com/NixOS/nixpkgs/commit/f02b45b5ac8cf6c472e891297fb4578cd144495d) libsoup_3: 3.4.0 → 3.4.1
* [`0e1c1d46`](https://github.com/NixOS/nixpkgs/commit/0e1c1d46d46cd8a509e07993bbb90e2d7e1664dd) mobile-broadband-provider-info: 20221107 → 20230416
* [`33f4c3fc`](https://github.com/NixOS/nixpkgs/commit/33f4c3fc4bb44d5813c6e6776a2bea9a0930327d) vala_0_56: 0.56.6 → 0.56.7
* [`3d2b0f14`](https://github.com/NixOS/nixpkgs/commit/3d2b0f145e831fa6aa4f437bd45452788b0fb718) maintainers: add zumorica
* [`82247b07`](https://github.com/NixOS/nixpkgs/commit/82247b07934e6d99fbd2af2b20f15cbaaf246f6f) fcitx5-skk,fcitx5-skk-qt: init at 5.0.15
* [`89657bcf`](https://github.com/NixOS/nixpkgs/commit/89657bcfb4b34b10142129ac35bfbd06cb93ae04) python310Packages.ytmusicapi: 0.25.1 -> 1.0.2
* [`c768d8ff`](https://github.com/NixOS/nixpkgs/commit/c768d8ff7292e770b29bc57b7e1bb71070e03691) space-station-14-launcher: init at 0.20.5
* [`46f2664b`](https://github.com/NixOS/nixpkgs/commit/46f2664b6f89b0e2527e7eee38cea72b24092ea8) faiss: 1.7.2 -> 1.7.4
* [`1d2a96ed`](https://github.com/NixOS/nixpkgs/commit/1d2a96eda36e00ccd4f07ba17fec11e76bc2e8bf) nixos/mediawiki: move virtualHost to httpd.virtualHost
* [`c129c9fa`](https://github.com/NixOS/nixpkgs/commit/c129c9fac02437818a50e439e7c571ea414e05ef) nixos/mediawiki: drop $wgEmergencyContact setting
* [`98a91032`](https://github.com/NixOS/nixpkgs/commit/98a9103299dcf0d78eb51439c869d62eeae2ea17) maintainers: add rogarb
* [`3b758d4a`](https://github.com/NixOS/nixpkgs/commit/3b758d4aab69d2219011cfe84a5d7a04aa76bb80) nixos/nextcloud: fix notify_push configuration parse error
* [`df49d775`](https://github.com/NixOS/nixpkgs/commit/df49d775de7b2aa81c98d741506c862f3fbc13a8) qt5.qtdatavis3d: init module
* [`efe64155`](https://github.com/NixOS/nixpkgs/commit/efe64155a224ba9507c4760da72ae50a9b21d8d4) numactl: move headers and mans to "dev" and "man" outputs
* [`a19acef5`](https://github.com/NixOS/nixpkgs/commit/a19acef56f2d1c95ff1c346122d495f624445bc2) cargo-auditable-cargo-wrapper: use makeWrapper
* [`37a9ea8f`](https://github.com/NixOS/nixpkgs/commit/37a9ea8f4a239bac76f90a17d9632a3893c0a124) cargo-auditable-cargo-wrapper: use more descriptive name
* [`be4e7ef9`](https://github.com/NixOS/nixpkgs/commit/be4e7ef905eeae7e927a2b4a9c4167c3b472608f) nixos/qemu-vm: fix diskless VMs
* [`f7416d72`](https://github.com/NixOS/nixpkgs/commit/f7416d72f65b563075fc5fdd213e20cf1fef0cb0) xorg.xorgserver: Fix Xquartz stub on macOS
* [`d6e84a45`](https://github.com/NixOS/nixpkgs/commit/d6e84a4574a200de63e8fe86ef8574b507fd366e) nixosTest: remove hostname limitations
* [`3ec3d283`](https://github.com/NixOS/nixpkgs/commit/3ec3d283c5c21567b2c1242fc6d3516d4ebb6e5b) nixos/tests: extra-python-packages -> nixos-test-driver/extra-python-packages
* [`e207f4a1`](https://github.com/NixOS/nixpkgs/commit/e207f4a116a64ee5468cd04d4311d5dc0b1e618e) nixosTests.nixos-test-driver.node-name: init
* [`b25259e0`](https://github.com/NixOS/nixpkgs/commit/b25259e021de4b3969090895e48fd213c4b4b444) nixos/stage-1: follow mount options
* [`8f94053a`](https://github.com/NixOS/nixpkgs/commit/8f94053a21261c894d408c35821b4efa27255c2f) nixosTests.early-mount-options: init
* [`43797d4b`](https://github.com/NixOS/nixpkgs/commit/43797d4b969794d8d8a99650747903cd0f512a7b) ffmpeg: don't enable tensorflow by default for full
* [`b65e9775`](https://github.com/NixOS/nixpkgs/commit/b65e9775fb4dc633978ec67156415cb32df661af) ppp: 2.4.9 -> 2.5.0
* [`c6d71ab7`](https://github.com/NixOS/nixpkgs/commit/c6d71ab78151b06abcc6ce6a442093bd4b3859a3) sstp: 1.0.18 -> unstable-2023-03-25
* [`c32144bd`](https://github.com/NixOS/nixpkgs/commit/c32144bd1dad019155b2fec7e8832492397a8564) nixos/tests/pppd: fix with ppp 2.5.0
* [`1ccfc77e`](https://github.com/NixOS/nixpkgs/commit/1ccfc77e9cac41c84b39aa6f9a26b11872ea7e23) pptpd: add patch for ppp 2.5.0 compatibility
* [`e353d3f3`](https://github.com/NixOS/nixpkgs/commit/e353d3f3d6f148455dad02f3921592b878e459ac) nixos/release-notes: add note on rp-pppoe plugin rename
* [`be518ad7`](https://github.com/NixOS/nixpkgs/commit/be518ad70721c8b737e99901f9b310443b0e26af) openvswitch-lts: 2.17.5 -> 2.17.6
* [`08074331`](https://github.com/NixOS/nixpkgs/commit/0807433107415671756c9547b802ffcec5d48a5b) openvswitch: 3.0.3 -> 3.1.1
* [`7dccfdf3`](https://github.com/NixOS/nixpkgs/commit/7dccfdf38e9cb76fb845b5372f18eb8da011de82) kbibtex: 0.9.3.2 -> 0.10.0
* [`062d01a9`](https://github.com/NixOS/nixpkgs/commit/062d01a965a9177d34540aa7ba32c4ef47c4d2e2) git: 2.40.0 -> 2.40.1
* [`d2cd23b9`](https://github.com/NixOS/nixpkgs/commit/d2cd23b9deec83a8c65abf8f2d2ace600922479e) xorg.xorgserver: Restore XQuartz.app's usage of environment variables.
* [`77f296ec`](https://github.com/NixOS/nixpkgs/commit/77f296ec593b4e07b5bd3b50f15d48a0c65c0d77) xquartz: Copy fonts to avoid ELOOP
* [`2d29afdc`](https://github.com/NixOS/nixpkgs/commit/2d29afdcf3c6676d148c1710513400e2714d0f59) obs-studio-plugins.obs-3d-effect: init at 0.0.2
* [`7fa4e34a`](https://github.com/NixOS/nixpkgs/commit/7fa4e34aaa51febe2442903c3c52af89884cd94f) SDL2: add meta.changelog
* [`cacea5f7`](https://github.com/NixOS/nixpkgs/commit/cacea5f70f2b0766d024b3faad76a1deebb04842)  networkmanager: add patch for ppp 2.5.0 ([nixos/nixpkgs⁠#228300](https://togithub.com/nixos/nixpkgs/issues/228300))
* [`2a09cfbf`](https://github.com/NixOS/nixpkgs/commit/2a09cfbf29367c801213c2bf842803608bbc9fa3) obs-studio-plugins.obs-command-source: init at 0.4.0
* [`4e7276cc`](https://github.com/NixOS/nixpkgs/commit/4e7276cc600d8dfe5e97482b48b8a8b619852f6f) ffmpeg: 5.1.2 -> 5.1.3 ([nixos/nixpkgs⁠#227846](https://togithub.com/nixos/nixpkgs/issues/227846))
* [`9e7091bc`](https://github.com/NixOS/nixpkgs/commit/9e7091bc6544008d9f766185b0c95c10c7349348) ovmf: enable IPv6 by default
* [`70ae9b59`](https://github.com/NixOS/nixpkgs/commit/70ae9b59433de039312e51b5c9f09468bb83bf6d) ovmf: add TLS support
* [`c449133f`](https://github.com/NixOS/nixpkgs/commit/c449133f880b756011f59e4f1a3e009510ba7be9) ovmf: support debugging
* [`e30c0604`](https://github.com/NixOS/nixpkgs/commit/e30c0604880a9eb353b620f193b01dae77a3d3c5) inspec: init at 5.21.29
* [`321bf53e`](https://github.com/NixOS/nixpkgs/commit/321bf53e32b244f53a0082dde053daf3014a5ae8) chef-cli: init at 18.2.7
* [`3dbeca1c`](https://github.com/NixOS/nixpkgs/commit/3dbeca1c7d74542cbacf990746913c95c3173dea) serverspec: init at 2.42.2
* [`2d5c1959`](https://github.com/NixOS/nixpkgs/commit/2d5c19598ad493b31d522ba89d2e683c5964b69a) rust-bindgen: 0.64.0 -> 0.65.1 ([nixos/nixpkgs⁠#228307](https://togithub.com/nixos/nixpkgs/issues/228307))
* [`59dc4739`](https://github.com/NixOS/nixpkgs/commit/59dc473937c2a0f478ed9384021d12fc3bf753cf) ruffle: nightly-2022-12-16 -> nightly-2023-04-10
* [`3dfafdc7`](https://github.com/NixOS/nixpkgs/commit/3dfafdc7917f871b268d3f6b91414e2e3632a80f) cbor-diag: 0.5.6 -> 0.8.4
* [`08080cc6`](https://github.com/NixOS/nixpkgs/commit/08080cc60075444dc4c43ab6bd50e22f50eaa2ae) python310Packages.pytest-ansible,python311Packages.pytest-ansible: 2.2.4 -> 3.0.0
* [`d018f767`](https://github.com/NixOS/nixpkgs/commit/d018f767e169950f02aeb95802c972c7b58772fc) xquartz: Fix package to be compatible with current xorg.xorgserver
* [`9ae8af51`](https://github.com/NixOS/nixpkgs/commit/9ae8af51c50dda225f6a566befcdf33b5578e11d) xquartz: Allow extra font directories to be passed
* [`c289fc34`](https://github.com/NixOS/nixpkgs/commit/c289fc341bd947cccac501f2321a8c8aeadcb3bd) gcc: disable libsanitizer on mips64n32
* [`a6a14f2e`](https://github.com/NixOS/nixpkgs/commit/a6a14f2e47c8dad93ee03dc3160d05b46448bfad) kotlin{-native}: 1.8.20 -> 1.8.21
* [`ae269eca`](https://github.com/NixOS/nixpkgs/commit/ae269eca3a6e0203ae3480c4d73fb19392a4fc88) lisp-modules.kons-9: init from trunk
* [`f3b1c3a6`](https://github.com/NixOS/nixpkgs/commit/f3b1c3a6290266534559e1f07a0250e9a08d72f8) obs-studio-plugins.obs-vintage-filter: init at 1.0.0
* [`13836ea1`](https://github.com/NixOS/nixpkgs/commit/13836ea146c155809786ea16315efb0db52c8404) linuxPackages.ax99100: fix build with Linux >= 6.2
* [`7c6d551e`](https://github.com/NixOS/nixpkgs/commit/7c6d551e07ec4d1dcbd0694e5cc755c7077fa8bd) maturin: 0.14.16 -> 0.14.17
* [`ea547c89`](https://github.com/NixOS/nixpkgs/commit/ea547c89730a8dae586a8be89ca124e4dcd0a041) python310Packages.cryptography: don't depend on pytest-benchmark
* [`c6355a70`](https://github.com/NixOS/nixpkgs/commit/c6355a709ca1a10144d53a0c6e4926e63c9a3223) python310Packages.pytest-benchmark: run tests
* [`cfc4c957`](https://github.com/NixOS/nixpkgs/commit/cfc4c957706ec37c67ed6800148fab6c72f1367d) gcc: fix fastStdenv breakage from [nixos/nixpkgs⁠#209870](https://togithub.com/nixos/nixpkgs/issues/209870)
* [`307c3bdd`](https://github.com/NixOS/nixpkgs/commit/307c3bdd0f95768fad3818a817651a5497dc53d1) mesa: fixup build after rust-bindgen update
* [`a2b4fe3b`](https://github.com/NixOS/nixpkgs/commit/a2b4fe3b83f5a1f866d8f909b8381f9f4f2d2ba7) libgcrypt: patch !isLinux builds after update
* [`fc0e13b4`](https://github.com/NixOS/nixpkgs/commit/fc0e13b4317a4331c6d73622757c187fca8c7fb1) python3Packages.sqlparse: 0.4.3 -> 0.4.4
* [`416dba1b`](https://github.com/NixOS/nixpkgs/commit/416dba1bbc1826abc793eb6c7a62e482e500fec1) faiss.tests: format = "other" now required
* [`458c1ec2`](https://github.com/NixOS/nixpkgs/commit/458c1ec2eb0897589caad0e38446f43ee889775e) python310Packages.openai: 0.27.4 -> 0.27.5
* [`485ce863`](https://github.com/NixOS/nixpkgs/commit/485ce863b6384de1476365fa03616d451659a36d) python310Packages.openaiauth: 0.3.2 -> 0.3.6
* [`367b30e1`](https://github.com/NixOS/nixpkgs/commit/367b30e1989bd70f24c67c670d5e7b47ae3b2898) python310Packages.openapi-core: 0.17.0 -> 0.17.1
* [`4fb1ee07`](https://github.com/NixOS/nixpkgs/commit/4fb1ee07ffbfe37f2021f86dc1a668e0d58bed0a) python310Packages.openapi-schema-validator: 0.4.3 -> 0.4.4
* [`23c75c67`](https://github.com/NixOS/nixpkgs/commit/23c75c674d0246beb4a86cd03494f5b94483eb8a) python310Packages.openapi-spec-validator: 0.5.5 -> 0.5.6
* [`589e358e`](https://github.com/NixOS/nixpkgs/commit/589e358e375944b9abbeb6f4db516c15a62a93c0) lnd: 0.15.5-beta -> 0.16.1-beta
* [`3e0cb1ab`](https://github.com/NixOS/nixpkgs/commit/3e0cb1ab7d27ee531915948c751c612c850e77a5) compiler-rt: use -ffreestanding when no libc
* [`e5d1511d`](https://github.com/NixOS/nixpkgs/commit/e5d1511d5b058786ea5ad87bdcca1275283850fa) lib.systems: allow specifying libc = null
* [`2839c94f`](https://github.com/NixOS/nixpkgs/commit/2839c94f1e2be5fe510597453afc64ed4dc9950b) pkgsLLVM.stdenv: use clangNoLibc when libc is null
* [`bfc7aaa8`](https://github.com/NixOS/nixpkgs/commit/bfc7aaa8af566318ad5b0ef35fc8652fecc2945e) wrapCCWith: disable pic when building for Windows
* [`4f1ba7a9`](https://github.com/NixOS/nixpkgs/commit/4f1ba7a97037bd2999caaccda1e094b87c42ecef) serf: patch for openssl_3
* [`993d5c3c`](https://github.com/NixOS/nixpkgs/commit/993d5c3c25a4de965a52dd9fcb8ab9769c27be99) AusweisApp2: 1.26.3 -> 1.26.4
* [`8b0215f7`](https://github.com/NixOS/nixpkgs/commit/8b0215f79c3d300af37fcf686cd62ea5628c7d27) obs-studio-plugins.obs-shaderfilter: init at v1.22
* [`0949f3cd`](https://github.com/NixOS/nixpkgs/commit/0949f3cd78a074a04a9778231b057a2536390697) makeFontsConf: add darwin system fonts ([nixos/nixpkgs⁠#228619](https://togithub.com/nixos/nixpkgs/issues/228619))
* [`0d585220`](https://github.com/NixOS/nixpkgs/commit/0d58522055e7bfdebe1c8621cd5583a7c983ba93) nginx: add meta section to modules
* [`50b8c237`](https://github.com/NixOS/nixpkgs/commit/50b8c237b76330a2b660b6e7c9a4501a034a2e2d) nginx: move aliases behind config.allowAliases
* [`7efebca8`](https://github.com/NixOS/nixpkgs/commit/7efebca89c10c8b075790d31dad12c31beb23383) prefetch-npm-deps: fix reproducibility
* [`503039f7`](https://github.com/NixOS/nixpkgs/commit/503039f741d0b24059284a3ca4568598da9b781b) quickemu: 4.6 -> 4.7
* [`99dac9d0`](https://github.com/NixOS/nixpkgs/commit/99dac9d094a9c8a14d8b2c3a35505e421ba0501a) gdcm: enable tests
* [`472602ec`](https://github.com/NixOS/nixpkgs/commit/472602ec4e8cd4bac5bd54dbd3f46f94e766fdf7) python310Packages.mkdocs-material: 9.0.15 -> 9.1.8
* [`194ddeef`](https://github.com/NixOS/nixpkgs/commit/194ddeefd5339f2a570a878e4f2b15f9585da06f) wrapBintoolsWith: support LINK.EXE-style args in purity checks
* [`80e73435`](https://github.com/NixOS/nixpkgs/commit/80e73435af9193522b55f5473c71dd6592491a75) python310Packages.dvc-objects: 0.21.1 -> 0.21.2
* [`c4a8de22`](https://github.com/NixOS/nixpkgs/commit/c4a8de225953bb0edde59ad0a46383de237292d8) soju: 0.5.2 -> 0.6.1
* [`99701191`](https://github.com/NixOS/nixpkgs/commit/997011915d4da1552beb27b2c5009177d9630b8f) linuxPackages.rtl8189es: 2022-10-30 -> 2023-03-14
* [`608908ed`](https://github.com/NixOS/nixpkgs/commit/608908ed7a44d8c4bebdd95832b6bdb27d10ab92) lit: move to python-modules
* [`8c168726`](https://github.com/NixOS/nixpkgs/commit/8c168726c51e47303eedf7ab782e25d2874ede38) python3Packages.triton-bin: init at 2.0.0
* [`ad01be00`](https://github.com/NixOS/nixpkgs/commit/ad01be006033b2b59b76e2a7da13690fe9e2621d) python3Packages.torch-bin: 1.13.1 -> 2.0.0
* [`b5a3a128`](https://github.com/NixOS/nixpkgs/commit/b5a3a12884b548b7d1e037c3e7440842292fefd3) python3Packages.torch-bin: update license
* [`64fb4575`](https://github.com/NixOS/nixpkgs/commit/64fb4575df7cee802f62c08a26709574cb991ca1) python3Packages.torchaudio-bin: 0.13.1 -> 2.0.1
* [`dc71f104`](https://github.com/NixOS/nixpkgs/commit/dc71f104174b94927e723bcb93544fb4dc5dc0d3) python3Packages.torchvision-bin: 0.14.1 -> 0.15.1
* [`a112e1e8`](https://github.com/NixOS/nixpkgs/commit/a112e1e8ce7fc00417337b77747188218cddc725) nixos/deepin/dde-daemon: init
* [`7a6edd64`](https://github.com/NixOS/nixpkgs/commit/7a6edd644824502974467858f8c1300d2874ec10) nixos/deepin/dde-api: init
* [`dba20db4`](https://github.com/NixOS/nixpkgs/commit/dba20db482ba308cbb36531127a6eff1d1e2e5ee) nixos/deepin/app-services: init
* [`7eafa181`](https://github.com/NixOS/nixpkgs/commit/7eafa181425883605aa78b6c36be916113d35700) deepin.dde-gsettings-schemas: init
* [`d55808c2`](https://github.com/NixOS/nixpkgs/commit/d55808c2c05e0694ea336afcec896545b7a03651) nixos/deepin: init
* [`d63d9821`](https://github.com/NixOS/nixpkgs/commit/d63d98212a6bfcf5dc88d608bb253d4f50ee9f6f) nixos/tests/deepin: init
* [`7f61f65d`](https://github.com/NixOS/nixpkgs/commit/7f61f65def6a56a1615498137c754207025c9b6e) nixos/doc: add release note for Deepin Desktop Environment
* [`83c29429`](https://github.com/NixOS/nixpkgs/commit/83c29429163acb1f03b606688de2c4e1cac62aa7) python3.pkgs.sphinxcontrib-log-cabinet: init at 1.0.1
* [`e7246768`](https://github.com/NixOS/nixpkgs/commit/e7246768380a03512d7f4703d4588fb0dd5786d3) python3.pkgs.sphinx-issues: init at 3.0.1
* [`7e4594a5`](https://github.com/NixOS/nixpkgs/commit/7e4594a5d2560d864e35dea705e6224631181e9e) python3.pkgs.jinja2: build offline documentation
* [`81b9269d`](https://github.com/NixOS/nixpkgs/commit/81b9269df9ec371f36423e3d9a2f76c5a3ea1d7c) vulkan-loader: 1.3.243 -> 1.3.249
* [`73b9b114`](https://github.com/NixOS/nixpkgs/commit/73b9b11429ce070a43f0aa129566de9061559939) vulkan-headers: 1.3.243 -> 1.3.249
* [`7287c0e0`](https://github.com/NixOS/nixpkgs/commit/7287c0e076c3fd69d55e96cdc5c46e951bed01d4) lib.generators.toLua: asBindings option
* [`82e9b3f3`](https://github.com/NixOS/nixpkgs/commit/82e9b3f35800dd0e838b78727b95138d72203dd3) lua.lib: lift toLua to top in generateLuarocksConfig
* [`7f94c155`](https://github.com/NixOS/nixpkgs/commit/7f94c15581c890e87527d18534c68315ca20c9e3) python310Packages.elasticsearch: add changelog to meta
* [`5b0c5978`](https://github.com/NixOS/nixpkgs/commit/5b0c59780758474d900d6a01619386b16dda61de) python310Packages.elastic-transport: init at 8.4.0
* [`2e30ea3f`](https://github.com/NixOS/nixpkgs/commit/2e30ea3fac4425e9354c3a273395857976394499) serial-studio: init at 1.1.7
* [`881d3983`](https://github.com/NixOS/nixpkgs/commit/881d3983e04758d0b347db690fab6fcecd1c47db) simgear: 2020.3.17 -> 2020.3.18
* [`c135b649`](https://github.com/NixOS/nixpkgs/commit/c135b649f6b59c4c4b435b9b8636c92b7905f40a) python310Packages.elastisearch8: init at 8.7.0
* [`5ac17eba`](https://github.com/NixOS/nixpkgs/commit/5ac17eba79230342b03e4c4868551dcf1f0bd3d3) python310Packages.es-client: init at 8.7.0
* [`54a58997`](https://github.com/NixOS/nixpkgs/commit/54a58997340a9155d4e71d521561d89625ca549f) minimap2: 2.24 -> 2.25
* [`a8142661`](https://github.com/NixOS/nixpkgs/commit/a8142661be2042a5489209d40c16468aff8388cf) ecs-agent: 1.70.2 -> 1.71.0
* [`164b8eb6`](https://github.com/NixOS/nixpkgs/commit/164b8eb615a69d1917505363b73b601376d32e58) protoc-gen-validate: 0.10.1 -> 1.0.0
* [`2cf69d3f`](https://github.com/NixOS/nixpkgs/commit/2cf69d3f03e988fd755e7d3f5e4eb2b33eec2d6a) tkimg: init at 623
* [`498a4497`](https://github.com/NixOS/nixpkgs/commit/498a4497ef1812c2cd21cf7549e3366b09a5fd91) therion: init at 6.1.7
* [`e7b3a70a`](https://github.com/NixOS/nixpkgs/commit/e7b3a70ae4219b06764ebf7cf72e7602f1828f01) python310Packages.psutil: 5.9.4 -> 5.9.5
* [`c187bb54`](https://github.com/NixOS/nixpkgs/commit/c187bb54b0e4b491ea2e5f371e46c6e0dc9cca94) python310Packages.simplejson: 3.18.3 -> 3.19.1
* [`04045cfc`](https://github.com/NixOS/nixpkgs/commit/04045cfccd972949dae73fcb5a1bbda7f2d61f9c) python310Packages.psutil: add changelog to meta
* [`5a6f0136`](https://github.com/NixOS/nixpkgs/commit/5a6f013602dafd0bb06af611c0e7891debdb4d3b) mpd: remove pipewire API workaround
* [`e4985271`](https://github.com/NixOS/nixpkgs/commit/e4985271e982cb5e5a93d7422ce1235212fb0e72) minio: 2023-04-20T17-56-55Z -> 2023-04-28T18-11-17Z
* [`82ff7c03`](https://github.com/NixOS/nixpkgs/commit/82ff7c031b65b084b366b8b93ab9e5a594deb4ee) libudev-zero: 1.0.1 -> 1.0.2
* [`08afd721`](https://github.com/NixOS/nixpkgs/commit/08afd721843f5e8e606cf342b7132ab70d9f61e1) rust-analyzer-unwrapped: 2023-04-17 -> 2023-04-24
* [`eeff5cfe`](https://github.com/NixOS/nixpkgs/commit/eeff5cfe50309cb860021808c5e6d7dd601d1d22) benthos: 4.13.0 -> 4.14.0
* [`36119530`](https://github.com/NixOS/nixpkgs/commit/361195305b6d3477ea324913cccc07d2170a358f) python3Packages.aiohttp: add setuptools to nativeBuildInputs, fix cross compilation
* [`fd955a68`](https://github.com/NixOS/nixpkgs/commit/fd955a683f7c768e259120db083b91fa361a14de) libvisio: set strictDeps, remove unneeded configureFlags
* [`6fd16207`](https://github.com/NixOS/nixpkgs/commit/6fd16207940d7a6cc2621f172b5b21e7617c0d2a) libvisio: add nickcao to maintainers
* [`705277a9`](https://github.com/NixOS/nixpkgs/commit/705277a96f1f6025ad3a20cd531c07c7ac57ac9f) libspatialaudio: fix libmysofa in .pc
* [`9c6d086e`](https://github.com/NixOS/nixpkgs/commit/9c6d086e7431cddceb6d508f9ad2ada42e14f837) vscode-extensions.sumneko.lua: 3.5.6 -> 3.6.19
* [`879dce99`](https://github.com/NixOS/nixpkgs/commit/879dce99e75b337b13319b4c8838f5a304b513c1) nimPackages.npeg: 1.0.1 -> 1.2.1
* [`5d6f3c7c`](https://github.com/NixOS/nixpkgs/commit/5d6f3c7c3f27f29dac3350ae81b9748a8680d08c) ansible-lint: 6.14.3 -> 6.15.0
* [`a46b99d9`](https://github.com/NixOS/nixpkgs/commit/a46b99d98526d52c843447eae47c19dc460b977f) gnomeExtensions: auto-update
* [`a1335c94`](https://github.com/NixOS/nixpkgs/commit/a1335c94d11ba64886d469782d7aef5a52d7bbfb) fluent-bit: 2.1.1 -> 2.1.2
* [`e7038aee`](https://github.com/NixOS/nixpkgs/commit/e7038aee97fb7b7d096549e68de17d6307567620) openblas: Enable loongarch64-linux
* [`c8f1166c`](https://github.com/NixOS/nixpkgs/commit/c8f1166ce664509384a24b8bb819f92f60406d63) openblas: fix build on new-world loongarch
* [`4c97c79e`](https://github.com/NixOS/nixpkgs/commit/4c97c79eb75cdc8116bfa89a1b1d850491b3e664) cloud-init: add patch for vultr
* [`a71059e0`](https://github.com/NixOS/nixpkgs/commit/a71059e0e9e5f6471186250d59c92964c6d9488c) operator-sdk: 1.28.0 -> 1.28.1
* [`d5962b7e`](https://github.com/NixOS/nixpkgs/commit/d5962b7e9754d979ca473162ebc4a36cbc99f2ed) gst_all_1.gst-plugins-bad: remove gstmicrodns
* [`ab4ff1fa`](https://github.com/NixOS/nixpkgs/commit/ab4ff1fa7fe3e05f95074ae4d17dcfa219526815) opengrok: 1.12.0 -> 1.12.3
* [`cd72014a`](https://github.com/NixOS/nixpkgs/commit/cd72014a8778cbc1007f66acb2b79ec1fac8e8cc) python3.pkgs.jinja2: don't build offline documentation by default
* [`de8b1cf6`](https://github.com/NixOS/nixpkgs/commit/de8b1cf647dcde12f59ffde2d1a17e003cf080b0) cloud-init module: format with nixpkgs-fmt
* [`4a1fd4af`](https://github.com/NixOS/nixpkgs/commit/4a1fd4afe03fe8ed4417df608ae86e6c3a4b3a6f) cloud-init module: remove superfluous lib. prefixes
* [`c96a05a2`](https://github.com/NixOS/nixpkgs/commit/c96a05a29339df5230385f0cfb9ee0c9a4a29017) llvmPackages_15.compiler-rt: fix missing builtins
* [`88be91f0`](https://github.com/NixOS/nixpkgs/commit/88be91f08c8fcf6a5912b83dea31fcee090e0dab) swiftpm2nix: add support for workspace-state v6
* [`f85d1219`](https://github.com/NixOS/nixpkgs/commit/f85d12198f4a4201d763cc481ccaf7025f0ec6ff) swift: 5.7.3 -> 5.8
* [`406a6dfa`](https://github.com/NixOS/nixpkgs/commit/406a6dfa26087dd7a71e938457a5a4302514a8bf) cloud-init module: adopt the settings format
* [`a8f650bd`](https://github.com/NixOS/nixpkgs/commit/a8f650bd325beb55111df3c8dcf1a639f36bf844) ft2-clone: 1.66 -> 1.67
* [`e471f696`](https://github.com/NixOS/nixpkgs/commit/e471f6963fe60c3315e25afc98a16e180cad5a10) tarball job: tag both derivations as big-parallel
* [`a4bab9f0`](https://github.com/NixOS/nixpkgs/commit/a4bab9f01985f3303b2ca9a9dd47c6562422e940) i3-cycle-focus: init at unstable-2021-09-27
* [`6a8ab7a8`](https://github.com/NixOS/nixpkgs/commit/6a8ab7a8c72e196cff03bcf21c0dafdd3a235b96) checkSSLCert: 2.66.0 -> 2.68.0
* [`ae8863a0`](https://github.com/NixOS/nixpkgs/commit/ae8863a0f6849310b9dc3e4f5932b356f8cbc3cc) mympd: 10.3.0 -> 10.3.1
* [`51b81abf`](https://github.com/NixOS/nixpkgs/commit/51b81abf6cee5b944945478a5505f47e72245080) checkSSLCert: update rev
* [`ac35d7ea`](https://github.com/NixOS/nixpkgs/commit/ac35d7ea860d691d68f6e856202bad890478fe0b) prefetch-npm-deps: look up hashes from cache when fixing up lockfiles
* [`a9589d36`](https://github.com/NixOS/nixpkgs/commit/a9589d36d95d7efc7e88efb6232f3ceb7cd2418e) xfce.thunar: 4.18.4 -> 4.18.6
* [`7d7f6ac2`](https://github.com/NixOS/nixpkgs/commit/7d7f6ac2ebca05d24f4b9d048970f4ccd734be95) qmidiarp: 0.6.5 -> 0.6.7
* [`65896054`](https://github.com/NixOS/nixpkgs/commit/658960546f2848d3f2fed3f6ba2888f1949d3ee5) xfce.xfce4-mpc-plugin: 0.5.2 -> 0.5.3
* [`2f5a2598`](https://github.com/NixOS/nixpkgs/commit/2f5a2598c2f5dee16a33d1c2cc96e78c8f7328fc) tangram: 2.0 -> 3.0
* [`44438e0d`](https://github.com/NixOS/nixpkgs/commit/44438e0dcdf800809e1bf1bed78dea90bb35037a) nixos/fstrim: fix overriding the timer interval
* [`16c80ce9`](https://github.com/NixOS/nixpkgs/commit/16c80ce91184447e2f4a8271bd8e75be644bc80c) zotero: remove version from name in desktopItem
* [`e4e730bd`](https://github.com/NixOS/nixpkgs/commit/e4e730bdbf5ffa85d61b6c646bb93ed3f1c51675) python310Packages.miniful: init at 0.0.6
* [`596aa930`](https://github.com/NixOS/nixpkgs/commit/596aa930b25112608086203e5e776bb3bf46715b) flutter: rename & expose builders to pkgs
* [`e4a4848c`](https://github.com/NixOS/nixpkgs/commit/e4a4848cc23fe295a3f4fb4730188cb47d491fab) python310Packages.fst-pso: init at 1.8.1
* [`b2772bd9`](https://github.com/NixOS/nixpkgs/commit/b2772bd9047e0cdde98532a3954b935ff6fcbe48) python310Packages.watchdog: 2.3.1 -> 3.0.0
* [`ad454c17`](https://github.com/NixOS/nixpkgs/commit/ad454c1708cc2bb2ac82fbeb6af5210c8411d3c2) or-tools: remove dev output
* [`bf02d717`](https://github.com/NixOS/nixpkgs/commit/bf02d717b59667cb7abc9c4a1c279ccdcd33c99a) python3Packages.protobuf: remove dev output
* [`4a288de7`](https://github.com/NixOS/nixpkgs/commit/4a288de75a4bce72ac6250ce923fcb7fa2ec15da) python310Packages.simpful: init at 2.10.0
* [`239286eb`](https://github.com/NixOS/nixpkgs/commit/239286eb094120bcad9e4fc4c91ca73e3a6f752a) veusz: 3.3.1 -> 3.6.2
* [`e2700c1b`](https://github.com/NixOS/nixpkgs/commit/e2700c1bce733351feecf677216579bae48b84a4) steam: add udev to non-game-sepcific deps for SteamVR
* [`b4b7c759`](https://github.com/NixOS/nixpkgs/commit/b4b7c759b63bb2e57b8f70b4b4879144fbffcc11) steam: add xdg-user-dirs to suppress log spam
* [`5bd5b8a5`](https://github.com/NixOS/nixpkgs/commit/5bd5b8a50aace4cf39c34c03af9fb07a6191c513) sbcl: 2.3.2 -> 2.3.4
* [`2ad219c8`](https://github.com/NixOS/nixpkgs/commit/2ad219c8aadb1666799d446bf66e1e863e473da4) sbcl: explicitly document the cleanup convention
* [`a3cad437`](https://github.com/NixOS/nixpkgs/commit/a3cad4378eea8b3dfa7c27180acecc92c51f02d9) pkgs/build-support: call the right makeWrapper function from wrapProgram<Type>
* [`a2332386`](https://github.com/NixOS/nixpkgs/commit/a2332386df7415d048f8291c75d25e65868efa91) gnuplot-qt: fix wrapper
* [`b9ae609d`](https://github.com/NixOS/nixpkgs/commit/b9ae609d63bcf1c838185167a3c74fda964067d6) cdrdao: 1.2.3 -> 1.2.5
* [`c9a5dacb`](https://github.com/NixOS/nixpkgs/commit/c9a5dacbb28342e5029cea75583879adbed9e481) maintainers: add cadkin
* [`dd321d9e`](https://github.com/NixOS/nixpkgs/commit/dd321d9e353cc85581b2d3daad727f9c539ca2b5) cargo-info: init at 0.7.3
* [`ab709141`](https://github.com/NixOS/nixpkgs/commit/ab709141dfc4fdd52330a7638a6dc3cb39920457) supergfxctl: 5.0.1 -> 5.1.1
* [`ce838d94`](https://github.com/NixOS/nixpkgs/commit/ce838d944fc8b46940017091e7f362eec58b3c69) firmware-updater: unstable(unversioned) -> unstable-2023-04-30
* [`699e707e`](https://github.com/NixOS/nixpkgs/commit/699e707e90a89fb06a9880df6b83c22428fd8deb) spotify: Fix login with firefox
* [`122e7746`](https://github.com/NixOS/nixpkgs/commit/122e7746ee795984b5f0f144567a1b86baaefc7b) gnupg: 2.4.0 -> 2.4.1
* [`20fb44f0`](https://github.com/NixOS/nixpkgs/commit/20fb44f0ccda841be8ca0b1982cd8e95246b798a) python310Packages.deepwave: 0.0.17 -> 0.0.18
* [`f5332168`](https://github.com/NixOS/nixpkgs/commit/f5332168e9a7a4799e515946684025482fe7807a) marble-marcher-ce: init at 1.4.5
* [`2ad790a0`](https://github.com/NixOS/nixpkgs/commit/2ad790a0c14d350a8d189d6b314b912689f93acc) matrix-synapse.tools.synadm: 0.40 -> 0.41.2
* [`9a8d6afb`](https://github.com/NixOS/nixpkgs/commit/9a8d6afb354aeb3d2462b8102c6237bbbd923264) python310Packages.django-stubs-ext: 0.8.0 -> 4.2.0
* [`df2c2e63`](https://github.com/NixOS/nixpkgs/commit/df2c2e63f1a5e25ba3afda9387893dfb320eac18) cpython: add loongarch triplets
* [`f20662b5`](https://github.com/NixOS/nixpkgs/commit/f20662b573e0b7b3fdb938b06be575cb347d70c6) python310Packages.django-stubs: 1.15.0 -> 4.2.0
* [`15725534`](https://github.com/NixOS/nixpkgs/commit/1572553498e032fb754f08d4ed5fd9b77c661f95) python310Packages.django-phonenumber-field: 7.0.2 -> 7.1.0
* [`66af8f3f`](https://github.com/NixOS/nixpkgs/commit/66af8f3f06a41ed7098bc2e8635a6bc67a9a57dd) python310Packages.docstring-parser: 0.14.1 -> 0.15
* [`8cad3dbe`](https://github.com/NixOS/nixpkgs/commit/8cad3dbe48029cb9def5cdb2409a6c80d3acfe2e) pgadmin4: fix build
* [`1a817360`](https://github.com/NixOS/nixpkgs/commit/1a817360a574b00d818fc096bce4b6c5c52ba718) python310Packages.docstring-parser: add changelog to meta
* [`43394c97`](https://github.com/NixOS/nixpkgs/commit/43394c9740a9da1841b077539f0b97ccd84fc20f) python310Packages.django-simple-captcha: 0.5.14 -> 0.5.17
* [`9a8dd15a`](https://github.com/NixOS/nixpkgs/commit/9a8dd15a14ccecb4ca03005cc91cc681fde22f2c) maude: remove Full Maude from release
* [`bb34e903`](https://github.com/NixOS/nixpkgs/commit/bb34e9035bb87a0a4e3c274f1d3507224602763b) kbibtex: specify meta.platforms
* [`85d926ec`](https://github.com/NixOS/nixpkgs/commit/85d926ecb2d0932f6cb3d53aa9b2ef26c5608cda) fzf: 0.39.0 -> 0.40.0
* [`06a34f67`](https://github.com/NixOS/nixpkgs/commit/06a34f672e51ef2a667a8ef8068f8cdfa763212a) kitsas: 4.0.3 -> 4.0.5
* [`b4cf1844`](https://github.com/NixOS/nixpkgs/commit/b4cf1844130b818ec8f5ffce3abf5510d4de7348) github-copilot-cli: init at 0.1.33
* [`6fac838f`](https://github.com/NixOS/nixpkgs/commit/6fac838faa2c5aba9897946d8fae7f1b991b6804) nodePackages: update
* [`b4b15b69`](https://github.com/NixOS/nixpkgs/commit/b4b15b69cb9afe1cd6b57c43ab031b49cbfce971) nodePackages.@⁠githubnext/github-copilot-cli: remove and alias to `github-copilit-cli`
* [`66208677`](https://github.com/NixOS/nixpkgs/commit/662086776815f70fe52b36c7a9b7d95945af295e) cloudflared: 2023.4.1 -> 2023.4.2
* [`a2871406`](https://github.com/NixOS/nixpkgs/commit/a28714066294c0a911cfe6d3b26d644aa3b4f810) signalbackup-tools: 20230426 -> 20230429
* [`a7a575ef`](https://github.com/NixOS/nixpkgs/commit/a7a575ef241c7aa1c16a602b8b69dc0275f8310f) sqlcipher: 4.5.3 -> 4.5.4
* [`3ab5ae2a`](https://github.com/NixOS/nixpkgs/commit/3ab5ae2aaacc712507048f0842a267864d8f0c17) jet: 0.4.24 -> 0.5.25
* [`f37c8f52`](https://github.com/NixOS/nixpkgs/commit/f37c8f521c77531cf2f78fdbd8245469b28faaa0) rambox: 2.1.2 -> 2.1.3
* [`d22efbaf`](https://github.com/NixOS/nixpkgs/commit/d22efbafd5c7811b377e52cbefe22ad65748fa1b) lf: 28 -> 29
* [`2e4d017b`](https://github.com/NixOS/nixpkgs/commit/2e4d017b7107a7bb198d45c28c1bc07e85619d02) flrig: 1.4.7 -> 1.4.8
* [`2e63d92e`](https://github.com/NixOS/nixpkgs/commit/2e63d92efdda0a8938d18ef54464e8b03390a99d) python310Packages.pygti: 0.9.3 -> 0.9.4
* [`b0b79328`](https://github.com/NixOS/nixpkgs/commit/b0b79328da01df5a1ab913c442dae25f0678ea3e) corectrl: 1.3.3 -> 1.3.5
* [`6bad6ca6`](https://github.com/NixOS/nixpkgs/commit/6bad6ca6b16cc2f0469cf2ee7340cc452d148e25) haguichi: 1.4.5 -> 1.4.6
* [`0e0ba124`](https://github.com/NixOS/nixpkgs/commit/0e0ba1246ef495b47082a26331c0be14c11de56a) buttercup-desktop: 2.19.0 -> 2.19.1
* [`4817b89e`](https://github.com/NixOS/nixpkgs/commit/4817b89e6d11e3cc96df5c053953a94f7526528c) vdr: 2.6.3 -> 2.6.4
* [`2bf18d9c`](https://github.com/NixOS/nixpkgs/commit/2bf18d9ccdd8320456a742a7acceef4a971a7f8c) aws-c-sdkutils: 0.1.8 -> 0.1.9
* [`067f90de`](https://github.com/NixOS/nixpkgs/commit/067f90de85fbd420c1b4e3634e0c140af21b0541) fedora-backgrounds: add proper flags for XFCE backgrounds
* [`08a3a248`](https://github.com/NixOS/nixpkgs/commit/08a3a248c4583b48cad1a40f4bdb38f826d0f9a7) fedora-backgrounds.f35: init at 35.0.1
* [`d5ee0d99`](https://github.com/NixOS/nixpkgs/commit/d5ee0d9922d5b65532ba2b2725763fae5263669b) fedora-backgrounds.f36: init at 36.1.2
* [`439a46e5`](https://github.com/NixOS/nixpkgs/commit/439a46e5fe18be1a802eec1d6837914103055073) fedora-backgrounds.f37: init at 37.0.5
* [`f437672b`](https://github.com/NixOS/nixpkgs/commit/f437672b0b7b7027989f007a2de066f630910fa3) fedora-backgrounds.f38: init at 38.1.1
* [`d217bc76`](https://github.com/NixOS/nixpkgs/commit/d217bc76e3483dce0e21dcd6b72d5e0e50d37b88) terraform-providers.buildkite: 0.16.0 -> 0.17.0
* [`ae872c42`](https://github.com/NixOS/nixpkgs/commit/ae872c42f030a29adc808bd87a018be1566ade06) nomachine-client: 7.10.1 → 8.4.2
* [`292c7b0b`](https://github.com/NixOS/nixpkgs/commit/292c7b0b5e42c1ac63ca33ac64e6bf047a1d3024) brev-cli: build with Go 1.20
* [`c949b052`](https://github.com/NixOS/nixpkgs/commit/c949b05297c0268f18957c1eff5bc5a5a3073162) doggo: build with Go 1.19
* [`93fa4b59`](https://github.com/NixOS/nixpkgs/commit/93fa4b5910e877abfc61f9a12ca045fbe537a6ef) norouter: build with Go 1.20
* [`db0666b8`](https://github.com/NixOS/nixpkgs/commit/db0666b8dc8a47f1cbd752c238a8294e943af3d3) ivy: 0.2.8 -> 0.2.10
* [`34b609f3`](https://github.com/NixOS/nixpkgs/commit/34b609f367bdd75a6e3d7b2c5701a33b5e233667) routedns: 0.1.5 -> 0.1.20
* [`dd36ed45`](https://github.com/NixOS/nixpkgs/commit/dd36ed450cd59fc492f1f4ad358f9d227c6c3384) xfce.xfce4-netload-plugin: 1.4.0 -> 1.4.1
* [`adea3473`](https://github.com/NixOS/nixpkgs/commit/adea347368d8dfceffca0d6b7f21d3054e92e397) gnome-builder: 44.1 → 44.2
* [`cdefca3d`](https://github.com/NixOS/nixpkgs/commit/cdefca3d7a883d56975d2d3d859f9540fdc9cec1) nixos/release-notes: fix typo
* [`948cf105`](https://github.com/NixOS/nixpkgs/commit/948cf105b99a4e1db6b786722a33ef1a1d376bd1) anki-bin: 2.1.61 -> 2.1.62
* [`b339c58d`](https://github.com/NixOS/nixpkgs/commit/b339c58df18a0c3b2fb951e1de1055d084c2b2c8) rsyslog: 8.2302.0 -> 8.2304.0
* [`313089a9`](https://github.com/NixOS/nixpkgs/commit/313089a9ff64198a5f6fda16910dbadb5447d6e2) libsoup_3: 3.4.1 → 3.4.2
* [`e689a64f`](https://github.com/NixOS/nixpkgs/commit/e689a64f24490753c79cf9e2139117607a21938d) ocamlPackages.postgresql: `postgresql` is a buildInput
* [`47e35d0f`](https://github.com/NixOS/nixpkgs/commit/47e35d0f361625fefeec24ad6e94bb78bf023af8) unpackerr: 0.11.1 -> 0.11.2
* [`97a2834c`](https://github.com/NixOS/nixpkgs/commit/97a2834cf313e5121fd9159d99f66c9767c7b109) vmware-horizon-client: 2206 -> 2303
* [`69443ec2`](https://github.com/NixOS/nixpkgs/commit/69443ec28a7027d3c73ac471c32bf5875067fca6) pipecontrol: 0.2.8 -> 0.2.10
* [`ab12ff29`](https://github.com/NixOS/nixpkgs/commit/ab12ff29abc17412807587fe7a7fb34102f5ebde) commonsCompress: 1.22 -> 1.23.0
* [`4c598381`](https://github.com/NixOS/nixpkgs/commit/4c598381e0b742608d481ae4bf88ac31f69df978) Update default.nix
* [`732d2353`](https://github.com/NixOS/nixpkgs/commit/732d2353098d5233dda2a293f2d2ccc7e47a00a6) restic-rest-server: 0.11.0 -> 0.12.0 ([nixos/nixpkgs⁠#228395](https://togithub.com/nixos/nixpkgs/issues/228395))
* [`82cea119`](https://github.com/NixOS/nixpkgs/commit/82cea11923906492263ea968ccd986a01238b5d9) gnome.geary: Fix build with Vala 0.56.7 & 0.57+
* [`292f3ae2`](https://github.com/NixOS/nixpkgs/commit/292f3ae2b0765a0bf0fe9fb63fe0325b77233f07) python3Packages.dbus-python-client-gen: 0.8.2 -> 0.8.3
* [`b02988a8`](https://github.com/NixOS/nixpkgs/commit/b02988a87c25347c863b5d6f7cc3eb1e2fbc8031) Revert "python310Packages.aioesphomeapi: Propagate protobuf dev output"
* [`ab9c7572`](https://github.com/NixOS/nixpkgs/commit/ab9c7572290cda3db7e05e3f4bbe5559eb98235c) python310Packages.plantuml-markdown: 3.8.1 -> 3.9.1
* [`d163a2e8`](https://github.com/NixOS/nixpkgs/commit/d163a2e8ffb103cf081d8ce5eaa78fd8643043aa) i3status-rust: 0.31.0 -> 0.31.1
* [`511a1dbe`](https://github.com/NixOS/nixpkgs/commit/511a1dbe6380f89fc583f12536d1f5b885d0812d) python310Packages.bucketstore: fix version specifier
* [`6e61ecf9`](https://github.com/NixOS/nixpkgs/commit/6e61ecf9bc08c45bc603b6b23dd159a32324b124) python3Packages.dask-gateway-server: 2022.4.0 -> 2022.10.0
* [`36fa6a8e`](https://github.com/NixOS/nixpkgs/commit/36fa6a8e56da5b877020908c090a6fdcd3bde92f) python310Packages.fastparquet: 2023.1.0 -> 2023.4.0
* [`298a77d9`](https://github.com/NixOS/nixpkgs/commit/298a77d9293d43578626994590ef95596689e372) python310Packages.dask-ml: 2022.5.27 -> 2023.3.24
* [`b12ad9a5`](https://github.com/NixOS/nixpkgs/commit/b12ad9a53455410ee950cc5735eb3258088542b9) python310Packages.dask: 2023.2.1 -> 2023.4.1
* [`1ff212f0`](https://github.com/NixOS/nixpkgs/commit/1ff212f0fe30a7733ffd1c69e08859da053fda67) python310Packages.dask-awkward: 2023.1.0 -> 2023.4.2
* [`39bcf885`](https://github.com/NixOS/nixpkgs/commit/39bcf885917b131f08cc385b91e9f52e6b46db8a) python310Packages.fsspec: 2022.10.0 -> 2023.1.0
* [`8643ea7e`](https://github.com/NixOS/nixpkgs/commit/8643ea7e10204d2817048ce21a4107ce458cf271) python310Packages.gcsfs: 2022.10.0 -> 2023.1.0
* [`085b06f4`](https://github.com/NixOS/nixpkgs/commit/085b06f4aa23b1cfb829eed35ff95c65f06cc729) python310Packages.ossfs: 2023.1.0 -> 2023.3.0
* [`ac22ea44`](https://github.com/NixOS/nixpkgs/commit/ac22ea44ff4cc67521facb39e4f7cd5451d07fda) python310Packages.fsspec: 2023.1.0 -> 2023.4.0
* [`0a197a4a`](https://github.com/NixOS/nixpkgs/commit/0a197a4a1e471ec5d3ed8b6a3b49a372e8a33ec9) python310Packages.gcsfs: 2023.1.0 -> 2023.4.0
* [`c3a2a238`](https://github.com/NixOS/nixpkgs/commit/c3a2a238f77763c952d5301f3aabe625f71a32aa) defaultGemConfig.grpc: update config
* [`a0366812`](https://github.com/NixOS/nixpkgs/commit/a03668123394151dd8e2df6068ef74aaff48b523) python310Packages.nats-py: disable failing test
* [`576d7d34`](https://github.com/NixOS/nixpkgs/commit/576d7d34c46dc2c40a86d2f8cdb7da28b7d54edf) asusctl: 4.5.8 -> 4.6.2
* [`6aed0cf7`](https://github.com/NixOS/nixpkgs/commit/6aed0cf741f8fdafbbeac98e8b15a447133d595c) fuzzylite: init at 6.0
* [`be3a8679`](https://github.com/NixOS/nixpkgs/commit/be3a867936d6f4b9872e1bb8902e8d237173270f) vcmi: 1.1.1 -> 1.2.1
* [`f050b8d3`](https://github.com/NixOS/nixpkgs/commit/f050b8d31283595ebc4041c42afb88a9323334ec) mu: 1.18.14 -> 1.10.3
* [`d74180d0`](https://github.com/NixOS/nixpkgs/commit/d74180d07b7720f7f34d06a3a44782c440973f87) mu: don't use (very) old version of texinfo
* [`fd70aa16`](https://github.com/NixOS/nixpkgs/commit/fd70aa16b13195ec8e2cb3117e4afcd192befcc4) exportarr: 1.3.1 -> 1.3.2
* [`790628ae`](https://github.com/NixOS/nixpkgs/commit/790628ae9f6bc4a8f5f7a2c6945b68f8e3139345) chromium: (cross) move bison and gperf to nativeBuildInputs
* [`5915f52e`](https://github.com/NixOS/nixpkgs/commit/5915f52e04878403b7b8604740ebf4aba2325e8f) python310Packages.python-keycloak: fix typo
* [`a4202cfe`](https://github.com/NixOS/nixpkgs/commit/a4202cfee50473b8d3534aea06ccb8903303f4c5) python310Packages.plantuml-markdown: add changelog to meta
* [`2fb1be6b`](https://github.com/NixOS/nixpkgs/commit/2fb1be6b1e1d16b77432ef4c8403fa9090934233) python310Packages.aiooss2: init at 0.2.5
* [`3fa9a546`](https://github.com/NixOS/nixpkgs/commit/3fa9a5467ac7e734b3244aa0594961e1e68c208b) python310Packages.tifffile: 20232.2.3 -> 2023.4.12
* [`02f05bbf`](https://github.com/NixOS/nixpkgs/commit/02f05bbf9207253b26737a9f175b6a496a018265) python310Packages.ossfs: 2023.1.0 -> 2023.4.0
* [`96a3364a`](https://github.com/NixOS/nixpkgs/commit/96a3364aa01e7ac051fb21aff91a9c43f9a1ab26) python310Packages.oss2: 2.16.0 -> 2.17.0
* [`965bdf48`](https://github.com/NixOS/nixpkgs/commit/965bdf48b1748a056a8ccb52ff3903437ad7369f) seaweedfs: 3.47 -> 3.48
* [`12e08bd3`](https://github.com/NixOS/nixpkgs/commit/12e08bd339ef5dbaabb4c892d0c7637c96bafe18) lib.kernel.unset: init
* [`b4403bcc`](https://github.com/NixOS/nixpkgs/commit/b4403bcc85d894446c11755d9b12a91a630cfc12) taskjuggler: add webrick for tj3webd
* [`5384c132`](https://github.com/NixOS/nixpkgs/commit/5384c132e2ef306575120255bf27f0ebe8bc02df) python310Packages.cwl-upgrader: add mypy-extensions
* [`9864b154`](https://github.com/NixOS/nixpkgs/commit/9864b15480f8c95728be14260409d1e6aeca51bf) kirigami-addons: 0.7.2 -> 0.8.0
* [`d5bc0875`](https://github.com/NixOS/nixpkgs/commit/d5bc08754b7a52f84ccd32aa523d3387f57f5b31) arianna: init at 1.0.0
* [`07bc8712`](https://github.com/NixOS/nixpkgs/commit/07bc8712aa28af72e0adf4767789697885d35c3f) python310Packages.pinocchio: 2.6.17 -> 2.6.18
* [`2af4b551`](https://github.com/NixOS/nixpkgs/commit/2af4b551c1ddd0fdcf0d43d46c9638fd8db31886) musl: tighten platforms
* [`5130c4f4`](https://github.com/NixOS/nixpkgs/commit/5130c4f4ef66b1cf34d63220bdd1cc8f20de6515) freshBootstrapTools: enable musl on RISC-V
* [`2d8e0c3c`](https://github.com/NixOS/nixpkgs/commit/2d8e0c3c986d9c7339dfde2d98f58d03949c2fb9) git-cola: 4.1.0 -> 4.2.1
* [`955c459a`](https://github.com/NixOS/nixpkgs/commit/955c459af5251f32d2ea91fb1411c644669bb486) glslang: 1.3.243.0 -> 12.1.0
* [`2c8f7f39`](https://github.com/NixOS/nixpkgs/commit/2c8f7f3911ed36fa565b343ab54ade8a2a23825d) spirv-tools: 1.3.243.0 -> 2023.2, remove spirv-headers version check
* [`4faf10e9`](https://github.com/NixOS/nixpkgs/commit/4faf10e97859351984739953fbf52ff498ff384f) python311Packages.dipy: 1.5.0 -> 1.7.0
* [`19ca45e3`](https://github.com/NixOS/nixpkgs/commit/19ca45e39f1dd7ec9f35cf836c7e7a3ff7f18304) vulkan/update-script: always update to latest upstream tags
* [`064bcc58`](https://github.com/NixOS/nixpkgs/commit/064bcc58cd4013825212f558d1e64abfdab9154d) vulkan-tools: 1.3.243 -> 1.3.249, remove vulkan-headers version check
* [`07fd3ec5`](https://github.com/NixOS/nixpkgs/commit/07fd3ec5dfc0c34d4c0c63ee0b20f688250bb698) vulkan-extension-layer: 1.3.243 -> 1.3.248, remove vulkan-headers version check
* [`a7d9cfdc`](https://github.com/NixOS/nixpkgs/commit/a7d9cfdc03810645c2480ed63486a28a03c195ac) vulkan-validation-layers: 1.3.243 -> 1.3.249
* [`040cf878`](https://github.com/NixOS/nixpkgs/commit/040cf878bf099bb7790f600c269bde1566b50d5a) python310Packages.django-import-export: 3.1.0 -> 3.2.0
* [`b54d45dc`](https://github.com/NixOS/nixpkgs/commit/b54d45dca0b09512997d29a84051f9cdb4027d60) python311Packages.dipy: add changelog to meta
* [`9fb69343`](https://github.com/NixOS/nixpkgs/commit/9fb69343d1f53fe9cee86ba139eea072dd1f1a3f) python311Packages.django-model-utils: 4.2.0 -> 4.3.1
* [`a7512939`](https://github.com/NixOS/nixpkgs/commit/a7512939c45238b167a18a8a65ab4dea1c65c39f) python311Packages.django-model-utils: add changelog to meta
* [`1de8d2f1`](https://github.com/NixOS/nixpkgs/commit/1de8d2f180afe1f1eac7548080cbcf8082f4d4fe) chromium: use python3 for build to work towards working cross
* [`14475881`](https://github.com/NixOS/nixpkgs/commit/1447588102afb8c20885f0bbbe768bc1933a863e) pythonPackages.maestral: 1.7.1 -> 1.7.2
* [`6027cc8c`](https://github.com/NixOS/nixpkgs/commit/6027cc8c1c4567d8e6d02c5ac1e4b8ff1193c08d) shell_gpt: 0.8.8 -> 0.9.0
* [`23ae9af6`](https://github.com/NixOS/nixpkgs/commit/23ae9af667a2b6aed396158a466543fcad91cb89) go-chromecast: 0.2.12 -> 0.3.1
* [`b06519dd`](https://github.com/NixOS/nixpkgs/commit/b06519dda9991f78ffb3f5ca1c0bfc04bc273e7f) nrfconnect: 3.11.1 -> 4.0.1
* [`d325bdb8`](https://github.com/NixOS/nixpkgs/commit/d325bdb8c37eb85387aab3b0c026ff76f065e11f) qownnotes: 23.4.7 -> 23.5.0
* [`d28ce724`](https://github.com/NixOS/nixpkgs/commit/d28ce724a6803a4709ca9578a8d1fbab42ba68b1) espeak-ng: fix cross
* [`7fe4909b`](https://github.com/NixOS/nixpkgs/commit/7fe4909bee9864df3d4bc196cb337aebaae32153) services.datadog: remove python2 from systemd service ([nixos/nixpkgs⁠#228312](https://togithub.com/nixos/nixpkgs/issues/228312))
* [`69deb715`](https://github.com/NixOS/nixpkgs/commit/69deb715bbaa056c090812ef78786f4030627d80) kopia: 0.12.1 -> 0.13.0
* [`33d2eac2`](https://github.com/NixOS/nixpkgs/commit/33d2eac2e94297fa8b97a45db64cea350ace2b74) clickhouse: set default logging level to warning
* [`fddf531c`](https://github.com/NixOS/nixpkgs/commit/fddf531c6fa3c769f70a4a0dfc4d886216f0107e) nixos/nextcloud: refactor database.createLocally
* [`4732abcb`](https://github.com/NixOS/nixpkgs/commit/4732abcb38d65f9a0265dadfd54cfe51b21dda73) tracker: 3.5.0 → 3.5.1
* [`64ac2802`](https://github.com/NixOS/nixpkgs/commit/64ac28023200d721f178659aac53e267202fba1e) orchis-theme: fix version number
* [`8ec8cee9`](https://github.com/NixOS/nixpkgs/commit/8ec8cee994590594adea5f300b9e513990be2a87) lightning-loop: 0.20.0 -> 0.23.0
* [`677357e5`](https://github.com/NixOS/nixpkgs/commit/677357e5d048457319fedc18fb897ad27de808de) evcc: 0.116.6 -> 0.116.7
* [`82395e8e`](https://github.com/NixOS/nixpkgs/commit/82395e8e244d1741d1411b159750419a85f2594f) theme-obsidian2: 2.22 -> 2.23
* [`8ae7eef5`](https://github.com/NixOS/nixpkgs/commit/8ae7eef571459df734088cba11958adf6055d49b) python310Packages.pyfume: init at 0.2.25
* [`20c9f17a`](https://github.com/NixOS/nixpkgs/commit/20c9f17a64affcb85a9a2d5e98c2e869b03b3952) youtube-tui: 0.7.0 -> 0.7.1
* [`7ca0c7b4`](https://github.com/NixOS/nixpkgs/commit/7ca0c7b4f7ec40f20486c9b068546602f49b087e) python310Packages.gensim: 4.3.0 -> 4.3.1
* [`2f5f736c`](https://github.com/NixOS/nixpkgs/commit/2f5f736c2cf82f62752b86b5b16344829051dd7b) python310Packages.debugpy: 1.6.6 -> 1.6.7
* [`616ba4ae`](https://github.com/NixOS/nixpkgs/commit/616ba4ae5cad56b00154da4889925eb767b51ce8) nixos/maddy: Add tls option
* [`2ad68a7d`](https://github.com/NixOS/nixpkgs/commit/2ad68a7d90ba08dbdd426cf0d8e4dd1f53d1af1f) stdenv: factor out `meta` attr augmentation for reusability
* [`2b6b08f9`](https://github.com/NixOS/nixpkgs/commit/2b6b08f921a7024b82c644416df0d5dd6d156e70) python310Packages.fuzzytm: init at 2.0.5
* [`a02f9c10`](https://github.com/NixOS/nixpkgs/commit/a02f9c10ea0b42560c7ff8cd017ff19ad946f8c0) trayscale: init at 0.9.6
* [`906025e4`](https://github.com/NixOS/nixpkgs/commit/906025e445ee67878cd69896c4e0275dc92af2ed) fishPlugins.github-copilot-cli-fish: init at 0.1.33
* [`c5eb25a2`](https://github.com/NixOS/nixpkgs/commit/c5eb25a2bbc76136881d34c9df4d92c7af384c92) rbdoom-3-bfg: 1.4.0 -> 1.5.0
* [`9013eeea`](https://github.com/NixOS/nixpkgs/commit/9013eeea6328a7b97a8122842a7694179241c1af) zigbee2mqtt: 1.30.3 -> 1.30.4
* [`ec38c9c7`](https://github.com/NixOS/nixpkgs/commit/ec38c9c76bbeda6fd6cf718f310fb12869c78108) grafana-agent: 0.33.0 -> 0.33.1
* [`cbcafdc1`](https://github.com/NixOS/nixpkgs/commit/cbcafdc13b3ae14847b305b8af64f25b65f9ca19) grafana-agent: add version test
* [`fe3c7bc1`](https://github.com/NixOS/nixpkgs/commit/fe3c7bc17e95a5ab86fe2a2c126335aebfe3e11f) python310Packages.channels-redis: 4.0.0 -> 4.1.0
* [`7931cb36`](https://github.com/NixOS/nixpkgs/commit/7931cb3647b42c04aeef1dd4b91217a311936d7f) python310Packages.channels-redis: add changelog to meta
* [`d309952a`](https://github.com/NixOS/nixpkgs/commit/d309952a5ddc3a97b7d126463281f63c3bb74505) nixos/mediawiki: make apache optional
* [`077e950f`](https://github.com/NixOS/nixpkgs/commit/077e950f7a6b6b52f49ec8ad6f1e4403d568711c) nixos/mediawiki: also test fcgi socket
* [`5564cf7e`](https://github.com/NixOS/nixpkgs/commit/5564cf7e32d4f617d8e5533f9adab6294e694b2b) wpsoffice: 11.1.0.11691 -> 11.1.0.11698
* [`fe2bd7e2`](https://github.com/NixOS/nixpkgs/commit/fe2bd7e2a2c6526f912c054c549ff1fb000623f0) networkmanager-l2tp: 1.20.4 -> 1.20.10 ([nixos/nixpkgs⁠#229312](https://togithub.com/nixos/nixpkgs/issues/229312))
* [`ed64acf4`](https://github.com/NixOS/nixpkgs/commit/ed64acf42d2e4fa4257a92cd792828bac9c80276) networkmanager-sstp: 1.3.1 -> unstable-2023-03-09
* [`856a549b`](https://github.com/NixOS/nixpkgs/commit/856a549bae7ffc959070028672b12fd4df6f1f69) checkov: 2.3.209 -> 2.3.212
* [`1c3c2c82`](https://github.com/NixOS/nixpkgs/commit/1c3c2c820321a411a3a71006de8c17a7255442d6) nixos/navidrome: add package option
* [`7b3d0a5e`](https://github.com/NixOS/nixpkgs/commit/7b3d0a5e74c4da8fa6f5765f6c95787081e78181) python311Packages.datasets: 2.11.0 -> 2.12.0
* [`4ee45a31`](https://github.com/NixOS/nixpkgs/commit/4ee45a31931f91587c0d955c392e8ca4f73318e6) python310Packages.datasette: 0.64.2 -> 0.64.3
* [`6f44a063`](https://github.com/NixOS/nixpkgs/commit/6f44a0632a991775ee098e9a54d95b13cbd2115c) python310Packages.invocations: 3.0.1 -> 3.0.2
* [`216ce975`](https://github.com/NixOS/nixpkgs/commit/216ce975ba58d4eab2e879280c78e8ee16d180fc) python310Packages.glean-sdk: 52.2.0 -> 52.6.0
* [`75fea21c`](https://github.com/NixOS/nixpkgs/commit/75fea21c44ed23ad363abc92004ef3ada16332f9) python311Packages.datafusion: 22.0.0 -> 23.0.0
* [`611d0883`](https://github.com/NixOS/nixpkgs/commit/611d0883038957b66a26bf4f8d96666f5db9d346) python310Packages.intake: 0.6.6 -> 0.6.8
* [`6dc70934`](https://github.com/NixOS/nixpkgs/commit/6dc70934843dc99cace63d0ab69e23fe86a172ca) arrow-cpp: 11.0.0 -> 12.0.0
* [`01d15621`](https://github.com/NixOS/nixpkgs/commit/01d15621fe60f6dcb66145011871847fccae43c2) python311Packages.datafusion: add changelog to meta
* [`c87e3dc9`](https://github.com/NixOS/nixpkgs/commit/c87e3dc91580e28224111d9275f0d7040181876e) python310Packages.invocations: add changelog to meta
* [`e07db3e3`](https://github.com/NixOS/nixpkgs/commit/e07db3e3795205a024905685450630a27315c08d) python310Packages.inform: 1.27 -> 1.28
* [`92fa862d`](https://github.com/NixOS/nixpkgs/commit/92fa862d74e8991b0c43a719c7508c991f188f33) python310Packages.inform: add changelog to meta
* [`6592c272`](https://github.com/NixOS/nixpkgs/commit/6592c2723fa9e12cb9e71268320cf1294ebe9888) python310Packages.inquirer: 3.1.2 -> 3.1.3
* [`965ca258`](https://github.com/NixOS/nixpkgs/commit/965ca25828ff1e88370ecf99fb8a4814e753d88a) python310Packages.kornia: 0.6.11 -> 0.6.12
* [`b3d0ead7`](https://github.com/NixOS/nixpkgs/commit/b3d0ead70e5e4531e668d69b443e43454dd10466) python310Packages.kornia: add changelog to meta
* [`9e4b3ac3`](https://github.com/NixOS/nixpkgs/commit/9e4b3ac34d6d41026ce703b05e5955e730f37938) python3Packages.desktop-notifier: 3.4.3 -> 3.5.1
* [`57cc5abf`](https://github.com/NixOS/nixpkgs/commit/57cc5abf4afb093055e06089b89e0e8b14107963) python310Packages.jupyter-ui-poll: init at 0.2.2
* [`0fd3f232`](https://github.com/NixOS/nixpkgs/commit/0fd3f2326368b2f5e40ad1203bf929db011c59ee) python310Packages.ipyniivue: init at 1.0.2
* [`f27f5ca6`](https://github.com/NixOS/nixpkgs/commit/f27f5ca67bd1604e154035b01313fe184bee539f) chromium: set `TERM=dumb` for `ninja`
* [`b5a89ae9`](https://github.com/NixOS/nixpkgs/commit/b5a89ae93a19c1f1fcb4aaede17c0466d7c00e8b) chromium: do not skip {pre,post}Build
* [`db3e78b8`](https://github.com/NixOS/nixpkgs/commit/db3e78b8d3c0c6c8d5da77250c0675d95f4a9a1a) rust-script: 0.26.0 -> 0.27.0
* [`0b9dd4a1`](https://github.com/NixOS/nixpkgs/commit/0b9dd4a1b646fa9906885dd39da12ecf4c358768) python310Packages.chalice: 1.27.3 -> 1.28.0
* [`e12ac412`](https://github.com/NixOS/nixpkgs/commit/e12ac412791391793d7c69fcb3575efbfce8da4d) system76-scheduler: init at 2.0.1
* [`b7956895`](https://github.com/NixOS/nixpkgs/commit/b7956895ee73310cb88dc059a72d52ccde386854) python310Packages.pytest-emoji: init at 0.2.0
* [`bbdaf29a`](https://github.com/NixOS/nixpkgs/commit/bbdaf29ab4283b4dc16840d59414e8fe36b71949) tensorflow-lite: mark with knownVulnerabilities
* [`dfb0349a`](https://github.com/NixOS/nixpkgs/commit/dfb0349a78fc60be082db19aa885167d8f8e234b) python310Packages.strawberry-graphql: 0.159.0 -> 0.176.0
* [`e9766716`](https://github.com/NixOS/nixpkgs/commit/e97667163ea4b9e17f2341c08c066ff47ce3722a) verilog: 11.0 -> 12.0
* [`f655e01c`](https://github.com/NixOS/nixpkgs/commit/f655e01c7c0e9519c82c455ae675d3e2d82db9aa) cxx-rs: 1.0.86 -> 1.0.94
* [`052341df`](https://github.com/NixOS/nixpkgs/commit/052341df029a36590dcb3d208d8b2073bf9f9ba5) python310Packages.sipyco: init at version 1.4 ([nixos/nixpkgs⁠#227876](https://togithub.com/nixos/nixpkgs/issues/227876))
* [`b017e297`](https://github.com/NixOS/nixpkgs/commit/b017e29705ff6bf879bd4c56c04ae4f1123272ef) stdenv: always update config script on loongarch64-linux
* [`70ae8a5d`](https://github.com/NixOS/nixpkgs/commit/70ae8a5df99d4ade4c2b43980912059a0e680318) arianna: 1.0.0 -> 1.0.1
* [`02aec068`](https://github.com/NixOS/nixpkgs/commit/02aec0681bf9e37812074235bc58dd0b525be65d) vimPlugins: update
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
