### PR TITLE
niv emacs-overlay: update 096b3845 -> 4acc71cd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "096b38450cbe3ba218e52f11c891eb0c67c3ca95",
-        "sha256": "0na1yw2b0x5hv25mi5iy3nly63b8q22avk88sr6qnkwabfxyzgd7",
+        "rev": "4acc71cdae77ca29a3b9fe71297e08f3d82ead7e",
+        "sha256": "0lkz1j9xffh5igw4b613012iwkgbg3g3dkiirkih889afcn75296",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/096b38450cbe3ba218e52f11c891eb0c67c3ca95.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/4acc71cdae77ca29a3b9fe71297e08f3d82ead7e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@096b3845...4acc71cd](https://github.com/nix-community/emacs-overlay/compare/096b38450cbe3ba218e52f11c891eb0c67c3ca95...4acc71cdae77ca29a3b9fe71297e08f3d82ead7e)

* [`908711c0`](https://github.com/nix-community/emacs-overlay/commit/908711c0c6eb1160ea0cbaf3187200674609d661) github actions: Set cachix auth token
* [`8a84e2bf`](https://github.com/nix-community/emacs-overlay/commit/8a84e2bfae1f6d5bd5c2e08e8f0a6d235aee4d71) flake.nix: Only expose hydraJobs on x86_64-linux
* [`a3467378`](https://github.com/nix-community/emacs-overlay/commit/a34673785802f2355a8be1870da45defad5b9ff4) Updated repos/emacs
* [`9a0f8dec`](https://github.com/nix-community/emacs-overlay/commit/9a0f8decb5be3cd0020888426cc4a3bc1fc5d67d) Updated repos/melpa
* [`fdf09998`](https://github.com/nix-community/emacs-overlay/commit/fdf09998a0484722757cfd5672a8b745bec982bb) Align with nixpkgs attribute syntax since https://github.com/NixOS/nixpkgs/pull/233301
* [`88d3f72d`](https://github.com/nix-community/emacs-overlay/commit/88d3f72dcc3d4b87499c54c2c66074d94890721e) Fix indentation
* [`fe9ad516`](https://github.com/nix-community/emacs-overlay/commit/fe9ad516f6404f8ce5fffd3955a29418eb82347f) flake.nix: Fixup typos in hydraJobs
* [`848c2a86`](https://github.com/nix-community/emacs-overlay/commit/848c2a86028488eff1683a30ed3ff2c70e772ea3) Updated repos/emacs
* [`dbb2bb4f`](https://github.com/nix-community/emacs-overlay/commit/dbb2bb4f40a27e2bba0bee5fe6f97e832a4583c6) Updated repos/melpa
* [`737fe5a5`](https://github.com/nix-community/emacs-overlay/commit/737fe5a55365f51bc3d47ffb0534a45cf0697c89) Remove exwm repo
* [`3fa0953d`](https://github.com/nix-community/emacs-overlay/commit/3fa0953df78d93754c611f368a8807e30ad5b9c1) Updated repos/emacs
* [`669d6397`](https://github.com/nix-community/emacs-overlay/commit/669d63975489ace6915437e04546edf300f7a847) Updated repos/melpa
* [`409f7606`](https://github.com/nix-community/emacs-overlay/commit/409f76066f48da486adf838e4adf0280546f44ad) Updated flake inputs
* [`3bc2a725`](https://github.com/nix-community/emacs-overlay/commit/3bc2a725ff3a5a3ede8ad7268a40b27454746dc2) Updated repos/elpa
* [`52c35b7d`](https://github.com/nix-community/emacs-overlay/commit/52c35b7dce1db6d87dc3258e1a1c6e8cd2be4c1a) Updated repos/emacs
* [`d2e5053c`](https://github.com/nix-community/emacs-overlay/commit/d2e5053c646c6f283553b46eab5723aee4fecfd2) Updated repos/melpa
* [`0e320163`](https://github.com/nix-community/emacs-overlay/commit/0e320163bcf62a4db3666d366f6752562c2aa409) Updated repos/nongnu
* [`081f0448`](https://github.com/nix-community/emacs-overlay/commit/081f04481f512a63988d4cbea5f91aa810e2ecdb) Updated flake inputs
* [`901768d7`](https://github.com/nix-community/emacs-overlay/commit/901768d7ab98e8081f994cd98d93a07f6b5078ec) Updated repos/elpa
* [`f49b868d`](https://github.com/nix-community/emacs-overlay/commit/f49b868da65b360332fc404662959d81c489906e) Updated repos/emacs
* [`3749415e`](https://github.com/nix-community/emacs-overlay/commit/3749415ec47d66e50e8005df7a02e165b60b7e1f) Updated repos/elpa
* [`7951eca6`](https://github.com/nix-community/emacs-overlay/commit/7951eca672c2b9e62919e70be3d2a3e13d7f87e4) Updated repos/melpa
* [`f39fec6a`](https://github.com/nix-community/emacs-overlay/commit/f39fec6afdc6a9e6fd7f9f44c9a2337171d7d331) Updated repos/emacs
* [`fbbf354b`](https://github.com/nix-community/emacs-overlay/commit/fbbf354bceb8d42d1e0eef8116b66e9947c84017) Updated repos/melpa
* [`92e2053f`](https://github.com/nix-community/emacs-overlay/commit/92e2053fd614bc0402754c5ed09fddd88560fbce) Updated repos/elpa
* [`2ec68d6f`](https://github.com/nix-community/emacs-overlay/commit/2ec68d6fd08db49d27ff2080c81a3012b11e8a57) Updated repos/emacs
* [`074dc30c`](https://github.com/nix-community/emacs-overlay/commit/074dc30cec64604d650fffcb90631f63900d76d9) Updated repos/melpa
* [`63810837`](https://github.com/nix-community/emacs-overlay/commit/638108373002d5eab0249aa68b43941bee4e204e) Updated flake inputs
* [`232c9fc5`](https://github.com/nix-community/emacs-overlay/commit/232c9fc5221652a8f353a3fa0dfd6c09a4401389) Updated repos/emacs
* [`9bc16d78`](https://github.com/nix-community/emacs-overlay/commit/9bc16d788b9b09e986b2fba5a76fe44d35010d52) Updated repos/melpa
* [`70db1748`](https://github.com/nix-community/emacs-overlay/commit/70db17480e76d556cc5363c1ba22cd591c83fa76) Updated repos/melpa
* [`f5ef413b`](https://github.com/nix-community/emacs-overlay/commit/f5ef413b70a689a476f7858236dc7f449eaa94db) Updated flake inputs
* [`daf30816`](https://github.com/nix-community/emacs-overlay/commit/daf30816d3159e7dc6dae227bfe4dfe9ecef5f83) Updated repos/emacs
* [`e214ae80`](https://github.com/nix-community/emacs-overlay/commit/e214ae80f69bb2c8642b4b98190e49321d3b7c72) Updated repos/melpa
* [`2e674f0d`](https://github.com/nix-community/emacs-overlay/commit/2e674f0d41cfcb62e1e7b1469841ac0e454b3af5) Updated repos/elpa
* [`3054f859`](https://github.com/nix-community/emacs-overlay/commit/3054f85921ad6e1f1015a51206255c71c012fb42) Updated repos/emacs
* [`22678cd2`](https://github.com/nix-community/emacs-overlay/commit/22678cd26cd886c9f29775b2102981b66b6d0a42) Updated repos/melpa
* [`378276bc`](https://github.com/nix-community/emacs-overlay/commit/378276bcf9df3c3b8dea6d34085578b7b5c7dd8f) Updated repos/emacs
* [`9bfa1758`](https://github.com/nix-community/emacs-overlay/commit/9bfa175833e5775d57f470f30b5404b04a7250be) Updated repos/melpa
* [`ec3643e9`](https://github.com/nix-community/emacs-overlay/commit/ec3643e9cf2e09e9a328ae53de7c602b05c07b61) Account for upstream renaming
* [`5c6bfc6d`](https://github.com/nix-community/emacs-overlay/commit/5c6bfc6d5a6a99d22f1949efddf06df468c87762) Updated flake inputs
* [`dee4fca6`](https://github.com/nix-community/emacs-overlay/commit/dee4fca68840d5a428f106099ede217f463626d4) Updated repos/emacs
* [`d0ed6edc`](https://github.com/nix-community/emacs-overlay/commit/d0ed6edc7561f7a5518bd51f501e0cc6f9aa3023) Updated repos/melpa
* [`1c17cd17`](https://github.com/nix-community/emacs-overlay/commit/1c17cd17b6d9d11bd9ff06c27e7a5397f4cd52fb) Updated repos/elpa
* [`201c7544`](https://github.com/nix-community/emacs-overlay/commit/201c7544f6842430e8cc872658bdf8a91de20503) Updated repos/melpa
* [`38c6ec9c`](https://github.com/nix-community/emacs-overlay/commit/38c6ec9ceedc710836fe557193d9750288148ef9) Updated repos/melpa
* [`f8704de7`](https://github.com/nix-community/emacs-overlay/commit/f8704de7d8dd727af1b180bcf6166f5c40e4063a) Updated repos/nongnu
* [`6a262f64`](https://github.com/nix-community/emacs-overlay/commit/6a262f645b5823565c37a072458310a3fcded27e) emacsUnstable -> emacs-unstable
* [`36e4c9f0`](https://github.com/nix-community/emacs-overlay/commit/36e4c9f03cd10c78b20c39434ad4ded85836a770) stable release: 22.11 -> 23.05
* [`2459202b`](https://github.com/nix-community/emacs-overlay/commit/2459202b5e72a56744b94125e26dfab7fcaddd66) Updated repos/emacs
* [`30c400a6`](https://github.com/nix-community/emacs-overlay/commit/30c400a67df95ad5012119bff4c8a9386d21e5c4) Updated repos/melpa
* [`c2d15fbd`](https://github.com/nix-community/emacs-overlay/commit/c2d15fbd774e1f0b00bc092b3283621598216ed2) Updated flake inputs
* [`73a0fbf8`](https://github.com/nix-community/emacs-overlay/commit/73a0fbf8fa3bb262ce18452495ff4db9fb750e6f) Updated repos/elpa
* [`0a32a899`](https://github.com/nix-community/emacs-overlay/commit/0a32a8997084a500d2af4e7a833312e0e2dcde32) Updated repos/emacs
* [`fe83f47d`](https://github.com/nix-community/emacs-overlay/commit/fe83f47d0a8240ec1d81928705f6b02dc722fbbd) Updated repos/melpa
* [`112adc7a`](https://github.com/nix-community/emacs-overlay/commit/112adc7a2f7ec84c7d1606063d5a69225700fbf6) Updated repos/emacs
* [`d80c21d6`](https://github.com/nix-community/emacs-overlay/commit/d80c21d639094ecc95f5ea437a141090499384d0) Updated repos/melpa
* [`eada483b`](https://github.com/nix-community/emacs-overlay/commit/eada483b061e1f41dd816be2e56493b9f7ddd513) Updated flake inputs
* [`0ffc9b86`](https://github.com/nix-community/emacs-overlay/commit/0ffc9b861a787de57cc2c7be4317e7765e112b3c) Updated repos/elpa
* [`1be23d1d`](https://github.com/nix-community/emacs-overlay/commit/1be23d1d41d7a0abd90bc874383bc900d700dd9f) Updated repos/melpa
* [`dc060c1e`](https://github.com/nix-community/emacs-overlay/commit/dc060c1e69b0542fdaa14729bdc8d4a36ac838e2) Updated flake inputs
* [`fe0dacbf`](https://github.com/nix-community/emacs-overlay/commit/fe0dacbf35a93bd7094ce9478ed1faf0c6a2784c) Updated repos/elpa
* [`f2f600ba`](https://github.com/nix-community/emacs-overlay/commit/f2f600ba705500152471fae17321468fdc8f3be3) Updated repos/emacs
* [`bdc9dc52`](https://github.com/nix-community/emacs-overlay/commit/bdc9dc52f1ae9772ebdca1f132554fe548392001) Updated repos/melpa
* [`eb1d1ce0`](https://github.com/nix-community/emacs-overlay/commit/eb1d1ce028583d406ea5f6ccb8110d184600af7d) Add elpaDevelPackages
* [`631e36d9`](https://github.com/nix-community/emacs-overlay/commit/631e36d9e02f4b2f9f1b32739c5fc12a66f94301) Updated repos/melpa
* [`efc7bd51`](https://github.com/nix-community/emacs-overlay/commit/efc7bd51d72102e3e28068abc77f4483722d66a0) Updated flake inputs
* [`28602238`](https://github.com/nix-community/emacs-overlay/commit/28602238a2769d71fbc14d83babf9fa802922c38) Updated repos/elpa
* [`a2e29b19`](https://github.com/nix-community/emacs-overlay/commit/a2e29b1990788b594bb97930a14b8ecb0e003ec3) Updated repos/emacs
* [`8f642115`](https://github.com/nix-community/emacs-overlay/commit/8f642115041750e13a82d3bc841bf38a814b9bc4) Updated repos/melpa
* [`3ee14d3e`](https://github.com/nix-community/emacs-overlay/commit/3ee14d3eb037733245940cd86b14be411d1089b1) Updated repos/elpa
* [`bd120f9a`](https://github.com/nix-community/emacs-overlay/commit/bd120f9a9d5df7c8b15350d0cf0d39ccb9392ca4) Updated repos/emacs
* [`e9a6f712`](https://github.com/nix-community/emacs-overlay/commit/e9a6f71242e325a643202270c4c4a237d885a8a4) Updated repos/melpa
* [`8cc5cb74`](https://github.com/nix-community/emacs-overlay/commit/8cc5cb74df95ca280537d202691d5a3d973533d3) Updated repos/nongnu
* [`e05da511`](https://github.com/nix-community/emacs-overlay/commit/e05da51198ca07d6c79d9eed3f5ef88748060989) Updated flake inputs
* [`b7a065e6`](https://github.com/nix-community/emacs-overlay/commit/b7a065e692e944e6b68d4285013ca426a8de6663) Updated repos/melpa
* [`85d65fcf`](https://github.com/nix-community/emacs-overlay/commit/85d65fcf3eb273036d1d7914cc7805503e95d474) Updated flake inputs
* [`fc0be2d9`](https://github.com/nix-community/emacs-overlay/commit/fc0be2d96af2b87f61b446ad576d0dd77d29bf1d) Updated repos/elpa
* [`bd1e0949`](https://github.com/nix-community/emacs-overlay/commit/bd1e09496cb8a46436ea273be48157e17a1b050b) Updated repos/melpa
* [`65e705b7`](https://github.com/nix-community/emacs-overlay/commit/65e705b7129f43e34b03441a5499f8663f4fdf5d) Updated repos/elpa
* [`f8fd8ce3`](https://github.com/nix-community/emacs-overlay/commit/f8fd8ce3bfc733a9278712a6ea5a626376d0b050) Updated repos/melpa
* [`82a84e07`](https://github.com/nix-community/emacs-overlay/commit/82a84e07b068909ea8423dd4f7689d4366f03494) Updated repos/nongnu
* [`54cb49d3`](https://github.com/nix-community/emacs-overlay/commit/54cb49d301ec3211e22b3e75d2aa4be346d0c1a2) Updated flake inputs
* [`6cd80103`](https://github.com/nix-community/emacs-overlay/commit/6cd801031986bc569ee958b88095f65fff1c8cf0) Updated flake inputs
* [`8ef245ef`](https://github.com/nix-community/emacs-overlay/commit/8ef245efe6b5346cf923d40ebfd5bc81a70a096b) Updated repos/elpa
* [`4167af18`](https://github.com/nix-community/emacs-overlay/commit/4167af18b056f269700d90c37a1b300571161b95) Updated repos/emacs
* [`84299e2a`](https://github.com/nix-community/emacs-overlay/commit/84299e2af47f89210b44ef9b6d0dea8af48997b8) Updated flake inputs
* [`31a4f7a3`](https://github.com/nix-community/emacs-overlay/commit/31a4f7a300060a06c0e0207e33120ac010562c58) Updated repos/elpa
* [`980d87d8`](https://github.com/nix-community/emacs-overlay/commit/980d87d8f7ef0ca51f6cd6ade8e6eaaef096edc7) Updated repos/melpa
* [`9a46e367`](https://github.com/nix-community/emacs-overlay/commit/9a46e36799e5ba7459ab45df12966e436cdc5194) Updated repos/nongnu
* [`224c28e3`](https://github.com/nix-community/emacs-overlay/commit/224c28e338776a5f50886feb5a39370133981195) Updated repos/melpa
* [`9ef77c9a`](https://github.com/nix-community/emacs-overlay/commit/9ef77c9a79c123ee6e1a57e720b4f0d31e6de5f1) Updated repos/melpa
* [`8627c2eb`](https://github.com/nix-community/emacs-overlay/commit/8627c2eb7075ac84f36295af1ff1c8170168cf29) Updated repos/elpa
* [`89e88190`](https://github.com/nix-community/emacs-overlay/commit/89e881901c67842dedc46081c2c57876f3334a98) Updated repos/emacs
* [`bfe8be18`](https://github.com/nix-community/emacs-overlay/commit/bfe8be184d1ca2c3bdfdb07b13d855d2e7fde040) Updated repos/melpa
* [`338449af`](https://github.com/nix-community/emacs-overlay/commit/338449af832d0b3f639feee4f5d507ebb7828a30) Updated flake inputs
* [`d7c61dfb`](https://github.com/nix-community/emacs-overlay/commit/d7c61dfb9a1a415e593a92827c3696b13fd885f3) Updated repos/emacs
* [`0adeaf14`](https://github.com/nix-community/emacs-overlay/commit/0adeaf14c80ce43d2c27ef35d195196a590694d2) Updated repos/melpa
* [`0aab8e31`](https://github.com/nix-community/emacs-overlay/commit/0aab8e31f11ca642ed02b9e280fc83122ac44d75) Updated repos/elpa
* [`d1064ac1`](https://github.com/nix-community/emacs-overlay/commit/d1064ac1903e633afb5fea40c080d7650b3a1987) Updated repos/emacs
* [`b769c7c0`](https://github.com/nix-community/emacs-overlay/commit/b769c7c0e616c238382d3dfe9c8e4cb7fdf3d1a3) Updated repos/melpa
* [`c5fecbd5`](https://github.com/nix-community/emacs-overlay/commit/c5fecbd5f818044311b92ecf8863668368b1cf87) Updated repos/elpa
* [`3f1d6a74`](https://github.com/nix-community/emacs-overlay/commit/3f1d6a7412d3fe0deea8797d35f8bf63cac0e069) Updated repos/emacs
* [`d248cdbb`](https://github.com/nix-community/emacs-overlay/commit/d248cdbbc9799d0cff8550e4fb4267bfac66e992) Updated repos/melpa
* [`78285374`](https://github.com/nix-community/emacs-overlay/commit/78285374856bc7be0cabfb84f6f3f5c62492aa44) Updated repos/melpa
* [`fdfb17aa`](https://github.com/nix-community/emacs-overlay/commit/fdfb17aa0c071c929a6eb60aaba47c910a2a3401) Updated flake inputs
* [`8b057c49`](https://github.com/nix-community/emacs-overlay/commit/8b057c492ad66a267c0f88239aee28ad28092adc) Updated repos/elpa
* [`48872523`](https://github.com/nix-community/emacs-overlay/commit/48872523952077389e8d48bd53155bb2ba3c8b28) Updated repos/emacs
* [`46e6fb89`](https://github.com/nix-community/emacs-overlay/commit/46e6fb892209960c4a4bf1b45dedfd11a144a541) Updated repos/melpa
* [`673dbc6f`](https://github.com/nix-community/emacs-overlay/commit/673dbc6f59193f12108bee125ca7a69f27ca9c21) Updated repos/melpa
* [`78af0d42`](https://github.com/nix-community/emacs-overlay/commit/78af0d42a89401b68349f608316fbf9366877424) Updated repos/melpa
* [`e878f59f`](https://github.com/nix-community/emacs-overlay/commit/e878f59f08b5bb16c1bd6e00b8d949f39ffbc6f6) Updated repos/elpa
* [`5df80efa`](https://github.com/nix-community/emacs-overlay/commit/5df80efae8fa03d9d199bea7c1cdf9d96cb8b2c2) Updated repos/melpa
* [`84904b62`](https://github.com/nix-community/emacs-overlay/commit/84904b628ac1158ed2a21ac3758a17f1f56665c7) Add emacs-unstable-pgtk to Hydra job
* [`f7761941`](https://github.com/nix-community/emacs-overlay/commit/f7761941086ebffb6f4ef232d45e7824a80acc80) Remove 22.11 handholding
* [`851949d3`](https://github.com/nix-community/emacs-overlay/commit/851949d30ba62bda2fbe04f99520af7514cdae16) Updated flake inputs
* [`6c25d4b1`](https://github.com/nix-community/emacs-overlay/commit/6c25d4b166ebadafca0afb554ece193362fb6938) Updated repos/elpa
* [`53ac682a`](https://github.com/nix-community/emacs-overlay/commit/53ac682af40ca1e2b8a61f3cc17138efd53d90c9) Updated repos/emacs
* [`a7275213`](https://github.com/nix-community/emacs-overlay/commit/a727521330457be462e5f5e90e40e02af77012eb) Updated repos/melpa
* [`d9c74049`](https://github.com/nix-community/emacs-overlay/commit/d9c74049fc523f59e153d21c5498dc94d884f3fc) Updated repos/nongnu
* [`d6753431`](https://github.com/nix-community/emacs-overlay/commit/d67534316f2307e133cfc4017e65c240af74fbb7) Updated repos/melpa
* [`94c7550a`](https://github.com/nix-community/emacs-overlay/commit/94c7550ae2155ebd04a7527b3a200deafece86dc) Extend fromUsePackage config argument compatibility
* [`d1e7e256`](https://github.com/nix-community/emacs-overlay/commit/d1e7e25632c64236bbd2c287188570485810cdc4) Updated repos/elpa
* [`faa5b836`](https://github.com/nix-community/emacs-overlay/commit/faa5b836e01ec639ad542fc8100b37b1c523e436) Updated repos/emacs
* [`a4682901`](https://github.com/nix-community/emacs-overlay/commit/a46829010dd9d129fd930ae76aba9f09b4160630) Updated repos/melpa
* [`f093275b`](https://github.com/nix-community/emacs-overlay/commit/f093275b35db193ceba13a98790fb6201788007b) Updated repos/elpa
* [`3978ea4e`](https://github.com/nix-community/emacs-overlay/commit/3978ea4e7de5ac60d1293e7d8e0d006562c348bc) Updated repos/emacs
* [`3a9f22bf`](https://github.com/nix-community/emacs-overlay/commit/3a9f22bf4de26dec7243ac10849c0afd6fc945f0) Updated repos/melpa
* [`f95c33d6`](https://github.com/nix-community/emacs-overlay/commit/f95c33d692cc174df41e40330aec4abf2a94b673) Updated repos/nongnu
* [`6e070c2b`](https://github.com/nix-community/emacs-overlay/commit/6e070c2bf2ebcaec125a18d4a512ea2df5b5a306) Updated repos/melpa
* [`12777320`](https://github.com/nix-community/emacs-overlay/commit/12777320cdee6698e5901f6392ff85f939adf11a) Updated repos/nongnu
* [`44d2a288`](https://github.com/nix-community/emacs-overlay/commit/44d2a28817f6a310f2b6e9e97f6f3075462e791c) Updated flake inputs
* [`63c1c17b`](https://github.com/nix-community/emacs-overlay/commit/63c1c17b453b1f6512d138f3dd78504bc2285f8b) Updated repos/elpa
* [`b28ae649`](https://github.com/nix-community/emacs-overlay/commit/b28ae64904fc4caf5d289e4dc2a4bed17307f843) Updated repos/emacs
* [`f806b442`](https://github.com/nix-community/emacs-overlay/commit/f806b44250b0010b29eff2dd411c32f99afae274) Updated repos/melpa
* [`58bd9bdb`](https://github.com/nix-community/emacs-overlay/commit/58bd9bdbfed334e70848849682bd1844ea773ed1) Updated flake inputs
* [`150318a2`](https://github.com/nix-community/emacs-overlay/commit/150318a26d7d0e5662a8f6d6fe9c9b306453997f) Updated repos/elpa
* [`1ab94d15`](https://github.com/nix-community/emacs-overlay/commit/1ab94d15a82c3e4bd295f3efa8f5145b18e0d6ff) Updated repos/melpa
* [`2628f120`](https://github.com/nix-community/emacs-overlay/commit/2628f12023115c1b5e0fdff257cd2e1f4cc199b5) Updated repos/melpa
* [`3a79248b`](https://github.com/nix-community/emacs-overlay/commit/3a79248bcaa5a58e30adb7d09ca78293c87a6d83) Updated repos/elpa
* [`bc40315e`](https://github.com/nix-community/emacs-overlay/commit/bc40315e13e6f90989736b82aada898701fb9506) Updated repos/emacs
* [`79ca8053`](https://github.com/nix-community/emacs-overlay/commit/79ca8053930cdb59124256c83caf06233cd69f92) Updated repos/melpa
* [`4e071c16`](https://github.com/nix-community/emacs-overlay/commit/4e071c1636ce8eebee9471b97f182de81c210283) Updated flake inputs
* [`7f8f6f66`](https://github.com/nix-community/emacs-overlay/commit/7f8f6f66bfd7b2eb6e3b3f61e1555c849f511fb8) Updated repos/elpa
* [`4796448d`](https://github.com/nix-community/emacs-overlay/commit/4796448d1f03b77ca09ba71091769a9cefea8d0c) Updated repos/emacs
* [`c479abe1`](https://github.com/nix-community/emacs-overlay/commit/c479abe17f32f40544fce3a7cd43fb60cbc7e118) Updated repos/melpa
* [`f0d599af`](https://github.com/nix-community/emacs-overlay/commit/f0d599afa9e7fd75cc3142e198bfb3b0b9d7dfb5) Updated repos/nongnu
* [`140fc803`](https://github.com/nix-community/emacs-overlay/commit/140fc80363d085b4ff267df88b6a47b7e969a68c) Updated repos/emacs
* [`a4c1f4b1`](https://github.com/nix-community/emacs-overlay/commit/a4c1f4b163c9ba956a6d09476a2fcb1feb9057ea) Updated repos/melpa
* [`061ac476`](https://github.com/nix-community/emacs-overlay/commit/061ac47666f79565738b02e85175a7ff8aa95073) Updated repos/elpa
* [`1ec1432d`](https://github.com/nix-community/emacs-overlay/commit/1ec1432d982b19e1cf0479389ce20f16e867b550) Updated repos/emacs
* [`df90f4db`](https://github.com/nix-community/emacs-overlay/commit/df90f4dbb6c6725518da63909f2310b715eb8d08) Updated repos/melpa
* [`842fdae4`](https://github.com/nix-community/emacs-overlay/commit/842fdae419c6cf5d3f967bd45c7ce31f3bd3da8d) Revert "Remove 22.11 handholding"
* [`33bf95a1`](https://github.com/nix-community/emacs-overlay/commit/33bf95a15a990be189546dd9374f978de4ce3d33) Updated repos/elpa
* [`a32a88a0`](https://github.com/nix-community/emacs-overlay/commit/a32a88a0e9cf0500f9288bf34a11382febf50101) Updated repos/emacs
* [`0991a66e`](https://github.com/nix-community/emacs-overlay/commit/0991a66e46783a13b9d42054bb89cb7e31e72355) Updated repos/melpa
* [`37ab2cb6`](https://github.com/nix-community/emacs-overlay/commit/37ab2cb6a09245809e862dde7ed9adcd5b83d62d) Updated repos/nongnu
* [`83dbe2a7`](https://github.com/nix-community/emacs-overlay/commit/83dbe2a7e6cfd9355b2b28bcf84b74ef196d9d22) Updated flake inputs
* [`78c1cebb`](https://github.com/nix-community/emacs-overlay/commit/78c1cebb5b7e5b15070e4e7d4bb75a600d793d8e) Updated repos/melpa
* [`128bdc6a`](https://github.com/nix-community/emacs-overlay/commit/128bdc6a54bcf514c515377240f0809377f3d9b0) Updated repos/nongnu
* [`01b081aa`](https://github.com/nix-community/emacs-overlay/commit/01b081aa14ba333ef98cb0f3e3db0f6cb35ecd87) Updated flake inputs
* [`a2c052a8`](https://github.com/nix-community/emacs-overlay/commit/a2c052a84f24808b0f6a6643c4fe9bf2d8e73271) Updated repos/elpa
* [`0fe0335f`](https://github.com/nix-community/emacs-overlay/commit/0fe0335fc9219d8040538e240f706f17a399f4d9) Updated repos/emacs
* [`f8f1aacc`](https://github.com/nix-community/emacs-overlay/commit/f8f1aacce3de2db735520e71fde8fbab4c9dbbfc) Updated repos/melpa
* [`0cf9b0e8`](https://github.com/nix-community/emacs-overlay/commit/0cf9b0e850ff7acf135973f61c78991168e76073) Updated flake inputs
* [`5e115a1f`](https://github.com/nix-community/emacs-overlay/commit/5e115a1fed44019a9d4fa33a134a90fe3a4db5e8) Updated repos/elpa
* [`5c1fb207`](https://github.com/nix-community/emacs-overlay/commit/5c1fb20757d924694aea3aad2777a669ebdebdd3) Updated repos/emacs
* [`407f005d`](https://github.com/nix-community/emacs-overlay/commit/407f005d3a16e358bd425e0214d2ae92b25a04f1) Updated repos/melpa
* [`37684ba5`](https://github.com/nix-community/emacs-overlay/commit/37684ba57c714172de8721836dfeef9140dbe184) Updated repos/emacs
* [`d6e4fff7`](https://github.com/nix-community/emacs-overlay/commit/d6e4fff770350f6e3d9de2400c943d96ef564145) Updated repos/melpa
* [`791aa0e0`](https://github.com/nix-community/emacs-overlay/commit/791aa0e08f96aa7b965ef409f7bf980915198b35) Updated flake inputs
* [`53624c2f`](https://github.com/nix-community/emacs-overlay/commit/53624c2fe357047387b84a8a3d7cb272882c19cd) Updated repos/elpa
* [`e74eb90b`](https://github.com/nix-community/emacs-overlay/commit/e74eb90b7a92632523ce8519eddb29c516bd70f6) Updated repos/melpa
* [`03584738`](https://github.com/nix-community/emacs-overlay/commit/0358473821c31a78a04495b476b2a22491a0519c) Updated repos/elpa
* [`f06b0902`](https://github.com/nix-community/emacs-overlay/commit/f06b09020d4c444288ed08baaa3fe35f3782bba6) Updated repos/emacs
* [`67bc8a38`](https://github.com/nix-community/emacs-overlay/commit/67bc8a38d8517ee1b9c8e2e850ad27b8923b4d0e) Updated repos/melpa
* [`25542eb7`](https://github.com/nix-community/emacs-overlay/commit/25542eb77bd1c3268d71ef83747d27144ea5ca72) Updated repos/emacs
* [`9a29c4e0`](https://github.com/nix-community/emacs-overlay/commit/9a29c4e014849d1e448051c4319a194e0041403a) Updated repos/melpa
* [`7f39dc5e`](https://github.com/nix-community/emacs-overlay/commit/7f39dc5ed946c5d74cceae1414b6778c81fde25d) Updated repos/nongnu
* [`a5a86728`](https://github.com/nix-community/emacs-overlay/commit/a5a86728852d17c105965b77097236c2684bc619) Updated flake inputs
* [`ee072f61`](https://github.com/nix-community/emacs-overlay/commit/ee072f617bacddd0bcbfe73385a4bf57f5234ab6) Updated repos/elpa
* [`72051757`](https://github.com/nix-community/emacs-overlay/commit/720517570242ec7e569670c65370a3f680a22502) Updated repos/emacs
* [`95f2e9aa`](https://github.com/nix-community/emacs-overlay/commit/95f2e9aad90b58cc0c8e9c296444a70c3d9a790e) Updated repos/melpa
* [`f4e99ba9`](https://github.com/nix-community/emacs-overlay/commit/f4e99ba9deb3aae811f3ed297758708a0e090b73) Updated repos/elpa
* [`64f65b5a`](https://github.com/nix-community/emacs-overlay/commit/64f65b5aab476cbf76f73524c29128aab0a33b56) Updated repos/emacs
* [`e36864d4`](https://github.com/nix-community/emacs-overlay/commit/e36864d48ed596547f4692aff1a5a7ce656c535e) Updated repos/melpa
* [`a12bde8e`](https://github.com/nix-community/emacs-overlay/commit/a12bde8e95c4f8310d394283e1ce493a9ddadb15) Updated repos/emacs
* [`48311d72`](https://github.com/nix-community/emacs-overlay/commit/48311d720c5d470a4b53d67991c9a62d88748921) Updated repos/melpa
* [`f4044dd7`](https://github.com/nix-community/emacs-overlay/commit/f4044dd7b32724179f0d1095a4f205d0553cd1b9) Updated repos/emacs
* [`505bd47e`](https://github.com/nix-community/emacs-overlay/commit/505bd47eed2d362e7c1540fdfde041388ca67d57) Updated repos/melpa
* [`6f82a427`](https://github.com/nix-community/emacs-overlay/commit/6f82a4270ce4d944137b03ba2a50132cb4da7a18) Updated flake inputs
* [`d20a3316`](https://github.com/nix-community/emacs-overlay/commit/d20a33163e93dc3706c9fb67dae61c145cc2a204) Updated repos/elpa
* [`c95026cf`](https://github.com/nix-community/emacs-overlay/commit/c95026cf31fd0ee2058924da74e8f220a1ca0cff) Updated repos/emacs
* [`1ceb43ef`](https://github.com/nix-community/emacs-overlay/commit/1ceb43ef790d7676fa50c0085438e51c0b67e657) Updated repos/melpa
* [`29ad7704`](https://github.com/nix-community/emacs-overlay/commit/29ad7704a8191bd9170ee7e50ae222f88fb675f9) Updated repos/melpa
* [`4b5ee9e6`](https://github.com/nix-community/emacs-overlay/commit/4b5ee9e67f0d645bed26c592705b9c7c6966db14) Updated repos/melpa
* [`7c966316`](https://github.com/nix-community/emacs-overlay/commit/7c96631604a985b25c00fb86ca36c160a07c2eba) Updated flake inputs
* [`bad77772`](https://github.com/nix-community/emacs-overlay/commit/bad77772438cfa02a2c52f8b352e673f2bdd6f29) Updated repos/elpa
* [`fdcc8d47`](https://github.com/nix-community/emacs-overlay/commit/fdcc8d475cf18d0bfe00bf494f08e607569abaa4) Updated repos/melpa
* [`ffd671a3`](https://github.com/nix-community/emacs-overlay/commit/ffd671a31cd104435913a7a6a04cc91885c177ea) Updated repos/melpa
* [`07c59811`](https://github.com/nix-community/emacs-overlay/commit/07c598114ea926927a2e26f4951fda4845a56a31) Updated repos/nongnu
* [`e880c1ac`](https://github.com/nix-community/emacs-overlay/commit/e880c1ac6040fc51b99cdcde8357f9c6c921bcbd) Updated repos/elpa
* [`1ba38cc6`](https://github.com/nix-community/emacs-overlay/commit/1ba38cc6418a5e76ca4f573511fc6e44921fb2dc) Updated repos/emacs
* [`f04afee5`](https://github.com/nix-community/emacs-overlay/commit/f04afee53c45ab899858d951ea0b12c3f88c3f9e) Updated repos/melpa
* [`df7ce0d8`](https://github.com/nix-community/emacs-overlay/commit/df7ce0d80770b38cd284358d7b11311984929586) Updated repos/elpa
* [`f060746e`](https://github.com/nix-community/emacs-overlay/commit/f060746e56c34bdec4de5bd17ae220032f878bff) Updated repos/emacs
* [`cf22b000`](https://github.com/nix-community/emacs-overlay/commit/cf22b000b04d017a0cf779ca67e6ca9cce6974e2) Updated repos/melpa
* [`023949f6`](https://github.com/nix-community/emacs-overlay/commit/023949f6f0ee018cb3db83d01ae22d396289de93) Updated flake inputs
* [`76a4a5cd`](https://github.com/nix-community/emacs-overlay/commit/76a4a5cd0546e57767c54fe6e8ad56f540b0fe54) Updated repos/emacs
* [`e6ef4e0b`](https://github.com/nix-community/emacs-overlay/commit/e6ef4e0b7814e6bd89d1049e0dacfee670cf2520) Updated repos/melpa
* [`8e81caaf`](https://github.com/nix-community/emacs-overlay/commit/8e81caaf00418200812761c4d0a8c45d9a599180) Updated repos/nongnu
* [`e0dfcc00`](https://github.com/nix-community/emacs-overlay/commit/e0dfcc009a6da5ba71044d0e2f4b30e965859e27) Updated flake inputs
* [`7f7983d6`](https://github.com/nix-community/emacs-overlay/commit/7f7983d6a85c2c00846aa8ba9ae2a2aaee640d2a) Updated repos/elpa
* [`d0f8977a`](https://github.com/nix-community/emacs-overlay/commit/d0f8977a474fcd1ea69be632d4376b82b8190081) Updated repos/emacs
* [`c0f731d7`](https://github.com/nix-community/emacs-overlay/commit/c0f731d7d193606c355444bb654b921ba07d9f83) Updated repos/melpa
* [`28260225`](https://github.com/nix-community/emacs-overlay/commit/282602258e28dea8faee93c4b931f73435b8ee4e) Updated repos/elpa
* [`e59d5129`](https://github.com/nix-community/emacs-overlay/commit/e59d51298e15d5db828fb836dfbb9f56fea8e42d) Updated repos/emacs
* [`41f4d133`](https://github.com/nix-community/emacs-overlay/commit/41f4d133abf0a955e138397754b6ced199c3a6aa) Updated repos/melpa
* [`be892858`](https://github.com/nix-community/emacs-overlay/commit/be8928584076092dd1a52e422bb737316baa3971) Updated flake inputs
* [`300cf066`](https://github.com/nix-community/emacs-overlay/commit/300cf0667c07e2af4c87d73850fcf1e2a667ebb3) Updated repos/melpa
* [`ceb35ffa`](https://github.com/nix-community/emacs-overlay/commit/ceb35ffa6615a7f96d36d7651570f722452b743b) Updated repos/nongnu
* [`91c4c39a`](https://github.com/nix-community/emacs-overlay/commit/91c4c39a4bbeeeb165542944d4c1d8652265649b) Updated repos/elpa
* [`db5f25f8`](https://github.com/nix-community/emacs-overlay/commit/db5f25f81ac25cb3bca7e5ca8d38cba70f864068) Updated repos/emacs
* [`d61bf076`](https://github.com/nix-community/emacs-overlay/commit/d61bf076fb5894c8184be50c72eb1def13e2d232) Updated repos/melpa
* [`445dc8fd`](https://github.com/nix-community/emacs-overlay/commit/445dc8fd5c1f4241679b1301511fb2905eebbaf4) Updated repos/elpa
* [`ceba2d47`](https://github.com/nix-community/emacs-overlay/commit/ceba2d47f6a07fe28ac255f5ece69c74011217e8) Updated repos/melpa
* [`8b343d6f`](https://github.com/nix-community/emacs-overlay/commit/8b343d6fee8481e33e529bf988e61801ca3d1178) Updated repos/nongnu
* [`1de4864b`](https://github.com/nix-community/emacs-overlay/commit/1de4864bc63d98fc84762fe73ec3e0925db2860d) Updated repos/melpa
* [`edf4b5c9`](https://github.com/nix-community/emacs-overlay/commit/edf4b5c9b016c4223ad2fddf523ef33c15c2fecb) Updated repos/nongnu
* [`c28a848f`](https://github.com/nix-community/emacs-overlay/commit/c28a848fefa32b205afc657d383f325a58868a8f) Updated flake inputs
* [`4776dc48`](https://github.com/nix-community/emacs-overlay/commit/4776dc485ad415b420048204a5e052cd73698858) Updated repos/elpa
* [`61fc240d`](https://github.com/nix-community/emacs-overlay/commit/61fc240dec67dbc1244f7be24c810877e54c5f93) Updated repos/emacs
* [`0d7cafc4`](https://github.com/nix-community/emacs-overlay/commit/0d7cafc401fd304d06c8d61656198ab242a2c9ae) Updated repos/melpa
* [`f214ae53`](https://github.com/nix-community/emacs-overlay/commit/f214ae5397d936623095c0540aeeed8874b84288) Updated flake inputs
* [`a64ec225`](https://github.com/nix-community/emacs-overlay/commit/a64ec22573752db975a72afdd2e9cd048585d4e3) Updated repos/elpa
* [`ba15aa13`](https://github.com/nix-community/emacs-overlay/commit/ba15aa139862dda17ba8c146d6302034b865f2d0) Updated repos/emacs
* [`ff567ec8`](https://github.com/nix-community/emacs-overlay/commit/ff567ec8110b57bc1df450e8083132991494985a) Updated repos/melpa
* [`81ec6621`](https://github.com/nix-community/emacs-overlay/commit/81ec662160951c188b14318b56ff5a4683234a0e) Updated repos/nongnu
* [`f42cc216`](https://github.com/nix-community/emacs-overlay/commit/f42cc216ad19b81c18657671b8681f1b005804b3) Updated repos/melpa
* [`42608957`](https://github.com/nix-community/emacs-overlay/commit/426089576c9fee91c1049307130ea45219db9017) Add commercial-emacs attribute
* [`529bc705`](https://github.com/nix-community/emacs-overlay/commit/529bc70504f88852421264f6adfcf2f627c4b75d) Updated flake inputs
* [`e9697464`](https://github.com/nix-community/emacs-overlay/commit/e96974648f0927d7b0fd8214fad9d5903d394634) Updated repos/elpa
* [`bc8e79b6`](https://github.com/nix-community/emacs-overlay/commit/bc8e79b656845439ef72346d3bf7333109bedd15) Updated repos/emacs
* [`2c48f3c8`](https://github.com/nix-community/emacs-overlay/commit/2c48f3c8cc381ce8ec207b3ee2c435a8aa594a65) Updated repos/melpa
* [`5554b776`](https://github.com/nix-community/emacs-overlay/commit/5554b77606dd4fe283d8b4a5f5969657d16411b4) Updated repos/elpa
* [`f403a159`](https://github.com/nix-community/emacs-overlay/commit/f403a15947d42eeb5888ce5935cb4c3fdf2f92f0) Updated repos/emacs
* [`4654df7d`](https://github.com/nix-community/emacs-overlay/commit/4654df7d1ca4379989fc0a1e28896d51d345f428) Updated repos/melpa
* [`1d490eef`](https://github.com/nix-community/emacs-overlay/commit/1d490eef2c4fd8e5f151fcaa8c1fcf195f332a3e) Updated repos/emacs
* [`2322e368`](https://github.com/nix-community/emacs-overlay/commit/2322e368874d6805d950dfef62583faa58959752) Updated repos/melpa
* [`5fb607b2`](https://github.com/nix-community/emacs-overlay/commit/5fb607b2ee0c37a9aa0570a53c11405b21883313) Updated repos/nongnu
* [`dc24fd4c`](https://github.com/nix-community/emacs-overlay/commit/dc24fd4cfd2d36d6bc984c99948f46a71ea42ac7) Updated repos/elpa
* [`0b1b05f3`](https://github.com/nix-community/emacs-overlay/commit/0b1b05f33d0eff54471137dc3163334a9d1d6965) Updated repos/emacs
* [`e6568d59`](https://github.com/nix-community/emacs-overlay/commit/e6568d59ffa7ed3aa95d47f1218891c3934693a9) Updated repos/melpa
* [`ca555235`](https://github.com/nix-community/emacs-overlay/commit/ca5552354228a4c10cfdc4aaa7dd22b784ee6dea) Updated repos/melpa
* [`87f01c66`](https://github.com/nix-community/emacs-overlay/commit/87f01c66cdd396c011569573990a893654b28db4) Updated flake inputs
* [`486a4c51`](https://github.com/nix-community/emacs-overlay/commit/486a4c51c483700f5d8fd686d164b9a4f06efe2c) Updated repos/elpa
* [`4acc71cd`](https://github.com/nix-community/emacs-overlay/commit/4acc71cdae77ca29a3b9fe71297e08f3d82ead7e) Updated repos/melpa
