### PR TITLE
niv zsh-autosuggestions: update 39aa7bed -> c3d4e576

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,10 +180,10 @@
         "homepage": null,
         "owner": "zsh-users",
         "repo": "zsh-autosuggestions",
-        "rev": "39aa7bed3a477af1eaa3aa72bcb6e6e616aa7dc0",
-        "sha256": "1a5zc24jyi0h8z4j8ry4yi4552w8ij2n7fiw6xwl8lzl1935cc7n",
+        "rev": "c3d4e576c9c86eac62884bd47c01f6faed043fc5",
+        "sha256": "1m8yawj7skbjw0c5ym59r1y88klhjl6abvbwzy6b1xyx3vfb7qh7",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/39aa7bed3a477af1eaa3aa72bcb6e6e616aa7dc0.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/c3d4e576c9c86eac62884bd47c01f6faed043fc5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-completions": {


### PR DESCRIPTION
## Changelog for zsh-autosuggestions:
Branch: master
Commits: [zsh-users/zsh-autosuggestions@39aa7bed...c3d4e576](https://github.com/zsh-users/zsh-autosuggestions/compare/39aa7bed3a477af1eaa3aa72bcb6e6e616aa7dc0...c3d4e576c9c86eac62884bd47c01f6faed043fc5)

* [`fc391d6b`](https://github.com/zsh-users/zsh-autosuggestions/commit/fc391d6bf611ff00f0f145575bcc1c6168cf9e6b) fix: Makefile SRC_DIR spacing
* [`f29bb7f0`](https://github.com/zsh-users/zsh-autosuggestions/commit/f29bb7f032403d831140ee814aba051601248d70) Create .gitignore for *.zwc
