### PR TITLE
niv nixpkgs: update 48516a89 -> 62441cb5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48516a891d020801bc5304375739d2604400c741",
-        "sha256": "0hqb8rbfx3yy5pcppsr6yyn5whwibwbn59cj83yjwa4i1gzr781j",
+        "rev": "62441cb5daf98a01b1eab80c2dd5e719fd2bd65d",
+        "sha256": "1rwl2h7ck18p4bcsyivwi57aziwzvhj7zw0zjzbcw9j2nmdsdlls",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/48516a891d020801bc5304375739d2604400c741.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/62441cb5daf98a01b1eab80c2dd5e719fd2bd65d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@48516a89...62441cb5](https://github.com/nixos/nixpkgs/compare/48516a891d020801bc5304375739d2604400c741...62441cb5daf98a01b1eab80c2dd5e719fd2bd65d)

* [`9f6dad5a`](https://github.com/NixOS/nixpkgs/commit/9f6dad5ab33d8994d4c09917b564dbc55482b39c) c-ares: ensure passthru.tests' curl is built with c-ares support
* [`c00e06a3`](https://github.com/NixOS/nixpkgs/commit/c00e06a3b206be3dbf3044080ce9413de449db11) sickgear: 0.25.60 -> 3.29.3
* [`fdb8abb3`](https://github.com/NixOS/nixpkgs/commit/fdb8abb3cd789935a6b2b4a9e0120851a90a6fbc) moodle: 4.1.3 -> 4.1.4
* [`ed04798c`](https://github.com/NixOS/nixpkgs/commit/ed04798c4b41cf1e5d7899cc2129869a38903148) h2: 2.1.210 -> 2.2.220
* [`d746f25d`](https://github.com/NixOS/nixpkgs/commit/d746f25d19551a98a7890045bc5896c91346360e) curl: Fix cross-compilation to Windows by not forcing gssSupport
* [`b0dc3d26`](https://github.com/NixOS/nixpkgs/commit/b0dc3d26f21f96400d4ab0310ef767f325a9ced6) doc/stdenv: Minor syntax fix.
* [`957541ad`](https://github.com/NixOS/nixpkgs/commit/957541ad6911d1b94c545a2f7a7a47964b73951a) nixos/modules/system/boot/binfmt.nix: update mips patterns
* [`05c2df5f`](https://github.com/NixOS/nixpkgs/commit/05c2df5f936d17de0461b66807466bcb22e16cbe) premake5: fix static build
* [`896b2b9d`](https://github.com/NixOS/nixpkgs/commit/896b2b9dbdd372d00e36c7275b5f3a8824a0652d) ArchiSteamFarm: 5.4.7.3 -> 5.4.8.3
* [`65988b25`](https://github.com/NixOS/nixpkgs/commit/65988b254651cf9dda3d7bb5c85e0cd775171558) apparmor: fix invalid reference when withPython=false
* [`eeb19e9f`](https://github.com/NixOS/nixpkgs/commit/eeb19e9f25248f9166dff02ca0eadf6aa21c4122) djvulibre: patch multiple CVEs
* [`cc4dcc08`](https://github.com/NixOS/nixpkgs/commit/cc4dcc08be45ee7889e99a4015a6523e641e6e65) grafana-agent: build and embed flow mode web ui
* [`c5d10719`](https://github.com/NixOS/nixpkgs/commit/c5d10719df43e4bbb0e27ca58822ab36fcc645ce) python310Packages.magic-filter: 1.0.10 -> 1.0.11
* [`cd135d42`](https://github.com/NixOS/nixpkgs/commit/cd135d423160b1c441688caf60c40344e2625c85) qtstyleplugin-kvantum: add suffix to Qt 6 variant
* [`6c462a52`](https://github.com/NixOS/nixpkgs/commit/6c462a529845ccdbe690c738c16d620772455a88) qtstyleplugin-kvantum: fix loading builtin themes on Qt 6
* [`003a1886`](https://github.com/NixOS/nixpkgs/commit/003a1886cbc0c49f30ed3999a02191553df1ba8f) gitlab: 16.1.3 -> 16.1.4
* [`103bb49f`](https://github.com/NixOS/nixpkgs/commit/103bb49f84536d8fedc2b88a8ad81ff59342d400) nixos/stage-2-init: Change permission of /etc/nixos only if it exists
* [`dc028fda`](https://github.com/NixOS/nixpkgs/commit/dc028fdac2393ec3ec178598095c3a314c0a8957) ceph: use availableOn instead of meta.available
* [`eb6b7c35`](https://github.com/NixOS/nixpkgs/commit/eb6b7c353cda74703796cdb9cbc45a44d16ee190) libdrm: use lib.availableOn instead of lib.meta.available
* [`094195fb`](https://github.com/NixOS/nixpkgs/commit/094195fb64e51f73bab70d60fee36f520f576fa7) jupyter-all: init a package to build all Jupyter kernels
* [`02459909`](https://github.com/NixOS/nixpkgs/commit/02459909ce7c7402a52697c590b1ca4d55d5d73f) mpd-mpris: 0.4.0-2 -> 0.4.1
* [`494196b3`](https://github.com/NixOS/nixpkgs/commit/494196b3daa86529a8d4270c5275812c77cb89a3) python311Packages.asyncpg: 0.27.0 -> 0.28.0
* [`71059446`](https://github.com/NixOS/nixpkgs/commit/71059446f9272597c8d92f3302ec2919aea6481a) spirv-tools: fix static build
* [`88c05254`](https://github.com/NixOS/nixpkgs/commit/88c052545610b9ee3e9b25144d855e897ce7728b) spirv-tools: Add windows to platforms
* [`98741b7e`](https://github.com/NixOS/nixpkgs/commit/98741b7e3f2ee558ef2a21a60681fa60980e90cb) maui-shell: 0.5.6 -> 0.6.6
* [`c2cd085f`](https://github.com/NixOS/nixpkgs/commit/c2cd085fec1f649189491c8dffc1c30e00cd9b39) metabase: 0.46.6.1 -> 0.46.7
* [`fbb3f828`](https://github.com/NixOS/nixpkgs/commit/fbb3f8286622e37e903d644b199e27492cf26ba5) pkg: 1.20.4 -> 1.20.5
* [`ee363c9a`](https://github.com/NixOS/nixpkgs/commit/ee363c9ad3be66532f637d0f6b5486724b6be91d) openmvs: 2.1.0 -> 2.2.0
* [`05db2ff9`](https://github.com/NixOS/nixpkgs/commit/05db2ff97e7d83845e666c6f85d6e24893f03683) albert: 0.20.14 -> 0.22.0
* [`7706f570`](https://github.com/NixOS/nixpkgs/commit/7706f570a73f48451657e708f7a9a174eb02755c) dnscrypt-proxy: rename from dnscrypt-proxy2
* [`ca28c0bb`](https://github.com/NixOS/nixpkgs/commit/ca28c0bb51f5040c48246a6417bdae1ba4512f27) upnp-router-control: 0.3.2 -> 0.3.3
* [`259aceec`](https://github.com/NixOS/nixpkgs/commit/259aceecef9baae7876cb5a029efaf107d6f909b) lobster: 2023.9 -> 2023.11
* [`87c629f1`](https://github.com/NixOS/nixpkgs/commit/87c629f19e5ee33e24a550aeb300f593ee3e8482) nimbo: 0.2.4 -> 0.3.0
* [`1dc9ecec`](https://github.com/NixOS/nixpkgs/commit/1dc9ecec908f8ee65bb144e66ef1e8d9819826c5) spatialite_tools: 5.1.0 -> 5.1.0a
* [`e4288684`](https://github.com/NixOS/nixpkgs/commit/e428868418b170a810f97039ab21f7e9031d0fa0) juju: 3.2.0 -> 3.2.2
* [`25e08610`](https://github.com/NixOS/nixpkgs/commit/25e0861024ed5bc257d56b88130906877ace61ab) utf8cpp: 3.2.3 -> 3.2.4
* [`a5017e3c`](https://github.com/NixOS/nixpkgs/commit/a5017e3c3af29805796e9333438a9a55ccefbc23) besu: 23.4.1 -> 23.4.4
* [`be63df41`](https://github.com/NixOS/nixpkgs/commit/be63df415e9d84e879debd5c3336d2642596a8ef) ibus-engines.table-others: 1.3.16 -> 1.3.17
* [`01f9a554`](https://github.com/NixOS/nixpkgs/commit/01f9a554f5e981df9f296e8fa0e3158367712f7a) mariadb_104: 10.4.30 -> 10.4.31
* [`ce6608f7`](https://github.com/NixOS/nixpkgs/commit/ce6608f77be9debf4104e51136840ca0f31f0e25) mariadb_105: 10.5.21 -> 10.5.22
* [`79f2db7c`](https://github.com/NixOS/nixpkgs/commit/79f2db7ca2b53ac3ee28593df9005612df7afa48) mariadb_106: 10.6.14 -> 10.6.15
* [`b14d7e88`](https://github.com/NixOS/nixpkgs/commit/b14d7e88b0c8a33676ce5a1186168f869f5e26f3) mariadb_1010: 10.10.5 -> 10.10.6
* [`a6e732f6`](https://github.com/NixOS/nixpkgs/commit/a6e732f6a0e311254142a9ed9d05808060005dca) mariadb_1011: 10.11.4 -> 10.11.5
* [`15054fe7`](https://github.com/NixOS/nixpkgs/commit/15054fe7a3efa76e2ab01f99b80c9a5781044b63) mariadb_110: 11.0.2 -> 11.0.3
* [`da614d98`](https://github.com/NixOS/nixpkgs/commit/da614d98e9540002bb1a1a9165177c3a6719f07f) lib/gvariant: init
* [`cce75fa5`](https://github.com/NixOS/nixpkgs/commit/cce75fa51e1ef5d6f1657b9c0b9ca1963f8f3b03) nixos/dconf: refractor
* [`fb52d5df`](https://github.com/NixOS/nixpkgs/commit/fb52d5df8669aa7ca64f3cb83c42c118cd244603) nixos/dconf: add settings support
* [`038d78d4`](https://github.com/NixOS/nixpkgs/commit/038d78d4ce9fdef9f271891953d946233fe5ed42) nixos/dconf: add locks support
* [`0e6827ed`](https://github.com/NixOS/nixpkgs/commit/0e6827ed9c09e517d47575e1b9e19f52e0961225) nixos/gdm: switch to dconf settings
* [`dc1330d7`](https://github.com/NixOS/nixpkgs/commit/dc1330d7d7877f49ac06c8a9059dd6b07d581f09) libburn: 1.5.4 -> 1.5.6
* [`c34b58af`](https://github.com/NixOS/nixpkgs/commit/c34b58af4a5697644974b451bc9b70cc0466ceda) weave-gitops: 0.28.0 -> 0.29.0
* [`c92c9601`](https://github.com/NixOS/nixpkgs/commit/c92c960150fa39336901439d8d04999d68fd8839) libdigidocpp: 3.15.0 -> 3.16.0
* [`667d0193`](https://github.com/NixOS/nixpkgs/commit/667d01930da84d532759a6eac04420fd533c0aee) vmagent: 1.91.3 -> 1.93.0
* [`d6258164`](https://github.com/NixOS/nixpkgs/commit/d625816428ab4c58370f6ad8e6f61e02986f7141) python311Packages.aiounifi: 52 -> 54
* [`7104b8f8`](https://github.com/NixOS/nixpkgs/commit/7104b8f8ec57292ff8c6da6016d2f498f62498d5) python311Packages.azure-identity: 1.13.0 -> 1.14.0
* [`005b2546`](https://github.com/NixOS/nixpkgs/commit/005b2546a8f9506183bcc04fdd663f1034bc1bfc) calendar-cli: 0.14.1 -> 1.0.1
* [`c7743cd4`](https://github.com/NixOS/nixpkgs/commit/c7743cd496fc1ccc76758276a3a9c0dbccaae8c3) esptool: 4.5.1 -> 4.6.2
* [`fc4d705d`](https://github.com/NixOS/nixpkgs/commit/fc4d705d09fedcd29c8972ce0d4f6c1b3b5e6de1) routino: 3.3.3 -> 3.4.1
* [`cff61911`](https://github.com/NixOS/nixpkgs/commit/cff61911e32dac371369a2f6a2928958ca1f9445) oneDNN_2: 2.7.1 -> 2.7.5
* [`c925bd93`](https://github.com/NixOS/nixpkgs/commit/c925bd932e586cf563fa7ff96ff4b417ce158f1a) xdg-dbus-proxy: 0.1.4 -> 0.1.5
* [`8c84eb3e`](https://github.com/NixOS/nixpkgs/commit/8c84eb3e93a786fdd04cfae91b8e65b425787b76) maintainers: add xyven1
* [`0a5c7c46`](https://github.com/NixOS/nixpkgs/commit/0a5c7c46a8bef60485040695c7e918227eb95841) muse: 3.1.1 -> 4.1.0
* [`08ca4e08`](https://github.com/NixOS/nixpkgs/commit/08ca4e08dd53d8986b293ef6d3d57fa6dd13c22b) thonny: 4.1.1 -> 4.1.2
* [`17e05cd1`](https://github.com/NixOS/nixpkgs/commit/17e05cd1f2d8efebb32e569b44c4e9e3bd7cbefc) maintainers/teams: add ororatech
* [`fe579efd`](https://github.com/NixOS/nixpkgs/commit/fe579efd1ac20ba59bbc7a46a89697949710870e) maintainers: add kip93
* [`70d93c13`](https://github.com/NixOS/nixpkgs/commit/70d93c13413177e950125ac44eecdd14a85aacea) maintainers: add victormeriqui
* [`b2788a6f`](https://github.com/NixOS/nixpkgs/commit/b2788a6f36baccc5d25f2f74a44799f72b7cad00) ddccontrol: 0.6.1 -> 0.6.2
* [`3575b65b`](https://github.com/NixOS/nixpkgs/commit/3575b65b68012f7bcfbe8ab2b187186f51d74693) oneDNN: use `finalAttrs` pattern
* [`ccf92769`](https://github.com/NixOS/nixpkgs/commit/ccf92769e9e1fc6557c4d57f5c9afb51aa1f07f4) oneDNN_2: use `finalAttrs` pattern
* [`253a0637`](https://github.com/NixOS/nixpkgs/commit/253a0637876f2115d534869a083dea1accabb7ee) xdg-dbus-proxy: use `finalAttrs` pattern
* [`9c536a29`](https://github.com/NixOS/nixpkgs/commit/9c536a29110d1923a9984005f9b1a62d9da17958) komikku: 1.22.0 -> 1.23.0
* [`0c3116f1`](https://github.com/NixOS/nixpkgs/commit/0c3116f1dda3e3e0e1953ff516e8320a452cc015) shopware-cli: 0.2.1 -> 0.2.6
* [`18b2685e`](https://github.com/NixOS/nixpkgs/commit/18b2685ebd4dea134291658a97879d638da03a6b) python311Packages.starlette: 0.26.1 -> 0.27.0
* [`902814d9`](https://github.com/NixOS/nixpkgs/commit/902814d9a14b1c6bbea57b7aae8f98517bc50b70) python311Packages.fastapi: 0.95.1 -> 0.95.2
* [`83326c2d`](https://github.com/NixOS/nixpkgs/commit/83326c2d47189cbe098c0719c56408f93c1e61d7) python3.pkgs.pygobject-stubs: init at 2.8.0
* [`a8de2f00`](https://github.com/NixOS/nixpkgs/commit/a8de2f00b434fb24e75c57fb397e89f941d50909) pgbackrest: 2.46 -> 2.47
* [`43475f18`](https://github.com/NixOS/nixpkgs/commit/43475f181c7318e3c085bd41653ce896513dd25f) stress-ng: 0.15.10 -> 0.16.04
* [`78edd5b6`](https://github.com/NixOS/nixpkgs/commit/78edd5b64e8c87ccbbc129aff560067bc41b4a58) mc: 4.8.29 -> 4.8.30
* [`518696b7`](https://github.com/NixOS/nixpkgs/commit/518696b7c1412c526c8b9bcadab3eb86002a2e32) python3.pkgs.gobject-stubs: Remove optional "dev" dependencies
* [`3c500a0c`](https://github.com/NixOS/nixpkgs/commit/3c500a0cc8290c547151daf95a701509f2860f36) python3.pkgs.gobject-stubs: Use lgpl21Plus license
* [`8b84d90d`](https://github.com/NixOS/nixpkgs/commit/8b84d90d84c6369dc6625ff620af2fd28b2edcfe) python3.pkgs.gobject-stubs: Disable the check phase
* [`ba787d2a`](https://github.com/NixOS/nixpkgs/commit/ba787d2a27c2f7c1b8596b41240516505c560fdc) python310Packages.ansible: 8.2.0 -> 8.3.0
* [`83705435`](https://github.com/NixOS/nixpkgs/commit/83705435680ebf6dc48e6adb819641280552d71b) fheroes2: 1.0.6 -> 1.0.7
* [`b2386a03`](https://github.com/NixOS/nixpkgs/commit/b2386a036a49d6c13e2a153897059e7ce02fbae8) bluej: 5.1.0 -> 5.2.0
* [`ccffaecb`](https://github.com/NixOS/nixpkgs/commit/ccffaecb98a626708a15d52d8f108ad75ee8d4bb) nuclear: 0.6.27 -> 0.6.30
* [`fb3601ed`](https://github.com/NixOS/nixpkgs/commit/fb3601ed52efa1b52e4776613c009f535ca2a657) netmaker: 0.20.5 -> 0.20.6
* [`1e7ec477`](https://github.com/NixOS/nixpkgs/commit/1e7ec4773b7d7fe1123699f830f79336b69ac14e) radarr: 4.6.4.7568 -> 4.7.5.7809
* [`06366e86`](https://github.com/NixOS/nixpkgs/commit/06366e869ebb47e0d2dbcc06396c3c027ebdd728) nwg-drawer: 0.3.8 -> 0.3.9
* [`0837ab43`](https://github.com/NixOS/nixpkgs/commit/0837ab431d4fab9a97890479465777ff7ecb777f) zrok: 0.4.2 -> 0.4.5
* [`63cdd30f`](https://github.com/NixOS/nixpkgs/commit/63cdd30f46b40a2249c54e29ea3612b1a6d61e40) circleci-cli: 0.1.28528 -> 0.1.28811
* [`fcef652d`](https://github.com/NixOS/nixpkgs/commit/fcef652da8210d753f85acaf0afb569be4cc40e4) honk: add `passthru.tests`
* [`cc4bb239`](https://github.com/NixOS/nixpkgs/commit/cc4bb239a3188bcb1501c2e282294b97da13546f) perf: enable `perf stat` evens supported by `libpfm`
* [`0f2fff26`](https://github.com/NixOS/nixpkgs/commit/0f2fff269d775522836c92ea02bb6298274a50a5) scaleft: 1.45.4 -> 1.67.4
* [`37c9f1ca`](https://github.com/NixOS/nixpkgs/commit/37c9f1cafa54e6289ea6c49524c1dc6a633e254b) scaleft: added passthru tests
* [`0bda00c6`](https://github.com/NixOS/nixpkgs/commit/0bda00c6deee9d1b2a7362849fefc7e9cf7c8471) linkerd_edge: 23.8.2 -> 23.8.3
* [`c862dce8`](https://github.com/NixOS/nixpkgs/commit/c862dce860d07c7a72075ccf307f156db85287be) angband: 4.2.4 -> 4.2.5
* [`0623457c`](https://github.com/NixOS/nixpkgs/commit/0623457cba4f956f026efb148aa0620ad24d83bb) libyang: 2.1.80 -> 2.1.111
* [`110ebe93`](https://github.com/NixOS/nixpkgs/commit/110ebe9382e7a060c99731f863222e79d215faf8) python310Packages.pytorch-lightning: 2.0.6 -> 2.0.7
* [`69c53285`](https://github.com/NixOS/nixpkgs/commit/69c53285a04c37f9dc4c2439ec83344093db3b20) omegat: 4.3.0 -> 6.0.0
* [`cceff19a`](https://github.com/NixOS/nixpkgs/commit/cceff19a9aa03e6ed19cf409e183a6d9ad709bf0) lima: 0.17.0 -> 0.17.2
* [`aee8eede`](https://github.com/NixOS/nixpkgs/commit/aee8eede5f0274d8d4306261f7f43f38a4c48dec) libcouchbase: 3.3.7 -> 3.3.8
* [`b0679238`](https://github.com/NixOS/nixpkgs/commit/b0679238bbdf322203b482fc588055fc56a79453) html-minifier: use buildNpmPackage
* [`8e53e1ba`](https://github.com/NixOS/nixpkgs/commit/8e53e1bae7f3df96627501966ec3ce3970523864) spotify-player: make build options configurable
* [`f7289e6e`](https://github.com/NixOS/nixpkgs/commit/f7289e6e80195c2876a5e502de95155b7eddc670) calaos_installer: 3.5 -> 3.11
* [`a93f86aa`](https://github.com/NixOS/nixpkgs/commit/a93f86aada0ca790fdac364ff1a8de2691ac60ad) benthos: 4.18.0 -> 4.19.0
* [`7820fd25`](https://github.com/NixOS/nixpkgs/commit/7820fd253d22a10b2548774116c6cd0d6a93ad0c) qcad: 3.28.1.0 -> 3.28.1.3
* [`38da5e47`](https://github.com/NixOS/nixpkgs/commit/38da5e47a6d924085a331c963df1017c4a18079e) avalanchego: 1.10.5 -> 1.10.8
* [`39132f4e`](https://github.com/NixOS/nixpkgs/commit/39132f4ee8d9fed8d357f6fafad3211648c96630) codeql: 2.14.1 -> 2.14.2
* [`fa524932`](https://github.com/NixOS/nixpkgs/commit/fa52493298669395ed1544d1623b29cadcc407c4) vscode-extensions.charliermarsh.ruff: 2023.32.0 -> 2023.34.0
* [`2da03072`](https://github.com/NixOS/nixpkgs/commit/2da03072206223ed6ee968bdd654a4d82da33001) buildFHSEnv: fix `NIX_LDFLAGS` propagation to `ld` wrapper
* [`eb831f75`](https://github.com/NixOS/nixpkgs/commit/eb831f759bc2c98ef84a0a97c60e5ab0b73f309c) nixos/stc: Improve mount unit handling
* [`a3dd3cce`](https://github.com/NixOS/nixpkgs/commit/a3dd3cce6e1aa8aaf1f8c9eba7233b2a334e686e) chickenPackages.chickenEggs: update
* [`f58a6078`](https://github.com/NixOS/nixpkgs/commit/f58a6078fa737bd9a2c68db99486132f88b132af) chickenPackages: turn into scope
* [`6ff3e836`](https://github.com/NixOS/nixpkgs/commit/6ff3e836369d0301fcfee5322cf97961b1c5d923) python311Packages.azure-mgmt-redhatopenshift: 1.2.0 -> 1.3.0
* [`e3b4ba39`](https://github.com/NixOS/nixpkgs/commit/e3b4ba396debb886ce4ce870deb6ce439b606cb0) ryujinx: 1.1.986 -> 1.1.999
* [`ea3df193`](https://github.com/NixOS/nixpkgs/commit/ea3df1934f447a126a5a6235953e73b39458c674) gatekeeper: 3.12.0 -> 3.13.0
* [`5b6244cb`](https://github.com/NixOS/nixpkgs/commit/5b6244cb5002bd5d0516874ee1cebe020be38c83) commit-mono: 1.132 -> 1.134
* [`73babca7`](https://github.com/NixOS/nixpkgs/commit/73babca767015d92e490d8d243abe51ab78db320) github-runner: 2.307.1 -> 2.308.0
* [`388bfcef`](https://github.com/NixOS/nixpkgs/commit/388bfcef4a51efb55b2b447d2634d16ce486d32c) nixos/github-runners: add `nodeRuntimes` option
* [`f3521c1e`](https://github.com/NixOS/nixpkgs/commit/f3521c1e551a6e2bc799e339382a18732a50ec97) ecs-agent: 1.73.1 -> 1.75.0
* [`1892d71c`](https://github.com/NixOS/nixpkgs/commit/1892d71c100b5b3b71005a431af11d3add3f5b0d) alsa-scarlett-gui: add alsa-utils to PATH
* [`59c8dfbe`](https://github.com/NixOS/nixpkgs/commit/59c8dfbe6af3a48e1d92b060583ea9d302e24354) samba: 4.18.5 -> 4.18.6
* [`55774d1e`](https://github.com/NixOS/nixpkgs/commit/55774d1ef67edec9646e2b6f9f5e40df110d2c52) qucs-s: 1.1.0 -> 2.0.0
* [`59bea061`](https://github.com/NixOS/nixpkgs/commit/59bea0616f43e3a73b320eb01286f22e7e068388) terraform-compliance: 1.3.34 -> 1.3.43
* [`faf2e634`](https://github.com/NixOS/nixpkgs/commit/faf2e6345043630fbd986a6773e026743db93549) arduino-language-server: 0.7.4 -> 0.7.5
* [`11c2f309`](https://github.com/NixOS/nixpkgs/commit/11c2f3098865e2298632ee5330bd7dadcf2418fa) pymavlink: 2.4.39 -> 2.4.40
* [`8fef15ab`](https://github.com/NixOS/nixpkgs/commit/8fef15abdb43d5f679bff48d907543624282c624) python310Packages.pybox2d: init at 2.3.10
* [`ba48b30b`](https://github.com/NixOS/nixpkgs/commit/ba48b30bb299b1e58c364bff84d113063b93a4ba) python310Packages.gymnasium: 0.29.0 -> 0.29.1
* [`57118402`](https://github.com/NixOS/nixpkgs/commit/5711840226e354fd299561e44a73abecdc7946bd) python311Packages.aiounifi: 54 -> 55
* [`3bf06839`](https://github.com/NixOS/nixpkgs/commit/3bf068398e66b372f3fe0de37a4699512a9a44a5) PageEdit: 1.9.20 -> 2.0.0
* [`22f6f916`](https://github.com/NixOS/nixpkgs/commit/22f6f9163693eac5c0ceacc2c10d81e62c05accb) rpi-imager: 1.7.4 -> 1.7.5
* [`8fe20401`](https://github.com/NixOS/nixpkgs/commit/8fe2040190e56e2d5763dd147cb59cea4c7f56aa) rpi-imager: add anthonyroussel to maintainers
* [`6db520b1`](https://github.com/NixOS/nixpkgs/commit/6db520b15db3c8649fcf9c78611350afd257afa0) rpi-imager: add passthru.updateScript
* [`1ca53897`](https://github.com/NixOS/nixpkgs/commit/1ca53897a2b0cc60d86d0ce38240d50225f1e262) xss-lock: add meta.mainProgram
* [`9dd22ab4`](https://github.com/NixOS/nixpkgs/commit/9dd22ab456f5fa4b2a47513edbc3e1af5620d273) buildMavenPackage: inherit sourceRoot
* [`996dbb16`](https://github.com/NixOS/nixpkgs/commit/996dbb160b80dadaf647bc5cf008c504ef5da939) rpi-imager: add installCheck
* [`4fce50f6`](https://github.com/NixOS/nixpkgs/commit/4fce50f63b7af54c42cab0993e084c32cac0b892) rpi-imager: disable telemetry by default
* [`ef345b63`](https://github.com/NixOS/nixpkgs/commit/ef345b63ec7d3cc3560016aca7a1f4cbcf2aca99) jellyfin-ffmpeg: 6.0-4 -> 6.0-5
* [`75f5ea32`](https://github.com/NixOS/nixpkgs/commit/75f5ea32fc16d8da2bc43dccc40578985db68468) igraph: use finalAttrs-based self-references
* [`e9594e0d`](https://github.com/NixOS/nixpkgs/commit/e9594e0d42fc8cca96a64e329ec2a9aedcb92cc5) svlint: 0.8.0 -> 0.9.0
* [`dc51f3f0`](https://github.com/NixOS/nixpkgs/commit/dc51f3f01a18d48d63f72a498c5c21c64b9af7c3) krane: 3.1.0 -> 3.3.0
* [`34dbf216`](https://github.com/NixOS/nixpkgs/commit/34dbf216e6267d1eab8beb4050a7dd47274c7774) unpoller: 2.8.0 -> 2.8.1
* [`6c2f7bcf`](https://github.com/NixOS/nixpkgs/commit/6c2f7bcfaad4951ea665a257f5b1e7b44da6b2fd) oneshot: 1.5.1 -> 2.0.1
* [`d8e85714`](https://github.com/NixOS/nixpkgs/commit/d8e857148c0468fb194313c8d7b326914c2038f2) s5cmd: 2.1.0 -> 2.2.0
* [`f6e73e4a`](https://github.com/NixOS/nixpkgs/commit/f6e73e4ac1aaa7984b0e928dab392e7e3503718b) klayout: 0.28.10 -> 0.28.11
* [`3d5fdc9a`](https://github.com/NixOS/nixpkgs/commit/3d5fdc9ade95bb9e0bdc07c3b1e07cbe68ff311d) net-snmp: 5.9.3 -> 5.9.4
* [`c7bb136a`](https://github.com/NixOS/nixpkgs/commit/c7bb136ae8fd0514a1fbeb15457d48aa13325b45) kubefirst: 2.2.7 -> 2.2.9
* [`8c1e87be`](https://github.com/NixOS/nixpkgs/commit/8c1e87bee2adedb3c7c6424b28a78b54ca2ae4fb) lightworks: 2022.1.1 -> 2023.1
* [`91b3c702`](https://github.com/NixOS/nixpkgs/commit/91b3c70278b83fa1e412945a5196d1a6336ff4fd) devede: 4.16.0 -> 4.17.0
* [`84b273f8`](https://github.com/NixOS/nixpkgs/commit/84b273f885fbcd470f5f82ab3300b20e0bf86f3e) playwright: 1.34.3 > 1.37.0
* [`146074e1`](https://github.com/NixOS/nixpkgs/commit/146074e17066cde84a857f469e80f95ab2d26335) xmrig-mo: 6.19.3-mo1 -> 6.20.0-mo1
* [`20124142`](https://github.com/NixOS/nixpkgs/commit/2012414272ad4c9816b00c3fd71aaa424c7d1966) giada: 0.24.0 -> 0.25.1
* [`56f2307a`](https://github.com/NixOS/nixpkgs/commit/56f2307ab6c41dda987e23eeec285e9fff3da960) genymotion: 3.4.0 -> 3.5.0
* [`cf8bd451`](https://github.com/NixOS/nixpkgs/commit/cf8bd45123420cf14d5012783f01fd90a42040b2) fishPlugins.fzf-fish: add meta.changelog
* [`c40323b9`](https://github.com/NixOS/nixpkgs/commit/c40323b934742284d0ca237fe3c09e5979be251e) fishPlugins.fzf-fish: 9.9 -> 10.0
* [`a2a7149a`](https://github.com/NixOS/nixpkgs/commit/a2a7149af1660801d69b417a8494411e81cd895a) mavproxy: 1.8.62 -> 1.8.66
* [`fc770285`](https://github.com/NixOS/nixpkgs/commit/fc770285db32dbbfa0f37a34176f57ec0da4db2d) python310Packages.libtmux: 0.22.1 -> 0.23.0post0
* [`aa8b09f4`](https://github.com/NixOS/nixpkgs/commit/aa8b09f450094844725671e84a31dbb76cd01d3c) cypress: 12.17.3 -> 12.17.4
* [`111bb59a`](https://github.com/NixOS/nixpkgs/commit/111bb59aebb3bf208541d269c2aedcef0b164048) gst_all_1.gst-plugins-rs: 0.10.11 -> 0.11.0
* [`d564dfa4`](https://github.com/NixOS/nixpkgs/commit/d564dfa4d0f913554882a0b9d0c49952c6eefa5a) sambamba: 1.0.0 -> 1.0.1
* [`06831bc1`](https://github.com/NixOS/nixpkgs/commit/06831bc1717b7afdfb3b1772143c685418318d73) ocamlPackages.domain_shims: init at 0.1.0
* [`53ef6d94`](https://github.com/NixOS/nixpkgs/commit/53ef6d94f339036f6a041a0405063d326e104a66) ocamlPackages.saturn: 0.3.0 (lockfree) → 0.4.0
* [`446297f8`](https://github.com/NixOS/nixpkgs/commit/446297f8678e5372e81923ec8bcc28de1ddbdefb) python310Packages.unstructured: add optional-dependencies
* [`d516998a`](https://github.com/NixOS/nixpkgs/commit/d516998a89d36c8b25ec5600750d489b02d61fe4) clojure: 1.11.1.1386 -> 1.11.1.1405
* [`250d3247`](https://github.com/NixOS/nixpkgs/commit/250d32477655f7fb70eaaf41e1d5de77bc9b2b5b) trivial-builders: add meta to writeShellApplication
* [`d07ebffd`](https://github.com/NixOS/nixpkgs/commit/d07ebffdef610aa571bf226b5fbe52a05d934103) yash: 2.54 -> 2.55
* [`46fd5f04`](https://github.com/NixOS/nixpkgs/commit/46fd5f04994db3ffa88a37f1b555e52dc1abcab9) semgrep: 1.35.0 -> 1.37.0
* [`e1960738`](https://github.com/NixOS/nixpkgs/commit/e1960738c2f1aab683018ab445e176964fd17a7b) birdfont: 2.32.3 -> 2.33.1
* [`55c42e89`](https://github.com/NixOS/nixpkgs/commit/55c42e893bb68332cffd13aac9f8711c57014c58) smartdns: 42 -> 43
* [`c99f6eae`](https://github.com/NixOS/nixpkgs/commit/c99f6eae3f973461c7da2a6c79e0e3722ca9b63c) kaniko: 1.13.0 -> 1.14.0
* [`f0ac17b9`](https://github.com/NixOS/nixpkgs/commit/f0ac17b9858bbd7e1f42cb07e12082a720e8a864) pulsar: 1.107.1 -> 1.108.0
* [`ee533072`](https://github.com/NixOS/nixpkgs/commit/ee5330729205f78878c775c72e84e5edbf9dab76) ntpd-rs: init at 0.3.7
* [`e4b2bd41`](https://github.com/NixOS/nixpkgs/commit/e4b2bd41b64923d6a43785b3850932f0177f767f) ombi: 4.39.1 -> 4.43.5
* [`c7f827e5`](https://github.com/NixOS/nixpkgs/commit/c7f827e55ed2e4cbdb513eebcfcdeca3435a2c2e) atlas: init at 0.13.3
* [`0e673417`](https://github.com/NixOS/nixpkgs/commit/0e67341785afe77a8e3f33d006871ada8c7c2b15) vnstat: 2.10 -> 2.11
* [`14d6d59b`](https://github.com/NixOS/nixpkgs/commit/14d6d59bc0a7d1577cc64c21301c4da7433815f7) easyrsa: 3.1.5 -> 3.1.6
* [`7c31a275`](https://github.com/NixOS/nixpkgs/commit/7c31a275321d81f33e289da29aa4367be416d18c) python310Packages.oldest-supported-numpy: fix numpy dependency
* [`94e6e837`](https://github.com/NixOS/nixpkgs/commit/94e6e837f4146e0373e071ad5b5a1d0c796b83f4) google-guest-oslogin: 20230808.00 -> 20230821.01
* [`e96a0b3c`](https://github.com/NixOS/nixpkgs/commit/e96a0b3c8bf728e9d711765450a3769223a67e40) insync: fix bwrap namespaces
* [`ad92eba1`](https://github.com/NixOS/nixpkgs/commit/ad92eba1ab6699df34ccb3ce89c223b77a1a0f62) python311Packages.pathvalidate: add changelog to meta
* [`1c36ac78`](https://github.com/NixOS/nixpkgs/commit/1c36ac78e7ff3a2c7b066680ab50e5459f94f9e1) tempo: 2.2.0 -> 2.2.1
* [`b2a14fc0`](https://github.com/NixOS/nixpkgs/commit/b2a14fc0e4afe6b9b781bfa25d77b3600e8202dc) qgis: disable building tests
* [`624d5537`](https://github.com/NixOS/nixpkgs/commit/624d5537b6d0443ba93b86429ebc88dd7682c82e) spire: 1.7.1 -> 1.7.2
* [`cf2aba5e`](https://github.com/NixOS/nixpkgs/commit/cf2aba5eeaac6edb58bbbefc1b5da47a6dd31c1c) nwg-dock: 0.3.6 -> 0.3.7
* [`3327b632`](https://github.com/NixOS/nixpkgs/commit/3327b632a42b598f826f4535de9aa3a93ebadf6e) goimports-reviser: 3.3.1 -> 3.4.1
* [`a20979b5`](https://github.com/NixOS/nixpkgs/commit/a20979b583a9df1933e8f8528bf70f375338833b) eventstore: 22.10.2 -> 23.6.0
* [`2cf93457`](https://github.com/NixOS/nixpkgs/commit/2cf9345708c68cce87f7bf4e54f93bc7c6c0c9a4) qgis-ltr: 3.28.7 -> 3.28.10
* [`09f9749a`](https://github.com/NixOS/nixpkgs/commit/09f9749a096b4b7978445bcaf519017268a8ac69) qgis: alphabetical sorting of dependencies
* [`0e82f77a`](https://github.com/NixOS/nixpkgs/commit/0e82f77a336926fb65594e5db07ce60e8817f218) qgis-ltr: alphabetical sorting of dependencies
* [`a791f731`](https://github.com/NixOS/nixpkgs/commit/a791f731e345efff318eb270d5cab1bb4d1273f8) qgis-ltr: disable building tests
* [`be3af7fe`](https://github.com/NixOS/nixpkgs/commit/be3af7fed08534debeade1e696d64bc352d465b6) vimPlugins: update
* [`c41a8609`](https://github.com/NixOS/nixpkgs/commit/c41a8609ed078126c9554a22db5adb88600bae52) vimPlugins.nvim-treesitter: update grammars
* [`169f5fa5`](https://github.com/NixOS/nixpkgs/commit/169f5fa54503c4831ac6c9ccfa60368d8df9c54b) poetryPlugins.poetry-plugin-export: 1.4.0 -> 1.5.0
* [`92236aff`](https://github.com/NixOS/nixpkgs/commit/92236affa23a5a44ade5fa78e31c674a10b2ab94) poetry: 1.5.1 -> 1.6.1
* [`c82aaab4`](https://github.com/NixOS/nixpkgs/commit/c82aaab4ec5978990c84d0b481771dbfe123953a) zeyple: use python3Packages.gpgme
* [`18cc7390`](https://github.com/NixOS/nixpkgs/commit/18cc73907831efe8c3023dfe2a3837172c708ab4) bazarr: add missing setuptools dependency
* [`c8aef93d`](https://github.com/NixOS/nixpkgs/commit/c8aef93daea3d1f5e7edd2399a80da3b507e87a6) maintainers: add pschmitt
* [`9fb1308f`](https://github.com/NixOS/nixpkgs/commit/9fb1308f23f119c261f5508ebd1145237faa3b60) python310Packages.stumpy: 1.11.1 -> 1.12.0
* [`061b238a`](https://github.com/NixOS/nixpkgs/commit/061b238aaf01b50a1b12b6b8801e637e8e1cef47) furnace: 0.6pre8 -> 0.6pre9
* [`26c4dcb7`](https://github.com/NixOS/nixpkgs/commit/26c4dcb79431cd8a9861398b5658410fbbd27a59) firefly-desktop: 1.3.3 -> 2.1.5
* [`2e2efe8d`](https://github.com/NixOS/nixpkgs/commit/2e2efe8d0abf9fdd44a9cd0e27d3005418a9cf69) thermald: 2.5.3 -> 2.5.4
* [`745de518`](https://github.com/NixOS/nixpkgs/commit/745de518cd1e93b8ef7a4090aced2cb447f599bb) asar: use buildNpmPackage
* [`7619eb3b`](https://github.com/NixOS/nixpkgs/commit/7619eb3b44297b75239d8b7b3f1885d359f705ce) sqldef: 0.12.7 -> 0.16.4
* [`790d32e0`](https://github.com/NixOS/nixpkgs/commit/790d32e0a32780af2bfd6f6c25f6e450668b6f83) python310Packages.apprise: 1.4.5 -> 1.5.0
* [`79af5861`](https://github.com/NixOS/nixpkgs/commit/79af586173707171f6a3edcca2c7b0f8bccbb5d8) dnsperf: 2.13.0 -> 2.13.1
* [`bf9f6f5c`](https://github.com/NixOS/nixpkgs/commit/bf9f6f5c72630155c904e2fa73b70335be638bee) python310Packages.numpyro: 0.12.1 -> 0.13.0
* [`d13a7e78`](https://github.com/NixOS/nixpkgs/commit/d13a7e781c410d8bfd71dbeb130815ab2c65a4f5) nifi: 1.23.0 -> 1.23.2
* [`16639091`](https://github.com/NixOS/nixpkgs/commit/1663909170519b16ae237c67685c412013f5e97b) homepage-dashboard: 0.6.28 -> 0.6.29
* [`097a680f`](https://github.com/NixOS/nixpkgs/commit/097a680f8da86c20a2c53960b365317a3662172a) python3Packages.pywebm: no longer maintained
* [`40e82051`](https://github.com/NixOS/nixpkgs/commit/40e82051b94f52a60473e2d0fef010bd1f402184) flutter: 3.10.5 -> 3.13.0
* [`c9de78a3`](https://github.com/NixOS/nixpkgs/commit/c9de78a33019f77e66cca95ee3b14f46b3a4450a) pantheon.wingpanel-indicator-power: 6.2.0 -> 6.2.1
* [`d189406a`](https://github.com/NixOS/nixpkgs/commit/d189406ad2c7ce9e937cdb3f6b033eef745a011e) hal-hardware-analyzer: 3.3.0 -> 4.2.0
* [`2936f4a9`](https://github.com/NixOS/nixpkgs/commit/2936f4a93e9e8d1039cfd4dd409ecaaa0ed96f6b) python311Packages.chacha20poly1305-reuseable: 0.4.1 -> 0.4.2
* [`094fb4a3`](https://github.com/NixOS/nixpkgs/commit/094fb4a32714ef84affe15178d6c1e395d66fd56) python311Packages.cyclonedx-python-lib: 4.0.1 -> 4.1.0
* [`2da80dbf`](https://github.com/NixOS/nixpkgs/commit/2da80dbfbacf47ba1a9070c4855d68e5d52a339f) openarena: fix make flags, cleanup
* [`a825461a`](https://github.com/NixOS/nixpkgs/commit/a825461ab98f8b50d8e0f64051cdbf2f92e53efc) python311Packages.home-assistant-bluetooth: 1.10.2 -> 1.10.3
* [`c0856cfa`](https://github.com/NixOS/nixpkgs/commit/c0856cfabc477763c9c65784d4d98b5f485b53af) soapui: fix runtime error on darwin
* [`1792924a`](https://github.com/NixOS/nixpkgs/commit/1792924a76bfd016110d491ebc0a49d76105905b) rust-traverse: init at 2.0.0
* [`dad5a449`](https://github.com/NixOS/nixpkgs/commit/dad5a4499ff1af4a224194601d1f2fc136b23d7e) libmediainfo: 23.06 -> 23.07
* [`4ea72764`](https://github.com/NixOS/nixpkgs/commit/4ea72764694f73871eb71b98052198952d039a5f) mediainfo: 23.06 -> 23.07
* [`05b53f83`](https://github.com/NixOS/nixpkgs/commit/05b53f830e184b360e087be69c5b4363965ea1cb) mediainfo-gui: 23.06 -> 23.07
* [`1c37010b`](https://github.com/NixOS/nixpkgs/commit/1c37010b1e5dfd2e22e3de5fa03e68918283e9e4) listmonk: modify the 1.20 Go support patch
* [`3aed80b2`](https://github.com/NixOS/nixpkgs/commit/3aed80b2c3349c64b354ead0803961723de66d23) nixpkgs-review: 2.10.0 -> 2.10.1
* [`f8c2f282`](https://github.com/NixOS/nixpkgs/commit/f8c2f28242996f18200fa8d1e68bbe11f956ac3d) python311Packages.ulid-transform: 0.8.0 -> 0.8.1
* [`0d0d5e69`](https://github.com/NixOS/nixpkgs/commit/0d0d5e6966d67afefd0cbdd41c3929d6d5d270be) python311Packages.zeroconf: 0.82.1 -> 0.84.0
* [`183be581`](https://github.com/NixOS/nixpkgs/commit/183be5810f53a204f0b115454e7605734548b04e) python311Packages.syrupy: 4.0.8 -> 4.2.1
* [`748d749b`](https://github.com/NixOS/nixpkgs/commit/748d749bb904d75c158ab8650bf9004eb34f5790) python311Packages.fnv-hash-fast: 0.4.0 -> 0.4.1
* [`2b3d6e6d`](https://github.com/NixOS/nixpkgs/commit/2b3d6e6d94812147a19c080f9115695a33c0cfea) python311Packages.pytibber: 0.28.0 -> 0.28.1
* [`524abda8`](https://github.com/NixOS/nixpkgs/commit/524abda807b279c9768be0b9e687983b1871d3e8) python311Packages.python-engineio: 4.5.1 -> 4.6.1
* [`0e5622c4`](https://github.com/NixOS/nixpkgs/commit/0e5622c48ddb2e8382a2ca4c43054e084c0d60df) python311Packages.bluetooth-data-tools: 1.9.0 -> 1.9.1
* [`bb9a7086`](https://github.com/NixOS/nixpkgs/commit/bb9a7086de891b22ea8f468357cd9d4f28d0881b) python311Packages.async-upnp-client: 0.34.1 -> 0.35.0
* [`871b2828`](https://github.com/NixOS/nixpkgs/commit/871b2828fd108fdd0af48269312f5079d5e0e6b1) python311Packages.bimmer-connected: 0.13.10 -> 0.14.0
* [`39067763`](https://github.com/NixOS/nixpkgs/commit/3906776371fc7375955141783fcc5d776c0f6a30) android-studio: 2022.3.1.18 -> 2022.3.1.19
* [`b8e66dbd`](https://github.com/NixOS/nixpkgs/commit/b8e66dbd698a016c2f1e49e3aa995700524c6691) android-studio-beta: 2022.3.1.17 -> 2023.1.1.7
* [`1c7fe3d7`](https://github.com/NixOS/nixpkgs/commit/1c7fe3d70399ca7e78dfc092931294b2e732b007) android-studio-canary: 2023.1.1.14 -> 2023.2.1.1
* [`07075b3f`](https://github.com/NixOS/nixpkgs/commit/07075b3ff92caf585121637ea673aa9e2b4d733b) fishPlugins.pure: 4.1.1 -> 4.7.0
* [`48de6493`](https://github.com/NixOS/nixpkgs/commit/48de649336a552051afdcc42b007c84cb24dd1b1) nixos/modules/honk: init
* [`94b81880`](https://github.com/NixOS/nixpkgs/commit/94b818800dd276dce4108239c281644a418fb9c1) maven: 3.9.3 -> 3.9.4
* [`7e427c35`](https://github.com/NixOS/nixpkgs/commit/7e427c3595baa4e729a091c59b2e1b3e6d22f19c) clac: 0.3.3 -> 0.3.3-unstable-2021-09-06
* [`c033c47c`](https://github.com/NixOS/nixpkgs/commit/c033c47cb3b51c700993bfa9e7e1e368eb0e7cac) vips: 8.14.3 -> 8.14.4
* [`5a5d0955`](https://github.com/NixOS/nixpkgs/commit/5a5d095526798afff81da9b8ad5c6f0df4dac313) cudaPackages.nccl: 2.18.3-1 -> 2.18.5-1; add updateScript
* [`a8fd3d60`](https://github.com/NixOS/nixpkgs/commit/a8fd3d603cb1c6f3799f1dd59e3846d33ecb2e44) fluidd: 1.25.0 -> 1.25.2
* [`39df712e`](https://github.com/NixOS/nixpkgs/commit/39df712ed59e768aead663f9064d231b0bf179e7) uclient: unstable-2022-02-24 -> unstable-2023-04-13
* [`0f14ca4c`](https://github.com/NixOS/nixpkgs/commit/0f14ca4cefcce1a0d50050ae3ceec27fb578e7e4) libubox: unstable-2023-01-03 -> unstable-2023-05-23
* [`0ff1e969`](https://github.com/NixOS/nixpkgs/commit/0ff1e969adeaee0716a9212145ecfeea4ab8e745) ubus: unstable-2021-02-15 -> unstable-2023-06-05
* [`3a8aa079`](https://github.com/NixOS/nixpkgs/commit/3a8aa079a51aea40912a9454d789a0f2ee35d7bc) uci: unstable-2021-04-14 -> unstable-2023-08-10
* [`54a92c8b`](https://github.com/NixOS/nixpkgs/commit/54a92c8bca5646e378b44e0245f09744597baffc) ustream-ssl: unstable-2022-12-08- -> unstable-2023-02-25
* [`9b625903`](https://github.com/NixOS/nixpkgs/commit/9b625903671ae8fb10ffa25a52b759e6892549c9) libnl-tiny: unstable-2022-12-13 -> unstable-2023-07-27
* [`d25e1e76`](https://github.com/NixOS/nixpkgs/commit/d25e1e766a69eb18d033e7171291de98ce1b63ac) talosctl: 1.4.7 -> 1.5.0
* [`41c8568b`](https://github.com/NixOS/nixpkgs/commit/41c8568b3ae2f066582c65b21f3134b2333bed94) web-eid-app: 2.3.1 -> 2.4.0
* [`21c0a31d`](https://github.com/NixOS/nixpkgs/commit/21c0a31d648a3db6f2d42b9b824a35afaf034c31) hcloud: 1.36.0 -> 1.37.0
* [`36d6b0bd`](https://github.com/NixOS/nixpkgs/commit/36d6b0bd9dd69babcc4ecde227eebbfa5a311d26) networkmanager_dmenu: 2.3.0 -> 2.3.1
* [`3d52741a`](https://github.com/NixOS/nixpkgs/commit/3d52741a6a66b816ee3cbc65bdebc108f8c82aa5) rsyslog: 8.2306.0 -> 8.2308.0
* [`d9faf957`](https://github.com/NixOS/nixpkgs/commit/d9faf957f472d8f40818ca16f6826cb3783e22f7) magma: 2.7.1 -> 2.7.2
* [`6aea9212`](https://github.com/NixOS/nixpkgs/commit/6aea92129082bed32d45ba1a4d99ef392a7bbc98) napari: 0.4.17 -> 0.4.18
* [`7f90f3b5`](https://github.com/NixOS/nixpkgs/commit/7f90f3b57cb881ddcf56e0627e9a5d0c10b80c2a) nixpacks: 1.12.0 -> 1.13.0
* [`744ceaee`](https://github.com/NixOS/nixpkgs/commit/744ceaeef0066a74f403195314d327930d74cb23) tegola: 0.17.0 -> 0.18.0
* [`001c0936`](https://github.com/NixOS/nixpkgs/commit/001c0936da3c5f6c7d4648fca8134f5c52bb99c4) elixir-ls: meta.mainProgram
* [`6e7daaa6`](https://github.com/NixOS/nixpkgs/commit/6e7daaa64130ce302798dea8587f19a7ca9f9204) risor: 0.15.0 -> 0.17.0
* [`d92e50c6`](https://github.com/NixOS/nixpkgs/commit/d92e50c6a3a5bb9c3271f416a684a1720c480fba) jwx: 2.0.11 -> 2.0.12
* [`1debaa9b`](https://github.com/NixOS/nixpkgs/commit/1debaa9be52924f746ab3a48ec62849d978552b6) brev-cli: 0.6.252 -> 0.6.259
* [`df280cdf`](https://github.com/NixOS/nixpkgs/commit/df280cdf95c318aa5a18a1a1e51ef315f5fc6092) shotman: 0.4.3 -> 0.4.5
* [`9824764b`](https://github.com/NixOS/nixpkgs/commit/9824764bf1901e71c99c67172a1b2a800100501c) open-stage-control: 1.25.2 -> 1.25.3
* [`3f68347f`](https://github.com/NixOS/nixpkgs/commit/3f68347f93dfce83e475942af2983316e8a426ec) faketty: 1.0.12 -> 1.0.13
* [`e5193e1e`](https://github.com/NixOS/nixpkgs/commit/e5193e1e6902114eee9d01d509cb6b6aa72b2849) kubernetes-controller-tools: 0.12.1 -> 0.13.0
* [`4aa29313`](https://github.com/NixOS/nixpkgs/commit/4aa293136ff795611cb568405bb1d2807fc4fb10) libcef: 116.0.14 -> 116.0.15
* [`cd23dfab`](https://github.com/NixOS/nixpkgs/commit/cd23dfabf74219f1d8ab2f56e25ba16302db3c41) python310Packages.textual: 0.33.0 -> 0.35.1
* [`28d93b85`](https://github.com/NixOS/nixpkgs/commit/28d93b854b08e21581d80e7a9171bd5f97e25e7b) sioyek: fix build
* [`8b800436`](https://github.com/NixOS/nixpkgs/commit/8b800436b908c4230c964a2fd0a53f856dbcdc7c) python310Packages.pip-tools: 7.2.0 -> 7.3.0
* [`196a8438`](https://github.com/NixOS/nixpkgs/commit/196a8438ee8afb9974e2ab71757d49b25cb8892e) python310Packages.djangorestframework-simplejwt: 5.2.2 -> 5.3.0
* [`b499f97c`](https://github.com/NixOS/nixpkgs/commit/b499f97cf52cf0ca5e8a2c80a9a1f83e2edc6af0) terraform-providers.ucloud: 1.36.1 -> 1.37.0
* [`73243f1c`](https://github.com/NixOS/nixpkgs/commit/73243f1cdf028e7232fe06d3f1c57b015477d4a3) python310Packages.bpycv: 0.3.6 -> 0.4.0
* [`409d682a`](https://github.com/NixOS/nixpkgs/commit/409d682a57d75bd303b35bdb95b933291674f338) coqPackages_8_14.coq-elpi: fix by using old camlp5
* [`2ae7493c`](https://github.com/NixOS/nixpkgs/commit/2ae7493cb6fe1e5d3f3c10a24a7de2ec4213f770) coqPackages.hierarchy-builder: 1.4.0 → 1.5.0
* [`116480d3`](https://github.com/NixOS/nixpkgs/commit/116480d33f9e2de18b1c596112d276fee0a46e28) kstars: 3.6.4 -> 3.6.6
* [`bffe2f18`](https://github.com/NixOS/nixpkgs/commit/bffe2f189eb5b9bb50a80a075b209caf5bb24e4a) warzone2100: fixup build after vulkan update
* [`be3cdca0`](https://github.com/NixOS/nixpkgs/commit/be3cdca0ec19bf7fbb186bd951fba08d81aca324) maintainers: add zaldnoay
* [`e18671d4`](https://github.com/NixOS/nixpkgs/commit/e18671d41f11b3d6447ecf6f2620fa4590efc89a) python311Packages.unstructured-api-tools: 0.10.10 -> 0.10.11
* [`1ffac91a`](https://github.com/NixOS/nixpkgs/commit/1ffac91a875571d4c43711a4663f79de41f1e793) pantheon.switchboard-plug-applications: 7.0.0 -> 7.0.1
* [`75919c95`](https://github.com/NixOS/nixpkgs/commit/75919c953f4abb6b25d88fbc5d14a95df8b1f85c) flyway: 9.21.1 -> 9.21.2
* [`5d914aa5`](https://github.com/NixOS/nixpkgs/commit/5d914aa52d2a0722a84bb4636e60e1e7bc9d87b9) ocamlPackages.arp: 3.0.0 → 3.1.0
* [`bdba8e0b`](https://github.com/NixOS/nixpkgs/commit/bdba8e0b677f8499bedd6d9a59960684cbf089cc) windmill: 1.131.0 -> 1.160.0
* [`830612d1`](https://github.com/NixOS/nixpkgs/commit/830612d1092173d91b135b2e911934863a205683) global-platform-pro: 18.09.14 -> 20.01.23
* [`35f2adf1`](https://github.com/NixOS/nixpkgs/commit/35f2adf1caf7933900bda7e1f3216db4f1d33b39) fetchMavenDeps: add missing pre/post runHooks
* [`e6f84c74`](https://github.com/NixOS/nixpkgs/commit/e6f84c74b341573488ded0e98a4bd2ec98a25dd9) grsync: 1.3.0 -> 1.3.1
* [`ed59f79b`](https://github.com/NixOS/nixpkgs/commit/ed59f79befe011f7a1db3be4fbbc71300d7fa4cc) kubeseal: 0.23.0 -> 0.23.1
* [`b86adcb6`](https://github.com/NixOS/nixpkgs/commit/b86adcb62880609cf06e14aa210460943eb34e9c) swaynotificationcenter: backport PR 296
* [`ab2a9efb`](https://github.com/NixOS/nixpkgs/commit/ab2a9efb9918bf6f0bad6cd60664a6b50ab7d057) skopeo: 1.13.2 -> 1.13.3
* [`53d2cd0b`](https://github.com/NixOS/nixpkgs/commit/53d2cd0bc1ae8a92f5e7d693b3a743111a244850) buildah: 1.31.2 -> 1.31.3
* [`b516af56`](https://github.com/NixOS/nixpkgs/commit/b516af56c13c1d97e8bef2aaed78aaf035d7bc2c) python310Packages.djangorestframework-simplejwt: add changelog to meta
* [`35d24bae`](https://github.com/NixOS/nixpkgs/commit/35d24bae405a23484cdd012e95e2e90441bd1352) hcloud: replace sha256 with hash
* [`97451829`](https://github.com/NixOS/nixpkgs/commit/97451829cd2fe5f8ae11fc1fca24de2533fdfdd7) python310Packages.pyiqvia: 2022.10.0 -> 2023.08.1
* [`c467dd64`](https://github.com/NixOS/nixpkgs/commit/c467dd643a64ffdbc59c347769d013959985ae0f) python310Packages.djangorestframework-simplejwt: add optional-dependencies
* [`c9b9a3a3`](https://github.com/NixOS/nixpkgs/commit/c9b9a3a38f88b10eb326dfcbd40ac8b824ed650d) armcord: 3.2.3 -> 3.2.4
* [`65fe58d0`](https://github.com/NixOS/nixpkgs/commit/65fe58d067767ccad9ffb4e13bea6a1a332fe79e) commitizen: 3.5.2 -> 3.7.0
* [`e95ba1eb`](https://github.com/NixOS/nixpkgs/commit/e95ba1eb1a24c3dd6487e24073729fc78e9356ac) transcrypt: 1.1.0 -> 2.2.3
* [`b945eca5`](https://github.com/NixOS/nixpkgs/commit/b945eca59b772ba20cbcd5e182772b2e41ddb395) exiftool: 12.62 -> 12.65
* [`f949b36c`](https://github.com/NixOS/nixpkgs/commit/f949b36ccf17235d2f1eed1f5ee6b5951c65a1f4) blackfire: 2.20.0 -> 2.21.0
* [`128321bc`](https://github.com/NixOS/nixpkgs/commit/128321bca98a63ad89fa1080416f3dc5d37fbae4) unstructured-api: init at 0.0.39
* [`e61a70f8`](https://github.com/NixOS/nixpkgs/commit/e61a70f884bd7bc49e8e0c9135c69a6f8e998910) vgmtools: unstable-2023-07-14 -> unstable-2023-08-27
* [`dbdd3d43`](https://github.com/NixOS/nixpkgs/commit/dbdd3d434f13423b3afa2ac5a40eedb5bb3d793e) python310Packages.mkdocs-minify: 0.6.3 -> 0.7.1
* [`1ccc1883`](https://github.com/NixOS/nixpkgs/commit/1ccc1883769e2f1cedde34507b2d836147a8dd6b) qtcreator: fix meta.license
* [`f7b59782`](https://github.com/NixOS/nixpkgs/commit/f7b5978272e32ffc7895530ed6b7e26d8c81c849) osc: 1.0.0b1 -> 1.3.0
* [`ab51ecad`](https://github.com/NixOS/nixpkgs/commit/ab51ecad592ea3b05b1678ff4f586fe39326637d) linux_xanmod: 6.1.46 -> 6.1.47
* [`dd7e988e`](https://github.com/NixOS/nixpkgs/commit/dd7e988ed495637568507c1ab80c3177b8b19f32) eza: v0.10.8 -> v0.10.9
* [`26a8c648`](https://github.com/NixOS/nixpkgs/commit/26a8c648570bf235b302085b6e54f96451849db8) ugrep: 4.0.4 -> 4.0.5
* [`cbe6f4eb`](https://github.com/NixOS/nixpkgs/commit/cbe6f4eb900fad425cbf8576ed57c750074da88d) linux_xanmod_latest: 6.4.11 -> 6.4.12
* [`838fea9a`](https://github.com/NixOS/nixpkgs/commit/838fea9a55a7ef7a7916f996433501100c37662b) pdfcpu: 0.4.1 -> 0.5.0
* [`c7dce3df`](https://github.com/NixOS/nixpkgs/commit/c7dce3df8c74ffcb8de3bf242b73712e5adc0227) brightnessctl: support cross compilation
* [`4bb3ee6b`](https://github.com/NixOS/nixpkgs/commit/4bb3ee6bc6c089fc3eb9f585e4c0c8a765065bed) zellij: 0.37.2 -> 0.38.0
* [`fc112148`](https://github.com/NixOS/nixpkgs/commit/fc1121488c2358644f2d149bebf049512471adc0) tuba: support cross compilation
* [`0fbb1591`](https://github.com/NixOS/nixpkgs/commit/0fbb1591d88975b8ded860e46459d7914339ea36) lsd: 0.23.1 -> 1.0.0, modernise packages, thin out maintainers
* [`9f9e0cc5`](https://github.com/NixOS/nixpkgs/commit/9f9e0cc5cc2fcb4dca56c9b2b011804b8af8c1f4) maintainers: add vuimuich
* [`e45b9d1b`](https://github.com/NixOS/nixpkgs/commit/e45b9d1b8c27121b6faa5e82f3a04b1045f09e61) citron: init at 0.15.0
* [`4e4d4ed5`](https://github.com/NixOS/nixpkgs/commit/4e4d4ed5c75439889e37af0b5696f67d8e138366) linux_6_5: init
* [`238eca32`](https://github.com/NixOS/nixpkgs/commit/238eca32de1c32ad6b6fe7f739726eceba533329) linux: 5.10.191 -> 5.10.192
* [`e1338219`](https://github.com/NixOS/nixpkgs/commit/e133821958541ff50e07b5bfa25e4179d5ce0816) linux: 5.15.127 -> 5.15.128
* [`385cbd7f`](https://github.com/NixOS/nixpkgs/commit/385cbd7fc4a7d0bc6d1d7b574a0b755e670ea171) linux: 6.1.47 -> 6.1.49
* [`be50d8c3`](https://github.com/NixOS/nixpkgs/commit/be50d8c358e62e2fb74a41b840c2d561358c42ac) linux_latest-libre: 19392 -> 19397
* [`1125d5fc`](https://github.com/NixOS/nixpkgs/commit/1125d5fcd2130e8ceb6776bbb288013847b2f686) linux/hardened/patches/6.1: 6.1.46-hardened1 -> 6.1.47-hardened1
* [`1b8869eb`](https://github.com/NixOS/nixpkgs/commit/1b8869eb7fb3f2d80efd1455a839f7b683ebd9ea) linux/hardened/patches/6.4: 6.4.11-hardened1 -> 6.4.12-hardened1
* [`da686a62`](https://github.com/NixOS/nixpkgs/commit/da686a62dc742ef1dc022c2f480b374a93dba622) style: format azure-cli/python-packages.nix
* [`c31fa5cf`](https://github.com/NixOS/nixpkgs/commit/c31fa5cf89f4edbdf0b27973fc222f7ffd489b1d) azure-cli: add missing azure-mgmt-appcontainers dependency
* [`6d448972`](https://github.com/NixOS/nixpkgs/commit/6d448972067003903b9a28b4d2055f3493c9a54d) azure-cli: add msrest to specific overrides
* [`e8efc18c`](https://github.com/NixOS/nixpkgs/commit/e8efc18c45ea7fbab70c22c9988f14d2bef39103) containerlab: 0.44.2 -> 0.44.3
* [`efc89b5e`](https://github.com/NixOS/nixpkgs/commit/efc89b5ef0bf17b8ff3ff566491fe65c6f792e98) ngtcp2-gnutls: 0.13.1 -> 0.18.0
* [`a144137f`](https://github.com/NixOS/nixpkgs/commit/a144137fa83c00a547a683f0a04c6135dbf4b404) knot-dns: 3.2.9 -> 3.3.0
* [`3f9b7920`](https://github.com/NixOS/nixpkgs/commit/3f9b79207b9f28c81939b1d306c76154ce6e4f47) python310Packages.approvaltests: 8.4.1 -> 9.0.0
* [`9836685e`](https://github.com/NixOS/nixpkgs/commit/9836685e51be33e9beb5d0603dd7abd9f11b53a6) python310Packages.apkit: init at unstable 2022-08-23
* [`fc0e6da3`](https://github.com/NixOS/nixpkgs/commit/fc0e6da3781a8eabf960339dffff849d6c3cf508) obs-studio-plugins.obs-freeze-filter: init at 0.3.3
* [`0944e191`](https://github.com/NixOS/nixpkgs/commit/0944e19139ab43427f5e70c2667667056368edfd) betterbird: 102.12.0-bb37 → 102.14.0-bb39
* [`77f65ff5`](https://github.com/NixOS/nixpkgs/commit/77f65ff563d2f20ef42c47c2efcaa241594a24de) gobble: init at 1.3
* [`ae60b3da`](https://github.com/NixOS/nixpkgs/commit/ae60b3da6be1648d92b6b9c2aafa3930e073b6b1) nimdow: 0.7.36->0.7.37
* [`7ce1c176`](https://github.com/NixOS/nixpkgs/commit/7ce1c176d073c81ffff1c3eac6c1976d0764fa18) hoard: 1.3.1 -> 1.4.2
* [`2cf01b04`](https://github.com/NixOS/nixpkgs/commit/2cf01b045047407130d0fa60318ae36cf222271c) linkerd: 2.13.6 -> 2.14.0
* [`df02fcb7`](https://github.com/NixOS/nixpkgs/commit/df02fcb79b4cae3652640ca66c2d1dfd0c6a4486) cc-wrapper: don't use fortify-headers for non-gcc compilers
* [`94eeeb87`](https://github.com/NixOS/nixpkgs/commit/94eeeb87851a71c7471fe289cd15e71f610c85b5) path-of-building.data: 2.33.3 -> 2.33.5
* [`f6c5130c`](https://github.com/NixOS/nixpkgs/commit/f6c5130ce5b0f6d373da23e70e3dfe4a4ac6e94c) armcord: add ludovicopiero as a maintainer
* [`676525be`](https://github.com/NixOS/nixpkgs/commit/676525be5f4cab89f92c4473361ea6e19b49ae23) nwg-panel: 0.9.11 -> 0.9.12
* [`06b94e0c`](https://github.com/NixOS/nixpkgs/commit/06b94e0ca507035cd6ac1823fdf20f7c2848216b) banana-vera: 1.30-python3.10 -> 1.30-fedora38
* [`5ae06f97`](https://github.com/NixOS/nixpkgs/commit/5ae06f97c70205121c2854b4ad92a0c7e21aaf15) neosay: init at 1.0.0
* [`553f5ac2`](https://github.com/NixOS/nixpkgs/commit/553f5ac2c8a52e98767847cccc70f9bd2d2b214c) bililiverecorder: init at 2.6.3
* [`e2ea9317`](https://github.com/NixOS/nixpkgs/commit/e2ea93179495026e326597e8406a0f8722a3d321) python311Packages.aioesphomeapi: 16.0.1 -> 16.0.2
* [`23e586d2`](https://github.com/NixOS/nixpkgs/commit/23e586d2640edea40cfbce12c2ffc91449ec4a4b) python311Packages.griffe: 0.35.1 -> 0.35.2
* [`08bb76a8`](https://github.com/NixOS/nixpkgs/commit/08bb76a88da3970073bf7ce9064beec0d05d4535) python311Packages.hahomematic: 2023.8.11 -> 2023.8.12
* [`395cd1b6`](https://github.com/NixOS/nixpkgs/commit/395cd1b6b7dec22c628227ddf078b4d86507e629) python310Packages.mypy-boto3-builder: 7.17.3 -> 7.18.0
* [`f66efd3d`](https://github.com/NixOS/nixpkgs/commit/f66efd3db721e6a4eced9edef3546fd1b8c8f122) python311Packages.publicsuffixlist: 0.10.0.20230824 -> 0.10.0.20230828
* [`581ba9b1`](https://github.com/NixOS/nixpkgs/commit/581ba9b16b39855860e564aa0528d89af5ad9d68) python311Packages.peaqevcore: 19.0.3 -> 19.1.2
* [`2f5042a9`](https://github.com/NixOS/nixpkgs/commit/2f5042a91ae3c328a2d5e36c4fc8e3771e0b1e27) python311Packages.pylitterbot: 2023.4.6 -> 2023.4.7
* [`f5fbea97`](https://github.com/NixOS/nixpkgs/commit/f5fbea9761033a847ce91508471ed57f3ae67e95) emacsWithPackages: do not add the wrapper path twice
* [`e8f6a5ce`](https://github.com/NixOS/nixpkgs/commit/e8f6a5ce341d3db1cb4c707eb58b3162f93353a3) emacsWithPackages: do not symlink $emacs/share/emacs
* [`1506ab49`](https://github.com/NixOS/nixpkgs/commit/1506ab49e39cb208774ac49c480b77e9edb4dea7) emacs: correct the order of profiles and their sub dirs in load-path
* [`6505082e`](https://github.com/NixOS/nixpkgs/commit/6505082e724da1906003aa17ae9fc9e550e86ef6) emacsWithPackages: load compiled site-start.el of $emacs if possible
* [`2d324ed8`](https://github.com/NixOS/nixpkgs/commit/2d324ed8f96721b74c3a232ffd4bf5af1497405b) emacs: fix the detection of native compilation for Emacs 29
* [`7d4ea94d`](https://github.com/NixOS/nixpkgs/commit/7d4ea94d02670f7028168a00cd11d621048201c2) emacs: keep the default first writable native-comp-eln-load-path dir
* [`2cc480a3`](https://github.com/NixOS/nixpkgs/commit/2cc480a38fa0f56b4fe92dd1681cb34cb6f7f17d) vnote: 3.16.0 -> 3.17.0
* [`7668df9e`](https://github.com/NixOS/nixpkgs/commit/7668df9e056d398ae6f8f16db2bb63dc29ef47ac) glicol-cli: init at 0.2.0
* [`87bd67e4`](https://github.com/NixOS/nixpkgs/commit/87bd67e47695f2eb5ab4348fb860683ac437bd81) checkov: 2.4.12 -> 2.4.14
* [`5962d5fe`](https://github.com/NixOS/nixpkgs/commit/5962d5fead2af2b4fc865ff18da1d14c24d767f6) python311Packages.aioqsw: 0.3.3 -> 0.3.4
* [`9a18f86d`](https://github.com/NixOS/nixpkgs/commit/9a18f86d7143e56f22a76748083a3917669ae5be) heisenbridge 1.14.4 -> 1.14.5
* [`5e3bb2d3`](https://github.com/NixOS/nixpkgs/commit/5e3bb2d3f4f5a570ed914183e1eead6c816a00d2) walk: 1.5.2 -> 1.6.2
* [`e1854055`](https://github.com/NixOS/nixpkgs/commit/e1854055c8e66a345e089ed95509ae3392dbbe04) colord-kde: fix missing buildInput
* [`49592646`](https://github.com/NixOS/nixpkgs/commit/49592646811c163374d39fb2372e85785c5695a6) cargo-shuttle: 0.24.0 -> 0.25.1
* [`6f316226`](https://github.com/NixOS/nixpkgs/commit/6f316226548b12881b63b4259a7265fef29c634e) sbcl: 2.3.7 -> 2.3.8
* [`9b7d2dbb`](https://github.com/NixOS/nixpkgs/commit/9b7d2dbb5c092a9c2d33b6bb9dc21dae02b54b91) tlsx: 1.1.3 -> 1.1.4
* [`49add44e`](https://github.com/NixOS/nixpkgs/commit/49add44e4dd93514339ff2d732596b441be31a09) openssh: add withPAM parameter
* [`ab269806`](https://github.com/NixOS/nixpkgs/commit/ab269806750ced45beac8d18db2f7f8a7eda1a29) squeezelite: 1.9.9.1430 -> 1.9.9.1449
* [`dca2cda7`](https://github.com/NixOS/nixpkgs/commit/dca2cda70bfcbbbdef45e0254d06d5bf0ddd8d49) convco: 0.4.1 -> 0.4.2
* [`3a8f2d0e`](https://github.com/NixOS/nixpkgs/commit/3a8f2d0e9ff854515932f62c510d600f8fe64810) docs: fix link to Nix manual on sandbox config
* [`858018fd`](https://github.com/NixOS/nixpkgs/commit/858018fd32cb4a05e3be01f5bf4bc1efb1f5bf55) gimme-aws-creds: 2.7.1 -> 2.7.2
* [`14aa0299`](https://github.com/NixOS/nixpkgs/commit/14aa0299977f7bfe84a4969526f4df138d30d543) python311Packages.homematicip: 1.0.14 -> 1.0.15
* [`1246976a`](https://github.com/NixOS/nixpkgs/commit/1246976a33d65044ed52090955184d88deda78dc) ansible-lint: 6.17.1 -> 6.18.0
* [`f92eaa93`](https://github.com/NixOS/nixpkgs/commit/f92eaa934e8374eb5463ac4fae6ea3baaec93b30) yabai: 5.0.6 -> 5.0.7
* [`1ac67f7b`](https://github.com/NixOS/nixpkgs/commit/1ac67f7b20326281add6dbf9e43380f3c5f8954a) yabai: add khaneliman to maintainers
* [`87456a91`](https://github.com/NixOS/nixpkgs/commit/87456a91ccb4a241f58033004cc7807387bf4be2) yabai: chore remove unused input
* [`87921072`](https://github.com/NixOS/nixpkgs/commit/87921072c592cedc9d718306063d9520eef8b78d) python311Packages.commoncode: 31.0.2 -> 31.0.3
* [`2872237c`](https://github.com/NixOS/nixpkgs/commit/2872237cb292fdfb39f109e103fdcd1f928ae229) python3Packages.pytest-recording: 0.12.2 -> 0.13.0
* [`ff0f3e23`](https://github.com/NixOS/nixpkgs/commit/ff0f3e23bc9665503eb573257ae54fe94d92b5a6) cargo-hack: 0.5.29 -> 0.6.2
* [`67664830`](https://github.com/NixOS/nixpkgs/commit/67664830e0ef8b63e8e530da88b7bdd0486ca542) cargo-edit: 0.12.0 -> 0.12.1
* [`bd194f33`](https://github.com/NixOS/nixpkgs/commit/bd194f336c1e69842255803199118f3d19b97bf7) pgbadger: 11.5 -> 12.2
* [`cf18421a`](https://github.com/NixOS/nixpkgs/commit/cf18421ae05dd695ca4389b9f1f4593c2a08927e) zoom-us: 5.15.10.6882 -> 5.15.11.7239
* [`3901f0c8`](https://github.com/NixOS/nixpkgs/commit/3901f0c853ae3e8b2d727b1035e7a2590a105833) libnvme: add withDocs
* [`81b28c7a`](https://github.com/NixOS/nixpkgs/commit/81b28c7a1fd6a58fa9151e881ed59ec03ffe58ea) python311Packages.pywemo: 1.2.1 -> 1.3.0
* [`c52b0593`](https://github.com/NixOS/nixpkgs/commit/c52b0593cf6c350d52b3b0f49d7879636fd450dd) prometheus-unbound-exporter: replace at 0.4.4
* [`f396deaa`](https://github.com/NixOS/nixpkgs/commit/f396deaae7d284ad0e1b6122321fc99c2c69ca26) python311Packages.pydaikin: 2.10.5 -> 2.11.0
* [`e1bb2fb1`](https://github.com/NixOS/nixpkgs/commit/e1bb2fb18b6a6a629fce2ebd0b4711b6f1f55d30) python311Packages.dbus-fast: 1.94.0 -> 1.94.1
* [`91bd90fa`](https://github.com/NixOS/nixpkgs/commit/91bd90fa6c1b12dc7d6fcf81cfa32c0ea77f6232) libredwg: 0.12.5 -> 0.12.5.6248
* [`c4484420`](https://github.com/NixOS/nixpkgs/commit/c4484420e3da01b758827b2367185b195bbc8ad2) teehee: init at 0.2.8
* [`89a65e6b`](https://github.com/NixOS/nixpkgs/commit/89a65e6bb87f8ecc6aa6318ed5bd851a30553e19) python311Packages.google-nest-sdm: 2.2.5 -> 3.0.2
* [`bb58b49f`](https://github.com/NixOS/nixpkgs/commit/bb58b49f1c76b07330b28f89b3d64e3d5a64f31a) x16-rom: 43 -> 44
* [`bea9b4cb`](https://github.com/NixOS/nixpkgs/commit/bea9b4cb7251b52e198ea04c3f24d7b4d5b0ceb7) x16-emulator: 43 -> 44
* [`9d8520f9`](https://github.com/NixOS/nixpkgs/commit/9d8520f98c32ea2ab3a64a2f531c806e19ec59ed) ccl: 1.12 -> 1.12.2
* [`0540402b`](https://github.com/NixOS/nixpkgs/commit/0540402bc313a3e3a0791b6a3101d99806ae7f60) python310Packages.ge25519: 1.4.3 -> 1.5.1
* [`5e963046`](https://github.com/NixOS/nixpkgs/commit/5e96304671865e6cd76ebd9551519d7a2fe99119) cargo-hack: 0.6.2 -> 0.6.3
* [`42615694`](https://github.com/NixOS/nixpkgs/commit/42615694121a20c57a183aff105af47453aadb77) apache-airflow: fixes to update scripts
* [`d81e8ba5`](https://github.com/NixOS/nixpkgs/commit/d81e8ba58dd6619c00889bee0f3c07cf9caec03d) apache-airflow: 2.6.2 -> 2.6.3
* [`73c5a5a7`](https://github.com/NixOS/nixpkgs/commit/73c5a5a778cebc386fbbc0e6423cc03550c32390) nixos/prometheus/unbound-exporter: update for new package
* [`9d98e4cd`](https://github.com/NixOS/nixpkgs/commit/9d98e4cdc12ab1760e81ac7d2ccc5c62227e3d6f) apache-airflow: 2.6.3 -> 2.7.0
* [`cba36e6f`](https://github.com/NixOS/nixpkgs/commit/cba36e6fae7157f897eb7536520600757d1d1faf) python310Packages.universal-pathlib: 0.1.1 -> 0.1.2
* [`fd2cba03`](https://github.com/NixOS/nixpkgs/commit/fd2cba036cdc868521d791ddf11ccf0e01c5ec6b) nomad: use $NIX_BUILD_TOP for build directory
* [`1b42afed`](https://github.com/NixOS/nixpkgs/commit/1b42afed8566c0c881e8f01189cd0c05247340f0) python311Packages.python-bsblan: 0.5.14 -> 0.5.15
* [`e6d4a0fc`](https://github.com/NixOS/nixpkgs/commit/e6d4a0fcedccef6a984dc964fe4c568d170249b2) python311Packages.botocore-stubs: 1.31.34 -> 1.31.36
* [`c7802e30`](https://github.com/NixOS/nixpkgs/commit/c7802e3062a11907fa56ec631ed8045b1a880dad) diffoscope: Fix test failure
* [`9cddba95`](https://github.com/NixOS/nixpkgs/commit/9cddba95ec1b29b089c614f2e3040b45c4662538) grapejuice: fix pip install
* [`1d96a0fb`](https://github.com/NixOS/nixpkgs/commit/1d96a0fb970c04a91d3fafe471bd4e7f04717350) lsd: fix build on darwin
* [`4a142365`](https://github.com/NixOS/nixpkgs/commit/4a142365387568f12f331af895c53d0e7b18cd13) multiviewer-for-f1: 1.26.2 -> 1.26.4
* [`bda4a666`](https://github.com/NixOS/nixpkgs/commit/bda4a66686c07c73012018019edff334f9a37d76) ispc: 1.19.0 -> 1.20.0
* [`f80a6e17`](https://github.com/NixOS/nixpkgs/commit/f80a6e17d34ea3b162c837623359651212b0c09a) fuc: 1.1.6 -> 1.1.7
* [`acafc8e7`](https://github.com/NixOS/nixpkgs/commit/acafc8e76e243458fcb1e48f44b6f1fc6bf070d2) flutter.buildFlutterApplication: fix passthru being ignored
* [`1e333d29`](https://github.com/NixOS/nixpkgs/commit/1e333d29f603cb2900a25a8e6dc30db1f519d3b8) termimage: init at 1.2.1
* [`46413612`](https://github.com/NixOS/nixpkgs/commit/464136121cbdf15b72f8978cb43a1dddc3326c92) python310Packages.debugpy: disable process test timeouts
* [`ecf7eb97`](https://github.com/NixOS/nixpkgs/commit/ecf7eb976f0409415deceee07c0223bf4b291ce8) ytree: 2.04 -> 2.05
* [`96e87134`](https://github.com/NixOS/nixpkgs/commit/96e8713483211701a4e4859778ccb911b0dbacc0) tdlib: 1.8.10 -> 1.8.16
* [`1a4c043d`](https://github.com/NixOS/nixpkgs/commit/1a4c043d7cbae7ac213bd99804f9d1e987b079ff) python310Packages.pytile: 2023.04.0 -> 2023.08.0
* [`f4870886`](https://github.com/NixOS/nixpkgs/commit/f48708863d78eda447e62bfc9b4fa642d95a4037) git-branchless: 0.7.1 -> 0.8.0
* [`e3bb3a18`](https://github.com/NixOS/nixpkgs/commit/e3bb3a18578382d21e66d2f927bc54cc2920902c) terraform-providers.bigip: 1.18.1 -> 1.19.0
* [`f17d8e60`](https://github.com/NixOS/nixpkgs/commit/f17d8e6060ef072c06eb3a951430c0aff4fca9ad) terraform-providers.alicloud: 1.209.0 -> 1.209.1
* [`e1f871cd`](https://github.com/NixOS/nixpkgs/commit/e1f871cd7602610a3a7a9a948dfd49c21bb51034) terraform-providers.google: 4.79.0 -> 4.80.0
* [`955f23b0`](https://github.com/NixOS/nixpkgs/commit/955f23b0794076fac641a621c821225f2ba237d1) terraform-providers.nomad: 1.4.20 -> 2.0.0
* [`222ddd8b`](https://github.com/NixOS/nixpkgs/commit/222ddd8b5b9ae8c3c90cf980d3a5e53ff71465ba) terraform-providers.google-beta: 4.79.0 -> 4.80.0
* [`3d958404`](https://github.com/NixOS/nixpkgs/commit/3d958404528cd939451ca2ed30473c3d7ae4d746) terraform-providers.talos: 0.3.1 -> 0.3.2
* [`cc573297`](https://github.com/NixOS/nixpkgs/commit/cc57329742c32ab6034e0baeb44b3b6ff8fd2ce9) postgresqlPackages.pgvector: 0.4.4 -> 0.5.0
* [`f5110873`](https://github.com/NixOS/nixpkgs/commit/f5110873c8295d83fd24a88c999c5c5465768807) python310Packages.us: 2.0.2 -> 3.1.1
* [`1678f4ec`](https://github.com/NixOS/nixpkgs/commit/1678f4ec11ccc1ed2a4034dc96e9b37c0ae79e48) worker-build: 0.0.17 -> 0.0.18
* [`0f4c6b4e`](https://github.com/NixOS/nixpkgs/commit/0f4c6b4e4ba8567750ae9e9cec6bb773061dc8ed) Add Cargo.lock directly
* [`cd11d668`](https://github.com/NixOS/nixpkgs/commit/cd11d6683ea11c6e8263824e785569c3cdf4c065) worker-build: newline for Cargo.lock
* [`e8083f30`](https://github.com/NixOS/nixpkgs/commit/e8083f3021054cdba15876fd26b6e0b417dc3395) coqPackages.coq-elpi: 1.17.0 → 1.18.0
* [`2d692efd`](https://github.com/NixOS/nixpkgs/commit/2d692efd6f6d1eb46d31b99687387cd5e2403ee3) python310Packages.nbsphinx: 0.9.2 -> 0.9.3
* [`f4d32255`](https://github.com/NixOS/nixpkgs/commit/f4d322550704180df3c43dd68c0c3970de12556f) python310Packages.aioridwell: 2023.07.0 -> 2023.08.0
* [`d80d1658`](https://github.com/NixOS/nixpkgs/commit/d80d16585dd2930472da55758f83a89ab7a412ef) ocamlPackages.paf: remove spurious dependency on mirage-stack
* [`bcdc6b15`](https://github.com/NixOS/nixpkgs/commit/bcdc6b151ba17d2737e8a5c8a10311883b6aff22) ocamlPackages.mirage-stack: remove at 4.0.0
* [`a5920ce5`](https://github.com/NixOS/nixpkgs/commit/a5920ce574dfc0b382861ed8526dbfcd75563695) ocamlPackages.tcpip: 7.1.2 → 8.0.0
* [`962ebbd1`](https://github.com/NixOS/nixpkgs/commit/962ebbd141efc923f09d2ed922bcced20e0bb6e4) python310Packages.clintermission: 0.3.0 -> 0.3.1
* [`e6699a5d`](https://github.com/NixOS/nixpkgs/commit/e6699a5d48535deaeb04811cdb654b1d2d12968d) python310Packages.universal-pathlib: disable on unsupported Python releases
* [`f0a25526`](https://github.com/NixOS/nixpkgs/commit/f0a25526fbd1fd282ee4bea5374c60cf2e7dace5) python310Packages.us: add format
* [`9f858f2b`](https://github.com/NixOS/nixpkgs/commit/9f858f2b5beea242404fcc5c9cf477a1dec548f6) python310Packages.us: update meta
* [`e3f4e3ff`](https://github.com/NixOS/nixpkgs/commit/e3f4e3ff069b5a207e0867d5f85ffdac6fcb19c8) python310Packages.oslo-serialization: 5.1.1 -> 5.2.0
* [`139db136`](https://github.com/NixOS/nixpkgs/commit/139db136bc56f811fd28d9d0430a61ffe624450d) python310Packages.us: enable tests
* [`00f5ce20`](https://github.com/NixOS/nixpkgs/commit/00f5ce200015bd1804bc563bfc19a6401ef5b8e2) python310Packages.geopy: 2.3.0 -> 2.4.0
* [`cfacb52c`](https://github.com/NixOS/nixpkgs/commit/cfacb52c2d6b775137244c97f28c7184369b222f) hivemind: use sri hash
* [`6a45e415`](https://github.com/NixOS/nixpkgs/commit/6a45e41567bdc27e8f3f44d830280c7cd71984db) vimiv-qt: fix wayland and mainProgram
* [`61a87b71`](https://github.com/NixOS/nixpkgs/commit/61a87b71a20979b2ab50255da12cdfdb2acb4abb) python311Packages.impacket: 0.10.0 -> 0.11.0
* [`f2c76c17`](https://github.com/NixOS/nixpkgs/commit/f2c76c1725ff4b8ce7322aab86b553051e2e0214) python311Packages.impacket: add myself as maintainer
* [`2baed3b7`](https://github.com/NixOS/nixpkgs/commit/2baed3b75fedf2662063acfe2104e846ac513338) python311Packages.impacket: add changelog to meta
* [`19b1071f`](https://github.com/NixOS/nixpkgs/commit/19b1071fb3a24188662e13a0cf79cd3863cbd3b0) faircamp: link to CoreServices on darwin
* [`68a49bb6`](https://github.com/NixOS/nixpkgs/commit/68a49bb641302afb4b91dd2ef6660129d43220fa) cfonts: 1.1.0 -> 1.1.2
* [`fba12239`](https://github.com/NixOS/nixpkgs/commit/fba1223913fa903bf51e6b2c313bc97b9c1c93b5) linuxKernel.packages.lenovo-legion: 2023-04-02-16-53-51 -> 0.0.5
* [`4073d2cc`](https://github.com/NixOS/nixpkgs/commit/4073d2ccf8d9f8e6e2daaf14bd54f6899f9ed19e) Re-add broken Darwin
* [`854e4a2e`](https://github.com/NixOS/nixpkgs/commit/854e4a2e5329f24fd991b0a62202bd0d7fe0808f) organicmaps: 2023.06.04-13 -> 2023.08.18-8
* [`437d2069`](https://github.com/NixOS/nixpkgs/commit/437d20694c0af4e9c24be3a2eda4edb5f9b34661) yewtube: 2.10.4 -> 2.10.5
* [`1a36c263`](https://github.com/NixOS/nixpkgs/commit/1a36c263d20d34ab4f47839d4b182ec9a4a3a04a) python310Packages.python-hosts: 1.0.3 -> 1.0.4
* [`259a2d51`](https://github.com/NixOS/nixpkgs/commit/259a2d5108fb984e2bec0934b3a41f2dfd9ba453) dig: fix nix run usage
* [`0c517cc8`](https://github.com/NixOS/nixpkgs/commit/0c517cc8109e10e4856c864e6814205bcbc277f3) python311Packages.cobs: init at 1.2.0
* [`05727304`](https://github.com/NixOS/nixpkgs/commit/05727304f8815825565c944d012f20a9a096838a) anki-bin: 2.1.65 -> 2.1.66
* [`b0e96863`](https://github.com/NixOS/nixpkgs/commit/b0e96863dc12c3598f9c270200379153c609b860) python311Packages.pkg-about: init at 1.0.8
* [`a37b4688`](https://github.com/NixOS/nixpkgs/commit/a37b4688063667e17d9bd36363ccf2f942c305aa) python3Packages.pipenv-poetry-migrate: 0.3.2 -> 0.4.0
* [`ab65d8c2`](https://github.com/NixOS/nixpkgs/commit/ab65d8c2dcac39c3729727256caa1833451c8434) eksctl: 0.153.0 -> 0.154.0
* [`b5f80b41`](https://github.com/NixOS/nixpkgs/commit/b5f80b41c5c9a7ed23758b110c4de53c20a355a6) charasay: 3.0.1 -> 3.1.0
* [`caf1c274`](https://github.com/NixOS/nixpkgs/commit/caf1c274e41278f67834a721678844dfb6515693) wlroots: set default to 0.16
* [`455eddba`](https://github.com/NixOS/nixpkgs/commit/455eddbaab06c72d554c84bbbc5b42e6c3a25e90) uncover: 1.0.5 -> 1.0.6
* [`5173271c`](https://github.com/NixOS/nixpkgs/commit/5173271c3b7db299667f793462efd6272f51c22b) weaviate: 1.21.0 -> 1.21.1
* [`cff9c7a2`](https://github.com/NixOS/nixpkgs/commit/cff9c7a2a01234a1a66860ecde0025b363caf84a) pantheon.wingpanel: 3.0.3 -> 3.0.4
* [`b0f40a85`](https://github.com/NixOS/nixpkgs/commit/b0f40a85be418c569e7a984aefc14e19b47efc3e) slskd: 0.18.1 -> 0.18.2
* [`a5299340`](https://github.com/NixOS/nixpkgs/commit/a529934027c05080f544c9c4504cd2de7b4563d8) netbird-ui: 0.22.6 -> 0.22.7
* [`139c4530`](https://github.com/NixOS/nixpkgs/commit/139c45309454156581e6d5a09d5b5cc9ebc1db70) moolticute: 1.01.0 -> 1.02.0
* [`959c1b37`](https://github.com/NixOS/nixpkgs/commit/959c1b371ffa781b07767f23b8fa3ac352c04ca7) python311Packages.aiohomekit: 2.6.16 -> 3.0.1
* [`eff18386`](https://github.com/NixOS/nixpkgs/commit/eff18386fe88b8e350ff4deb2a4b70282802c6b6) elpa-packages: updated 2023-08-26 (from overlay)
* [`d751b58f`](https://github.com/NixOS/nixpkgs/commit/d751b58f9907cd5eb8d4f330f58a3b4fae296fd1) elpa-devel-packages: updated 2023-08-26 (from overlay)
* [`9e2d9858`](https://github.com/NixOS/nixpkgs/commit/9e2d98584daf64e33bd9ffe0e56318cd49852b35) melpa-packages: updated 2023-08-26 (from overlay)
* [`8761b147`](https://github.com/NixOS/nixpkgs/commit/8761b1475b9d71fc21785bf1d703179fe77af58f) nongnu-packages: updated 2023-08-26 (from overlay)
* [`69c148b7`](https://github.com/NixOS/nixpkgs/commit/69c148b755e1b564f1b126e650ccbb08726e4bb6) rssguard: 4.4.0 -> 4.5.0
* [`2bbb18a2`](https://github.com/NixOS/nixpkgs/commit/2bbb18a2ce4b59a02d68a73d607fb04c8a2e32b4) tidal-hifi: 5.6.0 -> 5.7.0
* [`41bbc2c3`](https://github.com/NixOS/nixpkgs/commit/41bbc2c311f10086fcb9f149d06eb300ab7e2a7d) flutter: Supply CA bundle in sandbox
* [`bbc7ae0b`](https://github.com/NixOS/nixpkgs/commit/bbc7ae0b8f4c5899a23eeae5e431c04f7e2c4e9c) fluffychat: Resolve dependencies for Flutter 3.13.0
* [`92e5c1fc`](https://github.com/NixOS/nixpkgs/commit/92e5c1fcec8666f6df7a14da21b5769ca03dea0d) expidus.file-manager: Resolve dependencies for Flutter 3.13.0
* [`17bc84c2`](https://github.com/NixOS/nixpkgs/commit/17bc84c2edff2a819249b3e6cb389a7ec4719555) yubioath-flutter: Upgrade to Flutter 3.13.0
* [`d5ef1bc8`](https://github.com/NixOS/nixpkgs/commit/d5ef1bc8487e35f9755b5775bc4e0435c049543c) firmware-updater: unstable-2023-06-20 -> unstable-2023-09-17, upgrade to Flutter 3.13.0
* [`f5a2f237`](https://github.com/NixOS/nixpkgs/commit/f5a2f237deed2073c8fa0440e9099ccb120fa067) flutter37: Drop
* [`98fa8a27`](https://github.com/NixOS/nixpkgs/commit/98fa8a27f655ab555a859c056b8e7396d32bd35d) flutter: Remove artifact hashes for 3.10.5 engine
* [`0606fd67`](https://github.com/NixOS/nixpkgs/commit/0606fd67326ff8684c7e88a8d44ace1d968ceba6) yubioath-flutter: Remove reference removal
* [`1dcba055`](https://github.com/NixOS/nixpkgs/commit/1dcba055e58c5d37e90adc70a26ba7dc3931567f) buildDartApplication: Supply CA bundle to Dart in FOD
* [`5684bdf6`](https://github.com/NixOS/nixpkgs/commit/5684bdf6def6d4e57723888ef462e7bf6e225dbe) xcp: 0.10.2 -> 0.12.0
* [`17f1f8e2`](https://github.com/NixOS/nixpkgs/commit/17f1f8e22153184885df9f64ad767f07bd647e31) micronaut: 4.0.4 -> 4.0.5
* [`ac349229`](https://github.com/NixOS/nixpkgs/commit/ac349229924737ac0b75cb1172fb13c940c95cc9) goa: 3.12.3 -> 3.12.4
* [`a917cde4`](https://github.com/NixOS/nixpkgs/commit/a917cde4aa5f0948c11c3bdb23977cd5e5f8a2f9) beep: add meta.mainProgam
* [`55209e51`](https://github.com/NixOS/nixpkgs/commit/55209e512b0205fa360c2f46354561c37d57e155) keycloak.scim-for-keycloak: kc-15-b2 -> kc-20-b1
* [`e0c56c89`](https://github.com/NixOS/nixpkgs/commit/e0c56c8921948f3fd70b9fe61c10ecbcc6f33716) python311Packages.asyncua: 1.0.4 -> 1.0.4
* [`3f9ea77d`](https://github.com/NixOS/nixpkgs/commit/3f9ea77d2f8f2d8fdba687667b7545519112eadd) gitoxide: 0.28.0 -> 0.29.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
