### PR TITLE
niv niv: update 72255212 -> 0ebb80e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "7225521219f64df00de86c3b946a26f608f3b4dc",
-        "sha256": "04w9c06f70n0k9c4xhma4nfrkxxg7d039xd3v9dak8xd7avjb7v0",
+        "rev": "0ebb80e003c26d5388a9b74645fbdcfca3bdd0ef",
+        "sha256": "0wpnk1n4vjyqwjjrm6dvkyh7xr7983rszfhfcg31v106qhfnh41c",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/7225521219f64df00de86c3b946a26f608f3b4dc.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/0ebb80e003c26d5388a9b74645fbdcfca3bdd0ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@72255212...0ebb80e0](https://github.com/nmattia/niv/compare/7225521219f64df00de86c3b946a26f608f3b4dc...0ebb80e003c26d5388a9b74645fbdcfca3bdd0ef)

* [`c0f68a09`](https://github.com/nmattia/niv/commit/c0f68a09d60833bf2163b9d32dbd8dd1157bbfd3) Use recommended optparse applicative function ([nmattia/niv⁠#371](https://togithub.com/nmattia/niv/issues/371))
* [`0ebb80e0`](https://github.com/nmattia/niv/commit/0ebb80e003c26d5388a9b74645fbdcfca3bdd0ef) Bump cachix/install-nix-action from 20 to 21 ([nmattia/niv⁠#372](https://togithub.com/nmattia/niv/issues/372))
