### PR TITLE
niv powerlevel10k: update 011b8469 -> 873c4ff0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "011b8469ab716d7d6fd1dc050ebdff81b6b830b0",
-        "sha256": "1lr4v8y4pvm1xzsw7h1fahjpa2hf4nkz31ih2m5331bxr3kznw31",
+        "rev": "873c4ff09c559a507d33e528df7e27a8a48705d7",
+        "sha256": "1xiix03d9v76i63mm5rnrxs0s0f7kay468x572n4p8jzsibyhw8q",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/011b8469ab716d7d6fd1dc050ebdff81b6b830b0.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/873c4ff09c559a507d33e528df7e27a8a48705d7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@011b8469...873c4ff0](https://github.com/romkatv/powerlevel10k/compare/011b8469ab716d7d6fd1dc050ebdff81b6b830b0...873c4ff09c559a507d33e528df7e27a8a48705d7)

* [`f8595a35`](https://github.com/romkatv/powerlevel10k/commit/f8595a35bf062279a639b6bdbecc478c18c3f009) use powerlevel10k from homebrew/core when installing with brew
* [`be4c68fd`](https://github.com/romkatv/powerlevel10k/commit/be4c68fd0a6cc139cb02e24294c96a2a5e50576d) add Guix System icon ([romkatv/powerlevel10k⁠#2424](https://togithub.com/romkatv/powerlevel10k/issues/2424))
* [`215b20e0`](https://github.com/romkatv/powerlevel10k/commit/215b20e08714ba0539a83be2723ff8ab17702c88) bump version
* [`873c4ff0`](https://github.com/romkatv/powerlevel10k/commit/873c4ff09c559a507d33e528df7e27a8a48705d7) fix the path to powerlevel10k when installing with homebrew ([romkatv/powerlevel10k⁠#2429](https://togithub.com/romkatv/powerlevel10k/issues/2429))
