### PR TITLE
niv devenv: update 93ee7875 -> d02ba1bf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "93ee7875ff1622d496da80414724bae0263c1d23",
-        "sha256": "0pk2pnyly2bd2k486ivpvmjwd00az67sjybwxbhhfvrlj32fyq24",
+        "rev": "d02ba1bf61ecb584a94a03bb54f51b78ce08fda4",
+        "sha256": "03fsfqapz6k9vk0mphi7wlzva9hd5kswpw6wv3z9blbapa5rf982",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/93ee7875ff1622d496da80414724bae0263c1d23.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/d02ba1bf61ecb584a94a03bb54f51b78ce08fda4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@93ee7875...d02ba1bf](https://github.com/cachix/devenv/compare/93ee7875ff1622d496da80414724bae0263c1d23...d02ba1bf61ecb584a94a03bb54f51b78ce08fda4)

* [`bb564783`](https://github.com/cachix/devenv/commit/bb5647835382798006c5102731e543f790aca09f) Configure additional `rabbitmq` listeners
* [`84890598`](https://github.com/cachix/devenv/commit/848905986f477d1709f15100f0b5f64f36dd4a33) This configures a readiness probe for opensearch
* [`c441cc31`](https://github.com/cachix/devenv/commit/c441cc319a3b15bdbb5f79c8d9bebc47618e7962) Use cfg.settings instead
* [`e9362d44`](https://github.com/cachix/devenv/commit/e9362d446b6a2a9363c0456dd2b12c2f6d5368f0) Enable `languages.c` for Crystal
* [`d02ba1bf`](https://github.com/cachix/devenv/commit/d02ba1bf61ecb584a94a03bb54f51b78ce08fda4) CI: make space
