### PR TITLE
niv devenv: update 9d51052c -> 93ee7875

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "9d51052c5983724a9225fa62587e0cbe51e50622",
-        "sha256": "08hjdyiyaa5h8dkyh311f8vjv3i97jdzklz7ripq7v4cqjd7d49j",
+        "rev": "93ee7875ff1622d496da80414724bae0263c1d23",
+        "sha256": "0pk2pnyly2bd2k486ivpvmjwd00az67sjybwxbhhfvrlj32fyq24",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/9d51052c5983724a9225fa62587e0cbe51e50622.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/93ee7875ff1622d496da80414724bae0263c1d23.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@9d51052c...93ee7875](https://github.com/cachix/devenv/compare/9d51052c5983724a9225fa62587e0cbe51e50622...93ee7875ff1622d496da80414724bae0263c1d23)

* [`26c44113`](https://github.com/cachix/devenv/commit/26c44113c81b773a85d27f765ce8946dde7219b6) temporal: add temporal service
* [`525895f5`](https://github.com/cachix/devenv/commit/525895f5a8d3d99c99248154bced266aa164ef2a) temporal: add state config
* [`1fc5976a`](https://github.com/cachix/devenv/commit/1fc5976a1551bdab6ab7cee743424a134ff54a87) ci(temporal): fix port collision on macOS
* [`d12fb308`](https://github.com/cachix/devenv/commit/d12fb308ef41e693dd3142c7d16af21809bbc948) fix: pass extra arguments to the procfile script
* [`dba0fd1b`](https://github.com/cachix/devenv/commit/dba0fd1b759643ccb976f77cf9b2f82a08e0e32c) postgres: handle directory in postgres.initialDatabases.*.schema
* [`6da2f203`](https://github.com/cachix/devenv/commit/6da2f2030b6733ccbee06063c36839a8f2702805) postgres: handle schema files that doesn't end in a ;
* [`234a926b`](https://github.com/cachix/devenv/commit/234a926b60dab7d9906b8a05abcbde7f9b627df2) postgres: handle complicated SQL with sub-statements
* [`6480682f`](https://github.com/cachix/devenv/commit/6480682feca7bf252421f8912e8f8caeb79427a0) postgres: handle blank lines in complicated sql with sub-statements
* [`03071971`](https://github.com/cachix/devenv/commit/030719719849a8fb18db0f58c134731cd69d4518) move process implementations to separate modules
* [`cea2add3`](https://github.com/cachix/devenv/commit/cea2add3a0c5b9f3436626135895f9b3f57297e4) dependabot -> renovate
* [`32d5c7a1`](https://github.com/cachix/devenv/commit/32d5c7a19d98f4da61cf70f4f1911d39798705d2) bump actions
* [`93ee7875`](https://github.com/cachix/devenv/commit/93ee7875ff1622d496da80414724bae0263c1d23) Auto generate docs/reference/options.md
