### PR TITLE
niv nixpkgs: update 9c285006 -> 77671b68

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9c28500602ed01d3a89562b1c8842f38aa998aea",
-        "sha256": "1k9hgm6p7yfcw5357zbpbk9zy01zjikp3y6izxy74sfhkvpn8x6r",
+        "rev": "77671b681ce37f62461c82b566d1c0527bb76abf",
+        "sha256": "1sc88yzcgjapbzr8nxgj4ab6n1cj3gb02c8m9744pacxjvv1jyks",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/9c28500602ed01d3a89562b1c8842f38aa998aea.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/77671b681ce37f62461c82b566d1c0527bb76abf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@9c285006...77671b68](https://github.com/nixos/nixpkgs/compare/9c28500602ed01d3a89562b1c8842f38aa998aea...77671b681ce37f62461c82b566d1c0527bb76abf)

* [`98c43a7e`](https://github.com/NixOS/nixpkgs/commit/98c43a7eae3f88cffc748f0929cd421beb67ff94) skanlite: fix gsettings crash when saving a file
* [`727f92f6`](https://github.com/NixOS/nixpkgs/commit/727f92f6af8292d0893d8c8bc808ca253973a135) ghosttohugo: init at v0.5.3
* [`6bf3ef39`](https://github.com/NixOS/nixpkgs/commit/6bf3ef3935f7598e4a2d9d69ed9bbfc2832b625b) androidenv: remove avdmanager list target
* [`973a043a`](https://github.com/NixOS/nixpkgs/commit/973a043a4a064b0b3ee6757291859076662c3a38) x2x: 1.27 -> unstable-2023-04-30
* [`75bcc135`](https://github.com/NixOS/nixpkgs/commit/75bcc135aa7692e66b5a07ea599b0b0c9c21a2de) stockfish: 15 -> 16
* [`9eb19d6c`](https://github.com/NixOS/nixpkgs/commit/9eb19d6cf356174ebf5a8237dd45f91ade6a2ba3) goldendict: fix gsettings crash when adding paths for dictionaries
* [`c574e375`](https://github.com/NixOS/nixpkgs/commit/c574e375890f705a4f6d1fdc36e815594065565f) duplicity: add empty meta.maintainers, remove default meta.platforms, other cleanup
* [`99c6837a`](https://github.com/NixOS/nixpkgs/commit/99c6837a65d2fd240092dbddb019d1731da983dc) cc2538-bsl: remove unused rec
* [`4a032b19`](https://github.com/NixOS/nixpkgs/commit/4a032b19fc663d96e4a2e499cdd720e6bd87012b) boost: move isMips64n32 from meta.broken to meta.badPlatforms
* [`530a7a5e`](https://github.com/NixOS/nixpkgs/commit/530a7a5e43fbd67e3714ea31dad5eb493cfda094) alertmanager-bot: remove
* [`ba2f38d6`](https://github.com/NixOS/nixpkgs/commit/ba2f38d684cf0267bee46135cfd5b4794b6103b6) nixos/zigbee2mqtt: persist groups set via ui
* [`5110d348`](https://github.com/NixOS/nixpkgs/commit/5110d348b258aa3397b15876c68e5b17a4080c9c) wstunnel: correct listen option
* [`f0d3d747`](https://github.com/NixOS/nixpkgs/commit/f0d3d7475dabb1296d9f623dfa7a6adc2e67d854) sysstat: 12.6.2 -> 12.7.4
* [`9ba8910d`](https://github.com/NixOS/nixpkgs/commit/9ba8910d630318275733e71f9b92d63e47251c3a) python311Packages.joblib: 1.3.1 -> 1.3.2
* [`64a71aea`](https://github.com/NixOS/nixpkgs/commit/64a71aea985b7116f9334e9ecf5f9cc83ed46fb7) nixos/galene: do not restrict AF_NETLINK
* [`f7151209`](https://github.com/NixOS/nixpkgs/commit/f7151209c413d0ba51d2986e9e942eb37610b06c) nixos/woodpecker-agents: fix 'podman' example
* [`7d246a28`](https://github.com/NixOS/nixpkgs/commit/7d246a2873ea045ce7b2381f72a76f701f5abbd9) nixos/woodpecker-agents: fix typos in doc
* [`6dd4c5f7`](https://github.com/NixOS/nixpkgs/commit/6dd4c5f73faae32bea4bed2cf8f1a98328387129) nixos/woodpecker-agents: use 'literalExample'
* [`200c3bad`](https://github.com/NixOS/nixpkgs/commit/200c3bad4254b41202d8e96959c19e15a20c6434) nixos/woodpecker-agents: add 'path' option
* [`f3df41c6`](https://github.com/NixOS/nixpkgs/commit/f3df41c6db6774bf9ee57670081ff8e3871cd392) coreboot-utils: 4.20 -> 4.21
* [`c0e607da`](https://github.com/NixOS/nixpkgs/commit/c0e607da612b0203a5357cadb9b345c7c321c163) nixos/tests/wrappers: test apparmor configuration
* [`44fde723`](https://github.com/NixOS/nixpkgs/commit/44fde723be696020dc4c78d5deae3501b6cb088f) nixos/security/wrappers: generate a separate and more complete apparmor policy fragment for each wrapper
* [`1bdbc0b0`](https://github.com/NixOS/nixpkgs/commit/1bdbc0b0fedcb5fdcb60a88f9781e53d9b12d5c8) nixos/security/wrappers: stop using `.real` files
* [`e3550208`](https://github.com/NixOS/nixpkgs/commit/e3550208de58dbf1ce92de85fd555674bc00ce82) nixos/security/wrappers: read capabilities off /proc/self/exe directly
* [`c64bbd44`](https://github.com/NixOS/nixpkgs/commit/c64bbd4466fd00163d97e40eac0c7ec849dfb2a9) nixos/security/wrappers: remove all the assertions about readlink(/proc/self/exe)
* [`13d3b0c7`](https://github.com/NixOS/nixpkgs/commit/13d3b0c73350d1bcee16316a1d5c0f327f466f5c) nixos/security/wrappers: add one regression test for [nixos/nixpkgs⁠#98863](https://togithub.com/nixos/nixpkgs/issues/98863)
* [`4732cbf3`](https://github.com/NixOS/nixpkgs/commit/4732cbf3f88f451760345e9cdb54babbb543e22e) nixos/restic: use openssh as configured in programs.ssh
* [`dbb69f82`](https://github.com/NixOS/nixpkgs/commit/dbb69f82c6d3ef080f42f478fc366445539df757) nixos/restic: add wrapper scripts that set parameters for backup
* [`240ef426`](https://github.com/NixOS/nixpkgs/commit/240ef4262b6b3619238d24fae2de34270da6a72f) fw-ectool: init at unstable-2022-12-03
* [`a59f0307`](https://github.com/NixOS/nixpkgs/commit/a59f03079c8d87cbfef51c8ffd61e8da28d9bce4) fetchurl: Validate that a single hash was passed
* [`af5682b3`](https://github.com/NixOS/nixpkgs/commit/af5682b3e1ced9d3f764a548ee7e1459fbcc5969) fetchurl: Correctly handle { outputHash != ""; outputHashAlgo = "" }
* [`c5153127`](https://github.com/NixOS/nixpkgs/commit/c5153127c117479a7b346edb73ef86b4a14b069c) spdlog: 1.11.0 -> 1.12.0
* [`1b6d2086`](https://github.com/NixOS/nixpkgs/commit/1b6d20865438bd48511f1e54631bf93d6fadc5f2) hal-hardware-analyzer: fix build with fmt 10.1.0
* [`48cc84c5`](https://github.com/NixOS/nixpkgs/commit/48cc84c52254b0de33d09dfcbe57e2d09b8872ec) bear: 3.1.2 -> 3.1.3
* [`189b1424`](https://github.com/NixOS/nixpkgs/commit/189b14246a1992ff2454f75ae3478141fed2488b) nixos/networkd: Reload (not restart) when only .network units change
* [`a94a2633`](https://github.com/NixOS/nixpkgs/commit/a94a26338c244a03008a3b6c0e150b581538727d) arrow-cpp: 12.0.1 -> 13.0.0
* [`847757c2`](https://github.com/NixOS/nixpkgs/commit/847757c2b480cf55228918a7718783fd2227b6d2) python311Packages.adb-shell: 0.4.3 -> 0.4.4
* [`21977524`](https://github.com/NixOS/nixpkgs/commit/219775241d845a2c6220420d649e1f362053dc33) python3Packages.dask: disable failing test
* [`52a3f592`](https://github.com/NixOS/nixpkgs/commit/52a3f592df60fe092964de85740499e35a7683c8) python3Packages.intake: disable failing tests
* [`6d1b29b4`](https://github.com/NixOS/nixpkgs/commit/6d1b29b4a0c5b07e15c76cf70c85834189f318f8) python311Packages.plexapi: 4.15.0 -> 4.15.1
* [`e70f097a`](https://github.com/NixOS/nixpkgs/commit/e70f097aee00b657ff326a89f5eb67287210e3b5) python310Packages.wandb: remove tensorflow from nativeCheckInputs
* [`cf466c3c`](https://github.com/NixOS/nixpkgs/commit/cf466c3ce259dc4ac1d9bd102397d0da742771bd) clubhouse-cli: use buildNpmPackage
* [`472525b1`](https://github.com/NixOS/nixpkgs/commit/472525b1cf361b9a0aef3e3056d0a407708dcd37) python3Packages.dask-awkward: adjust to pyarrow-13
* [`c6af5494`](https://github.com/NixOS/nixpkgs/commit/c6af5494aad4c06c25595dd1e23fddbcf83b2a6f) nixos/nginx: fix services.nginx.defaultListen description
* [`9dc0b957`](https://github.com/NixOS/nixpkgs/commit/9dc0b95797894156a098e7be4364fd5ac60a52a5) soft-serve: 0.5.5 → 0.6.0
* [`de64a741`](https://github.com/NixOS/nixpkgs/commit/de64a741acec959d0565b6785577237a0b26083e) Disable faulty neomutt tests
* [`557163a1`](https://github.com/NixOS/nixpkgs/commit/557163a1ddbda6c3c71be1fab1318d3413be5bd1) boost183: init at 1.83.0
* [`11c98fd1`](https://github.com/NixOS/nixpkgs/commit/11c98fd1ec1d6fe769467754097fbc5e76f448d5) python3Packages.{google-cloud-bigquery,insightface,worldengine}: mark as broken
* [`fd3acad6`](https://github.com/NixOS/nixpkgs/commit/fd3acad64326a3b1ab9d7d07550b5ca5beaf848a) gnuradio: fix build with fmt-10.1
* [`4b919a5b`](https://github.com/NixOS/nixpkgs/commit/4b919a5b81789f7f5a49bf83d05174b75b719742) gerbera: fix build with fmt-10.1
* [`e06224be`](https://github.com/NixOS/nixpkgs/commit/e06224be9b1979f9eb152f2bd9342aaaad76b8a8) pdm: 2.8.2 -> 2.9.1
* [`7964e8a3`](https://github.com/NixOS/nixpkgs/commit/7964e8a38c95d4ad2c4ec9bbb28508c8442f1d4b) ibis-framework: disable tests broken by pyarrow13
* [`9ee9dfac`](https://github.com/NixOS/nixpkgs/commit/9ee9dfac229a2930f13c393c83a67cba5bb19808) jack-example-tools: init at 4
* [`05a33a50`](https://github.com/NixOS/nixpkgs/commit/05a33a501552095d3fb0fcd9f5ce4506fa9c8ad4) nheko: fix build with fmt-10.1
* [`383550ca`](https://github.com/NixOS/nixpkgs/commit/383550ca69371b8fee35cfc602b862574cbeabb0) lokinet: build with fmt9
* [`90ea2f63`](https://github.com/NixOS/nixpkgs/commit/90ea2f63fefdd743aa7ee5d7e044cc737feb9f5e) openroad: unstable-2023-03-31 -> unstable-2023-08-26
* [`6e56e31d`](https://github.com/NixOS/nixpkgs/commit/6e56e31d38828196d67434e73338fa1c658d2ecb) release-notes: add note about jack2 losing its tools
* [`e4bc74c9`](https://github.com/NixOS/nixpkgs/commit/e4bc74c9137570807f92f231c29862b2495ecd2e) steamguard-cli: init at 0.12.0
* [`be69155c`](https://github.com/NixOS/nixpkgs/commit/be69155c3a4f6638cd52edab8d6206805e33d76b) xmlstarlet: add meta.mainProgram
* [`3680de3f`](https://github.com/NixOS/nixpkgs/commit/3680de3fc987fa40bf773d66f8c8da77eef89446) tvbrowser: add meta.mainProgram
* [`3aa4d642`](https://github.com/NixOS/nixpkgs/commit/3aa4d64281537a0cda314b787daecf711ec8d951) expect: add meta.mainProgram
* [`104d8164`](https://github.com/NixOS/nixpkgs/commit/104d8164f25e514b961eda5755678c077b7419bc) cryptsetup: add meta.mainProgram
* [`1bb671bd`](https://github.com/NixOS/nixpkgs/commit/1bb671bd23957221b33d3779575d4eec3cb9e966) betterbird: add meta.mainProgram
* [`ff64c702`](https://github.com/NixOS/nixpkgs/commit/ff64c702c06f5dfbbc7576912ca64e359a06f642) dnsmasq: add meta.mainProgram
* [`47aa9e13`](https://github.com/NixOS/nixpkgs/commit/47aa9e133189ed0fd656b5c5ef96b04d89146431) dovecot: add meta.mainProgram
* [`09ee8956`](https://github.com/NixOS/nixpkgs/commit/09ee8956b93f4c5849bcc6157661d76f8de01213) asterisk: add meta.mainProgram
* [`b6f82dd3`](https://github.com/NixOS/nixpkgs/commit/b6f82dd3c72a9c6088fd51c0993b95e61bce480c) thunderbird{,-bin}: set meta.mainProgram=thunderbird
* [`fca305b3`](https://github.com/NixOS/nixpkgs/commit/fca305b300afe2bc75fc17a921191c1be0508ce7) exim: add meta.mainProgram
* [`1629803b`](https://github.com/NixOS/nixpkgs/commit/1629803b6799bc3f822412ccec4c1b9aa2b7a5c4) rabbitmq-server: 3.12.3 -> 3.12.4
* [`6de832b0`](https://github.com/NixOS/nixpkgs/commit/6de832b0e5136e8a22e55ce9db5b2e3ad3164466) nixos/logrotate: add extraArgs option
* [`fdbd15bc`](https://github.com/NixOS/nixpkgs/commit/fdbd15bc1a080237401190aef745318b2e5b5c00) bear: mark as broken on darwin
* [`142cb83c`](https://github.com/NixOS/nixpkgs/commit/142cb83c7327a7dc66c174491a23cb6e71f24fdb) hal-hardware-analyzer: mark as broken on darwin
* [`4acd903e`](https://github.com/NixOS/nixpkgs/commit/4acd903e58ef4ca5442891f96e64f0e687e501d1) python3Packages.huggingface-hub: 0.15.1 -> 0.16.4
* [`b938d093`](https://github.com/NixOS/nixpkgs/commit/b938d093539d048513e3ec41515925cf5a99d137) python3Packages.djangorestframework-stubs: init at 3.14.2
* [`cabb9231`](https://github.com/NixOS/nixpkgs/commit/cabb92314a618f3953d2e0e66e5249ff921deead) homebank: Enable support for darwin
* [`0958110e`](https://github.com/NixOS/nixpkgs/commit/0958110ed52c7aad58f4c60dd2f6d870edf3a897) wimboot: 2.7.5 -> 2.7.6
* [`61cc3526`](https://github.com/NixOS/nixpkgs/commit/61cc3526368508d05d20a006954a072a430c4c80) upbound: 0.18.0 -> 0.19.1
* [`6198bb8a`](https://github.com/NixOS/nixpkgs/commit/6198bb8acda16c7b958d255b4beaef5aede1cb2b) buildbot-www-react: init 3.9.2
* [`df4236c9`](https://github.com/NixOS/nixpkgs/commit/df4236c9043c2f7ee02847f8f1cccc0875d4ec6f) buildbot: supports reloading configuration
* [`3ee00994`](https://github.com/NixOS/nixpkgs/commit/3ee009942c6d6355709065b5d46f41b663dbbf11) networkmanager_dmenu: fix missing dependency on procps
* [`057fa9fa`](https://github.com/NixOS/nixpkgs/commit/057fa9faeef1c0626e28523094ed5663a0405794) jellyfin-ffmpeg: 6.0-5 -> 6.0-6
* [`c64ea820`](https://github.com/NixOS/nixpkgs/commit/c64ea820ed10877969df06dc22f5f22996101959) SDL2_ttf: use Harfbuzz from nixpkgs
* [`c5ddeee8`](https://github.com/NixOS/nixpkgs/commit/c5ddeee8f826c381d22734867afc28d21bb1d5f1) iptsd: 1.3.1 -> 1.3.2
* [`b7a270a6`](https://github.com/NixOS/nixpkgs/commit/b7a270a696adc31fc3c31c440f2e8020df742989) level-zero: 1.13.5 -> 1.14.0
* [`9280ab31`](https://github.com/NixOS/nixpkgs/commit/9280ab31fdf039b36715f0d26a2cf5b48a48aa49) terramate: 0.4.0 -> 0.4.1
* [`ce0e6900`](https://github.com/NixOS/nixpkgs/commit/ce0e690059abca0ba13c5d93ffe10278c7f05886) recyclarr: 5.2.1 -> 5.3.1
* [`f458e46e`](https://github.com/NixOS/nixpkgs/commit/f458e46ef0226818204d7b7f027c0a5d8ae7ff36) aws-nuke: 2.24.2 -> 2.25.0
* [`42f74914`](https://github.com/NixOS/nixpkgs/commit/42f749145d296d6106634e0104c857a05426f20a) perlPackages.Tk: fix build with clang 16
* [`a02761d7`](https://github.com/NixOS/nixpkgs/commit/a02761d722ddb9b23ed53e7b62b6b5537ba7d0a6) python311: enable cross-compilation to windows
* [`ba881ef6`](https://github.com/NixOS/nixpkgs/commit/ba881ef6132b55d533630a9e8ae43710831abdcb) firefox-esr-102-unwrapped: remove
* [`17aa5aa5`](https://github.com/NixOS/nixpkgs/commit/17aa5aa573a79e77021b5849c716d3cce9ebdbc6) dnglab: 0.5.0 -> 0.5.2
* [`3fdf8750`](https://github.com/NixOS/nixpkgs/commit/3fdf8750e8f8470c0d8a788a8d782726ee5861a7) puppeteer-cli: use buildNpmPackage
* [`cada8788`](https://github.com/NixOS/nixpkgs/commit/cada87887538ad501b3a777723d38ed322e12627) epstool: 3.08 -> 3.09
* [`2bb11b1c`](https://github.com/NixOS/nixpkgs/commit/2bb11b1c626826f5a3a575d6a46ed1ad22412cb4) java-language-server: 0.2.38 -> 0.2.46
* [`d7d5d9f1`](https://github.com/NixOS/nixpkgs/commit/d7d5d9f196ca81df0794a072f8bf840388aabcdf) puppeteer-cli: add meta
* [`8b4f8074`](https://github.com/NixOS/nixpkgs/commit/8b4f80741c6b832ad866ea1b5ec79ef7dbba2650) tests.cc-wrapper-*: extend to `llvmPackages_{10,11,12,13,14,15,git}
* [`3ca13784`](https://github.com/NixOS/nixpkgs/commit/3ca137844b4baaa42f10ee42d2142bcad2a2f20b) sharedown: use fetchYarnDeps
* [`b983f84b`](https://github.com/NixOS/nixpkgs/commit/b983f84b1f4d1faa3c972da7433e22bcf54b9435) wine: install in parallel
* [`4766ef13`](https://github.com/NixOS/nixpkgs/commit/4766ef136893dc0a04f09443e15418c7b3a5ac7f) python311Packages.ypy-websocket: 0.12.1 -> 0.12.2
* [`87cf41e1`](https://github.com/NixOS/nixpkgs/commit/87cf41e15445ef06cf13d9abe67a38dfc5cce63f) vault: 1.14.1 -> 1.14.2
* [`1df8afb5`](https://github.com/NixOS/nixpkgs/commit/1df8afb5cfb279b6952e5b48b8c2c902aefbf49c) miller: 6.8.0 -> 6.9.0
* [`d986d90a`](https://github.com/NixOS/nixpkgs/commit/d986d90a5ee34472e47a3e2fb834516fce241d37) bazel-gazelle: 0.32.0 -> 0.33.0
* [`84e0ab64`](https://github.com/NixOS/nixpkgs/commit/84e0ab64db497118126ee7c3c478d3be65598a77) micro: 2.0.11 -> 2.0.12
* [`11ee2466`](https://github.com/NixOS/nixpkgs/commit/11ee24664280ea426966df1503bcbcd6ee4f12ff) python311Packages.pylutron-caseta: 0.18.1 -> 0.18.2
* [`b47bd8cd`](https://github.com/NixOS/nixpkgs/commit/b47bd8cdc541fd903737fc67dce8b893a1ac393f) python310Packages.google-cloud-dataproc: 5.4.3 -> 5.5.0
* [`b352ab67`](https://github.com/NixOS/nixpkgs/commit/b352ab677bec91506b43c5455153cb555e6631ad) neovim: 0.9.1 -> 0.9.2
* [`839b5b97`](https://github.com/NixOS/nixpkgs/commit/839b5b97f3ce3bce3129f6b1f5afdde02b055d7d) qdrant: 1.4.1 -> 1.5.0
* [`fd61211e`](https://github.com/NixOS/nixpkgs/commit/fd61211eea97b43f34403190ab4f5cbb1cb50679) nextcloud-client 3.9.3 -> 3.9.4
* [`1a200899`](https://github.com/NixOS/nixpkgs/commit/1a2008992f3ab19bcd4963d6425a6f3a72cceb5f) certbot: 2.4.0 -> 2.6.0
* [`e0d46ebc`](https://github.com/NixOS/nixpkgs/commit/e0d46ebc89c3e8d5f79cb5c60b3355c8d5783fa1) python310Packages.pystache: 0.6.4 -> 0.6.5
* [`1f0b2214`](https://github.com/NixOS/nixpkgs/commit/1f0b22147ee17028bb83823a21fe2d55c0abcd7b) python310Packages.ansible-runner: 2.3.3 -> 2.3.4
* [`47a99ab5`](https://github.com/NixOS/nixpkgs/commit/47a99ab5251e41e7c90e0326734bf7bf74a75527) pdns: 4.8.1 -> 4.8.2
* [`a2f7bdde`](https://github.com/NixOS/nixpkgs/commit/a2f7bddec7aaf31dc4277bc279eb23c45b232f0c) pyenv: 2.3.25 -> 2.3.26
* [`618299f8`](https://github.com/NixOS/nixpkgs/commit/618299f8b89a7b75660b7f98f688468ebac48cc8) libdeltachat: 1.120.0 -> 1.121.0
* [`df53ba2c`](https://github.com/NixOS/nixpkgs/commit/df53ba2ca036dda30f3736ee6dbed79a18226800) python310Packages.cssbeautifier: init at 1.14.9
* [`dcf69ccc`](https://github.com/NixOS/nixpkgs/commit/dcf69ccc4fb9ede3c8e815119dd45579962c06cd) python310Packages.html-tag-names: init at 0.1.2
* [`cb936ef0`](https://github.com/NixOS/nixpkgs/commit/cb936ef04107de448bf96d82c70ec255e0f8e4e8) python310Packages.html-void-elements: init at 0.1.0
* [`08d84537`](https://github.com/NixOS/nixpkgs/commit/08d84537592bd541e78622d2101050f9409ef562) djlint: init at 1.32.1
* [`fa8cf9b3`](https://github.com/NixOS/nixpkgs/commit/fa8cf9b370f07a3ea5cd2c2076b3e2e67a87e851) erg: 0.6.19 -> 0.6.20
* [`586f0da8`](https://github.com/NixOS/nixpkgs/commit/586f0da8becbae452ebaa14add0bad920d82c43e) python310Packages.transmission-rpc: 4.3.0 -> 6.0.0
* [`5ebc1a62`](https://github.com/NixOS/nixpkgs/commit/5ebc1a62046e793db52178b4cd600b79e5a1cb92) ccache: 4.8.2 -> 4.8.3
* [`788dc509`](https://github.com/NixOS/nixpkgs/commit/788dc509e1c22981dfc98e869676bea85c94d884) cyber: unstable-2023-09-01 -> unstable-2023-09-07
* [`e15d196a`](https://github.com/NixOS/nixpkgs/commit/e15d196ac2aaea7648a8d857136088bb933b4ceb) cargo-component: unstable-2023-08-31 -> unstable-2023-09-06
* [`626c8c32`](https://github.com/NixOS/nixpkgs/commit/626c8c3224893df4b6eab1ff01df8abaad1c3476) tests.cc-wrapper: rework the logic, test newer `gcc` stdenvs too
* [`8d650ed2`](https://github.com/NixOS/nixpkgs/commit/8d650ed2294e0fbc8c8fbe5b5b568eaedc9a1a86) pkgs/top-level/release: update cc-wrapper attr names
* [`1b6c3aed`](https://github.com/NixOS/nixpkgs/commit/1b6c3aed6336efd056f5e3e0165e3e74f04b169f) tests.cc-wrapper: show more prominently what cc is being tested
* [`535447e2`](https://github.com/NixOS/nixpkgs/commit/535447e289be901fb309952e7bfc1c913083241d) tests.cc-wrapper: show command output on different line
* [`686516e0`](https://github.com/NixOS/nixpkgs/commit/686516e0bce756185b9709e51be1fd810c40565a) tests.cc-wrapper: filter out *MultiStdenv when not on and not building for linux and x86_64
* [`e0898be1`](https://github.com/NixOS/nixpkgs/commit/e0898be1c52d62d89071f95fffc39ee468201fbe) tests.cc-wrapper: filter unavailable gcc
* [`bcd62ff9`](https://github.com/NixOS/nixpkgs/commit/bcd62ff9eb0c07280063388847cf640c4c27ca10) Revert "tests.cc-wrapper: filter unavailable gcc"
* [`b61cc0d5`](https://github.com/NixOS/nixpkgs/commit/b61cc0d5e562555594ea174c5abd5de8e2f42fd7) biome: 1.1.1 -> 1.1.2
* [`137c5eec`](https://github.com/NixOS/nixpkgs/commit/137c5eec37acafc17298db62c0dba859c2883ebb) cargo-expand: 1.0.67 -> 1.0.68
* [`b2411cd2`](https://github.com/NixOS/nixpkgs/commit/b2411cd2d1dbbee4111792c12bc9dbec739f9b05) treesheets: unstable-2023-08-31 -> unstable-2023-09-07
* [`45639247`](https://github.com/NixOS/nixpkgs/commit/456392478fc7491973802a61ab6c3dbd33b732f7) libcef: 116.0.15 -> 116.0.20
* [`39ed4b64`](https://github.com/NixOS/nixpkgs/commit/39ed4b64ba5929e8e9221d06b719a758915e619b) terraform: 1.5.6 -> 1.5.7
* [`8221ee67`](https://github.com/NixOS/nixpkgs/commit/8221ee6705203a007e73e49b41baa91c9f056000) terraform: also, add qjoly as maintainer
* [`abe4d983`](https://github.com/NixOS/nixpkgs/commit/abe4d9830fd29c10e49ffc05bc6b3058dae32f39) ttop: 1.2.2 -> 1.2.3
* [`494ecbdd`](https://github.com/NixOS/nixpkgs/commit/494ecbdd32f6dc2a4ce46d6d5c8c4d1459aa164e) python310Packages.idasen: 0.10.1 -> 0.10.2
* [`08a73576`](https://github.com/NixOS/nixpkgs/commit/08a735768a510fea71c62337ccfc492d2a68b864) tandoor-recipes: 1.5.4 -> 1.5.6
* [`62596733`](https://github.com/NixOS/nixpkgs/commit/62596733c0c433af06dfc13ee89a98a26ce7b532) screentest: init at unstable-2021-05-10
* [`138565e8`](https://github.com/NixOS/nixpkgs/commit/138565e8df3ff7673a383dfa7a66a069ddc2c310) apache-airflow: fix passthru overriding
* [`3cc00c95`](https://github.com/NixOS/nixpkgs/commit/3cc00c95020b92705031a0426cebe5f42809cd5e) stdenvBootstrapTools: Bundle all *.o files from libc
* [`06182888`](https://github.com/NixOS/nixpkgs/commit/061828884688c580c909734db7305245f3ad87cb) cargo-semver-checks: 0.22.1 -> 0.23.0
* [`5472b080`](https://github.com/NixOS/nixpkgs/commit/5472b08075855a32ae254ac4f4777e139100bebc) lib/systems: disable pipewireSupport in qemu-user
* [`c9f2fec3`](https://github.com/NixOS/nixpkgs/commit/c9f2fec36917fcd318adba0961654d651a256f68) python310Packages.social-auth-app-django: 5.2.0 -> 5.3.0
* [`21dc6b70`](https://github.com/NixOS/nixpkgs/commit/21dc6b70520308846d8e7e6a17155fb17d1b1451) go_1_19: 1.19.12 -> 1.19.13
* [`e67b7b6a`](https://github.com/NixOS/nixpkgs/commit/e67b7b6ab5e1c8055597d5c02ad6d3c489f0f134) go_1_21: 1.21.0 -> 1.21.1
* [`e55c80af`](https://github.com/NixOS/nixpkgs/commit/e55c80af27282a37feb886e2a99f92ac898c3f7c) python310Packages.snowflake-connector-python: 3.1.1 -> 3.2.0
* [`2d6497dc`](https://github.com/NixOS/nixpkgs/commit/2d6497dc5b02e5b13396cf9815c998be8b17dba2) python311Packages.pyvista: 0.42.0 -> 0.42.1
* [`a26de147`](https://github.com/NixOS/nixpkgs/commit/a26de14753637e131685fd1913096113bd20d72f) python311Packages.aemet-opendata: 0.2.2 -> 0.4.4 ([nixos/nixpkgs⁠#251325](https://togithub.com/nixos/nixpkgs/issues/251325))
* [`51f25f51`](https://github.com/NixOS/nixpkgs/commit/51f25f51fe038a90288cfbca370cec12997ce35b) python311Packages.aioairzone: 0.6.7 -> 0.6.8 ([nixos/nixpkgs⁠#253489](https://togithub.com/nixos/nixpkgs/issues/253489))
* [`51297922`](https://github.com/NixOS/nixpkgs/commit/5129792275086d46968d064ea246f31ee6bc9bb3) python311Packages.aioesphomeapi: 16.0.3 -> 16.0.5
* [`73052ba9`](https://github.com/NixOS/nixpkgs/commit/73052ba9249659ea29aadc215b313cca26c6040a) python311Packages.aiolyric: 1.0.10 -> 1.1.0
* [`5fd9190d`](https://github.com/NixOS/nixpkgs/commit/5fd9190d3b99910b3c5ac11ffbd1c8c7517d665f) python311Packages.aioshelly: 5.4.0 -> 6.0.0
* [`83659c7c`](https://github.com/NixOS/nixpkgs/commit/83659c7c6eb4afdc3ab312aa51283717d329cf53) python311Packages.aiounifi: 61 -> 61
* [`31b59a1f`](https://github.com/NixOS/nixpkgs/commit/31b59a1fc08bc535d691fe62cd9e7069fc1b7de4) python311Packages.hatasmota: 0.6.5 -> 0.7.0
* [`18a30be8`](https://github.com/NixOS/nixpkgs/commit/18a30be86a903cdf73eab74f3679a2c50913b918) python311Packages.pymodbus: 3.3.2 -> 3.5.0
* [`f3cf0585`](https://github.com/NixOS/nixpkgs/commit/f3cf0585eb928af7971cb297f4d1b4eb25310b9f) python311Packages.aiotractive: 0.5.5 -> 0.5.6
* [`9187dc14`](https://github.com/NixOS/nixpkgs/commit/9187dc141c8cfd9913818e9085bc4bcad3972699) python311Packages.python-bsblan: 0.5.15 -> 0.5.16
* [`1028115c`](https://github.com/NixOS/nixpkgs/commit/1028115c8e0dfb0cfd1b5cbb9a44a75680c0b264) python311Packages.reolink-aio: 0.7.8 -> 0.7.9
* [`0ae97cda`](https://github.com/NixOS/nixpkgs/commit/0ae97cda12672463103fa49fbd539152b94c0abd) python311Packages.zwave-js-server-python: 0.49.0 -> 0.51.1
* [`3734044c`](https://github.com/NixOS/nixpkgs/commit/3734044c2d048fa7bda10ddd6ef0528d818a696b) python311Packages.aiocomelit: init at 0.0.6
* [`5646d24e`](https://github.com/NixOS/nixpkgs/commit/5646d24e0c5df907b8797a49f741861dee6ff3bc) python311Packages.aiovodafone: init at 0.0.8
* [`ee9e52a5`](https://github.com/NixOS/nixpkgs/commit/ee9e52a52ea4b1987ea03f7217c3e65b6e616c1c) python311Packages.universal-silabs-flasher: init at 0.0.13
* [`c1985b81`](https://github.com/NixOS/nixpkgs/commit/c1985b815f3ac2cb411567a184beb6fd73ab442f) python311Packages.aioruckus: init at 0.34
* [`f2e1a4b0`](https://github.com/NixOS/nixpkgs/commit/f2e1a4b0cdab05a2744a3e44ee1675f077167b9c) python311Packages.aiowaqi: init at 1.1.0
* [`c5c4ba32`](https://github.com/NixOS/nixpkgs/commit/c5c4ba3280302d83f62efd8da21f9065d4396be6) python311Packages.pywaze: init at 0.3.0
* [`a236e5f8`](https://github.com/NixOS/nixpkgs/commit/a236e5f81a5fbfdc9365527d4695cdb3e9b97180) python310Packages.gspread: 5.11.0 -> 5.11.1
* [`2d150393`](https://github.com/NixOS/nixpkgs/commit/2d15039387a2212f6718bffb937ebe04d7464ce5) tests.cc-wrapper: add supported and move tests to subsets
* [`74cce928`](https://github.com/NixOS/nixpkgs/commit/74cce92876075a577ea8186e6715765253601b02) deltachat-desktop: 1.40.1 -> 1.40.2
* [`f2792826`](https://github.com/NixOS/nixpkgs/commit/f2792826225b199169aac2b5e5e785f1e54a517c) btcpayserver: 1.11.3 -> 1.11.4
* [`e4110a5e`](https://github.com/NixOS/nixpkgs/commit/e4110a5ebf50ba1f9fa6397b83db986de84350fb) figma-linux: Add missing wrapGAppsHook
* [`1a25f677`](https://github.com/NixOS/nixpkgs/commit/1a25f677044bd036ccd2edcdbdfe81f5dbf3fa92) tagparser: 12.0.0 -> 12.1.0
* [`0a1748bf`](https://github.com/NixOS/nixpkgs/commit/0a1748bfaa89fc5e97fbd70fa84e674a044e4c88) papeer: 0.7.1 -> 0.7.2
* [`cb1d6c17`](https://github.com/NixOS/nixpkgs/commit/cb1d6c17a3b0325a1a564fac31dd61078afcf337) zef: 0.18.3 -> 0.19.1
* [`17c3168b`](https://github.com/NixOS/nixpkgs/commit/17c3168b41a6fef55f4d07ae133f540b40e0abf3) python310Packages.seatconnect: 1.1.7 -> 1.1.9
* [`3009e9fb`](https://github.com/NixOS/nixpkgs/commit/3009e9fb922285afe72ab530f752381d525a89f9) prometheus-rtl_433-exporter: use sri hash
* [`bf68b20e`](https://github.com/NixOS/nixpkgs/commit/bf68b20e5654c19489aa39d9bbf73ff92e6edd19) tfsec: 1.28.1 -> 1.28.2
* [`2a54f595`](https://github.com/NixOS/nixpkgs/commit/2a54f59560ac85ca40573d3f44b2085dda131f3b) python310Packages.bellows: 0.36.2 -> 0.36.3
* [`0251e264`](https://github.com/NixOS/nixpkgs/commit/0251e2645a0e06a033a436b1064891de2881cb5c) llvmPackages_15.libcxx: fix the generated linker script
* [`6bcca55e`](https://github.com/NixOS/nixpkgs/commit/6bcca55e0cf2e6ca52f19acf9b77fc2ac30044c8) python310Packages.adafruit-platformdetect: 3.49.0 -> 3.51.0
* [`3d7fb679`](https://github.com/NixOS/nixpkgs/commit/3d7fb6794ebd23c598be39b0f875eab279c54ff7) emacsPackages.ebuild-mode: switch to melpaBuild
* [`2bd22521`](https://github.com/NixOS/nixpkgs/commit/2bd2252183593fefdbadf4aeed1cbadcafb135ca) streamdeck-ui: 3.0.1 -> 3.1.0
* [`07d688c9`](https://github.com/NixOS/nixpkgs/commit/07d688c98d610aacc2230b2e7295a3169e60826b) sqlx-cli: use openssl instead of rustls
* [`3526a837`](https://github.com/NixOS/nixpkgs/commit/3526a837bf16ea6f329301c18eb32261600abfa1) bililiverecorder: 2.8.2 -> 2.9.0
* [`811b4628`](https://github.com/NixOS/nixpkgs/commit/811b46283ad2fe4170feafb9d75dcec21c92a6d6) git-credential-oauth: 0.10.0 -> 0.10.1
* [`497e8979`](https://github.com/NixOS/nixpkgs/commit/497e897975617597822200d8e03332ed2f701c40) gef: 2023.06 -> 2023.08
* [`03631d72`](https://github.com/NixOS/nixpkgs/commit/03631d72d71f269e2dac3661be74da9a90e2e227) gobgpd: 3.17.0 -> 3.18.0
* [`8db30464`](https://github.com/NixOS/nixpkgs/commit/8db304643574ca24fdf31c8a99ccaa207107baf8) scaleway-cli: 2.19.0 -> 2.20.0
* [`10bb3be6`](https://github.com/NixOS/nixpkgs/commit/10bb3be659f65c84b5639e83a94f3415927850bc) cudaPackages.cudnn: use libcublas split outputs
* [`6ce024fd`](https://github.com/NixOS/nixpkgs/commit/6ce024fd01ebf160b8176281e33c9410abaad7fb) sarasa-gothic: 0.41.8 -> 0.41.9
* [`d2f89d16`](https://github.com/NixOS/nixpkgs/commit/d2f89d16da066e87fc3779359c711db3bf583279) signal-cli: 0.12.0 -> 0.12.1
* [`225048f6`](https://github.com/NixOS/nixpkgs/commit/225048f694ac317dd46d4741303697cccc58d678) xray: 1.8.3 -> 1.8.4
* [`e7aa53ba`](https://github.com/NixOS/nixpkgs/commit/e7aa53bad09b3f92783f3a85426f2a6d6897baf3) nixops_unstable: mark cryptography insecure
* [`89ff90cc`](https://github.com/NixOS/nixpkgs/commit/89ff90cc5e93f225d4148e38ac8ee6d154369887) aws-nuke: install completions
* [`8c2225cf`](https://github.com/NixOS/nixpkgs/commit/8c2225cf4d983dfeae4f5284c447d309e4e71b99) aws-nuke: add ldflags
* [`a3b55ca3`](https://github.com/NixOS/nixpkgs/commit/a3b55ca3ca1de3a24f86d3852bb8ad7b75cb4830) dnscontrol: add mainProgram
* [`da2a0af1`](https://github.com/NixOS/nixpkgs/commit/da2a0af17aaabe0e7a21078721d4c45ec9d1b28b) twilio-cli: 5.13.0 -> 5.14.0
* [`c306ac2b`](https://github.com/NixOS/nixpkgs/commit/c306ac2b6c67ab7e79b4e3f736af4cc350d18257) millet: 0.13.0 -> 0.13.1
* [`6d260b47`](https://github.com/NixOS/nixpkgs/commit/6d260b4755be12151fef3ae69899801644c6e79b) luau: 0.593 -> 0.594
* [`c18551da`](https://github.com/NixOS/nixpkgs/commit/c18551dadaf67ef50fa5042b306fe1de9d957d0a) reviewdog: 0.14.2 -> 0.15.0
* [`8130c2a8`](https://github.com/NixOS/nixpkgs/commit/8130c2a8a4e8b925dcc6d17c5caf7a14ccfaa7d1) _1password: 2.20.0 -> 2.21.0
* [`d7490c9f`](https://github.com/NixOS/nixpkgs/commit/d7490c9f53e579c559b7e7bfcf44b50c428d9833) arti: 1.1.7 -> 1.1.8
* [`afaf2991`](https://github.com/NixOS/nixpkgs/commit/afaf2991dd193ba4ca5b9d1003b6e4b020c742a2) flow: 0.215.1 -> 0.216.1
* [`2644f6a7`](https://github.com/NixOS/nixpkgs/commit/2644f6a7f312a7e431e805dda64f97cc5c22326e) nodejs_20: 20.6.0 -> 20.6.1
* [`daac0de6`](https://github.com/NixOS/nixpkgs/commit/daac0de6bf55862511e6e0ad4cdb3971bf1e680c) python310Packages.breezy: 3.3.3 -> 3.3.4
* [`a454cd9d`](https://github.com/NixOS/nixpkgs/commit/a454cd9df728f9de48a155da8ec4695c5354ba07) redis: 7.2.0 -> 7.2.1
* [`e96e4c1d`](https://github.com/NixOS/nixpkgs/commit/e96e4c1d6b61aa4474a15ade7ccb75b822a7fef7) flexget: 3.9.5 -> 3.9.7
* [`e7b93874`](https://github.com/NixOS/nixpkgs/commit/e7b938742aebe23c25d097f76001a80f01dd8df0) vale: 2.28.2 -> 2.28.3
* [`f56a09ea`](https://github.com/NixOS/nixpkgs/commit/f56a09ea12b94a0628d83647ecc9a253e5fefc25) signal-cli: add changelog to meta
* [`9e58685b`](https://github.com/NixOS/nixpkgs/commit/9e58685b9c3ef347fd91cc477b0a08fc207b4f58) aws-nuke: add changelog to meta
* [`27dbd578`](https://github.com/NixOS/nixpkgs/commit/27dbd578cd467b5fde8d9a73c97dc7170959278f) dnscontrol: update homepage
* [`16086849`](https://github.com/NixOS/nixpkgs/commit/160868498fa7e77b5e1cce63b125645ded7337dd) rubyPackages: update
* [`75cfae1f`](https://github.com/NixOS/nixpkgs/commit/75cfae1fc1c719fdb28116bfa2dde1373fa82c09) expidus-file-manager: update 0.2.0 -> 0.2.1
* [`7b6bc252`](https://github.com/NixOS/nixpkgs/commit/7b6bc2521bc539c3a4ff479c0ec4ab902eee8594) poetry2nix: mark poetry insecure
* [`7af18297`](https://github.com/NixOS/nixpkgs/commit/7af1829797c1b3a15d2bbb158bad053d1ae621ce) mpir: fix build with clang 16
* [`ca72defe`](https://github.com/NixOS/nixpkgs/commit/ca72defe5fdde324c3bc28495bd7084fd878d4a3) syncthingtray-minimal: 1.4.5 -> 1.4.6
* [`435e6b77`](https://github.com/NixOS/nixpkgs/commit/435e6b772be10d2f03daaabd98f83b3d6b5e1667) python310Packages.wandb: 0.15.5 -> 0.15.10
* [`2932ee75`](https://github.com/NixOS/nixpkgs/commit/2932ee753d245a1b19535236886fba620c4faeba) deconz: init at 2.23.00
* [`6f085ddc`](https://github.com/NixOS/nixpkgs/commit/6f085ddcfe983d6ca025bf27434015ee5dc4cb6f) python310Packages.hvac: 1.1.1 -> 1.2.0
* [`bcfcff9a`](https://github.com/NixOS/nixpkgs/commit/bcfcff9ad15c6bbb4147655d9281b393250038b5) hashcat: patch to build on apple silicon
* [`71c971b0`](https://github.com/NixOS/nixpkgs/commit/71c971b0f1eafaf0c428a5138c8192d0cf87a94f) dotnet-sdk: 6.0.412 -> 6.0.413
* [`d2d7504a`](https://github.com/NixOS/nixpkgs/commit/d2d7504a4a88191da105f89726e96adb880fe620) dotnet-sdk_7: 7.0.306 -> 7.0.400
* [`cb686eeb`](https://github.com/NixOS/nixpkgs/commit/cb686eeb00c8d0e270f90adbd915564139baad4b) ibus-engines.typing-booster-unwrapped: 2.23.4 -> 2.24.0
* [`9acbef97`](https://github.com/NixOS/nixpkgs/commit/9acbef97fa4f1b2255808a0b750021936d1343b7) crun: 1.8.7 -> 1.9
* [`1171ea9c`](https://github.com/NixOS/nixpkgs/commit/1171ea9cc2a023858922cd1f4bdfe20052d52759) exploitdb: 2023-09-07 -> 2023-09-08
* [`6d208146`](https://github.com/NixOS/nixpkgs/commit/6d208146f8b4ed6ca7f2793a6e729147a2e62897) brotab: add missing dependency `setuptools`
* [`29c7ce56`](https://github.com/NixOS/nixpkgs/commit/29c7ce56873f050560f90bd99c116f1334d4723c) toybox: 0.8.9 -> 0.8.10
* [`0342a519`](https://github.com/NixOS/nixpkgs/commit/0342a5194b62f5c5375dbae9f065cb33722dc466) jupyter-console: expose as a tool for launching kernels
* [`06e13b24`](https://github.com/NixOS/nixpkgs/commit/06e13b240ddd87fb2499c24251897b6817b77fb9) bookstack: 23.06.2 -> 23.08.2
* [`3c3299bd`](https://github.com/NixOS/nixpkgs/commit/3c3299bdc2d866c5b3d3d13f98f52d1c7743bd9d) jotta-cli: 0.15.84961 -> 0.15.89752
* [`fd18c9fb`](https://github.com/NixOS/nixpkgs/commit/fd18c9fb9d85f2cf33d04f1f94f9fe8174a30ede) python310Packages.nvidia-ml-py: 12.535.77 -> 12.535.108
* [`e5f3c93a`](https://github.com/NixOS/nixpkgs/commit/e5f3c93afdf63241df3befd03a0d784214a37ce8) signal-desktop: 6.29.1 -> 6.30.1
* [`3115a7c1`](https://github.com/NixOS/nixpkgs/commit/3115a7c1d6b55272d419132352e7a863b2fa152d) signal-desktop-beta: 6.30.0-beta.2 -> 6.31.0-beta.1
* [`1e6c8f18`](https://github.com/NixOS/nixpkgs/commit/1e6c8f18cb35305cf6fa6b79cb3a4ed18d907af1) dolt: 1.8.8 -> 1.14.0
* [`82ea1d46`](https://github.com/NixOS/nixpkgs/commit/82ea1d463128e5f1716fee180beab1371a6cc8c2) python311Packages.dbus-fast: 1.95.0 -> 1.95.1
* [`c6915a43`](https://github.com/NixOS/nixpkgs/commit/c6915a43902b3f5d7e52bb5ad172173614cb4b21) exoscale-cli: 1.72.1 -> 1.72.2
* [`7539360c`](https://github.com/NixOS/nixpkgs/commit/7539360ce3c64cd6a71fb9ff63d96a265c39e5df) python311Packages.dbus-fast: 1.95.1 -> 1.95.2
* [`046eca9a`](https://github.com/NixOS/nixpkgs/commit/046eca9a24dd5fed66a93f6187c42182b7ed6c59) frugal: 3.16.24 -> 3.16.27
* [`5265e886`](https://github.com/NixOS/nixpkgs/commit/5265e8864a7006b8d441fce343a4f3812bd5a6fb) mssql_jdbc: 12.4.0 -> 12.4.1
* [`89261204`](https://github.com/NixOS/nixpkgs/commit/89261204b6a46929f9c6e2cf7e2281c7a2d1c5d7) zigbee2mqtt: 1.32.2 -> 1.33.0
* [`83b955f8`](https://github.com/NixOS/nixpkgs/commit/83b955f828f46061da86e8c334518f99e71ab431) python311Packages.dbus-fast: 1.95.2 -> 2.0.0
* [`a2bd84c8`](https://github.com/NixOS/nixpkgs/commit/a2bd84c8f85b8a05820c7ade6321b529ac2b99b3) heroic: specify electron version to match upstream
* [`f1541b81`](https://github.com/NixOS/nixpkgs/commit/f1541b8165da9e2cbdf2052effe4a4bffa258ca1) python311Packages.seatconnect: add changelog to meta
* [`451c2211`](https://github.com/NixOS/nixpkgs/commit/451c2211370e9b4bbac8b20de2a2a47256cf6c1e) python311Packages.seatconnect: remove postPatch section
* [`ac54c203`](https://github.com/NixOS/nixpkgs/commit/ac54c20330416a2a0e51e20ab0cb5ad0a8269a9b) linux: 5.15.130 -> 5.15.131
* [`1451d3d9`](https://github.com/NixOS/nixpkgs/commit/1451d3d9e6a1f93dce18e560ace56f00dad530ea) linux: 6.1.51 -> 6.1.52
* [`fa652714`](https://github.com/NixOS/nixpkgs/commit/fa652714fa858f0d82780dc5d627139be6f3c079) linux: 6.4.14 -> 6.4.15
* [`a3c47405`](https://github.com/NixOS/nixpkgs/commit/a3c4740523b50934c20b28d6a67f0f5fa2f29075) linux: 6.5.1 -> 6.5.2
* [`d056e2a9`](https://github.com/NixOS/nixpkgs/commit/d056e2a92bab392ada4d3f64affc47ee720f6284) imgui: 1.89.8 -> 1.89.9
* [`e381dfc8`](https://github.com/NixOS/nixpkgs/commit/e381dfc8156f4201ba9f7695704562cea033788a) sentry-cli: 2.20.5 -> 2.20.7
* [`b24287dd`](https://github.com/NixOS/nixpkgs/commit/b24287dde88c21108880d08bdd5dbc03240bd900) home-assistant: 2023.8.4 -> 2023.9.0
* [`4deda2a9`](https://github.com/NixOS/nixpkgs/commit/4deda2a9c8768ee52ac6ffc262d94bbb46596cab) python310Packages.pyruckus: remove
* [`de5fa879`](https://github.com/NixOS/nixpkgs/commit/de5fa879ed6fe0869b38fe93d15a87fb12620652) python311Packages.homeassistant-stubs: 2023.8.4 -> 2023.9.0
* [`c85eef94`](https://github.com/NixOS/nixpkgs/commit/c85eef94d291b29a369d9054c45ea7ef703d902f) python310Packages.bimmer-connected: provide test responses
* [`e7d3f6bc`](https://github.com/NixOS/nixpkgs/commit/e7d3f6bc3644d889049bbab40c43a9bc6117248e) home-assistant: pin plexapi at 4.13.2
* [`e40439b0`](https://github.com/NixOS/nixpkgs/commit/e40439b029cd0ac25aebac8e3d101b5a6a604d0e) python311Packages.zeroconf: 0.99.0 -> 0.102.0
* [`b3da5e68`](https://github.com/NixOS/nixpkgs/commit/b3da5e68a18f456ec57d9b1ea16713ba9d041d6c) home-assistant: pin zeroconf at 0.91.1
* [`8dfdd191`](https://github.com/NixOS/nixpkgs/commit/8dfdd191aa9604fb4c64479d829e10fb1ad62a27) maintainers: add dunxen
* [`01d9ff8c`](https://github.com/NixOS/nixpkgs/commit/01d9ff8cbf26b94430774c15c6f901bd4bfa29ff) julia-mono: 0.050 -> 0.051
* [`6ac6990b`](https://github.com/NixOS/nixpkgs/commit/6ac6990b8feac23039a881a891f5214cff13449f) linux/hardened/patches/4.14: 4.14.323-hardened1 -> 4.14.325-hardened1
* [`bb82e63c`](https://github.com/NixOS/nixpkgs/commit/bb82e63cbd172ca802c26a942a88573c2560f8ff) linux/hardened/patches/4.19: 4.19.292-hardened1 -> 4.19.294-hardened1
* [`d475f8ff`](https://github.com/NixOS/nixpkgs/commit/d475f8ff5eec2714cc6beac59ad9c04f364e2161) linux/hardened/patches/5.10: 5.10.191-hardened1 -> 5.10.194-hardened1
* [`0d7c44bf`](https://github.com/NixOS/nixpkgs/commit/0d7c44bfa8993d18f9408ac8c72cc16ba04884ab) linux/hardened/patches/5.15: 5.15.127-hardened1 -> 5.15.130-hardened1
* [`14a7fc87`](https://github.com/NixOS/nixpkgs/commit/14a7fc876f45439b23b1754cd3152473e444a88d) linux/hardened/patches/5.4: 5.4.254-hardened1 -> 5.4.256-hardened1
* [`93ee933c`](https://github.com/NixOS/nixpkgs/commit/93ee933c2e63e42ec5002715acc1b75c9442d40e) linux/hardened/patches/6.1: 6.1.47-hardened1 -> 6.1.51-hardened1
* [`632d72f4`](https://github.com/NixOS/nixpkgs/commit/632d72f463ae38bfe618016f1780717a95ffc77f) linux/hardened/patches/6.4: 6.4.12-hardened1 -> 6.4.14-hardened1
* [`652837d9`](https://github.com/NixOS/nixpkgs/commit/652837d9d4c876322a80d79961cd88f046fea162) freerdpUnstable: 2.11.0 -> 2.11.1
* [`131d3cb0`](https://github.com/NixOS/nixpkgs/commit/131d3cb085f239e5b8fb17bfac237ab9dcd59cd4) python310Packages.tensorflow-datasets: 4.9.2 -> 4.9.3
* [`f538d909`](https://github.com/NixOS/nixpkgs/commit/f538d909705432475dd3a81b965883426636cfee) oh-my-posh: 18.3.5 -> 18.7.0
* [`75900df4`](https://github.com/NixOS/nixpkgs/commit/75900df417fc3d5e1b6bc64dd31e4c65e069dda1) ocamlPackages.awa: remove spurious dependency
* [`b787aa20`](https://github.com/NixOS/nixpkgs/commit/b787aa207f8ca5d21021e704a4d177ea362f7723) ocaml-ng.ocamlPackages_5_1.ocaml: init at 5.1.0-rc3
* [`ceae7479`](https://github.com/NixOS/nixpkgs/commit/ceae74797d5d238c1496ce1c86295182535acd33) mission-center: 0.3.1 -> 0.3.2
* [`d1f1457e`](https://github.com/NixOS/nixpkgs/commit/d1f1457e3f66a757526da0cb49e5f93ba2c5dfc3) ocamlPackages.tls: 0.16.0 → 0.17.1
* [`dd57b3f2`](https://github.com/NixOS/nixpkgs/commit/dd57b3f25042f3fe7852d0e6a817da440aebfe98) php: fix path to `genfiles`
* [`3bdbcacb`](https://github.com/NixOS/nixpkgs/commit/3bdbcacb1fcf518f1d729af09076fecea40eb3a6) dolibarr: 17.0.3 -> 18.0.1
* [`3510b92a`](https://github.com/NixOS/nixpkgs/commit/3510b92a960406774682c41c438239a951802124) openimageio: 2.4.14.0 -> 2.4.15.0
* [`350a1b3e`](https://github.com/NixOS/nixpkgs/commit/350a1b3e022c3d05dba9e3ddf4050409a49ee474) home-assistant: propagate packaging
* [`b02edfa6`](https://github.com/NixOS/nixpkgs/commit/b02edfa6f948e0b6f3c5bc6b4368a53bb0d0aacb) python310Packages.unstructured-inference: 0.5.7 -> 0.5.22
* [`636f8009`](https://github.com/NixOS/nixpkgs/commit/636f80091e5e861055a413c7e43a453bc7e466fe) unstructured-api: 0.0.41 -> 0.0.42
* [`95fd689f`](https://github.com/NixOS/nixpkgs/commit/95fd689f85add9a871fedcb896104330236b338f) php: run `genfiles` for building extensions too
* [`717e80b7`](https://github.com/NixOS/nixpkgs/commit/717e80b7e069eabaa5e21a4d9dd152f25ecd3f4f) ssh-audit: 2.9.0 -> 3.0.0
* [`2b73c06a`](https://github.com/NixOS/nixpkgs/commit/2b73c06a68ba01045c23fefeb9bdc8ac1fa0c9b5) ssh-audit: add changelog to meta
* [`fd758bca`](https://github.com/NixOS/nixpkgs/commit/fd758bca2491eefe41e7081d7ac20b779581205d) ssh-audit: add format
* [`127ddbae`](https://github.com/NixOS/nixpkgs/commit/127ddbae4a8bc78fdf712a2434d414e8f2150ac0) atomic-swap: 0.4.1 -> 0.4.2
* [`a81e3dcd`](https://github.com/NixOS/nixpkgs/commit/a81e3dcd759ffb44348186bdc3751af9ea2f1005) treewide: replace libc == "msvcrt" with isMinGW
* [`1e0561d7`](https://github.com/NixOS/nixpkgs/commit/1e0561d78a3d3cd84bac45ab474af82e32802120) nixpkgs/systems: Add ucrt64 as MinGW libc
* [`345a334e`](https://github.com/NixOS/nixpkgs/commit/345a334e9e5f1b871101df8ff88628f5ba0c51d9) sd-local: 1.0.46 -> 1.0.48
* [`9c5afb2f`](https://github.com/NixOS/nixpkgs/commit/9c5afb2f9acdd7d9eb15b8fe1689cd91af05ed8c) nixos/binfmt: improve type annotations
* [`69defb96`](https://github.com/NixOS/nixpkgs/commit/69defb96b5513440d91cf071781eaf6d59e3fab7) nixosTests.sudo: use same maintainers as the package
* [`bbb41ff7`](https://github.com/NixOS/nixpkgs/commit/bbb41ff7190ec98840f69fc367a1ddf697c25396) sudo: drop edolstra from maintainers (inactive)
* [`a23d0e45`](https://github.com/NixOS/nixpkgs/commit/a23d0e45c08dc7cff2926ab43cdf0283a14dc996) gnome-frog: set meta.mainProgram
* [`aafab3b5`](https://github.com/NixOS/nixpkgs/commit/aafab3b5b60146c1976fe630c980ce5b26d9ec5d) gcc: for cross compilers, don't build libgcc twice
* [`05fd421a`](https://github.com/NixOS/nixpkgs/commit/05fd421ae8520ef5024a3c0daf58f78a9091b35b) leptosfmt: 0.1.13 -> 0.1.14
* [`7b11f011`](https://github.com/NixOS/nixpkgs/commit/7b11f011022b2ec01207c9cf5e989489306fe46f) python310Packages.dataclass-factory: 2.13 -> 2.16
* [`5cedb097`](https://github.com/NixOS/nixpkgs/commit/5cedb097a0a07c36125e274404b67ed9c51d88b0) androidenv.buildApp: fix after callPackage switch
* [`db76ee42`](https://github.com/NixOS/nixpkgs/commit/db76ee42c288dcc534d9ab1b6865b6d0a585c33d) jack-example-tools: add darwin support
* [`cb3749e4`](https://github.com/NixOS/nixpkgs/commit/cb3749e4235b008f489ec5a4f3f2a6099551903b) transmission-remote-gtk: 1.5.1 -> 1.6.0
* [`37fd4294`](https://github.com/NixOS/nixpkgs/commit/37fd4294fdba6e118c85abbe4e1e56358b76cdce) ldacbt: Mark as littleEndian-only
* [`f4e90e51`](https://github.com/NixOS/nixpkgs/commit/f4e90e518149e07c2749c1ab9450f837f53c68dc) cargo-make: 0.36.13 -> 0.37.0
* [`0ee24e0b`](https://github.com/NixOS/nixpkgs/commit/0ee24e0b6e290810df3c2b99b829bfe8d0298166) python3.pkgs.python-rtmidi: Fix build on darwin
* [`61905992`](https://github.com/NixOS/nixpkgs/commit/619059929d669c6d1ccd156fe83e411c195e7852) cargo-make: set meta.mainProgram
* [`a68dc64e`](https://github.com/NixOS/nixpkgs/commit/a68dc64ea14e01781c09d88a2333d642f2c960dd) xpra: depend on libappindicator
* [`9f815be6`](https://github.com/NixOS/nixpkgs/commit/9f815be60520665e139fb8575a64218fc7994ecc) perldevel: remove
* [`b90ab315`](https://github.com/NixOS/nixpkgs/commit/b90ab315c1407e6eb0dc53917c2d866d65e0eab2) unit: remove `withPerldevel` option
* [`fc4d0f61`](https://github.com/NixOS/nixpkgs/commit/fc4d0f61585c0ccdf7de2ef789d0095d0f0258fc) rusti-cal: init at 1.1.0
* [`a4f6862f`](https://github.com/NixOS/nixpkgs/commit/a4f6862fb17a1a325090a309b362cddba7292a61) klipper: fix cross compilation
* [`4c290503`](https://github.com/NixOS/nixpkgs/commit/4c2905034a76f582c977a6c9b980d99cd020b246) gitea: 1.20.3 -> 1.20.4
* [`8fd861d1`](https://github.com/NixOS/nixpkgs/commit/8fd861d13a28a5594f5c576b177054d8c6ea4182) famistudio: 4.1.2 -> 4.1.3
* [`f64409b5`](https://github.com/NixOS/nixpkgs/commit/f64409b5ed66aad87cbf565fd4b20573d9355c74) ifrextractor-rs: init at 1.5.1
* [`08a785c6`](https://github.com/NixOS/nixpkgs/commit/08a785c6a81a94cfc70a6f575101dd828c7aa973) python311Packages.reptor: init at 0.2
* [`966f8ac2`](https://github.com/NixOS/nixpkgs/commit/966f8ac265a3dd2764a67878d4ff6bd104e25d6c) ldeep: 1.0.11 -> 1.0.34
* [`0bcdfa92`](https://github.com/NixOS/nixpkgs/commit/0bcdfa925399c4dfc052ef9b0b03d92d7481831c) mobilizon: 3.1.3 -> 3.2.0
* [`5061d9da`](https://github.com/NixOS/nixpkgs/commit/5061d9daf0e3960dac85948de775497f81b509e8) systemd.watchdog: (docs): include note about systemd default watchdog reboot time
* [`eb45cdf9`](https://github.com/NixOS/nixpkgs/commit/eb45cdf9fadf3dfdb14e884c2d7faf39a0eb9310) pot: 2.0.0 -> 2.1.0
* [`a8e5d8fc`](https://github.com/NixOS/nixpkgs/commit/a8e5d8fcc5eac68c6701d2d01e1a26eb91681662) zint: set platforms
* [`a6a01252`](https://github.com/NixOS/nixpkgs/commit/a6a01252d5f73ad2c3e6e32aaabfff0bd2a41ef0) blueprint-compiler: add darwin support
* [`512804bd`](https://github.com/NixOS/nixpkgs/commit/512804bd67997a5acf9707ff4ed80cb064f87231) ldeep: migrate to python3.pkgs.buildPythonApplication
* [`ef7ff525`](https://github.com/NixOS/nixpkgs/commit/ef7ff5259e4290274213bb05784b1adfa88e4f2c) gtree: 1.9.8 -> 1.9.9
* [`bb5082a2`](https://github.com/NixOS/nixpkgs/commit/bb5082a2340a8786b8da363ce7a0a3756141769d) ttop: 1.2.3 -> 1.2.4
* [`9fc09f19`](https://github.com/NixOS/nixpkgs/commit/9fc09f19b2b410d50adcd1417a85952b2a36d4bc) organicmaps: remove broken flag on aarch64-linux
* [`0a4413e9`](https://github.com/NixOS/nixpkgs/commit/0a4413e9fc1d060c6bb26fdd7c85bed67006fb3b) maintainers-list: add akgrant43
* [`4667f482`](https://github.com/NixOS/nixpkgs/commit/4667f482fffe11c2b02087105fc90548d7204356) glamoroustoolkit: init at v0.7.2
* [`8d945f43`](https://github.com/NixOS/nixpkgs/commit/8d945f43659f783c74a895e6fa39e3dd0e03fd60) glamoroustoolkit: 0.7.2 -> 0.7.3
* [`5db0bf37`](https://github.com/NixOS/nixpkgs/commit/5db0bf375d4913cd52a2aade1116dc43ad566d45) maintainers: update techknowlogick email
* [`e71418ae`](https://github.com/NixOS/nixpkgs/commit/e71418aee099dbac8a76f83099241c620420328c) phpExtensions.phalcon: init at 5.3.0
* [`e57f9b53`](https://github.com/NixOS/nixpkgs/commit/e57f9b53d7a1c71beddf923de889c1216b0c7612) maintainers: add krzaczek
* [`5ee22799`](https://github.com/NixOS/nixpkgs/commit/5ee2279901a1847bd3e5ab4d3338f71dd5e2dd04) neovide: 0.11.1 -> 0.11.2
* [`48785cd7`](https://github.com/NixOS/nixpkgs/commit/48785cd7ac877b68b42f7afc7f53ea746ebcc3b4) deltachat-desktop: 1.40.2 -> 1.40.3
* [`695cfcb5`](https://github.com/NixOS/nixpkgs/commit/695cfcb515613ca2cf07edf7962f75022f7b4ac0) maintainers: add coffeeispower
* [`c054b2a0`](https://github.com/NixOS/nixpkgs/commit/c054b2a07bce2be3b85fed85f45aea6a4b97f5cc) bun: 0.8.1 -> 1.0.0
* [`2d41cc62`](https://github.com/NixOS/nixpkgs/commit/2d41cc62f5734cec455a5d6d4f3c25b4034d86f7) bun: add coffeeispower as a maintainer
* [`6f2a7f88`](https://github.com/NixOS/nixpkgs/commit/6f2a7f88d45484d493cee4b7aa3a315efc17b1ec) bun: fix changelog link
* [`7a7d94c2`](https://github.com/NixOS/nixpkgs/commit/7a7d94c2423f22ced14413e7c13836569656814a) zcfan: init at 1.2.1
* [`d9f6fcbb`](https://github.com/NixOS/nixpkgs/commit/d9f6fcbbcf248952f1a06e36057dc347fb159f86) nodePackages.surge: use buildNpmPackage
* [`5abf9d71`](https://github.com/NixOS/nixpkgs/commit/5abf9d714754292e683e34195057bf0ba66484f3) git-ps-rs: 6.8.0 -> 6.9.0
* [`5564a6d9`](https://github.com/NixOS/nixpkgs/commit/5564a6d912fe965d6e17a61d7f8e8c707adb5e2b) davinci-resolve: fix platforms
* [`3f46cdcb`](https://github.com/NixOS/nixpkgs/commit/3f46cdcb5b903fe1c07707fea9ee24ae09d964b2) Revert "Merge pull request [nixos/nixpkgs⁠#253760](https://togithub.com/nixos/nixpkgs/issues/253760) from chivay/bootstrap-scrt"
* [`8a618245`](https://github.com/NixOS/nixpkgs/commit/8a61824580f23a6b3d28d8ed7a9b1573ba9b45bd) apko: 0.8.0 -> 0.10.0
* [`4f175d00`](https://github.com/NixOS/nixpkgs/commit/4f175d005bb9b3b609f3b62e32a79a75aadf5017) python311Packages.ansi2image: init at 0.1.4
* [`e6077539`](https://github.com/NixOS/nixpkgs/commit/e60775396cd908c072b1640c3621d930bd0ebd7a) calibre: 6.25.0 -> 6.26.0
* [`e1a29104`](https://github.com/NixOS/nixpkgs/commit/e1a29104a2ba6d97b6cecc051d8e8c1122d62009) fsautocomplete: 0.62.0 -> 0.63.0
* [`42699ad0`](https://github.com/NixOS/nixpkgs/commit/42699ad01cb9273cdd57c2bdd102ecd49acecd59) knowsmore: init at 0.1.37
* [`b0cf0e8a`](https://github.com/NixOS/nixpkgs/commit/b0cf0e8a016b200e5b0962d01a2c655fe6f3197f) python310Packages.django-celery-results: 2.4.0 -> 2.5.1
* [`92cc6c9e`](https://github.com/NixOS/nixpkgs/commit/92cc6c9e15f0b437995044dcea8a22e5e03ad8a6) signalbackup-tools: 20230906 -> 20230907
* [`c49f338a`](https://github.com/NixOS/nixpkgs/commit/c49f338aeb7dee8ac3c7d1be3dbf0a6be996fd31) netlistsvg: init at 1.0.2
* [`8bb42ad1`](https://github.com/NixOS/nixpkgs/commit/8bb42ad1af99fdf51538f01133429b94655914de) nixos/hail: Remove module
* [`60577d70`](https://github.com/NixOS/nixpkgs/commit/60577d70c0e9c53b56654eab90c8656bdd40263c) php81Packages.phpstan: 1.10.28 -> 1.10.33
* [`5942921d`](https://github.com/NixOS/nixpkgs/commit/5942921df7465ff7610f92ae64322d08a759b930) redisinsight: init at 2.30.0
* [`f91277e5`](https://github.com/NixOS/nixpkgs/commit/f91277e5b2da7a8709130edf35eb48ba6326ff15) salt: 3006.2 -> 3006.3
* [`7726835b`](https://github.com/NixOS/nixpkgs/commit/7726835b6fdaa17fea3f75cb8f139ab87669f5a7) hydra: add `meta.homepage` attribute
* [`a744442a`](https://github.com/NixOS/nixpkgs/commit/a744442af7b4755947041ee170459f4bde72316f) python310Packages.baycomp: 1.0.2 -> 1.0.3
* [`b3728398`](https://github.com/NixOS/nixpkgs/commit/b37283985bf2d755aeb3ddba399021f65b68758b) jujutsu: 0.8.0 -> 0.9.0
* [`7d797175`](https://github.com/NixOS/nixpkgs/commit/7d79717584db8cfa995c3d6a456ff857dde27d3c) translatelocally: init at unstable-2023-08-25
* [`5fc4692a`](https://github.com/NixOS/nixpkgs/commit/5fc4692a988f6a024d5906869b5306373c80513f) python311Packages.pyenphase: 1.9.3 -> 1.11.0
* [`2b61909c`](https://github.com/NixOS/nixpkgs/commit/2b61909c74d04ee0a3fef587fce4d4a66e9b9fe7) python311Packages.pymodbus: 3.5.0 -> 3.5.1
* [`61b1d804`](https://github.com/NixOS/nixpkgs/commit/61b1d80412517aaf5cb3ce6fe7c2fed46deed885) python311Packages.hatasmota: 0.7.0 -> 0.7.1
* [`204f1bf1`](https://github.com/NixOS/nixpkgs/commit/204f1bf11ccd2ec88350f5554939eea2b1bcae7d) okta-aws-cli: 1.2.1 -> 1.2.2
* [`9c79e5e7`](https://github.com/NixOS/nixpkgs/commit/9c79e5e75a39bc3ce3fa783e0afd842791f164a3) phpunit: 10.3.2 -> 10.3.3
* [`bf0647fd`](https://github.com/NixOS/nixpkgs/commit/bf0647fd2e94fc0a5ad09c4435df1ade392031ff) open62541: 1.3.6 -> 1.3.7
* [`e8210b2a`](https://github.com/NixOS/nixpkgs/commit/e8210b2aacaf403016c32098990816922adf4974) plausible: 1.4.4 -> 1.5.1
* [`2de435ae`](https://github.com/NixOS/nixpkgs/commit/2de435ae54e205f51377a809d640126c5ae7226e) python311Packages.proxy-db: init at 0.3.1
* [`07654c80`](https://github.com/NixOS/nixpkgs/commit/07654c80ab46d161e4edb63bcae0a36beda94754) vscode-extensions.shd101wyy.markdown-preview-enhanced: 0.6.8 -> 0.6.10
* [`735ee001`](https://github.com/NixOS/nixpkgs/commit/735ee001603b71011558af2016df8c8ffbbed702) python310Packages.django-celery-results: add changelog to meta
* [`280ae7c1`](https://github.com/NixOS/nixpkgs/commit/280ae7c16124d870aa9df33d9fa0630129255d0f) python311Packages.aiomqtt: 1.1.0 -> 1.2.0
* [`00352662`](https://github.com/NixOS/nixpkgs/commit/003526627a79b9266db8bf22282f355abc96cd57) python311Packages.androidtv: 0.0.71 -> 0.0.72
* [`9f28e9f3`](https://github.com/NixOS/nixpkgs/commit/9f28e9f305da3e433673f92530cb391f675c15bf) python311Packages.google-resumable-media: 2.5.0 -> 2.6.0
* [`fe569ae8`](https://github.com/NixOS/nixpkgs/commit/fe569ae8348864daff80ad91c535908c44b81680) python310Packages.mkdocs-jupyter: 0.24.1 -> 0.24.2
* [`e3b940ce`](https://github.com/NixOS/nixpkgs/commit/e3b940ced6de07210abf7356bfd7945d4658995f) openssl_1_1: apply patch for CVE-2023-4807
* [`d33672d9`](https://github.com/NixOS/nixpkgs/commit/d33672d98338b2e1e61b73c808ddc3dd714ef5d3) protonmail-bridge: 3.4.1 -> 3.4.2
* [`c729c974`](https://github.com/NixOS/nixpkgs/commit/c729c9746e41ef8ceb9ba2222eefcac848c31bca) nixos/stalwart-mail: fixed broken link
* [`d60f027a`](https://github.com/NixOS/nixpkgs/commit/d60f027a8f2111a3b548d6da722757ecd44ae144) sslscan: 2.0.16 -> 2.1.0
* [`481363f9`](https://github.com/NixOS/nixpkgs/commit/481363f9a8964b284ba24b1dd093232d99012435) python3Packages.dulwich: 0.21.5 -> 0.21.6
* [`13f3a33c`](https://github.com/NixOS/nixpkgs/commit/13f3a33cef3bc9c52be24135136c3f458f289ec4) swayr: 0.26.1 -> 0.27.0
* [`b52d40b8`](https://github.com/NixOS/nixpkgs/commit/b52d40b8671322a492676fd07eaa8bbabc886123) xandikos: replace prometheus-client with aiohttp-openmetrics
* [`88aa035e`](https://github.com/NixOS/nixpkgs/commit/88aa035e6c43619ce9dcfb17cd3a88944d12ea75) nodePackages.three: drop ([nixos/nixpkgs⁠#252430](https://togithub.com/nixos/nixpkgs/issues/252430))
* [`d798b7fc`](https://github.com/NixOS/nixpkgs/commit/d798b7fcb3ae1d37ebd1f836baac1a7b60e95002) beamerpresenter: 0.2.3 -> 0.2.4
* [`0f754297`](https://github.com/NixOS/nixpkgs/commit/0f754297bda59acac131cf34c7182520caeda627) cdwe: init at 0.3.0
* [`14d4cb07`](https://github.com/NixOS/nixpkgs/commit/14d4cb079b2bafb3256678144c2e90e7688e95ac) chromium: 116.0.5845.140 -> 116.0.5845.179
* [`940560cb`](https://github.com/NixOS/nixpkgs/commit/940560cb24fed04b6ed7e52a16665d7c388a8b2b) ungoogled-chromium: 116.0.5845.140-1 -> 116.0.5845.179-1
* [`bbc6174e`](https://github.com/NixOS/nixpkgs/commit/bbc6174eaa76065f0d94a0c2a107dbb7594cc3c8) audiobookshelf: fix reference to getopt in wrapper
* [`7e72fc3e`](https://github.com/NixOS/nixpkgs/commit/7e72fc3eb1d305347b92855560be531963dba480) pythonPackages.debianbts: set `passthru.updateScript`
* [`24a196b7`](https://github.com/NixOS/nixpkgs/commit/24a196b7f7778ded54886d81e10caad3633f9a8c) pythonPackages.pysimplesoap: set `passthru.updateScript`
* [`2cb9160f`](https://github.com/NixOS/nixpkgs/commit/2cb9160ff2009fd8da8203d0783df81ada151f5b) pythonPackages.pysimplesoap: Clarify Py3 status
* [`fdd277ba`](https://github.com/NixOS/nixpkgs/commit/fdd277ba61849e0e9375c5d7ad53995201c50b44) sudo-rs: Set `passthru.updateScript`
* [`b9718ad8`](https://github.com/NixOS/nixpkgs/commit/b9718ad80f0b42b6fd966cdc56c6a788a00207ff) fasm: 1.73.30 -> 1.73.31
* [`8c78a69f`](https://github.com/NixOS/nixpkgs/commit/8c78a69f7858a91c2c4d6cf4823a61630cee0559) python311Packages.tika-client: 0.2.0 -> 0.4.0
* [`6347f918`](https://github.com/NixOS/nixpkgs/commit/6347f9180af666c66c902dda2c4f168be5f37a68) python310Packages.tidalapi: 0.7.2 -> 0.7.3
* [`af68c285`](https://github.com/NixOS/nixpkgs/commit/af68c285896f2a22eea2534aa193fe8d61835dcc) tageditor: 3.8.1 -> 3.9.0
* [`f18f45cb`](https://github.com/NixOS/nixpkgs/commit/f18f45cb839227dac3c9e2128d6bd3e22bedab9c) pick-colour-picker: unstable-2021-01-19 -> unstable-2022-05-08
* [`3050fea1`](https://github.com/NixOS/nixpkgs/commit/3050fea1e21762114b91ff16ca35a05c96c299fa) jsonnet-language-server: 0.13.0 -> 0.13.1
* [`6d652105`](https://github.com/NixOS/nixpkgs/commit/6d6521056ff67ef42e2af96f428baab43a806341) python311Packages.ropgadget: 7.2 -> 7.4
* [`6945a1e6`](https://github.com/NixOS/nixpkgs/commit/6945a1e6507ab5c8125206e71039959a485bd328) asymptote: 2.85 -> 2.86
* [`2959bb29`](https://github.com/NixOS/nixpkgs/commit/2959bb29e1f9ee71875c57b4c214f9dd2995082c) jinja2-cli: init at 0.8.2
* [`b2255c85`](https://github.com/NixOS/nixpkgs/commit/b2255c853984248296333112f5534b64a6eb5ac4) kafkactl: 3.2.0 -> 3.3.0
* [`d53bc44b`](https://github.com/NixOS/nixpkgs/commit/d53bc44bf8cd28409a1d7aa1cb21f47447c34547) swc: 0.91.68 -> 0.91.69
* [`0f5391d9`](https://github.com/NixOS/nixpkgs/commit/0f5391d982709145c0c0ade00e0d25e199cbec7d) circt: 1.53.0 -> 1.54.0
* [`eec16801`](https://github.com/NixOS/nixpkgs/commit/eec1680164f5eb031dca04f799de51fbddbf5295) OSCAR: 1.4.0 -> 1.5.0
* [`a50329c7`](https://github.com/NixOS/nixpkgs/commit/a50329c71e8e2cdebe1980defe02b98b3ad746a5) python310Packages.django-admin-sortable2: 2.1.8 -> 2.1.9
* [`c06df7d5`](https://github.com/NixOS/nixpkgs/commit/c06df7d5cf3e74d19284dbe2942f4c07a0525c8e) appgate-sdp: 6.2.1 -> 6.2.2
* [`7127ce9b`](https://github.com/NixOS/nixpkgs/commit/7127ce9b853bde56b1e79bb8c7fe11e2dcf362ea) haruna: 0.12.0 -> 0.12.1
* [`e72b8025`](https://github.com/NixOS/nixpkgs/commit/e72b80255cd71dddb50aede2b00ee300ab4ce03d) libzip: 1.10.0 -> 1.10.1
* [`c4603d97`](https://github.com/NixOS/nixpkgs/commit/c4603d974646018d972abe3e85efb36f1d5d70c4) python310Packages.pyfluidsynth: init at 1.3.2
* [`91ba9e80`](https://github.com/NixOS/nixpkgs/commit/91ba9e809f55c12b66d29740963dadc75bb6ffdc) upiano: init at 0.1.2
* [`8cb20d59`](https://github.com/NixOS/nixpkgs/commit/8cb20d59d1ae0e55ed85d6cc09a267106eff3f10) kubernetes-helmPlugins.helm-cm-push: 0.10.3 -> 0.10.4
* [`e71a2ba9`](https://github.com/NixOS/nixpkgs/commit/e71a2ba9f9b83264a2fd40992ff9a5dc1c998b16) helm-docs: 1.11.0 -> 1.11.1
* [`cb0549a7`](https://github.com/NixOS/nixpkgs/commit/cb0549a77360f0da0867e32a1137e37668705179) spotify-player: Fix darwin support
* [`edfb23dd`](https://github.com/NixOS/nixpkgs/commit/edfb23dd6bd661e5bef1c57cc0d0c6461dcf5619) zxpy: init at 1.6.3
* [`3bd98897`](https://github.com/NixOS/nixpkgs/commit/3bd988976711416ccfcfd0841d9e6bc66e348e46) ripsecrets: init at 0.1.6
* [`844ce3f6`](https://github.com/NixOS/nixpkgs/commit/844ce3f6ba4c650d3d4b8e32d09b8dd07c944fc8) libzip: fix changelog
* [`f25f2a42`](https://github.com/NixOS/nixpkgs/commit/f25f2a4209f9f86ce3d795f7531e128476ef9f68) nixos/stage-2-init: dont use install to create /etc/nixos if it's a symlink
* [`3b77dfcc`](https://github.com/NixOS/nixpkgs/commit/3b77dfcc7e271c94da22fabe8e2b4f29cf80016d) nwg-look: init at v0.2.4
* [`4d142377`](https://github.com/NixOS/nixpkgs/commit/4d1423771d142a659c423dfc5f7740bea10cbe27) nwg-look: init at v0.2.4
* [`1487dccc`](https://github.com/NixOS/nixpkgs/commit/1487dcccf30252e7b4eb5fe05057aaf912e4c614) mantainers: update max-amb email
* [`2bf84ca0`](https://github.com/NixOS/nixpkgs/commit/2bf84ca052283a0babbb7ad5911f0e674e25c602) python311Packages.anel-pwrctrl-homeassistant: init at 0.0.1.dev2
* [`4c8bb5df`](https://github.com/NixOS/nixpkgs/commit/4c8bb5dfe221373e090e48c046ed11d565b48f55) home-assistant: update component packages
* [`ad126661`](https://github.com/NixOS/nixpkgs/commit/ad12666129bae0a15d38fbe5dfae7397a536a728) linuxptp: 4.0 -> 4.1
* [`9b92c015`](https://github.com/NixOS/nixpkgs/commit/9b92c01581969e01cbe67bc5b11aca6b361132de) circt: add update script
* [`f11fd24a`](https://github.com/NixOS/nixpkgs/commit/f11fd24a0f63726f3d9e307550782085796b8381) pylyzer: 0.0.42 -> 0.0.43
* [`67057819`](https://github.com/NixOS/nixpkgs/commit/670578191cccdd0337b64f5b7ad11ec9c105ed3a) pika-backup: 0.6.1 -> 0.6.2
* [`ac77a8f7`](https://github.com/NixOS/nixpkgs/commit/ac77a8f7d0bf33a43789a636023180fc053b1ace) igv: 2.16.1 -> 2.16.2
* [`4c713a34`](https://github.com/NixOS/nixpkgs/commit/4c713a347949fd3558745b1c242ec0be33ffa1ea) nwg-look: init at v0.2.4
* [`2b580760`](https://github.com/NixOS/nixpkgs/commit/2b58076080ebb5dd2f1c50df1b7f82ebcfc3a9f2) discordchatexporter-cli: 2.36.1 -> 2.40.4
* [`b6fe1254`](https://github.com/NixOS/nixpkgs/commit/b6fe1254b211881a725415b55f57cc99b45c90e9) beamerpresenter: change sha256=... to hash="sha256..."
* [`9bf511d4`](https://github.com/NixOS/nixpkgs/commit/9bf511d4e37759195ccffdb709ec3059c0992600) nwg-look: init at v0.2.4
* [`dbdf22e7`](https://github.com/NixOS/nixpkgs/commit/dbdf22e7b319c76a34ab04ca2b378c992ab6c3d7) python311Packages.aiomqtt: update disabled
* [`fdd9ca06`](https://github.com/NixOS/nixpkgs/commit/fdd9ca0685b61b791052c624efc31253f6b109b7) python311Packages.phonenumbers: 8.13.19 -> 8.13.20
* [`d01094d9`](https://github.com/NixOS/nixpkgs/commit/d01094d95c994810a003fa321b0a49daf1ade140) python311Packages.pydiscourse: 1.4.0 -> 1.6.1
* [`49c2c56a`](https://github.com/NixOS/nixpkgs/commit/49c2c56a9410260da2c3dba59421f626c2bc9d99) python310Packages.ipyvue: 1.10.0 -> 1.10.1
* [`b10f3bc4`](https://github.com/NixOS/nixpkgs/commit/b10f3bc430c17b725451e8b34a022f17c509875f) dabet: 3.0.0 -> 3.0.1
* [`c0f8c523`](https://github.com/NixOS/nixpkgs/commit/c0f8c5239213c61b2d89e37c0ee5ff349dbb0a99) python310Packages.yaspin: 2.3.0 -> 3.0.1
* [`d8baf422`](https://github.com/NixOS/nixpkgs/commit/d8baf4220740e79a34e976e9ebfa789760659695) juce: init at 7.0.7
* [`4df7bca7`](https://github.com/NixOS/nixpkgs/commit/4df7bca761c40b0425e1385c617cb4078139b4e9) cargo-xbuild: 0.6.5 -> 0.6.6
* [`229a3ea4`](https://github.com/NixOS/nixpkgs/commit/229a3ea4fea1f71c7d341a17edbd6825981a9199) cargo-run-bin: 1.1.5 -> 1.2.0
* [`2c069c6c`](https://github.com/NixOS/nixpkgs/commit/2c069c6c0b93a9a50f6b04a898ef39e25090417d) liana: init at 2.0
* [`2d689f2a`](https://github.com/NixOS/nixpkgs/commit/2d689f2a0ebc824dfef68264bf737ae1ef5c9dc6) cargo-risczero: 0.14.0 -> 0.17.0
* [`1c3acb98`](https://github.com/NixOS/nixpkgs/commit/1c3acb9887bbafcbf32f30730e99543556836d3a) redisinsight: 2.30.0 -> 2.32
* [`9fb96cd6`](https://github.com/NixOS/nixpkgs/commit/9fb96cd66b74e7d66c070c890de84c3cd7eee19a) clj-kondo: 2023.07.13 -> 2023.09.07
* [`e4f179cf`](https://github.com/NixOS/nixpkgs/commit/e4f179cf0435b995518f74c98f55aece2d5ae461) pokeget-rs: 1.2.0 -> 1.3.0
* [`e2ce81d7`](https://github.com/NixOS/nixpkgs/commit/e2ce81d70a8eaf0f5d93b3480e1631d47e872eb6) terragrunt: 0.50.13 -> 0.50.14
* [`15101633`](https://github.com/NixOS/nixpkgs/commit/15101633674f34798ae8a53e7ef3106078b3d4c4) chainsaw: 2.6.2 -> 2.7.3
* [`7e864658`](https://github.com/NixOS/nixpkgs/commit/7e864658c74f923c954f50285ee6a75ce9932d6e) argocd: 2.8.0 -> 2.8.3
* [`57dd71eb`](https://github.com/NixOS/nixpkgs/commit/57dd71eb962999cef86245072b67cdaace462ca4) moon: 1.13.0 -> 1.13.3
* [`c2720af3`](https://github.com/NixOS/nixpkgs/commit/c2720af3f41e2ebd3439bc1239aafa219216cb13) ghorg: 1.9.7 -> 1.9.9
* [`ac692af9`](https://github.com/NixOS/nixpkgs/commit/ac692af932113f357217ae0d7d2c1449a1a4bafb) treewide: fix pythonImportsCheck typos
* [`909980af`](https://github.com/NixOS/nixpkgs/commit/909980af3eb291a60aa4665a0c71d24bd09471ac) automatic-timezoned: 1.0.124 -> 1.0.125
* [`331df191`](https://github.com/NixOS/nixpkgs/commit/331df1911c45ed8ce698a6736ae08d00aae7dab0) denaro: 2023.8.1 -> 2023.9.1
* [`acff1c4c`](https://github.com/NixOS/nixpkgs/commit/acff1c4c388aee11cee961c532d2259f012d5491) python3Packages.gradio-client: init at 0.5.0
* [`b64704d4`](https://github.com/NixOS/nixpkgs/commit/b64704d40fb686ca1806fffdf850f6f4d8d24556) python3Packages.gradio: 3.20.1 -> 3.43.1
* [`5e27c210`](https://github.com/NixOS/nixpkgs/commit/5e27c21084cb29d3a3c3f78c3da6e87e654deccf) python310Packages.nlpcloud: 1.1.43 -> 1.1.44
* [`615f37da`](https://github.com/NixOS/nixpkgs/commit/615f37daf0564a99f8b0f3c8782bf27fd8adee23) resholve: update README
* [`acfa26ad`](https://github.com/NixOS/nixpkgs/commit/acfa26ad27884a695dece679614c0d8415c9d21e) python310Packages.grpcio-reflection: 1.56.2 -> 1.58.0
* [`9be01e3f`](https://github.com/NixOS/nixpkgs/commit/9be01e3f142b4221b8d235574c07b29703d2ed77) statix: 0.5.6 -> 0.5.8
* [`cab76f5c`](https://github.com/NixOS/nixpkgs/commit/cab76f5c696ada2698baac713a2280e1d2131082) iosevka: 26.3.0 -> 26.3.3
* [`10562d69`](https://github.com/NixOS/nixpkgs/commit/10562d692dae1d8a564da68129fe433c1fb90e55) besu: 23.4.4 -> 23.7.2
* [`69bfaafc`](https://github.com/NixOS/nixpkgs/commit/69bfaafc9d41bb4e36920c0d96ceb489c21fd129) nixos/cfdyndns: add option to use CF token
* [`300d4b81`](https://github.com/NixOS/nixpkgs/commit/300d4b8114931e641062ad94d4c9011eefe89618) python311Packages.pysigma-backend-elasticsearch: 1.0.6 -> 1.0.7
* [`9ca9bd1a`](https://github.com/NixOS/nixpkgs/commit/9ca9bd1a81f5fbdaf79bf42429c02716d15be7d9) nushellPlugins: format plugin and fix darwin
* [`7a061b54`](https://github.com/NixOS/nixpkgs/commit/7a061b54de052f57588058cd188f44c79984e073) gnome-frog: 1.3.0 -> 1.4.2
* [`b33a0a26`](https://github.com/NixOS/nixpkgs/commit/b33a0a2674bb5efcd45e51f7ab9b69a0a841e3bf) kubernetes-polaris: 8.5.0 -> 8.5.1
* [`b4f34aaa`](https://github.com/NixOS/nixpkgs/commit/b4f34aaacc11ac07ee4c24ba18924773134a6f6d) python3Packages.weasyprint: restore overriding of fontconfig file
* [`fb5b92dc`](https://github.com/NixOS/nixpkgs/commit/fb5b92dcf8f8d1a45bac7f44144305c6cbeae75a) python311Packages.pydiscovergy: init at 2.0.3
* [`8d4a1b09`](https://github.com/NixOS/nixpkgs/commit/8d4a1b0941b48cc4f3438209c58a4d040537fa1a) home-assistant: update component-packages
* [`6f50091d`](https://github.com/NixOS/nixpkgs/commit/6f50091de76f06c63fe74fc401069c60cae64c53) nixos/listmonk: fixing datatype of options
* [`bfdb49b9`](https://github.com/NixOS/nixpkgs/commit/bfdb49b9c0a114dc882c60abd7644ccd3fb0a181) maskromtool: 2023-07-20 -> 2023-08-06
* [`7f559555`](https://github.com/NixOS/nixpkgs/commit/7f5595556c5de288db279ed8212655ed2721fe7d) python311Packages.bluetooth-auto-recovery: 1.2.1 -> 1.2.3
* [`1bacce1f`](https://github.com/NixOS/nixpkgs/commit/1bacce1fdf3efc0f1e2e3426d1d54ac8e3bcae0b) python311Packages.python-roborock: 0.32.4 -> 0.33.2
* [`fdc0f248`](https://github.com/NixOS/nixpkgs/commit/fdc0f248a891c17fae12ee2f49cee83fa85d886b) python311Packages.bleak: 0.21.0 -> 0.21.1
* [`a1abee07`](https://github.com/NixOS/nixpkgs/commit/a1abee0758440a5ba542f1f1466792b6b78a5739) Fix mujs dylib on Darwin
* [`df8e7395`](https://github.com/NixOS/nixpkgs/commit/df8e73951466837fa0faca15078a90e606746683) typstfmt: 0.2.1 -> 0.2.2
* [`73ccde3d`](https://github.com/NixOS/nixpkgs/commit/73ccde3dbce16c9fbd2c0028bb1a18e9df97cb38) cargo-hack: 0.6.5 -> 0.6.6
* [`c8883bd0`](https://github.com/NixOS/nixpkgs/commit/c8883bd0b785ddb2638175fd3697b0cff5690771) perldevel: add throwing alias
* [`2a521354`](https://github.com/NixOS/nixpkgs/commit/2a521354884eb7896f4563ff4c20e69d2d3bb4b3) trueseeing: 2.1.5 -> 2.1.7
* [`d051c852`](https://github.com/NixOS/nixpkgs/commit/d051c8529048ae29838fbcd182f3bec3f6bf3509) trueseeing: add changelog to meta
* [`154ba6c2`](https://github.com/NixOS/nixpkgs/commit/154ba6c2430db3c1dc5cfeea71a179d660ce5fcd) wipeout-rewrite: init at unstable-2023-08-13
* [`a49eb940`](https://github.com/NixOS/nixpkgs/commit/a49eb940a293f5ff3660d422ce1de00c41518338) zig: reword setup hook
* [`1b75ac31`](https://github.com/NixOS/nixpkgs/commit/1b75ac310a4fba9e8245a23760bd796f103eb851) doc/hooks/zig.section.md: reword
* [`bd374243`](https://github.com/NixOS/nixpkgs/commit/bd374243c08040fba0897727d05e05f08145fdf2) npmHooks: use adjacent packages, not buildPackages
* [`27b3d622`](https://github.com/NixOS/nixpkgs/commit/27b3d6221184faa0157c3917b1f57b4f9485f276) nix-doc: 0.6.0 -> 0.6.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
