### PR TITLE
niv nixpkgs: update 4295779f -> cfebfa1f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4295779fbaacb7158d5f32c4aa2740ef7b56d91b",
-        "sha256": "0996zv18q37mwcx2zwa9hhmc6mbr86y7sa8n3llcbb4ghz3aq0j0",
+        "rev": "cfebfa1f4a0279c0208b5e0f0b408770c4316023",
+        "sha256": "1bva7bvrypwjk5ymsprpvi9yvssf36l1xgbwcjq58f9sk7dh5z61",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4295779fbaacb7158d5f32c4aa2740ef7b56d91b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/cfebfa1f4a0279c0208b5e0f0b408770c4316023.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4295779f...cfebfa1f](https://github.com/nixos/nixpkgs/compare/4295779fbaacb7158d5f32c4aa2740ef7b56d91b...cfebfa1f4a0279c0208b5e0f0b408770c4316023)

* [`44886930`](https://github.com/NixOS/nixpkgs/commit/44886930e2133a655eca87c11e4a00ac37d0847f) removeReferencesTo: correct region reference in fixupHook
* [`31d9db0c`](https://github.com/NixOS/nixpkgs/commit/31d9db0cbb524dd37297dd272319bd73292594bd) sbc: 1.4 -> 2.0
* [`6ce68674`](https://github.com/NixOS/nixpkgs/commit/6ce68674a45a1c0e7fe0dcdb8635d474c454c1a6) mdbook-toc: init at 0.9.0
* [`0ae5315f`](https://github.com/NixOS/nixpkgs/commit/0ae5315f7c4f911a8ea1f7ee1e7c4b532284d2fd) wavpack: 5.5.0 -> 5.6.0
* [`88fd6601`](https://github.com/NixOS/nixpkgs/commit/88fd6601d81da77eb9792b7aeceb1db95365ec89) stdenv: remove the NIX_LIB*_IN_SELF_RPATH environment variables
* [`84fa095d`](https://github.com/NixOS/nixpkgs/commit/84fa095d6f7217ad04db332205c23ba158d436a1) libjack2: move headers to "dev" outputs
* [`13a4d747`](https://github.com/NixOS/nixpkgs/commit/13a4d7475443d000c78e681fd01c020404119994) jetbrains.dataspell: init at 2023.1
* [`40fcb33c`](https://github.com/NixOS/nixpkgs/commit/40fcb33c743f644c239ba99083c274677e52a764) donkey: init at 1.2.0
* [`520150fa`](https://github.com/NixOS/nixpkgs/commit/520150fa895863f94cf037fdec9076b0b2a188d7) nixos/logind: Add key handling options
* [`782769d6`](https://github.com/NixOS/nixpkgs/commit/782769d64ea6527a2a2186136062b256e162fb0d) vscode-extension.spellright: init at 3.0.112
* [`2fab3dec`](https://github.com/NixOS/nixpkgs/commit/2fab3dec74d139e015ecfc29d9f2c6b673d6c8db) vscode-extension.code-translate: init at 1.0.20
* [`6259dbc3`](https://github.com/NixOS/nixpkgs/commit/6259dbc3634b60049dfabbf33584c06ba0d357e5) vscode-extension.dictionary: init at 0.0.2
* [`0761a4e1`](https://github.com/NixOS/nixpkgs/commit/0761a4e194a0df5fa066aa7359bacab96f7a837f) vscode-extension.google-translate: init at 1.4.13
* [`7f975dc4`](https://github.com/NixOS/nixpkgs/commit/7f975dc416eb83cf954ad2b5075e1ee62444455f) vscode-extension.comment-translate: init at 2.2.4
* [`073696cd`](https://github.com/NixOS/nixpkgs/commit/073696cdea3b5cd05ef23261479f4d0504e9a349) vscode-extension.dictionary-completion: init at 1.2.2
* [`2c495fe7`](https://github.com/NixOS/nixpkgs/commit/2c495fe715a10c27fe8966c1f32648821521c1b3) maintainers: add tillkruss
* [`813d5958`](https://github.com/NixOS/nixpkgs/commit/813d5958a56a3e5b8dc803ccbb6988e51bb28f8a) vscode-extensions.janet-lang.vscode-janet: init at 0.0.2
* [`a15252ba`](https://github.com/NixOS/nixpkgs/commit/a15252ba8a76feb8fcb31e32f905aa2f5eef052a) linuxHeaders: 6.2 -> 6.3
* [`d568766f`](https://github.com/NixOS/nixpkgs/commit/d568766fc7512947dbb3576eda5e8e69b4d8547e) nixos/traefik: add environmentFiles option
* [`87bac138`](https://github.com/NixOS/nixpkgs/commit/87bac138dc682cd04f636ffdfe5a3dc3fc514578) openal: 1.22.2 -> 1.23.1
* [`908d02c1`](https://github.com/NixOS/nixpkgs/commit/908d02c1c05f010b0740d1c8e31851eff0abccaa) libv4l: 1.22.1 -> 1.24.1
* [`cbc99030`](https://github.com/NixOS/nixpkgs/commit/cbc990308c2e4995681b827488a90cc9c30de1af) valgrind: 3.20.0 -> 3.21.0
* [`d52f3f6d`](https://github.com/NixOS/nixpkgs/commit/d52f3f6d4b27399c5b081536b2872e81b35634b3) meteor: fix missing shared libraries: libcurl.so.4 & liblzma.so.5
* [`ec3cb5ea`](https://github.com/NixOS/nixpkgs/commit/ec3cb5eab5707c43f70a1910200ee3e67215f716) svt-av1: 1.4.1 -> 1.5.0
* [`e03a6c1c`](https://github.com/NixOS/nixpkgs/commit/e03a6c1c1d30c1b50fc22d80d8daf1a3a1ec0cb8) ffmpeg_5: add patches for svt-av1 1.5.0 compatibility
* [`32f663d5`](https://github.com/NixOS/nixpkgs/commit/32f663d5f5eaabdb3a9d225c8481287751ae7e5e) ffmpeg_4: add patch for svt-av1 1.5.0 compatibility
* [`549f616c`](https://github.com/NixOS/nixpkgs/commit/549f616c70046e1111ad251b47d2da591939c577) xdg-utils: unstable-2020-10-21 -> unstable-2022-11-06
* [`2c57ba1b`](https://github.com/NixOS/nixpkgs/commit/2c57ba1bd416da8287f358a87ed10ce6ef82a5e8) gst_all_1.gst-plugins-bad: enable webrtc
* [`c554c351`](https://github.com/NixOS/nixpkgs/commit/c554c35197451af88367911ccc0789b856770c87) phpExtensions.relay: init at 0.6.3
* [`838c2243`](https://github.com/NixOS/nixpkgs/commit/838c2243d277c168dbaa85013d09bce0d2700f7c) e2fsprogs: 1.46.6 -> 1.47.0
* [`ee4b582f`](https://github.com/NixOS/nixpkgs/commit/ee4b582f3f41d23883553d6594d8e113790a24e5) directx-headers: 1.610.0 -> 1.610.2
* [`6efc3981`](https://github.com/NixOS/nixpkgs/commit/6efc3981aab2b94545beef6e17a467bedfe748cf) gnu-efi: 3.0.15 -> 3.0.17
* [`5e692f20`](https://github.com/NixOS/nixpkgs/commit/5e692f20ab3b66d780231565caa735412b412a39) coze: init at 0.0.3
* [`8c160c81`](https://github.com/NixOS/nixpkgs/commit/8c160c810dfa67c9a2337af164cf8c64ed20d43c) libsForQt5.qca-qt5: 2.3.5 -> 2.3.6
* [`300dfa76`](https://github.com/NixOS/nixpkgs/commit/300dfa760bb1c173073f188b0b3e4ff2361f7b32) vscode-extensions.catppuccin.catppuccin-vsc-icons: init at 0.8.0
* [`42146b38`](https://github.com/NixOS/nixpkgs/commit/42146b38b42d01c2469c7713ecf6ce4050522549) vscode-extensions.catppuccin.catppuccin-vsc-icons: 0.8.0 -> 0.9.0
* [`8cfe7c9b`](https://github.com/NixOS/nixpkgs/commit/8cfe7c9b1b91f82a8bf76f241a2bb8092ba8c057) vscode-extensions.catppuccin.catppuccin-vsc-icons: 0.9.0 -> 0.10.0
* [`05c60fe9`](https://github.com/NixOS/nixpkgs/commit/05c60fe999c518912b1cd4d635ec3a14a4194ce8) m17n_lib: 1.8.0 -> 1.8.2
* [`8e474357`](https://github.com/NixOS/nixpkgs/commit/8e474357089900bc1126fd1bb0ccc7379fcaf297) pciutils: 3.9.0 -> 3.10.0
* [`93f5de39`](https://github.com/NixOS/nixpkgs/commit/93f5de39c082aa3da3ca6e3690b3aa9db1a5ed66) libssh: split headers to "dev" output
* [`bb910d1c`](https://github.com/NixOS/nixpkgs/commit/bb910d1cea6c033629d8b1fbcc0f7cfb7775caa2) libdaemon: move headers to "dev" outputs (and docs to "doc")
* [`d0f6e96b`](https://github.com/NixOS/nixpkgs/commit/d0f6e96bb5e9368186554b1dd45ad8301d0b0c1e) sbc: move headers to "dev" outputs
* [`cedb9d9b`](https://github.com/NixOS/nixpkgs/commit/cedb9d9b6f6f7eb2c73b1af14ec5f096706c127e) zimg: move headers to "dev" outputs (and docs to "doc")
* [`8078e39e`](https://github.com/NixOS/nixpkgs/commit/8078e39e688f7f5ecbf19bf3cfcc2c0268433882) libass: move headers to "dev" output
* [`b433ce9e`](https://github.com/NixOS/nixpkgs/commit/b433ce9eb9dfeaf550f64cd1c4558417518fc166) webrtc-audio-processing:  split headers to "dev" output
* [`7280d52c`](https://github.com/NixOS/nixpkgs/commit/7280d52cdd592261c6d34b28ab67bed46aa4fc8d) dav1d: split headers to "dev" output
* [`28b782e5`](https://github.com/NixOS/nixpkgs/commit/28b782e58dd18f3e97deb9b97c3517ad409c0407) libyaml: split headers to "dev" output
* [`1b9dbff0`](https://github.com/NixOS/nixpkgs/commit/1b9dbff0269cfb4252dd4a41057495e71286c183) libvisual: split headers to "dev" output
* [`673b8009`](https://github.com/NixOS/nixpkgs/commit/673b8009d39b3d50f3d57b5bc36efd5ab24bce39) graphite2: split headers to "dev" output
* [`f17ec411`](https://github.com/NixOS/nixpkgs/commit/f17ec4119080ea46400d4458a8ca9367f1d8056a) m17n_db: 1.8.0 -> 1.8.2
* [`80bf72d6`](https://github.com/NixOS/nixpkgs/commit/80bf72d6b0e142c1435751a5f1ad0f3db314127d) vim: 9.0.1441 -> 9.0.1544
* [`fee5a51a`](https://github.com/NixOS/nixpkgs/commit/fee5a51ab09d6b60657f96079885e4f56a53b87d) maintainers: add flemzord
* [`5d7a3d7b`](https://github.com/NixOS/nixpkgs/commit/5d7a3d7bfc913b469c3c8f9d85cb11f30f2aed84) libevdev: 1.13.0 -> 1.13.1
* [`c083a76b`](https://github.com/NixOS/nixpkgs/commit/c083a76b4b84fecbe11f1d08c0cc7bc9e2997e47) husky: init at 8.0.3
* [`f8ea57af`](https://github.com/NixOS/nixpkgs/commit/f8ea57afbb3f514b00cf3adf65ab99370977a8c8) libaom: 3.6.0 -> 3.6.1
* [`22b4111e`](https://github.com/NixOS/nixpkgs/commit/22b4111ea9d9728c62819993263875062ecb399c) vkbasalt: add bitness suffix to layer name
* [`b1efbff8`](https://github.com/NixOS/nixpkgs/commit/b1efbff8ec70f5a6ad564b32f7d5829139bad3be) flutter: Move artifact installation logic to the wrapper
* [`c6121c15`](https://github.com/NixOS/nixpkgs/commit/c6121c157c1b34a357d88b5f9ada2834aa63e7f7) xterm: 379 -> 380
* [`95152ad7`](https://github.com/NixOS/nixpkgs/commit/95152ad7a0fccb923941956ffb8cd89c583142e5) gnugrep: 3.7 -> 3.11
* [`658c76a5`](https://github.com/NixOS/nixpkgs/commit/658c76a54fa14b5a1cbaa966be7dac3fe1fe38a6) gnugrep: Re-enable check phase by default
* [`11c8f468`](https://github.com/NixOS/nixpkgs/commit/11c8f46850d0f56fa14c880db4e06fade3db2d67) gnugrep/stdenv: Fix PCRE support by replacing PCRE lib
* [`10396d0f`](https://github.com/NixOS/nixpkgs/commit/10396d0f86dc5f9edefda391bc2bae1c23d80b79) gnugrep: Add locales for tests
* [`e2627fbe`](https://github.com/NixOS/nixpkgs/commit/e2627fbe6937c2e9b81a3529e97590150667a339) mir: Modernise derivation
* [`6c3656cd`](https://github.com/NixOS/nixpkgs/commit/6c3656cdfcc3bc6df7515a3ad68b610d088efec9) vscode-extensions.charliermarsh.ruff: init at 2023.16.0
* [`a35d77b9`](https://github.com/NixOS/nixpkgs/commit/a35d77b9902253bb2dcd34dbc85f05302cb7214a) vscode-extensions.asdine.cue: init at 0.3.2
* [`8556a98d`](https://github.com/NixOS/nixpkgs/commit/8556a98d15c4aab09d239fd24e645144fb09c3e3) arcanist: 20220517 -> 20230401, switch to PHP 8.1
* [`92cab8e5`](https://github.com/NixOS/nixpkgs/commit/92cab8e5974abe06513c3c0669be95725436d759) column, locale: don't import from netbsd on darwin
* [`13087227`](https://github.com/NixOS/nixpkgs/commit/130872273061c9e9055abd7f35a3c57718358bd8) audiofile: remove -lgcc on i686-linux
* [`8d2846ed`](https://github.com/NixOS/nixpkgs/commit/8d2846edbba509300e44a7a27e912af835aebf4f) gcc: only disable aligned_alloc for darwin build/host/target platforms ([nixos/nixpkgs⁠#226290](https://togithub.com/nixos/nixpkgs/issues/226290))
* [`0e997bd6`](https://github.com/NixOS/nixpkgs/commit/0e997bd633a04655002e4080661782cd1649b995) perlPackages.TextWrapI18N: use unixtools.locale
* [`78123f3f`](https://github.com/NixOS/nixpkgs/commit/78123f3ffcdf1e66cac0145e6564b2d5b2fa2d39) vim: 9.0.1544 -> 9.0.1562
* [`5fea47d6`](https://github.com/NixOS/nixpkgs/commit/5fea47d66a6b28f7a4acf3f2f4c8179418605fed) moon: init at v1.5.1
* [`9bd3b23b`](https://github.com/NixOS/nixpkgs/commit/9bd3b23b3d6408fe382e654e4d474419c93c081f) maintainers: add abustany
* [`bf6797fc`](https://github.com/NixOS/nixpkgs/commit/bf6797fc1c00036c0fd0904e51f28c667cfc43eb) canon-cups-ufr2: 5.40 -> 5.70
* [`4e654f41`](https://github.com/NixOS/nixpkgs/commit/4e654f4136c9db74dd94f2c77fe7d8e1994e13b1) python311Packages.tldextract: 3.4.1 -> 3.4.2
* [`f172f279`](https://github.com/NixOS/nixpkgs/commit/f172f27981b78becc8fffc9bd5079dff0694665a) libcap: 2.68 -> 2.69
* [`514b0ba4`](https://github.com/NixOS/nixpkgs/commit/514b0ba424bc7734cd24ebbdb1fe3b2c6b5d0493) dav1d: 1.1.0 -> 1.2.0
* [`a695425e`](https://github.com/NixOS/nixpkgs/commit/a695425e46a89a879fbe290a4ffa162c2b4a20c9) linux: manual-config: use a non-random path for $buildRoot
* [`273d862e`](https://github.com/NixOS/nixpkgs/commit/273d862e4698cf64032fc01fad1398ae7f92ac92) gst_all_1: fix gst-python comment
* [`a3ed53be`](https://github.com/NixOS/nixpkgs/commit/a3ed53beabcb2cdbef1aa974494eb721453b8f97) python3Packages.gst-python: adopt maintainership as lilyinstarlight
* [`bae09e73`](https://github.com/NixOS/nixpkgs/commit/bae09e73193c9df84811f2a52b2b74fbc27aa91e) gst_all_1.*: adopt maintainership as lilyinstarlight
* [`45eb557a`](https://github.com/NixOS/nixpkgs/commit/45eb557afafd24a5d938e753ba1c6f8edee978a7) maptool: init at 1.13.0
* [`9d2e9515`](https://github.com/NixOS/nixpkgs/commit/9d2e951570b07c7327d4ac21330a37d0d91cb978) libuv: 1.44.2 -> 1.45.0
* [`99a83b49`](https://github.com/NixOS/nixpkgs/commit/99a83b49645c59a8ffed79b164909c1e75507015) libclc: 15.0.7 -> 16.0.3
* [`ab036e45`](https://github.com/NixOS/nixpkgs/commit/ab036e45ac19e29b2fa914bc04e1e7318a3f8861) libclc: fix cross
* [`2dde3712`](https://github.com/NixOS/nixpkgs/commit/2dde3712ed6466c3444cd50d218c3ddfcf0ee99b) fribidi: 1.0.12 -> 1.0.13
* [`c569ab48`](https://github.com/NixOS/nixpkgs/commit/c569ab488713faa42b49107ff9eeda4315eadfc9) maintainers-list.nix: add maintainer oaksoaj
* [`bf62e731`](https://github.com/NixOS/nixpkgs/commit/bf62e7316242cf26cb4fabb634d6746cbc150a38) basez: init at 1.6.2
* [`de91fb29`](https://github.com/NixOS/nixpkgs/commit/de91fb29211e5aec6a1cdc4f6a61bd5583128d37) mesa-demos: fix cross compilation, set strictDeps
* [`38bca182`](https://github.com/NixOS/nixpkgs/commit/38bca18244c229a19cec3c0e2239f1247f2af184) virtualbox: 7.0.6 -> 7.0.8
* [`9ee245dc`](https://github.com/NixOS/nixpkgs/commit/9ee245dce612a9cb5533c2d74ebe650abefdce8b) gst_all_1.gstreamer: 1.22.2 -> 1.22.3
* [`9f70ed7d`](https://github.com/NixOS/nixpkgs/commit/9f70ed7d490ba754734d4e87ab988d92728e3430) gst_all_1.gst-plugins-base: 1.22.2 -> 1.22.3
* [`3d447156`](https://github.com/NixOS/nixpkgs/commit/3d447156f4eea976e9e0cb9fc23b181f315f5544) gst_all_1.gst-plugins-good: 1.22.2 -> 1.22.3
* [`2c3f7d72`](https://github.com/NixOS/nixpkgs/commit/2c3f7d72f4095dc9819e418db45d56aee4d3b3c2) gst_all_1.gst-plugins-bad: 1.22.2 -> 1.22.3
* [`b8db7755`](https://github.com/NixOS/nixpkgs/commit/b8db77551974857881a5d611d84bd5e53d10bb53) gst_all_1.gst-plugins-ugly: 1.22.2 -> 1.22.3
* [`ce3b3a93`](https://github.com/NixOS/nixpkgs/commit/ce3b3a930121b2fcaaf3d0f3f62bc2211da62f65) gst_all_1.gst-libav: 1.22.2 -> 1.22.3
* [`5a1d3ebf`](https://github.com/NixOS/nixpkgs/commit/5a1d3ebf39050af28098e7395cb29c71bde2ca99) gst_all_1.gst-vaapi: 1.22.2 -> 1.22.3
* [`08f74f2c`](https://github.com/NixOS/nixpkgs/commit/08f74f2c8bcf4cd6434b029e653f962716670dd5) gst_all_1.gst-rtsp-server: 1.22.2 -> 1.22.3
* [`4ba31631`](https://github.com/NixOS/nixpkgs/commit/4ba3163184ea0ef57ee25edb76fa63d14ef65d6b) gst_all_1.gst-devtools: 1.22.2 -> 1.22.3
* [`f239891b`](https://github.com/NixOS/nixpkgs/commit/f239891b8b1f8a37c3b2bad8a800175a8ee232a6) gst_all_1.gst-editing-services: 1.22.2 -> 1.22.3
* [`1494009a`](https://github.com/NixOS/nixpkgs/commit/1494009afb85d61d37c44567bd5ad7ac9cb02795) python3Packages.gst-python: 1.22.2 -> 1.22.3
* [`fa8d4324`](https://github.com/NixOS/nixpkgs/commit/fa8d4324f61a54c413cab259a9e14a8e968999e7) stumpwm: Fix package conflict and HOME errors when loading modules
* [`64389fa7`](https://github.com/NixOS/nixpkgs/commit/64389fa7b61d1a9d602194e9b89d90089bde9ec2) haskellPackages: stackage LTS 20.20 -> LTS 20.21
* [`de1b01d3`](https://github.com/NixOS/nixpkgs/commit/de1b01d35ee20c71b0c715cf15ca1e2999bf2e15) all-cabal-hashes: 2023-05-10T18:33:26Z -> 2023-05-19T20:32:49Z
* [`95229474`](https://github.com/NixOS/nixpkgs/commit/9522947447de616466cd7adfa37b3c211bb8c661) haskellPackages: regenerate package set based on current config
* [`f7cb3244`](https://github.com/NixOS/nixpkgs/commit/f7cb3244103584aae65e9ebc2cd24206a95c1898) python310Packages.mkdocs-material: 9.1.8 -> 9.1.13
* [`f694182c`](https://github.com/NixOS/nixpkgs/commit/f694182c62d3cde22049fa75c427f49f0f4e8747) python310Packages.sqlalchemy: 2.0.13 -> 2.0.15
* [`37bb0dc7`](https://github.com/NixOS/nixpkgs/commit/37bb0dc70d30ae3fd60070140b24791db6797b6d) harfbuzz: 7.2.0 -> 7.3.0
* [`893efdc6`](https://github.com/NixOS/nixpkgs/commit/893efdc64986636b82e3eb3d0cb2f64febc88fe2) m17n_db: add changelog to meta
* [`656cdba3`](https://github.com/NixOS/nixpkgs/commit/656cdba3863e2044b1d82319b412f550c8660feb) alsa-lib: 1.2.8 -> 1.2.9
* [`33b4c4e7`](https://github.com/NixOS/nixpkgs/commit/33b4c4e7bbbcbca16c26803d53d87a17ee683649) rav1e: 0.6.4 -> 0.6.6
* [`093a5ffd`](https://github.com/NixOS/nixpkgs/commit/093a5ffd972947fc30601469a73849126e5b9ccd) gst_all_1.gst-plugins-rs: enable audiofx and hotdoc
* [`50894cc8`](https://github.com/NixOS/nixpkgs/commit/50894cc85b9529da829d5d21f93625eb59000232) liblc3: 1.0.2 -> 1.0.3
* [`0c5ec23f`](https://github.com/NixOS/nixpkgs/commit/0c5ec23f1346027ba410f4c881af124b4b3a3b9b) roc-toolkit: 0.2.3 -> 0.2.4
* [`15ebb224`](https://github.com/NixOS/nixpkgs/commit/15ebb22402989f6438f5bbb921e562fd619a61e5) nettle: 3.8.1 -> 3.9
* [`7b61a607`](https://github.com/NixOS/nixpkgs/commit/7b61a60758f6b12ade200d015db79cb2a5be2d3c) util-linux: 2.38.1 -> 2.39
* [`f69980a1`](https://github.com/NixOS/nixpkgs/commit/f69980a1f77e019cd38abf1d9f9fd51674f0425a) python310Packages.pydyf: 0.5.0 -> 0.6.0
* [`b1a49db9`](https://github.com/NixOS/nixpkgs/commit/b1a49db9145f61ba299f4ac68e203822a15b1d96) util-linux: add darwin support
* [`e3ef6258`](https://github.com/NixOS/nixpkgs/commit/e3ef6258965f14998455259603b5dd2e9d51f83e) util-linux: use real util-linux package on darwin
* [`febe4776`](https://github.com/NixOS/nixpkgs/commit/febe4776287fd81b9dc0fd88a8bcb686765c8a6b) linux: default stdenv.hostPlatform.linux-kernel
* [`beef658c`](https://github.com/NixOS/nixpkgs/commit/beef658c2b41f2d543fb3f09aa0fdc2c0ad06843) python3Packages.furo: 2023.3.27 -> 2023.5.20
* [`e5e02f32`](https://github.com/NixOS/nixpkgs/commit/e5e02f3214ae381142606cf5defc35888d73f883) linuxManualConfig: always depend on ubootTools
* [`6f2cc0fc`](https://github.com/NixOS/nixpkgs/commit/6f2cc0fc91331b0192a70ab526ca97fb365ccc62) xmake-core-sv: init at 1.1
* [`1304d94d`](https://github.com/NixOS/nixpkgs/commit/1304d94d907e9401bd7ef7e849dcaadb143e5e24) python310Packages.weasyprint: 58.1 -> 59.0
* [`42042047`](https://github.com/NixOS/nixpkgs/commit/42042047d25ac93cf446d27e89611d8216fb5016) python310Packages.cryptography: remove unused inputs
* [`77777770`](https://github.com/NixOS/nixpkgs/commit/77777770d11ae0f67f0516f2a35c9908bb898ac5) python310Packages.matplotlib: remove unused inputs
* [`42428ccc`](https://github.com/NixOS/nixpkgs/commit/42428ccca68a44c107222e35b07492757127ebcc) python310Packages.numpy: remove unused inputs
* [`42042041`](https://github.com/NixOS/nixpkgs/commit/42042041ddb28f172822854ae34372fa6aac5409) python310Packages.pandas: remove unused inputs
* [`a4de40fe`](https://github.com/NixOS/nixpkgs/commit/a4de40fe5ca5483ecc76278a8ea4712788c3a725) python310Packages.requests: 2.29.0 -> 2.31.0
* [`7b4c5210`](https://github.com/NixOS/nixpkgs/commit/7b4c521005a73d5b30f5947467e637e15c5c06a0) audit: 3.1 -> 3.1.1
* [`febcb284`](https://github.com/NixOS/nixpkgs/commit/febcb284b73060aa1ca6e7d1a2fbaae2f5b9296f) python3Packages.matplotlib: 3.7.0 -> 3.7.1
* [`f1b6469e`](https://github.com/NixOS/nixpkgs/commit/f1b6469e48aa4fdbf3233d67878add84bac86ecc) tbox: init at 1.7.3
* [`2f9b5e12`](https://github.com/NixOS/nixpkgs/commit/2f9b5e126aebb055e4ec50842709ae6cac759086) maturin: 0.14.17 -> 0.15.3
* [`507c3f74`](https://github.com/NixOS/nixpkgs/commit/507c3f748cc8b9942d9486ce48138484b896f6f1) emacsPackages.mind-wave 2d94f553a394ce73bcb91490b81e0fc042baa8d3 -> 5109162b74872091c5090a28389bef8f7020274c
* [`97c45e2f`](https://github.com/NixOS/nixpkgs/commit/97c45e2f5b2f20c092a9265c97fd9cab35fca60c) loganalyzer: init at 23.5.1
* [`aa047eb4`](https://github.com/NixOS/nixpkgs/commit/aa047eb431c03d982b5dda88702dbf97ecc76f22) hledger_1_29_2: fix dependency toward hledger-lib
* [`046dff39`](https://github.com/NixOS/nixpkgs/commit/046dff39fcdb5005154433a19b2b94b84651d850) vscode-extensions.catppuccin.catppuccin-vsc-icons: 0.10.0 -> 0.11.0
* [`eb1c777c`](https://github.com/NixOS/nixpkgs/commit/eb1c777cef1c21767aa27ae69d09733f785a6f7a) stumpwm-unwrapped: init
* [`e88bc03e`](https://github.com/NixOS/nixpkgs/commit/e88bc03e4bda196eb901fbbd38a684f45d0bc029) rocfft: revert split output workaround intended to fix hydra caching
* [`a946656e`](https://github.com/NixOS/nixpkgs/commit/a946656ee7e58913b7a722ae78b2e66f0722c418) doxygen: 1.9.6 -> 1.9.7
* [`a49b3d56`](https://github.com/NixOS/nixpkgs/commit/a49b3d56585185f6aab726f6ccdb3f8a46847670) python311Packages.sentry-sdk: 1.21.1 -> 1.24.0
* [`b4192eed`](https://github.com/NixOS/nixpkgs/commit/b4192eed495d9203ea1186b9362130b7cf006c24) python310Packages.txtorcon: 23.0.0 -> 23.5.0
* [`04b0bb33`](https://github.com/NixOS/nixpkgs/commit/04b0bb33922c5738875573c86b8b562218b4fca9) breitbandmessung: 3.1.0 -> 3.3.0; use electron_24
* [`f6d2c6a1`](https://github.com/NixOS/nixpkgs/commit/f6d2c6a13168d3ad516d73b9d97315878f4a9b36) curl: 8.0.1 -> 8.1.1
* [`d200470b`](https://github.com/NixOS/nixpkgs/commit/d200470be831e4c99609a19b3d1ab97cfa260025) furnace: 0.6pre4-hotfix -> 0.6pre5
* [`3c779c3f`](https://github.com/NixOS/nixpkgs/commit/3c779c3fa8f043e85f20323cad29216c28baae9b) quickbms: fix build
* [`67733387`](https://github.com/NixOS/nixpkgs/commit/67733387092fe234deb7d9994bef5aff856e167b) haskell.packages.ghc810.hls-tactics-plugin: remove doJailbreak and assert
* [`19f89fd1`](https://github.com/NixOS/nixpkgs/commit/19f89fd15edb7ce9fca55214ddf824a966573541) haskellPackages.swarm: update dependent brick version
* [`926bb3ca`](https://github.com/NixOS/nixpkgs/commit/926bb3cae9f93eac34a39907f10a9fb744a7bdd0) vscode-extensions.seatonjiang.gitmoji-vscode: init at 1.2.2
* [`a572ce9c`](https://github.com/NixOS/nixpkgs/commit/a572ce9cab30d88ceb4857330db2653a223a79cd) ocamlPackages.virtual_dom: 0.15.0 → 0.15.1
* [`2529f1cf`](https://github.com/NixOS/nixpkgs/commit/2529f1cf0a591cda28926815ab15b89b30da3e6d) ios-webkit-debug-proxy: init at 1.9.0
* [`04db3589`](https://github.com/NixOS/nixpkgs/commit/04db3589a8150c0a97869b10e269d6d5c516f3e9) lib.filesystem.pathType: Fix tests for Nix >= 2.14
* [`72a70bd7`](https://github.com/NixOS/nixpkgs/commit/72a70bd73bd91562e4ab2f4178a7dd0500de1864) haskellPackages.mkDerivation: New `intermediates` output
* [`33258207`](https://github.com/NixOS/nixpkgs/commit/33258207faf6938079289d6544e011e2bc198868) maintainers: Gabriel439 -> Gabriella439
* [`c072d786`](https://github.com/NixOS/nixpkgs/commit/c072d7867d215c0d5db843ef90fb2393a67384f5) maintainers: add mercury team
* [`b278ca21`](https://github.com/NixOS/nixpkgs/commit/b278ca21951756049272c752bcf2601318633205) tests.haskell.incremental: init
* [`77b857ff`](https://github.com/NixOS/nixpkgs/commit/77b857ffc9c597c7523dfd6588cd14e9b801f064) Rename Mercury team
* [`1535bd0c`](https://github.com/NixOS/nixpkgs/commit/1535bd0c58e0f7a093bea8d15e37f0cc1a719db2) Move intermediates under `share/haskell`
* [`ec2938bf`](https://github.com/NixOS/nixpkgs/commit/ec2938bfa5f98b43e5f87ba510ba3cdebaa16496) Document incremental build support for Haskell
* [`fa8fc4d4`](https://github.com/NixOS/nixpkgs/commit/fa8fc4d457fbed88d0a952c8b75fe8df579a974f) haskellPackages.coinor-clp: mark aarch64-linux as unsupported
* [`8b8f0d0a`](https://github.com/NixOS/nixpkgs/commit/8b8f0d0a76e9f57086bd88bb97d9c4003903902b) haskell: formatting fix after regenerating packages
* [`217ed543`](https://github.com/NixOS/nixpkgs/commit/217ed5437cc6fac1e5f4b8f8b81cf8d1a4c7d0e0) haskellPackages.yesod-core: fix build with Darwin sandbox enabled
* [`9b1c02ed`](https://github.com/NixOS/nixpkgs/commit/9b1c02ede8daf1c319ec7f1b60e8deba84fad8d3) haskellPackages.http2: fix build with Darwin sandbox enabled
* [`6d93518c`](https://github.com/NixOS/nixpkgs/commit/6d93518c5f05716bbbdd37e556eed06c076e54ba) pyrosimple: 2.7.0 -> 2.8.0
* [`16fc2300`](https://github.com/NixOS/nixpkgs/commit/16fc230080db71e9c39f303e1de42edfc9a19dbf) pyrosimple: Add vamega as maintainer
* [`67a752bf`](https://github.com/NixOS/nixpkgs/commit/67a752bf71dc9805a5ed5138fa63184873f20ffe) ocamlPackages.ocplib-endian: fix for OCaml 5.0
* [`ffcfca42`](https://github.com/NixOS/nixpkgs/commit/ffcfca42e4f263af4e1281769f050e01b114fd79) ocamlPackages.lwt: fix for OCaml 5.0
* [`56376c4e`](https://github.com/NixOS/nixpkgs/commit/56376c4eee79d43725bccff13258aaefa0ac8199) ocamlPackages.iter: 1.6 → 1.7
* [`77a95ebc`](https://github.com/NixOS/nixpkgs/commit/77a95ebc947abc73ed410cb0b059a27306093f99) linuxKernel.packages.lenovo-legion: init at 2023-04-02-16-53-51
* [`2c95ebad`](https://github.com/NixOS/nixpkgs/commit/2c95ebadf3d0c607921920a6ee1a64a492168dd9) nixos/code-server: add more command line options
* [`371b4c3e`](https://github.com/NixOS/nixpkgs/commit/371b4c3eb740835525ad460a55f535688e7656e0) nixos/code-server: init tests
* [`b196c7eb`](https://github.com/NixOS/nixpkgs/commit/b196c7eb8be326ee6da0741dc30d7ae73a3713cd) canon-cups-ufr2: Implement build for aarch64
* [`657e05ca`](https://github.com/NixOS/nixpkgs/commit/657e05cab0a0f92799288acb3566ee1b33d9adbb) canon-cups-ufr2: Remove libglade-2 buildInput
* [`5405dcff`](https://github.com/NixOS/nixpkgs/commit/5405dcffdf00814be1fec47e6b0798a707659508) linuxPackages.apfs: 0.3.1 -> 0.3.2
* [`1622dd9c`](https://github.com/NixOS/nixpkgs/commit/1622dd9ce428eea265ae720d7b479462f30ac677) linuxPackages.apfs: 0.3.2 -> 0.3.3
* [`de34f90f`](https://github.com/NixOS/nixpkgs/commit/de34f90f35f28190ec843bde71027fe8df552a42) python310Packages.home-assistant-chip-core: 2023.5.2 -> 2023.5.3
* [`0bebf70b`](https://github.com/NixOS/nixpkgs/commit/0bebf70bf6f5df055e50d76b4ad6dc82d973e192) python310Packages.home-assistant-chip-clusters: 2023.5.2 -> 2023.5.3
* [`89250966`](https://github.com/NixOS/nixpkgs/commit/89250966ad7a1d61587ab2216b39b30ee8259742) eslint_d: repackage using buildNpmPackage
* [`bd5568b0`](https://github.com/NixOS/nixpkgs/commit/bd5568b0d66e913bdff88e239f0289a7e6ae2021) nixops_unstable: update
* [`7f3706f7`](https://github.com/NixOS/nixpkgs/commit/7f3706f7e1cd6a9ef388733ae4c6d3b83df1ccc4) nixops_unstable: Set meta.mainProgram
* [`f56547c5`](https://github.com/NixOS/nixpkgs/commit/f56547c565a40b549364bbb0e8c6f5c1027a4227) python3Packages.broadbean: init at 0.11.0
* [`2ed439e0`](https://github.com/NixOS/nixpkgs/commit/2ed439e02b954e5be73377824e63ba6dacd2eedd) python3Packages.opencensus-ext-azure: init at 1.1.9
* [`938bca63`](https://github.com/NixOS/nixpkgs/commit/938bca634ea5a9c9936b139ff317cdb55dbbce5b) python3Packages.hickle: fixed failing unit tests
* [`6b6d9477`](https://github.com/NixOS/nixpkgs/commit/6b6d9477169f29977517b9f88f1a3e1b97a941bf) python3Packages.stringparser: init at 0.6
* [`56766e3f`](https://github.com/NixOS/nixpkgs/commit/56766e3f1f65b914c14bc27afbfac5f53deda7a3) python3Packages.pyvisa-sim: init at 0.5.1
* [`6c5049e5`](https://github.com/NixOS/nixpkgs/commit/6c5049e54ae5e7b19d43dc259c418d675c0f7638) python3Packages.qcodes: init at 0.38.1
* [`5941d984`](https://github.com/NixOS/nixpkgs/commit/5941d98418056ee01ca1f3bbaedcf12f366d8aec) python3Packages.qcodes-contrib-drivers: init at 0.18.0
* [`1f3b595b`](https://github.com/NixOS/nixpkgs/commit/1f3b595bfc2c9448c1f1eca5a45e706449be5f12) python311Packages.license-expression: 30.1.0 -> 30.1.1
* [`1a176b06`](https://github.com/NixOS/nixpkgs/commit/1a176b0657b1a1a2cfd796cdd689d261955bf4f1) python311Packages.neo4j: 5.8.1 -> 5.9.0
* [`ec5b05b1`](https://github.com/NixOS/nixpkgs/commit/ec5b05b17d22027d77ec55a504f6db7d85baaa5e) haskellPackages.cachix: Link a single nix version
* [`4a05329f`](https://github.com/NixOS/nixpkgs/commit/4a05329f1111d0c359b558ed0c9d18f4faea1aae) clamav: 1.0.1 -> 1.1.0
* [`e0d13fd0`](https://github.com/NixOS/nixpkgs/commit/e0d13fd0925802c287d097480bc1b17d38644e55) maturin: 0.15.3 -> 1.0.0
* [`906f2c55`](https://github.com/NixOS/nixpkgs/commit/906f2c556a86279825cc7f6e6a1c841a6410db89) maturin: update meta
* [`d7d6b1c4`](https://github.com/NixOS/nixpkgs/commit/d7d6b1c4453593888ae63cf69b85e37e3bde98e3) haskell.compiler.ghc928: init at 9.2.8
* [`f590d97b`](https://github.com/NixOS/nixpkgs/commit/f590d97bcb6990d5fa111fa31c89c1ed6ffc61b3) denaro: 2023.2.2 -> 2023.5.0; add updateScript
* [`5703ff7d`](https://github.com/NixOS/nixpkgs/commit/5703ff7dfb42ebffa95c6e57be890be8c7522d98) qc71_laptop: 2022-06-01 -> 2023-03-02
* [`dd2c53cb`](https://github.com/NixOS/nixpkgs/commit/dd2c53cb2cdc8723617f61c3134235faa1bd7cc8) pgmanage: 11.0.1 -> 11.0.1-git-a028604
* [`67321062`](https://github.com/NixOS/nixpkgs/commit/6732106210fe87ecb497b86dfa7a451ead65cdb4) network-interfaces-scripted: fix interface cleanup
* [`d07a2fc1`](https://github.com/NixOS/nixpkgs/commit/d07a2fc11806b325b19cd9f9d4c0b60f316bf473) srt-live-server: add missing ctime include
* [`8195adcf`](https://github.com/NixOS/nixpkgs/commit/8195adcf53b2fd4cb4b0eeb439ec8ce2a6ec2770) pgmanage: use a valid version number
* [`f42d43dc`](https://github.com/NixOS/nixpkgs/commit/f42d43dcca776bdaa82b3a85fc67cb5043e3b91d) linux_xanmod: 6.1.29 -> 6.1.30
* [`06fec0cf`](https://github.com/NixOS/nixpkgs/commit/06fec0cfe79b5e0559402a6422c70d2b746d1826) rbdoom-3-bfg: 1.5.0 -> 1.5.1
* [`4b94ae4b`](https://github.com/NixOS/nixpkgs/commit/4b94ae4bc62e7fb2b05da58ca997fd6c3c218a85) writeTextFile: set meta.mainProgram based on destination
* [`ea0b4a69`](https://github.com/NixOS/nixpkgs/commit/ea0b4a694aeacc4d2f28a001af14c0e9d85fd7ee) nixos/test/networking: test unusual interface names
* [`a4c6fca3`](https://github.com/NixOS/nixpkgs/commit/a4c6fca3200aaffd5e96d5770af049bec8c42eb4) k8sgpt: init at 0.3.5
* [`80fb8935`](https://github.com/NixOS/nixpkgs/commit/80fb89358fe0682bea268c884ce647fd50db1121) piknik: init at 0.10.1
* [`5c2207bc`](https://github.com/NixOS/nixpkgs/commit/5c2207bc4167b029f1a029bb58161a643f458f09) topfew: init at 0.9.0
* [`6a35ff3d`](https://github.com/NixOS/nixpkgs/commit/6a35ff3d8aee72e198343a3ccbd62ab0a3069e34) router: 1.18.1 -> 1.19.0
* [`19ff71d1`](https://github.com/NixOS/nixpkgs/commit/19ff71d1670ed89b78e7c9f5f9a36fae445638ca) python310Packages.tubeup: 0.0.35 -> 28.5.2023
* [`ac38c4d5`](https://github.com/NixOS/nixpkgs/commit/ac38c4d5d0c9a0a6cf279fcdb04f022cc1bddba7) python310Packages.tubeup: use pythonRelaxDepsHook
* [`f449215e`](https://github.com/NixOS/nixpkgs/commit/f449215e3850172ae90ae9783051a5a781cb3c87) python3Packages.mautrix: 0.19.14 -> 0.19.16
* [`6b2589cb`](https://github.com/NixOS/nixpkgs/commit/6b2589cb5b65a2962b42b34c7c286c65439f6020) mautrix-telegram: 0.13.0 -> 0.14.0
* [`02edbf8c`](https://github.com/NixOS/nixpkgs/commit/02edbf8c0922e2415b0af7763b4ca3b8fcc22af6) theforceengine: 1.09.100 -> 1.09.200
* [`43303aa5`](https://github.com/NixOS/nixpkgs/commit/43303aa5ae7f38be2e25c515e16456c8532edbd8) slack: 4.29.149 -> 4.32.122
* [`3014fe9e`](https://github.com/NixOS/nixpkgs/commit/3014fe9ef813ddfe184ed50289be4d707cb28ff9) plex: 1.32.1.6999-91e1e2e2c -> 1.32.2.7100-248a2daf0
* [`71fa8d5b`](https://github.com/NixOS/nixpkgs/commit/71fa8d5b8fb70f00f891cbf935860c81306d8b7c) lhasa: 0.3.1 -> 0.4.0
* [`77a6bb0c`](https://github.com/NixOS/nixpkgs/commit/77a6bb0c9ee82fa406c2177e3bd2aad31c6d4cdc) guile-opengl: 0.1.0 -> 0.2.0
* [`5defb3ed`](https://github.com/NixOS/nixpkgs/commit/5defb3edb1123c87f4861abaa4b54d69826acf50) shotman: 0.4.1 -> 0.4.3
* [`81da794d`](https://github.com/NixOS/nixpkgs/commit/81da794d5b2ae4ed04fdb773b0db20d6d121922a) memcached: 1.6.19 -> 1.6.20
* [`2f682e5b`](https://github.com/NixOS/nixpkgs/commit/2f682e5b6ce5a5784e85e605a337238e6993615f) krill: 0.12.3 -> 0.13.0
* [`be63ea17`](https://github.com/NixOS/nixpkgs/commit/be63ea178c0e812814ede769c4ae27002636ddde) haskellPackages: stackage LTS 20.21 -> LTS 20.23
* [`3389213f`](https://github.com/NixOS/nixpkgs/commit/3389213ff07f9990d6b8c8860c48e4f47f1b5c8e) all-cabal-hashes: 2023-05-19T20:32:49Z -> 2023-05-28T10:08:17Z
* [`286e0226`](https://github.com/NixOS/nixpkgs/commit/286e02266703ec430570271bf3ca3db61214650a) haskellPackages: regenerate package set based on current config
* [`b9d249b3`](https://github.com/NixOS/nixpkgs/commit/b9d249b3372c1ecdd8f1b07268c3e10c77267c54) ghc: 9.2.7 -> 9.2.8
* [`b3c8a947`](https://github.com/NixOS/nixpkgs/commit/b3c8a947325388e34797b0b9f9c5b73d4fbe4b1d) flrig: 1.4.8 -> 2.0.0
* [`a5472cf9`](https://github.com/NixOS/nixpkgs/commit/a5472cf9b5b72c8e2fbd12ee9c7ad493cd1eb6cd) shattered-pixel-dungeon: 1.1.2 -> 2.0.2
* [`5d1f52cb`](https://github.com/NixOS/nixpkgs/commit/5d1f52cb7a69e9a6a4fe24d8e66d558ff46c252a) maintainers: add hmajid2301
* [`0ae9df6c`](https://github.com/NixOS/nixpkgs/commit/0ae9df6c5e5ac796c6b70e969586b028a31d1ed1) nixos/murmur: make it be after network.target again
* [`798e1e0c`](https://github.com/NixOS/nixpkgs/commit/798e1e0c65c35e66d35870abc4de2d7e63d722be) accountsservice: 22.08.8 → 23.13.9
* [`3720991c`](https://github.com/NixOS/nixpkgs/commit/3720991c06f1e8d97c091b897881aa1d562269c7) rl-2305: mention buildFHSEnv switch to bubblewrap
* [`cc081200`](https://github.com/NixOS/nixpkgs/commit/cc081200b5d88ae92953ecb2831ee7524e3cf00a) nghttp3: 0.10.0 -> 0.11.0
* [`b4dee0f0`](https://github.com/NixOS/nixpkgs/commit/b4dee0f0e076a71ea4a241b8e87fb996354b8cac) ngtcp2: 0.14.1 -> 0.15.0
* [`f28c9875`](https://github.com/NixOS/nixpkgs/commit/f28c9875070facd99700b9293335aba7933cbde9) nixos/tests: update nginx-http3 test
* [`f4d48ec7`](https://github.com/NixOS/nixpkgs/commit/f4d48ec7d62136af80a4138bb7c0211886421377) python311Packages.pydaikin: 2.9.0 -> 2.9.1
* [`a20a458b`](https://github.com/NixOS/nixpkgs/commit/a20a458b5a1c65629951e1afc06584cfc840ed35) python311Packages.pyezviz: 0.2.0.12 -> 0.2.0.15
* [`242601ed`](https://github.com/NixOS/nixpkgs/commit/242601edc306c48b03d5e95abac3941bc1ac061b) iosevka: 23.0.0 -> 24.1.0
* [`f7ea3ca9`](https://github.com/NixOS/nixpkgs/commit/f7ea3ca9ebe7a28457e87ede2c51e9d84e48982f) abracadabra: init at 2.1.1
* [`d875bcb2`](https://github.com/NixOS/nixpkgs/commit/d875bcb2921e09c6e10502729a9d06da4d7b4dd1) labctl: init at 0.0.15
* [`263d6986`](https://github.com/NixOS/nixpkgs/commit/263d6986a8b5131aaa4c3a5e13714652cfd01870) python311Packages.aioairzone-cloud: init at 0.1.6
* [`bcbb670c`](https://github.com/NixOS/nixpkgs/commit/bcbb670c152ce4ed6404bf6d7e3fc1b1d4e91b99) BeatSaberModManager: wrap with xdg-utils
* [`3869e535`](https://github.com/NixOS/nixpkgs/commit/3869e5358960f428816c22e445de602a767db093) containerlab: init at 0.41.2
* [`09dbd2dd`](https://github.com/NixOS/nixpkgs/commit/09dbd2dd15aac9befbdbfc2a28ee226b8a48e399) python311Packages.xknx: 2.9.0 -> 2.10.0
* [`5d0e2af5`](https://github.com/NixOS/nixpkgs/commit/5d0e2af544f4c393d4a431c1c8386dd3edf906af) flirc: lock readline to 6.x version as required
* [`516cacda`](https://github.com/NixOS/nixpkgs/commit/516cacda21f0633765df2d1bf21e8d92a8b1fe65) invidious: unstable-2023-05-08 -> 2023-05-25
* [`25ef6a77`](https://github.com/NixOS/nixpkgs/commit/25ef6a77d22ec177a02ee813ac90c950a517c874) python311Packages.pyzipper: init at 0.3.6
* [`c35a99a2`](https://github.com/NixOS/nixpkgs/commit/c35a99a2b00c5c7adc273403c931a290c62aa85e) python311Packages.xknxproject: init at 3.1.0
* [`3e55c3a4`](https://github.com/NixOS/nixpkgs/commit/3e55c3a4e3214e387415dd2df5c87e6de2b8d158) python311Packages.zeroconf: 0.62.0 -> 0.63.0
* [`69092130`](https://github.com/NixOS/nixpkgs/commit/69092130cabd65baca3cb006052a6111165d311c) python311Packages.python-roborock: 0.18.6 -> 0.18.9
* [`19970af6`](https://github.com/NixOS/nixpkgs/commit/19970af60878670d7e05380734cede3690bc4c84) python311Packages.solax: 0.3.0 -> 0.3.1
* [`1166edde`](https://github.com/NixOS/nixpkgs/commit/1166eddee69cf6b67dcdecf7401a9134b36bb81b) python311Packages.slixmpp: 1.8.3 -> 1.8.4
* [`42846a13`](https://github.com/NixOS/nixpkgs/commit/42846a1387cc95595dd5004d042ffb98da16f239) python311Packages.slixmpp: remove patch
* [`c42debb8`](https://github.com/NixOS/nixpkgs/commit/c42debb8d15dd2f2000f07522958212a41b2de62) python311Packages.slixmpp: add changelog to meta
* [`69677348`](https://github.com/NixOS/nixpkgs/commit/6967734863fda2f611590e533150535243739eaa) python311Packages.solax: add format: 
* [`eded68eb`](https://github.com/NixOS/nixpkgs/commit/eded68eb202280ee0f22efcaf6a7080bce9f2050) botamusique: substitute version information
* [`6b7434d3`](https://github.com/NixOS/nixpkgs/commit/6b7434d32e252a9b01d2770081cfb7da3874a18a) esphome: 2023.5.4 -> 2023.5.5
* [`1203b93d`](https://github.com/NixOS/nixpkgs/commit/1203b93d868cb96688abafc179f638c42b2c437b) haskell.packages.ghc96.ghc-lib: 9.6.1.20230312 -> 9.6.2.20230523
* [`6c032d43`](https://github.com/NixOS/nixpkgs/commit/6c032d43e045a05aef87062b870f84057d89344f) release-haskell: remove pakcs because it is insecure
* [`588f16c9`](https://github.com/NixOS/nixpkgs/commit/588f16c917d580563159122f05b6ec0dd4f7f807) darwin.apple_sdk_11_0: deprecate clang*Stdenv
* [`701c1bbf`](https://github.com/NixOS/nixpkgs/commit/701c1bbf464a1a6b7ed3b026c42f66d1b9105c83) ddnet: 17.0 -> 17.0.1
* [`e0cce76a`](https://github.com/NixOS/nixpkgs/commit/e0cce76a068fe345b0a0222a9258a4afc496aa10) calico-pod2daemon: 3.25.1 -> 3.26.0
* [`25b9e543`](https://github.com/NixOS/nixpkgs/commit/25b9e543da9add39a2224206b8f3771cee12bd30) python3Packages.langchain: 0.0.180 -> 0.0.183
* [`d3d865b7`](https://github.com/NixOS/nixpkgs/commit/d3d865b7779a839cb97bd55c99cb8e7bd92f367a) python311Packages.django-rest-registration: 0.7.3 -> 0.8.2
* [`8fa14075`](https://github.com/NixOS/nixpkgs/commit/8fa14075fbcf6495f48adf5db9bcdad9d3f9679d) indent: fix build with clang 13 or newer
* [`2b16a73b`](https://github.com/NixOS/nixpkgs/commit/2b16a73b02c6ea6349e2170ee47ff419f8cdea23) obs-studio-plugins.obs-source-clone: 0.1.3 -> 0.1.4
* [`296282cb`](https://github.com/NixOS/nixpkgs/commit/296282cb0a70d5010099aef59a5456967a87d0ca) python310Packages.boxx: 0.10.8 -> 0.10.9
* [`69936995`](https://github.com/NixOS/nixpkgs/commit/699369959620a68839bee92df0bd71a53acbb692) httpdump: 20210126-d2e0dea -> unstable-2023-05-07
* [`e1de9a31`](https://github.com/NixOS/nixpkgs/commit/e1de9a317d5e3ac1a501e25be58e0f617de4d085) make-tarball.nix: support an absent revcount
* [`06ad004b`](https://github.com/NixOS/nixpkgs/commit/06ad004b991c34a0092608a102c1bb2d1fc40012) buildkite-agent: 3.46.1 -> 3.47.0
* [`8a029042`](https://github.com/NixOS/nixpkgs/commit/8a0290424007adc588b5e69edcedaf351b87b309) python310Packages.ariadne: fix build
* [`9eeb6bbf`](https://github.com/NixOS/nixpkgs/commit/9eeb6bbfecab77944c61b732183d12bddcd85df7) darwin.openwith: mark broken on x86_64
* [`c2847a44`](https://github.com/NixOS/nixpkgs/commit/c2847a442137594c99619aba61b10ee256e040bb) eksctl: 0.142.0 -> 0.143.0
* [`e2294f9f`](https://github.com/NixOS/nixpkgs/commit/e2294f9f88e8a044765d2a7bad508da582e3dd44) python3Packages.boa-api: disable checkPhase
* [`5c06b083`](https://github.com/NixOS/nixpkgs/commit/5c06b08329e561233c24b0ebde8e0c74e7f1ba2f) python3Packages.boa-api: add changelog to meta
* [`0143b169`](https://github.com/NixOS/nixpkgs/commit/0143b169358e0729e8f3503dc2d64605c812e00c) nixos/pufferpanel: buildFHSUserEnv -> buildFHSEnv
* [`6d93b778`](https://github.com/NixOS/nixpkgs/commit/6d93b7783264d34b424b6ef7c6271775d8bbe7aa) mqttmultimeter: init at 1.7.211
* [`910bf613`](https://github.com/NixOS/nixpkgs/commit/910bf6138ec36129f20ccaa8b463d5ede7271e01) haskellPackages.dyre: remove unneeded patch
* [`c81f3c71`](https://github.com/NixOS/nixpkgs/commit/c81f3c71e803418fbdf5a73a2fca7cf57ce7285d) python310Packages.shlib: 1.5 -> 1.6
* [`075761cf`](https://github.com/NixOS/nixpkgs/commit/075761cf7f3a9aec5644326b30843523f5b506e7) haskellPackages: regenerate package set based on current config
* [`2a8e5b25`](https://github.com/NixOS/nixpkgs/commit/2a8e5b25be099bba16bbecf36a00d1de7d829969) highlight: 4.5 -> 4.6
* [`6ff58377`](https://github.com/NixOS/nixpkgs/commit/6ff58377bd91fddae88ff6c5fb6ac1e5b9dcf609) python310Packages.azure-containerregistry: 1.0.0 -> 1.1.0
* [`6856d456`](https://github.com/NixOS/nixpkgs/commit/6856d456fa4f4a08f227c0aad980a8d3dd206ff5) haskell: mark hzk and zoovisitor as dont-distribute-packages
* [`d2bda17b`](https://github.com/NixOS/nixpkgs/commit/d2bda17bf57f83c150e64553998232488629e978) prometheus-node-exporter: 1.5.0 -> 1.6.0
* [`c479d2cb`](https://github.com/NixOS/nixpkgs/commit/c479d2cbefd49132c7781936474066e8f1c669c1) dnscontrol: 4.0.1 -> 4.1.0
* [`c06568b8`](https://github.com/NixOS/nixpkgs/commit/c06568b84482e42e1a486bc9135c40790cb51f4f) python310Packages.pytorch-metric-learning: 2.1.1 -> 2.1.2
* [`643a4d7e`](https://github.com/NixOS/nixpkgs/commit/643a4d7e460ffbad0d9168e2bef49a9d65a30280) xmake: init at 2.7.9
* [`21a36d67`](https://github.com/NixOS/nixpkgs/commit/21a36d6727c6a5f2921e8265252edc5c20d472f3) python3Packages.libsixel: fix build on darwin
* [`009b888a`](https://github.com/NixOS/nixpkgs/commit/009b888a1c1ae81b61245bef8fc7c5f30246474d) limitcpu: 2.9 -> 3.0
* [`5b7fc70b`](https://github.com/NixOS/nixpkgs/commit/5b7fc70b8f0b17b5ba149d1b578c1849b265a20b) python311Packages.boa-api: add format
* [`d8e449e4`](https://github.com/NixOS/nixpkgs/commit/d8e449e4618fff15896d30ac40d9820527eeb8a2) python310Packages.pytest-md-report: 0.3.0 -> 0.3.1
* [`4183f2f7`](https://github.com/NixOS/nixpkgs/commit/4183f2f731173ce03136ce307ac2d9fe587ded84) python310Packages.azure-containerregistry: update disabled
* [`de432ab2`](https://github.com/NixOS/nixpkgs/commit/de432ab2c2a6ce206396a6c3e1de407691fe97f9) insomnia: 2023.2.0 -> 2023.2.2
* [`7dd51c29`](https://github.com/NixOS/nixpkgs/commit/7dd51c298d7c1cefe8cc10c0f8e5e93916c6c43a) haskellPackages.hls-test-utils: remove unneeded patch
* [`1388b98f`](https://github.com/NixOS/nixpkgs/commit/1388b98f13f3a1e1ffd1e0dfb4398780205d6da1) haskell.packages.ghc94.cborg: remove unneeded patch
* [`47b2bd78`](https://github.com/NixOS/nixpkgs/commit/47b2bd788b4b2f9730b73b81cb30f0fab01e19a0) haskell.packages.ghc96.cborg: remove unneeded jailbreak
* [`e0688e7f`](https://github.com/NixOS/nixpkgs/commit/e0688e7fd08599d49eb4a55b0225d497c8ea5fcf) pleroma: 2.5.1 -> 2.5.2
* [`00fd888c`](https://github.com/NixOS/nixpkgs/commit/00fd888c67ea2abe313cca59e06811bdbc781423) prometheus-pushgateway: 1.5.1 -> 1.6.0
* [`b96bee72`](https://github.com/NixOS/nixpkgs/commit/b96bee721b019ccfc0f9d504c432b0f5af0020ea) avalanchego: 1.10.1 -> 1.10.2
* [`c03888fb`](https://github.com/NixOS/nixpkgs/commit/c03888fb67d3d560f6e1bcb277100367b2d89495) cloudflared: 2023.5.0 -> 2023.5.1
* [`1d73a587`](https://github.com/NixOS/nixpkgs/commit/1d73a58776f0ff58fa6c4b5181771130c4825875) alephone: 1.4 -> 1.6.1
* [`9d2ed18e`](https://github.com/NixOS/nixpkgs/commit/9d2ed18ece8e1e4f54395ed06a1fcabce5235218) New Aleph One scenario alephone-yuge
* [`6e9531b9`](https://github.com/NixOS/nixpkgs/commit/6e9531b9131da0c6542119f8d700e76d9c2eb1f4) alephone-apotheosis-x: init at 1.1
* [`cc62398c`](https://github.com/NixOS/nixpkgs/commit/cc62398c925d6f4482d640242a7076841902bb66) pomerium: 0.22.1 -> 0.22.2
* [`99dfe54b`](https://github.com/NixOS/nixpkgs/commit/99dfe54b639bbe1c9388e3f8fcfca7788ed2256b) haskell.packages.ghc94.hls-stylish-haskell-plugin: remove unneeded patch
* [`eca92b24`](https://github.com/NixOS/nixpkgs/commit/eca92b24351712a40aa8ff55b5c5be51c1a7f57d) haskell.packages.ghc94.hls-floskell-plugin: remove unneeded patch
* [`2130bdbd`](https://github.com/NixOS/nixpkgs/commit/2130bdbd452b2af94066bce447266c878d58bca9) haskell.packages.ghc94.hls-rename-plugin: remove unneeded patch
* [`8dcbea47`](https://github.com/NixOS/nixpkgs/commit/8dcbea47ed6907a79cd30eabaf51f70b8754f18a) raycast: 1.52.0 -> 1.52.1
* [`35cb10f8`](https://github.com/NixOS/nixpkgs/commit/35cb10f82eed240c1e67bb50aee6722f5d6aaa47) gtkcord4: 0.0.10 -> 0.0.11
* [`1c4d9e9a`](https://github.com/NixOS/nixpkgs/commit/1c4d9e9a752232eb35579ab9d213ab217897cb6f) ocamlPackages.ocamlfuse: 2.7.1_cvs7 -> 2.7.1_cvs8
* [`c1071ec8`](https://github.com/NixOS/nixpkgs/commit/c1071ec8c212b327af7677d9ffc6eef330bbfe6d) hugo: 0.112.4 -> 0.112.5
* [`b9a58b4a`](https://github.com/NixOS/nixpkgs/commit/b9a58b4ade8418d7d2675648c007981d4560edab) ocamlPackages.gapi-ocaml: 0.4.3 -> 0.4.4
* [`afd309e2`](https://github.com/NixOS/nixpkgs/commit/afd309e2a6c313902e98691eda6a0980e68cf105) ocamlPackages.oseq: 0.4 -> 0.5
* [`0c21ba61`](https://github.com/NixOS/nixpkgs/commit/0c21ba61bb648a669d436f214d3c803f4a137df7) ledger-live-desktop: 2.58.0->2.60.0
* [`ea47685d`](https://github.com/NixOS/nixpkgs/commit/ea47685d8a02715067c05de97aa148f489e3e8bb) cargo-expand: 1.0.51 -> 1.0.52
* [`c9c7de9d`](https://github.com/NixOS/nixpkgs/commit/c9c7de9db533a2dba085f1fd3b07110360d13f9e) gst_all_1.gst-plugins-rs: increase test timeout and disable livesync plugin for now
* [`ec5067be`](https://github.com/NixOS/nixpkgs/commit/ec5067be4d5ae53c164c9aac15905c192b60bdee) whatsapp-chat-exporter: init at 0.9.1
* [`a043fafe`](https://github.com/NixOS/nixpkgs/commit/a043fafe3dae61a7a2b6805539263834c21421d2) whatsapp-chat-exporter: remove options
* [`d72e8ab7`](https://github.com/NixOS/nixpkgs/commit/d72e8ab75d243bb9afbdd5a172b02acf6500a41c) python310Packages.pytest-md-report: raise minimal python version to 3.7
* [`853461b6`](https://github.com/NixOS/nixpkgs/commit/853461b6c8d6926110414b7f7d8633d76b530e2d) libssh: revert "dev" output split
* [`80625759`](https://github.com/NixOS/nixpkgs/commit/8062575956e2747dda404809656f5214df594f73) slurm: fixup build after splitting libyaml.outputs
* [`ee55a7e0`](https://github.com/NixOS/nixpkgs/commit/ee55a7e0b6739d2f5419d2fd779e442dfad4f02e) xfsprogs: removed unneeded make configure invocation and build inputs
* [`38c9e233`](https://github.com/NixOS/nixpkgs/commit/38c9e2336affada19048dea68d7e6b014817f632) xfsprogs: add liburcu to nativeBuildInputs with is required by crc32selftest, fixing cross compilation
* [`d27954a5`](https://github.com/NixOS/nixpkgs/commit/d27954a5618649128e0f9060e5d3d0ad33d30d80) manim: Pin networkx and watchdog
* [`722cdf5a`](https://github.com/NixOS/nixpkgs/commit/722cdf5a4ae132fcbd8cd2898228e75cb7f77ae4) haskellPackages.conferer-warp: not broken
* [`c92d120e`](https://github.com/NixOS/nixpkgs/commit/c92d120e01101fbdb1852dea90d218876be1ad01) libreoffice-still: 7.4.6.2 -> 7.4.7.2
* [`4b41ea8c`](https://github.com/NixOS/nixpkgs/commit/4b41ea8cbedbb8abd5cbbb7a834e34cdce81470f) python310Packages.jupyterhub: mark broken
* [`9da80915`](https://github.com/NixOS/nixpkgs/commit/9da80915062513c9a05044c7bb2749369f2b3d6e) libreoffice-fresh: 7.5.2.2 -> 7.5.4.1
* [`5ea70c4d`](https://github.com/NixOS/nixpkgs/commit/5ea70c4da24e8f97676b11a6c4b1a11e34d65661) haskell.packages.ghc96.hie-compat: remove unneeded patch
* [`179f7614`](https://github.com/NixOS/nixpkgs/commit/179f7614ae02beef5b4b9496dc09b6365ba1fec5) python310Packages.pontos: disable failing test
* [`8dd5367d`](https://github.com/NixOS/nixpkgs/commit/8dd5367d67a813eb63deb77210924d8a2cc53e6c) erdtree: 3.0.0 -> 3.0.1
* [`e5b4371b`](https://github.com/NixOS/nixpkgs/commit/e5b4371bd200aad001c7f1ad2c17edc1bbb6ddba) wxGTK31: drop mesa on darwin
* [`48a6774e`](https://github.com/NixOS/nixpkgs/commit/48a6774e27122dab8a7c10d518bd810b8b702994) wxGTK32: drop mesa on darwin
* [`41437056`](https://github.com/NixOS/nixpkgs/commit/41437056f77cc7683348955078ef7f84b9e6dc4c) vtk: drop mesa on darwin
* [`05ef1ae1`](https://github.com/NixOS/nixpkgs/commit/05ef1ae17f8ebf77138e2c6391b646cddb4cefd8) ueberzugpp: 2.8.5 -> 2.8.6
* [`83d32ac2`](https://github.com/NixOS/nixpkgs/commit/83d32ac2139fa711ba6cddd37ef5636bd5fe3317) clojure: Pass function to mkDerivation, remove rec
* [`5409925d`](https://github.com/NixOS/nixpkgs/commit/5409925d9806d4270b23828d0c1a35eda749db5a) botamusique: Backport fix for invalid version handling
* [`041094ad`](https://github.com/NixOS/nixpkgs/commit/041094ad2ff90eab7d3d044c3eaad463666d2caa) ocamlPackages.ppx_yojson_conv_lib: 0.15.0 -> 0.16.0
* [`63fa43ae`](https://github.com/NixOS/nixpkgs/commit/63fa43aeb29a4e2bb9a0a5a47610825e78b9f19c) gl2ps: drop mesa on darwin
* [`aa75b3fd`](https://github.com/NixOS/nixpkgs/commit/aa75b3fdf7b017ac3242e03e77ff658beb91162b) zgrab2: 20210327-17a5257 -> 20230323-911c86f
* [`6ad7a329`](https://github.com/NixOS/nixpkgs/commit/6ad7a32910f62212abcc7201519af68115f71ed2) swaynotificationcenter: 0.8.0 -> 0.9.0
* [`4f3419af`](https://github.com/NixOS/nixpkgs/commit/4f3419afdfc106294f7663c5e6894ec1ac1d5aed) keama: init at 4.4.3-P1
* [`96315531`](https://github.com/NixOS/nixpkgs/commit/963155315341bac20371b791fa356d1e53628cf1) Revert "nixos/ntfy-sh: add defaults, use dynamic user"
* [`111e3a55`](https://github.com/NixOS/nixpkgs/commit/111e3a55a6b047234b64cbf073dff07549c7f0fa) python3Packages.filterpy: 1.4.5 -> unstable-2022-08-23
* [`46a64903`](https://github.com/NixOS/nixpkgs/commit/46a649030ab875e645dcd3d6935a3bc225574cd9) python3Packages.filterpy: fix formatting
* [`1166f26b`](https://github.com/NixOS/nixpkgs/commit/1166f26bee18876adf2c3cacab831664b6b3e225) pqrs: 0.2.2 -> 0.3.1
* [`fe202e0a`](https://github.com/NixOS/nixpkgs/commit/fe202e0aaf8f96d1d0e2020eb08fa8ed8794a2db) mani: 0.23.0 -> 0.24.0
* [`19585912`](https://github.com/NixOS/nixpkgs/commit/19585912742698237faf9ddf65884fafbd51a20f) python3Packages.bx-py-utils: disable a broken test on darwin
* [`172ec1bf`](https://github.com/NixOS/nixpkgs/commit/172ec1bfa10b6968b8b46a820a07717d9b440368) python3Packages.bx-py-utils: add changelog to meta
* [`4b77b29b`](https://github.com/NixOS/nixpkgs/commit/4b77b29b0a6dc85352eea90f17400c8dc2fd9d92) bearer: 1.8.0 -> 1.8.1
* [`6a6581e8`](https://github.com/NixOS/nixpkgs/commit/6a6581e8f276deab898212d1b03c44e1c559c0cb) typical: init at 0.9.4
* [`ee566ee0`](https://github.com/NixOS/nixpkgs/commit/ee566ee06e9283e6243d3c891b9dd572f8cb8f57) calico-cni-plugin: 3.25.1 -> 3.26.0
* [`47f21185`](https://github.com/NixOS/nixpkgs/commit/47f21185eab61487c234bf0cb951876586842188) glooctl: 1.14.5 -> 1.14.6
* [`0ad8dd62`](https://github.com/NixOS/nixpkgs/commit/0ad8dd62975cb44ed2f5d8a122f756529798bec5) BeatSaberModManager: suffix PATH with xdg-utils rather than prefix
* [`10503ae8`](https://github.com/NixOS/nixpkgs/commit/10503ae83ca4319dc9bd3fd3090e1b4cb2d1eb38) signalbackup-tools: 20230523 -> 20230528-1
* [`4358d2ac`](https://github.com/NixOS/nixpkgs/commit/4358d2ac4feaff46846bb3b908c72497e8146d50) kyverno: 1.9.4 -> 1.9.5
* [`75222b20`](https://github.com/NixOS/nixpkgs/commit/75222b204c6594898a30d39d9f5d8f54b544b291) okteto: 2.15.3 -> 2.15.4
* [`93707532`](https://github.com/NixOS/nixpkgs/commit/93707532366ba2bc6b4b8ae920ba31246b20a613) xcp: 0.9.4 -> 0.10.0
* [`8549e57e`](https://github.com/NixOS/nixpkgs/commit/8549e57eceb5428c44b6b6e8cfe25d11a8715bfe) nuclei: 2.9.4 -> 2.9.5
* [`44ac2336`](https://github.com/NixOS/nixpkgs/commit/44ac2336097f9ea59d2acdfbe0daa37e042b5b46) charasay: init at 2.0.0
* [`82fffa02`](https://github.com/NixOS/nixpkgs/commit/82fffa024b9c9422650f0fb291b7a435935f3ebb) fluent-bit: 2.1.3 -> 2.1.4
* [`6ed04dd9`](https://github.com/NixOS/nixpkgs/commit/6ed04dd9168b01b1d802bb14ccf5a3eb915f283f) bearer: fix version
* [`65dd3c5d`](https://github.com/NixOS/nixpkgs/commit/65dd3c5d3567d1d78c06f200b2d9eafc54cee3f9) ftxui: 4.1.0 -> 4.1.1
* [`713371ee`](https://github.com/NixOS/nixpkgs/commit/713371eed7f1b62ba2c4557e19f231725f31ee2a) bearer: add version test
* [`c2a94a15`](https://github.com/NixOS/nixpkgs/commit/c2a94a153736c832441ec39f4196322835ad6305) kustomize-sops: 4.2.0 -> 4.2.1
* [`e1a8113c`](https://github.com/NixOS/nixpkgs/commit/e1a8113c122bd6d174bce81c0600de1c964d2402) matrix-synapse: 1.84.0 -> 1.84.1
* [`11c0b063`](https://github.com/NixOS/nixpkgs/commit/11c0b06392e386ba9f7834460b8e14bbfe48432b) musikcube: 3.0.0 -> 3.0.1
* [`0000007d`](https://github.com/NixOS/nixpkgs/commit/0000007dcc81f9872177714c6f4af261a47ac56a) nginxModules.vts: 0.2.1 -> 0.2.2, add SuperSandro2000 as maintainer
* [`819289b1`](https://github.com/NixOS/nixpkgs/commit/819289b1e59047de108479cc0986467bb7bc7a26) nginxModules.zstd: add SuperSandro2000 as maintainer
* [`376767d1`](https://github.com/NixOS/nixpkgs/commit/376767d1dc5a9867cda1e684ed679b34b8007496) youtube-tui: 0.7.1 -> 0.7.2
* [`439f2eea`](https://github.com/NixOS/nixpkgs/commit/439f2eea90fc4e42f57a8ecbd1e1cc929d2609d4) trurl: 0.6 -> 0.7
* [`37f7c78f`](https://github.com/NixOS/nixpkgs/commit/37f7c78f8f729bccc99eda7b47c13014b32fa847) lefthook: 1.4.0 -> 1.4.1
* [`280160bd`](https://github.com/NixOS/nixpkgs/commit/280160bd1d911ff4ccc7acfa493aff0362544700) dtc: 1.6.1 -> 1.7.0
* [`017dc5f5`](https://github.com/NixOS/nixpkgs/commit/017dc5f595c369d8fdad98aae7a5ca8fe0adad60) dk: init at 1.9
* [`22c8251d`](https://github.com/NixOS/nixpkgs/commit/22c8251d7fcaabbfc1ab0d812963384dcd5a5c72) nixos/dk: init
* [`75d58486`](https://github.com/NixOS/nixpkgs/commit/75d58486e8da99ea0e9d2033a4fa87872e36fc0f) checkstyle: 10.11.0 -> 10.12.0
* [`06161f19`](https://github.com/NixOS/nixpkgs/commit/06161f191dfe17c01bdb68cbaa688700aac29528) pdal: 2.4.3 -> 2.5.4
* [`d05b2422`](https://github.com/NixOS/nixpkgs/commit/d05b2422337ab75bfe1d8a58d6f17ff64d16210c) maintainers: add nim65s
* [`4431bab0`](https://github.com/NixOS/nixpkgs/commit/4431bab00361e3652201f1ae98d79913a36e3bc5) writeTextFile: fix when executable is not a bool
* [`2a819f2a`](https://github.com/NixOS/nixpkgs/commit/2a819f2a91b72222dddf1b756f89778b1b2d6c0a) noson: init at 5.4.1
* [`8769a90f`](https://github.com/NixOS/nixpkgs/commit/8769a90f90ed8ad74dfbc3f7702f50279a76cc72) vscode: disable ripgrep patching on macOS
* [`ad3402c6`](https://github.com/NixOS/nixpkgs/commit/ad3402c664dec9cc06203c39f7ec45513247ee31) wasmtime: fix lib on darwin
* [`28b9d1ae`](https://github.com/NixOS/nixpkgs/commit/28b9d1ae45fc046f2ebafdb324a73e53a1b7ba90) hyprwm: update packages
* [`d93dc82e`](https://github.com/NixOS/nixpkgs/commit/d93dc82ee92b80c20d57674a30943fed0f754655) nixos/river: fix display manager error
* [`f03d84d9`](https://github.com/NixOS/nixpkgs/commit/f03d84d954baedfc6fde4d8cdddd0e6a7b50b013) gridlock: init at unstable-2023-03-03
* [`f9bd3d9a`](https://github.com/NixOS/nixpkgs/commit/f9bd3d9aba8835c79402bcddd6e28eb366e6c2e2) nyarr: init at unstable-2023-03-03
* [`5dd9667a`](https://github.com/NixOS/nixpkgs/commit/5dd9667abdf6ebf314fe57d895d397784f72ae40) nitter: unstable-2023-04-21 -> unstable-2023-05-19
* [`f1423fd5`](https://github.com/NixOS/nixpkgs/commit/f1423fd5aec7967723ffc614faad18f7d8e6ca75) neovim: 0.9.0 -> 0.9.1
* [`d1896a86`](https://github.com/NixOS/nixpkgs/commit/d1896a86bc6919eab9630a759e1781143a27695b) chromiumBeta: 114.0.5735.35 -> 114.0.5735.45
* [`39b4e85e`](https://github.com/NixOS/nixpkgs/commit/39b4e85e6c89d69dd3be98553a995fa407febaf4) chromiumDev: 115.0.5773.4 -> 115.0.5790.3
* [`0b65e2c1`](https://github.com/NixOS/nixpkgs/commit/0b65e2c14d5dda4f5870afeeb6cb4ec8a8528fe3) vencord: 1.1.6 -> 1.2.5
* [`8d91de51`](https://github.com/NixOS/nixpkgs/commit/8d91de51459123b82c8b7728185b309a2a9e09ba) linuxPackages.ax99100: don't use lib.optional with a list
* [`2014fdae`](https://github.com/NixOS/nixpkgs/commit/2014fdae3dbe7fbaad6eb21b1a9df320bbd33fb5) flashrom: don't use lib.optional with a list
* [`b643a42a`](https://github.com/NixOS/nixpkgs/commit/b643a42a1f6e934deef1a7a0752ec05baa83419c) ghostscript: don't use lib.optional with a list
* [`17cb25a4`](https://github.com/NixOS/nixpkgs/commit/17cb25a433925e347673402651b944fecc6fafc0) cargo-dephell: don't use lib.optional with a list
* [`81fe865c`](https://github.com/NixOS/nixpkgs/commit/81fe865cf8ce06f9b4bf5538b1c8156b07d00a11) python310Packages.python-mapnik: don't use lib.optional with a list
* [`e4b6aeb3`](https://github.com/NixOS/nixpkgs/commit/e4b6aeb3a90b5c029a64ae5525b713ef1fe76a39) mpfr: don't use lib.optional with a list
* [`3605f48b`](https://github.com/NixOS/nixpkgs/commit/3605f48b4d96ca9dee48b45102370d1360b38cb0) ipe: don't use lib.optional with a list
* [`c8929e45`](https://github.com/NixOS/nixpkgs/commit/c8929e452353bc6ec4916ba7854adf877ad65aa9) xplorer: move cmake to nativeBuildInputs
* [`8733c553`](https://github.com/NixOS/nixpkgs/commit/8733c5536edadccaf8086c863a31e9143fce0041) swiftpm: move pkg-config to nativeBuildInputs
* [`c05fa242`](https://github.com/NixOS/nixpkgs/commit/c05fa24286a9e8cc357155e3a14ac92421be556b) sourcekit-lsp: move pkg-config to nativeBuildInputs
* [`6ddd5973`](https://github.com/NixOS/nixpkgs/commit/6ddd5973f4c219331c5f94a7852716b947ae35f7) haskell.packages.ghc96.haskell-language-server: explicitly disable fourmolu plugin
* [`dd9e4575`](https://github.com/NixOS/nixpkgs/commit/dd9e4575ec2eb18e0cb005f36d52a8d5edea84df) tests.haskell.incremental: change package used from turtle to temporary
* [`f0363f57`](https://github.com/NixOS/nixpkgs/commit/f0363f573ca5a012c60e118a2f8b11a458aa70d1) dart-sass: convert dartCompileFlags to a list
* [`ee5d3342`](https://github.com/NixOS/nixpkgs/commit/ee5d3342ebb57fd50886780aa6bc8b766283a022) python310Packages.skytemple-files: convert pytestFlagsArray to a list
* [`34233107`](https://github.com/NixOS/nixpkgs/commit/34233107b980cb52b634f27c5800a0fa6223e850) swift-format: convert swiftpmFlags to a list
* [`f7f05123`](https://github.com/NixOS/nixpkgs/commit/f7f0512311cefe81f345805756267c19574619b6) swiftPackages.swift-docc: convert swiftFlags to a list
* [`01507d38`](https://github.com/NixOS/nixpkgs/commit/01507d38f8c841609c04e51ec11aa4aac71216cd) plumed: 2.8.2 -> 2.9.0
* [`71a23afb`](https://github.com/NixOS/nixpkgs/commit/71a23afb458ebbc095caa8cd48a018d01888043d) iqtree: 2.2.2.4 -> 2.2.2.6
* [`5b809c2f`](https://github.com/NixOS/nixpkgs/commit/5b809c2f2fbd8118742e02edf0121c865282c53b) crowdsec: 1.5.1 -> 1.5.2
* [`c4e48ded`](https://github.com/NixOS/nixpkgs/commit/c4e48ded591c380c3c5b9b15077fe31263c0870a) emacs: a huge refactor
* [`3d43f48a`](https://github.com/NixOS/nixpkgs/commit/3d43f48a93c0b9ba6981c8533e92b816fd9ee6a7) emacs29: init at 20.0.91
* [`b27387cb`](https://github.com/NixOS/nixpkgs/commit/b27387cb03aef6ac9d7814ffe6032bed6b110479) flacon: 11.0.0 -> 11.1.0
* [`c9b945e0`](https://github.com/NixOS/nixpkgs/commit/c9b945e0f846182deeb23733f550f39182892ba3) webhook: 2.8.0 -> 2.8.1
* [`0d318719`](https://github.com/NixOS/nixpkgs/commit/0d3187197ef268d46d26c7e504b716dcf2069188) haskellPackages: mark builds failing on hydra as broken
* [`0b01e667`](https://github.com/NixOS/nixpkgs/commit/0b01e667c8f491bf5e25a2af6a72db2a4488e42d) lightning-loop: 0.23.0-beta -> 0.24.1-beta
* [`d21a85aa`](https://github.com/NixOS/nixpkgs/commit/d21a85aad3190ab6b640b682827e5336ab4b6f11) goflow2: 1.3.3 -> 1.3.4
* [`62042b00`](https://github.com/NixOS/nixpkgs/commit/62042b000904eb3c4581fad26f1b847e4e290406) ueberzugpp: drop uuid
* [`6519bda9`](https://github.com/NixOS/nixpkgs/commit/6519bda964865954344098ffa271f97cf25ed344) catnip: init at 1.8.0
* [`c8ac5e32`](https://github.com/NixOS/nixpkgs/commit/c8ac5e32b1976ff5955f83e25925b33c670fdd06) terraform-providers.infoblox: 2.3.0 -> 2.4.0
* [`0c664a56`](https://github.com/NixOS/nixpkgs/commit/0c664a56c89bfeab3d0fafe6d7eeff11f8ad3120) terraform-providers.pagerduty: 2.14.5 -> 2.14.6
* [`15b55f89`](https://github.com/NixOS/nixpkgs/commit/15b55f89753abf40e01da8bcaabb2d5291bb6ad4) terraform-providers.scaleway: 2.19.0 -> 2.20.0
* [`38a78a13`](https://github.com/NixOS/nixpkgs/commit/38a78a1302b649829ab05af934d914f436609e03) amazon-ecr-credential-helper: 0.7.0 -> 0.7.1
* [`4d49cc48`](https://github.com/NixOS/nixpkgs/commit/4d49cc4833628211e27474ab018c75bddbb8e90e) frp: 0.48.0 -> 0.49.0
* [`9cd3f2e6`](https://github.com/NixOS/nixpkgs/commit/9cd3f2e65111a31798f8598fb0c2590f09183ccb) clickhouse-backup: 2.2.6 -> 2.2.7
* [`4a579c64`](https://github.com/NixOS/nixpkgs/commit/4a579c64c2ee4040ed88e9980bedc8b21a98a545) haskell: mark additional packages as insecure
* [`d12ab6e1`](https://github.com/NixOS/nixpkgs/commit/d12ab6e1e76d6c81c0a3720a992b4beda22bd056) minio-client: 2023-05-18T16-59-00Z -> 2023-05-26T23-31-54Z
* [`2daea5bd`](https://github.com/NixOS/nixpkgs/commit/2daea5bde69cdec35d7dde7c342bdb4d92f5a3e2) bazel-gazelle: 0.30.0 -> 0.31.0
* [`5e78f55d`](https://github.com/NixOS/nixpkgs/commit/5e78f55ddd848763d2df7d41f9613f72b4752e15) all-cabal-hashes: 2023-05-28T10:08:17Z -> 2023-05-30T03:47:42Z
* [`38ced599`](https://github.com/NixOS/nixpkgs/commit/38ced599945494f021125044b216c7df2427ae4f) haskellPackages: regenerate package set based on current config
* [`599c8bb3`](https://github.com/NixOS/nixpkgs/commit/599c8bb3afb3c9446ee7183d4d3e4cc390dbd659) rust-analyzer-unwrapped: 2023-05-22 -> 2023-05-29
* [`f3da1b7c`](https://github.com/NixOS/nixpkgs/commit/f3da1b7c97bce21fd943e82dac02e44be38b369b) hpp-fcl, python3Packages.hpp-fcl: init at 2.3.3
* [`57d2ea76`](https://github.com/NixOS/nixpkgs/commit/57d2ea7636c28fc6180b52f4d551231bf467c7fe) powershell: drop openssl_1_1
* [`8e82668e`](https://github.com/NixOS/nixpkgs/commit/8e82668efc15c85eb244221f454738c621488ff8) zinit: 3.7 -> 3.11.0
* [`288b2fa5`](https://github.com/NixOS/nixpkgs/commit/288b2fa580edf3e7a4814422717b6055a5cf65ea) maddy: 0.6.3 -> 0.7.0
* [`e2f30e50`](https://github.com/NixOS/nixpkgs/commit/e2f30e50a87d221ed0cc16b6566d653f1e8ad9b1) netbird-ui: 0.20.3 -> 0.20.5
* [`63f73b32`](https://github.com/NixOS/nixpkgs/commit/63f73b3295d165a6d60cc3322ec46b2c37f646d0) nixos/maddy: change secrets option to accept a list of paths
* [`3407d5ea`](https://github.com/NixOS/nixpkgs/commit/3407d5eae1b9b96e9175564aaa91c5df9a72b0fc) dagger: 0.5.3 -> 0.6.0
* [`990e429f`](https://github.com/NixOS/nixpkgs/commit/990e429f0693329d3deb7fb482ecb5e9bbbc780e) blueberry: add missing libnotify
* [`997a334c`](https://github.com/NixOS/nixpkgs/commit/997a334cd2476c97e85abcad6fdbcbb18eb5f9af) re-flex: 3.3.2 -> 3.3.3
* [`b1a0d160`](https://github.com/NixOS/nixpkgs/commit/b1a0d1607e17da1052ea8e6099a3966a1b876b26) pacparser: 1.4.1 -> 1.4.2
* [`b03bb9fd`](https://github.com/NixOS/nixpkgs/commit/b03bb9fd44ee94cba1a4634a850398061f11bc3d) flyctl: 0.1.18 -> 0.1.20
* [`e5c96ab6`](https://github.com/NixOS/nixpkgs/commit/e5c96ab6fd5471cc710f45b1d5bd5833bff21c35) vtm: 0.9.9k -> 0.9.9l
* [`38d50c81`](https://github.com/NixOS/nixpkgs/commit/38d50c81f27e61b19e6bc688d88cb1a4475c8444) clj-kondo: 2023.05.18 -> 2023.05.26
* [`b8a6381d`](https://github.com/NixOS/nixpkgs/commit/b8a6381d6a31934b3785390ea8aa20c35922538a) R: 4.2.3 -> 4.3.0
* [`9db2a090`](https://github.com/NixOS/nixpkgs/commit/9db2a0900132fb83832dac8323acec8db60e400d) build(deps): bump cachix/install-nix-action from 20 to 21
* [`60706045`](https://github.com/NixOS/nixpkgs/commit/60706045e7d96358d7d9532dae92127a97702d13) credhub-cli: 2.9.15 -> 2.9.16
* [`4e6bb700`](https://github.com/NixOS/nixpkgs/commit/4e6bb700988d0f7350263981d2be5a8ce68d8f26) gnugrep: Fix build on Musl
* [`80a0edea`](https://github.com/NixOS/nixpkgs/commit/80a0edea9e3efdd2f2f51784a1b121dbd70a820e) gpg-tui: 0.9.5 -> 0.9.6
* [`f1a64372`](https://github.com/NixOS/nixpkgs/commit/f1a6437259a395d20d96bbed23c3149a69a847e2) picard: Fix inputs
* [`43abbf53`](https://github.com/NixOS/nixpkgs/commit/43abbf53f8ef60ecf6cb5567ba38c8ba9c6ad6e2) httplib: 0.12.3 -> 0.12.4
* [`3ef1b8d2`](https://github.com/NixOS/nixpkgs/commit/3ef1b8d27d58c2ffec7501174cecd3e54cc82902) prom2json: 1.3.2 -> 1.3.3
* [`036bb8ff`](https://github.com/NixOS/nixpkgs/commit/036bb8ff8123eb1e164a5b0eda5589b313cc994b) jack2, libjack2: fix jack2.pc after splitting outputs
* [`ec0c8471`](https://github.com/NixOS/nixpkgs/commit/ec0c8471022d591f88a46bca9046ea0ba317ea09) haskellPackages.hspec*: 2_11_0_1 -> 2_11_1
* [`7798454a`](https://github.com/NixOS/nixpkgs/commit/7798454aae5d03fbedf84cbe341cc37b17c59f44) rPackages: CRAN and BioC update
* [`3dea44a7`](https://github.com/NixOS/nixpkgs/commit/3dea44a74e7a123b4a9c26bf41a77e0191ddd582) gopsuinfo: 0.1.3 -> 0.1.4
* [`896e7068`](https://github.com/NixOS/nixpkgs/commit/896e70681ec0e11ba068d640d9707f3850b66d60) supabase-cli: 1.64.2 -> 1.64.8
* [`b4995a61`](https://github.com/NixOS/nixpkgs/commit/b4995a61c7aba0f8718f9d871c24b7a6f5b66466) powershell: 7.3.2 -> 7.3.4
* [`3f6b022a`](https://github.com/NixOS/nixpkgs/commit/3f6b022a4f74d3e6ca4981da67af5a2f3697870f) mongodb-compass: 1.36.4 -> 1.37.0
* [`f22a89cc`](https://github.com/NixOS/nixpkgs/commit/f22a89cc93a0f0a349f5dbf99d9e6ed236d7a57e) asnmap: 1.0.3 -> 1.0.4
* [`5cac5fa3`](https://github.com/NixOS/nixpkgs/commit/5cac5fa348ea38adad50da67fb872249ab842405) rathole: 0.4.7 -> 0.4.8
* [`f1f991ee`](https://github.com/NixOS/nixpkgs/commit/f1f991ee685740122889cf6a27278bd775a12684) minio: 2023-05-18T00-05-36Z -> 2023-05-27T05-56-19Z
* [`304940d9`](https://github.com/NixOS/nixpkgs/commit/304940d98e80e398df28a5388dbc4868ff97661d) buildGoModule: format
* [`4de1a607`](https://github.com/NixOS/nixpkgs/commit/4de1a6075961d555c9a35263ae1dbe90452ce862) xfce.xfce4-session: 4.18.2 -> 4.18.3
* [`afc0839b`](https://github.com/NixOS/nixpkgs/commit/afc0839bfd1a39b4071dcbfde259016096f79ee6) ddnet: 17.0.1 -> 17.0.2
* [`4a384405`](https://github.com/NixOS/nixpkgs/commit/4a38440507e9b1f47e6cdd4ca65c786bb81c39b6) bun: 0.6.3 -> 0.6.5
* [`5e64b96a`](https://github.com/NixOS/nixpkgs/commit/5e64b96a12d3120d0336bdd09afdeeeacf0f44db) rl-2305: alpha version for 23.05
* [`eb5ad04e`](https://github.com/NixOS/nixpkgs/commit/eb5ad04e643588f382ca5353e4d8f692a20d60ca) python311Packages.aliyun-python-sdk-kms: 2.16.0 -> 2.16.1
* [`fa59e82d`](https://github.com/NixOS/nixpkgs/commit/fa59e82dbc93da19170a0124637adc74d8801eee) grype: 0.62.1 -> 0.62.2
* [`88bc1844`](https://github.com/NixOS/nixpkgs/commit/88bc1844cd5edc6768799a120deb3f9e3cc89e14) python311Packages.meshtastic: 2.1.6 -> 2.1.7
* [`a7a0b827`](https://github.com/NixOS/nixpkgs/commit/a7a0b827dbc56e61bb7cca713adbd0df05843772) laminar: 1.2 → 1.3
* [`caa0a24a`](https://github.com/NixOS/nixpkgs/commit/caa0a24ab0c913ea250808ddfeef486ac2ac9f70) doc: clarify that meta.timeout is only for Hydra
* [`794e01a0`](https://github.com/NixOS/nixpkgs/commit/794e01a0d481413a9907d629a69eee8c1a4a7c40) python3.pkgs.glean-sdk: unvendor lmdb
* [`bdcdcbde`](https://github.com/NixOS/nixpkgs/commit/bdcdcbde2d82af336bb91932cfb619d7ce63dfd5) gnome.eog: 44.1 → 44.2
* [`acee9c72`](https://github.com/NixOS/nixpkgs/commit/acee9c724c22ded447623671ac326ac9adba478c) gnome.gnome-control-center: 44.1 → 44.2
* [`8f12355f`](https://github.com/NixOS/nixpkgs/commit/8f12355f841022ebe335fae68679bf70eb4a9d6e) gnome.sushi: 43.0 → 44.2
* [`cd26954d`](https://github.com/NixOS/nixpkgs/commit/cd26954d81c3b44a45800edc4a3ffb4a8f4a94a2) benthos: 4.15.0 -> 4.16.0
* [`a83735c6`](https://github.com/NixOS/nixpkgs/commit/a83735c6a2da97c2376bc1cdc4f0ac60af81f2c7) haskell.compiler.ghc962: init at 9.6.2
* [`b6813c0b`](https://github.com/NixOS/nixpkgs/commit/b6813c0b0c827ca0d25a1c725c79d0a54235074e) haskellPackages.thyme: drop stale override
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
