### PR TITLE
niv nixpkgs: update 67c352a9 -> ee5cc384

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "67c352a9379226f786fd25d1eb3c54fa8d131ab4",
-        "sha256": "0hv7wciy26ya2cb2ky9q9cnakly93dxkx9w5hkm78ry4cik4jdnj",
+        "rev": "ee5cc38432031b66e7fe395b14235eeb4b2b0d6e",
+        "sha256": "1081x7bnrq8165q9m6ynlpx3rc01i9m55n0sd16l5a3yqrk4b8n3",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/67c352a9379226f786fd25d1eb3c54fa8d131ab4.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ee5cc38432031b66e7fe395b14235eeb4b2b0d6e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@67c352a9...ee5cc384](https://github.com/nixos/nixpkgs/compare/67c352a9379226f786fd25d1eb3c54fa8d131ab4...ee5cc38432031b66e7fe395b14235eeb4b2b0d6e)

* [`81a8e123`](https://github.com/NixOS/nixpkgs/commit/81a8e123f61716058bdb125e72134636227b70a3) headless: Don't use deprecated vesa.
* [`e2d710b2`](https://github.com/NixOS/nixpkgs/commit/e2d710b2e94c21d509e38ff699806201999fc127) space-cadet-pinball: move makeWrapper to nativeBuildInputs
* [`1a185c0b`](https://github.com/NixOS/nixpkgs/commit/1a185c0b32fc76ad995cb013a4bc87a22595af13) deskew: ensure libtiff can be found at runtime
* [`930b1f47`](https://github.com/NixOS/nixpkgs/commit/930b1f473b505e326843cc1e7d989661364a9921) maintainers: add hacker1024
* [`52e9ddd3`](https://github.com/NixOS/nixpkgs/commit/52e9ddd3457998c0dd6d7c694d303adb0a4f6cad) nixos/gollum: <add option for user and group options>
* [`15a991e5`](https://github.com/NixOS/nixpkgs/commit/15a991e5e4a6082a6db3b3e74f0e7eb32dfaa0f3) brewtarget: 2.3.1 -> 3.0.5
* [`058eeda9`](https://github.com/NixOS/nixpkgs/commit/058eeda945ad8ad3e1022fd8a76cca79c74cf2cf) source-and-tags: deprecate phases
* [`88e81565`](https://github.com/NixOS/nixpkgs/commit/88e81565035fc5be524890bd5a34e02a85b7980e) ffmpeg: remove references to build platform compiler
* [`05885a16`](https://github.com/NixOS/nixpkgs/commit/05885a166b4ee787693d28ce1b7f7c8ccdd79e71) Update nixos/modules/services/misc/gollum.nix
* [`9af54d06`](https://github.com/NixOS/nixpkgs/commit/9af54d06f85f2d47a748f770dd43ea5b3106c70d) lssecret: init at unstable-2022-12-2
* [`593a8d9c`](https://github.com/NixOS/nixpkgs/commit/593a8d9c81021348dd6594ca55e2b0a65998d8e0) lieer: 1.3 -> 1.4
* [`d9fdc4d6`](https://github.com/NixOS/nixpkgs/commit/d9fdc4d6799913f1c4cbb169c7f44c43c927d117) kitty-img: init at 1.0.0
* [`3fecef31`](https://github.com/NixOS/nixpkgs/commit/3fecef31e7da27779c6c33a3e37fc43b2ff2aa3b) fre: init at 0.3.1
* [`baac8018`](https://github.com/NixOS/nixpkgs/commit/baac8018d2cec88837edf80a6d1377db666970d8) graphite-cursors: init at 2021-11-26
* [`e7ef329b`](https://github.com/NixOS/nixpkgs/commit/e7ef329b7bf9d4f8b7302a031a21572ffacd5b1d) csvkit: add setuptools to propagatedBuildInputs
* [`a0e4a519`](https://github.com/NixOS/nixpkgs/commit/a0e4a5194befdd7d3937321b728e78348792a9c0) python310Packages.msgpack: 1.0.4 -> 1.0.5
* [`78fff5c9`](https://github.com/NixOS/nixpkgs/commit/78fff5c9d4f8587dd924c1b674a0d9be161c6c80) python310Packages.msgpack: update changelog entry
* [`42b666a8`](https://github.com/NixOS/nixpkgs/commit/42b666a8377e867213979dc793aad9e27cae883e) python311Packages.appthreat-vulnerability-db: 5.1.1 -> 5.1.3
* [`26775c36`](https://github.com/NixOS/nixpkgs/commit/26775c365901eb099baa798ea0a1e38b6d9d51c9) ocamlformat: 0.24.1 -> 0.25.1
* [`5bd77fec`](https://github.com/NixOS/nixpkgs/commit/5bd77fec8393a791a7bd2db3a0d320b1d7402199) maintainers: add Julow
* [`3833306f`](https://github.com/NixOS/nixpkgs/commit/3833306fc4c166e54062c99796b6bc309a0defef) ocamlformat: add maintainer Julow
* [`be76fb11`](https://github.com/NixOS/nixpkgs/commit/be76fb11c918c9b1b116e1b4ee7a84c0dcc80d28) tlaplus: remove jdk dependency
* [`886fa6e8`](https://github.com/NixOS/nixpkgs/commit/886fa6e8af52f8410590c2aef9d5bbf0a7b7361b) add myself to the maintainers list
* [`ffb5d3d1`](https://github.com/NixOS/nixpkgs/commit/ffb5d3d10595919aa447ee46eb768ef46dfc0058) gnupg: fix tests
* [`e9e9fd28`](https://github.com/NixOS/nixpkgs/commit/e9e9fd2803db35484fc3ed1ff71757bc50c3d9da) kicli: init at 0.0.3
* [`f65f9b21`](https://github.com/NixOS/nixpkgs/commit/f65f9b215ed7d7543474eee1d2bb7baa99a08cd5) pythonPackages.devpi-common: mark as broken
* [`b8ea3f17`](https://github.com/NixOS/nixpkgs/commit/b8ea3f17c8038baca3d377d6c6111f1dd9a8c94b) python311Packages.routeros-api: init at 0.17.0
* [`967d1405`](https://github.com/NixOS/nixpkgs/commit/967d1405ac5695c180ea157bd80f8122660df627) python3Packages.wikipedia: init at 1.4.0
* [`b62f855b`](https://github.com/NixOS/nixpkgs/commit/b62f855b54e916d760b93b3ab893a10db4afdc4a) python3Packages.langchain: enable wikipedia
* [`d11f0362`](https://github.com/NixOS/nixpkgs/commit/d11f03622fa2b673dc3aa24cf43f77d9089cee05) hdf5: 1.14.0 -> 1.14.1-2
* [`00000008`](https://github.com/NixOS/nixpkgs/commit/00000008777eaba4e314cca3460fbcd1739dd559) mediawiki: use stdenvNoCC, remove extra derivation
* [`3f43324c`](https://github.com/NixOS/nixpkgs/commit/3f43324c557297f3caa80e7b7b140a3f5f4c1a74) maintainers: add carlthome
* [`d4e59e7f`](https://github.com/NixOS/nixpkgs/commit/d4e59e7f4a052d17a95f115176a75289de243b6b) python3Packages.mir_eval: init at 0.7
* [`ad7b199d`](https://github.com/NixOS/nixpkgs/commit/ad7b199d5dd9dbe008b926c622e4099e8eca6719) nixos/networkd: Fix typo in BridgeVLAN options
* [`f56cdd0e`](https://github.com/NixOS/nixpkgs/commit/f56cdd0e2b840a983457ac63f798ec4bdd196a9d) nushellPlugins.gstat: init
* [`5ac6839d`](https://github.com/NixOS/nixpkgs/commit/5ac6839d72e66016dd74611022348ea3476b3739) systemd-networkd: add bridge VLANs to DHCP server test
* [`879c2dd5`](https://github.com/NixOS/nixpkgs/commit/879c2dd588d42e6c09bec256a09d262c7abdce9d) nixos/nix-optimise: cleanup, remove with lib
* [`f2ea5c05`](https://github.com/NixOS/nixpkgs/commit/f2ea5c05c14e7c8ea962058f3028c2aca45993cd) nixos/nix-optimise: persist timer
* [`6ed59c84`](https://github.com/NixOS/nixpkgs/commit/6ed59c84208f8e14ee0b020b3b31090b04a3daa3) fmt_10: init at 10.0.0
* [`b005ff48`](https://github.com/NixOS/nixpkgs/commit/b005ff482d839a6ecd7b954be469864304185cda) fmt: add packages as reverse dependencies to passthru.tests
* [`b3b41261`](https://github.com/NixOS/nixpkgs/commit/b3b41261d5d0a4f59eebc92a794c7c1e8257ced2) fmt: add changelog to meta
* [`a04ba8f2`](https://github.com/NixOS/nixpkgs/commit/a04ba8f26ccfbe28bbe064bd73b4f05de628e26b) bear: fix compatiblity with fmt 10.0
* [`c171cc95`](https://github.com/NixOS/nixpkgs/commit/c171cc95be70f6d133bf797330111aae355453c2) fcitx5: fix compatiblity with fmt 10.0
* [`21ab21ac`](https://github.com/NixOS/nixpkgs/commit/21ab21acee0c83abdf2e59a598f6e2ad589b477c) spdlog: fix compatiblity with fmt 10.0
* [`aaf79643`](https://github.com/NixOS/nixpkgs/commit/aaf7964376b406df6cc457e7a1b1366349c06128) spdlog: add packages as reverse dependencies to passthru.tests
* [`a3b6c812`](https://github.com/NixOS/nixpkgs/commit/a3b6c8124afbb51206b1d4764a962c6ec67fac97) mkvtoolnix: fix compatiblity with fmt 10.0
* [`1d3593a6`](https://github.com/NixOS/nixpkgs/commit/1d3593a6d1252b070d8ba28ad3b15e8b80921f9b) clasp-common-lisp: build with fmt 9
* [`b84796f3`](https://github.com/NixOS/nixpkgs/commit/b84796f3eab1ca2d9bffe33b80298fa2cb171f68) fmt: 9.1.0 -> 10.0.0
* [`c7695805`](https://github.com/NixOS/nixpkgs/commit/c7695805ca3f39cf1285e3db2478b315333c023b) nixos/shadow: refactor login.defs config options
* [`00000049`](https://github.com/NixOS/nixpkgs/commit/000000491e310c10468065602a367b71a0e07d5b) maintainers/scripts/check-hydra-by-maintainer: don't check aliases
* [`290820f2`](https://github.com/NixOS/nixpkgs/commit/290820f2fa4c3b936b8f0451edbeb28c4e4401e2) maintainers/scripts/check-hydra-by-maintainer: remove pkgs.lib use
* [`e6e5e634`](https://github.com/NixOS/nixpkgs/commit/e6e5e634c770ec1b64e1906e52c292bc1dc8f1e8) below: Ship systemd service unit
* [`405e1f1e`](https://github.com/NixOS/nixpkgs/commit/405e1f1e54ecdf66e6a00c965e8a561498287b03) nixos/below: Add service module
* [`942f0a01`](https://github.com/NixOS/nixpkgs/commit/942f0a01fe34014763d0a602e2d97b7b92a33e6b) nixos/below: Explicitely mark descriptions as using Markdown
* [`d5151915`](https://github.com/NixOS/nixpkgs/commit/d5151915776a4980c09f483769899d282f23b382) autodock-vina: init at 1.2.3
* [`98939130`](https://github.com/NixOS/nixpkgs/commit/98939130b9f97ad4c2c7d28e36da0ce58c5de4de) rav1e: fix build with updated Darwin stdenv
* [`899eccf6`](https://github.com/NixOS/nixpkgs/commit/899eccf6125312455bd092532a0322a4497c3ead) llvm_{10..13}: backport gcc-13 fixes
* [`3582c352`](https://github.com/NixOS/nixpkgs/commit/3582c352f7aad446efa4f2afac2766045293a9bf) libmcfp: 1.2.3 -> 1.2.4
* [`baebaec1`](https://github.com/NixOS/nixpkgs/commit/baebaec1e8c918eae970b47b52bfec8c901866b1) libmcfp: fix format
* [`9c90277c`](https://github.com/NixOS/nixpkgs/commit/9c90277c080264f596494fa80f86c297150cf9ee) mediawriter: init at 5.0.6
* [`08bbf66c`](https://github.com/NixOS/nixpkgs/commit/08bbf66c31e4c138c881be2188d977dd6c543b06) fusee-nano: init at unstable-2023-05-17
* [`9e7e0fed`](https://github.com/NixOS/nixpkgs/commit/9e7e0fedef6d9639dd80d4856abfbbb1dc25ae4c) imath: 3.1.7 -> 3.1.9
* [`672fe652`](https://github.com/NixOS/nixpkgs/commit/672fe6521a45a8e46f5126e1c85184d189663980) arduinoOTA: init at 1.4.1
* [`dbcd187a`](https://github.com/NixOS/nixpkgs/commit/dbcd187add9ff7a11398f9a58e9ec302eb0fc264) nixos/udev: silence harmless warnings
* [`65b66d88`](https://github.com/NixOS/nixpkgs/commit/65b66d88a71714dbfd88f739d331f7f3a284d304) python311Packages.ruuvitag-ble: 0.1.1 -> 0.1.2
* [`7a3d7bd0`](https://github.com/NixOS/nixpkgs/commit/7a3d7bd067710b4a543b501ca0823aaddd920c35) python311Packages.bluetooth-data-tools: 0.4.0 -> 1.0.0
* [`37d2bd7d`](https://github.com/NixOS/nixpkgs/commit/37d2bd7d4b4a29e9208660de6304be0d25c4ef60) haskellPackages: stackage LTS 20.23 -> LTS 20.24
* [`6fa52faf`](https://github.com/NixOS/nixpkgs/commit/6fa52fafeece733c0eca24ca217e5b627c4479c3) all-cabal-hashes: 2023-05-31T06:44:49Z -> 2023-06-07T04:39:28Z
* [`3620f98a`](https://github.com/NixOS/nixpkgs/commit/3620f98a2a10312d1839f78a38b2b1382184b9ff) haskellPackages: regenerate package set based on current config
* [`42abe23c`](https://github.com/NixOS/nixpkgs/commit/42abe23c135498bef5134547d8ee8f5a8841a0e1) gst_all_1.gst-plugins-bad: add opencvSupport option
* [`fc8620b7`](https://github.com/NixOS/nixpkgs/commit/fc8620b7cf48ccbae1fe2eb45a4d34a21f6ae783) haskellPackages.fft: mark unbroken and dontCheck
* [`8dd6e8fc`](https://github.com/NixOS/nixpkgs/commit/8dd6e8fcfe50627c86307164b54b913a0d629296) haskellPackages.uuagc-cabal: no longer broken
* [`4bc9b75d`](https://github.com/NixOS/nixpkgs/commit/4bc9b75df61c063587399b8c0f3d6bff2e61bec8) cargo-c: 0.9.13 -> 0.9.20
* [`512c48da`](https://github.com/NixOS/nixpkgs/commit/512c48da84e313a8656b576efee3c83f8eafb628) Remove hydraPlatforms clause for uuagc-cabal
* [`2c5704bf`](https://github.com/NixOS/nixpkgs/commit/2c5704bf98d997c5e56b19a9f532a879425aa4e8) haskellPackages.vector: fix test suite with QuickCheck-2.14.3
* [`b0731bdd`](https://github.com/NixOS/nixpkgs/commit/b0731bddaea0f444bccc02d5ca1051c4223681ee) haskellPackages.math-functions: disable test unreliable with QuickCheck-2.13.4
* [`4e15d40d`](https://github.com/NixOS/nixpkgs/commit/4e15d40d2dbc44a9d34e63406a180c1b44f0c971) haskellPackages.aeson: fix test suite for QuickCheck-2.14.3
* [`271e7a9d`](https://github.com/NixOS/nixpkgs/commit/271e7a9d82d09e39ece124c7a6cb94fb78762fc0) haskell.compiler.ghcHEAD: 9.7.20230505 -> 9.7.20230527
* [`9dbcebd1`](https://github.com/NixOS/nixpkgs/commit/9dbcebd15430ba55fc99647319ba34dcfa2fa4fc) haskellPackages.mkDerivation: profiling depends on hostPlatform
* [`f1ad5052`](https://github.com/NixOS/nixpkgs/commit/f1ad5052729c70587ea2d357ba3258c73e5ee3a6) haskell.compiler.ghc961: remove at 9.6.1
* [`615b6cad`](https://github.com/NixOS/nixpkgs/commit/615b6cad641138bc8913d4587f1d77062ae3136c) haskellPackages.hledger*: unify and simplify overrides
* [`7b74e743`](https://github.com/NixOS/nixpkgs/commit/7b74e743f9237db2739758cf120354dc64c22da3) haskellPackages.hledger*: move overrides to configuration-nix.nix
* [`3582fd1e`](https://github.com/NixOS/nixpkgs/commit/3582fd1e3cc8517f8b52e1f248a62a97d6db850b) haskellPackages.hledger*: rely on install(1) and installManPage
* [`3195c953`](https://github.com/NixOS/nixpkgs/commit/3195c9539d0578a9dce6b02ca2b1faa4e9245282) haskellPackages.hledger_1_30_1: install man and info pages
* [`86433eb8`](https://github.com/NixOS/nixpkgs/commit/86433eb8fb8c8e4fbe2b85e9b3d03a641622ea49) haskellPackages.hledger-web_1_30: use matching dependency versions
* [`d5fa9726`](https://github.com/NixOS/nixpkgs/commit/d5fa9726414a185463203d2c7af211cca6a89e40) gnu-efi: fix musl build
* [`a8e31419`](https://github.com/NixOS/nixpkgs/commit/a8e31419dd5e02302c945a39f80407d5147cab9c) python310Packages.pamela: 1.0.0 -> 1.1.0
* [`68b6b4b7`](https://github.com/NixOS/nixpkgs/commit/68b6b4b7f129a76f27f94b3c805cecce92d23f3c) haskellPackages.aeson_2_1_2_1: apply patch for QC-2.14.3
* [`adc82e68`](https://github.com/NixOS/nixpkgs/commit/adc82e6806a9a75ec7c72f7cc30c7f43db2c1fed) haskell.packages.ghc96.ghc-exactprint: 1.7.0.0 -> 1.7.0.1
* [`a4133494`](https://github.com/NixOS/nixpkgs/commit/a4133494813b60488b2c511c55e4dbafdfa20aae) haskell.packages.ghc94.ghc-exactprint: 1.6.1.1 -> 1.6.1.3
* [`33814e22`](https://github.com/NixOS/nixpkgs/commit/33814e224f438a60e9b59abac06b0807b49ff8e4) haskellPackages.statistics: disable test cases broken with QC-2.13.4
* [`17d3aa74`](https://github.com/NixOS/nixpkgs/commit/17d3aa742213ecd3d1a6608eff7a7c01c3fd7eb2) mariadb_104: 10.4.29 -> 10.4.30
* [`04e9ffc0`](https://github.com/NixOS/nixpkgs/commit/04e9ffc0bc4a87da33ec324fe8422e4dfd361e07) mariadb_105: 10.5.20 -> 10.5.21
* [`2278f077`](https://github.com/NixOS/nixpkgs/commit/2278f07723f0d30767a4b27f7afd0ac3ab46a8bf) mariadb_106: 10.6.13 -> 10.6.14
* [`78e4cc18`](https://github.com/NixOS/nixpkgs/commit/78e4cc189e3ac134339d72c1b940ee3d7368c596) mariadb_1010: 10.10.4 -> 10.10.5
* [`ed5a9f05`](https://github.com/NixOS/nixpkgs/commit/ed5a9f057427eda4c393f209431017bddc62a654) mariadb_1011: 10.11.3 -> 10.11.4
* [`7eb8fc54`](https://github.com/NixOS/nixpkgs/commit/7eb8fc54d147bbd6a73fc24662716f4b72be8cdf) apparmor: 3.1.4 -> 3.1.5
* [`f4e2982a`](https://github.com/NixOS/nixpkgs/commit/f4e2982aa74fae31641612a11a1c6e8d33d3d0e7) hwdata: 0.370 -> 0.371
* [`3ed22708`](https://github.com/NixOS/nixpkgs/commit/3ed22708d0c54e646d4990ca76a24977013766a0) fetchfirefoxaddon: formatting
* [`2e02abd7`](https://github.com/NixOS/nixpkgs/commit/2e02abd798f741887ab4e5983c29e1c22f754c9b) fetchfirefoxaddon: make reproducible
* [`54d8532f`](https://github.com/NixOS/nixpkgs/commit/54d8532f40d7ccd47c3ace56ba0fda4276778fc1) bisq-desktop: formatting
* [`d634a624`](https://github.com/NixOS/nixpkgs/commit/d634a6244fa5d9ce035bcd6fc7604f1b062a81be) bisq-desktop: make reproducible
* [`90427d23`](https://github.com/NixOS/nixpkgs/commit/90427d2381a5293ca377be7306c5e3cecb69a255) pcsx2: formatting
* [`199cc23a`](https://github.com/NixOS/nixpkgs/commit/199cc23afee9a574a440ae4916f4112baac61234) pcsx2: make reproducible
* [`2db2887d`](https://github.com/NixOS/nixpkgs/commit/2db2887d2fc6205fe9a66a49b46b05fd059e44d9) slimmerjs: formatting
* [`013dde92`](https://github.com/NixOS/nixpkgs/commit/013dde9275cde07ae9d6993c11372606004c98db) slimmerjs: make reproducible
* [`bf818c85`](https://github.com/NixOS/nixpkgs/commit/bf818c857f12d97570fe11e48de55a28ec434cf3) mari0: formatting
* [`aea09ca7`](https://github.com/NixOS/nixpkgs/commit/aea09ca7070ba1339c021cd55f3c743d4731af65) mari0: make reproducible
* [`c0a48fca`](https://github.com/NixOS/nixpkgs/commit/c0a48fcaf5f2fee3ecc1d4512210c868543c6de3) orthorobot: formatting
* [`a7b2dbf4`](https://github.com/NixOS/nixpkgs/commit/a7b2dbf48d537997ccfe64fe5786c5c4338a4b29) orthorobot: make reproducible
* [`34e6a8b4`](https://github.com/NixOS/nixpkgs/commit/34e6a8b4a1d7f7dddd7f6faf9727da59de526acb) wireworld: formatting
* [`059f9dc3`](https://github.com/NixOS/nixpkgs/commit/059f9dc3c0f654f53779f0d4364911a31c216286) wireworld: make reproducible
* [`24eb37f2`](https://github.com/NixOS/nixpkgs/commit/24eb37f2a8d3514ad840eaff99e4dc4ca5baf876) pridefetch: formatting
* [`b06a89a0`](https://github.com/NixOS/nixpkgs/commit/b06a89a01ccf2ef8175e24b1ea58f33d7d594176) pridefetch: make reproducible
* [`8766168f`](https://github.com/NixOS/nixpkgs/commit/8766168f361300aa48ae7468293b111806feb2cb) haskellPackages.threadscope: Fix build
* [`21674281`](https://github.com/NixOS/nixpkgs/commit/21674281ace70505b82812c1d0f15c79ef9d928e) haskellPackages.threadscope: enable separate bin output
* [`054ef603`](https://github.com/NixOS/nixpkgs/commit/054ef603cc67c82b2586b14dbf1504fa683a5387) haskellPackages.threadscope: add maintainer
* [`9adb2102`](https://github.com/NixOS/nixpkgs/commit/9adb210298b00f2169f224a90fe7657f1020e12b) libgdiplus: 6.0.5 -> 6.1
* [`f93429eb`](https://github.com/NixOS/nixpkgs/commit/f93429ebe8d013c1757a68675197799bfc1a1917) haskellPackages.halide-haskell: native dependency on Halide
* [`69cd4fe5`](https://github.com/NixOS/nixpkgs/commit/69cd4fe5ea8384397f205a940e79ae2620843322) xterm: 380 -> 382
* [`034d6139`](https://github.com/NixOS/nixpkgs/commit/034d613977ef2e471d3a204e827a4d40458ddfd7) haskellPackages.active: fix test issue revealed by QC-2.14.3
* [`bed41135`](https://github.com/NixOS/nixpkgs/commit/bed41135a0ba7244df3226d0da528a09dd79f86a) nvfetcher: fix dependencies
* [`3d4769a9`](https://github.com/NixOS/nixpkgs/commit/3d4769a9e86a51117973281d8ab4328713c4c180) mupdf: actually build and install the shared libraries version
* [`28fe4eec`](https://github.com/NixOS/nixpkgs/commit/28fe4eec0fc391a6286fec45cdb11655824e1ab3) apple_sdk_11_0.stdenv: replace extraBuildInputs with CF from 11.0 SDK
* [`fc3668a3`](https://github.com/NixOS/nixpkgs/commit/fc3668a3ab9fe6d2f67a041f1d7f7bd955636b06) haskellPackages: Use separate bin output for multiple packages
* [`40fbc979`](https://github.com/NixOS/nixpkgs/commit/40fbc979883a11c91138a4ef45f0eeeddd4a9637) makeWrapper: fix flag handling
* [`458be187`](https://github.com/NixOS/nixpkgs/commit/458be187f2e896d911d2a7206fb866b9045bf8fb) python311Packages.vivisect: 1.1.0 -> 1.1.1
* [`f9854843`](https://github.com/NixOS/nixpkgs/commit/f98548431e788124b382ce9c88bb1ecb8f839ebb) python311Packages.funcy: 1.18 -> 2.0
* [`bdba17db`](https://github.com/NixOS/nixpkgs/commit/bdba17db08b2bb32306acc07df4034271ba67479) python311Packages.viv-utils: 0.7.7 -> 0.7.9
* [`497562f7`](https://github.com/NixOS/nixpkgs/commit/497562f7d7c427001268ceced5b1da42a1b3ee2a) python311Packages.funcy: add changelog to meta
* [`0ff0ba12`](https://github.com/NixOS/nixpkgs/commit/0ff0ba125cecf7e60246b82e021a084742f47069) libclc: fix .pc paths
* [`4d649f2b`](https://github.com/NixOS/nixpkgs/commit/4d649f2b63d6ab5be258cbdc60998ed3a80d98b5) glibc: split getent into its own output
* [`2c149715`](https://github.com/NixOS/nixpkgs/commit/2c149715fe2cb456c03d6495c474e8db306682cb) darwin.xnu: provide additional headers needed by Libsystem
* [`a48c2d3e`](https://github.com/NixOS/nixpkgs/commit/a48c2d3e9225d779ae2ba46bb73c1f81ca9246e8) darwin.libmalloc: add at 116.50.8
* [`81324e2e`](https://github.com/NixOS/nixpkgs/commit/81324e2ec3fba15669f8decb18257a9360bd44c7) darwin.libmalloc: add at 317.40.8 for the 11.0 SDK
* [`489ed847`](https://github.com/NixOS/nixpkgs/commit/489ed84733d9cf19c72c879c5a0f5b55f4fb7348) darwin.Libsystem: get malloc.h from darwin.libmalloc
* [`d2b67029`](https://github.com/NixOS/nixpkgs/commit/d2b670291fafe771501effe1e4917d92440bf390) darwin.Libsystem: get asl.h from upstream syslog sources
* [`a255182f`](https://github.com/NixOS/nixpkgs/commit/a255182f567abd87acc59206780627bccab0d10d) darwin.Libsystem: get pthread headers from darwin.libpthread
* [`b5738a87`](https://github.com/NixOS/nixpkgs/commit/b5738a87bd5392c3b9931d375f79170643c6c9f7) bundler: 2.4.13 -> 2.4.14
* [`75c15fb0`](https://github.com/NixOS/nixpkgs/commit/75c15fb009c2b657d55e2bdb79c6ddd8dc3291c1) ruby: rubygems 3.4.13 -> 3.4.14
* [`23cb6c15`](https://github.com/NixOS/nixpkgs/commit/23cb6c155b89b060eb2004cd0e1951a4097a81fe) darwin.Libc: stop vendoring headers from other packages
* [`224a9488`](https://github.com/NixOS/nixpkgs/commit/224a94882a57c4d5410d017d3de3884e6e889c88) python3Packages.pydantic: fix doctests race
* [`9c28d657`](https://github.com/NixOS/nixpkgs/commit/9c28d657554cfef4adef1d4ac7de681b4f04265d) gtk2: refactor
* [`9503e48c`](https://github.com/NixOS/nixpkgs/commit/9503e48c7066bec7ef2387f21c7b458a951c0c7a) python310Packages.hatch-fancy-pypi-readme: 22.8.0 -> 23.1.0
* [`c0b14e81`](https://github.com/NixOS/nixpkgs/commit/c0b14e815ab6ba76b4720695af30f6054460bb55) python310.pkgs.f5-icontrol-rest: init at 1.3.15
* [`83cbbfd0`](https://github.com/NixOS/nixpkgs/commit/83cbbfd0fb619f204be744865a0e0ce38ab21aa2) python310.pkgs.f5-sdk: init at 3.0.21
* [`156daca0`](https://github.com/NixOS/nixpkgs/commit/156daca04b87d8089042a6efcb7294659c5b0e90) python310.pkgs.netapp-lib: init at 2021.6.25
* [`fab29d17`](https://github.com/NixOS/nixpkgs/commit/fab29d1717927b6cccb718f5fc29424f0e1c880e) python310.pkgs.cliche: init at 0.10.108
* [`fde17beb`](https://github.com/NixOS/nixpkgs/commit/fde17beb21ef54497eda04327f5cfd8ca4fa87c3) python310.pkgs.recline: init at 2023.5
* [`3d5e359d`](https://github.com/NixOS/nixpkgs/commit/3d5e359d4e967f83d706c12f6990375af5aeb957) python310.pkgs.netapp-ontap: init at 9.12.1.0
* [`e8d0aa9d`](https://github.com/NixOS/nixpkgs/commit/e8d0aa9d19014bb74a75071e70b7175e9bf58722) Revert "gcc: install info files serially"
* [`f6a7658c`](https://github.com/NixOS/nixpkgs/commit/f6a7658c518cf6d2611a9e34b6a53b38d9ec52e8) gcc: disable parallelism when installing
* [`676bcc14`](https://github.com/NixOS/nixpkgs/commit/676bcc14c79f2c14cd018527d804024375e49b45) ayatana-ido: 0.9.2 -> 0.10.0
* [`d1ebfd2c`](https://github.com/NixOS/nixpkgs/commit/d1ebfd2c70e9c261d1251676ad62b7e6136bc5be) adoptopenjdk: 8.0.322+6 → 8.0.372+7, 11.0.16+101 → 11.0.19+7, 17.0.4+101 → 17.0.7+7
* [`1997c731`](https://github.com/NixOS/nixpkgs/commit/1997c731f1e5a0057fa2e9a1c846cc0d572a5919) openjdk11: 11.0.18+10 → 11.0.19+7
* [`b8ad87be`](https://github.com/NixOS/nixpkgs/commit/b8ad87becf89bf83a0f5957b7834073f5319530e) openjdk17: 17.0.6+10 → 17.0.7+7
* [`d106eaeb`](https://github.com/NixOS/nixpkgs/commit/d106eaeb837d2892fbf2afc9deb62ad864916fd9) jetbrains.jdk: 17.0.6-b829.9 → 17.0.7-b829.16
* [`5a907fd1`](https://github.com/NixOS/nixpkgs/commit/5a907fd122e2d7af0ea952e4f3b326a07af4730d) dhcpcd: Fetch source from GitHub
* [`5dc750a9`](https://github.com/NixOS/nixpkgs/commit/5dc750a92b4cfb4186180c0b83e603a44ac432cf) openresolv: Fetch source from GitHub
* [`6c0f4e3b`](https://github.com/NixOS/nixpkgs/commit/6c0f4e3b106109cb395d4f89dcca22eff9f0daf0) mirrors: Remove `roy`
* [`1ff65093`](https://github.com/NixOS/nixpkgs/commit/1ff6509383f4c74976b1d78702a1c8190aa5669a) cups: 2.4.3 -> 2.4.5
* [`ac06f870`](https://github.com/NixOS/nixpkgs/commit/ac06f8709fd5e60947c5a619cbbde1d1916d8c68) haskellPackages.sydtest: Unbreak by disabling test suite.
* [`7dc64e9b`](https://github.com/NixOS/nixpkgs/commit/7dc64e9b5afa8ae800e1b45a2a656f73bc2d9bec) python3Packages.mmtf-python: init at 1.1.3
* [`be04cbeb`](https://github.com/NixOS/nixpkgs/commit/be04cbebe13032e527737f3f6d978a70cc67b3b9) python3Packages.biopandas: init at 0.4.1
* [`427fd4ea`](https://github.com/NixOS/nixpkgs/commit/427fd4ea15b5d392ecee3dee8c805edc9165a596) python310Packages.respx: patch to support httpx 0.24
* [`b1600b56`](https://github.com/NixOS/nixpkgs/commit/b1600b56721473fb1f779ff49311afa7a8d498e2) ghcWithPackages: handle the boot dylib links separately for GHC 9.6
* [`77504c6a`](https://github.com/NixOS/nixpkgs/commit/77504c6a1e05a5434e7c831bae405e89acae4edf) ghcWithPackages: Fix a sed bug in patching package conf file
* [`be48010e`](https://github.com/NixOS/nixpkgs/commit/be48010eb2591e452b3f848c12c7a1ba2426890e) nixos/networkd: make overriding boot.initrd.systemd.package a little easier by using mkDefault
* [`90658842`](https://github.com/NixOS/nixpkgs/commit/9065884299b6ab835f72198c85a3d7ffb4a58407) qt5.qtbase: fix build with Darwin sandbox enabled
* [`d014e56d`](https://github.com/NixOS/nixpkgs/commit/d014e56db45098706d770f402abde2c66cfe0b07) qtpass: fix build with Darwin sandbox enabled
* [`71fc5f53`](https://github.com/NixOS/nixpkgs/commit/71fc5f5363c09b08d57be79dc9740c64e81cb2c5) qtkeychain: fix build with Darwin sandbox enabled
* [`64ac9d57`](https://github.com/NixOS/nixpkgs/commit/64ac9d57b4a31971d58b32861a42842d03831ac4) networkminer: init at 2.8
* [`051fe7c2`](https://github.com/NixOS/nixpkgs/commit/051fe7c2227563698ffff9844ea3229dd87d7dad) python3Packages.pkgutil-resolve-name: init at 1.3.10
* [`0f574794`](https://github.com/NixOS/nixpkgs/commit/0f574794a21a050a1d0ec28bc75663e569f7b7ff) python38Packages.jsonschema: depend on pkgutil-resolve-name
* [`9a550b13`](https://github.com/NixOS/nixpkgs/commit/9a550b1364b4a662749d6f6a52df0b9395fda9c8) haskellPackages: drop util-linux on darwin
* [`a2b597dd`](https://github.com/NixOS/nixpkgs/commit/a2b597dd56a270c4717d3e80c5218c7e2a8f9085) audiobookshelf: 2.2.20 -> 2.2.23
* [`352629f9`](https://github.com/NixOS/nixpkgs/commit/352629f949d1b699a9f40b7b928326839980b921) libjxl: 0.8.1 -> 0.8.2
* [`368aa725`](https://github.com/NixOS/nixpkgs/commit/368aa725c073a03c2c8999c372c4d1108f19b357) liburing: 2.3 -> 2.4
* [`da849d9c`](https://github.com/NixOS/nixpkgs/commit/da849d9c11a33b3bb85186a07453d4c977fe0d28) liburing: properly set configureFlags
* [`769c9c84`](https://github.com/NixOS/nixpkgs/commit/769c9c843c60d0250a5b4a0f712c4729cbe224e0) liburing: add nickcao to maintainers
* [`db230657`](https://github.com/NixOS/nixpkgs/commit/db230657fce0f8cf0c5bbee490bbef3dc84ab8dc) nixos/pixelfed: cleanup package cache at the very start
* [`cc22c861`](https://github.com/NixOS/nixpkgs/commit/cc22c861e805952b75941d467d826a70a7063a80) glibc: allow users of glibc/common.nix to override makeFlags
* [`b243596e`](https://github.com/NixOS/nixpkgs/commit/b243596eb72f12d5280447b9b817b9aa6f8e9f43) glibcLocales: use more than one core to build
* [`3b8e3c1f`](https://github.com/NixOS/nixpkgs/commit/3b8e3c1f3de24472dd6dbd1fcdb3912a067bd70c) stdenv: updateAutotoolsGnuConfigScriptsHook unconditionally
* [`238b7933`](https://github.com/NixOS/nixpkgs/commit/238b793373ab07e40a70cc0834c30c28859a8720) glibc: allow users of glibc/common.nix to override makeFlags
* [`7306386e`](https://github.com/NixOS/nixpkgs/commit/7306386eb35c9fbeb288d91b855e1267606ece27) glibcInfo: use makeFlags instead of buildPhase
* [`f8eadce2`](https://github.com/NixOS/nixpkgs/commit/f8eadce2780e6503e9bfd17f4e784f4dacb0cefd) licenses: add Fair Source License v0.9
* [`e4770e34`](https://github.com/NixOS/nixpkgs/commit/e4770e34b20cb75e262e80651e43ba67b3478c71) maturin: 1.0.1 -> 1.1.0
* [`d95b8c39`](https://github.com/NixOS/nixpkgs/commit/d95b8c39c8f066a401cf327de24f4af9f5604599) python310Packages.pydantic: 1.10.8 -> 1.10.9
* [`19e1801b`](https://github.com/NixOS/nixpkgs/commit/19e1801b37fc8566600059ca517570fd1a6d8129) softnet: init at 0.7.1
* [`f6850950`](https://github.com/NixOS/nixpkgs/commit/f6850950419a5ad478dd1922d7f6719a0d21f92e) python311Packages.sensor-state-data: 2.15.1 -> 2.16.0
* [`69eb2410`](https://github.com/NixOS/nixpkgs/commit/69eb241041bff98c5ff32184cffb8a58d07edbe6) python311Packages.bluetooth-data-tools: 1.0.0 -> 1.2.0
* [`b9c1ae2a`](https://github.com/NixOS/nixpkgs/commit/b9c1ae2a5f4662b9d96de881e4bab118d66dbd45) stdenv: eliminate duplicate gnu-config in extraNativeBuildInputs
* [`960a5142`](https://github.com/NixOS/nixpkgs/commit/960a5142aa812a2df307a6fab65b25ad698e13b5) nixos/gnupg: add systemd configuration
* [`51fd0092`](https://github.com/NixOS/nixpkgs/commit/51fd00925fe9b068070616a1ec119de297fc1171) gnupg: fix test attribute key
* [`8ea64499`](https://github.com/NixOS/nixpkgs/commit/8ea644997f7d92cac129ddbfab14b33997038dae) nixos/gpg-agent: move pinentry-program to /etc/gnupg/gpg-agent.conf
* [`38e58154`](https://github.com/NixOS/nixpkgs/commit/38e58154222a40774bbd3170c92546deccc364ae) odin: 0.13.0 -> dev-2023-05
* [`8f1b807d`](https://github.com/NixOS/nixpkgs/commit/8f1b807d71db7ece24455da35a6370b82276eba8) xorg.libX11: 1.8.4 → 1.8.6
* [`6fd39f36`](https://github.com/NixOS/nixpkgs/commit/6fd39f3661dfcdb0021de859b6377b0d8afce138) libopus: enable intrinsics only on supported platforms
* [`2dce714d`](https://github.com/NixOS/nixpkgs/commit/2dce714dff4c30c5fce406668793da74484260eb) python3.pkgs.invoke: install shell completions
* [`cfe665eb`](https://github.com/NixOS/nixpkgs/commit/cfe665eb266ee4728a70d4e13a540ecebd5948de) ispc: fix darwin
* [`b229e763`](https://github.com/NixOS/nixpkgs/commit/b229e76363274046ca1fe609a42a96e96ae3011f) tart: init at 1.6.0
* [`42bbff54`](https://github.com/NixOS/nixpkgs/commit/42bbff54242095d30ceed6cef23f53a66bf769d8) mruby: refactor
* [`8fe6cc35`](https://github.com/NixOS/nixpkgs/commit/8fe6cc3541ad3cd667bd3e9a0ddece359b894b5d) mruby: add marsam to maintainers
* [`b8c2f833`](https://github.com/NixOS/nixpkgs/commit/b8c2f83395b63e2db36be78215e462485d565377) pixelfed: add update script
* [`0b8f6f86`](https://github.com/NixOS/nixpkgs/commit/0b8f6f86d33e0647baa6be9a613186ccdf822c8b) rust-bindgen-unwrapped: 0.65.1 -> 0.66.0
* [`7bab4a93`](https://github.com/NixOS/nixpkgs/commit/7bab4a9310cbb07f1088ab6fbd1791056ef0d4a0) rpcsvc-proto: 1.4.3 -> 1.4.4
* [`8dc46af8`](https://github.com/NixOS/nixpkgs/commit/8dc46af8e38cba60e125fdd16772ee57cbb0b5f9) pixelfed: fix hash format in update script
* [`89e4a7dc`](https://github.com/NixOS/nixpkgs/commit/89e4a7dce65358cc1fb73d200ba1892251fabd00) pixelfed: 0.11.5 -> 0.11.8
* [`d99dd867`](https://github.com/NixOS/nixpkgs/commit/d99dd867fb4671d7527170d2c5311e6d8cf8eb88) nixos/pixelfed: fix code cache cleanup
* [`9b95a518`](https://github.com/NixOS/nixpkgs/commit/9b95a51835d0de55bc0af2e0dfe4fac2c34167bd) icu: 73.1 -> 73.2
* [`005cfc8b`](https://github.com/NixOS/nixpkgs/commit/005cfc8b0cea9cef36a8d129c3b06e0a98a918da) minimal-bootstrap: create top-level attr for bootstrap sources
* [`806a0022`](https://github.com/NixOS/nixpkgs/commit/806a00221597ef48bc3cc52e28a89c7fc7406c94) pixelfed: remove outdated dist note
* [`af620cbd`](https://github.com/NixOS/nixpkgs/commit/af620cbd40f3b16d1eb02c650589fede29abb1f2) libopenmpt: 0.7.1 -> 0.7.2
* [`f68295e5`](https://github.com/NixOS/nixpkgs/commit/f68295e52ef3af4e2cab1a92ce32e6644271d96d) mmlgui: unstable-2023-03-19 -> unstable-2023-06-12, fix cross
* [`251c5570`](https://github.com/NixOS/nixpkgs/commit/251c55700d3ef977506c3f664888780f707f4a55) llvmPackages_16: 16.0.1 -> 16.0.6
* [`1850284e`](https://github.com/NixOS/nixpkgs/commit/1850284e03b0b696005528e93f571d29ab5c0aef) binaryen: 112 -> 113
* [`0761348e`](https://github.com/NixOS/nixpkgs/commit/0761348e91e81b75d016e2733d41ebaa618bd899) emscripten: 3.1.24 -> 3.1.41
* [`ab4146f9`](https://github.com/NixOS/nixpkgs/commit/ab4146f9332da846eefa982b0020e76b2f98937d) cryptsetup: re-encrypt is a default extension now
* [`df215cfa`](https://github.com/NixOS/nixpkgs/commit/df215cfa9a2207be6d1ca404c0a78c3c7799aaf6) cryptsetup: compile against libargon2 by default
* [`11eb7901`](https://github.com/NixOS/nixpkgs/commit/11eb7901ae949e8692189eec5e677cfa500f7a2f) cryptsetup: add raitobezarius as a maintainer
* [`b8ac5b6c`](https://github.com/NixOS/nixpkgs/commit/b8ac5b6cfbc7925cad057214b994ffa65afa392e) cmake: 3.25.3 -> 3.26.4
* [`acf25727`](https://github.com/NixOS/nixpkgs/commit/acf257276d958a1507513f48bbd0c7c2a9e7b1ae) python3Packages.pkgutil-resolve-name: disable unexisting checks
* [`f3dde5bf`](https://github.com/NixOS/nixpkgs/commit/f3dde5bf8cbdcacce4d5272d5ad8209cc3757412) semgrep{,-core}: 1.15.0 -> 1.27.0
* [`130cc085`](https://github.com/NixOS/nixpkgs/commit/130cc08506d89ab743d7a22b32dd9a916386a0d4) maintainers: add tengkuizdihar
* [`6666666b`](https://github.com/NixOS/nixpkgs/commit/6666666b971820f26b613f4ae099fe1973d3d889) python311Packages.sqlalchemy-migrate: fix build
* [`6c153eff`](https://github.com/NixOS/nixpkgs/commit/6c153effc67f102ddf6f22ccf1748f4bd21fc3f5) xivlauncher: 1.0.3->1.0.4
* [`9420326d`](https://github.com/NixOS/nixpkgs/commit/9420326db0b7c04a4047610dace77d9d3c140fed) crunchy-cli: init at 3.0.0-dev.10
* [`96299edd`](https://github.com/NixOS/nixpkgs/commit/96299edd4cac0d5e8d7b653346cd53f683f47a8b) contributing: Explain how to run common tests
* [`967beb21`](https://github.com/NixOS/nixpkgs/commit/967beb212faa67b32218b112f85d959ccba13bc3) revolt-desktop: Use Ozone if NIXOS_OZONE_WL set
* [`a6fd470c`](https://github.com/NixOS/nixpkgs/commit/a6fd470ca7b654ea1b0f19bd57267c0451d17c5a) all-cabal-hashes: 2023-06-07T04:39:28Z -> 2023-06-19T20:13:38Z
* [`404d4194`](https://github.com/NixOS/nixpkgs/commit/404d419499bc42e5163618fcfadcf42262970733) haskellPackages: regenerate package set based on current config
* [`89c3ad66`](https://github.com/NixOS/nixpkgs/commit/89c3ad6656b902485c16d1aac3972dcfa5766b17) haskellPackages: stackage LTS 20.24 -> LTS 20.26
* [`4d4f5e2d`](https://github.com/NixOS/nixpkgs/commit/4d4f5e2db1f46114563eeaaf58d51316f31e671c) glibcLocales: enable parallel building
* [`e6714f38`](https://github.com/NixOS/nixpkgs/commit/e6714f38f7bff0110ba6b94c7d59dcf0d7c0774a) meson: 1.1.0 -> 1.1.1
* [`f5d83840`](https://github.com/NixOS/nixpkgs/commit/f5d83840943fb336a89d220e104045d7771df68e) rustPlatform.cargoBuildHook: don't let cargo strip
* [`dd4be848`](https://github.com/NixOS/nixpkgs/commit/dd4be8486a9d2deea0d734deb17135fdae7b018f) haskellPackages.fourmolu_0_13_0_0: Bump pin
* [`51c15f3b`](https://github.com/NixOS/nixpkgs/commit/51c15f3b4a0d53bffc2873951e7149731ab3db9f) haskellPackages: regenerate package set based on current config
* [`3780de2d`](https://github.com/NixOS/nixpkgs/commit/3780de2d515bae803de26545cf5891c211a9846b) haskellPackages: Restrict halide packages to linux
* [`d045cfa3`](https://github.com/NixOS/nixpkgs/commit/d045cfa32ac280f91faa1adadd31e1c164744c78) caeml: init at unstable-2023-05-24
* [`bb9ec832`](https://github.com/NixOS/nixpkgs/commit/bb9ec832fe93f64fd7c17213c6a9f8c7ca95f3ff) python3Packages.pygbm: remove
* [`6514705e`](https://github.com/NixOS/nixpkgs/commit/6514705ef6c8bd49fb94631590cff3caa2d3e71f) crystalline: init at 0.9.0
* [`85f32144`](https://github.com/NixOS/nixpkgs/commit/85f32144876d3bf47725243d738b43e6efcecf8d) maintainers: add donovanglover
* [`0e1992f5`](https://github.com/NixOS/nixpkgs/commit/0e1992f5e1985a96d88878b7b86885c237cdcf2e) ast-grep: 0.5.2 -> 0.6.6
* [`002b6f84`](https://github.com/NixOS/nixpkgs/commit/002b6f84a6ccdce80e013d3d8e0f27926ae574af) systemd: fix services not stopping
* [`1d6e72dd`](https://github.com/NixOS/nixpkgs/commit/1d6e72dd7b27cd7194a98c071579505aa8a2e1af) chromiumBeta: 115.0.5790.24 -> 115.0.5790.32
* [`f2affe59`](https://github.com/NixOS/nixpkgs/commit/f2affe590b11f744f8aae1063b04d8cffd60becd) chromiumDev: 116.0.5817.0 -> 116.0.5829.0
* [`cc3a3c40`](https://github.com/NixOS/nixpkgs/commit/cc3a3c40a2cc2eadb1c55ea44260817090f12cb3) nixos/tests/qemu-vm-volatile-root: init
* [`6571dd99`](https://github.com/NixOS/nixpkgs/commit/6571dd991284694f5b29e07f64c040b58404128e) deepin.dde-device-formatter: unstable-2022-09-05 -> 0.0.1.15
* [`08a31d7a`](https://github.com/NixOS/nixpkgs/commit/08a31d7ab80092a38aa15ed2b37f546148a329a7) fastJson: cleanup, use autoreconfHook
* [`558af1d8`](https://github.com/NixOS/nixpkgs/commit/558af1d8a580573309771fa42274723db6da4a1d) klee: 2.3 -> 3.0
* [`4540dccd`](https://github.com/NixOS/nixpkgs/commit/4540dccd9b1746a08efee1b2bf7741a96fbaab18) maintainers: add twesterhout
* [`d474fb31`](https://github.com/NixOS/nixpkgs/commit/d474fb31b69c75153a55b25de76ef7d3c1ba3332) halide: remove mesa dependency on darwin
* [`adf84c34`](https://github.com/NixOS/nixpkgs/commit/adf84c345f4b7afe9001265db94d0b0ba7ba924e) python310Packages.wxPython_4_2: 4.2.0 -> 4.2.1
* [`f468c07e`](https://github.com/NixOS/nixpkgs/commit/f468c07e5f3656a5e545c84a3908f17533404d85) codeql: fix passing in nix JDK
* [`2983baa4`](https://github.com/NixOS/nixpkgs/commit/2983baa4e7b742bee16b41632d65109340261550) zlib-ng: 2.0.7 -> 2.1.2
* [`0fe7fee6`](https://github.com/NixOS/nixpkgs/commit/0fe7fee623de691acff1db0178de01e39a22319d) minizip-ng: 3.0.10 -> 4.0.0
* [`dcb997cf`](https://github.com/NixOS/nixpkgs/commit/dcb997cfa7ab86a27ad6ce402a4308613ff486e4) svt-av1: 1.5.0 -> 1.6.0
* [`c0ce5cfa`](https://github.com/NixOS/nixpkgs/commit/c0ce5cfac0593987aaedc78fd88ef059be157881) electrum-grs 4.3.1 -> 4.4.4
* [`4f488c66`](https://github.com/NixOS/nixpkgs/commit/4f488c66843735f275c8c135dface1402b7b3d51) ayatana-webmail: init at 22.12.15
* [`35e76337`](https://github.com/NixOS/nixpkgs/commit/35e763373dfb50171d2c74c1b009364274c3e5f4) haskellPackages.active: drop now released patch
* [`d7f7d694`](https://github.com/NixOS/nixpkgs/commit/d7f7d6944fc5e644367663e9e00f1ee39885d6f7) gst_all_1.gstreamer: 1.22.3 -> 1.22.4
* [`5d991712`](https://github.com/NixOS/nixpkgs/commit/5d9917129b898b18e33b49ffb0cb7913451c4b4e) gst_all_1.gst-plugins-base: 1.22.3 -> 1.22.4
* [`d1fe0fbf`](https://github.com/NixOS/nixpkgs/commit/d1fe0fbfde04ac181185a88d0ea8f53788b46503) gst_all_1.gst-plugins-good: 1.22.3 -> 1.22.4
* [`e13ccc02`](https://github.com/NixOS/nixpkgs/commit/e13ccc027af864ba389944444f378431278a2c7b) gst_all_1.gst-plugins-bad: 1.22.3 -> 1.22.4
* [`0d837978`](https://github.com/NixOS/nixpkgs/commit/0d837978578da7329c41c5bdd2051ac0ddfc6ae3) gst_all_1.gst-plugins-ugly: 1.22.3 -> 1.22.4
* [`83ee43f1`](https://github.com/NixOS/nixpkgs/commit/83ee43f14ac3b5c787de30493147ad7b59bb9971) gst_all_1.gst-libav: 1.22.3 -> 1.22.4
* [`86a93027`](https://github.com/NixOS/nixpkgs/commit/86a9302763763c20b9a74ce0478dbdd4bdf82154) gst_all_1.gst-vaapi: 1.22.3 -> 1.22.4
* [`e1f34891`](https://github.com/NixOS/nixpkgs/commit/e1f3489145d380cb6abc954af196b6ef00fe4a44) gst_all_1.gst-rtsp-server: 1.22.3 -> 1.22.4
* [`a9e9eecc`](https://github.com/NixOS/nixpkgs/commit/a9e9eecce735ce713fd21e8bc452c4f84c7203f9) gst_all_1.gst-devtools: 1.22.3 -> 1.22.4
* [`1315ca3a`](https://github.com/NixOS/nixpkgs/commit/1315ca3a292d09dfe256714ba1799ec529b701c5) gst_all_1.gst-editing-services: 1.22.3 -> 1.22.4
* [`3c755e6e`](https://github.com/NixOS/nixpkgs/commit/3c755e6e5ccadb11fbc4050d7f3b25aacc2153eb) python3Packages.gst-python: 1.22.3 -> 1.22.4
* [`388f53c7`](https://github.com/NixOS/nixpkgs/commit/388f53c71719785e0357a08222b78cb882df6aaf) wasm-pack: 0.11.1 -> 0.12.0
* [`7c98b979`](https://github.com/NixOS/nixpkgs/commit/7c98b979343d1204b03e423169dad10676a8b369) bitwarden: 2023.5.0 -> 2023.5.1
* [`fd8e2ca0`](https://github.com/NixOS/nixpkgs/commit/fd8e2ca0df35ddb67ad07f18cd570293ae0344b7) stdenv: fix makeStaticDarwin not composing with stdenvNoCC
* [`e1b4124f`](https://github.com/NixOS/nixpkgs/commit/e1b4124f0a5b3eba6daa864a68826c019232f7e6) boost: fix cross compilation for darwin hosts
* [`f97423f8`](https://github.com/NixOS/nixpkgs/commit/f97423f87d6d9d20955b09018aaa7c39a80ef870) nixStatic: backport fix for aarch64-darwin
* [`42b5817e`](https://github.com/NixOS/nixpkgs/commit/42b5817e6b94974614cc9d0f803c14551274d6c5) pkgsStatic: add support for non-linux host platforms
* [`220877ab`](https://github.com/NixOS/nixpkgs/commit/220877abfe6c44f3a41ec1012ff9058206e9dba0) qpwgraph: 0.4.2 -> 0.4.4
* [`5d00e7ae`](https://github.com/NixOS/nixpkgs/commit/5d00e7aee56622a3961b105b09341e6102f0bb58) indilib: unbreak on x86_64-darwin
* [`ba1ed02a`](https://github.com/NixOS/nixpkgs/commit/ba1ed02af7347e73a4f06c471b193160fb1e72e1) mswatch: init at unstable-2018-11-21
* [`3221b01f`](https://github.com/NixOS/nixpkgs/commit/3221b01f736b8e89f91bc1c352b5ce6877425c45) python310Packages.asyncssh: 2.13.1 -> 2.13.2
* [`ecef9a79`](https://github.com/NixOS/nixpkgs/commit/ecef9a792c1bb8a663c1397316071434df4b797b) sdl2: 2.26.5 -> 2.28.0
* [`6701ee50`](https://github.com/NixOS/nixpkgs/commit/6701ee506325a1dda45ec3eae8b5f05ec0cc1ae2) proxysql: 2.5.2 -> 2.5.3
* [`0a81cf8e`](https://github.com/NixOS/nixpkgs/commit/0a81cf8e7a327420340850ed6916c3d60e894f7d) linux: set ZPOOL=y
* [`3132820c`](https://github.com/NixOS/nixpkgs/commit/3132820c2fe5a5d4730f21c8bd8844213299ee5b) python3Packages.pytest-ordering: remove
* [`fcad29d7`](https://github.com/NixOS/nixpkgs/commit/fcad29d73e2283be4286bd0151a527abec36cfd6) python3Packages.pytest-sanic: remove
* [`8f3b487e`](https://github.com/NixOS/nixpkgs/commit/8f3b487ee41e2786b9bcf25b5499b729089d5c04) openraPackages_2019: remove usages of `with lib;`
* [`f626023b`](https://github.com/NixOS/nixpkgs/commit/f626023bea132ea3fbc9fe4f641a9546231eaa0d) openraPackages_2019: remove dependency on dotnetPackages
* [`44f2f9ef`](https://github.com/NixOS/nixpkgs/commit/44f2f9efcdc66b468ac785bcb490df4d37cb3f33) openraPackages_2019: don't use pkgs.lib
* [`6d284bd5`](https://github.com/NixOS/nixpkgs/commit/6d284bd5621c7b49770aae252881f480f857476a) python310Packages.jenkins-job-builder: 4.3.0 -> 5.0.2
* [`867f6fc8`](https://github.com/NixOS/nixpkgs/commit/867f6fc82d8945a1b6ff6f5946d8891847886398) perlPackages.Po4a: disable tests on darwin
* [`c7050453`](https://github.com/NixOS/nixpkgs/commit/c7050453c2ce57663950cae6c178e78e54a3a435) ryujinx: 1.1.898 -> 1.1.900
* [`10240e04`](https://github.com/NixOS/nixpkgs/commit/10240e0456d0bdcccd23feb594eedfc119c07450) intel-gmmlib: 22.3.5 -> 22.3.7
* [`774f2e0a`](https://github.com/NixOS/nixpkgs/commit/774f2e0ac81b410b58bf39545dd95c7ca7f1907f) python310Packages.drms: 0.6.3 -> 0.6.4
* [`57ca44c0`](https://github.com/NixOS/nixpkgs/commit/57ca44c0aea940569d367af13894a0cb0975c502) lib: simplify stringToCharacters
* [`c0090464`](https://github.com/NixOS/nixpkgs/commit/c009046498ae0df70c8fd69a9f9e238bad91a3ac) libcef: 112.3.0 -> 114.2.11
* [`2e4f8554`](https://github.com/NixOS/nixpkgs/commit/2e4f8554d2ae1d2785e369ade41bbea5cc4fced8) lapce: disable updater
* [`a2a94f70`](https://github.com/NixOS/nixpkgs/commit/a2a94f709b4d034c482862b58d34f65742f0c6a6) xpra: 4.4.5 -> 4.4.6
* [`867a815b`](https://github.com/NixOS/nixpkgs/commit/867a815b42b0b9e8854200ca63df8e844f80ee53) linkerd: 2.13.4 -> 2.13.5
* [`c311c7c5`](https://github.com/NixOS/nixpkgs/commit/c311c7c5cc53618c333609d899d2c4263d74603a) e2fsprogs: avoid incompatible features in mke2fs
* [`5183c8d2`](https://github.com/NixOS/nixpkgs/commit/5183c8d21d95fa6c9e9c7ba97bd68066e8585209) ocamlPackages.carton-lwt: disable tests
* [`e4ba29c3`](https://github.com/NixOS/nixpkgs/commit/e4ba29c31d6a15fc51e6d64a957edb00e9ca655d) ocamlPackages.awa: 0.2.0 → 0.3.0
* [`52e23a92`](https://github.com/NixOS/nixpkgs/commit/52e23a92cb98d2a8429685a3f4bbc8f1dfa5a67a) linkerd_edge: 23.5.1 -> 23.6.2
* [`4d7410cf`](https://github.com/NixOS/nixpkgs/commit/4d7410cfc44aaf5d7644b36cc74d0e1a2cfb7f5b) bonzomatic: 2022-08-20 -> 2023-06-15
* [`ca6fdc2c`](https://github.com/NixOS/nixpkgs/commit/ca6fdc2c4cf959404b020c6798a302ae20f0a977) glslang: 12.1.0 -> 12.2.0
* [`88d00dd4`](https://github.com/NixOS/nixpkgs/commit/88d00dd40a76e71f9981cbfa80b81c3210686f96) vulkan-headers: 1.3.249 -> 1.3.254
* [`c7bd8021`](https://github.com/NixOS/nixpkgs/commit/c7bd8021487fdbf766ed8c9939459fe91aa25b7c) vulkan-loader: 1.3.249 -> 1.3.254
* [`f0137c3f`](https://github.com/NixOS/nixpkgs/commit/f0137c3f667abb9cabf1920ac67151ceb5ddcb94) vulkan-validation-layers: 1.3.249 -> 1.3.254
* [`b727077e`](https://github.com/NixOS/nixpkgs/commit/b727077eaaa09e8b3d83556664bc0f164e67b156) vulkan-tools: 1.3.249 -> 1.3.254
* [`0eb5d95d`](https://github.com/NixOS/nixpkgs/commit/0eb5d95df1e892a0d304c9344488ff5fca1d6e52) vulkan-tools-lunarg: 1.3.249 -> 1.3.250
* [`1a8fd67c`](https://github.com/NixOS/nixpkgs/commit/1a8fd67c6c446f62c8a933a2929be391e61d5300) vulkan-extension-layer: 1.3.248 -> 1.3.254
* [`4127d596`](https://github.com/NixOS/nixpkgs/commit/4127d59666edd58e367a181a3e03908dd13d6390) spirv-headers: 1.3.243.0 -> 1.3.250.0
* [`f2a2be87`](https://github.com/NixOS/nixpkgs/commit/f2a2be87eba1669663d076cf8b0d5a133eda8f0b) spirv-cross: 1.3.243.0 -> 1.3.250.0
* [`7226a563`](https://github.com/NixOS/nixpkgs/commit/7226a56365d2767cd2588d09e7e205c3c72f85c7) spirv-tools: 2023.2 -> 2023.3.rc1
* [`7d3bac5b`](https://github.com/NixOS/nixpkgs/commit/7d3bac5b4b0f581359d8ec072ecc46f50876bf87) eid-mw: 5.1.10 -> 5.1.11
* [`6a7265ed`](https://github.com/NixOS/nixpkgs/commit/6a7265ed5089e6cf632d76b36bb07e020d3bf36e) vtm: 0.9.9m -> 0.9.9n
* [`24b76063`](https://github.com/NixOS/nixpkgs/commit/24b7606377e811895ebde0522702c4241d600cba) alfaview: 8.67.1 -> 8.71.0
* [`11b086f4`](https://github.com/NixOS/nixpkgs/commit/11b086f40b2b05fe4aeea636f1d700b7035f8c90) mesa: 23.1.2 -> 23.1.3
* [`58f2d07c`](https://github.com/NixOS/nixpkgs/commit/58f2d07ce9f3257901068952190250a52468b6bd) jsvc: 1.3.3 -> 1.3.4
* [`a49f40eb`](https://github.com/NixOS/nixpkgs/commit/a49f40eb679d5f5fd94f915f4366c0897d615895) innernet: 1.5.5 -> 1.6.0
* [`2818fc37`](https://github.com/NixOS/nixpkgs/commit/2818fc37e64e7e4e48736ef3adb6674112e29591) level-zero: 1.11.0 -> 1.12.0
* [`d213bcdd`](https://github.com/NixOS/nixpkgs/commit/d213bcdda9b677863cd80c4191872605a7865bf9) sem: 0.28.1 -> 0.28.2
* [`0407179f`](https://github.com/NixOS/nixpkgs/commit/0407179fe192f71511873b981010621bd768d55a) questdb: 7.1.3 -> 7.2
* [`4fba8a2d`](https://github.com/NixOS/nixpkgs/commit/4fba8a2d38a78117c385cab2b2b697fa914b4d06) i2pd: 2.47.0 -> 2.48.0
* [`f0f259fa`](https://github.com/NixOS/nixpkgs/commit/f0f259fa257e63a47dede6d6e2a141674cc78217) oapi-codegen: 1.12.4 -> 1.13.0
* [`f68f5aa7`](https://github.com/NixOS/nixpkgs/commit/f68f5aa7c03bbbcaa5893fa13fde6f2b0e265d7f) python310Packages.chart-studio: 5.13.1 -> 5.15.0
* [`93ba4194`](https://github.com/NixOS/nixpkgs/commit/93ba4194baf98ce95f2cbf8d4ea15bb38713ed0a) swiProlog: 8.3.29 -> 9.1.10
* [`8f80aff7`](https://github.com/NixOS/nixpkgs/commit/8f80aff7653bfa03e057dccb7827bcaa1a2b017f) vimPlugins.flash-nvim: init at 2023-06-23
* [`136b0c9c`](https://github.com/NixOS/nixpkgs/commit/136b0c9cd5ad661485a7eec50e47e655cfe9481b) vimPlugins: update
* [`ae13bf81`](https://github.com/NixOS/nixpkgs/commit/ae13bf81342fee1f2fb87484ee3025779cc0fe09) vimPlugins.nvim-treesitter: update grammars
* [`5a30a61b`](https://github.com/NixOS/nixpkgs/commit/5a30a61b942ef2e2ed158e3f02200d2b60842134) confd-calico: 3.26.0 -> 3.26.1
* [`4edf0b8b`](https://github.com/NixOS/nixpkgs/commit/4edf0b8bc4679400b493699dd2b89f2416c5346b) maintainers: add proofconstruction
* [`ebf50ab5`](https://github.com/NixOS/nixpkgs/commit/ebf50ab5f0ed54c06cc47a4d6c2f7cd68a3c457e) prometheus-sql-exporter: 0.4.5 -> 0.4.7
* [`ddd94a31`](https://github.com/NixOS/nixpkgs/commit/ddd94a31036dd31dcb5f6bb509f7dae5f97fdb69) wl-screenrec: init at unstable-2023-05-31
* [`296b322b`](https://github.com/NixOS/nixpkgs/commit/296b322b40a13f3e3fbd86da8ac89fb9d3bb23bb) qucs-s: 1.0.2 -> 1.1.0
* [`f6b37dda`](https://github.com/NixOS/nixpkgs/commit/f6b37ddaf2e42d7b525ca7e48996cd9d8a7a621e) nixos/qemu-vm: use cfg.host.pkgs
* [`a574161d`](https://github.com/NixOS/nixpkgs/commit/a574161d80c9679a97f0e823467575ad9e4f67bd) yoshimi: 2.3.0 -> 2.3.0.2
* [`0f97f013`](https://github.com/NixOS/nixpkgs/commit/0f97f01345ab36db9279e320d1ecdda4525a8b6f) uftrace: 0.13.1 -> 0.14
* [`5889903a`](https://github.com/NixOS/nixpkgs/commit/5889903ade1a1cca51b6959926e723dcdc1b0511) qbittorrent: 4.5.3 -> 4.5.4
* [`869ab00b`](https://github.com/NixOS/nixpkgs/commit/869ab00b4a87b43c894bd0d693aa802acc05b8b4) calico-cni-plugin: 3.26.0 -> 3.26.1
* [`2c0a8e50`](https://github.com/NixOS/nixpkgs/commit/2c0a8e50509e4875b893065e91f1ba311da28885) z3: add changelog to meta
* [`f87301f5`](https://github.com/NixOS/nixpkgs/commit/f87301f5f1957778ec80a27705477e66dd323bb0) z3_4_11: 4.11.0 -> 4.11.2
* [`cce72805`](https://github.com/NixOS/nixpkgs/commit/cce72805397bbed740bf1536c47f86f05eff3548) z3_4_12: 4.12.1 -> 4.12.2
* [`8c7e8a18`](https://github.com/NixOS/nixpkgs/commit/8c7e8a186664dbe49f5ae574088f5f69db751ce5) ip2location-c: 8.5.1 -> 8.6.1
* [`268b1047`](https://github.com/NixOS/nixpkgs/commit/268b10478c49f3ede36f6dc64af4a3d28546e06f) firefox-devedition-bin-unwrapped: 115.0b7 -> 115.0b9
* [`61cb7602`](https://github.com/NixOS/nixpkgs/commit/61cb760268910c8feeaa4d07986a61cb76b16b28) haskellPackages: dontCheck implicit due to flaky tests
* [`3fc46c59`](https://github.com/NixOS/nixpkgs/commit/3fc46c59386793545cb721709036babee889e307) haskellPackages.config-value: allow alex-3.2.7.4
* [`44397c80`](https://github.com/NixOS/nixpkgs/commit/44397c80e3fceef3030fe127c77840f22b8c4b06) jwx: 2.0.9 -> 2.0.11
* [`d5c5e51d`](https://github.com/NixOS/nixpkgs/commit/d5c5e51d7f04ae8a77b17ad1ec7b7fbc211c3e80) liquid-dsp: 1.5.0 -> 1.6.0
* [`6df1c562`](https://github.com/NixOS/nixpkgs/commit/6df1c56223496ac21598f24aa409e8e46cbeb5e2) sequoia: 0.28.0 -> 0.30.1
* [`3718dfbc`](https://github.com/NixOS/nixpkgs/commit/3718dfbcda52d51262c1bcf32eb9c113337cff07) haskellPackages.lsp: restrict to 1.6.*
* [`d593a191`](https://github.com/NixOS/nixpkgs/commit/d593a19150b187041c7ac8b1d11404c7388392c5) netmaker-full: 0.20.1 -> 0.20.2
* [`f9184387`](https://github.com/NixOS/nixpkgs/commit/f9184387e15f084152d273b664c6e256f546b7ce) haskellPackages.jsaddle-webkit2gtk: drop upstreamed patch
* [`65339236`](https://github.com/NixOS/nixpkgs/commit/653392366ddbc050e86159666860c469912f0b8f) abuild: 3.11.7 -> 3.11.9
* [`b77e33c4`](https://github.com/NixOS/nixpkgs/commit/b77e33c4e0430d72824bf108497be604466f11ea) minizinc: 2.7.5 -> 2.7.6
* [`840afa1d`](https://github.com/NixOS/nixpkgs/commit/840afa1db7fc75e0cc6190411733647ae8883fca) libdatachannel: init at 0.18.5
* [`e908b125`](https://github.com/NixOS/nixpkgs/commit/e908b12552a8815c0f316ff1255ed0c555d2bf2a) lego: 4.12.1 -> 4.12.3
* [`6916d29f`](https://github.com/NixOS/nixpkgs/commit/6916d29f04f607a4cfaf091479a208c9f83ae2b8) kubedb-cli: 0.33.0 -> 0.34.0
* [`bee59c68`](https://github.com/NixOS/nixpkgs/commit/bee59c68563543f9367b303ed9eefddab7c7b82d) therion: 6.1.7 -> 6.1.8
* [`a949ec75`](https://github.com/NixOS/nixpkgs/commit/a949ec75d30390a73d396d54c1c7eb49d151396f) libqb: 2.0.6 -> 2.0.7
* [`9c16cea2`](https://github.com/NixOS/nixpkgs/commit/9c16cea2bbd0b8e172bec49382d1e35861892263) buildDotnetModule: allow lockFile path to be set in nugetDeps
* [`4c85d73e`](https://github.com/NixOS/nixpkgs/commit/4c85d73eeaa9a5f80316c8d3e4cd7f0f4be48478) python310Packages.pytorch-lightning: 2.0.2 -> 2.0.4
* [`91e2645a`](https://github.com/NixOS/nixpkgs/commit/91e2645ab5d09d84838abef7bc3a9ac594a2c28d) innernet: add changelog to meta
* [`9125b7d1`](https://github.com/NixOS/nixpkgs/commit/9125b7d14096de753974a405d021c90f37ad306d) mediamtx: 0.23.5 -> 0.23.6
* [`24763408`](https://github.com/NixOS/nixpkgs/commit/24763408cc343b8710a3638b720d1e44dff1d852) dolt: 1.3.0 -> 1.5.0
* [`0c7cacba`](https://github.com/NixOS/nixpkgs/commit/0c7cacbac49d3d73b40edfd6e09a41cc18e569e9) horizon-eda: 2.4.0 -> 2.5.0
* [`22564683`](https://github.com/NixOS/nixpkgs/commit/22564683831cfaf0cd891bc2fa1a27dd8d47d5bb) vapoursynth: 62 -> 63
* [`ee8ba995`](https://github.com/NixOS/nixpkgs/commit/ee8ba995a746b317d94abcbaeb877f200e1cd37b) buildDotnetModule: make fetch-deps find output path automatically
* [`cf9976de`](https://github.com/NixOS/nixpkgs/commit/cf9976de74326b753af0d5bfca0729b23c2d5fd1) buildDotnetModule: unset TMPDIR instead of setting it empty
* [`d6fa0f0a`](https://github.com/NixOS/nixpkgs/commit/d6fa0f0a266da2287a00d98307c66f7657dd4170) buildDotnetModule: use tmp file for fetch-deps output
* [`afe26f5f`](https://github.com/NixOS/nixpkgs/commit/afe26f5f1ddbae20808d32c82a4bf6b8933bd1e3) buildDotnetModule: remove fetch-deps from tool packages
* [`bca3a9ed`](https://github.com/NixOS/nixpkgs/commit/bca3a9edfc51b1e29673e98151df1b6a94dc44dd) buildDotnetModule: fix indentation
* [`f2027f49`](https://github.com/NixOS/nixpkgs/commit/f2027f4960497d771df5ea1641f237a62fa36465) nuget-to-nix: set nullglob
* [`7af46fb0`](https://github.com/NixOS/nixpkgs/commit/7af46fb0476330aaa2fe7a1627827007005918ef) roslyn: remove extended-deps.nix
* [`0db8d328`](https://github.com/NixOS/nixpkgs/commit/0db8d3283c0f083fd84544354ae0a3165325e1f9) kde-rounded-corners: 0.3.0 -> 0.4.0
* [`4b2a77fd`](https://github.com/NixOS/nixpkgs/commit/4b2a77fdc40bac19e510e0c509c99486df0dfbc6) python310Packages.micawber: 0.5.4 -> 0.5.5
* [`d9ed07cf`](https://github.com/NixOS/nixpkgs/commit/d9ed07cfcfe30e41fe6b2e382752011a628a3361) deltachat-desktop: remove noop override
* [`9f5feba8`](https://github.com/NixOS/nixpkgs/commit/9f5feba8955f3293e13934710d27fa330f0649ce) discord-development: 0.0.216 -> 0.0.217
* [`0a41b1e2`](https://github.com/NixOS/nixpkgs/commit/0a41b1e2858fce702e6571afa8356feb9fd9f81a) minimal-bootstrap.writeTextFile: don't force preferLocalBuild as local system might not support stage0-posix
* [`6538fff2`](https://github.com/NixOS/nixpkgs/commit/6538fff2eb3c85599a708c85f79af3ecd296e90a) faustPhysicalModeling: 2.59.6 -> 2.60.3
* [`754d5785`](https://github.com/NixOS/nixpkgs/commit/754d578555ac5dba329c20331532c36a3d7180c1) diamond: 2.1.7 -> 2.1.8
* [`82dc8d7b`](https://github.com/NixOS/nixpkgs/commit/82dc8d7b7978544f704671f1f526b34fd5d45741) minimal-bootstrap.linux-headers: init at 4.14.67
* [`0b6f86e4`](https://github.com/NixOS/nixpkgs/commit/0b6f86e46a0884fd4f5e849c441a0b06c6809ac7) minimal-bootstrap.binutils-mes: init at 2.20.1
* [`bd99e569`](https://github.com/NixOS/nixpkgs/commit/bd99e56908c5a1645d550ee432b1c584e4bdceda) minimal-bootstrap.gcc2-mes: init at 2.95.3
* [`a6f479ad`](https://github.com/NixOS/nixpkgs/commit/a6f479ad5316a3957a0329c6dbd50bbf4b2a09a5) minimal-bootstrap.glibc22: init at 2.2.5
* [`ca32151b`](https://github.com/NixOS/nixpkgs/commit/ca32151ba7519cf5e691d09ed2c2860738b3f008) vdo: 8.2.0.2 -> 8.2.2.2
* [`2aceb939`](https://github.com/NixOS/nixpkgs/commit/2aceb9395cb29a8a286abd56fc999f50e94643b8) python310Packages.oci: 2.104.2 -> 2.104.3
* [`f299c4a6`](https://github.com/NixOS/nixpkgs/commit/f299c4a6b89a2b11c8881891777ccb212d456a12) python310Packages.pyro-ppl: 1.8.4 -> 1.8.5
* [`817377bd`](https://github.com/NixOS/nixpkgs/commit/817377bd15ab191caaea6bfcd665370f5608ad81) python310Packages.pyro-ppl: add changelog to meta
* [`2bd7b1e1`](https://github.com/NixOS/nixpkgs/commit/2bd7b1e147aca074314cdbef47e63b353e136206) python310Packages.micawber: disable on unsupported python releases
* [`4124eb7b`](https://github.com/NixOS/nixpkgs/commit/4124eb7bd56f7aefc302032c2696a1acbd8b8344) compressFirmwareXz: preserve meta attributes
* [`4628e55a`](https://github.com/NixOS/nixpkgs/commit/4628e55adbddce3b2ee142243e12060370085e64) rpm-ostree: 2023.4 -> 2023.5
* [`0a12cf4a`](https://github.com/NixOS/nixpkgs/commit/0a12cf4a845ba4581ea2cd5f9ddcf2fba793c7cc) python310Packages.pymupdf: 1.22.3 -> 1.22.5
* [`7be3ecb7`](https://github.com/NixOS/nixpkgs/commit/7be3ecb7adbe7ad4830c635cabb73747e470f4e8) lttng-tools: 2.13.9 -> 2.13.10
* [`61da0e3b`](https://github.com/NixOS/nixpkgs/commit/61da0e3bb38854e0e7f5d88736e1bd8ba4d465f0) tidal-hifi: 5.2.0 -> 5.3.0
* [`8a702e16`](https://github.com/NixOS/nixpkgs/commit/8a702e16d916919019e03a6304560b0e8bf8e596) quickemu: 4.7 -> 4.8
* [`6a703e87`](https://github.com/NixOS/nixpkgs/commit/6a703e8776c5eaf6aef1e3fb2c001b1bb98f5dea) figma-agent: 0.2.7 -> 0.2.8
* [`0f53d2ac`](https://github.com/NixOS/nixpkgs/commit/0f53d2ac1719e70667eaed4895f176d4ec8dd1fd) falcoctl: 0.5.0 -> 0.5.1
* [`e0eb796b`](https://github.com/NixOS/nixpkgs/commit/e0eb796b96efb811ba8358cc8b0a5ce191af178d) k4dirstat: 3.4.2 -> 3.4.3
* [`e7d05a7d`](https://github.com/NixOS/nixpkgs/commit/e7d05a7d092924c8271175395be4d9e7e6b5c20b) obs-studio-plugins.obs-vaapi: 0.2.0 -> 0.3.1
* [`ca6f6192`](https://github.com/NixOS/nixpkgs/commit/ca6f61927794c25e97e16bc03c5fa0b2a14e38fd) tela-icon-theme: 2023-02-03 -> 2023-06-25
* [`a430d797`](https://github.com/NixOS/nixpkgs/commit/a430d7979471cbc44413574460a6d0a7e93ab160) obs-studio-plugins.obs-vaapi: add meta.changelog
* [`9589a3cd`](https://github.com/NixOS/nixpkgs/commit/9589a3cda769694f1a0a8b21ec1d96482eaad37a) libtoxcore: drop unnecessary dependency on msgpack
* [`8ddf3139`](https://github.com/NixOS/nixpkgs/commit/8ddf313977dba7f8912a91fc2cae4cebabbd9bc6) karmor: fix version
* [`40d36f54`](https://github.com/NixOS/nixpkgs/commit/40d36f54d3334ea04e2a87d3c86782ba50e4d328) karmor: add version test
* [`3364233f`](https://github.com/NixOS/nixpkgs/commit/3364233f46fd5b87b6a9bbf1fdb45d902a93c6ac) linux_xanmod_latest: 6.3.5 -> 6.3.9
* [`986c78a3`](https://github.com/NixOS/nixpkgs/commit/986c78a3819e020c139ca4e11bfd29ecd61a7318) linux_xanmod: 6.1.31 -> 6.1.35
* [`c8b6f790`](https://github.com/NixOS/nixpkgs/commit/c8b6f790fc7c0199db67a92968da3e0b8a579173) endlessh-go: 20230211 -> 20230613
* [`7eab3292`](https://github.com/NixOS/nixpkgs/commit/7eab3292c211dae2550c542ddbe2dc09903402bc) pulumi: 3.71.0 -> 3.72.2
* [`56c7d5e2`](https://github.com/NixOS/nixpkgs/commit/56c7d5e2e82cff9a5953a5905805d5b82bf3f2d3) kodiPackages.libretro-2048: init at 1.0.0.136
* [`1eebe0b7`](https://github.com/NixOS/nixpkgs/commit/1eebe0b71ea6fe9bee4e84112a959406770b6412) kodiPackages.vfs-rar: init at 20.1.0
* [`fd9f4d86`](https://github.com/NixOS/nixpkgs/commit/fd9f4d86fe8bd07a23ff520d6f3fbb2574977b18) tengine: 2.4.0 -> 2.4.1
* [`11116f81`](https://github.com/NixOS/nixpkgs/commit/11116f81a24cfa18a006f0d4d7a764206429d269) nats-streaming-server: 0.25.4 -> 0.25.5
* [`00406647`](https://github.com/NixOS/nixpkgs/commit/00406647e67e659e015f68def3a954909a7d2b7b) oculante: 0.6.65 -> 0.6.66
* [`35181468`](https://github.com/NixOS/nixpkgs/commit/35181468b88ca05495df0f81f1da06f153c1ec00) newsboat: 2.31 -> 2.32
* [`275579cf`](https://github.com/NixOS/nixpkgs/commit/275579cfe76b2d031b8553a1ffd70bf4b6ee314e) spotdl: 4.1.10 -> 4.1.11
* [`a2942a1f`](https://github.com/NixOS/nixpkgs/commit/a2942a1f345d80b1cb6b83c4b90b40af3c926e5d) srvc: 0.19.1 -> 0.20.0
* [`b8c958d2`](https://github.com/NixOS/nixpkgs/commit/b8c958d270c7bf436981617441260d1d29f4d7e5) nano-wallet: 25.0 -> 25.1
* [`c4cf696a`](https://github.com/NixOS/nixpkgs/commit/c4cf696adc1562a686e7244e1534eb5a2f6924c2) saga: misc improvements, add geospatial team to maintainers
* [`74d8cf61`](https://github.com/NixOS/nixpkgs/commit/74d8cf6138d485edb7e7b71cecb96c58c0b1b222) blueprint-compiler: 0.6.0 -> 0.8.1
* [`4ba86107`](https://github.com/NixOS/nixpkgs/commit/4ba8610783e0b750fef7d49d36e5fa545f37b8a2) textpieces: mark broken
* [`c7f52b43`](https://github.com/NixOS/nixpkgs/commit/c7f52b430b7f18d6847b005749e9b7e7f56bfdef) python311Packages.moreorless: init at 0.4.0
* [`db106725`](https://github.com/NixOS/nixpkgs/commit/db1067257254b9e4eea3e0b940d626568f849897) python311Packages.stdlibs: init at 2022.10.9
* [`fe0f5128`](https://github.com/NixOS/nixpkgs/commit/fe0f51280653081262f90f438c6b89e8f079ea6c) python311Packages.trailrunner: init at 1.4.0
* [`2b28bfdf`](https://github.com/NixOS/nixpkgs/commit/2b28bfdfaad053ba0f1ce241a6c4a7ccc314b5c4) python311Packages.volatile: init at 2.1.0
* [`825f4e8b`](https://github.com/NixOS/nixpkgs/commit/825f4e8b77b5431832ea181b3c19990deef2b214) python310Packages.yfinance: 0.2.20 -> 0.2.22
* [`b5843e3c`](https://github.com/NixOS/nixpkgs/commit/b5843e3c6844ea01cbabfb4b574033651c36a660) python311Packages.usort: init at 1.1.0b2
* [`b01137d2`](https://github.com/NixOS/nixpkgs/commit/b01137d267a169659e0fc45bafab6016ecd7899d) python311Packages.ufmt: init at 2.1.0
* [`de1ca081`](https://github.com/NixOS/nixpkgs/commit/de1ca081be5489f00ae56c036a27090fdd30cd13) space-station-14-launcher: remove dotnet-specific dependencies
* [`bfb09d2b`](https://github.com/NixOS/nixpkgs/commit/bfb09d2b6e6ae10a86a3327ed0e7e10d6175f99a) python310Packages.pytorch-metric-learning: 2.1.2 -> 2.2.0
* [`fe1fdd93`](https://github.com/NixOS/nixpkgs/commit/fe1fdd9312e5eada9f5850fea2fb0b282533e788) python310Packages.huawei-lte-api: 1.6.11 -> 1.7
* [`d544d281`](https://github.com/NixOS/nixpkgs/commit/d544d2815d8da0aa1b657b4701f6fb4c3b8638cf) python310Packages.dvc-data: 2.0.2 -> 2.3.0
* [`58d60d9f`](https://github.com/NixOS/nixpkgs/commit/58d60d9fbc2e05a08981a6728fff9e924ed58da7) signalbackup-tools: 20230615 -> 20230625
* [`dd2d2f33`](https://github.com/NixOS/nixpkgs/commit/dd2d2f33182f337049e6549d6bcc620b4a910426) unityhub: add 2019 editor dependencies
* [`2ffac987`](https://github.com/NixOS/nixpkgs/commit/2ffac9873d802a94b3cc1bba4697daa32f296ab1) unityhub: 3.4.2 -> 3.5.0
* [`e10e22f8`](https://github.com/NixOS/nixpkgs/commit/e10e22f890bb194b306f6e955ccfdda31eff9aa5) oh-my-zsh: 2023-06-19 -> 2023-06-20
* [`56efd49d`](https://github.com/NixOS/nixpkgs/commit/56efd49dacf35bd2744c55498a147b92f4decb02) kubeshark: 40.5 -> 41.1
* [`b90b8b77`](https://github.com/NixOS/nixpkgs/commit/b90b8b772603d87c5bdbef28c8967b17b202904c) dagger: 0.6.1 -> 0.6.2
* [`6ff2648d`](https://github.com/NixOS/nixpkgs/commit/6ff2648d31af49162b9a727b5845e41ae41a3a44) cloudfox: 1.11.1 -> 1.11.2
* [`581cdbc4`](https://github.com/NixOS/nixpkgs/commit/581cdbc4e6d16fa89964e5929ae5d258ca8eadd7) immudb: 1.4.1 -> 1.5.0
* [`79dd7b03`](https://github.com/NixOS/nixpkgs/commit/79dd7b033a835fa64c35a2152cb4351ef94c54e3) bazel-gazelle: 0.31.0 -> 0.31.1
* [`8c581c40`](https://github.com/NixOS/nixpkgs/commit/8c581c406832d14d572e17a4cd53d8ff9fc0bf76) chezmoi: 2.34.1 -> 2.34.2
* [`c01687ad`](https://github.com/NixOS/nixpkgs/commit/c01687ad363828bc4bb288c13090c1fe56c32ac6) maintainers/team-list: add siraben to minimal-bootstrap
* [`85b47261`](https://github.com/NixOS/nixpkgs/commit/85b47261a17a6b27bd75cf33a4d076ad6395d00c) maintainers: add earthengine
* [`713324f5`](https://github.com/NixOS/nixpkgs/commit/713324f5fd59833f5c5c4e0cc840fb8119baf8db) duckscript: 0.8.19 -> 0.8.20
* [`9d746127`](https://github.com/NixOS/nixpkgs/commit/9d746127bc6a7e3d8f52dbf4811f5344cba75b50) esbuild: 0.18.8 -> 0.18.9
* [`983bbf6c`](https://github.com/NixOS/nixpkgs/commit/983bbf6c1e1f98d76a0f0c9cf31d7b2fb8d5634a) millet: 0.11.4 -> 0.12.0
* [`952db33c`](https://github.com/NixOS/nixpkgs/commit/952db33c5e1389d6af4b6abe503caf489d205383) nfpm: 2.30.1 -> 2.31.0
* [`c33c6c4a`](https://github.com/NixOS/nixpkgs/commit/c33c6c4aa419f75076ec36ef196c496b7120d91a) esbuild: 0.18.9 -> 0.18.10
* [`8396ec6f`](https://github.com/NixOS/nixpkgs/commit/8396ec6f6d68c2eff29b5a74aee1f47c0c26b35b) python310Packages.mt-940: 4.28.0 -> 4.30.0
* [`0836e162`](https://github.com/NixOS/nixpkgs/commit/0836e1621d5e27e009fcb773ca6815d10f919d00) hydra_unstable: 2023-03-27 -> 2023-06-25
* [`850cfffa`](https://github.com/NixOS/nixpkgs/commit/850cfffabc40ce79dbaec027be15c8d57749e35b) python3Packages.tensorly: 0.8.0 -> 0.8.1 re-enabled tests
* [`cb26e423`](https://github.com/NixOS/nixpkgs/commit/cb26e4230dedb788f9612d00332b11efac003da7) clickhouse: 23.3.3.52 -> 23.3.5.9
* [`12bd7ee3`](https://github.com/NixOS/nixpkgs/commit/12bd7ee3e0e7886af5648441d2e370face79b8a6) erlang_26: 26.0 -> 26.0.1
* [`dc7641c3`](https://github.com/NixOS/nixpkgs/commit/dc7641c3fd8ad4cc4c21d94cb2081b39130701a3) yaydl: init at 0.13.0
* [`b3cdc496`](https://github.com/NixOS/nixpkgs/commit/b3cdc49627b4ef8dcf32a012555437d97ecc2854) python310Packages.rq: 1.15 -> 1.15.1
* [`bee727f2`](https://github.com/NixOS/nixpkgs/commit/bee727f27d477fbc1d8d28d4660bbb2ed10ff18f) kodiPackages.inputstreamhelper: 0.5.10+matrix.1 -> 0.6.1+matrix.1
* [`8b3bdd95`](https://github.com/NixOS/nixpkgs/commit/8b3bdd95800f373474abeebf3bcad77a17c4ce84) python311Packages.env-canada: 0.5.34 -> 0.5.35
* [`4fee5002`](https://github.com/NixOS/nixpkgs/commit/4fee50025618c4e8135fccce190c62afce1546c9) python311Packages.fastapi-mail: 1.2.8 -> 1.3.0
* [`b9ddf070`](https://github.com/NixOS/nixpkgs/commit/b9ddf07050dfa9c58090e5e06245a774a791e6a9) python311Packages.hahomematic: 2023.6.0 -> 2023.6.1
* [`f76121ff`](https://github.com/NixOS/nixpkgs/commit/f76121ffe4ffbc77ef7e2dfcab1f3adc707f2e0b) python310Packages.mt-940: add changelog to meta
* [`bd8f4a24`](https://github.com/NixOS/nixpkgs/commit/bd8f4a24e139892d1c8cc5c0e7a88e28d9d5d4f4) R: 4.3.0 -> 4.3.1
* [`eb9c56e3`](https://github.com/NixOS/nixpkgs/commit/eb9c56e3c401f21ee8b045fb646230b0c561804d) python311Packages.mt-940: enable tests
* [`d127b831`](https://github.com/NixOS/nixpkgs/commit/d127b831b50b0cd8880c06ac946ffdf0d5997b07) fastjet: 3.4.0 -> 3.4.1
* [`d123c351`](https://github.com/NixOS/nixpkgs/commit/d123c351d107e7043528dbebbf4f812ae194412e) libgbinder: 1.1.33 -> 1.1.34
* [`88703715`](https://github.com/NixOS/nixpkgs/commit/8870371562828a4f18bdda5b559fcdbeeede6a3e) knot-dns: 3.2.7 -> 3.2.8
* [`b7abbd1a`](https://github.com/NixOS/nixpkgs/commit/b7abbd1a242a839bfe28cd1fbcab9c8a4c40397a) snac2: 2.31 -> 2.35
* [`be3f9ce9`](https://github.com/NixOS/nixpkgs/commit/be3f9ce9e2f75ed49782036a7df2de3d81d5d3d9) python311Packages.pyezviz: 0.2.1.3 -> 0.2.1.6
* [`6b8cefb4`](https://github.com/NixOS/nixpkgs/commit/6b8cefb40bf149dddfa51c7c3c38301b7894006d) python310Packages.ytmusicapi: 1.0.2 -> 1.1.0
* [`46336e7a`](https://github.com/NixOS/nixpkgs/commit/46336e7a53e6da594c246eabe8924a204f9a1257) displaylink: 5.6.1-59.184 -> 5.7.0-61.129
* [`df720da7`](https://github.com/NixOS/nixpkgs/commit/df720da7f09899dada20872600a5e7de31a2a995) minimal-bootstrap: make sources a non-tarballs.nixos.org FOD
* [`109633be`](https://github.com/NixOS/nixpkgs/commit/109633bef055415528456848bbbe93fdfdfb73ba) gst_all_1.gst-plugins-rs: drop the raptorq test everywhere
* [`9a6b99ec`](https://github.com/NixOS/nixpkgs/commit/9a6b99ec5acb7e6cb572f54dd2a92dade66680e8) cod: mark package as not broken on linux
* [`d57a0896`](https://github.com/NixOS/nixpkgs/commit/d57a08965239e9b32cdea58213ce99d699be3f04) eos-installer: set meta.mainProgram
* [`d6ad2260`](https://github.com/NixOS/nixpkgs/commit/d6ad2260206b164a1d74ec2166cde7ae3b9dc343) awsume: init at 4.5.3
* [`4ef8777e`](https://github.com/NixOS/nixpkgs/commit/4ef8777e3c0b3634039208c0d9e69200b5adbf9b) openvscode-server: 1.79.1 -> 1.79.2
* [`c8080b06`](https://github.com/NixOS/nixpkgs/commit/c8080b06a9458f8c898ea4537dab82d32e71d06c) separate minimal-bootstrap-sources from make-minimal-bootstrap-sources
* [`e3cbd650`](https://github.com/NixOS/nixpkgs/commit/e3cbd650f503ffe059cac271b20e47fd6afebcc1) stratovirt: add micro_vm-allow-SYS_clock_gettime.patch
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
