### PR TITLE
niv powerlevel10k: update 932954a8 -> 1d96f5e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "932954a8b1e31ae540e9df5e5e464100d46e53ec",
-        "sha256": "1hk3i02668iyi3sc4g8qqrf488352f1nn9vrf7z5w2wbbpvlr0hd",
+        "rev": "1d96f5e066a5dd569ddd24787d7e9a3c3abe3024",
+        "sha256": "160y3v41giwv1zmlvx8117lla6yfimpagm1l0x47d872l5yx2nli",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/932954a8b1e31ae540e9df5e5e464100d46e53ec.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/1d96f5e066a5dd569ddd24787d7e9a3c3abe3024.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@932954a8...1d96f5e0](https://github.com/romkatv/powerlevel10k/compare/932954a8b1e31ae540e9df5e5e464100d46e53ec...1d96f5e066a5dd569ddd24787d7e9a3c3abe3024)

* [`2453fd27`](https://github.com/romkatv/powerlevel10k/commit/2453fd27e20e9c1e4bac43eb1b8b9476749e429f) Update README.md as Terminus is now known as Tabby
* [`646bae0d`](https://github.com/romkatv/powerlevel10k/commit/646bae0dd629045e08928c3ba7baa54fbbe79faa) docs: Terminus is now called Tabby
* [`e8aa8cce`](https://github.com/romkatv/powerlevel10k/commit/e8aa8cce7f3c2017a21e62f502217be22e066aea) unquote ID in /etc/os-release ([romkatv/powerlevel10k⁠#2388](https://togithub.com/romkatv/powerlevel10k/issues/2388))
* [`1d96f5e0`](https://github.com/romkatv/powerlevel10k/commit/1d96f5e066a5dd569ddd24787d7e9a3c3abe3024) unquote ID in /etc/os-release ([romkatv/powerlevel10k⁠#2388](https://togithub.com/romkatv/powerlevel10k/issues/2388))
