### PR TITLE
niv home-manager: update 607d8fad -> 28614ed7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "607d8fad96436b134424b9935166a7cd0884003e",
-        "sha256": "0l85b6q7ff258lk3kx19flra8ajhf9mym81ijpknnz21yq979q7q",
+        "rev": "28614ed7a1e3ace824c122237bdc0e5e0b62c5c3",
+        "sha256": "0mlzfgp2v2kibn5p60aw2mdbwh6ymy2xqlpwafg85krv2xk4r941",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/607d8fad96436b134424b9935166a7cd0884003e.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/28614ed7a1e3ace824c122237bdc0e5e0b62c5c3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@607d8fad...28614ed7](https://github.com/nix-community/home-manager/compare/607d8fad96436b134424b9935166a7cd0884003e...28614ed7a1e3ace824c122237bdc0e5e0b62c5c3)

* [`24d590cc`](https://github.com/nix-community/home-manager/commit/24d590cc32ca9c685668c3e5a67e57327613d32f) wezterm: add integrations for Bash and Zsh ([nix-community/home-manager⁠#3934](https://togithub.com/nix-community/home-manager/issues/3934))
* [`79e03fbe`](https://github.com/nix-community/home-manager/commit/79e03fbe24dde6fe10662723870400d87a9cb40d) lib: remove listOrDagOf type
* [`28614ed7`](https://github.com/nix-community/home-manager/commit/28614ed7a1e3ace824c122237bdc0e5e0b62c5c3) lib: add functions to create DAGs from lists
