### PR TITLE
niv devenv: update 2f1d49ae -> b0bc8ec6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2f1d49aeee1378c44293ca2f61bf3a9004986fb7",
-        "sha256": "1p0rvv3izj7ajp6aljavrk060x7vf2mkqgpzk47r8dfjcb0i7dwd",
+        "rev": "b0bc8ec6e52726cadfe5c6695b07408b69adc307",
+        "sha256": "1kq68mdkzzw2chmyqzkqn2l4gjs1vlys0kkgxhyqgblbhxdichrl",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/2f1d49aeee1378c44293ca2f61bf3a9004986fb7.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/b0bc8ec6e52726cadfe5c6695b07408b69adc307.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@2f1d49ae...b0bc8ec6](https://github.com/cachix/devenv/compare/2f1d49aeee1378c44293ca2f61bf3a9004986fb7...b0bc8ec6e52726cadfe5c6695b07408b69adc307)

* [`d9f0660c`](https://github.com/cachix/devenv/commit/d9f0660c7f8b0995555bb366619367fc5b3416ec) modules: fix evaluation when modules emit warnings
* [`e4b57a65`](https://github.com/cachix/devenv/commit/e4b57a65089c9b8a5b50b72dd68413cce4c009a3) postgres: add an `extensions` option
* [`7e04f5c6`](https://github.com/cachix/devenv/commit/7e04f5c6c433ae34a0289d678235eb06deeb4afa) postgres: demonstrate extensions in the example
* [`d2dfc732`](https://github.com/cachix/devenv/commit/d2dfc732433a32c8fb3abddd1ddf2881646c3294) module: use showWarnings to displays warnings
* [`3c7029a4`](https://github.com/cachix/devenv/commit/3c7029a46217065d1632c8f65f41667cecc10905) ruby: add "follows: nixpkgs" in assertion message
* [`98e5f90f`](https://github.com/cachix/devenv/commit/98e5f90f2542f5bd4c0cb614a277e6f2356124ce) Auto generate docs/reference/options.md
* [`a007dd13`](https://github.com/cachix/devenv/commit/a007dd13fa40325dc26abc34a2d8231a4cb13710) chore(deps): bump cachix/install-nix-action from 20 to 21
* [`89044dd3`](https://github.com/cachix/devenv/commit/89044dd350b7d08f170ba03885f63405d8bd9156) Use nixpkgs#gleam package instead of vic/gleam-nix
* [`4426f036`](https://github.com/cachix/devenv/commit/4426f036b3f87e4b22d36696f8a82f9eab541de5) vault: speed up the test and improve logging
