### PR TITLE
niv fast-syntax-highlighting: update 13d7b4e6 -> cf318e06

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "13d7b4e63468307b6dcb2dadf6150818f242cbff",
-        "sha256": "0ghzqg1xfvqh9z23aga7aafrpxbp9bpy1r8vk4avi6b80p3iwsq2",
+        "rev": "cf318e06a9b7c9f2219d78f41b46fa6e06011fd9",
+        "sha256": "1bmrb724vphw7y2gwn63rfssz3i8lp75ndjvlk5ns1g35ijzsma5",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/13d7b4e63468307b6dcb2dadf6150818f242cbff.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/cf318e06a9b7c9f2219d78f41b46fa6e06011fd9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@13d7b4e6...cf318e06](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/13d7b4e63468307b6dcb2dadf6150818f242cbff...cf318e06a9b7c9f2219d78f41b46fa6e06011fd9)

* [`cf318e06`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/cf318e06a9b7c9f2219d78f41b46fa6e06011fd9) Add '--message' to git commit syntax highlighting ([zdharma-continuum/fast-syntax-highlighting⁠#57](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/57))
