### PR TITLE
niv powerlevel10k: update dff735c2 -> 0a9eb73e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "dff735c26173183dc44864ae5d9aa4c1d74fe150",
-        "sha256": "0nwrsrbf7hghx5x82zskw7hslliyizk8fza7spqds8xsdbp0rdpm",
+        "rev": "0a9eb73e161fd4d73140bd90c00c52602cf9aa42",
+        "sha256": "12x01yll48vkckka5j3d584kxczrvrbnlzmsz0zxbfq0zzbwx2pg",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/dff735c26173183dc44864ae5d9aa4c1d74fe150.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/0a9eb73e161fd4d73140bd90c00c52602cf9aa42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@dff735c2...0a9eb73e](https://github.com/romkatv/powerlevel10k/compare/dff735c26173183dc44864ae5d9aa4c1d74fe150...0a9eb73e161fd4d73140bd90c00c52602cf9aa42)

* [`ce0bee97`](https://github.com/romkatv/powerlevel10k/commit/ce0bee979bec1b63d2d2005d96253bbe87fe2a72) wizard: check for unicode 9 support before asking about U+F0737
* [`0af598cb`](https://github.com/romkatv/powerlevel10k/commit/0af598cbed78660066f8a8f4465844501ba5695b) wizard: add a screen for detecting faulty terminals that render glyphs such as U+F0001 as wide (e.g., Windows Terminal)
* [`5d16c106`](https://github.com/romkatv/powerlevel10k/commit/5d16c106ed2807fb368dcac4df0e2b3dd619bb8d) nvm: implement POWERLEVEL9K_NVM_SHOW_SYSTEM and default to true
* [`4ed8aae3`](https://github.com/romkatv/powerlevel10k/commit/4ed8aae3246da5c8f16978266ba6af139a1d06ca) nvm: implement POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW and default to false
* [`016512f4`](https://github.com/romkatv/powerlevel10k/commit/016512f493c52d2b32d4ade4fbd4638617a8cf83) nvm: change the default value of POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW to true and fix the way it is used ([romkatv/powerlevel10k⁠#2296](https://togithub.com/romkatv/powerlevel10k/issues/2296))
* [`0a9eb73e`](https://github.com/romkatv/powerlevel10k/commit/0a9eb73e161fd4d73140bd90c00c52602cf9aa42) nvm: change the default value of POWERLEVEL9K_NVM_PROMPT_ALWAYS_SHOW back to false ([romkatv/powerlevel10k⁠#2296](https://togithub.com/romkatv/powerlevel10k/issues/2296))
