### PR TITLE
niv home-manager: update 43ed7048 -> 607d8fad

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "43ed7048f670661d1ae2ea0d2f7655e87e7b0461",
-        "sha256": "09kjxkpxz4vwj03hdwh2y469h0i3wvzwd31gb9v6d269jl9iciax",
+        "rev": "607d8fad96436b134424b9935166a7cd0884003e",
+        "sha256": "0l85b6q7ff258lk3kx19flra8ajhf9mym81ijpknnz21yq979q7q",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/43ed7048f670661d1ae2ea0d2f7655e87e7b0461.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/607d8fad96436b134424b9935166a7cd0884003e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@43ed7048...607d8fad](https://github.com/nix-community/home-manager/compare/43ed7048f670661d1ae2ea0d2f7655e87e7b0461...607d8fad96436b134424b9935166a7cd0884003e)

* [`9f82227b`](https://github.com/nix-community/home-manager/commit/9f82227b64245c273d98dd02dedd44fc7576041e) lib/file-type: convert `executable` to bool ([nix-community/home-manager⁠#4036](https://togithub.com/nix-community/home-manager/issues/4036))
* [`54a9d645`](https://github.com/nix-community/home-manager/commit/54a9d6456eaa6195998a0f37bdbafee9953ca0fb) waybar: merge multiple style definitions ([nix-community/home-manager⁠#4038](https://togithub.com/nix-community/home-manager/issues/4038))
* [`b2a6cf7b`](https://github.com/nix-community/home-manager/commit/b2a6cf7b59343f4c1c29f5777b16ccd8f6e6495b) docs: update copyright years
* [`33ccc5c2`](https://github.com/nix-community/home-manager/commit/33ccc5c28572d200f1e8d93fccba17e084e5f587) Switch stable branch to release-23.05
* [`f1490b8c`](https://github.com/nix-community/home-manager/commit/f1490b8caf2ef6f59205c78cf1a8b68e776214a3) Switch current unstable version to 23.11
* [`53ccbe01`](https://github.com/nix-community/home-manager/commit/53ccbe017079d5fba2b605cb9f9584629bebd03a) fish: use babelfish for `hm-session-vars.sh` ([nix-community/home-manager⁠#4012](https://togithub.com/nix-community/home-manager/issues/4012))
* [`96078e4a`](https://github.com/nix-community/home-manager/commit/96078e4a939b5e5fec1cfd83a11b3df7146a58ff) Fix release notes ([nix-community/home-manager⁠#4044](https://togithub.com/nix-community/home-manager/issues/4044))
* [`76a816a8`](https://github.com/nix-community/home-manager/commit/76a816a89685448127e28b00f14d2e813f23a9f9) Update translation files
* [`4d8fedfd`](https://github.com/nix-community/home-manager/commit/4d8fedfd29f05657dcdd8cdc437c31b4dba7ee6b) Translate using Weblate (Swedish)
* [`efed2ccd`](https://github.com/nix-community/home-manager/commit/efed2ccd9f7fbdae1f355b245bed7864dee96317) Translate using Weblate (Spanish)
* [`04f6c292`](https://github.com/nix-community/home-manager/commit/04f6c2925b2e625504cd5a6ee758d320596f6394) Translate using Weblate (Persian)
* [`3876cc61`](https://github.com/nix-community/home-manager/commit/3876cc613ac3983078964ffb5a0c01d00028139e) Translate using Weblate (Ukrainian)
* [`29519461`](https://github.com/nix-community/home-manager/commit/29519461834c08395b35f840811faf8c23e3b61c) ripgrep: add module ([nix-community/home-manager⁠#4017](https://togithub.com/nix-community/home-manager/issues/4017))
* [`bffc49ff`](https://github.com/nix-community/home-manager/commit/bffc49ffb255f213d2f902043da37b3016450f4a) ripgrep: remove configDir
* [`221056c5`](https://github.com/nix-community/home-manager/commit/221056c59ffab1e513fcf8ccb1079a8d44848fa9) tests: fix `getOutput` on stubs
* [`57ed23cd`](https://github.com/nix-community/home-manager/commit/57ed23cd29e7b72518e19d2917e2b2880a94162c) flake.lock: Update
* [`607d8fad`](https://github.com/nix-community/home-manager/commit/607d8fad96436b134424b9935166a7cd0884003e) i3-sway: quote output names ([nix-community/home-manager⁠#4059](https://togithub.com/nix-community/home-manager/issues/4059))
