### PR TITLE
niv nixpkgs: update 32df108c -> 9c285006

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32df108c42d909b93bb06e0ddb63f6072767c912",
-        "sha256": "1bgbfiy8zsyrb5cdmffsifdh5c2bdi1xx5zjgb493cysmvi5199z",
+        "rev": "9c28500602ed01d3a89562b1c8842f38aa998aea",
+        "sha256": "1k9hgm6p7yfcw5357zbpbk9zy01zjikp3y6izxy74sfhkvpn8x6r",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/32df108c42d909b93bb06e0ddb63f6072767c912.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9c28500602ed01d3a89562b1c8842f38aa998aea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@32df108c...9c285006](https://github.com/nixos/nixpkgs/compare/32df108c42d909b93bb06e0ddb63f6072767c912...9c28500602ed01d3a89562b1c8842f38aa998aea)

* [`25043c26`](https://github.com/NixOS/nixpkgs/commit/25043c264d1b78ab1e87ab83f270f9f5c4d8fea3) steam: add openssl to fhsenv
* [`c441ee72`](https://github.com/NixOS/nixpkgs/commit/c441ee72492f37d56482db24534ccd8e208f5b3f) pax-utils: Fix build on non-Linux by disabling libcap
* [`c5cdffd4`](https://github.com/NixOS/nixpkgs/commit/c5cdffd40a1234440930cea75f580013bf0ee24b) chrysalis: 0.12.0 -> 0.13.2
* [`42f0af4a`](https://github.com/NixOS/nixpkgs/commit/42f0af4abea7fb92a8cee685a69e75f74f5e2f14) nixos/duplicati: add package option
* [`95278172`](https://github.com/NixOS/nixpkgs/commit/952781729fbc137349a043daf2aaa2aa0e2e023c) doc/lisp: minor changes to manual
* [`38955360`](https://github.com/NixOS/nixpkgs/commit/38955360ce726864d63d2c6da4fcd5b514a7c52e) parrot: init at 1.6.0
* [`ec1a115d`](https://github.com/NixOS/nixpkgs/commit/ec1a115d5ca7d2a4dbbc6c831c368a316e29214b) cava: add SDL2 library during build
* [`b991ea83`](https://github.com/NixOS/nixpkgs/commit/b991ea8385f053138eb2e68af69db7f6a52c4579) doc/lisp: clarify section on importing from Quicklisp
* [`9ce6e34d`](https://github.com/NixOS/nixpkgs/commit/9ce6e34ddf8be0fe467881fb25ed3c4d496ae133) doc/lisp: add links to sections and upstream websites
* [`827b70a9`](https://github.com/NixOS/nixpkgs/commit/827b70a9b461d2d54af236da4d75f572391a765e) doc/lisp: document arguments of buildASDFSystem
* [`fcd6294e`](https://github.com/NixOS/nixpkgs/commit/fcd6294e6e1981eff314eff2a435a5a063c63dc1) prisma-engines: 5.0.0 -> 5.2.0
* [`11462274`](https://github.com/NixOS/nixpkgs/commit/11462274e13a45125311caf7ed4041b7cbf3c42c) nodePackages.prisma: 5.0.0 -> 5.2.0
* [`91871abb`](https://github.com/NixOS/nixpkgs/commit/91871abbde55599b48e11e978b4a46a10372c633) jetbrains: 2023.2 -> 2023.2.1
* [`c269ed0c`](https://github.com/NixOS/nixpkgs/commit/c269ed0caeb2e0adcfb3a547f7dd68dc459f2984) jetbrains.plugins: update
* [`0f4de63e`](https://github.com/NixOS/nixpkgs/commit/0f4de63e334bc3dfd3aac212dc474d4520c740c5) redis: 7.0.12 -> 7.2.0
* [`de708041`](https://github.com/NixOS/nixpkgs/commit/de70804137dd5b3de415f0113d80e6028ca3b712) coursera-dl: apply patch for python 3.11 compatibility
* [`11322c28`](https://github.com/NixOS/nixpkgs/commit/11322c28c5582128a01431a2c0edefcaf53e5927) pb: init at 0.1.0
* [`75ce7214`](https://github.com/NixOS/nixpkgs/commit/75ce7214f11bb85d011b1a991609c2a6be13b3e3) lunar-client: adapt and update to 3.0.7
* [`774c20b6`](https://github.com/NixOS/nixpkgs/commit/774c20b684674ba8945ca0ffd3b850965e14c570) connman: 1.41 -> 1.42
* [`0bb5211e`](https://github.com/NixOS/nixpkgs/commit/0bb5211e807d060664f7905b9390426910293406) connman: update maintainers
* [`f6fa02c9`](https://github.com/NixOS/nixpkgs/commit/f6fa02c984f46a7157e72feab59608662d740d3a) openrbg: set default based on what microcode updates are enabled
* [`6b2934d6`](https://github.com/NixOS/nixpkgs/commit/6b2934d6e906a53634085a0cd636f2f0d110a6ed) nixos/yazi: init
* [`00f21850`](https://github.com/NixOS/nixpkgs/commit/00f21850c29a125cfece65b6b3dfa9d884ec7736) maintainers: add hbjydev
* [`2f5f1647`](https://github.com/NixOS/nixpkgs/commit/2f5f1647c36f08195b008f6d5e4418d4e8c3dc29) pythonPackages: add qt6 override
* [`fd32af39`](https://github.com/NixOS/nixpkgs/commit/fd32af39eb317c507c645983f7c8781be5b0aea0) lxd: add missing tools to wrapper
* [`c7a2d51c`](https://github.com/NixOS/nixpkgs/commit/c7a2d51cb45d6aa56702a0a2db9ab859fdee5830) webcord: 4.3.0 -> 4.4.0
* [`b43c6252`](https://github.com/NixOS/nixpkgs/commit/b43c62522a74c9f40fe917eaeb936600390d3f3f) fava: 1.25.1 -> 1.26
* [`6b1a276e`](https://github.com/NixOS/nixpkgs/commit/6b1a276e79c8b4890b9724c312d68c275c90f4c1) python311Packages.simplepush: init at 2.2.3
* [`846fcf2c`](https://github.com/NixOS/nixpkgs/commit/846fcf2cd047fbc09e77fa533336a53709a2c8a9) ejs: init at 3.1.9
* [`ee6a7153`](https://github.com/NixOS/nixpkgs/commit/ee6a7153f8e519fe48d99a2e881d66ddb55d53f4) ticktick: init at 1.0.80
* [`0bf94d42`](https://github.com/NixOS/nixpkgs/commit/0bf94d42a2ca4bcd97a4ba064eabbdb7d3a95dc2) victoriametrics: 1.93.1 -> 1.93.3
* [`f541a9c8`](https://github.com/NixOS/nixpkgs/commit/f541a9c8a00f8aff5b505d24d717b4b30cabe836) python310Packages.marisa-trie: 0.8.0 -> 1.0.0
* [`914e2e3c`](https://github.com/NixOS/nixpkgs/commit/914e2e3ca20bc48fe0495d52a3ebf4c693264590) python310Packages.whodap: 0.1.8 -> 0.1.9
* [`efb0b2f9`](https://github.com/NixOS/nixpkgs/commit/efb0b2f9c7368072be0c2b2bb79e7f86356f3f84) picard: disable autoupdate
* [`1b52b0b5`](https://github.com/NixOS/nixpkgs/commit/1b52b0b5b5e6c4e919e358625681fd618becc042) grafana-agent: 0.36.0 -> 0.36.1
* [`212c6180`](https://github.com/NixOS/nixpkgs/commit/212c61802ab40db1d3a859898ac16bc224ff735b) gmime3: 3.2.12 -> 3.2.14
* [`fada58ef`](https://github.com/NixOS/nixpkgs/commit/fada58ef4e13f543851783f2d3da393627027a8c) httplib: 0.13.3 -> 0.14.0
* [`b16dcb4c`](https://github.com/NixOS/nixpkgs/commit/b16dcb4ccfc417b13b9b31043ba14febf3c18e2d) linuxKernel.kernels.linux_zen: 6.4.7-zen1 -> 6.5.2-zen1
* [`35a6870f`](https://github.com/NixOS/nixpkgs/commit/35a6870faf75ad3938f27e1e8d4a4ad4948c89ad) linuxKernel.kernels.linux_lqx: 6.4.7-lqx1 -> 6.4.14-lqx1
* [`0f3ca379`](https://github.com/NixOS/nixpkgs/commit/0f3ca379ea0f51ade6495579d27ed3183ef76f44) python310Packages.dm-tree: fix runtime error
* [`53370b75`](https://github.com/NixOS/nixpkgs/commit/53370b75c1616c631cf72cd9d4426c2fbc906f68) turso-cli: 0.81.0 -> 0.82.0
* [`fdb36984`](https://github.com/NixOS/nixpkgs/commit/fdb369847dccc3a757b9d7223059ec959eebbfcd) bearer: 1.21.0 -> 1.22.0
* [`64cdda3d`](https://github.com/NixOS/nixpkgs/commit/64cdda3d48f972a75f19b52f7a5626b2f5f4d1c8) agi: 3.3.0 -> 3.3.1
* [`1df4a270`](https://github.com/NixOS/nixpkgs/commit/1df4a27001f8c57a639422468c70d2e7240f8349) pythonPackages.shiboken6: add egg_info
* [`37594142`](https://github.com/NixOS/nixpkgs/commit/37594142641d30ce152fb121b1c7cce95b1d48a0) jotdown: 0.3.1 -> 0.3.2
* [`a1dfb662`](https://github.com/NixOS/nixpkgs/commit/a1dfb662ff97879183c4ce71c753f33586ead2b7) netcdf: 4.9.0 -> 4.9.2
* [`41841755`](https://github.com/NixOS/nixpkgs/commit/418417551185cd5a722b25f9ba6bd7b93779074f) netcdf: enable tests on aarch64-darwin
* [`b6ea266e`](https://github.com/NixOS/nixpkgs/commit/b6ea266e8360ecaeb1354786dbf3ecba46313de6) netcdf: fix build with clang 16
* [`041e8955`](https://github.com/NixOS/nixpkgs/commit/041e8955d707a6fea4782e5f348f497725ada69c) pythonPackages.pyside6: add egg_info
* [`58671ffe`](https://github.com/NixOS/nixpkgs/commit/58671ffebe524aadbef3abbfa52553ed050ad18f) streamdeck-ui: use new repo
* [`a02a5025`](https://github.com/NixOS/nixpkgs/commit/a02a5025c1e6c4a4891bc2c1b4615120c0170470) streamdeck-ui: add systemd user service
* [`0fb2fbc3`](https://github.com/NixOS/nixpkgs/commit/0fb2fbc3934318d52d3ae3f0d49efd143eac9388) streamdeck-ui: 2.0.6 -> 3.0.1
* [`44813a8a`](https://github.com/NixOS/nixpkgs/commit/44813a8a613c8e56db614b2ea450f8ed0d06cbad) streamdeck-ui: split desktop items
* [`1f03581c`](https://github.com/NixOS/nixpkgs/commit/1f03581c0cf5bff9da82b9e20c900da069b50480) netcdf: fix tests on Linux
* [`a178a0ee`](https://github.com/NixOS/nixpkgs/commit/a178a0ee19e7d115ccd7901e58dd42f3cdaa77c0) sqlc: 1.20.0 -> 1.21.0
* [`f4450f90`](https://github.com/NixOS/nixpkgs/commit/f4450f90f4426051d5ba0b4350e5995985095bb0) micropad: use fetchYarnDeps
* [`31ef3887`](https://github.com/NixOS/nixpkgs/commit/31ef38877462c55d57a8a5134d28ed1987ed31d2) micropad: 4.2.1 -> 4.3.0
* [`9b698788`](https://github.com/NixOS/nixpkgs/commit/9b69878816562041923753557001d8e2760dd942) emacs: update the feature used for tramp-remote-path
* [`40b35dcd`](https://github.com/NixOS/nixpkgs/commit/40b35dcd376c5b2377af2180612c1cfb9c669f69) python310Packages.piccolo-theme: 0.16.1 -> 0.17.0
* [`695d8aa6`](https://github.com/NixOS/nixpkgs/commit/695d8aa69b64e18e0c9dfb75686350e08ad51de9) nodejs_20: 20.5.1 -> 20.6.0
* [`d168d670`](https://github.com/NixOS/nixpkgs/commit/d168d67027fae056dfe1b1871281d22fa8635aee) clusterctl: 1.5.0 -> 1.5.1
* [`3c244406`](https://github.com/NixOS/nixpkgs/commit/3c244406e113ae884390bf01d9d505dd75fd88b0) gtkcord4: 0.0.11-1 -> 0.0.12
* [`bb4fa9be`](https://github.com/NixOS/nixpkgs/commit/bb4fa9bea047eed15c450f3d3b6de294bafcdca9) rmtrash: 1.14 -> 1.15
* [`1ec8907c`](https://github.com/NixOS/nixpkgs/commit/1ec8907cf405aa7253787318fc3ec4ac9552ac52) ssh-chat: use sri hash
* [`267491d9`](https://github.com/NixOS/nixpkgs/commit/267491d9cb20fb6ca662cbdea1ed8a69aa2b061d) ngtcp2-gnutls: 0.18.0 -> 0.19.1
* [`19e4704a`](https://github.com/NixOS/nixpkgs/commit/19e4704a71e8283ec6b391da67367d31a01dd667) logseq: 0.9.15 -> 0.9.17
* [`3d3c4135`](https://github.com/NixOS/nixpkgs/commit/3d3c4135ead502058bc531a2da36bbdeb84b6869) python310Packages.faraday-plugins: 1.13.0 -> 1.13.2
* [`b54d97ae`](https://github.com/NixOS/nixpkgs/commit/b54d97ae3fbf2043a2df23b230162f717a3a1d85) home-assistant: update component-packages
* [`85684726`](https://github.com/NixOS/nixpkgs/commit/856847266d6ba62a630518ca3956b93e8130ebb8) python310Packages.dvc-data: 2.15.4 -> 2.16.0
* [`f1e32f73`](https://github.com/NixOS/nixpkgs/commit/f1e32f734c8e4a5e6917b46237bab5ee58461af2) python310Packages.mwparserfromhell: 0.6.4 -> 0.6.5
* [`618e9a86`](https://github.com/NixOS/nixpkgs/commit/618e9a86e16117ad0b437b461ba674a6ba97c03e) python311Packages.pyenphase: init at 1.9.1
* [`619398f1`](https://github.com/NixOS/nixpkgs/commit/619398f19c64b1cab4cd860d4f3f2c217a44e387) cloudfox: 1.12.0 -> 1.12.2
* [`ebf2611c`](https://github.com/NixOS/nixpkgs/commit/ebf2611caca215a91d3c616b04c6f4f9ab0bea65) python311Packages.griffe: 0.36.0 -> 0.36.1
* [`4888905c`](https://github.com/NixOS/nixpkgs/commit/4888905cfde66ffc055f05d3c1ca6ff3c3009d7c) tgpt: 1.7.5 -> 1.7.6
* [`fb5cada4`](https://github.com/NixOS/nixpkgs/commit/fb5cada4a148cdce80175d1634ec56bdd443387a) checkov: 2.4.27 -> 2.4.29
* [`8a106b44`](https://github.com/NixOS/nixpkgs/commit/8a106b44eb47b4ae5556167f8aab0f5e4ed6b8b6) cava: add SDL, libGL, and pipewire libs during build and autoconf archive for opengl detection
* [`d9a9badb`](https://github.com/NixOS/nixpkgs/commit/d9a9badb08dfd2a604252b6a84cf66a6e5251c10) python311Packages.dvc: 3.17.0 -> 3.18.0
* [`24e95ae4`](https://github.com/NixOS/nixpkgs/commit/24e95ae4f6187ed510f6f5dfc0c558becd365814) python311Packages.tldextract: 3.4.4 -> 3.5.0
* [`bea17789`](https://github.com/NixOS/nixpkgs/commit/bea17789fc28e54f09de1faa394f993191ca8992) qovery-cli: 0.68.0 -> 0.68.1
* [`2481fc68`](https://github.com/NixOS/nixpkgs/commit/2481fc685a9a6fde7bdd33702372e57d97a14419) exploitdb: 2023-09-05 -> 2023-09-07
* [`bda16445`](https://github.com/NixOS/nixpkgs/commit/bda16445a28dc46d7d051c3eb8ca22c2938d595b) python311Packages.aiorecollect: 2023.08.0 -> 2023.09.0
* [`e8155c92`](https://github.com/NixOS/nixpkgs/commit/e8155c92e4ef5a656f3292870d3730cdf95cece2) python311Packages.sense-energy: 0.12.0 -> 0.12.1
* [`b4896f9e`](https://github.com/NixOS/nixpkgs/commit/b4896f9e452bfb11dbca39240acb353fca56801f) odpic: 4.6.1 -> 5.0.0
* [`bfad3f0d`](https://github.com/NixOS/nixpkgs/commit/bfad3f0d2c0dde2a2a67ef8a99a60861b16375fd) odpic: nixpkgs-fmt
* [`1d1a8f9d`](https://github.com/NixOS/nixpkgs/commit/1d1a8f9dd2f6a73e41a6dd10950cb9c1bec6ca48) odpic: drop myself as a maintainer
* [`f7b1f00b`](https://github.com/NixOS/nixpkgs/commit/f7b1f00bfbb4aebf6c58f7bc4c163b5a45933df4) oracle-instantclient: drop myself as a maintainer
* [`3281c2ce`](https://github.com/NixOS/nixpkgs/commit/3281c2ce5c14d524e0fa7f4f3f2218782eae7514) python311Packages.dbus-fast: 1.94.1 -> 1.95.0
* [`01492629`](https://github.com/NixOS/nixpkgs/commit/0149262972251110cd2bff07ad04a615c50f3a81) python311Packages.zeroconf: 0.97.0 -> 0.98.0
* [`3c3c37ea`](https://github.com/NixOS/nixpkgs/commit/3c3c37ea901eb27cb789f2db2ddb644762b3ea54) python311Packages.zeroconf: 0.98.0 -> 0.99.0
* [`5b0ed68c`](https://github.com/NixOS/nixpkgs/commit/5b0ed68c106c1cbe3b573f3d1ca8c73eb203e346) qemu: add pipewire support (8.1 feature)
* [`5ae2b275`](https://github.com/NixOS/nixpkgs/commit/5ae2b2751833bece606e0cbc64cfbd4bd331e628) nixos/surrealdb: incorporate beta 10 changes
* [`808cfccb`](https://github.com/NixOS/nixpkgs/commit/808cfccb66d49301985d734d6e1e0c41da176b0d) python310Packages.unstructured-inference: add paddleocr dependency
* [`ba4c8154`](https://github.com/NixOS/nixpkgs/commit/ba4c81544acdb2fc64ec23d607ecb4aa6a44d1d1) python310Packages.marisa-trie: add changelog to meta
* [`e5b6a21a`](https://github.com/NixOS/nixpkgs/commit/e5b6a21a70e6cd9100b656373fa1dbd85460640c) beam/buildMix: add appConfigPath arg
* [`36ff7d5d`](https://github.com/NixOS/nixpkgs/commit/36ff7d5d5d5132d9177e36ae817a485cb5eb40db) mobilizon: init at 3.1.3
* [`fc67d297`](https://github.com/NixOS/nixpkgs/commit/fc67d297de95200ab5a4f68fe5d53c46c87b315e) nixos/mobilizon: add release notes
* [`04114b51`](https://github.com/NixOS/nixpkgs/commit/04114b5182f3c53da43e1abfdc38c5f784311dcd) python310Packages.marisa-trie: add format
* [`52893df0`](https://github.com/NixOS/nixpkgs/commit/52893df0e561d51e609959f3823f2d73d8cfde2d) python311Packages.pyenphase: 1.9.1 -> 1.9.2
* [`fdc2d674`](https://github.com/NixOS/nixpkgs/commit/fdc2d674ea0cabd95a5c9a9f5d04f8fded1b908b) python311Packages.pyenphase: 1.9.2 -> 1.9.3
* [`e764124b`](https://github.com/NixOS/nixpkgs/commit/e764124b1191fa63999276e0de74cbd4970c4052) geolite-legacy: 20220621 -> 20230901
* [`30cdffb5`](https://github.com/NixOS/nixpkgs/commit/30cdffb568eb581a80a911e129e6e05ec0fa00c2) Revert "meshcentral: use fetchYarnDeps"
* [`7da7141f`](https://github.com/NixOS/nixpkgs/commit/7da7141f018126f974a6fa56ec059fe70d01b03b) python310Packages.vertica-python: 1.3.4 -> 1.3.5
* [`46fc99a2`](https://github.com/NixOS/nixpkgs/commit/46fc99a2b1391e5b6a881644891a113bb295e395) microcom: 2019.01.0 -> 2023.09.0
* [`69b243f5`](https://github.com/NixOS/nixpkgs/commit/69b243f50f8ca9bcbe41f2682e31f7518a469c84) sdbus-cpp: 1.2.0 -> 1.3.0
* [`643f30ac`](https://github.com/NixOS/nixpkgs/commit/643f30acdce71856f46c0115de792c93fe6000f4) grafana-loki,promtail: 2.8.4 -> 2.9.0
* [`f3b7478a`](https://github.com/NixOS/nixpkgs/commit/f3b7478a34eadcf15fcf77d657504fe5599d5a33) commit-mono: 1.135 -> 1.136
* [`c53ada6c`](https://github.com/NixOS/nixpkgs/commit/c53ada6cab1e5d63a04d9e3336321ef3e3cd0a80) deepin.deepin-reader: 5.10.29 -> 6.0.2
* [`03cd769d`](https://github.com/NixOS/nixpkgs/commit/03cd769df0372c6f2850ea58679b945d89675b79) clightning: patch clnrest.py shebang
* [`f13bd8f1`](https://github.com/NixOS/nixpkgs/commit/f13bd8f12d91e274b873d5e1e9381cb3fbf19922) python310Packages.mkdocstrings-python: 1.6.0 -> 1.6.2
* [`72e1bef9`](https://github.com/NixOS/nixpkgs/commit/72e1bef9f60a0dd02b1292df1c1ce1b0d3d0ca5d) biome: 1.1.0 -> 1.1.1
* [`0dbab138`](https://github.com/NixOS/nixpkgs/commit/0dbab138f2054c454169ecd266a829e9071a9908) browsr: 1.14.0 -> 1.15.0
* [`b36902ed`](https://github.com/NixOS/nixpkgs/commit/b36902edf0e50636d3e7e7c870f3743dc0c6cf80) python310Packages.qbittorrent-api: 2023.7.52 -> 2023.9.53
* [`7b15fbcf`](https://github.com/NixOS/nixpkgs/commit/7b15fbcf2c40af9fc604bd157f766c58da780d36) matrix-sliding-sync: 0.99.9 -> 0.99.10
* [`56cdfbeb`](https://github.com/NixOS/nixpkgs/commit/56cdfbeb16ae9f8d9164258743bf5584b5cce82b) python310Packages.datadog: 0.46.0 -> 0.47.0
* [`29ef0cc1`](https://github.com/NixOS/nixpkgs/commit/29ef0cc1fdcbe0708b064a8f951fc564dff9ff67) elementary-xfce-icon-theme: 0.17 -> 0.18
* [`9c912844`](https://github.com/NixOS/nixpkgs/commit/9c912844847c1f182363fdd0fe68a920ed6a68cf) greybird: 3.23.2 -> 3.23.3
* [`b310a15b`](https://github.com/NixOS/nixpkgs/commit/b310a15bc38cf01196365a720cb2d61385fa7f4f) v2ray-domain-list-community: 20230902035830 -> 20230905081311
* [`e6f31513`](https://github.com/NixOS/nixpkgs/commit/e6f315132dbd8d6c44a9eaee09c3966ee2e211bb) python310Packages.pyaml: 23.9.1 -> 23.9.3
* [`b8c87147`](https://github.com/NixOS/nixpkgs/commit/b8c871475afd0e529f1e2bc6f56763d2b9487f25) nixos/infiniband: add support for configurable guids
* [`407f8a38`](https://github.com/NixOS/nixpkgs/commit/407f8a380647942b8fc3ee67bb59d55820e5f8b5) emacs: use llvmPackages_14 from `apple_sdk_11_0`
* [`cd7b1642`](https://github.com/NixOS/nixpkgs/commit/cd7b1642e058be1260b8980eb342a42a3612194e) scarab: 1.34.0.0 -> 2.1.0.0
* [`b10a9b22`](https://github.com/NixOS/nixpkgs/commit/b10a9b22db67ff8f36e369d7aaf5abe49301173a) checkov: 2.4.29 -> 2.4.30
* [`d5c95c05`](https://github.com/NixOS/nixpkgs/commit/d5c95c05020f668b0e0ce317c0785624a1fe2b08) python310Packages.sdds: 0.3.1 -> 0.4.0
* [`7115a4d3`](https://github.com/NixOS/nixpkgs/commit/7115a4d3c9735bce1a5969b16524c6c7d389a3aa) python310Packages.karton-config-extractor: 2.1.1 -> 2.2.0
