### PR TITLE
niv doomemacs: update 07fca786 -> 90b1b221

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "07fca786154551f90f36535bfb21f8ca4abd5027",
-        "sha256": "1zs4pq2q24xhb9f3miwfcvsi45ijgmyqw368681qcp0bn4akc0m8",
+        "rev": "90b1b221fe7c20f2edef341a780e194cd22c7daa",
+        "sha256": "0afhq19k6f3wcklimkkaw7g9ngdvvf3qigcyn6zrnilg35w1vi97",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/07fca786154551f90f36535bfb21f8ca4abd5027.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/90b1b221fe7c20f2edef341a780e194cd22c7daa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@07fca786...90b1b221](https://github.com/doomemacs/doomemacs/compare/07fca786154551f90f36535bfb21f8ca4abd5027...90b1b221fe7c20f2edef341a780e194cd22c7daa)

* [`6074fc3a`](https://github.com/doomemacs/doomemacs/commit/6074fc3aa827ebc8130c28f1014263bfeaba0d27) feat(julia): add julia-snail
* [`5ab4527b`](https://github.com/doomemacs/doomemacs/commit/5ab4527b181cc65f4a7dc513972d48601b2ddffc) fix(julia): update eglot environment discovery
* [`6b9ce024`](https://github.com/doomemacs/doomemacs/commit/6b9ce02433c78530661c99b2f9fa594bd8139344) fix(julia): add check for vterm for snail
* [`f2c75dea`](https://github.com/doomemacs/doomemacs/commit/f2c75dea9a2f16937889cda0088094778cf0b0fb) feat(julia): add snail repl mode keybindings
* [`ed4d12df`](https://github.com/doomemacs/doomemacs/commit/ed4d12df0575648cc398333d926d0b5355961955) feat(julia): use julia-snail as repl when +snail
* [`d10bb6dc`](https://github.com/doomemacs/doomemacs/commit/d10bb6dc420206ffa5662857566be36046defa5b) feat(julia): add snail keybindings to snail repl mode
* [`71c21005`](https://github.com/doomemacs/doomemacs/commit/71c210050fefd808078f47ffdb5d5810c23da13a) nit(julia): add note about send-region/buffer not working quite right
* [`de434f5c`](https://github.com/doomemacs/doomemacs/commit/de434f5c2989d7916af5c33458264d23ef9af0e6) fix(julia): use cider result face for snail popup
* [`727cb231`](https://github.com/doomemacs/doomemacs/commit/727cb231cc2b59bf496073cd940866a5f6750109) docs(julia): add notes about +snail flag
* [`9a3e950a`](https://github.com/doomemacs/doomemacs/commit/9a3e950a646cdf92628275fc47b67f4242abf887) docs(julia): add keybindings
* [`1b3bc7b7`](https://github.com/doomemacs/doomemacs/commit/1b3bc7b7fbabb95e0e2b68a63d4a2a19b5f62c2f) fix(julia): featurep! => modulep!
* [`85f81211`](https://github.com/doomemacs/doomemacs/commit/85f812111a21492522d1ecfb93c6c4c08b3e1399) bump: :lang julia
* [`76c1330a`](https://github.com/doomemacs/doomemacs/commit/76c1330aa3bb771e83833f02d0970517a7bb8e0c) nit(julia): Format keybindings
* [`8daa99ff`](https://github.com/doomemacs/doomemacs/commit/8daa99ff4776ab0aca921c5f38656d57f527ac45) bump: :lang julia
* [`5b322601`](https://github.com/doomemacs/doomemacs/commit/5b32260127e82675d056db8600c306f85b8831c0) bump: :lang julia
* [`785ade7b`](https://github.com/doomemacs/doomemacs/commit/785ade7ba3a3d460a5cf409022638fa1005851a2) fix: featurep! => modulep!
* [`1d662a54`](https://github.com/doomemacs/doomemacs/commit/1d662a54a88153d428a4c43ae94a326c35a71a06) bump: :lang nix
* [`547584b8`](https://github.com/doomemacs/doomemacs/commit/547584b831103b9e29d46613cd47d83bcaf805c0) refactor(org): move org-crypt and related hooks behind a '+crypt' flag
* [`96ab62d5`](https://github.com/doomemacs/doomemacs/commit/96ab62d566fa876f1301d547d90c12c1692de3ac) tweak(ledger): map `ledger-report` in `ledger-report-mode-map`
* [`12dfc62a`](https://github.com/doomemacs/doomemacs/commit/12dfc62ae516ba4708759d126950ceed372ce857) fix(lib): doom-system-distro-version: check nixos-version first
* [`7cd0b87c`](https://github.com/doomemacs/doomemacs/commit/7cd0b87cd68e6ddacf2a937564648cf1d4246843) fix(lib): doom-region-*: only use evil visual range in visual mode
* [`b0826b9a`](https://github.com/doomemacs/doomemacs/commit/b0826b9a9097cdf2ca1e48b9de9a21898d494b83) tweak(config): feature-gate company keybindings
* [`0f843535`](https://github.com/doomemacs/doomemacs/commit/0f843535bef7263a93bd71b925be5a5fe867f2f9) bump: :completion vertico
* [`57e2e989`](https://github.com/doomemacs/doomemacs/commit/57e2e989b1e7d91e846972bdd46a6a95debd8d18) fix(scala): remove -emacs suffix from metals executable
* [`a8dc2919`](https://github.com/doomemacs/doomemacs/commit/a8dc291971a9fe1d413f6de6603db4cadb3993f1) fix(lsp): warn about server installers for lsp-mode
* [`81ec1a70`](https://github.com/doomemacs/doomemacs/commit/81ec1a70d0e44f96db8a03371e6d4157f699aab7) fix(lsp): advise eglot-ensure to always load
* [`435a3836`](https://github.com/doomemacs/doomemacs/commit/435a383635b212a9219dfe632c0748ca5827c366) fix(evil): remap after eglot is loaded
* [`b6976822`](https://github.com/doomemacs/doomemacs/commit/b6976822250948df327ba26e689219d09d384d93) bump: :tools lsp
* [`3e3af2a6`](https://github.com/doomemacs/doomemacs/commit/3e3af2a629b25f6583225180c6c3280d1bb3493d) fix(lookup): correctly scrape identifier in pdf-view-mode
* [`f70e3824`](https://github.com/doomemacs/doomemacs/commit/f70e382463679dcbffd48482e472b76779471943) docs(unicode): describe [doomemacs/doomemacs⁠#7164](https://togithub.com/doomemacs/doomemacs/issues/7164)
* [`3e81655b`](https://github.com/doomemacs/doomemacs/commit/3e81655b0e49e051e0b0a76f0dc901d5edaf9eef) feat: add 'harfbuzz to `features`
* [`705a439c`](https://github.com/doomemacs/doomemacs/commit/705a439ca5200816271eee3c5d721f91f876d2d0) feat(lua): associate *.fenneldoc w/ fennel-mode
* [`8b892f52`](https://github.com/doomemacs/doomemacs/commit/8b892f5299a01a186399d7f0dd128f4d703a5f21) bump: :tools lookup
* [`a82163cb`](https://github.com/doomemacs/doomemacs/commit/a82163cb9978de49c269aee389598617610b81f2) bump: :completion ivy
* [`d8d26fa3`](https://github.com/doomemacs/doomemacs/commit/d8d26fa3c8757e64c1b8a7da8f00deb5fa918640) bump: :lang python
* [`2b79787f`](https://github.com/doomemacs/doomemacs/commit/2b79787f1e597a045cbd40f806d8269b4bc3ec14) bump: :tools tree-sitter
* [`0cc20558`](https://github.com/doomemacs/doomemacs/commit/0cc20558036a79ffbf233f4e9dca65c2c41d54f3) bump: :tools debugger lsp
* [`c79f55f7`](https://github.com/doomemacs/doomemacs/commit/c79f55f7760b09d0633dddfcc01cd6e0ea47ef45) bump: :lang org
* [`9a80f783`](https://github.com/doomemacs/doomemacs/commit/9a80f783eb85abfe2cdfc16c16005cc19d88ce1d) docs(org): link to packages with doom-package:*
* [`1cd2a287`](https://github.com/doomemacs/doomemacs/commit/1cd2a287f58898b2616de8ce75fc369345d75deb) nit: comment revision, spellcheck, & reformatting
* [`fecf1f8d`](https://github.com/doomemacs/doomemacs/commit/fecf1f8d280e5c10def16ed72685965e175c5ce5) docs(rust): fix links & revise
* [`46d0a309`](https://github.com/doomemacs/doomemacs/commit/46d0a309109daa49fa3d53bbf5c321585306445d) docs(ruby): document imenu issues
* [`9fdaa4c3`](https://github.com/doomemacs/doomemacs/commit/9fdaa4c3db4787f3e852c966fd2dc5184831c963) docs(undo): unfo-fu -> undo-fu
* [`a548851c`](https://github.com/doomemacs/doomemacs/commit/a548851c9f05819d508e190533cb0c1740d4dbbd) docs: future proof discord link in readme
* [`83cea903`](https://github.com/doomemacs/doomemacs/commit/83cea903f032c0385ed1343f8982d053ffabfad7) docs(latex): update packages to install
* [`f0b58fc4`](https://github.com/doomemacs/doomemacs/commit/f0b58fc4528db20f77568d3e16db3c32193d480f) fix(lookup): powerthesaurus eager-loading transient, hydra, lv
* [`98f3af7a`](https://github.com/doomemacs/doomemacs/commit/98f3af7a7cbc5a9490394c491b0117ae2e6a967b) feat(vc): browse-at-remote: recognize gitlab.* hosts
* [`89e444ef`](https://github.com/doomemacs/doomemacs/commit/89e444ef85ea030211acec021d71a1d17b737dcf) fix(javascript): use top-level node_modules in monorepos
* [`37f4653f`](https://github.com/doomemacs/doomemacs/commit/37f4653f5e6aa099932259b7c2d38fea37331e0b) docs: don't set user-* variables by default
* [`177157b0`](https://github.com/doomemacs/doomemacs/commit/177157b044f05fb7d166ec80a0a6ddc361d9b873) fix(popup): cycle windows with no-other-window property
* [`9245a347`](https://github.com/doomemacs/doomemacs/commit/9245a347a4c2e11341eedef2e62ab23510131305) module: add :tools collab
* [`90642871`](https://github.com/doomemacs/doomemacs/commit/906428710231512f6a4b6edf69e80e5276a7fa15) fix(clojure): tree-sitter in clojure{c,script}-mode
* [`0d30ef18`](https://github.com/doomemacs/doomemacs/commit/0d30ef188abecdfd19ef144c0bc6311943563c18) docs(lispy): add "Working with Brackets"
* [`1cae082d`](https://github.com/doomemacs/doomemacs/commit/1cae082d668fe491a952168818d5604f5a19cf95) feat(syntax): add flymake configuration
* [`b957142e`](https://github.com/doomemacs/doomemacs/commit/b957142e3ec8eee9aa0ec465562e17589090a9b7) feat(lsp): use flymake when enabled
* [`4696f0d4`](https://github.com/doomemacs/doomemacs/commit/4696f0d4cedb713a6acb761da74811d5349a3fdb) tweak(syntax): feat gate flycheck in all modules
* [`3d7e61fd`](https://github.com/doomemacs/doomemacs/commit/3d7e61fdcd24ab87af6ff21aae3259775ed372b7) nit(syntax): note recipes can be removed soon
* [`37bfe082`](https://github.com/doomemacs/doomemacs/commit/37bfe0824b4a7c9585acb454ce2065cc6fc427ac) tweak(lsp): feature gate flycheck eglot
* [`532ad087`](https://github.com/doomemacs/doomemacs/commit/532ad087f43dd739b9e5f8dfd4db615f001407d6) bump: :tools biblio
* [`2a33d649`](https://github.com/doomemacs/doomemacs/commit/2a33d64973f628b19f04015f97c529abb3295d41) fix(biblio): check for +roam2 for citar-org-roam
* [`8d999424`](https://github.com/doomemacs/doomemacs/commit/8d9994246971c2d895cc74f232e0b06169467b34) feat(biblio): add +icons for citar
* [`90b1b221`](https://github.com/doomemacs/doomemacs/commit/90b1b221fe7c20f2edef341a780e194cd22c7daa) docs(syntax): add flymake flag
