### PR TITLE
niv niv: update 1d057c4a -> 9341b102

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "1d057c4a3a11c67a619a244e39d90d438023ecc6",
-        "sha256": "1smfsqdxf9mm1vpgpmhsji89jbzygm57jsn2414pcksz8iiyp05x",
+        "rev": "9341b1027da2c2f95f8e808a3cb4b403e0a62c77",
+        "sha256": "1l996s518iv7bcfzzhxlsn35ahbslpbvhl3ds1zpnama7la23y9b",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/1d057c4a3a11c67a619a244e39d90d438023ecc6.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/9341b1027da2c2f95f8e808a3cb4b403e0a62c77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@1d057c4a...9341b102](https://github.com/nmattia/niv/compare/1d057c4a3a11c67a619a244e39d90d438023ecc6...9341b1027da2c2f95f8e808a3cb4b403e0a62c77)

* [`9341b102`](https://github.com/nmattia/niv/commit/9341b1027da2c2f95f8e808a3cb4b403e0a62c77) Bump actions/checkout from 3 to 4 ([nmattia/niv⁠#376](https://togithub.com/nmattia/niv/issues/376))
