### PR TITLE
niv nixpkgs: update 59f057ef -> 48516a89

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "59f057ef4608e7c7a342137935083e8ed7707339",
-        "sha256": "0dcsnbjawv6k5cwfrvr8lh4d2a4b3sq75ihwww8vic9xc27al1fn",
+        "rev": "48516a891d020801bc5304375739d2604400c741",
+        "sha256": "0hqb8rbfx3yy5pcppsr6yyn5whwibwbn59cj83yjwa4i1gzr781j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/59f057ef4608e7c7a342137935083e8ed7707339.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/48516a891d020801bc5304375739d2604400c741.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@59f057ef...48516a89](https://github.com/nixos/nixpkgs/compare/59f057ef4608e7c7a342137935083e8ed7707339...48516a891d020801bc5304375739d2604400c741)

* [`9da75fda`](https://github.com/NixOS/nixpkgs/commit/9da75fdaf147dc525861e8a534780d563c897dba) nixos/update-users-groups: add support for account expiry
* [`ea0022cc`](https://github.com/NixOS/nixpkgs/commit/ea0022cc22d9f8d4559eeb22676194ce94c29b41) libpcap: add some key reverse dependencies to passthru.tests
* [`605ccc82`](https://github.com/NixOS/nixpkgs/commit/605ccc82967d8fbd52f7b3e04e15b9fb10a88129) gnat-bootstrap: parameterize better
* [`990a9bda`](https://github.com/NixOS/nixpkgs/commit/990a9bda5f4cc832e27cc8ff2b4c790e9c5e4fd8) headsetcontrol: 2.6.1 -> 2.7.0
* [`466e154f`](https://github.com/NixOS/nixpkgs/commit/466e154fb2249287234ae58348810f02b813a8d4) apptainer, singularity: fix wrapper PATH prefix
* [`0fcf35ae`](https://github.com/NixOS/nixpkgs/commit/0fcf35ae5819e6510075353f7658a912951dcafb) singularity: specify "nvidia-container-cli path"
* [`66ca0dc9`](https://github.com/NixOS/nixpkgs/commit/66ca0dc9a203eb7b2a0c2d5f85a04ea71d828c8b) python3Packages.setuptools-odoo: init at 3.1.12
* [`879d6402`](https://github.com/NixOS/nixpkgs/commit/879d6402acf5eba2fcf9455fab16e4768a3ca4b2) nccl-tests: init at 2.13.6
* [`e3682a9f`](https://github.com/NixOS/nixpkgs/commit/e3682a9fddd457d468c04b91de758e368ee245d9) maintainers: add jmillerpdt
* [`5ec85dc8`](https://github.com/NixOS/nixpkgs/commit/5ec85dc83ef8adeb620866701e9b58cc9fcbd76b) python3Packages.manifestoo-core: init at 0.11.0
* [`8d6db778`](https://github.com/NixOS/nixpkgs/commit/8d6db778ff575a709bfdf3b650c02dca3dcf72df) python3Packages.click-odoo: init at 1.6.0
* [`dd4cb577`](https://github.com/NixOS/nixpkgs/commit/dd4cb577d92212e76e5a29745fccef5fc01f7e03) python3Packages.click-odoo-contrib: init at 1.16.1
* [`cb0966b9`](https://github.com/NixOS/nixpkgs/commit/cb0966b94f5e112f262fafd70ddbc833928ecd59) python3Packages.manifestoo: init at 0.7
* [`7ac8d2c6`](https://github.com/NixOS/nixpkgs/commit/7ac8d2c63bed21f0cca9c564fc8bc05bcf54bbf2) python3Packages.syrupy: fix wrong version disabler
* [`7e26c8d0`](https://github.com/NixOS/nixpkgs/commit/7e26c8d097778f073c8d975951e226762ec76e84) prometheus-exporter-nextcloud: support for auth tokens
* [`8d0dce91`](https://github.com/NixOS/nixpkgs/commit/8d0dce91bc0190eab64811aa40c9ae021891032f) tcl: fix [nixos/nixpkgs⁠#243831](https://togithub.com/nixos/nixpkgs/issues/243831)
* [`d45bbf15`](https://github.com/NixOS/nixpkgs/commit/d45bbf150de2303cbd7983ca553b57ea9f61c49b) tcl: add test for [nixos/nixpkgs⁠#243831](https://togithub.com/nixos/nixpkgs/issues/243831)
* [`40f2137a`](https://github.com/NixOS/nixpkgs/commit/40f2137a73bb4e24fee895a30d7ac4ca3b1e0889) kodiPackages.libretro-nestopia: init at 1.52.0.41
* [`cfa38c50`](https://github.com/NixOS/nixpkgs/commit/cfa38c50047e18303ffea37bfe938ae672b3a425) burpsuite: 2023.5.3 -> 2023.7.2
* [`ae011819`](https://github.com/NixOS/nixpkgs/commit/ae011819c4bba539bc8cabd57ee4cc1ccb7428a2) gettext: do not output date when --no-translator is set
* [`df047df6`](https://github.com/NixOS/nixpkgs/commit/df047df64c1f5d96a186eedcf6b3d27a7ef27639) python310Packages.poetry-core: 1.5.1 -> 1.6.1
* [`d391373c`](https://github.com/NixOS/nixpkgs/commit/d391373c40f5677081299ca210aa22eba5261c73) nixos/emacs: start emacs service with the graphical-session
* [`cc781739`](https://github.com/NixOS/nixpkgs/commit/cc781739cdc12d22d6e94a75d2ed57ecd2b50e67) python3Packages.notmuch2: use bindingconfig that works on darwin
* [`52e979f9`](https://github.com/NixOS/nixpkgs/commit/52e979f9e63793ee9f4e1d3dc3c2ad02a83de885) gtk2,gtk3: rename derivation name
* [`5465c92c`](https://github.com/NixOS/nixpkgs/commit/5465c92c112def29ff20ee9e42555ff6ee3f7523) python310Packages.liquidctl: 1.12.1 -> 1.13.0
* [`bcdc4d97`](https://github.com/NixOS/nixpkgs/commit/bcdc4d976cfc2ab8a922f716ea90048b1328b371) nixos/netbox: remove "with lib;"
* [`a57a322b`](https://github.com/NixOS/nixpkgs/commit/a57a322b8dfe6be69f3567469596682edf0ef73d) nixos/netbox: add GIT_PATH environment variable
* [`d1b0a954`](https://github.com/NixOS/nixpkgs/commit/d1b0a9543db7f64f6d443a0e8629e86ad8d68e16) nixos/netbox: move migration into the preStart netbox.service, reindex
* [`de8086be`](https://github.com/NixOS/nixpkgs/commit/de8086be4f91bb6e6aa5be83fa3adb5a3b45fd79) nixos/tests/netbox-upgrade: init
* [`fce8aa18`](https://github.com/NixOS/nixpkgs/commit/fce8aa18b17ad32edd5b46b99527465a4ff27d5a) netbox: 3.5.6 -> 3.5.7
* [`1bac8f5a`](https://github.com/NixOS/nixpkgs/commit/1bac8f5aa1046a8882a6dba2ad66f4b11d1ab066) netbox,netbox_3_3: link netbox-upgrade NixOS test
* [`127e2ed6`](https://github.com/NixOS/nixpkgs/commit/127e2ed645137ccbcbedb3ba316e1c8bf3ab9ae1) nixos/update-users-groups: add nixos test for the expires option
* [`44a7059b`](https://github.com/NixOS/nixpkgs/commit/44a7059bf287366e96f8188cf834a0a63932e220) nixos/update-users-groups: set expiry correctly for new users
* [`ed25f5de`](https://github.com/NixOS/nixpkgs/commit/ed25f5deeef0159f9c78bb9a07e4170d178feb23) librsvg: add some key reverse dependencies to passthru.tests
* [`d834d538`](https://github.com/NixOS/nixpkgs/commit/d834d5384106efc3a453970668e4da89047f2a4d) perlPackages.Connector: 1.35 -> 1.47, fix test
* [`b3ba3569`](https://github.com/NixOS/nixpkgs/commit/b3ba35694bae2a30f9a474f1a8e297485b31c383) airwindows-lv2: 20.0 -> 22.0
* [`506ac6f3`](https://github.com/NixOS/nixpkgs/commit/506ac6f30189f12b8f20900bb53bdc54a900cc9b) halloy: 23.1-alpha1 -> 2023.4
* [`535dacce`](https://github.com/NixOS/nixpkgs/commit/535dacce8b9e618bd9873dc95a9465f19956925d) python310Packages.cookiecutter: 2.1.1 -> 2.3.0
* [`b48e3ae9`](https://github.com/NixOS/nixpkgs/commit/b48e3ae9c265a554e31dca9aa0fcce8c287b0a71) file: 5.44 -> 5.45
* [`b39c3d55`](https://github.com/NixOS/nixpkgs/commit/b39c3d55e82fc950a0b4959aacb666a4b5502600) python311Packages.plexapi: 4.14.0 -> 4.15.0
* [`cde30ecc`](https://github.com/NixOS/nixpkgs/commit/cde30ecca423378346f9c6cae78f699fe64755d7) python311Packages.plexapi: update disabled
* [`f9451522`](https://github.com/NixOS/nixpkgs/commit/f9451522670ed2d30dcb16b8c51c6d833466fe83) vscode-extensions.ms-python.black-formatter: init at 2023.4.1
* [`28fbfa46`](https://github.com/NixOS/nixpkgs/commit/28fbfa4655695f54680bca0b0f51f6b8bb1f81e6) vscode-extensions.ms-python.isort: init at 2023.10.1
* [`f0c74d42`](https://github.com/NixOS/nixpkgs/commit/f0c74d421c7b089535ed437672caaa58af84eb13) Update pkgs/tools/misc/file/default.nix
* [`6bc5f7dd`](https://github.com/NixOS/nixpkgs/commit/6bc5f7dd871dd10dca313c78b5ba84faed3fdae4) kakoune-unwrapped: 2022.10.31 -> 2023.08.05
* [`addfb000`](https://github.com/NixOS/nixpkgs/commit/addfb000c4f2ae2643886c7c3206b7b06fdad850) tmux: add extraConfigBeforePlugins
* [`0fb2e4d5`](https://github.com/NixOS/nixpkgs/commit/0fb2e4d5e7fe57308b9aebb661ca2aefc50ecda0) python3Packages.skytemple-rust: 1.4.0.post0 -> 1.5.3
* [`9078796c`](https://github.com/NixOS/nixpkgs/commit/9078796cda8fa7e3919ea86f7a23c98bfa05a2b5) python3Packages.explorerscript: 0.1.2 -> 0.1.3
* [`13de9df3`](https://github.com/NixOS/nixpkgs/commit/13de9df3ed817b927827758d0f56652ce0730a8b) python3Packages.skytemple-files: 1.4.7 -> 1.5.4
* [`ff1c16ca`](https://github.com/NixOS/nixpkgs/commit/ff1c16ca6d0eb0d68c7a19ceae02cfc5bff1bc44) skytemple: 1.4.7 -> 1.5.4
* [`ed60ed35`](https://github.com/NixOS/nixpkgs/commit/ed60ed3562fd9497a0cbae6208ee6a94cf277b9e) Fix useDotnetFromEnv's DOTNET_ROOT detection
* [`19109823`](https://github.com/NixOS/nixpkgs/commit/19109823eaa1797290dff4f2220dad917e10b2c7) golden-cheetah*: 3.6-RC4 -> 3.6
* [`e58c588c`](https://github.com/NixOS/nixpkgs/commit/e58c588c2df02300d779295dea2b2375f147c9fb) golden-cheetah-bin: add adamcstephens as maintainer
* [`4f587fec`](https://github.com/NixOS/nixpkgs/commit/4f587fec6f82636645e47b4e328d49e9b87235de) amdvlk: 2023.Q2.3 -> 2023.Q3.1
* [`ee9d0f21`](https://github.com/NixOS/nixpkgs/commit/ee9d0f21fcc6d06cc072924321e196a7376ccde1) python311Packages.hahomematic: 2023.7.0 -> 2023.7.3
* [`5fda11d3`](https://github.com/NixOS/nixpkgs/commit/5fda11d324f9db6cc6be31303c135a42b1c68b60) python311Packages.hahomematic: 2023.7.3 -> 2023.8.2
* [`9dcecbdb`](https://github.com/NixOS/nixpkgs/commit/9dcecbdb3198fa8642dcaa56a0f845260bb7cfb5) fetchzip: cleanup and improve metrics a bit
* [`9437e4da`](https://github.com/NixOS/nixpkgs/commit/9437e4da350a43ff94c3dd06fdf2d20683dd2581) fetchurl: cleanup a bit by moving the warning into assert
* [`4823d1bf`](https://github.com/NixOS/nixpkgs/commit/4823d1bf38a937f0d7482bd399e0e535681e48c6) tor-browser-bundle-bin: deprecate useHardenedMalloc
* [`2e9514b7`](https://github.com/NixOS/nixpkgs/commit/2e9514b773c2551e3a670ea15f1e48dfb30d97af) abseil-cpp_202308: init at 20230802.0
* [`c77a7929`](https://github.com/NixOS/nixpkgs/commit/c77a7929bfc7ce89a85b96c94edf4314965c18ac) openturns: 1.20 -> 1.21
* [`86500186`](https://github.com/NixOS/nixpkgs/commit/86500186c5a5d62af6c16cbcd0515083ae6d7e06) snappy: fix building with clang16
* [`87db4570`](https://github.com/NixOS/nixpkgs/commit/87db45704f10be545ea29d335ac6196e9515312d) stdenv: Print `_allFlags` debug output to stderr
* [`6ddcf930`](https://github.com/NixOS/nixpkgs/commit/6ddcf930d32101afc62ae7f8cf7ba966703fe72f) diffoscope: 246 -> 247
* [`c2b897e6`](https://github.com/NixOS/nixpkgs/commit/c2b897e69e86dfd45921af1bdaa5f374cf78554f) python310Packages.sparse: fix tests
* [`12b3fa5b`](https://github.com/NixOS/nixpkgs/commit/12b3fa5b8bc4ab811464a3fd9b9fa134152236d3) deadd-notification-center: 2.0.4 -> 2.1.1
* [`ae58f006`](https://github.com/NixOS/nixpkgs/commit/ae58f006172cfe982abfc608ba4b31ffbd5aaeb9) avahi: add patch for CVE-2023-1981
* [`98de48fc`](https://github.com/NixOS/nixpkgs/commit/98de48fc8fc8653d82ed4769209564126d299878) pythonRelaxDepsHook: remove version from pkg_name
* [`0976f9a6`](https://github.com/NixOS/nixpkgs/commit/0976f9a6178877912443559955e98e5b67b3303b) liburing: backport upstream parallel build fix
* [`8117571d`](https://github.com/NixOS/nixpkgs/commit/8117571dffac05c488eaadc8893be33219f8f4ea) zotero-translation-server: init at unstable-2023-07-13
* [`c9c027e4`](https://github.com/NixOS/nixpkgs/commit/c9c027e4af1c4c29d8df712e48b336eb16ba7f9e) python3.pkgs.pandas: add missing build dependencies ([nixos/nixpkgs⁠#248623](https://togithub.com/nixos/nixpkgs/issues/248623))
* [`62030612`](https://github.com/NixOS/nixpkgs/commit/620306122cbc4cf7140886501a68047161f4368f) python3.pkgs.jsonschema: add pip test dependency ([nixos/nixpkgs⁠#247311](https://togithub.com/nixos/nixpkgs/issues/247311))
* [`f06e634d`](https://github.com/NixOS/nixpkgs/commit/f06e634dc53b037ebfa570d71f100b076092332f) python3.pkgs.astroid: add wheel and pip dependencies ([nixos/nixpkgs⁠#247258](https://togithub.com/nixos/nixpkgs/issues/247258))
* [`8e951a31`](https://github.com/NixOS/nixpkgs/commit/8e951a317e8798c37e53b70c500242acd56ab805) python3.pkgs.gevent: use cython3 and update build dependencies ([nixos/nixpkgs⁠#248606](https://togithub.com/nixos/nixpkgs/issues/248606))
* [`ca8258f1`](https://github.com/NixOS/nixpkgs/commit/ca8258f19cfd52fe12243eed49e1ab695fde0820) python3.pkgs.scipy: relax build dependency constraints ([nixos/nixpkgs⁠#248612](https://togithub.com/nixos/nixpkgs/issues/248612))
* [`0c23400b`](https://github.com/NixOS/nixpkgs/commit/0c23400bf9b258ec5c8808699572529c6399f1da) SDL2: 2.28.1 -> 2.28.2
* [`b358ebd8`](https://github.com/NixOS/nixpkgs/commit/b358ebd870d409ed098e27b681d31000cb1121c9) treewide: replace `setSourceRoot = "sourceRoot=$PWD"` and similar with `sourceRoot = "."`
* [`d098c821`](https://github.com/NixOS/nixpkgs/commit/d098c821d60e64858e3dc4d4a218998b0ddc5a40) treewide: remove unneeded dots and slashes in `sourceRoot`s
* [`68be474e`](https://github.com/NixOS/nixpkgs/commit/68be474e30887a66e0530edfc898b74fb5dd5d26) linuxPackages.xpadneo: simplify sourceRoot
* [`5a0f953d`](https://github.com/NixOS/nixpkgs/commit/5a0f953d9ffe5c40df263ccccffa647a86729f5a) linuxPackages.xone: simplify sourceRoot
* [`60e834fa`](https://github.com/NixOS/nixpkgs/commit/60e834fa00b5a21dad55278b2ed0b1fa74e84579) rox-filer: simplify sourceRoot
* [`6e6d8bea`](https://github.com/NixOS/nixpkgs/commit/6e6d8bea3a4c27c549e609c6371d56b957dbeb7c) luaPackages.readline: simplify sourceRoot
* [`93831661`](https://github.com/NixOS/nixpkgs/commit/93831661f4a9c17d348ae6e8afda97afd98466e6) tpm2-tss: use installCheckPhase instead of checkPhase, cleanup
* [`72c5b631`](https://github.com/NixOS/nixpkgs/commit/72c5b631113496fb87bbe3cd27e8bb448182b442) s2n-tls: 1.3.47 -> 1.3.48
* [`e00ad608`](https://github.com/NixOS/nixpkgs/commit/e00ad60852a2f7c2aadb5a3365b3cd0a30ce3914) python3.pkgs.gyp: patch shebang in mac_tool.py
* [`d395dbee`](https://github.com/NixOS/nixpkgs/commit/d395dbee943550a1b637e3b7551c9d166620cea6) ssm-agent: 3.0.755.0 -> 3.2.1297.0
* [`8e56a263`](https://github.com/NixOS/nixpkgs/commit/8e56a2635fe3fe31a03f0d60d90cb476ddb8619c) CoreFoundation: specify the tbd explicitly
* [`e42bdbac`](https://github.com/NixOS/nixpkgs/commit/e42bdbacb7f463a05fafb8c0722b453688d1dedf) python3Packages.pymdown-extensions: 9.9.2 -> 10.1.0
* [`f40c84b1`](https://github.com/NixOS/nixpkgs/commit/f40c84b14956cbbfd4da8503a9bf33c1495de4ca) libraw: add patch for CVE-2023-1729
* [`39070fdc`](https://github.com/NixOS/nixpkgs/commit/39070fdc9b861e776407a06546fcd77cfa842889) libraw: add some key reverse dependencies to passthru.tests
* [`c76bb0d5`](https://github.com/NixOS/nixpkgs/commit/c76bb0d58e85f555067547d7ca487dc733549863) nixos/zsh: add enableLsColors
* [`ab5780d3`](https://github.com/NixOS/nixpkgs/commit/ab5780d323d8f4ea51c3f73ba79a55fd8cc35428) python3.pkgs.pyqt-builder: 1.14.1 -> 1.15.2
* [`86ec0707`](https://github.com/NixOS/nixpkgs/commit/86ec07079f68080e42d3c3993dd8d46c59c7efca) nss: accidentally patching same file twice
* [`d6b4100c`](https://github.com/NixOS/nixpkgs/commit/d6b4100cb5e7ef35a44e135d30c28bce09f8d5bb) hwdata: 0.372 -> 0.373
* [`10d01745`](https://github.com/NixOS/nixpkgs/commit/10d01745451b4ad369c69a0ea0c0f486cbe17491) waf: refactor
* [`3fb619b6`](https://github.com/NixOS/nixpkgs/commit/3fb619b6fa7fe8af17fc465061c3b1830bdc2a1d) wafHook: refactor
* [`8ad7ef76`](https://github.com/NixOS/nixpkgs/commit/8ad7ef7624e395d4c9435d456f7a61a1c7933687) wafHook: refactor setup-hook.sh
* [`b5549d90`](https://github.com/NixOS/nixpkgs/commit/b5549d90f263871da428ae89e82bd5a6d7092cdf) wafHook: documentation
* [`a7e095d9`](https://github.com/NixOS/nixpkgs/commit/a7e095d9fd601f62f3dd802ac27f6ee54af5d392) nixos/zram-generator: init
* [`0814089e`](https://github.com/NixOS/nixpkgs/commit/0814089e0591faeb74ef09f3c12e9daacbe396d3) nixos/zram: use nixos/zram-generator as backing implementation
* [`44c0e453`](https://github.com/NixOS/nixpkgs/commit/44c0e453edffb021808f4db883dbeec41bd91319) python311Packages.aioquic: 0.9.20 -> 0.9.21
* [`6057b825`](https://github.com/NixOS/nixpkgs/commit/6057b825d74b3c1988d3b2df0895e855f2cbeb8c) python311Packages.google-cloud-kms: 2.18.0 -> 2.19.1
* [`a8b13e73`](https://github.com/NixOS/nixpkgs/commit/a8b13e733a49040884c10a53432dcd16836c05df) libGLU: Enable build parallelism
* [`0aac0979`](https://github.com/NixOS/nixpkgs/commit/0aac097901dd8d73cd44f87b06685bdbf89b4f47) fdk_aac: Enable build parallelism
* [`70cea510`](https://github.com/NixOS/nixpkgs/commit/70cea510a8027b94bf9aa396fad767f8d47c07a8) glog: disable broken test under clang
* [`4de2a329`](https://github.com/NixOS/nixpkgs/commit/4de2a329dbc84b69806d0a13f47f1f11f23a7cac) python3Packages.pymdown-extensions: add key reverse dependencies to passthru.tests
* [`8981783b`](https://github.com/NixOS/nixpkgs/commit/8981783b6071234bcc7fb6dc1b2c0ad3f833797b) services/prometheus/exporters: add mysqld
* [`66de20bc`](https://github.com/NixOS/nixpkgs/commit/66de20bc456a1ff2499db3e56560792fc6afa8eb) tests/prometheus-exporters: add test for mysqld exporter
* [`134aacd4`](https://github.com/NixOS/nixpkgs/commit/134aacd40bd55186093cbe318abf175c66f7b96d) python3Packages.tornado: 6.2.0 -> 6.3.3
* [`ae481cb7`](https://github.com/NixOS/nixpkgs/commit/ae481cb7c05d8176c1145fbf5055b69f7b1e3f86) python3Packages.aws-sam-translator: 1.60.1 -> 1.73.0
* [`61a8a776`](https://github.com/NixOS/nixpkgs/commit/61a8a776ea73207b3dce96048579d97a61b58fc7) python3Packages.tornado: add some key reverse dependencies to passthru.tests
* [`93d5da9d`](https://github.com/NixOS/nixpkgs/commit/93d5da9d1f0394c31bf2ab272a5f8dd2805c210e) wt4: 4.9.1 -> 4.10.0
* [`a9428864`](https://github.com/NixOS/nixpkgs/commit/a9428864ddd355f2981596a5a9c773f29f345078) Revert "gtk2,gtk3: rename derivation name"
* [`0fc50aec`](https://github.com/NixOS/nixpkgs/commit/0fc50aecd97a77fe77221e95fd09393a77c38531) python3.pkgs.socksio: unpin flit-core dependency ([nixos/nixpkgs⁠#248943](https://togithub.com/nixos/nixpkgs/issues/248943))
* [`8894e03c`](https://github.com/NixOS/nixpkgs/commit/8894e03cbb9abde664518f65971cbaf02fd67672) dataexplorer: 3.7.9 -> 3.8.0
* [`975a086b`](https://github.com/NixOS/nixpkgs/commit/975a086ba669403b9620a5083d0bd3b69fb2675c) cri-tools: v1.27.1 -> v1.28.0
* [`c2625ce3`](https://github.com/NixOS/nixpkgs/commit/c2625ce30b6bf59e21e1793712ca4365f99d8a0d) flyway: 9.21.0 -> 9.21.1
* [`3483420d`](https://github.com/NixOS/nixpkgs/commit/3483420d725a59b264bcbbc599ac09138cdebe53) watchman: 2023.01.30.00 -> 2023.08.14.00
* [`6bcf6a8d`](https://github.com/NixOS/nixpkgs/commit/6bcf6a8d4f4070e2f5a64ca4ee6f3c44d4f0f168) python3Packages.pillow: Fix cross compilation
* [`20642ff7`](https://github.com/NixOS/nixpkgs/commit/20642ff730760c1d330c22c0f90a9118ab5d6c0b) docutils: 0.19 → 0.20.1
* [`e6653c7a`](https://github.com/NixOS/nixpkgs/commit/e6653c7a1e7ed8846ac5e3ceeb964366fddcb919) plasma-pass: Fix fetch tag
* [`6883e882`](https://github.com/NixOS/nixpkgs/commit/6883e8826a2fcdc24975438813cf1a1c9ab76c79) util-linux: 2.39 -> 2.39.1
* [`db7d4957`](https://github.com/NixOS/nixpkgs/commit/db7d49573f8ec1af4cdd0e5b203fe7b1fba0043e) python3Packages.pillow-simd: Fix cross compilation
* [`862ba6f2`](https://github.com/NixOS/nixpkgs/commit/862ba6f2977065a5fe661e2e04db79153625b758) python310Packages.dm-haiku: fix build
* [`cd6106c4`](https://github.com/NixOS/nixpkgs/commit/cd6106c49716c9a35f9c332078e19857b759207b) python3Packages.tornado_4: add patch for CVE-2023-28370
* [`0809ce01`](https://github.com/NixOS/nixpkgs/commit/0809ce01f054fb3962e3d27f1c5425eb552a4c73) python3Packages.tornado_5: add patch for CVE-2023-28370
* [`9646cb5c`](https://github.com/NixOS/nixpkgs/commit/9646cb5c499a8f6d7ba113cee6a3caff2f4a85e8) buildDotnetGlobalTool: fix typo
* [`0f5c7b48`](https://github.com/NixOS/nixpkgs/commit/0f5c7b4827c6e54ae774f7048e2042f8d6124ada) qt5.qtbase: backport patch to fix things crashing on exit
* [`df104cf1`](https://github.com/NixOS/nixpkgs/commit/df104cf15fa75b4280f72804dbdd25bd650c6953) notation: 1.0.0-rc.7 -> 1.0.0
* [`620e8688`](https://github.com/NixOS/nixpkgs/commit/620e8688f34dde0bb3c7ec7d5a65bdf73ab9adc8) kodiPackages.pvr-iptvsimple: 20.10.1 -> 20.11.0
* [`ae8aba38`](https://github.com/NixOS/nixpkgs/commit/ae8aba3836997fb10ea49cd0ae58d555d22aa397) doc/stdenv/stdenv.chapter.md: add information about nix-update-script and nixpkgs-update
* [`58091ad8`](https://github.com/NixOS/nixpkgs/commit/58091ad80822f96f0ff96a4fe55d7f206e2efd03) python3Packages.wasmer: not broken on darwin
* [`50b25b5c`](https://github.com/NixOS/nixpkgs/commit/50b25b5cadac986b9c40e526f16efac3b1689426) seahub: fix PIL compatibility
* [`bcfab5f1`](https://github.com/NixOS/nixpkgs/commit/bcfab5f12d2eeb85fa12f6504b35b1b4c9827fb8) seafile-server: 9.0.6 -> 9.0.10
* [`58ff0b6d`](https://github.com/NixOS/nixpkgs/commit/58ff0b6d8c480a925cbce3d4f21a351d4e0c3ab2) victoriametrics: 1.92.1 -> 1.93.0
* [`998b9918`](https://github.com/NixOS/nixpkgs/commit/998b9918bf17b65c4ec5167c8da7875fa21350b6) mariadb-connector-c: 3.1.13 -> 3.1.21
* [`44104377`](https://github.com/NixOS/nixpkgs/commit/441043771bba6febfef32adf79e68cf134433e7b) mariadb-connector-c: 3.2.5 -> 3.2.7
* [`d4faf87c`](https://github.com/NixOS/nixpkgs/commit/d4faf87c9fb20e5869a26b3e76725d7a55a89de7) mariadb-connector-c: init at 3.3.5
* [`272b35bc`](https://github.com/NixOS/nixpkgs/commit/272b35bc9188cbe4ddaaf9bd30155c6f383b4031) mariadb-connector-c: enable default v3.3.x
* [`611b957c`](https://github.com/NixOS/nixpkgs/commit/611b957c98e52da33e86b379bc2ec883a1320294) mariadb-connector-c: fix locate libdir and plugindir
* [`0d8421c9`](https://github.com/NixOS/nixpkgs/commit/0d8421c9062ed39acb19b934374853de84dcc4c5) noson: fix pulse audio streaming support
* [`5b5d3328`](https://github.com/NixOS/nixpkgs/commit/5b5d3328c8de6ac4d0f99f668fa30698c404e0e6) liblc3: 1.0.3 -> 1.0.4
* [`68cc0258`](https://github.com/NixOS/nixpkgs/commit/68cc02588d4659c77b9e5bfab7ff848c2b5248ca) qt5: include qttranslations properly
* [`0597d865`](https://github.com/NixOS/nixpkgs/commit/0597d865ef4f763f3fed54702b29ce328d28e2b4) qt6: include qttranslations properly
* [`4d0a7641`](https://github.com/NixOS/nixpkgs/commit/4d0a76416f5ca0402bfe7fc3fcd52a6d36c660c3) qt6.qtwebengine: don't try to install locales to qtbase translation directory
* [`6edd6f71`](https://github.com/NixOS/nixpkgs/commit/6edd6f71c7a089e88e500243904ea76ef023930c) treewide: clean up all qttranslations workarounds
* [`d139cdac`](https://github.com/NixOS/nixpkgs/commit/d139cdace150e5641d83b969e94ec29e6677d746) maturin: 1.1.0 -> 1.2.0
* [`e12ae527`](https://github.com/NixOS/nixpkgs/commit/e12ae52757fd6af24601f4fae8a25777ab3f3304) fluffychat: 1.12.1 -> 1.13.0
* [`1ff383d2`](https://github.com/NixOS/nixpkgs/commit/1ff383d2b4cb21aaba5ee3ae36baef30b8270959) pt2-clone: 1.61 -> 1.62.2
* [`aa418392`](https://github.com/NixOS/nixpkgs/commit/aa418392e3dbd8ba79ca7003f8fce98b970ae714) Revert "docutils: 0.19 → 0.20.1"
* [`c81c467d`](https://github.com/NixOS/nixpkgs/commit/c81c467dce23cc8fc270b6f6e3d522184661cf6e) python3.pkgs.cmake: init stub at 3.26.4
* [`068068ff`](https://github.com/NixOS/nixpkgs/commit/068068ff53691a4cacb0a0b20a25d69be6b99166) python3.pkgs.scikit-build-core: depend on top-level cmake
* [`d8569354`](https://github.com/NixOS/nixpkgs/commit/d856935455c241bcaf0315c1d8f3ce515e6a8c48) python3.pkgs.awkward-cpp: depend on top-level cmake
* [`0f02768e`](https://github.com/NixOS/nixpkgs/commit/0f02768eba6b7707cfb038b94251bac8527a14be) maturin: 1.2.0 -> 1.2.2
* [`ee6af9e1`](https://github.com/NixOS/nixpkgs/commit/ee6af9e11cf6f4ff313d7cdef3ec59792d82d12b) vscode-extensions.ms-vscode-remote.remote-containers: init at 0.305.0
* [`f8eff75c`](https://github.com/NixOS/nixpkgs/commit/f8eff75c1658e53c0ea7bbf5bca8c0d7f2027a5a) kubemqctl: 3.5.1 -> 3.7.2
* [`ec36e021`](https://github.com/NixOS/nixpkgs/commit/ec36e0218f785b4776496a9733334faec704cb4e) nixos/security/wrappers: stop using `.real` files
* [`11ca4dcb`](https://github.com/NixOS/nixpkgs/commit/11ca4dcbb806217bd16a3df44b8368c936a7f415) nixos/security/wrappers: read capabilities off /proc/self/exe directly
* [`ff204ca3`](https://github.com/NixOS/nixpkgs/commit/ff204ca32b7b393caa1d33fc8a795f45f5c118e5) nixos/security/wrappers: remove all the assertions about readlink(/proc/self/exe)
* [`46c9aed6`](https://github.com/NixOS/nixpkgs/commit/46c9aed62b25cc98460a623dfa3680cca5fbf91b) nixos/security/wrappers: add one regression test for [nixos/nixpkgs⁠#98863](https://togithub.com/nixos/nixpkgs/issues/98863)
* [`85e41cbd`](https://github.com/NixOS/nixpkgs/commit/85e41cbd72d9e3f7543c8a284a2a731a0902d423) steampipe: 0.20.9 -> 0.20.10
* [`852288c3`](https://github.com/NixOS/nixpkgs/commit/852288c32f1fdaf9aab96fdf546530ec88306654) htslib: 1.17 -> 1.18
* [`697f9aee`](https://github.com/NixOS/nixpkgs/commit/697f9aee9c13a083940288c739519393d1c1cc80) picard: 2.9 -> 2.9.1
* [`b563d910`](https://github.com/NixOS/nixpkgs/commit/b563d910a099890033b62dfaf269ce85e44b0e4d) gnu-config: use the unpackPhase, so .overrideAttrs(_:{patches=...}) works
* [`3ddf69b3`](https://github.com/NixOS/nixpkgs/commit/3ddf69b37d472e6cb548deb9ab0a3004543b4070) gnu-config: set dontUpdateAutotoolsGnuConfigScripts = true
* [`23128611`](https://github.com/NixOS/nixpkgs/commit/2312861130ec0c9d1b60526e3ba0ac9659ab8844) docutils: 0.19 -> 0.20.1
* [`6a98b124`](https://github.com/NixOS/nixpkgs/commit/6a98b124b3a7b92e44deadf5f427f240a4cca445) nvtop: 3.0.1 -> 3.0.2
* [`2c24a6d4`](https://github.com/NixOS/nixpkgs/commit/2c24a6d45a816a034898c6ae21f1347ed12ede95) python311Packages.dataclasses-json: 0.5.9 -> 0.5.14
* [`c19e4174`](https://github.com/NixOS/nixpkgs/commit/c19e4174fbda5531cfd23fe4a99b403e20c7c9b3) apply pr comments
* [`814012a2`](https://github.com/NixOS/nixpkgs/commit/814012a2306c49815543f3a072126c03c13426b7) python3.pkgs.ninja: add __version__ to stub
* [`adf01a32`](https://github.com/NixOS/nixpkgs/commit/adf01a3233d7c89a4fd7dcd0c867513aec634740) python3.pkgs.cmake: add __version__ to stub
* [`c4013826`](https://github.com/NixOS/nixpkgs/commit/c40138269ccfe2f6354d88753ffce71a93a6dfac) python3Packages.humanize: 4.7.0 -> 4.8.0
* [`3d854d48`](https://github.com/NixOS/nixpkgs/commit/3d854d481260676ba70cf5940e575f9ab876a473) python3.pkgs.scikit-build-core: add missing test dependencies
* [`57b6095d`](https://github.com/NixOS/nixpkgs/commit/57b6095d584eeac62e557f61841f624aa0381ece) python3.pkgs.awkward-cpp: add ninja build dependency
* [`3432d092`](https://github.com/NixOS/nixpkgs/commit/3432d092bc947cd8c2cfbf83a875b37aef126f66) waf: 2.0.25 -> 2.0.26
* [`e2fd2417`](https://github.com/NixOS/nixpkgs/commit/e2fd2417f6ed93007e8dad18163ea042c82d3226) janet: 1.29.1 -> 1.30.0
* [`a7759b6b`](https://github.com/NixOS/nixpkgs/commit/a7759b6bb7947ac0635e3b1c5b0a2cb1ebeb7aee) mongosh: 1.10.4 -> 1.10.5
* [`04655024`](https://github.com/NixOS/nixpkgs/commit/046550242fc65e29ddc6c3ed8f5c28da8792296e) libcifpp: 5.1.0.1 -> 5.1.2
* [`2021b571`](https://github.com/NixOS/nixpkgs/commit/2021b571fbb8b91170a025501041e82878792b5f) python310Packages.rdkit: 2023.03.2 -> 2023.03.3
* [`c9b4998c`](https://github.com/NixOS/nixpkgs/commit/c9b4998cc9545fa9f968ec29a8a05350dc0e2ed4) qt-5/modules/qtbase.nix: omit --host and --build configureFlags
* [`0af69c7c`](https://github.com/NixOS/nixpkgs/commit/0af69c7c52cdfe15b917c06bf52e712eeaf247d9) ncdu: pie for darwin builds
* [`a68a6b0b`](https://github.com/NixOS/nixpkgs/commit/a68a6b0b7e138ffd7ceea58de6f1eb6f479ae1e6) anilibria-winmaclinux: init at 1.2.9
* [`95a0ebbd`](https://github.com/NixOS/nixpkgs/commit/95a0ebbd99aa14cec70e5dac3a44a9f497b45abf) python310Packages.atlassian-python-api: 3.40.0 -> 3.41.0
* [`994f2560`](https://github.com/NixOS/nixpkgs/commit/994f2560d0931b1714f5ae6e86dbd567dd70f8d8) Fix nixBufferBuilders for newer emacs
* [`fa8eefef`](https://github.com/NixOS/nixpkgs/commit/fa8eefefde3d8e63da35e75df4eaa208309c32a1) libarchive: make static patch unconditional
* [`8c33d725`](https://github.com/NixOS/nixpkgs/commit/8c33d725d74ad842bc89f52b9f2d3a78fcd70148) python310Packages.types-protobuf: 4.23.0.2 -> 4.24.0.1
* [`8bf903bb`](https://github.com/NixOS/nixpkgs/commit/8bf903bb317f4ca26c9b36d5508e7e528ecfbaca) newsflash: 2.3.0 -> 2.3.1
* [`f1c0589e`](https://github.com/NixOS/nixpkgs/commit/f1c0589e4c778cc5852a14c6776a7053177983c3) nixos/tests/lxd: move into subdir, use minimal init, remove sleeps
* [`6ff766da`](https://github.com/NixOS/nixpkgs/commit/6ff766dafe8c19db06270a65909dfff87a607382) kodiPackages.arteplussept: 1.1.10 -> 1.4.0
* [`8d9f56ac`](https://github.com/NixOS/nixpkgs/commit/8d9f56ac2d04d6ed3f4c2321496749c0de539ebb) last: 1460 -> 1471
* [`2311ba8e`](https://github.com/NixOS/nixpkgs/commit/2311ba8e91172b9a6138ef0790685a762f46c985) python3Packages.cairocffi: 1.5.1 -> 1.6.1
* [`57251cfc`](https://github.com/NixOS/nixpkgs/commit/57251cfc8b95e1cd0e0bfc9a850a4f1911303476) python310Packages.python-manilaclient: 4.5.0 -> 4.5.1
* [`8377b96e`](https://github.com/NixOS/nixpkgs/commit/8377b96e127962bc4d569b4d800e0a4239976b0d) maintainers: add dawidd6
* [`ca2198dd`](https://github.com/NixOS/nixpkgs/commit/ca2198ddf92368442fb78d42e31d9b437fb1696d) python310Packages.molecule-plugins: init at 23.4.1
* [`83bd85b7`](https://github.com/NixOS/nixpkgs/commit/83bd85b72ba7641d70382bd59a29c32572875e50) molecule: init at 5.1.0
* [`fb77c22c`](https://github.com/NixOS/nixpkgs/commit/fb77c22cb259b35a3758811ebb71b9a3eb5eef7a) libsndfile: 1.2.0 -> 1.2.2
* [`8d002691`](https://github.com/NixOS/nixpkgs/commit/8d00269199b26d547560d6911ba301c925bd5da5) granted: fix packaging and mark as broken
* [`bf7a81d8`](https://github.com/NixOS/nixpkgs/commit/bf7a81d8ddb8beb92609fad6a4dc78996b4e4b73) nixBufferBuilders: Don't assume the user has used eshell
* [`f0deb16f`](https://github.com/NixOS/nixpkgs/commit/f0deb16f8e8bb4b61b7d204713ec3d3f18b284a8) libime: 1.0.17 -> 1.1.0
* [`b5e9eb26`](https://github.com/NixOS/nixpkgs/commit/b5e9eb26c26c3314d53dd2b6d2c35508b0c81638) fcitx5: 5.0.23 -> 5.1.0
* [`33614fda`](https://github.com/NixOS/nixpkgs/commit/33614fda223ffee95787f9babeae1d6904d93a08) re2: 2023-03-01 -> 2023-08-01
* [`f5e30de2`](https://github.com/NixOS/nixpkgs/commit/f5e30de2ff3a41fe966be628a58fcac900ee9183) re2: add networkexception as maintainer
* [`85231259`](https://github.com/NixOS/nixpkgs/commit/85231259f0a6d88f654973a201cbfbc888f965a7) oil: 0.16.0 -> 0.17.0
* [`c48e3d8c`](https://github.com/NixOS/nixpkgs/commit/c48e3d8ccc70b2e28032933dcbb4d4804d13e971) ocamlPackages.ppx_bench: 0.15.0 → 0.15.1
* [`a60e0da5`](https://github.com/NixOS/nixpkgs/commit/a60e0da56302bc09573bc45fb3f86d7fb57a61a3) pythonPackages.fb-re2: fix build with new re2 release
* [`741fa23a`](https://github.com/NixOS/nixpkgs/commit/741fa23a326eabad7e6d7af7f9473e1b6096e0b2) python3Packages.types-mock: init at 5.1.0.1
* [`18ff1913`](https://github.com/NixOS/nixpkgs/commit/18ff1913703624e7024d3dffe1c4cc31c9e79a49) python3Packages.types-appdirs: init at 1.4.3.5
* [`a520ba04`](https://github.com/NixOS/nixpkgs/commit/a520ba04c48259c3337f24817199e3009b78d068) python3Packages.tableauserverclient: init at 0.25
* [`02c688f1`](https://github.com/NixOS/nixpkgs/commit/02c688f182be4767678949062c6f9de3d3ad1f9a) python3Packages.pyinstaller-versionfile: init at 2.1.1
* [`470705e7`](https://github.com/NixOS/nixpkgs/commit/470705e777e10c7f7743cad8f537e6c1efd41914) python3Packages.tabcmd: init at 2.0.12
* [`e728d92e`](https://github.com/NixOS/nixpkgs/commit/e728d92e8a727279acb128ab798096e25fed9087) slskd: 0.17.8 → 0.18.1
* [`1260276f`](https://github.com/NixOS/nixpkgs/commit/1260276f1a7b2aeccbc16acdfb54c54c06aa3cc5) libjack2: 1.9.19 -> 1.9.22
* [`8e6c0c14`](https://github.com/NixOS/nixpkgs/commit/8e6c0c14a47046fb9424aaf9371ec743bcc0f9c2) libredirect: Fix segfault handling null paths
* [`1bda6e59`](https://github.com/NixOS/nixpkgs/commit/1bda6e5984e1e2c4f879d36943dbe632f724ed44) python3.pkgs.pg8000: add versioningit dependency
* [`bff13ed2`](https://github.com/NixOS/nixpkgs/commit/bff13ed20e3061fbef3dba8d6a7ca9411be9c4e3) libcap: add some key reverse-dependencies to passthru.tests
* [`a08d69ba`](https://github.com/NixOS/nixpkgs/commit/a08d69ba6322ebb2a2cd3dec4b5b6919f335bc29) nixos/restic: wait for network-online for timed backups
* [`d2ed3258`](https://github.com/NixOS/nixpkgs/commit/d2ed3258d1680df6cb2104d5f932922897ea1353) firebase-tools: use buildNpmPackage
* [`ea57eff1`](https://github.com/NixOS/nixpkgs/commit/ea57eff1def0ce1374628a195285854cab851ddd) python310Packages.datashader: 0.15.1 -> 0.15.2
* [`dc340b88`](https://github.com/NixOS/nixpkgs/commit/dc340b88601fa927baa84bfc3854134a1c3ad639) grapejuice: 7.8.3 -> 7.14.4
* [`9f92f12c`](https://github.com/NixOS/nixpkgs/commit/9f92f12c8e0fe449ec8aa599584d9bdab3cb743b) python310Packages.tinyrecord: init at 0.2.0
* [`c24fb60d`](https://github.com/NixOS/nixpkgs/commit/c24fb60d9215f44a4628cae57eeb87da391367d3) python310Packages.edk2-pytool-library: 0.16.2 -> 0.17.0
* [`c518bfce`](https://github.com/NixOS/nixpkgs/commit/c518bfced3241f4c4129031530f7981bc6b8bbc0) v2ray-domain-list-community: 20230810162343 -> 20230815132423
* [`9ff30574`](https://github.com/NixOS/nixpkgs/commit/9ff305745fff0d2b9d1df325b933247434ffb011) python310Packages.textual: 0.32.0 -> 0.33.0
* [`54f3eb13`](https://github.com/NixOS/nixpkgs/commit/54f3eb132e88e417ed3aa55db33b75b2f8ea7967) mupdf: add updateScript
* [`5b83b203`](https://github.com/NixOS/nixpkgs/commit/5b83b203e255d2875b436d81db93dfd14a255017) ruby.rubygems: 3.4.18 -> 3.4.19
* [`dbd39375`](https://github.com/NixOS/nixpkgs/commit/dbd393758ac301de5490ae3e3134f15da2b2611a) mupdf: add changelog to meta
* [`c8705bc0`](https://github.com/NixOS/nixpkgs/commit/c8705bc056ad1b4ad5741bc7e41a002f438de248) bundler: 2.4.18 -> 2.4.19
* [`c6bce150`](https://github.com/NixOS/nixpkgs/commit/c6bce150f3ca58136d6d5e7061b86f61f03bc898) flexget: 3.9.1 -> 3.9.3
* [`3199cf23`](https://github.com/NixOS/nixpkgs/commit/3199cf23621dfec14f671e1a82245c418c0946b3) python310Packages.grpcio-testing: 1.56.2 -> 1.57.0
* [`a40945ad`](https://github.com/NixOS/nixpkgs/commit/a40945ad67992bf4399d5827a6cae464c85d499e) mupdf: 1.22.1 -> 1.23.0
* [`42fa9734`](https://github.com/NixOS/nixpkgs/commit/42fa97340b1fa390f9252fb1f5968acf21704007) ansible-doctor: use poetry-dynamic-versioning like upstream
* [`b593190d`](https://github.com/NixOS/nixpkgs/commit/b593190dbfb46dc4abf3337fa1880014fff487f1) ansible-later: use poetry-dynamic-versioning like upstream
* [`027907e0`](https://github.com/NixOS/nixpkgs/commit/027907e0335c5daf7a184d3dc26d7adb8cfbaebb) python3.pkgs.python-rtmidi: 1.5.4 -> 1.5.5
* [`47049f79`](https://github.com/NixOS/nixpkgs/commit/47049f796be22b763a365342aefc0ad8a08d26a4) argo: 3.4.8 -> 3.4.10
* [`0ceee835`](https://github.com/NixOS/nixpkgs/commit/0ceee835407d6dc6b430a97a09a7fd7d2eb792f7) pipenv: remove wheel install test, enable unit tests
* [`204870b5`](https://github.com/NixOS/nixpkgs/commit/204870b535885d545265458c6cb920f3e901883a) python3.pkgs.pytest-mockservers: fully replace poetry with poetry-core
* [`e3a7e830`](https://github.com/NixOS/nixpkgs/commit/e3a7e8306a128caf5fac8b1141eabae32f0d0dca) maintainers: add rapiteanu
* [`f64d4203`](https://github.com/NixOS/nixpkgs/commit/f64d4203b6c5707fab623af895923dc6d262c866) vscode-wikitext: add rapiteanu as maintainer
* [`0fe1529f`](https://github.com/NixOS/nixpkgs/commit/0fe1529f1a17dec2bac906d3405551cbef2719fe) julia_19: disable install check for aarch64-linux
* [`68f2fb2f`](https://github.com/NixOS/nixpkgs/commit/68f2fb2f38c61f33d6891583bb1afaf35ac6c633) python310Packages.numba: fix cuda path patch
* [`aa1b22fa`](https://github.com/NixOS/nixpkgs/commit/aa1b22fac38e45d21a418985c65882583f0830a8) fzf-make: add preview dependencies
* [`ac4e14be`](https://github.com/NixOS/nixpkgs/commit/ac4e14be09eb976af772679cb0c70fead7b667f9) fzf-make: 0.6.0 -> 0.7.0
* [`1d37534b`](https://github.com/NixOS/nixpkgs/commit/1d37534b1c1ac6259ee189a6c3971763765a1fc4) python310Packages.molecule-plugins: set optional-dependencies
* [`658ab4b4`](https://github.com/NixOS/nixpkgs/commit/658ab4b45b317948bd93c796c544baa7a1bcb068) cc-wrapper: add fortify flags after invocation args, not before
* [`0f2a905c`](https://github.com/NixOS/nixpkgs/commit/0f2a905cab41156831f427d9f03f3757a916fa14) python310Packages.pyprecice: 2.5.0.3 -> 2.5.0.4
* [`3fd84991`](https://github.com/NixOS/nixpkgs/commit/3fd84991771643bdd80383b6840bf25954e522ad) graphqurl: use buildNpmPackage
* [`5ecb6664`](https://github.com/NixOS/nixpkgs/commit/5ecb666419b989143f1563388a8b44e43abbcb8f) python3.pkgs.pyerfa: add missing build dependencies
* [`38fcb282`](https://github.com/NixOS/nixpkgs/commit/38fcb28228591fcf24778cf55aee24485ea11f00) python3.pkgs.astropy: fix build dependencies
* [`db58732c`](https://github.com/NixOS/nixpkgs/commit/db58732cbe6646cc8e54d67e1bad554049f3159f) whitesur-kde: init at unstable-2023-08-15
* [`60195447`](https://github.com/NixOS/nixpkgs/commit/60195447f3135c770b3792859be8d36e5413b6c7) august: init at unstable-2023-08-13
* [`b33de270`](https://github.com/NixOS/nixpkgs/commit/b33de2708f7edfaac2f6d9c3fea72912fe17b9ec) grapejuice: use upstream installation script
* [`25fa8c87`](https://github.com/NixOS/nixpkgs/commit/25fa8c87ba132365063d9234f5fbb84732432ec0) sngrep: add patch for CVE-2023-36192
* [`df7d2ff5`](https://github.com/NixOS/nixpkgs/commit/df7d2ff505932c552b83d6d8c029b29b53a98591) sngrep: enable tests
* [`51824a08`](https://github.com/NixOS/nixpkgs/commit/51824a08f3289f771594db0cf6b700392b2c0cf4) etlegacy: remove unused `runCommand` argument
* [`81f84d95`](https://github.com/NixOS/nixpkgs/commit/81f84d95e46f651b18c95106e8a623b38d479673) etlegacy: add `drupol` as maintainer
* [`918f740a`](https://github.com/NixOS/nixpkgs/commit/918f740a6775fec57fdd5d27cde2e1303ed7bc9f) etlegacy: reduce amount of local vars
* [`9a0d0c1b`](https://github.com/NixOS/nixpkgs/commit/9a0d0c1b50196bf884467870362b0204c72140ea) etlegacy: refactor `fetchAsset`
* [`389ced53`](https://github.com/NixOS/nixpkgs/commit/389ced5395d7b776c04be4f4d7ed69c8a7dab97c) btc-rpc-explorer: use buildNpmPackage
* [`2aa7c01f`](https://github.com/NixOS/nixpkgs/commit/2aa7c01f0ab76eb6d40a384f649b75d7a4cc098d) python3.pkgs.matplotlib: add missing build dependencies ([nixos/nixpkgs⁠#249459](https://togithub.com/nixos/nixpkgs/issues/249459))
* [`186fa79b`](https://github.com/NixOS/nixpkgs/commit/186fa79bbca899c1d8c18b554b87116650c33cbc) pv: 1.6.20 -> 1.7.24
* [`6e94d939`](https://github.com/NixOS/nixpkgs/commit/6e94d939928536f95f3baf4efff0189acd7f6e62) pv: Add myself as maintainer
* [`10028cfc`](https://github.com/NixOS/nixpkgs/commit/10028cfcc3c3371a27202e11d31272907ea2b9d8) calcurse: 4.8.0 -> 4.8.1
* [`a27d23aa`](https://github.com/NixOS/nixpkgs/commit/a27d23aa3b2e7058dc72ca6d640764a621276046) calcurse: Add myself as maintainer
* [`5d2290bb`](https://github.com/NixOS/nixpkgs/commit/5d2290bb58f0252ad6ea29723827d40765099c44) python3.pkgs.bootstrap.flit-core: init at 3.8.0
* [`8fe3d15c`](https://github.com/NixOS/nixpkgs/commit/8fe3d15c179c827bb9ed05d6352e9e54ea8ca9b3) python3.pkgs.bootstrap.installer: init at 0.7.0
* [`b53cef70`](https://github.com/NixOS/nixpkgs/commit/b53cef70f252f3978d6befcb1ec0b6ffd603949d) python3.pkgs.bootstrap.build: init at 0.10.0
* [`a4d66bcc`](https://github.com/NixOS/nixpkgs/commit/a4d66bcc5fc51140c889fe9aa17720c50214d38b) python3.pkgs.pypaInstallHook: init
* [`93d25dda`](https://github.com/NixOS/nixpkgs/commit/93d25dda841f320fcd2316ba69d26a935653c451) python3.pkgs.pypaBuildHook: switch to pyproject-build
* [`e8cca499`](https://github.com/NixOS/nixpkgs/commit/e8cca499a84e06147d5d990dd0ae20ae17b21c66) python2.{buildPythonPackage,buildPythonApplication}: extract into its own file
* [`6c85fff3`](https://github.com/NixOS/nixpkgs/commit/6c85fff302615c62bf4f632bca661bc48298b0a3) python3.pkgs.buildPythonPackage: switch to PyPA build and installer
* [`0d764788`](https://github.com/NixOS/nixpkgs/commit/0d7647889c6701d8a0e6fa784e886012011ca2d8) python3.pkgs.installer: move tests to passthru
* [`349f57fb`](https://github.com/NixOS/nixpkgs/commit/349f57fb426225483f12e082e5ab5da8137eefe8) python3.pkgs.pyproject-hooks: move tests to passthru
* [`e1cafe64`](https://github.com/NixOS/nixpkgs/commit/e1cafe642a5e7d265d7b1dc55e2ddda81d219377) python3.pkgs.build: move tests to passthru
* [`4e7188c3`](https://github.com/NixOS/nixpkgs/commit/4e7188c39a4b4c5d21134ae4496af0c799a8a264) python3.pkgs.buildPythonPackage: disable conflict check for setuptools and wheel
* [`dd1256d2`](https://github.com/NixOS/nixpkgs/commit/dd1256d2ca410915f8ad91a2a0d1464b4d19f23f) python3.pkgs.pythonRelaxDepsHook: don't propagate wheel
* [`3cd71e0a`](https://github.com/NixOS/nixpkgs/commit/3cd71e0ae67cc48f1135e55bf78cb0d67b53ff86) python3.pkgs.wheel: 0.38.4 -> 0.41.1
* [`6b639088`](https://github.com/NixOS/nixpkgs/commit/6b6390885543ee52d0569128648ffefb3d2439b7) poetry2nix.overrides.wheel: adapt to new wheel version
* [`253a2912`](https://github.com/NixOS/nixpkgs/commit/253a291274c2790008fe57c97983d3581a2c7798) poetry2nix.overrides: update build systems for bootstrap packages
* [`5a9dda28`](https://github.com/NixOS/nixpkgs/commit/5a9dda28aa00dd88de3329c29bcdae40591d4634) python3.pkgs.setuptools: build without bootstrapped-pip
* [`ab554373`](https://github.com/NixOS/nixpkgs/commit/ab5543735a9386e249c54e29789b167dc2515172) python3.pkgs.pip: build without bootstrapped-pip
* [`e60ec675`](https://github.com/NixOS/nixpkgs/commit/e60ec6753b802a4efd8229419736ac56414ec2eb) python3.pkgs.cypari2: build without bootstrapped-pip
* [`43c7517c`](https://github.com/NixOS/nixpkgs/commit/43c7517c80f96c961f4f80707b9e8fe57b3bd3d0) python3.pkgs.pip: 23.0.1 -> 23.2.1
* [`d7fea443`](https://github.com/NixOS/nixpkgs/commit/d7fea4436982ba8f1af72db7acfce47a874055ee) python3.pkgs.pip-tools: 6.13.0 -> 7.2.0
* [`b56b0dde`](https://github.com/NixOS/nixpkgs/commit/b56b0dde195e67306d5352cdd1143d3e24388bdf) python3.pkgs.setuptools: 67.4.0 -> 68.0.0
* [`a9b70860`](https://github.com/NixOS/nixpkgs/commit/a9b70860d082b9580e0bb3200e07cb85acbaf209) python310Packages.attrs: 22.2.0 -> 23.1.0
* [`9c363cc8`](https://github.com/NixOS/nixpkgs/commit/9c363cc83f9ee77afe7c330abe12d7cdf3458f81) python3.pkgs.pip: install shell completions
* [`39fc4335`](https://github.com/NixOS/nixpkgs/commit/39fc433514bb0fcf121be187b873bf2565df74a7) python3.pkgs.jedi: 0.18.2 -> 0.19.0
* [`6c1313a9`](https://github.com/NixOS/nixpkgs/commit/6c1313a965d81e74e801d98620ccb56f8ee8de3b) python3.pkgs.scramp: remove versioningit reference
* [`db401169`](https://github.com/NixOS/nixpkgs/commit/db401169605e8941ebd8488f4c9b2973f7668e1a) python3.pkgs.pyproject-api: 1.5.0 -> 1.5.4
* [`1f47268f`](https://github.com/NixOS/nixpkgs/commit/1f47268fae1f0952178d3bfb44038fd67ea73f9e) awsebcli: fixup, remove scripts from setup.py
* [`84503a6c`](https://github.com/NixOS/nixpkgs/commit/84503a6c46fe4c80c016d4fe28e4563da73dd491) python3.pkgs.scipy: Don't relax deps twice
* [`854302c4`](https://github.com/NixOS/nixpkgs/commit/854302c4e666a3648f974d288e7a2bf3d79f953a) python3.pkgs.scipy: Fix some issues in update script
* [`bc1fea42`](https://github.com/NixOS/nixpkgs/commit/bc1fea42cafcd99b6fa4b2896ec27470073c8e96) python3.pkgs.scipy: 1.11.1 -> 1.11.2
* [`3c3fd2fe`](https://github.com/NixOS/nixpkgs/commit/3c3fd2fe9d6916764e84501e42ebdf49798e70b1) home-assistant: unpin and fix build dependencies
* [`3229b1e3`](https://github.com/NixOS/nixpkgs/commit/3229b1e3de84cae19856649c18647c8914d51304) home-assistant-intents: fix package
* [`e2dc2280`](https://github.com/NixOS/nixpkgs/commit/e2dc22802f4cda0cc555d311d442d3cc9bf0aeee) python310Packages.funsor: init at 0.4.5
* [`d3ad6882`](https://github.com/NixOS/nixpkgs/commit/d3ad6882542d76f43e9a1b430a2b0d5a686108b0) python310Packages.numpyro: 0.11.0 -> 0.12.1
* [`ccbd98db`](https://github.com/NixOS/nixpkgs/commit/ccbd98db50f27ff15014284f876beee2217bceae) trivial-builders/applyPatches: carry `meta` information to the patched source
* [`b4b1ce24`](https://github.com/NixOS/nixpkgs/commit/b4b1ce244338c3b8b66a6fd17f9dd3aa3e31f9ec) fetchNextcloudApp: meta propagation for licenses, etc.
* [`c74490e0`](https://github.com/NixOS/nixpkgs/commit/c74490e000168b59f73062a059608dce5a0e1859) nextcloud*Packages: add description, homepage, licenses from JSON
* [`850af444`](https://github.com/NixOS/nixpkgs/commit/850af444356b0865337f204c3802b3ac57491695) applyPatches: fix adding meta information
* [`d35670a3`](https://github.com/NixOS/nixpkgs/commit/d35670a3cb5daafa80d37c3262ff29a252c0dad8) ftxui: 4.1.1 -> 5.0.0
* [`8b2f34f7`](https://github.com/NixOS/nixpkgs/commit/8b2f34f7e9df1b0b367c541203caf50e67e05c9f) kodiPackages.myconnpy: 8.0.18+matrix.1 -> 8.0.33
* [`c317dcec`](https://github.com/NixOS/nixpkgs/commit/c317dcec0d36ba6c51f73bd23b5425a3f1d03141) nextcloud*Packages: expose proper license information
* [`9a62a468`](https://github.com/NixOS/nixpkgs/commit/9a62a468740f355b6cfa5113583eece980a17869) fetchNextcloudApp: remove backwards compat for old interface
* [`c7589fc6`](https://github.com/NixOS/nixpkgs/commit/c7589fc67c770ba2b41702955945a1d75a2c3bd5) nextcloud*Packages: update
* [`fd1defeb`](https://github.com/NixOS/nixpkgs/commit/fd1defebf3b20114343f3e8e56528d7a769b07c6) deepin.deepin-terminal: 6.0.5 -> 6.0.6
* [`0cbe9ce3`](https://github.com/NixOS/nixpkgs/commit/0cbe9ce37cc6f25e2aa40443541e3148ecac2500) timetagger_cli: init at 23.8.3
* [`a63e9e63`](https://github.com/NixOS/nixpkgs/commit/a63e9e6310c5af5c7d6f3778a3317b32c111efdd) gotemplate: 3.7.2 -> 3.7.4
* [`bbb0c192`](https://github.com/NixOS/nixpkgs/commit/bbb0c1921f03b5a0503ec18903c3d760fa26e938) directx-shader-compiler: 1.7.2212.1 -> 1.7.2308
* [`9b98a569`](https://github.com/NixOS/nixpkgs/commit/9b98a569a819139837cf1b99401c6910312318d6) openrgb: 0.8 -> 0.9
* [`a8147398`](https://github.com/NixOS/nixpkgs/commit/a81473988db5102a414680b1ecbb554e10131a73) python3Packages.python-magic: backport fix for file-5.45
* [`17beb2d7`](https://github.com/NixOS/nixpkgs/commit/17beb2d70cd656d0b87d4d7ac770ce47071d75dd) iosevka: 26.0.2 -> 26.2.1
* [`0482394f`](https://github.com/NixOS/nixpkgs/commit/0482394fe0eb4d3eba91bded8e1d9dbef1bb7c64) ragnarwm: init at 1.3.1
* [`66b6041d`](https://github.com/NixOS/nixpkgs/commit/66b6041d369c8e48250dbf35b6f413e8318bb77d) mupdf: add some key reverse-dependencies to passthru.tests
* [`f07f9add`](https://github.com/NixOS/nixpkgs/commit/f07f9addb14c7c4dac2563faa4f74575e8514fde) etlegacy: build server and client
* [`93b7095e`](https://github.com/NixOS/nixpkgs/commit/93b7095e087b4fd6fae18dc1e49d0fd478afdacc) veilid: 0.1.9 -> 0.1.10
* [`1461c8fd`](https://github.com/NixOS/nixpkgs/commit/1461c8fdd3e89a7ebfd37cfadeb123c28285a76a) etlegacy: update `cmakeFlags` and change default install directories
* [`eab7a243`](https://github.com/NixOS/nixpkgs/commit/eab7a24373dcfbb1af49e4730a1dc40dd46df3b6) etlegacy: disable `fortify` to have fully working binaries
* [`3c9d0679`](https://github.com/NixOS/nixpkgs/commit/3c9d06797bfd1a19c4d52bab2808223d63d130b0) etlegacy: remove `mainprogram` attribute
* [`2f416c0e`](https://github.com/NixOS/nixpkgs/commit/2f416c0e6899c95b889cea16b6382b038ed0b14c) python3Packages.pillow: pull zlib-1.3 fix pending upstream inclusion
* [`75b136a9`](https://github.com/NixOS/nixpkgs/commit/75b136a9504243803b47b4924d42906a3c7cc07d) signal-cli: 0.11.11 -> 0.12.0
* [`4b695e64`](https://github.com/NixOS/nixpkgs/commit/4b695e64f7cf7f1c5ca66148f540c1ee0c7fe5df) mympd: 10.3.3 -> 11.0.3
* [`a9d662cc`](https://github.com/NixOS/nixpkgs/commit/a9d662ccde3497c1a69a8ffe083ca6de4783ce66) rwedid: init at 0.3.2
* [`efa7e407`](https://github.com/NixOS/nixpkgs/commit/efa7e4071573ad4daada203410315dbd09fc81aa) opensnitch: 1.6.2 -> 1.6.3
* [`e88fa156`](https://github.com/NixOS/nixpkgs/commit/e88fa156882c8cac42b0ddafb4dc7b056e9c409e) mympd: Remove enabled by default lua support
* [`12fe23d2`](https://github.com/NixOS/nixpkgs/commit/12fe23d257ab439cad84efa47d64af83a925bc9a) mympd: Disable tests explicitly
* [`5691969e`](https://github.com/NixOS/nixpkgs/commit/5691969ebdab5b0c82500832dc2edb3999dece11) mympd: Reenable strictoverflow hardening flag
* [`def20ba1`](https://github.com/NixOS/nixpkgs/commit/def20ba1ac028d7fe4673c4dac98acbd7c9a184b) kuma,kuma-cp,kuma-dp,kuma-experimental,kumactl: 1.8.1 → 2.3.1
* [`b882b0fa`](https://github.com/NixOS/nixpkgs/commit/b882b0faf18b5a39e66e9fb99b152d3360e9270f) nodePackages.ionic: drop
* [`2db32b89`](https://github.com/NixOS/nixpkgs/commit/2db32b8995c5f204c0fe556cda35e75015662fd1) pipreqs: 0.4.11 -> 0.4.13
* [`3e11564e`](https://github.com/NixOS/nixpkgs/commit/3e11564e9512b1c66e25b59ff9e40e5a14fe4305) python311Packages.json-schema-for-humans: remove postPatch section
* [`d998c261`](https://github.com/NixOS/nixpkgs/commit/d998c261ccb6abd400bcd837025e73fb45bda11f) etlegacy: replace `writeScriptBin` with `writeShellApplication`
* [`bc586df9`](https://github.com/NixOS/nixpkgs/commit/bc586df93d44ce2a672e2afb3ea60f67a62ddf39) etlegacy: add `meta.longDescription`
* [`2836fd6f`](https://github.com/NixOS/nixpkgs/commit/2836fd6fce609d0fb1b01a9cb75500750a6ea5f3) etlegacy: reformat files
* [`6d1c5dd1`](https://github.com/NixOS/nixpkgs/commit/6d1c5dd1dc19b7eaed2b43d8bf2f709daba8e012) pytlv: init at 0.71
* [`51ff54b5`](https://github.com/NixOS/nixpkgs/commit/51ff54b5cc9b26ce2b57d8c0cc1e7a7d6e0922ce) python3.pkgs.gsm0338: init at 1.1.0
* [`ba1d1a86`](https://github.com/NixOS/nixpkgs/commit/ba1d1a863bfbf487a064e198d41f9968137c7307) python3.pkgs.smpp_pdu: init at unstable-2022-09-02
* [`980b0a92`](https://github.com/NixOS/nixpkgs/commit/980b0a9206491e5425dfa89e8083029fe15f70ad) python3.pkgs.pysim: init at unstable-2023-08-11
* [`21676ee7`](https://github.com/NixOS/nixpkgs/commit/21676ee7618e5d2a59a68bd0c986811c4a7d7666) rune: init at 0.12.4
* [`e2e76267`](https://github.com/NixOS/nixpkgs/commit/e2e76267f8b7da8ade9d8f266c40950c969c4166) cloudfox: 1.11.3 -> 1.12.0
* [`d8a05ef6`](https://github.com/NixOS/nixpkgs/commit/d8a05ef6761a5d0ca1e8105c176dcfd0f2b3cf29) docker-compose: 2.20.2 -> 2.20.3
* [`f232a997`](https://github.com/NixOS/nixpkgs/commit/f232a99788e2ea9f699c635f10ac17619fb1019e) famistudio: 4.1.1 -> 4.1.2
* [`5a14ee34`](https://github.com/NixOS/nixpkgs/commit/5a14ee3432fc4352b82af87b985c96e685c49fbc) flannel: 0.22.0 -> 0.22.2
* [`130c8509`](https://github.com/NixOS/nixpkgs/commit/130c8509c26e1625732684afbcc5df321d3242ad) minio-client: 2023-08-08T17-23-59Z -> 2023-08-15T23-03-09Z
* [`8bcca535`](https://github.com/NixOS/nixpkgs/commit/8bcca535055a7eda125f2e62cf75a09cdc4bbb20) skopeo: 1.13.1 -> 1.13.2
* [`c70cc9e1`](https://github.com/NixOS/nixpkgs/commit/c70cc9e18f73b2d3be82e4ae997aa715256ce45e) mdbook-i18n-helpers: 0.1.0 -> 0.2.0
* [`a1d02bae`](https://github.com/NixOS/nixpkgs/commit/a1d02bae32ce388e4ce29bfaabb045a9f70c8d07) round: use sri hash
* [`41f57af8`](https://github.com/NixOS/nixpkgs/commit/41f57af82eeeb89d378b81cd8e12916d0eb8899f) gyb: 1.72 -> 1.74
* [`25c4a8c0`](https://github.com/NixOS/nixpkgs/commit/25c4a8c092749bef04610e68708dc4e9af823660) wrap: fix build
* [`777f796b`](https://github.com/NixOS/nixpkgs/commit/777f796b00dbac2cf99cf49aa9c2337a7a82af6a) python311Packages.apscheduler: 3.10.1 -> 3.10.4
* [`0b6d7c88`](https://github.com/NixOS/nixpkgs/commit/0b6d7c886f645dcefdd6571cfbe5de47e0323d6e) kfctl: remove
* [`6dd3e7ff`](https://github.com/NixOS/nixpkgs/commit/6dd3e7ffad40fa54e05e93d33c6746602ad0c2ec) vivaldi: 6.1.3035.204 -> 6.1.3035.302
* [`ded62fa1`](https://github.com/NixOS/nixpkgs/commit/ded62fa170d9ac1583512fa85689b4255290672b) cargo-chef: 0.1.61 -> 0.1.62
* [`57d4fda9`](https://github.com/NixOS/nixpkgs/commit/57d4fda94a6bf6ed756d02b1faad9901b3525acd) python3.pkgs.imageio-ffmpeg: patch out pip requirement
* [`45723a95`](https://github.com/NixOS/nixpkgs/commit/45723a95c4bdb8239ebd1086008fda795d53b8cd) geographiclib: 2.2 -> 2.3
* [`9c4a92c0`](https://github.com/NixOS/nixpkgs/commit/9c4a92c0a70d90d658ef27e2dcbab4ca72f1a86c) twitch-tui: 2.4.1 -> 2.5.1
* [`c1f2a6ac`](https://github.com/NixOS/nixpkgs/commit/c1f2a6acc1806a9aa16006e10c59c63d83762608) turtle-build: init at 0.4.6
* [`9f8313ee`](https://github.com/NixOS/nixpkgs/commit/9f8313eef1ee32e8cad7e2c911d76a1a2bceec08) tere: 1.4.0 -> 1.5.0
* [`d6855fb3`](https://github.com/NixOS/nixpkgs/commit/d6855fb33a6c4455a63558c96379f5dd92ec52e8) bootstrap-studio: 6.2.1 -> 6.4.5
* [`00832443`](https://github.com/NixOS/nixpkgs/commit/00832443839d9e37f2b67f30aa2e4419c94be7d9) vcv-rack: 2.3.0 -> 2.4.0
* [`72213750`](https://github.com/NixOS/nixpkgs/commit/722137507f669e822d4acc3d47d5257ef3c93e28) gaphor: fix double wrapping
* [`d0c4b57e`](https://github.com/NixOS/nixpkgs/commit/d0c4b57e1f49b4d649b378108de1f0ac8bb9e35d) gobgpd: 3.16.0 -> 3.17.0
* [`2d2a53d1`](https://github.com/NixOS/nixpkgs/commit/2d2a53d19717c3334387e2a0d714ffd0fc98feb5) iosevka-bin: 26.2.0 -> 26.2.1
* [`489add96`](https://github.com/NixOS/nixpkgs/commit/489add96d5cb751e373db0773ee0720e803cfef9) ollama: 0.0.14 -> 0.0.15
* [`d9cde8f9`](https://github.com/NixOS/nixpkgs/commit/d9cde8f9fc9ee2bd05a159bb71b5696e39b069e6) bearer: 1.19.1 -> 1.19.2
* [`c6d28294`](https://github.com/NixOS/nixpkgs/commit/c6d282948bdb9d5ab80c52d6209c246d76629941) llhttp: 9.0.0 -> 9.0.1
* [`ce3b2a76`](https://github.com/NixOS/nixpkgs/commit/ce3b2a768346e51de1f503b2cbdecdcca1ca8f6f) postgresqlPackages.plpgsql_check: 2.3.4 -> 2.4.0
* [`c7e06317`](https://github.com/NixOS/nixpkgs/commit/c7e063170a0992409919c0cb9bc9e735952721d7) flexget: 3.9.3 -> 3.9.4
* [`aff2ef70`](https://github.com/NixOS/nixpkgs/commit/aff2ef70756dafb346f3fc11e62e7f6759b0cd00) ungit: use buildNpmPackage
* [`1430b563`](https://github.com/NixOS/nixpkgs/commit/1430b56362a4719e807568dc38c9b060b118f063) qt5.qtbase: fix cross compilation
* [`8ca5a5a7`](https://github.com/NixOS/nixpkgs/commit/8ca5a5a7687c76d13ae3a4b2769778ed09acf574) ocamlPackages.uring: 0.6 → 0.7 ([nixos/nixpkgs⁠#250313](https://togithub.com/nixos/nixpkgs/issues/250313))
* [`c820e8b5`](https://github.com/NixOS/nixpkgs/commit/c820e8b553fc77e4e2f05cbe99861cffc7e859e2) doppler: 3.65.1 -> 3.65.2
* [`aa47da4c`](https://github.com/NixOS/nixpkgs/commit/aa47da4c2c37d2889c85885c401c805bf4fb9844) ocamlPackages.qcheck-multicoretests-util: init at 0.2
* [`991356c8`](https://github.com/NixOS/nixpkgs/commit/991356c8074eedea2ee40879188b9a8a622b3b4b) ocamlPackages.qcheck-lin: init at 0.2
* [`6698fd45`](https://github.com/NixOS/nixpkgs/commit/6698fd456eed52fdf91e5fd48b6d6cef478ff3ff) ocamlPackages.qcheck-stm: init at 0.2
* [`c11be190`](https://github.com/NixOS/nixpkgs/commit/c11be19059c24d385cd28218f9a6ded9e87bf1da) default-gcc-version: init
* [`0f7bf37e`](https://github.com/NixOS/nixpkgs/commit/0f7bf37e5a9b8ac4a690303310c00e8edc5d74cd) gcc: cp ./13/default.nix ./default.nix
* [`2e16ac59`](https://github.com/NixOS/nixpkgs/commit/2e16ac593afc9217c05f8f1099a1cee09a584527) gcc: default.nix: replace ../ with ./
* [`59daa069`](https://github.com/NixOS/nixpkgs/commit/59daa069474fa5025762eafb86f5fa5bd1a89997) gcc: default.nix: parameterize by version
* [`c3bae705`](https://github.com/NixOS/nixpkgs/commit/c3bae705a970726297d3b22f40816c91c5760dfd) gcc: if atLeast 13, use deduplicated version
* [`dc3eb566`](https://github.com/NixOS/nixpkgs/commit/dc3eb566d1314c00e24b66b2997064dbe58fe6cc) gcc: if atLeast 12, use deduplicated version
* [`8a822d6e`](https://github.com/NixOS/nixpkgs/commit/8a822d6e5d94f8c5e7ce0785f463d6068e8b5bc5) gcc: if atLeast 11, use deduplicated version
* [`c72e1360`](https://github.com/NixOS/nixpkgs/commit/c72e136046856c960890e59ed0443e2fde1816e8) gcc: if atLeast 10, use deduplicated version
* [`01902c7b`](https://github.com/NixOS/nixpkgs/commit/01902c7b4574fc5ae446af88764c96137a87eabd) gcc: if atLeast 9, use deduplicated version
* [`942d7ecf`](https://github.com/NixOS/nixpkgs/commit/942d7ecf08d70273056413e2ed41a39cc82b2bc2) gcc: if atLeast 8, use deduplicated version
* [`b3d07e87`](https://github.com/NixOS/nixpkgs/commit/b3d07e87d2cdd29f501b13070065d0cec3f01ebd) gcc: if atLeast 7, use deduplicated version
* [`b505fb47`](https://github.com/NixOS/nixpkgs/commit/b505fb47118d939e00ac5ad26a2164509c6d210f) gcc: if atLeast 6, use deduplicated version
* [`8a4148a5`](https://github.com/NixOS/nixpkgs/commit/8a4148a538e59935a172bed626552d2743d2d45b) gcc: if atLeast 4.9, use deduplicated version
* [`da873870`](https://github.com/NixOS/nixpkgs/commit/da87387073d524816aee9667344dbec5cfb66c6f) gcc: if atLeast 4.8, use deduplicated version
* [`7367bb69`](https://github.com/NixOS/nixpkgs/commit/7367bb691df526292d0cd37bdba25319c4ad982b) gcc: move patches attribute into patches/ subdirectory
* [`02198751`](https://github.com/NixOS/nixpkgs/commit/02198751fa6a44b9c4a74c5d0bbcc0d75918db87) gcc: move version-map out of all-packages.nix, into pkgs/
* [`57e57243`](https://github.com/NixOS/nixpkgs/commit/57e5724306c43715181766233a956d88bd1fa766) gcc: update gccFun for deduplicated gcc expressions
* [`869b6392`](https://github.com/NixOS/nixpkgs/commit/869b6392857a857334d333184cda1f3b1bddab0e) gcc: clean up version conditions
* [`fa0fc88e`](https://github.com/NixOS/nixpkgs/commit/fa0fc88e0c2434cb519bbf1ad637eadd08ab3218) gcc: match weird whack-a-mole per-version hash algorithm
* [`39b20be0`](https://github.com/NixOS/nixpkgs/commit/39b20be0570873b60bdc3520fb5ec2bcdb359062) gcc: resolve merge conflict from staging
* [`bb5ee1fe`](https://github.com/NixOS/nixpkgs/commit/bb5ee1fe60d560cf12a83bb668e8763c777cd920) default-gcc-version: init
* [`671b761d`](https://github.com/NixOS/nixpkgs/commit/671b761d05acb95983437582390a492079c1e0cb) gcc: cp ./13/default.nix ./default.nix
* [`57a2dfe6`](https://github.com/NixOS/nixpkgs/commit/57a2dfe6469cdf6635c28eb6f41db1a013ac99e9) gcc: default.nix: replace ../ with ./
* [`9dc98729`](https://github.com/NixOS/nixpkgs/commit/9dc98729220e051863e3351965c9f81a78cf86a2) gcc: default.nix: parameterize by version
* [`93d63aaa`](https://github.com/NixOS/nixpkgs/commit/93d63aaa0558fde20f3fedc2e0d74b91a2bc0999) gcc: if atLeast 13, use deduplicated version
* [`e9ece66a`](https://github.com/NixOS/nixpkgs/commit/e9ece66a8032e2432a1f240d3bce5c9940a95233) gcc: if atLeast 12, use deduplicated version
* [`72fe0428`](https://github.com/NixOS/nixpkgs/commit/72fe04286e8f4f60a21d384788e59dbe94764434) gcc: if atLeast 11, use deduplicated version
* [`10ee71f5`](https://github.com/NixOS/nixpkgs/commit/10ee71f582c2820737f5586c92f16d64dfe4ad28) gcc: if atLeast 10, use deduplicated version
* [`4116fc3e`](https://github.com/NixOS/nixpkgs/commit/4116fc3e6f72807a1f2cc07f9c2250cf0e3d2c98) gcc: if atLeast 9, use deduplicated version
* [`e7afebbc`](https://github.com/NixOS/nixpkgs/commit/e7afebbc4ca7048a6f96c360fae5065e3e82297c) gcc: if atLeast 8, use deduplicated version
* [`33f7f2c5`](https://github.com/NixOS/nixpkgs/commit/33f7f2c5aa13eb64d1b762dc42d248a30eb0e0e3) gcc: if atLeast 7, use deduplicated version
* [`920df10a`](https://github.com/NixOS/nixpkgs/commit/920df10ab7fced6d1f5a0f3a32870fe0d3761e98) gcc: if atLeast 6, use deduplicated version
* [`beeb48d1`](https://github.com/NixOS/nixpkgs/commit/beeb48d17a18f34f95ef8bec2f8cc31c956b5cd9) gcc: if atLeast 4.9, use deduplicated version
* [`95475034`](https://github.com/NixOS/nixpkgs/commit/95475034d5d510c77086dd0e702d4c8a37e016aa) gcc: if atLeast 4.8, use deduplicated version
* [`911452cc`](https://github.com/NixOS/nixpkgs/commit/911452ccbdea2285872936c5594a66cc5af7d4a5) gcc: move patches attribute into patches/ subdirectory
* [`30171782`](https://github.com/NixOS/nixpkgs/commit/30171782b773f1a7522aff989929660633a03706) gcc: move version-map out of all-packages.nix, into pkgs/
* [`74dce901`](https://github.com/NixOS/nixpkgs/commit/74dce901aae2dd82d6ce69fb85b88ea884795200) gcc: update gccFun for deduplicated gcc expressions
* [`de363654`](https://github.com/NixOS/nixpkgs/commit/de36365466722008d066061ca78b272a3e8da073) gcc: clean up version conditions
* [`8f225b51`](https://github.com/NixOS/nixpkgs/commit/8f225b515fb2e2f30d71c063428189fdf190c6c0) gcc: match weird whack-a-mole per-version hash algorithm
* [`8221d5f4`](https://github.com/NixOS/nixpkgs/commit/8221d5f4e75e5ccf1b5cb98d90cfdea115e2cdfc) gcc: resolve merge conflict from staging
* [`cbc976a9`](https://github.com/NixOS/nixpkgs/commit/cbc976a97c3372e1eec5db021db994b85e098d12) fix: install go.env in go_1_21
* [`f4ef1153`](https://github.com/NixOS/nixpkgs/commit/f4ef1153c6a2f02a468faaf5c3fb5877070f90d5) git-bars: init at 2023-08-08
* [`4e04a0c5`](https://github.com/NixOS/nixpkgs/commit/4e04a0c5d12b2a89a99df4b9d29f9a2787fda819) grantlee: 5.2.0 -> 5.3.1
* [`ba83b25a`](https://github.com/NixOS/nixpkgs/commit/ba83b25a50edbf38a84da60d831115ca2b405876) freetube: 0.18.0 -> 0.19.0
* [`380a34d0`](https://github.com/NixOS/nixpkgs/commit/380a34d03cd7cda2844483fb2d2c382b588aefaa) nim2: init 2.0.0
* [`b9c26088`](https://github.com/NixOS/nixpkgs/commit/b9c260884b61c0e52e94c5b3565041f58e7091d6) buildNimPackage: use nimFlags in checkPhase
* [`0e5fcd67`](https://github.com/NixOS/nixpkgs/commit/0e5fcd671f41ffa1c27dba03144242ea39086eb0) nimPackages.sdl2: 2.0.4 -> 2.0.5
* [`12cf9186`](https://github.com/NixOS/nixpkgs/commit/12cf91863a18d37d27d59698d86d6f5554749c72) nimPackages.nimsimd: 1.0.0 -> 1.2.5
* [`e1d9fa5e`](https://github.com/NixOS/nixpkgs/commit/e1d9fa5ebedf08e4785dc02382e0332725357d71) nimPackages.chroma: 0.2.5 -> 0.2.7
* [`4b332175`](https://github.com/NixOS/nixpkgs/commit/4b3321751b4918f866f2d1b0eafa5e3b75569710) nimPackages.flatty: disable tests
* [`9ae4174b`](https://github.com/NixOS/nixpkgs/commit/9ae4174b9ad6be8cddc7b8e2068b8d283b040b76) nimPackages.astpatternmatching: update
* [`2d369b5f`](https://github.com/NixOS/nixpkgs/commit/2d369b5f108cb8ac52874ec64eeedd3e9e8b61bc) nimPackages.npeg: disable threads
* [`27974e05`](https://github.com/NixOS/nixpkgs/commit/27974e05e215ee08fdf9c67c56a36c5dbe69394c) nimPackages.vmath: use legacy memory-management
* [`13223196`](https://github.com/NixOS/nixpkgs/commit/132231963c98484fa5acc3121f9018e0c9cba0f7) nimPackages.pixie: disable tests
* [`063b8706`](https://github.com/NixOS/nixpkgs/commit/063b8706631cf726102a34d6dbb1c060e7fc5c3b) nimPackages.syndicate: 20230530 -> 20230801
* [`714fb068`](https://github.com/NixOS/nixpkgs/commit/714fb0684e9e65852857420b42f722529d358839) nitter: build with Nim-2
* [`9025a583`](https://github.com/NixOS/nixpkgs/commit/9025a583b1f3e2cf328a02b3f2ac88d187ce047b) nimPackages.hts: 0.3.4 -> 0.3.23, rename from hts-nim
* [`ed353dc7`](https://github.com/NixOS/nixpkgs/commit/ed353dc72116731a20aefeb303f55a0b906c3e0b) mosdepth: build with Nim-2
* [`62dba544`](https://github.com/NixOS/nixpkgs/commit/62dba54481387e524422db58d9e212511fe92dbb) nimPackages.smtp: package broken out of standard library
* [`c9afaec4`](https://github.com/NixOS/nixpkgs/commit/c9afaec459c918145c602f8f92d3e9ee22c1bcfd) nimPackages.db_connector: package broken out of standard library
* [`f81e02d9`](https://github.com/NixOS/nixpkgs/commit/f81e02d9a77194058af95847f22d7db10b555563) qt5.qtbase: implement @⁠OPNA2608 suggestion
* [`b9553044`](https://github.com/NixOS/nixpkgs/commit/b955304456e58c3be8df824d7ad2ffc997411945) gcc: patches: fix patch name
* [`1b0ed9f8`](https://github.com/NixOS/nixpkgs/commit/1b0ed9f81b357f0ac7e383bb26014b441f7edfb1) gcc: patches: fix patch name
* [`130e063a`](https://github.com/NixOS/nixpkgs/commit/130e063a3d7f2728ca65046e7a6164184db1f1f6) pypaInstallHook: enter "dist" directory before installing ([nixos/nixpkgs⁠#250464](https://togithub.com/nixos/nixpkgs/issues/250464))
* [`2d7ce9a2`](https://github.com/NixOS/nixpkgs/commit/2d7ce9a27aeaf9953f4d1e4ec7d9f5a935d8ffed) qtcreator: 11.0.1 -> 11.0.2
* [`0bf9bcd9`](https://github.com/NixOS/nixpkgs/commit/0bf9bcd95eaf7d8b9196f52d68be7e0b3f3bc766) snarkos: 2.1.4 -> 2.1.6
* [`f24e6920`](https://github.com/NixOS/nixpkgs/commit/f24e6920409f24daee6b3a42cb9e2d463e01f594) python310Packages.hyperpyyaml: mark broken
* [`f1724c5d`](https://github.com/NixOS/nixpkgs/commit/f1724c5dc1eefc9afe352491864f654965622316) python310Packages.speechbrain: 0.5.14 -> 0.5.15
* [`9efe01b8`](https://github.com/NixOS/nixpkgs/commit/9efe01b89287526dec27a1d05ec49abca1bd7662) slirp4netns: 1.2.0 -> 1.2.1
* [`1e42f77b`](https://github.com/NixOS/nixpkgs/commit/1e42f77bd5e3e1de8145d946f29232c04c1afa13) heroic: enable Wayland IME support
* [`8bc5ba46`](https://github.com/NixOS/nixpkgs/commit/8bc5ba46ba506afb93901466a0e02c0486665913) wpsoffice: 11.1.0.11698 -> 11.1.0.11704
* [`90a233cf`](https://github.com/NixOS/nixpkgs/commit/90a233cf3a564ef404f1b44ff3c7af838bdd984d) python311Packages.griffe: 0.33.0 -> 0.34.0
* [`e179ccdb`](https://github.com/NixOS/nixpkgs/commit/e179ccdb5555247277863a6ba533d5ea5f114b54) python311Packages.opower: 0.0.29 -> 0.0.31
* [`1415759a`](https://github.com/NixOS/nixpkgs/commit/1415759ada33e32b27a8ddf8bb71d37b21f06120) python311Packages.aioqsw: 0.3.2 -> 0.3.3
* [`bad5c41d`](https://github.com/NixOS/nixpkgs/commit/bad5c41dfd303dfa099c05d952b89fa7b446d100) meshlab: correct the release tag to MeshLab-2022.02
* [`2182bbb5`](https://github.com/NixOS/nixpkgs/commit/2182bbb572e93b141f3b74151b2ad6e4c2da8a59) dprint: 0.40.0 -> 0.40.2
* [`4f2e5c57`](https://github.com/NixOS/nixpkgs/commit/4f2e5c57e19e030141e18a13108354fa4c2d55b9) datadog-agent: unpin go1.18
* [`c2ed44ed`](https://github.com/NixOS/nixpkgs/commit/c2ed44ed0e403b4d814b9d7d1250426b126602fc) fcitx5-anthy: 5.0.14 -> 5.1.0
* [`b96993e6`](https://github.com/NixOS/nixpkgs/commit/b96993e633147d3a73a5584b479b95d8eb61bd2a) fcitx5-chewing: 5.0.14 -> 5.1.0
* [`871cb46f`](https://github.com/NixOS/nixpkgs/commit/871cb46f2eef05086f57c87c5190f3487afaa829) fcitx5-chinese-addons: 5.0.17 -> 5.1.0
* [`2087b8b0`](https://github.com/NixOS/nixpkgs/commit/2087b8b07a70aa23a86492737df3f81f42b2f9ec) fcitx5-configtool: 5.0.17 -> 5.1.0
* [`977df426`](https://github.com/NixOS/nixpkgs/commit/977df4263fdbc1c6da6752c1255950ac22be71a3) fcitx5-gtk: 5.0.23 -> 5.1.0
* [`56a34582`](https://github.com/NixOS/nixpkgs/commit/56a34582a76576347203ff1d5cd6067672c54aa4) fcitx5-hangul: 5.0.11 -> 5.1.0
* [`868cd36a`](https://github.com/NixOS/nixpkgs/commit/868cd36a31dd04759c4a716344b41f70e4324d43) fcitx5-m17n: 5.0.11 -> 5.1.0
* [`f4f3a1c0`](https://github.com/NixOS/nixpkgs/commit/f4f3a1c01ea8a2096dd86693eadd8a10f53b0a76) libsForQt5.fcitx5-qt: 5.0.17 -> 5.1.0
* [`22c0a2a7`](https://github.com/NixOS/nixpkgs/commit/22c0a2a73d8f19bf0bc41e169f097dbaf41d86f6) fcitx5-rime: 5.0.16 -> 5.1.1
* [`34ba8145`](https://github.com/NixOS/nixpkgs/commit/34ba814550fc8f3ec9a8e6db937f8e1a9c7e3b89) fcitx5-skk: 5.0.15 -> 5.1.0
* [`6afe7876`](https://github.com/NixOS/nixpkgs/commit/6afe7876fa1b5fb7f2f2052d5e661597d0cd3c7b) fcitx5-table-extra: 5.0.13 -> 5.1.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
