### PR TITLE
niv devenv: update 873e7901 -> 92ae3568

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "873e7901efcefe8f0000975adc8b3b9b58c41fc4",
-        "sha256": "06rzsdi464kk3zmwwjry2h160lwk2hs32s0s2wnxv050ablrlci1",
+        "rev": "92ae3568a0f463e6c7334e54a21a3b7e4ffb014e",
+        "sha256": "0iansfr6hvkl5anllv2wi2bkr6ss1p669paly1n9db7n6ig3kp9h",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/873e7901efcefe8f0000975adc8b3b9b58c41fc4.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/92ae3568a0f463e6c7334e54a21a3b7e4ffb014e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@873e7901...92ae3568](https://github.com/cachix/devenv/compare/873e7901efcefe8f0000975adc8b3b9b58c41fc4...92ae3568a0f463e6c7334e54a21a3b7e4ffb014e)

* [`c867e9c5`](https://github.com/cachix/devenv/commit/c867e9c529af99a0332299da50c01ad6af1ed183) Add readiness check for memcached
* [`a3498924`](https://github.com/cachix/devenv/commit/a349892412ac769d2486ed7fd6a8b6931ecd7bd8) Add memcached to process-compose example
* [`638c315b`](https://github.com/cachix/devenv/commit/638c315b277050eb8beaca493249233fad7a9ccc) haskell: Parameterize `stack` package
* [`31db563d`](https://github.com/cachix/devenv/commit/31db563da6eab90575a34b85d605acfb8278c120) Auto generate docs/reference/options.md
