### PR TITLE
niv powerlevel10k: update 951d6957 -> 3ce7bac4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "951d6957895b1887567b3ea7e548f9533daa3c83",
-        "sha256": "05hhk0v1vq0xjrcsgkcgq7is62bnji6n74zqm5cj19d68pyrvari",
+        "rev": "3ce7bac4ff2e07b9f1182c7bf7a1cac7c7ffdf9e",
+        "sha256": "1kxqxa8692acjplij098364338rvbslnsvgpq0pw2gckmpjq6brj",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/951d6957895b1887567b3ea7e548f9533daa3c83.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/3ce7bac4ff2e07b9f1182c7bf7a1cac7c7ffdf9e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@951d6957...3ce7bac4](https://github.com/romkatv/powerlevel10k/compare/951d6957895b1887567b3ea7e548f9533daa3c83...3ce7bac4ff2e07b9f1182c7bf7a1cac7c7ffdf9e)

* [`7bb3f053`](https://github.com/romkatv/powerlevel10k/commit/7bb3f053186f597b1a93a0fb7daf02e8fa83376d) annotate right prompt for warp ([romkatv/powerlevel10k⁠#2307](https://togithub.com/romkatv/powerlevel10k/issues/2307))
* [`f4a7e6d0`](https://github.com/romkatv/powerlevel10k/commit/f4a7e6d0e033b1428279313c6849ceec0a3f1757) force shell integration when running under warp ([romkatv/powerlevel10k⁠#2307](https://togithub.com/romkatv/powerlevel10k/issues/2307))
* [`8cce8464`](https://github.com/romkatv/powerlevel10k/commit/8cce84643f53354a227fccd109c61d99940d910a) set P9K_VERSION ([romkatv/powerlevel10k⁠#2307](https://togithub.com/romkatv/powerlevel10k/issues/2307))
