### PR TITLE
niv doomemacs: update 7a750304 -> 844a82c4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "7a7503045850ea83f205de6e71e6d886187f4a22",
-        "sha256": "1pxw6nvl84ywbp0j3x4wcrjw61j414rhzwf6ln7dg0yy1r0z7yx7",
+        "rev": "844a82c4a0cacbb5a1aa558c88675ba1a9ee80a3",
+        "sha256": "06g9rn12xdynbfx1gv7p82i50l64apm6gfypjih24kcz6fairw2r",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/7a7503045850ea83f205de6e71e6d886187f4a22.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/844a82c4a0cacbb5a1aa558c88675ba1a9ee80a3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@7a750304...844a82c4](https://github.com/doomemacs/doomemacs/compare/7a7503045850ea83f205de6e71e6d886187f4a22...844a82c4a0cacbb5a1aa558c88675ba1a9ee80a3)

* [`41f31ba9`](https://github.com/doomemacs/doomemacs/commit/41f31ba9ce406c057732b9788a6d756953b9d759) fix(snippets): fix snippet uuid completion
* [`46433762`](https://github.com/doomemacs/doomemacs/commit/464337626852d5462f61d3456b02255bf05e0757) fix(snippets): fix +snippets/new and +snippets/new-alias file creation
* [`36370674`](https://github.com/doomemacs/doomemacs/commit/363706744d72f11e3ac6de3a178ed56f2fd45480) feat(snippets): select mode for new snippet
* [`406594b9`](https://github.com/doomemacs/doomemacs/commit/406594b9af87bc0faae191161950887eaee65486) refactor(snippets): use cond instead of nested if
* [`9c2d50d9`](https://github.com/doomemacs/doomemacs/commit/9c2d50d97e88587b419ad4881c1c62a6b71817ff) nit: fix docstrings
* [`b84403a9`](https://github.com/doomemacs/doomemacs/commit/b84403a9faccb81f485b8fa19b96571b84026469) nit: remove superfluous package cookies
* [`034da906`](https://github.com/doomemacs/doomemacs/commit/034da90693774346fea587e39e43788b6ed1903f) refactor(eshell): remove wait for esh-module
* [`b261afe5`](https://github.com/doomemacs/doomemacs/commit/b261afe59ddba705bd38c9cd0d3aedab904dd2be) fix(org): use file URI for org-re-reveal-root
* [`3d82e3d4`](https://github.com/doomemacs/doomemacs/commit/3d82e3d46ded0365463273bcb80487b689ca1016) fix(vertico): gate which-key integration
* [`d5f86f17`](https://github.com/doomemacs/doomemacs/commit/d5f86f179f0a0900d355c1f3c3e03e7004bda7e4) tweak(default): add multi-buffer imenu commands
* [`088bd387`](https://github.com/doomemacs/doomemacs/commit/088bd387f6c901273ad166b67a14bf1745026c4f) tweak(lib): add alpha-background support to opacity setter
* [`62074bfc`](https://github.com/doomemacs/doomemacs/commit/62074bfcbb7f332ca8aa123f1a4828a5e3ba98e7) tweak(emoji): add emoji-search binding for Emacs 29
* [`20393c70`](https://github.com/doomemacs/doomemacs/commit/20393c707488c47df5bd755ec9032bd098d29b1f) feat(default): add use consult-man if available
* [`3cafa022`](https://github.com/doomemacs/doomemacs/commit/3cafa0223e5327e5b75e93fd6b567d404cbaf3c3) fix(org): check org-fold-outline in invisible property
* [`0e8f458d`](https://github.com/doomemacs/doomemacs/commit/0e8f458d99955f83fccd14ee405fcf701047eeca) fix(popup): add wdired hacks
* [`f4e74e17`](https://github.com/doomemacs/doomemacs/commit/f4e74e17ade41e8cb2daa48b8bec6623c58a72c3) fix(lib): doom/help-packages: handle missing homepage
* [`a23e0210`](https://github.com/doomemacs/doomemacs/commit/a23e021032121bd825197b37b7879daf8bf68189) tweak(irc): check circe-notifications is bound
* [`42d5fd83`](https://github.com/doomemacs/doomemacs/commit/42d5fd83504f8aa80f3248036006fbcd49222943) docs(irc): add circe notification warning
* [`5be4517b`](https://github.com/doomemacs/doomemacs/commit/5be4517bca5a59ad15f5b55f63ac43b50d5440f8) refactor(vertico): consult-dir: drop dependence on docker-tramp
* [`43467ba4`](https://github.com/doomemacs/doomemacs/commit/43467ba4b915dbaa1b7bc8d0b84ee6a2809ea154) fix(chinese): void-function pyim-cregexp-ivy error
* [`d94fce55`](https://github.com/doomemacs/doomemacs/commit/d94fce553b5c840138d9afa413cc7021aa1c7934) dev(ci): replace add-to-project workflow
* [`f811e4fa`](https://github.com/doomemacs/doomemacs/commit/f811e4fa4965f0cf1cc75b5bc07ca3e55dc22471) dev: update supported Emacs version in issue template
* [`9cc9351c`](https://github.com/doomemacs/doomemacs/commit/9cc9351cae8096115d72ff17b354d8b5cdf50957) feat(file-templates): add c-mode/__main.c
* [`25602409`](https://github.com/doomemacs/doomemacs/commit/25602409b625635c519b4249aea83661c777467a) refactor(file-templates): c++-mode/__main.cpp: modernize
* [`3a01faed`](https://github.com/doomemacs/doomemacs/commit/3a01faed49f12c491d9bf499f0532e9660caafc6) feat(fortran): `SPC m f o` opens project config
* [`ca9f84d6`](https://github.com/doomemacs/doomemacs/commit/ca9f84d664b5c89ed3e4214ce8d246e796244d4e) fix(evil): add evil-embrace support for c++-ts-mode
* [`bef076b6`](https://github.com/doomemacs/doomemacs/commit/bef076b65597ff4658b17369804fcb5508de527f) bump: :editor evil
* [`56d396c5`](https://github.com/doomemacs/doomemacs/commit/56d396c5f6730f971deeb3d9cab5c3a1acb9ec9d) release(modules): 23.09.0-dev
* [`d8e16db6`](https://github.com/doomemacs/doomemacs/commit/d8e16db60579f1fd9a8a1f9ce6a7cc6d6e964618) fix(emacs-lisp): Doom API demos in help(ful) docs
* [`c1b0326c`](https://github.com/doomemacs/doomemacs/commit/c1b0326ce72b7df185596daf5ba8f0ac836b42b6) bump: :core
* [`deb83dc6`](https://github.com/doomemacs/doomemacs/commit/deb83dc6a91e9bc24b8569e7ea1ae7ef2b4b7b66) fix(lib): doom-docs-mode: hiding property drawers
* [`75d40468`](https://github.com/doomemacs/doomemacs/commit/75d4046820957401a2561e53dc935ad27e2b52ea) fix(lib): doom/reload-docs: `org-id-get' warnings
* [`7f3d5d54`](https://github.com/doomemacs/doomemacs/commit/7f3d5d54bd502099d19970160c230be790cf54d8) refactor(lib): hoist new org-id-locations-file value
* [`a7123bf6`](https://github.com/doomemacs/doomemacs/commit/a7123bf65f03032be16d63ee7b9c06b91a133073) fix: write native-comp cache to $EMACSLOCALDIR
* [`f427c8a3`](https://github.com/doomemacs/doomemacs/commit/f427c8a30ed6d90c30c816f2b55c4933690325d1) tweak: scroll-conservatively = 10
* [`d8372b6e`](https://github.com/doomemacs/doomemacs/commit/d8372b6e2d58c10d52ebb5112d7a8576e1ebe5ee) fix(popup): +popup/raise: recursive popup
* [`a44e8d6b`](https://github.com/doomemacs/doomemacs/commit/a44e8d6bfd06e8746030eb1f2e6d3a200a2f4682) nit: general reformatting & minor comment revision
* [`46d7404b`](https://github.com/doomemacs/doomemacs/commit/46d7404befcdf5a69cc164fe448ac75bd9b9b598) refactor!(ligatures): use ligature.el for Emacs28+
* [`20cdba39`](https://github.com/doomemacs/doomemacs/commit/20cdba39a8207d170640853a9c1a2bacc9b368df) fix(evil): more reliable window detection
* [`2a73bb4e`](https://github.com/doomemacs/doomemacs/commit/2a73bb4e7c82ea851d55dc7ab31337d93a3eb265) bump: :ui treemacs
* [`fd98b44e`](https://github.com/doomemacs/doomemacs/commit/fd98b44e6a71a6ac43580a059d66b0327a95c99d) tweak(workspaces): prefill current name on rename
* [`dababf9a`](https://github.com/doomemacs/doomemacs/commit/dababf9ae99382bcb2f3f7c06257925f5ab91961) feat(php): doctor: rudimentary php & composer checks
* [`95a5a32a`](https://github.com/doomemacs/doomemacs/commit/95a5a32aacb1a66b281823f6fe44129d2b6cff92) docs: expand multiple/non-standard config checks
* [`447b59c9`](https://github.com/doomemacs/doomemacs/commit/447b59c9c06dbb9fb9cec1e57f1d10c3c3049107) docs: properly indent core doctor checks
* [`69cedebf`](https://github.com/doomemacs/doomemacs/commit/69cedebfdac25807fa1b916805434a3ccc6c8b70) docs: add fish shell check
* [`89421f01`](https://github.com/doomemacs/doomemacs/commit/89421f018be70d0a6c34009ce461a56b202b637c) bump: :app rss
* [`0f0fade3`](https://github.com/doomemacs/doomemacs/commit/0f0fade3c028dafea56bd9ca45f0e6b57af4f5db) fix(layout): bepo: void-variable org-capture-mode-map error
* [`8e671f49`](https://github.com/doomemacs/doomemacs/commit/8e671f494d5dd4906d8f2715364ec7ccd0ad34cf) fix(emacs-lisp): failure to look up module docs
* [`af8ec870`](https://github.com/doomemacs/doomemacs/commit/af8ec870acf2500389e06151e8ab015e00118acc) fix(lib): 'back to *' links in doom-docs
* [`261f94c7`](https://github.com/doomemacs/doomemacs/commit/261f94c768aa986284c6c9b55be101e418ab9b10) bump: :tools
* [`7acb6728`](https://github.com/doomemacs/doomemacs/commit/7acb67285c58f99cac72337e975286aba5ca540e) dev: shell.nix: add emacs 29, 30.0.50, & CI versions
* [`f26b038e`](https://github.com/doomemacs/doomemacs/commit/f26b038ec3aae2c10123d05c1571c2280bdfef99) fix: prevent quit in the middle of doom/escape
* [`7bdf7cf7`](https://github.com/doomemacs/doomemacs/commit/7bdf7cf7c0bbaa76d983ef8930bfe90cd3c8a85e) refactor: doom-guess-mode-h: return non-nil on success
* [`4ecd616c`](https://github.com/doomemacs/doomemacs/commit/4ecd616cd8f60640d6b0be2ffc3d762e88099bb4) refactor(format): replace with apheleia
* [`115bfc52`](https://github.com/doomemacs/doomemacs/commit/115bfc52a2227b2d1cd0fd2976f594afb42e2781) fix(format): correctly adjust shfmt
* [`3aa9796b`](https://github.com/doomemacs/doomemacs/commit/3aa9796b84dc975399a73624c6b407897adb7c6c) fix(format): resolve list expansion issues
* [`cd79edf1`](https://github.com/doomemacs/doomemacs/commit/cd79edf134ed03abbc3190bb56d22c229e011bc9) feat(format): add :lang emacs-lisp formatter
* [`bfb963f2`](https://github.com/doomemacs/doomemacs/commit/bfb963f2f3fcd74650037ff5ea34495406509e7d) feat(format): add :lang cc formatter
* [`9a7eae77`](https://github.com/doomemacs/doomemacs/commit/9a7eae77c8a2a2edc07c337f7858151da8efb641) feat(format): add :lang clojure formatter
* [`4d51e46c`](https://github.com/doomemacs/doomemacs/commit/4d51e46c9fd40c944eda6ddee02588c799306615) feat(format): add :lang common-lisp formatter
* [`078bf0dd`](https://github.com/doomemacs/doomemacs/commit/078bf0dd2e15dff0e5e0738bc6a08c8cc60178db) feat(format): add :lang crystal formatter
* [`53fe5df6`](https://github.com/doomemacs/doomemacs/commit/53fe5df6b569ca098f9857446d11b1b3b071536f) feat(format): add :lang csharp formatter
* [`f80f52ba`](https://github.com/doomemacs/doomemacs/commit/f80f52ba4f0361e25d3918ca1d9b80755a4ec006) feat(format): add :lang data formatter
* [`a9b4f6e2`](https://github.com/doomemacs/doomemacs/commit/a9b4f6e21979683a107094c028a9f62a1fdde6e5) feat(format): add :lang erlang formatter
* [`12c901cf`](https://github.com/doomemacs/doomemacs/commit/12c901cf28e7fdcad82263ef50460a2220a868a0) feat(format): add :lang gdscript formatter
* [`efd5ee00`](https://github.com/doomemacs/doomemacs/commit/efd5ee00eaf0dc73d7bd7ecce3c465498f2e1b41) feat(format): add :lang fortran formatter
* [`856d365f`](https://github.com/doomemacs/doomemacs/commit/856d365f2f37c9a85cc94ec69c3f731fe201de51) feat(format): add :lang hy formatter
* [`5cbc7a02`](https://github.com/doomemacs/doomemacs/commit/5cbc7a0258eef20914cf135b5aed370f490bc682) feat(format): add :lang nim formatter
* [`d1697cb4`](https://github.com/doomemacs/doomemacs/commit/d1697cb4d9b073dfe4b8c90fc6f210e53556129d) feat(format): add :lang purescript formatter
* [`7bdf8802`](https://github.com/doomemacs/doomemacs/commit/7bdf8802a5e3ce2cc40c12310e6250ba84a67eb0) feat(format): add :lang racket formatter
* [`caa6b2bb`](https://github.com/doomemacs/doomemacs/commit/caa6b2bb3b1181d037e40cd64a7b071d8e0b6c09) feat(format): add :lang rst formatter
* [`3c96f33c`](https://github.com/doomemacs/doomemacs/commit/3c96f33cb8d43cabea5b01dd8e5c451826da2b4c) feat(format): add :lang scala formatter
* [`d8dc579f`](https://github.com/doomemacs/doomemacs/commit/d8dc579fcba3670a460c0329d3b7536d72431650) feat(format): add :lang scheme formatter
* [`7b46177d`](https://github.com/doomemacs/doomemacs/commit/7b46177d197cb2bdd2460d43fa39c9b09416c60f) feat(format): add :lang sml formatter
* [`c2980d1d`](https://github.com/doomemacs/doomemacs/commit/c2980d1d7b767e195e055ebe4e25e7148b90d487) feat(format): add :lang swift formatter
* [`c7794ba0`](https://github.com/doomemacs/doomemacs/commit/c7794ba06c46e99147c4dcebb4f8450fcfd8587a) feat(format): add :lang zig formatter
* [`7e155041`](https://github.com/doomemacs/doomemacs/commit/7e15504163d03594c23e565ca4c2cae027e43bbc) feat(format): add :tools docker formatter
* [`dc3b5c37`](https://github.com/doomemacs/doomemacs/commit/dc3b5c3710ac906afec00347061d42c4b744c512) fix(format): handle git-gutter nicely
* [`9093f986`](https://github.com/doomemacs/doomemacs/commit/9093f986dcc9792b2abf8323ecd673945f61127a) docs(beancount): Add formatter docs
* [`c9d9051e`](https://github.com/doomemacs/doomemacs/commit/c9d9051ef9e1d79eb088315b2c21a444e32404e8) docs(cc): Add formatter docs
* [`be26181d`](https://github.com/doomemacs/doomemacs/commit/be26181d4f7e36dca600f6004ed3abaa086bac90) docs(clojure): add formatter docs
* [`d8dcac69`](https://github.com/doomemacs/doomemacs/commit/d8dcac6908f0bbc1e351342c5c62930f67949e2a) docs(common-lisp): add formatter docs
* [`ebfc1905`](https://github.com/doomemacs/doomemacs/commit/ebfc1905592ff2df9c90fc4bf9cecfea0ca99e6e) docs(crystal): add formatter docs
* [`274b6e2d`](https://github.com/doomemacs/doomemacs/commit/274b6e2d4d430cd402ea8449294643de852a2a8c) docs(csharp): add formatter docs
* [`d38489b0`](https://github.com/doomemacs/doomemacs/commit/d38489b02d16ad20cef58f54751100c0acf7b403) docs(dart): add formatter docs
* [`e4faa8f2`](https://github.com/doomemacs/doomemacs/commit/e4faa8f2a45eb7a39e217a7103c29f0c97f976a1) docs(elixir): add formatter docs
* [`659b6ff6`](https://github.com/doomemacs/doomemacs/commit/659b6ff6ddad7e6818b27778b481be99fb37ef90) docs(elm): add formatter docs
* [`0a79b404`](https://github.com/doomemacs/doomemacs/commit/0a79b40443d996123ae0a73298a62076f2c027c6) docs(emacs-lisp): add formatter docs
* [`50876500`](https://github.com/doomemacs/doomemacs/commit/508765002b4142285427333171afe7aeea7bc58b) docs(erlang): add formatter docs
* [`d2f31907`](https://github.com/doomemacs/doomemacs/commit/d2f3190766a755c5e4b071283f1d55e9c9e738e3) docs(fortran): add formatter docs
* [`ca38e5a9`](https://github.com/doomemacs/doomemacs/commit/ca38e5a9a5cf5a0aab21908ef611c5ed3bcf9008) feat(format): add :lang fsharp formatter
* [`26819c33`](https://github.com/doomemacs/doomemacs/commit/26819c33f379f7341c3cd6e9b15c4aa7735f2ae5) docs(fsharp): add formatter docs
* [`cc9bda36`](https://github.com/doomemacs/doomemacs/commit/cc9bda36c273a0cd8194d84cfff5fcc2e4271601) fix(cc): remove executable-find formatter check
* [`65b0b148`](https://github.com/doomemacs/doomemacs/commit/65b0b148497c1b1a1e5f1e2e95eda7862b12b095) fix(crystal): remove executable-find formatter check
* [`a5756f1e`](https://github.com/doomemacs/doomemacs/commit/a5756f1e19df47c0d919b4a5399bd816c3381278) fix(csharp): reduce formatter complexity
* [`9c2d0b00`](https://github.com/doomemacs/doomemacs/commit/9c2d0b00d74b4307fc7145057fc8aef5f222427a) fix(data): remove executable-find formatter check
* [`c6291ecf`](https://github.com/doomemacs/doomemacs/commit/c6291ecfc069f1cb1ac0a76d62a2fd37bb6de03d) fix(erlang): remove executable-find formatter check
* [`e44a7b3c`](https://github.com/doomemacs/doomemacs/commit/e44a7b3c5b1f8b010f397b5465bc4f93c128133c) fix(fortran): remove executable-find formatter check
* [`d92219d8`](https://github.com/doomemacs/doomemacs/commit/d92219d8d8bfaa2963f1adc3c46102a190c60c5f) fix(gdscript): remove executable-find formatter check
* [`e3a337eb`](https://github.com/doomemacs/doomemacs/commit/e3a337ebd438e3ee3bdb27a9864064f87b301044) fix!(go): prefer upstream formatter config
* [`09d0f8b9`](https://github.com/doomemacs/doomemacs/commit/09d0f8b984579cb581a5de46f06d6521a7502e93) docs(graphql): add formatter docs
* [`dd4c0b38`](https://github.com/doomemacs/doomemacs/commit/dd4c0b385f9b81c829d84d6c6d6ef5f2a16fc1c6) docs(haskell): add formatter docs
* [`24bfd3f5`](https://github.com/doomemacs/doomemacs/commit/24bfd3f5b49e494731a8daef002b4973ce30b33d) docs(java): add formatter docs
* [`39bbdde8`](https://github.com/doomemacs/doomemacs/commit/39bbdde8c9c1f0c1e47b464cf29f62fc165663a7) docs(javascript): add formatter docs
* [`65a62282`](https://github.com/doomemacs/doomemacs/commit/65a62282a6708a249939df1a4f96d0bf0da48d2c) docs(json): add formatter docs
* [`311959ea`](https://github.com/doomemacs/doomemacs/commit/311959ea1d47bc462d279b21ad3607a899d1ac8b) docs(kotlin): add install docs
* [`8410d9fe`](https://github.com/doomemacs/doomemacs/commit/8410d9fe70a75471264db07e067ecddcf4cd46c4) docs(latex): add formatter docs
* [`0577da30`](https://github.com/doomemacs/doomemacs/commit/0577da300b2db82ad604520108a9b487cf972554) docs(lua): add formatter docs
* [`51d3954c`](https://github.com/doomemacs/doomemacs/commit/51d3954c825aebc1bf5adb501904e083569e99a0) docs(markdown): add formatter docs
* [`9efadb5a`](https://github.com/doomemacs/doomemacs/commit/9efadb5a420c9a2824f22aa3d9112e320cb49a1f) docs(nim): add formatter docs
* [`c86943f9`](https://github.com/doomemacs/doomemacs/commit/c86943f97bd684687d962c1db3ec626f4711a144) docs(purescript): add install docs
* [`601f9b0d`](https://github.com/doomemacs/doomemacs/commit/601f9b0db61c88839d19eb262893f034057a49bf) docs(python): add formatter docs
* [`15f21fcb`](https://github.com/doomemacs/doomemacs/commit/15f21fcb15b711d8fef271259816ed2528ab2abe) docs(racket): add formatter docs
* [`92ee29fe`](https://github.com/doomemacs/doomemacs/commit/92ee29fec92daa2f88b0497168737a838325f334) docs(rst): add formatter docs
* [`2e6ea90c`](https://github.com/doomemacs/doomemacs/commit/2e6ea90cf20b007d92d21eb6cbd898adc3a845aa) docs(ruby): add formatter docs
* [`ee4a377c`](https://github.com/doomemacs/doomemacs/commit/ee4a377cfa361ae7769ea2e3fea65fcf6bdfa259) docs(rust): update rustfmt command
* [`a7e8ee69`](https://github.com/doomemacs/doomemacs/commit/a7e8ee691006b7d6808b23f1b5d2429f2e554d54) docs(scala): add formatter docs
* [`fa145f5c`](https://github.com/doomemacs/doomemacs/commit/fa145f5cc15405204b7c214f2f1539377aa68050) docs(sh): add formatter docs
* [`308ab453`](https://github.com/doomemacs/doomemacs/commit/308ab45300ce7c5c861ad246aa43092b221ad963) docs(sml): add formatter docs
* [`580ec33d`](https://github.com/doomemacs/doomemacs/commit/580ec33d3a6bf518ae32553287a7a1554de6d8cd) feat(sml): add :lang sml formatter
* [`076c6d91`](https://github.com/doomemacs/doomemacs/commit/076c6d9183575c51511d536bc4a91e1c2e61246d) docs(solidity): add formatter docs
* [`4a55ac84`](https://github.com/doomemacs/doomemacs/commit/4a55ac843c6b966d60a0267db91d1c5c444782da) docs(swift): add formatter docs
* [`953cfd34`](https://github.com/doomemacs/doomemacs/commit/953cfd342b82320fd05fae8ca5e6ee8d3e31366c) docs(web): add formatter docs
* [`679d0d00`](https://github.com/doomemacs/doomemacs/commit/679d0d00932358eb62065ff08b3c516cdbce88a4) docs(docker): add formatter docs
* [`e852bbcf`](https://github.com/doomemacs/doomemacs/commit/e852bbcf6cd01b29d7e4c00280daec70aca42d3c) docs(yaml): add formatter docs
* [`457aeecc`](https://github.com/doomemacs/doomemacs/commit/457aeeccc0b6ba5d15711e1079c2accb45cdf114) fix(format): better handle format-on-save disable
* [`926b8f13`](https://github.com/doomemacs/doomemacs/commit/926b8f132862dbcbc0a23c77765180d2a75bbc61) docs(format): redo docs to handle refactor
* [`b34533de`](https://github.com/doomemacs/doomemacs/commit/b34533de968f1b468b193b7c1e52ad5968588d63) fix(format): load format-on-save-disabled-modes fn
* [`550767ef`](https://github.com/doomemacs/doomemacs/commit/550767efe2fecda7bfd11fea5c6ff9e889f44dff) fix(format): apheleia-inhibit-functions after load
* [`b0e57974`](https://github.com/doomemacs/doomemacs/commit/b0e579741e7ea16635b8725bca419a1a264dd281) fix(format): react to ns change
* [`12d520a3`](https://github.com/doomemacs/doomemacs/commit/12d520a3771ec509fa1e83499aa86d114e4619ed) fix(format): remove merged formatter
* [`249a39ac`](https://github.com/doomemacs/doomemacs/commit/249a39acb49e65e32a424e7ffeba69b3174394a4) fix(format): pin apheleia
* [`79172239`](https://github.com/doomemacs/doomemacs/commit/79172239a711f6af8ae9ebd30c632ca7a335b0ed) fix(clojure): prefer cljfmt now it supports STDIN
* [`bc58da7c`](https://github.com/doomemacs/doomemacs/commit/bc58da7c78eef3b4a38743724337c22fa831eb14) fix(zig): correct doctor check
* [`f67f3914`](https://github.com/doomemacs/doomemacs/commit/f67f3914433d613e16442e76b7407c4fe9a4ea09) fix(common-lisp): amend sly-compat hook
* [`23a39b0a`](https://github.com/doomemacs/doomemacs/commit/23a39b0a14d8fa15ecba0e1d2d4d732c49480d0b) fix(clojure): remove executable-find formatter check
* [`ce93f899`](https://github.com/doomemacs/doomemacs/commit/ce93f899fd0ec069cb1fa43c9c8841991785e524) fix(format): improve function/module loading safety
* [`dd68bbb7`](https://github.com/doomemacs/doomemacs/commit/dd68bbb7da530bd99e2bce77a41d4f01b6db119c) fix(format): removed unused argument
* [`9787022b`](https://github.com/doomemacs/doomemacs/commit/9787022b839d2d22cb772c6d61cc7f35b9dd5e95) refactor!: replace all-the-icons with nerd-icons
* [`aa49edc2`](https://github.com/doomemacs/doomemacs/commit/aa49edc216b30ab7104037a9365aaad06ae09b31) docs(helm,ivy,vertico,ido): add incompatibility checks
* [`1fce8522`](https://github.com/doomemacs/doomemacs/commit/1fce8522f8f987d8d1ac1e74e6009db670c3d93b) bump: :editor multiple-cursors
* [`42047422`](https://github.com/doomemacs/doomemacs/commit/420474222e27a5f9eea10b132b43c4dc2ccdd5bb) bump: :editor lispy parinfer snippets word-wrap
* [`c5d4f818`](https://github.com/doomemacs/doomemacs/commit/c5d4f818d1b34dede1c74dd15af5067f0970e0b9) fix(ivy): void-function nerd-icons-ivy-rich-mode error
* [`5efec260`](https://github.com/doomemacs/doomemacs/commit/5efec260ef891cc4ca1134ca1418c870eda7418e) fix(format): use correct lisp format function
* [`0c793906`](https://github.com/doomemacs/doomemacs/commit/0c793906236db018ba460862e23d9f62d061249c) fix(tabs): replace all-the-icons with nerd-icons
* [`3b692e92`](https://github.com/doomemacs/doomemacs/commit/3b692e92f5ca27cb0ea7b9d964a42f1b466704bd) refactor(modeline): remove doom-modeline-buffer-modified shim
* [`cd2477e7`](https://github.com/doomemacs/doomemacs/commit/cd2477e79c95088148403d591864652704c56a86) refactor(collab): s/featurep!/modulep!
* [`e97b05c0`](https://github.com/doomemacs/doomemacs/commit/e97b05c07cfb5e560a8ebaaf09e8f0d094ccb802) fix: nerd-icons-material => nerd-icons-mdicon
* [`928e5640`](https://github.com/doomemacs/doomemacs/commit/928e5640c5f7889f4f5b16ec94467c7e6ad78e07) feat(lua): enable rainbow-delimiters in fennel-mode
* [`eec8808f`](https://github.com/doomemacs/doomemacs/commit/eec8808f453d551b6b32fbedfb506d4d706c0665) bump: :app rss
* [`b58dc721`](https://github.com/doomemacs/doomemacs/commit/b58dc721aa192ed24eb718a40c54636eb8f89c35) fix: lingering autoloads from inactive packages
* [`0b2e6d70`](https://github.com/doomemacs/doomemacs/commit/0b2e6d707075e90c642808cb01377538a9726c53) docs(format): clarify how to update macro in private config
* [`31913491`](https://github.com/doomemacs/doomemacs/commit/3191349182cc1c2d79127773670d7c4c5b32f9ac) docs(format): set-formatter!: escape quotes in docstring
* [`e47accb7`](https://github.com/doomemacs/doomemacs/commit/e47accb77324ffff6e9a72bf820a0f73d2e804f3) fix(modeline): update icons for +light
* [`7920b0d4`](https://github.com/doomemacs/doomemacs/commit/7920b0d46c8f026b9e018cd966ccf9546f655912) fix(format): update missing values & set buffer modification
* [`e44508f6`](https://github.com/doomemacs/doomemacs/commit/e44508f67c205ace4c74aa635b57752884ddc29d) docs(format): improve note about regional formatting
* [`57965f18`](https://github.com/doomemacs/doomemacs/commit/57965f18a5f301ff4319062fad8e78e67928563e) fix(treemacs): replace all-the-icons with nerd-icons
* [`aab52159`](https://github.com/doomemacs/doomemacs/commit/aab52159517476506b82d78cd13f7930ebd59c7b) fix(format): use +vc-gutter-update-h instead
* [`34f583d3`](https://github.com/doomemacs/doomemacs/commit/34f583d3960ee48f0df1fd1772894e26fd6bd8eb) fix(ocaml): Prevent clobbering +format-with globally
* [`8e1f5509`](https://github.com/doomemacs/doomemacs/commit/8e1f5509ead5e90ecb9a9ea7a15207360f3d1e7e) fix(undo): add emacs version check for vundo
* [`3627b82f`](https://github.com/doomemacs/doomemacs/commit/3627b82fd33663ff0e9b6252e2836fd33cc889fd) docs: revise and fix nerd-icons doctor check
* [`8340141e`](https://github.com/doomemacs/doomemacs/commit/8340141e6934167dc69b24cc27f5309ac4837866) fix(eshell): pcomplete after quotes in emacs <=28
* [`ae8c5cfd`](https://github.com/doomemacs/doomemacs/commit/ae8c5cfddee1142bf3564db8604041294ee4721a) fix(org): org-roam-node-display-template: strip :box from org-tag
* [`88bb0453`](https://github.com/doomemacs/doomemacs/commit/88bb0453887517f144a80fbf60f399176c613d8d) docs(*): replace all-the-icons with nerd-icons
* [`589f92c0`](https://github.com/doomemacs/doomemacs/commit/589f92c086d5ea72c4e3b8ac7db1d5a95009ed2e) docs: use GH markdown alerts
* [`41de7d9d`](https://github.com/doomemacs/doomemacs/commit/41de7d9d0173c617261ac58324c6b562c2d95f31) bump: :lang org
* [`5f3a6674`](https://github.com/doomemacs/doomemacs/commit/5f3a667400e77c41f170dd99634c0efc7ea3ae42) bump: :lang cc
* [`8230b78a`](https://github.com/doomemacs/doomemacs/commit/8230b78ad515351d42f8e9bd64b09b394dff79c7) fix(ligatures): set-font-ligatures!
* [`0f663d00`](https://github.com/doomemacs/doomemacs/commit/0f663d007bf51a657a53f4f9dffeffd0a2d7cba2) docs(evil,latex,vterm,treemacs): correct notices
* [`2be3cf4b`](https://github.com/doomemacs/doomemacs/commit/2be3cf4b38251eae13cba5daf6ae5bb6964de4a4) bump: nerd-icons-dired
* [`2b08b2da`](https://github.com/doomemacs/doomemacs/commit/2b08b2da332bf3119ef027fe094eebc77e1150b3) bump: :emacs vc
* [`a60d8b3d`](https://github.com/doomemacs/doomemacs/commit/a60d8b3da4324170e3bdcb7e73a5e35e0d828a4f) fix(ligatures): proper resetting of font-ligatures
* [`f369b48b`](https://github.com/doomemacs/doomemacs/commit/f369b48b2a2b48993eaeeb1336ffc45bdac211f7) fix(org): use correct doom-module link follow function
* [`54c67acf`](https://github.com/doomemacs/doomemacs/commit/54c67acf2a668ead6af55235b6ded16777778b40) nit(org): use consistent link follow function names
* [`c3342a80`](https://github.com/doomemacs/doomemacs/commit/c3342a80113c7711ae9b7c0f65423232c8166f7e) nit(org): make activate function suffixes consistent
* [`2279a42c`](https://github.com/doomemacs/doomemacs/commit/2279a42c50109d4e4adf2be7ed922ad8d0bd21e1) fix(org): address fancy links regressions
* [`4b81a70a`](https://github.com/doomemacs/doomemacs/commit/4b81a70aff1404bc8481e9e75e40e57625dbb546) nit(docs): fix typo and extraneous backquote
* [`a02b4ddf`](https://github.com/doomemacs/doomemacs/commit/a02b4ddfe37bf33ded84e2d852a20311d48025c7) fix(mu4e): replace obsolete/removed functions
* [`531a8bdf`](https://github.com/doomemacs/doomemacs/commit/531a8bdfebe4ad717042b766a75a4d77e9d62be6) fix(mu4e): remove broken pretty bullets advice
* [`fed0f49c`](https://github.com/doomemacs/doomemacs/commit/fed0f49ca7d23101fe309fad664e596c32b60b70) fix(dart,scala,swift,treemacs): ignore lsp-* packages for eglot
* [`7266c113`](https://github.com/doomemacs/doomemacs/commit/7266c11366bd4e5ee63234f9a6f7c0047c5e2cc0) fix(swift): activate `lsp!` on +lsp
* [`cdbf58a8`](https://github.com/doomemacs/doomemacs/commit/cdbf58a8710403fff829326af86741928903a3e4) refactor(format): swap to string-blank-p & memq
* [`fba8dda5`](https://github.com/doomemacs/doomemacs/commit/fba8dda5c80c0bbda255172be9b766d670a95d3a) bump: :term
* [`7cae2b01`](https://github.com/doomemacs/doomemacs/commit/7cae2b01f6d6add0415ad6d1c37c689ac478fcb2) bump: :emacs ibuffer undo
* [`7da57e72`](https://github.com/doomemacs/doomemacs/commit/7da57e72f1a5b9300a0a3586e97e1d2e62ff4a44) bump: :ui
* [`a4d95674`](https://github.com/doomemacs/doomemacs/commit/a4d95674ec8ed653e0d2349d65042d1c8a2248e5) tweak(format): doom-debug-variables: add apheleia-log-only-errors
* [`96e6b72b`](https://github.com/doomemacs/doomemacs/commit/96e6b72be6ed90465535cd6d7b9ef62b3ae7492a) nit(beancount): revise docstrings & sharp-quotes functions
* [`36651d6e`](https://github.com/doomemacs/doomemacs/commit/36651d6e6662cfe5e784f39936cf10df888db785) tweak(beancount): include directives for next/prev transaction
* [`c5e387f7`](https://github.com/doomemacs/doomemacs/commit/c5e387f7b42be1870565a5ab72f92f03e8a76e4a) fix(beancount): previous-transaction: jump-to-start behavior
* [`1baea0c4`](https://github.com/doomemacs/doomemacs/commit/1baea0c4c2c528e78c4f3881d5c2650ac7bd73b6) feat(beancount): add +beancount/occur command
* [`96aed4bf`](https://github.com/doomemacs/doomemacs/commit/96aed4bf351cc2e918384626a80cc8ef0105dd33) perf(evil): defer evil-collection-tab-bar
* [`3983fba5`](https://github.com/doomemacs/doomemacs/commit/3983fba5b5d9ed0b707cfa49dcab2038d5b2aed2) perf(zig): quote flycheck-define-checker
* [`db29f71f`](https://github.com/doomemacs/doomemacs/commit/db29f71f103d268fc42a5ebe2b14f2dc82432f81) fix(org): add missing autoloads for org-attach
* [`844a82c4`](https://github.com/doomemacs/doomemacs/commit/844a82c4a0cacbb5a1aa558c88675ba1a9ee80a3) bump: :lang ruby
