### PR TITLE
niv zsh-completions: update 83f09c46 -> 5328eb7c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "83f09c461535e2372242c6282b66dbbbef6d508a",
-        "sha256": "10cf8fsspvdpl34z9i0ni7h8ya55mb9y05f0dyc5z4spkclqh49i",
+        "rev": "5328eb7c01270417ad6d0ce75682dea00dfa18f2",
+        "sha256": "0hd5d6fz9zfqywk9ks8rjq863fg7qfr4zl8rmdp2jrva875mcjf1",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/83f09c461535e2372242c6282b66dbbbef6d508a.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/5328eb7c01270417ad6d0ce75682dea00dfa18f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@83f09c46...5328eb7c](https://github.com/zsh-users/zsh-completions/compare/83f09c461535e2372242c6282b66dbbbef6d508a...5328eb7c01270417ad6d0ce75682dea00dfa18f2)

* [`e359dcb1`](https://github.com/zsh-users/zsh-completions/commit/e359dcb1d373aa7b2f36825d43ed75ffda0b0b8f) Update rspec completion to version 3.12.0
* [`3a817b89`](https://github.com/zsh-users/zsh-completions/commit/3a817b893e9f06e619cea0d3d767d6d7452b4146) Update rfkill completion
