### PR TITLE
niv powerlevel10k: update 79753faa -> 944f52fc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "79753faacb6dc511088cb0d136ec438873613932",
-        "sha256": "0v3xylrqr7q4z40ibpsffyx545x47rifg0zhqd57nrgvl178wdkj",
+        "rev": "944f52fc430259ff49f497f3516a3ddfb45a0a6b",
+        "sha256": "1iq95w9lzxym50gg7q9sb8a9d0fl1zfvswzvgcbs9sf8zcgd6qbb",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/79753faacb6dc511088cb0d136ec438873613932.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/944f52fc430259ff49f497f3516a3ddfb45a0a6b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@79753faa...944f52fc](https://github.com/romkatv/powerlevel10k/compare/79753faacb6dc511088cb0d136ec438873613932...944f52fc430259ff49f497f3516a3ddfb45a0a6b)

* [`6740f08f`](https://github.com/romkatv/powerlevel10k/commit/6740f08f61395665714fbba150c82e99ffe0e784) chezmoi: add chezmoi prompt
* [`29c0b258`](https://github.com/romkatv/powerlevel10k/commit/29c0b258505c5214667c20ce4cb5d4f7e743776c) feat: enable chezmoi prompt in configurations
* [`6db5920b`](https://github.com/romkatv/powerlevel10k/commit/6db5920bb9ecdba25b8253a93120f973b686199f) feat: add chezmoi icon
* [`9ed51ec3`](https://github.com/romkatv/powerlevel10k/commit/9ed51ec315cd438063f6514e50dd630bad9c62f2) doc: add chezmoi prompt in the README
* [`e4b89254`](https://github.com/romkatv/powerlevel10k/commit/e4b8925478d79795713c80dca4680782a33cdc1b) Added cert manager cmctl to POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND
* [`7b197465`](https://github.com/romkatv/powerlevel10k/commit/7b197465803cd5f646e916b631f1b239d02efebf) feat: add color and custom icon
* [`3ecef8c6`](https://github.com/romkatv/powerlevel10k/commit/3ecef8c6a5d12d7aaf0335efc3483c4145371337) feat(chezmoi): add instant_prompt_chezmoi
* [`cc4878ae`](https://github.com/romkatv/powerlevel10k/commit/cc4878aef2bdefbac98fa135fca6070d27e4f041) fix chezmoi segment and rename it to chezmoi_shell ([romkatv/powerlevel10k⁠#2311](https://togithub.com/romkatv/powerlevel10k/issues/2311))
* [`944f52fc`](https://github.com/romkatv/powerlevel10k/commit/944f52fc430259ff49f497f3516a3ddfb45a0a6b) move chezmoi_shell in the docs closer to other shell indicator segments
