### PR TITLE
niv home-manager: update feb70061 -> a88df2fb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "feb70061596134d403e14cc5ef7b01ab114d1dbd",
-        "sha256": "1iwc3240hlr15jpcsgxr09gknyinqs6q1r91hzrx4qbldbxam9ka",
+        "rev": "a88df2fb101778bfd98a17556b3a2618c6c66091",
+        "sha256": "0wb5bxxx7isqcgzcfg8a6pl7hwkzl3z0rnbr9vjzvxrs4vz53366",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/feb70061596134d403e14cc5ef7b01ab114d1dbd.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a88df2fb101778bfd98a17556b3a2618c6c66091.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@feb70061...a88df2fb](https://github.com/nix-community/home-manager/compare/feb70061596134d403e14cc5ef7b01ab114d1dbd...a88df2fb101778bfd98a17556b3a2618c6c66091)

* [`8045eb45`](https://github.com/nix-community/home-manager/commit/8045eb45a79b5e585df781c02500d33c9ed96ae0) pasystray: add `extraOptions`
* [`92364581`](https://github.com/nix-community/home-manager/commit/92364581dd3ada6981c4ddc5def8a35a1b945e75) tests: sort test list
* [`ee9f5dc8`](https://github.com/nix-community/home-manager/commit/ee9f5dc8f691c69f9bd84194fdbf63d41efb6649) flake.lock: Update
* [`f5b920f4`](https://github.com/nix-community/home-manager/commit/f5b920f4d2f920a1982ca844cfd22c8f1e82ed7e) fluxbox: fix xsession command
* [`8aac47a1`](https://github.com/nix-community/home-manager/commit/8aac47a140de1153a90bcc509596c65f6d82d832) waybar: fix service After value
* [`7ee73f53`](https://github.com/nix-community/home-manager/commit/7ee73f5363bc0f4b0f8042665168c25c90dd16f9) rofi-pass: add package option
* [`6f882433`](https://github.com/nix-community/home-manager/commit/6f88243322c315360c1f31a8fc6c43006db51465) starship: use `use` instead of `source` for nushell
* [`3e7202c6`](https://github.com/nix-community/home-manager/commit/3e7202c6387b744dca4feb4217459512886761b5) flake.lock: Update
* [`8847dd8b`](https://github.com/nix-community/home-manager/commit/8847dd8bf35a50e012088d6eef6010a6884b3632) Translate using Weblate (Thai)
* [`0ed5f978`](https://github.com/nix-community/home-manager/commit/0ed5f9786bba801c59fb53eef497438040acd471) Add translation using Weblate (Thai)
* [`408ba131`](https://github.com/nix-community/home-manager/commit/408ba13188ff9ce309fa2bdd2f81287d79773b00) neomutt: fix STARTTLS
* [`e0c70942`](https://github.com/nix-community/home-manager/commit/e0c70942c0e7178a56289adea20c056a3cda7c5e) programs.sway: separate trayOutput values for sway ([nix-community/home-manager⁠#4489](https://togithub.com/nix-community/home-manager/issues/4489))
* [`7413408b`](https://github.com/nix-community/home-manager/commit/7413408b047c12125cf3b76e5d8fa53c297ac1ee) yazi: add fish and nushell integration
* [`2d27bdcd`](https://github.com/nix-community/home-manager/commit/2d27bdcd640759a5fb1b48125fee7280adad95f7) direnv: fix nushell syntax
* [`835465e8`](https://github.com/nix-community/home-manager/commit/835465e8ba2459034e4ab192b1c6db35d1c0d638) lsd: allow user to configure colors
* [`baf222f2`](https://github.com/nix-community/home-manager/commit/baf222f2fba7bbe6fd2289a6845c884f5cb499d8) tests: add mainProgram to stub packages
* [`4a633326`](https://github.com/nix-community/home-manager/commit/4a6333265ed8f3abf4769db60735522bbaa7819d) flake.lock: Update
* [`a88df2fb`](https://github.com/nix-community/home-manager/commit/a88df2fb101778bfd98a17556b3a2618c6c66091) bacon: add module
