### PR TITLE
niv devenv: update 892ddef1 -> 9fb94a34

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "892ddef1fba6a956c172e6c1bb7c830795c713a2",
-        "sha256": "0d2gjby8c8pp6flb10c8sirnmygfhhahvqxikq65z5zfvydvdnlz",
+        "rev": "9fb94a348179ee0074beeac2dce2d30f18588e4d",
+        "sha256": "0pbnsjzdmllbgaj8l55d5bb963h915cpcl4c1pl19k7xk9blaxrg",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/892ddef1fba6a956c172e6c1bb7c830795c713a2.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/9fb94a348179ee0074beeac2dce2d30f18588e4d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@892ddef1...9fb94a34](https://github.com/cachix/devenv/compare/892ddef1fba6a956c172e6c1bb7c830795c713a2...9fb94a348179ee0074beeac2dce2d30f18588e4d)

* [`0d08083c`](https://github.com/cachix/devenv/commit/0d08083c19d1f03302ca17eba920852c171e942c) python: poetry: use .venv in DEVENV_ROOT instead of DEVENV_STATE
* [`12a637d1`](https://github.com/cachix/devenv/commit/12a637d1996e3f17f7323137b40f422448a6047c) python: venv: use local VENV_PATH variable
* [`f2bc461d`](https://github.com/cachix/devenv/commit/f2bc461da2d92259ac4a7f7c4f5e85426dea3af6) python: poetry: always check for correct python interpreter
* [`fbf8406b`](https://github.com/cachix/devenv/commit/fbf8406b622d214890c166676993cf56702a8931) python: poetry: install when pyproject.toml changes
* [`e207a8ef`](https://github.com/cachix/devenv/commit/e207a8ef9911eba7f9a5e7761e47dc532931d482) typo
* [`a9553258`](https://github.com/cachix/devenv/commit/a95532580b46082c46faf17b9250bec2513ba518) Add a devenv-up package
* [`cb38839e`](https://github.com/cachix/devenv/commit/cb38839e20c3459be0aacddb4c9eb6be0da8f0d8) Add --no-link flag
* [`e1e76acb`](https://github.com/cachix/devenv/commit/e1e76acb22c65f2b0313fce1b7e85ea97c1c8102) Set VENV_PATH properly
* [`01721ce8`](https://github.com/cachix/devenv/commit/01721ce87b8c7bb9e0efa5648a43af297df21a07) Add shell language support.
* [`f415d8c8`](https://github.com/cachix/devenv/commit/f415d8c88c295a082d9918d6f874f6916ce4dd9f) Revert "Set VENV_PATH properly"
* [`ff78ecd8`](https://github.com/cachix/devenv/commit/ff78ecd88b5e8c15b274c71560f68ab431eeb94f) Auto generate docs/reference/options.md
* [`8a772861`](https://github.com/cachix/devenv/commit/8a772861347dfa1b2750717a9d91d59b2dc9ea12) lang/shell: Add bats libs to bats package
* [`11991254`](https://github.com/cachix/devenv/commit/11991254e8173f3f35aa26ba1f13d85e8303ef2b) vscode: switch to Nix extension with lsp support
* [`fc0ff0e2`](https://github.com/cachix/devenv/commit/fc0ff0e2a1dc882f10a83af80acb16403007bbb0) containers: set the defaults for containers accordingly
* [`def76d0b`](https://github.com/cachix/devenv/commit/def76d0ba0d3743bdfa3a8fdb3903e0928b3c6f0) fly.io: test containers
* [`9b6566c5`](https://github.com/cachix/devenv/commit/9b6566c51efa2fdd6c6e6053308bc3a1c6817d31) common-patterns: document container exclusion
