### PR TITLE
niv devenv: update 68ea687e -> f839f486

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "68ea687ed567d578543d89b47281119a3511ac08",
-        "sha256": "1xv25j6k1dq6ch4pns64hvm790nrzm47gywn7fqgb1c5ak4xvydx",
+        "rev": "f839f486b98609f3477c0410b31a6f831b390d48",
+        "sha256": "0zavaszi98jz5p7fc0lm9zjrf2fy8ygrhfh8ds1wf6k338snhgga",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/68ea687ed567d578543d89b47281119a3511ac08.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/f839f486b98609f3477c0410b31a6f831b390d48.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@68ea687e...f839f486](https://github.com/cachix/devenv/compare/68ea687ed567d578543d89b47281119a3511ac08...f839f486b98609f3477c0410b31a6f831b390d48)

* [`f1ed54ad`](https://github.com/cachix/devenv/commit/f1ed54ad6c9071d6b0d5bb0a96e86ecab37a1ff3) feat: allow to quiet output from python virtual env installation
* [`30c94723`](https://github.com/cachix/devenv/commit/30c947236eec8bfbc02e75de407c01ad58789104) containers: provide /usr/bin/env
* [`3654eb5d`](https://github.com/cachix/devenv/commit/3654eb5d47218cfa2d12280ba5ac1ace0a9dd225) Auto generate docs/reference/options.md
* [`00aed4ab`](https://github.com/cachix/devenv/commit/00aed4abf0fdfe31ea0b2e557044e2e99006e178) containers: provision ca certificates
* [`32f89b57`](https://github.com/cachix/devenv/commit/32f89b57ca513ee520fb691c572d1ccb6c85cae8) containers: set registry correctly from devenv.nix
* [`97336c7b`](https://github.com/cachix/devenv/commit/97336c7b020055f7270e3add4e701e2f72ca7555) docs(phoenix): add example for elixir phoenix
* [`78061dc3`](https://github.com/cachix/devenv/commit/78061dc39500a79a6994c887ea3950dabf23466e) fix(phoenix): handle case when installed on non-linux
* [`e782de22`](https://github.com/cachix/devenv/commit/e782de221c81f14252cc289086f6a1f91d44be44) fix(phoenix): add missing dependency rebar3
* [`8542d775`](https://github.com/cachix/devenv/commit/8542d7754b5cbb89d36bc2c983c66413bb339f84) fix(phoenix): make in-place editing compatible with macos and linux
* [`e10d6734`](https://github.com/cachix/devenv/commit/e10d6734a022589be6b1ea173f3746efb68a3a23) fix(phoenix): use unix domain socket for postgresql
* [`78766e0d`](https://github.com/cachix/devenv/commit/78766e0df9ba0ff1923511b288d0489ba2d3a077) Fix shell scripts in process-compose
* [`624397eb`](https://github.com/cachix/devenv/commit/624397ebe765337ab906842af54cafa7ea31940b) Clean up devenv info processes
* [`02458734`](https://github.com/cachix/devenv/commit/02458734ee59f19299cd6b6bd9a1c3859d71ec0e) [BUG] Use a full path `mktemp` to not leave orphans in `$DEVENV_ROOT`
