### PR TITLE
niv home-manager: update b01eb1eb -> f06a43dc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b01eb1eb3b579c74e6a4189ef33cc3fa24c40613",
-        "sha256": "1gs86h6happ39l99kiiaiiw0riwv9g7vlxbvr4nx7g46c55g2iq2",
+        "rev": "f06a43dca05fb7f1aa44742bf861d9c827b45122",
+        "sha256": "11zp8jf24ajqdh7aqia16dksdz0rbkxdn7f3jvpwwh084391x7dd",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/b01eb1eb3b579c74e6a4189ef33cc3fa24c40613.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f06a43dca05fb7f1aa44742bf861d9c827b45122.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@b01eb1eb...f06a43dc](https://github.com/nix-community/home-manager/compare/b01eb1eb3b579c74e6a4189ef33cc3fa24c40613...f06a43dca05fb7f1aa44742bf861d9c827b45122)

* [`c8dafb18`](https://github.com/nix-community/home-manager/commit/c8dafb187b7b010bf279a7bf0842eaadf3e387a8) specialisation: renamed from specialization
* [`d437f0d4`](https://github.com/nix-community/home-manager/commit/d437f0d4e0f72fe76688142e954a4a9b61ac9833) specialisation: fix path
* [`cbbceb48`](https://github.com/nix-community/home-manager/commit/cbbceb4894acb9750388e0cf535aa7a5663b207c) offlineimap: Add package option ([nix-community/home-manager⁠#4021](https://togithub.com/nix-community/home-manager/issues/4021))
* [`8da11353`](https://github.com/nix-community/home-manager/commit/8da1135365829e77fb5b17cfa4587860f306147f) aerc: improve module ([nix-community/home-manager⁠#3150](https://togithub.com/nix-community/home-manager/issues/3150))
* [`d9a97e8b`](https://github.com/nix-community/home-manager/commit/d9a97e8b33227a6086538ac2d3d1960b03ed940c) calendars: add missing modules ([nix-community/home-manager⁠#4087](https://togithub.com/nix-community/home-manager/issues/4087))
* [`0d1e053c`](https://github.com/nix-community/home-manager/commit/0d1e053ce997f1dc181a0790c3b1ba2c76550ace) vdirsyncer: Add missing include of services module ([nix-community/home-manager⁠#4089](https://togithub.com/nix-community/home-manager/issues/4089))
* [`25230267`](https://github.com/nix-community/home-manager/commit/252302673da838acb7ea545c5b945037fce9ae22) Translate using Weblate (Chinese (Simplified))
* [`e4aa9fd8`](https://github.com/nix-community/home-manager/commit/e4aa9fd83b5c2d43b3c9c9de979a8675fcb8e563) Translate using Weblate (Japanese)
* [`62f111ef`](https://github.com/nix-community/home-manager/commit/62f111ef1e50e518dbb3f0782a31dcd244a0a2d7) ci: bump cachix/install-nix-action from 20 to 21
* [`5db22bce`](https://github.com/nix-community/home-manager/commit/5db22bce05c776057fdb289da17f6c12049c4624) flake.lock: Update
* [`75b24cc5`](https://github.com/nix-community/home-manager/commit/75b24cc557d4947ab46691142863e5a5db5c3f78) thunderbird: support aliases
* [`32376992`](https://github.com/nix-community/home-manager/commit/32376992f7ef4d7ae76dda690de5b23725fd8300) qt: add "kde" to qt.platformTheme ([nix-community/home-manager⁠#4085](https://togithub.com/nix-community/home-manager/issues/4085))
* [`194086df`](https://github.com/nix-community/home-manager/commit/194086df82d235919c1f8da68c4af2490d4675f9) git-credential-oauth: add module
* [`e0034971`](https://github.com/nix-community/home-manager/commit/e0034971f9def16bbc32124147787bc0f09f0e59) comodoro: add module
* [`d214b93e`](https://github.com/nix-community/home-manager/commit/d214b93ee3c82b2746b85e8cb96bc150c6a74e50) Add missing qt modules ([nix-community/home-manager⁠#4094](https://togithub.com/nix-community/home-manager/issues/4094))
* [`4e09c832`](https://github.com/nix-community/home-manager/commit/4e09c83255c5b23d58714d56672d3946faf1bcef) qt: bunch of fixes and updates ([nix-community/home-manager⁠#4095](https://togithub.com/nix-community/home-manager/issues/4095))
* [`ea2f1761`](https://github.com/nix-community/home-manager/commit/ea2f17615e31783ace1271a3325e9cac27c3b4d8) khal: improve module ([nix-community/home-manager⁠#4088](https://togithub.com/nix-community/home-manager/issues/4088))
* [`9ba7b399`](https://github.com/nix-community/home-manager/commit/9ba7b3990eb1f4782ea3f5fe7ac4f3c88dd7a32c) qt: fix breeze-qt5 path ([nix-community/home-manager⁠#4098](https://togithub.com/nix-community/home-manager/issues/4098))
* [`162c17b0`](https://github.com/nix-community/home-manager/commit/162c17b0c9b9e3d80c7e731c03ad24157364432d) fontconfig: minor update of generated configuration
* [`f7c4dae2`](https://github.com/nix-community/home-manager/commit/f7c4dae2c818dc281ab73567f2fb6820c3597fb9) Translate using Weblate (French)
* [`edf9cf65`](https://github.com/nix-community/home-manager/commit/edf9cf65238609db16680be74fe28d4d4858476e) home-manager: prioritize `-I` parameters
* [`28c82303`](https://github.com/nix-community/home-manager/commit/28c823032cabfaa340a09e1d84cf45d11375c644) Bump install-nix-action to v22 ([nix-community/home-manager⁠#4111](https://togithub.com/nix-community/home-manager/issues/4111))
* [`0480dabc`](https://github.com/nix-community/home-manager/commit/0480dabc99e1b669ebe909949180fa2786e733cd) vdirsyncer: Fix service by moving the options before the command ([nix-community/home-manager⁠#4109](https://togithub.com/nix-community/home-manager/issues/4109))
* [`a10aa82e`](https://github.com/nix-community/home-manager/commit/a10aa82e8aaee11d8e8b8c5e7e19f758a7553bf0) docs: Document osConfig module argument ([nix-community/home-manager⁠#4103](https://togithub.com/nix-community/home-manager/issues/4103))
* [`6bdd72b9`](https://github.com/nix-community/home-manager/commit/6bdd72b914fc3472be807bc9b427650b49808a94) clipman: wrong module name in description ([nix-community/home-manager⁠#4117](https://togithub.com/nix-community/home-manager/issues/4117))
* [`f06a43dc`](https://github.com/nix-community/home-manager/commit/f06a43dca05fb7f1aa44742bf861d9c827b45122) starship: add enable_transience for fish ([nix-community/home-manager⁠#3975](https://togithub.com/nix-community/home-manager/issues/3975))
