### PR TITLE
niv devenv: update 63d20fe0 -> 42a26aa1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "63d20fe09aa09060ea9ec9bb6d582c025402ba15",
-        "sha256": "062cgxrfhncc5w9k2y0w70vgip5bzdin9gmbk4625szs6hzm74xk",
+        "rev": "42a26aa1b2265cf505df056e040e2b1ef8073b76",
+        "sha256": "148b0iy5xmdqf50hy1p1m5fmgzfc370a028z7qjxikcvk50nljgv",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/63d20fe09aa09060ea9ec9bb6d582c025402ba15.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/42a26aa1b2265cf505df056e040e2b1ef8073b76.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@63d20fe0...42a26aa1](https://github.com/cachix/devenv/compare/63d20fe09aa09060ea9ec9bb6d582c025402ba15...42a26aa1b2265cf505df056e040e2b1ef8073b76)

* [`27dd4859`](https://github.com/cachix/devenv/commit/27dd4859c69043db88b0c2a8190788d3a9c2d1ef) varnish: allow using module collection
* [`7aedf429`](https://github.com/cachix/devenv/commit/7aedf42997c83461956b6deccd482ddcc85250b8) varnish: add test
* [`328a162f`](https://github.com/cachix/devenv/commit/328a162f692e878bdb8d0283d937eadf1684cd51) Auto generate docs/reference/options.md
* [`0ede4b29`](https://github.com/cachix/devenv/commit/0ede4b29b9e012d7e62de945ae91cf68867f0354) Add the zig langauge server to the zig integration
* [`1fc5d143`](https://github.com/cachix/devenv/commit/1fc5d1432f85ac62ebc50a824aca288ced393ffb) Fix deprecated mkdocs plugin options
* [`be5070c4`](https://github.com/cachix/devenv/commit/be5070c41b2cb82bc0b6872dc06f7cf21fcea9e3) Expand GitHub Actions docs into a full example
* [`9ee03e5f`](https://github.com/cachix/devenv/commit/9ee03e5f9112ef31660fe7ffc03e8f84338f3c8e) Update metadata for the GitHub Actions guide
* [`022c0fdc`](https://github.com/cachix/devenv/commit/022c0fdcec5dc885fb507b262a0fdc6e7cb81069) Fix mkdoc plugin override
* [`8ef70a81`](https://github.com/cachix/devenv/commit/8ef70a8194276b496e04e3e058dfadff6c7e8044) Update mkdocs
* [`d12218b4`](https://github.com/cachix/devenv/commit/d12218b404f43ee2dbb5eeb91a0ebcd929813154) Fix configs for new mkdocs
* [`163df64e`](https://github.com/cachix/devenv/commit/163df64e398d32a2acd52e4b1635ab25ac89b873) Bump runtime python
* [`361c767b`](https://github.com/cachix/devenv/commit/361c767be9bd5a28f401ba8ddebc680807afb915) Update CF build script
* [`540265b5`](https://github.com/cachix/devenv/commit/540265b58b93eb93cd468de1f980ecac46be73b2) OCaml: Add the ocp-indent package
* [`cb54e540`](https://github.com/cachix/devenv/commit/cb54e540a85c5e029b175e2b8d0de29afb704192) remove mkdocs insiders now that blog is part of community
