### PR TITLE
niv zsh-autosuggestions: update 9908eb49 -> 39aa7bed

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": null,
         "owner": "zsh-users",
         "repo": "zsh-autosuggestions",
-        "rev": "9908eb49a3fd18e25cfd8a0b9aa841e58429e59d",
-        "sha256": "1qqi3kxynpgjvbn20svaxbff84r3aj39n7nl33wh20ifrqxqrkp2",
+        "rev": "39aa7bed3a477af1eaa3aa72bcb6e6e616aa7dc0",
+        "sha256": "1a5zc24jyi0h8z4j8ry4yi4552w8ij2n7fiw6xwl8lzl1935cc7n",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/9908eb49a3fd18e25cfd8a0b9aa841e58429e59d.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/39aa7bed3a477af1eaa3aa72bcb6e6e616aa7dc0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-completions": {


### PR DESCRIPTION
## Changelog for zsh-autosuggestions:
Branch: master
Commits: [zsh-users/zsh-autosuggestions@9908eb49...39aa7bed](https://github.com/zsh-users/zsh-autosuggestions/compare/9908eb49a3fd18e25cfd8a0b9aa841e58429e59d...39aa7bed3a477af1eaa3aa72bcb6e6e616aa7dc0)

* [`7795a357`](https://github.com/zsh-users/zsh-autosuggestions/commit/7795a357e6dbeabe0fcfbe9cd144b93e648144ae) Install: Add Alpine Linux package
* [`c14ad9fc`](https://github.com/zsh-users/zsh-autosuggestions/commit/c14ad9fc4656066fded0d7e2eca051ff805b5abe) Update Install.md
* [`309d32ac`](https://github.com/zsh-users/zsh-autosuggestions/commit/309d32ac9ed5f68a63600d203b656b4100e5589f) Update INSTALL link for Mac OS - homebrew moved under z/
