### PR TITLE
niv home-manager: update c24deeca -> a6d1d954

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c24deeca64538dcbc589ed8da9146e4ca9eb85b7",
-        "sha256": "0l16sh9v3s8rsiaf16bc3fbnmk0i1ca3vx6f261ryrr2jhvl4xcy",
+        "rev": "a6d1d954b81caf4c9291b8ac35452fef842f289b",
+        "sha256": "0xrdn680b9hjc13m9mwqr0n701hwrdcy18cmax4vyddyir8gdc40",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c24deeca64538dcbc589ed8da9146e4ca9eb85b7.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a6d1d954b81caf4c9291b8ac35452fef842f289b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c24deeca...a6d1d954](https://github.com/nix-community/home-manager/compare/c24deeca64538dcbc589ed8da9146e4ca9eb85b7...a6d1d954b81caf4c9291b8ac35452fef842f289b)

* [`3be2abb2`](https://github.com/nix-community/home-manager/commit/3be2abb2e6df41d9ddd5816032adf91691328225) i18n: Use glibcLocales from NixOS if possible ([nix-community/home-manager⁠#2333](https://togithub.com/nix-community/home-manager/issues/2333)) ([nix-community/home-manager⁠#4177](https://togithub.com/nix-community/home-manager/issues/4177))
* [`d895a774`](https://github.com/nix-community/home-manager/commit/d895a774489cacd10c0140d54c4d158a53dcde90) vdirsyncer: synchronize metadata as well ([nix-community/home-manager⁠#4167](https://togithub.com/nix-community/home-manager/issues/4167))
* [`4a26e210`](https://github.com/nix-community/home-manager/commit/4a26e21030a6ea9adbcc967812286bbe71fe45c5) programs.khal
* [`b406b8d1`](https://github.com/nix-community/home-manager/commit/b406b8d1bc90f6cd3e120d189b3e929f17ca4aea) PULL_REQUEST_TEMPLATE.md: add maintainer cc section ([nix-community/home-manager⁠#4193](https://togithub.com/nix-community/home-manager/issues/4193))
* [`b66af0ac`](https://github.com/nix-community/home-manager/commit/b66af0ac666d01f95c8f83e60b02a851700c048c) Translate using Weblate (Indonesian)
* [`2f78e6fc`](https://github.com/nix-community/home-manager/commit/2f78e6fcba61ce81536d19e6c662e55ab272d539) antidote: static file move to /tmp
* [`b23c7501`](https://github.com/nix-community/home-manager/commit/b23c7501f7e0a001486c9a5555a6c53ac7b08e85) i3: remove deprecated example in i3.config.startup ([nix-community/home-manager⁠#4201](https://togithub.com/nix-community/home-manager/issues/4201))
* [`719de878`](https://github.com/nix-community/home-manager/commit/719de878f75b293eb3a8ab30943ae6ecf458c0a4) imapnotify: Add launchd agent ([nix-community/home-manager⁠#3291](https://togithub.com/nix-community/home-manager/issues/3291))
* [`34db2f05`](https://github.com/nix-community/home-manager/commit/34db2f05219bcb0e41cc85490e4c338e2405546c) unison: Allow using same option multiple times ([nix-community/home-manager⁠#4208](https://togithub.com/nix-community/home-manager/issues/4208))
* [`f288310b`](https://github.com/nix-community/home-manager/commit/f288310b7adf9775e405f251eb4920969fd8afa5) goimapnotify: remove test dependency on notmuch
* [`af715ed8`](https://github.com/nix-community/home-manager/commit/af715ed857f9d94086e4ef833949944bf0322521) tests: some minor cleanups
* [`050d01a6`](https://github.com/nix-community/home-manager/commit/050d01a62cfe19642fb193084acf34a428a67223) darcs: add module
* [`069d450b`](https://github.com/nix-community/home-manager/commit/069d450b6d2da9369ee5a8ddb2dbf909d3535471) pyenv: add module
* [`98282a48`](https://github.com/nix-community/home-manager/commit/98282a481df50d357e9cbfa7e6a6d481df37e8c2) swayosd: add module
* [`24805d3c`](https://github.com/nix-community/home-manager/commit/24805d3ca73f7d4c34239efaa1c73d2d4558a8ea) himalaya: fix notmuch backend
* [`e15010ee`](https://github.com/nix-community/home-manager/commit/e15010ee6e9bd356a6746ff9b9f9a9097ee8ddcf) nushell: add login.nu configuration option
* [`86157256`](https://github.com/nix-community/home-manager/commit/86157256d2e0d257c53eefeb008230f043e12210) flake.lock: Update
* [`fad47555`](https://github.com/nix-community/home-manager/commit/fad475553ae2de3ba1dbcab980698ac070d04e72) imapnotify: use direct nix store path for config
* [`b70db52f`](https://github.com/nix-community/home-manager/commit/b70db52ff06f30e3de7f21b6ea47e75baa0c46f6) imapnotify: move test
* [`a6d1d954`](https://github.com/nix-community/home-manager/commit/a6d1d954b81caf4c9291b8ac35452fef842f289b) ssh-agent: add assertion and fix news entry ([nix-community/home-manager⁠#4210](https://togithub.com/nix-community/home-manager/issues/4210))
