### PR TITLE
niv emacs-overlay: update ff0f8af5 -> 2806dea6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6",
-        "sha256": "11ifgvbvjlymjcvg2b1cb16qcch7h19l373rb4wphm07p12k6ain",
+        "rev": "2806dea6457fed28013169a05a6dcf9c722d5465",
+        "sha256": "18l9y79sdq6faqaqlc8rxa8nd3mbd6ymqd5fl5iy0pdn95c1vz22",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/2806dea6457fed28013169a05a6dcf9c722d5465.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@ff0f8af5...2806dea6](https://github.com/nix-community/emacs-overlay/compare/ff0f8af5d4f511adf3a3252d1c09bfdc1912e8c6...2806dea6457fed28013169a05a6dcf9c722d5465)

* [`b16aa6ad`](https://github.com/nix-community/emacs-overlay/commit/b16aa6adfa4441d21ffbc03eb4bd920ab33f9e1d) Updated repos/elpa
* [`b9322bb7`](https://github.com/nix-community/emacs-overlay/commit/b9322bb77735b382ebc85fd49d2e7cd27c494ebe) Updated repos/melpa
* [`7f7a4a26`](https://github.com/nix-community/emacs-overlay/commit/7f7a4a26bcdb1e55ce53a688224a5c4b41b52d40) Updated repos/emacs
* [`e9ce36f0`](https://github.com/nix-community/emacs-overlay/commit/e9ce36f0a9be20f669f6decefe04e0e8ebef97c4) Updated repos/emacs
* [`86b479f9`](https://github.com/nix-community/emacs-overlay/commit/86b479f9dde9f84afe82a09ef5fbf568d8b69443) Updated repos/elpa
* [`bc5b7755`](https://github.com/nix-community/emacs-overlay/commit/bc5b7755626ebb5f4170ea487441542d68ca2ad5) Updated repos/emacs
* [`c714a62e`](https://github.com/nix-community/emacs-overlay/commit/c714a62eadc38c9a568bd3bce2892e2cab75b86d) Updated repos/melpa
* [`92fde964`](https://github.com/nix-community/emacs-overlay/commit/92fde9649b26dce1bd29924086360987cc8c7b2b) Updated repos/melpa
* [`7e92a74b`](https://github.com/nix-community/emacs-overlay/commit/7e92a74b402e39056ca0bfae6bfc758552503866) Updated repos/emacs
* [`ca955fac`](https://github.com/nix-community/emacs-overlay/commit/ca955facdc9b29fde6dbd12823b7f4809fc5f18b) Updated repos/melpa
* [`f5719229`](https://github.com/nix-community/emacs-overlay/commit/f57192297f370f8f01b1476023ca29caf032b20a) Updated repos/emacs
* [`9ce6881c`](https://github.com/nix-community/emacs-overlay/commit/9ce6881c337289f24f1514cd052141c1552ddde1) Updated repos/melpa
* [`9eb99c31`](https://github.com/nix-community/emacs-overlay/commit/9eb99c310710d00bf76e310b7911444705305ac1) Updated repos/emacs
* [`8459a591`](https://github.com/nix-community/emacs-overlay/commit/8459a591ac280c044465359d110d981bf46faa7b) Updated repos/melpa
* [`66321c1f`](https://github.com/nix-community/emacs-overlay/commit/66321c1feed738c78bae6462fbbf18379fea2678) Updated repos/emacs
* [`38cedeb8`](https://github.com/nix-community/emacs-overlay/commit/38cedeb83b1ecc5ead82e6fe943dc3473627f3f6) Updated repos/melpa
* [`afb6411e`](https://github.com/nix-community/emacs-overlay/commit/afb6411ee8d3a8162ad8773162c031cb7c40383e) Updated repos/emacs
* [`42a2a718`](https://github.com/nix-community/emacs-overlay/commit/42a2a718bdcbe389e7ef284666d4aba09339a416) Updated repos/melpa
* [`5f9bc90b`](https://github.com/nix-community/emacs-overlay/commit/5f9bc90bd2fd0bf53cc4e2643b083fa75b358461) Updated repos/melpa
* [`e0902043`](https://github.com/nix-community/emacs-overlay/commit/e0902043a891c61adcca88b7697ce322022a2663) Updated repos/melpa
* [`6531e307`](https://github.com/nix-community/emacs-overlay/commit/6531e30704d09a017096945087cf8cfbdda0ce8a) Updated repos/emacs
* [`24984a17`](https://github.com/nix-community/emacs-overlay/commit/24984a172baa197143d5983e9ab1b0e4cff72b30) Updated repos/melpa
* [`ea185dc2`](https://github.com/nix-community/emacs-overlay/commit/ea185dc25842517a953ffa3669dc5c42a3537461) Updated repos/nongnu
* [`88c96778`](https://github.com/nix-community/emacs-overlay/commit/88c96778a9d536e3127dacd15d9272cf546fb6e0) Updated repos/emacs
* [`c6b0d4f8`](https://github.com/nix-community/emacs-overlay/commit/c6b0d4f80939d6ca1a6c35767ca9e327563cb70a) Updated repos/melpa
* [`1368f04f`](https://github.com/nix-community/emacs-overlay/commit/1368f04fa0fe140d6aeda411e08f51cea8a86e8d) Updated repos/nongnu
* [`be510b24`](https://github.com/nix-community/emacs-overlay/commit/be510b24fec289d602f3f9d96aebe685d3d3a080) Updated repos/melpa
* [`45390ac3`](https://github.com/nix-community/emacs-overlay/commit/45390ac325cf96b5ddab60d7dcf93a8ae8bb6705) Updated repos/elpa
* [`807dfca1`](https://github.com/nix-community/emacs-overlay/commit/807dfca1f6deebd2a4224f78fc64c1eea803876b) Updated repos/emacs
* [`e0b9cb72`](https://github.com/nix-community/emacs-overlay/commit/e0b9cb722b80f55bb6f851a3f61e52b9247917e7) Updated repos/melpa
* [`5e73b139`](https://github.com/nix-community/emacs-overlay/commit/5e73b1394d1803169779e261f69f9f3afc2bda32) Updated repos/emacs
* [`927b8020`](https://github.com/nix-community/emacs-overlay/commit/927b8020ce1f98b23568061cf6dd5594be294ff4) Updated repos/melpa
* [`99161e3c`](https://github.com/nix-community/emacs-overlay/commit/99161e3cad53bc4a372899b633bef820efe0abed) Updated repos/emacs
* [`1f1b95c4`](https://github.com/nix-community/emacs-overlay/commit/1f1b95c4fca959fac6dad0e0a7156bd9f0b2071e) Updated repos/melpa
* [`0fdaa4ae`](https://github.com/nix-community/emacs-overlay/commit/0fdaa4ae06d2e9c534841d6b91c2d2aa99d9c2ac) Updated repos/elpa
* [`8522f60c`](https://github.com/nix-community/emacs-overlay/commit/8522f60ce0d7900ccb604b42e4c397e54d9387a6) Updated repos/emacs
* [`3b885f77`](https://github.com/nix-community/emacs-overlay/commit/3b885f77c366a83f021375bf7252185bc1c914d5) Updated repos/melpa
* [`21d40b52`](https://github.com/nix-community/emacs-overlay/commit/21d40b527260498eeb9aed8d2200e4f79d6b152c) Updated repos/nongnu
* [`3326dd49`](https://github.com/nix-community/emacs-overlay/commit/3326dd49b853982b7c397510c0817ad2835e4dfc) Updated repos/melpa
* [`c25f4cb9`](https://github.com/nix-community/emacs-overlay/commit/c25f4cb97b6efaac40971e73fe8ad94450ad81ad) Updated repos/nongnu
* [`b44c5279`](https://github.com/nix-community/emacs-overlay/commit/b44c5279cbdbbaff6d89120c4467548b3ace59bc) Updated repos/melpa
* [`e7f98354`](https://github.com/nix-community/emacs-overlay/commit/e7f983545565e1c6dc0fab2800eb3ba6e63d87ef) Updated repos/emacs
* [`56eb6aa1`](https://github.com/nix-community/emacs-overlay/commit/56eb6aa1df5361a751b6d36f0c7f0e8b93d5ed52) Updated repos/melpa
* [`455fd36f`](https://github.com/nix-community/emacs-overlay/commit/455fd36fed041e008cd62139820a96777000eb2d) Updated repos/nongnu
* [`f7875e12`](https://github.com/nix-community/emacs-overlay/commit/f7875e12ba554c480a9cc5bdaabb7bd4af49ab01) Updated repos/melpa
* [`a160e897`](https://github.com/nix-community/emacs-overlay/commit/a160e897d1f9f3b0fedf191a79d8ab99a09bcfd6) Updated repos/nongnu
* [`5aa2545f`](https://github.com/nix-community/emacs-overlay/commit/5aa2545f47e7da23b17653f26905d306587753ff) Updated repos/elpa
* [`4fcd9f9f`](https://github.com/nix-community/emacs-overlay/commit/4fcd9f9f582537d6b0ac6332eb22dd543a58212e) Updated repos/emacs
* [`5faeffd3`](https://github.com/nix-community/emacs-overlay/commit/5faeffd3d6d7f35348ef21f5245da783c7cd395f) Updated repos/melpa
* [`3e6b225d`](https://github.com/nix-community/emacs-overlay/commit/3e6b225de6dd5b0882575c78eb35832861926a01) Updated repos/emacs
* [`86884a77`](https://github.com/nix-community/emacs-overlay/commit/86884a7788f2bae2d8e61c666454d0f8e8cd6436) Updated repos/melpa
* [`6fe1b6ed`](https://github.com/nix-community/emacs-overlay/commit/6fe1b6ed8880aa6631be652b9c7eac98bca7307f) Updated repos/nongnu
* [`59216360`](https://github.com/nix-community/emacs-overlay/commit/592163607796fde463be9ef4a274199587fd0578) Updated repos/melpa
* [`5699d7d9`](https://github.com/nix-community/emacs-overlay/commit/5699d7d9a8a16f24f60dfb113a6364357a44ddb8) Updated repos/elpa
* [`4b9c4f3e`](https://github.com/nix-community/emacs-overlay/commit/4b9c4f3e81b89d614f699bfdca2100d4d08ed6da) Updated repos/emacs
* [`e9cef363`](https://github.com/nix-community/emacs-overlay/commit/e9cef3633f160bf671b9196bce99467629b5133e) Updated repos/melpa
* [`7088aa8a`](https://github.com/nix-community/emacs-overlay/commit/7088aa8ae10401974d31309ad34b9329ac986b35) Updated repos/elpa
* [`fe4fff6e`](https://github.com/nix-community/emacs-overlay/commit/fe4fff6e1f1df516e26a46053be025220812c8c7) Updated repos/melpa
* [`e6b5351e`](https://github.com/nix-community/emacs-overlay/commit/e6b5351ef8059316e5114626f473dd15994318db) Updated repos/melpa
* [`54ee34be`](https://github.com/nix-community/emacs-overlay/commit/54ee34beac07927cbc3b410f4f72cf8e55724cda) Updated repos/elpa
* [`93aecc81`](https://github.com/nix-community/emacs-overlay/commit/93aecc818fe8aeb36c7db226c285782fa1a662a7) Updated repos/emacs
* [`f8da8193`](https://github.com/nix-community/emacs-overlay/commit/f8da819375f9e8e41a22bfb2b299750c942b90d7) Updated repos/melpa
* [`d21ddf4a`](https://github.com/nix-community/emacs-overlay/commit/d21ddf4ac8afb13bd55440191a404d03b847edd3) Updated repos/elpa
* [`2948ffc1`](https://github.com/nix-community/emacs-overlay/commit/2948ffc1d2d9ca9bcb22297234dadd369633e87b) Updated repos/melpa
* [`523d2a9d`](https://github.com/nix-community/emacs-overlay/commit/523d2a9d5de18e423e031236fe5f725c8f837459) Updated repos/melpa
* [`399fbe3b`](https://github.com/nix-community/emacs-overlay/commit/399fbe3bece5760eec63f0c3cae52ed84e9f6e28) Updated repos/elpa
* [`e1c896e1`](https://github.com/nix-community/emacs-overlay/commit/e1c896e1e9448a6e383bafb28251d90c33ed772d) Updated repos/emacs
* [`b0100f5f`](https://github.com/nix-community/emacs-overlay/commit/b0100f5fdc823be12bbcb31bcc5293fc74e04a56) Updated repos/melpa
* [`96b86966`](https://github.com/nix-community/emacs-overlay/commit/96b869664b0ac95ca663bf8193997349d85d6710) Updated repos/elpa
* [`5a6b94af`](https://github.com/nix-community/emacs-overlay/commit/5a6b94af408be55d38fa1b8e70d611eff0238b0c) Updated repos/emacs
* [`12024c92`](https://github.com/nix-community/emacs-overlay/commit/12024c92a6af3f4c3f96ee8b6a4f7d271fa2507e) Updated repos/melpa
* [`344aa306`](https://github.com/nix-community/emacs-overlay/commit/344aa3068e31728d386f8be1cbeb3c93ad415606) Updated repos/emacs
* [`e21161b6`](https://github.com/nix-community/emacs-overlay/commit/e21161b6dc1105dda3bc39285ee304c0246249a3) Updated repos/melpa
* [`c9266074`](https://github.com/nix-community/emacs-overlay/commit/c9266074575d3067996db265ff70362af9eb4c0b) Updated repos/nongnu
* [`77437c3b`](https://github.com/nix-community/emacs-overlay/commit/77437c3bc8a6cd7057e3ec8032c8d987199a9da8) Updated repos/elpa
* [`562094fa`](https://github.com/nix-community/emacs-overlay/commit/562094fa746d70f2d6575165e349afd935cb61d5) Updated repos/emacs
* [`1e922fda`](https://github.com/nix-community/emacs-overlay/commit/1e922fda2d7f6e29844ea215b7e4e110ba6ee4bf) Updated repos/melpa
* [`c4f91e0b`](https://github.com/nix-community/emacs-overlay/commit/c4f91e0b5fe9de0c58beeaf524bde380f3e74bf4) Updated repos/elpa
* [`fc1f1e0d`](https://github.com/nix-community/emacs-overlay/commit/fc1f1e0d1a4132939df71ad63b7be0e726fc1844) Updated repos/melpa
* [`ecbd0cc0`](https://github.com/nix-community/emacs-overlay/commit/ecbd0cc016443a5492338993c9f5f5da3da03d5e) Updated repos/emacs
* [`bea7c7ba`](https://github.com/nix-community/emacs-overlay/commit/bea7c7ba1c24ff791f2506e8af6e4eb88a414af5) Updated repos/melpa
* [`9a9271d9`](https://github.com/nix-community/emacs-overlay/commit/9a9271d9e599f96bf35039e9df3426b42c4b8e63) Updated repos/emacs
* [`39aaaf04`](https://github.com/nix-community/emacs-overlay/commit/39aaaf0465f7278b9f28358ff154ed26475620fe) Updated repos/melpa
* [`3fc9857c`](https://github.com/nix-community/emacs-overlay/commit/3fc9857cccad4eafd02cf4e060dc71e73359a643) Updated repos/elpa
* [`c6cf3fb5`](https://github.com/nix-community/emacs-overlay/commit/c6cf3fb55c42a1344ef578121956a5440873c40e) Updated repos/melpa
* [`023d9770`](https://github.com/nix-community/emacs-overlay/commit/023d9770e37b6af1856b4ac506dd5cb9ce7db01d) Updated repos/nongnu
* [`bd593adc`](https://github.com/nix-community/emacs-overlay/commit/bd593adc4469b86260085d8ac3148c6d5a65a669) Updated repos/melpa
* [`40c99422`](https://github.com/nix-community/emacs-overlay/commit/40c99422b0a022ba8ae62ed40899c5089fd0885f) Updated repos/elpa
* [`44c65a19`](https://github.com/nix-community/emacs-overlay/commit/44c65a19dbc861423eadb52995ef2f825435eabe) Updated repos/emacs
* [`fabfebd7`](https://github.com/nix-community/emacs-overlay/commit/fabfebd7b94348ff179d630d192da5c62429a68d) Updated repos/melpa
* [`0cd24f74`](https://github.com/nix-community/emacs-overlay/commit/0cd24f74d6d5ec9a881af1c149aefc4503261825) Updated repos/elpa
* [`977b854e`](https://github.com/nix-community/emacs-overlay/commit/977b854eac3fb6802d7adcab15a242ffe82c9301) Updated repos/melpa
* [`f4a8c7d5`](https://github.com/nix-community/emacs-overlay/commit/f4a8c7d56584b087ae1eff81f4419029ab42fa69) Updated repos/nongnu
* [`edfd74f3`](https://github.com/nix-community/emacs-overlay/commit/edfd74f3705815b93cc4fb7759376f4f2e101334) Updated repos/emacs
* [`9b41f829`](https://github.com/nix-community/emacs-overlay/commit/9b41f8296a3898bdb87b9d091f9df540a982b242) Updated repos/melpa
* [`4a6aaa0c`](https://github.com/nix-community/emacs-overlay/commit/4a6aaa0c97057dc7a2ba82a9e16d5524f84f004f) Updated repos/emacs
* [`e4cc7646`](https://github.com/nix-community/emacs-overlay/commit/e4cc7646293b591244f9e1cacdab53170084846b) Updated repos/melpa
* [`67fd0f86`](https://github.com/nix-community/emacs-overlay/commit/67fd0f86c7be58f14ec840b9823d5c8d60912eb4) Updated repos/emacs
* [`2086d4d6`](https://github.com/nix-community/emacs-overlay/commit/2086d4d64e443bd81df254d037885b44254df75f) Updated repos/melpa
* [`f8824fa1`](https://github.com/nix-community/emacs-overlay/commit/f8824fa1a882d07921d229c35d7076428e9d9075) Updated repos/nongnu
* [`920411b5`](https://github.com/nix-community/emacs-overlay/commit/920411b53cefe79eed0a462df11278df8306e1de) Updated repos/emacs
* [`adefd0c1`](https://github.com/nix-community/emacs-overlay/commit/adefd0c1974731350a6ec6b960178bb9fa970942) Updated repos/melpa
* [`aad7bd32`](https://github.com/nix-community/emacs-overlay/commit/aad7bd32496f49d5cc05b7929752886bbdb264ca) Updated repos/elpa
* [`dde451de`](https://github.com/nix-community/emacs-overlay/commit/dde451ded0f4fd7d8812f1537ac29aee2692bea1) Updated repos/emacs
* [`338da822`](https://github.com/nix-community/emacs-overlay/commit/338da822b1506c26c18e6fced9527a8de4f08665) Updated repos/melpa
* [`2b441f5b`](https://github.com/nix-community/emacs-overlay/commit/2b441f5b9c86c967539783b9cda078d4be3eee29) Updated repos/elpa
* [`92b2a377`](https://github.com/nix-community/emacs-overlay/commit/92b2a37794728c2e8a867ed6d22f559b3c67f9c1) Updated repos/emacs
* [`c691550c`](https://github.com/nix-community/emacs-overlay/commit/c691550c6c01e1684e80024b7243873a0f17c688) Updated repos/melpa
* [`016a781c`](https://github.com/nix-community/emacs-overlay/commit/016a781cc93d3c7f7005b6ba12f667e9861056e0) Updated repos/nongnu
* [`55139469`](https://github.com/nix-community/emacs-overlay/commit/551394696c8db0fa65cc3e49fa6a81bc733b7a8a) Updated repos/melpa
* [`0da5effd`](https://github.com/nix-community/emacs-overlay/commit/0da5effdc8bef9bbfb4938ccb8a21dd22f47760f) added missing 'pkgs.' at start of package name for example. ([nix-community/emacs-overlay⁠#324](https://togithub.com/nix-community/emacs-overlay/issues/324))
* [`434e9c63`](https://github.com/nix-community/emacs-overlay/commit/434e9c63d4cedb9b8bcbd75ebdef00268e135459) Updated repos/emacs
* [`95c844b1`](https://github.com/nix-community/emacs-overlay/commit/95c844b1985808df780acc1835a354fe3ff27282) Updated repos/melpa
* [`743b7d89`](https://github.com/nix-community/emacs-overlay/commit/743b7d89b7525531458beb333aed29e1261bbd38) Updated repos/elpa
* [`5843c82e`](https://github.com/nix-community/emacs-overlay/commit/5843c82e182db1c246c0849a500c51991f62a83c) Updated repos/emacs
* [`8c867d0f`](https://github.com/nix-community/emacs-overlay/commit/8c867d0fbab638cdb4707feae3d2d2245315bd68) Updated repos/melpa
* [`8fc1eaa8`](https://github.com/nix-community/emacs-overlay/commit/8fc1eaa840ea7cdf601c7bb3479b6418ebb06d35) Updated repos/emacs
* [`f438072a`](https://github.com/nix-community/emacs-overlay/commit/f438072ac6d2a0271a0ac5ad566d9612a9b35bb9) Updated repos/melpa
* [`2b2674b8`](https://github.com/nix-community/emacs-overlay/commit/2b2674b88fbb73b028dd21a7394c9dde30f80bb4) Updated repos/elpa
* [`d63827ee`](https://github.com/nix-community/emacs-overlay/commit/d63827ee414eb99d8791d1db0d95c2a0521af843) Updated repos/emacs
* [`859e27b4`](https://github.com/nix-community/emacs-overlay/commit/859e27b4dccdfee45ea258510bbfcceaa527a85e) Updated repos/melpa
* [`1d37ae5b`](https://github.com/nix-community/emacs-overlay/commit/1d37ae5b3815f1723c9cf24096414b1ea44bd2e5) Updated repos/elpa
* [`fa8e1c5a`](https://github.com/nix-community/emacs-overlay/commit/fa8e1c5a787356fe12a56d915f23fd93660ba2e9) Updated repos/melpa
* [`34e7e913`](https://github.com/nix-community/emacs-overlay/commit/34e7e913bb78cbb10a1fac073b55eaacb10c1f7c) Updated repos/nongnu
* [`9d1c3a8f`](https://github.com/nix-community/emacs-overlay/commit/9d1c3a8f981b7f95b2d7d92b0b18b5796e49a3c4) Updated repos/emacs
* [`b17ab0c8`](https://github.com/nix-community/emacs-overlay/commit/b17ab0c887c0332ea0006f7522da58833084b4e3) Updated repos/melpa
* [`bbf5f5da`](https://github.com/nix-community/emacs-overlay/commit/bbf5f5da6bd4c6e002dd766b8c337a0c40f7c467) Updated repos/nongnu
* [`3901afec`](https://github.com/nix-community/emacs-overlay/commit/3901afec03ce67ecb377eac43c401cfb29508584) Updated repos/elpa
* [`deeb9232`](https://github.com/nix-community/emacs-overlay/commit/deeb9232d4545b989cb0ec025db5eacaaa0ed400) Updated repos/melpa
* [`18bfb00e`](https://github.com/nix-community/emacs-overlay/commit/18bfb00ee5e6fed0ad873bc2702ebf6131a7a4a3) Updated repos/melpa
* [`0bd4cb5e`](https://github.com/nix-community/emacs-overlay/commit/0bd4cb5ef11985ad1eb6f6ad7e24d0cd86e91dd5) Updated repos/melpa
* [`a506541e`](https://github.com/nix-community/emacs-overlay/commit/a506541e0dcd1b2bf0c4268d88dfc62fb6a50f4e) Updated repos/elpa
* [`54a099d3`](https://github.com/nix-community/emacs-overlay/commit/54a099d3c0c09d2117539075951ce4d0eac67312) Updated repos/emacs
* [`b4d748b3`](https://github.com/nix-community/emacs-overlay/commit/b4d748b3b06fece127426314c1e42e238da9c4e7) Updated repos/melpa
* [`d8223443`](https://github.com/nix-community/emacs-overlay/commit/d8223443e229d973f1ba287d18df8431bf5bc9c6) Updated repos/emacs
* [`925b7805`](https://github.com/nix-community/emacs-overlay/commit/925b78051c9c8d2a5908483927046a8802377c5a) Updated repos/melpa
* [`25cbd5b0`](https://github.com/nix-community/emacs-overlay/commit/25cbd5b0f32cab75356a0a8e73aa2913529db36a) Updated repos/nongnu
* [`fd44d0d5`](https://github.com/nix-community/emacs-overlay/commit/fd44d0d55374c24bf92aa59b4131a5cada358bb6) Updated repos/melpa
* [`af00099e`](https://github.com/nix-community/emacs-overlay/commit/af00099ef2272d442b90dc888ecd2a1543748144) Updated repos/elpa
* [`c3f786d5`](https://github.com/nix-community/emacs-overlay/commit/c3f786d5c27e7c9337ec28299d360b4d99d01cf3) Updated repos/emacs
* [`9a0b3d89`](https://github.com/nix-community/emacs-overlay/commit/9a0b3d89865cd20ebbfbdc8573a8e7eed70ab205) Updated repos/melpa
* [`4f65398a`](https://github.com/nix-community/emacs-overlay/commit/4f65398a9b2739e61db17ddbc1642117f1a5c1ca) Updated repos/melpa
* [`e1aa2803`](https://github.com/nix-community/emacs-overlay/commit/e1aa280376d294408cc97b068aa98b5f7bf0c9ec) Updated repos/emacs
* [`37d3fd88`](https://github.com/nix-community/emacs-overlay/commit/37d3fd88e6e7c7dd3b5b659cf3cf18f0d81a55c9) Updated repos/melpa
* [`93fa3515`](https://github.com/nix-community/emacs-overlay/commit/93fa3515c250d0a92adb993c6adf3edd73f259b2) Updated repos/elpa
* [`40b39715`](https://github.com/nix-community/emacs-overlay/commit/40b3971545145dbff2a0e811ea297c9b346c3ddf) Updated repos/emacs
* [`27d44f3b`](https://github.com/nix-community/emacs-overlay/commit/27d44f3be97f9a3e21e076052af0532719b59c91) Updated repos/melpa
* [`082c2c37`](https://github.com/nix-community/emacs-overlay/commit/082c2c3775c7fba9642e02106cc19dee1f997e54) Updated repos/emacs
* [`2806dea6`](https://github.com/nix-community/emacs-overlay/commit/2806dea6457fed28013169a05a6dcf9c722d5465) Updated repos/melpa
