### PR TITLE
niv home-manager: update 8bde7a65 -> 886ea1d2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8bde7a651b94ba30bd0baaa9c4a08aae88cc2e92",
-        "sha256": "0c2zjrfmpdhv7r2v61p1z34r6j8gkmh6wzara1k5kmm2rak0sdvi",
+        "rev": "886ea1d213efd1082f419d066e89ef37635dc970",
+        "sha256": "1av0mdwyy7n0wsb0afwjr53dy2m9nwfgkl9wg4q9zpm8ys9xlwxg",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/8bde7a651b94ba30bd0baaa9c4a08aae88cc2e92.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/886ea1d213efd1082f419d066e89ef37635dc970.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@8bde7a65...886ea1d2](https://github.com/nix-community/home-manager/compare/8bde7a651b94ba30bd0baaa9c4a08aae88cc2e92...886ea1d213efd1082f419d066e89ef37635dc970)

* [`a7eab56b`](https://github.com/nix-community/home-manager/commit/a7eab56be526bb0c052ffe187177268efabc4808) programs.khal: add `settings` option ([nix-community/home-manager⁠#4375](https://togithub.com/nix-community/home-manager/issues/4375))
* [`f5c15668`](https://github.com/nix-community/home-manager/commit/f5c15668f9842dd4d5430787d6aa8a28a07f7c10) tests: update to match latest TOML output
* [`7ac2cd01`](https://github.com/nix-community/home-manager/commit/7ac2cd01ae5bf01e12e4517f38a89cb753c6bd6f) tmpfiles: use only `xdg.configFile`
* [`fae8af43`](https://github.com/nix-community/home-manager/commit/fae8af43e201a8929ce45a5ea46192bbd1ffff18) Translate using Weblate (Polish)
* [`8e49b883`](https://github.com/nix-community/home-manager/commit/8e49b883890ccb52c059abb152b00a416342ec1c) flake.lock: Update
* [`886ea1d2`](https://github.com/nix-community/home-manager/commit/886ea1d213efd1082f419d066e89ef37635dc970) accounts.email: fix runbox.com TLS setup ([nix-community/home-manager⁠#4408](https://togithub.com/nix-community/home-manager/issues/4408))
