### PR TITLE
niv home-manager: update d9995d94 -> 43ed7048

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d9995d94f194955d1f1af0e1ad5866a904196c20",
-        "sha256": "1j887rbq7pagv819ivbrzga10lj37mff83z35cy2p21z9pqzy2kv",
+        "rev": "43ed7048f670661d1ae2ea0d2f7655e87e7b0461",
+        "sha256": "09kjxkpxz4vwj03hdwh2y469h0i3wvzwd31gb9v6d269jl9iciax",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d9995d94f194955d1f1af0e1ad5866a904196c20.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/43ed7048f670661d1ae2ea0d2f7655e87e7b0461.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d9995d94...43ed7048](https://github.com/nix-community/home-manager/compare/d9995d94f194955d1f1af0e1ad5866a904196c20...43ed7048f670661d1ae2ea0d2f7655e87e7b0461)

* [`58eb968c`](https://github.com/nix-community/home-manager/commit/58eb968c21d309a6c2b020ea8d64e25c38ceebba) flake.lock: Update
* [`d1f04b0f`](https://github.com/nix-community/home-manager/commit/d1f04b0f365a34896a37d9015637796537ec88a3) yt-dlp: generate config if settings or extraConfig are defined ([nix-community/home-manager⁠#4018](https://togithub.com/nix-community/home-manager/issues/4018))
* [`bec196cd`](https://github.com/nix-community/home-manager/commit/bec196cd9b5f34213c7dc90ef2a524336df70e30) helix: improve warning message for languages option ([nix-community/home-manager⁠#4023](https://togithub.com/nix-community/home-manager/issues/4023))
* [`6a192256`](https://github.com/nix-community/home-manager/commit/6a1922568337e7cf21175213d3aafd1ac79c9a2e) home-manager: verify username and home directory
* [`2d963854`](https://github.com/nix-community/home-manager/commit/2d963854ae2499193c0c72fd67435fee34d3e4fd) ssh: don't install a client by default ([nix-community/home-manager⁠#4016](https://togithub.com/nix-community/home-manager/issues/4016))
* [`43ed7048`](https://github.com/nix-community/home-manager/commit/43ed7048f670661d1ae2ea0d2f7655e87e7b0461) Drop remaining CODEOWNERS reference from PR template ([nix-community/home-manager⁠#4033](https://togithub.com/nix-community/home-manager/issues/4033))
