### PR TITLE
niv powerlevel10k: update f851f41f -> 69d726d9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "f851f41fc14d5bd66266b4b4af917d50c1c8b7fe",
-        "sha256": "1w7nw2nvgpl5sx5jqnsp05n8z3i5rgbnalyg52nm26c5n5w6qqrs",
+        "rev": "69d726d9fbe5bcd1f590ce06184727d9563e9950",
+        "sha256": "048hwn8jp3w538y7f3lynmzlribjrc5rccj0hlww6jf54zls1dfq",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/f851f41fc14d5bd66266b4b4af917d50c1c8b7fe.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/69d726d9fbe5bcd1f590ce06184727d9563e9950.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@f851f41f...69d726d9](https://github.com/romkatv/powerlevel10k/compare/f851f41fc14d5bd66266b4b4af917d50c1c8b7fe...69d726d9fbe5bcd1f590ce06184727d9563e9950)

* [`717f9a18`](https://github.com/romkatv/powerlevel10k/commit/717f9a1881c1bd179658951b8628f1b395c1cb11) fix typos in docs and comments
* [`22cb2f79`](https://github.com/romkatv/powerlevel10k/commit/22cb2f79ddb89a368dd823e815fa1b0587ff1b6a) Squashed 'gitstatus/' changes from 4b47ca047..abb4f6a52
* [`9401ed17`](https://github.com/romkatv/powerlevel10k/commit/9401ed17c0a8c3d1654214a204b8d5b5f7ccf386) Squashed 'gitstatus/' changes from abb4f6a52..bdaad2e8d
