### PR TITLE
niv home-manager: update da6874e8 -> 958c0630

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da6874e8bb82204323b94154585a1471c739f73e",
-        "sha256": "0vsfbv9fsbaybxlw924ahbyn05fjvya7dviqk9sgf3mmwmpn1q8y",
+        "rev": "958c06303f43cf0625694326b7f7e5475b1a2d5c",
+        "sha256": "1xi5vnavngsn39lmxhg52pa8kk3yk0s9w4ki7z30fqimlwa3mq1h",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/da6874e8bb82204323b94154585a1471c739f73e.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/958c06303f43cf0625694326b7f7e5475b1a2d5c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@da6874e8...958c0630](https://github.com/nix-community/home-manager/compare/da6874e8bb82204323b94154585a1471c739f73e...958c06303f43cf0625694326b7f7e5475b1a2d5c)

* [`18791781`](https://github.com/nix-community/home-manager/commit/18791781ea86cbec6bce8bcb847444b9c73b8b3b) browserpass: support librewolf
* [`b84767a1`](https://github.com/nix-community/home-manager/commit/b84767a145e04d07ef699d266161cda605f48b11) xplr: add module
* [`75cfe974`](https://github.com/nix-community/home-manager/commit/75cfe974e2ca05a61b66768674032b4c079e55d4) Translate using Weblate (German)
* [`9db5b89f`](https://github.com/nix-community/home-manager/commit/9db5b89f40736943d017a761da044479044be182) pqiv: add module
* [`1ccd0c93`](https://github.com/nix-community/home-manager/commit/1ccd0c935ca8ade5e0826da8ac4f1bff3f473da6) pqiv: only run tests on Linux platforms
* [`aa59f917`](https://github.com/nix-community/home-manager/commit/aa59f917462f2d25ffd1f3128a063d4d3d1642d4) fcitx5: add `fcitx5-config-qt` to test stub
* [`2471d965`](https://github.com/nix-community/home-manager/commit/2471d965a3522025157a790fc49c3567fd56e26e) flake.lock: Update
* [`6a94c1a5`](https://github.com/nix-community/home-manager/commit/6a94c1a59737783c282c4031555a289c28b961e4) fix(qt): allow theming for apps started by systemd ([nix-community/home-manager⁠#4349](https://togithub.com/nix-community/home-manager/issues/4349))
* [`bdb5bcad`](https://github.com/nix-community/home-manager/commit/bdb5bcad01ff7332fdcf4b128211e81905113f84) home-cursor: improve icon compatibility
* [`958c0630`](https://github.com/nix-community/home-manager/commit/958c06303f43cf0625694326b7f7e5475b1a2d5c) flake.lock: Update
