### PR TITLE
niv nixpkgs: update 94a42157 -> fe0b3b66

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "94a42157f48abfe2c27b1afadd3bf8f94334f08d",
-        "sha256": "0acdfxx0gbdm14aqa0l7m6asyjkqmadizpni8caynlkf4vprx94d",
+        "rev": "fe0b3b663e98c85db7f08ab3a4ac318c523c0684",
+        "sha256": "1amc0lhq1zgznnlzz1yi6rifk9mh8p067y83476bcwrb4d6hsvn3",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/94a42157f48abfe2c27b1afadd3bf8f94334f08d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/fe0b3b663e98c85db7f08ab3a4ac318c523c0684.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@94a42157...fe0b3b66](https://github.com/nixos/nixpkgs/compare/94a42157f48abfe2c27b1afadd3bf8f94334f08d...fe0b3b663e98c85db7f08ab3a4ac318c523c0684)

* [`ca237fdf`](https://github.com/NixOS/nixpkgs/commit/ca237fdfa54fd5d05df9ecea316747890707d2cf) dav1d: add some key reverse dependencies to passthru.tests
* [`50a3fdd0`](https://github.com/NixOS/nixpkgs/commit/50a3fdd03c8544d73f51a15945ae183a59c72a84) wordpress: fixed installing of languages
* [`296682e7`](https://github.com/NixOS/nixpkgs/commit/296682e70cc2dff231cde3b9cfde8e32634a9cfa) appcleaner: init at 3.6.8
* [`d75f9285`](https://github.com/NixOS/nixpkgs/commit/d75f9285f735e06462bab3dd149cc99bbbe691c4) taglib: 0.13.0 -> 0.13.1
* [`b60fb55a`](https://github.com/NixOS/nixpkgs/commit/b60fb55a38c021ec8f8c545fd59c6ef279ce6e6c) perlPackages.FileBaseDir: 0.08 -> 0.09
* [`1b64bc69`](https://github.com/NixOS/nixpkgs/commit/1b64bc6920d009c3f2a6f73aef413a41bd64f41e) perlPackages.TestFile: 1.443 -> 1.993
* [`fce5f0a1`](https://github.com/NixOS/nixpkgs/commit/fce5f0a11411d638ce466aeead5089dd0a10f654) autoconf-archive: 2022.09.03 -> 2023.02.20
* [`f01288ec`](https://github.com/NixOS/nixpkgs/commit/f01288ec4ee16d0410ab32e2a72bfbc3966b6bd7) inputplug: mark broken on Darwin
* [`c3bd9805`](https://github.com/NixOS/nixpkgs/commit/c3bd98051b7c0e5e88740b85dd5e2f4c63504b6e) libmd: 1.0.4 -> 1.1.0
* [`898a23d4`](https://github.com/NixOS/nixpkgs/commit/898a23d41482caa7ec52c8a680750495e48177e7) libmd: enable tests
* [`e6e8e254`](https://github.com/NixOS/nixpkgs/commit/e6e8e254fe4d936dbc5339bc5bc1334bc73069b2) libbsd: 0.11.7 -> unstable-2023-04-29
* [`935c3fe4`](https://github.com/NixOS/nixpkgs/commit/935c3fe4062fbf52f70b0ddc263f70d1a37c5edb) libbsd: enable tests
* [`a227fd1f`](https://github.com/NixOS/nixpkgs/commit/a227fd1fe78ec19e7d823ef808830e86a705fc12) xdg-utils: enable cross compilation
* [`5ee69670`](https://github.com/NixOS/nixpkgs/commit/5ee69670071f583bdffe2718dc46763fa1698f92) gtk3: compile schemas even when cross compiling
* [`7a1c5e3a`](https://github.com/NixOS/nixpkgs/commit/7a1c5e3a5d1ff82c8afa659c7f903d5309d5de6a) gtk4: compile schemas even when cross compiling
* [`e647b4f5`](https://github.com/NixOS/nixpkgs/commit/e647b4f55cd2f93fd09f8a08ff2a4e778e747bbd) libksba: 1.6.3 -> 1.6.4
* [`c2d5ed97`](https://github.com/NixOS/nixpkgs/commit/c2d5ed9744aaa8b3cb6d6491d224cecda52d4924) prometheus-sabnzbd-exporter: init at 0.1.70
* [`5e75b363`](https://github.com/NixOS/nixpkgs/commit/5e75b3630247c5be083a8af40ebe3c5528f531f4) nixos/prometheus-sabnzbd-exporter: init
* [`81d8fdb6`](https://github.com/NixOS/nixpkgs/commit/81d8fdb6ab4790adc7d85c70e4c58c2a56b0ac93) protobuf: use nixpkgs gtest
* [`2cd0ae83`](https://github.com/NixOS/nixpkgs/commit/2cd0ae83117083951d7c197a33152b9307e5cb2b) protobuf: use finalAttrs pattern
* [`301b33cd`](https://github.com/NixOS/nixpkgs/commit/301b33cd74a7f48e713ec69d0954ba1f4c492726) protobuf: add grpc as reverse dependency to passthru.tests
* [`9e5fabaf`](https://github.com/NixOS/nixpkgs/commit/9e5fabaf13e8d3f6c6f9c756e37bc803164d5a82) protobuf: update meta
* [`a0c77aec`](https://github.com/NixOS/nixpkgs/commit/a0c77aecaaf24a32600b88d05406dfd57e1b8639) lib.systems: add ubootArch
* [`a97e8fc2`](https://github.com/NixOS/nixpkgs/commit/a97e8fc272782d69d94053bc434b9b6fef399a7b) make-initrd-ng: use hostPlatform.ubootArch for uinitrdArch
* [`52194457`](https://github.com/NixOS/nixpkgs/commit/521944571a8c573c184c5f46fd438b047f009e47) systemd-networkd: add dhcpv6Config options
* [`fb59bf8a`](https://github.com/NixOS/nixpkgs/commit/fb59bf8a6dcecd120c85cefa1e757091c2e69bd2) systemd-networkd: add option to assign ipv6 prefix
* [`8708ae0e`](https://github.com/NixOS/nixpkgs/commit/8708ae0e37084d44dfc2d89e5d14731382f82236) bash: disable `bash-malloc` everywhere, not just on `musl`
* [`2f755a79`](https://github.com/NixOS/nixpkgs/commit/2f755a79da0689887154a5c582308808456753b2) libsForQt5.qtwayland: Fix cross
* [`1f845ebc`](https://github.com/NixOS/nixpkgs/commit/1f845ebc343350c18e9d292c6999174b9c63fad2) nixos/tests/systemd-initrd-vlan: init
* [`2cb4671e`](https://github.com/NixOS/nixpkgs/commit/2cb4671ebcfbe75cff7bca5975ff7202e3fb52de) nixos/network-interfaces-systemd: add VLAN interfaces in systemd-initrd
* [`a3211ceb`](https://github.com/NixOS/nixpkgs/commit/a3211ceb47e20a4466b95051bbb047b54a7fdd60) nixos/tests/systemd-initrd-bridge: init
* [`1f34babe`](https://github.com/NixOS/nixpkgs/commit/1f34babe84854576c936969f8a879403be9f2515) nixos/network-interfaces-systemd: add bridge interfaces in systemd-initrd
* [`541c50e9`](https://github.com/NixOS/nixpkgs/commit/541c50e90928b514893d12b2a2a2529cd0f4bc4c) cemu: 2.0-45 -> 2.0-47
* [`49479825`](https://github.com/NixOS/nixpkgs/commit/49479825a16cb8d2bff9ae2ea246fb4059721d96) maintainers: add dpc
* [`d1609855`](https://github.com/NixOS/nixpkgs/commit/d16098555ca00020281a3de75a9b9a154e453161) rblake2sum: init at 0.3.1
* [`1080a271`](https://github.com/NixOS/nixpkgs/commit/1080a271d50970bf5fda199a14910cb7563aa5e9) domine: init at nightly-2023-08-10
* [`b9a010e2`](https://github.com/NixOS/nixpkgs/commit/b9a010e21350218264ece5757f0bea1a2c1760d4) gperf_3_0: fix build with clang 16
* [`99e0607c`](https://github.com/NixOS/nixpkgs/commit/99e0607c5a9c8e41d2e6769d01bf059a873b0e29) libicns: 0.8.1 -> unstable-2022-04-10
* [`dfc00b41`](https://github.com/NixOS/nixpkgs/commit/dfc00b41c6ddaa64fb12f790ebb866fb752cc741) imlib2: 1.11.1 -> 1.12.0
* [`29055efa`](https://github.com/NixOS/nixpkgs/commit/29055efa16064eb88d8d46bcc69b18e9c25768bb) unixODBC: 2.3.11 -> 2.3.12
* [`57446b6d`](https://github.com/NixOS/nixpkgs/commit/57446b6d132355abce314bfe7e557cabd7312ca3) imlib2: update changelog
* [`eff3e2b8`](https://github.com/NixOS/nixpkgs/commit/eff3e2b8637f88c5c68e6d598420bd17f9d592ba) pythonPackages.auditok: init at 0.1.5
* [`bc644aee`](https://github.com/NixOS/nixpkgs/commit/bc644aee70ff319d98ee1a75c8faf4767d6cdca6) nixos/networkd: allow state ranges in RequiredForOnline
* [`718d63a4`](https://github.com/NixOS/nixpkgs/commit/718d63a44a7634867a837d09156629317ef05114) linuxHeaders: 6.4 -> 6.5
* [`8a85456b`](https://github.com/NixOS/nixpkgs/commit/8a85456bcc7061ec6c52c23786970d2229e8c744) python3Packages.google-auth-oauthlib: fix test failure on Darwin
* [`a25d6143`](https://github.com/NixOS/nixpkgs/commit/a25d6143c6517218a470298cf826737ef623fab3) which: enable 64-bit API on 32-bit systems
* [`80013356`](https://github.com/NixOS/nixpkgs/commit/800133566d79ba66faec6f2aca40f9e52b6a7c4d) firefox wrapper: fix merging of policies files
* [`047f87f3`](https://github.com/NixOS/nixpkgs/commit/047f87f3859d82a1f793fbfe08873a23d7f4df3e) libavif: 0.11.1 -> 1.0.1
* [`db8f2d6e`](https://github.com/NixOS/nixpkgs/commit/db8f2d6e5830630f9600e7bb9b904c2ad943bb7d) maturin: 1.2.2 -> 1.2.3
* [`57e995b3`](https://github.com/NixOS/nixpkgs/commit/57e995b37696119a23726c122a1c4928cf214058) re2: 2023-08-01 -> 2023-09-01
* [`f2e1dad5`](https://github.com/NixOS/nixpkgs/commit/f2e1dad58bb2a441e062420990e9a3cdaf963550) ffmpeg_4: fix crash with clang 16
* [`9db1e83c`](https://github.com/NixOS/nixpkgs/commit/9db1e83c07dd7006889deb839ceb83e8b0102101) libmodplug: fix build with clang 16
* [`286e3f3d`](https://github.com/NixOS/nixpkgs/commit/286e3f3d01f3461ebe003693a539df6edaef7cc5) R: fix build with clang 16 on x86_64-darwin
* [`7fc80bcd`](https://github.com/NixOS/nixpkgs/commit/7fc80bcd4e5b1a5fb314d08a9a9a054e4ec875bd) python3Packages.scipy: support for disabling tests
* [`422ef042`](https://github.com/NixOS/nixpkgs/commit/422ef0420f6fe2183b9c20084662a2d9090386b5) python3Packages.scipy: disable failing tests on aarch64-darwin
* [`92d99c52`](https://github.com/NixOS/nixpkgs/commit/92d99c521b2c02fa645b3b993ac4bbaf49e43ddd) plotutils: fix build with clang 16
* [`b998eaa9`](https://github.com/NixOS/nixpkgs/commit/b998eaa96e6539cffd86057bba3fe8aed1b37470) hwdata: 0.373 -> 0.374
* [`87e5a14f`](https://github.com/NixOS/nixpkgs/commit/87e5a14f18fde5feda74c9232a010964d89d227f) s2n-tls: 1.3.48 -> 1.3.50
* [`3eac04a7`](https://github.com/NixOS/nixpkgs/commit/3eac04a72c45b511054997f3f289721d46885aa9) protobuf: 3.24.2 -> 3.24.3
* [`d9b1d8cf`](https://github.com/NixOS/nixpkgs/commit/d9b1d8cfcf8555516ac732e9c8b10c4ed52ffee0) python310Packages.mypy: ignore broken test on i686
* [`fccf04b6`](https://github.com/NixOS/nixpkgs/commit/fccf04b6200b711977dbfe9a59e3356bfe768932) treewide: replace -DCMAKE_BUILD_TYPE in cmakeFlags with cmakeBuildType
* [`ab1957d1`](https://github.com/NixOS/nixpkgs/commit/ab1957d1daf248b29de1db21ea3349bda56c8c92) libhwy: 1.0.5 -> 1.0.7
* [`aa820d15`](https://github.com/NixOS/nixpkgs/commit/aa820d150287e7116d68a0554b563ee8019afb59) capnproto: 0.10.4 -> 1.0.1
* [`2ce1ae2c`](https://github.com/NixOS/nixpkgs/commit/2ce1ae2cfd73efbc24d7575baa71773b1331f1f3) ffmpeg: re-enable video4linux2 support
* [`dde4c871`](https://github.com/NixOS/nixpkgs/commit/dde4c871e1d39b7eac25a69e427ab8c050b35fb1) shadow: 4.13 -> 4.14.0
* [`05c541d0`](https://github.com/NixOS/nixpkgs/commit/05c541d09a5d4f3486c534b6bf5ecacded3129d2) pipewire: Make ldacbt support optional based on availability
* [`40c3e0a4`](https://github.com/NixOS/nixpkgs/commit/40c3e0a4b33a9cf2929770844fa9a7c7a30986e0) vipsdisp: 2.5.1 -> 2.6.0
* [`cb41a145`](https://github.com/NixOS/nixpkgs/commit/cb41a14588b77c0bf2bc524655538893fa7c47eb) vipsdisp: set meta.mainProgram
* [`0b72a1e9`](https://github.com/NixOS/nixpkgs/commit/0b72a1e93de66e0e17949b860a057c4cbfcecd7e) ell: 0.57 -> 0.58
* [`f9dc9b17`](https://github.com/NixOS/nixpkgs/commit/f9dc9b17a404620e8026e3511762816a4e2b44e2) vipsdisp: set platforms
* [`c95192b9`](https://github.com/NixOS/nixpkgs/commit/c95192b9962b2b72bc4c9af5d9c3821de49b8a9d) jq: 1.6 -> 1.7
* [`14735954`](https://github.com/NixOS/nixpkgs/commit/147359540a678898fe0eaff47f8e0437bd74a54b) yq: 3.2.2 -> 3.2.3
* [`37f76d36`](https://github.com/NixOS/nixpkgs/commit/37f76d36c5e2c716a2276e5755fcd0464193911d) python3Packages.jq: 1.4.1 -> 1.5.0, apply patch for jq 1.7
* [`bee39a01`](https://github.com/NixOS/nixpkgs/commit/bee39a0151af0c29fc934e9c21fdcd52094ff462) jetbrains  added udev to extraLdPath
* [`405e6eea`](https://github.com/NixOS/nixpkgs/commit/405e6eea236ded7d89e868d7a2c722c4d4d77ebd) brotli: 1.0.9 -> 1.1.0
* [`e8cc4e54`](https://github.com/NixOS/nixpkgs/commit/e8cc4e54ce3acd408ef566e2ac4861038e10e874) sqlite, sqlite-analyzer: 3.42.0 -> 3.43.1
* [`a0d5d8ec`](https://github.com/NixOS/nixpkgs/commit/a0d5d8ec475e9198663f938f80f8eb625ed66a1e) libimagequant: 4.2.0 -> 4.2.1
* [`ed9e2bdc`](https://github.com/NixOS/nixpkgs/commit/ed9e2bdc72a6ea91514085564fe56555bfc7342b) vim: 9.0.1811 -> 9.0.1897
* [`80422d2a`](https://github.com/NixOS/nixpkgs/commit/80422d2aab525f8cf0363c991e80398edfe19078) polkit: 122 -> 123
* [`aa6dafe3`](https://github.com/NixOS/nixpkgs/commit/aa6dafe3d657c4162d0d84f3c2f77041281bb2c9) cracklib: 2.9.8 -> 2.9.11
* [`706ffe10`](https://github.com/NixOS/nixpkgs/commit/706ffe10a1748a253cfa3e1e62d5b5d0629f37b2) libGLU: 9.0.2 -> 9.0.3
* [`72ea0d15`](https://github.com/NixOS/nixpkgs/commit/72ea0d15d10bb00312cd9240acf1fd4d81a8e7d7) libpng: 1.6.39 -> 1.6.40
* [`c57e6b69`](https://github.com/NixOS/nixpkgs/commit/c57e6b692ab0d27b9573d700f72b0c71eab771e9) python3.pkgs.pypaBuildHook: fix conflicts
* [`ad1eacd2`](https://github.com/NixOS/nixpkgs/commit/ad1eacd27921118f800e8ddccdb73a5b40f00f2b) qpdf: 11.5.0 -> 11.6.1
* [`18b50081`](https://github.com/NixOS/nixpkgs/commit/18b500811c2676bb2da63594403e581c7c899206) systemdMinimal: expose `withRepart` flag and disable it
* [`fe6e2993`](https://github.com/NixOS/nixpkgs/commit/fe6e29938174d1548bdcf02e0100824b272442ed) systemd: 253.5 -> 254-rc1
* [`ded7958b`](https://github.com/NixOS/nixpkgs/commit/ded7958b99cb525987bf8db736c07db8f9c53c12) systemd: 254-rc1 -> 254-rc2
* [`bf993ea3`](https://github.com/NixOS/nixpkgs/commit/bf993ea3cb2c89a32c9d0fdf49432374ec51a56b) systemd: 254-rc2 -> 254-rc3
* [`202da644`](https://github.com/NixOS/nixpkgs/commit/202da6443bdc7c245bbd931efe2becdfafdcd8a8) systemd: 254-rc3 -> 254
* [`1ea060a2`](https://github.com/NixOS/nixpkgs/commit/1ea060a2b843eb171d371db7e28694fce24f608e) systemd: introduce `withBootloader` for sd-boot, sd-stub, sd-addon
* [`2696e44c`](https://github.com/NixOS/nixpkgs/commit/2696e44c42293568fd9ecd30f7d77c37ed6699da) systemd: make `systemd-sysupdate` optional via `withSysupdate`
* [`b2aaa2bf`](https://github.com/NixOS/nixpkgs/commit/b2aaa2bfd80f2368109f00a2366963945f96b403) systemd: make `withPasswordQuality` always disabled
* [`8d368314`](https://github.com/NixOS/nixpkgs/commit/8d368314fd2f90b9fb81acd7242928cd63ec6efb) python3Packages.systemd: add raitobezarius as a maintainer
* [`5a638b0c`](https://github.com/NixOS/nixpkgs/commit/5a638b0cbd674bde8da2b284aaed17ebb3a61b0f) python3Packages.systemd: ignore tests that uses a direct system open call for /etc/machine-id
* [`79c3740e`](https://github.com/NixOS/nixpkgs/commit/79c3740ee55133a0fd24e862a3ccf31804cbd657) nixos/console: use systemd-vconsole-setup.service from upstream for sd initrd
* [`97ee93da`](https://github.com/NixOS/nixpkgs/commit/97ee93da1036db7425a5cefd00085fcf8c813504) systemd: apply upstream patch for tmpfiles
* [`c56ec54b`](https://github.com/NixOS/nixpkgs/commit/c56ec54ba53abac3d9328db542f2d4def47fdc0f) systemd: 254 -> 254.3
* [`f902c6a1`](https://github.com/NixOS/nixpkgs/commit/f902c6a1b93cc368c81b870029fb9653b219a9d4) systemd: add release notes for v254
* [`e2699cd2`](https://github.com/NixOS/nixpkgs/commit/e2699cd256e560c72faf0c65d32205b8e7edb52b) nixos/image: fix for systemd 254
* [`57365d22`](https://github.com/NixOS/nixpkgs/commit/57365d224ca3142e1d95f340e71f50ce0d6ea3c5) systemdStage1: re-include repart
* [`0d2fb006`](https://github.com/NixOS/nixpkgs/commit/0d2fb0062482b577df24b757833e6195a9fc2fba) curl: Fix github src url
* [`a68ceade`](https://github.com/NixOS/nixpkgs/commit/a68ceade950265539c38acbb52f5773ca82e3bc1) curl: 8.2.1 -> 8.3.0
* [`b8400a71`](https://github.com/NixOS/nixpkgs/commit/b8400a7134fed120c7a3d8b0b2942c06580ffcb5) sqlite: fix hash for 3.43.1 (was for 3.43.0)
* [`99176f9c`](https://github.com/NixOS/nixpkgs/commit/99176f9cd585dd5e2b8429afada60b512f00756b) python310Packages.django_4: 4.2.4 -> 4.2.5
* [`3332da28`](https://github.com/NixOS/nixpkgs/commit/3332da283ab2422a438f57165772b4daaf25a1d5) maintainers: add aviallon
* [`7e5d326a`](https://github.com/NixOS/nixpkgs/commit/7e5d326ad3911724270951810d56a9dc5672cb11) srb2: 2.2.11 -> 2.2.13
* [`6cb24743`](https://github.com/NixOS/nixpkgs/commit/6cb2474327e3941c31f170de34d8a97c9871ea4f) libwebp: 1.3.1 -> 1.3.2
* [`19bdef92`](https://github.com/NixOS/nixpkgs/commit/19bdef92254ab32924a291abea1c9ac2017d1f00) webrtc-audio-processing_1: 1.0 -> 1.3, cleanup
* [`d3f95211`](https://github.com/NixOS/nixpkgs/commit/d3f95211ad0ebe92af43362ee450ad0c9748e943) pipewire: 0.3.79 -> 0.3.80
* [`8565cd86`](https://github.com/NixOS/nixpkgs/commit/8565cd862a614cc53a5798d398b8b11d98122ba0) systemd: allow udev-trigger to run on lxd containers with nesting
* [`f38a57f0`](https://github.com/NixOS/nixpkgs/commit/f38a57f07241c01dbba370e5b718e24169741f17) ffmpeg-full: fix cross
* [`c147fe79`](https://github.com/NixOS/nixpkgs/commit/c147fe79a57283f06a2e1f792edba49d2c5ecb80) ffmpeg: set strictDeps
* [`b234bbff`](https://github.com/NixOS/nixpkgs/commit/b234bbff0f6884d868495dfd574b9b8a46771bdb) systemd: re-exclude kernel-install from patchShebangs
* [`2f2d611c`](https://github.com/NixOS/nixpkgs/commit/2f2d611c4031a859e32423abc5cff132001ba0ab) python3.pkgs.iniconfig: improve doCheck = false comment
* [`e22dff17`](https://github.com/NixOS/nixpkgs/commit/e22dff17f502154b89994c07c7edd7a34925db65) nixos/amd.sev: add `hardware.cpu.amd.sevGuest` option
* [`f13bf0c0`](https://github.com/NixOS/nixpkgs/commit/f13bf0c0d4ae69ef5752cfc0489019451f319e01) nixos/amd.sev: add test
* [`1af1d8b8`](https://github.com/NixOS/nixpkgs/commit/1af1d8b85525228638631b0b553f1275ce0eac22) g4music: 3.2 -> 3.3
* [`0283ef30`](https://github.com/NixOS/nixpkgs/commit/0283ef30372811d4d85931a39a815690fae005f2) python3.pkgs.primer3: enable tests
* [`09e3d7d7`](https://github.com/NixOS/nixpkgs/commit/09e3d7d7e41731e44024d019443b3ee7c5c2bf70) jq: add a release note
* [`e7ffffce`](https://github.com/NixOS/nixpkgs/commit/e7ffffce821ab8e50a347069e50b908d8a0177e0) iwd: 2.7 -> 2.8
* [`b485dd00`](https://github.com/NixOS/nixpkgs/commit/b485dd0036f316fecbb304430e2ca9518e5c0b4f) deterministic-uname: fix default output
* [`7427bf84`](https://github.com/NixOS/nixpkgs/commit/7427bf84381900c0037568d660a162106505bbbe) perlPackages.Starman: enable IPv6
* [`718f1dbf`](https://github.com/NixOS/nixpkgs/commit/718f1dbf144b5c07dbdea6630b2d213eebb88b3f) python310Packages.pytorch-lightning: 2.0.8 -> 2.0.9
* [`25afc4a9`](https://github.com/NixOS/nixpkgs/commit/25afc4a9101a34a405b4e18ed7262c930e93fe7a) brotli: revert upstream fix for rpath on darwin
* [`65cd5cb5`](https://github.com/NixOS/nixpkgs/commit/65cd5cb5c7fc978df7e4266a1baa78b30ea601c6) micronaut: 4.0.5 -> 4.1.1
* [`06ce1d93`](https://github.com/NixOS/nixpkgs/commit/06ce1d93b06334f63c04576d2ce5e0c2599a9ece) repro-get: 0.4.0 -> 0.4.1
* [`6dff71c2`](https://github.com/NixOS/nixpkgs/commit/6dff71c2110f9b178e1287761712876f0822739e) twitterBootstrap: 5.3.1 -> 5.3.2
* [`bc52a332`](https://github.com/NixOS/nixpkgs/commit/bc52a33219ac0f4ecdfc27d04eb33764dadbad62) ibus-engines.table: 1.17.0 -> 1.17.3
* [`02c62932`](https://github.com/NixOS/nixpkgs/commit/02c62932808d5f3af6bf23018e865637a72b924e) lmdb: don't attempt the .so if static, as it would fail
* [`c7052c9a`](https://github.com/NixOS/nixpkgs/commit/c7052c9a79a523820adddbc22115cfa587ff2404) liblouis: 3.26.0 -> 3.27.0
* [`0976bcec`](https://github.com/NixOS/nixpkgs/commit/0976bcec5d10f2db621ceaaf158b3dc4d5100a09) qcad: 3.28.1.3 -> 3.28.2.2
* [`790aa985`](https://github.com/NixOS/nixpkgs/commit/790aa985e30bfd09c485f54d7dda64c2212a4115) one_gadget: 1.7.2 → 1.8.1
* [`05ae00f9`](https://github.com/NixOS/nixpkgs/commit/05ae00f98deeee7fff00db3bba92b0b9b44b0f04) one_gadget: wrap with binutils in path
* [`ac86a6cd`](https://github.com/NixOS/nixpkgs/commit/ac86a6cdbf3354dee2b3d2874a6d24bcd161190a) open-stage-control: 1.25.3 -> 1.25.5
* [`7ae1eab8`](https://github.com/NixOS/nixpkgs/commit/7ae1eab886c8c22850bbc7369e38961e1a33af10) ulogd: add support for multiple logging stacks
* [`987b0245`](https://github.com/NixOS/nixpkgs/commit/987b0245281d862f83791621b988a394f21059cc) duckscript: 0.8.20 -> 0.9.0
* [`0f5f638b`](https://github.com/NixOS/nixpkgs/commit/0f5f638b059f62621b5dd4833781c2e591aed369) python310Packages.trytond: 6.8.3 -> 6.8.4
* [`913e70d7`](https://github.com/NixOS/nixpkgs/commit/913e70d77b67722a5b3bd42f21b9ea4cc02046e9) minimal-bootstrap.musl11: init at 1.1.24
* [`d999a493`](https://github.com/NixOS/nixpkgs/commit/d999a493b031e766b785c37731b45690451cf869) minimal-bootstrap.tinycc-musl: init at 0.9.27
* [`1340efd4`](https://github.com/NixOS/nixpkgs/commit/1340efd49058147ccf9bae2ae74b47923acb9f27) minimal-bootstrap.musl: remove optional gawk dependency
* [`29837bfc`](https://github.com/NixOS/nixpkgs/commit/29837bfce33f6462773a9d47a7c0080ade7a2370) goa: 3.12.4 -> 3.13.0
* [`319c4c18`](https://github.com/NixOS/nixpkgs/commit/319c4c18124b692918c6567b10197ba1d3cd17ed) webrtc-audio-processing: don't mark broken, instead mark not available
* [`eedc27d9`](https://github.com/NixOS/nixpkgs/commit/eedc27d96e07c72ee1447d2017bf0522c208a838) pipewire: backport patch to build with webrtc-audio-processing 0.3, use it where 1.x isn't available
* [`482619da`](https://github.com/NixOS/nixpkgs/commit/482619dac70c36b0876223d95daf5a8ef616c0fb) services.postgres: move the generated statement at the top of the file
* [`956a1876`](https://github.com/NixOS/nixpkgs/commit/956a1876aa635227807bc7c620e46933a06a5ef6) services.postgresql: add identMap example
* [`b53c715e`](https://github.com/NixOS/nixpkgs/commit/b53c715e504fa1a2a3c2f252a0d714170b03f92d) services.postgres: add initialScript example
* [`f0aab9d2`](https://github.com/NixOS/nixpkgs/commit/f0aab9d21bcad40872392599d56bf2595407fc2d) cockatrice: 2021-02-03-Development-2.8.1-beta -> 2023-09-14-Release-2.9.0
* [`29b34960`](https://github.com/NixOS/nixpkgs/commit/29b34960941724194b1cbe8b9b2656aed30b2468) quick-lint-js: 2.15.0 -> 2.16.0
* [`7a8d4f5d`](https://github.com/NixOS/nixpkgs/commit/7a8d4f5d763a4de765364eb8e9f3dec15157d05b) opensubdiv: 3.5.0 -> 3.5.1
* [`bd19b534`](https://github.com/NixOS/nixpkgs/commit/bd19b5345762d2da23ff9b38bca251144dfd8d20) discordchatexporter-cli: 2.40.4 -> 2.41
* [`238999ab`](https://github.com/NixOS/nixpkgs/commit/238999ab24fa9280f7f6528e3246ab68632139c7) mmdoc: 0.19.0 -> 0.20.0
* [`7ef25b3f`](https://github.com/NixOS/nixpkgs/commit/7ef25b3f727bdb553cd2bd5c8c5086ceb1652a28) doppler: 3.65.2 -> 3.66.0
* [`feedf12f`](https://github.com/NixOS/nixpkgs/commit/feedf12f5ee3e93716bdab75e35a344b43843a42) gptman: 1.0.1 -> 1.0.2
* [`52b3775c`](https://github.com/NixOS/nixpkgs/commit/52b3775c6bb2992841ef03ed6619f4055522a21e) questdb: 7.3.1 -> 7.3.2
* [`fc778ae5`](https://github.com/NixOS/nixpkgs/commit/fc778ae574344a8d9f2add5ce8834ecb32df6d31) webdis: 0.1.21 -> 0.1.22
* [`2f2a55e6`](https://github.com/NixOS/nixpkgs/commit/2f2a55e67581a1b0dde3af4401496827e4556ae3) nodejs_18: 18.17.1 -> 18.18.0
* [`15caf7f7`](https://github.com/NixOS/nixpkgs/commit/15caf7f787dc4d472ba36f1619bee7d9e3ff01ae) nodejs: 20.6.1 -> 20.7.0
* [`c43bf843`](https://github.com/NixOS/nixpkgs/commit/c43bf843f5bc2b2abc55fb1875cd80a31f97f427) jfrog-cli: 2.46.2 -> 2.48.0
* [`207905e5`](https://github.com/NixOS/nixpkgs/commit/207905e5fb78a666b397aa8b2a5f76b7388de9b9) gotrue-supabase: 2.92.0 -> 2.96.0
* [`8b8be4a5`](https://github.com/NixOS/nixpkgs/commit/8b8be4a5a6a1a6e36408ce9017cd76239c0492d4) dolt: 1.14.0 -> 1.15.0
* [`f1575437`](https://github.com/NixOS/nixpkgs/commit/f1575437751c1f32dec7eec9e37597a040a3c8dc) go-ethereum: 1.12.2 -> 1.13.0
* [`9f00881f`](https://github.com/NixOS/nixpkgs/commit/9f00881f25faddc67e97e0ac11e3c3c22401db2b) pyrosimple: 2.10.2 -> 2.11.1
* [`64fe8c92`](https://github.com/NixOS/nixpkgs/commit/64fe8c929292b56436fa587641a4e589e2ee67ff) nixos/nginx: allow enabling QUIC packet routing using eBPF
* [`2a7bd72b`](https://github.com/NixOS/nixpkgs/commit/2a7bd72b8c1e52cde1f49feb2e8178dedd3de9bf) ansible-lint: 6.19.0 -> 6.20.0
* [`4d53f8dd`](https://github.com/NixOS/nixpkgs/commit/4d53f8dd796f317c9feacce1c9aea44ddf5a04c2) hishtory: 0.208 -> 0.215
* [`2ce1cc69`](https://github.com/NixOS/nixpkgs/commit/2ce1cc692238202dbbbc0cdd5c35a1046bb8a991) udisks2: 2.10.0 -> 2.10.1
* [`55ca1c13`](https://github.com/NixOS/nixpkgs/commit/55ca1c13870a664b3eaeb86df38a3263a481be19) python310Packages.async-tkinter-loop: 0.8.1 -> 0.9.1
* [`89081e1f`](https://github.com/NixOS/nixpkgs/commit/89081e1fdfeb34613a7ad27ad4c99b54b2b55787) uhdm: 1.73 -> 1.74
* [`cd939e87`](https://github.com/NixOS/nixpkgs/commit/cd939e87fd052244d2cdaa3e0c72519b70edb62d) komga: 1.3.1 -> 1.4.0
* [`47479bfe`](https://github.com/NixOS/nixpkgs/commit/47479bfea0ac510363cc6a794fd5209ca59b986f) cyclonedds: 0.10.3 -> 0.10.4
* [`4e0f7ccf`](https://github.com/NixOS/nixpkgs/commit/4e0f7ccf8689be4a45f22d9abdbedf56fb7693a2) super-productivity: 7.13.2 -> 7.14.3
* [`8a8e44fc`](https://github.com/NixOS/nixpkgs/commit/8a8e44fcf95266356afc6ad602b07e515e552999) q: 0.11.4 -> 0.12.0
* [`e2738b7c`](https://github.com/NixOS/nixpkgs/commit/e2738b7c5df5a0e4b3fed403bf1896156c844471) unpoller: 2.8.3 -> 2.9.2
* [`4cbfe34d`](https://github.com/NixOS/nixpkgs/commit/4cbfe34d2687bb9b3e85859c07eaa5ba08fe4c9d) python310Packages.google-cloud-language: 2.11.0 -> 2.11.1
* [`3b673297`](https://github.com/NixOS/nixpkgs/commit/3b673297e7626351fd9904f6664fd3f45e70ca1b) nixos/usbguard: restore ruleFile option
* [`92024134`](https://github.com/NixOS/nixpkgs/commit/92024134ff16550d25c5ef6c59758d71919367c4) logseq: 0.9.17 -> 0.9.18
* [`88effd89`](https://github.com/NixOS/nixpkgs/commit/88effd89ac9d6716592adc7586361cfd4ab66c7d) webdis: use `finalAttrs` pattern
* [`c14a11b7`](https://github.com/NixOS/nixpkgs/commit/c14a11b76f0d471cc6ac43ee71dda93e0662727d) python3Packages.pycatch22: init at 0.4.3
* [`648fd590`](https://github.com/NixOS/nixpkgs/commit/648fd590c88a97441d231028582428dd46a34af9) brave: 1.58.124 -> 1.58.129
* [`0b88560e`](https://github.com/NixOS/nixpkgs/commit/0b88560e1877707b59f272643d1a39c2996d7372) linuxPackages.rtl8821cu: unstable-2023-04-28 -> unstable-2023-09-10
* [`6fa3318b`](https://github.com/NixOS/nixpkgs/commit/6fa3318bf1f1c7b1c63b5abe476edf6330d3af0d) python310Packages.chart-studio: 5.16.1 -> 5.17.0
* [`f17dd885`](https://github.com/NixOS/nixpkgs/commit/f17dd885896d41b8d6e55ed9d19aed6a6f79054d) guile-lib: add foo-dogsquared as maintainer
* [`08070c94`](https://github.com/NixOS/nixpkgs/commit/08070c94d93c7570dc8cedf6fb8097a5eed7f4e9) guile-lib: fix module installation in the output
* [`26a6f833`](https://github.com/NixOS/nixpkgs/commit/26a6f833caae42138d73ba14b69397d19a0d643d) python310Packages.types-protobuf: 4.24.0.1 -> 4.24.0.2
* [`ed7c0c6e`](https://github.com/NixOS/nixpkgs/commit/ed7c0c6e7579db97c8889f5bd2bdd8a66f60aab9) nixos/wireguard: add metric option
* [`c32c0dd6`](https://github.com/NixOS/nixpkgs/commit/c32c0dd64a3277256dee95c29fec770c2c3ad3c8) opencv3,opencv4: disable some unnecessary vendoring on Darwin
* [`7ae09eb5`](https://github.com/NixOS/nixpkgs/commit/7ae09eb5e235ec17cd25f2551d443bc8a5e2933a) gnome.networkmanager-openvpn: 1.10.0 -> 1.10.2
* [`d2e33274`](https://github.com/NixOS/nixpkgs/commit/d2e33274cecd491b008429c40b86c32ba7bb429d) asdf-vm: 0.12.0 -> 0.13.1
* [`7d40fbbc`](https://github.com/NixOS/nixpkgs/commit/7d40fbbc04cded4adbbcd3e87546d43bdacf47e8) nix-prefetch-git: ignore global and user git config
* [`d069d823`](https://github.com/NixOS/nixpkgs/commit/d069d823665368e4bdb2c47515a4a879fd0b6f75) abaddon: 0.1.11 -> 0.1.12
* [`352e44ac`](https://github.com/NixOS/nixpkgs/commit/352e44ac6ab6476e6ee700f982b68858fb617e40) thunderbird-bin: 115.2.2 -> 115.2.3
* [`f6a0b114`](https://github.com/NixOS/nixpkgs/commit/f6a0b11498db921075522965cddaacf1225526bb) thunderbird: 115.2.2 -> 115.2.3
* [`e23b4dad`](https://github.com/NixOS/nixpkgs/commit/e23b4dadce0871375f139dff55633759c64c741d) pulumiPackages.pulumi-command: 0.7.1 -> 0.9.0
* [`e9dbf653`](https://github.com/NixOS/nixpkgs/commit/e9dbf65372e9a5f57fbad9c5e161d993da389aae) appflowy: 0.3.1 -> 0.3.2
* [`b081177e`](https://github.com/NixOS/nixpkgs/commit/b081177efec77f502dfa5fb271c296ee7d4148ee) bazarr: 1.2.4 -> 1.3.0
* [`cf423daa`](https://github.com/NixOS/nixpkgs/commit/cf423daab0632fddae83954e74b28b8f89fac3ac) beluga: 1.1 -> 1.1.1
* [`1e704c4f`](https://github.com/NixOS/nixpkgs/commit/1e704c4fc97f9c376be36de83d3c3c834c674ed6) sublime-music: switch to pypaBuildHook
* [`e87e6a7e`](https://github.com/NixOS/nixpkgs/commit/e87e6a7ea4be61eaeb6aea15ae4f1555e23e9b98) cambrinary: switch to pypaBuildHook
* [`c2972f56`](https://github.com/NixOS/nixpkgs/commit/c2972f562e0c62891791b92f937713c6c08af04f) offpunk: switch to pypaBuildHook
* [`c8466f96`](https://github.com/NixOS/nixpkgs/commit/c8466f963af897fa90fb686ed3b6327027d57211) apio: switch to pypaBuildHook
* [`1907ffe5`](https://github.com/NixOS/nixpkgs/commit/1907ffe551191c46acdf124b415c5421a1d24deb) python3Packages.aiohttp-remotes: switch to pypaBuildHook
* [`71df6d03`](https://github.com/NixOS/nixpkgs/commit/71df6d035517da6b12a73d6a5aef2ec484368c35) python3Packages.aioprocessing: switch to pypaBuildHook
* [`e57034f9`](https://github.com/NixOS/nixpkgs/commit/e57034f9a778384481dede840e1adc8b0ba947af) modules/xmr-stak: drop broken cudaSupport option
* [`0fe33eca`](https://github.com/NixOS/nixpkgs/commit/0fe33eca934de1e356f966bd9cb6288694762159) python3Packages.aiorun: switch to pypaBuildHook
* [`6eefba10`](https://github.com/NixOS/nixpkgs/commit/6eefba1026f1a9c45ffff4571da35c1c7ac152a5) python3Packages.argon2-cffi: switch to pypaBuildHook
* [`9ecbc309`](https://github.com/NixOS/nixpkgs/commit/9ecbc30949f9e99f7a2b50f71972d73bb1baaf9a) python3Packages.asyncinotify: switch to pypaBuildHook
* [`22fb5906`](https://github.com/NixOS/nixpkgs/commit/22fb5906f0228e4f4b9b5016c1ff9ae454bbfccd) python3Packages.asyncstdlib: switch to pypaBuildHook
* [`ce95c6a0`](https://github.com/NixOS/nixpkgs/commit/ce95c6a009552157b09ede0d5b7d04d9021308ad) python3Packages.bash_kernel: switch to pypaBuildHook
* [`66164e42`](https://github.com/NixOS/nixpkgs/commit/66164e42971e30d47b3b1e956c3de544e139d118) python3Packages.circus: switch to pypaBuildHook
* [`de34407b`](https://github.com/NixOS/nixpkgs/commit/de34407b5e2c9ea2b9ea57ab3dae938f506ce041) python3Packages.confuse: switch to pypaBuildHook
* [`4f3459f8`](https://github.com/NixOS/nixpkgs/commit/4f3459f829f6680da9f43ae311e208bf40b4ca3c) python3Packages.ecs-logging: switch to pypaBuildHook
* [`8816729b`](https://github.com/NixOS/nixpkgs/commit/8816729b27d7f364f55a2113687d0721564e7f93) python3Packages.emborg: switch to pypaBuildHook
* [`5871c4c5`](https://github.com/NixOS/nixpkgs/commit/5871c4c5acb4db6ff65438b96145e6f7a56238c0) python3Packages.formbox: switch to pypaBuildHook
* [`0956b8a7`](https://github.com/NixOS/nixpkgs/commit/0956b8a719afe3b1620aa259ac6193da63199da0) python3Packages.gidgethub: switch to pypaBuildHook
* [`fd22d2c1`](https://github.com/NixOS/nixpkgs/commit/fd22d2c146d2c807a8ac67155720a331b8b8a345) python3Packages.gspread: switch to pypaBuildHook
* [`bb35132e`](https://github.com/NixOS/nixpkgs/commit/bb35132ec04fb8771da7ad273011a4e4aeb45924) python3Packages.ipwhl: switch to pypaBuildHook
* [`9c96f968`](https://github.com/NixOS/nixpkgs/commit/9c96f9681cc38262843edd0eef0d4485b1a9a940) python3Packages.jupyter-book: switch to pypaBuildHook
* [`64316f7e`](https://github.com/NixOS/nixpkgs/commit/64316f7e72296241d1a6375cb4951980a7bfd245) python3Packages.jupyter-cache: switch to pypaBuildHook
* [`b2450a44`](https://github.com/NixOS/nixpkgs/commit/b2450a4468f234ce6135d23055dca31e3c1c1c36) python3Packages.loca: switch to pypaBuildHook
* [`215bfa6c`](https://github.com/NixOS/nixpkgs/commit/215bfa6c370f93a2a0cd901878573c2ab151a6d0) python3Packages.looseversion: switch to pypaBuildHook
* [`a6bfb787`](https://github.com/NixOS/nixpkgs/commit/a6bfb7870aad0a540efafe873b7c73474fb6d0d1) python3Packages.mdformat-admon: switch to pypaBuildHook
* [`67d46e48`](https://github.com/NixOS/nixpkgs/commit/67d46e48f411ca8f8fb89c63500480afa8e54d14) python3Packages.mdformat-footnote: switch to pypaBuildHook
* [`aff7cc7d`](https://github.com/NixOS/nixpkgs/commit/aff7cc7d30ed6470ca7bbf2a54e92861e9dc1022) python3Packages.mdformat-frontmatter: switch to pypaBuildHook
* [`8627ba0e`](https://github.com/NixOS/nixpkgs/commit/8627ba0ee3b4437b1d3596ead1bf077e486ead1a) python3Packages.mdformat-mkdocs: switch to pypaBuildHook
* [`912f2d54`](https://github.com/NixOS/nixpkgs/commit/912f2d5455cb780b99194234fad37e5ca840ae2f) python3Packages.mdformat-simple-breaks: switch to pypaBuildHook
* [`08aefa71`](https://github.com/NixOS/nixpkgs/commit/08aefa71308bdc113abec09dcd40cb6a04d3f986) python3Packages.mdformat-tables: switch to pypaBuildHook
* [`a3310c5f`](https://github.com/NixOS/nixpkgs/commit/a3310c5f42b79a437023fad19038667556e3c641) python3Packages.mediafile: switch to pypaBuildHook
* [`4f964291`](https://github.com/NixOS/nixpkgs/commit/4f964291fd4bbca9c89a4407660f5ce23b78a020) python3Packages.mediapy: switch to pypaBuildHook
* [`7494c984`](https://github.com/NixOS/nixpkgs/commit/7494c98401c5e5065ab6d8ffb4b2f286768f7810) python3Packages.more-itertools: switch to pypaBuildHook
* [`abeab7a5`](https://github.com/NixOS/nixpkgs/commit/abeab7a556b7f9b85e6330ba8b78e351481e8c0c) python3Packages.myst-nb: switch to pypaBuildHook
* [`e827c3de`](https://github.com/NixOS/nixpkgs/commit/e827c3de446a94921e499972db58155b26bd36a3) python3Packages.nestedtext: switch to pypaBuildHook
* [`3b82eeee`](https://github.com/NixOS/nixpkgs/commit/3b82eeeee07b719cd82b915d36e7b7a941519376) python3Packages.nkdfu: switch to pypaBuildHook
* [`853e5e7a`](https://github.com/NixOS/nixpkgs/commit/853e5e7ab939c6161567eed881de2faac9e8d7ed) python3Packages.parametrize-from-file: switch to pypaBuildHook
* [`7f546348`](https://github.com/NixOS/nixpkgs/commit/7f54634877fef530ce087b42a474aad50ee89b09) python3Packages.pep440: switch to pypaBuildHook
* [`fd63dcad`](https://github.com/NixOS/nixpkgs/commit/fd63dcad87df8358efe464123f690df6c790ae25) python3Packages.pkgutil-resolve-name: switch to pypaBuildHook
* [`2269823b`](https://github.com/NixOS/nixpkgs/commit/2269823b60168fb6d12d1f9b7fb9dff8e806342e) python3Packages.pytest-celery: switch to pypaBuildHook
* [`0a452225`](https://github.com/NixOS/nixpkgs/commit/0a452225569d745aebaf49703f6462afe9d21467) python3Packages.pytest-check: switch to pypaBuildHook
* [`ebeac39d`](https://github.com/NixOS/nixpkgs/commit/ebeac39db776b75fd2dc822b6d6055caf75e1dc0) python3Packages.pytest-cid: switch to pypaBuildHook
* [`3ab1cf59`](https://github.com/NixOS/nixpkgs/commit/3ab1cf59b8e8b86011beaec41fc306a30add654e) python3Packages.pytest-param-files: switch to pypaBuildHook
* [`a624dbce`](https://github.com/NixOS/nixpkgs/commit/a624dbce03fc6668ea7f08011cf76d3eaa34f327) python3Packages.pytest-raisin: switch to pypaBuildHook
* [`6f4a2b3b`](https://github.com/NixOS/nixpkgs/commit/6f4a2b3b5f83579db10937a99eb2b67b7df5d05d) python3Packages.python_docs_theme: switch to pypaBuildHook
* [`3c276bf4`](https://github.com/NixOS/nixpkgs/commit/3c276bf446ab23176d407f3c856eb50bbbe4d83e) python3Packages.qpsolvers: switch to pypaBuildHook
* [`6b47bddf`](https://github.com/NixOS/nixpkgs/commit/6b47bddf451e736b338aa9569bd98f38a721be6d) python3Packages.quantiphy-eval: switch to pypaBuildHook
* [`47f66619`](https://github.com/NixOS/nixpkgs/commit/47f66619260032eee0d90689b7c9097eebac2b2b) python3Packages.quantiphy: switch to pypaBuildHook
* [`a0b432b9`](https://github.com/NixOS/nixpkgs/commit/a0b432b97ecca5a2dd6af73f8a4e81efb6e7aedc) python3Packages.rkm-codes: switch to pypaBuildHook
* [`a99e50dd`](https://github.com/NixOS/nixpkgs/commit/a99e50dd28e913ff2951c1b2a08eeb3490c1121c) python3Packages.rsskey: switch to pypaBuildHook
* [`c5c0a0fb`](https://github.com/NixOS/nixpkgs/commit/c5c0a0fbe8c45fc02a7e973b905e7f3bdfd1d504) python3Packages.solo-python: switch to pypaBuildHook
* [`fc5f9e52`](https://github.com/NixOS/nixpkgs/commit/fc5f9e52de8470db68dd4120666b027c6c9b87ed) python3Packages.sphinx-design: switch to pypaBuildHook
* [`ce739945`](https://github.com/NixOS/nixpkgs/commit/ce739945450e5013cd526fc90c25778feb84ef23) python3Packages.sphinx-external-toc: switch to pypaBuildHook
* [`8c2b94fe`](https://github.com/NixOS/nixpkgs/commit/8c2b94fe2fb1686355d1040f8245611ee342078c) python3Packages.sphinx-hoverxref: switch to pypaBuildHook
* [`1951f905`](https://github.com/NixOS/nixpkgs/commit/1951f9050a8c31c20330bd9cf79745a89ced97b0) python3Packages.sphinx-inline-tabs: switch to pypaBuildHook
* [`c7161dc1`](https://github.com/NixOS/nixpkgs/commit/c7161dc133a34373015361c9392c375c91d6c96c) python3Packages.sphinx-mdinclude: switch to pypaBuildHook
* [`3e53c1fb`](https://github.com/NixOS/nixpkgs/commit/3e53c1fb8accad954c05ffe641a6c9c703e3f6c0) python3Packages.sphinx-notfound-page: switch to pypaBuildHook
* [`7040fb7e`](https://github.com/NixOS/nixpkgs/commit/7040fb7e9a0662ac9a4030c593a87c3eb95327f6) python3Packages.sphinx-pytest: switch to pypaBuildHook
* [`37303b44`](https://github.com/NixOS/nixpkgs/commit/37303b44dbe8937a4cb0599dee5a3a6fceb56773) python3Packages.threadpoolctl: switch to pypaBuildHook
* [`3bdd8904`](https://github.com/NixOS/nixpkgs/commit/3bdd890423c620b5f47a5e75a8a6a443a97ec469) python3Packages.tidyexc: switch to pypaBuildHook
* [`e5d07ab7`](https://github.com/NixOS/nixpkgs/commit/e5d07ab75212cb621f09f0dc6c0b30120ad8f5a5) python3Packages.tinycss2: switch to pypaBuildHook
* [`2fdcc599`](https://github.com/NixOS/nixpkgs/commit/2fdcc599895f2e4f956c871c7868a62da0b06de9) python3Packages.turnt: switch to pypaBuildHook
* [`4fcabcd8`](https://github.com/NixOS/nixpkgs/commit/4fcabcd8371cca9e0312cb3d5fdc60d30efbe0fd) python3Packages.zeversolarlocal: switch to pypaBuildHook
* [`f9f04e77`](https://github.com/NixOS/nixpkgs/commit/f9f04e7728edab4d92e5e428c793c9820cc7f9d1) brutalmaze: switch to pypaBuildHook
* [`3a2a8ad8`](https://github.com/NixOS/nixpkgs/commit/3a2a8ad856768282d19855ec9c33903689a31075) spf-engine: switch to pypaBuildHook
* [`f8fd7dea`](https://github.com/NixOS/nixpkgs/commit/f8fd7deaabf2e8d8ff0b76a0d4e7afd9ac3e59d4) pynitrokey: switch to pypaBuildHook
* [`c2ab4589`](https://github.com/NixOS/nixpkgs/commit/c2ab4589dce637ac098859bb965b09b08488788f) trueseeing: switch to pypaBuildHook
* [`175f10a5`](https://github.com/NixOS/nixpkgs/commit/175f10a559cd9dd65b096b0ea1a776ce4d746b23) poetry2nix: remove flitBuildHook
* [`bdda7b0a`](https://github.com/NixOS/nixpkgs/commit/bdda7b0a538857f34a413076e06c3a4353efc70a) python3Packages.flitBuildHook: remove
* [`c179caee`](https://github.com/NixOS/nixpkgs/commit/c179caee7e5713bee0f879e779e9d7f6c0e5054f) ginac: 1.8.6 -> 1.8.7
* [`6c8c72da`](https://github.com/NixOS/nixpkgs/commit/6c8c72da9e561a1e5e1be82f290b194c7a1210f3) python310Packages.ml-dtypes: 0.3.0 -> 0.3.1
* [`2cf64b1f`](https://github.com/NixOS/nixpkgs/commit/2cf64b1f132ec7081b9fa3010f45c7c10546c00d) python310Packages.opencensus: 0.11.2 -> 0.11.3
* [`d660b340`](https://github.com/NixOS/nixpkgs/commit/d660b340ee492ccf0723c41e16b93b4abfd9ea46) neuron-mpi: 8.2.2 -> 8.2.3
* [`965683c7`](https://github.com/NixOS/nixpkgs/commit/965683c77b6efb4b906237205397f9baf8259b8d) mongoc: 1.24.3 -> 1.24.4
* [`288c66cc`](https://github.com/NixOS/nixpkgs/commit/288c66cca7429b5f6c1c97a165107a2ac4b6d815) gtkmm3: 3.24.7 -> 3.24.8
* [`84ec00c0`](https://github.com/NixOS/nixpkgs/commit/84ec00c0cbe4c2ad6ae3bd6aa6bf401ca4baa7ad) prometheus-junos-czerwonk-exporter: 0.10.1 -> 0.12.0
* [`d1498e87`](https://github.com/NixOS/nixpkgs/commit/d1498e8782aa8c33f352d19c11c24a6ad78c5148) icingaweb2-ipl: 0.12.0 -> 0.13.0
* [`f408dd93`](https://github.com/NixOS/nixpkgs/commit/f408dd932d4c08d511ddfd68c82324a40e1d5f41) python311Packages.pycookiecheat: 0.5.0 -> 0.6.0
* [`8ef0db39`](https://github.com/NixOS/nixpkgs/commit/8ef0db39e552f4405c407d1be6ee34cb40251f23) protobuf: downgrade default to 3.21 on darwin
* [`47f278a9`](https://github.com/NixOS/nixpkgs/commit/47f278a93631dfb050fca039041646d0377b36b2) dig: tiny code cleanup
* [`4059c4f7`](https://github.com/NixOS/nixpkgs/commit/4059c4f71b3a7339261c0183e365fd8016f24bdb) python311Packages.playwright: 1.37.0 -> 1.38.0
* [`56a9f901`](https://github.com/NixOS/nixpkgs/commit/56a9f90105bd4c448888a87f12be199ab6ebe9a4) libite: 2.5.3 -> 2.6.0
* [`d9c08b45`](https://github.com/NixOS/nixpkgs/commit/d9c08b45684cf6f62f01e086b969b331b18d888e) weechatScripts.wee-slack: 2.10.0 -> 2.10.1
* [`af255c48`](https://github.com/NixOS/nixpkgs/commit/af255c4822842f3500b073a21347e5dd20e72795) maintainers: add mxmlnkn
* [`7ec4ed7b`](https://github.com/NixOS/nixpkgs/commit/7ec4ed7b6cc516640c2305f1c7754a0d904c4af2) python3Packages.indexed-bzip2: init at 1.5.0
* [`2dabc275`](https://github.com/NixOS/nixpkgs/commit/2dabc2752ef8031186c30c0598420e037482d4dc) timeular: 6.2.2 -> 6.3.0
* [`215bb8cf`](https://github.com/NixOS/nixpkgs/commit/215bb8cf5178203cd9df53697e19d2e2a707a02f) teamspeak_client: 3.6.1 -> 3.6.2
* [`62e82eb3`](https://github.com/NixOS/nixpkgs/commit/62e82eb37718f12a5ff5866346170b3113bb7445) linux_xanmod: 6.1.53 -> 6.1.54
* [`cf82e3fa`](https://github.com/NixOS/nixpkgs/commit/cf82e3faabd8d60b3bf526e521db7c4c791ca5f8) linux_xanmod_latest: 6.5.3 -> 6.5.4
* [`b6cece01`](https://github.com/NixOS/nixpkgs/commit/b6cece0113aab5dfada6bb847a03fbc837616c98) python310Packages.jupytext: 1.15.1 -> 1.15.2
* [`2058c02b`](https://github.com/NixOS/nixpkgs/commit/2058c02bad2e5840a2d06d289e98402088d6e411) maintainers: add blankparticle to maintainer-list
* [`69c1daba`](https://github.com/NixOS/nixpkgs/commit/69c1daba76f1c567eaf5da9e0f7259e3f743a673) anilibria-winmaclinux: 1.2.9 -> 1.2.10
* [`6a21aa98`](https://github.com/NixOS/nixpkgs/commit/6a21aa98d33b07dcb7cb49bfa3842b79e7101fb8) python310Packages.localstack-ext: 1.4.0 -> 2.2.0
* [`1d600455`](https://github.com/NixOS/nixpkgs/commit/1d600455cff63d05f3f4bf287f7f28622d32bf2a) mysql80: use finalAttrs
* [`2778e6be`](https://github.com/NixOS/nixpkgs/commit/2778e6befb4505a2d5afeb249e5dc144a328cd40) typesense: 0.25.0 -> 0.25.1
* [`22e7e75b`](https://github.com/NixOS/nixpkgs/commit/22e7e75bfa6f5f4e106c3a0b03c8680126284bc4) cpp-utilities: 5.24.0 -> 5.24.1
* [`185f5e42`](https://github.com/NixOS/nixpkgs/commit/185f5e4254e5aca6d09c455a185a36161316aacf) ldtk: 1.3.4 -> 1.4.0
* [`60c5c0e6`](https://github.com/NixOS/nixpkgs/commit/60c5c0e61b3a7a5d45dec334f33af2ec27b930c5) chezmoi: 2.38.0 -> 2.40.0
* [`1987b350`](https://github.com/NixOS/nixpkgs/commit/1987b350441c59b49127e9cdd2c2596b8a664edb) python3Packages.indexed-gzip: init at 1.8.5
* [`c8976d58`](https://github.com/NixOS/nixpkgs/commit/c8976d5878f1d71ba7dc967dc80b891f4e04b255) python3Packages.indexed-zstd: init at 1.6.0
* [`be9536a6`](https://github.com/NixOS/nixpkgs/commit/be9536a65210441e6c86dd755378ae58d53cb065) python3Packages.python-xz: init at 0.4.0
* [`25c3d229`](https://github.com/NixOS/nixpkgs/commit/25c3d229c7c6558ad86b692a78313abb148453fb) python3Packages.rapidgzip: init at 0.10.3
* [`7e7f626d`](https://github.com/NixOS/nixpkgs/commit/7e7f626d2823be7f546aaa21914ec88b50265bfb) python3Packages.ratarmountcore: init at 0.6.0
* [`5e6a8a64`](https://github.com/NixOS/nixpkgs/commit/5e6a8a643be83c1559e0803cba9b39ea530681a0) python3Packages.ratarmount: init at 0.14.0
* [`a3e7a80c`](https://github.com/NixOS/nixpkgs/commit/a3e7a80c7e4ba80cb46ca813030e03a5a67e6b79) mattermost: 7.10.5 -> 8.1.2
* [`7027aace`](https://github.com/NixOS/nixpkgs/commit/7027aace9fd4ae285e469f8dd15471ab993e7754) bun: 1.0.2 -> 1.0.3
* [`7179886a`](https://github.com/NixOS/nixpkgs/commit/7179886a422562bda2a369b79e30c1afea734581) mangohud: remove unused argument
* [`7ca0ac08`](https://github.com/NixOS/nixpkgs/commit/7ca0ac08596bd6d8f28b662084a58f71c44cf007) mangohud: remove unused `rec`
* [`b91d9a2f`](https://github.com/NixOS/nixpkgs/commit/b91d9a2f0bf7ec620ec1889c57ef06c27f757c0a) jetty: 11.0.15 -> 11.0.16
* [`da787051`](https://github.com/NixOS/nixpkgs/commit/da787051f25bdcef6cb5bb775b8f217269cd4e30) python3Packages.gitpython: 3.1.33 -> 3.1.37
* [`3d8f9f08`](https://github.com/NixOS/nixpkgs/commit/3d8f9f087bbd68726cdacbee5fae21077e9e5766) python311Packages.pygobject-stubs: 2.8.0 -> 2.9.0
* [`860f42f4`](https://github.com/NixOS/nixpkgs/commit/860f42f451f655126c4f103687fd3a51ed7341ef) paperwm: remove manually packaged extension
* [`10ecc311`](https://github.com/NixOS/nixpkgs/commit/10ecc31186b8189bfc14fcc655a4b01f97e42cce) kics: 1.7.7 -> 1.7.8
* [`788cb578`](https://github.com/NixOS/nixpkgs/commit/788cb5788ecab74e12e4d7ae79d142a17a68b922) tts: 0.16.0 -> 0.17.4
* [`8d17521a`](https://github.com/NixOS/nixpkgs/commit/8d17521a05047d5eb83d21e1adb518f68aeb61a4) gi-crystal: 0.17.0 -> 0.18.0
* [`d20d9767`](https://github.com/NixOS/nixpkgs/commit/d20d9767d059d695573dd3a3281eec5872c302cd) poethepoet: init at 0.23.0
* [`db522ccd`](https://github.com/NixOS/nixpkgs/commit/db522ccd096603be4bb3bd6fe11b6c096c85d779) keepassxc: 2.7.5 -> 2.7.6
* [`840a10e8`](https://github.com/NixOS/nixpkgs/commit/840a10e87e211e1ba4290fc1d57862763525ae17) imagemagick: add perlPackages.ImageMagick to passthru.tests
* [`58c5f021`](https://github.com/NixOS/nixpkgs/commit/58c5f021cc670b7f1765b796761d4ab3de1ef75c) imagemagick: add changelog to meta
* [`e912f128`](https://github.com/NixOS/nixpkgs/commit/e912f12890fa716c9d74d92e935bcbe198bc1bd9) imagemagick: 7.1.1-15 -> 7.1.1-18
* [`7ed92e9d`](https://github.com/NixOS/nixpkgs/commit/7ed92e9d6c07c91bb7ac70056aee2139acb605b0) upscayl: 2.8.1 -> 2.8.6
* [`402f3bdc`](https://github.com/NixOS/nixpkgs/commit/402f3bdce63968854da316dbf7ec3b243402b331) quictls: 3.0.10-quic1 -> 3.1.2-quic1
* [`efeded00`](https://github.com/NixOS/nixpkgs/commit/efeded0094d6501b5c6c83f4c691948bf22d8834) xplr: add desktop file and icons
* [`861f42fa`](https://github.com/NixOS/nixpkgs/commit/861f42fa6d79232959b493fe511d80ebde3b1a4b) camunda-modeler: 5.14.0 -> 5.15.1
* [`00e12944`](https://github.com/NixOS/nixpkgs/commit/00e129441455e51ce21266b99119b08a551d012e) urbit: 2.11 -> 2.12
* [`272a0e1e`](https://github.com/NixOS/nixpkgs/commit/272a0e1edb97cbf7cd9903577e363396e54557a8) hmmer: 3.3.2 -> 3.4
* [`b289d79b`](https://github.com/NixOS/nixpkgs/commit/b289d79b8df0f6acfca1fb2367eb71438a3f8ed2) hmmer: add changelog to meta
* [`af539b1b`](https://github.com/NixOS/nixpkgs/commit/af539b1ba3f053e4d61c669cce44da9c266da10d) phrase-cli: 2.11.0 -> 2.12.0
* [`75459e50`](https://github.com/NixOS/nixpkgs/commit/75459e5011257b4a4f62e15056f50d2840bcd5fe) phrase-cli: add changelog to meta
* [`7ee668c4`](https://github.com/NixOS/nixpkgs/commit/7ee668c4e91b3b6dcecf42479b6828620270ea36) bdsync: 0.11.2 -> 0.11.3
* [`42f4e77d`](https://github.com/NixOS/nixpkgs/commit/42f4e77d305240baf4d444e1abfa4f339277007f) bdsync: update homepage
* [`0aa3284c`](https://github.com/NixOS/nixpkgs/commit/0aa3284cedc271fcefdf2326fda8e92df16c12c9) oxtools: 1.1.3 -> 1.2.4
* [`c45be3d8`](https://github.com/NixOS/nixpkgs/commit/c45be3d879f245c6a2b4947ef169268bb8637934) tutanota-desktop: 3.118.7 -> 3.118.8
* [`f0ae65de`](https://github.com/NixOS/nixpkgs/commit/f0ae65ded87345b350a9e81831caa8b6504e0970) jellyfin: 10.8.10 -> 10.8.11
* [`042b5520`](https://github.com/NixOS/nixpkgs/commit/042b55200a43e2e7b206a78f4864a9a740359103) jellyfin-web: 10.8.10 -> 10.8.11
* [`b9f372ba`](https://github.com/NixOS/nixpkgs/commit/b9f372ba3b71185386aef37d6974ff27fb338e21) protobuf: avoid the failing tests on darwin
* [`83ab82d0`](https://github.com/NixOS/nixpkgs/commit/83ab82d09a92d9ccad5e7f2ed73a4e46b7c675fd) protobuf: off-by-one error in failing tests
* [`4bf44efc`](https://github.com/NixOS/nixpkgs/commit/4bf44efc331db774fe4e5663f27b7e0837c58f17) python310Packages.elasticsearch8: 8.9.0 -> 8.10.0
* [`33acbf67`](https://github.com/NixOS/nixpkgs/commit/33acbf67f8479bc35dc10f6e75ecf522e826c3a9) routinator: 0.12.2 -> 0.13.0
* [`7fed4e81`](https://github.com/NixOS/nixpkgs/commit/7fed4e818c92731e1bb99e5a1d91304fda5fef19) gnuplot: 5.4.8 -> 5.4.9
* [`6c7e7684`](https://github.com/NixOS/nixpkgs/commit/6c7e768420039f5757c6ef4999f267ec18492c90) netbox_3_5: introduce alias
* [`c5ba4c68`](https://github.com/NixOS/nixpkgs/commit/c5ba4c687ebef2c7286416814ff80552cc0177c4) nixos/kanata: add default value, doc and warning for devices
* [`5142fe84`](https://github.com/NixOS/nixpkgs/commit/5142fe840a1a6497dacc8034141532e5ad75fd95) mercury: 22.01.7 -> 22.01.8
* [`c22fda4a`](https://github.com/NixOS/nixpkgs/commit/c22fda4a136f65b01c6f0729b001bd72168b016f) python310Packages.lifelines: 0.27.7 -> 0.27.8
* [`59d2aafc`](https://github.com/NixOS/nixpkgs/commit/59d2aafc586ee43b2a0cc643cb19f23031bab8f6) gtree: 1.9.9 -> 1.9.11
* [`a9261391`](https://github.com/NixOS/nixpkgs/commit/a92613918693b0d8e11cbe24d525319576bc7a20) xgboost: 1.7.6 -> 2.0.0
* [`37ff97c1`](https://github.com/NixOS/nixpkgs/commit/37ff97c18ff5417203a1ad2aa839d8c77d7c41e5) oha: 0.6.3 -> 0.6.4
* [`af565af2`](https://github.com/NixOS/nixpkgs/commit/af565af2c72d52d9a670ad47858377f0093c868f) clash-meta: 1.15.1 -> 1.16.0
* [`19113107`](https://github.com/NixOS/nixpkgs/commit/191131077b330289deb5057800a824646a741909) unifi7: 7.4.156 -> 7.5.176
* [`8de99dd1`](https://github.com/NixOS/nixpkgs/commit/8de99dd1cea43450348dec005a49914585b9f1c9) armbian-firmware: init at unstable-2023-09-16
* [`376d892b`](https://github.com/NixOS/nixpkgs/commit/376d892b75762d7adf0a45eb22b74ff471952a57) goredo: 1.30 -> 1.31
* [`30750a3f`](https://github.com/NixOS/nixpkgs/commit/30750a3fa42d6e76490d4a8db6a95fd119c3cf99) perlPackages.ImageMagick: 7.1.0-0 -> 7.1.1-18
* [`db9532dc`](https://github.com/NixOS/nixpkgs/commit/db9532dc4495326d2c8a752dee01896942e6bdf3) nextcloudPackages: update
* [`f2c59d34`](https://github.com/NixOS/nixpkgs/commit/f2c59d3401eedd47689d80e4767bfc951b1eadb2) libsForQt5.kdegraphics-thumbnailers: hardcode Ghostscript path
* [`70b5588b`](https://github.com/NixOS/nixpkgs/commit/70b5588b4e72555f6e788afc0acd3060ab828aef) buildFHSEnvBubblewrap: allow being passed 'pname'
* [`f54c698a`](https://github.com/NixOS/nixpkgs/commit/f54c698a92b14401bd1a00189d2b00fd593fac81) zola: add patch for CVE-2023-40274
* [`2b1dc159`](https://github.com/NixOS/nixpkgs/commit/2b1dc1595822bab15f12c0ba61cdea6ccc393534) palemoon-bin: 32.3.1 -> 32.4.0.1
* [`2ef86dc8`](https://github.com/NixOS/nixpkgs/commit/2ef86dc8488665215739cc0d8990166fe28cfc2d) updated hashes
* [`9428d4d1`](https://github.com/NixOS/nixpkgs/commit/9428d4d129ebb942a6b1c2b52fbe98a6ca55217b) python310Packages.scooby: 0.7.2 -> 0.7.3
* [`e010347d`](https://github.com/NixOS/nixpkgs/commit/e010347d2c738072db109bab3cb9d3e4bebda3fd) chromium: 117.0.5938.88 -> 117.0.5938.92
* [`03720cb5`](https://github.com/NixOS/nixpkgs/commit/03720cb5c6336bbc54ead7d9a9a55e1907837235) ungoogled-chromium: 117.0.5938.88-1 -> 117.0.5938.92-1
* [`6d7c3242`](https://github.com/NixOS/nixpkgs/commit/6d7c3242752be338d5278c6efb9a2c6da9530178) chromedriver: 117.0.5938.88 -> 117.0.5938.92
* [`c105d042`](https://github.com/NixOS/nixpkgs/commit/c105d04235201cad37ad078aa322df69b52e4ba8) python310Packages.django-types: 0.17.0 -> 0.18.0
* [`bed792a1`](https://github.com/NixOS/nixpkgs/commit/bed792a1750111269b95a2123d25675e4f782258) flashfocus: 2.3.1 -> 2.4.0
* [`9f78b12f`](https://github.com/NixOS/nixpkgs/commit/9f78b12f14b694c9bb225300a2931c25b57d09a0) flashfocus: use python3Packages
* [`8f395bb3`](https://github.com/NixOS/nixpkgs/commit/8f395bb3b761417fc57520b2c859f628424e1a7c) wallust: 2.6.1 -> 2.7.1
* [`c9555ed4`](https://github.com/NixOS/nixpkgs/commit/c9555ed4788ecfd2ba249c10d246ceee1b1e70a9) python310Packages.python-lsp-jsonrpc: 1.1.1 -> 1.1.2
* [`540128da`](https://github.com/NixOS/nixpkgs/commit/540128daca90f06f50b12fee8371a7a67c15fd18) powershell: 7.3.4 -> 7.3.7
* [`599abc26`](https://github.com/NixOS/nixpkgs/commit/599abc266c31b3d912e3b96254bce38651f27636) slack: Updatescript allow independent updates between linux and macos
* [`900cf249`](https://github.com/NixOS/nixpkgs/commit/900cf249683b73e0f09aafe13dbc3966d754619a) tailspin: 1.4.0 -> 1.5.1
* [`60894304`](https://github.com/NixOS/nixpkgs/commit/608943047157e05fc547e119dc46ed8b629cd075) nghttp3: 0.14.0 -> 0.15.0
* [`44de196b`](https://github.com/NixOS/nixpkgs/commit/44de196b3e318aece55e9cd57afa50f0e402e567) libsolv: 0.7.24 -> 0.7.25
* [`0ee7eda9`](https://github.com/NixOS/nixpkgs/commit/0ee7eda9f63f67baa8b5a24e0df21a1dd8807d33) goreleaser: 1.20.0 -> 1.21.0
* [`e071b148`](https://github.com/NixOS/nixpkgs/commit/e071b148152e7ea5c7d63449cf7d10643a4033a2) python310Packages.bibtexparser: 1.4.0 -> 1.4.1
* [`55446ef5`](https://github.com/NixOS/nixpkgs/commit/55446ef5abfb46ccf28ef94ba161ec8a0ba7ee1c) msitools: 0.102 -> 0.103
* [`4560afb3`](https://github.com/NixOS/nixpkgs/commit/4560afb3fdec2f9a37286b1825ff208b219ee0b1) rectangle-pro: 3.0.9 -> 3.0.11
* [`18ed405d`](https://github.com/NixOS/nixpkgs/commit/18ed405de1f077ab9faa5ae8eec86a293aebcb1e) gitea-actions-runner: 0.2.5 -> 0.2.6
* [`55f81984`](https://github.com/NixOS/nixpkgs/commit/55f819840cd2a50a23d64b199f90685240e6938c) python310Packages.ray: clean up
* [`c144e291`](https://github.com/NixOS/nixpkgs/commit/c144e2919b2974f138031bccc0981a3570594388) postman: 10.15.0 → 10.18.6
* [`0a017f94`](https://github.com/NixOS/nixpkgs/commit/0a017f947fc9a060bfdd79a8e885f1d54fd8a592) ppsspp-sdl: 1.16.1 -> 1.16.2
* [`1fe8e279`](https://github.com/NixOS/nixpkgs/commit/1fe8e279c6cda3f82928d35372a4f7fa8308301c) zimfw: 1.12.0 -> 1.12.1
* [`0ec8744e`](https://github.com/NixOS/nixpkgs/commit/0ec8744ee4ad02ec5f55dd0ea71aee190d7f6a77) pinniped: 0.25.0 -> 0.26.0
* [`45db1589`](https://github.com/NixOS/nixpkgs/commit/45db15894162298e37434a0184cb5caea2bb4262) earthly: 0.7.17 -> 0.7.19
* [`ff24f7f0`](https://github.com/NixOS/nixpkgs/commit/ff24f7f057475133f049c185db4ad131c9b37686) tempo: 2.2.2 -> 2.2.3
* [`d496fdaf`](https://github.com/NixOS/nixpkgs/commit/d496fdaf2a62b3441d316163838485bf7e4d798d) keybase{-gui}: 6.0.2 → 6.2.2
* [`18de4486`](https://github.com/NixOS/nixpkgs/commit/18de4486c53ca3caf7cb018bab615795e55474bf) oauth2-proxy: 7.4.0 -> 7.5.1
* [`588430cf`](https://github.com/NixOS/nixpkgs/commit/588430cf83681baf643c0dee5c3379aaabd5a205) mdbook-admonish: 1.11.1 -> 1.12.1
* [`4246e2df`](https://github.com/NixOS/nixpkgs/commit/4246e2df282de09090a6b236a8bbc4d9b5efe399) sbt-extras: 2023-09-14 -> 2023-09-18
* [`f5eea362`](https://github.com/NixOS/nixpkgs/commit/f5eea362ada3b6afce3f51daef485daed9ca0009) hugo: 0.118.2 -> 0.119.0
* [`48e2e83d`](https://github.com/NixOS/nixpkgs/commit/48e2e83db5ae5bb915d5956ba198ea0fb02f3b61) ocamlPackages.ptime: fix evaluation
* [`aa54e0d6`](https://github.com/NixOS/nixpkgs/commit/aa54e0d65df183b8914adf7c2db543055e060ecf) inetutils: add patch for CVE-2023-40303
* [`cc841fa4`](https://github.com/NixOS/nixpkgs/commit/cc841fa4302161b7e76f496686242f7d152fbcec) inetutils: enable tests
* [`110b0e7b`](https://github.com/NixOS/nixpkgs/commit/110b0e7b4269aa7aa00ef1294c9abe9c13780756) python310Packages.unearth: 0.10.0 -> 0.11.0
* [`90bfd22d`](https://github.com/NixOS/nixpkgs/commit/90bfd22df36b8930978ad3b9d2391c38f8e4989c) slweb: 0.6.7 -> 0.6.9
* [`c0b75164`](https://github.com/NixOS/nixpkgs/commit/c0b7516465a16407337218faf778533edd4c00a8) php81Extensions.mongodb: 1.16.1 -> 1.16.2
* [`0c4487f5`](https://github.com/NixOS/nixpkgs/commit/0c4487f5be818f26c5e7183515ce2c0136856dd0) mympd: 12.0.1 -> 12.0.2
* [`9d7860c7`](https://github.com/NixOS/nixpkgs/commit/9d7860c7e7830d9bf82733cecd443ff167dc2174) maintainers: add alexoundos
* [`17f036f4`](https://github.com/NixOS/nixpkgs/commit/17f036f4fbdd1024ebc91ff58686b9b8ce62990b) castopod: init at 1.6.4
* [`cf6e43a3`](https://github.com/NixOS/nixpkgs/commit/cf6e43a3dd32d1fce0a315afd365aa90ee19130d) nixos/castopod: init
* [`c220d280`](https://github.com/NixOS/nixpkgs/commit/c220d280b0696d1e8a49d1174f57e0880f33a421) nixosTests.castopod: init
* [`11885016`](https://github.com/NixOS/nixpkgs/commit/11885016e8aef680b26b92d1559f747f7c693ea4) flyway: 9.22.0 -> 9.22.2
* [`7afff92b`](https://github.com/NixOS/nixpkgs/commit/7afff92bb5433924743b9b99b5a40b755f3e40eb) python311Packages.pytest-md-report: 0.4.0 -> 0.4.1
* [`a7e7daf6`](https://github.com/NixOS/nixpkgs/commit/a7e7daf60d360dd518903db8dd0874419ccc6f01) qemu: 8.1.0 -> 8.1.1
* [`fbba24df`](https://github.com/NixOS/nixpkgs/commit/fbba24df231a268138f60ba513cf2e8549128777) pkg: 1.20.5 -> 1.20.7
* [`2b0d750c`](https://github.com/NixOS/nixpkgs/commit/2b0d750c75458435655fdc1614e982c8a5f31734) lego: 4.14.0 -> 4.14.2
* [`19c44fc4`](https://github.com/NixOS/nixpkgs/commit/19c44fc47bb58d2667207d1d6d5619d5cb201b3b) python311Packages.aliyun-python-sdk-iot: 8.56.0 -> 8.57.0
* [`fbfb0538`](https://github.com/NixOS/nixpkgs/commit/fbfb0538bb92e818537efcbded9dddb04fa2c867) theharvester: 4.4.3 -> 4.4.4
* [`b9abb322`](https://github.com/NixOS/nixpkgs/commit/b9abb322774ccc19641858cdc0c5902474550e7f) python311Packages.wsgidav: 4.2.0 -> 4.3.0
* [`ebecdc91`](https://github.com/NixOS/nixpkgs/commit/ebecdc9177ee053e0b44b1690f1321ff9c0af81a) python311Packages.aioesphomeapi: 16.0.5 -> 16.0.6
* [`252db83b`](https://github.com/NixOS/nixpkgs/commit/252db83bd02449fc4d9043c358ad9b835b260193) python311Packages.aemet-opendata: 0.4.4 -> 0.4.5
* [`192fd736`](https://github.com/NixOS/nixpkgs/commit/192fd73631fc3c64117da7a1c80ce5fab99410e8) python311Packages.bluetooth-data-tools: 1.11.0 -> 1.12.0
* [`555db284`](https://github.com/NixOS/nixpkgs/commit/555db28461e9e590ce3173eb55ad21a544231e29) gotify-server: 2.3.0 -> 2.4.0 ([nixos/nixpkgs⁠#257191](https://togithub.com/nixos/nixpkgs/issues/257191))
* [`4dfc7ef0`](https://github.com/NixOS/nixpkgs/commit/4dfc7ef0faa5ca64e80504b91dbbe75e45e9950d) python310Packages.s3fs: 2023.9.1 -> 2023.9.2
* [`2896a520`](https://github.com/NixOS/nixpkgs/commit/2896a5203907130e3da4b6557552cbfb60c75eeb) python310Packages.sagemaker: 2.184.0.post0 -> 2.187.0
* [`892c7521`](https://github.com/NixOS/nixpkgs/commit/892c75210b5cb824229f53e3e5b497bd8e5b4c1a) python311Packages.rns: 0.5.9 -> 0.6.0
* [`68ae453d`](https://github.com/NixOS/nixpkgs/commit/68ae453d2469b621a4e6058a8e48238cba566348) python311Packages.nomadnet: 0.3.7 -> 0.3.8
* [`80b7bfad`](https://github.com/NixOS/nixpkgs/commit/80b7bfad6dde0c122918bfb1480ad20ed9d53032) python311Packages.gitlike-commands: init at 0.2.1
* [`23e910bb`](https://github.com/NixOS/nixpkgs/commit/23e910bb7f22945d5e87ba9a65a5365fd6d57954) ddnet: 17.2.1 -> 17.3
* [`96fc2689`](https://github.com/NixOS/nixpkgs/commit/96fc2689944cf258cf117ce2094699a84f43f37f) python311Packages.thelogrus: init at 0.7.0
* [`f6e94961`](https://github.com/NixOS/nixpkgs/commit/f6e94961765802e246df1c925d52358fb9f41ed3) Make rPackage.sf build fixes 257221
* [`d75b2f56`](https://github.com/NixOS/nixpkgs/commit/d75b2f56d0808450c49cebcb7a1beabc0bbd704c) erlang_26: 26.0.2 -> 26.1
* [`acc1ad38`](https://github.com/NixOS/nixpkgs/commit/acc1ad38e78d15c094698041e72d0bd65f3d33e4) python311Packages.ha-mqtt-discoverable: init at 0.10.0
* [`801e33f5`](https://github.com/NixOS/nixpkgs/commit/801e33f56288bbbac28acdfe783e9229441fb9a8) neovim: pass wrapper args only once ([nixos/nixpkgs⁠#257136](https://togithub.com/nixos/nixpkgs/issues/257136))
* [`6b7e9200`](https://github.com/NixOS/nixpkgs/commit/6b7e9200e7477bdb8fba18f5fbfecfc054f9c207) python310Packages.transmission-rpc: 7.0.0 -> 7.0.1
* [`436e6e81`](https://github.com/NixOS/nixpkgs/commit/436e6e81211521ebc2c1d63f0c88614581857afe) ha-mqtt-discoverable-cli: init at 0.2.1
* [`ddf49610`](https://github.com/NixOS/nixpkgs/commit/ddf49610feeaf223ca65dd73d6ebff104ebc7ae4) python311Packages.policy-sentry: 0.12.9 -> 0.12.10
* [`7dce442a`](https://github.com/NixOS/nixpkgs/commit/7dce442ac9e6ea1d5c202bc29ae0b163bfd2dfa7) python310Packages.yamlordereddictloader: 0.4.0 -> 0.4.2
* [`78d96b5c`](https://github.com/NixOS/nixpkgs/commit/78d96b5c8ba7ebbf6350cc0b0e08257eef0ef7a7) cdo: 2.2.0 -> 2.2.2 ([nixos/nixpkgs⁠#257101](https://togithub.com/nixos/nixpkgs/issues/257101))
* [`6ae570f7`](https://github.com/NixOS/nixpkgs/commit/6ae570f76b959a7467983cb99a4f7fffe33d155d) pythonInterpreters.pypy27_prebuilt: 3.7.11 -> 3.7.12
* [`de810c81`](https://github.com/NixOS/nixpkgs/commit/de810c814c751bd19aa055ded9ca36c2cd917a6f) python310Packages.pinecone-client: 2.2.2 -> 2.2.4
* [`897629a4`](https://github.com/NixOS/nixpkgs/commit/897629a42f8a105fd88b261821f8d1094f1d7e77) pict-rs: 0.4.2 -> 0.4.3
* [`9b15be3a`](https://github.com/NixOS/nixpkgs/commit/9b15be3aa95477afa6088dabd1d106e2c8be462a) pythonInterpreters.pypy39_prebuilt: 7.3.11 -> 7.3.12
* [`517371b5`](https://github.com/NixOS/nixpkgs/commit/517371b548437595f13c3a7149f654a4eff2804f) python310Packages.pyfiglet: 1.0.1 -> 1.0.2
* [`54c3b0f1`](https://github.com/NixOS/nixpkgs/commit/54c3b0f1dae6a321b0f42bdd7ce1b3437c32dc25) mattermost-desktop: 5.3.1 -> 5.5.0
* [`e0874acb`](https://github.com/NixOS/nixpkgs/commit/e0874acbdd225736634dd352e9939da093dfaa4e) pypy27: 7.3.11 -> 7.3.12
* [`c5c30274`](https://github.com/NixOS/nixpkgs/commit/c5c30274a30231438347f2ede1a504b9b5c86b9a) nixosTests.tinywl: fix by adding Mesa drivers
* [`2b0c3f00`](https://github.com/NixOS/nixpkgs/commit/2b0c3f0001b0c8ac7932d5cb780b842c35e7e75c) pypy39: 3.7.11 -> 3.7.12
* [`ec9b9147`](https://github.com/NixOS/nixpkgs/commit/ec9b914767dcd589bc47d8ed73f21e429b95c4e6) eza: 0.13.0 -> 0.13.1
* [`310c3a1e`](https://github.com/NixOS/nixpkgs/commit/310c3a1e26cd33defd3228383de12324da40e406) clang-tools: add optional support for libcxx
* [`795e0c08`](https://github.com/NixOS/nixpkgs/commit/795e0c0851dd6fb1e22fabdd62c75a7d7cd37940) pypy310: init at 3.7.12
* [`3bf3656c`](https://github.com/NixOS/nixpkgs/commit/3bf3656cd084c806ee3b9e9a3247481829437c2a) linux_testing: 6.6-rc2 -> 6.6-rc3
* [`80ab54b3`](https://github.com/NixOS/nixpkgs/commit/80ab54b3afb73a3563f1d5bf48269191f1a7c52e) python3Packages.qtile: 0.22.1 -> 0.23.0
* [`2fcf9739`](https://github.com/NixOS/nixpkgs/commit/2fcf97398d9b9afac2db46302a81e671f06bdf72) python3Packages.pywlroots: 0.15.24 -> 0.16.5
* [`544a62c5`](https://github.com/NixOS/nixpkgs/commit/544a62c5a52f970faa849cd3d20598c560d3e7fb) uutils-coreutils-noprefix: init at 0.0.20
* [`df70b260`](https://github.com/NixOS/nixpkgs/commit/df70b260cede5b9458d4c3a48d7d7fe2d5b6e719) newsboat: 2.32 -> 2.33
* [`6500b458`](https://github.com/NixOS/nixpkgs/commit/6500b4580c2a1f3d0f980d32d285739d8e156d92) Revert "nixos/boot/rasbperrypi: add support for boot.initrd.secret with uboot ([nixos/nixpkgs⁠#240358](https://togithub.com/nixos/nixpkgs/issues/240358))" ([nixos/nixpkgs⁠#257251](https://togithub.com/nixos/nixpkgs/issues/257251))
* [`7694f0e7`](https://github.com/NixOS/nixpkgs/commit/7694f0e7fba69301c53ea939084b1b09c2c083df) python310Packages.gspread: 5.11.1 -> 5.11.2
* [`8eb2f6c4`](https://github.com/NixOS/nixpkgs/commit/8eb2f6c4192e07c0f2e4523853e5bb6c5a485cdb) python310Packages.softlayer: 6.1.8 -> 6.1.9
* [`034b9ec5`](https://github.com/NixOS/nixpkgs/commit/034b9ec5f7f3dfcf19c962246f0d4bdb1541c9c6) pantheon.appcenter: 7.3.0 -> 7.4.0 ([nixos/nixpkgs⁠#257248](https://togithub.com/nixos/nixpkgs/issues/257248))
* [`ddccd7aa`](https://github.com/NixOS/nixpkgs/commit/ddccd7aa5558744f294f0ed1fb1f40d3bb5b1300) mg.meta.mainProgram: init
* [`7bcb119e`](https://github.com/NixOS/nixpkgs/commit/7bcb119e9a728198ce15e446d97bcb81f832773c) lynx.meta.mainProgram: init
* [`584d0cce`](https://github.com/NixOS/nixpkgs/commit/584d0cce2afd35c161315600eeef8823392f60ff) catgirl.meta.mainProgram: init
* [`ac683a48`](https://github.com/NixOS/nixpkgs/commit/ac683a485f14fa632e1a870c375ae9615ef70560) cloud-hypervisor.meta.mainProgram: init
* [`a2024d5e`](https://github.com/NixOS/nixpkgs/commit/a2024d5e35eca912eceeac60484afe0dd37d845b) crosvm.meta.mainProgram: init
* [`bcbcb3b5`](https://github.com/NixOS/nixpkgs/commit/bcbcb3b54bd62e50107523cd2fee762ca021c606) weston.meta.mainProgram: init
* [`c1a53897`](https://github.com/NixOS/nixpkgs/commit/c1a53897ad4290a1cbfa02fbe6f3869577b93744) wayland-proxy-virtwl.meta.mainProgram: init
* [`d72b2ed9`](https://github.com/NixOS/nixpkgs/commit/d72b2ed9acc6d66be266bc21b9f8462c45841832) python27: disable tests that expect Python 3+
* [`90897a92`](https://github.com/NixOS/nixpkgs/commit/90897a92507b9a3709366e9fc9694529ea8ffb8d) zoom-us: 5.15.12.7665 -> 5.16.1.8561
* [`33da8de2`](https://github.com/NixOS/nixpkgs/commit/33da8de2cf7b959be2a4e841c88466a29b9dd696) firefox-unwrapped: 117.0.1 -> 118.0
* [`90b6e231`](https://github.com/NixOS/nixpkgs/commit/90b6e231f626296300afb2309e66be4f4a573f8f) firefox-bin-unwrapped: 117.0.1 -> 118.0
* [`63971ee5`](https://github.com/NixOS/nixpkgs/commit/63971ee519cafb072d13416ea834374b3f4e9abe) firefox-esr-115-unwrapped: 115.2.1esr -> 115.3.0esr
* [`47c93f08`](https://github.com/NixOS/nixpkgs/commit/47c93f08d11f12ba6104d82b568ab5c0627f34b7) cargo-audit: 0.18.1 -> 0.18.2
* [`f90b4f2d`](https://github.com/NixOS/nixpkgs/commit/f90b4f2d9afe8706f35f44f62314b98a2d744d92) python3Packages.tifffile: skip large tests
* [`0594cd57`](https://github.com/NixOS/nixpkgs/commit/0594cd578af2035e4df34ca1277de51a2c5bfb62) python310Packages.zigpy: 0.57.1 -> 0.57.2
* [`35501552`](https://github.com/NixOS/nixpkgs/commit/3550155242c3fea52e2257d38714d87051766b85) sing-box: 1.4.3 -> 1.4.5
* [`a884775f`](https://github.com/NixOS/nixpkgs/commit/a884775ffb2c6d050ef5c0a0c156228d14dff93d) findomain: fix build on darwin
* [`370097ce`](https://github.com/NixOS/nixpkgs/commit/370097ce864f731c6e281ab3970cef1b39dfa06f) remove the misleading warning on using `nix-env` for split outputs ([nixos/nixpkgs⁠#255947](https://togithub.com/nixos/nixpkgs/issues/255947))
* [`f1bdffc9`](https://github.com/NixOS/nixpkgs/commit/f1bdffc97aa837599ea012702e97713367d034ab) micropython: 1.19.1 -> 1.20.0
* [`d822acc5`](https://github.com/NixOS/nixpkgs/commit/d822acc538a8b261b9a7e43781a848627b9cf7f0) amdvlk: 2023.Q3.1 -> 2023.Q3.2
* [`0d4cbbb9`](https://github.com/NixOS/nixpkgs/commit/0d4cbbb9df1c38f9c64a254a4d75b4951618c224) teams-for-linux: 1.3.8 -> 1.3.11
* [`fba19509`](https://github.com/NixOS/nixpkgs/commit/fba19509b1ebed5a341494d9e501cc4cf7a7fb59) use `nix-shell -p` for `dhall-to-nixpkgs` example
* [`d8b16f74`](https://github.com/NixOS/nixpkgs/commit/d8b16f741886704c3d9b3983d61c6ad448b5a623) pgrok: move to node-packages.nix
* [`43eecf9c`](https://github.com/NixOS/nixpkgs/commit/43eecf9c7a7e119fb400e57dfebf86f0345890ea) firefox-bin: cleanup, use autoPatchelfHook
* [`40483b3b`](https://github.com/NixOS/nixpkgs/commit/40483b3bb58e75182cfec66d8e8c24b47f56888d) firefox-bin: derive binary name from channel
* [`db6eb8f6`](https://github.com/NixOS/nixpkgs/commit/db6eb8f6bbfca56cb56c67880d03452d739e7b7b) firefox-*-bin: fix branding and wmClass config to match upstream
* [`a079fbbc`](https://github.com/NixOS/nixpkgs/commit/a079fbbcabee88c1f439d31fd4dac350887a3407) python311Packages.aiohomekit: 3.0.3 -> 3.0.4
* [`33c352b2`](https://github.com/NixOS/nixpkgs/commit/33c352b2f440d8e5e061c3b085092fbc014e026b) python311Packages.aliyun-python-sdk-core: 2.13.36 -> 2.14.0
* [`eb83e438`](https://github.com/NixOS/nixpkgs/commit/eb83e438cb775c9cc5417becb73ab1ec28c7353d) python311Packages.aiocomelit: 0.0.6 -> 0.0.8 ([nixos/nixpkgs⁠#256641](https://togithub.com/nixos/nixpkgs/issues/256641))
* [`b1f5f4fc`](https://github.com/NixOS/nixpkgs/commit/b1f5f4fc2d43286ba2065b054bb7f39344e0f6a2) python311Packages.bellows: 0.36.3 -> 0.36.4
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
