### PR TITLE
niv devenv: update f839f486 -> 63d20fe0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "f839f486b98609f3477c0410b31a6f831b390d48",
-        "sha256": "0zavaszi98jz5p7fc0lm9zjrf2fy8ygrhfh8ds1wf6k338snhgga",
+        "rev": "63d20fe09aa09060ea9ec9bb6d582c025402ba15",
+        "sha256": "062cgxrfhncc5w9k2y0w70vgip5bzdin9gmbk4625szs6hzm74xk",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/f839f486b98609f3477c0410b31a6f831b390d48.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/63d20fe09aa09060ea9ec9bb6d582c025402ba15.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@f839f486...63d20fe0](https://github.com/cachix/devenv/compare/f839f486b98609f3477c0410b31a6f831b390d48...63d20fe09aa09060ea9ec9bb6d582c025402ba15)

* [`2aaf69be`](https://github.com/cachix/devenv/commit/2aaf69bef73d4545246898c96b1c3c341186e82a) chore(deps): bump cachix/install-nix-action from 22 to 23
* [`cc8350e8`](https://github.com/cachix/devenv/commit/cc8350e8ba3e4ce2b9de429879a98cc2ebafb057) mysql: make settings attrs lazy
* [`63d20fe0`](https://github.com/cachix/devenv/commit/63d20fe09aa09060ea9ec9bb6d582c025402ba15) Auto generate docs/reference/options.md
