### PR TITLE
niv doomemacs: update 90b1b221 -> 7a750304

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "90b1b221fe7c20f2edef341a780e194cd22c7daa",
-        "sha256": "0afhq19k6f3wcklimkkaw7g9ngdvvf3qigcyn6zrnilg35w1vi97",
+        "rev": "7a7503045850ea83f205de6e71e6d886187f4a22",
+        "sha256": "1pxw6nvl84ywbp0j3x4wcrjw61j414rhzwf6ln7dg0yy1r0z7yx7",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/90b1b221fe7c20f2edef341a780e194cd22c7daa.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/7a7503045850ea83f205de6e71e6d886187f4a22.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@90b1b221...7a750304](https://github.com/doomemacs/doomemacs/compare/90b1b221fe7c20f2edef341a780e194cd22c7daa...7a7503045850ea83f205de6e71e6d886187f4a22)

* [`6c6cf955`](https://github.com/doomemacs/doomemacs/commit/6c6cf955e71eab8c1583dc71e4e34cba59dcf9ea) fix(syntax): s/use-package/use-package!
* [`833be113`](https://github.com/doomemacs/doomemacs/commit/833be113682b2fa3281d5ec3a67829750b3be481) fix(syntax): update flycheck binding check
* [`24601b30`](https://github.com/doomemacs/doomemacs/commit/24601b300e87e909340524476713dcaaa5d095cd) fix(syntax): s/postframe/posframe
* [`764ed796`](https://github.com/doomemacs/doomemacs/commit/764ed7960a59bcc97454a7f4036ac93dd07b5111) feat(scheme): register scsh interpreter
* [`ea7d6ef1`](https://github.com/doomemacs/doomemacs/commit/ea7d6ef1cca4fff6df8e68c2d7e9efc3c014593d) release(modules): 23.08.0-dev
* [`d52ebe8f`](https://github.com/doomemacs/doomemacs/commit/d52ebe8fd1f9163166a75a605228d26f67caaa3a) bump: :core
* [`fc327f5b`](https://github.com/doomemacs/doomemacs/commit/fc327f5be67edeeccf37e77dd6e74e63fce4990c) bump: :tools debugger lsp
* [`7c63b353`](https://github.com/doomemacs/doomemacs/commit/7c63b353d2908c079f1f42460f64b7af84359a0b) bump: :tools magit
* [`45e34fb7`](https://github.com/doomemacs/doomemacs/commit/45e34fb723c1426c8edf04a965a0f65a36258e9d) bump: :lang beancount emacs-lisp sh
* [`a7f3db97`](https://github.com/doomemacs/doomemacs/commit/a7f3db972f2552d9e6ed252846490a828c722e70) bump: :config default use-package
* [`7efcbf92`](https://github.com/doomemacs/doomemacs/commit/7efcbf9208fc71907c17f1630b552663d6cf0e2a) bump: :email
* [`150ccd63`](https://github.com/doomemacs/doomemacs/commit/150ccd630565848ad196c77b5ed18d50fc937e2e) fix(cli): set LC_ALL to force english output
* [`b1cc7190`](https://github.com/doomemacs/doomemacs/commit/b1cc719063226f8ce76c7a08742da4081c3d5067) feat(lib): add base-directory arg to project-file-exists-p!
* [`b17257cf`](https://github.com/doomemacs/doomemacs/commit/b17257cf989de9148399694fadabd7728546b3ae) fix(lua): love2d project check
* [`c8070f11`](https://github.com/doomemacs/doomemacs/commit/c8070f11a44810e066130d6cd9a0679a3f2b76fa) fix(cli): suppress coding-system prompts
* [`09504ef9`](https://github.com/doomemacs/doomemacs/commit/09504ef9fea6def957b6a2cec3fba907b56eba9b) feat: ask before quickloading a session
* [`6aa9ebae`](https://github.com/doomemacs/doomemacs/commit/6aa9ebae64f3d7ba0cc6c2930da6a104088060fb) tweak(doom-dashboard): recentf now top menu section
* [`23c0eeba`](https://github.com/doomemacs/doomemacs/commit/23c0eeba454c95ecbd19b7df9ad09e83704eb323) fix(multiple-cursors): check evil-local-mode instead of the global one
* [`5639ebf9`](https://github.com/doomemacs/doomemacs/commit/5639ebf9420f6b4084a0a7226d42007ab1e1cb6c) fix(lsp): check npm when eglot is enabled
* [`5155f4aa`](https://github.com/doomemacs/doomemacs/commit/5155f4aa7880c265ff8ca0c2cde011d749e57223) fix(lib): unquote base-directory in project-file-exists-p!
* [`5bb59ad4`](https://github.com/doomemacs/doomemacs/commit/5bb59ad4b0c345909113e02207ee25b4120bac66) bump: :lang elm fsharp haskell lean lua purescript solidity web zig
* [`ea616350`](https://github.com/doomemacs/doomemacs/commit/ea616350c70b5ad4b9dfecb7f656cf74c459d439) docs: mention 29.1 support
* [`21df7d0b`](https://github.com/doomemacs/doomemacs/commit/21df7d0bebff3bc965acf8c8d6c7973b92f8150c) bump: :editor evil
* [`7a5f5d07`](https://github.com/doomemacs/doomemacs/commit/7a5f5d07e72d496ff614e0892c78b62b31aaac4d) bump: :ui
* [`9e9c7d9e`](https://github.com/doomemacs/doomemacs/commit/9e9c7d9e6d0014e76365de2a76eb82cc37a60641) bump: :editor evil
* [`7a750304`](https://github.com/doomemacs/doomemacs/commit/7a7503045850ea83f205de6e71e6d886187f4a22) revert: fix(cli): set LC_ALL to force english output
