### PR TITLE
niv emacs-overlay: update f88e77ec -> a8239b33

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f88e77ec11c9325e61bf06bb2eeed13f90ff2e42",
-        "sha256": "1wrnwy79r4yrkhf66qfhmq75dv7d44h1aabjw4wzmsbb3bzjnpzn",
+        "rev": "a8239b33859352caabc400e051c649481f4a02b2",
+        "sha256": "12avqrj96b634g1m73y6ayin2cr8q5vw6ml0r81iv8ws6g2h6py7",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/f88e77ec11c9325e61bf06bb2eeed13f90ff2e42.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/a8239b33859352caabc400e051c649481f4a02b2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@f88e77ec...a8239b33](https://github.com/nix-community/emacs-overlay/compare/f88e77ec11c9325e61bf06bb2eeed13f90ff2e42...a8239b33859352caabc400e051c649481f4a02b2)

* [`fa03b902`](https://github.com/nix-community/emacs-overlay/commit/fa03b90235a301e0758251653cecf0274474c738) Updated repos/elpa
* [`1bab7021`](https://github.com/nix-community/emacs-overlay/commit/1bab70211bbeaf58048865111501ecf6d870561b) Updated repos/emacs
* [`c45a4e9a`](https://github.com/nix-community/emacs-overlay/commit/c45a4e9a687936dade94b60f423ee1699d8e8ac8) Updated repos/melpa
* [`00eb85ea`](https://github.com/nix-community/emacs-overlay/commit/00eb85ea0fa4133a9e94164df3e5c2f872cdc3f6) Updated flake inputs
* [`f3f7544d`](https://github.com/nix-community/emacs-overlay/commit/f3f7544db1a2a5c0a1e65539b6d6e03caf93a616) Updated repos/emacs
* [`32282591`](https://github.com/nix-community/emacs-overlay/commit/32282591ce0496c2a38b593b8bc01aff2ba7c14b) Updated repos/melpa
* [`272e7390`](https://github.com/nix-community/emacs-overlay/commit/272e7390a3417f235616146786c89d025d37fd51) Updated flake inputs
* [`02703a16`](https://github.com/nix-community/emacs-overlay/commit/02703a16e4843001d247c46001e6e0e3208a7880) Updated repos/elpa
* [`e787c5f2`](https://github.com/nix-community/emacs-overlay/commit/e787c5f2d958dd8feeaaad8a9fc55cf74432f958) Updated repos/emacs
* [`d4d8903c`](https://github.com/nix-community/emacs-overlay/commit/d4d8903c024b763ea40db264dd531085651f09e3) Updated repos/melpa
* [`3fd9c9cc`](https://github.com/nix-community/emacs-overlay/commit/3fd9c9cc73dad139a2e93d26db49990fbddd22c1) Updated repos/elpa
* [`4b109795`](https://github.com/nix-community/emacs-overlay/commit/4b109795232987698d9504195b133ca405dd2a57) Updated repos/emacs
* [`3d321ff0`](https://github.com/nix-community/emacs-overlay/commit/3d321ff0fc591165423b20a33942d71f513200b1) Updated repos/melpa
* [`0cfbf704`](https://github.com/nix-community/emacs-overlay/commit/0cfbf7042022ba9e823e9d5dfb5fb6385ceba45a) Updated repos/nongnu
* [`f1108d88`](https://github.com/nix-community/emacs-overlay/commit/f1108d889900fc41737a17b1c3547eb5998c3352) Updated flake inputs
* [`de69125c`](https://github.com/nix-community/emacs-overlay/commit/de69125c2723bc7dd69dca2576cd79f3b79d0213) Updated repos/emacs
* [`23f1e77b`](https://github.com/nix-community/emacs-overlay/commit/23f1e77b20b424b57434559c1151fa0476664b03) Updated repos/melpa
* [`0433e4ec`](https://github.com/nix-community/emacs-overlay/commit/0433e4ecf91a2befec43722a1129c3f724a260c0) Updated repos/elpa
* [`66c46e81`](https://github.com/nix-community/emacs-overlay/commit/66c46e81a1687c4ae52691c82e180bb4bcb19de8) Updated repos/emacs
* [`b0c67285`](https://github.com/nix-community/emacs-overlay/commit/b0c6728523179f33d2d3b1842f042dcd6d017d15) Updated repos/melpa
* [`546710c0`](https://github.com/nix-community/emacs-overlay/commit/546710c03df958e2d429ea1c8b3f1f194dd2938a) Updated flake inputs
* [`0dfbff15`](https://github.com/nix-community/emacs-overlay/commit/0dfbff157a23365540f309b3d86f45c67e733e2b) Updated repos/elpa
* [`da978ea1`](https://github.com/nix-community/emacs-overlay/commit/da978ea183dde2decb3c2b76e0aae700046ec299) Updated repos/emacs
* [`7aa949aa`](https://github.com/nix-community/emacs-overlay/commit/7aa949aab0540e8e4b7de704017cef6622c54fef) Updated repos/melpa
* [`9fa144a7`](https://github.com/nix-community/emacs-overlay/commit/9fa144a785236df075f8681d2f6beab3dd3a1b0d) Updated repos/emacs
* [`c00836a1`](https://github.com/nix-community/emacs-overlay/commit/c00836a1827db0b69310ef64a778b30dd73e433c) Updated repos/melpa
* [`58f69930`](https://github.com/nix-community/emacs-overlay/commit/58f69930f1da1f15e792c302b96de2eccf3b4be8) Updated flake inputs
* [`3072f404`](https://github.com/nix-community/emacs-overlay/commit/3072f40414cc3b106a9750ca8183aa35eec8cfc3) Updated repos/elpa
* [`6543d3cf`](https://github.com/nix-community/emacs-overlay/commit/6543d3cfe16ee58be0bf7a8451b5bb17330757bd) Updated repos/emacs
* [`5b560c5f`](https://github.com/nix-community/emacs-overlay/commit/5b560c5fa73d718fb546404418a234e31d8bacf0) Updated repos/melpa
* [`61b086b2`](https://github.com/nix-community/emacs-overlay/commit/61b086b237faa50de8794de74fe0054b639ab48b) Updated repos/elpa
* [`c5206291`](https://github.com/nix-community/emacs-overlay/commit/c5206291274e6c00e7c2704581f9fdc06905593b) Updated repos/emacs
* [`63556f57`](https://github.com/nix-community/emacs-overlay/commit/63556f57263f866e461f152dde9aa0a7c70776ab) Updated repos/melpa
* [`bc5ac6ca`](https://github.com/nix-community/emacs-overlay/commit/bc5ac6ca9244f20811900632def4e00c6e6ac20e) Updated repos/nongnu
* [`eaaca1ae`](https://github.com/nix-community/emacs-overlay/commit/eaaca1aeaa49dce375a7ba2e83581f3d366b99ab) Updated repos/emacs
* [`cbdbd456`](https://github.com/nix-community/emacs-overlay/commit/cbdbd45697307d0e2d2a58e446953080da590b12) Updated repos/melpa
* [`adfa2fd7`](https://github.com/nix-community/emacs-overlay/commit/adfa2fd70583ef3c87df4a12f23d86d84bc5882d) Updated flake inputs
* [`1ba22842`](https://github.com/nix-community/emacs-overlay/commit/1ba22842a27171ecc9cc73a6b0e2a6a2d25a3244) Updated repos/elpa
* [`aed704c7`](https://github.com/nix-community/emacs-overlay/commit/aed704c73686bb8a8f16feadd5b7e76f1f9af5d2) Updated repos/emacs
* [`e59b3046`](https://github.com/nix-community/emacs-overlay/commit/e59b3046f1033e7186cd887b1eaea1a064889418) Updated repos/melpa
* [`2d21a318`](https://github.com/nix-community/emacs-overlay/commit/2d21a318ffc4f55bd904ab5f0325ee1a31e4d1de) Updated repos/elpa
* [`8eb732ee`](https://github.com/nix-community/emacs-overlay/commit/8eb732ee438ceeb0f509f98b38b1d34443c9b92c) Updated repos/melpa
* [`3adaef3b`](https://github.com/nix-community/emacs-overlay/commit/3adaef3b1bebdc244a03ee19f705f5a3190a33d9) Updated repos/nongnu
* [`65d51a53`](https://github.com/nix-community/emacs-overlay/commit/65d51a53d08577b5399795374784d5e228af4ebf) Updated repos/emacs
* [`2b93f8f1`](https://github.com/nix-community/emacs-overlay/commit/2b93f8f1670c4eaa67ff74043e34a9a0374080e3) Updated repos/melpa
* [`9b19cc20`](https://github.com/nix-community/emacs-overlay/commit/9b19cc202da6dcb1eda2ad2f6a1cc8548001fb29) Updated repos/nongnu
* [`cfc2d6ce`](https://github.com/nix-community/emacs-overlay/commit/cfc2d6cee919f9ea64ea1a13cc275ed41e0621f4) Updated repos/elpa
* [`737dadc8`](https://github.com/nix-community/emacs-overlay/commit/737dadc85f5c0a7d01d1fff2b44feda88f98e5ea) Updated repos/emacs
* [`6feb2028`](https://github.com/nix-community/emacs-overlay/commit/6feb20284f9c670836d9ffb1c074f7d347a3458a) Updated repos/melpa
* [`6fb937f3`](https://github.com/nix-community/emacs-overlay/commit/6fb937f3e64795fb7f3309f571b76933a40ab9e2) Updated repos/elpa
* [`4aaf3131`](https://github.com/nix-community/emacs-overlay/commit/4aaf3131bea8e1cacefdc8b6d892af1b60a20c73) Updated repos/emacs
* [`86d5dd1a`](https://github.com/nix-community/emacs-overlay/commit/86d5dd1ae7f1fe5ef478a8fa47481bcd0eb1d27f) Updated repos/melpa
* [`f3945cc2`](https://github.com/nix-community/emacs-overlay/commit/f3945cc285cf84244759db727a91a2056649f4b5) Updated repos/nongnu
* [`9159ba79`](https://github.com/nix-community/emacs-overlay/commit/9159ba797f3c5c4a5ea96bca0ce48999610ed84e) Updated repos/emacs
* [`e71a6578`](https://github.com/nix-community/emacs-overlay/commit/e71a65780f0591e49a4564f4d2c33e982a4e0452) Updated repos/melpa
* [`f5c2366c`](https://github.com/nix-community/emacs-overlay/commit/f5c2366c5d8f241b8c66e4b18be8ad25ffdb4e48) Updated repos/nongnu
* [`ae6d90ea`](https://github.com/nix-community/emacs-overlay/commit/ae6d90ea7e65c6ddcfcbaa5554eadc35eb4ee6c9) Updated flake inputs
* [`747473dc`](https://github.com/nix-community/emacs-overlay/commit/747473dc2ef8f0d55a91864ccf1c1d24062828fe) Updated repos/elpa
* [`b8f6a2f5`](https://github.com/nix-community/emacs-overlay/commit/b8f6a2f5d913541a40fb3d31795b2092dfaf53da) Updated repos/emacs
* [`e709d677`](https://github.com/nix-community/emacs-overlay/commit/e709d677e1cbe46b784e990c5796a8c7592d256c) Updated repos/melpa
* [`e398890f`](https://github.com/nix-community/emacs-overlay/commit/e398890fc3ec845082e63b81bca41eb13f06a77d) Updated flake inputs
* [`2a00aaf9`](https://github.com/nix-community/emacs-overlay/commit/2a00aaf989a1f8b16a2e79b31661bdd31753ab4b) Updated repos/elpa
* [`7b13830d`](https://github.com/nix-community/emacs-overlay/commit/7b13830d8a7265a2bd8d5ef0b864a3001cf8d076) Updated repos/emacs
* [`e91d53d2`](https://github.com/nix-community/emacs-overlay/commit/e91d53d2fa6595fb241187971a7c344420ea1d32) Updated repos/melpa
* [`d0913f8d`](https://github.com/nix-community/emacs-overlay/commit/d0913f8d9105a4001e19499534db69d015e1c377) Updated repos/emacs
* [`e588a8c9`](https://github.com/nix-community/emacs-overlay/commit/e588a8c946f68523ccc20b1ffef899054da44cdc) Updated repos/melpa
* [`b28f670a`](https://github.com/nix-community/emacs-overlay/commit/b28f670a73c4c434c247daed1519ab5255d88250) Updated flake inputs
* [`25cc11bc`](https://github.com/nix-community/emacs-overlay/commit/25cc11bc1da4b54d6dae2823e0cd1d590eeb1fa6) Updated repos/elpa
* [`e21e1400`](https://github.com/nix-community/emacs-overlay/commit/e21e1400290ad1720eec89bc6b7f7edfa034f19a) Updated repos/emacs
* [`b2224dca`](https://github.com/nix-community/emacs-overlay/commit/b2224dca4b778d6bf0e0b827eee9d122ecf2d125) Updated repos/melpa
* [`96f28387`](https://github.com/nix-community/emacs-overlay/commit/96f28387962e0cbe7a1c861b47411246bd4d5e1b) elisp.nix: add version for default.el package
* [`e04309d1`](https://github.com/nix-community/emacs-overlay/commit/e04309d19514494ae641111c75883c953e518a65) elisp.nix: improve pname of default.le package
* [`3ec6e142`](https://github.com/nix-community/emacs-overlay/commit/3ec6e142fb4f95e5eebcb527ff8bdfd2720a41c2) Updated flake inputs
* [`e0776709`](https://github.com/nix-community/emacs-overlay/commit/e0776709537c54f894092483f72b65fd0f42efe4) Updated repos/elpa
* [`df79d003`](https://github.com/nix-community/emacs-overlay/commit/df79d0032f3b92b9e0b43899bb5b102adebe0751) Updated repos/emacs
* [`17e3463d`](https://github.com/nix-community/emacs-overlay/commit/17e3463ddecf5c59ab2ef2bea4723a7c7fde042f) Updated repos/melpa
* [`a48229b4`](https://github.com/nix-community/emacs-overlay/commit/a48229b413cb78c1d4a1a2dfb52072d1777d600f) Updated repos/nongnu
* [`2f8464e3`](https://github.com/nix-community/emacs-overlay/commit/2f8464e3db2675344bd11c90ca29e0549fd82bde) Updated repos/emacs
* [`055dd50c`](https://github.com/nix-community/emacs-overlay/commit/055dd50c75b05d9008f7e76e9e3b185bce6c45f1) Updated repos/melpa
* [`bb66fc3e`](https://github.com/nix-community/emacs-overlay/commit/bb66fc3e52bff6aa3a1997985c999bd89d20ac36) Updated repos/nongnu
* [`2fd86678`](https://github.com/nix-community/emacs-overlay/commit/2fd86678e7a33f043dd0f3385aa4429fd972dec1) Updated repos/elpa
* [`6209d225`](https://github.com/nix-community/emacs-overlay/commit/6209d225323045477a2fb0910fe486c526192733) Updated repos/emacs
* [`badf38fc`](https://github.com/nix-community/emacs-overlay/commit/badf38fcef05e02764781847ffe498016401e5a5) Updated repos/melpa
* [`c1555251`](https://github.com/nix-community/emacs-overlay/commit/c1555251c5bc7a8ff486271891b99384faa3a62f) Updated repos/elpa
* [`87e7e6a9`](https://github.com/nix-community/emacs-overlay/commit/87e7e6a91c5f065056fbf5b3f0bcb1e457363c5f) Updated repos/emacs
* [`4595bf8d`](https://github.com/nix-community/emacs-overlay/commit/4595bf8d14331aa4f7650445d99d3cee152cf921) Updated repos/melpa
* [`a9bbef37`](https://github.com/nix-community/emacs-overlay/commit/a9bbef37c102aafd6a9247c011f2ae90f3c71b16) Updated repos/nongnu
* [`3ee9b625`](https://github.com/nix-community/emacs-overlay/commit/3ee9b6259e19628bb91632cc2979eb2a3ca0d53e) Updated repos/emacs
* [`8a991ee0`](https://github.com/nix-community/emacs-overlay/commit/8a991ee0e84c21f1a9e85558900a23d17fd86ebc) Updated repos/melpa
* [`8e921c1a`](https://github.com/nix-community/emacs-overlay/commit/8e921c1a525227797dcceff637dff1077a57c223) Updated repos/nongnu
* [`67cc794e`](https://github.com/nix-community/emacs-overlay/commit/67cc794e38f1bacd7e910ae25700297cfe122b58) Updated repos/elpa
* [`63ee207a`](https://github.com/nix-community/emacs-overlay/commit/63ee207a9b728848c54a813da243dc35fabf4b55) Updated repos/emacs
* [`2276b94b`](https://github.com/nix-community/emacs-overlay/commit/2276b94b3d43467372de17708ab3468a5821fcfc) Updated repos/melpa
* [`f0695fd2`](https://github.com/nix-community/emacs-overlay/commit/f0695fd28524a8750948797e44d6ea55ba14c277) Updated flake inputs
* [`dd8d6900`](https://github.com/nix-community/emacs-overlay/commit/dd8d6900f5d674037c80c904ef8a5aeaf7dc9a3d) Updated repos/elpa
* [`caa1559a`](https://github.com/nix-community/emacs-overlay/commit/caa1559ab0a460c78bcfe9d84b70f134226cb66b) Updated repos/emacs
* [`cda419bc`](https://github.com/nix-community/emacs-overlay/commit/cda419bccab17c45d00f200a987d30e9c93c9590) Updated repos/melpa
* [`a362619e`](https://github.com/nix-community/emacs-overlay/commit/a362619e417b203069af72b4aa9c04898e271d67) Updated flake inputs
* [`2d0f7488`](https://github.com/nix-community/emacs-overlay/commit/2d0f74881662ce78e7e81d7216e63aef25c270a6) Updated repos/emacs
* [`7c354859`](https://github.com/nix-community/emacs-overlay/commit/7c354859bf3c9f0e475d3c0f94117b5928ec1a3c) Updated repos/melpa
* [`40fcebc3`](https://github.com/nix-community/emacs-overlay/commit/40fcebc368859916fa886b550d75cc70af106e7b) Updated repos/nongnu
* [`56400bcc`](https://github.com/nix-community/emacs-overlay/commit/56400bccac1fa7ded7e52345660145f9bdfe1c4c) Updated flake inputs
* [`9e6bd8eb`](https://github.com/nix-community/emacs-overlay/commit/9e6bd8ebcbff30a258f55ccff6cd49c2df23ad70) Updated repos/elpa
* [`2ae5dd5b`](https://github.com/nix-community/emacs-overlay/commit/2ae5dd5b8cf58ef4190812c0515151c8f6fe9584) Updated repos/emacs
* [`60b1fbf2`](https://github.com/nix-community/emacs-overlay/commit/60b1fbf240f3daec4d431ef002f084a6cd7564a1) Updated repos/melpa
* [`7d8e7e2e`](https://github.com/nix-community/emacs-overlay/commit/7d8e7e2ede87daff5723eb1a289ed0f414c52f0f) Updated repos/elpa
* [`bf93c44f`](https://github.com/nix-community/emacs-overlay/commit/bf93c44f6282008e2d37aae2b046c9b7cd2a5c27) Updated repos/emacs
* [`42157ddb`](https://github.com/nix-community/emacs-overlay/commit/42157ddb4e4a255d16e6a50a792893cbd1a3098c) Updated repos/melpa
* [`49a58d1c`](https://github.com/nix-community/emacs-overlay/commit/49a58d1c74e0d11660b35e39de5064b6a9b8e46b) Updated repos/emacs
* [`44e23c7e`](https://github.com/nix-community/emacs-overlay/commit/44e23c7e34d2db1aae968e2314bb65a410743c60) Updated repos/melpa
* [`3e6fd7ff`](https://github.com/nix-community/emacs-overlay/commit/3e6fd7ff09f69fb2a2698ed72754988093106a7e) Updated repos/elpa
* [`75585538`](https://github.com/nix-community/emacs-overlay/commit/75585538baf8be7ad06a652e7257201ce3eb676d) Updated repos/emacs
* [`d532507e`](https://github.com/nix-community/emacs-overlay/commit/d532507e854bbfb3f311a9f30dcbffaeceeff83f) Updated repos/melpa
* [`0a11d513`](https://github.com/nix-community/emacs-overlay/commit/0a11d513b3ef0bf5d6c4dadab16e556285ef1b23) Updated repos/elpa
* [`cb506eff`](https://github.com/nix-community/emacs-overlay/commit/cb506effff8359dd1f1e8bb25b7f14748246c8d9) Updated repos/emacs
* [`852a183a`](https://github.com/nix-community/emacs-overlay/commit/852a183aff11700a4ea544cb175d0ad67ab78bc3) Updated repos/melpa
* [`a1e0d360`](https://github.com/nix-community/emacs-overlay/commit/a1e0d3603a09f7c0f24748c18f820b38d660250c) Updated repos/nongnu
* [`da6f2d71`](https://github.com/nix-community/emacs-overlay/commit/da6f2d71fbfbef1fee13bb63fdbdaf7109e7ba62) Updated repos/emacs
* [`a5a0ccee`](https://github.com/nix-community/emacs-overlay/commit/a5a0cceea2af1920bcd6b1ae6d1c4e4f7a2ac229) Updated repos/melpa
* [`865b6c6d`](https://github.com/nix-community/emacs-overlay/commit/865b6c6d2b89b057792ef2ec76402d89631d7c11) Updated flake inputs
* [`966cd565`](https://github.com/nix-community/emacs-overlay/commit/966cd5652fa19276f5c0c619f151ddd08d55c001) Updated repos/elpa
* [`1a5448dc`](https://github.com/nix-community/emacs-overlay/commit/1a5448dc1217f6ac60abb5642eb93325cfc32d15) Updated repos/emacs
* [`fd93bcba`](https://github.com/nix-community/emacs-overlay/commit/fd93bcba17ac65351337668e0b711d27583ce0b4) Updated repos/melpa
* [`677acb34`](https://github.com/nix-community/emacs-overlay/commit/677acb34345aa0a6f2f53cd1c96cbf0de1e4f011) Updated repos/elpa
* [`1d04123e`](https://github.com/nix-community/emacs-overlay/commit/1d04123efb9db2b0404059e542c145d169ec4b38) Updated repos/emacs
* [`844afe34`](https://github.com/nix-community/emacs-overlay/commit/844afe34cbe49d83e7ae016564db4f72237a0bfa) Updated repos/melpa
* [`f87fd033`](https://github.com/nix-community/emacs-overlay/commit/f87fd033970d2a96e998cd0542684797841fd983) Updated flake inputs
* [`8b3222a2`](https://github.com/nix-community/emacs-overlay/commit/8b3222a270a1c147f64907acc9304e74bdd9e817) Updated repos/emacs
* [`b99f00b0`](https://github.com/nix-community/emacs-overlay/commit/b99f00b0bc835dd490b455c8df0bab2acc16021c) Updated repos/melpa
* [`480818d7`](https://github.com/nix-community/emacs-overlay/commit/480818d71dca89456112892d210e3e132f9b4dd3) Updated repos/elpa
* [`48035733`](https://github.com/nix-community/emacs-overlay/commit/4803573315a823fb2155be6237f586d7e112d67f) Updated repos/melpa
* [`f36b068e`](https://github.com/nix-community/emacs-overlay/commit/f36b068e0de24fee824a22ac5ae43a434dfa6e52) Updated repos/elpa
* [`12e00cd9`](https://github.com/nix-community/emacs-overlay/commit/12e00cd9135799e5d242d06cb5052973e888a4cc) Updated repos/emacs
* [`1e357455`](https://github.com/nix-community/emacs-overlay/commit/1e357455afc8b9a4d027a3d4204fee5090f9ebc8) Updated repos/melpa
* [`d39b2ded`](https://github.com/nix-community/emacs-overlay/commit/d39b2ded7ba4c09cb533bdb5f20bcbfb1fb9fcf1) Updated repos/emacs
* [`4d65e731`](https://github.com/nix-community/emacs-overlay/commit/4d65e731b6c3891445cdd80ad0c3c94f7955b039) Updated repos/melpa
* [`389e2bb8`](https://github.com/nix-community/emacs-overlay/commit/389e2bb8464805f2172f1d28e123772c90b71ba9) Updated repos/elpa
* [`6c42e237`](https://github.com/nix-community/emacs-overlay/commit/6c42e23739b535610f0215da4562612511a662ed) Updated repos/emacs
* [`918199ae`](https://github.com/nix-community/emacs-overlay/commit/918199aeaa2c9b9d0f73e304a187a05b99fd9050) Updated repos/melpa
* [`fa24d4f9`](https://github.com/nix-community/emacs-overlay/commit/fa24d4f9e82373e0b049a189b3b73fdad025b2f4) Updated repos/elpa
* [`15a70c95`](https://github.com/nix-community/emacs-overlay/commit/15a70c955aae1d0ed0f7e910e1f80ab47411e947) Updated repos/emacs
* [`da471a2c`](https://github.com/nix-community/emacs-overlay/commit/da471a2c6e368f2950f1491d21dfb873b8e8474d) Updated repos/melpa
* [`d46176b7`](https://github.com/nix-community/emacs-overlay/commit/d46176b7a377be68dfc73c72e0d4411429f28af6) Updated flake inputs
* [`d337b424`](https://github.com/nix-community/emacs-overlay/commit/d337b42484d8870187d7af66d78b7d1634a4812a) Updated repos/emacs
* [`02592572`](https://github.com/nix-community/emacs-overlay/commit/02592572580285c9930aae5c6503b7396694f54d) Updated repos/melpa
* [`a600dd5e`](https://github.com/nix-community/emacs-overlay/commit/a600dd5e1af89a6a6f0b7124e9b08f2906da2f4d) Updated repos/elpa
* [`8025128b`](https://github.com/nix-community/emacs-overlay/commit/8025128bdbd073959a5117108aae6203e4f57859) Updated repos/emacs
* [`90182afc`](https://github.com/nix-community/emacs-overlay/commit/90182afcb4fdb564a653959a8a2d818714e115fb) Updated repos/melpa
* [`3bfa9b49`](https://github.com/nix-community/emacs-overlay/commit/3bfa9b49784a7ab06eff13bbe00ad113463b6ce1) Updated flake inputs
* [`221c84d8`](https://github.com/nix-community/emacs-overlay/commit/221c84d8e1c39493d346156c7dd691bf0894f79d) Updated repos/elpa
* [`17ccac7c`](https://github.com/nix-community/emacs-overlay/commit/17ccac7c829aa5c813d56d345982c76ea63c5c7d) Updated repos/emacs
* [`09dcac84`](https://github.com/nix-community/emacs-overlay/commit/09dcac84503438c493cc9dd89133812ad4cd56cb) Updated repos/melpa
* [`64b05ab3`](https://github.com/nix-community/emacs-overlay/commit/64b05ab33999b6dbe0ef96d2b864f5ae86bb15f9) Updated repos/nongnu
* [`e99d7455`](https://github.com/nix-community/emacs-overlay/commit/e99d7455e1e97867fdbce7833a8082dbf6db947b) Updated repos/emacs
* [`a2f3aa88`](https://github.com/nix-community/emacs-overlay/commit/a2f3aa88ca33c18c3d0601d17a83005d02d68a2d) Updated repos/melpa
* [`0b8cb044`](https://github.com/nix-community/emacs-overlay/commit/0b8cb0442f66eb4c0794027e01e9353e8a56e535) Updated repos/elpa
* [`ded7f657`](https://github.com/nix-community/emacs-overlay/commit/ded7f65789c7947de345b5841fb510549e29fb40) Updated repos/emacs
* [`058738a9`](https://github.com/nix-community/emacs-overlay/commit/058738a9f775d36eba4c98c6bb1f8dcccc2c4d0d) Updated repos/melpa
* [`a3d0aa99`](https://github.com/nix-community/emacs-overlay/commit/a3d0aa995278692977354f6bcd77d84c928212e2) Updated repos/elpa
* [`aa8b5b40`](https://github.com/nix-community/emacs-overlay/commit/aa8b5b40fa14de118c4aa6537acde3548017814d) Updated repos/emacs
* [`75f353b4`](https://github.com/nix-community/emacs-overlay/commit/75f353b459cda9fc4143da18ece3320920c1cfc1) Updated repos/melpa
* [`2b2087a9`](https://github.com/nix-community/emacs-overlay/commit/2b2087a9164ed16c72456f7f3e06495ab358c074) Updated repos/emacs
* [`2c1b7d3f`](https://github.com/nix-community/emacs-overlay/commit/2c1b7d3f7338992d737f8bff5d2325b67f4d8b56) Updated repos/melpa
* [`7e26d097`](https://github.com/nix-community/emacs-overlay/commit/7e26d097d352f41e00fcc225529292843283010c) Updated repos/nongnu
* [`6f58040d`](https://github.com/nix-community/emacs-overlay/commit/6f58040df928cb39590a23690ae0a2599e6d1c25) Updated repos/elpa
* [`466a200c`](https://github.com/nix-community/emacs-overlay/commit/466a200c1b1dbb8756e37c5dac522bfa0a77799d) Updated repos/emacs
* [`4662917a`](https://github.com/nix-community/emacs-overlay/commit/4662917ab91fa7140b2d90aaead9f1c9d2bbdda5) Updated repos/melpa
* [`3b7180ef`](https://github.com/nix-community/emacs-overlay/commit/3b7180ef6df579d3e313dfc21bc6ec04e29cae54) Updated flake inputs
* [`43eef180`](https://github.com/nix-community/emacs-overlay/commit/43eef180576a34c22e4dac3728eb1fe83ca88912) Updated repos/elpa
* [`7408d246`](https://github.com/nix-community/emacs-overlay/commit/7408d246b6277a5242de2f3f2ca9a1fd606256b2) Updated repos/emacs
* [`ba7e09b5`](https://github.com/nix-community/emacs-overlay/commit/ba7e09b5699524e7eb0e157f75456bbf2dfecb33) Updated repos/melpa
* [`c8b16cbc`](https://github.com/nix-community/emacs-overlay/commit/c8b16cbc2dca35a619d513487be8c939d83b9869) Updated repos/nongnu
* [`3f4de408`](https://github.com/nix-community/emacs-overlay/commit/3f4de4086b6a6a8c18d404e03cbb15b472031f1b) Updated repos/emacs
* [`c724333b`](https://github.com/nix-community/emacs-overlay/commit/c724333b2d3235b01101d62908ed1d43d18ac515) Updated repos/melpa
* [`c79cb9a9`](https://github.com/nix-community/emacs-overlay/commit/c79cb9a91b9d0b251f91628f171fd45765be6605) Updated repos/elpa
* [`82acb54a`](https://github.com/nix-community/emacs-overlay/commit/82acb54af089e147adb1cd0ce640bd1eea42d65a) Updated repos/emacs
* [`88b2f014`](https://github.com/nix-community/emacs-overlay/commit/88b2f01437587ee4ffb2bf4a866cf731f05fe270) Updated repos/melpa
* [`8f241476`](https://github.com/nix-community/emacs-overlay/commit/8f241476c2088beedbb28400e100bc2edee89331) Updated repos/elpa
* [`7766f0c1`](https://github.com/nix-community/emacs-overlay/commit/7766f0c176748b8a5c26579e06c626ac9c2bf3ae) Updated repos/emacs
* [`56689381`](https://github.com/nix-community/emacs-overlay/commit/56689381ea01e234a5ac331227002fbf22b794f3) Updated repos/melpa
* [`7f5e241f`](https://github.com/nix-community/emacs-overlay/commit/7f5e241fec8046e55c27f3bb06c077d61e61d985) Updated flake inputs
* [`981ebc68`](https://github.com/nix-community/emacs-overlay/commit/981ebc687900a6253ba5af9c9a78755e0e1c6d1e) Updated repos/emacs
* [`32cf0314`](https://github.com/nix-community/emacs-overlay/commit/32cf0314159f4b2eb85970483124e7df730e3413) Updated repos/melpa
* [`b13ebf36`](https://github.com/nix-community/emacs-overlay/commit/b13ebf36c5f6e474a4a72c377f13570ed90a3497) Updated repos/elpa
* [`6c9b7336`](https://github.com/nix-community/emacs-overlay/commit/6c9b73360f6df363192a6c6e91923c166a7c46b7) Updated repos/emacs
* [`aee5e8a4`](https://github.com/nix-community/emacs-overlay/commit/aee5e8a427c8a942458d2bad7b97cbad30b75aec) Updated repos/melpa
* [`a75f68b8`](https://github.com/nix-community/emacs-overlay/commit/a75f68b8e2ca8197b8349d59020051a410ecb462) Updated repos/elpa
* [`6ac47686`](https://github.com/nix-community/emacs-overlay/commit/6ac47686676d3b3447cf9fce39702706fd6349a1) Updated repos/emacs
* [`4400a216`](https://github.com/nix-community/emacs-overlay/commit/4400a216f0f6970dc8e9c6fd9917efd3c34978b7) Updated repos/melpa
* [`961ca255`](https://github.com/nix-community/emacs-overlay/commit/961ca255c7a1016667f1515f236008785064321a) Updated repos/nongnu
* [`866ccd1c`](https://github.com/nix-community/emacs-overlay/commit/866ccd1c578a2d3e94d7bfe6bd20bbf4ed98fa90) Updated repos/emacs
* [`8013106f`](https://github.com/nix-community/emacs-overlay/commit/8013106f71c73c162e484c78eaa410479d8ac767) Updated repos/melpa
* [`a8b7b06b`](https://github.com/nix-community/emacs-overlay/commit/a8b7b06b6c6f47cbad4d7396188d6083eddaa13d) Updated repos/nongnu
* [`fd440ec3`](https://github.com/nix-community/emacs-overlay/commit/fd440ec31aaca97a9bace0fdf40520a57105b6e9) Updated repos/elpa
* [`6100bd42`](https://github.com/nix-community/emacs-overlay/commit/6100bd42be9243340f98c125c8231a7a90f10875) Updated repos/emacs
* [`5359ead9`](https://github.com/nix-community/emacs-overlay/commit/5359ead9b36cc845578ad5e9b63164258b0baf9e) Updated repos/melpa
* [`af50b85b`](https://github.com/nix-community/emacs-overlay/commit/af50b85bf45fcd1727dd9cffc0af8095e9ae4be1) Updated repos/elpa
* [`0459b75e`](https://github.com/nix-community/emacs-overlay/commit/0459b75eedf119ecd319290c8069b5d31602e298) Updated repos/emacs
* [`7c79408f`](https://github.com/nix-community/emacs-overlay/commit/7c79408fdb61af5fa209410fd44572458a75823d) Updated repos/melpa
* [`22d79486`](https://github.com/nix-community/emacs-overlay/commit/22d79486d74da1f76739ad690543e5f912f4cb91) Updated repos/nongnu
* [`d0fe459c`](https://github.com/nix-community/emacs-overlay/commit/d0fe459c0e66ad8db48cd837043882107fc48199) Updated repos/emacs
* [`e6b40dbd`](https://github.com/nix-community/emacs-overlay/commit/e6b40dbd73e82668ed06d4a1ee91f39fd2ffead3) Updated repos/melpa
* [`a754c0bc`](https://github.com/nix-community/emacs-overlay/commit/a754c0bcd29dc7bac6559e968513618030142aa3) Updated flake inputs
* [`857b18a8`](https://github.com/nix-community/emacs-overlay/commit/857b18a802c1e3a1410376131fc2469ce26e5299) Updated repos/elpa
* [`b55e8195`](https://github.com/nix-community/emacs-overlay/commit/b55e819525b4771c8ea3e1607475ccb66487488f) Updated repos/emacs
* [`d4134054`](https://github.com/nix-community/emacs-overlay/commit/d4134054da75ace5ed3aa9d69af93e44f7aa02a3) Updated repos/melpa
* [`27ee1c63`](https://github.com/nix-community/emacs-overlay/commit/27ee1c63e562bfe1655432ce4dd0124fc9e8b7d7) Updated repos/nongnu
* [`13d782b6`](https://github.com/nix-community/emacs-overlay/commit/13d782b620415584ac459c1ea2038e21bc4c2678) Updated repos/elpa
* [`b973c5f4`](https://github.com/nix-community/emacs-overlay/commit/b973c5f418ceaff006f5bfb5cec282a56b4e4843) Updated repos/emacs
* [`46540317`](https://github.com/nix-community/emacs-overlay/commit/4654031722ea5daef38eb9849ad92dedf58ce50f) Updated repos/melpa
* [`96515262`](https://github.com/nix-community/emacs-overlay/commit/965152624606d9cde16037e070070fa19955292c) Updated repos/nongnu
* [`de7bdcff`](https://github.com/nix-community/emacs-overlay/commit/de7bdcff3945af5a7fd1d46db5da36cfc20ebb10) Updated repos/emacs
* [`6250aed8`](https://github.com/nix-community/emacs-overlay/commit/6250aed868aca06b750f326aebb5542595a06bb6) Updated repos/melpa
* [`78058576`](https://github.com/nix-community/emacs-overlay/commit/78058576a4239866757c497434b380e4130e654d) Updated flake inputs
* [`43e15ec4`](https://github.com/nix-community/emacs-overlay/commit/43e15ec4730567daf68b0e30d96a010f4d1a4d96) Updated repos/elpa
* [`ebcee24d`](https://github.com/nix-community/emacs-overlay/commit/ebcee24d43975e5357c9b882a9333a5cf54567e3) Updated repos/emacs
* [`993e836c`](https://github.com/nix-community/emacs-overlay/commit/993e836cb642e2e9439cd9588866ebfe602bd96d) Updated repos/melpa
* [`29b881a5`](https://github.com/nix-community/emacs-overlay/commit/29b881a58b0315f186dacdfe810f64fb80fedcda) Updated repos/elpa
* [`1e235371`](https://github.com/nix-community/emacs-overlay/commit/1e2353718dae536f38b7ae79d355fc99d82ee48f) Updated repos/emacs
* [`dec44849`](https://github.com/nix-community/emacs-overlay/commit/dec44849139d56e2f33abd886de76b33272cfe49) Updated repos/melpa
* [`8c25f714`](https://github.com/nix-community/emacs-overlay/commit/8c25f71493cef83a6d41d8f46dc93bf3b5791c34) Updated repos/nongnu
* [`1a4a1b7f`](https://github.com/nix-community/emacs-overlay/commit/1a4a1b7fdeb5126e7273f036517f1cd926b756f8) Updated repos/emacs
* [`c37e82e1`](https://github.com/nix-community/emacs-overlay/commit/c37e82e1b2a1b88679e823518a746e1f6fd85833) Updated repos/melpa
* [`d073b90d`](https://github.com/nix-community/emacs-overlay/commit/d073b90d4942257caa847becd802875391daadf5) Updated repos/nongnu
* [`92e70b93`](https://github.com/nix-community/emacs-overlay/commit/92e70b93e626500314d86e96d29b2a99c06200f3) Updated flake inputs
* [`153d4bd9`](https://github.com/nix-community/emacs-overlay/commit/153d4bd9c5d96988d0befcd9ca59d2aea51b920f) Updated repos/elpa
* [`c8624745`](https://github.com/nix-community/emacs-overlay/commit/c8624745507e9450246bcbcf8bd048371402ab3f) Updated repos/emacs
* [`e668440b`](https://github.com/nix-community/emacs-overlay/commit/e668440b43285b0da87a2b635aceabc5b8a04d71) Updated repos/melpa
* [`f8b9c452`](https://github.com/nix-community/emacs-overlay/commit/f8b9c45255b423c13d55bbbde9040b6b83f87e7e) Updated flake inputs
* [`9868564a`](https://github.com/nix-community/emacs-overlay/commit/9868564a5c35849d2acc6386a23e17c0d64cb809) Updated repos/elpa
* [`9d5abaad`](https://github.com/nix-community/emacs-overlay/commit/9d5abaad6bac8b1281e438fe82ad6a1605d45224) Updated repos/emacs
* [`793361e0`](https://github.com/nix-community/emacs-overlay/commit/793361e03fd91716e79ee4ccf253c86fec4b8ccf) Updated repos/melpa
* [`56c89573`](https://github.com/nix-community/emacs-overlay/commit/56c895734daee7a0535b6341635ffab30bdd758f) Updated repos/nongnu
* [`89f5f943`](https://github.com/nix-community/emacs-overlay/commit/89f5f9436186e89409282ad36efc7beb1ec3b838) Updated repos/emacs
* [`5a8b611e`](https://github.com/nix-community/emacs-overlay/commit/5a8b611e684b5299b6c782b5d022d86610accd7d) Updated repos/melpa
* [`12046672`](https://github.com/nix-community/emacs-overlay/commit/120466726bee4aaaa344f394cd8108898fa79265) Updated flake inputs
* [`53bba0c7`](https://github.com/nix-community/emacs-overlay/commit/53bba0c75fb233e41f774f4cf40b166a81ed7b09) Updated repos/elpa
* [`2e6c0cc5`](https://github.com/nix-community/emacs-overlay/commit/2e6c0cc53a944bd1d335ac7fd608be314309599e) Updated repos/emacs
* [`1a83f945`](https://github.com/nix-community/emacs-overlay/commit/1a83f945d03576aa6f160136f0ff6094ed6fed34) Updated repos/melpa
* [`77cac135`](https://github.com/nix-community/emacs-overlay/commit/77cac1359ae49dc811b098ef79dd9572055e29cd) Updated repos/elpa
* [`b969676c`](https://github.com/nix-community/emacs-overlay/commit/b969676c6f06a795bd7e55e2b31c691b14717c0f) Updated repos/emacs
* [`5f0b496a`](https://github.com/nix-community/emacs-overlay/commit/5f0b496aa00886a17cf42faa94dce57e0f7ab20c) Updated repos/melpa
* [`3495b58e`](https://github.com/nix-community/emacs-overlay/commit/3495b58e97e9c124c070974c240b9c181133ee7f) Updated flake inputs
* [`137c9c6b`](https://github.com/nix-community/emacs-overlay/commit/137c9c6b2791ba61af8ca6e889b5f079db0302c7) Updated repos/emacs
* [`417fb22d`](https://github.com/nix-community/emacs-overlay/commit/417fb22dd4f7e3a36185675a801f2ab687b762c7) Updated repos/melpa
* [`f5276446`](https://github.com/nix-community/emacs-overlay/commit/f52764468eeaa05affd95c9b9236bb0e2dbf2555) Updated repos/nongnu
* [`564f10b3`](https://github.com/nix-community/emacs-overlay/commit/564f10b3d0bf2b8a654cc882f835e14e41e9a666) Updated repos/elpa
* [`267403ea`](https://github.com/nix-community/emacs-overlay/commit/267403ea06d2fd17b25f12bd9a4e7c7d9f2dc920) Updated repos/emacs
* [`d1a316b5`](https://github.com/nix-community/emacs-overlay/commit/d1a316b529df678413ba05c970c0c9bdcb6c0d37) Updated repos/melpa
* [`d9451a59`](https://github.com/nix-community/emacs-overlay/commit/d9451a5960c6579350cfacb48157511ef189fa6f) Updated repos/elpa
* [`6c91a132`](https://github.com/nix-community/emacs-overlay/commit/6c91a13299501344a571b7b8f03b91574761c2d2) Updated repos/emacs
* [`bcb0cc66`](https://github.com/nix-community/emacs-overlay/commit/bcb0cc6626d0e79ff188c30cad72f52692c1048d) Updated repos/melpa
* [`16ee19ac`](https://github.com/nix-community/emacs-overlay/commit/16ee19acf5814f52dd15e4c9a5746300792514c3) Updated repos/emacs
* [`46b20ea5`](https://github.com/nix-community/emacs-overlay/commit/46b20ea5a73cd14d0d657482f5bc2bbaed51b100) Updated repos/melpa
* [`33a110d0`](https://github.com/nix-community/emacs-overlay/commit/33a110d0702c6be0c19300a400c252a15ac4b077) Updated repos/elpa
* [`89d3c18a`](https://github.com/nix-community/emacs-overlay/commit/89d3c18ab7b1c8c82988963e9c899818d7238530) Updated repos/emacs
* [`83f62558`](https://github.com/nix-community/emacs-overlay/commit/83f62558d3f1893b39f1d9ba4743e68ff686e175) Updated repos/melpa
* [`bca27e2c`](https://github.com/nix-community/emacs-overlay/commit/bca27e2c4357d43f5341d7be6f948d812974b406) Updated flake inputs
* [`339d2749`](https://github.com/nix-community/emacs-overlay/commit/339d2749956728f28faea2802f017eb5adb2905d) Updated repos/elpa
* [`ae922112`](https://github.com/nix-community/emacs-overlay/commit/ae922112b4bc3b057f140c2034a058ebfdff790a) Updated repos/emacs
* [`1ed073b9`](https://github.com/nix-community/emacs-overlay/commit/1ed073b93b1683386f8b5570bb184ae4571acdf8) Updated repos/melpa
* [`7b4ab613`](https://github.com/nix-community/emacs-overlay/commit/7b4ab613acffae47fd39dc1977d282e5fbdcf147) Updated repos/nongnu
* [`6327ed2e`](https://github.com/nix-community/emacs-overlay/commit/6327ed2edf881db9cd85a5a378d2c38b75fa76b2) Updated repos/emacs
* [`f69f384c`](https://github.com/nix-community/emacs-overlay/commit/f69f384ca636e905e54d60ea59b0f47e6aa43a0c) Updated repos/melpa
* [`e49d4559`](https://github.com/nix-community/emacs-overlay/commit/e49d4559d74ffebee805abaf095bd988d2edb280) Updated repos/elpa
* [`5483c49a`](https://github.com/nix-community/emacs-overlay/commit/5483c49a377c93fe1f7cb675801dd5eb41659d2a) Updated repos/emacs
* [`7d102cbd`](https://github.com/nix-community/emacs-overlay/commit/7d102cbd9fb40fcfc4ee9145c0bff9c29f507c2f) Updated repos/melpa
* [`10f15ca7`](https://github.com/nix-community/emacs-overlay/commit/10f15ca7346d387069ad85cda1ec3dc671eddc93) Updated repos/elpa
* [`c3f89991`](https://github.com/nix-community/emacs-overlay/commit/c3f89991189752a91a09b60715d8e1f487c85673) Updated repos/emacs
* [`5cd2d18e`](https://github.com/nix-community/emacs-overlay/commit/5cd2d18e49c20e9a1ac02dcd7c96899f7ab3867a) Updated repos/melpa
* [`65957eda`](https://github.com/nix-community/emacs-overlay/commit/65957eda7abfdf4d64accd7562fa84e272bb1829) Updated repos/nongnu
* [`dd15f47a`](https://github.com/nix-community/emacs-overlay/commit/dd15f47adcd1b6c9c089cb4267dfefa9a153de97) Updated repos/emacs
* [`7f45bea1`](https://github.com/nix-community/emacs-overlay/commit/7f45bea11d98f9f542bcdeadeeaa33472c1224e2) Updated repos/melpa
* [`ecfd9381`](https://github.com/nix-community/emacs-overlay/commit/ecfd9381b0bbaa06bf992fd7951b1e1e12eac936) Updated flake inputs
* [`49c6c177`](https://github.com/nix-community/emacs-overlay/commit/49c6c1776f5868115cdf85f69cb83a6cd044eeb3) Updated repos/elpa
* [`ef992bca`](https://github.com/nix-community/emacs-overlay/commit/ef992bca01ef97e8bbd1136693d24665390f39ce) Updated repos/melpa
* [`39fb8ab9`](https://github.com/nix-community/emacs-overlay/commit/39fb8ab905f7ea939596b81d9ab080d337735f6d) Updated flake inputs
* [`e92c05be`](https://github.com/nix-community/emacs-overlay/commit/e92c05be6950bd466c9d469b20139b9664d20339) Updated repos/elpa
* [`f32c6288`](https://github.com/nix-community/emacs-overlay/commit/f32c6288cc50298c04a86364e5947c28981c2f7d) Updated repos/emacs
* [`c530e2d5`](https://github.com/nix-community/emacs-overlay/commit/c530e2d5bf52bfbfacbb55d146e47f89d6e50bc6) Updated repos/emacs
* [`ec14828e`](https://github.com/nix-community/emacs-overlay/commit/ec14828ed25f48db0c94f49d29ebe1a455a5a58c) Updated repos/melpa
* [`11b1dc12`](https://github.com/nix-community/emacs-overlay/commit/11b1dc12267a6d02ae74cd1cdfeeea41bc4a7d25) Updated repos/elpa
* [`9c4a1eb0`](https://github.com/nix-community/emacs-overlay/commit/9c4a1eb0f410dcb312b0f0bee3db246628a8cf48) Updated repos/emacs
* [`a3807ae3`](https://github.com/nix-community/emacs-overlay/commit/a3807ae37389f6effb13e30cc12933cfdd325d80) Updated repos/melpa
* [`28901d49`](https://github.com/nix-community/emacs-overlay/commit/28901d491eff866b2dd60901061a11c8b087589c) Updated repos/elpa
* [`fde36a82`](https://github.com/nix-community/emacs-overlay/commit/fde36a82921c45a7ceb2b381c7df40f4a331bf6f) Updated repos/emacs
* [`eb779447`](https://github.com/nix-community/emacs-overlay/commit/eb77944798e364a4030aa7eb6ee54023d42ebf1f) Updated repos/melpa
* [`db6c96d7`](https://github.com/nix-community/emacs-overlay/commit/db6c96d74eb0e60e7e344e81a56b33390e33474d) Updated repos/nongnu
* [`51291b4c`](https://github.com/nix-community/emacs-overlay/commit/51291b4c1d10902528ac26f05e61c3631ecb5800) Updated repos/emacs
* [`2987da8f`](https://github.com/nix-community/emacs-overlay/commit/2987da8f34f6f17ebfaf17ea1494498d2317f8f8) Updated repos/melpa
* [`e9fcd775`](https://github.com/nix-community/emacs-overlay/commit/e9fcd7753afabc19f5987d82759afe218d3bc70b) Updated repos/nongnu
* [`7f325c66`](https://github.com/nix-community/emacs-overlay/commit/7f325c66ddf7b2297386238af3dbf556e8826075) Updated repos/elpa
* [`45d7c2af`](https://github.com/nix-community/emacs-overlay/commit/45d7c2af760a90ca776210ba5b75f085ccea63f3) Updated repos/emacs
* [`a8239b33`](https://github.com/nix-community/emacs-overlay/commit/a8239b33859352caabc400e051c649481f4a02b2) Updated repos/melpa
