### PR TITLE
niv zsh-completions: update 5328eb7c -> 955ac75d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "5328eb7c01270417ad6d0ce75682dea00dfa18f2",
-        "sha256": "0hd5d6fz9zfqywk9ks8rjq863fg7qfr4zl8rmdp2jrva875mcjf1",
+        "rev": "955ac75daf456dc24dc147a82e7df38af3edd8e3",
+        "sha256": "1rfhm18byv4abxhzxgnw4miv0kvmvlhzw2zr7d5n8iz4zdiz76sm",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/5328eb7c01270417ad6d0ce75682dea00dfa18f2.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/955ac75daf456dc24dc147a82e7df38af3edd8e3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@5328eb7c...955ac75d](https://github.com/zsh-users/zsh-completions/compare/5328eb7c01270417ad6d0ce75682dea00dfa18f2...955ac75daf456dc24dc147a82e7df38af3edd8e3)

* [`05fd7004`](https://github.com/zsh-users/zsh-completions/commit/05fd7004040974c97d619b7490cc47d648c7cbff) Update for go 1.21
* [`30fd8208`](https://github.com/zsh-users/zsh-completions/commit/30fd8208050e4838d5c439e306e042864b291290) Update protoc completion for version 24.0
* [`b44635f0`](https://github.com/zsh-users/zsh-completions/commit/b44635f0d98124e40ec4e3ae20730aac53b37595) Update rubocop completion for version 1.55
* [`ba54f170`](https://github.com/zsh-users/zsh-completions/commit/ba54f170a6250080ca88089ac6bf8cfbfe3c2b43) Avoid defining local variable options
* [`2a2efae5`](https://github.com/zsh-users/zsh-completions/commit/2a2efae5f601f6bb7efffa944412c4fd6d96a5f7) Update flutter and dart completion
