### PR TITLE
niv nixpkgs: update da5286cd -> 03f5806f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5286cd2b23e080b383594d6069e4487ef233de",
-        "sha256": "07d7ikcz6shr8y45c6jqbi6k1nj8m5s4nq2njc1xn1aahrdzqx8j",
+        "rev": "03f5806fdaad03086b334540f42e8a86c8b06424",
+        "sha256": "06dnx1sxlhyr116hz9i7krmja3l9l3bh2x6i1iynnmbv04h5mrk0",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/da5286cd2b23e080b383594d6069e4487ef233de.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/03f5806fdaad03086b334540f42e8a86c8b06424.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@da5286cd...03f5806f](https://github.com/nixos/nixpkgs/compare/da5286cd2b23e080b383594d6069e4487ef233de...03f5806fdaad03086b334540f42e8a86c8b06424)

* [`e0839d42`](https://github.com/NixOS/nixpkgs/commit/e0839d420b7586a6aa0548ee7aa09128b1582202) address some of the points mentioned in [nixos/nixpkgs⁠#206260](https://togithub.com/nixos/nixpkgs/issues/206260)
* [`20535eed`](https://github.com/NixOS/nixpkgs/commit/20535eedbbf56e0194de0d2256cebd434d1af7e0) transcribe: 9.21 -> 9.25
* [`7db4087a`](https://github.com/NixOS/nixpkgs/commit/7db4087a32387bb28586993a6487cd048ac96277) xdg-utils: mark broken if cross
* [`f6c5e4c2`](https://github.com/NixOS/nixpkgs/commit/f6c5e4c27352c349ee4d45d7f6ca0cdf02f90deb) firefox: late-bind xdg-utils if broken
* [`cecd3613`](https://github.com/NixOS/nixpkgs/commit/cecd3613bb3520fc018e26831060facf189f71b7) python310Packages.notmuch2: fix cross compilation
* [`498565a5`](https://github.com/NixOS/nixpkgs/commit/498565a5781d9c680d8bb933befaabdf61a8eafa) rpm: 4.18.0 -> 4.18.1
* [`cc23d764`](https://github.com/NixOS/nixpkgs/commit/cc23d764f113d98073e81f357b459c354e93a56b) keepassxc: 2.7.4 -> 2.7.5
* [`da7e8554`](https://github.com/NixOS/nixpkgs/commit/da7e8554012444550437ae1a285154cd8e77592b) add robwalt to maintainer list
* [`9ad0793b`](https://github.com/NixOS/nixpkgs/commit/9ad0793b40b687a4b63182cabd7827cc5a76f532) nixos/podman: persist timer
* [`83bad4c6`](https://github.com/NixOS/nixpkgs/commit/83bad4c63120591a822446e6a2823ccb0a5d0fd0) trilium-desktop: add startupWMClass to desktop icon
* [`70315e6f`](https://github.com/NixOS/nixpkgs/commit/70315e6fac1af960254868d29b77e51d637d5471) srb2kart: 1.3.0 -> 1.6.0
* [`3b3e8d90`](https://github.com/NixOS/nixpkgs/commit/3b3e8d90e1fb9915b0762d7572680e85dc9c1590) python3Packages.fiona: 1.9.1 -> 1.9.4
* [`fa9ebf60`](https://github.com/NixOS/nixpkgs/commit/fa9ebf60da0a40026ddb17411bd6eb5198d8143c) muchsync: set XAPIAN_CONFIG to fix cross compilation
* [`08a1cfec`](https://github.com/NixOS/nixpkgs/commit/08a1cfec3c4aad18e31695c39d92abd55492f16a) maintainers: add fwc
* [`75f419f2`](https://github.com/NixOS/nixpkgs/commit/75f419f222d5458a8a946dd137f7657b57ec4776) nixos/buildkite-agents: simplify service definition
* [`356af2c0`](https://github.com/NixOS/nixpkgs/commit/356af2c0b6afe85a399824c5744b4b0266d237d4) musl: add mips platforms
* [`3b603806`](https://github.com/NixOS/nixpkgs/commit/3b60380611978b9f8ebab000f826cb73f7578982) fteqw: init at unstable-2022-08-09
* [`257dd316`](https://github.com/NixOS/nixpkgs/commit/257dd3165872b7758c6845869e922168ad9f1cb0) binutils-unwrapped: add option to have gold as ld
* [`f8a9063f`](https://github.com/NixOS/nixpkgs/commit/f8a9063f53d951cc52be290c86f8b1ed711be658) nv-codec-headers-12: init at 12.0.16.0
* [`f3719756`](https://github.com/NixOS/nixpkgs/commit/f3719756b550113c1acbbab00c89a56fb77256f2) treewide: use optionalString instead of 'then ""'
* [`8ef3c5b7`](https://github.com/NixOS/nixpkgs/commit/8ef3c5b70e8aac987594dde103da016915e0d6a8) linuxPackages.nvidiaPackages.mkDriver: init
* [`3d03da5e`](https://github.com/NixOS/nixpkgs/commit/3d03da5e880a287cfb5d4b6734781c056c30f256) bintools-unwrapped: fix linker = "gold";
* [`c42a7b66`](https://github.com/NixOS/nixpkgs/commit/c42a7b668c340fb32bc40cf8dfd0214f85dbb0d1) Revert "Merge pull request [nixos/nixpkgs⁠#233377](https://togithub.com/nixos/nixpkgs/issues/233377) from ncfavier/revert-226088"
* [`345745b6`](https://github.com/NixOS/nixpkgs/commit/345745b6da9693adecfc69cc55c5753646d63060) nixos/syncthing: fix syncthing-init running by default
* [`eef9190d`](https://github.com/NixOS/nixpkgs/commit/eef9190d2b25b766297a2798f28223550e6217ac) nixosTests.syncthing-no-settings: init
* [`2729a006`](https://github.com/NixOS/nixpkgs/commit/2729a006ccb3f549b2383b50f0f05a353b2f2827) python310Packages.jupyter-server: cleanup dependencies
* [`fb480f51`](https://github.com/NixOS/nixpkgs/commit/fb480f51e82677aeb79f9d7322027ca0e5ed1592) jellyfin-ffmpeg: 5.1.2-8 -> 6.0-4
* [`3b9ec6d4`](https://github.com/NixOS/nixpkgs/commit/3b9ec6d418e5579331215c5f50255449f576fec4) bitwig-studio5: init at 5.0
* [`ece0da78`](https://github.com/NixOS/nixpkgs/commit/ece0da78783041e44cb908555b17180781a38d10) roomeqwizard: 5.20.5 -> 5.20.13
* [`48c25dca`](https://github.com/NixOS/nixpkgs/commit/48c25dcaf2deb249615707a310af23ccb42b04c3) spdlog: reformat expression arguments, and comment about fmt_9
* [`a35e1694`](https://github.com/NixOS/nixpkgs/commit/a35e1694a8970f82ff4fcbd9142cb4960350c0e0) gcc: if isM68k, look for libgcc_s.so.2 (instead of .so.1)
* [`895c2434`](https://github.com/NixOS/nixpkgs/commit/895c24349c7e715bca41d6718e10fdd782cc0dcc) test.cross.sanity: add pkgs.pkgsCross.m68k.stdenv
* [`7cc9ced7`](https://github.com/NixOS/nixpkgs/commit/7cc9ced775f83af14c97a9cccc5ad0dee1f33299) Update nixos/modules/services/misc/cgminer.nix
* [`e7707372`](https://github.com/NixOS/nixpkgs/commit/e770737241360cdfd09b421eea83160dce02c212) Update nixos/modules/services/networking/libreswan.nix
* [`b1421597`](https://github.com/NixOS/nixpkgs/commit/b1421597f9b3957eb164728af87d4f498fdf0a94) komga: 0.165.0 -> 1.1.0
* [`9d941d80`](https://github.com/NixOS/nixpkgs/commit/9d941d80f641bd176b34dc78b52ac8921ae27d24) fanficfare: 4.24.0 -> 4.25.0
* [`8ef1ecd4`](https://github.com/NixOS/nixpkgs/commit/8ef1ecd44a6b104c929bc498708042aa7ad6b5bc) xercesc: Use curl network backend
* [`4d38fa04`](https://github.com/NixOS/nixpkgs/commit/4d38fa043b5e9d3b5ffd541ac96c5627f92d6ae0) nixos/networkd: support netdev MAC addresses
* [`faba775b`](https://github.com/NixOS/nixpkgs/commit/faba775beb2f009e6d9fe5bf0861310b569d7ba1) nixos/networkd: support `Independent` flag for VXLAN netdevs
* [`43b9e26b`](https://github.com/NixOS/nixpkgs/commit/43b9e26bbba0da7037adca09c3b698ee84cf3ec8) gnome-podcasts: 0.5.1 -> 0.6.0
* [`a7df6bc9`](https://github.com/NixOS/nixpkgs/commit/a7df6bc9d1a5621b3ec2750c82d3356c4fe88dbe) rofi-pass: 2.0.2 -> unstable-2023-07-04 and init rofi-pass-wayland
* [`d278fd78`](https://github.com/NixOS/nixpkgs/commit/d278fd78af3cc0c9ccbff0ca9fbc37edb55fe97f) lib.systems.extensions.sharedLibrary: do not `throw`
* [`15f3926b`](https://github.com/NixOS/nixpkgs/commit/15f3926baa32c4eb7b73d6b25c9d4de40358d0f6) gdc: switch to gdc11 for now
* [`424952b7`](https://github.com/NixOS/nixpkgs/commit/424952b7b4c515941fc6aaac597636ba56a348e2) gccWithoutTargetLibc: link libgcc_s.so using -mnewlib if isPower
* [`71a96bd9`](https://github.com/NixOS/nixpkgs/commit/71a96bd985dcaa116a0c59f5f19f811b44461849) mastodon: simplify update script
* [`2458c94c`](https://github.com/NixOS/nixpkgs/commit/2458c94c9e177ad92aedc8b128a1e92e4dc3bd56) lib/systems: strip kernel to avoid reference cycles
* [`284d76ee`](https://github.com/NixOS/nixpkgs/commit/284d76ee3ddfde84bcc491f45d7e322da02bbae6) linuxManualConfig: restore functionality of isModular and buildDTBs
* [`68a3f565`](https://github.com/NixOS/nixpkgs/commit/68a3f565fbae452dea16cc600be1876164fad475) licenses: add Hippocratic License v3.0
* [`a0837c8e`](https://github.com/NixOS/nixpkgs/commit/a0837c8e55ed5da791a387af34f773a83d2a5cda) i2p: 2.2.1 -> 2.3.0
* [`218ef2f4`](https://github.com/NixOS/nixpkgs/commit/218ef2f4059f7b031f93cd4ac3fab9a3faf81b8b) nixosTests.installer: Make sure we boot into the config we generated
* [`faa1b3ba`](https://github.com/NixOS/nixpkgs/commit/faa1b3babcd338bf1a67486071b71e9514b86060) nixosTests.installer: Fix driverInteractive
* [`d00e242b`](https://github.com/NixOS/nixpkgs/commit/d00e242b805a5580e542dd5fb7c6b3e035be8697) nixos: Add nixos.channel.enable
* [`61afc4d1`](https://github.com/NixOS/nixpkgs/commit/61afc4d1662fe426f02b28e386f2e053f887b6d6) nixos/nix-channel: Take care of NIX_PATH's non-empty default when disabled
* [`27c3ccab`](https://github.com/NixOS/nixpkgs/commit/27c3ccab53c332906c13e49d5c32b9486c5b7451) expidus.file-manager: init at 0.1.2
* [`9fb0a911`](https://github.com/NixOS/nixpkgs/commit/9fb0a911cc7b29d232db4272233cb22c64faebef) zsh-abbr: init at 5.1.0
* [`24556f7b`](https://github.com/NixOS/nixpkgs/commit/24556f7be5ad328c60e051f3ec73dc980fb8e0e2) pufferpanel: build frontend from source
* [`406467c5`](https://github.com/NixOS/nixpkgs/commit/406467c5cd8a781308bfd4193db44f2eb1c5c253) pufferpanel: remove pathDeps argument
* [`da4bcf47`](https://github.com/NixOS/nixpkgs/commit/da4bcf47c5d07699e44955ce46339af8cbbea087) pufferpanel: 2.6.6 -> 2.6.7
* [`a3f5a65f`](https://github.com/NixOS/nixpkgs/commit/a3f5a65f9458f130488fc6f2e6e4302b6a83e69e) mattermost: 7.10.2 -> 7.10.3
* [`41b8228d`](https://github.com/NixOS/nixpkgs/commit/41b8228d5dee849528a451d892f4fb4312b87fab) liblcf: 0.7.0 -> 0.8
* [`c19472b4`](https://github.com/NixOS/nixpkgs/commit/c19472b46e8376c16676a455a39679f0a7ba64af) notesnook: init at 2.5.7
* [`95879241`](https://github.com/NixOS/nixpkgs/commit/958792414e72a61af9aa836d3c4fa89f53e377fa) gst_all_1.gst-plugins-rs: 0.10.9 -> 0.10.10
* [`8f4f1ce0`](https://github.com/NixOS/nixpkgs/commit/8f4f1ce005ceba182805d5a8866e39269b9a23a5) nixos/atop: Fix regression in enabling atop units
* [`f4079a45`](https://github.com/NixOS/nixpkgs/commit/f4079a45d31bac551b5853ad6f229e27f99a3ad6) k3s_1_26: 1.26.5+k3s1 -> 1.26.6+k3s1
* [`b936a530`](https://github.com/NixOS/nixpkgs/commit/b936a53005fb9f4f933ad4af7be315de77ab1856) stevenblack-blocklist: 3.11.19 -> 3.13.10
* [`a1d0ee8c`](https://github.com/NixOS/nixpkgs/commit/a1d0ee8c505472625e1c48a73843447269878bf0) nixos/nix-channel: Apply suggestions from code review
* [`c60195e1`](https://github.com/NixOS/nixpkgs/commit/c60195e154f14fadf9e209d768163814770eb689) python310Packages.qudida: init at 0.0.4
* [`c97588ee`](https://github.com/NixOS/nixpkgs/commit/c97588eedcb4a0ed6de1723e2e7441476bd22ccb) integration test driver: Adapt test script checking output
* [`c916884f`](https://github.com/NixOS/nixpkgs/commit/c916884f86d37299cf7dde4dcd4a82ac43a98540) integration test driver: Synchronize integration test driver's docstrings in Machine class methods with nixos documentation
* [`4d462ed5`](https://github.com/NixOS/nixpkgs/commit/4d462ed57210b63a147574668e2116e14c720701) capnproto-rust: 0.17.1 -> 0.17.2
* [`0129dffb`](https://github.com/NixOS/nixpkgs/commit/0129dffb45c31cf8fab930bcbcb644517d0fc472) thelounge: 4.4.0 -> 4.4.1
* [`bca6b6ac`](https://github.com/NixOS/nixpkgs/commit/bca6b6ac984ed6ff86dd2be0480778c0f70ff6ad) teamspeak_client: 3.5.6 -> 3.6.0
* [`4535fcd6`](https://github.com/NixOS/nixpkgs/commit/4535fcd653bf5f88b95067f567ed46c3e96403f2) teamspeak_client: add myself to maintainers
* [`6543a56a`](https://github.com/NixOS/nixpkgs/commit/6543a56a0e77d2da8f610cd5cfe3bc6c4adf307b) Revert "teamspeak_client: use llvmPackages_10"
* [`ce562027`](https://github.com/NixOS/nixpkgs/commit/ce56202750e32fcc69fc86dab32413e6f6485c62) cemu: 2.0-39 -> 2.0-44
* [`846ad444`](https://github.com/NixOS/nixpkgs/commit/846ad444c722abf49d744814fde831cd3c21d599) integration test driver: Auto-generate integration test driver's machine
* [`42657b37`](https://github.com/NixOS/nixpkgs/commit/42657b37b8bb8624f6ff728cd6cb647ebae58912) fatcat: init at 1.1.1
* [`076f6c09`](https://github.com/NixOS/nixpkgs/commit/076f6c0945f07fd71c8fdfb7eda342de4602173e) easyrpg-player: 0.7.0 -> 0.8, enable on Darwin
* [`caa1c579`](https://github.com/NixOS/nixpkgs/commit/caa1c5799330bc085efc9c676b5421474fd05eda) cp210x-program: init at 0.4.1
* [`6626d8cc`](https://github.com/NixOS/nixpkgs/commit/6626d8cc4de80f063da7ab871ecdc66f40f28e0b) lib.path.removePrefix: init
* [`27df9441`](https://github.com/NixOS/nixpkgs/commit/27df9441f99a75fe46272922a61f0c0eacd46177) temporal-cli: Passthru nested drvs to make accessing them easier
* [`0acafaf3`](https://github.com/NixOS/nixpkgs/commit/0acafaf34a0165da042a0cc7cfc2d1b77cdda773) pokefinder: 4.0.1 -> 4.1.1
* [`9d8609e1`](https://github.com/NixOS/nixpkgs/commit/9d8609e1b9c401e7c1e141a9c16cadc62f1729e2) python310Packages.albumentations: init at 1.3.1
* [`70ef85e7`](https://github.com/NixOS/nixpkgs/commit/70ef85e778674b973b8a42e643a3d4727f38d761) python3Packages.enochecker-core: init at 0.10.0
* [`5de79e7e`](https://github.com/NixOS/nixpkgs/commit/5de79e7e62e219dbdfd6061d9234b5cd1ce6c259) enochecker-test: init at 0.9.0
* [`983e3f7d`](https://github.com/NixOS/nixpkgs/commit/983e3f7d18f4b1f6b40fe6a754cae8a426d90234) lomiri.geonames: init at 0.3.0
* [`a905df37`](https://github.com/NixOS/nixpkgs/commit/a905df379928ecabf82f961c04d93c38afa8a58c) wlr-which-key: init at 0.1.0
* [`da58b136`](https://github.com/NixOS/nixpkgs/commit/da58b136157c8bfd6e2d90db8c4609939cef8bb9) nixos/gitea: revert change to RuntimeDirectoryMode
* [`d08ce39c`](https://github.com/NixOS/nixpkgs/commit/d08ce39c7470995468df2559f70b1418caf726a9) wsl-vpnkit: init at 0.4.1
* [`77f010e7`](https://github.com/NixOS/nixpkgs/commit/77f010e75f18b77855cd6f802332485507b24cf8) temporal-cli: Fix Darwin builds with sandbox enabled
* [`080fed44`](https://github.com/NixOS/nixpkgs/commit/080fed44601cb62faa303a35feeb9052fe631d2d) cloud-hypervisor: 32.0 -> 33.0
* [`15259fff`](https://github.com/NixOS/nixpkgs/commit/15259fffeb0cee7e67c3cd87185fc4c24a13d3c0) cartridges: init at 2.0.4
* [`609c49f7`](https://github.com/NixOS/nixpkgs/commit/609c49f7406d0d44fabebf5eb6cd145faff52eab) lomiri.geonames: Use CMAKE_CROSSCOMPILING_EMULATOR instead of patching in emulator call
* [`632165b8`](https://github.com/NixOS/nixpkgs/commit/632165b83dc576272d01249e308aeacc6f00f34a) famistudio: 4.0.6 -> 4.1.0
* [`4528a489`](https://github.com/NixOS/nixpkgs/commit/4528a489dfbb5b6c6196462a5fe17a76d59494b9) python3Packages.spacy-lookups-data: init at 1.0.3
* [`c907360e`](https://github.com/NixOS/nixpkgs/commit/c907360ea275593f1ef49e2a5337171c02c9b553) lomiri.libusermetrics: init at 1.3.0
* [`2b41b90a`](https://github.com/NixOS/nixpkgs/commit/2b41b90ace980cfa1ed79b9e60893532f37037a0) opensycl: add maintainer
* [`47f570f6`](https://github.com/NixOS/nixpkgs/commit/47f570f62cffb574ec539a9fb7622c8da68e9e2b) python3Packages.allpairspy: add nickcao to maintainers
* [`f0c58ea8`](https://github.com/NixOS/nixpkgs/commit/f0c58ea8088f058d9b1c4e8a2159fe0abd4b4498) python3Packages.allpairspy: fetch source from github
* [`3221ca8b`](https://github.com/NixOS/nixpkgs/commit/3221ca8be04f47d408c77b4f33c0fc84e61af798) python3Packages.allpairspy: move setuptools to nativeBuildInputs, fix cross compilation
* [`c3817eff`](https://github.com/NixOS/nixpkgs/commit/c3817eff6571f84a74baab3af5ac1517ea45b813) python3Packages.aggdraw: set format, add missing dependencies
* [`42d7668b`](https://github.com/NixOS/nixpkgs/commit/42d7668b37d0848399ae4d7aa6f6b5e3d76fc227) volta: update description to warn about using on NixOS
* [`0938d80a`](https://github.com/NixOS/nixpkgs/commit/0938d80a8d8611499c3175748ee6f0b9390b62bc) maintainers: add krupkat
* [`47919deb`](https://github.com/NixOS/nixpkgs/commit/47919debed4d3d32538ce761ee02f9b40221f319) musescore: 4.0.2 -> 4.1.0
* [`84ec2a53`](https://github.com/NixOS/nixpkgs/commit/84ec2a53f477d16023e1fb3a6dc847f118e95a28) archivebox: fix build issue on dependency
* [`a28f9684`](https://github.com/NixOS/nixpkgs/commit/a28f9684e225b3a5b1a78b8ffe530f07ae4bdc11) maintainers: add babeuh
* [`a008b6d8`](https://github.com/NixOS/nixpkgs/commit/a008b6d8305d0c871d6290f5a93c1d7c43ec0642) python310Packages.tbm-utils: improve build and enable tests
* [`83a4d4fd`](https://github.com/NixOS/nixpkgs/commit/83a4d4fd2fb4616b60ec0a238dc3e7505eed1a67) crystalline: 0.9.0 -> 0.10.0
* [`a848ecd6`](https://github.com/NixOS/nixpkgs/commit/a848ecd60ae0855291bc2422bc218d7be42a73a3) igraph: 0.10.4 -> 0.10.6
* [`f8da6c27`](https://github.com/NixOS/nixpkgs/commit/f8da6c2777a8c8613e6b6e94b61c85d098b78829) python310Packages.igraph: 0.10.4 -> 0.10.6
* [`07382e73`](https://github.com/NixOS/nixpkgs/commit/07382e73d0e1e0d3c2b764c1d62438cf17e39ae4) gdal: 3.7.0 -> 3.7.1
* [`532c0893`](https://github.com/NixOS/nixpkgs/commit/532c089362dad27783e3ed315d173f74bc648501) jamesdsp: 2.5.1 -> 2.6.0
* [`7843bd9b`](https://github.com/NixOS/nixpkgs/commit/7843bd9b1c6ceb4368c5af8dcc3a09a544b8ae93) xpano: init at 0.16.1
* [`b2f4cdf2`](https://github.com/NixOS/nixpkgs/commit/b2f4cdf2fedf586e9d756f8aa2e01cc183fe1fa7) lomiri.geonames: Upstream better GNUInstallDirs variable usage
* [`0b9be173`](https://github.com/NixOS/nixpkgs/commit/0b9be173860cd1d107169df87f1c7af0d5fac4aa) restish: init at 0.17.0
* [`31aab03f`](https://github.com/NixOS/nixpkgs/commit/31aab03f3d68f4a743aa4686b121a3d9a889c368) pythonPackages.mkdocs-linkcheck: init at unstable-2021-08-24
* [`3b4473b0`](https://github.com/NixOS/nixpkgs/commit/3b4473b04d9ef01bc4dc8f885efeb34bbfbed850) memos: 0.13.1 -> 0.13.2
* [`12e39387`](https://github.com/NixOS/nixpkgs/commit/12e393872800dcb3852998374372c435e2e3fa89) python311Packages.python-arango: Add setuptools to propagatedBuildInputs
* [`497eedf7`](https://github.com/NixOS/nixpkgs/commit/497eedf79696814d3f02fa0b6899d7682a003dc4) python310Packages.jaraco-classes: rename from jaraco_classes
* [`cc906707`](https://github.com/NixOS/nixpkgs/commit/cc90670759f199c27012f253ec5304b3d053c1ba) python310Packages.jaraco-functools: rename from jaraco_functools
* [`d54c4d1e`](https://github.com/NixOS/nixpkgs/commit/d54c4d1e0a53ad5fda27366aad90920c54d4a922) python310Packages.jaraco-text: rename from jaraco_text
* [`710af268`](https://github.com/NixOS/nixpkgs/commit/710af268f3d67779573d8460bc8cb2d22af542b5) python310Packages.jaraco-collections: rename from jaraco_collections
* [`b84acafe`](https://github.com/NixOS/nixpkgs/commit/b84acafe03b66e46d7e6893cf085a3e8e31d43cd) python310Packages.jaraco-itertools: rename from jaraco_itertools
* [`00a63233`](https://github.com/NixOS/nixpkgs/commit/00a63233caeb7019d9513c64a65b2200b13fde80) python310Packages.jaraco-logging: rename from jaraco_logging
* [`0811561a`](https://github.com/NixOS/nixpkgs/commit/0811561af67bdef7b932f6f8868cda8361dd4266) python310Packages.jaraco-stream: rename from jaraco_stream
* [`4cbdf0d1`](https://github.com/NixOS/nixpkgs/commit/4cbdf0d1fc1cde13ba9e99173ee83946a2389d81) fetchsvn: support hash parameter alongside sha256
* [`c9e8e912`](https://github.com/NixOS/nixpkgs/commit/c9e8e912cb359360c31c22f2eb1a7da5cba62625) nixos/patroni: use Python 3.10
* [`3be5b19b`](https://github.com/NixOS/nixpkgs/commit/3be5b19b3cb052eb32edaabc0f4611752be6ac6f) gnunet: 0.17.6 -> 0.19.4
* [`b689125e`](https://github.com/NixOS/nixpkgs/commit/b689125eec7537505f7bb2b87f6123fdc7cb8eec) cozette: 1.19.2 -> 1.20.1
* [`f9236b37`](https://github.com/NixOS/nixpkgs/commit/f9236b37e820e0ed8197f1aed7d908c6b6fc73bd) python3Packages.slack-sdk: fix build
* [`eaeb1f21`](https://github.com/NixOS/nixpkgs/commit/eaeb1f21e739f45274ce30d3a8b554a3b7b548c2) python3Packages.slack-sdk: 3.20.2 -> 3.21.3
* [`9aff2cad`](https://github.com/NixOS/nixpkgs/commit/9aff2cad80a635bee007a47833ca1255f7327c69) python3Packages.slack-bolt: init at 1.18.0
* [`9986d2cc`](https://github.com/NixOS/nixpkgs/commit/9986d2cc90396fbafc154323dc820be9a7bc4ae9) mox: init at 0.0.5
* [`6cc5c4f0`](https://github.com/NixOS/nixpkgs/commit/6cc5c4f04eaeae102192c2941fa1202eb914b732) terramate: init at 0.3.0
* [`85b75636`](https://github.com/NixOS/nixpkgs/commit/85b756369f28952994979a45d307fb7400310896) musescore: format with nixpkgs-fmt
* [`4416f5b7`](https://github.com/NixOS/nixpkgs/commit/4416f5b78a27371de63d06aa0cc73cbbf9f0e8ea) musescore: Switch to wrapQtAppsHook and stdenv.mkDerivation
* [`97022c01`](https://github.com/NixOS/nixpkgs/commit/97022c015bd997b15ec4aa89d3da2aabac588aed) uutils-coreutils: 0.0.19 -> 0.0.20
* [`bfe4db82`](https://github.com/NixOS/nixpkgs/commit/bfe4db82ae0cfc12bdde6e5a2b942b75881ec986) gdal: add package tests
* [`092f2294`](https://github.com/NixOS/nixpkgs/commit/092f2294129b3457221bc0c7b46e9f384d89da7d) dioxus-cli: 0.1.4 -> 0.3.2
* [`fe2a3e5e`](https://github.com/NixOS/nixpkgs/commit/fe2a3e5e353bf87f514c24fc6e0ac2a35ef99f37) minimacy: 1.0.0 -> 1.1.0
* [`c020eb25`](https://github.com/NixOS/nixpkgs/commit/c020eb255c84892e3c219359142c658658bf72c0) moon: 1.10.0 -> 1.10.1
* [`38f7d6a9`](https://github.com/NixOS/nixpkgs/commit/38f7d6a98aa2891aad0ba265e13764f3432cab06) opengrok: 1.12.11 -> 1.12.12
* [`d93aa8ce`](https://github.com/NixOS/nixpkgs/commit/d93aa8ce7921f707bfb47ea0a316e2c04a0e077a) bookstack: 23.06.1 -> 23.06.2
* [`bb8999ea`](https://github.com/NixOS/nixpkgs/commit/bb8999eaf4b6e5fa738448ca98c92da0005a0f9b) cloudlog: 2.4.3 -> 2.4.5
* [`265b0eae`](https://github.com/NixOS/nixpkgs/commit/265b0eaee456e639c9515ac4eb3f74006d78a11c) shattered-pixel-dungeon: 2.1.3 -> 2.1.4
* [`d762c946`](https://github.com/NixOS/nixpkgs/commit/d762c946cb62c6bee38a3d703fee073682e448d1) borgmatic: add darwin support
* [`b2a78a21`](https://github.com/NixOS/nixpkgs/commit/b2a78a21ecef72efa0b58d8398a940ee3ae0cb42) v2raya: 2.0.2 -> 2.0.5
* [`523ef878`](https://github.com/NixOS/nixpkgs/commit/523ef8787cfe8df53277309e50798434361f9522) tiny: 0.10.0 -> 0.11.0
* [`846baad2`](https://github.com/NixOS/nixpkgs/commit/846baad288f117907059d0db48b0ab053db7ee62) maintainers: add dotemup
* [`58d4cfb4`](https://github.com/NixOS/nixpkgs/commit/58d4cfb4fa142c6a03f855cdcb728219ce4092f6) vscodium: 1.80.0.23188 -> 1.80.1.23194
* [`71632b0d`](https://github.com/NixOS/nixpkgs/commit/71632b0dace3db1ac9a1a459e49b2f52a018861c) pict-rs: Use main ffmpeg attribute
* [`f0e8c9e0`](https://github.com/NixOS/nixpkgs/commit/f0e8c9e00da07df1f6afed4b57a258e1043a28f6) maintainers: add fptje
* [`1b62507f`](https://github.com/NixOS/nixpkgs/commit/1b62507fd7a9e01f117f1171d1c6633f63cb3646) vivaldi-ffmpeg-codecs: 112.0.5615.49 -> 111306
* [`5d8252e5`](https://github.com/NixOS/nixpkgs/commit/5d8252e51fc351a1509f2f97d0a5fb51f41c5881) ictree: init at 1.0.1
* [`925cfb87`](https://github.com/NixOS/nixpkgs/commit/925cfb87a3353c5dec4a9435fbb8ea7b9a9b10c9) opensycl: init at 0.9.4
* [`fe3b9fd7`](https://github.com/NixOS/nixpkgs/commit/fe3b9fd75f71627df578561c29486c1cbba1c70a) maintainer: added myself (tymscar) as a maintainer to some Jetbrain IDEs
* [`4d0d2601`](https://github.com/NixOS/nixpkgs/commit/4d0d2601a6e6d404a7c7932c21b5972036e4ec4d) jetbrains: fix remote dev server for IDEs
* [`5fd5888d`](https://github.com/NixOS/nixpkgs/commit/5fd5888d42a12f099157617dadef5d1ae20cdbab) foxotron: 2023-02-23 -> 2023-07-16
* [`c253a1f7`](https://github.com/NixOS/nixpkgs/commit/c253a1f717ffee624a2a7a64755b561425661889) python3Packages.hid-parser: init at  0.0.3
* [`65cd6dc0`](https://github.com/NixOS/nixpkgs/commit/65cd6dc03e441ec29d5b495e42f357cd51f367e2) solaar: 1.1.8 -> 1.1.9
* [`3cb419b2`](https://github.com/NixOS/nixpkgs/commit/3cb419b2ac5dfc2c978d434dc892aa38f11d690b) gnunet-gtk: 0.15.0 -> 0.19.0
* [`8ab9ac32`](https://github.com/NixOS/nixpkgs/commit/8ab9ac32b30e4ffd5dd8df322cefec15caf99fe1) fheroes2: 1.0.5 -> 1.0.6
* [`82b5af51`](https://github.com/NixOS/nixpkgs/commit/82b5af51e282c70b2af2223e88f0eb4f45307a93) treesheets: unstable-2023-07-08 -> unstable-2023-07-15
* [`3790f40a`](https://github.com/NixOS/nixpkgs/commit/3790f40a40d9cc7aed1f51acadf04dc6c4e3312e) dysk: 2.6.1 -> 2.7.1
* [`3e74a1e2`](https://github.com/NixOS/nixpkgs/commit/3e74a1e2cb197083542982e729435c0d343c45db) python310Packages.nvidia-ml-py: 11.525.131 -> 12.535.77
* [`c0e69cd1`](https://github.com/NixOS/nixpkgs/commit/c0e69cd146bb741505733a29bef4c35ff19b888b) nvitop: relax version for dependency python3Packages.nvidia-ml-py
* [`59077f0b`](https://github.com/NixOS/nixpkgs/commit/59077f0b65c6e4900549a78bbe344bdadd944b49) swww: 0.7.3 -> 0.8.1
* [`75e44fae`](https://github.com/NixOS/nixpkgs/commit/75e44fae31281cedab6a8af201be220ba7e74573) diesel-cli-ext: init at 0.3.13
* [`d893530e`](https://github.com/NixOS/nixpkgs/commit/d893530e3a493e7f15ffa7a0b0bb9e95fd221236) pat: init at 0.15.0
* [`9f3cb3e6`](https://github.com/NixOS/nixpkgs/commit/9f3cb3e6d26fa6797ca8d2370981bfd40d91fff8) standardnotes: 3.165.9 -> 3.166.9
* [`14a355b0`](https://github.com/NixOS/nixpkgs/commit/14a355b0a3f44fc0e69c9db459446a0b9e395b2a) ipv6calc: 4.0.2 -> 4.1.0
* [`d3fa477a`](https://github.com/NixOS/nixpkgs/commit/d3fa477a6f8218ea288100e378e3ec569d0ef2df) chromiumDev: 116.0.5845.14 -> 116.0.5845.32
* [`90ed2c1d`](https://github.com/NixOS/nixpkgs/commit/90ed2c1dfa762ba2b87d609141fb52d9fa623f2e) chromiumBeta: 115.0.5790.40 -> 115.0.5790.56
* [`27ec2e38`](https://github.com/NixOS/nixpkgs/commit/27ec2e384f2f8312ad2f9646c6703869fa86e086) chromiumBeta: 115.0.5790.56 -> 115.0.5790.90
* [`44e0efb8`](https://github.com/NixOS/nixpkgs/commit/44e0efb8180160dc26489b7e877f1d86ff13d94c) ocamlPackages.dtools: 0.4.4 -> 0.4.5
* [`ffae070a`](https://github.com/NixOS/nixpkgs/commit/ffae070a13afb7f6295efc0a23e0e8bef204e364) python310Packages.weconnect: 0.55.0 -> 0.56.2
* [`acd943e1`](https://github.com/NixOS/nixpkgs/commit/acd943e1bf8957589e415abde42b0306845ba1e3) chromium: add networkexception as maintainer
* [`85f6fef8`](https://github.com/NixOS/nixpkgs/commit/85f6fef8f1e3cd72321e951c62854be8b4a2eb48) go-toml: 2.0.8 -> 2.0.9
* [`4c3a027b`](https://github.com/NixOS/nixpkgs/commit/4c3a027b8b8a07ee0883bc2ca7ddc8dddc9cd1e6) simplotask: 1.8.1 -> 1.9.0
* [`2987602c`](https://github.com/NixOS/nixpkgs/commit/2987602c97b696e4c758d08024c5757c2cb916ab) python310Packages.ome-zarr: 0.6.1 -> 0.8.0
* [`23560842`](https://github.com/NixOS/nixpkgs/commit/23560842c0296f5e61fbaaa7038d0a6c17e79db5) glooctl: 1.14.11 -> 1.14.12
* [`51266516`](https://github.com/NixOS/nixpkgs/commit/512665160ba66e972a2456926e0122859b93e97a) cpm-cmake: 0.38.1 -> 0.38.2
* [`5187d573`](https://github.com/NixOS/nixpkgs/commit/5187d5731a465b1388893b98eccde58d2acf0945) system76-keyboard-configurator: 1.3.7 -> 1.3.8
* [`42ebc102`](https://github.com/NixOS/nixpkgs/commit/42ebc1025a5ca0e421fcc79f75e8f1b47215e93a) timg: 1.5.0 -> 1.5.1
* [`af4b2dee`](https://github.com/NixOS/nixpkgs/commit/af4b2deeb47aee00407088804b0f30fa402edd38) python3Packages.google-cloud-artifact-registry: init at 1.8.2
* [`08a0cb20`](https://github.com/NixOS/nixpkgs/commit/08a0cb20b46dedbe7efc42a3a28f9f2f4dc8ea16) python3Packages.wandb: 0.15.3 -> 0.15.5
* [`f49a76d7`](https://github.com/NixOS/nixpkgs/commit/f49a76d7f535806e2455890d135666b543781a8a) simdjson: 3.2.0 -> 3.2.1
* [`1a0f9c0d`](https://github.com/NixOS/nixpkgs/commit/1a0f9c0d2584f2de3c5dc77d827e4003a09e2cd4) wayst: unstable-2021-04-05 -> unstable-2023-07-16
* [`7e82daa7`](https://github.com/NixOS/nixpkgs/commit/7e82daa7d191c5cbfe551bc02191a2fc4366da98) gitea: 1.19.4 -> 1.20.0
* [`51aae864`](https://github.com/NixOS/nixpkgs/commit/51aae8647b0d7aa2cb19ab519656d115bd437a8b) dysk: install man page and shell completions
* [`21035489`](https://github.com/NixOS/nixpkgs/commit/21035489ccf3835906f321a5232754dd0bd2bc81) cargo-expand: 1.0.59 -> 1.0.61
* [`31457349`](https://github.com/NixOS/nixpkgs/commit/31457349fba1fdc2f1206002e49548ffcaf554f1) xv: 4.1.1 -> 4.2.0
* [`26df6096`](https://github.com/NixOS/nixpkgs/commit/26df609652fc21de9347ca28d9f5c0776c8c0ae3) wallust 2.4.1 -> 2.5.0
* [`7f91c0c5`](https://github.com/NixOS/nixpkgs/commit/7f91c0c52f26f584444bd76d63d44a2db0222c73) level-zero: 1.12.0 -> 1.13.1
* [`1002346c`](https://github.com/NixOS/nixpkgs/commit/1002346cb5620fa90a925f0660532363d08a94e2) mermerd: 0.8.0 -> 0.8.1
* [`10d739a4`](https://github.com/NixOS/nixpkgs/commit/10d739a45c48cbdbf1127cc8a7977b0cf84a7d9d) prometheus-smokeping-prober: 0.6.1 -> 0.7.1
* [`182c6c09`](https://github.com/NixOS/nixpkgs/commit/182c6c0996555b88694dd03a7684aab0db2e29e2) saml2aws: 2.36.9 -> 2.36.10
* [`69c7c720`](https://github.com/NixOS/nixpkgs/commit/69c7c720a90fb3fdb81e1aa6127d88f16b69208a) clickhouse-backup: 2.3.0 -> 2.3.1
* [`3a10a26e`](https://github.com/NixOS/nixpkgs/commit/3a10a26e3ed94b71f4544e798dfd5b94f48de5c9) questdb: 7.2 -> 7.2.1
* [`1878ff08`](https://github.com/NixOS/nixpkgs/commit/1878ff08ceb85682f37420e87e9daf1998fb07e5) jless: 0.8.0 -> 0.9.0
* [`88b9203b`](https://github.com/NixOS/nixpkgs/commit/88b9203b60f0ef22ea0551f88df4518c920c4eb0) murex: 4.3.3200 -> 4.4.6110
* [`185927ab`](https://github.com/NixOS/nixpkgs/commit/185927ab08e7b336890376c57db0cbc31aedb638) ast-grep: 0.8.0 -> 0.9.0
* [`128d2c2a`](https://github.com/NixOS/nixpkgs/commit/128d2c2a0b74621e697bbf1ad572210b43aebb13) jujutsu: 0.7.0 -> 0.8.0
* [`a9584671`](https://github.com/NixOS/nixpkgs/commit/a9584671c3ae1f458a11e9eac80b6eec55ef76e6) jujutsu: overhaul build expression
* [`50068e0c`](https://github.com/NixOS/nixpkgs/commit/50068e0caae4f78183c4bbd1464e81930b33a1ee) jujutsu: add myself as a maintainer
* [`05a98f74`](https://github.com/NixOS/nixpkgs/commit/05a98f74c7d8cc6001b95553450a44691a0f34c9) ast-grep: 0.9.0 -> 0.9.1
* [`9b1bda6f`](https://github.com/NixOS/nixpkgs/commit/9b1bda6fffae0a2683e8c5381eeff9f7f0862b33) python3Packages.gocardless-pro: init at 1.45.0
* [`3e4ce678`](https://github.com/NixOS/nixpkgs/commit/3e4ce678cbb9be137cda6cdc04c0f8043c86fac2) x16-rom: 41 -> 43
* [`d44583b7`](https://github.com/NixOS/nixpkgs/commit/d44583b78e742d8398e0f9227c5c4a87c5dbf1b0) x16-emulator: 41 -> 43
* [`a28f3028`](https://github.com/NixOS/nixpkgs/commit/a28f30282ff4bde6e2f1a8d0a9bf67c350093099) x16-emulator: mark as broken on ARM
* [`f026efee`](https://github.com/NixOS/nixpkgs/commit/f026efee20f7740cc0bc2d88296fcc4ca6cd460d) ocamlPackages.gsl: disable for OCaml ≥ 5.0
* [`7e212cc9`](https://github.com/NixOS/nixpkgs/commit/7e212cc9752edacf28f3579440f9adf4c5e346ae) ocamlPackages.printbox-text: disable tests with OCaml ≥ 5.0
* [`81bd52e5`](https://github.com/NixOS/nixpkgs/commit/81bd52e5b9c55f260819344c347db6b9717ecc61) temporal: 1.21.1 -> 1.21.2
* [`cc27aaf4`](https://github.com/NixOS/nixpkgs/commit/cc27aaf43d846eaa462d1f0df42ec519cdf994e9) maintainers: Add sund3RRR as a maintainer
* [`1af80623`](https://github.com/NixOS/nixpkgs/commit/1af806231f4adc4cbede9981f60f631693f1a5b1) pdfhummus: 4.5.8 -> 4.5.9
* [`629e8603`](https://github.com/NixOS/nixpkgs/commit/629e86032ba50701434896f3a3a59655a2141882) intel-compute-runtime: 23.17.26241.24 -> 23.22.26516.18
* [`5c514d49`](https://github.com/NixOS/nixpkgs/commit/5c514d49caac654f1c59f9dff4523f0b5ebf162e) coqPackages.compcert: 3.12 → 3.13
* [`84637a67`](https://github.com/NixOS/nixpkgs/commit/84637a672b32d8dd311d94afefd482366114a794) coqPackages.compcert: enable for Coq 8.17
* [`594a3819`](https://github.com/NixOS/nixpkgs/commit/594a3819ada0d622e0afa3c55109870fee72d07d) gi-crystal: init at 0.17.0
* [`08d50db3`](https://github.com/NixOS/nixpkgs/commit/08d50db3749dd5fd6ce0eac34b556320ca6a5a25) sofia_sip: 1.13.15 -> 1.13.16
* [`eff3fae7`](https://github.com/NixOS/nixpkgs/commit/eff3fae704d98b122f24d8f57b483504e97aa37b) go-musicfox: 4.1.2 -> 4.1.4
* [`a01b86cf`](https://github.com/NixOS/nixpkgs/commit/a01b86cfada1e89d43307ef5868fed5187450051) pcm: 202302 -> 202307
* [`1f18836f`](https://github.com/NixOS/nixpkgs/commit/1f18836f68e25671e842e156ecbe10add7bb124b) snappymail: 2.28.3 -> 2.28.4
* [`76f5020e`](https://github.com/NixOS/nixpkgs/commit/76f5020eb9c26e8d3ab6a946386d24b05136b89b) rke2: 1.27.2+rke2r1 -> 1.27.3+rke2r1 ([nixos/nixpkgs⁠#243712](https://togithub.com/nixos/nixpkgs/issues/243712))
* [`7a09421c`](https://github.com/NixOS/nixpkgs/commit/7a09421c37be3a51e3cd09a9f43069d7d8a0e2b8) kubepug: 1.5.0 -> 1.5.1
* [`d2e92fc0`](https://github.com/NixOS/nixpkgs/commit/d2e92fc0885abe0216ade960834957381ff3a04e) mackerel-agent: 0.77.0 -> 0.77.1
* [`e40f81da`](https://github.com/NixOS/nixpkgs/commit/e40f81daee7eafdf57760f5a05ff2f13bade727b) civo: 1.0.59 -> 1.0.60
* [`a2d01ab2`](https://github.com/NixOS/nixpkgs/commit/a2d01ab246ad5c88e6fbf6e9df18b08c659a1015) treesheets: unstable-2023-07-15 -> unstable-2023-07-16
* [`5cd93388`](https://github.com/NixOS/nixpkgs/commit/5cd933887c4acaf0b5b1b13c808d960de72c3395) kubernetes-controller-tools: 0.12.0 -> 0.12.1
* [`b5266fe6`](https://github.com/NixOS/nixpkgs/commit/b5266fe69e20483e0148676e542a85550c12baa1) nixpacks: 1.10.0 -> 1.10.1
* [`d74cf634`](https://github.com/NixOS/nixpkgs/commit/d74cf634b7f4db1475294adf149f86b9d5c0f389) ugrep: 3.12.2 -> 3.12.3
* [`04f35f40`](https://github.com/NixOS/nixpkgs/commit/04f35f4012e13c695907e5a2db25c9f960903a74) rke: 1.4.6 -> 1.4.7
* [`7e3c1693`](https://github.com/NixOS/nixpkgs/commit/7e3c16938a31ebe5a51b0c9a9a05b6cc59e3686e) cmark-gfm: 0.29.0.gfm.11 -> 0.29.0.gfm.12
* [`002c2c03`](https://github.com/NixOS/nixpkgs/commit/002c2c038e0b62638891da954bbf124b45d1a4f9) bpftune: init at unstable-2023-05-30
* [`b47c483b`](https://github.com/NixOS/nixpkgs/commit/b47c483bf8860ac9dbcc7d72a80f98bfd2b1584a) nixos/bpftune: init
* [`4cd70e12`](https://github.com/NixOS/nixpkgs/commit/4cd70e125d1baabb0846bdbfd4d87cf69e5fed8a) nixos/bpftune: init basic test
* [`975bd53d`](https://github.com/NixOS/nixpkgs/commit/975bd53d395a4fb674d02ce7ccff82045e9fcd67) bpftune: unstable-2023-05-30 -> unstable-2023-07-11
* [`bc8224ca`](https://github.com/NixOS/nixpkgs/commit/bc8224cab6eb57117193f3ac06fcc46d5775cd4c) bpftune: unstable-2023-07-11 -> unstable-2023-07-14, enable parallel building
* [`be25742a`](https://github.com/NixOS/nixpkgs/commit/be25742af91a797efcefcf8283a06630e9dbb1ad) gleam: 0.30.0 -> 0.30.1
* [`ce4fb8a2`](https://github.com/NixOS/nixpkgs/commit/ce4fb8a2a7cfd8a9157271dc6aad899d0edca9fc) sqlx-cli: 0.7.0 -> 0.7.1
* [`07dcfda4`](https://github.com/NixOS/nixpkgs/commit/07dcfda49ebffdddfd61a19b8cdf6f8f5fe34940) python3Packages.mautrix: 0.19.16 -> 0.20.0
* [`1a9dba58`](https://github.com/NixOS/nixpkgs/commit/1a9dba582019362c5e2d5b275dbb2f4dd53acd78) mautrix-facebook: 0.4.1 -> unstable-2023-07-16
* [`5bfe80b3`](https://github.com/NixOS/nixpkgs/commit/5bfe80b36e176661ba4ddc20f2fbdc7d0c3aaf45) mautrix-telegram: drop mautrix override
* [`a08da459`](https://github.com/NixOS/nixpkgs/commit/a08da4592ce2448f4099f35c0a948f6eb8705bd5) hydra_unstable: 2023-06-25 -> 2023-07-17
* [`d77d4807`](https://github.com/NixOS/nixpkgs/commit/d77d48074020b16884211af0b47ef55c7c7da146) v2ray-domain-list-community: 20230707041058 -> 20230717050659
* [`0da3a58a`](https://github.com/NixOS/nixpkgs/commit/0da3a58aac05d09b4c24c211a004555bcd40a013) mautrix-googlechat: unstable-2023-01-25 -> unstable-2023-07-16
* [`28cf9328`](https://github.com/NixOS/nixpkgs/commit/28cf9328b0ed8f319b442a93abc479fad752d6b4) heisenbridge: 1.14.2 -> 1.14.3
* [`929965d6`](https://github.com/NixOS/nixpkgs/commit/929965d6ca206f1011771668ce47b6c80ccec0a6) linkerd_edge: 23.7.1 -> 23.7.2
* [`34ae3396`](https://github.com/NixOS/nixpkgs/commit/34ae339624f4b560d9eda9fee9fa7b035290cfd6) maintainers: add aqrln
* [`15b46bc5`](https://github.com/NixOS/nixpkgs/commit/15b46bc5e4f8ba8f63f047e12864683a5549fbe4) prisma-engines: add aqrln maintainer
* [`00543a72`](https://github.com/NixOS/nixpkgs/commit/00543a72dbb06ed3af52452699e07e1e9ed2c507) prisma-engines: 4.13.0 -> 5.0.0
* [`42105b2b`](https://github.com/NixOS/nixpkgs/commit/42105b2ba37a5f98b0996c34aa5dc3979975c6a4) nixos/gitea: explicitly set CHUNKED_UPLOAD_PATH to writable location
* [`b8a8e973`](https://github.com/NixOS/nixpkgs/commit/b8a8e973b079978d1af22ba043516e7985fd3809) nixos/tests/gitea: fix
* [`f101816b`](https://github.com/NixOS/nixpkgs/commit/f101816bbfb25fc93f7b47c32f65fba0fc2aae5d) minify: 2.11.1 -> 2.12.7
* [`0509afee`](https://github.com/NixOS/nixpkgs/commit/0509afee4ff3a6627070d17182227f988930f72d) monsoon: 0.7.0 -> 0.8.0
* [`b8e27780`](https://github.com/NixOS/nixpkgs/commit/b8e27780849944891f34def632cc25b4ab70addb) steampipe: 0.20.8 -> 0.20.9
* [`5a4e1c0f`](https://github.com/NixOS/nixpkgs/commit/5a4e1c0f2a086c436b43679e4bf8a767a3e211fd) thedesk: 24.1.2 -> 24.1.3
* [`6dc07a31`](https://github.com/NixOS/nixpkgs/commit/6dc07a318fb753c8be0bc9a68b9d609794aae7da) nats-server: 2.9.19 -> 2.9.20
* [`7f67ec3e`](https://github.com/NixOS/nixpkgs/commit/7f67ec3e725e2e7f24e1cfb56953a64996f393f6) osu-lazer-bin: 2023.621.0 -> 2023.717.0
* [`cb93b201`](https://github.com/NixOS/nixpkgs/commit/cb93b201c005f03d2d814ef8b61daa857288b449) osu-lazer: 2023.621.0 -> 2023.717.0
* [`1cf572bd`](https://github.com/NixOS/nixpkgs/commit/1cf572bdd1cb6f02e3b468b2ba166486b95d928c) nodePackages.prisma: 4.13.0 -> 5.0.0
* [`d914f16b`](https://github.com/NixOS/nixpkgs/commit/d914f16b33f3019f0c1dbe91330586388c74b20f) scaleway-cli: 2.17.0 -> 2.18.0
* [`f2c07100`](https://github.com/NixOS/nixpkgs/commit/f2c07100a75cdd03f2173e1b639a3392ed949ffe) teams-for-linux: 1.1.11 -> 1.2.4
* [`66688cb7`](https://github.com/NixOS/nixpkgs/commit/66688cb7a13f365876da3cd0e944be75dd584b83) chiaki4deck: init at 1.3.3
* [`5e73f0c1`](https://github.com/NixOS/nixpkgs/commit/5e73f0c1c96cd09f1961d0d102d12c2641d0ac62) nixos/lxd: fix default ui package
* [`e75ee0e2`](https://github.com/NixOS/nixpkgs/commit/e75ee0e29ca2da0bbbe1d210244e829286a04ba1) clash-geoip: 20230612 -> 20230712
* [`7a9d01d4`](https://github.com/NixOS/nixpkgs/commit/7a9d01d44c0ebfb00fb314f05fa2755888a0e18f) seqkit: 2.4.0 -> 2.5.0
* [`1dafcf11`](https://github.com/NixOS/nixpkgs/commit/1dafcf11b3c9044ef237c2649136c0e83f205090) riemann-c-client: fix sources location
* [`e096745b`](https://github.com/NixOS/nixpkgs/commit/e096745b76623c9d19ec6e588d34f68f3a1313db) oh-my-posh: 17.9.0 -> 17.11.2
* [`b8e23112`](https://github.com/NixOS/nixpkgs/commit/b8e231128d29387fd9f0c2f0f9e3fee3a4d5b9fd) krew: 0.4.3 -> 0.4.4
* [`1f14a267`](https://github.com/NixOS/nixpkgs/commit/1f14a26765861a6dd071187b40b91ac42070e2ac) activemq: 5.18.1 -> 5.18.2
* [`3b32c6f5`](https://github.com/NixOS/nixpkgs/commit/3b32c6f516dd806348e2b2a4d0a5e9d078d7c9ce) musescore: Remove unneeded qt deps from buildInputs
* [`014929ac`](https://github.com/NixOS/nixpkgs/commit/014929ac5041c6da91c78f5c1458b3ebad9078b6) musescore: remove unneeded bundled libraries and headers from $out
* [`167a5853`](https://github.com/NixOS/nixpkgs/commit/167a5853acbe8b2e4699d68b0d11bb2cdbf01b5e) python310Packages.webargs: 8.2.0 -> 8.3.0
* [`32610b4e`](https://github.com/NixOS/nixpkgs/commit/32610b4ecb5348f488e43eb4ffd71b9a9ef5deb6) cargo-show-asm: 0.2.19 -> 0.2.20
* [`4ec2f8b2`](https://github.com/NixOS/nixpkgs/commit/4ec2f8b213f130daf76c30badb11737bccf39ee2) kitty: 0.29.0 -> 0.29.1
* [`1c52dbd0`](https://github.com/NixOS/nixpkgs/commit/1c52dbd0f1a46f6a0eec88f2d54f746ee90aa020) neovim-qt: fix desktop icon passthrough
* [`a88798a9`](https://github.com/NixOS/nixpkgs/commit/a88798a9907dbd61bcd7780e079cc6b75ef13374) pulsar: 1.106.0 -> 1.107.1
* [`15edec16`](https://github.com/NixOS/nixpkgs/commit/15edec16c93a6c591855078ea8acb762f4966784) VictoriaMetrics: 1.91.0 -> 1.91.3 ([nixos/nixpkgs⁠#242354](https://togithub.com/nixos/nixpkgs/issues/242354))
* [`2bc81837`](https://github.com/NixOS/nixpkgs/commit/2bc8183744c426dc503ed6b6b34c8628ac091fd7) xlockmore: 5.71 -> 5.72
* [`db975582`](https://github.com/NixOS/nixpkgs/commit/db975582f12570b51ab856f33499ed6a56c7b8cb) cargo-local-registry: 0.2.5 -> 0.2.6
* [`529febf3`](https://github.com/NixOS/nixpkgs/commit/529febf315c3dc45a745b1326f0234633a1f92f3) wishlist: 0.11.0 -> 0.12.0
* [`ff6db138`](https://github.com/NixOS/nixpkgs/commit/ff6db138bb780f58c1ee83c177636d04ba8be23d) plantuml: 1.2023.9 -> 1.2023.10
* [`2383c38e`](https://github.com/NixOS/nixpkgs/commit/2383c38e4e80c0869b019053dfab668a2771c4d3) python311Packages.unearth: 0.9.1 -> 0.9.2
* [`9fb59f21`](https://github.com/NixOS/nixpkgs/commit/9fb59f211deac5980b25638f08ecdbc4e227ac22) libjwt: 1.15.3 -> 1.16.0
* [`d237a731`](https://github.com/NixOS/nixpkgs/commit/d237a7318c3613b55469e80ae2c0d7ded901fca2) nixos/samba-wsdd: add openFirewall option
* [`f86bdb48`](https://github.com/NixOS/nixpkgs/commit/f86bdb48b7a8a91d89292ed21a3ec2881ebc0d08) python310Packages.looseversion: 1.2.0 -> 1.3.0
* [`2fd1640d`](https://github.com/NixOS/nixpkgs/commit/2fd1640d60014b501933fc1e5e851639ed3640b4) urbit: 2.10 -> 2.11
* [`0b1845d4`](https://github.com/NixOS/nixpkgs/commit/0b1845d417992f6419f416b0548e769855013a8f) typer: init at unstable-2023-02-08
* [`b673a2ea`](https://github.com/NixOS/nixpkgs/commit/b673a2eaeba61b331b475078eb244d9a3a28ecfe) python310Packages.tidalapi: 0.7.1 -> 0.7.2
* [`196a89e1`](https://github.com/NixOS/nixpkgs/commit/196a89e1fe6567ad39a620a0f8eeb10262b9ece0) yq-go: 4.34.1 -> 4.34.2
* [`8a0d4e51`](https://github.com/NixOS/nixpkgs/commit/8a0d4e5106ea4bf0d9dae020fe049251e3ff3a29) confetty: init at unstable-2022-11-05
* [`414c4b69`](https://github.com/NixOS/nixpkgs/commit/414c4b691ee66332e347d3b7cd48f1e83f459663) monkeysAudio: 10.16 -> 10.17
* [`ae910ed9`](https://github.com/NixOS/nixpkgs/commit/ae910ed9b8b6fd040c452a968c8cd0dc0b2f5c75) papermc: 1.19.3.375 -> 1.20.1.83
* [`8895d556`](https://github.com/NixOS/nixpkgs/commit/8895d55614546816673685b08af17c1f4ad5676e) musescore: Fix darwin build from source
* [`139259a3`](https://github.com/NixOS/nixpkgs/commit/139259a37711f4a38371ef47c391535ea8d00e90) slskd: init module ([nixos/nixpkgs⁠#233648](https://togithub.com/nixos/nixpkgs/issues/233648))
* [`080e97c7`](https://github.com/NixOS/nixpkgs/commit/080e97c7f970544d5dbb94164b1df3a5a62da864) build-support: Add fetchpijul function.
* [`a8a1252b`](https://github.com/NixOS/nixpkgs/commit/a8a1252b0919c9d4f2b6d5f58c04412cffcae309) nodePackages: update to latest
* [`4a4636b5`](https://github.com/NixOS/nixpkgs/commit/4a4636b54448fbee76cc6cdfe96d429495f92928) linux_rt_5_4: remove now-applied patch
* [`10ff0a07`](https://github.com/NixOS/nixpkgs/commit/10ff0a076bdb4ba3138cc69e39f38e6e577c4d1d) nixos/tests/kernel-generic: also expose rt kernels and linux_libre
* [`456c0392`](https://github.com/NixOS/nixpkgs/commit/456c0392a0ebbf16b4cca1f63570c47d87de6ccf) linux/patches: drop obsolete CVE-2023-32233 patch
* [`08fda9a3`](https://github.com/NixOS/nixpkgs/commit/08fda9a34df44f3d7d279645846b3cd0038ceed4) maintainers: add gigglesquid
* [`76a0d092`](https://github.com/NixOS/nixpkgs/commit/76a0d0928d5de933153e1709a5404dedeff4d808) gridcoin-research: init at 5.4.5.0
* [`14ef6934`](https://github.com/NixOS/nixpkgs/commit/14ef6934ca5cdf2a17c0dda30d4bf3d3e8ecff23) ferretdb: 1.5.0 -> 1.6.0 ([nixos/nixpkgs⁠#243986](https://togithub.com/nixos/nixpkgs/issues/243986))
* [`e6dc17c3`](https://github.com/NixOS/nixpkgs/commit/e6dc17c315d747f810be36cb7de87b7e55c96cf5) signalbackup-tools: 20230707 -> 20230716
* [`52ba084d`](https://github.com/NixOS/nixpkgs/commit/52ba084db960522411d9427b32804ba371ffd9ba) imgproxy: 3.18.1 -> 3.18.2
* [`655d4aae`](https://github.com/NixOS/nixpkgs/commit/655d4aae458c5b70fd1083ac80ef7c06f7976578) okta-aws-cli: 1.0.2 -> 1.1.0
* [`f847a087`](https://github.com/NixOS/nixpkgs/commit/f847a087871f445c69e2cc7b04b5b91a186388d0) goawk: 1.23.3 -> 1.24.0
* [`5aa2794e`](https://github.com/NixOS/nixpkgs/commit/5aa2794e179ece6066a20b7af8487960111709d0) sozu: 0.15.1 -> 0.15.2
* [`184dfbc8`](https://github.com/NixOS/nixpkgs/commit/184dfbc8a1c627a09fee4529c9c9b0e8ae64b81e) bcc: 0.26.0 -> 0.28.0 ([nixos/nixpkgs⁠#240520](https://togithub.com/nixos/nixpkgs/issues/240520))
* [`28f90732`](https://github.com/NixOS/nixpkgs/commit/28f90732f42c27fea2cc5ddbd66c27684be6b22a) fluent-bit: 2.1.6 -> 2.1.7
* [`99ce6d1b`](https://github.com/NixOS/nixpkgs/commit/99ce6d1bb5b84e48e33f3ae7f5492fdf0dfcf449) qgroundcontrol: 4.2.6 -> 4.2.8
* [`4a716c50`](https://github.com/NixOS/nixpkgs/commit/4a716c50feec750263bee793ceb571be536dff19) xastir: switch from imagemagick6 to graphicsmagick
* [`48e895c2`](https://github.com/NixOS/nixpkgs/commit/48e895c202e8cee25141b58532f3c8d760e9f607) primecount: 7.8 -> 7.9
* [`162485b1`](https://github.com/NixOS/nixpkgs/commit/162485b1de0e570a1ee0a4717f3fda770d540f08) monsoon: add changelog to meta
* [`422aa836`](https://github.com/NixOS/nixpkgs/commit/422aa836426d18951e2a107d5eb0ffa78fdd44b6) micronaut: 3.9.4 -> 4.0.0
* [`4be0901a`](https://github.com/NixOS/nixpkgs/commit/4be0901a28000af08dba62912d73ac62ffd89294) runme: 1.4.1 -> 1.5.0
* [`7277d9a1`](https://github.com/NixOS/nixpkgs/commit/7277d9a1a6530729282d9a4cb084fcf76af4db81) sqlcmd: 1.2.0 -> 1.2.1
* [`222222be`](https://github.com/NixOS/nixpkgs/commit/222222bedb944bf20a678b76e84f512e8e45150a) nixos/stage-1: fix mount replacement in extra-utils
* [`96576af5`](https://github.com/NixOS/nixpkgs/commit/96576af5087cff93878e394898265077f7886582) python310Packages.libcst: 0.4.9 -> 1.0.1
* [`1179c6c3`](https://github.com/NixOS/nixpkgs/commit/1179c6c3705509ba25bd35196fca507d2a227bd0) bosh-cli: 7.3.0 -> 7.3.1
* [`a6aae555`](https://github.com/NixOS/nixpkgs/commit/a6aae555e2ae851ccf86c2b18df693258b0a35de) ezquake: 3.2.3 -> 3.6.2 ([nixos/nixpkgs⁠#226174](https://togithub.com/nixos/nixpkgs/issues/226174))
* [`835701ca`](https://github.com/NixOS/nixpkgs/commit/835701caa5b75d14e892ffa873dc14ff48c6d37b) fava: 1.24.4 -> 1.25
* [`907421e6`](https://github.com/NixOS/nixpkgs/commit/907421e622cee1a3436b5e57dd9aa4a814b60d49) dae: 0.2.0 -> 0.2.1
* [`050cb731`](https://github.com/NixOS/nixpkgs/commit/050cb731484f3bf78f1c1eb8208ecb0b697522b5) scanmem: enable GUI, some drive-by cleanups
* [`6bfa5436`](https://github.com/NixOS/nixpkgs/commit/6bfa54365ba1e1be09a5545dcf91b55fdf08b41a) maestro: 1.30.0 -> 1.30.3
* [`dd2a8921`](https://github.com/NixOS/nixpkgs/commit/dd2a8921445a52c60da1c48a479ea599c6f0ccd9) nixos/boot/stage-1: chase symlinks when copying binaries
* [`25a4bfde`](https://github.com/NixOS/nixpkgs/commit/25a4bfde79494db8a64ebecfdd3320d153034197) python3Packages.pyramid-chameleon: unmark broken
* [`5136088b`](https://github.com/NixOS/nixpkgs/commit/5136088b472fb723588f62df6f59467d36b0e2c2) sxhkd: apply patch for multiple layouts
* [`467f6548`](https://github.com/NixOS/nixpkgs/commit/467f6548bf02c59a7fe854f3e5683587fd59c758) ntfy-sh: 2.5.0 -> 2.6.2
* [`1809c2db`](https://github.com/NixOS/nixpkgs/commit/1809c2db8461c0f632348611abd6cfec0477a86f) maintainers: add maeve
* [`85ea4214`](https://github.com/NixOS/nixpkgs/commit/85ea4214a3e63670dc0b8af56f16e03e78a05e5a) sumo: 1.17.0 -> 1.18.0
* [`28c85e04`](https://github.com/NixOS/nixpkgs/commit/28c85e041706f6bbed3b689a4cf7e2eb3022ef61) vscode-extensions.astro-build.astro-vscode: 1.0.6 -> 2.1.1
* [`9858973d`](https://github.com/NixOS/nixpkgs/commit/9858973daddbccb53a926265a5458e7e81791f8f) nixos/vaultwarden: Fix Markdown syntax of link
* [`dbf9f5c0`](https://github.com/NixOS/nixpkgs/commit/dbf9f5c0db56b00589b21d273628992cedb8b0cd) python3.pkgs.django-cacheops: fix on darwin ([nixos/nixpkgs⁠#243941](https://togithub.com/nixos/nixpkgs/issues/243941))
* [`41d57564`](https://github.com/NixOS/nixpkgs/commit/41d57564703300a5d795b380165d1cd4ee708b97) python3Packages.maxminddb: fix build on Darwin
* [`fc4feb98`](https://github.com/NixOS/nixpkgs/commit/fc4feb9812fd43cb05d0e75feda2c9fa1ad3a0fe) gscreenshot: 3.4.0 -> 3.4.1
* [`2cd443b6`](https://github.com/NixOS/nixpkgs/commit/2cd443b691ce9bc9f3cb22b5207c9c7c8538e17d) recyclarr: 5.1.0 -> 5.1.1
* [`e44e079e`](https://github.com/NixOS/nixpkgs/commit/e44e079e806e49a42a82726982fbcdff63b9ba1d) nextcloud-apps.json: adds memories
* [`c39f24e4`](https://github.com/NixOS/nixpkgs/commit/c39f24e4df69ded4f3c08507f08545905f0b5d52) nextcloudApps: update package sets
* [`38176f81`](https://github.com/NixOS/nixpkgs/commit/38176f81b00c02317d9d1cfdf52ff2e27f174202) vintagestory: add support for experimental .net 7 build
* [`5e586714`](https://github.com/NixOS/nixpkgs/commit/5e586714147b4160b4d1762d67f6400dfe5eee80) vintagestory: add gigglesquid as maintainer
* [`146a53dd`](https://github.com/NixOS/nixpkgs/commit/146a53dd88b4cfba382f3ceb6beb2f04458aec59) healthchecks: 2.8.1 -> 2.10
* [`91cbf1f6`](https://github.com/NixOS/nixpkgs/commit/91cbf1f64b5405fd829cf155e2902ba1cac3d5d6) keycloak: 21.1.2 -> 22.0.0
* [`9d69c3e7`](https://github.com/NixOS/nixpkgs/commit/9d69c3e721dd677e3065cf7b7332570b79db7c6b) bats: 1.9.0 -> 1.10.0
* [`3297ece1`](https://github.com/NixOS/nixpkgs/commit/3297ece10cb7cdcc5c166f2fdaeb8fc5f84d3ec6) cri-o-unwrapped: 1.27.0 -> 1.27.1
* [`e3932a30`](https://github.com/NixOS/nixpkgs/commit/e3932a3040ee82717ca0c17afc29c97378629c21) pineapple-pictures: support wayland
* [`0d0283a6`](https://github.com/NixOS/nixpkgs/commit/0d0283a6fab39fa6f4cf983d3595ecb35ca49251) tailwindcss: 3.3.2 -> 3.3.3
* [`e1d0d9a0`](https://github.com/NixOS/nixpkgs/commit/e1d0d9a0cdb7dd7c11d302da776d6e29c390ff27) istioctl: 1.18.0 -> 1.18.1
* [`a22d4de3`](https://github.com/NixOS/nixpkgs/commit/a22d4de3a5989afcbcee9d7ef1ffa592e6b8818e) erigon: 2.48.0 -> 2.48.1
* [`9a654c1e`](https://github.com/NixOS/nixpkgs/commit/9a654c1e64286e7f23de9d8bdcefa26f92ca46d4) Add zmitchell to maintainers
* [`40b2fa5e`](https://github.com/NixOS/nixpkgs/commit/40b2fa5ead8f28a37ac2ba04bb78868cf458703b) python3Packages.duct-py: init at 0.6.4
* [`5107d158`](https://github.com/NixOS/nixpkgs/commit/5107d158ab05cb3ccac57ce224c23375e05d4aeb) msgpack-c: use finalAttrs pattern
* [`a268072f`](https://github.com/NixOS/nixpkgs/commit/a268072f4ec055d0e96cd05f4642e0871b5b15c5) msgpack-cxx: use finalAttrs pattern
* [`775b0efe`](https://github.com/NixOS/nixpkgs/commit/775b0efe7b107e9a7363d439917f266a364eb84b) prometheus-nginxlog-exporter: 1.10.0 -> 1.11.0
* [`b2827ad2`](https://github.com/NixOS/nixpkgs/commit/b2827ad23e14041d67be72998d7c7da6d8bcb904) clj-kondo: 2023.05.26 -> 2023.07.13
* [`54b42700`](https://github.com/NixOS/nixpkgs/commit/54b42700a55ca197a344853636059ae8cebb5f38) python310Packages.shap: 0.42.0 -> 0.42.1
* [`43036c0d`](https://github.com/NixOS/nixpkgs/commit/43036c0dd09c6ac7869885f2acc75d1c494f0138) python310Packages.shap: add natsukium as maintainer
* [`63213db6`](https://github.com/NixOS/nixpkgs/commit/63213db6158669a391a7e46f0b96537d0f56ce1a) jackett: 0.21.462 -> 0.21.484
* [`87f1c4f3`](https://github.com/NixOS/nixpkgs/commit/87f1c4f3f32c42ab35e8ce9be50fae068b3c4d99) cargo-espflash: 2.0.0 -> 2.0.1
* [`4f5c68d9`](https://github.com/NixOS/nixpkgs/commit/4f5c68d977ab8c43b3e1a3298ed0d441f3a7c2a1) griffe: 0.32.0 -> 0.32.1
* [`5ea3d52b`](https://github.com/NixOS/nixpkgs/commit/5ea3d52bd6c1d2cd3e745232dac898706c4d4e08) tbls: 1.68.0 -> 1.68.1
* [`50ab32d8`](https://github.com/NixOS/nixpkgs/commit/50ab32d8f5f66330499db95c53557b8b30e3fd86) pv-migrate: 1.1.0 -> 1.2.0
* [`1ea6bd07`](https://github.com/NixOS/nixpkgs/commit/1ea6bd071f9f4e108f5b8f3504d18bf7ece79e76) python3Packages.python-youtube: init at 0.9.0
* [`6259ca2e`](https://github.com/NixOS/nixpkgs/commit/6259ca2edd76902d5c84225d6169fb32bcf4e44c) topicctl: 1.9.1 -> 1.10.1
* [`2ed31639`](https://github.com/NixOS/nixpkgs/commit/2ed3163991e4723130c72456970c2643688567ee) google-guest-agent: 20230707.00 -> 20230711.00
* [`1334681c`](https://github.com/NixOS/nixpkgs/commit/1334681c75df3137dfeeaa31e96db82cf242b247) datree: 1.9.10 -> 1.9.17
* [`5e3dcc35`](https://github.com/NixOS/nixpkgs/commit/5e3dcc35f4d43c2e522e7d8727abdf81fd0f321e) supabase-cli: 1.75.6 -> 1.79.0
* [`1881de65`](https://github.com/NixOS/nixpkgs/commit/1881de655849efc0e1ae42da7c1416d049eb4190) raycast: 1.55.1 -> 1.55.2
* [`1edff8f0`](https://github.com/NixOS/nixpkgs/commit/1edff8f04f47a29ecb7ae1d81a3776de503dfced) esbuild: 0.18.13 -> 0.18.14
* [`c75eb703`](https://github.com/NixOS/nixpkgs/commit/c75eb7033642e836e4801966a17b068a577c8129) rbw: 1.7.1 -> 1.8.1
* [`3e7753c8`](https://github.com/NixOS/nixpkgs/commit/3e7753c8e9bfa0d43f9af78ec6d990bd88d48dee) terraform-providers.digitalocean: 2.28.1 -> 2.29.0
* [`51a1351d`](https://github.com/NixOS/nixpkgs/commit/51a1351d0e7f1ea9fc74ae18fc6c3a8d20c57df6) terraform-providers.gitlab: 16.1.0 -> 16.1.1
* [`0db56a3f`](https://github.com/NixOS/nixpkgs/commit/0db56a3f3033b3b7c4aa00f6c8cccd872580a2de) terraform-providers.google: 4.73.1 -> 4.73.2
* [`f925c283`](https://github.com/NixOS/nixpkgs/commit/f925c283afd63c6d93263d32dbf0668b281eb88c) terraform-providers.gridscale: 1.21.0 -> 1.21.1
* [`5c2c70be`](https://github.com/NixOS/nixpkgs/commit/5c2c70be4405cb1756940b686126ad884e5fc322) terraform-providers.google-beta: 4.73.1 -> 4.73.2
* [`04146b0d`](https://github.com/NixOS/nixpkgs/commit/04146b0debc2c4b9fe9a063663915607c21d8118) terraform-providers.signalfx: 7.0.0 -> 8.0.0
* [`0ec6cf51`](https://github.com/NixOS/nixpkgs/commit/0ec6cf5107516ecdd53ee5d2a7486d3b4fd80d6a) terraform-providers.spotinst: 1.125.1 -> 1.126.0
* [`d710935c`](https://github.com/NixOS/nixpkgs/commit/d710935cd424840efbf504ff9e18c3bc96e82cbb) mergerfs: 2.35.1 -> 2.36.0
* [`ebae1b9b`](https://github.com/NixOS/nixpkgs/commit/ebae1b9bc0f0f830e1e96a78b0fd8a9c5ca1f147) python310Packages.chiavdf: 1.0.8 -> 1.0.9
* [`bb904f2a`](https://github.com/NixOS/nixpkgs/commit/bb904f2a21f162c441244610a34b8e7e2c03879c) python310Packages.peaqevcore: 18.1.11 -> 19.0.0
* [`083a9cb4`](https://github.com/NixOS/nixpkgs/commit/083a9cb41fcc9058d669e9aa6960cd8b2f1c36ff) erlang_25: 25.3.2.3 -> 25.3.2.4
* [`5dd736df`](https://github.com/NixOS/nixpkgs/commit/5dd736dff724d87cd2df3e733b6cc389dd0f5a1a) python310Packages.detectron2: cleanup
* [`c0965a82`](https://github.com/NixOS/nixpkgs/commit/c0965a825651a4dbff24c15d1a494ce6b0346dbe) vimPlugins: update
* [`08debd7f`](https://github.com/NixOS/nixpkgs/commit/08debd7ffab5bb141aa9b14bba0053bcd30e14d6) vimPlugins.nvim-treesitter: update grammars
* [`5938996c`](https://github.com/NixOS/nixpkgs/commit/5938996c18d800b98f4965698a8d02d46b7c427c) python310Packages.casbin: 1.21.0 -> 1.22.0
* [`420a207d`](https://github.com/NixOS/nixpkgs/commit/420a207d494f11fd754d76e7c72f205f766fbddc) toot: 0.36.0 -> 0.37.0
* [`71de4bca`](https://github.com/NixOS/nixpkgs/commit/71de4bcaecbfb839df1ad77ad030ffc9ef136883) monsoon: fix rev
* [`7687c0cf`](https://github.com/NixOS/nixpkgs/commit/7687c0cfcb0230adcb5fabfc35a4bacf4b39f60d) nuclei: 2.9.8 -> 2.9.9
* [`e5a20914`](https://github.com/NixOS/nixpkgs/commit/e5a20914cae9e8ac162f9bc557ce5e6bfcb869b6) omnisharp-roslyn: 1.39.7 -> 1.39.8
* [`0f06f483`](https://github.com/NixOS/nixpkgs/commit/0f06f483c785e72f3b9ba53aaaacc884bd4bd032) exploitdb: 2023-07-12 -> 2023-07-18
* [`33255390`](https://github.com/NixOS/nixpkgs/commit/3325539064abedc6f143e9cd14a608b0b7f75e37) e16: 1.0.27 -> 1.0.28
* [`f89973e3`](https://github.com/NixOS/nixpkgs/commit/f89973e36a307788f0edf4ab1729ba6f0a6258f6) python310Packages.paddle_bfloat: build from source ([nixos/nixpkgs⁠#243898](https://togithub.com/nixos/nixpkgs/issues/243898))
* [`67f82ec5`](https://github.com/NixOS/nixpkgs/commit/67f82ec53a38af84424e83f56df646c48a974ce9) python310Packages.repeated-test: 2.3.1 -> 2.3.3
* [`62f5b9ee`](https://github.com/NixOS/nixpkgs/commit/62f5b9eeec65cc23e5e63ccd916afca6b80a3ca2) gr-framework: init at 0.72.9
* [`56f69fa2`](https://github.com/NixOS/nixpkgs/commit/56f69fa276f5a2e637e42be67e3b2eeb68a49b63) python311Packages.pyxbe: 1.0.2 -> 1.0.3
* [`d31e7c52`](https://github.com/NixOS/nixpkgs/commit/d31e7c52820c76402cacbfebb6634f51f0012a6c) rclone: 1.63.0 -> 1.63.1 ([nixos/nixpkgs⁠#244073](https://togithub.com/nixos/nixpkgs/issues/244073))
* [`ca1dd491`](https://github.com/NixOS/nixpkgs/commit/ca1dd491c6e2d4831e94a0908c7ddf8b9e22d5ee) nixos/firefox: stop reading nixpkgs.config.firefox.enableEUWebID
* [`3f751bfd`](https://github.com/NixOS/nixpkgs/commit/3f751bfdf6d1086317d175b628a17690605cccd1) nixos/bpftune: drop flaky tests
* [`a516f3b9`](https://github.com/NixOS/nixpkgs/commit/a516f3b98aa56f85382b36cb77abf6202ad32030) python310Packages.dissect-cobaltstrike: fix darwin sandbox build
* [`386b81c1`](https://github.com/NixOS/nixpkgs/commit/386b81c136728d8c59d38753e88aa8fbbec95304) treewide: drop inactive maintainer costrouc from all python packages
* [`69fbf748`](https://github.com/NixOS/nixpkgs/commit/69fbf7488937a5e0437b57716c249e1c66fa7925) pmaintainers: add mschwaig
* [`a9bef3d2`](https://github.com/NixOS/nixpkgs/commit/a9bef3d296c74f1ed758a227f18afd74f93e2c21) tensorflow-lite: 2.5.0 -> 2.13.0, switch build to bazel
* [`3be38faf`](https://github.com/NixOS/nixpkgs/commit/3be38faf5962bb0d860132de3ff7708b24544e10) laurel: 0.5.2 -> 0.5.3
* [`c701855a`](https://github.com/NixOS/nixpkgs/commit/c701855a9b23f09f9c5353305222e86011b068c7) graphite-cli: fix build
* [`9cd0172e`](https://github.com/NixOS/nixpkgs/commit/9cd0172e6e14181692c56844f11a32c4162d01aa) reuse: 1.1.2 -> 2.0.0
* [`cb997317`](https://github.com/NixOS/nixpkgs/commit/cb997317e838d13cc8660530e12a7da9a5e0061f) reuse: 2.0.0 -> 2.1.0
* [`f3ab6958`](https://github.com/NixOS/nixpkgs/commit/f3ab69582dede416e9b4c34d3b0ed15b5ecd5238) zarf: 0.28.1 -> 0.28.2
* [`8e3c5226`](https://github.com/NixOS/nixpkgs/commit/8e3c522630fb1129c402fd931f91a14b1913e0c5) maintainers: adding fd
* [`dd3fec45`](https://github.com/NixOS/nixpkgs/commit/dd3fec45d4cc8803d3a1491d0d20b0b5ed6bf4ec) age-plugin-tpm: add disclaimer about experimentalness
* [`aa2fc5e1`](https://github.com/NixOS/nixpkgs/commit/aa2fc5e1ea3ed4fd9606b881bbfaa8173cb51c05) foot: 1.14.0 -> 1.15.0
* [`e4263f5e`](https://github.com/NixOS/nixpkgs/commit/e4263f5e9ad6c1e6507c88d02fc588b43c035247) python310Packages.jupyter-contrib-core: init at 0.4.2
* [`6eb2c2fd`](https://github.com/NixOS/nixpkgs/commit/6eb2c2fddb0c359e250dbcec72b203f32609c038) python310Packages.jupyter-nbextensions-configurator: init at 0.6.3
* [`0a473faa`](https://github.com/NixOS/nixpkgs/commit/0a473faa8d5c61789c3b6b0040be077b5ae55f0a) python310Packages.jupyter-highlight-selected-word: init at 0.2.0
* [`5f35b11a`](https://github.com/NixOS/nixpkgs/commit/5f35b11a0d87b597e418b363c8a4ca086a01e3ed) python310Packages.jupyter-contrib-nbextensions: init at 0.7.0
* [`b6989092`](https://github.com/NixOS/nixpkgs/commit/b69890924f342b625d62b245fb006dd71ada1956) koka: 2.4.0 -> 2.4.2
* [`c2abd110`](https://github.com/NixOS/nixpkgs/commit/c2abd1103150e3c0921feb5b130b0475576b6fc3) pacman: disable fortify3
* [`74e81c59`](https://github.com/NixOS/nixpkgs/commit/74e81c592668edf6fdd650df89cf008704b6aa7e) buck2: fix selection logic in update.sh
* [`7e7c8fc8`](https://github.com/NixOS/nixpkgs/commit/7e7c8fc893a5ff638a4f26ea2824407e61524875) buck2: unstable-2023-07-11 -> unstable-2023-07-15
* [`5b86eecf`](https://github.com/NixOS/nixpkgs/commit/5b86eecfabf1fdb96aedbaee40e51c6490050931) buck2: migrate linux binary to static musl build
* [`062d0531`](https://github.com/NixOS/nixpkgs/commit/062d0531487198173aa63a2bd23755f8e7eed1e2) linuxPackages.nvidia_x11_legacy470: 470.182.03 -> 470.199.02
* [`b282da1f`](https://github.com/NixOS/nixpkgs/commit/b282da1f4d143289183f19356819172a2de37e60) python310Packages.cpyparsing: 2.4.7.2.1.1 -> 2.4.7.2.1.2
* [`815a2d26`](https://github.com/NixOS/nixpkgs/commit/815a2d26224e7f3db0f9d7a56efb84c0a3b3e3de) mlt: fix binary not being wrapped if enableQt is disabled
* [`fba18d84`](https://github.com/NixOS/nixpkgs/commit/fba18d8445001b850dce5aea52a7f4a22516f189) xorg.xkeyboardconfig_custom: update for 2.39
* [`e4ab8a7d`](https://github.com/NixOS/nixpkgs/commit/e4ab8a7d1e31616ba47f11265c03e4707299af24) nixos/tests/keymap: add custom layouts test
* [`ec234a6b`](https://github.com/NixOS/nixpkgs/commit/ec234a6b202346781d7abd49a02bd20539d8e1be) goldendict: fix wrong rev in fetchFromGitHub
* [`6bc52c38`](https://github.com/NixOS/nixpkgs/commit/6bc52c386fe9b6aebb8b18533e6009021e955500) oddjob: init at 0.34.7
* [`d5d30e9c`](https://github.com/NixOS/nixpkgs/commit/d5d30e9c6d9d2cb6085b083692f17d3f06415adb) cargo-binstall: 1.0.0 -> 1.1.0
* [`03431f12`](https://github.com/NixOS/nixpkgs/commit/03431f1244a92659cf26a1b6e40de5db00c5e310) lib: Add README
* [`581d7c88`](https://github.com/NixOS/nixpkgs/commit/581d7c88bea4216fb47c2a98f38af59f2d14485d) lib/tests: Unify documentation of individual testable files
* [`8c9d9a35`](https://github.com/NixOS/nixpkgs/commit/8c9d9a3551377cc6b78d2bf287706d59013c2131) rust-analyzer-unwrapped: 2023-07-10 -> 2023-07-17
* [`162893f9`](https://github.com/NixOS/nixpkgs/commit/162893f92a42113dd46947861595f5ef0719403b) nixos/oddjob: init at 0.34.7
* [`dcb6892b`](https://github.com/NixOS/nixpkgs/commit/dcb6892b51ef9d64c4628b50ca2f25eedf51dd49) smemstat: 0.02.11 -> 0.02.12
* [`6142a24d`](https://github.com/NixOS/nixpkgs/commit/6142a24d9b39fc8938317ac9ce038be5e1572941) himalaya: 0.8.1 -> 0.8.4
* [`e0cb60b7`](https://github.com/NixOS/nixpkgs/commit/e0cb60b7ebda06a9cea5907f50864ecd251d760f) dvc: 3.5.0 -> 3.5.1
* [`c8a7edce`](https://github.com/NixOS/nixpkgs/commit/c8a7edcee18af4f98c945e55ff43b5900d88c18a) nixos/engelsystem: pin php at 8.1
* [`9beee120`](https://github.com/NixOS/nixpkgs/commit/9beee1207b34654e7dc708b36eaef2f77fbc9402) chickenPackages: update eggs
* [`44be05fa`](https://github.com/NixOS/nixpkgs/commit/44be05fa15721cd70e37308e32e2c4402fed4968) tmuxPlugins.tmux-fzf: unstable-2022-08-02 -> unstable-2023-07-06
* [`0000023c`](https://github.com/NixOS/nixpkgs/commit/0000023c847ca03f4a630cec8f6b0a6fd7424bc8) portmod: cleanup unused inputs
* [`588a7b4d`](https://github.com/NixOS/nixpkgs/commit/588a7b4d8d9fd1d0255b678211ea8f387bc0582b) imagemagick: 7.1.1-12 -> 7.1.1-13
* [`ee1c36f4`](https://github.com/NixOS/nixpkgs/commit/ee1c36f4859005ff3fe370c302cde19e998150e0) evcc: 0.118.8 -> 0.118.9
* [`6a38b237`](https://github.com/NixOS/nixpkgs/commit/6a38b237044d8b20db66bb3de95aec46ae9d9115) python310Packages.ical: 4.5.4 -> 5.0.0
* [`a5f8a090`](https://github.com/NixOS/nixpkgs/commit/a5f8a0908cd813f159fa4826e637482cca00b18b) gnome.cheese: 44.0.1 → 44.1
* [`fa503f4b`](https://github.com/NixOS/nixpkgs/commit/fa503f4b921b3af86a7fcf9b2e02a00fd79bc1a8) lib.attrsets.mergeAttrsList: init
* [`ac911576`](https://github.com/NixOS/nixpkgs/commit/ac9115761e71b90390cc463040a900aa8567a572) linuxPackages.nvidia_x11_production: 535.54.03 -> 535.86.05
* [`5e35de6f`](https://github.com/NixOS/nixpkgs/commit/5e35de6ff1a7c04042f94148e51401564a074ff6) qq: support wayland ozone
* [`cc4091be`](https://github.com/NixOS/nixpkgs/commit/cc4091be0fac90a1ef1f22b7c33104023af74bc2) palemoon-bin: 32.2.1 -> 32.3.1
* [`27cb23a0`](https://github.com/NixOS/nixpkgs/commit/27cb23a0cd232aa9eca36c72c4951a0345ba48ff) maintainers: add azazak123
* [`03269a6b`](https://github.com/NixOS/nixpkgs/commit/03269a6bbcfe1a0a0027b6f8aed8011c3ddcb15a) hyprland-per-window-layout: init at 2.3
* [`e118624e`](https://github.com/NixOS/nixpkgs/commit/e118624e4569240161cbd0b3888ff618424570b4) gotrue-supabase: 2.82.2 -> 2.83.1
* [`1f9d30c9`](https://github.com/NixOS/nixpkgs/commit/1f9d30c9af258c0d46e701a56eb7a1c21b59cfde) syft: 0.84.1 -> 0.85.0
* [`e51903bb`](https://github.com/NixOS/nixpkgs/commit/e51903bb1afd247acfd3b123de9197971fa769d5) python311Packages.pynina: 0.3.0 -> 0.3.1
* [`c03a4eef`](https://github.com/NixOS/nixpkgs/commit/c03a4eef7f4dc21057c28795e7136f711f0d0637) python311Packages.pynina: add changelog
* [`2ef88095`](https://github.com/NixOS/nixpkgs/commit/2ef880952feec17e889f7dd40edc7c314adf5fa5) python310Packages.bandcamp-api: 0.1.15 -> 0.2.2
* [`7e0f542d`](https://github.com/NixOS/nixpkgs/commit/7e0f542df82a92384f7d0d7cb63630efab53a95d) inform6: 6.41-r5 -> 6.41-r6
* [`29d53c75`](https://github.com/NixOS/nixpkgs/commit/29d53c75294a51b9441cf43dd0a7ef0123e50ba8) botan3: init at 3.1.1
* [`6b7dbf54`](https://github.com/NixOS/nixpkgs/commit/6b7dbf5415069dc39dfb158e9d2aa5b985399472) element-{desktop,web}: 1.11.35 -> 1.11.36 ([nixos/nixpkgs⁠#244193](https://togithub.com/nixos/nixpkgs/issues/244193))
* [`45497da7`](https://github.com/NixOS/nixpkgs/commit/45497da716dd3fd431dea6f29ad4cc3fbd064707) botan2: small cleanup
* [`94d894f3`](https://github.com/NixOS/nixpkgs/commit/94d894f3efdc07f3943bcc0639773e76c9570162) livebook: 0.9.2 -> 0.10.0
* [`e27ce9a6`](https://github.com/NixOS/nixpkgs/commit/e27ce9a6168227bbaa4739e5b4139076937ca56b) jetbrains: 2023.1.3 -> 2023.1.5
* [`895d66d9`](https://github.com/NixOS/nixpkgs/commit/895d66d915f66d75a610294515b3c7da506c0444) luaPackages.magick: init at 1.6.0
* [`7e8fe39b`](https://github.com/NixOS/nixpkgs/commit/7e8fe39bb97e55098da6b980d76f1b0cfdf0d3eb) jetbrains.plugins: update
* [`231f5353`](https://github.com/NixOS/nixpkgs/commit/231f53532dc91f93cc797d31b64097234d069249) python310Packages.datadog: 0.45.0 -> 0.46.0
* [`92c3002d`](https://github.com/NixOS/nixpkgs/commit/92c3002d68868c5217d881150152ec8492f26fed) viceroy: 0.5.1 -> 0.6.0
* [`ba716667`](https://github.com/NixOS/nixpkgs/commit/ba71666710a569da722d4bb99c2c8606fbcb0d1f) mullvad.openvpn-mullvad: 2.5.3 -> 2.6.0
* [`b2ccb3e0`](https://github.com/NixOS/nixpkgs/commit/b2ccb3e074efa11af4c1d878402189724a9d7d62) mullvad.openvpn-mullvad: Fix postPatch
* [`f362d21d`](https://github.com/NixOS/nixpkgs/commit/f362d21d6f1a1e819ef3f56fa94eb1c2b16d5bf0) mullvad.openvpn-mullvad: Move hooks to nativeBuildInputs
* [`369fbaae`](https://github.com/NixOS/nixpkgs/commit/369fbaae615ca2c51a8e3ed7b030099ed7906540) mullvad.openvpn-mullvad: Update configureFlags to match the flags from mullvadvpn-app-binaries on Linux too
* [`daeb3028`](https://github.com/NixOS/nixpkgs/commit/daeb3028ccf41e8bcee3cc98b6e0ef610cd509c3) unison: M4i -> M5b
* [`2dd80af4`](https://github.com/NixOS/nixpkgs/commit/2dd80af40e2ad8c81de706883eff33c0371441a6) python310Packages.asteval: 0.9.30 -> 0.9.31
* [`79b5848b`](https://github.com/NixOS/nixpkgs/commit/79b5848bbfb463f0a3006d56ac41ac74aee17f2f) wasm-tools: 1.0.36 -> 1.0.37
* [`5a68f339`](https://github.com/NixOS/nixpkgs/commit/5a68f339eee7e237ba13ab0b3a994b9711e92b70) ra-multiplex: init at 0.2.2
* [`d470477e`](https://github.com/NixOS/nixpkgs/commit/d470477e2e7c9be917b21bea9d5edf721c050a9a) jql: 7.0.1 -> 7.0.2
* [`0c1da334`](https://github.com/NixOS/nixpkgs/commit/0c1da334ad9e0ff3c0dae51d24fec1c2dff36b4e) python310Packages.mkdocstrings-python: 0.10.1 -> 1.2.0
* [`55d2974b`](https://github.com/NixOS/nixpkgs/commit/55d2974b0f83e2e56a0cb07318eab4843fff6b95) python310Packages.universal-pathlib: 0.0.23 -> 0.0.24
* [`65ba40e6`](https://github.com/NixOS/nixpkgs/commit/65ba40e6120d705039b3b0b0376332060c64dac5) tunwg: 23.06.14+dbfe3aa -> 23.07.15+3213668
* [`7dc1810c`](https://github.com/NixOS/nixpkgs/commit/7dc1810cb1467b8b66a0e635f3f361c0d132c4af) matrix-synapse: 1.87.0 -> 1.88.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
