### PR TITLE
niv nixpkgs: update c2993f32 -> 67c352a9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2993f32a25fb875710b8eb9617b28e56ab7dec8",
-        "sha256": "0l47bci2vd7awmnkqy2f4chywhkq4lwdvh23klv1p2b8nmaiyddk",
+        "rev": "67c352a9379226f786fd25d1eb3c54fa8d131ab4",
+        "sha256": "0hv7wciy26ya2cb2ky9q9cnakly93dxkx9w5hkm78ry4cik4jdnj",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c2993f32a25fb875710b8eb9617b28e56ab7dec8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/67c352a9379226f786fd25d1eb3c54fa8d131ab4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c2993f32...67c352a9](https://github.com/nixos/nixpkgs/compare/c2993f32a25fb875710b8eb9617b28e56ab7dec8...67c352a9379226f786fd25d1eb3c54fa8d131ab4)

* [`796974e3`](https://github.com/NixOS/nixpkgs/commit/796974e32ea3abe14ec94ef632c2491314ce0454) datadog-agent: suppress datadog-agent loading errors
* [`7b71f112`](https://github.com/NixOS/nixpkgs/commit/7b71f112e1d9cf1f01ac49faf3b3addbe01b283b) libnut: init at unstable-2020-11-06
* [`bdf307f1`](https://github.com/NixOS/nixpkgs/commit/bdf307f192ea432a5f63bc83d2d2d49c1394e323) sdrplay: add support for aarch64
* [`f24f7ed2`](https://github.com/NixOS/nixpkgs/commit/f24f7ed242fb89cb23d4fdd832b4b24f8c12e28c) nixos/testing: increase systemd device timeout
* [`cf90db8b`](https://github.com/NixOS/nixpkgs/commit/cf90db8b708b01909ecdc1ca1f579db1f49005ce) nixiso/opentelemetry-collector: init
* [`40875c6b`](https://github.com/NixOS/nixpkgs/commit/40875c6b6e51ef54e1e1db4242dad463726c91df) cpupower: inherit patches from kernel
* [`87b42fea`](https://github.com/NixOS/nixpkgs/commit/87b42fea6702040aae6df95ae753a662a31d3ec2) slimserver: 7.9.2 -> 8.3.1
* [`b6453574`](https://github.com/NixOS/nixpkgs/commit/b64535747889e2913a203df0f6e05393409ef971) slimserver: fix load of plugin ShairTunes2
* [`196a95c0`](https://github.com/NixOS/nixpkgs/commit/196a95c01eacf8dbd4e6d615f02f3cdbf49b011c) slimserver: add adamcstephens as a maintainer
* [`866f75e5`](https://github.com/NixOS/nixpkgs/commit/866f75e5b9579a4c4f6391b68c2a31633ab13e30) lib.path.append: Add a law
* [`e8f6265c`](https://github.com/NixOS/nixpkgs/commit/e8f6265c3b9db66ba67f33923d59c503285004d4) eyedropper: 0.5.1 -> 0.6.0
* [`954e7dc3`](https://github.com/NixOS/nixpkgs/commit/954e7dc3d1bd11001d4edc995f8980adf33d85db) chromium: (cross) strip aarch64-linux-gnu- toolprefix only for native builds
* [`7b63a3b9`](https://github.com/NixOS/nixpkgs/commit/7b63a3b996aa6f44592a96284a1ca8683a70ad9a) nix-serve-ng: use upstream commit that is compatible with Nix 2.13
* [`61c9ea32`](https://github.com/NixOS/nixpkgs/commit/61c9ea32ec216355bedfd3c6b173054387572068) aprutil: 1.6.1 -> 1.6.3
* [`a6de979e`](https://github.com/NixOS/nixpkgs/commit/a6de979ec5c4177776d3bc4574c5bf9d0f1e86e9) rose-pine-gtk: add missing gtk-4.0 files
* [`4e68c536`](https://github.com/NixOS/nixpkgs/commit/4e68c536a48ca9e2f703f507de9d9cbb1c981a7d) forge-mtg: 1.6.53 -> 1.6.56
* [`48ac8a3b`](https://github.com/NixOS/nixpkgs/commit/48ac8a3bacad6452e13cf1dfe594e407680afec3) z3: 4.12.1
* [`d53d5a8b`](https://github.com/NixOS/nixpkgs/commit/d53d5a8b38f8ecbf75388a1582efd4c19e61d5da) llvmPackages.lldb: deduplicate >10
* [`dd3651b9`](https://github.com/NixOS/nixpkgs/commit/dd3651b95bf26cc6aba7f9a7ba7d6e2e64015d81) crystal_1_8: 1.8.1 -> 1.8.2
* [`fcc9ed06`](https://github.com/NixOS/nixpkgs/commit/fcc9ed06a5254226042ba00ac6a60fd75f40a402) azure-functions-core-tools: 4.0.4915 -> 4.0.5095
* [`f85cd886`](https://github.com/NixOS/nixpkgs/commit/f85cd886c48a603cca842f3304996e6ed7f796c3) pritunl-client: add shell completions
* [`619b142a`](https://github.com/NixOS/nixpkgs/commit/619b142a7fc0eb694a9d4efb987e4835ca4ed247) nixos-rebuild: allow passing --log-format
* [`4a81dfdb`](https://github.com/NixOS/nixpkgs/commit/4a81dfdb35574523ef744c115ae83173e461ccc2) lndmanage: 0.14.2 -> 0.15.0
* [`bec0dbe3`](https://github.com/NixOS/nixpkgs/commit/bec0dbe358538527bc1ba7e3ce8aa7679c709b1a) streamlink: 5.3.0 -> 5.5.1
* [`7798b4b0`](https://github.com/NixOS/nixpkgs/commit/7798b4b06e6f5bc663a5f71c3e28b7cd2652a40d) networkmanager-openconnect: 1.2.8 -> 1.2.10
* [`457f5681`](https://github.com/NixOS/nixpkgs/commit/457f56813d21053aa3a58a6a6b5d6dcb3b019e6c) k3s: add "1_26" builder which can be used for 1_27 too
* [`c71ef26e`](https://github.com/NixOS/nixpkgs/commit/c71ef26ecc9e4353589b4987d27d7c60e3b94755) k3s: init 1.27.1+k3s1
* [`2257ccd5`](https://github.com/NixOS/nixpkgs/commit/2257ccd54463d051611862d6a82753238eff22fd) k3s: name builder less confusingly
* [`109b44ea`](https://github.com/NixOS/nixpkgs/commit/109b44ea65a08b4a8f9253076ac2920a3673a151) openrct2: 0.4.4 -> 0.4.5
* [`c86ee97f`](https://github.com/NixOS/nixpkgs/commit/c86ee97f3b078af2cd6be7e95a0e83ecf197ac44) pgweb: 0.11.11 -> 0.14.0
* [`03c969f0`](https://github.com/NixOS/nixpkgs/commit/03c969f0cbf769c99bb2d5ef74ed567d9dd0e745) openssh_hpn: 9.2p1 -> 9.3p1
* [`a92bc576`](https://github.com/NixOS/nixpkgs/commit/a92bc576b12c47e5f4e765b3ff9ee3545905ebbc) nixos/stage-1: support bind mounts of files
* [`44f0488f`](https://github.com/NixOS/nixpkgs/commit/44f0488ff20b0219f0174d9075bf94a0fd6f9fa1) advi: use ghostscriptX instead of gs discovered at build time
* [`3b141061`](https://github.com/NixOS/nixpkgs/commit/3b141061769db1b712a027ade19312ac112a9dab) python3Packages.kmapper: mark broken
* [`b4ff6d58`](https://github.com/NixOS/nixpkgs/commit/b4ff6d58ee4f2d67742ec46f62de1ff16786a1c0) ktlint: 0.49.0 -> 0.49.1
* [`b4da951e`](https://github.com/NixOS/nixpkgs/commit/b4da951ec277047419df3369dd6d16e25971b60e) vaapiIntel: add enableGui option, adopt to SuperSandro2000
* [`fdb8f499`](https://github.com/NixOS/nixpkgs/commit/fdb8f4994a578fa848cc369fce6d15028ab7a459) vaapiIntel: rename to intel-vaapi-driver
* [`a0c1804f`](https://github.com/NixOS/nixpkgs/commit/a0c1804f59923be3c02428983a9495d08135f165) python310Packages.ansible: 7.2.0 -> 8.0.0
* [`7573c269`](https://github.com/NixOS/nixpkgs/commit/7573c269a899af49e88007e46154d9a263fac843) nixos/tests/apfs: clean up code
* [`871fd1b2`](https://github.com/NixOS/nixpkgs/commit/871fd1b210130a903985d61444c8a7903d3b3b8d) nss: 3.89.1 -> 3.90
* [`dceec615`](https://github.com/NixOS/nixpkgs/commit/dceec61589874828cb295646d44f7d423d1695dd) persist-queue: 0.8.0 -> 0.8.1
* [`661fec2d`](https://github.com/NixOS/nixpkgs/commit/661fec2d7c323828c26e5a3608903ac0b3238da0) citra: proper cubeb dependencies
* [`a4f1a02b`](https://github.com/NixOS/nixpkgs/commit/a4f1a02babaaed9d20c9088d4d52a2f1c2efbbbf) duckstation: proper cubeb dependencies
* [`a12628e2`](https://github.com/NixOS/nixpkgs/commit/a12628e25ef0f6dcb95c1b982bcc8debe5ee8de2) rpcs3: proper cubeb dependencies
* [`9f33aeaa`](https://github.com/NixOS/nixpkgs/commit/9f33aeaa7f7718999e543bc8198eee977ec0422d) pcsx2: proper cubeb dependencies
* [`789cd5ec`](https://github.com/NixOS/nixpkgs/commit/789cd5ec5e60dc08e21a2ec6672115bf0d00e1e3) gnome-solanum: 3.0.1 -> 4.0.0
* [`c3be5083`](https://github.com/NixOS/nixpkgs/commit/c3be5083f72db3cc09b2cd968dec4582170bb300) maintainers: add 999eagle
* [`f95647d1`](https://github.com/NixOS/nixpkgs/commit/f95647d1f6524a4411d89bc2f8e13851b6082ee9) python3Packages.pyqtchart: init at 5.15.6
* [`82070ce6`](https://github.com/NixOS/nixpkgs/commit/82070ce6fd7b96e9581551d26e9d205d144be4eb) python3Packages.pyqt3d: init at 5.15.6
* [`de21e91f`](https://github.com/NixOS/nixpkgs/commit/de21e91ff9b48480b382f2787e3769b86f190efb) python3Packages.pyqtdatavisualization: init at 5.15.5
* [`c856aad7`](https://github.com/NixOS/nixpkgs/commit/c856aad7728c715153bbf2ecade6b66d80067a48) python3Packages.pyqt5: add QtSerialPort
* [`dff0b1b4`](https://github.com/NixOS/nixpkgs/commit/dff0b1b4084c64f87a369daddcaee9a12733f05d) python3Packages.pyqt5: add QtDesigner
* [`a41e9730`](https://github.com/NixOS/nixpkgs/commit/a41e973062ddc4b0d1d43f1e11dfa25f0068d2a2) stdenv: add alderlake support
* [`64bfa05b`](https://github.com/NixOS/nixpkgs/commit/64bfa05b36ae13bb94327bb9154afdf4d7bfbdf7) vmTools: download debs from snapshot URLs
* [`ee0c8cd1`](https://github.com/NixOS/nixpkgs/commit/ee0c8cd15cd4ef5c3cf2292dc7c760de5e709eac) nixosTests.os-prober: fix filesystem for Debian
* [`6cee1ac9`](https://github.com/NixOS/nixpkgs/commit/6cee1ac9563cb04beb74f3fbdb7e721c8ee4ffe9) python310Packages.kombu: 5.2.4 -> 5.3.0
* [`e823bb58`](https://github.com/NixOS/nixpkgs/commit/e823bb582a22b8d28e36fb07dc75658591a1ad74) python310Packages.celery: 5.2.7 -> 5.3.0
* [`1887a9e9`](https://github.com/NixOS/nixpkgs/commit/1887a9e9a5531548c90ce17b5d0b125bbcb41f34) nghttp3: 0.11.0 -> 0.12.0
* [`8c00cae9`](https://github.com/NixOS/nixpkgs/commit/8c00cae9ce2dc06b619e958263defbba2f875ce4) python310Packages.pylsp-mypy: 0.6.6 -> 0.6.7
* [`bbd4ce7d`](https://github.com/NixOS/nixpkgs/commit/bbd4ce7d5e33e678f85475970985339651273cdc) wgautomesh: clearer documentation for `gossip_secret_file`
* [`5e8556cb`](https://github.com/NixOS/nixpkgs/commit/5e8556cbc2249b2cfc86ee8328d21636a45c8a9d) qdjango: init at unstable-2018-03-07
* [`450c30dd`](https://github.com/NixOS/nixpkgs/commit/450c30dd8d5b3b51db6c9194d01b7a608532a2f1) whereami: init at unstable-2022-02-18
* [`0997ae19`](https://github.com/NixOS/nixpkgs/commit/0997ae1903b0f18cd9e43e4a65ffdd8f1e1ff285) nixos/manual: disallow docbook option docs
* [`7542a1aa`](https://github.com/NixOS/nixpkgs/commit/7542a1aa8fde98d8ff2792f852af19a8bc798842) lib/options: remove literalDocBook
* [`5f35ae16`](https://github.com/NixOS/nixpkgs/commit/5f35ae16ec0ff4bb71776e3538fde2f561310b64) nixos-render-docs: remove literalDocBook support
* [`c0124439`](https://github.com/NixOS/nixpkgs/commit/c01244394c0b7278c507d6d5de9e4a78db85d1fa) nixos/make-options-doc: force markdownByDefault
* [`34eeac55`](https://github.com/NixOS/nixpkgs/commit/34eeac55449400f866573a3c9027c1d336db40a4) nixos-render-docs: default to markdown for options
* [`af1f07ff`](https://github.com/NixOS/nixpkgs/commit/af1f07ff03c59b081ff29f069f6c28009dfffad7) nixos/make-options-doc: check for manual paths in options.json
* [`1418c986`](https://github.com/NixOS/nixpkgs/commit/1418c986b00d2386baac359ee80e004fdba5083c) nixos/make-options-doc: remove options postprocessing
* [`20152b42`](https://github.com/NixOS/nixpkgs/commit/20152b4269356ab04cab7b3c7b0df3fea3455637) nixos/doc: remove docbook options compatibility
* [`d36f950d`](https://github.com/NixOS/nixpkgs/commit/d36f950d405369abca5144b14a201bc25c4a080a) lib: turn *MD functions into aliases
* [`f52f531a`](https://github.com/NixOS/nixpkgs/commit/f52f531a4e4791f79902ed3f4162bfd8ae899c01) nixos/make-options-doc: deprecate docbook outputs
* [`b206f4db`](https://github.com/NixOS/nixpkgs/commit/b206f4db2cfcef26d135217275f1677c0c95b449) xonsh: 0.13.4 -> 0.14.0
* [`73b97833`](https://github.com/NixOS/nixpkgs/commit/73b978331520d318d5ca6b4ae0732d09f392603a) pixelorama: 0.10.3 -> 0.11
* [`e0b817cc`](https://github.com/NixOS/nixpkgs/commit/e0b817ccb706921d8e387eabb1e219ca073ddc30) pixelorama: use finalAtts pattern with mkDerivation instead of rec
* [`44a7a7c5`](https://github.com/NixOS/nixpkgs/commit/44a7a7c5c76c619b1386c6e9f4545399f3c445c1) arduino-cli: 0.32.2 -> 0.33.0
* [`3f2f5bea`](https://github.com/NixOS/nixpkgs/commit/3f2f5bea96961fd0337f7fd3c523ad338155b078) nixos/keter: 2.0 -> 2.1
* [`5c4ae23e`](https://github.com/NixOS/nixpkgs/commit/5c4ae23ec0e2b613eeb93b93092b486e755bc975) nixos/keter: Run nixpkgs-fmt
* [`b5cc73db`](https://github.com/NixOS/nixpkgs/commit/b5cc73db7dcf3a731ca1215dab75a78d47a44042) nixos/version: remove nixpkgs commit rev from initrd
* [`9bb37b46`](https://github.com/NixOS/nixpkgs/commit/9bb37b460776b2605748fa8aad098f3c4dedcf1a) scala_3: 3.2.2 -> 3.3.0
* [`59207cc9`](https://github.com/NixOS/nixpkgs/commit/59207cc93015ba7a5b0436bb669587cb81177326) nixos/adguardhome: Add `allowDHCP` option
* [`43f5975c`](https://github.com/NixOS/nixpkgs/commit/43f5975c69bde0bb10ae6e966b806e404071c5d4) minimal-bootstrap.xz: init at 5.0.8
* [`0eef6b58`](https://github.com/NixOS/nixpkgs/commit/0eef6b580136f1ad38455d9a9496ab73b10d2942) python3Packages.ev3dev2: fix build failure
* [`c5b7187c`](https://github.com/NixOS/nixpkgs/commit/c5b7187c109dc85dee6a8478bd4ab6c0bcbac726) sway-unwrapped: rename wlroots_0_16 argument to wlroots
* [`c892be9f`](https://github.com/NixOS/nixpkgs/commit/c892be9f5808a0ad01284f330affa412390b5608) wlroots: pass enableXWayland as derivation attribute
* [`898559e7`](https://github.com/NixOS/nixpkgs/commit/898559e730be1fc6a10d0e720b88a13fa940ea60) sway: move enableXWayland to derivation attribute
* [`9231527e`](https://github.com/NixOS/nixpkgs/commit/9231527e6b8dfa047a3ab9a5c3a11f10c656fe0c) qdjango: Potential test fix for Darwin
* [`592213ad`](https://github.com/NixOS/nixpkgs/commit/592213ad3f4de2cf3a0f13ab8271122e5e9f9822) lib.path.hasPrefix: init
* [`f30598cd`](https://github.com/NixOS/nixpkgs/commit/f30598cd5be47567a40e288742581e7651bf5d52) proxmark3-rrg: support darwin + more build options
* [`65a69692`](https://github.com/NixOS/nixpkgs/commit/65a69692469e3efb797e83eae8ae9e2938022347) libtraceevent: 1.6.2 -> 1.7.3
* [`426903d2`](https://github.com/NixOS/nixpkgs/commit/426903d2fba217314309e3002e0247d3a772564e) nixos/manual: remove docbook intermediates
* [`6fcb6eee`](https://github.com/NixOS/nixpkgs/commit/6fcb6eee774e3e5cc9b49f1b6a081ad5f992f5d2) nixos/doc: set meta generator for html manuals properly
* [`b9756b4d`](https://github.com/NixOS/nixpkgs/commit/b9756b4de176bbf2086702050d24f8f90fd0f4d9) lib: unhide _module.args
* [`3e7649f0`](https://github.com/NixOS/nixpkgs/commit/3e7649f01be8b7a4295bd414e6cb905affff7d66) docbook-xsl: remove nixos-specific patch
* [`a742767b`](https://github.com/NixOS/nixpkgs/commit/a742767bafecf0644585309b744e24f90cdff207) nixos/nixpkgs: Make default Nixpkgs lazy when overridden
* [`36ea2bbf`](https://github.com/NixOS/nixpkgs/commit/36ea2bbfe81ccf1118fd0ef66b13868fa3cc27e4) lib.modules: Add mergeAttrDefinitionsWithPrio
* [`8f31bff7`](https://github.com/NixOS/nixpkgs/commit/8f31bff7940ed8d8d3e250e6ab7e7bc5b6160f1d) nixos/nixpkgs: Don't check when _module.args.pkgs is set
* [`025d82d4`](https://github.com/NixOS/nixpkgs/commit/025d82d45cf50400f68f06c5d07458f54926956e) libguestfs, guestfs-tools: 1.48.(4/2) -> 1.50.1
* [`4caa2a52`](https://github.com/NixOS/nixpkgs/commit/4caa2a5271364a4ef50ea575bac2d18084c54364) python310Packages.nvchecker: 2.11 -> 2.12
* [`d246683f`](https://github.com/NixOS/nixpkgs/commit/d246683fe9be9918a4a023b3e56914d7a8bbb4fa) postgresqlPackages.postgis: 3.3.2 -> 3.3.3
* [`91785f14`](https://github.com/NixOS/nixpkgs/commit/91785f14b45470636c4f984d49987e5016b1fed7) libtraceevent: switch to meson build system
* [`1fa9d967`](https://github.com/NixOS/nixpkgs/commit/1fa9d96767375e8331691e0e6f805f5721daf1b8) libtracefs: 1.6.4 -> 1.7.0
* [`9e9dac32`](https://github.com/NixOS/nixpkgs/commit/9e9dac32f7b17997d3a3f53f7a3375ef965c271f) libtracefs: switch to meson build system
* [`fca08595`](https://github.com/NixOS/nixpkgs/commit/fca0859538f28373ec0ab26ccfd52a57447c1680) trace-cmd: 3.1.6 -> 3.2
* [`bec93160`](https://github.com/NixOS/nixpkgs/commit/bec93160c9672121f65a30fcaa3c966d86dfe1a3) trace-cmd: add myself to maintainers
* [`40c923aa`](https://github.com/NixOS/nixpkgs/commit/40c923aa13806beae85966bf063bd865812fefa8) davmail: enable sandboxing options
* [`3b849a57`](https://github.com/NixOS/nixpkgs/commit/3b849a57f2c83086178ca80b995dfd82177af974) ardour: fix default plugin search paths
* [`29aa4da1`](https://github.com/NixOS/nixpkgs/commit/29aa4da16b77b6dcd6e8bb77c9c1f6e2f9790cb4) spotify: 1.2.9.743.g85d9593d -> 1.2.11.916.geb595a67
* [`a0bc9475`](https://github.com/NixOS/nixpkgs/commit/a0bc94754019b4f7c9e158f1d415dcf273884135) xmp: 4.1.0 -> 4.2.0
* [`d8cd7961`](https://github.com/NixOS/nixpkgs/commit/d8cd7961b8f0740925eb9d859cf9341de447d604) marker: 2020.04.04.2 -> 2023.05.02
* [`9537e607`](https://github.com/NixOS/nixpkgs/commit/9537e6070961016b93096608017630559671e2c0) marker: add aleksana as maintainer
* [`428e7ad7`](https://github.com/NixOS/nixpkgs/commit/428e7ad738b274f4acf3c037539deb370b770063) libxc: 6.2.0 -> 6.2.2
* [`46e39be4`](https://github.com/NixOS/nixpkgs/commit/46e39be44e92159f191433057a508ab63bdf3b5a) maintainers: add gobidev
* [`4424f3c9`](https://github.com/NixOS/nixpkgs/commit/4424f3c9a03d80e95d5e66b29a465c0833a9a035) pfetch-rs: init at 2.7.0
* [`1a2a8961`](https://github.com/NixOS/nixpkgs/commit/1a2a89610409ac7348e11067f458e3e7818a9160) pdal: 2.5.4 -> 2.5.5
* [`c4181f9a`](https://github.com/NixOS/nixpkgs/commit/c4181f9af1e1cca1b3b77c5a534f21ba1faa93db) elasticmq-server-bin: 1.4.1 -> 1.4.2
* [`302442c0`](https://github.com/NixOS/nixpkgs/commit/302442c0f5d7124d0457abe1e929691b1b7f0d2e) elasticmq-server-bin: use finalAttrs pattern
* [`d90fb7b8`](https://github.com/NixOS/nixpkgs/commit/d90fb7b86185aeaa0b1bf76c0b93969c989f39ed) eartag: 0.4.0 -> 0.4.1
* [`ceb1f85b`](https://github.com/NixOS/nixpkgs/commit/ceb1f85bc0fe219a21f9d7b2a592ebea6f724490) androidStudioPackages.beta: 2022.3.1.12 -> 2022.3.1.16
* [`3e4fdbd6`](https://github.com/NixOS/nixpkgs/commit/3e4fdbd63f9ab77c81921c22e60ba1bdcd0ddc20) python311Packages.zeroconf: 0.64.0 -> 0.64.1
* [`6f3a7c5b`](https://github.com/NixOS/nixpkgs/commit/6f3a7c5b5524c6bc21bbb7d9dbdaa424d877e2bb) python311Packages.zeroconf: 0.64.1 -> 0.66.0
* [`983f5564`](https://github.com/NixOS/nixpkgs/commit/983f5564baee2de94b8d50f6fa9830ef2e483b50) python311Packages.zeroconf: 0.66.0 -> 0.68.0
* [`d9dd89d3`](https://github.com/NixOS/nixpkgs/commit/d9dd89d3681f7ea298dc5cf7bdc87a99372e5f23) vscode-extensions.charliermarsh.ruff: 2023.22.0 -> 2023.24.0
* [`50940008`](https://github.com/NixOS/nixpkgs/commit/50940008e8cfda297fb0dcd94bd254975f4e3e68) mavenbuild: drop
* [`c2e920a1`](https://github.com/NixOS/nixpkgs/commit/c2e920a10771d81414da4a03fa7fcf21b8ba5db6) FIL-plugins: fix cross compilation
* [`81e1baaf`](https://github.com/NixOS/nixpkgs/commit/81e1baafcf5ab6c12861cff9abd4e913cc3a20bf) python310Packages.css-inline: 0.9.0 -> 0.10.0
* [`e837475e`](https://github.com/NixOS/nixpkgs/commit/e837475e8bab1cd543faf783e18286d7b35efc14) assimp: fix build for riscv
* [`c3fa4f91`](https://github.com/NixOS/nixpkgs/commit/c3fa4f91707f5b007539f9ce5fd0319cc2f6db66) nixos/systemd: Make the fsck unit depend only on FS packages.
* [`84d4a19c`](https://github.com/NixOS/nixpkgs/commit/84d4a19c5cc898572a1b7bfd96ae4650172e0503) phlare: 0.5.1 -> 0.6.1
* [`130b79cb`](https://github.com/NixOS/nixpkgs/commit/130b79cbaf7ddaba59c8c8e775ed5cc0db22c378) duckdb: 0.8.0 -> 0.8.1
* [`f55a9879`](https://github.com/NixOS/nixpkgs/commit/f55a98797ebd16fced61396b37db3410066869b8) evcc: 0.118.0 -> 0.118.1
* [`367403c8`](https://github.com/NixOS/nixpkgs/commit/367403c873d0317322eca6e712f3ddfb6eca0999) python3Packages.sqlglot: 15.0.0 -> 16.3.1
* [`0bfba0e5`](https://github.com/NixOS/nixpkgs/commit/0bfba0e58dd9c918056d9ebc86b7e0a9ffe6224f) ryujinx: 1.1.826 -> 1.1.897
* [`36790217`](https://github.com/NixOS/nixpkgs/commit/3679021787f838231ea8986f303a9af9f78ebbb1) snapper: 0.10.4 -> 0.10.5
* [`42a6b41e`](https://github.com/NixOS/nixpkgs/commit/42a6b41e33ca888149dc65708722a7e3d93194e3) nixos/snapper/test: fix, make compliant with new config scheme
* [`69b61d23`](https://github.com/NixOS/nixpkgs/commit/69b61d23ea12b040dde6ea88ca361c3bb9c880a6) python311Packages.pypoolstation: 0.4.9 -> 0.5.1
* [`a9f25221`](https://github.com/NixOS/nixpkgs/commit/a9f25221a9c34b1a5d636eada2587ea6991d2a34) python311Packages.pywemo: 0.9.2 -> 1.0.0
* [`53cacfbc`](https://github.com/NixOS/nixpkgs/commit/53cacfbc492f8cc81a8692cbbfa46e0e3d7a6d95) meek: init at 0.38.0
* [`b84df913`](https://github.com/NixOS/nixpkgs/commit/b84df913cd67e9a5338b6879e1953e210786c242) oculante: 0.6.64 -> 0.6.65
* [`c17cbfd0`](https://github.com/NixOS/nixpkgs/commit/c17cbfd032597718789ed774a76a3ac6c3c7cb9a) boundary: 0.12.2 -> 0.13.0
* [`2cedfd3e`](https://github.com/NixOS/nixpkgs/commit/2cedfd3e51c3cc15f74959dc1217b9f54f7c05ab) licenses: add Knuth license
* [`42046d39`](https://github.com/NixOS/nixpkgs/commit/42046d39235e62a2d6b6d958d81c91e3edd7190a) python311Packages.cssutils: 2.7.0 -> 2.7.1
* [`48710d0a`](https://github.com/NixOS/nixpkgs/commit/48710d0ae606683ee3339f5ba7237c749fe583b6) i2p: 2.2.0 -> 2.2.1
* [`a9c9b628`](https://github.com/NixOS/nixpkgs/commit/a9c9b6280d48ff1144ced9047c6400d2cfa991a6) vencord: 1.2.5 -> 1.2.8
* [`9ac92490`](https://github.com/NixOS/nixpkgs/commit/9ac924903fd50adedf26bf9872ac7732778e2e3d) python310Packages.django-cleanup: 7.0.0 -> 8.0.0
* [`9bbc24e2`](https://github.com/NixOS/nixpkgs/commit/9bbc24e2669869121f66ca10808f2bbd1c92d0c4) urdfdom: cleanup dependencies
* [`f68a0d0f`](https://github.com/NixOS/nixpkgs/commit/f68a0d0fd7539d93c7454989f71fd1c824f3b46f) urdfdom: 3.1.0 -> 3.1.1
* [`3e51c9a0`](https://github.com/NixOS/nixpkgs/commit/3e51c9a04c3c2f810ed925691418f77af8ef0c42) scrcpy: use adb from android-tools
* [`7e3053b5`](https://github.com/NixOS/nixpkgs/commit/7e3053b534472be706b516403b75112815a50847) alfred,batctl: don't override PKG_CONFIG
* [`144ded54`](https://github.com/NixOS/nixpkgs/commit/144ded54abc95d9e8824ea3706d7440ab11a7e61) suricata: 6.0.12 -> 6.0.13
* [`2f68d8cb`](https://github.com/NixOS/nixpkgs/commit/2f68d8cb10e1b9b5a695cfff175d81630850624e) nixos/grafana: reformat
* [`5e4ec145`](https://github.com/NixOS/nixpkgs/commit/5e4ec14596fc081a844947f4e0ce5bc7ade5e591) nixos/grafana: update and add settings
* [`d699a144`](https://github.com/NixOS/nixpkgs/commit/d699a144aecce6ca64271e505efaa9af90902bb5) catppuccin-kde: fix install script
* [`7170ab45`](https://github.com/NixOS/nixpkgs/commit/7170ab4522aad5447f2d2a90d88f73e9ba93b2f2) sarasa-gothic: 0.41.0 -> 0.41.2
* [`6c9be0bf`](https://github.com/NixOS/nixpkgs/commit/6c9be0bf7a004a8c5da4b404bb68c3c0f3a92baf) lib/systems: remove redundant test from selectEmulator
* [`3f9911ab`](https://github.com/NixOS/nixpkgs/commit/3f9911abb8ca20edd7c0eb77d1a2b42a52b263cf) android-udev-rules: 20230303 -> 20230614
* [`0247863e`](https://github.com/NixOS/nixpkgs/commit/0247863e1e1252979c47441bf1e7fd9396856d0c) vgmtools: unstable-2023-04-17 -> unstable-2023-05-04
* [`69a2b23a`](https://github.com/NixOS/nixpkgs/commit/69a2b23a01f7aeec80e3ab5c37440bbf5329c7a5) pkgs/top-level/release: cache openssl-1.1.1u instead of openssl-1.1.1t
* [`d97c592d`](https://github.com/NixOS/nixpkgs/commit/d97c592db5f4cfe2add1eca40a73a539daade195) glooctl: 1.14.7 -> 1.14.8
* [`7197fb5e`](https://github.com/NixOS/nixpkgs/commit/7197fb5ed6c1b1d828a4d352a0db6a3697387707) konstraint: 0.29.0 -> 0.29.1
* [`24c524f8`](https://github.com/NixOS/nixpkgs/commit/24c524f89d6e2ce76742a4b883bf1a48b8e60e13) licenses: add LPPL-1.0
* [`b21e5093`](https://github.com/NixOS/nixpkgs/commit/b21e5093676517083b0b5de708652b10bf961be5) licenses: add LPPL-1.3a
* [`617c9e26`](https://github.com/NixOS/nixpkgs/commit/617c9e26a29d26194a9add72ccb00f0f15db4580) licenses: add CC-BY-1.0
* [`69976120`](https://github.com/NixOS/nixpkgs/commit/69976120f746d0ba3f19bb9188279f9cf44282ef) licenses: add CC-BY-SA-1.0
* [`e4fdd4e6`](https://github.com/NixOS/nixpkgs/commit/e4fdd4e6aedded3653ff39873fc8dee7279ae8ca) licenses: add CC-BY-SA-2.0
* [`ed956973`](https://github.com/NixOS/nixpkgs/commit/ed95697332e5d1c3368225eacfb12923bbed3998) licenses: add Artistic-1.0-cl8
* [`a2c3bc9d`](https://github.com/NixOS/nixpkgs/commit/a2c3bc9df6e7bdd9b7ed49e4ccad9a9584667144) licenses: add GFSL
* [`b165189b`](https://github.com/NixOS/nixpkgs/commit/b165189b972ec6d116766508794e654f96b5a575) licenses: add GFL
* [`8a22ed47`](https://github.com/NixOS/nixpkgs/commit/8a22ed472e93c8380a2c734466d65f25167da33f) texlive.tlpdb.nix: extract licensing information
* [`a83af56b`](https://github.com/NixOS/nixpkgs/commit/a83af56bcb78c6ae2a4cc98b1e0290d07cff32e2) texlive: add license to texlive packages
* [`fa742847`](https://github.com/NixOS/nixpkgs/commit/fa7428470abdfea7a4e1e1ac5d3e9ebac452f2a2) texlive.combine: expose licensing information of combined packages
* [`890fbc31`](https://github.com/NixOS/nixpkgs/commit/890fbc31f88bf340871cfeb854af3a8cab93bac0) python310Packages.annoy: 1.17.2 -> 1.17.3
* [`88397203`](https://github.com/NixOS/nixpkgs/commit/88397203d37c147f640136c765702dc16a51bf04) python310Packages.dvclive: 2.11.1 -> 2.11.3
* [`5d14150c`](https://github.com/NixOS/nixpkgs/commit/5d14150c1ee6bad969a7193056e4a3ebaa0c663b) maintainers: add Misaka13514
* [`b1d3870f`](https://github.com/NixOS/nixpkgs/commit/b1d3870fb3e97e2e542cb66a2d7e0a527412622e) raycast: 1.53.3 -> 1.53.4
* [`cd7cf98d`](https://github.com/NixOS/nixpkgs/commit/cd7cf98d5d90c54dc1a2489c134441ade0a41d9a) python3Packages.python-ev3dev2: rename from python3Packages.ev3dev2
* [`f8cd609d`](https://github.com/NixOS/nixpkgs/commit/f8cd609d852ba0ae43d2c37f26b302debd131779) Fix: make Espanso.app on darwin
* [`cf68bb58`](https://github.com/NixOS/nixpkgs/commit/cf68bb58a4c422eb6e7e8fbab1211a09df245d6a) soupault: 4.4.0 → 4.6.0
* [`2e3abfcf`](https://github.com/NixOS/nixpkgs/commit/2e3abfcf8a9f6e1993c1eaf810dee8dea799177a) reviewdog: 0.14.1 -> 0.14.2
* [`5789287a`](https://github.com/NixOS/nixpkgs/commit/5789287a95caf4ea3228cdc15a0901b063fbebe6) esbuild: 0.18.4 -> 0.18.5
* [`568f51fb`](https://github.com/NixOS/nixpkgs/commit/568f51fbd8993f039efa1487a51f23047e1244ce) millet: 0.11.0 -> 0.11.1
* [`afaa3c2f`](https://github.com/NixOS/nixpkgs/commit/afaa3c2fe1ebdd12bbe957ad619948897486b6a5) flow: 0.208.0 -> 0.209.0
* [`14c735cc`](https://github.com/NixOS/nixpkgs/commit/14c735ccf7cbd829c48b77eb02f226fb3972b53d) ocamlPackages.camomile_0_8_2: drop
* [`9a415334`](https://github.com/NixOS/nixpkgs/commit/9a41533476ebb5a32b28dc9b8b46c2c1ee41497f) Update pkgs/development/libraries/libnut/default.nix
* [`c51debb0`](https://github.com/NixOS/nixpkgs/commit/c51debb0a1bdb134eb3fa138408fd23f8e170680) Update pkgs/development/libraries/libnut/default.nix
* [`e01226be`](https://github.com/NixOS/nixpkgs/commit/e01226be9ebbba24206abcd0674f460b20c4f55e) Remove pkgs/development/libraries/libnut/prefix.patch and remove
* [`0b282be9`](https://github.com/NixOS/nixpkgs/commit/0b282be97a6264b540322b470eaf3a069d95e8f4) emacsPackages.ebuild-mode: 1.63 -> 1.64
* [`cc4fdf09`](https://github.com/NixOS/nixpkgs/commit/cc4fdf09992b2432da13b67f23fdce7749200ec8) debian-devscripts: 2.22.2 -> 2.23.5
* [`3b41d265`](https://github.com/NixOS/nixpkgs/commit/3b41d265b1a87b95c17095fc35a27bc3896c34e1) czkawka: 5.1.0 -> 6.0.0
* [`bcd1d4c9`](https://github.com/NixOS/nixpkgs/commit/bcd1d4c93613c0d6f269d00cc69bd2f54f4402e4) waypoint: 0.11.1 -> 0.11.2
* [`61e5bba2`](https://github.com/NixOS/nixpkgs/commit/61e5bba2b7239d15719700603ffc04f11ecaf36e) gcc11: 11.3.0 -> 11.4.0
* [`855da7b4`](https://github.com/NixOS/nixpkgs/commit/855da7b46f60233a640d682802fc9caca1ed85fb) python310Packages.pdf2image: 1.16.2 -> 1.16.3
* [`bf8de9dd`](https://github.com/NixOS/nixpkgs/commit/bf8de9ddba83bff2e245368c40d5aca42418229e) haruna: 0.11.0 -> 0.11.1
* [`5a2449f5`](https://github.com/NixOS/nixpkgs/commit/5a2449f5966a081b5b8ef569dc0513950a75d4c4) dart: 3.0.4 -> 3.0.5
* [`0e12588e`](https://github.com/NixOS/nixpkgs/commit/0e12588e4a0de4422dfad9a17648623bbd4e466e) python3Packages.ruff-lsp: 0.0.31 -> 0.0.32
* [`b7257455`](https://github.com/NixOS/nixpkgs/commit/b725745509f5599e62b162679e9338647dec67e3) openscenegraph: unbreak on darwin
* [`e390743e`](https://github.com/NixOS/nixpkgs/commit/e390743e490d2d4217dbe587b323427acc9ce14d) gnome-video-effects: 0.5.0 → 0.6.0
* [`c1392fba`](https://github.com/NixOS/nixpkgs/commit/c1392fba87cece15e4d4903005823c4faf1f7daa) evince: 44.1 → 44.2
* [`03ddc757`](https://github.com/NixOS/nixpkgs/commit/03ddc75701a1be07e9d501b280d0dd1a14d1ff9c) lua53Packages.vstruct: mark as not broken
* [`972852bd`](https://github.com/NixOS/nixpkgs/commit/972852bd9bb283367d574831d242c3fdd318ef69) python310Packages.flower: 1.2.0 -> 2.0.0
* [`8ff0ff40`](https://github.com/NixOS/nixpkgs/commit/8ff0ff403a01289e51a2cf01a47994106b7c2fed) python310Packages.bytecode: 0.14.1 -> 0.14.2
* [`652c4994`](https://github.com/NixOS/nixpkgs/commit/652c4994d4b68d4bc0348fab96d9064dbc9b8fca) tang: 13 -> 14
* [`b344d0aa`](https://github.com/NixOS/nixpkgs/commit/b344d0aa4ed40f23a8ea5279e71ce97aa7406ab7) gnome-extension-manager: 0.4.1 -> 0.4.2
* [`d2ff0235`](https://github.com/NixOS/nixpkgs/commit/d2ff023578818a888fd45fa9287380f805a72d02) alpine-make-vm-image: 0.11.0 -> 0.11.1
* [`4a40e22a`](https://github.com/NixOS/nixpkgs/commit/4a40e22af27f15dadd2c231ca3f49bb304a89725) ly: 0.2.1 -> 0.6.0
* [`8a7056ca`](https://github.com/NixOS/nixpkgs/commit/8a7056caa120cc36c9fb9a5d8aca5e9cc2d3a2df) ansifilter: 2.19 -> 2.20
* [`020954a0`](https://github.com/NixOS/nixpkgs/commit/020954a039f1263a6ce5097c366709bec1320527) aws-nuke: 2.21.2 -> 2.22.1
* [`4f97cf71`](https://github.com/NixOS/nixpkgs/commit/4f97cf71e491f3e3888b8922b50da35d748fa2a2) cargo-make: 0.36.10 -> 0.36.11
* [`2d2c35a0`](https://github.com/NixOS/nixpkgs/commit/2d2c35a0233bdbe25599038443a914aa346eab65) lobster: 2023.6 -> 2023.9
* [`ab031005`](https://github.com/NixOS/nixpkgs/commit/ab0310055a06c89b146685146af256b057b25ca0) omnisharp-roslyn: 1.39.6 -> 1.39.7
* [`f3f4a347`](https://github.com/NixOS/nixpkgs/commit/f3f4a347a5917119e6043ff0a4afe77667c2a676) gitlab: 16.0.4 -> 16.0.5
* [`42fe020a`](https://github.com/NixOS/nixpkgs/commit/42fe020a71a17ce6c4134e45d11f602b9160354f) shattered-pixel-dungeon: 2.0.2 -> 2.1.2
* [`f3ccc82a`](https://github.com/NixOS/nixpkgs/commit/f3ccc82a1bfe9b9931f210de0bc22ed2fc5a09c3) thunderbird-unwrapped: 102.11.2 -> 102.12.0
* [`5e6ac68f`](https://github.com/NixOS/nixpkgs/commit/5e6ac68f5b493a0efde6d39caea281247fd4dddd) linearicons-free: init at v1.0.0
* [`36a9154a`](https://github.com/NixOS/nixpkgs/commit/36a9154a103b814d8629b2fe2004b9a8c5369ac6) tigervnc: 1.12.0 -> 1.13.1
* [`e0276f64`](https://github.com/NixOS/nixpkgs/commit/e0276f64837a697948f237347fa5f57cd50bef57) python310Packages.pytest-testmon: 2.0.8 -> 2.0.9
* [`1cb20cc4`](https://github.com/NixOS/nixpkgs/commit/1cb20cc435bab5215c43912afe8188682fe9ba53) python310Packages.python-lsp-server: 1.7.2 -> 1.7.3
* [`0998d4e4`](https://github.com/NixOS/nixpkgs/commit/0998d4e4e26e34c70e2b88b8a97ea0c0c1ff7e3a) rio: init at 0.0.6.1+2023-06-18
* [`a8972d19`](https://github.com/NixOS/nixpkgs/commit/a8972d1910313bb070cc074dc46151e82c472fb2) build(deps): bump cachix/install-nix-action from 21 to 22
* [`ac33ccf7`](https://github.com/NixOS/nixpkgs/commit/ac33ccf7794eba28746111cfed5d89419857daf6) mono: add licensing details
* [`09465e0c`](https://github.com/NixOS/nixpkgs/commit/09465e0cd9a1fa70f5da66e6f64d6c675c9e8833) skawarePackages.buildManPages: default to new sr.ht upstream
* [`86388ba6`](https://github.com/NixOS/nixpkgs/commit/86388ba6881aae014fb945ede340083fef0fd637) skawarePackages.*-man-pages: updates including build system changes
* [`689b28ea`](https://github.com/NixOS/nixpkgs/commit/689b28eaa10ea38fd62f5d213b5379058c538acf) tidal-hifi: 5.1.0 -> 5.2.0
* [`901ea34c`](https://github.com/NixOS/nixpkgs/commit/901ea34c4bb362df3c913c3f67b3a790fac85e49) python310Packages.pyslurm: 22.5.1 -> 23.2.1
* [`bc43b20d`](https://github.com/NixOS/nixpkgs/commit/bc43b20df1c2c254c0006d8d880012a87b379278) python310Packages.pypoolstation: 0.5.1 -> 0.5.3
* [`6498a6f3`](https://github.com/NixOS/nixpkgs/commit/6498a6f3cc99194b334fa670b55dc0a46dd0efd6) elpa: 2022.11.001 -> 2023.05.001
* [`5e5e2d77`](https://github.com/NixOS/nixpkgs/commit/5e5e2d77c5c24d26fe941f5706d2bc1e4b03148e) metasploit: 6.3.20 -> 6.3.21
* [`0479d24b`](https://github.com/NixOS/nixpkgs/commit/0479d24b0e25105415527dd3ea72c55ba69cb985) python3Packages.lzallright: init at 0.2.3
* [`b1f3f99a`](https://github.com/NixOS/nixpkgs/commit/b1f3f99a8fa5257444f3dafc530b7554aeb24c3d) python3Packages.lzallright: fix build on darwin
* [`27f0209a`](https://github.com/NixOS/nixpkgs/commit/27f0209a1cee9a3a4da86bb9b55bb8399cf0862c) maestro: 1.28.0 -> 1.29.0
* [`a9d8ac0b`](https://github.com/NixOS/nixpkgs/commit/a9d8ac0b1e46f03bb221c33d01796e23b02e65ed) openmolcas: fix hash
* [`5fe5c104`](https://github.com/NixOS/nixpkgs/commit/5fe5c1046e05a8e11d637c06ac66ea10343efd34) maskromtool: 2023-05-30 -> 2023-06-17
* [`038104d3`](https://github.com/NixOS/nixpkgs/commit/038104d33d68262887bab827cdd14e5e0e4e12b5) jefferson: adding myself as maintainer
* [`6425f1df`](https://github.com/NixOS/nixpkgs/commit/6425f1df47a423bc85083911057d2cabcdc49761) pdal: change package maintainer to geospatial team
* [`346d88fb`](https://github.com/NixOS/nixpkgs/commit/346d88fbb863bf85e0ac905dbed98c0ea6b17b12) miniaudicle: 1.3.5.2 -> 1.4.2.0
* [`88497d06`](https://github.com/NixOS/nixpkgs/commit/88497d066bfdc6b372d9825ca01b41375e2fb6a2) tuic: init at 1.0.0
* [`75650d79`](https://github.com/NixOS/nixpkgs/commit/75650d79da6c841ae27cd4b1392a11d74b117c26) emacs: add nativeComp passthru
* [`8ce78934`](https://github.com/NixOS/nixpkgs/commit/8ce789347789e66ab213978cd341c19dab463eab) emacs: add back treeSitter passthru
* [`9d00bae2`](https://github.com/NixOS/nixpkgs/commit/9d00bae2b86bd4c5950eacd9c77d6f55745f3ac1) python3Packages.fiona: change package maintainer to geospatial team
* [`9c824ed0`](https://github.com/NixOS/nixpkgs/commit/9c824ed0797cf4fc9a86065fcbde1997a104ec2a) jefferson: 0.4.2 -> 0.4.5
* [`f2f12fc9`](https://github.com/NixOS/nixpkgs/commit/f2f12fc902bf4c722beae0828ca776a2c9463217) python3Packages.shapely: change package maintainer to geospatial team
* [`3ef5accb`](https://github.com/NixOS/nixpkgs/commit/3ef5accbff272bb3b223ab89c21a9db69a43719d) emacs: add back support in wrapper for using passthru.nativeComp
* [`5f253d25`](https://github.com/NixOS/nixpkgs/commit/5f253d2521e371b7e5cb6ee72ba885ada985118b) emacs: add back support in wrapper for using passthru.treeSitter
* [`0c6cc352`](https://github.com/NixOS/nixpkgs/commit/0c6cc3524469570d27253ea556c42c472a9ef183) vectorscan: util-linux is only a dependency on linux platforms
* [`8ce423e9`](https://github.com/NixOS/nixpkgs/commit/8ce423e9c57a6e075a8b966bb6ee815c22c7cbdd) n2n: Add libcap support
* [`67a038ca`](https://github.com/NixOS/nixpkgs/commit/67a038cacf73500668f6f8d67b5e2f8ed1608bf8) tests.importCargoLock.maturin: reexport maturin.tests.pyo3
* [`ee7cdc12`](https://github.com/NixOS/nixpkgs/commit/ee7cdc123d7f6f591c1a5cee60c544d1bdbd8d0a) upnp-router-control: 0.3.1 -> 0.3.2
* [`13a7c6fc`](https://github.com/NixOS/nixpkgs/commit/13a7c6fc5e3e8dc58fa52cde07cb85a556757fc8) vimPlugins.nvim-coverage: init at 2023-05-26
* [`fd09e062`](https://github.com/NixOS/nixpkgs/commit/fd09e06205ef2827eda307a0f6660a76c9e1b9e1) vimPlugins: update
* [`ba36bdc1`](https://github.com/NixOS/nixpkgs/commit/ba36bdc1eaef9c667d1b988c50ce10bf535cc548) elixir_1_15: init at 1.15.0
* [`bf2e7265`](https://github.com/NixOS/nixpkgs/commit/bf2e7265e3fd397c85f6858d873844e59048ae68) elixir: Locate generate_app.escript via defaulted argument
* [`925f9e5d`](https://github.com/NixOS/nixpkgs/commit/925f9e5d8099992d02b065b990ef15ce986293cd) grass: change package maintainer to geospatial team
* [`605c86ad`](https://github.com/NixOS/nixpkgs/commit/605c86ad63bac191f54dfe0c6133bc8732cb13dd) nym: 0.11.0 -> 1.1.21
* [`354c859e`](https://github.com/NixOS/nixpkgs/commit/354c859ef37ec8d315e44a8d5d03eff683f522c0) checkov: 2.3.294 -> 2.3.296
* [`f28c626a`](https://github.com/NixOS/nixpkgs/commit/f28c626a1964c2fbf5703d86ea83abc1694cbab4) qgis: change package maintainer to geospatial team
* [`c9bda816`](https://github.com/NixOS/nixpkgs/commit/c9bda816a44a61a23ef62093897314a933aa57e2) python311Packages.pyezviz: 0.2.0.17 -> 0.2.1.2
* [`d1ab4689`](https://github.com/NixOS/nixpkgs/commit/d1ab4689ddb34c5babac00006d23ddce61136f3c) geos: change package maintainer to geospatial team
* [`dfa022d8`](https://github.com/NixOS/nixpkgs/commit/dfa022d8797275a43874fa271e4e669bedec9a2f) rustus: 0.7.3 -> 0.7.4
* [`d5a697ad`](https://github.com/NixOS/nixpkgs/commit/d5a697ad4dadd38c6a722bec4938183d3362e1be) bird-lg: 1.3.0 -> 1.3.1
* [`16f96cf4`](https://github.com/NixOS/nixpkgs/commit/16f96cf4eef17925b326454589790beaf4cecc8a) bird-lg: add e1mo as maintainer
* [`d739f2a4`](https://github.com/NixOS/nixpkgs/commit/d739f2a438c2f0b06c95d0928439a015b6873b91) gql: init at 0.1.0
* [`9005e656`](https://github.com/NixOS/nixpkgs/commit/9005e6565b12f2de1caebce1a9f8b7727510a38e) remmina: 1.4.30 -> 1.4.31
* [`eccb905f`](https://github.com/NixOS/nixpkgs/commit/eccb905f15c4c7ee6d372f23278e24c4384bc955) typos: 1.15.0 -> 1.15.1
* [`7f00f80a`](https://github.com/NixOS/nixpkgs/commit/7f00f80a34cc6d8b9aaa5d1b4b84043ddbc79db7) python311Packages.hap-python: 4.6.0 -> 4.7.0
* [`6764cc2a`](https://github.com/NixOS/nixpkgs/commit/6764cc2a0909396c435ee4c915c72c7db1be6bae) cargo-docset: init at 0.3.1
* [`bcd1885f`](https://github.com/NixOS/nixpkgs/commit/bcd1885f12b74e3febcba458f8ca1aba6252408a) matrix-hookshot: 4.2.0 -> 4.3.0
* [`67f5018f`](https://github.com/NixOS/nixpkgs/commit/67f5018fe6f71a704c1606da8d2eb2af917972e3) cloud-init: 23.1.2 -> 23.2
* [`ed463681`](https://github.com/NixOS/nixpkgs/commit/ed463681f0c79c8b98277e07843a57a2bc493d93) librealsense: Fix bad include directories in cmake
* [`3abdd5f2`](https://github.com/NixOS/nixpkgs/commit/3abdd5f25e71d7ce954e2f10a48c5bbe32819948) tiny-cuda-nn: quote strings; use strictDeps; format with alejandra
* [`6e29224f`](https://github.com/NixOS/nixpkgs/commit/6e29224f076c750a89f66247070957332c625258) python3Packages.rdkit: add meta.changelog
* [`e1f0a688`](https://github.com/NixOS/nixpkgs/commit/e1f0a6884420dd5591b25b6a0e5fc17b4939c7f0) python3Packages.rdkit: 2023.03.1 -> 2023.03.2
* [`85b87c5c`](https://github.com/NixOS/nixpkgs/commit/85b87c5cc408a3561c57d21c7bfb733d1f7f7f41) librealsense: Refactor postInstall for better clarity
* [`31342eea`](https://github.com/NixOS/nixpkgs/commit/31342eea54f23119e4456372195123bd30fc4ccf) installer: remove reference to non existing doc option
* [`97f556ca`](https://github.com/NixOS/nixpkgs/commit/97f556cac1530ab7fd1dc75c4066fc9405f00cce) installer: remove unused with
* [`ee7c1271`](https://github.com/NixOS/nixpkgs/commit/ee7c127185f0f4de7f896158959d644efaab4619) zellij: 0.37.0 -> 0.37.1
* [`99ad2409`](https://github.com/NixOS/nixpkgs/commit/99ad2409dd7c4e09bd371e2688679518b315e069) leftwm: 0.4.1 -> 0.4.2
* [`4cf8f94c`](https://github.com/NixOS/nixpkgs/commit/4cf8f94c885519ea3ca37d97a5365048f4ab9174) leftwm: unbreak on aarch64-linux
* [`c254f4c6`](https://github.com/NixOS/nixpkgs/commit/c254f4c6302abe4c9585240fb16fe4d9486512ad) teleport_12: 12.1.5 -> 12.4.7
* [`6957b8ed`](https://github.com/NixOS/nixpkgs/commit/6957b8ed8b6019b82883c6a857a9d089e257650e) docbook-xsl: restore nixos-specific patch
* [`29a57bc3`](https://github.com/NixOS/nixpkgs/commit/29a57bc337b4678134464a6fa58532aa4c664dac) just: 1.13.0 -> 1.14.0
* [`60a29d1d`](https://github.com/NixOS/nixpkgs/commit/60a29d1d67e74b16e70d3ba76c18c48b25f5fc76) vimPlugins.clipboard-image-nvim: fix for neovim 9.0
* [`7df14eb9`](https://github.com/NixOS/nixpkgs/commit/7df14eb95849bf767911c7df270944d147785c38) cargo-hakari: 0.9.24 -> 0.9.25
* [`273f433a`](https://github.com/NixOS/nixpkgs/commit/273f433a8ada7a18a75b6c23a20e2a5d86631ad6) cargo-guppy: unstable-2023-04-15 -> unstable-2023-06-19
* [`e3d764a4`](https://github.com/NixOS/nixpkgs/commit/e3d764a4e2d14a8c0b0f846df5bd53828523e3cf) python3.pkgs.python-jenkins: fix build by skipping some tests
* [`e9e3f2e7`](https://github.com/NixOS/nixpkgs/commit/e9e3f2e7362aba3ef709173d1777f0b893fc0ebf) python3.pkgs.jenkins-job-builder: fix build by relaxing setuptools requirement
* [`d280b8b7`](https://github.com/NixOS/nixpkgs/commit/d280b8b7b7cd84561a4a2056d79bcb1b569f7a8c) gitkraken: 9.4.0 -> 9.5.1
* [`ee0a21a0`](https://github.com/NixOS/nixpkgs/commit/ee0a21a0f75285ddcdfb5e5044b6b2dae78507d3) vimPlugins.remember-nvim: init at 2023-06-12
* [`c47552a0`](https://github.com/NixOS/nixpkgs/commit/c47552a048e0dd0555cd40aa481fbe6c88e1fa36) vimPlugins.nvim-test: init at 2023-05-02
* [`dccdc7cb`](https://github.com/NixOS/nixpkgs/commit/dccdc7cbfbfac3c13bdea8a2a363ea666a782bea) vimPlugins: update
* [`5477d51c`](https://github.com/NixOS/nixpkgs/commit/5477d51c9f5afaf0b11725c78a23ef9d48177696) vimPlugins: resolve github repository redirects
* [`b89ad7be`](https://github.com/NixOS/nixpkgs/commit/b89ad7bea72f2fb2116c2a352b8780c3b434853f) vimPlugins.nvim-treesitter: update grammars
* [`f982d017`](https://github.com/NixOS/nixpkgs/commit/f982d017f6658674bf80f15cfc5d15c22252c5c8) ferretdb: 1.3.0 -> 1.4.0 ([nixos/nixpkgs⁠#238641](https://togithub.com/nixos/nixpkgs/issues/238641))
* [`1b62e692`](https://github.com/NixOS/nixpkgs/commit/1b62e692b2e786abfcb021d3117d1e414f4a3d30) deltachat-desktop: 1.36.4 -> 1.38.0
* [`bc954fa3`](https://github.com/NixOS/nixpkgs/commit/bc954fa3162c2a8d838af3d887fdae14c6351e94) ghidra{,-bin}: 10.3 -> 10.3.1
* [`a06de115`](https://github.com/NixOS/nixpkgs/commit/a06de115e8e2f77c8e2342d94afc9b15fc019e94) phpExtensions.uv: init at 0.3.0 ([nixos/nixpkgs⁠#238329](https://togithub.com/nixos/nixpkgs/issues/238329))
* [`398e2724`](https://github.com/NixOS/nixpkgs/commit/398e2724b6593c738d6d33539789e9b357a46195) python311Packages.aioshelly: 5.3.2 -> 5.4.0
* [`692f285a`](https://github.com/NixOS/nixpkgs/commit/692f285ae8567990c3320eb26412cd31b9e582e7) plex: 1.32.3.7192-7aa441827 -> 1.32.4.7195-7c8f9d3b6
* [`4b9825f1`](https://github.com/NixOS/nixpkgs/commit/4b9825f1bde06eb89bb7e98372bf68690eb72df8) python310Packages.pipdeptree: 2.7.1 -> 2.9.3
* [`4cd14d5a`](https://github.com/NixOS/nixpkgs/commit/4cd14d5a7efa48ef5340ed7849ebefc8d2b4eaf7) spark2014: do not hardcode gnat12 version
* [`7414fffa`](https://github.com/NixOS/nixpkgs/commit/7414fffaa4479e89b4cec6d498524c93a37d2183) sbt-extras: 2023-01-05 -> 2023-06-07
* [`ed93c9d3`](https://github.com/NixOS/nixpkgs/commit/ed93c9d353392ac74fcf6fff8efe4f1c9b4069a4) fakeroute: 0.2 -> 0.3
* [`7d263715`](https://github.com/NixOS/nixpkgs/commit/7d263715bdf3b05bc58b9ed4d5bea9b075ff0c70) nixos/fakeroute: run as unprivileged user
* [`623d7d21`](https://github.com/NixOS/nixpkgs/commit/623d7d2124465e60a3f39f96e0299fa4c3c7b055) nixos/tests/fakeroute: init
* [`2619ad2a`](https://github.com/NixOS/nixpkgs/commit/2619ad2aadf804f993963306db56dd1b2ceb1bb8) python310Packages.tempest: 34.2.0 -> 35.0.0
* [`cad01910`](https://github.com/NixOS/nixpkgs/commit/cad0191069a27074cb99c8d70461aaf534840dec) python310Packages.django-webpack-loader: 2.0.0 -> 2.0.1
* [`3c41050a`](https://github.com/NixOS/nixpkgs/commit/3c41050a9ae4690df29323b4966d2b608c8cbdc7) python310Packages.gcal-sync: 4.2.0 -> 4.2.1
* [`df648e53`](https://github.com/NixOS/nixpkgs/commit/df648e53072f019586e95a01f02e968bfb25f4bb) python310Packages.python-sql: 1.4.0 -> 1.4.1
* [`68ce9466`](https://github.com/NixOS/nixpkgs/commit/68ce946623c1936cf178fb3cd9b663cb9193c30f) cargo-semver-checks: 0.21.0 -> 0.22.0
* [`b672c2f3`](https://github.com/NixOS/nixpkgs/commit/b672c2f3fa5fe9182c5c3fa2c6c409c9724911e9) python310Packages.textual: 0.27.0 -> 0.28.0
* [`77f7c892`](https://github.com/NixOS/nixpkgs/commit/77f7c89255507fb0f6428bf368464feb09d54922) gitui: 0.22.1 -> 0.23.0
* [`c32649ae`](https://github.com/NixOS/nixpkgs/commit/c32649ae9a8327aebd44cbabd7f5590667a311b6) python310Packages.ipyvue: 1.9.1 -> 1.9.2
* [`651cd4e4`](https://github.com/NixOS/nixpkgs/commit/651cd4e4c7a689ed3a8d848305177fd1faeef54f) cargo-local-registry: init at 0.2.3
* [`1a3c2c36`](https://github.com/NixOS/nixpkgs/commit/1a3c2c360e250387a2608f31f771141a91229c57) armadillo: 12.4.0 -> 12.4.1
* [`9c3d3e90`](https://github.com/NixOS/nixpkgs/commit/9c3d3e90573959e85e4cdf172f745d334dd67415) txr: 287 -> 288
* [`91f5da5b`](https://github.com/NixOS/nixpkgs/commit/91f5da5ba17a38bd1ef1a2c74fb8b73c96bb7bc3) protonup-qt: 2.7.7 -> 2.8.0
* [`9225919e`](https://github.com/NixOS/nixpkgs/commit/9225919e9641878bec27418759b092a5f3b0a9a1) firefox-devedition-bin-unwrapped: 114.0b7 -> 115.0b7
* [`873907f0`](https://github.com/NixOS/nixpkgs/commit/873907f0358b171b82b8f16439a83a3e03a5cb1b) cargo-show-asm: rename pname to cargo-show-asm
* [`7c021b54`](https://github.com/NixOS/nixpkgs/commit/7c021b54320aff65614d9f02dc59a1988736622b) jackett: 0.21.241 -> 0.21.258
* [`45a19246`](https://github.com/NixOS/nixpkgs/commit/45a19246c767468848fc882a4ed2247ceb72bfac) python310Packages.mmh3: 3.1.0 -> 4.0.0
* [`058a2b24`](https://github.com/NixOS/nixpkgs/commit/058a2b24ce29a81198de920b9470e5f931363fbb) python310Packages.primer3: 1.0.0 -> 2.0.0
* [`1f82259d`](https://github.com/NixOS/nixpkgs/commit/1f82259dd11c32856bfb8696e202f89a1e09a7c0) python3Packages.autopep8: 2.0.1 -> 2.0.2
* [`46eb157f`](https://github.com/NixOS/nixpkgs/commit/46eb157f62762bb5d0b082b945f64756cbec88eb) hugo: 0.113.0 -> 0.114.0
* [`9a23a043`](https://github.com/NixOS/nixpkgs/commit/9a23a0432dd56de6958f3b2a37031b85baf18907) python310Packages.requests-futures: 1.0.0 -> 1.0.1
* [`b29b0940`](https://github.com/NixOS/nixpkgs/commit/b29b09406eff0c941a907749b17c6267ef25aadf) discord-canary: 0.0.158 -> 0.0.160
* [`9e51e112`](https://github.com/NixOS/nixpkgs/commit/9e51e11203cc790fa34fbe87879d82c4824bc6c2) patchelfUnstable: unstable-2023-04-25 -> unstable-2023-06-08
* [`98f010cc`](https://github.com/NixOS/nixpkgs/commit/98f010cc7be8c7ab3bb5cbb67209996e48946b48) python310Packages.elementpath: 4.1.2 -> 4.1.3
* [`5a414bf8`](https://github.com/NixOS/nixpkgs/commit/5a414bf8b70bec21b0ff229d91aece5bb14604ac) coursier: 2.1.4 -> 2.1.5
* [`ea6c32f5`](https://github.com/NixOS/nixpkgs/commit/ea6c32f5451271e22464080e847f2f4008685a1f) terraform-providers.acme: 2.15.0 -> 2.15.1
* [`6834eb4c`](https://github.com/NixOS/nixpkgs/commit/6834eb4ced75b282b345546882cbaae7b6b7da41) terraform-providers.ovh: 0.30.0 -> 0.31.0
* [`112c6961`](https://github.com/NixOS/nixpkgs/commit/112c6961b00ed9700282832039893397e4a90f5f) terraform-providers.remote: 0.1.1 -> 0.1.2
* [`720649c9`](https://github.com/NixOS/nixpkgs/commit/720649c947eaef3ad52aa7ca615401f093af1f54) maintainers: add johnpyp
* [`b78cc40d`](https://github.com/NixOS/nixpkgs/commit/b78cc40d5612b95cc387bad095435892e4d0b306) python310Packages.globus-sdk: 3.19.0 -> 3.21.0
* [`dede7835`](https://github.com/NixOS/nixpkgs/commit/dede78354896756fd92e2e4f9c8c284f4a521611) oh-my-zsh: 2023-06-16 -> 2023-06-19
* [`e1dd655e`](https://github.com/NixOS/nixpkgs/commit/e1dd655e55e56b8d20f19b7cf16fb8635ca591f0) python310Packages.django-webpack-loader:  add changelog to meta
* [`bd507fd6`](https://github.com/NixOS/nixpkgs/commit/bd507fd64825c9428fc33ea44a7a8ea28e93f4aa) python310Packages.python-sql: add changelog to meta
* [`53faea4c`](https://github.com/NixOS/nixpkgs/commit/53faea4ce240aae614dee423731a59ebdf58af7a) python310Packages.mmh3: update meta
* [`2675cab4`](https://github.com/NixOS/nixpkgs/commit/2675cab41cc3f8c09f8f130994b1139b04e93a01)  python310Packages.mmh3: add format
* [`729b60e7`](https://github.com/NixOS/nixpkgs/commit/729b60e70d5900a460ace93440c4580fdf3db8f3) python310Packages.primer3: add changelog to meta
* [`fdd5d7e8`](https://github.com/NixOS/nixpkgs/commit/fdd5d7e8262ff9d77329f357f2b7a9f201a31657) python310Packages.primer3: add format
* [`b704c4f9`](https://github.com/NixOS/nixpkgs/commit/b704c4f97b6710634df58ed432b2bc7dc2bf8455) mavenfod: make mvnHash empty by default
* [`7a5b3f5f`](https://github.com/NixOS/nixpkgs/commit/7a5b3f5fc7d233de306ab5514b4972766858e4ab) python311Packages.karton-mwdb-reporter: 1.2.0 -> 1.3.0
* [`8cff0900`](https://github.com/NixOS/nixpkgs/commit/8cff0900bc947cd659647843174120b7085afb46) crystfel: fix x86_64 hash ([nixos/nixpkgs⁠#238606](https://togithub.com/nixos/nixpkgs/issues/238606))
* [`1b5a054e`](https://github.com/NixOS/nixpkgs/commit/1b5a054e0a45066bbf2272340d907ca2920f2ed6) jd-cli: convert to mavenfod
* [`9ccbc664`](https://github.com/NixOS/nixpkgs/commit/9ccbc66411058793a756fdfa364a0eb52b0c5d17) python311Packages.filedepot: 0.9.0 -> 0.10.0
* [`c9e72a5a`](https://github.com/NixOS/nixpkgs/commit/c9e72a5ae954d3869dcbf829158eabca045d34e9) python311Packages.dvc-objects: 0.22.0 -> 0.23.0
* [`a6cfbad8`](https://github.com/NixOS/nixpkgs/commit/a6cfbad8c31da78765173ae35e73542a3a3b47a4) python311Packages.dvc-data: 1.7.0 -> 2.0.2
* [`06f73278`](https://github.com/NixOS/nixpkgs/commit/06f73278ea94847f3adce6fa318367401a27c1fa) digital: convert to mavenfod
* [`6a5479f4`](https://github.com/NixOS/nixpkgs/commit/6a5479f4afb4305e33710d7ce44888b13d018905) python311Packages.pycep-parser: 0.4.0 -> 0.4.1
* [`6e95560c`](https://github.com/NixOS/nixpkgs/commit/6e95560c5d3f1fff322e196c2f5d32aca859fbfc) python311Packages.pycep-parser: add changelog to meta
* [`41690f6b`](https://github.com/NixOS/nixpkgs/commit/41690f6bd7c78c1e915259e37c9252a642439c95) python311Packages.pyopnsense: 0.3.0 -> 0.4.0
* [`2b0c45f1`](https://github.com/NixOS/nixpkgs/commit/2b0c45f123f2fccc0e187506c5f9986978c8e0ad) python311Packages.pyopnsense: add changelog to meta
* [`c44a486d`](https://github.com/NixOS/nixpkgs/commit/c44a486d0ad97be7ecd01484e0e76a803ec05bb4) java-language-server: convert to mavenfod
* [`205ee073`](https://github.com/NixOS/nixpkgs/commit/205ee073b053fc4d87d5adf2ebd44ebbef7bca4d) Revert "texlive.combine: expose licensing information of combined packages"
* [`f737b4d3`](https://github.com/NixOS/nixpkgs/commit/f737b4d32c82f13db2eac9093958cb4214660563) ocamlPackages.seqes: init at 0.2
* [`781d1ac8`](https://github.com/NixOS/nixpkgs/commit/781d1ac810fbf3a340fe723aa6c2b2f627b50d9f) kord: 0.5.16 -> 0.6.1
* [`cf4ce518`](https://github.com/NixOS/nixpkgs/commit/cf4ce51861fe1e7bb74b74d6dfd45a57e6d63dcf) ocamlPackages.tezos-bls12-381-polynomial: drop at 1.0.1
* [`0a705f57`](https://github.com/NixOS/nixpkgs/commit/0a705f573b7e2fa7a7d6bb0761b249d7b7711e11) ocamlPackages.bls12-381: 5.0.0 -> 6.1.0
* [`5ba6eab7`](https://github.com/NixOS/nixpkgs/commit/5ba6eab7c2e153f2532e4211c0b362930bc8d2dd) ligo: 0.66.0 -> 0.67.1
* [`2278b4b6`](https://github.com/NixOS/nixpkgs/commit/2278b4b61b2d5e986294d3bd370f0fc57a83d583) ocamlPackages.bls12-381-hash: drop at 1.0.0
* [`eade7e00`](https://github.com/NixOS/nixpkgs/commit/eade7e0058e1cd730bdd27839a5d471bd2e17595) tbe: fix build, clean up dependencies
* [`cf7bda34`](https://github.com/NixOS/nixpkgs/commit/cf7bda3428b7832a74a26eee33123a256a10ca19) lowdown: delete liblowdown.so symlink on darwin
* [`048a14cd`](https://github.com/NixOS/nixpkgs/commit/048a14cd1e46eaee9fe6a1dd44008f6c94b58919) lowdown: move so version into variable
* [`86a6a488`](https://github.com/NixOS/nixpkgs/commit/86a6a4887639ebae64e8d200b75c5b7055e173a3) lowdown: check if soVersion is up to date on non darwin
* [`8751ca45`](https://github.com/NixOS/nixpkgs/commit/8751ca45de9016d5e1ec89fb682bc65919507e9c) lowdown: 1.0.1 -> 1.0.2
* [`1079029f`](https://github.com/NixOS/nixpkgs/commit/1079029f407cbcfa386164eb76710efee62de8c1) lowdown: make assertions in postInstall prettier
* [`95843569`](https://github.com/NixOS/nixpkgs/commit/958435697725228571974bed73e80846c446b97b) python3Packages.zake: remove
* [`b949778b`](https://github.com/NixOS/nixpkgs/commit/b949778bed83f359787cc9af76579b8155bf49b5) dtc: fix cross
* [`0dc2832c`](https://github.com/NixOS/nixpkgs/commit/0dc2832c9d41ba824260f81f393a738fda449577) python310Packages.nextcord: 2.4.2 -> 2.5.0
* [`49f51811`](https://github.com/NixOS/nixpkgs/commit/49f51811402165958b9907410dbfc4ee57e36065) forge-mtg: convert to mavenfod
* [`4f72b6af`](https://github.com/NixOS/nixpkgs/commit/4f72b6af8bb66addaeffc0f59c85bb2813d47ff7) fetchgit: fetch submodules in parallel
* [`dcbae5b0`](https://github.com/NixOS/nixpkgs/commit/dcbae5b0aaed3a705719d15616087d7f5ff15973) emacs29: 29.0.91 -> 29.0.92 (both pretest)
* [`1431c97d`](https://github.com/NixOS/nixpkgs/commit/1431c97d557ade80c58e42b9ff6307944e190a90) schemaspy: convert to mavenfod
* [`870f0ced`](https://github.com/NixOS/nixpkgs/commit/870f0ced6d1f58a46faa7cf0f957fec433f14202) python3Packages.pyblock: remove
* [`d48e365f`](https://github.com/NixOS/nixpkgs/commit/d48e365ff604796ecfd970bc6bc3a7546d8b0a12) nixosTests.os-prober: add missing kbd extra dep
* [`baa3beee`](https://github.com/NixOS/nixpkgs/commit/baa3beee5d15c2f6991a71757d2c8573b90e0526) hugo: add version test
* [`bc95815e`](https://github.com/NixOS/nixpkgs/commit/bc95815e9e793dc27ff9ab9cd9865550b992ea9f) firmware-updater: unstable-2023-04-30 -> unstable-2023-06-20
* [`fdbfdee4`](https://github.com/NixOS/nixpkgs/commit/fdbfdee4a45878d0727909af0a77d2fbe0a0203f) maven: 3.8.6 -> 3.9.2
* [`13dd515a`](https://github.com/NixOS/nixpkgs/commit/13dd515a921667b798a30823b888e9a2135a480b) maven: adjust hashes of pull-maven-dependencies derivations
* [`d85eb004`](https://github.com/NixOS/nixpkgs/commit/d85eb0045cb2f566d84cd57372482f564fcae506) python310Packages.requests-futures: add changelog to meta
* [`4b123e5b`](https://github.com/NixOS/nixpkgs/commit/4b123e5bf3193f34535fb8ba33ba783268bc8c4a) python310Packages.requests-futures: add format
* [`7e7e848d`](https://github.com/NixOS/nixpkgs/commit/7e7e848d4a8d0f15d37c4eed9cba74caf6fd2e86) abseil-cpp_202301: init at 20230125.3
* [`6bc5bf19`](https://github.com/NixOS/nixpkgs/commit/6bc5bf199a2ffb6e4c2b15b22ec6a3af75df4953) abseil-cpp: default to 202301
* [`3fb023ee`](https://github.com/NixOS/nixpkgs/commit/3fb023ee2cd03156e485b010040b73198bb45dc6) ycmd: unpin abseil-cpp
* [`3be39b9e`](https://github.com/NixOS/nixpkgs/commit/3be39b9e8e5881a3b2a4841260aee43b4ab6e23b) fcitx5-mozc: unpin abseil-cpp
* [`ec5c7327`](https://github.com/NixOS/nixpkgs/commit/ec5c73273f50d3caf0ff125e277abb6350373c74) libreoffice: unpin abseil-cpp
* [`b4b5df3b`](https://github.com/NixOS/nixpkgs/commit/b4b5df3b96f1a5f44d083e3929b5d16a2a53d317) tensorflow-lite: unpin abseil-cpp
* [`9cee059d`](https://github.com/NixOS/nixpkgs/commit/9cee059d967a00f39b6bbf8556baa0629cff08a9) telegram-desktop: unpin abseil-cpp
* [`bc2ccccf`](https://github.com/NixOS/nixpkgs/commit/bc2ccccf5a1473eb93b2ba635323273057b56b36) kotatogram-desktop: unpin abseil-cpp
* [`6df03ef2`](https://github.com/NixOS/nixpkgs/commit/6df03ef2653f0803707ba88b3298b977f45a6a19) or-tools: bump pin of abseil-cpp
* [`21d2bc83`](https://github.com/NixOS/nixpkgs/commit/21d2bc83c0ac34e4307ac45423cdad5d487588b4) onnxruntime: unpin abseil-cpp
* [`7adbc86b`](https://github.com/NixOS/nixpkgs/commit/7adbc86b9ebfd3a369e93cf6f5a49e86bec63833) webrtc-audio-processing: unpin abseil-cpp
* [`3ad7b66e`](https://github.com/NixOS/nixpkgs/commit/3ad7b66e4cc9ada8f480647981224c7ffc3e84ae) dragonflydb: switch abseil-cpp lib to fetch source
* [`24b87664`](https://github.com/NixOS/nixpkgs/commit/24b8766447880ce50aeefefd090da68dadd161d3) python3Packages.dm-tree: unpin abseil-cpp
* [`3a95da64`](https://github.com/NixOS/nixpkgs/commit/3a95da643cfc574d2be5c677cbede1b3224cae16) redpanda-server: bump abseil-cpp pin
* [`7f43f953`](https://github.com/NixOS/nixpkgs/commit/7f43f9538125612907c55982a3125032fdb07e71) abseil-cpp_202111: drop
* [`b337874d`](https://github.com/NixOS/nixpkgs/commit/b337874d6181c8d1752efada7699fc94d14c38e0) python3Packages.warble: init at 1.2.9 ([nixos/nixpkgs⁠#238628](https://togithub.com/nixos/nixpkgs/issues/238628))
* [`d22a44e5`](https://github.com/NixOS/nixpkgs/commit/d22a44e57a3d0d2f2b13918826e66d6debbd67ac) hb dep is added later, after we check the version number
* [`2118d0b2`](https://github.com/NixOS/nixpkgs/commit/2118d0b250cda2d8e42afd17c736961de43e6567) exhibitor: convert to mavenfod
* [`13ded184`](https://github.com/NixOS/nixpkgs/commit/13ded18417c156bbf95c0978de892d95612ef86d) global-platform-pro: convert to mavenfod
* [`9ce09740`](https://github.com/NixOS/nixpkgs/commit/9ce0974026d06e0a999879ff87c06b0c5e88ce52) gephi: convert to mavenfod
* [`570c2535`](https://github.com/NixOS/nixpkgs/commit/570c2535e5da615b2ee9c442c5809727642a1c2d) cryptomator: convert to mavenfod
* [`9b6474dd`](https://github.com/NixOS/nixpkgs/commit/9b6474dd6cf92e3a48eec24e126564f8c9c3901f) kernel/common-config: enable AMD Zen BRS
* [`b79dc449`](https://github.com/NixOS/nixpkgs/commit/b79dc4496b2a21e4bc09287e7a58bab99f00f5e9) kernel/common-config: enable CONFIG_PMIC_OPREGION and friends for Bay Trail
* [`23f23b56`](https://github.com/NixOS/nixpkgs/commit/23f23b5603ff94bdda2c93475f8448620f4d3fa4) kernel/common-config: enable DAMON
* [`ff0826dc`](https://github.com/NixOS/nixpkgs/commit/ff0826dcbe7979facfaea18889af55f350f500e8) prometheus-pve-exporter: 2.2.2 -> 2.3.0
* [`22145812`](https://github.com/NixOS/nixpkgs/commit/22145812185f4bc95a515354b6e4a09c9d89a308) licenses: add mulan-psl2
* [`e0b050e1`](https://github.com/NixOS/nixpkgs/commit/e0b050e13e6b04f9232a8eb2db4487ad545e721a) stratovirt: init at 2.2.0
* [`5ba353aa`](https://github.com/NixOS/nixpkgs/commit/5ba353aa7e0163c305d1b6b7844be1c60fdf005d) python310Packages.pinocchio: 2.6.18 -> 2.6.19
* [`fb8b3868`](https://github.com/NixOS/nixpkgs/commit/fb8b386820cb5c86dc07ca5d24484d74b2cea90b) python3Packages.pymatgen-lammps: remove
* [`32cef91b`](https://github.com/NixOS/nixpkgs/commit/32cef91b38c15fa575f1b78d4c3b6bf39ee68fce) python3Packages.pyres: remove
* [`1c30b4b8`](https://github.com/NixOS/nixpkgs/commit/1c30b4b8287ca0c12f4250ce53721df90b6c52c3) todoist-electron: 1.0.8 -> 8.3.3
* [`2e5b94de`](https://github.com/NixOS/nixpkgs/commit/2e5b94de00fa9735d6fe8d4892c8bee113f7a726) nss_latest: remove curve25519 support
* [`549e40bf`](https://github.com/NixOS/nixpkgs/commit/549e40bff0d1c498ad033c82bb59dcbee78fdbe5) buildMozillaMach: pin icu to 72
* [`2c98dbcb`](https://github.com/NixOS/nixpkgs/commit/2c98dbcbdbcad280d7f7f59fae4e596d3b1cba22) typos: 1.15.1 -> 1.15.2
* [`b5914758`](https://github.com/NixOS/nixpkgs/commit/b59147582366aedf9d515d7e5301efc7f746f6e3) fluffychat: 1.11.2 -> 1.12.1
* [`a44624d9`](https://github.com/NixOS/nixpkgs/commit/a44624d9b17d886c5678163e47f415e69386fba7) schemaspy: fix hash
* [`6c639e86`](https://github.com/NixOS/nixpkgs/commit/6c639e869c1fa420c707724eeba107a5017df0d2) buildDotnetModule: tweaks to support paket
* [`abf6081b`](https://github.com/NixOS/nixpkgs/commit/abf6081bc2aeb6746044b3528bb5f5dd5b3f0d84) buildDotnetModule: add useDotnetFromEnv option
* [`6b84101c`](https://github.com/NixOS/nixpkgs/commit/6b84101c477ab7b89322aa24a26e4d14affb84e3) omnisharp-roslyn: use usedotnetFromEnv instead of overriding fixup phase
* [`6caee409`](https://github.com/NixOS/nixpkgs/commit/6caee40955d8693948dad8b6c4aa27e576a67dc5) fsautocomplete: init at 0.60.0
* [`3408b40f`](https://github.com/NixOS/nixpkgs/commit/3408b40fb5a2c066f18ab0e62a87025d5f2f265d) buildDotnetGlobalTool: init
* [`00038e26`](https://github.com/NixOS/nixpkgs/commit/00038e264e13074b7cb769226a830193db981767) pbm: init at 1.3.1
* [`c31dfa25`](https://github.com/NixOS/nixpkgs/commit/c31dfa2513e8f658d48896f5ad492085b4f9331f) fable: init at 4.1.4
* [`0d9142d4`](https://github.com/NixOS/nixpkgs/commit/0d9142d4df02ca1284c52bf4c272d062133c392d) buildDotnetGlobalTool: document dotnet global tools and their packaging
* [`8c05c0f7`](https://github.com/NixOS/nixpkgs/commit/8c05c0f7b4c853a783ed068e1542d0aaf6f397f9) vimPlugins.dropbar-nvim: init at 2023-06-19
* [`18a2847e`](https://github.com/NixOS/nixpkgs/commit/18a2847ebc0f2c3b296a1701adb52f4c3453e172) vimPlugins.eyeliner-nvim: init at 2023-04-26
* [`ef8aae5f`](https://github.com/NixOS/nixpkgs/commit/ef8aae5fac2690d4a44b92f1cf746b6014e090a3) vimPlugins.highlight-undo-nvim: init at 2023-06-19
* [`b4e7688a`](https://github.com/NixOS/nixpkgs/commit/b4e7688a19498f4d0f15e628793282b1f30e45fa) vimPlugins.notifier-nvim: init at 2023-06-09
* [`584132a4`](https://github.com/NixOS/nixpkgs/commit/584132a452d24f7fa22a0639e860a2a6213ecf34) vimPlugins.nvim-pqf: init at 2023-04-20
* [`5d685dcb`](https://github.com/NixOS/nixpkgs/commit/5d685dcbbcdd0b57d547b0e2b49662ab7cebcb0f) vimPlugins.substitute-nvim: init at 2023-05-16
* [`b8fae924`](https://github.com/NixOS/nixpkgs/commit/b8fae9241c1f25e857ab8be99078cb92237b90aa) vimPlugins.wrapping-nvim: init at 2023-05-28
* [`3309ff78`](https://github.com/NixOS/nixpkgs/commit/3309ff781b13cee8179a07ca7cd1b15123dc34ef) cargo-duplicates: init at 0.5.1
* [`27543eeb`](https://github.com/NixOS/nixpkgs/commit/27543eeb80066cdce94bb5ff07f40084aa4341fd) rio: 0.0.6.1-unstable-2023-06-18 -> 0.0.7
* [`c69533db`](https://github.com/NixOS/nixpkgs/commit/c69533db40d4530be47c595b9098189a87730b38) cambalache: 0.10.3 → 0.12.1
* [`9d905447`](https://github.com/NixOS/nixpkgs/commit/9d905447da5179f5887224f2eac8b2e5c46ceba0) snagboot: 1.0 -> 1.1
* [`ea942af7`](https://github.com/NixOS/nixpkgs/commit/ea942af73265a585e075cb89df1d19864c9ab103) crystal: cleanup
* [`f68ff8bf`](https://github.com/NixOS/nixpkgs/commit/f68ff8bfa8736672c59582b2c2bb26828228cac4) shellhub-agent: 0.12.1 -> 0.12.2
* [`d13769fd`](https://github.com/NixOS/nixpkgs/commit/d13769fd8e4a22bc302c37e428ea25959b8ceba9) clickhouse: build on darwin
* [`7e2f4ffd`](https://github.com/NixOS/nixpkgs/commit/7e2f4ffde2638c55123f7495085642e49af89a7d) plasma: 5.27.5 -> 5.27.6
* [`ffe85a9b`](https://github.com/NixOS/nixpkgs/commit/ffe85a9b3ec91066b9740cd1639558065cefcd5e) flatpak-kcm: add dependency
* [`a1399760`](https://github.com/NixOS/nixpkgs/commit/a1399760826319c99d01f5870df3d95efb281f79) plasma-sdk: fix build
* [`20d982bb`](https://github.com/NixOS/nixpkgs/commit/20d982bb04169ce5c76c4156ae9c1e5028e397d4) plasma-workspace: refresh patch
* [`75a3ce93`](https://github.com/NixOS/nixpkgs/commit/75a3ce9316a845985a51c3640f03196751d4036e) maven: remove builder.sh
* [`00bc3c53`](https://github.com/NixOS/nixpkgs/commit/00bc3c531dc3a074717e80dc0914c5e7d390c2d2) maven.buildMavenPackage: rename from javaPackages.mavenfod
* [`40001fa4`](https://github.com/NixOS/nixpkgs/commit/40001fa439d86c0ef3a7d31d213620242047843f) treewide: remove mavenfod overrides
* [`c2730b96`](https://github.com/NixOS/nixpkgs/commit/c2730b96dc6130cece9eb0546b2eb74b44cefcda) public-inbox: add xapian to PATH
* [`dca41555`](https://github.com/NixOS/nixpkgs/commit/dca415554f27352768e7c85edec71271e70196b7) treewide: replace mavenfod with buildMavenPackage
* [`2a619ae2`](https://github.com/NixOS/nixpkgs/commit/2a619ae20ea22ad7346b0fd2aa17dcd7fe939174) graphene-hardened-malloc: refactor
* [`5ee788cb`](https://github.com/NixOS/nixpkgs/commit/5ee788cbe04dc7b4bf24294149fd96dea781741e) vimPlugins.hex-nvim: init at 2023-05-25
* [`f756a4cf`](https://github.com/NixOS/nixpkgs/commit/f756a4cf7d0725727edd23d88c7d3dc2d879b78f) vimPlugins: update
* [`483f8899`](https://github.com/NixOS/nixpkgs/commit/483f889998e65bda773c518a8c93a24bbc76bc3e) vimPlugins.nvim-treesitter: update grammars
* [`68c68f39`](https://github.com/NixOS/nixpkgs/commit/68c68f39dbc7395bd68cb5faa7974681308ccb3c) nixos/public-inbox: remove unused indexing code
* [`03216e70`](https://github.com/NixOS/nixpkgs/commit/03216e705c057b73761162db9198bb30e9d60932) nixos/public-inbox: make coderepo paths accessible
* [`eafa1fd1`](https://github.com/NixOS/nixpkgs/commit/eafa1fd10d709fb2e5b85865cb475f1c074c33f8) nixos/public-inbox: set ProtectHome=tmpfs
* [`74fd95a6`](https://github.com/NixOS/nixpkgs/commit/74fd95a6349a70a0990cc0073eaadafa914edd0b) gifski: enable video support
* [`725e8ab4`](https://github.com/NixOS/nixpkgs/commit/725e8ab49c6a0014d963c9dffb769b65e5a527d4) cudaPackages: bump default cudaPackages_11_7 -> cudaPackages_11_8 ([nixos/nixpkgs⁠#238622](https://togithub.com/nixos/nixpkgs/issues/238622))
* [`c1f146de`](https://github.com/NixOS/nixpkgs/commit/c1f146de50feadf50f0bc759c4adbc18e1cf5dd6) jetbrains: 2023.1 -> 2023.1.3
* [`51bd2aca`](https://github.com/NixOS/nixpkgs/commit/51bd2aca103a777b346915155458942618839c91) matrix-synapse: 1.85.2 -> 1.86.0
* [`be5d19cf`](https://github.com/NixOS/nixpkgs/commit/be5d19cf359915d0003be1ef33bde99b551a54b4) python311Packages.aioairzone: 0.6.3 -> 0.6.4
* [`5471a3f1`](https://github.com/NixOS/nixpkgs/commit/5471a3f19c1240a806a84512eeab2a2a7a022138) python311Packages.yeelight: 0.7.10 -> 0.7.11
* [`adb3dec3`](https://github.com/NixOS/nixpkgs/commit/adb3dec36ba045a258e42793bb8fc5400e3295dd) onefetch: 2.17.1 -> 2.18.0
* [`f02f863b`](https://github.com/NixOS/nixpkgs/commit/f02f863bb20371912cfd4fbb1188dda802818ad9) python310Packages.archinfo: 9.2.55 -> 9.2.56
* [`0ecd3cc1`](https://github.com/NixOS/nixpkgs/commit/0ecd3cc1362cf34bf15d226a20b6aa3ed7e36226) python310Packages.ailment: 9.2.55 -> 9.2.56
* [`93bd59e9`](https://github.com/NixOS/nixpkgs/commit/93bd59e9275e59d8b7e42fb52556180376d73191) python310Packages.pyvex: 9.2.55 -> 9.2.56
* [`1506b982`](https://github.com/NixOS/nixpkgs/commit/1506b9825cf87270ae91fe8665a454336c334ab4) python310Packages.claripy: 9.2.55 -> 9.2.56
* [`71e3207a`](https://github.com/NixOS/nixpkgs/commit/71e3207a1891bc4da4aec09c7898ee767c883c4d) python310Packages.cle: 9.2.55 -> 9.2.56
* [`5f1d9b11`](https://github.com/NixOS/nixpkgs/commit/5f1d9b111044abc1ce43c660239670ad7039bade) python310Packages.angr: 9.2.55 -> 9.2.56
* [`3294dbc9`](https://github.com/NixOS/nixpkgs/commit/3294dbc932a61f211351ed70f33012dbbeb54ec8) exploitdb: 2023-06-16 -> 2023-06-20
* [`fb7d067c`](https://github.com/NixOS/nixpkgs/commit/fb7d067c37a0c16f8d74d241df8c68d4ecea4505) python311Packages.can: 4.2.1 -> 4.2.2
* [`4d32b87d`](https://github.com/NixOS/nixpkgs/commit/4d32b87dc0491f7bd448fe4b83aea995b69c28ff) topiary: 0.2.2 -> 0.2.3 ([nixos/nixpkgs⁠#238767](https://togithub.com/nixos/nixpkgs/issues/238767))
* [`4f02b42a`](https://github.com/NixOS/nixpkgs/commit/4f02b42a94b50e762ae1b96fd0365768adafd9d5) cargo-shuttle: 0.18.0 -> 0.19.0 ([nixos/nixpkgs⁠#238766](https://togithub.com/nixos/nixpkgs/issues/238766))
* [`3281d1e7`](https://github.com/NixOS/nixpkgs/commit/3281d1e7491c32d7423c814830603ddaa28b84e0) kops_1_26: 1.26.3 -> 1.26.4 ([nixos/nixpkgs⁠#238727](https://togithub.com/nixos/nixpkgs/issues/238727))
* [`a224021c`](https://github.com/NixOS/nixpkgs/commit/a224021ca6f4caa3b9523d7952ce21f1e96192dd) vscode-extensions.charliermarsh.ruff: 2023.24.0 -> 2023.26.0 ([nixos/nixpkgs⁠#238720](https://togithub.com/nixos/nixpkgs/issues/238720))
* [`bb155b29`](https://github.com/NixOS/nixpkgs/commit/bb155b29209d93784bae06d48385a923c1b6c5db) multipass: 1.12.0 -> 1.12.1 ([nixos/nixpkgs⁠#238719](https://togithub.com/nixos/nixpkgs/issues/238719))
* [`8cf67b6f`](https://github.com/NixOS/nixpkgs/commit/8cf67b6fa707fce6284527a92c4841f0c691be22) vscode-extensions.esbenp.prettier-vscode: 9.13.0 -> 9.14.0 ([nixos/nixpkgs⁠#238706](https://togithub.com/nixos/nixpkgs/issues/238706))
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
