### PR TITLE
niv nixpkgs: update fe0b3b66 -> e904535e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fe0b3b663e98c85db7f08ab3a4ac318c523c0684",
-        "sha256": "1amc0lhq1zgznnlzz1yi6rifk9mh8p067y83476bcwrb4d6hsvn3",
+        "rev": "e904535e00cf4651f543779ec05a6528c257310e",
+        "sha256": "013j2a5yq44vd913190qb00lmikhszfvvaxbsxfj23av1r8zwqpk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/fe0b3b663e98c85db7f08ab3a4ac318c523c0684.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e904535e00cf4651f543779ec05a6528c257310e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@fe0b3b66...e904535e](https://github.com/nixos/nixpkgs/compare/fe0b3b663e98c85db7f08ab3a4ac318c523c0684...e904535e00cf4651f543779ec05a6528c257310e)

* [`0685074c`](https://github.com/NixOS/nixpkgs/commit/0685074cea31dba471417db9d6cc8853e0b7b273) nixos/pgmanage: use package option
* [`ea9bc335`](https://github.com/NixOS/nixpkgs/commit/ea9bc3357b94092f1d340badfdddd3a0ed49d987) perlPackages.MojoliciousPluginI18N: init at 1.6
* [`d97724ac`](https://github.com/NixOS/nixpkgs/commit/d97724aca4d2310bdf584b560456b8f9f7376fff) perlPackages.Yancy: init at 1.088
* [`4a33cdf6`](https://github.com/NixOS/nixpkgs/commit/4a33cdf644e5deff70008927ff939694e0bb11dc) perlPackages.CPANAudit: init at 20230309.004
* [`183651da`](https://github.com/NixOS/nixpkgs/commit/183651dabaaeb2b5e387f184322a0b4cf4164cee) perlPackages.ModuleExtractVERSION: init at 1.116
* [`1ed6468c`](https://github.com/NixOS/nixpkgs/commit/1ed6468c276a295f5a336f126ef695ab25f58acb) nixos.tinyproxy: init
* [`ae31454d`](https://github.com/NixOS/nixpkgs/commit/ae31454d41ae6d706f80a9deb3cf5c4d5c89c334) nixosTests.tinyproxy: init
* [`e2712f31`](https://github.com/NixOS/nixpkgs/commit/e2712f31813a94ffe49063faccd784d06ee825eb) python3Packages.beautifulsoup4: add some key reverse dependencies to passthru.tests
* [`e23693e1`](https://github.com/NixOS/nixpkgs/commit/e23693e12944091b2cc27675f4d14b77f805bfea) systemd stage 1 networking: Use KeepConfiguration
* [`1222f87a`](https://github.com/NixOS/nixpkgs/commit/1222f87acb4cd1164c09c629e0ee17930dac7ec6) python311Packages.succulent: init at 0.2.3
* [`f89d78b6`](https://github.com/NixOS/nixpkgs/commit/f89d78b6744008c877b2e855efb5826009f99f1b) pdfstudioviewer: mark broken
* [`926c920c`](https://github.com/NixOS/nixpkgs/commit/926c920c12703883a7e946e9bbebf8d0d00af31a) gcc: tighten condition for inhibit_libc=true
* [`1ce7106b`](https://github.com/NixOS/nixpkgs/commit/1ce7106b9e49a0abb9e83a84454a4a4af66c0374) python3Packages.pyqt5-stubs: init at 5.15.6.0
* [`ee8b4482`](https://github.com/NixOS/nixpkgs/commit/ee8b4482ab02747f8a21f40f9a825e2e854b7dc2) python3Packages.qt-material: init at 2.14
* [`5f445e8c`](https://github.com/NixOS/nixpkgs/commit/5f445e8cf578d0e180d50fca1f13e55a3739a39a) nixos/matrix-synapse: fix duplicate Content-Type header in example
* [`746bbc96`](https://github.com/NixOS/nixpkgs/commit/746bbc964e39218dd3b028989b5019c795327039) python310Packages.robotframework: 6.0.2 -> 6.1.1
* [`8131fc5e`](https://github.com/NixOS/nixpkgs/commit/8131fc5ee61d7730270f7311f7db68c532d39f1a) nixos/gnupg: require sockets.target, not just gpg-agent.socket
* [`faa21821`](https://github.com/NixOS/nixpkgs/commit/faa21821a7253cc88bc003def16c1ef200ec2311) maintainers: add rickvanprim
* [`8400b140`](https://github.com/NixOS/nixpkgs/commit/8400b1403977d28c7c95a8e88885d667c3bcbe19) cargo-bazel: init at 0.8.0
* [`b7ced4be`](https://github.com/NixOS/nixpkgs/commit/b7ced4be935ec7d7771cc209d5aa3844a1ced844) python3Packages.irctokens: 2.0.1 -> 2.0.2
* [`c7ca9e5f`](https://github.com/NixOS/nixpkgs/commit/c7ca9e5ffb093c07391314054bc23067fe4d8a3d) python3Packages.ircstates: 0.11.8 -> 0.12.1
* [`7ebafb89`](https://github.com/NixOS/nixpkgs/commit/7ebafb8972f30a89e0927cabdc01f9e5a4d8fd4d) python3Packages.ircrobots: 0.4.6 -> 0.6.6
* [`a8f2eb65`](https://github.com/NixOS/nixpkgs/commit/a8f2eb65876a5fadb851861f3ca6b97e6d983447) fallout-ce: init at 1.0.0
* [`14beb3f6`](https://github.com/NixOS/nixpkgs/commit/14beb3f644164def45aedd5d57600b7114ce7e4c) fallout2-ce: init at 1.2.0
* [`1143c63f`](https://github.com/NixOS/nixpkgs/commit/1143c63f1a8e6cebd8234fdb23afa5358ef8f2a5) container2wasm: init at 0.4.0
* [`140b6ebd`](https://github.com/NixOS/nixpkgs/commit/140b6ebdccd99e665629e4be9ba51d21cbc4be3b) google-guest-agent: 20230726.00 -> 20230821.00
* [`e39d5799`](https://github.com/NixOS/nixpkgs/commit/e39d57991886bcae28a1c7f51afa66ebdfb56a72) lib/licenses: add Elastic License 2.0, drop Elastic License
* [`05d054f2`](https://github.com/NixOS/nixpkgs/commit/05d054f25b361db1d11ce4fb62a0e57c1f0cccd4) ludusavi: 0.20.0 -> 0.21.0
* [`7a2e2458`](https://github.com/NixOS/nixpkgs/commit/7a2e2458a6b6b367c96bd3ea0124c77da9fc9cc8) mariadb-connector-odbc: fix build with clang 16 on Darwin
* [`6943a9a6`](https://github.com/NixOS/nixpkgs/commit/6943a9a6febe3eb9fb8310082ff420896f8fae1e) timidity: fix build with clang 16
* [`d9d02dfc`](https://github.com/NixOS/nixpkgs/commit/d9d02dfc325634873c3e57eb20ec1c90cbe38c8d) millipixels: init at 0.22.0
* [`9805b907`](https://github.com/NixOS/nixpkgs/commit/9805b9075efaa3be5605a7686328d500f69b2032) makemkv: clarify license
* [`ae0f776b`](https://github.com/NixOS/nixpkgs/commit/ae0f776b7200c82e0e78c6214ae0dad6369b742d) makemkv: make reproducible
* [`36a51e27`](https://github.com/NixOS/nixpkgs/commit/36a51e27cbcbd8c77ccf67cb79c738e391d0e9ad) makemkv: enable parallel building
* [`fc37c2d5`](https://github.com/NixOS/nixpkgs/commit/fc37c2d52491ff23835e69594bc0dfc7bb437794) linuxManualConfig: generalize `depmod` resolution
* [`435cacfb`](https://github.com/NixOS/nixpkgs/commit/435cacfb5e51410742e3e04bf4060c77422e3b6c) dotnet-sdk_6: 6.0.413 -> 6.0.414
* [`2986a48d`](https://github.com/NixOS/nixpkgs/commit/2986a48d63d923df43ad5e3ab8d2e73882cb0b06) dotnet-sdk: 7.0.400 -> 7.0.401
* [`246013fb`](https://github.com/NixOS/nixpkgs/commit/246013fb25376a2f8131779319123c2fbc5d283b) nitrokey-app2: init at 2.1.2
* [`ab466279`](https://github.com/NixOS/nixpkgs/commit/ab466279f2f85293341206aa37b70ce541ce0f17) dotnet-sdk_8: 8.0.100-preview.5.23303.2 -> 8.0.100-rc.1.23455.8
* [`c1cb90fd`](https://github.com/NixOS/nixpkgs/commit/c1cb90fd89311be9d48018baad3775f42368246e) haskellPackages: stackage LTS 21.7 -> LTS 21.11
* [`b350e5ae`](https://github.com/NixOS/nixpkgs/commit/b350e5ae2de35d985273d6134ed8109ce2434701) all-cabal-hashes: 2023-08-17T07:12:25Z -> 2023-09-13T23:29:30Z
* [`a32485c0`](https://github.com/NixOS/nixpkgs/commit/a32485c038d11571119c678ba39f0f00c81c9a39) haskellPackages: regenerate package set based on current config
* [`e6078ca6`](https://github.com/NixOS/nixpkgs/commit/e6078ca68424ccbd43ecf0a04e999070aed08c18) haskellPackages: Fix eval errors by bumping overrides
* [`3e197c9b`](https://github.com/NixOS/nixpkgs/commit/3e197c9b232feb44b9c4bc7c24e87356ffad9b07) haskell-language-server: Fix build
* [`af03cff7`](https://github.com/NixOS/nixpkgs/commit/af03cff7fb96024611a1365cc158917ccac6da05) haskellPackages.binrep: unbreak
* [`67cba441`](https://github.com/NixOS/nixpkgs/commit/67cba441aff0a2f202a5328829e49534a51f3433) haskellPackages.binrep: regenerate unbroken
* [`6887adc3`](https://github.com/NixOS/nixpkgs/commit/6887adc3e7983532bddb4ca6ff50f3521dd928f4) pandoc: bump skylighting deps
* [`9d5f44d3`](https://github.com/NixOS/nixpkgs/commit/9d5f44d3094761c49e97369b225634895b0e37bb) haskellPackages.text_2_0_2: regenerate for elm
* [`77202d8f`](https://github.com/NixOS/nixpkgs/commit/77202d8f23ca254f724bf26bca636b2ac7f2e1e8) haskellPackages.reflex-dom: remove old jailbreak
* [`0c0bed6a`](https://github.com/NixOS/nixpkgs/commit/0c0bed6abc39a7696b980ab397302f277735d132) haskell.packages.ghc96.doctest: 0.22.0 -> 0.22.1
* [`b6100863`](https://github.com/NixOS/nixpkgs/commit/b6100863bdb713f9d222105ce80edc720a997d6f) haskell.packages.ghc96.ghc-lib-parser-ex: 9.6.0.1 -> 9.6.0.2
* [`26d55116`](https://github.com/NixOS/nixpkgs/commit/26d55116d7683466534f8f7fef80342012af014f) haskell.packages.ghc96.ormolu: 0.7.1.0 -> 0.7.2.0
* [`18d98390`](https://github.com/NixOS/nixpkgs/commit/18d983908399e4a5a0066c2b129963af9df351eb) rnginline: 0.0.2 -> 1.0.0
* [`7386d0ab`](https://github.com/NixOS/nixpkgs/commit/7386d0ab04f22db72aa99c9b43572a5aeddcf95c) haskell.packages.ghc96.haskell-language-server: Fix build
* [`ad19d330`](https://github.com/NixOS/nixpkgs/commit/ad19d330aa4d1a1d41ccc7b744d3b849c9d9abf9) nix-output-monitor: 2.0.0.6 -> 2.0.0.7
* [`44197b75`](https://github.com/NixOS/nixpkgs/commit/44197b751d1d3abe45d3a56bd1a133e3d29504bc) haskellPackages.jsaddle: Drop obsolete overrides
* [`ed737c0c`](https://github.com/NixOS/nixpkgs/commit/ed737c0c189d204684fad19f04ac00b945f66f7e) haskellPackages.jsaddle-webkit2gtk: Drop obsolete overrides
* [`a4deb19a`](https://github.com/NixOS/nixpkgs/commit/a4deb19a3c8b71dbea5c078e6cffbe07262f4bf7) Revert "haskellPackages.reflex-dom: remove old jailbreak"
* [`09b047f6`](https://github.com/NixOS/nixpkgs/commit/09b047f6b3236d73b27725131b8d5a1ab1242cdc) haskellPackages.reflex-dom: Backpin to unbreak
* [`316bc558`](https://github.com/NixOS/nixpkgs/commit/316bc558ecdd93f8790a6270f8f16fe2c9266a86) haskellPackages.patat: Fix build by patching commit relaxing bounds
* [`dd8e9658`](https://github.com/NixOS/nixpkgs/commit/dd8e96584138078d6321bc0732773825a9fe481d) filebot: 5.0.3 -> 5.1.1
* [`4270524d`](https://github.com/NixOS/nixpkgs/commit/4270524d3f5f528d9b2d9497579ba9fc404e8ab7) build-rust-crate: add stripExclude for .rlib
* [`c30f7457`](https://github.com/NixOS/nixpkgs/commit/c30f7457af2c08cb99a2e2e7ab6a269a76a8b3b4) mysql_jdbc: 8.0.33 -> 8.1.0
* [`d49a4c10`](https://github.com/NixOS/nixpkgs/commit/d49a4c10ceba6dc6e6557c735fbde99dd21bb1b6) nginxModules.njs: 0.7.10 -> 0.8.1
* [`a4f9ea33`](https://github.com/NixOS/nixpkgs/commit/a4f9ea332a749a849525ea98c34939ef59ae6b8d) haskell-docs: Fix typo in function name
* [`0a71cf07`](https://github.com/NixOS/nixpkgs/commit/0a71cf07a82eacd0a618fe7ba7016f7de5f5c2f5) nixos/rust-motd: run once on bootup
* [`11376df6`](https://github.com/NixOS/nixpkgs/commit/11376df6d40c8fdbbd3c9a048b742dc032a88d15) nixos/rust-motd: allow ordering sections by `priority`
* [`214cf0b9`](https://github.com/NixOS/nixpkgs/commit/214cf0b9343dc619a36aedd2320bb1d73915c6de) nixos/rust-motd: .attrs.json -> "$NIX_ATTRS_JSON_FILE"
* [`b907fe51`](https://github.com/NixOS/nixpkgs/commit/b907fe51eca60d818766fb6d9618acf63988925f) python310Packages.msgpack: 1.0.5 -> 1.0.6
* [`8eff84a4`](https://github.com/NixOS/nixpkgs/commit/8eff84a4fe91c8bed051864d0003474fbc1f5421) jacinda: build with alex >= 3.4 as new release requires
* [`02f0dc8c`](https://github.com/NixOS/nixpkgs/commit/02f0dc8cfff494b59cc3431cd86b9a9cf636a275) grocy: add package option
* [`9bd59c62`](https://github.com/NixOS/nixpkgs/commit/9bd59c622a1ee74744f1b2708e956b0a3ee90515) postgresql: add dlSuffix to passthru
* [`cc61b5a1`](https://github.com/NixOS/nixpkgs/commit/cc61b5a175c396ce8f0c8a4f0e780d2488e19677) postgresqlPackages.pg_bigm: use GitHub mirror
* [`f861efe8`](https://github.com/NixOS/nixpkgs/commit/f861efe860f43d73732ec5fe5074e243b0f1de17) postgresql16Packages.pg_bigm: fix build
* [`6d602bbc`](https://github.com/NixOS/nixpkgs/commit/6d602bbc4d1a67ae50099d9743f0117d799f3bba) postgresql16Packages.pgvector: fix build on darwin
* [`81beb99b`](https://github.com/NixOS/nixpkgs/commit/81beb99b825e07991d34e36586e347cf44f47250) postgresql16Packages.pg_ivm: 1.6 -> 1.7
* [`994ba384`](https://github.com/NixOS/nixpkgs/commit/994ba38473c8ff77cdabbc21cc5170579b339430) postgresql16Packages.pgaudit: 1.7.0 -> 16.0
* [`87ced975`](https://github.com/NixOS/nixpkgs/commit/87ced975e705c7edd10324fbff8a6b51e97c34df) postgresql16Packages.tds_fdw: unstable-2021-12-14 -> unstable-2023-07-20
* [`c11d47d9`](https://github.com/NixOS/nixpkgs/commit/c11d47d99b87af913d509685797944af69368def) postgresql16Packages.pg_cron: fix build on darwin
* [`430ee544`](https://github.com/NixOS/nixpkgs/commit/430ee544ade88b9e65005c5617b2ec71e06610c6) postgresql16Packages.temporal_tables: unstable-2021-02-20 -> 1.2.2
* [`9f0afbb9`](https://github.com/NixOS/nixpkgs/commit/9f0afbb9082bb9de62b43c5c84c600dd83d27b02) postgresql16Packages.pg_hll: 2.17 -> 2.18
* [`d2ef404d`](https://github.com/NixOS/nixpkgs/commit/d2ef404d4c17858f69729494360177486279f9a5) postgresql16Packages.jsonb_deep_sum: fix build on darwin
* [`5649f3bc`](https://github.com/NixOS/nixpkgs/commit/5649f3bcbe23deb5ddb3dcb59e0bae07ea734552) postgresql16Packages.periods: fix build on darwin
* [`da5f6e21`](https://github.com/NixOS/nixpkgs/commit/da5f6e21c66094bef103b938683cc5384754d320) postgresql16Packages.pgroonga: fix build on darwin
* [`7b5d0633`](https://github.com/NixOS/nixpkgs/commit/7b5d06339f52688f920503d24e6cd3cd9a77ed46) postgresql16Packages.pgrouting: 3.5.0 -> 3.5.1
* [`e803ddca`](https://github.com/NixOS/nixpkgs/commit/e803ddcaf5a947e8fab28945758c9d011f304ba4) postgresql16Packages.pgsql-http: fix build on darwin
* [`6f9e07dd`](https://github.com/NixOS/nixpkgs/commit/6f9e07dd45f0aed349ef90ddff996f05d7df3974) postgresql16Packages.pgtap: 1.3.0 -> 1.3.1
* [`47a896f3`](https://github.com/NixOS/nixpkgs/commit/47a896f3c72ee5a528e496175eb4d949867122d3) postgresql16Packages.pg_hint_plan: fix build on darwin
* [`daaca707`](https://github.com/NixOS/nixpkgs/commit/daaca707452a4290ba76c39f352408b0ec35d9c7) postgresql16Packages.pg_partman: 4.7.4 -> 5.0.0
* [`59d85138`](https://github.com/NixOS/nixpkgs/commit/59d851384d42001a437733fefe13ed00d3dbb4b8) postgresql16Packages.pg_net: 0.7.2 -> 0.7.3
* [`3000d76e`](https://github.com/NixOS/nixpkgs/commit/3000d76eb1b45f1886c3e5ce4640fe8ccba519a6) postgresql16Packages.pg_rational: fix build on darwin
* [`fb97353d`](https://github.com/NixOS/nixpkgs/commit/fb97353d273fe31c25caab817efa77405586b5f3) postgresql16Packages.pg_relusage: fix build on darwin
* [`f282039b`](https://github.com/NixOS/nixpkgs/commit/f282039b9b700284240087651ffc1d35a1fd4c83) postgresql16Packages.pg_repack: fix build on darwin
* [`cb7bcf0a`](https://github.com/NixOS/nixpkgs/commit/cb7bcf0ace5f535156ad7ca3a2501e04f869e9d6) postgresql16Packages.pg_safeupdate: fix build on darwin
* [`2c81b4ba`](https://github.com/NixOS/nixpkgs/commit/2c81b4ba39a502a5725caa7d3c0811d5ef146f4b) postgresql16Packages.pg_similarity: fix build on darwin
* [`7120d71d`](https://github.com/NixOS/nixpkgs/commit/7120d71de540b15c8c0f36820872f61fd30cf56d) postgresql16Packages.pg_topn: 2.5.0 -> 2.6.0
* [`d8b08955`](https://github.com/NixOS/nixpkgs/commit/d8b0895554b108737718c8512392c3120e222aca) postgresql16Packages.plpgsql_check: 2.5.1 -> 2.5.3
* [`89da03b5`](https://github.com/NixOS/nixpkgs/commit/89da03b52afab792804fc8da10cebf2c45f33d93) postgresql16Packages.plr: fix build on darwin
* [`190ddae4`](https://github.com/NixOS/nixpkgs/commit/190ddae4a009b17c74a29b7fef09382e826996ad) postgresql16Packages.repmgr: fix build on darwin
* [`ac7d7f10`](https://github.com/NixOS/nixpkgs/commit/ac7d7f10a7fb7f460ac5a00b6de7e1ac77d3fdd1) postgresql16Packages.rum: fix build on darwin
* [`baedf9c0`](https://github.com/NixOS/nixpkgs/commit/baedf9c0b8c371e9c1fb0300463969b33b6eaab2) postgresql16Packages.tsearch-extras: fix build on darwin
* [`ad99a539`](https://github.com/NixOS/nixpkgs/commit/ad99a539a4d9c45f3c1e60d498cd386dfd6b6bea) postgresql16Packages.wal2json: fix build on darwin
* [`831519f0`](https://github.com/NixOS/nixpkgs/commit/831519f0eaf2c66366743d2cc0b6da46cd11f016) postgresql16Packages.pg_partman: mark as broken on PostgreSQL<14
* [`aa7811a8`](https://github.com/NixOS/nixpkgs/commit/aa7811a8f5badaf9b0e52e2349efb9653c45e3a4) postgresql11Packages.pg_partman: mark as broken
* [`f6f5f608`](https://github.com/NixOS/nixpkgs/commit/f6f5f60879c8bee472d37d79b53757a47098b446) bcachefs tests: unlock directly to the right keyring
* [`6226c4ac`](https://github.com/NixOS/nixpkgs/commit/6226c4ac2217373ecf07a656e1e41745f3cf0b4d) python3Packages.snaptime: init at 0.2.4
* [`f95ce22d`](https://github.com/NixOS/nixpkgs/commit/f95ce22df600f04e949f16df54abe5d1b1653990) python3Packages.maya: 0.3.3 -> 0.6.1
* [`87741537`](https://github.com/NixOS/nixpkgs/commit/87741537ba05291d50b8913e94066ee77c6eb779) minio: 2023-09-07T02-05-02Z -> 2023-09-20T22-49-55Z
* [`352ff3f2`](https://github.com/NixOS/nixpkgs/commit/352ff3f22631470832d5ad1b197d4aeaa614058c) Update pkgs/build-support/rust/build-rust-crate/default.nix
* [`a19f1acc`](https://github.com/NixOS/nixpkgs/commit/a19f1accc30d970aa47bed76d3f9955ec2871431) transmission, transmission_4: set mainProgram
* [`e1cab491`](https://github.com/NixOS/nixpkgs/commit/e1cab4915c82fb1d54c32481ff51ad0c790f6fa2) transmission_4: restore nixosTests
* [`ea9254a5`](https://github.com/NixOS/nixpkgs/commit/ea9254a5a58911e9d1d108aa2923ebbb6a78e1d9) nixosTests.tranmission_4: init
* [`966558ff`](https://github.com/NixOS/nixpkgs/commit/966558ffdec558b8980d7ecec919d1f6af00fb59) time: refactor
* [`17ef5378`](https://github.com/NixOS/nixpkgs/commit/17ef53788f4d74a9bfd2a683f66193284e3640ac) mx-puppet-discord: use nodejs-18
* [`4fec13e8`](https://github.com/NixOS/nixpkgs/commit/4fec13e83269a1e0659beaf4c26624ad77d0da78) nvfetcher: mark non-broken
* [`df8dcb43`](https://github.com/NixOS/nixpkgs/commit/df8dcb433932620800cc93ee86ec426338f9b7f8) tio: 2.6 -> 2.7
* [`8da77156`](https://github.com/NixOS/nixpkgs/commit/8da771560c5d664f4de452fb901a1eb2c7507382) nixos/device-tree: Allow custom dtbSource and expose compileDts
* [`20b83a46`](https://github.com/NixOS/nixpkgs/commit/20b83a46d62422b7070035a32ae23cce408d4034) netdata: disable installation of non-free v2 dashboard
* [`dc1d9bc1`](https://github.com/NixOS/nixpkgs/commit/dc1d9bc1b97fce2026c17a8be6553a0cb8397c3b) framesh: 0.6.7 -> 0.6.8
* [`a99948c4`](https://github.com/NixOS/nixpkgs/commit/a99948c46a6afb533c43fe202f80d01fe78acad3) vscode-extensions.davidanson.vscode-markdownlint: 0.51.0 -> 0.52.0
* [`da589d2b`](https://github.com/NixOS/nixpkgs/commit/da589d2bc054ae3fae1b9d18bc2cca38762f9685) haskell.packages.ghcHEAD.inline-c-cpp: drop obsolete override
* [`36d49df5`](https://github.com/NixOS/nixpkgs/commit/36d49df59d0cb314160ce26ffb06584194fa1aff) python3Packages.python-ndn: 0.3-3 -> 0.4.1
* [`81b2e15c`](https://github.com/NixOS/nixpkgs/commit/81b2e15c2cec67b87e9e52a3ab6e1760e260161c) flatpak: Fix flatpak path in launchers
* [`beee2842`](https://github.com/NixOS/nixpkgs/commit/beee2842bdc9281c94c95ea9c89f20b3da53ffd3) discourse: 3.1.0.beta4 -> 3.2.0.beta4
* [`80bd5341`](https://github.com/NixOS/nixpkgs/commit/80bd53412a43e86d9fcd8291214d0a005444102d) discourse: Update plugin versions
* [`4c3c3b50`](https://github.com/NixOS/nixpkgs/commit/4c3c3b50b15bf5dd15836adeeeaaa539ebb506ad) maintainers: added schinmai-akamai
* [`8cc6699f`](https://github.com/NixOS/nixpkgs/commit/8cc6699fd45384e9c8528218d69e65ff664938cf) nuget: move out of dotnet-packages and the dotnetPackages namespaces
* [`eb42fb07`](https://github.com/NixOS/nixpkgs/commit/eb42fb0787d7a8922294a1a2b6867b6dc0213b3f) fluxcd: 2.1.0 -> 2.1.1
* [`6d4baca8`](https://github.com/NixOS/nixpkgs/commit/6d4baca8df69eb33ce5cc03d6998d087efa670f0) python3Packages.sqids: init at 0.3.0
* [`1c9e9f97`](https://github.com/NixOS/nixpkgs/commit/1c9e9f97ee09d607e0da28845f4862fdcc3b2d03) postfix: mangle store paths in /etc/postfix/makedefs.out
* [`042f4f89`](https://github.com/NixOS/nixpkgs/commit/042f4f899ec1d5e1a5d6bb4042c301c6c4d7633e) ast-grep: 11.1 -> 12.1
* [`8ba6b9f0`](https://github.com/NixOS/nixpkgs/commit/8ba6b9f074b3cf49b4eb507cf9bdf5e8f9d37d07) ast-grep: disable `test_unmatching_id`
* [`8fbec03e`](https://github.com/NixOS/nixpkgs/commit/8fbec03ebdf00c5040c6b18777fa3141c30e701a) polkadot: 1.0.0 -> 1.1.0
* [`048895be`](https://github.com/NixOS/nixpkgs/commit/048895bea062cc38ecea91c8bc5ee8edd0abd8d9) rke: 1.4.8 -> 1.4.10
* [`fc121a9e`](https://github.com/NixOS/nixpkgs/commit/fc121a9ea669fd76b43c68222d95bc876fcbc5bb) yaru-theme: 23.04.4 -> 23.10.0
* [`830b8248`](https://github.com/NixOS/nixpkgs/commit/830b8248d94a310213a21b628453348dc3eb41af) qt6ct: 0.8 -> 0.9
* [`78dd0f11`](https://github.com/NixOS/nixpkgs/commit/78dd0f11859a0c0805838c4245ce57ed7b4ab4b7) nuget: 6.3.1.1 -> 6.6.1.2
* [`30f3705c`](https://github.com/NixOS/nixpkgs/commit/30f3705c0421a1b9b048175efc32229eab17d594) msbuild: fix usage of nuget
* [`d77b59b4`](https://github.com/NixOS/nixpkgs/commit/d77b59b41d038ad9c3878d8ccb2a35f87d178acb) nixos/rust-motd: use a second attribute (`order`) for the of sections in TOML
* [`477a6035`](https://github.com/NixOS/nixpkgs/commit/477a60351c2a234cce5d6b6df9dfbf3b1ab29dc4) minimal-bootstrap.gnused: replace glibc with musl
* [`665d3605`](https://github.com/NixOS/nixpkgs/commit/665d36050736d95904c689940e64aea00350b887) minimal-bootstrap.binutils: add musl version
* [`20e65d89`](https://github.com/NixOS/nixpkgs/commit/20e65d89e60d3667c529cbfb73772220046d18c1) minimal-bootstrap.diffutils: use musl
* [`60ae6bf7`](https://github.com/NixOS/nixpkgs/commit/60ae6bf75109fb902dc67f45488f5c2ec13eaf8e) minimal-bootstrap.binutils: remove binutils-mes and binutils-glibc
* [`4166e1fd`](https://github.com/NixOS/nixpkgs/commit/4166e1fded92631a42efd5785a40fb83a9186d2a) minimal-bootstrap.gawk: build with musl
* [`3fd09b75`](https://github.com/NixOS/nixpkgs/commit/3fd09b754739423a1ecf9027ce460aa9fca1ae37) minimal-bootstrap.xz: build with musl
* [`114d57a0`](https://github.com/NixOS/nixpkgs/commit/114d57a054671ce8a1c9aba807c4bd24329f7923) minimal-bootstrap.findutils: rebuild with musl
* [`109ba064`](https://github.com/NixOS/nixpkgs/commit/109ba06491384c48290b9159c323d5723e22ee19) minimal-bootstrap.gnumake: rebuild with musl
* [`e2520589`](https://github.com/NixOS/nixpkgs/commit/e25205899ad22430b622301ab5148ac3346e6fd5) minimal-bootstrap.tinycc-musl: add alloca to libtcc1
* [`7287781f`](https://github.com/NixOS/nixpkgs/commit/7287781fc337c5253e181dce38ebb1972ffa829b) minimal-bootstrap.musl11: always flush stdio
* [`a5d9d1cf`](https://github.com/NixOS/nixpkgs/commit/a5d9d1cf496be8e19c3652e9df03eaea6ecea60b) minimal-bootstrap.gawk: use libs from tinycc-musl
* [`3e95cade`](https://github.com/NixOS/nixpkgs/commit/3e95cadee893e998f2f53ef688fffd6493c06f5b) minimal-bootstrap.musl: parallelise build
* [`c9ba05b2`](https://github.com/NixOS/nixpkgs/commit/c9ba05b20da750f3924e6f7d3aa1fb6fe8376c4c) minimal-bootstrap.*: replace uses of musl11 with tinycc-musl.libs
* [`0173d3bd`](https://github.com/NixOS/nixpkgs/commit/0173d3bd90826538c20cc53eb0db8b3ff326f51d) minimal-bootstrap.tinycc-musl: 0.9.27 -> unstable-2023-04-20
* [`d73a8465`](https://github.com/NixOS/nixpkgs/commit/d73a846519525a34def7bd1a787c0f303135c788) minimal-bootstrap.gnutar-musl: init at 1.12
* [`a680950c`](https://github.com/NixOS/nixpkgs/commit/a680950c8828624ddc71aadcf1e0ca20db544836) minimal-bootstrap.coreutils-musl: init at 9.4
* [`29b98b0f`](https://github.com/NixOS/nixpkgs/commit/29b98b0f89ae12f4160762c7bb01c7e70944580d) minimal-bootstrap.gcc46: build with tinycc-musl
* [`25a264c6`](https://github.com/NixOS/nixpkgs/commit/25a264c6c4f4ee85c1e844dd8ba1973d2fd57a2b) minimal-bootstrap.tinycc-musl: unstable-2023-04-20 -> unstable-2023-07-10
* [`1c1962f9`](https://github.com/NixOS/nixpkgs/commit/1c1962f97536041ce38116feebc52e4e35ec9396) minimal-bootstrap.bash: build with musl
* [`454dc76a`](https://github.com/NixOS/nixpkgs/commit/454dc76ae85b9db28430a95171c08aa1fa81f19e) minimal-bootstrap.gawk: 5.2.0 -> 5.2.2, parallelise
* [`ee8bf1d3`](https://github.com/NixOS/nixpkgs/commit/ee8bf1d3effd139508db98ed3fb2ad4da2a59fa7) minimal-bootstrap.xz: parallelise
* [`d7b804e0`](https://github.com/NixOS/nixpkgs/commit/d7b804e08edb143432b386c6242f3468494d35e9) minimal-bootstrap.diffutils: parallelise
* [`47900241`](https://github.com/NixOS/nixpkgs/commit/47900241a2527e3bbc134ef03ec7488f22231df7) minimal-bootstrap.findutils: parallelise
* [`b99da9eb`](https://github.com/NixOS/nixpkgs/commit/b99da9eb04095ce8bcf9b6b82708a8ca71cf8775) minimal-bootstrap.gnumake-musl: fix pname
* [`2f400ede`](https://github.com/NixOS/nixpkgs/commit/2f400edeb3451b4b1429d727b506f796d1324573) minimal-bootstrap.binutils: parallelise
* [`adf49a8b`](https://github.com/NixOS/nixpkgs/commit/adf49a8b0c74762559ea518b953080b810efee9f) minimal-bootstrap.bzip2: build with musl
* [`2dda9ec8`](https://github.com/NixOS/nixpkgs/commit/2dda9ec8f3c8b82edf558d8896ec4eb8cd5fc86c) xtensor: 0.24.6 -> 0.24.7, allow bound checks
* [`2112a277`](https://github.com/NixOS/nixpkgs/commit/2112a277f9a64498154e465d6abe86c2dfd8c377) lammps: 23Jun2022_update4 -> 2Aug2023_update1
* [`43dece63`](https://github.com/NixOS/nixpkgs/commit/43dece63bf5dc936a2fc2fde69751730285c35f8) haskell.packages.ghc96.ormolu: enableSeparateBinOutput
* [`53598bba`](https://github.com/NixOS/nixpkgs/commit/53598bba6781a4462b1307dbb6a707f0c39aeeab) inih: 56 -> 57
* [`eb2c1361`](https://github.com/NixOS/nixpkgs/commit/eb2c136196b982ace64b802d0a300b911e9a4265) regreet: fix user group in tmpfiles rules
* [`bfcf9702`](https://github.com/NixOS/nixpkgs/commit/bfcf9702fe9f1e69bdf58fe6b553e324d7c52781) goimports-reviser: 3.4.1 -> 3.4.5
* [`5e5d80aa`](https://github.com/NixOS/nixpkgs/commit/5e5d80aaaaa7cc60fc8da840e02ef62a2644a7da) gnome.pomodoro: 0.23.1 -> 0.24.0
* [`98ec3459`](https://github.com/NixOS/nixpkgs/commit/98ec34599e61caabc1430e44968fbf7b56cfe918) exaile: 4.1.2 -> 4.1.3
* [`1f1e07b4`](https://github.com/NixOS/nixpkgs/commit/1f1e07b4c42f830244855b80cd03dc95f12439fc) exaile: Support more media formats by default
* [`fcbe7810`](https://github.com/NixOS/nixpkgs/commit/fcbe7810be77a98f13210acc0e8f2b1e687e291d) linkerd: 2.14.0 -> 2.14.1
* [`ce037d23`](https://github.com/NixOS/nixpkgs/commit/ce037d233ecd7f268c8369ef2461439246cf40a1) ocamlPackages.mdx: 2.3.0 → 2.3.1
* [`1d78ad9e`](https://github.com/NixOS/nixpkgs/commit/1d78ad9ea4fe35bfeb42df910220f0b5b82f6750) haskell.compiler.ghc96: 9.6.2 -> 9.6.3
* [`237f7ba7`](https://github.com/NixOS/nixpkgs/commit/237f7ba7d2b2be46049e3327eb8208b5ac450940) networkd: Allow combinations of WakeOnLan policies
* [`14a58308`](https://github.com/NixOS/nixpkgs/commit/14a58308972a1110210582a715511508826b047d) bepasty: 1.1.0 -> 1.2.0
* [`7a0a6edd`](https://github.com/NixOS/nixpkgs/commit/7a0a6eddce62ba47a8fb2d3db62d1eacb7fadc74) bepasty: enable tests
* [`27d0a8a0`](https://github.com/NixOS/nixpkgs/commit/27d0a8a0cda0a178f5b04afb434a8bef47c84cda) network.interfaces: Add option to configure WakeOnLan policy
* [`26659918`](https://github.com/NixOS/nixpkgs/commit/2665991874fa47b21fdd0e5f004dcfbd37b6a6e2) gpodder: add mutagen to propagatedBuildInputs
* [`54068e71`](https://github.com/NixOS/nixpkgs/commit/54068e71ebb343c74c4e51dd39382aa3c6b158d9) python311Packages.msgpack: 1.0.6 -> 1.0.7
* [`cfe6d8f4`](https://github.com/NixOS/nixpkgs/commit/cfe6d8f43329ebbe65e18f03865ae2e707ae9b8c) clash-verge: 1.3.5 -> 1.3.7
* [`9784de79`](https://github.com/NixOS/nixpkgs/commit/9784de790961967642f91c4b87d15dfe810b5e12) ocamlPackages.containers: 3.11 → 3.12
* [`264cd9eb`](https://github.com/NixOS/nixpkgs/commit/264cd9ebfa0d4b6ef33d8c2092d97a9de2ab4b3e) rimgo: init at 1.2.0
* [`f857cfd5`](https://github.com/NixOS/nixpkgs/commit/f857cfd5bee8e5f10f7361cdcb032ba04aee8d54) rimgo: add module
* [`f1e7c634`](https://github.com/NixOS/nixpkgs/commit/f1e7c63477b14b58b261f6c9ecbb68b9e96772f5) ocamlPackages.msgpck: init at 1.7
* [`57de6a85`](https://github.com/NixOS/nixpkgs/commit/57de6a855001eaf849fff1f25859e5a1ddd39ddc) nixos/rust-motd: refactor assertion and TOML generation
* [`cd9baa85`](https://github.com/NixOS/nixpkgs/commit/cd9baa85553dc2f1bcbff4253286343e169e2475) searxng: move to pkgs/by-name
* [`76afde84`](https://github.com/NixOS/nixpkgs/commit/76afde84e7bc4dd9381167907e66d93bf74dea35) _9base: init at unstable-2019-09-11
* [`6caacd0d`](https://github.com/NixOS/nixpkgs/commit/6caacd0d8143f2c871ff337783237d62c60ff99d) polkadot: apply suggestions from code review
* [`d17e8110`](https://github.com/NixOS/nixpkgs/commit/d17e81101c8de974938c257632def37086b93074) mdds: 2.0.3 -> 2.1.1
* [`2f053897`](https://github.com/NixOS/nixpkgs/commit/2f05389728698922d0bcc2d9c11163b36a2e4e19) libreoffice: improve nixpkgs' README update instructions
* [`b597a74a`](https://github.com/NixOS/nixpkgs/commit/b597a74a2213943e0faeb3ce563f2235c78b644c) libreoffice: small reformatting to postConfigure
* [`babd7931`](https://github.com/NixOS/nixpkgs/commit/babd79315b4bb717c88b684b015d398fb3658eea) libreoffice: get rid of src-$VARIANT/override.nix
* [`7932ddf6`](https://github.com/NixOS/nixpkgs/commit/7932ddf60441563e36aa0ae377537a515658f2a6) libreoffice: always use stdenv.mkDerivation
* [`27b1afd0`](https://github.com/NixOS/nixpkgs/commit/27b1afd0063b5f619c02183127b7e5e2c985cd31) libreoffice: use finalAttrs in mkDerivation
* [`0c1c0049`](https://github.com/NixOS/nixpkgs/commit/0c1c00490849d49f5bf4a06f4269d4050e1be104) supersonic: init at 0.5.2
* [`efeecdd6`](https://github.com/NixOS/nixpkgs/commit/efeecdd66bb9527326e3abb9c614f598a1ff6b40) libpsm2: 11.2.230 -> 12.0.1
* [`90160e5f`](https://github.com/NixOS/nixpkgs/commit/90160e5fe3f373d033fcedc8042677b8e3f0f74b) libreoffice: reorder/reformat buildInputs a bit
* [`9ee9d1a7`](https://github.com/NixOS/nixpkgs/commit/9ee9d1a7ffe22264b14d6f4c864230f25440dd75) ast-grep: 12.1 -> 12.2
* [`a6f750c2`](https://github.com/NixOS/nixpkgs/commit/a6f750c23e583360716dedf31c2ecc444bfc7591) ast-grep: use by-name
* [`97d158a0`](https://github.com/NixOS/nixpkgs/commit/97d158a0953783cb53a3cffd2238587264d06ae5) bitbake-language-server: init at 0.0.6
* [`3cbbea53`](https://github.com/NixOS/nixpkgs/commit/3cbbea53a12ebd461e047e594027ee6777f36e68) lib.fileset: Don't use non-reproducible ulimit for stack overflow testing
* [`340330d1`](https://github.com/NixOS/nixpkgs/commit/340330d1c8fb92df9be7093e6ceaa4bbf801147e) python310Packages.clevercsv: 0.8.1 -> 0.8.2
* [`6cfd79b4`](https://github.com/NixOS/nixpkgs/commit/6cfd79b45922c35b99c486803615555ed4bd653d) anydesk: 6.2.1 -> 6.3.0
* [`b924bd1d`](https://github.com/NixOS/nixpkgs/commit/b924bd1d3b996ceb9c0df897bd035e6c43b08cd5) linkerd_edge: 23.8.3 -> 23.9.4
* [`8f8ab8c1`](https://github.com/NixOS/nixpkgs/commit/8f8ab8c1d5f2b2ce877ba0f82f1d424c552b350a) ldtk: 1.4.0 -> 1.4.1
* [`9798aa9d`](https://github.com/NixOS/nixpkgs/commit/9798aa9da9c4ec6397b7bad313712d5deba1e5cd) python310Packages.pony: 0.7.16 -> 0.7.17
* [`a6759db4`](https://github.com/NixOS/nixpkgs/commit/a6759db47c1ad79f5441f0912035df271fa99008) libcef: 116.0.24 -> 117.1.5
* [`f4eadf92`](https://github.com/NixOS/nixpkgs/commit/f4eadf9232064476961b4537d799d67c4543183a) python310Packages.chiabip158: 1.2 -> 1.3
* [`3b3c403a`](https://github.com/NixOS/nixpkgs/commit/3b3c403a84071426046a848f92fcc57219930f64) renderdoc: 1.28 -> 1.29
* [`29704681`](https://github.com/NixOS/nixpkgs/commit/29704681e47357beb334c343f7a38aa487a2f61b) python310Packages.mistune: 3.0.1 -> 3.0.2
* [`05290d4a`](https://github.com/NixOS/nixpkgs/commit/05290d4aa063c722b7687369c854b4cdbdc1cfa7) plasma-workspace: backport patch for cleaner shutdowns
* [`3121793f`](https://github.com/NixOS/nixpkgs/commit/3121793f8cd9c48d499ce4069c650092cdf22f2e) moar: 1.17.0 -> 1.17.1
* [`eb39c29b`](https://github.com/NixOS/nixpkgs/commit/eb39c29b1bebdbc899c83f613a9830e4718003c0) moar: add meta.mainProgram
* [`28ada42d`](https://github.com/NixOS/nixpkgs/commit/28ada42d6175b79030cd58d0fe0a2762c8663460) python310Packages.dask-glm: 0.2.0 -> 0.3.0
* [`66eebd56`](https://github.com/NixOS/nixpkgs/commit/66eebd56d33d22f405b06e17358b737fc0412f7f) winePackages.{unstable,staging}: 8.14 -> 8.17
* [`b5500b87`](https://github.com/NixOS/nixpkgs/commit/b5500b878f855eb556bec62188ea958e167806e6) update duckdb and python duckdb to v0.9.0
* [`27f5da48`](https://github.com/NixOS/nixpkgs/commit/27f5da489b9d9843bc9c7c2ca95b70da50a09601) ucx: 1.14.1 -> 1.15.0
* [`2d02df2f`](https://github.com/NixOS/nixpkgs/commit/2d02df2fc29d9e12682d1cc4e394cb1877781223) scalapack: slipt outputs -> out, dev
* [`c883a530`](https://github.com/NixOS/nixpkgs/commit/c883a5308937b5f5cf343ea4fbdae4c150d84302) c2pk: remove unit tests from output
* [`ecce246e`](https://github.com/NixOS/nixpkgs/commit/ecce246e13aa2dea5c80122347031cdcb030189e) elpa: split outputs and enable parallel builds
* [`b03d6294`](https://github.com/NixOS/nixpkgs/commit/b03d629461ca2216d4c31d8cdf70550fe7c731a3) make duckdb-engine build with duckdb 0.9.0. disable autoload and autoinstall as they seem buggy -- even if extension is built in they can download and load an extension automatically.
* [`722cb79d`](https://github.com/NixOS/nixpkgs/commit/722cb79dcb357c9f0a7c532d0348077c3fd02c69) python310Packages.pony: update disabled
* [`efcde1d6`](https://github.com/NixOS/nixpkgs/commit/efcde1d6685d05db10e3bce06563d225cba90c48) python310Packages.pony: update disabledTests
* [`f1b44ffc`](https://github.com/NixOS/nixpkgs/commit/f1b44ffc1c06ae6aa99a501c59d25f58f316f79b) nwchem: remove test jobs from output
* [`12678720`](https://github.com/NixOS/nixpkgs/commit/12678720a519272d5a15da7f97449cb7d3094d55) expand tabs
* [`3aacc1a3`](https://github.com/NixOS/nixpkgs/commit/3aacc1a324466853ddc871936bcda36816515c25) python3Packages.mypy-boto3-ebs, python3Packages.mypy-boto3-s3: build using shared buildMypyBoto3Package
* [`9ffd5471`](https://github.com/NixOS/nixpkgs/commit/9ffd5471c7f255b7bad0b3d136464f37660d010c) python3Packages.mypy-boto3-cognito-idp: init at 1.28.36
* [`a097cfe1`](https://github.com/NixOS/nixpkgs/commit/a097cfe10a5e074218e00de705a18e32ab1c4c28) python3Packages.mypy-boto3-*: add myself (mbalatsko) as maintainer
* [`7dcacb4f`](https://github.com/NixOS/nixpkgs/commit/7dcacb4fccbdb9c850c1989b9c2c20e1639a1f43) zf: 0.8.0 -> 0.9.0
* [`219e644d`](https://github.com/NixOS/nixpkgs/commit/219e644d5a7b50de01596130d126f6e00fbc7ebd) zf: fix test
* [`ca058766`](https://github.com/NixOS/nixpkgs/commit/ca058766c8e0ea8d7a1ecb66e4b9617c91884cb5) python3Packages.sentence-transformers: add changelog
* [`48e763b1`](https://github.com/NixOS/nixpkgs/commit/48e763b1aca8426ec4a7798c5b4ab89ada7631b5) ucx: use getDev to pickup rdam-core includes
* [`646b227d`](https://github.com/NixOS/nixpkgs/commit/646b227da417c16235ec80b3b5c8c7e82708fb08) slurm: use getDev to pickup rdma-core includes
* [`476626b6`](https://github.com/NixOS/nixpkgs/commit/476626b62270a338799f225bc608ef6854eb1314) rdma-core: split outputs -> out, man, dev
* [`aadaa919`](https://github.com/NixOS/nixpkgs/commit/aadaa919abde30a5ffa7d677b19ff1fdaf1a62ad) shepherd: use fetchYarnDeps
* [`9c3b9200`](https://github.com/NixOS/nixpkgs/commit/9c3b920041b880eecb9a7f0ce7ec56c8309e0c26) aws-azure-login: use fetchYarnDeps
* [`62c6d285`](https://github.com/NixOS/nixpkgs/commit/62c6d285c8a385eeb17c9ee99a02fed7b2f8cf40) exiv2: 0.27.6 -> 0.28.0
* [`c09a9edd`](https://github.com/NixOS/nixpkgs/commit/c09a9edd5f37d2d91dc74c39b3e5df54d785ffc8) gpscorrelate: add patch for exiv2 0.28
* [`d959f3cd`](https://github.com/NixOS/nixpkgs/commit/d959f3cd45f4b2bb4d7c4e5488377180e7a4359c) viewnior: add patch for exiv2 0.28
* [`8e7c07d6`](https://github.com/NixOS/nixpkgs/commit/8e7c07d65aff56760077487cb3d638ad2c441dea) haskellPackages.typerep-map: Fix build
* [`dad3ce43`](https://github.com/NixOS/nixpkgs/commit/dad3ce439862ff49e79bf966a3ce831985b5fd4d) cp2k: fix libxsmm includes (use getDev)
* [`f1116cae`](https://github.com/NixOS/nixpkgs/commit/f1116caeb6c4d101257220381e1cc3d61dc71c46) libxsmm: split outputs -> out, dev, doc
* [`cf9ee8ab`](https://github.com/NixOS/nixpkgs/commit/cf9ee8abc5886208d8a1285d7bc3c1605f2a394b) usbrelay: 1.2 -> 1.2.1
* [`bf60265e`](https://github.com/NixOS/nixpkgs/commit/bf60265e0cf5cdfc1d233fd2c5036398f59ae12e) nomacs: 3.17.2206 -> 3.17.2285
* [`a47bd714`](https://github.com/NixOS/nixpkgs/commit/a47bd714b20bcff84159dfbdbd327a158ae9b6e9) mysql_jdbc: update homepage
* [`a4bb0a4f`](https://github.com/NixOS/nixpkgs/commit/a4bb0a4f1c79e5046ee0a798597197152b921fe5) xml2rfc: 3.18.0 -> 3.18.1
* [`8ee13f11`](https://github.com/NixOS/nixpkgs/commit/8ee13f11b4ca1a4588271e7121041b5bfe10bd52) enchant: 2.6.0 -> 2.6.1
* [`2b4283fb`](https://github.com/NixOS/nixpkgs/commit/2b4283fb65ae0ab5ba01f61ec7b194c071fbe987) vips: 8.14.4 -> 8.14.5
* [`53980180`](https://github.com/NixOS/nixpkgs/commit/539801807e9dc0e4d472e5f94112df255f63f983) amdvlk: 2023.Q3.2 -> 2023.Q3.3
* [`5e3b2fc6`](https://github.com/NixOS/nixpkgs/commit/5e3b2fc6698d66cb8522ca3d39c605e370dc0f59) kubernetes: 1.28.1 -> 1.28.2
* [`673d22a7`](https://github.com/NixOS/nixpkgs/commit/673d22a71cdbbabe05effd581a916b2c27ec1204) flexget: pin transmission-rpc version
* [`3c9d8d13`](https://github.com/NixOS/nixpkgs/commit/3c9d8d13d99a354e13f15d4e06f1f7f00868638e) resvg: 0.35.0 -> 0.36.0
* [`589eef50`](https://github.com/NixOS/nixpkgs/commit/589eef504cd41e2f8cae0efd7d3af7bf1b14f7aa) upterm: 0.10.0 → 0.12.0
* [`145f7181`](https://github.com/NixOS/nixpkgs/commit/145f7181aad5dd8497a385f058b93c2290a08ab7) lexmark-aex: init at 1.0
* [`71affb0d`](https://github.com/NixOS/nixpkgs/commit/71affb0d731d5244956830d46237bb9cb6bfdbcb) python310Packages.pytest-spec: init at unstable-2023-06-04
* [`d81e04ed`](https://github.com/NixOS/nixpkgs/commit/d81e04ede94a2336eb15286eb685594d17cbc94f) use the full hash and shallow git clone
* [`a3fa44cd`](https://github.com/NixOS/nixpkgs/commit/a3fa44cd5683817704235b32a8312c6737cfe26c) duckdb: 0.8.1 -> 0.9.0
* [`a8a4ec36`](https://github.com/NixOS/nixpkgs/commit/a8a4ec367a395ae0f4f55d91227c1c39232eb123) cl-duckdb: fix build for duckdb 0.9
* [`092d2553`](https://github.com/NixOS/nixpkgs/commit/092d2553622f83f6362637915f93d6f3b6c614d3) jwx: 2.0.12 -> 2.0.13
* [`f4b36600`](https://github.com/NixOS/nixpkgs/commit/f4b3660042e1b424728f6ed55f0a09a38ad3dc45) mlx42: init at 2.3.2
* [`db9265e1`](https://github.com/NixOS/nixpkgs/commit/db9265e1975c88964e1aebc7df8f5bc890f99f98) skip failing duckdb tests.
* [`14a78a8e`](https://github.com/NixOS/nixpkgs/commit/14a78a8ee77484cd2cd1e0f152562f783e5a5f22) vapoursynth: 63 -> 64
* [`78589543`](https://github.com/NixOS/nixpkgs/commit/785895439e7c986750f25823ab6fafbc1c896586) haskellPackages.amazonka: Fix build
* [`3c893582`](https://github.com/NixOS/nixpkgs/commit/3c89358266d49dd853c1464fa389ac830a6a5ab8) watchmate: 0.4.4 -> 0.4.5
* [`582e1924`](https://github.com/NixOS/nixpkgs/commit/582e1924c9e1f171fc5008209c63c1c575c85faa) libreoffice: write a whole, batteries included updateScript
* [`86737e18`](https://github.com/NixOS/nixpkgs/commit/86737e187ff29b734b12f54bfc356242d8e8f3e3) xmake: 2.8.2 -> 2.8.3
* [`aa584531`](https://github.com/NixOS/nixpkgs/commit/aa58453133202566fed71c8e544dd0caad30d3d4) mailctl: 0.8.8 -> 0.9.2
* [`b6ef70c6`](https://github.com/NixOS/nixpkgs/commit/b6ef70c692c2faee7c83038ca661a09d60175083) poethepoet: 0.23.0 -> 0.24.0
* [`6962ebbe`](https://github.com/NixOS/nixpkgs/commit/6962ebbec03a97ba9a271b04feef6f6fbc189278) broot: 1.25.2 -> 1.26.1
* [`0f8f0673`](https://github.com/NixOS/nixpkgs/commit/0f8f06733af064f766c7f3f0fe171774ab79fb11) nss-mdns: fix version number format, general cleanup
* [`eb030641`](https://github.com/NixOS/nixpkgs/commit/eb0306415f7cbaa71f66861c5e4f21762aea8093) wordpress: update languages and plugins
* [`6013fe8f`](https://github.com/NixOS/nixpkgs/commit/6013fe8f4198f1c2d6cb5e51a9ebd1400a843448) vim/update.py: ran through black
* [`901b21c5`](https://github.com/NixOS/nixpkgs/commit/901b21c555fa9820393b31ee54ade8cee915c895) vimPluginsUpdater: init
* [`c77aa0c0`](https://github.com/NixOS/nixpkgs/commit/c77aa0c0e052620bcee1bb92f8a2b400bd389bf2) vimPlugins: update
* [`525faa08`](https://github.com/NixOS/nixpkgs/commit/525faa083dfcc27fa717c36a2b2a119487cd36a5) vimPlugins: resolve github repository redirects
* [`6eb49b72`](https://github.com/NixOS/nixpkgs/commit/6eb49b7201d5cf2ce968ed967ba959abe1802a39) xorg.xf86videosiliconmotion: 1.7.9 -> 1.7.10
* [`90698280`](https://github.com/NixOS/nixpkgs/commit/906982808d11ab18f73a2d6c677941e37b8d01d6) dbip-country-lite: 2023-09 -> 2023-10
* [`f40761c7`](https://github.com/NixOS/nixpkgs/commit/f40761c7f8eda43599d9458ed6ac5316c3096ab9) cffi-libffi: use ffi.h patch for darwin
* [`a689220a`](https://github.com/NixOS/nixpkgs/commit/a689220a5d7f84f85d36311bb0cf017061eb72d9) duckdb: Incorporate changes from [nixos/nixpkgs⁠#257452](https://togithub.com/nixos/nixpkgs/issues/257452)
* [`ece6d4eb`](https://github.com/NixOS/nixpkgs/commit/ece6d4ebfb535bf8a42d1fbc8c70e802c65c438c) esphome: 2023.9.0 -> 2023.9.1
* [`b2ef0ae4`](https://github.com/NixOS/nixpkgs/commit/b2ef0ae4cf1e0c8fc6b8a13f5128a1b1eca3f7d8) qgis, qgis-ltr: add patch for exiv2 0.28
* [`1ea0789d`](https://github.com/NixOS/nixpkgs/commit/1ea0789d3f62145c074ef1368512c635caeeb440) act: 0.2.51 -> 0.2.52
* [`bf0eeb3c`](https://github.com/NixOS/nixpkgs/commit/bf0eeb3c34274db85323c17cdcb7b4bb34cf9a71) python310Packages.spacy-pkuseg: 0.0.32 -> 0.0.33
* [`df7bf176`](https://github.com/NixOS/nixpkgs/commit/df7bf1764399517b58d622d9b76f87c9561b3b99) bootstrap-tools-cross: remove bootstrap files for systems which are not used in stdenv/linux/default.nix
* [`a1c2c50c`](https://github.com/NixOS/nixpkgs/commit/a1c2c50cbc481337294c9b75b85df36720ebee00) bootstrap-tools-cross: sort
* [`e89df8be`](https://github.com/NixOS/nixpkgs/commit/e89df8be25f793f981a061154064d25c70fd94e3) python310Packages.b2sdk: 1.24.0 -> 1.24.1
* [`a7baaa78`](https://github.com/NixOS/nixpkgs/commit/a7baaa78eb019d3d51eb088974ec95ba940fc864) racket, racket_7_9: drop gcc7Stdenv
* [`46ecf918`](https://github.com/NixOS/nixpkgs/commit/46ecf91843ed7cf4c16ce9073f8aa0a25ff6704a) stdenv: remove unused loongson2f bootstrap files
* [`259d112c`](https://github.com/NixOS/nixpkgs/commit/259d112c054bc91de15427b7611abe3b77f27171) nixos/gonic: allow gonic to perform non-local DNS resolution
* [`0848edf7`](https://github.com/NixOS/nixpkgs/commit/0848edf7a091235297aacb6de04677c1d70de1c4) bootstrap-tools-cross: Add a note about what should be here
* [`cdf3badf`](https://github.com/NixOS/nixpkgs/commit/cdf3badfd96aa84463bc16f2d8962ba1364db6de) python310Packages.jupyter-ydoc: 1.0.2 -> 1.1.1
* [`4974701f`](https://github.com/NixOS/nixpkgs/commit/4974701f12f26cbc584af2ffcc73393735e1c24b) budgie.budgie-desktop: 10.8 -> 10.8.1
* [`e64a8d3f`](https://github.com/NixOS/nixpkgs/commit/e64a8d3ffdb66b2f1c1a20390971de6c5c256d7f) cocogitto: 5.5.0 -> 5.6.0
* [`4c1be45f`](https://github.com/NixOS/nixpkgs/commit/4c1be45f3e97ab00e4500040b8e06252bb8908bf) sundials: 6.6.0 -> 6.6.1
* [`b2441077`](https://github.com/NixOS/nixpkgs/commit/b244107711fd44aa289dbe2a761d317d0975c492) hysteria: 2.0.2 -> 2.0.3
* [`51ef74c6`](https://github.com/NixOS/nixpkgs/commit/51ef74c6484c190384325915bd98bc8b13d7004e) jmol: 16.1.39 -> 16.1.41
* [`8f376b70`](https://github.com/NixOS/nixpkgs/commit/8f376b70f50de654234c5d4ba654a82044047c39) discord-development: 0.0.232 -> 0.0.234
* [`3fa92366`](https://github.com/NixOS/nixpkgs/commit/3fa92366e39a59363edd384e3c832bb3a0a42b25) discord-canary: 0.0.167 -> 0.0.169
* [`e90add3e`](https://github.com/NixOS/nixpkgs/commit/e90add3e1839b6b16300849a75771bd47822682d) release: add `darwin.linux-builder` as a blocker
* [`204e0cae`](https://github.com/NixOS/nixpkgs/commit/204e0caee0287f49b685ca96f722e09721d16d09) mobilizon: cleanup code a bit
* [`7418da6f`](https://github.com/NixOS/nixpkgs/commit/7418da6f809b3fecb6b2f82dedfed1af96b42687) use --inplace for python build
* [`a1a557bd`](https://github.com/NixOS/nixpkgs/commit/a1a557bd4345cc2e490f7f56b5f9403248732ebd) restore the original set of unittest excludes and add "Test using a remote optimizer pass in case thats important to someone"
* [`4ad7a433`](https://github.com/NixOS/nixpkgs/commit/4ad7a433efd93246ebf3113ac8247c4fadd0683e) haskell.packages.ghc96.tls: work around aarch64 codegen bug
* [`fd2795d0`](https://github.com/NixOS/nixpkgs/commit/fd2795d0bcd0d001378914728510a71ae20f7421) restore original version strategy with no git hash.
* [`85318c39`](https://github.com/NixOS/nixpkgs/commit/85318c391531d7c292727382c7c8661f75548152) httpfs extension was not bundled. just bundle all of the in tree extensions
* [`711b27d7`](https://github.com/NixOS/nixpkgs/commit/711b27d7e1d1dc69c83aa9cc34c93bbe59fe289c) python310Packages.glyphslib: 6.4.0 -> 6.4.1
* [`bfbe80f1`](https://github.com/NixOS/nixpkgs/commit/bfbe80f1b4d0521aaa9e99234291979fe2f6f6d8) exclude additional httpfs tests which access network
* [`5edabf7c`](https://github.com/NixOS/nixpkgs/commit/5edabf7c0b904e62b65027e2bc4dbed4e98788d1) moonraker: add useGpiod
* [`430a6cb7`](https://github.com/NixOS/nixpkgs/commit/430a6cb7902dd709d8d47504738aa91537d1fbf4) disable one more httpfs test test/sql/json/table/read_json_objects.test
* [`a9d95ded`](https://github.com/NixOS/nixpkgs/commit/a9d95ded63e499febe6d12c43e225407755f2cb4) remove tabs
* [`af0b550f`](https://github.com/NixOS/nixpkgs/commit/af0b550fa71e85c37a437e451c04fbe1277f3adb) python310Packages.pydyf: 0.7.0 -> 0.8.0
* [`8f9d4bf6`](https://github.com/NixOS/nixpkgs/commit/8f9d4bf6b703c1b871b7544a8c6d38088735bce1) qtile: sort build inputs
* [`e6241c8e`](https://github.com/NixOS/nixpkgs/commit/e6241c8e40854a187c50916c350c99407beb9075) qtile: add iwlib as a build input
* [`fea59e85`](https://github.com/NixOS/nixpkgs/commit/fea59e85c337eea1211f9ff524ab676770d99239) python310Packages.chispa: 0.9.3 -> 0.9.4
* [`96087b62`](https://github.com/NixOS/nixpkgs/commit/96087b627688f1b05334e0a72e1a5b6b29666a00) python310Packages.sagemaker: 2.187.0 -> 2.188.0
* [`d86dee81`](https://github.com/NixOS/nixpkgs/commit/d86dee814075f031d8c150dec47a27f342171a8b) rust-analyzer-unwrapped: 2023-09-18 -> 2023-09-25
* [`495bc50e`](https://github.com/NixOS/nixpkgs/commit/495bc50e4d6f2dc962aac8fea058ac3897520fb1) python310Packages.pytrafikverket: 0.3.6 -> 0.3.7
* [`e7943aa1`](https://github.com/NixOS/nixpkgs/commit/e7943aa168894768e350f525f74775f38b48489d) fix bad merge
* [`fef9a2a1`](https://github.com/NixOS/nixpkgs/commit/fef9a2a11b64817ab9fbdf29b8a305e6e11f8304) fix bad merge
* [`d5942e45`](https://github.com/NixOS/nixpkgs/commit/d5942e4513b6fb571b7df328ff7b060c56dbb88e) fix bad merge
* [`0c64ac90`](https://github.com/NixOS/nixpkgs/commit/0c64ac9065d6524e58f9e6fca2c021b4da446c1d) python310Packages.aiostream: 0.5.0 -> 0.5.1
* [`49787f4d`](https://github.com/NixOS/nixpkgs/commit/49787f4dfbb5acbce40ed0eea90677011de32456) pdf2djvu: 0.9.18.2 -> 0.9.19 ([nixos/nixpkgs⁠#256782](https://togithub.com/nixos/nixpkgs/issues/256782))
* [`2958e1b6`](https://github.com/NixOS/nixpkgs/commit/2958e1b60ae7ca80d07c69b1c7c9582616b4c3c3) discord: Add update script for darwin
* [`cec7bbec`](https://github.com/NixOS/nixpkgs/commit/cec7bbec36bda4f48d698310a48c92ff3a79e5d6) discord-canary: 0.0.312 -> 0.0.314
* [`51c30df0`](https://github.com/NixOS/nixpkgs/commit/51c30df0c783d9f016768b5b94c913e4ac70f176) discord-development: 0.0.8795 -> 0.0.8797
* [`30fac10d`](https://github.com/NixOS/nixpkgs/commit/30fac10dbcd7cf941ae8360984c50afeed315187) discord-ptb: 0.0.77 -> 0.0.79
* [`b56f06f3`](https://github.com/NixOS/nixpkgs/commit/b56f06f3e8c6f48973a43765f4b02c756ba30da4) ocamlPackages.camomile: 1.0.2 → 2.0.0
* [`af225c64`](https://github.com/NixOS/nixpkgs/commit/af225c640e134190a7e2a87a4036b2c6ffaceec7) rye: 0.13.0 -> 0.14.0
* [`087eac26`](https://github.com/NixOS/nixpkgs/commit/087eac2653882ca3a8fe7e804e5d937129e41e3b) imagemagick: 7.1.1-18 -> 7.1.1-19
* [`7ae94d93`](https://github.com/NixOS/nixpkgs/commit/7ae94d93b0805fd6657898cd7ddd6970906f5ec0) dia: unstable-2022-12-14 -> unstable-2023-09-28
* [`e09c8c43`](https://github.com/NixOS/nixpkgs/commit/e09c8c43a70a2cea98c62271c2a7a7f92c8a0f4c) python311Packages.bthome-ble: 3.1.1 -> 3.2.0
* [`39ce8cc6`](https://github.com/NixOS/nixpkgs/commit/39ce8cc6c80b640f779afd43354a39c412f85bbc) metasploit: 6.3.35 -> 6.3.36
* [`c1db4a4d`](https://github.com/NixOS/nixpkgs/commit/c1db4a4d94c74f691db3c82bd6ce94e30c2ea7b9) python311Packages.garminconnect: 0.2.7 -> 0.2.8
* [`86ce2be1`](https://github.com/NixOS/nixpkgs/commit/86ce2be1bb40411184f552dc305f499ed34962b8) python311Packages.garth: 0.4.34 -> 0.4.36
* [`7138c234`](https://github.com/NixOS/nixpkgs/commit/7138c2341d441187f4f198637a9788b136387e38) python311Packages.hahomematic: 2023.9.8 -> 2023.10.0
* [`1349f043`](https://github.com/NixOS/nixpkgs/commit/1349f043f5a79535d0541d47f87385965228253d) python311Packages.plugwise: 0.33.0 -> 0.33.1
* [`d01d9177`](https://github.com/NixOS/nixpkgs/commit/d01d91772fe3b329e5e0d099f27b64bdc55f8b5d) python311Packages.pydrawise: 2023.9.3 -> 2023.9.4
* [`cb4bdb95`](https://github.com/NixOS/nixpkgs/commit/cb4bdb95e1ff4c24f792a184adb0f269a9b716b9) python311Packages.publicsuffixlist: 0.10.0.20230927 -> 0.10.0.20231002
* [`d4471d8b`](https://github.com/NixOS/nixpkgs/commit/d4471d8b19c464af044e044ba0f029ef110d252a) python310Packages.pytest-repeat: 0.9.1 -> 0.9.2
* [`59479521`](https://github.com/NixOS/nixpkgs/commit/594795213b5939efb6d7062781143b8ade1c8a43) python311Packages.prawcore: 2.3.0 -> 2.4.0
* [`157406aa`](https://github.com/NixOS/nixpkgs/commit/157406aa102f486933da04a257bcfaf405ebc7af) catppuccin-gtk: 0.6.2 -> 0.7.0
* [`67aa71bf`](https://github.com/NixOS/nixpkgs/commit/67aa71bfb05b977801cda1a17a621057e924048d) python310Packages.pytest-repeat: add changelog to meta
* [`2102e74b`](https://github.com/NixOS/nixpkgs/commit/2102e74b4a3d4ed5d68d603e2fb192a1d009dabf) eduke32: 20221225 -> 20230926
* [`458f8b1d`](https://github.com/NixOS/nixpkgs/commit/458f8b1d3df80f46602260ddb6dbbc9b6dcda606) python311Packages.rns: 0.6.0 -> 0.6.1
* [`eafbb77f`](https://github.com/NixOS/nixpkgs/commit/eafbb77ff47d28dea49d62a884950e978ac2e89e) nimPackages.atlas: init unstable-2023-09-22
* [`f73c2114`](https://github.com/NixOS/nixpkgs/commit/f73c21141493099f97c51b6d5f06f0bb27698a20) Repackage Nimble in nimPackages
* [`7901ce6a`](https://github.com/NixOS/nixpkgs/commit/7901ce6aefbc0654ce5f690921f79a55bdba2a05) Remove Nimble from Nim wrapper
* [`d5ecd32b`](https://github.com/NixOS/nixpkgs/commit/d5ecd32ba115269c3d9fdf208b5cb7c2873601be) python311Packages.pytest-repeat: add format
* [`24dad2c1`](https://github.com/NixOS/nixpkgs/commit/24dad2c1d6dec1e500559a8012d5e6980bdfcee5) nitter: depend on openssl with buildInputs
* [`bb91de38`](https://github.com/NixOS/nixpkgs/commit/bb91de3827ae2ecddef1f4cb89dcbec9f37a356f) nim: do not dlload openssl
* [`006a72a6`](https://github.com/NixOS/nixpkgs/commit/006a72a68d65c99b324d4b9154739ec85eee0609) nimPackages.jsony: ~1.1.4 -> 1.1.5
* [`486846db`](https://github.com/NixOS/nixpkgs/commit/486846dbef5b1beaec16ebb6e3eafb21c0ebfea1) python3Packages.tsfresh: init at 0.20.1
* [`5891a8e9`](https://github.com/NixOS/nixpkgs/commit/5891a8e987b1889d1d302764a17f259de279b405) python3Packages.tbats: init at 1.1.3
* [`283ab0a6`](https://github.com/NixOS/nixpkgs/commit/283ab0a6394e9a99aa5d37ba58436078cbd4ef16) python3Packages.dataprep-ml: init at 0.0.18
* [`5e6b138f`](https://github.com/NixOS/nixpkgs/commit/5e6b138f309e3b598ef7aa7e71a42c7455323bb0) python3Packages.seasonal: init at 0.3.1
* [`f902cb49`](https://github.com/NixOS/nixpkgs/commit/f902cb49892d300ff15cb237e48aa1cad79d68c3) nim: fix evaluation
* [`e4301a7b`](https://github.com/NixOS/nixpkgs/commit/e4301a7b8e97399b39e2e9da23da860d653cc3c6) linux_testing: 6.6-rc3 -> 6.6-rc4
* [`d928e497`](https://github.com/NixOS/nixpkgs/commit/d928e497d596086a8b4ea65255eab15838def8d2) linux-rt_5_10: 5.10.180-rt89 -> 5.10.194-rt95
* [`a012fd2d`](https://github.com/NixOS/nixpkgs/commit/a012fd2df1b1d9e92d366b726c220678b5c6c0e2) linux-rt_5_15: 5.15.129-rt67 -> 5.15.133-rt69
* [`1bf420fb`](https://github.com/NixOS/nixpkgs/commit/1bf420fb6fd071f3893ceb51bd4ff6df81a123d2) linux-rt_5_4: 5.4.254-rt85 -> 5.4.257-rt87
* [`0692b3e5`](https://github.com/NixOS/nixpkgs/commit/0692b3e52a7af1d9029562377a7b7fd5d6a8044a) prosody: fix cross
* [`7cea28f1`](https://github.com/NixOS/nixpkgs/commit/7cea28f1c4a601cea296b5c03fd9aff089346fcb) sudo-rs: 0.2.0 -> 0.2.1
* [`2ed60261`](https://github.com/NixOS/nixpkgs/commit/2ed602617c68fe42dff2b5b4d09ce86b00407d90) shim-unsigned: passthru target attribute
* [`1d953af5`](https://github.com/NixOS/nixpkgs/commit/1d953af53e724c3aa3ff3bbd6b5a12cfa978518c) cp2k: fix libxc includes (use getDev)
* [`ef2d57ee`](https://github.com/NixOS/nixpkgs/commit/ef2d57ee1c16eafda5305b2532ca14bdbedf24d2) libxc: split outputs -> out, dev
* [`62e95d09`](https://github.com/NixOS/nixpkgs/commit/62e95d095d38ceeb3d56614e33ca668907bdce54) nixos/qemu-vm: optionally disable overriding fileSystems
* [`8cdc1087`](https://github.com/NixOS/nixpkgs/commit/8cdc1087b930adb29358a22ef8a756e23316fdc1) secretscanner: restrict platforms to x86_64-linux
* [`76a8ec16`](https://github.com/NixOS/nixpkgs/commit/76a8ec168c7da80df5773f15b925ce13044d1a39) hyperscan: enable build for x86_64-darwin
* [`053e4b08`](https://github.com/NixOS/nixpkgs/commit/053e4b089cc0fe0b3a695e057518e759a832674c) hyperscan: build chimera in static build
* [`0533f4e4`](https://github.com/NixOS/nixpkgs/commit/0533f4e43d9727ec20427bc2438fd1432a68f208) python3Packages.hyperscan: init at 0.6.0
* [`1f83264b`](https://github.com/NixOS/nixpkgs/commit/1f83264b9fa2e2bc8c09a267eaf21e3c6cba4362) girouette: init at 0.7.4
* [`4515a08c`](https://github.com/NixOS/nixpkgs/commit/4515a08c28db4eb0fc1ea3fc91601e874978ec99) chickenPackages.chickenEggs: update
* [`da4f1205`](https://github.com/NixOS/nixpkgs/commit/da4f120515928b4dc201d53d392f639c1f9e6755) cloud-sql-proxy: 2.6.1 -> 2.7.0
* [`f0a8d614`](https://github.com/NixOS/nixpkgs/commit/f0a8d6145eb704e46c5bf48edaab719e527bb47c) turso-cli: 0.82.0 -> 0.85.3 ([nixos/nixpkgs⁠#257627](https://togithub.com/nixos/nixpkgs/issues/257627))
* [`6adef231`](https://github.com/NixOS/nixpkgs/commit/6adef231599313fa44b4f4da685440c016e39c43) conntrack-tools: 1.4.7 -> 1.4.8
* [`73f0bd48`](https://github.com/NixOS/nixpkgs/commit/73f0bd489091d30cd899d85575855896d5fdd597) qownnotes: 23.9.4 -> 23.10.0
* [`a6cd76d7`](https://github.com/NixOS/nixpkgs/commit/a6cd76d7e992db61629b7ee23766bc9fa886ca62) python3Packages.torchaudio: fix the cuda build
* [`208220b5`](https://github.com/NixOS/nixpkgs/commit/208220b5eb79872b477f4a0a3782a7124ebe6740) yajl: 2.1.0 -> unstable-2022-04-20
* [`e8d14083`](https://github.com/NixOS/nixpkgs/commit/e8d14083e2bb264585cbcb47d197b06d6ec7e915) yajl: fix static compilation
* [`63869a3e`](https://github.com/NixOS/nixpkgs/commit/63869a3e447f58ac2f28e2e045fd9ae7e009c93f) yajl: enable included and pkg-config tests
* [`5d744d8b`](https://github.com/NixOS/nixpkgs/commit/5d744d8bbf9649b8f3caeccbaedafeffdf626da8) sweet-nova: unstable-2023-04-02 -> unstable-2023-09-30
* [`17d8ae43`](https://github.com/NixOS/nixpkgs/commit/17d8ae43c16240ac5f5ddd74847fb17c48e3708e) eza: 0.13.1 -> 0.14.0
* [`7e0b4a80`](https://github.com/NixOS/nixpkgs/commit/7e0b4a80205a64750873e53a5eea0e86d757c5f2) fixup! python3Packages.torchaudio: fix the cuda build
* [`64b870f0`](https://github.com/NixOS/nixpkgs/commit/64b870f0e29710fd4455207089283c6d44f72e03) thunderbird: add libcanberra to libs to fix notification sound
* [`524181b5`](https://github.com/NixOS/nixpkgs/commit/524181b5b817b1d2aac2693a6058558679555450) nixos/locate: rip out dbfile overrides
* [`342cc761`](https://github.com/NixOS/nixpkgs/commit/342cc761dfd76ac6caaaafd96b3aac8f0311119a) nixos/gpsd: add extraArgs option
* [`8199e4ff`](https://github.com/NixOS/nixpkgs/commit/8199e4ffcc7447e03e1efa4019cca876accac029) sgt-puzzles: add updateScript
* [`b5e505b4`](https://github.com/NixOS/nixpkgs/commit/b5e505b44002321d0728ba5bcc3a86964595ecaa) exim: 4.96 -> 4.96.1
* [`75fa9052`](https://github.com/NixOS/nixpkgs/commit/75fa90526923931caabb8ee19bef0f2df97a9f8d) p2pool: 3.6.2 -> 3.7
* [`13c1cb4f`](https://github.com/NixOS/nixpkgs/commit/13c1cb4f646a57abcc5bd275c816c3f9d112851a) assimp: 5.2.5 -> 5.3.1
* [`d13d9963`](https://github.com/NixOS/nixpkgs/commit/d13d9963979ceb7db1bb79b60f9c378901c9f56b) fastfetch: 2.0.5 -> 2.1.0
* [`02199cf5`](https://github.com/NixOS/nixpkgs/commit/02199cf57500a57540215738165eafcb9e5ceba3) esphome: 2023.9.1 -> 2023.9.2
* [`5653e06e`](https://github.com/NixOS/nixpkgs/commit/5653e06ea3dc3801661ad83e96c4b3dcb52bdf8d) topiary: 0.2.3 -> 0.3.0
* [`d61adf2d`](https://github.com/NixOS/nixpkgs/commit/d61adf2d13b9350fb072ecbd6c696eaa03227098) asciinema-agg: 1.4.2 -> 1.4.3
* [`415ebe61`](https://github.com/NixOS/nixpkgs/commit/415ebe619e1acc3ee8ecf4bd7a8d9ad952eb7afe) git-mit: 5.12.153 -> 5.12.154
* [`78ff155c`](https://github.com/NixOS/nixpkgs/commit/78ff155c4b9f2e672b57271117dbd80c57462d7c) jql: 7.0.3 -> 7.0.4
* [`e807bbbc`](https://github.com/NixOS/nixpkgs/commit/e807bbbca85b56f40e2d2245f009c1c2fbb21d65) funzzy: 1.0.1 -> 1.1.1
* [`79e97e48`](https://github.com/NixOS/nixpkgs/commit/79e97e485c573a25290ac96afa9e4118d8fe286f) veilid: 0.2.1 -> 0.2.3
* [`5eddd012`](https://github.com/NixOS/nixpkgs/commit/5eddd012ab1b6ef5424ed707fa955e2bfa8a5a85) typos: 1.16.15 -> 1.16.16
* [`81f35699`](https://github.com/NixOS/nixpkgs/commit/81f35699275b1abe98d0f1b46c4a3b143b004ef5) cargo-expand: 1.0.71 -> 1.0.72
* [`1fcb41f7`](https://github.com/NixOS/nixpkgs/commit/1fcb41f796d091e9ebcd90d28c8fd8b5b93231be) python312: 3.12.0-rc3 -> 3.12.0
* [`85f0aeae`](https://github.com/NixOS/nixpkgs/commit/85f0aeae20bd9e565df7b36f46271c7d3e405292) python310Packages.apycula: 0.9.0 -> 0.9.1
* [`5503ff2c`](https://github.com/NixOS/nixpkgs/commit/5503ff2ce4513a5160f6f50e562df13e0eec502a) python311Packages.teslajsonpy: 3.9.3 -> 3.9.4
* [`0acad96a`](https://github.com/NixOS/nixpkgs/commit/0acad96a52ecfe3039ce4da0f180c36e201b4d1b) python311Packages.tplink-omada-client: 1.3.4 -> 1.3.5
* [`6f5427ab`](https://github.com/NixOS/nixpkgs/commit/6f5427abfb5f48c252f1e164bef5be9a0269bacc) svdtools: 0.3.1 -> 0.3.3
* [`0c576ab4`](https://github.com/NixOS/nixpkgs/commit/0c576ab4c09b9c9429ca6d56b17bcfbdd5ca2d0a) svd2rust: 0.30.0 -> 0.30.1
* [`8e7b0531`](https://github.com/NixOS/nixpkgs/commit/8e7b0531fa2e370641f05dcf550222605f2cf34b) python311Packages.alexapy: 1.27.1 -> 1.27.2
* [`7ed04801`](https://github.com/NixOS/nixpkgs/commit/7ed04801ba75405d3bcb3850478f7faff78088c6) python311Packages.alexapy: 1.27.2 -> 1.27.3
* [`634ca1e9`](https://github.com/NixOS/nixpkgs/commit/634ca1e9ce2bf39ae435480f1aa53e8b10258a46) python311Packages.alexapy: 1.27.3 -> 1.27.4
* [`bb871a9f`](https://github.com/NixOS/nixpkgs/commit/bb871a9f1720a89fc6789e324b7b2215b4dc00a6) checkov: 2.4.57 -> 2.4.59
* [`3ed9162f`](https://github.com/NixOS/nixpkgs/commit/3ed9162faf20c0d81947a28b075be1b6160d8bf1) python311Packages.nibe: 2.3.0 -> 2.4.0
* [`615ccb25`](https://github.com/NixOS/nixpkgs/commit/615ccb250e694f5956ccd067944abc901edf6829) fishPlugins.done: 1.17.0 -> 1.17.1
* [`ae3682cb`](https://github.com/NixOS/nixpkgs/commit/ae3682cb17b93d2d3bedf4be439c4a9688760881) linux_6_4: drop (EOL)
* [`cc63974f`](https://github.com/NixOS/nixpkgs/commit/cc63974f629702717fc11db4498c03bbc1a1aba0) ruff: 0.0.291 -> 0.0.292
* [`5568d392`](https://github.com/NixOS/nixpkgs/commit/5568d392c618485584c97fa4245839e16754e934) ovh-ttyrec: 1.1.6.7 -> 1.1.7.1
* [`e6f82644`](https://github.com/NixOS/nixpkgs/commit/e6f826441506a520f6909a2e099c4a7dd37b718a) chatterino2: 2.4.5 -> 2.4.6
* [`9e47b650`](https://github.com/NixOS/nixpkgs/commit/9e47b650c83692e65450e587007d59d9fd1b4ff6) cargo-tarpaulin: 0.27.0 -> 0.27.1
* [`c97b86ad`](https://github.com/NixOS/nixpkgs/commit/c97b86adfde9d6a25f1ab87bc6bc8c46b408b1ad) gobgp: 3.18.0 -> 3.19.0
* [`a8f4d0b7`](https://github.com/NixOS/nixpkgs/commit/a8f4d0b7e43f1d4036df5621afab0650d7920da8) tui-journal: 0.3.1 -> 0.3.2
* [`dc439e41`](https://github.com/NixOS/nixpkgs/commit/dc439e41db1136d63f15fd42c0fa8b4f3b65f93b) nixos/environment: move XDG_CONFIG_DIRS to sessionVariables
* [`cf2074d3`](https://github.com/NixOS/nixpkgs/commit/cf2074d36502d2c129bc970bd5aad9501d9cc133) orogene: 0.3.32 -> 0.3.33
* [`3ff00e53`](https://github.com/NixOS/nixpkgs/commit/3ff00e533b4d08b38ffeb49a2fd7c4073c85a91b) python310Packages.pyftpdlib: 1.5.7 -> 1.5.8
* [`f8d1b78e`](https://github.com/NixOS/nixpkgs/commit/f8d1b78e8a4c6d8b3f0287649fd2980fdf9e3337) adw-gtk3: 4.5 -> 4.9
* [`b19e9beb`](https://github.com/NixOS/nixpkgs/commit/b19e9bebdc8ee7dce5a4c40e510165f0011008b7) doc: minimal documentation of supported platforms
* [`562ced53`](https://github.com/NixOS/nixpkgs/commit/562ced5399dad30ce86ead8bdf3c8b970511adfc) ocamlPackages.ocsigen_server: 5.0.1 → 5.1.0
* [`651f3f58`](https://github.com/NixOS/nixpkgs/commit/651f3f588a44a3abd9f9b0acc7f536637607298f) python310Packages.ocrmypdf: 15.0.1 -> 15.0.2
* [`56ae5a82`](https://github.com/NixOS/nixpkgs/commit/56ae5a8275b5d8c56037dc33964b306ae6493fbe) python311Packages.pywerview: 0.5.1 -> 0.5.2
* [`04fcfb07`](https://github.com/NixOS/nixpkgs/commit/04fcfb072fe18e6a6b3488dc366542f39f19e5d6) python3Packages.accessanalyzer: init at 1.28.36
* [`0dcdf60c`](https://github.com/NixOS/nixpkgs/commit/0dcdf60c38dbef4749e83715db976996551fa45b) workflows/check-by-name: Better error when base branch also fails
* [`b58322e0`](https://github.com/NixOS/nixpkgs/commit/b58322e0cd53026f3ffd8684f32a797cc13e1435) python3Packages.qtile-extras: 0.22.1 -> 0.23.0
* [`e554d726`](https://github.com/NixOS/nixpkgs/commit/e554d7260d3c55e823d9df427dda4fe17b9a6982) google-guest-agent: add changelog to meta
* [`73b01822`](https://github.com/NixOS/nixpkgs/commit/73b01822c4409bcd4b0028d59d11fc044580e61d) linux/update-mainline.py: log to stderr
* [`5d67dd66`](https://github.com/NixOS/nixpkgs/commit/5d67dd663eceb96e0823ccdf6c1ae9b705c2a469) container2wasm: add changelog to meta
* [`9f5a2891`](https://github.com/NixOS/nixpkgs/commit/9f5a28917fe21f9aa7dbfe45f71379792eca91c1) container2wasm: fix version in help output
* [`d641f408`](https://github.com/NixOS/nixpkgs/commit/d641f4085487acbadee82a62298f1bf4bafdbab9) container2wasm: 0.4.0 -> 0.5.1
* [`ab1869c2`](https://github.com/NixOS/nixpkgs/commit/ab1869c2de9215d5984d3a2a15316455f0483276) python3Packages.python-tds: init at 1.13.0
* [`8eda1efc`](https://github.com/NixOS/nixpkgs/commit/8eda1efc8696e4161bdea960b3953bc443498ec7) python3Packages.mindsdb-evaluator: init at 0.0.11
* [`a91596cc`](https://github.com/NixOS/nixpkgs/commit/a91596cc8e6e9ce3ed9b59a44501724c84c74404) flexget: 3.9.10 -> 3.9.11
* [`fcafb9b6`](https://github.com/NixOS/nixpkgs/commit/fcafb9b6664a3ac30bc5d732cc4817012a4e2d00) goaccess: 1.7.2 -> 1.8
* [`ae45f7b7`](https://github.com/NixOS/nixpkgs/commit/ae45f7b7b97d3b349815062b669a96371ebacb6a) trufflehog: 3.57.0 -> 3.58.0
* [`bef9ffa1`](https://github.com/NixOS/nixpkgs/commit/bef9ffa1ec589fc683af3a00b6d530df32d65a5e) python311Packages.pymyq: 3.1.10 -> 3.1.11
* [`a0d92ca1`](https://github.com/NixOS/nixpkgs/commit/a0d92ca13e1430b2f6cd048c69486a572d621f24) python311Packages.aiowaqi: 1.1.1 -> 2.0.0
* [`0f901096`](https://github.com/NixOS/nixpkgs/commit/0f90109665791cbfd1d97bf0ecdc68785d717b0f) signalbackup-tools: 20230929 -> 20231002-1
* [`973096c1`](https://github.com/NixOS/nixpkgs/commit/973096c1319b6024febf27bc4371aeb82fe309e4) nickel: 1.2.1 -> 1.2.2
* [`0c19eb69`](https://github.com/NixOS/nixpkgs/commit/0c19eb6916ade1024700a42ef72ba69656053f3c) algol68g: 3.3.23 -> 3.3.24
* [`b76fa275`](https://github.com/NixOS/nixpkgs/commit/b76fa2759ecd6f1993eae0c73c54f8af428cabad) python311Packages.zeroconf: 0.115.0 -> 0.115.1
* [`71c71d5c`](https://github.com/NixOS/nixpkgs/commit/71c71d5c69c99f203818a91b8e475df19ac6bf1f) typos: 1.16.16 -> 1.16.17
* [`8c106e21`](https://github.com/NixOS/nixpkgs/commit/8c106e21c991dbd82c3dc30adb3ecd451ddf8049) ruff-lsp: 0.0.39 -> 0.0.40
* [`254230e2`](https://github.com/NixOS/nixpkgs/commit/254230e251a29a4ed22a33e753b4f2e530210743) mermaid-cli: use fetchYarnDeps
* [`2e43e13e`](https://github.com/NixOS/nixpkgs/commit/2e43e13ec344a4ae4594b735b28d5356bfc9b428) nodePackages: update
* [`5eb4f493`](https://github.com/NixOS/nixpkgs/commit/5eb4f4936d761f6aaf7c4af3adbdbaa40e58c95f) ldmud: 3.6.6 -> 3.6.7
* [`13da5616`](https://github.com/NixOS/nixpkgs/commit/13da5616f01a0d13ccfb949042f4daacd5134f2f) src-cli: 5.1.2 -> 5.2.0
* [`c42909d3`](https://github.com/NixOS/nixpkgs/commit/c42909d342e2bad6739a31e608f41ad62d545ce1) liblinphone: fix build
* [`9297eab8`](https://github.com/NixOS/nixpkgs/commit/9297eab8686bde9b8ae2224d954363ed4b07548f) python311Packages.scooby: 0.7.3 -> 0.7.4
* [`b206b081`](https://github.com/NixOS/nixpkgs/commit/b206b0817cfc8ba3aaaee2d4cbcb05aa19d60a97) tailscale: 1.50.0 -> 1.50.1
* [`0ba49949`](https://github.com/NixOS/nixpkgs/commit/0ba49949b087f0b358dafc118588f80dabcc885e) nixos/network-interfaces-systemd: don't set network-level domains
* [`28ab2b27`](https://github.com/NixOS/nixpkgs/commit/28ab2b278d782367c43092a31f8360c0454f3edc) nixos/networkd: make wait-online not time out
* [`5d230261`](https://github.com/NixOS/nixpkgs/commit/5d230261c9a4f282b6e841dca1e77b16b9cf7e12) mlocate: fix default dbfile location after [nixos/nixpkgs⁠#258575](https://togithub.com/nixos/nixpkgs/issues/258575)
* [`f98a338e`](https://github.com/NixOS/nixpkgs/commit/f98a338eec41e707d16003fec9fb3f7be33f550b) plocate: fix default dbfile location after [nixos/nixpkgs⁠#258575](https://togithub.com/nixos/nixpkgs/issues/258575)
* [`b53f8170`](https://github.com/NixOS/nixpkgs/commit/b53f817088d841966f54f867155df50b85934a33) nixos/locate: cleanup optional parenthesis
* [`41a80a15`](https://github.com/NixOS/nixpkgs/commit/41a80a152ef44fc48b8313099b5936e0c23936a9) kaufkauflist: 2.2.0 → 3.0.0
* [`24df0201`](https://github.com/NixOS/nixpkgs/commit/24df0201248ff6f648cdb18d109a9c161f6b7897) alacritty: 0.12.2 -> 0.12.3
* [`5d505a03`](https://github.com/NixOS/nixpkgs/commit/5d505a032df0c07a1a25106968788cc73e628c5a) komikku: 1.23.0 -> 1.24.2
* [`e026e949`](https://github.com/NixOS/nixpkgs/commit/e026e949349d1ba66ee22f3330fb67ac36ba7046) vscode-extensions.firefox-devtools.vscode-firefox-debug: 2.9.8 -> 2.9.10
* [`4f267a0b`](https://github.com/NixOS/nixpkgs/commit/4f267a0b776931134e131c8b65c35c95e3b30483) percona-xtrabackup_8_0: 8.0.29-22 -> 8.0.34-29
* [`a32c37ad`](https://github.com/NixOS/nixpkgs/commit/a32c37ad48a267d93f09396683797341e0f2215e) maintainers: update water-sucks's email
* [`ea9e92e5`](https://github.com/NixOS/nixpkgs/commit/ea9e92e57816111dd37e742bdf5b584d3db9eeeb) vendir: 0.34.4 -> 0.35.0
* [`22dc9cc8`](https://github.com/NixOS/nixpkgs/commit/22dc9cc80f308dd153a068b5ba20c7da4c6cb21a) git-cliff: 1.3.0 -> 1.3.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
