### PR TITLE
niv zsh-completions: update c05d0fdf -> 2c1e9af1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "c05d0fdfe08ff3cd4fe0603f5032a2c0ed2bd25a",
-        "sha256": "1iq54c076r66chbkcpbpd003y0wgqld6f9sqs49ibsdcf3k3cr3c",
+        "rev": "2c1e9af19562bfb74a9167122c460bd22e39c06d",
+        "sha256": "00bz7lsvnpzsfkmm2qb69jjgnnx2n1xcdqlyj6xwzibcy5wmv43w",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/c05d0fdfe08ff3cd4fe0603f5032a2c0ed2bd25a.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/2c1e9af19562bfb74a9167122c460bd22e39c06d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@c05d0fdf...2c1e9af1](https://github.com/zsh-users/zsh-completions/compare/c05d0fdfe08ff3cd4fe0603f5032a2c0ed2bd25a...2c1e9af19562bfb74a9167122c460bd22e39c06d)

* [`d88edeed`](https://github.com/zsh-users/zsh-completions/commit/d88edeed35aaf57493809535f8658edaa2b8be87) Do not use global variable, use local variable instead
* [`41e7188d`](https://github.com/zsh-users/zsh-completions/commit/41e7188db57a62f15ec05dd6c3663e2b3b9e9f2b) Support THC secure-delete
* [`1fab9820`](https://github.com/zsh-users/zsh-completions/commit/1fab9820473ac1d94606783d590068790fc57026) Update cppcheck completion for version 2.12
* [`4351e114`](https://github.com/zsh-users/zsh-completions/commit/4351e11484579c18d028c5d5f74c8bf304b52e94) Don't set global variable in srm completion
