### PR TITLE
niv zsh-completions: update 449cc702 -> a7bdfdf5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "449cc702dc0363cd8fc37cc2d1fdb422f6d4d0e8",
-        "sha256": "1ps0ixmlfdrpg0ikx97ikgpskrd7w49qjk22izzi5cw8ychgqi6r",
+        "rev": "a7bdfdf56e4e76dc302e270f965f96d8c70929e6",
+        "sha256": "0dxriaji8n3wclrmd9yc13j9269x3h3n383isr3jl3m7zklgmm73",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/449cc702dc0363cd8fc37cc2d1fdb422f6d4d0e8.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/a7bdfdf56e4e76dc302e270f965f96d8c70929e6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@449cc702...a7bdfdf5](https://github.com/zsh-users/zsh-completions/compare/449cc702dc0363cd8fc37cc2d1fdb422f6d4d0e8...a7bdfdf56e4e76dc302e270f965f96d8c70929e6)

* [`7427f0a2`](https://github.com/zsh-users/zsh-completions/commit/7427f0a29479275c7c5b6f0728ac327aaa09dda2) Add dart completion
* [`4f59353f`](https://github.com/zsh-users/zsh-completions/commit/4f59353fe14cbeb9addbe93f16c7f7090fcd0f07) Remove deprecated 'flutter format' completion
* [`4516f61d`](https://github.com/zsh-users/zsh-completions/commit/4516f61d969148dc41afa7757146e5b166261ec0) Support 'fvm dart' completion
* [`212b0d50`](https://github.com/zsh-users/zsh-completions/commit/212b0d50f1b81212c3f5f6bd196e806a43fe0b83) Add tsc and ts-node completions
* [`8990e740`](https://github.com/zsh-users/zsh-completions/commit/8990e74097c8cb03234798c16e2f88dcd283796f) Update vnstat completion
