### PR TITLE
niv powerlevel10k: update 1d96f5e0 -> f851f41f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "1d96f5e066a5dd569ddd24787d7e9a3c3abe3024",
-        "sha256": "160y3v41giwv1zmlvx8117lla6yfimpagm1l0x47d872l5yx2nli",
+        "rev": "f851f41fc14d5bd66266b4b4af917d50c1c8b7fe",
+        "sha256": "1w7nw2nvgpl5sx5jqnsp05n8z3i5rgbnalyg52nm26c5n5w6qqrs",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/1d96f5e066a5dd569ddd24787d7e9a3c3abe3024.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/f851f41fc14d5bd66266b4b4af917d50c1c8b7fe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@1d96f5e0...f851f41f](https://github.com/romkatv/powerlevel10k/compare/1d96f5e066a5dd569ddd24787d7e9a3c3abe3024...f851f41fc14d5bd66266b4b4af917d50c1c8b7fe)

* [`7e9a79f3`](https://github.com/romkatv/powerlevel10k/commit/7e9a79f3f1ffefadde83630f9beb6e9708d26b42) new segment: per_directory_history ([romkatv/powerlevel10k⁠#2384](https://togithub.com/romkatv/powerlevel10k/issues/2384))
* [`12aa3fa3`](https://github.com/romkatv/powerlevel10k/commit/12aa3fa3c423fa2aaaf9fe22d8c2021af1d73ecb) Add rocky icon
* [`367c667d`](https://github.com/romkatv/powerlevel10k/commit/367c667de66e8227d55b4726390d07aa45c4b3f6) Add rocky icon to wizard
* [`68104494`](https://github.com/romkatv/powerlevel10k/commit/68104494a7d407d4b8044cb445eea09e111120ac) bump version + cleanup ([romkatv/powerlevel10k⁠#2391](https://togithub.com/romkatv/powerlevel10k/issues/2391))
* [`a8fa0e2a`](https://github.com/romkatv/powerlevel10k/commit/a8fa0e2a1b67513331f19dab96de92333ad832f5) Add documentation explaining lack of support for skipHash
* [`9bb15e9f`](https://github.com/romkatv/powerlevel10k/commit/9bb15e9ffbf43663a77949ea31d6f18c74e8981c) docs: rephrase "Git status looks incorrect" section
* [`f851f41f`](https://github.com/romkatv/powerlevel10k/commit/f851f41fc14d5bd66266b4b4af917d50c1c8b7fe) remove MULTIBYTE requirement from the configuration wizard ([romkatv/powerlevel10k⁠#2397](https://togithub.com/romkatv/powerlevel10k/issues/2397))
