### PR TITLE
niv nixpkgs: update ee5cc384 -> 2169d3b0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee5cc38432031b66e7fe395b14235eeb4b2b0d6e",
-        "sha256": "1081x7bnrq8165q9m6ynlpx3rc01i9m55n0sd16l5a3yqrk4b8n3",
+        "rev": "2169d3b0bce0daa64d05abbdf9da552a7b8c22a7",
+        "sha256": "151fl31656crvy0hpk653cbiawrwrda6c6k8q0pr8blspld8f1zf",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ee5cc38432031b66e7fe395b14235eeb4b2b0d6e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/2169d3b0bce0daa64d05abbdf9da552a7b8c22a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ee5cc384...2169d3b0](https://github.com/nixos/nixpkgs/compare/ee5cc38432031b66e7fe395b14235eeb4b2b0d6e...2169d3b0bce0daa64d05abbdf9da552a7b8c22a7)

* [`3a35ba33`](https://github.com/NixOS/nixpkgs/commit/3a35ba334a04712539f4e29f52d027505fc86048) stm32cubemx: add working desktop file
* [`31ac2b8e`](https://github.com/NixOS/nixpkgs/commit/31ac2b8e920806e6f9e361b94e030ae589b9c227) maintainers: add dbalan
* [`1b50bc0d`](https://github.com/NixOS/nixpkgs/commit/1b50bc0dbf2b5f12385410f2c99d97b60bfaf990) iwlib: init at 1.7.0
* [`31328f27`](https://github.com/NixOS/nixpkgs/commit/31328f27084bdb202353188f8202883e2ecff10b) maintainers: add jcspeegs
* [`044d653f`](https://github.com/NixOS/nixpkgs/commit/044d653f7a9279f65c59f24d91cd384380834445) maintainers: add sents
* [`93242070`](https://github.com/NixOS/nixpkgs/commit/93242070ae7e3c427a8b3e3a79c8dc6a6b3e77ae) nixos/gitea: don't recursively change file owners/permissions
* [`10706a02`](https://github.com/NixOS/nixpkgs/commit/10706a026b481344a17e45d44ef01f8e65076744) chromium: (cross): use cc-wrapper-clang instead of bare clang
* [`3db7a3ab`](https://github.com/NixOS/nixpkgs/commit/3db7a3ab006a891f226f36a77d9d3c553d5e7e06) maintainers/team-list: Add team gitlab
* [`e52907eb`](https://github.com/NixOS/nixpkgs/commit/e52907eb4796382890a99ee50582f2eaef30999f) gitlab: Add gitlab team members to maintainers
* [`5c64716a`](https://github.com/NixOS/nixpkgs/commit/5c64716a89f1ac525aa0852c2e1915c0881a7a3a) gitaly: Add gitlab team members to maintainers
* [`314cc14e`](https://github.com/NixOS/nixpkgs/commit/314cc14e7e9b7591f0befed5b23e688950d298b3) gitlab-pages: Add gitlab team members to maintainers
* [`be9536f4`](https://github.com/NixOS/nixpkgs/commit/be9536f47033cbc226d96ed4632aaff8eaef18cb) gitlab-shell: Add gitlab team members to maintainers
* [`517fb6a8`](https://github.com/NixOS/nixpkgs/commit/517fb6a862cbc451340a9b38553c3ade3b774150) gitlab-workhorse: Add gitlab team members to maintainers
* [`27d73b3d`](https://github.com/NixOS/nixpkgs/commit/27d73b3d46799064eaca9a3da99ebfca75ad6f0e) nixos/gitlab: Add gitlab team members to maintainers
* [`7312a905`](https://github.com/NixOS/nixpkgs/commit/7312a90546791db2c8276a93ed8655db09675902) gitlab-runner: Add gitlab team members to maintainers
* [`2681d4ff`](https://github.com/NixOS/nixpkgs/commit/2681d4ff1285f65ec3428a2f2ab68e2d6dbec762) nixos/gitlab-runner: Add gitlab team members to maintainers
* [`f20a84a4`](https://github.com/NixOS/nixpkgs/commit/f20a84a47c1bbe9657331be9a8da14461887e6d5) librealsense: fix intel darwin build
* [`76449dbe`](https://github.com/NixOS/nixpkgs/commit/76449dbe331dd7c56e58885f7f04bdc2451897d0) libsegfault: fix darwin build
* [`13bab5f2`](https://github.com/NixOS/nixpkgs/commit/13bab5f29721d7b1b9eb6404e4e4791778997cb8) python310Packages.prometheus-client: 0.16.0 -> 0.17.0
* [`a7fc0b6e`](https://github.com/NixOS/nixpkgs/commit/a7fc0b6e7016aa62c8a1e1f038d28d4b33f96e5c) mod_tile: testing enabled
* [`0f0a33aa`](https://github.com/NixOS/nixpkgs/commit/0f0a33aa5d37749ad0ce356011d04dd82e15cceb) libsForQt5.ark: rar handler alternative
* [`f14e6d63`](https://github.com/NixOS/nixpkgs/commit/f14e6d63c6c522310595345c830286d55e3ca937) iroh: init at 0.4.1
* [`9fc4a74c`](https://github.com/NixOS/nixpkgs/commit/9fc4a74ca0a97cb0733d70253d96559a5f78b9db) aw-core: 0.5.12 -> 0.5.14, add gitUpdater
* [`40e3e640`](https://github.com/NixOS/nixpkgs/commit/40e3e640dd50680087641f657b3c5a014d68dd45) aw-client: 0.5.11 -> 0.5.12, add gitUpdater
* [`61d43dee`](https://github.com/NixOS/nixpkgs/commit/61d43dee5f1ca98be582ccc5dcde04015adb8f8f) nixos: Extract module for activation script inclusion into toplevel
* [`a16986f1`](https://github.com/NixOS/nixpkgs/commit/a16986f1a32a44ddb5b6f84a179ea1ee0278b2b3) nixos: Move installBootLoader to activation script modules
* [`193f4fea`](https://github.com/NixOS/nixpkgs/commit/193f4fea90a1b26d7bbf8d04b60f6522e830dd65) nixos/activatable-system: Make substitutions explicit
* [`471ee27e`](https://github.com/NixOS/nixpkgs/commit/471ee27e4e07eb4364da170671b1ec8d72389b0f) vulkan-extension-layer: fix setup hook when XDG_DATA_DIRS unset
* [`cbb69aa1`](https://github.com/NixOS/nixpkgs/commit/cbb69aa1c1e69720233e26eda2abf578a53128b8) nixos/usbguard: add USBGuard dbus daemon option
* [`e1fedfdf`](https://github.com/NixOS/nixpkgs/commit/e1fedfdf455e381d2657c84fe4ea41478d5a5479) nixos/ceph: run statix fix
* [`d64e1f0b`](https://github.com/NixOS/nixpkgs/commit/d64e1f0b405bee479b191cdde71ddfdce2c4387d) nixos/ceph: add options to configure package used by each component
* [`1300aec8`](https://github.com/NixOS/nixpkgs/commit/1300aec817921a7c3e69030e0c8dbc844540180e) python3Packages.aws-lambda-builders: 1.28.0 -> 1.34.0
* [`60770614`](https://github.com/NixOS/nixpkgs/commit/6077061403503589d225fc0a51a514800517d813) nixos/ruby-modules: proper treatment to ruby modules of type git/url
* [`5220b6e2`](https://github.com/NixOS/nixpkgs/commit/5220b6e2e03e5d488c07f6d8802cf12206a70a98) plymouth: unstable-2021-10-18 -> unstable-2023-06-05
* [`ef0c0d5c`](https://github.com/NixOS/nixpkgs/commit/ef0c0d5c2fd4732de1fb061bb2ecb77148941b61) nixos/plymouth: use new runtime paths for plugins and themes
* [`7fb39752`](https://github.com/NixOS/nixpkgs/commit/7fb397525677e565eb6e2887d955a91c8a24f795) nixos/plymouth: add actual logo defaultText and move existing to example
* [`d4cab20b`](https://github.com/NixOS/nixpkgs/commit/d4cab20b3a76fef4b9a487c37107df6351ebce33) zfs: add option to restore kernel_neon for linux 6.2 support on aarch64
* [`64bc856b`](https://github.com/NixOS/nixpkgs/commit/64bc856b5829cabc9a38513b47cba7d79e78f506) mongodb-5_0: 5.0.7 -> 5.0.18
* [`089a24b2`](https://github.com/NixOS/nixpkgs/commit/089a24b2e37d9145e11fd669ec8fa6dd3c3d8be3) maintainers: Add Lomiri team
* [`8b3e7893`](https://github.com/NixOS/nixpkgs/commit/8b3e7893acb79a178eefcb03485e905ba1fd3a08) lomiri.cmake-extras: init at unstable-2022-11-21
* [`01aee17e`](https://github.com/NixOS/nixpkgs/commit/01aee17eea837454532d669553a11bd4030c8bfe) dbus-test-runner: init at unstable-2019-10-02
* [`14e5f6d4`](https://github.com/NixOS/nixpkgs/commit/14e5f6d4f3489da62ef74c948543a2ad4ae34275) libqtdbustest: init at unstable-2017-01-06
* [`45a995e1`](https://github.com/NixOS/nixpkgs/commit/45a995e1612588b0a7f7341a2d43484cef4f3545) libqtdbusmock: init at unstable-2017-03-16
* [`cd338359`](https://github.com/NixOS/nixpkgs/commit/cd3383596b2837ea168f7daf83f407b77e12aef3) lomiri.lomiri-api: init at 0.2.0
* [`79892d9c`](https://github.com/NixOS/nixpkgs/commit/79892d9c4f4e787f36a6dab08b54fc26c8ecbe71) lomiri.gmenuharness: init at 0.1.4
* [`da75051b`](https://github.com/NixOS/nixpkgs/commit/da75051bd0079fe015e3f2d95dc99bac4378a07f) lomiri.lomiri-api: 0.2.0 -> 0.2.1
* [`4a010408`](https://github.com/NixOS/nixpkgs/commit/4a010408a92bb4d87cd616837f702914068d109a) lomiri.gmenuharness: Fetch widget attribute rename patch
* [`d32d5d53`](https://github.com/NixOS/nixpkgs/commit/d32d5d5302224253b64a838a139ae668347a24e8) lomiri.cmake-extras: Change QML module installation path
* [`d777e147`](https://github.com/NixOS/nixpkgs/commit/d777e147c07817afbb88083d93784541b1b35b22) dynein: init at 0.2.1
* [`0000005e`](https://github.com/NixOS/nixpkgs/commit/0000005ec61c166d27aedc3195b189886a0118c3) mastodon: use fetchFromGitHub, fix shellcheck hints
* [`8f6c6952`](https://github.com/NixOS/nixpkgs/commit/8f6c69528e9bb138a8a04c37bd145ae69352ce5c) driversi686Linux.amdvlk: 2023.Q2.2 -> 2023.Q2.3
* [`ff214dbb`](https://github.com/NixOS/nixpkgs/commit/ff214dbbc91b0d43a34d3d5f343aba6b140b0780) nsync: 1.25.0 -> 1.26.0
* [`008dc892`](https://github.com/NixOS/nixpkgs/commit/008dc892205c39230477ad197ff6f06971f38388) Darktable: 4.2.1 -> 4.4.0
* [`fca3189a`](https://github.com/NixOS/nixpkgs/commit/fca3189a7a681108b67882972fb97fdf8a9c5123) k3s: Fix override
* [`086b323b`](https://github.com/NixOS/nixpkgs/commit/086b323b403fdd8a670e95fac1b318004b56dc6b) jetbrains: 2023.1.2 -> 2023.1.4
* [`79dfc50b`](https://github.com/NixOS/nixpkgs/commit/79dfc50bb8fa528b14675acbb55c4845c346f945) lib.systems.architectures: add microarchitecture levels
* [`fa176827`](https://github.com/NixOS/nixpkgs/commit/fa176827502349fd3b32ea1c3c40dcec6f411a36) python311Packages.pytest-freezer: 0.4.6 -> 0.4.8
* [`00ea4037`](https://github.com/NixOS/nixpkgs/commit/00ea4037bf72c6f9b859e05cd1858e5de1ddf5b4) gst_all_1.gst-plugins-rs: 0.10.8 -> 0.10.9
* [`adc534cf`](https://github.com/NixOS/nixpkgs/commit/adc534cf66ad27d2e0dffc66597076c2d847c984) firewalld: 1.3.3 -> 2.0.0
* [`3e96fd98`](https://github.com/NixOS/nixpkgs/commit/3e96fd980db95ad6268cb5ea79dcff6aaa21e098) nixos/network-interfaces: restrict IPv6 privacy address overrides to interface
* [`3d33c5c7`](https://github.com/NixOS/nixpkgs/commit/3d33c5c7dfb31c31d7383afbc91873dbdf18f582) n8n: add WEBHOOK_URL environment variable
* [`0212047f`](https://github.com/NixOS/nixpkgs/commit/0212047fcf535830739229f01fc12060c1ac30a0) cryptopp: 8.7.0 -> 8.8.0
* [`990b72f6`](https://github.com/NixOS/nixpkgs/commit/990b72f6af560fd43884338f2d442230d4c18137) nixos/activatable-system: Make system builder commands env independent
* [`7891c8cd`](https://github.com/NixOS/nixpkgs/commit/7891c8cdafff3bb59476e48136964dcfe933d7df) nixos/activatable-system: Move legacy variables to top-level
* [`9edad17d`](https://github.com/NixOS/nixpkgs/commit/9edad17d298a8f6cd7bdc6b540b74ff1f7f1338e) nixos/top-level: Remove unused builder variables
* [`89664199`](https://github.com/NixOS/nixpkgs/commit/89664199e18d45e1e629b011aaff0336987694b7) nixos/tests/switch-test.nix: Fix warnings
* [`772d6076`](https://github.com/NixOS/nixpkgs/commit/772d6076e825dc999a04245f7dfa3cb19082ec28) nixos: Add system.activatable flag for images that are pre-activated
* [`73833971`](https://github.com/NixOS/nixpkgs/commit/73833971e314fd61ca28fa14abe37381b2f1829a) maintainers: add conni2461
* [`15bcd972`](https://github.com/NixOS/nixpkgs/commit/15bcd972ccd4fb30489bd5d38223eee3e3a5b688) tailwindcss-bin: init at 3.3.2
* [`b8b52d76`](https://github.com/NixOS/nixpkgs/commit/b8b52d7668fb53049964dfca1cf574afd6f8d425) Use makeDesktopItems but copy it to the correct path in the buildCommand manualy.
* [`eaa0ea40`](https://github.com/NixOS/nixpkgs/commit/eaa0ea40f3abbdffaab1c6d3b33df94b7c3f8b62) nng: 1.6.0-prerelease update for rPackages.nanonext
* [`9c0aebc8`](https://github.com/NixOS/nixpkgs/commit/9c0aebc83fd6bdab7b0a0f60532e92bc3d4ef0f3) python310Packages.scikit-rf: 0.25.0 -> 0.27.1
* [`809f8c3d`](https://github.com/NixOS/nixpkgs/commit/809f8c3d7abf4b173832dbb90eae004a409100fe) asciidoctor: add the tilt gem
* [`2ac1da88`](https://github.com/NixOS/nixpkgs/commit/2ac1da889bfd305acee7f77083b74f65fb5b6008) mongodb-6_0: 6.0.6 -> 6.0.7
* [`4d897323`](https://github.com/NixOS/nixpkgs/commit/4d8973239b0d252eb44701cd468d4150468069a7) python3Packages.pygsl: init at 2.3.3
* [`19e48f0d`](https://github.com/NixOS/nixpkgs/commit/19e48f0da9d62be9b936ca4a33f6df23a7a123b2) buildNpmPackage: add npmWorkspace and npmPruneFlags args
* [`3990bb5b`](https://github.com/NixOS/nixpkgs/commit/3990bb5b5ee89fa64a6a6b5a3e486bdabe7290b9) doc/languages-frameworks/javascript: add npmWorkspace and npmPruneFlags args
* [`ccbf9160`](https://github.com/NixOS/nixpkgs/commit/ccbf91600960170f88fc95981219911959214100) python311Packages.objgraph: 3.5.0 -> 3.6.0
* [`2f6f50e8`](https://github.com/NixOS/nixpkgs/commit/2f6f50e8e711bf03fe707372f4d91b3353448ceb) python3Packages.bottombar: init at 1.0
* [`8a05296a`](https://github.com/NixOS/nixpkgs/commit/8a05296acc89a9019da6691890f7aa60b2abd54b) python3Packages.nutils: 7.2 -> 7.3
* [`363c846d`](https://github.com/NixOS/nixpkgs/commit/363c846d778942c8025bbd7c72b9ec1a1979da44) nixos/iso-image: make graphical grub configurable
* [`e4f361f3`](https://github.com/NixOS/nixpkgs/commit/e4f361f35238ebcc23be262c4a32d3e6ff53ddfc) installation-cd: enable graphicalGrub
* [`9af03832`](https://github.com/NixOS/nixpkgs/commit/9af0383296227450889a6d41107d892c29eb0c21) prefetch-npm-deps: support NIX_BUILD_CORES
* [`aa2f51f0`](https://github.com/NixOS/nixpkgs/commit/aa2f51f0d2522b6eea996930e005b49a0a195798) prefetch-npm-deps: update deps and base64 usage
* [`d2897e46`](https://github.com/NixOS/nixpkgs/commit/d2897e463dcf858bdba4261fc05a88701ebbd6e4) prefetch-npm-deps: use isahc instead of ureq
* [`ba7a869a`](https://github.com/NixOS/nixpkgs/commit/ba7a869a9a6090e59239b4720426e70234aeefb3) prefetch-npm-deps: add env_logger
* [`a5b7078a`](https://github.com/NixOS/nixpkgs/commit/a5b7078a2d18be2801dec11d868d254699d4188b) cdesktopenv: 2.3.2 -> 2.5.1
* [`a83d76a2`](https://github.com/NixOS/nixpkgs/commit/a83d76a28743d3a380c4a80c3ee3e588dc6a3fc5) ols: init at fd13619
* [`ce54db6f`](https://github.com/NixOS/nixpkgs/commit/ce54db6fe127c5199e088273fa0b275ef7f1cb44) lib.generators.toINIWithGlobalSection: give sections a default
* [`bdda5257`](https://github.com/NixOS/nixpkgs/commit/bdda52578dbd284cedc50798016fdea6c5f0a217) proxmox-backup-client: fetch external patches from AUR package
* [`5e714a59`](https://github.com/NixOS/nixpkgs/commit/5e714a5952cda67af1ab60fc8e7f2241a4840596) proxmox-backup-client: 2.4.1 -> 3.0.1
* [`5d511d1a`](https://github.com/NixOS/nixpkgs/commit/5d511d1a1b792b2c239c16261ac1bc9ba5c5ea88) proxmox-backup-client: add changelog url
* [`8e367709`](https://github.com/NixOS/nixpkgs/commit/8e367709d4276631fcf41e8219864605f7765830) anytype: 0.31.0 -> 0.32.3
* [`eb8ac66e`](https://github.com/NixOS/nixpkgs/commit/eb8ac66ec494649dda3eb842cac775250850909d) sozu: 0.13.6 -> 0.15.0
* [`f1ecc7ee`](https://github.com/NixOS/nixpkgs/commit/f1ecc7ee4184ac816fb8548ebc1927d76db5460d) exa: 0.10.1 -> unstable-2023-03-01
* [`0fab94a8`](https://github.com/NixOS/nixpkgs/commit/0fab94a8446934d5f27ffc21f07d5b5187970369) xonsh: Add wrapper
* [`570f3efd`](https://github.com/NixOS/nixpkgs/commit/570f3efd1d447597fd1d468188d785dfe1207b44) flutter: Separate cache and unwrapped derivations
* [`4c0e06a9`](https://github.com/NixOS/nixpkgs/commit/4c0e06a9fda5384bf7f7c1c97bbd969c0fb5a750) scaphandre: add passthru updateScript & testVersion
* [`f856229c`](https://github.com/NixOS/nixpkgs/commit/f856229c9af1b59f4573c629578ba52694d02858) nixos/prometheus/exporters: adjust scaphandre assertions
* [`3bb60d94`](https://github.com/NixOS/nixpkgs/commit/3bb60d94c28c2ba80d9a4be14b498d3d35dc2791) ryujinx: 1.1.900 -> 1.1.942
* [`80e58241`](https://github.com/NixOS/nixpkgs/commit/80e58241b3fa9ff9de9945fb0eb36d836a2c41b0) proxmox-backup-client: add passthru.tests.version
* [`05e5ae68`](https://github.com/NixOS/nixpkgs/commit/05e5ae68399451d6efa6e1b33d7a7dbda567432a) libisofs: add darwin support
* [`e60b71c9`](https://github.com/NixOS/nixpkgs/commit/e60b71c93d3a2b4a5efb3a9943a3948352d12bdf) prometheus-snmp-exporter: 0.21.0 -> 0.22.0
* [`61aa98e4`](https://github.com/NixOS/nixpkgs/commit/61aa98e412d8150f7a57b39c57b4751d6ae7e2d8) helmfile: 0.154.0 -> 0.155.0
* [`831a625b`](https://github.com/NixOS/nixpkgs/commit/831a625b9542b3d26eb387c4d78732d80dae2e29) python310Packages.requests-unixsocket: patch to make compatible with urllib3 2+
* [`2efcf829`](https://github.com/NixOS/nixpkgs/commit/2efcf8291e11b45c9549c8b45a371e033f1c8eb6) lkl: Let `mount` find `lklfuse` mount helper
* [`be340912`](https://github.com/NixOS/nixpkgs/commit/be34091292b2bb0107f111c575f4fa93cc990fdf) skeema: 1.10.0 -> 1.10.1
* [`c8ae88d9`](https://github.com/NixOS/nixpkgs/commit/c8ae88d97b35ba575e27f8b72663783118bc329b) lib.platforms.mips{,64}-embedded: init
* [`041256b3`](https://github.com/NixOS/nixpkgs/commit/041256b33b5e2e8ec19d8e5c783965295155e0e9) goreleaser: 1.18.2 -> 1.19.0
* [`82f3b53e`](https://github.com/NixOS/nixpkgs/commit/82f3b53ef1f8f9536ed44d2395cd64f7978f0104) mullvad-vpn: 2023.3 -> 2023.4
* [`50a75a4c`](https://github.com/NixOS/nixpkgs/commit/50a75a4c09fae38d0f4cc3e2d5115a55425e3350) python310Packages.cherrypy: set CI environment variable
* [`5975e6d7`](https://github.com/NixOS/nixpkgs/commit/5975e6d734e0b207c94e936ffaa8ac8f252da1b3) rabbitmq-server: 3.12.0 -> 3.12.1
* [`3bdd9bf5`](https://github.com/NixOS/nixpkgs/commit/3bdd9bf5d37a77dc6ff83bd0f315ed3e4b1f8d8d) guile-fibers: 1.2.0 -> 1.3.1
* [`16726417`](https://github.com/NixOS/nixpkgs/commit/167264179b81749dc5550bd29c7efa4e3e7b782e) buildFHSEnv: cleanup
* [`62b2adc7`](https://github.com/NixOS/nixpkgs/commit/62b2adc753eaec8c3b3b10593055e96450c82b36) buildFHSEnv: add multiArch flag
* [`f0c58f6e`](https://github.com/NixOS/nixpkgs/commit/f0c58f6e96d821fcb32b507cb453df4fef8f59cc) tree-wide: use new multiArch buildFHSEnv argument
* [`173962ee`](https://github.com/NixOS/nixpkgs/commit/173962eef901c40356d14bfdfe223194427f32ea) steam: declare need for multiArch explicitly
* [`ff777e9f`](https://github.com/NixOS/nixpkgs/commit/ff777e9f390f86e9ce6dd1d160a669c9b1b12d98) lutris: declare need for multiArch explicitly
* [`7bdd9b33`](https://github.com/NixOS/nixpkgs/commit/7bdd9b33d4b7c7563fa039b185de9a1abc47a700) python310Packages.timetagger: 23.4.1 -> 23.6.1
* [`0ec1adc4`](https://github.com/NixOS/nixpkgs/commit/0ec1adc42af2a38ff7419685a27286031d170619) ceph-csi: 3.8.0 -> 3.9.0
* [`9728d07c`](https://github.com/NixOS/nixpkgs/commit/9728d07c0810d2b7500727cb51050e5bd88038bb) python310Packages.ansible: 8.0.0 -> 8.1.0
* [`9b5dc4c9`](https://github.com/NixOS/nixpkgs/commit/9b5dc4c95f2fe881565234c35446b82e487fa03c) python310Packages.jaraco-abode: 5.0.1 -> 5.1.0
* [`d25d899c`](https://github.com/NixOS/nixpkgs/commit/d25d899caa3b29060db0286ea42dcb12a0f716c7) podofo010: 0.10.0 -> 0.10.1
* [`8c331344`](https://github.com/NixOS/nixpkgs/commit/8c33134465ee45d2a2d9a060fe0da6c1232e9a1b) nixos-render-docs: don't double-escape link titles
* [`effbaf0a`](https://github.com/NixOS/nixpkgs/commit/effbaf0ab40a06d547a42ec50073aa500d4bbbd5) nixos-render-docs: maybe omit link target files
* [`2bf3bb4f`](https://github.com/NixOS/nixpkgs/commit/2bf3bb4f6b70a69d43c8c50eac735e1e95d16eb4) nixos-render-docs: hide nav headers/footers if not needed
* [`bc9e913c`](https://github.com/NixOS/nixpkgs/commit/bc9e913c3f6881e4602c5956b342642090456c84) cargo-public-api: add curl dependency
* [`b962ff92`](https://github.com/NixOS/nixpkgs/commit/b962ff92ff414b325c1b73f24f2ff3b0ae613dd7) nixos-render-docs: add support for section tocs
* [`2a319ab3`](https://github.com/NixOS/nixpkgs/commit/2a319ab3d3b7480e9155e50575178c618918691c) go-cqhttp: 1.0.1 -> 1.1.0
* [`1fe03311`](https://github.com/NixOS/nixpkgs/commit/1fe03311b054c744603a428c585fc90771ed5b33) oil: remove obsolete readline workaround
* [`ac8f90be`](https://github.com/NixOS/nixpkgs/commit/ac8f90bee64dce1e3f1a12f166c4239a2351139f) sagittarius-scheme: 0.9.9 -> 0.9.10
* [`b3dceb7b`](https://github.com/NixOS/nixpkgs/commit/b3dceb7b378baeca1fce587e3824d3d70e828204) gmic: 3.2.5 -> 3.2.6
* [`a251dc3f`](https://github.com/NixOS/nixpkgs/commit/a251dc3f85bfe85ad02fe8e472b156d970dd4193) workrave: 1.10.50 -> 1.10.51.1
* [`62b79368`](https://github.com/NixOS/nixpkgs/commit/62b79368803f82f1435dc099fd0f71559be3530e) python310Packages.python-lsp-server: 1.7.3 -> 1.7.4
* [`8c2d14a6`](https://github.com/NixOS/nixpkgs/commit/8c2d14a6b850458020fd4ce079a90ee87e64c7a6) nixos-render-docs: add image support
* [`e5e738b7`](https://github.com/NixOS/nixpkgs/commit/e5e738b72a879f7c12b314df11f0d1528fc066dc) nixos-render-docs: genericize block numbering
* [`8fb4cf8b`](https://github.com/NixOS/nixpkgs/commit/8fb4cf8b7c6f9d180a59e0f33405bc6a61e24d60) nixos-render-docs: add support for figures
* [`ac7be1f1`](https://github.com/NixOS/nixpkgs/commit/ac7be1f106c139f6153576a80372b2e216f005fc) nixos-render-docs: add support for tables
* [`538b3d1b`](https://github.com/NixOS/nixpkgs/commit/538b3d1b3c12cc07f00dcec374b16a469b3679ff) nixos-render-docs: add footnote support
* [`a5414c29`](https://github.com/NixOS/nixpkgs/commit/a5414c29a06be9e00d1318cdeb609a42586a976a) doc: build placeholder epub in its own derivation
* [`b521f451`](https://github.com/NixOS/nixpkgs/commit/b521f451a3b2dcee1c72cd11a87d14249b125ce9) doc-support: don't expose locationsXml
* [`ce525957`](https://github.com/NixOS/nixpkgs/commit/ce525957545a0d307856b1ab8816b589871d65fa) rabbitmq-server: add changelog to meta
* [`be4d19ff`](https://github.com/NixOS/nixpkgs/commit/be4d19ff1a9a327ae805fdb344470ed6450256fc) doc: render nixpkgs manual with nrd
* [`f397309f`](https://github.com/NixOS/nixpkgs/commit/f397309f4e6c7a219a7703b629f6a4e8d4e7a58b) doc: remove remnants of docbook times
* [`70cbd8c6`](https://github.com/NixOS/nixpkgs/commit/70cbd8c6c07378c7bf8b6d224d904c33a430914f) doc: pull option docs out of doc-support
* [`fc1b58b5`](https://github.com/NixOS/nixpkgs/commit/fc1b58b593bf8257a7757e69b9a70c2ca3337e20) doc: inline doc-support to main drv
* [`1d87cbda`](https://github.com/NixOS/nixpkgs/commit/1d87cbdaad01849c0fe9723bf1b7d015728b58ca) python311Packages.pyheck: init at 0.1.5
* [`610f826d`](https://github.com/NixOS/nixpkgs/commit/610f826d4acaff263317ff6bb74d0848830692eb) foomatic-db: unstable 2023-03-30 -> 2023-06-30
* [`71753a2f`](https://github.com/NixOS/nixpkgs/commit/71753a2f26e4a916aa3db1111dcc76ae23d5f21f) python311Packages.dotwiz: init at 0.4.0
* [`eddeb83f`](https://github.com/NixOS/nixpkgs/commit/eddeb83f1ca86ebad92e112da94e6751d9de304c) shattered-pixel-dungeon: include XDG desktop and icon files
* [`863f0ec6`](https://github.com/NixOS/nixpkgs/commit/863f0ec663a6c650953e68ba6bb5b0e73046aa57) Update pkgs/servers/go-cqhttp/default.nix
* [`54817dd1`](https://github.com/NixOS/nixpkgs/commit/54817dd19569fce29cc67ad8bc960fc18f5d3c18) scarab: extract and install icons with icoutils
* [`00ee6c28`](https://github.com/NixOS/nixpkgs/commit/00ee6c28d39b3c7580b1a0b868a56a27c90cd127) deepsecrets: init at 1.0.6
* [`c8def495`](https://github.com/NixOS/nixpkgs/commit/c8def49591b86c54374b315470909e4ed22a116d) scarab: add custom updateScript
* [`2cf3f4c9`](https://github.com/NixOS/nixpkgs/commit/2cf3f4c93111418e7a38f5f0ab6909900ec011fd) scarab: 1.31.0.0 -> 1.33.0.0
* [`8361dd68`](https://github.com/NixOS/nixpkgs/commit/8361dd68894dd5773a9aee77aaa81b30a1811334) unityhub: edit libraries, update meta
* [`b1079e41`](https://github.com/NixOS/nixpkgs/commit/b1079e41dca991b42c31a2ca7fc0281c77ed196d) maintainers: add fricklerhandwerk
* [`c2baf09d`](https://github.com/NixOS/nixpkgs/commit/c2baf09dbe26b86a3446689dfb45acdc98f20ee5) sigtop: init at 2022-03-21
* [`7d184531`](https://github.com/NixOS/nixpkgs/commit/7d184531ad180e33b4bc6f35b31ea1aa1d69513a) reorder inputs
* [`fd3292ca`](https://github.com/NixOS/nixpkgs/commit/fd3292cafc3135e42e888fd87467dc92c7d1a7e5) update hash format
* [`fe1ef16e`](https://github.com/NixOS/nixpkgs/commit/fe1ef16ea9814ddf2e8b54dadbd4997d09e6f902) update to 0.3.1
* [`97b602a7`](https://github.com/NixOS/nixpkgs/commit/97b602a7b89ead508c900612770ae439e74b1b51) python310Packages.skorch: 0.13.0 -> 0.14.0
* [`d51ebb61`](https://github.com/NixOS/nixpkgs/commit/d51ebb617312413931abe160bd526dca2f40c7de) nixos/networkd: refactor
* [`ff017b99`](https://github.com/NixOS/nixpkgs/commit/ff017b995248f7c51f0b27e6beaad92af2859710) opensbi: 1.2 -> 1.3
* [`015d143f`](https://github.com/NixOS/nixpkgs/commit/015d143f0ec3f8107cb4531f5fad28e889dedd99) lesspipe: 2.07 -> 2.08
* [`3ac39cd5`](https://github.com/NixOS/nixpkgs/commit/3ac39cd5ffd9c69c0edc1781b0afad19046481bf) iosevka-bin: 24.1.3 -> 24.1.4
* [`415b87f2`](https://github.com/NixOS/nixpkgs/commit/415b87f2ebd5a70538f02fee8ce86875d7d4531b) panoply: 5.2.7 -> 5.2.8
* [`a4b7a625`](https://github.com/NixOS/nixpkgs/commit/a4b7a6253286337e212da47835fd3785ea861abb) tsm-client: update package metadata urls
* [`f194412e`](https://github.com/NixOS/nixpkgs/commit/f194412e36bff594767b95c4bd023c653a4cae41) protoc-gen-go: 1.29.1 -> 1.31.0
* [`bc6bea72`](https://github.com/NixOS/nixpkgs/commit/bc6bea7274bab0cecef383f3b085a8e44c90aceb) samplebrain: init at 0.18.5
* [`5a62c9ea`](https://github.com/NixOS/nixpkgs/commit/5a62c9eaba58e99578caa08bf2f3e803ccbfc24f) arrow-cpp: 12.0.0 -> 12.0.1
* [`4a667af8`](https://github.com/NixOS/nixpkgs/commit/4a667af888f4fa330f4ade4d2c8fd6da4911c3be) python310Packages.jaraco_collections: add "env." prefix
* [`22d953a3`](https://github.com/NixOS/nixpkgs/commit/22d953a3193740e1dfef52f9c7488fbb1cb68c0c) peertube: enable building on Darwin and aarch64-linux
* [`47b4b9fc`](https://github.com/NixOS/nixpkgs/commit/47b4b9fc9fb2871e538f70348775db351803d7d9) perlPackages.FinanceQuote: 1.56 -> 1.57
* [`7357b109`](https://github.com/NixOS/nixpkgs/commit/7357b109beb2a925734f937e1a4ff8385d462cef) halloy: init at 23.1-alpha1
* [`7dd840c3`](https://github.com/NixOS/nixpkgs/commit/7dd840c31d7276dfb3df3626399dce994f4b99a4) python310Packages.pymunk: 6.4.0 -> 6.5.1
* [`1539e263`](https://github.com/NixOS/nixpkgs/commit/1539e263f81056237160741bedbaa49623cdf5cb) simgrid: 3.32 -> 3.34
* [`1862e828`](https://github.com/NixOS/nixpkgs/commit/1862e828f5739f45806e88e820fafb5690ae00a4) metal-cli: 0.14.1 -> 0.15.0
* [`9223fdbd`](https://github.com/NixOS/nixpkgs/commit/9223fdbd6db97956966810b8445f066f29bb16c0) python311Packages.dirty-equals: add changelog to meta
* [`1130d57a`](https://github.com/NixOS/nixpkgs/commit/1130d57afb05ef863cb2dfdadae917fd6cc957c7) gollum: add maintainer
* [`0a85190a`](https://github.com/NixOS/nixpkgs/commit/0a85190a977f47dd93abe8d5b8da120976d880a0) wpa_supplicant: enable WPA3-SAE-PK
* [`4bec3f20`](https://github.com/NixOS/nixpkgs/commit/4bec3f204362fa22a0740c8a572ffef3b322596d) hostapd: enable new stable features such as WiFi6 and structure .config
* [`1fa9f03e`](https://github.com/NixOS/nixpkgs/commit/1fa9f03eecdbe55248fd5971b66f71c0104115fe) nixos/hostapd: rewrite to support multi-AP, password from file, and more
* [`89ea487a`](https://github.com/NixOS/nixpkgs/commit/89ea487a360ed21c0e45964639594ba74598abb7) teams-for-linux: 1.1.8 -> 1.1.9
* [`77de6276`](https://github.com/NixOS/nixpkgs/commit/77de62763602af0f2f17f45f7881a552124f983b) erdtree: 3.1.1 -> 3.1.2
* [`9a77c9d7`](https://github.com/NixOS/nixpkgs/commit/9a77c9d74e9834746cedaae460e8169ecdede9f5) gtree: 1.8.5 -> 1.8.6
* [`a7023da6`](https://github.com/NixOS/nixpkgs/commit/a7023da6411760aa977d7f315ba4c99c68e084c5) govc: 0.30.4 -> 0.30.5
* [`eade7923`](https://github.com/NixOS/nixpkgs/commit/eade7923a0823c7367ba2da594331e99d4a4e271) python311Packages.pytest-examples: init at 0.0.9
* [`9fb92044`](https://github.com/NixOS/nixpkgs/commit/9fb920443c849adb84167f0b89652591503b2ad2) python311Packages.dirty-equals: 0.5.0 -> 0.6.0
* [`f548cc50`](https://github.com/NixOS/nixpkgs/commit/f548cc50b0a0b484799254abe75ec9a32f281546) malt: 1.2.1 -> 1.2.2
* [`2db28381`](https://github.com/NixOS/nixpkgs/commit/2db283819ec54421fda37279b5ebc200607a58c3) cbmc: 5.76.1 -> 5.86.0
* [`71c2d9fa`](https://github.com/NixOS/nixpkgs/commit/71c2d9fadcae1b9d5ead5e67101bd2839aa7751a) linkerd_edge: 23.6.2 -> 23.6.3
* [`b3ab2efa`](https://github.com/NixOS/nixpkgs/commit/b3ab2efa17ce6b781e2362bee49df75de426c412) balena-cli: 16.5.0 -> 16.6.2
* [`d7e721f6`](https://github.com/NixOS/nixpkgs/commit/d7e721f614aef3e6bd7f4dfb6c1526e00d257fad) plausible: fix admin user password seed and SMTP passwords
* [`df9dd08c`](https://github.com/NixOS/nixpkgs/commit/df9dd08c608d7fd1876bd99e0c5cb7f2e7d084cb) dae: 0.1.10.p1 -> 0.2.0
* [`73d24f8a`](https://github.com/NixOS/nixpkgs/commit/73d24f8aacaac15443505f2a5efbda21beb83543) dasel: add shell completions to output
* [`ab01576c`](https://github.com/NixOS/nixpkgs/commit/ab01576cb1570db4b971f87bddb13d9c93f8b4bb) sddm-chili-theme: init at 0.1.5
* [`a8999715`](https://github.com/NixOS/nixpkgs/commit/a8999715994568adbbb2a54c823db7aadfbfd10d) nixos/nix-daemon: fix grammatical mistake in description
* [`4df93f37`](https://github.com/NixOS/nixpkgs/commit/4df93f374d8372bd1af11a8967e8ac20c4a3b99b) python3Packages.mautrix: 0.19.16 -> 0.20.0
* [`cf118b5f`](https://github.com/NixOS/nixpkgs/commit/cf118b5faff805cdb2dfb5490e9f1f6833452ae9) kubelogin-oidc: 1.27.0 -> 1.28.0
* [`bb55edd5`](https://github.com/NixOS/nixpkgs/commit/bb55edd515ac095c775652923d38b40637c690e9) mautrix-telegram: 0.14.0 -> 0.14.1
* [`cb16c505`](https://github.com/NixOS/nixpkgs/commit/cb16c505719450d51cb347f73e4d273be4380cb0) veryfasttree: 3.1.1 -> 4.0
* [`f003f31c`](https://github.com/NixOS/nixpkgs/commit/f003f31ca1b358b8836c7d69a633589102199b3a) bazarr: 1.2.1 -> 1.2.2
* [`0000006f`](https://github.com/NixOS/nixpkgs/commit/0000006fe82e889af95a716d02702866968187f1) python310Packages.matplotlib: disable tkinter for PyPy
* [`a7d4f895`](https://github.com/NixOS/nixpkgs/commit/a7d4f895ffd716770296808a727cc62889c5c454) trilium-desktop: 0.60.3 -> 0.60.4
* [`0b423ab8`](https://github.com/NixOS/nixpkgs/commit/0b423ab82c4b5e7890f6f343f96c6ed37cfc5299) frugal: 3.16.23 -> 3.16.24
* [`bb17f9bf`](https://github.com/NixOS/nixpkgs/commit/bb17f9bf9776a47772a53efd48f002199d285192) kaniko: 1.11.0 -> 1.12.0
* [`1efeb630`](https://github.com/NixOS/nixpkgs/commit/1efeb63005c617f623b826c26efdfadd0d398850) ecs-agent: 1.72.0 -> 1.73.0
* [`95dad9c0`](https://github.com/NixOS/nixpkgs/commit/95dad9c02ddc013334333cfb2883a94dcc0e3ad0) vscode-extensions.kahole.magit: 0.6.40 -> 0.6.43
* [`5b2c7a9a`](https://github.com/NixOS/nixpkgs/commit/5b2c7a9a5234a77dcc2fff98d9c63f82477bab56) python310Packages.plaid-python: 14.1.0 -> 15.0.0
* [`28216d7d`](https://github.com/NixOS/nixpkgs/commit/28216d7debb565a85bb308a34081b1bf4b691d5d) python311Packages.nose3: disable tests also on python 3.11
* [`a10e518f`](https://github.com/NixOS/nixpkgs/commit/a10e518fdfd4e99a21fcd2479dc425a286978735) palemoon-bin: 32.2.0 -> 32.2.1
* [`642bf367`](https://github.com/NixOS/nixpkgs/commit/642bf367bf9aa139a89c3a4523d7d6890647adf3) easyeffects: 7.0.4 -> 7.0.5
* [`7b337580`](https://github.com/NixOS/nixpkgs/commit/7b337580a3e56dfb7cfde8fe8cc31e2e71cc74eb) pypy3Packages.sphinx: disable broken tests
* [`e2aa6f11`](https://github.com/NixOS/nixpkgs/commit/e2aa6f1104103b2a84b2895ddc5c77e25edd33b6) whitesur-icon-theme: 2023-01-08 -> 2023-07-03
* [`eecdba31`](https://github.com/NixOS/nixpkgs/commit/eecdba31eb8f0ad0ecbf1166c1d90a1fc978b909) kubectl-cnpg: init at 1.20.1
* [`683ac85e`](https://github.com/NixOS/nixpkgs/commit/683ac85ec308532f93cc1cab747ceb7667cdc0b7) python310Packages.opuslib: fix tests with libopus 1.4
* [`6cdb0811`](https://github.com/NixOS/nixpkgs/commit/6cdb0811911557b8d35987c7bc5eb33cda8df6f0) elixir_1_15: 1.15.1 -> 1.15.2
* [`3a077754`](https://github.com/NixOS/nixpkgs/commit/3a077754598b1d23b12219170e63fd6e59445228) p2pool: 3.4 -> 3.5
* [`748708bd`](https://github.com/NixOS/nixpkgs/commit/748708bd74a4bfa65b7446d504b8adff06d7b502) phpExtensions.blackfire: use `finalAttrs` pattern
* [`bce4ab58`](https://github.com/NixOS/nixpkgs/commit/bce4ab5812fde862ae0ef6b153af285cfda22533) wazero: init at 1.2.1
* [`9ec00a91`](https://github.com/NixOS/nixpkgs/commit/9ec00a91201c1e63d57e089b9bfc689e1bc86ed8) spyre: pull in patches to fix build on Darwin
* [`5122cffd`](https://github.com/NixOS/nixpkgs/commit/5122cffda9e9493cf1c6abc415f176d07fb1d531) kics: 1.7.1 -> 1.7.2
* [`20fbb1ec`](https://github.com/NixOS/nixpkgs/commit/20fbb1ec9cf178fad55e99664b5f98e16f71f27e) klipper-estimator: 3.4.0 -> 3.5.0
* [`d29263b4`](https://github.com/NixOS/nixpkgs/commit/d29263b4470198e69ab45ae35b8aa2535863bbb2) kubevirt: 0.59.1 -> 0.59.2
* [`6e3e0b14`](https://github.com/NixOS/nixpkgs/commit/6e3e0b14d7e4c6eba75bc72967ab098473eed9db) hexfiend: init at 2.16.0
* [`58e19ff2`](https://github.com/NixOS/nixpkgs/commit/58e19ff2daf82d049f0f5962e2fef004f05f3ab9) tidb: 7.1.0 -> 7.2.0
* [`74ca5540`](https://github.com/NixOS/nixpkgs/commit/74ca55400e6c559ce2452bb39b0b3c9e83d3abb1) mastodon: add runHooks
* [`586391c3`](https://github.com/NixOS/nixpkgs/commit/586391c324654e46832e16ce1c8e0f105b6ef71e) python310Packages.cons: 0.4.5 -> 0.4.6
* [`6c00f165`](https://github.com/NixOS/nixpkgs/commit/6c00f165ff7c2d3dee077f665405640e4d7e9262) python310Packages.pvlib: 0.7.2 -> 0.10.0
* [`7656e214`](https://github.com/NixOS/nixpkgs/commit/7656e2149d4d3618c301f97d7e7b2dc33c7d6a70) notmuch: add support for sexp queries
* [`3ca85596`](https://github.com/NixOS/nixpkgs/commit/3ca8559625a626309023f9928db13227184a5577) notmuch: install notmuch-git
* [`b3c21a7a`](https://github.com/NixOS/nixpkgs/commit/b3c21a7a0e92d8517bcebc2b2a41f1dae8e4376a) python310Packages.policy-sentry: 0.12.6 -> 0.12.7
* [`06a0c1c7`](https://github.com/NixOS/nixpkgs/commit/06a0c1c7e47934ead76bf1065d6954e52b93e255) python310Packages.django-maintenance-mode: fix build
* [`3e1716fe`](https://github.com/NixOS/nixpkgs/commit/3e1716fe60431a047654ec2c04aa64adda227f9c) python310Packages.pytrends: 4.9.0 -> 4.9.2
* [`6c7baf2d`](https://github.com/NixOS/nixpkgs/commit/6c7baf2d25d235190997e373f34a242cec3d198f) corsix-th: init at 0.66
* [`13499263`](https://github.com/NixOS/nixpkgs/commit/13499263c982f3cfddd6a7b7b228091ab0720e55) python310Packages.python-binance: fix build
* [`336cfa75`](https://github.com/NixOS/nixpkgs/commit/336cfa7585cfbd311eb0772d53883bb8a7a9fb6e) cargo-tarpaulin: 0.26.0 -> 0.26.1
* [`2c8953ca`](https://github.com/NixOS/nixpkgs/commit/2c8953ca9a6d7ea57e735c7d940efdc4e155cef0) buildah: 1.30.0 -> 1.31.0
* [`3d7ec184`](https://github.com/NixOS/nixpkgs/commit/3d7ec18427eff03464cc7eda86a2aa51e021b346) python310Packages.openstacksdk: 1.2.0 -> 1.3.1
* [`eb287469`](https://github.com/NixOS/nixpkgs/commit/eb28746930f5bbc3fe71ed7ee7dbf885dd055305) iptsd: fix build
* [`aede03d5`](https://github.com/NixOS/nixpkgs/commit/aede03d51004e4b356a8f70faa054325dedb12e5) gallery-dl: 1.25.6 -> 1.25.7
* [`2d9440a4`](https://github.com/NixOS/nixpkgs/commit/2d9440a46744ee794165846bd2579d1eff52d8c5) twspace-crawler: 1.12.1 -> 1.12.2
* [`e47ce504`](https://github.com/NixOS/nixpkgs/commit/e47ce5045352cd24a46c5275728ac525e398416f) atomic-swap: 0.4.0 -> 0.4.1
* [`9eade54d`](https://github.com/NixOS/nixpkgs/commit/9eade54db008c4a1eccee60c9080d00d47932918) hcledit: 0.2.8 -> 0.2.9
* [`70051f80`](https://github.com/NixOS/nixpkgs/commit/70051f8071090f4b3c0abeee554c7cbb5bbcbbf3) python310Packages.jiwer: 3.0.1 -> 3.0.2
* [`d6dc969a`](https://github.com/NixOS/nixpkgs/commit/d6dc969aa659c05534f368fe5b5107540239fdb5) gede: 2.18.2 -> 2.18.3
* [`71757743`](https://github.com/NixOS/nixpkgs/commit/71757743efc8a32d0b8d2aa64b1819c313e83d57) clash-verge: 1.3.2 -> 1.3.3
* [`d183e16c`](https://github.com/NixOS/nixpkgs/commit/d183e16cb1306aeb76fdb6ccec9b8b72b3273364) fpattern: fix: skip dev output, use explicit repo name
* [`3e838cfe`](https://github.com/NixOS/nixpkgs/commit/3e838cfed2bce578f4d72fd81c810550e3f9d2e6) mongodb-compass: 1.38.0 -> 1.38.2
* [`097299ac`](https://github.com/NixOS/nixpkgs/commit/097299ac4fc6f939d276ff287a445adcf732b338) coqPackages.CoLoR: 1.8.3 → 1.8.4
* [`118f623a`](https://github.com/NixOS/nixpkgs/commit/118f623af4d32ae1f308e35af4c7941f15feee13) python310Packages.lazy-loader: 0.2 -> 0.3
* [`45ab9549`](https://github.com/NixOS/nixpkgs/commit/45ab9549752acb6c9953dcf10289728fc1d22813) python310Packages.cons: update changelog
* [`3fd1391d`](https://github.com/NixOS/nixpkgs/commit/3fd1391d450045cae791de71fa99c1f38f713adb) python310Packages.cons: add format
* [`f1f231cf`](https://github.com/NixOS/nixpkgs/commit/f1f231cfaa3beda414b7122ba095befbe2c1126e) namecoin: 24.0 -> 25.0
* [`83f005b4`](https://github.com/NixOS/nixpkgs/commit/83f005b42a80e46919a915ee08d82558c8a03d61) python310Packages.jiwer: add changelog to meta
* [`2d36f513`](https://github.com/NixOS/nixpkgs/commit/2d36f513c29fda83529dab75241fc9f94c7a29db) python310Packages.jiwer: disble on unsupported Python releases
* [`6dc2e6f3`](https://github.com/NixOS/nixpkgs/commit/6dc2e6f34fcfc19d3e2280557671268f61d1297c) vscode-extensions.esbenp.prettier-vscode: 9.16.0 -> 9.19.0
* [`65585d6c`](https://github.com/NixOS/nixpkgs/commit/65585d6c539097c829dff8c1bbad90ee3ab3bc2c) nixos/anuko-time-tracker: improve module options
* [`144afddc`](https://github.com/NixOS/nixpkgs/commit/144afddc0b100305efe35c555f8f02cc30a54db3) python310Packages.cachecontrol: 0.12.11 -> 0.13.1
* [`61301ffc`](https://github.com/NixOS/nixpkgs/commit/61301ffc9ed71b3d83258181a43c9334904b637c) pip-audit: 2.5.6 -> 2.6.0
* [`3ac20dcf`](https://github.com/NixOS/nixpkgs/commit/3ac20dcf73fde5e30b19ec81cad5f1a4ed0a256a) deepin.deepin-editor: 6.0.7 -> 6.0.10
* [`4563446e`](https://github.com/NixOS/nixpkgs/commit/4563446e28ccdfdae3b437390ce11081a7493bca) erigon: 2.47.0 -> 2.48.0
* [`47e7af84`](https://github.com/NixOS/nixpkgs/commit/47e7af84d10f5a0caf9e3d33bbbb09986bb22ce1) maintainers: remove earthengine
* [`bf61b6a5`](https://github.com/NixOS/nixpkgs/commit/bf61b6a502d4ffdfc8125c570ce11d9b63e55711) python310Packages.types-pyopenssl: 23.2.0.0 -> 23.2.0.1
* [`e4a654ea`](https://github.com/NixOS/nixpkgs/commit/e4a654ea5aa6b742e8f1b4ea91fe4bd60d07b945) cimg: 3.2.5 -> 3.2.6
* [`98f2ff08`](https://github.com/NixOS/nixpkgs/commit/98f2ff08e3242666c04388bce95e09780e7e1a9c) gmic-qt: 3.2.5 -> 3.2.6
* [`99c38239`](https://github.com/NixOS/nixpkgs/commit/99c3823939cc7aef91221f3eb3aa63b130cc619d) urn-timer: unstable-2023-03-18 -> unstable-2023-07-01
* [`caf192ef`](https://github.com/NixOS/nixpkgs/commit/caf192effc5ab1b8937139cfcfa18847f1d42040) python310Packages.sphinx-navtree: remove
* [`4acdff5e`](https://github.com/NixOS/nixpkgs/commit/4acdff5e91f003a837c381344e8e8064b2becfe3) coqPackages.interval: 4.6.1 → 4.7.0
* [`70965da5`](https://github.com/NixOS/nixpkgs/commit/70965da5f8004a403e2c462808a4af206fbd648d) clojure-lsp: 2023.05.04-19.38.01 -> 2023.07.01-22.35.41
* [`0a93a9c6`](https://github.com/NixOS/nixpkgs/commit/0a93a9c699ea87834eabd444ea275f8da32db9d6) python310Packages.sphinxcontrib-bayesnet: unmark broken
* [`7919df9b`](https://github.com/NixOS/nixpkgs/commit/7919df9b60e92925350f61413d290ec5c2fb6f62) python310Packages.sphinxcontrib-bayesnet: fix format
* [`4404f3a1`](https://github.com/NixOS/nixpkgs/commit/4404f3a19bb69f96fbeaa7d2ab4a5cc4d8a52210) prowlarr: 1.5.2.3484 -> 1.6.3.3608
* [`87a15ed5`](https://github.com/NixOS/nixpkgs/commit/87a15ed501198389297a08ac471ccf0af2965d56) deepin.util-dfm: 1.2.8 -> 1.2.12
* [`bfdae37e`](https://github.com/NixOS/nixpkgs/commit/bfdae37ecaa7874f97b182e5726a498c708350c3) python310Packages.types-redis: 4.5.5.2 -> 4.6.0.1
* [`64a3f0ea`](https://github.com/NixOS/nixpkgs/commit/64a3f0ea07ae1dc4825abf2cd3ae2f7828c54e93) deepin.dde-file-manager: 6.0.15 -> 6.0.23
* [`f53b5bd7`](https://github.com/NixOS/nixpkgs/commit/f53b5bd71f3e7f31eca09af8c510da7744b0f3a8) python310Packages.python-pushover: remove
* [`bbb80e08`](https://github.com/NixOS/nixpkgs/commit/bbb80e088d4617e1fbd82b850bd72ec153fd6348) rtl8723bs: remove
* [`7987e2c1`](https://github.com/NixOS/nixpkgs/commit/7987e2c1ca27a3e7860f1bfdbdbd3ed5628e6c9a) rtl8723bs-firmware: remove
* [`fa06a0f0`](https://github.com/NixOS/nixpkgs/commit/fa06a0f01b53e8647c4422c5038ebb86ad4fef6c) mongoose: 3.0.4 -> 3.0.5
* [`4a22edaf`](https://github.com/NixOS/nixpkgs/commit/4a22edafaabc5965ac0e1d9883641c65e26ff02c) babashka: Add wrapper
* [`82d4f6b4`](https://github.com/NixOS/nixpkgs/commit/82d4f6b43ddc9868a6f512d8cf71bf144dd0e11c) veryfasttree: fix build on darwin
* [`8d8a0e7a`](https://github.com/NixOS/nixpkgs/commit/8d8a0e7a4579ef83393bdd064056551518399709) ymuse: refactor
* [`747390e9`](https://github.com/NixOS/nixpkgs/commit/747390e952f48883317bf7a5af2d249c319171df) rlwrap: 0.46 -> 0.46.1
* [`711f2388`](https://github.com/NixOS/nixpkgs/commit/711f23885de6c81fa9c1e46f167908ded283c4fc) gamescope: 3.11.52-beta6 -> 3.12.0-beta9
* [`505c52d1`](https://github.com/NixOS/nixpkgs/commit/505c52d1b05de044f41e625be136ea88750cc73e) s5cmd: 2.0.0 -> 2.1.0
* [`2efcdcc8`](https://github.com/NixOS/nixpkgs/commit/2efcdcc87b62ca504d80910c68a5fc54aa1f22c3) Add pkgconfig support to blst
* [`775fb11a`](https://github.com/NixOS/nixpkgs/commit/775fb11a2568e69b6333cd4eb5fea83dd25fd8d2) paperwm: 44.3.0 -> 44.3.1
* [`79d5144d`](https://github.com/NixOS/nixpkgs/commit/79d5144d16de3ff56cf11e555bcf2749c987cf0f) ptcollab: 0.6.4.5 -> 0.6.4.6
* [`92adcec7`](https://github.com/NixOS/nixpkgs/commit/92adcec7c6286be1ef3278c1a96f70f8be7f75c4) python311Packages.pontos: 23.6.2 -> 23.7.0
* [`1898ead6`](https://github.com/NixOS/nixpkgs/commit/1898ead643697c797c59eaf6ed4e3fedfff6f325) python311Packages.mitogen: 0.3.3 -> 0.3.4
* [`cb095a93`](https://github.com/NixOS/nixpkgs/commit/cb095a9384e2ae2e63d2fc7dc77a5f1337b84777) python311Packages.androidtvremote2: 0.0.9 -> 0.0.10
* [`f534b012`](https://github.com/NixOS/nixpkgs/commit/f534b012e6e1ee4a6b111e61f3cdcf65e11c65cc) gdal: add geospatial team to maintainers
* [`0a40ab39`](https://github.com/NixOS/nixpkgs/commit/0a40ab39525e1ac0fe6fa9c364c474a03d271b26) proj: add geospatial team to maintainers
* [`4e1fe784`](https://github.com/NixOS/nixpkgs/commit/4e1fe7846410ada22e1ea9e0497ba002f4246d1f) python311Packages.certipy-ad: 4.4.0 -> 4.5.1
* [`3c2c4146`](https://github.com/NixOS/nixpkgs/commit/3c2c41462b999c538673e3e737eb39a06581d3c7) python310Packages.django_4: 4.2.2 -> 4.2.3
* [`2040b2c3`](https://github.com/NixOS/nixpkgs/commit/2040b2c382f68d95c144452a93493077f977a618) csharp-ls: init at 0.8.0
* [`6ed8715a`](https://github.com/NixOS/nixpkgs/commit/6ed8715a2d876ccaad2b554befc0df022027c296) lib/maintainers.nix: add aldoborrero
* [`41d56a06`](https://github.com/NixOS/nixpkgs/commit/41d56a0624ce3471c34025b35af050fb23854366) mdformat: support plugins
* [`dc1c3646`](https://github.com/NixOS/nixpkgs/commit/dc1c3646a26890ebda08e116f625e11f17a295cd) mdformat-beautysh: init at 0.1.1
* [`9fbd8b57`](https://github.com/NixOS/nixpkgs/commit/9fbd8b575eb2310dee32a5733d0e40c242001e00) mdformat-footnote: init at 0.1.1
* [`f7607d0a`](https://github.com/NixOS/nixpkgs/commit/f7607d0a300779ccc20d5cb69b756d3833130838) mdformat-frontmatter: init at 2.0.1
* [`da7459f4`](https://github.com/NixOS/nixpkgs/commit/da7459f412d5003e77d56a676b90bae00c531e95) mdformat-gfm: init at 0.3.5
* [`81578d2c`](https://github.com/NixOS/nixpkgs/commit/81578d2c371bfc08de5c7a4d82a13a9ac1ec6690) mdformat-mkdocs: init at 1.0.2
* [`40c281ad`](https://github.com/NixOS/nixpkgs/commit/40c281ad7a451efba1c37184ed7188c3adfaf84e) mdformat-nix-alejandra: init at 0.1.0
* [`ae56d8f1`](https://github.com/NixOS/nixpkgs/commit/ae56d8f1919fd86e84ef991d9bfbef3aced2b15b) mdformat-simple-breaks: init at 0.0.1
* [`d72ad7d4`](https://github.com/NixOS/nixpkgs/commit/d72ad7d4db0eff63ba16affbc259635b2e70f267) mdformat-tables: init at 0.4.1
* [`0ee2fe15`](https://github.com/NixOS/nixpkgs/commit/0ee2fe15fc272f5acc61787a305dd7cc013fcd33) mdformat-toc: init at 0.3.0
* [`e2403007`](https://github.com/NixOS/nixpkgs/commit/e24030071b8a659d5278f316d0e7554660fe6242) mdformat-admon: init at 0.4.0
* [`b242d910`](https://github.com/NixOS/nixpkgs/commit/b242d910d00289a2282020fa4ab01187a336af59) pgadmin4: 7.3 -> 7.4
* [`1640749d`](https://github.com/NixOS/nixpkgs/commit/1640749d55a15d18d04f32658040e49b4d739d66) python3Packages.zipstream-ng: 1.5.0 -> 1.6.0
* [`7e8129be`](https://github.com/NixOS/nixpkgs/commit/7e8129be5a0ad189a41322ab92bce261341b95f3) python3Packages.add-trailing-comma: 2.4.0 -> 3.0.0
* [`b5c1e285`](https://github.com/NixOS/nixpkgs/commit/b5c1e285a6ead67d307ddd3596d229fdb3ae6f48) roundcube: 1.6.1 -> 1.6.2
* [`24016b96`](https://github.com/NixOS/nixpkgs/commit/24016b96336d249e48f48d8d849940f561ce80d1) stellarium: 23.1 -> 23.2
* [`baf5010b`](https://github.com/NixOS/nixpkgs/commit/baf5010b3c35cfa92766c89784db076be905f18a) doomrunner: init at 1.7.2
* [`0896ea43`](https://github.com/NixOS/nixpkgs/commit/0896ea435b94082550cd769e097e9f9b152e2ef9) kanidm: apply migration fixes
* [`11d22229`](https://github.com/NixOS/nixpkgs/commit/11d22229ad01f17682b13ec98f95286ce0ff11e6) nix-plugins: 10.0.0 -> 11.0.0
* [`e9207b05`](https://github.com/NixOS/nixpkgs/commit/e9207b05011b7cf46face625a4f69c946688902b) nixos/*: unhide remaining systemd stage-1 options
* [`90e4770f`](https://github.com/NixOS/nixpkgs/commit/90e4770f8133351244c1d76975a9a4350b32a3d0) nushell: refactor
* [`94859c4b`](https://github.com/NixOS/nixpkgs/commit/94859c4b536fb952ef8c74315cc8fd4ad266812f) tts: 0.15.0 -> 0.15.5
* [`ce105275`](https://github.com/NixOS/nixpkgs/commit/ce105275e5c098b2a59664ac876500903c3e24e9) proxmox-backup-client: add explanatory comments to patches
* [`03c47cb3`](https://github.com/NixOS/nixpkgs/commit/03c47cb3f532275806fab43a2d1708b6f2a214b5) argc: 1.6.0 -> 1.7.0
* [`fe01e756`](https://github.com/NixOS/nixpkgs/commit/fe01e756ec0dd802462bef34178a7d3009c8fd0e) matrix-sliding-sync: init at 0.99.3
* [`4f36ba2e`](https://github.com/NixOS/nixpkgs/commit/4f36ba2e6ff5db5468d3df4ac86ee2627efb4f37) pythonPackages.pysubs2: init at 1.6.1 ([nixos/nixpkgs⁠#238877](https://togithub.com/nixos/nixpkgs/issues/238877))
* [`4c3a93c7`](https://github.com/NixOS/nixpkgs/commit/4c3a93c7da617de57435ee813c18f5a24c66f88f) python3Packages.celery-singleton: init at 0.3.1
* [`38364c52`](https://github.com/NixOS/nixpkgs/commit/38364c52d2c8082908bf73fc2cc430370f08e85c) python310Packages.gaphas: 3.11.1 -> 3.11.2
* [`b9088405`](https://github.com/NixOS/nixpkgs/commit/b9088405de0e72988ff7be152110e24ac44faf5f) python310Packages.sphinxcontrib-katex: 0.9.6 -> 0.9.7
* [`14386924`](https://github.com/NixOS/nixpkgs/commit/143869247eb779a321544fbcff34fd9dd1cd647a) rtl8723bs-firmware: cleanup
* [`1a7adacc`](https://github.com/NixOS/nixpkgs/commit/1a7adacc7e280c39af9d240a59a9465e82d0d54b) oranda: 0.0.3 -> 0.1.0
* [`feb99f39`](https://github.com/NixOS/nixpkgs/commit/feb99f39feb576979c5d706d1cffec01d079bd70) typos: 1.15.9 -> 1.15.10
* [`4c5cf146`](https://github.com/NixOS/nixpkgs/commit/4c5cf146b93048a71b8faa6d0f1c549135d7b318) kubectl-gadget: 0.17.0 -> 0.18.0
* [`70cc0d41`](https://github.com/NixOS/nixpkgs/commit/70cc0d412fc64a0db9d2b2c49f296e2ce628d585) nixos/gitea: only require databases if createDatabase is set
* [`349a86e3`](https://github.com/NixOS/nixpkgs/commit/349a86e3cb80d56ffd4a710167b9e092996d951f) maintainers: add mccurdyc
* [`c562010d`](https://github.com/NixOS/nixpkgs/commit/c562010d3dd91fa03c7d143a1204b27beac4a17e) gitrs: init at 0.3.6
* [`c0388b10`](https://github.com/NixOS/nixpkgs/commit/c0388b103a3f583ce9af302e0680dd6915138c0b) vscode-extensions.devsense.composer-php-vscode: 1.34.13295 -> 1.36.13428
* [`dc8677d0`](https://github.com/NixOS/nixpkgs/commit/dc8677d05676d4f0dd6143ab81f2df06cf264585) vscode-extensions.devsense.phptools-vscode: 1.34.13295 -> 1.36.13428
* [`3ec619c8`](https://github.com/NixOS/nixpkgs/commit/3ec619c81474add206d50ab5a63820f7aba40f92) tmux: provide `tmux-256color` terminfo on macOS
* [`297be700`](https://github.com/NixOS/nixpkgs/commit/297be700ea69b909adb087c57f9454cce76d438a) vscode-extensions.devsense.profiler-php-vscode: 1.34.13295 -> 1.36.13428
* [`792f6a73`](https://github.com/NixOS/nixpkgs/commit/792f6a73c28f1d985a23ba56a502a1b2e13a0de2) perlPackages.EvalSafe: init at 0.02
* [`e181e94b`](https://github.com/NixOS/nixpkgs/commit/e181e94b538674051918a27495f4f11bf1319db7) perlPackages.MsgPackRaw: init at 0.05
* [`aab9abe3`](https://github.com/NixOS/nixpkgs/commit/aab9abe330dbeba9fcbe301f5aacb26b5b360b7a) perlPackages.NeovimExt: init at 0.06
* [`b86bac63`](https://github.com/NixOS/nixpkgs/commit/b86bac63dcf9035635626d010b28359b383eb4ff) rsonpath: 0.5.0 -> 0.5.1
* [`74feaf3a`](https://github.com/NixOS/nixpkgs/commit/74feaf3a8f85c3cf60c6a02e9b13d95a6655b919) fsautocomplete: 0.60.0 -> 0.60.1
* [`1bcbba50`](https://github.com/NixOS/nixpkgs/commit/1bcbba5012be1ecd3a05a6358bdd45f0e8add7bb) phpPackages.composer: 2.5.7 -> 2.5.8
* [`39bea5f1`](https://github.com/NixOS/nixpkgs/commit/39bea5f1ba4b81eb2e06a58908b68f39d6d85290) phpPackages.composer: switch to `finalAttrs` pattern
* [`bf84aea4`](https://github.com/NixOS/nixpkgs/commit/bf84aea48ef964f59e652b57ff5b63e044dfec64) tdb: fix `install_name` on Darwin
* [`03ccaf67`](https://github.com/NixOS/nixpkgs/commit/03ccaf6743c1b149f680a7426578052723d9b855) fdm: enable on Darwin
* [`651511be`](https://github.com/NixOS/nixpkgs/commit/651511bea8679046cd6729c9bff2f25a65629e93) vimPlugins.bufjump-nvim: init at 2021-12-05
* [`f04539a7`](https://github.com/NixOS/nixpkgs/commit/f04539a7105292cc10017163cb971c2482a04420) vimPlugins: update
* [`d8a14c1f`](https://github.com/NixOS/nixpkgs/commit/d8a14c1f6763c70b3e85ee9cbf810db38dfd9d6b) vimPlugins.nvim-treesitter: update grammars
* [`3814796d`](https://github.com/NixOS/nixpkgs/commit/3814796dc6a41d6d7083f9cae9bd013c9343515d) lightningcss: 1.21.2 → 1.21.3
* [`37eb3cb5`](https://github.com/NixOS/nixpkgs/commit/37eb3cb5e3803097b2963213c7ffb2c5cc52f744) poedit: 3.3.1 -> 3.3.2
* [`17ecbea5`](https://github.com/NixOS/nixpkgs/commit/17ecbea5ff67f8c7ccf169ce2f75d2c2c6a971e8) patcher9x: init at 0.8.50
* [`33937987`](https://github.com/NixOS/nixpkgs/commit/339379873ce7107a3ea7b483a3329fed1accc17a) Revert "python3Packages.mautrix: 0.19.16 -> 0.20.0"
* [`2ae8e338`](https://github.com/NixOS/nixpkgs/commit/2ae8e33832a3e0996a44e3cc06deea0f97c15325) {libqalculate, qalculate-gtk, qalculate-qt}: 4.6.1 -> 4.7.0
* [`c98011e6`](https://github.com/NixOS/nixpkgs/commit/c98011e6ef750084a8c8927d199bda6c7f4a6675) python310Packages.pyamg: 5.0.0 -> 5.0.1
* [`f7f55552`](https://github.com/NixOS/nixpkgs/commit/f7f55552165fe2eac627f2afea72a8a180001f05) sipexer: 1.0.3 -> 1.1.0 ([nixos/nixpkgs⁠#240929](https://togithub.com/nixos/nixpkgs/issues/240929))
* [`42c94d06`](https://github.com/NixOS/nixpkgs/commit/42c94d06fdb683ab9bd72a9cd624868386d0f0cd) stdenv: fix overriding with attrset when finalAttrs isn't used
* [`e724e691`](https://github.com/NixOS/nixpkgs/commit/e724e691ee472b82bc1a9dccd195005223503b59) ryujinx: 1.1.942 -> 1.1.952
* [`17a6a914`](https://github.com/NixOS/nixpkgs/commit/17a6a914bb8bd301a05db4ef894e622f653f60ee) mediaelch: 2.10.0 -> 2.10.2
* [`23578c3d`](https://github.com/NixOS/nixpkgs/commit/23578c3d7dbb5be065c48633af59e880559de2a8) python310Packages.pyamg: add changelog to meta
* [`ce04f4b0`](https://github.com/NixOS/nixpkgs/commit/ce04f4b021ff6f620a45df95759132bb3302c913) python310Packages.pyamg: add format
* [`8966721a`](https://github.com/NixOS/nixpkgs/commit/8966721a83b52756ec530f9b07f6207c7ae912ff) python311Packages.shellingham: 1.5.0.post1 -> 1.5.1
* [`1bd34149`](https://github.com/NixOS/nixpkgs/commit/1bd3414907e57cf434f6d36d40b82a775f469342) python311Packages.shellingham: add changelog to meta
* [`5eb9c438`](https://github.com/NixOS/nixpkgs/commit/5eb9c438ddc68aa6a02c788a82a53d0a975b2c11) ruff: 0.0.275 -> 0.0.276
* [`e53128d1`](https://github.com/NixOS/nixpkgs/commit/e53128d1a7dba4548d5711b66e0e9ac1850c1494) python311Packages.typer: tests are failing on Linux as well
* [`2920b6fc`](https://github.com/NixOS/nixpkgs/commit/2920b6fc16a9ed5d51429e94238b28306ceda79e) ciscoPacketTracer8: 8.2.0 -> 8.2.1, refactor
* [`70eb0c17`](https://github.com/NixOS/nixpkgs/commit/70eb0c17bedb238f1adb988a8a334f17ffd09b07) python310Packages.demes: init at version 0.2.3
* [`e920956b`](https://github.com/NixOS/nixpkgs/commit/e920956b117a61e19d7ace53af4f776c2d1dbb1a) python310Packages.avro: 1.11.1 -> 1.11.2
* [`5904ce8e`](https://github.com/NixOS/nixpkgs/commit/5904ce8eb1f5ae60eba33eae6f5787b19e8d76dd) evcxr: 0.14.2 -> 0.15.0 ([nixos/nixpkgs⁠#241253](https://togithub.com/nixos/nixpkgs/issues/241253))
* [`c689e7f7`](https://github.com/NixOS/nixpkgs/commit/c689e7f7e1b4dc905a5f204c0157965da983d7c9) rio: 0.0.7 -> 0.0.8
* [`5ef952ae`](https://github.com/NixOS/nixpkgs/commit/5ef952ae13ecd729f689f23e19937277c9556393) rio: enable Wayland by default
* [`445b2f27`](https://github.com/NixOS/nixpkgs/commit/445b2f276ff1f10a16bac69a398b87347924d7ff) ubpm: init at 1.7.3 ([nixos/nixpkgs⁠#224593](https://togithub.com/nixos/nixpkgs/issues/224593))
* [`88afee92`](https://github.com/NixOS/nixpkgs/commit/88afee92ac2018234c7ed5348717f5c59f89ef62) pacup: 1.1.0 -> 2.0.0
* [`de9800a8`](https://github.com/NixOS/nixpkgs/commit/de9800a8a8d4d7f7d6513a4ff466aa54da624854) python311Packages.pyezviz: 0.2.1.6 -> 0.2.1.7
* [`c337948b`](https://github.com/NixOS/nixpkgs/commit/c337948beaeb68dad8dcf7fb2f116d139902b05a) trivy: 0.42.1 -> 0.43.0
* [`d667de92`](https://github.com/NixOS/nixpkgs/commit/d667de92a310f730a9c122083879f47051a1c066) python3Packages.pyamg: enable tests
* [`57c8cf04`](https://github.com/NixOS/nixpkgs/commit/57c8cf047ccdf827cae33e8b76729bd4e881c0fc) sqlfluff: 2.1.1 -> 2.1.2
* [`8e1c9ca8`](https://github.com/NixOS/nixpkgs/commit/8e1c9ca8d17b5fc9223c17821c6a5b8e374ada73) nixpkgs-review: 2.9.2 -> 2.9.3
* [`532a7d3f`](https://github.com/NixOS/nixpkgs/commit/532a7d3f1d67781c06a5bd9be8a89a9198ea91fc) cudaPackages_12_2.cudatoolkit: init at 12.2.0
* [`cf6bc18b`](https://github.com/NixOS/nixpkgs/commit/cf6bc18bed822f721348b3bd753b26c261079e3b) nuclei: 2.9.7 -> 2.9.8 ([nixos/nixpkgs⁠#241301](https://togithub.com/nixos/nixpkgs/issues/241301))
* [`11f27bda`](https://github.com/NixOS/nixpkgs/commit/11f27bda2d6f502fde5f39557ee6399439d8461e) signal-desktop: 6.21.0 -> 6.23.0, signal-desktop-beta: 6.22.0-beta.3 ([nixos/nixpkgs⁠#240986](https://togithub.com/nixos/nixpkgs/issues/240986))
* [`283674ec`](https://github.com/NixOS/nixpkgs/commit/283674ec6e87017ccf44b7f5d83c967cf7873f63) vscode-extensions-betterthantomorrow.calva: 2.0.205 -> 2.0.374 ([nixos/nixpkgs⁠#240946](https://togithub.com/nixos/nixpkgs/issues/240946))
* [`47c98868`](https://github.com/NixOS/nixpkgs/commit/47c98868cd70d278e992259810a909866bc3447e) clightd: 5.7 -> 5.8 ([nixos/nixpkgs⁠#240816](https://togithub.com/nixos/nixpkgs/issues/240816))
* [`28e0f926`](https://github.com/NixOS/nixpkgs/commit/28e0f9265eb0341e02509d798cc1977590eb0ee1) python310Packages.wsgi-intercept: 1.12.0 -> 1.12.1
* [`fb15b4ac`](https://github.com/NixOS/nixpkgs/commit/fb15b4ac4ed0f757c574bdba240607c2a9201f46) tqsl: add wrapGAppsHook, remove cmakeWrapper
* [`309f54ae`](https://github.com/NixOS/nixpkgs/commit/309f54ae5b69a9c4f47f516fadc4fc1c568c822b) flutter: Remove Flutter 2
* [`e60e8125`](https://github.com/NixOS/nixpkgs/commit/e60e8125bb9ff9518d618eddbd9f2b6275eb6024) flutter2: Add throwing alias
* [`74588d77`](https://github.com/NixOS/nixpkgs/commit/74588d77b49697ef86027284dce641256316bf12) squashfuse: 0.1.105 -> 0.2.0
* [`93ae7729`](https://github.com/NixOS/nixpkgs/commit/93ae7729be038a4969ae01760c83bf16029c7907) maintainers: add @⁠shymega
* [`c36301bc`](https://github.com/NixOS/nixpkgs/commit/c36301bcc0433a1acb6e1815d346239381ae7630) input-leap: init at unstable-2023-05-24
* [`fc431f15`](https://github.com/NixOS/nixpkgs/commit/fc431f1530314832c07b756122a7ed19c77ba28a) teams-for-linux: 1.1.9 -> 1.1.11 ([nixos/nixpkgs⁠#241371](https://togithub.com/nixos/nixpkgs/issues/241371))
* [`e0ca6a14`](https://github.com/NixOS/nixpkgs/commit/e0ca6a14deb173272fd600f84fb2f3e650c6dfc3) open-pdf-sign: 0.1.4 -> 0.1.5 ([nixos/nixpkgs⁠#241366](https://togithub.com/nixos/nixpkgs/issues/241366))
* [`d6d9a9a8`](https://github.com/NixOS/nixpkgs/commit/d6d9a9a8b879f8de3b7a61ea2d8c531742565c09) benthos: 4.17.0 -> 4.18.0
* [`7085a16a`](https://github.com/NixOS/nixpkgs/commit/7085a16a13c4ecc3f0b69169644d10134cdb42ac) dysk: rename from lfs, 2.6.0 -> 2.6.1
* [`4790a8eb`](https://github.com/NixOS/nixpkgs/commit/4790a8ebdb4767ad917b4cc3c77ff263201abbf5) dysk: add figsoda as a maintainer
* [`83f4ce50`](https://github.com/NixOS/nixpkgs/commit/83f4ce50aa4fc42af387fe406bea235374b73264) rust-analyzer-unwrapped: 2023-06-26 -> 2023-07-03
* [`34181be0`](https://github.com/NixOS/nixpkgs/commit/34181be0248331fa3acd3dc4e4be01074cd731d3) stdenvAdapters: don't use lib.optional with a list
* [`8154b072`](https://github.com/NixOS/nixpkgs/commit/8154b0725789f330255236ea707787065ee5d0d8) jackett: 0.21.341 -> 0.21.364
* [`9da2e4a8`](https://github.com/NixOS/nixpkgs/commit/9da2e4a8842e68e7030596eef88d41405e4c16cb) rars: 1.5 -> 1.6 ([nixos/nixpkgs⁠#241306](https://togithub.com/nixos/nixpkgs/issues/241306))
* [`475f2428`](https://github.com/NixOS/nixpkgs/commit/475f2428cbf185aa28abeac87bb11b52f8591f5f) geomyidae: 0.51 -> 0.69 ([nixos/nixpkgs⁠#241307](https://togithub.com/nixos/nixpkgs/issues/241307))
* [`f979f99b`](https://github.com/NixOS/nixpkgs/commit/f979f99b32c62e701e5f29f9acfd643ad8cf6626) maintainers: add galen
* [`e4ec073f`](https://github.com/NixOS/nixpkgs/commit/e4ec073f07d66b530681ead7b946a3fd7d43d8bf) cargo-component: unstable-2023-06-20 -> unstable-2023-06-22
* [`939f0c5b`](https://github.com/NixOS/nixpkgs/commit/939f0c5b90f6bea76c563a03a2fd7fdfb110fc09) python310Packages.Polygon3: init at 3.0.9
* [`05bb118a`](https://github.com/NixOS/nixpkgs/commit/05bb118a996239c61c505166660f84b1d19cb282) python310Packages.lanms-neo: init at 1.0.2
* [`d46a37cb`](https://github.com/NixOS/nixpkgs/commit/d46a37cbb6b5c9cc7327a117db57743b7466ea59) taproot-assets: 0.1.0-alpha -> 0.2.2
* [`40d8e0c4`](https://github.com/NixOS/nixpkgs/commit/40d8e0c4297966ba1aeca0ab85dfff77698b3374) kind2: fix build
* [`a54fd9a1`](https://github.com/NixOS/nixpkgs/commit/a54fd9a15875b511f7f3370dfb1db25b11ef7dc7) autospotting: unstable-2022-02-17 -> unstable-2023-07-03
* [`c9471b21`](https://github.com/NixOS/nixpkgs/commit/c9471b21465e21c24d2de211d23fd29242e04270) hvm: fix build
* [`ae0e991f`](https://github.com/NixOS/nixpkgs/commit/ae0e991f7f2ac4f0dfe31373ede73b50bdf60214) go-org: 1.5.0 -> 1.7.0
* [`46aeca61`](https://github.com/NixOS/nixpkgs/commit/46aeca6159a6a1b3e65860261edaf9c3c3a0c366) gofu: unstable-2022-04-01 -> unstable-2023-04-25
* [`2a79157f`](https://github.com/NixOS/nixpkgs/commit/2a79157f4e5fe556f77a437b88a6e5e8736dd08e) keylight-controller-mschneider82: 0.1.0 -> 0.1.1
* [`d3923d6a`](https://github.com/NixOS/nixpkgs/commit/d3923d6ad37722971876d25e47e8da74ceecd3fa) python310Packages.holidays: 0.27.1 -> 0.28
* [`00aa6e95`](https://github.com/NixOS/nixpkgs/commit/00aa6e9524979b72f3de7354694aa9d64fb0c7db) kanshi: 1.3.1 -> 1.4.0
* [`366a19da`](https://github.com/NixOS/nixpkgs/commit/366a19da2acca39b1b1f1c72e021c1e27c97c6d5) partio: 1.14.6 -> 1.17.0
* [`497220bb`](https://github.com/NixOS/nixpkgs/commit/497220bbb83c1d9235d8cb837e88c552c51bd7a2) pantheon.wingpanel-indicator-nightlight: 2.1.1 -> 2.1.2
* [`82875aa7`](https://github.com/NixOS/nixpkgs/commit/82875aa714948887a2144ca699d1ec5a0fe729dc) pantheon.elementary-notifications: 6.0.3 -> 7.0.0
* [`1d750c36`](https://github.com/NixOS/nixpkgs/commit/1d750c3699f81974ade7540ae770ca10e498e4ac) orbuculum: 2.0.0 -> 2.1.0
* [`eb4ec1d4`](https://github.com/NixOS/nixpkgs/commit/eb4ec1d4d80e1796e925ee45632838a7035b52bd) terraform-providers.baiducloud: 1.19.7 -> 1.19.8
* [`4f25c0c2`](https://github.com/NixOS/nixpkgs/commit/4f25c0c242b275838e37e81a5b0b10ea86e4d42c) terraform-providers.checkly: 1.6.6 -> 1.6.7
* [`da318056`](https://github.com/NixOS/nixpkgs/commit/da318056bdf5fd91c603b097a4823af4c9fcd9fc) terraform-providers.datadog: 3.26.0 -> 3.27.0
* [`98a3c57b`](https://github.com/NixOS/nixpkgs/commit/98a3c57b72d9c7f6488139d5ac10e43cf577796c) terraform-providers.google: 4.71.0 -> 4.72.0
* [`4215c51e`](https://github.com/NixOS/nixpkgs/commit/4215c51e792aedbbd6fca1334a7595a63ca5b277) terraform-providers.google-beta: 4.71.0 -> 4.72.0
* [`4b4a5a4b`](https://github.com/NixOS/nixpkgs/commit/4b4a5a4b294dc8e460719ce2e78ae44b90b1c85c) terraform-providers.tfe: 0.45.0 -> 0.46.0
* [`a07e4358`](https://github.com/NixOS/nixpkgs/commit/a07e435835cebcc17dd27373b79b0c21c6718f08) unciv: 4.6.19 -> 4.7.6-patch1
* [`75acb2f1`](https://github.com/NixOS/nixpkgs/commit/75acb2f184869deb2d22e104afb6a30a16b99000) gobgp: 3.15.0 -> 3.16.0
* [`f6dc216e`](https://github.com/NixOS/nixpkgs/commit/f6dc216ee26c2e92558992074c81148f7f500ba3) deck: 1.22.0 -> 1.23.0 ([nixos/nixpkgs⁠#241292](https://togithub.com/nixos/nixpkgs/issues/241292))
* [`80d1952b`](https://github.com/NixOS/nixpkgs/commit/80d1952b0130d453aa643bbf09f79fce51a267f0) gotrue-supabase: 2.77.1 -> 2.78.0
* [`27b0307e`](https://github.com/NixOS/nixpkgs/commit/27b0307e77bdd6d69c66f0c8ef6a91eb8e19656e) dockle: 0.4.5 -> 0.4.11
* [`ab333250`](https://github.com/NixOS/nixpkgs/commit/ab3332501062c582b9b4d01e1b5e90dd9e4a2f04) libnitrokey: fix build on darwin
* [`1b5ad64b`](https://github.com/NixOS/nixpkgs/commit/1b5ad64b5220fc9cff92300162ed4c909a66d480) errcheck: unstable-2022-03-26 -> 1.6.3
* [`f3bab733`](https://github.com/NixOS/nixpkgs/commit/f3bab73364c90241083e0a843e542a673d926f54) fission: 1.14.1 -> 1.19.0
* [`45170fdb`](https://github.com/NixOS/nixpkgs/commit/45170fdb53589871f3e4a13f0080c61113b15580) lib3mf: fix building tests on aarch64-darwin
* [`0509d2e0`](https://github.com/NixOS/nixpkgs/commit/0509d2e08f1a0ed7f845a96ca83a1fe851c5ac44) gauge: 1.4.3 -> 1.5.1
* [`7f85c39b`](https://github.com/NixOS/nixpkgs/commit/7f85c39b8b4792434dafc45961b670b75937d0e1) vtm: 0.9.9o -> 0.9.9q
* [`8d68d951`](https://github.com/NixOS/nixpkgs/commit/8d68d951af287d61d560af4894aaebceb3f1cd28) dex-oidc: 2.36.0 -> 2.37.0
* [`5d180a74`](https://github.com/NixOS/nixpkgs/commit/5d180a74db22b06b7bb3651804871e2b0d9a3eec) python310Packages.nlpcloud: 1.0.42 -> 1.0.43
* [`bc25e988`](https://github.com/NixOS/nixpkgs/commit/bc25e988284a1f9e539ea1acb4573519e3bd21f4) nuclei: update rev
* [`3095204c`](https://github.com/NixOS/nixpkgs/commit/3095204c38fd8f837ef0660d2254b56a0d382007) python311Packages.python-kasa: 0.5.1 -> 0.5.2
* [`dc3fa5c6`](https://github.com/NixOS/nixpkgs/commit/dc3fa5c6af73d9f5651416bc63a4ea773ccc6149) python310Packages.holidays: update disabled
* [`c6759017`](https://github.com/NixOS/nixpkgs/commit/c67590170e771cd23fe40353dff55fadf9fb963d) php81Packages.box: 4.2.0 -> 4.3.8 ([nixos/nixpkgs⁠#241427](https://togithub.com/nixos/nixpkgs/issues/241427))
* [`16c79f5f`](https://github.com/NixOS/nixpkgs/commit/16c79f5f3011894a4214da4642bfc2381bb76758) fitnesstrax: remove since it is gone upstream
* [`f3a22964`](https://github.com/NixOS/nixpkgs/commit/f3a2296445df5ca6b8aa6aac6132365c0735c751) passage: use getopt from nix on darwin ([nixos/nixpkgs⁠#241293](https://togithub.com/nixos/nixpkgs/issues/241293))
* [`1a6370f6`](https://github.com/NixOS/nixpkgs/commit/1a6370f64c97a65c1422bf467575b47116c33a02) wagyu: update tag to disambiguate revision
* [`7e681d7f`](https://github.com/NixOS/nixpkgs/commit/7e681d7f668e033fff1c660a3d3b442de7e5947b) slowlorust: fix build on darwin
* [`95cca6d2`](https://github.com/NixOS/nixpkgs/commit/95cca6d266935d3f2650385e54ec20b34b54c52a) gucci: 1.6.6 -> 1.6.10
* [`5109666f`](https://github.com/NixOS/nixpkgs/commit/5109666fad662f8ba9316e318645713f4aec2efd) sonic-pi: 4.3.0 -> 4.4.0
* [`041a1248`](https://github.com/NixOS/nixpkgs/commit/041a124886908f0fe9c9d4fa4ba4f82c27426787) gex: 0.3.8 -> 0.4.0
* [`a7994459`](https://github.com/NixOS/nixpkgs/commit/a7994459daae5fef56e9982bf733cfee7a869f6a) libfabric: 1.18.0 -> 1.18.1
* [`441e925d`](https://github.com/NixOS/nixpkgs/commit/441e925d48165eea0f262c2e9ccb6deecf85d7f5) prometheus-fastly-exporter: 7.5.1 -> 7.6.0
* [`77ccd192`](https://github.com/NixOS/nixpkgs/commit/77ccd192b3b92b52658b7df5d306b290163e07c7) git-codereview: 1.2.0 -> 1.3.0
* [`bb625eb4`](https://github.com/NixOS/nixpkgs/commit/bb625eb45c21990e5c268ee4a7d02b9c5abd737c) pulsarctl: 2.10.3.3 -> 2.11.1.3
* [`ab139747`](https://github.com/NixOS/nixpkgs/commit/ab1397475c5f21cdb78e91e1a4a782cb8f6935c1) jami: use fmt_9 and msgpack
* [`010d2011`](https://github.com/NixOS/nixpkgs/commit/010d201115c29274294f4b3301817906a2d58546) ardour: set mainProgram in meta
* [`5c7df30c`](https://github.com/NixOS/nixpkgs/commit/5c7df30c0aae8ec6dcb96edfd661643d5a25fd9b) ankisyncd-rs: add package for anki-sync-server-rs
* [`668f528b`](https://github.com/NixOS/nixpkgs/commit/668f528b6ca75a0a80ab5bb137d85a4ba677c603) nixos/ankisyncd: use ankisyncd-rs instead of the old python one
* [`fbe3e3b4`](https://github.com/NixOS/nixpkgs/commit/fbe3e3b44e64f20236c568bd11c0e5c82f5c1792) replace ankisyncd with ankisyncd-rs
* [`7fa32147`](https://github.com/NixOS/nixpkgs/commit/7fa3214703352ebd39a800b7f79d6f30753e06e9) ankisyncd: 1.1.3 -> 1.1.4
* [`fae866cf`](https://github.com/NixOS/nixpkgs/commit/fae866cfcb9846f27cccaa514b054a233b371a31) clightning: 23.05.1 -> 23.05.2
* [`f43320fb`](https://github.com/NixOS/nixpkgs/commit/f43320fb1f1a44b840e4456ba572fbc0e1c91b7a) cardinal: set mainProgram in meta
* [`9cf1e8c1`](https://github.com/NixOS/nixpkgs/commit/9cf1e8c111137e582c7bd96de8cc1b63b5be93a7) symfony-cli: add meta.mainProgram
* [`c6d23e81`](https://github.com/NixOS/nixpkgs/commit/c6d23e811b2fa08eae8c6bdc793193dab0559542) liquibase: 4.17.2 -> 4.23.0
* [`1f0ac736`](https://github.com/NixOS/nixpkgs/commit/1f0ac736b48dbeaed1b3da975d13246b4d3a886c) nixos/caddy: add support for reload
* [`27b7132e`](https://github.com/NixOS/nixpkgs/commit/27b7132e811addbe6dad8e07daf90b23bc86d3a1) nixos/caddy: remove admin check
* [`71d96f5d`](https://github.com/NixOS/nixpkgs/commit/71d96f5d59d0f180729c07d6c4201f16c01b3e10) konstraint: 0.29.1 -> 0.30.0
* [`0daabae8`](https://github.com/NixOS/nixpkgs/commit/0daabae8e7b441f563192884c4dcdf2fa771412f) hcxdumptool: 6.3.0 -> 6.3.1
* [`4da27723`](https://github.com/NixOS/nixpkgs/commit/4da27723f3135a769ca52aff05148c76b7bb5123) mullvad-vpn: support `aarch64-linux`
* [`06e93417`](https://github.com/NixOS/nixpkgs/commit/06e9341752d178a2cd42ba3ba714504825dcdb6c) sexp: 0.8.6 -> sexpp 0.8.7
* [`f7b9340a`](https://github.com/NixOS/nixpkgs/commit/f7b9340a7256d08380ccfa4810ee908d304b7b38) nwg-dock-hyprland: 0.1.2 -> 0.1.3
* [`cdd89a86`](https://github.com/NixOS/nixpkgs/commit/cdd89a8638502c8ed3388d47e1f98b8ba21e7441) noto-fonts: 23.5.1 -> 23.7.1
* [`07f07296`](https://github.com/NixOS/nixpkgs/commit/07f072968ca17e9e5f018a9b2042be5f2b582662) passage: fix getopt path on darwin
* [`7a1ff1ae`](https://github.com/NixOS/nixpkgs/commit/7a1ff1ae896c48a18759e3c2db6ddcc4170aef3d) rPackages.pbdZMQ: use zeromq from nixpkgs instead of vendored copy
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
