### PR TITLE
niv powerlevel10k: update 9b47a22f -> 951d6957

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "9b47a22f13402ba95262b66ada569f122f5528a0",
-        "sha256": "16y57mzmjc56glwwzg4v6cgxz5j8r5za8ngsrmjazsrd30qd6lb2",
+        "rev": "951d6957895b1887567b3ea7e548f9533daa3c83",
+        "sha256": "05hhk0v1vq0xjrcsgkcgq7is62bnji6n74zqm5cj19d68pyrvari",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/9b47a22f13402ba95262b66ada569f122f5528a0.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/951d6957895b1887567b3ea7e548f9533daa3c83.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@9b47a22f...951d6957](https://github.com/romkatv/powerlevel10k/compare/9b47a22f13402ba95262b66ada569f122f5528a0...951d6957895b1887567b3ea7e548f9533daa3c83)

* [`a69aa22f`](https://github.com/romkatv/powerlevel10k/commit/a69aa22fa8a4fe0927bb73716c2f7c9d2580a51d) show the right cwd when some part of it gets renamed ([romkatv/powerlevel10k⁠#2304](https://togithub.com/romkatv/powerlevel10k/issues/2304))
* [`951d6957`](https://github.com/romkatv/powerlevel10k/commit/951d6957895b1887567b3ea7e548f9533daa3c83) Update README.md
