### PR TITLE
niv home-manager: update f06a43dc -> 3bc1bc40

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f06a43dca05fb7f1aa44742bf861d9c827b45122",
-        "sha256": "11zp8jf24ajqdh7aqia16dksdz0rbkxdn7f3jvpwwh084391x7dd",
+        "rev": "3bc1bc40121eb0975dc3d96741300bb4fd16be29",
+        "sha256": "1j8w7mrq2823qnh8za9fafdx2xm99ffic34shqbfc72j3ryi4wpy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f06a43dca05fb7f1aa44742bf861d9c827b45122.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/3bc1bc40121eb0975dc3d96741300bb4fd16be29.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f06a43dc...3bc1bc40](https://github.com/nix-community/home-manager/compare/f06a43dca05fb7f1aa44742bf861d9c827b45122...3bc1bc40121eb0975dc3d96741300bb4fd16be29)

* [`e8b5f8f9`](https://github.com/nix-community/home-manager/commit/e8b5f8f9b3368dcc4814129d6f66c1af7cf3b6e5) Update documentation to mention renamed option name. ([nix-community/home-manager⁠#4126](https://togithub.com/nix-community/home-manager/issues/4126))
* [`ec58f8be`](https://github.com/nix-community/home-manager/commit/ec58f8bed77b2982560c66239ce170f3764f6a36) borgmatic: add missing support for output and hooks
* [`e6d134ce`](https://github.com/nix-community/home-manager/commit/e6d134ce12ed78c1ac31745853aa1e74310f1a7d) home-environment: re-enable Nixpkgs release check
* [`da27ee44`](https://github.com/nix-community/home-manager/commit/da27ee446b7160081be1ef089c7843641a01d52e) flake.lock: Update
* [`1b615306`](https://github.com/nix-community/home-manager/commit/1b615306089aafcf6b375adb1cb568511c00b143) Translate using Weblate (German)
* [`9a76fb9a`](https://github.com/nix-community/home-manager/commit/9a76fb9a852fdf9edd3b0aabc119efa1d618f969) home-environment: allow skipping sanity checks
* [`9ce6977f`](https://github.com/nix-community/home-manager/commit/9ce6977fe76fb408042a432e314764f8d1d86263) himalaya: adjust module for 0.8.X ([nix-community/home-manager⁠#4093](https://togithub.com/nix-community/home-manager/issues/4093))
* [`50cb4d8a`](https://github.com/nix-community/home-manager/commit/50cb4d8a1ef1240a54074addf081bd96dbbcab12) programs.helix: add defaultEditor ([nix-community/home-manager⁠#4127](https://togithub.com/nix-community/home-manager/issues/4127))
* [`1fefd7bb`](https://github.com/nix-community/home-manager/commit/1fefd7bb8da0eec6755747f410fa491411a94296) gtk: Add gtk4.extraCss option ([nix-community/home-manager⁠#4133](https://togithub.com/nix-community/home-manager/issues/4133))
* [`29358e8b`](https://github.com/nix-community/home-manager/commit/29358e8be7e93c75cc0248a077db528e8617a507) starship: Remove INSIDE_EMACS checks when enabling shell integration ([nix-community/home-manager⁠#4135](https://togithub.com/nix-community/home-manager/issues/4135))
* [`a4817894`](https://github.com/nix-community/home-manager/commit/a4817894576f9cd01d784e60a0bfb143c81fc2be) treewide: remove marsam as maintainer ([nix-community/home-manager⁠#4136](https://togithub.com/nix-community/home-manager/issues/4136))
* [`6c78ba79`](https://github.com/nix-community/home-manager/commit/6c78ba7932567331fb8ebabf34a143b998bb5f23) docs/contributing: link to NMT's bash-lib ([nix-community/home-manager⁠#4125](https://togithub.com/nix-community/home-manager/issues/4125))
* [`91df8b34`](https://github.com/nix-community/home-manager/commit/91df8b34719aeb158e89fcef28e8e5f4ccaada36) Translate using Weblate (Indonesian)
* [`b9046172`](https://github.com/nix-community/home-manager/commit/b9046172a580a648045e7c2f7077cc143936ad8f) Add translation using Weblate (Indonesian)
* [`70ac1887`](https://github.com/nix-community/home-manager/commit/70ac18872a5f1a57a4546ff58888bf67a8bbb5b3) antidote: add module
* [`491f74db`](https://github.com/nix-community/home-manager/commit/491f74db894b5c5843a9e4b123aa773e1b21583f) antidote: fix package source path
* [`d2b6f2d1`](https://github.com/nix-community/home-manager/commit/d2b6f2d154bf6b27a93ed895392f80c503df7cfa) zellij: fix module description for shell integrations
* [`29872a1c`](https://github.com/nix-community/home-manager/commit/29872a1c8f5ed2fde270afb0583d1fabce5e0459) docs: update nmd
* [`28b6c367`](https://github.com/nix-community/home-manager/commit/28b6c3670cbfab9ff78e6de8cd38f93ec42d253b) docs: update nmd
* [`b59f682e`](https://github.com/nix-community/home-manager/commit/b59f682e860185e0670148d44be290c469bcc300) fish: consider man pages from extraOutputsToInstall
* [`68aebb45`](https://github.com/nix-community/home-manager/commit/68aebb45de644b81a71f0c7b8b22ad51c9a0df7a) fish: follow links to find man pages
* [`172d46d4`](https://github.com/nix-community/home-manager/commit/172d46d4b2677b32277d903bdf4cff77c2cc6477) docs: bump nmd
* [`0ee5ab61`](https://github.com/nix-community/home-manager/commit/0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179) ci: build manual and push to home-manager.dev
* [`3bc1bc40`](https://github.com/nix-community/home-manager/commit/3bc1bc40121eb0975dc3d96741300bb4fd16be29) antidote: fix .dot path
