### PR TITLE
niv powerlevel10k: update 0a9eb73e -> 9b47a22f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0a9eb73e161fd4d73140bd90c00c52602cf9aa42",
-        "sha256": "12x01yll48vkckka5j3d584kxczrvrbnlzmsz0zxbfq0zzbwx2pg",
+        "rev": "9b47a22f13402ba95262b66ada569f122f5528a0",
+        "sha256": "16y57mzmjc56glwwzg4v6cgxz5j8r5za8ngsrmjazsrd30qd6lb2",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0a9eb73e161fd4d73140bd90c00c52602cf9aa42.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/9b47a22f13402ba95262b66ada569f122f5528a0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@0a9eb73e...9b47a22f](https://github.com/romkatv/powerlevel10k/compare/0a9eb73e161fd4d73140bd90c00c52602cf9aa42...9b47a22f13402ba95262b66ada569f122f5528a0)

* [`064f4d22`](https://github.com/romkatv/powerlevel10k/commit/064f4d22097a8086eb857f04d11c00eb4b452275) whitelist DCS in startup console output ([romkatv/powerlevel10k⁠#2299](https://togithub.com/romkatv/powerlevel10k/issues/2299))
* [`1dcd8825`](https://github.com/romkatv/powerlevel10k/commit/1dcd8825937e2a58519bef4fb7ef3f0322a91db8) set P9K_STARTUP_CONSOLE_OUTPUT to assist in debugging startup console output problems
* [`9b47a22f`](https://github.com/romkatv/powerlevel10k/commit/9b47a22f13402ba95262b66ada569f122f5528a0) Update README.md
