### PR TITLE
niv home-manager: update 958c0630 -> 8bde7a65

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "958c06303f43cf0625694326b7f7e5475b1a2d5c",
-        "sha256": "1xi5vnavngsn39lmxhg52pa8kk3yk0s9w4ki7z30fqimlwa3mq1h",
+        "rev": "8bde7a651b94ba30bd0baaa9c4a08aae88cc2e92",
+        "sha256": "0c2zjrfmpdhv7r2v61p1z34r6j8gkmh6wzara1k5kmm2rak0sdvi",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/958c06303f43cf0625694326b7f7e5475b1a2d5c.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/8bde7a651b94ba30bd0baaa9c4a08aae88cc2e92.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@958c0630...8bde7a65](https://github.com/nix-community/home-manager/compare/958c06303f43cf0625694326b7f7e5475b1a2d5c...8bde7a651b94ba30bd0baaa9c4a08aae88cc2e92)

* [`a0ad9817`](https://github.com/nix-community/home-manager/commit/a0ad98174c7a1f9747a76025a83b50e37181bbde) home-cursor: remove IFD when linking icon directories
* [`ca4126e3`](https://github.com/nix-community/home-manager/commit/ca4126e3c568be23a0981c4d69aed078486c5fce) nixos: only refer to `users.users` if needed
* [`ea59b79f`](https://github.com/nix-community/home-manager/commit/ea59b79f31beaf4a8cb0ea2fc4dfba5732e4212a) bat: generate cache file in XDG cache home
* [`8eb8c212`](https://github.com/nix-community/home-manager/commit/8eb8c212e50e2fd95af5849585a2eb819add0a1e) qcal: add module
* [`6a20e40a`](https://github.com/nix-community/home-manager/commit/6a20e40acaebf067da682661aa67da8b36812606) flake.lock: Update
* [`9706fb8e`](https://github.com/nix-community/home-manager/commit/9706fb8e441a7c56c68bb079480938ed505e8102) flake.lock: Update
* [`f8c5fd75`](https://github.com/nix-community/home-manager/commit/f8c5fd75092448ac134d7fb823556b37d3c821f5) chromium: add support for dictionaries
* [`90e62f96`](https://github.com/nix-community/home-manager/commit/90e62f96c775162580091085831f89b49dba2ee3) programs.yazi: add module ([nix-community/home-manager⁠#4373](https://togithub.com/nix-community/home-manager/issues/4373))
* [`35cbed7a`](https://github.com/nix-community/home-manager/commit/35cbed7ac74035279cecb7c037fe96f7afb3e746) aerc: cleanup unused bindings
* [`0962772e`](https://github.com/nix-community/home-manager/commit/0962772e0bc4631394b694df27331e9a3a5a5028) antidote: cleanup unused bindings
* [`455cc8cf`](https://github.com/nix-community/home-manager/commit/455cc8cf1c768a1d85c30ea102c574cc77663101) offlineimap: cleanup unused bindings
* [`43ec65ad`](https://github.com/nix-community/home-manager/commit/43ec65ad553dab80a8f619e6e3e888002772ce58) Translate using Weblate (Danish)
* [`8bde7a65`](https://github.com/nix-community/home-manager/commit/8bde7a651b94ba30bd0baaa9c4a08aae88cc2e92) ci: bump DeterminateSystems/update-flake-lock from 19 to 20
