### PR TITLE
niv home-manager: update 886ea1d2 -> 5171f5ef

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "886ea1d213efd1082f419d066e89ef37635dc970",
-        "sha256": "1av0mdwyy7n0wsb0afwjr53dy2m9nwfgkl9wg4q9zpm8ys9xlwxg",
+        "rev": "5171f5ef654425e09d9c2100f856d887da595437",
+        "sha256": "0vc7jncpg9bcvipsby7yiwczbkng75cwhmxwdwr0b72rjy1ng9ks",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/886ea1d213efd1082f419d066e89ef37635dc970.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/5171f5ef654425e09d9c2100f856d887da595437.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@886ea1d2...5171f5ef](https://github.com/nix-community/home-manager/compare/886ea1d213efd1082f419d066e89ef37635dc970...5171f5ef654425e09d9c2100f856d887da595437)

* [`3c0e381f`](https://github.com/nix-community/home-manager/commit/3c0e381fef63e4fbc6c3292c9e9cbcf479c01794) carapace: add module
* [`b22d7bab`](https://github.com/nix-community/home-manager/commit/b22d7bab30076bbb73744867d6c5bf7d6380570c) flake.lock: Update
* [`91341cde`](https://github.com/nix-community/home-manager/commit/91341cde4143b10ee66e994a53c35d376ad6cdfb) eza: add module
* [`f1d4f49e`](https://github.com/nix-community/home-manager/commit/f1d4f49e716df353eb7851b2eec4afe58aa3b697) just: simplify
* [`19c6a408`](https://github.com/nix-community/home-manager/commit/19c6a4081b14443420358262f8416149bd79561a) emacs: add version for default.el package
* [`f9041d12`](https://github.com/nix-community/home-manager/commit/f9041d12a90e8bc0c90e03be2ebe26a6c6e6fd70) home-manager: fix some completions commands
* [`11c91750`](https://github.com/nix-community/home-manager/commit/11c91750b0e056342fbee01fcf87548dda960fba) Translate using Weblate (Czech)
* [`3dd5470e`](https://github.com/nix-community/home-manager/commit/3dd5470e59deab403a1c832cd047dd2ca08fc897) Add translation using Weblate (Czech)
* [`2b637f32`](https://github.com/nix-community/home-manager/commit/2b637f3289772168800e4c95fa4168741a5886f1) Translate using Weblate (Czech)
* [`f7848d3e`](https://github.com/nix-community/home-manager/commit/f7848d3e5f15ed02e3f286029697e41ee31662d7) nixos: increase TimeoutStartSec from 1m30s to 5m
* [`ac1c7c34`](https://github.com/nix-community/home-manager/commit/ac1c7c34dbf4f3f213f47a4cb8d09a4b4bb18b18) exa: replace with eza
* [`edda5599`](https://github.com/nix-community/home-manager/commit/edda5599d6bb6e6b7689e7f283c5b12b420dd7da) ci: bump cachix/install-nix-action from 22 to 23
* [`bfe38782`](https://github.com/nix-community/home-manager/commit/bfe38782355f2f10bd705c31ff2e71b6471d3f8f) flake.lock: Update
* [`ae2cc6a8`](https://github.com/nix-community/home-manager/commit/ae2cc6a88c19a61c23dba9faf64df85ddd09c510) ci: bump actions/checkout from 3 to 4
* [`5171f5ef`](https://github.com/nix-community/home-manager/commit/5171f5ef654425e09d9c2100f856d887da595437) swaylock: document the need for host PAM configuration
