### PR TITLE
niv powerlevel10k: update 4dca4bdf -> 932954a8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "4dca4bdfbb118953b73a131f511094462165971d",
-        "sha256": "1q2smindq4lvpb3xyvpya5mv3hnf3chakdp49qaxny8cwjky9jc1",
+        "rev": "932954a8b1e31ae540e9df5e5e464100d46e53ec",
+        "sha256": "1hk3i02668iyi3sc4g8qqrf488352f1nn9vrf7z5w2wbbpvlr0hd",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/4dca4bdfbb118953b73a131f511094462165971d.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/932954a8b1e31ae540e9df5e5e464100d46e53ec.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@4dca4bdf...932954a8](https://github.com/romkatv/powerlevel10k/compare/4dca4bdfbb118953b73a131f511094462165971d...932954a8b1e31ae540e9df5e5e464100d46e53ec)

* [`0c28fec1`](https://github.com/romkatv/powerlevel10k/commit/0c28fec137b2a505667d1980ece0c1943a033000) fix pattern coloration for azure defined classes
* [`07849757`](https://github.com/romkatv/powerlevel10k/commit/078497570f58aa9fc4fe3a7cfd5951a67d7c8f5d) clean up the handling of POWERLEVEL9K_AZURE_CLASSES and put it in all configs ([romkatv/powerlevel10k⁠#2379](https://togithub.com/romkatv/powerlevel10k/issues/2379))
* [`93d97b7e`](https://github.com/romkatv/powerlevel10k/commit/93d97b7eba9fb4e0866dd8e4e2eda9a89226bd84) better comments
* [`932954a8`](https://github.com/romkatv/powerlevel10k/commit/932954a8b1e31ae540e9df5e5e464100d46e53ec) do not display an indicator when a git branch is up to date with a remote
