### PR TITLE
niv zsh-completions: update 67921bc1 -> 0cee6ab5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "67921bc12502c1e7b0f156533fbac2cb51f6943d",
-        "sha256": "164jw74qlrpl6lawa4wjyhn2d04zw36ac0jsg4r6ql8769kfal8q",
+        "rev": "0cee6ab50885845464724a6501f872f842253b36",
+        "sha256": "1hw5hd0r5pvda4bkff0dkb3zxm8fflprhyl62dm6vllpgz0cx9ca",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/67921bc12502c1e7b0f156533fbac2cb51f6943d.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/0cee6ab50885845464724a6501f872f842253b36.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@67921bc1...0cee6ab5](https://github.com/zsh-users/zsh-completions/compare/67921bc12502c1e7b0f156533fbac2cb51f6943d...0cee6ab50885845464724a6501f872f842253b36)

* [`a2dae495`](https://github.com/zsh-users/zsh-completions/commit/a2dae495f788cdac2916490426038704bb185a4d) Update supervisorctl completion
* [`43a0fd3b`](https://github.com/zsh-users/zsh-completions/commit/43a0fd3b44f46f7ead4874c0f3221282571f9688) Add supervisord completion
* [`abbd9122`](https://github.com/zsh-users/zsh-completions/commit/abbd91220b76e4ec73e4aa970c77e10ee9402474) Refactoring direnv
* [`db793207`](https://github.com/zsh-users/zsh-completions/commit/db79320716c3f456f38f7629026ad5fd8341a5ee) Fix wrong initial value settings
* [`ae3a2e44`](https://github.com/zsh-users/zsh-completions/commit/ae3a2e440005fd04a88ce49d405a37326fba45bc) Fix port's cache policy function
* [`9dfd82bc`](https://github.com/zsh-users/zsh-completions/commit/9dfd82bc78d1964d28e75df604e7a16345194008) Fix broken gtk-launch completion and update
* [`76dde7cb`](https://github.com/zsh-users/zsh-completions/commit/76dde7cb7b51014e42691118aaac8f03c5812821) Refactoring port
* [`1ec2fd37`](https://github.com/zsh-users/zsh-completions/commit/1ec2fd373fd369e6151b35fb51b4d19a2a37ea7e) Update node completion to v20.6.0
