### PR TITLE
niv niv: update 0ebb80e0 -> 914aba08

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "0ebb80e003c26d5388a9b74645fbdcfca3bdd0ef",
-        "sha256": "0wpnk1n4vjyqwjjrm6dvkyh7xr7983rszfhfcg31v106qhfnh41c",
+        "rev": "914aba08a26cb10538b84d00d6cfb01c9776d80c",
+        "sha256": "0gx316gc7prjay5b0cr13x4zc2pdbiwxkfkpjvrlb2rml80lm4pm",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/0ebb80e003c26d5388a9b74645fbdcfca3bdd0ef.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/914aba08a26cb10538b84d00d6cfb01c9776d80c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@0ebb80e0...914aba08](https://github.com/nmattia/niv/compare/0ebb80e003c26d5388a9b74645fbdcfca3bdd0ef...914aba08a26cb10538b84d00d6cfb01c9776d80c)

* [`914aba08`](https://github.com/nmattia/niv/commit/914aba08a26cb10538b84d00d6cfb01c9776d80c) Bump cachix/install-nix-action from 21 to 22 ([nmattia/niv⁠#373](https://togithub.com/nmattia/niv/issues/373))
