### PR TITLE
niv home-manager: update c0deab0e -> d9995d94

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0deab0effd576e70343cb5df0c64428e0e0d010",
-        "sha256": "116sfxrabapw1hz6cvr8digr2lgx0h421yh2h11fxi601c5d6qf4",
+        "rev": "d9995d94f194955d1f1af0e1ad5866a904196c20",
+        "sha256": "1j887rbq7pagv819ivbrzga10lj37mff83z35cy2p21z9pqzy2kv",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c0deab0effd576e70343cb5df0c64428e0e0d010.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d9995d94f194955d1f1af0e1ad5866a904196c20.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c0deab0e...d9995d94](https://github.com/nix-community/home-manager/compare/c0deab0effd576e70343cb5df0c64428e0e0d010...d9995d94f194955d1f1af0e1ad5866a904196c20)

* [`b7d814c5`](https://github.com/nix-community/home-manager/commit/b7d814c5744dca7e70b3dc2638f06568dce96ca6) tests: bump nmt to latest
* [`e14e7970`](https://github.com/nix-community/home-manager/commit/e14e797041e393abd1ffab597d299a72d3b582e5) neomutt: add missing stub in test ([nix-community/home-manager⁠#3996](https://togithub.com/nix-community/home-manager/issues/3996))
* [`59659243`](https://github.com/nix-community/home-manager/commit/59659243cd4ababda605e79b4a9c2e6d83e24c86) PR_TEMPLATE: Note nix3 test method in checklist ([nix-community/home-manager⁠#3972](https://togithub.com/nix-community/home-manager/issues/3972))
* [`c10403a5`](https://github.com/nix-community/home-manager/commit/c10403a5739d6275334710903fe709bc8d587980) Update ssh.nix ([nix-community/home-manager⁠#4000](https://togithub.com/nix-community/home-manager/issues/4000))
* [`b9a52ad2`](https://github.com/nix-community/home-manager/commit/b9a52ad20e58ebd003444915e35e3dd2c18fc715) script-directory: add module ([nix-community/home-manager⁠#3995](https://togithub.com/nix-community/home-manager/issues/3995))
* [`27ef11f0`](https://github.com/nix-community/home-manager/commit/27ef11f0218d9018ebb2948d40133df2b1de622d) helix: update languages.toml generation (support every option in languages.toml) ([nix-community/home-manager⁠#4003](https://togithub.com/nix-community/home-manager/issues/4003))
* [`13a74643`](https://github.com/nix-community/home-manager/commit/13a74643d72b1891b03f2566983819d451bd4b56) home-manager: fix error message in flake check
* [`ba006d7c`](https://github.com/nix-community/home-manager/commit/ba006d7cca2cb871c6a31bdbc130c05cde5ca8e8) script-directory: fix news entry ([nix-community/home-manager⁠#4010](https://togithub.com/nix-community/home-manager/issues/4010))
* [`d9995d94`](https://github.com/nix-community/home-manager/commit/d9995d94f194955d1f1af0e1ad5866a904196c20) lib/file-type: fix xrefs ([nix-community/home-manager⁠#4007](https://togithub.com/nix-community/home-manager/issues/4007))
