### PR TITLE
niv devenv: update 6f761f07 -> c81f0263

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "6f761f07c5f53d5cc4a139db3f41a7f4a0821ffa",
-        "sha256": "0xv5jqcb35i7fgsilf2kj9snyw4sq6c6g2ns9xgiws300b9dx4hg",
+        "rev": "c81f0263446629e961a82736565565dc75eeb733",
+        "sha256": "1b89rm389b9v5krp8jh1v68zcwnavc7cvdg0gyi7szvxza1pldyh",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/6f761f07c5f53d5cc4a139db3f41a7f4a0821ffa.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/c81f0263446629e961a82736565565dc75eeb733.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@6f761f07...c81f0263](https://github.com/cachix/devenv/compare/6f761f07c5f53d5cc4a139db3f41a7f4a0821ffa...c81f0263446629e961a82736565565dc75eeb733)

* [`35162cfc`](https://github.com/cachix/devenv/commit/35162cfc38cf2961bf8ac1c03789b3a0630b7d50) define options
* [`1584e0d0`](https://github.com/cachix/devenv/commit/1584e0d0c3b6f5254e289c6d8101f2c9c6d21603) work
* [`bc53d8d0`](https://github.com/cachix/devenv/commit/bc53d8d0ad65dbda511dbba282c88226121d2b34) expose components option, use package instead of packages
* [`c413b446`](https://github.com/cachix/devenv/commit/c413b446d07fc7d3f01db00c357bef064ddbec68) remove work file
* [`da9c5a84`](https://github.com/cachix/devenv/commit/da9c5a84523e09398892da38124a1d8986b5ae46) remove RUST_SRC_PATH...?
* [`8c7cf8ed`](https://github.com/cachix/devenv/commit/8c7cf8eddacf623194f803ae9745aa73fa0b624c) fix package.defaultText
* [`3177156f`](https://github.com/cachix/devenv/commit/3177156f1ea86e796de01bc2fa099443faa9a431) fix diff
* [`4c387adb`](https://github.com/cachix/devenv/commit/4c387adbdbef40e55bac32d97048cc83923731be) add toolchain option
* [`8fe7d072`](https://github.com/cachix/devenv/commit/8fe7d072df43880060e1a0d49dce6bbb22917d17) mutual exclusion
* [`96830f2c`](https://github.com/cachix/devenv/commit/96830f2c0d2a688cdbd523ef50b43b4c64a20136) optionally set pre-commit tools
* [`78d45bde`](https://github.com/cachix/devenv/commit/78d45bdedddb0fb8c4d1f67290a343557ed1f56a) Revert "mutual exclusion"
* [`499e6024`](https://github.com/cachix/devenv/commit/499e602489b71b78f88de835a07e09607cfce02b) further fix pre-commit tools
* [`b5416967`](https://github.com/cachix/devenv/commit/b5416967f6c01f4974da6e009eb8901ceda0ad87) lazyAttrsOf fenix toolchain type
* [`e6ae3ec6`](https://github.com/cachix/devenv/commit/e6ae3ec6379db24a9b18207826312b8376b79642) Make env a submodule
* [`7fa5a464`](https://github.com/cachix/devenv/commit/7fa5a4647003161a5699af55b0946d91f88ac130) Change to str type
* [`ca4b111f`](https://github.com/cachix/devenv/commit/ca4b111fdef79ca28ea609f417e78a0efe3f6d5e) DEVENV_PROFILE should be a path
* [`c3682b80`](https://github.com/cachix/devenv/commit/c3682b80bfd4c1d7b9425cacb1aa8559a8dd0ebb) [feature]: Add ability for process.exec to be multiline
* [`c5ce5e63`](https://github.com/cachix/devenv/commit/c5ce5e634ceb0e03c414286af04c71fb832269ed) change back to str
* [`ef4e235e`](https://github.com/cachix/devenv/commit/ef4e235eb3eca5df581cfeccb58a66394c81c08f) temporary - define using only fenix
* [`36c43869`](https://github.com/cachix/devenv/commit/36c43869ea9cd56dae35e8eafdafe3eec1dec609) profile doesnt exist on toolchains :(
* [`80d4636a`](https://github.com/cachix/devenv/commit/80d4636ac3259457203df32e3033e7ea1f56a766) todo
* [`8e5b2bfc`](https://github.com/cachix/devenv/commit/8e5b2bfcca2f0a055a3339a3cdd2e8de079adc39) Honor process-compose `port` and `tui` options
* [`ce36bb6c`](https://github.com/cachix/devenv/commit/ce36bb6cebedfdfd19e4043836d51bde8b3c1419) docs: add services, improve language docs and tweak homepage
* [`3065f439`](https://github.com/cachix/devenv/commit/3065f43914ccd2d92365b307e8a967c7b5609308) github: add enhancement and question templates
* [`dd29f745`](https://github.com/cachix/devenv/commit/dd29f745cf278b55ae49ac274ca77e5462989ce6) devenv version: print also system
* [`ed538b70`](https://github.com/cachix/devenv/commit/ed538b703ec07b54409944f530d5dc32c4b85150) python: make example more generic
* [`1d17bde4`](https://github.com/cachix/devenv/commit/1d17bde4e4a5e3c485640f5f19a2a187d90daaa2) re-add nixpkgs by default, get some things working
* [`516e812d`](https://github.com/cachix/devenv/commit/516e812d4ad8574c0438ccf800b22e34607f8fa5) cleanup
* [`b33d5b04`](https://github.com/cachix/devenv/commit/b33d5b04bfdbb861bf37e6b5ed09a33d2d1d0424) more cleanup
* [`79fe18e1`](https://github.com/cachix/devenv/commit/79fe18e1fc8c4be4566a13d8ec8259675346e11e) re-add pre-commit tools stuff
* [`a9a86363`](https://github.com/cachix/devenv/commit/a9a863638528ea5d2274fcc74ac2815fb0abebee) marginally better type
* [`0f74b516`](https://github.com/cachix/devenv/commit/0f74b51685bd31c4fb4381749db79fe89c064da1) cleaner diff
* [`617cb7b0`](https://github.com/cachix/devenv/commit/617cb7b0319cd8f9bb005060b9222e67ed768b51) even cleaner diff
* [`55baf719`](https://github.com/cachix/devenv/commit/55baf7198f3c9fc2511a88418912df36bcbf0dfb) fix docs
* [`54ba6b7d`](https://github.com/cachix/devenv/commit/54ba6b7db4c65e5d8f1f4b8b287803346642a524) better pre-commit.tools instantiation
* [`9049f844`](https://github.com/cachix/devenv/commit/9049f8449aac08751eff4e59152cf7998db18e35) add review comment for posterity
* [`8ca2cd32`](https://github.com/cachix/devenv/commit/8ca2cd32f03233acb5f2e4378e2547ffe854a185) little cleanup
* [`7f8d0169`](https://github.com/cachix/devenv/commit/7f8d016938f34650eca6e055bbc06d2a9fc93f8e) simplify
* [`31e5862a`](https://github.com/cachix/devenv/commit/31e5862a090a40d32df25e1accac145e4f1d136f) a couple of fixes
* [`4fc913b7`](https://github.com/cachix/devenv/commit/4fc913b755e9e1e53ccc9ade67ed1511cc0ccdb8) fix rust-src handling
* [`d599d10e`](https://github.com/cachix/devenv/commit/d599d10ed9f7bb8c38d183d6f95817aa1e69a114) switch back to fenix, fix rust-src detection
* [`1c8bfc15`](https://github.com/cachix/devenv/commit/1c8bfc15829623b8efdb1d60c0d88f5baf2641ae) fallback on null for pre-commit tools
* [`0d0dedcd`](https://github.com/cachix/devenv/commit/0d0dedcd24a925c193fed96b410dd18105e198e9) slight docs improvement
* [`b98d24dd`](https://github.com/cachix/devenv/commit/b98d24ddc6d46252df1920fea44241f8fb6e45b2) doc: fix python example
* [`82b841ca`](https://github.com/cachix/devenv/commit/82b841ca356c93bdb25a719f4eb544569f04e392) Point to all service definitions in the docs.
* [`464ba827`](https://github.com/cachix/devenv/commit/464ba827fcb8fb54415ffcb542ee1c2fe230d035) Update docs/services.md
* [`e31e2943`](https://github.com/cachix/devenv/commit/e31e294337fc40bf94adcb7cc15ddbb6a070b098) doc: make sure we use latest tag with flakes
* [`c6e53263`](https://github.com/cachix/devenv/commit/c6e532631b7d2fa6d5e095435984d3543765f17f) use privacy focused phantom analytics
* [`0c0570fe`](https://github.com/cachix/devenv/commit/0c0570fe13988374911873d55eb4eb9dac716ba6) container: allow copyToRoot to be a list
* [`70d8ee26`](https://github.com/cachix/devenv/commit/70d8ee2698a1378ebef1e29075995b04c056f7c7) Auto generate docs/reference/options.md
* [`cfef2b16`](https://github.com/cachix/devenv/commit/cfef2b166a69789faed291b21ec9714dc92f8b92) address review
* [`1a1f5726`](https://github.com/cachix/devenv/commit/1a1f5726f25299c12a19298a82053559fbcb6e11) error message for unset components
* [`e2e1f371`](https://github.com/cachix/devenv/commit/e2e1f371ddd331386f2b3e24100399db348184c2) mkDefault for fenix toolchain components
* [`e2ac9a78`](https://github.com/cachix/devenv/commit/e2ac9a782ac37515e084859e7fef5a686d940d15) fix mkIf channel
* [`65c10564`](https://github.com/cachix/devenv/commit/65c105643a56a30445df66d86ae592395a519ddb) containers: instruct how to set up remote builder
* [`41cea1b8`](https://github.com/cachix/devenv/commit/41cea1b859bc8836134160832a6c344f70eb8ed7) doc: note where to find all language options
* [`9ba9e3b9`](https://github.com/cachix/devenv/commit/9ba9e3b908a12ddc6c43f88c52f2bf3c1d1e82c1) doc: remove warning about macos and containers
* [`e6d08ade`](https://github.com/cachix/devenv/commit/e6d08adee618bc3de95f7ad5825697b3cac74167) Add an example for DEVENV_ROOT
* [`4d6573cc`](https://github.com/cachix/devenv/commit/4d6573cca17b4c7fba34c56d266376358f0265e8) update rust example
* [`3ca8bf34`](https://github.com/cachix/devenv/commit/3ca8bf340adef6282192a2f6581f7786a0bd3d00) doc: using-with-flakes needs to use main branch to get all the updates
* [`1e4701fb`](https://github.com/cachix/devenv/commit/1e4701fb1f51f8e6fe3b0318fc2b80aed0761914) typo
* [`ddba5b44`](https://github.com/cachix/devenv/commit/ddba5b442488a0036bba88097b9048d83dd0e709) env: fix infinite recursion errors
* [`1802002f`](https://github.com/cachix/devenv/commit/1802002fe851b01064484b7e1204be1b8329cae5) fix infinite recurse in languages.rust on macos
* [`e4a48ced`](https://github.com/cachix/devenv/commit/e4a48ced9b4910a3031ffc18525bddd0e04b858c) Add an example hello world rust app and test it.
* [`a0072963`](https://github.com/cachix/devenv/commit/a0072963244220b3301375b484e8926131146fce) Implement dotenv integration
* [`d9e5c076`](https://github.com/cachix/devenv/commit/d9e5c076f6112a3e3c1c40fcbaf9624530603eb1) version -> channel
* [`cc085ec0`](https://github.com/cachix/devenv/commit/cc085ec00841ab9b67e50cc246bf1ad3d9e6b674) Auto generate docs/reference/options.md
* [`10229589`](https://github.com/cachix/devenv/commit/1022958920915e3aafdb5bf830121161b38c0824) doc: flakes support for dotenv works
* [`cb137b5b`](https://github.com/cachix/devenv/commit/cb137b5bd3fe8451611c7ecb8d988749391b2819) bump install-nix-action
* [`995e7ec9`](https://github.com/cachix/devenv/commit/995e7ec9868cdfe669ad0b68258d15860a2a5472) doc: document dotenv.filename
* [`8ba049dd`](https://github.com/cachix/devenv/commit/8ba049dd0298bf6605d908c1ca0ee88e2a66bf68) dotenv: improve hint
* [`e19997d6`](https://github.com/cachix/devenv/commit/e19997d60cfaa57bf1c8e1dba3aef00f5a046a58) add logos
* [`c8d0dd77`](https://github.com/cachix/devenv/commit/c8d0dd774e8fd0e9dc63e5f7c821a41659f10d78) ignore .env files
* [`ccf8e270`](https://github.com/cachix/devenv/commit/ccf8e27079f2ba2b2335c82ccc66bbcc753da6e9) document vscode integration
* [`4d32f270`](https://github.com/cachix/devenv/commit/4d32f270c290afd8faecd365f57f0a5ed6ad77fe) rust example: remove disable pre-commit hooks
* [`3477deed`](https://github.com/cachix/devenv/commit/3477deed6f069094f4fc8d0beece826f73a883ba) mkDefault for pre-commit tools
* [`0af16235`](https://github.com/cachix/devenv/commit/0af162353c6c997d567053b3aeb45fbc25a72457) Fix a bug in flake integration
* [`6a30b674`](https://github.com/cachix/devenv/commit/6a30b674fb5a54eff8c422cc7840257227e0ead2) dotenv.enable: don't crash if the file is missing but hint how to get started
* [`bad82763`](https://github.com/cachix/devenv/commit/bad8276329b90387ca5a4e071e558bdff937c484) Update examples/rust/.test.sh
* [`9691d307`](https://github.com/cachix/devenv/commit/9691d307f1f4b3827db13692cecaa9598cddf2c5) fix: php-fpm termination
* [`5023b680`](https://github.com/cachix/devenv/commit/5023b680196cc93011d2d6f12d0d24bbb514c797) Update languages.md (typo)
* [`85b58351`](https://github.com/cachix/devenv/commit/85b5835192787dc697650b627d9e8a7d0b4753ff) add renamed hints
* [`7d235b92`](https://github.com/cachix/devenv/commit/7d235b925c8385995645f26a440a54e5aeff3fb9) remove example lock
* [`c81f0263`](https://github.com/cachix/devenv/commit/c81f0263446629e961a82736565565dc75eeb733) Auto generate docs/reference/options.md
