### PR TITLE
niv zsh-completions: update c0fe16fd -> c05d0fdf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "c0fe16fdadfc8fa8e26247e467bf09aeb7f3b4ca",
-        "sha256": "0h6b8czv5d1wnkpqcb7w0mnflm5vm6v56i6w7ny9gh5mpm1gqyz7",
+        "rev": "c05d0fdfe08ff3cd4fe0603f5032a2c0ed2bd25a",
+        "sha256": "1iq54c076r66chbkcpbpd003y0wgqld6f9sqs49ibsdcf3k3cr3c",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/c0fe16fdadfc8fa8e26247e467bf09aeb7f3b4ca.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/c05d0fdfe08ff3cd4fe0603f5032a2c0ed2bd25a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@c0fe16fd...c05d0fdf](https://github.com/zsh-users/zsh-completions/compare/c0fe16fdadfc8fa8e26247e467bf09aeb7f3b4ca...c05d0fdfe08ff3cd4fe0603f5032a2c0ed2bd25a)

* [`0a1a8b89`](https://github.com/zsh-users/zsh-completions/commit/0a1a8b89d9dd591f28d5a948241223989c7a06b4) Update rails new and generate completion
* [`9f9c4dec`](https://github.com/zsh-users/zsh-completions/commit/9f9c4dec36301c08614447db1385bc4dfb31c1ed) Update generator subcommand completions
* [`d7f6a06e`](https://github.com/zsh-users/zsh-completions/commit/d7f6a06e1a8a76bffcc91bcd8fd35cd873ef87dc) Remove needless generate functions
* [`8068693a`](https://github.com/zsh-users/zsh-completions/commit/8068693aee055a64297ee969bfeb060702205620) Update console and server completions
* [`1a9467fd`](https://github.com/zsh-users/zsh-completions/commit/1a9467fdffc88b3406570f2d156c62604da7d3ea) Update generate and destroy completions
* [`7a195989`](https://github.com/zsh-users/zsh-completions/commit/7a19598927e6cfefcba233bfb713d42377fca072) Update test completion
* [`2c5bfabb`](https://github.com/zsh-users/zsh-completions/commit/2c5bfabb5e679c80936b70a9556c605662d2ab50) Add task completions
* [`e7ccc559`](https://github.com/zsh-users/zsh-completions/commit/e7ccc5594743032a487d8f2d785458732bcf4cbe) Fix missing completion
