### PR TITLE
niv home-manager: update 2f84579a -> d309a62e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f84579a70b8c74e5ebb37299a0c3ba279f09382",
-        "sha256": "08q1p8x2sbxndkdb7012agamlg1x0b9vl44lhh7r2bb9j67vd6y9",
+        "rev": "d309a62ee81faec56dd31a263a0184b0e3227e36",
+        "sha256": "1h9cfxxa2ap8vf4b98hkwc48yg72kmcc3y4qjzah0h5fsw0cmgvr",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/2f84579a70b8c74e5ebb37299a0c3ba279f09382.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d309a62ee81faec56dd31a263a0184b0e3227e36.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@2f84579a...d309a62e](https://github.com/nix-community/home-manager/compare/2f84579a70b8c74e5ebb37299a0c3ba279f09382...d309a62ee81faec56dd31a263a0184b0e3227e36)

* [`1add3c3a`](https://github.com/nix-community/home-manager/commit/1add3c3a99ce2c2486cf524c2b42677787916a9e) manual: add test
* [`23ad3d2b`](https://github.com/nix-community/home-manager/commit/23ad3d2b5398402967bbc566fae3f15cb1a1be27) version: add `isReleaseBranch`
* [`82c157f2`](https://github.com/nix-community/home-manager/commit/82c157f255c28fb2ff7e37b81ec584cc286fab9a) flake: temporarily pin nixpkgs version
* [`59b93365`](https://github.com/nix-community/home-manager/commit/59b933653ab2ba7b7976cbb8b4b134a7363edf6f) docs: use `nixosOptionsDoc`
* [`11b09b10`](https://github.com/nix-community/home-manager/commit/11b09b10e4404b3247ea6f56fb2248102e8e33d8) treewide: add missing option descriptions
* [`e2a1cb50`](https://github.com/nix-community/home-manager/commit/e2a1cb50d8c1da9df3f98ae5f6459f4e1dd867d6) treewide: fix `mkEnableOption` arguments
* [`3228f92b`](https://github.com/nix-community/home-manager/commit/3228f92b9087775869a3cbfb0669a2eb6540452a) treewide: manually convert some docs to Markdown
* [`3222c99a`](https://github.com/nix-community/home-manager/commit/3222c99a916f4019ecf1bc6d3c59f08294857b2e) treewide: convert parameterized docs to Markdown
* [`9e4a73c2`](https://github.com/nix-community/home-manager/commit/9e4a73c25e9b6348392fd7c17e88dc78a25475a1) treewide: convert custom `enable` docs to Markdown
* [`21c700d1`](https://github.com/nix-community/home-manager/commit/21c700d14bd7e406aba86f70bb7da13df78a68e8) treewide: convert options with lists to Markdown
* [`71df5071`](https://github.com/nix-community/home-manager/commit/71df507159dde0f7f5ac6874a813c486786ec0e7) treewide: convert options with tables to Markdown
* [`e04de5b3`](https://github.com/nix-community/home-manager/commit/e04de5b308ffe8def2bd5c463a426286222b5e82) treewide: `mkPackageOption` -> `mkPackageOptionMD`
* [`b5a65b91`](https://github.com/nix-community/home-manager/commit/b5a65b91fb0244a7e71e1bc75e666a8b2f78ce7c) treewide: `mkAliasOption` -> `mkAliasOptionMD`
* [`c1d8d2a3`](https://github.com/nix-community/home-manager/commit/c1d8d2a3d1cc7b5ee5849d486140c15e7d82d336) treewide: adjust some DocBook for conversion
* [`36a53d9f`](https://github.com/nix-community/home-manager/commit/36a53d9f26f2ec2530263250e808262bc78fc3be) treewide: convert all option docs to Markdown
* [`60e42285`](https://github.com/nix-community/home-manager/commit/60e4228504f65aca821965e8cf7f4d1449d57c38) flake: remove temporary nixpkgs pin
* [`7398af11`](https://github.com/nix-community/home-manager/commit/7398af11b88bc905caaf2596b34ac4e8b6c6449d) docs: clean up after Markdown migration
* [`9f9e277b`](https://github.com/nix-community/home-manager/commit/9f9e277b60a6e6915ad3a129e06861044b50fdf2) treewide: remove now-redundant `lib.mdDoc` calls
* [`8c350c20`](https://github.com/nix-community/home-manager/commit/8c350c2069ac3eed6344fa62e3249afa0ce2728c) docs: update for Markdown migration
* [`0841242b`](https://github.com/nix-community/home-manager/commit/0841242b94638fcd010f7f64e56b7b1cad50c697) ripgrep: don't set env. variable if no config ([nix-community/home-manager⁠#4254](https://togithub.com/nix-community/home-manager/issues/4254))
* [`44ba0184`](https://github.com/nix-community/home-manager/commit/44ba0184376c1bf017b8f2646a6040fb66d9c3e8) jujutsu: update for Jujutsu 0.8.0 ([nix-community/home-manager⁠#4250](https://togithub.com/nix-community/home-manager/issues/4250))
* [`c707d4f5`](https://github.com/nix-community/home-manager/commit/c707d4f552bb91512c1df677b2d33ec6000c5230) docs: hide `_module.*` from NixOS/nix-darwin docs
* [`1c60851e`](https://github.com/nix-community/home-manager/commit/1c60851e5e50754e8547df22eab5e6d19aed7181) Translate using Weblate (Swedish)
* [`975f5aa6`](https://github.com/nix-community/home-manager/commit/975f5aa643a08edf1c16a4510d1c3e008386976f) Translate using Weblate (Spanish)
* [`2e2b24e5`](https://github.com/nix-community/home-manager/commit/2e2b24e5bcafad740a35ca07b2107624efa1c9e1) Translate using Weblate (Ukrainian)
* [`0cb3ac57`](https://github.com/nix-community/home-manager/commit/0cb3ac57fca6b52c42e4c0f560185540ae1dfb6c) Translate using Weblate (Indonesian)
* [`1443abd2`](https://github.com/nix-community/home-manager/commit/1443abd2696ec6bd6fb9701e6c26b277a27b4a3e) script-directory: fix documentation link ([nix-community/home-manager⁠#4258](https://togithub.com/nix-community/home-manager/issues/4258))
* [`ee567324`](https://github.com/nix-community/home-manager/commit/ee5673246de0254186e469935909e821b8f4ec15) hyprland: add module
* [`76dd6c66`](https://github.com/nix-community/home-manager/commit/76dd6c66190db0d46ac6b3ca816cc17b581df42c) hyprland: prioritize variables and beziers ([nix-community/home-manager⁠#4263](https://togithub.com/nix-community/home-manager/issues/4263))
* [`fb03fa55`](https://github.com/nix-community/home-manager/commit/fb03fa5516d4e86059d24ab35a611ffa3a359547) flake.lock: Update
* [`ab70a023`](https://github.com/nix-community/home-manager/commit/ab70a02363e28738f8c6e2793e4d6b7105a0494d) git-sync: add darwin support
* [`a30f5b5b`](https://github.com/nix-community/home-manager/commit/a30f5b5b35e2d974fb5e1a3721eaec723ef48c89) gh-dash: add module
* [`d309a62e`](https://github.com/nix-community/home-manager/commit/d309a62ee81faec56dd31a263a0184b0e3227e36) tmate: don't generate empty config file ([nix-community/home-manager⁠#4271](https://togithub.com/nix-community/home-manager/issues/4271))
