### PR TITLE
niv nixpkgs: update 77671b68 -> 44d14bee

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "77671b681ce37f62461c82b566d1c0527bb76abf",
-        "sha256": "1sc88yzcgjapbzr8nxgj4ab6n1cj3gb02c8m9744pacxjvv1jyks",
+        "rev": "44d14bee4bab76ded86caa12b49b5ae7fbeab671",
+        "sha256": "1hdn2ywivnd1d2qhnaql9wpqgrhknhz0n0dgv5v6fd03v5sjsk8g",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/77671b681ce37f62461c82b566d1c0527bb76abf.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/44d14bee4bab76ded86caa12b49b5ae7fbeab671.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@77671b68...44d14bee](https://github.com/nixos/nixpkgs/compare/77671b681ce37f62461c82b566d1c0527bb76abf...44d14bee4bab76ded86caa12b49b5ae7fbeab671)

* [`fee76f18`](https://github.com/NixOS/nixpkgs/commit/fee76f189c53266391aa7485f017de3a51f86461) lib: Create make-btrfs-fs library to match make-ext4-fs.
* [`2946b819`](https://github.com/NixOS/nixpkgs/commit/2946b819c209f4a1a9e87a725fc9e5ed2452c178) cc-wrapper: fix linking against GCC libs for non-GCC
* [`2e84da97`](https://github.com/NixOS/nixpkgs/commit/2e84da9766fa52f58775baf6e6e75018fbbd76e8) maintainers: add refi64
* [`572c5ff1`](https://github.com/NixOS/nixpkgs/commit/572c5ff117986f2db5ac2b7bf91045164488ed6e) itamae: init at 1.14.1
* [`e320ebd8`](https://github.com/NixOS/nixpkgs/commit/e320ebd86cf6d98d5b0a898e3a4d6b3eff42371e) lean4: init at 4.0.0
* [`6f89774b`](https://github.com/NixOS/nixpkgs/commit/6f89774b673b05339aa93b017f89da8a802f7b2a) zulip: Respect NIXOS_OZONE_WL to enable Wayland mode
* [`05fa4387`](https://github.com/NixOS/nixpkgs/commit/05fa4387331f380b6132dbd84cca233d64480b14) tree-sitter: set emcc cache outside of nix store
* [`4f348cd7`](https://github.com/NixOS/nixpkgs/commit/4f348cd724fe69bab111c6d169b7a1a54bb6b763) libyuv: add pkg-config .pc file
* [`93efcdac`](https://github.com/NixOS/nixpkgs/commit/93efcdac790aa92425d3492645e75f2292dbc9c9) nixos/networkd: add DHCPServer PXE boot options
* [`f5a0d549`](https://github.com/NixOS/nixpkgs/commit/f5a0d549d3f888cdcc3cc732d45064ec99d2a97a) knxd: init at 0.14.59
* [`676c18e5`](https://github.com/NixOS/nixpkgs/commit/676c18e5b99f01ebe0d3b934029eb5e0b61d04bd) wlcs: 1.5.0 -> 1.6.0
* [`ae7fb110`](https://github.com/NixOS/nixpkgs/commit/ae7fb1102f8668467bfc18320ad04a1137beae4f) mir: 2.13.0 -> 2.14.1
* [`3ab6c3d2`](https://github.com/NixOS/nixpkgs/commit/3ab6c3d20dae48b67604613baad67ed6f45a9785) buildkite-agent: add updateScript
* [`aaf518fd`](https://github.com/NixOS/nixpkgs/commit/aaf518fdfb89af632dfad7edef83d7481d7ff6a6) matcha-rss-digest: init at 0.6
* [`8d374ceb`](https://github.com/NixOS/nixpkgs/commit/8d374cebcd8736d19c289e6d1166ab0b7428adc7) nixos/forgejo: init
* [`02601e17`](https://github.com/NixOS/nixpkgs/commit/02601e17a53eadd488bd8ca16dbb656fd46d1764) nixosTests.forgejo: fork from nixosTests.gitea
* [`7b786b39`](https://github.com/NixOS/nixpkgs/commit/7b786b39cb0d42949720482b78c31fcfe35b41c7) CODEOWNERS: init forgejo
* [`a1a5db1a`](https://github.com/NixOS/nixpkgs/commit/a1a5db1a80158a5fee3e469508221534db90e8c6) megapixels: 1.6.1 -> 1.7.0
* [`785ed11d`](https://github.com/NixOS/nixpkgs/commit/785ed11d0a71952c7a27fc66d7754bae1da09a64) prefetch-npm-deps: fix error typo and unnecessary name qualifier
* [`12470428`](https://github.com/NixOS/nixpkgs/commit/12470428371756f09db4e8d243d7adb8c025ab83) geogebra: Fix 3D view
* [`ca70b78b`](https://github.com/NixOS/nixpkgs/commit/ca70b78b71e92b98d1695f79647f187920da4c37) psmisc: 23.5 -> 23.6
* [`c873b591`](https://github.com/NixOS/nixpkgs/commit/c873b591218ff01a14e8f8070eea68172f1e5196) linuxPackages.apfs: 0.3.3 -> 0.3.4
* [`dc24d568`](https://github.com/NixOS/nixpkgs/commit/dc24d568469bfa46188aa4a4e60992190f50a8c6) boinc: 7.22.2 -> 7.24.1
* [`49670257`](https://github.com/NixOS/nixpkgs/commit/49670257591b049f844694d95f71859c0dbe30e7) all-cabal-hashes: 2023-07-24T19:28:29Z -> 2023-08-17T07:12:25Z
* [`8f494d29`](https://github.com/NixOS/nixpkgs/commit/8f494d298398e3c1157b50239f3bd3d6670efe2e) haskellPackages: stackage LTS 21.3 -> LTS 21.7
* [`c1b77b86`](https://github.com/NixOS/nixpkgs/commit/c1b77b8641b9943b6532dff178dd268b3b7d4d92) haskellPackages: regenerate package set based on current config
* [`0a088cfd`](https://github.com/NixOS/nixpkgs/commit/0a088cfd184cf2b3f895f112c57024eca21fad7c) haskellPackages: reflect lsp-types 2.0.1.0 -> 2.0.1.1
* [`8d847a62`](https://github.com/NixOS/nixpkgs/commit/8d847a62ae0208bba5e0ec46489697af3eb334d0) haskellPackages.pandoc-cli: reflect updates of dependencies
* [`ef2488f1`](https://github.com/NixOS/nixpkgs/commit/ef2488f189309d1275d51d6169c115f9b996891b) haskellPackages.yesod-core: remove obsolete override
* [`9dc1cb39`](https://github.com/NixOS/nixpkgs/commit/9dc1cb39a3e294016b483f50e62b947a7f097359) haskell.packages.ghc8107.ghc-lib{,-parser}: reflect hackage updates
* [`d6bd8986`](https://github.com/NixOS/nixpkgs/commit/d6bd89869e0bfaaa200907d77aeecf65dd3c5f10) arion: remove obsolete override
* [`3c62c467`](https://github.com/NixOS/nixpkgs/commit/3c62c4675e3e50ffb45cf1c5f6260bc657cce10b) taffybar: remove obsolete overrides
* [`14c332b4`](https://github.com/NixOS/nixpkgs/commit/14c332b453a0e0346d93811f501c5d1ac1f41956) haskell.packages.ghc96: reflect version updates
* [`a74411e3`](https://github.com/NixOS/nixpkgs/commit/a74411e309901379ffec5e1aca1949cda9617775) util-linux: 2.39.1 -> 2.39.2
* [`edcf8304`](https://github.com/NixOS/nixpkgs/commit/edcf830429642d06eee298cbcff6b0e61fa24cd4) haskellPackages.shellify: re-add
* [`1107a396`](https://github.com/NixOS/nixpkgs/commit/1107a3960af9c3b31af795119f74a0f05caf2620) haskellPackages.bloomfilter: drop patches obsoleted by release
* [`55d5ebb0`](https://github.com/NixOS/nixpkgs/commit/55d5ebb07a992762c4535c01602ece55e85ada72) remmina: use `desktopToDarwinBundle`
* [`e7f7c7ba`](https://github.com/NixOS/nixpkgs/commit/e7f7c7ba79ef62450a8fe91b91d91746211223af) kbd: 2.6.1 -> 2.6.2
* [`a88b90c9`](https://github.com/NixOS/nixpkgs/commit/a88b90c9dbb0db665ed62bb47296f4f3524cd267) lib.generators.toGitINI: escape string values in configuration
* [`dba9d4e3`](https://github.com/NixOS/nixpkgs/commit/dba9d4e33a2dd73d052aee9f71f494b086d43647) haskellPackages.lsp_2_1_0_0: allow building individually
* [`f434e83d`](https://github.com/NixOS/nixpkgs/commit/f434e83d62f8cc887309670ae551f24fec95611b) angsd: pull patch pending upstream inclusion for parallel build fix
* [`66884a49`](https://github.com/NixOS/nixpkgs/commit/66884a4912003e8090ef6e2a203f9544c4d7702c) writeDarwinBundle: use binary wrapper
* [`d004ba09`](https://github.com/NixOS/nixpkgs/commit/d004ba09a3b56fd8f01b1135da056c3fd5116f06) gzip: 1.12 -> 1.13
* [`62c676ce`](https://github.com/NixOS/nixpkgs/commit/62c676ce6feb25edb7df6376b3013c4ec0193f6d) gcc: patches: reorganize and simplify
* [`14756018`](https://github.com/NixOS/nixpkgs/commit/147560180c5b39266d10c6a6b8f54110d9667b99) lib.generators.toGitINI: added test
* [`1bf815d9`](https://github.com/NixOS/nixpkgs/commit/1bf815d91c37b72e695a181e83c5dc560eefda73) git-annex: update sha256 for 10.20230802
* [`c4bea423`](https://github.com/NixOS/nixpkgs/commit/c4bea4230563296643626a20af0c5e34c83c778a) haskell-language-server: revert accidentally committed overrides
* [`4788fa95`](https://github.com/NixOS/nixpkgs/commit/4788fa95f894d1ae112c3a7f38ffb8974d9e1691) haskellPackages.spdx: apply patches for GHC >= 9.4
* [`26d2cf5e`](https://github.com/NixOS/nixpkgs/commit/26d2cf5e3b397ed3100344ba75bf33348f832797) haskell-language-server: Fix build
* [`044214a6`](https://github.com/NixOS/nixpkgs/commit/044214a6ee26dfecbb8e75279f5310d9a951c3a9) haskell-language-server: Update error message
* [`7dfb3949`](https://github.com/NixOS/nixpkgs/commit/7dfb3949da392b142081e23a6a2c0cd5e57fdce6) haskell.packages.ghc96.haskell-language-server: Fix build
* [`10f89607`](https://github.com/NixOS/nixpkgs/commit/10f8960700464ee286c1d45721a47d8c1b25f7da) haskell.packages.ghc92.haskell-language-server: Fix build
* [`f3953649`](https://github.com/NixOS/nixpkgs/commit/f39536498ce8d2810cf9e9f8256e79d5d00a8468) haskell.packages.ghc90.haskell-language-server: Fix build
* [`3ced05d8`](https://github.com/NixOS/nixpkgs/commit/3ced05d8b7015b277f56367038cddf890ce4b410) haskell.packages.ghc810.haskell-language-server: Fix build
* [`100dbc76`](https://github.com/NixOS/nixpkgs/commit/100dbc7605189145af65ad50068dc45c93d7e0b4) haskellPackages: regenerate package set based on current config
* [`20a575b9`](https://github.com/NixOS/nixpkgs/commit/20a575b98ea6e654b0306f5661ac635a0534472b) zlib: 1.2.13 -> 1.3
* [`63116095`](https://github.com/NixOS/nixpkgs/commit/63116095578828cad175e60f1c9066f2972c9175) git: 2.41.0 -> 2.42.0
* [`9124084e`](https://github.com/NixOS/nixpkgs/commit/9124084e5ac5a31968e4b6f63e322d6bf2530866) git: added kashw2 maintainer
* [`3b9d2b14`](https://github.com/NixOS/nixpkgs/commit/3b9d2b14582f10b55db96a6834df9f89c85f625f) mpfr: 4.2.0 -> 4.2.1
* [`38606a7b`](https://github.com/NixOS/nixpkgs/commit/38606a7b72dfc0aec9e8b9fa4adaf4f4a2ec25a7) haskellPackages: clear broken and transitive broken package lists
* [`0e4865df`](https://github.com/NixOS/nixpkgs/commit/0e4865dfbe082cd0ff4afbb7b0e0741012289947) rustdesk: 1.1.9 -> 1.2.2
* [`868fac2a`](https://github.com/NixOS/nixpkgs/commit/868fac2a1dde1ad728bbf4aca6e061f96efee6e6) python310Packages.viennarna: rename from ViennaRNA
* [`ae0bfcb1`](https://github.com/NixOS/nixpkgs/commit/ae0bfcb156a66efb4e914152669c13066eb75594) viennarna: rename from ViennaRNA
* [`7f2b8695`](https://github.com/NixOS/nixpkgs/commit/7f2b8695603896819b09570a255d8c4f42274c47) nixos/tts: fix error messages read before text
* [`33c4d1eb`](https://github.com/NixOS/nixpkgs/commit/33c4d1eba0dcbca231b74d4eccca1d0ec1be3de1) djenrandom: init at 1.0
* [`8e15df47`](https://github.com/NixOS/nixpkgs/commit/8e15df471550f875284109797d9942eeb6280fa6) libkcapi: init at 1.4.0
* [`3a4ca00c`](https://github.com/NixOS/nixpkgs/commit/3a4ca00c848d68e5558975f4d0e5c4e347fca623) libxml2: 2.11.4 → 2.11.5
* [`d664c7a1`](https://github.com/NixOS/nixpkgs/commit/d664c7a1d48ad00849af85ae393aaca6af9b7b0d) libinput: 1.23.0 -> 1.24.0
* [`7212d3de`](https://github.com/NixOS/nixpkgs/commit/7212d3de28f450a1938ca226bfbdf6fa3c815181) maintainers: add ashvith-shetty
* [`c52e31c8`](https://github.com/NixOS/nixpkgs/commit/c52e31c8b8964e0d1122f852b68a662952ce4ac5) gpgme: 1.21.0 -> 1.22.0
* [`ceae7b4e`](https://github.com/NixOS/nixpkgs/commit/ceae7b4e07070b3ffe67d05ce646766f28800e95) python311Packages.trustme: 0.9.0 -> 1.1.0
* [`9d830541`](https://github.com/NixOS/nixpkgs/commit/9d830541990252e859c00c9b5a7579bc9305c79c) nano: add file as a dependency to allow libmagic usage
* [`cf6f6b2b`](https://github.com/NixOS/nixpkgs/commit/cf6f6b2b00446e1ee21d7ec2df381bc404a16cc3) shellify: init at 0.10.0.3
* [`833956a6`](https://github.com/NixOS/nixpkgs/commit/833956a621dbbd84a8ea4a6510e51890b5e8e56e) python3.pkgs.django-google-analytics-app: init at 6.0.0
* [`261473c2`](https://github.com/NixOS/nixpkgs/commit/261473c2fb2e3d9961e075cab5d51e73be203ba8) python3.pkgs.django-simple-history: init at 3.4.0
* [`82d1d895`](https://github.com/NixOS/nixpkgs/commit/82d1d895265d7f1c43633c5160a6736ef1ecf2ba) python310Packages.cython_3: 3.0.0 -> 3.0.2
* [`0ed874c0`](https://github.com/NixOS/nixpkgs/commit/0ed874c00368dddfde556faf64d1df3bde33d405) insomnia: add electron wayland flags
* [`c25f7f89`](https://github.com/NixOS/nixpkgs/commit/c25f7f894fa6d9018a4b79607dfadef6b4cb7fae) stdenv: Add hack to fix cmake canExecute cross-compilation
* [`dffc9738`](https://github.com/NixOS/nixpkgs/commit/dffc973811550f2583db87d88c5715cac2ebc53c) hotdoc: 0.13.7 -> 0.15
* [`cbef76ec`](https://github.com/NixOS/nixpkgs/commit/cbef76ec11247fe2d0d412cf2dfdeb0c98f4e70a) openexr_3: 3.1.10 -> 3.1.11
* [`dbd590c8`](https://github.com/NixOS/nixpkgs/commit/dbd590c8db3bc5744395168baacb498abfbf435e) clamav: 1.1.0 -> 1.2.0
* [`e6f657ba`](https://github.com/NixOS/nixpkgs/commit/e6f657ba8784f0673c03ff14217072f5f24e162b) echidna: fix build due to brick-1.9
* [`ae6630cb`](https://github.com/NixOS/nixpkgs/commit/ae6630cb5be679a34d4bbfae4673a471c2e925fe) haskellPackages.servant-foreign: allow hspec >= 2.10
* [`aaaa44d1`](https://github.com/NixOS/nixpkgs/commit/aaaa44d12965c0b209e8e5e10682dbca2f87e563) python3Packages.twisted: fix tests on Darwin
* [`28c0cd5b`](https://github.com/NixOS/nixpkgs/commit/28c0cd5b1731d0d586c15cab88fd9ba309a77f0d) cpython: remove broken include/python3.X/python3.Xm symlink
* [`3d68e13d`](https://github.com/NixOS/nixpkgs/commit/3d68e13d7155bd25b65c02c298166cfb773ce4ea) kexec-tools: Use gccStdenv
* [`620f9f11`](https://github.com/NixOS/nixpkgs/commit/620f9f11f83de7fa68b346ff80adfc9914c50ce6) iproute2: Dont hardcode gcc
* [`9f52275e`](https://github.com/NixOS/nixpkgs/commit/9f52275e52509dc667e6b42514ce1531416254a5) treewide: change wafConfigureFlags to configureFlags
* [`9679a121`](https://github.com/NixOS/nixpkgs/commit/9679a1216ecb95b1b4b4f93a21d7b220307b17a7) doc/hooks/waf.section.md: update
* [`1db1e3c4`](https://github.com/NixOS/nixpkgs/commit/1db1e3c46750e53fa3649bcd2893a248fe6de292) stdenv: Fix possible issues discovered with
* [`083e133f`](https://github.com/NixOS/nixpkgs/commit/083e133f671a9b001fd04e0c25b8621df829acfa) SDL2: 2.28.2 -> 2.28.3
* [`9e9f7c4a`](https://github.com/NixOS/nixpkgs/commit/9e9f7c4aa648ff7fa4d919a235bcce068d3f5fd0) nixos/healthchecks: define default DB_NAME for postgres and mysql
* [`4a81613a`](https://github.com/NixOS/nixpkgs/commit/4a81613aa6cd11349948476f17daf350b4d07740) nixos/healthchecks: add EMAIL_HOST_PASSWORD_FILE option
* [`7f5e8a01`](https://github.com/NixOS/nixpkgs/commit/7f5e8a01137bc1227673dd28b22a4a5c659cc9eb) nixos/healthchecks: enable _FILE variants for all secrets
* [`1769609d`](https://github.com/NixOS/nixpkgs/commit/1769609dc0f5bb4bab18d2245e28b052f66b7a71) zxing-cpp: 1.4.0 -> 2.1.0
* [`19a58cef`](https://github.com/NixOS/nixpkgs/commit/19a58cefaac2aacb877f08741c326be124e2c4c7) zxing-cpp: refactor
* [`b5f6513d`](https://github.com/NixOS/nixpkgs/commit/b5f6513d3b616ca44e34149556f73417cdd6f408) python3.pkgs.zxing_cpp: refactor
* [`5c63f69e`](https://github.com/NixOS/nixpkgs/commit/5c63f69ed238b8b555ca35cb7d3ae05faf2b06a8) gcc.patches: For gcc49 apply libsanitizer-no-cyclades-9 patch later
* [`b6fbef42`](https://github.com/NixOS/nixpkgs/commit/b6fbef42493fd879aa64d9da6a468d138bf18595) mailctl: add to release-haskell.nix
* [`6796f05e`](https://github.com/NixOS/nixpkgs/commit/6796f05e1e2f850e296ad1301fef03ca36208d3e) vala_0_56: 0.56.9 → 0.56.13
* [`5c58c59c`](https://github.com/NixOS/nixpkgs/commit/5c58c59c4e75ab7b6a58b43503da8b14c08a27d2) haskellPackages.GLUT: make sure patch applies despite revisions
* [`0bffcc3f`](https://github.com/NixOS/nixpkgs/commit/0bffcc3f3cef71004f130a62432cf8615eb7731b) setup-hooks/strip: add stripExclude
* [`10e6c90c`](https://github.com/NixOS/nixpkgs/commit/10e6c90caa645e590efbb0db826cd9b2ecda061f) haskellPackages.hix: lift upper bound on path-io
* [`7511d5bf`](https://github.com/NixOS/nixpkgs/commit/7511d5bfbf426ddd492e53a5b12cdd7c6bc8d53c) haskellPackages: mark builds failing on hydra as broken
* [`00b08246`](https://github.com/NixOS/nixpkgs/commit/00b0824635f1ab030234124d79af4fbea1d0053c) maintainers/haskell/hydra-report.hs: allow disabling log requesting
* [`76dc1535`](https://github.com/NixOS/nixpkgs/commit/76dc15354424f88c38124d5467b18dd5476ecc40) maintainers/haskell/hydra-report.hs: work around bulk status timeout
* [`71cbb538`](https://github.com/NixOS/nixpkgs/commit/71cbb538a5b9cb6b69cea6f0c386f29b5f5a5f2e) maintainers/haskell/hydra-report.hs: increase timeout to 15min
* [`fa98c56f`](https://github.com/NixOS/nixpkgs/commit/fa98c56f75e798656dc8df7dca11f9bc06cee6f8) setup-hooks/separate-debug-info.sh: Warn if necessary variables are not set
* [`5a835f67`](https://github.com/NixOS/nixpkgs/commit/5a835f67429e95871a3502d6bfd7055754ca1508) maintainers/haskell/mark-broken.sh: allow passing --no-request-logs
* [`3691e28c`](https://github.com/NixOS/nixpkgs/commit/3691e28cd9eeca6f7f0c502fec9fcb2d41db14cb) luajit_2_1: 2.1.0-2022-10-04 -> 2.1.1693350652
* [`64566a52`](https://github.com/NixOS/nixpkgs/commit/64566a5234b57c0fc528c5f421d8e2ca1f30d054) luajit_2_0: 2.0.5-2022-09-13 -> 2.0.1693340858
* [`79cfd230`](https://github.com/NixOS/nixpkgs/commit/79cfd230650b0f2393440ee9408a651384dee0e2) davinci-resolve: 18.1.4 -> 18.5.1
* [`01901b6d`](https://github.com/NixOS/nixpkgs/commit/01901b6df5fa0fe69d7410e3e73afe81e4693e59) luajit: add optional arg enableRegisterAllocationRandomization
* [`fdc5f7e0`](https://github.com/NixOS/nixpkgs/commit/fdc5f7e0cb699e3033946144c99f9e6ecffa8824) haskellPackages.twain: build against supported version of http2
* [`d28bfba5`](https://github.com/NixOS/nixpkgs/commit/d28bfba5de8ad4a53f8b71ee18899818f9461d38) mailctl: fix broken transitive dependency
* [`d215f3eb`](https://github.com/NixOS/nixpkgs/commit/d215f3eb05223eec2e46948b4cb222e7d7e3ab7b) mailctl: use haskellPackages
* [`bed24e66`](https://github.com/NixOS/nixpkgs/commit/bed24e6636981af532001e783c295566510f258b) fwupd: 1.9.4 -> 1.9.5
* [`700241a4`](https://github.com/NixOS/nixpkgs/commit/700241a42283a691f7a6d8514b0211e50bc02693) ffmpeg: include svt-av1 in small variant
* [`9836e250`](https://github.com/NixOS/nixpkgs/commit/9836e250547d8158d7bbfe1b4fee93919308d671) ffmpeg: remove unused inputs and recs
* [`50540511`](https://github.com/NixOS/nixpkgs/commit/50540511442762499b69a09aba3d0da7fe489938) tmuxPlugins.catppuccin: unstable-2023-07-15 -> unstable-2023-08-21
* [`6fdc291d`](https://github.com/NixOS/nixpkgs/commit/6fdc291d5ae37d9e7de89f44eb28c4806e694d8b) nixos/terminfo: Add terminfo outputs for rio & tmux
* [`63e43aaa`](https://github.com/NixOS/nixpkgs/commit/63e43aaa9f8a1b370130495c3f4c2d1c8428b391) open-vm-tools: 12.2.5 -> 12.3.0
* [`bbefd707`](https://github.com/NixOS/nixpkgs/commit/bbefd70784df8580d34c868858c61462b1b2d616) nixos/sshd: avoid mock host key, permit `RequiredRSASize`
* [`a391e946`](https://github.com/NixOS/nixpkgs/commit/a391e9469ae9291d7a5cdc106c0d7cae79bb70a6) python3Packages.wikitextparser: init at 0.54.0
* [`44500c34`](https://github.com/NixOS/nixpkgs/commit/44500c34d49073bd80a13546414ea156ebd72c9c) unbound: 1.17.1 -> 1.18.0
* [`d5ef2443`](https://github.com/NixOS/nixpkgs/commit/d5ef2443ad167e6f3f2f1052761328768c508058) unbound: add prometheus exporter test to passthru
* [`36d3eb27`](https://github.com/NixOS/nixpkgs/commit/36d3eb27cf54bb1dedc794a8bacd455067158360) fortify-headers: patch wchar.h's include behaviour
* [`96391c3e`](https://github.com/NixOS/nixpkgs/commit/96391c3e8b997c40776f01d93fc79f28f200871d) fortify-headers: add patch to restore macro values after #undef
* [`1d179cbc`](https://github.com/NixOS/nixpkgs/commit/1d179cbc675cc624bae4643b70e535e8d3d8a602) build(deps): bump cachix/install-nix-action from 22 to 23
* [`a169de11`](https://github.com/NixOS/nixpkgs/commit/a169de11b1f0947f3ad3c20ad6e7db26b4da3287) mindustry: 145.1 -> 146
* [`90fcbd21`](https://github.com/NixOS/nixpkgs/commit/90fcbd21f67203adeb676ea694696c1c115adc18) ocamlPackages.tar: 2.2.2 → 2.5.1
* [`ac54dfcd`](https://github.com/NixOS/nixpkgs/commit/ac54dfcdf24d6969026f06ef963795094293f387) haskellPackages.file-io: unbreak for ghc 9.6
* [`98090246`](https://github.com/NixOS/nixpkgs/commit/9809024653669a07266ffc7833349b89b5f5aed0) llvmPackages.lldb: use substituteAll
* [`ba46866a`](https://github.com/NixOS/nixpkgs/commit/ba46866a27b73de53c3a1b3ba9f402eea65ad429) maintainers/scripts/haskell: Fix a typo
* [`e9bc0852`](https://github.com/NixOS/nixpkgs/commit/e9bc0852c11edd6c9b6ee828a2e6bf84b0dfd6c6) llvmPackages.lldb: hash changing post-deduplication changes
* [`91089054`](https://github.com/NixOS/nixpkgs/commit/91089054d48e54eb2a7eddb90d26303d193fd4f4) llvmPackages.bintools-unwrapped: deduplicate
* [`627bb740`](https://github.com/NixOS/nixpkgs/commit/627bb740a9ff4ff8d4679eee3474f19aa980be5e) llvmPackages.bintools-unwrapped: use targetPrefix for variable name like binutils does
* [`c6ec700b`](https://github.com/NixOS/nixpkgs/commit/c6ec700b3f90213edd8cda64e799645ffbe3d534) libfabric: 1.18.1 -> 1.19.0
* [`c53fc9a1`](https://github.com/NixOS/nixpkgs/commit/c53fc9a1e40b0b75e2a78497851488fc1d3b6aa7) calibre-web: fix static environ method in tornado
* [`7d648026`](https://github.com/NixOS/nixpkgs/commit/7d6480265169a3c6760f5ca3e146b94cbef342b3) way-displays: 1.8.1 -> 1.9.0
* [`91ebe5ff`](https://github.com/NixOS/nixpkgs/commit/91ebe5ff733996ba89ebfe9b92b86b11665dd548) localsend: 1.11.0 -> 1.11.1
* [`566f5fcd`](https://github.com/NixOS/nixpkgs/commit/566f5fcd2daeccf1dfc102983fbc05952044b14c) python3.pkgs.pybind11: disable fortify hardening on musl
* [`a6cc0a75`](https://github.com/NixOS/nixpkgs/commit/a6cc0a7530cc47ad58284d32a59ab147e89b7953) cdrtools: disable fortify hardening on musl
* [`f732e2cb`](https://github.com/NixOS/nixpkgs/commit/f732e2cbb103ed6ee4f3c56ace18b16b31e9cf7a) nix: disable fortify hardening on musl
* [`65d145e5`](https://github.com/NixOS/nixpkgs/commit/65d145e597c48d2ef59cff3ac885cb246657598f) dtool: init at 0.12.0
* [`1abf09fd`](https://github.com/NixOS/nixpkgs/commit/1abf09fd9c0c8fcb0be9c361fc7db5e9d6fda493) wafHook: resurrect alias
* [`f2f9262b`](https://github.com/NixOS/nixpkgs/commit/f2f9262b925de33e05e9e4673568b1b4f8300889) treewide: waf.hook -> wafHook
* [`cad7cea4`](https://github.com/NixOS/nixpkgs/commit/cad7cea44a28cdd15f71d13e3816cd076821b64c) waf: use wafConfigureFlags instead of configureFlags in setup-hook.sh
* [`e24107b3`](https://github.com/NixOS/nixpkgs/commit/e24107b347885af86928e0c1eb5c1c3b4d16e17e) treewide: convert configureFlags to wafConfigureFlags when appropriate
* [`b3a1dd84`](https://github.com/NixOS/nixpkgs/commit/b3a1dd846972cd27fe3a3d27db91a14f2ecaa7ca) waf: prefix all setup-hook variables with `waf`
* [`83b98f9b`](https://github.com/NixOS/nixpkgs/commit/83b98f9b352d9b84da2b1d4a2ec95cbce694388c) doc/hooks/waf.section.md: update
* [`ea946c74`](https://github.com/NixOS/nixpkgs/commit/ea946c7423f89e31a56ce244fbaacc87131b0844) llvmPackages.libcxxabi: dedupe `wasm.patch`
* [`ac62f864`](https://github.com/NixOS/nixpkgs/commit/ac62f864ca4422a1a9d4e0315d61d1321f9d369c) llvmPackages.libcxxabi: dedupe `no-threads.patch`
* [`079fa2f0`](https://github.com/NixOS/nixpkgs/commit/079fa2f075d515497c878683f768b3afba643bb5) llvmPackages.compiler-rt: dedupe `codesign.patch` 7-12
* [`3b16ddfd`](https://github.com/NixOS/nixpkgs/commit/3b16ddfda757b34d567630445f9579865805d9c8) llvmPackages.clang: dedupe `purity.patch` 5-8
* [`1d620bec`](https://github.com/NixOS/nixpkgs/commit/1d620bec207eb5e884e0bc83b2e9c6238beaa872) llvmPackages.lldb: deduplicate git
* [`d7d68a1a`](https://github.com/NixOS/nixpkgs/commit/d7d68a1a04b8846bff8b5816679441ad5c97f290) llvmPackages.lldb: remove unnecessary inherit
* [`df93f142`](https://github.com/NixOS/nixpkgs/commit/df93f142cb12b8fc4f64dc0440ef0f9d0d721283) haskellPackages: regenerate package set based on current config
* [`6b364e8d`](https://github.com/NixOS/nixpkgs/commit/6b364e8d8203a213408d4d2f072cda761fb1ba6c) rtx: 2023.8.2 -> 2023.9.0
* [`a463c129`](https://github.com/NixOS/nixpkgs/commit/a463c1294411bc522a9788ed0f6a7ebddd44b15a) mercurial: 6.5.1 -> 6.5.2
* [`5d9e03bd`](https://github.com/NixOS/nixpkgs/commit/5d9e03bdcc08ca9ac6571fbdfc315c87f2a65f2b) mercurial: add changelog to meta attrs
* [`09c8e209`](https://github.com/NixOS/nixpkgs/commit/09c8e2090ecbd7d117f535a9742f988c88ba15a3) go_1_20: 1.20.7 -> 1.20.8
* [`6e30039c`](https://github.com/NixOS/nixpkgs/commit/6e30039c0fa29df679606c6de9a606f4c2046c1e) powerdns-admin: use fetchYarnDeps
* [`5049680b`](https://github.com/NixOS/nixpkgs/commit/5049680bc864c579f7b5c854ab642b34a2783036) nnn: add plugins, quitcd, and pcre and extra make flags build options
* [`bea05181`](https://github.com/NixOS/nixpkgs/commit/bea05181f8188997e127709031cdd8db805944ce) vimPlugins.nvim-remote-containers: init at 2023-08-01
* [`e480fdf4`](https://github.com/NixOS/nixpkgs/commit/e480fdf4a388f413fd4b57e9ff159562e9cc5b2f) ghidra: 10.3.2 -> 10.3.3
* [`9692128a`](https://github.com/NixOS/nixpkgs/commit/9692128afea267f0a6cc40693be0f2f709a36e6b) photofield: 0.10.4 -> 0.11.0
* [`48e6cd00`](https://github.com/NixOS/nixpkgs/commit/48e6cd003863df7a02318272c2a22fbd2244d0e9) gnome.gnome-boxes: 44.2 → 44.3
* [`28fb2d91`](https://github.com/NixOS/nixpkgs/commit/28fb2d91b40e93cf7e2e204cfd22320f365405a4) gnome.mutter: 44.3 → 44.4
* [`41acd5bc`](https://github.com/NixOS/nixpkgs/commit/41acd5bc573fa3b20b17ea700874441753356d9e) gnome.gnome-shell: 44.3 → 44.4
* [`b3a68616`](https://github.com/NixOS/nixpkgs/commit/b3a6861647e6c0cd59fa481ff1afe6fc4b94cc5a) python310Packages.invoke: 2.0.0 -> 2.2.0
* [`5014e83d`](https://github.com/NixOS/nixpkgs/commit/5014e83de1a11112e840703fd141a9aa28c54a8a) mpvScripts.mpvacious: 0.23 -> 0.24
* [`67c637b9`](https://github.com/NixOS/nixpkgs/commit/67c637b91604cde0264115f42647cdc3c07580e9) mesa: 23.1.5 -> 23.1.7
* [`0bffb7f9`](https://github.com/NixOS/nixpkgs/commit/0bffb7f9c995f5a771e4a794017d594e966c248d) lesscpy 0.13.0 -> 0.15.1
* [`5e680aac`](https://github.com/NixOS/nixpkgs/commit/5e680aac1dfd0833d09d53d9021a62c7b170f0c8) postgresqlPackages.pgsql-http: init at 1.6.0
* [`dfde9c83`](https://github.com/NixOS/nixpkgs/commit/dfde9c83bce9e6c2bc903dfc1bca3bf93b3f52de) postgresqlPackages.postgis: 3.3.3 -> 3.4.0
* [`9dbc33ba`](https://github.com/NixOS/nixpkgs/commit/9dbc33baf5276e0beb2f71e20e9fa5399aabca3c) igraph: 0.10.6 -> 0.10.7
* [`490e9836`](https://github.com/NixOS/nixpkgs/commit/490e9836480ecff91f5c0ad8c07630b9d90abe6f) python310Packages.igraph: 0.10.6 -> 0.10.7
* [`fc58f1e4`](https://github.com/NixOS/nixpkgs/commit/fc58f1e42dcedce00fd0b47ee4d9266ea5d463b6) igraph: add passthru.tests
* [`c9457233`](https://github.com/NixOS/nixpkgs/commit/c945723356c17f0570217dedefac645721d6fb70) buildFHSEnv: disable security features by default
* [`befdc3bb`](https://github.com/NixOS/nixpkgs/commit/befdc3bbca1a3a5805b2de39afdf4226f1519592) glooctl: 1.14.12 -> 1.15.4
* [`a1d38823`](https://github.com/NixOS/nixpkgs/commit/a1d38823079bdf7836dd44392e5e1029087d8c85) nixos/modules: Add declarationPositions
* [`7bd68a8b`](https://github.com/NixOS/nixpkgs/commit/7bd68a8bde33873eea657cd79d745615b6ae412d) soapysdr: cleanup expression
* [`2bdd5de8`](https://github.com/NixOS/nixpkgs/commit/2bdd5de8915f045a55d24f9b019c86179bcc6783) gnuradio: add support for soapysdr plugins in the wrapper
* [`f71d0eec`](https://github.com/NixOS/nixpkgs/commit/f71d0eec7b4ba674e6431a67bac3b60223b8ba9f) python310Packages.tensorflow-bin: 2.12.0 -> 2.13.0
* [`c75f4f64`](https://github.com/NixOS/nixpkgs/commit/c75f4f640a0c005dabd48cd463566668701c7040) iruby: update to 0.7.4, fix build, and add update script
* [`5666a378`](https://github.com/NixOS/nixpkgs/commit/5666a378cb3cafbeb075740244b7a316d0ba9f7a) nixos/users-groups: rename passwordFile in hashedPasswordFile
* [`e7807d69`](https://github.com/NixOS/nixpkgs/commit/e7807d695dd67aa9d1dad0ad3d6f809a1fb9da06) microsoft-edge: 115.0.1901.188 -> 116.0.1938.76
* [`159f903e`](https://github.com/NixOS/nixpkgs/commit/159f903eb1c0e68a200c5a96ee05bf542fd15027) google-cloud-sdk-gce: unpin the python version
* [`a4701fcf`](https://github.com/NixOS/nixpkgs/commit/a4701fcf3e9c01ae7ba4d298f0abd45a694343c7) quicktype: use buildNpmPackage
* [`fcb3e5f0`](https://github.com/NixOS/nixpkgs/commit/fcb3e5f0f7a784becac4893c21d08ce78a0cf53e) python310Packages.textnets: 0.8.8 -> 0.9.3
* [`20acd199`](https://github.com/NixOS/nixpkgs/commit/20acd199f4202da863f290b50345d30c85db913c) nixos/adguardhome: Fix openFirewall
* [`150b2ff4`](https://github.com/NixOS/nixpkgs/commit/150b2ff4d5307a33cb1b1bc8f13ca038a39bf645) nixos/terminfo: Improve snippet generating the “all terminfo” list
* [`91b85376`](https://github.com/NixOS/nixpkgs/commit/91b8537619df82351e1c6c5a15b0132e46ae6b2d) contour: Provide terminfo in separate output
* [`a4116e92`](https://github.com/NixOS/nixpkgs/commit/a4116e92892034e2f25036e9033d0f06fbf5b3b1) st: Provide terminfo in separate output
* [`c5de4a5b`](https://github.com/NixOS/nixpkgs/commit/c5de4a5be3d54436d8cdf2deb3f40dd7c52ddea6) yaft: Provide terminfo in separate output
* [`bc9bf862`](https://github.com/NixOS/nixpkgs/commit/bc9bf8621c99a683f5195bee441b355841692774) python312: 3.12.0b4 -> 3.12.0rc2
* [`ab5b8e65`](https://github.com/NixOS/nixpkgs/commit/ab5b8e656af09171554dc4f49188d3ca46c1edf0) python38: 3.8.17 -> 3.8.18
* [`0a6f3b58`](https://github.com/NixOS/nixpkgs/commit/0a6f3b585712858a07a62c887f1d7179cdfe4e0c) python39: 3.9.17 -> 3.9.18
* [`5f714e9c`](https://github.com/NixOS/nixpkgs/commit/5f714e9c4738093efa0d66bed995fcbc0b8915d0) haskellPackages.byte-count-reader: add maintainer
* [`d25f8089`](https://github.com/NixOS/nixpkgs/commit/d25f808980c69b804b0d84cefddc4216e6c5b624) syncthing: 1.23.7 -> 1.24.0
* [`dd4a28f9`](https://github.com/NixOS/nixpkgs/commit/dd4a28f97b9a6935c06b3f1f5b98144188318a89) vscode: 1.81.1 -> 1.82.0
* [`a9aabffa`](https://github.com/NixOS/nixpkgs/commit/a9aabffa44b36289e7cd2f3c340f4f2e2f733e16) vscodium: 1.81.1.23222 -> 1.82.0.23250
* [`accf4fc5`](https://github.com/NixOS/nixpkgs/commit/accf4fc5eef28746b0578543851314d7d49a4353) vscodium: add ludovicopiero as maintainers
* [`83df91b7`](https://github.com/NixOS/nixpkgs/commit/83df91b7fcc4fc9b0d004027b269b701921f7ce5) haskellPackages.HDRUtils: don't distribute because transitively insecure
* [`e85e7016`](https://github.com/NixOS/nixpkgs/commit/e85e701664208f353c65568b694a4e91d25c6553) haskellPackages.chalkboard: add darwin as bad platform
* [`df41622d`](https://github.com/NixOS/nixpkgs/commit/df41622d86ff444250f6baacadc50b00413b568e) haskellPackages.gi-gtk-layer-shell: not supported on darwin
* [`3a5a2209`](https://github.com/NixOS/nixpkgs/commit/3a5a22091e4c3ef127e212ab165dcbcdb9e3cbbc) haskellPackages.hb3sum: only supported on x86
* [`62ba01c0`](https://github.com/NixOS/nixpkgs/commit/62ba01c06e57e0e9386446f7326408728c08c8c8) haskellPackages.htune: supported platform is linux
* [`f1e71e87`](https://github.com/NixOS/nixpkgs/commit/f1e71e873e34e6b32f38552521f5c1b9fa45b4c0) haskellPackages.jobqueue: don't buisld becdue to transitive dep on openssl-1.1
* [`2ae3d9f7`](https://github.com/NixOS/nixpkgs/commit/2ae3d9f78da50068ec6ba5af6101dcfd47472dc2) haskellPackages.persistent-zookeeper: fix misspelling
* [`babe4ab7`](https://github.com/NixOS/nixpkgs/commit/babe4ab799d2a48d8eb760e0ce035926283b7b45) haskellPackages.sdr: disable on darwin
* [`6f305fba`](https://github.com/NixOS/nixpkgs/commit/6f305fba18be84b835cc828c55a39ebd56053f2e) azure-cli : 2.51.0 -> 2.52.0
* [`01eec38f`](https://github.com/NixOS/nixpkgs/commit/01eec38f90306b0b68ba1c715c05244dcc2e5554) haskellPackages.tensorflow: mark broken
* [`8bddf58c`](https://github.com/NixOS/nixpkgs/commit/8bddf58c4aa5dbdd4b60b087aa30c32451ade21d) freetype: enable 64-bit API on 32-bit systems
* [`cf3d29d6`](https://github.com/NixOS/nixpkgs/commit/cf3d29d63f7a0b372f0bc7ae460884e999ba9c35) sage: If docs are not enabled then don't include a doc attribute
* [`63c1a559`](https://github.com/NixOS/nixpkgs/commit/63c1a559a63d917b885369298264c54383264fe9) bitwarden: 2023.5.1 -> 2023.8.3
* [`59e48e33`](https://github.com/NixOS/nixpkgs/commit/59e48e33c4d17e189e1bf4f551f6c83fb8748f9d) nixos/direnv: remove persistDerivations
* [`3c9e3aa4`](https://github.com/NixOS/nixpkgs/commit/3c9e3aa44b2ee9c3e43eb0bb5ab42252815ca451) syncthing: 1.23.7 -> 1.24.0
* [`b11afc4c`](https://github.com/NixOS/nixpkgs/commit/b11afc4cbd7cfd9a408972cbec609be443982b98) meshcentral: use fetchYarnDeps
* [`662d915f`](https://github.com/NixOS/nixpkgs/commit/662d915f60d3c93659782058ecdd283a675ebeb3) nodePackages.swagger: drop
* [`35fb1352`](https://github.com/NixOS/nixpkgs/commit/35fb13529ce3a22986d76948979bd4c6f0734a38) flyctl: 0.1.84 -> 0.1.90
* [`37716c97`](https://github.com/NixOS/nixpkgs/commit/37716c97b69d795290ee8e06a08c298b91793493) hyprkeys: init at 1.0.3
* [`b7e82cf0`](https://github.com/NixOS/nixpkgs/commit/b7e82cf0fad9d77b98a9757581b4940074b76c2c) prusa-slicer: 2.6.0 -> 2.6.1
* [`ce371a2c`](https://github.com/NixOS/nixpkgs/commit/ce371a2c962977274428c63c4e45dc1b69c6378d) Improve update.sh script to fetch latest version automatically
* [`c3dea1fc`](https://github.com/NixOS/nixpkgs/commit/c3dea1fcee1d77cef80ba236bcabc4c36c39ec65) dt: 1.2.3 -> 1.2.4
* [`172dd925`](https://github.com/NixOS/nixpkgs/commit/172dd925f5d0d0a0568d2e9d25ad32fb8fcea182) postgresqlPackages.periods: 1.2.1 -> 1.2.2
* [`1a5ae14b`](https://github.com/NixOS/nixpkgs/commit/1a5ae14bcb055629579cfa80aebff937870a2207) elan: 2.0.1 -> 3.0.0
* [`70cd8158`](https://github.com/NixOS/nixpkgs/commit/70cd815865cafa1a17ddf2c47146eabeb025be66) postgresqlPackages.pg_partman: 4.7.3 -> 4.7.4
* [`58f1cd99`](https://github.com/NixOS/nixpkgs/commit/58f1cd9922542bac8e15f2fe1660ba3159128830) postgresqlPackages.pg_ivm: 1.5.1 -> 1.6
* [`01d15288`](https://github.com/NixOS/nixpkgs/commit/01d15288e5abba33795862cd72e9377bf3cfdff9) postgresqlPackages.pgjwt: unstable-2021-11-13 -> unstable-2023-03-02
* [`21043dee`](https://github.com/NixOS/nixpkgs/commit/21043dee811dc0be1d29a2a2fdc1f12090db193b) maintainers: add luochen1990
* [`cda839e9`](https://github.com/NixOS/nixpkgs/commit/cda839e95ec8d98f49eae0fd03dd9aaa38afb8a1) linux_xanmod: 6.1.47 -> 6.1.52
* [`3f2f8de5`](https://github.com/NixOS/nixpkgs/commit/3f2f8de5efc8f2fd7bdaf200af7ad9f415977534) linux_xanmod_latest: 6.4.12 -> 6.4.15
* [`33e27d70`](https://github.com/NixOS/nixpkgs/commit/33e27d70f7845a6a5d203788f4a528c52946f421) cardinal: 23.02 -> 23.07
* [`fe873e2b`](https://github.com/NixOS/nixpkgs/commit/fe873e2ba2f129ef0cbce35a535089aefd20a243) cardinal: wrapped `CardinalMini`
* [`d7d79781`](https://github.com/NixOS/nixpkgs/commit/d7d79781a9d180853669b15280a2129498b4e4cc) pleroma: 2.5.4 -> 2.5.5
* [`6192e58f`](https://github.com/NixOS/nixpkgs/commit/6192e58f18f965bfce5a23ca0d9fde00a64cd9bd) pleroma: add yayayayaka to maintainers
* [`f58c894e`](https://github.com/NixOS/nixpkgs/commit/f58c894e7c7b1640247e1e35a09c5d4ff0b9bb19) python310Packages.langsmith: 0.0.24 -> 0.0.35
* [`31d343bb`](https://github.com/NixOS/nixpkgs/commit/31d343bbd0c586ca633d1a51fa41b02c217f4ccb) python310Packages.langchain: 0.0.268 -> 0.0.285
* [`0c509f40`](https://github.com/NixOS/nixpkgs/commit/0c509f405d8ee7bda5736217eb1c8b3f0c406606) matrix-synapse-unwrapped: 1.91.1 -> 1.91.2
* [`566e32dd`](https://github.com/NixOS/nixpkgs/commit/566e32dd4290d951267e2a4d44a45c4c99f04efb) nixos/bcache: add a `boot.bcache.enable` kill switch
* [`a30ff3f1`](https://github.com/NixOS/nixpkgs/commit/a30ff3f1903f745cdacc7f88acc17d25cfc14ceb) libcap_pam, libintlOrEmpty: manually convert old aliases to throws
* [`a4ab521f`](https://github.com/NixOS/nixpkgs/commit/a4ab521f6a03c8f5571e0f1063e16b10421e5973) python3Packages.bokeh: 2.4.3 -> 3.2.2
* [`611255fd`](https://github.com/NixOS/nixpkgs/commit/611255fd6edb68774d43a2ac182e26dd91bd85e4) python3Packages.panel: 0.14.4 -> 1.2.2
* [`f5839272`](https://github.com/NixOS/nixpkgs/commit/f5839272e7a64bc5d6c68c5d999047b615cf394e) python3Packages.livelossplot: 0.5.4 -> 0.5.5
* [`f049a752`](https://github.com/NixOS/nixpkgs/commit/f049a75266f5db7e5b0821c0a4b7e91c72868596) python3Packages.intake: 0.7.0 -> unstable-2023-08-24
* [`33e5abf1`](https://github.com/NixOS/nixpkgs/commit/33e5abf1ab9b03a5b394d89e3658cc2649ea69df) python3Packages.intake: fix tests on darwin
* [`0e1a8027`](https://github.com/NixOS/nixpkgs/commit/0e1a8027d128f993a323878d34b1bf453f7cb636) nixos/swraid: fix regression for old initrd and add test coverage
* [`ea985a66`](https://github.com/NixOS/nixpkgs/commit/ea985a66fdff90a23c9a3eaf7f50f650601c8961) python311Packages.acunetix: init at 0.0.7
* [`c8d03f8a`](https://github.com/NixOS/nixpkgs/commit/c8d03f8a7e956e65b56c4d300c2bfb0f1f17e2a0) python311Packages.autoslot: ini at 2022.12.1
* [`37256bfd`](https://github.com/NixOS/nixpkgs/commit/37256bfd6a5ec2533f6caa4be3e9f89245a84b51) ghunt: init at 2.0.1
* [`b343fdee`](https://github.com/NixOS/nixpkgs/commit/b343fdee84ca283a43fd7d95abbe46d2b3b4b6a7) python311Packages.ipymarkup: init at 0.9.0
* [`3ed64b73`](https://github.com/NixOS/nixpkgs/commit/3ed64b73838e4b43ea99ad49d3610550caf35eba) python311Packages.razdel: init at 0.5.0
* [`9e227c3b`](https://github.com/NixOS/nixpkgs/commit/9e227c3bbdcc2dee1a841ea12ad040a454116e7b) python311Packages.yargy: init at 0.16.0
* [`64c24354`](https://github.com/NixOS/nixpkgs/commit/64c24354880f143f25709f39dab2bc4a8ac728e4) python311Packages.navec: init at 0.10.0
* [`c828e04e`](https://github.com/NixOS/nixpkgs/commit/c828e04e2bd60de12de85965751f85073a31ec6c) python311Packages.slovnet: init at 0.6.0
* [`b87ea3b1`](https://github.com/NixOS/nixpkgs/commit/b87ea3b156c303427a884b13198a2814825aed64) python311Packages.natasha: init at 1.6.0
* [`36026496`](https://github.com/NixOS/nixpkgs/commit/36026496120235cd128fbda4f4a671b8f8f701f1) rdiff-backup: 2.2.5 -> 2.2.6
* [`b93460e1`](https://github.com/NixOS/nixpkgs/commit/b93460e13404d107d57efacb366353bc625b16c2) rosenpass: init at 0.2.0
* [`7370e7ac`](https://github.com/NixOS/nixpkgs/commit/7370e7acb6fb041fc803f864ba28a36b866a0a82) dumpasn1: add meta.mainProgram
* [`a26609e4`](https://github.com/NixOS/nixpkgs/commit/a26609e4f6c00c8e54d5fbed23f3ce0734323e18) bluetuith: add meta.mainProgram
* [`9dc075af`](https://github.com/NixOS/nixpkgs/commit/9dc075af65e33e669238e92341ea83f5ae656a9c) nixd: add meta.mainProgram
* [`66f97d6c`](https://github.com/NixOS/nixpkgs/commit/66f97d6c65eebb64d895f70294c65f745a6f2c1f) svt-av1: enable link-time-optimization
* [`0bf98c46`](https://github.com/NixOS/nixpkgs/commit/0bf98c46997e48e5e8e9ad651e52a30bae362d7b) cargo-llvm-cov: add myself as a maintainer
* [`8ad79505`](https://github.com/NixOS/nixpkgs/commit/8ad7950576b691cf29b397c34c93767a64951cae) cargo-llvm-cov: mark as broken on some platforms
* [`eae65c5f`](https://github.com/NixOS/nixpkgs/commit/eae65c5f85a3d23908f72adb653fa2e2fbc89a7d) cargo-llvm-cov: refactor to fix tests
* [`cefb386e`](https://github.com/NixOS/nixpkgs/commit/cefb386e7813b26c67196b8966991a971b9e2dce) cargo-llvm-cov: document test failure modes
* [`a3cb994e`](https://github.com/NixOS/nixpkgs/commit/a3cb994e1b91beab5729b932c122c4a7a66cc50d) symbolicator: init at 23.8.0
* [`c3a73730`](https://github.com/NixOS/nixpkgs/commit/c3a737301bba18f92b275cc709d4129ae80e5bb1) deluge: do not use libtorrent-rasterbar-1_2_x
* [`728f977a`](https://github.com/NixOS/nixpkgs/commit/728f977a2f9ba2976b72eefa1c2ef20f14107f90) esbuild-config: init at 1.0.1
* [`1b3bdf7f`](https://github.com/NixOS/nixpkgs/commit/1b3bdf7fce8f2e0f3de1f1027787d75e2b35d741) performous: 1.2.0 -> 1.3.0
* [`9701a454`](https://github.com/NixOS/nixpkgs/commit/9701a454f195a49e9d524023da25e8d453aa21ae) fan2go: 0.8.0 -> 0.8.1
* [`191dee48`](https://github.com/NixOS/nixpkgs/commit/191dee486fe6025c3f885e7e9455a36673924393) nixos/systemd-boot: Fix Memtest86+ name.
* [`09587329`](https://github.com/NixOS/nixpkgs/commit/0958732966b9f1652d07bd7509adec902323099d) lutgen: init at 0.8.3
* [`0af6c474`](https://github.com/NixOS/nixpkgs/commit/0af6c474ee50b0ab95c30a8e556e61468ad789fa) wireless-regdb: 2023.05.03 -> 2023.09.01
* [`2923f914`](https://github.com/NixOS/nixpkgs/commit/2923f914fd4cafb73765de517e32767f75d8aed9) nats-server: 2.9.21 -> 2.9.22
* [`7728271b`](https://github.com/NixOS/nixpkgs/commit/7728271b31b5b4d05ccbea1f4599b5ecb7e8958f) near-cli: use mkYarnPackage
* [`36954758`](https://github.com/NixOS/nixpkgs/commit/36954758756a9f0df22c1074d792bbc0d6da60ad) staruml: 5.1.0 -> 6.0.0
* [`343b3aa3`](https://github.com/NixOS/nixpkgs/commit/343b3aa36c010f4b7327285756535f865e0871a3) murex: 4.4.9500 -> 5.0.9310
* [`2bbe1e43`](https://github.com/NixOS/nixpkgs/commit/2bbe1e437d16fbe86ad8177aaf77265b56388cd9) ocamlPackages.pp_loc: init at 2.1.0
* [`2ab03da4`](https://github.com/NixOS/nixpkgs/commit/2ab03da4fdfebfb5c408a9ca90968e1c06184bd6) eterm: remove
* [`d85f5aa4`](https://github.com/NixOS/nixpkgs/commit/d85f5aa4e8f40af2202bf64e77653fff3c7e07da) terraform-ls: 0.31.4 -> 0.31.5
* [`93e6542d`](https://github.com/NixOS/nixpkgs/commit/93e6542ddecc456d59efd9469fb5946f4ef5d56b) python310Packages.clarifai-grpc: 9.5.0 -> 9.8.0
* [`a8b31a80`](https://github.com/NixOS/nixpkgs/commit/a8b31a802d25cad6845a4b2db7b4c58ca772e3fb) mob: 4.4.5 -> 4.4.6
* [`ec86c2cf`](https://github.com/NixOS/nixpkgs/commit/ec86c2cfa2b35cae9f8af728ac05f46967f8621d) devbox: 0.5.11 -> 0.5.13
* [`705b998b`](https://github.com/NixOS/nixpkgs/commit/705b998b83cf05219c9f69dd6b6514eb5cbd4081) anbox: always use postmarket OS images
* [`b26fa0eb`](https://github.com/NixOS/nixpkgs/commit/b26fa0ebdd833e4292a31b59a57c36b2bcca9e9e) spicetify-cli: 2.23.0 -> 2.23.2
* [`5bac46e3`](https://github.com/NixOS/nixpkgs/commit/5bac46e3f928bac7d0a36921072ca4d4d3dfef92) crowdin-cli: 3.13.0 -> 3.14.0
* [`dcfad716`](https://github.com/NixOS/nixpkgs/commit/dcfad71665178e69f58a6c6e9a6b57519cf39416) python310Packages.griffe: 0.36.1 -> 0.36.2
* [`2a780f55`](https://github.com/NixOS/nixpkgs/commit/2a780f5572392f8a456b692dc58c0daa2d5f536e) commitizen: add shell completions
* [`5bfcb490`](https://github.com/NixOS/nixpkgs/commit/5bfcb490ac3ee1f072828486eba5b11c6956dba3) sshs: use sri hash
* [`5a31db94`](https://github.com/NixOS/nixpkgs/commit/5a31db94ce0922c4c75a0178b782a58aa6ba7814) zeal: 0.6.1.20230320 -> 0.6.1.20230907
* [`01b54c0f`](https://github.com/NixOS/nixpkgs/commit/01b54c0f258513b9dccd72d83bdcffcd16e9db62) opencomposite: init at unstable-2023-07-02
* [`576def89`](https://github.com/NixOS/nixpkgs/commit/576def8911f2f58c91bc50eac5e60f3a6c897bad) black: 23.3.0 -> 23.9.1
* [`ea818544`](https://github.com/NixOS/nixpkgs/commit/ea8185445f0b730be991c9aa1cf68beccdfeca89) eza: 0.11.0 -> 0.11.1
* [`1ad90fec`](https://github.com/NixOS/nixpkgs/commit/1ad90fec0c99b122634757b0912e34cbad361dec) knot-dns: 3.3.0 -> 3.3.1
* [`855b9047`](https://github.com/NixOS/nixpkgs/commit/855b90470096230d6af54aa103e0c7cb70d6aa8c) python310Packages.aiohomekit: 3.0.2 -> 3.0.3
* [`2e66f109`](https://github.com/NixOS/nixpkgs/commit/2e66f109edbe8bc2d9242abe8bf91023a5c69e15) nixos/pam: fix typo in fscrypt enable option
* [`e344b4ed`](https://github.com/NixOS/nixpkgs/commit/e344b4ed1331fbe10c5c49ab28bbdf7a50202316) python311Packages.homeassistant-stubs: 2023.9.0 -> 2023.9.1
* [`aeed58aa`](https://github.com/NixOS/nixpkgs/commit/aeed58aa1dcb179484b2815db26ec0a289e24f9a) lastpass-cli: 1.3.4 -> 1.3.6
* [`56420ecf`](https://github.com/NixOS/nixpkgs/commit/56420ecfc83f784447a1bafab9cbc360fa8786e4) maintainers: add ianliu
* [`86cb61cc`](https://github.com/NixOS/nixpkgs/commit/86cb61cc0c2866494358b7b0cf325feb10295417) python310Packages.sqlite-utils: 3.35 -> 3.35.1
* [`e2202c04`](https://github.com/NixOS/nixpkgs/commit/e2202c0494a1d706b846a7c21c9bb2548859c5ff) python310Packages.ansible-compat: 4.1.8 -> 4.1.10
* [`951b5238`](https://github.com/NixOS/nixpkgs/commit/951b5238446327e6c1824982e2f376a313de9f93) shellhub-agent: 0.12.4 -> 0.12.5
* [`7fc032e5`](https://github.com/NixOS/nixpkgs/commit/7fc032e5951b69de22b923e5bf64b0ca34c5b3e3) haskellPackages.aeson_2_2_0_0: get compiling
* [`e020d1a4`](https://github.com/NixOS/nixpkgs/commit/e020d1a4dcc4eabaeb4cf097849584f08d743eab) fdroidserver: use python deps from input
* [`96a2ad27`](https://github.com/NixOS/nixpkgs/commit/96a2ad272774f77b98561275c6ed411251424d69) fdroidserver: use ruamel.yaml 0.17.21
* [`9a70b1e2`](https://github.com/NixOS/nixpkgs/commit/9a70b1e242053ba9e3480ed7dc795917a7b1f631) build(deps): bump actions/checkout from 3 to 4
* [`5581c067`](https://github.com/NixOS/nixpkgs/commit/5581c0677cb7c41d6e65de0b0efd33f042c2d51a) bintools-wrapper: fix dynamic linker for powerpc64 big-endian
* [`437d00dd`](https://github.com/NixOS/nixpkgs/commit/437d00dde346bdd596ffe2686ec4ba67e01fde65) workflows/check-by-name: Make runnable without approval
* [`60291d6b`](https://github.com/NixOS/nixpkgs/commit/60291d6be1744c7272c607b7e3aaab74c627be0b) python310Packages.aioaladdinconnect: 0.1.57 -> 0.1.58
* [`bb3a1572`](https://github.com/NixOS/nixpkgs/commit/bb3a1572ea6958c5952a9863ab37a4dfc67c78b9) kde/frameworks: 5.109.0 -> 5.110.0
* [`3993e3b2`](https://github.com/NixOS/nixpkgs/commit/3993e3b2c8da5b34d3285a2aabc1e477585af6e3) sublime4: 4143 -> 4152
* [`b10dd4e6`](https://github.com/NixOS/nixpkgs/commit/b10dd4e62b110eacf607aca2b53d957cc2e65997) python310Packages.pipenv-poetry-migrate: 0.4.0 -> 0.5.0
* [`6af4900c`](https://github.com/NixOS/nixpkgs/commit/6af4900ced5bf0080bd2eea8f6cefc9d71b3311c) sing-box: 1.4.1 -> 1.4.2
* [`426b7388`](https://github.com/NixOS/nixpkgs/commit/426b738897e9cc314b34d09f53684f66894febd2) keycloak: 22.0.1 -> 22.0.2
* [`e5aa6fd1`](https://github.com/NixOS/nixpkgs/commit/e5aa6fd14dd016aead9f4e897b95d3ae536db805) python310Packages.chispa: 0.8.3 -> 0.9.3
* [`26e73d29`](https://github.com/NixOS/nixpkgs/commit/26e73d29784854ea02b9639e1c64cb535325a211) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.15.2 -> 0.16.0
* [`9defdc50`](https://github.com/NixOS/nixpkgs/commit/9defdc50675d15b69c49745d7004d8492e777c28) python310Packages.stanza: 1.5.0 -> 1.5.1
* [`acdede90`](https://github.com/NixOS/nixpkgs/commit/acdede901e1ff4e6afaf3d117c79de5818b6b338) slack: 4.33.84 -> 4.34.115
* [`def9b6a5`](https://github.com/NixOS/nixpkgs/commit/def9b6a5a5f6576472030c0d0dc60eefc8f9c6b3) hexo-cli: init at 4.3.1
* [`abd6bdbf`](https://github.com/NixOS/nixpkgs/commit/abd6bdbfdd261d90d9015e3f9aab0f1e0a780c79) maintainers: add willswats
* [`45715a7d`](https://github.com/NixOS/nixpkgs/commit/45715a7dc7ebc4d0b2a43360e3c9fddfe6f459f8) hyprshade: init v0.9.3
* [`f790e47a`](https://github.com/NixOS/nixpkgs/commit/f790e47a38d2ebab075153bbbc1f5dce152f0985) gallery-dl: add meta.mainProgram
* [`35320515`](https://github.com/NixOS/nixpkgs/commit/353205154a5857c1c52ecaba8469bc40f31572e6) cargo-hack: 0.6.6 -> 0.6.7
* [`74c782d0`](https://github.com/NixOS/nixpkgs/commit/74c782d0d3de0bf6ead55fa7adba241568488d0e) cppcheck: refactor
* [`87eaf61a`](https://github.com/NixOS/nixpkgs/commit/87eaf61a2fca77df031bc148e5b18c93cf85f7c7) cppcheck: 2.11.1 -> 2.12.0
* [`633c705e`](https://github.com/NixOS/nixpkgs/commit/633c705ec592b1c3b1c5cac157aa6de3e878a8f4) unimap: init at 0.6.0
* [`a94ba027`](https://github.com/NixOS/nixpkgs/commit/a94ba027ff10f1689361a5cbafeffc300e760570) nest-cli: 9.4.2 -> 10.1.17
* [`93840b48`](https://github.com/NixOS/nixpkgs/commit/93840b48780adc5cee3c7259a2440d756f6bf32c) openssl_1_1: 1.1.1v -> 1.1.1w
* [`b76116f9`](https://github.com/NixOS/nixpkgs/commit/b76116f9bc98ee1925d7f1fbdc29c17bdf7630cd) mariadb_104: remove
* [`93342cd1`](https://github.com/NixOS/nixpkgs/commit/93342cd1dd998e5b02ead8dd2ec5c21be4149f0b) mujs: fix darwin dylib
* [`ac4fd1a1`](https://github.com/NixOS/nixpkgs/commit/ac4fd1a1098a3954b0e10fa8288a6492040102bb) Revert "Fix mujs dylib on Darwin"
* [`5f105f87`](https://github.com/NixOS/nixpkgs/commit/5f105f87787b15a4f7179b6414b9fbe4063e34da) nixos/acme: add option to set credential files
* [`ade414b6`](https://github.com/NixOS/nixpkgs/commit/ade414b6c7b9b5fe5cf69d4a1508973f7f4787f0) nixos/acme: rename option credentialsFile to environmentFile
* [`e895f786`](https://github.com/NixOS/nixpkgs/commit/e895f7867b34bc0885d07c2baeda2fda6ce8492f) python310Packages.netutils: 1.5.0 -> 1.6.0
* [`17983f67`](https://github.com/NixOS/nixpkgs/commit/17983f679ae893336a050c79312f8a8de48470e6) python311Packages.scikit-build-core: 0.4.8 -> 0.5.0
* [`a6d7135b`](https://github.com/NixOS/nixpkgs/commit/a6d7135b409717656d3b73f3dd71b065fecf5746) nyxt: 3.6.0 -> 3.7.0
* [`9e6c80af`](https://github.com/NixOS/nixpkgs/commit/9e6c80af47f376d5e06eaa5637f7d062c7690e46) lightningcss: 1.21.6 → 1.21.8
* [`cfaf1e68`](https://github.com/NixOS/nixpkgs/commit/cfaf1e6807950340a7bb62c847a2157aa9d28fce) schismtracker: 20220506 -> 20230906
* [`a4a5d651`](https://github.com/NixOS/nixpkgs/commit/a4a5d65150c2251e5afbebbbe4771d2df60b612a) fdroidserver: remove obfusk from maintainer and add linsui and jugendhacker
* [`372f4223`](https://github.com/NixOS/nixpkgs/commit/372f42234ec69869489f350e77d676eb4fef68ad) n8n: 1.3.1 -> 1.5.1
* [`1b854c3c`](https://github.com/NixOS/nixpkgs/commit/1b854c3c566c0de1ebe655f19de81818b8d43357) tor: 0.4.8.4 -> 0.4.8.5
* [`1b04b02b`](https://github.com/NixOS/nixpkgs/commit/1b04b02b35be932b406c07ef8f2621a501ad29ea) phpExtensions.memcache: init at 8.2
* [`2f5a505c`](https://github.com/NixOS/nixpkgs/commit/2f5a505cabb19d34e63620293665ff721b25fd5c) libcef: 116.0.20 -> 116.0.21
* [`22049a1a`](https://github.com/NixOS/nixpkgs/commit/22049a1aa3cacbc06e0447ff3a6934e37529fb55) qovery-cli: 0.68.1 -> 0.69.1
* [`9ea2f927`](https://github.com/NixOS/nixpkgs/commit/9ea2f927edbe47fbab875814d87410ceac555fb5) tfsec: 1.28.2 -> 1.28.4
* [`2d23d629`](https://github.com/NixOS/nixpkgs/commit/2d23d629d3c018cd4e6989ed52e0410bb642a50a) libretro.same_cdi: init at unstable-2023-02-28
* [`f73f403b`](https://github.com/NixOS/nixpkgs/commit/f73f403bd3e1f347134c7a7c8e3128a1f54e759f) python311Packages.netutils: 1.5.0 -> 1.6.0
* [`2794fc67`](https://github.com/NixOS/nixpkgs/commit/2794fc676873d0ce9b46df34e66a16ad12c4dfc0) the-legend-of-edgar: disable fortify flag
* [`d9efdf85`](https://github.com/NixOS/nixpkgs/commit/d9efdf8555ba61c9e37b25dacdf0174b4ed88cfe) the-legend-of-edgar: 1.36 -> 1.36-unstable-2023-07-11
* [`0843e54f`](https://github.com/NixOS/nixpkgs/commit/0843e54fdafb46f110126d4715db15d3c7f5ef28) the-legend-of-edgar: migrate to by-name
* [`b474e456`](https://github.com/NixOS/nixpkgs/commit/b474e456514688528e2b749576ca47edcbd39255) uclibc: 1.0.42 -> 1.0.44
* [`0d18c7fa`](https://github.com/NixOS/nixpkgs/commit/0d18c7fa975b20378a64d6461bc13e16581d5e79) python311Packages.dbus-fast: 2.0.1 -> 2.2.0
* [`463fb9db`](https://github.com/NixOS/nixpkgs/commit/463fb9db44da6391497b5d3d635f62a865ed60f7) setzer: 56 -> 59
* [`db63bec9`](https://github.com/NixOS/nixpkgs/commit/db63bec91211c7163ee785d89c129d7da9682f1a) ruff: 0.0.287 -> 0.0.288
* [`16f22b62`](https://github.com/NixOS/nixpkgs/commit/16f22b62572556f4f7f183c0e8162b2b9fbf3842) python311Packages.hatasmota: 0.7.1 -> 0.7.2
* [`9c69cada`](https://github.com/NixOS/nixpkgs/commit/9c69cadafe42848a944ae21e0ee5743a40f27f78) python311Packages.pyunifiprotect: 4.10.6 -> 4.20.0
* [`a18b1444`](https://github.com/NixOS/nixpkgs/commit/a18b14441588fa7bbf27bfe30f7c44a67298effc) dool: 1.2.0 -> 1.3.0
* [`deca376b`](https://github.com/NixOS/nixpkgs/commit/deca376b4624ab126a49ed40d8c8c5e68174fb81) sqlfluff: 2.3.1 -> 2.3.2
* [`3d20eacb`](https://github.com/NixOS/nixpkgs/commit/3d20eacb34757b915ab50eb1b5bb1986a0cf6024) python311Packages.flux-led: 1.0.2 -> 1.0.4
* [`f4c711b8`](https://github.com/NixOS/nixpkgs/commit/f4c711b8c1f1d0e1e5dc703e8a454a4df6324cb8) python311Packages.aiohomekit: 3.0.2 -> 3.0.3
* [`32883aec`](https://github.com/NixOS/nixpkgs/commit/32883aecc9429f8aae239f796153b0f9641d6aae) zfsUnstable: 2.1.13 -> 2.2.0-rc4
* [`8ed26ec9`](https://github.com/NixOS/nixpkgs/commit/8ed26ec9b0d43b867d1c868060a9a8929ce9b82d) python311Packages.aiovodafone: 0.1.0 -> 0.2.0
* [`7c12bfe2`](https://github.com/NixOS/nixpkgs/commit/7c12bfe29199710dc262933df0a3653d215e4328) cargo-edit: 0.12.1 -> 0.12.2
* [`9aa73db4`](https://github.com/NixOS/nixpkgs/commit/9aa73db4d766304c6ec8c9344426d298570cf67b) python311Packages.zeroconf: 0.103.0 -> 0.104.0
* [`7f1a1944`](https://github.com/NixOS/nixpkgs/commit/7f1a19449ea27da2dfa85d002e05f0950dec1e79) python311Packages.zeroconf: 0.104.0 -> 0.105.0
* [`e2bc6ba9`](https://github.com/NixOS/nixpkgs/commit/e2bc6ba99bc4113c36ee80fa7818b5f62f32cc18) cargo-release: 0.24.11 -> 0.24.12
* [`f720420b`](https://github.com/NixOS/nixpkgs/commit/f720420b4822a38bc265abf6efdc0f854e7fa32b) python311Packages.zeroconf: 0.105.0 -> 0.106.0
* [`59f17891`](https://github.com/NixOS/nixpkgs/commit/59f17891e1ae8d7ccb7fd29972d812cef5cb5906) python311Packages.zeroconf: 0.106.0 -> 0.107.0
* [`955b4267`](https://github.com/NixOS/nixpkgs/commit/955b42677beffc5cf086b7c612165a9e84492ec1) python311Packages.zeroconf: 0.107.0 -> 0.108.0
* [`e66e868f`](https://github.com/NixOS/nixpkgs/commit/e66e868f4e877b185fdce573524f25f3272da67d) python310Packages.litellm: init at 0.1.574
* [`e38bce9d`](https://github.com/NixOS/nixpkgs/commit/e38bce9d300e6bbbf39e7574c27d533bbfdeb559) python310Packages.tokentrim: init at unstable-2023-09-07
* [`bfdce9bc`](https://github.com/NixOS/nixpkgs/commit/bfdce9bcf7be062133cc77c117626c5a9b53cfcb) open-interpreter: init at 0.1.2
* [`d13e9427`](https://github.com/NixOS/nixpkgs/commit/d13e942758a6a1571dee59b32fe3d60651626342) python3Packages.pymongo-inmemory: init at 0.3.0
* [`0996a248`](https://github.com/NixOS/nixpkgs/commit/0996a248c55eefb4431f38dc54815eb6dc40fed9) python3Packages.cachier: init at 2.2.1
* [`da8348f1`](https://github.com/NixOS/nixpkgs/commit/da8348f1869f07bbb053b7e5731afa27d8088e8c) oranda: 0.3.1 -> 0.4.0
* [`59d6aba0`](https://github.com/NixOS/nixpkgs/commit/59d6aba0dc9c8553fd2e6f39f4e471513b87d480) maintainers: add knarkzel and nyanbinary
* [`abe6f843`](https://github.com/NixOS/nixpkgs/commit/abe6f84302896434c871f868abdd93d02e02acaa) headphones-toolbox: init at 0.0.3
* [`38c1400f`](https://github.com/NixOS/nixpkgs/commit/38c1400f67f6af73821d5be82f0ddab548e707e2) dockerTools: use makeOverridable for buildImage family of functions
* [`680dfee1`](https://github.com/NixOS/nixpkgs/commit/680dfee1714545c59edcc8a7755755f5164f5307) 23.11 release notes: add note on dockerTools & makeOverridable
* [`dac2ac1d`](https://github.com/NixOS/nixpkgs/commit/dac2ac1d0b7706db3334c9f01a560612f91c3887) crystal: add PKG_CONFIG_PATH
* [`f59d4d16`](https://github.com/NixOS/nixpkgs/commit/f59d4d161b5ca1774b09c03050548c1da6a9ca2f) git-cliff: 1.2.0 -> 1.3.0
* [`9e0b164a`](https://github.com/NixOS/nixpkgs/commit/9e0b164a6d7a5933f8383894fd023670a57d996b) ripsecrets: 0.1.6 -> 0.1.7
* [`3efda46d`](https://github.com/NixOS/nixpkgs/commit/3efda46dd5d6e57521209a19826ea344409e4091) fastjet-contrib: 1.049 -> 1.052
* [`9da9228f`](https://github.com/NixOS/nixpkgs/commit/9da9228f98c63f0083a59684c5b4c7d841acad7f) python311Packages.vg: init at 2.0.0
* [`e2712661`](https://github.com/NixOS/nixpkgs/commit/e2712661790665b4aa4223652ca8a182490a04ed) prefetch-npm-deps: add support for NIX_NPM_TOKENS env var
* [`7f76ac6e`](https://github.com/NixOS/nixpkgs/commit/7f76ac6e098c7d0b8793b829cf122da5901e130c) fetchNpmDeps: pass NIX_NPM_TOKENS as an impure env var
* [`804d0108`](https://github.com/NixOS/nixpkgs/commit/804d0108a8ddfca27534ba696c058bc0fa5dd82a) reason: 3.8.2 → 3.9.0
* [`a6dfd14e`](https://github.com/NixOS/nixpkgs/commit/a6dfd14e598cc820ac92143a896d775395bd4762) tidal-hifi: 5.7.0 -> 5.7.1
* [`a5d727ed`](https://github.com/NixOS/nixpkgs/commit/a5d727ed98a9bbf6727f58298fff30e41745b3d8) retool: use pythonRelaxDepsHook
* [`e27e3020`](https://github.com/NixOS/nixpkgs/commit/e27e30204b9c77f2b1650c4dad80f100b44b2dfb) pkgs/by-name: Add manual migration guidelines
* [`a677beb8`](https://github.com/NixOS/nixpkgs/commit/a677beb85044d75be0b6a793efd7d2aeb1d948d6) python310Packages.google-cloud-pubsub: 2.18.3 -> 2.18.4
* [`adedd9b5`](https://github.com/NixOS/nixpkgs/commit/adedd9b597be1913de87b8429923b15efdea8c5b) webcord: revert to electron_25 ([nixos/nixpkgs⁠#254588](https://togithub.com/nixos/nixpkgs/issues/254588))
* [`e270be8f`](https://github.com/NixOS/nixpkgs/commit/e270be8f44a36a24be946107479c8b2f1bfcc082) iproute2: fix cross regression from 620f9f11f83de7fa68b346ff80adfc9914c50ce6
* [`e1daf722`](https://github.com/NixOS/nixpkgs/commit/e1daf722d2afd847ce6a0b52182c78267658ae5d) webcord-vencord: override pname argument
* [`1758408c`](https://github.com/NixOS/nixpkgs/commit/1758408ca9a3fa5f3466e8965fb841f6add30a4c) python310Packages.simplefix: 1.0.15 -> 1.0.16
* [`ccf340e2`](https://github.com/NixOS/nixpkgs/commit/ccf340e27011eb10d1f7dc0ec4c77c2d89802454) ruff-lsp: 0.0.38 -> 0.0.39
* [`d518eb94`](https://github.com/NixOS/nixpkgs/commit/d518eb94eee9d88e7a4aad37b8cd0065f394a79d) tests.nixpkgs-check-by-name: Fix for symlinked tempdirs
* [`9c9a7e00`](https://github.com/NixOS/nixpkgs/commit/9c9a7e00829169a68ee9ec0c6e5d2071ae1285b5) tests.nixpkgs-check-by-name: Fix with parallel tests
* [`0a176dfc`](https://github.com/NixOS/nixpkgs/commit/0a176dfc4cea922d852a227c4f1c39f30b6eaf09) libvirt: 9.6.0 -> 9.7.0
* [`2ec2a963`](https://github.com/NixOS/nixpkgs/commit/2ec2a9636d19f703e59c22c8497a516a19632399) opentabletdriver: 0.6.2.0 -> 0.6.3.0
* [`0cc35e3e`](https://github.com/NixOS/nixpkgs/commit/0cc35e3eac146453fd153aa8cab38e56cb1b44f5) python3Packages.gps3: 0.33.3 -> 2017-11-01
* [`3b02740a`](https://github.com/NixOS/nixpkgs/commit/3b02740aef3c19b53aa4de383d37658f624990ed) python310Packages.mkdocstrings-python: 1.6.2 -> 1.6.3
* [`284898d6`](https://github.com/NixOS/nixpkgs/commit/284898d6be534d4068e901d2e98ae68b09831228) Use BUNDLE_FORCE_RUBY_PLATFORM=1 + further update.sh improvements
* [`879ce8e7`](https://github.com/NixOS/nixpkgs/commit/879ce8e7cf787bb8acee987bded27057d1b8ad13) python310Packages.qutip: 4.7.2 -> 4.7.3
* [`7de036fa`](https://github.com/NixOS/nixpkgs/commit/7de036faedfb45e3220144111c0ed06325170a74) pluto: 5.18.3 -> 5.18.4
* [`34992839`](https://github.com/NixOS/nixpkgs/commit/34992839e4c085d1681b5ca153e36dcbfa3caa7d) numix-icon-theme-circle: 23.08.16 -> 23.09.11
* [`90fba395`](https://github.com/NixOS/nixpkgs/commit/90fba39526014b94ec1d97ce156476a1d32f714f) emacs: disable native compilation when cross-compiling
* [`476a4158`](https://github.com/NixOS/nixpkgs/commit/476a4158be2a1ec7eb215fe561d9f01598b47c3e) python310Packages.textual: 0.35.1 -> 0.36.0
* [`82a2a96f`](https://github.com/NixOS/nixpkgs/commit/82a2a96f98c901480dae61201d3f91fad3956f3d) meme-bingo-web: init at 0.2.0
* [`8a1734ec`](https://github.com/NixOS/nixpkgs/commit/8a1734ec9810406427cccff8b2e40eb0d181c2d2) nixos/meme-bingo-web: init service
* [`55358478`](https://github.com/NixOS/nixpkgs/commit/553584785af2285087eb51c759228546579a7a0c) python310Packages.pontos: 23.8.5 -> 23.9.0
* [`6195c0e8`](https://github.com/NixOS/nixpkgs/commit/6195c0e8081b03fefa341b73fa5a0a8695b70fff) minimal-bootstrap.bash: add `bin/sh` symlink
* [`04a90698`](https://github.com/NixOS/nixpkgs/commit/04a90698aa2615d33eb5360a6cb4de3f1cf3571a) minimal-bootstrap.gawk-mes: rename from gawk
* [`8dedcd86`](https://github.com/NixOS/nixpkgs/commit/8dedcd8658f8e603eecc51bee93d90f8866f52ce) python310Packages.hypothesmith: 0.2.3 -> 0.3.0
* [`dc0f76eb`](https://github.com/NixOS/nixpkgs/commit/dc0f76eb106e8501ec4af254739f5e650551cc59) pitivi: pass hicolor-theme to fix missing icons
* [`c17f4fe1`](https://github.com/NixOS/nixpkgs/commit/c17f4fe14aca52217d1dde9f865ec53c8ec02ed7) millet: 0.13.1 -> 0.13.2
* [`8d1dc613`](https://github.com/NixOS/nixpkgs/commit/8d1dc6137c657e1d617dc8057e29be32abdf4617) rclone: 1.63.1 -> 1.64.0
* [`41edd759`](https://github.com/NixOS/nixpkgs/commit/41edd7597449d8e49334871457d93f897b54fab2) postgresqlPackages.plpgsql_check: 2.4.0 -> 2.5.0
* [`2d857eae`](https://github.com/NixOS/nixpkgs/commit/2d857eae06decfe6eb25ac6df659dc51af0c44c7) vault: fix build on darwin
* [`468b7481`](https://github.com/NixOS/nixpkgs/commit/468b748170ba8e9bc921272e7e3802cbb79ed1e7) clamav: fix build on darwin
* [`3ebe7971`](https://github.com/NixOS/nixpkgs/commit/3ebe79716dc1d555fa1d411f498d19ea8cce99e2) pgpool: 4.4.3 -> 4.4.4
* [`ee7b10cb`](https://github.com/NixOS/nixpkgs/commit/ee7b10cb56ccae246603db4da27bff14a85e07cc) python310Packages.google-cloud-datastore: 2.17.0 -> 2.18.0
* [`5a3d1bcb`](https://github.com/NixOS/nixpkgs/commit/5a3d1bcb12edfeb665e41351163fd1628cb29c23) minimal-bootstrap.gawk: init at 4.1.4
* [`5845f8a7`](https://github.com/NixOS/nixpkgs/commit/5845f8a7f004d84ce3990f9e92706fc577d406d2) matrix-hook: init at 1.0.0
* [`a056c7dd`](https://github.com/NixOS/nixpkgs/commit/a056c7dd070e8a0fa7b90bfcb42b6806fa8af38a) minimal-bootstrap.stage0-posix: support x86_64-linux
* [`fd61c0ee`](https://github.com/NixOS/nixpkgs/commit/fd61c0eee06c4cf1932fcda46a45f67488f824a0) minimal-bootstrap.mes: remove unneeded platform flag
* [`461aa2d8`](https://github.com/NixOS/nixpkgs/commit/461aa2d82fc8196ab979b560ead321d84593bcd2) r2modman: pin to Electron 25
* [`363e9382`](https://github.com/NixOS/nixpkgs/commit/363e9382a54b0cc2eec27638a7534adaaf063951) r2modman: fix launching Steam games
* [`9b95f21c`](https://github.com/NixOS/nixpkgs/commit/9b95f21cdb383f56c5a769240c946ef376778fb9) nvidia,nixos/nvidia: add datacenter drivers compatible with default cudaPkgs
* [`bc554a87`](https://github.com/NixOS/nixpkgs/commit/bc554a877796c5d7befc4851315c0aca5c4119f7) polypane: 14.0.1 -> 14.1.0
* [`43286ace`](https://github.com/NixOS/nixpkgs/commit/43286ace2c8741fd030f9ea669a082786a95a0ae) xjadeo: 0.8.12 -> 0.8.13
* [`5666ee05`](https://github.com/NixOS/nixpkgs/commit/5666ee051e9447d1f0e176e69ef5c3e93405a744) discord-development: 0.0.217 -> 0.0.232
* [`968efb72`](https://github.com/NixOS/nixpkgs/commit/968efb72fdaf8bf889b2908f11d171b1151f730a) libsForQt5.qtutilities: 6.13.0 -> 6.13.1
* [`d5e6e8ac`](https://github.com/NixOS/nixpkgs/commit/d5e6e8ac0323dd902002a4b46190ddab75f57666) veryfasttree: 4.0.2 -> 4.0.3
* [`d69b4708`](https://github.com/NixOS/nixpkgs/commit/d69b47088a19b7ef6344c079c86c618a1ec17bec) tailscale: 1.48.1 -> 1.48.2
* [`cfc486ab`](https://github.com/NixOS/nixpkgs/commit/cfc486abb1c3d5bd7bb71e0b77ade9ed7c44be92) eza: create exa compatiblity symlink ([nixos/nixpkgs⁠#254600](https://togithub.com/nixos/nixpkgs/issues/254600))
* [`28fd8865`](https://github.com/NixOS/nixpkgs/commit/28fd8865f32f68dc2dfdddc8b24f4009acb995ce) obsidian: 1.4.5 -> 1.4.11
* [`cf0e893e`](https://github.com/NixOS/nixpkgs/commit/cf0e893e777b853f13fac983b39549362438c19a) swiftshader: 2020-11-06 -> 2023-09-11
* [`8a5b4621`](https://github.com/NixOS/nixpkgs/commit/8a5b46216222d9ae5c52d59895c2ce2d2d9cfee7) circleci-cli: 0.1.28811 -> 0.1.28995
* [`fd0060da`](https://github.com/NixOS/nixpkgs/commit/fd0060da7732646e4dbb7b355b9af2ffa6da5c3f) terraform: remove marsam from maintainers
* [`13274f33`](https://github.com/NixOS/nixpkgs/commit/13274f3330e7f1e9ec3cb9e073c580e478479e9a) sqldef: 0.16.4 -> 0.16.7
* [`1ee50a29`](https://github.com/NixOS/nixpkgs/commit/1ee50a29288f768c55211963be8040671814986d) go_1_21: install from distpack archive
* [`ef8ed516`](https://github.com/NixOS/nixpkgs/commit/ef8ed516be809064c7b720b06f68bbb3f79002f1) tau-hydrogen: init at 1.0.11
* [`2ca828ae`](https://github.com/NixOS/nixpkgs/commit/2ca828aef3f057fe1030eac6ec0ba2632069d08b) kubevpn: 1.1.36 -> 1.2.0
* [`e876bd0e`](https://github.com/NixOS/nixpkgs/commit/e876bd0eef888f8882b41bc47ee52758c970f255) pdfhummus: 4.5.10 -> 4.5.11
* [`269d085c`](https://github.com/NixOS/nixpkgs/commit/269d085c62f717ac4bb774a5b39808618ebc2bf0) kotlin-language-server: 1.3.3 -> 1.3.5
* [`813e0007`](https://github.com/NixOS/nixpkgs/commit/813e00074293f74e12800982b9025c5cdf25f08b) linux_testing: 6.5-rc7 -> 6.6-rc1
* [`ccb56950`](https://github.com/NixOS/nixpkgs/commit/ccb5695018da1b83d38db0440a77d89c65428820) python310Packages.python-ironicclient: 5.3.0 -> 5.4.0
* [`e9f27ac1`](https://github.com/NixOS/nixpkgs/commit/e9f27ac1602ec761b86d817d143904c2f80e92ac) python310Packages.argh: 0.28.1 -> 0.29.3
* [`0500ff76`](https://github.com/NixOS/nixpkgs/commit/0500ff76bcacb66b6c7525a45046f6c5169ce7d2) chromium: 116.0.5845.179 -> 116.0.5845.187
* [`cb5c388d`](https://github.com/NixOS/nixpkgs/commit/cb5c388d491abf636773de862d6dcda3bf496529) sleek-grub-theme: init at unstable-2022-06-04
* [`2f9026a9`](https://github.com/NixOS/nixpkgs/commit/2f9026a94cd1ca29ab0e8d9fdc3e7109a2f406d6) python310Packages.sagemaker: 2.177.1 -> 2.184.0.post0
* [`3bcd7865`](https://github.com/NixOS/nixpkgs/commit/3bcd7865cfb0ee40c4af103a2d979f14868e8043) aardvark-dns: fix test instead of skipping it
* [`29b58cfa`](https://github.com/NixOS/nixpkgs/commit/29b58cfaaecc826fb61d490b8ac44f2c4e7d7dc9) vbam: 2.1.6 -> 2.1.7
* [`1b2ce448`](https://github.com/NixOS/nixpkgs/commit/1b2ce448169fb48373aff61151d6f0b823a98ff1) rke2: 1.27.3+rke2r1 -> 1.27.5+rke2r1
* [`5212d482`](https://github.com/NixOS/nixpkgs/commit/5212d482ac246f4bd733f3c266da55608fc97fd2) vimPlugins.markdown-preview-nvim: use mkYarnModules
* [`e70ead89`](https://github.com/NixOS/nixpkgs/commit/e70ead8965be7d28cc851cf8775d4029b44ff827) mtr: import a patch from upstream to fix segfault
* [`7ccc63ea`](https://github.com/NixOS/nixpkgs/commit/7ccc63eaa280333805e2bc1941b59763dbb80ff5) cargo-rdme: init at 1.4.2
* [`49fa5fd4`](https://github.com/NixOS/nixpkgs/commit/49fa5fd4c28b602456f3a28f2c5d890b5c6ed950) minify: 2.12.8 -> 2.12.9
* [`f437e7b5`](https://github.com/NixOS/nixpkgs/commit/f437e7b5b45bf95c27c7f3ad21e0f2f5ea1a74d6) aliyun-cli: 3.0.180 -> 3.0.181
* [`ea47befc`](https://github.com/NixOS/nixpkgs/commit/ea47befc874f241560ceebb68a6ddcdb71227346) subfinder: 2.6.2 -> 2.6.3
* [`4d666f0a`](https://github.com/NixOS/nixpkgs/commit/4d666f0afac15102b244f25425d5bb4651f66598) vulkan-validation-layers: enable separateDebugInfo
* [`9bcefc6c`](https://github.com/NixOS/nixpkgs/commit/9bcefc6c1b5335b44f9f35b80d4210f1e5814c16) commonsCompress: 1.23.0 -> 1.24.0
* [`8e6eae59`](https://github.com/NixOS/nixpkgs/commit/8e6eae5965c19c8ad2de2bd3d5d3f7e66a2e216b) rust-analyzer-unwrapped: 2023-09-04 -> 2023-09-11
* [`474fac1b`](https://github.com/NixOS/nixpkgs/commit/474fac1b73c5cec6e4f5098903bdf05e332c7cec) grpc_cli: 1.57.0 -> 1.58.0
* [`4091b4ee`](https://github.com/NixOS/nixpkgs/commit/4091b4eee2f9dc2bf0c8750cd60576758e5779f0) unpoller: 2.8.1 -> 2.8.3
* [`0c634976`](https://github.com/NixOS/nixpkgs/commit/0c634976411118a2aace4fb6fe70cb398b73bc9a) top-level: Convert aliases older than 2020 to throws
* [`8dcbced5`](https://github.com/NixOS/nixpkgs/commit/8dcbced52ae7973a28193d89bbb105a1522230a7) maintainers/scripts/remove-old-aliases: Drop `pkgs.` prefix if present
* [`e656f001`](https://github.com/NixOS/nixpkgs/commit/e656f0015562c901695d4839dbff4b0476075150) flexoptix-app: 5.13.4 -> 5.16.0
* [`0894ffc3`](https://github.com/NixOS/nixpkgs/commit/0894ffc3666dd6e769545d10fd2986b2e898eb51) numix-icon-theme-square: 23.08.16 -> 23.09.11
* [`d36449b1`](https://github.com/NixOS/nixpkgs/commit/d36449b1fb1de9b6775003ead73bf873879db939) plasma: 5.27.7 -> 5.27.8
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
