### PR TITLE
niv nixpkgs: update 273b32ab -> 4295779f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "273b32abe2565301552f0874c97ea954a8db67c9",
-        "sha256": "0nb60mna88z4v05hc0zkh3z12af6gprr6vwzqqw5dxh94hpcbjir",
+        "rev": "4295779fbaacb7158d5f32c4aa2740ef7b56d91b",
+        "sha256": "0996zv18q37mwcx2zwa9hhmc6mbr86y7sa8n3llcbb4ghz3aq0j0",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/273b32abe2565301552f0874c97ea954a8db67c9.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4295779fbaacb7158d5f32c4aa2740ef7b56d91b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@273b32ab...4295779f](https://github.com/nixos/nixpkgs/compare/273b32abe2565301552f0874c97ea954a8db67c9...4295779fbaacb7158d5f32c4aa2740ef7b56d91b)

* [`d66d778a`](https://github.com/NixOS/nixpkgs/commit/d66d778a2261e80a505910edb45965ec14e9a04c) sharpsat-td: init at unstable-2021-09-05
* [`0e3abbdc`](https://github.com/NixOS/nixpkgs/commit/0e3abbdce5edd2997666fefc7619382f90653b24) portmidi: 2.0.3 -> 2.0.4
* [`6c30280f`](https://github.com/NixOS/nixpkgs/commit/6c30280f3b6d7698139efae646d101d11d8a895c) par: 1.52 -> 1.53.0
* [`4e925deb`](https://github.com/NixOS/nixpkgs/commit/4e925deb4b45a01e99951745b5ca7a4b6078b352) pythonPackages.torrent_parser: init at 0.4.1
* [`64b2964f`](https://github.com/NixOS/nixpkgs/commit/64b2964fd08cf18e2a7e6b04dd2f5000d7cfd69d) easysnap: unstable-2020-04-04 -> unstable-2022-06-03
* [`e1f44d60`](https://github.com/NixOS/nixpkgs/commit/e1f44d60926b8477a6a29f559608db09a333dc3b) linuxkit: Fix building on Darwin
* [`64faf237`](https://github.com/NixOS/nixpkgs/commit/64faf2372d12d7d603af253a29bca10aaf3293cb) linuxkit: Fix Darwin runtime OS detection
* [`75420e40`](https://github.com/NixOS/nixpkgs/commit/75420e401e66a38667ede826b90e911a31666878) netplan: 0.105 -> 0.106
* [`3e7a003f`](https://github.com/NixOS/nixpkgs/commit/3e7a003ff79e7bb9bae1b65c23d1f5336e767092) alpine-make-vm-image: 0.9.0 -> 0.11.0
* [`8e95f0ac`](https://github.com/NixOS/nixpkgs/commit/8e95f0ac605955a686b79250963f6a3085da2e11) mitscheme:11.2 -> 12.1 https://www.gnu.org/software/mit-scheme/release.html
* [`ab5741b2`](https://github.com/NixOS/nixpkgs/commit/ab5741b2bde9e3cfad1e15e5c916da03fc757801) flatbuffers: 22.11.23 -> 23.3.3
* [`7d70d357`](https://github.com/NixOS/nixpkgs/commit/7d70d35787dc1a32f82bf452f2c410bf2628763e) xrootd: decouple test-runner build and passthru.tests.test-runner
* [`8d999d48`](https://github.com/NixOS/nixpkgs/commit/8d999d48c54c03ad96271fccb52710e5f737006b) factor: Fix "resource:work" pointing to store
* [`78c9a71c`](https://github.com/NixOS/nixpkgs/commit/78c9a71c4d185a372c3e16d5bc044eb46268c854) webp-pixbuf-loader: 0.0.7 -> 0.2.2
* [`9471e692`](https://github.com/NixOS/nixpkgs/commit/9471e692403aa4a27baf815f5f97e8564ffb85b3) xrootd: use fixed-point style mkDerivation
* [`da98c610`](https://github.com/NixOS/nixpkgs/commit/da98c61085bf0fe3706324718f4aea6eb4e0e277) xrootd: add tests.test-xrdcp and passthru fetchxrd
* [`4da1bc0b`](https://github.com/NixOS/nixpkgs/commit/4da1bc0bfae785def0f379ae88b293744519f821) marvin: 22.13.0 -> 23.4.0
* [`5b70dbe7`](https://github.com/NixOS/nixpkgs/commit/5b70dbe789b632ba14adfb42859c3c5c579b7340) ocamlPackages.csexp: 1.5.1 -> 1.5.2
* [`b947c057`](https://github.com/NixOS/nixpkgs/commit/b947c0575ab3c07b64ed052df5332d4ab3ac2741) ocamlPackages.csexp: remove result from dependencies
* [`3a4ba9e8`](https://github.com/NixOS/nixpkgs/commit/3a4ba9e8ea7eb26e68adae559aadb13f76d7ad77) ocamlPackages.csexp: add changelog to meta
* [`8d024220`](https://github.com/NixOS/nixpkgs/commit/8d02422093330569723b92dbad086f803b2f081a) ocamlPackages.csexp: add liquidsoap as reverse dependency to passthru.tests
* [`73760889`](https://github.com/NixOS/nixpkgs/commit/737608898d8863e9223750026c92434edef9e013) sfsexp: 1.4.0 -> 1.4.1
* [`d3c39539`](https://github.com/NixOS/nixpkgs/commit/d3c39539a36d49022477ce8d09892c04b9c676a9) k3s: add packaging README regarding release versioning
* [`c701a4dd`](https://github.com/NixOS/nixpkgs/commit/c701a4dd299aaa82589e4e4d4ce49ae330729a25) lib.sources.pathType and co.: Move to lib.filesystem
* [`91d57a60`](https://github.com/NixOS/nixpkgs/commit/91d57a60f40f639c70529d603215a1941dbe437a) maintainers: add Ch1keen
* [`d9f789ca`](https://github.com/NixOS/nixpkgs/commit/d9f789ca0b2145e0d214cb8ee94970d23c270079) wootility: 3.5.12 -> 4.5.0
* [`1f1505ce`](https://github.com/NixOS/nixpkgs/commit/1f1505cef459cd5b8a248d79646e404c0e024c2c) tesseract5: 5.3.0 -> 5.3.1
* [`9e16748a`](https://github.com/NixOS/nixpkgs/commit/9e16748aa7e1413517e55a5d7108a6b35a2e656b) python310Packages.soxr: 0.3.4 -> 0.3.5
* [`19abbaa2`](https://github.com/NixOS/nixpkgs/commit/19abbaa2d6d1fa6d8605d2c7f6c869ccefa6a873) mpvScripts.seekTo: init at unstable-2022-10-02
* [`589d611a`](https://github.com/NixOS/nixpkgs/commit/589d611a40b9648cc9fd057d95131519fca8dd73) mpvScripts.occivink: Add generic helper for all scripts in repo
* [`a3266137`](https://github.com/NixOS/nixpkgs/commit/a3266137669cc737199fc2f03b26efc0b76f2e74) mpvScripts.blacklistExtensions: init at unstable-2022-10-02
* [`290dcc75`](https://github.com/NixOS/nixpkgs/commit/290dcc75e9a9a081041abd4ef40f41a6d10cb9f2) mpvScripts.occivink: Minor fixes to the generic helper
* [`947f8256`](https://github.com/NixOS/nixpkgs/commit/947f8256a41453771c9875640461a108f62f0098) mpvScripts.occivink: make FDOs (Fixed-Output Derivations)
* [`61f8876d`](https://github.com/NixOS/nixpkgs/commit/61f8876da746ef5aa1325822b8d2ecaf0467b40c) libuv: add some key reverse-dependencies to passthru.tests
* [`f0f805db`](https://github.com/NixOS/nixpkgs/commit/f0f805db879136abebc23c095a73f279b1b59ec8) droidcam: 1.9.0 -> 2.0.0
* [`88954fe9`](https://github.com/NixOS/nixpkgs/commit/88954fe971cf01482e9ca604c0e5c522fee1f877) linphone: 5.0.8 -> 5.0.15
* [`00380b68`](https://github.com/NixOS/nixpkgs/commit/00380b685ce39388e85d05d654b3e48421088978) witness: 0.1.12 -> 0.1.13
* [`97329855`](https://github.com/NixOS/nixpkgs/commit/973298556361049922fe40c7a58eede9133e571b) lima-bin: 0.15.0 -> 0.15.1
* [`71caaca6`](https://github.com/NixOS/nixpkgs/commit/71caaca6f3c1d0eca6391ed6b389255714bc1907) mpris-scrobbler: add ListenBrainz to the desc.
* [`a1715d12`](https://github.com/NixOS/nixpkgs/commit/a1715d12b0b08873b22c4e479c47e1d5072b9091) matterbridge: 1.25.2 -> 1.26.0
* [`6c774132`](https://github.com/NixOS/nixpkgs/commit/6c7741326492e8d313ea801db9a737bfaec88b43) pcb2gcode: 2.4.0 -> 2.5.0
* [`af92bfe9`](https://github.com/NixOS/nixpkgs/commit/af92bfe9b3dadc000efa8861d369c562f3746ba7) gerbv: 2.7.0 -> 2.9.6, switch to the maintained fork
* [`2759dddd`](https://github.com/NixOS/nixpkgs/commit/2759dddde7e6e655435cd05793f93a60ffde5bce) Darktable: 4.2.0 -> 4.2.1
* [`d8d762ae`](https://github.com/NixOS/nixpkgs/commit/d8d762ae3da64aec746f60baeb92b5b5964fbbdb) belle-sip: 5.2.37 -> 5.2.53
* [`cf340b85`](https://github.com/NixOS/nixpkgs/commit/cf340b8524c27f0758cbde1ab2b4ee0045f18f7c) himalaya: 0.7.1 -> 0.7.3
* [`29ab2ff6`](https://github.com/NixOS/nixpkgs/commit/29ab2ff6bbfdaaaf36a7e26aed88d88f03a3975c) himalaya: remove sha256 prefixes
* [`d8595bbd`](https://github.com/NixOS/nixpkgs/commit/d8595bbde6a4601905385a09e7de2d421a50867e) mkvtoolnix: 75.0.0 -> 76.0
* [`d24b7cb9`](https://github.com/NixOS/nixpkgs/commit/d24b7cb9cd8064dea957f2e096707bfb0b9aa8fe) libsForQt5.packagekit-qt: 1.0.2 -> 1.1.1
* [`d18c6089`](https://github.com/NixOS/nixpkgs/commit/d18c6089de5ccc8df7bba547214bbeb0987be8f5) clp: 1.17.7 -> 1.17.8
* [`a09d2a69`](https://github.com/NixOS/nixpkgs/commit/a09d2a6951263b379f38b593841e49979fa0e11e) flare-signal: 0.6.0 -> 0.8.0
* [`920a7f55`](https://github.com/NixOS/nixpkgs/commit/920a7f550063f49ae7d7128e0b6dbb4b12f82088) kord: 0.4.2 -> 0.5.16
* [`1597d646`](https://github.com/NixOS/nixpkgs/commit/1597d6463e00f76f6327ae0354b5079f2a4cd3fe) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.13.0 -> 0.14.5
* [`868143d3`](https://github.com/NixOS/nixpkgs/commit/868143d320da4a3be2e68e17e1727c04af32230a) rdkafka: 2.0.2 -> 2.1.1
* [`9df7ea9b`](https://github.com/NixOS/nixpkgs/commit/9df7ea9b2666e62e453d3fb9c9e8bc92e3707901) rover: 0.11.0 → 0.14.0
* [`dfabdcc5`](https://github.com/NixOS/nixpkgs/commit/dfabdcc511ff1c2869599d93b741bbe929b2a024) srsran: 22.10 -> 23_04
* [`2e420f98`](https://github.com/NixOS/nixpkgs/commit/2e420f985d1bd0e6f2dda07f7ced969e8b23642f) p4c: 1.2.3.8 -> 1.2.3.9
* [`6dfe6cbf`](https://github.com/NixOS/nixpkgs/commit/6dfe6cbf6be6f4f29a73ad89454b186deec5844d) zsh-autocomplete: 22.01.21 -> 23.05.02
* [`be054903`](https://github.com/NixOS/nixpkgs/commit/be054903373d064a0189ca4a1469a546edd32e37) savvycan: 208 -> 213
* [`391a9612`](https://github.com/NixOS/nixpkgs/commit/391a9612d81f6ad76fae37c93a160471a947b9da) haskellPackages: ghcWithPackages needs buildHaskellPackages scope
* [`4a9fd814`](https://github.com/NixOS/nixpkgs/commit/4a9fd8149e7e99936a5997abc1905bf85b0c2d69) amazon-ecr-credential-helper: 0.6.0 -> 0.7.0
* [`3349cfc4`](https://github.com/NixOS/nixpkgs/commit/3349cfc4dfd02fbb58d3219da0b41f1d6c70721c) cpio: add some key reverse dependencies to passthru.tests
* [`dfe15d67`](https://github.com/NixOS/nixpkgs/commit/dfe15d67772a7454848df32a4837dadb1f166601) avalanchego: 1.10.0 -> 1.10.1
* [`2eed1de9`](https://github.com/NixOS/nixpkgs/commit/2eed1de920645e2a5a22c0c668fcf37efdf7e365) stratisd: split out initrd support
* [`1632e73b`](https://github.com/NixOS/nixpkgs/commit/1632e73b19cd25ac3bc0c27f07e932728c3e893c) nixos/stratis: enable booting from stratis volume
* [`9f1bc0fa`](https://github.com/NixOS/nixpkgs/commit/9f1bc0fa02647fb826968f5d217c204feb38babc) address review comments
* [`d1411444`](https://github.com/NixOS/nixpkgs/commit/d1411444b62e4d4c0d83dd8d7d44a4a45de1c51d) add installer test for stratis root fs
* [`e7902715`](https://github.com/NixOS/nixpkgs/commit/e7902715efa9560c3678cdfe677e4817302b5483) rascal: 0.6.2 -> 0.28.2
* [`7d5f8e14`](https://github.com/NixOS/nixpkgs/commit/7d5f8e142a68c1ae243f8004eb10d4204f874579) gbenchmark: 1.7.1 -> 1.8.0
* [`d1e71d7c`](https://github.com/NixOS/nixpkgs/commit/d1e71d7c0b537ef06f08ef9a7a946505f7ff9c5f) python310Packages.yt-dlp: use headless ffmpeg
* [`fd589ed1`](https://github.com/NixOS/nixpkgs/commit/fd589ed13c2564543769ad1fd2cc60702564e1db) fire: Fix build on Darwin
* [`a6bb4116`](https://github.com/NixOS/nixpkgs/commit/a6bb41168f32f34ae13fbdf29ca877fc4e6b3a21) dexed: Fix build on Darwin
* [`8aa320b4`](https://github.com/NixOS/nixpkgs/commit/8aa320b4c2d0d7699170f6da154ebb7598e4d154) address code review issues
* [`b785451d`](https://github.com/NixOS/nixpkgs/commit/b785451d45b21241c7e8dfb12b6f30ec88c7b30d) circumflex: 2.8.2 -> 2.9.1
* [`85003bfe`](https://github.com/NixOS/nixpkgs/commit/85003bfef9a988ff7a0c31298239e5f32eee2e46) vscode-extensions.davidanson.vscode-markdownlint: 0.49.0 -> 0.50.0
* [`f15d0ecc`](https://github.com/NixOS/nixpkgs/commit/f15d0ecc320439626ae7278ce7250d12efe08d4b) raspberrypi-wireless-firmware: fix broken firmware symlink
* [`378ab7d5`](https://github.com/NixOS/nixpkgs/commit/378ab7d595a2fdd75f6bd6e970b5892113587831) kubernetes-helm: 3.11.3 -> 3.12.0
* [`f9c2637c`](https://github.com/NixOS/nixpkgs/commit/f9c2637ca54d4c8c3911fdb01010dc6705662cb3) organicmaps: 2023.04.02-7 -> 2023.05.08-7
* [`df1ff1b2`](https://github.com/NixOS/nixpkgs/commit/df1ff1b25376a7e1745c8e7337063288ffbbe089) webtorrent_desktop: build from source and use packaged electron
* [`5b905627`](https://github.com/NixOS/nixpkgs/commit/5b905627180b727fe72ee2fc1bc51dbf199d6a6a) bespokesynth: Fix build on Darwin
* [`aa277959`](https://github.com/NixOS/nixpkgs/commit/aa27795944ff6288ed85b7baafcfe92356949d69) python311Packages.scikit-fmm: 2022.8.15 -> 2023.4.2
* [`d960eac8`](https://github.com/NixOS/nixpkgs/commit/d960eac81589b3a1b4d147ec4e764dab9b1667d3) way-displays: 1.7.1 -> 1.8.1
* [`ee29d7be`](https://github.com/NixOS/nixpkgs/commit/ee29d7be2a6b7f268fdec30cd610ccc55ca3b59c) huggle: 3.4.10 -> 3.4.12
* [`0c8fd95c`](https://github.com/NixOS/nixpkgs/commit/0c8fd95c185b4f33af421a005a12a95a0e85e109) jazz2: 1.8.0 -> 1.9.1
* [`dff44407`](https://github.com/NixOS/nixpkgs/commit/dff444070a261ab199d8ff509ca671686f9d28da) python3.pkgs.aiosql: init at 8.0
* [`7d610004`](https://github.com/NixOS/nixpkgs/commit/7d61000468c79c568ac1375bb87c4f684c42b713) synergyWithoutGUI: 1.14.5.22 -> 1.14.6.19-stable
* [`93cd9ddc`](https://github.com/NixOS/nixpkgs/commit/93cd9ddced6ebe66c9d8ae367f4c08aceaeb811a) open62541: 1.3.5 -> 1.3.6
* [`9dd76ff7`](https://github.com/NixOS/nixpkgs/commit/9dd76ff79cf5d6d8939a170787b0dfdec42a129b) wolfram-engine: add 13.2.0
* [`a9fb7b6c`](https://github.com/NixOS/nixpkgs/commit/a9fb7b6cdee967659505d08be3449bb1c9742f36) mitscheme: 11.2 -> 12.1
* [`df06e8ef`](https://github.com/NixOS/nixpkgs/commit/df06e8ef6479315b015d328a2f52769556cdaada) python310Packages.wheezy-captcha: init at 3.0.2
* [`d0d2104a`](https://github.com/NixOS/nixpkgs/commit/d0d2104a0150da4e869ad3aeb07da69724146df3) python310Packages.captcha: init at 0.4
* [`2fc39411`](https://github.com/NixOS/nixpkgs/commit/2fc3941121e072a3fd471d47bfbb135d208933af) libngspice: 37 -> 40
* [`d804f10c`](https://github.com/NixOS/nixpkgs/commit/d804f10cc2bc1b316b96ca333d635e7892103b75) clash-geoip: 20230312 -> 20230512
* [`592d1928`](https://github.com/NixOS/nixpkgs/commit/592d1928d0e2f529875196ca776b30aff84d4460) cask-server: 0.5.6 -> 0.6.0
* [`e8a7c684`](https://github.com/NixOS/nixpkgs/commit/e8a7c684aeffac6e673c0dc97e3fcd3e0c5f82ee) tome4: 1.7.4 -> 1.7.5
* [`00153062`](https://github.com/NixOS/nixpkgs/commit/001530620374be5f7344c5dc6184e5a855519675) vulkan-caps-viewer: 3.29 -> 3.30
* [`e3a53e1c`](https://github.com/NixOS/nixpkgs/commit/e3a53e1c973765a8cdac282292894fc14d61f1ed) vulkan-caps-viewer: replace withX11 with x11Support to match no-x-libs
* [`027a84d6`](https://github.com/NixOS/nixpkgs/commit/027a84d6e31be82418a62872eb5d96e93cd0d4e1) opentsdb: add meta.sourceProvenance
* [`6ed215b8`](https://github.com/NixOS/nixpkgs/commit/6ed215b81ab0b5336b3bd6a4c10015a31af6a5b1) opentsdb: add patches for CVE-2023-25826 & CVE-2023-25827
* [`f6db29a5`](https://github.com/NixOS/nixpkgs/commit/f6db29a5d3e5e2fc7dfa69663fc5f3c1688755f9) opentsdb: bump dependencies covering various vulnerabilities
* [`e9c96e43`](https://github.com/NixOS/nixpkgs/commit/e9c96e43993b9baf13e86051fe1cb9bdb533b5fd) kaufkauflist: 2.0.0 → 2.2.0
* [`1c0cbd22`](https://github.com/NixOS/nixpkgs/commit/1c0cbd22de6b946b0059d55b70bacb6d1e1b7a91) space-station-14-launcher: 0.20.5 -> 0.21.1
* [`de450842`](https://github.com/NixOS/nixpkgs/commit/de45084228e0e17273a66b5e1fc75e69f1bf4fad) mpv-shim-default-shaders: init at 2.1.0
* [`c2adda6f`](https://github.com/NixOS/nixpkgs/commit/c2adda6f9d6937683aa35a73137281a3180833cb) plex-mpv-shim: add devusb to maintainers
* [`ca89dec4`](https://github.com/NixOS/nixpkgs/commit/ca89dec4c365133448c82a81bddc7c984a3ace79) plex-mpv-shim: add mpv-shim-default-shaders
* [`20a65903`](https://github.com/NixOS/nixpkgs/commit/20a65903132c737e45167e66842cae669ff046a0) pythonPackages.pythonefl: broken with python 3.11
* [`2983698c`](https://github.com/NixOS/nixpkgs/commit/2983698c4b4d8c46c524f1e0c705163dda645786) release-notes: note ability to build powerpc64le-linux NixOS ISOs
* [`c87e1115`](https://github.com/NixOS/nixpkgs/commit/c87e1115d75fffc0b83a0f94f32c93e47f13cc15) release-notes: mention that powerpc64 now uses IEEE-standard floats
* [`fa770eff`](https://github.com/NixOS/nixpkgs/commit/fa770eff5974c6e6e66c299ee3c8f0dae80f69ad) pgadmin4: 7.0 -> 7.1
* [`9f75fd7e`](https://github.com/NixOS/nixpkgs/commit/9f75fd7e6fde4fecb91398eed3aa0690f3f87c86) csound: fix cross with gettext hack
* [`c534a778`](https://github.com/NixOS/nixpkgs/commit/c534a77804f00423391adc946fadfad189d08d3f) closurecompiler: 20221102 -> 20230502
* [`447657c2`](https://github.com/NixOS/nixpkgs/commit/447657c2de3b4e0d445e8c000650e97af6d7cc7f) mir: Pull patch to fix evdev device misses
* [`1ae0367a`](https://github.com/NixOS/nixpkgs/commit/1ae0367a5d3fe396b270d6aceaef76214c2e34af) python310Packages.pycotap: 1.2.2 -> 1.3.1
* [`b0cd1014`](https://github.com/NixOS/nixpkgs/commit/b0cd1014895c9e0dab88957204d02fb8f8e14a58) dnsdist: 1.7.3 -> 1.8.0
* [`3aa262b6`](https://github.com/NixOS/nixpkgs/commit/3aa262b644feff5153888ed85661450cb151088b) make nixos-generate-config generate stratis pool UUIDs
* [`ce0016f0`](https://github.com/NixOS/nixpkgs/commit/ce0016f005b1bf2d626acc3a1fec68ce212635b4) fluidd: 1.23.5 -> 1.24.0
* [`ebe4326a`](https://github.com/NixOS/nixpkgs/commit/ebe4326a6ffb238f2bec01b300909d85c369f3d9) apr: 1.7.2 -> 1.7.4
* [`a5304185`](https://github.com/NixOS/nixpkgs/commit/a53041856d8a719efc0ffb257b5ac41961a73554) pulsar: 1.104.0 -> 1.105.0
* [`b1240a8d`](https://github.com/NixOS/nixpkgs/commit/b1240a8d283f2b1ae822a656a23336627b2e6385) graylog: 5.0.6 -> 5.0.7
* [`7f8b3d2f`](https://github.com/NixOS/nixpkgs/commit/7f8b3d2f49eeba7d36eee6305e68665dccb001f9) faust: 2.54.9 -> 2.59.6
* [`314c64c4`](https://github.com/NixOS/nixpkgs/commit/314c64c409455ee49665ab2c7262b28965d17390) grocy: mark as broken
* [`bc48fa8f`](https://github.com/NixOS/nixpkgs/commit/bc48fa8f5e3c09b1c401b21388f2f429df1ad536) limesurvey: mark as broken
* [`f4fb6894`](https://github.com/NixOS/nixpkgs/commit/f4fb689471ce598ba908837e437f263f414be9bf) faustPhysicalModeling: 2.54.9 -> 2.59.6
* [`f3e1791f`](https://github.com/NixOS/nixpkgs/commit/f3e1791f20e7fa0c3b14cac412dbba8b5d96680b) matrix-sdk-crypto-nodejs: 0.1.0-beta.3 -> 0.1.0-beta.6
* [`7c8ebaba`](https://github.com/NixOS/nixpkgs/commit/7c8ebabaaaa886f44e138f2fc01489c0c072ff16) matrix-hookshot: 3.2.0 -> 4.0.0
* [`83292811`](https://github.com/NixOS/nixpkgs/commit/83292811117d8079648988df23419fd01fbec729) matrix-sdk-crypto-nodejs: reintroduce 0.1.0-beta.3
* [`92814241`](https://github.com/NixOS/nixpkgs/commit/92814241a8b992c18accbb939360654369eb2cc4) improve stratis initrd support
* [`94ffe0e0`](https://github.com/NixOS/nixpkgs/commit/94ffe0e09355194180716a286b7fe3652505d5c4) python310Packages.nbsphinx: 0.8.12 -> 0.9.1
* [`ae773733`](https://github.com/NixOS/nixpkgs/commit/ae7737333acbe580f01ce600f74b059e1f2f71db) wpsoffice: don't need wrapGAppsHook nor wrapQtAppsHook
* [`d64d4bb3`](https://github.com/NixOS/nixpkgs/commit/d64d4bb38728661f5266043092183fd177e9abf1) wpsoffice: set autoPatchelfIgnoreMissingDeps rather than remove libraries
* [`82c4abd1`](https://github.com/NixOS/nixpkgs/commit/82c4abd1944b15c57fa05acdc9985210fca71d2d) dotnet-sdk_8: 8.0.0-preview.3.23177.8 -> 8.0.0-preview.4.23260.4
* [`f09bffe4`](https://github.com/NixOS/nixpkgs/commit/f09bffe4d78b7f4377e1405e74d296c7e0ca44be) linuxPackages.rtl8821cu: unstable-2022-12-07 -> unstable-2023-04-28
* [`c904468a`](https://github.com/NixOS/nixpkgs/commit/c904468ae4950ca68753fa49cb7e9acd02a18c07) discord-sh: unstable-2022-05-19 -> 2.0.0
* [`815c6480`](https://github.com/NixOS/nixpkgs/commit/815c64807b4cc7bea5737334aefe087394cf7bfe) renpy: 8.0.1 -> 8.1.0
* [`c7f171bb`](https://github.com/NixOS/nixpkgs/commit/c7f171bb1466d3a648ea159b8657550e25aa6c79) mustache.tcl: init at 1.1.3.4
* [`b976e947`](https://github.com/NixOS/nixpkgs/commit/b976e947e1804cb669574a20393cede8ee95c2e1) clash-verge: remove unpackPhase
* [`c4e7a4e7`](https://github.com/NixOS/nixpkgs/commit/c4e7a4e71512a20fb5070d119d95a6a8149b86b7) aerc: 0.14.0 -> 0.15.2
* [`a7091811`](https://github.com/NixOS/nixpkgs/commit/a709181137c3a88a078ccc7fff204b18e4cbf7e5) clash-verge: use clash and clash-meta from nixpkgs
* [`52600003`](https://github.com/NixOS/nixpkgs/commit/52600003a45bf6f4ef761e0310f7b0934e632b41) wire-desktop: linux 3.30.3018 -> 3.31.3060
* [`fd9f2638`](https://github.com/NixOS/nixpkgs/commit/fd9f2638aa1f3622f23ef42cbcdc08df41dce2ce) wire-desktop: mac 3.30.4506 -> 3.31.4556
* [`e4bee97b`](https://github.com/NixOS/nixpkgs/commit/e4bee97bdd8b6a7bf40436b861a01d85261c2210) python3Packages.google-search-results: init at 2.4.2
* [`65dfad9a`](https://github.com/NixOS/nixpkgs/commit/65dfad9a5bf8c82866531bfe8057e84a9cf33d27) python3Packages.langchain: enable google-search-results
* [`e5264e45`](https://github.com/NixOS/nixpkgs/commit/e5264e45b7d69cb994bab8117da192c568666d98) coqPackages.coquelicot: 3.3.0 -> 3.3.1
* [`7a3bc4f1`](https://github.com/NixOS/nixpkgs/commit/7a3bc4f18f6dd9d60d350081390a9495266fff81) coqPackages.multinomials: 1.5.6 -> 1.6.0
* [`52c9e5c8`](https://github.com/NixOS/nixpkgs/commit/52c9e5c8f900e25b4188676e1f86ea6248476e58) coqPackages.coqeal: 1.1.1 -> 1.1.3
* [`ed1f52d4`](https://github.com/NixOS/nixpkgs/commit/ed1f52d4c256ef2785249c58b9db6b9c9675f426) Mathcomp 1.16.0 -> 1.17.0
* [`a0b78023`](https://github.com/NixOS/nixpkgs/commit/a0b7802372dc59317d06c474ea4de00e7f04c09f) nixos/thelounge: add package option
* [`9cae9ca3`](https://github.com/NixOS/nixpkgs/commit/9cae9ca3a02a247124a34214e197ac6cf60713da) zfs: fix check for latestCompatibleLinuxPackages
* [`bb74c098`](https://github.com/NixOS/nixpkgs/commit/bb74c0982b3a41d0d4db277dbdb44ee4087df39b) microsoft-edge: 111.0.1661.44 -> 113.0.1774.42
* [`96b18b3e`](https://github.com/NixOS/nixpkgs/commit/96b18b3ef6e4a0152bc63c51daffeaa380f2af02) python311Packages.glyphslib: 6.1.0 -> 6.2.2
* [`f59effcb`](https://github.com/NixOS/nixpkgs/commit/f59effcbbfe9a1eb8e1dec2ca2b13b4cad22f4c1) mdbook: 0.4.28 -> 0.4.29
* [`cc3bec8f`](https://github.com/NixOS/nixpkgs/commit/cc3bec8ffe905596039c5e221f9c8c02f70ad8f9) pgadmin4: add update script
* [`68719046`](https://github.com/NixOS/nixpkgs/commit/6871904642122b9135e97bf4e41103d6bff97b33) python10Packages.flask-sessionstore: init at 0.4.5
* [`fbe371c0`](https://github.com/NixOS/nixpkgs/commit/fbe371c0196088ac03a186a5c343d137a780362c) python310Packages.flask-session-captcha: init at 1.3.0
* [`ae1ce53f`](https://github.com/NixOS/nixpkgs/commit/ae1ce53f74bb3aa0e6313cbc4423b73b50833592) mattermost-desktop: 5.1.0 -> 5.3.1
* [`7292cd64`](https://github.com/NixOS/nixpkgs/commit/7292cd649e4cbd2cfd1f03334f64743f7f59e376) yuzu: mainline 1430 -> 1437, early access 3588 -> 3596
* [`eea3e3bc`](https://github.com/NixOS/nixpkgs/commit/eea3e3bc569dfd8d5baa4be50ef8c9cf31643644) python311Packages.pywbem: 1.6.0 -> 1.6.1
* [`65da60a9`](https://github.com/NixOS/nixpkgs/commit/65da60a99fc7ad5ef04918b401e988885806bf34) python310Packages.ipyparallel: 8.4.1 -> 8.6.1
* [`d2e320b3`](https://github.com/NixOS/nixpkgs/commit/d2e320b34f982e987b152af9ba0cbc31d31d279e) python310Packages.frozendict: 2.3.5 -> 2.3.8
* [`243ed081`](https://github.com/NixOS/nixpkgs/commit/243ed08106eeda7e5af79b5a5a833863b398e5c1) python310Packages.phonopy: 2.17.1 -> 2.19.1
* [`57379b6e`](https://github.com/NixOS/nixpkgs/commit/57379b6e8e1bc15ae1a061f9e2992a5862cb7b1c) swayr: 0.25.0 -> 0.26.1
* [`c2ab94c9`](https://github.com/NixOS/nixpkgs/commit/c2ab94c9e3b2f6ace2c754185e8fddfa7568ffcc) python310Packages.geopandas: 0.12.2 -> 0.13.0
* [`0488b1a6`](https://github.com/NixOS/nixpkgs/commit/0488b1a64f16059b0180a03e29ee243651f67f84) python310Packages.pyvcd: 0.3.0 -> 0.4.0
* [`0d425b79`](https://github.com/NixOS/nixpkgs/commit/0d425b7946a4d73a791a2c8b869ca3d85572a1e2) fiano: init at 1.2.0
* [`e8d796f8`](https://github.com/NixOS/nixpkgs/commit/e8d796f8abcb536834e690ddf5cdc4aca2e583cd) fiano: add jmbaur as maintainer
* [`c1b16089`](https://github.com/NixOS/nixpkgs/commit/c1b1608958f2bccce953c4c0b9013b0f49542fb1) python310Packages.beancount-parser: 0.1.23 -> 0.2.0
* [`0c876562`](https://github.com/NixOS/nixpkgs/commit/0c87656233559adfc30d4949f0b337f86e3ae0f7) python310Packages.mailsuite: 1.9.14 -> 1.9.15
* [`abc55e61`](https://github.com/NixOS/nixpkgs/commit/abc55e615af2a60391131196dbe95dffc101b39a) libremidi: init at unstable-2023-05-05
* [`8df19830`](https://github.com/NixOS/nixpkgs/commit/8df198304541c24ecc57d78584f1edc5d11506e5) coursier: 2.1.2 -> 2.1.4
* [`7af1276c`](https://github.com/NixOS/nixpkgs/commit/7af1276c38fcacca632fdbc8a5416e04d9677e1d) python310Packages.pylink-square: 1.0.0 -> 1.1.0
* [`4ccb965f`](https://github.com/NixOS/nixpkgs/commit/4ccb965fd0b406e3630a8550a2d344f295f0c5a0) adwaita-qt: 1.4.1 → 1.4.2
* [`4a56b265`](https://github.com/NixOS/nixpkgs/commit/4a56b2655ef3ce7b1513ab6feb0b485edbe548e8) lib/options: nullable mkPackageOption
* [`7346aedd`](https://github.com/NixOS/nixpkgs/commit/7346aedd84591af616f386dcffdbb74662ee6156) dbus-broker: Fetch dependencies from tags instead of branches
* [`2e3134c5`](https://github.com/NixOS/nixpkgs/commit/2e3134c536b6d2782415c2982a1860dd77302f9a) apfsprogs: build apfs-snap
* [`734d45cc`](https://github.com/NixOS/nixpkgs/commit/734d45ccf4873b8a99c1b934207704e76cfb746e) apfsprogs: unstable-2023-03-21 -> unstable-2023-05-16
* [`d212ec13`](https://github.com/NixOS/nixpkgs/commit/d212ec13b8907f631606f0130f6cd73e10b95285) nixos/synapse: allow omitting `trusted_key_servers[].verify_keys`
* [`ef80e110`](https://github.com/NixOS/nixpkgs/commit/ef80e11032c66d9e978eff9472687c983361fe08) nixos/systemd-repart: enable creating root partition
* [`765349d3`](https://github.com/NixOS/nixpkgs/commit/765349d3450b1e2b559d0d91bd58978c8effd938) minor refactoring
* [`f35a3d2d`](https://github.com/NixOS/nixpkgs/commit/f35a3d2dcc7dc1d843d6759175288ac564c7bf32) qtile: move to python-modules
* [`123c8e3f`](https://github.com/NixOS/nixpkgs/commit/123c8e3fa8df5ff9c2183be4c6ecb2d9cc52406f) pgadmin4: remove comments and add exit trap to update.sh
* [`264f6081`](https://github.com/NixOS/nixpkgs/commit/264f60811ed58c6e184389dba410dc48e30f6c3c) ceph: use https to download src, use inherit
* [`b9ed6e19`](https://github.com/NixOS/nixpkgs/commit/b9ed6e1919bddb94f543c843c08b297849008fe4) clash-verge: 1.3.1 -> 1.3.2
* [`4231ee5b`](https://github.com/NixOS/nixpkgs/commit/4231ee5bef676971a3e3f53efe846629c01511e7) sunvox: 2.0e -> 2.1c
* [`5cab4317`](https://github.com/NixOS/nixpkgs/commit/5cab4317606b0dcc117f2d01fbb55add59840312) emborg: 1.35 -> 1.37
* [`97516c60`](https://github.com/NixOS/nixpkgs/commit/97516c60341ddf1f753cb6f7a5ae8427d59b1aa2) prismlauncher: introduce unwrapped packages
* [`fa7b31cf`](https://github.com/NixOS/nixpkgs/commit/fa7b31cf86937f9be2eccf41265c947a35213554) prismlauncher: simplify postUnpack
* [`b130e618`](https://github.com/NixOS/nixpkgs/commit/b130e618d6e657e6b1bc6a419926c3559da6fa9f) prismlauncher: allow empty msaClientID
* [`26dda3c4`](https://github.com/NixOS/nixpkgs/commit/26dda3c45ebdc910527a1f18bce360034bdbdb96) prismlauncher: enable PIE
* [`e17bf7b2`](https://github.com/NixOS/nixpkgs/commit/e17bf7b2723b4ebfb200473b6bc56b2abac271ba) prismlauncher: expose parameters of unwrapped package
* [`34ebe704`](https://github.com/NixOS/nixpkgs/commit/34ebe70480280f09059fbdb75b4d88900e823bf3) wpsoffice: remove unnecessary build inputs
* [`1d2fe316`](https://github.com/NixOS/nixpkgs/commit/1d2fe316ae5344af192b6be2cf291dbb8edfd373) gnustep.gorm: 1.2.28 -> 1.3.1
* [`6695c8d7`](https://github.com/NixOS/nixpkgs/commit/6695c8d7d07affa96f2d828d8cd534f44a073f07) buildkite-agent: 3.46.0 -> 3.46.1
* [`62414260`](https://github.com/NixOS/nixpkgs/commit/6241426029577e4bc7bd287946951f52b47be1ca) beancount-black: 0.2.0 -> 0.2.1
* [`16c6122a`](https://github.com/NixOS/nixpkgs/commit/16c6122a88c218ff3f9eb621cf432be37b17a612) varnish73: init at 7.3.0
* [`1da4ea5a`](https://github.com/NixOS/nixpkgs/commit/1da4ea5ac2170c7201419d3572a66e319a51eaa4) janet: 1.27.0 -> 1.28.0
* [`d2814c73`](https://github.com/NixOS/nixpkgs/commit/d2814c733ab26e72468db940c904dc3bcce489d0) maxima-ecl-5_45: remove
* [`9926e299`](https://github.com/NixOS/nixpkgs/commit/9926e299c2d0db1bb2bf036631378a78952e7ae5) eclib: 20221012 -> 20230424
* [`57c940b9`](https://github.com/NixOS/nixpkgs/commit/57c940b93dfdffe4ac71d36ff7d95ed4526ea9a9) pari: 2.15.2 -> 2.15.3
* [`51541df9`](https://github.com/NixOS/nixpkgs/commit/51541df9822f85499a10f08ec0297791d3318941) singular: 4.3.1p2 -> 4.3.2p1
* [`dcb2cc84`](https://github.com/NixOS/nixpkgs/commit/dcb2cc849eb2cf158aca419f1cecf1202d5409eb) nginx: fix build of module spnego-http-auth
* [`7f2dad03`](https://github.com/NixOS/nixpkgs/commit/7f2dad03e6a0e6a07c99ececc0dd5a06fcfeda6b) vscode-extensions.vadimcn.vscode-lldb: use "buildNpmPackage" instead of "node2nix"
* [`0c1b4e56`](https://github.com/NixOS/nixpkgs/commit/0c1b4e562626d9fb6e481fdc93c4a1577a1d35cb) ntfy-sh: 2.4.0 -> 2.5.0
* [`ac9915b1`](https://github.com/NixOS/nixpkgs/commit/ac9915b1eaaa93edcb7da8af2b2f797f6c3da4a2) lib/tests: add mkPackageOption tests
* [`9ddcd2c9`](https://github.com/NixOS/nixpkgs/commit/9ddcd2c9881a1e98fc740a3d8f2af04748155a9b) dae: 0.1.8 -> 0.1.9patch1
* [`cf05feda`](https://github.com/NixOS/nixpkgs/commit/cf05fedad8070e319a35e557b71cfa48eeacc967) vorta: don't replace Exec line in desktop file
* [`f5b67921`](https://github.com/NixOS/nixpkgs/commit/f5b67921f62451eb35448b7b7c83ee078974ac9a) lib/licenses: Business Source License 1.1 is redistributable
* [`14a00b2d`](https://github.com/NixOS/nixpkgs/commit/14a00b2d20fa78f10f4d72df336454c8cd18ef21) vencord-web-extension: init at 1.1.6
* [`01808964`](https://github.com/NixOS/nixpkgs/commit/0180896459796c89b8ca805f2d56fc49d074e926) vencord: allow building Discord scripts
* [`3f28fcef`](https://github.com/NixOS/nixpkgs/commit/3f28fcef421532c1bc8c5bec2ea356217f5608e0) vencord: add Scrumplex to maintainers
* [`9e844c16`](https://github.com/NixOS/nixpkgs/commit/9e844c164ca71d7aebaa38b042edac501e158bab) discord: add option to install Vencord
* [`2562f4dd`](https://github.com/NixOS/nixpkgs/commit/2562f4dd61558102c09efed45d330992b6f94913) discord: add Scrumplex to maintainers
* [`aa7c7c11`](https://github.com/NixOS/nixpkgs/commit/aa7c7c11c3bab5eb3900fd025732e44ddc54078a) saml2aws: 2.36.7 -> 2.36.8
* [`8a9b1630`](https://github.com/NixOS/nixpkgs/commit/8a9b1630417192d8ccbcd2abac4e4882cde089cf) mediamtx: 0.22.2 -> 0.23.0
* [`41142c05`](https://github.com/NixOS/nixpkgs/commit/41142c05d3507a393472dbc5c148f9760efbbe26) pathvector: 6.2.1 -> 6.3.0
* [`ca45ef8e`](https://github.com/NixOS/nixpkgs/commit/ca45ef8e0eea84d57ab10f40ce3fb5a7b73303f3) linuxPackages.ipu6-drivers: 2023-02-20 -> 2023-05-19
* [`e7479fca`](https://github.com/NixOS/nixpkgs/commit/e7479fca5519560746857c4e495d30d5f9d17f5b) linuxPackages.ivsc-driver: 2023-01-06 -> 2023-03-10
* [`d8e2957d`](https://github.com/NixOS/nixpkgs/commit/d8e2957d46a59a5260601317bd858ccfe8bf26c2) tvm: 0.11.1 -> 0.12.0
* [`576db5c3`](https://github.com/NixOS/nixpkgs/commit/576db5c3d134df8e7277013fffe1731e89422aec) bun: 0.5.9 -> 0.6.2
* [`3e2f8313`](https://github.com/NixOS/nixpkgs/commit/3e2f83136073490aa7ca188586cbe515604e919e) libopenmpt: doCheck only if canExecute
* [`3c29814d`](https://github.com/NixOS/nixpkgs/commit/3c29814d29034f848da59aa7b97b9b7f842b25ee) pyinfra: 2.6.2 -> 2.7
* [`42014037`](https://github.com/NixOS/nixpkgs/commit/4201403756fcf5d9e7d13c868871179dfbc0ad13) icingaweb2-ipl: 0.11.1 -> 0.12.0
* [`a08884b3`](https://github.com/NixOS/nixpkgs/commit/a08884b3c5f0d699affbd186c5013c674f1d929f) signalbackup-tools: 20230510 -> 20230518
* [`4bf9a6a4`](https://github.com/NixOS/nixpkgs/commit/4bf9a6a42e1e1f06456364b50f8b88ad32ad4b64) xst: 0.8.4.1 -> 0.9.0
* [`47af6c82`](https://github.com/NixOS/nixpkgs/commit/47af6c8215ab87fbb2fca2dc24783ae04e6af00d) soft-serve: 0.4.7 -> 0.5.4
* [`e85f142b`](https://github.com/NixOS/nixpkgs/commit/e85f142bb3a08239abfbca677ad1ff42359e93a1) python311Packages.holoviews: 1.15.4 -> 1.16.0
* [`2dc01526`](https://github.com/NixOS/nixpkgs/commit/2dc0152662a43d0f4f6871499e48d1daaf03e419) kind: 0.18.0 -> 0.19.0
* [`6a4959cd`](https://github.com/NixOS/nixpkgs/commit/6a4959cd8ed4647083a9743d6ac7a3eec6a8f223) jen: init at 1.6.0
* [`b0e04c01`](https://github.com/NixOS/nixpkgs/commit/b0e04c01e7cbcb0c72c4742c54b2ebbb614c561d) teams-for-linux: 1.0.92 -> 1.0.93
* [`f1ad765f`](https://github.com/NixOS/nixpkgs/commit/f1ad765f694574ad4635f3c254bd894f00f8a3d9) spire: 1.6.3 -> 1.6.4
* [`2df91b7a`](https://github.com/NixOS/nixpkgs/commit/2df91b7a0083ad4113f34a88954f04bedbbcc2c2) python310Packages.nvidia-ml-py: 11.525.84 -> 11.525.112
* [`dd3b15fd`](https://github.com/NixOS/nixpkgs/commit/dd3b15fdc20c371290e9e124094e88e957786e9a) gloox: 1.0.26 -> 1.0.27
* [`c8faadaf`](https://github.com/NixOS/nixpkgs/commit/c8faadaf0b75e6af75b2f66705f3d6d8bbee03ca) cyrus-sasl-xoauth2: init at 0.2
* [`acd73911`](https://github.com/NixOS/nixpkgs/commit/acd73911d4cae66dbe1f8f716cd71297b5651c4f) tmux-mem-cpu-load: 3.7.0 -> 3.8.0
* [`a298c2ec`](https://github.com/NixOS/nixpkgs/commit/a298c2ecfeacaf228a5df6319f13454eda62fd12) urbit: 2.3 -> 2.6
* [`e42b89ff`](https://github.com/NixOS/nixpkgs/commit/e42b89ffbac888e3b7125fcc6e6314d8fc84a6c8) conan: 2.0.0 -> 2.0.5
* [`04132971`](https://github.com/NixOS/nixpkgs/commit/041329716f2deed3c3c7fc0cb2a50e45171ffb8b) trytond: 6.6.7 -> 6.8.1
* [`6f1b1552`](https://github.com/NixOS/nixpkgs/commit/6f1b155206ff6c0bb8c0241dc29d98cdac366e27) nbxplorer: 2.3.62 -> 2.3.63
* [`2277443b`](https://github.com/NixOS/nixpkgs/commit/2277443bdcdbd5d66566e83796ff64126c52a364) dolphin-emu: 5.0-18498 -> 5.0-19368
* [`6920289a`](https://github.com/NixOS/nixpkgs/commit/6920289a445cb5d0e92e8fd42de4d16be48a2422) remote-touchpad: 1.4.0 -> 1.4.1
* [`cfb3bfac`](https://github.com/NixOS/nixpkgs/commit/cfb3bfac895d3b0347a5e9a44f5206f3d9101006) dbmate: 2.2.0 -> 2.3.0
* [`06eb0626`](https://github.com/NixOS/nixpkgs/commit/06eb062687ea5e4c7aaa6b2574941d1b827ddb93) minimacy: 0.6.4 -> 1.0.0
* [`d2685891`](https://github.com/NixOS/nixpkgs/commit/d26858914eb6f2d03d78ecb6023adc682b274ef4) swayfx: 0.2 -> 0.3
* [`bdf0a7c7`](https://github.com/NixOS/nixpkgs/commit/bdf0a7c7cda0fa7b359a0d5fcf988f7d8c0867a1) dbmate: add changelog to meta
* [`524f06e3`](https://github.com/NixOS/nixpkgs/commit/524f06e386afc41c14696392df81fd81f403d05d) squeezelite: add darwin support
* [`5b3843c2`](https://github.com/NixOS/nixpkgs/commit/5b3843c25d732e5ba0ff1f78ad499611f9e9f8ee) abbreviate: init at 1.6.0
* [`8bc1db0a`](https://github.com/NixOS/nixpkgs/commit/8bc1db0a0d9f4d11ebef187559f08a38e5a08a5e) bottles: 51.5 -> 51.6
* [`8d0b23a5`](https://github.com/NixOS/nixpkgs/commit/8d0b23a5e4ab92baa505c1a76760c4d34bbd84f3) bombardier: init at 1.2.6
* [`c921e7c2`](https://github.com/NixOS/nixpkgs/commit/c921e7c28b9587e5cc08861b7f8fb621eb643b10) heroic: small cleanup
* [`e62ba2f9`](https://github.com/NixOS/nixpkgs/commit/e62ba2f97771c2ffd6cccbeac7370a4f4520bf0a) scriptisto: init at 2.1.1
* [`19bf4ba0`](https://github.com/NixOS/nixpkgs/commit/19bf4ba0e0c0789f57f03e4de6c908e00fe17f2a) giac, giac-with-xcas: 1.9.0-29 -> 1.9.0-43
* [`0edaaae3`](https://github.com/NixOS/nixpkgs/commit/0edaaae3ffd117b88879bf655260654947ee2dc4) sage: 9.8 -> 10.0
* [`ce1811a2`](https://github.com/NixOS/nixpkgs/commit/ce1811a2f3bd69659f0a64931e1c072ea85437e7) matrix-recorder: remove
* [`8b9b0f56`](https://github.com/NixOS/nixpkgs/commit/8b9b0f56b3e7463a57843c464a4ef08e5176778a) webfontkitgenerator: init at 1.0.3
* [`9695889e`](https://github.com/NixOS/nixpkgs/commit/9695889e9035cc4ba177e732d37e6b011ce04c6a) n8n: regenerate with nodejs 18
* [`961af3e1`](https://github.com/NixOS/nixpkgs/commit/961af3e15f7e3070321df461511946458ca8fddb) cloudcompare: disable qRANSAC_SD plugin to fix build
* [`399793ab`](https://github.com/NixOS/nixpkgs/commit/399793ab53ffa5bc2e1a5e58fbfcaa146481e5a0) critcmp: init at 0.1.7
* [`ab2095c8`](https://github.com/NixOS/nixpkgs/commit/ab2095c815247cd7827baa7659e483cc259303de) cargo-benchcmp: init at 0.4.4
* [`00000003`](https://github.com/NixOS/nixpkgs/commit/0000000324d0f1e01cef043cf20fac9afc2dc693) nixos/portunus: use openldap compiled with libxcrypt-legacy
* [`5eb2c2b2`](https://github.com/NixOS/nixpkgs/commit/5eb2c2b23dcfa65eac83e0e92851e24333a6c34d) pipe-rename: 1.6.2 -> 1.6.3
* [`11c934a0`](https://github.com/NixOS/nixpkgs/commit/11c934a00eaae7947e920b6e389c6ed8aa752c9e) python38Packages.eth-hash: fix the build by not depending on safe-pysha3
* [`b835e443`](https://github.com/NixOS/nixpkgs/commit/b835e44341228e166d75af728298b24ad13697af) kool: init at 2.1.0
* [`3dc228ff`](https://github.com/NixOS/nixpkgs/commit/3dc228ff812fe3a299a8e6b48b5f22bb2b03c7b9) dlib: 19.24 -> 19.24.2
* [`bb351a3b`](https://github.com/NixOS/nixpkgs/commit/bb351a3b5ebabf1f8a0f3a06b4bf024fe502fd74) gotrue-supabase: 2.47.1 -> 2.67.1
* [`a88ea63a`](https://github.com/NixOS/nixpkgs/commit/a88ea63aa18c2ea26195fda16388821e8fd3267e) httpie: 3.2.1 -> 3.2.2
* [`78008695`](https://github.com/NixOS/nixpkgs/commit/7800869591895c83c3ef43861c1f225c02693b78) waydroid: 1.3.4 -> 1.4.1
* [`21cd3ea8`](https://github.com/NixOS/nixpkgs/commit/21cd3ea8b88346e2331ef01126a7a890567427c0) epgstation: use node 18
* [`059006b8`](https://github.com/NixOS/nixpkgs/commit/059006b84b3c1a6d987e9f09bcaf356c99c2ed6f) nixos/epgstation: add required directories to tmpfiles.d
* [`94eb60a7`](https://github.com/NixOS/nixpkgs/commit/94eb60a7d21f3fb594de4f5a5ac40cf24779881d) nixos/epgstation: add a new option 'ffmpeg'
* [`e1f0e2f0`](https://github.com/NixOS/nixpkgs/commit/e1f0e2f0d9a40c3df8eca8ced6e604a814abb79d) lwc: init at unstable-2022-07-26
* [`c13e4258`](https://github.com/NixOS/nixpkgs/commit/c13e4258f6bc07334eb3f18383e028cf47ea8b87) sageWithDoc: run src/doc/bootstrap script before docbuild
* [`32d1d6e7`](https://github.com/NixOS/nixpkgs/commit/32d1d6e7bf2a44c420008f769605d9a9dbf2f358) httpref: init at 1.6.1
* [`41556d76`](https://github.com/NixOS/nixpkgs/commit/41556d761ca42556d6c0461c7d175633a892b614) shell2http: init at 1.16.0
* [`2de68091`](https://github.com/NixOS/nixpkgs/commit/2de6809185070def0eaa3da51f522943bc280d88) fontfinder: init at 2.1.0
* [`00000006`](https://github.com/NixOS/nixpkgs/commit/00000006e9812e28fecc192a3883e01e88053f89) nixos/tests: init portunus
* [`13b07c61`](https://github.com/NixOS/nixpkgs/commit/13b07c6139dc580b0d4924b40225455d357ddc09) vscode, vscodium: use Nixpkgs `ripgrep` by default
* [`1619fe40`](https://github.com/NixOS/nixpkgs/commit/1619fe4067ba02c16eb3523916d52237e2dac286) werf: 1.2.233 -> 1.2.235
* [`1a13b4c0`](https://github.com/NixOS/nixpkgs/commit/1a13b4c0f965f72be51637330aaddfac67a1f118) powerdns-admin: 0.3.0 -> 0.4.1
* [`752cf0f4`](https://github.com/NixOS/nixpkgs/commit/752cf0f485774753d3b104bb7bab4f6b58cc1d41) orogene: 0.3.26 -> 0.3.27
* [`b158d280`](https://github.com/NixOS/nixpkgs/commit/b158d2803fbe94465a1cbf3e0d835eeb7e5cfe85) mailutils: 3.15 -> 3.16
* [`fcfb25c7`](https://github.com/NixOS/nixpkgs/commit/fcfb25c7bacad75d1a394e825b120e0114bb8925) python3Packages.matplotlib: fix the minimum Python version
* [`7d2ef688`](https://github.com/NixOS/nixpkgs/commit/7d2ef6889198f70de87b23aa383fc0c262803712) squeezelite: reduce LDADD
* [`4ed03057`](https://github.com/NixOS/nixpkgs/commit/4ed030571d358b170e863202a1daf7e04e65ab51) maintainers: add seirl
* [`b31a6e87`](https://github.com/NixOS/nixpkgs/commit/b31a6e8782f8a8faadd05f0840a83bb6ef0a8fa9) hadoop: 3.3.4 -> 3.3.5
* [`679d2c54`](https://github.com/NixOS/nixpkgs/commit/679d2c5493ad30e812c4dcfcf2da8da160d14716) hbase: 2.4.16 -> 2.4.17, 2.5.3 -> 2.5.4
* [`8586478e`](https://github.com/NixOS/nixpkgs/commit/8586478e174493b4eff3ef4904e814a0480aecf4) minimal-bootstrap.gnugrep: init at 2.4
* [`d55fa729`](https://github.com/NixOS/nixpkgs/commit/d55fa72969dde83659845d042154350e52fcda1a) esphome: 2023.5.1 -> 2023.5.2
* [`5ad9a631`](https://github.com/NixOS/nixpkgs/commit/5ad9a631d652d26e1a3b9d8b3ac120df06ccb86c) go2rtc: init at 1.5.0
* [`ae9bada0`](https://github.com/NixOS/nixpkgs/commit/ae9bada02d463980dea332fc5c6c1dccd0ac7793) minimal-bootstrap: mark recurseIntoAttrs on compiler packages
* [`eae2018b`](https://github.com/NixOS/nixpkgs/commit/eae2018b5402c5c5f7aae91deeadc41e0b4b9b35) nixos/go2rtc: init
* [`b4260c35`](https://github.com/NixOS/nixpkgs/commit/b4260c35b8eedd05745b3eaa37d1cf6e8203c0c8) python3Packages.wordcloud: unstable-2023-01-04 -> 1.9.1.1
* [`8dd18f69`](https://github.com/NixOS/nixpkgs/commit/8dd18f69875f88412105a40279522b110ffe4f5e) navidrome: Use npmConfigHook and fetchNpmDeps for the UI bits
* [`d7c98fc6`](https://github.com/NixOS/nixpkgs/commit/d7c98fc6e49e465c004d5b4d113e66f10b2c283c) org-stats: init at 1.11.2
* [`b0657b61`](https://github.com/NixOS/nixpkgs/commit/b0657b6185e3d45fed9a5d5282f34bd52dbf794c) jsonfmt: init at 0.5.0
* [`c812170c`](https://github.com/NixOS/nixpkgs/commit/c812170c74f4cb21a5794eead6205edd0058b8db) shogun: refactor derivation
* [`5873454b`](https://github.com/NixOS/nixpkgs/commit/5873454b52893f451903362fbb15a2ac27b7f918) shogun: fix compiler warnings
* [`61fc2d2c`](https://github.com/NixOS/nixpkgs/commit/61fc2d2c898a7d84936f53058239aa5af24c5f16) shogun: disable tests that take too long
* [`70b3662a`](https://github.com/NixOS/nixpkgs/commit/70b3662a675b2a439eae1251532e4fe9daeb31ae) shogun: disable broken test
* [`8f52b7e1`](https://github.com/NixOS/nixpkgs/commit/8f52b7e13e3903d0260b128dc9d0a8e58c875994) srvc: 0.17.1 -> 0.18.0
* [`1d6faf84`](https://github.com/NixOS/nixpkgs/commit/1d6faf84a9098f5121e1c25dc24beee5130cdab3) python3Packages.word2vec: remove
* [`3ee719e7`](https://github.com/NixOS/nixpkgs/commit/3ee719e763011313277daec010e05e569cb6277c) kde-cli-tools: 5.27.5 -> 5.27.5.1
* [`00b70818`](https://github.com/NixOS/nixpkgs/commit/00b70818302f64a039ddabeeb987e21fec5ab1d7) starcharts: init at 1.7.0
* [`f6e677ac`](https://github.com/NixOS/nixpkgs/commit/f6e677ac8bcb03624182e2acc42648344ddd3efd) intel-compute-runtime: 23.05.25593.11 -> 23.13.26032.30
* [`3bfd604d`](https://github.com/NixOS/nixpkgs/commit/3bfd604d163b5017cdc8b9af1fc5d0c1863b463f) python3Packages.scikit-fmm: 2022.8.15 -> 2023.4.2
* [`46607b06`](https://github.com/NixOS/nixpkgs/commit/46607b063715c478354b0a7d5523e7b42f966cd5) ecs-agent: 1.71.0 -> 1.71.1
* [`11200746`](https://github.com/NixOS/nixpkgs/commit/11200746852ab36c23e850234ef66c90d1c9a9ac) gtk4: Backport fixes to fix regression in nautilus, mutter
* [`fe3a69ab`](https://github.com/NixOS/nixpkgs/commit/fe3a69ab0c7557224e610ae225bc95fab4603963) postgresqlPackages.timescaledb: 2.10.3 -> 2.11.0
* [`48aecaac`](https://github.com/NixOS/nixpkgs/commit/48aecaac35ccbb2dee2837c1de61fb95ade0eb97) jetbrains: 2023.1.1 → 2023.1.2
* [`009626ac`](https://github.com/NixOS/nixpkgs/commit/009626acbc0582eb8edf7fbe057bc135b3f93ce7) jetbrains.jdk: 17.0.6-b829.5 → 17.0.6-b829.9
* [`2a7863eb`](https://github.com/NixOS/nixpkgs/commit/2a7863eb2f1adfddf98136bbff1a1f670e5fb4ff) iwd: 2.3 -> 2.4
* [`47c722bd`](https://github.com/NixOS/nixpkgs/commit/47c722bd77738ac42c71ac5ce883f2653c4d85a4) coqPackages_8_17.dpdgraph: init at 1.0+8.17
* [`b36979ec`](https://github.com/NixOS/nixpkgs/commit/b36979ec74488ce153d936eb630e71010c251193) iqtree: 2.2.0.4 -> 2.2.2.4
* [`7033262f`](https://github.com/NixOS/nixpkgs/commit/7033262fa9abfeb0b8ccb6b77dc4e39f79682099) python3Packages.rdkit: use boost182 instead of default
* [`aa945561`](https://github.com/NixOS/nixpkgs/commit/aa9455616dc6c008ddcc2749da24f28a34c81dea) python310Packages.atlassian-python-api: 3.36.0 -> 3.37.0
* [`2f9d8929`](https://github.com/NixOS/nixpkgs/commit/2f9d89291a977ba7f84934d4d7d7df506ca8a7df) python310Packages.trimesh: 3.21.6 -> 3.21.7
* [`cf87e1bc`](https://github.com/NixOS/nixpkgs/commit/cf87e1bc8681574b8b192d768db34edf6768fa80) terraform-providers.alicloud: 1.204.1 -> 1.205.0
* [`b72f90dc`](https://github.com/NixOS/nixpkgs/commit/b72f90dc4b04e17f00fb35f98e99b01b4cd556fd) python310Packages.pysimplegui: 4.60.4 -> 4.60.5
* [`fd4c32ce`](https://github.com/NixOS/nixpkgs/commit/fd4c32ce8314cc60e4735049a61e14389de35b8a) refinery-cli: 0.8.9 -> 0.8.10
* [`0a560af5`](https://github.com/NixOS/nixpkgs/commit/0a560af56c4e58bf7e9265df99ad056d7715409c) crow-translate: 2.10.4 -> 2.10.5
* [`0e592e45`](https://github.com/NixOS/nixpkgs/commit/0e592e45b5dcf63843052a5b8727621807725a3d) doulos-sil: 6.101 -> 6.200
* [`7f0d4a35`](https://github.com/NixOS/nixpkgs/commit/7f0d4a351a111a125e88460a06a9fb10c3f45a1a) moar: 1.15.0 -> 1.15.1
* [`337e364e`](https://github.com/NixOS/nixpkgs/commit/337e364e623baffc3b481598f8902adca25706f5) vimPlugins.vim-agda: init at 2022-03-01
* [`bbac6aa5`](https://github.com/NixOS/nixpkgs/commit/bbac6aa50614392a813c8b7ca512cae139f6e568) python310Packages.manifest-ml: 0.1.5 -> 0.1.7
* [`a68600dc`](https://github.com/NixOS/nixpkgs/commit/a68600dc25b1fc184d13ff85d11615ed485bfab5) coqPackages.coqprime: 8.15 → 8.17
* [`aee4db0f`](https://github.com/NixOS/nixpkgs/commit/aee4db0fdab8e46d8bb5a914277bd6fbca77cc55) steam: fix lib32 dependencies
* [`243b7515`](https://github.com/NixOS/nixpkgs/commit/243b751546712242ee95a5b4e279f59bbee4967e) vimPlugins: update
* [`3ccafedc`](https://github.com/NixOS/nixpkgs/commit/3ccafedc92337df89e95ac1ac70f3650bdcf8dec) vimPlugins.nvim-treesitter: update grammars
* [`c009c2bc`](https://github.com/NixOS/nixpkgs/commit/c009c2bc1da372716785b3afac0ff23a5660bf0d) helix: add maintainer
* [`cf6ff11e`](https://github.com/NixOS/nixpkgs/commit/cf6ff11e138fe536ceddb7c582fb56721aeeb5ae) vscode-extensions.vadimcn.vscode-lldb: 1.8.1 -> 1.9.1
* [`7102501b`](https://github.com/NixOS/nixpkgs/commit/7102501b042d4141a4c0a46fee6be4f0290d5c66) ktextaddons: 1.2.0 -> 1.3.2
* [`1d0432ec`](https://github.com/NixOS/nixpkgs/commit/1d0432ec589c12815b84e2c944c38b800e541145) neomutt: 20230512 -> 20230517
* [`af48b134`](https://github.com/NixOS/nixpkgs/commit/af48b134fe4b14a3f85443accf5dad55d9e2c10b) python3Packages.rdkit: fix x86_64-darwin build
* [`5f61ab39`](https://github.com/NixOS/nixpkgs/commit/5f61ab39e014327d9a63948e7b688a2d75939ce8) python3Packages.rdkit: add natsukium as maintainers
* [`4543fbb6`](https://github.com/NixOS/nixpkgs/commit/4543fbb6f2049e8340438d50fd21e16caa2b3a4e) python311Packages.basemap: 1.3.6 -> 1.3.7
* [`c92f2244`](https://github.com/NixOS/nixpkgs/commit/c92f2244d1a31ed5ac66d3c625c332e817a1e92a) wordpress6_2: 6.2.1 -> 6.2.2
* [`1493a57c`](https://github.com/NixOS/nixpkgs/commit/1493a57cb6c7f0bc0a51d64c27da07055b357af3) privacyidea: fix build
* [`137b97e2`](https://github.com/NixOS/nixpkgs/commit/137b97e2f619cee1fbb8a624f5ad395a84efcca3) linuxkit: Sign binary with entitlements on Darwin
* [`eeefa71d`](https://github.com/NixOS/nixpkgs/commit/eeefa71db439b9d2d41544fd564207259ed58a88) ronin: init at 2.0.1
* [`9e87ab20`](https://github.com/NixOS/nixpkgs/commit/9e87ab2007852d1d733977a2e3d66658d9392efe) vscode: fix decrypting credentials after update
* [`81f2413b`](https://github.com/NixOS/nixpkgs/commit/81f2413b24f69f9aba616a7c88430466e73c8f6e) python311Packages.dvc-render: 0.5.2 -> 0.5.3
* [`cefb9d33`](https://github.com/NixOS/nixpkgs/commit/cefb9d3323fe9150fd3e208920068d5b0c34e4d1) python311Packages.easyenergy: 0.3.0 -> 0.3.1
* [`4cd4acc5`](https://github.com/NixOS/nixpkgs/commit/4cd4acc547b193f7bdc43f3acd65abeaa460e777) victoriametrics: 1.89.1 -> 1.91.0
* [`7d0f6a92`](https://github.com/NixOS/nixpkgs/commit/7d0f6a92764501247e7fefe2212a8afd0b536856) python311Packages.p1monitor: 2.3.0 -> 2.3.1
* [`469a3126`](https://github.com/NixOS/nixpkgs/commit/469a3126d4c5e1facb0d4e548d60401b18012af3) dvc: 2.57.2 -> 2.57.3
* [`8fb63c30`](https://github.com/NixOS/nixpkgs/commit/8fb63c30392b418ee3fd388564ef770d9b96c1e0) python310Packages.dvclive: 2.9.0 -> 2.10.0
* [`a507668d`](https://github.com/NixOS/nixpkgs/commit/a507668d8de9c0ca17a012191cbb82ef94388d59) libcpr: use version variable as Git rev
* [`9c64df11`](https://github.com/NixOS/nixpkgs/commit/9c64df11a33ad50de4d6f6e8f218e948125eb92f) openexr_3: disable tests for armv7l-linux
* [`6d71b5d6`](https://github.com/NixOS/nixpkgs/commit/6d71b5d6de16abfa008340f3bf5ad51e6eb7f677) iqtree: set platforms
* [`0b3a80b2`](https://github.com/NixOS/nixpkgs/commit/0b3a80b2d750b927be92bffb2543f69cbc33373b) wget: 1.21.3 -> 1.21.4
* [`d5e090d2`](https://github.com/NixOS/nixpkgs/commit/d5e090d2d82ccd3b32df4a856284d9ac355dd72c) Revert "nixos/syncthing: use rfc42 style settings"
* [`d42b8bcd`](https://github.com/NixOS/nixpkgs/commit/d42b8bcdf981569e39e95ee2a39598bc59d1a9d3) maintainers: add benwis
* [`02df3006`](https://github.com/NixOS/nixpkgs/commit/02df300699f8e4c24b39eeb7e034403880715dc5) cargo-leptos: init at 0.1.8
* [`c281a355`](https://github.com/NixOS/nixpkgs/commit/c281a355fef9f01c06816327be230e7c5cd6b699) nixos/iso-image: prepend to ISO menu labels
* [`91ede81b`](https://github.com/NixOS/nixpkgs/commit/91ede81bc4586f73f4961dae13563e1d33fc5231) imagemagick: 7.1.1-9 -> 7.1.1-10
* [`9be9b726`](https://github.com/NixOS/nixpkgs/commit/9be9b726f4b57814f67b58e860aec7cae2c18675) linux_testing: 6.4-rc2 -> 6.4-rc3
* [`a4b25ea8`](https://github.com/NixOS/nixpkgs/commit/a4b25ea80898ea87ec2427719f2ec2dee427019a) python310Packages.bx-py-utils: 78 -> 80
* [`ae823091`](https://github.com/NixOS/nixpkgs/commit/ae823091d6632baf6015d8bd0ddb03506fdec1d5) bzip3: 1.3.0 -> 1.3.1
* [`beced9da`](https://github.com/NixOS/nixpkgs/commit/beced9da0a4b384f2beae3ecb4be782f274d342f) lf: 29 -> 30
* [`d79d7bdb`](https://github.com/NixOS/nixpkgs/commit/d79d7bdbf43df9aa19f3c3234c0729c54cee6105) lens: Change lens' listed license from MIT to their own proprietary license.
* [`49a5cd8b`](https://github.com/NixOS/nixpkgs/commit/49a5cd8be665a5152b941890db54c8a92a69ce5a) darwin.sigtool: add meta
* [`0c3b2e5e`](https://github.com/NixOS/nixpkgs/commit/0c3b2e5e888a186bbeec1f256eab13daa66fd2c0) python38Packages.matplotlib: allow building
* [`afdf7705`](https://github.com/NixOS/nixpkgs/commit/afdf7705ade56663b6a16a3546c303decc6f1999) nixos/iso-image: add some types
* [`8ecdde2a`](https://github.com/NixOS/nixpkgs/commit/8ecdde2a510487c46c82d3173ec9b5e18c46327a) mercury: 22.01.5 -> 22.01.6
* [`dcc1dea7`](https://github.com/NixOS/nixpkgs/commit/dcc1dea7e90ea1493c0b79f1241d7a7565259880) minimal-bootstrap.gawk: init at 3.0.6
* [`e433d329`](https://github.com/NixOS/nixpkgs/commit/e433d329583c40f263e34b5fa1c5540a906a915a) minimal-bootstrap: remove imports from outside bootstrap
* [`64830202`](https://github.com/NixOS/nixpkgs/commit/648302027d44a2f8be89a1f35478c982d72b699d) spark: init 3.3.2, 3.2.4
* [`ebafd551`](https://github.com/NixOS/nixpkgs/commit/ebafd551d74a6bf3d315876c401635395c5d84e9) nixos/hercules-ci-agent: sync module with upstream
* [`bc87c59c`](https://github.com/NixOS/nixpkgs/commit/bc87c59c15e484a43afc0c2659c0d0c45bc9f78b) minimal-bootstrap.mes: remove unused import
* [`a1dedc90`](https://github.com/NixOS/nixpkgs/commit/a1dedc908d1d9f7e2b9490dc7b3b3020e8fe7d0b) lib.filesystem.pathType and co.: Add tests
* [`5346636c`](https://github.com/NixOS/nixpkgs/commit/5346636c20ff57410b25a6a8897d4e95f75e040c) lib.filesystem: Minor refactor
* [`bb6eab0b`](https://github.com/NixOS/nixpkgs/commit/bb6eab0bdbe060cb578fc9be5925a76a1635424f) lib.filesystem.pathType: Fix for filesystem root argument
* [`d064d972`](https://github.com/NixOS/nixpkgs/commit/d064d972f07b908db3efb909d6663bee3adf8d40) lib.filesystem.pathType: Improve error for non-existent paths
* [`84a3d633`](https://github.com/NixOS/nixpkgs/commit/84a3d633d6f3653675d794ef5e8e90bf0cb7c502) lib.filesystem.pathType and co.: Improve documentation
* [`fcaa2b10`](https://github.com/NixOS/nixpkgs/commit/fcaa2b1097e46c286b4651f5f2d7653f52ae860b) lib.filesystem.pathType: Use new builtins.readFileType if available
* [`378bf1a6`](https://github.com/NixOS/nixpkgs/commit/378bf1a6192a5d46ceb7e07af7be1d37b93b47c7) lib/filesystem.nix: Update top comment
* [`c856c0e9`](https://github.com/NixOS/nixpkgs/commit/c856c0e9fab9cb7d558ed87c073213d82d1b4917) buzztrax: init at unstable-2022-01-26 ([nixos/nixpkgs⁠#233364](https://togithub.com/nixos/nixpkgs/issues/233364))
* [`4f19b06e`](https://github.com/NixOS/nixpkgs/commit/4f19b06ecf75acd24e7d909b512852e3bc569347) easyeffects: cleanup
* [`a9c8820c`](https://github.com/NixOS/nixpkgs/commit/a9c8820c432a589594251a1c8753b9f170a3763a) python3Packages.xmldiff: 2.6.1 -> 2.6.3
* [`f752ef56`](https://github.com/NixOS/nixpkgs/commit/f752ef56b1e79d3d6e461c92b29990158dd2374f) exabgp: init at 4.2.21
* [`5be78a1b`](https://github.com/NixOS/nixpkgs/commit/5be78a1b0f33657b7ba4430e72f836908941b179) minimal-bootstrap.gnutar: init at 1.12
* [`d8e94638`](https://github.com/NixOS/nixpkgs/commit/d8e94638d1082e9d8c78e2b548b26fef2d46638c) minimal-bootstrap.gzip: init at 1.2.4
* [`27cba6ca`](https://github.com/NixOS/nixpkgs/commit/27cba6ca2e190acd655f2abd77a81c9ccfdbf383) minimal-bootstrap.bzip2: init at 1.0.8
* [`0979d42f`](https://github.com/NixOS/nixpkgs/commit/0979d42f87b27f569aac9c245b67a4cf440af338) super-tiny-icons: unstable-2022-11-07 -> unstable-2023-05-22
* [`699c09e0`](https://github.com/NixOS/nixpkgs/commit/699c09e0f0c0336e6eee226e4c1c8744218ffcb5) python3Packages.ziafont: move from Bitbucket to GitHub
* [`a6fdc73e`](https://github.com/NixOS/nixpkgs/commit/a6fdc73e9190caa262ab9cbc2668b5eb86f27b8a) python3Packages.ziafont: 0.5 -> 0.6
* [`f4dd5097`](https://github.com/NixOS/nixpkgs/commit/f4dd5097d48a2589cf8dc3729c7ac9e56bdb4526) python3Packages.ziamath: move from Bitbucket to GitHub
* [`45bbe93a`](https://github.com/NixOS/nixpkgs/commit/45bbe93a1721bbeed6377cc7ce676d538a3b4908) python3Packages.schemdraw: move from Bitbucket to GitHub
* [`d24f3752`](https://github.com/NixOS/nixpkgs/commit/d24f37524d565a169c119a319324a411165a868f) exabgp: add raitobezarius as a maintainer
* [`8239e01b`](https://github.com/NixOS/nixpkgs/commit/8239e01b7a1a114f63f70617da72e3acb6547121) minimal-bootstrap.tinycc-mes: remove unused ln-boot dependency
* [`f7e665cc`](https://github.com/NixOS/nixpkgs/commit/f7e665ccceaf040670885b73e45762e4539d030e) petsc: 3.17.4 -> 3.19.1, fixed build
* [`d402a52e`](https://github.com/NixOS/nixpkgs/commit/d402a52e2680d731656cfa412abbd6fc39d92385) minimal-bootstrap.ln-boot: fix typo in usage
* [`8f5833f3`](https://github.com/NixOS/nixpkgs/commit/8f5833f36749cafdc721c976abdc6d1791f302a1) python3Packages.wordfreq: fix build
* [`b7fc6db8`](https://github.com/NixOS/nixpkgs/commit/b7fc6db83c9a98f291d13e8d94abbd8e76e45340) bootspec: 0.2.0 -> 1.0.0
* [`5a5e1013`](https://github.com/NixOS/nixpkgs/commit/5a5e10130e6016a171f2ceab96c398625e6dc01b) nqptp: unstable-2022-09-12 -> 1.2.1
* [`4a2a84f2`](https://github.com/NixOS/nixpkgs/commit/4a2a84f246ee7a4958c7716bc76b53af912b5968) fishPlugins.fzf-fish: use script from unixtools
* [`98c51822`](https://github.com/NixOS/nixpkgs/commit/98c518221d0a56946cf41e0715a80acc909075e2) mlxbf-bootimages: init at 4.0.3-12704
* [`a0765981`](https://github.com/NixOS/nixpkgs/commit/a0765981b7c29b9fa17c31a4fc51e78cfc399fb1) alacritty: 0.12.0 -> 0.12.1
* [`b4e891e9`](https://github.com/NixOS/nixpkgs/commit/b4e891e9a4f00fdb3d22aa30cb3fded31c85c902) libvirt: disable util-linux on darwin
* [`a92e03c6`](https://github.com/NixOS/nixpkgs/commit/a92e03c6d37527139f593d17c27a44379224468b) python3Packages.desktop-notifier: 3.5.2 -> 3.5.3
* [`38bbcb5f`](https://github.com/NixOS/nixpkgs/commit/38bbcb5f42235ac3175595757f85621d0fdf9498) rcodesign: init at 0.22.0
* [`76f9a4b6`](https://github.com/NixOS/nixpkgs/commit/76f9a4b6170eabf374a44641b88be5729d629509) frigate: init at 0.12.0
* [`f11d33af`](https://github.com/NixOS/nixpkgs/commit/f11d33afb7cc37b90a3b350621522e80da000dd8) nixos/frigate: init
* [`c7ad6560`](https://github.com/NixOS/nixpkgs/commit/c7ad6560b0f5eb606a03698b7a123473725d57db) nixos/tests/frigate: init
* [`2c1cc783`](https://github.com/NixOS/nixpkgs/commit/2c1cc78307e618d2f0dc7d3176361617ee53a23b) nginxModules.vod: 1.29 -> 1.31
* [`9d0bbc2c`](https://github.com/NixOS/nixpkgs/commit/9d0bbc2c12c5b38c059bae15d17e2a601fc9a567) nginxModules.secure-token: 2020-08-28 -> 1.5
* [`d5f0da15`](https://github.com/NixOS/nixpkgs/commit/d5f0da152a8245169e85823f67543e1851c82490) Revert "Merge pull request [nixos/nixpkgs⁠#230693](https://togithub.com/nixos/nixpkgs/issues/230693) from Atemu/fix/fhsenv-escape-runScript-path"
* [`8912c50f`](https://github.com/NixOS/nixpkgs/commit/8912c50fc7c9241fd49e61c2387eb0126a49a679) doc:fhs-envs: mention that runScript must be escaped by the caller
* [`e57efc6c`](https://github.com/NixOS/nixpkgs/commit/e57efc6cb719064b99edfa670ab6cbfaed1433f8) doc:fhs-envs: format example properly
* [`3009b128`](https://github.com/NixOS/nixpkgs/commit/3009b12817c15e439609aaa794815de40a27564b) doc:fhs-envs: reword
* [`eb88a2eb`](https://github.com/NixOS/nixpkgs/commit/eb88a2eb0a6d1b3a770d78a0238c30f074cb5571) maestral-qt: 1.7.1 -> 1.7.2
* [`3fae96d5`](https://github.com/NixOS/nixpkgs/commit/3fae96d584fd2f27874c75faf50c330c4b6d792e) gitlab: 15.11.3 -> 15.11.5 ([nixos/nixpkgs⁠#233373](https://togithub.com/nixos/nixpkgs/issues/233373))
* [`180f05bf`](https://github.com/NixOS/nixpkgs/commit/180f05bf8c1423726974f23b3aacf32fafe9264a) topiary: 0.1.0 -> 0.2.0
* [`ec7d7940`](https://github.com/NixOS/nixpkgs/commit/ec7d794042bb60167977a6683fe3c3038d3f3dec) cnspec: init at 8.10.0
* [`d98364dc`](https://github.com/NixOS/nixpkgs/commit/d98364dcbb55267e30ed6642c5523edd03882042) ockam: init at 0.87.0
* [`95893689`](https://github.com/NixOS/nixpkgs/commit/95893689008e11846dbbf159d07cb8e155611218) pony-corral: unstable -> 0.7.0
* [`bcacb9f4`](https://github.com/NixOS/nixpkgs/commit/bcacb9f40428a0c70b4373dc3ab77b543d1244a8) ponyc: update google benchmark dep
* [`5954c7a6`](https://github.com/NixOS/nixpkgs/commit/5954c7a6df0b0aecbdd9c5e02b2e1e7ab25b77f5) conan: fix build on aarch64-darwin
* [`e1a80940`](https://github.com/NixOS/nixpkgs/commit/e1a80940a50ef7631d71497f9ff41817098fa092) kicad: make KICAD7_TEMPLATE_DIR a single path
* [`bc4250f4`](https://github.com/NixOS/nixpkgs/commit/bc4250f411bb2616b4243487e5dde3f760c8e5b3) ansible_2_14: 2.14.5 -> 2.14.6
* [`7daa2b14`](https://github.com/NixOS/nixpkgs/commit/7daa2b144f6f7ea8fa0d030e13b2e60650136972) ansible_2_13: 2.13.9 -> 2.13.10
* [`ef6a9bcf`](https://github.com/NixOS/nixpkgs/commit/ef6a9bcf32b4b200e6e284f971bc89693b87bf34) scip: init at 0.2.3
* [`41f1482b`](https://github.com/NixOS/nixpkgs/commit/41f1482be7d5d012bc9e1a24b30c6d8578908933) lean: 3.50.3 -> 3.51.0
* [`90013dee`](https://github.com/NixOS/nixpkgs/commit/90013dee5cffd6bdda7e362127a39f21b7e8bb59) wayland: remove useless passthru.version
* [`c88e9991`](https://github.com/NixOS/nixpkgs/commit/c88e9991222460bbfab97c2a071a63d77c49fd2e) sage: add meta.platforms
* [`98f77fac`](https://github.com/NixOS/nixpkgs/commit/98f77faca4e780e4fed97b488beb2777808df918) gitkraken: 9.3.0 -> 9.4.0
* [`9ba91a14`](https://github.com/NixOS/nixpkgs/commit/9ba91a149bb5c74b255cbc68b221be8a8793129d) vscode-extensions.nvarner.typst-lsp: 0.4.1 -> 0.5.0
* [`7ea816fd`](https://github.com/NixOS/nixpkgs/commit/7ea816fd248e9115a6cb3b5c1567334fbf475400) ferretdb: 1.1.0 -> 1.2.0
* [`5aaa7ff0`](https://github.com/NixOS/nixpkgs/commit/5aaa7ff0720332c32910dc4eca3bdd86eb39fc2a) python310Packages.crocoddyl: 1.9.0 -> 2.0.0
* [`5e46fe26`](https://github.com/NixOS/nixpkgs/commit/5e46fe26bf3aac02ec82a0ac719e0224267ed17b) firefox-beta-bin-unwrapped: 114.0b6 -> 114.0b7
* [`0d5bb3e3`](https://github.com/NixOS/nixpkgs/commit/0d5bb3e36035820727a06f3c1babc4220095c629) firefox-devedition-bin-unwrapped: 114.0b6 -> 114.0b7
* [`ac7ec4c4`](https://github.com/NixOS/nixpkgs/commit/ac7ec4c46acd228ac95c4d3bd094a365555072cb) firefox-beta-unwrapped: 114.0b6 -> 114.0b7
* [`a68f2e67`](https://github.com/NixOS/nixpkgs/commit/a68f2e67c70650828f682dfbb0ae689cec0795c5) firefox-devedition-unwrapped: 114.0b6 -> 114.0b7
* [`b7dc436b`](https://github.com/NixOS/nixpkgs/commit/b7dc436b6ecd338f67d04f9d45ab75bfb18b2ef5) python310Packages.can: 4.2.0 -> 4.2.1
* [`eb34adff`](https://github.com/NixOS/nixpkgs/commit/eb34adff558f6b0d5da10dd6450acf993f8262cc) python310Packages.torch: drop util-linux
* [`0a7a068d`](https://github.com/NixOS/nixpkgs/commit/0a7a068d4985e0987eaf6e2c476d463ef24e2d66) esptool: set meta.mainProgram
* [`1e923ee6`](https://github.com/NixOS/nixpkgs/commit/1e923ee61f2b4f6c821de291f38d187f79b89bab) halfempty: fix build on darwin
* [`b8b30dff`](https://github.com/NixOS/nixpkgs/commit/b8b30dff6eb2a3a3945d86c74808e44e23b36d51) x264: fix cross compilation to x86_64
* [`d6ca06e7`](https://github.com/NixOS/nixpkgs/commit/d6ca06e7e21134f940860966de69d57f2376789b) vectorscan: init at 5.4.9
* [`0000006c`](https://github.com/NixOS/nixpkgs/commit/0000006cd8260daf062d00594923c6a078895144) procs: 0.13.4 -> 0.14.0
* [`1ebed52d`](https://github.com/NixOS/nixpkgs/commit/1ebed52d627d9f3a82ddb3e6e5e9c353c4d2a341) isso: 0.12.6.2 -> 0.13.0
* [`13807f6e`](https://github.com/NixOS/nixpkgs/commit/13807f6e707f434a02fc17193c867b5857d36181) nvd: 0.2.0 -> 0.2.3
* [`09e292fb`](https://github.com/NixOS/nixpkgs/commit/09e292fba614125a2a9a64859e8dd7b754e34b47) funzzy: init at 0.6.0
* [`2c28f1de`](https://github.com/NixOS/nixpkgs/commit/2c28f1de7cdc10be556d2106108411dd2482794b) 23.11 is Tapir
* [`89eb9831`](https://github.com/NixOS/nixpkgs/commit/89eb98312cfe7662ff78e680410f4e6693bb3b12) python310Packages.llfuse: 1.4.3 -> 1.4.4
* [`0a3aeb76`](https://github.com/NixOS/nixpkgs/commit/0a3aeb76b9cd260a9597707e9d4e8c2ee59fda97) wamr: init at 1.2.2
* [`4a01ba47`](https://github.com/NixOS/nixpkgs/commit/4a01ba47ee010b27ae970c7d2c60ebf16b5878df) wasmtime: 8.0.1 -> 9.0.0
* [`89f08d7c`](https://github.com/NixOS/nixpkgs/commit/89f08d7cd9f097e08949cf7e890c01b8cd0a7e9f) typos: 1.14.10 -> 1.14.11
* [`e76740fb`](https://github.com/NixOS/nixpkgs/commit/e76740fb19226e6fdf99a003154eab4354e661d8) python310Packages.ocrmypdf: 14.1.0 -> 14.2.0
* [`7ce5b8e7`](https://github.com/NixOS/nixpkgs/commit/7ce5b8e78ac314176bf898d250677e59fdd30866) mpd: 0.23.12 -> 0.23.13
* [`5be79791`](https://github.com/NixOS/nixpkgs/commit/5be79791019d5b76d94be4bf10ad55b80a5d4448) mattermost: 7.8.4 -> 7.8.5
* [`66e97b49`](https://github.com/NixOS/nixpkgs/commit/66e97b497d722c6c2172069db7cf7904c7e9b429) cnspec: fix build on darwin
* [`351ff5ae`](https://github.com/NixOS/nixpkgs/commit/351ff5aefca3ad9ed8d8b56e258ffa30de9dc8f6) tf-summarize: init a 0.3.2 ([nixos/nixpkgs⁠#233472](https://togithub.com/nixos/nixpkgs/issues/233472))
* [`f5911e40`](https://github.com/NixOS/nixpkgs/commit/f5911e4068eb669d9ed0aaed5f2db49498792192) blender: Add Python to passthru for use in addon drvs ([nixos/nixpkgs⁠#230884](https://togithub.com/nixos/nixpkgs/issues/230884))
* [`7cded0fa`](https://github.com/NixOS/nixpkgs/commit/7cded0fa373276aec3d19e16e6836a456928a851) mediamtx: fix version
* [`b4d2d2d5`](https://github.com/NixOS/nixpkgs/commit/b4d2d2d5a4bdd5070126aa70d8032c13484cc7df) direnv: 2.32.2 -> 2.32.3
* [`058d1ff8`](https://github.com/NixOS/nixpkgs/commit/058d1ff8ce40b330dc5360fae958865e4e887262) unifont: 15.0.01 -> 15.0.02
* [`e6cd1720`](https://github.com/NixOS/nixpkgs/commit/e6cd172041d01e103d818ce26dfe1efa2269b42a) unifont_upper: 15.0.01 -> 15.0.02
* [`adb54ab7`](https://github.com/NixOS/nixpkgs/commit/adb54ab7bdc0bb25f8971660de2a94c0b3dffb45) rustc: remove unused argument
* [`63dd9190`](https://github.com/NixOS/nixpkgs/commit/63dd9190dc078ca0969cb6d23e4a563ba6e9c539) sem: init at 0.28.1
* [`257ac0dd`](https://github.com/NixOS/nixpkgs/commit/257ac0ddd460e09cb348a7948b302d7a64548e37) esphome: 2023.5.2 -> 2023.5.3
* [`72aab129`](https://github.com/NixOS/nixpkgs/commit/72aab12981a0cd8f60b4246962cbe1cb28cec705) python311Packages.shodan: 1.29.0 -> 1.29.1
* [`bb820fba`](https://github.com/NixOS/nixpkgs/commit/bb820fbaf63ed18d9b382e7fd70a72840e5d7d6b) apbs: init at 3.4.1 ([nixos/nixpkgs⁠#230644](https://togithub.com/nixos/nixpkgs/issues/230644))
* [`5a4800d6`](https://github.com/NixOS/nixpkgs/commit/5a4800d69c361b2a21d930b8fd336ea7ba761f84) minimal-bootstrap.coreutils: backport `uniq` stdio patch
* [`427dbe51`](https://github.com/NixOS/nixpkgs/commit/427dbe5140e890914a2e5fab41cf84775af3b15e) unixODBCDrivers.mariadb: fix cross
* [`467c7ca0`](https://github.com/NixOS/nixpkgs/commit/467c7ca038593b2d9a573b83dc036db144e84e26) cargo: mark broken for cross compilation to x86
* [`c68a5bb8`](https://github.com/NixOS/nixpkgs/commit/c68a5bb85a79034d2f62bfdb36e9149f0a60f690) nixos/iso-image: enable BIOS boot by default if possible
* [`8bbe4ca1`](https://github.com/NixOS/nixpkgs/commit/8bbe4ca114594d7902366ee6f3932151596744da) poke: 2.4 -> 3.2
* [`1e8c4198`](https://github.com/NixOS/nixpkgs/commit/1e8c419898448628d0ad478e83c5f1bb1f8ff478) kubernetes-helmPlugins.helm-diff: 3.7.0 -> 3.8.0
* [`ccab0a33`](https://github.com/NixOS/nixpkgs/commit/ccab0a335b5de93f21fd0fa00ad52d32a9dd050c) commonsDaemon: 1.3.3 -> 1.3.4
* [`18ca5161`](https://github.com/NixOS/nixpkgs/commit/18ca51617f8ccd7095b57fcc762c4c5de20b4a29) maintainers: add leonid
* [`f1af5ee2`](https://github.com/NixOS/nixpkgs/commit/f1af5ee2675dea3c28337f462d99e71a0da0d4b0) epub2txt2: init 2.06
* [`cfae3663`](https://github.com/NixOS/nixpkgs/commit/cfae366324b4f322088e8728a1ebd2f374a8554d) argc: 1.1.0 -> 1.2.0
* [`2b85317d`](https://github.com/NixOS/nixpkgs/commit/2b85317d4d73201804a670cf2ce0daa2145de021) radioboat: 0.2.3 -> 0.3.0
* [`32376ec1`](https://github.com/NixOS/nixpkgs/commit/32376ec1e798c52da4aa214c0ad5220ca89d6353) wlrctl: 0.2.1 -> 0.2.2
* [`b4c4a0bf`](https://github.com/NixOS/nixpkgs/commit/b4c4a0bfc98147a7e766c5b83fa150f601255b32) steampipe: 0.19.5 -> 0.20.2
* [`b180969b`](https://github.com/NixOS/nixpkgs/commit/b180969b05c16f967f13d5da386c75e0bd6ab986) xfce.libxfce4ui: 4.18.3 -> 4.18.4
* [`532f12d1`](https://github.com/NixOS/nixpkgs/commit/532f12d1fc270e62135e6c12e47ee7a182b2c552) xfce.xfce4-panel: 4.18.3 -> 4.18.4
* [`f3f607dc`](https://github.com/NixOS/nixpkgs/commit/f3f607dcc3a77fa5d3df432aecd4e9c49dcb61ed) layan-gtk-theme: update 2021-06-30 -> 2023-05-23
* [`3869deb3`](https://github.com/NixOS/nixpkgs/commit/3869deb3ab7e12478e09ddabfda2059684c17249) discord-canary: 0.0.151 -> 0.0.154
* [`835bdc9b`](https://github.com/NixOS/nixpkgs/commit/835bdc9b9760f20cb07617b4a16ddb8b999a2f89) ssocr: 2.22.1 -> 2.23.1
* [`6835a7b5`](https://github.com/NixOS/nixpkgs/commit/6835a7b510f4ae446eeb6246833b29763e7625db) gremlin-console: 3.6.3 -> 3.6.4
* [`dd7ea505`](https://github.com/NixOS/nixpkgs/commit/dd7ea5054d998e775f641e3aa6fc1570d8757943) python310Packages.python-pidfile: 3.0.0 -> 3.1.1
* [`7c758b9f`](https://github.com/NixOS/nixpkgs/commit/7c758b9f222db5b01ea60dd7da54f6e0b3ad7f44) python310Packages.macfsevents: 0.8.1 -> 0.8.4
* [`9babe90b`](https://github.com/NixOS/nixpkgs/commit/9babe90b02f8c1878dc4b6b4c729da2145de92a4) millet: 0.9.7 -> 0.9.8
* [`8860c02b`](https://github.com/NixOS/nixpkgs/commit/8860c02b5b4f14fb889277649bfb5318ce2c8828) bundletool: 1.15.0 -> 1.15.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
