### PR TITLE
niv home-manager: update a6d1d954 -> 2f84579a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a6d1d954b81caf4c9291b8ac35452fef842f289b",
-        "sha256": "0xrdn680b9hjc13m9mwqr0n701hwrdcy18cmax4vyddyir8gdc40",
+        "rev": "2f84579a70b8c74e5ebb37299a0c3ba279f09382",
+        "sha256": "08q1p8x2sbxndkdb7012agamlg1x0b9vl44lhh7r2bb9j67vd6y9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a6d1d954b81caf4c9291b8ac35452fef842f289b.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/2f84579a70b8c74e5ebb37299a0c3ba279f09382.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a6d1d954...2f84579a](https://github.com/nix-community/home-manager/compare/a6d1d954b81caf4c9291b8ac35452fef842f289b...2f84579a70b8c74e5ebb37299a0c3ba279f09382)

* [`e42fb597`](https://github.com/nix-community/home-manager/commit/e42fb59768f0305085abde0dd27ab5e0cc15420c) flake.lock: Update
* [`bec87d53`](https://github.com/nix-community/home-manager/commit/bec87d536c9f441ffeb603fc821fa7e613585d00) aerc: add assertion to limit per-account extraConfig to UI config ([nix-community/home-manager⁠#4196](https://togithub.com/nix-community/home-manager/issues/4196))
* [`d2e47de5`](https://github.com/nix-community/home-manager/commit/d2e47de53650d48fd95eb0ec92049d1cb7f09520) home-cursor.nix: enable gtk module when enabling gtk config generation ([nix-community/home-manager⁠#4144](https://togithub.com/nix-community/home-manager/issues/4144))
* [`f63b39a6`](https://github.com/nix-community/home-manager/commit/f63b39a67dcfeae4ed326acba181c898753ae7ad) i3-sway: multiple outputs ([nix-community/home-manager⁠#4223](https://togithub.com/nix-community/home-manager/issues/4223))
* [`c1cdce3d`](https://github.com/nix-community/home-manager/commit/c1cdce3d89741d402d8fd2c93e3d2643ff85b053) i3-sway: allow arbitrary floating modifier ([nix-community/home-manager⁠#4229](https://togithub.com/nix-community/home-manager/issues/4229))
* [`55985674`](https://github.com/nix-community/home-manager/commit/559856748982588a9eda6bfb668450ebcf006ccd) zsh: fix custom syntax highlighting styles ([nix-community/home-manager⁠#4236](https://togithub.com/nix-community/home-manager/issues/4236))
* [`34603224`](https://github.com/nix-community/home-manager/commit/346032240c15d8b6034847dc7a5f53312a5a57fc) Translate using Weblate (French)
* [`f5b03feb`](https://github.com/nix-community/home-manager/commit/f5b03feb33629cb2b6dd513935637e8cc718a5ba) imapnotify: Use JSON type for extraConfig ([nix-community/home-manager⁠#4238](https://togithub.com/nix-community/home-manager/issues/4238))
* [`1e7ba710`](https://github.com/nix-community/home-manager/commit/1e7ba7102e62cec727e1579a157e510bf123b350) home-manager: remove Home Manager default paths
* [`232fe3d4`](https://github.com/nix-community/home-manager/commit/232fe3d450dac73e55cf6fd2d73600c6cb82cd8b) flake.lock: Update
* [`2f84579a`](https://github.com/nix-community/home-manager/commit/2f84579a70b8c74e5ebb37299a0c3ba279f09382) Update translation files
