### PR TITLE
niv zsh-completions: update 955ac75d -> 67921bc1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "955ac75daf456dc24dc147a82e7df38af3edd8e3",
-        "sha256": "1rfhm18byv4abxhzxgnw4miv0kvmvlhzw2zr7d5n8iz4zdiz76sm",
+        "rev": "67921bc12502c1e7b0f156533fbac2cb51f6943d",
+        "sha256": "164jw74qlrpl6lawa4wjyhn2d04zw36ac0jsg4r6ql8769kfal8q",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/955ac75daf456dc24dc147a82e7df38af3edd8e3.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/67921bc12502c1e7b0f156533fbac2cb51f6943d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@955ac75d...67921bc1](https://github.com/zsh-users/zsh-completions/compare/955ac75daf456dc24dc147a82e7df38af3edd8e3...67921bc12502c1e7b0f156533fbac2cb51f6943d)

* [`7494992b`](https://github.com/zsh-users/zsh-completions/commit/7494992babe35df55cc626e0a0979360676bced7) Refactoring udisksctl completion
* [`5794f18e`](https://github.com/zsh-users/zsh-completions/commit/5794f18e01ea04b89557b4e9796b5e4a24676fe5) Refactor fvm completion
* [`76032402`](https://github.com/zsh-users/zsh-completions/commit/760324021989b3c5fc8e1af4e453af2cae50083f) Update nanoc completion and cleanup its code
* [`796ee337`](https://github.com/zsh-users/zsh-completions/commit/796ee337fac490d2be50e92baf334d71b8abcd14) Accpet multiple env arguments
