### PR TITLE
niv nixpkgs: update 94f1362d -> c2993f32

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "94f1362dc88c55be6b4c6886f2e937e9e86c6943",
-        "sha256": "00w7n93jgc9aw2hzqjd4nl9v8m1ls8mfx9g1hwzg8gqbv29g5rwb",
+        "rev": "c2993f32a25fb875710b8eb9617b28e56ab7dec8",
+        "sha256": "0l47bci2vd7awmnkqy2f4chywhkq4lwdvh23klv1p2b8nmaiyddk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/94f1362dc88c55be6b4c6886f2e937e9e86c6943.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c2993f32a25fb875710b8eb9617b28e56ab7dec8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@94f1362d...c2993f32](https://github.com/nixos/nixpkgs/compare/94f1362dc88c55be6b4c6886f2e937e9e86c6943...c2993f32a25fb875710b8eb9617b28e56ab7dec8)

* [`02b2dfa9`](https://github.com/NixOS/nixpkgs/commit/02b2dfa9f5a2e65b56b9261238843636a43c8494) pdfdiff: 0.92 -> 0.93
* [`743c9b57`](https://github.com/NixOS/nixpkgs/commit/743c9b579ed529c03546356cc26e0672d40f28e3) natron: 2.3.15 -> 2.5.0
* [`0eede3e3`](https://github.com/NixOS/nixpkgs/commit/0eede3e318601380c287408f45a55b8ba0249b0b) natron: add missing dependencies mentioned in warnings
* [`86f3bba6`](https://github.com/NixOS/nixpkgs/commit/86f3bba6d26ff650f7bd8a9b16487c69d54017e1) nixos/cfs-zen-tweaks: fix service name typo
* [`2eabe75f`](https://github.com/NixOS/nixpkgs/commit/2eabe75fff03f160e6ed9d240dca5ce36978efcd) fuc: init at 1.1.6
* [`5bb7bd47`](https://github.com/NixOS/nixpkgs/commit/5bb7bd472aec085096c3b4bafb549e60af312e30) python3.pkgs.django-rosetta: init at 0.9.8
* [`26699b3c`](https://github.com/NixOS/nixpkgs/commit/26699b3cb5e4bfe9395656f9f8e915194e8c3ba0) python3.pkgs.django-admin-datta: init at 1.0.7
* [`f37fc7ad`](https://github.com/NixOS/nixpkgs/commit/f37fc7adaea6434b12a7179ab644c95b0f562d63) Add libappindicator to the build inputs of tauon
* [`09dd617e`](https://github.com/NixOS/nixpkgs/commit/09dd617e1fddf22a6bcc01e8438417c7f55e1ae3) python3Packages.autoflake: depend on tomli for older pythons
* [`f4d5a76a`](https://github.com/NixOS/nixpkgs/commit/f4d5a76a811df99d26706336dda940556c4491f5) netdata module: add automatic claim
* [`29fa7a1a`](https://github.com/NixOS/nixpkgs/commit/29fa7a1a8b98457856fb1a28c9851432114a601e) gut: 0.2.7 -> 0.2.8
* [`60f2f44f`](https://github.com/NixOS/nixpkgs/commit/60f2f44f8b45206f83625dac47e233efe3220949) obs-studio-plugins.obs-teleport: 0.6.5 -> 0.6.6
* [`2778f6ee`](https://github.com/NixOS/nixpkgs/commit/2778f6eeda2ca9959c960c211b9a935e3e205ef5) python3Packages.pymavlink: 2.4.37 -> 2.4.38
* [`329c8a2e`](https://github.com/NixOS/nixpkgs/commit/329c8a2e632533ea4e3d0db651c02034a37a0141) mavproxy: 1.8.59 -> 1.8.60
* [`14793fac`](https://github.com/NixOS/nixpkgs/commit/14793fac6c173e111d9be6a21135d59bf805b1c4) Update nixos/modules/services/monitoring/netdata.nix
* [`db8b28dc`](https://github.com/NixOS/nixpkgs/commit/db8b28dc5dcd75009953f97762d6d196b9e519c2) Update nixos/modules/services/monitoring/netdata.nix
* [`49cb4264`](https://github.com/NixOS/nixpkgs/commit/49cb42647ad1d299c3640ea2c8576581e17777be) python310Packages.filelock: 3.9.0 -> 3.12.0
* [`85d28c62`](https://github.com/NixOS/nixpkgs/commit/85d28c6239618a941178de00330432285635deed) maintainers: add aither64
* [`6ef393f0`](https://github.com/NixOS/nixpkgs/commit/6ef393f0bc632e6ae954ebd7124c93073430ebad) ardour: 7.3 -> 7.4
* [`79eab03a`](https://github.com/NixOS/nixpkgs/commit/79eab03a25b022c0a2c5c0a79577a248831e8dd2) pythonPackages.xstatic-font-awesome: init at 6.2.1.1
* [`13d5bbfd`](https://github.com/NixOS/nixpkgs/commit/13d5bbfd03eb67fa0176d9a17e118d44d07472dc) pythonPackages.xstatic-asciinema-player: init at 2.6.1.1
* [`becd4e0f`](https://github.com/NixOS/nixpkgs/commit/becd4e0f3b4258b60593f6a6c2d72e8ba1887c19) bepasty: 0.5.0 -> 1.1.0
* [`b031ba3d`](https://github.com/NixOS/nixpkgs/commit/b031ba3d529e246fdbfa0d7b50e6621b7a96f8c4) bepasty: fix license to bsd2
* [`50bd5730`](https://github.com/NixOS/nixpkgs/commit/50bd5730c4d12fcdfed3c296b5e3c87834cdbcae) libopus: 1.3.1 -> 1.4
* [`dcfcce73`](https://github.com/NixOS/nixpkgs/commit/dcfcce73a2e4b5681caa875722190328395c6cfe) fixup! libopus: 1.3.1 -> 1.4
* [`19dd609d`](https://github.com/NixOS/nixpkgs/commit/19dd609d0c74b9bddc1cc1c91324aa576f6eb918) subtitleedit: 3.6.12 -> 3.6.13
* [`bc9d28d8`](https://github.com/NixOS/nixpkgs/commit/bc9d28d808316e71e51c804412af74e0d76171dd) mudlet: 4.17.0 -> 4.17.2
* [`baf654c5`](https://github.com/NixOS/nixpkgs/commit/baf654c5b67d6626a9841df53f5cee393e074b2c) flat-remix-gnome: update 20221107 -> 20230508.
* [`d58c684e`](https://github.com/NixOS/nixpkgs/commit/d58c684ecfcfab0dfd2c4a499c3ffe76b92809f8) faust: replace qt4 with qt5
* [`bfded400`](https://github.com/NixOS/nixpkgs/commit/bfded4004799c48f47e67ae2f4de387211966fd4) fix faust2jaqt packages:
* [`5c5a5090`](https://github.com/NixOS/nixpkgs/commit/5c5a50907112916cc1613af4cb4415718ddfca61) libwacom: 2.6.0 -> 2.7.0
* [`45ad7c04`](https://github.com/NixOS/nixpkgs/commit/45ad7c046e3f91e1b758ef12d78112fb521d07d7) libwacom-surface: 2.6.0 -> 2.7.0
* [`2683d63d`](https://github.com/NixOS/nixpkgs/commit/2683d63d7f62971a69c60b5c6e46e1b391d3bbb4) mymcplus: init at 3.0.5
* [`afdcccd1`](https://github.com/NixOS/nixpkgs/commit/afdcccd135ed693cd053484db87f8bb1ed3f554e) python3Packages.mmcif-pdbx: init at 2.0.1
* [`f9741e3d`](https://github.com/NixOS/nixpkgs/commit/f9741e3dcb443f4111c5b3fb35366da8bf6347a5) python3Packages.propka: init at 3.5.0
* [`22716330`](https://github.com/NixOS/nixpkgs/commit/22716330eb97ae7336f9ed04b19a5e3568f5635f) pdb2pqr: init at 3.6.1
* [`507bde9c`](https://github.com/NixOS/nixpkgs/commit/507bde9c5d95556ed6861fe97b65d6b39fdb89e4) python310Packages.platformdirs: 3.0.0 -> 3.5.1
* [`9588972f`](https://github.com/NixOS/nixpkgs/commit/9588972fe983654d05df0695899bc96c46c622f9) diffutils: 3.9 -> 3.10
* [`0f0e98dd`](https://github.com/NixOS/nixpkgs/commit/0f0e98dd5ef635037997f97e9269bd6d97f7e068) gawk: 5.2.1 -> 5.2.2
* [`3ecba95f`](https://github.com/NixOS/nixpkgs/commit/3ecba95fef283b0aa781827ec0cab2d56da68e20) ftxui: set strictDeps, fix cross compilation
* [`0000022b`](https://github.com/NixOS/nixpkgs/commit/0000022b48036f65ebc514fbb7c89071aea1248d) python310Packages.hypothesis: move documentation to passthru to reduce dependencies
* [`64820b8b`](https://github.com/NixOS/nixpkgs/commit/64820b8b87af5ee68f4caf2b3f8af9582a23fdb6) imhex: 1.27.1 -> 1.29.0
* [`00000000`](https://github.com/NixOS/nixpkgs/commit/00000000b0be738315769701d1bc6ee298ad44a9) treewide: remove removed hypothesis enableDocumentation option
* [`998c9067`](https://github.com/NixOS/nixpkgs/commit/998c9067cfe93c84de52cc4e3ff080350ca954b7) feedbackd: 0.1.0 -> 0.2.0
* [`39666bc4`](https://github.com/NixOS/nixpkgs/commit/39666bc44976392ca98e3a924739ae2b0338757d) phoc: 0.25.0 -> 0.27.0
* [`259c3940`](https://github.com/NixOS/nixpkgs/commit/259c394055c77508266c81c57ad87b0e1500b195) phosh: 0.25.1 -> 0.27.0
* [`6e3500fd`](https://github.com/NixOS/nixpkgs/commit/6e3500fdd0d762d2fe4bf42a307aa1b8f608fa76) glances: 3.3.1 -> 3.4.0.2
* [`5c5474ff`](https://github.com/NixOS/nixpkgs/commit/5c5474ff6ba16b96efd2906b0bbcdb54f318b795) maintainers: add jacfal
* [`c98d687f`](https://github.com/NixOS/nixpkgs/commit/c98d687fd6e11132efa99780d4cbbe0e6a95446c) gcc{6..11}: import a patch into nixpkgs
* [`256c3a7a`](https://github.com/NixOS/nixpkgs/commit/256c3a7a534106cfc441c88b97c4514793bccda3) tests.dotnet: init with test for projectReferences
* [`0d298148`](https://github.com/NixOS/nixpkgs/commit/0d2981488007617e666959b55e43fb1b2c2409f8) mkNugetSource: Also copy .nupkg files from subdirectories
* [`cd68d5d7`](https://github.com/NixOS/nixpkgs/commit/cd68d5d7b92c62c07ad94b05a31f5c413f8612a5) Revert "kotatogram-desktop/tg_owt: supply right openssl version"
* [`7cd7ada4`](https://github.com/NixOS/nixpkgs/commit/7cd7ada4ff26f9f9e23167f3ead714a8c38865df) frink: generate rlwrap helper files for tab completion
* [`b6d13a0d`](https://github.com/NixOS/nixpkgs/commit/b6d13a0d7fce48b5bcce8093926df36abb05e467) frink: 2023-01-31 -> 2023-05-22
* [`0daa2844`](https://github.com/NixOS/nixpkgs/commit/0daa28448ff72308eb42d9ce5b5b8b76ab958e37) qpdf: 11.3.0 -> 11.4.0
* [`8d4a81b1`](https://github.com/NixOS/nixpkgs/commit/8d4a81b1851be7823e23d26bd02abcfb902d2bef) pkgsMusl.postgresql: fix build
* [`ee949ed9`](https://github.com/NixOS/nixpkgs/commit/ee949ed987167af2db88fe716f55fb65e3b3ca58) obs-studio-plugins.advanced-scene-switcher: 1.21.1 -> 1.22.1
* [`233af5c4`](https://github.com/NixOS/nixpkgs/commit/233af5c42afd03fc3710dcdea05cdcd5aa9c913d) libsForQt5.mlt: Fix build when config.cudaSupport is enabled
* [`53f5acc1`](https://github.com/NixOS/nixpkgs/commit/53f5acc1346e97b93d1d19fae6dfc1c0a0f96202) gdb: 13.1 -> 13.2
* [`15da7dce`](https://github.com/NixOS/nixpkgs/commit/15da7dce6ac7e1950c0e3bc1747a81899843de12) configd: fix build with newer LLVM and bootstrap
* [`0d3355a4`](https://github.com/NixOS/nixpkgs/commit/0d3355a439f2100f232e0319a0cb393134dbbdbe) swift-corelibs: set NIX_COREFOUNDATION_RPATH in a hook
* [`46becf05`](https://github.com/NixOS/nixpkgs/commit/46becf054edda6719480c7fcd7f2a08a0947213a) zeromq: backport gcc-13 fix
* [`3daf4897`](https://github.com/NixOS/nixpkgs/commit/3daf489719edd9776a0a452c9b4954b77e744584) nlohmann_json: backport gcc-13 fix
* [`eed6207e`](https://github.com/NixOS/nixpkgs/commit/eed6207e96b7fa62d624e259bd6da00976a6701b) abseil-cpp: backport gcc-13 fix
* [`9ff76a51`](https://github.com/NixOS/nixpkgs/commit/9ff76a51e918788ecbc5df0189310352eb055c2d) graphite2: disable broken 'nametabletest' (fails on gcc-13)
* [`204136bd`](https://github.com/NixOS/nixpkgs/commit/204136bd950e0bbab16041d2e71b71b0fad0f90c) nodejs: add -licuuc to libv8 pkg-config file
* [`4d2df72e`](https://github.com/NixOS/nixpkgs/commit/4d2df72e6a080b5f2e5c89a4f51a9af66291083f) linuxPackages_5_4_hardened.kernel: option removed in 5.4.208
* [`a65a9e31`](https://github.com/NixOS/nixpkgs/commit/a65a9e313181d325bec9abf20149bcf1bfd07de4) linuxPackages_5_4_hardened.kernel: unbreak
* [`7c043234`](https://github.com/NixOS/nixpkgs/commit/7c043234ecd084e90947aaf63cea5be96beee015) darwin.stdenv: drop NIX_COREFOUNDATION_RPATH from preHook
* [`34bc14a8`](https://github.com/NixOS/nixpkgs/commit/34bc14a8ec5fdda5fcffb259850ebfe2ead16f3d) deadd-notification-center: unstable-2022-11-07 -> 2.0.3
* [`7f330db6`](https://github.com/NixOS/nixpkgs/commit/7f330db6cc5d0074e8a7adaa62ba874f782eb9c6) linuxKernel.packages.linux_(4_14,4_19}_hardened: unbreak
* [`89c480cd`](https://github.com/NixOS/nixpkgs/commit/89c480cdc0a61513128aa2424ec9545f7dcf4b6c) linuxKernel.kernels.linux_*_hardened: move overrides to kernels
* [`8e25b8e8`](https://github.com/NixOS/nixpkgs/commit/8e25b8e8c9c83d77fb6ff4a0a23d255573ef43a3) cmocka: 1.1.6 -> 1.1.7
* [`1364837d`](https://github.com/NixOS/nixpkgs/commit/1364837d91fdf2647a7141f60ee8a78b1e1f16ff) unzip: fix configure script when using clang 16
* [`5b6c95c4`](https://github.com/NixOS/nixpkgs/commit/5b6c95c4cb2c30dae4891347c1b14a8524541050) nixos/nextcloud: Mention that adminpassFile is only used on startup
* [`ff169668`](https://github.com/NixOS/nixpkgs/commit/ff16966860a59e8b8db805bf57d41f4deabdc395) rustc: 1.69.0 -> 1.70.0
* [`78629229`](https://github.com/NixOS/nixpkgs/commit/786292291ab453c93e5923aad62faf3e4544e423) maintainers: add sigmanificient
* [`b7d4d9f5`](https://github.com/NixOS/nixpkgs/commit/b7d4d9f519342669406874b78fbcf7f28384f39a) getopt: fix build on clang 16
* [`9cd4e84a`](https://github.com/NixOS/nixpkgs/commit/9cd4e84a4dda995091afe3560d3ef517c7b31cb0) libelf: fix build with clang 16 on Darwin
* [`7b782450`](https://github.com/NixOS/nixpkgs/commit/7b78245076befdcc932b81c059db899f99f989a5) openexr_2: fix CVE-2021-3933, enable tests
* [`993283e6`](https://github.com/NixOS/nixpkgs/commit/993283e666e58e6458835831db038a36d052082e) python310Packages.markupsafe: 2.1.2 -> 2.1.3
* [`f4a67500`](https://github.com/NixOS/nixpkgs/commit/f4a67500798a93200144ce7c4bf8471458b9958c) rustPlatform.fetchCargoTarball: remove explicit sparse protocol
* [`3425805f`](https://github.com/NixOS/nixpkgs/commit/3425805fe49f763e86a3aaea9ce0e36b96993d2b) nettle: 3.9 -> 3.9.1
* [`17fa0e2f`](https://github.com/NixOS/nixpkgs/commit/17fa0e2fbf7a94a4f9313df2bcda17a16ab20b48) systemd: 253.3 -> 253.5
* [`0d6a6827`](https://github.com/NixOS/nixpkgs/commit/0d6a6827ea0ce8dda8481670ce48e4e28fb02c16) fontconfig: 2.14.0 → 2.14.2
* [`b5d2d701`](https://github.com/NixOS/nixpkgs/commit/b5d2d701d1e983fe82770905e8fce703ba38caa3) nixos/fontconfig: refactor antialias option for fontconfig 2.14.1
* [`bd97ff5f`](https://github.com/NixOS/nixpkgs/commit/bd97ff5ff453f664791fe28bdbdffbcebdded464) nixos/fontconfig: Change default antialiasing style to greyscale instead of subpixel
* [`90aa8bb0`](https://github.com/NixOS/nixpkgs/commit/90aa8bb0cda124c54664a075237d87938c998823) python311Packages.google-api-python-client: 2.84.0 -> 2.88.0
* [`de643091`](https://github.com/NixOS/nixpkgs/commit/de643091d7596cddaeaa9690ff4d03d3a3304983) util-linux: backport bcache checksum patches
* [`69a18e95`](https://github.com/NixOS/nixpkgs/commit/69a18e957de86712307aca972666c9353e47d8a3) python310Packages.xiaomi-ble: 0.17.1 -> 0.17.2
* [`ab8bc692`](https://github.com/NixOS/nixpkgs/commit/ab8bc692eb96d5e67b0a2088794a34fe562ce7b0) at-spi2-core: 2.48.0 → 2.48.3
* [`eb9d4dbe`](https://github.com/NixOS/nixpkgs/commit/eb9d4dbe5c35febbe1e2c1118acfb7c279d58900) gtk3: 3.24.37 → 3.24.38
* [`eacc4e2d`](https://github.com/NixOS/nixpkgs/commit/eacc4e2d243385517aca8fe8924a913c0ebf94c3) maturin: 1.0.0 -> 1.0.1
* [`4e2cfde9`](https://github.com/NixOS/nixpkgs/commit/4e2cfde94e3f267c709876bbc05ba6f7455504a2) modules: fix fontconfig.nix to use '$dst', not 'dst'
* [`09799e8b`](https://github.com/NixOS/nixpkgs/commit/09799e8b80d7bb647cf28b2ca99875145e71417f) apple_sdk: fix infinite recursion
* [`6ce8a3e5`](https://github.com/NixOS/nixpkgs/commit/6ce8a3e5fa02607838a292a79181584fe3ab32c9) s2n-tls: 1.3.44 -> 1.3.45
* [`01b36425`](https://github.com/NixOS/nixpkgs/commit/01b36425890182d3a1898c27d479189a7c496646) linux.configfile: remove unused kernelTarget attr
* [`36689480`](https://github.com/NixOS/nixpkgs/commit/36689480f32ff890eb578e8b7be3b7a6ea7f799a) google-cloud-cpp: schedule on big-parallel machines
* [`7ffd3c33`](https://github.com/NixOS/nixpkgs/commit/7ffd3c33b63a14f28dda7dd5c8ee841ad3b76fc6) ghidra: mark broken only for x86_64-darwin
* [`6a6110bd`](https://github.com/NixOS/nixpkgs/commit/6a6110bd76cfd8715f47217e2ca2aab1585b4528) emacs generic.nix: require `pname`
* [`441036d7`](https://github.com/NixOS/nixpkgs/commit/441036d7f901a745e8436167dd4dcc9cebf88f54) emacs generic.nix: append `-macport` to pname when appropriate
* [`196d71b2`](https://github.com/NixOS/nixpkgs/commit/196d71b29564b46b53842e07bc558da1abb91b93) emacs generic: decouple Xwidgets from X
* [`f0fb2461`](https://github.com/NixOS/nixpkgs/commit/f0fb24611876f48151defbe1df51401ae926a150) gotosocial: init at 0.9.0
* [`45ffb335`](https://github.com/NixOS/nixpkgs/commit/45ffb33514488fd27b9355081a687db8312d97f4) nixos/gotosocial: init
* [`d55edbca`](https://github.com/NixOS/nixpkgs/commit/d55edbca4a6b3cbc66f19a046234df0900183313) openexr: backport gcc-13 fix
* [`2f85bdb3`](https://github.com/NixOS/nixpkgs/commit/2f85bdb32d4fff90958d59216e7232151fc45fe5) python311Packages.zwave-js-server-python: 0.48.1 -> 0.49.0
* [`d6c138df`](https://github.com/NixOS/nixpkgs/commit/d6c138dff20ca14eede530b04af499fbf2ea8dbf) libssh2: propagate openssl
* [`89ce4d8c`](https://github.com/NixOS/nixpkgs/commit/89ce4d8cac2502f60d5d82a8189a1feae250538c) Revert "libvlc: fix build by providing openssl"
* [`953ee5df`](https://github.com/NixOS/nixpkgs/commit/953ee5df829e7dc1e4d7823078c4f564365732e7) nixos/pixelfed: Fix missing permissions for nginx serving files
* [`d88d36cf`](https://github.com/NixOS/nixpkgs/commit/d88d36cfbb55e611453afd3940ccffd2428458a0) evcxr: fix build with rust 1.70
* [`fc5804e5`](https://github.com/NixOS/nixpkgs/commit/fc5804e55d0172bffc2255b0cdfa734b7abfadc0) git: 2.40.1 -> 2.41.0
* [`eb16dc66`](https://github.com/NixOS/nixpkgs/commit/eb16dc66c11340373f140d924042a2aff7072aed) borgmatic: 1.7.9 -> 1.7.14
* [`52e3cd33`](https://github.com/NixOS/nixpkgs/commit/52e3cd33edb129574a7920dcbc27330e282e21c9) maintainers: add michaelCTS
* [`e27de005`](https://github.com/NixOS/nixpkgs/commit/e27de0051702e7c134b2e5746e116b44302dc15e) gnugrep: enable parallel build and tests
* [`7ca12d5f`](https://github.com/NixOS/nixpkgs/commit/7ca12d5f710da18d1c0199bd5c0c91347913eeb0) ffsend: Fix segmentation fault
* [`601c3752`](https://github.com/NixOS/nixpkgs/commit/601c3752a2ad98bdf6bca353a706fd98763708df) composable_kernel: revert split output workaround
* [`0cdcc8cd`](https://github.com/NixOS/nixpkgs/commit/0cdcc8cd250fcd9fb7bc8bf7cf9871962497130b) netbox: 3.5.0 -> 3.5.3
* [`a46c5ee8`](https://github.com/NixOS/nixpkgs/commit/a46c5ee816eb042b299ac9ca1c765c48a54d7424) nixos/netbox: make systemd units more consistent with upstream
* [`d7ccc251`](https://github.com/NixOS/nixpkgs/commit/d7ccc25142f62b4c25a75ae016a1ff552cc446d4) elfutils: split debuginfod into its own output
* [`4fcb96e0`](https://github.com/NixOS/nixpkgs/commit/4fcb96e0f6032d317331f949fb2bf9e470b16a5a) cacert: 3.89.1 -> 3.90
* [`1073ea7f`](https://github.com/NixOS/nixpkgs/commit/1073ea7fa621b06f0131e72ec59d9c5a71fad8f2) libxcrypt: 4.4.33 -> 4.4.35
* [`fd76e6c2`](https://github.com/NixOS/nixpkgs/commit/fd76e6c2ab5f9b0d2468215fe16187247b092bc5) gnugrep: disable gnulib tests on x86_64-darwin as well
* [`fe12b14f`](https://github.com/NixOS/nixpkgs/commit/fe12b14ffdad455de14ca3c696aa510fd10cad7c) digikam: Fix build when config.cudaSupport is enabled
* [`ed3b102d`](https://github.com/NixOS/nixpkgs/commit/ed3b102d1e51fe69d73dac210719e3a75f69fa85) treewide: use use lib.optionalAttrs instead of 'then {}'
* [`deb3d80a`](https://github.com/NixOS/nixpkgs/commit/deb3d80ae0ccafe4f19d3edf32e2eb7fda283978) go_1_20: 1.20.4 -> 1.20.5
* [`d4c5f8f3`](https://github.com/NixOS/nixpkgs/commit/d4c5f8f3943622038209660bd8fdb2fe5b3f9c5b) python3Packages.openai: 0.27.7 -> 0.27.8
* [`eed18924`](https://github.com/NixOS/nixpkgs/commit/eed18924fe76f2ec37d03dd93470265093619632) furtherance: 1.7.0 -> 1.8.0
* [`e7be5d27`](https://github.com/NixOS/nixpkgs/commit/e7be5d2733e467a0a07a657c126b753db3564c30) python310Packages.keepalive: remove use_2to3
* [`206d9848`](https://github.com/NixOS/nixpkgs/commit/206d984884d21ae2d15ea23ab7ff499c68ed5521) wine: tweak update script to allow gecko versions to diverge
* [`a9428cb1`](https://github.com/NixOS/nixpkgs/commit/a9428cb1d996e5c6ea033a0d84499555747d5381) winePackages.stable: 8.0 -> 8.0.1
* [`13180826`](https://github.com/NixOS/nixpkgs/commit/131808261a30a2dd9742098a2a5d864dbc70cfc5) rustc: use llvm_16
* [`4c9f1d74`](https://github.com/NixOS/nixpkgs/commit/4c9f1d74f3db759c400f8a2e62df43ed94d3631f) python3Packages.python-ipware: init at 0.9.0
* [`c720089d`](https://github.com/NixOS/nixpkgs/commit/c720089d58d6a090d7daf32709f4070c604e9ca2) ocl-icd: 2.3.1 -> 2.3.2
* [`0cddbe54`](https://github.com/NixOS/nixpkgs/commit/0cddbe54736bf0a4bf918d1c16b02189a1644a41) questdb: init at 7.1.3
* [`8ae1986f`](https://github.com/NixOS/nixpkgs/commit/8ae1986fa4b014c22d8cb719f6bedaea5b605871) udp2raw: disable address sanitization
* [`f80d434d`](https://github.com/NixOS/nixpkgs/commit/f80d434d9478f201506fd61081ecd7154734b98f) python310: 3.10.11 -> 3.10.12
* [`342ba7d6`](https://github.com/NixOS/nixpkgs/commit/342ba7d647dfffe82961da54830feef2a4c52441) python311: 3.11.3 -> 3.11.4
* [`a1768a41`](https://github.com/NixOS/nixpkgs/commit/a1768a41da3b01767b7249fbb09903660c3f671e) furtherance 1.8.0 changed rec into finalAttrs
* [`b66a6ce0`](https://github.com/NixOS/nixpkgs/commit/b66a6ce01b1aef4bfe947ac0bfc0128050289eac) nixos/no-x-libs: gst_all_1.gst-plugins-base: disable wayland to disable GL
* [`2e261a4c`](https://github.com/NixOS/nixpkgs/commit/2e261a4c35a23861511bff59ccead92127437546) gst_all_1.gst-plugins-good: add option to build without X11
* [`5896d330`](https://github.com/NixOS/nixpkgs/commit/5896d330e9262f674a787ad157d1afdecab22341) nixos/no-x-libs: disable x11 of gst_all_1.gst_plugins_good
* [`d22b35a3`](https://github.com/NixOS/nixpkgs/commit/d22b35a34860baa79fdec92e136b36d0b0fb5cae) gnomeExtensions: auto-update
* [`bf442ea3`](https://github.com/NixOS/nixpkgs/commit/bf442ea3fe08a5e00740942550ea54ebfdf04759) gnugrep: disable tests x86_64-darwin
* [`ccc56fb2`](https://github.com/NixOS/nixpkgs/commit/ccc56fb2767c66e7061e409b78cae69091e02c4b) _7kaa: 2.15.4p1 -> 2.15.5
* [`3c70e81e`](https://github.com/NixOS/nixpkgs/commit/3c70e81e47a30bb68211d1dce3bf803438296ea0) protoc-gen-dart: init at 2.1.0
* [`e5e43e6b`](https://github.com/NixOS/nixpkgs/commit/e5e43e6beb418dbd2900fb692b1e8e6585f2cbcb) emacs generic: rename attributes
* [`5d68e901`](https://github.com/NixOS/nixpkgs/commit/5d68e9014cf30d00218d9a03e21d67d696115a41) build-support/emacs: synchronize with emacs' modified attributes
* [`c8cb3bb3`](https://github.com/NixOS/nixpkgs/commit/c8cb3bb3789e3b1f990651a9715be26f880e417a) mu: synchronize with emacs' modified attributes
* [`ac258860`](https://github.com/NixOS/nixpkgs/commit/ac258860572c11bdc2566eb6e0bcf517ee9dfdd0) syncthingtray: 1.4.1 -> 1.4.2
* [`ba1d14e0`](https://github.com/NixOS/nixpkgs/commit/ba1d14e0cd945dfd2ee3586ee8aeb35823128c63) argocd: 2.7.3 -> 2.7.4
* [`bb317093`](https://github.com/NixOS/nixpkgs/commit/bb317093e86714c78a21f57f2480da513544eb8f) aragorn: 1.2.38 -> 1.2.41
* [`597e4e86`](https://github.com/NixOS/nixpkgs/commit/597e4e8652452df886c863c4ccc671ddb491ecae) aragorn: fix format
* [`99d35260`](https://github.com/NixOS/nixpkgs/commit/99d352606ae11b5df657c3ea7176829cef483cbf) tfupdate: 0.6.7 -> 0.6.8
* [`996cc009`](https://github.com/NixOS/nixpkgs/commit/996cc009c64bb5039308efc0656e55eb9bafa25b) mesa: fix build without valgrind
* [`bdb76dc8`](https://github.com/NixOS/nixpkgs/commit/bdb76dc8c72f13b50418933cc666e8d1d39476de) vcluster: 0.12.3 -> 0.15.1
* [`cc74941c`](https://github.com/NixOS/nixpkgs/commit/cc74941cc331021d9d878202a10c48942c5f7c40) terragrunt: 0.45.18 -> 0.46.3
* [`344daa4c`](https://github.com/NixOS/nixpkgs/commit/344daa4cb8258ed5beaf817dd8edfb9a689c620e) yosys: 0.29 -> 0.30
* [`9789f453`](https://github.com/NixOS/nixpkgs/commit/9789f453cb9cd8f81f81ebfe359a8cadcdcdacff) syncthingtray: 1.4.2 -> 1.4.3
* [`f5df675d`](https://github.com/NixOS/nixpkgs/commit/f5df675dce3209ef975e3613db9bfea19f3676e0) python311Packages.py-multihash: remove pytest-runner
* [`ca282f26`](https://github.com/NixOS/nixpkgs/commit/ca282f269974c82669971b484dd84a86d99ffc7e) python310Packages.structlog: 22.3.0 -> 23.1.0
* [`9ea42327`](https://github.com/NixOS/nixpkgs/commit/9ea4232765c73c47bcc6966fabf3ce7bd1b64a70) pacup: init at 1.1.0
* [`38da8a92`](https://github.com/NixOS/nixpkgs/commit/38da8a92a08e0d3340466038c93f2419bbdda8d7) pt2-clone: 1.58 -> 1.59
* [`9de26779`](https://github.com/NixOS/nixpkgs/commit/9de2677944f7d84a0e7082aa9f2d5b10fd1e1064) audacity: 3.3.2 -> 3.3.3
* [`d5802550`](https://github.com/NixOS/nixpkgs/commit/d5802550f2abfc1f34038ac76a2aa1d2cf34c05c) python311Packages.structlog: add changelog to meta
* [`b2ff7cef`](https://github.com/NixOS/nixpkgs/commit/b2ff7ceff25d3e7cb0f6e18ee84d7921cee03d7d) nixos/tests: Test that Remote SSH can patch Node
* [`fbf5e75a`](https://github.com/NixOS/nixpkgs/commit/fbf5e75aa21f45420853738b0a1910155fc1f696) vscode: Update remote-ssh commit hash with updater
* [`3e9a51a7`](https://github.com/NixOS/nixpkgs/commit/3e9a51a78b9028a91e2201b5d241a884ebbe84a1) nixos/tests: Make remote-ssh test work with flakes
* [`011df7a7`](https://github.com/NixOS/nixpkgs/commit/011df7a76bfea22173cae9628eadcd2c5140d5b2) vscode-remote-ssh: Run patchelf on included Node
* [`8bf8b8fd`](https://github.com/NixOS/nixpkgs/commit/8bf8b8fd68b644f3c1ab3a52464173212da2dfaf) vscode: move rev and vscodeServer to derivation
* [`4a854187`](https://github.com/NixOS/nixpkgs/commit/4a8541875e3bcdd8b1914eb76a858d805c0b4994) glib: 2.76.2 → 2.76.3
* [`ee002b53`](https://github.com/NixOS/nixpkgs/commit/ee002b53e5161c439a91d492e28bcafdf39696f0) linuxPackages_latest.prl-tools: 18.3.0-53606 -> 18.3.1-53614
* [`d78f8820`](https://github.com/NixOS/nixpkgs/commit/d78f88200558d61625abfc08541a765443d4ccf2) nextcloud25: 25.0.6 -> 25.0.7
* [`aa3a5b91`](https://github.com/NixOS/nixpkgs/commit/aa3a5b91e3314938913c2fb6a6bf939039eb63b0) p4c: 1.2.3.9 -> 1.2.4.0
* [`5f3abbad`](https://github.com/NixOS/nixpkgs/commit/5f3abbad246cbb23ef56d9c10ae4e81153e8273c) python3Packages.pylion: init at 0.5.2
* [`33c54f6a`](https://github.com/NixOS/nixpkgs/commit/33c54f6afb9011aacfcb4bbbda633fb940e2fc17) python3Packages.gudhi: 3.4.1 -> 3.8.0
* [`572f5a9a`](https://github.com/NixOS/nixpkgs/commit/572f5a9a79cf8d424df96e6e73894e1da73a07ad) typst: 0.4.0 -> 0.5.0
* [`6be63ce5`](https://github.com/NixOS/nixpkgs/commit/6be63ce59010be21642db26b11c28a903ea1bc29) kbd: split vlock into its own output
* [`9b2577b2`](https://github.com/NixOS/nixpkgs/commit/9b2577b29c9f0c55a072d5d1afd9b9de4ec837c8) gst_all_1.gst-plugins-rs: 0.10.7 -> 0.10.8
* [`51311815`](https://github.com/NixOS/nixpkgs/commit/513118150221c92b4edbbfdc411ca42d88ecbc85) digimend: 10 -> unstable-2023-05-03
* [`b7301c9d`](https://github.com/NixOS/nixpkgs/commit/b7301c9d4ea7d7f56173d41c27ac9fe276888ae8) lego: 4.12.0 -> 4.12.1
* [`fa7b0d03`](https://github.com/NixOS/nixpkgs/commit/fa7b0d03d143238646ef7d6b968074535fdd60af) libsidplayfp: 2.4.2 -> 2.5.0
* [`2ab7adb0`](https://github.com/NixOS/nixpkgs/commit/2ab7adb090a485697db58bfbabc7e87738bedcbe) halftone: 0.2.1 -> 0.3.0
* [`f28e1546`](https://github.com/NixOS/nixpkgs/commit/f28e1546cb67dae44f26f3059c9a99bbc3455ac7) awscli2: 2.11.22 -> 2.11.27
* [`1c8ea72d`](https://github.com/NixOS/nixpkgs/commit/1c8ea72d94cd92b8e8b79f1d2f8d8f789d852705) prometheus-statsd-exporter: 0.23.1 -> 0.24.0
* [`5b9eb4db`](https://github.com/NixOS/nixpkgs/commit/5b9eb4db1edb7c9d833890685f8a99dfbd1e8303) hydrogen: 1.1.1 -> 1.2.1
* [`76cabe16`](https://github.com/NixOS/nixpkgs/commit/76cabe1644504ea4ae1cd8b99e3796cd9b5ddfc9) nixos/ddclient: remove obsolete ipv6 option
* [`a597197e`](https://github.com/NixOS/nixpkgs/commit/a597197edb79b70ee4e24894f436c7cf21a76c09) ungoogled-chromium: 114.0.5735.90 -> 114.0.5735.106
* [`00000548`](https://github.com/NixOS/nixpkgs/commit/00000548be47185b89d697bb8b0d09484e54a879) zammad: fix path to sendmail
* [`3f93ec58`](https://github.com/NixOS/nixpkgs/commit/3f93ec5814547ea75c709058dae0a14c17c98758) nixos/caddy: change `acmeCA` default to `null`
* [`93b9fc8a`](https://github.com/NixOS/nixpkgs/commit/93b9fc8ac0ecf51c393ecafe73ba80277c700165) nixos/caddy: omit empty `bind` directive when `listenAddresses` is empty
* [`f3d7f8af`](https://github.com/NixOS/nixpkgs/commit/f3d7f8af3a67a3a874e81e4c7f33024482746ca4) python310Packages.image-match: remove
* [`66aed5e6`](https://github.com/NixOS/nixpkgs/commit/66aed5e6a6874536796227826a5dbbb5346c3273) python310Packages.markdownsuperscript: remove
* [`830f5b33`](https://github.com/NixOS/nixpkgs/commit/830f5b33ddfbfa8d8864a6724fcac87f893ec88a) doc: add missing section IDs
* [`e42a5c78`](https://github.com/NixOS/nixpkgs/commit/e42a5c78e75aba56b546cbcb8efdf46587fea276) doc: make sure section depths are consecutive
* [`f9ba3027`](https://github.com/NixOS/nixpkgs/commit/f9ba30270ef6121e3923338d21fd63291c9baf28) pkgs/config: add missing mdDoc
* [`2ecc93d6`](https://github.com/NixOS/nixpkgs/commit/2ecc93d6fe1be154da6ef9e268b46ec242998511) doc: normalize markdown for nixos-render-docs
* [`2f76a3df`](https://github.com/NixOS/nixpkgs/commit/2f76a3df6405df203b7392edca0e5000d4787057) doc: don't use docbook program listings/callouts
* [`a8fc5424`](https://github.com/NixOS/nixpkgs/commit/a8fc5424ad2299c59ca8b1de1f662872c343acc0) librewolf: 113.0.2-1 -> 114.0.1-2
* [`28df5f4a`](https://github.com/NixOS/nixpkgs/commit/28df5f4a30defa92aff2e68dce638d94e7d544de) gitlab-runner: 16.0.1 -> 16.0.2
* [`c83276f1`](https://github.com/NixOS/nixpkgs/commit/c83276f1e62ed919cbd01def21fa36eb05163bdb) sublime-music: 0.11.16 -> 0.12.0
* [`4cccbcd7`](https://github.com/NixOS/nixpkgs/commit/4cccbcd7688f0d002a344739a257cef0ec6b3bc6) dtc: fix cross
* [`9c863246`](https://github.com/NixOS/nixpkgs/commit/9c8632460d46dc293fcaad58b84b2af0d5d25ca9) maintainers: add weathercold
* [`c1668191`](https://github.com/NixOS/nixpkgs/commit/c1668191afd9a2e55bb6df823c7b9ad2bffa8fc6) python311Packages.typer: 0.7.0 -> 0.9.0
* [`cd4ab1d9`](https://github.com/NixOS/nixpkgs/commit/cd4ab1d9fd9f921451625bc131f8e2d07922ed64) darwin.system_cmds: fix build with clang 16
* [`2eb6d185`](https://github.com/NixOS/nixpkgs/commit/2eb6d1855614db8878e8dbfc433edf08dfeb4bf7) python310Packages.spacy: 3.5.2 -> 3.5.3
* [`2c9c83b0`](https://github.com/NixOS/nixpkgs/commit/2c9c83b03e2d57fc9caffe9e5c5b9fa58b28470c) python310Packages.coinmetrics-api-client: 2023.5.26.17 -> 2023.6.8.20
* [`c1329913`](https://github.com/NixOS/nixpkgs/commit/c13299137efdd6381affadef18867af558c9b7fc) shell-genie: relax typer contraint
* [`1267c765`](https://github.com/NixOS/nixpkgs/commit/1267c76570009813c1879a4699aabc63d0d2c4c0) python311Packages.rstcheck: relax typer constraint
* [`ba8ca6aa`](https://github.com/NixOS/nixpkgs/commit/ba8ca6aa28359c5096bbcb4b42a952f74f38df24) dbx: migrate to pythonRelaxDepsHook
* [`52b1193e`](https://github.com/NixOS/nixpkgs/commit/52b1193e3814dacc52d120c79750d44e8238f11a) kdeconnect-kde: add kirigami-addons to buildInputs
* [`bfa77475`](https://github.com/NixOS/nixpkgs/commit/bfa774756cf466859f9f75b2ca176de93057df56) kdeconnect-kde: set mainProgram to kdeconnect-app
* [`06611403`](https://github.com/NixOS/nixpkgs/commit/06611403c5aad7424ebe161bd9a6661020c9468d) jruby: 9.3.9.0 -> 9.4.3.0
* [`76a2ed5e`](https://github.com/NixOS/nixpkgs/commit/76a2ed5ef537fc94aac1145a9c62d978376e6671) buildRubyGem: only set NIX_CFLAGS_COMPILE on Ruby MRI
* [`67124319`](https://github.com/NixOS/nixpkgs/commit/671243193cf629a2472f881776db3429d16c536f) jruby: Use finalAttrs pattern
* [`d1b239ac`](https://github.com/NixOS/nixpkgs/commit/d1b239ac5dc9d1a0bc9e8f5ebf3653c293a9e8ea) zim: install desktop application icon
* [`d5ee2c96`](https://github.com/NixOS/nixpkgs/commit/d5ee2c96ec7d5697d446def5fb5128e8e8ad94c7) r2modman: init at 3.1.42
* [`e86fb7d8`](https://github.com/NixOS/nixpkgs/commit/e86fb7d8633eef4ceea4ba917d0347584458483c) snappymail: 2.27.3 -> 2.28.1
* [`408f7eab`](https://github.com/NixOS/nixpkgs/commit/408f7eabfb5b86ac358b543c075eee80b1829f0b) arkade: 0.9.19 -> 0.9.22
* [`a7ce6c15`](https://github.com/NixOS/nixpkgs/commit/a7ce6c151a2017971bc79680da068073a06cb469) dbus: fill meta.changelog
* [`2931f3b2`](https://github.com/NixOS/nixpkgs/commit/2931f3b2f7d727e1e9657a63a3293b445b9aeba6) mesa: 23.1.1 -> 23.1.2
* [`615e29ce`](https://github.com/NixOS/nixpkgs/commit/615e29ce545a12f157ca4a4b22b29ff4505daf96) helm-dashboard: 1.3.1 -> 1.3.2
* [`56d862b1`](https://github.com/NixOS/nixpkgs/commit/56d862b1c7e0aac66b9169d88bf501f8f9088a81) iwd: 2.4 -> 2.5
* [`413d8a4f`](https://github.com/NixOS/nixpkgs/commit/413d8a4f82e252a9bbbab3c4fd8bdde5d1db9e63) yandex-browser: 23.3.1.906-1 -> 23.5.1.754-1
* [`515dffe4`](https://github.com/NixOS/nixpkgs/commit/515dffe4bdb21569139c5793c96f1c554f2bc274) hostapd: Enable 802.11ax (Wi-Fi 6) support
* [`dcb6f6e9`](https://github.com/NixOS/nixpkgs/commit/dcb6f6e91b8d6a12a09f587186748bcb7d80e904) dart: 2.19.6 -> 3.0.4
* [`2da8e0ea`](https://github.com/NixOS/nixpkgs/commit/2da8e0eafce6a41f46bc9e1dcfb8dd27ba8e2438) libopus: fix build on aarch64-linux
* [`f9f11c2d`](https://github.com/NixOS/nixpkgs/commit/f9f11c2d17bf4b7c0a683359399929385efa93ca) maintainers: add flutter team
* [`166b95a5`](https://github.com/NixOS/nixpkgs/commit/166b95a53617ac29eeada0dfef8eae521cbda133) wpa_supplicant: Enable 802.11ax (Wi-Fi 6) support
* [`e2645f1a`](https://github.com/NixOS/nixpkgs/commit/e2645f1aaf96f062d3450632292479fad1b7a0c3) libopus: fix build
* [`b0e7251f`](https://github.com/NixOS/nixpkgs/commit/b0e7251fa53aac7d8e63faa170221da0adc68fbc) fixup! libopus: fix build
* [`14d92d3b`](https://github.com/NixOS/nixpkgs/commit/14d92d3bbaeb8906b568a4683ce09e9012175516) python311Packages.apispec-webframeworks: init at 0.5.2
* [`7c37217a`](https://github.com/NixOS/nixpkgs/commit/7c37217a76ffc97c7dc5535d919f22dcc71f0d9b) winePackages.{unstable,staging}: 8.5 -> 8.10
* [`6f57740f`](https://github.com/NixOS/nixpkgs/commit/6f57740f0beaabfbc0b125c9404653e55433d56d) dbus: 1.14.6 -> 1.14.8
* [`e3be7e3b`](https://github.com/NixOS/nixpkgs/commit/e3be7e3b8aa2993cf65228166e4a8dda4a3825fb) python311Packages.filedepot: init at 0.9.0
* [`5c99fa66`](https://github.com/NixOS/nixpkgs/commit/5c99fa668628e22d8c982181040df514ef751ea1) python311Packages.simplekv: init at 0.14.1
* [`a7912a08`](https://github.com/NixOS/nixpkgs/commit/a7912a08f37205c0e1ac2edca3567e41f7814264) python311Packages.pyunifiprotect: 4.10.2 -> 4.10.3
* [`7b0bb8cf`](https://github.com/NixOS/nixpkgs/commit/7b0bb8cf510d29ed73665e41c8c2e45df99fb7d5) python311Packages.knx-frontend: 2023.5.31.141540 -> 2023.6.9.195839
* [`1350e522`](https://github.com/NixOS/nixpkgs/commit/1350e522fa2e6fcc57874a6060f92617fb3a086f) nixos-generate-config: Fix generated hostPlatform.system
* [`4eb013f5`](https://github.com/NixOS/nixpkgs/commit/4eb013f5c00834a4b44ca748aab393728389ecb0) maintainers: add hulr
* [`302759c2`](https://github.com/NixOS/nixpkgs/commit/302759c2082d4cecc3823b5a9ea0eb10b547bc94) oil: 0.15.0 -> 0.16.0
* [`8afaa1ae`](https://github.com/NixOS/nixpkgs/commit/8afaa1ae0f3f5d18a9c3c715cf990f76d9dffa36) python311Packages.structlog: disable on unsupported Python releases
* [`b143354a`](https://github.com/NixOS/nixpkgs/commit/b143354ab9274088777c3f377a135606afe89c0d) gnss-share: 0.6 -> 0.7.1
* [`d17050ed`](https://github.com/NixOS/nixpkgs/commit/d17050ed8705203d23401dc877084a2158bc2890) osu-lazer-bin: 2023.511.0 -> 2023.610.0
* [`56f1e61a`](https://github.com/NixOS/nixpkgs/commit/56f1e61a9a8f0fe880f5ca8854cef833959b3b58) libopus: fix pkg-config path
* [`46c81a5e`](https://github.com/NixOS/nixpkgs/commit/46c81a5e6b42f3c217eda8f17b460ffbb99ff83a) libopus: add ffmpeg as reverse dependencies to passthru.tests
* [`af37dec0`](https://github.com/NixOS/nixpkgs/commit/af37dec087bf9da70ab32c1f26506f74b6d3fc9b) electrum: 4.4.0 -> 4.4.4
* [`3e210b28`](https://github.com/NixOS/nixpkgs/commit/3e210b282fa40ca56678d8d616d77fd39e22f486) texlive: generate "fixed-hashes.nix" from Nix expression
* [`5ef2470f`](https://github.com/NixOS/nixpkgs/commit/5ef2470f1523554039b6b24706af0bc40d4209c4) texlive: assert that all fixed hashes are present
* [`46a696bf`](https://github.com/NixOS/nixpkgs/commit/46a696bfc1557bf22e4c94694be53bc1e391b2fe) osu-lazer: 2023.511.0 -> 2023.610.0
* [`74d437f3`](https://github.com/NixOS/nixpkgs/commit/74d437f37a7172e47f40688a5dbd622d9f251a2a) maintainers: add getpsyched
* [`565efb4a`](https://github.com/NixOS/nixpkgs/commit/565efb4ad0b5c8c2ba1c212f75ae880787b7db82) eks-node-viewer: 0.2.1 -> 0.4.0
* [`aad51856`](https://github.com/NixOS/nixpkgs/commit/aad518563260400780a210725e14be22f7ddfa5a) tauon: 7.6.4 -> 7.6.5
* [`6b1052e4`](https://github.com/NixOS/nixpkgs/commit/6b1052e4e327fdc5b3357e10b0c5111ed5d1f81e) CONTRIBUTING.md: Add section for mass-ping handling
* [`7db587ba`](https://github.com/NixOS/nixpkgs/commit/7db587baa7a1830ee616dc7039e4330f3dcabbd9) linkerd_stable: 2.13.3 -> 2.13.4
* [`fa6c3680`](https://github.com/NixOS/nixpkgs/commit/fa6c36805e3210082f8369d10e2353c32753c96b) oven-media-engine: 0.15.11 -> 0.15.12
* [`81c64e5a`](https://github.com/NixOS/nixpkgs/commit/81c64e5ab81343b0d704ba8e371681bfd31105df) clipboard-jh: 0.7.1 -> 0.8.0
* [`b32d7b29`](https://github.com/NixOS/nixpkgs/commit/b32d7b2966fd7ecac74f8146639991f78b3ece5a) bottom: 0.9.1 -> 0.9.2
* [`764e7266`](https://github.com/NixOS/nixpkgs/commit/764e7266f0296c91660b6187d99ee9580216cd85) fclones-gui: 0.1.0 -> 0.1.2
* [`f1bb5c6c`](https://github.com/NixOS/nixpkgs/commit/f1bb5c6cae5d885801522cc580830db6dcf08d8c) argc: 1.4.0 -> 1.5.0
* [`8692fdbd`](https://github.com/NixOS/nixpkgs/commit/8692fdbd12ab451a6199703d792e4676c8a185c1) pocketbase: 0.16.4 -> 0.16.5
* [`a2fd982c`](https://github.com/NixOS/nixpkgs/commit/a2fd982c4c86e59cab58708598709dd673ac535b) dolt: 1.2.2 -> 1.3.0
* [`729752c2`](https://github.com/NixOS/nixpkgs/commit/729752c22ebcd771e5164390c84e04172b0ec2b8) glooctl: 1.14.6 -> 1.14.7
* [`b81eddec`](https://github.com/NixOS/nixpkgs/commit/b81eddec27d62ea37375d0454cf9a8bc78560988) gotrue-supabase: 2.69.2 -> 2.70.0
* [`bdc99301`](https://github.com/NixOS/nixpkgs/commit/bdc9930174dc77a4dabb657061b38ddbaf1eaedd) miller: 6.7.0 -> 6.8.0
* [`abc07527`](https://github.com/NixOS/nixpkgs/commit/abc07527e04ad8f7f80f22180f07825173d5ba98) dbus-broker: v32 -> v33
* [`170eb1dd`](https://github.com/NixOS/nixpkgs/commit/170eb1dd15868ab21ca94344055e8936b55ef16d) antidote: 1.8.6 -> 1.8.7
* [`4a5460f3`](https://github.com/NixOS/nixpkgs/commit/4a5460f3d95855a4075a6df3e5ca2977eee899b5) eks-node-viewer: fix license
* [`8e2beaf0`](https://github.com/NixOS/nixpkgs/commit/8e2beaf0f4cbd668a60576a3b88cc015d5505998) aravis: 0.8.26 -> 0.8.27
* [`451d527a`](https://github.com/NixOS/nixpkgs/commit/451d527a2b8994b0118c5e49432b0284c4fd1669) eks-node-viewer: fix version
* [`271a8420`](https://github.com/NixOS/nixpkgs/commit/271a8420c7658152cc08a4ffa61a775a2c67669b) eks-node-viewer: add version test
* [`2f20e0e1`](https://github.com/NixOS/nixpkgs/commit/2f20e0e13100f97cb382ebde88cc2215cfde255c) nixos/nix-daemon: fix URL for nix.conf
* [`1115715e`](https://github.com/NixOS/nixpkgs/commit/1115715e8239ea35101b072beede2a225d4b7141) raycast: 1.53.0 -> 1.53.2
* [`b0e31d08`](https://github.com/NixOS/nixpkgs/commit/b0e31d08e153cd2fccfea34d6e2461ac4395f5e5) prometheus-json-exporter: 0.5.0 -> 0.6.0
* [`c18e2371`](https://github.com/NixOS/nixpkgs/commit/c18e23718742e8cf8aa9150e2085c762b4a907f3) terraform: 1.4.6 -> 1.5.0
* [`b594eeae`](https://github.com/NixOS/nixpkgs/commit/b594eeaeb3a50340c075318cee66927d9849a09a) rage: 0.9.1 -> 0.9.2
* [`1caf98c3`](https://github.com/NixOS/nixpkgs/commit/1caf98c3a73313707d64150cfe5f81a64112f534) readability-cli: repackage using buildNpmPackage
* [`fb7456db`](https://github.com/NixOS/nixpkgs/commit/fb7456dbd628266a678d6642f73a99fd7451f358) flow: 0.207.0 -> 0.208.0
* [`de66e21e`](https://github.com/NixOS/nixpkgs/commit/de66e21e768e4ac00f614f23284374d1dbe1ade5) rust-analyzer-unwrapped: 2023-05-29 -> 2023-06-05
* [`f55ff4fc`](https://github.com/NixOS/nixpkgs/commit/f55ff4fc60958fe986b5be8d61336f12485a00d0) minizinc: 2.7.4 -> 2.7.5
* [`59f6636b`](https://github.com/NixOS/nixpkgs/commit/59f6636b3692e3f8f41e738dae292c3391b257e2) brev-cli: 0.6.229 -> 0.6.236
* [`7bc75d30`](https://github.com/NixOS/nixpkgs/commit/7bc75d30327d5e4e886b5b2807756161fd6a60cc) faas-cli: 0.16.4 -> 0.16.7
* [`09c1d496`](https://github.com/NixOS/nixpkgs/commit/09c1d496d9cbf3dfdc97aa8fcef395ebcbc3d1fa) ocamlPackages.qtest: fix for OCaml 5.0
* [`c98657f1`](https://github.com/NixOS/nixpkgs/commit/c98657f164494345d8466797528ad6f94b6a3bc9) ocamlPackages.omd: fix for OCaml 5.0
* [`4e3d46a3`](https://github.com/NixOS/nixpkgs/commit/4e3d46a3ea37d09c3d6dda557a0623c18ed58afe) ocamlPackages.functoria: 4.3.4 → 4.3.6
* [`cdcd3765`](https://github.com/NixOS/nixpkgs/commit/cdcd3765ae7f83675d04a84e6d9da28f9968b0a2) mediamtx: 0.23.4 -> 0.23.5
* [`1bcccfa8`](https://github.com/NixOS/nixpkgs/commit/1bcccfa84fbe0af85a1ffc42a96db80566849537) hysteria: 1.3.4 -> 1.3.5
* [`a1c660b5`](https://github.com/NixOS/nixpkgs/commit/a1c660b55d8f3e50fb7bb4124954b63b8dc743e9) python311Packages.elkm1-lib: 2.2.4 -> 2.2.5
* [`882d513d`](https://github.com/NixOS/nixpkgs/commit/882d513d5480f5e42b617a3fe2cf4dd6c00a5011) python311Packages.teslajsonpy: 3.8.1 -> 3.9.0
* [`e7fc5271`](https://github.com/NixOS/nixpkgs/commit/e7fc527121d07d33ea5bf0973d05bbe57ca77c50) go-migrate: 4.16.0 -> 4.16.1
* [`a85e561d`](https://github.com/NixOS/nixpkgs/commit/a85e561de7861d06df97597dd587289e683cbc31) soju: 0.6.1 -> 0.6.2
* [`0e54476f`](https://github.com/NixOS/nixpkgs/commit/0e54476f40d2b2a4937dd920145095288676fac1) python311Packages.peaqevcore: 18.1.7 -> 18.1.11
* [`2d0b521a`](https://github.com/NixOS/nixpkgs/commit/2d0b521a7085a0dc90f6b4686005fb99e1c88528) python311Packages.publicsuffixlist: 0.10.0.20230608 -> 0.10.0.20230611
* [`e8433322`](https://github.com/NixOS/nixpkgs/commit/e84333228987532f86b02e0a7b9cc873c6c34b7d) python311Packages.sentry-sdk: 1.25.0 -> 1.25.1
* [`69f06fc2`](https://github.com/NixOS/nixpkgs/commit/69f06fc20c8338928bb30fc35909377820ef30dd) python311Packages.sqltrie: 0.5.0 -> 0.6.0
* [`835a38ca`](https://github.com/NixOS/nixpkgs/commit/835a38caebcd1153130488afc152a5aa2178245c) python311Packages.dvc-data: 0.55.0 -> 1.7.0
* [`bd28a38e`](https://github.com/NixOS/nixpkgs/commit/bd28a38ebff69e9ffc1eb5ffb7668c3637027d8f) coqPackages.InfSeqExt: 20200131 → 20230107
* [`00144a91`](https://github.com/NixOS/nixpkgs/commit/00144a917583836e965b69d7481bf4074c2ca200) coqPackages.StructTact: 20210328 → 20230107
* [`e59d94ef`](https://github.com/NixOS/nixpkgs/commit/e59d94ef4c54884223eba6369304ec51af5a1387) coqPackages.Cheerios: 20200201 → 20230107
* [`30620750`](https://github.com/NixOS/nixpkgs/commit/30620750e8915bc6ebebfa1da65a746d3b03717b) coqPackages.Verdi: 20211026 → 20230503
* [`dc8bbbf0`](https://github.com/NixOS/nixpkgs/commit/dc8bbbf0ddef96ffcc257e689b7465d9f4d449c9) ueberzugpp: 2.8.6 -> 2.8.7
* [`75b5f4b1`](https://github.com/NixOS/nixpkgs/commit/75b5f4b106e04e47611d7309d0e7531d5c07840a) ocamlPackages.mariadb: fix for OCaml 5.0
* [`a7096702`](https://github.com/NixOS/nixpkgs/commit/a70967020f7a6d0584aa8058526d8a5cbf91cf87) ocamlPackages.bz2: disable for OCaml ≥ 5.0
* [`03dc92bc`](https://github.com/NixOS/nixpkgs/commit/03dc92bce19848f26edf53c662845a60a129b811) ocamlPackages.ansiterminal: fix for OCaml 5.0
* [`1bbb5689`](https://github.com/NixOS/nixpkgs/commit/1bbb56892d6a324a348c31031da3df07347fc839) fluxcd: 2.0.0-rc.3 -> 2.0.0-rc.5
* [`9d50d0a3`](https://github.com/NixOS/nixpkgs/commit/9d50d0a3db94b7117e27ee128d12604df94d4519) keepalived: 2.2.7 -> 2.2.8
* [`f78c7798`](https://github.com/NixOS/nixpkgs/commit/f78c77989ce65a25c3bd657996c22ed8abe917e1) clightning: 23.05 -> 23.05.1
* [`365f55d3`](https://github.com/NixOS/nixpkgs/commit/365f55d3444459b14d0c459f4d67a899aaa59cb4) python311Packages.bitarray: 2.7.4 -> 2.7.5
* [`ea6957a7`](https://github.com/NixOS/nixpkgs/commit/ea6957a7eef612323c1803b654b4a28f80b7b56d) parallel: 20230422 -> 20230522
* [`07abb71b`](https://github.com/NixOS/nixpkgs/commit/07abb71b8389d6a79f9e117fcd1e3bd53888cd00) qv2ray: unstable-2022-09-25 -> unstable-2023-06-09
* [`579dda9a`](https://github.com/NixOS/nixpkgs/commit/579dda9aecbb6dd339970e1e498af5cb7df28511) syft: 0.82.0 -> 0.83.0
* [`d84ed53f`](https://github.com/NixOS/nixpkgs/commit/d84ed53fcecbec3f397be1f08082ecd32577cedd) appflowy: 0.1.5 -> 0.1.6
* [`1e07280e`](https://github.com/NixOS/nixpkgs/commit/1e07280e7860e2bbdcc4b892cdba906464e62d4c) appflowy: 0.1.6 -> 0.2.1
* [`25b2813b`](https://github.com/NixOS/nixpkgs/commit/25b2813b09576f3301e4e52733e8eca7d71470e9) jbang: 0.107.0 -> 0.108.0
* [`c8cb1f7a`](https://github.com/NixOS/nixpkgs/commit/c8cb1f7a2df211360ff492b13ffdf896a8c25d00) ocamlPackages.minisat: 0.4 -> 0.5
* [`b3f70e80`](https://github.com/NixOS/nixpkgs/commit/b3f70e806e4ba1196b83003cc1a8ead1c4ce7dbe) python310Packages.mlflow: 2.3.2 -> 2.4.1
* [`9f10b6a0`](https://github.com/NixOS/nixpkgs/commit/9f10b6a012f17fd0e51436ad49a3508a1e39301d) python310Packages.nlpcloud: 1.0.41 -> 1.0.42
* [`98b94235`](https://github.com/NixOS/nixpkgs/commit/98b94235ef91c49553fe879eb168150c6652d53c) libmilter: 8.17.1 -> 8.17.2
* [`7c3c8d3d`](https://github.com/NixOS/nixpkgs/commit/7c3c8d3d94cc9182eb8002de02e2f2c4349236a5) gcr: use lib.meta.availableOn instead of isLinux
* [`67f5dcfd`](https://github.com/NixOS/nixpkgs/commit/67f5dcfd94e7544f32cd7324a774cf61aa9401b8) nixos/nspawn: fix spelling of systemd.nspawn MachineID option
* [`7ccb7998`](https://github.com/NixOS/nixpkgs/commit/7ccb7998d0e4cb88c18d84adbef0e37f2475f42f) maintainers: add zi3m5f
* [`f8664556`](https://github.com/NixOS/nixpkgs/commit/f86645566dcbab4cf57c312959844264f3694d69) nixos/tests/systemd-nspawn-configfile: init
* [`e1792ede`](https://github.com/NixOS/nixpkgs/commit/e1792ede74e1cec38f8018fcde8b2c657336388e) lyx: fix cross compilation
* [`dbb0a93d`](https://github.com/NixOS/nixpkgs/commit/dbb0a93db7c33a43c09219db0d97ef7c02cbc34b) timeular: 5.8.7 -> 5.9.0
* [`31eebcd4`](https://github.com/NixOS/nixpkgs/commit/31eebcd47bbc5dec0029f416545a65730c831dc0) oh-my-posh: 16.9.1 -> 17.0.0
* [`24235292`](https://github.com/NixOS/nixpkgs/commit/2423529216312570d302553e74bd0feeb9723f16) python3Packages.click-aliases: init at 1.0.1
* [`3da8671d`](https://github.com/NixOS/nixpkgs/commit/3da8671d44c7cc3cc9e44588ce31b1f20afa3a5e) pynitrokey: add update script
* [`269c517f`](https://github.com/NixOS/nixpkgs/commit/269c517fe89b42c97de1bf86ae5a441ed7136b9e) pynitrokey: 0.4.37 -> 0.4.38
* [`1605374b`](https://github.com/NixOS/nixpkgs/commit/1605374b3ece6dc7b9e4e13b06eead10ad0b2a34) libmwaw: 0.3.21 -> 0.3.22
* [`3c0a8a7d`](https://github.com/NixOS/nixpkgs/commit/3c0a8a7dfd283f28645d8aefa693dc68d68c8dd0) boost: cleanup
* [`0368dcd2`](https://github.com/NixOS/nixpkgs/commit/0368dcd2d8e6625d195dd64a996a08c5e3673848) readarr: 0.1.4.1596 -> 0.1.8.1889
* [`be335749`](https://github.com/NixOS/nixpkgs/commit/be335749cf85e5e868b753e8f2f2a46fcf9b8abf) build(deps): bump korthout/backport-action from 1.2.0 to 1.3.1
* [`84d5e900`](https://github.com/NixOS/nixpkgs/commit/84d5e900a3001846420d1559679ffa23c28c1bb5) sqlcmd: 1.0.0 -> 1.1.0
* [`feb76c2a`](https://github.com/NixOS/nixpkgs/commit/feb76c2a63c5d90ee8a1f4bcc6d70cf237106a0a) python310Packages.types-ujson: 5.7.0.5 -> 5.8.0.0
* [`1714556e`](https://github.com/NixOS/nixpkgs/commit/1714556e3185d125494d2148edaee387b52df5cb) rust-script: 0.27.0 -> 0.28.0
* [`f2689c26`](https://github.com/NixOS/nixpkgs/commit/f2689c2617a32c81c170c2ffd53791cdb2fe2b04) fclones: 0.31.1 -> 0.32.1
* [`26a04d34`](https://github.com/NixOS/nixpkgs/commit/26a04d344223abd4ba08048efcb95cc2c761e42b) python310Packages.pyvmomi: 8.0.1.0 -> 8.0.1.0.1
* [`ea118c2b`](https://github.com/NixOS/nixpkgs/commit/ea118c2b96cff2d6b1b3c15df5156e6a0b537eba) oha: 0.5.8 -> 0.5.9
* [`c910e69f`](https://github.com/NixOS/nixpkgs/commit/c910e69f34054f719f969851944746028d19a4cf) topiary: 0.2.1 -> 0.2.2
* [`8e640173`](https://github.com/NixOS/nixpkgs/commit/8e640173144746f9babe2bc3338e5d5eb79f1f70) python310Packages.pynvim: fix & adopt
* [`18095b8d`](https://github.com/NixOS/nixpkgs/commit/18095b8d94285d85312b85db2d31cb234b88ef77) cannelloni: move cmake to nativeBuildInputs
* [`3fdaa004`](https://github.com/NixOS/nixpkgs/commit/3fdaa00460d722acee106cff629461511731c18f) cannelloni: remove -DCMAKE_BUILD_TYPE=Release
* [`bd77d4ae`](https://github.com/NixOS/nixpkgs/commit/bd77d4ae46a32fda5d28c02b0f2cb33c7f722c8e) nixos/lemmy: support nginx
* [`7cb8758c`](https://github.com/NixOS/nixpkgs/commit/7cb8758c67682150167b0c5c0501e9faaa5423a3) lerpn: init at unstable-2023-06-08
* [`81b627fc`](https://github.com/NixOS/nixpkgs/commit/81b627fc5b71e6638227f10fd5995a9039542aff) deck: init at 1.22.0
* [`06375c59`](https://github.com/NixOS/nixpkgs/commit/06375c5962ed3a4298bc91c1ac25fd121437a479) doc/languages-frameworks/python: add missing back quote
* [`35964909`](https://github.com/NixOS/nixpkgs/commit/3596490914ec9f24b20a16366363f41ebe9059d0) nushellPlugins.query: 0.80.0 -> 0.81.0
* [`025cb1e9`](https://github.com/NixOS/nixpkgs/commit/025cb1e9b0ed6a09f4f7cacbb2ffe9ccb1ad5287) timewarrior: install bash completion
* [`e2432e9a`](https://github.com/NixOS/nixpkgs/commit/e2432e9abfb67bc41fc375c1cdc024c5f428fa0d) xorriso: fix build on darwin
* [`8255903b`](https://github.com/NixOS/nixpkgs/commit/8255903b7179aba39506026f053190723e95f05e) neovimUtils.buildNeovimPluginFrom2Nix: rename to buildNeovimPlugin
* [`81b72e4a`](https://github.com/NixOS/nixpkgs/commit/81b72e4a232f0839aabdd2892ed82c5c3529d0ba) nfpm: 2.29.0 -> 2.30.1
* [`afef3070`](https://github.com/NixOS/nixpkgs/commit/afef30702372a920b423e29d9fdbe5f10cf00438) sqitch: add Algorithm::Backoff
* [`aa4c2c06`](https://github.com/NixOS/nixpkgs/commit/aa4c2c069509ddebc8ffd1185ba7cb70c64f4557) freeipmi: 1.6.10 -> 1.6.11
* [`51aa21dc`](https://github.com/NixOS/nixpkgs/commit/51aa21dc1992b9ab19bdcce7b3f808088e976d6d) texlab: 5.6.0 -> 5.7.0
* [`72a87b6e`](https://github.com/NixOS/nixpkgs/commit/72a87b6e4e7eac919f9c68d5ed69dd975c782835) jql: 6.0.8 -> 6.0.9
* [`a09afc8d`](https://github.com/NixOS/nixpkgs/commit/a09afc8dacfcf4fe3a551f557268b8488cc7c675) topiary: Add passthru.updateScript
* [`7beefa98`](https://github.com/NixOS/nixpkgs/commit/7beefa9836c8356d088ed685d02f999e610d4c12) realvnc-vnc-viewer: 7.5.0 -> 7.5.1
* [`6f747a9f`](https://github.com/NixOS/nixpkgs/commit/6f747a9f14c300b2c381afce86b8e4104826c662) pantheon.granite7: 7.2.0 -> 7.3.0
* [`143d2345`](https://github.com/NixOS/nixpkgs/commit/143d234583aa22d5e28bf07f93623d1af498f4a8) matplotlib: add numpy to nativeBuildInputs to fix cross compilation ([nixos/nixpkgs⁠#237334](https://togithub.com/nixos/nixpkgs/issues/237334))
* [`3edc20aa`](https://github.com/NixOS/nixpkgs/commit/3edc20aa55f722a76e8002b627c9edf05aba4a5f) nixos/doc: stub out epub manual
* [`a88de40e`](https://github.com/NixOS/nixpkgs/commit/a88de40ede4b945ccf646777f9ea7054a504b9fd) matrix-synapse: disable test parallelism on aarch64-linux
* [`c415521d`](https://github.com/NixOS/nixpkgs/commit/c415521d6393a9608e273fb65e594ff4b6697f6e) doc: stub out epub manual
* [`bd76d802`](https://github.com/NixOS/nixpkgs/commit/bd76d802e6c50bbd9837e94525234e5682ce1e42) ocamlPackages.odoc: 2.1.1 -> 2.2.0
* [`2ff21ec9`](https://github.com/NixOS/nixpkgs/commit/2ff21ec9976e2b42f5c9f3c01efe1f15096caa16) python310Packages.cloudflare: 2.11.2 -> 2.11.6
* [`927290d2`](https://github.com/NixOS/nixpkgs/commit/927290d2a65d47d573f287e5297651093a8fda1a) codon: 0.15.5 -> 0.16.1
* [`662d9a40`](https://github.com/NixOS/nixpkgs/commit/662d9a407277a2d86465ffcbeeda1c957a33a4ac) mdbook-toc: 0.9.0 -> 0.12.0
* [`3b0f5393`](https://github.com/NixOS/nixpkgs/commit/3b0f5393d9eb3a90ce4e4b0ed8d671a5ac977a46) neovimUtils.grammarToPlugin: install tree-sitter grammars for neovim without nvim-treesitter
* [`cf1c78a7`](https://github.com/NixOS/nixpkgs/commit/cf1c78a7d4276e83038d30281d783920cd9f1808) ctranslate2: init at 3.15.1
* [`32f6c393`](https://github.com/NixOS/nixpkgs/commit/32f6c393a109457ca464754946b8128c2d71d7ec) python310Packages.ctranslate2: init at 3.15.1
* [`9d1d140a`](https://github.com/NixOS/nixpkgs/commit/9d1d140acfad806f5768d4e5d276b55a3a4c50b0) python310Packages.faster-whisper: init at 0.6.0
* [`3e235f99`](https://github.com/NixOS/nixpkgs/commit/3e235f99b9ce612aae9abb89cdd2920d6d56f021) wyoming-piper: init at 0.0.3
* [`dd8a4a6e`](https://github.com/NixOS/nixpkgs/commit/dd8a4a6eb8cafc5abee60a4cf4bdc1b8cd565045) wyoming-faster-whisper: init at 0.0.3
* [`9c67abf2`](https://github.com/NixOS/nixpkgs/commit/9c67abf20ae3fb25d62cd79187b5bcc21627f531) piper-tts: rename from larynx
* [`7f17f8da`](https://github.com/NixOS/nixpkgs/commit/7f17f8da9fc7ee2aeccf0b535b4d492b58219752) nixos/wyoming/piper: init
* [`f213f33f`](https://github.com/NixOS/nixpkgs/commit/f213f33f156575661264dee8dbf81ab7c419751d) nixos/wyoming/faster-whisper: init
* [`0b80a5bf`](https://github.com/NixOS/nixpkgs/commit/0b80a5bf008ef23744cd4181c3e6119e1fd48e64) limesurvey: 5.6.9+230306 -> 6.1.2+230606, unmark broken
* [`41c1ca30`](https://github.com/NixOS/nixpkgs/commit/41c1ca3071a68bdf4eef727bbb739d0e6d02ed57) python310Packages.jug: 2.2.2 -> 2.2.3
* [`e299fd50`](https://github.com/NixOS/nixpkgs/commit/e299fd503b25489d130177f344e48b3feadc809c) albert: 0.20.13 -> 0.20.14
* [`76a48e3a`](https://github.com/NixOS/nixpkgs/commit/76a48e3a45f53ba82a140a6dd4ab1795027dd3a3) osv-scanner: 1.3.3 -> 1.3.4
* [`fbb732ae`](https://github.com/NixOS/nixpkgs/commit/fbb732aebc1f375f2b5fb8e5d938c995864e8d2e) wamr: use finalAttrs pattern
* [`cddc346b`](https://github.com/NixOS/nixpkgs/commit/cddc346b139cfa7278a41e90741a082050346b8e) opera: 99.0.4788.31 -> 99.0.4788.65
* [`3a368ed0`](https://github.com/NixOS/nixpkgs/commit/3a368ed0453b0256761667cfad9e1065db5ebf51) infra: fix license
* [`7fd448e9`](https://github.com/NixOS/nixpkgs/commit/7fd448e9f9a4e5b0161ec7fa106338c7e1ade1e0) basex: 10.4 -> 10.6
* [`6e4d5da3`](https://github.com/NixOS/nixpkgs/commit/6e4d5da32df626c2478a9bcc9e32632586976bf5) libwps: 0.4.13 -> 0.4.14
* [`44ffb724`](https://github.com/NixOS/nixpkgs/commit/44ffb7247b91b2d5f936d8fa7c12fe576e9785a3) snd: 23.3 -> 23.4
* [`33730f9e`](https://github.com/NixOS/nixpkgs/commit/33730f9edf27246d345dd1553b5f178cfa39fb39) signalbackup-tools: 20230607 -> 20230612-1
* [`988243af`](https://github.com/NixOS/nixpkgs/commit/988243af0fea936141a39ad6350069cc32d60057) werf: 1.2.239 -> 1.2.240
* [`41559ec4`](https://github.com/NixOS/nixpkgs/commit/41559ec4a0e1c74bfe2551e6a782b5c817007d68) computecpp-unwrapped: 2.3.0 -> 2.11.0
* [`e74d8f74`](https://github.com/NixOS/nixpkgs/commit/e74d8f74f8fcead254999eca397d53a040381085) gsl: allow to build on all platforms
* [`5be27f19`](https://github.com/NixOS/nixpkgs/commit/5be27f190e686ad1f6df3413487f806b72128fa2) funzzy: 1.0.0 -> 1.0.1
* [`332fedbe`](https://github.com/NixOS/nixpkgs/commit/332fedbe9bc5243c8c2710926d5dd18916604059) notepad-next: enable on darwin
* [`79799711`](https://github.com/NixOS/nixpkgs/commit/79799711f49886919255d4573e89ab516d9e7288) python310Packages.rpy2: 3.5.11 -> 3.5.12
* [`11ab69a4`](https://github.com/NixOS/nixpkgs/commit/11ab69a41c5064fdc71d2befa3fbdc38ca687221) vimPlugins.iron-nvim: init at 2023-06-04
* [`80a3b4b7`](https://github.com/NixOS/nixpkgs/commit/80a3b4b7de2fa0570904c1e4bea7fda58be60c5d) android-studio: fix launching firefox from inside buildFHSUserEnv
* [`6a546b4a`](https://github.com/NixOS/nixpkgs/commit/6a546b4aacd6ef203b765a2d8e49512a87f2328c) vimPlugins: update
* [`2573f74d`](https://github.com/NixOS/nixpkgs/commit/2573f74d064aaf0e5c6b1941d668586d01e42ba4) nodePackages: update to latest
* [`d1a70874`](https://github.com/NixOS/nixpkgs/commit/d1a7087498d83c4d87242ada38a8ea7a1d82184b) vimPlugins.nvim-treesitter: update grammars
* [`9394bae3`](https://github.com/NixOS/nixpkgs/commit/9394bae3a30b91b2d0b58a846340baad7b4601ce) python310Packages.gidgethub: 5.2.1 -> 5.3.0
* [`f1fc3222`](https://github.com/NixOS/nixpkgs/commit/f1fc32221419a26751bf1fb0e1783c9f2e87749c) maintainers: add lord-valen
* [`a016e367`](https://github.com/NixOS/nixpkgs/commit/a016e36701c1164e0da5956262257ee24fe2460f) clight: 4.9 -> 4.10
* [`ec238a4f`](https://github.com/NixOS/nixpkgs/commit/ec238a4f39678fe86a17cafbc3472317466d34ff) cassandra_4: 4.1.0 -> 4.1.2
* [`8f35b335`](https://github.com/NixOS/nixpkgs/commit/8f35b33597b5fa73150d90f87fda65a8ec60dade) cargo-make: 0.36.9 -> 0.36.10
* [`5841d035`](https://github.com/NixOS/nixpkgs/commit/5841d0353a2adbbc91e377ad9f0afce2bbefb6cb) cctools-llvm: fix build with clang 16
* [`a8c0d558`](https://github.com/NixOS/nixpkgs/commit/a8c0d5583c8a5d6baf968d8311082b5960b153f7) iosevka: 24.1.1 -> 24.1.3
* [`543cfd9f`](https://github.com/NixOS/nixpkgs/commit/543cfd9fffc3a2ae4597089f6e7aaa1b3a7097d8) lact: init at 0.4.3
* [`bf600011`](https://github.com/NixOS/nixpkgs/commit/bf600011a079a3653c621ed8b90c73fc222d333e) consul: 1.15.2 -> 1.15.3
* [`e640c091`](https://github.com/NixOS/nixpkgs/commit/e640c091d62b26b8b30828bc5931f474b3d0a92c) oxigraph: 0.3.16 -> 0.3.17
* [`fc860204`](https://github.com/NixOS/nixpkgs/commit/fc8602043a01f102d01d2e5ae19356ee91ebcb50) srvc: 0.19.0 -> 0.19.1
* [`2f380f35`](https://github.com/NixOS/nixpkgs/commit/2f380f353f73b1ee626fce4087bdba3ca86f2373) erdtree: 3.0.1 -> 3.0.2
* [`a0f3dede`](https://github.com/NixOS/nixpkgs/commit/a0f3dede94b69ea049a711e76a5a52aec920a805) go-migrate: fix build on darwin
* [`35f0f6ac`](https://github.com/NixOS/nixpkgs/commit/35f0f6aca1e418619e28aae00e3b5908ba8b389b) pachyderm: 2.6.1 -> 2.6.3
* [`d2897cfd`](https://github.com/NixOS/nixpkgs/commit/d2897cfde88f13f5c81e5865ea104cdf24adb430) faustStk: remove duplicate
* [`7735e9b1`](https://github.com/NixOS/nixpkgs/commit/7735e9b13843365cbc57e78e7d9e30a62de27f49) constant-detune-chorus: mark broken
* [`4ebc4f74`](https://github.com/NixOS/nixpkgs/commit/4ebc4f74783bd02abd3a3d534225962d633d0d16) bearer: 1.9.0 -> 1.11.0
* [`6f3ea67c`](https://github.com/NixOS/nixpkgs/commit/6f3ea67cff553268fe0b562b97c54bac94ac2e70) telegraf: 1.26.3 -> 1.27.0
* [`4daf4a4a`](https://github.com/NixOS/nixpkgs/commit/4daf4a4add82882bcf812b8ff60a5b193e6b44e6) algolia-cli: 1.3.6 -> 1.3.7
* [`b992b750`](https://github.com/NixOS/nixpkgs/commit/b992b7502b9aa6a0f4b13663b10a40cd34cc0d00) ytt: 0.45.1 -> 0.45.2
* [`3c34f79b`](https://github.com/NixOS/nixpkgs/commit/3c34f79bf7aa618104d3f47724c457e7bf3584a9) ytt: 0.45.2 -> 0.45.3
* [`17a36446`](https://github.com/NixOS/nixpkgs/commit/17a36446ae44becb0abe2a54f404d6b6f7814409) ytt: install completions
* [`4a73c642`](https://github.com/NixOS/nixpkgs/commit/4a73c642d160bc619fe1d6afe12bb892dca1e5e7) murex: 4.1.6140 -> 4.1.7300
* [`d9abe6bc`](https://github.com/NixOS/nixpkgs/commit/d9abe6bc7c369dc4039cdd993bc6b5897e1f510d) unciv: 4.6.15 -> 4.6.19
* [`6ebe3fdc`](https://github.com/NixOS/nixpkgs/commit/6ebe3fdc4fb11896c9881d2f2d263391aa9cc6a9) adguardian: 1.5.0 -> 1.6.0
* [`fc5724e3`](https://github.com/NixOS/nixpkgs/commit/fc5724e33a4a51c3d6c80959360714a227e03d72) pythonPackages.polars: Fix build on darwin
* [`9145ccba`](https://github.com/NixOS/nixpkgs/commit/9145ccba2b6abd0f0f71a423e2c6ed02ac6dd1ad) jitsi-meet: 1.0.7235 -> 1.0.7322
* [`8b25845d`](https://github.com/NixOS/nixpkgs/commit/8b25845df346fe9875ef21287f54ad332e8f1969) gocryptfs: 2.3.2 -> 2.4.0
* [`9136cdd5`](https://github.com/NixOS/nixpkgs/commit/9136cdd591a2e2c68a38acf703af6c5fc4e2bed9) chezmoi: 2.34.0 -> 2.34.1
* [`4476d199`](https://github.com/NixOS/nixpkgs/commit/4476d19942290a863ad712d989b964e1d4f73e4a) rustus: 0.7.2 -> 0.7.3
* [`eb201eed`](https://github.com/NixOS/nixpkgs/commit/eb201eedd39ed626ee1e2187a856777ce3673320) subfinder: 2.5.9 -> 2.6.0
* [`9a2263c0`](https://github.com/NixOS/nixpkgs/commit/9a2263c0519b652554f97abc0d0ad4fceeb7e1b5) kubefirst: 2.0.8 -> 2.1.0
* [`e84b8cc1`](https://github.com/NixOS/nixpkgs/commit/e84b8cc15f7ebec61a158ac2328b1622b057bae7) ockam: 0.88.0 -> 0.89.0
* [`9b470145`](https://github.com/NixOS/nixpkgs/commit/9b4701455d57f9aa1ab466d8ed4323598592cb10) python3Packages.pyqt6: 6.5.0 -> 6.5.1
* [`a01eaa10`](https://github.com/NixOS/nixpkgs/commit/a01eaa1096e9e175ab4185b6fc4066ec51c3a078) python311Packages.grequests: 0.6.0 -> 0.7.0
* [`033f7b62`](https://github.com/NixOS/nixpkgs/commit/033f7b623a4c6f45fa7ea8e4b20a09501c65e8fa) ccache: disable failing test `test.fileclone` on aarch64-darwin
* [`bbb54b28`](https://github.com/NixOS/nixpkgs/commit/bbb54b288728076fdaaf842fc1cddfeab062d32d) python310Packages.steamship: 2.16.9 -> 2.17.7
* [`85918aad`](https://github.com/NixOS/nixpkgs/commit/85918aad1004f4e778f9b839c69976d986997a61) python310Packages.pycm: 3.8 -> 4.0
* [`1ef5dad4`](https://github.com/NixOS/nixpkgs/commit/1ef5dad4a30e05841406d6220ade55fb7674d220) postgresql11JitPackages.pgroonga: 3.0.5 -> 3.0.6
* [`10d0ac11`](https://github.com/NixOS/nixpkgs/commit/10d0ac11bc083cbcf0d6340950079b3888095abf) gpodder: wrap with missing `xdg-utils` path
* [`865f67ec`](https://github.com/NixOS/nixpkgs/commit/865f67ec1f1ed25a65ffb3afdf05fcb3979399e8) gpodder: 3.10.21 -> 3.11.1
* [`3bee849a`](https://github.com/NixOS/nixpkgs/commit/3bee849a371f35ee3ce6169096dd5736e438c2f8) python310Packages.pyreadstat: 1.2.1 -> 1.2.2
* [`491efa0b`](https://github.com/NixOS/nixpkgs/commit/491efa0b3e7e6708d6a923ea7f7ec7c33ad12c97) test-driver: respect timeout in wait_until_fails
* [`28eaa7eb`](https://github.com/NixOS/nixpkgs/commit/28eaa7ebc151292f24b32d17016ad3aa950ecfc5) rage: fix hash
* [`823132b1`](https://github.com/NixOS/nixpkgs/commit/823132b18007d830f21a8b1ff7af36678fe5e6e9) postgresqlPackages.pgvector: 0.4.3 -> 0.4.4
* [`104992f3`](https://github.com/NixOS/nixpkgs/commit/104992f3cf43dd4060c14650cc4d1b491a384db5) emacs: disable withXwidgets on darwin
* [`e0f32a36`](https://github.com/NixOS/nixpkgs/commit/e0f32a3637298f9cf0d48a659625bb47ba339ead) esbuild: 0.18.0 -> 0.18.2
* [`7fd1f842`](https://github.com/NixOS/nixpkgs/commit/7fd1f842a0be6c1f40c70eb440610784f9215248) terraform-providers.cloudamqp: 1.26.2 -> 1.27.0
* [`7fdbd940`](https://github.com/NixOS/nixpkgs/commit/7fdbd9403702fc1f6ec1ca14d266f41df3b596fb) terraform-providers.google: 4.68.0 -> 4.69.1
* [`439a3b0f`](https://github.com/NixOS/nixpkgs/commit/439a3b0fee9e4ea6e317f750c27b0f71c55cec5c) terraform-providers.google-beta: 4.68.0 -> 4.69.1
* [`4c50b8d5`](https://github.com/NixOS/nixpkgs/commit/4c50b8d5323a61cc6772a8bf5ad22d10d35ac5d3) terraform-providers.lxd: 1.9.1 -> 1.10.0
* [`763b7038`](https://github.com/NixOS/nixpkgs/commit/763b7038453d4758ca12c6c312f0b5d9edaa8754) terraform-providers.newrelic: 3.24.1 -> 3.24.2
* [`fc102de2`](https://github.com/NixOS/nixpkgs/commit/fc102de2711d5659ad18b46f0265b9959d5071a9) terraform-providers.opsgenie: 0.6.23 -> 0.6.24
* [`5a4d1a68`](https://github.com/NixOS/nixpkgs/commit/5a4d1a6897e116e7e3d5bc4117679dcf8fbce39d) terraform-providers.okta: 4.0.0 -> 4.0.1
* [`eb464f27`](https://github.com/NixOS/nixpkgs/commit/eb464f2771a3796dd54c27d58fe58e9ee6a493e8) ocamlPackages.parmap: 1.2.4 → 1.2.5
* [`635e71f6`](https://github.com/NixOS/nixpkgs/commit/635e71f62c734dc1f2a9d8f61b43bb032a183c83) ocamlPackages.cudf: 0.9 → 0.10
* [`b4e057c8`](https://github.com/NixOS/nixpkgs/commit/b4e057c88d3a97d2c11a0ba61775d222dbc459a9) ocamlPackages.dose3: cleanup
* [`c146c440`](https://github.com/NixOS/nixpkgs/commit/c146c4407229ed949b5538104b10a7c5c98489a5) prometheus-graphite-exporter: 0.13.3 -> 0.14.0
* [`78105286`](https://github.com/NixOS/nixpkgs/commit/781052862d6c7c8153e373541fba504369254c3d) grafana-agent: 0.34.0 -> 0.34.1
* [`6e43312a`](https://github.com/NixOS/nixpkgs/commit/6e43312a048faebcadb0138a6f9caf2aaf47aef5) frugal: 3.16.21 -> 3.16.23
* [`126fd86c`](https://github.com/NixOS/nixpkgs/commit/126fd86c3eefcc49bb894225cc5c4a870ce1a84a) ocamlPackages.mtime: 1.2.0 → 2.0.0
* [`8201afb7`](https://github.com/NixOS/nixpkgs/commit/8201afb77f65bf56ca52fe79d510fa9ad4e66515) ocamlPackages.mtime: create 1.x fork for compat
* [`e6eac639`](https://github.com/NixOS/nixpkgs/commit/e6eac639d9ecceab4a32a3514b2d03aa3affe0da) kaniko: 1.10.0 -> 1.11.0
* [`bf7e9519`](https://github.com/NixOS/nixpkgs/commit/bf7e951996bc9d6ad734e5670e2a517dfdbaa7b1) ocamlPackages.iomux: init at 0.3
* [`b81b9b0d`](https://github.com/NixOS/nixpkgs/commit/b81b9b0df913cee1ffffd99d09ea19258813518e) ocamlPacakges.domain-local-await: init at 0.2.0
* [`a748ffdb`](https://github.com/NixOS/nixpkgs/commit/a748ffdb6edbfc19eac10c522cb2e45af86c8e08) ocamlPackages.eio: init at 0.10
* [`ea7ec527`](https://github.com/NixOS/nixpkgs/commit/ea7ec527b7a758b433d9d10275608ab5f755447e) fluidd: 1.24.0 -> 1.24.1
* [`7fe2fde4`](https://github.com/NixOS/nixpkgs/commit/7fe2fde4823d8c036286b9d969c2af04e3f5909f) vscode-extensions.streetsidesoftware.code-spell-checker: 2.20.4 -> 2.20.5
* [`6e7a9f52`](https://github.com/NixOS/nixpkgs/commit/6e7a9f522dfbf6d8d7d24a3de435138f45e790bd) orbiton: 2.62.1 -> 2.62.3
* [`0046dd78`](https://github.com/NixOS/nixpkgs/commit/0046dd7807dc2fb5e02dbdf6cbe55783a8041369) xwayland: 23.1.1 -> 23.1.2
* [`79e9b121`](https://github.com/NixOS/nixpkgs/commit/79e9b1211fa40d903e28c6da05da66d0c1e119dd) zlint: 3.4.1 -> 3.5.0
* [`cd587988`](https://github.com/NixOS/nixpkgs/commit/cd587988357f3db3af8e8b66d6b3995cc39c849f) upscayl: init at 2.5.5
* [`2ad18c3c`](https://github.com/NixOS/nixpkgs/commit/2ad18c3c7cccc04f7f8180184f0ed7031fe5a2d0) python311Packages.aiobiketrax: 0.5.0 -> 1.0.0
* [`d154f62f`](https://github.com/NixOS/nixpkgs/commit/d154f62fc7e8406c6fa9a6c849de89b8042930a7) python311Packages.aiooss2: 0.2.5 -> 0.2.6
* [`9d8a6280`](https://github.com/NixOS/nixpkgs/commit/9d8a62806e02b92d31dd93188ebb07d5326a9d05) ocrmypdf: 14.2.0 -> 14.2.1
* [`c56085fc`](https://github.com/NixOS/nixpkgs/commit/c56085fc3e9c05848c454d0b4fd98b642a071c40) checkov: 2.3.285 -> 2.3.288
* [`48b45dbf`](https://github.com/NixOS/nixpkgs/commit/48b45dbfda3ce446b9a28ad06e855166f92b344f) calibre: 6.20.0 -> 6.21.0
* [`d0ef16f0`](https://github.com/NixOS/nixpkgs/commit/d0ef16f091a3af95dc0dccb20b8bc44919df0bcf) d2: 0.4.2 -> 0.5.1
* [`3a86958c`](https://github.com/NixOS/nixpkgs/commit/3a86958c974bc3a03c32ab33ecfc0ec9498c7869) prometheus-junos-czerwonk-exporter: init at 0.10.1 + module ([nixos/nixpkgs⁠#235433](https://togithub.com/nixos/nixpkgs/issues/235433))
* [`18c7f623`](https://github.com/NixOS/nixpkgs/commit/18c7f6237f92ef5ef9d7cf106ec2ffb72af336fc) lib.systems.{equals,toLosslessStringMaybe}: init
* [`14401854`](https://github.com/NixOS/nixpkgs/commit/144018541b20a0aa74ce32120b3a27660fab93dd) lib.systems.equals: Ignore all function attributes reflectively
* [`390f3e17`](https://github.com/NixOS/nixpkgs/commit/390f3e17e0982f78e0cb6a7a3d59aeffc719ee68) maintainers: add moody
* [`7005cdfa`](https://github.com/NixOS/nixpkgs/commit/7005cdfa529ce62445a2229632e0d101f7578bf3) grafanaPlugins.grafana-clickhouse-datasource: init at 3.1.0
* [`3150f25f`](https://github.com/NixOS/nixpkgs/commit/3150f25faa599c6c6215295144f5c6b4a87eea6e) lib/tests/release.nix: Run systems tests on OfBorg
* [`313b938d`](https://github.com/NixOS/nixpkgs/commit/313b938d21ad04e882dfdd4ed920518d243d922e) drawio: 21.2.8 -> 21.3.7
* [`3aada931`](https://github.com/NixOS/nixpkgs/commit/3aada931469e7656f6287c2b081455a967c6b659) nsd: 4.6.1 -> 4.7.0
* [`cf3969fe`](https://github.com/NixOS/nixpkgs/commit/cf3969fe0f87d6dbb3cb55df267d8b8a0bfccca1) json2tsv: 1.0 -> 1.1
* [`96ce8d59`](https://github.com/NixOS/nixpkgs/commit/96ce8d59649f20c21b01f146bcd6b37aa14cd59e) grafanaPlugins.grafanaPlugin: add platform only when multiple zipHash are specified ([nixos/nixpkgs⁠#237513](https://togithub.com/nixos/nixpkgs/issues/237513))
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
