### PR TITLE
niv nixpkgs: update cfebfa1f -> 94f1362d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cfebfa1f4a0279c0208b5e0f0b408770c4316023",
-        "sha256": "1bva7bvrypwjk5ymsprpvi9yvssf36l1xgbwcjq58f9sk7dh5z61",
+        "rev": "94f1362dc88c55be6b4c6886f2e937e9e86c6943",
+        "sha256": "00w7n93jgc9aw2hzqjd4nl9v8m1ls8mfx9g1hwzg8gqbv29g5rwb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/cfebfa1f4a0279c0208b5e0f0b408770c4316023.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/94f1362dc88c55be6b4c6886f2e937e9e86c6943.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@cfebfa1f...94f1362d](https://github.com/nixos/nixpkgs/compare/cfebfa1f4a0279c0208b5e0f0b408770c4316023...94f1362dc88c55be6b4c6886f2e937e9e86c6943)

* [`d06ff9a1`](https://github.com/NixOS/nixpkgs/commit/d06ff9a1e11a8260d197484d235d7bd6ff29c61e) s5: init at 0.1.12
* [`7af30ade`](https://github.com/NixOS/nixpkgs/commit/7af30ade700b87cdc6f75754faeb00f3c44a1bca) brutefir: init at 1.0o
* [`f8de38cc`](https://github.com/NixOS/nixpkgs/commit/f8de38cc1202de407d7473fe0c11597af341d421) yash: 2.53 -> 2.54
* [`cf4dfd7d`](https://github.com/NixOS/nixpkgs/commit/cf4dfd7d3a814287c578608571d02b8c01afb248) rex: 1.13.4 -> 1.14.0
* [`8c17fe98`](https://github.com/NixOS/nixpkgs/commit/8c17fe986a9eca75f5eb4b1bfc9174018427c4ba) nixos/hedgedoc: allow `clientSecret` to be null
* [`8ca0687b`](https://github.com/NixOS/nixpkgs/commit/8ca0687b97298518ec7a074427de074d06ebc20a) nixos/nano: refactor nanorc creation
* [`6a611866`](https://github.com/NixOS/nixpkgs/commit/6a611866aeaeb59941d286a1191d48533a2b131f) rubyPackages.bulma-clean-theme: init at 0.13.1
* [`2fe08b98`](https://github.com/NixOS/nixpkgs/commit/2fe08b98288373247a46cfec5f0b9ea05a310794) aqbanking: 6.5.3 -> 6.5.4
* [`b379febf`](https://github.com/NixOS/nixpkgs/commit/b379febffbf19c0508d08cbac86d2940b1f79b7a) coreboot-utils: fix cross-compilation
* [`65046891`](https://github.com/NixOS/nixpkgs/commit/650468916e4c43ff3484339074d45641d9e30472) streamdeck-ui: add qt5.qtwayland on linux as dependency
* [`aecce41a`](https://github.com/NixOS/nixpkgs/commit/aecce41aa6c471946108e81ae9a9534850ea2e1e) mdslides: init at unstable-2022-12-15
* [`d7e66095`](https://github.com/NixOS/nixpkgs/commit/d7e6609505d1b533133414d0df77413a8257209c) coreutils: 9.1 -> 9.3
* [`65366c06`](https://github.com/NixOS/nixpkgs/commit/65366c0602e2042f6bd045204dd13aa2dc5749fa) coreutils: Re-enable hole seeking on Darwin
* [`7af8ace2`](https://github.com/NixOS/nixpkgs/commit/7af8ace239b12d21a3f1aef32b87f1fd79c00c36) nixos/smokeping: Format smokeping source code
* [`804bb25f`](https://github.com/NixOS/nixpkgs/commit/804bb25f486e1e8640551532b49045f0d9c43f9e) photoprism: 221118-e58fee0fb -> 230506-9de9a3540
* [`ab4ec73b`](https://github.com/NixOS/nixpkgs/commit/ab4ec73b99473730d02073089326ccece6e599b5) rdkafka: rename repo owner
* [`b93cf7fc`](https://github.com/NixOS/nixpkgs/commit/b93cf7fc8a9bbc6af4395e71f70bc14487279916) grpc-interceptor: init at 0.15.1
* [`c9378b03`](https://github.com/NixOS/nixpkgs/commit/c9378b033dfc45f394f43a72f8d34c4b5d4054d0) zrythm: 1.0.0-beta.4.6.3 -> 1.0.0-beta.4.9.1
* [`61d68ad1`](https://github.com/NixOS/nixpkgs/commit/61d68ad177f0d5726d9a6229bb2fe3679543a1aa) maintainers: add tm-drtina
* [`c491427c`](https://github.com/NixOS/nixpkgs/commit/c491427c43641bed9f4d810e8de615cd072b37e4) python3Packages.argparse-dataclass: init at 1.0.0
* [`efa1227d`](https://github.com/NixOS/nixpkgs/commit/efa1227dca0b69ccd71d9586a19c67b9139b9457) ldtk: 1.3.2 -> 1.3.3
* [`e927275f`](https://github.com/NixOS/nixpkgs/commit/e927275ff0b2e3de9c4c8f0c541921d4565a18b1) photoprism: 230506-9de9a3540 -> 230513-0b780defb
* [`09aaa3d4`](https://github.com/NixOS/nixpkgs/commit/09aaa3d4f89318a14691871696355bd000bced88) vscodeEnv: add parens to fix optionals invocation in vscodeEnv.nix
* [`e035bf06`](https://github.com/NixOS/nixpkgs/commit/e035bf06c5ccd65fe0c2b19bfacfb0d130db0858) aws-secretsmanager-caching: fix missing setuptools at runtime
* [`b340d44a`](https://github.com/NixOS/nixpkgs/commit/b340d44a03616fdb41eec79edfd1b98e7dc139cc) oracle-instantclient: x86_64-linux 21.9.0.0.0 -> 21.10.0.0.0
* [`6e272215`](https://github.com/NixOS/nixpkgs/commit/6e272215fcfe088e0dd3532001173baf33341137) libopenmpt: 0.6.10 -> 0.7.1
* [`0bc3481a`](https://github.com/NixOS/nixpkgs/commit/0bc3481a19fb21404ba14a4d0eab8afd81052ed5) sord: extract "dev", "doc", "man" outputs
* [`8b0cc098`](https://github.com/NixOS/nixpkgs/commit/8b0cc098433231837c24e94149e8da24af9be7c8) libcap_ng: extract dev, man outputs
* [`a7853ab9`](https://github.com/NixOS/nixpkgs/commit/a7853ab93a06d5fe96ca77a17c5cbd422ea30a86) soxr: extract dev output
* [`d7a9402f`](https://github.com/NixOS/nixpkgs/commit/d7a9402f63e47acbc2d61599266374645b4cd6fe) vivictpp: init at 0.3.1
* [`2e12fc11`](https://github.com/NixOS/nixpkgs/commit/2e12fc11c5b87c241aecb35dcb2c19a606187c4d) qt6ct: init at 0.8
* [`5c08d4fa`](https://github.com/NixOS/nixpkgs/commit/5c08d4fa3e78d8af3e7529aa382e52ad13a566d9) nixos/qt: also install qt6ct if using qt5ct
* [`3ce4e70b`](https://github.com/NixOS/nixpkgs/commit/3ce4e70bda0612ae39604352f18eb25392658106) qt6Packages.qtstyleplugin-kvantum: init at 1.0.10
* [`39d29247`](https://github.com/NixOS/nixpkgs/commit/39d29247694680d7ca362026b3d6b760bd284a5e) emscripten: 3.1.24 -> 3.1.39
* [`8392a8ba`](https://github.com/NixOS/nixpkgs/commit/8392a8baa91cb35716b0b37d74542b8b44afbaf0) binaryen: 112 -> 113
* [`3ce34532`](https://github.com/NixOS/nixpkgs/commit/3ce345322d8a2f04c15ec246034db51ae3869926) json-c: fix build on LLVM 15+
* [`5d0918ec`](https://github.com/NixOS/nixpkgs/commit/5d0918ec3ca8035720b35a260e0318a2c92dc634) emscriptenPackages.libxml2: fix build on darwin
* [`c59c8796`](https://github.com/NixOS/nixpkgs/commit/c59c87962d03551adac82f947caa809e973ebe8c) openconnect: 9.01 -> 9.12
* [`ff488199`](https://github.com/NixOS/nixpkgs/commit/ff4881996e584d2b8462bef02f37face63ce75a8) darwin.apple_sdk_10_12.frameworks.System: init
* [`13532826`](https://github.com/NixOS/nixpkgs/commit/13532826524693318930574c2ead977ff66a6a83) far2l: remove libSystem hack
* [`35bb9e5a`](https://github.com/NixOS/nixpkgs/commit/35bb9e5ac77352bb2c9f7936bfc9a3384f68c2f6) monit: remove libSystem hack
* [`37c95bc8`](https://github.com/NixOS/nixpkgs/commit/37c95bc86883ef71af43dc8aeef3dad887d3b715) nixos/self-deploy: set after to requires, type to
* [`ab59da89`](https://github.com/NixOS/nixpkgs/commit/ab59da89555ec615c641e32996452c6c477e258c) apparmor: 3.1.3 -> 3.1.4
* [`2d63374a`](https://github.com/NixOS/nixpkgs/commit/2d63374a2911bebbd35f19a0af8aa75615234c23) nixosTests.apparmor: fix after 5252e855952c555469f081306584dd8a12959ded
* [`4f64a5c1`](https://github.com/NixOS/nixpkgs/commit/4f64a5c1415dd1f187fa0d19b95f8271e68589f4) nixosTests.apparmor: fix expected.rules
* [`5dc3bb5e`](https://github.com/NixOS/nixpkgs/commit/5dc3bb5e1426885f7589ec765eac31f473c2456c) gst_all_1.gst-plugins-bad: add option to build without gui libraries
* [`94baf8bf`](https://github.com/NixOS/nixpkgs/commit/94baf8bfd9110656f9fc022f12ec42ec8b1550fd) nixos/no-x-libs: add gst-plugins-bad
* [`34cdc0a9`](https://github.com/NixOS/nixpkgs/commit/34cdc0a9f9c042e2b23d9fba5fb0780b090d6fae) gst_all_1.gst-plugins-rs: fix build if gst-plugins-base is build without gl
* [`354600ac`](https://github.com/NixOS/nixpkgs/commit/354600acec89da417358c4226d0616c156cb7456) jitsi-meet: 1.0.6943 -> 1.0.7235
* [`b3e7774d`](https://github.com/NixOS/nixpkgs/commit/b3e7774d215fd5b89eab4a11417b76844eb4e1b3) xpra: 4.4.4 -> 4.4.5
* [`719a4274`](https://github.com/NixOS/nixpkgs/commit/719a4274e8dc5c52113912a89f9df11d1b001c17) mupdf: 1.21.1 -> 1.22.1
* [`57c353f2`](https://github.com/NixOS/nixpkgs/commit/57c353f2066250847c4525a0c6774c3d724909d2) tracker: pull fix pending upstream inclusion for sqlite-3.42.0 support
* [`8b001c38`](https://github.com/NixOS/nixpkgs/commit/8b001c38c261b638a9a1048c85091d089b819b21) ell: 0.56 -> 0.57
* [`b3210448`](https://github.com/NixOS/nixpkgs/commit/b3210448b94ae374010bb732691e1af1df145f95) kernelPatches.fix-em-ice-bonding: remove
* [`a98aaa50`](https://github.com/NixOS/nixpkgs/commit/a98aaa50313a80115157aeb3ee986366c473adaf) dbus: fix build with Darwin sandbox enabled
* [`51a0839f`](https://github.com/NixOS/nixpkgs/commit/51a0839f725b74ccbca7d63b37b5e967329e6b3c) openldap: fix build on Darwin with sandbox enabled
* [`b1e19579`](https://github.com/NixOS/nixpkgs/commit/b1e19579348b80256192941b387f15d2da98353f) libglvnd: fix build with newer clang
* [`ea5c5d44`](https://github.com/NixOS/nixpkgs/commit/ea5c5d44dbe2a399e8ab6df2d9b8fac3c7f49d6b) ffmpeg_4: 4.4.3 -> 4.4.4
* [`dca8139f`](https://github.com/NixOS/nixpkgs/commit/dca8139f96aec5f9435c60e85f56fda6ad4ff7af) gnu-efi: patch to fix build for riscv64
* [`6a6598d5`](https://github.com/NixOS/nixpkgs/commit/6a6598d5be4c395a75c391362581c3921a311289) gnu-efi: add nickcao to maintainers
* [`c5f569a0`](https://github.com/NixOS/nixpkgs/commit/c5f569a09aa6b87390be253151ded5d4cee4baab) lua5_4: 5.4.4 -> 5.4.6
* [`6c71202d`](https://github.com/NixOS/nixpkgs/commit/6c71202df2eecd15d2b34b2f4f399a9c411bcc58) binutils: fix CVE-2023-1972
* [`a9b654ab`](https://github.com/NixOS/nixpkgs/commit/a9b654ab35f3d9bd0f75e0530bda2d5dbd961c05) meson: fix build with case-sensitive store on Darwin
* [`50d19221`](https://github.com/NixOS/nixpkgs/commit/50d192213f54cae93d7536f6a8ab71b8c89a2e42) libssh: fix build with newer clang
* [`6f02d8f9`](https://github.com/NixOS/nixpkgs/commit/6f02d8f9d09991429d59976fb020f504534a6c63) meson: save out-of-tree patches locally
* [`3b052229`](https://github.com/NixOS/nixpkgs/commit/3b0522299a073a9a77c8e31213505dad4d7eec2c) aflplusplus: 2.64c -> 4.05c
* [`2619e471`](https://github.com/NixOS/nixpkgs/commit/2619e47187e4c81200fd467a2bd7c4d6290a85fc) python310Packages.verspec: init at 0.1.0
* [`f6209b44`](https://github.com/NixOS/nixpkgs/commit/f6209b44440106d8df224ba3a051e3a0be778e8d) python310Packages.mike: init at 2023-05-06
* [`8939bd58`](https://github.com/NixOS/nixpkgs/commit/8939bd58931385dbfe586810a19205e9a967f45f) python310Packages.pydantic: 1.10.7 -> 1.10.8
* [`44a91fd4`](https://github.com/NixOS/nixpkgs/commit/44a91fd4bb4b68644fc8950ecb178a213437d58e) python310Packages.pydantic: add changelog to meta
* [`cf9bb1f7`](https://github.com/NixOS/nixpkgs/commit/cf9bb1f7dd17bdde9647389814b6815e8bf382d5) xpra: add changelog to meta
* [`12912eb6`](https://github.com/NixOS/nixpkgs/commit/12912eb612e86f02f3229dd0bdab589bdc6ed59c) twitch-chat-downloader: switch to maintained fork
* [`70aa5ef3`](https://github.com/NixOS/nixpkgs/commit/70aa5ef316bddf8102631760eeec968aca2a4a9a) amdvlk: 2023.Q2.1 -> 2023.Q2.2
* [`c78434b2`](https://github.com/NixOS/nixpkgs/commit/c78434b2cd028f808db1619c47642872f36c657b) gcc12: 12.2.0 -> 12.3.0
* [`5d119a26`](https://github.com/NixOS/nixpkgs/commit/5d119a26aaca516c276040dd2aa799e82289d5df) mirrors/gcc: push 'bigsearch' lower
* [`675a2733`](https://github.com/NixOS/nixpkgs/commit/675a2733c5888e8393da000e36708a80764fad97) http-parser: enable parallel building
* [`19ceafd2`](https://github.com/NixOS/nixpkgs/commit/19ceafd2abd7ca44d03ff95471e471eecfb3d2a8) dblab: init at 0.20.0
* [`dc6fd4b5`](https://github.com/NixOS/nixpkgs/commit/dc6fd4b5e7e6e0788448f2e8f7370aa2a163838f) graphviz: drop libdevil backend
* [`53c4a138`](https://github.com/NixOS/nixpkgs/commit/53c4a1381ff1a2c4d6e725f008da4fd1a291bbf6) qt5: update patches
* [`e0b6ea2f`](https://github.com/NixOS/nixpkgs/commit/e0b6ea2f7afdf045326054468e148867d9620b48) maintainers: add LucaGuerra
* [`d6ef6621`](https://github.com/NixOS/nixpkgs/commit/d6ef66212ba90dcffb1207ba86d5a85ebf02ecd8) lz4: fix cross compilation to linux
* [`c7b1d6b8`](https://github.com/NixOS/nixpkgs/commit/c7b1d6b8d0fd88dba90cc515956c3bba7a03c5cd) ffmpeg: remove withLTO option
* [`d933e272`](https://github.com/NixOS/nixpkgs/commit/d933e2728683ea44fdc0571c8be7b62fc34b591b) c-ares: 1.19.0 -> 1.19.1
* [`47f22c96`](https://github.com/NixOS/nixpkgs/commit/47f22c968376a2b100aab5e3ba4c2fa92ea813e6) python310Packages.anyio: 3.6.2 -> 3.7.0
* [`de811dcf`](https://github.com/NixOS/nixpkgs/commit/de811dcf691336a78bcc33bc84785aa325d4c4be) maintainers: add nielsegberts
* [`d6628cff`](https://github.com/NixOS/nixpkgs/commit/d6628cffd1d192b506aa99eda080971bfb3a8f52) gettext: 0.21 -> 0.21.1
* [`43f61cf8`](https://github.com/NixOS/nixpkgs/commit/43f61cf8d47009a1ff44c20fd202641b3f1de79c) libvterm-neovim: 0.3.1 -> 0.3.2
* [`d3edadc4`](https://github.com/NixOS/nixpkgs/commit/d3edadc491f05f105ded0fb5c026e1a21b336ab2) mesa_22_3: drop
* [`fcb01998`](https://github.com/NixOS/nixpkgs/commit/fcb01998279625e12ea6917478cb9fe18d7d504c) mesa: mark as broken on darwin
* [`7f7ab8be`](https://github.com/NixOS/nixpkgs/commit/7f7ab8be9713618c1ed5f51287b8ace58c55da84) mesa: 23.0.3 -> 23.1.1
* [`061f3a19`](https://github.com/NixOS/nixpkgs/commit/061f3a192d6c0f271977768f60b8157deaa6fec5) gst-plugins: exclude mesa dependency on darwin
* [`4062535a`](https://github.com/NixOS/nixpkgs/commit/4062535a3ef0b7f75bea95906e84a428bc9884f7) SDL2: exclude mesa dependency on darwin
* [`f2d0adda`](https://github.com/NixOS/nixpkgs/commit/f2d0addab63d04e210ec82d25e3de11fa37d07db) python3Packages.flask: 2.2.3 -> 2.2.5
* [`d121e1cd`](https://github.com/NixOS/nixpkgs/commit/d121e1cd49613a48c3d0cc4a2fd8d2d40688c48c) SDL2_ttf: drop libGL on darwin
* [`de988db9`](https://github.com/NixOS/nixpkgs/commit/de988db9c97e37cfec8418f18d872ce6d53cd1f4) init at 11.0.2
* [`dc9aa0c8`](https://github.com/NixOS/nixpkgs/commit/dc9aa0c84c812581dd6c5944f232880ed1d69be8) libcs50: init at 11.0.2
* [`b9d1dde3`](https://github.com/NixOS/nixpkgs/commit/b9d1dde37ba8f039c28b3d38e85aa3c919740a2a) pkg-config: fix build with newer clang
* [`db335972`](https://github.com/NixOS/nixpkgs/commit/db33597286f6e47a6936e6888b78ea14252c511a) python3Packages.poetry-core: fix build with newer clang
* [`50f1dbc5`](https://github.com/NixOS/nixpkgs/commit/50f1dbc5ede04954274d58aa1c21dfc0b2b0ad8d) cairo: fix build with newer clang
* [`56480a72`](https://github.com/NixOS/nixpkgs/commit/56480a72c917b020ee8d1ae64f30ef349a513675) darwin.adv_cmds: fix implicit int, which is an error in clang 16
* [`c9b93786`](https://github.com/NixOS/nixpkgs/commit/c9b9378674d6c75c5c190da56e66a04bdc80258b) libidn2: drop Darwin error patch
* [`e10c3398`](https://github.com/NixOS/nixpkgs/commit/e10c33986ce73f4b103e9ab3203a5e11f4c850a1) nss_esr: backport gcc-13 fix
* [`1a29857b`](https://github.com/NixOS/nixpkgs/commit/1a29857b8a93f5259f0c2e919becc0bf9db24f85) stdenv/setup.sh: deal with Nix < 2.4 structured attrs
* [`9de90335`](https://github.com/NixOS/nixpkgs/commit/9de90335f9058a3cb628bc576ce208a8281521eb) gcc13: drop already upstreamed mingwW64 patch
* [`0b499eb8`](https://github.com/NixOS/nixpkgs/commit/0b499eb86239cae23e52ba7c8ad2c3d30e6ed5b8) python3Packages.cffi: fix build with newer clang
* [`74dd80c6`](https://github.com/NixOS/nixpkgs/commit/74dd80c693582318e48e4ddbcceef57e5e54f2c1) perlPackages.FinanceQuote: 1.55 -> 1.56
* [`4c8943c8`](https://github.com/NixOS/nixpkgs/commit/4c8943c83097f2366213a2467e38ee09864b2175) nomad: add bash completion
* [`6f554cca`](https://github.com/NixOS/nixpkgs/commit/6f554cca37c21fe8b48f030a36d9b252ac87e713) sqlite: 3.41.2 -> 3.42.0
* [`dd0dee4c`](https://github.com/NixOS/nixpkgs/commit/dd0dee4c97bc517e6c9bc1964778eb61651a1180) autoPatchelfHook: Add support for single files
* [`e79e306a`](https://github.com/NixOS/nixpkgs/commit/e79e306aa93ea6000a96c6f3faf75a38c2d74050) qq: 3.1.2-12912 -> 3.1.2-13107
* [`1aa68d1d`](https://github.com/NixOS/nixpkgs/commit/1aa68d1d21c2101ed003bc55a45730226ac30c2a) xnu: fix build with newer clang
* [`73e5ebfc`](https://github.com/NixOS/nixpkgs/commit/73e5ebfce572c12c71b4a6131cf8b3d9348d4ef2) openssl: 3.0.8 -> 3.0.9 ([nixos/nixpkgs⁠#235006](https://togithub.com/nixos/nixpkgs/issues/235006))
* [`40312724`](https://github.com/NixOS/nixpkgs/commit/40312724c6cef1b340e4e8cda3371fdb333c69bc) CODEOWNERS: reduce scope for fricklerhandwerk
* [`a91f6eba`](https://github.com/NixOS/nixpkgs/commit/a91f6eba1e40545e9b323988fda4cd27561c6009) buildGoPackage: remove `ldflags` and `with builtins`
* [`aea73adf`](https://github.com/NixOS/nixpkgs/commit/aea73adfddadfd4df2d6851991a45a9fb603c9d7) buildGo{Module,Package}: remove input argument "tags"
* [`6727bab0`](https://github.com/NixOS/nixpkgs/commit/6727bab05eb516fa3c6ec53c39c4b7499ee55539) systemd-boot: Patch for firmwares that fail to load large files
* [`df7b1829`](https://github.com/NixOS/nixpkgs/commit/df7b182922671c0b83a080084c475ab91450efcd) tetraproc: fix typo
* [`2f85a3ce`](https://github.com/NixOS/nixpkgs/commit/2f85a3ce1c4da94727cc3e25b367de6c0793edf3) tig: fix typo
* [`3565fdf3`](https://github.com/NixOS/nixpkgs/commit/3565fdf30c0bd455a8d99c6a09a393a25c25fd9f) pkgs/build-support: fix typos
* [`29f3903f`](https://github.com/NixOS/nixpkgs/commit/29f3903f622bf206d479cfd536392104af8e4f45) nix-prefetch-git: fix typo
* [`0eb3ea39`](https://github.com/NixOS/nixpkgs/commit/0eb3ea39970441d5468e05d380226ed928743a85) xen: fix typo
* [`58f559cd`](https://github.com/NixOS/nixpkgs/commit/58f559cdb0de5c88f75b397f9ed7229bec898034) gperf: fix build with clang 16
* [`259b15f2`](https://github.com/NixOS/nixpkgs/commit/259b15f25d4d98ac8c097cb5d9b2aa76482ceb40) rewrite-tbd: avoid infinite recursion when cmake is not cmakeMinimal
* [`7b44d1b1`](https://github.com/NixOS/nixpkgs/commit/7b44d1b1bcda3eccef49b44c37d78be17504ddcd) mysql-shell: unpin protobuf
* [`96d38da8`](https://github.com/NixOS/nixpkgs/commit/96d38da8e393b9723afabf17becc6e78fe451d1a) all-cabal-hashes: 2023-05-30T03:47:42Z -> 2023-05-31T06:44:49Z
* [`138d6b44`](https://github.com/NixOS/nixpkgs/commit/138d6b446388e85f3f7d8c0d6661a46519aa3530) haskellPackages: regenerate package set based on current config
* [`268a7bab`](https://github.com/NixOS/nixpkgs/commit/268a7bab34430c5b6f50e379653ccbda4fff4a9b) libssh2: 1.10.0 -> 1.11.0
* [`e1c7d577`](https://github.com/NixOS/nixpkgs/commit/e1c7d5776f090ac68451be7a271c19371dc85a2b) python3Packages.cacheyou: init at 23.3
* [`f0f0ab20`](https://github.com/NixOS/nixpkgs/commit/f0f0ab209e68fa1e9739d7676ca0bb728f2a6a1c) pdm: 2.6.1 -> 2.7.0
* [`450d3f71`](https://github.com/NixOS/nixpkgs/commit/450d3f71238b8bd717442f99510a8a85508b3019) filebot: 5.0.2 -> 5.0.3
* [`cbea42d3`](https://github.com/NixOS/nixpkgs/commit/cbea42d369bae323ed9fc050b294aa69c7a22dbe) wizer: 1.6.0 -> 3.0.1
* [`0ad178d9`](https://github.com/NixOS/nixpkgs/commit/0ad178d902aee02c3538098aafe8a75ed619a8c6) tk: hardcode path to TK_LIBRARY
* [`8a6917f7`](https://github.com/NixOS/nixpkgs/commit/8a6917f715543d7ca3480ef15770c595241d7a87) thonny: drop TK_LIBRARY
* [`0c813b23`](https://github.com/NixOS/nixpkgs/commit/0c813b23401e2472028e23e8c0111512e6396882) opencv: add patches for CVE-2023-2617 & CVE-2023-2618
* [`0fa17e3f`](https://github.com/NixOS/nixpkgs/commit/0fa17e3f9a1a7bc6317ccf43688e15bf6e04e1ab) unison: M4h -> M4i
* [`01a87851`](https://github.com/NixOS/nixpkgs/commit/01a87851f46c668ae57121954be639e5866d8f0c) python311Packages.pyroute2: 0.7.8 -> 0.7.9
* [`c54049db`](https://github.com/NixOS/nixpkgs/commit/c54049db5cd08f410a162be0eddc6fbdb751f2dc) cargo-msrv: avoid updating rc and beta releases
* [`369ffe0a`](https://github.com/NixOS/nixpkgs/commit/369ffe0a4a94ee9f787160064fe95f59085e3667) jenkins: 2.387.2 -> 2.401.1
* [`c1265476`](https://github.com/NixOS/nixpkgs/commit/c12654760c29c26407fc7f19db76339f256cd85e) haskellPackages.mkDerivation: small clean up
* [`9babdca0`](https://github.com/NixOS/nixpkgs/commit/9babdca06c91655d8b3110ff231d6b1c92aa161a) go-migrate: 4.15.2 -> 4.16.0
* [`457bc623`](https://github.com/NixOS/nixpkgs/commit/457bc6234a9f451c9e6a82b263e3d2a22ea414c9) libsForQt5.mlt: 7.14.0 -> 7.16.0
* [`01e06549`](https://github.com/NixOS/nixpkgs/commit/01e06549c6db0a7fc54da02d4ed19f63bf1d336d) util-linux: backport patches fixing mount on older kernels
* [`d1ca66c5`](https://github.com/NixOS/nixpkgs/commit/d1ca66c578c1cde4f494d20416cad8f158d2d52d) wlsunset: 0.2.0 -> 0.3.0
* [`5a372bc2`](https://github.com/NixOS/nixpkgs/commit/5a372bc2fa4809933e61835b02a7927d8e8368a7) sqlite3-to-mysql: 1.4.16 -> 1.4.19
* [`34f8702a`](https://github.com/NixOS/nixpkgs/commit/34f8702a482204b668e10f78fe3662692d4272fb) falcoctl: init at 0.5.0
* [`31b198ad`](https://github.com/NixOS/nixpkgs/commit/31b198ad6fc85ee8af80771063dda06a99de043f) dtc: fix linker options so it also works in Darwin
* [`219b3970`](https://github.com/NixOS/nixpkgs/commit/219b397071617fb3a71be757f64f0586be971ad4) dtc: avoid building tests in case doCheck is disabled
* [`a5ba7119`](https://github.com/NixOS/nixpkgs/commit/a5ba7119689205dfceadb9426af1b7f276f2e341) hishtory: init at 0.208
* [`df0c65cf`](https://github.com/NixOS/nixpkgs/commit/df0c65cf19ca44118285050d2764bd3af3e60624) dolt: 0.40.28 -> 1.2.2
* [`54216d1f`](https://github.com/NixOS/nixpkgs/commit/54216d1f5a51d00dd18c4a2817d008f27657d54d) dtc: remove postFixup as meson installs the dylib properly
* [`4c3e82df`](https://github.com/NixOS/nixpkgs/commit/4c3e82df39cf68b803123eb664f19c2b088478dd) libcs50: init at 11.0.2
* [`3c389546`](https://github.com/NixOS/nixpkgs/commit/3c389546e505d316adc82e1fb5d5172a74a01f1c) libcs50: init at 11.0.2
* [`b9705cfa`](https://github.com/NixOS/nixpkgs/commit/b9705cfa422cff771a067dad14d64c775d416ddb) nwg-dock-hyprland: init at 0.1.2
* [`4ebf00ed`](https://github.com/NixOS/nixpkgs/commit/4ebf00ed431b64f8ce0c91634116bcc37b687476) nix: 2.13.3 -> 2.15.1
* [`794f6f1f`](https://github.com/NixOS/nixpkgs/commit/794f6f1f25e792cdac7b52c84c2c833a9feb7193) fzf: build with CGO_ENABLED=0
* [`588022ae`](https://github.com/NixOS/nixpkgs/commit/588022aef7abae20ee90deecd9f8e74cf26aed53) nodePackages: expose nodejs attribute
* [`d4fe69fa`](https://github.com/NixOS/nixpkgs/commit/d4fe69faeaeb6dc0d7b8ba6a55098f1482db1dec) nix-fallback-paths.nix: Update to 2.15.1
* [`26f1090e`](https://github.com/NixOS/nixpkgs/commit/26f1090e1792526fb450a2f9c1c48e67c2471e14) cimg: 3.2.4 -> 3.2.5
* [`84fb288f`](https://github.com/NixOS/nixpkgs/commit/84fb288f46faa746b0718060f396a875529eae14) cups: fix nixos test references
* [`2ca22f6b`](https://github.com/NixOS/nixpkgs/commit/2ca22f6b823eb38c8e182e5bae39d40ebbe87c59) cups: 2.4.2 -> 2.4.3
* [`5b90f7a6`](https://github.com/NixOS/nixpkgs/commit/5b90f7a6a942ec630ea24cc202bb2a57b3f726a4) coding-conventions: include the preceding upstream version when packaging a commit without a version attached
* [`cdedbea0`](https://github.com/NixOS/nixpkgs/commit/cdedbea00a4c4dc6a77373c7ff7af99fa9a99e71) dpkg: 1.21.21ubuntu1 -> 1.21.22
* [`59948084`](https://github.com/NixOS/nixpkgs/commit/59948084487e20337e481daddbacb08251dab499) criu: add gnutar and gzip in PATH
* [`550ed635`](https://github.com/NixOS/nixpkgs/commit/550ed635d444e1b6fdf838878c2b0e019a1d5a31) rke2: 1.27.1+rke2r1 -> 1.27.2+rke2r1
* [`cbc146cf`](https://github.com/NixOS/nixpkgs/commit/cbc146cf93208e6aede09f64b9b7f8c0931918d0) libxc: 6.1.0 -> 6.2.0
* [`295ff35f`](https://github.com/NixOS/nixpkgs/commit/295ff35f2410dff5fb897567abe3b13fa621a2df) cc-wrapper: try to better guess meta.mainProgram
* [`2a5125b4`](https://github.com/NixOS/nixpkgs/commit/2a5125b4f725c06899a3234b47a4b4a90d64b9f8) llvmPackages_16: 16.0.1 -> 16.0.5
* [`916f9bca`](https://github.com/NixOS/nixpkgs/commit/916f9bcaee1e9e101617d0bfe70b9fe1e5249017) jpexs: 15.0.0 -> 18.4.1
* [`5b482ad5`](https://github.com/NixOS/nixpkgs/commit/5b482ad5b2837872ae2370a46bdf17ebab6a7a9d) tuifimanager: 2.3.4 -> 3.0.0
* [`cc3ee6d8`](https://github.com/NixOS/nixpkgs/commit/cc3ee6d82b575a5f105124498ebf01abcdf98604) Revert [nixos/nixpkgs⁠#230601](https://togithub.com/nixos/nixpkgs/issues/230601): "gnu-efi: 3.0.15 -> 3.0.17"
* [`36613013`](https://github.com/NixOS/nixpkgs/commit/36613013753cd58cb1f934090db6dc49233a5587) tandoor-recipes: 1.4.9 -> 1.4.12
* [`6bd9402c`](https://github.com/NixOS/nixpkgs/commit/6bd9402c5ff2e6450689666e5fd6ae8c8ef3c70a) cups: fix build on darwin
* [`16eb3e00`](https://github.com/NixOS/nixpkgs/commit/16eb3e00ca3e7e02964b57e13a17b9a88d154988) mdbook: 0.4.29 -> 0.4.30
* [`03ba3aae`](https://github.com/NixOS/nixpkgs/commit/03ba3aae127d19edabb60690351a58a99e0281c0) wibo: 0.3.0 -> 0.4.2
* [`8f0515db`](https://github.com/NixOS/nixpkgs/commit/8f0515dbf74c886b61639ccad5a1ea7c2f51265d) emacs.pkgs.treesit-grammars: refactor
* [`0498957e`](https://github.com/NixOS/nixpkgs/commit/0498957eac499b1280c008b9fec77b7f1a830b0d) nixos/smokeping: Fix smokeping preStart systemd
* [`9ea7d9a4`](https://github.com/NixOS/nixpkgs/commit/9ea7d9a4ce244f36598cbe83270a37c05818a1a4) Revert Merge [nixos/nixpkgs⁠#234128](https://togithub.com/nixos/nixpkgs/issues/234128): gnu-efi: patch to fix build for riscv64
* [`af903dfb`](https://github.com/NixOS/nixpkgs/commit/af903dfb0ce6b7e38bf94b6773113387db8ad002) chirp: unstable-2023-03-15 -> unstable-2023-06-02
* [`ddb34194`](https://github.com/NixOS/nixpkgs/commit/ddb341942c1a72198eceabc0024ce37c90cd6766) haskellPackages.clash-prelude: Mark broken only for GHC 9.2
* [`59d55eab`](https://github.com/NixOS/nixpkgs/commit/59d55eab4c36efcf20b4586c3cfe2b4df212d2da) haskellPackages: maint. coinor-clp, linear-programming, comfort-blas
* [`4994570a`](https://github.com/NixOS/nixpkgs/commit/4994570ab3bc5a94363cc91d008be773147861d1) lammps: Add doronbehar as maintainer
* [`5d92bfbb`](https://github.com/NixOS/nixpkgs/commit/5d92bfbb4c3180cb2b4343d01a0f92d896fad8f6) gnome.mutter43: 43.5 → 43.6
* [`c48a125f`](https://github.com/NixOS/nixpkgs/commit/c48a125faae225aeb1dd6c6699241520a1ac39ca) planus: init at 0.4.0
* [`e8f5f874`](https://github.com/NixOS/nixpkgs/commit/e8f5f8745461e18c9da44923f53f7fa7d3995577) maintainers: add lukaswrz
* [`3e8f3147`](https://github.com/NixOS/nixpkgs/commit/3e8f314771c92b4cc9fb87b03e7e3b3d21e82b33) lavat: Init at 2.0.0
* [`4c101ed3`](https://github.com/NixOS/nixpkgs/commit/4c101ed35764fbd7efcd2eadd56bf2a4ff51ea24) photoprism: 230513-0b780defb -> 230603-378d4746a
* [`1f3b4712`](https://github.com/NixOS/nixpkgs/commit/1f3b4712f5a87a7b02f2f72f1d08578f668195f2) egglog: init at unstable-2023-05-22
* [`9c04f9ec`](https://github.com/NixOS/nixpkgs/commit/9c04f9ec7d03dcfcbe22eb927991a34123c40067) git-credential-keepassxc: 0.12.0 -> 0.13.0
* [`66c6053b`](https://github.com/NixOS/nixpkgs/commit/66c6053b10b6623457b68b2ec7e0fb2a7c651313) lammps: 29Oct2020 -> 23Jun2022_update4
* [`39f6dbc3`](https://github.com/NixOS/nixpkgs/commit/39f6dbc3792b88ce6572a95b1a26108393ff2e29) gvisor: 20221102.1 -> 20230529.0
* [`5d126b14`](https://github.com/NixOS/nixpkgs/commit/5d126b145a4861193947dd0a39da56d755fc7ebe) vyper: 0.3.8 -> 0.3.9
* [`513dc55d`](https://github.com/NixOS/nixpkgs/commit/513dc55db61fe9c8a15f862d640b2d3ed724318d) intel-cmt-cat: 4.5.0 -> 4.6.0
* [`0d394b14`](https://github.com/NixOS/nixpkgs/commit/0d394b14280f49eb5d39a297715ac7cd1511bc60) pacproxy: init at 2.0.5
* [`cdced93f`](https://github.com/NixOS/nixpkgs/commit/cdced93fd4fd5b5b7b1b350588b5dfa6237a7417) ent-go: 0.11.0 -> 0.12.3
* [`431e42eb`](https://github.com/NixOS/nixpkgs/commit/431e42eb13573b4064e150d3fa7180504f58fd8b) ent-go: unpin go
* [`984d7a10`](https://github.com/NixOS/nixpkgs/commit/984d7a10d19c89bae91a2fc32cff2f0b4f656bed) thiefmd: 0.2.5 -> 0.2.7
* [`04b8795d`](https://github.com/NixOS/nixpkgs/commit/04b8795d8ee09dbca2a1c7e9ec14911ddc23c35e) hdf5_1_10: mark vulnerable
* [`ef06a18b`](https://github.com/NixOS/nixpkgs/commit/ef06a18b11c3d47791b463d6659ea5033c6c68c5) galene: 0.7.0 -> 0.7.1
* [`52f3a1c4`](https://github.com/NixOS/nixpkgs/commit/52f3a1c42ce20135eb7074e2d325daa09126d83f) fetchgit: require sparseCheckout be a list of strings
* [`62de9b1c`](https://github.com/NixOS/nixpkgs/commit/62de9b1c93ff3f2cfd2e5a99b0181f28d17080a8) krill: 0.13.0 -> 0.13.1
* [`ca78d062`](https://github.com/NixOS/nixpkgs/commit/ca78d062a73ffa7f37bfdc9c863467355cf60a11) ocserv: 1.1.6 -> 1.1.7
* [`b2138be2`](https://github.com/NixOS/nixpkgs/commit/b2138be293b56ceefa391bf42d81c8040a656a5e) unifiedpush-common-proxies: 1.3.0 -> 1.5.0
* [`37a9952b`](https://github.com/NixOS/nixpkgs/commit/37a9952b431535a71dc43a144ccad556755216f0) unifiedpush-common-proxies: unpin go
* [`fd9d20bf`](https://github.com/NixOS/nixpkgs/commit/fd9d20bfd5b701051d0f03762f010f0752457c56) python311Packages.wagtail: disable on unsupported Python releases
* [`8e4b25c4`](https://github.com/NixOS/nixpkgs/commit/8e4b25c4b032063106164badc1be4129bc340813) python311Packages.wagtail-localize: disable failing test
* [`08d9e34f`](https://github.com/NixOS/nixpkgs/commit/08d9e34f03e1cdd25b25e2d55f278ea99faf628e) bluez-alsa: 4.0.0 -> 4.1.0
* [`48a0434a`](https://github.com/NixOS/nixpkgs/commit/48a0434ae792d78c343bc6cdae14250537ea8348) python3Packages.apache-airflow: 2.5.1 -> 2.6.0
* [`092fc911`](https://github.com/NixOS/nixpkgs/commit/092fc91112e01e5568384454846bea0d4f2dd0b0) python3Packages.flask-appbuilder: 4.2.1 -> 4.3.1
* [`33d6d0cc`](https://github.com/NixOS/nixpkgs/commit/33d6d0cce80c0f68f0212d09d381d2c8eef39f1b) python3Packages.python-daemon: 2.3.0 -> 3.0.1
* [`f9599292`](https://github.com/NixOS/nixpkgs/commit/f95992929d5e17427322a6997a236316bedcc05c) python3Packages.rich-argparse: init at 1.1.0
* [`3a124e90`](https://github.com/NixOS/nixpkgs/commit/3a124e9033160dcc2c143975a68663d1ea7e27eb) ocenaudio: 3.11.25 -> 3.12.2
* [`0ce8040f`](https://github.com/NixOS/nixpkgs/commit/0ce8040f6b55388b621b69a93077a0af79ea5349) python3Packages.sv-ttk: init at 2.4.5
* [`ac0254d4`](https://github.com/NixOS/nixpkgs/commit/ac0254d4c8299b9dff24c18206274dd102d059a7) sccache: 0.5.2 -> 0.5.3
* [`5dfcee77`](https://github.com/NixOS/nixpkgs/commit/5dfcee77945aca69685472c1b16acdac6fb209a7) waycorner: init at 0.2.1
* [`46f30a03`](https://github.com/NixOS/nixpkgs/commit/46f30a032e1d83c552e1d50356f0ff4ff596e285) libvlc: fix build by providing openssl
* [`7da24051`](https://github.com/NixOS/nixpkgs/commit/7da24051923f23ebe22ea176a7b826b07bd77eef) python3Packages.apsw: 3.41.0 -> 3.42.0 ([nixos/nixpkgs⁠#233027](https://togithub.com/nixos/nixpkgs/issues/233027))
* [`3cf373b2`](https://github.com/NixOS/nixpkgs/commit/3cf373b299655179c92cb2705b5b36ead1af480e) comodoro: init at 0.0.8
* [`1f3cc522`](https://github.com/NixOS/nixpkgs/commit/1f3cc522ba37076f4912a5a785cb424003ab4540) iosevka: 24.1.0 -> 24.1.1
* [`2d6b28f0`](https://github.com/NixOS/nixpkgs/commit/2d6b28f0680eb5a03c95d51101788ea7f0d70a33) emacsPackages.elpaDevelPackages: init
* [`1dbc3047`](https://github.com/NixOS/nixpkgs/commit/1dbc3047591787a4b8cd4001124ee0a3389d77d4) google-cloud-cpp: extend .meta.platforms
* [`efd6f2ac`](https://github.com/NixOS/nixpkgs/commit/efd6f2ac3085883b07b539227180550fc2456838) google-cloud-cpp: downgrade a warning on aarch64-linux
* [`add8dd84`](https://github.com/NixOS/nixpkgs/commit/add8dd840205aa9539d37591829eff3b48dd1359) google-cloud-cpp: schedule on big-parallel machines
* [`b4e5de4b`](https://github.com/NixOS/nixpkgs/commit/b4e5de4ba4666951e501a01e1d1483531ce32009) nixos/hardware/i2c: fix uaccess rule
* [`07310e59`](https://github.com/NixOS/nixpkgs/commit/07310e59a62ae8e5b7e15580e06e085cd9ea0a70) Revert "google-cloud-cpp: schedule on big-parallel machines"
* [`37b72120`](https://github.com/NixOS/nixpkgs/commit/37b721206e8cfaa635d2415f2b91056e55577acd) fclones: 0.30.0 -> 0.31.0, add figsoda as a maintainer
* [`c7474746`](https://github.com/NixOS/nixpkgs/commit/c747474697d9deb5d823a0763e5c57c75e7a4bba) bfc: mark as broken on aarch64-linux
* [`845ed634`](https://github.com/NixOS/nixpkgs/commit/845ed6342efc552afd6b58d7b4cb37868b5173fa) plasma5Packages.kcoreaddons: add darwin support
* [`8902dfbe`](https://github.com/NixOS/nixpkgs/commit/8902dfbe468700847ce8bcd7b6c0e3ee79843e20) plasma5Packages.qqc2-desktop-style: add darwin support
* [`8f7d2c18`](https://github.com/NixOS/nixpkgs/commit/8f7d2c182909a46058deaf56903aeee032684222) plasma5Packages.ktexteditor: add darwin support
* [`b9ed2ba5`](https://github.com/NixOS/nixpkgs/commit/b9ed2ba5165ec0a18f0c338074fe22a05b7f32d3) plasma5Packages: relax platforms
* [`9b6f9e46`](https://github.com/NixOS/nixpkgs/commit/9b6f9e462436c27dade3f263a337d67625f27b32) nixos/tests/taskserver: Fix build
* [`ab1a5558`](https://github.com/NixOS/nixpkgs/commit/ab1a55581989d069a4bbccf2c951d3c48a34f099) bookletimposer: fix "ValueError: Namespace Gtk not available"
* [`c805bb68`](https://github.com/NixOS/nixpkgs/commit/c805bb680168f9832d7f273cc74841c6a9bf8d2b) python311Packages.pyschlage: init at 2023.5.0
* [`af17209b`](https://github.com/NixOS/nixpkgs/commit/af17209b793318646a8c4c2bfe588755a89eb502) renderdoc: 1.26 -> 1.27
* [`93fc2ce7`](https://github.com/NixOS/nixpkgs/commit/93fc2ce7c0dcbbc036d3148fc7c51f8caea89887) python311Packages.django-stubs-ext: 4.2.0 -> 4.2.1
* [`00949fae`](https://github.com/NixOS/nixpkgs/commit/00949faeb31c0eca568555681cc179c96726ea0c) nerdctl: 1.3.1 -> 1.4.0
* [`45cb7359`](https://github.com/NixOS/nixpkgs/commit/45cb7359f825ea18ba5f6e482089fb71ccc032f1) dufs: 0.33.0 -> 0.34.1
* [`a818ffcc`](https://github.com/NixOS/nixpkgs/commit/a818ffcc548aec9b77ab180feb8ca3570c102d98) sentry-native: 0.6.2 -> 0.6.3
* [`e86d6235`](https://github.com/NixOS/nixpkgs/commit/e86d62355e5913e5d46d6d47344851bc32aeb911) kora-icon-theme: 1.5.6 -> 1.5.7
* [`1db6ed08`](https://github.com/NixOS/nixpkgs/commit/1db6ed088587a8783fed13fcb9870960e456a99e) berglas: fix version
* [`c9d6b8a2`](https://github.com/NixOS/nixpkgs/commit/c9d6b8a2bac3d3d869533a00629e7924c2695b04) berglas: add version test
* [`0427c4cc`](https://github.com/NixOS/nixpkgs/commit/0427c4cc090657c7315febd38bc40eebdd21f754) argc: 1.2.0 -> 1.3.0
* [`14aa5c4d`](https://github.com/NixOS/nixpkgs/commit/14aa5c4db195dfaf9923be8dda9e5bb85fe175ab) python311Packages.django-stubs-ext: drop outdated postPatch
* [`5176a4f1`](https://github.com/NixOS/nixpkgs/commit/5176a4f11356a338331d82e63563f8510b67317d) nixos: Use systemd-makefs for autoFormat
* [`b4975023`](https://github.com/NixOS/nixpkgs/commit/b497502357c0f944c839e645097f44a7c3279971) nixos: Use systemd-growfs for autoResize
* [`4f21db7e`](https://github.com/NixOS/nixpkgs/commit/4f21db7edf268744ab28d3de5843507e33ae2f7e) containerd: 1.7.1 -> 1.7.2
* [`0aa6a144`](https://github.com/NixOS/nixpkgs/commit/0aa6a144bd31199d2e1904483f43ad579d0620e0) faudio: 23.05 -> 23.06
* [`d31ea9f4`](https://github.com/NixOS/nixpkgs/commit/d31ea9f454db93212a451c0b0a88b4cba9a99237) zsh-forgit: 23.05.0 -> 23.06.0
* [`6ecc0520`](https://github.com/NixOS/nixpkgs/commit/6ecc05202e27151addd53042f1a174ccaa84ebe5) nebula: 1.7.1 -> 1.7.2
* [`7789efcf`](https://github.com/NixOS/nixpkgs/commit/7789efcfd34c29d217e1a29dbe715de6ef1e3093) Revert "Merge [nixos/nixpkgs⁠#235219](https://togithub.com/nixos/nixpkgs/issues/235219): llvmPackages_16: 16.0.1 -> 16.0.5"
* [`39e30fa4`](https://github.com/NixOS/nixpkgs/commit/39e30fa40e26b2e7a0afbee4689c57519dc6e165) wasmtime: 9.0.2 -> 9.0.3
* [`03b12fe9`](https://github.com/NixOS/nixpkgs/commit/03b12fe93e9544f2e24864075c22ba249559447a) shipyard: 0.5.2 -> 0.5.27
* [`ee29a69f`](https://github.com/NixOS/nixpkgs/commit/ee29a69fce242f263c516c4a2fe9cdfd77e98b0b) jackett: 0.21.114 -> 0.21.128
* [`a73a51b4`](https://github.com/NixOS/nixpkgs/commit/a73a51b43e826da500932ff7251bab4fee770f1c) zed: 1.7.0 -> 1.8.1
* [`674f0300`](https://github.com/NixOS/nixpkgs/commit/674f0300a49ddf81df8f510d35ad089c7167ab86) akkoma: 3.8.0 -> 3.9.3
* [`7b4cdeb6`](https://github.com/NixOS/nixpkgs/commit/7b4cdeb609ce113ec189819ecd09a9f6ea30f913) akkoma-fe: 2023-04-14 -> 2023-05-23
* [`9047bfe2`](https://github.com/NixOS/nixpkgs/commit/9047bfe2cda86edd00e67c90891a163a410b6b82) exploitdb: 2023-06-03 -> 2023-06-05
* [`b41324c0`](https://github.com/NixOS/nixpkgs/commit/b41324c0874bf40ec83dd65c43b8aa885dadc9c1) haskellPackages.hercules-ci-agent: add 'Do not chdir the build worker' patch
* [`dd6a3acf`](https://github.com/NixOS/nixpkgs/commit/dd6a3acff377ab3133a0adb99335a74e1701c7b7) librewolf: 113.0-3 -> 113.0.2-1
* [`24251811`](https://github.com/NixOS/nixpkgs/commit/24251811ad81788b76cd1a45f69b2b9719904ac1) kubescape: 2.3.4 -> 2.3.5
* [`04ed5679`](https://github.com/NixOS/nixpkgs/commit/04ed5679329ac6863f655fdeca332a18c36b621d) subtitlr: 0.1.0 -> 0.1.1
* [`4a1b4968`](https://github.com/NixOS/nixpkgs/commit/4a1b4968e368591a0b598ff678d61afa6fc91607) sing-geoip.generator: unstable-2022-07-05 -> 20230512
* [`3553c7d4`](https://github.com/NixOS/nixpkgs/commit/3553c7d4fd7c750734853b7cc14b466656dd5b7d) metasploit: 6.3.18 -> 6.3.19
* [`a49f2aa0`](https://github.com/NixOS/nixpkgs/commit/a49f2aa0450a6681ef6aaf4fc62562d475103513) python310Packages.imageio: unbreak on darwin
* [`92fae8aa`](https://github.com/NixOS/nixpkgs/commit/92fae8aa90a6a7b69a684342c916a888e14ea253) dnsx: 1.1.1 -> 1.1.4
* [`2bfa0ebd`](https://github.com/NixOS/nixpkgs/commit/2bfa0ebd131dc2ee8fa077a87401d8bd9c94ca72) blink: fix build on x86_64-darwin
* [`0bc9fe18`](https://github.com/NixOS/nixpkgs/commit/0bc9fe18cfb9d9780c8d08c44c681a3337c5b464) unparam: unstable-2021-12-14 -> unstable-2023-03-12
* [`b97dce16`](https://github.com/NixOS/nixpkgs/commit/b97dce16bdfc480ee761b3a3f906c0ccabda93b8) python311Packages.dvc-data: 0.54.2 -> 0.54.3
* [`1c6dd060`](https://github.com/NixOS/nixpkgs/commit/1c6dd06094ebbd959974aee877e4e77c32851690) python311Packages.peaqevcore: 18.0.6 -> 18.1.1
* [`77318633`](https://github.com/NixOS/nixpkgs/commit/77318633ba6b2eb2e0c32417ad03244397624edf) python311Packages.pyquil: 3.5.2 -> 3.5.4
* [`d26057e9`](https://github.com/NixOS/nixpkgs/commit/d26057e90ba470feeb8a8cb416ff2cc06e87eff5) python311Packages.python-roborock: 0.21.0 -> 0.21.1
* [`acb79214`](https://github.com/NixOS/nixpkgs/commit/acb792148179dd40b781142e099d97ae2145a715) python311Packages.dwdwfsapi: 1.0.6 -> 1.0.7
* [`3f4fab2b`](https://github.com/NixOS/nixpkgs/commit/3f4fab2b847b3e6340c543bd03c4892d20d03d26) python311Packages.dwdwfsapi: add changelog to meta
* [`898d1c18`](https://github.com/NixOS/nixpkgs/commit/898d1c18f560a20c3749bcf1d7f4dea3ca745cc4) python311Packages.getmac: 0.9.3 -> 0.9.4
* [`4e59b918`](https://github.com/NixOS/nixpkgs/commit/4e59b91865dfe66ac336ecbd757253c04dfe6a3b) flrig: 2.0.0 -> 2.0.01
* [`72a51aa1`](https://github.com/NixOS/nixpkgs/commit/72a51aa1b1c7a32cf3fa2e93a801d6df4bc378f5) python311Packages.pyipp: 0.13.0 -> 0.14.1
* [`56ffd31b`](https://github.com/NixOS/nixpkgs/commit/56ffd31b7732e8603a2133e0c0ac0c65be9c3acd) python311Packages.zeroconf: 0.63.0 -> 0.64.0
* [`1e0a1334`](https://github.com/NixOS/nixpkgs/commit/1e0a13349f70642da520494cb16b223f28cae458) python311Packages.wallbox: 0.4.12 -> 0.4.14
* [`5567510f`](https://github.com/NixOS/nixpkgs/commit/5567510f9e54f33125d3ccad021a63739e318532) python311Packages.wallbox: add changelog to meta
* [`0d8edf79`](https://github.com/NixOS/nixpkgs/commit/0d8edf794256da892a3b49cd99593f39d64219dd) python311Packages.blinkpy: 0.20.0 -> 0.21.0
* [`35e670ca`](https://github.com/NixOS/nixpkgs/commit/35e670cae6bc4b7113efc9cdc8fe552dee3e896b) python311Packages.transmission-rpc: 4.2.2 -> 4.3.0
* [`a7e6f9c0`](https://github.com/NixOS/nixpkgs/commit/a7e6f9c0425625d8cd91815d2e2e9f46ce65f304) python311Packages.hass-nabucasa: 0.66.2 -> 0.67.1
* [`4e01b2eb`](https://github.com/NixOS/nixpkgs/commit/4e01b2eba6310919ce99035583dc4014a2d11c0b) python311Packages.croniter: 1.3.14 -> 1.3.15
* [`92f83095`](https://github.com/NixOS/nixpkgs/commit/92f83095da543ccfc37ebc9c95b94d1850c12544) python311Packages.croniter: add changelog to meta
* [`a68ba824`](https://github.com/NixOS/nixpkgs/commit/a68ba8249129c9b48066cc04d16d0cce2bcb71f4) diesel-cli: 2.0.1 -> 2.1.0
* [`f3e5af36`](https://github.com/NixOS/nixpkgs/commit/f3e5af3683d16e1fc1ae928f0a41f333f2e64f68) alacritty: unbreak on darwin
* [`748cb091`](https://github.com/NixOS/nixpkgs/commit/748cb0913f4d40f21406aaeaeb06737630ad939f) rabbitmq-server: 3.11.10 -> 3.12.0
* [`424d1f9b`](https://github.com/NixOS/nixpkgs/commit/424d1f9b6c0820138f02d79ec0de97d625acb70d) sc-controller: 0.4.8.9 -> 0.4.8.11
* [`87354cb6`](https://github.com/NixOS/nixpkgs/commit/87354cb640274192865ee082f44ae141e4e82bd2) pyrtlsdr: 0.2.7 -> 0.2.93
* [`522463b4`](https://github.com/NixOS/nixpkgs/commit/522463b4f22f04ee870cff8b8eb1c80b0ae3b6a9) python310Packages.pyopengl: unbreak on darwin
* [`83ff7cdc`](https://github.com/NixOS/nixpkgs/commit/83ff7cdc656b2953ef02f22cf3d8df3c44d243a4) rapidyaml: init at 0.5.0
* [`50511e0a`](https://github.com/NixOS/nixpkgs/commit/50511e0a272f7f3ddc80277601b8f5c70615cb70) ansible-language-server: 1.0.4 -> 1.0.5
* [`0f14e3bf`](https://github.com/NixOS/nixpkgs/commit/0f14e3bf1912c3a8b0213e4c174e9dcff22541ec) python3Packages.rasterio: fix execution of Python test suite
* [`8d630481`](https://github.com/NixOS/nixpkgs/commit/8d630481b36500d65d6b5b8bb5e419e0314bb00b) mkvtoolnix: 76.0 -> 77.0
* [`e695f6af`](https://github.com/NixOS/nixpkgs/commit/e695f6af174339c7e3c53ad0254323b8464ea9a9) python3Packages.geopandas: 0.13.0 -> 0.13.1
* [`11f7b66f`](https://github.com/NixOS/nixpkgs/commit/11f7b66fdf3a094bc5499f10e1bf34717e4382b3) filebrowser: init at 2.23.0
* [`465a8b33`](https://github.com/NixOS/nixpkgs/commit/465a8b33d508ccc32610272e149eec2964177526) nerdfonts: 3.0.1 -> 3.0.2
* [`0c2d8f11`](https://github.com/NixOS/nixpkgs/commit/0c2d8f11c01457cc65b6390dac376f303d365dfe) monotone: unpin boost170
* [`45a924fb`](https://github.com/NixOS/nixpkgs/commit/45a924fb47f7735ae2d21e7d342400b618f5e3ac) python311Packages.pysnooz: 0.8.4 -> 0.8.5
* [`f9a0f4a6`](https://github.com/NixOS/nixpkgs/commit/f9a0f4a620090300271a243b2aec06fa6218bc62) pcsx2: 1.7.3331 -> 1.7.4554
* [`fe6850b6`](https://github.com/NixOS/nixpkgs/commit/fe6850b67cbe820997532fa2021e323d04740b3d) Revert "binaryen: 112 -> 113" (part of PR [nixos/nixpkgs⁠#229718](https://togithub.com/nixos/nixpkgs/issues/229718))
* [`ba9cb938`](https://github.com/NixOS/nixpkgs/commit/ba9cb93813ec9e912f6f1ba9b13eddbabe476299) Revert "emscripten: 3.1.24 -> 3.1.39" (part of PR [nixos/nixpkgs⁠#229718](https://togithub.com/nixos/nixpkgs/issues/229718))
* [`e86547dd`](https://github.com/NixOS/nixpkgs/commit/e86547dd43445bb31e56067543ccf6022980215a) blink: use checkTarget
* [`c3f3039f`](https://github.com/NixOS/nixpkgs/commit/c3f3039fe38f88f8c4f3e106cbaa2a5f7aec76de) paperwork: also install paperwork-json
* [`b28dd99d`](https://github.com/NixOS/nixpkgs/commit/b28dd99d9e1e255172b7e95813c83b23695a941a) rgp: 1.15 -> 1.15.1
* [`4649e2c6`](https://github.com/NixOS/nixpkgs/commit/4649e2c604dd8d5000ffce957e0e687f49bcaab4) vulkan-cts: 1.3.5.2 -> 1.3.6.0
* [`bdd343ec`](https://github.com/NixOS/nixpkgs/commit/bdd343ece720a653b61ba0efeb8435d802cb3de1) chessdb: drop TK_LIBRARY
* [`a6f42ce4`](https://github.com/NixOS/nixpkgs/commit/a6f42ce4cfa7e2f8ca844abc8c1ea3f9d8d89943) vkeybd: drop TK_LIBRARY
* [`440c4bd0`](https://github.com/NixOS/nixpkgs/commit/440c4bd0ec002a0d5fd7064fff333419dfd2eae1) wordnet: drop TK_LIBRARY
* [`fdcd339e`](https://github.com/NixOS/nixpkgs/commit/fdcd339e76c06ff732b62420f4d836717ddcad69) qogir-icon-theme: 2023-02-23 -> 2023-06-05
* [`6a050b80`](https://github.com/NixOS/nixpkgs/commit/6a050b80fa37f59ca8de60170a0571cd85cb78df) fetchMixDeps: transition to hash
* [`da072c0d`](https://github.com/NixOS/nixpkgs/commit/da072c0d594456cd309f79785b4a97408e3562ac) gluesql: init at 0.14.0
* [`4ebd93e6`](https://github.com/NixOS/nixpkgs/commit/4ebd93e6669bbb718bc5957a0673d6dce311be51) python311Packages.gehomesdk: 0.5.10 -> 0.5.11
* [`c346b9ce`](https://github.com/NixOS/nixpkgs/commit/c346b9ce227bda38ee656e3e24e30b38ad9440be) scid: 4.3 -> 5.0.2
* [`796031c1`](https://github.com/NixOS/nixpkgs/commit/796031c1db7d8db6bd2c47fdc9934db60a4230cc) rsign2: 0.6.2 -> 0.6.3
* [`af702af3`](https://github.com/NixOS/nixpkgs/commit/af702af3527f37f3c47fd765f82053092b5572c1) cpp-netlib: unpin boost169
* [`eaf0edf4`](https://github.com/NixOS/nixpkgs/commit/eaf0edf4af0586a381220fca9e0a692a0f83e7c0) ycmd: unpin boost174
* [`6f6b3e3f`](https://github.com/NixOS/nixpkgs/commit/6f6b3e3f1bbc85705a65ea3e02e21625e0156f4f) librime: unpin boost174
* [`a1caaaf7`](https://github.com/NixOS/nixpkgs/commit/a1caaaf7a432c85f84d92371d76a22020510cd12) libnest2d: unpin boost174
* [`b4222d66`](https://github.com/NixOS/nixpkgs/commit/b4222d66617edc4eb3e31fd515c0704165eae806) python: add conditionals to be able to compile with 3.6 or older
* [`9f3e0de1`](https://github.com/NixOS/nixpkgs/commit/9f3e0de184cd5efa6fe7012db2a3d6a98f6907c7) cypthon: moduralize so it can be called with other versions
* [`9d83529d`](https://github.com/NixOS/nixpkgs/commit/9d83529d7f1d359a90040069f7040f429288ab06) licenses: add Caldera and Info-Zip
* [`fb7ca344`](https://github.com/NixOS/nixpkgs/commit/fb7ca344ad5116261be724aa3325c2358d7b3b5d) minimal-bootstrap.heirloom-devtools: init at 070527
* [`9883fd26`](https://github.com/NixOS/nixpkgs/commit/9883fd26cdf1b5476837f6351616a90bc59534ad) minimal-bootstrap.heirloom: init at 070715
* [`1c56e6a8`](https://github.com/NixOS/nixpkgs/commit/1c56e6a840c6be18da089b93c102a06fedfb8562) firefox-unwrapped: 113.0.2 -> 114.0
* [`8030e154`](https://github.com/NixOS/nixpkgs/commit/8030e154caa9971aa4387e1bdb25f8af1b0c6355) firefox-bin-unwrapped: 113.0.2 -> 114.0
* [`d083027e`](https://github.com/NixOS/nixpkgs/commit/d083027ea596861f06ed3cf4f274fd857047c24a) firefox-esr-102-unwrapped: 102.11.0esr -> 102.12.0esr
* [`5a54b575`](https://github.com/NixOS/nixpkgs/commit/5a54b575784f168ec8b6d4f001ab23d0c26913b6) easysnap: don't use -n
* [`afe337e6`](https://github.com/NixOS/nixpkgs/commit/afe337e62e361c8028bcf066f07d49d79abf696d) metals: don't use cp -n
* [`57e1ea5a`](https://github.com/NixOS/nixpkgs/commit/57e1ea5a18d2c96d166a9edb341aaaeae24d0691) nixos/libvirtd: don't use cp -n
* [`a91653fe`](https://github.com/NixOS/nixpkgs/commit/a91653fe7919d123c4ce5f9e668c7fd57a529152) composable_kernel: wat
* [`9b804b89`](https://github.com/NixOS/nixpkgs/commit/9b804b8941f64fc979470081e7c2048934a88c77) cudaPackages.cudatoolkit: mark libnvrtc-builtins needed for libnvrtc
* [`4a5db704`](https://github.com/NixOS/nixpkgs/commit/4a5db704ee15647b738c22f90525ddc128614683) aaaaxy: 1.4.2 -> 1.4.6
* [`4f9b6e18`](https://github.com/NixOS/nixpkgs/commit/4f9b6e18708359d0906bda81b3c805ad17603de2) speedtest-go: 1.6.2 -> 1.6.3
* [`7afe3ce0`](https://github.com/NixOS/nixpkgs/commit/7afe3ce0b073cd417b18b3651979efb275ec6c81) python3Packages.sfepy: 2022.3 -> 2023.1
* [`7fab78b0`](https://github.com/NixOS/nixpkgs/commit/7fab78b0e1116efa20b162228994eb3a8e8de7fe) pluto: 5.16.3 -> 5.16.4
* [`634fa771`](https://github.com/NixOS/nixpkgs/commit/634fa7716ba4c67b02270b56a8438e400c5bfe38) python310Packages.tidalapi: 0.7.0 -> 0.7.1
* [`ae280978`](https://github.com/NixOS/nixpkgs/commit/ae280978f39d59feef84efdeec5861bf64354b46) btrfs-progs: 6.3 -> 6.3.1
* [`573b91a2`](https://github.com/NixOS/nixpkgs/commit/573b91a20db4b6000f9f411e80e734a8c8ec2145) cargo-shuttle: 0.17.0 -> 0.18.0
* [`05ba2c2a`](https://github.com/NixOS/nixpkgs/commit/05ba2c2a0112c9c3c7f6380975bd344248d5ce91) cardboard: set meta.knownVulnerabilities
* [`c79b173d`](https://github.com/NixOS/nixpkgs/commit/c79b173db5b4a61782d0afb8a798ac15ff355301) linuxPackages.nvidia_x11_beta: fix optix denoiser
* [`cc208010`](https://github.com/NixOS/nixpkgs/commit/cc20801002cdfa867adee8117088c8a81214de7a) djot-js: init at 0.2.3
* [`a6ccec37`](https://github.com/NixOS/nixpkgs/commit/a6ccec371af23fe382170e623eef70d9e2d1f115) python310Packages.django_4: 4.2.1 -> 4.2.2
* [`29112957`](https://github.com/NixOS/nixpkgs/commit/29112957e03fade73fc1f318f3ced5f9c7e8d049) libsForQt5.kimageannotator: 0.6.0 -> 0.6.1
* [`66cd9e42`](https://github.com/NixOS/nixpkgs/commit/66cd9e425dca1bc8feaa772b58b00dc57b6ce6c7) jotdown: init at 0.3.0
* [`54be076a`](https://github.com/NixOS/nixpkgs/commit/54be076ae77da1f45fbc6c88419657f828e6237e) nixos/exim: apply privilege restrictions
* [`08126bf3`](https://github.com/NixOS/nixpkgs/commit/08126bf314038095936690896a81f0d6a7385b4e) apache-airflow: remove from main pythonPackages
* [`18a4f8fd`](https://github.com/NixOS/nixpkgs/commit/18a4f8fd6a3a77a4fee3747f41da1328e1134884) cargo-workspaces: unset verifyCargoDeps
* [`5f0f7b82`](https://github.com/NixOS/nixpkgs/commit/5f0f7b822b037406d16498e23edee0d785a73d77) elmPackages.elm-test-rs: unset verifyCargoDeps
* [`ac9053b0`](https://github.com/NixOS/nixpkgs/commit/ac9053b0205e9085991b7cfcdc40637c35d262e7) solana: unset verifyCargoDeps
* [`25762896`](https://github.com/NixOS/nixpkgs/commit/25762896dc4fa20b3a3753cff07f7db16788219b) solana-validator: unset verifyCargoDeps, remove unused parameters
* [`70c41b8d`](https://github.com/NixOS/nixpkgs/commit/70c41b8db192c8d807a9e2bee6dfa543237be9fe) python310Packages.apscheduler: 3.10.0 -> 3.10.1
* [`5c816ce3`](https://github.com/NixOS/nixpkgs/commit/5c816ce341d32b10f7900e7e966b8b7694d33525) python3Packages.apache-airflow: add entry to python-aliases.nix declaring its removal
* [`23a95f14`](https://github.com/NixOS/nixpkgs/commit/23a95f14171cc131f13cb01674d3d53c3c082e2e) litecoin: migrate to boost177
* [`c9c6853c`](https://github.com/NixOS/nixpkgs/commit/c9c6853ceda3b2027a1f2490e8ecded2854d7240) rye: unstable-2023-04-23 -> 0.6.0
* [`6eea0513`](https://github.com/NixOS/nixpkgs/commit/6eea0513e4b62703062356442ce28f3817b4448b) python310Packages.wagtail-factories: 4.0.0 -> 4.1.0
* [`aae1c913`](https://github.com/NixOS/nixpkgs/commit/aae1c913c8c2265af445a84c4babe56c6d6e7c90) vimPlugins: update
* [`1d72634c`](https://github.com/NixOS/nixpkgs/commit/1d72634c0aaa6a6fa287b75b4382dedb5924cb74) vimPlugins: resolve github repository redirects
* [`802dccb9`](https://github.com/NixOS/nixpkgs/commit/802dccb900b9b86a210cfc849b1862be01b32f9b) vimPlugins.nvim-treesitter: update grammars
* [`07961f53`](https://github.com/NixOS/nixpkgs/commit/07961f5341722ac039f0cb7168cd78941301643a) python310Packages.jupyterlab-lsp: 4.0.1 -> 4.2.0
* [`98586c41`](https://github.com/NixOS/nixpkgs/commit/98586c419d710a035e123b12d7970a4ba711d869) minidlna: 1.3.2 -> 1.3.3
* [`6cf21cc3`](https://github.com/NixOS/nixpkgs/commit/6cf21cc370671d4e7dbe4bbfdf36638b67b1ac28) python310Packages.glom: 23.1.1 -> 23.3.0
* [`c229f485`](https://github.com/NixOS/nixpkgs/commit/c229f485d13f7685a8e9a57b084461c260e9b888) portfolio: 0.62.1 -> 0.63.1
* [`491a6bed`](https://github.com/NixOS/nixpkgs/commit/491a6bed5f720ef335353fc85d395f73a5dd654b) python310Packages.pydrive2: 1.15.3 -> 1.15.4
* [`7b48fd90`](https://github.com/NixOS/nixpkgs/commit/7b48fd902d695e3a100c34912b7e5323ecbc1be7) python310Packages.pytest-testmon: 2.0.6 -> 2.0.8
* [`fc11013c`](https://github.com/NixOS/nixpkgs/commit/fc11013c20ad195b78dce984d4b317ac1420cf9b) mozart2: unpin boost169
* [`d7d559e9`](https://github.com/NixOS/nixpkgs/commit/d7d559e9dc9d0dc3928889bb157890203416c042) python310Packages.asyncmy: 0.2.7 -> 0.2.8
* [`d2220210`](https://github.com/NixOS/nixpkgs/commit/d2220210ed100b3b88ffb7726c534de2466e086c) asciidoctorj: 2.5.8 -> 2.5.10
* [`dd8c5e5f`](https://github.com/NixOS/nixpkgs/commit/dd8c5e5f701e72ca46f285343a30fb0e7991f23a) lavat: replace fetchFromGitHub "sha256" with generic "hash" argument
* [`c282d8e5`](https://github.com/NixOS/nixpkgs/commit/c282d8e5a39d4760fe487e1c59d7a611192a56bf)  clickhouse: compress src to not exceed hydra limit ([nixos/nixpkgs⁠#236060](https://togithub.com/nixos/nixpkgs/issues/236060))
* [`d334c136`](https://github.com/NixOS/nixpkgs/commit/d334c136dedb03b4ff8292a2a14d16401ce3abd1) codespelunker: init at 1.0.0
* [`4fd6968b`](https://github.com/NixOS/nixpkgs/commit/4fd6968b01aa07064156dfba9eb66619bdff71b2) python310Packages.fenics: migrate to boost172
* [`7af82333`](https://github.com/NixOS/nixpkgs/commit/7af8233309e8b3fb468043dd7c8ade5a02f78411) rustypaste: 0.10.0 -> 0.10.1
* [`8a31dbd8`](https://github.com/NixOS/nixpkgs/commit/8a31dbd8946083b8a6d5722fc53c1350c2de15bd) python3Packages.kneed: init at 0.8.3
* [`03951cc2`](https://github.com/NixOS/nixpkgs/commit/03951cc24a04b6662083bfc62f7b4188d4e9a73b) _1password-gui: 8.10.6 -> 8.10.7
* [`58feedd1`](https://github.com/NixOS/nixpkgs/commit/58feedd1df098d6daa9d78f2bf9bf0e6fb0aeb41) erlang-ls: 0.46.2 -> 0.47.1
* [`2f3f758b`](https://github.com/NixOS/nixpkgs/commit/2f3f758b346ed03be56527ece34cad22ce31187f) sarasa-gothic: 0.40.7 -> 0.41.0
* [`374bc6b4`](https://github.com/NixOS/nixpkgs/commit/374bc6b470df5a4057b09a9eacb49559c83c9a7a) duckscript: 0.8.18 -> 0.8.19
* [`3219e1b6`](https://github.com/NixOS/nixpkgs/commit/3219e1b609291884efd13ded7b3a04cb1cd3f9a6) netbird: 0.20.8 -> 0.21.0
* [`1e3c63e8`](https://github.com/NixOS/nixpkgs/commit/1e3c63e8ad1c25ce9d00e833b3550bcb2d0c8804) gobgp: 3.14.0 -> 3.15.0
* [`e0402159`](https://github.com/NixOS/nixpkgs/commit/e0402159c1329156d6b225fd4cf2e357b8c05bca) chezmoi: 2.33.6 -> 2.34.0
* [`14d96ff6`](https://github.com/NixOS/nixpkgs/commit/14d96ff665fb5f95b97f828c93b64a7159edd632) icewm: 3.3.5 -> 3.4.0
* [`1df6f0d0`](https://github.com/NixOS/nixpkgs/commit/1df6f0d08ab3f9dc6b4cdf13a58d228a9c0962db) lapce: 0.2.7 -> 0.2.8
* [`e58b4a10`](https://github.com/NixOS/nixpkgs/commit/e58b4a101ba50a0a7e10015ec9996c39038e94c9) bun: 0.6.6 -> 0.6.7
* [`01f27b3a`](https://github.com/NixOS/nixpkgs/commit/01f27b3aab27e74b6581e2d8895f45636815321e) kodi.packages.steam-library: 0.8.1 -> 0.9.0
* [`276e5400`](https://github.com/NixOS/nixpkgs/commit/276e54000ed52125ea62946563c137e7422fd845) python3Packages.py-partiql-parser: init at 0.3.3
* [`656e46dd`](https://github.com/NixOS/nixpkgs/commit/656e46dd8f0ecdee62a48248bd80e77c3a1fdbdb) pocketbase: 0.16.3 -> 0.16.4
* [`339541ef`](https://github.com/NixOS/nixpkgs/commit/339541ef7de1d0fc44bb678a44469f3f67f3be79) kluctl: 2.20.2 -> 2.20.4
* [`7b150c86`](https://github.com/NixOS/nixpkgs/commit/7b150c862e626e15732e569e9d3fcfb6c2f63b3e) josm: 18721 -> 18746
* [`8549e37e`](https://github.com/NixOS/nixpkgs/commit/8549e37ebcff8916da2977416941dc521f24da16) bilibili: 1.10.1-1 -> 1.10.1-4
* [`005a176b`](https://github.com/NixOS/nixpkgs/commit/005a176bbe82b2d75801289ac17466ecbcc238fc) svd2rust: 0.28.0 -> 0.29.0
* [`9894760f`](https://github.com/NixOS/nixpkgs/commit/9894760f9c5c0ad05d29a796955a3594db5a59b5) apfsprogs: unstable-2023-05-16 -> unstable-2023-06-06
* [`37695f78`](https://github.com/NixOS/nixpkgs/commit/37695f78bb9bf6d2380304c94c5eb8607f25adbd) gnomeExtensions: compile schemas if present
* [`ef2bb9e1`](https://github.com/NixOS/nixpkgs/commit/ef2bb9e1ee29648da73cac14d20f04c112966896) minio-client: 2023-05-26T23-31-54Z -> 2023-05-30T22-41-38Z
* [`d7f28652`](https://github.com/NixOS/nixpkgs/commit/d7f28652048b3bed6a512542e62ea1a50691e349) buf: 1.20.0 -> 1.21.0
* [`ac24fe0d`](https://github.com/NixOS/nixpkgs/commit/ac24fe0d78841ddb1b1fcc9c5e12eb9bbf00e601) system76-keyboard-configurator: 1.3.3 -> 1.3.4
* [`6ae9c646`](https://github.com/NixOS/nixpkgs/commit/6ae9c6462ee79056447c784581ece6caff82a0a8) btcpayserver-altcoins: 1.10.0 -> 1.10.1
* [`5ec42ff5`](https://github.com/NixOS/nixpkgs/commit/5ec42ff5e943f6742d840e54f14a3d403a2269da) kubevirt: 0.59.0 -> 0.59.1
* [`f4449c13`](https://github.com/NixOS/nixpkgs/commit/f4449c134845fa1501facd621860bf449543e558) azure-storage-azcopy: 10.18.1 -> 10.19.0
* [`37dfd9d3`](https://github.com/NixOS/nixpkgs/commit/37dfd9d34c42b650d5b1deca47af4315aecbffa3) vtm: 0.9.9l -> 0.9.9m
* [`f479eedb`](https://github.com/NixOS/nixpkgs/commit/f479eedb71128bfcd52c608e17515046bce47e6a) hugo: 0.112.7 -> 0.113.0
* [`0b0942a0`](https://github.com/NixOS/nixpkgs/commit/0b0942a0e8a05bffaf907afe068a91242eb10a40) exoscale-cli: 1.69.0 -> 1.70.0
* [`16534366`](https://github.com/NixOS/nixpkgs/commit/165343664aa38ae448e35dcf63550ca13fdba0ab) terraform-providers.bigip: 1.17.1 -> 1.18.0
* [`287aef78`](https://github.com/NixOS/nixpkgs/commit/287aef7896470a3fc73cb6ebfeaa83fcd7e83853) terraform-providers.datadog: 3.25.0 -> 3.26.0
* [`ffe56945`](https://github.com/NixOS/nixpkgs/commit/ffe56945dbdc2cc8bbcb05a7689a6d0ee7ade73d) terraform-providers.equinix: 1.14.2 -> 1.14.3
* [`2cdba078`](https://github.com/NixOS/nixpkgs/commit/2cdba0786d5a2b27bca6d4de56a4eeb38bbac242) terraform-providers.google: 4.67.0 -> 4.68.0
* [`fc004699`](https://github.com/NixOS/nixpkgs/commit/fc0046998bb0fdc170053bccec9ac9ba3be13086) terraform-providers.google-beta: 4.67.0 -> 4.68.0
* [`20c59acd`](https://github.com/NixOS/nixpkgs/commit/20c59acd4a7ca87a74a3d544e697134917059e5c) terraform-providers.keycloak: 4.2.0 -> 4.3.0
* [`b7956e31`](https://github.com/NixOS/nixpkgs/commit/b7956e313a547df4fc66ffabc29a865ad3a5474e) terraform-providers.helm: 2.10.0 -> 2.10.1
* [`b142f5ad`](https://github.com/NixOS/nixpkgs/commit/b142f5ad68d149cfb78b5aad6c0871b334220d04) terraform-providers.kubernetes: 2.21.0 -> 2.21.1
* [`22467e24`](https://github.com/NixOS/nixpkgs/commit/22467e240f390f029d6c745ce031f0ffbdc40916) terraform-providers.spotinst: 1.121.0 -> 1.122.0
* [`974a6582`](https://github.com/NixOS/nixpkgs/commit/974a6582256abceca841d0206d4b4deb462ee8ee) prometheus-domain-exporter: 1.17.1 -> 1.21.1
* [`c1c81125`](https://github.com/NixOS/nixpkgs/commit/c1c81125f2b29c753de32c34e761628012c722f0) packer: 1.9.0 -> 1.9.1
* [`16e24b9c`](https://github.com/NixOS/nixpkgs/commit/16e24b9ce0e3f46971c9f862a0d60d5cc671310d) kubergrunt: 0.11.2 -> 0.11.3
* [`b1685df0`](https://github.com/NixOS/nixpkgs/commit/b1685df057273b621da537a21bccc24faedf4991) gnome.nautilus: 44.1 → 44.2.1
* [`8c49349c`](https://github.com/NixOS/nixpkgs/commit/8c49349c746bb9765223461025141a65d6ca0a4e) prowlarr: 1.4.1.3258 -> 1.5.2.3484
* [`b0ea292e`](https://github.com/NixOS/nixpkgs/commit/b0ea292eea70a36861bc3a0f7d22d836b7fc047f) eartag: 0.3.3 -> 0.4.0
* [`181398d1`](https://github.com/NixOS/nixpkgs/commit/181398d1de64d8b77005996158337426493254f4) xfce.xfce4-panel-profiles: 1.0.13 -> 1.0.14
* [`902abd54`](https://github.com/NixOS/nixpkgs/commit/902abd54b1b1597a7f1955130ef28c6033970c6e) toast: 0.47.3 -> 0.47.4
* [`ca10cb55`](https://github.com/NixOS/nixpkgs/commit/ca10cb55d9dbdc7b14add23558536040a1bc7c1d) dataexplorer: 3.7.7 -> 3.7.8
* [`3cdd5df1`](https://github.com/NixOS/nixpkgs/commit/3cdd5df17a49112a830a48753d8d4afdfbad07f5) skaffold: 2.4.1 -> 2.5.0
* [`71c758e1`](https://github.com/NixOS/nixpkgs/commit/71c758e19dfdcbe64d8e53ff2df305f8b5144b6f) gojq: 0.12.12 -> 0.12.13
* [`ebef2348`](https://github.com/NixOS/nixpkgs/commit/ebef2348149be0286899ee7ef192efd40ed17cd9) arc_unpacker: migrate to boost175
* [`d10a8262`](https://github.com/NixOS/nixpkgs/commit/d10a82624371c8ed4959455ec288d15c66b4fa42) grpc_cli: 1.55.0 -> 1.55.1
* [`085e4e9a`](https://github.com/NixOS/nixpkgs/commit/085e4e9a663e53832b805846ec9d226c1c45894b) gitlab: 16.0.1 -> 16.0.2 ([nixos/nixpkgs⁠#236150](https://togithub.com/nixos/nixpkgs/issues/236150))
* [`2a1346ed`](https://github.com/NixOS/nixpkgs/commit/2a1346edba7cb61b396e03cb6bc542404e019c1c) lagrange: 1.16.2 -> 1.16.3
* [`7cd71872`](https://github.com/NixOS/nixpkgs/commit/7cd71872549f1e6aa992dd74ec0402ce73c18b74) knot-dns: 3.2.6 -> 3.2.7
* [`5f2dc48e`](https://github.com/NixOS/nixpkgs/commit/5f2dc48ebab740dbd0b39dee8d4a1b8e3a743c0e) lima-bin: 0.15.1 -> 0.16.0
* [`20729ee2`](https://github.com/NixOS/nixpkgs/commit/20729ee2a5573a1e1cb9c69ae22100b01a8143ea) martin: 0.8.4 -> 0.8.6
* [`89369a73`](https://github.com/NixOS/nixpkgs/commit/89369a73f701a8c034d8f47fca041b965cbba9ad) grype: 0.62.2 -> 0.62.3
* [`59745a48`](https://github.com/NixOS/nixpkgs/commit/59745a48e0c58875b9175bf54bfb5369400909ff) python311Packages.aiounifi: 47 -> 48
* [`b15c9a09`](https://github.com/NixOS/nixpkgs/commit/b15c9a094a89c2fecf924b25e47c741e1c6cc3f7) xmrig-mo: 6.19.2-mo1 -> 6.19.3-mo1
* [`993a787b`](https://github.com/NixOS/nixpkgs/commit/993a787b22ed1aa483d712c7c5ffb83caf36a4c5) cudatext-gtk: 1.194.4 -> 1.195.0
* [`a3deb65c`](https://github.com/NixOS/nixpkgs/commit/a3deb65c596a71bee76984c8244596753cceecb1) pokerth, pokerth-server: unpin boost16x
* [`a1fc0a93`](https://github.com/NixOS/nixpkgs/commit/a1fc0a9375488be9dd62935088b54f4dacc79924) shipyard: rename to jumppad
* [`a64e32f9`](https://github.com/NixOS/nixpkgs/commit/a64e32f981af7d202580080a593448b501c0e20b) nc4nix: unstable-2023-05-25 -> unstable-2023-06-05
* [`afdb5e26`](https://github.com/NixOS/nixpkgs/commit/afdb5e26aa37805036964d6e1afb6f658cdf923e) goawk: 1.23.1 -> 1.23.2
* [`eacc7be1`](https://github.com/NixOS/nixpkgs/commit/eacc7be1e93a2b9b9c710ec8ccf8ba05db5b4bea) pigz: 2.6 -> 2.7 ([nixos/nixpkgs⁠#223504](https://togithub.com/nixos/nixpkgs/issues/223504))
* [`04c41a12`](https://github.com/NixOS/nixpkgs/commit/04c41a12cfcf2ec67a88e3ace841f1b51863a063) coqPackages.mathcomp-word: 2.0 → 2.1
* [`aa884b8f`](https://github.com/NixOS/nixpkgs/commit/aa884b8f3d5e5a3afb6bdcd21ebab8e55512f025) improve documentation for `nix.settings.sandbox` ([nixos/nixpkgs⁠#188541](https://togithub.com/nixos/nixpkgs/issues/188541))
* [`eda3b244`](https://github.com/NixOS/nixpkgs/commit/eda3b244e0923f5d0d1ddcde6aa48ab75bff6126) ddnet: 17.0.2 -> 17.0.3
* [`5d7bc2de`](https://github.com/NixOS/nixpkgs/commit/5d7bc2defd32a899579358a19bd8cd3664c65699) emulationstation: unpin boost169
* [`18c17409`](https://github.com/NixOS/nixpkgs/commit/18c1740930d80ec1943865659167be26f388241c) sioclient: init at unstable-2023-02-13
* [`e2a1c654`](https://github.com/NixOS/nixpkgs/commit/e2a1c6547a18f81956013c5b8b083a03af952513) freedv: 1.8.9 -> 1.8.10.1
* [`1e07f76f`](https://github.com/NixOS/nixpkgs/commit/1e07f76fa847e55a7043afd516a5b185af7d985e) maintainers: add vector1dev
* [`84147995`](https://github.com/NixOS/nixpkgs/commit/84147995a72c9eab7f9f7ccbca00492f5c0bd2ad) lenpaste: init at 1.3
* [`48c729b0`](https://github.com/NixOS/nixpkgs/commit/48c729b0aee20cc5ed7474ffe04418f2e6558652) python311Packages.elastic-apm: 6.15.1 -> 6.16.0
* [`962a2fd8`](https://github.com/NixOS/nixpkgs/commit/962a2fd8c5b8a5f83dd3c00387c6879f16ebbe9b) iosevka-bin: 24.1.0 -> 24.1.1
* [`84b084b8`](https://github.com/NixOS/nixpkgs/commit/84b084b884a880abd4fe6b9556cb192e05ff478f) ispike: unpin boost16x
* [`e092318a`](https://github.com/NixOS/nixpkgs/commit/e092318a9f5f247fbb63fbb78e2f17d97f88fbd7) dae: 0.1.10 -> 0.1.10.p1
* [`a97ce491`](https://github.com/NixOS/nixpkgs/commit/a97ce4912be9f02bab63c6ba927578119ab750f8) ciftilib: unpin boost16x
* [`e97e82f8`](https://github.com/NixOS/nixpkgs/commit/e97e82f83125aa7f6e96203764b3d10e480e1b76) python310Packages.pdm-backend: set package version through setup-hook
* [`5120d113`](https://github.com/NixOS/nixpkgs/commit/5120d113c8b4b50d4e4b3a270dbbf7a2f7b6583c) mirtk: unpin boost16x
* [`f868530b`](https://github.com/NixOS/nixpkgs/commit/f868530bcc48eff8188804428adc9d4a5c56ffdc) seaweedfs: 3.51 -> 3.52
* [`c64d697b`](https://github.com/NixOS/nixpkgs/commit/c64d697b3fdf52e55f8c262b157ac3be87528282) surrealdb-migrations: 0.9.5 -> 0.9.8
* [`8cfe61fb`](https://github.com/NixOS/nixpkgs/commit/8cfe61fbbf7a7a8c167f92caaa1930212095e044) rustus: init at 0.7.2
* [`f27a1e68`](https://github.com/NixOS/nixpkgs/commit/f27a1e6871599031d12677da8f82ce79e475e575) meilisearch: 1.1.1 -> 1.2.0
* [`63165c08`](https://github.com/NixOS/nixpkgs/commit/63165c088fcddb2e2eaaf655be5346aa80fca5bf) nexttrace: 1.1.6 -> 1.1.7-1
* [`e5ebd5de`](https://github.com/NixOS/nixpkgs/commit/e5ebd5ded6c8d6a321feceb25895d6d849053f22) rustic-rs: 0.5.3 -> 0.5.4
* [`aa5acfed`](https://github.com/NixOS/nixpkgs/commit/aa5acfed2758882ee14ae79ce506d9459552a1b9) egl-wayland: 1.1.11 -> 1.1.12
* [`38deb5dc`](https://github.com/NixOS/nixpkgs/commit/38deb5dceacfbe1355e0e7262712c3164b0b7210) ecs-agent: 1.71.1 -> 1.71.2
* [`3f467ff4`](https://github.com/NixOS/nixpkgs/commit/3f467ff45f3c24e8767e0d607e2a02bee9d95b20) mongodb-4_2: drop
* [`3d4b845b`](https://github.com/NixOS/nixpkgs/commit/3d4b845beba39d24df946b7bf6e7326507ba621f) qemu: 8.0.0 -> 8.0.2
* [`33c50b88`](https://github.com/NixOS/nixpkgs/commit/33c50b885b0e8b64e7f3e0f08638f18caa8638cb) browserpass: fix dynamic loader
* [`a830a587`](https://github.com/NixOS/nixpkgs/commit/a830a5871386fa773334cf985b6f5f444fe65d27) chromium: 114.0.5735.90 -> 114.0.5735.106
* [`47d1a746`](https://github.com/NixOS/nixpkgs/commit/47d1a74603aa23283fc205c63059f7fc32714755) python3Packages.geopandas: 0.13.1 -> 0.13.2
* [`4e6190be`](https://github.com/NixOS/nixpkgs/commit/4e6190bec3fac06953919f5e3af5579d178aee5b) worker-build: 0.0.16 -> 0.0.17
* [`3a952222`](https://github.com/NixOS/nixpkgs/commit/3a9522220fd72b66058a1c35d63af5312ec198ed) tfautomv: 0.5.1 -> 0.5.2
* [`03972059`](https://github.com/NixOS/nixpkgs/commit/03972059c325fe3783c812043b45025cfa10ba6b) nixVersions.nix_2_16: 2.16.0 -> 2.16.1
* [`5153f780`](https://github.com/NixOS/nixpkgs/commit/5153f78041cc9aa3a38ed13251af39570048b30d) joplin-desktop: 2.10.18 -> 2.10.19
* [`3b0e48a7`](https://github.com/NixOS/nixpkgs/commit/3b0e48a74ca267a92e2f6bf73bea742681ec05ec) google-cloud-sdk: 426.0.0 -> 433.0.1
* [`03ae1101`](https://github.com/NixOS/nixpkgs/commit/03ae11014e016425300e95b180376c8cfd6ca32d) foundationdb{51,52,60,61}: drop
* [`49cacc1d`](https://github.com/NixOS/nixpkgs/commit/49cacc1dcd63e0621a55a503dca36eef31ee49d9) glfw3: drop libGL on darwin
* [`6b123950`](https://github.com/NixOS/nixpkgs/commit/6b1239502606eef0262e0143f233370512fcdb62) vimPlugins.edgy-nvim: init at 2023-06-06
* [`39bb4b77`](https://github.com/NixOS/nixpkgs/commit/39bb4b7769ddf43cae23c3e313b34c77e6a274f8) vimPlugins: update
* [`6996f768`](https://github.com/NixOS/nixpkgs/commit/6996f76885d81fbc1b066fe346713630e6ac9e1b) lib/tests: Add findFirst tests
* [`9790e701`](https://github.com/NixOS/nixpkgs/commit/9790e70150c83693fa2bcdc65814d01536bf4915) lib.list.findFirst: Make lazier
* [`28d10f75`](https://github.com/NixOS/nixpkgs/commit/28d10f7543938ccff3a6bed583591af388011d96) castnow: wrap with ffmpeg
* [`7dbcfa1a`](https://github.com/NixOS/nixpkgs/commit/7dbcfa1a02656cb2092d91119a521755b26db454) linux: 5.10.181 -> 5.10.182
* [`d77a4053`](https://github.com/NixOS/nixpkgs/commit/d77a40536993382b483addb82af3b3e57957b90a) linux: 5.15.114 -> 5.15.115
* [`c8a665ff`](https://github.com/NixOS/nixpkgs/commit/c8a665ff5fced6cf16582627eacd15ac439bf229) linux: 5.4.244 -> 5.4.245
* [`705a0244`](https://github.com/NixOS/nixpkgs/commit/705a02444269f0cf61f81b195d61e493701c039b) linux: 6.1.31 -> 6.1.32
* [`f7a3f7ca`](https://github.com/NixOS/nixpkgs/commit/f7a3f7cad123308378fac03379d0975238741c3b) linux: 6.3.5 -> 6.3.6
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
