### PR TITLE
niv home-manager: update 6f9b5b83 -> 3c1d8758

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30",
-        "sha256": "1glsbl0an2ac2612n8mk5id6aq6md15qfnpj5i99vvvqywikplyx",
+        "rev": "3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d",
+        "sha256": "15lbabsqc5h5aj32gjzi9l4n9jmy7z9laby1i9k17z73726fjgv0",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@6f9b5b83...3c1d8758](https://github.com/nix-community/home-manager/compare/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30...3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d)

* [`55ce64c3`](https://github.com/nix-community/home-manager/commit/55ce64c3ca031eefb1adac85bb0025887ed7a221) scmpuff: enable or disable aliases
* [`30d2dc8d`](https://github.com/nix-community/home-manager/commit/30d2dc8d689a9060290892164aa4000778e1b42b) flake.lock: Update
* [`e63c30fe`](https://github.com/nix-community/home-manager/commit/e63c30fe9792b57dea1eab98be6871a0e42a33c9) home-manager: fix assignment to read-only variable
* [`4e52d9b7`](https://github.com/nix-community/home-manager/commit/4e52d9b7f7ed92bd98f9eb53f61d838a3928c9cb) flake.lock: Update
* [`b0e0d826`](https://github.com/nix-community/home-manager/commit/b0e0d82696297964f231c37a38e3c64b22ae03e5) zsh-abbr: add module
* [`2874c6fc`](https://github.com/nix-community/home-manager/commit/2874c6fce6de69eaedaa690b5fd6d3c70a2827af) thefuck: add module
* [`8aef005d`](https://github.com/nix-community/home-manager/commit/8aef005d44ee726911e9f793495bb40f2fbf5a05) Translate using Weblate (Indonesian)
* [`68f7d8c0`](https://github.com/nix-community/home-manager/commit/68f7d8c0fb0bfc67d1916dd7f06288424360d43a) firefox: set ADD_DATE and LAST_MODIFIED of bookmarks to 1
* [`44635279`](https://github.com/nix-community/home-manager/commit/44635279a0dfca43d2b980422f295def1aca0c08) bat: allow setting themes/syntaxes without IFD
* [`ed0770e9`](https://github.com/nix-community/home-manager/commit/ed0770e96225f998ea128549ad446d9b1568cb2c) hyprland: allow customizing systemd
* [`31a27e48`](https://github.com/nix-community/home-manager/commit/31a27e48062742241ab06ccdbed189f28040cdaf) fish: query pname and version for completions
* [`b2a2133c`](https://github.com/nix-community/home-manager/commit/b2a2133c9a0b0aa4d06d72b5891275f263ee08df) flake: fix nixpkgs `config`
* [`3c1d8758`](https://github.com/nix-community/home-manager/commit/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d) flake.lock: Update
