### PR TITLE
niv nixpkgs: update df2e373b -> 48377a19

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "df2e373b15dd502114e8a671f3675d50ed1ebc90",
-        "sha256": "1f7hh1kx6nncn7pibg8afnvzsqcql2578w8a8nb2vhlfp3ay5lni",
+        "rev": "48377a1934063d63930524b250604103e246d863",
+        "sha256": "120bjvpzw5i7qm0kyi7wxbw41jgpkwljz2rz5h5c84gh6gj38i91",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/df2e373b15dd502114e8a671f3675d50ed1ebc90.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/48377a1934063d63930524b250604103e246d863.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@df2e373b...48377a19](https://github.com/nixos/nixpkgs/compare/df2e373b15dd502114e8a671f3675d50ed1ebc90...48377a1934063d63930524b250604103e246d863)

* [`bb83ccf1`](https://github.com/NixOS/nixpkgs/commit/bb83ccf125f062d8200f8718157c62b8daa61583) Added TODO messages in comments
* [`627cf54a`](https://github.com/NixOS/nixpkgs/commit/627cf54a8296e77bd03f071203a89e3416741045) textadept:11.4 -> 12.0
* [`bb60502d`](https://github.com/NixOS/nixpkgs/commit/bb60502dbc2c5c8fad6197fd000167ad63f22e71) processing: 4.1.1 -> 4.2
* [`9b514c0f`](https://github.com/NixOS/nixpkgs/commit/9b514c0ff7ad0006bde589329e57b3e5e92a6322) textadept:11.4 -> 12.0
* [`c69a660d`](https://github.com/NixOS/nixpkgs/commit/c69a660d99e2fa0833faf9da3ecb84510cb88ebc) textadept:11.4 -> 12.0
* [`2c664e3a`](https://github.com/NixOS/nixpkgs/commit/2c664e3a6540b7515b5753063f03a936fdfffaf0) nixos/prometheus-ipmi-exporter: allow AF_UNIX address family
* [`f2d7b338`](https://github.com/NixOS/nixpkgs/commit/f2d7b3381bdfb39de7c07044ff47ee561feec8df) cmtk: 3.3.1 -> 3.3.2
* [`1c04bc64`](https://github.com/NixOS/nixpkgs/commit/1c04bc64347f1445eb40853a1eb3ea4aa7af716c) organicmaps: 2023.05.08-7 -> 2023.06.04-13
* [`057dd0ef`](https://github.com/NixOS/nixpkgs/commit/057dd0effeb0a748738b1b93f8cb072a0ddc439f) libiconvReal: implement ABI compatibility on Darwin
* [`b9b36021`](https://github.com/NixOS/nixpkgs/commit/b9b360217c9f8e42cc8a71151e3c61cb2b41b076) ruby-modules/gem-config: Add fix for sass-embedded
* [`7ce443a4`](https://github.com/NixOS/nixpkgs/commit/7ce443a48a06c0f2960317be36709a8c64c9f598) rubyPackages.webrick: init at 1.8.1
* [`1db04a81`](https://github.com/NixOS/nixpkgs/commit/1db04a815b709540f93532600cedbe1b1c3a2b82) rekor-cli, rekor-server: 1.2.1 -> 1.2.2
* [`8a6a09f6`](https://github.com/NixOS/nixpkgs/commit/8a6a09f620087fb3db9f4a8cd2de7de45de1c8f4) jextract: init at unstable-2023-04-14
* [`5205c73d`](https://github.com/NixOS/nixpkgs/commit/5205c73d9311bcf458ed0fe1f4ce381bf3842b3d) nixos/gitea: add WORK_PATH to config
* [`84ada07d`](https://github.com/NixOS/nixpkgs/commit/84ada07d731fc43c854d38220e59556d4bddb5af) xdg-utils: mark broken if cross
* [`758bf4cb`](https://github.com/NixOS/nixpkgs/commit/758bf4cb8a7cf53eb0695e7bc28fc7f8820b2489) chromium: late-bind xdg-utils if broken
* [`c25897c1`](https://github.com/NixOS/nixpkgs/commit/c25897c1f327ebba6f73ef7ed6b9b6c93a2f3101) chromium: take llvmPackages from pkgsBuildTarget
* [`53af611d`](https://github.com/NixOS/nixpkgs/commit/53af611dd20722f52302fc9efc298eb46684093c) chromium: invoke ungoogled-chromium via buildPackages
* [`5f3c644b`](https://github.com/NixOS/nixpkgs/commit/5f3c644b1ad7b73de1888177cea86b44513fb670) chromium: control llvmPackages version selection with a string
* [`0a05fbb9`](https://github.com/NixOS/nixpkgs/commit/0a05fbb9a010337454b942011bfa92168b2efc17) chromium: cross compilation support
* [`7eaaa6ef`](https://github.com/NixOS/nixpkgs/commit/7eaaa6ef228f22f681d3ee298bb7cd055486397c) openssl: prevent -march= flags from being added on mips
* [`f46093d1`](https://github.com/NixOS/nixpkgs/commit/f46093d1c7edf08babb892dd8896deb291f39b68) realvnc-vnc-viewer: support darwin
* [`0eabede4`](https://github.com/NixOS/nixpkgs/commit/0eabede44b064fb3da5026d4dc5f01fa4c1fd3cf) nixos/apparmor: make abstractions/ssl_certs more go friendly
* [`df7941dc`](https://github.com/NixOS/nixpkgs/commit/df7941dc4ea49d65fe182715adf9a2761ab097ca) ulogd: support postgresql, mysql and sqlite as databases
* [`ab391719`](https://github.com/NixOS/nixpkgs/commit/ab391719c222c4b60ce5671faabd1bd9da436e6e) libfilezilla: fix darwin intel build
* [`01693fd5`](https://github.com/NixOS/nixpkgs/commit/01693fd5e8fd2c18d5bb8b14bab802f4a1550763) ffmpeg: fix configure errors on native riscv
* [`9145e6df`](https://github.com/NixOS/nixpkgs/commit/9145e6df84b171a96ff3b3e2ba5d6d5083b25834) nixos/apparmor: add missing abstraction/nss-systemd
* [`ad7ffe3a`](https://github.com/NixOS/nixpkgs/commit/ad7ffe3a7c270a82e06caea439963278bbc70348) nixos/apparmor: fix syntax in abstractions/bash
* [`62b322de`](https://github.com/NixOS/nixpkgs/commit/62b322de1ccc9135aff0c60589b6bc6affce7438) elf2uf2-rs: support darwin
* [`7c9da3ef`](https://github.com/NixOS/nixpkgs/commit/7c9da3ef2f445a2b8c7e843c7afdc96c6e5e80ca) uboot: 2023.01 -> 2023.04
* [`48514113`](https://github.com/NixOS/nixpkgs/commit/485141130e1693a3f8519cc5e52f5f8c886d63e5) uboot: add pyelftools to nativeBuildInputs as it is now required for boards that us binman
* [`d4ffd4aa`](https://github.com/NixOS/nixpkgs/commit/d4ffd4aa09b14ac7fabb5b57a467e812b847515c) ubootRock{,Pro}64: drop extraMakeFlags as the u-boot.itb target has been removed
* [`6bf04fc9`](https://github.com/NixOS/nixpkgs/commit/6bf04fc9c9c099558f3355683a8aece21bbf15a3) cmtk: fix darwin build
* [`7014b723`](https://github.com/NixOS/nixpkgs/commit/7014b723d94b1814ccbd49c84e8bd6898acf5610) cmtk: enable some compile options
* [`e7c8cbc2`](https://github.com/NixOS/nixpkgs/commit/e7c8cbc2b17e21e451d9afdc468601d448d764f5) cmtk: fix format
* [`68e6a47c`](https://github.com/NixOS/nixpkgs/commit/68e6a47ce76c4eaa7a9ae13f55a51d49ec6145ad) uboot: 2023.04 -> 2023.07.02
* [`0f474b4c`](https://github.com/NixOS/nixpkgs/commit/0f474b4c6cd6202d346bc7b7220b88f3c281e478) nixos/apparmor: support custom i18n glibc locales
* [`12561782`](https://github.com/NixOS/nixpkgs/commit/125617826334fbf6be4f4f0e312f40b137bcb932) apparmor: fix python import issues
* [`72f2c8d6`](https://github.com/NixOS/nixpkgs/commit/72f2c8d6c681590d8c973bb79bdd21060aec9c53) lib/tests/modules: Test that _module.args works when a default argument is set
* [`ced170c0`](https://github.com/NixOS/nixpkgs/commit/ced170c030a409f8e21a7c1e20bced6a9397c1d2) nixos/miniflux: add apparmor policy
* [`30ad9053`](https://github.com/NixOS/nixpkgs/commit/30ad9053abddb3128e90c023faf64e0bdd4fce1a) nixos/murmur: add apparmor policy
* [`f6e2b681`](https://github.com/NixOS/nixpkgs/commit/f6e2b681222f4b06ca45f7299890e89f3c3ee465) paml: 4.9j -> 4.10.7
* [`d2c50694`](https://github.com/NixOS/nixpkgs/commit/d2c506948b538b6c0b178e6db59aad47a747f831) paml: refactor
* [`6760151c`](https://github.com/NixOS/nixpkgs/commit/6760151c497523ccf11435740dc2bc777e8732c6) _389-ds-base: 2.4.1 -> 2.4.2
* [`4fba4f3a`](https://github.com/NixOS/nixpkgs/commit/4fba4f3abe7f22962e2e5237b43565a62ac836cb) windmill: 1.100.1 -> 1.131.0
* [`642dac2e`](https://github.com/NixOS/nixpkgs/commit/642dac2e5e01ee1213f846eb6f203b5f31eb548d) python310Packages.ypy-websocket: 0.9.0 -> 0.12.1
* [`250ddaff`](https://github.com/NixOS/nixpkgs/commit/250ddaff9eff9a7dc71ad101d12e3124fec7cd30) superTuxKart: fix build on darwin
* [`7796d4c3`](https://github.com/NixOS/nixpkgs/commit/7796d4c32cb2af397c3a0b3a6603cac585b6341d) doc2go: init at 0.4.1
* [`9929a854`](https://github.com/NixOS/nixpkgs/commit/9929a854654970358542a3c210d55468758678e8) python310Packages.cohere: 4.9.0 -> 4.16.0
* [`3eea344b`](https://github.com/NixOS/nixpkgs/commit/3eea344be3afdea61111702fe0e6b6c27568e60e) crystal_1_9: 1.9.0 -> 1.9.2
* [`4bf62878`](https://github.com/NixOS/nixpkgs/commit/4bf6287811d5dbedd33f50d6a6544724ef3422e5) dq: init at 20230101
* [`34f9116c`](https://github.com/NixOS/nixpkgs/commit/34f9116c5868f81ac83daae291c67a16a002605c) cegui: 0.8.7 -> unstable-2023-03-18
* [`73c36c64`](https://github.com/NixOS/nixpkgs/commit/73c36c646a5579b2abdb86ba5f943233df07ed14) opendungeons: unstable-2021-11-06 -> unstable-2023-03-18
* [`98e07b5b`](https://github.com/NixOS/nixpkgs/commit/98e07b5b2dab24a16312733bcbffc66d0815f738) ogre1_10: remove
* [`d24b7320`](https://github.com/NixOS/nixpkgs/commit/d24b7320e21771a854f456e4eb2cf6a75cb6fbc1) python3Packages.ml-dtypes: init at 0.2.0
* [`f0f7e3db`](https://github.com/NixOS/nixpkgs/commit/f0f7e3db76fdcb58fad3bccab4f7d516f7357417) python3Packages.jaxlib-bin: 0.4.4 -> 0.4.12
* [`263a816a`](https://github.com/NixOS/nixpkgs/commit/263a816ac7192fda639bffe3687157c0e70d5d1a) buildBazelPackage: add support for bazel run targets
* [`fe108f01`](https://github.com/NixOS/nixpkgs/commit/fe108f01195ae84247a1905efcb120fb54ccd8a9) python3Packages.jaxlib: 0.4.4 -> 0.4.12
* [`7a10de4a`](https://github.com/NixOS/nixpkgs/commit/7a10de4a37010d6f3808b8a70a0308b641f31030) python3Packages.jax: 0.4.5 -> 0.4.12
* [`237e4da7`](https://github.com/NixOS/nixpkgs/commit/237e4da744e99b1aedcfced12977ff3d48a15754) python310Packages.pyradiomics: init at 3.1.0
* [`4d2ce90a`](https://github.com/NixOS/nixpkgs/commit/4d2ce90a43e3a7d2775fd2060f202fa0daf8d44c) qmapshack: 1.16.1 → 1.17.0
* [`4bf7264c`](https://github.com/NixOS/nixpkgs/commit/4bf7264c3874b1815215f41aa05f6f8734ea0468) maintainers: add keto
* [`112b8fd0`](https://github.com/NixOS/nixpkgs/commit/112b8fd025fc76bd2a84fc0b2eec32f66633012e) ldid-procursus: init at 2.1.5-procursus7
* [`e196c81a`](https://github.com/NixOS/nixpkgs/commit/e196c81a2343895fa9fd3782c20c67f180619dcc) udisks2: fix conf file loading warnings
* [`c2089256`](https://github.com/NixOS/nixpkgs/commit/c2089256f954b4d73b23542141125943ffe4eb3e) qpwgraph: 0.4.5 -> 0.5.1
* [`a287870f`](https://github.com/NixOS/nixpkgs/commit/a287870f99f03ac9ae9d75728ec4882babf51b6c) perlPackages.DataUUID: Add patch for CVE-2013-4184
* [`6e5d526c`](https://github.com/NixOS/nixpkgs/commit/6e5d526c5eb1e78c8d37cfbece9b5a035e995a37) linuxKernel.kernels.linux_zen: 6.4.2-zen1 -> 6.4.6-zen1
* [`760bd2ac`](https://github.com/NixOS/nixpkgs/commit/760bd2acfa68857b0190362985e9f9fa70ed9074) linuxKernel.kernels.linux_lqx: 6.4.2-lqx1 -> 6.4.6-lqx1
* [`3f948b76`](https://github.com/NixOS/nixpkgs/commit/3f948b7664bf15cdd15019f4f8ec05b7b070762d) netbsd.compat: use strip from cctools-port
* [`8764644b`](https://github.com/NixOS/nixpkgs/commit/8764644b3efc3850e2791c814a0e0317076ea162) logseq: match upstream electron version
* [`4e14f5fe`](https://github.com/NixOS/nixpkgs/commit/4e14f5fee6a68ee5fb56d07e70e86fcfcebdc7d3) lib.path.subpath.components: init
* [`407db583`](https://github.com/NixOS/nixpkgs/commit/407db583c54245136fe8e73976abadb7eb9fad80) lib/path/README.md: Justify returning subpaths
* [`77fb8334`](https://github.com/NixOS/nixpkgs/commit/77fb83341106dbdc4473fc5fb97ef25a3e7e2b24) kubo: 0.20.0 -> 0.21.0
* [`6051ebe0`](https://github.com/NixOS/nixpkgs/commit/6051ebe0ceead3b43f37511695269fb95c3dc4a9) lammps: Add meta.mainProgram
* [`10e7c631`](https://github.com/NixOS/nixpkgs/commit/10e7c631c862270dca61be057525a8193e7f1967) lammps: Install vim and neovim files
* [`eae54103`](https://github.com/NixOS/nixpkgs/commit/eae54103cac6e381565c70b7ed8310f15b648c8b) lammps: always enable cuda opengl runpath support
* [`52ec937b`](https://github.com/NixOS/nixpkgs/commit/52ec937b7786187feb97c4570839b100745cb1e6) minimal-bootstrap.findutils: init at 4.4.2
* [`f3615998`](https://github.com/NixOS/nixpkgs/commit/f3615998acc45521fb58485bce7dbecf2adee4d1) github-desktop: switch to `finalAttrs` pattern
* [`059cc3bf`](https://github.com/NixOS/nixpkgs/commit/059cc3bfbe48e42e6bb6303cc65346f053f04cdd) github-desktop: 3.2.1 -> 3.2.5
* [`bdd9f325`](https://github.com/NixOS/nixpkgs/commit/bdd9f325dc9bf7f7b81546da400561955a0307d8) vimPlugins.headlines-nvim: init at 2023-07-27
* [`b6f8b53e`](https://github.com/NixOS/nixpkgs/commit/b6f8b53efdd5914b7c2904e5567342d5ed870812) vimPlugins: update
* [`98b53d5e`](https://github.com/NixOS/nixpkgs/commit/98b53d5eb43e6b91526f78e4a53132f22940d99b) vimPlugins.nvim-treesitter: update grammars
* [`4e19f709`](https://github.com/NixOS/nixpkgs/commit/4e19f709903bbae4a3dd1ccb704602ac3e3d53ff) vimPlugins.sg-nvim: fix cargoHash
* [`001f224f`](https://github.com/NixOS/nixpkgs/commit/001f224fccf52937cc1355507de89c30b32ee30a) dhcp: remove
* [`413d9d38`](https://github.com/NixOS/nixpkgs/commit/413d9d3864e58ae59c77210e8591968a3121496f) nixos/dhcp(46): remove
* [`993dee10`](https://github.com/NixOS/nixpkgs/commit/993dee10f4a4fe7e73332852946923bd197381db) airgeddon: remove optional dhcp dependency
* [`0d49e021`](https://github.com/NixOS/nixpkgs/commit/0d49e0217e5a8062bbf3efbb7a977b354783bef7) blueman: dhcp -> dhcpcd
* [`9bd4df7c`](https://github.com/NixOS/nixpkgs/commit/9bd4df7c0216b5957c4c07b2e11ae3b3bdbd5b4d) google-guest-agent: drop dhcp dependency
* [`00d7684a`](https://github.com/NixOS/nixpkgs/commit/00d7684ad88ca52ae1a3f4e47854c956f4f829d0) maintainers: rename imsofi to soupglasses
* [`09a90490`](https://github.com/NixOS/nixpkgs/commit/09a904902b74c4acfcd2d0c0b20fd0cb1173a30e) python310Packages.pyemd: 0.5.1 -> 1.0.0
* [`108c1d88`](https://github.com/NixOS/nixpkgs/commit/108c1d886668fd66c05176cf505ef5bdeadffbde) python3Packages.tpm2-pytss: enable tests
* [`f87a1453`](https://github.com/NixOS/nixpkgs/commit/f87a14534e24716e09b05f57c9385c335f749283) python310Packages.pecan: 1.4.2 -> 1.5.1
* [`dd4a8019`](https://github.com/NixOS/nixpkgs/commit/dd4a80196d23f6b61e6b32cacab493e9cf55da3a) proxmark3: Replace with rfidresearchgroup fork
* [`30e93c9f`](https://github.com/NixOS/nixpkgs/commit/30e93c9f3c045de3d28514aeba11fd84bbd6b460) super-slicer: use patched wxGTK31 instead of wxGTK32
* [`0db4de68`](https://github.com/NixOS/nixpkgs/commit/0db4de6899ee98bf18e3576f3f62f3bbc32b74fe) sqlite-utils: repair, add test
* [`dc617c66`](https://github.com/NixOS/nixpkgs/commit/dc617c662350c026fade3b0561e43314f0a56da6) vdrPlugins.softhddevice: 1.10.3 -> 1.11.1
* [`5cd25a3e`](https://github.com/NixOS/nixpkgs/commit/5cd25a3eced3a9585ddd861d98dfaccd1db0549d) vdrPlugins.markad: 3.1.1 -> 3.3.3
* [`ab05d0a7`](https://github.com/NixOS/nixpkgs/commit/ab05d0a75cf2d278a0fb0dc853e43d6d59d312c1) python310Packages.langchain: 0.0.240 -> 0.0.247
* [`63c54748`](https://github.com/NixOS/nixpkgs/commit/63c547482f3c5d6551c30f050c21541864f8c14c) armcord: 3.2.0 -> 3.2.1
* [`bcd64169`](https://github.com/NixOS/nixpkgs/commit/bcd641697ebf2bb71a93b7a31c48a24f6bf9a82a) texlive: do not exclude translations for tlmgr
* [`fba0cc72`](https://github.com/NixOS/nixpkgs/commit/fba0cc72fe6ca23f4a24889c59af20227d49ef9c) texlive.tlpdb.nix: extract binary files, formats, script extensions
* [`a55e801c`](https://github.com/NixOS/nixpkgs/commit/a55e801ca6207174e9b487885e58d8c234ec2c4f) texlive.combine: remove cleanBrokenLinks
* [`5ecc48b8`](https://github.com/NixOS/nixpkgs/commit/5ecc48b8fffc2e38a1603c4f11f8dafb021eb714) texlive: build bin containers for binaries and scripts
* [`1ab65c8c`](https://github.com/NixOS/nixpkgs/commit/1ab65c8c809f83901c22534723be09c15d187180) tests.texlive.binaries: test non-combined binaries with empty PATH, where possible
* [`39750551`](https://github.com/NixOS/nixpkgs/commit/39750551aa6aa0ea758af5457ea74f7bdfe7eb93) tests.texlive.shebangs: init, check that all shebangs are in Nix
* [`56af1c19`](https://github.com/NixOS/nixpkgs/commit/56af1c19817f4a3a58937a7918e140a9797aa1b1) tests.texlive.rpdfcrop: init, check that rpdfcrop runs in restricted mode
* [`01af9404`](https://github.com/NixOS/nixpkgs/commit/01af940407e412979718970acc0072a49a9e282e) texlive.combine: include packages with man pages by default
* [`07e50252`](https://github.com/NixOS/nixpkgs/commit/07e50252e16adee7f9aef5be9949c0c2fef21285) texlive.combine: add ghostscript to wrappers instead of combining
* [`0dfda317`](https://github.com/NixOS/nixpkgs/commit/0dfda31778fe0c1f39a1aac4a297c41bf93a98f1) texlive: document how to review the bin containers
* [`9822bbfc`](https://github.com/NixOS/nixpkgs/commit/9822bbfc339554d90bc12ae9cf866e1b07e50991) texlive.bin.latexindent: add alias to new binary container
* [`3273352d`](https://github.com/NixOS/nixpkgs/commit/3273352d0552e93412d6cb3e99824a7dd6443922) ns-usbloader: init at 7.0
* [`d6e26fdf`](https://github.com/NixOS/nixpkgs/commit/d6e26fdf0261f579afb4467ced26b3481dfb6aee) cypress: 12.17.1 -> 12.17.2
* [`3d6d095d`](https://github.com/NixOS/nixpkgs/commit/3d6d095d8492c0031271882f815d11f88be549c5) onionshare-gui: add patch to fix qrcode
* [`62ddedb4`](https://github.com/NixOS/nixpkgs/commit/62ddedb4eab4d187a43e6fd72d9bc66a360fb23d) xmlstarlet: fix build with clang 16
* [`a350234f`](https://github.com/NixOS/nixpkgs/commit/a350234f5654f783dc0d14ff78b3ddbc0ce6833e) zap: 2.12.0 -> 2.13.0
* [`734527c6`](https://github.com/NixOS/nixpkgs/commit/734527c6b39ca07b273793d8798d37c16ed79a6b) weaviate: 1.19.8 -> 1.20.3
* [`21f8c554`](https://github.com/NixOS/nixpkgs/commit/21f8c5549ba880ed447b4d7ca9c02c3006e1a656) k3d: 5.4.4 -> 5.5.1
* [`68648494`](https://github.com/NixOS/nixpkgs/commit/686484946d52a08b2c9419bc508cbda321a018c8) python3Packages.sagemaker: 2.135.0 -> 2.173.0
* [`fb483752`](https://github.com/NixOS/nixpkgs/commit/fb4837529d889f8da49ff3220f93a22e20c5ea2a) flexget: 3.7.11 -> 3.8.0
* [`be8d600d`](https://github.com/NixOS/nixpkgs/commit/be8d600da9aeffc902550eab23b74280a798f8f0) python310Packages.sure: 2.0.0 -> 2.0.1
* [`9d1f56be`](https://github.com/NixOS/nixpkgs/commit/9d1f56beda73ca75f9353e2daf110a17fcf7d127) barman: 3.4.0 -> 3.7.0
* [`b980f26d`](https://github.com/NixOS/nixpkgs/commit/b980f26d34d6950d35d99373446c113e280521bf) git-lfs: install completions
* [`217edcfa`](https://github.com/NixOS/nixpkgs/commit/217edcfa903736b27cbbc62d81bccd80a43adf64) ocamlPackages.unix-errno: 0.6.1 -> 0.6.2
* [`1109e5f0`](https://github.com/NixOS/nixpkgs/commit/1109e5f000e5b8ec25e18b602a60da28c61373fa) spicedb-zed: 0.10.2 -> 0.12.1
* [`594e5473`](https://github.com/NixOS/nixpkgs/commit/594e5473e37346850d8652d084f9cf8c09b2caad) vtm: 0.9.9r -> 0.9.9t
* [`3adecdfc`](https://github.com/NixOS/nixpkgs/commit/3adecdfcbcaf2223bf52746bd5e733516b897f6f) proxysql: 2.5.3 -> 2.5.4
* [`6678a5ad`](https://github.com/NixOS/nixpkgs/commit/6678a5ad5f04fbc7e95ed065254d9e3a03e71910) confy: 0.6.5 -> 0.7.0
* [`25100a4a`](https://github.com/NixOS/nixpkgs/commit/25100a4aae920e92b25cdda8f84e9710e2dfc1d5) awscli2: 2.13.3 -> 2.13.5
* [`d9fd4ba7`](https://github.com/NixOS/nixpkgs/commit/d9fd4ba73348f702d38c477fa0fd7eaf88015cbe) hid-nintendo: remove
* [`b7edd6fd`](https://github.com/NixOS/nixpkgs/commit/b7edd6fd304d052e2bdb6dbc6b1e42fb17d39c12) hwatch: expand platforms
* [`96672039`](https://github.com/NixOS/nixpkgs/commit/96672039104b1fe06b6cd0573b32e531d62bd2ef) globalping-cli: init at 1.1.0
* [`b4fc8684`](https://github.com/NixOS/nixpkgs/commit/b4fc86847e8a4546235f8eec591b04cb147bf753) forgejo: add adamcstephens as maintainer
* [`eddea44e`](https://github.com/NixOS/nixpkgs/commit/eddea44e43d689a1583cc181f192d3aebdf80957) trufflehog: 3.45.1 -> 3.45.3
* [`82109414`](https://github.com/NixOS/nixpkgs/commit/82109414b666e9c64e3ea82347053579fb933d23) mediaelch: 2.10.2 -> 2.10.4
* [`8363e675`](https://github.com/NixOS/nixpkgs/commit/8363e6750d1ac3da55a63ff254374f3f09142d66) rpcs3: 0.0.28-15372-38a5313ed -> 0.0.28-15409-fd6829f75
* [`eab45971`](https://github.com/NixOS/nixpkgs/commit/eab45971205cefdcc8ddd5522e0253ca403e2584) iio-sensor-proxy: 3.0 -> 3.5
* [`8761d9db`](https://github.com/NixOS/nixpkgs/commit/8761d9dbd5972107048dcf0bf6de32a54b872f18) iio-sensor-proxy: change maintainer
* [`60e3a11e`](https://github.com/NixOS/nixpkgs/commit/60e3a11e1ea74f2608dcb439b6675af3a9e5b987) lxd: add dependencies to wrapper for VM support
* [`1b47c020`](https://github.com/NixOS/nixpkgs/commit/1b47c0202fc35f69aaca37c785623e5a7f153e9c) chezmoi: 2.35.2 -> 2.36.1
* [`162cc6d3`](https://github.com/NixOS/nixpkgs/commit/162cc6d3d2bf3549f47dd3702ad8cc0f7d7020b3) weave-gitops: 0.27.0 -> 0.28.0
* [`aa7ee35c`](https://github.com/NixOS/nixpkgs/commit/aa7ee35c8a48f62cb75fd08aee452758c59e3c95) forgejo: 1.20.1-0 -> 1.20.2-0
* [`ff10792a`](https://github.com/NixOS/nixpkgs/commit/ff10792ad121277cd09a0be73c22975066844eb8) helmsman: 3.16.4 -> 3.17.0
* [`0610720d`](https://github.com/NixOS/nixpkgs/commit/0610720dadffe0aa77a72fa7a92fb643f1ea8337) apple_sdk_11_0: Add MediaRemote private framework
* [`15cadbb7`](https://github.com/NixOS/nixpkgs/commit/15cadbb7c036a9708adbc644c90a8492e65ab9ae) aaaaxy: 1.4.33 -> 1.4.39
* [`6c84ca2d`](https://github.com/NixOS/nixpkgs/commit/6c84ca2d811ad796a4184dc08fcf31e2002c27b2) maintainers: add hexclover
* [`c3591639`](https://github.com/NixOS/nixpkgs/commit/c3591639b0b3377158e5b0806041c943d53bbfa0) grype: 0.64.0 -> 0.64.2
* [`d68f7974`](https://github.com/NixOS/nixpkgs/commit/d68f7974fa76c401829b3a0ba419db7450529bc9) gambit: 4.9.3 -> 4.9.5
* [`785b7d40`](https://github.com/NixOS/nixpkgs/commit/785b7d40ebe51d40a583db630d4befe495284912) gambit-unstable: 2020-09-20 -> 2023-07-30
* [`9165d5cb`](https://github.com/NixOS/nixpkgs/commit/9165d5cbe9ee86d49ce2f39647c5e61d6bc88893) maintainers: add max-amb
* [`c1df21e5`](https://github.com/NixOS/nixpkgs/commit/c1df21e5b61f1bb45a6204fc9d592ecd20e3b6be) alt-server: init at 0.0.5
* [`33fc2f21`](https://github.com/NixOS/nixpkgs/commit/33fc2f21b951bf15c361d12c77f6b3c6a6443009) winePackages.stable: 8.0.1 -> 8.0.2
* [`42255e72`](https://github.com/NixOS/nixpkgs/commit/42255e72642f8ad144ed47a1373a423523a7fd50) maintainers: add jtbx
* [`9f6754b7`](https://github.com/NixOS/nixpkgs/commit/9f6754b7ae4b30307133300e6975b9702f6763d3) farge: init at 1.0.9
* [`5b36914d`](https://github.com/NixOS/nixpkgs/commit/5b36914d210fda6d1a38f4468f7d79bfbcb8da4e) lagrange: 1.16.5 -> 1.16.6
* [`fb8f43e5`](https://github.com/NixOS/nixpkgs/commit/fb8f43e5bfdd76bb6140e3ab1dd72a479843def8) sketchybar: add khaneliman as maintainer
* [`05277105`](https://github.com/NixOS/nixpkgs/commit/0527710541cd2eab6a43206ad4d72dc4e6a6787f) sketchybar: 2.15.1 -> 2.15.2
* [`85bd250f`](https://github.com/NixOS/nixpkgs/commit/85bd250fffd410880a8fc02b253c82cbc614e2af) pkgsMusl.systemdMinimal: fix build
* [`4986e8bf`](https://github.com/NixOS/nixpkgs/commit/4986e8bf74fe2ec62d4384c7508d98b3fbc2f5f0) mame: 0.256 -> 0.257
* [`95c39466`](https://github.com/NixOS/nixpkgs/commit/95c3946692836205b2a5d26f6d06a6f1611034d4) skhd: add khaneliman as maintainer
* [`caaace49`](https://github.com/NixOS/nixpkgs/commit/caaace4918cff22ca9110152bcc41808d4005007) python311Packages.tensorflow: mark as broken
* [`2c38aefa`](https://github.com/NixOS/nixpkgs/commit/2c38aefa2b773a990f582e63aa9cf623783707b0) vscode: Fix icon name
* [`cba62cad`](https://github.com/NixOS/nixpkgs/commit/cba62cad7047d596b06551eca31feff4d44a892b) ocamlPackages.rfc7748: fix for OCaml ≥ 5.0
* [`5bd5a258`](https://github.com/NixOS/nixpkgs/commit/5bd5a25808dc23a702d4aeb334555285d29cc2a6) ocamlPackages.sosa: fix for OCaml ≥ 5.0
* [`6f3cf1c1`](https://github.com/NixOS/nixpkgs/commit/6f3cf1c1a8f6ba1915cd8619458abaf86f347946) ocamlPackages.xenstore-tool: fix for OCaml ≥ 5.0
* [`b0f41a7c`](https://github.com/NixOS/nixpkgs/commit/b0f41a7c3af0ffaccc68ee1c6bda54f75f7674b8) scheherazade-new: 3.300 → 4.000
* [`53e5d09b`](https://github.com/NixOS/nixpkgs/commit/53e5d09b2d2050b2a4e5cf5fd2217bb466c8ed24) bibtex-tidy: use buildNpmPackage
* [`d213d1e1`](https://github.com/NixOS/nixpkgs/commit/d213d1e173c657498d408a92fbdacef955d51e3b) ocamlPackages.ptime: 1.0.0 -> 1.1.0
* [`7e54422b`](https://github.com/NixOS/nixpkgs/commit/7e54422bf9c323ce1aef3063dcd1108910b2b4c8) ledger-live-desktop: 2.64.1 -> 2.64.2
* [`45a973d3`](https://github.com/NixOS/nixpkgs/commit/45a973d3f0e68dbf5cd4d267a097c5329dc9d850) grcov: 0.8.18 -> 0.8.19
* [`0bd14a0c`](https://github.com/NixOS/nixpkgs/commit/0bd14a0cc02d2b5f9978c41c452662df8bc403fc) d2: 0.5.1 -> 0.6.0
* [`a9e76af1`](https://github.com/NixOS/nixpkgs/commit/a9e76af1b9ef7a5e00690907cf00fa8c696eb76b) kdocker: init at 5.4
* [`dd1154c1`](https://github.com/NixOS/nixpkgs/commit/dd1154c11c5bda5e36cb132a3ef43f68e58afb68) go-task: 3.27.1 -> 3.28.0
* [`012ff4f8`](https://github.com/NixOS/nixpkgs/commit/012ff4f8b039d5f78a1b4e38a4b1c0261e5b1efd) keycloak.plugins.keycloak-metrics-spi: build from source
* [`f4105cf5`](https://github.com/NixOS/nixpkgs/commit/f4105cf5bad6553b2bf8f29bde724bee7e075ac9) ghorg: 1.9.6 -> 1.9.7
* [`bf7cfe89`](https://github.com/NixOS/nixpkgs/commit/bf7cfe89530b28b4cfb9615b6537200b7abd64cc) libraqm: init at 0.10.1
* [`c38219f1`](https://github.com/NixOS/nixpkgs/commit/c38219f1ced7f1d0d83606abea3a1576c0fc2ce0) nushell: 0.83.0 -> 0.83.1
* [`5becdd85`](https://github.com/NixOS/nixpkgs/commit/5becdd85fcee634edeba5e6feef3bd3ef23ac510) nu_scripts: unstable-2023-07-24 -> unstable-2023-07-29
* [`f7a4a376`](https://github.com/NixOS/nixpkgs/commit/f7a4a3764f3675af8d7aec314a550546cd603f0c) nushellPlugins.gstat: 0.83.0 -> 0.83.1
* [`5ba1b5be`](https://github.com/NixOS/nixpkgs/commit/5ba1b5be5a22b2f955ee294d347ba8b76e172bc2) nushellPlugins.query: 0.83.0 -> 0.83.1
* [`c1d8ad53`](https://github.com/NixOS/nixpkgs/commit/c1d8ad53ece0a509091529f1f89cc4c2ae67bc94) sketchybar: use `finalAttrs` pattern
* [`956bdd6f`](https://github.com/NixOS/nixpkgs/commit/956bdd6f2268a0ba2fe9b95d6842b570bb36065f) ogre_14: init at 14.0.1
* [`ad796a73`](https://github.com/NixOS/nixpkgs/commit/ad796a732d0bc85fd0c68c33ca8f388cebbb021d) keycloak-scim-user-storage-api: 20230412 -> 20230710
* [`fcc76889`](https://github.com/NixOS/nixpkgs/commit/fcc768897b8c42690aabd2f481ecf73138969cad) vengi-tools: 0.0.24 -> 0.0.25
* [`45cbde5b`](https://github.com/NixOS/nixpkgs/commit/45cbde5b8d7f193faacb00828509dce5f26131eb) gnubg: 1.06.002 -> 1.07.001
* [`bf287a02`](https://github.com/NixOS/nixpkgs/commit/bf287a02caa56ce0c71e01723315894af2f062d0) gnubg: add desktop item
* [`8c028ce6`](https://github.com/NixOS/nixpkgs/commit/8c028ce6ff47689f444f77fc66baf8a898021381) maintainers: add rs0vere
* [`27a2a7e5`](https://github.com/NixOS/nixpkgs/commit/27a2a7e519b8014130a4af846a92bd0668bd1c5b) trino-cli: 418 -> 422
* [`b4395db6`](https://github.com/NixOS/nixpkgs/commit/b4395db6756b2872fadbd8060d35a8a2e1f23f5b) hmcl: init at 3.5.5
* [`69bc2ad7`](https://github.com/NixOS/nixpkgs/commit/69bc2ad72fb743b7581a01c59e73a839a6d83c87) matrix-appservice-irc: 0.38.0 -> 1.0.1
* [`3b0560c6`](https://github.com/NixOS/nixpkgs/commit/3b0560c6d93c0be269c31b4910e1c6cff3df569e) unifi-protect-backup: 0.9.1 -> 0.9.4
* [`237fb148`](https://github.com/NixOS/nixpkgs/commit/237fb1483246285ce1ed60e6ab40d760a8f7af06) matrix-appservice-slack: 2.1.1 -> 2.1.2
* [`bcb34716`](https://github.com/NixOS/nixpkgs/commit/bcb347160cb0b728048a4435d674b8fb28a51a31) matrix-hookshot: 4.4.0 -> 4.4.1
* [`e513d4f7`](https://github.com/NixOS/nixpkgs/commit/e513d4f71f7d2b06c60e54e9a3f31561eea1d636) semgrep{,-core}: 1.27.0 -> 1.34.1
* [`f66a1742`](https://github.com/NixOS/nixpkgs/commit/f66a17427221bbbb76bdd5ef8011030341c4a457) texstudio: 4.5.2 -> 4.6.2
* [`07347b53`](https://github.com/NixOS/nixpkgs/commit/07347b5352cd1ba9f80930690638980600a503ee) texstudio: qt5 -> qt6
* [`48d622fe`](https://github.com/NixOS/nixpkgs/commit/48d622fe551fb2a269a0260e35593b97432b31b6) git-cinnabar: 0.6.1 -> 0.6.2
* [`0261a4fc`](https://github.com/NixOS/nixpkgs/commit/0261a4fc378952310bf371c1ad9d6931c6596914) cp2k: 2023.1 -> 2023.2
* [`0b5456b3`](https://github.com/NixOS/nixpkgs/commit/0b5456b363efbe38e14b7481f990f8de535165a5) firefox-unwrapped: 115.0.2 -> 115.0.3 ([nixos/nixpkgs⁠#246324](https://togithub.com/nixos/nixpkgs/issues/246324))
* [`79e370f2`](https://github.com/NixOS/nixpkgs/commit/79e370f220bfa77cb6e818500876038ab00666a2) espup: init at 0.4.1
* [`4b3d2bd4`](https://github.com/NixOS/nixpkgs/commit/4b3d2bd40e18fd326432decf70a92cb11af1c1f1) maintainers: add knightpp
* [`b6adf477`](https://github.com/NixOS/nixpkgs/commit/b6adf477384bdb5f2237c0efaaab05be77021798) python310Packages.azure-mgmt-authorization: 3.0.0 -> 4.0.0
* [`72d4cb47`](https://github.com/NixOS/nixpkgs/commit/72d4cb47279ab49c6de2121f6c7a4fd7999e6d5b) hugo: 0.115.4 -> 0.116.0
* [`86a31e1e`](https://github.com/NixOS/nixpkgs/commit/86a31e1efa4418d18c0a7c1c7936b5b7511b493d) init tesh at 0.3.0: TEstable SHell sessions in Markdown
* [`9809ccfa`](https://github.com/NixOS/nixpkgs/commit/9809ccfa25eb05942a5320d5e9a907846d5a681e) mysql-shell: 8.0.33 -> 8.0.34
* [`24e2bb4e`](https://github.com/NixOS/nixpkgs/commit/24e2bb4e8c09ff245162860f0201a1e1a3f68dc0) amdgpu_top: 0.1.9 -> 0.1.11
* [`31d4a4af`](https://github.com/NixOS/nixpkgs/commit/31d4a4af19f34cf1e3df9f6760396e3f133425fc) nixos/bird: fix checkConfig with cross-compilation
* [`403f35e9`](https://github.com/NixOS/nixpkgs/commit/403f35e92ff9bd82be6f23b82dcbeccb6e8f14d9) proxysql: use `finalAttrs` pattern
* [`0445837c`](https://github.com/NixOS/nixpkgs/commit/0445837cc7aeb9ad73c51f20ba0b71295be367cc) nixos/fish: fix cross build
* [`25dc50e6`](https://github.com/NixOS/nixpkgs/commit/25dc50e6df4818aea2001f604dc8d2e87d949f09) python310Packages.azure-mgmt-network: 23.1.0 -> 24.0.0
* [`c1b8959e`](https://github.com/NixOS/nixpkgs/commit/c1b8959ecdf8dd3ad26ff7bd2498234a2bb9b06c) rehex: 0.5.4 -> 0.60.1
* [`a72614f0`](https://github.com/NixOS/nixpkgs/commit/a72614f09300b02e79bef0193fe2d0a579a5aa9e) python310Packages.mwdblib: 4.4.0 -> 4.5.0
* [`819bb53c`](https://github.com/NixOS/nixpkgs/commit/819bb53c2c49065ece6bfc4eb5d97eff08f0eda4) nvc: 1.10.0 -> 1.10.1
* [`07c88c96`](https://github.com/NixOS/nixpkgs/commit/07c88c96579b2e51fa4055256ad5b7d149e3523e) python310Packages.pyvista: 0.40.1 -> 0.41.1
* [`176f7e77`](https://github.com/NixOS/nixpkgs/commit/176f7e778f1ec77aabfde36bd2585415d936e8f0) yutto: 2.0.0b24 -> 2.0.0b28
* [`70bd808e`](https://github.com/NixOS/nixpkgs/commit/70bd808e818e26175b4b82635e0ebaf523be3652) mastodon: 4.1.5 -> 4.1.6 ([nixos/nixpkgs⁠#246348](https://togithub.com/nixos/nixpkgs/issues/246348))
* [`9d789710`](https://github.com/NixOS/nixpkgs/commit/9d78971007802fc8c4a30cb9e64645b624a6e4ab) nixos/boot/initrd-network: add option to enable udhcpc ([nixos/nixpkgs⁠#240406](https://togithub.com/nixos/nixpkgs/issues/240406))
* [`6dfbb7c8`](https://github.com/NixOS/nixpkgs/commit/6dfbb7c89f716038a2567d6eb6f7f86e52cc876f) ocamlPackages.ptime: use `finalAttrs` pattern
* [`9ea70cf7`](https://github.com/NixOS/nixpkgs/commit/9ea70cf76f37f31c63626ef47bdf5e3727633184) backintime-common: add missing dependency 'packaging'
* [`0ade0802`](https://github.com/NixOS/nixpkgs/commit/0ade08025f12e1b419b6ea66ef8e6cddafeb4f02) textadept:11.4 -> 12.0
* [`9520bdd0`](https://github.com/NixOS/nixpkgs/commit/9520bdd08839adb23d5750fb659871273e197038) code-server: 4.15.0 -> 4.16.0
* [`38a927f1`](https://github.com/NixOS/nixpkgs/commit/38a927f1fb7719ed13bc13a6a419a923297fda05) nixdoc: 2.3.0 -> 2.4.0
* [`0cfbbe92`](https://github.com/NixOS/nixpkgs/commit/0cfbbe928a6b94d4d38b9341a8d3972f55462c2d) python310Packages.mypy-boto3-s3: 1.28.12 -> 1.28.15.post1
* [`daa869b5`](https://github.com/NixOS/nixpkgs/commit/daa869b53b560ca9a0acfb9c6f26924466a15cdb) tracker: fix cross using mesonEmulatorHook
* [`a676b98b`](https://github.com/NixOS/nixpkgs/commit/a676b98bf0d5b3d76e2c38c3f02875a93b50e941) libsForQt5.mlt: 7.16.0 -> 7.18.0
* [`022d53ed`](https://github.com/NixOS/nixpkgs/commit/022d53ede9c920f28e97e83794798e2dfa9c49dc) python310Packages.ttstokenizer: init at 1.0.0
* [`21ad1050`](https://github.com/NixOS/nixpkgs/commit/21ad1050bf67f6a31acc38d41b7999e1a0bd0ca0) gopls: 0.12.4 -> 0.13.0 ([nixos/nixpkgs⁠#246366](https://togithub.com/nixos/nixpkgs/issues/246366))
* [`0ccd0c3c`](https://github.com/NixOS/nixpkgs/commit/0ccd0c3c3e31e72592dc46e371ec77690795da78) spectacle: backport a patch to fix region capture preview being misaligned
* [`b0e1416a`](https://github.com/NixOS/nixpkgs/commit/b0e1416a6b7fff4e3c4c837d1d7b0cf4910e63e3) karma: use buildNpmPackage
* [`e75a8ae6`](https://github.com/NixOS/nixpkgs/commit/e75a8ae64834b45486c5b1e322b4b178ffc85f97) karma: 0.114 -> 0.115
* [`8aa5c814`](https://github.com/NixOS/nixpkgs/commit/8aa5c814085bc5b75632154eec4121b45c4d5c05) xournalpp: 1.1.3 -> 1.2.0
* [`bb2fd1be`](https://github.com/NixOS/nixpkgs/commit/bb2fd1be106ae26671b4a5533199401ba3b9cbd0) botan: fix cross compilation on aarch64
* [`930080b0`](https://github.com/NixOS/nixpkgs/commit/930080b04eceda49805a9250dfc66169d8cb9bda) python310Packages.aiopvpc: 4.2.1 -> 4.2.2
* [`6a08fa52`](https://github.com/NixOS/nixpkgs/commit/6a08fa5215193c4ff599b2c5e37da0f42f0cb492) juicity: 0.1.0 -> 0.1.1
* [`63ac8333`](https://github.com/NixOS/nixpkgs/commit/63ac833319dd7e85aa400b8134b8966cff972ab1) obsidian: 1.3.5 -> 1.3.7
* [`e6e16bc1`](https://github.com/NixOS/nixpkgs/commit/e6e16bc11843045aa95dbe1194f9bf0cbb083e0e) lib.getExe: Do not make assumptions about the main program
* [`1027dd69`](https://github.com/NixOS/nixpkgs/commit/1027dd692c39c56e38e724f0cacf4d4237ea1b25) gtop: use buildNpmPackage
* [`89ed1546`](https://github.com/NixOS/nixpkgs/commit/89ed15464cdd0b21ed0bfd87f86be5e5256843fa) libgudev: fix cross
* [`02169286`](https://github.com/NixOS/nixpkgs/commit/021692865a0e1fbce7d32be7f289f2041299bd31) matrix-synapse.plugins.matrix-synapse-s3-storage-provider: init at 1.2.1 ([nixos/nixpkgs⁠#229192](https://togithub.com/nixos/nixpkgs/issues/229192))
* [`946f7868`](https://github.com/NixOS/nixpkgs/commit/946f7868f04239d2285cb06ed3a0c9d04b0e534c) kubectl-explore: init at 0.7.1
* [`458308d1`](https://github.com/NixOS/nixpkgs/commit/458308d15f23149c9466879847e4e36ce1396fc5) maintainers: add koralowiec
* [`8ab3c9ed`](https://github.com/NixOS/nixpkgs/commit/8ab3c9edf8bb695d1004fd9a4c9f30043088386f) process-compose: 0.51.4 -> 0.60.0
* [`26e8499f`](https://github.com/NixOS/nixpkgs/commit/26e8499f22ba8ba5005f6a573d2d4df453e56d33) minify: 2.12.7 -> 2.12.8
* [`2df128a4`](https://github.com/NixOS/nixpkgs/commit/2df128a4eff1681a9c9091fec5a72e5bfb7ab3dd) python310Packages.graphene: 3.2.2 -> 3.3.0
* [`3a9486d6`](https://github.com/NixOS/nixpkgs/commit/3a9486d67a42e67755364390059ab5b883fc3a68) urn-timer: unstable-2023-07-01 -> unstable-2023-07-31
* [`5f68deff`](https://github.com/NixOS/nixpkgs/commit/5f68deff215080ef3ecdf9a5b1a7bf866cfc70d8) nerdctl: 1.4.0 -> 1.5.0
* [`516ca7d8`](https://github.com/NixOS/nixpkgs/commit/516ca7d8a332ae784d0f4c06d460aa61dd11b463) notes: init at 2.2.0
* [`d64cc4bd`](https://github.com/NixOS/nixpkgs/commit/d64cc4bd17f6a377cb7cedfe1f4da245d5a9d13a) imagemagick: 7.1.1-14 -> 7.1.1-15
* [`bc65031e`](https://github.com/NixOS/nixpkgs/commit/bc65031eba8feef02db5e0f868c366cd966cbe12) yuzu-ea: 3702 -> 3783, yuzu-mainline: 1475 -> 1513
* [`ec1431a5`](https://github.com/NixOS/nixpkgs/commit/ec1431a59ec3dda9098f61be00b2ab5be9a84360) ruff: 0.0.280 -> 0.0.281
* [`bf67dadd`](https://github.com/NixOS/nixpkgs/commit/bf67dadda4e8b52878bb6d6fb72b49b8a68883bd) qovery-cli: 0.61.0 -> 0.63.0
* [`e0f32f89`](https://github.com/NixOS/nixpkgs/commit/e0f32f89449cbd52c8cf24050c10a5ff61f03510) buildMavenPackage: inherit maven
* [`3d5cfe2f`](https://github.com/NixOS/nixpkgs/commit/3d5cfe2f1048f5432d79b0a02ab89a9018b808fd) terrascan: 1.18.1 -> 1.18.2
* [`e658ffa9`](https://github.com/NixOS/nixpkgs/commit/e658ffa994c2e356fb9387c02e5204df5e590a94) treewide: cleanup maven packages
* [`30464bb5`](https://github.com/NixOS/nixpkgs/commit/30464bb5c54d8c706443f433db6777284b8a99d2) treewide: fix mvnHash
* [`544eb3d6`](https://github.com/NixOS/nixpkgs/commit/544eb3d6faee05138c0c1c9299f7e5eaf751574b) python311Packages.reolink-aio: 0.7.3 -> 0.7.6
* [`d36353cf`](https://github.com/NixOS/nixpkgs/commit/d36353cf86b485131d8220f952ce3cc5537687f1) nixos/oddjob: Maybe fix, but mark as broken
* [`c613ccf1`](https://github.com/NixOS/nixpkgs/commit/c613ccf1f878481762e7e5ff9a6b3d16f58ac3bd) python310Packages.types-tabulate: 0.9.0.2 -> 0.9.0.3
* [`4e862547`](https://github.com/NixOS/nixpkgs/commit/4e862547cca09b1354dd8fb4a212f1568b62cbb0) vscode-extensions.emroussel.atomize-atom-one-dark-theme: init at 2.0.2
* [`869f62aa`](https://github.com/NixOS/nixpkgs/commit/869f62aa48fa76aa0909f80630c8517a7f09ff0a) vscode-extensions.wmaurer.change-case: init at 1.0.0
* [`637af7a0`](https://github.com/NixOS/nixpkgs/commit/637af7a0fc7cd6b0ae3485feba896bb3eea0728e) vscode-extensions.bierner.docs-view: init at 0.0.11
* [`fb22f5b8`](https://github.com/NixOS/nixpkgs/commit/fb22f5b887f82604ed0536d268e655e4b3435eee) vscode-extensions.unifiedjs.vscode-mdx: init at 1.4.0
* [`3f525f2c`](https://github.com/NixOS/nixpkgs/commit/3f525f2cb90e972e0c0492ec1e429ffb8e3f16f6) vscode-extensions.enkia.tokyo-night: init at 1.0.0
* [`eee1968d`](https://github.com/NixOS/nixpkgs/commit/eee1968d375560eea1c392132a7b2dfb34cbfc96) vscode-extensions.dotenv.dotenv-vscode: init at 0.28.0
* [`4c1d3cee`](https://github.com/NixOS/nixpkgs/commit/4c1d3cee607c7e37ae1129836930fb5b9003af23) treewide: Add meta.mainProgram
* [`11ac0cad`](https://github.com/NixOS/nixpkgs/commit/11ac0cadf063287e6ab6d32db669015fb9e8e6f4) metasploit: 6.3.26 -> 6.3.27
* [`d4352f40`](https://github.com/NixOS/nixpkgs/commit/d4352f4098f4bdb8f42f4aeb51ead10ac8fd5c7b) jdt-language-server: 1.21.0 -> 1.26.0
* [`0700a52a`](https://github.com/NixOS/nixpkgs/commit/0700a52ae2285a74d3d916538570811ce2a6d61e) dnsrecon: 1.1.4 -> 1.1.5
* [`124f4800`](https://github.com/NixOS/nixpkgs/commit/124f4800ff86667bcf1ce3a5d1c587f7ebc41d98) apkid: 2.1.4 -> 2.1.5
* [`f6aa3f51`](https://github.com/NixOS/nixpkgs/commit/f6aa3f512c4d0b43385aa4b43729d6cc306e1b94) python311Packages.vsure: 2.6.2 -> 2.6.4
* [`e84e4e46`](https://github.com/NixOS/nixpkgs/commit/e84e4e46d5fbd3140c5a9a88ba8b2925f8643113) tilt: 0.33.1 -> 0.33.3
* [`e278cb21`](https://github.com/NixOS/nixpkgs/commit/e278cb21fd41386cd717f43b04283cd693be297d) python311Packages.python-roborock: 0.30.2 -> 0.30.3
* [`78da6da2`](https://github.com/NixOS/nixpkgs/commit/78da6da249f1a3c608803d0049487bc898327633) python311Packages.pywemo: 1.1.0 -> 1.2.0
* [`57f4bdf4`](https://github.com/NixOS/nixpkgs/commit/57f4bdf484c4d5d64c3ea5576ebbc85dd635afc4) git-cinnabar: use `finalAttrs` pattern
* [`d32e0305`](https://github.com/NixOS/nixpkgs/commit/d32e030506c510069c1f594ba2a611deb56a65d9) vscode-extensions.mkhl.direnv: 0.13.0 -> 0.14.0
* [`925f72c6`](https://github.com/NixOS/nixpkgs/commit/925f72c696727156f4066729c29fbcee8d853cd2) dune_3: 3.9.2 -> 3.10.0
* [`c11dd78f`](https://github.com/NixOS/nixpkgs/commit/c11dd78f49a44794eaf16e3876cb99aca63a2b64) linuxKernel.kernels.linux_zen: 6.4.6-zen1 -> 6.4.7-zen1
* [`72ed94cd`](https://github.com/NixOS/nixpkgs/commit/72ed94cd1a01e12a3c1b050957b56e79b5bac893) linuxKernel.kernels.linux_zen: 6.4.6-lqx1 -> 6.4.7-lqx1
* [`062b7457`](https://github.com/NixOS/nixpkgs/commit/062b745704093f27ec938c8df6dc9c7f00ae8034) sagoin: 0.2.2 -> 0.2.3
* [`a8b50538`](https://github.com/NixOS/nixpkgs/commit/a8b5053805b3a9734000c20475d5eeb2eafb0fd1) skhd: 0.3.5 -> 0.3.9
* [`684f3c72`](https://github.com/NixOS/nixpkgs/commit/684f3c72b469c359dc5057c2468c4ebc5971c138) skhd: use `finalAttrs` pattern
* [`55a4d6be`](https://github.com/NixOS/nixpkgs/commit/55a4d6be907ba43d79e40da9f7faf27deb4a80ef) fluffychat: use 'pname' instead of 'name'
* [`9f51c70b`](https://github.com/NixOS/nixpkgs/commit/9f51c70b4f37cb70d918dfd566184f04c8bc7615) maintainers: add justinlime
* [`2107f93e`](https://github.com/NixOS/nixpkgs/commit/2107f93efce9e3495842672c59be97947ffbae07) weechat: set mainProgram
* [`65023ddb`](https://github.com/NixOS/nixpkgs/commit/65023ddb58d728bb998d9019e5aae773de9f636e) maintainers.anselmschueler: add pgp key
* [`12ac911b`](https://github.com/NixOS/nixpkgs/commit/12ac911bf8e74c8172e5fbceb31401dce1230239) ollama: init at 0.0.12
* [`d78c7243`](https://github.com/NixOS/nixpkgs/commit/d78c7243b329d9fb74d8687e4c23c1150a094fca) farge: fix dependencies & font issue
* [`058f8493`](https://github.com/NixOS/nixpkgs/commit/058f8493a4bf5e0cd4b54f8496f68deae3c3e56a) threema-desktop: 1.2.27→ 1.2.31
* [`5296e4d4`](https://github.com/NixOS/nixpkgs/commit/5296e4d48f0868346e4dabd4d6416be3fdc492ad) firefox-unwrapped: 115.0.3 -> 116.0
* [`d3f038b1`](https://github.com/NixOS/nixpkgs/commit/d3f038b168fc5b631f247930ce38e48ca0473132) firefox-bin-unwrapped: 115.0.2 -> 116.0
* [`e6f8d33e`](https://github.com/NixOS/nixpkgs/commit/e6f8d33ee801556f051b532028a5a093b3623c76) firefox-esr-115-unwrapped: 115.0.3esr -> 115.1.0esr
* [`88e23bca`](https://github.com/NixOS/nixpkgs/commit/88e23bcaf717612f400b1951be115443c6b656cc) firefox-esr-102-unwrapped: 102.13.0esr -> 102.14.0esr
* [`ea0e99fa`](https://github.com/NixOS/nixpkgs/commit/ea0e99fa2681d9fb2a4d4d6b42ba16fe630e5125) firefox-esr-unwrapped: migrate to 115 ESR series
* [`bff917a3`](https://github.com/NixOS/nixpkgs/commit/bff917a3ed37b1f9e705b5c07210acd295691770) AusweisApp2: 1.26.5 -> 1.26.7
* [`e98bea13`](https://github.com/NixOS/nixpkgs/commit/e98bea13f9aa88cf06a3ad0a69d4739b6207e72d) aliyun-cli: 3.0.169 -> 3.0.170
* [`01644616`](https://github.com/NixOS/nixpkgs/commit/0164461684445b87208aa73cf3f456e55e8cb832) qrcodegen: refactor
* [`7d4892c6`](https://github.com/NixOS/nixpkgs/commit/7d4892c6876d2ed772042c31471da64f97e488a4) maintainers: remove mcbeth
* [`aeeda1c3`](https://github.com/NixOS/nixpkgs/commit/aeeda1c346453f037ab4d95bffd89b16eac225a1) bearer: 1.16.0 -> 1.17.0
* [`7e9bd874`](https://github.com/NixOS/nixpkgs/commit/7e9bd8747ee4006f067f094e0843513de0a482d5) vscode-extensions.serayuzgur.crates: 0.5.10 → 0.6.0
* [`f6ac56eb`](https://github.com/NixOS/nixpkgs/commit/f6ac56ebed3476362d4424c7b87519b68e96e509) bazarr: 1.2.3 -> 1.2.4
* [`7592343f`](https://github.com/NixOS/nixpkgs/commit/7592343f14bb7d4100e23a324584fd98de208ea5) avrdude: 7.1 -> 7.2
* [`6948d36b`](https://github.com/NixOS/nixpkgs/commit/6948d36b2cb4b49a82a9ff5aa273d0b183312af8) linux: 5.10.187 -> 5.10.188
* [`19f617fa`](https://github.com/NixOS/nixpkgs/commit/19f617fa72cf3613f83623fd4287f99d3e2306be) linux: 5.15.122 -> 5.15.123
* [`09f94571`](https://github.com/NixOS/nixpkgs/commit/09f94571ebd9561e9c30d4c75b3d253691fb937d) linux: 5.4.250 -> 5.4.251
* [`3cbc1fc7`](https://github.com/NixOS/nixpkgs/commit/3cbc1fc7bb267a6b4a8107d8f9dddce02322cb14) linux: 6.1.41 -> 6.1.42
* [`9dd903ca`](https://github.com/NixOS/nixpkgs/commit/9dd903ca6306961590d565272b2b30c08136ee9e) linux: 6.4.6 -> 6.4.7
* [`cc26897d`](https://github.com/NixOS/nixpkgs/commit/cc26897da9bb2bb5519b6832e2e9c743bfd7d831) linux/hardened/patches/5.10: 5.10.187-hardened1 → 5.10.188-hardened1
* [`a05924dc`](https://github.com/NixOS/nixpkgs/commit/a05924dc861557e6e3cdf7714fb304de66faf6b8) linux/hardened/patches/5.15: 5.15.122-hardened1 → 5.15.123-hardened1
* [`643694ae`](https://github.com/NixOS/nixpkgs/commit/643694ae27cb614f4fd9a2003f94c469d32679ef) linux/hardened/patches/5.4: 5.4.250-hardened1 → 5.4.251-hardened1
* [`fc861244`](https://github.com/NixOS/nixpkgs/commit/fc86124473ed5fc124edb5bb6ad26535a58a895c) linux/hardened/patches/6.1: 6.1.41-hardened1 → 6.1.42-hardened1
* [`580cd965`](https://github.com/NixOS/nixpkgs/commit/580cd965b80b924c69fb8e8cc13c9292cb0dc66f) linux/hardened/patches/6.4: 6.4.6-hardened1 → 6.4.7-hardened1
* [`2b664fb0`](https://github.com/NixOS/nixpkgs/commit/2b664fb088b3986057d26541f17ae72d1334b3e0) adguardhome: 0.107.34 -> 0.107.35
* [`bc5fd403`](https://github.com/NixOS/nixpkgs/commit/bc5fd40358eb13325c1f68c0e1f375f9cb147f9a) libgpiod: fix src hash
* [`65047c0c`](https://github.com/NixOS/nixpkgs/commit/65047c0c0f7a685bf1c88854311a1a624064b642) libgpiod: drop outdated patch
* [`1eb9b0f9`](https://github.com/NixOS/nixpkgs/commit/1eb9b0f9b681c26334b6cc165b01b8196122ad73) specr-transpile: init at 0.1.20
* [`646b556f`](https://github.com/NixOS/nixpkgs/commit/646b556f90002f57bce4f5fa62b582f7d030e58a) azure-storage-azcopy: 10.19.0 -> 10.20.0
* [`80d4b035`](https://github.com/NixOS/nixpkgs/commit/80d4b03586abb6a8b5aba586ee185191efebde45) assemblyscript: 0.27.5 -> 0.27.6
* [`bafc87ee`](https://github.com/NixOS/nixpkgs/commit/bafc87ee1279f9f10690056df15066258b4f310b) ast-grep: 0.9.2 -> 0.10.0
* [`0d28359c`](https://github.com/NixOS/nixpkgs/commit/0d28359c911e90d90894bf8af487e8ae629486c4) xfce.xfce4-clipman-plugin: 1.6.3 -> 1.6.4
* [`30e4b015`](https://github.com/NixOS/nixpkgs/commit/30e4b015dfce1b8111ebcb3277e8b6660c5f2f90) bacon: 2.12.0 -> 2.12.1
* [`019d9ec5`](https://github.com/NixOS/nixpkgs/commit/019d9ec5d9013ccc311e52a42870df6c8c402c7a) aravis: 0.8.27 -> 0.8.28
* [`96d403ee`](https://github.com/NixOS/nixpkgs/commit/96d403ee2479f2070050353b94808209f1352edb) pythia: 8.309 -> 8.310 ([nixos/nixpkgs⁠#246455](https://togithub.com/nixos/nixpkgs/issues/246455))
* [`c52ce848`](https://github.com/NixOS/nixpkgs/commit/c52ce848e88d9f32d4c863e67fd7d7333b1b42cf) vscode-extensions.usernamehw.errorlens: 3.8.0 -> 3.12.0
* [`6fce47d4`](https://github.com/NixOS/nixpkgs/commit/6fce47d4d1c7f4a5687c0f9a69b2b253944c4c6d) prometheus-sachet: 0.3.1 -> 0.3.2
* [`487c6ac2`](https://github.com/NixOS/nixpkgs/commit/487c6ac2bde71c2513cc40524ff7ace3e2f778f1) bcftools: 1.17 -> 1.18
* [`bd03eac9`](https://github.com/NixOS/nixpkgs/commit/bd03eac9ef8056ac9994192ccc98b122459f0c3c) libreoffice-bin: 7.4.7 -> 7.5.5
* [`5ea94a7d`](https://github.com/NixOS/nixpkgs/commit/5ea94a7d2c3ff7c0222b39519e17b451c0e2d739) grype: 0.64.2 -> 0.65.0
* [`14fe716c`](https://github.com/NixOS/nixpkgs/commit/14fe716c14b6b236e2d85a26de0cc11187407df6) python310Packages.google-cloud-translate: 3.11.2 -> 3.11.3
* [`9d882891`](https://github.com/NixOS/nixpkgs/commit/9d8828915bd4731d25b8d92d61832722c8f0685e) sing-box: 1.3.4 -> 1.3.5
* [`00acd521`](https://github.com/NixOS/nixpkgs/commit/00acd52145cdd06e0f12317b14f57e551c30f42c) libmodsecurity: 3.0.9 -> 3.0.10
* [`97588fcd`](https://github.com/NixOS/nixpkgs/commit/97588fcdb27354c3226e658cda3c50588def21f1) polaris: 0.13.5 -> 0.14.0
* [`9c5f0aac`](https://github.com/NixOS/nixpkgs/commit/9c5f0aacfa8f4dc1aa082e80359b617a2e7aa965) allure: 2.23.0 -> 2.23.1
* [`43696083`](https://github.com/NixOS/nixpkgs/commit/436960830627e55d8e6c601be064ceda52ec6f6c) circt: 1.45.0 -> 1.48.0
* [`444797ac`](https://github.com/NixOS/nixpkgs/commit/444797ac0240a84157d685ab9513bfc7bdd568ff) circt: fix version info
* [`409982ac`](https://github.com/NixOS/nixpkgs/commit/409982ace43554a3d221bfa3e56bbe51bc3abe4c) python310Packages.meeko: 0.4.0 -> 0.5.0
* [`891b97ca`](https://github.com/NixOS/nixpkgs/commit/891b97ca5c6524d1416e9e8a9fa3b7efd3062751) offpunk: 1.9.2 -> 1.10
* [`47528410`](https://github.com/NixOS/nixpkgs/commit/47528410f55973504a610c7a21ea2f52e80eef02) terraform-providers.buildkite: 0.21.2 -> 0.22.0
* [`c177cbaf`](https://github.com/NixOS/nixpkgs/commit/c177cbaf2e88305b4a40cd6cd1a23a692030cc59) terraform-providers.alicloud: 1.208.0 -> 1.208.1
* [`f9d80454`](https://github.com/NixOS/nixpkgs/commit/f9d8045440b2e11f9e989faaadc896cac638601e) terraform-providers.google: 4.75.1 -> 4.76.0
* [`615056cb`](https://github.com/NixOS/nixpkgs/commit/615056cba5fcc681a4253e97f3697e84e54a4fd8) terraform-providers.huaweicloud: 1.52.1 -> 1.53.0
* [`10161f84`](https://github.com/NixOS/nixpkgs/commit/10161f84e3ea759816a53658ee39f6527af89c41) terraform-providers.google-beta: 4.75.1 -> 4.76.0
* [`b2e3b4f6`](https://github.com/NixOS/nixpkgs/commit/b2e3b4f6b844e3f27084dbc5a065a8e0a4c3a8bd) terraform-providers.opennebula: 1.2.2 -> 1.3.0
* [`24631ebe`](https://github.com/NixOS/nixpkgs/commit/24631ebe1f85a52312031169415964df2b6d2266) terraform-providers.snowflake: 0.68.2 -> 0.69.0
* [`b0b6752a`](https://github.com/NixOS/nixpkgs/commit/b0b6752ad4d30d6f0bbebaff37feac75a6905d18) terraform-providers.yandex: 0.95.0 -> 0.96.1
* [`b13c0104`](https://github.com/NixOS/nixpkgs/commit/b13c0104a6e4758b47c447db64872753c330c7fc) terraform-providers.tencentcloud: 1.81.17 -> 1.81.18
* [`02add5a9`](https://github.com/NixOS/nixpkgs/commit/02add5a9cff50db2f48a50d1cf6c35e23ec576c6) fuzzel: 1.9.1 -> 1.9.2
* [`6a446660`](https://github.com/NixOS/nixpkgs/commit/6a446660229f6f202007b45a4771613c4c5ff060) ocamlPackages.x509: 0.16.4 -> 0.16.5
* [`69a9c350`](https://github.com/NixOS/nixpkgs/commit/69a9c3509e4799f19921b36228607b960e409d5a) dbip-country-lite: 2023-07 -> 2023-08
* [`0c388c5c`](https://github.com/NixOS/nixpkgs/commit/0c388c5c9d72e0479156b7cc2ad29476ad70d330) v2ray-domain-list-community: 20230725085751 -> 20230730120627
* [`b5de13f7`](https://github.com/NixOS/nixpkgs/commit/b5de13f73a66e3b9e5378b2876394957b4207b95) python310Packages.accelerate: 0.19.0 -> 0.21.0
* [`2838d990`](https://github.com/NixOS/nixpkgs/commit/2838d990639de962915b9701b1b0e3bc85938265) circt: refactor patch to substituteInPlace
* [`b0ba7d24`](https://github.com/NixOS/nixpkgs/commit/b0ba7d2406ef905c47656c0053e8c0453cab5397) nixos/tests/nextcloud: Fix broken webdav url
* [`f6cc80e7`](https://github.com/NixOS/nixpkgs/commit/f6cc80e7932b0f3664cd7637fc43bda3ec5e7f04) python311Packages.async-lru: 2.0.3 -> 2.0.4
* [`14cc800e`](https://github.com/NixOS/nixpkgs/commit/14cc800e2151a14b12190a47a3fd994921527576) vaultwarden: 1.29.0 -> 1.29.1
* [`48bbc6d9`](https://github.com/NixOS/nixpkgs/commit/48bbc6d96485d3222ba3f8bf94dba359c895f3bb) doc/maven: prefer maven.buildMavenPackage over mvn2nix
* [`9c13db21`](https://github.com/NixOS/nixpkgs/commit/9c13db213589ab77b57538b6c29c7480426a0b12) python310Packages.subarulink: 0.7.6-1 -> 0.7.7
* [`80b45192`](https://github.com/NixOS/nixpkgs/commit/80b45192a4ec0d604ac540dc14d2c9527da1a31d) uwsgi: 2.0.21 -> 2.0.22
* [`77829e44`](https://github.com/NixOS/nixpkgs/commit/77829e4496d188c93909e2dcfa68e092afaddb97) uwsgi: use `finalAttrs` pattern
* [`57304313`](https://github.com/NixOS/nixpkgs/commit/573043135592bb27f5b5e7214d7b8ce8f1493845) phrase-cli: 2.8.2 -> 2.8.4
* [`a50da75c`](https://github.com/NixOS/nixpkgs/commit/a50da75c9d6869b8fe68620b94717b7d06ecfcfe) unciv: 4.7.8-patch1 -> 4.7.11
* [`3a60b170`](https://github.com/NixOS/nixpkgs/commit/3a60b170e93d328141ff9f80f4f5a22997bde45a) codeql: 2.14.0 -> 2.14.1
* [`fc5ec900`](https://github.com/NixOS/nixpkgs/commit/fc5ec9004e7cfc7c9a6648d1af4be03700443566) kubeshark: 41.3 -> 41.6
* [`286e1914`](https://github.com/NixOS/nixpkgs/commit/286e1914ebdd24445b58f8b628c62df62d21cd71) convco: 0.4.0 -> 0.4.1
* [`2843aae3`](https://github.com/NixOS/nixpkgs/commit/2843aae36e59e2ceab1270aaebb71491124f4dd8) litefs: 0.5.1 -> 0.5.2
* [`a58db6d3`](https://github.com/NixOS/nixpkgs/commit/a58db6d363066ea95eddd9cd082d20aa6c15a1db) deepin.dde-calendar: 5.8.30 -> 5.10.1
* [`b62cc33c`](https://github.com/NixOS/nixpkgs/commit/b62cc33c4b6083b929e0eab20d81645de9e13807) dnsproxy: 0.51.0 -> 0.52.0
* [`9278b39e`](https://github.com/NixOS/nixpkgs/commit/9278b39e9012cb85ea41e578697caa873282d0bb) deepin-terminal: enable nixosTests.terminal-emulators
* [`d937df65`](https://github.com/NixOS/nixpkgs/commit/d937df65cadb80769e30b272d7b66eb7aa9f0b9c) hugo: 0.116.0 -> 0.116.1
* [`6fbb653d`](https://github.com/NixOS/nixpkgs/commit/6fbb653d0e1382a87f24b883a5322db201d21c7e) nixosTests.terminal-emulators: deprecated `machine' attribute by `nodes.machine'
* [`f048ac13`](https://github.com/NixOS/nixpkgs/commit/f048ac137f809dff57840e08928f729aa8e5a4d9) netsurf: rewrite
* [`69533f60`](https://github.com/NixOS/nixpkgs/commit/69533f60436c6309e859bce1905447a209dd6ffc) netsurf.buildsystem: rewrite
* [`4da2dd25`](https://github.com/NixOS/nixpkgs/commit/4da2dd2537d840774e6b2393817b48409ba7665d) netsurf.buildsystem: remove samueldr from meta.maintainers
* [`3c69727d`](https://github.com/NixOS/nixpkgs/commit/3c69727d690cc102a3599f2e411dc2d520d7681f) netsurf.libcss: rewrite
* [`122e4d26`](https://github.com/NixOS/nixpkgs/commit/122e4d2668bd7b4b6ee57ee47b2c884c7f76eb81) netsurf.libdom: rewrite
* [`01464665`](https://github.com/NixOS/nixpkgs/commit/01464665344357380298a586a86299aed9aa82e0) netsurf.libhubbub: rewrite
* [`7532dba8`](https://github.com/NixOS/nixpkgs/commit/7532dba814684525fb42f8f50a164e55e5d63aaf) netsurf.libnsbmp: rewrite
* [`fac9f0f2`](https://github.com/NixOS/nixpkgs/commit/fac9f0f2bc043b31efabd85599c1fadc61fdf7ad) netsurf.libnsfb: rewrite
* [`87f1a677`](https://github.com/NixOS/nixpkgs/commit/87f1a6779d63b7d1b85f94ec2e5c9f077a61ecd4) netsurf.libnsgif: rewrite
* [`83316029`](https://github.com/NixOS/nixpkgs/commit/833160293ddf368f05df1ab27d36c7e36991cdc5) netsurf.libnslog: rewrite
* [`d3a897ce`](https://github.com/NixOS/nixpkgs/commit/d3a897ce7b9b76a156b43bc5eb74d48f7e4b0ba7) netsurf.libnspsl: rewrite
* [`1cfc288a`](https://github.com/NixOS/nixpkgs/commit/1cfc288a9d06997d210ae749549259ebc721d123) netsurf.libnsutils: rewrite
* [`c69f48cb`](https://github.com/NixOS/nixpkgs/commit/c69f48cbe4c14eafe7b16e4f5084d443e83cb2a8) netsurf.libparserutils: rewrite
* [`7481369b`](https://github.com/NixOS/nixpkgs/commit/7481369b32ad5477263358029b1a25a42921e533) netsurf.libsvgtiny: rewrite
* [`f9ba74eb`](https://github.com/NixOS/nixpkgs/commit/f9ba74eb845390239e02b977488851647c7efb8c) netsurf.libutf8proc: rewrite
* [`ab1e4564`](https://github.com/NixOS/nixpkgs/commit/ab1e456470557d34589bd8b265e9c5e0fb5f3867) netsurf.libwapcaplet: rewrite
* [`84f2d4c5`](https://github.com/NixOS/nixpkgs/commit/84f2d4c55e012f9b4e62ce4aeda31935d31fbdc7) netsurf.nsgenbind: rewrite
* [`0cd95a61`](https://github.com/NixOS/nixpkgs/commit/0cd95a61f3bc7108f2c834abca9de050dac15485) netsurf.browser: rewrite
* [`a85a699e`](https://github.com/NixOS/nixpkgs/commit/a85a699e40708b452d36c70725396ff67dc48e66) zigHook: init
* [`9d9af3d4`](https://github.com/NixOS/nixpkgs/commit/9d9af3d49f42f3b45478783bb528dd1c525e14cc) zigHook: remove badPlatforms
* [`130d2fa5`](https://github.com/NixOS/nixpkgs/commit/130d2fa5e54a882ddd22ce8856c8aa81aee1040e) doc/hooks/index.md: add zig.section.md
* [`3788d280`](https://github.com/NixOS/nixpkgs/commit/3788d28081ade320eafb7ed7e80beb10eceac8f4) bun: 0.7.0 -> 0.7.1
* [`a282d365`](https://github.com/NixOS/nixpkgs/commit/a282d365927e4ddb1463eb7a432829e0033a8248) nixos/tests/binary-cache.nix: remove overuses of `with`
* [`eb03402e`](https://github.com/NixOS/nixpkgs/commit/eb03402e28f72690887d1eab28440d9bd193f233) nixos/tests/buildkite-agents.nix: remove overuses of `with`
* [`c532a4f2`](https://github.com/NixOS/nixpkgs/commit/c532a4f227954413d2dd0dea04976c9f6b8c0165) nixos/tests/deepin.nix: remove overuses of `with`
* [`62f6f010`](https://github.com/NixOS/nixpkgs/commit/62f6f01085a36111d92ec7617c6958f67de9235a) nixos/tests/initrd-network-ssh/default.nix: remove overuses of `with`
* [`c5ffb694`](https://github.com/NixOS/nixpkgs/commit/c5ffb694d9789688ae52af1fa9d528607be1e8e1) nixos/tests/osquery.nix: remove overuses of `with`
* [`2dd9923c`](https://github.com/NixOS/nixpkgs/commit/2dd9923c8aa058b7b2df28a6dfdae40d7defe3e3) nixos/tests/sftpgo.nix: remove overuses of `with`
* [`871bf7c8`](https://github.com/NixOS/nixpkgs/commit/871bf7c87545eeaf67d594d14f33f8bfc18674ac) nixos/tests/systemd-initrd-networkd-ssh.nix: remove overuses of `with`
* [`fd01b3f5`](https://github.com/NixOS/nixpkgs/commit/fd01b3f59c33fa4cd17cad256df92798f076678f) nixos/atuin: fix `database.createLocally` behaviour
* [`b6fbd873`](https://github.com/NixOS/nixpkgs/commit/b6fbd87328f8eabd82d65cc8f75dfb74341b0ace)  nixos/atuin: harden systemd unit
* [`34ee0260`](https://github.com/NixOS/nixpkgs/commit/34ee0260ec2efcde59948202b01c5799cb298d6b) treewide: Add meta.mainProgram
* [`0ed9e35a`](https://github.com/NixOS/nixpkgs/commit/0ed9e35a220b9de5b9462deba3900605e174809d) writers: Set mainProgram
* [`6be7022c`](https://github.com/NixOS/nixpkgs/commit/6be7022c510741580dac6a491942f30911d7c4dd) tellico: 3.5 -> 3.5.1
* [`3b55cf99`](https://github.com/NixOS/nixpkgs/commit/3b55cf992cb06bfb81203b7a9008326ab54c8973) dayon: init at 11.0.7
* [`cdadadb5`](https://github.com/NixOS/nixpkgs/commit/cdadadb5c0adc57cfbcd35cd2f7c54498da3abe8) trivy: 0.43.1 -> 0.44.0
* [`6f53567a`](https://github.com/NixOS/nixpkgs/commit/6f53567aa8ffbb1e54ad24e3d90def1acd08ae6d) rubyfmt: init at 0.8.1
* [`c3784eb9`](https://github.com/NixOS/nixpkgs/commit/c3784eb94b6aaa93af287a8a237d6fb97b409718) rubyfmt: add support for macos arm64/x86
* [`24a04f48`](https://github.com/NixOS/nixpkgs/commit/24a04f48c1ad779a30fb35055967bb9848db41fd) suricata: 6.0.13 -> 7.0.0
* [`1e0ff610`](https://github.com/NixOS/nixpkgs/commit/1e0ff6105a54e298154123fafef583364879a070) pnpm-lock-export: use fork with v6 support
* [`57cfb2ac`](https://github.com/NixOS/nixpkgs/commit/57cfb2aca0592a7bbff08ca0d04494a46d3b9fbb) woodpecker-*: 0.15.11 -> 1.0.0
* [`8bbf6a32`](https://github.com/NixOS/nixpkgs/commit/8bbf6a3281b48a5e87b22af85e2db44013a2374a) release-notes: note breaking woodpecker update
* [`18dd5156`](https://github.com/NixOS/nixpkgs/commit/18dd51567e0fa185aa44abe10f28bc3a1309f1c5) alsa-scarlett-gui: fixed desktop entry
* [`66f8bb0d`](https://github.com/NixOS/nixpkgs/commit/66f8bb0d81ce0ac35cf505f5ea85abdb7ee12149) alsa-scarlett-gui: fix for deskop integration
* [`97edbb78`](https://github.com/NixOS/nixpkgs/commit/97edbb78c63efa7c51556981b55b697513f11a8d) alsa-scarlet-gui: light refactoring
* [`40171226`](https://github.com/NixOS/nixpkgs/commit/4017122623dceb80601c5aaf1c6fb64dbe36c9f2) alsa-scarlett-gui: Change icons path back to relative in desktop entry file
* [`b0575287`](https://github.com/NixOS/nixpkgs/commit/b057528757f15f34b09b8ff1419ee6624fc25b14) alsa-scarlett-gui: light refactoring
* [`149fb38d`](https://github.com/NixOS/nixpkgs/commit/149fb38d5e7e4a6ea4c1710672dcc5cbd68d41d8) plasma: 5.27.6 -> 5.27.7
* [`bd4a2f50`](https://github.com/NixOS/nixpkgs/commit/bd4a2f50d9d512aca5c321b9c641296a72e6816a) dualsensectl: 0.3 -> 0.4
* [`fc6eaa7b`](https://github.com/NixOS/nixpkgs/commit/fc6eaa7b36b6095daadd2dbf5dab5383add6d77f) indilib: 1.9.8 -> 2.0.2
* [`63b07e8d`](https://github.com/NixOS/nixpkgs/commit/63b07e8d665b04ac22487761c01588f8ef31bda0) indi-full: 1.9.8 -> 2.0.2, reenable Atik, Pentax and SX drivers
* [`ab6fef15`](https://github.com/NixOS/nixpkgs/commit/ab6fef15e09ce7d3592d0e59e89dac341f96b514) stellarium: add patch for indi 2.0 compatibility
* [`9506c321`](https://github.com/NixOS/nixpkgs/commit/9506c321190043cdfad4488d06aef9aeda1d21c9) plasma-sdk: unbreak build, again
* [`25c6bcaf`](https://github.com/NixOS/nixpkgs/commit/25c6bcafd0d11b17850b114331d4efddd1e4df18) matrix-synapse: 1.88.0 -> 1.89.0
* [`fdd97a47`](https://github.com/NixOS/nixpkgs/commit/fdd97a473861a849a9319b20dfa12d26ffc6ba88) matrix-appservice-irc: add package.json to package
* [`d9fcede9`](https://github.com/NixOS/nixpkgs/commit/d9fcede9dd8249dfe0cc79055f9a6fcc6a237cf9) gopass: 1.15.5 -> 1.15.6
* [`2b63ca9f`](https://github.com/NixOS/nixpkgs/commit/2b63ca9fb82569a14cf2cb0b23b431f62ec28140) python310Packages.transformers: 4.30.2 -> 4.31.0
* [`419974c6`](https://github.com/NixOS/nixpkgs/commit/419974c6bebc2f5f70d6f8423ac5e5ba209736e0) iotas: 0.1.14 -> 0.2.2
* [`e31b7df1`](https://github.com/NixOS/nixpkgs/commit/e31b7df1b85516222cbd64eb4251347c6afb4d3e) zettlr-beta: init at 3.0.0-beta.7
* [`1015d9a9`](https://github.com/NixOS/nixpkgs/commit/1015d9a9f890bcc203b1a3fe2ad3aa73495bfe4a) containerd: 1.7.2 -> 1.7.3
* [`27657a22`](https://github.com/NixOS/nixpkgs/commit/27657a22bac96cc314a7120d9f65f20c6a44ff56) sage: use overrideScope instead of packageOverrides
* [`c0d7558c`](https://github.com/NixOS/nixpkgs/commit/c0d7558c8fa159171d87ca699f04388875accf29) exercism: 3.1.0 -> 3.2.0
* [`e6254d80`](https://github.com/NixOS/nixpkgs/commit/e6254d8087fdba4384260c3cac57f16232306cee) teamspeak_client: set mainProgram
* [`a5215068`](https://github.com/NixOS/nixpkgs/commit/a5215068347747a633c46d2b178a1fc360ea129b) hedgedoc: use `lib.mkPackageOptionMD`
* [`b7062f43`](https://github.com/NixOS/nixpkgs/commit/b7062f43e21fb362d739bc295ef50ca60c15bd33) hedgedoc: add `enableStatsApi` configuration option
* [`88bf8ce4`](https://github.com/NixOS/nixpkgs/commit/88bf8ce451d62745ef85c80a26c875dd94b2b1fa) mailcatcher: 0.7.1 -> 0.9.0
* [`f8fb337a`](https://github.com/NixOS/nixpkgs/commit/f8fb337a70b57651dc936ff8d74e5a4e9eff3df1) i3status-rust: 0.31.8 -> 0.31.9
* [`3bf9e658`](https://github.com/NixOS/nixpkgs/commit/3bf9e658814b7f97cc733d8c712b0b0ecfc91a04) doc/maven: add stable-maven-plugins back
* [`fa8883c5`](https://github.com/NixOS/nixpkgs/commit/fa8883c580bab92ed17648cc872dc994bba3f99a) hedgedoc: remove top level `with lib;`
* [`828dea33`](https://github.com/NixOS/nixpkgs/commit/828dea331a689ea9ab3f9045f232ced849adb349) openssl_1_1: 1.1.1u -> 1.1.1v
* [`98c77ecf`](https://github.com/NixOS/nixpkgs/commit/98c77ecf8f8c9d1f635b0c0ac34d70a6a497a59c) textadept:11.4 -> 12.0
* [`a200cca6`](https://github.com/NixOS/nixpkgs/commit/a200cca618a319e57ef55836e9120a09c935d1ef) probe-run: 0.3.9 -> 0.3.10
* [`c89298b8`](https://github.com/NixOS/nixpkgs/commit/c89298b854db23e4716e2d825717a02a46f55a48) confy: use fetchzip, for consistent hashes
* [`184d15cc`](https://github.com/NixOS/nixpkgs/commit/184d15cc068def96972c88a4d4a80336fe13bc88) kanidm: 1.1.0-alpha.12 -> 1.1.0-beta.13
* [`1a521973`](https://github.com/NixOS/nixpkgs/commit/1a521973ec712cba2c5460f001ffa16565cf5df7) ruff: 0.0.281 -> 0.0.282
* [`75c279bf`](https://github.com/NixOS/nixpkgs/commit/75c279bf1be3149e042e4668fbb14fbd4109314a) vimPlugins.sniprun: 1.3.5 -> 1.3.6
* [`ff7718ea`](https://github.com/NixOS/nixpkgs/commit/ff7718ea0b117d0a956587c35cf64a954c320e62) vscode-extensions.mskelton.npm-outdated: init at 2.2.0
* [`b96dbd03`](https://github.com/NixOS/nixpkgs/commit/b96dbd032cb63f028c7a66f3b7cafda91c239b9c) cbmc: 5.87.0 -> 5.88.1
* [`5c281855`](https://github.com/NixOS/nixpkgs/commit/5c2818553e1afa1cac5a100b88d120d1f59d5575) copilot-cli: 1.28.0 -> 1.29.0
* [`1d74cc4b`](https://github.com/NixOS/nixpkgs/commit/1d74cc4b3430a2d892a27b46cee380105c4d5ae6) zx: use buildNpmPackage
* [`9d73abc0`](https://github.com/NixOS/nixpkgs/commit/9d73abc0493a7529250c19eba337ca7dd44a8f9b) steam-rom-manager: 2.3.40 -> 2.4.17
* [`501cf3e1`](https://github.com/NixOS/nixpkgs/commit/501cf3e1af264f714c7940592fe6507af3c67344) mucommander: 1.2.0-1 -> 1.3.0-1
* [`46ae299b`](https://github.com/NixOS/nixpkgs/commit/46ae299b3e744c78cf1b2dccf097f4fa24d181ff) python310Packages.imap-tools: 1.1.0 -> 1.2.0
* [`5b9a9d3f`](https://github.com/NixOS/nixpkgs/commit/5b9a9d3f48979871fffa570bc8106aaddf2a36a1) graphite-gtk-theme: 2022-09-02 -> 2023-05-17
* [`bd0411d8`](https://github.com/NixOS/nixpkgs/commit/bd0411d80a138c6c422702b6def65c485c893a3e) highlight: 4.6 -> 4.7
* [`198d6eed`](https://github.com/NixOS/nixpkgs/commit/198d6eedbc980aa9a9e146892d57b03fc24f4994) code-server: 4.16.0 -> 4.16.1
* [`c4adddbc`](https://github.com/NixOS/nixpkgs/commit/c4adddbccc74d8b5ceaf4c931812be1b3f94462c) signalbackup-tools: 20230723-1 -> 20230730
* [`4091f295`](https://github.com/NixOS/nixpkgs/commit/4091f2955ad26914eafd39ceb72f2cebefb1238f) freefilesync: 12.4 -> 12.5
* [`19bb652e`](https://github.com/NixOS/nixpkgs/commit/19bb652ec2dcbc66efd74e6cefc11e1b56a4cb33) logseq: Add libstdc++ to the wrapper
* [`0aa50f25`](https://github.com/NixOS/nixpkgs/commit/0aa50f25b199f985097e852bfc6d9230aea39b87) typos: 1.16.1 -> 1.16.2
* [`4faa67a7`](https://github.com/NixOS/nixpkgs/commit/4faa67a748167ee77787a233120627941344eb61) runme: 1.6.0 -> 1.7.0
* [`609ebcaf`](https://github.com/NixOS/nixpkgs/commit/609ebcafaf9de3c223a090b6cb4ea0d81873e185) cockroachdb-bin: init at 23.1.7
* [`400caec5`](https://github.com/NixOS/nixpkgs/commit/400caec501bd7ccc01fb990c7cef25b4ea8dc51d) papirus-icon-theme: 20230601 -> 20230801
* [`910a1f6f`](https://github.com/NixOS/nixpkgs/commit/910a1f6f45e7b3008b5db85c65bf8d2d2e85ab6e) python311Packages.archinfo: 9.2.61 -> 9.2.62
* [`cf894b89`](https://github.com/NixOS/nixpkgs/commit/cf894b89a83dbe205010fe70b7f987ebd087b4a8) python311Packages.ailment: 9.2.61 -> 9.2.62
* [`17ec32bb`](https://github.com/NixOS/nixpkgs/commit/17ec32bb2401511d95d6216fa49a51a8d7b28e85) python311Packages.pyvex: 9.2.61 -> 9.2.62
* [`f130e9e9`](https://github.com/NixOS/nixpkgs/commit/f130e9e9b43f9e43da5375d9fbd28413c279686f) python311Packages.claripy: 9.2.61 -> 9.2.62
* [`1ac4d37c`](https://github.com/NixOS/nixpkgs/commit/1ac4d37ced281c156325376c2b5d8876d7c6fc5f) python311Packages.cle: 9.2.61 -> 9.2.62
* [`e56e3657`](https://github.com/NixOS/nixpkgs/commit/e56e36571be7c5004986c8c7d5511e1b11e42088) python311Packages.angr: 9.2.61 -> 9.2.62
* [`676cef57`](https://github.com/NixOS/nixpkgs/commit/676cef571797c11e037d41cc077aa51855a4440f) grafana: 10.0.2 -> 10.0.3 ([nixos/nixpkgs⁠#246616](https://togithub.com/nixos/nixpkgs/issues/246616))
* [`3f0f188b`](https://github.com/NixOS/nixpkgs/commit/3f0f188b02fbda26d9dab03dbebe328a3cbb4293) prometheus: 2.45.0 -> 2.46.0 ([nixos/nixpkgs⁠#246617](https://togithub.com/nixos/nixpkgs/issues/246617))
* [`353b200c`](https://github.com/NixOS/nixpkgs/commit/353b200c0ebfea55babbd2bb142dc39c5e75a740) restic: 0.15.2 -> 0.16.0 ([nixos/nixpkgs⁠#246614](https://togithub.com/nixos/nixpkgs/issues/246614))
* [`72a5376d`](https://github.com/NixOS/nixpkgs/commit/72a5376da3a3051138b8f48a224f0149b147acd6) element-{desktop,web}: 1.11.36 -> 1.11.37 ([nixos/nixpkgs⁠#246606](https://togithub.com/nixos/nixpkgs/issues/246606))
* [`0b6ee2c7`](https://github.com/NixOS/nixpkgs/commit/0b6ee2c78369833f6c208ad6c4431b615e17432f) foot: 1.15.1 -> 1.15.2 ([nixos/nixpkgs⁠#246561](https://togithub.com/nixos/nixpkgs/issues/246561))
* [`77ff9b72`](https://github.com/NixOS/nixpkgs/commit/77ff9b727c4bcb883f8d118815dfc02916fc896a) buck2: unstable-2023-07-18 -> unstable-2023-08-01
* [`3b6b6477`](https://github.com/NixOS/nixpkgs/commit/3b6b64775dda990b9092205ff7a12b9f4b702417) docker_24: init at 24.0.5
* [`c13044c9`](https://github.com/NixOS/nixpkgs/commit/c13044c93c59db741c53f18086bcb441967bcf35) docker: zfs patch is in >= 23.x
* [`1f202ea2`](https://github.com/NixOS/nixpkgs/commit/1f202ea20d0b402aaf1f2c8ea3524bded536969c) docker: clean up buildInputs for cli
* [`503953bd`](https://github.com/NixOS/nixpkgs/commit/503953bd0055016817b9a96998c404a070b3e481) docker: disable man pages building
* [`1c353c50`](https://github.com/NixOS/nixpkgs/commit/1c353c50ff6fa3df770007de622de165f5302874) docker: add glibc buildInput only on >=23.x
* [`fbe83582`](https://github.com/NixOS/nixpkgs/commit/fbe83582ce61e8c67827c564bccf7191cc360881) rustywind: 0.16.0 -> 0.17.0
* [`6c12007b`](https://github.com/NixOS/nixpkgs/commit/6c12007b07fd8cfa976fe9726de94ec6524e2b93) cargo-all-features: 1.9.0 -> 1.10.0
* [`48284913`](https://github.com/NixOS/nixpkgs/commit/48284913a2e017a5e9bf0b119bcfd594a88482df) haproxy: use `finalAttrs` pattern
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
