### PR TITLE
niv devenv: update b0bc8ec6 -> 873e7901

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b0bc8ec6e52726cadfe5c6695b07408b69adc307",
-        "sha256": "1kq68mdkzzw2chmyqzkqn2l4gjs1vlys0kkgxhyqgblbhxdichrl",
+        "rev": "873e7901efcefe8f0000975adc8b3b9b58c41fc4",
+        "sha256": "06rzsdi464kk3zmwwjry2h160lwk2hs32s0s2wnxv050ablrlci1",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/b0bc8ec6e52726cadfe5c6695b07408b69adc307.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/873e7901efcefe8f0000975adc8b3b9b58c41fc4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@b0bc8ec6...873e7901](https://github.com/cachix/devenv/compare/b0bc8ec6e52726cadfe5c6695b07408b69adc307...873e7901efcefe8f0000975adc8b3b9b58c41fc4)

* [`ea5a6060`](https://github.com/cachix/devenv/commit/ea5a6060bb8a57b8747d2d25b309955e0df45488) javascript: add corepack option
* [`30a42f6d`](https://github.com/cachix/devenv/commit/30a42f6d0c59babcadf62be6df885454b320e779) Add Meilisearch service
* [`8d6d129b`](https://github.com/cachix/devenv/commit/8d6d129b666778538b76bcb069ab82f813094e5c) Auto generate docs/reference/options.md
* [`9b94ede5`](https://github.com/cachix/devenv/commit/9b94ede5d4f690ee7f37837ec1b3f622111585d2) python: poetry: add support for installing dependency groups
* [`47dcf0b2`](https://github.com/cachix/devenv/commit/47dcf0b2d611e577e893c3d29180783e3a2cff35) python: poetry: add support for extras
* [`6cd52515`](https://github.com/cachix/devenv/commit/6cd525159758f1edc5a9b294911858a533080085) python: poetry: include poetry install arguments in checksum
* [`e206d8f2`](https://github.com/cachix/devenv/commit/e206d8f2e3e8d6aa943656052f15bdfea8146b8d) Auto generate docs/reference/options.md
* [`d0d9ccdd`](https://github.com/cachix/devenv/commit/d0d9ccddac8708cbc0984f33c5b2ff98a332284f) Difftastic language edit
* [`5bd7c3ea`](https://github.com/cachix/devenv/commit/5bd7c3ea94f7a60a4101c9459e39b0a6e7b594b0) Getting started proofread
* [`b0e6e4b5`](https://github.com/cachix/devenv/commit/b0e6e4b550c04474e9822fed75eea6c6d496f3a9) Codespaces proofread
* [`c49c6fd9`](https://github.com/cachix/devenv/commit/c49c6fd99ea02b799e1b4fdd9b535a4cc78db64b) GitHub Actions proofread
* [`b2fddad0`](https://github.com/cachix/devenv/commit/b2fddad0c0ea607c7a315c9cc03f3214ff431f24) Auto generate docs/reference/options.md
* [`ce0f8a49`](https://github.com/cachix/devenv/commit/ce0f8a49e1bdae6588a00bd61e6468414cef8c09) fix poetry install extras
* [`1626c87d`](https://github.com/cachix/devenv/commit/1626c87d9aead022165ffcced3bd892eb16cc3f9) Auto generate docs/reference/options.md
* [`ecd91d50`](https://github.com/cachix/devenv/commit/ecd91d5063e7b432b751ce706ec8b3559a89eeac) Add languages.python.version
* [`b5d2da49`](https://github.com/cachix/devenv/commit/b5d2da494f738022a6ede0edfe04c937e1c1237d) Auto generate docs/reference/options.md
* [`4618f401`](https://github.com/cachix/devenv/commit/4618f4011d12d0c603978a2bcbbdab060d1c8bb2) haskell: Fix error when `languageServer` is set to `null`
