### PR TITLE
niv emacs-overlay: update 4acc71cd -> e8d273d9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4acc71cdae77ca29a3b9fe71297e08f3d82ead7e",
-        "sha256": "0lkz1j9xffh5igw4b613012iwkgbg3g3dkiirkih889afcn75296",
+        "rev": "e8d273d9f31998c892fd16396b9b6c51566a64b2",
+        "sha256": "1f0ld13dslx5yn63fdj40a7zbaq2hnyy76wzbqyrl4dfkgbkxx5j",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/4acc71cdae77ca29a3b9fe71297e08f3d82ead7e.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/e8d273d9f31998c892fd16396b9b6c51566a64b2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@4acc71cd...e8d273d9](https://github.com/nix-community/emacs-overlay/compare/4acc71cdae77ca29a3b9fe71297e08f3d82ead7e...e8d273d9f31998c892fd16396b9b6c51566a64b2)

* [`a4eefefb`](https://github.com/nix-community/emacs-overlay/commit/a4eefefbc172964c836521d3242dc27d5f02b18d) Updated flake inputs
* [`0c1f7f44`](https://github.com/nix-community/emacs-overlay/commit/0c1f7f44130ef6bb31cebe0dbcbba158a31daaae) Updated repos/elpa
* [`009c85b7`](https://github.com/nix-community/emacs-overlay/commit/009c85b7f12d48dd7a534dfd6f4096c6dd577e55) Updated repos/emacs
* [`525aaf59`](https://github.com/nix-community/emacs-overlay/commit/525aaf59a6bc06b80a19c1158c307627e0eef1a7) Updated repos/melpa
* [`bc36053b`](https://github.com/nix-community/emacs-overlay/commit/bc36053b24c95ffcbd6fd679735ff18a2b6c6697) Updated repos/elpa
* [`8c2bf1be`](https://github.com/nix-community/emacs-overlay/commit/8c2bf1be5a5f6467fa03eab7132ad6e6c40f2e60) Updated repos/emacs
* [`54c0d37e`](https://github.com/nix-community/emacs-overlay/commit/54c0d37eb161dd90a6da788676143091e5108613) Updated repos/melpa
* [`48424827`](https://github.com/nix-community/emacs-overlay/commit/48424827aa80414955fe2f161c94b884c5073a31) Updated repos/elpa
* [`dc15eed1`](https://github.com/nix-community/emacs-overlay/commit/dc15eed1ec726f00cb41bdaa3c7a3b38e9cc54b6) Updated repos/emacs
* [`9ff7c99f`](https://github.com/nix-community/emacs-overlay/commit/9ff7c99ff19c08e15f5012990dbf83d0068d0646) Updated repos/melpa
* [`21d3a568`](https://github.com/nix-community/emacs-overlay/commit/21d3a5680ab159782635ead834a406afa9186cf0) Updated flake inputs
* [`5e277f09`](https://github.com/nix-community/emacs-overlay/commit/5e277f09508ec5633857d5a3a8ef0f67914a814f) Updated repos/emacs
* [`42d29a68`](https://github.com/nix-community/emacs-overlay/commit/42d29a68c6b16aeb4a92141a743e564fe8dbbfad) Updated repos/melpa
* [`2659c275`](https://github.com/nix-community/emacs-overlay/commit/2659c275b75b029627cfa5daa51fdd55b46dd246) Updated flake inputs
* [`8a229b75`](https://github.com/nix-community/emacs-overlay/commit/8a229b756728fb3cecb2c6e4bd11045e1da42fb7) Updated repos/elpa
* [`cbe60479`](https://github.com/nix-community/emacs-overlay/commit/cbe604798e93f7490a9a1fe5d3be5787485bac06) Updated repos/emacs
* [`3372519e`](https://github.com/nix-community/emacs-overlay/commit/3372519e7d0a4fa74beaa60dc07f3fd2b34379d7) Updated repos/melpa
* [`53e153e2`](https://github.com/nix-community/emacs-overlay/commit/53e153e2c46e21ccb49155da2f448d428f47d0be) Updated flake inputs
* [`1a2047ac`](https://github.com/nix-community/emacs-overlay/commit/1a2047ac2aa3770b9634d8fe3f0191dfa6f448f9) Updated repos/elpa
* [`f1d42619`](https://github.com/nix-community/emacs-overlay/commit/f1d42619627cb573d23ae41131115de72866c3ba) Updated repos/emacs
* [`f443f77e`](https://github.com/nix-community/emacs-overlay/commit/f443f77e16da5b244761ae7d5c45064418c9df7b) Updated repos/melpa
* [`9e1ae85e`](https://github.com/nix-community/emacs-overlay/commit/9e1ae85e9e949da6c457122fe0ff2210aa7676ac) Updated repos/emacs
* [`388758cb`](https://github.com/nix-community/emacs-overlay/commit/388758cbdd4fb1fa3c24543a5f19e9f0f570c3eb) Updated repos/melpa
* [`4a2791f0`](https://github.com/nix-community/emacs-overlay/commit/4a2791f0041034dcf525aa8aa71a623624a38bcc) Updated repos/emacs
* [`3d790419`](https://github.com/nix-community/emacs-overlay/commit/3d790419f80b908cca53e256556d3dd1332ec052) Updated repos/melpa
* [`c9f31918`](https://github.com/nix-community/emacs-overlay/commit/c9f3191845c0a681a6c624e25fd267d7b50bcbbd) Updated repos/elpa
* [`d4f72b53`](https://github.com/nix-community/emacs-overlay/commit/d4f72b539c1123294d53fbea2d8c88053e36d6a8) Updated repos/emacs
* [`324b98c5`](https://github.com/nix-community/emacs-overlay/commit/324b98c5cccb731ccb6f2b4e3e45a8c6d199c4bf) Updated repos/melpa
* [`984950c6`](https://github.com/nix-community/emacs-overlay/commit/984950c68da3892237f66c1bf5051116214b25c9) Updated repos/nongnu
* [`e5d2edd9`](https://github.com/nix-community/emacs-overlay/commit/e5d2edd98d6f8c58ec756991d4aeac6542040c26) Updated flake inputs
* [`e018e015`](https://github.com/nix-community/emacs-overlay/commit/e018e01518119131c1358d523aa1f6f37349ed9f) Updated repos/melpa
* [`6c137eb3`](https://github.com/nix-community/emacs-overlay/commit/6c137eb3b7783c0ea9fa4cb1f6058671b470d412) Updated flake inputs
* [`50211263`](https://github.com/nix-community/emacs-overlay/commit/502112634ab6ad399e7377726d2afe751f88f47b) Updated repos/elpa
* [`37c8498a`](https://github.com/nix-community/emacs-overlay/commit/37c8498a09fb9cce79844076524be8bc3e0a1676) Updated repos/emacs
* [`54567ac5`](https://github.com/nix-community/emacs-overlay/commit/54567ac566cd6bfa2607fbe155f9e009ce72306a) Updated repos/melpa
* [`8d653d51`](https://github.com/nix-community/emacs-overlay/commit/8d653d517603879aea30e8a3ef5b0d9fe5f28b4c) Updated repos/elpa
* [`38426b19`](https://github.com/nix-community/emacs-overlay/commit/38426b1997b4cd62929efa081ccd9e019d63656a) Updated repos/emacs
* [`44bffe24`](https://github.com/nix-community/emacs-overlay/commit/44bffe245cd8ce2281cf0a60021a4dccb6e78148) Updated repos/melpa
* [`fcac8e09`](https://github.com/nix-community/emacs-overlay/commit/fcac8e09c6a7b5fb4272f33021351823e74719a2) Updated flake inputs
* [`be1374aa`](https://github.com/nix-community/emacs-overlay/commit/be1374aad75cb15de580de541a4bc9ddb318f524) Updated repos/emacs
* [`c084710d`](https://github.com/nix-community/emacs-overlay/commit/c084710df62bb9f681e52452a0cf518d1bfcedec) Updated repos/melpa
* [`81dae096`](https://github.com/nix-community/emacs-overlay/commit/81dae0960994014e2604a0739d70ad2869db56eb) Updated repos/elpa
* [`2722973a`](https://github.com/nix-community/emacs-overlay/commit/2722973ab81c2f9c0bb5f65da028a628006176fc) Updated repos/emacs
* [`f0f67575`](https://github.com/nix-community/emacs-overlay/commit/f0f675751b0ddfff1edf44013064b5f5f52f9493) Updated repos/melpa
* [`558fb879`](https://github.com/nix-community/emacs-overlay/commit/558fb8793b51294e1e51a0534810991253d08565) Updated flake inputs
* [`68584a6a`](https://github.com/nix-community/emacs-overlay/commit/68584a6a829040d50249c66e78e3afced8d78d11) Updated repos/elpa
* [`158b659a`](https://github.com/nix-community/emacs-overlay/commit/158b659aa7aaf3768f6fb66e291efedd0d4c14f2) Updated repos/emacs
* [`05f4c43b`](https://github.com/nix-community/emacs-overlay/commit/05f4c43b163391ac984cfbe2b4787350ee565b3e) Updated repos/melpa
* [`a207c4f5`](https://github.com/nix-community/emacs-overlay/commit/a207c4f5ceaf2a32762a16a94e3ef03107f02830) Updated repos/emacs
* [`b27e6e2d`](https://github.com/nix-community/emacs-overlay/commit/b27e6e2dbc2099558895500785752c074a2ff0c0) Updated repos/melpa
* [`384a5ab7`](https://github.com/nix-community/emacs-overlay/commit/384a5ab7093aa886660778299589f69cfb4a002f) Updated flake inputs
* [`b90b088e`](https://github.com/nix-community/emacs-overlay/commit/b90b088e76178f29527d9d58eac8d4beb3cb66e1) Updated repos/elpa
* [`ab825d23`](https://github.com/nix-community/emacs-overlay/commit/ab825d23508d5b82ef4297bdeb75b819f1f32a7f) Updated repos/emacs
* [`dd1f9e91`](https://github.com/nix-community/emacs-overlay/commit/dd1f9e916bb34d1aee6787ef8c0244a43ef9ebf0) Updated repos/melpa
* [`b58bab85`](https://github.com/nix-community/emacs-overlay/commit/b58bab859c3b49e2cc886f2f0656df159cfa67d9) Updated repos/elpa
* [`cba77472`](https://github.com/nix-community/emacs-overlay/commit/cba774729581c6e2d7494a3362c534653b3ac84e) Updated repos/melpa
* [`542b794a`](https://github.com/nix-community/emacs-overlay/commit/542b794af3361112cb395061bb689db69710742c) Updated repos/emacs
* [`195774bc`](https://github.com/nix-community/emacs-overlay/commit/195774bcf05d7ede83f69bd374fc7986b1d119dc) Updated repos/melpa
* [`017d882a`](https://github.com/nix-community/emacs-overlay/commit/017d882abf3d98ea1267f7304581154911419822) Updated repos/nongnu
* [`64880552`](https://github.com/nix-community/emacs-overlay/commit/648805528f507b9aafb62a53576c73fef4784639) Updated repos/elpa
* [`ac5c8c01`](https://github.com/nix-community/emacs-overlay/commit/ac5c8c011accc146dc3807c269c1a5c0dc90c040) Updated repos/emacs
* [`4417a897`](https://github.com/nix-community/emacs-overlay/commit/4417a89727cae4cdc82fa20ba1b72e00381761c6) Updated repos/melpa
* [`d3e20d91`](https://github.com/nix-community/emacs-overlay/commit/d3e20d91a439f41b27057b4c3f2aab946c5cd07b) Updated repos/elpa
* [`cbbcb890`](https://github.com/nix-community/emacs-overlay/commit/cbbcb890fc8c064e0a4df4a51f5c79251c5a177f) Updated repos/emacs
* [`18917e76`](https://github.com/nix-community/emacs-overlay/commit/18917e7696c5826ee1da92650a71763c630551d7) Updated repos/melpa
* [`ad199493`](https://github.com/nix-community/emacs-overlay/commit/ad199493b3b0a9f9d3d5e738b660420f33de8a08) Updated repos/nongnu
* [`9117cdc6`](https://github.com/nix-community/emacs-overlay/commit/9117cdc60ed70efcb041c6845426c520cc208256) Updated flake inputs
* [`4c2d8cfc`](https://github.com/nix-community/emacs-overlay/commit/4c2d8cfc2b3452673ed2f3a10dfe1ad7d0781f6b) Updated repos/emacs
* [`25e94b64`](https://github.com/nix-community/emacs-overlay/commit/25e94b64c5ec9970034e9d304ca157d1c2b8be8b) Updated repos/melpa
* [`ec12f6d5`](https://github.com/nix-community/emacs-overlay/commit/ec12f6d5131ea43b2023547b93ad28d1b6c00b57) Updated repos/nongnu
* [`cc8608d6`](https://github.com/nix-community/emacs-overlay/commit/cc8608d67b4aca94c991995b35345a362a240715) Updated flake inputs
* [`c3f1bc56`](https://github.com/nix-community/emacs-overlay/commit/c3f1bc567cf983dd1c24842c7d49536fa880aca7) Updated repos/emacs
* [`7396cfbe`](https://github.com/nix-community/emacs-overlay/commit/7396cfbe95160ecdfc429d03e90b410daad74283) Updated repos/melpa
* [`4af87a22`](https://github.com/nix-community/emacs-overlay/commit/4af87a2204f060f84e96201931e1fcffdf44c081) Updated repos/elpa
* [`2a779188`](https://github.com/nix-community/emacs-overlay/commit/2a779188014aad4cfc73860c97121d9707259e2a) Updated repos/emacs
* [`8f8f9146`](https://github.com/nix-community/emacs-overlay/commit/8f8f914627e409da50961c63e70403e5662aba1e) Updated repos/melpa
* [`0aeb4446`](https://github.com/nix-community/emacs-overlay/commit/0aeb4446b3ca3f4870febe3052d46bfbc04d2d7b) Updated repos/melpa
* [`3613a74e`](https://github.com/nix-community/emacs-overlay/commit/3613a74eb4f21ddc15bcbce38f0b19fe29f540f4) Updated flake inputs
* [`d6fc172b`](https://github.com/nix-community/emacs-overlay/commit/d6fc172b2b6a1e5913dc3984a77187b9e74a3532) Updated repos/elpa
* [`491cafb3`](https://github.com/nix-community/emacs-overlay/commit/491cafb35537047a53b63190345a7a22356af841) Updated repos/melpa
* [`9b236438`](https://github.com/nix-community/emacs-overlay/commit/9b2364383aa323d96a993dd0d83f222b06719115) Updated repos/elpa
* [`4dab49d3`](https://github.com/nix-community/emacs-overlay/commit/4dab49d3be79a7534a29a06f8706c9f01eaf3a94) Updated repos/emacs
* [`df24379e`](https://github.com/nix-community/emacs-overlay/commit/df24379e2d7b3813579aab6d3cc54a95d60a9bd5) Updated repos/melpa
* [`f32956e4`](https://github.com/nix-community/emacs-overlay/commit/f32956e4b9d91e50b60bca2f74f6562f78717d93) Updated repos/nongnu
* [`51a880a4`](https://github.com/nix-community/emacs-overlay/commit/51a880a4295282653eb7218cec9debc881326567) Updated flake inputs
* [`eb33a3c6`](https://github.com/nix-community/emacs-overlay/commit/eb33a3c6858dec13712235b2a03c0049c9a83b97) Updated repos/melpa
* [`0ec5e897`](https://github.com/nix-community/emacs-overlay/commit/0ec5e897a813a707ff679e81bef98a38c32c95b8) Updated repos/nongnu
* [`e5049960`](https://github.com/nix-community/emacs-overlay/commit/e504996083b0c68434a5afbd4af30745e383d99f) Updated repos/elpa
* [`efeb4d19`](https://github.com/nix-community/emacs-overlay/commit/efeb4d191efaae3dccdd79f3ea5715d8d989d9e0) Updated repos/emacs
* [`2074e430`](https://github.com/nix-community/emacs-overlay/commit/2074e430f834ad2e20ce5ee2ee2897586bad0d60) Updated repos/melpa
* [`ee91d915`](https://github.com/nix-community/emacs-overlay/commit/ee91d9159908315797a9777c9648f711f519563e) Updated repos/elpa
* [`1c77a4bb`](https://github.com/nix-community/emacs-overlay/commit/1c77a4bbaec495dfa0dc0101b6287f0aace69c14) Updated repos/emacs
* [`02b70d97`](https://github.com/nix-community/emacs-overlay/commit/02b70d971b263b4144b0b57510f87e2bdd3a1fd1) Updated repos/melpa
* [`79c2d78c`](https://github.com/nix-community/emacs-overlay/commit/79c2d78c4a86b443873969258fb0592230d5acd2) Updated repos/nongnu
* [`b2d0f67b`](https://github.com/nix-community/emacs-overlay/commit/b2d0f67bd2b65e0d4590a8f0475601c2dc584969) Updated repos/emacs
* [`735f70b8`](https://github.com/nix-community/emacs-overlay/commit/735f70b83ac7ea5a0234359786e5a80e5ffa291c) Updated repos/melpa
* [`beeb4388`](https://github.com/nix-community/emacs-overlay/commit/beeb43885eb9e01f9f1597dee9064580ea258183) Updated flake inputs
* [`36347e7e`](https://github.com/nix-community/emacs-overlay/commit/36347e7e9a4b39086f34205648787f1f521dd5b8) Updated repos/elpa
* [`e7c44f07`](https://github.com/nix-community/emacs-overlay/commit/e7c44f079343396a4f03180acdb6e2ba1364a67a) Updated repos/emacs
* [`6c050da8`](https://github.com/nix-community/emacs-overlay/commit/6c050da8195828eb90efba9b467ca828cbdb59a8) Updated repos/melpa
* [`f3e45bdc`](https://github.com/nix-community/emacs-overlay/commit/f3e45bdc05e329377988fb797b5314caad2c6ea0) Updated repos/elpa
* [`103c6198`](https://github.com/nix-community/emacs-overlay/commit/103c61982ff8932a2f4b62af6e1d47949fcac220) Updated repos/melpa
* [`83649036`](https://github.com/nix-community/emacs-overlay/commit/83649036536aa64f80828873d95d87b21d18494f) Updated repos/nongnu
* [`f7564ad8`](https://github.com/nix-community/emacs-overlay/commit/f7564ad8e3e022a431a9d67f385df316478003a3) Updated repos/melpa
* [`6448e0b9`](https://github.com/nix-community/emacs-overlay/commit/6448e0b9f2a07a4724e9d26a4fdf47d2b85e0430) Updated flake inputs
* [`65dee518`](https://github.com/nix-community/emacs-overlay/commit/65dee51897dccde2b869c277a00a391c906399c3) Updated repos/emacs
* [`ffba0e05`](https://github.com/nix-community/emacs-overlay/commit/ffba0e0555ff10eb213ce52d1410f2aad4b93771) Updated repos/melpa
* [`81009c48`](https://github.com/nix-community/emacs-overlay/commit/81009c4834f0c54e6c35b3874e514ca82dec1426) Updated repos/elpa
* [`60e762f8`](https://github.com/nix-community/emacs-overlay/commit/60e762f87dacd2648f94e1ad99f6e71c4d5ad6a3) Updated repos/melpa
* [`b432eb3e`](https://github.com/nix-community/emacs-overlay/commit/b432eb3e59da481d63c0a71a11a1881133138e56) Updated repos/nongnu
* [`d4d0b701`](https://github.com/nix-community/emacs-overlay/commit/d4d0b701d77cce92ea1403be2ad9118005ad25e0) Updated flake inputs
* [`cead5b49`](https://github.com/nix-community/emacs-overlay/commit/cead5b4982ab70a4e224dcb8cc95308fb8cb2ac9) Updated repos/emacs
* [`690557c0`](https://github.com/nix-community/emacs-overlay/commit/690557c06d8330cc43d8f470f90a22878290fd11) Updated repos/melpa
* [`3fbcace5`](https://github.com/nix-community/emacs-overlay/commit/3fbcace5b46e8b75d45314914f0ac58cc680ab81) Updated repos/nongnu
* [`0910889d`](https://github.com/nix-community/emacs-overlay/commit/0910889d8b47ee43ae58329d18fe6706f85d899c) Updated flake inputs
* [`fa643a8a`](https://github.com/nix-community/emacs-overlay/commit/fa643a8a136b6d24172d4a3f012df07d9baf584d) Updated repos/elpa
* [`199d73b3`](https://github.com/nix-community/emacs-overlay/commit/199d73b373b3d49866b4dde9aee97ebd9f8b276a) Updated repos/emacs
* [`357e0d33`](https://github.com/nix-community/emacs-overlay/commit/357e0d33bb28c3e558eba0c7822590927040015d) Updated repos/melpa
* [`0da2b0ca`](https://github.com/nix-community/emacs-overlay/commit/0da2b0caa2bb0e2b9749b8d3a5b602bb55a4d345) Updated repos/elpa
* [`c557b749`](https://github.com/nix-community/emacs-overlay/commit/c557b749a6e7f7ae5af7b0b7829fddb91d7d5d43) Updated repos/emacs
* [`d853845d`](https://github.com/nix-community/emacs-overlay/commit/d853845d96c5f209ae2a61357547909c1a788d3a) Updated repos/melpa
* [`a44ec998`](https://github.com/nix-community/emacs-overlay/commit/a44ec998f6c8f04973f8e8630847157efec2bbfb) Updated repos/nongnu
* [`532a8b21`](https://github.com/nix-community/emacs-overlay/commit/532a8b213267f46bd6b170062234b18fda1e73b4) Updated repos/emacs
* [`bebe5a82`](https://github.com/nix-community/emacs-overlay/commit/bebe5a826c1d3f6711e459b1f29559efc127169e) Updated repos/melpa
* [`99757bed`](https://github.com/nix-community/emacs-overlay/commit/99757bed9044e2a778077c8254e22358be331186) Updated repos/nongnu
* [`d4900389`](https://github.com/nix-community/emacs-overlay/commit/d490038959ac10964e1c54c0e093c40ff00a1ced) Updated repos/elpa
* [`bcd4795c`](https://github.com/nix-community/emacs-overlay/commit/bcd4795c623699df243b709160b6bbf228ae1a69) Updated repos/emacs
* [`86113db3`](https://github.com/nix-community/emacs-overlay/commit/86113db3e974e154772474017b26a90254d0aa81) Updated repos/melpa
* [`0068408b`](https://github.com/nix-community/emacs-overlay/commit/0068408b4cc5698d6b4b55700359a3d85fe84540) Updated flake inputs
* [`c77ac9ff`](https://github.com/nix-community/emacs-overlay/commit/c77ac9fff722a633e9aa5badc89dc99d245aa5d5) Updated repos/elpa
* [`46220779`](https://github.com/nix-community/emacs-overlay/commit/46220779ac91f721f355e6e233c1d5a4dd49cb27) Updated repos/emacs
* [`3998784d`](https://github.com/nix-community/emacs-overlay/commit/3998784d02091a70316eecd435cc6e3e780ff63c) Updated repos/melpa
* [`09d1858b`](https://github.com/nix-community/emacs-overlay/commit/09d1858b06b85cdc105d7c58ccd5c1a70e1980fc) Updated flake inputs
* [`449e672b`](https://github.com/nix-community/emacs-overlay/commit/449e672bc77bb3604d3970dc8ad2195efbbae080) Updated repos/emacs
* [`d0a4bfcb`](https://github.com/nix-community/emacs-overlay/commit/d0a4bfcb6c78b9f71ad096771be0c6029973734c) Updated repos/melpa
* [`b93864f9`](https://github.com/nix-community/emacs-overlay/commit/b93864f99e0186c03f078c1d7bbc2bd0840011be) flake: Filter out non derivation attributes from hydra jobs
* [`0d890d28`](https://github.com/nix-community/emacs-overlay/commit/0d890d28b3489dd96c4fac8cd49bd360ab1f908c) Add basic evaluation check to run on pull requests
* [`d068b271`](https://github.com/nix-community/emacs-overlay/commit/d068b271bdc9b604fb514aa7fabd4ae22a4ed0c3) Remove ensure API breakage notice
* [`0f4fd73a`](https://github.com/nix-community/emacs-overlay/commit/0f4fd73a5f7dcd180ae6c7bcfa7285f830d9d8e1) Updated repos/elpa
* [`50d8ac56`](https://github.com/nix-community/emacs-overlay/commit/50d8ac56af9357c11844c492e63a60f76e946b7c) Updated repos/emacs
* [`084807d7`](https://github.com/nix-community/emacs-overlay/commit/084807d7ac3ce106e3dee92c5b012c8362f0395d) Updated repos/melpa
* [`d1e53169`](https://github.com/nix-community/emacs-overlay/commit/d1e53169c807b4cc38eb3c46271855152590962f) Updated flake inputs
* [`c0b857fe`](https://github.com/nix-community/emacs-overlay/commit/c0b857fe888c2b6d3b4bee2cc9b13bab344e59be) Updated repos/elpa
* [`aa03a306`](https://github.com/nix-community/emacs-overlay/commit/aa03a306dce0dd9edd5eb7085db0bd5092160a0e) Updated repos/emacs
* [`f34553f0`](https://github.com/nix-community/emacs-overlay/commit/f34553f0f5cc85b6edd571198867d904f8c089e1) Updated repos/melpa
* [`4c3cb10e`](https://github.com/nix-community/emacs-overlay/commit/4c3cb10e40504e91e3619b770030c675d6278302) Updated repos/nongnu
* [`5aedb85a`](https://github.com/nix-community/emacs-overlay/commit/5aedb85aedecf6eab465862b3d41fb91cc9df6be) Updated flake inputs
* [`1cd1cde1`](https://github.com/nix-community/emacs-overlay/commit/1cd1cde19875bc7a4ec06bcbf1a7b74b1e5fe1bc) Updated repos/emacs
* [`aa9011e2`](https://github.com/nix-community/emacs-overlay/commit/aa9011e25ca971ee914cc8db9224d213b691e8b0) Updated repos/melpa
* [`6c2bc4e1`](https://github.com/nix-community/emacs-overlay/commit/6c2bc4e1c1eb83d77060b0cc9fcbe7ff99da4e56) Updated flake inputs
* [`ffc222e8`](https://github.com/nix-community/emacs-overlay/commit/ffc222e84e4516c1c0920252124c42816ca67ee8) Updated repos/elpa
* [`8019616c`](https://github.com/nix-community/emacs-overlay/commit/8019616cffc4478d7a05d6f16d427d0c90df2248) Updated repos/emacs
* [`f55f6538`](https://github.com/nix-community/emacs-overlay/commit/f55f65384775ddce98368b86bf76816d6d3c5901) Updated repos/melpa
* [`1cfcbae1`](https://github.com/nix-community/emacs-overlay/commit/1cfcbae16b09925e3cd089e877c5278d78fb2cea) Updated repos/elpa
* [`ccbe339b`](https://github.com/nix-community/emacs-overlay/commit/ccbe339bc261353a7e3cb93ce6bf5221535e3b39) Updated repos/emacs
* [`7eda134a`](https://github.com/nix-community/emacs-overlay/commit/7eda134a8c17ec036ce67a478428d4bac0594aaf) Updated repos/melpa
* [`a205da87`](https://github.com/nix-community/emacs-overlay/commit/a205da878adef23aab68dd0f915a505c8571f7b2) Updated flake inputs
* [`63eed2ba`](https://github.com/nix-community/emacs-overlay/commit/63eed2ba81521e0846c30cfc742b5545ba9004c2) Updated repos/emacs
* [`c118418a`](https://github.com/nix-community/emacs-overlay/commit/c118418a55e9e9ae6732beb91831947beeceed8b) Updated repos/melpa
* [`d09c2516`](https://github.com/nix-community/emacs-overlay/commit/d09c2516f7370bbe5e474e4355a6362e1317e2f1) Updated repos/nongnu
* [`bcc6f8f7`](https://github.com/nix-community/emacs-overlay/commit/bcc6f8f72bc96564792c3d04ecd37dac958c8333) Updated flake inputs
* [`e9654d9a`](https://github.com/nix-community/emacs-overlay/commit/e9654d9abfb964d1d064d5e77221073e0ec4e430) Updated repos/elpa
* [`643a0866`](https://github.com/nix-community/emacs-overlay/commit/643a086606bbc5b56b7a700edcc69a2ad68a4917) Updated repos/emacs
* [`8c3d5922`](https://github.com/nix-community/emacs-overlay/commit/8c3d5922afd522c2ad12c046242abcd2da4e700e) Updated repos/melpa
* [`7c2b8cdb`](https://github.com/nix-community/emacs-overlay/commit/7c2b8cdb9b156723e72fb82d3ea82ffa810af9ed) Updated repos/elpa
* [`210cb623`](https://github.com/nix-community/emacs-overlay/commit/210cb6239a8576800ff246166007b2939e96ff51) Updated repos/emacs
* [`cffb75cf`](https://github.com/nix-community/emacs-overlay/commit/cffb75cf9e402be7e1a62fe4d67fe2d26713a3ba) Updated repos/melpa
* [`5986e83a`](https://github.com/nix-community/emacs-overlay/commit/5986e83a5c1f975c3553fac8c23dceaecd07cb0f) Updated flake inputs
* [`73469614`](https://github.com/nix-community/emacs-overlay/commit/734696146dc893effe746da6dadfb4b65c636cb1) Updated repos/emacs
* [`2747f52c`](https://github.com/nix-community/emacs-overlay/commit/2747f52c2c919ec72f8e422626a852134a403f53) Updated repos/melpa
* [`162c3ea5`](https://github.com/nix-community/emacs-overlay/commit/162c3ea5aab7f324adc33dacfa3f87510050cba2) Updated repos/elpa
* [`bb06a68d`](https://github.com/nix-community/emacs-overlay/commit/bb06a68dba7b316472dab0a7255a3ea21be45812) Updated repos/melpa
* [`46336f09`](https://github.com/nix-community/emacs-overlay/commit/46336f09b2e019238097b11d8f412ef260bb8715) Updated repos/elpa
* [`c6dda944`](https://github.com/nix-community/emacs-overlay/commit/c6dda94449f4840a088216eff16d3d6a24f8c44e) Updated repos/emacs
* [`eba67dfe`](https://github.com/nix-community/emacs-overlay/commit/eba67dfe6c63f4baab70bec7dc4e9ec9a80f2c4a) Updated repos/melpa
* [`cea09a24`](https://github.com/nix-community/emacs-overlay/commit/cea09a24ced2a2fa136ec907d07c8df555b5557a) Updated repos/emacs
* [`5f4523e4`](https://github.com/nix-community/emacs-overlay/commit/5f4523e4c97618ad9383eaf594411808ef098656) Updated repos/melpa
* [`77d29448`](https://github.com/nix-community/emacs-overlay/commit/77d29448dfbed86b0493ebd6d5345db91100c31f) Updated repos/elpa
* [`8cdf1abd`](https://github.com/nix-community/emacs-overlay/commit/8cdf1abd1a1d9edb3e5a77bb5328709064f94183) Updated repos/emacs
* [`38b18086`](https://github.com/nix-community/emacs-overlay/commit/38b180866b9ab9b9fcf68ed98e97bb33e9579da2) Updated repos/melpa
* [`11dac95e`](https://github.com/nix-community/emacs-overlay/commit/11dac95ef5c6c5238854213beaa3cddc9c1f7dc7) Updated flake inputs
* [`22692ad9`](https://github.com/nix-community/emacs-overlay/commit/22692ad91c85a6f0642564205ea32bf1092dffc2) Updated repos/elpa
* [`93c4fa53`](https://github.com/nix-community/emacs-overlay/commit/93c4fa53dcc26ea00672995deba057f59850d76a) Updated repos/melpa
* [`574432d3`](https://github.com/nix-community/emacs-overlay/commit/574432d3110d18214826653a7cd497d1575d77fa) Updated repos/melpa
* [`c243dcc7`](https://github.com/nix-community/emacs-overlay/commit/c243dcc7ea5fa3f1ccc781e8d7867e62e2525c06) Updated repos/nongnu
* [`2fa82eb3`](https://github.com/nix-community/emacs-overlay/commit/2fa82eb31d3130b5ee0c227350a0ee8c0d1eec2a) Updated repos/elpa
* [`e567076d`](https://github.com/nix-community/emacs-overlay/commit/e567076d50f800ebad3f336391b43a0c55ef8858) Updated repos/emacs
* [`fe2035cc`](https://github.com/nix-community/emacs-overlay/commit/fe2035cc0ddf11231d440a59268ccb4e778d3c94) Updated repos/melpa
* [`4f67a6b0`](https://github.com/nix-community/emacs-overlay/commit/4f67a6b09dec90a167e6263f0487fc7f5334bb91) Updated repos/elpa
* [`1f2ada6e`](https://github.com/nix-community/emacs-overlay/commit/1f2ada6e32cdc7274c2384c9dc57a76e65626301) Updated repos/emacs
* [`6027193b`](https://github.com/nix-community/emacs-overlay/commit/6027193b125cea9983d69bfb7261b7417869d1b2) Updated repos/melpa
* [`25fc3974`](https://github.com/nix-community/emacs-overlay/commit/25fc3974fba5589fcf61d258a309ea23e9763ccf) Updated repos/nongnu
* [`00401900`](https://github.com/nix-community/emacs-overlay/commit/004019000fefc2021744b0e6481ba95db5400024) Updated flake inputs
* [`6fe23f0a`](https://github.com/nix-community/emacs-overlay/commit/6fe23f0a4196b39afe00a4fd1629115b58947f6d) Updated repos/melpa
* [`22f9e2a1`](https://github.com/nix-community/emacs-overlay/commit/22f9e2a121f6a8ec6d631d1cc51db0ed7362eb6c) Updated flake inputs
* [`6e7e79e2`](https://github.com/nix-community/emacs-overlay/commit/6e7e79e24d37fca3b2f9f9a4e02ab65c45116f7c) Updated repos/elpa
* [`2b70559f`](https://github.com/nix-community/emacs-overlay/commit/2b70559ffe69d8dfaf8bbc8b794b37901b64481d) Updated repos/emacs
* [`b16c71aa`](https://github.com/nix-community/emacs-overlay/commit/b16c71aaf1d246e58a5206361b70071e6ec65cf5) Updated repos/melpa
* [`bd864742`](https://github.com/nix-community/emacs-overlay/commit/bd86474205eed43f75539a154edbf7670007a4d8) Updated flake inputs
* [`7bb17e59`](https://github.com/nix-community/emacs-overlay/commit/7bb17e59c1efa639e5900a2ca44307cec4e78f7d) Updated repos/elpa
* [`47eb4910`](https://github.com/nix-community/emacs-overlay/commit/47eb49104f31c11c985dbce1aa6fd4b41f337554) Updated repos/emacs
* [`ec2afcdc`](https://github.com/nix-community/emacs-overlay/commit/ec2afcdc4b4284246f66264777c4670e52d0d505) Updated repos/melpa
* [`3fd7df8e`](https://github.com/nix-community/emacs-overlay/commit/3fd7df8e48255363c9460e8284f5ec92a3cc4403) Updated repos/nongnu
* [`31fe8df6`](https://github.com/nix-community/emacs-overlay/commit/31fe8df61a64c1278cf89de6b41988211e85fa8f) Updated repos/emacs
* [`2a7ada9c`](https://github.com/nix-community/emacs-overlay/commit/2a7ada9c1d9e5772ae0244ab73f8ea377fb88b21) Updated repos/melpa
* [`3862b237`](https://github.com/nix-community/emacs-overlay/commit/3862b237a56b02ddd88c9dcfc74c9ee3d3f936a5) Updated repos/nongnu
* [`cefe6528`](https://github.com/nix-community/emacs-overlay/commit/cefe6528106f9df427cc415a7ba47e31a4dc55ef) Updated flake inputs
* [`c83c2687`](https://github.com/nix-community/emacs-overlay/commit/c83c26878cdcf43cc02a6838a232545b1b6203b7) Updated repos/elpa
* [`c6a21136`](https://github.com/nix-community/emacs-overlay/commit/c6a21136003a8d377a50079c1e785886d96ab8b0) Updated repos/emacs
* [`6c47e62b`](https://github.com/nix-community/emacs-overlay/commit/6c47e62b612814daf38f830cd32187768b813fac) Updated repos/melpa
* [`7054cf08`](https://github.com/nix-community/emacs-overlay/commit/7054cf08ed2a2f81589e94a4bf5bce48c1dd1109) Updated flake inputs
* [`b0037119`](https://github.com/nix-community/emacs-overlay/commit/b0037119c05675312e8ab3f0ec7f149005792f1b) Updated repos/elpa
* [`9d8c7399`](https://github.com/nix-community/emacs-overlay/commit/9d8c7399ba7560a70f13be28b61254a563186ca4) Updated repos/emacs
* [`f50142b8`](https://github.com/nix-community/emacs-overlay/commit/f50142b8483dfeb1f3725aae4064ffac20340cdb) Updated repos/melpa
* [`5f8b7d8f`](https://github.com/nix-community/emacs-overlay/commit/5f8b7d8f8f10894e536c23b0d6ed2f27751a7bd8) Updated repos/emacs
* [`1a0dddeb`](https://github.com/nix-community/emacs-overlay/commit/1a0dddebbe6499e905b7638163ed543df79e6e87) Updated repos/melpa
* [`d0d1e369`](https://github.com/nix-community/emacs-overlay/commit/d0d1e3695cb80db1d75cf03082658a98d5dedb44) Updated repos/nongnu
* [`478c8f35`](https://github.com/nix-community/emacs-overlay/commit/478c8f359adb4e021d8f45001af6dce5528afbbd) Updated repos/elpa
* [`00bb40d9`](https://github.com/nix-community/emacs-overlay/commit/00bb40d978624cfb8a194f978a22c4c3059522e5) Updated repos/emacs
* [`02551988`](https://github.com/nix-community/emacs-overlay/commit/02551988a01ed9a1857f9c2b6b80854ba2bd0f06) Updated repos/melpa
* [`deaebf8f`](https://github.com/nix-community/emacs-overlay/commit/deaebf8f0a2034eb5015e916df40c2ddf5629eb9) nativeComp -> withNativeCompilation
* [`08ec70f2`](https://github.com/nix-community/emacs-overlay/commit/08ec70f27c8cbf8c5c04df947815f3a189da5df9) Updated repos/elpa
* [`767f9cc8`](https://github.com/nix-community/emacs-overlay/commit/767f9cc84819396a2e62c15e6e5bbd07cd7bc725) Updated repos/melpa
* [`379d9c26`](https://github.com/nix-community/emacs-overlay/commit/379d9c260bd91845a334c58aeddf05e55868547c) Updated repos/nongnu
* [`9fcfdcaa`](https://github.com/nix-community/emacs-overlay/commit/9fcfdcaad14a411cd3eb97d046ba332cb4750af3) Updated repos/emacs
* [`9855d7f2`](https://github.com/nix-community/emacs-overlay/commit/9855d7f268dffa9643f9bc3eaabb7957f4a3c476) Updated repos/melpa
* [`4826a80d`](https://github.com/nix-community/emacs-overlay/commit/4826a80da08f1043975d5f4e56f342184e9514af) Updated flake inputs
* [`e0d37a09`](https://github.com/nix-community/emacs-overlay/commit/e0d37a0991beabdac6ba023c77376ee4b98a4068) Updated repos/emacs
* [`caf71437`](https://github.com/nix-community/emacs-overlay/commit/caf71437399bd01b2053c124f3a01240514cfc05) Updated repos/melpa
* [`866a2434`](https://github.com/nix-community/emacs-overlay/commit/866a243457f36c075a092a85a58281d8c3d3c791) Updated repos/elpa
* [`70e79125`](https://github.com/nix-community/emacs-overlay/commit/70e79125be41c75fa57e0564be866bb0dc8407ed) Updated repos/melpa
* [`9815e71d`](https://github.com/nix-community/emacs-overlay/commit/9815e71dd833db0b076072df6f7ea46737854470) Updated repos/nongnu
* [`18ccf7f4`](https://github.com/nix-community/emacs-overlay/commit/18ccf7f4eabef7fc4d563da64620107a77fd44ae) Updated flake inputs
* [`200d738d`](https://github.com/nix-community/emacs-overlay/commit/200d738d1ca461e761f94f1327ec22b24860a743) Updated repos/melpa
* [`9e011822`](https://github.com/nix-community/emacs-overlay/commit/9e011822a39acb8d7d3501c361b3e59a1da90ffa) Updated repos/nongnu
* [`33f8ab84`](https://github.com/nix-community/emacs-overlay/commit/33f8ab84d069b8b399b6bdf79156fd670ed6cc9f) Updated repos/elpa
* [`7213e9a7`](https://github.com/nix-community/emacs-overlay/commit/7213e9a7398b894c62bfb2a5a0fea120caffceb9) Updated repos/emacs
* [`a8d06a34`](https://github.com/nix-community/emacs-overlay/commit/a8d06a3438ef4d32167ccb256c4b42441e841dc4) Updated repos/melpa
* [`828ee154`](https://github.com/nix-community/emacs-overlay/commit/828ee154515dedd1e5ef6e753ce455b937bf7a8e) Updated repos/elpa
* [`708b54bb`](https://github.com/nix-community/emacs-overlay/commit/708b54bb60e8ffc4ebe4ecb67e6fe22553571d85) Updated repos/emacs
* [`53bee007`](https://github.com/nix-community/emacs-overlay/commit/53bee0073ec62b4549f4d8ded7acba6b4368f89a) Updated repos/melpa
* [`8557a967`](https://github.com/nix-community/emacs-overlay/commit/8557a967260b6f6fca567dcf6d1dee47aa71871f) Updated repos/nongnu
* [`2d4b3adc`](https://github.com/nix-community/emacs-overlay/commit/2d4b3adc452151958a483e41f696c2fb6277c4b1) Updated repos/emacs
* [`22c986c6`](https://github.com/nix-community/emacs-overlay/commit/22c986c6ed401dcdbc5fdbfe7e0cf551a35b58dc) Updated repos/melpa
* [`72e4bb8b`](https://github.com/nix-community/emacs-overlay/commit/72e4bb8b43760b8fe90d76940b67bec53c04cd53) Updated flake inputs
* [`8dce1412`](https://github.com/nix-community/emacs-overlay/commit/8dce1412af0b2f40e61819f3a1abe29c3eb2f73b) Updated repos/elpa
* [`90593b42`](https://github.com/nix-community/emacs-overlay/commit/90593b4284e396ff68fdcb8b19ee4e7c4f9b88ad) Updated repos/emacs
* [`2e1e8922`](https://github.com/nix-community/emacs-overlay/commit/2e1e89226ae423cd0b1d33986f8ef1389548fecb) Updated repos/melpa
* [`eb07b0b3`](https://github.com/nix-community/emacs-overlay/commit/eb07b0b3eb0130c2f06535ed425a26d939efd346) Updated flake inputs
* [`4a838e63`](https://github.com/nix-community/emacs-overlay/commit/4a838e63177bd354c23d4440ddaeb574a477d09e) Updated repos/elpa
* [`271ef8ab`](https://github.com/nix-community/emacs-overlay/commit/271ef8ab2d9ee4cd4c0930de5076c3836568359e) Updated repos/emacs
* [`4aeae735`](https://github.com/nix-community/emacs-overlay/commit/4aeae735d19b2012108c41cbf9ff8dfc7895b97f) Updated repos/melpa
* [`2837a959`](https://github.com/nix-community/emacs-overlay/commit/2837a959ae3d1b150e0969baef405e7cbe14935b) Updated flake inputs
* [`c41d0144`](https://github.com/nix-community/emacs-overlay/commit/c41d0144b56a67e74359abba5e5313e5512d2444) Updated repos/emacs
* [`140bccd8`](https://github.com/nix-community/emacs-overlay/commit/140bccd893fda29984c3e7b188181a851b40c7c7) Updated repos/melpa
* [`d2dac086`](https://github.com/nix-community/emacs-overlay/commit/d2dac086c3bcaf686be6deb56368fcd426e5c434) Updated repos/nongnu
* [`65f3b980`](https://github.com/nix-community/emacs-overlay/commit/65f3b980daf2e07eaa16b1011ae1f332b7c5b63d) Updated repos/elpa
* [`c1f1dd1a`](https://github.com/nix-community/emacs-overlay/commit/c1f1dd1a32951b01979f340ba733fde352ca20c6) Updated repos/emacs
* [`01c076bb`](https://github.com/nix-community/emacs-overlay/commit/01c076bb6f9fd34630f4c87cfab18ea4e85ef819) Updated repos/melpa
* [`6f2b8e6b`](https://github.com/nix-community/emacs-overlay/commit/6f2b8e6bc177a65f73cbcd15a6932a8dcd90b89e) Updated repos/elpa
* [`aa4147fb`](https://github.com/nix-community/emacs-overlay/commit/aa4147fb5fba763697588e992385b46066728c2f) Updated repos/emacs
* [`5bb02950`](https://github.com/nix-community/emacs-overlay/commit/5bb029505a7cc53054e6b66a75c98f68857b0928) Updated repos/melpa
* [`dc232f41`](https://github.com/nix-community/emacs-overlay/commit/dc232f41f9aa86ad78cf202994f2f4ccedf28b30) Updated repos/emacs
* [`8ed56a78`](https://github.com/nix-community/emacs-overlay/commit/8ed56a78e273e25ac93c95c98a9f0531311c2e1e) Updated repos/melpa
* [`534f2c53`](https://github.com/nix-community/emacs-overlay/commit/534f2c534d5f74e10b3f8539e0e04decd6974383) Updated flake inputs
* [`138d813c`](https://github.com/nix-community/emacs-overlay/commit/138d813c96198de63505b027227bf5b5202612cc) Updated repos/elpa
* [`8e63b446`](https://github.com/nix-community/emacs-overlay/commit/8e63b4460857743ccb79e9ffcc77e2ebbc5d206e) Updated repos/emacs
* [`7ad10dd0`](https://github.com/nix-community/emacs-overlay/commit/7ad10dd0d14aa95e7644a9177978b40c69a1363e) Updated repos/melpa
* [`19bd8a49`](https://github.com/nix-community/emacs-overlay/commit/19bd8a49b5a456efeb0f49a312a29239143c06a4) Updated flake inputs
* [`d767de73`](https://github.com/nix-community/emacs-overlay/commit/d767de73ba1e3b9fe58719d520b9ef7c8bff4cf0) Updated repos/elpa
* [`c4d8c3db`](https://github.com/nix-community/emacs-overlay/commit/c4d8c3db4c075a6842f82fce718c66bc65cb6dfe) Updated repos/emacs
* [`e9982c6d`](https://github.com/nix-community/emacs-overlay/commit/e9982c6dd9ef4d47aed955013820cd15104be6df) Updated repos/melpa
* [`4a6297cf`](https://github.com/nix-community/emacs-overlay/commit/4a6297cfd174c32aa311fe8a5b131ce7c4423411) Updated flake inputs
* [`b0e60539`](https://github.com/nix-community/emacs-overlay/commit/b0e605397802b33321333165948b156b1faa60b7) Updated repos/melpa
* [`d4a78ddc`](https://github.com/nix-community/emacs-overlay/commit/d4a78ddc335535921d0fa00f35825addc3acf00f) Updated repos/emacs
* [`2a52d78c`](https://github.com/nix-community/emacs-overlay/commit/2a52d78c85ee0608938670c7db79ffaba6f7b31d) Updated repos/melpa
* [`a96a41c0`](https://github.com/nix-community/emacs-overlay/commit/a96a41c04acde4a11ab86d00b420059b32353b09) Updated repos/elpa
* [`16cc5e0d`](https://github.com/nix-community/emacs-overlay/commit/16cc5e0dbb4e93f81263d7e744622d3fd9de7033) Updated repos/emacs
* [`0b7aef5e`](https://github.com/nix-community/emacs-overlay/commit/0b7aef5e21dc3b525eca3c6fcc6d826f84dc8d03) Updated repos/melpa
* [`e8a2c8a1`](https://github.com/nix-community/emacs-overlay/commit/e8a2c8a1396670ff8bcfef925c9f3a393778d0ed) Updated repos/emacs
* [`20d88829`](https://github.com/nix-community/emacs-overlay/commit/20d888290e50bccfe62924dc20b3687e524c0a43) Updated repos/melpa
* [`21a51e88`](https://github.com/nix-community/emacs-overlay/commit/21a51e882f77a0866e530f9b29d61b292237b97a) Updated repos/nongnu
* [`f353bff1`](https://github.com/nix-community/emacs-overlay/commit/f353bff1dadfbe229b61afd6da67baad97b437b4) Updated flake inputs
* [`138cfb06`](https://github.com/nix-community/emacs-overlay/commit/138cfb0636cc06e1e8a413a31245f84f1b8f8317) Updated repos/elpa
* [`b58e4f27`](https://github.com/nix-community/emacs-overlay/commit/b58e4f27c1fa582cc797de527c40f8d092abb1ed) Updated repos/emacs
* [`5148f0e3`](https://github.com/nix-community/emacs-overlay/commit/5148f0e35c9b884eec954113941c4292f60e55fa) Updated repos/melpa
* [`6db9db90`](https://github.com/nix-community/emacs-overlay/commit/6db9db90925ad6cf0ea6240f17f2c97feaa1f042) Updated repos/elpa
* [`5f3b555b`](https://github.com/nix-community/emacs-overlay/commit/5f3b555bfadc32d3f26a486088ea2e3dcb976ca0) Updated repos/emacs
* [`bc5c4075`](https://github.com/nix-community/emacs-overlay/commit/bc5c4075a4279ec023db525abab3eb9f4ceacaa7) Updated repos/melpa
* [`1a5fac1e`](https://github.com/nix-community/emacs-overlay/commit/1a5fac1edad2f1f29b6ebf0f857401771699b436) Updated repos/nongnu
* [`7951ca5a`](https://github.com/nix-community/emacs-overlay/commit/7951ca5a9227877296c49a7ab0ce8dd430c12be5) Updated repos/melpa
* [`452f3afb`](https://github.com/nix-community/emacs-overlay/commit/452f3afbf3f4b59349691879640ac6f52f2b7be3) Updated repos/elpa
* [`5d370050`](https://github.com/nix-community/emacs-overlay/commit/5d3700503c012ce1495016cce9bcfe018a6493cb) Updated repos/emacs
* [`e8d273d9`](https://github.com/nix-community/emacs-overlay/commit/e8d273d9f31998c892fd16396b9b6c51566a64b2) Updated repos/melpa
