### PR TITLE
niv zsh-completions: update 0cee6ab5 -> bed209ca

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "0cee6ab50885845464724a6501f872f842253b36",
-        "sha256": "1hw5hd0r5pvda4bkff0dkb3zxm8fflprhyl62dm6vllpgz0cx9ca",
+        "rev": "bed209ca6454d2fab69654e79a47e716a4efff61",
+        "sha256": "1w70s7ax4fqicm5m92snvzw9kcn8snpdxkvy2mr7wgl1gj2h5wqi",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/0cee6ab50885845464724a6501f872f842253b36.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/bed209ca6454d2fab69654e79a47e716a4efff61.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@0cee6ab5...bed209ca](https://github.com/zsh-users/zsh-completions/compare/0cee6ab50885845464724a6501f872f842253b36...bed209ca6454d2fab69654e79a47e716a4efff61)

* [`28f60290`](https://github.com/zsh-users/zsh-completions/commit/28f602902e2b437ce52871e65057d11891ee7f77) Add completion script for chatblade
* [`facf9182`](https://github.com/zsh-users/zsh-completions/commit/facf9182501c09f2955fa69b924b4e55b872a4a9) Apply suggestions from code review
* [`6cbfc1b9`](https://github.com/zsh-users/zsh-completions/commit/6cbfc1b94295fa918821e1e452ffba700f17f517) Update fwupdmgr completion to 1.8.12
* [`7e9e1451`](https://github.com/zsh-users/zsh-completions/commit/7e9e14517dcf3a553a0c3e0ca93880863ee66abf) remove trailing spaces
* [`fb707804`](https://github.com/zsh-users/zsh-completions/commit/fb7078044b0603e1ab1ad9753eb55798d60a99e3) prevent global variables from overwriting
* [`0d26ab80`](https://github.com/zsh-users/zsh-completions/commit/0d26ab80ed4316f22c90787a80d26c662f97ac67) "local state" breaks --session completion
* [`c118ed45`](https://github.com/zsh-users/zsh-completions/commit/c118ed452da2915102e35e33e629bbe2f163b6eb) implement suggestions
