### PR TITLE
niv home-manager: update 5171f5ef -> feb70061

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5171f5ef654425e09d9c2100f856d887da595437",
-        "sha256": "0vc7jncpg9bcvipsby7yiwczbkng75cwhmxwdwr0b72rjy1ng9ks",
+        "rev": "feb70061596134d403e14cc5ef7b01ab114d1dbd",
+        "sha256": "1iwc3240hlr15jpcsgxr09gknyinqs6q1r91hzrx4qbldbxam9ka",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/5171f5ef654425e09d9c2100f856d887da595437.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/feb70061596134d403e14cc5ef7b01ab114d1dbd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5171f5ef...feb70061](https://github.com/nix-community/home-manager/compare/5171f5ef654425e09d9c2100f856d887da595437...feb70061596134d403e14cc5ef7b01ab114d1dbd)

* [`a0ddf43b`](https://github.com/nix-community/home-manager/commit/a0ddf43b6268f1717afcda54133dea30435eb178) xplr: add module
* [`c4c25944`](https://github.com/nix-community/home-manager/commit/c4c259442785ab79184184aad611ab56b439d3b0) flake.lock: Update
* [`d12c8fc8`](https://github.com/nix-community/home-manager/commit/d12c8fc85bf43436383fbb85194d5e8429baecc7) emacs: fix emacs-extra-config test
* [`aed5ed97`](https://github.com/nix-community/home-manager/commit/aed5ed979eced3790a39d069f08884061bda3c82) bat: allow adding custom syntaxes
* [`5f5cb7a6`](https://github.com/nix-community/home-manager/commit/5f5cb7a61360ba6555cf0875c590c0fe0f698d5e) carapace: add xgettext workaround
* [`f07207f8`](https://github.com/nix-community/home-manager/commit/f07207f8cab92d52b3871c760b8007ab32ff66cb) home-manager: fix typo
* [`a8cde785`](https://github.com/nix-community/home-manager/commit/a8cde785062bdc2a6a52e330dfb461f969f4558d) home-manager: update translation templates
* [`d9b88b43`](https://github.com/nix-community/home-manager/commit/d9b88b43524db1591fb3d9410a21428198d75d49) Update translation files
* [`e63a6b34`](https://github.com/nix-community/home-manager/commit/e63a6b34792884bfe4056d1ef561b5611589b8ad) programs.i3status-rust: reload on config change ([nix-community/home-manager⁠#4466](https://togithub.com/nix-community/home-manager/issues/4466))
* [`f092a922`](https://github.com/nix-community/home-manager/commit/f092a9220220e390c76605b6c4e2238774050f8b) programs.rio: add module ([nix-community/home-manager⁠#4118](https://togithub.com/nix-community/home-manager/issues/4118))
* [`feb70061`](https://github.com/nix-community/home-manager/commit/feb70061596134d403e14cc5ef7b01ab114d1dbd) git: replace gitToInit with lib function
