### PR TITLE
niv devenv: update 92ae3568 -> 9d51052c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "92ae3568a0f463e6c7334e54a21a3b7e4ffb014e",
-        "sha256": "0iansfr6hvkl5anllv2wi2bkr6ss1p669paly1n9db7n6ig3kp9h",
+        "rev": "9d51052c5983724a9225fa62587e0cbe51e50622",
+        "sha256": "08hjdyiyaa5h8dkyh311f8vjv3i97jdzklz7ripq7v4cqjd7d49j",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/92ae3568a0f463e6c7334e54a21a3b7e4ffb014e.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/9d51052c5983724a9225fa62587e0cbe51e50622.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@92ae3568...9d51052c](https://github.com/cachix/devenv/compare/92ae3568a0f463e6c7334e54a21a3b7e4ffb014e...9d51052c5983724a9225fa62587e0cbe51e50622)

* [`eae00252`](https://github.com/cachix/devenv/commit/eae002528893ba224f88b35163ff3ec273f67784) Pass arguments to `devenv up` through to implementation
* [`bfd4f29e`](https://github.com/cachix/devenv/commit/bfd4f29e50d10bfd72dc40e5cf5a3176a6cc3e52) feat: add support for permittedInsecurePackages
* [`2ef80938`](https://github.com/cachix/devenv/commit/2ef80938facf2b359711d39f4d0a9669ad24acc8) Add readiness check for rabbitmq
* [`552f3615`](https://github.com/cachix/devenv/commit/552f36157a2e2cd8f36e0f7791c46825d4e8e57b) Add readiness check to elasticsearch
* [`b095f9b7`](https://github.com/cachix/devenv/commit/b095f9b71b7997c7328c9543e004726fb37cba60) bump deps
* [`9ccd0d6a`](https://github.com/cachix/devenv/commit/9ccd0d6ac70b74f3108e1d8f3565ae545ba1f760) set local modules when invoking devenv-test-example
* [`6e7279ae`](https://github.com/cachix/devenv/commit/6e7279aeb428f804967399deca03e9788ea29133) Add languages.python.venv.requirements
* [`c51a56ba`](https://github.com/cachix/devenv/commit/c51a56bac8853c019241fe8d821c0a0d82422835) Auto generate docs/reference/options.md
* [`bcc8fc75`](https://github.com/cachix/devenv/commit/bcc8fc75dec877cdaaf168386842e07493cb61fa) chore(deps): update pre-commit-hooks input
* [`495cabaa`](https://github.com/cachix/devenv/commit/495cabaa00a7dd46fbc92db710e7dbb73dc76298) Convert integer to string in healthcheck
* [`5200404a`](https://github.com/cachix/devenv/commit/5200404ac8d501bde360cfeae7d8bd020a44755c) Auto generate docs/reference/options.md
* [`410ad883`](https://github.com/cachix/devenv/commit/410ad8833b08e3e182c095314c3f4a0f762bfa65) arm64 ci
* [`f9edaeaf`](https://github.com/cachix/devenv/commit/f9edaeafc7b40d2ab064b4a56e2291988c1e9b30) Use nc for healthcheck
* [`1b990e22`](https://github.com/cachix/devenv/commit/1b990e2237e9a7004897a1ef39c8f855eeee990a) fix [cachix/devenv⁠#654](https://togithub.com/cachix/devenv/issues/654)
