### PR TITLE
niv devenv: update 9fb94a34 -> e91205ac

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "9fb94a348179ee0074beeac2dce2d30f18588e4d",
-        "sha256": "0pbnsjzdmllbgaj8l55d5bb963h915cpcl4c1pl19k7xk9blaxrg",
+        "rev": "e91205acb792f6a49ea53ab04c04fbc2a85039cd",
+        "sha256": "1fl3k496921x0afvribcxqkp914k0hy7m5av9ky45niiyvdrp04k",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/9fb94a348179ee0074beeac2dce2d30f18588e4d.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/e91205acb792f6a49ea53ab04c04fbc2a85039cd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@9fb94a34...e91205ac](https://github.com/cachix/devenv/compare/9fb94a348179ee0074beeac2dce2d30f18588e4d...e91205acb792f6a49ea53ab04c04fbc2a85039cd)

* [`6ddb5c75`](https://github.com/cachix/devenv/commit/6ddb5c75bc67ec4c9a17cda84f16a81c9f6871ff) [FEAT] Do not use single-user mode when initializing postgres
* [`0d0d6996`](https://github.com/cachix/devenv/commit/0d0d69965e2551c7321346c76deaecd2289e553c) [REFACTOR] Rework initialization script to be more indempotent
* [`9b21ab91`](https://github.com/cachix/devenv/commit/9b21ab9147b0d1d601f4a6e13c19aaba2858a6ad) fix [cachix/devenv⁠#752](https://togithub.com/cachix/devenv/issues/752): fix eval with flakes
* [`79308565`](https://github.com/cachix/devenv/commit/793085657e4f743d803f4d330f22e85e5c4b1d2c) [REFACTOR] Small QoL changes to the init script output
* [`c03dad78`](https://github.com/cachix/devenv/commit/c03dad78c42ef7a0c804fca4bc0bbe6d7bd25cb9) Fix mkcert Integration When nss Is Used
* [`a1b7932e`](https://github.com/cachix/devenv/commit/a1b7932e63ab7fa21f7a81050d65b7c3b8d91ecc) Example: timescale
* [`37ae863b`](https://github.com/cachix/devenv/commit/37ae863bd105ce95e6f08071517053c07f884b70) [BUG] fix python-poetry .test.sh to work with new .venv directory
* [`47b242ec`](https://github.com/cachix/devenv/commit/47b242ec15c71472ac7db8209460f28874c1b609) [BUG] Fix postgres .test.sh
* [`b821cc2c`](https://github.com/cachix/devenv/commit/b821cc2cd153ef14a4a7c4d75f43a25df9baf1f8) feat: correct mysqlx socket location
* [`d2f99552`](https://github.com/cachix/devenv/commit/d2f9955293e602483695028fadda68823db0f518) javascript: add npmInstall option
* [`da313abf`](https://github.com/cachix/devenv/commit/da313abf0fb6d21210f6d555acabf40425e080f1) Auto generate docs/reference/options.md
* [`e91205ac`](https://github.com/cachix/devenv/commit/e91205acb792f6a49ea53ab04c04fbc2a85039cd) doc: add escaping pattern
