### PR TITLE
niv powerlevel10k: update ab8bac01 -> 20323d6f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "ab8bac01e2a90e1cd749d4936e4decbdba3c2727",
-        "sha256": "1glsfyb4sfgs1d3gjcji5q1qlzpwgzz7xljphyb407qj3b3m7x9m",
+        "rev": "20323d6f8cd267805a793dafc840d22330653867",
+        "sha256": "09zh3z2f6c1p0lsi5m1i5zcvnk860npnc6ykzffynzcd086gqdv4",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/ab8bac01e2a90e1cd749d4936e4decbdba3c2727.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/20323d6f8cd267805a793dafc840d22330653867.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@ab8bac01...20323d6f](https://github.com/romkatv/powerlevel10k/compare/ab8bac01e2a90e1cd749d4936e4decbdba3c2727...20323d6f8cd267805a793dafc840d22330653867)

* [`017395a2`](https://github.com/romkatv/powerlevel10k/commit/017395a266aa15011c09e64e44a1c98ed91c478c) release v1.19.0
* [`20323d6f`](https://github.com/romkatv/powerlevel10k/commit/20323d6f8cd267805a793dafc840d22330653867) display `=` in git status if up to date with the remote ([romkatv/powerlevel10k⁠#2361](https://togithub.com/romkatv/powerlevel10k/issues/2361))
