### PR TITLE
niv powerlevel10k: update 944f52fc -> ab8bac01

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "944f52fc430259ff49f497f3516a3ddfb45a0a6b",
-        "sha256": "1iq95w9lzxym50gg7q9sb8a9d0fl1zfvswzvgcbs9sf8zcgd6qbb",
+        "rev": "ab8bac01e2a90e1cd749d4936e4decbdba3c2727",
+        "sha256": "1glsfyb4sfgs1d3gjcji5q1qlzpwgzz7xljphyb407qj3b3m7x9m",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/944f52fc430259ff49f497f3516a3ddfb45a0a6b.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/ab8bac01e2a90e1cd749d4936e4decbdba3c2727.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@944f52fc...ab8bac01](https://github.com/romkatv/powerlevel10k/compare/944f52fc430259ff49f497f3516a3ddfb45a0a6b...ab8bac01e2a90e1cd749d4936e4decbdba3c2727)

* [`360dcd39`](https://github.com/romkatv/powerlevel10k/commit/360dcd3907a7556a2ffa841380142e1f9dc6ec33) respect XDG_DATA_HOME when looking for the timewarrior data directory ([romkatv/powerlevel10k⁠#2344](https://togithub.com/romkatv/powerlevel10k/issues/2344))
* [`ab8bac01`](https://github.com/romkatv/powerlevel10k/commit/ab8bac01e2a90e1cd749d4936e4decbdba3c2727) Add sparkctl to POWERLEVEL9K_KUBECONTEXT_SHOW_ON_COMMAND ([romkatv/powerlevel10k⁠#2346](https://togithub.com/romkatv/powerlevel10k/issues/2346))
