### PR TITLE
niv home-manager: update 903e06d7 -> da6874e8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "903e06d734bcae48efb79b9afd51b406d2744179",
-        "sha256": "10ag313wgpz9hbzf4azhlymq89m3l4vz49shabz3ag80disbvmr7",
+        "rev": "da6874e8bb82204323b94154585a1471c739f73e",
+        "sha256": "0vsfbv9fsbaybxlw924ahbyn05fjvya7dviqk9sgf3mmwmpn1q8y",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/903e06d734bcae48efb79b9afd51b406d2744179.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/da6874e8bb82204323b94154585a1471c739f73e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@903e06d7...da6874e8](https://github.com/nix-community/home-manager/compare/903e06d734bcae48efb79b9afd51b406d2744179...da6874e8bb82204323b94154585a1471c739f73e)

* [`7b8d43fb`](https://github.com/nix-community/home-manager/commit/7b8d43fbaf8450c30caaed5eab876897d0af891b) modules: types.string throws error now ([nix-community/home-manager⁠#4324](https://togithub.com/nix-community/home-manager/issues/4324))
* [`a8f8f483`](https://github.com/nix-community/home-manager/commit/a8f8f48320c64bd4e3a266a850bbfde2c6fe3a04) mu: add package option ([nix-community/home-manager⁠#4325](https://togithub.com/nix-community/home-manager/issues/4325))
* [`6e1eff9a`](https://github.com/nix-community/home-manager/commit/6e1eff9aac0e8d84bda7f2d60ba6108eea9b7e79) kanshi: support adaptive sync ([nix-community/home-manager⁠#4328](https://togithub.com/nix-community/home-manager/issues/4328))
* [`255f9210`](https://github.com/nix-community/home-manager/commit/255f921049df8d45fb5afa2529b79106edbd8301) programs.khal: uncomment locale config ([nix-community/home-manager⁠#4319](https://togithub.com/nix-community/home-manager/issues/4319))
* [`406d34d9`](https://github.com/nix-community/home-manager/commit/406d34d919e9e8b831b531782cf5ef6995188566) lf: simplify option validation ([nix-community/home-manager⁠#4334](https://togithub.com/nix-community/home-manager/issues/4334))
* [`c3ab5ea0`](https://github.com/nix-community/home-manager/commit/c3ab5ea047e6dc73df530948f7367455749d8906) home-manager: handle profile list in Nix >2.17
* [`88067b9b`](https://github.com/nix-community/home-manager/commit/88067b9b148ed86f81d80d13e49f0f848dbd96e0) hyprland: remove xwayland.hidpi ([nix-community/home-manager⁠#4302](https://togithub.com/nix-community/home-manager/issues/4302))
* [`d08812fe`](https://github.com/nix-community/home-manager/commit/d08812fe1a850b5948b2101cb4adcb6f8c4faa94) Translate using Weblate (Portuguese (Brazil))
* [`da6874e8`](https://github.com/nix-community/home-manager/commit/da6874e8bb82204323b94154585a1471c739f73e) Translate using Weblate (Romanian)
