### PR TITLE
niv niv: update 914aba08 -> 1d057c4a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "914aba08a26cb10538b84d00d6cfb01c9776d80c",
-        "sha256": "0gx316gc7prjay5b0cr13x4zc2pdbiwxkfkpjvrlb2rml80lm4pm",
+        "rev": "1d057c4a3a11c67a619a244e39d90d438023ecc6",
+        "sha256": "1smfsqdxf9mm1vpgpmhsji89jbzygm57jsn2414pcksz8iiyp05x",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/914aba08a26cb10538b84d00d6cfb01c9776d80c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/1d057c4a3a11c67a619a244e39d90d438023ecc6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@914aba08...1d057c4a](https://github.com/nmattia/niv/compare/914aba08a26cb10538b84d00d6cfb01c9776d80c...1d057c4a3a11c67a619a244e39d90d438023ecc6)

* [`1d057c4a`](https://github.com/nmattia/niv/commit/1d057c4a3a11c67a619a244e39d90d438023ecc6) Bump cachix/install-nix-action from 22 to 23 ([nmattia/niv⁠#375](https://togithub.com/nmattia/niv/issues/375))
