### PR TITLE
niv nixpkgs: update 48377a19 -> 2a600eea

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48377a1934063d63930524b250604103e246d863",
-        "sha256": "120bjvpzw5i7qm0kyi7wxbw41jgpkwljz2rz5h5c84gh6gj38i91",
+        "rev": "2a600eea3eedd2a1be81d4595e8259bb780bd865",
+        "sha256": "0ikl1fil3cmadc64lxq8qi0dh608barx04a1i7fmkymlkljil00i",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/48377a1934063d63930524b250604103e246d863.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/2a600eea3eedd2a1be81d4595e8259bb780bd865.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@48377a19...2a600eea](https://github.com/nixos/nixpkgs/compare/48377a1934063d63930524b250604103e246d863...2a600eea3eedd2a1be81d4595e8259bb780bd865)

* [`93b5ec00`](https://github.com/NixOS/nixpkgs/commit/93b5ec008455834e208e7fcab48031a285a36bb4) clang-unwrapped: mv {$out,$python}/share/scan-view/*.py
* [`d7ee877f`](https://github.com/NixOS/nixpkgs/commit/d7ee877f3e55a25470db9cf4ae945458579ddd37) storj-uplink: init at 1.85.1
* [`e59046bc`](https://github.com/NixOS/nixpkgs/commit/e59046bc48bd57a15b99b92be55520af4923f5c3) python{2,3}Packages.bootstrapped-pip: remove extraneous entry from PYTHONPATH
* [`9a4efdea`](https://github.com/NixOS/nixpkgs/commit/9a4efdeaaee2a3d043cb8052d4447a789cf04daf) python3Packages.s3transfer: remove unused inputs, fix cross compilation
* [`040b2296`](https://github.com/NixOS/nixpkgs/commit/040b2296e2611bf3b491cdc9142f3ef1efbb3890) python3Packages.s3transfer: add nickcao to maintainers
* [`65a512da`](https://github.com/NixOS/nixpkgs/commit/65a512daf3e755852a8138fed6ee0fa4a984d19b) remmina: Use the system's cert store
* [`52c41d40`](https://github.com/NixOS/nixpkgs/commit/52c41d40077e0189a253c079fbf572fa98e0dc94) linuxConsoleTools: 1.6.1 -> 1.8.1
* [`9f805a40`](https://github.com/NixOS/nixpkgs/commit/9f805a40876f52643fd0543fe3bbe5b93b257dba) Set doesn't take a colon
* [`fdfe1993`](https://github.com/NixOS/nixpkgs/commit/fdfe19932f5b92662b9d2c8c6a6902cb06b3debd) Use `set-default` so that we don't override the exisiting
* [`9617d41a`](https://github.com/NixOS/nixpkgs/commit/9617d41ab1c78a75bb909b58d013a51101bdaef1) nixos/libvirtd: add support for nixos managed libvirt hooks
* [`96cccdd5`](https://github.com/NixOS/nixpkgs/commit/96cccdd56f510692e4b16c85a4bdba0021f614dd) lib: fix nix-doc variable "Type" in comment
* [`830db0d7`](https://github.com/NixOS/nixpkgs/commit/830db0d715f1189f80012e138f7ff99eb7f45ef0) nghttp2: 1.51.0 -> 1.54.0
* [`c5e85ef0`](https://github.com/NixOS/nixpkgs/commit/c5e85ef0f1bbf3070a161f749f1acd05920873f0) pythonPackages: remove nghttp2 package
* [`5c16796c`](https://github.com/NixOS/nixpkgs/commit/5c16796c696cce4daf20bd9797fc12174c82841b) xfstests: 2022.09.04 -> 2023.05.14
* [`e6787495`](https://github.com/NixOS/nixpkgs/commit/e678749572e588743ad884ff8fa230556b13e3c3) johnny: init at 2.2
* [`060c700b`](https://github.com/NixOS/nixpkgs/commit/060c700b166acc8fcd83f0d195e4372baab179e9) freetype: 2.13.0 -> 2.13.1
* [`b09195fb`](https://github.com/NixOS/nixpkgs/commit/b09195fb75ff56a2e7c4747a47c9b048749d4397) openexr_3: 3.1.7 -> 3.1.9
* [`9999bf7a`](https://github.com/NixOS/nixpkgs/commit/9999bf7a21105486d44b759f56fd1a05fb312d9e) treewide: gobject-introspection from buildInputs to nativeBuildInputs
* [`9d663f7f`](https://github.com/NixOS/nixpkgs/commit/9d663f7fcd1fbae2c1895151d8a98234593a6d39) setuptools-rust: fix cross compilation
* [`f5f80fa8`](https://github.com/NixOS/nixpkgs/commit/f5f80fa89c89ed56024bbf9b579cf1d1bf2ff82b) python-modules/cryptography: fix cross-build
* [`43449be7`](https://github.com/NixOS/nixpkgs/commit/43449be7e7daaa6c448c0b5a386ea89e73f84cf2) memtier-benchmark: 1.4.0 -> 2.0.0
* [`af1706e0`](https://github.com/NixOS/nixpkgs/commit/af1706e0b828dcc6d16a3ecc5e213a107b8a9a1e) kbd: 2.5.1 -> 2.6.1
* [`557c380c`](https://github.com/NixOS/nixpkgs/commit/557c380c6d8c13819095a0a33bf726e3f99443f3) cryptomator: 1.8.0 -> 1.9.1
* [`fc478ad9`](https://github.com/NixOS/nixpkgs/commit/fc478ad9ffc6086ebf04e407a922ac43f94c4d25) nixos/minio: allow distributed nodes
* [`0436d3fb`](https://github.com/NixOS/nixpkgs/commit/0436d3fbc5d3888bd972a74c68dd19e71f7b8bb4) ocamlPackages.ssl: 0.5.13 -> 0.6.0
* [`f4162143`](https://github.com/NixOS/nixpkgs/commit/f41621432fbf15ff8f8e51eaa978bf394b171953) perl: 5.36.0 -> 5.38.0
* [`5173b569`](https://github.com/NixOS/nixpkgs/commit/5173b569f5de95ac902e809f71d04e69062884e9) unit: add perl538 as default, remove perl534
* [`ae7c95e5`](https://github.com/NixOS/nixpkgs/commit/ae7c95e55c106aa6b2f98d21b871bc3491865917) slimserver: replace perl534Packages with perlPackages
* [`c7387bbc`](https://github.com/NixOS/nixpkgs/commit/c7387bbc8a2df93530dfade5aae2e99796c38804) perl.mini: fix modules for compatibility with miniperl
* [`c865c30a`](https://github.com/NixOS/nixpkgs/commit/c865c30a00d1efc9b5d17eb40168ec910cf399f5) perlPackages.ModuleBuild: fix cross-compilation
* [`c16e6148`](https://github.com/NixOS/nixpkgs/commit/c16e61489710cf9f89650bc750464348a243ae48) perlPackages.BKeywords: 1.24 -> 1.26
* [`4da042f5`](https://github.com/NixOS/nixpkgs/commit/4da042f5171b1b21bfb54efd40792b119b6b8f84) perlPackages.MIMECharset: 1.012.2 -> 1.013.1
* [`b99636d9`](https://github.com/NixOS/nixpkgs/commit/b99636d903bc38194136bd8d3dd53b4649df8aa1) perlPackages.TestSimple13: 1.302183 -> 1.302195
* [`6ab63f9a`](https://github.com/NixOS/nixpkgs/commit/6ab63f9acb8b2f0e3e8cbe234a7c1b1f7d241ee3) perlPackages.TestTrap: 0.3.4 -> 0.3.5
* [`984dc4c0`](https://github.com/NixOS/nixpkgs/commit/984dc4c0484ad726e8ceeaf3b752cdc8afba8cfd) perlPackages.TestWithoutModule: 0.20 -> 0.21
* [`5e8767c9`](https://github.com/NixOS/nixpkgs/commit/5e8767c9458bbf8380a98b0738173d7f991a23c3) perlPackages.Test2Harness: 1.000042 -> 1.000152
* [`fd94d3ff`](https://github.com/NixOS/nixpkgs/commit/fd94d3ff348685ffc84da8f7a8ab378f243c226a) perlPackages.XSParseKeyword: 0.25 -> 0.34
* [`caf22a33`](https://github.com/NixOS/nixpkgs/commit/caf22a33eb1119004a7f5b9b9faafab6dad7f976) gcc: copy gcc/builder.sh to gcc/common/builder.nix
* [`72284b0d`](https://github.com/NixOS/nixpkgs/commit/72284b0d404d1b1c30f2013a88e8a44df65bb405) gcc: make common/builder.nix into valid Nix syntax
* [`1157e1d8`](https://github.com/NixOS/nixpkgs/commit/1157e1d85625dc1ff035f1781079971ed25dbf59) gcc: add args to common/builder.nix, split up script into phases
* [`c413f5a6`](https://github.com/NixOS/nixpkgs/commit/c413f5a6c104ab62c41fb1abba919858a8fac56a) gcc: remove `builder = ../builder.sh` from gcc/${version}/default.nix
* [`e3f05c22`](https://github.com/NixOS/nixpkgs/commit/e3f05c22aa70784b146d681b68bec8aab86c8e39) gcc: use common/builder.nix
* [`67da7b9a`](https://github.com/NixOS/nixpkgs/commit/67da7b9a1f5d7320e05c7cfa3da2458f15806a14) gcc: remove builder.sh
* [`5eaf1792`](https://github.com/NixOS/nixpkgs/commit/5eaf17927e285e207d66fcf497707a8af22ac0b9) gcc: add `-g` to `declare`
* [`e99f6372`](https://github.com/NixOS/nixpkgs/commit/e99f6372fab940ca96c399055b2dcb7c6160fc3e) gcc: use callFile instead of callPackage for builder.nix
* [`76216360`](https://github.com/NixOS/nixpkgs/commit/7621636030c887b4d7d000813a7be61869a16cf7) gcc: use Nix instead of bash for conditional
* [`aae530ab`](https://github.com/NixOS/nixpkgs/commit/aae530ab37c3885d419c075ead0c18fc87852e95) datadog-agent: 7.38.1 -> 7.45.1
* [`af0cd7a9`](https://github.com/NixOS/nixpkgs/commit/af0cd7a997b69c8ff9e42044599e5cb12fa43c6b) libvirt: 9.4.0 -> 9.5.0
* [`77219b63`](https://github.com/NixOS/nixpkgs/commit/77219b639f32f9d63847d01cf4a5366dae135d96) maintainers: add nrhtr
* [`361004bc`](https://github.com/NixOS/nixpkgs/commit/361004bca648e69c8f75c9b38027a0a8b55a7c9c) grizzly: init at 0.2.0
* [`ac63d48e`](https://github.com/NixOS/nixpkgs/commit/ac63d48eb174f4c176942351fa4714368c851853) groff: 1.22.4 -> 1.23.0
* [`ad224d61`](https://github.com/NixOS/nixpkgs/commit/ad224d61d0d807def43bb1c8b9253082aafb16d2) nixos manual contributing link to nixpkgs syntax
* [`b05435b7`](https://github.com/NixOS/nixpkgs/commit/b05435b738f2a46c28f43bdd95581f4ec6131078) zsh-fzf-history-search: init at unstable-23-03-08
* [`70945eb7`](https://github.com/NixOS/nixpkgs/commit/70945eb79bae07d272105d21c6cf50d2ed3a5e20) setup-hooks/strip: parallelise stripping
* [`d3314ac5`](https://github.com/NixOS/nixpkgs/commit/d3314ac57a6354177872d36e8841c1d901e33a88) python310Packages.hy: 0.26.0 -> 0.27.0
* [`2a979057`](https://github.com/NixOS/nixpkgs/commit/2a979057afb74c503c9bb889ebac3d92b0ce378b) python310Packages.packaging: 23.0 -> 23.1
* [`5471b05e`](https://github.com/NixOS/nixpkgs/commit/5471b05ee0af030fb61f11feeb34bcb3ad8d5d1d) libipt: 2.0.5 -> 2.0.6
* [`55aeb4c7`](https://github.com/NixOS/nixpkgs/commit/55aeb4c785f62ae660c886b87fd0e70349a54095) gpgme: 1.20.0 -> 1.21.0
* [`9f9b8a07`](https://github.com/NixOS/nixpkgs/commit/9f9b8a0733464fadecbe81afd23cf008f1490aa9) boost: fix for python 3.11
* [`1e7432b5`](https://github.com/NixOS/nixpkgs/commit/1e7432b5dea5825c692ef492f0aa2e68ce66933c) catch2_3: 3.3.2 -> 3.4.0
* [`8f4874ca`](https://github.com/NixOS/nixpkgs/commit/8f4874ca39dc2d1a4d3aa133eba42bb69d9d6fac) rustc: 1.70.0 -> 1.71.0
* [`15c89454`](https://github.com/NixOS/nixpkgs/commit/15c894549733cce90835e5a374fe16d780584a89) openldap: disable flaky test 063
* [`d02150a7`](https://github.com/NixOS/nixpkgs/commit/d02150a7831d091cce0605b8532f1c4911bd9ae9) libredirect: fix build with clang 16
* [`9cea350c`](https://github.com/NixOS/nixpkgs/commit/9cea350c5b0eb3ceeedcf94931cdf541be4ea361) geoipupdate: 5.1.1 -> 6.0.0
* [`97725d54`](https://github.com/NixOS/nixpkgs/commit/97725d548cea38785765b9ba328ab109fbd50808) aws-c-auth: 0.6.26 -> 0.7.0
* [`5c77d5e2`](https://github.com/NixOS/nixpkgs/commit/5c77d5e298e46a133d4a696df2024a4d8a83c64d) aws-c-common: 0.8.15 -> 0.8.23
* [`8c58c719`](https://github.com/NixOS/nixpkgs/commit/8c58c7193d072fcd6895c7db6181f8827b5119bf) aws-c-event-stream: 0.2.20 -> 0.3.1
* [`de83ac7a`](https://github.com/NixOS/nixpkgs/commit/de83ac7a3361f60aac0a7486fe81a18c0d3c7404) aws-c-http: 0.7.6 -> 0.7.11
* [`8dce46cd`](https://github.com/NixOS/nixpkgs/commit/8dce46cdf744798c21a6c1aee7ee178d7b05bfb2) aws-c-mqtt: 0.8.8 -> 0.8.14
* [`5830cf65`](https://github.com/NixOS/nixpkgs/commit/5830cf6523d3be4708958155bb717a67dec8d3ff) aws-c-s3: 0.2.8 -> 0.3.13
* [`9c64e1b5`](https://github.com/NixOS/nixpkgs/commit/9c64e1b5b31c109a98e8552431369a655eae7a6a) aws-c-compression: 0.2.16 -> 0.2.17
* [`23622ddc`](https://github.com/NixOS/nixpkgs/commit/23622ddca3f460d1ff2e39ad0db5a41d38f53812) aws-c-io: 0.13.19 -> 0.13.29
* [`bed3cd45`](https://github.com/NixOS/nixpkgs/commit/bed3cd45eb4077647d9351b8e9e9e1440e520a47) aws-checksums: 0.1.14 -> 0.1.17
* [`12694303`](https://github.com/NixOS/nixpkgs/commit/126943039a727e37c093246daf7923cfa8f03c73) aws-crt-cpp: 0.20.2 -> 0.20.3
* [`0c2ee7b4`](https://github.com/NixOS/nixpkgs/commit/0c2ee7b4ca5dd0ee8252b1c6453b7293a84d4c19) aws-c-sdkutils: 0.1.9 -> 0.1.11
* [`7df07b05`](https://github.com/NixOS/nixpkgs/commit/7df07b059dd34b17c7533ac4416c312f93ec3988) aws-c-cal: 0.5.21 -> 0.6.0
* [`213fb14d`](https://github.com/NixOS/nixpkgs/commit/213fb14d1f90ce6e81edee897adf6f618f2fa6fd) aws-sdk-cpp: 1.11.37 -> 1.11.118
* [`b3d27652`](https://github.com/NixOS/nixpkgs/commit/b3d27652719cb09053b35bb6f51820f7045e6417) rustPlatform.maturinBuildHook: fix postBuild hook to use ./dist contract
* [`f87ce0b9`](https://github.com/NixOS/nixpkgs/commit/f87ce0b9fdcc07b8f8cdc0265e600aa75d515cc4) python3Packages.typing-extensions: 4.5.0 -> 4.7.1
* [`ad8037c0`](https://github.com/NixOS/nixpkgs/commit/ad8037c088b4912ac93352ebad3576e25aa07046) s2n-tls: 1.3.46 -> 1.3.47
* [`68a039b3`](https://github.com/NixOS/nixpkgs/commit/68a039b31c809cf0f98c6772487bd662cfe19c12) qpdf: 11.4.0 -> 11.5.0
* [`6abb925f`](https://github.com/NixOS/nixpkgs/commit/6abb925f63b868ac8217296b3acd7658b2ea4ab1) CertDump: init at 2023-07-12
* [`078ebb0f`](https://github.com/NixOS/nixpkgs/commit/078ebb0fe8c9c30639fdf3fb1e8af8a582319c9d) libgit2: 1.6.4 -> 1.7.0
* [`de3e686c`](https://github.com/NixOS/nixpkgs/commit/de3e686cc895d81d6fa53f60463bb4eb6db9677e) python310Packages.pygit2: pin libgit2 to libgit2, run tests again
* [`c2861bcb`](https://github.com/NixOS/nixpkgs/commit/c2861bcbdf4a2a3e92b39df64498381c0e43779c) add separate configurable datadog process agent
* [`ec38b4db`](https://github.com/NixOS/nixpkgs/commit/ec38b4db76ff518d525b1d6d0127c216d125d7b3) rhash: 1.4.3 -> 1.4.4
* [`670a1501`](https://github.com/NixOS/nixpkgs/commit/670a15018d8e13af208c1913b48ae250fe7c9ffe) matrix-synapse-plugins.matrix-http-rendezvous-synapse: fix maturin hook use
* [`c39948ee`](https://github.com/NixOS/nixpkgs/commit/c39948ee5205498aa86424555b3d5112f3931c24) python310Packages.matplotlib: 3.7.1 -> 3.7.2 ([nixos/nixpkgs⁠#243000](https://togithub.com/nixos/nixpkgs/issues/243000))
* [`a679e388`](https://github.com/NixOS/nixpkgs/commit/a679e38851e7a5820f61b60ff7b905d958127a38) python3Packages.pydantic-core: init at 2.3.0
* [`048f9a4a`](https://github.com/NixOS/nixpkgs/commit/048f9a4adf4a1db1864990a7a377fb2bf9687751) fix whitespace issue
* [`acb18236`](https://github.com/NixOS/nixpkgs/commit/acb182363b506a3add9781711e2ecbeec3e5c3d3) cc-wrapper: use -fwrapv instead of -fno-strict-overflow in clang
* [`3ac870f5`](https://github.com/NixOS/nixpkgs/commit/3ac870f5104a942049b563794f932f60ee40da82) eigenpy: 3.0.0 -> 3.1.0
* [`ba2eae16`](https://github.com/NixOS/nixpkgs/commit/ba2eae1629ee81ee8fd79c3c224fe189b44bd4fa) xterm: 383 -> 384
* [`2b777c9b`](https://github.com/NixOS/nixpkgs/commit/2b777c9bb8da9720c9fa318be57d54ae40aa8cea) python310Packages.bugsnag: 4.4.0 -> 4.5.0
* [`d4bafeb6`](https://github.com/NixOS/nixpkgs/commit/d4bafeb68ce76cd9419e4f05a5e8698871639a0c) python310Packages.mmh3: 4.0.0 -> 4.0.1
* [`8bfc5549`](https://github.com/NixOS/nixpkgs/commit/8bfc5549710640830237bcc9352bd5b276613cfb) python3Packages.python-ndn: init at 0.3-3
* [`4df9ed01`](https://github.com/NixOS/nixpkgs/commit/4df9ed01d3baeef55783a54b3f81d9d0a87fa6f5) python310Packages.cmdstanpy: init at 1.1.0
* [`7845969b`](https://github.com/NixOS/nixpkgs/commit/7845969b448dd8dfa9a2e74cb9dd33ef363dc6e0) python310Packages.lunarcalendar: init at 0.0.9
* [`bb417263`](https://github.com/NixOS/nixpkgs/commit/bb4172634d3574ae0df51a96dabfcb9f4df61e41) python310Packages.prophet: init at 1.1.4
* [`68cf1649`](https://github.com/NixOS/nixpkgs/commit/68cf164989bc8579bc750455d5062e2be8d0ce2c) example-robot-data: 4.0.7 -> 4.0.8
* [`5658c811`](https://github.com/NixOS/nixpkgs/commit/5658c811551b903ee55f191e2641e98304425c10) octoprint: 1.9.1 -> 1.9.2
* [`4bea964c`](https://github.com/NixOS/nixpkgs/commit/4bea964cfb53e3e6e559ee5c5ee3d2c4a00271da) crocoddyl: 2.0.0 -> 2.0.1
* [`a5ccd2c5`](https://github.com/NixOS/nixpkgs/commit/a5ccd2c5c8a0610cfe8fab09a7fb67b40c4c1313) nixos/nvidia: cleaned up reorganized and reformatted
* [`80324375`](https://github.com/NixOS/nixpkgs/commit/803243754d8ba8dc9a0c482b5153a12ef2a2aa9c) cargo-c: 0.9.20 -> 0.9.21
* [`89ed1134`](https://github.com/NixOS/nixpkgs/commit/89ed11345889a542a5ca5c1b95a866d150306232) dex2jar: 2.0 -> 2.1
* [`19fdb7d4`](https://github.com/NixOS/nixpkgs/commit/19fdb7d4e8a437922eb19ef1b7769399f7981740) gnutar: 1.34 -> 1.35
* [`eb9357ac`](https://github.com/NixOS/nixpkgs/commit/eb9357ac4b3fecaa1155ce0a8dda3757c49e5c0c) curl: 8.1.2 -> 8.2.0
* [`9c55f23e`](https://github.com/NixOS/nixpkgs/commit/9c55f23e53d820fdf7ec80249b3f23139638097d) python3: Add manpage symlink to fix ‘man python’
* [`890fbb83`](https://github.com/NixOS/nixpkgs/commit/890fbb83327f0bbb1e485c0ec57bebb21a580cc3) python310Packages.nlpcloud: 1.0.43 -> 1.1.43
* [`c4e2e455`](https://github.com/NixOS/nixpkgs/commit/c4e2e455a90b2626f2caf262b4ac5fda516e709a) python310Packages.pyvmomi: 8.0.1.0.1 -> 8.0.1.0.2
* [`aa0b1193`](https://github.com/NixOS/nixpkgs/commit/aa0b11935a30a343033425e7d0210ca1e6da5e8c) nodejs: 18.16.1 -> 18.17.0
* [`901246e1`](https://github.com/NixOS/nixpkgs/commit/901246e11a1619918cd646b3888779da7a3eec99) re2c: 3.0 -> 3.1
* [`0b404939`](https://github.com/NixOS/nixpkgs/commit/0b404939da709d8ffe8c01721b5925536749cea4) sratom: fix requires
* [`fe0bdcd1`](https://github.com/NixOS/nixpkgs/commit/fe0bdcd1c6f9ff29fe507f4b2bd16bb6b476e9c6) Revert "python3Packages.numpy: temporarily avoid rebuild on !isClang"
* [`f94d2b74`](https://github.com/NixOS/nixpkgs/commit/f94d2b74f6c11d4f1c72a67046be05bb2c77f917) python3Packages.numpy: apply patches unconditionally
* [`f65d93f9`](https://github.com/NixOS/nixpkgs/commit/f65d93f9f8dc60fa382919de9fe9869181920e30) dnscrypt-wrapper: disable fortify3 hardening flag
* [`f56fdf43`](https://github.com/NixOS/nixpkgs/commit/f56fdf43e464c660e00d443bfc20c213f8118882) python310Packages.aiohttp: 3.8.4 -> 3.8.5
* [`0829e0d6`](https://github.com/NixOS/nixpkgs/commit/0829e0d626cbb04e5777a196ed4f61c76451384b) python311Packages.syrupy: 4.0.2 -> 4.0.7
* [`391c5a84`](https://github.com/NixOS/nixpkgs/commit/391c5a8437799bbf6a0bf264737a4a692dc3553e) plymouth: unstable-2023-06-05 -> unstable-2023-06-17
* [`06a02d3a`](https://github.com/NixOS/nixpkgs/commit/06a02d3a8cb14bc9d8c2bdd754dde63f71493b25) man-db: fix tests for groff 1.23.0
* [`c1718f59`](https://github.com/NixOS/nixpkgs/commit/c1718f59e0bd2af933de924a7f97aec785e4c679) librsvg: fix cross compilation by using emulator for shell completion generation
* [`6573695a`](https://github.com/NixOS/nixpkgs/commit/6573695a89e2a4842eb9c969a0b816f08d472ee8) libhwy: 1.0.4 -> 1.0.5
* [`bb5ead49`](https://github.com/NixOS/nixpkgs/commit/bb5ead49eb547e3e6efb1ef131b5e90ab47b9fbd) lsp-plugins: 1.2.7 -> 1.2.8
* [`665174dc`](https://github.com/NixOS/nixpkgs/commit/665174dc1e88416113b89a9e794ccc29fe4ff4a1) pipewire: 0.3.74 -> 0.3.75
* [`5093766f`](https://github.com/NixOS/nixpkgs/commit/5093766f79b6d14a6a833de1b91f5557b4160232) setup-hooks/strip: Print strip stderr if command fails
* [`2ae18b7e`](https://github.com/NixOS/nixpkgs/commit/2ae18b7e10a064c1d2c4d4720d0a88f3d3d29296) setup-hooks/strip: Add -- before $cmd
* [`f46c8c1b`](https://github.com/NixOS/nixpkgs/commit/f46c8c1bcd9830d5e7b0d9264c8dd8f688518d9d) setup-hooks/strip: Exit if `cmd` or `ranlibCmd` are empty
* [`833ddd48`](https://github.com/NixOS/nixpkgs/commit/833ddd482f71c8cfcd0bb81ef9d8e36b1bf5ebdf) python310Packages.vowpalwabbit: 9.8.0 -> 9.9.0
* [`c7c288fb`](https://github.com/NixOS/nixpkgs/commit/c7c288fbd5ba0adbe15b6cd03b0ecd170597d619) nixos/dnscrypt-wrapper: avoid using polkit
* [`1c054164`](https://github.com/NixOS/nixpkgs/commit/1c054164ad1132ebabc5130682aafa9a25371972) avalonia-ilspy: build from source
* [`f3d1b5e4`](https://github.com/NixOS/nixpkgs/commit/f3d1b5e413faf5fe2e9a32c0e2830e02bb92e5cf) cargo-c: 0.9.21 -> 0.9.22
* [`e8f63fc2`](https://github.com/NixOS/nixpkgs/commit/e8f63fc293e036618ea0c192ad2bec9d8c9b646b) cargo-c: add rav1e as reverse dependency to passthru.tests
* [`fda4366b`](https://github.com/NixOS/nixpkgs/commit/fda4366ba5f47196285b72379cab181326a8f2a9) xxHash: 0.8.1 -> 0.8.2
* [`3ca33e5e`](https://github.com/NixOS/nixpkgs/commit/3ca33e5ef4f8c3e24013905cf741330c9ace3a6c) p11-kit: build with meson
* [`6a237805`](https://github.com/NixOS/nixpkgs/commit/6a2378058a9ca90587764a2ed08c0fdc772edb92) lm-sensors: add documentation
* [`da3f443e`](https://github.com/NixOS/nixpkgs/commit/da3f443e1f82ecc98c4b52a1feeb68087e4ae008) mesa: 23.1.3 -> 23.1.4
* [`f7557ec3`](https://github.com/NixOS/nixpkgs/commit/f7557ec309ef53a1ce615e411a4bf71864edcb86) aws-sdk-cpp: include dev output as header path hint
* [`ad44318e`](https://github.com/NixOS/nixpkgs/commit/ad44318e80ff3ed73c964c953b5c41578acdaff2) mindustry-server: enable on aarch64-linux
* [`d0a692d0`](https://github.com/NixOS/nixpkgs/commit/d0a692d0ba245bbf9ba9fbd11891b68c8079d1e5) python310Packages.pyworld: 0.3.3 -> 0.3.4
* [`cb72f5e1`](https://github.com/NixOS/nixpkgs/commit/cb72f5e17c7b9d70c5b15f8942d5892381e16df3) libpfm: 4.12.0 -> 4.13.0
* [`e37a0e09`](https://github.com/NixOS/nixpkgs/commit/e37a0e09e21d34dbca2d6f0f7efb7f36437809ac) gnutar: pull missing `libintl` dependency on Darwin
* [`afaab4f1`](https://github.com/NixOS/nixpkgs/commit/afaab4f120eb7ed4a01ffc9d89eacb4accb34bbb) darwin.xnu: Fix stripDirs
* [`0ee36e16`](https://github.com/NixOS/nixpkgs/commit/0ee36e16a3d757c65bc5d113cb79c4f8c185d384) clap: init at 1.1.8
* [`4cd5d647`](https://github.com/NixOS/nixpkgs/commit/4cd5d647d4b5d778592cd2f2d517220e6e7111bc) python310Packages.globus-sdk: 3.23.0 -> 3.25.0
* [`64fe5a97`](https://github.com/NixOS/nixpkgs/commit/64fe5a97f1938c3883273444f2e4252a3448a71e) p11-kit: use mesonEmulatorHook for cross compilation
* [`f256bf2d`](https://github.com/NixOS/nixpkgs/commit/f256bf2dc4e293749e18ed83b8eca2ac7c0a39b9) flite: add audioBackend option
* [`9a982a69`](https://github.com/NixOS/nixpkgs/commit/9a982a694624e68a214ade601afcf01493f4536b) flite: add getchoo as maintainer
* [`7e14cda1`](https://github.com/NixOS/nixpkgs/commit/7e14cda1570b0f83a787554027d8355cf53812bd) Darktable: 4.4.1 -> 4.4.2
* [`45e33f66`](https://github.com/NixOS/nixpkgs/commit/45e33f667243a8bd1debc0d8e581a7d4c9c3e145) rustc: build rust-analyzer-proc-macro-srv
* [`cfc43b99`](https://github.com/NixOS/nixpkgs/commit/cfc43b993366f6bed865711a5916d627c4e18ade) python310Packages.okonomiyaki: 1.3.2 -> 1.4.0
* [`bafa6a3d`](https://github.com/NixOS/nixpkgs/commit/bafa6a3d6ebea9b021a6de725652a04b9059b8e2) python310Packages.holoviews: 1.16.2 -> 1.17.0
* [`d6e0134a`](https://github.com/NixOS/nixpkgs/commit/d6e0134a6e071dfd2809735b35d8b989cef2313c) python310Packages.pox: 0.3.2 -> 0.3.3
* [`f9d74d4b`](https://github.com/NixOS/nixpkgs/commit/f9d74d4b41559b1a3028bc355425865e29b780e0) python310Packages.azure-mgmt-batch: 17.0.0 -> 17.1.0
* [`69d67d04`](https://github.com/NixOS/nixpkgs/commit/69d67d04e1410bbb1e084bbf9a29797faabdc8f8) libjack2: fix cross compilation
* [`3d66844c`](https://github.com/NixOS/nixpkgs/commit/3d66844c2de9f7d2e11e78225cfc7dcdd67109d7) gcc: revert "do not install sys-include headers for cross-compilers."
* [`b79effa1`](https://github.com/NixOS/nixpkgs/commit/b79effa1bd12557eeb4fe42e7c7ae6cbf9a2edd7) curl: 8.2.0 -> 8.2.1
* [`9096d43a`](https://github.com/NixOS/nixpkgs/commit/9096d43ade3b73afd450891309fb9adf4ebb69a9) giflib: clean up
* [`007173a9`](https://github.com/NixOS/nixpkgs/commit/007173a9dbdebdb94cec37cb88a01480a47c0e15) pkgsCross.mingwW64.giflib: fix build
* [`7bc650ec`](https://github.com/NixOS/nixpkgs/commit/7bc650eccac8ee2d032a5beee6d44ff18527f7b6) pkgsCross.mingwW64.gettext: fix build
* [`ce6bf3bb`](https://github.com/NixOS/nixpkgs/commit/ce6bf3bb54d95b7f8e9cc0e0506c123f8f349768) cfitsio: clean up
* [`2cb203a6`](https://github.com/NixOS/nixpkgs/commit/2cb203a61d6e4856f2ed84e4bfea9e7ccf563ed9) pkgsCross.mingwW64.popt: Fix build
* [`3a10c8d2`](https://github.com/NixOS/nixpkgs/commit/3a10c8d2d245e3fa27d631bf61904801df69c491) python310Packages.pytorch-metric-learning: 2.2.0 -> 2.3.0
* [`0d0b61be`](https://github.com/NixOS/nixpkgs/commit/0d0b61bec1d42d597ea58abbf513539338f4db96) python310Packages.django-auth-ldap: 4.3.0 -> 4.4.0
* [`e10a5b08`](https://github.com/NixOS/nixpkgs/commit/e10a5b08e01957738d27f39df14eee10d784947c) python310Packages.ansible: 8.1.0 -> 8.2.0
* [`7f81aee4`](https://github.com/NixOS/nixpkgs/commit/7f81aee4334f59fbb70ae619468b73358b2d3330) gst_all_1.gstreamer: 1.22.4 -> 1.22.5
* [`072efc09`](https://github.com/NixOS/nixpkgs/commit/072efc09d725adb0df178ca173bc6c30a690c2a9) gst_all_1.gst-plugins-base: 1.22.4 -> 1.22.5
* [`db11ed9b`](https://github.com/NixOS/nixpkgs/commit/db11ed9baf395630420098c19f86da23e6d3da02) gst_all_1.gst-plugins-good: 1.22.4 -> 1.22.5
* [`dea7113e`](https://github.com/NixOS/nixpkgs/commit/dea7113ed87390933fead14dc4585700c26a50c7) gst_all_1.gst-plugins-bad: 1.22.4 -> 1.22.5
* [`45ccf5cb`](https://github.com/NixOS/nixpkgs/commit/45ccf5cb9763063d9c36382eb8480244069c60a6) gst_all_1.gst-plugins-ugly: 1.22.4 -> 1.22.5
* [`072c20b6`](https://github.com/NixOS/nixpkgs/commit/072c20b6e4425ede0c8e34da5147a94e37e872a7) gst_all_1.gst-vaapi: 1.22.4 -> 1.22.5
* [`efe1b514`](https://github.com/NixOS/nixpkgs/commit/efe1b51491b6fa30c72c7b107eb8e8efb1ee25fd) gst_all_1.gst-libav: 1.22.4 -> 1.22.5
* [`db3f0f44`](https://github.com/NixOS/nixpkgs/commit/db3f0f44b54213dab0297c10caa10d44f6286704) gst_all_1.gst-devtools: 1.22.4 -> 1.22.5
* [`edd437e4`](https://github.com/NixOS/nixpkgs/commit/edd437e4a3e01bca632a0862776a1d7c8d6e92f7) gst_all_1.gst-rtsp-server: 1.22.4 -> 1.22.5
* [`a4a6baaf`](https://github.com/NixOS/nixpkgs/commit/a4a6baaf317eff3e4ead98f4b36c052f29004ecb) gst_all_1.gst-editing-services: 1.22.4 -> 1.22.5
* [`98024703`](https://github.com/NixOS/nixpkgs/commit/98024703773fd539b50423deb13b987335ac202a) python3Packages.gst-python: 1.22.4 -> 1.22.5
* [`01234fa1`](https://github.com/NixOS/nixpkgs/commit/01234fa16fdb2eee8ccc52f8310c9354c214734f) ngtcp2: 0.15.0 -> 0.17.0
* [`c1a72d14`](https://github.com/NixOS/nixpkgs/commit/c1a72d1469b8f6525270fc2e09a20de5674ccee6) cacert: 3.90 -> 3.92
* [`46388074`](https://github.com/NixOS/nixpkgs/commit/46388074bef0736c8b5598d5efc8f50134f6653d) python3Packages.tensorstore: init at 0.1.40
* [`33e97611`](https://github.com/NixOS/nixpkgs/commit/33e976114d3cfcb2f5b7d442eac3e62228c9f048) python3Packages.flax: fix build
* [`82e028c1`](https://github.com/NixOS/nixpkgs/commit/82e028c18638018e2a8e26863d655ed6820000f3) python310Packages.pyprecice: 2.5.0.2 -> 2.5.0.3
* [`9458958f`](https://github.com/NixOS/nixpkgs/commit/9458958f4a9b69919bc1073ae471b81313cbd377) ruby: fix build with clang 16
* [`9816ca55`](https://github.com/NixOS/nixpkgs/commit/9816ca55c2fd0619542f420f8e6cfaa8ebaf4ea8) stdenv: Make condition clearer
* [`821a7796`](https://github.com/NixOS/nixpkgs/commit/821a77962d870e633bf9a3096bcc9aae4c97a220) python3Packages.mkdocs-git-revision-date-localized-plugin: init at 1.2.0
* [`0bd475c2`](https://github.com/NixOS/nixpkgs/commit/0bd475c296ed8d6a27323249996745beb9755fc0) nixos/tests/dnscrypt-wrapper: fix flakyness
* [`9b5a4870`](https://github.com/NixOS/nixpkgs/commit/9b5a48709be4126acfb4717393b7c242bfbd5ac1) python311Packages.service-identity: 21.1.0 -> 23.1.0
* [`d74195bc`](https://github.com/NixOS/nixpkgs/commit/d74195bc77c03b6b7aa7c3433205dd518f245ef2) python310Packages.cryptography: 40.0.1 -> 41.0.1
* [`c185e249`](https://github.com/NixOS/nixpkgs/commit/c185e249f47b0578c71118c588bb3c316a3e62ed) python310Packages.pluggy: 1.0.0 -> 1.2.0
* [`b99bb507`](https://github.com/NixOS/nixpkgs/commit/b99bb507d252d2496a0f589a69ae21651b6c3672) python310Packages.pluggy: run tests
* [`c499860f`](https://github.com/NixOS/nixpkgs/commit/c499860fbcc16cb7a4b8b5ba47604bb789d93ad5) python310Packages.virtualenv: 20.19.0 -> 20.24.0
* [`141d87e4`](https://github.com/NixOS/nixpkgs/commit/141d87e423f771b718a86c795bd151ba7124b439) python310Packages.tzlocal: 4.2 -> 4.3
* [`4bb701de`](https://github.com/NixOS/nixpkgs/commit/4bb701de1c25c811dea0fcb347cb959604bac078) python311Packages.pycryptodome: 3.17.0 -> 3.18.0
* [`cfd1870f`](https://github.com/NixOS/nixpkgs/commit/cfd1870ff9a39d01c2c1da50bb6787137b758ce3) python311Packages.validators: 0.20.0 -> 0.21.1
* [`2f118991`](https://github.com/NixOS/nixpkgs/commit/2f11899180915f33189c155898f3cfa8d4c12595) python310Packages.pyyaml: 6.0 -> 6.0.1
* [`1b43a8d6`](https://github.com/NixOS/nixpkgs/commit/1b43a8d663a97f06b01da09a490f260660f33e12) python310Packages.pytest-asyncio: 0.20.3 -> 0.21.0
* [`93035489`](https://github.com/NixOS/nixpkgs/commit/9303548967b946a2ad3e6637a4ce18f09dc74d18) python310Packages.httpcore: 0.16.3 -> 0.17.2
* [`d8f45eef`](https://github.com/NixOS/nixpkgs/commit/d8f45eef765d42684fb8f2b5b5f5033d31bac43e) python3Packages.httpx: 0.23.3 -> 0.24.1
* [`85c6c7b6`](https://github.com/NixOS/nixpkgs/commit/85c6c7b64bae700a48dac5ae3ad23cffdd3757b5) python311Packages.flask-limiter: disable on unsupported Python releases
* [`aade3b0c`](https://github.com/NixOS/nixpkgs/commit/aade3b0c00aeb84e884fc3e5fddf17c035d4133e) python311Packages.flask-limiter: 3.1.0 -> 3.3.1
* [`6ac38ebe`](https://github.com/NixOS/nixpkgs/commit/6ac38ebe01db9e58ad33a8f4b9620a2dab98eb97) python311Packages.devtools: 0.10.0 -> 0.11.0
* [`2c3472e0`](https://github.com/NixOS/nixpkgs/commit/2c3472e0016e905c77e7e62a58ea115861a817b1) python311Packages.pytest-httpserver: 1.0.6 -> 1.0.7
* [`c0496407`](https://github.com/NixOS/nixpkgs/commit/c0496407bc0d592041cf800bc3c38dcc7eeaac97) python310Packages.filelock: 3.12.0 -> 3.12.2
* [`d67efb43`](https://github.com/NixOS/nixpkgs/commit/d67efb43e4507a203b0c9070385b677fee6fd693) python310Packages.requests-toolbelt: 0.10.1 -> 1.0.0
* [`8d849205`](https://github.com/NixOS/nixpkgs/commit/8d8492057b750492389f563f2cebbd55fb4f764b) python3Packages.platformdirs: 3.5.1 -> 3.9.1
* [`39b470e1`](https://github.com/NixOS/nixpkgs/commit/39b470e1189bb23998ee46384ab5e26ab3ab4396) python310Packages.dj-rest-auth: 3.0.0 -> 4.0.1
* [`de8fad0e`](https://github.com/NixOS/nixpkgs/commit/de8fad0e43aaf15e95d0f597eb984811ee5f20a1) python310Packages.httpcore: add passthru.tests
* [`9e6ff886`](https://github.com/NixOS/nixpkgs/commit/9e6ff886edd1fa1ac801aa09d9f0f75a2767273d) python310Packages.sphinx-autodoc-typehints: 1.22 -> 1.23.0
* [`dd7721ac`](https://github.com/NixOS/nixpkgs/commit/dd7721acb7e24f24b0d84b7516b6fe2baa1bc85d) python311Packages.python-rtmidi: 1.4.9 -> 1.5.4
* [`51db3f6c`](https://github.com/NixOS/nixpkgs/commit/51db3f6c4aeb04ff2c507dc386eb4eb8d38ed488) ledfx: 2.0.67 -> 2.0.69
* [`8e5efa27`](https://github.com/NixOS/nixpkgs/commit/8e5efa270ff4d360d9a106e49d3b46b3c5395c58) python310Packages.pybind11: 2.10.4 -> 2.11.1
* [`5262a7d1`](https://github.com/NixOS/nixpkgs/commit/5262a7d1c9c81d86fb8c75104fd16f2c7b868aee) doc/python: Demonstrate how to override the blas implementation
* [`8056d854`](https://github.com/NixOS/nixpkgs/commit/8056d8544f315deb6bd4e490164fb19f7acb1e73) xsimd: Fix cross compilation
* [`1298c367`](https://github.com/NixOS/nixpkgs/commit/1298c367b106f005c06b8537bd8954d7ff97885c) pip-build-hook.sh: Support $pipBuildFlags
* [`6560d008`](https://github.com/NixOS/nixpkgs/commit/6560d0086cb710e24ab55670d955e5e96feb7ded) python3.pkgs.pypaBuildHook: init
* [`9176d9e1`](https://github.com/NixOS/nixpkgs/commit/9176d9e14118ca39eb7f76d4051c1e965efb1f16) python3.pkgs.pythran: 0.11.0 -> 0.13.1
* [`4c772b98`](https://github.com/NixOS/nixpkgs/commit/4c772b984f5648d05b701c4ac36ee4157aa775ec) python3.pkgs.meson-python: 0.12.1 -> 0.13.1
* [`70d182be`](https://github.com/NixOS/nixpkgs/commit/70d182be3fd458c42dd196dadd971f5f5abdf608) python3.pkgs.meson-python: populate python build flags with $mesonFlags
* [`68efe0a5`](https://github.com/NixOS/nixpkgs/commit/68efe0a5a7f8dad328a6e41dfba052b9620587ec) python3.pkgs.scipy: Add doronbehar as maintainer
* [`8f4914fa`](https://github.com/NixOS/nixpkgs/commit/8f4914fae672acd60975b1dbf92ec4fa5b4ee2f1) python3.pkgs.scipy: 1.10.1 -> 1.11.1
* [`6828bf6f`](https://github.com/NixOS/nixpkgs/commit/6828bf6fbef157192ff1475dc97f127f4fb61571) python310Packages.pyopenssl: 23.1.1 -> 23.2.0
* [`58e9dcfe`](https://github.com/NixOS/nixpkgs/commit/58e9dcfe7616bfe786213cf8ede314b48c699aaf) python310Packages.pandas: 1.5.3 -> 2.0.3
* [`ca7f8c87`](https://github.com/NixOS/nixpkgs/commit/ca7f8c877527bd4107b974fa0e5383af79d20baf) python310Packages.scipy: relax pybind11 dependency
* [`9f456a06`](https://github.com/NixOS/nixpkgs/commit/9f456a06dc2ec0785c31a15a488bc0c08214038b) python310Packages.constantly: use python variant of overrideAttrs
* [`39f9cc8d`](https://github.com/NixOS/nixpkgs/commit/39f9cc8ded7dc9887b80edb268ed92081809a68c) python310Packages.a2wsgi: init at 1.7.0
* [`802e5ab6`](https://github.com/NixOS/nixpkgs/commit/802e5ab6f1c68bec37985152721bbc3319799b7a) python310Packages.uvicorn: 0.20.0 -> 0.23.1
* [`a5e4dd0a`](https://github.com/NixOS/nixpkgs/commit/a5e4dd0aa8228ae30690f61afa57872cebe23efe) python310Packages.gunicorn: 20.1.0 -> 21.1.0
* [`052f5aea`](https://github.com/NixOS/nixpkgs/commit/052f5aea580dd5a10d179fe682f521f28c3bb5d4) python310Packages.calver: move tests to passthru.tests
* [`a020d643`](https://github.com/NixOS/nixpkgs/commit/a020d64376be75d2ca78a57b926036dcf41844e1) python310Packages.hatchling: 0.13.0 -> 0.18.0
* [`dc15a2b6`](https://github.com/NixOS/nixpkgs/commit/dc15a2b6864c0f45ab932b283ce37c92fdc360e1) python310Packages.trove-classifiers: 2023.5.24 -> 2023.7.6
* [`5cad16a5`](https://github.com/NixOS/nixpkgs/commit/5cad16a52944d21e31bf428aa4593b464b36bdf1) python310Packages.jsonschema-specifications: init at 2023.7.1
* [`8a280b59`](https://github.com/NixOS/nixpkgs/commit/8a280b59d72622028dd7af387a162a90e8985d41) python310Packages.jsonschema-spec: 0.1.4 -> 0.2.3
* [`7c1f46aa`](https://github.com/NixOS/nixpkgs/commit/7c1f46aa9089aa0e8645da888e14e16a49594f3d) python310Packages.referencing: 0.29.1 -> 0.30.0
* [`bcc2a1b1`](https://github.com/NixOS/nixpkgs/commit/bcc2a1b1118993413520e954c7d16ad211ae399b) python310Packages.jsonschema: 4.17.3 -> 4.18.4
* [`1ee622b1`](https://github.com/NixOS/nixpkgs/commit/1ee622b10fcafcf2343960e3ffae0169afc59804) python310Packages.twisted: disable failing test due to pyopenssl update
* [`2e5cb27e`](https://github.com/NixOS/nixpkgs/commit/2e5cb27eb9ced8da9ce8cbeaca13d15785c841fd) python310Packages.keyring: 23.13.1 -> 24.2.0
* [`895e78a4`](https://github.com/NixOS/nixpkgs/commit/895e78a474b1470ea6bf38bc043c780dcafb9e36) python310Packages.pikepdf: 7.2.0 -> 8.1.1
* [`b9012fdf`](https://github.com/NixOS/nixpkgs/commit/b9012fdfc6772418017b797a63a3002a756e634e) python310Packages.cairocffi: 1.4.0 -> 1.5.1
* [`43c94158`](https://github.com/NixOS/nixpkgs/commit/43c941588e716f0e2c63b390e16dfe34edaf93a4) maturin: remove seemingly unused dbus buildInput
* [`9ccbaee2`](https://github.com/NixOS/nixpkgs/commit/9ccbaee24d9f36b86bf1664bcf71e3ca569b6d57) python310Packages.pyjwt: 2.7.0 -> 2.8.0
* [`61f5fbb4`](https://github.com/NixOS/nixpkgs/commit/61f5fbb485c7471889098dede354196195834e27) python310Packages.click: 8.1.3 -> 8.1.6
* [`55717243`](https://github.com/NixOS/nixpkgs/commit/55717243edb5034161455ffbf679a5890332232c) python3.pkgs.numpy: 1.24.2 -> 1.25.1
* [`59a8e991`](https://github.com/NixOS/nixpkgs/commit/59a8e9915e3b054e972ee922966e409e07d5c87b) python310Packages.cython_3: 3.0.0b2 -> 3.0.0
* [`1148d236`](https://github.com/NixOS/nixpkgs/commit/1148d2369b59cc1a9ee8fdb826c2f8dd5c9dfd6e) python311Packages.factory_boy: 3.2.1 -> 3.3.0
* [`d9c4b673`](https://github.com/NixOS/nixpkgs/commit/d9c4b673b6b64da50e7ce3087c8a7c9bd12bf89a) python310Packages.jsonschema: run tests with pytest
* [`21b9b3ad`](https://github.com/NixOS/nixpkgs/commit/21b9b3ad7e084693d8bc990e6f9e7cc255b14844) python310Packages.openapi-schema-validator: 0.4.4 -> 0.6.0
* [`23d55b92`](https://github.com/NixOS/nixpkgs/commit/23d55b922a176e9221f4dae111107fd3f8eb127a) python310Packages.openapi-spec-validator: 0.5.6 -> 0.6.0
* [`470db3a7`](https://github.com/NixOS/nixpkgs/commit/470db3a7bda494e2233bb9c29052f55302cfe2cc) python310Packages.django-oauth-toolkit: disable pytest-xdist for now
* [`4c0061c9`](https://github.com/NixOS/nixpkgs/commit/4c0061c983a2bcb888f5c478cfb7631ec1090c22) python310Packages.urllib3: 1.26.14 -> 1.26.16
* [`587e94be`](https://github.com/NixOS/nixpkgs/commit/587e94be0b971306cbc7f7ff3f8e493ceec4d0e9) python3.pkgs.gunicorn: 21.1.0 -> 21.2.0
* [`21366ecb`](https://github.com/NixOS/nixpkgs/commit/21366ecb4d5d86e568b6d0cc0cdf0336e17118ad) python3.pkgs.drf-spectacular: 0.26.2 -> 0.26.3
* [`f88e0be2`](https://github.com/NixOS/nixpkgs/commit/f88e0be2a36cb447633986a7ec7ac5b1bb3d6f00) baserow: don't require outdated peer dependencies
* [`a37a318c`](https://github.com/NixOS/nixpkgs/commit/a37a318c536ac1e4460878e3d1b65500587d63ba) python310Packages.scikit-build: 0.16.7 -> 0.17.6
* [`39b5325a`](https://github.com/NixOS/nixpkgs/commit/39b5325a660f7e4a44019f38eede486b9a4419a4) taskflow: 3.5.0 -> 3.6.0
* [`1bc94584`](https://github.com/NixOS/nixpkgs/commit/1bc94584869724430bf382184bb55dda4660e43d) rapidfuzz-cpp: 1.11.3 -> 2.0.0
* [`6879da99`](https://github.com/NixOS/nixpkgs/commit/6879da99662636c3aeac986fe46f82c8002e5092) python310Packages.rapidfuzz: 3.0.0 -> 3.1.1
* [`8d2246e7`](https://github.com/NixOS/nixpkgs/commit/8d2246e7c4f0ef719ccb00d3dd9ffab1950b6b87) python310Packages.levenshtein: 0.21.0 -> 0.21.1
* [`7588527e`](https://github.com/NixOS/nixpkgs/commit/7588527ebf510330e2eaf8850efceaeb78dde894) python310Packages.objgraph: fix tests
* [`0122a38f`](https://github.com/NixOS/nixpkgs/commit/0122a38ff28102edf9e4b0c218b9475963d2f528) python310Packages.objgraph: specify optional dependencies
* [`4e7b3a41`](https://github.com/NixOS/nixpkgs/commit/4e7b3a4137edac2ee054f7a915473ca099a051d7) poetry: fix build
* [`57040932`](https://github.com/NixOS/nixpkgs/commit/57040932807c563a4ea32b27f2ea8986aa92d751) python310Packages.botocore: 1.29.79 -> 1.31.9
* [`438475da`](https://github.com/NixOS/nixpkgs/commit/438475dac5dba9674cc79b439c0736acf14430e3) python310Packages.boto3: 1.26.79 -> 1.28.9
* [`50d38ab7`](https://github.com/NixOS/nixpkgs/commit/50d38ab78d5c5a995d149683e9e1b8a637876601) awscli: 1.27.79 -> 1.29.9
* [`10fd6d03`](https://github.com/NixOS/nixpkgs/commit/10fd6d034b94c40ca869fcfec5ba6fecdb749542) awscli2: 2.12.7 -> 2.13.3
* [`0f23a142`](https://github.com/NixOS/nixpkgs/commit/0f23a142ecb07b876abc4e429d295d4c241e894d) awsebcli: refactor, relax dependencies, and enable tests
* [`aeb8940c`](https://github.com/NixOS/nixpkgs/commit/aeb8940c3631ae7cc0619af44033d06d145d7c00) python310Packages.fixtures: 3.0.0 -> 4.1.0
* [`c4af83ca`](https://github.com/NixOS/nixpkgs/commit/c4af83ca96d30a21df15ba793479eb7a2c9fa96e) bashate: add missing testtools dependency
* [`a34f191c`](https://github.com/NixOS/nixpkgs/commit/a34f191c663eb9dff68e15e02a37a22fef3302ec) pifpaf: add missing testtools dependency
* [`6a048d0e`](https://github.com/NixOS/nixpkgs/commit/6a048d0ed4fc0302b6c67591fc93d48d5caa3578) python310Packages.pyopnsense: add missing testtools dependency
* [`f542b15d`](https://github.com/NixOS/nixpkgs/commit/f542b15d755fafcf47208c90455d286d34783df2) python310Packages.oslotest: add missing six dependency
* [`b12b1ae9`](https://github.com/NixOS/nixpkgs/commit/b12b1ae9e12ff5c1aee0150580b39e76a729725b) python310Packages.ldappool: add missing six dependency
* [`3ba65a37`](https://github.com/NixOS/nixpkgs/commit/3ba65a3719c0ea2da7d31d36b5572a9ce64a8f98) python310Packages.rustworkx: add missing testtools dependency
* [`6d45281d`](https://github.com/NixOS/nixpkgs/commit/6d45281dde8fc05e6ab0e706681bfbb6330ed2ed) csvs-to-sqlite: 1.2 -> 1.3
* [`02cd4de8`](https://github.com/NixOS/nixpkgs/commit/02cd4de89cb702549dade434c2aba61a28f96d60) python310Packages.botocore: add format = "setuptools"
* [`f3503c5e`](https://github.com/NixOS/nixpkgs/commit/f3503c5e4e144d9f4a15c1e188fa7b6cb49ee3fe) ansible-later: relax dependency on PyYAML
* [`0718c345`](https://github.com/NixOS/nixpkgs/commit/0718c3451758a10493d1078e3e80e1abba32fbc2) aws-sam-cli: unpin pyopenssl
* [`d407a2dd`](https://github.com/NixOS/nixpkgs/commit/d407a2dd4c66d1205ed133361b126d4532d0c2c5) awscli2: allow using cryptography version 41
* [`852ab542`](https://github.com/NixOS/nixpkgs/commit/852ab542d219e5b1c0c176d3171fc2e04ce35a4a) conan: relax dependency on pyyaml
* [`4cfa09c5`](https://github.com/NixOS/nixpkgs/commit/4cfa09c5cde625988c5b47854bc0d75b0e5c599f) das: 0.3.6 -> 0.3.8
* [`ab735664`](https://github.com/NixOS/nixpkgs/commit/ab7356640a41814fbf8b5e537683ca7fa6b6e9af) python310Packages.nbformat: 5.7.3 -> 5.9.1
* [`34c84513`](https://github.com/NixOS/nixpkgs/commit/34c8451309ee85e2419deb0eab90b8ff87f0f7c8) python3Packages.pytest-xdist: 3.2.1 → 3.3.1
* [`4ccda2d3`](https://github.com/NixOS/nixpkgs/commit/4ccda2d36dc14c40b785c2062a5e9b850eca2e49) python310Packages.zipp: 3.15.0 -> 3.16.2
* [`c34f0668`](https://github.com/NixOS/nixpkgs/commit/c34f0668efd17ad0169faaf7cd3dd8b0fbfa7609) python310Packages.lxml: 4.9.2 -> 4.9.3-3
* [`e1007b09`](https://github.com/NixOS/nixpkgs/commit/e1007b0935b633e7d65597e3a14284893619a49b) python310Packages.traitlets: cleanup dependencies, change homepage to be more usefull
* [`81267368`](https://github.com/NixOS/nixpkgs/commit/81267368ca91ec71a6c91188116e1c1e2e894e22) python310Packages.qtconsole: add missing dependency on ipython_genutils
* [`1ea53651`](https://github.com/NixOS/nixpkgs/commit/1ea53651736373060be37cc684372ceb108f3c47) python310Packages.uharfbuzz: 0.24.1 -> 0.37.1, drop inactive maintainer
* [`5330b05d`](https://github.com/NixOS/nixpkgs/commit/5330b05d9952aad7606d5c0658d65faf1955c659) python3.pkgs.ruamel-yaml: 0.17.21 -> 0.17.32
* [`4af6b796`](https://github.com/NixOS/nixpkgs/commit/4af6b7960e5e2120e3f0c4d69096f878d7bf45b8) awscli2: pin ruamel-yaml
* [`ce48f9a2`](https://github.com/NixOS/nixpkgs/commit/ce48f9a2696b4cb93a17dc49b0b8d2f93213434c) pypy310Packages.eventlet: replace nose with nose3, disable hanging tests on pypy
* [`2dafa7e5`](https://github.com/NixOS/nixpkgs/commit/2dafa7e5f2d7ae3c2f3a555cb9b4a9971871b084) python3Packages.sympy: 1.11.2 -> 1.12.0
* [`b2fe286c`](https://github.com/NixOS/nixpkgs/commit/b2fe286ca2073d837950a46affe3d9529bccab21) python310Packages.pytest: 7.2.1 -> 7.4.0
* [`8eb97ac1`](https://github.com/NixOS/nixpkgs/commit/8eb97ac1a167406b7f70e911f4c828300ac6ab13) python310Packages.pytest-asyncio: 0.21.0 -> 0.21.1
* [`3d826ee5`](https://github.com/NixOS/nixpkgs/commit/3d826ee5b32972a065199aba80be0a0feca52963) python310Packages.pytest-mock: 3.10.0 -> 3.11.1
* [`92eaff99`](https://github.com/NixOS/nixpkgs/commit/92eaff99ce684fe3f7d7991a8b525dc857706ec3) python310Packages.pytest-rerunfailures: 11.1.2 -> 12.0
* [`3060a601`](https://github.com/NixOS/nixpkgs/commit/3060a6016f0e2023d8513634c511c7e42d09d2a5) python310Packages.pytest-env: 0.8.1 -> 0.8.2
* [`3f0c47f5`](https://github.com/NixOS/nixpkgs/commit/3f0c47f531cacf2917593d7545e557fd5208a96c) python310Packages.pytest-subtests: 0.10.0 -> 0.11.0
* [`155e8790`](https://github.com/NixOS/nixpkgs/commit/155e879007665dab64cf32dc543ca40534f0002f) python310Packages.pytest-metadata: 2.0.4 -> 3.0.0
* [`99a038df`](https://github.com/NixOS/nixpkgs/commit/99a038dfca5f471dcb7ec3954ae4f5327862a331) python310Packages.pytest-cov: 4.0.0 -> 4.1.0
* [`35ffaa2b`](https://github.com/NixOS/nixpkgs/commit/35ffaa2bb46733c93a31b0b9cbc319b31b22568a) python310Packages.pytest-factoryboy: 2.1.0 -> 2.5.1
* [`39818200`](https://github.com/NixOS/nixpkgs/commit/3981820055c3e752ba5798195578e3ec7c0be8dd) python310Packages.flit: 3.8.0 -> 3.9.0
* [`6d05ab18`](https://github.com/NixOS/nixpkgs/commit/6d05ab18ede1d6dba71e2f19de92ad900cef1618) python310Packages.pdm-backend: 2.1.1 -> 2.1.4
* [`af94d88a`](https://github.com/NixOS/nixpkgs/commit/af94d88a26ac01e60b37ad9a155398c75ba5f70e) python310Packages.pdm-pep517: 1.1.2 -> 1.1.4
* [`ea1795f0`](https://github.com/NixOS/nixpkgs/commit/ea1795f035607ba6915990c74a46a1dd1bdfae4d) python310Packages.setuptools-rust: 1.5.2 -> 1.6.0
* [`9f2565b0`](https://github.com/NixOS/nixpkgs/commit/9f2565b0ffad2a8924f6738db721f095afefea1b) python310Packages.django-bootstrap3: 23.1 -> 23.4
* [`48ad096c`](https://github.com/NixOS/nixpkgs/commit/48ad096cebb2c8a8b646fc9729bd693229720c6b) python310Packages.django-bootstrap4: 23.1 -> 23.2
* [`f2d9add2`](https://github.com/NixOS/nixpkgs/commit/f2d9add2370e50b4152e191c15d433c39c0f2c74) python310Packages.django-js-asset: 2.0 -> 2.1
* [`e40f85f3`](https://github.com/NixOS/nixpkgs/commit/e40f85f3586f3650059b8d2d7c008a5fd46897da) python3.pkgs.chacha20poly1305-reuseable: 0.2.5 -> 0.3.0
* [`96f2b967`](https://github.com/NixOS/nixpkgs/commit/96f2b9670902b1bb78557a51f00f3f9f29863565) python310Packages.graphene-django: 3.1.2 -> 3.1.3
* [`57c99aa8`](https://github.com/NixOS/nixpkgs/commit/57c99aa8ce37dd5df2ec4aa93f3012958e9f5b6a) python311Packages.crownstone-cloud: remove asynctest
* [`af32a731`](https://github.com/NixOS/nixpkgs/commit/af32a73150b2d23e437c837db3e6dccc97d36236) python311Packages.aioimaplib: disable tests
* [`74e4efff`](https://github.com/NixOS/nixpkgs/commit/74e4efff459474f98a05e20e1748d7efb22638c9) python310Packages.fnv-hash-fast: 0.3.1 -> 0.4.0
* [`ed1a0dce`](https://github.com/NixOS/nixpkgs/commit/ed1a0dce0cb59a427a895d12369a615bbd2b5318) python310Packages.cryptography: 41.0.1 -> 41.0.2
* [`a51b9d5e`](https://github.com/NixOS/nixpkgs/commit/a51b9d5eafff6e894c1c5fdf4587ca592975cf68) python310Packages.msgspec: fix hash mismatch
* [`6d8f291f`](https://github.com/NixOS/nixpkgs/commit/6d8f291f9a0625cc449114a3fe1675251584fdbf) python310Packages.sqlalchemy: 2.0.18 -> 2.0.19
* [`1f78dc9a`](https://github.com/NixOS/nixpkgs/commit/1f78dc9a7ed910a89fcc21dd2aa4ab74806d238c) python310Packages.typing-inspect: 0.8.0 -> 0.9.0
* [`d37303e9`](https://github.com/NixOS/nixpkgs/commit/d37303e9b3a60144a93dfd16e0ecadfd801fa817) python310Packages.aiohttp: disable regularly failing tests
* [`71c4dd55`](https://github.com/NixOS/nixpkgs/commit/71c4dd5581a3690e9bbe526a5f37845fbc19726f) python310Packages.pygments: 2.14.0 -> 2.15.1
* [`bbc9723a`](https://github.com/NixOS/nixpkgs/commit/bbc9723a8e9bcfd714bcc3e19a2512f3ea8cd9c3) python310Packages.pygments-better-html: 0.1.4 -> 0.1.5
* [`cc1fceff`](https://github.com/NixOS/nixpkgs/commit/cc1fceff620afbad9f007923e2d5149da063debc) python310Packages.snitun: disable failing test
* [`7466da3e`](https://github.com/NixOS/nixpkgs/commit/7466da3ef231fb3a25f93747b0812401d3fba48c) python310Packages.scikit-learn: 1.2.1 -> 1.3.0
* [`2a06c513`](https://github.com/NixOS/nixpkgs/commit/2a06c513cda7de66bde3bbff4a2db17eab06315e) python310Packages.joblib: 1.2.0 -> 1.3.1
* [`52dc6bf6`](https://github.com/NixOS/nixpkgs/commit/52dc6bf6290b34a7c0fdec37bbc276a4ff03e26a) python310Packages.av: use headless ffmpeg variant
* [`bdf1a965`](https://github.com/NixOS/nixpkgs/commit/bdf1a96570808dc9e11cfbb1ffa5b8a7ff001e2d) python310Packages.pillow: 9.5.0 -> 10.0.0
* [`8cb27687`](https://github.com/NixOS/nixpkgs/commit/8cb27687cdf9ca6f3e476c7c49a25acc829e1487) python310Packages.kombu: 5.3.0 -> 5.3.1
* [`5c0d3d36`](https://github.com/NixOS/nixpkgs/commit/5c0d3d36b9639c8481d53f2515af1e09476ef5af) python310Packages.celery: 5.3.0 -> 5.3.1
* [`f56d0307`](https://github.com/NixOS/nixpkgs/commit/f56d03070951e7870683e57606e52c722c9f6503) home-assistant: deselect failing tests
* [`3009624d`](https://github.com/NixOS/nixpkgs/commit/3009624dc8ec45887e47a3ca0a5842a33cec6d8c) python310Packages.pytest-randomly: 3.12.0 -> 3.13.0
* [`0190e1d8`](https://github.com/NixOS/nixpkgs/commit/0190e1d8bdb6783bac2106b302970388f648b2d9) python310Packages.zarr: 2.14.2 -> 2.16.0
* [`7fdc9291`](https://github.com/NixOS/nixpkgs/commit/7fdc9291b6d76347bbfdd79fbea89df74472b924) python310Packages.xarray: 2023.2.0 -> 2023.7.0
* [`37036dc2`](https://github.com/NixOS/nixpkgs/commit/37036dc2d4f836af3d90cd37b4bd5220d682a910) python310Packages.jupyter-server: 2.0.6 -> 2.7.0
* [`42205573`](https://github.com/NixOS/nixpkgs/commit/42205573c18651c1a4dd8c8e162757902fc2d8bb) python310Packages.pint: 0.20.1 -> 0.22
* [`b9af64aa`](https://github.com/NixOS/nixpkgs/commit/b9af64aad28a6d9a0e09cd7494923db44e72b279) python310Packages.mypy: 1.3.0 -> 1.4.1
* [`95558af1`](https://github.com/NixOS/nixpkgs/commit/95558af10f40d664642619fdf1602f64e48da6a8) python310Packages.astroid: 2.14.2 -> 2.15.6
* [`d09efd67`](https://github.com/NixOS/nixpkgs/commit/d09efd672dcb82fe19cf522bfcf02b946d85f846) python310Packages.pylint: 2.16.2 -> 2.17.5
* [`c8fcb9a4`](https://github.com/NixOS/nixpkgs/commit/c8fcb9a4b476f842380547c4064e37b6f060fa08) python310Packages.sanic-testing: 22.12.0 -> 23.6.0
* [`ffaaf0c1`](https://github.com/NixOS/nixpkgs/commit/ffaaf0c1960ef368a7ecb806e58f7c10837c02af) python310Packages.sanic-routing: 22.8.0 -> 23.6.0
* [`0ef17cbd`](https://github.com/NixOS/nixpkgs/commit/0ef17cbd0c83dac24b6aee1e72273d3bab263908) python310Packages.html5tagger: init at 1.3.0
* [`06e2ff5a`](https://github.com/NixOS/nixpkgs/commit/06e2ff5aa00689406b7ba0c97bb4fa8ce018c90e) python310Packages.tracerite: init at 1.1.0
* [`49eeca4a`](https://github.com/NixOS/nixpkgs/commit/49eeca4abec240d545d5c9233ee8325ebd251ed0) python310Packages.sanic: 22.12.0 -> 23.6.0
* [`18601b84`](https://github.com/NixOS/nixpkgs/commit/18601b84248ffec5f490d3481f6005c7f83b5bca) python311Packages.hologram: disable
* [`7933516c`](https://github.com/NixOS/nixpkgs/commit/7933516c827da88f818825c6ca57bef79b18bec2) python310Packages.poetry-core: use vendored tomlkit
* [`d84e0dde`](https://github.com/NixOS/nixpkgs/commit/d84e0ddeb66e44cea31dc62487f2719f8b3bd93c) python310Packages.tomlkit: 0.11.6 -> 0.12.1
* [`5cb5c7d9`](https://github.com/NixOS/nixpkgs/commit/5cb5c7d9fb5fffcbb96b5622c37819b226361df0) hatch: 1.6.3 -> 1.7.0
* [`e0326ced`](https://github.com/NixOS/nixpkgs/commit/e0326ced66114dc965cdb697643aa81b58ab4e53) python310Packages.prance: 0.22.02.22.0 -> 23.06.21.0
* [`5444a903`](https://github.com/NixOS/nixpkgs/commit/5444a903c6ba25bb3c8c5bf94982fa6c1fa5c7f2) python310Packages.dnspython: 2.3.0 -> 2.4.1
* [`c5c2cce5`](https://github.com/NixOS/nixpkgs/commit/c5c2cce5c9cd21b47a22d0a0af3f94eeeaf35512) python310Packages.usort: 1.1.0b2 -> 1.0.7
* [`258a83f9`](https://github.com/NixOS/nixpkgs/commit/258a83f9e79d76726cf04eb27901aed7fb47daf6) python311Packages.cherrypy: disable failing tests
* [`c677ee5c`](https://github.com/NixOS/nixpkgs/commit/c677ee5cd45d8d46c5a290f14fd3410091c9388e) python310Packages.cvxpy: 1.3.1 -> 1.3.2
* [`d2a74c54`](https://github.com/NixOS/nixpkgs/commit/d2a74c54547514172267a6efe49d40758f18df08) python310Packages.markdown: 3.4.3 -> 3.4.4
* [`ab0ca887`](https://github.com/NixOS/nixpkgs/commit/ab0ca887e9d8d07d8cbbf7ae520e241d577d313e) python310Packages.pikepdf: 8.1.1 -> 8.2.1
* [`4cd4b1b1`](https://github.com/NixOS/nixpkgs/commit/4cd4b1b166d7ac2e8135f70e9456fa9babd356f1) dnscrypt-wrapper: link NixOS test
* [`ba981fd9`](https://github.com/NixOS/nixpkgs/commit/ba981fd9525a98f09ce91d77dc966a84c8aa6482) pipewire: 0.3.75 -> 0.3.76
* [`ae735c53`](https://github.com/NixOS/nixpkgs/commit/ae735c533cd091ff54df7425c6695edba08fede1) python310Packages.repath: specify dependencies as function args
* [`ddc1932d`](https://github.com/NixOS/nixpkgs/commit/ddc1932de9bd88c5ea2fd9a54d3ac68270057590) python310Packages.flet-core: specify dependencies as function args
* [`c7437c58`](https://github.com/NixOS/nixpkgs/commit/c7437c5836ae7b0c9436d3b468bbba0197c524ee) python310Packages.flet-core: specify dependencies as function args
* [`e66ea733`](https://github.com/NixOS/nixpkgs/commit/e66ea733b0374cff001e3132cf366214e60a75f0) python310Packages.dashing: specify dependencies as function args
* [`92d6b02a`](https://github.com/NixOS/nixpkgs/commit/92d6b02a3399172d9cd604d04847bc8fdb52a7ad) python310Packages.glad2: specify dependencies as function args
* [`22ad0e7e`](https://github.com/NixOS/nixpkgs/commit/22ad0e7ec01c587a34929a8477d368cf307dd346) python310Packages.dask: 2023.4.1 -> 2023.7.1
* [`652646b8`](https://github.com/NixOS/nixpkgs/commit/652646b867c2ba6aa3b0ecaf5f11302469dbb04b) python310Packages.mlflow: 2.4.2 -> 2.5.0
* [`a0277221`](https://github.com/NixOS/nixpkgs/commit/a0277221af97947ba47bac9f7508a94bd47894bf) python310Packages.willow: 1.4.1 -> 1.5.1
* [`83efccef`](https://github.com/NixOS/nixpkgs/commit/83efccef831bfd2e383f4135e37c8d1268108c67) python310Packages.wagtail: 4.2.2 -> 5.0.2
* [`f6a944e3`](https://github.com/NixOS/nixpkgs/commit/f6a944e359f382a47721bcf3d6f8ab3c5d306b82) qt5: remove overrideScope'
* [`18496434`](https://github.com/NixOS/nixpkgs/commit/184964348dd79da0dead70fa1e5b8b9b924734f4) python311Packages.packageurl-python: 0.11.1 -> 0.11.2
* [`fb942c26`](https://github.com/NixOS/nixpkgs/commit/fb942c26f03ff68d23b066473e7d225c54ab019f) eris-go: 20230202 -> 20230729
* [`354821c1`](https://github.com/NixOS/nixpkgs/commit/354821c1e8e30ce8522dc90ccb3e2026b31067b7) nixos/eris-server: init
* [`bc268c29`](https://github.com/NixOS/nixpkgs/commit/bc268c2946a39cdb24c7c4c440d791058cec52a3) thonny: 4.0.2 -> 4.1.1
* [`8a0886a3`](https://github.com/NixOS/nixpkgs/commit/8a0886a3459fbbec66e5e1b2c789d65ac0f64bed) python310Packages.tifffile: 2023.4.12 -> 2023.7.18
* [`98b53179`](https://github.com/NixOS/nixpkgs/commit/98b53179768c5e0dd3107471116e1d5e51f96128) libgit2: fixup build on x86_64-darwin
* [`a061657b`](https://github.com/NixOS/nixpkgs/commit/a061657b0e1a6291dff9333e7438e1197075a633) ihp-new: 1.0.1 -> 1.1.0
* [`6427a6b6`](https://github.com/NixOS/nixpkgs/commit/6427a6b6228b8b683531f46f6ca079b575d5bcb5) yandex-browser: 23.5.4.682-1 -> 23.7.1.1148-1
* [`86d286cb`](https://github.com/NixOS/nixpkgs/commit/86d286cb9ef5d1d26b5c35add35be80269c03a5c) xsimd: 9.0.1 -> 11.1.0
* [`8bd2ba2f`](https://github.com/NixOS/nixpkgs/commit/8bd2ba2f434489a86e7289e024efb33d094dcaf8) xsimd: Reformat
* [`39919b8f`](https://github.com/NixOS/nixpkgs/commit/39919b8f215110c1516f5c6b300f5ee69df23fd4) stdenv: use improved strip.sh for aarch64-linux
* [`24d382d2`](https://github.com/NixOS/nixpkgs/commit/24d382d2c121b67d0492c9e847620e8a87f896f4) python3.pkgs.pygit2: remove patches from libgit2 pin
* [`eba9bbc2`](https://github.com/NixOS/nixpkgs/commit/eba9bbc251db942ae27f87824cae643b5f3198c2) dtrx: 8.5.1 -> 8.5.3
* [`97a9d12b`](https://github.com/NixOS/nixpkgs/commit/97a9d12b6c31a58e9067eae7cdcd3f53055c124c) dtrx: don't double-wrap the binary
* [`f1d5f976`](https://github.com/NixOS/nixpkgs/commit/f1d5f9766ee821b812045922816a4a670e0d57fa) libsmbios: Fix build ([nixos/nixpkgs⁠#246264](https://togithub.com/nixos/nixpkgs/issues/246264))
* [`91e2f185`](https://github.com/NixOS/nixpkgs/commit/91e2f185c03242cd37485b153757b947933e8071) libsmbios: future proof RPATH fix
* [`ef573449`](https://github.com/NixOS/nixpkgs/commit/ef573449913f7c3c883945aac284b2d036aad2a4) python3Packages.tensorstore: specify meta.sourceProvenance
* [`b6723f5c`](https://github.com/NixOS/nixpkgs/commit/b6723f5c10b655293336dd03e90de9e0653e8249) python310Packages.pytools: 2023.1 -> 2023.1.1
* [`c706309a`](https://github.com/NixOS/nixpkgs/commit/c706309a9ff4e38d3a7cc7182133f2d44d2a2f52) plasma5Packages.accounts-qt: fixup a hack that broke
* [`88b27970`](https://github.com/NixOS/nixpkgs/commit/88b2797038045ef81fa9973195b2274902c59ec9) xsimd: Fix exp10 darwin build error
* [`e6133a81`](https://github.com/NixOS/nixpkgs/commit/e6133a81c8189d79276e82db87d50af795899497) libhwy: fix build on aarch64
* [`af1383d2`](https://github.com/NixOS/nixpkgs/commit/af1383d24979ee9c2dd51d5ecf6efa450e9b1583) python310Packages.knack: 0.10.1 -> 0.11.0
* [`3349da7e`](https://github.com/NixOS/nixpkgs/commit/3349da7ee5e716efa32acdc018b9015ea7530ad4) speedtest-explorer: Remove as unmaintained
* [`9738ead1`](https://github.com/NixOS/nixpkgs/commit/9738ead17fb2e1aa92137bcb1203af20198e1341) prometheus-speedtest-exporter: Remove as unmaintained
* [`8fd0ff15`](https://github.com/NixOS/nixpkgs/commit/8fd0ff15837347ed488abdb8232ad0ae40c52971) libhwy: apply the new patch conditionally
* [`83b15dcf`](https://github.com/NixOS/nixpkgs/commit/83b15dcf00ada01914865318296c6fb157fd1347) python311Packages.coinmetrics-api-client: 2023.6.8.20 -> 2023.7.11.17
* [`9b77a408`](https://github.com/NixOS/nixpkgs/commit/9b77a40817291115c8528e138bec371c75258738) python310Packages.dkimpy: 1.1.4 -> 1.1.5
* [`8de38f57`](https://github.com/NixOS/nixpkgs/commit/8de38f57c0b47a5d69df6911729483da7ad91132) python310Packages.py-partiql-parser: 0.3.5 -> 0.3.6
* [`6b072a37`](https://github.com/NixOS/nixpkgs/commit/6b072a37c519b07ea3f5fa1fa72a385806ab740e) python310Packages.spacy-lookups-data: 1.0.3 -> 1.0.5
* [`4fa2f56b`](https://github.com/NixOS/nixpkgs/commit/4fa2f56bb86a31f805f8ee5be5732288b6773171) python3Packages.pythran: unvendor the xsimd dependency
* [`9bef3687`](https://github.com/NixOS/nixpkgs/commit/9bef3687ff5f07e342cc3394b4438f35f71522c2) Revert "openexr_3: 3.1.7 -> 3.1.9"
* [`9a55390d`](https://github.com/NixOS/nixpkgs/commit/9a55390da7d6b4850039a1084c0d1d47a7ada640) openttd: 13.3 -> 13.4
* [`0e24afe8`](https://github.com/NixOS/nixpkgs/commit/0e24afe8ea1e53c017c24df6e2c0c991d6f2af91) openttd-jgrpp: 0.54.1 -> 0.54.4
* [`000bb303`](https://github.com/NixOS/nixpkgs/commit/000bb3038f7713d23bc511aebc9e1ef06b085ef4) openttd-jgrpp: override meta.homepage and meta.changelog
* [`a4a03bb2`](https://github.com/NixOS/nixpkgs/commit/a4a03bb261829d49d0cc19b06d435ce371addd5a) xsimd: fix more failing tests
* [`dd4c506d`](https://github.com/NixOS/nixpkgs/commit/dd4c506d8821565e45f4ed293e3724aa44b29cc4) python3.pkgs.tables: fix tests for numpy 1.25
* [`cc5cd006`](https://github.com/NixOS/nixpkgs/commit/cc5cd006dba90094845e454a9c0c5b9e91b1a361) qzdl: init at unstable-2023-04-04
* [`0d4c3913`](https://github.com/NixOS/nixpkgs/commit/0d4c3913b217c783efaacf45e8d482bc7373959f) nixos/no-x-libs: use pythonPackagesExtensions to construct python overlay
* [`5a9fe440`](https://github.com/NixOS/nixpkgs/commit/5a9fe4403fdd466676c0c170dd7981e60a78557a) python3.pkgs.pythran: remove unneeded deps
* [`2d13c9f1`](https://github.com/NixOS/nixpkgs/commit/2d13c9f12d65fc38f36ab1d95f41c46d4f90d04a) linux: 5.10.187 -> 5.10.188
* [`2d415c57`](https://github.com/NixOS/nixpkgs/commit/2d415c57a3375e9b48ef7dd391d01be5f0e15337) linux: 5.15.122 -> 5.15.123
* [`3cc38bd1`](https://github.com/NixOS/nixpkgs/commit/3cc38bd1c9fef10d911e05a118ec687c597a5962) linux: 5.4.250 -> 5.4.251
* [`41ba292d`](https://github.com/NixOS/nixpkgs/commit/41ba292da525fd43ec7724bfe8579f8f9da386d4) linux: 6.1.41 -> 6.1.42
* [`f35c7759`](https://github.com/NixOS/nixpkgs/commit/f35c775969bbc6bf51880f42e5eae43428112907) linux: 6.4.6 -> 6.4.7
* [`8adc59a3`](https://github.com/NixOS/nixpkgs/commit/8adc59a3fa769affc0750ba801fa9c3066feacb6) linux/hardened/patches/5.10: 5.10.187-hardened1 → 5.10.188-hardened1
* [`fad0ee83`](https://github.com/NixOS/nixpkgs/commit/fad0ee83f29282b7e538cd9ffbff3f8f9a5f2134) linux/hardened/patches/5.15: 5.15.122-hardened1 → 5.15.123-hardened1
* [`57d4b822`](https://github.com/NixOS/nixpkgs/commit/57d4b822785661fb03d12407301a91459b7dcc36) linux/hardened/patches/5.4: 5.4.250-hardened1 → 5.4.251-hardened1
* [`de33dd4f`](https://github.com/NixOS/nixpkgs/commit/de33dd4fa1496a74dcd3b635001e522ac2732054) linux/hardened/patches/6.1: 6.1.41-hardened1 → 6.1.42-hardened1
* [`8481c2c3`](https://github.com/NixOS/nixpkgs/commit/8481c2c3fe9b887dd7f9b7bf43a283568c5cf138) linux/hardened/patches/6.4: 6.4.6-hardened1 → 6.4.7-hardened1
* [`eccb6203`](https://github.com/NixOS/nixpkgs/commit/eccb6203926e7d0ed73d4fe624d2948786de91bb) cp2k: 2023.1 -> 2023.2
* [`991770e4`](https://github.com/NixOS/nixpkgs/commit/991770e4318d9a980c455751b9530e24f1368137) bun: 0.7.0 -> 0.7.1
* [`2f630887`](https://github.com/NixOS/nixpkgs/commit/2f63088723a2a85fc2cabdd881f4e1651b3009f0) gtop: use buildNpmPackage
* [`2abdb71b`](https://github.com/NixOS/nixpkgs/commit/2abdb71b9969eec4101f3eeded08ccf673805380) confy: 0.6.5 -> 0.7.0
* [`01e53f70`](https://github.com/NixOS/nixpkgs/commit/01e53f70657cc8948c7701b5471e62be1282b6a3) python3.pkgs.scipy: really exit when tests fail.
* [`d61583bb`](https://github.com/NixOS/nixpkgs/commit/d61583bbc8fa6cdf4796b0bfd6003292ab8d1be8) python3.pkgs.scipy: set HOME to a writeable directory
* [`94a86351`](https://github.com/NixOS/nixpkgs/commit/94a86351df7b62a98143157066ae736f6d17addd) perlPackages.BerkeleyDB: 0.64 -> 0.65
* [`676eaea4`](https://github.com/NixOS/nixpkgs/commit/676eaea4a4d942ed8602b1b0c10dbef49058ef20) perlPackages.CryptX: 0.076 -> 0.078
* [`5be1087e`](https://github.com/NixOS/nixpkgs/commit/5be1087e8f05241672908e96030bd1fe978ada53) perlPackages.DataClone: add patch for perl 5.38.0
* [`f7a347ee`](https://github.com/NixOS/nixpkgs/commit/f7a347eeb601a0a6ce6299363d927e34f9cd13bb) perlPackages.DevelCaller: 2.06 -> 2.07
* [`74e20f52`](https://github.com/NixOS/nixpkgs/commit/74e20f52728e0b139aea412ab457e9e9db20c676) perlPackages.DevelFindPerl: 0.015 -> 0.016
* [`d0122478`](https://github.com/NixOS/nixpkgs/commit/d01224781f715fa82a615e914a1e924d9f24ccff) perlPackages.DevelNYTProf: 6.10 -> 6.12
* [`5a9c09f2`](https://github.com/NixOS/nixpkgs/commit/5a9c09f2f7e50122bb2d56ded80b2142a1439ba6) perlPackages.ExceptionBase: add patch for perl 5.38.0
* [`42dde6e4`](https://github.com/NixOS/nixpkgs/commit/42dde6e410e019620973f048385a5c6aabaf2831) perlPackages.ExtUtilsConstant: add patch for failing test
* [`86683e13`](https://github.com/NixOS/nixpkgs/commit/86683e13dd7c4645a7de9321860629391e1e19d9) perlPackages.HTMLMason: 1.59 -> 1.60
* [`ad79d89c`](https://github.com/NixOS/nixpkgs/commit/ad79d89c35a9c85ca9ecef865baadc4f953ca2bc) perlPackages.LogLog4perl: 1.53 -> 1.57
* [`eb8100ea`](https://github.com/NixOS/nixpkgs/commit/eb8100ea15fa4aa1fcab5267b7d9f25420556a54) eigenpy: 3.1.0 -> 3.1.1
* [`f09adcd9`](https://github.com/NixOS/nixpkgs/commit/f09adcd95753904f7306ce9c3484c91e5b1a7315) fxlinuxprint{,util}: fix src again
* [`894d47f9`](https://github.com/NixOS/nixpkgs/commit/894d47f9896096587aed6028099a90430355199d) nixos/grub: Always install with bootloader id
* [`f12b2165`](https://github.com/NixOS/nixpkgs/commit/f12b216574f5dfd6f26a8be5b19661e89d92c983) nixos/grub: Fix extraFiles in subdirectories
* [`50063bf9`](https://github.com/NixOS/nixpkgs/commit/50063bf9d62f782757bf33a83fec40db593841d6) nixos/grub: Add support for timeoutStyle
* [`c867c6d1`](https://github.com/NixOS/nixpkgs/commit/c867c6d17288a604d08e313092d0db7c19f11d60) nixos/grub: Insert required image modules for themes
* [`1d416595`](https://github.com/NixOS/nixpkgs/commit/1d416595adfc7d48ef06ee49ffd2d9efee2c8859) nixos/grub: Remove `with` with broad scopes.
* [`f977c9cb`](https://github.com/NixOS/nixpkgs/commit/f977c9cbb7a087a5fc3dae94c4f1d7caf6fb73db) python310Packages.pylink-square: 1.1.0 -> 1.2.0
* [`2d6a598a`](https://github.com/NixOS/nixpkgs/commit/2d6a598a8a8691080a7b12e316ce7aac64cab88a) python310Packages.trytond: 6.8.2 -> 6.8.3
* [`c4ee3d50`](https://github.com/NixOS/nixpkgs/commit/c4ee3d504af9e6e9476642a8952daad49b98f222) nuclear: 0.6.6 -> 0.6.27
* [`b84ea26f`](https://github.com/NixOS/nixpkgs/commit/b84ea26fc8c582a64968dbbc554b0c61584f5789) python3.pkgs.llvmlite: 0.39.1 -> 0.40.1
* [`e7cd5935`](https://github.com/NixOS/nixpkgs/commit/e7cd5935912e405ec15cba1d2a2fa5142a66188a) python311Packages.steamship: 2.17.18 -> 2.17.22
* [`f39227ed`](https://github.com/NixOS/nixpkgs/commit/f39227edf76f4649488e64df9b7fb251c9a4e5fa) python3.pkgs.llvmlite: 0.40.1 -> 0.41.0dev0
* [`dfff667d`](https://github.com/NixOS/nixpkgs/commit/dfff667d324cfe954b822ffbb4ed621e75b24a7e) python3.pkgs.numba: 0.56.4 -> unstable-2023-08-02
* [`e754f294`](https://github.com/NixOS/nixpkgs/commit/e754f2946b9d101b94d8fea49cb545c17aa3846f) buildBazelPackage: add support for bazel run targets
* [`22114b44`](https://github.com/NixOS/nixpkgs/commit/22114b44bd01225ee690cb87962d927b54d54319) python3Packages.ml-dtypes: init at 0.2.0
* [`7b16d5d8`](https://github.com/NixOS/nixpkgs/commit/7b16d5d8cb8f2bda4a9bf4948b58fb6d4714061d) python3Packages.jaxlib-bin: 0.4.4 -> 0.4.14
* [`06ef57da`](https://github.com/NixOS/nixpkgs/commit/06ef57da87f0c88778fbf2b2496663f68a6927ed) python3Packages.jax: 0.4.5 -> 0.4.14
* [`6232bc9c`](https://github.com/NixOS/nixpkgs/commit/6232bc9c7bc1974770751a50c2aa4f3d14e4e133) python3Packages.jaxlib: 0.4.4 -> 0.4.14
* [`c25f522d`](https://github.com/NixOS/nixpkgs/commit/c25f522dda2cc9a7f8798fafe7630c83493b8931) sage: import upstream numpy/scipy upgrade patches
* [`8a06f432`](https://github.com/NixOS/nixpkgs/commit/8a06f4327e4133df69834ace5c40e225cb742a10) libgit2_1_5: fixup build after 98b5317976
* [`96ccfc7f`](https://github.com/NixOS/nixpkgs/commit/96ccfc7f2fb51c2949b2b7d9509fcab125add4f3) python3.pkgs.numba-scipy: relax more deps, using hook
* [`b6a2d04e`](https://github.com/NixOS/nixpkgs/commit/b6a2d04e3339d882fb3060ecd1ffa941ed98fb11) maintainers: add mxkrsv
* [`4c5ac009`](https://github.com/NixOS/nixpkgs/commit/4c5ac0094f7b2a4060c59569ff178ca349d8a8ba) minecraft-server: fix update script
* [`0f47d4b5`](https://github.com/NixOS/nixpkgs/commit/0f47d4b51c415f8c5993ce0c0e71b9942a582e23) minecraft-server: 1.20 -> 1.20.1, 1.7.9 -> 1.7.10
* [`c0e86ede`](https://github.com/NixOS/nixpkgs/commit/c0e86edeaed45ff13d2a1b367916385013a5a8ed) python310Packages.jupytext: add meta.changelog
* [`04dd5a8a`](https://github.com/NixOS/nixpkgs/commit/04dd5a8a3b1e34cd2c55042c4d1f6c08b92d9b96) python310Packages.jupytext: 1.14.1 -> 1.15.0
* [`aea90b67`](https://github.com/NixOS/nixpkgs/commit/aea90b672a1a4c523dfc05ad0eab1ef77490c280) python310Packages.jupyter-ydoc: 0.3.4 -> 1.0.2
* [`223f4934`](https://github.com/NixOS/nixpkgs/commit/223f4934999ea36f0bb87885c89867ab0775e179) python310Packages.jupyter-collaboration: init at 1.0.1
* [`1f820d2c`](https://github.com/NixOS/nixpkgs/commit/1f820d2c571ecc6443dd0e43a475caf97e4e54e9) python310Packages.jupyter-server: 2.0.6 -> 2.7.0
* [`e206cf41`](https://github.com/NixOS/nixpkgs/commit/e206cf41b49cb2fd832c65301999a1017c23aa9f) python310Packages.jupyterlab: 3.6.3 -> 4.0.3
* [`8f09dfbd`](https://github.com/NixOS/nixpkgs/commit/8f09dfbdfdd3cb94e842207e99bbfcecee709f4a) python310Packages.jupyterlab_server: 2.19.0 -> 2.24.0
* [`690e58e1`](https://github.com/NixOS/nixpkgs/commit/690e58e11de69953a1e76d0b9cc5f8caee63badd) python310Packages.notebook: 6.5.2 -> 7.0.1
* [`f4d63170`](https://github.com/NixOS/nixpkgs/commit/f4d63170eeb5edc3b464c04ef79de1774f728a35) python3Packages.jaxlib: fix dependency hash on aarch64-linux
* [`dfe6f3e4`](https://github.com/NixOS/nixpkgs/commit/dfe6f3e4cbeb773b64bad93a10f14003e98a1481) python3.pkgs.cx_Freeze: switch to pyproject build
* [`043c1325`](https://github.com/NixOS/nixpkgs/commit/043c1325f657fea146becf0f7246bb4a398595f5) python310Packages.cx-freeze: rename from cx_Freeze
* [`17f4ee84`](https://github.com/NixOS/nixpkgs/commit/17f4ee84949ab85b549a34db33e322b52f2c97af) python3.pkgs.astropy-extension-helpers: add build and test dependencies
* [`c46eadf0`](https://github.com/NixOS/nixpkgs/commit/c46eadf0341a42e494060ffbf255d012abac68e4) python3.pkgs.rdflib: add pip test dependency
* [`697cd3f2`](https://github.com/NixOS/nixpkgs/commit/697cd3f2d329f745fc1839ef4c8ac3719414a3c1) python3.pkgs.qcodes: add build and test dependencies and fix constraints
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
