### PR TITLE
niv nixpkgs: update 118e0e7e -> 273b32ab

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "118e0e7e93ce6211f2f1203b6f20363b19dad335",
-        "sha256": "0bd87b6p3kgfjq25rdsbcrc5ky6abbrbf45lkf0c77kflsyc63bx",
+        "rev": "273b32abe2565301552f0874c97ea954a8db67c9",
+        "sha256": "0nb60mna88z4v05hc0zkh3z12af6gprr6vwzqqw5dxh94hpcbjir",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/118e0e7e93ce6211f2f1203b6f20363b19dad335.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/273b32abe2565301552f0874c97ea954a8db67c9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@118e0e7e...273b32ab](https://github.com/nixos/nixpkgs/compare/118e0e7e93ce6211f2f1203b6f20363b19dad335...273b32abe2565301552f0874c97ea954a8db67c9)

* [`df1243d8`](https://github.com/NixOS/nixpkgs/commit/df1243d8569ae15410e44e87505a03d98c0b1954) nixos/epgstation: fix startup issue
* [`00fe2c7e`](https://github.com/NixOS/nixpkgs/commit/00fe2c7e98b0cb71846566d6375f5baaefbaf80e) nixos/epgstation: set NODE_ENV to "production"
* [`c01ab055`](https://github.com/NixOS/nixpkgs/commit/c01ab055129f503fb09946ef7ba162264ecc31ed) arm-trusted-firmware: 2.7 -> 2.8
* [`ec36d701`](https://github.com/NixOS/nixpkgs/commit/ec36d701273059eecdf1290e4a206068fa7da5e0) mullvad-vpn: add binaries to PATH for GUI launcher script
* [`9dcb0f71`](https://github.com/NixOS/nixpkgs/commit/9dcb0f711272f2abde6d0e0e55f419aeacd82d8d) mullvad-vpn: format with nixpkgs-fmt
* [`4d20bfa2`](https://github.com/NixOS/nixpkgs/commit/4d20bfa277c96d0a831cf7dfce767e9f7dc38c59) python310Packages.bqscales: init at 0.3.1
* [`8e20c592`](https://github.com/NixOS/nixpkgs/commit/8e20c592a94f789cb87c7c79eb686ba425b41c3c) python310Packages.bqplot: init at 0.12.36
* [`d0d1cd1f`](https://github.com/NixOS/nixpkgs/commit/d0d1cd1f4ed2a57b7686ffec64f9aebbea81d218) python310Packages.posix_ipc: fix pythonImportsCheck usage
* [`d4a18327`](https://github.com/NixOS/nixpkgs/commit/d4a1832792089c3d5bc730336c1a31fe60994f34) python310Packages.netcdf4: fix pythonImportsCheck usage
* [`b5641a8e`](https://github.com/NixOS/nixpkgs/commit/b5641a8e7c4a1b570c7fc9864c02f416ba1d947b) python310Packages.gpaw: fix pythonImportsCheck usage
* [`9cae03db`](https://github.com/NixOS/nixpkgs/commit/9cae03dbcdb0ce6fb5bb904d25caf578ab3b4b41) apt-offline: fix pythonImportsCheck usage
* [`58786e0a`](https://github.com/NixOS/nixpkgs/commit/58786e0ac1f49ef8eb824a63527af9896d1657ac) python310Packages.openpyxl: 3.1.1 -> 3.1.2
* [`367eb7b5`](https://github.com/NixOS/nixpkgs/commit/367eb7b59ae41879e126655baffd0a0f4596ba7c) python310Packages.openpyxl: add changelog to meta
* [`6e38489a`](https://github.com/NixOS/nixpkgs/commit/6e38489a88a99a6b41edbfa52393af70a85b33c9) python310Packages.openpyxl: disable on unsupported Python releases
* [`938942a8`](https://github.com/NixOS/nixpkgs/commit/938942a8060eb19c6f065f21bfa34d81d3f86499) python310Packages.openpyxl: update meta
* [`84245134`](https://github.com/NixOS/nixpkgs/commit/84245134332ce762aae4d242df3e0edc511d1221) python310Packages.openpyxl: enable tests
* [`40848756`](https://github.com/NixOS/nixpkgs/commit/4084875660f235974266232bf4b69e8940b2e405) libxcrypt: Add check for enabledCryptSchemeIds
* [`3797e65b`](https://github.com/NixOS/nixpkgs/commit/3797e65be35db31b2660579a1ca831c33fe30745) squashfsTools: enabled LZMA compression support
* [`43e6f67f`](https://github.com/NixOS/nixpkgs/commit/43e6f67f753626765a5b0318fcc99c0a7a317724) nixos/snapper: support more options
* [`01e1c5bd`](https://github.com/NixOS/nixpkgs/commit/01e1c5bd408a6d5298a7c7c7f4ac983470b892ae) albert: 0.17.6 -> 0.20.13
* [`4f01c5e9`](https://github.com/NixOS/nixpkgs/commit/4f01c5e97213a6d844f8db4384b6b917cc402f5c) libosmocore: add janik as maintainer, move to osmocom dir
* [`5bff386a`](https://github.com/NixOS/nixpkgs/commit/5bff386ace6ee1f6caeb39fe8c017f96a642cd47) libasn1c: init at 0.9.35
* [`7de385c2`](https://github.com/NixOS/nixpkgs/commit/7de385c2d2b0d36dda806c8977cd4ea5667c8dfc) libosmoabis: init at 1.4.0
* [`84fe5cce`](https://github.com/NixOS/nixpkgs/commit/84fe5ccedb3793429b65d5f710ac8f086a471d42) osmo-hlr: init at 1.6.1
* [`1457d54a`](https://github.com/NixOS/nixpkgs/commit/1457d54ab12db2e443b2cc80c15119b09f053f92) libosmo-netif: init at 1.3.0
* [`de717798`](https://github.com/NixOS/nixpkgs/commit/de717798994291d0c11fe67fb73842272aa4fff1) libosmo-sccp: init at 1.7.0
* [`a2cae9db`](https://github.com/NixOS/nixpkgs/commit/a2cae9db3c309913f21254521ec2f14907c762d1) osmo-mgw: init at 1.11.1
* [`fd12f22c`](https://github.com/NixOS/nixpkgs/commit/fd12f22cdd903ae7f56aaa2970ea3573261ccdbb) osmo-msc: init at 1.10.0
* [`ffd24c84`](https://github.com/NixOS/nixpkgs/commit/ffd24c84f28d8c8ff047a2bffee5e3bca020f0dd) osmo-bsc: init at 1.9.1
* [`89c5cfec`](https://github.com/NixOS/nixpkgs/commit/89c5cfec7d24dbcfb8ab9a7c3d8766c86aac9c0a) osmo-iuh: init at 1.4.0
* [`f168d499`](https://github.com/NixOS/nixpkgs/commit/f168d4993ee4b0e6838c9d7e6f09dddedbe1317e) osmo-hnbgw: init at 1.4.0
* [`1a416021`](https://github.com/NixOS/nixpkgs/commit/1a4160212a149d7996047de99b8b891d024b6566) osmo-ggsn: init at 1.10.1
* [`5c6abb1c`](https://github.com/NixOS/nixpkgs/commit/5c6abb1c25beed4a3ec26242b08b1f1693316f29) osmo-sgsn: init at 1.10.0
* [`405fe5f5`](https://github.com/NixOS/nixpkgs/commit/405fe5f5b2887f4ae5f02d85beb492cbd8e08ffe) osmo-bts: init at 1.6.0
* [`0c051ec4`](https://github.com/NixOS/nixpkgs/commit/0c051ec4f2047c1fdb398fd5d11d7b97a5d0a23c) osmo-pcu: init at 1.2.0
* [`9933b4d7`](https://github.com/NixOS/nixpkgs/commit/9933b4d78e646a9f53cf45b70b27e4b9498f2279) osmo-hnodeb: init at 0.1.1
* [`b475406d`](https://github.com/NixOS/nixpkgs/commit/b475406db789413f7063b66c29ca31f3e8e74f4a) osmo-sip-connector: init at 1.6.2
* [`aff28842`](https://github.com/NixOS/nixpkgs/commit/aff288424f58905da60931ad86a50a03c7552af3) nixos/mastodon: fixup sidekiq jobClasses assertion
* [`b41c49ee`](https://github.com/NixOS/nixpkgs/commit/b41c49ee2d28a86e2fd4733d1d03cb010d4ddbcf) elk7: 7.17.4 -> 7.17.9
* [`90d55a09`](https://github.com/NixOS/nixpkgs/commit/90d55a091ff3fd20077e997ea9e5832e2994c2e9) livecaptions: init at 0.4.0
* [`cf90064c`](https://github.com/NixOS/nixpkgs/commit/cf90064c7f1113ddc6432f1e665c8991f958138d) python310Packages.aiosqlite: 0.18.0 -> 0.19.0
* [`77c0b522`](https://github.com/NixOS/nixpkgs/commit/77c0b522b7d689294c48fcceb14cb42a39ea5d88) nixos/lib/make-disk-image: do not compile a full arch QEMU to convert images
* [`a22826f4`](https://github.com/NixOS/nixpkgs/commit/a22826f46a93ad5ab08fb2fbf859aa92a58dcc84) nixos/lib/make-(multi|single)-disk-zfs-image: use qemu_kvm (host arch) instead of qemu (all arches)
* [`f9c48388`](https://github.com/NixOS/nixpkgs/commit/f9c4838812e06e69b14f214879fa3fcff4ddaf6d) maintainers/scripts/ec2/amazon-image: use qemu_kvm (host arch) instead of qemu (all arches)
* [`b69534e0`](https://github.com/NixOS/nixpkgs/commit/b69534e0729cbaab649fdbce8643d0760ee42b68) maintainers/scripts/openstack/openstack-image-zfs: use qemu_kvm (host arch) instead of qemu (all arches)
* [`f9d74191`](https://github.com/NixOS/nixpkgs/commit/f9d741912f30cb0819eb426dca03125b54260bc7) nixos/tests/systemd-repart: use qemu_kvm (host arch) instead of qemu (all arches)
* [`c89ec983`](https://github.com/NixOS/nixpkgs/commit/c89ec98379909135e6280ee640ee24d42408869a) amazon-ec2-utils: Fix shebang not being patched
* [`d9f812d2`](https://github.com/NixOS/nixpkgs/commit/d9f812d2fc5452a2794396a90e0ed6a2700adb0d) Remove some binaries installed with Boogie that conflict with Dafny
* [`30124c4a`](https://github.com/NixOS/nixpkgs/commit/30124c4a5f15bb1412a0c4644af68641736dabc2) pkgs.dafny: 2.3.0 -> 3.7.3
* [`d9b3d774`](https://github.com/NixOS/nixpkgs/commit/d9b3d774486f76dfa4c930b86e9a912e454e2220) Some minor fixes, cleanup installed binaries for dafny
* [`11458e36`](https://github.com/NixOS/nixpkgs/commit/11458e36d75efbeddec1d2816b9a9977e9f21347) Use fetchFromGitHub instead of fetchurl
* [`4e5d7a4c`](https://github.com/NixOS/nixpkgs/commit/4e5d7a4ca0d09e37672579b453d1af210ee6ca52) Simplify a deletion
* [`09d1509a`](https://github.com/NixOS/nixpkgs/commit/09d1509ad36c538eea526d04b9f8fe4585b2fbf6) Simplify a deletion in Boogie
* [`38fb7426`](https://github.com/NixOS/nixpkgs/commit/38fb742663922a8e55255bbef6c6bf1fa067738b) rustPlatform.importCargoLock: fix [package] section handling
* [`6efefdc8`](https://github.com/NixOS/nixpkgs/commit/6efefdc8c16fe1c483f35e3c5f6c1de45f5f4e23) buildDotnetModule: add support for dotnet tools
* [`4025de07`](https://github.com/NixOS/nixpkgs/commit/4025de07898e602876cb55ad636ff8857ed7b50f) dafny: add missing deps
* [`a3c2acc9`](https://github.com/NixOS/nixpkgs/commit/a3c2acc931fca975bd51aa0a07180036bfb75c2c) dafny: fix build by simulating gradle
* [`bfebb2de`](https://github.com/NixOS/nixpkgs/commit/bfebb2de80f4ed606b02d95516b99026ad007d64) dafny: fix build by pruning old deps
* [`54149f4b`](https://github.com/NixOS/nixpkgs/commit/54149f4b1d75122d1bdf7ccec7b264b885658150) dafny: 3.7.3 -> 4.0.0
* [`d4f814d9`](https://github.com/NixOS/nixpkgs/commit/d4f814d956f6d5b6d498cb0ce645d1bc3a87a1e1) dafny: move to separate file
* [`c0c08de5`](https://github.com/NixOS/nixpkgs/commit/c0c08de5b438f77698debfec757115cc3e13a5cc) dafny: remove unused deps
* [`4855d9a3`](https://github.com/NixOS/nixpkgs/commit/4855d9a3df84062e99455858c698c80e108adf51) .gitattributes: fix typo
* [`5102f0a7`](https://github.com/NixOS/nixpkgs/commit/5102f0a78d71c6a5b8c8c722cba21a4a556b3754) chickenPackages: separate build phase
* [`290c354d`](https://github.com/NixOS/nixpkgs/commit/290c354d4460556cfccdfc2ff4adcb364c7bce3b) otf2bdf: init at 3.1
* [`f75ad820`](https://github.com/NixOS/nixpkgs/commit/f75ad820a1370a20f80b6943836002c09d39f91f) nodejs_14: is EOL on 2023-04-30
* [`91071ad0`](https://github.com/NixOS/nixpkgs/commit/91071ad0ff6966fb9005e69199407241b16b30fb) yabai: 5.0.2 -> 5.0.4
* [`0782eb2b`](https://github.com/NixOS/nixpkgs/commit/0782eb2b02348cc501a3eb8a6cfcf0d384a0decf) python311Packages.dbus-fast: 1.85.0 -> 1.86.0
* [`4fb59cd0`](https://github.com/NixOS/nixpkgs/commit/4fb59cd0f9a24932bbde9342f1f40907def6079e) mattermost: 7.8.3 -> 7.8.4
* [`c64c9382`](https://github.com/NixOS/nixpkgs/commit/c64c9382ef026bcaa3fc768bcbb52a91604f52af) python310Packages.awswrangler: 2.19.0 -> 3.0.0
* [`6a4e5794`](https://github.com/NixOS/nixpkgs/commit/6a4e5794d3c92e1a02db8a1a8683700bef0a8445) bundlewrap: 4.17.0 -> 4.17.1
* [`ced4c998`](https://github.com/NixOS/nixpkgs/commit/ced4c998272087ee62ad28918bf26d60239e95b9) gotemplate: init at 3.7.2
* [`0e1efc22`](https://github.com/NixOS/nixpkgs/commit/0e1efc2291c25c0620b57f0363d8701d52a9881c) gnome-extension-manager: 0.4.0 -> 0.4.1
* [`d34f3e8f`](https://github.com/NixOS/nixpkgs/commit/d34f3e8f31730a7078f00c58bbc0691363824e65) wavm: init at 2022-05-14
* [`cc41b47c`](https://github.com/NixOS/nixpkgs/commit/cc41b47c6f4fbc841dd4bdb89e11d7c00e42e76a) nixos/lib: hash triggers after converting them to string in systemd-lib
* [`4bf5f14f`](https://github.com/NixOS/nixpkgs/commit/4bf5f14f100e7be19be4492c73d03ed3354c9d90) bundlewrap: 4.17.1 -> 4.17.2
* [`5d3e887c`](https://github.com/NixOS/nixpkgs/commit/5d3e887cb5221b659ad0e24029b7f1bb530631aa) winbox: 3.37 -> 3.38
* [`59310002`](https://github.com/NixOS/nixpkgs/commit/593100029e5cae7e20015c917390086fb8b59cb7) python310Packages.wandb: 0.15.0 -> 0.15.2
* [`85a722b7`](https://github.com/NixOS/nixpkgs/commit/85a722b7b08079af13d68beb3d58a95de5306345) vsce: 2.15.0 -> 2.19.0
* [`f68ae132`](https://github.com/NixOS/nixpkgs/commit/f68ae132f843f17e4a3fb881e49b032026450d48) nodejs_16: also mark EOL
* [`e9d434cd`](https://github.com/NixOS/nixpkgs/commit/e9d434cd0354f3d9da4b310c57dfbacfb9735219) gnuplot: fix cross-compilation by disabling docs and demos
* [`b4ce2478`](https://github.com/NixOS/nixpkgs/commit/b4ce2478b6986693e9f1c8d0cf8e40f19765eeff) nodePackages: add script to remove attrs for aliases
* [`95951134`](https://github.com/NixOS/nixpkgs/commit/95951134807baa62b5488898cb62aa54991c1f5e) nixos/openrgb: fix data dir & amd i2c
* [`6ad25364`](https://github.com/NixOS/nixpkgs/commit/6ad253649458680e9444524e9c488fed9b449354) xp-pen-deco-01-v2-driver: 3.3.9 -> 3.2.4
* [`e7642984`](https://github.com/NixOS/nixpkgs/commit/e764298465fec2fd3e07f6794413622ec494d5d7) emacs.pkgs.treesit-grammars: init fake package
* [`0088a924`](https://github.com/NixOS/nixpkgs/commit/0088a924e98c991edf006305ecbe4fe925fc22ed) nodePackages: make json file formatting consistent
* [`ffc1e6da`](https://github.com/NixOS/nixpkgs/commit/ffc1e6da3cfad0f83ebe9eb34f845254273559cd) qownnotes: 23.5.0 -> 23.5.3
* [`dd2c3b13`](https://github.com/NixOS/nixpkgs/commit/dd2c3b1310963d5c2c2fbfa1677d4d213bb6ce1a) nixos/lxc-container: ensure /sbin/init is updated on nixos-rebuild boot
* [`ada7f142`](https://github.com/NixOS/nixpkgs/commit/ada7f14219b6cb50d766c28aa64164d17f8bc2d6) kubo: 0.19.2 -> 0.20.0
* [`69055c4a`](https://github.com/NixOS/nixpkgs/commit/69055c4ad5795e9af430fc427ce60d20eba2c403) python3Packages.uptime-kuma-api: 0.10.0 -> 0.13.0
* [`c2690b65`](https://github.com/NixOS/nixpkgs/commit/c2690b6544838e149819eeafd0be842b0aab1e48) alice-lg: init at 6.0.0
* [`3cc08f8a`](https://github.com/NixOS/nixpkgs/commit/3cc08f8a51ee4c7f03ddaf1074bfd25d3b8e5a83) all-cabal-hashes: 2023-04-29T17:51:14Z -> 2023-05-10T18:33:26Z
* [`27fc9be1`](https://github.com/NixOS/nixpkgs/commit/27fc9be18d59b977c2e5dccb97c88712e703f2f9) haskellPackages: stackage LTS 20.19 -> LTS 20.20
* [`5bedf1dd`](https://github.com/NixOS/nixpkgs/commit/5bedf1ddff49973a6be0f08e44878078064d6c05) haskellPackages: regenerate package set based on current config
* [`bacda588`](https://github.com/NixOS/nixpkgs/commit/bacda5885c67735b7d72692827b89fd10e3fbe7d) haskellPackages.utility-ht: drop obsolete override
* [`dda78940`](https://github.com/NixOS/nixpkgs/commit/dda789409e32aa58c43b737b7299f4c309b43ca9) python310Packages.sqlalchemy: 2.0.9 -> 2.0.13
* [`2467a8ef`](https://github.com/NixOS/nixpkgs/commit/2467a8efeb31aafd00ee2b49a117106558fea19a) python3Packages.uptime-kuma-api: add changelog to meta
* [`cd96817b`](https://github.com/NixOS/nixpkgs/commit/cd96817b29c9299d36b1916a84b9c07bd89b5c19) buildFHSEnvBubblewrap: escape runScript path
* [`bd3a5d09`](https://github.com/NixOS/nixpkgs/commit/bd3a5d095cc80e1bf03c2c6d7b00e51c1e5933eb) stress-ng: 0.15.06 -> 0.15.07
* [`474775b0`](https://github.com/NixOS/nixpkgs/commit/474775b07b0d142830b4004369cd41846c95799e) python310Packages.cloudsmith-api: 2.0.1 -> 2.0.2
* [`cb0cd0ac`](https://github.com/NixOS/nixpkgs/commit/cb0cd0ac2fa7d7522adc67eeb7235d5ac3074f96) libmysqlconnectorcpp: 8.0.32 -> 8.0.33
* [`bff6c679`](https://github.com/NixOS/nixpkgs/commit/bff6c67911ed74cf560bd2b00fb1da32bd2fed63) python.pipInstallHook: avoid producing wrong direct_url.json file
* [`05129aab`](https://github.com/NixOS/nixpkgs/commit/05129aab01a352e6f46487633820d9d75681538d) nixos/lib: save triggers of systemd into nix store
* [`ce61ac4a`](https://github.com/NixOS/nixpkgs/commit/ce61ac4ae42549cf031f104d1e9c7725e9b12b18) python310Packages.ignite: 0.4.11 -> 0.4.12
* [`56226c46`](https://github.com/NixOS/nixpkgs/commit/56226c4674d43c086ab8cf4e2be8656afcac4918) make-squashfs: use `__structuredAttrs`
* [`ea81a246`](https://github.com/NixOS/nixpkgs/commit/ea81a2465eeef6d470786a4e8a8c5d8e9b5db9f3) make-iso9660-image: use `__structuredAttrs`
* [`c0996593`](https://github.com/NixOS/nixpkgs/commit/c09965934936988a99cd4570f09aeb0ad77a2003) python311Packages.croniter: 1.3.8 -> 1.3.14
* [`6953c766`](https://github.com/NixOS/nixpkgs/commit/6953c7664e08bdced7f948fe437a62c93a696575) pdm: 2.5.2 -> 2.6.1
* [`6ed3e360`](https://github.com/NixOS/nixpkgs/commit/6ed3e360a4ea5bad857eb740dedfe7312e9a7899) linkerd: 2.13.2 -> 2.13.3
* [`5bdf6381`](https://github.com/NixOS/nixpkgs/commit/5bdf63819b383c47aad629ec3fe404b77a6b58a3) nixos/top-level.nix: Add system.checks
* [`2e2f0d28`](https://github.com/NixOS/nixpkgs/commit/2e2f0d28ea8e3873f57aec6ed517dab8f6494c11) nixos: Use checks instead of extraDependencies
* [`27d23bac`](https://github.com/NixOS/nixpkgs/commit/27d23bace970e86869f2d70a9582a8be9a2bc3cc) calico-*: Set platforms to Linux only
* [`ed99fb0f`](https://github.com/NixOS/nixpkgs/commit/ed99fb0f5c2693787a54eb61e3906e7e309d6081) python310Packages.ndindex: 1.6 -> 1.7
* [`a958b2a1`](https://github.com/NixOS/nixpkgs/commit/a958b2a126c5bae7b9b7fa8b3dbf480704a9dbff) ledger-live-desktop: 2.57.0->2.58.0
* [`c5629915`](https://github.com/NixOS/nixpkgs/commit/c56299151cbbd9804f6a2e5aac3364355d9a9baf) postgresql_11: 11.19 -> 11.20
* [`b201c295`](https://github.com/NixOS/nixpkgs/commit/b201c295c73892f7d607e78174a64a2f45d5e609) postgresql_12: 12.14 -> 12.15
* [`370e6c89`](https://github.com/NixOS/nixpkgs/commit/370e6c896d2cd9a596bd849a99f6a16da6971e2d) postgresql_13: 13.10 -> 13.11
* [`08b80543`](https://github.com/NixOS/nixpkgs/commit/08b80543669b063db79bb1202220006c2e945de4) postgresql_14: 14.7 -> 14.8
* [`3abafec0`](https://github.com/NixOS/nixpkgs/commit/3abafec08f228c6c592c8d7f8b449dff00bdb702) postgresql_15: 15.2 -> 15.3
* [`677ef435`](https://github.com/NixOS/nixpkgs/commit/677ef435c397a7e19997525d109648dcbaaf64ce) proxysql: 2.5.1 -> 2.5.2
* [`93c02649`](https://github.com/NixOS/nixpkgs/commit/93c026494ad5e2902d9e1afc10015f453c77f918) rshim-user-space: init at 2.0.7
* [`d921f741`](https://github.com/NixOS/nixpkgs/commit/d921f741f70555c645beaab0eef067a7619db5b4) maintainers: add kidanger
* [`efbcbc56`](https://github.com/NixOS/nixpkgs/commit/efbcbc56117ce738227e54fadc147f349ac8892c) graylog: init at 4.0.8, 4.3.8, 5.0.6
* [`e6776498`](https://github.com/NixOS/nixpkgs/commit/e6776498deb01f7945d57645c8ed04d25dd81bf5) maintainers: add f2k1de
* [`117f6944`](https://github.com/NixOS/nixpkgs/commit/117f6944c73de13bc488cdb98879547f45001d75) aliases: add graylog
* [`20060ea7`](https://github.com/NixOS/nixpkgs/commit/20060ea7697893f539965c2323548a8543e49fdc) JXplorer: init at 3.3.1.2
* [`c7629a78`](https://github.com/NixOS/nixpkgs/commit/c7629a78b771521edf3db96bd8fbab0ae72b2604) graylog: let the user decide which version of graylog to use
* [`33109727`](https://github.com/NixOS/nixpkgs/commit/331097278592500c55e9c67fc505b42457cdfd75) androidenv: update repo.json with a new strategy to expire
* [`578b1cd8`](https://github.com/NixOS/nixpkgs/commit/578b1cd844e30d257af47162df000662e717e7ab) unityhub: update FHS dep openssl_1_1 -> openssl_3
* [`16ad0ec3`](https://github.com/NixOS/nixpkgs/commit/16ad0ec345e1f54f64d3b05d568c3746b701edb8) electron-fiddle: 0.32.1 → 0.32.6
* [`85a7b22c`](https://github.com/NixOS/nixpkgs/commit/85a7b22c6e3fea97f2b0b6b9435c6c6298157b58) nixos/maintainers/scripts/cloudstack/cloudstack-image.nix: get rid of `with lib`
* [`0a1db386`](https://github.com/NixOS/nixpkgs/commit/0a1db3863228537d88667e0731fe7af5d9912a60) nixos/maintainers/scripts/lxd/lxd-image-inner.nix: get rid of `with lib`
* [`80f0839f`](https://github.com/NixOS/nixpkgs/commit/80f0839fde4c38ebce05a4f896542f9bd56d9e7c) nixos/maintainers/scripts/lxd/lxd-image.nix: get rid of `with lib`
* [`1be3d363`](https://github.com/NixOS/nixpkgs/commit/1be3d3633602fe85821990d0c054ce6b040e7b34) nixos/maintainers/scripts/lxd/nix.tpl: get rid of `with lib`
* [`4c6a1417`](https://github.com/NixOS/nixpkgs/commit/4c6a14172058ba37527da454f37a513d35a3a1c7) nixos/modules/rename.nix: get rid of `with lib`
* [`d87f1b8c`](https://github.com/NixOS/nixpkgs/commit/d87f1b8c9f6060319b277f089f6e698de3fd1567) nixos/tests/hardened.nix: get rid of `with lib`
* [`5bba43ec`](https://github.com/NixOS/nixpkgs/commit/5bba43ec576f2d8ffb4119c2383233df8f912398) nixos/tests/nfs/kerberos.nix: get rid of `with lib`
* [`dc5919aa`](https://github.com/NixOS/nixpkgs/commit/dc5919aa58b1967264f07459fd6343ed3d4bc9de) nixos/tests/quake3.nix: get rid of `with lib`
* [`047734d8`](https://github.com/NixOS/nixpkgs/commit/047734d8e6bc7aa8c4b26cdaf583e6ab9cf3d4ac) nixos/tests/boot-stage1.nix: get rid of `with lib`
* [`b5a6dff6`](https://github.com/NixOS/nixpkgs/commit/b5a6dff664b0f60a4e9fde6f48e1e97def093b20) nixos/tests/budgie.nix: get rid of `with lib`
* [`87586867`](https://github.com/NixOS/nixpkgs/commit/87586867d6b73a4bbd8578da478a4e20257a2799) nixos/tests/calibre-web.nix: get rid of `with lib`
* [`7aa945d9`](https://github.com/NixOS/nixpkgs/commit/7aa945d9496f3fee0184e939052ce94d30079430) nixos/tests/cinnamon.nix: get rid of `with lib`
* [`4e180394`](https://github.com/NixOS/nixpkgs/commit/4e180394490ee15caeb742982e7f3bb6e27bca94) nixos/tests/convos.nix: get rid of `with lib`
* [`defe8992`](https://github.com/NixOS/nixpkgs/commit/defe8992398696ff8ef97201e1536e371db2ab59) nixos/tests/fluidd.nix: get rid of `with lib`
* [`b51ac3bd`](https://github.com/NixOS/nixpkgs/commit/b51ac3bd4c4dffb8b4e99df763b596fa0e9e41df) nixos/tests/gnome-flashback.nix: get rid of `with lib`
* [`ca96a578`](https://github.com/NixOS/nixpkgs/commit/ca96a578a54963c2400de0d4592796d781093d5b) nixos/tests/gnome-xorg.nix: get rid of `with lib`
* [`3002c44f`](https://github.com/NixOS/nixpkgs/commit/3002c44f4811f0c32ebb82251c41e3917dedf9fb) nixos/tests/gnome.nix: get rid of `with lib`
* [`d1a2a4cb`](https://github.com/NixOS/nixpkgs/commit/d1a2a4cbccd45e7ff3b32c0f073eb04d42651329) nixos/tests/hibernate.nix: get rid of `with lib`
* [`70e8a86b`](https://github.com/NixOS/nixpkgs/commit/70e8a86b2b1e06c8daec4120c5c506f9674b7e5c) nixos/tests/pantheon.nix: get rid of `with lib`
* [`71418004`](https://github.com/NixOS/nixpkgs/commit/714180048b5cf2ea0baa4fbc1632669882f1da0d) nixos/tests/redis.nix: get rid of `with lib`
* [`f872db7a`](https://github.com/NixOS/nixpkgs/commit/f872db7aed7bec423dbe332cc2946f2db5bbc57f) nixos/tests/ulogd.nix: get rid of `with lib`
* [`75a76768`](https://github.com/NixOS/nixpkgs/commit/75a76768fe9d81f38f3640862805c2d9086445f4) nixos/tests/xautolock.nix: get rid of `with lib`
* [`5202b743`](https://github.com/NixOS/nixpkgs/commit/5202b743058166133051bbf980cba8136b97f093) nixos/tests/3proxy.nix: get rid of `with lib`
* [`5252e855`](https://github.com/NixOS/nixpkgs/commit/5252e855952c555469f081306584dd8a12959ded) nixos/tests/apparmor.nix: get rid of `with lib`
* [`a4af083f`](https://github.com/NixOS/nixpkgs/commit/a4af083f62896a460d6904d13a099672c4fb6563) nixos/tests/atuin.nix: get rid of `with lib`
* [`6d1287bb`](https://github.com/NixOS/nixpkgs/commit/6d1287bb756d22111e3770fbd24cb43629152759) nixos/tests/bazarr.nix: get rid of `with lib`
* [`ba6bc92d`](https://github.com/NixOS/nixpkgs/commit/ba6bc92d5edeb9cc8055bb43e767dcb84a6d9f37) nixos/tests/cadvisor.nix: get rid of `with lib`
* [`334b1689`](https://github.com/NixOS/nixpkgs/commit/334b168990a27099ae0a42bc3b9fe6b88c146adc) nixos/tests/common/acme/server/default.nix: get rid of `with lib`
* [`5ee5e4bb`](https://github.com/NixOS/nixpkgs/commit/5ee5e4bb465cd7530e5f01de779334ca6cdc7870) nixos/tests/common/auto.nix: get rid of `with lib`
* [`a137b416`](https://github.com/NixOS/nixpkgs/commit/a137b4161d6b7ccb4312dc07c5c90ccaa85e5a85) nixos/tests/couchdb.nix: get rid of `with lib`
* [`18d90beb`](https://github.com/NixOS/nixpkgs/commit/18d90beb1ad6ad9703937752837f0d326913c6c9) nixos/tests/doas.nix: get rid of `with lib`
* [`1792f2c6`](https://github.com/NixOS/nixpkgs/commit/1792f2c61c78d6232e8597b574c2b096420c7193) nixos/tests/doh-proxy-rust.nix: get rid of `with lib`
* [`49483ab7`](https://github.com/NixOS/nixpkgs/commit/49483ab7689dd20013a75dbd01d7e681faaf8747) nixos/tests/esphome.nix: get rid of `with lib`
* [`9bdb3ee1`](https://github.com/NixOS/nixpkgs/commit/9bdb3ee1755f2da2f410712147d18520a61b8133) nixos/tests/hadoop/hdfs.nix: get rid of `with lib`
* [`081a3c1f`](https://github.com/NixOS/nixpkgs/commit/081a3c1fbec0bc4743442a131ac25b31d0bdc434) nixos/tests/iftop.nix: get rid of `with lib`
* [`cb95162f`](https://github.com/NixOS/nixpkgs/commit/cb95162f89fa71d71d00efd566bbf4126b7abd0e) nixos/tests/jackett.nix: get rid of `with lib`
* [`67fd24d5`](https://github.com/NixOS/nixpkgs/commit/67fd24d50920ab63f7f54b27e016205b19a1a819) nixos/tests/jirafeau.nix: get rid of `with lib`
* [`80042b4c`](https://github.com/NixOS/nixpkgs/commit/80042b4cd3dd8f19bf3450b6ba4c99c1d8f4488a) nixos/tests/komga.nix: get rid of `with lib`
* [`9f34f195`](https://github.com/NixOS/nixpkgs/commit/9f34f195e1bd8a96c58743ce526ebd98a9df5342) nixos/tests/libreddit.nix: get rid of `with lib`
* [`63517032`](https://github.com/NixOS/nixpkgs/commit/635170328010cca3d9e84bd6d332d66053139114) nixos/tests/lidarr.nix: get rid of `with lib`
* [`13dc33c7`](https://github.com/NixOS/nixpkgs/commit/13dc33c7ac8b292cabaeab3739179c2547893f39) nixos/tests/miniflux.nix: get rid of `with lib`
* [`ca916d0f`](https://github.com/NixOS/nixpkgs/commit/ca916d0f614d2cf505e7fcb0f8a65c348d851111) nixos/tests/misc.nix: get rid of `with lib`
* [`aa7d79c0`](https://github.com/NixOS/nixpkgs/commit/aa7d79c0f6784e367c311d7ee656a428b6dcd006) nixos/tests/mpv.nix: get rid of `with lib`
* [`2e4a81b2`](https://github.com/NixOS/nixpkgs/commit/2e4a81b23ab08a60def6d9cc0861abc8f660fbfc) nixos/tests/n8n.nix: get rid of `with lib`
* [`757b9f1b`](https://github.com/NixOS/nixpkgs/commit/757b9f1be6abac8674679617d2cfc64616205c66) nixos/tests/noto-fonts.nix: get rid of `with lib`
* [`98f50648`](https://github.com/NixOS/nixpkgs/commit/98f50648847d0118359baecda8cdc9feda4bdffd) nixos/tests/nzbhydra2.nix: get rid of `with lib`
* [`56934ebe`](https://github.com/NixOS/nixpkgs/commit/56934ebec436a3baa375629977375a58bc7dcb82) nixos/tests/oci-containers.nix: get rid of `with lib`
* [`196debcf`](https://github.com/NixOS/nixpkgs/commit/196debcf296540849a639becb2916f70d92544ea) nixos/tests/odoo.nix: get rid of `with lib`
* [`4e9cdcb6`](https://github.com/NixOS/nixpkgs/commit/4e9cdcb64ee36d68acc2f6ab013c5aecb9526942) nixos/tests/ombi.nix: get rid of `with lib`
* [`8cc0632c`](https://github.com/NixOS/nixpkgs/commit/8cc0632c464c0390c16a8e32c8b59b5ade6c2899) nixos/tests/please.nix: get rid of `with lib`
* [`a8790192`](https://github.com/NixOS/nixpkgs/commit/a8790192f3634328236924a9ba41cd459a38322b) nixos/tests/polaris.nix: get rid of `with lib`
* [`cb47374b`](https://github.com/NixOS/nixpkgs/commit/cb47374b5e187bbc3ef8d97f1e528db3f94d2f78) nixos/tests/prowlarr.nix: get rid of `with lib`
* [`2f459bb0`](https://github.com/NixOS/nixpkgs/commit/2f459bb0c48fdea41137c78b1efa3ce6f1bb9f3d) nixos/tests/radarr.nix: get rid of `with lib`
* [`1b26f82e`](https://github.com/NixOS/nixpkgs/commit/1b26f82eede5dd6ac3af663f6dde9b3cc1d430c5) nixos/tests/readarr.nix: get rid of `with lib`
* [`5f00f1f4`](https://github.com/NixOS/nixpkgs/commit/5f00f1f49c38ded052d6e76853ebd21fa3b48dba) nixos/tests/sonarr.nix: get rid of `with lib`
* [`bef35b3b`](https://github.com/NixOS/nixpkgs/commit/bef35b3b88b0b3072d6a971d3e155d3055bc1ec9) nixos/tests/sudo.nix: get rid of `with lib`
* [`07b75a58`](https://github.com/NixOS/nixpkgs/commit/07b75a58e1664dc0913c2a1a5d0a6635987fe9ce) nixos/tests/systemd-timesyncd.nix: get rid of `with lib`
* [`de2927e3`](https://github.com/NixOS/nixpkgs/commit/de2927e336fd653cb805afe8af8ed3006ff2dedf) nixos/tests/tor.nix: get rid of `with lib`
* [`9fe5926b`](https://github.com/NixOS/nixpkgs/commit/9fe5926b1553272ed34a5ed99aa141870ab6d960) nixos/tests/uptime-kuma.nix: get rid of `with lib`
* [`21b0935d`](https://github.com/NixOS/nixpkgs/commit/21b0935d38efb2ade3bf6d9a08ab9211eeef4497) nixos/tests/xss-lock.nix: get rid of `with lib`
* [`6955c0c0`](https://github.com/NixOS/nixpkgs/commit/6955c0c03b1736a5fa57730f56085cb1f5703038) nixos/tests/yabar.nix: get rid of `with lib`
* [`aec8ddde`](https://github.com/NixOS/nixpkgs/commit/aec8dddef7af66a7a4dc93449a23bdf638d342b6) nixos/tests/gitlab.nix: get rid of `with lib`
* [`7efdfdce`](https://github.com/NixOS/nixpkgs/commit/7efdfdce8072d89949c7f251d1892ea5089840ac) sof-firmware: 2.2.4 -> 2.2.5
* [`21763334`](https://github.com/NixOS/nixpkgs/commit/217633348b08a5c6e49ced153a06dd8959dc7f96) shikane: init at 0.2.0
* [`bd77a751`](https://github.com/NixOS/nixpkgs/commit/bd77a7517c0f6fb7740037b19d737bd03ceefe9c) python310Packages.tensorrt: fix pythonImportsCheck usage
* [`7b50880a`](https://github.com/NixOS/nixpkgs/commit/7b50880a5f6b47e62d374f7c8a5853f03bdafb74) python310Packages.dvc-ssh: fix pythonImportsCheck usage
* [`a49541f0`](https://github.com/NixOS/nixpkgs/commit/a49541f0c782a406b551a73390bf5819fe7e59cd) python310Packages.dvc-gs: fix pythonImportsCheck usage
* [`813f2635`](https://github.com/NixOS/nixpkgs/commit/813f263511ae4382881f48b8ae15bb1fad27e6e4) grpc: 1.54.0 -> 1.54.2
* [`52f92673`](https://github.com/NixOS/nixpkgs/commit/52f9267369b6d23bff90515d16b10877054f32ed) python310Packages.dvc-azure: fix pythonImportsCheck usage
* [`d4cc1658`](https://github.com/NixOS/nixpkgs/commit/d4cc1658d9b3a6485af5d326b2845573700a032a) python310Packages.grpcio-tools: 1.54.0 -> 1.54.2
* [`26f6badb`](https://github.com/NixOS/nixpkgs/commit/26f6badb14b4d6c7c5e36cd4a67396a0fb006353) bundler: 2.4.12 -> 2.4.13
* [`5ffbdcdc`](https://github.com/NixOS/nixpkgs/commit/5ffbdcdcaaa8fc50142f226f1fd3f1d6981693e3) python310Packages.dvc-s3: fix pythonImportsCheck usage
* [`2093048e`](https://github.com/NixOS/nixpkgs/commit/2093048e1de653966bcb55eef812687725234f56) python310Packages.grpcio-status: 1.54.0 -> 1.54.2
* [`a9610a4d`](https://github.com/NixOS/nixpkgs/commit/a9610a4dde74873fc039e50170e40b4270ff2cec) ruby.rubygems: 3.4.12 -> 3.4.13
* [`5ffdf341`](https://github.com/NixOS/nixpkgs/commit/5ffdf341ffa7d8a91d57ef463c161d47fbf88809) faiss: fix pythonImportsCheck usage in comment
* [`d2c39ba0`](https://github.com/NixOS/nixpkgs/commit/d2c39ba0b07ef77e7be941687a2235da7f2385f2) tests.pkg-config.defaultPkgConfigPackages: fix cross compilation
* [`9efcaa10`](https://github.com/NixOS/nixpkgs/commit/9efcaa10c5c8a409684935cb921450f1b8007523) python311Packages.boto: fix build
* [`31edd356`](https://github.com/NixOS/nixpkgs/commit/31edd356923369bc09cccefb85abc5affd368eb4) zammad: 5.1.1 -> 5.4.1
* [`dbb940f4`](https://github.com/NixOS/nixpkgs/commit/dbb940f433142d933a54e94f1827f0d09536f138) nixos/zfs: disable unlock timeout with systemd
* [`fac13da6`](https://github.com/NixOS/nixpkgs/commit/fac13da65cac5f54ac7d2422baedaeb8ee264302)  ledger-live-desktop: 2.57.0->2.58.0
* [`14a440a5`](https://github.com/NixOS/nixpkgs/commit/14a440a59818ae5ee1b3a3caeb0d85b85ba0eb36) python310Packages.bayespy: add patch to fix deprecated numpy types
* [`27ce8eb0`](https://github.com/NixOS/nixpkgs/commit/27ce8eb0d1a5c2c9a9d181c748d52892d98555f4) python3.pkgs.wrapt: build offline documentation
* [`7212cbc7`](https://github.com/NixOS/nixpkgs/commit/7212cbc712093bf212d96011503ccd18578f7689) xorg.libxcvt: 0.1.1 -> 0.1.2
* [`be9c774c`](https://github.com/NixOS/nixpkgs/commit/be9c774c1472c0f2e8bf8c570af53449998702b2) python311Packages.brian2: add patch to fix deprecated numpy types
* [`101f4b5a`](https://github.com/NixOS/nixpkgs/commit/101f4b5afdb0a323e9f6b4c08b8568930ee56871) linuxPackages.nvidia_x11_legacy470: kernel 6.4 support
* [`f6ad55ab`](https://github.com/NixOS/nixpkgs/commit/f6ad55ab2fb2247b9350be6a10134a98becc64f6) linuxPackages.nvidia_x11: kernel 6.4 support
* [`af114e54`](https://github.com/NixOS/nixpkgs/commit/af114e543f814d772f0107c668038819e03fa5ad) linuxPackages.nvidia_x11_legacy370: fix up to kernel 6.3
* [`0b14e79f`](https://github.com/NixOS/nixpkgs/commit/0b14e79f1ca4b1722d222d8a089f5ee961be1a91) linuxPackages.nvidia_x11_legacy390: mark broken on linux 6.2
* [`e6d4b3b1`](https://github.com/NixOS/nixpkgs/commit/e6d4b3b10191a42e5dd5ad51079a9d7e45c72a00) keycloak-metrics-spi: 2.5.3 -> 3.0.0
* [`8028e8ae`](https://github.com/NixOS/nixpkgs/commit/8028e8ae73a9024faa0a00e42924e6e4f9e49484) keycloak: 20.0.5 -> 21.1.1
* [`3f1ff3ed`](https://github.com/NixOS/nixpkgs/commit/3f1ff3edafcb0a060f44caa19025a5fc1a7a3782) mpvScripts.webtorrent-mpv-hook: fix build on aarch64-linux
* [`f3f709af`](https://github.com/NixOS/nixpkgs/commit/f3f709af742fa6a78fb6bf76b4ab1614144236cd) nixos/vikunja: add 'port' option
* [`b981ba28`](https://github.com/NixOS/nixpkgs/commit/b981ba288c463ea8e0f2d476e3bd8a9525e15d39) nixos/vikunja: test 'port' option
* [`d0c183ac`](https://github.com/NixOS/nixpkgs/commit/d0c183ac29e095f63baf5b914795c6f82457b20d) orogene: init at 0.3.25
* [`3948414c`](https://github.com/NixOS/nixpkgs/commit/3948414cc773fdafb7d7535a449532418afb9f1f) win-virtio: 0.1.196-1 -> 0.1.229-1
* [`0e6443b4`](https://github.com/NixOS/nixpkgs/commit/0e6443b440a35cbce79ba49d1380756faadf916e) win-virtio: refactor
* [`b3d29db3`](https://github.com/NixOS/nixpkgs/commit/b3d29db31ed1d57b439583d0fb9fc710176d602f) vimPlugins: update
* [`c90b977c`](https://github.com/NixOS/nixpkgs/commit/c90b977cdf549011017a7ca49a41ec5c1dc5693d) vimPlugins.nvim-treesitter: update grammars
* [`4b176f4e`](https://github.com/NixOS/nixpkgs/commit/4b176f4ec4843ceadaa444c5e879eb74edb2f229) vimPlugins.openscad-nvim: fix patch
* [`89f389dd`](https://github.com/NixOS/nixpkgs/commit/89f389dd941b4d85c10651f1b5f1c5f5db97f173) nvidia_x11: replace pre/postPatch with patchFlags
* [`64b347a3`](https://github.com/NixOS/nixpkgs/commit/64b347a30a7f82d9746bf95a34a648360c1199f4) betterlockscreen: make dunst optional
* [`9b9eaf02`](https://github.com/NixOS/nixpkgs/commit/9b9eaf0208516f4f72ad64b2c6d8e672ccf480d1) insync: superceded by insync-v3
* [`7a6a78c9`](https://github.com/NixOS/nixpkgs/commit/7a6a78c9700cf0205975ae07e0b04c2e3442fc8c) insync-v3: remove
* [`11b96796`](https://github.com/NixOS/nixpkgs/commit/11b967964222e17ea69e33bab13d1bba7156d7bc) insync: 3.3.5.40925 -> 3.8.5.50499
* [`c3b69fdb`](https://github.com/NixOS/nixpkgs/commit/c3b69fdb05e86fcd5d6e621ec036706afbc0fde9) python311Packages.mizani: 0.8.1 -> 0.9.0
* [`01a31b8c`](https://github.com/NixOS/nixpkgs/commit/01a31b8c2dd573caf2cbfedbbaabd8c2fae2812e) blender: enable wayland
* [`71d6ed69`](https://github.com/NixOS/nixpkgs/commit/71d6ed698f6a6228fe97f69ea761614dd602a8bd) nixos/gnupg: default to qt pinentry program in deepin
* [`641eadf1`](https://github.com/NixOS/nixpkgs/commit/641eadf1e111d17e9a99f2d46d8a6f141b2fecfc) php80Packages.psysh: 0.11.16 -> 0.11.17
* [`67099b1d`](https://github.com/NixOS/nixpkgs/commit/67099b1d59d3baf4a9ae9e69772a987c3f9f2832) miniflux: 2.0.43 -> 2.0.44
* [`5999c297`](https://github.com/NixOS/nixpkgs/commit/5999c297dbfc9f08bd85e4773387580d65c06fe1) python310Packages.pyworld: 0.3.2 -> 0.3.3
* [`f2b4a6d3`](https://github.com/NixOS/nixpkgs/commit/f2b4a6d3a3167807cff651519ebafbff66efde83) awscli2: 2.11.15 -> 2.11.20
* [`e1daacf9`](https://github.com/NixOS/nixpkgs/commit/e1daacf987d6064bd7dc65a30e7715990bc1c011) pahole: patch to force single-threaded mode if reproducibility is desired
* [`b7edd2e7`](https://github.com/NixOS/nixpkgs/commit/b7edd2e76dc48dbb5e3907b8b7ad416c5770e466) python310Packages.weconnect: 0.54.2 -> 0.55.0
* [`333d2850`](https://github.com/NixOS/nixpkgs/commit/333d285072d7e026f50003e69b1758130bf7a22e) deepin.deepin-screensaver: init at 5.0.16
* [`f0cab06f`](https://github.com/NixOS/nixpkgs/commit/f0cab06f93d4ee25d437015a57aaa6789a102143) godot: 3.5.1 -> 3.5.2
* [`7452a2d1`](https://github.com/NixOS/nixpkgs/commit/7452a2d176f539244a16c7818d1ba5d7e6cd82de) python310Packages.numpyro: add missing input for tests
* [`2472f4ea`](https://github.com/NixOS/nixpkgs/commit/2472f4eaee09d97b874f1c0bbc8a0667c4e54a56) flashrom: unbreak darwin
* [`2015ab2d`](https://github.com/NixOS/nixpkgs/commit/2015ab2d5cfde97f19e7abd7d3490376991b0d92) flashrom-stable: unbreak darwin
* [`d080004d`](https://github.com/NixOS/nixpkgs/commit/d080004dfa05265c4a85a3db9f8c2142b0b88707) viceroy: 0.4.5 -> 0.5.0
* [`cddb66d6`](https://github.com/NixOS/nixpkgs/commit/cddb66d6552f3fb9912081601303d890dd693cc0) python310Packages.scikit-image: rename from scikitimage
* [`3830fa6e`](https://github.com/NixOS/nixpkgs/commit/3830fa6e2816e217be8477e8c12300383476f9bc) mods: init at 0.1.1
* [`bc4e3288`](https://github.com/NixOS/nixpkgs/commit/bc4e32887545e8cbbbffe99cf44271b9059d10cf) cloudlog: 2.4.1 -> 2.4.2
* [`d9f9708a`](https://github.com/NixOS/nixpkgs/commit/d9f9708a99765239405543f45cf979400a978ae2) meshcentral: nodejs_16 -> nodejs_18
* [`5e27d26c`](https://github.com/NixOS/nixpkgs/commit/5e27d26c055ee4a30bc4e7a8c232b828c7a60aaa) python310Packages.tensorflow-metadata: 1.13.0 -> 1.13.1
* [`17d4034e`](https://github.com/NixOS/nixpkgs/commit/17d4034e89f418108837af481e043586a0e44568) texlive: unpack and expose useful tlpkg/ content
* [`1623309e`](https://github.com/NixOS/nixpkgs/commit/1623309ee2df85e952f79ea7ed7c75137b48f48b) texlive: execute postaction scripts
* [`6c680af3`](https://github.com/NixOS/nixpkgs/commit/6c680af3ae851731d6cf056fb549342ab382c805) i3status-rust: 0.31.2 -> 0.31.4
* [`2403d25b`](https://github.com/NixOS/nixpkgs/commit/2403d25b6f6475ef0a2125f3f4b133902d2fba72) star-history: 1.0.11 -> 1.0.12
* [`3aa6580f`](https://github.com/NixOS/nixpkgs/commit/3aa6580f465ad97bf69a04213899e59350e70ef4) nixos/trippy: init
* [`f4b86504`](https://github.com/NixOS/nixpkgs/commit/f4b86504ea6be349598c73db15580837cf711e9a) dae: 0.1.7 -> 0.1.8
* [`7ecb6dff`](https://github.com/NixOS/nixpkgs/commit/7ecb6dffd2895009bbf4556455c31c4d4f30db10) gphotos-sync: 3.04 -> 3.1.2
* [`f9f76529`](https://github.com/NixOS/nixpkgs/commit/f9f76529cd9682bee8a3a805cb4c8f7e0f8e7af4) nixos/nextcloud: default createLocally to false
* [`33465c23`](https://github.com/NixOS/nixpkgs/commit/33465c23ea6464cf353083c45beb8f4eadbba75e) python310Packages.ecos: 2.0.10 -> 2.0.11
* [`ef5407df`](https://github.com/NixOS/nixpkgs/commit/ef5407df8d8f815a2f72c84b7d0b0a3ba453ca2a) python3.pkgs.textual: 0.23.0 -> 0.24.1
* [`58511b12`](https://github.com/NixOS/nixpkgs/commit/58511b124ef34f1a0c89aa58a7e87a8861bc5700) python3.pkgs.xdg-base-dirs: init at 6.0.0
* [`893c5215`](https://github.com/NixOS/nixpkgs/commit/893c521565957bdf54962d542b77cadace030b07) factorio: fix eval
* [`6cac1dec`](https://github.com/NixOS/nixpkgs/commit/6cac1dec78a3adb1629ae7f5124aa4e46953ba1e) alsa-ucm-conf: 1.2.8 -> 1.2.9
* [`272154f2`](https://github.com/NixOS/nixpkgs/commit/272154f2602ac55700c15cf38f84c44a67fb11b0) mangohud: add bitness suffix to layer name
* [`7eacc7f5`](https://github.com/NixOS/nixpkgs/commit/7eacc7f5492f39286696e57fa99bb2becf711bd5) mangohud: make lower bitness support configurable
* [`a30d3677`](https://github.com/NixOS/nixpkgs/commit/a30d3677d0db9fbc5c4afc18bd69c379d45b4393) fblog: 4.3.0 -> 4.4.0
* [`ee50fcd6`](https://github.com/NixOS/nixpkgs/commit/ee50fcd6ac7c54b95a36a81d5b666f8e44d03eab) open-stage-control: 1.24.2 -> 1.25.0
* [`e3c06521`](https://github.com/NixOS/nixpkgs/commit/e3c0652181ea9ee1a8a87ea494e234422ffd848e) python310Packages.aionotion: 2023.05.1 -> 2023.05.4
* [`09512358`](https://github.com/NixOS/nixpkgs/commit/09512358faf83630fc6db5e876cd57c363fc32d6) python310Packages.bellows: 0.35.2 -> 0.35.5
* [`4cbe7d35`](https://github.com/NixOS/nixpkgs/commit/4cbe7d35504dc1a45cc4335e9b090b25c9de714f) home-assistant: 2023.5.2 -> 2023.5.3
* [`7b17416a`](https://github.com/NixOS/nixpkgs/commit/7b17416a3cbef61847841d96b6b4b66f2b875df6) openslp: update broken patch URLs
* [`247fce9f`](https://github.com/NixOS/nixpkgs/commit/247fce9fe8c489b6e97fd3cb4210cc8e41288804) SDL_classic: update broken patch URL
* [`482fab4e`](https://github.com/NixOS/nixpkgs/commit/482fab4ebc7c8f0ee1231626384d3839057e86d6) linux_xanmod_latest: 6.3.1 -> 6.3.2
* [`e064d246`](https://github.com/NixOS/nixpkgs/commit/e064d246d6fed31de53afec8aa2d6991c156a698) linux_xanmod: 6.1.27 -> 6.1.28
* [`671ac5d2`](https://github.com/NixOS/nixpkgs/commit/671ac5d2a5681e33bc8d75eb03155b2401d91b90) libphonenumber: patch code generation tool for build reproducibility
* [`afd2bbf2`](https://github.com/NixOS/nixpkgs/commit/afd2bbf22c36da54feaef33331eb3073ef69d150) clisp: remove broken status on Darwin
* [`9d4e72cd`](https://github.com/NixOS/nixpkgs/commit/9d4e72cd73ee83c1a63beb71fecb5787d4450d3b) clisp-tip: mark Darwin as broken instead of restricting platforms
* [`0849fd59`](https://github.com/NixOS/nixpkgs/commit/0849fd5947752858ad351d4a3cd0cb37068d4202) motrix: 1.8.14 -> 1.8.19
* [`f9713de0`](https://github.com/NixOS/nixpkgs/commit/f9713de024f457b49fa44908f3db235d8f989fe3) python3Packages.muscima: init at unstable-2023-04-26
* [`ed68fa60`](https://github.com/NixOS/nixpkgs/commit/ed68fa60fba4c00c701c0d38f13d9aed0316d26b) python3Packages.mung: init at unstable-2022-07-10
* [`bc87805d`](https://github.com/NixOS/nixpkgs/commit/bc87805d558718feca01013063a73d19998b9e3d) python3Packages.omrdatasettools: init at 1.3.1
* [`207731e3`](https://github.com/NixOS/nixpkgs/commit/207731e3e35bc0f62b3d1a270acc023566c612e1) clisp: enable ffcall on Darwin
* [`c23d2709`](https://github.com/NixOS/nixpkgs/commit/c23d2709c1b16cce9e8bb7c3b47f5a35d4a232af) python310Packages.intensity-normalization: unbreak
* [`1dd536c5`](https://github.com/NixOS/nixpkgs/commit/1dd536c54c896105b1e0c1d0661c91dd61fee63f) chipsec: 1.8.1 -> 1.10.6
* [`e3d1294a`](https://github.com/NixOS/nixpkgs/commit/e3d1294a9fa1962ba511e86b33e7d1c9bffbc41a) chipsec: add erdnaxe to maintainers
* [`ce85120c`](https://github.com/NixOS/nixpkgs/commit/ce85120cbcbccb02d9d864a34802efd72d91fe72) minimal-bootstrap: Expose some details
* [`207bab50`](https://github.com/NixOS/nixpkgs/commit/207bab506251fc2086d08a88b6bf8ab387c4d5f6) minimal-bootstrap: Support `passthru.tests`
* [`f7a07504`](https://github.com/NixOS/nixpkgs/commit/f7a07504535cf5d9f24a3885649ef1a374dcad57) heroic: remove leftover files
* [`8b16fe92`](https://github.com/NixOS/nixpkgs/commit/8b16fe92d62a4913618c8673bd1cab4332fa2670) python310Packages.cvxpy: 1.3.0 -> 1.3.1
* [`921458fb`](https://github.com/NixOS/nixpkgs/commit/921458fbcb5c0701f0f10042628dde7a320da40a) example-robot-data: 4.0.5 -> 4.0.6
* [`179ba02c`](https://github.com/NixOS/nixpkgs/commit/179ba02c2b93e6b9dc04c52234d0e428da4a3078) nerdfix: 0.3.0 -> 0.3.1
* [`47e8beba`](https://github.com/NixOS/nixpkgs/commit/47e8bebacd676c7c0fdd577b6a933b36db078e8b) koreader: add support for aarch64-linux
* [`74c5abae`](https://github.com/NixOS/nixpkgs/commit/74c5abae16e6d087fc205dddb041850381786373) mpvScripts.{autocrop,autodeint}: add to all-packages.nix
* [`72b02105`](https://github.com/NixOS/nixpkgs/commit/72b021051f4d16f029dfe0073bd37e107f57991b) nix-output-monitor: comment and cleanup
* [`b53cb861`](https://github.com/NixOS/nixpkgs/commit/b53cb8614489d51018339e55d09558eafad8d8bd) python310Packages.yfinance: add missing input html5lib
* [`4414a2d9`](https://github.com/NixOS/nixpkgs/commit/4414a2d94878818f7645b080fdf8f11ea9a1b92a) nix-output-monitor: 2.0.0.5 -> 2.0.0.6
* [`043c0b67`](https://github.com/NixOS/nixpkgs/commit/043c0b67cfb94907fdbf3fe35db71dc6343e6596) python311Packages.aionotion: 2023.05.1 -> 2023.05.4
* [`0509b75c`](https://github.com/NixOS/nixpkgs/commit/0509b75c80716628e8a36225071cd65bd8c22862) uptime-kuma: 1.21.2 -> 1.21.3
* [`1e84e403`](https://github.com/NixOS/nixpkgs/commit/1e84e403c7ca58489369ab5f0a56213f682c3c84) python310Packages.guppy3: 3.1.2 -> 3.1.3
* [`1064eb90`](https://github.com/NixOS/nixpkgs/commit/1064eb90c603a96ceaa8ee71b20042e305aaae4d) python310Packages.logging-journald: 0.6.4 -> 0.6.5
* [`5cabe53d`](https://github.com/NixOS/nixpkgs/commit/5cabe53dfc8c89624b64f0f66c7c87efa9859e0b) python310Packages.onvif-zeep-async: 3.1.3 -> 3.1.7
* [`37ea427c`](https://github.com/NixOS/nixpkgs/commit/37ea427cd829f51f95b7c2539eedc057204a5820) python310Packages.findimports: 2.2.0 -> 2.3.0
* [`650d4029`](https://github.com/NixOS/nixpkgs/commit/650d40293d9987a58feadedabc70704d01df83d0) python310Packages.atenpdu: 0.6.0 -> 0.6.1
* [`7c38f9ce`](https://github.com/NixOS/nixpkgs/commit/7c38f9ce7c4ee07b7797699488d10dd6fca6b6d0) python310Packages.dvc-data: 0.49.1 -> 0.50.0
* [`94e69e30`](https://github.com/NixOS/nixpkgs/commit/94e69e30f2352bd14a9d2c68f9108d91c7a81e8c) python310Packages.pydeps: 1.12.3 -> 1.12.4
* [`9bb523f5`](https://github.com/NixOS/nixpkgs/commit/9bb523f5c93538d45d26d768eaf2377c6388d3f4) python310Packages.pyaussiebb: 0.0.16 -> 0.0.18
* [`5544f243`](https://github.com/NixOS/nixpkgs/commit/5544f2430f2345e73d200ece069f5bd8bc4dbc30) exploitdb: 2023-05-12 -> 2023-05-14
* [`0e60ea38`](https://github.com/NixOS/nixpkgs/commit/0e60ea38d85731058768cac1831dde160339a072) python310Packages.sensor-state-data: 2.14.0 -> 2.15.1
* [`345e8896`](https://github.com/NixOS/nixpkgs/commit/345e8896adb22a44af8d7aefe2b4ed960e33ff22) python310Packages.rns: 0.5.1 -> 0.5.2
* [`eaa4b4c1`](https://github.com/NixOS/nixpkgs/commit/eaa4b4c1540bc87b5d3a02b9605e3875842b7620) python310Packages.python-roborock: 0.17.3 -> 0.17.6
* [`3d95de61`](https://github.com/NixOS/nixpkgs/commit/3d95de61994d2cc814feee8a7a88652194afd985) python3Packages.retworkx: remove
* [`0c7631d3`](https://github.com/NixOS/nixpkgs/commit/0c7631d319ef137503ddbf1899890c64364f870e) minimal-bootstrap.tcc: Dedup, separate compiler from libs
* [`6dfead1d`](https://github.com/NixOS/nixpkgs/commit/6dfead1d52f7347fab6cac621e5dd45a67ca56a3) minimal-bootstrap.derivationWithMeta: Do more conds at eval time
* [`a8996288`](https://github.com/NixOS/nixpkgs/commit/a89962887cad256970267668a3218505e321aebd) minimal-bootstrap.mes: Parallelize
* [`275ce8c4`](https://github.com/NixOS/nixpkgs/commit/275ce8c4e414fdd65abc4975f64c314038665d31) python310Packages.django-localflavor: init at 4.0
* [`6d2ffb19`](https://github.com/NixOS/nixpkgs/commit/6d2ffb194e421ebaca1990eed926eda690b4085a) python310Packages.arviz: 0.15.0 -> 0.15.1
* [`e639bfd1`](https://github.com/NixOS/nixpkgs/commit/e639bfd14d095566a363343aebaac51572d64185) python310Packages.h5netcdf: fix versioning
* [`5a78c28a`](https://github.com/NixOS/nixpkgs/commit/5a78c28a10a9d39485511a8f33a163c8d156a9d5) minimal-bootstrap.mes-libc: This can be all source
* [`5435eaaa`](https://github.com/NixOS/nixpkgs/commit/5435eaaa4d34d941c9493da7a3918d4925162469) nixos/rshim: init
* [`23f849f4`](https://github.com/NixOS/nixpkgs/commit/23f849f49d982d7251773a6319af81259b20e06b) minimal-boostrap.mes: Separate compiler and libs
* [`dde08220`](https://github.com/NixOS/nixpkgs/commit/dde0822009c8b04e673854d50a8c93f31af67421) python310Packages.dj-static: init at 0.0.6
* [`33b15fdc`](https://github.com/NixOS/nixpkgs/commit/33b15fdce01f528cba388d1e023f04491c0879b3) security/acme: Fix listenHTTP bug with IPv6 addresses
* [`8ed86700`](https://github.com/NixOS/nixpkgs/commit/8ed86700a2d33243b390b8ed14b8d3c8457c0308) nixos/alice-lg: init
* [`55bd75e9`](https://github.com/NixOS/nixpkgs/commit/55bd75e98fdb899eb9a9e5929efb2c9097c20d7b) birdwatcher: init at 2.2.4
* [`40136a1f`](https://github.com/NixOS/nixpkgs/commit/40136a1f7f3c6f2484b5455f911c7c35743b7df2) nixos/birdwatcher: init
* [`7edb72db`](https://github.com/NixOS/nixpkgs/commit/7edb72db10be8a47a818c3a808fe2926a767ed29) truvari: add patches to fix `truvari anno`
* [`ac3d1b53`](https://github.com/NixOS/nixpkgs/commit/ac3d1b53371a928e2123d2689e4163a4192f8df1) restic-integrity: init at 1.2.1
* [`b4c19e85`](https://github.com/NixOS/nixpkgs/commit/b4c19e85483dea24e59c0f05f57b15fa59ee70ad) python310Packages.skrl: 0.10.1 -> 0.10.2; unbreak
* [`32e78a7a`](https://github.com/NixOS/nixpkgs/commit/32e78a7a827575639273b757dce10b0ecfd27a2d) Update pkgs/applications/misc/koreader/default.nix
* [`b89decb1`](https://github.com/NixOS/nixpkgs/commit/b89decb10715783bd6daacc18518d4be25e3ce15) blueman: 2.3.4 -> 2.3.5
* [`b0aff56c`](https://github.com/NixOS/nixpkgs/commit/b0aff56c9c77a37d0bef82bc1083b7848a9f563f) blueman: specify changelog
* [`211f15a2`](https://github.com/NixOS/nixpkgs/commit/211f15a271fe2e300aef7daa688d5060ac41ea46) phantomsocks: fix build tag
* [`e20c707a`](https://github.com/NixOS/nixpkgs/commit/e20c707a1b9ea3f0bd8b7c267406888cea755743) eksctl: 0.140.0 -> 0.141.0
* [`063c724e`](https://github.com/NixOS/nixpkgs/commit/063c724efee38e5f6eab1f5228f6ea5d0d0a4e16) cirrus-cli: 0.97.0 -> 0.98.0
* [`76d34bfa`](https://github.com/NixOS/nixpkgs/commit/76d34bfa54727e423662aabad4e491ca32a9effa) argo-rollouts: 1.4.1 -> 1.5.0
* [`8f62edb0`](https://github.com/NixOS/nixpkgs/commit/8f62edb01f32b9410451271d2492e1c6f9b2088a) step-cli: 0.24.3 -> 0.24.4
* [`17d26e4c`](https://github.com/NixOS/nixpkgs/commit/17d26e4c7fc1ab8697d63523daf2d2742f432d2a) linux: patch to fix MAP_32BIT crashes, e.g. Haskell
* [`fd64f69c`](https://github.com/NixOS/nixpkgs/commit/fd64f69c731e77d8b645afc4e8dbec74ba207bf9) mympd: 10.3.1 -> 10.3.2
* [`ec83b05f`](https://github.com/NixOS/nixpkgs/commit/ec83b05fef2b49282e7213776b053da246e3965a) tanka: 0.24.0 -> 0.25.0
* [`61748c7d`](https://github.com/NixOS/nixpkgs/commit/61748c7d97c41edd1bed867a5daf95b22291215c) cloudmonkey: 6.2.0 -> 6.3.0
* [`ebdfb209`](https://github.com/NixOS/nixpkgs/commit/ebdfb20941c66e7ace30b57706e9012dfbf202dd) step-kms-plugin: 0.8.2 -> 0.8.3
* [`17cb9a8e`](https://github.com/NixOS/nixpkgs/commit/17cb9a8e810c34e7081c007dcc022c54e0433a17) mixxx: 2.3.4 -> 2.3.5
* [`eae5f836`](https://github.com/NixOS/nixpkgs/commit/eae5f83649645c1db5fd0474b95ab709aabed5fd) chipsec: mark broken on hardened kernels older than 5.4
* [`b05ef018`](https://github.com/NixOS/nixpkgs/commit/b05ef018ff27c71304cdf1d19b9e7a1103f3a233) craftos-pc: fix broken hashes
* [`60c69da2`](https://github.com/NixOS/nixpkgs/commit/60c69da248a9e0c2b4aadf0e1c6da5916b808d4d) fastp: 0.23.2 -> 0.23.3
* [`8ec463eb`](https://github.com/NixOS/nixpkgs/commit/8ec463eba8ccbef12b26b441ef1728e824cd3c30) zeek: 5.2.0 -> 5.2.1
* [`05ad50d1`](https://github.com/NixOS/nixpkgs/commit/05ad50d1ff5e958f554211a12989c6d0f2a0f23a) velero: 1.10.3 -> 1.11.0
* [`bac8c263`](https://github.com/NixOS/nixpkgs/commit/bac8c263a7a7a8d637aed93238cb3da2bc127a6d) rofi-power-menu: 3.0.2 -> 3.1.0
* [`8abdc92c`](https://github.com/NixOS/nixpkgs/commit/8abdc92c8c0b44e1ea4a4e58cd15448473fe9dd5) colmena: 0.3.2 -> 0.4.0
* [`3d6d1d4d`](https://github.com/NixOS/nixpkgs/commit/3d6d1d4d6b510c180eeeff0f1966330418abdce5) nerd-font-patcher: 2.2.2 -> 3.0.1
* [`4461bbcc`](https://github.com/NixOS/nixpkgs/commit/4461bbccec34e661daf3c6e08418f041664a599d) python311Packages.azure-mgmt-iothub: 2.3.0 -> 2.4.0
* [`6d48cf61`](https://github.com/NixOS/nixpkgs/commit/6d48cf61f8a7ebcd26ddeb63ff63269b4b04a29a) phpunit: 10.1.2 -> 10.1.3
* [`77d3ac18`](https://github.com/NixOS/nixpkgs/commit/77d3ac188fbff8ab565f8e11c5962c99b9c831e5) swayrbar: 0.3.5 -> 0.3.6
* [`6692d1dc`](https://github.com/NixOS/nixpkgs/commit/6692d1dcc1d70b97bba4b7f7f8e07a324f4716c6) flightgear: 2020.3.17 -> 2020.3.18
* [`95756349`](https://github.com/NixOS/nixpkgs/commit/957563496326be189ca8c0b7494799f8368d7a8f) python311Packages.cinemagoer: 2022.12.27 -> 2023.5.1
* [`75ae91d5`](https://github.com/NixOS/nixpkgs/commit/75ae91d5059c2b729e1f0c65d98c1770a04786b5) libcouchbase: 3.3.6 -> 3.3.7
* [`964d55b1`](https://github.com/NixOS/nixpkgs/commit/964d55b1e02051f94f3d0bb9dab800e2f72b8a3f) vimPlugins.monokai-pro-nvim: init at 2023-05-13
* [`90237f91`](https://github.com/NixOS/nixpkgs/commit/90237f910af764922d2241eeaeece0d6940fb886) libpkgconf: 1.9.4 -> 1.9.5
* [`c240ad39`](https://github.com/NixOS/nixpkgs/commit/c240ad39d3a963be04d128111c3def7b15617103) xfce.mousepad: 0.6.0 -> 0.6.1
* [`3be4449a`](https://github.com/NixOS/nixpkgs/commit/3be4449adcf8a14a30e459549904b0c4615da7cd) bodyclose: init at 2023-04-21
* [`587fa62e`](https://github.com/NixOS/nixpkgs/commit/587fa62e815927939f2872c96e95396cb985445d) xfce.ristretto: 0.13.0 -> 0.13.1
* [`83df8d51`](https://github.com/NixOS/nixpkgs/commit/83df8d51b6911eb97a7f96c989e337ff2e3d32c9) xfce.xfce4-screenshooter: 1.10.3 -> 1.10.4
* [`47d41eda`](https://github.com/NixOS/nixpkgs/commit/47d41eda7cebd6679ad17de1be97747bfb53fc3f) xfce.xfce4-i3-workspaces-plugin: 1.4.0 -> 1.4.1
* [`cedcd620`](https://github.com/NixOS/nixpkgs/commit/cedcd620c50b0cca699373cb4d9186670e8b4455) python311Packages.azure-mgmt-iothub: disable on unsupported Python releases
* [`25f3323d`](https://github.com/NixOS/nixpkgs/commit/25f3323d60271ac9b668757322c47f96aa7ca726) nixos/etcd: Fix mapping of clientCertAuth option
* [`01ddcaa8`](https://github.com/NixOS/nixpkgs/commit/01ddcaa879471f82eb5f8e704897e272a8206786) bwa: 0.7.17 -> unstable-2022-09-23
* [`c85dced2`](https://github.com/NixOS/nixpkgs/commit/c85dced23e4d0a0a860371880aad0d8bca83ed6f) bwa: update license
* [`04dd7f41`](https://github.com/NixOS/nixpkgs/commit/04dd7f41e720c10c48ba65f60a3063740fe081c8) bwa: add runHook
* [`09f4bf7f`](https://github.com/NixOS/nixpkgs/commit/09f4bf7f166d4bf2e09b1923ae5744e6193caf44) nixos/pam: enable unlocking ZFS home dataset
* [`5466f767`](https://github.com/NixOS/nixpkgs/commit/5466f767556b12a6db4bcaa6e9ab9970d28b0d29) nixos/pam: improve documentation of ZFS module
* [`87cbaf7c`](https://github.com/NixOS/nixpkgs/commit/87cbaf7ce339136ccbd639b7b5a1cf988d0fa440) nixos/pam: assert ZFS support for PAM module
* [`56e894b0`](https://github.com/NixOS/nixpkgs/commit/56e894b0b137b223d297896b13c84a12345b58d5) nixos/pam: add test for ZFS home dataset unlocking
* [`1bb61875`](https://github.com/NixOS/nixpkgs/commit/1bb618759ed431be9d140a3247c92f11be94e671) python310Packages.atlassian-python-api: 3.34.0 -> 3.36.0
* [`b2cc7fb2`](https://github.com/NixOS/nixpkgs/commit/b2cc7fb23db7a104f223649932fdb128278159eb) python311Packages.py-zabbix: add patch to remove getargspec
* [`f3f6bacd`](https://github.com/NixOS/nixpkgs/commit/f3f6bacd0b47d66fabbc48136d6d43c73ba17a4d) python311Packages.types-python-dateutil: 2.8.19.12 -> 2.8.19.13
* [`53c8cd6a`](https://github.com/NixOS/nixpkgs/commit/53c8cd6af820e96057065f33d37edf630e1dd4a3) zfs.meta.platforms: restrict to upstream-supported $TARGET_CPUs
* [`77f98373`](https://github.com/NixOS/nixpkgs/commit/77f983732c0fcdd2df55e141209ba7c776416f1d) ocamlPackages.ocaml_expat: remove at 0.9.1 (for OCaml < 4.02)
* [`bc9afd16`](https://github.com/NixOS/nixpkgs/commit/bc9afd16865cddb0f2f2be9f65741626779687f1) ocamlPackages.tcslib: remove unused input
* [`c81792a4`](https://github.com/NixOS/nixpkgs/commit/c81792a4571d5a6ba7a7f3d84cbc0e5dc5f16335) ocamlPackages.ounit2: disable for OCaml < 4.08
* [`70c1240b`](https://github.com/NixOS/nixpkgs/commit/70c1240b6fb88a51f06942b00dc5092bc13fd35c) python3Packages.cocotb: fix failing build ([nixos/nixpkgs⁠#231184](https://togithub.com/nixos/nixpkgs/issues/231184))
* [`46f2510f`](https://github.com/NixOS/nixpkgs/commit/46f2510f2bf5721673f885023af223180765ad24) python310Packages.atlassian-python-api: add changelog to meta
* [`a951a512`](https://github.com/NixOS/nixpkgs/commit/a951a512236c7122f8822441ed16d4eb08823763) python310Packages.cheetah3: 3.2.6.post2 -> 3.3.1
* [`c984f441`](https://github.com/NixOS/nixpkgs/commit/c984f4414cb3673b2b04834e89fdc4df4865607a) python311Packages.ciscoconfparse: 1.7.18 -> 1.7.24
* [`b30ab8f1`](https://github.com/NixOS/nixpkgs/commit/b30ab8f1de88aec7167439002b66e13be47e94a9) unixbench: init at unstable-2023-04-12
* [`a0ca4311`](https://github.com/NixOS/nixpkgs/commit/a0ca431141b4ff32509f791a91a0c01e07fbd37e) Add coqPackages.mathcomp 2.0.0
* [`8b72abdb`](https://github.com/NixOS/nixpkgs/commit/8b72abdbe8a57191b36f9901f36d1a7eecd59ec0) libudev-zero: fix cross compilation
* [`6b2ac1c4`](https://github.com/NixOS/nixpkgs/commit/6b2ac1c44caa398f33c09a7f354e5cf1fb8357d6) monotoneViz: update broken patch URLs
* [`3f446bfb`](https://github.com/NixOS/nixpkgs/commit/3f446bfbd356a58ce673d88b6e78f368f707c9f1) nixos/pam: fix ZFS support assertion
* [`6250f860`](https://github.com/NixOS/nixpkgs/commit/6250f8607c0f8550571fb6fe79c5da76cbeb91f7) psst: 2022-10-13 -> 2023-05-13
* [`da95e6a2`](https://github.com/NixOS/nixpkgs/commit/da95e6a2e6f1f4d104715bb3a231a9e4a65c1f1c) psst: add update script
* [`e232bbd9`](https://github.com/NixOS/nixpkgs/commit/e232bbd926aa692cbbc1ddfeb4635714a0a7549d) python311Packages.extractcode: add missing input six
* [`146f2449`](https://github.com/NixOS/nixpkgs/commit/146f2449a19101ee202aa578a2b1d7377779890b) kiwix-tools: 3.4.0 -> 3.5.0
* [`adede1eb`](https://github.com/NixOS/nixpkgs/commit/adede1eb03c4cbacf1836288cc55f87f45b3217a) mjolnir: 1.5.0 -> 1.6.4, build with mkYarnPackage
* [`c256ecf7`](https://github.com/NixOS/nixpkgs/commit/c256ecf7a3f5f5b8ac63c70a1ad216cf1f8312fc) nixos/mjolnir: explicitly set --mjolnir-config
* [`18fa9fc6`](https://github.com/NixOS/nixpkgs/commit/18fa9fc63fa79e98e7d0875ccf5b93ee1a06c356) slweb: 0.5.4 -> 0.5.5
* [`a9a1928b`](https://github.com/NixOS/nixpkgs/commit/a9a1928bd28de5b40780568e83c820b9d33d0043) ocamlPackages.cmarkit: init at 0.1.0
* [`5a8a8e0d`](https://github.com/NixOS/nixpkgs/commit/5a8a8e0d9f0731cc4cf6a561d72b017c38eb2ae3) labwc: 0.6.2 -> 0.6.3
* [`80c0a5de`](https://github.com/NixOS/nixpkgs/commit/80c0a5deb91480495f839ba1845931f38a01c417) python3Packages.ruff-lsp: 0.0.24 -> 0.0.27
* [`bc053c32`](https://github.com/NixOS/nixpkgs/commit/bc053c32fcee4aeda68b9168085b79fc57c126e3) abaddon: init at 0.1.10
* [`538dfc60`](https://github.com/NixOS/nixpkgs/commit/538dfc605c5769494a40708868a2129891661434) python3Packages.justbases: 0.15 -> 0.15.2
* [`847b66d0`](https://github.com/NixOS/nixpkgs/commit/847b66d0551456737741733fbd2bdec64c1b4326) privacyidea: fix build
* [`49eee7c7`](https://github.com/NixOS/nixpkgs/commit/49eee7c7aa6bafa76d3dd822b9a07981c6175bb5) privacyidea: build on linux only
* [`4e8b848f`](https://github.com/NixOS/nixpkgs/commit/4e8b848f13657af4ebd44a0a0fb525c39d195f12) bdf2psf: 1.218 -> 1.220
* [`bf65f7c2`](https://github.com/NixOS/nixpkgs/commit/bf65f7c29192d629e772afce7b3ff7eb90c72c69) python310Packages.pymc: 5.0.2 -> 5.3.1
* [`3c63d740`](https://github.com/NixOS/nixpkgs/commit/3c63d74009b1ba84b9f3633bb48d7373a8a0cb4c) ruff: add ruff-lsp to passthru.tests
* [`d8f99d83`](https://github.com/NixOS/nixpkgs/commit/d8f99d83e77fcc6ff1d274d9aa37ed2d555c7d77) python310Packages.css-inline: init at 0.8.7
* [`5ce9c57e`](https://github.com/NixOS/nixpkgs/commit/5ce9c57e1a23ae50aed8f33265a9c09b3ffc2a81) muso: avoid build failure using an updated lockfile
* [`f3587b78`](https://github.com/NixOS/nixpkgs/commit/f3587b78c38ba82d8818bb9ed3e3e7bab1502c40) muso: don't mark as broken on aarch64-linux
* [`6852dc23`](https://github.com/NixOS/nixpkgs/commit/6852dc2359784c34941270d3f9532b0d7cfcd225) nixos/rshim: fix shell escape
* [`46dfed60`](https://github.com/NixOS/nixpkgs/commit/46dfed6010a624a7aec49bbc63752847ae3ff15a) nixos/tests/rshim: init
* [`75951ec5`](https://github.com/NixOS/nixpkgs/commit/75951ec554c37f56bf1c1aebd15582baf8005eb0) python311Packages.aioecowitt: 2023.01.0 -> 2023.5.0
* [`aa24b33e`](https://github.com/NixOS/nixpkgs/commit/aa24b33e2420f5bd98d17595bd041c593d1283b6) python310Packages.pyvicare: 2.27.2 -> 2.28.1
* [`f197c8db`](https://github.com/NixOS/nixpkgs/commit/f197c8db8f17d99bbc13d406f71e95f3b3be6c5a) python310Packages.python-gvm: 23.4.2 -> 23.5.0
* [`73df46ee`](https://github.com/NixOS/nixpkgs/commit/73df46ee7794def95ae22affff53dfc0bd14e5db) ruby_3_0: make it use OpenSSL 3
* [`969c48ea`](https://github.com/NixOS/nixpkgs/commit/969c48ead61b86c445baf14f608522eeadac55f1) ov: 0.15.0 -> 0.22.0
* [`32866f8d`](https://github.com/NixOS/nixpkgs/commit/32866f8d58979e8dbdf92bfaa72d2883eee861f7) nixos/syncthing: use rfc42 style settings
* [`77ef06b4`](https://github.com/NixOS/nixpkgs/commit/77ef06b4a2cbacd43053a7f19f03e654541f3ec2) kubescape: 2.3.1 -> 2.3.2
* [`5c1696e3`](https://github.com/NixOS/nixpkgs/commit/5c1696e3a501941ad576afe0b9aa5be91b771b1a) teams-for-linux: 1.0.83 -> 1.0.88
* [`26e68112`](https://github.com/NixOS/nixpkgs/commit/26e68112909a3bb6fca067122e81b3c4fe1c167c) Revert "Merge pull request [nixos/nixpkgs⁠#229369](https://togithub.com/nixos/nixpkgs/issues/229369) from markuskowa/add-libsomo-s"
* [`292ac0da`](https://github.com/NixOS/nixpkgs/commit/292ac0da99fc47a38f4ed27f50d2364aea023ff1) libosmoabis, libosmo-{netif,sccp}: add markuskowa to maintainers
* [`95e1099d`](https://github.com/NixOS/nixpkgs/commit/95e1099d2a042ed6d4c23ae3bd46317e0d28c5c5) restic: add persistent default for timer unit
* [`ba12f1bc`](https://github.com/NixOS/nixpkgs/commit/ba12f1bc521b5b5f6cfb449775b28f0561407c80) trippy: 0.7.0 -> 0.8.0
* [`f6e4dcb0`](https://github.com/NixOS/nixpkgs/commit/f6e4dcb061fb2148dc086ecc27333f13cdf09e97) deno: 1.33.2 -> 1.33.3
* [`55061dd7`](https://github.com/NixOS/nixpkgs/commit/55061dd7220ed4854f878c152143ff51238a7d85) dbus_cplusplus: update broken patch URLs
* [`2ee66a30`](https://github.com/NixOS/nixpkgs/commit/2ee66a3000fd65bc76e83a62e57337a9dccdb7c2) keyd: run systemd service as root user
* [`2632233a`](https://github.com/NixOS/nixpkgs/commit/2632233a8a0c21f6cc53ae77a9419539883e9524) frogmouth: init at 0.5.0
* [`0066142d`](https://github.com/NixOS/nixpkgs/commit/0066142d564c46212dfca02bfb9d145514a0b4f7) coreboot-toolchain: 4.19 -> 4.20
* [`c98bca9c`](https://github.com/NixOS/nixpkgs/commit/c98bca9ca9f677e3811dc6e768faac584dc1bd6c) python310Packages.textual: fix build on darwin
* [`00ca6e1c`](https://github.com/NixOS/nixpkgs/commit/00ca6e1c97160b8d0528494ef2aa92a1f9c5c757) shopware-cli: 0.1.62 -> 0.1.70
* [`25f85bdc`](https://github.com/NixOS/nixpkgs/commit/25f85bdcc2c6e73456568f7fc8107e6cb76febef) schildichat: 1.11.22-sc.1 -> 1.11.30-sc.2 ([nixos/nixpkgs⁠#231938](https://togithub.com/nixos/nixpkgs/issues/231938))
* [`25f705da`](https://github.com/NixOS/nixpkgs/commit/25f705da1208eb0468c217e91204f8a3f6f58187) gst_all_1.gst-plugins-rs: init at 0.10.7
* [`4f8d022f`](https://github.com/NixOS/nixpkgs/commit/4f8d022f85e82d56ee24a09909f5ee60f71f3279) mopidy: add gst-plugins-rs
* [`77f0d209`](https://github.com/NixOS/nixpkgs/commit/77f0d2095a8271fdb6e0d08c90a7d93631fd2748) mopidy-spotify: re-init at unstable-2023-04-21
* [`725bb2a7`](https://github.com/NixOS/nixpkgs/commit/725bb2a78be8696e21b16b1abb714a6c9f427304) ast-grep: init at 0.5.2
* [`3c0f0d84`](https://github.com/NixOS/nixpkgs/commit/3c0f0d84a8813412156d8008de96da39287a2cc5) nixosTests.mjolnir: unbreak
* [`696596a8`](https://github.com/NixOS/nixpkgs/commit/696596a8a0c9b0c00764051c399569a1583765df) owncloud: 3.2.1 -> 4.0.0
* [`190bf8b2`](https://github.com/NixOS/nixpkgs/commit/190bf8b28146dee803060e71ba10710778453f60) mlxbf-bootctl: init at 1.1-6
* [`391b059c`](https://github.com/NixOS/nixpkgs/commit/391b059c1d93889e597797841fa20148f7e6dd4c) nixosTests.pgadmin4: increase test coverage ([nixos/nixpkgs⁠#229632](https://togithub.com/nixos/nixpkgs/issues/229632))
* [`97fab1a3`](https://github.com/NixOS/nixpkgs/commit/97fab1a38c9e973b424a7750eafec2b88c1fa8cf) chenglou92.rescript-vscode: 1.8.1 -> 1.16.0 ([nixos/nixpkgs⁠#231648](https://togithub.com/nixos/nixpkgs/issues/231648))
* [`892ed412`](https://github.com/NixOS/nixpkgs/commit/892ed4125cd71880afdf216771d98e2b5883242c) urbit: add sourceProvenance
* [`15a3b9bb`](https://github.com/NixOS/nixpkgs/commit/15a3b9bb0999b5aa9169170f16341e21c498e197) python310Packages.ldap3: fix pyasn1 0.5.0 compability
* [`7b5de605`](https://github.com/NixOS/nixpkgs/commit/7b5de60571114e26789fc2689125c326f36c0fa0) certipy: fix build with pyasn1 0.5.0
* [`532b383f`](https://github.com/NixOS/nixpkgs/commit/532b383f4387304cc0109226475c73e48396d3df) kemai: init at 0.9.2
* [`d925734d`](https://github.com/NixOS/nixpkgs/commit/d925734d3bb7f12924e6016cd33222684b5435f5) Nim: add meta.mainProgram
* [`4f57c4c1`](https://github.com/NixOS/nixpkgs/commit/4f57c4c1f9fffdc2e572434bb684fac7bde921e7) anki-bin: 2.1.62 -> 2.1.63
* [`10092e14`](https://github.com/NixOS/nixpkgs/commit/10092e14180fdff037aea3a14ad3faeaf6950ac1) licenses: add CC-BY-NC-ND-4.0
* [`c728afcb`](https://github.com/NixOS/nixpkgs/commit/c728afcb686a6b83758e1d1acccdd7071fbb5b04) seaweedfs: 3.49 -> 3.50
* [`76876f35`](https://github.com/NixOS/nixpkgs/commit/76876f35474a180c842fdf8243f8d3578c1a7751) cargo-shuttle: init at 0.16.0
* [`763dbd1d`](https://github.com/NixOS/nixpkgs/commit/763dbd1d4676ae832d819db409fcc22b87fb1e1f) sfwbar: init at 1.0_beta11
* [`1784646f`](https://github.com/NixOS/nixpkgs/commit/1784646fc10266683fa63a32beaa2a37804f6df5) fritzing: added meta.mainProgram ([nixos/nixpkgs⁠#232059](https://togithub.com/nixos/nixpkgs/issues/232059))
* [`81bc5f3d`](https://github.com/NixOS/nixpkgs/commit/81bc5f3db8f9ba812836036d5d3e54e933ca2cd6) pkgs/linux: Vendor maple tree patch
* [`88e57d0b`](https://github.com/NixOS/nixpkgs/commit/88e57d0bb238d296a2b57a21d722ed95f115630e) vpv: init at 0.8.1
* [`66f045a6`](https://github.com/NixOS/nixpkgs/commit/66f045a65f89ec18af9e1f8cf5eb45cef37a0eee) betaflight-configurator: reduce size
* [`8a4f0162`](https://github.com/NixOS/nixpkgs/commit/8a4f016281d5d1458013aef414e17574f883d338) nixos/maddy: tls.loader add acme support, add secrets option
* [`2abc432a`](https://github.com/NixOS/nixpkgs/commit/2abc432af3456a360446cebf942f2bbc10f03184) bilibili: 1.9.2-1 -> 1.10.1-1
* [`1d37fe15`](https://github.com/NixOS/nixpkgs/commit/1d37fe1526f18f315eec9cd1a9f75846a1acddce) nixos/openvscode-server: init
* [`cce7cdd2`](https://github.com/NixOS/nixpkgs/commit/cce7cdd2938c02a550270ef0e8185b4da9f66860) nixosTests.openvscode-server: init
* [`0aab74c3`](https://github.com/NixOS/nixpkgs/commit/0aab74c3efb57cd659a9679689da8036b148d2db) python310Packages.types-pillow: 9.4.0.17 -> 9.5.0.4
* [`f1ad4e25`](https://github.com/NixOS/nixpkgs/commit/f1ad4e2582b9ae5477df819b641c1f1c72738899) dog: support cross-compilation
* [`c2eefa77`](https://github.com/NixOS/nixpkgs/commit/c2eefa7785cd271abba157c0f29e37668565f0b4) python311Packages.aioesphomeapi: 13.7.4 -> 13.7.5
* [`1794d78d`](https://github.com/NixOS/nixpkgs/commit/1794d78df4cc08453a6c482bec8acdec517c26e5) python311Packages.hahomematic: 2023.5.1 -> 2023.5.2
* [`77668613`](https://github.com/NixOS/nixpkgs/commit/776686132f33ea8e0c9549c2e8cffc2bb503ccf7) python311Packages.losant-rest: 1.17.3 -> 1.17.4
* [`437220cd`](https://github.com/NixOS/nixpkgs/commit/437220cd683bb6038dfeac075285269e79c61b9f) python311Packages.dvc-render: 0.4.0 -> 0.5.0
* [`591e14d6`](https://github.com/NixOS/nixpkgs/commit/591e14d6caf9c2cd4382d3a2375f2c8e0d851c20) python310Packages.dvclive: 2.8.1 -> 2.9.0
* [`0ad5a247`](https://github.com/NixOS/nixpkgs/commit/0ad5a24738e0f456a1f2c43e2381fe51f75fa0b8) pngcheck: support cross compilation and install man page
* [`bab30c06`](https://github.com/NixOS/nixpkgs/commit/bab30c06f176eef80cb5e110102583c13d883fbb) dumptorrent: support cross compilation
* [`f5ab2390`](https://github.com/NixOS/nixpkgs/commit/f5ab2390de07615b7c86b5af1b3b94fc31d05853) _90secondportraits: use copyDesktopItems
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
