### PR TITLE
niv nixpkgs: update 44d14bee -> 94a42157

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44d14bee4bab76ded86caa12b49b5ae7fbeab671",
-        "sha256": "1hdn2ywivnd1d2qhnaql9wpqgrhknhz0n0dgv5v6fd03v5sjsk8g",
+        "rev": "94a42157f48abfe2c27b1afadd3bf8f94334f08d",
+        "sha256": "0acdfxx0gbdm14aqa0l7m6asyjkqmadizpni8caynlkf4vprx94d",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/44d14bee4bab76ded86caa12b49b5ae7fbeab671.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/94a42157f48abfe2c27b1afadd3bf8f94334f08d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@44d14bee...94a42157](https://github.com/nixos/nixpkgs/compare/44d14bee4bab76ded86caa12b49b5ae7fbeab671...94a42157f48abfe2c27b1afadd3bf8f94334f08d)

* [`3fd98e7f`](https://github.com/NixOS/nixpkgs/commit/3fd98e7fcb2fdc1b7699fd7de2bc83c67cf21c4a) nixos/fish: fix completion generation for non-derivation packages
* [`f5244e48`](https://github.com/NixOS/nixpkgs/commit/f5244e48fa9bd5d9c84d3515788c32608f848e18) python3Packages.django-types: init at 0.17.0
* [`bf383adf`](https://github.com/NixOS/nixpkgs/commit/bf383adf0ae173ce4506fdc4e59d9368f8adae91) nixos/user-groups: Add to $NIX_PROFILES paths
* [`aca70420`](https://github.com/NixOS/nixpkgs/commit/aca7042069b59a296c4ea2055ae0746eae8ce3a7) lib/systems: Add rustc config for aarch64-embedded
* [`a4a9bada`](https://github.com/NixOS/nixpkgs/commit/a4a9bada52bfc37a586394dd170b689a4f343604) calamares-nixos-extensions 0.3.12 -> 0.3.13
* [`5809b0bb`](https://github.com/NixOS/nixpkgs/commit/5809b0bbe679d2f8e822f4c33eb8c918d7c1c60a) mpvScripts.mpv-webm: init at unstable-2023-02-23
* [`8a543acc`](https://github.com/NixOS/nixpkgs/commit/8a543acc2bd7dc5493d67fff220f458697c20089) lib.systems: add qemu's funky custom name for mips n32
* [`75ac5184`](https://github.com/NixOS/nixpkgs/commit/75ac5184481e70649dbbda37cbc5280a1224dd50) system-config-printer: 1.5.15 -> 1.5.18
* [`751f2037`](https://github.com/NixOS/nixpkgs/commit/751f2037b730cb3a6fb879c5502cb51c7bc36b95) python311Packages.base64io: init at 1.0.3
* [`212f361b`](https://github.com/NixOS/nixpkgs/commit/212f361bc57af3a2f0526f178c1ad93eb3c56090) python311Packages.aws-encryption-sdk: init at 3.1.1
* [`c8866dd3`](https://github.com/NixOS/nixpkgs/commit/c8866dd30227d2353beb14ddeb294c16d59d5536) aws-encryption-sdk-cli: init at 4.1.0
* [`6380f7a4`](https://github.com/NixOS/nixpkgs/commit/6380f7a45c776731c4117921ecddd594bf353538) maintainers: add materus to maintainer-list
* [`15bf6b71`](https://github.com/NixOS/nixpkgs/commit/15bf6b71ce88c64b7876e32bcacfd06307755b11) obs-studio: fix script plugin path
* [`2f57513f`](https://github.com/NixOS/nixpkgs/commit/2f57513f3af413a38b22d1e1a29ca81a56b6fc02) pgrok: 1.3.4 -> 1.4.0
* [`5b8893c5`](https://github.com/NixOS/nixpkgs/commit/5b8893c5653b64300e86a1b515f31737b2cee18e) CODEOWNERS: remove matthewbauer
* [`0df5c9a8`](https://github.com/NixOS/nixpkgs/commit/0df5c9a81da7966e74da54a9952dabdd3134a6aa) flutter: Pass through engineArtifacts in wrapper
* [`2c622185`](https://github.com/NixOS/nixpkgs/commit/2c622185a7f9d81ae92490d881c46b26e9f94e58) nixos/calibre-web: add package and enableKepubify options
* [`84347c21`](https://github.com/NixOS/nixpkgs/commit/84347c2195eb5a7df786b2fbe046d34fdfe716c4) flutter: Use wrapGAppsHook
* [`fac229cd`](https://github.com/NixOS/nixpkgs/commit/fac229cd1a325ccad3326be021c2fdafddd2506a) starship: expose presets in share/starship/presets
* [`54444b58`](https://github.com/NixOS/nixpkgs/commit/54444b58924801f1eb0fdefc67f2cff572459bc6) qgis: add nixos tests
* [`b8e4cb40`](https://github.com/NixOS/nixpkgs/commit/b8e4cb404469ff8d3434ded189b81d6a2b20f175) llvm-spirv-translator: add llvm 16 variant
* [`238571b2`](https://github.com/NixOS/nixpkgs/commit/238571b21b35085b22a219bc01cf73a0582bc2bb) llvm-spirv-translator: fix build on Darwin
* [`af20d738`](https://github.com/NixOS/nixpkgs/commit/af20d738aebbad73c4191f9c83f2082b3841a3da) psqlodbc: 09.01.0200 -> 13.00.0000
* [`a771dc85`](https://github.com/NixOS/nixpkgs/commit/a771dc85ea6aa11e58eae2db674755cf842acff1) rymdport: 3.4.0 -> 3.5.0
* [`088aa6b9`](https://github.com/NixOS/nixpkgs/commit/088aa6b9654faacc8a1f4f834edd19c52fafeab4) libmysqlconnectorcpp: 8.0.33 -> 8.1.0
* [`f8b52716`](https://github.com/NixOS/nixpkgs/commit/f8b52716c5e81cfba24511a10ee4752b5d1a159f) basex: 10.6 -> 10.7
* [`516fac53`](https://github.com/NixOS/nixpkgs/commit/516fac53b3745d5f9e35920ba38322efb983944e) p2pool: 3.5 -> 3.6.2
* [`82c9a7f8`](https://github.com/NixOS/nixpkgs/commit/82c9a7f8b314282be1566969c5b3b8fb5b410ad7) ssm-agent: 3.2.1297.0 -> 3.2.1478.0
* [`e59a84aa`](https://github.com/NixOS/nixpkgs/commit/e59a84aaf89de542acca7f11fb13d0ac84f72a15) maintainers: add chrpinedo
* [`a6f9389e`](https://github.com/NixOS/nixpkgs/commit/a6f9389efbba66b1abf60c123608b5097428df14) python310Packages.pplpy: 0.8.7 -> 0.8.9
* [`af801525`](https://github.com/NixOS/nixpkgs/commit/af801525d1c6779750154f62f3af5ab87eab6621) jetbrains-toolbox: 2.0.2.16660 -> 2.0.3.17006
* [`a5792e0b`](https://github.com/NixOS/nixpkgs/commit/a5792e0be6a4a0790a7e1dfd3a0792c6290d6929) python3Packages.curlify: init at 2.2.1
* [`39a37b77`](https://github.com/NixOS/nixpkgs/commit/39a37b7705a1d6f7535d76b0a927b0cd4740964b) pricehist: init at 1.4.6
* [`029ab831`](https://github.com/NixOS/nixpkgs/commit/029ab83160b0fb325b448480fc85a1792de6d407) metabase: 0.46.7 -> 0.47.0
* [`66fe11f3`](https://github.com/NixOS/nixpkgs/commit/66fe11f3b3db36242af206163cb47c00b7ccc48d) temporal: 1.21.5 -> 1.22.0
* [`bd2dc33d`](https://github.com/NixOS/nixpkgs/commit/bd2dc33d76b644539fafb74cbb6945d5c8ce79a2) bkt: 0.6.1 -> 0.7.1
* [`29dcaf75`](https://github.com/NixOS/nixpkgs/commit/29dcaf75557b43b3e5879f445ad0ccde0de324cf) duo-unix: 2.0.1 -> 2.0.2
* [`bd0cbb43`](https://github.com/NixOS/nixpkgs/commit/bd0cbb43ec48dedd399c72b3bc04f980041ed20b) nixos/plasma5: remove pointless setuid wrappers
* [`3ff659c2`](https://github.com/NixOS/nixpkgs/commit/3ff659c21cebcd38d054f91743817347d08428bb) vassal: 3.6.19 -> 3.7.0
* [`8985e494`](https://github.com/NixOS/nixpkgs/commit/8985e494fec349de833f5177635e1ace938a5715) python311Packages.aws-sam-translator: 1.73.0 -> 1.74.0
* [`1e64d7fb`](https://github.com/NixOS/nixpkgs/commit/1e64d7fbb7e1b58a74935d830152cce8a333e0c4) nqptp: 1.2.1 -> 1.2.3
* [`c4244c7a`](https://github.com/NixOS/nixpkgs/commit/c4244c7aa3e37a1aa2837566260a14737f277663) plausible: 1.5.1 -> 2.0.0
* [`a4488872`](https://github.com/NixOS/nixpkgs/commit/a44888726ae32ca773ecc1c5408f8fbad6fa93d6) valentina: 0.7.51 -> 0.7.52
* [`d33bba68`](https://github.com/NixOS/nixpkgs/commit/d33bba68d1de4941eade084114732d14ed9e2d1a) svt-av1: 1.6.0 -> 1.7.0
* [`d85fe4c6`](https://github.com/NixOS/nixpkgs/commit/d85fe4c603a2017d905cb047d7d8b8a3d39d1bfb) hmat-oss: 1.8.1 -> 1.9.0
* [`930d2462`](https://github.com/NixOS/nixpkgs/commit/930d2462cd285d95c2f57679e0f5a7e44ce71baf) optipng: Use libpng instead of libpng-1.2
* [`a5702e4c`](https://github.com/NixOS/nixpkgs/commit/a5702e4cfcac907b04ffa117693c90d507b43230) zrok: 0.4.5 -> 0.4.6
* [`aba7bd4b`](https://github.com/NixOS/nixpkgs/commit/aba7bd4be475eb02d1525c84b9f2f4c1a4fc3a74) moonlight-embedded: 2.5.3 -> 2.6.0
* [`f453cea7`](https://github.com/NixOS/nixpkgs/commit/f453cea72410fb14c6cdda95eecd22d7d2ca81a7) python311Packages.libpcap: init at 1.11.0b7
* [`f7f848d8`](https://github.com/NixOS/nixpkgs/commit/f7f848d8cb9e1ef7b96278ab61f6ea2034bc0342) plausible: add softinio as maintainer
* [`085fba72`](https://github.com/NixOS/nixpkgs/commit/085fba725a167f0baac8bd7b7d71627e50022a44) libgphoto2: 2.5.30 -> 2.5.31
* [`c44396d6`](https://github.com/NixOS/nixpkgs/commit/c44396d6d43f87999836e3fbbc14c3188759269e) mergerfs: 2.36.0 -> 2.37.0
* [`da65911d`](https://github.com/NixOS/nixpkgs/commit/da65911d2383a07099a210be65dfd75fc154c09f) konstraint: 0.30.0 -> 0.31.0
* [`6b205f7c`](https://github.com/NixOS/nixpkgs/commit/6b205f7c7d38fa1470747cd92675885c95997524) jamulus: reformat function arguments
* [`7e5a7d17`](https://github.com/NixOS/nixpkgs/commit/7e5a7d17d0914ffd19126b04c337031946dbfb10) jamulus: 3.8.2 -> 3.10.0
* [`776debde`](https://github.com/NixOS/nixpkgs/commit/776debdeacc7379ad1f7c6c22af190f0afe30d59) jamulus: set meta.mainProgram
* [`b9a1f449`](https://github.com/NixOS/nixpkgs/commit/b9a1f44937ed39eaaa5d88ac10925dc46d8ed72f) maintainers: add wigust
* [`9f2a0d2f`](https://github.com/NixOS/nixpkgs/commit/9f2a0d2f541b8053798fd6c9b12a20066a1c7a6d) tmuxifier: init at 0.13.0
* [`51656463`](https://github.com/NixOS/nixpkgs/commit/51656463993256d8a065b0bf62395d47a2688cd6) cvc5: 1.0.7 -> 1.0.8
* [`56fabe7b`](https://github.com/NixOS/nixpkgs/commit/56fabe7b4e58716b6e0846ed7b1a365beb61b868) weave-gitops: 0.29.0 -> 0.31.2
* [`c171b0f9`](https://github.com/NixOS/nixpkgs/commit/c171b0f984880d0e28b68f3a3efc62f6a0b0c3f1) ocenaudio: 3.12.6 -> 3.12.7
* [`fbbddf76`](https://github.com/NixOS/nixpkgs/commit/fbbddf7650d6944acc0350f112bfa29b35845f76) netpbm: 11.3.4 -> 11.3.5
* [`6be969da`](https://github.com/NixOS/nixpkgs/commit/6be969daf178f7f2fbaff57a9326e79020115d7f) xorg: add meta.mainProgram to various utilities
* [`45198cf3`](https://github.com/NixOS/nixpkgs/commit/45198cf36973c84c55ead9c51978c0b005595f53) coursier: 2.1.6 -> 2.1.7
* [`227a75a6`](https://github.com/NixOS/nixpkgs/commit/227a75a6d4aed0272e5e20674a077daa9c30c82f) python311Packages.aliyun-python-sdk-kms: 2.16.1 -> 2.16.2
* [`456ce8dc`](https://github.com/NixOS/nixpkgs/commit/456ce8dc34adae6c43d80286827fdad8249388b8) jetbrains: fix darwin errors on macOS 13
* [`399f01d5`](https://github.com/NixOS/nixpkgs/commit/399f01d509b0a53d8e1486ea94215378783acc46) wasmer: 4.0.0 -> 4.1.1
* [`66a5b626`](https://github.com/NixOS/nixpkgs/commit/66a5b626e152f8ba47b24d713e2885656758a365) wasmer: 4.1.1 -> 4.1.2
* [`babf61b6`](https://github.com/NixOS/nixpkgs/commit/babf61b6e32a38bbf9e890ff333d0452175ae053) wasmer: 4.1.2 -> 4.2.0
* [`fa7ea4f8`](https://github.com/NixOS/nixpkgs/commit/fa7ea4f889cabf8fb449b3dd01aaa2249e7ef124) scala_2_13: 2.13.11 -> 2.13.12
* [`8ff38d74`](https://github.com/NixOS/nixpkgs/commit/8ff38d746d1236bf87aae3a8885fcbdd08e23d5d) scala_3: 3.3.0 -> 3.3.1
* [`edbb4618`](https://github.com/NixOS/nixpkgs/commit/edbb4618bb3045641cb01f1999ce4d3b2a52609b) mdbook-admonish: 1.10.2 -> 1.11.1
* [`7dfc3337`](https://github.com/NixOS/nixpkgs/commit/7dfc333726c9a41901b4c2cc81d5757a48d0bccb) cherrytree: 0.99.56 -> 1.0.1
* [`278cae3e`](https://github.com/NixOS/nixpkgs/commit/278cae3e45c3ac2480b5e04f998bc63887d1cce9) frugal: 3.16.27 -> 3.17.0
* [`1f4f6f40`](https://github.com/NixOS/nixpkgs/commit/1f4f6f40dffb5b1c03d047d4cb20c17817890a42) openapi-generator-cli: 6.6.0 -> 7.0.0
* [`a8f616d1`](https://github.com/NixOS/nixpkgs/commit/a8f616d11c6df6677b940cdb0c8945c5c1b0998e) bazel_6: Add diffutils and gnupatch to initialEnvironment
* [`d8119659`](https://github.com/NixOS/nixpkgs/commit/d8119659d4e4f57e5dd0c0be700354d10f64cb21) musikcube: 3.0.1 -> 3.0.2
* [`c463b4f2`](https://github.com/NixOS/nixpkgs/commit/c463b4f200bac76c9d5fd79ebd821d47b3a63d32) nixos/environment: drop QT_PLUGIN_PATH for qt4 and kde4 as they has been removed
* [`dcefa3a7`](https://github.com/NixOS/nixpkgs/commit/dcefa3a7d11e8ce4c82353ba747d13c57962b20f) starboard: 0.15.13 -> 0.15.15
* [`9b07b4d2`](https://github.com/NixOS/nixpkgs/commit/9b07b4d2d050b9c4e2f2b88c6b731d9d8cafd3db) nexttrace: 1.1.7-1 -> 1.2.1.1
* [`a4e01b7a`](https://github.com/NixOS/nixpkgs/commit/a4e01b7af96a5a0c7464ec72963faa4f31114e4b) sundials: 6.6.0 -> 6.6.1
* [`4f461f7b`](https://github.com/NixOS/nixpkgs/commit/4f461f7b7788d9aafc6021f1384423dabe605ad0) nixos/modules/system/resolved: disable DNSSEC validation by default
* [`4fba45de`](https://github.com/NixOS/nixpkgs/commit/4fba45ded59c9c669b0b4183fc9fe9d1c1cbe8b3) hydrogen: 1.2.1 -> 1.2.2
* [`d1c13359`](https://github.com/NixOS/nixpkgs/commit/d1c1335908813fa659a02aa61222672b03b9239f) nixos/switch-to-configuration: Test more action things
* [`211e2d73`](https://github.com/NixOS/nixpkgs/commit/211e2d738bbb9b19ce873203e8bc72c832072e15) nixos/switchTest: Also test init interface version
* [`e0717ce8`](https://github.com/NixOS/nixpkgs/commit/e0717ce857afab4a72a1d2b1e69d91e482b3370d) nixos/switchTest: Also test systemd restarts
* [`1ae69c58`](https://github.com/NixOS/nixpkgs/commit/1ae69c5842694099c7672a2fb3ffbadaf48c1371) nixos/environment: drop KDEDIRS as a leftover from KDE4
* [`c3e64122`](https://github.com/NixOS/nixpkgs/commit/c3e6412260dd30f82b715f976fff834fbeddae2f) nixos/switchTest: Also test restarting from aborted switches
* [`43555b34`](https://github.com/NixOS/nixpkgs/commit/43555b34363a372a0ac2051808d7c70f0599bf99) mfoc-hardnested: unstable-2021-08-14 -> unstable-2023-03-27
* [`48abfde8`](https://github.com/NixOS/nixpkgs/commit/48abfde844547c1b62c8a082ccccd9caf2d650bd) lib/fileset: Test function improvement
* [`19b39dcc`](https://github.com/NixOS/nixpkgs/commit/19b39dcc934aba37e39b5f492c2919dd93b74870) lib.fileset: Internal representation v1
* [`9e5aa81a`](https://github.com/NixOS/nixpkgs/commit/9e5aa81a22bf7a9a3fe3f0de0feb1dde3101b721) systemd-lib: add name to X-{Reloads,Restart}-Triggers to easily identify to which service/unit/... they belong
* [`7d4eb3f1`](https://github.com/NixOS/nixpkgs/commit/7d4eb3f1b7c74b3812c1873b6136a18387310bb8) lib.fileset.toSource: Evaluate fileset even for empty directories
* [`7c6b0b10`](https://github.com/NixOS/nixpkgs/commit/7c6b0b107a5f212503b12e0656cac2ac27227e84) lib.fileset: Minor internal type doc fix
* [`355cfada`](https://github.com/NixOS/nixpkgs/commit/355cfada4090b2623bf19a355133d5b56b031fe0) nixos/vikunja: install 'vikunja' CLI tool
* [`82e36fd2`](https://github.com/NixOS/nixpkgs/commit/82e36fd2bd17486a849909e1d6e86f1be33a9f0e) ryujinx: 1.1.999 -> 1.1.1012
* [`3da98e6c`](https://github.com/NixOS/nixpkgs/commit/3da98e6c45caadcce0f451b081a1862b2d49c50a) pferd: 3.4.3 -> 3.5.0
* [`32371a32`](https://github.com/NixOS/nixpkgs/commit/32371a323f24fe27c0d3bee21daa1fcdabf1c291) timoni: add update script
* [`dd5771c0`](https://github.com/NixOS/nixpkgs/commit/dd5771c0f491f353a8de4ee3e6efad0af4054406) minecraft-server-hibernation: 2.4.10 -> 2.5.0
* [`b6c58883`](https://github.com/NixOS/nixpkgs/commit/b6c588833fb71752b183b066e7daf2e03787d19c) buildkite-agent: 3.50.3 -> 3.55.0
* [`b4a0a97c`](https://github.com/NixOS/nixpkgs/commit/b4a0a97c5c358fc5ccb3014417e033bc2fc84e57) ArchiSteamFarm: 5.4.8.3 -> 5.4.9.3
* [`026179d7`](https://github.com/NixOS/nixpkgs/commit/026179d746616902c891795d12c205e9223dceb5) vtm: 0.9.9t -> 0.9.9u
* [`6a36d420`](https://github.com/NixOS/nixpkgs/commit/6a36d420f26d60539bd7131bf34c3afadf7a79e4) betterbird: 102.15.0-bb40 -> 102.15.1-bb41
* [`b1731362`](https://github.com/NixOS/nixpkgs/commit/b1731362ae8805fafa18f5a314a201ec1f75c55f) obs-studio: add materus to obs maintainers
* [`30a7be48`](https://github.com/NixOS/nixpkgs/commit/30a7be48b3b24dcb9519c1016e0e421cd7aed182) grype: 0.66.0 -> 0.68.0
* [`66cf9f15`](https://github.com/NixOS/nixpkgs/commit/66cf9f15c1282f66774b885b85cfc9a2b54d5ddb) cypress: 12.17.4 -> 13.2.0
* [`31a534ef`](https://github.com/NixOS/nixpkgs/commit/31a534effb42607e98802bbec82e91480fea5af4) orchard: init at 0.12.0
* [`9a7693b7`](https://github.com/NixOS/nixpkgs/commit/9a7693b7044146879c9cd7c9aab6154d73a8e73d) buildMavenPackage: refactor to run test in drv only
* [`4ec7cd46`](https://github.com/NixOS/nixpkgs/commit/4ec7cd46465fca672759be818fdcf03323f250f4) buildMavenPackage: hide offline build behind feature flag
* [`6e05e49f`](https://github.com/NixOS/nixpkgs/commit/6e05e49f473d43f7db2a147517a90a6b3ff1e860) buildMavenPackage: rename manualMvnArtifactIds to manualMvnArtifacts
* [`cb4a2e1b`](https://github.com/NixOS/nixpkgs/commit/cb4a2e1bb84c3dc6ce5aefdb5d4746c635371da0) autocorrect: 2.8.4 -> 2.8.5
* [`72a455b1`](https://github.com/NixOS/nixpkgs/commit/72a455b13db608ba0a9dcf8b93fdbb35ea4a9311) jetbrains-rust-rover: init at 232.9921.46(EAP)
* [`dbeadd98`](https://github.com/NixOS/nixpkgs/commit/dbeadd986e9ab56640dd1d7453b0b09fdc8e3586) lunar-client: 3.0.7 -> 3.0.10
* [`de0bef17`](https://github.com/NixOS/nixpkgs/commit/de0bef17b395e5f9b5fd7da8741a5bd445bb74f0) bandwhich: 0.20.0 -> unstable-2023-09-11
* [`25393c59`](https://github.com/NixOS/nixpkgs/commit/25393c592672744c5af421b8af3c19306d74498d) argocd-autopilot: 0.4.15 -> 0.4.16
* [`86e452d2`](https://github.com/NixOS/nixpkgs/commit/86e452d213fbb7568b5e5bdf2dd57f1688c1b709) apache-airflow: 2.7.0 -> 2.7.1
* [`109596f6`](https://github.com/NixOS/nixpkgs/commit/109596f660dc630c11ca655d8d8a36f221f622d4) python311Packages.azure-mgmt-recoveryservices: 2.4.0 -> 2.5.0
* [`bd3888a5`](https://github.com/NixOS/nixpkgs/commit/bd3888a5de4eb2d13a800219410c026f4c5e23ca) polypane: 14.1.0 -> 15.0.0
* [`b9705058`](https://github.com/NixOS/nixpkgs/commit/b9705058c617bd553eb3bbf70687abe3599f812d) juicefs: 1.0.4 -> 1.1.0
* [`929c3eff`](https://github.com/NixOS/nixpkgs/commit/929c3effe74336b0fbe6c78d6a3405b9883f35c6) jetbrains-rust-rover: add to plugins/tests and to friendly_to_plugin list
* [`362d112e`](https://github.com/NixOS/nixpkgs/commit/362d112ec2f606485b760ab6e3e6340210ef290b) flmsg: 4.0.22 -> 4.0.23
* [`2dd73a78`](https://github.com/NixOS/nixpkgs/commit/2dd73a789c910d34ecddf091d6444242f3346d74) jetbrains-rust-rover: fix url template
* [`573b47ec`](https://github.com/NixOS/nixpkgs/commit/573b47ec6dc7879abf5a28a0db417630228d7a70) jetbrains: 2023.2.1 -> 2023.2.2
* [`99f77489`](https://github.com/NixOS/nixpkgs/commit/99f7748964cc2e6464fd5d3f1d01d319fb2fc437) jetbrains.plugins: update
* [`52e82cf5`](https://github.com/NixOS/nixpkgs/commit/52e82cf5948be9caf37d8fcc1eb7fb64f4fd087a) yed: 3.23.1 -> 3.23.2
* [`b9eceb59`](https://github.com/NixOS/nixpkgs/commit/b9eceb590ff6be653b8d34f642f1b13be89b4ea0) jetbrains-rust-rover: fix plugin tests, remove autopatching of plugins shipped with ide
* [`f52c368f`](https://github.com/NixOS/nixpkgs/commit/f52c368f1700c810e16c5d918e09a87559c15509) coreboot-toolchain: Unpin gnat
* [`f6ec82bb`](https://github.com/NixOS/nixpkgs/commit/f6ec82bbf37eedbc20abde3323aaabcc1b2dc328) jetbrains-rust-rover: patch intellij-rust-native-helper plugin
* [`7f699475`](https://github.com/NixOS/nixpkgs/commit/7f6994759fd3bd97ef3ff4e8df9a9868515be3c8) termius: 7.56.1 -> 8.1.2
* [`2288921c`](https://github.com/NixOS/nixpkgs/commit/2288921c10881f74b817c6e3db8016bcded8ce65) dnscontrol: 4.3.0 -> 4.4.0
* [`23643498`](https://github.com/NixOS/nixpkgs/commit/236434985fdbc508c780b2cf2758ec17352fc67e) protonup-qt: 2.8.0 -> 2.8.2
* [`1f10ced2`](https://github.com/NixOS/nixpkgs/commit/1f10ced26aa1a8c9ed2ae8f2242a524ed8dd8655) dnf5: 5.1.1 -> 5.1.3
* [`6b61971c`](https://github.com/NixOS/nixpkgs/commit/6b61971c7a8cb46c53e673faf5e5512cef034000) hwloc: 2.9.2 -> 2.9.3
* [`bccdedaa`](https://github.com/NixOS/nixpkgs/commit/bccdedaac12a80285270fb4bce81776553a24277) azure-functions-core-tools: 4.0.5095 -> 4.0.5348
* [`a791332e`](https://github.com/NixOS/nixpkgs/commit/a791332eb58719c156f90ab2b4eabc6f34b4a86b) azure-functions-core-tools: add myself as maintainer
* [`52547eb5`](https://github.com/NixOS/nixpkgs/commit/52547eb55c58f59e6290a961afd093cc7d9fce51) google-cloud-sdk: 433.0.1 -> 446.0.1
* [`1dc4b125`](https://github.com/NixOS/nixpkgs/commit/1dc4b125e97149bbf548ed4faf4f50cf0d6e41b1) openipmi: 2.0.33 -> 2.0.34
* [`59c5ffcf`](https://github.com/NixOS/nixpkgs/commit/59c5ffcf9f6f938dc2581194b99a367b3e1cc736) vectorscan: 5.4.9 -> 5.4.10.1
* [`3d479ec0`](https://github.com/NixOS/nixpkgs/commit/3d479ec07620ab6deabd0bf536008fa93d01452d) python3Packages.automx2: init at 2022.01
* [`20ba9f9b`](https://github.com/NixOS/nixpkgs/commit/20ba9f9b4e3269223df78c6a9062819eda791e34) mongodb-tools: 100.7.3 -> 100.7.5
* [`1ecd0757`](https://github.com/NixOS/nixpkgs/commit/1ecd07570098ad5b18efcdf4fb3a5d7667d279ed) python3Packages.automx2: 2022.1 -> unstable-2023-08-23
* [`e567f85a`](https://github.com/NixOS/nixpkgs/commit/e567f85a645f74d7b753a942bbb7af7f7d9f04fa) blast: 2.14.0 -> 2.14.1
* [`0186b258`](https://github.com/NixOS/nixpkgs/commit/0186b2584130e3a2d00257a009f98320422609ab) kubebuilder: 3.11.1 -> 3.12.0
* [`3e99ce8f`](https://github.com/NixOS/nixpkgs/commit/3e99ce8f10a912f06fe071c975478de5b9ec012a) yoshimi: 2.3.0.2 -> 2.3.0.3
* [`cac0b620`](https://github.com/NixOS/nixpkgs/commit/cac0b62031f731c553cb12421f015c5f332823a1) vivaldi: 6.2.3105.45 -> 6.2.3105.48
* [`2d149d2a`](https://github.com/NixOS/nixpkgs/commit/2d149d2ae1e21734353065b4b81d66d3f2ccc66e) fastlane: 2.214.0 -> 2.215.0
* [`ae5dcd6c`](https://github.com/NixOS/nixpkgs/commit/ae5dcd6ce160a9dabf2b5823b3b9430246eaa094) unit: 1.30.0 -> 1.31.0
* [`cbe40c63`](https://github.com/NixOS/nixpkgs/commit/cbe40c63c0b8d88a4531b8200504bbb76e0b17c3) normcap: init at 0.4.4
* [`ea73e73f`](https://github.com/NixOS/nixpkgs/commit/ea73e73fd16435472c6bc1ab28afe6ec995de437) albert: 0.22.0 -> 0.22.4
* [`7a116738`](https://github.com/NixOS/nixpkgs/commit/7a116738d3ce46e36af58ece4ec6a877def9ebba) python311Packages.azure-storage-file-share: 12.13.0 -> 12.14.1
* [`a8da24aa`](https://github.com/NixOS/nixpkgs/commit/a8da24aa7b50457821156bfd80db7f16fe03e641) drawio: 21.6.8 -> 21.7.5
* [`f62db777`](https://github.com/NixOS/nixpkgs/commit/f62db777b62290749d9ab297a4315034cedf98c9) EmptyEpsilon 2021.06.23 -> 2023.06.17
* [`19513236`](https://github.com/NixOS/nixpkgs/commit/195132361d725e8677b4cf3150bb62fd88fcfbd1) kvmtool: add mfrw as maintainer
* [`ab63498f`](https://github.com/NixOS/nixpkgs/commit/ab63498ff6e39a8ed926cadece8e2491aa9ba1c7) kvmtool: unstable-2023-04-06 -> unstable-2023-07-12
* [`c06e06f3`](https://github.com/NixOS/nixpkgs/commit/c06e06f34344ba7d8c2029ee036c94f2930fdf76) kvmtool: fix mainProgram as lkvm instead of nvramtool
* [`b78376b5`](https://github.com/NixOS/nixpkgs/commit/b78376b5d41b10822ab0f9acc0e2d2adf1a0141c) phpPackages.phan: 5.4.1 -> 5.4.2
* [`818a7517`](https://github.com/NixOS/nixpkgs/commit/818a7517a1008f32b1085a0815857dbd5ae91fed) biome: 1.2.1 -> 1.2.2
* [`6e57ed42`](https://github.com/NixOS/nixpkgs/commit/6e57ed42666e82331f85f838a0df1f853c840b39) python3.pkgs.astropy-extension-helpers: 1.0.0 -> 1.1.0
* [`23787a93`](https://github.com/NixOS/nixpkgs/commit/23787a933765d124f609456504eb114cc06af94c) python3.pkgs.pyerfa: 2.0.0.1 -> 2.0.0.3
* [`174db7dc`](https://github.com/NixOS/nixpkgs/commit/174db7dcf95f6265b1cb7d653e0cd259aa8e43fc) python3.pkgs.pyerfa: Enable and fix tests & more
* [`18490c2c`](https://github.com/NixOS/nixpkgs/commit/18490c2caf2c6f60582cd61676a30f073ae7ab28) python3.pkgs.astropy: 5.2.1 -> 5.3.3
* [`221fbf12`](https://github.com/NixOS/nixpkgs/commit/221fbf1231cc61b6e400bdbce9b624357529e6e1) python3.pkgs.astropy: enable and fix tests.
* [`55b52d27`](https://github.com/NixOS/nixpkgs/commit/55b52d274e4a8d8f48e6174ec9a6721762fd119a) python3.pkgs.astroquery: mark as broken
* [`0f9f87d1`](https://github.com/NixOS/nixpkgs/commit/0f9f87d1bfa395cb5ce1f374e3d7a83c7ff17f42) lunarml: unstable-2023-08-25 → unstable-2023-09-16
* [`3d6db82c`](https://github.com/NixOS/nixpkgs/commit/3d6db82cbd1aa4ef91186c3bdb0dd167fc54f9da) nuspell: 5.1.2 -> 5.1.3
* [`646b6a14`](https://github.com/NixOS/nixpkgs/commit/646b6a141576b99bef98942529b4a71d3e3b0ee7) python3Packages.langid: init at 1.1.6
* [`c8b64f21`](https://github.com/NixOS/nixpkgs/commit/c8b64f21ba7611ba123507cdd73735bd024df793) mautrix-whatsapp: 0.10.0 -> 0.10.1
* [`a8a93eb3`](https://github.com/NixOS/nixpkgs/commit/a8a93eb30f30102d1f71e8b5e8b8a0e6057cf55b) gdal: 3.7.1 -> 3.7.2
* [`9abe8e8e`](https://github.com/NixOS/nixpkgs/commit/9abe8e8ea26d60a3488e3699b402dd0e02eb96d1) celeste: 0.5.2 -> 0.5.8
* [`b4521212`](https://github.com/NixOS/nixpkgs/commit/b4521212e4a40e59e2df709bb6e1b5c680ca88ee) wordpress: 6.2.2 -> 6.3.1
* [`4738cb0c`](https://github.com/NixOS/nixpkgs/commit/4738cb0cb9451b7187726b2f83146ce47b04f4c2) celeste: install desktop file and icons
* [`66100e22`](https://github.com/NixOS/nixpkgs/commit/66100e22f6df5cf3d602c0a8a6f8529286932424) nixos/virtualisation: allow configuring openssh root login on GCE
* [`f460c54f`](https://github.com/NixOS/nixpkgs/commit/f460c54fe1aed9df2d1319cdffe46bf8f0da97ac) metadata-cleaner: 2.5.0 -> 2.5.4
* [`e85d5986`](https://github.com/NixOS/nixpkgs/commit/e85d598603e39f63c8211cf0b745e1acabb7faa0) python310Packages.m3u8: 3.5.0 -> 3.6.0
* [`5fd7abad`](https://github.com/NixOS/nixpkgs/commit/5fd7abad640815d43217c6e409879e2fa3208856) dioxus-cli: 0.4.0 -> 0.4.1
* [`42039260`](https://github.com/NixOS/nixpkgs/commit/4203926036517984734bae99d4c34399e1fa731b) kubectl-gadget: 0.19.0 -> 0.20.0
* [`8ea1377e`](https://github.com/NixOS/nixpkgs/commit/8ea1377e35f107b434a8c28b126a051191fa43c8) abcmidi: 2023.06.25 -> 2023.09.13
* [`0dc0b0fd`](https://github.com/NixOS/nixpkgs/commit/0dc0b0fd16623f7ac4951d41fa59927f0f4ac9a8) python310Packages.pytube: 12.1.2 -> 15.0.0
* [`d148c48f`](https://github.com/NixOS/nixpkgs/commit/d148c48f03c26f64e2dbd3ea85c08bd4bf53341b) python3Packages.pdoc: 14.0.0 -> 14.1.0
* [`e6458473`](https://github.com/NixOS/nixpkgs/commit/e64584735c479766489d6408ec696e9eaae6745e) python310Packages.svg2tikz: 1.2.0 -> 2.1.0
* [`ab0f9a2d`](https://github.com/NixOS/nixpkgs/commit/ab0f9a2d7154e1db21ba437ec5ca66616ec2b18a) minio: 2023-08-16T20-17-30Z -> 2023-09-07T02-05-02Z
* [`6431e433`](https://github.com/NixOS/nixpkgs/commit/6431e433ed6d1bb73c14fd4ff90287e86b31eba2) mate.mate-desktop: 1.26.1 -> 1.26.2
* [`e3d9e645`](https://github.com/NixOS/nixpkgs/commit/e3d9e645738a367bf5a7ed5d73b68155c553fced) sarasa-gothic: 0.41.9 -> 0.41.10
* [`66a2e4a3`](https://github.com/NixOS/nixpkgs/commit/66a2e4a395631ae3e390470e19876c0742b6d7e3) yyjson: 0.7.0 -> 0.8.0
* [`21a57293`](https://github.com/NixOS/nixpkgs/commit/21a5729360313c0df23ee4af12ad3f78f70b161a) unison-ucm: M5e -> M5f
* [`093b9608`](https://github.com/NixOS/nixpkgs/commit/093b9608ce050113ec071e0494a87350c25de85f) fmt: 10.1.0 -> 10.1.1
* [`06f188a5`](https://github.com/NixOS/nixpkgs/commit/06f188a5fa33b705e21fee0cf4a3c3dec067c911) python310Packages.gprof2dot: 2021.02.21 -> 2022.07.29
* [`771000e5`](https://github.com/NixOS/nixpkgs/commit/771000e5bd9835ed5884b0985a9bb32bcd144c89) bitwig-studio5: 5.0.4 -> 5.0.7
* [`3a44cbc9`](https://github.com/NixOS/nixpkgs/commit/3a44cbc914bc16aa18694a426349aa22a89eef89) cargo-tarpaulin: 0.26.1 -> 0.27.0
* [`234d022c`](https://github.com/NixOS/nixpkgs/commit/234d022cdb259777740eaf1925c2bfebc58aebcf) cargo-binstall: 1.3.0 -> 1.3.1
* [`0063c5a5`](https://github.com/NixOS/nixpkgs/commit/0063c5a5b649f3f060ff9d8fc9ce10df8a93af77) todoman: 4.3.1 -> 4.3.2
* [`75145d37`](https://github.com/NixOS/nixpkgs/commit/75145d37dc87e505bd065b62a6b29177e5077fa5) fx: 24.1.0 -> 30.0.0
* [`964bda83`](https://github.com/NixOS/nixpkgs/commit/964bda8339cd22533cc0655602017bbd5ea55e3b) monkeysAudio: 10.20 -> 10.22
* [`fa25e841`](https://github.com/NixOS/nixpkgs/commit/fa25e84147cb79a16c4e0db83f11af06ec2c42c3) trafficserver: 9.2.1 -> 9.2.2
* [`c9445958`](https://github.com/NixOS/nixpkgs/commit/c94459586a92677cbe1e0f9d038abce2afacbf9e) python3Packages.pmdarima: init at 2.0.3
* [`96bdf87d`](https://github.com/NixOS/nixpkgs/commit/96bdf87dfe76d40197978ec57a00d076ab5aa672) grass: code cleanup
* [`f073c3b5`](https://github.com/NixOS/nixpkgs/commit/f073c3b584aa5e7df4a2963cd3ed12784e6b1b6b) python311Packages.simple-websocket: init at 0.9.0
* [`cc4362b0`](https://github.com/NixOS/nixpkgs/commit/cc4362b0265e1d496b8fe6f81cc5251e34d3cc60) k8sgpt: 0.3.14 -> 0.3.15
* [`a08d9b3e`](https://github.com/NixOS/nixpkgs/commit/a08d9b3e4b945ad2f0365c942de1352fe6a73c4f) fluidd: 1.25.2 -> 1.25.3
* [`b6ae95f7`](https://github.com/NixOS/nixpkgs/commit/b6ae95f74b9e4e7e9a4c186971d299ea37ded41c) vencord: 1.4.6 -> 1.4.7
* [`c4bf73c1`](https://github.com/NixOS/nixpkgs/commit/c4bf73c1088741526ecde15fd8a9d1eb8973a15e) buildkit-nix: 0.1.0 -> 0.1.1
* [`89b4001f`](https://github.com/NixOS/nixpkgs/commit/89b4001f956391d8b22eeeff022397b7b6902791) hyprland-autoname-workspaces: 1.1.7 -> 1.1.10
* [`cdaeac03`](https://github.com/NixOS/nixpkgs/commit/cdaeac035476696c50b7db9be4bba06e615096f6) gcsfuse: 1.0.1 -> 1.1.0
* [`762ad8ef`](https://github.com/NixOS/nixpkgs/commit/762ad8efb4f7a597af5e7e221febe31908bc9dee) linuxPackages.nvidia_x11_legacy340: fix up to kernel 6.6
* [`67bf9e4e`](https://github.com/NixOS/nixpkgs/commit/67bf9e4e998c1e4818161ee7d868b7222502d9e5) linuxPackages.nvidia_x11_legacy470: kernel 6.6 support
* [`3f293ea9`](https://github.com/NixOS/nixpkgs/commit/3f293ea9ecd5c50e5bd393fd1c560275ea0e6975) ugrep: 4.0.5 -> 4.1.0
* [`c3db9514`](https://github.com/NixOS/nixpkgs/commit/c3db9514d366339cb64923f2c152543aabfb10b9) pylyzer: 0.0.43 -> 0.0.45
* [`f1d92463`](https://github.com/NixOS/nixpkgs/commit/f1d92463adf272abc01f1b6b4f687536dadc82de) obs-studio-plugins.obs-pipewire-audio-capture: 1.1.0 -> 1.1.1
* [`edeeb033`](https://github.com/NixOS/nixpkgs/commit/edeeb033c76e4bcd2cfb0a3aca9c7de304e6fd9d) neocmakelsp: 0.6.3 -> 0.6.5
* [`0d452b70`](https://github.com/NixOS/nixpkgs/commit/0d452b70ce738fa76ba6af8187638e6fdd5ae1b1) granted: 0.14.4 -> 0.16.0
* [`7340ed33`](https://github.com/NixOS/nixpkgs/commit/7340ed33317441340ff844a9c861217d50300e07) ddns-go: 5.6.1 -> 5.6.2
* [`1866206b`](https://github.com/NixOS/nixpkgs/commit/1866206b5f9bc18ecdf22ea1604f63f2510c626d) nixpacks: 1.14.0 -> 1.15.0
* [`527e3dc0`](https://github.com/NixOS/nixpkgs/commit/527e3dc045f4e5e2da8ef092cb39e389201e888a) meli: re-introduce at 0.8.1
* [`4b42ef1f`](https://github.com/NixOS/nixpkgs/commit/4b42ef1fb8a7a2bbe9f8e59747c769687a5997cc) arrpc: init at 3.2.0
* [`7b2debed`](https://github.com/NixOS/nixpkgs/commit/7b2debed85ab15fdfce66779e32b02228c7cb60e) nextdns: 1.39.4 -> 1.40.1
* [`f0a727d8`](https://github.com/NixOS/nixpkgs/commit/f0a727d81cbae6e3ba51961aebd3bd16e26a2404) grpc-gateway: 2.17.1 -> 2.18.0
* [`06841209`](https://github.com/NixOS/nixpkgs/commit/068412090ae1e7fe3bc2a311c4b75beee7275bed) seasocks: 1.4.5 -> 1.4.6
* [`d494f4a4`](https://github.com/NixOS/nixpkgs/commit/d494f4a4ba501c2fd2ff5be8cbf54d43d79f0a8a) libquotient: 0.8.1.1 -> 0.8.1.2
* [`b50f5276`](https://github.com/NixOS/nixpkgs/commit/b50f52760388050d6180bd6581e0b745eaa4cae8) reason: 3.9.0 -> 3.10.0
* [`743a0e74`](https://github.com/NixOS/nixpkgs/commit/743a0e7463319b91ce5f6439ff23aa1318124ac4) cardinal: 23.07 -> 23.09
* [`24849a18`](https://github.com/NixOS/nixpkgs/commit/24849a18bc15bf805086454c2bc8a1daec539b93) commit-mono: 1.136 -> 1.138
* [`373afc63`](https://github.com/NixOS/nixpkgs/commit/373afc63d5972d1ba28f2704062c310d5aeb4933) trivy: fix version ldflag
* [`59a058bd`](https://github.com/NixOS/nixpkgs/commit/59a058bd02581df437d7e126f6be2e8cd4e4ef0e) python310Packages.simplefix: 1.0.16 -> 1.0.17
* [`6cbb28ee`](https://github.com/NixOS/nixpkgs/commit/6cbb28ee08220cb58861ccf663bcef20805aacb5) gitter: remove (unmaintained upstream, probably useless now)
* [`43bfe968`](https://github.com/NixOS/nixpkgs/commit/43bfe968344428e1f90971620396dace2d3bbb24) n8n: 1.5.1 -> 1.6.1
* [`6c37e275`](https://github.com/NixOS/nixpkgs/commit/6c37e275805c28fc3cd9a321cddb0063a5ad2402) bfc: 1.11.0 -> 1.12.0
* [`eb019b5a`](https://github.com/NixOS/nixpkgs/commit/eb019b5a6b7a5b9f96d91a9cd5cd46b2389a1d5a) maintainers: Fix github account names
* [`b5e284ca`](https://github.com/NixOS/nixpkgs/commit/b5e284cae3690644d5881e623228989bdbc154c0) discord-canary: 0.0.166 -> 0.0.167
* [`6b811487`](https://github.com/NixOS/nixpkgs/commit/6b811487a69e254d56d7c0277fae182cc248a9ff) kopia: 0.13.0 -> 0.14.1
* [`7f5c8e20`](https://github.com/NixOS/nixpkgs/commit/7f5c8e202304525044efb7cd570c3798f0a871f7) gitui: 0.24.2 -> 0.24.3
* [`80a5c4cf`](https://github.com/NixOS/nixpkgs/commit/80a5c4cf7ce50da594e92c0028cba73ef94acd79) python310Packages.types-pytz: 2023.3.0.1 -> 2023.3.1.0
* [`c161ba1a`](https://github.com/NixOS/nixpkgs/commit/c161ba1af18ba8d03b497059fe15e5a4c5ffb722) pam_rssh: fix 1.1.0 update
* [`f7b6e482`](https://github.com/NixOS/nixpkgs/commit/f7b6e482bf1d3513be9b377da3a539d8ccf3f245) python310Packages.murmurhash: 1.0.9 -> 1.0.10
* [`75801e0f`](https://github.com/NixOS/nixpkgs/commit/75801e0ffa9ce4a06a46b4aea78ba6db1c74234c) feishu: 6.1.11 -> 6.9.16
* [`e405a284`](https://github.com/NixOS/nixpkgs/commit/e405a284a8d31ec6ef7c8309e13e1b4c072f9f44) lf: 30 -> 31
* [`183845f8`](https://github.com/NixOS/nixpkgs/commit/183845f851288c815baa85b2d0b528a3d526dc52) transmission-remote-gtk: fix TLS support
* [`98a4b8f0`](https://github.com/NixOS/nixpkgs/commit/98a4b8f08d97d35451ca95f0941ebcfb707bd834) libcoap: 4.3.1 -> 4.3.3
* [`5efaf495`](https://github.com/NixOS/nixpkgs/commit/5efaf495d0e33cc39d10ef6842436dd278420a60) urlencode: init at 1.0.1
* [`047fd08c`](https://github.com/NixOS/nixpkgs/commit/047fd08cecafa89072692498c8f1ee7c7dbf61a6) figma-linux: use `finalAttrs` pattern
* [`4c6eaaaa`](https://github.com/NixOS/nixpkgs/commit/4c6eaaaa92a3bf6bf241bb54dda8bbb37b0dd77c) figma-linux: added `kashw2` maintainer
* [`c15f5f32`](https://github.com/NixOS/nixpkgs/commit/c15f5f322b401f9d14d0d2701b9abb106aff7d67) liquibase: 4.23.1 -> 4.23.2
* [`f15212aa`](https://github.com/NixOS/nixpkgs/commit/f15212aad86ad80fb355c8071c1e1e9a9ea879c7) nixos/synapse: cleanup, split out listener type and service config
* [`b7c41da8`](https://github.com/NixOS/nixpkgs/commit/b7c41da8d68c7e82c9957cc530e1141f0ca5aba6) nixos/synapse: update listener settings
* [`b3291801`](https://github.com/NixOS/nixpkgs/commit/b32918012814fcca1c5cd6c815b5565d71e96610) nixos/synapse: add option to configure redis automatically
* [`72a26e2b`](https://github.com/NixOS/nixpkgs/commit/72a26e2b5465b967c462e08b8c64151356683c17) nixos/synapse: add options to configure workers
* [`3a6a07ec`](https://github.com/NixOS/nixpkgs/commit/3a6a07ecf1b38dd887f7af4bec3da6fe3c8eb227) nixos/synapse: automatically configure replication listener
* [`b20cbb12`](https://github.com/NixOS/nixpkgs/commit/b20cbb12cdcb1fb81a22f58f028a2d876eafa832) nixos/synapse: add test for running synapse with workers
* [`2edea761`](https://github.com/NixOS/nixpkgs/commit/2edea7611bff66697e1aa5f5b8921a5be9d3e6a6) nixos/synapse: document options better
* [`857b4932`](https://github.com/NixOS/nixpkgs/commit/857b4932eca927df0f2cb1ac8bbbae72a0960c0b) nixos/synapse: remove obsolete log context
* [`53ab84cf`](https://github.com/NixOS/nixpkgs/commit/53ab84cf49a6146de35f31f81960185ff6075d55) nixos/synapse: automatically configure logging for synapse and workers
* [`ca1ffe58`](https://github.com/NixOS/nixpkgs/commit/ca1ffe586948c3e5446387fe15ee241d0cd153ec) nixos/synapse: move services.matrix-synapse.workers.config to services.matrix-synapse.workers
* [`c693c2fd`](https://github.com/NixOS/nixpkgs/commit/c693c2fd963b7a4b94958c471baed36bfe563879) nixos/synapse: simplify replication listener assertion
* [`dea34ad0`](https://github.com/NixOS/nixpkgs/commit/dea34ad0fa3ecd3bed440b9b0a8e4b57a540583a) nixos/synapse: default tls to off for workers and document worker replication port
* [`99e7130d`](https://github.com/NixOS/nixpkgs/commit/99e7130d69320e77bed8a71710f656b6a0a7f84e) matrix-synapse: add worker test to passthru.tests
* [`6b95c618`](https://github.com/NixOS/nixpkgs/commit/6b95c618e231487a3cd105b59d3f7df199abcd4b) nixos/rl-2311: fix option references for synapse workers
* [`aed8a5c6`](https://github.com/NixOS/nixpkgs/commit/aed8a5c6cd849a8fa819ccdbd6877915227d500a) nixos/synapse: add documentation for required reverse proxy setup
* [`9ea632ea`](https://github.com/NixOS/nixpkgs/commit/9ea632eadd875b9990d17bbc0b4f6da1c0ab7ce5) python310Packages.skorch: 0.14.0 -> 0.15.0
* [`84397fa9`](https://github.com/NixOS/nixpkgs/commit/84397fa9afcbacab6579654c7f6ed36b0cec9ed2) argo-rollouts: 1.5.1 -> 1.6.0
* [`163ae47d`](https://github.com/NixOS/nixpkgs/commit/163ae47dcce731852134150c203e24b7b5a3db8c) python3Packages.dtw-python: init at 1.3.0
* [`443321ae`](https://github.com/NixOS/nixpkgs/commit/443321aed24916a572c67c7cb0d678c3aff9ec0d) ocamlPackages.telegraml: prepare for batteries 3.7.1
* [`fefd0ab1`](https://github.com/NixOS/nixpkgs/commit/fefd0ab1c1b0c8225e87085572f95804f58eb3ae) ocamlPackages.batteries: 3.6.0 → 3.7.1
* [`c7d62eec`](https://github.com/NixOS/nixpkgs/commit/c7d62eecb9bfbc3954bbc11c628df83226cb9677) ocamlPackages.batteries: enable tests on AArch64
* [`31fa96e0`](https://github.com/NixOS/nixpkgs/commit/31fa96e09eda434c3ef39f0fcc4e21d370e7d762) python3Packages.spsdk: remove unused binding
* [`e2505099`](https://github.com/NixOS/nixpkgs/commit/e250509945196183b0637a88df70ffdcb80e21dc) python3Packages.spsdk: fix dependency toward importlib-metadata
* [`2f216e2a`](https://github.com/NixOS/nixpkgs/commit/2f216e2afcd7361443866157f74f0ecf6fe45ff2) python3Packages.spsdk: Add meta.mainProgram
* [`09ffed3f`](https://github.com/NixOS/nixpkgs/commit/09ffed3fd459a441396e2cdfa8de1851d27654a7) python3Packages.spsdk: Add passthru.tests.version
* [`4902bf5d`](https://github.com/NixOS/nixpkgs/commit/4902bf5db2f71e6fbc1fef22d6401f56a237f1b4) nomad_1_6: 1.6.1 -> 1.6.2
* [`98369b70`](https://github.com/NixOS/nixpkgs/commit/98369b70bce62f6acf2a1b77da40ae8378aae00c) checkov: 2.4.39 -> 2.4.41
* [`f8d1facf`](https://github.com/NixOS/nixpkgs/commit/f8d1facf21fef929bd4e3d85c7fea028866455ad) python311Packages.adafruit-platformdetect: 3.51.0 -> 3.52.0
* [`33839fb5`](https://github.com/NixOS/nixpkgs/commit/33839fb5f9067f35483911eb8fea8426950ee1e2) python311Packages.adlfs: 2023.8.0 -> 2023.9.0
* [`7ae80f1a`](https://github.com/NixOS/nixpkgs/commit/7ae80f1a0044ae7678f3d80ebefbf2ed5915ea32) python311Packages.aliyun-python-sdk-iot: 8.55.0 -> 8.56.0
* [`b9c58de1`](https://github.com/NixOS/nixpkgs/commit/b9c58de18344881bc701f74b32e015183469104e) python311Packages.bleak-retry-connector: 3.1.3 -> 3.2.1
* [`1bfc3460`](https://github.com/NixOS/nixpkgs/commit/1bfc3460e87a66180d536f1813c518cc2b1d9af8) python311Packages.elkm1-lib: 2.2.5 -> 2.2.6
* [`733a4898`](https://github.com/NixOS/nixpkgs/commit/733a4898207a311c23013a2615b19e127495f40a) dockerfile-language-server-nodejs: 0.10.2 -> 0.11.0
* [`22d3caa6`](https://github.com/NixOS/nixpkgs/commit/22d3caa6b261a2fe580392cb2fd9da1039865f13) python311Packages.pyunifiprotect: 4.20.0 -> 4.21.0
* [`43185ef7`](https://github.com/NixOS/nixpkgs/commit/43185ef7d6354ba9aafef047647ff8400b9d1eb3) python311Packages.simplefix: add changelog to meta
* [`1545da4c`](https://github.com/NixOS/nixpkgs/commit/1545da4c45b01ac648ddc50975b31bb57d0b5167) python311Packages.simplefix: switch to unittestCheckHook
* [`32558a61`](https://github.com/NixOS/nixpkgs/commit/32558a617a6a7af00fe7db3a56ca9293daee47cb) python3Packages.mrsqm: init at 0.0.4
* [`7c31eff8`](https://github.com/NixOS/nixpkgs/commit/7c31eff8ecd46ea3fd3188f9e80d6d8dbbb0a093) python3Packages.osc: 1.3.0 -> 1.3.1
* [`187afc5d`](https://github.com/NixOS/nixpkgs/commit/187afc5d1bd84226dd9b89da3e8a2e6ab4eb4274) rustc-wasm32: init at 1.70.0
* [`fe806f61`](https://github.com/NixOS/nixpkgs/commit/fe806f61369a4e5ff0386a05e609b4762d3043f5) pagefind: init at 1.0.3
* [`2cdff5b2`](https://github.com/NixOS/nixpkgs/commit/2cdff5b22459fd001d94ead7ccf4ee702a8c60b2) python311Packages.fschat: init at 0.2.28
* [`9b49ad3b`](https://github.com/NixOS/nixpkgs/commit/9b49ad3bb898d297922be9f20dd3c35db84ddcea) python3Packages.manuf: init at 1.1.5
* [`24f6a70a`](https://github.com/NixOS/nixpkgs/commit/24f6a70abfa36d9a6c604bd324e4509e92777bc4) nixos/synapse: make sure workers require main process
* [`bf303b81`](https://github.com/NixOS/nixpkgs/commit/bf303b813ea9ea914608f70c8d6d4718712f559b) twingate: 2023.227.93197 -> 2023.250.97645
* [`6635d9b9`](https://github.com/NixOS/nixpkgs/commit/6635d9b938a671b792770c2fe6f71d958011dd13) vimiv-qt: 0.8.0 -> 0.9.0
* [`fcdcccae`](https://github.com/NixOS/nixpkgs/commit/fcdcccaed6748dc53a748a170125158262510d2b) nixos/caddy: ensure vhosts come after user-specified `cfg.extraConfig`
* [`92f31b5b`](https://github.com/NixOS/nixpkgs/commit/92f31b5b7c33632c91f0b79204c8632388c47ece) bun: install completions
* [`7f95df95`](https://github.com/NixOS/nixpkgs/commit/7f95df95119ad2d7619a7326cbdbc748cb14c143) go-mockery: 2.33.2 -> 2.33.3
* [`f7f62b2c`](https://github.com/NixOS/nixpkgs/commit/f7f62b2c4db9c209e28bc3834dd6a52e294fbf85) aucatctl: use `finalAttrs` pattern
* [`6bd6bd64`](https://github.com/NixOS/nixpkgs/commit/6bd6bd649ab88e5f09462af17869371d16ef5d24) timoni: 0.12.1 -> 0.13.1
* [`bac2b589`](https://github.com/NixOS/nixpkgs/commit/bac2b589d040087f57e86ae4244d443767ce6b5b) talosctl: 1.5.1 -> 1.5.2
* [`463ac30c`](https://github.com/NixOS/nixpkgs/commit/463ac30c1f3a0b991e0e73e782b976da4d521079) static-web-server: 2.21.1 -> 2.22.0
* [`58eb45b0`](https://github.com/NixOS/nixpkgs/commit/58eb45b0fe0ec308f7bdfaf5534ce1213ee22a82) warp: add Darwin support
* [`645aba8d`](https://github.com/NixOS/nixpkgs/commit/645aba8ded2a05eb437a6c48059f1b75c302961d) python311Packages.smbprotocol: 1.10.1 -> 1.11.0
* [`ea808045`](https://github.com/NixOS/nixpkgs/commit/ea8080450e9b8b3f863e9325cd2cd1526693df10) python311Packages.oss2: 2.17.0 -> 2.18.1
* [`742f2ff3`](https://github.com/NixOS/nixpkgs/commit/742f2ff317ff984124958f856684b95a0fed9063) monkeysAudio: add meta.mainProgram
* [`e57121b8`](https://github.com/NixOS/nixpkgs/commit/e57121b8cad3c9a7a387f1bd818fa259bbf1bc21) pot: 2.3.0 -> 2.4.2
* [`1547629c`](https://github.com/NixOS/nixpkgs/commit/1547629c6e7cf63497899f8f3e14b24756be652b) pomerium: 0.22.2 -> 0.23.0
* [`b5685e91`](https://github.com/NixOS/nixpkgs/commit/b5685e915ab3df2684160ae9ee6297743672c3e8) sqlitecpp: 3.3.0 -> 3.3.1
* [`fa06bd92`](https://github.com/NixOS/nixpkgs/commit/fa06bd92acef0a26a2265a7af194e98b45af09b0) python311Packages.intake: update hash
* [`9cba42dd`](https://github.com/NixOS/nixpkgs/commit/9cba42ddb7b5ff94d309116d0f204f54b1814b69) flaca: 2.2.2 -> 2.3.0
* [`94202fcd`](https://github.com/NixOS/nixpkgs/commit/94202fcdadacfd646218a5ccdeb82f79b84b5328) sem: 0.28.2 -> 0.28.3
* [`d368bcfc`](https://github.com/NixOS/nixpkgs/commit/d368bcfc4bf9c62252ddf9469b1b29cac5572234) utm: 4.2.5 -> 4.3.5
* [`6e55577f`](https://github.com/NixOS/nixpkgs/commit/6e55577f33e5dab722409fd88c0e506623f83748) build-support/php/composer-local-repo-plugin: 1.0.0 -> 1.0.2
* [`b0bd1943`](https://github.com/NixOS/nixpkgs/commit/b0bd1943b329a4fd0106fe5d305d296964c84fa6) python3Packages.torch: migrate to CUDA redist from CUDA Toolkit
* [`0850dcb3`](https://github.com/NixOS/nixpkgs/commit/0850dcb31880f01ded53a92a18b0fb6d088bbda6) rectangle: 0.70 -> 0.71
* [`9adfe998`](https://github.com/NixOS/nixpkgs/commit/9adfe9986a63d7125f3c9c2fdb640ac3343356a4) ecs-agent: 1.75.0 -> 1.75.3
* [`2ea050d3`](https://github.com/NixOS/nixpkgs/commit/2ea050d3787d5f000fc1eb374061dd315d083c5a) ponyc: fix build on darwin
* [`9084f59d`](https://github.com/NixOS/nixpkgs/commit/9084f59d3668d616d01a9114a2e1b0b8d17757cd) nixos/installer: mention search.nixos.org
* [`f6b76f03`](https://github.com/NixOS/nixpkgs/commit/f6b76f03c7cad3f43b65c3de8c05fe03efd7ffb6) python3Packages.kotsu: init at 0.3.3
* [`ad04da46`](https://github.com/NixOS/nixpkgs/commit/ad04da4637b5e7a256007dc59a492ff8c667464d) soft-serve: 0.6.0 -> 0.6.1
* [`1f9360da`](https://github.com/NixOS/nixpkgs/commit/1f9360dabb824ba689e692d9093d27d7c2807092) glamoroustoolkit: 0.7.3 -> 0.8.1
* [`794fb021`](https://github.com/NixOS/nixpkgs/commit/794fb0217fe4a2aa098355422e8b6f64f1adc534) libuninameslist: 20221022 -> 20230916
* [`a6fe29c2`](https://github.com/NixOS/nixpkgs/commit/a6fe29c2fbdc05d2d19e243505cda257e853b990) wasmer: disable tests
* [`90036927`](https://github.com/NixOS/nixpkgs/commit/90036927a909c7e9f77560970b2d7d4de4d72698) monkeysAudio: give stdenv.mkDerivation a function
* [`d82098c2`](https://github.com/NixOS/nixpkgs/commit/d82098c215ec37780158974708d0d6f6ac1facc2) cloud-init: 23.2.2 -> 23.3.1
* [`5ee9b315`](https://github.com/NixOS/nixpkgs/commit/5ee9b315dcc6b510fde80c7896807e03023611c7) github-runner: 2.308.0 -> 2.309.0
* [`7efb824d`](https://github.com/NixOS/nixpkgs/commit/7efb824dac868bb23a1529ca83e12c9ca15403af) qt6.qtgrpc: add patch for protobuf 23 support
* [`87ddec76`](https://github.com/NixOS/nixpkgs/commit/87ddec764c228ca9b143b5f85252f4e686f0429f) python3Packages.reorder-python-imports: 3.9.0 -> 3.11.0
* [`7fcb2b07`](https://github.com/NixOS/nixpkgs/commit/7fcb2b07a263966915a4c7317fc7b0db77becd13) python3Packages.flask-migrate: 4.0.4 -> 4.0.5
* [`04b53be1`](https://github.com/NixOS/nixpkgs/commit/04b53be12571675e9ddea719b420dc237c9b10f4) python311Packages.debugpy: 1.6.7.post1 -> 1.8.0
* [`2906a9fe`](https://github.com/NixOS/nixpkgs/commit/2906a9fe40806a32113a2bb1fb4436dc6ce57aa2) granted: remove broken attribute
* [`495afc10`](https://github.com/NixOS/nixpkgs/commit/495afc1071391c1b0573791e39a49338476e3807) freetube: add darwin support
* [`138113ed`](https://github.com/NixOS/nixpkgs/commit/138113ed2dcefce691a00d7c493de87f50806863) sing-box: 1.4.2 -> 1.4.3
* [`fec31bb0`](https://github.com/NixOS/nixpkgs/commit/fec31bb05134fe38fb89e521557eed9830c709dc) cargo-shuttle: 0.25.1 -> 0.26.0
* [`e2c25280`](https://github.com/NixOS/nixpkgs/commit/e2c25280758d6d5b03de9ae69f4431e5a588afa4) BEAM docs: recommend `nix-shell -p` and `shell.nix` instead of `nix-env` ([nixos/nixpkgs⁠#255131](https://togithub.com/nixos/nixpkgs/issues/255131))
* [`00a68ebf`](https://github.com/NixOS/nixpkgs/commit/00a68ebfd3ca6b0f68fe36278ade963289c207d7) snazy: 0.52.0 -> 0.52.1
* [`be057ad0`](https://github.com/NixOS/nixpkgs/commit/be057ad0256d08728fdb9201bcffdc0d7f8ddb05) risor: 0.17.0 -> 1.1.1
* [`2ed9b44d`](https://github.com/NixOS/nixpkgs/commit/2ed9b44d0c5249d1d17f5ff542030a380d7eca07) libsForQt5.qtkeychain: fix build on x86_64-darwin
* [`1b721a90`](https://github.com/NixOS/nixpkgs/commit/1b721a908ca5fdd08be919eb5959db301b8f316b) upscayl: 2.7.5 -> 2.8.1
* [`f4ab4900`](https://github.com/NixOS/nixpkgs/commit/f4ab49005831177f0a87bc0471df76965f6964e9) open-vm-tools: Move from rec to finalAttrs
* [`35d066de`](https://github.com/NixOS/nixpkgs/commit/35d066de5f78498696e570615505b1c872602c17) rewrite `runCommand` interface docs
* [`16cb9380`](https://github.com/NixOS/nixpkgs/commit/16cb9380f5927107a6397f9f9479fb82d84ef13a) Update overrides.nix, compile leaderf vim plugin
* [`9e043994`](https://github.com/NixOS/nixpkgs/commit/9e0439949a379e2a9a6fc7fda3402350befa26a5) python311Packages.appthreat-vulnerability-db: 5.4.1 -> 5.4.2
* [`03d6f353`](https://github.com/NixOS/nixpkgs/commit/03d6f3538902af1aae6e8b953a76ccdf710befce) python311Packages.hahomematic: 2023.9.1 -> 2023.9.2
* [`f7671768`](https://github.com/NixOS/nixpkgs/commit/f76717681dc50a9541cc889a67b3286c1103143a) python311Packages.hsluv: 5.0.3 -> 5.0.4
* [`d8f4c08f`](https://github.com/NixOS/nixpkgs/commit/d8f4c08f371f72e6bea1b4106fc852d2b9e6e4ce) nextcloud25: 25.0.10 -> 25.0.11
* [`3f292985`](https://github.com/NixOS/nixpkgs/commit/3f2929850f3dcd236298251adc3cd4deb63274a9) nextcloud26: 26.0.5 -> 26.0.6
* [`ff404e6b`](https://github.com/NixOS/nixpkgs/commit/ff404e6b415aa67dfcdc8c8cec63bbe78d72d362) nextcloud27: 27.0.2 -> 27.1.0
* [`5570c265`](https://github.com/NixOS/nixpkgs/commit/5570c265acd23ebcc09e67b3aef51e6c61251fb0) python311Packages.aiolifx-themes: 0.4.8 -> 0.4.9
* [`839ff463`](https://github.com/NixOS/nixpkgs/commit/839ff463f07d47a8e650eccb62ae00f1ef186e2f) python311Packages.casbin: 1.27.0 -> 1.28.0
* [`017a7431`](https://github.com/NixOS/nixpkgs/commit/017a7431a5c79c09e308b12dd55677a5dbdac933) python311Packages.azure-storage-queue: 12.6.0 -> 12.7.1
* [`642de174`](https://github.com/NixOS/nixpkgs/commit/642de1740b230bb57407b763480f825a84cc7ab1) python311Packages.clevercsv: 0.8.0 -> 0.8.1
* [`9b8c85fb`](https://github.com/NixOS/nixpkgs/commit/9b8c85fb02b1c8238e1e3d664c496d7efa507537) python311Packages.fritzconnection: 1.13.1 -> 1.13.2
* [`bddaaf18`](https://github.com/NixOS/nixpkgs/commit/bddaaf18f15bf38f032df4d807ebb63c6bc9e27a) python311Packages.google-cloud-compute: 1.14.0 -> 1.14.1
* [`38a5ede5`](https://github.com/NixOS/nixpkgs/commit/38a5ede5c38f60a81dab77ac43c7fd45daf03f66) opencv3: remove enableVtk flag
* [`0db4dea3`](https://github.com/NixOS/nixpkgs/commit/0db4dea3b9e0cd5c48073986a057f05e58b8745a) mirtk: 2.0.0 -> unstable-2022-07-22
* [`66212346`](https://github.com/NixOS/nixpkgs/commit/66212346b2fd83eeed7d57b347793183367f1f25) python311Packages.google-auth-httplib2: 0.1.0 -> 0.1.1
* [`d9dda8f4`](https://github.com/NixOS/nixpkgs/commit/d9dda8f4ba7e148998db866a47302dca28334546) python311Packages.google-cloud-dataproc: 5.5.0 -> 5.5.1
* [`27ebcf32`](https://github.com/NixOS/nixpkgs/commit/27ebcf326e531249c99337fdc756ecb8716d8bcc) python311Packages.google-cloud-dlp: 3.12.2 -> 3.12.3
* [`f9757692`](https://github.com/NixOS/nixpkgs/commit/f975769295f7f71a4d549debd6995d30d08ee89b) python311Packages.ical: 5.0.1 -> 5.1.0
* [`af8dfc58`](https://github.com/NixOS/nixpkgs/commit/af8dfc58f9e783eb0cbaa99c4ab13990c8c9b03f) easyeffects: 7.0.5 -> 7.1.0
* [`62f5b69e`](https://github.com/NixOS/nixpkgs/commit/62f5b69eca7bb8b91237d6dc121bf4b27ed6c14b) reindeer: unstable-2023-08-14 -> unstable-2023-09-16
* [`c53164b1`](https://github.com/NixOS/nixpkgs/commit/c53164b1d7b67639e7addae8f388067a3bee5240) buck2: unstable-2023-09-01 -> unstable-2023-09-15
* [`409d29ca`](https://github.com/NixOS/nixpkgs/commit/409d29ca737309e51e58483aa0ef0a8d4489d9a1) nixos/sudo: Split up `configFile` into individual sections
* [`45415137`](https://github.com/NixOS/nixpkgs/commit/454151375d626a148fdb4423d577994319d6bd97) nixos/sudo: Don't include empty sections
* [`8742134c`](https://github.com/NixOS/nixpkgs/commit/8742134c80539b3f8e9c7c51b13a225a92e97b9a) nixos/sudo: Only keep SSH_AUTH_SOCK if used for authentication
* [`0365b05f`](https://github.com/NixOS/nixpkgs/commit/0365b05f13a4230d75bb63708694ee4692638236) nixos/terminfo: Add config option not to add extra sudo config
* [`f5aadb56`](https://github.com/NixOS/nixpkgs/commit/f5aadb56bed0bba1c5ade776ac49cb1d8a56ecf9) nixos/sudo: Refactor option definitions
* [`8b9e867a`](https://github.com/NixOS/nixpkgs/commit/8b9e867ac83fdc8a3ec4bd7746b455c2b0b79b2d) nixos/sudo: Refactor checks for Todd C. Miller's implemetation
* [`3a95964f`](https://github.com/NixOS/nixpkgs/commit/3a95964fd5ba6240c4d08ee9a5e76faa94c8934a) nixos/sudo: Drop useless `lib.` qualifiers
* [`b1eab8ca`](https://github.com/NixOS/nixpkgs/commit/b1eab8ca53dca000ffb5dcb7db62685bc2948215) nixos/sudo: Handle `root`'s default rule through `extraRules`
* [`717e51a1`](https://github.com/NixOS/nixpkgs/commit/717e51a140d6af347b5362ddb149a2c343b947b8) nixos/sudo: Make the default rules' options configurable
* [`c11da391`](https://github.com/NixOS/nixpkgs/commit/c11da39117871fce949423b3e27da6b796d36957) nixos/sudo: Drop the sudoers comment for `extraRules`
* [`f0107b4f`](https://github.com/NixOS/nixpkgs/commit/f0107b4f63a70925050954f647d14f6e256362d8) nixos/sudo: Check syntax using the configured package
* [`914bf583`](https://github.com/NixOS/nixpkgs/commit/914bf5836974520e6cfd3e687dead3937f6d3db2) nixos/{sudo, terminfo}: Adjust defaults for compatibility with `sudo-rs`
* [`f66eb0df`](https://github.com/NixOS/nixpkgs/commit/f66eb0df3b238af9e0f88918a52adfd11db7ac84) nixos/sudo: Only wrap `sudoedit` when using Miller's sudo
* [`4729358f`](https://github.com/NixOS/nixpkgs/commit/4729358fa5d9a9d817fe4ccff27d8656c17b2075) nixos/test-driver: do not break if the command writes to stderr
* [`8c0a9c12`](https://github.com/NixOS/nixpkgs/commit/8c0a9c12b1b35b43ff44a82534f0557c9236159b) python3Packages.cadquery: mark broken
* [`cc12dbf5`](https://github.com/NixOS/nixpkgs/commit/cc12dbf5bb951bbbb2f0a5d3646967a03290e46c) python3Packages.pythonocc-core: remove unused `smesh` dependency
* [`ba6b7b05`](https://github.com/NixOS/nixpkgs/commit/ba6b7b05cf42edfd0cfdf72ac96491f902b44b3e) smesh: remove at 6.7.6
* [`5a82c615`](https://github.com/NixOS/nixpkgs/commit/5a82c61519f2961f9e0cecae8b5c246fa4d2f0b1) elmerfem: unstable-2023-02-03 -> 2023-09-18
* [`3fd75f93`](https://github.com/NixOS/nixpkgs/commit/3fd75f93ab155e6d9467e19d31d777b76ccd3183) treewide: add meta.mainProgram ([nixos/nixpkgs⁠#255932](https://togithub.com/nixos/nixpkgs/issues/255932))
* [`7b5b3f51`](https://github.com/NixOS/nixpkgs/commit/7b5b3f5124331ea5679c100e6d58f1493ad4e64d) nixos/sudo: Add tests for sudo-rs too
* [`d63eb55e`](https://github.com/NixOS/nixpkgs/commit/d63eb55e81ad6a87263c0c94f4362fd64d780e50) nixos/sudo: Generate `sudo-i` PAM config for interactive use of `sudo-rs`
* [`d8d0b801`](https://github.com/NixOS/nixpkgs/commit/d8d0b8019ff3db7d06e7654c65f8ec41b3a7b535) nixos/sudo: Add myself as maintainer
* [`c4bc48ab`](https://github.com/NixOS/nixpkgs/commit/c4bc48abe3ddf8be028019380dc71062aa618cd5) fsautocomplete: 0.63.0 -> 0.63.1
* [`dd4281be`](https://github.com/NixOS/nixpkgs/commit/dd4281be50acf3eff62f95e909aae76c6874af00) htmldoc: 1.9.16 -> 1.9.17
* [`73983b3d`](https://github.com/NixOS/nixpkgs/commit/73983b3d62d3a50b72a126b0c786b8e4af899e2a) eza: 0.12.0 -> 0.13.0
* [`2a550d8c`](https://github.com/NixOS/nixpkgs/commit/2a550d8ccddefcd1d2bbf51e5e29e18f9e15e9a1) fluffychat: 1.13.0 -> 1.14.1
* [`229e2253`](https://github.com/NixOS/nixpkgs/commit/229e2253f2cde7baecbe267f1f33556b0ce71a93) python310Packages.mkdocstrings-python: 1.6.3 -> 1.7.0
* [`79f57f7d`](https://github.com/NixOS/nixpkgs/commit/79f57f7d475070cbceed07ec119ae8b8036ddfa2) goss,dgoss: 0.4.1 -> 0.4.2
* [`682493b2`](https://github.com/NixOS/nixpkgs/commit/682493b2c4f2d31c7503774d913e12e01c30f52c) team-list.nix: nixos-modules -> module-system
* [`4e2fcbf7`](https://github.com/NixOS/nixpkgs/commit/4e2fcbf7ee7004690cc9e5a0e71e09cb27e3b8a7) team-list.nix: remove members who did not join
* [`1bca401e`](https://github.com/NixOS/nixpkgs/commit/1bca401e4a65efb3fb66b054bbeaf66be26aa3cb) keepass: 2.53.1 -> 2.54
* [`c5e032fd`](https://github.com/NixOS/nixpkgs/commit/c5e032fda7deeecd1a3855a8c44a139f13c73d0b) vectorscan: fix changelog url
* [`8e0d9713`](https://github.com/NixOS/nixpkgs/commit/8e0d97130a1cc0087f37f5c7308e38abfbc32d7a) typos: 1.16.11 -> 1.16.12
* [`fd45d4a3`](https://github.com/NixOS/nixpkgs/commit/fd45d4a3cbe3184240a20fa0c48d6ffa287d424d) hydron: mark as vulnerable to CVE-2023-4863
* [`4e0e370d`](https://github.com/NixOS/nixpkgs/commit/4e0e370d304b8a799430b6cc59f55000d37e8b08) rdma-core: 47.0 -> 48.0
* [`3b605d20`](https://github.com/NixOS/nixpkgs/commit/3b605d204dae49e76fb3bc790f49df569abade39) jna: add macos platforms
* [`ad07cd4f`](https://github.com/NixOS/nixpkgs/commit/ad07cd4fc2e37cdeca8f6b920f4d955fa280f595) treewide: add version tests ([nixos/nixpkgs⁠#255781](https://togithub.com/nixos/nixpkgs/issues/255781))
* [`8e11eef3`](https://github.com/NixOS/nixpkgs/commit/8e11eef3146ae19873ee9ff4e7590a0250fdee15) python311Packages.onnx: protobuf 3.x -> 4.x
* [`23e1d1e4`](https://github.com/NixOS/nixpkgs/commit/23e1d1e4dae96ebe63ea64753e6bea95c4554ba5) spglib: 2.0.2 -> 2.1.0
* [`d03e80e2`](https://github.com/NixOS/nixpkgs/commit/d03e80e2537bfae06ce57b44448a2d29613e97d7) buildMavenPackage: refactor
* [`057cd2a7`](https://github.com/NixOS/nixpkgs/commit/057cd2a739428b4c7b5168f1f39a67bc9f3d44e1) rocketchat-desktop: 3.8.11 -> 3.9.7
* [`9867c0da`](https://github.com/NixOS/nixpkgs/commit/9867c0da21def5493993c5f84946266222443608) python310Packages.objax: switch back to GitHub for sources
* [`66867a88`](https://github.com/NixOS/nixpkgs/commit/66867a88354d9db75a72e0d1460b1437f12ed5df) solc: 0.8.19 -> 0.8.21
* [`839b721b`](https://github.com/NixOS/nixpkgs/commit/839b721ba2e5fd366e945759610e78a2df0f7525) staruml: 6.0.0 -> 6.0.1
* [`45a3bafb`](https://github.com/NixOS/nixpkgs/commit/45a3bafb6c715e84c5664bf329fda5d516a26746) staruml: use `finalAttrs` pattern
* [`b703fb03`](https://github.com/NixOS/nixpkgs/commit/b703fb03614010cd1feb529cb1acd80045bacd48) geos: add package tests
* [`54d99123`](https://github.com/NixOS/nixpkgs/commit/54d991232fac3646682dfa5f0650c87126116b68) python310Packages.intake: unstable-2023-08-24 -> 0.7.0
* [`a62cc898`](https://github.com/NixOS/nixpkgs/commit/a62cc898e35600208d688c707a1fbf882444fb6c) mattermost: 7.10.3 -> 7.10.5
* [`113b904e`](https://github.com/NixOS/nixpkgs/commit/113b904e4eeb71d2c2317bbb0c675bc46426975c) thc-hydra: patch to build on darwin
* [`a11c1555`](https://github.com/NixOS/nixpkgs/commit/a11c1555527f64f9ff34a0af0abae5044e47be69) python3Packages.torch: add descriptive messages when marked broken
* [`d30d4b9c`](https://github.com/NixOS/nixpkgs/commit/d30d4b9ca3f058121252e3e9149befdcba98dd5a) spacer: 0.2 -> 0.3.0
* [`d102d7c2`](https://github.com/NixOS/nixpkgs/commit/d102d7c2ec58eb9d101def4336ad72968d7a550e) python3.pkgs.deploykit: 1.1.0 -> 1.1.1
* [`c54fc2a4`](https://github.com/NixOS/nixpkgs/commit/c54fc2a40f7807bb7ef23c548202cfef10ffda3f) gpsprune: add media type associations
* [`f799d5a5`](https://github.com/NixOS/nixpkgs/commit/f799d5a52729dfdf02a6cb4dc2d5cc1c7129ecee) openscenegraph: opencascade -> opencascade-occt
* [`b2e44fcf`](https://github.com/NixOS/nixpkgs/commit/b2e44fcf6f56f6e7f497fe4071c3cbd709101517) opencascade: remove at 0.18.3
* [`f110cccd`](https://github.com/NixOS/nixpkgs/commit/f110cccd04ab950e949aa03b90ce5e6999840ae3) vtk_8: remove
* [`515c5b8b`](https://github.com/NixOS/nixpkgs/commit/515c5b8b2872c2539c6436dcc128506b9e05472a) vintagestory: 1.18.10 -> 1.18.12
* [`1ab0c301`](https://github.com/NixOS/nixpkgs/commit/1ab0c3013048ad2cd8d3e57c1f473f44bff94f5c) zpaqfranz: init at 58.9
* [`ca423410`](https://github.com/NixOS/nixpkgs/commit/ca423410e0e6b9e16a4e21e2aaa26330401e4622) vscode: 1.82.1 -> 1.82.2
* [`b5080d84`](https://github.com/NixOS/nixpkgs/commit/b5080d84d69dbc6454db1cd9df37bbb3319a6ae3) bookstack: 23.08.2 -> 23.08.3
* [`bddafba6`](https://github.com/NixOS/nixpkgs/commit/bddafba6a54a4ea07428a6ff0713898f81b25cca) python3Packages.jax: remove pytest-xdist
* [`a371387a`](https://github.com/NixOS/nixpkgs/commit/a371387aba8fa4bdd71c27cbfe71427aa835b48f) python3Packages.sourmash: 4.8.3 -> 4.8.4
* [`11c29642`](https://github.com/NixOS/nixpkgs/commit/11c29642f03f26adc9ef64303da2e841d37fcf6c) smooth: unvendor all the things
* [`65033fea`](https://github.com/NixOS/nixpkgs/commit/65033fea280074d45e7aca7d8e5c26d361a10f59) mosdepth: 0.3.4 -> 0.3.5
* [`36457b7a`](https://github.com/NixOS/nixpkgs/commit/36457b7ac84d8d5262a68ae3d283b4ec141ebb25) libcef: 116.0.21 -> 116.0.24
* [`d1c4cdff`](https://github.com/NixOS/nixpkgs/commit/d1c4cdff10be436f0d92e7c72dc23a87d59fd285) mongodb-compass: 1.39.3 -> 1.39.4
* [`67786d3c`](https://github.com/NixOS/nixpkgs/commit/67786d3c299c0f70cfa0f8f0f8ef6d48b4c745c1) eksctl: 0.156.0 -> 0.157.0
* [`0b5a25c9`](https://github.com/NixOS/nixpkgs/commit/0b5a25c9afda77a66b2fbe52ae15bc2abde83711) lightningcss: 1.21.8 → 1.22.0
* [`b271eb8a`](https://github.com/NixOS/nixpkgs/commit/b271eb8aabdfd45d23a5fdac3fa747c95916b1d7) lightningcss: add mainProgram
* [`7d112f7d`](https://github.com/NixOS/nixpkgs/commit/7d112f7da3312cb07116b5f9bac647f0f943a596) luksroot: fix issue when yubikey is detached during boot process
* [`67c5103f`](https://github.com/NixOS/nixpkgs/commit/67c5103f409f244ec9de2a21e8094aeea96e0b4e) nixos/gdm: add banner option
* [`f276974e`](https://github.com/NixOS/nixpkgs/commit/f276974e8d117279efdc396ae1cc7f9f75994ede) ncmpc: 0.48 -> 0.49
* [`c14d62f2`](https://github.com/NixOS/nixpkgs/commit/c14d62f2729e8a1cef3f542aded5f4881578abaa) sudo-font: 0.69 -> 0.74
* [`4d9a02ac`](https://github.com/NixOS/nixpkgs/commit/4d9a02acc8827d32219e044d43be9ec2f5a8e9c4) spicedb: 1.23.0 -> 1.25.0
* [`1e581837`](https://github.com/NixOS/nixpkgs/commit/1e581837434fe188c1baec98f0d3c40ae1cc9094) less: migrate to by-name
* [`78cccac7`](https://github.com/NixOS/nixpkgs/commit/78cccac71c66d3a8115a8ce61ca016d7dc4ecabf) less: 633 -> 643
* [`068c6d4e`](https://github.com/NixOS/nixpkgs/commit/068c6d4e036f7ad67e7661d6dbd5a95822229bcd) typst-lsp: 0.9.5 -> 0.10.0
* [`fd09de7b`](https://github.com/NixOS/nixpkgs/commit/fd09de7be5279da58b5f6b417cc9f40def8d4b7d) mksh: migrate to by-name
* [`88a627e0`](https://github.com/NixOS/nixpkgs/commit/88a627e01273c4301e3ab533a5e85fea51d5ecd9) rc: migrate to by-name
* [`c3f4c7f5`](https://github.com/NixOS/nixpkgs/commit/c3f4c7f54ce38f1bf69d2a557c4c37c036436073) elvish: refactor
* [`cd0f8741`](https://github.com/NixOS/nixpkgs/commit/cd0f8741040c151636d218954d237db89dfd349f) python310Packages.adafruit-platformdetect: 3.52.0 -> 3.52.1
* [`0656a6bb`](https://github.com/NixOS/nixpkgs/commit/0656a6bbe25431fb1289066eefe266760b5c6bd0) python310Packages.devito: 4.8.1 -> 4.8.2
* [`8d7450d8`](https://github.com/NixOS/nixpkgs/commit/8d7450d882c304f69006afce471604e7a58a02a8) mkgmap: 4910 -> 4912
* [`9be4eb37`](https://github.com/NixOS/nixpkgs/commit/9be4eb374c741d954984ebe33c866948dae7e0dd) fastlane: 2.215.0 -> 2.215.1
* [`8346a7a1`](https://github.com/NixOS/nixpkgs/commit/8346a7a1550c90025a33eb3f363b9f493804747d) fastlane: 2.215.1 -> 2.216.0
* [`d967d5ea`](https://github.com/NixOS/nixpkgs/commit/d967d5eaf0bf1e1706655e2d8b545102e40cfebf) hubot-sans: 1.0 -> 1.0.1
* [`a20074e0`](https://github.com/NixOS/nixpkgs/commit/a20074e0e1e20e4413b5d06c99a0939384e112db) python310Packages.scrapy: 2.10.1 -> 2.11.0
* [`a3a47cef`](https://github.com/NixOS/nixpkgs/commit/a3a47cef4a9bea9181b6716daaaa098047c02d87) fastlane: update homepage
* [`8773e987`](https://github.com/NixOS/nixpkgs/commit/8773e987e1cfaf4912a145d4e8889076e19740d8) python310Packages.merge3: 0.0.13 -> 0.0.14
* [`86b5f4a9`](https://github.com/NixOS/nixpkgs/commit/86b5f4a9a5da93ca435df5ed4ad5d67aec286a24) dtools: 2.103.1 -> 2.105.2
* [`73f56ebb`](https://github.com/NixOS/nixpkgs/commit/73f56ebb44169721b73fe01ba9af305ad2c6817b) sd-local: 1.0.48 -> 1.0.49
* [`f58d86bf`](https://github.com/NixOS/nixpkgs/commit/f58d86bf7ee06eacec444b805ba0731df382428b) archiver: use sri hash
* [`54774ec0`](https://github.com/NixOS/nixpkgs/commit/54774ec01256bf6fe46193c89d25a3cafe2b19c1) denaro: 2023.9.1 -> 2023.9.2
* [`49f824c8`](https://github.com/NixOS/nixpkgs/commit/49f824c80e6b4b4aea509c31b218538ffcf1818b) dmd: 2.100.2 -> 2.105.2
* [`637e6a10`](https://github.com/NixOS/nixpkgs/commit/637e6a109736b6b1c0a20a8eef3707b1a53641d5) proj: 9.2.1 -> 9.3.0
* [`8176b59b`](https://github.com/NixOS/nixpkgs/commit/8176b59b41ff2167ad76c68641f8a74f70b715e3) pachyderm: 2.7.0 -> 2.7.2
* [`3dd248db`](https://github.com/NixOS/nixpkgs/commit/3dd248db21547e8f1daa8cf4807e20d40b1f4358) ocamlPackages.ocamlgraph: 2.0.0 → 2.1.0
* [`42cfdd46`](https://github.com/NixOS/nixpkgs/commit/42cfdd46b35f4a5ad58d9eed4eb0761ea3a76984) cargo-crev: 0.24.3 -> 0.25.0
* [`835736de`](https://github.com/NixOS/nixpkgs/commit/835736de35faba3e57a7a4becc6b7e472ae72317) coder: fix broken pkg ([nixos/nixpkgs⁠#255964](https://togithub.com/nixos/nixpkgs/issues/255964))
* [`1e2db104`](https://github.com/NixOS/nixpkgs/commit/1e2db1049e380d53380ba8929727db7e8f42448a) ruplacer: 0.8.1 -> 0.8.2
* [`3e88dd24`](https://github.com/NixOS/nixpkgs/commit/3e88dd245d64f692f549471d97c95b05df3fba96) pocketbase: 0.18.3 -> 0.18.6
* [`80245697`](https://github.com/NixOS/nixpkgs/commit/802456973b5bd0cb4a77ce6ff08445d17abfca44) qc: 0.5.0 -> 0.5.1
* [`b2321351`](https://github.com/NixOS/nixpkgs/commit/b23213515635acc2bc25b88b5c926d3c74a54aab) python311Packages.botocore-stubs: 1.31.40 -> 1.31.50
* [`026c784c`](https://github.com/NixOS/nixpkgs/commit/026c784c2e653a0c20ff27c7239fd3587afa431b) python311Packages.hahomematic: 2023.9.2 -> 2023.9.3
* [`660af05e`](https://github.com/NixOS/nixpkgs/commit/660af05e145bbef61dbfbbcc86703ce387225ea3) python311Packages.requests-pkcs12: 1.18 -> 1.21
* [`e4a18671`](https://github.com/NixOS/nixpkgs/commit/e4a186713d25e6d7b888f4f4f55e80317727af99) qovery-cli: 0.70.0 -> 0.70.1
* [`28a4b953`](https://github.com/NixOS/nixpkgs/commit/28a4b95339798f2c4f62796c7fe0c56771db861f) checkSSLCert: 2.72.0 -> 2.74.0
* [`9bfe6dbe`](https://github.com/NixOS/nixpkgs/commit/9bfe6dbee7e0b9a83e8b2cb9e89e9b3fcd95c973) python311Packages.ossfs: 2023.5.0 -> 2023.8.0
* [`fdce1f54`](https://github.com/NixOS/nixpkgs/commit/fdce1f549f128dbcb9d946f5166034ed132ee445) grype: 0.68.0 -> 0.68.1
* [`90040cd3`](https://github.com/NixOS/nixpkgs/commit/90040cd36a1c01cf407f93315b268c1ead75e494) linux/hardened/patches/6.5: init at 6.5.3-hardened1
* [`965c4299`](https://github.com/NixOS/nixpkgs/commit/965c4299171c8af08554ff0b5a0f957e4a5830af) wine: Fix missing X11 libraries for Wayland build
* [`07a24f16`](https://github.com/NixOS/nixpkgs/commit/07a24f168dcef415dd3bde0ec5d660b320556b11) wine: add libXfixes
* [`e3a6b0c4`](https://github.com/NixOS/nixpkgs/commit/e3a6b0c4eb15f003b3d7890230bd1a15fe4531e3) python3Packages.django-ninja: init at 0.22.2
* [`0ddfdc7c`](https://github.com/NixOS/nixpkgs/commit/0ddfdc7c1a70510db19cf2e75b4b278d074d17f0) wine: sort supportFlags
* [`bbe10e59`](https://github.com/NixOS/nixpkgs/commit/bbe10e590e9dc07497e0fcce080aae94f4f0a65e) HentaiAtHome: 1.6.1 -> 1.6.2
* [`c511f60c`](https://github.com/NixOS/nixpkgs/commit/c511f60c4845468b112c0ce082edbfd63a797c9d) flutter: 3.13.0 -> 3.13.4
* [`b27d40ed`](https://github.com/NixOS/nixpkgs/commit/b27d40ed61d286ed9c96c970f46caac27cf21438) mimir: 2.9.0 -> 2.10.0
* [`3eb91e96`](https://github.com/NixOS/nixpkgs/commit/3eb91e96ba5253d8fdf459802eedfa86cd8b951b) python310Packages.metakernel: 0.30.0 -> 0.30.1
* [`b2c5d080`](https://github.com/NixOS/nixpkgs/commit/b2c5d08055f67825a296468f29b8ec85b712c77f) buildMavenPackage: use mvnParameters as before
* [`d9d1ed16`](https://github.com/NixOS/nixpkgs/commit/d9d1ed167583941a009035c50669ab29c7eb4a2a) bloat: unstable-2022-12-17 -> unstable-2023-09-18
* [`7c76105a`](https://github.com/NixOS/nixpkgs/commit/7c76105a0a0f6fb66d8be5b27b47012dec02f380) python3Packages.geopandas: drop Python 3.8 support
* [`3b528a2f`](https://github.com/NixOS/nixpkgs/commit/3b528a2fd085304ef35141d340a2872690a79718) gr-framework: refactor
* [`71213240`](https://github.com/NixOS/nixpkgs/commit/71213240ae0a4686d5e842f2ee3a17a9b982d30e) qownnotes: 23.8.1 -> 23.9.4
* [`dd4bd3da`](https://github.com/NixOS/nixpkgs/commit/dd4bd3dabb74985b632a39c812c13d9c878f2eb0) jmol: 16.1.35 -> 16.1.39
* [`3dba9d65`](https://github.com/NixOS/nixpkgs/commit/3dba9d65a639ca493128a3132abfb8788b6e140e) reaper: 6.81 -> 6.82
* [`4da06a2e`](https://github.com/NixOS/nixpkgs/commit/4da06a2ec81198050c0b0569588b71e7c5d4a649) harsh: 0.8.28 -> 0.8.29
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
