### PR TITLE
niv devenv: update c388b8c5 -> c9089634

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c388b8c57116a71174d26b09c0c38b4b6b5bac3a",
-        "sha256": "0qyyc7pfl4kh77daqqpq7762hzwlpvgkwyizz5x4b76hmv4gll9h",
+        "rev": "c90896345449b92d8f503cf8c2a339088bec0ddc",
+        "sha256": "00qx6nwqam0dykzwlxz2w70nim7likprnfp1795bq48yyhh7s8m4",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/c388b8c57116a71174d26b09c0c38b4b6b5bac3a.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/c90896345449b92d8f503cf8c2a339088bec0ddc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@c388b8c5...c9089634](https://github.com/cachix/devenv/compare/c388b8c57116a71174d26b09c0c38b4b6b5bac3a...c90896345449b92d8f503cf8c2a339088bec0ddc)

* [`0f553e32`](https://github.com/cachix/devenv/commit/0f553e3293f12ca93672a6f2726bed3b88e3ec1e) feat: add HashiCorp Vault service
* [`c0b0db7b`](https://github.com/cachix/devenv/commit/c0b0db7b5b3df14f04679a870bab2f4223a67749) feat(vault): Unseal the vault automatically if it is sealed on startup
* [`c2519e12`](https://github.com/cachix/devenv/commit/c2519e12398cbbb353d8bffd30f7870d9feb5b65) feat(vault): Add basic test to vault example to assert that the vault server has started
* [`3e7daec9`](https://github.com/cachix/devenv/commit/3e7daec9cd36ee056fcd63bf240fceb89f219550) feat(vault): Fix vault example test
* [`d5e7d6a8`](https://github.com/cachix/devenv/commit/d5e7d6a874eb528c95b0aed60d21f63a0d279846) feat(vault): Disable mlock by default on all platforms
* [`65fe1f73`](https://github.com/cachix/devenv/commit/65fe1f73f401bad774a7296fa538a19b12a02d5a) Auto generate docs/reference/options.md
* [`dc81d327`](https://github.com/cachix/devenv/commit/dc81d327c947640155c55f348a32912c0633c3d9) Pre-commit hooks proofread
* [`10dbfda8`](https://github.com/cachix/devenv/commit/10dbfda8d1e105598ada8fe405d7df2667141ee2) feat(vault): Add better debugging to test script and allow more time for service startup
* [`a76273bf`](https://github.com/cachix/devenv/commit/a76273bfceaeec145756eede905e6715207c36dc) Common patterns language edit
* [`ecca323e`](https://github.com/cachix/devenv/commit/ecca323e32b8186d37d68e17ba79d9db69ad6ad0) Automatic shell activation proofread
* [`7ad5b177`](https://github.com/cachix/devenv/commit/7ad5b177ce4d759eb77a3d52eb14888a954f22ae) Auto generate docs/reference/options.md
* [`af42cb79`](https://github.com/cachix/devenv/commit/af42cb79bafa88d34b42540d2792e3615efa2203) Auto generate docs/reference/options.md
* [`4c3c3486`](https://github.com/cachix/devenv/commit/4c3c34864af90535dfb148e5b4f25f56fe50f2f1) Using with flake.parts language edit
* [`e86edd1e`](https://github.com/cachix/devenv/commit/e86edd1e622af21399cb7e2787eb39ebf45d9af7) Keep entrypoint when overriding cmd
* [`c9630435`](https://github.com/cachix/devenv/commit/c9630435eeea11a833026385eec4d1ed9524be7c) feat: add Pascal/Object Pascal language support
* [`c62ffeb1`](https://github.com/cachix/devenv/commit/c62ffeb15423dd6fe81e10a93b83f9b4dcc4572a) fix(pascal): fix lazarus option
* [`1c47c099`](https://github.com/cachix/devenv/commit/1c47c099a23413619e9e1c7a53cdb3382d5b3026) examples: python-poetry: test using python packages from nixpkgs
* [`c5cc52bd`](https://github.com/cachix/devenv/commit/c5cc52bd6e121e9fb040d33776d1157ee99b35cd) python: append value of DEVENV_PROFILE to PYTHONPATH
* [`a908c8bb`](https://github.com/cachix/devenv/commit/a908c8bb7d21f97e1aff3489307087fa68913e5d) Auto generate docs/reference/options.md
* [`af6810ab`](https://github.com/cachix/devenv/commit/af6810ab0f233779d122073e3f8ebfc6c27e78e2) Update pre-commit-hooks input
* [`eca49ebf`](https://github.com/cachix/devenv/commit/eca49ebfb983f5c70282a44e6cffb5ae44d4f95f) Correct using-with-flake-parts.md  .envrc content for direnv
* [`c4006ccb`](https://github.com/cachix/devenv/commit/c4006ccba1b3e4533de462cee5933e0ccf5f1d6a) Auto generate docs/reference/options.md
* [`1059d6fa`](https://github.com/cachix/devenv/commit/1059d6fa0e787b5f92987ca251d82c207115114d) feat: lock deno to project scope
