### PR TITLE
niv home-manager: update a88df2fb -> 6f9b5b83

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a88df2fb101778bfd98a17556b3a2618c6c66091",
-        "sha256": "0wb5bxxx7isqcgzcfg8a6pl7hwkzl3z0rnbr9vjzvxrs4vz53366",
+        "rev": "6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30",
+        "sha256": "1glsbl0an2ac2612n8mk5id6aq6md15qfnpj5i99vvvqywikplyx",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a88df2fb101778bfd98a17556b3a2618c6c66091.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a88df2fb...6f9b5b83](https://github.com/nix-community/home-manager/compare/a88df2fb101778bfd98a17556b3a2618c6c66091...6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30)

* [`dd88dbc6`](https://github.com/nix-community/home-manager/commit/dd88dbc69438384bd94f8282584a86798750028c) neovim: expose `finalPackage`
* [`0f4e5b49`](https://github.com/nix-community/home-manager/commit/0f4e5b4999fd6a42ece5da8a3a2439a50e48e486) keychain: fix edge-cases in nushell integration
* [`1d813ff5`](https://github.com/nix-community/home-manager/commit/1d813ff5a677c2e97a4cb0726bbb3b6ebce1c8ed) qt: remove qtstyleplugin-kvantum-qt4
* [`9d4cdf8c`](https://github.com/nix-community/home-manager/commit/9d4cdf8cc4da54beb5d2e927af7a259bb4a00645) Translate using Weblate (Danish)
* [`2ccb5cb5`](https://github.com/nix-community/home-manager/commit/2ccb5cb542357af20eb18c83f38571da7b3bcff6) Translate using Weblate (Turkish)
* [`4f02e35f`](https://github.com/nix-community/home-manager/commit/4f02e35f9d150573e1a710afa338846c2f6d850c) direnv: add package options
* [`f1b7775d`](https://github.com/nix-community/home-manager/commit/f1b7775d2393f41acd2b46acaccf0ab6431dea8b) awscli: add module
* [`ae896c81`](https://github.com/nix-community/home-manager/commit/ae896c810f501bf0c3a2fd7fc2de094dd0addf01) home-manager: set profile path variables lazily
* [`209a24df`](https://github.com/nix-community/home-manager/commit/209a24dff2b1098f24013cb4877d86cd0ae67c21) wpaperd: add wpaperd configuration
* [`6f9b5b83`](https://github.com/nix-community/home-manager/commit/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30) khard: add module
