### PR TITLE
niv nixpkgs: update 2169d3b0 -> da5286cd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2169d3b0bce0daa64d05abbdf9da552a7b8c22a7",
-        "sha256": "151fl31656crvy0hpk653cbiawrwrda6c6k8q0pr8blspld8f1zf",
+        "rev": "da5286cd2b23e080b383594d6069e4487ef233de",
+        "sha256": "07d7ikcz6shr8y45c6jqbi6k1nj8m5s4nq2njc1xn1aahrdzqx8j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/2169d3b0bce0daa64d05abbdf9da552a7b8c22a7.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/da5286cd2b23e080b383594d6069e4487ef233de.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@2169d3b0...da5286cd](https://github.com/nixos/nixpkgs/compare/2169d3b0bce0daa64d05abbdf9da552a7b8c22a7...da5286cd2b23e080b383594d6069e4487ef233de)

* [`80d6a33b`](https://github.com/NixOS/nixpkgs/commit/80d6a33ba604c6aa421c775a1f903f0c0346e5fe) nixos/nitter: wait for online network
* [`6b2a42af`](https://github.com/NixOS/nixpkgs/commit/6b2a42af7dab783341f21f7c394bea5474afe483) openmodelica: add openscenegraph to OMEdit build (enables 3D animation)
* [`e7cd275c`](https://github.com/NixOS/nixpkgs/commit/e7cd275cd837aebf98fbbc89b037bda475de9e42) fetchYarnDeps: account for more yarn.lock spec edge cases
* [`88375f1b`](https://github.com/NixOS/nixpkgs/commit/88375f1b74211487c0574033f958fdc06b783312) fetchYarnDeps: fix test hashes
* [`a777753e`](https://github.com/NixOS/nixpkgs/commit/a777753eb26c96144d58f899b5893509a87b6f5a) fetchYarnDeps: add more git url tests
* [`61dfdf0c`](https://github.com/NixOS/nixpkgs/commit/61dfdf0ce0da14f74ed3153ef2f4c66db2475e51) maintainers: add septem9er
* [`6ccf7944`](https://github.com/NixOS/nixpkgs/commit/6ccf7944210698b57371819148c4fbc64f9188e1) Cardinal: 22.12 -> 23.02
* [`d0ae3989`](https://github.com/NixOS/nixpkgs/commit/d0ae39891514ab7f0cbfe668870f54f5749fc177) python310Packages.ypy-websocket: 0.8.4 -> 0.9.0
* [`4d9c9540`](https://github.com/NixOS/nixpkgs/commit/4d9c9540969e09e6a538db0f4f1e59fd0d4e7492) python310Packages.jupyter-server-ydoc: relax ypy-websocket version pin
* [`62ddc304`](https://github.com/NixOS/nixpkgs/commit/62ddc304f8b463aac02f9a72ab46959a1ea0dcb2) opendht: 2.4.12 -> 2.5.5
* [`2222222b`](https://github.com/NixOS/nixpkgs/commit/2222222b0f41747f14fcbeb20a03c7dfc16b9389) libva: build minimal without a dependency on wayland
* [`55555553`](https://github.com/NixOS/nixpkgs/commit/55555553a33fbc6bc880fcb5d62b6683dd7f8e95) libva: remove libva-minimal input
* [`e6bbace6`](https://github.com/NixOS/nixpkgs/commit/e6bbace6236aa6b3cda1df667b19d7d1ec2e18b0) eventstore: add meta.mainProgram
* [`34711ba5`](https://github.com/NixOS/nixpkgs/commit/34711ba5cfbe6eb28bef5f53aca02d622880ba59) kaldi: Fix build
* [`e8588071`](https://github.com/NixOS/nixpkgs/commit/e8588071cc2905a13c164292bd7e93ca29d1031c) kaldi: Remove openfst from inputs
* [`5abf11a9`](https://github.com/NixOS/nixpkgs/commit/5abf11a956794ba5245fb7636bf9b895d5a5281b) kaldi: Add update script
* [`2024f7d1`](https://github.com/NixOS/nixpkgs/commit/2024f7d11d5c9df21728ba5c15ffac370692bb29) kaldi: unstable-2022-09-26 → unstable-2023-05-02
* [`eb0b0131`](https://github.com/NixOS/nixpkgs/commit/eb0b0131ceacce1b1d1cbecc1f27fd747a9b507e) util-linux: split mount, login and swap utils into their own outputs
* [`7cfeb768`](https://github.com/NixOS/nixpkgs/commit/7cfeb768e5f2a160075d8736101444c10f1c5ea6) fix herbstluftwm session command
* [`c4939290`](https://github.com/NixOS/nixpkgs/commit/c493929058118b0b28dbccfc059f45782383121d) opustags: 1.8.0 -> 1.9.0
* [`b504b9e2`](https://github.com/NixOS/nixpkgs/commit/b504b9e2800d297e34b326f6bf6f1161215eef02) dav1d: 1.2.0 -> 1.2.1
* [`cf5bf9b4`](https://github.com/NixOS/nixpkgs/commit/cf5bf9b41aa3746289ab4cfbfcd63489457edc44) apparmor: fix licenses and add myself as maintainer
* [`e0225767`](https://github.com/NixOS/nixpkgs/commit/e02257675875bcef6740c3da79a418a5afaf5c0d) mercurial: 6.4.3 -> 6.4.5
* [`c83df39b`](https://github.com/NixOS/nixpkgs/commit/c83df39b80e8715b5056b94c6d97e749ce2d90ca) apparmor: 3.1.5 -> 3.1.6
* [`8d745b52`](https://github.com/NixOS/nixpkgs/commit/8d745b523224ab346668ae96b4927950f8ed848f) maintainers: add CaitlinDavitt
* [`10092837`](https://github.com/NixOS/nixpkgs/commit/1009283759dafbc9d47ea226f80caa6602217206) mpd-notification: init at 0.8.7
* [`e0d2053b`](https://github.com/NixOS/nixpkgs/commit/e0d2053b87da7184b60256bae136c4c54a53a3d9) build-support: Use response-expanded params in pie test
* [`37b323d6`](https://github.com/NixOS/nixpkgs/commit/37b323d6fd5d03daba5d2717e8ab72f98f1d2ea0) nss_esr: 3.79.4 -> 3.90
* [`bb536346`](https://github.com/NixOS/nixpkgs/commit/bb53634671d5bb63e060919d5062d079b5e50b98) nss: drop now-unused patches and conditions
* [`ad242e48`](https://github.com/NixOS/nixpkgs/commit/ad242e48376b3578b98dae8459ca9a97e44d4d93) python310Packages.sqlalchemy: 2.0.15 -> 2.0.17
* [`d684b0f7`](https://github.com/NixOS/nixpkgs/commit/d684b0f78c7d7b3b97704e9d90a99b669e8dee8a) vim: 9.0.1562 -> 9.0.1642
* [`d9a3464f`](https://github.com/NixOS/nixpkgs/commit/d9a3464ffc3a3521aafb927fa65353be8f102c5f) python3Packages.zstd: 1.5.4.0 -> 1.5.5.1
* [`77d4f4fe`](https://github.com/NixOS/nixpkgs/commit/77d4f4feee0798084925a9b2affe6fa37dee97e8) discourse.assets: work around `cannot execute: required file not found`
* [`b682b96a`](https://github.com/NixOS/nixpkgs/commit/b682b96a7f29ddc5bfb262251693fe323ea50201) libtiff: 4.5.0 -> 4.5.1
* [`f0e6e947`](https://github.com/NixOS/nixpkgs/commit/f0e6e9472c8c2077276bce32f166dc790ead11a1) flac: 1.4.2 -> 1.4.3
* [`db3e94c3`](https://github.com/NixOS/nixpkgs/commit/db3e94c3b2046108932442d0b9c77711d4588574) hardening flags: enable fortify3 by default
* [`59a02631`](https://github.com/NixOS/nixpkgs/commit/59a02631bfc08aee9b88cadb5def2d1bce0a6a97) orc: 0.4.33 -> 0.4.34
* [`89f67171`](https://github.com/NixOS/nixpkgs/commit/89f671716a4a23e121ab68e7d691fef283ef5e00) fzf: patch fzf-tmux' bc dependency
* [`c368a898`](https://github.com/NixOS/nixpkgs/commit/c368a898f8f5d3fdae717fa0d40bffb534c8f7d0) orc: add changelog to meta
* [`bc4e2de3`](https://github.com/NixOS/nixpkgs/commit/bc4e2de3ab793c72850b529d1ff4ce53ed5baacd) xorg.libXau: 1.0.9 -> 1.0.11
* [`f2d4baf4`](https://github.com/NixOS/nixpkgs/commit/f2d4baf4113c3bc8bcfa8f1fd3b3d024efc9c3c3) pulumiPackages.pulumi-language-go: fix build
* [`8f519f4c`](https://github.com/NixOS/nixpkgs/commit/8f519f4c985c3c1c649316367889351a5174083e) pulumiPackages.pulumi-language-nodejs: fix build
* [`6802820e`](https://github.com/NixOS/nixpkgs/commit/6802820e0624a66185b2d1bda2b8ba26dac0d18d) mesa: build i915 driver
* [`0feb3279`](https://github.com/NixOS/nixpkgs/commit/0feb32794a52d271b13b9a131f7629ecc8bc7659) pipewire: 0.3.71 -> 0.3.72
* [`afecc9a6`](https://github.com/NixOS/nixpkgs/commit/afecc9a625fadddecc210e844827fb19cc641133) pypy3Packages.cryptography: fix build under pypy
* [`67bf09ea`](https://github.com/NixOS/nixpkgs/commit/67bf09ea95bc940bed1c80e5c70090bb1ee16ab6) ghostscript: fix dynamic linking of gsx on darwin
* [`a15a0ca7`](https://github.com/NixOS/nixpkgs/commit/a15a0ca7ab2017fb16041b27928e5b98bdda6444) linuxHeaders: 6.3 -> 6.4
* [`212a2837`](https://github.com/NixOS/nixpkgs/commit/212a283707cd9135ad79663c5c47d5c09fd76907) rust-bindgen: 0.66.0 -> 0.66.1
* [`b00ac84e`](https://github.com/NixOS/nixpkgs/commit/b00ac84e2c855d4fb830a48cfac268dcecac1844) raspberrypiWirelessFirmware: symlinks for Zero 2W
* [`169f3a1b`](https://github.com/NixOS/nixpkgs/commit/169f3a1bbd14562fab8192e6608f99f9eaccfdea) python310Packages.matplotlib: add setuptools to nativeBuildInputs
* [`1370fe7c`](https://github.com/NixOS/nixpkgs/commit/1370fe7c360fc1f9ae512de45923f2053f4cb67c) nixos/no-x-libs: add python3.pkgs.matplotlib
* [`4920af40`](https://github.com/NixOS/nixpkgs/commit/4920af40fce2c56ae2c4fd08ad1ff8b6f1dc80b1) doc/reviewing-contributions: Add points about patches
* [`c3c028d2`](https://github.com/NixOS/nixpkgs/commit/c3c028d2bbce1a527c20dc7195d6b5f876965daa) graylogPlugins.splunk: init at 0.5.0-rc.1
* [`2c71f447`](https://github.com/NixOS/nixpkgs/commit/2c71f447307bf5863eed771fccc68f645bb6d937) s2n-tls: 1.3.45 -> 1.3.46
* [`90acc831`](https://github.com/NixOS/nixpkgs/commit/90acc83140073d12489f742ae99aee9669dc2222) tpm2-tss: 3.2.0 -> 4.0.1
* [`a0a4354a`](https://github.com/NixOS/nixpkgs/commit/a0a4354a13f7c25bad03173ffa528d220dec5a63) doc/reviewing-contributions: Remove wrong fetchpatch detail
* [`40961a8f`](https://github.com/NixOS/nixpkgs/commit/40961a8ff5cec582b86533c3e4ed651f77da2540) pypy3Packages.execnet: disable tests as they randomly crash, cleanup
* [`903f19e0`](https://github.com/NixOS/nixpkgs/commit/903f19e08e9105552f3d971c7874d23c1371749c) libfido2: disable fortify3 hardening flag
* [`86b30e35`](https://github.com/NixOS/nixpkgs/commit/86b30e3551c88ad56f0605bfd32bb095b648b8b9) bundler: 2.4.14 -> 2.4.15
* [`4e00c6ce`](https://github.com/NixOS/nixpkgs/commit/4e00c6cee416e3aa236c447bd8ac0ec4a391c5aa) ruby.rubygems: 3.4.14 -> 3.4.15
* [`4f27b3ce`](https://github.com/NixOS/nixpkgs/commit/4f27b3cea1798a6b312d42a91db44de364017776) python310Packages.ocrmypdf: 14.2.1 -> 14.3.0
* [`d7474a3a`](https://github.com/NixOS/nixpkgs/commit/d7474a3a1cc734e6388fff7f1e8f7e3293a60b33) graphviz: 7.1.0 -> 8.0.5
* [`b3fa79bb`](https://github.com/NixOS/nixpkgs/commit/b3fa79bb8965f7d3353daf99b137170314899a53) submitting-changes.chapter.md: explain *why* we have three branches
* [`910d4f76`](https://github.com/NixOS/nixpkgs/commit/910d4f761a0859f35149f0952b64d2c49c8841d4) Revert "Revert "submitting-changes.chapter.md: explain *why* we have three branches""
* [`8a74c9bd`](https://github.com/NixOS/nixpkgs/commit/8a74c9bd31e17e5e817f4757deabc94e6bd5f6be) gnupg: remove systemd user config
* [`dce1a859`](https://github.com/NixOS/nixpkgs/commit/dce1a85956e797ecee5dcd174c12fa9560fd5836) Revert "Revert "gnupg: 2.4.0 -> 2.4.1""
* [`541797be`](https://github.com/NixOS/nixpkgs/commit/541797bedc0fc5a273ff3cb499ef7a260c3b7cc3) maintainers: add goatchurchprime
* [`e05bacf4`](https://github.com/NixOS/nixpkgs/commit/e05bacf4e83c3e42addb3f39023ce30c49dac57c) importCargoLock: fix git dep config file
* [`80d4ee36`](https://github.com/NixOS/nixpkgs/commit/80d4ee361542f9a3e6a3b7b996e81329c6350446) pot: remove the workground for different branch of the same git dep
* [`86f94c3e`](https://github.com/NixOS/nixpkgs/commit/86f94c3e45e0ea38ecd2aebfecc1680530fd3a34) prefetch-yarn-deps: add tests passthru
* [`5cdfd8ac`](https://github.com/NixOS/nixpkgs/commit/5cdfd8acfb6f8312f35c58e1dd7336eea9f4480f) python310Packages.dask-histogram: init at 2023.6.0
* [`e7c7d928`](https://github.com/NixOS/nixpkgs/commit/e7c7d9284503e20de502572aa8ff0ac5a72599a7) python310Packages.correctionlib: init at 2.2.2
* [`09373814`](https://github.com/NixOS/nixpkgs/commit/0937381495f2cbb16b7ed719546a1cbdaf6ed51d) python310Packages.coffea: init at 2023.6.0.rc1
* [`4f67734e`](https://github.com/NixOS/nixpkgs/commit/4f67734e2b75afe8d42adf1b5c088150254db02d) jq: fix build with clang 16 on Darwin
* [`e3323ac2`](https://github.com/NixOS/nixpkgs/commit/e3323ac20c3f0744f3f6128a5464652121eb8d4f) boost{175,176,177,178,179,180}: fix build with libc++ 15+
* [`cec7b5e8`](https://github.com/NixOS/nixpkgs/commit/cec7b5e87ce04a19e9b26366cf9cd6f5139a6870) boost{175,176,177,178,179,180}: fix build with clang 16
* [`4abf3027`](https://github.com/NixOS/nixpkgs/commit/4abf3027d8ee8b120d0bfc0f17e00bb28a3150cc) opensp: fix build with clang 16
* [`91ef45c9`](https://github.com/NixOS/nixpkgs/commit/91ef45c98ad8b569cb39a5ddbb14894adb9822a3) gcc: disable glibc<->libgcc circularity workaround for windows and LLVM
* [`7272366a`](https://github.com/NixOS/nixpkgs/commit/7272366a522ea55ab0c5e37c586d09e6942df6e6) xterm: 382 -> 383
* [`18bbf33b`](https://github.com/NixOS/nixpkgs/commit/18bbf33b382828c495c33619e692f5978fa7c8a2) test.cross.mbuffer: init
* [`550137e3`](https://github.com/NixOS/nixpkgs/commit/550137e330ebb5e0d7b114f8af2e0d244e07dcb7) configd: fix build with clang 16
* [`6f43859a`](https://github.com/NixOS/nixpkgs/commit/6f43859a3a55d05167d50a244c9e4c79e009e873) CODEOWNERS: ping @⁠amjoseph-nixpkgs on certain trees
* [`ffd7dbc6`](https://github.com/NixOS/nixpkgs/commit/ffd7dbc6dd40e2aeb80f367d0997106e7c22b07b) threadsCross: factor out copy-and-pasted code
* [`cf77dee3`](https://github.com/NixOS/nixpkgs/commit/cf77dee3ad8cce0e14f783121f42021e2dc9a2e3) cctools-port: fix build with clang 16 on x86_64-darwin
* [`9269d582`](https://github.com/NixOS/nixpkgs/commit/9269d5823d1b8ef09d2fe042d34716b294f6bcd2) tlaplus18: init at 1.8.0
* [`e4a1b664`](https://github.com/NixOS/nixpkgs/commit/e4a1b664ea516067ff8843a7d7d7e8d4f9cb48be) cups: 2.4.5 -> 2.4.6
* [`581894d4`](https://github.com/NixOS/nixpkgs/commit/581894d4379d86134dc7bda2150ebc2505e03775) libuv: 1.45.0 -> 1.46.0
* [`75f431fb`](https://github.com/NixOS/nixpkgs/commit/75f431fb84e45c4830b803dbd6dd75f6baf4db1b) xmlto: fix build with clang 16
* [`fb26d16e`](https://github.com/NixOS/nixpkgs/commit/fb26d16e99a2ac71377297d9d37867d9d31f115e) test.cross.sanity: init
* [`4f04d221`](https://github.com/NixOS/nixpkgs/commit/4f04d2215ae852664e013b66b3534d81b7130ff3) srt: 1.5.1 -> 1.5.2
* [`81b944e5`](https://github.com/NixOS/nixpkgs/commit/81b944e502b4da06b25411be6c96b4202ab18daf) libwebp: 1.3.0 -> 1.3.1
* [`dbb11d09`](https://github.com/NixOS/nixpkgs/commit/dbb11d0990bdae1fa6466e91ce345ecf135a8717) grass: alphabetical reordering of dependencies
* [`77c75090`](https://github.com/NixOS/nixpkgs/commit/77c75090b69fbc7e628b5d5c5d56e95171c1976d) bluez: remove sap feature from build
* [`6980e6b3`](https://github.com/NixOS/nixpkgs/commit/6980e6b35aacccd4e75a76a384f9dec30f31fa55) lib.systems: introduce hasSharedLibraries
* [`e41f2172`](https://github.com/NixOS/nixpkgs/commit/e41f217257cf34d1328cad141cfb01c6f8093b37) gcc: use hasSharedLibraries instead of isStatic
* [`2affd455`](https://github.com/NixOS/nixpkgs/commit/2affd455a40a28825f356307ce5bd8fa2f202217) gccCrossStageStatic: enable dynamic libraries, rename to gccWithoutTargetLibc
* [`443dfc4b`](https://github.com/NixOS/nixpkgs/commit/443dfc4b05360794aa0304459177557107274559) gcc: s_crossStageStatic_withoutTargetLibc_
* [`63305d00`](https://github.com/NixOS/nixpkgs/commit/63305d00d32e8c743e36155a7d8cd544dc676d5b) gcc: withoutTargetLibc: build libgcc_s.so
* [`96a2f1b4`](https://github.com/NixOS/nixpkgs/commit/96a2f1b4e1315251f1916f64c4632dbf7eb40522) gcc: kludge to prevent mass-rebuild
* [`3baf330d`](https://github.com/NixOS/nixpkgs/commit/3baf330d55b79466e7f6c6a16dcc112a4c596d8b) linux_6_1: 6.1.36 -> 6.1.37
* [`062a762d`](https://github.com/NixOS/nixpkgs/commit/062a762d9cc9f7f6c73f1b87c7394ca404ddf422) linux_6_3: 6.3.10 -> 6.3.11
* [`01d54a2e`](https://github.com/NixOS/nixpkgs/commit/01d54a2e6434a399c38c4cd3febc7aeec5b78d02) linux_6_4: 6.4 -> 6.4.1
* [`3ea8390d`](https://github.com/NixOS/nixpkgs/commit/3ea8390db35bc464c08800884f0305d9a3cd16f8) perl: use makeBinaryWrapper for perl.withPackages
* [`37023bfd`](https://github.com/NixOS/nixpkgs/commit/37023bfde7e35079c93dcb65e85e99be18efefae) minimal-bootstrap: use recursive FOD to make nix unpack bootstrap sources
* [`f391b86e`](https://github.com/NixOS/nixpkgs/commit/f391b86e969bd439b806227c4ae6fda0d7ecd622) gridtracker: add wrapGAppsHook
* [`b2574122`](https://github.com/NixOS/nixpkgs/commit/b2574122a9f41f67a82e69aad79c29a69e0c55bb) cctools: make cctools-llvm the default on Darwin
* [`79dffec1`](https://github.com/NixOS/nixpkgs/commit/79dffec139fdfc7d086e360762f1815b86eae7c4) grass: add package tests
* [`6302ba07`](https://github.com/NixOS/nixpkgs/commit/6302ba07e3e3b493d0c67957fc343265f9a018d6) db: fix build with clang 16
* [`38018514`](https://github.com/NixOS/nixpkgs/commit/38018514e88f9e724bc709554e56bfe84acb46ac) db: fix build with clang 16 on Darwin
* [`a8453970`](https://github.com/NixOS/nixpkgs/commit/a845397040d1b85cec4ee41edb8598d8086c3d95) darwin.stdenv: refactor stdenv definition
* [`8c16d17b`](https://github.com/NixOS/nixpkgs/commit/8c16d17bdc9c0da8bc655cfc4ef601b1b9bef2d6) swift-corelibs: fix build with clang 16
* [`aeb53a82`](https://github.com/NixOS/nixpkgs/commit/aeb53a823f21caf9bbe4c30773e343ab95ff8d81) swift-corelibs: switch build system to cmake
* [`6dbdf283`](https://github.com/NixOS/nixpkgs/commit/6dbdf283cfe0620578ab198af3569195e0900a11) swift-corelibs: switch to nixpkgs icu
* [`ebc1bcf4`](https://github.com/NixOS/nixpkgs/commit/ebc1bcf409aa6398eb6da67aa95a5c2a2b944fc2) swift-corelibs: don’t link against libcurl
* [`8bee297d`](https://github.com/NixOS/nixpkgs/commit/8bee297d1517f527fbbac310e6096f573e226b9c) swift-corelibs: actually provide and use the hook
* [`5a450bdd`](https://github.com/NixOS/nixpkgs/commit/5a450bdd9f3d5f79b5a95c5c0905509516bd7ab7) xorg.*: update to latest version
* [`3c92ad4d`](https://github.com/NixOS/nixpkgs/commit/3c92ad4d9b178a17619173a843edbe3500614ec1) python3Packages.matplotlib-sixel: add imagemagick runtime dependency
* [`a10db193`](https://github.com/NixOS/nixpkgs/commit/a10db1930cbdfbee274abd0a80ac4226295e4696) transmission_4: init at 4.0.3
* [`d5188368`](https://github.com/NixOS/nixpkgs/commit/d5188368ce62dca0821b5a157f9d7d6124d0cc82) libutp_3_4: init at 3.4
* [`760949b7`](https://github.com/NixOS/nixpkgs/commit/760949b72bcb5762ffed8c39124f1704e784b1d4) transmission_4: make sure to use dependencies from nixpkgs
* [`a58c8585`](https://github.com/NixOS/nixpkgs/commit/a58c8585e285b371d751316781f96a27cbbb1855) transmission_4: mark as broken on x86_64-darwin
* [`16f4d582`](https://github.com/NixOS/nixpkgs/commit/16f4d582a6dd369c9f9bd757185a6a44f25b6170) python310Packages.django_3: 3.2.19 -> 3.2.20
* [`61f8ae06`](https://github.com/NixOS/nixpkgs/commit/61f8ae06645f9b3723c08ab3d7822669e72b0b32) upwork: 5.8.0.24 -> 5.8.0.31
* [`9258734d`](https://github.com/NixOS/nixpkgs/commit/9258734d718d3416bbf958dfff4da28b66f474b2) srb2: 2.2.10 -> 2.2.11
* [`c30b80d3`](https://github.com/NixOS/nixpkgs/commit/c30b80d36146dba83ef3eec172acbb84e4057bb1) sysdig: 0.31.5 -> 0.32.0
* [`597f8379`](https://github.com/NixOS/nixpkgs/commit/597f83798dd95205862b31e27db54684d6026617) diffutils: disable hanging test on x86_64-darwin
* [`ddbc49bb`](https://github.com/NixOS/nixpkgs/commit/ddbc49bb57ad076adaf45ab70ba840e2cee0a154) xorg.xorgcffiles: drop upstreamed patch
* [`c24f38ad`](https://github.com/NixOS/nixpkgs/commit/c24f38ad30a59481b1e6fd7d243e8b34be294c91) xorg.xkeyboardconfig: build with meson
* [`5428e352`](https://github.com/NixOS/nixpkgs/commit/5428e35252285714f582da44ec7ad558b1dfb20a) probe-rs: 0.18.0 -> 0.19.0
* [`39762cef`](https://github.com/NixOS/nixpkgs/commit/39762cefc6eb0990d8764b1fab9b6b5716d8c3f1) astc-encoder: 4.4.0 -> 4.5.0
* [`1d35186f`](https://github.com/NixOS/nixpkgs/commit/1d35186f4098b394a4c6fd0cf3f0e2d5465e8c92) xorg.xf86inputkeyboard: set meta.platforms
* [`04d69226`](https://github.com/NixOS/nixpkgs/commit/04d69226f73e2f6ff375e2b8e7dbfcb62158feb1) git-town: 7.8.0 -> 9.0.0
* [`6c6abbac`](https://github.com/NixOS/nixpkgs/commit/6c6abbacd3c8d9e551149d69b055150d791aff64) openexr: increase test timeout
* [`e27bbea5`](https://github.com/NixOS/nixpkgs/commit/e27bbea50676ed9a0d17d528de4a66ce5c68d441) zimg: 3.0.4 -> 3.0.5
* [`1f8c860f`](https://github.com/NixOS/nixpkgs/commit/1f8c860f636971e56f55ef02b1e55525d0653ed4) maintainers: add james-atkins
* [`f83c38eb`](https://github.com/NixOS/nixpkgs/commit/f83c38ebe9261813b78187f1fcbd3c2b06685042) libxcrypt: Fix building with -march=native
* [`1cdbaeaf`](https://github.com/NixOS/nixpkgs/commit/1cdbaeaf702cb1e86818875f6656c50b32e6e76c) python310Packages.translatehtml: compatibility with new beautifulsoup4
* [`57712bce`](https://github.com/NixOS/nixpkgs/commit/57712bcec31879a65442c9604a6ee392b11bb765) epsonscan2: init at 6.7.61.0
* [`ded1ecbf`](https://github.com/NixOS/nixpkgs/commit/ded1ecbf585abb277c0fb1203fd266de8fcd02f4) iproute2: 6.3.0 -> 6.4.0
* [`52d1e118`](https://github.com/NixOS/nixpkgs/commit/52d1e118b9f1dc2479e114e9343a14770c3c7e38) ubports-click: Propagate required pkg-config packages properly
* [`73d415c1`](https://github.com/NixOS/nixpkgs/commit/73d415c165ebb5d9a39d990bfbc48539e55a8e54) python311Packages.asgiref: 3.6.0 -> 3.7.2
* [`1006bdac`](https://github.com/NixOS/nixpkgs/commit/1006bdaced4ad1a44d78285bced48bbc307d6bee) lightningcss: 1.21.3 → 1.21.5
* [`8502d527`](https://github.com/NixOS/nixpkgs/commit/8502d5278e4aeb190ba2b297163257940f5d3e3b) clash: 1.16.0 -> 1.17.0
* [`2f4d7504`](https://github.com/NixOS/nixpkgs/commit/2f4d7504f53043568d6d2a191daa1d2440cc5306) kicad: 7.0.5 -> 7.0.6
* [`f7d7f295`](https://github.com/NixOS/nixpkgs/commit/f7d7f295f00ae511a7863b06b8a03bcb1368a72d) kondo: 0.6 -> 0.7
* [`009757a8`](https://github.com/NixOS/nixpkgs/commit/009757a868e3aac087d79d91fc19b59f9f2df047) bookstack: 23.01.1 -> 23.06.1
* [`2b89bab3`](https://github.com/NixOS/nixpkgs/commit/2b89bab3064427407e9df8ac632544d5bcf80b7c) maintainers: add exploitoverload
* [`8622fad8`](https://github.com/NixOS/nixpkgs/commit/8622fad872df2fd801460a5549e8217647565820) python311Packages.semver: 3.0.0 -> 3.0.1
* [`8a2c033e`](https://github.com/NixOS/nixpkgs/commit/8a2c033ef59c39e58353171b344eddfcac6701b5) kotlin{-native}: 1.8.22 -> 1.9.0
* [`6d1b8e5a`](https://github.com/NixOS/nixpkgs/commit/6d1b8e5adea572f24733a05d01dfd91a9f953661) osl: add darwin support
* [`10247a1e`](https://github.com/NixOS/nixpkgs/commit/10247a1e16b5a4c7b1a520f0254e6086849d9293) Darktable: 4.4.0 -> 4.4.1
* [`88a717c5`](https://github.com/NixOS/nixpkgs/commit/88a717c5c00b997fbb4c9028d49b9bf3ba14b0b7) maintainers: add freyacodes
* [`680ee304`](https://github.com/NixOS/nixpkgs/commit/680ee304caed509735a7126368714959b4a61cf7) nixos/usbguard: rename services.usbguard.implictPolicyTarget to services.usbguard.implicitPolicyTarget
* [`f8db5a81`](https://github.com/NixOS/nixpkgs/commit/f8db5a813ce14a94544012471445861c2841eb16) python311Packages.maxminddb: 2.3.0 -> 2.4.0
* [`46451b57`](https://github.com/NixOS/nixpkgs/commit/46451b5737e0c44e1a4380b9f9375e2e85670621) pipewire: 0.3.72 -> 0.3.73
* [`225b64d4`](https://github.com/NixOS/nixpkgs/commit/225b64d40cdde4ca26a6114c9703b115165854e3) sheldon: 0.6.6 -> 0.7.3
* [`65f8078a`](https://github.com/NixOS/nixpkgs/commit/65f8078adcc5d0e8ce7eb538e83e6eb8f07231d2) appflowy: 0.2.4 -> 0.2.5
* [`8df36831`](https://github.com/NixOS/nixpkgs/commit/8df3683112f97fe11d0b40d2b7cd47914504d897) jami: add patch for opendht 2.5
* [`abcb4d0f`](https://github.com/NixOS/nixpkgs/commit/abcb4d0fbc50fee855b491fdde1846ba931a8e9b) mountain-duck: init at 4.14.1.21330
* [`9be0bfb5`](https://github.com/NixOS/nixpkgs/commit/9be0bfb5e06ce2d88b40df1235142f99389b39c4) runCommand: don't set meta.position if meta is given
* [`13db1532`](https://github.com/NixOS/nixpkgs/commit/13db153222047780ac06475998cb9c0fb82cfb8b) mediainfo: 23.04 -> 23.06
* [`1e16a937`](https://github.com/NixOS/nixpkgs/commit/1e16a937ca4c148841c15760ddc02f47ce487735) vmware-guest module: work under aarch64
* [`532b6a24`](https://github.com/NixOS/nixpkgs/commit/532b6a241764c7f6382c9e4cfc6b6ae397d53859) python3Packages.metawear: init at 1.0.8
* [`d615ce6c`](https://github.com/NixOS/nixpkgs/commit/d615ce6c71cda43cdcb82f57ad103f21513818e2) f3d: 2.0.0 -> 2.1.0
* [`55c09fa5`](https://github.com/NixOS/nixpkgs/commit/55c09fa5069d9ef00b1ed521eb4065a2104db1e8) dendrite: 0.12.0 -> 0.13.1
* [`b39481bc`](https://github.com/NixOS/nixpkgs/commit/b39481bc09a6bede802f0bb7b805694ea9cf7f2d) gcc: fix build on x86_64-darwin
* [`0378e2e6`](https://github.com/NixOS/nixpkgs/commit/0378e2e65ec8bdac95f56bbe54694bf148702fc5) invoice: init at 0.1.0
* [`6ac252c0`](https://github.com/NixOS/nixpkgs/commit/6ac252c041f6cb38d7ad9f93a2714db09d20f04c) .github/labeler.yml: Add lib label
* [`1d591b34`](https://github.com/NixOS/nixpkgs/commit/1d591b34d82a0eee1b5dd7f39d724cde51a932d0) summon: 0.8.2 -> 0.9.6
* [`8dea8eee`](https://github.com/NixOS/nixpkgs/commit/8dea8eeed97cc2dee5b48056917f677935e80c7f) virter: init at 0.25.0
* [`93320f3e`](https://github.com/NixOS/nixpkgs/commit/93320f3e303824e40f5ac91ff4d1712927cae0c7) rustc: link libc++abi on Darwin
* [`d0ce5d64`](https://github.com/NixOS/nixpkgs/commit/d0ce5d642d235d10863a0d19d554b84c8e4bab37) libxml2Python: Remove updateScript
* [`30645470`](https://github.com/NixOS/nixpkgs/commit/30645470ee167d28952b486aec301e074573a12c) gcab: 1.5 → 1.6
* [`831b8c3d`](https://github.com/NixOS/nixpkgs/commit/831b8c3d44ea947d32b90bc01c1c734f072f3a1a) gvfs: 1.50.4 → 1.50.5
* [`81a554f1`](https://github.com/NixOS/nixpkgs/commit/81a554f12538f6f3df3cc83cbf8fd0c4d0b1d8d0) msitools: 0.101 → 0.102
* [`9818a0e0`](https://github.com/NixOS/nixpkgs/commit/9818a0e0f88eea940ee399f7533f4a0b682cd469) malcontent: 0.11.0 → 0.11.1
* [`d178fcaf`](https://github.com/NixOS/nixpkgs/commit/d178fcafb3859a11da39ab04268fbc365d8b52f5) hid-tools: 0.3.1 → 0.4
* [`b04a0492`](https://github.com/NixOS/nixpkgs/commit/b04a04929cccfaabf811a8442b9b03da1c7ea9fe) nixos/ananicy: add extraTypes, extraCgroups
* [`ff28d7a9`](https://github.com/NixOS/nixpkgs/commit/ff28d7a9823583812c4edc366dcd1d39647bd38c) nixos/ananicy: don't error if $out/ananicy-cpp doesn't exist
* [`aae2268e`](https://github.com/NixOS/nixpkgs/commit/aae2268e0a451c16570962945fffa8876df883d5) nixos/ananicy-cpp: add rulesProvider
* [`49e2fb7a`](https://github.com/NixOS/nixpkgs/commit/49e2fb7aaefe9f37c86d46d9e1c56edde3f4e2cc) webcord: 4.2.0 -> 4.3.0, add updateScript
* [`d08c422d`](https://github.com/NixOS/nixpkgs/commit/d08c422dfb907036a9c2ab3dd5845ae0b12d2c92) webcord-vencord: override electron to use electron_24
* [`6975e32f`](https://github.com/NixOS/nixpkgs/commit/6975e32fc40f0a44dbc337795cf0ff69a0780899) .github/labeler.yml: Add module system label
* [`7d630c5c`](https://github.com/NixOS/nixpkgs/commit/7d630c5c6b029dbde2f538d3c947d6c3730a63b5) latex2html: 2023 -> 2023.2
* [`ce4922b6`](https://github.com/NixOS/nixpkgs/commit/ce4922b6604d805a5258f4451157a775ae1de299) babl: 0.1.102 → 0.1.106
* [`2362cd5a`](https://github.com/NixOS/nixpkgs/commit/2362cd5a2eed7f35e7dbbfd0a003317541e2bdaf) deja-dup: 44.1 → 44.2
* [`92d43670`](https://github.com/NixOS/nixpkgs/commit/92d436705bfc79d1cd35a5b81fe3ac9195422526) gnome-keysign: 1.2.0 → 1.3.0
* [`74d0c97c`](https://github.com/NixOS/nixpkgs/commit/74d0c97cc69a72f3dd738f77edcb111339a7dc88) speechd: 0.11.2 → 0.11.4
* [`33660f9e`](https://github.com/NixOS/nixpkgs/commit/33660f9e2d343bcfe09d75db527981296730b338) gnome.geary: 43.0 → 44.0
* [`33fadac2`](https://github.com/NixOS/nixpkgs/commit/33fadac2296ee622ad7803becfbb52d7f4169bb5) gedit: Fix updateScript attr-path
* [`5a5c3071`](https://github.com/NixOS/nixpkgs/commit/5a5c30719220dbd1c8ae0e20ebefa614bc9818ed) gnome.gnome-shell: 44.2 → 44.3
* [`20627266`](https://github.com/NixOS/nixpkgs/commit/20627266997d164e22bcb5c991b7d912ccd41137) gnome.mutter: 44.2 → 44.3
* [`7b0df0c0`](https://github.com/NixOS/nixpkgs/commit/7b0df0c04225a107e283a210cbee95f462d8ad7d) ananicy-cpp-rules: init at unstable-2023-06-28
* [`1b1f2531`](https://github.com/NixOS/nixpkgs/commit/1b1f25312dea83efcea0307e6407af5d9adc93aa) ananicy: unstable-2021-11-05 -> unstable-2023-03-21
* [`edb06020`](https://github.com/NixOS/nixpkgs/commit/edb060209ac72de4257cc95b466172baebd75ae2) catnip-gtk4: init at unstable-2023-06-17
* [`6ebedadd`](https://github.com/NixOS/nixpkgs/commit/6ebedaddb657e8d72b837b3398462866d5a86cc6) cctools-llvm: match binutils targetPrefix definition
* [`4716cb5c`](https://github.com/NixOS/nixpkgs/commit/4716cb5cff7aaf6c4c3a5dda20f6b51723fb13ee) vaultenv: 0.15.1 -> 0.16.0
* [`cfc32c25`](https://github.com/NixOS/nixpkgs/commit/cfc32c250ae211494f2ebcda824ace108d5deee2) python310Packages.pydevd: fix darwin
* [`8859693c`](https://github.com/NixOS/nixpkgs/commit/8859693cf49ccec545650ef318c1ad6227041ba0) timg: 1.4.5 -> 1.5.0
* [`ff151813`](https://github.com/NixOS/nixpkgs/commit/ff15181308fa6511fb1e677bb05cf9c67ffcf4a7) python3Packages.torch: disable fortify3 hardening flag
* [`54dfd13d`](https://github.com/NixOS/nixpkgs/commit/54dfd13dbff5dcf68ed7a28c8975bfde942309c8) python311Packages.pyezviz: 0.2.2.0 -> 0.2.2.1
* [`5df36451`](https://github.com/NixOS/nixpkgs/commit/5df36451ccdbebf6113a2f4b1200bb9ed565feac) python311Packages.restrictedpython: 6.0 -> 6.1
* [`de5233cf`](https://github.com/NixOS/nixpkgs/commit/de5233cf6126d0e8973ae1443a482bace34a5173) givaro: backport gcc-13 build fix
* [`b6186e18`](https://github.com/NixOS/nixpkgs/commit/b6186e18b8180b0315f7cc84490f1bc7f3a2d918) linbox: disable fortify3 hardening flag
* [`8dda3552`](https://github.com/NixOS/nixpkgs/commit/8dda355280f699d7ae92e1464a0de1db58d14cfb) apptainer: disable fortify3 hardening flag
* [`9dad8416`](https://github.com/NixOS/nixpkgs/commit/9dad8416be218ad1f667452b4bd766637054755a) minetest: use lua5_1 if luajit is not supported
* [`0a2b5044`](https://github.com/NixOS/nixpkgs/commit/0a2b50444ef4ba198650f6d8a8bc7456a8d655b4) linux_xanmod: 6.1.35 -> 6.1.37
* [`c3354e71`](https://github.com/NixOS/nixpkgs/commit/c3354e71d3f46112026715456c64f6e8a92833b3) linux_xanmod_latest: 6.3.9 -> 6.4.1
* [`3feefc9d`](https://github.com/NixOS/nixpkgs/commit/3feefc9d3263a836d9e5e5380a7f51f33fa07476) root5: disable fortify3 hardening flags
* [`c83bb71e`](https://github.com/NixOS/nixpkgs/commit/c83bb71e1041d91ecf9d5d2f24209328d494f8c2) minijail: disable fortify3 hardening flag
* [`48ae1081`](https://github.com/NixOS/nixpkgs/commit/48ae1081ebe48452dc83e5f496fefd3d13c1b4ed) libshumate: 1.0.3 → 1.0.4
* [`0675fa07`](https://github.com/NixOS/nixpkgs/commit/0675fa07701a2ba3123d529ba14beea511ac6d0b) python310Packages.vallox-websocket-api: 3.2.1 -> 3.3.0
* [`fe111c93`](https://github.com/NixOS/nixpkgs/commit/fe111c9311dd4338394f07d15ea6ecb5c67e120c) python3Packages.array-record: init at 0.4.0
* [`02b72078`](https://github.com/NixOS/nixpkgs/commit/02b720784cf4f11b3656bb5ebe0b4a07f8eeccdc) firefox-beta-bin-unwrapped: 115.0b9 -> 116.0b2
* [`2d69c0df`](https://github.com/NixOS/nixpkgs/commit/2d69c0df8f6fb760e75192beb4c58433f8855e3f) lineselect: 0.1.3 -> 0.1.6
* [`f6a103dc`](https://github.com/NixOS/nixpkgs/commit/f6a103dc3819ee7ce8cf7b20a8f279ad82ea2c96) nanomq: disable fortify3 hardening flag for idl_serial build
* [`7631229b`](https://github.com/NixOS/nixpkgs/commit/7631229b5e6623e77dccc66d9cf78d56e169784c) beets: fix embedart with imagick 7.1.1-12
* [`d0a98a0f`](https://github.com/NixOS/nixpkgs/commit/d0a98a0fc2a93f51c1b1873e1d71456c168957e9) beets-unstable: unstable-2022-08-27 -> unstable-2023-07-05
* [`7d687c1d`](https://github.com/NixOS/nixpkgs/commit/7d687c1d642e50f9c7cec73f38e5631f916945af) gvm-libs: disable fortify3 hardening flag
* [`c3217f1f`](https://github.com/NixOS/nixpkgs/commit/c3217f1f80e8165b0fb38f296c3ce28e252e2abe) libevdevc: disable fortify3 hardening flag
* [`8e6d31c9`](https://github.com/NixOS/nixpkgs/commit/8e6d31c9c9b9054359739b83f630b4aad637e0b6) mympd: disable fortify3 hardening flag
* [`445c385b`](https://github.com/NixOS/nixpkgs/commit/445c385bc560213ee0a48346031c66c8ffa10a74) yubihsm-shell: disable fortify3 hardening flag
* [`e37dc856`](https://github.com/NixOS/nixpkgs/commit/e37dc856069c85a3f92cd7e14093f8f6e7b742f8) hash_extender: disable fortify3 hardening flag
* [`19e8e87b`](https://github.com/NixOS/nixpkgs/commit/19e8e87be08d8cbee9167786a8767a746bf64d4b) mpd-discord-rpc: 1.7.0 -> 1.7.1
* [`d629ca54`](https://github.com/NixOS/nixpkgs/commit/d629ca54b21f580ec6b6b2c9974b6a048698e08f) k3s: symlinks for kubectl crictl & ctr
* [`1f55fe36`](https://github.com/NixOS/nixpkgs/commit/1f55fe36787515a05a061cb50b753cf4fd01f5e1) drawterm: enable strict deps and parallel builds
* [`c810782e`](https://github.com/NixOS/nixpkgs/commit/c810782ee6e95b1a860459f64bd4bb5935039c72) cctools-llvm: use cctools assembler on x86_64-darwin and LLVM 11
* [`937f472e`](https://github.com/NixOS/nixpkgs/commit/937f472e92ac60d2a7e155ef61c7f86eb7b4ef2b) Revert "gcc: fix build on x86_64-darwin"
* [`0e4e1588`](https://github.com/NixOS/nixpkgs/commit/0e4e158866864d08f85be5a7197676e431671666) raycast: 1.54.1 -> 1.55.1
* [`62a35867`](https://github.com/NixOS/nixpkgs/commit/62a35867c509f4412897d897acb78ab0856e0185) nextcloud-client: disable fortify3 hardening flag
* [`2c0610c5`](https://github.com/NixOS/nixpkgs/commit/2c0610c52e1e58a246eb121072cf213bf83e3a44) intel-graphics-compiler: disable fortify3 hardening flag
* [`bf559807`](https://github.com/NixOS/nixpkgs/commit/bf5598072e9e387074a47404e2f1606c4f3259e7) beep: disable fortify3 hardening flag
* [`b8c46080`](https://github.com/NixOS/nixpkgs/commit/b8c4608033012f2ebd1f6a3e16b91fb61a3e0016) tunwg: init at 23.06.14+dbfe3aa
* [`f9b03f1d`](https://github.com/NixOS/nixpkgs/commit/f9b03f1df5358125d04ce04ef4b7d1889b310be3) dino: 0.4.2 -> 0.4.3
* [`552efeba`](https://github.com/NixOS/nixpkgs/commit/552efeba59d5e7b75046161a91679d273eda1e8a) nut: actually update to 2.8.0
* [`eef54766`](https://github.com/NixOS/nixpkgs/commit/eef5476659f1a4990e892122fcd9aa4e6157328f) nut: add support for SNMP and CGI
* [`a99c630c`](https://github.com/NixOS/nixpkgs/commit/a99c630c27626d5a15ef11634d1999af63a3bdb4) nut: build with libusb 1.0
* [`a6af9565`](https://github.com/NixOS/nixpkgs/commit/a6af956520903fdbb764dfd8b8c5a4a6188e23c0) iina: fix 1.3.2 hash mismatch and add passthru.updateScript
* [`23231e2c`](https://github.com/NixOS/nixpkgs/commit/23231e2cf8a587b557cedbc5e1a08ebaa1d27095) pypy3Packages.babel: fix build
* [`856ebe6f`](https://github.com/NixOS/nixpkgs/commit/856ebe6fecf584d1db2fa08df3da285ff78b30b8) darwin.stdenv: allow `patchShebangs` during the bootstrap
* [`e5987423`](https://github.com/NixOS/nixpkgs/commit/e59874236b8c1e85f9c2655a0964bbafe4cdaaad) kodi: 20.1 -> 20.2
* [`145e24ab`](https://github.com/NixOS/nixpkgs/commit/145e24ab9aae370c217b327062355d3103508455) python310Packages.influxdb: allow binding to localhost on darwin
* [`598cabfc`](https://github.com/NixOS/nixpkgs/commit/598cabfc17b3688a9c7f825bad13f6d121ddbc07) python310Packages.mechanicalsoup: allow binding to localhost on darwin
* [`6884d744`](https://github.com/NixOS/nixpkgs/commit/6884d74408fb695186593f53e99d452ba0f61dec) runme: 1.3.0 -> 1.4.0
* [`2d28de89`](https://github.com/NixOS/nixpkgs/commit/2d28de89af7a3d87ebccd9a6c4b40787076df443) grass-sass: 0.12.4 -> 0.13.0
* [`51c6a069`](https://github.com/NixOS/nixpkgs/commit/51c6a06979391c685e8e605ea364f7d053e1acb4) iwd: 2.6 -> 2.7
* [`f91df581`](https://github.com/NixOS/nixpkgs/commit/f91df581608f5f33e7ef4c6831348dcf2a6a539c) psi-plus: 1.5.1646 -> 1.5.1650
* [`267caf59`](https://github.com/NixOS/nixpkgs/commit/267caf599d053d859e0290d588b617fe407b2cff) kubepug: 1.4.0 -> 1.5.0
* [`eacab25f`](https://github.com/NixOS/nixpkgs/commit/eacab25f413a9161730072e1f521c649f68198a8) orbiton: 2.62.3 -> 2.62.5
* [`7adf8665`](https://github.com/NixOS/nixpkgs/commit/7adf866562cabd27941d59ffe86f83f4de8ba5e0) catgirl: 2.1 -> 2.2
* [`79567351`](https://github.com/NixOS/nixpkgs/commit/79567351195e4c9136cb39d6bcfbe4e61ef72478) kubefirst: 2.2.0 -> 2.2.2
* [`495b199f`](https://github.com/NixOS/nixpkgs/commit/495b199f8fb34338a95076421a2066f1addf423d) python3Packages.annotated-types: init at 0.5.0
* [`38145de4`](https://github.com/NixOS/nixpkgs/commit/38145de4f399b3d7e94b966c910f91ec5c9f0f13) python310Packages.pyrainbird: allow binding to localhost on darwin
* [`02963742`](https://github.com/NixOS/nixpkgs/commit/02963742b86a1ce7cfcf897e449fecdab436fbc7) python310Packages.python-jenkins: allow binding to localhost on darwin
* [`7ac2d7d4`](https://github.com/NixOS/nixpkgs/commit/7ac2d7d454669221e9ec1dfd8d073e1b06cafc88) python310Packages.qcodes: allow binding to localhost on darwin
* [`31e46042`](https://github.com/NixOS/nixpkgs/commit/31e4604256a93a15e64a9be66afca2be46af82b2) python310Packages.flower: allow binding to localhost on darwin
* [`553f395f`](https://github.com/NixOS/nixpkgs/commit/553f395f983f442f6046b018c6b3008ba5bd6dd2) python310Packages.softlayer: allow binding to localhost on darwin
* [`f0417515`](https://github.com/NixOS/nixpkgs/commit/f041751506b24a374f946a67c9f06036dc2dd248) python310Packages.google-nest-sdm: allow binding to localhost on darwin
* [`e63a9e7f`](https://github.com/NixOS/nixpkgs/commit/e63a9e7fedc49416e6bfce4ad24698aa14c49854) python310Packages.pytest-base-url: allow binding to localhost on darwin
* [`43f27e9e`](https://github.com/NixOS/nixpkgs/commit/43f27e9e60f786dbb2fe4ecfb21ac684ad11c927) libbytesize: 2.8 -> 2.9
* [`105465eb`](https://github.com/NixOS/nixpkgs/commit/105465eb60c294a311287877203ef1f07b5441e5) vnote: 3.13.0 -> 3.15.1
* [`1ac5b46e`](https://github.com/NixOS/nixpkgs/commit/1ac5b46eff61c1d93a9dee4427db95d01b2ad2ff) neo-cowsay: 2.0.1 -> 2.0.4
* [`9249df1f`](https://github.com/NixOS/nixpkgs/commit/9249df1ff0bdcf708a34a97ee36e84b8bdeb2e42) python310Packages.timetagger: 23.6.1 -> 23.7.1
* [`5b9b2e5f`](https://github.com/NixOS/nixpkgs/commit/5b9b2e5fbb4d1d7d62f89b85142b97dc8a770a19) redis: 7.0.11 -> 7.0.12
* [`35209747`](https://github.com/NixOS/nixpkgs/commit/35209747ccd58dd2e1a751b958f7703164c212b7) python310Packages.zigpy-znp: 0.11.2 -> 0.11.3
* [`29f96cc8`](https://github.com/NixOS/nixpkgs/commit/29f96cc801de8e2efd80f76ca80a389f548d3595) vala-lint: unstable-2022-09-15 -> unstable-2023-05-25
* [`151fbd05`](https://github.com/NixOS/nixpkgs/commit/151fbd059f302dbd2fc9a42d0f481d204ac62e50) python3Packages.pymatting: init at 1.1.2
* [`cfe29b36`](https://github.com/NixOS/nixpkgs/commit/cfe29b36b27ea51f66a6dd9438f74ec46ad17efd) python310Packages.google-cloud-bigquery-storage: 2.20.0 -> 2.22.0
* [`c3d60b00`](https://github.com/NixOS/nixpkgs/commit/c3d60b00cee75c60888dd1a05999663427f270fd) php81Packages.psalm: 5.9.0 -> 5.13.1
* [`b288728c`](https://github.com/NixOS/nixpkgs/commit/b288728cd49bc777bdffba3d4ae001a5aa937997) libva-utils: 2.18.2 -> 2.19.0
* [`58201154`](https://github.com/NixOS/nixpkgs/commit/5820115420a388ef79bb156b9738b8c030452d5b) vivaldi: 6.0.2979.22 -> 6.1.3035.111
* [`9d6e454b`](https://github.com/NixOS/nixpkgs/commit/9d6e454b857fb472fa35fc8b098fa5ac307a0d7d) gptcommit: 0.5.8 -> 0.5.10
* [`49148a3f`](https://github.com/NixOS/nixpkgs/commit/49148a3f7feb418da2b1288530441a5998f6eb61) seafile-{shared/client}: 9.0.2 -> 9.0.3
* [`b75c5aea`](https://github.com/NixOS/nixpkgs/commit/b75c5aea9abaacee3dd9d65e7a141e09ce632f07) vdrPlugins.softhddevice: 1.9.7 -> 1.10.3
* [`92317986`](https://github.com/NixOS/nixpkgs/commit/92317986be606cb086640384f99b1cc99e6a8743) hwloc: 2.9.1 -> 2.9.2
* [`79899a0b`](https://github.com/NixOS/nixpkgs/commit/79899a0b24795ea252b55b8206ec9848983c5190) jackett: 0.21.364 -> 0.21.449
* [`31b0d9b1`](https://github.com/NixOS/nixpkgs/commit/31b0d9b169ce496b797c40e554d89a10d5b8270e) citrix_workspace: 23.02.0 -> 23.07.0
* [`7e5faf7e`](https://github.com/NixOS/nixpkgs/commit/7e5faf7e4e46e35e59c8b6893b9295dcf6fce98c) python310Packages.pytest-parallel: init at 0.1.1
* [`dc8c60ec`](https://github.com/NixOS/nixpkgs/commit/dc8c60ecb18c4392beca17629bb88053a265a496) python310Packages.nbexec: init at 0.2.0
* [`8b49fc8e`](https://github.com/NixOS/nixpkgs/commit/8b49fc8efb8af985a2c2f33a3b52259b5e35f00f) python310Packages.pdfplumber: init at 0.9.0
* [`dab0c5cc`](https://github.com/NixOS/nixpkgs/commit/dab0c5cc6ca071ac65613e3d8d46b02b71b33c1c) python310Packages.iopath: init at 0.1.9
* [`9f915755`](https://github.com/NixOS/nixpkgs/commit/9f915755ba06cd3520a80c6ca62801cd0b825bdf) python310Packages.lazy_imports: ini at 0.3.1
* [`ef115853`](https://github.com/NixOS/nixpkgs/commit/ef1158539c27f6a09e5b9c61079b1111e8973ea4) python310Packages.prompthub-py: init at 4.0.0
* [`c6a50bb8`](https://github.com/NixOS/nixpkgs/commit/c6a50bb86f6087ac6d4c8096dba09d976e3bb430) python310Packages.rank_bm25: init at 0.2.2
* [`61dcc12a`](https://github.com/NixOS/nixpkgs/commit/61dcc12ab787e497354adfad71b264cf87031978) python310Packages.boilerpy3: init at 1.0.6
* [`e422f19d`](https://github.com/NixOS/nixpkgs/commit/e422f19d9dedfb8fe7fa772905762c4907971c87) python310Packages.stemming: init at 1.0.1
* [`93681ae8`](https://github.com/NixOS/nixpkgs/commit/93681ae822f40dbfab43d9b9cd9533a26a557542) python310Packages.quantulum3: init at 0.9.0
* [`724040fe`](https://github.com/NixOS/nixpkgs/commit/724040fe18c59d8ab93d805f8572e58f716d56d5) citrix_workspace: remove obsolete version checks
* [`a8b1bb8b`](https://github.com/NixOS/nixpkgs/commit/a8b1bb8bdea5b00dc8c6f7dd6510e890a5558905) python310Packages.pyvista: 0.39.1 -> 0.40.0
* [`bfb26144`](https://github.com/NixOS/nixpkgs/commit/bfb26144e7fb8c6839d076252ddc405fe3199700) timetagger: unbreak
* [`bd489764`](https://github.com/NixOS/nixpkgs/commit/bd489764b007da4c8bcc1c89a80fdfd6a6505ab6) mu: 1.10.4 -> 1.10.5
* [`e9ffb19d`](https://github.com/NixOS/nixpkgs/commit/e9ffb19d7949b14f49020cb08e7010ed58c01499) python310Packages.allpairspy: 2.5.0 -> 2.5.1
* [`34b3a809`](https://github.com/NixOS/nixpkgs/commit/34b3a809efcd30bf1508cd246af4e9d0c6357259) buildLuarocksPackage: rename file to match its role
* [`43121245`](https://github.com/NixOS/nixpkgs/commit/431212450d0713ba71aa37ba4a11778356de1e20) github-runner: 2.305.0 -> 2.306.0 ([nixos/nixpkgs⁠#242515](https://togithub.com/nixos/nixpkgs/issues/242515))
* [`b7594b7f`](https://github.com/NixOS/nixpkgs/commit/b7594b7f8f6a0e97eb6c98079e0443bdfb2ce1f3) rauc: 1.9 -> 1.10
* [`ca90d55f`](https://github.com/NixOS/nixpkgs/commit/ca90d55f0f03a2a12be3aba6f0c75c3a64deeaee) yabai: 5.0.4 -> 5.0.6
* [`ddfedb9b`](https://github.com/NixOS/nixpkgs/commit/ddfedb9b1d95978946a84c3c28da9039ba7ad89f) terraspace: 2.2.7 -> 2.2.8
* [`88671138`](https://github.com/NixOS/nixpkgs/commit/886711387b87ad74f8408eadd2068af7793d80fe) vital: init at 1.5.5
* [`f566f674`](https://github.com/NixOS/nixpkgs/commit/f566f6744d799b1e189f613df5eaf2ac798d608b) odin: dev-2023-05 -> dev-2023-07
* [`a3092152`](https://github.com/NixOS/nixpkgs/commit/a3092152a22e413bad38de5757510ea8b4e1c44b) py-spy: make fixes more legal
* [`ea1d1a8f`](https://github.com/NixOS/nixpkgs/commit/ea1d1a8f5283dd585149e61215cb40650304722c) bup: don't error out on implicit-function-declaration on darwin
* [`a566cc79`](https://github.com/NixOS/nixpkgs/commit/a566cc7901519651c4e2c04e881ff516f41cdd51) esphome: 2023.6.4 -> 2023.6.5
* [`4dcd4c38`](https://github.com/NixOS/nixpkgs/commit/4dcd4c38e80d62fbd123caeadf16e9efc32c4130) btop: cleanup
* [`c8bb2d35`](https://github.com/NixOS/nixpkgs/commit/c8bb2d35d957ef3f838808f4a1bd99f9603d85ec) phpExtensions.datadog_trace: 0.82.0 -> 0.89.0
* [`5416f26e`](https://github.com/NixOS/nixpkgs/commit/5416f26eee04e9bd0d7720c93366e21603d2c35d) phpExtensions.mongodb: 1.15.0 -> 1.16.1
* [`e0698cf8`](https://github.com/NixOS/nixpkgs/commit/e0698cf8980650e4733ca39d8151facbd7297e7f) jsonnet: fix linking issue with libjsonnet++
* [`f7ae3cc5`](https://github.com/NixOS/nixpkgs/commit/f7ae3cc5e721bf3de583d22faaa9a49197dac1d9) govulncheck: unstable-2023-03-22 -> 0.2.0
* [`cc9a177a`](https://github.com/NixOS/nixpkgs/commit/cc9a177a73d79a0deccefa000e089eeec26497a0) zoom-us: 5.15.2.4260 -> 5.15.3.4839
* [`a44fe488`](https://github.com/NixOS/nixpkgs/commit/a44fe4884e693b0372989fedce51541501049371) cargo-shuttle: 0.20.0 -> 0.21.0
* [`47d3edc4`](https://github.com/NixOS/nixpkgs/commit/47d3edc400bd6df6db485187fdaf257f1482b755) python310Packages.layoutparser: init at 0.3.4
* [`193583c2`](https://github.com/NixOS/nixpkgs/commit/193583c2415a0f129655d51e818a32e5ab92e0a5) sbt: 1.9.1 -> 1.9.2 ([nixos/nixpkgs⁠#242598](https://togithub.com/nixos/nixpkgs/issues/242598))
* [`6d6e7bcf`](https://github.com/NixOS/nixpkgs/commit/6d6e7bcfc70d086371b85f7d8194575e8f20b335) weechatScripts.multiline: 0.6.3 -> 0.6.4
* [`13d4e094`](https://github.com/NixOS/nixpkgs/commit/13d4e09476dfa07c4839a362297e84478e2fae9d) treesheets: unstable-2023-05-18 -> unstable-2023-07-08
* [`4eca4508`](https://github.com/NixOS/nixpkgs/commit/4eca45085db234cd48fcbf4bf5b4932eb74868b6) util-linux: fix linking login and swap tools to bin output
* [`5d8f9910`](https://github.com/NixOS/nixpkgs/commit/5d8f9910f51b9f1e054c4bcfb2be274103cabdbc) python310Packages.django-mysql: 4.10.0 -> 4.11.0
* [`cdd03a70`](https://github.com/NixOS/nixpkgs/commit/cdd03a70d83691bc3483386efbffcc0ecd6ee037) python3Packages.std2: init at unstable-2023-07-05
* [`7c5819f4`](https://github.com/NixOS/nixpkgs/commit/7c5819f41e2807ee8c0cb76141719a6209d12ec0) python3Packages.pynvim-pp: init at unstable-2023-07-05
* [`7e128265`](https://github.com/NixOS/nixpkgs/commit/7e128265b7803c7cf52bb2bfa7f3a574fdb30e1d) vimPlugins.coq_nvim: use pynvim-pp and std2 from nixpkgs
* [`2888b42f`](https://github.com/NixOS/nixpkgs/commit/2888b42f444713aaf532d693c7fd95947581eddd) vimPlugins.chad: rename to chadtree
* [`0c5a3761`](https://github.com/NixOS/nixpkgs/commit/0c5a37611232642a4bcd9fa36386b09bc7fe7eb3) vimPlugins: update
* [`aa33c85d`](https://github.com/NixOS/nixpkgs/commit/aa33c85d012ca9334f42e1d7fbfbdcc2e36a1f8b) vimPlugins.nvim-treesitter: update grammars
* [`fde35735`](https://github.com/NixOS/nixpkgs/commit/fde35735f552ab6ace339c9c86622958df2bcc9b) vimPlugins.chadtree: add python dependencies
* [`e50826a2`](https://github.com/NixOS/nixpkgs/commit/e50826a280ec8e19ff3ea067200c06e114c5774f) gnirehtet: 2.5.1 -> 2.5.1
* [`0b277bcc`](https://github.com/NixOS/nixpkgs/commit/0b277bcc2b40c6ecd728c44635fa92262bedf620) nixos/swraid: make entire module optional
* [`77361da1`](https://github.com/NixOS/nixpkgs/commit/77361da1e59ec800db78d045a857027369fdc488) rqbit: 2.1.5 -> 2.2.0
* [`bcb9b2b7`](https://github.com/NixOS/nixpkgs/commit/bcb9b2b7230e8b2c7efee8a382e79344b72b6e20) phpExtensions.mongodb: prevent `buildPecl` to always use the same version of PHP
* [`020b80bf`](https://github.com/NixOS/nixpkgs/commit/020b80bf26f1d83dde192264c95b516390f3b2e6) phpExtensions.datadog_trace: prevent `buildPecl` to always use the same version of PHP
* [`809effe6`](https://github.com/NixOS/nixpkgs/commit/809effe63b29084c41ecdfbd320f29d95c63e3e4) python3Packages.ping3: init at 4.0.4
* [`1662bdef`](https://github.com/NixOS/nixpkgs/commit/1662bdeff58b6ac3e28b733430377578615623ee) nitter: unstable-2023-05-19 -> unstable-2023-07-10
* [`e647fd4b`](https://github.com/NixOS/nixpkgs/commit/e647fd4bf4c9bfe284f6b5ae07fac65da6378639) mullvad-closest: init at unstable-2023-07-09
* [`de3cc624`](https://github.com/NixOS/nixpkgs/commit/de3cc6244aec1d0c339ffc7f6cdf4c477db6d797) coloquinte: init at version 0.3.1
* [`6984a720`](https://github.com/NixOS/nixpkgs/commit/6984a7201cbae604cb6fb9e7bb6f39c5dd3278c5) zsh: enable function subdirs
* [`db9ff9eb`](https://github.com/NixOS/nixpkgs/commit/db9ff9eb8a5a60b9484e7780684bb0e89c471224) blender: 3.5.1 -> 3.6.0
* [`daae938f`](https://github.com/NixOS/nixpkgs/commit/daae938fb12eebe9070c0652ef1dc7089051b701) python310Packages.pytest-pudb: init at 0.7.0
* [`19a6554e`](https://github.com/NixOS/nixpkgs/commit/19a6554e28dab9015c300a904528a342c8ea6275) xilinx-bootgen: unstable-2019-10-23 -> xilinx_v2023.1
* [`f92063b1`](https://github.com/NixOS/nixpkgs/commit/f92063b129045e37361aba9b111d5b7f8f849791) kodiPackages.chardet: 4.0.0+matrix.1 -> 5.1.0
* [`4aa3a285`](https://github.com/NixOS/nixpkgs/commit/4aa3a2857cb6defa501e11bbab261ad7a24197ac) btcpayserver: 1.10.2 -> 1.10.3
* [`099ad1be`](https://github.com/NixOS/nixpkgs/commit/099ad1be50110c2405527554feeb32b64692da15) firefox_decrypt: unstable-2023-05-14 -> unstable-2023-07-06
* [`f7817725`](https://github.com/NixOS/nixpkgs/commit/f78177251824680bf23cf348e28d16367568911f) circt: 1.44.0 -> 1.45.0
* [`685f2907`](https://github.com/NixOS/nixpkgs/commit/685f290786f872dc11336abe8624368b7ae3f264) yabai: fix hash
* [`bc13dcae`](https://github.com/NixOS/nixpkgs/commit/bc13dcae857706ac5fb63f4f3109eb7ad5970890) signalbackup-tools: 20230628 -> 20230707
* [`7e9c6274`](https://github.com/NixOS/nixpkgs/commit/7e9c6274d69dd41473e37ffeecf126790a02f72f) brave: 1.52.129 -> 1.52.130
* [`c86eb69b`](https://github.com/NixOS/nixpkgs/commit/c86eb69b639870622e9f3f11200d1e908d60c6f7) python310Packages.uproot: 5.0.9 -> 5.0.10
* [`3ff52713`](https://github.com/NixOS/nixpkgs/commit/3ff5271315a29e26f666774b81e888e5f05ad240) typos: 1.15.10 -> 1.16.0
* [`a9e20ed1`](https://github.com/NixOS/nixpkgs/commit/a9e20ed1e0568ddebc89b01afd93424ea578260d) {nickel,nls}: 1.0.0 -> 1.1.1
* [`76a2c098`](https://github.com/NixOS/nixpkgs/commit/76a2c09872b82b0dc2aed3635b4c83cd55ffcbb4) linkerd_edge: 23.6.3 -> 23.7.1
* [`c0f963a3`](https://github.com/NixOS/nixpkgs/commit/c0f963a33805a7906de59b1f4bd73962d0130d5b) boot.initrd.services.swraid -> boot.swraid
* [`7d2124f9`](https://github.com/NixOS/nixpkgs/commit/7d2124f9e3206166d82e72990cb5637c25a42b47) stage-1: Only copy mdadm and mdmon into initramfs if enabled
* [`4127a265`](https://github.com/NixOS/nixpkgs/commit/4127a265589c0612227380fc2392d975369989f6) python310Packages.total-connect-client: 2023.2 -> 2023.7
* [`c64ab88f`](https://github.com/NixOS/nixpkgs/commit/c64ab88f6c4c7e37f5b8c9ac1a501df6a1447b0e) liquibase: include all jars from internal/lib instead of just a few
* [`49d503a9`](https://github.com/NixOS/nixpkgs/commit/49d503a9fa55327a73621c266e8eb19f96def714) liquibase: include jars in --version output
* [`86115ca9`](https://github.com/NixOS/nixpkgs/commit/86115ca9db03a8ae7dd8af8130f15f611905e4b4) liquibase: indentation cleanup
* [`0123e9d4`](https://github.com/NixOS/nixpkgs/commit/0123e9d47067ad4306bde9c706b2ec3e8c2ac7e1) taplo: 0.8.0 -> 0.8.1
* [`4b21d79c`](https://github.com/NixOS/nixpkgs/commit/4b21d79c830da885c465b59ac609dcf299a0d3d1) boxxy: 0.7.2 -> 0.8.0
* [`f93ea48c`](https://github.com/NixOS/nixpkgs/commit/f93ea48c582b4608647f4decfc3e2cb4bdf2966f) findimagedupes: drop
* [`d3e87f9e`](https://github.com/NixOS/nixpkgs/commit/d3e87f9e9d75f68831dc9d5d1c2e4ce91a1534e1) python310Packages.pydrive2: 1.16.0 -> 1.16.1
* [`3b6bc9b5`](https://github.com/NixOS/nixpkgs/commit/3b6bc9b536dd09c91de596b3028fe6a468372865) nixos/filesystems: init squashfs
* [`0f9bf615`](https://github.com/NixOS/nixpkgs/commit/0f9bf615a485302b55e23cec66913e2ee11b8725) nixos/tests: add squashfs test
* [`ae55861e`](https://github.com/NixOS/nixpkgs/commit/ae55861ec2eb626fa71289156ade12ef5575173b) nixos/tests: add myself to maintainers of erofs test
* [`64fc7918`](https://github.com/NixOS/nixpkgs/commit/64fc7918243e4785272bf60076ce37c1b77dc09f) python310Packages.pyoverkiz: 1.9.0 -> 1.9.1
* [`24f6749d`](https://github.com/NixOS/nixpkgs/commit/24f6749d624a158d7a4d89ed2fdb96bc1c6cba76) numix-icon-theme-square: 23.06.21 -> 23.07.08
* [`cc4bcc83`](https://github.com/NixOS/nixpkgs/commit/cc4bcc832db99ee63a9e5b852d9c1a1b926849e5) python311Packages.aioesphomeapi: 15.1.3 -> 15.1.4
* [`d1daf261`](https://github.com/NixOS/nixpkgs/commit/d1daf2612e699dd23e3eb5d7a448b5ae859893fb) python311Packages.meshtastic: 2.1.9 -> 2.1.10
* [`358bfca0`](https://github.com/NixOS/nixpkgs/commit/358bfca06a42cb8117a216cc1a0baaea8eb97bb9) python311Packages.pontos: 23.7.5 -> 23.7.6
* [`7efd0157`](https://github.com/NixOS/nixpkgs/commit/7efd01577c2f0a1960efd46ceedfc7b519117e2c) python311Packages.python-roborock: 0.29.2 -> 0.30.0
* [`2f7bf343`](https://github.com/NixOS/nixpkgs/commit/2f7bf343c386718ba4a710a90282d690f82d843b) python311Packages.rpds-py: 0.8.8 -> 0.8.10
* [`65384b45`](https://github.com/NixOS/nixpkgs/commit/65384b45f805d9c89ea6a48abd69f8c31f6af607) python311Packages.sentry-sdk: 1.27.1 -> 1.28.0
* [`69b3dc11`](https://github.com/NixOS/nixpkgs/commit/69b3dc11f607e61fb8d9cf1ce65108e20a5edd2f) tgpt: 1.6.12 -> 1.7.0
* [`a53e2257`](https://github.com/NixOS/nixpkgs/commit/a53e2257c2bdb798a5d119f639ac038ab9ff3d07) python311Packages.time-machine: 2.10.0 -> 2.11.0
* [`c6a783d6`](https://github.com/NixOS/nixpkgs/commit/c6a783d6c4cffd15c7a9ed63f31e7124eac125e8) python311Packages.aiomisc: 17.3.2 -> 17.3.4
* [`2ff236ef`](https://github.com/NixOS/nixpkgs/commit/2ff236efb5e6412c8d51fd3606ea42848933b086) ocamlPackages.tdigest: add passthru.updateScript
* [`5a7603fc`](https://github.com/NixOS/nixpkgs/commit/5a7603fcffec8f7ffde3b9f4fb9869b7285f2ef7) ocamlPackages.tdigest: 2.1.1 -> 2.1.2
* [`6d4d3ccc`](https://github.com/NixOS/nixpkgs/commit/6d4d3ccc2502be4e0b3aab2d9ff67eb257cb969c) checkov: 2.3.312 -> 2.3.318
* [`a876b31e`](https://github.com/NixOS/nixpkgs/commit/a876b31e5a6286d0d74224f865b4f2626c78c0fe) python311Packages.griffe: 0.30.0 -> 0.31.0
* [`ce0bdd56`](https://github.com/NixOS/nixpkgs/commit/ce0bdd56873121c5c4e0ae8e0d91ad4e3256d5e8) python311Packages.nibe: 2.2.0 -> 2.3.0
* [`47a1c5e5`](https://github.com/NixOS/nixpkgs/commit/47a1c5e5828fdc3baf7c82c38fa61f944bbb2ac4) dvc: 3.4.0 -> 3.5.0
* [`ef823ba3`](https://github.com/NixOS/nixpkgs/commit/ef823ba338eb5ff75dcbbe6667c7414730fbbe90) linuxKernel.kernels.linux_zen: 6.4.1-zen1 -> 6.4.2-zen1
* [`322da8a2`](https://github.com/NixOS/nixpkgs/commit/322da8a27c29be88cd70c768a38824ad0c6fb27f) linuxKernel.kernels.linux_lqx: 6.3.11-lqx2 -> 6.4.2-lqx1
* [`0b96527d`](https://github.com/NixOS/nixpkgs/commit/0b96527d9a2d19c5055d8540918f2dce8a1fe9da) wrapGAppsHook4: fix gtk4 for the wrong system
* [`38e60b74`](https://github.com/NixOS/nixpkgs/commit/38e60b74ce84ebcc27c7405f084449a7f0a9cd52) chromiumDev: 116.0.5845.4 -> 116.0.5845.14
* [`f2699a0a`](https://github.com/NixOS/nixpkgs/commit/f2699a0ae5c757b910409141e4e282f2334be37e) python3Packages.pypika: init at 0.48.9
* [`995fe666`](https://github.com/NixOS/nixpkgs/commit/995fe666a57fd81f89ef34eef79e934da38bf96c) doomrunner: 1.7.2 -> 1.7.3
* [`c43ff97b`](https://github.com/NixOS/nixpkgs/commit/c43ff97b6c2e8a41c836785129d885f6f1f4af60) rust-analyzer-unwrapped: 2023-07-03 -> 2023-07-10
* [`b2beb5cc`](https://github.com/NixOS/nixpkgs/commit/b2beb5cc272cc398c60612c758eaa3f8552b82ef) xemu: 0.7.96 -> 0.7.97
* [`2cc4331f`](https://github.com/NixOS/nixpkgs/commit/2cc4331f03642f5c04b3f4e916c1fa439a588ccb) ugrep: 3.12.1 -> 3.12.2
* [`529285f6`](https://github.com/NixOS/nixpkgs/commit/529285f6718eb549e13414180f29a8176e4f96d9) fastgron: 0.6.3 -> 0.6.4
* [`4e2f40d6`](https://github.com/NixOS/nixpkgs/commit/4e2f40d64e57e8bd9d5d8e85cf54c663b031661e) python310Packages.mlflow: 2.4.1 -> 2.4.2
* [`deb25e39`](https://github.com/NixOS/nixpkgs/commit/deb25e39fa9c5842e06f5f741b2e371bc263c575) librewolf-unwrapped: 115.0-1 -> 115.0.1-1
* [`f152e6f8`](https://github.com/NixOS/nixpkgs/commit/f152e6f861baf093bc27b48ca924b7b95b1e9fcf) sakura: 3.8.5 -> 3.8.7
* [`2f2ec1bc`](https://github.com/NixOS/nixpkgs/commit/2f2ec1bca994f62cad652026226c2cef26face16) python310Packages.flammkuchen: 1.0.2 -> 1.0.3
* [`66fb236f`](https://github.com/NixOS/nixpkgs/commit/66fb236fabd92e463fc24744058da81790f76ba6) jove: 4.17.4.9 -> 4.17.5.3
* [`b5daa1cc`](https://github.com/NixOS/nixpkgs/commit/b5daa1cc8dc43783c2d92d99eec2684f012ec6c7) pantheon.elementary-files: 6.4.0 -> 6.4.1
* [`67792127`](https://github.com/NixOS/nixpkgs/commit/6779212701c3d7ef78491b5bfd85d534e5724b7a) python311Packages.tensorboard: enable
* [`c9ff9e4b`](https://github.com/NixOS/nixpkgs/commit/c9ff9e4bb92a3218d7c3afc335de22cb77fd8331) julia_19-bin: 1.9.1 -> 1.9.2
* [`233a8f00`](https://github.com/NixOS/nixpkgs/commit/233a8f00a3d01f56b88ee5653aa781a0077092ce) sqlx-cli: add xrelkd as maintainer
* [`4c2141f9`](https://github.com/NixOS/nixpkgs/commit/4c2141f91aed4e3ecc5b18d08e2c3270f2c123c1) sqlx-cli: 0.6.2 -> 0.7.0
* [`efbb6ed9`](https://github.com/NixOS/nixpkgs/commit/efbb6ed9442e7429777c75e4b63af0bf3aa66927) julia_19: 1.9.1 -> 1.9.2
* [`49b8dbf0`](https://github.com/NixOS/nixpkgs/commit/49b8dbf0e6f654a4182fcda54cb888d1579ed599) python310Packages.mask-rcnn: remove
* [`9f35ab95`](https://github.com/NixOS/nixpkgs/commit/9f35ab953bc2be03373de3ff08cf629317446f64) python310Packages.imgaug: remove
* [`8eea1bc4`](https://github.com/NixOS/nixpkgs/commit/8eea1bc42ad09ee4a47d969630d7179bae2401de) msgpack-cxx: 6.0.0 -> 6.1.0
* [`20912be3`](https://github.com/NixOS/nixpkgs/commit/20912be33e6203cd80080e1228880e029244adf0) pdns: 4.8.0 -> 4.8.1
* [`d48573ec`](https://github.com/NixOS/nixpkgs/commit/d48573ec1f67b644a4b1d9b0247840045e23dc49) gedit: fix cross compilation
* [`1473a98d`](https://github.com/NixOS/nixpkgs/commit/1473a98df47445b7f2f614183193c2e6496b6731) v2ray-domain-list-community: 20230627034247 -> 20230707041058
* [`a5b7dcfd`](https://github.com/NixOS/nixpkgs/commit/a5b7dcfd2ccb9e8bffd24add225b6883d55cd135) ryujinx: 1.1.952 -> 1.1.958
* [`abbb7ed8`](https://github.com/NixOS/nixpkgs/commit/abbb7ed8dc2d2ab36c4de290b19e90852440f71a) python310Packages.pycookiecheat: fix darwin
* [`9c642f9a`](https://github.com/NixOS/nixpkgs/commit/9c642f9a682d1a0e11f58f869d650fd5fda035df) python310Packages.langchainplus-sdk: 0.0.17 -> 0.0.20
* [`7725bae4`](https://github.com/NixOS/nixpkgs/commit/7725bae47790df188298189b6d4a35a636e6e4d6) python310Packages.langchain: 0.0.220 -> 0.0.229
* [`ab78ab62`](https://github.com/NixOS/nixpkgs/commit/ab78ab62131d1bf22f3eb1519d97568bf5bab1a9) b3sum: 1.4.0 -> 1.4.1
* [`a187ec43`](https://github.com/NixOS/nixpkgs/commit/a187ec43efbeec0f3be6f9d13a6836fcbb914a9d) nodePackages: update to latest
* [`8d0f2453`](https://github.com/NixOS/nixpkgs/commit/8d0f24539192c22a86ab58b2e2603a2aeb28eaa8) dyff: 1.5.7 -> 1.5.8
* [`03848975`](https://github.com/NixOS/nixpkgs/commit/03848975178ba9fe61ad2e5b62a63f0cb581479f) python310Packages.allpairspy: use pyproject format
* [`834ed320`](https://github.com/NixOS/nixpkgs/commit/834ed32062fddd7bb1d85e883458a9d54093ee26) python310Packages.allpairspy: add changelog to meta
* [`ddb72f3e`](https://github.com/NixOS/nixpkgs/commit/ddb72f3e0538f04b933f1f3572574bdb7a19f53c) ruby.rubygems: 3.4.15 -> 3.4.16
* [`8742e41f`](https://github.com/NixOS/nixpkgs/commit/8742e41f50277a7353c0ab5b93bf01d42a97f39f) python310Packages.robomachine: fix build
* [`f6929215`](https://github.com/NixOS/nixpkgs/commit/f6929215e1e411dbb6cbf214ca29917560e2be13) ast-grep: 0.6.6 -> 0.7.2
* [`727f936b`](https://github.com/NixOS/nixpkgs/commit/727f936b840267f14d6ba6e43653aba4ee383f9a) ast-grep: 0.7.2 -> 0.8.0
* [`e6644549`](https://github.com/NixOS/nixpkgs/commit/e66445492bfbc1322b679d512af23851ab26308a) bundler: 2.4.15 -> 2.4.16
* [`f374ddb4`](https://github.com/NixOS/nixpkgs/commit/f374ddb4f9a5c6ac5f974c2156cf0a4dcb60c450) scalafmt: 3.7.7 -> 3.7.8
* [`ab5d13ef`](https://github.com/NixOS/nixpkgs/commit/ab5d13ef49d0819ed35b80e582cbf7cd0be45e06) iosevka-bin: 25.0.0 -> 25.0.1
* [`f8cbb456`](https://github.com/NixOS/nixpkgs/commit/f8cbb4568e1c5c2cf5e84b5958271224da86d90c) thermald: 2.5.2 -> 2.5.3
* [`c385a816`](https://github.com/NixOS/nixpkgs/commit/c385a8168d97a47b4c027c1fcd02c79132d69db4) terraform-providers.google: 4.72.1 -> 4.73.0
* [`f1bcb173`](https://github.com/NixOS/nixpkgs/commit/f1bcb173b6e1ed901e0eaba54bf46c8670f3a853) terraform-providers.google-beta: 4.72.1 -> 4.73.0
* [`e1ff0c46`](https://github.com/NixOS/nixpkgs/commit/e1ff0c46fea02c438a2453977d6554bcbecbf747) terraform-providers.ibm: 1.54.0 -> 1.55.0
* [`547a7502`](https://github.com/NixOS/nixpkgs/commit/547a750222e2dc5a07a3d085dc5a165b7b44cdd8) terraform-providers.tencentcloud: 1.81.12 -> 1.81.13
* [`68c5d276`](https://github.com/NixOS/nixpkgs/commit/68c5d276f1254ec5827f2118b12016f289841847) cbmc: 5.86.0 -> 5.87.0
* [`cf6c1fb1`](https://github.com/NixOS/nixpkgs/commit/cf6c1fb1852b225b64f01f118813e50cda7d2158) dagger: 0.6.2 -> 0.6.3
* [`9a762384`](https://github.com/NixOS/nixpkgs/commit/9a7623847e972a2c839126d1d04eeba6b5fbc42a) python3Packages.qgrid: init at 1.3.1
* [`4ccdd2d0`](https://github.com/NixOS/nixpkgs/commit/4ccdd2d01731c792f70f580a20f04ccf00fbf2e5) python3Packages.experiment-utilities: init at 0.3.3
* [`6be818a2`](https://github.com/NixOS/nixpkgs/commit/6be818a24c23430fa5e7e25566260262bcebeff8) wcslib: 7.12 -> 8.1
* [`80f1bea8`](https://github.com/NixOS/nixpkgs/commit/80f1bea8bc6c5bd98489cf1fd9af3b0795de63e1) linux: 6.4.2 -> 6.4.3
* [`daf48638`](https://github.com/NixOS/nixpkgs/commit/daf4863891eadae16e0774d92ad503c5db29ffc3) ocamlPackages.duppy: 0.9.2 -> 0.9.3
* [`bf852a38`](https://github.com/NixOS/nixpkgs/commit/bf852a38e6a7eb52da2d50775191cb8f3f9212f1) python310Packages.hydrus-api: 5.0.0 -> 5.0.1
* [`a0ace46e`](https://github.com/NixOS/nixpkgs/commit/a0ace46ec0825338c10eeaa6566506a5e0c53620) karmor: 0.13.7 -> 0.13.11
* [`8901906d`](https://github.com/NixOS/nixpkgs/commit/8901906ddf83487ddaedf6f8b477191a21b8822a) gossa: 0.2.2 -> 1.0.0
* [`34b396fe`](https://github.com/NixOS/nixpkgs/commit/34b396feef90b1930decab6ae08cb213d14a8100) maintainers: add shortcord
* [`35881fdd`](https://github.com/NixOS/nixpkgs/commit/35881fdd9de7c0a4c33c462ab2d4a6896546944a) obs-tuna: init at 1.9.6
* [`fc8230b1`](https://github.com/NixOS/nixpkgs/commit/fc8230b13ad946cab0e64f4748d788c6deb7cf67) elan: 1.4.6 -> 2.0.0
* [`6d2e7cb9`](https://github.com/NixOS/nixpkgs/commit/6d2e7cb9d9754979cfc97f6fa5d4b07f4cb36216) act: 0.2.46 -> 0.2.48
* [`a8d729f5`](https://github.com/NixOS/nixpkgs/commit/a8d729f533d6e30920d058efb8aa13e5194af96c) python3Packages.rasterio: 1.3.7 -> 1.3.8
* [`4ac37707`](https://github.com/NixOS/nixpkgs/commit/4ac377076f426b637fd2734841daf4028b67e435) flowblade: 2.10.0.3 -> 2.10.0.4
* [`6c3c21ea`](https://github.com/NixOS/nixpkgs/commit/6c3c21eaa8b84ba582ef45bc457bcd2bb5b2e503) vscode-extensions.mgt19937.typst-preview: init at 0.6.0
* [`d1e18a36`](https://github.com/NixOS/nixpkgs/commit/d1e18a369a6c89d150a503c599d11674fa18a581) lib/modules.nix: Inline byName
* [`b2bbed2f`](https://github.com/NixOS/nixpkgs/commit/b2bbed2f792ce2ca82bffd4ab0c111b792d22fb2) ns-3: v35 -> v39
* [`f76f2d5b`](https://github.com/NixOS/nixpkgs/commit/f76f2d5b9b19be642eb2f8f37cc8e6c44987bf32) obs-studio-plugins.waveform: init at 1.7.0
* [`3f1c1883`](https://github.com/NixOS/nixpkgs/commit/3f1c188330f8f7f8cf7c4876ac0cd4d6cb14982e) antidote: 1.8.9 -> 1.9.0
* [`7ff753d4`](https://github.com/NixOS/nixpkgs/commit/7ff753d4495c2b4cd9deba97def55507f151b87a) linuxKernel.kernels.linux_{lqx,zen}: add thiagokokada as maintainer
* [`c70a5e92`](https://github.com/NixOS/nixpkgs/commit/c70a5e922322f081c6cfb249a6cf4fbf291e53ee) lib/modules.nix: Apply argument `attr` of old byName
* [`65de1821`](https://github.com/NixOS/nixpkgs/commit/65de18210d67a513ffd90d17b91738b597476f7a) lib/modules.nix: Apply argument `f` of old old byName
* [`eb410eab`](https://github.com/NixOS/nixpkgs/commit/eb410eab821b013017196cc39a401c030051937c) lib/modules.nix: Apply argument `modules` of old old old byName
* [`fb988c61`](https://github.com/NixOS/nixpkgs/commit/fb988c6193788f57ab4d53d8cbc8c014e88952ae) lib/modules.nix: Apply argument `module` of old f
* [`448b153f`](https://github.com/NixOS/nixpkgs/commit/448b153f819c1fc43db5954ee9788f6f51b93b27) lib/modules.nix: Rename defnsByName' -> rawDefinitionsByName
* [`c28dd7d9`](https://github.com/NixOS/nixpkgs/commit/c28dd7d9210731257775e8bd8722e27eb260c00e) lib/modules.nix: Rename defnsByName -> pushedDownDefinitionsByName
* [`6acc3114`](https://github.com/NixOS/nixpkgs/commit/6acc3114c30564d112c2c83836c9eb0685165d9a) lib/modules.nix: Make entire definition list strict in config check
* [`68dd30b7`](https://github.com/NixOS/nixpkgs/commit/68dd30b73feb05dc168a6e2b0b88c41c6eaa8bfb) eksctl: 0.147.0 -> 0.148.0
* [`4dd51a9a`](https://github.com/NixOS/nixpkgs/commit/4dd51a9acec772931976d325c7021b7156c13335) lib/modules.nix: Inline single-use `subtree` bindings
* [`b04d2fc9`](https://github.com/NixOS/nixpkgs/commit/b04d2fc96b8ef5d975ba74937337aaeddc3da550) desync: 0.9.4 -> 0.9.5
* [`94b55ad8`](https://github.com/NixOS/nixpkgs/commit/94b55ad8593af823efa8e04995f6cba72acf9c3e) epubcheck: 5.0.1 -> 5.1.0
* [`c9e19143`](https://github.com/NixOS/nixpkgs/commit/c9e191434b5918319ddc7cc7641d876d275afebe) shairport-sync: fix cross compilation
* [`421fdfd9`](https://github.com/NixOS/nixpkgs/commit/421fdfd975d3d5743ffdb1d17ad856e39002bdce) fwupd: 1.9.2 -> 1.9.3
* [`cdd8d886`](https://github.com/NixOS/nixpkgs/commit/cdd8d88604d1ae6ea88a576d5bca75509055e850) hpp-fcl: 2.3.4 -> 2.3.5
* [`8f700580`](https://github.com/NixOS/nixpkgs/commit/8f700580b984290adefa4b32ce1abafda04af6cf) lib/modules.nix: Format
* [`8014460c`](https://github.com/NixOS/nixpkgs/commit/8014460c4dbf26d6f962c01920b2c25fc00e0d03) lib.mergeModules: Add context to error message
* [`beccfc84`](https://github.com/NixOS/nixpkgs/commit/beccfc847b7959009450483cac132729f7eb4e36) gotrue-supabase: 2.78.0 -> 2.82.2
* [`1a6a9e90`](https://github.com/NixOS/nixpkgs/commit/1a6a9e902363636ffe0c653ac9c1c47bc962e20a) godot_4: 4.0.3-stable -> 4.1-stable
* [`ef59ce64`](https://github.com/NixOS/nixpkgs/commit/ef59ce6401f102d29b15555b1d4e48bde4ff8b8e) sile: 0.14.9 → 0.14.10
* [`073bd4e7`](https://github.com/NixOS/nixpkgs/commit/073bd4e7cdf03323568a07fa63ab71343db27cf5) python3Packages.desktop-notifier: 3.5.4 -> 3.5.6
* [`861aa4a1`](https://github.com/NixOS/nixpkgs/commit/861aa4a1f1229f8bc82d04870cc4a270a5b7f6d3) earthly: 0.7.10 -> 0.7.11
* [`3f5a442e`](https://github.com/NixOS/nixpkgs/commit/3f5a442eabf05c388b59f9b7d00974d02b71881a) wazero: 1.2.1 -> 1.3.0
* [`21ed35db`](https://github.com/NixOS/nixpkgs/commit/21ed35db1dd28759cb6f01439cd32f46cc6a88d3) cargo-modules: 0.9.1 -> 0.9.2
* [`063c1122`](https://github.com/NixOS/nixpkgs/commit/063c1122e204bfdf6de5a9e35ccb374be7addc28) bluetuith: 0.1.5 -> 0.1.6
* [`e2e2443f`](https://github.com/NixOS/nixpkgs/commit/e2e2443f5c2760db73ad69f5475c89af1b8564a8) mailpit: init at 1.7.1
* [`e1fba23d`](https://github.com/NixOS/nixpkgs/commit/e1fba23d1b022503ab387133dab3fe315a925e25) bloop: 1.5.6 -> 1.5.8
* [`94cd157e`](https://github.com/NixOS/nixpkgs/commit/94cd157e28d800c46b1c55b2a3e9e3d0737e0990) faas-cli: 0.16.11 -> 0.16.12
* [`e88126e2`](https://github.com/NixOS/nixpkgs/commit/e88126e25137590a9a9c6c5b78c9602d853c5748) httplib: 0.12.6 -> 0.13.1
* [`b20da498`](https://github.com/NixOS/nixpkgs/commit/b20da498a62fc1fd0c3aa63cd9c3237b94f56f4e) redli: 0.7.0 -> 0.9.0
* [`29bc7675`](https://github.com/NixOS/nixpkgs/commit/29bc76758f81f6999377f20380f22ce9ff559983) sish: 2.8.1 -> 2.9.2
* [`8a14c954`](https://github.com/NixOS/nixpkgs/commit/8a14c95463bd1ec6a3b3232d3e3c7dea46c42cb0) fn-cli: 0.6.25 -> 0.6.26
* [`9e61bc0a`](https://github.com/NixOS/nixpkgs/commit/9e61bc0a591d271195a914a21b05dae0832877a4) ua: unstable-2021-12-18 -> unstable-2022-10-23
* [`52842fcd`](https://github.com/NixOS/nixpkgs/commit/52842fcd63d9e7e0099b0b37b8bf186187b43e34) webwormhole: unstable-2021-01-16 -> unstable-2023-02-25
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
