### PR TITLE
niv home-manager: update 4fd794d3 -> 903e06d7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fd794d3df88735dcf9662155d77b08a2e2dde29",
-        "sha256": "1rzjzmzlr4r5sr3dnbba8yhbq783sk3y4m5drwrnsr0xw4y1i7v5",
+        "rev": "903e06d734bcae48efb79b9afd51b406d2744179",
+        "sha256": "10ag313wgpz9hbzf4azhlymq89m3l4vz49shabz3ag80disbvmr7",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/4fd794d3df88735dcf9662155d77b08a2e2dde29.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/903e06d734bcae48efb79b9afd51b406d2744179.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@4fd794d3...903e06d7](https://github.com/nix-community/home-manager/compare/4fd794d3df88735dcf9662155d77b08a2e2dde29...903e06d734bcae48efb79b9afd51b406d2744179)

* [`04da1b90`](https://github.com/nix-community/home-manager/commit/04da1b908be79dd88c4e2ef43363a4d5a1536df2) Translate using Weblate (Chinese (Simplified))
* [`310c0063`](https://github.com/nix-community/home-manager/commit/310c0063b2558e94ad8bc3c1f2ddead82e0872cd) Update translation files
* [`89df56fe`](https://github.com/nix-community/home-manager/commit/89df56fefe728bed13b4b5b99af196017e330dd5) fish: fix session vars build in cross-compiled system ([nix-community/home-manager⁠#4293](https://togithub.com/nix-community/home-manager/issues/4293))
* [`4542db60`](https://github.com/nix-community/home-manager/commit/4542db605602898fe0c431e19f01e1af2865dae8) man: fix caches generation in cross-compiled system ([nix-community/home-manager⁠#4294](https://togithub.com/nix-community/home-manager/issues/4294))
* [`8c731978`](https://github.com/nix-community/home-manager/commit/8c731978f0916b9a904d67a0e53744ceff47882c) nushell: deprecation of let-env ([nix-community/home-manager⁠#4292](https://togithub.com/nix-community/home-manager/issues/4292))
* [`a146ab6a`](https://github.com/nix-community/home-manager/commit/a146ab6a61c20b97b8343c7c77870a4a3f645b1c) himalaya: update a link to ticket
* [`484a1c94`](https://github.com/nix-community/home-manager/commit/484a1c94424d296b15af3e6858f08b576b842ec2) network-manager-applet: remove `--sm-disable` flag
* [`b2ac1d2c`](https://github.com/nix-community/home-manager/commit/b2ac1d2c32ac11b8d231d23622cdc4b2f28d07d2) flake.lock: Update
* [`e79f416b`](https://github.com/nix-community/home-manager/commit/e79f416b61da725fe167e74a33f344b2edee61f7) Translate using Weblate (German)
* [`9b0bc4ce`](https://github.com/nix-community/home-manager/commit/9b0bc4ce7917f7b6f597fbe00b655fd992f63147) Translate using Weblate (Romanian)
* [`86dd48d7`](https://github.com/nix-community/home-manager/commit/86dd48d70a2e2c17e84e747ba4faa92453e68d4a) Translate using Weblate (Korean)
* [`a4f45087`](https://github.com/nix-community/home-manager/commit/a4f450879119a2a000264bd5ac90b186e1147617) jujutsu: fix zsh completion ([nix-community/home-manager⁠#4305](https://togithub.com/nix-community/home-manager/issues/4305))
* [`15043a65`](https://github.com/nix-community/home-manager/commit/15043a65915bcc16ad207d65b202659e4988066b) zsh: Add `zsh.history.ignoreAllDups` config option ([nix-community/home-manager⁠#4248](https://togithub.com/nix-community/home-manager/issues/4248))
* [`0a014a72`](https://github.com/nix-community/home-manager/commit/0a014a729cdd54d9919ff36b714d047909d7a4c8) aerc: do not use smtp-starttls ([nix-community/home-manager⁠#4272](https://togithub.com/nix-community/home-manager/issues/4272))
* [`903e06d7`](https://github.com/nix-community/home-manager/commit/903e06d734bcae48efb79b9afd51b406d2744179) taffybar: Avoid restarting too quickly ([nix-community/home-manager⁠#4316](https://togithub.com/nix-community/home-manager/issues/4316))
