### PR TITLE
niv nixpkgs: update 055a2f47 -> 118e0e7e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "055a2f470bced98bb34a5d94b775c410e1594cc2",
-        "sha256": "1x932hnirdk9vmfwdnk73rahmy8hsm6g2zkmxpyw108gca3788jm",
+        "rev": "118e0e7e93ce6211f2f1203b6f20363b19dad335",
+        "sha256": "0bd87b6p3kgfjq25rdsbcrc5ky6abbrbf45lkf0c77kflsyc63bx",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/055a2f470bced98bb34a5d94b775c410e1594cc2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/118e0e7e93ce6211f2f1203b6f20363b19dad335.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@055a2f47...118e0e7e](https://github.com/nixos/nixpkgs/compare/055a2f470bced98bb34a5d94b775c410e1594cc2...118e0e7e93ce6211f2f1203b6f20363b19dad335)

* [`060f0dd4`](https://github.com/NixOS/nixpkgs/commit/060f0dd496b10c5516de48977f268505a51ab116) nixos/alertmanager: add checkConfig option
* [`fa60722e`](https://github.com/NixOS/nixpkgs/commit/fa60722e9677065b9f5de64d8dd2049a85692085) webdav-server-rs: Add debug option
* [`4e899b3a`](https://github.com/NixOS/nixpkgs/commit/4e899b3a9407a0767fb349a8adb139ec9806d831) scorecard: add 'version' test
* [`41e97e2b`](https://github.com/NixOS/nixpkgs/commit/41e97e2b78a0aec99e9c1af2dd1ff317ceab7885) cyanrip: 0.8.1 -> 0.9.0
* [`a74c704b`](https://github.com/NixOS/nixpkgs/commit/a74c704b706f0916cdff88c9dbbd1559b2282742) ldc: 1.30.0 -> 1.31.0, bump bootstrap ldc to 1.30.0, bump LLVM to 14
* [`2df04eae`](https://github.com/NixOS/nixpkgs/commit/2df04eae4dfa9664a2af9898c6978ced5dd1d5a2) matrix-synapse.plugins.matrix-synapse-ldap3: add patch to read password from file, adopt into c3d2 team
* [`862d0ffd`](https://github.com/NixOS/nixpkgs/commit/862d0ffd8408ead760d37aa1c839c1ccf2effe28) pixelfed: init at 0.11.5
* [`7cfcfdc4`](https://github.com/NixOS/nixpkgs/commit/7cfcfdc4d4feafdf816862a6ae31eb5be6163406) copy-tarballs.pl: fix DEBUG mode
* [`c60fc240`](https://github.com/NixOS/nixpkgs/commit/c60fc2406ac3844ec924c95652da3ba604c6feed) Working on update to cling 0.9
* [`838dae41`](https://github.com/NixOS/nixpkgs/commit/838dae41887ef044a93655830d7b563e3acc391b) First clang patch
* [`34058417`](https://github.com/NixOS/nixpkgs/commit/3405841706c4c5c41f35d3fa3a1c5cac42c9ee7b) Bringing over more patches
* [`d395cc96`](https://github.com/NixOS/nixpkgs/commit/d395cc96341901d8be4c3d5a3627e44536198a4f) Tweaking LLVM patch
* [`d7b1cb48`](https://github.com/NixOS/nixpkgs/commit/d7b1cb48aa8d150f9954a9cce99e95a799b8fd4c) More on cling patch
* [`167f5fba`](https://github.com/NixOS/nixpkgs/commit/167f5fba6feffd5025ea3917f99ea795ed3aac2b) stc: init at 1.4
* [`30767056`](https://github.com/NixOS/nixpkgs/commit/30767056805d785f7e9f30856d6e618d48f46866) syncthing-cli: rename the package
* [`8fd7b69d`](https://github.com/NixOS/nixpkgs/commit/8fd7b69da1b32bce2a60557154792f2fd72b0522) copy-tarballs: use all the urls of each file
* [`1f4212d7`](https://github.com/NixOS/nixpkgs/commit/1f4212d792f0844d5109f879286ea5afbda02c10) python310Packages.pytz: 2023.2 -> 2023.3
* [`5068ff7d`](https://github.com/NixOS/nixpkgs/commit/5068ff7d86760c5df055fa92a24b106995d02040) c0: init at unstable-2022-10-25
* [`d77f11a7`](https://github.com/NixOS/nixpkgs/commit/d77f11a719f78a8ab6dd000a640c5cad79d189a5) Able to build cling 0.9
* [`fddb69ff`](https://github.com/NixOS/nixpkgs/commit/fddb69ff3d910a61e091ea8681e509228a29825d) Remove notes and fix clang include in flags
* [`c7f579c8`](https://github.com/NixOS/nixpkgs/commit/c7f579c80e60d86618b77078ea45f0c57e041a58) wch-isp: init at 0.2.4
* [`5b3534dd`](https://github.com/NixOS/nixpkgs/commit/5b3534dd2e437395f2d4ea5fece149316aadd709) neovim-unwrapped: apply patch to fix the `#gsub!` directive
* [`978e32e8`](https://github.com/NixOS/nixpkgs/commit/978e32e8b56dec34d26fc13d828e21c6c8fc61f8) Take only the include dir from llvmPackages_9.llvm.dev
* [`cfb12933`](https://github.com/NixOS/nixpkgs/commit/cfb1293342612966c12a4ed5928ef0005fa0e013) Patch cling/tools/driver/CMakeLists.txt, it works now!
* [`fe00f3f4`](https://github.com/NixOS/nixpkgs/commit/fe00f3f4620b28297667403fe7e11ea9c56138cb) Force installation of ClingTargets.cmake
* [`65d801bf`](https://github.com/NixOS/nixpkgs/commit/65d801bfefd32e1a77967f7f37f66adee1498d76) gotools: don't build getgo
* [`616c81c6`](https://github.com/NixOS/nixpkgs/commit/616c81c641b1660f23536275b8b23d2e3af37f31) Include the Jupyter kernel in $out/share/jupyter
* [`040f19b5`](https://github.com/NixOS/nixpkgs/commit/040f19b5cd7c5e45f481a6ca2af09d4346028723) opencl-headers: 2023.02.06 -> 2023.04.17
* [`bccc7293`](https://github.com/NixOS/nixpkgs/commit/bccc72930ffc04edc27788a1c8c7cd5d9bfc9caa) spotifyd: 0.3.4 -> 0.3.5
* [`729d2eea`](https://github.com/NixOS/nixpkgs/commit/729d2eea291e74fab6e50d3ae95d4396f7784e28) mindustry-wayland: set SDL environment variables
* [`51c5aae8`](https://github.com/NixOS/nixpkgs/commit/51c5aae874bb78de29e8deb309147a1f026d818c) nixos/pixelfed: init module
* [`f341151c`](https://github.com/NixOS/nixpkgs/commit/f341151cfa872ff8d80d3c00e090380920cda8c5) nixos/tests/pixelfed: init test
* [`9795cee2`](https://github.com/NixOS/nixpkgs/commit/9795cee2e6798d5ae0f534804012d200ef66029a) klipperscreen: init at 0.3.2
* [`077588ad`](https://github.com/NixOS/nixpkgs/commit/077588ad1a1449554603c226abe1de824923cc38) androidenv: put a much nicer error message that includes the available options
* [`72fe314d`](https://github.com/NixOS/nixpkgs/commit/72fe314d9e25f3e288c5eae65b92838420cfad36) python310Packages.espeak-phonemizer: 1.2.0 -> 1.3.0
* [`95009b6a`](https://github.com/NixOS/nixpkgs/commit/95009b6a04b154bffff6820cca4ac371a70b4286) python310Packages.poetry-plugin-export: 1.3.0 -> 1.3.1
* [`70014459`](https://github.com/NixOS/nixpkgs/commit/70014459098d0aab86a13287738389dbd36d9939) lib/systems: add mips64[el] entries to qemuArch
* [`ab36cfe8`](https://github.com/NixOS/nixpkgs/commit/ab36cfe8caab180b9d25eea740f79ea91b17d672) get_iplayer: 3.27 -> 3.31
* [`4147b878`](https://github.com/NixOS/nixpkgs/commit/4147b878bcdd6fc8e8b6395215c71a0ebd0b23c1) nixos-test-driver: include a timeout for the recv call, do not assume sh == bash
* [`c346a8c0`](https://github.com/NixOS/nixpkgs/commit/c346a8c0d51fff13d8690efd3431237d936b4c5f) obs-studio-plugins.advanced-scene-switcher: 1.20.5 -> 1.21.1
* [`69fbab6f`](https://github.com/NixOS/nixpkgs/commit/69fbab6f199eb4cf4ced6014d6f2cce52183ae4a) pkgs/top-level/release-cross.nix: comment explaining how to build all bootstrapFiles
* [`2bb0f80d`](https://github.com/NixOS/nixpkgs/commit/2bb0f80dad467d0b2460c26a5b812506034a954e) gtest: 1.12.1 -> 1.13.0
* [`293b0f4b`](https://github.com/NixOS/nixpkgs/commit/293b0f4b1c8efb99f49fe26ae6af4f75bb81b8fc) libcap: 2.67 -> 2.68
* [`f3db2f8c`](https://github.com/NixOS/nixpkgs/commit/f3db2f8c81e08737eef11aa1636f3e8349b5c934) python3Packages.nbdime: 3.1.1 -> 3.2.0, unmark broken
* [`796121dc`](https://github.com/NixOS/nixpkgs/commit/796121dc9bcdf7ec98b4d4e5a383b5bae486b75e) tt-rss: unstable-2022-10-15 -> unstable-2023-04-13, module use PHP 8.1
* [`47f761bd`](https://github.com/NixOS/nixpkgs/commit/47f761bd92d2a32d1700245fd4e2ceedbf6249b8) osv-scanner: 1.3.1 -> 1.3.2
* [`293ca686`](https://github.com/NixOS/nixpkgs/commit/293ca686108c85dc0b2e78f661e32593db595088) yubikey-manager: 5.0.1 -> 5.1.1
* [`24493411`](https://github.com/NixOS/nixpkgs/commit/244934112c73ef9ba020ad305785571693730e93) latte-dock: fix dependencies
* [`62681989`](https://github.com/NixOS/nixpkgs/commit/626819899dd035b9c5b43d1208a2735765112253) harfbuzz: 7.1.0 -> 7.2.0
* [`743c4833`](https://github.com/NixOS/nixpkgs/commit/743c4833d4c0f7ce947814673cace7d9df99e8ce) resumed: init at 3.0.1
* [`352e17b8`](https://github.com/NixOS/nixpkgs/commit/352e17b8d080269e6be2e607581df499acf649b2) iproute2: 6.2.0 -> 6.3.0
* [`34872850`](https://github.com/NixOS/nixpkgs/commit/348728504792ade9ce89b20284a1b6dd12ca5d43) haskellPackages: stackage LTS 20.18 -> LTS 20.19
* [`1918689f`](https://github.com/NixOS/nixpkgs/commit/1918689f6bd96b740f55fd16c39fe9d1a20005f4) all-cabal-hashes: 2023-04-22T18:19:29Z -> 2023-04-29T17:51:14Z
* [`d313e055`](https://github.com/NixOS/nixpkgs/commit/d313e055d74750b8ff3ce361374a9b1b14a68dea) haskellPackages: regenerate package set based on current config
* [`346bb477`](https://github.com/NixOS/nixpkgs/commit/346bb477bf92bf6ec8eac1790bf2693917b2d1e6) haskellPackages.hspec*_2_11_0: update references to be hspec*_2_11_0_1
* [`de9cb16e`](https://github.com/NixOS/nixpkgs/commit/de9cb16e77745c80cb05e8a816e0fef92109f8b2) python310Packages.beautifulsoup4: 4.11.2 -> 4.12.2
* [`d0f13efc`](https://github.com/NixOS/nixpkgs/commit/d0f13efc061536af2ea1bf95c369d825def789ec) python310Packages.responses: 0.22.0 -> 0.23.1
* [`ce0a2d2b`](https://github.com/NixOS/nixpkgs/commit/ce0a2d2b85103dc6000d52d76939832c26aec2f2) nixos/no-x-libs: disable wayland for mpv
* [`9248e007`](https://github.com/NixOS/nixpkgs/commit/9248e0074c54c22ea4a6765bba379a67e4df6c26) mpv: make vaapi support depending on x11/wayland
* [`4a7ab822`](https://github.com/NixOS/nixpkgs/commit/4a7ab822a6dbe90b2c08f662dcad7dc607ad718f) icu73: init at 73.1
* [`e89be818`](https://github.com/NixOS/nixpkgs/commit/e89be8188504a19de9f3256981cf6c6363ec8939) icu: 72.1 -> 73.1
* [`eb811a6e`](https://github.com/NixOS/nixpkgs/commit/eb811a6ee0ca939df84a8f87934a06065eb15cae) nix-info: fix nix-info --help to exit 0
* [`1a8bd1ba`](https://github.com/NixOS/nixpkgs/commit/1a8bd1ba8a2d5d156c1f5efb01f396f76ba4334c) python310Packages.mpd2: 3.0.5 -> 3.1.0
* [`042e5ad6`](https://github.com/NixOS/nixpkgs/commit/042e5ad6de1df897402446ab43902b4fa7fddca2) python310Packages.chacha20poly1305-reuseable: 0.2.2 -> 0.2.5
* [`1cfb18d7`](https://github.com/NixOS/nixpkgs/commit/1cfb18d793baea004abee9f65e813346dacbe0ca) maintainers/scripts/haskell/merge-and-open-pr.sh: Pass --fast to regeneration script
* [`be99ff0d`](https://github.com/NixOS/nixpkgs/commit/be99ff0da4648a7683d3490e11ac8a5a5545df4e) haskellPackages.scalendar: Fix eval
* [`1737266d`](https://github.com/NixOS/nixpkgs/commit/1737266d2b983646be29e186d940b032166f6223) haskellPackages.comfort-fftw: Drop obsolete override
* [`05e9a223`](https://github.com/NixOS/nixpkgs/commit/05e9a22322e6570a6650d1bf0e135d727780e206) maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh: Make more robust against eval errors
* [`f45d05f4`](https://github.com/NixOS/nixpkgs/commit/f45d05f42d35868954093da4998bb01ca826f841) haskellPackages: Revert wrongly trimmed transitive-broken.yaml
* [`bb28ce2e`](https://github.com/NixOS/nixpkgs/commit/bb28ce2edac595f6c12b4610b31831f4a67fd8ea) maintainers: add jurraca
* [`2222808e`](https://github.com/NixOS/nixpkgs/commit/2222808e838289613600b35d8f037e34f6ee7353) libimagequant: 4.1.1 -> 4.2.0
* [`3455cf2a`](https://github.com/NixOS/nixpkgs/commit/3455cf2a7221ebd1987cb325f30669bed4d183aa) harfbuzz: add changelog to meta
* [`66edbd22`](https://github.com/NixOS/nixpkgs/commit/66edbd22eac73303dbf03670fe962840c0b8f5a7) python3Packages.mautrix: 0.19.12 -> 0.19.13
* [`67c9083d`](https://github.com/NixOS/nixpkgs/commit/67c9083d2872a649592e8d9ad58c1d05013bcfc3) python3Packages.mdutils: 1.5.1 -> 1.6.0
* [`8b5b0ca9`](https://github.com/NixOS/nixpkgs/commit/8b5b0ca9ffe7be40994943395383691d5e8f4d60) zmusic: 1.1.11 -> 1.1.12
* [`616e0ecb`](https://github.com/NixOS/nixpkgs/commit/616e0ecbb756931df80684060def0f476d7adfa8) haskellPackages.guardian: Fix eval error
* [`a5c7cc63`](https://github.com/NixOS/nixpkgs/commit/a5c7cc63d12a043a2b76dde790ac78bc7454fb81) libosmo-abis: init at 1.4.0
* [`44de9e24`](https://github.com/NixOS/nixpkgs/commit/44de9e2412a68815754a4d8598f48ae60f815437) libosmo-netif: init at 1.3.0
* [`4fa350d5`](https://github.com/NixOS/nixpkgs/commit/4fa350d506908f8add9c8c55e808cfdb3915649f) libosmo-sccp: init at 1.7.0
* [`1b8e6908`](https://github.com/NixOS/nixpkgs/commit/1b8e6908243d1fdb8c9118b8db123ccdb6457d5b) trusting-trust.stage0-posix: init at unstable-2023-04-16
* [`ba4a163e`](https://github.com/NixOS/nixpkgs/commit/ba4a163e61f9466e1d6c505c0a2a3abc7de6375d) trusting-trust.mes: init at 0.24.2
* [`ccafb8b1`](https://github.com/NixOS/nixpkgs/commit/ccafb8b110fb503aeaa9fb2f5d132bb5c009b8b4) trusting-trust.tinycc-with-mes-libc: init at unstable-2023-04-20
* [`d0594d2f`](https://github.com/NixOS/nixpkgs/commit/d0594d2f4230dcd59182245e15ad7c35fae6ee41) minimal-bootstrap: rename from trusting-trust
* [`b390cba8`](https://github.com/NixOS/nixpkgs/commit/b390cba84b25d42a9b27943abe799551df0eddb3) minimal-bootstrap.stage0-posix: replace runBareCommand with raw derivation
* [`c8ecd8ed`](https://github.com/NixOS/nixpkgs/commit/c8ecd8ed5778bf57a1044a0dfbb7254e790e3a74) minimal-bootstrap.stage0-posix: replace mkKaemDerivation with runCommand
* [`71dcd605`](https://github.com/NixOS/nixpkgs/commit/71dcd605578fd936ed147e7ca212954360add766) minimal-bootstrap: remove most uses of builtins.fetchTarball
* [`ba346eb8`](https://github.com/NixOS/nixpkgs/commit/ba346eb8acd5fdb483180091cc9353ab74a7c4f7) minimal-bootstrap.stage0-posix: remove builtins.fetchTarball
* [`5d423c3a`](https://github.com/NixOS/nixpkgs/commit/5d423c3ac081651d4c8fc57667b08dd0b47eee80) minimal-bootstrap: add source attribution
* [`dc11b48d`](https://github.com/NixOS/nixpkgs/commit/dc11b48d10e9fc012820359f79e1cf4305874efd) minimal-bootstrap.tinycc: refactor mes-libc into separate file
* [`59e11ad4`](https://github.com/NixOS/nixpkgs/commit/59e11ad4e4c4f825cf5080dc30d30d7e185cda81) minimal-bootstrap: add meta attributes
* [`60ebcafd`](https://github.com/NixOS/nixpkgs/commit/60ebcafd4768bbe77f162d5c17ec35569be405e5) minimal-bootstrap.stage0-posix: remove mkKaemDerivation0 abstration
* [`773cadd5`](https://github.com/NixOS/nixpkgs/commit/773cadd5e71d7776d5f17daa2a9975ee6ebf5587) minimal-bootstrap.kaem: move definition
* [`8ea19fbc`](https://github.com/NixOS/nixpkgs/commit/8ea19fbc18d07975bd3bb13de8abf5e1fbe279de) minimal-bootstrap: inherit system from hostPlatform
* [`8ef86405`](https://github.com/NixOS/nixpkgs/commit/8ef86405b6b213fdf2ddcc3afe4fff1128eebd7c) minimal-bootstrap.writeTextFile: remove extra derivations
* [`8950041e`](https://github.com/NixOS/nixpkgs/commit/8950041e2ba85960594a82b67b6cfb15c3a3a500) minimal-bootstrap.mes: inline config.h
* [`d59fb08f`](https://github.com/NixOS/nixpkgs/commit/d59fb08f647a80dd58c103f7870ecc2e0acefae6) minimal-bootstrap: makeDerivationWithMeta supports passthru
* [`760ab354`](https://github.com/NixOS/nixpkgs/commit/760ab354879a78636074e1940f9a18fe18278592) minimal-bootstrap.nyacc: init at 1.00.2, split from mes
* [`a4caff6e`](https://github.com/NixOS/nixpkgs/commit/a4caff6ea407bf21a8b4e921ad6af736e1f9577e) minimal-bootstrap: remove confusing fetchtarball abstraction
* [`7ed2e9a6`](https://github.com/NixOS/nixpkgs/commit/7ed2e9a660ac450cc990343f4f9e9eebc2d55743) minimal-bootstrap: be more explicit when declaring "system"
* [`ae7bbb0e`](https://github.com/NixOS/nixpkgs/commit/ae7bbb0e4d78d59db19eb13ae13994fe776d0e45) minimal-bootstrap.mes: major rewrite for readability
* [`0cbdbdc2`](https://github.com/NixOS/nixpkgs/commit/0cbdbdc20db1dcb8fe34e2ef8cb7df136b525f0b) minimal-bootstrap.mescc-tools: formatting
* [`e055a75e`](https://github.com/NixOS/nixpkgs/commit/e055a75edd41976b2a20621a04fd993df06bc54e) minimal-bootstrap.ln-boot: init at unstable-2023-05-01
* [`1b065103`](https://github.com/NixOS/nixpkgs/commit/1b065103f5e68b54f52b8e7344efdc01b9393859) minimal-bootstrap.mes: split out mes-libc package
* [`f519f097`](https://github.com/NixOS/nixpkgs/commit/f519f097e4d733de994ee09c4bba80b55b9321af) minimal-libc.tinycc-mes: refactor into common.nix
* [`ebbc6ea8`](https://github.com/NixOS/nixpkgs/commit/ebbc6ea8b3053d7f72b3bf5f1f1c431cffc6ca87) minimal-bootstrap.stage0-posix: assert hex0 result
* [`f08154ac`](https://github.com/NixOS/nixpkgs/commit/f08154ac04ea224299188a0b5dcb016d3fba2515) minimal-bootrap: init make-bootstrap-sources.nix
* [`c0566f82`](https://github.com/NixOS/nixpkgs/commit/c0566f82e5048aa00c54e99944c7b8ef4b38fd8a) minimal-bootstrap: rebase onto master
* [`c2fd974d`](https://github.com/NixOS/nixpkgs/commit/c2fd974d5b284bc2f0e5d815eb0c80a0d8490b2c) minimal-bootstrap.stage0-posix: highlight hex0-seed
* [`5f4f945c`](https://github.com/NixOS/nixpkgs/commit/5f4f945cfffb4e57ad665196af00ab9cc760855c) minimal-bootstrap: refactor out bootstrap-sources.nix
* [`dc975fd1`](https://github.com/NixOS/nixpkgs/commit/dc975fd1b61417cf99c3bcaf4199befea9c50a3e) minimal-bootstrap.stage0: unstable-2023-04-24 -> unstable-2023-05-02
* [`9c7c80fa`](https://github.com/NixOS/nixpkgs/commit/9c7c80faa8b3655def1060a3c3ea2279792e7b27) maintainers: add therealr5
* [`ef41eed2`](https://github.com/NixOS/nixpkgs/commit/ef41eed24f0c2b03f6dc435d9bfe53c279fbf68b) maintainers/scripts/haskell/*transitive-broken*: Fix an error message
* [`ad38216d`](https://github.com/NixOS/nixpkgs/commit/ad38216dc6767d43d658064fd61b6962db016cd7) haskellPackages: Add maintainer shlok
* [`2a950c29`](https://github.com/NixOS/nixpkgs/commit/2a950c290ccc463abe5d43b796b68cd7a2a556a0) haskellPackages: regenerate package set based on current config
* [`36559748`](https://github.com/NixOS/nixpkgs/commit/365597483fa31442cafa9c60cca177965904b677) minimal-bootstrap: remove redundant definition
* [`f11c25ef`](https://github.com/NixOS/nixpkgs/commit/f11c25efa02f39bbc1b3747a828caeeb167f7360) haskellPackages.streamly-archive: unbreak
* [`0dfbd852`](https://github.com/NixOS/nixpkgs/commit/0dfbd852605a42cefcaeaade901c0f021b62605a) python310Packages.archinfo: 9.2.48 -> 9.2.49
* [`ed07f47b`](https://github.com/NixOS/nixpkgs/commit/ed07f47be1c05974cd75a8bac969dbaadbb69e9f) python310Packages.ailment: 9.2.48 -> 9.2.49
* [`2f4ce2c2`](https://github.com/NixOS/nixpkgs/commit/2f4ce2c27f010442c976a2896a94070cfb3ca18c) python310Packages.pyvex: 9.2.48 -> 9.2.49
* [`c924a76f`](https://github.com/NixOS/nixpkgs/commit/c924a76f332586bc5b83a20dca065f0828659300) python310Packages.claripy: 9.2.48 -> 9.2.49
* [`f9272eb8`](https://github.com/NixOS/nixpkgs/commit/f9272eb82e3a0917d0a4a0a301f094a3e5a98a3f) python310Packages.cle: 9.2.48 -> 9.2.49
* [`ab855db4`](https://github.com/NixOS/nixpkgs/commit/ab855db4c442576a58adf9deabdce0ba47ae2959) python310Packages.angr: 9.2.48 -> 9.2.49
* [`c005ef2c`](https://github.com/NixOS/nixpkgs/commit/c005ef2cece97d672d988737f7ca3624186dc7e4) python310Packages.django-prometheus: 2.2.0 -> 2.3.1
* [`bfe4de87`](https://github.com/NixOS/nixpkgs/commit/bfe4de87c910e489875c86851b2b05b1b39d05f7) python310Packages.django-rq: 2.7.0 -> 2.8.0
* [`5d6f0234`](https://github.com/NixOS/nixpkgs/commit/5d6f02349bd0b531cc5f8289d9e9f111fa340315) meson: apply fix for detect_voidp_size
* [`956fad66`](https://github.com/NixOS/nixpkgs/commit/956fad668dffee7fce0b346917428b7eeb5afc40) terraform-backend-git: install shell completions
* [`4b802889`](https://github.com/NixOS/nixpkgs/commit/4b802889d3e9e583a7afbdca7afcf408f3c4a326) terraform-backend-git: fix version
* [`06e21ebb`](https://github.com/NixOS/nixpkgs/commit/06e21ebba59065969c57876764829d72eeca3534) minimal-bootstrap: dont use top-level newScope to prevent accidentally using top-level attrs
* [`1e88aa25`](https://github.com/NixOS/nixpkgs/commit/1e88aa25949731f5d372ae7a510e56dea84f9e9a) minimal-bootstrap.mes: generate list of source files
* [`d8edffa5`](https://github.com/NixOS/nixpkgs/commit/d8edffa5f76ae2ae9879af8a1e041f41cc6183da) lego: 4.10.2 -> 4.11.0
* [`c5432d1f`](https://github.com/NixOS/nixpkgs/commit/c5432d1f9649c570449f786cca184418073dcb05) minimal-bootstrap: move utils out of stage0-posix
* [`bac62a38`](https://github.com/NixOS/nixpkgs/commit/bac62a387df1128671bb6b232d36496f7eeee5d0) cve-bin-tool: 3.1.2 -> 3.2
* [`02dfea94`](https://github.com/NixOS/nixpkgs/commit/02dfea94468f8b795b0e1347745c1d06b48a4a88) libjpeg: 2.1.4 -> 2.1.5.1
* [`99e1385c`](https://github.com/NixOS/nixpkgs/commit/99e1385ccf495ffc0f1b704d362d14c03df19e2f) heroic: 2.6.2 -> 2.7.1
* [`d8816fb9`](https://github.com/NixOS/nixpkgs/commit/d8816fb9493eba6bd8d6021cefd7a331de319c97) gogdl: 0.4 -> 0.7.1
* [`83d14593`](https://github.com/NixOS/nixpkgs/commit/83d1459330ec3da2111a512074895435e0f7390a) llvmPackages_git.llvm: backport patch for musl 1.2.4
* [`776ba7a4`](https://github.com/NixOS/nixpkgs/commit/776ba7a41013ff4c6de306d1f63815bf15e5f5ab) llvm_15: backport patch for musl 1.2.4
* [`7a9443a4`](https://github.com/NixOS/nixpkgs/commit/7a9443a4fefe5118e4d45b70cdaab4edd2cd11b1) llvm_14: backport patch for musl 1.2.4
* [`0bcf8ae8`](https://github.com/NixOS/nixpkgs/commit/0bcf8ae82b1fbae1e9d3796445a0f297a853a749) llvm_13: backport patch for musl 1.2.4
* [`45093ead`](https://github.com/NixOS/nixpkgs/commit/45093ead781069fbfccd89e53d9d701f81f27c20) llvm_12: backport patch for musl 1.2.4
* [`2a859f53`](https://github.com/NixOS/nixpkgs/commit/2a859f5366a641224d64f2d747b2ef95a908b3d6) llvm_11: backport patch for musl 1.2.4
* [`fe654118`](https://github.com/NixOS/nixpkgs/commit/fe6541184747f872eec66610886ea63d1f2b304f) llvm_10: backport patch for musl 1.2.4
* [`768007c2`](https://github.com/NixOS/nixpkgs/commit/768007c210be99c50549564224625a092df9525e) llvm_9: backport patch for musl 1.2.4
* [`d93bd8e2`](https://github.com/NixOS/nixpkgs/commit/d93bd8e23d4e6bae55b3eb9eacefe10edc24faf8) llvm_8: backport patch for musl 1.2.4
* [`f6b50611`](https://github.com/NixOS/nixpkgs/commit/f6b50611084d4015355ccc52033d4abdbf0efdae) llvm_7: backport patch for musl 1.2.4
* [`12d4b4ad`](https://github.com/NixOS/nixpkgs/commit/12d4b4ad2fd38386cda87b155031797264b50b70) llvm_6: backport patch for musl 1.2.4
* [`ad10899a`](https://github.com/NixOS/nixpkgs/commit/ad10899abf3897cd4a2688782bfd74500b1babca) llvm_5: backport patch for musl 1.2.4
* [`a6bb2cc2`](https://github.com/NixOS/nixpkgs/commit/a6bb2cc2d4024219afabf6a1deca5a769777298e) Revert "haskellPackages: Add maintainer shlok"
* [`9e7bcdd1`](https://github.com/NixOS/nixpkgs/commit/9e7bcdd1c0823a4ed026d89de867fb7e5e8d4407) haskellPackages: Add maintainer shlok
* [`668b20d5`](https://github.com/NixOS/nixpkgs/commit/668b20d59d589cd67716b28336c16cdbe976bcfe) Revert "git: fix in completion scripts references to environment utils"
* [`b03cc9ce`](https://github.com/NixOS/nixpkgs/commit/b03cc9ce119e686283b3017c7bc0414c635bd044) Revert "git: also patch the ls command for git-core scripts"
* [`61a54726`](https://github.com/NixOS/nixpkgs/commit/61a547260ea51c5ffced37ecb4419c6a194ffb6b) python310Packages.django-markup: 1.7 -> 1.7.2
* [`a1a4c4d6`](https://github.com/NixOS/nixpkgs/commit/a1a4c4d6296ec93e72dac23df6965681e384af74) haskellPackages.streamly-lmdb: unbreak
* [`4d1f2a74`](https://github.com/NixOS/nixpkgs/commit/4d1f2a74912bfe8daeddfdec331ec1502daa3f19) python310Packages.xnatpy: init at 0.5.1
* [`5ef89e7f`](https://github.com/NixOS/nixpkgs/commit/5ef89e7f1233eca21b389cee6bff736626084ab1) itch: 25.5.1 -> 25.6.2
* [`834b6fbf`](https://github.com/NixOS/nixpkgs/commit/834b6fbf2bd872f9a0efbca673d11086183a9b27) Revert "tomlplusplus: apply fix for detect_voidp_size"
* [`546d4d4b`](https://github.com/NixOS/nixpkgs/commit/546d4d4b769f214ba337dadc57277bbb32b6099d) nixos/nextcloud: add configureRedis option
* [`da15c505`](https://github.com/NixOS/nixpkgs/commit/da15c5054e9d11bb3afb697ec0eedad74aab09b1) nixos/nextcloud-notify_push: add bendDomainToLocalhost
* [`094aeff1`](https://github.com/NixOS/nixpkgs/commit/094aeff17c046b38c54a327c73dbaaa23c9a078d) go_1_20: 1.20.3 -> 1.20.4
* [`53b268ad`](https://github.com/NixOS/nixpkgs/commit/53b268ad4a513decaad91d69483ac48319ed54cb) cc-wrapper: support `--`
* [`40c914f1`](https://github.com/NixOS/nixpkgs/commit/40c914f1be018545992a5b2e3182f3b940f907ce) cc-wrapper-test: add tests for `--`
* [`053d15a9`](https://github.com/NixOS/nixpkgs/commit/053d15a9c64dc940cd5e5509eefd962edc988939) ledfx: 2.0.64 -> 2.0.67
* [`08b4149d`](https://github.com/NixOS/nixpkgs/commit/08b4149d34f7b1bbcef63f79904de9eac1d5ee9f) python311Packages.rich: 13.3.1 -> 13.3.5
* [`1df91a6c`](https://github.com/NixOS/nixpkgs/commit/1df91a6cbaea034b1020e42b85a90b8b369d47fd) python311Packages.textual: 0.15.1 -> 0.23.0
* [`59e3c779`](https://github.com/NixOS/nixpkgs/commit/59e3c779d3e37760d7b48ea77790a3ad828351d4) python310Packages.pyasn1-modules: 0.2.8 -> 0.3.0
* [`f99abaaa`](https://github.com/NixOS/nixpkgs/commit/f99abaaa6c71fef62400339353b74a1d86d2c2b2) python310Packages.pyasn1: 0.4.8 -> 0.5.0
* [`9edd42ed`](https://github.com/NixOS/nixpkgs/commit/9edd42ed406fa8c4dcc7806c2b93604b438e5cb1) python310Packages.requests: 2.28.2 -> 2.29.0
* [`12a4c5db`](https://github.com/NixOS/nixpkgs/commit/12a4c5db1560da968c33ca976951692ca8f55ea6) hwdata: 0.369 -> 0.370
* [`d0ef78a3`](https://github.com/NixOS/nixpkgs/commit/d0ef78a36d63728582dd5fd7612622f085d338eb) python310Packages.orjson: 3.8.9 -> 3.8.11
* [`8f73b48c`](https://github.com/NixOS/nixpkgs/commit/8f73b48cadb899e4121de6e66a0871d523790f6b) imlib2: 1.10.0 -> 1.11.1
* [`28419a44`](https://github.com/NixOS/nixpkgs/commit/28419a442d5ea6f112eb2e530dac6bafbff0d1b7) haskellPackages.streamly-archive: improve unbreak
* [`85c17404`](https://github.com/NixOS/nixpkgs/commit/85c17404e46684845525d6d524d23b04f12262f9) mutagen: 0.16 -> 0.17
* [`d36cd858`](https://github.com/NixOS/nixpkgs/commit/d36cd8587bc765aa57d9748cacbbf3f1e3e4ffaa) Revert "linux_6_1: rebuild on x86_64-linux"
* [`22b7fb73`](https://github.com/NixOS/nixpkgs/commit/22b7fb734ab8314ad6d31e810b837b12fe936dbb) haskellPackages.fourmolu_0_12_0_0: unbreak
* [`3cb794b0`](https://github.com/NixOS/nixpkgs/commit/3cb794b0f32667c092427d2c9f12a2e9d8b488b7) haskellPackages.lzma: fix build
* [`bbeedced`](https://github.com/NixOS/nixpkgs/commit/bbeedcedc72cbe5c72ffa018dead44aeaf428e8d) rtl88x2bu: 2023-02-24 -> 2023-03-17
* [`acd926d3`](https://github.com/NixOS/nixpkgs/commit/acd926d3d1e7d2fa0f1a8db7642a4621c0276efa) rtl88x2bu: add myself on maintainers list
* [`4e84de97`](https://github.com/NixOS/nixpkgs/commit/4e84de9755438acd60f3690020c736e2b649c987) ruby_3_0: unpin openssl_1_1
* [`6538d97f`](https://github.com/NixOS/nixpkgs/commit/6538d97fd4bdb2104f397d245614c46fe7d14629) python310Packages.django_3: 3.2.18 -> 3.2.19
* [`22ba1c06`](https://github.com/NixOS/nixpkgs/commit/22ba1c06b03d27f326f75b2bab8cd0e864593821) Revert "haskellPackages.hercules-ci-agent: Work around corrupted file on cache.nixos.org"
* [`3d2bdd07`](https://github.com/NixOS/nixpkgs/commit/3d2bdd0788d7fa05883cafc1f8c2ab29527ef4f1) python: implement PEP 668 ([nixos/nixpkgs⁠#229166](https://togithub.com/nixos/nixpkgs/issues/229166))
* [`476713fc`](https://github.com/NixOS/nixpkgs/commit/476713fc66714809025b6e910a827a642d7fb484) pythonPackages.finvizfinance: init at 0.14.5
* [`9647ad3d`](https://github.com/NixOS/nixpkgs/commit/9647ad3dc835f6431eff30ce961595d989ea7771) dracula-icon-theme: init at unstable-2021-07-21
* [`ad6906fe`](https://github.com/NixOS/nixpkgs/commit/ad6906feb7db94531a3cc3077be07ef544bb7352) doxygen: enable sqlite3 output
* [`a6a88340`](https://github.com/NixOS/nixpkgs/commit/a6a8834043fd746f69ae0f4693d8e6857269be0c) doxygen: use apple_sdk_11_0
* [`e5c113e3`](https://github.com/NixOS/nixpkgs/commit/e5c113e3e79047f1f60a551cbf28c2ca85853a05) doxygen: add output for examples
* [`3d50ced8`](https://github.com/NixOS/nixpkgs/commit/3d50ced84899e986f2b71e615f9871d64dd45dbe) act: 0.2.44 -> 0.2.45
* [`1b6078a2`](https://github.com/NixOS/nixpkgs/commit/1b6078a24a42c0d809a8739ffd24758f857c52e4) nixos/no-x-libs: add pipewire
* [`90639071`](https://github.com/NixOS/nixpkgs/commit/906390715c7815603bf217a949817f92b0759e91) pipewire: disable options which depend on x11 if it is disabled
* [`ccfcf667`](https://github.com/NixOS/nixpkgs/commit/ccfcf66751a82fd02133de1d16cdcfdd87bae63b) chromiumBeta: 113.0.5672.63 -> 114.0.5735.16
* [`a166a729`](https://github.com/NixOS/nixpkgs/commit/a166a7294c0306bb02ac0800adb2d247a08690e5) heroic: Rewrite using mkDerivation+fetchYarnDeps
* [`52fdb8a6`](https://github.com/NixOS/nixpkgs/commit/52fdb8a669b3adb8332df10053ac636b6b6989a4) gnome-obfuscate: 0.0.7 -> 0.0.9
* [`621e0861`](https://github.com/NixOS/nixpkgs/commit/621e086136a176088d2531d583aff8384ed4d4da) nwchem: 7.0.2 -> 7.2.0
* [`028866fa`](https://github.com/NixOS/nixpkgs/commit/028866fa071e7f40c20b847e8f9f69745a43dfe3) rust-hypervisor-firmware: fix build
* [`782c8b44`](https://github.com/NixOS/nixpkgs/commit/782c8b44ddda7b5c51ad22d388d93bb39f05586e) buildDartApplication: init
* [`d161ef56`](https://github.com/NixOS/nixpkgs/commit/d161ef5631ae8826255e6c517b4fa59c369bf0f2) buildFlutterApplication: add docs
* [`211d7f62`](https://github.com/NixOS/nixpkgs/commit/211d7f629255cfa14ed63b363271afd35ab53d63) dart-sass: use buildDartApplication
* [`70d3f5c0`](https://github.com/NixOS/nixpkgs/commit/70d3f5c0b4814d63ff364eec75b3b82d3e09a39c) buildFlutterApplication: default vendorHash to ""
* [`21b6bec0`](https://github.com/NixOS/nixpkgs/commit/21b6bec0ff14f55c37a655529d6ad2e81f1c4212) nixos/config/swap: improve randomEncrytion
* [`576c04a3`](https://github.com/NixOS/nixpkgs/commit/576c04a3c8955ca746d7ebad871a2e18f798e3ea) cpio: 2.13 -> 2.14
* [`d347b040`](https://github.com/NixOS/nixpkgs/commit/d347b0400c3ee88747e104f098d1960ece55117a) mkNugetSource: remove mono from build closure
* [`f08af5a3`](https://github.com/NixOS/nixpkgs/commit/f08af5a3d41eeaa2eff918020d543ecb6b7ffcb1) yuzu: reanimate, clean up, switch to qt6
* [`c9335064`](https://github.com/NixOS/nixpkgs/commit/c933506468763ce2b09637f5bdc9fdcb4a6a562e) haskellPackages.utility-ht: 0.0.16 -> 0.0.17
* [`608aa362`](https://github.com/NixOS/nixpkgs/commit/608aa362a0dfb8c1bbafb14456ddab81555df5df) haskellPackages.cabal2nix-unstable: 2023-04-11 -> 2023-05-05
* [`6929fbd5`](https://github.com/NixOS/nixpkgs/commit/6929fbd57c1a37059d61d33c086781f4eaa29e42) python311Packages.yfinance: 0.2.16 -> 0.2.19b1
* [`2376eb8d`](https://github.com/NixOS/nixpkgs/commit/2376eb8d7e413a3f486ddc8075f856e62cb99ef5) libbpf: 1.1.0 -> 1.2.0
* [`5e8a2729`](https://github.com/NixOS/nixpkgs/commit/5e8a27296be1eb559c0a727884a380ad65c31b3c) nixosTests.bpf: disable kfunc test on aarch64
* [`bc4549fe`](https://github.com/NixOS/nixpkgs/commit/bc4549fe3a13688aef1c486666b6ba351cc8b2bf) cacert: 3.86 -> 3.89.1
* [`f7cce1f7`](https://github.com/NixOS/nixpkgs/commit/f7cce1f73caf9b12d0e59561e18437f18f91ee27) python310Packages.mesa: 1.2.0 -> 1.2.1
* [`023a7822`](https://github.com/NixOS/nixpkgs/commit/023a7822f81558c43870dfdb414bc2975b7e6f84) xz: 5.4.2 -> 5.4.3
* [`4a58cb90`](https://github.com/NixOS/nixpkgs/commit/4a58cb90e999fcbbb2100796889d91b23464d2b2) csound: drop override for JACK_HEADER
* [`c01b90c8`](https://github.com/NixOS/nixpkgs/commit/c01b90c8824a9ddcd645c20467ae2452f709b945) python311Packages.pysensibo: 1.0.25 -> 1.0.27
* [`7cd5b9a6`](https://github.com/NixOS/nixpkgs/commit/7cd5b9a6e8c3e4e423d7d10533cc2f1e98a4eca8) lib/options: fix rendering of options with only a defaultText
* [`1c963cea`](https://github.com/NixOS/nixpkgs/commit/1c963cea481fcf01e5386492149fa11eeeed7469) nixos/gitea-actions-runner: init
* [`f89d168e`](https://github.com/NixOS/nixpkgs/commit/f89d168e57499356c792b480d522c1886f52a899) heroic: add patch for upstream bugfix
* [`3a31db0f`](https://github.com/NixOS/nixpkgs/commit/3a31db0fe1656d42f117e2a4780de9afc32a4d67) yosys: 0.27 -> 0.28 https://github.com/YosysHQ/yosys/releases/tag/yosys-0.28
* [`f2fba69f`](https://github.com/NixOS/nixpkgs/commit/f2fba69fe67fdeab96a100fef27fbea1fe30ee74) wireshark: do not install redundant files
* [`c55f97b6`](https://github.com/NixOS/nixpkgs/commit/c55f97b61669e98de56493d18d968944a2af8d0b) publii: init at 0.42.1
* [`36af1fea`](https://github.com/NixOS/nixpkgs/commit/36af1fea0601a24173cae578d743b759bbecd891) cgal_5: 5.5.1 -> 5.5.2
* [`5838729f`](https://github.com/NixOS/nixpkgs/commit/5838729f9e97689554d994fe59521f9a2ea35ce1) release-cross.nix: fix the fix in [nixos/nixpkgs⁠#188339](https://togithub.com/nixos/nixpkgs/issues/188339)
* [`2f8f6c61`](https://github.com/NixOS/nixpkgs/commit/2f8f6c616a62cbdb358374eebfb2b500c560c670) flyway: 9.16.1 -> 9.17.0
* [`f3af767c`](https://github.com/NixOS/nixpkgs/commit/f3af767c944fcc714edb81fb902ea8e7a409c9f5) python310Packages.mobly: 1.12.1 -> 1.12.2
* [`d237a92e`](https://github.com/NixOS/nixpkgs/commit/d237a92e63aafab6d63ebb5f5e2d96b77c3727aa) update-python-libraries: Fix some issues
* [`8fc1e2d0`](https://github.com/NixOS/nixpkgs/commit/8fc1e2d0c75f44564ad3e2b5b2e21ee878cf22fb) python310Packages.home-assistant-chip-core: 2023.2.2 -> 2023.4.1
* [`ffbcdd1d`](https://github.com/NixOS/nixpkgs/commit/ffbcdd1d2bd301afc6a32792751e77ead5fb59db) python310Packages.home-assistant-chip-clusters: 2023.2.2 -> 2023.4.1
* [`2f5ee5e9`](https://github.com/NixOS/nixpkgs/commit/2f5ee5e9a94fdb6aa23e84b7c8e90fcdeb232bb8) python310Packages.python-matter-server: 3.2.0 -> 3.3.1
* [`cfe5a796`](https://github.com/NixOS/nixpkgs/commit/cfe5a79639c826fe507b5eb54ebfe08d6191d10b) zfs: make kernel packages overridable
* [`04cc54e2`](https://github.com/NixOS/nixpkgs/commit/04cc54e2aea14e2ec6683ab41b65a916f5d960a6) trino-cli: 413 -> 416
* [`edf3073b`](https://github.com/NixOS/nixpkgs/commit/edf3073b2ddc7c349476a2b9382070cace5d2260) miriway: unstable-2023-03-17 -> unstable-2023-04-25
* [`839246f9`](https://github.com/NixOS/nixpkgs/commit/839246f9e67b56d80a5ed89ae7b90011ae8fc7fe) gexiv2: 0.14.0 → 0.14.1
* [`1d31f5a1`](https://github.com/NixOS/nixpkgs/commit/1d31f5a144728e0ba603f5969bc01c73602f6297) python310Packages.torchmetrics: 0.11.3 -> 0.11.4
* [`c1cf75f6`](https://github.com/NixOS/nixpkgs/commit/c1cf75f63671e13ff18f0b0feb6531694f8a769f) yubikey-manager-qt: 1.2.4 -> 1.2.5
* [`78471198`](https://github.com/NixOS/nixpkgs/commit/78471198a104cd596744a0539d03fbedc64c31f2) python310Packages.pytorch-lightning: 1.9.3 -> 2.0.2
* [`fcf5b127`](https://github.com/NixOS/nixpkgs/commit/fcf5b127a9af2a7fbf19fd527c94c61f3e0affbb) texmaker: 5.1.3 -> 5.1.4
* [`aece2b1d`](https://github.com/NixOS/nixpkgs/commit/aece2b1d78a7fe3ae5de3dcdaa7739f64eceaca7) libssh: 0.10.4 -> 0.10.5
* [`fc3c5947`](https://github.com/NixOS/nixpkgs/commit/fc3c5947a92ea531a6cc07de3e2c18c9d984bb6f) nixos/miriway: Adjust default and example config
* [`445d7cae`](https://github.com/NixOS/nixpkgs/commit/445d7cae2aebeabe4f9ba6ecd2f2177ac1be4bcb) nixos/config/swap: refactor startup script generation
* [`4e8cbf95`](https://github.com/NixOS/nixpkgs/commit/4e8cbf953163b9d070a80b6a30a74eaca93861ee) elmPackages: Use nodejs 18
* [`c72178cf`](https://github.com/NixOS/nixpkgs/commit/c72178cf2bcccb31c0709488ebd3ec3f5b62bd0d) boost165: remove unused pkg
* [`61e3deef`](https://github.com/NixOS/nixpkgs/commit/61e3deefae49a0320f84986fb4d58fc42d207682) boost166: remove unused pkg
* [`74dd873c`](https://github.com/NixOS/nixpkgs/commit/74dd873c11179fb83a38d4d55da43d6de0355c37) shod: 2.5.0 -> 2.6.2
* [`fc5922aa`](https://github.com/NixOS/nixpkgs/commit/fc5922aa663069870e026f7cb3eeef94e7043f07) moonlander: init at unstable-2021-05-23
* [`5fbb31c7`](https://github.com/NixOS/nixpkgs/commit/5fbb31c71e185160200afddc802d04409768c4e3) python310Packages.pure-protobuf: 2.2.3 -> 2.3.0
* [`e7a72819`](https://github.com/NixOS/nixpkgs/commit/e7a72819bd9ff280b837088cbce946ca2f9b617f) harmonia: 0.6.2 -> 0.6.3
* [`cf729a46`](https://github.com/NixOS/nixpkgs/commit/cf729a4690b4de9a2a5cd2ecfe9efe3d1bf8a073) metasploit: 6.3.14 -> 6.3.15
* [`760f0009`](https://github.com/NixOS/nixpkgs/commit/760f00091cf53c03e8175bc7132602265358ad77) libressl_3_5: remove
* [`220cb227`](https://github.com/NixOS/nixpkgs/commit/220cb2276b58d2b01e2a872dd8dd23f3d803e3e8) libressl: 3.6.2 -> 3.7.2
* [`cad2dad0`](https://github.com/NixOS/nixpkgs/commit/cad2dad05ee21f3196fce29249df82987931a40f) jql: 6.0.6 -> 6.0.7
* [`a8da2a57`](https://github.com/NixOS/nixpkgs/commit/a8da2a5714befb418b9ee287f39b04ad1ac6d429) python310Packages.pynamodb: 5.4.1 -> 5.5.0
* [`77a317d6`](https://github.com/NixOS/nixpkgs/commit/77a317d6565c9b005da89a96c3f4f908718b2423) ocamlPackages.yojson: 2.0.2 -> 2.1.0
* [`633f7677`](https://github.com/NixOS/nixpkgs/commit/633f76779de03234ad3f82e79fc492e8b3ae5df5) xrdp: 0.9.21.1 -> 0.9.22
* [`3f229e3f`](https://github.com/NixOS/nixpkgs/commit/3f229e3f9db391a03b5c0b122eb4a34cf5bfe134) texstudio: 4.5.1 -> 4.5.2
* [`a30bcb5d`](https://github.com/NixOS/nixpkgs/commit/a30bcb5d38bd42fe125920790104d58aebb9e9b4) boost: Remove references to unsupported versions
* [`e4bb5049`](https://github.com/NixOS/nixpkgs/commit/e4bb50499d104e1218bd6c711442f2e1273780b1) symfony-cli: 5.5.4 -> 5.5.5
* [`37fee8c5`](https://github.com/NixOS/nixpkgs/commit/37fee8c5090a593176c7718e9a0485d2265ddab0) connman: fix build with ppp 2.5.0 using upstream patch
* [`6936f33c`](https://github.com/NixOS/nixpkgs/commit/6936f33c1b09332ee7c33b4afdd61cc443d2abf1) connman: add patch for CVE-2023-28488
* [`448dcd5a`](https://github.com/NixOS/nixpkgs/commit/448dcd5acd77c35ee9cdffcd2d0301a756ad7bf1) obs-studio-plugins.obs-move-transition: 2.8.0 -> 2.9.0
* [`47714372`](https://github.com/NixOS/nixpkgs/commit/477143726308da9543b6e1f87bef971a3717f782) python310Packages.pure-protobuf: add changelog to meta
* [`44967277`](https://github.com/NixOS/nixpkgs/commit/449672772579651498a07b14beebc5d4169545a6) vkd3d: 1.7 -> 1.7.1
* [`a46d56ac`](https://github.com/NixOS/nixpkgs/commit/a46d56ac76977ae4fc9c9dd55f5410fc4de4ac26) lilypond-unstable: 2.25.3 -> 2.25.4
* [`0913693c`](https://github.com/NixOS/nixpkgs/commit/0913693cb92f2ccfca344758afca413d15d50dbb) freenect: 0.6.4 -> 0.7.0
* [`3f4dcd38`](https://github.com/NixOS/nixpkgs/commit/3f4dcd381a157002199dc11238ce9efba5bce593) libgcrypt: Use pname in changelog url
* [`c09feb83`](https://github.com/NixOS/nixpkgs/commit/c09feb83e0c31c31cec291bc6ecc05a659a76c12) gnupg: Add changelog
* [`416f268c`](https://github.com/NixOS/nixpkgs/commit/416f268c64baf844a81eacf9d946820a8f484ee7) acl: backport patch for musl 1.2.4
* [`1124a754`](https://github.com/NixOS/nixpkgs/commit/1124a754598516e85d39da3aa6cdf38113179aee) xorg.libpciaccess: backport patch for musl 1.2.4
* [`ad28c1eb`](https://github.com/NixOS/nixpkgs/commit/ad28c1ebcb3720cbda10a03442aab55331ae2738) gdb: backport patch for musl 1.2.4
* [`112278bd`](https://github.com/NixOS/nixpkgs/commit/112278bdb4a111a8aa74612441c0555562c8d5e0) dprint: 0.34.5 -> 0.36.1
* [`50eb1f9a`](https://github.com/NixOS/nixpkgs/commit/50eb1f9a976b6e8b118e54dc39766d2d3456b628) arti: 1.1.3 -> 1.1.4
* [`19a98ed8`](https://github.com/NixOS/nixpkgs/commit/19a98ed8c33d72db8623de4c93c7ed9ceb684944) python310Packages.xmlschema: 2.2.1 -> 2.2.3
* [`2f34bfa4`](https://github.com/NixOS/nixpkgs/commit/2f34bfa4098e85b82a80b4764556310326b6e62a) seaweedfs: 3.48 -> 3.49
* [`0cad34a2`](https://github.com/NixOS/nixpkgs/commit/0cad34a2eb550f3bb9c5e3c93211121e8557ca24) slweb: 0.5 -> 0.5.4
* [`34629fce`](https://github.com/NixOS/nixpkgs/commit/34629fce5f0708fc2d6e833ef82252826d2bfbca) python3.pkgs.deprecated: build offline documentation
* [`3cba89d0`](https://github.com/NixOS/nixpkgs/commit/3cba89d0b9fd6df959d4f8ba7b370ed13e9940c4) pgbouncer: 1.18.0 -> 1.19.0
* [`bbaa71fa`](https://github.com/NixOS/nixpkgs/commit/bbaa71fa605a42889d4cb0dcddba5a74c44374bd) wireless-regdb: 2023.02.13 -> 2023.05.03
* [`ab7fe9cb`](https://github.com/NixOS/nixpkgs/commit/ab7fe9cbd5d8c82694aff14f7449bda4ba6ba5b9) nostr-rs-relay: init at 0.8.9
* [`d1cdbd59`](https://github.com/NixOS/nixpkgs/commit/d1cdbd59ff13fd9e5d2e1b44f8b089c6e3806994) python310Packages.urlman: init at 2.0.1
* [`a6617870`](https://github.com/NixOS/nixpkgs/commit/a661787068b4beb95ba9ffcc4096dadfcf02c02d) btrfs-progs: 6.2.2 -> 6.3
* [`059eb9dd`](https://github.com/NixOS/nixpkgs/commit/059eb9dd2a2c85c7e26dffc43c8265f3b9da61da) whois: 5.5.16 -> 5.5.17
* [`34752a7c`](https://github.com/NixOS/nixpkgs/commit/34752a7cbc870e0849f653dc8d744bcb23084794) python310Packages.oci: 2.93.0 -> 2.100.0
* [`ad091aec`](https://github.com/NixOS/nixpkgs/commit/ad091aec7272b72bd51a19e862cf4f3ef7cfa632) python310Packages.laspy: 2.3.0 -> 2.4.1
* [`f326911c`](https://github.com/NixOS/nixpkgs/commit/f326911cb926d264d784186219f4608bf557170f) temporal-cli: combine temporal-cli and tctl
* [`36659ccc`](https://github.com/NixOS/nixpkgs/commit/36659ccc58e276cc9144b7c3c06f8c043bd49218) cudatext: 1.193.0 -> 1.193.3
* [`0cd17d28`](https://github.com/NixOS/nixpkgs/commit/0cd17d282e9fd68b8117498c97e109b2321373aa) clojure-lsp: 2023.04.19-12.43.29 -> 2023.05.04-19.38.01
* [`ce879b7a`](https://github.com/NixOS/nixpkgs/commit/ce879b7a03d46b1eff6d22735f97a6d5151e167e) mate.eom: 1.26.0 -> 1.26.1
* [`886b42c9`](https://github.com/NixOS/nixpkgs/commit/886b42c9163b5a2a258cbc4502acc5798916f580) mate.mate-menus: 1.26.0 -> 1.26.1
* [`52a4a15c`](https://github.com/NixOS/nixpkgs/commit/52a4a15c54757df3cb462dc01ef72cae27df9865) mate.mate-power-manager: 1.26.0 -> 1.26.1
* [`d9edc0e4`](https://github.com/NixOS/nixpkgs/commit/d9edc0e441c4a1d66ff0e494d05670069f2fb6e9) mate.mate-control-center: 1.26.0 -> 1.26.1
* [`ea4810f7`](https://github.com/NixOS/nixpkgs/commit/ea4810f719e19a62684bae3c0e317d53821e5882) terraform-providers.argocd: 5.2.0 -> 5.3.0
* [`884ffbd8`](https://github.com/NixOS/nixpkgs/commit/884ffbd847e015e0d6cb2767ba72f7e7320bf8ef) terraform-providers.thunder: 1.2.1 -> 1.2.2
* [`c9e0280e`](https://github.com/NixOS/nixpkgs/commit/c9e0280eccc9819fe56528f87fadb23a517af8d3) chat-downloader: 0.2.4 -> 0.2.5
* [`956989c4`](https://github.com/NixOS/nixpkgs/commit/956989c424ac77eb257814883490409a78f682cf) gallery-dl: 1.25.3 -> 1.25.4
* [`c8fed841`](https://github.com/NixOS/nixpkgs/commit/c8fed841a9a5f35fdec7eb4fa53c706ef7b2beb2) python310Packages.m3u8: 0.9.0 -> 3.4.0
* [`d906740e`](https://github.com/NixOS/nixpkgs/commit/d906740e607f9f1cf37b50da905fb422bfee834b) python310Packages.scrapy: 2.8.0 -> 2.9.0
* [`4148410a`](https://github.com/NixOS/nixpkgs/commit/4148410a8d92f370cd03172934e19bd12ca612cf) exploitdb: 2023-05-06 -> 2023-05-08
* [`42fa5c37`](https://github.com/NixOS/nixpkgs/commit/42fa5c37039717af4fa0e2536d9b535476d3d2e7) findup: 1.0 -> 1.1
* [`71bc2475`](https://github.com/NixOS/nixpkgs/commit/71bc2475051d5edb694fb561f1e7e470d36e8d7f) rymdport: 3.3.4 -> 3.3.5
* [`96b99ece`](https://github.com/NixOS/nixpkgs/commit/96b99eceae25d76ac48f8b8ff9935c479e2b652d) python3Packages.persist-queue: init at 0.8.0
* [`dc183476`](https://github.com/NixOS/nixpkgs/commit/dc1834765273a071d734e5c7f5b38cf118ec6a3a) python3Packages.timeslot: init at 0.1.2
* [`d868a402`](https://github.com/NixOS/nixpkgs/commit/d868a4026344809497f2f83dfaacafd67496f438) python3Packages.takethetime: init at 0.3.1
* [`91f97cae`](https://github.com/NixOS/nixpkgs/commit/91f97cae903fe739799183fc0cdb9b4287d5c61b) python3Packages.aw-core: init at 0.5.12
* [`58291dd0`](https://github.com/NixOS/nixpkgs/commit/58291dd04b7dfb4ce1d1f135651a5fa009b9e073) python3Packages.aw-client: init at 0.5.11
* [`c175aa62`](https://github.com/NixOS/nixpkgs/commit/c175aa624b3239728956b09f904445b2f8142ced) activitywatch: init at 0.12.2
* [`0cb9e0c3`](https://github.com/NixOS/nixpkgs/commit/0cb9e0c390607342158b89d8d2e723e73607e8ef) activitywatch: simple symlinkJoin wrapper
* [`ccdcf369`](https://github.com/NixOS/nixpkgs/commit/ccdcf369264e16f35b7bbdbc5b3e0332a38c7e15) hyprpaper: 0.1.0 -> 0.2.0
* [`9d1a27e2`](https://github.com/NixOS/nixpkgs/commit/9d1a27e2fdd970acd629ac0f3b14bcf0ee0a4c7f) snakemake: 7.14.2 -> 7.25.3 ([nixos/nixpkgs⁠#230524](https://togithub.com/nixos/nixpkgs/issues/230524))
* [`0f1a8bbf`](https://github.com/NixOS/nixpkgs/commit/0f1a8bbf31e16352b0a4dd17e4b9e3668ec48558) s2n-tls: 1.3.42 -> 1.3.43
* [`21bfc01c`](https://github.com/NixOS/nixpkgs/commit/21bfc01c6596d466dfe60427d3c683bdba718485) terragrunt: 0.45.8 -> 0.45.9
* [`0c10795b`](https://github.com/NixOS/nixpkgs/commit/0c10795b203d345ae2922e6ec0c8e12448b28540) iosevka-bin: 22.1.0 -> 22.1.1
* [`38365fa0`](https://github.com/NixOS/nixpkgs/commit/38365fa0727943b606035622ce61afc5a86ad8fa) python311.pkgs.dlib: fix build
* [`09be62f2`](https://github.com/NixOS/nixpkgs/commit/09be62f24af64d76389a0927236eedfe4aef2b03) velero: 1.10.2 -> 1.10.3
* [`7ec3f49e`](https://github.com/NixOS/nixpkgs/commit/7ec3f49e551f6b4579c35d603fad67960dc0b0df) starlark: unstable-2023-01-12 -> unstable-2023-03-02
* [`d384201c`](https://github.com/NixOS/nixpkgs/commit/d384201cb94d570153f6e470bbf143c5345b6632) stc-cli: init at 1.4
* [`62621d61`](https://github.com/NixOS/nixpkgs/commit/62621d615af8147bbd9449c81c37dde12ee6a85a) python310Packages.aioesphomeapi: 13.7.3 -> 13.7.4
* [`86cf3fca`](https://github.com/NixOS/nixpkgs/commit/86cf3fca1f540e42a9c4f106b60553abbfadaf03) python310Packages.fakeredis: 2.11.2 -> 2.12.0
* [`88e433cd`](https://github.com/NixOS/nixpkgs/commit/88e433cd98655e8d630103d171b5dcbb92fc7969) harmonia: 0.6.2 -> 0.6.3
* [`227778a1`](https://github.com/NixOS/nixpkgs/commit/227778a165cc77815bebe8a9d0db9ecf32279da7) python310Packages.rules: init at 3.3.0
* [`8f7728b1`](https://github.com/NixOS/nixpkgs/commit/8f7728b109aca83a232b6e73a38c4b512312e9ca) aiac: 2.2.0 -> 2.4.0
* [`49a401bd`](https://github.com/NixOS/nixpkgs/commit/49a401bd9f1ad216d080e67a45cae1ddb7f19f35) k9s: 0.27.3 -> 0.27.4
* [`2cd1e737`](https://github.com/NixOS/nixpkgs/commit/2cd1e7370b2be33aab230924d70d26b6e3db66d0) praat: 6.3.09 -> 6.3.10
* [`050ae0b8`](https://github.com/NixOS/nixpkgs/commit/050ae0b8c3706552ada228278e228ad88448a2e2) vimPlugins: update
* [`d1c650ff`](https://github.com/NixOS/nixpkgs/commit/d1c650ffce9e0ab2fa19d9fbfd4d8d87235a76fd) vimPlugins: resolve github repository redirects
* [`19c9424d`](https://github.com/NixOS/nixpkgs/commit/19c9424dc4a49f42bed4cf4303595c53f3401986) vimPlugins.nvim-treesitter: update grammars
* [`4f147aba`](https://github.com/NixOS/nixpkgs/commit/4f147aba442380f7a28d3ed860ee36dca52cbdf9) odo: 3.9.0 -> 3.10.0
* [`32884796`](https://github.com/NixOS/nixpkgs/commit/328847963640c290799da2c437d7234cb4c37966) nixos/envfs: make mounts non-critical
* [`8fa10a01`](https://github.com/NixOS/nixpkgs/commit/8fa10a0118e715b2dc2285bcd8466fe60a1488c0) Add nodePackages.dotenv-vault
* [`22463e0c`](https://github.com/NixOS/nixpkgs/commit/22463e0c0aa3adb7ba3d9c56919ef8d3163e0606) qtcreator-qt6: 10.0.0 -> 10.0.1
* [`82c77862`](https://github.com/NixOS/nixpkgs/commit/82c778627ddd05c893882ff5966e496e2e7424ad) nixos/release: add deepin closure
* [`ae2c8327`](https://github.com/NixOS/nixpkgs/commit/ae2c8327978b46425d49000af2fc6773a32e296c) buf: 1.17.0 -> 1.18.0
* [`66fb2f53`](https://github.com/NixOS/nixpkgs/commit/66fb2f539ab647fa5cdeaef5cffbd37f59c71984) nixos/proxmox-image: Disable O_DIRECT to fix assert
* [`8fae5ee3`](https://github.com/NixOS/nixpkgs/commit/8fae5ee3213024a3f498ebccbc1e94ac4a77ef8e) sbomnix: init at 1.4.5
* [`0d82490a`](https://github.com/NixOS/nixpkgs/commit/0d82490a70d549ca17b0a3d68a66f01970c3733d) libgen-cli: 1.0.9 -> 1.0.10
* [`1366148e`](https://github.com/NixOS/nixpkgs/commit/1366148e2cf78b56d6efe9bc86eca4f2ae505306) conftest: 0.41.0 -> 0.42.1
* [`7911717f`](https://github.com/NixOS/nixpkgs/commit/7911717ffb070b5a950fd523bb8483b2b10d3f66) davmail: 6.0.1 -> 6.1.0
* [`072bc43d`](https://github.com/NixOS/nixpkgs/commit/072bc43dd50377b6853088fe78915359e1af23ab) vorta: install symbolic icon
* [`ed2700a6`](https://github.com/NixOS/nixpkgs/commit/ed2700a6f3a6d2698590b83223c3870949999e00) goreleaser: 1.18.1 -> 1.18.2
* [`a265d187`](https://github.com/NixOS/nixpkgs/commit/a265d187c92952c0dcc625957f1a18a0db5023c3) hyprpaper: mark as broken on darwin
* [`242f70a3`](https://github.com/NixOS/nixpkgs/commit/242f70a32280c575c5066571ad69ff16621ee125) python311Packages.cle: use binaries 9.2.49
* [`4adcaa61`](https://github.com/NixOS/nixpkgs/commit/4adcaa61cb6daff6682adb43b233e2000217bb7b) python310Packages.laspy: add changelog to meta
* [`c60d2ffe`](https://github.com/NixOS/nixpkgs/commit/c60d2ffe2e149a5227540a3abf08f14d31141483) texlive.combine: call faketime from within fmtutil
* [`4cdf91c8`](https://github.com/NixOS/nixpkgs/commit/4cdf91c85b11bb534e0e46d17e1e5aadb2c1d1ca) free42: 3.0.17 -> 3.0.20
* [`bf7de549`](https://github.com/NixOS/nixpkgs/commit/bf7de549b97ed64658b2d90d7a3f3c3cb0c64984) nixos/iso-image: targetPlatform -> hostPlatform
* [`f07083aa`](https://github.com/NixOS/nixpkgs/commit/f07083aa44d80a4de6964a1b46906d9b1aa7dd7e) svls: 0.2.8 -> 0.2.9
* [`ad7ca342`](https://github.com/NixOS/nixpkgs/commit/ad7ca342548760325dd60e90baf1040a76f02ab5) supabase-cli: 1.55.0 -> 1.55.1
* [`cd0bccbb`](https://github.com/NixOS/nixpkgs/commit/cd0bccbbe036450829a0565d6d921d728ad9985d) stdenv: fix inputDerivation with allowed refs
* [`49554a9b`](https://github.com/NixOS/nixpkgs/commit/49554a9b9bb43471defe41cfa5af38301cc1a523) python310Packages.wandb: disable more tests
* [`69e3dbda`](https://github.com/NixOS/nixpkgs/commit/69e3dbdae08e93cc7b6b962de1216dabe79fe571) gtklock: 2.0.1 -> 2.1.0
* [`d6b6fd95`](https://github.com/NixOS/nixpkgs/commit/d6b6fd9544629e01a57cc5908ae2e8a5511a074a) nwchem: enable new features (dftd3, libxc, plumed)
* [`f4bd6710`](https://github.com/NixOS/nixpkgs/commit/f4bd6710d77aa40dea748142efdb56c1e702b01a) nwchem: build with ILP64 support
* [`9e49dc15`](https://github.com/NixOS/nixpkgs/commit/9e49dc15f5dddd4a6353e529ffb76f6827676731) analitza: init at 23.04.0
* [`547071ee`](https://github.com/NixOS/nixpkgs/commit/547071ee6381cf15683c0e1ad97de5e815501888) sage: expose sage-with-env
* [`abf66be4`](https://github.com/NixOS/nixpkgs/commit/abf66be4b2088fbd9cd15df81c3e37405f38c7a7) cantor: init at 23.04.0
* [`842704c7`](https://github.com/NixOS/nixpkgs/commit/842704c7cf148022d3769a824ee24af0e6ea7a40) labplot: init at 2.10.0
* [`a01513b8`](https://github.com/NixOS/nixpkgs/commit/a01513b8ac0e7956e7d7bed3c82e05418421676e) nodePackages: fix typo in aliases
* [`ecc1ec2c`](https://github.com/NixOS/nixpkgs/commit/ecc1ec2c72a2e46a3ba19fd150009ea9cfc9d8c7) llvmPackages_latest: move to aliases.nix
* [`da41baa9`](https://github.com/NixOS/nixpkgs/commit/da41baa9898752f6d0b9f9788074d59fa103e250) llvmPackages_latest: 14.0.6 -> 16.0.1
* [`86eb7dfb`](https://github.com/NixOS/nixpkgs/commit/86eb7dfb25b35d3fc5eae2eea453b2ad5aaefe3e) linux_testing: 6.3-rc7 -> 6.4-rc1
* [`4d15632c`](https://github.com/NixOS/nixpkgs/commit/4d15632cafdcd748d32076fd3f0ad0744f5dd7ec) linuxManualConfig: fix inaccurate FIXME comment
* [`410e3820`](https://github.com/NixOS/nixpkgs/commit/410e3820cd0d274f30c23b322c8020d1463655cd) vscodium: Fix darwin build
* [`ef42b975`](https://github.com/NixOS/nixpkgs/commit/ef42b9754764aaebd1ac1a6ba7b3ccf3790a582a) ppp: specify statedir for .pid file
* [`c51b6e40`](https://github.com/NixOS/nixpkgs/commit/c51b6e4044dd51575bfd6888e71ddf6183ef65b9) openfortivpn: 1.20.2 -> 1.20.3
* [`142ca91f`](https://github.com/NixOS/nixpkgs/commit/142ca91f3687e6ed4fe6e9475675627ba9fc3b3a) wayback: init at v0.19.1
* [`d206e6b0`](https://github.com/NixOS/nixpkgs/commit/d206e6b03a50de7dc8f837e822f81a48981eeccd) maintainers: add alanpearce
* [`c85f31a0`](https://github.com/NixOS/nixpkgs/commit/c85f31a0714b9765c940e8304f66d7b8562d2de6) calamares-nixos-extensions: 0.3.11 -> 0.3.12
* [`4b7bda49`](https://github.com/NixOS/nixpkgs/commit/4b7bda49375e5edc78a9820356d67324f7545b9c) snowsql: 1.2.23 -> 1.2.26 ([nixos/nixpkgs⁠#230504](https://togithub.com/nixos/nixpkgs/issues/230504))
* [`025062c3`](https://github.com/NixOS/nixpkgs/commit/025062c31f53bb33fec08a1ac308f5a1cf914cf3) nodejs: 20.0.0 -> 20.1.0 ([nixos/nixpkgs⁠#229774](https://togithub.com/nixos/nixpkgs/issues/229774))
* [`9bba5798`](https://github.com/NixOS/nixpkgs/commit/9bba57982b00bf540fdab9f0b730f486f4a15de5) python3Packages.dbus-signature-pyparsing: 0.04 -> 0.4.1
* [`a740532a`](https://github.com/NixOS/nixpkgs/commit/a740532ae5501f06f7fdd7fdf2688414f65ffec0) spark: 3.2.2 -> 3.4.0
* [`2ba2e11e`](https://github.com/NixOS/nixpkgs/commit/2ba2e11ec3c02636b4ff62e05394181e18b88fa1) python3Packages.into-dbus-python: 0.08 -> 0.8.2
* [`a7b0283b`](https://github.com/NixOS/nixpkgs/commit/a7b0283b760b270edaf1ca83c4daf46f2f258299) ukmm: 0.8.1 -> 0.8.2
* [`a7fdc74b`](https://github.com/NixOS/nixpkgs/commit/a7fdc74ba2ce31744085776cab317e43407cd082) python3Packages.dbus-client-gen: 0.5 -> 0.5.1
* [`03b85bb6`](https://github.com/NixOS/nixpkgs/commit/03b85bb69740f10e11e119955758bdbe8273b3fc) jumpy: fix build on aarch64-linux
* [`6fc57cd1`](https://github.com/NixOS/nixpkgs/commit/6fc57cd12caa044e3a805b4f24dd05bbca300a5c) python3Packages.latex2mathml: 3.75.3 -> 3.75.5
* [`0cf8791b`](https://github.com/NixOS/nixpkgs/commit/0cf8791b0da91b1e40e380a8e54dfb99634062f7) bootspec: 0.1.0 -> 0.2.0
* [`eedea22c`](https://github.com/NixOS/nixpkgs/commit/eedea22c63aa622d83e5f51c5383705a4f85e4db) firefox-unwrapped: 112.0.2 -> 113.0
* [`fc87813b`](https://github.com/NixOS/nixpkgs/commit/fc87813b2d6c18f3c209f5b17bd5c3e83060d2f4) cocogitto: fix typo
* [`e4307e64`](https://github.com/NixOS/nixpkgs/commit/e4307e647177ade2f67be2f8a276a2cd7e0b8775) firefox-bin-unwrapped: 112.0.2 -> 113.0
* [`e55674d0`](https://github.com/NixOS/nixpkgs/commit/e55674d082075a6706e2d2bcb858cb85107de71a) firefox-esr-102-unwrapped: 102.10.0esr -> 102.11.0esr
* [`42bfc866`](https://github.com/NixOS/nixpkgs/commit/42bfc8668c215ea41aea40789bffaafed1dd3221) curl: fix typo
* [`a8b0a292`](https://github.com/NixOS/nixpkgs/commit/a8b0a292b7f6f9a7ccd1949c919ac9378f5eae53) rgp: 1.14.1 -> 1.15
* [`2b900cb3`](https://github.com/NixOS/nixpkgs/commit/2b900cb3ba6b32e918876bde994296266c3255da) elm: fix typo
* [`660ea298`](https://github.com/NixOS/nixpkgs/commit/660ea2988507e8ab30e231f0f98388c6c3aa189e) wakeonlan: fix Perl shebangs on darwin
* [`a43f655b`](https://github.com/NixOS/nixpkgs/commit/a43f655bff33035db8cad239c388a2627033b787) ppsspp-sdl: 1.15.2 -> 1.15.3
* [`560123c4`](https://github.com/NixOS/nixpkgs/commit/560123c48223929e99f1d478abaad04fe0b7469b) ghc: fix typos
* [`b5ed549a`](https://github.com/NixOS/nixpkgs/commit/b5ed549a07dc226da2af9a3455a5e8eafb86fc8f) gscreenshot: fix typo
* [`81b2f19e`](https://github.com/NixOS/nixpkgs/commit/81b2f19eb7d1599578c4f5abfa45254b38dfcd12) gvisor: fix typo
* [`1eb04445`](https://github.com/NixOS/nixpkgs/commit/1eb044459cfad4619f69d457d101a0b051c885c5) haskell-modules: fix typos
* [`5b0b5c8d`](https://github.com/NixOS/nixpkgs/commit/5b0b5c8d3a22060111b3c632630164a54e3cc077) haskellPackages.RBTree: fix typo
* [`82faf2f0`](https://github.com/NixOS/nixpkgs/commit/82faf2f00644bae4582cb87b6a54289aad87253d) haskellPackages.data-rtuple: fix typo
* [`1f7f2e89`](https://github.com/NixOS/nixpkgs/commit/1f7f2e8907cab5886f5febcda999ccb12f0c9eac) haskellPackages.dclabel: fix typo
* [`c1356da2`](https://github.com/NixOS/nixpkgs/commit/c1356da2df99fba319a5e9c060c5042b35b3f006) haskellPackages.haskell-snake: fix typo
* [`004c3f3c`](https://github.com/NixOS/nixpkgs/commit/004c3f3c59fddbfc967ee93ba9adb7792553aa3d) haskellPackages.test-sandbox-compose: fix typo
* [`1b0067e8`](https://github.com/NixOS/nixpkgs/commit/1b0067e88fa0f2dee5bac81cb4ae5f520b58dcf8) kdevelop: fix typo
* [`2367aa7e`](https://github.com/NixOS/nixpkgs/commit/2367aa7eab21a6b829effafeb2eb839b8d2d5fd7) cargo-raze: fix build on darwin
* [`ee4a1a8b`](https://github.com/NixOS/nixpkgs/commit/ee4a1a8b3f5d234a6fe9c951d575c38526b5a1ba) flit: disable tests for PEP 668 ([nixos/nixpkgs⁠#230706](https://togithub.com/nixos/nixpkgs/issues/230706))
* [`4a348ef4`](https://github.com/NixOS/nixpkgs/commit/4a348ef47ea60856351c70c349a964a58d3ac644) spark_2_4, spark_3_1, spark_3_2, spark2: remove
* [`7e72f076`](https://github.com/NixOS/nixpkgs/commit/7e72f076d5f2ce7675db88059f2746e7b08e7d63) netdata: 1.38.1 -> 1.39.0
* [`1073924a`](https://github.com/NixOS/nixpkgs/commit/1073924a1b7c879c1c81d79def657e08d4e5b348) trezor-suite: 22.11.1 -> 23.4.2
* [`91e71916`](https://github.com/NixOS/nixpkgs/commit/91e719166042337f6564f21ff2c2ed9d604853ff) llvm: fix typos
* [`1c736034`](https://github.com/NixOS/nixpkgs/commit/1c73603403c201857c07a5cbf5ff1b4d198abc8e) ueberzugpp: init at 2.8.0
* [`cb3cb2eb`](https://github.com/NixOS/nixpkgs/commit/cb3cb2eb334f70f3e7d377a63f54c752b055a283) mu: fix typo
* [`0acb5e24`](https://github.com/NixOS/nixpkgs/commit/0acb5e2466b2638aef1f27344564536b0b7435ec) gnatcoll-core: fix build on x86_64-darwin
* [`f0397a31`](https://github.com/NixOS/nixpkgs/commit/f0397a3180a3b2f26035ede297c167eb77c93dcc) mydumper: fix typo
* [`16658f76`](https://github.com/NixOS/nixpkgs/commit/16658f763475f33e1e4dce3489c5b30dc137cc79) nixos/netdata: introduce `deadlineBeforeStopSec`
* [`f894efb0`](https://github.com/NixOS/nixpkgs/commit/f894efb0be9c77ef0f647548f520edb3c20f2e35) maintainers: update star-szr
* [`a6bcd9c0`](https://github.com/NixOS/nixpkgs/commit/a6bcd9c0b4c731ce4f38fed181c19337acd17ced) cargo-supply-chain: 0.3.2 -> 0.3.3
* [`290280d6`](https://github.com/NixOS/nixpkgs/commit/290280d67803bf4a03cdcae5bfb49aa8ba218c53) conceal: mark as broken on darwin
* [`d2e06ffe`](https://github.com/NixOS/nixpkgs/commit/d2e06ffe205ca3836a16b27d7fba7e392cc333ec) base16384: init at 2.2.2
* [`87124068`](https://github.com/NixOS/nixpkgs/commit/87124068e361a21ea9f2a6c1254f929179db996f) linuxPackages.ddvb: Mark broken on 6.2+
* [`561c6f2b`](https://github.com/NixOS/nixpkgs/commit/561c6f2b6cbd3dff2d40571889c1ca1cece3a70f) gnatcoll-python3: fix build on x86_64-darwin
* [`cfb2f8e3`](https://github.com/NixOS/nixpkgs/commit/cfb2f8e38e8f5e39dd63a720be10fe6a5fc6b054) skjold: 0.4.1 -> 0.6.1
* [`72429736`](https://github.com/NixOS/nixpkgs/commit/72429736c3cffc10bab7be491568bf7b4a96bf4f) node-packages: fix typo
* [`d454823d`](https://github.com/NixOS/nixpkgs/commit/d454823d203aead2a5536e51b4ef92bd4060ebaf) opencv: fix typo
* [`849897fa`](https://github.com/NixOS/nixpkgs/commit/849897fa300db00a7957d7d94ef88459d7bd4afc) perf-linux: fix typo
* [`0d90723f`](https://github.com/NixOS/nixpkgs/commit/0d90723fb0363a5e991d8e5ac58ebea8214add2b) polypane: fix typo
* [`5214b089`](https://github.com/NixOS/nixpkgs/commit/5214b0890c33cf64114505760245d72475562e11) python3Packages.betterproto: fix typo
* [`2d091690`](https://github.com/NixOS/nixpkgs/commit/2d091690f500908f2d15d78838145d82d397d9b1) python3Packages.extractcode: fix typo
* [`e371de93`](https://github.com/NixOS/nixpkgs/commit/e371de93d1a397e7df2d13f2e5685581998cadf2) python3Packages.notion-client: fix typo
* [`db1bb2d7`](https://github.com/NixOS/nixpkgs/commit/db1bb2d7e8fb3efcf11889e063c39f0dc9b4f33e) python3Packages.os-service-type: fix typo
* [`1ab5058e`](https://github.com/NixOS/nixpkgs/commit/1ab5058e7c9023ca90279f2f8975ddb1a3115c1b) python3Packages.protobuf: fix typo
* [`b1203829`](https://github.com/NixOS/nixpkgs/commit/b12038291dca645e422ecabc353949349ee9bb13) python3Packages.pytest-cases: fix typo
* [`c13a5e7e`](https://github.com/NixOS/nixpkgs/commit/c13a5e7eb68916563c68fd9082ef18a897e5bc28) quicksynergy: fix typo
* [`09aba852`](https://github.com/NixOS/nixpkgs/commit/09aba852bf9d015923287746d80e4b3cca3c9e17) libsForQt5.qtconnectivity: fix build on darwin
* [`03bdcc50`](https://github.com/NixOS/nixpkgs/commit/03bdcc5042f66fe88b9a2caf5d196a214cd2a9e4) inql: fix invalid version specifier
* [`6c7265ca`](https://github.com/NixOS/nixpkgs/commit/6c7265cae4f78a17ac5202bf7c21fc235ebf426b) ocamlPackages.lambdasoup: 0.7.3 → 1.0.0
* [`3edf6e18`](https://github.com/NixOS/nixpkgs/commit/3edf6e18e60dc06a8374f1241b1e450c2aa58e71) gdal: fix build on x86_64-darwin
* [`edf57fef`](https://github.com/NixOS/nixpkgs/commit/edf57fef9be5a9ec629f914561a6ec46ea543bbc) nixos/fzf: fix evaluation if ohMyZsh is enabled
* [`b98d314b`](https://github.com/NixOS/nixpkgs/commit/b98d314b4a449a40677de813f353d60b5c4ab170) spotifywm: make behave as patch instead of separate package
* [`78aa6738`](https://github.com/NixOS/nixpkgs/commit/78aa6738d03b049b2b5a9e889fdd047cb2f9a50e) spotifywm: add the-argus as maintainer
* [`f3b780d9`](https://github.com/NixOS/nixpkgs/commit/f3b780d933a6cc171afca42b5e95e4642d4e3692) spotifywm: don't needlessly propagate spotify
* [`b0a78067`](https://github.com/NixOS/nixpkgs/commit/b0a7806728e3dd26d76f2bd9bff26be30879e242) osmtogeojson: init at 3.0.0-beta.5
* [`17189a59`](https://github.com/NixOS/nixpkgs/commit/17189a599679df90dcb192d55e041f42c07caa69) linuxPackages.ipu6-drivers: Mark broken on 6.3+
* [`d9385a3d`](https://github.com/NixOS/nixpkgs/commit/d9385a3df161e906f44f8535fc4012c39451797a) gabutdm: init at 2.1.5
* [`504893d0`](https://github.com/NixOS/nixpkgs/commit/504893d0ead59885305bef50b6b1f345755ab938) nnn: add desktop file, fix nerd icons, add option to build with emojis
* [`7d8aa990`](https://github.com/NixOS/nixpkgs/commit/7d8aa99067c3c03e82a3010249380353d2fa7ef5) python310Packages.avion: fix specifier
* [`6fbca348`](https://github.com/NixOS/nixpkgs/commit/6fbca348755d5f9c69066f024a3b9de72ee3f2c3) hblock: init at v3.4.1
* [`8d4f643c`](https://github.com/NixOS/nixpkgs/commit/8d4f643c66fcda5b7e427e5ae82a26bc7b74f77d) linux: enable CR50 TPM found on chromebooks
* [`4302b7d1`](https://github.com/NixOS/nixpkgs/commit/4302b7d1999c35814af1a4a36fce9b5a6ec15ba4) _1password-gui: package fixups
* [`14f0233d`](https://github.com/NixOS/nixpkgs/commit/14f0233db845be1eb3047e0de8c4a8fa1d02f64c) python310Packages.papis: 0.12 -> 0.13
* [`8d76c0b6`](https://github.com/NixOS/nixpkgs/commit/8d76c0b6fb552bc61d9e7708c182dd41b4349e44) peertube: 5.0.0 -> 5.1.0
* [`1afcb4c6`](https://github.com/NixOS/nixpkgs/commit/1afcb4c6ef456e33279a16c3a21be1e85ad6ef01) nixos/peertube: update nginx configuration
* [`5c2a7490`](https://github.com/NixOS/nixpkgs/commit/5c2a7490cfb8f98c8a47fd9abedbae745c99df6b) nixos/systemd-repart: fix
* [`8c061c33`](https://github.com/NixOS/nixpkgs/commit/8c061c33a426495df7cbaced2303eeadaed731db) acpica-tools: 20221020 -> 20230331
* [`a8443f15`](https://github.com/NixOS/nixpkgs/commit/a8443f153087c6cc935ca7096f124eac5b61185a) acpica-tools: disable -Werror to fix i686-linux builds
* [`760c58b5`](https://github.com/NixOS/nixpkgs/commit/760c58b59bc3d3770aeec041353359cf0c4d629a) portfolio: 0.62.0 -> 0.62.1
* [`e4d83f71`](https://github.com/NixOS/nixpkgs/commit/e4d83f712908d31c544325972a712c9a91348a39) labplot: fix nix run .#labplot
* [`164edb84`](https://github.com/NixOS/nixpkgs/commit/164edb8468f8ad4c9f22b1e5ffb315f1b0d1b4a8) plausible: mark broken following node-16 deprecation
* [`8aafc553`](https://github.com/NixOS/nixpkgs/commit/8aafc553aeeb7383a0f9066540a5db27e1558876) buildFHSEnv: use default values as fallback for XDG_DATA_DIRS
* [`42f56362`](https://github.com/NixOS/nixpkgs/commit/42f56362b04925fdb62191fbf3bb4c56674eac85) steam: fix missing dependency on gsettings-desktop-schemas
* [`d85abd27`](https://github.com/NixOS/nixpkgs/commit/d85abd2764d672cee626f1f440734f37509443b2) nixos/systemd-repart: definition files in initrd
* [`e47ac004`](https://github.com/NixOS/nixpkgs/commit/e47ac00467cca80fcd50e35ccc4b68b5fca0cee8) strace: 6.2 -> 6.3
* [`c69d499b`](https://github.com/NixOS/nixpkgs/commit/c69d499ba5e50f437ff91926944a83c48727a9b4) python310Packages.tlds: init at 2023050800
* [`be7f4699`](https://github.com/NixOS/nixpkgs/commit/be7f4699c24fda4aa186a869510bf7fd7e5e55e0) python3Packages.afdko: disable one more failing test on i686-linux
* [`91c469d8`](https://github.com/NixOS/nixpkgs/commit/91c469d823909da481d9944541120d47e323b000) sarasa-gothic: 0.40.6 -> 0.40.7
* [`d7550058`](https://github.com/NixOS/nixpkgs/commit/d7550058e0276613b3a2cdddd9cdd4f2f30d9e7f) python310Packages.defusedcsv: init at 2.0.0
* [`3a6716cc`](https://github.com/NixOS/nixpkgs/commit/3a6716ccb9c18ca2b8b9abad0775fe9bcc9498b7) python310Packages.django-i18nfield: init at 1.9.4
* [`38e83e44`](https://github.com/NixOS/nixpkgs/commit/38e83e44040757950e69a358ec82c65bedad03c9) python310Packages.drf-ujson2: init at 1.7.2
* [`07de4d29`](https://github.com/NixOS/nixpkgs/commit/07de4d29146fc6e37bdc72174551facc770f2885) python310Packages.paypalhttp: init at 1.0.0
* [`5e524c51`](https://github.com/NixOS/nixpkgs/commit/5e524c5150e4f93f690488af52a8c9babdd48a99) python310Packages.paypal-checkout-serversdk: init at 1.0.
* [`2a2e8b66`](https://github.com/NixOS/nixpkgs/commit/2a2e8b663c0969de611c9bf0823c3423725124ac) python310Packages.django-mysql: init at 4.9.0
* [`7be2ba70`](https://github.com/NixOS/nixpkgs/commit/7be2ba708efe0db4ae10120ec952c1f39d1797f6) python310Packages.python-u2flib-server: init at 5.0.1
* [`2e546199`](https://github.com/NixOS/nixpkgs/commit/2e546199d3aaa361a37c9dc64f083a3072b6a97b) python310packages.pyuca: init at 1.2
* [`7857ee84`](https://github.com/NixOS/nixpkgs/commit/7857ee842e0ac32e494311a12f250722731eeb35) python310Packages.slimit: init at unstable-2018-08-08
* [`35f4603c`](https://github.com/NixOS/nixpkgs/commit/35f4603c864c2e16b9ea24a8e724eda65f973b5e) python310Packages.static3: init at 0.7.0
* [`cd9a466b`](https://github.com/NixOS/nixpkgs/commit/cd9a466b20c597bc8ab2c3aed5ea61579afb7483) python310Packages.vat-moss: init at 0.11.0
* [`ea1cef8c`](https://github.com/NixOS/nixpkgs/commit/ea1cef8c0015eeda3f64e7c06ea719e8ee762b1e) ArchiSteamFarm.ui: use buildNpmPackage
* [`8950bdb5`](https://github.com/NixOS/nixpkgs/commit/8950bdb5fa94acdecb7d5ee3dedcb37ebdd76742) signalbackup-tools: 20230429 -> 20230508-1
* [`3a0e931d`](https://github.com/NixOS/nixpkgs/commit/3a0e931dc00e5d64960b5628a389dd28594818ad) authy: 2.2.2 -> 2.3.0
* [`8b458f0a`](https://github.com/NixOS/nixpkgs/commit/8b458f0ad0ba580ad0e766b01fd12f2447cc4262) python311Packages.python-rtmidi: disable
* [`22ed6b17`](https://github.com/NixOS/nixpkgs/commit/22ed6b17d29695d88b82603a9d5f881f1291b5f6) qt6Packages.qtkeychain: allow building with qt6
* [`46fadaaa`](https://github.com/NixOS/nixpkgs/commit/46fadaaa0f167c4d023e9bc7dc0c3af40245e313) libquotient: 0.7.1 -> 0.7.2
* [`8d447c56`](https://github.com/NixOS/nixpkgs/commit/8d447c5626cfefb9b129d5b30103344377fe09bc) quaternion: 0.0.95.1 -> 0.0.95.81
* [`0d46a222`](https://github.com/NixOS/nixpkgs/commit/0d46a2221b525ca5c4c8f6440057f73c75d5ad4f) docker-compose-language-service: use nodejs default
* [`f3e0d0af`](https://github.com/NixOS/nixpkgs/commit/f3e0d0af869dae9767e5ea93119e91f27f06759a) benthos: 4.14.0 -> 4.15.0
* [`e138708d`](https://github.com/NixOS/nixpkgs/commit/e138708d302b925c55391908dcfdd7bfacbdcbb9) qdrant: 1.1.1 -> 1.1.3
* [`d058bd6c`](https://github.com/NixOS/nixpkgs/commit/d058bd6c0722531453ba2a9f4b6a729bcb094bd3) minio: 2023-04-28T18-11-17Z -> 2023-05-04T21-44-30Z
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
