### PR TITLE
niv nixpkgs: update 2a600eea -> 59f057ef

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2a600eea3eedd2a1be81d4595e8259bb780bd865",
-        "sha256": "0ikl1fil3cmadc64lxq8qi0dh608barx04a1i7fmkymlkljil00i",
+        "rev": "59f057ef4608e7c7a342137935083e8ed7707339",
+        "sha256": "0dcsnbjawv6k5cwfrvr8lh4d2a4b3sq75ihwww8vic9xc27al1fn",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/2a600eea3eedd2a1be81d4595e8259bb780bd865.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/59f057ef4608e7c7a342137935083e8ed7707339.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@2a600eea...59f057ef](https://github.com/nixos/nixpkgs/compare/2a600eea3eedd2a1be81d4595e8259bb780bd865...59f057ef4608e7c7a342137935083e8ed7707339)

* [`b51302ed`](https://github.com/NixOS/nixpkgs/commit/b51302ed47ad40536050c41f4bf021a0076fe3d0) Add `stdenv.cc.libcxx` to detect the standard C++ library
* [`c927a4cf`](https://github.com/NixOS/nixpkgs/commit/c927a4cfed58c0d5bb1bcde4cd7782b2b9e96151) python310Packages.python-rapidjson: 1.9 -> 1.10
* [`92939f4c`](https://github.com/NixOS/nixpkgs/commit/92939f4ce233018d7bde58f8fbfd405a9a6c8e28) lib/systems/parse.nix: show respect where deserved
* [`ebd46190`](https://github.com/NixOS/nixpkgs/commit/ebd4619053711ffb317a36dca4b118ae33f17828) patch-shebangs: add a flag to update shebangs with store paths
* [`07be8b4c`](https://github.com/NixOS/nixpkgs/commit/07be8b4c3989dd451c1a54dc8ae00dcee3b8785f) maintainers: add rotaerk
* [`7c05751d`](https://github.com/NixOS/nixpkgs/commit/7c05751d3eb3b0cd63ec518a26279b55f917507c) haskellPackages: stackage LTS 20.26 -> LTS 21.0
* [`45134baa`](https://github.com/NixOS/nixpkgs/commit/45134baa29492771eb731e23c16b915820170800) all-cabal-hashes: 2023-06-19T20:13:38Z -> 2023-06-28T16:36:39Z
* [`ff11be7c`](https://github.com/NixOS/nixpkgs/commit/ff11be7cbff74717137360c919fd0ee8859d56cd) haskellPackages: regenerate package set based on current config
* [`59e94be9`](https://github.com/NixOS/nixpkgs/commit/59e94be9fea7441abd0fef034b019e3f392bd89f) ghc: update default version 9.2.x -> 9.4.x
* [`871fdf1d`](https://github.com/NixOS/nixpkgs/commit/871fdf1dcb5afc41c59f76e8e585d91849053015) haskellPackages: Remove obsolete aeson_2_1_2_1 overrides
* [`29c34218`](https://github.com/NixOS/nixpkgs/commit/29c342186d0852cfeca2f4fa9410f579dbc7ec58) haskellPackages: drop more outdated overrides
* [`bfe0cb4e`](https://github.com/NixOS/nixpkgs/commit/bfe0cb4ebdd87f3995af37344c6dc3e19b474ac6) haskellPackages: drop more obsolete overrides
* [`28cd493d`](https://github.com/NixOS/nixpkgs/commit/28cd493da3a155c59a08717f16c2a9d8e01a2276) haskellPackages: drop more obsolete overrides
* [`1008860a`](https://github.com/NixOS/nixpkgs/commit/1008860a08aa835682e86169d995d0e55450b462) haskellPackages.foldable1-classes-compat: Disable tests to break recursion cycle
* [`c2431c66`](https://github.com/NixOS/nixpkgs/commit/c2431c66427ac717ee02c42d3e1a85a3bf96df47) haskellPackages.attoparsec-iso8601: Remove redundant override
* [`34478fa7`](https://github.com/NixOS/nixpkgs/commit/34478fa7f51c52c2fdfefe93eec3c2c09ccd48fa) haskellPackages.cachix: Remove redundant override
* [`79245124`](https://github.com/NixOS/nixpkgs/commit/79245124c709ac2783e0fd59940a408f5c24e50a) haskellPackages: cleanup Cabal versions
* [`10844fd0`](https://github.com/NixOS/nixpkgs/commit/10844fd0b3847ab9674dcc87998874770336b7b5) haskellPackages.streamly-lmdb: drop obsolete override
* [`c5e61a11`](https://github.com/NixOS/nixpkgs/commit/c5e61a111a0f1ba722b5e4511474b46d0ef7e304) haskellPackages: Dump obsolete overrides for hls dependencies
* [`7b7f7933`](https://github.com/NixOS/nixpkgs/commit/7b7f7933bd8e537b1567795c35b21ce11271f70b) haskellPackages: regenerate package set based on current config
* [`dcf434af`](https://github.com/NixOS/nixpkgs/commit/dcf434af95f3a4c039ba46d88a1ba7df217dc7ad) haskellPackages.gi-soup: drop obsolete manual version pin
* [`64bee977`](https://github.com/NixOS/nixpkgs/commit/64bee9771ee832c9fbfc1f78d3ca361c805a4502) haskell.packages.ghc94: remove remaining manually chosen versions
* [`3ad6e939`](https://github.com/NixOS/nixpkgs/commit/3ad6e93971ffc1296777fb80551abad2e20f4c24) haskell.packages.ghc94.shake-cabal: drop bound
* [`20d2845c`](https://github.com/NixOS/nixpkgs/commit/20d2845ce61035c89270dd155fd0892c481a4234) haskellPackages.sensei: works with Stackage LTS hspec versions now
* [`4c2f247e`](https://github.com/NixOS/nixpkgs/commit/4c2f247e11fb36c7b4c8603e9fc8f3f195d10fe2) haskell.packages.*.Cabal-syntax: expose dummy packages for GHC < 9.4
* [`babf4f93`](https://github.com/NixOS/nixpkgs/commit/babf4f9327d0fed073fcea11543c3a6113b7c241) haskell.packages.*.hashable: provide data-array-byte for GHC < 9.4
* [`2eacf4f9`](https://github.com/NixOS/nixpkgs/commit/2eacf4f93fc9c6cf823312aaebf82f0ba496f0d3) haskellPackages.singletons-*: drop obsolete overrides
* [`95b5aab7`](https://github.com/NixOS/nixpkgs/commit/95b5aab7d1fbf9d0c14877fbf6d5485fbd190428) haskellPackages.integer-conversion: drop stale broken flag
* [`974363bf`](https://github.com/NixOS/nixpkgs/commit/974363bfc16a9979b3e718357f269d520ab20957) haskell.packages.ghc96.foundation: drop obsolete patch
* [`32f8dd4b`](https://github.com/NixOS/nixpkgs/commit/32f8dd4beea32725ac68d6e56f65d6d23b97c1e2) haskell.packages.ghc96: drop now unnessary version pins
* [`e905807b`](https://github.com/NixOS/nixpkgs/commit/e905807bf275512db3085d4523a45d7d67d7a7bf) haskellPackages.swarm: drop obsolete brick override
* [`f50da30a`](https://github.com/NixOS/nixpkgs/commit/f50da30a5ddca84b5f4dc87490ba6330d3dd0ff2) haskell.packages.*.system-cxx-std-lib: make sure attr always exists
* [`e97404a5`](https://github.com/NixOS/nixpkgs/commit/e97404a52fd14ac72e1ea245b3abc9e42a301305) haskellPackages: remove versioned references to hspec-meta-2.10.5
* [`5dcd4af4`](https://github.com/NixOS/nixpkgs/commit/5dcd4af462681e74b3f3e8156c306dd118605f29) haskellPackages.streamly-archive: drop obsolete override
* [`69eb7120`](https://github.com/NixOS/nixpkgs/commit/69eb712039562ba856ff7b6a230f2749ae9e4290) haskellPackages.graphql: drop obsolete jailbreak
* [`a64bd8ff`](https://github.com/NixOS/nixpkgs/commit/a64bd8ff32d9a9ec66d4ea1c51439ec5b056b064) haskellPackages.wai-token-bucket-ratelimiter: drop obsolete jailbreak
* [`f8ea1144`](https://github.com/NixOS/nixpkgs/commit/f8ea114431f1681fc5b204961fe0242624cbf41b) haskellPackages.guardian: remove unnecessary path-io override
* [`df2e2e4d`](https://github.com/NixOS/nixpkgs/commit/df2e2e4de9f2b00ab94666a442b7e8c0d6f86e08) haskellPackages.hslua-repl: mark unbroken
* [`dddbca4e`](https://github.com/NixOS/nixpkgs/commit/dddbca4e22f8e213b3a80eac215ee59649457f45) haskellPackages.string-qq: jailbreak because of too strict bounds on text in tests
* [`f5b28a07`](https://github.com/NixOS/nixpkgs/commit/f5b28a0744186f9be570bedbc5717012577df150) haskellPackages.hslua-typing: mark unbroken
* [`c15e0b6b`](https://github.com/NixOS/nixpkgs/commit/c15e0b6bdcb77f7a9bfef427b158c32023e33dff) haskellPackages.crypton-x509: get building
* [`e003a7ad`](https://github.com/NixOS/nixpkgs/commit/e003a7adc1f5caeee6c197098b23ce870d81437e) haskellPackages.pandoc-cli: get building
* [`18ff7569`](https://github.com/NixOS/nixpkgs/commit/18ff756909d94a3ec1cd97da20c14eaec56b002a) haskellPackages.ShellCheck_0_8_0: remove
* [`dbe2c9e2`](https://github.com/NixOS/nixpkgs/commit/dbe2c9e2ba9df18cf2471c8cd5cd43fe16b65a6a) haskellPackages.pandoc-cli: Expose overriden dependencies
* [`06672ed4`](https://github.com/NixOS/nixpkgs/commit/06672ed4e0e820375baa3f5ae507d93e5402f8e5) pandoc: Use pandoc-cli package
* [`a68afb51`](https://github.com/NixOS/nixpkgs/commit/a68afb5101236307e3f11109b666eb103e43ef02) haskellPackages: regenerate package set based on current config
* [`b00a29fd`](https://github.com/NixOS/nixpkgs/commit/b00a29fdd6265fc325f2227605b8d3ef6cdd5344) haskellPackages: Drop trailing whitespace
* [`96eed7bc`](https://github.com/NixOS/nixpkgs/commit/96eed7bcb8ff7f18bb3213131a81e7852a51d5c7) spago: remove myself as maintainer
* [`b049eee8`](https://github.com/NixOS/nixpkgs/commit/b049eee84066b4c9ba61d76c4441d4d83dccc2cb) haskellPackages.purenix: remove myself as maintainer
* [`84627b05`](https://github.com/NixOS/nixpkgs/commit/84627b0594b55669cdb18dcb7d5fe89a00e79fce) stack: get building
* [`6cc8bbe4`](https://github.com/NixOS/nixpkgs/commit/6cc8bbe4b62b8a2005c78093220751bcdb804922) haskell.packages.{ghc88,ghc810}.OneTuple: depend on foldable1-classes-compat
* [`54ebdad4`](https://github.com/NixOS/nixpkgs/commit/54ebdad42dd5861538de31319206fcef78ec9df5) haskell.packages.{ghc88,ghc810}.base-compat-batteries: loosen OneTuple bound
* [`5407503f`](https://github.com/NixOS/nixpkgs/commit/5407503fba4bee22db41444ed2097e315e0b662d) haskell.packages.*.cabal-install: provide correct versions of deps
* [`c244ddfa`](https://github.com/NixOS/nixpkgs/commit/c244ddfaa1ce62401d066641d3bdf06093d50e33) haskellPackages: Cleanup overrides in main.yaml
* [`766d4624`](https://github.com/NixOS/nixpkgs/commit/766d462426fdb3c1a2af6993bf916e4225ca8758) haskell.packages.ghc94.haskell-gi: add __CabalEagerPkgConfigWorkaround for some packages
* [`5afd9751`](https://github.com/NixOS/nixpkgs/commit/5afd97510b8da477240546d3c22b9d20780688fd) haskell.packages.ghc94.haskell-gi: add __CabalEagerPkgConfigWorkaround for more packages
* [`64b2287b`](https://github.com/NixOS/nixpkgs/commit/64b2287b70fdbbfefd9469f9e8a19d53de653873) haskell.packages.ghc94.haskell-gi: add __CabalEagerPkgConfigWorkaround for even more packages
* [`44e687d5`](https://github.com/NixOS/nixpkgs/commit/44e687d50f8e8eb62658fec9dcacb7ad5086e085) termonad: get building
* [`a739c59d`](https://github.com/NixOS/nixpkgs/commit/a739c59d4e2fa1d9050c315baf3e0d23fbcc8148) haskellPackages.large-hashable: restrict to GHC < 9.4
* [`a712e72a`](https://github.com/NixOS/nixpkgs/commit/a712e72a8aac135a3cd9c336e2e4b0b7b9f429e4) haskell.packages.ghc96.hpack: test no Hydra
* [`eda8d293`](https://github.com/NixOS/nixpkgs/commit/eda8d2938155ab0734852a7dd31e35af7f4a7acd) haskell.packages.ghc96.language-haskell-extract: patch TH code
* [`cc025c68`](https://github.com/NixOS/nixpkgs/commit/cc025c684dd431fad3cf93bf2c83d94e963722be) haskell.packages.ghc96.monad-par: patch for mtl >= 2.3
* [`2fbdec4b`](https://github.com/NixOS/nixpkgs/commit/2fbdec4b072f720eb831676c23ea0bd96922e2fe) haskellPackages.irc-{client,conduit}: lift upper bound on tls and text
* [`04b987ad`](https://github.com/NixOS/nixpkgs/commit/04b987ade5286c97d6877a98c5ecdedac9a5599c) haskell-ci: allow lattices-2.2
* [`9b491439`](https://github.com/NixOS/nixpkgs/commit/9b491439e5df0ae75c046c27dc45211acf9055ce) haskellPackages.rel8: allow hedgehog
* [`55b8958f`](https://github.com/NixOS/nixpkgs/commit/55b8958f7d7e76a3328e7287c8c7d7572d980f9d) tests.haskell.shellFor: change package used in extraDependencies test
* [`7f77b751`](https://github.com/NixOS/nixpkgs/commit/7f77b75171bdb36252dc3f9bfcca638e29f62a19) gitit: patch for Stackage LTS-21 compat
* [`58018115`](https://github.com/NixOS/nixpkgs/commit/580181157de59194e8e3b4b5551dc7b660e5284d) haskellPackages.hnix-store-core_0_6_1_0: allow algebraic-graphs 0.7
* [`8aeb0de9`](https://github.com/NixOS/nixpkgs/commit/8aeb0de93dd371d4e578f1d4e21c4ddf8a8460e0) haskell: re-enable profiling on aarch64
* [`20b0406a`](https://github.com/NixOS/nixpkgs/commit/20b0406a00aa630e4f98cf737e528a47e639ae18) haskell.*.ghc*BinaryMinimal: remove
* [`3274e92d`](https://github.com/NixOS/nixpkgs/commit/3274e92dc5899c57f69a8dd9b90fc97bcc96bc99) git-annex: update sha256 for 10.20230626
* [`8a5e2cb1`](https://github.com/NixOS/nixpkgs/commit/8a5e2cb13f2ab881974a60e8c6539529bacd0125) git-annex: provide unix-compat < 0.7
* [`c4b23c7e`](https://github.com/NixOS/nixpkgs/commit/c4b23c7e7e462d039692f643c68add735ef3ecc3) haskellPackages.optics: temporarily disable tests
* [`9ec80c88`](https://github.com/NixOS/nixpkgs/commit/9ec80c88e37b6ae55ed280d64d8a802c6ae5f2d1) haskellPackages.hermes-json_0_2_0_1: stop generating because it is no longer used
* [`c5bb5c1e`](https://github.com/NixOS/nixpkgs/commit/c5bb5c1e54232fa37024d5186c5ba6e4b83db0de) haskellPackages.hermes-json: jailbreak
* [`96223b9d`](https://github.com/NixOS/nixpkgs/commit/96223b9d0de13e82f374c2da271fbfeded75e1a9) haskellPackages.hiedb: fix compiling with algebraic-graphs-0.7
* [`375e877c`](https://github.com/NixOS/nixpkgs/commit/375e877c2149e6d7556ed2d14376f9a137b5cffa) haskellPackages.implicit-hie: lock to earlier version for ghcide
* [`8dc6c681`](https://github.com/NixOS/nixpkgs/commit/8dc6c6812dfcd907922b21d1ce24e1789fb2e4c4) haskellPackages.hls-overloaded-record-dot-plugin: set HOME for tests
* [`7c9c1c48`](https://github.com/NixOS/nixpkgs/commit/7c9c1c4802b7284b34a89c95d7ea16e56a404a12) haskellPackages.stylish-haskell: 0.14.5.0 -> 0.14.4.0
* [`0e504b68`](https://github.com/NixOS/nixpkgs/commit/0e504b6873bd61226782ce6ac9f89fb299af8aa4) haskell.packages.ghc96.ConfigFile: add build patch
* [`83d68068`](https://github.com/NixOS/nixpkgs/commit/83d68068cf115a18f6a2670d9dd9e5299f0f248d) haskell.packages.ghc96.warp: Fix build
* [`76a030ef`](https://github.com/NixOS/nixpkgs/commit/76a030effd500633f45680b731fdf09856247fb2) haskell.packages.ghc96.{cairo,glib,pango}: remove jailbreaks
* [`285a85da`](https://github.com/NixOS/nixpkgs/commit/285a85dac4a9afa9480392746bcd8af4c0fe2b0b) haskell.packages.ghc96.gi-cairo-connector: add jailbreak for mtl
* [`689ff4fd`](https://github.com/NixOS/nixpkgs/commit/689ff4fd8f947974e836a08162b0c429ea420d82) haskell.packages.ghc96.taffybar: Fix build with blunt force
* [`30e99edd`](https://github.com/NixOS/nixpkgs/commit/30e99eddbeca88f171d3708780d74f2efb9ac4d7) haskell.packages.ghc96.gi-gtk: Work around compiler issue
* [`b93b279b`](https://github.com/NixOS/nixpkgs/commit/b93b279b6ecacd9b4dc9c6c6d27a7ce6bd9de16b) haskell.packages.ghc92.ghc-exactprint: revert to old version
* [`fccf6292`](https://github.com/NixOS/nixpkgs/commit/fccf629213cd2ca3657c641a88bb6e2413f4dcc3) jacinda: patch for alex >= 3.3
* [`7b60b7eb`](https://github.com/NixOS/nixpkgs/commit/7b60b7ebf739f4d02fde1a9f453467c108ce0cb3) haskellPackages.cmark: allow text == 2.0.*
* [`e6088690`](https://github.com/NixOS/nixpkgs/commit/e6088690a1dba93242c66fc7394ba4486e75bb54) haskellPackages.pandoc-emphasize-code: Disable tests, allow text == 2.0.*
* [`7542fb7c`](https://github.com/NixOS/nixpkgs/commit/7542fb7cbc3eee8e7a58b4934253a7dd29ff340a) haskellPackages.espial: Fix build by patching with upstream commit
* [`de679473`](https://github.com/NixOS/nixpkgs/commit/de679473b879a88b2b8dee98eecb408c0348f0bd) haskell.packages.ghc94.svgcairo: add __CabalEagerPkgConfigWorkaround
* [`5af63b49`](https://github.com/NixOS/nixpkgs/commit/5af63b4958cc33679b3987ed0350a572a21ab63c)  haskell.packages.ghc94.gtk3: add __CabalEagerPkgConfigWorkaround
* [`ca0091f0`](https://github.com/NixOS/nixpkgs/commit/ca0091f00ba635f486185f2613face27c5699052) haskellPackages.hercules-ci-agent: nixPackage 2.14 -> 2.16
* [`65f90b54`](https://github.com/NixOS/nixpkgs/commit/65f90b5469e0b036262d21822c942f71274f897a) haskellPackages.{cachix,hercules-ci-agent}: fix build
* [`297448c9`](https://github.com/NixOS/nixpkgs/commit/297448c99c8f3bb9895c130f950a87486a628be8) haskellPackages.cabal2nix-unstable: unstable-2023-05-05 -> unstable-2023-07-10
* [`1b36ac8e`](https://github.com/NixOS/nixpkgs/commit/1b36ac8eec5195a42bbb2b980b4cf5c5fc3d88fa) haskellPackages.rest-rewrite: regenerate with new version of cabal2nix
* [`3ba086a6`](https://github.com/NixOS/nixpkgs/commit/3ba086a64b3997ee82e331abaf3af7049e3fc742) haskellPackages.rest-rewrite: fix by creating graphs directory for tests
* [`1eddb04a`](https://github.com/NixOS/nixpkgs/commit/1eddb04ac9fd76f0183e23b1c00e23b66fd013ac) haskell.compiler.{ghc962,ghcHEAD}: no rendered src on aarch64-linux
* [`ed377370`](https://github.com/NixOS/nixpkgs/commit/ed377370497dc036bacaa253d8f3d9311f5404e5) add maintainer lu15w1r7h
* [`fc97e60a`](https://github.com/NixOS/nixpkgs/commit/fc97e60a594ee6aee5aacfe46098661b70c83e0c) haskellPackages.shelly: fix test script execution
* [`72652d46`](https://github.com/NixOS/nixpkgs/commit/72652d46c8a4690432826ce956ed6f573d689bd6) haskell.packages.ghc9{4,6}.th-extras: drop bound on template-haskell
* [`970d1dda`](https://github.com/NixOS/nixpkgs/commit/970d1ddaa63d0f6f3004a036bafb5bc02b0c8ab8) haskellPackages.aeson-better-errors: allow aeson == 2.1.*
* [`08aba291`](https://github.com/NixOS/nixpkgs/commit/08aba291862ebd58f4fc42460e4a7b1700aac790) haskellPackages.base-compat{,batteries}: 0.12.2 -> 0.12.3
* [`c50fc90f`](https://github.com/NixOS/nixpkgs/commit/c50fc90fe689f2dcba5c708832fd1454c5998d93) proj: 9.2.0 -> 9.2.1
* [`5bab0075`](https://github.com/NixOS/nixpkgs/commit/5bab0075cf283f753f593e3f36c9dd7915a1df40) python310Packages.pyproj: 3.5.0 -> 3.6.0
* [`b9be587f`](https://github.com/NixOS/nixpkgs/commit/b9be587f5ed01c9548def9822c2dfb715fd24cca) haskellPackages.patat: Patch to bump dependencies, override pandoc
* [`4ad43ff1`](https://github.com/NixOS/nixpkgs/commit/4ad43ff1cb6926714d8d691c821b9094dbf70b2f) haskellPackages.protoeaaudio: unbreak
* [`bc8fbc25`](https://github.com/NixOS/nixpkgs/commit/bc8fbc25723b05e0f909faa6589641867200775b) lib.lists.hasPrefix: init
* [`9fdc0bb2`](https://github.com/NixOS/nixpkgs/commit/9fdc0bb2bfa2d1dd631bb39f3b9e7cfec16bcd54) lib.lists.removePrefix: init
* [`d72b2ae9`](https://github.com/NixOS/nixpkgs/commit/d72b2ae9c0729a3c79046bd61d319864870f2d26) haskellPackages.matrix-client: jailbreak
* [`22b8869e`](https://github.com/NixOS/nixpkgs/commit/22b8869e6165eabcd8067bd507fc4524bf1f8b5b) haskellPackages.shh: jailbreak
* [`240ae41c`](https://github.com/NixOS/nixpkgs/commit/240ae41cbfac5cb3d912bb31c35957774d1e342c) haskellPackages.jsaddle: patch
* [`732e4469`](https://github.com/NixOS/nixpkgs/commit/732e4469cbcfeef847f46c99f3cddb7b6558021d) darwin.adv_cmds: fix build with clang 16
* [`5bd1f315`](https://github.com/NixOS/nixpkgs/commit/5bd1f315ba5935761b912bf6237282e2bb3e2693) haskellPackages.reflex-dom-core: Fix build
* [`ace41329`](https://github.com/NixOS/nixpkgs/commit/ace41329a55baca40cb4c4baccd19670cdaa65c7) haskellPackages.{gtk,gio}: Use established workaround
* [`5619bfa7`](https://github.com/NixOS/nixpkgs/commit/5619bfa758703baec61399868ad77bd2400e7599) haskellPackages.ghcjs-dom: jailbreak
* [`de6a8565`](https://github.com/NixOS/nixpkgs/commit/de6a8565eea11dfe06a6ae4163d883c338b12037) haskellPackages: Add workaround for more haskell-gi packages
* [`c78223a5`](https://github.com/NixOS/nixpkgs/commit/c78223a5fff5cd89819a88f23de03d3b8d45c796) tests.haskell.upstreamStackHpackVersion: init
* [`ebcb9db2`](https://github.com/NixOS/nixpkgs/commit/ebcb9db21d0c3c20eb83f3ee3739223d4e5a8a0c) haskell.packages.{ghc90x,ghc94x}: Remove unnecessary jailbreaks
* [`bae7b8ae`](https://github.com/NixOS/nixpkgs/commit/bae7b8ae569e51cff47f8e45edf161a7eca3f344) haskellPackages.lvar: jailbreak
* [`065de168`](https://github.com/NixOS/nixpkgs/commit/065de168f785f25a446236a4376a3a2a0a812d76) python310Packages.mock: 4.0.3 -> 5.1.0
* [`cb91c4cc`](https://github.com/NixOS/nixpkgs/commit/cb91c4cc3dac3c67b3e0ce733fe69d2ebbf4c627) python310Packages.mock: update meta
* [`ce52bf9c`](https://github.com/NixOS/nixpkgs/commit/ce52bf9cc39c66850a399cb573b50bce809658c5) meson: 1.1.1 -> 1.2.0
* [`2da166c1`](https://github.com/NixOS/nixpkgs/commit/2da166c1cebfebdd8d20a275d04bf67b2aea21cb) haskellPackages.ema: check, jailbreak
* [`23bb7c65`](https://github.com/NixOS/nixpkgs/commit/23bb7c65c37945745c87ad9f002a428d51753b13) haskellPackages.shh: jailbreak
* [`fd429f5b`](https://github.com/NixOS/nixpkgs/commit/fd429f5bac9a254f98b86bd8dab301272627ba63) matrix-synapse: Prune deps, add missing deps, expose extras
* [`34531285`](https://github.com/NixOS/nixpkgs/commit/3453128510040c6ad343b98cd44eab5397c63c2e) matrix-synapse: Add wrapper to configure extras
* [`1076c3ad`](https://github.com/NixOS/nixpkgs/commit/1076c3ada61204581af579474791fc67451a7b39) nixos/matrix-synapse: Allow passing extras, discover extras from config
* [`549bc4bc`](https://github.com/NixOS/nixpkgs/commit/549bc4bc664e52019a3ce001a205d55a3a3d40ce) nixos/tests/matrix-synapse: Test redis on postgres instance
* [`2ae77417`](https://github.com/NixOS/nixpkgs/commit/2ae77417684142658105185a72019c484d5dd0df) haskellPackages: stackage LTS 21.0 -> LTS 21.3
* [`0ded80fc`](https://github.com/NixOS/nixpkgs/commit/0ded80fcf59ff2d0e7485f1d1e39337bd5b6ad3f) haskellPackages.digits: work around broken Setup.hs
* [`97e72246`](https://github.com/NixOS/nixpkgs/commit/97e7224610336bd09b0ff9e94e14934931099027) haskellPackages.toml-parser: drop broken flag
* [`091d02e7`](https://github.com/NixOS/nixpkgs/commit/091d02e79bebd23ebec2aa856d4441df911a2b5f) haskellPackages.css-syntax: drop broken flag
* [`0767e0b6`](https://github.com/NixOS/nixpkgs/commit/0767e0b6bdd5199f5153cfbac26516c3d91a4e9e) open-vm-tools: Add myself as a maintainer
* [`4657ff6c`](https://github.com/NixOS/nixpkgs/commit/4657ff6ca7096f39480f93bf828204f5a46eceb5) nixos/jool: add service for setting up SIIT/NAT64
* [`48a4a6bc`](https://github.com/NixOS/nixpkgs/commit/48a4a6bc5f6406f1dbb88e346174c852aa422a3d) nixos/tests/jool: init
* [`41934b58`](https://github.com/NixOS/nixpkgs/commit/41934b580aa8eb1c2703c81f31decb99091b66a5) jool-cli: add patch to validate the configuration
* [`1f28c8de`](https://github.com/NixOS/nixpkgs/commit/1f28c8defc116a8c6ee7f30ac984931b064b0697) nixos/jool: validate the configuration
* [`e5319b35`](https://github.com/NixOS/nixpkgs/commit/e5319b3512dca9909ce8ac4c597bd59b9d4d02f3) {jool,jool-cli}: link tests to passthu
* [`15a61635`](https://github.com/NixOS/nixpkgs/commit/15a61635a343715d3074a94828cb10fe83e869a1) nixos/release-notes: mention new Jool module
* [`d344c8de`](https://github.com/NixOS/nixpkgs/commit/d344c8deffd6313b66baaae86c02b8bbd259d1b3) maintainers: add viluon
* [`8217e236`](https://github.com/NixOS/nixpkgs/commit/8217e2362e0dc3598657cfe42e9f0802f6d58986) ccemux: 1.1.1 -> unstable-2023-07-08
* [`d073105d`](https://github.com/NixOS/nixpkgs/commit/d073105d6b346e4bdc27a22ad50cffcdc8a4b630) nixos/switch-to-configuration: fix ignoring of template unit specialization dropins
* [`7dd4145f`](https://github.com/NixOS/nixpkgs/commit/7dd4145f59d69554fa80dfe821b53689bec0bcec) stack: make sure it is pointing at stack-2.11.1
* [`bb835df4`](https://github.com/NixOS/nixpkgs/commit/bb835df448b93f81b2ea69b21853903f539fdb69) haskellPackages.sym: disable tests
* [`a1c61ad9`](https://github.com/NixOS/nixpkgs/commit/a1c61ad97b377f285d513f19c21e9155e15feb5e) python310Packages.imagededup: init at 0.3.2
* [`69516a90`](https://github.com/NixOS/nixpkgs/commit/69516a90d636871a51bdce37abf3c72e53ae0dd5) gitit: drop upstreamed patches
* [`c20801b9`](https://github.com/NixOS/nixpkgs/commit/c20801b9d68f71331102fc8204a67ad6596e1f27) haskell.packages.ghc962.weeder: test on Hydra
* [`99e148dd`](https://github.com/NixOS/nixpkgs/commit/99e148dd2719749c3e4c141161ca62dd177276a2) bash: fix parallel build failure on unwind_prot.o
* [`500b36d0`](https://github.com/NixOS/nixpkgs/commit/500b36d057ceaa7ad3e2e282958a44ed607b021f) all-cabal-hashes: 2023-07-19T20:56:38Z -> 2023-07-24T19:28:29Z
* [`b6e5f009`](https://github.com/NixOS/nixpkgs/commit/b6e5f0095db0a662320ab5131ad4818a9281c848) futhark: provide lsp >= 2.1
* [`d877ca18`](https://github.com/NixOS/nixpkgs/commit/d877ca18d10960faf16627722fccc9c483fd9b60) haskellPackages.rest-rewrite: remove fix that is no longer necessary
* [`57789376`](https://github.com/NixOS/nixpkgs/commit/577893765661c2e7d91422ecf740d1a1a5ffe12e) maintainers: add tbidne
* [`401be824`](https://github.com/NixOS/nixpkgs/commit/401be824b2439de92a26ed65c25fe34710d55daf) pspp: 1.4.1 -> 1.6.2
* [`832b2cdb`](https://github.com/NixOS/nixpkgs/commit/832b2cdbefe78088a2e1c208706aec4a1ba82920) haskell.packages.ghc96.warp: remove override to 3.3.28
* [`13acc8f9`](https://github.com/NixOS/nixpkgs/commit/13acc8f938462347858f089f576ce396ac849906) haskell.packages.ghc96: assorted jailbreaks
* [`d8e11a49`](https://github.com/NixOS/nixpkgs/commit/d8e11a49436ff1af7ba145aa4e182baa29203531) haskell.packages.ghc96.relude: jailbreak and skip tests
* [`5efd8107`](https://github.com/NixOS/nixpkgs/commit/5efd81070c9e98883f614327574854faf2bc38f6) haskell.packages.ghc96.servant: use 0.20 and jailbreaks
* [`e45b99df`](https://github.com/NixOS/nixpkgs/commit/e45b99dfb50a6ca3a62ed3c3048bfda2fae453e0) haskell.packages.ghc94.hnix: Add patch to fix compile errors
* [`0b415623`](https://github.com/NixOS/nixpkgs/commit/0b4156230b1cf59f1cf19d1b80b7d489af1793d1) haskell.packages.*.ghc-source-gen: shuffle broken flags around
* [`a38770bd`](https://github.com/NixOS/nixpkgs/commit/a38770bd69115aff3afde572bbce804df62fdaee) libavif: build gdk-pixbuf loader and thumbnailer
* [`52f0aec3`](https://github.com/NixOS/nixpkgs/commit/52f0aec3f095a1d74fb50e9e370f43d3f623496f) pandoc: provide matching version of skylighting{,-core}
* [`e31a4d90`](https://github.com/NixOS/nixpkgs/commit/e31a4d909d1fae09ba0f5be643f08f4f4e685678) haskellPackages.hspec*_2_11_4: provide missing versioned deps
* [`2e45100c`](https://github.com/NixOS/nixpkgs/commit/2e45100c5c7230f30bc9eddef8a7fc8f813c6adf) darwin-stdenv: revert `NIX_CC_NO_RESPONSE_FILE` logic
* [`6f41cccb`](https://github.com/NixOS/nixpkgs/commit/6f41cccb9edf416eed1cd754f6d1c567781365e0) haskell: don't pin stack to version in LTS, but take the latest from hackage
* [`645dfb80`](https://github.com/NixOS/nixpkgs/commit/645dfb80b80aa6965e10dba0730ffc3bc4bfdc1b) stack: unset pin to Stackage LTS
* [`911d466f`](https://github.com/NixOS/nixpkgs/commit/911d466fcabbae5ec32614c564dbde0dd8ceae6e) stack: remove old, unused override from ghc86
* [`5ff4edd3`](https://github.com/NixOS/nixpkgs/commit/5ff4edd3353c1cdc983adac0f533b127afedebdf) haskell.packages.ghc94.hnix: Add note to patch
* [`7442abab`](https://github.com/NixOS/nixpkgs/commit/7442abab185f11c54d0ad64373df58af143ade3e) haskell.packages.ghc96: assorted jailbreaks
* [`95137259`](https://github.com/NixOS/nixpkgs/commit/9513725990ae41829f1461d86598d3c67d74caea) gdb: disable sim by default
* [`9461addd`](https://github.com/NixOS/nixpkgs/commit/9461adddf13e48fd1fe6f60e3feabe693f0611ef) haskellPackages.hnix: make GHC 9.4 patch unconditional
* [`5c24ad1f`](https://github.com/NixOS/nixpkgs/commit/5c24ad1f299cb0d3023f59c04501eb3c8172469a) haskell.packages.ghc94.taffybar: apply pkgconfig workaround
* [`2635c9eb`](https://github.com/NixOS/nixpkgs/commit/2635c9eb1d639bfd4fad7d838e713da5d00b0cde) haskell.packages.ghc96.monad-par: tweak override
* [`83a24f92`](https://github.com/NixOS/nixpkgs/commit/83a24f92e8cf4a8001e105c5472414c0e56a217c) haskell.packages.ghc96.xmonad-contrib: patch for mtl-2.3
* [`9954c0da`](https://github.com/NixOS/nixpkgs/commit/9954c0da184ebcea71f3b8cfc103e572391715b6) haskell.packages.ghc96.arbtt: patch for unix-2.8.0.0
* [`b80298b1`](https://github.com/NixOS/nixpkgs/commit/b80298b11dad8e6ecaeb060419dc868b18d206db) python310Packages.pyqt6-sip: 13.5.1 -> 13.5.2
* [`c01fcb6b`](https://github.com/NixOS/nixpkgs/commit/c01fcb6b2e2285e1cc7f3e6d7a00a072390b194d) arion: allow base >= 4.17
* [`30e58da8`](https://github.com/NixOS/nixpkgs/commit/30e58da8aa5d8595c8cbce90cef9ea0f5e71d14c) tix: fix build with clang 16
* [`522bad71`](https://github.com/NixOS/nixpkgs/commit/522bad71594ec4ad81930e40c2eee9fefc5ad1de) jetbrains.jcef: 654 -> 672
* [`c200f5e4`](https://github.com/NixOS/nixpkgs/commit/c200f5e411fc738780000bb6eafe8105993ad488) partial revert of f3719756b550
* [`17d25bf7`](https://github.com/NixOS/nixpkgs/commit/17d25bf7621334f0534b59422903984183223585) Revert "linuxManualConfig: restore functionality of isModular and buildDTBs"
* [`007f7941`](https://github.com/NixOS/nixpkgs/commit/007f794167df4387bcf5f2c37f6881667805cad1) Revert "lib/systems: strip kernel to avoid reference cycles"
* [`c801a96a`](https://github.com/NixOS/nixpkgs/commit/c801a96a0db9609b2ebfa4ed2a8577cbe90ff9a1) Revert "linuxManualConfig: set badPlatforms"
* [`eecef61b`](https://github.com/NixOS/nixpkgs/commit/eecef61ba5c8f3f6ec21752b7f5c15c91a04a7b5) Revert "linux.configfile: remove unused kernelTarget attr"
* [`06f20db4`](https://github.com/NixOS/nixpkgs/commit/06f20db451844c5f048e99e3e3f6870ae998c9e5) Revert "linuxManualConfig: always depend on ubootTools"
* [`ddaa949a`](https://github.com/NixOS/nixpkgs/commit/ddaa949afe18949396a1de532df60ffaea5bf2a3) Revert "linux: default stdenv.hostPlatform.linux-kernel"
* [`479dd15b`](https://github.com/NixOS/nixpkgs/commit/479dd15b5f076f48dc367c5d97e6ee13f80cd694) Revert "linux: manual-config: use a non-random path for $buildRoot"
* [`92f7becc`](https://github.com/NixOS/nixpkgs/commit/92f7beccb29bb68443cbcb81b05e4df6bb91f2e9) Revert "linuxManualConfig: fix inaccurate FIXME comment"
* [`37eb25a4`](https://github.com/NixOS/nixpkgs/commit/37eb25a4285919205f311d26952c752913e2cd1c) Revert "linuxManualConfig: get rid of drvAttrs"
* [`3aff6553`](https://github.com/NixOS/nixpkgs/commit/3aff6553615124198331f845ce3f07ddd731c2c5) Revert "linuxManualConfig: install GDB scripts"
* [`12a06dc2`](https://github.com/NixOS/nixpkgs/commit/12a06dc2b8507b01c5ba96f94e8f4bf241df6a0d) Revert "linuxManualConfig: use the default make target"
* [`93021f12`](https://github.com/NixOS/nixpkgs/commit/93021f12c3bb97448bb40d75c29401d49333b531) Revert "linuxManualConfig: unpack directly into $dev"
* [`dbe0d20b`](https://github.com/NixOS/nixpkgs/commit/dbe0d20b573e7e4536169456cb55f691d5f678ec) Revert "linuxManualConfig: don't build inside source tree"
* [`2b55fad1`](https://github.com/NixOS/nixpkgs/commit/2b55fad13c462f563d942aec6aff25d39074da90) haskellPackages.inline-c-cpp: drop obsolete patch
* [`cd1c98b6`](https://github.com/NixOS/nixpkgs/commit/cd1c98b6399cea3b53cda25b30e7559b9f2de3a4) haskellPackages: regenerate package set based on current config
* [`8ecc5ecc`](https://github.com/NixOS/nixpkgs/commit/8ecc5ecc5a40f585d39f725f88f0459586849bb1) haskellPackages.dependent-sum-template: back pin for ghc 9.4 compat
* [`4e729092`](https://github.com/NixOS/nixpkgs/commit/4e7290929bad55d69f3340958ec32fa61cd5ed3a) vault-bin: 1.13.3 -> 1.14.1
* [`6f79f108`](https://github.com/NixOS/nixpkgs/commit/6f79f108682505c2d7942d343bd58748f3fae0f5) python310Packages.zope-i18nmessageid: rename from zope_i18nmessageid
* [`a2a660dc`](https://github.com/NixOS/nixpkgs/commit/a2a660dc509644cb46b7af6b12a7067c5d6cae52) python310Packages.zope-i18nmessageid: refactor
* [`83a7b7de`](https://github.com/NixOS/nixpkgs/commit/83a7b7de26e2f21cf4b15468f2e0a41bd7d58a94) python310Packages.zope-i18nmessageid: 5.1.1 -> 6.0.1
* [`3a7597b8`](https://github.com/NixOS/nixpkgs/commit/3a7597b8a62d354bdebd3606333e22d3198bd345) test-driver: add persistent history
* [`43da9e8f`](https://github.com/NixOS/nixpkgs/commit/43da9e8fff25822b6a5ba54e242ff94177b77f0f) glibcLocales: disable parallelism to restore deterministic locales
* [`da781ec4`](https://github.com/NixOS/nixpkgs/commit/da781ec44ef8fd5b5e1c433423f3169df39920e6) haskellPackages.shellify: add me as a maintainer
* [`65328600`](https://github.com/NixOS/nixpkgs/commit/65328600e8a78d4490239587b146fed3b193a77c) python310Packages.scikit-build-core: add meta.changelog
* [`eeed0aa1`](https://github.com/NixOS/nixpkgs/commit/eeed0aa1044378dbc7c0127f5afb71a1c3bbf2b5) maintainers: add jaduff
* [`f785a3d7`](https://github.com/NixOS/nixpkgs/commit/f785a3d748949ba60ecf4ad65df02514cfcee05b) python310Packages.srsly: 2.4.6 -> 2.4.7
* [`7adf0a4e`](https://github.com/NixOS/nixpkgs/commit/7adf0a4eeb0ac19b07ca17f27e20ca4cee12df3d) setup-hooks/strip: resolve/uniq symlinks before stripping
* [`227a5732`](https://github.com/NixOS/nixpkgs/commit/227a57329fd3fd6bc1bc835faa097f3f784c676c) haskell.packages.ghc8107.ghc-lib-parser: lift lower base bound
* [`e138e656`](https://github.com/NixOS/nixpkgs/commit/e138e656c7c3f7c25b62a73b9011f921563f4ee5) godot3: refactor and rename from godot
* [`e555a7b3`](https://github.com/NixOS/nixpkgs/commit/e555a7b3d19ec4e32ee63fa7bf632f3193d08a11) godot3: add mono builds
* [`893ae858`](https://github.com/NixOS/nixpkgs/commit/893ae858d584f7e820e76acab83feac06d1b917a) gogdl: 0.7.2 -> 0.7.3
* [`5a29bee7`](https://github.com/NixOS/nixpkgs/commit/5a29bee734c4df3789970a988d7d163b220c83b0) legendary-gl: 0.20.32 -> 0.20.33
* [`64e8c6f7`](https://github.com/NixOS/nixpkgs/commit/64e8c6f72dcb679b2ddc9131923350a7474ff4b5) klee: use LLVM 12
* [`2141d987`](https://github.com/NixOS/nixpkgs/commit/2141d9879ad46ff7cb518e9bfd9b3a4312e8591a) Revert "stdenv: use improved strip.sh for aarch64-linux"
* [`474577db`](https://github.com/NixOS/nixpkgs/commit/474577db766dd899008daff12f2d275c1737bed3) python310Packages.scikit-build-core: 0.2.0 -> 0.4.8
* [`e66c9682`](https://github.com/NixOS/nixpkgs/commit/e66c968210752c7fe25033264b683c2ab820c223) librsvg: use installShellCompletion, little cleanup
* [`bb89f903`](https://github.com/NixOS/nixpkgs/commit/bb89f903f4e5fc365dac2791a2f124e86d770875) Revert "libhwy: apply the new patch conditionally"
* [`5a3870c2`](https://github.com/NixOS/nixpkgs/commit/5a3870c212a0d3f65c26ff599a261b02fe8fac6a) nixos/matrix-synapse: expose final matrix-synapse package via `package`-option
* [`638460ab`](https://github.com/NixOS/nixpkgs/commit/638460ab9f9ff4db8d3946a946bd5f5f429a2d88) nixos/release-notes: reword section for synapse wrapper changes
* [`5bf466da`](https://github.com/NixOS/nixpkgs/commit/5bf466dae98770bc36fde98eb515bb2e58e0e1cb) matrix-synapse: fix PYTHONPATH wrapper
* [`190886c5`](https://github.com/NixOS/nixpkgs/commit/190886c5cca51bee671c5f3329ce03e119768029) nixos/matrix-synapse: clarify that `extras` are additive
* [`701d0e1d`](https://github.com/NixOS/nixpkgs/commit/701d0e1da6372db7951025ff0b24ec48e82453d8) nixos/matrix-synapse: fix path to extras for additive settings
* [`9f6ed8c2`](https://github.com/NixOS/nixpkgs/commit/9f6ed8c2b26ad960b40c652dcc3a744e954ee449) nixos/release-notes: use redis as example for extras in synapse
* [`4d5658d7`](https://github.com/NixOS/nixpkgs/commit/4d5658d7bd41b4d4fa5dbc2b2992dba58dc37cdf) nile: init at 1.0.0
* [`0e012f05`](https://github.com/NixOS/nixpkgs/commit/0e012f05c757c66d8d8f03bb165028afd1b2cc12) heroic: 2.8.0 -> 2.9.1
* [`f0f53431`](https://github.com/NixOS/nixpkgs/commit/f0f53431d187a3e10b3caae3f1439faab39e14e1) djvulibre: fix build with clang 16
* [`80701428`](https://github.com/NixOS/nixpkgs/commit/80701428e9e7819c5dc3cb2be40afc670386e769) heroic: patch out DRM support
* [`6f2b3ba0`](https://github.com/NixOS/nixpkgs/commit/6f2b3ba027f0d74614ba1b21f15ea45b0beb0385) cc-wrapper: use a temporary file for reponse file
* [`876950ae`](https://github.com/NixOS/nixpkgs/commit/876950aeaadc4b46002095d4d36f28e4d40d11ac) ray: 2.4.0 -> 2.6.1
* [`7110fa6d`](https://github.com/NixOS/nixpkgs/commit/7110fa6dc4dd96bb5e593c5a5dd34dcee3bbf278) openldap: 2.6.5 -> 2.6.6
* [`62b8af17`](https://github.com/NixOS/nixpkgs/commit/62b8af17d8bda579ef9e2c319533e136868dcc1c) autogen: apply more patches to avoid crashes
* [`b889dfdb`](https://github.com/NixOS/nixpkgs/commit/b889dfdb3447f03ae1e2c8e6fa63dbeb85f3d258) openssl: 3.0.9 -> 3.0.10
* [`9a424242`](https://github.com/NixOS/nixpkgs/commit/9a424242d7db53b835e34dee4b8e8c20ec0bd3e5) go_1_21: init at 1.21rc3
* [`41ccfa32`](https://github.com/NixOS/nixpkgs/commit/41ccfa322e0f2e6719f805c73384f9ae4f542107) buildGoModule: refactor GO111MODULE
* [`86cd7e09`](https://github.com/NixOS/nixpkgs/commit/86cd7e0948fd14e1a0dc3356132d666c60fc2bbd) buildGo{Module,Package}: set GOTOOLCHAIN to local
* [`3392d56b`](https://github.com/NixOS/nixpkgs/commit/3392d56b728983d5437cf50b0872515c24b87a05) buildGoModule: set GOPROXY to go default
* [`d2facca5`](https://github.com/NixOS/nixpkgs/commit/d2facca5c0c776bef2e142e129df90355ec80a27) nixos/matrix-synapse: fix option description of `extras` option
* [`8e912feb`](https://github.com/NixOS/nixpkgs/commit/8e912feb2939866ef68d57fc00bab73b5f84f7c1) codesign_allocate: reference cctools
* [`974c1466`](https://github.com/NixOS/nixpkgs/commit/974c1466b36af5f317e7eec395f17d4a22ce2632) microsoft-edge 114.0.1823.79 -> 115.0.190.188
* [`c34eba07`](https://github.com/NixOS/nixpkgs/commit/c34eba07c937aaee8949a3c8e90497716a1bae80) k2tf: reproducible vendor
* [`4b428f76`](https://github.com/NixOS/nixpkgs/commit/4b428f7689e27048b9a13df22a0c7fd7975cfb8e) go_1_20: 1.20.6 -> 1.20.7
* [`c407e3cb`](https://github.com/NixOS/nixpkgs/commit/c407e3cbbaaba05db64c8e1ec929c75cfa4eba50) zip: fix build with clang 16
* [`c2472016`](https://github.com/NixOS/nixpkgs/commit/c2472016795553a0b27cafc7640719480a1169a2) grocy: 3.3.0 -> 4.0.0
* [`644f2a10`](https://github.com/NixOS/nixpkgs/commit/644f2a109a31eb0d745b41f96aa08987e1bde9ad) librsvg: 2.56.2 -> 2.56.3
* [`3d3f25e5`](https://github.com/NixOS/nixpkgs/commit/3d3f25e54aa9a06e6c49fe9b366ab350e17ce028) haskellPackages.generic-data-functions: add raehik as maintainer
* [`835e5c95`](https://github.com/NixOS/nixpkgs/commit/835e5c9587057fe63347c07659da55e3df34b1e8) haskellPackages.heystone: add raehik as maintainer
* [`0f05762b`](https://github.com/NixOS/nixpkgs/commit/0f05762ba71bf242ee71a38fc814ef6afb2dc27d) haskellPackages.refined: add raehik as maintainer
* [`f789cae4`](https://github.com/NixOS/nixpkgs/commit/f789cae407295bd46a00adeec4b463b416dd942f) haskellPackages.refined1: add raehik as maintainer
* [`da718d17`](https://github.com/NixOS/nixpkgs/commit/da718d171b7503ffdc4aad86390fa167c018ec70) haskellPackages.flatparse: add raehik as maintainer
* [`c2e7e060`](https://github.com/NixOS/nixpkgs/commit/c2e7e06037377a0efbe46c72416e053f5594a2e9) umockdev: 0.17.17 -> 0.17.18
* [`7197b9f0`](https://github.com/NixOS/nixpkgs/commit/7197b9f03beca59576cdaddc2c0de8d0161ccf85) glibcLocales: fix extraNativeBuildInputs definition ([nixos/nixpkgs⁠#246537](https://togithub.com/nixos/nixpkgs/issues/246537))
* [`34061e98`](https://github.com/NixOS/nixpkgs/commit/34061e987cc445d9c5cd34f86aeb61e219a2a1c0) Update stable sha256 hash to SRI hash
* [`23275b78`](https://github.com/NixOS/nixpkgs/commit/23275b7891b78451509b88cad7b1f2ccfa2ceb17) gmp: 6.2.1 -> 6.3.0
* [`95c1cbda`](https://github.com/NixOS/nixpkgs/commit/95c1cbdae9211fb92893939bd5824e523223bd5b) go_1_21: 1.21rc3 -> 1.21rc4
* [`6464ea45`](https://github.com/NixOS/nixpkgs/commit/6464ea459026750f45ec35456ded6cf8956e4283) python3.pkgs.django-extensions: add pip to test dependencies
* [`dc2fae9f`](https://github.com/NixOS/nixpkgs/commit/dc2fae9f69a0828c1b23fb41d768f60dede359cb) xz: 5.4.3 -> 5.4.4
* [`f699824f`](https://github.com/NixOS/nixpkgs/commit/f699824f6e0525ec3873fefa557ee49a18478ed4) python310Packages.django: migrate to django_4
* [`27b8b774`](https://github.com/NixOS/nixpkgs/commit/27b8b774748938d727895fb8b3d3a534707b545a) python310Packages.django-scim2: 0.17.3 -> 0.19.0
* [`79105aad`](https://github.com/NixOS/nixpkgs/commit/79105aad78e10f7bffc0cdace35ca5b0d6bdf324) python310Packages.django-cachalot: 2.5.3 -> 2.6.1
* [`0116a04d`](https://github.com/NixOS/nixpkgs/commit/0116a04d7b64299bf64dfdc50afb3d58ebb2bbfa) python310Packages.django-mailman: fix build
* [`b528b277`](https://github.com/NixOS/nixpkgs/commit/b528b277579e2a9a2e99a58725e967960d80eca1) python310Packages.django-compat: drop
* [`7a56f386`](https://github.com/NixOS/nixpkgs/commit/7a56f3863fad43458141dbafff68679a056ad561) python310Packages.django-haystack: disable tests on django_4
* [`002f6c08`](https://github.com/NixOS/nixpkgs/commit/002f6c08cb5280ee93ad2295d422bd8f79e21e8f) python310Packages.mezzanine: propagate pytz
* [`bff5a07e`](https://github.com/NixOS/nixpkgs/commit/bff5a07ef86c1ac3ff7d83631d94fffa78578d83) python310Packages.django-sites: mark broken with django_4
* [`fe50817d`](https://github.com/NixOS/nixpkgs/commit/fe50817d1035e24c124ab6578d9080f388c4a784) python310Packages.django-modelcluster: disable failing test
* [`ca5c50bc`](https://github.com/NixOS/nixpkgs/commit/ca5c50bcf94e3f9af6f3e3456a5155ffb61bfea0) python310Packages.drf-nested-routers: fix django4 compat
* [`008c1402`](https://github.com/NixOS/nixpkgs/commit/008c1402d2f372bc15603edaf5f1ef2a78ed0b14) python310Packages.djangorestframework-guardian: mark broken with django4
* [`a8932746`](https://github.com/NixOS/nixpkgs/commit/a8932746670c00d542e51416bb080b248faecf68) python310Packages.django-pattern-library: mark broken with django4
* [`f1bc601c`](https://github.com/NixOS/nixpkgs/commit/f1bc601c44eb23d1f263ef37918418d9918557e5) python310Packages.wagtail: 4.2.2 -> 5.0.2
* [`87f04f12`](https://github.com/NixOS/nixpkgs/commit/87f04f12a469f9da4f34f161314a076a1a2df144) python310Packages.willow: 1.4.1 -> 1.5.1
* [`7cb5d050`](https://github.com/NixOS/nixpkgs/commit/7cb5d0503cdcf616f2c0ab09827cf31f82f52837) python310Packages.qcodes: disable timing-sensitive test
* [`84f6a675`](https://github.com/NixOS/nixpkgs/commit/84f6a6755a0832ca0e9b22c158a13869f3805132) mailmanPackages: pin to django_3
* [`f4d64ea1`](https://github.com/NixOS/nixpkgs/commit/f4d64ea14978c37a74d5086a8b0bf25fcae65e52) baserow: pin django_3
* [`dc9e7779`](https://github.com/NixOS/nixpkgs/commit/dc9e777948aacad8ad054b7306984de7db98819a) python310Packages.nplusone: mark broken with django_4
* [`99dca946`](https://github.com/NixOS/nixpkgs/commit/99dca946e6f8daa0e9626e42f402023db0cf0def) privacyidea: pin to django_3
* [`4523c65f`](https://github.com/NixOS/nixpkgs/commit/4523c65f95093a267ffe545a4be67a0d8773e0d5) gogdl: apply upstream PR patch for timeouts issue
* [`ee15765c`](https://github.com/NixOS/nixpkgs/commit/ee15765c6519e59b9197661d8ba91c935a12a32e) rtkit: reduce logging
* [`99524a94`](https://github.com/NixOS/nixpkgs/commit/99524a94ff31e1443a09d4b5326f5e69dd698b71) python3.pkgs.ninja-python: add tjni as a maintainer of this stub
* [`d36556b8`](https://github.com/NixOS/nixpkgs/commit/d36556b8a5db361933833d33876f4e8a815d1e0d) python3.pkgs.ninja-python: replace with a stub implementation
* [`a586a9e5`](https://github.com/NixOS/nixpkgs/commit/a586a9e55fcb0c3e961c49f9945f1078fb60ea7f) python3.pkgs.ninja: rename from ninja-python
* [`39dd3d18`](https://github.com/NixOS/nixpkgs/commit/39dd3d18bc2819b332d480aa1dd8d1084d0a635a) python3.pkgs.meson-python: depend on top-level ninja
* [`0a0caf5d`](https://github.com/NixOS/nixpkgs/commit/0a0caf5d2a2206398bac243bdbdda9668b15e01d) poppler: 23.07.0 -> 23.08.0
* [`b6901e6c`](https://github.com/NixOS/nixpkgs/commit/b6901e6c16cdd184e4dab0afb68a1c0c4850ed1c) staruml: 4.1.6 -> 5.1.0
* [`a0374195`](https://github.com/NixOS/nixpkgs/commit/a0374195704e4ab5306e3a54993bcf585b06fcb8) removed `xorg.libxshmfence` build input
* [`7110f64a`](https://github.com/NixOS/nixpkgs/commit/7110f64a3c500efeeafeb216a52c748235b99148) pipewire: 0.3.76 -> 0.3.77
* [`65e801cb`](https://github.com/NixOS/nixpkgs/commit/65e801cb43a4ec4d9d7445fc42b9c51d3c1cad81) chromedriver: fix update script
* [`ca73fb02`](https://github.com/NixOS/nixpkgs/commit/ca73fb024a757f3ddf1a32a2e88cc2bccb88479c) makeBinaryWrapper: remove cc dependency on aarch64-darwin
* [`166ff8fe`](https://github.com/NixOS/nixpkgs/commit/166ff8fe1f7e9fd3fc5322dc2893105e5e790704) treewide: fix sandbox darwin build
* [`2837dc76`](https://github.com/NixOS/nixpkgs/commit/2837dc7608960473c145187861591ddc6950e7eb) jetbrains: autocommit updates
* [`8eff2eea`](https://github.com/NixOS/nixpkgs/commit/8eff2eea8cbe5893055e1dc831f49c4a40d60179) Revert "Revert "python3: splice python within python3Packages.callPackage""
* [`b067d888`](https://github.com/NixOS/nixpkgs/commit/b067d888c88512a94f476ac9aa25db27e61572f2) openjdk{8-20}: bump darwin version
* [`26afb65e`](https://github.com/NixOS/nixpkgs/commit/26afb65e0e9f1cf70ae728a327784203baa579a2) python311Packages.responses: 0.23.1 -> 0.23.3
* [`dc5cd92e`](https://github.com/NixOS/nixpkgs/commit/dc5cd92e5074a9c95ed1c99e125cff44c58faf7c) abseil-cpp_202301: install test helpers
* [`9e397b9d`](https://github.com/NixOS/nixpkgs/commit/9e397b9d0042839420047a4154e6e33fd634a846) protobuf3: 21.12 -> 24.4
* [`742b7e4a`](https://github.com/NixOS/nixpkgs/commit/742b7e4ade3b918aa20f0025c9292862809bd40b) todoman: 4.1.0 -> 4.3.1
* [`79e4abbb`](https://github.com/NixOS/nixpkgs/commit/79e4abbb7ccb92d01f45d6cbc1b83a8e093be28b) todoman: add `meta.mainProgram`
* [`9d571384`](https://github.com/NixOS/nixpkgs/commit/9d5713843f65cd0dcf06d40dd34d8b1f2bd25da8) ed: refactor
* [`06a4aa3c`](https://github.com/NixOS/nixpkgs/commit/06a4aa3cdf162b54a5f914903750f3871dabea5e) edUnstable: init at 1.20-pre2
* [`842726c6`](https://github.com/NixOS/nixpkgs/commit/842726c6dc3bea1bbed2c3227fc9ed360196e301) fortify-headers: init at 1.1alpine1
* [`2b8a7515`](https://github.com/NixOS/nixpkgs/commit/2b8a7515d884ede294f1ce66558952e80cdf6091) python3.pkgs.gunicorn: replace setuptools with packaging dependency
* [`a1429b7b`](https://github.com/NixOS/nixpkgs/commit/a1429b7bc2b9b4beef3f8d68c9f0ea7bc9418589) ruby.rubygems: 3.4.17 -> 3.4.18
* [`f3bb6aa4`](https://github.com/NixOS/nixpkgs/commit/f3bb6aa4b5e6bfc14649ff869f853b0731d1a1f0) bundler: 2.4.17 -> 2.4.18
* [`aa6f3286`](https://github.com/NixOS/nixpkgs/commit/aa6f3286bc72f4694afbcacdab9258eb63ae74af) gupnp: fix compilation
* [`da269e3c`](https://github.com/NixOS/nixpkgs/commit/da269e3c82bfedf580b861d6a001f3992e5b6e05) gupnp_1_6: 1.6.4 -> 1.6.5
* [`57f6447d`](https://github.com/NixOS/nixpkgs/commit/57f6447df5841b2e3dd9e541826ad8b6a3a273fd) dcrd: fix tests when run on darwin
* [`524c7521`](https://github.com/NixOS/nixpkgs/commit/524c7521b054ea7217daf501f6c9062dc52b1dbf) guile: cleanup setup hook
* [`95c4a1fe`](https://github.com/NixOS/nixpkgs/commit/95c4a1fe96f2f6f406b805754099cb724aafdf42) cc-wrapper: include fortify-headers before libc includes for musl
* [`1f4b42aa`](https://github.com/NixOS/nixpkgs/commit/1f4b42aa79fcaff595139ed33bf60014424e30bb) gnu-config: give sources a name
* [`9e34d8ec`](https://github.com/NixOS/nixpkgs/commit/9e34d8ec273f4b2c14b7ba01f4e90e03dbc1ef18) gnu-config: use install(1) to make buildCommand simpler
* [`9e910fdd`](https://github.com/NixOS/nixpkgs/commit/9e910fdd8b11b421a3ed4535874f97d1f4715aef) gnu-config: 2023-01-21 -> 2023-07-31
* [`c317e99e`](https://github.com/NixOS/nixpkgs/commit/c317e99ee76c755bc691237c396ba2761c17bbcf) dsview: 1.2.2 -> 1.3.0
* [`91d0b754`](https://github.com/NixOS/nixpkgs/commit/91d0b754b83a292eeda83e10e247f4e464df41ad) roc-toolkit: 0.2.4 -> 0.2.5
* [`03957138`](https://github.com/NixOS/nixpkgs/commit/039571384104482363a3ea46be13f55aee9eb383) openexr_3: 3.1.7 -> 3.1.10
* [`4a02f979`](https://github.com/NixOS/nixpkgs/commit/4a02f979258afd0e858c6350ea2cfa08a5ebfd11) t-rex: mark broken
* [`decf1f8d`](https://github.com/NixOS/nixpkgs/commit/decf1f8d738b37b71162f7b17731f666ffc6cc60) python3.pkgs.flit-core: remove passthru tests ([nixos/nixpkgs⁠#245671](https://togithub.com/nixos/nixpkgs/issues/245671))
* [`1b66a905`](https://github.com/NixOS/nixpkgs/commit/1b66a9059256ee6873fda5955db11e1dbb4613b5) go: Don't symlink bin-directory but binaries instead to avoid breaking pkgs.symlinkJoin without error-message
* [`1b6e441e`](https://github.com/NixOS/nixpkgs/commit/1b6e441e020a40edd7fdeed8a19f8dda0f8fc104) graphviz: 8.0.5 -> 8.1.0
* [`6d54e634`](https://github.com/NixOS/nixpkgs/commit/6d54e6346c880ca67819cd787893275851008d0f) gnutls: 3.8.0 -> 3.8.1
* [`bb9d1e62`](https://github.com/NixOS/nixpkgs/commit/bb9d1e62bfa1cd6a77d9571edc3e35642cc26d23) python311Packages.msal: 1.22.0 -> 1.23.0
* [`f6f780f1`](https://github.com/NixOS/nixpkgs/commit/f6f780f129f50df536fb301b9dac554f9744ab4b) haskell.compiler.ghc94*: apply Cabal cycle patch on aarch64-darwin
* [`a83158c7`](https://github.com/NixOS/nixpkgs/commit/a83158c7b9c248032de5be0e69a38c5c44f00801) haskellPackages.mkDerivation: propagate pc deps for GHC >= 9.4
* [`69b514d2`](https://github.com/NixOS/nixpkgs/commit/69b514d2492bd6330f906150d472ea1e09b82f59) haskellPackages.mkDerivation: don't ev allPkgconfigDepends too early
* [`0b533488`](https://github.com/NixOS/nixpkgs/commit/0b5334887f1aad2ddd47dc3378c58e85f53b7204) haskellPackages.hercules-ci-cnix-store: don't use overrideAttrs
* [`520a544e`](https://github.com/NixOS/nixpkgs/commit/520a544ee5f90541b8a457b12d3d17f74f80d515) setup-hooks/strip: Create the log file in '$TMDPIR'
* [`f8ffc1dd`](https://github.com/NixOS/nixpkgs/commit/f8ffc1dd4c11befb38a268c90817cf0e1c767173) haskellPackages.yesod-core: temporarily disable broken tests
* [`3e7b0176`](https://github.com/NixOS/nixpkgs/commit/3e7b01767fd23c2a330602e8b89a461095944464) mercurial: 6.5 -> 6.5.1
* [`bd50b5fc`](https://github.com/NixOS/nixpkgs/commit/bd50b5fcf5bd8b14a58beb96d92efeb3e455a965) graylog-5_1: init at 5.1.4
* [`c83122a3`](https://github.com/NixOS/nixpkgs/commit/c83122a346025e3455f1a1272121401bfcf91211) python310Packages.pyotp: 2.8.0 -> 2.9.0
* [`2cf416ff`](https://github.com/NixOS/nixpkgs/commit/2cf416ff2349fd28708819ef44eb00bc4976f3e5) python310Packages.jupyterlab_server: run tests
* [`a89e6f73`](https://github.com/NixOS/nixpkgs/commit/a89e6f73abf45be87379a4849fa7197442456d4b) shhgit: remove
* [`9892d71d`](https://github.com/NixOS/nixpkgs/commit/9892d71dc6c292af737fc383204609e8a3cbe860) fstar: 2023.02.01 -> 2023.04.25
* [`88f20627`](https://github.com/NixOS/nixpkgs/commit/88f20627977e430e5ccbdebb8e36550c7ea55fe3) haskellPackages.mkDerivation: opt to only propagate pkgConfigModules
* [`2e876061`](https://github.com/NixOS/nixpkgs/commit/2e876061cca520e8c1c1ade93e332ec685bf745f) haskellPackages.mkDerivation: allow overriding automatic propagation
* [`aacf9a8c`](https://github.com/NixOS/nixpkgs/commit/aacf9a8c733d7d370de779e2526e6d439005039e) pcre2: list pkgConfigModules provided by the package
* [`06d13d55`](https://github.com/NixOS/nixpkgs/commit/06d13d55edef963e47fb74d1bee8bfc0e9111188) haskellPackages.gi-javascriptcore: respect argv limit for GHC >= 9.4
* [`fb4da9bc`](https://github.com/NixOS/nixpkgs/commit/fb4da9bcad23e065a7dc8836fb573bb323c6590a) R: split tex output for use with texlive.combine
* [`e6990d6c`](https://github.com/NixOS/nixpkgs/commit/e6990d6cc40484fe09ce7309b955dbd85a6f0d32) python3Packages.ffmpy: init at 0.3.1
* [`c0c84051`](https://github.com/NixOS/nixpkgs/commit/c0c84051fd74e070509dd4e4fcb86c5af39f636c) python3Packages.markdown-it-py: fix linkify extra
* [`94ea536f`](https://github.com/NixOS/nixpkgs/commit/94ea536fc7a8fcba4b6e15f0c0d90a53c0ef2425) python3Packages.gradio: init at 3.20.1
* [`f6332ded`](https://github.com/NixOS/nixpkgs/commit/f6332ded451f1acc9b176a6dd180b1a073f8b509) python3.pkgs.ansi2html: dependency cleanup ([nixos/nixpkgs⁠#247246](https://togithub.com/nixos/nixpkgs/issues/247246))
* [`c9ac4cce`](https://github.com/NixOS/nixpkgs/commit/c9ac4ccecbc56ed58a01192462c1d232050bc0c8) haskellPackages.{webkit2gtk3-javascriptscore,gi-webkit2}: Populate pkg-config based on metadata
* [`9fda0fb7`](https://github.com/NixOS/nixpkgs/commit/9fda0fb7ecb7a8771382a8d1f57f94b28e6c57a4) haskellPackages.jsaddle-webkit2gtk: allow-newer: aeson, text
* [`0a96f3ee`](https://github.com/NixOS/nixpkgs/commit/0a96f3ee2538f1839dbdca58a78943ad368e5ffa) haskell.compiler.ghc946: init at 9.4.6
* [`6c2a0262`](https://github.com/NixOS/nixpkgs/commit/6c2a02629255f5c626598aa5b0a478ff67bd1c3e) haskellPackages.ghc: 9.4.5 -> 9.4.6
* [`4eaf775d`](https://github.com/NixOS/nixpkgs/commit/4eaf775dc14c70095b99050e8a78188b87957307) maintainers: add tiredofit
* [`f409e12f`](https://github.com/NixOS/nixpkgs/commit/f409e12f4d199e96f412d5345cffc38b890bdc81) python311Packages.azure-synapse-artifacts: 0.16.0 -> 0.17.0
* [`3487a5f6`](https://github.com/NixOS/nixpkgs/commit/3487a5f6980345b08ef23c8e0bbf201389680fe4) python3.pkgs.xsdata: 22.12 -> 23.7
* [`7f9cee66`](https://github.com/NixOS/nixpkgs/commit/7f9cee66dedcd1961f9e6062ed2bad08a898b90e) qtpy: pyside -> pyside2
* [`3f866629`](https://github.com/NixOS/nixpkgs/commit/3f8666295104180f95d27d209453dc1c83565b2f) haskell.packages.ghc9{0,2}.haskell-language-server: Fix build
* [`d58ec512`](https://github.com/NixOS/nixpkgs/commit/d58ec5127e8ad3603c6629ccceab664f63323ba8) haskell.packages.ghc810.haskell-language-server: Fix build
* [`b676a511`](https://github.com/NixOS/nixpkgs/commit/b676a511c399419d57edc7bca5926c3b4999193b) haskellPackages.systemd-api: Restrict to linux
* [`d1bb8b3b`](https://github.com/NixOS/nixpkgs/commit/d1bb8b3b441d1e760431f4b8a18540d47cb6f942) dysnomia: use supervisor from python3Packages
* [`2a0b0e3d`](https://github.com/NixOS/nixpkgs/commit/2a0b0e3d781b46872c26ab7df5027225aec6b94d) pyditz: use python3Packages
* [`bb02d103`](https://github.com/NixOS/nixpkgs/commit/bb02d103645ab1556cadf8795436b4b60116fdb4) nixops_unstable: update
* [`4b51c536`](https://github.com/NixOS/nixpkgs/commit/4b51c5360ff0ac76d6ea4ce269726249d36b2ce8) nixops_unstable: Fix tests attribute
* [`e05eb5e9`](https://github.com/NixOS/nixpkgs/commit/e05eb5e9ec6c5f15c90765fbfdfac63cc04a2084) python310Packages.rapidfuzz: 3.1.1 -> 3.2.0
* [`39fb5c36`](https://github.com/NixOS/nixpkgs/commit/39fb5c360ae7b03b8df07d1c10a4187436dcb3ee) haskellPackages.monad-bayes: Jailbreak and override
* [`cba189dc`](https://github.com/NixOS/nixpkgs/commit/cba189dc2f1b3ceba0206c8a4eb7e9970fbf61f4) haskellPackages.fclabels: allow 9.4 core pkgs and base-orphans-0.9.0
* [`ec22277c`](https://github.com/NixOS/nixpkgs/commit/ec22277ca6b5be4169f2d9bf0e5f09d567498739) sway-contrib: switch source to new separate repo
* [`32db1fb6`](https://github.com/NixOS/nixpkgs/commit/32db1fb6e0ac37da546a4b7e6f984760e8061547) ghc942 + ghc943: Apply the Cabal patch for --enable-relocatable
* [`ef17252d`](https://github.com/NixOS/nixpkgs/commit/ef17252dbc758688974feffeb47098108385aaf5) tinygo: fix reproducible vendor
* [`69b99a75`](https://github.com/NixOS/nixpkgs/commit/69b99a750fe49a3049df830f578a82c1ca87d9bb) python3Packages.spdx-tools: 0.7.1 -> 0.8.0
* [`bdea49df`](https://github.com/NixOS/nixpkgs/commit/bdea49df12cd1229c96279a7c14f406671b85c6f) haskellPackages.inline-c-cpp: fix darwin build
* [`72b94272`](https://github.com/NixOS/nixpkgs/commit/72b94272c96eef5fe866d10fd76544e54789759c) python3Packages.oscrypto: fixup with openssl 3.0.10
* [`ea4241aa`](https://github.com/NixOS/nixpkgs/commit/ea4241aad9ccb6792a50555bf13b4c7ed06ef0a8) python3.pkgs.pycups: 1.9.73 -> 2.0.1
* [`a5b92645`](https://github.com/NixOS/nixpkgs/commit/a5b92645f1e6762e4b53f48652cb766184d84e77) qt6.qtbase: fix macdeployqt would not find qmlimportscanner
* [`983cc8fa`](https://github.com/NixOS/nixpkgs/commit/983cc8fa111cc7874a066f5532afae8a08f47032) invidious: unstable-2023-06-06 -> unstable-2023-08-07
* [`3984fbf0`](https://github.com/NixOS/nixpkgs/commit/3984fbf02b4a4e2390f9c21c61d5b3d8c4d28cde) invidious: fix update script
* [`e9b39616`](https://github.com/NixOS/nixpkgs/commit/e9b39616ec078addaf9cf23d175eff2506559ef7) qt5: 5.15.9 -> 5.15.10
* [`1f093dfa`](https://github.com/NixOS/nixpkgs/commit/1f093dfa6fd4a453401ba8752c0021c2d1eb40f4) php82: 8.2.8 -> 8.2.9
* [`498d2f50`](https://github.com/NixOS/nixpkgs/commit/498d2f50b62f00038cd2f88e57b2d325aed409f0) maintainers: add katexochen
* [`9c5bcb98`](https://github.com/NixOS/nixpkgs/commit/9c5bcb988057caeab3e3b5f149bbd4b72999c14f) mediamtx: 0.23.8 -> 1.0.0
* [`362810ea`](https://github.com/NixOS/nixpkgs/commit/362810eabe415b82f917b363aa104b8d87198a79) nixos/mediamtx: refactor
* [`4fc07e7b`](https://github.com/NixOS/nixpkgs/commit/4fc07e7b4817932b3e1295d23c029699c9a49212) nixos/tests/mediamtx: init
* [`61f38f60`](https://github.com/NixOS/nixpkgs/commit/61f38f6046f0441bf59b008b0597920d94263ddf) protobuf: move abseil-cpp to propagatedBuildInputs
* [`71f1732d`](https://github.com/NixOS/nixpkgs/commit/71f1732d40df62d4a9467890e745424a28a27144) protobufc: 1.4.1 -> unstable-2023-07-08
* [`46602935`](https://github.com/NixOS/nixpkgs/commit/4660293567c99261baaf511b5a2475fadd1fd510) forge-mtg: 1.6.56 -> 1.6.57
* [`6208dded`](https://github.com/NixOS/nixpkgs/commit/6208ddedf4c50842d39faef3fe64623ad620c660) valhalla: 3.1.0 -> 3.4.0
* [`720895e1`](https://github.com/NixOS/nixpkgs/commit/720895e124b8e339f595c7712a3d6307a9b7f276) rPackages: CRAN and BioC update
* [`b606993d`](https://github.com/NixOS/nixpkgs/commit/b606993d672e031e07d64f96489104877ab3617a) postgresql_11: 11.20 -> 11.21
* [`36304844`](https://github.com/NixOS/nixpkgs/commit/363048444bd07577fcdc6ec911b9fedd20d94c64) postgresql_12: 12.15 -> 12.16
* [`f2566487`](https://github.com/NixOS/nixpkgs/commit/f256648786200f9604385b99abf6a570b48ae475) postgresql_13: 13.11 -> 13.12
* [`8f5976b4`](https://github.com/NixOS/nixpkgs/commit/8f5976b479152ae8c5372a29ba9b7d38fd420431) postgresql_14: 14.8 -> 14.9
* [`061c96b4`](https://github.com/NixOS/nixpkgs/commit/061c96b486cc471185b38b56cd0c962c122336cc) postgresql_15: 15.3 -> 15.4
* [`0869c1be`](https://github.com/NixOS/nixpkgs/commit/0869c1bef76d6237130c180b3b8f8355884e6a81) python3.pkgs.dbus-fast: build cython optimized version ([nixos/nixpkgs⁠#247308](https://togithub.com/nixos/nixpkgs/issues/247308))
* [`4f6efcf8`](https://github.com/NixOS/nixpkgs/commit/4f6efcf85a79385e33694ffbab7a95135d58f498) python3.pkgs.bluetooth-data-tools: 1.6.1 -> 1.7.0 ([nixos/nixpkgs⁠#247272](https://togithub.com/nixos/nixpkgs/issues/247272))
* [`03ef7028`](https://github.com/NixOS/nixpkgs/commit/03ef7028ce6e181b48f11c8e8a5b8c71c6c452c5) python3.pkgs.orjson: 3.9.2 -> 3.9.4 ([nixos/nixpkgs⁠#248273](https://togithub.com/nixos/nixpkgs/issues/248273))
* [`9dd8601a`](https://github.com/NixOS/nixpkgs/commit/9dd8601a6dea9c4217a1b494cc802377d89c45fa) python3.pkgs.josepy: fix tests with setuptools 67.5.0+ ([nixos/nixpkgs⁠#246920](https://togithub.com/nixos/nixpkgs/issues/246920))
* [`b5fde732`](https://github.com/NixOS/nixpkgs/commit/b5fde732b417a6e53262b197f905346242c1bfe2) python3.pkgs.aiohttp: fix tests with setuptools 67.5.0+ ([nixos/nixpkgs⁠#247310](https://togithub.com/nixos/nixpkgs/issues/247310))
* [`2123502c`](https://github.com/NixOS/nixpkgs/commit/2123502c630b014a50057fdedf059b39db8b4d6c) matrix-conduit: small refactor
* [`f8e105c5`](https://github.com/NixOS/nixpkgs/commit/f8e105c513476c41de5e02b89eab94b208ac7166) matrix-conduit: 0.5.0 -> 0.6.0
* [`0aaf6775`](https://github.com/NixOS/nixpkgs/commit/0aaf677516f0960222c6fe7326d58f1408e3eca0) qtwebengine: 5.15.13 -> 5.15.14, remove hack
* [`02fd938f`](https://github.com/NixOS/nixpkgs/commit/02fd938fb7471116c13a30caf30df4039ea93b87) nixos/conduit: disable update checks by default
* [`92dff845`](https://github.com/NixOS/nixpkgs/commit/92dff845fa01423dc250d2e6e7062786e7ce4999) gnutls: patch an API breakage from last update
* [`09d32e26`](https://github.com/NixOS/nixpkgs/commit/09d32e2612b01472cd48a0b48bfab5479ac3811d) nixos/virtualisation.docker: Do not assert 32 bit libraries available on ARM ([nixos/nixpkgs⁠#246179](https://togithub.com/nixos/nixpkgs/issues/246179))
* [`df8ba791`](https://github.com/NixOS/nixpkgs/commit/df8ba791834285019d6a66c0830a290bd8c111c3) openssh: 9.3p2 -> 9.4p1
* [`3f51296d`](https://github.com/NixOS/nixpkgs/commit/3f51296ddb563c15cc1f47dcd9eced7199d0a1b9) openssh_hpn: 9.3p2 -> 9.4p1
* [`289c8665`](https://github.com/NixOS/nixpkgs/commit/289c86652919d8486c5741d87262dc295937197c) openssh_gssapi: 9.3p2 -> 9.4p1
* [`39ed10c9`](https://github.com/NixOS/nixpkgs/commit/39ed10c9100edb9c11943fa7d0eb7bd7968f4052) grpc: 1.54.2 -> 1.57.0
* [`dc00a834`](https://github.com/NixOS/nixpkgs/commit/dc00a834e58fce25e0e63f0d119860a208aa5870) python3Packages.worldengine: replace dead homepage
* [`bab20c7d`](https://github.com/NixOS/nixpkgs/commit/bab20c7df7025b680038b276408546ac14b7afd4) gcc10: 10.4.0 -> 10.5.0
* [`287a5b6b`](https://github.com/NixOS/nixpkgs/commit/287a5b6baafd99677c267c780c6649f920b43720) gcc10: apply a patch more often
* [`dc1e382f`](https://github.com/NixOS/nixpkgs/commit/dc1e382f94f90b0fa8559a42d034f1742a8f94c4) gcc13: 13.1.0 -> 13.2.0
* [`05245fc0`](https://github.com/NixOS/nixpkgs/commit/05245fc0ea7a7af15bed9544c4c2f4d639a80ef2) nixos/picom: add `package` option
* [`44759783`](https://github.com/NixOS/nixpkgs/commit/44759783f53e614c8cd2a94f83c744f91f919e36) yaegi: init at 0.15.1
* [`56f88869`](https://github.com/NixOS/nixpkgs/commit/56f88869536fa60f3bb61358572ffe43b492a39f) anko: init at 0.1.9
* [`e795ddf9`](https://github.com/NixOS/nixpkgs/commit/e795ddf93d380e1f185498d06770839d5e406324) javaPackages.compiler.openjdk17: add zulu javaFX java package on darwin
* [`b89c4a12`](https://github.com/NixOS/nixpkgs/commit/b89c4a12c24e5dcc7a05e8e4fe5140db97442964) javaPackages.compiler.openjdk18: add zulu javaFX java package on darwin
* [`12871db0`](https://github.com/NixOS/nixpkgs/commit/12871db0eef625d989ab47476acc2daac8b6972f) javaPackages.compiler.openjdk19: add zulu javaFX java package on darwin
* [`ef0add88`](https://github.com/NixOS/nixpkgs/commit/ef0add88ddb471f39233164f6fcd8d0516505dfc) javaPackages.compiler.openjdk20: add zulu javaFX java package on darwin
* [`0cc75a5e`](https://github.com/NixOS/nixpkgs/commit/0cc75a5ec7e6828bd15dd62dfdf221bdcd04e9cd) cyber: init at unstable-2023-08-11
* [`f68619b5`](https://github.com/NixOS/nixpkgs/commit/f68619b5f3ff2d77fa152e8e18e0472d91b19f13) wallust 2.51 -> 2.6.1
* [`4c8b3fe3`](https://github.com/NixOS/nixpkgs/commit/4c8b3fe3baf55a84f46efdfd5920434b9c57ee39) python3.pkgs.dot2tex: fix duplicate script breaking installation
* [`6cb07752`](https://github.com/NixOS/nixpkgs/commit/6cb07752da5843e668d05d42666768e00dcea2e8) firefox_decrypt: add missing build dependencies
* [`c958dcee`](https://github.com/NixOS/nixpkgs/commit/c958dcee0230a6b5c00c62629c267405c9f9bc61) python3.pkgs.protobuf: fix build after updating protobuf to 3.23.4 ([nixos/nixpkgs⁠#248231](https://togithub.com/nixos/nixpkgs/issues/248231))
* [`34f1f577`](https://github.com/NixOS/nixpkgs/commit/34f1f577054ad2f15d19c31016e90a654809bc7b) Revert "Merge [nixos/nixpkgs⁠#244853](https://togithub.com/nixos/nixpkgs/issues/244853): mesa: 23.1.3 -> 23.1.4"
* [`174c3d6d`](https://github.com/NixOS/nixpkgs/commit/174c3d6dff252800f50c67da0de0f14dae8ee69b) coredns: 1.10.1 -> 1.11.0
* [`68e6cc58`](https://github.com/NixOS/nixpkgs/commit/68e6cc58316ba5952662420f76ae2ba1d8f2d8a6) nixos-rebuild: Include manual page in the package
* [`9d0bb6e6`](https://github.com/NixOS/nixpkgs/commit/9d0bb6e67a4a1922fefc9c0a35bd5b1f0482aaac) nixos-option: Include manual page in the package
* [`be50a4d2`](https://github.com/NixOS/nixpkgs/commit/be50a4d290f5959c43849abe7e46f8a2358f4283) mailmanPackages.postorius: 1.3.6 -> 1.3.8
* [`9c961501`](https://github.com/NixOS/nixpkgs/commit/9c9615018927f47efb18f3da0653a0f269086179) mailmanPackages.hyperkitty: 1.3.5 -> 1.3.7
* [`892661f4`](https://github.com/NixOS/nixpkgs/commit/892661f45b57a188986a2f5518d163146b11fd9e) mailmanPackages.web: 0.0.5 -> 0.0.6
* [`2cefe69f`](https://github.com/NixOS/nixpkgs/commit/2cefe69f6f97b705fc49cdfb9bccca4d01280fa0) mailmanPackages.python: allow changing python package-set used for mailman
* [`8b45dd86`](https://github.com/NixOS/nixpkgs/commit/8b45dd8698683cd45cf1710666a7542d49b09eb9) mailmanPackages: remove psycopg2 pin
* [`d85e9676`](https://github.com/NixOS/nixpkgs/commit/d85e9676b5c696f0267f9d7b671b95d8e112d36a) slack: 4.33.73 -> 4.33.84
* [`32f75a0f`](https://github.com/NixOS/nixpkgs/commit/32f75a0f2af55b50061629fd4e51221f15ada457) nixos/install-tools: Add manpages to packages instead of seperating them
* [`783d1a8f`](https://github.com/NixOS/nixpkgs/commit/783d1a8ff514b86bd6b6529c2c6388c81d0b2b59) python3.pkgs.zigpy: add build dependencies and fix constraints
* [`54de0067`](https://github.com/NixOS/nixpkgs/commit/54de00678a07c07aa88426bab529977d3cba63e3) python3.pkgs.statsmodels: add build dependencies and fix constraints
* [`e3d87e2e`](https://github.com/NixOS/nixpkgs/commit/e3d87e2e79782f7d1a7f4ad9dbbea6be32ea8cf1) vimPlugins.knap: init at 2023-07-25
* [`85da72d7`](https://github.com/NixOS/nixpkgs/commit/85da72d7910ca848bfb0c97949d6db23e6171c17) vimPlugins.markid: init at 2023-07-01
* [`e2c0dbc9`](https://github.com/NixOS/nixpkgs/commit/e2c0dbc9b97bcc8341f3d4f31eb068277d578862) vimPlugins.fold-preview-nvim: init at 2023-01-27
* [`2bacf176`](https://github.com/NixOS/nixpkgs/commit/2bacf176fca4982d9eefd582f706dfe2456e955e) vimPlugins.plantuml-previewer-vim: init at 2023-03-07
* [`ec113b60`](https://github.com/NixOS/nixpkgs/commit/ec113b6034efeac78f8b40657424d201c5a0e19f) vimPlugins.distant-nvim: init at 2023-07-24
* [`0dbbf2c0`](https://github.com/NixOS/nixpkgs/commit/0dbbf2c0f0c168d40c39ef512970b8a0f101c075) vimPlugins.pretty-fold-nvim: init at 2022-07-20
* [`fa929416`](https://github.com/NixOS/nixpkgs/commit/fa9294160940d0fe58460b696dd2fb2acff79b4e) vimPlugins.nvim-unception: init at 2023-04-11
* [`16674df0`](https://github.com/NixOS/nixpkgs/commit/16674df0a9ec3660c4425cfafe5e5914dc453d99) vimPlugins.mind-nvim: init at 2023-03-22
* [`3b36a4cd`](https://github.com/NixOS/nixpkgs/commit/3b36a4cd0fde81e7cf74396c1b6b69aec077c771) vimPlugins.nvim-search-and-replace: init at 2022-09-06
* [`d17eedff`](https://github.com/NixOS/nixpkgs/commit/d17eedff193c178f4b28e24ccff6e90f67c99522) vimPlugins.nabla-nvim: init at 2023-04-22
* [`924a07dc`](https://github.com/NixOS/nixpkgs/commit/924a07dc227b69b53e3f43d2d08996d33b364c92) nixos/doc: Improve documentation of documentation
* [`c6aca926`](https://github.com/NixOS/nixpkgs/commit/c6aca92608beffbba54a15f6820d3b5921b60883) python3.pkgs.shapely: add missing build dependencies
* [`d482e00d`](https://github.com/NixOS/nixpkgs/commit/d482e00d611047d015838c8f308d5dfda9eb5e77) jetbrains: 2023.1.4 -> 2023.2
* [`50dc54de`](https://github.com/NixOS/nixpkgs/commit/50dc54de04e7ba4f7eb3f6d38f905d03e74f0bd2) jetbrains.plugins: update
* [`f5fbc5ee`](https://github.com/NixOS/nixpkgs/commit/f5fbc5eeaadb92e4a9e2b7a72579c5c3fb2536fc) python3.pkgs.git-filter-repo: fix duplicate script error during install
* [`62e4c576`](https://github.com/NixOS/nixpkgs/commit/62e4c5767da8ff1a98e369e288f175a6f48ce56e) musescore: re-enable using system freetype
* [`a56241ed`](https://github.com/NixOS/nixpkgs/commit/a56241ed7b801f93af02f5a52e8e1f0a811484de) jetbrains: Commit in one line
* [`68840afd`](https://github.com/NixOS/nixpkgs/commit/68840afd8fa104c9873753fa61be0f75033f523b) invoice2data: clean up some build and runtime dependencies
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
