### PR TITLE
niv emacs-overlay: update 2806dea6 -> 096b3845

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2806dea6457fed28013169a05a6dcf9c722d5465",
-        "sha256": "18l9y79sdq6faqaqlc8rxa8nd3mbd6ymqd5fl5iy0pdn95c1vz22",
+        "rev": "096b38450cbe3ba218e52f11c891eb0c67c3ca95",
+        "sha256": "0na1yw2b0x5hv25mi5iy3nly63b8q22avk88sr6qnkwabfxyzgd7",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/2806dea6457fed28013169a05a6dcf9c722d5465.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/096b38450cbe3ba218e52f11c891eb0c67c3ca95.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@2806dea6...096b3845](https://github.com/nix-community/emacs-overlay/compare/2806dea6457fed28013169a05a6dcf9c722d5465...096b38450cbe3ba218e52f11c891eb0c67c3ca95)

* [`d4fbab64`](https://github.com/nix-community/emacs-overlay/commit/d4fbab64e7423db3e9c391d382d65ed9019fe762) Updated repos/melpa
* [`6384b7e2`](https://github.com/nix-community/emacs-overlay/commit/6384b7e26999e59a9a27c78c11bad677766edab1) Updated repos/melpa
* [`e0c0b3f0`](https://github.com/nix-community/emacs-overlay/commit/e0c0b3f09829e333326a10a051a0836b27b1e08d) Updated repos/melpa
* [`3c1b5e0b`](https://github.com/nix-community/emacs-overlay/commit/3c1b5e0bb800541b1f5d41cf23fdd2394858d507) Updated repos/melpa
* [`960aa61f`](https://github.com/nix-community/emacs-overlay/commit/960aa61f1c9c62ecb210e52f2859413fae5699a4) Updated repos/elpa
* [`1fb7acff`](https://github.com/nix-community/emacs-overlay/commit/1fb7acff3753a86c973a25d7f1c06cd574a3716d) Updated repos/emacs
* [`8f327ba7`](https://github.com/nix-community/emacs-overlay/commit/8f327ba75dc95080ffab59a4f68b2c73b52d3cb3) Updated repos/melpa
* [`e4b7303a`](https://github.com/nix-community/emacs-overlay/commit/e4b7303ac641902d7f5e541071fea537d723871a) Updated repos/emacs
* [`e790cd00`](https://github.com/nix-community/emacs-overlay/commit/e790cd0042a4ad62419bbe411cd013d8d1549cea) Updated repos/melpa
* [`3dedbf67`](https://github.com/nix-community/emacs-overlay/commit/3dedbf675c93de8941778a12676cc8fd39c27d3f) Updated repos/nongnu
* [`24e553ce`](https://github.com/nix-community/emacs-overlay/commit/24e553ce39c07dcfdb56375190e1ec92f1df0317) Updated repos/melpa
* [`9a691c70`](https://github.com/nix-community/emacs-overlay/commit/9a691c7088459182b7dd37b7acdb21f805c81a7e) Work around [nix-community/emacs-overlay⁠#318](https://togithub.com/nix-community/emacs-overlay/issues/318)
* [`e7cd4e40`](https://github.com/nix-community/emacs-overlay/commit/e7cd4e4053af9872840f04e7a36c5f11aa81648b) Work around https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-05/msg01512.html
* [`dd907639`](https://github.com/nix-community/emacs-overlay/commit/dd907639163218e99839668ca416c1fb1a762825) Updated repos/emacs
* [`7fba168f`](https://github.com/nix-community/emacs-overlay/commit/7fba168f4473eb769715f5ef8cc08c1c3bc50431) Updated repos/melpa
* [`30d50ec9`](https://github.com/nix-community/emacs-overlay/commit/30d50ec907edd37cafd215a922e97a0d58af4994) Updated repos/melpa
* [`72c88808`](https://github.com/nix-community/emacs-overlay/commit/72c888082acc0a75cc8a76c9b15603f1044b168c) Updated repos/melpa
* [`95692612`](https://github.com/nix-community/emacs-overlay/commit/956926122e62ea2ce0875ca48f781e5cc4bfea13) Updated repos/emacs
* [`095e709a`](https://github.com/nix-community/emacs-overlay/commit/095e709a3b488538c5bd05399803a73c05db8d8b) Updated repos/melpa
* [`5eda5719`](https://github.com/nix-community/emacs-overlay/commit/5eda5719cc4366ddcab47e109b52ce13690d9e0c) Updated repos/emacs
* [`c7ca2818`](https://github.com/nix-community/emacs-overlay/commit/c7ca2818d7562c62f4c7f5e55d59979144e3f078) Updated repos/melpa
* [`1058bda4`](https://github.com/nix-community/emacs-overlay/commit/1058bda4a06d3951cefbe79aaf92168cfacf1c4a) Updated repos/nongnu
* [`12a1b383`](https://github.com/nix-community/emacs-overlay/commit/12a1b383b9e8fa630321742729daf3901f1a8558) Updated repos/emacs
* [`23dfd9c7`](https://github.com/nix-community/emacs-overlay/commit/23dfd9c7e508ab17b3171c8c37551479ce845c2c) Updated repos/melpa
* [`5a3f2fe5`](https://github.com/nix-community/emacs-overlay/commit/5a3f2fe5101a01edeadac40210518e9cfbbaaef7) Updated repos/melpa
* [`8ae5e04b`](https://github.com/nix-community/emacs-overlay/commit/8ae5e04ba2f5366fea35d20682af009e4f790298) Updated repos/nongnu
* [`6ec9045f`](https://github.com/nix-community/emacs-overlay/commit/6ec9045f8b81b187d0628a8986ca47e163f90285) Updated repos/melpa
* [`8b10f751`](https://github.com/nix-community/emacs-overlay/commit/8b10f751e48ae0e48b3f037a352c7447dc7d1afe) Updated repos/melpa
* [`77269bb9`](https://github.com/nix-community/emacs-overlay/commit/77269bb9a0c99fdc5f356eac10b41172775194fc) Updated repos/melpa
* [`f6f7f8ef`](https://github.com/nix-community/emacs-overlay/commit/f6f7f8ef79ab84f6585a7d6ee7b8cb65719f4f1f) Revert "Work around https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-05/msg01512.html"
* [`7e8059be`](https://github.com/nix-community/emacs-overlay/commit/7e8059be4e368c5162b242a26fc1d809f455231a) Update inputs
* [`b03abde2`](https://github.com/nix-community/emacs-overlay/commit/b03abde24c0f40d83a907dc56a3c57857b4916e7) Updated repos/emacs
* [`0c1a3b4d`](https://github.com/nix-community/emacs-overlay/commit/0c1a3b4d76ceb3898afbe083f6b75ff132a00e54) Updated repos/melpa
* [`26f860f7`](https://github.com/nix-community/emacs-overlay/commit/26f860f7016359c128ec9523ae763afdf5415755) Updated repos/emacs
* [`3ed7dbbb`](https://github.com/nix-community/emacs-overlay/commit/3ed7dbbbfaf8014175bc25d3f88702e4e522d9d6) Updated repos/melpa
* [`04f25058`](https://github.com/nix-community/emacs-overlay/commit/04f25058fbe3ae1aadd435aba49b66493e939f83) Updated repos/melpa
* [`41823560`](https://github.com/nix-community/emacs-overlay/commit/4182356068ac0ead0d0e3cf994f2b09d2b8ac6b3) Updated repos/emacs
* [`7735f53e`](https://github.com/nix-community/emacs-overlay/commit/7735f53ef8f28d80ca5339e486e29177ed7c8297) Updated repos/melpa
* [`bb1c627b`](https://github.com/nix-community/emacs-overlay/commit/bb1c627bf3d413f4518d52830c4b87701d9caab7) Updated repos/elpa
* [`e2e5f216`](https://github.com/nix-community/emacs-overlay/commit/e2e5f216161dd40d8d6e60b7db22a05bef7c5188) Updated repos/emacs
* [`a7dd3403`](https://github.com/nix-community/emacs-overlay/commit/a7dd340354f3bd500019428ba5928b36d6e76f1b) Updated repos/melpa
* [`509a7ef0`](https://github.com/nix-community/emacs-overlay/commit/509a7ef0ea8d63fac38a09f68fde3f4fe8678c92) Remove tree-sitter stuff
* [`77c0c823`](https://github.com/nix-community/emacs-overlay/commit/77c0c82383520020990fb0fe12592fcfaf5a4d3a) Account for upstream refactor
* [`936f581f`](https://github.com/nix-community/emacs-overlay/commit/936f581fed5296053cb6098063fa706dec7fc13f) Make emacsLsp overridable
* [`9bdb618f`](https://github.com/nix-community/emacs-overlay/commit/9bdb618fa89c631fa1ea58cb1a2134fa1e839a80) Updated repos/elpa
* [`cbe51a02`](https://github.com/nix-community/emacs-overlay/commit/cbe51a02085cd9c9ccfb992f0c6b899835c2344c) Updated repos/emacs
* [`8d024852`](https://github.com/nix-community/emacs-overlay/commit/8d0248521591916db73447016588fae5b9594f66) Updated repos/melpa
* [`f3de842d`](https://github.com/nix-community/emacs-overlay/commit/f3de842d61a82311589af736888c0bd52e300615) Updated repos/nongnu
* [`e20a3891`](https://github.com/nix-community/emacs-overlay/commit/e20a3891139758fd04ef1905c19e3e1fcc744179) Account for nixpkgs checkouts lacking withTreeSitter attribute
* [`2143986e`](https://github.com/nix-community/emacs-overlay/commit/2143986e6283433634dc0f661b665b3351b808af) Clarify to-do
* [`030b0280`](https://github.com/nix-community/emacs-overlay/commit/030b0280030dd18024ef97d7618c9126ac8ea50d) Update inputs
* [`ad1bee73`](https://github.com/nix-community/emacs-overlay/commit/ad1bee73d84d38ba67ca949720d08ad82d08af7f) Updated repos/emacs
* [`d0fc4dae`](https://github.com/nix-community/emacs-overlay/commit/d0fc4dae0e0248453324e8d05733163a6a2f102e) Updated repos/melpa
* [`4bd64d30`](https://github.com/nix-community/emacs-overlay/commit/4bd64d30e696a9dd2e459c16b8ea1122dd5b9d64) Updated repos/emacs
* [`6ec96835`](https://github.com/nix-community/emacs-overlay/commit/6ec96835d9328bcb245d81c5997eea2ec6144fea) Updated repos/melpa
* [`7d59cba4`](https://github.com/nix-community/emacs-overlay/commit/7d59cba4540fe4dac590475afbec3b3786dd6530) Move hydra jobsets to flake.nix
* [`ea1a1424`](https://github.com/nix-community/emacs-overlay/commit/ea1a14245ed6817ee3f44627444d1f9d1794004d) Remove hydra jobset files
