### PR TITLE
niv devenv: update 49ebb9b0 -> 68ea687e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "49ebb9b0a85949f364bacf0088c4142ed451f59e",
-        "sha256": "1mvjih46kby43158805qxvbhy5xxd10ny9hfcfxgq1fv7kac076j",
+        "rev": "68ea687ed567d578543d89b47281119a3511ac08",
+        "sha256": "1xv25j6k1dq6ch4pns64hvm790nrzm47gywn7fqgb1c5ak4xvydx",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/49ebb9b0a85949f364bacf0088c4142ed451f59e.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/68ea687ed567d578543d89b47281119a3511ac08.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@49ebb9b0...68ea687e](https://github.com/cachix/devenv/compare/49ebb9b0a85949f364bacf0088c4142ed451f59e...68ea687ed567d578543d89b47281119a3511ac08)

* [`9d2d5164`](https://github.com/cachix/devenv/commit/9d2d51646879fae0f6141cfcff474051955b6cf6) Set `$CARGO_INSTALL_ROOT` and `$PATH` used in `cargo install`
* [`bbb8eb22`](https://github.com/cachix/devenv/commit/bbb8eb22e24d79ed70e0bd0bb80f637a11ff6096) Add tests
* [`e6bd0891`](https://github.com/cachix/devenv/commit/e6bd08918e0fdd60c8654353c92f3e17d625e786) Update nixos release and systems helper
* [`f998473b`](https://github.com/cachix/devenv/commit/f998473b033f4e528c1817f71d6c0f4b298ff73b) couchdb: remove logFile, doesn't exist
* [`8df5c7af`](https://github.com/cachix/devenv/commit/8df5c7aff147ca99519a644f8f61dcbac6cf484b) couchdb: fix casing of settings
* [`100f639d`](https://github.com/cachix/devenv/commit/100f639d8fe503cf38e722d3bb5224db5b9aa5db) couchdb: fix missing config files
* [`6b84a85d`](https://github.com/cachix/devenv/commit/6b84a85dd5cde41cbf992b6b2445bf25fe0abb21) Auto generate docs/reference/options.md
* [`df97eafc`](https://github.com/cachix/devenv/commit/df97eafc83dcad00ccbfa010e25708226a0a927f) Reformat rust.nix
