### PR TITLE
niv zsh-completions: update 66c4b6fe -> 83f09c46

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "66c4b6fe720fc34bd18dbb879aa005fc7352c65b",
-        "sha256": "1s4wqsgr411dzvyrh95g1n9l09ndwk47ynbnzsxlwmlqy6g1cimy",
+        "rev": "83f09c461535e2372242c6282b66dbbbef6d508a",
+        "sha256": "10cf8fsspvdpl34z9i0ni7h8ya55mb9y05f0dyc5z4spkclqh49i",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/66c4b6fe720fc34bd18dbb879aa005fc7352c65b.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/83f09c461535e2372242c6282b66dbbbef6d508a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@66c4b6fe...83f09c46](https://github.com/zsh-users/zsh-completions/compare/66c4b6fe720fc34bd18dbb879aa005fc7352c65b...83f09c461535e2372242c6282b66dbbbef6d508a)

* [`302f477e`](https://github.com/zsh-users/zsh-completions/commit/302f477e10dde8f1ad355befd918124947516def) Update httpie completion
* [`323231ac`](https://github.com/zsh-users/zsh-completions/commit/323231ac9d157f86480f4b2969dccf5be4d3d599) Add version to dart completion for maintenance
* [`cfc3d2a2`](https://github.com/zsh-users/zsh-completions/commit/cfc3d2a2073a7ebd2b7536c31fc78d19d2277932) Update go completion version 1.21
