### PR TITLE
niv devenv: update c81f0263 -> 892ddef1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c81f0263446629e961a82736565565dc75eeb733",
-        "sha256": "1b89rm389b9v5krp8jh1v68zcwnavc7cvdg0gyi7szvxza1pldyh",
+        "rev": "892ddef1fba6a956c172e6c1bb7c830795c713a2",
+        "sha256": "0d2gjby8c8pp6flb10c8sirnmygfhhahvqxikq65z5zfvydvdnlz",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/c81f0263446629e961a82736565565dc75eeb733.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/892ddef1fba6a956c172e6c1bb7c830795c713a2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@c81f0263...892ddef1](https://github.com/cachix/devenv/compare/c81f0263446629e961a82736565565dc75eeb733...892ddef1fba6a956c172e6c1bb7c830795c713a2)

* [`a76ca789`](https://github.com/cachix/devenv/commit/a76ca789503937cc6c351d935aa74d4a3ac2439a) bug_report: clarify reproducability steps
* [`a02dd37c`](https://github.com/cachix/devenv/commit/a02dd37c1b99353a8f535611cdd35c567207a728) fix test cleanup handling, add a simple test for postgres
* [`6ce54bcb`](https://github.com/cachix/devenv/commit/6ce54bcbcf59c18fdfb258b9d5ff10773fcf1bb6) fix rust example
* [`1e542aed`](https://github.com/cachix/devenv/commit/1e542aed39875027a6045cd4e7d0a84f05ba9d24) minio: configure client if minio is enabled
* [`c9551d42`](https://github.com/cachix/devenv/commit/c9551d4277445cecd94a82517ebbe1eee33a6514) minio: remove redundant script wrapper
* [`0c41e264`](https://github.com/cachix/devenv/commit/0c41e264e55dee43bdcb0408fbc1cd1ab213da07) minio: remove redundant checks around mkdir -p
* [`4251bcb7`](https://github.com/cachix/devenv/commit/4251bcb79cff28e6adafe3f32acb98695c0c8d80) minio: add 'afterStart' option for extra init commands
* [`1f9c319c`](https://github.com/cachix/devenv/commit/1f9c319cac2f495c6c3aefd0b25c411d3d76c278) minio: add example
* [`8abde84b`](https://github.com/cachix/devenv/commit/8abde84bf39defba214c1be63c3d9c133b780d65) minio: match default credentials
* [`5e150be6`](https://github.com/cachix/devenv/commit/5e150be6deb62bbe8c8ce91a48a3eca932708c30) postgres: use socket relative to PGDATA
* [`cbb5b965`](https://github.com/cachix/devenv/commit/cbb5b965be62ef00f1e8548c78c9548ea2b38d6a) Auto generate docs/reference/options.md
* [`cae45228`](https://github.com/cachix/devenv/commit/cae4522884ecf9f390ed21cefd2aeb4bac56559c) fix traps on darwin
* [`8d246b0c`](https://github.com/cachix/devenv/commit/8d246b0c01721c546cdef6786560e5bd1ffae689) Add RubyOnRails example
* [`c290c3f0`](https://github.com/cachix/devenv/commit/c290c3f0ec2f5c4c5be36e7c21414e145affaac0) Make devenv.root be overridable
* [`22a8681f`](https://github.com/cachix/devenv/commit/22a8681fefdfcbaa3ee7f74b043203b7879fe3fe) flake-parts: Add devenv imports example and doc
* [`374fb8e2`](https://github.com/cachix/devenv/commit/374fb8e243607fd0321b693f0125a5ba39ea52c0) docs/guides/using-with-flake-parts.md: Various small improvements
* [`7b54d477`](https://github.com/cachix/devenv/commit/7b54d477fc9034e8a50865e75d61daffdf229eb4) feat: add mailpit
* [`f30510b2`](https://github.com/cachix/devenv/commit/f30510b2459b92acc65d6b5aebc722c1e80f01db) feat(blackfire): add option to enable apm
* [`488bd4c7`](https://github.com/cachix/devenv/commit/488bd4c771392bd607e276efc2ca0a2e7cec9f1e) feat(php): allow disabling pre-enabled php extensions
* [`7d5b629e`](https://github.com/cachix/devenv/commit/7d5b629ec05db9b954a1cfc34a0fafec420e7377) Auto generate docs/reference/options.md
* [`52831686`](https://github.com/cachix/devenv/commit/528316865f1c2d4793e6a101599152799a6b5f70) send quit to memcached to terminate healthcheck successfully
* [`7621b307`](https://github.com/cachix/devenv/commit/7621b307ee8c7ac80a5a97dbcaebafd20f9d15f5) Auto generate docs/reference/options.md
* [`60ff7af2`](https://github.com/cachix/devenv/commit/60ff7af2493a27025ababb525ed393ccb8b76579) mysql: fix example comment
* [`e00c247a`](https://github.com/cachix/devenv/commit/e00c247a1a0c64b83c5d863e23607fce566d3d75) mysql: add failing test
* [`0fa9c1d6`](https://github.com/cachix/devenv/commit/0fa9c1d6e61424f76003edac1f595956f27bbf95) mysql: fix db existance check
* [`d7e0a3e2`](https://github.com/cachix/devenv/commit/d7e0a3e20b8ad8fcd9c86e97161fe8d5d05ab625) mailpit: persist database
* [`412e0167`](https://github.com/cachix/devenv/commit/412e016770125c9ad3b7c482e5b44a78da19b74e) mailpit: add sendmail to $PATH
* [`0bc93455`](https://github.com/cachix/devenv/commit/0bc9345583562fde1fd4e0deaa856601356425fb) mailpit: add example and test
* [`4e4fb341`](https://github.com/cachix/devenv/commit/4e4fb34128568bf19468819d965facefc194a58a) php: fix harmless exec bug
* [`8fc0ab71`](https://github.com/cachix/devenv/commit/8fc0ab714195a2fec77f75a2b29782fdc2e9965a) processes: eliminate shell wrapper
* [`4c12ac42`](https://github.com/cachix/devenv/commit/4c12ac42d8455f9475d7e1cda627636904b58065) Simplify installation by having a dedicated url and add cachix caches to flakes
* [`b3e36aa5`](https://github.com/cachix/devenv/commit/b3e36aa5dc5af4c5b773635c77131721ea27595d) clickhouse: make the test more robust
* [`ebf4a08e`](https://github.com/cachix/devenv/commit/ebf4a08e97b84cba6303f1c69282b0a3b53d6d08) docs: revamp getting started
* [`12bd0b02`](https://github.com/cachix/devenv/commit/12bd0b02c19866e196788290d1200692a4699032) docs: add copy buttons for snippets
* [`6ceb4be1`](https://github.com/cachix/devenv/commit/6ceb4be1690ca8411cd6de27ab7ab65faee1e7a2) docs: fix getting started link and simplify titles
* [`b409e6a6`](https://github.com/cachix/devenv/commit/b409e6a6bb6c4734e11357945f9888771c5a7bc5) docs: move updating note below the installation instructions
* [`cfb797e8`](https://github.com/cachix/devenv/commit/cfb797e822fe7810e1db7a4be01c323f75204ef5) bump deps
* [`b9c9d83e`](https://github.com/cachix/devenv/commit/b9c9d83e89c0405ab02880132a0601911c477250) devenv.nix: enable nix
* [`c22e796f`](https://github.com/cachix/devenv/commit/c22e796ffe937b971b0797c10e460ad47d6d7e70) Allow plain file imports
