### PR TITLE
niv home-manager: update d309a62e -> 4fd794d3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d309a62ee81faec56dd31a263a0184b0e3227e36",
-        "sha256": "1h9cfxxa2ap8vf4b98hkwc48yg72kmcc3y4qjzah0h5fsw0cmgvr",
+        "rev": "4fd794d3df88735dcf9662155d77b08a2e2dde29",
+        "sha256": "1rzjzmzlr4r5sr3dnbba8yhbq783sk3y4m5drwrnsr0xw4y1i7v5",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d309a62ee81faec56dd31a263a0184b0e3227e36.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/4fd794d3df88735dcf9662155d77b08a2e2dde29.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d309a62e...4fd794d3](https://github.com/nix-community/home-manager/compare/d309a62ee81faec56dd31a263a0184b0e3227e36...4fd794d3df88735dcf9662155d77b08a2e2dde29)

* [`0306d5ed`](https://github.com/nix-community/home-manager/commit/0306d5ed7e9d1662b55ec0d08afc73d4cb5eadca) git-sync: add news entry for darwin
* [`ba2c0737`](https://github.com/nix-community/home-manager/commit/ba2c0737cc848db03470828fdb5e86df75ed42a8) firefox: make package nullable ([nix-community/home-manager⁠#4113](https://togithub.com/nix-community/home-manager/issues/4113))
* [`8d243f7d`](https://github.com/nix-community/home-manager/commit/8d243f7da13d6ee32f722a3f1afeced150b6d4da) gpg: fix typo ([nix-community/home-manager⁠#4277](https://togithub.com/nix-community/home-manager/issues/4277))
* [`5c232267`](https://github.com/nix-community/home-manager/commit/5c23226768abd3402636f4d3c65aea8450997102) hyprland: use `toKeyValue`'s `indent` argument ([nix-community/home-manager⁠#4274](https://togithub.com/nix-community/home-manager/issues/4274))
* [`f58889c0`](https://github.com/nix-community/home-manager/commit/f58889c07efa8e1328fdf93dc1796ec2a5c47f38) gnome-terminal: add assertion on profile names
* [`729ab77f`](https://github.com/nix-community/home-manager/commit/729ab77f9e998e0989fa30140ecc91e738bc0cb1) home-manager: skip manual in uninstall configuration
* [`3db43afc`](https://github.com/nix-community/home-manager/commit/3db43afcb4a755221530ff821ec4ac30eca77033) home-manager: rework news command
* [`4fd794d3`](https://github.com/nix-community/home-manager/commit/4fd794d3df88735dcf9662155d77b08a2e2dde29) gh: option to enable helper for additional hosts ([nix-community/home-manager⁠#4288](https://togithub.com/nix-community/home-manager/issues/4288))
