### PR TITLE
niv home-manager: update 3bc1bc40 -> c24deeca

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3bc1bc40121eb0975dc3d96741300bb4fd16be29",
-        "sha256": "1j8w7mrq2823qnh8za9fafdx2xm99ffic34shqbfc72j3ryi4wpy",
+        "rev": "c24deeca64538dcbc589ed8da9146e4ca9eb85b7",
+        "sha256": "0l16sh9v3s8rsiaf16bc3fbnmk0i1ca3vx6f261ryrr2jhvl4xcy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/3bc1bc40121eb0975dc3d96741300bb4fd16be29.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c24deeca64538dcbc589ed8da9146e4ca9eb85b7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@3bc1bc40...c24deeca](https://github.com/nix-community/home-manager/compare/3bc1bc40121eb0975dc3d96741300bb4fd16be29...c24deeca64538dcbc589ed8da9146e4ca9eb85b7)

* [`4c08f65a`](https://github.com/nix-community/home-manager/commit/4c08f65ab5105a55eed3fc9003f3e6874b69fe13) broot: fix test ([nix-community/home-manager⁠#4170](https://togithub.com/nix-community/home-manager/issues/4170))
* [`9dd107a1`](https://github.com/nix-community/home-manager/commit/9dd107a1d5395fae9b969597e02f3ef3a43ddd47) flake: add formatter ([nix-community/home-manager⁠#3620](https://togithub.com/nix-community/home-manager/issues/3620))
* [`f5f64ac0`](https://github.com/nix-community/home-manager/commit/f5f64ac022ed379442286a4e81a2a7cdc552cb28) zsh: allow setting custom syntax highlighting styles ([nix-community/home-manager⁠#4122](https://togithub.com/nix-community/home-manager/issues/4122))
* [`47c2adc6`](https://github.com/nix-community/home-manager/commit/47c2adc6b31e9cff335010f570814e44418e2b3e) docs: update link to allowed users setting ([nix-community/home-manager⁠#4176](https://togithub.com/nix-community/home-manager/issues/4176))
* [`a7002d6b`](https://github.com/nix-community/home-manager/commit/a7002d6bfca54742d5fc9b485a1879953b4585b9) kakoune: add defaultEditor option
* [`17ce23ea`](https://github.com/nix-community/home-manager/commit/17ce23ea56aeecbd01dfeb08f6a7902c80f27311) lsd: use -A instead of -a in aliases ([nix-community/home-manager⁠#4173](https://togithub.com/nix-community/home-manager/issues/4173))
* [`0f710127`](https://github.com/nix-community/home-manager/commit/0f71012724b151aa02c8f05f2dc0e121e7a4371e) README: Remove the pills ([nix-community/home-manager⁠#4181](https://togithub.com/nix-community/home-manager/issues/4181))
* [`44d1a854`](https://github.com/nix-community/home-manager/commit/44d1a8542ac92f0ce75d970090216245043a2709) sxhkd: allow usage of derivations as keybind commands ([nix-community/home-manager⁠#4169](https://togithub.com/nix-community/home-manager/issues/4169))
* [`7a0e9a67`](https://github.com/nix-community/home-manager/commit/7a0e9a67824aa05f972459aefc2caafe6fdc0f88) chromium: fix `commandLineArgs` to use the user specified package ([nix-community/home-manager⁠#4175](https://togithub.com/nix-community/home-manager/issues/4175))
* [`2d9210f2`](https://github.com/nix-community/home-manager/commit/2d9210f25ed18d5d4e11e6b886de4027c0c51a94) ssh-agent: init module ([nix-community/home-manager⁠#4178](https://togithub.com/nix-community/home-manager/issues/4178))
* [`89d10f8a`](https://github.com/nix-community/home-manager/commit/89d10f8adce369a80e046c2fd56d1e7b7507bb5b) news: fix typo in programs.zsh.antidote entry
* [`53c75ac2`](https://github.com/nix-community/home-manager/commit/53c75ac2e6de7eb6f4837a0f1abf55abe013afad) flake.lock: Update ([nix-community/home-manager⁠#4161](https://togithub.com/nix-community/home-manager/issues/4161))
* [`c85d9137`](https://github.com/nix-community/home-manager/commit/c85d9137db45a1c9c161f4718b13cc3bd4cbd173) ci: autolabel calendars PRs ([nix-community/home-manager⁠#4165](https://togithub.com/nix-community/home-manager/issues/4165))
* [`8c66b46a`](https://github.com/nix-community/home-manager/commit/8c66b46a86afa21763766ef97d7c8be5f3954e2b) home-manager: Use `path:` URI type for flake default ([nix-community/home-manager⁠#3646](https://togithub.com/nix-community/home-manager/issues/3646))
* [`c24deeca`](https://github.com/nix-community/home-manager/commit/c24deeca64538dcbc589ed8da9146e4ca9eb85b7) xfconf: remove properties with null values ([nix-community/home-manager⁠#4192](https://togithub.com/nix-community/home-manager/issues/4192))
