### PR TITLE
niv zsh-syntax-highlighting: update 1386f121 -> 143b25eb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -240,10 +240,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "1386f1213eb0b0589d73cd3cf7c56e6a972a9bfd",
-        "sha256": "0a39xfwxdq8zmzw8s40fvham7689am1icn03lhdj1882qjb7pb48",
+        "rev": "143b25eb98aa3227af63bd7f04413e1b3e7888ec",
+        "sha256": "1j8zjf4k0f78p4ihb5y1mml30ksakskb99q1fms0xabm9rr858ac",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/1386f1213eb0b0589d73cd3cf7c56e6a972a9bfd.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/143b25eb98aa3227af63bd7f04413e1b3e7888ec.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@1386f121...143b25eb](https://github.com/zsh-users/zsh-syntax-highlighting/compare/1386f1213eb0b0589d73cd3cf7c56e6a972a9bfd...143b25eb98aa3227af63bd7f04413e1b3e7888ec)

* [`143b25eb`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/143b25eb98aa3227af63bd7f04413e1b3e7888ec) docs: Fix Homebrew link
