### PR TITLE
niv home-manager: update 28614ed7 -> b01eb1eb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "28614ed7a1e3ace824c122237bdc0e5e0b62c5c3",
-        "sha256": "0mlzfgp2v2kibn5p60aw2mdbwh6ymy2xqlpwafg85krv2xk4r941",
+        "rev": "b01eb1eb3b579c74e6a4189ef33cc3fa24c40613",
+        "sha256": "1gs86h6happ39l99kiiaiiw0riwv9g7vlxbvr4nx7g46c55g2iq2",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/28614ed7a1e3ace824c122237bdc0e5e0b62c5c3.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/b01eb1eb3b579c74e6a4189ef33cc3fa24c40613.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@28614ed7...b01eb1eb](https://github.com/nix-community/home-manager/compare/28614ed7a1e3ace824c122237bdc0e5e0b62c5c3...b01eb1eb3b579c74e6a4189ef33cc3fa24c40613)

* [`3512a6da`](https://github.com/nix-community/home-manager/commit/3512a6dafb7836cfceef00dcb29ce6f01c2ce280) rtx: add module ([nix-community/home-manager⁠#4051](https://togithub.com/nix-community/home-manager/issues/4051))
* [`39c7d0a9`](https://github.com/nix-community/home-manager/commit/39c7d0a97a77d3f31953941767a0822c94dc01f5) imv: add module ([nix-community/home-manager⁠#4032](https://togithub.com/nix-community/home-manager/issues/4032))
* [`cc6745b3`](https://github.com/nix-community/home-manager/commit/cc6745b35fefe48624ebf573382e1e0e4a6fe85e) aerc: add package option ([nix-community/home-manager⁠#4065](https://togithub.com/nix-community/home-manager/issues/4065))
* [`f889ec0e`](https://github.com/nix-community/home-manager/commit/f889ec0ec366e3ad8fb94e3afa7a31f3ee1da3b9) tests: `--show-trace` in CI ([nix-community/home-manager⁠#4070](https://togithub.com/nix-community/home-manager/issues/4070))
* [`69bdd6de`](https://github.com/nix-community/home-manager/commit/69bdd6de50df2082901d94dbf70ecb762d8b636c) tests/stubs: inherit default versions from pkgs ([nix-community/home-manager⁠#4069](https://togithub.com/nix-community/home-manager/issues/4069))
* [`7d07f8b6`](https://github.com/nix-community/home-manager/commit/7d07f8b6f9db338dffa9b11e047bf82efa4ad696) Translate using Weblate (Chinese (Simplified))
* [`2bbfc3a7`](https://github.com/nix-community/home-manager/commit/2bbfc3a78afb4ea60345a5660d8d4173da66c884) Translate using Weblate (Russian)
* [`9b8ba302`](https://github.com/nix-community/home-manager/commit/9b8ba302ff38fe25b4a30c7dcafeb26d0ef37f9d) Clean up deprecated lib functions ([nix-community/home-manager⁠#4068](https://togithub.com/nix-community/home-manager/issues/4068))
* [`1e5d741e`](https://github.com/nix-community/home-manager/commit/1e5d741ea3f3290d7ac06a02ded24bfdc7aadb37) Espanso: Fix broken module to be compatible with Espanso version 2.x ([nix-community/home-manager⁠#4066](https://togithub.com/nix-community/home-manager/issues/4066))
* [`301b3648`](https://github.com/nix-community/home-manager/commit/301b3648927c050b224daa90cb4a99e4329456f2) maintainers: add rasmus-kirk as a maintainer
* [`e7fdcb40`](https://github.com/nix-community/home-manager/commit/e7fdcb40b2ddb79ed0b166e9694b361581c3dddb) joshuto: add the joshuto file manager
* [`000df987`](https://github.com/nix-community/home-manager/commit/000df987957b459b4e3de9e8977f95028e627424) flake.lock: Update
* [`2a69182c`](https://github.com/nix-community/home-manager/commit/2a69182c569b190ae0d95244707db4d1209de6cf) Revert "maintainers: add rasmus-kirk as a maintainer" ([nix-community/home-manager⁠#4076](https://togithub.com/nix-community/home-manager/issues/4076))
* [`0945875a`](https://github.com/nix-community/home-manager/commit/0945875a2a20de314093b0f9d4d5448e9b4fdccb) boxxy: add module ([nix-community/home-manager⁠#4075](https://togithub.com/nix-community/home-manager/issues/4075))
* [`0144ac41`](https://github.com/nix-community/home-manager/commit/0144ac418ef633bfc9dbd89b8c199ad3a617c59f) sway: add support for XDG autostart using systemd ([nix-community/home-manager⁠#3747](https://togithub.com/nix-community/home-manager/issues/3747))
* [`b0cdae4e`](https://github.com/nix-community/home-manager/commit/b0cdae4e9baa188d69ba84aa1b7406b7bebe37f6) browserpass: test on Darwin again ([nix-community/home-manager⁠#4081](https://togithub.com/nix-community/home-manager/issues/4081))
* [`9e37a1b6`](https://github.com/nix-community/home-manager/commit/9e37a1b6f9507ed27080518ff4007988a50c957e) programs.joshuto: add the joshuto file manager ([nix-community/home-manager⁠#4004](https://togithub.com/nix-community/home-manager/issues/4004))
* [`b01eb1eb`](https://github.com/nix-community/home-manager/commit/b01eb1eb3b579c74e6a4189ef33cc3fa24c40613) Add infrastructure for contacts and calendars ([nix-community/home-manager⁠#4078](https://togithub.com/nix-community/home-manager/issues/4078))
