### PR TITLE
niv emacs-overlay: update e8d273d9 -> f88e77ec

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e8d273d9f31998c892fd16396b9b6c51566a64b2",
-        "sha256": "1f0ld13dslx5yn63fdj40a7zbaq2hnyy76wzbqyrl4dfkgbkxx5j",
+        "rev": "f88e77ec11c9325e61bf06bb2eeed13f90ff2e42",
+        "sha256": "1wrnwy79r4yrkhf66qfhmq75dv7d44h1aabjw4wzmsbb3bzjnpzn",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/e8d273d9f31998c892fd16396b9b6c51566a64b2.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/f88e77ec11c9325e61bf06bb2eeed13f90ff2e42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@e8d273d9...f88e77ec](https://github.com/nix-community/emacs-overlay/compare/e8d273d9f31998c892fd16396b9b6c51566a64b2...f88e77ec11c9325e61bf06bb2eeed13f90ff2e42)

* [`021a6434`](https://github.com/nix-community/emacs-overlay/commit/021a6434c2dc98ced1ae6d9ee09f6bd70abd5ec8) Updated flake inputs
* [`7258fadc`](https://github.com/nix-community/emacs-overlay/commit/7258fadcf56b3e0d25041b615b8c946538bd2c2a) Updated repos/elpa
* [`1fb626ea`](https://github.com/nix-community/emacs-overlay/commit/1fb626ea36729268ffea467203e416643ae23a76) Updated repos/emacs
* [`20a8571e`](https://github.com/nix-community/emacs-overlay/commit/20a8571ed6deae1ca09fdab67b58b74f1d515e70) Updated repos/melpa
* [`fa97a075`](https://github.com/nix-community/emacs-overlay/commit/fa97a0757899ea3b1415d5f376e2d9a4ab8526f8) Updated repos/nongnu
* [`613eb3bd`](https://github.com/nix-community/emacs-overlay/commit/613eb3bdb2a6579fd13895daf890470190d4bb9b) flake: Set herculesCI attribute
* [`c2f27863`](https://github.com/nix-community/emacs-overlay/commit/c2f278632a1e768540797c7cf08a8ec5f6658396) Updated repos/emacs
* [`427290aa`](https://github.com/nix-community/emacs-overlay/commit/427290aa4ff074cfe31f3abd439bb9d1d24f6fc8) Updated repos/melpa
* [`ae1b93b1`](https://github.com/nix-community/emacs-overlay/commit/ae1b93b12f369bcdbd9020b82c834275cc1189f2) Updated flake inputs
* [`2fe6f1fa`](https://github.com/nix-community/emacs-overlay/commit/2fe6f1faa09356b52aa9ac2386fceb3083d5182e) Updated repos/elpa
* [`f6e88d37`](https://github.com/nix-community/emacs-overlay/commit/f6e88d37f1fd7b378274534bbc51017896adda99) Updated repos/emacs
* [`bf8fea22`](https://github.com/nix-community/emacs-overlay/commit/bf8fea22b4d5a5c59837c11d4675d4aa3a312957) Updated repos/melpa
* [`bbb1c3f2`](https://github.com/nix-community/emacs-overlay/commit/bbb1c3f284928d093fe78e46acf633558a02ebbc) Updated flake inputs
* [`e5f2aff9`](https://github.com/nix-community/emacs-overlay/commit/e5f2aff9f7b83b1a654ed7d73a6b52591a60c98a) Updated repos/elpa
* [`5ff1b929`](https://github.com/nix-community/emacs-overlay/commit/5ff1b929437f83edda31d58f724d7c04beec4b90) Updated repos/emacs
* [`6b676f9e`](https://github.com/nix-community/emacs-overlay/commit/6b676f9e3b025a515b03295058c9af7e90ef2299) Updated repos/melpa
* [`0971dc25`](https://github.com/nix-community/emacs-overlay/commit/0971dc25fd34b0afbd8a91a8e19b1561eaa58078) Updated repos/melpa
* [`79a2ebe2`](https://github.com/nix-community/emacs-overlay/commit/79a2ebe26dd8e1f8e9c322702bdaef215a7e5290) Updated flake inputs
* [`8effa416`](https://github.com/nix-community/emacs-overlay/commit/8effa4160894429f46797a733f046f6774802886) Updated repos/elpa
* [`faa9a5c9`](https://github.com/nix-community/emacs-overlay/commit/faa9a5c9943bfe416447b7b894054662cf91fff3) Updated repos/emacs
* [`29b43ef2`](https://github.com/nix-community/emacs-overlay/commit/29b43ef219428e5941f07099c4a85f8fb795e6ae) Updated repos/melpa
* [`27ccce4a`](https://github.com/nix-community/emacs-overlay/commit/27ccce4a103b9a7b6a5aeea79f814e68f74e3de6) Updated repos/elpa
* [`4714eba2`](https://github.com/nix-community/emacs-overlay/commit/4714eba269eaa9f7c51bdc93bdfa6133b4d4b0be) Updated repos/emacs
* [`65c258c3`](https://github.com/nix-community/emacs-overlay/commit/65c258c3b2b07e1907ee416ed8b6b3fd0ceb59a3) Updated repos/melpa
* [`2d34418e`](https://github.com/nix-community/emacs-overlay/commit/2d34418ee2bec29a321cfde1d26a0760e4e825cd) Updated repos/emacs
* [`b6774efb`](https://github.com/nix-community/emacs-overlay/commit/b6774efb5bfaefa655eb274690e2eaae15dd8f61) Updated repos/melpa
* [`791acfa7`](https://github.com/nix-community/emacs-overlay/commit/791acfa700b9f96c35635fde2a17a66b4ed88c9e) Updated repos/nongnu
* [`045c54f6`](https://github.com/nix-community/emacs-overlay/commit/045c54f6732be12c2197d91580288b17e92126c0) Updated flake inputs
* [`124dbd2d`](https://github.com/nix-community/emacs-overlay/commit/124dbd2d4fab13cdb3d301fdfe825161f295c919) Updated repos/elpa
* [`fa67d937`](https://github.com/nix-community/emacs-overlay/commit/fa67d93761c733b5d3a08c34f97c249730a8ba92) Updated repos/emacs
* [`71248041`](https://github.com/nix-community/emacs-overlay/commit/712480410743739b4739652245a1fae4cf9ec38d) Updated repos/melpa
* [`7c87d368`](https://github.com/nix-community/emacs-overlay/commit/7c87d368d3ece43a3818839016c140461b151714) Updated repos/elpa
* [`78bf041f`](https://github.com/nix-community/emacs-overlay/commit/78bf041f6e8a39fd14e60bc558daffbb21f4bba3) Updated repos/emacs
* [`180dc7cb`](https://github.com/nix-community/emacs-overlay/commit/180dc7cbf6af0cae6ce6c404e9dd5ea3b3790733) Updated repos/melpa
* [`30870d42`](https://github.com/nix-community/emacs-overlay/commit/30870d421125f4dfdc9074084547456e53ded022) Updated repos/emacs
* [`60b5b4a4`](https://github.com/nix-community/emacs-overlay/commit/60b5b4a490b2af46e274b55cdad93d3d004b6445) Updated repos/melpa
* [`4ba15d6f`](https://github.com/nix-community/emacs-overlay/commit/4ba15d6f4310459e6da08dcd4d3df7f4d102bdf0) Updated repos/nongnu
* [`d52a216c`](https://github.com/nix-community/emacs-overlay/commit/d52a216cbba5185e8d3b76b7877bfc8c3f62c018) Updated flake inputs
* [`41a61172`](https://github.com/nix-community/emacs-overlay/commit/41a611728bafc86f6a4ab4cacbe5dfd93fe72dd2) Updated repos/elpa
* [`f19693dd`](https://github.com/nix-community/emacs-overlay/commit/f19693ddaf1fa3b500e2a8a672416f3bd9f43335) Updated repos/emacs
* [`a0928a82`](https://github.com/nix-community/emacs-overlay/commit/a0928a82ae68f4697f39c6e0ffcba763ea02a66b) Updated repos/melpa
* [`677411f8`](https://github.com/nix-community/emacs-overlay/commit/677411f81c538b75de05e517447cc0d50cad2b80) Updated flake inputs
* [`377a1950`](https://github.com/nix-community/emacs-overlay/commit/377a1950ea7cafebe3c00e0254ec35afd952275e) Updated repos/elpa
* [`0f0e9780`](https://github.com/nix-community/emacs-overlay/commit/0f0e97805c949e227df8503df13335fad57f271d) Updated repos/melpa
* [`73706e2c`](https://github.com/nix-community/emacs-overlay/commit/73706e2ca003576596689c09dd78129cffe0f0da) Updated flake inputs
* [`e10103d1`](https://github.com/nix-community/emacs-overlay/commit/e10103d1d5e90f4c20136053ad3d4379fdcc2f33) Updated repos/melpa
* [`0058e1a5`](https://github.com/nix-community/emacs-overlay/commit/0058e1a5d69643ea75d2f9413cc9a88d9b9a6660) Updated repos/elpa
* [`1cbe9a11`](https://github.com/nix-community/emacs-overlay/commit/1cbe9a110139664184fb204ddaf9f5966a7bbbe7) Updated repos/melpa
* [`48fb66cd`](https://github.com/nix-community/emacs-overlay/commit/48fb66cd702f2d2d2174921228ab687905a0b332) Updated repos/elpa
* [`6ebbe7a6`](https://github.com/nix-community/emacs-overlay/commit/6ebbe7a6255b6f15dcd463f5d9d178c0047669c9) Updated repos/emacs
* [`5385985f`](https://github.com/nix-community/emacs-overlay/commit/5385985f2a2bed8c06a0ee5292db6452ff03a6ad) Updated repos/melpa
* [`86cf67a7`](https://github.com/nix-community/emacs-overlay/commit/86cf67a7d42149b824989a3c56eed4982fa32f78) Updated flake inputs
* [`c2a9b15b`](https://github.com/nix-community/emacs-overlay/commit/c2a9b15bfdfc64439c99d9aa2448abf327ee8ec9) Updated repos/emacs
* [`1203b663`](https://github.com/nix-community/emacs-overlay/commit/1203b663961eb0c7b14f7de701eb4435c83c99e6) Updated repos/melpa
* [`4d4fe30a`](https://github.com/nix-community/emacs-overlay/commit/4d4fe30a4cc9adef490fcc6c3bb7aaf08563c6d0) Updated repos/nongnu
* [`01ac4e5b`](https://github.com/nix-community/emacs-overlay/commit/01ac4e5bb60e20e379f63cf985c2852c68b1cba6) Updated flake inputs
* [`c9cfdfab`](https://github.com/nix-community/emacs-overlay/commit/c9cfdfabd0592d7d863c2cc9a060940bf4c9eacd) Updated repos/elpa
* [`2fba9af9`](https://github.com/nix-community/emacs-overlay/commit/2fba9af913627163eefff5cdfdb34000c5570454) Updated repos/emacs
* [`82414fa8`](https://github.com/nix-community/emacs-overlay/commit/82414fa88228ec424cae00a851392d049a7bcf08) Updated repos/melpa
* [`19ca2cfe`](https://github.com/nix-community/emacs-overlay/commit/19ca2cfe4aaf0325477759324064c65a4ee1b18d) Updated flake inputs
* [`d6a258e4`](https://github.com/nix-community/emacs-overlay/commit/d6a258e4c3fa2fb2c2ef1e618374c2060fb74f73) Updated repos/elpa
* [`00dd474a`](https://github.com/nix-community/emacs-overlay/commit/00dd474a31e8bfb7d5a03d7601080cf50d3250c5) Updated repos/emacs
* [`232b747e`](https://github.com/nix-community/emacs-overlay/commit/232b747ee38d4eef266b678b4ce651da8bdd98b3) Updated repos/melpa
* [`80a88432`](https://github.com/nix-community/emacs-overlay/commit/80a88432bf97e3724c5161655e31e74f58744d42) Updated repos/nongnu
* [`7824a7a5`](https://github.com/nix-community/emacs-overlay/commit/7824a7a5da50e3ea5c5931a6844af385059c397e) Updated flake inputs
* [`729bd733`](https://github.com/nix-community/emacs-overlay/commit/729bd73303f90446523bc2893f34aba474d539b2) Updated repos/emacs
* [`bd2e35dd`](https://github.com/nix-community/emacs-overlay/commit/bd2e35dd08cfcba71fe2679b16021207955f3e9a) Updated repos/melpa
* [`47fd5567`](https://github.com/nix-community/emacs-overlay/commit/47fd556725bcc96a831ef13fc1bb0eccbfd4a895) Updated repos/nongnu
* [`5cc25d21`](https://github.com/nix-community/emacs-overlay/commit/5cc25d21aa67fa2b63b4576c5e459e2cf6cf37d3) Updated repos/elpa
* [`f623e40e`](https://github.com/nix-community/emacs-overlay/commit/f623e40eb6e50b5600dcc89b8fc70546d03ba3c1) Updated repos/emacs
* [`b8be6749`](https://github.com/nix-community/emacs-overlay/commit/b8be67490446e0d90f52b6131ee73c516787a015) Updated repos/melpa
* [`cf18b8b2`](https://github.com/nix-community/emacs-overlay/commit/cf18b8b2e89529fa6b72182e5b1605705d88fe96) Updated repos/elpa
* [`547a1c32`](https://github.com/nix-community/emacs-overlay/commit/547a1c32b8cd2852942d10fb480a450998b5c75e) Updated repos/emacs
* [`272e342d`](https://github.com/nix-community/emacs-overlay/commit/272e342d19304b4058b519cfc1b6ed1dd501fb83) Updated repos/melpa
* [`3c5a8694`](https://github.com/nix-community/emacs-overlay/commit/3c5a869494bbd768b832a4567ae93d1c1224571c) Updated repos/nongnu
* [`ad62842d`](https://github.com/nix-community/emacs-overlay/commit/ad62842dc77e9589bf15ba7f155edcecb6b212c4) Updated flake inputs
* [`1abe5dbc`](https://github.com/nix-community/emacs-overlay/commit/1abe5dbc82f50aa9e45a6c8c7147910d74923d30) Updated repos/emacs
* [`3e235f8b`](https://github.com/nix-community/emacs-overlay/commit/3e235f8b8edd2f262dde5e35d80299ad17877904) Updated repos/melpa
* [`8fec2d96`](https://github.com/nix-community/emacs-overlay/commit/8fec2d96e94b620d62ee5dbf52bd757c2c45ec9f) Updated repos/nongnu
* [`f2f9c764`](https://github.com/nix-community/emacs-overlay/commit/f2f9c764ee69c0e1a8675557dd0ed9a6f0854ea0) Updated repos/elpa
* [`2fe48690`](https://github.com/nix-community/emacs-overlay/commit/2fe486906f25d97fd162e6c3d0d65b9f5efb00ff) Updated repos/emacs
* [`18e68ce4`](https://github.com/nix-community/emacs-overlay/commit/18e68ce41210cd4a00653f349285f9097c542fc4) Updated repos/melpa
* [`fe6c925d`](https://github.com/nix-community/emacs-overlay/commit/fe6c925d324b9c3b1491032fe5ec8fcb7a8738c4) Updated repos/elpa
* [`2c179d4f`](https://github.com/nix-community/emacs-overlay/commit/2c179d4fd73df180496f1ed098fafd108cf1aaa4) Updated repos/emacs
* [`c9d9eb07`](https://github.com/nix-community/emacs-overlay/commit/c9d9eb070ff7acebea0fd50b627acc6bffa935ca) Updated repos/melpa
* [`332d0cfc`](https://github.com/nix-community/emacs-overlay/commit/332d0cfcd041400033eb4c440e7d32b94f193bd1) Updated repos/nongnu
* [`f5e773b9`](https://github.com/nix-community/emacs-overlay/commit/f5e773b94fde8fb8bc968dd6ea7dbd4f34767d6c) Updated flake inputs
* [`8294a4dd`](https://github.com/nix-community/emacs-overlay/commit/8294a4dd5749494485acc2059d69e1e607e91d73) Updated repos/emacs
* [`707daad5`](https://github.com/nix-community/emacs-overlay/commit/707daad5fa2bc37a405d4be86dd503876cd9135a) Updated repos/melpa
* [`480bb421`](https://github.com/nix-community/emacs-overlay/commit/480bb4215373504b4eed4352df96b11b255bab76) Updated repos/elpa
* [`7035ddfb`](https://github.com/nix-community/emacs-overlay/commit/7035ddfb6be5ed2113c1f82b5259ed4bd2f3776c) Updated repos/emacs
* [`573d65a4`](https://github.com/nix-community/emacs-overlay/commit/573d65a4ddd835f7b1c0600b2b115aeab4fa18a9) Updated repos/melpa
* [`eefbb3eb`](https://github.com/nix-community/emacs-overlay/commit/eefbb3eb9ae5a60882d247cab6ebcd9a8459ca89) Updated flake inputs
* [`fbbe8644`](https://github.com/nix-community/emacs-overlay/commit/fbbe864447c3050f70bb0679c5d380e477e1e1f9) Updated repos/elpa
* [`f1f8d5a9`](https://github.com/nix-community/emacs-overlay/commit/f1f8d5a96e9594053d022e3daef1db9ca2c22e45) Updated repos/emacs
* [`582d7ae8`](https://github.com/nix-community/emacs-overlay/commit/582d7ae8dbb68ef97de803ef2f40d13fc12d8c83) Updated repos/melpa
* [`892604bf`](https://github.com/nix-community/emacs-overlay/commit/892604bf0d592b7da4847d8f18729974f24596f0) Updated repos/emacs
* [`26414ecb`](https://github.com/nix-community/emacs-overlay/commit/26414ecbfc8280e07447cdc236f733a15f57bebd) Updated repos/melpa
* [`0ac7913c`](https://github.com/nix-community/emacs-overlay/commit/0ac7913c1f81f4b705a268a0bd462729b7c2e7ec) Updated repos/nongnu
* [`0ad793fd`](https://github.com/nix-community/emacs-overlay/commit/0ad793fdb265d03b158fe06679b42334d24cdac3) Updated flake inputs
* [`7975232e`](https://github.com/nix-community/emacs-overlay/commit/7975232eeef327c73b66c9498530941385dabbbc) Updated repos/elpa
* [`c0354f83`](https://github.com/nix-community/emacs-overlay/commit/c0354f83b1ee12c6634c065f05cedc612eb530ab) Updated repos/emacs
* [`0be36058`](https://github.com/nix-community/emacs-overlay/commit/0be36058b192ac18229ec023d7f642555165ed7a) Updated repos/melpa
* [`ee24a9ba`](https://github.com/nix-community/emacs-overlay/commit/ee24a9baa6e24d45639c33cb592146d0036462ac) Updated flake inputs
* [`c2b37676`](https://github.com/nix-community/emacs-overlay/commit/c2b376768b1ec58cd6b28bca3dfbd7998bd7f26a) Updated repos/elpa
* [`01045b21`](https://github.com/nix-community/emacs-overlay/commit/01045b21c08a322789d9aaaf7892c1bdaf38ea66) Updated repos/emacs
* [`f6a34676`](https://github.com/nix-community/emacs-overlay/commit/f6a346762491a4655c3b43da5f2f154b57237a44) Updated repos/melpa
* [`ab287b58`](https://github.com/nix-community/emacs-overlay/commit/ab287b58200d6fb1961ed8ac1eed94dd78a46be9) Updated repos/emacs
* [`c13ae6eb`](https://github.com/nix-community/emacs-overlay/commit/c13ae6eb68176037cc5acb03288262b69f331b03) Updated repos/melpa
* [`8e5b30f6`](https://github.com/nix-community/emacs-overlay/commit/8e5b30f62a106ce4d8bc8667d4b2ef1a44e6ca0c) Updated repos/elpa
* [`c55a17a0`](https://github.com/nix-community/emacs-overlay/commit/c55a17a01a5625e8f5e3f6c43adc3ff70743ca21) Updated repos/emacs
* [`90e7e479`](https://github.com/nix-community/emacs-overlay/commit/90e7e4796d880ee6ad230e791e62a15f539851fd) Updated repos/melpa
* [`a867651b`](https://github.com/nix-community/emacs-overlay/commit/a867651bfb4329f8d823e2c9dbf5a115ffba7d9f) Updated flake inputs
* [`da7815c6`](https://github.com/nix-community/emacs-overlay/commit/da7815c67a40219b3995f2c834df238639f90820) Updated repos/elpa
* [`794e133c`](https://github.com/nix-community/emacs-overlay/commit/794e133c8a2dd8c3e30293e40e0d8b82020d98af) Updated repos/emacs
* [`65b4af30`](https://github.com/nix-community/emacs-overlay/commit/65b4af301be5a4ed08899f5cc183d16ed7c2daa1) Updated repos/melpa
* [`7463e180`](https://github.com/nix-community/emacs-overlay/commit/7463e1809a81bfb563662a620588b3feacc8ec59) Updated repos/emacs
* [`cbd7f152`](https://github.com/nix-community/emacs-overlay/commit/cbd7f1524a5ed88d918944d72e30b1b308107b5f) Updated repos/melpa
* [`ff32272f`](https://github.com/nix-community/emacs-overlay/commit/ff32272f326687e101ffb3e480cec43445eb5000) Updated repos/nongnu
* [`dfb595c8`](https://github.com/nix-community/emacs-overlay/commit/dfb595c892ff9f9a1955a31cbb45dd97ee51e655) Updated repos/elpa
* [`ccb3ac22`](https://github.com/nix-community/emacs-overlay/commit/ccb3ac22ef8928dec991bf4273bd0064acc3374a) Updated repos/emacs
* [`e46cf9e0`](https://github.com/nix-community/emacs-overlay/commit/e46cf9e07a3a6c4f065ace50976bf0f915c02d97) Updated repos/melpa
* [`5e622602`](https://github.com/nix-community/emacs-overlay/commit/5e622602038a97ae8955103e5d44c9dddb81eb1b) Updated repos/elpa
* [`f6250def`](https://github.com/nix-community/emacs-overlay/commit/f6250def7c2d1282535b6a310bd1d8290721a99e) Updated repos/emacs
* [`b311f6d4`](https://github.com/nix-community/emacs-overlay/commit/b311f6d4da9e75d75770f3cce2525eaea9c5ecbc) Updated repos/melpa
* [`07173e89`](https://github.com/nix-community/emacs-overlay/commit/07173e89a668ea643fbb6415440cc5ff566b8ea1) Updated repos/nongnu
* [`440dc53a`](https://github.com/nix-community/emacs-overlay/commit/440dc53a517ebffce82c551d4b6740d02e1c4e12) Updated repos/emacs
* [`9279ce71`](https://github.com/nix-community/emacs-overlay/commit/9279ce7180483c5ec9e6da74b87000a49a4942c0) Updated repos/melpa
* [`e9a73ce4`](https://github.com/nix-community/emacs-overlay/commit/e9a73ce4aaa5192d242342bc2f974434ea25e957) Updated flake inputs
* [`4ac9e3fa`](https://github.com/nix-community/emacs-overlay/commit/4ac9e3fa0db0e3e3595d4e11573431ef24e82e84) Updated repos/elpa
* [`5cf81db8`](https://github.com/nix-community/emacs-overlay/commit/5cf81db89a78ae2d35d7adc306b6062e7e837fde) Updated repos/emacs
* [`def0e546`](https://github.com/nix-community/emacs-overlay/commit/def0e546482c60a2cb17a282e39466b0daa02e54) Updated repos/melpa
* [`b95d1097`](https://github.com/nix-community/emacs-overlay/commit/b95d109790f4f9214a5ffbbfb528043dffc26f88) Updated flake inputs
* [`aab422e8`](https://github.com/nix-community/emacs-overlay/commit/aab422e8a7806336add8b7b7e7f4552780427a45) Updated repos/elpa
* [`418701a2`](https://github.com/nix-community/emacs-overlay/commit/418701a2fae2964d667c6ab96a465d1e3116ffa0) Updated repos/emacs
* [`ee309584`](https://github.com/nix-community/emacs-overlay/commit/ee309584c89d9603338c77cfa931944fbafac6b4) Updated repos/melpa
* [`373706f3`](https://github.com/nix-community/emacs-overlay/commit/373706f3c552c9cae784b0ad28f70daf5753e69f) Updated flake inputs
* [`578f0332`](https://github.com/nix-community/emacs-overlay/commit/578f0332ec68db82f441b6112561070c0c836d7b) Updated repos/emacs
* [`aae3c605`](https://github.com/nix-community/emacs-overlay/commit/aae3c60518d98de6780f08cd99ed84016474089f) Updated repos/melpa
* [`c888ee96`](https://github.com/nix-community/emacs-overlay/commit/c888ee96354322919f12ad8771ac4eddf0d50d11) Updated repos/elpa
* [`7caa1491`](https://github.com/nix-community/emacs-overlay/commit/7caa1491ddf4422185709cd2501d0bfdd21758d2) Updated repos/emacs
* [`7a4b5bbc`](https://github.com/nix-community/emacs-overlay/commit/7a4b5bbc06182e2f704630cd77a614ab0d9c2f2e) Updated repos/melpa
* [`46af608d`](https://github.com/nix-community/emacs-overlay/commit/46af608d0a06238e97221969eff4ad4e42ed5c99) Updated flake inputs
* [`e7963040`](https://github.com/nix-community/emacs-overlay/commit/e79630407bb906f27ca80a3875d271e08ed347d0) Updated repos/elpa
* [`ddc08d21`](https://github.com/nix-community/emacs-overlay/commit/ddc08d21a8cc2daf8837a83b98c8944a22f3e319) Updated repos/emacs
* [`cd7b1c80`](https://github.com/nix-community/emacs-overlay/commit/cd7b1c80be8ebec768f610b4fa2cb14dee342f1c) Updated repos/melpa
* [`a86f50ba`](https://github.com/nix-community/emacs-overlay/commit/a86f50bad1a801e8e5a179244a5c0c63d2ae6ec8) Updated repos/nongnu
* [`fa3b5f73`](https://github.com/nix-community/emacs-overlay/commit/fa3b5f732f136689349911fe5480722eb76a1770) Updated repos/emacs
* [`8fd061df`](https://github.com/nix-community/emacs-overlay/commit/8fd061dfb95bfc1823f9ac6718680b59b4f22895) Updated repos/melpa
* [`4c2006bf`](https://github.com/nix-community/emacs-overlay/commit/4c2006bf7ed2d62d14d7ebc0d8a1a728bd281bcc) Updated flake inputs
* [`937799af`](https://github.com/nix-community/emacs-overlay/commit/937799af65bd725807dc5172829807900605c9ca) Updated repos/elpa
* [`7c9dd63b`](https://github.com/nix-community/emacs-overlay/commit/7c9dd63bc22eb3f841ac3ecab9d2ab0113adce0b) Updated repos/emacs
* [`ff4dba89`](https://github.com/nix-community/emacs-overlay/commit/ff4dba8979ddc3bfa40867d4f256cc7f0e635d75) Updated repos/melpa
* [`f95e0b71`](https://github.com/nix-community/emacs-overlay/commit/f95e0b71c99a880ebc9c554831a5168303b0c982) Updated flake inputs
* [`e61eeb13`](https://github.com/nix-community/emacs-overlay/commit/e61eeb13d412468366e85c542c988a4b9bc7d5aa) Updated repos/elpa
* [`11388785`](https://github.com/nix-community/emacs-overlay/commit/113887853934077a2c7379315f3ac56f014a6c69) Updated repos/emacs
* [`c46f414d`](https://github.com/nix-community/emacs-overlay/commit/c46f414d642a1bbadb9d1f783ec895374cf9997a) Updated repos/melpa
* [`314ea6e0`](https://github.com/nix-community/emacs-overlay/commit/314ea6e0c500c52886d7d375229716e34995e643) Updated flake inputs
* [`5a919b71`](https://github.com/nix-community/emacs-overlay/commit/5a919b715801423ee4d0ea16d5f61fb059f36f42) Updated repos/emacs
* [`70a19b59`](https://github.com/nix-community/emacs-overlay/commit/70a19b59cc994aa5f5abe1da9eb920ca483c32fb) Updated repos/melpa
* [`50bd6119`](https://github.com/nix-community/emacs-overlay/commit/50bd61195c8f9ddbaa862a2fcf4f40f82769a5ba) Updated repos/nongnu
* [`c91ccadc`](https://github.com/nix-community/emacs-overlay/commit/c91ccadc2acf61f0d8277b532a83b3d4f9c4e3ca) Updated repos/elpa
* [`362c72b8`](https://github.com/nix-community/emacs-overlay/commit/362c72b86b625b141f3a763e6e9aab6e3290c7e1) Updated repos/emacs
* [`37514671`](https://github.com/nix-community/emacs-overlay/commit/3751467118141bafb77a277a6f2626332ab33154) Updated repos/melpa
* [`1cfe12c0`](https://github.com/nix-community/emacs-overlay/commit/1cfe12c02506a1a03697244c4ba1fa910bf1286e) Updated flake inputs
* [`3406ae23`](https://github.com/nix-community/emacs-overlay/commit/3406ae23eaeae6de11131f9f3e9e710320f886eb) Updated repos/elpa
* [`ddb0bcdc`](https://github.com/nix-community/emacs-overlay/commit/ddb0bcdc29fc51dca95ebb25001a079edff5e3f4) Updated repos/emacs
* [`6d79e2ce`](https://github.com/nix-community/emacs-overlay/commit/6d79e2ce84fc36425e4ce8ebb46585707848748d) Updated repos/melpa
* [`818d2d92`](https://github.com/nix-community/emacs-overlay/commit/818d2d92a321c58e8dd60e25e5aa3a6fcc861869) Updated repos/emacs
* [`6ec2e6f0`](https://github.com/nix-community/emacs-overlay/commit/6ec2e6f01d41269eaa541b99d3612dae36b6e711) Updated repos/melpa
* [`6fb25eb0`](https://github.com/nix-community/emacs-overlay/commit/6fb25eb0280b719bd42b139e827c2deaa73726f7) Updated flake inputs
* [`aea5646a`](https://github.com/nix-community/emacs-overlay/commit/aea5646af89a91328207a68bc9e1786be41ca9bc) Updated repos/elpa
* [`75a00122`](https://github.com/nix-community/emacs-overlay/commit/75a001220097148491348844c219e7addaa857e6) Updated repos/emacs
* [`5f96a733`](https://github.com/nix-community/emacs-overlay/commit/5f96a733098d90912cba5329bf2cc75849000c09) Updated repos/melpa
* [`02537af0`](https://github.com/nix-community/emacs-overlay/commit/02537af062e360bf2ebbfe156f4c65dadee5e9e1) Updated repos/elpa
* [`d5defcfc`](https://github.com/nix-community/emacs-overlay/commit/d5defcfcd38fee261926ddc3e3eb9e69ecdf5df0) Updated repos/emacs
* [`f92eaef4`](https://github.com/nix-community/emacs-overlay/commit/f92eaef404ab814e458a9e56f08b0508e0ef73ad) Updated repos/melpa
* [`be3d29b7`](https://github.com/nix-community/emacs-overlay/commit/be3d29b73101cf618b2a078df2e75f2200daf103) Updated repos/emacs
* [`886a3eaf`](https://github.com/nix-community/emacs-overlay/commit/886a3eaf0ba319c69c4b2326a250e1e1b55ea20c) Updated repos/melpa
* [`d9bbf2be`](https://github.com/nix-community/emacs-overlay/commit/d9bbf2beb40509ce619314e07a19b3dbe3e72899) Updated repos/nongnu
* [`e95a03cb`](https://github.com/nix-community/emacs-overlay/commit/e95a03cba8fde349f53f73f40a471932cb22e835) Updated flake inputs
* [`0942dab5`](https://github.com/nix-community/emacs-overlay/commit/0942dab572ea68e563369610633a054375a0987a) Updated repos/elpa
* [`9e95aa5e`](https://github.com/nix-community/emacs-overlay/commit/9e95aa5eba12ebde91850726aa90305aeac5219b) Updated repos/emacs
* [`07500c25`](https://github.com/nix-community/emacs-overlay/commit/07500c2529eb8af81b1b26d82e3c3704520d8ffd) Updated repos/melpa
* [`2a71fbec`](https://github.com/nix-community/emacs-overlay/commit/2a71fbecb20078a1413b094c48d59af282177623) Updated flake inputs
* [`915496a6`](https://github.com/nix-community/emacs-overlay/commit/915496a63319b872114dd421bad3fd35fe3e038b) Updated repos/elpa
* [`b0fd9132`](https://github.com/nix-community/emacs-overlay/commit/b0fd913206441b66a0bd98e4a04bad6cf6ff2e2d) Updated repos/emacs
* [`d5f2211b`](https://github.com/nix-community/emacs-overlay/commit/d5f2211b47ec2afa0050e705c571d421b8920b38) Updated repos/melpa
* [`d899f2d3`](https://github.com/nix-community/emacs-overlay/commit/d899f2d3ad2d3587e6f9122298746f715db1c072) Updated repos/nongnu
* [`db87f9f4`](https://github.com/nix-community/emacs-overlay/commit/db87f9f4967e6844689736d911e76443f8744e01) Updated repos/emacs
* [`8cd99f6d`](https://github.com/nix-community/emacs-overlay/commit/8cd99f6d89361b9d1005924897214ac2a125fa34) Updated repos/melpa
* [`5df91433`](https://github.com/nix-community/emacs-overlay/commit/5df91433bba7fecf9394c2e07f3f53b357c4f63a) Updated repos/nongnu
* [`c29d54c7`](https://github.com/nix-community/emacs-overlay/commit/c29d54c73631f78073871810dd66ac18bb860916) Updated flake inputs
* [`37e6e917`](https://github.com/nix-community/emacs-overlay/commit/37e6e9176d24752bd570822307eaba4e67e24bb8) Updated repos/elpa
* [`6549d1cd`](https://github.com/nix-community/emacs-overlay/commit/6549d1cdd858b15b6462fb06ccccb3f69f187dc8) Updated repos/emacs
* [`d133599c`](https://github.com/nix-community/emacs-overlay/commit/d133599cc484fdb2ac6c96fafe20f73bcfb42a81) Updated repos/melpa
* [`86aec142`](https://github.com/nix-community/emacs-overlay/commit/86aec14224626b94086f5b7bcd6913714b9431d4) Updated flake inputs
* [`ddaa645c`](https://github.com/nix-community/emacs-overlay/commit/ddaa645c7b83a4eec50e5066e863650db8c4269a) Updated repos/elpa
* [`e9887d6f`](https://github.com/nix-community/emacs-overlay/commit/e9887d6f16491c2ffa6c571d47a59eaee3a6bd6d) Updated repos/emacs
* [`7ff51b6e`](https://github.com/nix-community/emacs-overlay/commit/7ff51b6e33c3fd5895c1f46eabb2bfdfa43e1050) Updated repos/melpa
* [`16cb5f6c`](https://github.com/nix-community/emacs-overlay/commit/16cb5f6ce021d40aa8d531b9908a1a60254fdfa7) Updated repos/emacs
* [`fcc338ec`](https://github.com/nix-community/emacs-overlay/commit/fcc338ec334ec93adb816d5ebaeef6f34093f2b8) Updated repos/melpa
* [`45a20b7f`](https://github.com/nix-community/emacs-overlay/commit/45a20b7f3888b8e2b71f95b0b5705833aa0296aa) Updated repos/elpa
* [`5b261137`](https://github.com/nix-community/emacs-overlay/commit/5b26113704e83faa837e3cd0f9b38cde438bbebe) Updated repos/emacs
* [`9a738849`](https://github.com/nix-community/emacs-overlay/commit/9a7388497abed4a4c0fffd938fab35f1168ce8c9) Updated repos/melpa
* [`b5dca466`](https://github.com/nix-community/emacs-overlay/commit/b5dca466e700917bb9bfb0810c58dcbc468163bf) Updated repos/elpa
* [`af79d725`](https://github.com/nix-community/emacs-overlay/commit/af79d725a93dedfb833c0f29808afeb6ea93e4ea) Updated repos/emacs
* [`33a166b2`](https://github.com/nix-community/emacs-overlay/commit/33a166b214c841d6fa5874ccc925871b2394a7e3) Updated repos/melpa
* [`57d10a23`](https://github.com/nix-community/emacs-overlay/commit/57d10a230d77beb1d57df73d2257a63233de8956) Updated repos/emacs
* [`027e735d`](https://github.com/nix-community/emacs-overlay/commit/027e735d9a612a31b9adf54b9341086dadbeb7e7) Updated repos/melpa
* [`0642592d`](https://github.com/nix-community/emacs-overlay/commit/0642592d60f705e0e27fcd96e26f965df4e573e0) Updated flake inputs
* [`ba1b47e3`](https://github.com/nix-community/emacs-overlay/commit/ba1b47e3d19612e632e0973e3edaee93d12f9f09) Updated repos/elpa
* [`1facd6f1`](https://github.com/nix-community/emacs-overlay/commit/1facd6f1687e3699ac3cbf982508d94e237739c3) Updated repos/emacs
* [`519c98ce`](https://github.com/nix-community/emacs-overlay/commit/519c98cef1aa5901568266146d085d230d92952f) Updated repos/melpa
* [`d0690f82`](https://github.com/nix-community/emacs-overlay/commit/d0690f82d86a51ce68534f7847d259d701d63d2e) Updated repos/elpa
* [`ce383ac9`](https://github.com/nix-community/emacs-overlay/commit/ce383ac90c14bac6a60e6de844f57386ae22a390) Updated repos/emacs
* [`9b3881d1`](https://github.com/nix-community/emacs-overlay/commit/9b3881d181a32137f97514cbf43cc51bafcef283) Updated repos/melpa
* [`9a622ba9`](https://github.com/nix-community/emacs-overlay/commit/9a622ba9efa7b6680a41d1ca1129cebe5602d6dd) Updated repos/emacs
* [`e4959460`](https://github.com/nix-community/emacs-overlay/commit/e4959460ea8e7d122baab8fd967bc604df928bec) Updated repos/melpa
* [`d75d6345`](https://github.com/nix-community/emacs-overlay/commit/d75d6345f5256b6cdb42e3c7a3b116980db769a5) Updated flake inputs
* [`63059600`](https://github.com/nix-community/emacs-overlay/commit/63059600f244d80c0a196e002314898a2549c634) Updated repos/elpa
* [`c1c7cd68`](https://github.com/nix-community/emacs-overlay/commit/c1c7cd68cd957e2f86446364155dfa834970b1f2) Updated repos/emacs
* [`f4b61f88`](https://github.com/nix-community/emacs-overlay/commit/f4b61f881ac07096f8e3b61a80e4062bca104e2a) Updated repos/melpa
* [`455454d3`](https://github.com/nix-community/emacs-overlay/commit/455454d3ae8350a8e969bae71d2d8200674d5bfd) Updated flake inputs
* [`282a39f3`](https://github.com/nix-community/emacs-overlay/commit/282a39f33026b0a7a58b040ce69c439c9b3d2602) Updated repos/elpa
* [`31522ea2`](https://github.com/nix-community/emacs-overlay/commit/31522ea208a7a4f8bdeb97b3e45befd962c22d52) Updated repos/emacs
* [`c82b1bb8`](https://github.com/nix-community/emacs-overlay/commit/c82b1bb82f4935d7b6d85d5ed8fe7cbade780c72) Updated repos/melpa
* [`deff1dd2`](https://github.com/nix-community/emacs-overlay/commit/deff1dd2f8ac8709413097ca17d02546ef0c7c0c) Updated repos/emacs
* [`eefb0f73`](https://github.com/nix-community/emacs-overlay/commit/eefb0f73a36674a145a2049654b958549408e5a7) Updated repos/melpa
* [`05a15119`](https://github.com/nix-community/emacs-overlay/commit/05a1511966eeb5218d55f921146abff21aad1684) Updated repos/nongnu
* [`c2b22168`](https://github.com/nix-community/emacs-overlay/commit/c2b22168439f3416dc0af6e34d90ac559fd8671e) Updated flake inputs
* [`8e2d4169`](https://github.com/nix-community/emacs-overlay/commit/8e2d4169af63f9ba2ecb3ea1bded1e2cca9c1d41) Updated repos/elpa
* [`206f7382`](https://github.com/nix-community/emacs-overlay/commit/206f738286d6a6de92d50c6f4558b96596ae3712) Updated repos/emacs
* [`a72132a5`](https://github.com/nix-community/emacs-overlay/commit/a72132a55c96f2f97e076f041dbfb158c2e937a6) Updated repos/melpa
* [`48c23895`](https://github.com/nix-community/emacs-overlay/commit/48c238951118c836eeb34ebf9d33dbb68df80a63) Updated flake inputs
* [`7e873877`](https://github.com/nix-community/emacs-overlay/commit/7e873877291f82909048021c6e7bb8877d6d775d) Updated repos/elpa
* [`89a902eb`](https://github.com/nix-community/emacs-overlay/commit/89a902eb586fc601688af59d9d27cf0b6d8ebc94) Updated repos/emacs
* [`4d3f7851`](https://github.com/nix-community/emacs-overlay/commit/4d3f7851b9524c2de0bd3631108471ddad8b0d10) Updated repos/melpa
* [`47a74774`](https://github.com/nix-community/emacs-overlay/commit/47a747748b3a978425ad7eeec008ef7308e7a92a) Updated repos/nongnu
* [`70621186`](https://github.com/nix-community/emacs-overlay/commit/7062118613938e63466438e8079ae54835d5dd8f) Updated repos/emacs
* [`a4ba3330`](https://github.com/nix-community/emacs-overlay/commit/a4ba33301f3652eb28ed13fd635c4cf7127867c6) Updated repos/melpa
* [`9ef499ed`](https://github.com/nix-community/emacs-overlay/commit/9ef499ed35baf1e70f2a530462e9aeb505ad3da4) Updated repos/nongnu
* [`685873c1`](https://github.com/nix-community/emacs-overlay/commit/685873c16190c520a4550bd98c2773cbc0f09f54) Updated flake inputs
* [`fc653f96`](https://github.com/nix-community/emacs-overlay/commit/fc653f96dd8bee1ed21fade86b185d60a6c3bc6c) Updated repos/elpa
* [`7c78afad`](https://github.com/nix-community/emacs-overlay/commit/7c78afad4565bcb49b3c848c6f1fb28f0cb361d7) Updated repos/melpa
* [`8c523d66`](https://github.com/nix-community/emacs-overlay/commit/8c523d6633a6d696655197a08d420dc2ff5d06fe) Updated repos/elpa
* [`7064099c`](https://github.com/nix-community/emacs-overlay/commit/7064099ccd5fe73aba02e962367bd47fc777a6d9) Updated repos/emacs
* [`6ca342ac`](https://github.com/nix-community/emacs-overlay/commit/6ca342ac670b56ad15124314d71852276e892062) Updated repos/melpa
* [`f5fa17dd`](https://github.com/nix-community/emacs-overlay/commit/f5fa17dd97c62ca3a478582e6e3846bdbe5353f2) Updated repos/emacs
* [`5ba64c3a`](https://github.com/nix-community/emacs-overlay/commit/5ba64c3a5cd7a11804e7d6cb59c742e6d66858a6) Updated repos/melpa
* [`81465f07`](https://github.com/nix-community/emacs-overlay/commit/81465f07ee68381dc370f9da1a882d581c335338) Updated repos/nongnu
* [`82240e9e`](https://github.com/nix-community/emacs-overlay/commit/82240e9eb0dc141ceb70693f1227b6959b5529e7) Updated repos/elpa
* [`d971be9e`](https://github.com/nix-community/emacs-overlay/commit/d971be9ece9aec7d3c5b8327826d1652a3f92bfc) Updated repos/emacs
* [`8e45f9ec`](https://github.com/nix-community/emacs-overlay/commit/8e45f9ecfa29bf2b1374a14160644385610b5276) Updated repos/melpa
* [`dc92de52`](https://github.com/nix-community/emacs-overlay/commit/dc92de52c734355e11dbd579633b3f3a8de4f5bc) Updated flake inputs
* [`a6815d96`](https://github.com/nix-community/emacs-overlay/commit/a6815d961eb7591e15853fb20785fb5478ba64f2) Updated repos/elpa
* [`96a046d9`](https://github.com/nix-community/emacs-overlay/commit/96a046d92fe31c75168e2e29389dbe5f73581319) Updated repos/emacs
* [`9a146838`](https://github.com/nix-community/emacs-overlay/commit/9a14683828917fe3f6f278eabe4782cf3b1970e1) Updated repos/melpa
* [`c7945db5`](https://github.com/nix-community/emacs-overlay/commit/c7945db5a0e0e9699b2284970cf5a01d6fd0cdf1) Updated flake inputs
* [`27745f15`](https://github.com/nix-community/emacs-overlay/commit/27745f1541a12350bd5875dfadfe821b405b85a1) Updated repos/emacs
* [`7792d7ed`](https://github.com/nix-community/emacs-overlay/commit/7792d7ed901e9535ea9683764a6e991573b3a184) Updated repos/melpa
* [`300460e8`](https://github.com/nix-community/emacs-overlay/commit/300460e827e39285f98a1c105bdc6601ded8ccf8) Updated repos/nongnu
* [`89eaefa7`](https://github.com/nix-community/emacs-overlay/commit/89eaefa707ffefe658797348bb0cff90ad655d84) Updated flake inputs
* [`345e2621`](https://github.com/nix-community/emacs-overlay/commit/345e2621e1cea385d545bc0697a0341ce26deab1) Updated repos/elpa
* [`707b73f1`](https://github.com/nix-community/emacs-overlay/commit/707b73f19bef0e17e607778cd3749e9d4a5e7007) Updated repos/emacs
* [`40b61b86`](https://github.com/nix-community/emacs-overlay/commit/40b61b865a1fcd7d470456e594fe08ded7dbbe55) Updated repos/melpa
* [`86d5bb75`](https://github.com/nix-community/emacs-overlay/commit/86d5bb75f9e60b85c4b627948f4f5a5236905f28) Updated repos/nongnu
* [`43015739`](https://github.com/nix-community/emacs-overlay/commit/430157395e34c8d7df9fd576e49345aca4aec635) Updated repos/elpa
* [`f075bfef`](https://github.com/nix-community/emacs-overlay/commit/f075bfefa5c09bce7f519e2608c38cd67c484a9d) Updated repos/emacs
* [`123ac69d`](https://github.com/nix-community/emacs-overlay/commit/123ac69d1d430562dd1a266a2f50296eaac7d65d) Updated repos/melpa
* [`9261beea`](https://github.com/nix-community/emacs-overlay/commit/9261beea9f0073ef82353216679a2b3414fe93c6) Updated repos/emacs
* [`7bc0bbb1`](https://github.com/nix-community/emacs-overlay/commit/7bc0bbb1d4ff82629707a79bc4070372889c4b1b) Updated repos/melpa
* [`411bc3de`](https://github.com/nix-community/emacs-overlay/commit/411bc3de01ab32cdd6a7e1ff9fdebc8ea9741cfb) Updated flake inputs
* [`f47d41f2`](https://github.com/nix-community/emacs-overlay/commit/f47d41f2a4690a29c2d21fba89f07d0251daa3da) Updated repos/elpa
* [`5fc3461e`](https://github.com/nix-community/emacs-overlay/commit/5fc3461e99f1e98eb94cc557ecdca3521cee2010) Updated repos/emacs
* [`86dd13ec`](https://github.com/nix-community/emacs-overlay/commit/86dd13ecf891934a28707d982aa490e701e72fc2) Updated repos/melpa
* [`e281a007`](https://github.com/nix-community/emacs-overlay/commit/e281a007be5be8d34ecdf8d04854885d1efe98d1) Updated flake inputs
* [`83584628`](https://github.com/nix-community/emacs-overlay/commit/835846287dc6243245f2adfa0d1c6874bc920761) Updated repos/elpa
* [`82e36542`](https://github.com/nix-community/emacs-overlay/commit/82e36542ec58b2f274cd3565165764ad8251a298) Updated repos/emacs
* [`69e073c0`](https://github.com/nix-community/emacs-overlay/commit/69e073c0f5065828632ca0b7446acc242e1123e3) Updated repos/melpa
* [`78ec4983`](https://github.com/nix-community/emacs-overlay/commit/78ec4983ba820b37fc2e7c998ead39be6bec7f6d) Updated repos/nongnu
* [`bf25f35e`](https://github.com/nix-community/emacs-overlay/commit/bf25f35e7266b21ba6db1865080a05463ad87ffd) Updated repos/emacs
* [`7c239d6e`](https://github.com/nix-community/emacs-overlay/commit/7c239d6ec798caba895588ee98e42d6a3df318e0) Updated repos/melpa
* [`ae330a78`](https://github.com/nix-community/emacs-overlay/commit/ae330a787488e1cef773c8fdc8f7b5eda3c4683b) Updated flake inputs
* [`f9dd2465`](https://github.com/nix-community/emacs-overlay/commit/f9dd2465af09d592cb5669dad1cd2e613c0485ea) Updated repos/elpa
* [`d92436b3`](https://github.com/nix-community/emacs-overlay/commit/d92436b3acb5e4c78497c47e388cf2644269ea13) Updated repos/emacs
* [`8f28153c`](https://github.com/nix-community/emacs-overlay/commit/8f28153cad22536fa6d5929bc87e9fafb3c11c68) Updated repos/melpa
* [`f16ba939`](https://github.com/nix-community/emacs-overlay/commit/f16ba939fdda877edbe0bcb3d0e594b546a2c829) Updated repos/elpa
* [`c94cfe46`](https://github.com/nix-community/emacs-overlay/commit/c94cfe46a40e449ca0eb8b917e4e99a6cd29095d) Updated repos/emacs
* [`1f2b5c46`](https://github.com/nix-community/emacs-overlay/commit/1f2b5c46f23ef9c9ae1de301e0cb6a2022c11913) Updated repos/melpa
* [`2a762092`](https://github.com/nix-community/emacs-overlay/commit/2a762092db6b66e7e0fb32f380d6260a00b14ff9) Updated repos/nongnu
* [`9e1f0784`](https://github.com/nix-community/emacs-overlay/commit/9e1f078407e6142aa4a305111c88544ff37f4346) Updated repos/emacs
* [`76e16043`](https://github.com/nix-community/emacs-overlay/commit/76e1604362f675c6b9ee37bd9feca2b87730a987) Updated repos/melpa
* [`4c037b20`](https://github.com/nix-community/emacs-overlay/commit/4c037b20c4e25e0f02a8ed3fb22a1d2651eff6b6) Updated repos/elpa
* [`07f973fa`](https://github.com/nix-community/emacs-overlay/commit/07f973fa320bca955c594b1e7b01cca58cd6d587) Updated repos/emacs
* [`18db5f94`](https://github.com/nix-community/emacs-overlay/commit/18db5f949c4a8d2c8a04e446092414fcd65e6bcd) Updated repos/melpa
* [`475accbc`](https://github.com/nix-community/emacs-overlay/commit/475accbc73dd220d4d575b3723d1d74d10a63b4d) Updated flake inputs
* [`0c5f0637`](https://github.com/nix-community/emacs-overlay/commit/0c5f0637c05833da636a5bb3d65dcaa2914e0d6b) Updated repos/elpa
* [`dec98e66`](https://github.com/nix-community/emacs-overlay/commit/dec98e663c16a50ba8be243e64f5305971cd970c) Updated repos/emacs
* [`f6c7aac8`](https://github.com/nix-community/emacs-overlay/commit/f6c7aac869b4972803fbdbfe7c903d37155104e6) Updated repos/melpa
* [`12332e7a`](https://github.com/nix-community/emacs-overlay/commit/12332e7a2a2f3899dcca76c752464ca87215dd53) Updated repos/nongnu
* [`67bdae2a`](https://github.com/nix-community/emacs-overlay/commit/67bdae2a814726e8f30b6acf90c429e7b6a2b166) Updated repos/emacs
* [`e39c3883`](https://github.com/nix-community/emacs-overlay/commit/e39c38830e3e31c1c975710bddf90da2a5a35acb) Updated repos/melpa
* [`870175f4`](https://github.com/nix-community/emacs-overlay/commit/870175f464ae939ccce11b7aaf2946953a7752f0) Updated flake inputs
* [`b5d6cc66`](https://github.com/nix-community/emacs-overlay/commit/b5d6cc66818395e88b09f8d409ed59a38836534d) Updated repos/elpa
* [`7e29cd54`](https://github.com/nix-community/emacs-overlay/commit/7e29cd544496761fb22ae3a0e0c10b8ac70b80d2) Updated repos/emacs
* [`c98175e1`](https://github.com/nix-community/emacs-overlay/commit/c98175e11975e29300e082bba2f63e12fd804127) Updated repos/melpa
* [`7b26a48e`](https://github.com/nix-community/emacs-overlay/commit/7b26a48eceda3bee6b3ec62b789f8d269eb42ddc) Updated repos/elpa
* [`b80c45ff`](https://github.com/nix-community/emacs-overlay/commit/b80c45ffae2b32fb976abf76b7d7d723790126f2) Updated repos/emacs
* [`7a565988`](https://github.com/nix-community/emacs-overlay/commit/7a565988476b5e20224425f9b3a322e97b1c3d28) Updated repos/melpa
* [`6bc1f87f`](https://github.com/nix-community/emacs-overlay/commit/6bc1f87faed1388fe83c295bc944bf7dfaafa8df) Updated repos/nongnu
* [`aeceeab4`](https://github.com/nix-community/emacs-overlay/commit/aeceeab4dc6c3e7f196e73979f1ebe758be0e296) Updated repos/emacs
* [`ddde5514`](https://github.com/nix-community/emacs-overlay/commit/ddde5514d990a472dcc6b96c835a6beb5c4a2549) Updated repos/melpa
* [`47c99763`](https://github.com/nix-community/emacs-overlay/commit/47c9976307a563c6c80250669e47c4b10a4801aa) Updated repos/nongnu
* [`bd47f2c5`](https://github.com/nix-community/emacs-overlay/commit/bd47f2c5d8a26ab4fa5854e81b4741466768236b) Updated repos/elpa
* [`2731b08f`](https://github.com/nix-community/emacs-overlay/commit/2731b08f4fd6e0ee026dbcdcf192a0f3c46cb230) Updated repos/emacs
* [`f88e77ec`](https://github.com/nix-community/emacs-overlay/commit/f88e77ec11c9325e61bf06bb2eeed13f90ff2e42) Updated repos/melpa
