### PR TITLE
niv devenv: update 1344383a -> 2f1d49ae

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "1344383a60ac5d18eb0f85555023004755bc2d11",
-        "sha256": "1kzvm6c7idf5dnkh6whl1ndb4xfg9xsgz54s36b741ayqxf65s3k",
+        "rev": "2f1d49aeee1378c44293ca2f61bf3a9004986fb7",
+        "sha256": "1p0rvv3izj7ajp6aljavrk060x7vf2mkqgpzk47r8dfjcb0i7dwd",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/1344383a60ac5d18eb0f85555023004755bc2d11.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/2f1d49aeee1378c44293ca2f61bf3a9004986fb7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@1344383a...2f1d49ae](https://github.com/cachix/devenv/compare/1344383a60ac5d18eb0f85555023004755bc2d11...2f1d49aeee1378c44293ca2f61bf3a9004986fb7)

* [`db5bcec5`](https://github.com/cachix/devenv/commit/db5bcec51859924fcf9c18ffffe18abb617c674c) Remove extra spaces for CI
* [`3006bd4b`](https://github.com/cachix/devenv/commit/3006bd4b571fb2ef0df79725e9ec46f7f9b89063) Update nix lang link in basics doc
* [`0b81b57a`](https://github.com/cachix/devenv/commit/0b81b57a85897781b189423819842a9933a80f4c) Add support for Gleam language.
* [`b48f9ebe`](https://github.com/cachix/devenv/commit/b48f9ebe57ead1f3c755ed9a0ecc1abd3492a136) Auto generate docs/reference/options.md
* [`dea4ad90`](https://github.com/cachix/devenv/commit/dea4ad9035b6ad0cde20101a608303925df564d4) postgres: make the unix socket setting overridable
* [`71cb1a97`](https://github.com/cachix/devenv/commit/71cb1a97c6c570194a5472b6416b22edecb2671f) docs: add missing build dependency
* [`3d36606e`](https://github.com/cachix/devenv/commit/3d36606e03f1679753224e6c8a63e762320fd8a2) ruby: fix macos tests
* [`ae998857`](https://github.com/cachix/devenv/commit/ae998857be05348fcfe896cab71b8b758c6a11d6) ruby: add bundler options and priotize bundler above ruby
* [`0443677c`](https://github.com/cachix/devenv/commit/0443677c79de0d98c1311a5bf0f46194081bf91b) examples: ruby: restrict ruby in Gemfile
* [`e5b37df6`](https://github.com/cachix/devenv/commit/e5b37df68c51992ea2cb346260194dfc790c5a1f) examples: ruby: test for bundler
* [`c560239e`](https://github.com/cachix/devenv/commit/c560239ef0ab4514108d53fe50db2d7489677f8b) ruby: bundler: override ruby for bundler package
* [`e791b1d1`](https://github.com/cachix/devenv/commit/e791b1d165a2ac71227950ea7236dea67316c5a7) examples: ruby: nixpkgs-ruby should follows nixpkgs for now
* [`2f1d49ae`](https://github.com/cachix/devenv/commit/2f1d49aeee1378c44293ca2f61bf3a9004986fb7) Auto generate docs/reference/options.md
