### PR TITLE
niv nixpkgs: update 62441cb5 -> 32df108c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62441cb5daf98a01b1eab80c2dd5e719fd2bd65d",
-        "sha256": "1rwl2h7ck18p4bcsyivwi57aziwzvhj7zw0zjzbcw9j2nmdsdlls",
+        "rev": "32df108c42d909b93bb06e0ddb63f6072767c912",
+        "sha256": "1bgbfiy8zsyrb5cdmffsifdh5c2bdi1xx5zjgb493cysmvi5199z",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/62441cb5daf98a01b1eab80c2dd5e719fd2bd65d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/32df108c42d909b93bb06e0ddb63f6072767c912.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@62441cb5...32df108c](https://github.com/nixos/nixpkgs/compare/62441cb5daf98a01b1eab80c2dd5e719fd2bd65d...32df108c42d909b93bb06e0ddb63f6072767c912)

* [`ea5cd9c3`](https://github.com/NixOS/nixpkgs/commit/ea5cd9c3351179063fff991e9b673c83f8458f3e) discord-gamesdk: specify `sourceProvenance`
* [`d7eb628e`](https://github.com/NixOS/nixpkgs/commit/d7eb628ee86a8383d5249cc831b2b5095164fd1d) dolphin-emu-primehack: fix name in desktop file
* [`39cabe4c`](https://github.com/NixOS/nixpkgs/commit/39cabe4c890e6be90c2787915a946f0dcccc4764) llvmPackages: remove `extend` attribute
* [`ad945416`](https://github.com/NixOS/nixpkgs/commit/ad945416620b651dce0857c75377d979e7a8ac71) fetchgit: don't shallow clone if deepClone is requested
* [`9e51ec86`](https://github.com/NixOS/nixpkgs/commit/9e51ec86e7f0ddcad75ef07bde29389af7a2d4f2) nixos/nftables: add checkRulesetRedirects option
* [`75e405c1`](https://github.com/NixOS/nixpkgs/commit/75e405c156caa918874ab00e8e6b73691a17d644) nixos/nftables: use environment.etc for redirects
* [`0ab3a1fd`](https://github.com/NixOS/nixpkgs/commit/0ab3a1fd7888ce09e480787a0c6cd11bbfc97a7e) nixos/nftables: add redirect for /etc/hosts
* [`dbed8140`](https://github.com/NixOS/nixpkgs/commit/dbed814062cc051172fd4d68fe014e8e16b95a26) fishPlugins.tide: 5.5.1 -> 5.6.0
* [`7e2c738a`](https://github.com/NixOS/nixpkgs/commit/7e2c738a2ea9b8f573fc79a96e42a6112eaf2b12) errbot: 6.1.7 -> 6.1.9
* [`eccc4d34`](https://github.com/NixOS/nixpkgs/commit/eccc4d3403cb4450db1941e99ec63c34c07763c4) tpm2-tss: remove space from patch name
* [`0984477a`](https://github.com/NixOS/nixpkgs/commit/0984477a8d296bfa05e4655b660ae507850760bb) kodiPackages.certifi: 2022.9.24 -> 2023.5.7
* [`8c7898a1`](https://github.com/NixOS/nixpkgs/commit/8c7898a108fa5a6a2daf3acee38f05b66833a53b) stegsolve: more precise license
* [`f81d0d15`](https://github.com/NixOS/nixpkgs/commit/f81d0d15fb6c9002a56754aa5a8e4d189728e0c5) bfs: 2.6.3 -> 3.0.1
* [`46383fc8`](https://github.com/NixOS/nixpkgs/commit/46383fc82bb6c7b2442889422ed62e3cafdb0161) linuxManualConfig: set badPlatforms
* [`614b6392`](https://github.com/NixOS/nixpkgs/commit/614b63922b6fd8bcc28760fa52c495f55fa35800) ubootTools: add man pages
* [`01b07afe`](https://github.com/NixOS/nixpkgs/commit/01b07afeaea778bf7612bc6720defbd563186621) temporal-cli: Disable tests on x86_64-darwin due to Rosetta 2
* [`f01cc78a`](https://github.com/NixOS/nixpkgs/commit/f01cc78af37b7a5d74e820199d96711dc4f2a2a2) hunspellDicts: add pt_PT
* [`4932b98c`](https://github.com/NixOS/nixpkgs/commit/4932b98c465202de792b5bb7a0750a9ff5514f37) crowdsec: Correct versioning flags in build
* [`f8262c2c`](https://github.com/NixOS/nixpkgs/commit/f8262c2cc6d20efd062d0b2b53db168ced639454) ceph: 17.2.5 -> 18.2.0
* [`b675aae9`](https://github.com/NixOS/nixpkgs/commit/b675aae932b2bc11ac4cc581f3a931a0e3249ed6) exim: Fix exiwhat command
* [`4337cf0e`](https://github.com/NixOS/nixpkgs/commit/4337cf0e721c18c90385660fb1366be4050b340e) lvm2: 2.03.21 -> 2.03.22
* [`23b3bf2c`](https://github.com/NixOS/nixpkgs/commit/23b3bf2c6998a5807947f680d00c7d63dd52aae8) python310Packages.pikepdf: 8.2.1 -> 8.3.0
* [`79aeeeff`](https://github.com/NixOS/nixpkgs/commit/79aeeefffadb822764c68eb16294bff7238d5bc2) tuifimanager: 3.0.0 -> 3.3.1
* [`8522d789`](https://github.com/NixOS/nixpkgs/commit/8522d789be48eb151be33f2c5053f425158ec4f2) cargo-auditable-cargo-wrapper: fix wrapper
* [`dc7cdbe4`](https://github.com/NixOS/nixpkgs/commit/dc7cdbe466be4b1b632a8d4d0be5f4a9b372b1f1) cargo-auditable-cargo-wrapper: add test
* [`3f52185d`](https://github.com/NixOS/nixpkgs/commit/3f52185de86ebe49ad46d9aee13d00f39e71a202) boot.initrd.systemd: make TPM2 modules optional
* [`dbcf59a8`](https://github.com/NixOS/nixpkgs/commit/dbcf59a84dce9752d99372967cb1b34c37cf8658) gtkgreet: add support for svg icons
* [`922e463e`](https://github.com/NixOS/nixpkgs/commit/922e463e3de6a0267a76574e8c5857de86d7f61a) soulseekqt: don’t linger in a read-only directory after installing
* [`12891a7e`](https://github.com/NixOS/nixpkgs/commit/12891a7e73887c00b49bce91143534f9a73fc25e) gtklock: add support for svg icons
* [`4ed06680`](https://github.com/NixOS/nixpkgs/commit/4ed066807b97385e39017a9a1506c36e5ea3c9d3) python310Packages.faust-cchardet: 2.1.18 -> 2.1.19
* [`67df31a8`](https://github.com/NixOS/nixpkgs/commit/67df31a8984ab3067af5b65446d2808b0aedadc6) playerctl: support cross compilation
* [`04df8d64`](https://github.com/NixOS/nixpkgs/commit/04df8d6442dbada8dfd017135d547575d4814131) make-startupitem: fix typo in comment
* [`59285ada`](https://github.com/NixOS/nixpkgs/commit/59285ada550952b1a9e5eadfa08f099a433089fe) dolphin-emu: 5.0-19368 -> 5.0-19870
* [`8fd949b7`](https://github.com/NixOS/nixpkgs/commit/8fd949b78ea141663ea4aacb3bdb52d129f4d818) exempi: 2.6.3 -> 2.6.4
* [`d991b1a9`](https://github.com/NixOS/nixpkgs/commit/d991b1a910419537ebba3259685352ff9c25af25) uptime-kuma: 1.22.1 -> 1.23.0
* [`1d5976fa`](https://github.com/NixOS/nixpkgs/commit/1d5976fa3271997a041895fcf41db5f8cd04c8e7) gawkextlib: unstable-2019-11-21 -> unstable-2022-10-20
* [`b0146128`](https://github.com/NixOS/nixpkgs/commit/b0146128dfdee0d1d9b22569a3a509a6018503e0) srisum: init at 5.0.0
* [`0b1ef8ea`](https://github.com/NixOS/nixpkgs/commit/0b1ef8ea9e8b5c35e1d48a88f6cff506a6ba432e) grocy: 4.0.0 -> 4.0.2
* [`509b5ad9`](https://github.com/NixOS/nixpkgs/commit/509b5ad9dbae637871020cd15e2d87ba6be6f194) youtube-music: Respect NIXOS_OZONE_WL
* [`55e4f1fe`](https://github.com/NixOS/nixpkgs/commit/55e4f1fea4c38928bef9db71b12010c5e6ecad38) cm256cc: pull fix pending upstream inclusion for gcc-13
* [`32cd6f0e`](https://github.com/NixOS/nixpkgs/commit/32cd6f0e304625ec803545ac97509fd8f796ec9b) linuxPackages.ena: 2.8.6 -> 2.8.9
* [`74ac8308`](https://github.com/NixOS/nixpkgs/commit/74ac830839ebe3297dafa25d36961b137325d689) protobuf: init 3.24
* [`0138e327`](https://github.com/NixOS/nixpkgs/commit/0138e327c1e3f879c22c54614476514705c04d54) grocy: clear viewcache before start
* [`2a3e20ab`](https://github.com/NixOS/nixpkgs/commit/2a3e20abeb14861b62d5d3b459573d5658c603d7) geos: pull upstream fix for gcc-13 build failure
* [`ac089967`](https://github.com/NixOS/nixpkgs/commit/ac08996721fc184b1f91613105dfbd062ac0e8a8) gradience: add glib-networking to buildInputs
* [`65fb82ba`](https://github.com/NixOS/nixpkgs/commit/65fb82bad16dab2e8ed4974255203da0e26bbff9) python311Packages.cryptography: 41.0.2 -> 41.0.3
* [`ea8fbffd`](https://github.com/NixOS/nixpkgs/commit/ea8fbffd04cb4955ce4f2f1afca2e13fc77129c8) python311Packages.cryptography-vectors: 41.0.2 -> 41.0.3
* [`307c7f49`](https://github.com/NixOS/nixpkgs/commit/307c7f49379eae127b1e036f73d638cbd5018502) ft2-clone: Apply patch to fix Darwin building
* [`30b6520d`](https://github.com/NixOS/nixpkgs/commit/30b6520d9e5486d19af0143d91008807435eab4b) python3.pkgs.pip: install man pages
* [`b1c95fb8`](https://github.com/NixOS/nixpkgs/commit/b1c95fb843374ca29684b89009a54955a22db8c5) python3Packages.pip: silence pip warning in build
* [`2b2ff201`](https://github.com/NixOS/nixpkgs/commit/2b2ff2019e44d8aabf8985dce89955a2f8678312) python3.pkgs.ruamel-base: add pythonNamespaces to remove nspkg.pth file
* [`1dbcbb2d`](https://github.com/NixOS/nixpkgs/commit/1dbcbb2d284de7b56dbb089e5a73afce0abb43aa) mopidy-soundcloud: 3.0.1 -> 3.0.2
* [`397a1afc`](https://github.com/NixOS/nixpkgs/commit/397a1afc5ba2f1fa99710c8ff0d6dda7a821f99d) habitat: 1.6.652 -> 1.6.848
* [`0d1afbfa`](https://github.com/NixOS/nixpkgs/commit/0d1afbfaf2778c9bcabb2c6778b870e1ecdf9651) habitat: add qjoly as maintainer
* [`59b0c42c`](https://github.com/NixOS/nixpkgs/commit/59b0c42c6af10aa3221d68143d726d9bd5a80c66) python310Packages.regex: 2022.10.31 -> 2023.8.8
* [`9ab635ff`](https://github.com/NixOS/nixpkgs/commit/9ab635ff4151456339a6bb31f21c5f791fcf420b) python3.pkgs.flask-limiter: update hash to reflect what's on GitHub now
* [`ecee8ebf`](https://github.com/NixOS/nixpkgs/commit/ecee8ebfb8637cceecfa6760683d37c25354eb2f) python311Packages.dnspython: 2.4.1 -> 2.4.2
* [`89091b56`](https://github.com/NixOS/nixpkgs/commit/89091b56f7919a7b4983a7114ca26bc14d8da217) kile-wl: 2021-09-30 → 2023-07-23
* [`c6cdcbc4`](https://github.com/NixOS/nixpkgs/commit/c6cdcbc4bdea2e588d8ddffc97a30886f4a63d72) addmissing beautifulsoup4 dependency
* [`3b8f3523`](https://github.com/NixOS/nixpkgs/commit/3b8f35231dd46b75f2ecd68c3f7dce16642bb40a) vcluster: 0.15.2 -> 0.15.6
* [`58f7dcd5`](https://github.com/NixOS/nixpkgs/commit/58f7dcd5c8040ad423c5016c662cff100c3a5219) valhalla: fix build with gcc 12
* [`900db7c0`](https://github.com/NixOS/nixpkgs/commit/900db7c04ef9cc23824cc27f9b533bfd1a45635e) valhalla: Fix build error relating to std::set
* [`7547f3c0`](https://github.com/NixOS/nixpkgs/commit/7547f3c0ab0b072b2ab6e3e30d1ae837883c0a18) nwg-bar: Fix display of svg icons
* [`094bfcf2`](https://github.com/NixOS/nixpkgs/commit/094bfcf23765c4f4630088fdba2bff3c3a549e9e) Reapply "python3Packages.pillow & python3Packages.pillow-simd: Fix cross compilation""
* [`e2a51f1e`](https://github.com/NixOS/nixpkgs/commit/e2a51f1e497c50809402170876b5ddf085586e74) libgit2: 1.7.0 -> 1.7.1
* [`d4c11433`](https://github.com/NixOS/nixpkgs/commit/d4c11433b850c1c8e82cf4c9913305bfd833e44b) protobuf: 3.24.1 -> 3.24.2
* [`c81ba0d2`](https://github.com/NixOS/nixpkgs/commit/c81ba0d29cc2317663a11bf5df693d6279d29fa1) discount: fix up dylib paths on darwin
* [`796ced2b`](https://github.com/NixOS/nixpkgs/commit/796ced2b2a414c7a16971c6d7fe6b63915b51a20) python311Packages.anyio: 3.7.0 -> 3.7.1
* [`25f04778`](https://github.com/NixOS/nixpkgs/commit/25f04778a873353581441d1461fae566b6274690) signal-desktop: 6.27.1 -> 6.29.1
* [`ebc420ce`](https://github.com/NixOS/nixpkgs/commit/ebc420cea1cfe52b16b1e05b010c84eaa093ce73) signal-desktop-beta: 6.24.0-beta.1 -> 6.30.0-beta.2
* [`5abaf61d`](https://github.com/NixOS/nixpkgs/commit/5abaf61d0fa88efbb36da7139c9004f63006d345) wafHook: assimilated under waf.passthru.hook
* [`100df07b`](https://github.com/NixOS/nixpkgs/commit/100df07ba59fc23419fd0826a2a9273af3514df2) ams-lv2: change wafHook to waf.hook
* [`d6f05c5c`](https://github.com/NixOS/nixpkgs/commit/d6f05c5cf5019b43280b4475f1ac4503c1d2a6d0) ardour-6: change wafHook to waf.hook
* [`04f6ad41`](https://github.com/NixOS/nixpkgs/commit/04f6ad419b58205319334e66c8f0a4fc5b823dd9) ardour: change wafHook to waf.hook
* [`6b342ad5`](https://github.com/NixOS/nixpkgs/commit/6b342ad576d0fe63c1f13846ff3251ee2449028f) fomp: change wafHook to waf.hook
* [`8dd441e6`](https://github.com/NixOS/nixpkgs/commit/8dd441e6cfbef2d5413c6440845ad36153a0adcf) guitarix: change wafHook to waf.hook
* [`500a456d`](https://github.com/NixOS/nixpkgs/commit/500a456d7cda1de8d59c840f746a6941fd699151) ingen: change wafHook to waf.hook
* [`a3e2ad55`](https://github.com/NixOS/nixpkgs/commit/a3e2ad556ea6ab1d139d2f91e57c59fc320899ee) jalv: change wafHook to waf.hook
* [`34daee39`](https://github.com/NixOS/nixpkgs/commit/34daee396d3f18d785de973de1e894a1832cc732) mda-lv2: change wafHook to waf.hook
* [`e1ded261`](https://github.com/NixOS/nixpkgs/commit/e1ded261e1c284052010cbbd2c1194f8185aadb6) non: change wafHook to waf.hook
* [`c3760fa9`](https://github.com/NixOS/nixpkgs/commit/c3760fa98a6475856c435414d9aef018a14ffc70) patchage: change wafHook to waf.hook
* [`de420719`](https://github.com/NixOS/nixpkgs/commit/de42071988daced2449d3ddb0017851b0fcca6e3) hamster: change wafHook to waf.hook
* [`6437704b`](https://github.com/NixOS/nixpkgs/commit/6437704b043cdfca7e38904d43a6725b90a05e8d) kupfer: change wafHook to waf.hook
* [`0edf0918`](https://github.com/NixOS/nixpkgs/commit/0edf0918bbdbe839ecac69ab575a85d0d344f2f6) semantik: change wafHook to waf.hook
* [`46f28863`](https://github.com/NixOS/nixpkgs/commit/46f28863df90194e75effb56e055381a3b3124c1) xfce.xfce4-namebar-plugin: change wafHook to waf.hook
* [`fb3878d3`](https://github.com/NixOS/nixpkgs/commit/fb3878d323b26505844fed0aa7c8df3afae8b596) talloc: change wafHook to waf.hook
* [`ccc75bc8`](https://github.com/NixOS/nixpkgs/commit/ccc75bc846e38e5861c4c02ec44435e98e51235e) tdb: change wafHook to waf.hook
* [`4ad2212f`](https://github.com/NixOS/nixpkgs/commit/4ad2212f1993fe3c29829eb0625ee4b0546ca4a0) tevent: change wafHook to waf.hook
* [`11b910d8`](https://github.com/NixOS/nixpkgs/commit/11b910d8c735143eb5825e690b4bf910fcbea77b) jackaudio: change wafHook to waf.hook
* [`4da1700a`](https://github.com/NixOS/nixpkgs/commit/4da1700a02b5c379ad368002b5d88cd0378946dc) nfd: change wafHook to waf.hook
* [`a10cefb3`](https://github.com/NixOS/nixpkgs/commit/a10cefb38abe5d069484d1fc5c386662276fe59f) samba4: change wafHook to waf.hook
* [`22482d87`](https://github.com/NixOS/nixpkgs/commit/22482d879b48ae45c62ac47797d55549f0296611) blockhash: change wafHook to waf.hook
* [`7bcd1ad3`](https://github.com/NixOS/nixpkgs/commit/7bcd1ad3adcc8a728c06132db59e4aaf58760742) ndn-tools: change wafHook to waf.hook
* [`7bb6472b`](https://github.com/NixOS/nixpkgs/commit/7bb6472b59345206db18ff5cfbca50af66397793) saldl: change wafHook to waf.hook
* [`b420fedf`](https://github.com/NixOS/nixpkgs/commit/b420fedfa2b4298eb1e9c3277620d244fddb007d) aubio: change wafHook to waf.hook
* [`b6b4958e`](https://github.com/NixOS/nixpkgs/commit/b6b4958ed93580ca13e9efcb847214f29165bfba) lilv: change wafHook to waf.hook
* [`d6af0d07`](https://github.com/NixOS/nixpkgs/commit/d6af0d07defe9db1bf876e43b6ddcfa18b045888) lvtk: change wafHook to waf.hook
* [`a08164d5`](https://github.com/NixOS/nixpkgs/commit/a08164d5197bf4bad6061a0a413ba44416aadca5) ntk: change wafHook to waf.hook
* [`1e9f0794`](https://github.com/NixOS/nixpkgs/commit/1e9f0794e3e5b68d53e9bc60665fdc4c5925eb72) raul: change wafHook to waf.hook
* [`63688a26`](https://github.com/NixOS/nixpkgs/commit/63688a260e7a4379dd554cc95fcbfbff1bd9d3d8) suil: change wafHook to waf.hook
* [`27022a9a`](https://github.com/NixOS/nixpkgs/commit/27022a9a22c43b4a85c4fb4ecca9835fd84986f8) ganv: change wafHook to waf.hook
* [`4d4f7031`](https://github.com/NixOS/nixpkgs/commit/4d4f70310d555ce14852c953a43ab5e82c201abc) ldb: change wafHook to waf.hook
* [`74ce9c7e`](https://github.com/NixOS/nixpkgs/commit/74ce9c7ef3c52555c3adac8c013209ac8563dd15) ndn-cxx: change wafHook to waf.hook
* [`54a729c1`](https://github.com/NixOS/nixpkgs/commit/54a729c1b0a6a5e0bead3726ae33272f7d39990d) pflask: change wafHook to waf.hook
* [`8e93a78e`](https://github.com/NixOS/nixpkgs/commit/8e93a78ef45fb8853c302a2c373fbe50f11548f3) doc/hooks/waf.section.md: change wafHook to waf.hook
* [`5e0eb2b8`](https://github.com/NixOS/nixpkgs/commit/5e0eb2b87fdbcf4e999f5cfac9bd6d36d641580a) wafHook: move to aliases.nix
* [`9121853f`](https://github.com/NixOS/nixpkgs/commit/9121853fe555c56d11b31c8e3e8215dab8a49628) vulkan-cts: Add update script
* [`b3a5a103`](https://github.com/NixOS/nixpkgs/commit/b3a5a103094ac10d551307afc82e1a21cec1948a) vulkan-cts: 1.3.6.0 -> 1.3.6.3
* [`ff8e878f`](https://github.com/NixOS/nixpkgs/commit/ff8e878f09a6c7d276ef8b2381c1999319056988) linuxPackages.vmware: w17.0.0 -> workstation-17.0.2-2023-08-12
* [`4bbc004a`](https://github.com/NixOS/nixpkgs/commit/4bbc004a216e5e24730b2c59fc5cb73456e1ac77) vmware-workstation: 17.0.0 -> 17.0.2
* [`e7fb2651`](https://github.com/NixOS/nixpkgs/commit/e7fb26513b8489efe94afd63f330dcb1568c1b77) valhalla, osmscout-server: fix build
* [`bc42935f`](https://github.com/NixOS/nixpkgs/commit/bc42935fe312aeda06b407ba02d15876f8c874e5) bespokesynth: 1.1.0 -> unstable-2023-08-17
* [`bac515fa`](https://github.com/NixOS/nixpkgs/commit/bac515fa9d2d9dce1746f1674bc8aad9193c5092) cargo-auditable-cargo-wrapper: don't wrap if cargo-auditable is meta.broken ([nixos/nixpkgs⁠#250615](https://togithub.com/nixos/nixpkgs/issues/250615))
* [`4cf8b0a6`](https://github.com/NixOS/nixpkgs/commit/4cf8b0a644da5198cc13500dca421eee9d7b4b35) libquotient: 0.8.0 -> 0.8.1.1
* [`46c3bc73`](https://github.com/NixOS/nixpkgs/commit/46c3bc73957c72c1a567fb84a1887a1e96d8f444) pufferpanel: 2.6.7 -> 2.6.9
* [`a3fdde0d`](https://github.com/NixOS/nixpkgs/commit/a3fdde0d7af9e683cf4d946551bcd500a29295e7) btcpayserver: 1.11.2 -> 1.11.3
* [`1e162f37`](https://github.com/NixOS/nixpkgs/commit/1e162f37fef709dc39de9cc4f6f094b3552f2c94) rustc: 1.71.1 -> 1.72.0
* [`146b5cde`](https://github.com/NixOS/nixpkgs/commit/146b5cde0384dac3ca64351f83c02331072be279) drogon: 1.8.3 -> 1.8.5
* [`f6d29806`](https://github.com/NixOS/nixpkgs/commit/f6d2980672440077471b9adedae46860a0701552) drogon: 1.8.5 -> 1.8.6
* [`2eeb227d`](https://github.com/NixOS/nixpkgs/commit/2eeb227d778ac0b90e9cae03247b610c2ada8314) gcc: move dll to output
* [`cc9ac45f`](https://github.com/NixOS/nixpkgs/commit/cc9ac45f18a864fc112e8fa35a617722b10f673e) libxcrypt: Fix windows cross
* [`783e4dcb`](https://github.com/NixOS/nixpkgs/commit/783e4dcba8384b6082220466fc4e6c631e7f2293) xorg.xorgproto: Fix windows cross
* [`13dd91e3`](https://github.com/NixOS/nixpkgs/commit/13dd91e301c487e53a5c9f902d645ac273f86b90) xorg.libxcb: fix mingw cross
* [`22e67d38`](https://github.com/NixOS/nixpkgs/commit/22e67d38f242efded994d2f85af989a41e57f3e9) drogon: fix cross-compiling
* [`6ea1c15e`](https://github.com/NixOS/nixpkgs/commit/6ea1c15e35d36bd4924c33b98ce718335d07d0ea) xorg.libpthreadstubs: add windows to platforms
* [`8f2c75b2`](https://github.com/NixOS/nixpkgs/commit/8f2c75b260661a8385d75499bea7efcf05a4c4ad) vim: 9.0.1642 -> 9.0.1811
* [`b0312f6d`](https://github.com/NixOS/nixpkgs/commit/b0312f6dafdd4dd357d93ec07b3e34698dde956d) nodejs_18: backport v8 trap handler conditional compilation
* [`deb5cc6d`](https://github.com/NixOS/nixpkgs/commit/deb5cc6dc8a300ef9d64252445329f288869440e) nodejs: do not pass --without-snapshot
* [`3751f6ab`](https://github.com/NixOS/nixpkgs/commit/3751f6abb015d6141f33acd82ef7a55e76a02217) nodejs_{18,20}: fix cross compilation from aarch64-linux
* [`80e825ed`](https://github.com/NixOS/nixpkgs/commit/80e825ede84cd9b5b04db94b7173041d22156838) nodejs: do not run patchShebangs with build inputs
* [`f6b56c91`](https://github.com/NixOS/nixpkgs/commit/f6b56c9136e9f60ec6befc1ea1e9b1725b8f8f33) nodejs: install shell completions and man pages when cross-compiling
* [`51d74ca1`](https://github.com/NixOS/nixpkgs/commit/51d74ca18f35aafc63b44fa8bf5b65ecd8cedee5) nodejs: mark as broken when cross-compiling for different OS
* [`608c96ee`](https://github.com/NixOS/nixpkgs/commit/608c96eefc876a8db5785cfb8d6fb8789f5a61f6) nodejs: run a subset of test suite
* [`c66389c6`](https://github.com/NixOS/nixpkgs/commit/c66389c6e1d8b1f08c9c8fbda0fdcf9436088b87) nodejs: remove no-op postPatch phase
* [`d9dc4b0a`](https://github.com/NixOS/nixpkgs/commit/d9dc4b0a0752aa26cece191e1ca6f7ef3b01210e) nodejs: patch shebangs for shell scripts when cross-compiling
* [`e4d6d1b0`](https://github.com/NixOS/nixpkgs/commit/e4d6d1b05b39ae31db8f16a1e3e0bfb39d764771) nodejs: cross-compile with icu
* [`e29c3309`](https://github.com/NixOS/nixpkgs/commit/e29c3309399b7d7ef8f606c300cd973da40012f2) nodejs: use fetchpatch for cross-compilation patches
* [`65ff987f`](https://github.com/NixOS/nixpkgs/commit/65ff987f802042659f9a3a1f8000182a5a9cd7ee) nodejs: set strictDeps and patch bash shebangs
* [`2c884115`](https://github.com/NixOS/nixpkgs/commit/2c88411556d0cc612b31e2d12cd30c82bd5a996e) nodejs_20: remove upstreamed patch
* [`24a612e4`](https://github.com/NixOS/nixpkgs/commit/24a612e4e3c60e56149d8d139a294fd5c9a209e4) libsndfile: enable tests
* [`e371c0c3`](https://github.com/NixOS/nixpkgs/commit/e371c0c30042873f5bcbc91b0a1196daab3d8f93) libsndfile: add some key reverse-dependencies to passthru.tests
* [`dbe7ef1d`](https://github.com/NixOS/nixpkgs/commit/dbe7ef1d350575dab964d9dd7e3d839d3311e709) fortify-headers: 1.1alpine1 -> 1.1alpine3
* [`110fec86`](https://github.com/NixOS/nixpkgs/commit/110fec86264a9a3b9efcb9909baa6f41b8e5c26f) python3Packages.python-jenkins: 1.7.0 -> 1.8.1
* [`4ec3ee59`](https://github.com/NixOS/nixpkgs/commit/4ec3ee592e7474284c657172d558a93aa1f3fae9) libmbim: backport Intel mutual authentication and intel tools patches
* [`40c633b4`](https://github.com/NixOS/nixpkgs/commit/40c633b4556beb863e0f8790b84561cd4307aa9d) yuzu: add missing unzip tool
* [`582e30fb`](https://github.com/NixOS/nixpkgs/commit/582e30fb299b5fdf078db0a7029cb2e7261d0171) wasabiwallet: 2.0.3 -> 2.0.4
* [`097d5918`](https://github.com/NixOS/nixpkgs/commit/097d59184b593017639cb6ccce46b584b0362e5f) windows.dlfcn: init at 1.3.1
* [`fa5c7c19`](https://github.com/NixOS/nixpkgs/commit/fa5c7c1916d2fd8796f4b86d6d19d5676bb22119) elixir_1_15: 1.15.4 -> 1.15.5
* [`cb498323`](https://github.com/NixOS/nixpkgs/commit/cb498323ae2bf73e8047889691afcb3fec4028b7) Remove dotnet dependency
* [`ac6c6c0e`](https://github.com/NixOS/nixpkgs/commit/ac6c6c0ed4d69d2b3282ad22926ef8b64107dce6) cargo-c: 0.9.22 -> 0.9.23
* [`72aee237`](https://github.com/NixOS/nixpkgs/commit/72aee2374d06cba8991e7fd2a80d2f28da123514) cargo-c: 0.9.23 -> 0.9.24
* [`397a55ac`](https://github.com/NixOS/nixpkgs/commit/397a55ac9f0b0bfa98305d30daf09924cacc81ea) audit: 3.1.1 -> 3.1.2
* [`172e7570`](https://github.com/NixOS/nixpkgs/commit/172e7570a1fa212bf7b02c6bf2f98fe86ef06330) ferretdb: 1.8.0 -> 1.9.0
* [`3d4e0708`](https://github.com/NixOS/nixpkgs/commit/3d4e0708a0559fa3ff63fe45f30f2b564fceb7e1) gcc: move dll.a in lib64 to lib output too
* [`5dccbfa3`](https://github.com/NixOS/nixpkgs/commit/5dccbfa32d5e90e283eb1a435cec358fded4fd30) systemd: add firstboot and sysusers
* [`28ef9ebc`](https://github.com/NixOS/nixpkgs/commit/28ef9ebcad9e2af9507e3c882c39d2766eef89e5) monado: unstable-2023-01-14 -> unstable-2023-08-22
* [`34c4db57`](https://github.com/NixOS/nixpkgs/commit/34c4db5741f1b3e1b374eb914d74566a64f1a6ee) k3d: 5.5.2 -> 5.6.0
* [`1820a048`](https://github.com/NixOS/nixpkgs/commit/1820a0482b8f8bda4ce38f56029b5c40b0fd95fd) localstack: 1.4.0 -> 2.2.0
* [`c625ae7c`](https://github.com/NixOS/nixpkgs/commit/c625ae7ca5cb4853fd674f647908190f0d51c036) outline: 0.70.2 -> 0.71.0
* [`059d0f24`](https://github.com/NixOS/nixpkgs/commit/059d0f24f24d783040a30e44c16759f789f0b676) dart-sass: update dart-pub dependencies
* [`f7fdc2ea`](https://github.com/NixOS/nixpkgs/commit/f7fdc2eab3f7473d19cd5a99f86fdb54be02d57f) protoc-gen-dart: 2.1.0 -> 3.1.0
* [`afa60f52`](https://github.com/NixOS/nixpkgs/commit/afa60f520761d2a293128e0d1b771fb203731fd8) pipewire: 0.3.78 -> 0.3.79
* [`047bef69`](https://github.com/NixOS/nixpkgs/commit/047bef69a0686d672ef8d85d41ff5c8695446a83) python3Packages.pytimeparse2: init at 1.7.1
* [`afabeca0`](https://github.com/NixOS/nixpkgs/commit/afabeca0a9d2c216b09ab6465f54796dc877a4ca) python3Packages.mysql-connector: 8.0.29 -> 8.0.33
* [`13920df8`](https://github.com/NixOS/nixpkgs/commit/13920df8bc8449fc2c3845e153aa782f836898bc) sqlite3-to-mysql: 1.4.19 -> 2.0.3
* [`3d457083`](https://github.com/NixOS/nixpkgs/commit/3d4570836c526bbac20ff3c5c9ff3a2102fb92c0) python310Packages.dunamai: 1.16.0 -> 1.18.0
* [`b522470d`](https://github.com/NixOS/nixpkgs/commit/b522470d14812144f6d317d2c356e99e1ff8ceff) python310Packages.poetry-dynamic-versioning: 0.21.5 -> 1.0.1
* [`a55496d2`](https://github.com/NixOS/nixpkgs/commit/a55496d2220cffa00802cf3d1dea6dcb5602ae45) git-up: 1.6.1 -> 2.2.0
* [`6a6f2b53`](https://github.com/NixOS/nixpkgs/commit/6a6f2b535c8c0439d71ff185d49472f499fac0ed) workcraft: 3.4.0 -> 3.4.1
* [`cec0c13f`](https://github.com/NixOS/nixpkgs/commit/cec0c13f9e9a3a69d935d8a9d01579d1506e2a7a) kpcli: 3.8.1 -> 4.0
* [`ced869e5`](https://github.com/NixOS/nixpkgs/commit/ced869e53757ff87edcacddf87bd4edb450719d5) python310Packages.pytest-quickcheck: unbreak and enable tests
* [`172e1980`](https://github.com/NixOS/nixpkgs/commit/172e1980cbc307f52230ff83709cdbda53ffc87f) gixy: use nose3 for python 3.11 compatibility
* [`33802217`](https://github.com/NixOS/nixpkgs/commit/33802217ecc1f57d9e0d6221fc36483b730fe6bb) grin: use nose3 for python 3.11 compatibility
* [`c0158e9c`](https://github.com/NixOS/nixpkgs/commit/c0158e9c47d00533610e0a1d579c2f5e1c5ceb25) dosfstools: backport reproducible builds patch
* [`12ce5527`](https://github.com/NixOS/nixpkgs/commit/12ce5527d709515a2ee94e74d65d5edca2069abd) chez: 9.5.8a -> 9.6.2
* [`38e5440a`](https://github.com/NixOS/nixpkgs/commit/38e5440ae42a06d0be5000d298e6c4acde176cda) dioxus-cli: 0.3.2 -> 0.4.0
* [`7209bb10`](https://github.com/NixOS/nixpkgs/commit/7209bb10582cd86ac2e329435dd5e66b05c21151) wolfram-engine: add 13.3.0
* [`6c5d6e21`](https://github.com/NixOS/nixpkgs/commit/6c5d6e211f841c9a1eea90393bd6d4229433e0f8) harmonia: 0.7.1 -> 0.7.2
* [`ac6948d3`](https://github.com/NixOS/nixpkgs/commit/ac6948d37ae076d2d0dd952004a22d46ceb739b1) hitch: 1.7.3 -> 1.8.0
* [`60241e28`](https://github.com/NixOS/nixpkgs/commit/60241e28b4630128a632441b420f3915419ed53c) ldtk: 1.3.3 -> 1.3.4
* [`40654da9`](https://github.com/NixOS/nixpkgs/commit/40654da9cfb3517c10f103f4b6a9a2c2e903ce80) fldigi: 4.1.26 -> 4.1.27
* [`be7ba211`](https://github.com/NixOS/nixpkgs/commit/be7ba211942f0316ac135010f884587def853189) ananicy-cpp: 1.1.0 -> 1.1.1
* [`b167e0cb`](https://github.com/NixOS/nixpkgs/commit/b167e0cb88ff5a72fd755c40659f0564a7b35f6c) nss_latest: 3.92 -> 3.93
* [`a2e3cf7e`](https://github.com/NixOS/nixpkgs/commit/a2e3cf7ef3f878ba2e19c778460343d4d3df8187) apptainer: 1.1.7 -> 1.2.2
* [`6a6c30df`](https://github.com/NixOS/nixpkgs/commit/6a6c30dfc11e7c0d6eee912f1382e5d447e6db09) singularity-ce: 3.11.1 -> 3.11.4
* [`ee4f4ad1`](https://github.com/NixOS/nixpkgs/commit/ee4f4ad14c6940363fdae16771b555159d97da46) python3Packages.magic-wormhole-mailbox-server: disable tests darwin
* [`6c94b44f`](https://github.com/NixOS/nixpkgs/commit/6c94b44f10745486eaa24d35547506637b719bd3) python3Packages.magic-wormhole: disable some tests darwin
* [`535aeb83`](https://github.com/NixOS/nixpkgs/commit/535aeb830337ff63d28f9651055ab614497bc8b8) ledger-live-desktop: 2.64.2 -> 2.66.0
* [`1086f093`](https://github.com/NixOS/nixpkgs/commit/1086f093a94d57e5ce1db60407a7fdcf1ea047d2) win-dll-links: also copy dll from dependencies
* [`9c6b8300`](https://github.com/NixOS/nixpkgs/commit/9c6b83001df255b402638fc3f49f961b9b3ac267) anytype: wayland support
* [`bbaa00d7`](https://github.com/NixOS/nixpkgs/commit/bbaa00d7af3eb728643586da503231ccc2d85ae5) ocenaudio: 3.12.5 -> 3.12.6
* [`2127f215`](https://github.com/NixOS/nixpkgs/commit/2127f215e0e5154defdfd3221f63afef2bf00b60) khard: add manpages to output
* [`fe1afb81`](https://github.com/NixOS/nixpkgs/commit/fe1afb817c42636bed6fa4a35a75df75223fa63d) vimPlugins: update
* [`eecbc4d7`](https://github.com/NixOS/nixpkgs/commit/eecbc4d783d55ae4b2fa9b926c5a6edad5da2ae2) vimPlugins.nvim-treesitter: update grammars
* [`32e0283e`](https://github.com/NixOS/nixpkgs/commit/32e0283e7e726caf26464df6b66eb79583b5458c) miriway: unstable-2023-04-25 -> unstable-2023-07-07
* [`eb9139e9`](https://github.com/NixOS/nixpkgs/commit/eb9139e9d7354f2d78763da78e4f921d04872488) miriway: unstable-2023-07-07 -> unstable-2023-07-27
* [`5a619b15`](https://github.com/NixOS/nixpkgs/commit/5a619b154de591749bdf5db9887826122d23c894) vimPlugins.tabout-nvim: init at 2023-03-29
* [`8ea64223`](https://github.com/NixOS/nixpkgs/commit/8ea642233e2fc98429a68073c9c55951c551c63d) vimPlugins: update
* [`135c253b`](https://github.com/NixOS/nixpkgs/commit/135c253bf5276436f5f5760e30ddf19623beaf09) liblinphone: 5.2.17 -> 5.2.98
* [`58a47651`](https://github.com/NixOS/nixpkgs/commit/58a476519e5878ae1467452e15c77dd913c21fe2) timetrap: add shell completions
* [`c1f26cac`](https://github.com/NixOS/nixpkgs/commit/c1f26cac27c78942f0e61a1fff6cdc4a63f02960) libfprint: 1.94.5 -> 1.94.6
* [`444da4c5`](https://github.com/NixOS/nixpkgs/commit/444da4c576d104ce8727fcd4375f4c25ae2ba3e5) maintainers: add mbalatsko
* [`3042545a`](https://github.com/NixOS/nixpkgs/commit/3042545ab400f4feb1452e7f6e3d22577c906c9d) bitmask-vpn: 0.21.6 -> 0.21.11
* [`bdce9a2b`](https://github.com/NixOS/nixpkgs/commit/bdce9a2bc24462430553415ee6b00017a24059cb) emacs: fix build on x86_64-darwin
* [`83922839`](https://github.com/NixOS/nixpkgs/commit/83922839dcd32494d334d035ec65ccab00a43ce2) maim: set meta.mainProgram
* [`a04ec10a`](https://github.com/NixOS/nixpkgs/commit/a04ec10ad3eded85f8a638472b0422551fc3c59b) python3Packages.beautiful-date: init at 2.2.0
* [`7b42c82b`](https://github.com/NixOS/nixpkgs/commit/7b42c82b10ba6097389842c610118f9a32875a45) python311Packages.gitpython: 3.1.32 -> 3.1.33
* [`9843cf30`](https://github.com/NixOS/nixpkgs/commit/9843cf30fb4dff195f852dd66ade8ea1b584342e) python310Packages.awscrt: 0.19.0 -> 0.19.1
* [`637b93ca`](https://github.com/NixOS/nixpkgs/commit/637b93ca3fb3a8af97edf2a280622000e9aef84d) strace: 6.4 -> 6.5
* [`56f1e95e`](https://github.com/NixOS/nixpkgs/commit/56f1e95e095d56d1184e405d3c114afa8473332a) buildMix: use C.UTF-8 locale
* [`c4a9adf7`](https://github.com/NixOS/nixpkgs/commit/c4a9adf735182e4e8dcbfda34a7c8965f7786592) birdtray: 1.9.0 -> 1.11.3
* [`6486bfb8`](https://github.com/NixOS/nixpkgs/commit/6486bfb81e50c72fa090a7409560942de84c6afa) upscayl: 2.5.5 -> 2.7.5
* [`5a78c87b`](https://github.com/NixOS/nixpkgs/commit/5a78c87b194ddc1c0d427f9d15a2bf6b44892ed4) bambootracker,bambootracker-qt6: 0.6.2 -> 0.6.3
* [`08749678`](https://github.com/NixOS/nixpkgs/commit/08749678c0029fcaa2bf850988039c0b13ca4cfe) python310Packages.python-manilaclient: 4.5.1 -> 4.6.0
* [`87ee7d31`](https://github.com/NixOS/nixpkgs/commit/87ee7d31d4839850c0f806ba45f152a5219efe8e) mixRelease: use C.UTF-8 locale
* [`d1774357`](https://github.com/NixOS/nixpkgs/commit/d1774357eb6573f38bc74b11b82897a0a5d3e4be) staruml: fix url
* [`aa2f2dd7`](https://github.com/NixOS/nixpkgs/commit/aa2f2dd7df771a8c94b7f92d2ca09789e7525a1e) anki: refactor
* [`5ccdb37a`](https://github.com/NixOS/nixpkgs/commit/5ccdb37a8b1f17a9d2c5e77b46f156826bbada54) anki: 2.1.65 -> 2.1.66
* [`d0decc53`](https://github.com/NixOS/nixpkgs/commit/d0decc53e9776bb3abd443a4506931137f8d19ad) dae: 0.2.4 -> 0.3.0
* [`02918d98`](https://github.com/NixOS/nixpkgs/commit/02918d98b2c410972ff594236a3288930ff12b4d) Lamdera: 1.1.0 -> 1.2.0
* [`173ff5d2`](https://github.com/NixOS/nixpkgs/commit/173ff5d2dd09a27a209babe3a6803a17028d07f3) nixos/dae: add more config options
* [`8f070876`](https://github.com/NixOS/nixpkgs/commit/8f070876da873e8b26480a95945dad369b2bd73a) nixos/dae: add confgFile option
* [`5ab45102`](https://github.com/NixOS/nixpkgs/commit/5ab4510232f561100a3d35a6740f2c1cbaaab1b3) nixos/budgie: Use the Network Manager Applet indicator
* [`17e38620`](https://github.com/NixOS/nixpkgs/commit/17e386205b4bb0f36b87ec8e6ca4006131efbe20) nixos/dae: add basic test
* [`e54143b3`](https://github.com/NixOS/nixpkgs/commit/e54143b3dfb3b4f296026d5745488cd1724b8a74) python310Packages.bytecode: 0.14.2 -> 0.15.0
* [`4f3085c7`](https://github.com/NixOS/nixpkgs/commit/4f3085c78837405639b38d2fcc49a6ec76ab1ffa) maintainers: add p-rintz
* [`fba2be0a`](https://github.com/NixOS/nixpkgs/commit/fba2be0a14230846f717a3f743b2545c60ec04de) pocket-updater-utility: init at 2.31.0
* [`c1db61de`](https://github.com/NixOS/nixpkgs/commit/c1db61decda8332a63cb75430960f76813e24a63) nomad_1_4: 1.4.6 -> 1.4.12
* [`6df23bec`](https://github.com/NixOS/nixpkgs/commit/6df23bec96e173e3005f687c2cc83437bcc47b7a) nomad_1_2, nomad_1_3: remove
* [`053e6957`](https://github.com/NixOS/nixpkgs/commit/053e69578fc1b2845ce3b768bd55a75588fe8b6e) nixos/testing/driver: Copy cross fix from `modules/misc/nixpkgs.nix`
* [`c0b3521e`](https://github.com/NixOS/nixpkgs/commit/c0b3521ea96145b9d3aec077debebfc6e5a696fd) chessx: 1.5.8 -> 1.6.0
* [`8c7a4fdb`](https://github.com/NixOS/nixpkgs/commit/8c7a4fdb2584f5427c10f2f187f92a3411d23576) chessx: replace rec with finalAttrs idiom
* [`e66d4940`](https://github.com/NixOS/nixpkgs/commit/e66d4940421639c89ecb532a8f86958ddbee5c7e) pysensation: init at 1.0.0
* [`9a4f4fd9`](https://github.com/NixOS/nixpkgs/commit/9a4f4fd961d7317347cec8cd138b72772064ca87) riemann_c_client: 1.10.5 -> 2.1.1
* [`42cd0173`](https://github.com/NixOS/nixpkgs/commit/42cd017335733c3e982a307c9e2b17dcbcb9bd16) smb3-foundry: 1.2 -> 1.3.1
* [`9ceb6108`](https://github.com/NixOS/nixpkgs/commit/9ceb6108ec2c51196e0eefef4e36f98a58de3582) libblockdev: 3.0.2 -> 3.0.3
* [`81ae5f2c`](https://github.com/NixOS/nixpkgs/commit/81ae5f2ce50f77acb8b60b1c1b7de2bb6c978325) pscale: 0.153.0 -> 0.154.0
* [`69953bf9`](https://github.com/NixOS/nixpkgs/commit/69953bf91bd97417ac16a4a4396098d9131a361d) python310Packages.sklearn-deap: 0.2.3 -> 0.3.0
* [`ab4c60fe`](https://github.com/NixOS/nixpkgs/commit/ab4c60fe7877bb63999b57e5f3b969a6e3b8d982) python310Packages.astropy-healpix: 0.7 -> 1.0.0
* [`4a65ac39`](https://github.com/NixOS/nixpkgs/commit/4a65ac398b822a8e3572d2764a0b5f47ccc0c27b) python310Packages.sklearn-deap: refactor
* [`ec0755d5`](https://github.com/NixOS/nixpkgs/commit/ec0755d5f74a274d204d1b2fc5cdb95a4667efb9) nixos/dae: add example link
* [`84908688`](https://github.com/NixOS/nixpkgs/commit/8490868860c9a411ab2629789fb0bed0da229879) aardvark-dns: skip a broken test (for now)
* [`f68f55c9`](https://github.com/NixOS/nixpkgs/commit/f68f55c9f01c761ebe1939d5310fa09d0ed42bc3) conceal: 0.3.2 -> 0.4.1
* [`5ee40b84`](https://github.com/NixOS/nixpkgs/commit/5ee40b84ccda195b6ed5264fa8b2713a856b6751) exiv2: fix build on armv7l-linux
* [`6cfa5c53`](https://github.com/NixOS/nixpkgs/commit/6cfa5c532d532e33903a9ee6f2459adb4d5c0cfd) inotify-tools: 3.22.6.0 -> 4.23.8.0
* [`48a0c7d7`](https://github.com/NixOS/nixpkgs/commit/48a0c7d771b9d419bf5fad150fd844ed529fbca5) cryptowatch-desktop: 0.5.0 -> 0.7.1
* [`57df80f0`](https://github.com/NixOS/nixpkgs/commit/57df80f0b43ee1c18d7146e88ddc3ed8de7ffbab) python310Packages.mautrix: 0.20.0 -> 0.20.1
* [`69596874`](https://github.com/NixOS/nixpkgs/commit/69596874f16acc9cc93560e05ae5974758afc8ea) nixos/mautrix-telegram: drop removed --base-config flag
* [`da72738d`](https://github.com/NixOS/nixpkgs/commit/da72738d891edb6064b8aa90c4a8569154259a62) bindle: 0.8.1 -> 0.9.1
* [`ed12decb`](https://github.com/NixOS/nixpkgs/commit/ed12decbebf1ceff4f870bb4c9097c1dceda81ce) python310Packages.dataclass-factory: init at 2.13
* [`c887a8e3`](https://github.com/NixOS/nixpkgs/commit/c887a8e3fb996fcffea1c02ace915eeda9556020) pylyzer: 0.0.41 -> 0.0.42
* [`3163d1f3`](https://github.com/NixOS/nixpkgs/commit/3163d1f389a25b90ee5a9c68b9caa17e73068f81) python310Packages.steamship: 2.17.22 -> 2.17.27
* [`c032a3d0`](https://github.com/NixOS/nixpkgs/commit/c032a3d0c88822fe4093c1666e711b97bde5a576) python310Packages.shazamio: init at 0.4.0.1
* [`03763976`](https://github.com/NixOS/nixpkgs/commit/037639761100817b4e4a4717c23f1e1266a09db4) shaq: init at 0.0.1
* [`8730ee44`](https://github.com/NixOS/nixpkgs/commit/8730ee441abaed5e505002951094f8289ddd341f) python310Packages.b2sdk: add changelog to meta
* [`78f30804`](https://github.com/NixOS/nixpkgs/commit/78f308049e61c533f20977f49969fd6d59a8d909) shaq: add mig4ng to maintainers
* [`1a8886c0`](https://github.com/NixOS/nixpkgs/commit/1a8886c0ba86d90a0ce3aead4a108b0a0b23d3ab) code-maat: init at 1.0.3
* [`334893d9`](https://github.com/NixOS/nixpkgs/commit/334893d9e94218be5e100dad328323bca377e519) multiviewer-for-f1: 1.26.4 -> 1.26.6
* [`511eecaa`](https://github.com/NixOS/nixpkgs/commit/511eecaa073dcff03fa8abb9e96658c3b565d898) xmedcon: add wrapGAppsHook
* [`1375f052`](https://github.com/NixOS/nixpkgs/commit/1375f052e426e683939b775968a55e23cf046783) xmedcon: update project homepage
* [`e932745c`](https://github.com/NixOS/nixpkgs/commit/e932745cb865454a3c97c846a35f8ec02d73c61d) nixos/mautrix-whatsapp: fix docbook description
* [`1a9944f3`](https://github.com/NixOS/nixpkgs/commit/1a9944f36dd48a23ea2f1615a65a59e53b96e2ea) python311Packages.cwl-upgrader: 1.2.8 -> 1.2.9
* [`4321787a`](https://github.com/NixOS/nixpkgs/commit/4321787acd2afabe0540d713b646f29bcbabdb5f) python311Packages.cwl-utils: 0.28 -> 0.29
* [`1087417b`](https://github.com/NixOS/nixpkgs/commit/1087417b1485d0cf7c50ca894c5624779a291db6) eww: unstable-2023-06-10 -> unstable-2023-08-18
* [`44d193a0`](https://github.com/NixOS/nixpkgs/commit/44d193a01b5d4a0c3343199e300b1837a0d0cea2) maintainers: add smona
* [`3727f253`](https://github.com/NixOS/nixpkgs/commit/3727f2536df52d2cc758b11d90452b657a432a13) imhex: 1.29.0 -> 1.30.1
* [`718a40cd`](https://github.com/NixOS/nixpkgs/commit/718a40cd48212a606bb2b57181054ae7e8a3fc5f) leo-editor: 6.7.3 -> 6.7.4
* [`9e045711`](https://github.com/NixOS/nixpkgs/commit/9e0457115e7eb3f106b9ea60ab3ca92daed5b03f) nixos/mautrix-whatsapp: use  static user and group
* [`9ee75852`](https://github.com/NixOS/nixpkgs/commit/9ee75852d207067c0b1c72663336efd5300e51e7) budgie.budgie-gsettings-overrides: Update defaults
* [`f195dcec`](https://github.com/NixOS/nixpkgs/commit/f195dceceb3289c98d3903a1b8f8e12981fe39d3) tidalapi: drop myself (rodrgz) as maintainer
* [`69bd38ca`](https://github.com/NixOS/nixpkgs/commit/69bd38ca882dab3b659a4c504ab42ab008a878cc) mopidy-tidal: drop myself (rodrgz) as maintainer
* [`245e0846`](https://github.com/NixOS/nixpkgs/commit/245e08466695448d727f466e194c60a3374c7e89) asusctl: 4.7.0 -> 4.7.1
* [`d928a8d6`](https://github.com/NixOS/nixpkgs/commit/d928a8d6d9c232834979fbab9efe3c1df359f8a0) bitwarden-menu: drop myself (rodrgz) as maintainer
* [`035f9051`](https://github.com/NixOS/nixpkgs/commit/035f90512492114e001f54438a47614d69da23e0) nixos/mautrix-whatsapp: fix merging of default settings
* [`5fc70937`](https://github.com/NixOS/nixpkgs/commit/5fc70937a127092c48645d6f5061c0be9d45c69a) nixos/mautrix-whatsapp: set default homeserver address
* [`4fb82121`](https://github.com/NixOS/nixpkgs/commit/4fb8212162e1e90489412ab2ddabe6fcfdcce341) nixos/mautrix-whatsapp: log to the journal only
* [`bc6d8df4`](https://github.com/NixOS/nixpkgs/commit/bc6d8df46e3af8e1f5db7dc3ba56c385bf419f1c) betterlockscreen: 4.0.4 -> 4.2.0
* [`a0463e87`](https://github.com/NixOS/nixpkgs/commit/a0463e87b3fb903e4d64010bbcad8e9a16dad787) zon2nix: 0.1.1 -> 0.1.2
* [`2b2cb749`](https://github.com/NixOS/nixpkgs/commit/2b2cb749d66122a849a41d62e123935011e3ab85) v2ray-domain-list-community: 20230825070717 -> 20230902035830
* [`d0d2a84f`](https://github.com/NixOS/nixpkgs/commit/d0d2a84f6a1a9c500d09aee353e9735e08a988fe) gama: 2.24 -> 2.25
* [`2c39c216`](https://github.com/NixOS/nixpkgs/commit/2c39c216f6ee98690076948ec037f081ba7c4848) editorconfig-checker: 2.7.0 -> 2.7.1
* [`66e7520c`](https://github.com/NixOS/nixpkgs/commit/66e7520c903b85e6f6ae17ca6899025516db4302) python311Packages.uptime-kuma-api: 1.1.0 -> 1.2.0
* [`ca297a76`](https://github.com/NixOS/nixpkgs/commit/ca297a76d5dce2026943f51f504f7e2a89a96d1c) yor: 0.1.183 -> 0.1.185
* [`9a3fc4f7`](https://github.com/NixOS/nixpkgs/commit/9a3fc4f78bdad83b134a753645ce27d093c5a2c8) gremlin-console: 3.6.4 -> 3.7.0
* [`3327f3dd`](https://github.com/NixOS/nixpkgs/commit/3327f3dd81f549f6cd7daedb1799f53294cb5473) entr: 5.2 -> 5.4
* [`300cc1bd`](https://github.com/NixOS/nixpkgs/commit/300cc1bdad8e1219fa917306b602bae85a4ecf28) gex: 0.6.2 -> 0.6.3
* [`93f70364`](https://github.com/NixOS/nixpkgs/commit/93f70364095ec2a3bbede24fc8b474dd78b261d6) veilid: 0.2.0 -> 0.2.1
* [`a481f7cc`](https://github.com/NixOS/nixpkgs/commit/a481f7cc2b79f2f0547aef57fdf59f57d7a84109) fwts: 23.05.00 -> 23.07.00
* [`a69062ae`](https://github.com/NixOS/nixpkgs/commit/a69062aebc6b47115cb7731629a2b42a237b412f) treesheets: unstable-2023-08-17 -> unstable-2023-08-31
* [`9624bf57`](https://github.com/NixOS/nixpkgs/commit/9624bf57366d27bfd686b113c57b5a7dcc88f0ed) ldid-procursus: install zsh completion
* [`669ca2d9`](https://github.com/NixOS/nixpkgs/commit/669ca2d92d8439d8c1d7f9554eaeb965f70c6fe8) charles4: 4.6.2 -> 4.6.4
* [`3b312533`](https://github.com/NixOS/nixpkgs/commit/3b3125338b7bbbc6b5103de80ae500656312f14d) k3sup: 0.12.15 -> 0.13.0
* [`8ccbd9fd`](https://github.com/NixOS/nixpkgs/commit/8ccbd9fd3dc6ba9636ac9b92bea0366b974f3066) k8sgpt: 0.3.13 -> 0.3.14
* [`0f847958`](https://github.com/NixOS/nixpkgs/commit/0f847958a5c7cc82484155a6739f9ba8ac1ce540) kaniko: 1.14.0 -> 1.15.0
* [`cad449e0`](https://github.com/NixOS/nixpkgs/commit/cad449e0652f524c84ff0a200b2f72072a929bba) karmor: 0.13.13 -> 0.13.15
* [`df5202c2`](https://github.com/NixOS/nixpkgs/commit/df5202c24cc5140ef0c9a891bf31875da8c2178d) python310Packages.python-swiftclient: 4.3.0 -> 4.4.0
* [`58fb5c35`](https://github.com/NixOS/nixpkgs/commit/58fb5c35bd3fb3177211aeb94134601813431a1a) eza: 0.10.9 -> 0.11.0
* [`0a9b1beb`](https://github.com/NixOS/nixpkgs/commit/0a9b1bebe605bea14e3a38ef41184b0f24e095f6) anbox: 2021-10-20 -> 2023-02-03
* [`12b9e2b2`](https://github.com/NixOS/nixpkgs/commit/12b9e2b25903049f5dddbc4f03751134dda3777f) anbox: fix compatibility with LXC 4
* [`0d09cc7c`](https://github.com/NixOS/nixpkgs/commit/0d09cc7cf6588be8efb4d3dda99b9c1e7de1919b) anbox: be ten times more patient when launching
* [`0c30c277`](https://github.com/NixOS/nixpkgs/commit/0c30c277a67ca213c558c87f7bc6b7d54ae11786) anbox: remove (thankfully inactive) "su" default
* [`11aa36c6`](https://github.com/NixOS/nixpkgs/commit/11aa36c61ec21f5a1760ae6399520a868619a7de) anbox: fix and reclaim anbox-application-manager
* [`e8a39314`](https://github.com/NixOS/nixpkgs/commit/e8a39314fcb623e9191eb2f810e222e93f703de7) anbox: ensure .desktop files use a correct `anbox`
* [`73767bb3`](https://github.com/NixOS/nixpkgs/commit/73767bb345c7d943b2bc1cd213d7cc9b87e03a64) anbox: fix `WM_CLASS`
* [`5adb7395`](https://github.com/NixOS/nixpkgs/commit/5adb7395998f106b739187f8a93a82d9ad44653e) anbox: add patch to provide window icon
* [`c6e16040`](https://github.com/NixOS/nixpkgs/commit/c6e16040372328532280ae419e94fa4580096550) portfolio: 0.65.1 -> 0.65.3
* [`7e87f6c5`](https://github.com/NixOS/nixpkgs/commit/7e87f6c593e5aef7f13fdf10082795854778af0d) topology: 9.0.0 -> 10.2.0
* [`02643fe4`](https://github.com/NixOS/nixpkgs/commit/02643fe422c8b7a25acc7df31fc6b44efe9a616a) coq_8_18: init at 8.18+rc1
* [`ae24e3e5`](https://github.com/NixOS/nixpkgs/commit/ae24e3e528c90aee944c5ca23fab715d72d6b1f2) Add a few packages for Coq 8.18 and MathComp 2.0
* [`aa256916`](https://github.com/NixOS/nixpkgs/commit/aa25691630cb54c5c3d261198cb838bbce2afb5c) CONTRIBUTING: Add note about how to commit new maintainers-list.nix entry
* [`8c27922a`](https://github.com/NixOS/nixpkgs/commit/8c27922a0e2de18f1fadb4f2bd65d5cb9de16b64) qemu: 8.0.4 -> 8.1.0
* [`41408ef8`](https://github.com/NixOS/nixpkgs/commit/41408ef861782d35cb937d081181f86fe3ec8126) python310Packages.fastrlock: 0.8.1 -> 0.8.2
* [`c2e15454`](https://github.com/NixOS/nixpkgs/commit/c2e15454d89eebbbb300fed9679463af21b6f1a7) python310Packages.aiohttp-socks: 0.8.0 -> 0.8.1
* [`2fefc498`](https://github.com/NixOS/nixpkgs/commit/2fefc49874bd395a24995a81761952fecdf28d89) conmon-rs: 0.5.0 -> 0.6.0
* [`c7c4c1cd`](https://github.com/NixOS/nixpkgs/commit/c7c4c1cd93e39449f187a3bc0c565a313d875c37) timoni: 0.11.1 -> 0.12.1
* [`971a08f3`](https://github.com/NixOS/nixpkgs/commit/971a08f34e51bffde9a4fa6b99f2895f4f993bb0) gitRepo: 2.36 -> 2.36.1
* [`4fd0172a`](https://github.com/NixOS/nixpkgs/commit/4fd0172a49042a062a3d8f5841d9025f8c804d46) okta-aws-cli: 1.1.0 -> 1.2.1
* [`f5de44f0`](https://github.com/NixOS/nixpkgs/commit/f5de44f0ea808bd71c9ccf37a4bd9dc04ef61443) goss: 0.3.18 -> 0.4.1
* [`27b998f5`](https://github.com/NixOS/nixpkgs/commit/27b998f564f6effc43b2950bcc3d51a0391d5b2c) goss: add anthonyroussel to maintainers
* [`81dad28a`](https://github.com/NixOS/nixpkgs/commit/81dad28a547481d707b3a2bad27cfdbf17d5a8c2) goss: add passthru.updateScript, tests.version
* [`291fcd94`](https://github.com/NixOS/nixpkgs/commit/291fcd94b8b43e075cf59d133d0233c1ed461d8b) dgoss: 0.3.18 -> 0.4.1
* [`65f9a7b4`](https://github.com/NixOS/nixpkgs/commit/65f9a7b416427d3c52ed68cc2020dafa76adc108) dgoss: add anthonyroussel to maintainers
* [`7acdac76`](https://github.com/NixOS/nixpkgs/commit/7acdac7610eff04fde1f9a013e70acc31c8d4c45) elementary-cmake-modules: remove
* [`a6b0593e`](https://github.com/NixOS/nixpkgs/commit/a6b0593e97349d622612c7f9c0f83d7d6dc0da0f) python310Packages.python-cinderclient: 9.3.0 -> 9.4.0
* [`3774c197`](https://github.com/NixOS/nixpkgs/commit/3774c19728cced8c811ddecd3f77f9d94dfe5963) python3Packages.gcsa: init at 2.1.0
* [`c4f129b8`](https://github.com/NixOS/nixpkgs/commit/c4f129b801d55da8052e6912205fb07ff8168c12) python310Packages.django-jinja: 2.10.2 -> 2.11.0
* [`c63750bd`](https://github.com/NixOS/nixpkgs/commit/c63750bd5c81f7fd2b0f01f049b4b3fd50a9d77b) python310Packages.webauthn: 1.8.1 -> 1.10.1
* [`f7d4fbd9`](https://github.com/NixOS/nixpkgs/commit/f7d4fbd94a135210d0f4f0df80d6dc2953c46d1d) qjoypad: misc cleanups
* [`1607621a`](https://github.com/NixOS/nixpkgs/commit/1607621a5a82e1967deaf998ec3d6f0634cafc08) tagainijisho: misc cleanups
* [`d5107300`](https://github.com/NixOS/nixpkgs/commit/d510730093d2977639beb5a87b85a7f76aeb48e5) qscreenshot: 1.0 -> unstable-2021-10-18
* [`de1d98ca`](https://github.com/NixOS/nixpkgs/commit/de1d98cabef2f251a28241abf9432d8e1bb18b72) vite: 1.2pre1543 -> unstable-2022-05-17
* [`85d2adb0`](https://github.com/NixOS/nixpkgs/commit/85d2adb0cda26fb677f20573d56355b3b6aa7c04) flatcam: 8.5 -> unstable-2022-02-02
* [`173409fb`](https://github.com/NixOS/nixpkgs/commit/173409fbc9fc264d6f923798d99255e901e5c710) texmacs: remove darwin version, because it depends on qt4
* [`79ff04f3`](https://github.com/NixOS/nixpkgs/commit/79ff04f384c49225dc1128ea4401507895af3335) lutris: remove qt4
* [`308baf30`](https://github.com/NixOS/nixpkgs/commit/308baf304984fb5bb94f0b69f4b4dc8d5030405d) uim: remove qt4, fix qt5
* [`6c62a211`](https://github.com/NixOS/nixpkgs/commit/6c62a2116194bd0356e744a25c0d62c152cc8ebe) namecoin: remove GUI support
* [`faee0c0e`](https://github.com/NixOS/nixpkgs/commit/faee0c0e0fa5427e43bb23454bd272539a883e51) hime: remove qt4 support
* [`608ed10f`](https://github.com/NixOS/nixpkgs/commit/608ed10f046f97525a843da65f3306c4eec3b23c) omapd: remove
* [`f3fe2513`](https://github.com/NixOS/nixpkgs/commit/f3fe251344c0a1e3977f8cefb814050a69709052) structure-synth: remove
* [`2b77e759`](https://github.com/NixOS/nixpkgs/commit/2b77e759facf3c621f5d45d20aaa607e3cc3da3b) acoustidFingerprinter: remove
* [`44c3cb96`](https://github.com/NixOS/nixpkgs/commit/44c3cb965f58883a6802c28b4aac29b880d86106) windows.jom: remove
* [`35ffde90`](https://github.com/NixOS/nixpkgs/commit/35ffde90e53c7801ab02b09a2faf67a70058d434) tworld2: remove
* [`0a293e70`](https://github.com/NixOS/nixpkgs/commit/0a293e705ee08d7e99227579de090a8fd53afd06) valkyrie: remove
* [`85f01126`](https://github.com/NixOS/nixpkgs/commit/85f0112696f56ab0b8ac34b2f3a76bb49c137526) ssr: remove
* [`10e80ccb`](https://github.com/NixOS/nixpkgs/commit/10e80ccb52ac6c2ab36680328c9d54f79c1fb054) qmidiroute: remove
* [`e0a6d462`](https://github.com/NixOS/nixpkgs/commit/e0a6d4627c5a9af0ad5fb8fffcc4cd5a9d707bca) qtscrobbler: remove
* [`b4ad3f98`](https://github.com/NixOS/nixpkgs/commit/b4ad3f983c3b85d99fdedf29aa7e57b49a842c6a) resim: remove
* [`32e055ac`](https://github.com/NixOS/nixpkgs/commit/32e055ac0d2769f17e54e1f2100f48f17ada36cf) animbar: remove
* [`4ab15dde`](https://github.com/NixOS/nixpkgs/commit/4ab15ddeda8bd5e8d3c07ee70b0b865cf723df42) qmetro: remove
* [`bf64cf4c`](https://github.com/NixOS/nixpkgs/commit/bf64cf4ca3cac9a590f5891aea8f647902af44bd) navipowm: remove
* [`c189ea39`](https://github.com/NixOS/nixpkgs/commit/c189ea39cf9b6b609c1d241e7b2083e6d2d482a0) scantailor: remove
* [`4ec86689`](https://github.com/NixOS/nixpkgs/commit/4ec86689f777024990a7f03aa0506552cd9f1619) sqliteman: remove
* [`7e09025e`](https://github.com/NixOS/nixpkgs/commit/7e09025e465eb110f6105213882929d88942adcc) qscintilla-qt4: remove
* [`0fcbbbb7`](https://github.com/NixOS/nixpkgs/commit/0fcbbbb772a4e18f07a721b1a1a69b5c87015434) qtstyleplugin-kvantum-qt4: remove
* [`cf0862e5`](https://github.com/NixOS/nixpkgs/commit/cf0862e525546119835b212e72754968b5e2ef5d) qwt6_qt4: remove
* [`20e37855`](https://github.com/NixOS/nixpkgs/commit/20e3785582ce82cec1b5d3138413f410a16d747a) gambatte: remove
* [`c8e5c5c2`](https://github.com/NixOS/nixpkgs/commit/c8e5c5c2228ddd58f01b7229e0bb4a92a9585990) screencloud: remove
* [`9f648b8a`](https://github.com/NixOS/nixpkgs/commit/9f648b8a42cc821adfd019d5b98859c4b9064d72) scribus_1_4: remove
* [`b861791b`](https://github.com/NixOS/nixpkgs/commit/b861791b642479a334cbb1295352fa838388d59d) ibus-qt: remove
* [`5dbd4333`](https://github.com/NixOS/nixpkgs/commit/5dbd4333f2a2586439736f25f6a46ea8cefe8cbc) subdownloader: remove
* [`0141f9ac`](https://github.com/NixOS/nixpkgs/commit/0141f9aca023444eabcf4669c94bb37036208765) eql: remove
* [`a7d78e6b`](https://github.com/NixOS/nixpkgs/commit/a7d78e6be3f6e3a4796ef8dc9982f10c2550ac68) qimageblitz: remove
* [`869eda7c`](https://github.com/NixOS/nixpkgs/commit/869eda7c26da9eca03284cfc3efa6743277e878d) qt-mobility: remove
* [`e60b6e18`](https://github.com/NixOS/nixpkgs/commit/e60b6e18bec93875fb4894b04a70f802c9162c98) prison: remove
* [`61abba66`](https://github.com/NixOS/nixpkgs/commit/61abba66e29285518d80e946715e42085836c668) ntrack: remove
* [`76eb2c64`](https://github.com/NixOS/nixpkgs/commit/76eb2c64b1f33f91b28521d091f598ba35003038) libjreen: remove
* [`141579b8`](https://github.com/NixOS/nixpkgs/commit/141579b8a2ae2605fef8294244d1802899477e5c) seexpr: remove
* [`fd9213cf`](https://github.com/NixOS/nixpkgs/commit/fd9213cf753a19cc371b215d29edabf31e1ac4cb) aliza: remove
* [`f1ca7eec`](https://github.com/NixOS/nixpkgs/commit/f1ca7eecbb1346bb67741850b359ea0778fcddab) avogadro: remove
* [`f72bd506`](https://github.com/NixOS/nixpkgs/commit/f72bd5065d73f69cd6858f96d2567ffa0246c03e) qfsm: remove
* [`6d581655`](https://github.com/NixOS/nixpkgs/commit/6d581655101e824e926040e59163855090b41b98) hydrogen_0: remove
* [`045f8c5b`](https://github.com/NixOS/nixpkgs/commit/045f8c5b66e81f6e7bb3561ad41aa4f24e41317f) fmbt: remove
* [`9a87752f`](https://github.com/NixOS/nixpkgs/commit/9a87752f0b1fd2ea5fd8d0a0995ef812a018a601) pyside*: remove
* [`3d1d7419`](https://github.com/NixOS/nixpkgs/commit/3d1d7419d49b0fe86d757123f63d772218afe844) qucs: remove
* [`ea9b800d`](https://github.com/NixOS/nixpkgs/commit/ea9b800dde09c7c6ce96bce0784f68d757ac66e4) python3.pkgs.Nuitka: remove unused pyqt4 dependency
* [`80192466`](https://github.com/NixOS/nixpkgs/commit/80192466619ecdcd91e7d4af334a60e5762be5ad) python3.pkgs.ete3: remove pyqt4
* [`1b4c4704`](https://github.com/NixOS/nixpkgs/commit/1b4c4704ceebdeb687fc73f0ab12f82277055b59) pyqt4: remove
* [`048adf01`](https://github.com/NixOS/nixpkgs/commit/048adf01c95f59c8afa962296698c6698d10aab7) qt4: remove
* [`002c11bf`](https://github.com/NixOS/nixpkgs/commit/002c11bf75e90af717a631ece4642dee68a08648) Revert "segger-jlink: init at 7.66"
* [`5bf895d1`](https://github.com/NixOS/nixpkgs/commit/5bf895d1067772ab57f27c3d2e4d690e473562bc) Revert "nrf-command-line-tools: init at 10.16.0"
* [`5f9b7b33`](https://github.com/NixOS/nixpkgs/commit/5f9b7b331703922b50d91c371f0174ad43902173) Revert "nrfconnect: init at 3.11.1"
* [`10fdd2c9`](https://github.com/NixOS/nixpkgs/commit/10fdd2c9493d3431b0cb4dec4df206ae3a7526a5) Revert "sbclPackages: fix build of qt, qt-libs and qtools"
* [`1be50b50`](https://github.com/NixOS/nixpkgs/commit/1be50b5017aa3777ab09b0f4244b79fa6814bde6) Revert "smokegen,smokeqt: enable strictDeps and don't use pkgs"
* [`2b85e7e9`](https://github.com/NixOS/nixpkgs/commit/2b85e7e9b8735246da30d80359df82b15217e8be) Revert "smokeqt: init at v4.14.3"
* [`2ab41bea`](https://github.com/NixOS/nixpkgs/commit/2ab41bea09072e618e4bf0524c07dc1abc7b33ad) Revert "smokegen: init at v4.14.3"
* [`5211e5be`](https://github.com/NixOS/nixpkgs/commit/5211e5be8c067d6a6087cac4d304f8b3b08ab710) yate: drop gui support
* [`1bd59b1e`](https://github.com/NixOS/nixpkgs/commit/1bd59b1e614f69efb6f787ce6704c626f38a2c8d) lisp-modules: drop qt4 stuff
* [`7f728d40`](https://github.com/NixOS/nixpkgs/commit/7f728d409f0d88e28f3d72adfe8ee4692950ba47) flatcam: fix after daf490f1f9b5abd9ef9fe115e4d11a2b55a2ccbd
* [`f5753523`](https://github.com/NixOS/nixpkgs/commit/f57535235be77732da1c00cecc4ea6a8352e4038) flatcam: build with python39
* [`9b85f8d6`](https://github.com/NixOS/nixpkgs/commit/9b85f8d67cb41c36354130fe560d013fe5f0e5e5) instead-launcher: remove
* [`9afd8341`](https://github.com/NixOS/nixpkgs/commit/9afd83416855cf3afcc795ee0f48a130e4f8b1d6) dssi: remove optional qt4 support
* [`eedffc8c`](https://github.com/NixOS/nixpkgs/commit/eedffc8c7fcc6a32652e539fc5b977b78c544a4c) bililiverecorder: add mainProgram metadata
* [`d3425bf1`](https://github.com/NixOS/nixpkgs/commit/d3425bf16de5db1e75a8344ab9d43ecdfeb156e7) python310Packages.scs: 3.0.0 -> 3.2.3
* [`d777a5bd`](https://github.com/NixOS/nixpkgs/commit/d777a5bd0422ccabf892d7128346f7950b70d84a) python311Packages.osqp: 0.6.2.post8 -> 0.6.3
* [`d80bf9ad`](https://github.com/NixOS/nixpkgs/commit/d80bf9ad96ca5c61f255507b49ee168509140d38) python311Packages.daqp: init at 0.5.1
* [`9a4c9773`](https://github.com/NixOS/nixpkgs/commit/9a4c9773cf3ced368afbd5b27072f971b9853e4e) python311Packages.qpsolvers: init at 3.4.0
* [`1ec7e3c1`](https://github.com/NixOS/nixpkgs/commit/1ec7e3c1401ab60a3af39d791e5acc24ad50b1f1) portfolio-filemanager: 0.9.15 -> 1.0.0
* [`311ce2ad`](https://github.com/NixOS/nixpkgs/commit/311ce2ad111e9abe4215ad6bf8503ffb9be48f3c) nixosTests.custom-ca: resolve out of memory situations
* [`d51aa069`](https://github.com/NixOS/nixpkgs/commit/d51aa069bed029345fc4bd9a4f861291d4836c6e) multimon-ng: add sox as dependency
* [`a6f1b66d`](https://github.com/NixOS/nixpkgs/commit/a6f1b66d11008c5ff3c6f5d5b25f448498d479b9) kubectl-klock: 0.3.2 -> 0.4.0
* [`29659595`](https://github.com/NixOS/nixpkgs/commit/29659595dbba4ee56a359f0d620eb2419ff00044) parallel: 20230622 -> 20230822
* [`1625dc93`](https://github.com/NixOS/nixpkgs/commit/1625dc93086db97190383a4b610bfa181decec8a) maintainers: add linuxissuper
* [`cecfb9af`](https://github.com/NixOS/nixpkgs/commit/cecfb9af77e07000d06d0f0c16298cddeb177d11) sirikali: init at 1.5.1
* [`f69a37cd`](https://github.com/NixOS/nixpkgs/commit/f69a37cdb4371c95f204de7660f1c7f274ea7771) cargo-hack: 0.6.4 -> 0.6.5
* [`8d7937e4`](https://github.com/NixOS/nixpkgs/commit/8d7937e487d2fdfa5254494e320bbd77720e93ce) cargo-deny: 0.14.1 -> 0.14.2
* [`a1badc74`](https://github.com/NixOS/nixpkgs/commit/a1badc74aea62ae82efdd4391f926d8075e776d5) klavaro: 3.13 -> 3.14
* [`3ff4ec19`](https://github.com/NixOS/nixpkgs/commit/3ff4ec19b643efd5bd7fa80dfea84e7c1742cf0b) vault-ssh-plus: 0.7.0 -> 0.7.1
* [`884c0800`](https://github.com/NixOS/nixpkgs/commit/884c080079bff520ed99f378799e3be05c3a8b5a) wasmtime: fix build due to cargo-auditable issue
* [`0bb3184a`](https://github.com/NixOS/nixpkgs/commit/0bb3184aa7aad089fdb103cf31c9eb0176c0c2bb) nuclei: 2.9.13 -> 2.9.14
* [`fd80879e`](https://github.com/NixOS/nixpkgs/commit/fd80879e01fa8dc9ef4cc342d6ebea1dc61d7fd8) herbstluftwm: fix tests with recent X versions
* [`ad71d310`](https://github.com/NixOS/nixpkgs/commit/ad71d3105c02faa55517d67cc047b8a572159fbf) uhdm: 1.57 -> 1.73
* [`7d1ddd1d`](https://github.com/NixOS/nixpkgs/commit/7d1ddd1dfb104285155f303aaf954a47347d8734) surelog: 1.57 -> 1.73
* [`8c603d5a`](https://github.com/NixOS/nixpkgs/commit/8c603d5a8c9479177c8dd0993e9884eb9cf88ec0) yosys-symbiflow: 1.20230425 -> 1.20230808
* [`85cd8cae`](https://github.com/NixOS/nixpkgs/commit/85cd8caee853dc525f2a280a6a1003b36b17d348) sketchybar: 2.16.1 -> 2.16.3
* [`238a2f85`](https://github.com/NixOS/nixpkgs/commit/238a2f85cf6a2a610acd02791fdf5acc9f1f701a) kraft: 0.6.4 -> 0.6.6
* [`ffa7b3b5`](https://github.com/NixOS/nixpkgs/commit/ffa7b3b5eb38502bd107351d4a8f3d8ecae8a718) pixelorama: 0.11.1 -> 0.11.2
* [`eb85576d`](https://github.com/NixOS/nixpkgs/commit/eb85576db1c7dcb9753f50eb03a947da08516dbc) python310Packages.jupyter-console: rename from jupyter_console
* [`a960eac8`](https://github.com/NixOS/nixpkgs/commit/a960eac815df737abecd83054e9ef1939bda0959) python310Packages.jupyter-console: add jupyter team as maintainers
* [`8012e0d2`](https://github.com/NixOS/nixpkgs/commit/8012e0d22686f9a305f46f73dc04b71218a27e14) python310Packages.jupyter-console: 6.6.1 -> 6.6.3
* [`66e2c847`](https://github.com/NixOS/nixpkgs/commit/66e2c8475da97ec3aec9c79884e632b9d6d2bbbe) git-credential-manager: fix update script
* [`00ed10aa`](https://github.com/NixOS/nixpkgs/commit/00ed10aae6e4ce7a3ed849b2882bd06a5b1d319b) git-credential-manager: 2.2.2 -> 2.3.2
* [`59488a31`](https://github.com/NixOS/nixpkgs/commit/59488a3177948782987a0402e654e4c5f00c31c4) python310Packages.oslo-concurrency: 5.1.1 -> 5.2.0
* [`ed1a0aba`](https://github.com/NixOS/nixpkgs/commit/ed1a0aba9437921af6ed0a3504cbf354949beeef) python310Packages.ansible-core: 2.15.2 -> 2.15.3
* [`3c15feef`](https://github.com/NixOS/nixpkgs/commit/3c15feef7770eb5500a4b8792623e2d6f598c9c1) root: 6.26.10 -> 6.28.06 ([nixos/nixpkgs⁠#215187](https://togithub.com/nixos/nixpkgs/issues/215187))
* [`355a9fa0`](https://github.com/NixOS/nixpkgs/commit/355a9fa0408983446be73ce20d7535eea1319c4b) nixos/jool: allow to manage multiple instances
* [`640c86c2`](https://github.com/NixOS/nixpkgs/commit/640c86c256e620be9f0120e461466d9d0eec985b) nixos/tests/jool: update for module changes
* [`f5c50d58`](https://github.com/NixOS/nixpkgs/commit/f5c50d58fb72a0bce5f0d2d259eebadb05d08d74) python310Packages.s3fs: 2023.6.0 -> 2023.9.0
* [`b058de4a`](https://github.com/NixOS/nixpkgs/commit/b058de4ac8539d60534e76eb2b92441384f02e1f) nixos/release-notes: reword the Jool note
* [`1fdf8696`](https://github.com/NixOS/nixpkgs/commit/1fdf8696628d52ca6e4da58447feefc2450ee9b6) ttop: 1.2.0 -> 1.2.1
* [`bf5b1639`](https://github.com/NixOS/nixpkgs/commit/bf5b163916d68b8b62cacdbe1c3a2896a8e62ff1) python311Packages.celery: 5.3.3 -> 5.3.4
* [`5c3d7775`](https://github.com/NixOS/nixpkgs/commit/5c3d7775dd8aa28e19b525e9bfab57fa611d0bc0) libuev: init at 2.4.0
* [`a9fea437`](https://github.com/NixOS/nixpkgs/commit/a9fea43703c233740cd6200f1acd6af06e160bd0) uftpd: init at 2.15
* [`218a9bb2`](https://github.com/NixOS/nixpkgs/commit/218a9bb2b8cac8811a2a480c31e57d3a8aa02972) cudatext: 1.197.0 -> 1.198.0
* [`225b3007`](https://github.com/NixOS/nixpkgs/commit/225b3007d9a56e980422efad069798d4d177ed1c) python311Packages.weconnect: 0.57.0 -> 0.58.0
* [`1cc25658`](https://github.com/NixOS/nixpkgs/commit/1cc256582032fe7c812f01ac962bc20f35409f28) python311Packages.weconnect-mqtt: 0.45.1 -> 0.46.0
* [`e095938c`](https://github.com/NixOS/nixpkgs/commit/e095938c264cbf9d4df737a2535d6e642293097e) cinny, cinny-desktop: build from source
* [`954a4160`](https://github.com/NixOS/nixpkgs/commit/954a416000e35da8fdda1f3a92ac55b010f4095e) fh: 0.1.2 -> 0.1.3
* [`0f65b87e`](https://github.com/NixOS/nixpkgs/commit/0f65b87e6e1db2c0775026f914e0cd7f4011ba44) subtitleedit: 3.6.13 -> 4.0.0
* [`4b7c9533`](https://github.com/NixOS/nixpkgs/commit/4b7c95337352905e37666e7faf4f869ca3e01dd9) python311Packages.dirty-equals: 0.6.0 -> 0.7.0
* [`980e521d`](https://github.com/NixOS/nixpkgs/commit/980e521db450cfdca69edddf092a70a534a864ce) clightning: 23.05.2 -> 23.08
* [`2609945e`](https://github.com/NixOS/nixpkgs/commit/2609945edf05a7ecf7ce4d7eafac7c228d37cefd) python310Packages.pytorch-lightning: 2.0.7 -> 2.0.8
* [`1bd2aad7`](https://github.com/NixOS/nixpkgs/commit/1bd2aad718238eb3ec78eed517314f1c14fc0c79) jrnl: 3.3 -> 4.0.1
* [`bfdccb62`](https://github.com/NixOS/nixpkgs/commit/bfdccb6298c5d8cd533fef37c9efe1c20bbfbf6a) pkgs/stdenv: fix typo in booter.nix docs
* [`6e8591a8`](https://github.com/NixOS/nixpkgs/commit/6e8591a8d17cbd3a2142b1b2db7959ad55c1c3dc) nixos/mimir: add extraFlags option
* [`5a02eb69`](https://github.com/NixOS/nixpkgs/commit/5a02eb69db253d8f80f166bbf297126002acbc59) python311Packages.zeroconf: 0.93.1 -> 0.94.0
* [`34398795`](https://github.com/NixOS/nixpkgs/commit/34398795e8d465a37e7e7d461b6b865c333503b4) python311Packages.zeroconf: 0.94.0 -> 0.95.0
* [`26c497ea`](https://github.com/NixOS/nixpkgs/commit/26c497ea0068e97971c7bff575e009aae7afaaac) python311Packages.zeroconf: 0.95.0 -> 0.96.0
* [`7af19665`](https://github.com/NixOS/nixpkgs/commit/7af19665dcf9d3cbb80e1609fdbf260107330c2d) python311Packages.zeroconf: 0.96.0 -> 0.97.0
* [`46511166`](https://github.com/NixOS/nixpkgs/commit/46511166bbc3e2b20009bcde5243825f65f0461c) python311Packages.vsure: 2.6.6 -> 2.6.7
* [`91c779c4`](https://github.com/NixOS/nixpkgs/commit/91c779c49d78a6d687fbe6f9943b2f23297c22ac) checkov: 2.4.22 -> 2.4.25
* [`6a213fd1`](https://github.com/NixOS/nixpkgs/commit/6a213fd14043c081f816498687ab9fdc67ca5596) python311Packages.casbin: 1.26.0 -> 1.27.0
* [`12962a9c`](https://github.com/NixOS/nixpkgs/commit/12962a9c277a72c133f19f5aea5035474ff4ff9d) sbt-extras: 2023-07-25 -> 2023-08-28
* [`94bfdb51`](https://github.com/NixOS/nixpkgs/commit/94bfdb5169ceffa3ca855979e7892fbdb0868151) python310Packages.pyaml: 23.7.0 -> 23.9.1
* [`a6616e7d`](https://github.com/NixOS/nixpkgs/commit/a6616e7d712219ef00b4f05f5f843a40aa79ff83) sudo-rs: init at 0.2.0
* [`10b6e8ba`](https://github.com/NixOS/nixpkgs/commit/10b6e8ba218b188438d6bd702985601ddc7b14da) nixos/sudo: Guard against `security.sudo.package = pkgs.sudo-rs;`
* [`fd8e0695`](https://github.com/NixOS/nixpkgs/commit/fd8e069585ee554501c843bbdb15795a7aba3ff6) sudo-rs: Patch to work with NixOS' suid wrappers
* [`01b3a6c8`](https://github.com/NixOS/nixpkgs/commit/01b3a6c894bb1028e935d78a91fbbbae85b46053) python310Packages.sphinxcontrib-plantuml: 0.25 -> 0.26
* [`bcbbfd86`](https://github.com/NixOS/nixpkgs/commit/bcbbfd86e08623eaf33a5b9838533c841f9ca59a) edge-runtime: 1.10.0 -> 1.14.0
* [`571ed5c7`](https://github.com/NixOS/nixpkgs/commit/571ed5c7a147efbf092c561036cecf1faa3e79cd) envoy: 1.26.3 -> 1.26.4
* [`e9ce489b`](https://github.com/NixOS/nixpkgs/commit/e9ce489b46e9ad7b14ef9915e585f6da9b661d0b) asciidoctor-with-extensions: init asciidoctor-reducer at 1.0.5
* [`2fe9b165`](https://github.com/NixOS/nixpkgs/commit/2fe9b16547a4415e6fe24af8bb23304858a21afb) civo: 1.0.61 -> 1.0.65
* [`0c40d640`](https://github.com/NixOS/nixpkgs/commit/0c40d6402254af2f089ec18767480fe6eaa525d3) cloudfoundry-cli: 8.7.1 -> 8.7.2
* [`a58c29c0`](https://github.com/NixOS/nixpkgs/commit/a58c29c0ff662590f9294a66c1637ad8be4af06a) python310Packages.idasen: 0.10.0 -> 0.10.1
* [`f07ef496`](https://github.com/NixOS/nixpkgs/commit/f07ef496bc463c6e7efe6069d1cabe5757e3b90e) rot8: init at 0.1.5
* [`0401989e`](https://github.com/NixOS/nixpkgs/commit/0401989eb975f53fe7ddb4a8e103c4c5186bc445) zsh: fix configure script with clang 16
* [`caaf41e9`](https://github.com/NixOS/nixpkgs/commit/caaf41e94b6e6c65104be7e7484685f02a0845c4) python310Packages.appthreat-vulnerability-db: 5.2.5 -> 5.4.1
* [`674e9559`](https://github.com/NixOS/nixpkgs/commit/674e95592a60f09c2f05fd2471538d5889ce386c) python310Packages.b2sdk: 1.19.0 -> 1.24.0
* [`53ffac98`](https://github.com/NixOS/nixpkgs/commit/53ffac981fe3a12b69d93476374fee098e444a03) backblaze-b2: add changelog to meta
* [`e6be272c`](https://github.com/NixOS/nixpkgs/commit/e6be272cf86f0e96fc92db0600ed8c02acbcbbe0) backblaze-b2: 3.7.0 -> 3.9.0
* [`3f31c365`](https://github.com/NixOS/nixpkgs/commit/3f31c365bd6777e1f8d12d76c3ca3e14499cc658) python311Packages.setuptools-gettext: 0.1.3 -> 0.1.5
* [`d966364b`](https://github.com/NixOS/nixpkgs/commit/d966364bafa6ab91a0738d41791359be9ec7da41) harmonist: 0.4.1 -> 0.5.1
* [`21d18dce`](https://github.com/NixOS/nixpkgs/commit/21d18dce210e68aa27d899b81dc400216fc9af43) matrix-synapse: 1.91.0 -> 1.91.1
* [`834d7f14`](https://github.com/NixOS/nixpkgs/commit/834d7f1430cc6360aabb4e3b8b59ef56ad6f9a43) mongoc: 1.24.2 -> 1.24.3
* [`2caa3c48`](https://github.com/NixOS/nixpkgs/commit/2caa3c4810f6d84c630c04505f35842d5dce0f72) granted: 0.14.2 -> 0.14.4
* [`168ac2a0`](https://github.com/NixOS/nixpkgs/commit/168ac2a0ab631c0639d6cdf618522e3c689604bb) freerdp: 2.10.0 -> 2.11.0
* [`f7a60568`](https://github.com/NixOS/nixpkgs/commit/f7a60568739d5c4e17627c6a4f5db9edd9106071) sile: 0.14.10 -> 0.14.11
* [`c98d709b`](https://github.com/NixOS/nixpkgs/commit/c98d709bbf58de8481291d05fac12a325f7f3b29) oxker: 0.3.1 -> 0.3.2
* [`4e04adc0`](https://github.com/NixOS/nixpkgs/commit/4e04adc0b7ef8ed0f723a537bf1249deda7f5051) gammaray: 2.11.3 -> 3.0.0
* [`a29e4700`](https://github.com/NixOS/nixpkgs/commit/a29e4700e311f7a8bddf59ce4b4e809caa2a1967) python310Packages.metakernel: 0.29.5 -> 0.30.0
* [`2893230b`](https://github.com/NixOS/nixpkgs/commit/2893230b5084f2ae56fe6e3d6633b33660927187) weggli: init at 0.2.4
* [`f555a4ab`](https://github.com/NixOS/nixpkgs/commit/f555a4ab3fbcd97b1ccbc75ffe6c93e213f7375c) perlnavigator: init at 0.6.0
* [`045805f0`](https://github.com/NixOS/nixpkgs/commit/045805f04f573fe61209b0b6d55ac75769732901) nodePackages.ocaml-language-server: drop
* [`2572c1ba`](https://github.com/NixOS/nixpkgs/commit/2572c1ba16f3c895bdaab94aaec2f16a58abb8d6) copyq: unstable-2023-04-14 -> 7.1.0
* [`d3e19090`](https://github.com/NixOS/nixpkgs/commit/d3e19090a0d6a34128b84db9e7422132ed53295a) protonmail-bridge: 3.3.2 -> 3.4.1
* [`834e3450`](https://github.com/NixOS/nixpkgs/commit/834e34501cdd255b34c9f36e40e59138d32878e6) kn: 1.10.0 -> 1.11.0
* [`b21ef1ae`](https://github.com/NixOS/nixpkgs/commit/b21ef1ae24aabbf30a67cb9c2ae90d6375569248) codeql: 2.14.2 -> 2.14.3
* [`086fe9c9`](https://github.com/NixOS/nixpkgs/commit/086fe9c93c64d2e7f391d71fd1ff3ef3ab0c88d3) kissat: 3.0.0 -> 3.1.0
* [`33534269`](https://github.com/NixOS/nixpkgs/commit/33534269f890ae2413c8701c9cf3369a232cd4f1) bluetuith: 0.1.6 -> 0.1.7
* [`40daff23`](https://github.com/NixOS/nixpkgs/commit/40daff23f8c89ade104796fa05a8c1732c8bb4ab) gitui: 0.24.1 -> 0.24.2
* [`147d81d1`](https://github.com/NixOS/nixpkgs/commit/147d81d15594cd73f3ad38ae36dae09c1004292f) nixos/atuin: fix enable option typo
* [`df0ab79a`](https://github.com/NixOS/nixpkgs/commit/df0ab79a6e3bdb771baf1c2324762c1251c0b910) oras: 1.0.1 -> 1.1.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
