### PR TITLE
niv devenv: update ade3ae52 -> 49ebb9b0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "ade3ae522baf366296598e232b7b063d81740bbb",
-        "sha256": "1zfa79gbvajnq3c8x70vcdqsr8nxvcq4ab88rglvh0pf0mgq7vc0",
+        "rev": "49ebb9b0a85949f364bacf0088c4142ed451f59e",
+        "sha256": "1mvjih46kby43158805qxvbhy5xxd10ny9hfcfxgq1fv7kac076j",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/ade3ae522baf366296598e232b7b063d81740bbb.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/49ebb9b0a85949f364bacf0088c4142ed451f59e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@ade3ae52...49ebb9b0](https://github.com/cachix/devenv/compare/ade3ae522baf366296598e232b7b063d81740bbb...49ebb9b0a85949f364bacf0088c4142ed451f59e)

* [`83a2456d`](https://github.com/cachix/devenv/commit/83a2456dfcb5821ef87581955b57e5d7c41c185e) docs: add note about resetting service state
* [`247990cb`](https://github.com/cachix/devenv/commit/247990cb9f24fcaa76059c60b9742cd0cd2b8895) Add "Built with Nix" badge
* [`b7b88467`](https://github.com/cachix/devenv/commit/b7b88467a03940ed996ab2bfcb135d1f24623947) Update languages example to use rust channel.
