### PR TITLE
niv home-manager: update ef9f73e6 -> 8dbc5048

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "knl",
         "repo": "home-manager",
-        "rev": "ef9f73e66415c53720cee597ed765d29e633b2d4",
-        "sha256": "0xvi515l7r4c679vmw2jshjpa7qf4mx18r37aln3mr4lck68xrll",
+        "rev": "8dbc5048b38d7d72943edd88338ef08005597e1a",
+        "sha256": "1fg3iyggymd6p52a0wg482kx8nabird4qf96dwy8j27rsbbnrwad",
         "type": "tarball",
-        "url": "https://github.com/knl/home-manager/archive/ef9f73e66415c53720cee597ed765d29e633b2d4.tar.gz",
+        "url": "https://github.com/knl/home-manager/archive/8dbc5048b38d7d72943edd88338ef08005597e1a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: unbroken
Commits: [knl/home-manager@ef9f73e6...8dbc5048](https://github.com/knl/home-manager/compare/ef9f73e66415c53720cee597ed765d29e633b2d4...8dbc5048b38d7d72943edd88338ef08005597e1a)

* [`788777b5`](https://github.com/knl/home-manager/commit/788777b536df6e4c48fa158a9245c6f8a82beb43) nushell: add envVars attribute ([knl/home-manager⁠#3930](https://togithub.com/knl/home-manager/issues/3930))
* [`514c0a71`](https://github.com/knl/home-manager/commit/514c0a71f47cb80282742d7e4b6913c2c0582c2d) helix: provide more detailed settings description ([knl/home-manager⁠#3932](https://togithub.com/knl/home-manager/issues/3932))
* [`6abb775e`](https://github.com/knl/home-manager/commit/6abb775e75a7f25451781dc704cfe03f27ad7496) himalaya: improve derivation for v0.7.X ([knl/home-manager⁠#3664](https://togithub.com/knl/home-manager/issues/3664))
* [`ae6d5466`](https://github.com/knl/home-manager/commit/ae6d5466bf3ee61f5565f1631a787a7eda68c99d) firefox: support bookmark tags ([knl/home-manager⁠#3942](https://togithub.com/knl/home-manager/issues/3942))
* [`f3824311`](https://github.com/knl/home-manager/commit/f3824311a16cbe70dbaeedc17a97dfcd11901c3f) readline: Add support for keynames ([knl/home-manager⁠#3947](https://togithub.com/knl/home-manager/issues/3947))
* [`38271ead`](https://github.com/knl/home-manager/commit/38271ead8e7b291beb9d3b8312e66c3268796c0a) xfconf: support uint ([knl/home-manager⁠#3946](https://togithub.com/knl/home-manager/issues/3946))
* [`669669fc`](https://github.com/knl/home-manager/commit/669669fcb403e3137dfe599bbcc26e60502c3543) Translate using Weblate (Polish)
* [`a834ddf8`](https://github.com/knl/home-manager/commit/a834ddf88cb2eb4f77b7c0a2d6e2e8e0fb37c4e3) flake: set source path in home-manager tool
* [`c7529068`](https://github.com/knl/home-manager/commit/c7529068002983f4a0489ec625fe51dd1d4ec0c5) flake.lock: Update
* [`3e906060`](https://github.com/knl/home-manager/commit/3e906060a88a6929c40b7170e73e7adf9e84a8a8) docs: Add inline anchors for direct linking to GVariant types
* [`81d5b220`](https://github.com/knl/home-manager/commit/81d5b220cde5860b529e87fdc3aae55718c24030) docs: Fix broken GVariant docs link
* [`cfa5c286`](https://github.com/knl/home-manager/commit/cfa5c2869b535e5e83dac6b04745f673c591e0d2) docs: GVariant dictionaries are already supported
* [`a0ddb8af`](https://github.com/knl/home-manager/commit/a0ddb8af40bee08737170b167e04ab608215d8de) docs: Mention GVariant auto-coercion at the top
* [`13d666dd`](https://github.com/knl/home-manager/commit/13d666dd68d18dd20760662b78e885559f90991d) docs: Mention GVariant format strings
* [`ea29b1a8`](https://github.com/knl/home-manager/commit/ea29b1a8d1e2717581f4db852ad6647fc03bd00d) docs: Add GVariant cross-references
* [`0b4ec666`](https://github.com/knl/home-manager/commit/0b4ec66640ad5a1aa912a2ae7643f9756e71b4a7) dconf: Warn about strict typing of options
* [`6fc82e56`](https://github.com/knl/home-manager/commit/6fc82e56971523acfe1a61dbcb20f4bb969b3990) i3status-rust: revert [knl/home-manager⁠#3938](https://togithub.com/knl/home-manager/issues/3938) ([knl/home-manager⁠#3957](https://togithub.com/knl/home-manager/issues/3957))
* [`01730248`](https://github.com/knl/home-manager/commit/017302483c2c4372e7a680f390d7bb861335d849) xfconf: fix type order ([knl/home-manager⁠#3961](https://togithub.com/knl/home-manager/issues/3961))
* [`de8ba413`](https://github.com/knl/home-manager/commit/de8ba413c578b68ef602c4f4c5909d9636a5bf92) home-environment: honor use-xdg-base-directories
* [`d12ca778`](https://github.com/knl/home-manager/commit/d12ca77844a08b8b44edae0d66be0922544c2172) atuin: Replace dead link in documentation ([knl/home-manager⁠#3962](https://togithub.com/knl/home-manager/issues/3962))
* [`e34fbe18`](https://github.com/knl/home-manager/commit/e34fbe18011483d1aac6f44cd2f03c0c89196812) pass-secret-service: Add dbus file, assert ([knl/home-manager⁠#3953](https://togithub.com/knl/home-manager/issues/3953))
* [`78ceec68`](https://github.com/knl/home-manager/commit/78ceec68f29ed56d6118617e9f0f588bf164067f) xsession: cleanup systemd variables ([knl/home-manager⁠#3636](https://togithub.com/knl/home-manager/issues/3636))
* [`3f3fa731`](https://github.com/knl/home-manager/commit/3f3fa731ad0f99741d4dc98e8e1287b45e30b452) gnome-keyring: fix pass-secret-service assertion ([knl/home-manager⁠#3963](https://togithub.com/knl/home-manager/issues/3963))
* [`983f8a1b`](https://github.com/knl/home-manager/commit/983f8a1bb965b261492123cd8e2d07da46d4d50a) git-cliff: add module
* [`010c2698`](https://github.com/knl/home-manager/commit/010c26987729d6a2e0e19da6df7c3f0465ae03b3) zsh: add `package` option ([knl/home-manager⁠#3945](https://togithub.com/knl/home-manager/issues/3945))
* [`b365342a`](https://github.com/knl/home-manager/commit/b365342adb36fd659a1472dced6f55b706c15162) ledger: add structural `settings` option ([knl/home-manager⁠#3661](https://togithub.com/knl/home-manager/issues/3661))
* [`fa720861`](https://github.com/knl/home-manager/commit/fa720861b5b68536434360aa0ccf0a5fb9060a73) translate-shell: add module ([knl/home-manager⁠#3659](https://togithub.com/knl/home-manager/issues/3659))
* [`f714b170`](https://github.com/knl/home-manager/commit/f714b170315770f5cb34107b17f2925f0aed7dd4) emacs: extend startWithUserSession to start after graphical session ([knl/home-manager⁠#3010](https://togithub.com/knl/home-manager/issues/3010))
* [`622fa737`](https://github.com/knl/home-manager/commit/622fa73725caa1f11ae184e70b406b207875ef9d) beets: add mpdIntegration ([knl/home-manager⁠#3755](https://togithub.com/knl/home-manager/issues/3755))
* [`d9917765`](https://github.com/knl/home-manager/commit/d991776527b641b029a5916597a1261e2f3b4235) taskwarrior: add package option ([knl/home-manager⁠#3768](https://togithub.com/knl/home-manager/issues/3768))
* [`2f6a917a`](https://github.com/knl/home-manager/commit/2f6a917ade976325093dc60abe17cc72bdf3b76e) i3-sway: fix indentation of `bar` blocks ([knl/home-manager⁠#3978](https://togithub.com/knl/home-manager/issues/3978))
* [`6be87366`](https://github.com/knl/home-manager/commit/6be873663e5b16ded72f9b17b984f64be02437f0) ssh: add setEnv option ([knl/home-manager⁠#3935](https://togithub.com/knl/home-manager/issues/3935))
* [`d97e8f88`](https://github.com/knl/home-manager/commit/d97e8f8861a7ad3cb2f72adf5b2cd14ab302c593) systemd: accept derivations as values for systemd options ([knl/home-manager⁠#3974](https://togithub.com/knl/home-manager/issues/3974))
* [`cc9f65d1`](https://github.com/knl/home-manager/commit/cc9f65d104e5227d103a529a9fc3687ef4ccb117) zellij: adds options to integrate with zsh, bash and fish shells ([knl/home-manager⁠#3926](https://togithub.com/knl/home-manager/issues/3926))
* [`a835096f`](https://github.com/knl/home-manager/commit/a835096fd2bcc369f57b76b9b17cc00348f595f5) kitty: add shellIntegration ([knl/home-manager⁠#3759](https://togithub.com/knl/home-manager/issues/3759))
* [`70c8bd08`](https://github.com/knl/home-manager/commit/70c8bd08e6c186e5c628a4e5af6f7ad67cd344b8) zellij: disables shell integrations by default ([knl/home-manager⁠#3981](https://togithub.com/knl/home-manager/issues/3981))
* [`8345a316`](https://github.com/knl/home-manager/commit/8345a3166dd482f98e37b502e30dc56a16da4853) kitty: minor fixes
* [`caa47705`](https://github.com/knl/home-manager/commit/caa47705f791b43feb63f612f2fd13d08275675c) beets: minor fixes
* [`1eac5feb`](https://github.com/knl/home-manager/commit/1eac5febc412b3aa6acc29c705e99d425f180b62) translate-shell: add news entry
* [`19c509a6`](https://github.com/knl/home-manager/commit/19c509a6fa945212e478e5522149117162217bc5) emacs: minor fixes
* [`eec22729`](https://github.com/knl/home-manager/commit/eec22729990ddf53d1e45e74624ddf667cdbe11b) tests: various minor cleanups
* [`130abb8d`](https://github.com/knl/home-manager/commit/130abb8dbdf441be2dbd3c2d42398faeff5d89b1) Translate using Weblate (German)
* [`93849977`](https://github.com/knl/home-manager/commit/938499771727f2a53a19eb178f16fc42ff53a9f8) Translate using Weblate (Japanese)
* [`e0026e16`](https://github.com/knl/home-manager/commit/e0026e16a5beff80f641e4edca318e654baa5a9b) fuzzel: add module
* [`6702b22b`](https://github.com/knl/home-manager/commit/6702b22b9805bc1879715d4111e3764cd4237aed) ssh: install an ssh client
* [`db3d440e`](https://github.com/knl/home-manager/commit/db3d440e2664e8aaf67742b6fd545cf148fe5016) kitty: improve error message when theme not found ([knl/home-manager⁠#3989](https://togithub.com/knl/home-manager/issues/3989))
* [`e4272987`](https://github.com/knl/home-manager/commit/e4272987f785a8848205263abb4911b922c21e1b) Drop CODEOWNERS
