### PR TITLE
niv devenv: update b4ce82b6 -> ade3ae52

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b4ce82b6a54022c688f9f916b9f7a9c9ed959de1",
-        "sha256": "0w605cyw9xxy2z39lfid5v9xfdr4shwvxzgbbnbrcc6l35c603r1",
+        "rev": "ade3ae522baf366296598e232b7b063d81740bbb",
+        "sha256": "1zfa79gbvajnq3c8x70vcdqsr8nxvcq4ab88rglvh0pf0mgq7vc0",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/b4ce82b6a54022c688f9f916b9f7a9c9ed959de1.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/ade3ae522baf366296598e232b7b063d81740bbb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@b4ce82b6...ade3ae52](https://github.com/cachix/devenv/compare/b4ce82b6a54022c688f9f916b9f7a9c9ed959de1...ade3ae522baf366296598e232b7b063d81740bbb)

* [`507bdcad`](https://github.com/cachix/devenv/commit/507bdcad35253545d43a1fc0898da6ecebb6b52a) docs: add optional linux/macos packages installation snippet
* [`20073032`](https://github.com/cachix/devenv/commit/200730320f4d42e4d6236b3dcf63d3cbf4225d22) Init CockroachDB Service
* [`be12f100`](https://github.com/cachix/devenv/commit/be12f1006c49d4c133bbe95b9a3a8fa29f342bc2) fix docs
* [`d70cec86`](https://github.com/cachix/devenv/commit/d70cec868e832149110ca160494aac91a40e113f) add modern C example
* [`ade3ae52`](https://github.com/cachix/devenv/commit/ade3ae522baf366296598e232b7b063d81740bbb) Auto generate docs/reference/options.md
