### PR TITLE
niv devenv: update e91205ac -> b4ce82b6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e91205acb792f6a49ea53ab04c04fbc2a85039cd",
-        "sha256": "1fl3k496921x0afvribcxqkp914k0hy7m5av9ky45niiyvdrp04k",
+        "rev": "b4ce82b6a54022c688f9f916b9f7a9c9ed959de1",
+        "sha256": "0w605cyw9xxy2z39lfid5v9xfdr4shwvxzgbbnbrcc6l35c603r1",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/e91205acb792f6a49ea53ab04c04fbc2a85039cd.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/b4ce82b6a54022c688f9f916b9f7a9c9ed959de1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@e91205ac...b4ce82b6](https://github.com/cachix/devenv/compare/e91205acb792f6a49ea53ab04c04fbc2a85039cd...b4ce82b6a54022c688f9f916b9f7a9c9ed959de1)

* [`150c582b`](https://github.com/cachix/devenv/commit/150c582b3356fc9e382f31c4718c37a72de96b7a) Add `lua-language-server` to `languages.lua`
* [`81e7928d`](https://github.com/cachix/devenv/commit/81e7928df0903723af66cca346e6602d029ca610) docs: display edit button
* [`95cf8bd5`](https://github.com/cachix/devenv/commit/95cf8bd565c311bb8b85cb0511ceea566764a1f4) rust: use tools from custom toolchain for pre-commit hooks
* [`5054606f`](https://github.com/cachix/devenv/commit/5054606f418bba13b4430993989a5342a3e074fb) languages.python.venv.requirements can be a path
* [`09f99037`](https://github.com/cachix/devenv/commit/09f990374fa04aedab5b0e1d980b79a5c035c017) format
* [`b4ce82b6`](https://github.com/cachix/devenv/commit/b4ce82b6a54022c688f9f916b9f7a9c9ed959de1) Auto generate docs/reference/options.md
