### PR TITLE
niv nixpkgs: update 03f5806f -> df2e373b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "03f5806fdaad03086b334540f42e8a86c8b06424",
-        "sha256": "06dnx1sxlhyr116hz9i7krmja3l9l3bh2x6i1iynnmbv04h5mrk0",
+        "rev": "df2e373b15dd502114e8a671f3675d50ed1ebc90",
+        "sha256": "1f7hh1kx6nncn7pibg8afnvzsqcql2578w8a8nb2vhlfp3ay5lni",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/03f5806fdaad03086b334540f42e8a86c8b06424.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/df2e373b15dd502114e8a671f3675d50ed1ebc90.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@03f5806f...df2e373b](https://github.com/nixos/nixpkgs/compare/03f5806fdaad03086b334540f42e8a86c8b06424...df2e373b15dd502114e8a671f3675d50ed1ebc90)

* [`838f3744`](https://github.com/NixOS/nixpkgs/commit/838f374448892f094ff69d9a00772a68a1643cc2) dnglab: init at 0.5.0
* [`0dd442cb`](https://github.com/NixOS/nixpkgs/commit/0dd442cba236bf47c2aa9762f10c949f014ffc6e) ansible-vault-rw: init at 2.1.0
* [`9c66acbc`](https://github.com/NixOS/nixpkgs/commit/9c66acbc34a9399fb2d814df194c1df1db60bc59) hop-cli: init at 0.2.35
* [`25e94e1c`](https://github.com/NixOS/nixpkgs/commit/25e94e1cd253879f054540d60acf6e20cd666a99) steam: add indication for the nix option
* [`91ba76a1`](https://github.com/NixOS/nixpkgs/commit/91ba76a123eec8b4450cc32342e408183e587829) greetd.greetd: 0.8.0 -> 0.9.0
* [`30748218`](https://github.com/NixOS/nixpkgs/commit/30748218fbee423cb5868283322c6b679c2055b4) nixos/sogo: fix nginx proxy_buffer config
* [`db730508`](https://github.com/NixOS/nixpkgs/commit/db7305086f7917980b3c57de64c8e9984abfd7b2) memtest86plus: 6.10 -> 6.20
* [`f652c833`](https://github.com/NixOS/nixpkgs/commit/f652c8335446a841b4ee5b0be1a0a783e449e743) nixos/manual: rectify partitioning commands for UEFI/GPT
* [`db17d622`](https://github.com/NixOS/nixpkgs/commit/db17d622844efaeeb35ffefbaabd205c21b09c59) nixos/cage: add environment config
* [`4f1ccb7f`](https://github.com/NixOS/nixpkgs/commit/4f1ccb7fc58e83d9cf7f92e820c7ecaba2801982) nixos/docker: add extraPackages option
* [`9414d3b1`](https://github.com/NixOS/nixpkgs/commit/9414d3b12063950d6503476d25df5320346684e9) isocodes: 4.11.0 -> 4.15.0
* [`fadc824f`](https://github.com/NixOS/nixpkgs/commit/fadc824f205cb2bc34d06997c9efe155be1308cc) nixos/etc: keep directories in derivation name
* [`8bdfbb36`](https://github.com/NixOS/nixpkgs/commit/8bdfbb36ff1f3cc0e167fbf08aa13135ad7d6558) libdc1394: 2.2.6 -> 2.2.7
* [`2bf38f5f`](https://github.com/NixOS/nixpkgs/commit/2bf38f5fab33ce36cc16ea72086ef7ccb7ed6a5f) pr-template: Use semantic H2 level headings
* [`0cf9f467`](https://github.com/NixOS/nixpkgs/commit/0cf9f4674b82ff6eed2f7eb315cd24f51e4c9739) measureme: init at 10.1.1
* [`d7f89bbf`](https://github.com/NixOS/nixpkgs/commit/d7f89bbfb664f96768492f4b943c94a5f327ed51) nixos/proxmox-image: add additionalSpace, bootSize and diskSize options
* [`60b9fd7d`](https://github.com/NixOS/nixpkgs/commit/60b9fd7d8f30c93f202efe0a3bd50e7bb58f94cb) ibmcloud-cli: init at 2.17.0
* [`7127bb90`](https://github.com/NixOS/nixpkgs/commit/7127bb909f863ab200b729ffc5dd83538511e048) janet: 1.28.0 -> 1.29.1
* [`457600c5`](https://github.com/NixOS/nixpkgs/commit/457600c552eea1eaaf9375cbb2ccf0807611e7bc) openiscsi: 2.1.8 -> 2.1.9
* [`caa52ee1`](https://github.com/NixOS/nixpkgs/commit/caa52ee13b8e5528c92e7d02a89fe1cf7b83c44d) fluidsynth: 2.3.2 -> 2.3.3
* [`419cdefe`](https://github.com/NixOS/nixpkgs/commit/419cdefed5f49e26c222b40f04de6fb64926605d) edgedb: 2.3.1 -> 3.3.0
* [`3b07356d`](https://github.com/NixOS/nixpkgs/commit/3b07356d2d55c5eacc7a11eb08c3a8de97884b2f) linux/kernel/common-config: support DFS radiations for ath(9|10)k drivers
* [`53135cc8`](https://github.com/NixOS/nixpkgs/commit/53135cc8c7e8fa6d562bea8fc68dc5b553a7e76a) nixos/grub: don't die on EFI-only systems if devices != ["nodev"]
* [`1fe50e1e`](https://github.com/NixOS/nixpkgs/commit/1fe50e1e56dea88de09dc8e8ecb9dbef2a55d22a) libassuan: 2.5.5 -> 2.5.6
* [`e30c15c9`](https://github.com/NixOS/nixpkgs/commit/e30c15c90912d3a206f1672284e3540dc03d62a9) python310Packages.constantly: run tests
* [`b9ea34eb`](https://github.com/NixOS/nixpkgs/commit/b9ea34eb6072638d60a1e898e31d148e5091d32c) hello-wayland: enable debug info
* [`c57c0181`](https://github.com/NixOS/nixpkgs/commit/c57c018132d653669bd242e95cac57061208d9f0) curl: 8.1.1 -> 8.1.2
* [`555555a3`](https://github.com/NixOS/nixpkgs/commit/555555a3d24d46bd04ea1815240b6a6afce31ee8) python310Packages.pytest-timeout: remove dependency on pytest-cov
* [`c2431373`](https://github.com/NixOS/nixpkgs/commit/c24313730ad80d165f7a1104f6431749ae16881b) python310Packages.pluggy: 1.0.0 -> 1.2.0
* [`2a376a59`](https://github.com/NixOS/nixpkgs/commit/2a376a59a343364d3dbcff5a28ff29493c4fbc0c) python310Packages.pluggy: run tests
* [`be82b8b8`](https://github.com/NixOS/nixpkgs/commit/be82b8b8035d0c77b83369bd8d39b874e9a7e77a) libde265: 1.0.11 -> 1.0.12
* [`b8e19af5`](https://github.com/NixOS/nixpkgs/commit/b8e19af5dd30283355522c3cd14884099255391c) cdo: 2.0.5 -> 2.2.0
* [`c04c1a17`](https://github.com/NixOS/nixpkgs/commit/c04c1a1777586016d8f3bec1d84df6122107d495) Revert "gcc: kludge to prevent mass-rebuild"
* [`74a5fa10`](https://github.com/NixOS/nixpkgs/commit/74a5fa10cd822f478edfac7418acafdcaf978240) python310Packages.yarl: 1.8.2 -> 1.9.2
* [`ab34ae3f`](https://github.com/NixOS/nixpkgs/commit/ab34ae3f19e3b4caeefa6d683a944d2da7114630) p11-kit: 0.24.1 -> 0.25.0
* [`f829b240`](https://github.com/NixOS/nixpkgs/commit/f829b240458ba852eb604a84583383ff2d6eed8f) stdenv: fix stagesNative
* [`e91520bb`](https://github.com/NixOS/nixpkgs/commit/e91520bb298fe524f41ba73c608ee86f21b1b552) maintainers: add mib
* [`65e54a76`](https://github.com/NixOS/nixpkgs/commit/65e54a769aeb829c3a5ab99dbd37cc45fc08dd8d) slipstream: init at 1.9.1
* [`eb65a8b1`](https://github.com/NixOS/nixpkgs/commit/eb65a8b165e6e3cbbd78f541f638ef29baf014e0) slipstream: remove platforms
* [`0020bf2f`](https://github.com/NixOS/nixpkgs/commit/0020bf2ff058fd9216f80d0c3f43168ae825fc45) slipstream: use hash not sha256 for github fetch
* [`8ce763b6`](https://github.com/NixOS/nixpkgs/commit/8ce763b65cdc2b6a23e47ebbf171fbd5bb36823d) slipstream: implement finalAttrs pattern
* [`f70b53ea`](https://github.com/NixOS/nixpkgs/commit/f70b53ea0b207fd2b6f380d4b439bd677ad851e6) slipstream: use buildMavenPackage
* [`d2891886`](https://github.com/NixOS/nixpkgs/commit/d2891886e261dd9f95ac4d532112f1279e445ffd) slipstream: run {pre,post}Install hooks
* [`463469e1`](https://github.com/NixOS/nixpkgs/commit/463469e1c3d4416d50ed35a9b281569cc38d3078) redpanda: 23.1.10 -> 23.1.13
* [`8c860646`](https://github.com/NixOS/nixpkgs/commit/8c8606462418f9859f951c37a3b24177dfebea51) vala: Merge graphviz patches into one
* [`089f6ad1`](https://github.com/NixOS/nixpkgs/commit/089f6ad1ed1cc83369f4f13444d4a16b76614e95) vala: 0.56.7 → 0.56.9
* [`aacc9049`](https://github.com/NixOS/nixpkgs/commit/aacc904981c803ae89d017ea1737a160932af9ef) slipstream: remove wrapper
* [`daf9c822`](https://github.com/NixOS/nixpkgs/commit/daf9c822dd68da88aaf6ab777cca8b2c2fcfafaf) slipstream: get jdk from args
* [`ae059c58`](https://github.com/NixOS/nixpkgs/commit/ae059c58a1fb991a719c6b9f3c91138e13c97f8a) slipstream: document slipstream weirdness
* [`fe0b0028`](https://github.com/NixOS/nixpkgs/commit/fe0b00287c11dc6ce8c050d45071097b59c22940) openresolv: 3.12.0 -> 3.13.2
* [`b6d09323`](https://github.com/NixOS/nixpkgs/commit/b6d093238c3980219b05c7e715ec72d2408fa2a7) python310Packages.exceptiongroup: 1.1.0 -> 1.1.2
* [`364b1d29`](https://github.com/NixOS/nixpkgs/commit/364b1d2985cb4d94609edb9cea947075d497bf57) slipstream: add platform
* [`a103593b`](https://github.com/NixOS/nixpkgs/commit/a103593b3bb84fdfd5185eeb5efa27f51ae6116b) slipstream: remove debug statement
* [`fa2f58df`](https://github.com/NixOS/nixpkgs/commit/fa2f58df64816bed16a595ff717614d71e4557b1) rofi-screenshot: init at 2023-07-02
* [`40e25a46`](https://github.com/NixOS/nixpkgs/commit/40e25a4612717b829971f8c1bf43ed237881faef) python311Packages.pyudev: 0.24.0 -> 0.24.1
* [`714410a1`](https://github.com/NixOS/nixpkgs/commit/714410a12c2f02f85d70ce0c0f11be29ee739591) urlscan: add changelog to meta
* [`62e11bcb`](https://github.com/NixOS/nixpkgs/commit/62e11bcb582f79f9158bf4de28069ed5743dadaf) urlscan: migrate to python3.pkgs
* [`067cc9d6`](https://github.com/NixOS/nixpkgs/commit/067cc9d6aef4255fe0a8bbe1906169044dd41e64) maven: 3.9.2 -> 3.9.3
* [`f4dc0763`](https://github.com/NixOS/nixpkgs/commit/f4dc0763b8b4010efac145d06aa1b4c8138f9c47) libxslt: 1.1.37 → 1.1.38
* [`7d9be8a3`](https://github.com/NixOS/nixpkgs/commit/7d9be8a366921ed8193a4b58a8e8bde5f94daa1d) libxml2: 2.10.4 → 2.11.4
* [`a23a2a12`](https://github.com/NixOS/nixpkgs/commit/a23a2a12005a51bc2558b784743bf19e50ab6295) itstool: 2.0.6 → 2.0.7
* [`9e2f0bed`](https://github.com/NixOS/nixpkgs/commit/9e2f0bed3f59a9b1c0d889ad06d669005338d2f9) openldap: drop unused db
* [`d45279b3`](https://github.com/NixOS/nixpkgs/commit/d45279b3a8bbe37a07b008e2e4e2cef224335e7f) libxcrypt: 4.4.35 -> 4.4.36
* [`3d1f8812`](https://github.com/NixOS/nixpkgs/commit/3d1f881267eccba49ddc25446aa35e6b08733360) python310Packages.numpy: run tests correct so that the build can fail
* [`76c7dfef`](https://github.com/NixOS/nixpkgs/commit/76c7dfef031a0897862d90b9834649824b8734d6) gjs: 1.76.0 → 1.76.2
* [`c8e3cbac`](https://github.com/NixOS/nixpkgs/commit/c8e3cbacd75f836591fed3959938a89cde60110b) glib-networking: 2.76.0 → 2.76.1
* [`e86eb603`](https://github.com/NixOS/nixpkgs/commit/e86eb603b3258e6472d82aed3ff92a4b5156981c) gupnp_1_6: 1.6.3 → 1.6.4
* [`1b499400`](https://github.com/NixOS/nixpkgs/commit/1b499400c0e815a4ce1c0a95f7717a3fda25065c) tracker: 3.5.1 → 3.5.3
* [`72f9a50f`](https://github.com/NixOS/nixpkgs/commit/72f9a50f5b21397141833e419fce8be3a0bd877a) networkmanager: 1.42.6 → 1.42.8
* [`c543d280`](https://github.com/NixOS/nixpkgs/commit/c543d28001ad48a39b703b165a43949784aa5231) libqmi: 1.32.2 → 1.32.4
* [`32fcf619`](https://github.com/NixOS/nixpkgs/commit/32fcf619c831f7df6f642a078c2a48ed49fefe32) librsvg: 2.55.1 → 2.56.2
* [`cd94a00a`](https://github.com/NixOS/nixpkgs/commit/cd94a00aa7447246854fcc859cb07b59d2a73d36) stoken: Clean up
* [`55196411`](https://github.com/NixOS/nixpkgs/commit/551964118c57d9d921d4eb511d9c06025cb621c2) stoken: 0.92 → 0.93
* [`2c821a97`](https://github.com/NixOS/nixpkgs/commit/2c821a977e988cbec52560f9fb73d216bfc5b83f) manticoresearch: 5.0.3 -> 6.0.4
* [`024afa2e`](https://github.com/NixOS/nixpkgs/commit/024afa2e99c5eb380286ee3cd86a49651d23937f) zsh-forgit: add completions
* [`e4d1cba3`](https://github.com/NixOS/nixpkgs/commit/e4d1cba3b63d174150c121febc1205928e1fac28) openiscsi: drop multipath test
* [`29bd4a3a`](https://github.com/NixOS/nixpkgs/commit/29bd4a3af92d8155686909604f6736c8e4af9b1a) aria2: build with GNUTLS instead of OpenSSL
* [`18a5f185`](https://github.com/NixOS/nixpkgs/commit/18a5f1857e77d8be77725a5f00b279b1c774f5c6) pdm: add update script
* [`34c9206e`](https://github.com/NixOS/nixpkgs/commit/34c9206ed2c0c25203d8bea39732decb1dd94d01) pdm: 2.7.0 -> 2.7.4
* [`d9a4482c`](https://github.com/NixOS/nixpkgs/commit/d9a4482cd8a46c116ca1df817a32782efd96f007) umockdev: Move libgudev tests into passthru
* [`7ff70d5a`](https://github.com/NixOS/nixpkgs/commit/7ff70d5ab3f61b6d196ceefdbc3afdbba6eeacea) python310Packages.pillow: 9.4.0 -> 9.5.0
* [`446a8703`](https://github.com/NixOS/nixpkgs/commit/446a8703c3b183f69a1660e1aad8b8ba9b1fe724) python310Packages.sqlalchemy: 2.0.17 -> 2.0.18
* [`1faabed2`](https://github.com/NixOS/nixpkgs/commit/1faabed23a59dddc10549d5fe0585ed55bafbff9) python310Packages.Cython: 0.29.34 -> 0.29.36
* [`a27a2a80`](https://github.com/NixOS/nixpkgs/commit/a27a2a801479688084753ac329bdc9886f2ad3b0) libgudev: Enable tests
* [`eafa5c93`](https://github.com/NixOS/nixpkgs/commit/eafa5c93d9cc7778207851f0929592c6039f72d1) libgudev: 237 → 238
* [`b5f26311`](https://github.com/NixOS/nixpkgs/commit/b5f263117a3a8ea5bc2b39196626bddd5e931491) mutest: unstable-2019-08-26 → 0-unstable-2023-02-24
* [`50c922e3`](https://github.com/NixOS/nixpkgs/commit/50c922e39552af0bf3f3b62259bf61c369cbd6dc) nixos/test-driver: use the short form argument to base64 for busybox compatibility.
* [`16925245`](https://github.com/NixOS/nixpkgs/commit/16925245d91de30cfffb5dbf84615d6322aa15c0) librdf_raptor2: backport fix for `libxml2-2.11`
* [`c05483d2`](https://github.com/NixOS/nixpkgs/commit/c05483d2746039dab959065e061095a943d5ddd6) nixos/test-driver: add a test for [nixos/nixpkgs⁠#241938](https://togithub.com/nixos/nixpkgs/issues/241938).
* [`0e5066d6`](https://github.com/NixOS/nixpkgs/commit/0e5066d63ebfc38e281b98d88a2e71fd5a40facb) soundsource: init at 5.6.0
* [`43aea8aa`](https://github.com/NixOS/nixpkgs/commit/43aea8aa449520c756661d3d4db5997cc1b2db45) unnaturalscrollwheels: init at 1.3.0
* [`a76023f2`](https://github.com/NixOS/nixpkgs/commit/a76023f25608951bd0e4a5193e959976d0bc05ee) db: make patches and autoreconfHook unconditional
* [`7e34e3aa`](https://github.com/NixOS/nixpkgs/commit/7e34e3aaf9c4d93de80f27c54c6a20c4f19e36fb) keka: init at 1.3.2
* [`84b0836c`](https://github.com/NixOS/nixpkgs/commit/84b0836cb06e23f0b8e2e11dc575d4a545c0d44e) python310Packages.orjson: 3.8.11 -> 3.9.2
* [`68232d7e`](https://github.com/NixOS/nixpkgs/commit/68232d7e8d56c367550f120eba5dbc0fb0b58909) cyberduck: init at 8.6.0.39818
* [`10df97fc`](https://github.com/NixOS/nixpkgs/commit/10df97fcdabf2d486a068c1920f216d64355bbdb) disk-inventory-x: init at 1.3
* [`41b146ff`](https://github.com/NixOS/nixpkgs/commit/41b146ff40ade8fea42addebc2f5bc7a36a154f9) gcc: restore 'Configured with:' output on 'gcc -v' output
* [`44f637aa`](https://github.com/NixOS/nixpkgs/commit/44f637aa8d933ec682b461877f12125d5857657c) nixos/paperless: use toShellVars for paperless-manage
* [`d87a6a99`](https://github.com/NixOS/nixpkgs/commit/d87a6a99f6dca40f54ec8e325c045afcb450066f) luarocks: can be embedded with lua.withPackages
* [`55032e71`](https://github.com/NixOS/nixpkgs/commit/55032e712fe1669aa4c43e771d729f01d7f7a5f8) glib: 2.76.3 → 2.76.4
* [`97e3abba`](https://github.com/NixOS/nixpkgs/commit/97e3abba79c5ffb17685abc22d43325ed93e5672) glab: 1.30.0 -> 1.31.0
* [`5d100b06`](https://github.com/NixOS/nixpkgs/commit/5d100b06f6c590f5428c6c9706015e16b712d2cf) darwin.rewrite-tbd: 20201114 -> unstable-2023-03-27
* [`7ba01765`](https://github.com/NixOS/nixpkgs/commit/7ba01765aca525dfc64f751663850144c0a17528) libopus: increase test timeouts
* [`f27695d7`](https://github.com/NixOS/nixpkgs/commit/f27695d7ba5c028a8c7c775f3d79a4a7624877f7) openexr: increase test timeout
* [`67d8fed6`](https://github.com/NixOS/nixpkgs/commit/67d8fed633fbbefa33e22a7997ffacc59eae440c) python310Packages.requests-mock: 1.10.0 -> 1.11.0
* [`0142902f`](https://github.com/NixOS/nixpkgs/commit/0142902fc47c001e00a27309255a86b8e75697d0) nix-prefetch-git: add sri-hash to output
* [`2616bb76`](https://github.com/NixOS/nixpkgs/commit/2616bb762b6834a2f20109aebab2c29317084469) nixos/paperless: explain how to set JSON env vars
* [`8ec5e67f`](https://github.com/NixOS/nixpkgs/commit/8ec5e67f632a1e5d1bc262da8b707d8728a502d8) pypy3Packages.protobuf: fix build
* [`d18dd1e6`](https://github.com/NixOS/nixpkgs/commit/d18dd1e6fb0f1d9305b3b6f94647e052cc75a310) thrift: 0.18.0 -> 0.18.1
* [`983f896b`](https://github.com/NixOS/nixpkgs/commit/983f896bf4ed35dbf1fc25041de8c11b2d20ce5b) xmrig: 6.19.3 -> 6.20.0
* [`ef2d657a`](https://github.com/NixOS/nixpkgs/commit/ef2d657a01ccb6d217d3d1699586046825628ebf) buildenv: Limit exclusion of info/dir
* [`dbc15271`](https://github.com/NixOS/nixpkgs/commit/dbc15271f6e57bdec94fe05cfb75356f6b3b6f1c) litefs: 0.4.0 -> 0.5.1
* [`134f4d0a`](https://github.com/NixOS/nixpkgs/commit/134f4d0a9a4badc2155bd9232e1217d6e0582de1) wildmidi: Enable on Darwin, refactor config
* [`da2c4c3e`](https://github.com/NixOS/nixpkgs/commit/da2c4c3e4f7bd48bc7eb6f1b175e09fcc8f1fef5) gst_all_1.gst-plugins-bad: enable wildmidi on Darwin
* [`f43a46f8`](https://github.com/NixOS/nixpkgs/commit/f43a46f8b8a26e636711da6ac6e216ad70e9be89) fluidsynth: Fix CMake config
* [`ff496136`](https://github.com/NixOS/nixpkgs/commit/ff49613671a9d7ac49cf17f124e0c05a9ee191a1) ragel: enableParallelBuilding
* [`5df1c24a`](https://github.com/NixOS/nixpkgs/commit/5df1c24a273e39ee940a546d8076cbff6cb49faa) rustc: remove Darwin special-casing
* [`958f27af`](https://github.com/NixOS/nixpkgs/commit/958f27af752b20991af309abd1c840245df9d5e2) ncurses: provide pkg-config alias files for libtinfo / libtic
* [`77e1f512`](https://github.com/NixOS/nixpkgs/commit/77e1f5126149a16355687e2c7b3e6ea068f65b9b) gupnp: Fix build against libxml2 2.11
* [`a51b82fd`](https://github.com/NixOS/nixpkgs/commit/a51b82fd42bd8d409666a8d007e154ce5dfac2c9) openldap: 2.6.4 -> 2.6.5
* [`1f5542d7`](https://github.com/NixOS/nixpkgs/commit/1f5542d720ae7aa4724445b19b27e0bd88e16a6a) pythonPackages.mkdocs-git-authors-plugin: init at 0.7.2
* [`64eda016`](https://github.com/NixOS/nixpkgs/commit/64eda016c31d83c2ee1243623e64ee1c5ec3e5dc) mercurial: 6.4.5 -> 6.5
* [`880aa44d`](https://github.com/NixOS/nixpkgs/commit/880aa44d4b8709471798916d812388ab828f56a4) androidStudioPackages.canary: 2022.3.1.12 -> 2023.1.1.12
* [`230e21f8`](https://github.com/NixOS/nixpkgs/commit/230e21f8b275e8c0345b55250e79413e1d881afb) osv-detector: 0.6.0 -> 0.11.1
* [`3badec17`](https://github.com/NixOS/nixpkgs/commit/3badec17c6987c2048a03ad9c1e30cc6a21469f7) ipe: 7.2.26 -> 7.2.27
* [`a0366ab2`](https://github.com/NixOS/nixpkgs/commit/a0366ab2ff342ebbeffef6ffb58ecaa1433c69aa) libnftnl: 1.2.5 -> 1.2.6
* [`66454844`](https://github.com/NixOS/nixpkgs/commit/6645484498d6850b54dc25affbfee07d5a2b1f7d) libva: 2.18.0 -> 2.19.0
* [`6245a65b`](https://github.com/NixOS/nixpkgs/commit/6245a65b022e0e42a8bedff8db8722a15a70a6d5) python312: 3.12.0b3 -> 3.12.0b4
* [`7247d3fe`](https://github.com/NixOS/nixpkgs/commit/7247d3fe7c4f2e6eb32967e0a24e664afdcbed5d) wayland-protocols: 1.31 -> 1.32
* [`4cb9db11`](https://github.com/NixOS/nixpkgs/commit/4cb9db113dcb9656a7b5ddda48bca776b3d2757e) pythonPackages.importlib-metadata: 6.0.0 -> 6.6.0
* [`e3d7757c`](https://github.com/NixOS/nixpkgs/commit/e3d7757ca841b05fc1d4cab10ca3fa7cc1cde0c3) pythonPackages.importlib-metadata: 6.6.0 -> 6.8.0
* [`6dee9bc9`](https://github.com/NixOS/nixpkgs/commit/6dee9bc9703434aa3299ccc563d5684b8c098927) yapf: 0.32.0 -> 0.40.1
* [`3c53623b`](https://github.com/NixOS/nixpkgs/commit/3c53623bf432a069463b32d2ac806b0936b815f6) go_1_20: 1.20.5 -> 1.20.6
* [`416d02f9`](https://github.com/NixOS/nixpkgs/commit/416d02f9fd22f7b512f1fd00fb080d6fe4ac70fb) upower: Clean up
* [`b9c867fd`](https://github.com/NixOS/nixpkgs/commit/b9c867fdad9678b68342ee79b924a54692ca3fbc) upower: 1.90.0 → 1.90.2
* [`9b0ac382`](https://github.com/NixOS/nixpkgs/commit/9b0ac38252ba7988339371c5fe4f1be8ffdf97d1) systemd: 253.5 -> 253.6
* [`e2741563`](https://github.com/NixOS/nixpkgs/commit/e27415632b4e5b2bb32d65a3a7d37f8a164fc5be) bat-extras: 2023.03.21 -> 2023.06.15
* [`68b134cd`](https://github.com/NixOS/nixpkgs/commit/68b134cdfc3561336e88020982e9ed1cbb239a5f) hwdata: 0.371 -> 0.372
* [`d08e84b3`](https://github.com/NixOS/nixpkgs/commit/d08e84b3be26b302686cd6a93d1e9791547350fe) upower: Add installed tests
* [`5f23eb96`](https://github.com/NixOS/nixpkgs/commit/5f23eb96cddf606c78e803ecc207b34d25d69440) ntp: 4.2.8p15 -> 4.2.8p17
* [`1c29673f`](https://github.com/NixOS/nixpkgs/commit/1c29673fcce3aecd0cb4f30058c266ea5480c8a3) treewide: go-modules -> goModules
* [`e00e2ef5`](https://github.com/NixOS/nixpkgs/commit/e00e2ef50969315cdf3c2acdd5a78e4a06c7ce45) python3Packages.dokuwiki: init at 1.3.3
* [`f79c73c2`](https://github.com/NixOS/nixpkgs/commit/f79c73c2ca8b4d01c78eb1448bd85e9c12405ad8) dotnet-sdk: update.sh - fail if determining a nuget hash fails
* [`42179486`](https://github.com/NixOS/nixpkgs/commit/4217948676306cbbb89a4d63a3c7aff76e8858b6) dotnet-sdk: update.sh - run atomically
* [`78220cae`](https://github.com/NixOS/nixpkgs/commit/78220caeb09b972179dbd0bad1c9680e10e8bdc7) dotnet-sdk: 6.0.411 -> 6.0.412
* [`da60cdbc`](https://github.com/NixOS/nixpkgs/commit/da60cdbcb7f4f136a2fd05b043a55c8ee49d67ec) libbpf: 1.2.0 -> 1.2.2
* [`3601ccf5`](https://github.com/NixOS/nixpkgs/commit/3601ccf5aeece88bf85f4373aa9aaf3c939b0e73) pjsip: 2.13 -> 2.13.1
* [`e2261e5b`](https://github.com/NixOS/nixpkgs/commit/e2261e5bf249b05f41ec6c73ea9804e9dee23fe5) boost: 1.79 -> 1.81
* [`f324b010`](https://github.com/NixOS/nixpkgs/commit/f324b010b38dddbfd4f7aa247fd065f911e2b8a5) perl536Packages.XMLLibXML: 2.0207 -> 2.0208
* [`2ff55fd9`](https://github.com/NixOS/nixpkgs/commit/2ff55fd9e5251fbd07adce76f23d3f837345686f) perl536Packages.XMLLibXML: disable failing test
* [`1c4975fb`](https://github.com/NixOS/nixpkgs/commit/1c4975fb1a652c20362b5e6b49142e3d1af1e13b) adguardhome: 0.107.32 -> 0.107.34
* [`7fe73b8d`](https://github.com/NixOS/nixpkgs/commit/7fe73b8d6fd7275265431b64ec8bc18d3c197882) python310Packages.sh: disable timing sensitive test
* [`865b541b`](https://github.com/NixOS/nixpkgs/commit/865b541b7aaf5a4f0b280077f9a3a850af3107e2) at-spi2-core: fix build with clang 16
* [`1e0904de`](https://github.com/NixOS/nixpkgs/commit/1e0904de344379b71a49a1f5d67a64c4f001502b) rustdesk: init at 1.1.8
* [`5566720c`](https://github.com/NixOS/nixpkgs/commit/5566720c28a1f039878162ab542d55c5bb3078c3) openssl_3: apply patch for CVE-2023-2975
* [`dc84bd68`](https://github.com/NixOS/nixpkgs/commit/dc84bd68b10290b09b2dd92d3477aa17a963061e) scala-cli: 1.0.1 -> 1.0.2
* [`5ed0964a`](https://github.com/NixOS/nixpkgs/commit/5ed0964a7559e19eee6f4ae2cf41789f09b60734) kubevirt: 0.59.2 -> 1.0.0
* [`504676a4`](https://github.com/NixOS/nixpkgs/commit/504676a454d06bdd60003f4f7c009ae14a43e829) cudaPackages.cudnn: fix missing libcublas paths
* [`742eef7c`](https://github.com/NixOS/nixpkgs/commit/742eef7c3083387c557146a4cff07ab3a182a55c) ruby.rubygems: 3.4.16 -> 3.4.17
* [`ef619b5e`](https://github.com/NixOS/nixpkgs/commit/ef619b5e3b6e07c358784e1d7ba8790e3ae4cc7f) bundler: 2.4.16 -> 2.4.17
* [`235cec51`](https://github.com/NixOS/nixpkgs/commit/235cec51d39c6a30d3c79fd48f43a6dc76ab3bb9) python3Packages.discordpy: fix libopus path on Darwin
* [`9d8f99b1`](https://github.com/NixOS/nixpkgs/commit/9d8f99b18d4527cbb939a18c25c3df0be4bf2376) python310Packages.sqlalchemy-continuum: 1.3.14 -> 1.4.0
* [`b195e5fe`](https://github.com/NixOS/nixpkgs/commit/b195e5fe7d1f76d85ad82163ee07e9448bd27f2e) python3Packages.certifi: 2022.12.07 -> 2023.05.07
* [`83ecf7a2`](https://github.com/NixOS/nixpkgs/commit/83ecf7a242a738d557ecd91cdc77e977392391f6) icinga2: 2.13.7 -> 2.14.0
* [`b2537bc8`](https://github.com/NixOS/nixpkgs/commit/b2537bc8328d8c222cd4a047ff62fc4f465bb2c9) docker-slim: 1.40.2 -> 1.40.3
* [`dd853579`](https://github.com/NixOS/nixpkgs/commit/dd8535795f190b77ec0844527e81fc7e18549cc6) cloud-sql-proxy: 1.31.2 -> 2.5.0
* [`ffb261fd`](https://github.com/NixOS/nixpkgs/commit/ffb261fdb7f01315260f12c73f2bbd484321668b) Note breaking change for cloud-sql-proxy
* [`1733d803`](https://github.com/NixOS/nixpkgs/commit/1733d8032aa620b7b6eae67cc8aa53747c7b905c) Revert Merge [nixos/nixpkgs⁠#240480](https://togithub.com/nixos/nixpkgs/issues/240480): python310Packages.pluggy: 1.0.0 -> 1.2.0
* [`0ff1541f`](https://github.com/NixOS/nixpkgs/commit/0ff1541fefb3d4121abce01922caa75e680a525f) movit: 1.6.3 -> 1.7.0
* [`3107091a`](https://github.com/NixOS/nixpkgs/commit/3107091aa4135c66f5133f92e6d30f72f49f307f) pkg: 1.19.1 -> 1.20.4
* [`d8d75123`](https://github.com/NixOS/nixpkgs/commit/d8d751233834d511ed5c5be6c6cd2e2d36a168cc) pop: init at 0.1.0
* [`7fc0e333`](https://github.com/NixOS/nixpkgs/commit/7fc0e3334e183a87a749a000b8111b92b5c1245f) nixos/tailscale: add authKeyFile option
* [`342e6c6b`](https://github.com/NixOS/nixpkgs/commit/342e6c6bff00dcaae7f1c075c37da3848fa5b0c6) nftables: 1.0.7 -> 1.0.8 ([nixos/nixpkgs⁠#243985](https://togithub.com/nixos/nixpkgs/issues/243985))
* [`e8a72341`](https://github.com/NixOS/nixpkgs/commit/e8a723411272ce0a8ec21392f7541b1d39d6702d) python3Packages.ninja-python: init at 1.11.1
* [`56c79e60`](https://github.com/NixOS/nixpkgs/commit/56c79e60ce4bdb7e9d6fde1c98039dba39717ab2) ispc: 1.18.1 -> 1.19.0
* [`4d22e3fc`](https://github.com/NixOS/nixpkgs/commit/4d22e3fc7810f38c5d7337a69e5b9c87bdc8e9cc) libzip: 1.9.2 -> 1.10.0
* [`aaef56b7`](https://github.com/NixOS/nixpkgs/commit/aaef56b7baeea7b80941fd2d65895f0e84eb36d3) python3Packages.picosvg: init at 0.22.0
* [`673285bd`](https://github.com/NixOS/nixpkgs/commit/673285bdd89f0b073d18a55207196eadb08a4e48) python310Packages.pytest-ansible: disable tests that fail in darwin sandbox
* [`9d70dfd6`](https://github.com/NixOS/nixpkgs/commit/9d70dfd612b811f9d18b57e159c9c469b7408850) nixos/tests/nixos-test-driver/busybox: Improve name
* [`6a5370f0`](https://github.com/NixOS/nixpkgs/commit/6a5370f0f1eb6d3942e3c6c75f2546508893e289) twingate client: 1.0.60 -> 1.0.83
* [`d305cd86`](https://github.com/NixOS/nixpkgs/commit/d305cd86a357ff0daa408c9ed4ab79e3748c0340) gupnp-av: mitigate build error due to deprecations in libxml2
* [`f6cd7355`](https://github.com/NixOS/nixpkgs/commit/f6cd7355c5c2e9b489398275a3c17093b944112f) abc-verifier: unstable-2023-02-23 -> unstable-2023-06-28
* [`ead2ae78`](https://github.com/NixOS/nixpkgs/commit/ead2ae782e2802b9790db13d417f5fc8fdb186db) yosys: 0.30 -> 0.31
* [`7594c74c`](https://github.com/NixOS/nixpkgs/commit/7594c74ceab016bc99ea24d4ed1a20308e586981) dosbox: Fix on Darwin
* [`3f99b556`](https://github.com/NixOS/nixpkgs/commit/3f99b556de2a23347dd6160430a98cc6c7d2097d) boinc: add headless option
* [`9bc84eba`](https://github.com/NixOS/nixpkgs/commit/9bc84eba6f1eb30dbc526895b8e934f4be7470ab) nixos/boinc: add boinc-headless example to package option
* [`d093a4d2`](https://github.com/NixOS/nixpkgs/commit/d093a4d25f868a49f938f2077d79b175cf327046) argo: 3.4.7 -> 3.4.8
* [`0e86572b`](https://github.com/NixOS/nixpkgs/commit/0e86572b927ad8d118433ddb4018280e83f5d20f) firefox-esr-115-unwrapped: 115.0.2eser -> 115.0.3esr
* [`e43792e8`](https://github.com/NixOS/nixpkgs/commit/e43792e88d8ebdc5f878d9857b9ab599ff1d582c) lib.systems.bluefield2: remove cpu profile
* [`e881a9cb`](https://github.com/NixOS/nixpkgs/commit/e881a9cb1a9c172ee1a83268ca31072e83cfa814) linux_testing: 6.4-rc7 -> 6.5-rc2
* [`8416bd00`](https://github.com/NixOS/nixpkgs/commit/8416bd002e17a6a24b9c56c8de52344e4d759ee8) cjose: 0.6.2.1 -> 0.6.2.2
* [`dea588af`](https://github.com/NixOS/nixpkgs/commit/dea588afa7a81ae36916e2d97f9ea018ddce7082) freedv: 1.8.11 -> 1.8.12
* [`53dcfd24`](https://github.com/NixOS/nixpkgs/commit/53dcfd24ad71bb1a26c9d17cbd2af1f83a2da7a3) lib.lists.findFirstIndex: init
* [`7c5cf1a2`](https://github.com/NixOS/nixpkgs/commit/7c5cf1a2d0684f9c0835339aa9d7dceb2caf49b8) tijolo: init at 0.7.3
* [`922d989f`](https://github.com/NixOS/nixpkgs/commit/922d989f1f7798ea4350d565d092042c6b658d9a) python310Packages.steamship: 2.17.11 -> 2.17.18
* [`c519ceaa`](https://github.com/NixOS/nixpkgs/commit/c519ceaa21fd2fb14557a7543e4884cd6ead8b94) patch all cudnn libraries to require libcublas
* [`1c0a219e`](https://github.com/NixOS/nixpkgs/commit/1c0a219ee21aa179de174968e71a290b35ae0954) python3Packages.numpy: fix build with clang 16
* [`8e12c817`](https://github.com/NixOS/nixpkgs/commit/8e12c817e9e2401006d05a1ad5fc7b2d49938d73) python3Packages.numpy: fix test failure on aarch64-darwin
* [`4f923aa4`](https://github.com/NixOS/nixpkgs/commit/4f923aa46c86a74b9b10a6f000e566f36e711e70) python3Packages.numpy: fix test failure on x86_64-darwin under Rosetta 2
* [`9f46beb6`](https://github.com/NixOS/nixpkgs/commit/9f46beb6a7ea29625a029d5a96cc1df51aa74edf) cudaPackages.setupCudaHook: init
* [`39ecbaa4`](https://github.com/NixOS/nixpkgs/commit/39ecbaa495b2b7f0591d53de71d1c1cc5c865b52) godot_4: clean up scons flag generation
* [`f37c9c60`](https://github.com/NixOS/nixpkgs/commit/f37c9c60d2c831e1b1998bd3bd31fab7833ff7ad) godot_4: provide better version information
* [`b1d9284d`](https://github.com/NixOS/nixpkgs/commit/b1d9284def5d401c410a4ca545447aedeb207dac) mysql80: 8.0.33 -> 8.0.34
* [`8a722767`](https://github.com/NixOS/nixpkgs/commit/8a722767d94ebb82e02998c6e36c18b96c1cc7a1) playwright: 1.34.0 -> 1.36.0
* [`c7d95f97`](https://github.com/NixOS/nixpkgs/commit/c7d95f978af0ee26160d2a00a95ea1fd5e270232) iptsd: 1.2.1 -> 1.3.0
* [`a6cbe9f3`](https://github.com/NixOS/nixpkgs/commit/a6cbe9f3c18dd20d3757db5b1a28383195240d93) stellar-core: 19.11.0 -> 19.12.0
* [`0ddfe30b`](https://github.com/NixOS/nixpkgs/commit/0ddfe30bdafcb2896f7b0ebcd0f092578196d8da) setzer: 55 -> 56
* [`bfb24acb`](https://github.com/NixOS/nixpkgs/commit/bfb24acbd0804c9fd7964eadebde8f6d53eff7f9) cudaPackages_10.cudatoolkit: fix infinite recursion in setupCudaHook
* [`4df8614c`](https://github.com/NixOS/nixpkgs/commit/4df8614c048509ee21bc66405394107498bb03a0) magma: symlinkJoin -> CUDAToolkit_ROOT
* [`251d3166`](https://github.com/NixOS/nixpkgs/commit/251d3166c5b706eb33b985da6332fa6dfd5e43a3) cudaPackages.saxpy: init at unstable-2023-07-11
* [`e1c91b23`](https://github.com/NixOS/nixpkgs/commit/e1c91b230122dceca76e600aae5a97d2f590ebb2) improve cudnn fix
* [`be333da5`](https://github.com/NixOS/nixpkgs/commit/be333da51f4547fd662aaf69f6db3aaf802f70c9) nixos/evdevremapkeys: init
* [`531b0830`](https://github.com/NixOS/nixpkgs/commit/531b083070d30c98b01bb8b3d2080ef536aa385f) maintainers: add votava
* [`94ea0081`](https://github.com/NixOS/nixpkgs/commit/94ea0081e1357a0fa407097c884a7684053ca15b) hydrogen-web: init at 0.4.0
* [`7ea07d2c`](https://github.com/NixOS/nixpkgs/commit/7ea07d2c0c919cb3b49de10e9134d15a449a8ba4) python3Packages.numpy: temporarily avoid rebuild on !isClang
* [`2fda37fb`](https://github.com/NixOS/nixpkgs/commit/2fda37fb1a874ce681c3843812191ad321a8a794) gnustep.base: patch build after libxml2 update
* [`e3b95650`](https://github.com/NixOS/nixpkgs/commit/e3b95650f78c61215106cd3dd1c45c76e975a99e) librsvg: fix link failure on x86_64-darwin
* [`dd3ce32e`](https://github.com/NixOS/nixpkgs/commit/dd3ce32ea78f3c3a6eefb987ac4193da48591be9) maintainers: add srid
* [`4fafb3b9`](https://github.com/NixOS/nixpkgs/commit/4fafb3b90b877263bf7674a77ed7be6cd235f5e1) tree-wide: incorporate common out-of-tree cudaSupport overlays
* [`74549ec6`](https://github.com/NixOS/nixpkgs/commit/74549ec63bb6b125590bbb0fa2db24106c257a11) tree-wide: 'enableCuda ? false' -> 'config.cudaSupport or false' to respect global defaults
* [`bf9e6fe9`](https://github.com/NixOS/nixpkgs/commit/bf9e6fe9b852ea9185b9d495dc974491d4fbf355) tree-wide: rm `cudaSupport ? false` formal parameters
* [`a17baa5d`](https://github.com/NixOS/nixpkgs/commit/a17baa5db4f809809e4ae8cae66f2935cd37f2ab) doc: update #cuda to reflect the recommended config.cudaSupport style
* [`c81adfe7`](https://github.com/NixOS/nixpkgs/commit/c81adfe72f8f7d9d20a36cd4848302f16bebce3b) audiobookshelf: 2.2.23 -> 2.3.3
* [`13399321`](https://github.com/NixOS/nixpkgs/commit/133993211b39907a09986b338e9394908de223f2) config.cudaSupport: init option
* [`c6eaa6e5`](https://github.com/NixOS/nixpkgs/commit/c6eaa6e560f97df2380a4b06cc6e73888ff514fe) ldb: 2.6.2 -> 2.7.2
* [`74bec517`](https://github.com/NixOS/nixpkgs/commit/74bec51799ede2f8c677525e21bb0b848b6310cd) samba: 4.17.7 -> 4.18.5
* [`b5cbaa3a`](https://github.com/NixOS/nixpkgs/commit/b5cbaa3aa001858647cfd29f5f143dad6380ecd6) vscode-extensions.charliermarsh.ruff: 2023.30.0 -> 2023.32.0
* [`471dbe9b`](https://github.com/NixOS/nixpkgs/commit/471dbe9bcfb844fb045f5591c35967f15e161657) treewide: consume config.cudaSupport as required
* [`88d6d585`](https://github.com/NixOS/nixpkgs/commit/88d6d5853958ed4d8f89450b130f5cd4aca590ff) libreoffice, libreoffice-fresh, libreoffice-still, libreoffice-qt: pin all LibreOffice to boost179 for now
* [`16fe763e`](https://github.com/NixOS/nixpkgs/commit/16fe763e739f11ada09f9b5e82cb57eb25994560) python3Packages.django-tables2: 2.4.1 -> 2.6.0
* [`2cbd486c`](https://github.com/NixOS/nixpkgs/commit/2cbd486c248371e86d5d24201e5f9b2bb0662fd1) netbox: 3.5.4 -> 3.5.6
* [`7ccc63c5`](https://github.com/NixOS/nixpkgs/commit/7ccc63c530740d73e5a8c1962ec66bd308d365de) vscode-extensions.batisteo.vscode-django: init at 1.10.0
* [`a5fd93b9`](https://github.com/NixOS/nixpkgs/commit/a5fd93b951745d8c37ee0925f6f321cacbdc5e7a) python310Packages.pyxnat: 1.5 -> 1.6
* [`7f61b016`](https://github.com/NixOS/nixpkgs/commit/7f61b01600ecbdaa2a57c51097f2ece9e421c4fe) lib.lists.commonPrefix: init
* [`554a7c10`](https://github.com/NixOS/nixpkgs/commit/554a7c100a9102fd411ce7e276e53253f1a5c950) nixos-container: add missing restart command
* [`7d7cd748`](https://github.com/NixOS/nixpkgs/commit/7d7cd74829b3aa79afe3907f4584a2cd9e7dfa7b) firecracker: 1.3.1 -> 1.4.0
* [`f5d5556a`](https://github.com/NixOS/nixpkgs/commit/f5d5556aafba1e0c64c2a34d740fb208c3a30e9b) ceph: fixup the embedded sqlalchemy
* [`1ce92c15`](https://github.com/NixOS/nixpkgs/commit/1ce92c15f2cc96e02b3b43ee3b2cd8ff86f68432) nanoemoji: init at 0.15.1
* [`c4c0a7e9`](https://github.com/NixOS/nixpkgs/commit/c4c0a7e9222a36c061878406237774789c87446d) gamescope: 3.12.0-beta9 -> 3.12.0-beta10
* [`944e7073`](https://github.com/NixOS/nixpkgs/commit/944e707389f84183b9dc9c6fef7414d2c7a6b653) protonmail-bridge: 3.2.0 -> 3.3.2
* [`dc42ccec`](https://github.com/NixOS/nixpkgs/commit/dc42ccec8763730af36bce384d8d42f920d05604) systemd: fix ukify (to cross compile)
* [`d0ad6448`](https://github.com/NixOS/nixpkgs/commit/d0ad6448518ad089e3a82f9467827b7017c1d7e2) systemc: 2.3.3 -> 2.3.4
* [`a655cc3d`](https://github.com/NixOS/nixpkgs/commit/a655cc3d9e914fe9613c4abf238da154aa7626b3) verilator: use systemc and other fixes
* [`b1c681c9`](https://github.com/NixOS/nixpkgs/commit/b1c681c99f9dd3ba0b077010fb885c7b0aeb2578) libtickit: init at 0.4.3
* [`32b64278`](https://github.com/NixOS/nixpkgs/commit/32b642781c950d6d1eb2d56dda8c6b848ff56e6b) flare-signal: 0.8.0 -> 0.9.0
* [`0e1c1dad`](https://github.com/NixOS/nixpkgs/commit/0e1c1dad5fb4bcd5410e4a1ff19c09ded249655e) nanoemoji: avoid escaping hell
* [`f4f6be1e`](https://github.com/NixOS/nixpkgs/commit/f4f6be1e9a12e0c9e71d1d960fc2cc7b56566ace) python310Packages.nbconflux: fix build
* [`e90d5111`](https://github.com/NixOS/nixpkgs/commit/e90d5111a4c4c04fbe8ed9ec3240a2c8e1f4e35e) pyCA: fixup the embedded sqlalchemy
* [`9249f600`](https://github.com/NixOS/nixpkgs/commit/9249f60087559789a5ebc72bf4fc41c99122b96b) treewide: fixup the embedded sqlalchemy
* [`443c79e6`](https://github.com/NixOS/nixpkgs/commit/443c79e698fac691ece37779675db26bebef6bcf) grafana-loki,promtail: 2.8.2 -> 2.8.3
* [`1356b229`](https://github.com/NixOS/nixpkgs/commit/1356b2292ba5572c70fd5fdb4a54009fc702fff7) ryujinx: 1.1.960 -> 1.1.968
* [`5f6ce0da`](https://github.com/NixOS/nixpkgs/commit/5f6ce0da68694bb0ff876ec01b839b7f12cc9c17) avalanchego: 1.10.4 -> 1.10.5
* [`98d4da0f`](https://github.com/NixOS/nixpkgs/commit/98d4da0f82e46acdd96d5e1b31f2e064179dc3a8) tlsclient: rec -> finalAttrs pattern
* [`278cd2be`](https://github.com/NixOS/nixpkgs/commit/278cd2be26d71ab80a119c94261afcaffe443d59) tlsclient: add passthru.updateScript
* [`7d518f6e`](https://github.com/NixOS/nixpkgs/commit/7d518f6e37713b86ab18fc34e4fd64df44c429d1) tlsclient: 1.5 -> 1.6.4
* [`af484128`](https://github.com/NixOS/nixpkgs/commit/af484128b9fb0ac7dde3ab10c92ca768df766572) _9ptls: init at 1.6.4
* [`a028e983`](https://github.com/NixOS/nixpkgs/commit/a028e9839103123fd16479d55c1e97dac15f881d) pam_dp9ik: 1.5 -> 1.6.4
* [`cc91ea49`](https://github.com/NixOS/nixpkgs/commit/cc91ea49218f2dd7b4bb1e7d1370beb96f164671) booster: 0.10 -> 0.11
* [`1397d491`](https://github.com/NixOS/nixpkgs/commit/1397d49173a60f25fa7bb6376c97a0f76cce4c8b) tailscale: 1.44.0 -> 1.46.0
* [`37ea9eb0`](https://github.com/NixOS/nixpkgs/commit/37ea9eb02d668d2252a74a117a9936a9150d5323) ghidra: 10.3.1 -> 10.3.2
* [`d9aab437`](https://github.com/NixOS/nixpkgs/commit/d9aab4375beb7e926e8d7e2be7d1fa77e86f441a) lego: 4.12.3 -> 4.13.2
* [`82e6b3ff`](https://github.com/NixOS/nixpkgs/commit/82e6b3ffa24c3882cc74808ba0d6acaea1658016) insomnia: 2023.2.2 -> 2023.4.0
* [`576b6737`](https://github.com/NixOS/nixpkgs/commit/576b6737c40edf0b9645c95cbdfa87ee5a159fb7) weave-gitops: 0.26.0 -> 0.27.0
* [`22ea58da`](https://github.com/NixOS/nixpkgs/commit/22ea58da80ff6aaa5938523c911c21533bf62ae5) norminette: 3.3.51 -> 3.3.53
* [`b6167072`](https://github.com/NixOS/nixpkgs/commit/b616707267e5c93337996d8fb401adf0b94a9e8a) armadillo: 12.4.1 -> 12.6.0
* [`428102a7`](https://github.com/NixOS/nixpkgs/commit/428102a72095f2f6505d843f3a5c1aa4e9418022) python310Packages.opentelemetry-api: relax importlib-metadata constraint
* [`f1a2ebf2`](https://github.com/NixOS/nixpkgs/commit/f1a2ebf21f87bfd9b78fd7ac43476a431642a825) ilspycmd: init at 8.0
* [`774e250a`](https://github.com/NixOS/nixpkgs/commit/774e250ab3f1c1b4664d8d4e72456d4b4a7d332d) grandperspective: 3.0.1 -> 3.4.1
* [`ee43a52a`](https://github.com/NixOS/nixpkgs/commit/ee43a52a7051a414f92327f5e69a7c77dd3a37aa) okteto: 2.16.5 -> 2.18.0
* [`57e35969`](https://github.com/NixOS/nixpkgs/commit/57e359691b20ad47308e097eb7748982f6ce737d) webkitgtk: 2.40.3 → 2.40.4
* [`5f88e10c`](https://github.com/NixOS/nixpkgs/commit/5f88e10c4d886a1f0e95356e0ec0418df362b16e) maintainers: add marie
* [`ecc230a0`](https://github.com/NixOS/nixpkgs/commit/ecc230a006f4e06b07019e2e835614805826fc07) ocamlPackages.mm: 0.8.3 -> 0.8.4
* [`c04c43cc`](https://github.com/NixOS/nixpkgs/commit/c04c43ccd1f7b789ffc3363d9c46fb98e79afd41) writers: fix fsharp writer
* [`e136d9b0`](https://github.com/NixOS/nixpkgs/commit/e136d9b0c843586fa0b7c48af12c924c8a5e2697) fricas: 1.3.8 -> 1.3.9
* [`383fa81e`](https://github.com/NixOS/nixpkgs/commit/383fa81e6f910d797b79161bac6d825e0034da2f) lib/generators/toKeyValue: add `indent` parameter
* [`3836a2e3`](https://github.com/NixOS/nixpkgs/commit/3836a2e32d046636925a79bb33052fdccb9a9412) sof-firmware: 2.2.5 -> 2.2.6
* [`02a5e9c9`](https://github.com/NixOS/nixpkgs/commit/02a5e9c93332836fb20911f82c6410936ee94ff9) nixos/networkmanager: create pppd lock directory
* [`2b3c6bad`](https://github.com/NixOS/nixpkgs/commit/2b3c6bad0aa29c27d0c0eb5187c4d9e09999078b) vokoscreen-ng: 3.6.0 -> 3.7.0
* [`ba2ce6e7`](https://github.com/NixOS/nixpkgs/commit/ba2ce6e73bf1e0352d09477854cd30a807b7a296) various packages: pin boost179
* [`73ee03cb`](https://github.com/NixOS/nixpkgs/commit/73ee03cbc5a20c6c3d61946558e7aea4a48c5119) writers: split out the tests
* [`d0c7ffc5`](https://github.com/NixOS/nixpkgs/commit/d0c7ffc596bd8da9298d693d1bdd0559c6777311) writers: make room for other types of writers
* [`504e42b5`](https://github.com/NixOS/nixpkgs/commit/504e42b559d74b013e95d93f5fc3868f756fd46b) writers: introduce data writers
* [`fbab0d0d`](https://github.com/NixOS/nixpkgs/commit/fbab0d0d31dad1fcac897c23fdb4af36e8c08766) retroarch: prefer wrapper over patch
* [`21856d71`](https://github.com/NixOS/nixpkgs/commit/21856d71a4ea304d14259aac89696801d08638f2) steam-small: add dbus
* [`ffba10cd`](https://github.com/NixOS/nixpkgs/commit/ffba10cd9a48c9736fde33d4d145eea43ddd532b) linux_6_3: drop as EOL
* [`029a3f43`](https://github.com/NixOS/nixpkgs/commit/029a3f43989febc3b2f9b5dbbfbc7f51edaf1894) python3Packages.magic-filter: init at 1.0.10
* [`6baf91f9`](https://github.com/NixOS/nixpkgs/commit/6baf91f97429f39dcd9445d08ad772c9c6b1daaa) python3Packages.aiogram: init at 2.25.1
* [`c7c2ee93`](https://github.com/NixOS/nixpkgs/commit/c7c2ee938a3f557171f03bfc6733e406550d11a8) go2rtc: 1.6.0 -> 1.6.2
* [`6847c28a`](https://github.com/NixOS/nixpkgs/commit/6847c28a86bdc705ffa8c5fc701a70d684387cbb) sharedown: 5.2.2 -> 5.3.1
* [`c86609fe`](https://github.com/NixOS/nixpkgs/commit/c86609fefb4ec299d3a7757c50b1a667d3779b1e) rtz: init at 0.3.2
* [`fdac5ffc`](https://github.com/NixOS/nixpkgs/commit/fdac5ffcfa0c7b3a5e428aa49116fffd7d3bdfe9) bazel-buildtools: 6.1.1 -> 6.1.2
* [`67b8982a`](https://github.com/NixOS/nixpkgs/commit/67b8982a7af412714ee50cb6368a6e764977f09b) urlscan: 0.9.10 -> 1.0.0
* [`203bc5a2`](https://github.com/NixOS/nixpkgs/commit/203bc5a2fe442d3cf413b0c93ba3a9cd2df4a1cf) python310Packages.fastavro: 1.7.4 -> 1.8.2
* [`e9c2faa3`](https://github.com/NixOS/nixpkgs/commit/e9c2faa3b23ea522a8564f601ff26f6de06a232a) python310Packages.google-cloud-bigtable: 2.19.0 -> 2.20.0
* [`cc4061b8`](https://github.com/NixOS/nixpkgs/commit/cc4061b896f6477b485740baedc32a03fbbd668d) ctranslate2: 3.16.1 -> 3.17.1
* [`4e7b378d`](https://github.com/NixOS/nixpkgs/commit/4e7b378df33dc46eba6f482e7b1990f85650f479) python310Packages.faster-whisper: 0.6.0 -> 0.7.0
* [`3c10b650`](https://github.com/NixOS/nixpkgs/commit/3c10b650b91ab6a6ca6839f5e280e091cba793aa) virtualbox: 7.0.8 -> 7.0.10
* [`ae246d5e`](https://github.com/NixOS/nixpkgs/commit/ae246d5e99eee698985caec08375b10f644ae306) numix-icon-theme-square: 23.07.08 -> 23.07.21
* [`a00e777b`](https://github.com/NixOS/nixpkgs/commit/a00e777b17d97db9b1ae533017c8b79b83bae5fe) mmv: 2.4 -> 2.5
* [`668e2daf`](https://github.com/NixOS/nixpkgs/commit/668e2dafb6b1aa2d57cd438979ad25b98d5e5764) nixos/nix-channel: fix editorconfig warnings and apply nixpkgs-fmt
* [`8e057e6e`](https://github.com/NixOS/nixpkgs/commit/8e057e6e858936ee694d47b5ea4245ab8e34095e) gupnp-tools: fixup build after libxml2 upgrade
* [`74e5a1a5`](https://github.com/NixOS/nixpkgs/commit/74e5a1a56b4d08d3d6eba8db2c3f13f74043a7da) nfd: fixup build after boost version changes
* [`16b32782`](https://github.com/NixOS/nixpkgs/commit/16b32782b4a31a2f49a474d9ddc6eaa6ffd31739) rstudio: supply missing #include <set>
* [`326932c8`](https://github.com/NixOS/nixpkgs/commit/326932c8e14ed67e33ed94b0fb3f4b3b42296545) age-plugin-ledger: init at 0.1.2
* [`b01545f8`](https://github.com/NixOS/nixpkgs/commit/b01545f8ccb3a5e3abd6d112e0862b6165f0bd6d) winePackages.{unstable,staging}: 8.10 -> 8.13
* [`7d9b2ace`](https://github.com/NixOS/nixpkgs/commit/7d9b2ace146548171d98aa193fa7f07fea59d108) zsh-vi-mode: 0.9.0 -> 0.10.0
* [`047fa8db`](https://github.com/NixOS/nixpkgs/commit/047fa8dbdfc31476d9420f303596eb78172cddcf) nixos/syncthing: Use API to merge / override configurations
* [`d3bfd1cc`](https://github.com/NixOS/nixpkgs/commit/d3bfd1ccfb30463dca0cca8f7859efccfff7d21e) jfrog-cli: 2.42.1 -> 2.43.1
* [`db097eb3`](https://github.com/NixOS/nixpkgs/commit/db097eb3b5b82965eb7dce659479f77a25241d27) lib: add fetchFrom9Front
* [`5dde2776`](https://github.com/NixOS/nixpkgs/commit/5dde2776d32b9f6ea206a13df2d5db1bc3710ad9) unstableGitUpdater: add deepClone argument for non shallow clones
* [`a978e48e`](https://github.com/NixOS/nixpkgs/commit/a978e48e52011048325b0b0f8380d6100fc1f44a) rc-9front: use fetchFrom9Front
* [`a0839b51`](https://github.com/NixOS/nixpkgs/commit/a0839b51017c93a099723c1787635b7f03eba93b) drawterm: use fetchFrom9Front
* [`a4cdbf35`](https://github.com/NixOS/nixpkgs/commit/a4cdbf35126375f93596f3b2e23c362fc858dca8) curl-impersonate: update goModules usage
* [`0abe9b54`](https://github.com/NixOS/nixpkgs/commit/0abe9b54d89af92de1c6cae8dd26aaec96303fa8) kbt: init at 1.0.0
* [`e518edd7`](https://github.com/NixOS/nixpkgs/commit/e518edd71800c1eff22b0f931a9d11ab23613c05) linux: 5.15.120 -> 5.15.121
* [`39157de5`](https://github.com/NixOS/nixpkgs/commit/39157de5fd5384b56aecfd1c24e3d6c55da0e2c0) linux: 6.1.39 -> 6.1.40
* [`f1237348`](https://github.com/NixOS/nixpkgs/commit/f1237348f36c98cb5f74e9d7211b8f62969716bf) linux: 6.4.4 -> 6.4.5
* [`ffe2bb95`](https://github.com/NixOS/nixpkgs/commit/ffe2bb9584c7be6cd86f4df84807c0e36393293b) samply: init at 0.11.0
* [`65e9c1bd`](https://github.com/NixOS/nixpkgs/commit/65e9c1bddeea3d1e6d11ce0893beb9c41f46ddc4) pbm: 1.3.1 -> 1.3.2
* [`73a1cc7c`](https://github.com/NixOS/nixpkgs/commit/73a1cc7c9de3a47fab64f33e3ec30684934120a6) dotnet-sdk_7: 7.0.305 -> 7.0.306
* [`bf293bd1`](https://github.com/NixOS/nixpkgs/commit/bf293bd14e65984e79f10acfe82faf34482be6d7) zeronet-conservancy: 0.7.8.1 -> 0.7.9
* [`c0bc1690`](https://github.com/NixOS/nixpkgs/commit/c0bc16904cc9025ee0a2dcbb439ca53d9c001df8) chromiumDev: 116.0.5845.42 -> 117.0.5897.3
* [`b6320904`](https://github.com/NixOS/nixpkgs/commit/b6320904b88282be463abc40352b302b6e9aa5ad) chromium: 115.0.5790.98 -> 115.0.5790.102
* [`3aeac399`](https://github.com/NixOS/nixpkgs/commit/3aeac3991ffb383a051e87df4a5e58eb3a67448d) ungoogled-chromium: 115.0.5790.98 -> 115.0.5790.102
* [`1aa85533`](https://github.com/NixOS/nixpkgs/commit/1aa855331bfc91bd7c9fa70de693f3c2904f09bd) backends: move meta to the end, fix formatting
* [`1c5e23c4`](https://github.com/NixOS/nixpkgs/commit/1c5e23c40559f0711b3a5b5ee94c230a5c852683) nixos/xfce: add environment.xfce.excludePackages option
* [`ff13fe9f`](https://github.com/NixOS/nixpkgs/commit/ff13fe9f6cec2893ea7812a07541759262fe3282) maintainers: add @⁠ryota-ka
* [`26248c58`](https://github.com/NixOS/nixpkgs/commit/26248c58506ff638b771f618269c4676aa6fe613) yarn-berry: init at 3.4.1
* [`58010207`](https://github.com/NixOS/nixpkgs/commit/580102072a464c253145d36c6cb7f46648014681) pyp: init at 1.1.0
* [`a9a80133`](https://github.com/NixOS/nixpkgs/commit/a9a80133c12f0f343c2e103db371718cde4a6576) mautrix-signal: 0.4.2 -> 0.4.3
* [`eb04b6a3`](https://github.com/NixOS/nixpkgs/commit/eb04b6a36ed39d003c08e412c5987ae4a5e7da8c) python310.pkgs.ucsmsdk: init at 0.9.14
* [`893526b3`](https://github.com/NixOS/nixpkgs/commit/893526b3971b191347884f38550ca172693acde3) vcard: init at 0.15.4
* [`e8c91460`](https://github.com/NixOS/nixpkgs/commit/e8c91460284ac0da365ccd83752cf21cdcbbdbd3) partclone: 0.3.23 -> 0.3.24
* [`29d916a0`](https://github.com/NixOS/nixpkgs/commit/29d916a0d05eebeea3b3dcba3bb5d24939b78856) tengine: 2.4.1 -> 3.0.0
* [`6068a73e`](https://github.com/NixOS/nixpkgs/commit/6068a73e5f10b686d8a2c4da97657cd09aff41ae) gen-license: init at 0.1.2
* [`1242a9d5`](https://github.com/NixOS/nixpkgs/commit/1242a9d55eae3621890fb45c62398362bbfa5af1) maintainers: add ryanccn
* [`91fa2044`](https://github.com/NixOS/nixpkgs/commit/91fa2044923854958b577b1e0614acd5847d436b) plexamp: 4.7.4 -> 4.8.1
* [`99471701`](https://github.com/NixOS/nixpkgs/commit/994717010e7e92f21b2ffc42ecbe3a95bcd38a05) evcc: 0.118.9 -> 0.118.10
* [`4f22040d`](https://github.com/NixOS/nixpkgs/commit/4f22040dbd70cc39a572cd8bb3b808c13ab3dd06) erg: 0.6.16 -> 0.6.17
* [`83c185b8`](https://github.com/NixOS/nixpkgs/commit/83c185b899cae4819f7890615f732f17b7b8e284) timoni: init at 0.10.0
* [`fe89df18`](https://github.com/NixOS/nixpkgs/commit/fe89df18bf0e6136560fd81b17a7b92d7b87ca19) xfce.xfce4-pulseaudio-plugin: enable playing sound with volume change
* [`f5724ae4`](https://github.com/NixOS/nixpkgs/commit/f5724ae4bed6d5cdf42a1e94a79ef1be848aed7b) treewide: adopt a few packages that sandro dropped maintainership for
* [`15b3b806`](https://github.com/NixOS/nixpkgs/commit/15b3b8065c6b29810eceff554b128ab5961c7095) python310Packages.pyslurm: 23.2.1 -> 23.2.2
* [`7fc27444`](https://github.com/NixOS/nixpkgs/commit/7fc27444daf36b95a063a6d89e759288c966305d) ventoy: 1.0.93 -> 1.0.94
* [`1ef31a70`](https://github.com/NixOS/nixpkgs/commit/1ef31a70de16f76fbaac4df2b213cd79bdba6893) python310Packages.pytest-md-report: 0.3.1 -> 0.4.0
* [`f67e1c6e`](https://github.com/NixOS/nixpkgs/commit/f67e1c6e508d7c3461c745b4c7913a19bd9ccb3f) twspace-dl: 2023.1.22.1 -> 2023.7.24.1
* [`a6b6203b`](https://github.com/NixOS/nixpkgs/commit/a6b6203b6d2c85409eeea1a318910d1f6e6cfc66) sv-lang: init at 3.0
* [`0310e3c7`](https://github.com/NixOS/nixpkgs/commit/0310e3c7ac017b9fb2600ef90f7141e4f0e67a41) CODEOWNERS: add ajoseph for kernel/manual-config.nix
* [`1d0b3064`](https://github.com/NixOS/nixpkgs/commit/1d0b3064664e89edb4322348397bcdeb51bdb8e6) cmusfm: 0.4.1 -> 0.5.0
* [`43ab7e5e`](https://github.com/NixOS/nixpkgs/commit/43ab7e5e485c35232c8af35cfac6e58d2362e0f4) standardnotes: 3.166.9 -> 3.167.2
* [`29e6553d`](https://github.com/NixOS/nixpkgs/commit/29e6553d1fa2b6849482486638ac85de9301b203) ocamlPackages.dolog: 3.0 → 6.0.0
* [`a53a1e42`](https://github.com/NixOS/nixpkgs/commit/a53a1e4267e2e0aa2a4c0ea3c229d445ae748edd) vivaldi: 6.1.3035.111 -> 6.1.3035.204
* [`2e1db341`](https://github.com/NixOS/nixpkgs/commit/2e1db341fc618873bd5ea36127854e3edc95a25f) apkg: 0.4.0 -> 0.4.1
* [`121b60ae`](https://github.com/NixOS/nixpkgs/commit/121b60ae9deb4b392a29dfaa5eeace6bd1297666) libqb: 2.0.7 -> 2.0.8
* [`a1854817`](https://github.com/NixOS/nixpkgs/commit/a18548174bda3d76790be07c74888d14aed6c565) gnmic: init at 0.31.3
* [`319e47f4`](https://github.com/NixOS/nixpkgs/commit/319e47f43d87a4bbd84a04fdd553b397c0eaea7a) dotter: 0.12.16 -> 0.13.0
* [`8a1a9ffe`](https://github.com/NixOS/nixpkgs/commit/8a1a9ffe48ee23fe0d5b9a46493f4dea9bf020ee) balena-cli: 16.6.2 -> 16.7.5
* [`e1ebc51e`](https://github.com/NixOS/nixpkgs/commit/e1ebc51ef647d5d54f0ae002fd13edea0ae3ae94) jabref: fix gapps wrapper
* [`7da39a7a`](https://github.com/NixOS/nixpkgs/commit/7da39a7a9e8849db860cd1adfad2bcb5539d4f76) treewide .goModules: revert renaming the derivation
* [`1264b312`](https://github.com/NixOS/nixpkgs/commit/1264b312da9b98478e16b5a4e5c0dbf831013305) python3Packages.asyncua: fix build on darwin
* [`fb9dba73`](https://github.com/NixOS/nixpkgs/commit/fb9dba73f3ef76847c6716a3c0c4a16673e99686) opcua-client-gui: enable on darwin
* [`f48ff765`](https://github.com/NixOS/nixpkgs/commit/f48ff765a138a7e93be8559e4c57a25cc5d9a14a) banana-cursor: init at 1.0.0
* [`d00a7933`](https://github.com/NixOS/nixpkgs/commit/d00a7933295d76378cbe967c45905d4515d2f7f7) python310Packages.azure-mgmt-netapp: 10.0.0 -> 10.1.0
* [`cb589b7e`](https://github.com/NixOS/nixpkgs/commit/cb589b7ec81b51498f92b916441e8163221319ed) otus-lisp: init at 2.4
* [`b825f65c`](https://github.com/NixOS/nixpkgs/commit/b825f65c90107d5ae49cb5fdcd0c52532f60fc42) nixos/nix-channel: only try to remove the nix-channel binary if it exists
* [`d6cdb6a4`](https://github.com/NixOS/nixpkgs/commit/d6cdb6a43ff374559d82c3429243a3eefa2aea03) glabels-qt: init at unstable-2021-02-06
* [`c161060d`](https://github.com/NixOS/nixpkgs/commit/c161060dc7e17f427cbb6e79e88248fdf3c57539) goofys: update vendor hash
* [`533ff854`](https://github.com/NixOS/nixpkgs/commit/533ff8546ba1cab0072c846c588def683613eac8) nixos/mosquitto: leverage systemd credentials
* [`49ecac85`](https://github.com/NixOS/nixpkgs/commit/49ecac852780039f7c040a3e8eccae7b8427adcb) python310Packages.discogs-client: 2.6 -> 2.7
* [`27a83e4c`](https://github.com/NixOS/nixpkgs/commit/27a83e4cc42d1f224812d6a48ba15e993b297713) sing-box: 1.3.0 -> 1.3.3
* [`4ec8ab12`](https://github.com/NixOS/nixpkgs/commit/4ec8ab12c5d59b514557300296f90946f7a13686) jazz2: 2.0.0 -> 2.1.0
* [`59236a39`](https://github.com/NixOS/nixpkgs/commit/59236a397915ad44a36c87e5d2b906cf9671de1a) jackett: 0.21.484 -> 0.21.532
* [`9135e2d0`](https://github.com/NixOS/nixpkgs/commit/9135e2d0cccd186357d87bc5fc40572102ed88a9) lazygit: 0.39.3 -> 0.39.4
* [`cb2f5313`](https://github.com/NixOS/nixpkgs/commit/cb2f5313320368ab0324958733d5f41cc59587c7) nixos/xfce: allow exclusion of xfce4-notifyd
* [`3428dd4b`](https://github.com/NixOS/nixpkgs/commit/3428dd4bef7ea4d81f6da347150281e0efb6d6c0) docker: apply fix starting containers with a local connection with the CLI
* [`7d57cbdd`](https://github.com/NixOS/nixpkgs/commit/7d57cbddc613acd5df610c45a4228b8681af4110) docker: remove mikroskeem from maintainers
* [`048928fa`](https://github.com/NixOS/nixpkgs/commit/048928fa014fdeb76c65e0b96a3b8a6b03b11f66) repgrep: 0.14.1 -> 0.14.2
* [`df8d0648`](https://github.com/NixOS/nixpkgs/commit/df8d064819a5bb95a10875c781df197bf2bfbf57) wazero: 1.3.0 -> 1.3.1
* [`dbdbd6c9`](https://github.com/NixOS/nixpkgs/commit/dbdbd6c97bf1713efdcb3f06cfac5f3713bccd5b) cargo-diet: 1.2.5 -> 1.2.7
* [`e0a31e06`](https://github.com/NixOS/nixpkgs/commit/e0a31e067a758e2b4d091ca0c4016224d7a6b7c4) vimPlugins.hover-nvim: init at 2023-07-10
* [`c22e3427`](https://github.com/NixOS/nixpkgs/commit/c22e3427056932d3b93e72b3972db7104be08b29) vimPlugins: update
* [`c1a72eec`](https://github.com/NixOS/nixpkgs/commit/c1a72eec236d5ba4c7afabdcb6b117d9c1641a35) vimPlugins.nvim-treesitter: update grammars
* [`06fe6028`](https://github.com/NixOS/nixpkgs/commit/06fe60288c8baa39c51356d789497937c7591fb4) purescript: 0.15.9 -> 0.15.10
* [`4d345751`](https://github.com/NixOS/nixpkgs/commit/4d345751990f2f37131230605f957d1d0ae9d22b) spicetify-cli: 2.21.0 -> 2.22.0
* [`1b54927c`](https://github.com/NixOS/nixpkgs/commit/1b54927c85f63a5f8c2180de730f89c96540c018) sbt: 1.9.2 -> 1.9.3 ([nixos/nixpkgs⁠#245161](https://togithub.com/nixos/nixpkgs/issues/245161))
* [`0a47d548`](https://github.com/NixOS/nixpkgs/commit/0a47d548015ec7a2306c545ec1cf060348e7885e) docs/python: clarify allowance of using toosl to autogenerate packages
* [`1a2d2661`](https://github.com/NixOS/nixpkgs/commit/1a2d2661803baa43f223896fe043aa8b99f0ab27) temporal-cli: fix missing meta.platforms preventing Hydra builds ([nixos/nixpkgs⁠#243518](https://togithub.com/nixos/nixpkgs/issues/243518))
* [`04522024`](https://github.com/NixOS/nixpkgs/commit/045220244eb3234d507bbe27d4bf514f92d39f7a) moonfire-nvr: init at 0.7.6
* [`acc4cfd4`](https://github.com/NixOS/nixpkgs/commit/acc4cfd48b3bf17b50a8394ea0d6a12c6fc11b2a) vorta: strip away output dependency on `qt5.qtwayland.dev`
* [`3c342d47`](https://github.com/NixOS/nixpkgs/commit/3c342d47850bee40e729925f99d401a126081d65) polkadot: 0.9.43 -> 1.0.0
* [`dd0b6dc8`](https://github.com/NixOS/nixpkgs/commit/dd0b6dc833ddd91791490bd81ffb8c1ae2a8b7f6) homepage-dashboard: 0.6.21 -> 0.6.23
* [`5162df32`](https://github.com/NixOS/nixpkgs/commit/5162df32399c7e9d77cc38702202983dbe9ad113) nixos/fonts: rename fonts.fonts option to fonts.packages, other cleanups
* [`b0c67b4b`](https://github.com/NixOS/nixpkgs/commit/b0c67b4b6e0d21fd47097886f5c21cfb6bf27aad) treewide: rename fonts.fonts to fonts.packages
* [`f9fdeb2d`](https://github.com/NixOS/nixpkgs/commit/f9fdeb2dbcf36636e2c2e537fe9eb1b31d84195b) nixos/ghostscript: evaporate the extra whitespace
* [`983e4778`](https://github.com/NixOS/nixpkgs/commit/983e477848a2f4ca8c51086ea9c3bdde37f8170a) nvitop: 1.1.2 -> 1.2.0
* [`2cf16635`](https://github.com/NixOS/nixpkgs/commit/2cf16635698c958670f793ee7da323b2ef39fa49) lscolors: 0.14.0 -> 0.15.0
* [`3bcec2f5`](https://github.com/NixOS/nixpkgs/commit/3bcec2f5814002aa9006e5de2ebc6620dc59415f) seaweedfs: 3.54 -> 3.55
* [`abd2beb0`](https://github.com/NixOS/nixpkgs/commit/abd2beb086cc0b7927f52f5f3f4da880f7abac5f) dae: 0.2.1 -> 0.2.2
* [`073eb1fc`](https://github.com/NixOS/nixpkgs/commit/073eb1fcf630c5942b59a7c128a2e4bb547dd6da) amass: 4.0.2 -> 4.0.3
* [`d7e262cd`](https://github.com/NixOS/nixpkgs/commit/d7e262cd45f47540928fc924f50e1c7d9d8faf82) python310Packages.tesserocr: 2.6.0 -> 2.6.1
* [`a10542b2`](https://github.com/NixOS/nixpkgs/commit/a10542b2418c60a3a0955328daec6f2015f9b150) signalbackup-tools: 20230716 -> 20230723-1
* [`a4397122`](https://github.com/NixOS/nixpkgs/commit/a4397122848f847f33a5960ecbbcc9049dead253) ssw: 0.6 -> 0.8
* [`a02597d3`](https://github.com/NixOS/nixpkgs/commit/a02597d3b26dfc902354c9d5a8c836d83113d0ee) gtree: 1.8.7 -> 1.9.1
* [`3e36355e`](https://github.com/NixOS/nixpkgs/commit/3e36355e44999d194185c4f974e3d3961b447986) kops: 1.26.4 -> 1.27.0 ([nixos/nixpkgs⁠#245208](https://togithub.com/nixos/nixpkgs/issues/245208))
* [`98775d73`](https://github.com/NixOS/nixpkgs/commit/98775d735c80cb1019e5c607af75027c55608fdc) jaq: 0.10.0 -> 0.10.1
* [`e2d32444`](https://github.com/NixOS/nixpkgs/commit/e2d324442ef85ef4a25ff02e9d95fff49619d7c9) python310Packages.pynisher: 1.0.7 -> 1.0.8
* [`5f5090b3`](https://github.com/NixOS/nixpkgs/commit/5f5090b3f1cbd8690109e090caa677507cdeb642) linuxPackages.nvidia_x11_vulkan_beta: 525.47.31 -> 525.47.34
* [`3f996855`](https://github.com/NixOS/nixpkgs/commit/3f99685567ca047bd6d14502bba8725ffb5f4a19) python310Packages.ijson: 3.2.2 -> 3.2.3
* [`0d0161c9`](https://github.com/NixOS/nixpkgs/commit/0d0161c9db563ad3378e41c4a83921e7b1bdf240) forgejo: 1.19.4-0 -> 1.20.1-0
* [`fc8f6d7f`](https://github.com/NixOS/nixpkgs/commit/fc8f6d7fdd4de35f67149950cf80e16cddd45380) mission-center: init at 0.2.5
* [`6937f7e4`](https://github.com/NixOS/nixpkgs/commit/6937f7e4e808cdb9224647cb2e2897aae7e56c77) psitop: init at 1.0.0
* [`b34a51f5`](https://github.com/NixOS/nixpkgs/commit/b34a51f5a7ec2b7f57ed291fee7852f03634a409) nixos/gogs: fix deprecations for 0.13.0
* [`099935b6`](https://github.com/NixOS/nixpkgs/commit/099935b62402f4328d96ff0331d25f98414e45ae) treewide: use lib.optionalAttrs
* [`05f31b13`](https://github.com/NixOS/nixpkgs/commit/05f31b13153680de84cb13d7645d80df14938a4e) lscolors: fix build to include the binary
* [`517fd7c3`](https://github.com/NixOS/nixpkgs/commit/517fd7c36500f64fc168d8bc4fd3c11e5fb77632) pan: 0.146 -> 0.154
* [`519d8cf9`](https://github.com/NixOS/nixpkgs/commit/519d8cf92da9b6a2aec0205b3428982512868b15) wooting: update udev rules
* [`12ad49a1`](https://github.com/NixOS/nixpkgs/commit/12ad49a130d7f7be7b832fddce93d37ee4460ddb) wooting: clarify requirements for hardware option to work
* [`7a59cd3d`](https://github.com/NixOS/nixpkgs/commit/7a59cd3dc9a0a1353b835ed2c563a0e8ca09d5b6) python310Packages.jsbeautifier: 1.14.8 -> 1.14.9
* [`0d751200`](https://github.com/NixOS/nixpkgs/commit/0d75120022142ce867f2fa386853e84c471be18b) ax25-tools: set localstatedir to /var/lib
* [`1269a601`](https://github.com/NixOS/nixpkgs/commit/1269a601e3253b99026aa473c7a5faef472ea62e) ax25-apps: set localstatedir to /var/lib
* [`3d9bc923`](https://github.com/NixOS/nixpkgs/commit/3d9bc923c8166a83d07d44616d8c593868887d15) diffoscope: 243 -> 245
* [`ee70eede`](https://github.com/NixOS/nixpkgs/commit/ee70eede34df4981fbc1272809fa470133c2a82c) python310Packages.py-partiql-parser: 0.3.3 -> 0.3.5
* [`8315db77`](https://github.com/NixOS/nixpkgs/commit/8315db77f6fcc5bbb1392065ba2f5721f120b656) teams-for-linux: 1.2.4 -> 1.2.8
* [`5577734d`](https://github.com/NixOS/nixpkgs/commit/5577734d9ebd438576a28571ae2da33d8ee8b85c) labplot: 2.10.0 -> 2.10.1
* [`83793ca8`](https://github.com/NixOS/nixpkgs/commit/83793ca8980283a6f62c028ebed336b9d1bbf80f) nixos/fonts: rename fonts.enableDefaultFonts to fonts.enableDefaultPackages
* [`2edc744f`](https://github.com/NixOS/nixpkgs/commit/2edc744f3f37721f732dd2311c8f1178192137bf) iosevka: 25.1.0 -> 25.1.1
* [`3c070741`](https://github.com/NixOS/nixpkgs/commit/3c070741a9e39701961ec1bef5da725cad3da07a) osm2pgsql: fix build
* [`9325a80a`](https://github.com/NixOS/nixpkgs/commit/9325a80a11ed2bffa693d36e79112072769acdf4) fix libcudnn also on cuda12
* [`2e35954c`](https://github.com/NixOS/nixpkgs/commit/2e35954cd0a47ce0d34ba0f9224f239ceda7cba7) runme: 1.5.2 -> 1.6.0
* [`a1ca2856`](https://github.com/NixOS/nixpkgs/commit/a1ca285684b3560348256e30fb407139c6510984) jbang: 0.109.0 -> 0.110.0
* [`8f93629b`](https://github.com/NixOS/nixpkgs/commit/8f93629b373d183f060f6c17c096bb4752223f8b) wtwitch: 2.6.2 -> 2.6.3
* [`9a476c8e`](https://github.com/NixOS/nixpkgs/commit/9a476c8ea4729dd8d1a8b3d7d152183dca5af686) xemu: 0.7.103 -> 0.7.104
* [`b2d51404`](https://github.com/NixOS/nixpkgs/commit/b2d514047e58e39b767ef5a208872b7ce9685454) xeus-zmq: init at 1.1.0
* [`fb3c8210`](https://github.com/NixOS/nixpkgs/commit/fb3c82106d8f62bf7082aef77a88af7498452d9b) babeld: 1.12.2 -> 1.13
* [`a5e12bb6`](https://github.com/NixOS/nixpkgs/commit/a5e12bb624287e3754705d7aae3d1a5af9a23b00) nixVersions.nix_2_17: init at 2.17.0
* [`df4d4190`](https://github.com/NixOS/nixpkgs/commit/df4d4190de92f26d22bcc2a586d0e353bdbbf21b) nixVersions.unstable: 2.16 -> 2.17
* [`08ed19ef`](https://github.com/NixOS/nixpkgs/commit/08ed19ef7519241b01bf69c46e9cd7928c2711dc) vimPlugins.starrynight: init at 2021-09-09
* [`0a316e72`](https://github.com/NixOS/nixpkgs/commit/0a316e72b3df8896d3476ab51e7897f827a35428) vimPlugins.vim-paper: init at 2023-03-16
* [`5040aa7d`](https://github.com/NixOS/nixpkgs/commit/5040aa7df42cf73a7652943e9685ac325b6bbd33) vimPlugins.preto: init at 2023-02-10
* [`77ef2bda`](https://github.com/NixOS/nixpkgs/commit/77ef2bdad6fec360bb97d95eb3d39f48bfdd08eb) vimPlugins.yescapsquit-vim: init at 2022-08-31
* [`4b251ef3`](https://github.com/NixOS/nixpkgs/commit/4b251ef318b74e12b0026955296ced0807d0f8a1) vimPlugins.nvim-treesitter: update grammars
* [`73cd4671`](https://github.com/NixOS/nixpkgs/commit/73cd4671c90b86361047ced2458765e4188a4922) kubecfg: 0.30.0 -> 0.31.4
* [`64bb2055`](https://github.com/NixOS/nixpkgs/commit/64bb20559cf4e211a3897954aacfb8fc917dd40a) vimPlugins: update
* [`38544a2d`](https://github.com/NixOS/nixpkgs/commit/38544a2d8828d26dfd6095ab454862629a17dfcd) reaper: 6.80 -> 6.81
* [`35f43f95`](https://github.com/NixOS/nixpkgs/commit/35f43f9532c4485661cb30737c8e721aa647e04e) python310Packages.unstructured: init at 0.8.1
* [`d12b1511`](https://github.com/NixOS/nixpkgs/commit/d12b1511014bb99d353dd4974a8ef7a353e82d9e) stalwart-mail: init at 0.3.1
* [`d082e927`](https://github.com/NixOS/nixpkgs/commit/d082e9270463af942f16af719ae7ef96f12eae1d) vimPlugins.sg-nvim: fix vendor hash
* [`dc70d2f6`](https://github.com/NixOS/nixpkgs/commit/dc70d2f61a836221631777fad9d5269e64ccb0a3) meteo: 0.9.9.1 -> 0.9.9.2
* [`055d7833`](https://github.com/NixOS/nixpkgs/commit/055d78335d86af40cf1a3553eb11b9678cb5ddc6) coqPackages.bignums: 8.17.0 → 9.0.0+coq8.17
* [`7c411521`](https://github.com/NixOS/nixpkgs/commit/7c411521a542826bbd5a96935a4ac6de2c86f259) tutanota-desktop: 3.113.3 -> 3.115.2
* [`686af29f`](https://github.com/NixOS/nixpkgs/commit/686af29f95592fabbf2bb41cfe0095af448fad91) gh: 2.32.0 -> 2.32.1
* [`4500316e`](https://github.com/NixOS/nixpkgs/commit/4500316e6333dfd210c42c86e319802837a2a625) python310Packages.opentelemetry-instrumentation-grpc: init at 0.39b0
* [`0dd9a9cf`](https://github.com/NixOS/nixpkgs/commit/0dd9a9cfed17041e6bdb1946da67962155f82cbe) python310Packages.opentelemetry-instrumentation-aiohttp-client: init at 0.39b0
* [`7687b846`](https://github.com/NixOS/nixpkgs/commit/7687b8464f0770cc8a1d97e9082335bf84bb318b) mosquitto: fix bug with firefox wss http/2
* [`9ae366f1`](https://github.com/NixOS/nixpkgs/commit/9ae366f1792b26c35a07dcafc6ff1ada7d818fad) podman: 4.5.1 -> 4.6.0
* [`335de715`](https://github.com/NixOS/nixpkgs/commit/335de7152a0ac17d05fff55cbc30cee49c81c50b) coqPackages.ceres: 0.4.0 → 0.4.1
* [`72c7597d`](https://github.com/NixOS/nixpkgs/commit/72c7597d20881c1755a38536a20bc645779186fe) coqPackages.parsec: 0.1.1 → 0.1.2
* [`208aa1b0`](https://github.com/NixOS/nixpkgs/commit/208aa1b09626aec182961a9420b3d5731ab70769) pantheon.elementary-settings-daemon: 1.2.0 -> 1.3.0
* [`1ad62e1b`](https://github.com/NixOS/nixpkgs/commit/1ad62e1b314be2399059f8313ab5a2ed6e47bb71) pantheon.elementary-tasks: 6.3.1 -> 6.3.2
* [`eda2ca13`](https://github.com/NixOS/nixpkgs/commit/eda2ca13b38b23f58f64576aaeed4ceec62deb0c) pantheon.elementary-calendar: 6.1.2 -> 7.0.0
* [`09ac4e27`](https://github.com/NixOS/nixpkgs/commit/09ac4e278469a50e84b9dc3489ca78ff54514de2) pantheon.switchboard-plug-sound: 2.3.2 -> 2.3.3
* [`3cce91e6`](https://github.com/NixOS/nixpkgs/commit/3cce91e692d99fae8affc820799e1138279440d4) pantheon.switchboard-plug-pantheon-shell: 6.4.0 -> 6.5.0
* [`bdb0a583`](https://github.com/NixOS/nixpkgs/commit/bdb0a58369b22a8288474705928cf29cdbaa5abc) pantheon.switchboard-plug-keyboard: 3.1.1 -> 3.2.0
* [`c2d48610`](https://github.com/NixOS/nixpkgs/commit/c2d486102b76d1c2d24c156b75330a89e750c38c) komga: 1.1.0 -> 1.2.1
* [`31f992d3`](https://github.com/NixOS/nixpkgs/commit/31f992d386162638634280bdccaa3a8243dca23b) pantheon.elementary-notifications: Backport fix for broken notification filter
* [`1b3feb10`](https://github.com/NixOS/nixpkgs/commit/1b3feb10442e3685ea60db844437cb596a0eb601) ocamlPackages.dypgen: init at 0.2 for OCaml ≥ 4.07
* [`fd6eae63`](https://github.com/NixOS/nixpkgs/commit/fd6eae6343483fa1e7e9717341e9ce80414023ec) vipsdisp: 2.5.0 -> 2.5.1
* [`173f8aa3`](https://github.com/NixOS/nixpkgs/commit/173f8aa342fc4c353212a629fcb7a3a9846eefe8) cryfs: 0.11.3 -> 0.11.4
* [`7d1ed7a7`](https://github.com/NixOS/nixpkgs/commit/7d1ed7a7884ea27c44325d43f7b6fc09329cf2d3) ocamlPackages.cmdliner: 1.1.1 -> 1.2.0
* [`cac50294`](https://github.com/NixOS/nixpkgs/commit/cac50294ee0211f15c40c65147ac9d59b5e135fe) twitch-cli: 1.1.19 -> 1.1.20
* [`f19af411`](https://github.com/NixOS/nixpkgs/commit/f19af411327306454b7c0cba51a88a26311bedad) scummvm: 2.7.0 -> 2.7.1
* [`8cefff16`](https://github.com/NixOS/nixpkgs/commit/8cefff16f0a1a12917ead68f4389400ddd758dfa) terraform-providers.consul: 2.17.0 -> 2.18.0
* [`46dfe90b`](https://github.com/NixOS/nixpkgs/commit/46dfe90bfe1ece5f7e418c100d2455f1876ffcba) terraform-providers.github: 5.31.0 -> 5.32.0
* [`99d7ed1b`](https://github.com/NixOS/nixpkgs/commit/99d7ed1b0eb96183d615f4d8da5d724ac858c2c9) terraform-providers.google: 4.74.0 -> 4.75.0
* [`91f2c5db`](https://github.com/NixOS/nixpkgs/commit/91f2c5db149e34cf1f13f2359d01ee29bd3b6582) terraform-providers.google-beta: 4.74.0 -> 4.75.0
* [`af494677`](https://github.com/NixOS/nixpkgs/commit/af494677d968639dcddd5c446c277e101ae66e1b) terraform-providers.hcloud: 1.41.0 -> 1.42.0
* [`5c1906aa`](https://github.com/NixOS/nixpkgs/commit/5c1906aa2526facc27f04e4165afd2dee6194551) terraform-providers.spotinst: 1.127.0 -> 1.128.0
* [`40b736f0`](https://github.com/NixOS/nixpkgs/commit/40b736f0e836d0a189d26bb457007029bc67bd17) last: 1456 -> 1460
* [`16c27410`](https://github.com/NixOS/nixpkgs/commit/16c27410de37364f08f2997231727089b29f23cb) linux: 4.19.288 -> 4.19.289
* [`d5cddc3d`](https://github.com/NixOS/nixpkgs/commit/d5cddc3d2f0accbea6525c394855b4d5674f724d) linux: 5.10.186 -> 5.10.187
* [`c28af224`](https://github.com/NixOS/nixpkgs/commit/c28af224b5e2598ac76b30b8a5f44b84cb7cea17) linux: 5.15.121 -> 5.15.122
* [`6da37409`](https://github.com/NixOS/nixpkgs/commit/6da374098b4d6b53b434e63f80338aaec6ba62f2) linux: 5.4.249 -> 5.4.250
* [`04141e98`](https://github.com/NixOS/nixpkgs/commit/04141e9828f4ad2db272f1aaca5a5ec5bc4f9247) linux: 6.1.40 -> 6.1.41
* [`e998e521`](https://github.com/NixOS/nixpkgs/commit/e998e5216c0ce4a2b0c5c2f05e083df01f4c4cd3) linux: 6.4.5 -> 6.4.6
* [`0c75a062`](https://github.com/NixOS/nixpkgs/commit/0c75a062bb27b20fc6003e4f7f8a4f093ed80676) linux-firmware: 20230625 -> unstable-2023-07-24
* [`20be59d0`](https://github.com/NixOS/nixpkgs/commit/20be59d08ad62f5bb89be95cbfbfc6757facf563) python310Packages.pyrainbird: 3.0.0 -> 3.0.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
