### PR TITLE
niv nixpkgs: update e904535e -> baa913c9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e904535e00cf4651f543779ec05a6528c257310e",
-        "sha256": "013j2a5yq44vd913190qb00lmikhszfvvaxbsxfj23av1r8zwqpk",
+        "rev": "baa913c9eb89ac65d5177731c5f9d42f981eb073",
+        "sha256": "0mqhf1p392a3jvq7fr6a09x26dq0my9gwgw8wq66xc9738pyrqjq",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e904535e00cf4651f543779ec05a6528c257310e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/baa913c9eb89ac65d5177731c5f9d42f981eb073.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e904535e...baa913c9](https://github.com/nixos/nixpkgs/compare/e904535e00cf4651f543779ec05a6528c257310e...baa913c9eb89ac65d5177731c5f9d42f981eb073)

* [`6c532409`](https://github.com/NixOS/nixpkgs/commit/6c53240915d3079daf699044d1aa732f892283cd) zsh-f-sy-h: init at v1.67
* [`a48f1123`](https://github.com/NixOS/nixpkgs/commit/a48f11239dfa1bc5eabec22102dd5036ca492ccb) dolphin: add qtimageformats
* [`e9a134f5`](https://github.com/NixOS/nixpkgs/commit/e9a134f5d074e12a45011c1781656d49412a8d2b) maintainers: add u2x1
* [`1f8b5c03`](https://github.com/NixOS/nixpkgs/commit/1f8b5c039e9726ab4d17181a9eb9f63871007246) lib.fix: Improve doc
* [`0015d8a4`](https://github.com/NixOS/nixpkgs/commit/0015d8a4d8feaccfd8a478cb024b4701358b48cf) kio-extras: add libX11 and libXcursor to buildInputs
* [`396c219f`](https://github.com/NixOS/nixpkgs/commit/396c219fec1179fd54c2d7a7aa7a4b3e08f7063a) nhentai: 0.4.16 -> 0.5.3
* [`6afbeda9`](https://github.com/NixOS/nixpkgs/commit/6afbeda9d67dbf8ef62399eb5779721577c9a89b) smtprelay: init at 1.10.0
* [`1b111841`](https://github.com/NixOS/nixpkgs/commit/1b111841756a353e860e8462fd9e4a7094d8815c) jetbrains.*: allow overriding of the `vmopts` file
* [`32d226f7`](https://github.com/NixOS/nixpkgs/commit/32d226f7977027debb8de9ae5dfa1cb5e1953b72) puredata: add darwin support
* [`a23abab1`](https://github.com/NixOS/nixpkgs/commit/a23abab1427a84149e001db2f6a0a56005ecc906) puredata: 0.50-2 -> 0.53-2
* [`6ef4223c`](https://github.com/NixOS/nixpkgs/commit/6ef4223c631541269ceb6fa2000ea1821c7012c1) cyclone: 0.3beta-2 -> 0.7-0
* [`2be1815b`](https://github.com/NixOS/nixpkgs/commit/2be1815baf80a56b5a1cd99b5391997f2c8a56f2) puredata: 0.53-2 -> 0.54-0
* [`e6832908`](https://github.com/NixOS/nixpkgs/commit/e6832908ad8d83788d33ad97dbd5c8f6e4d72051) gem: 2020-09-22 -> 2023-07-28
* [`c5a5c7d0`](https://github.com/NixOS/nixpkgs/commit/c5a5c7d0adfa4aae1b8d142182d9f947c6b9ecc2) cyclone: mark broken
* [`e3f46dfb`](https://github.com/NixOS/nixpkgs/commit/e3f46dfb1f1864886d18be71053ef5b0aa2daade) percollate: init at 4.0.2
* [`91281e7f`](https://github.com/NixOS/nixpkgs/commit/91281e7f6b8a042058d1313a691bda551ba9cee3) cups-brother-hl2260d: init at 3.2.0-1
* [`39862cd4`](https://github.com/NixOS/nixpkgs/commit/39862cd40deab773c91a9d2166f24fc62e75072d) openutau: pull in bump for avalonia to fix crashes
* [`02925a26`](https://github.com/NixOS/nixpkgs/commit/02925a263f5a6e56aa9956998663d54c880bc4c4) cyclone: 0.7-0 -> unstable-2023-09-12
* [`ac38e6c3`](https://github.com/NixOS/nixpkgs/commit/ac38e6c3516271046f88ae9fd17e9017e14c434e) plasma5/systemsettings: add kirigami-addons
* [`2917eced`](https://github.com/NixOS/nixpkgs/commit/2917eced084a7f63b4c661032fa1e97c76227ccd) alpine-make-vm-image: 0.11.1 -> 0.12.0
* [`daa1757d`](https://github.com/NixOS/nixpkgs/commit/daa1757df572301570edc5faf4786dad95347317) youtube-tui: 0.7.1 -> 0.8.0
* [`62941d93`](https://github.com/NixOS/nixpkgs/commit/62941d939b665c5deccf5d871b3ff1ab854c0bac) ccacheStdenv: support cross compilation
* [`81daaece`](https://github.com/NixOS/nixpkgs/commit/81daaece83d67a2061e3a54a79dfd2ecacf78f95) prometheus-imap-mailstat-exporter: init at 0.0.1
* [`b4e162a1`](https://github.com/NixOS/nixpkgs/commit/b4e162a109eb84911c68d1695a3e524b7650da90) nixos/networking: warn when both networkd and dhcpcd can collide
* [`129dcb9f`](https://github.com/NixOS/nixpkgs/commit/129dcb9f7d26e8bf6920982b519bdffd27970742) livecaptions: 0.4.0 -> 0.4.1
* [`40a4f5eb`](https://github.com/NixOS/nixpkgs/commit/40a4f5eb85ccd39c97896479556d2c16343372cb) livecaptions: set mainProgram
* [`3ed419cd`](https://github.com/NixOS/nixpkgs/commit/3ed419cd2f01117facf2b97c5fba31e55511b781) breezy: add github support
* [`48926aa4`](https://github.com/NixOS/nixpkgs/commit/48926aa490da5d615d99949a73a272ccdc9ec3fa) jimtcl: Fix cross compilation and allow disable of SDL
* [`72db60de`](https://github.com/NixOS/nixpkgs/commit/72db60de1f655abcb342e228674decc061e3a0fb) argyllcms: 2.3.1 -> 3.0.0
* [`909dd762`](https://github.com/NixOS/nixpkgs/commit/909dd7625b678202932c8396523c0aec3f669da1) tev: 1.23 -> 1.26
* [`272b458b`](https://github.com/NixOS/nixpkgs/commit/272b458b2911439102aa03994a22ed046bce49b0) gwyddion: 2.61 -> 2.63
* [`da318342`](https://github.com/NixOS/nixpkgs/commit/da318342a156a09642b56f0437c15929f9486be0) tinycdb: 0.78 -> 0.80
* [`1bf0cb05`](https://github.com/NixOS/nixpkgs/commit/1bf0cb05c8ac852504b88a8850ef873bf49ee329) lunar-client: wayland support
* [`093f354a`](https://github.com/NixOS/nixpkgs/commit/093f354a1777e462bd80398c4fc624c4d383dc68) nixos/users-groups: escape hatch for enabling a shell system-wide
* [`46269985`](https://github.com/NixOS/nixpkgs/commit/46269985eb359a410f1fba2e852e0f8e7cf03eeb) antidote: 1.9.1 -> 1.9.2
* [`49c41304`](https://github.com/NixOS/nixpkgs/commit/49c4130466ad7e6ee9439282c6e9628646308cdc) lemminx: disable flaky test
* [`3ca5220a`](https://github.com/NixOS/nixpkgs/commit/3ca5220a5b6ac18aca26841d6789144e93abaafd) ergo: 5.0.13 -> 5.0.14
* [`e03fc13f`](https://github.com/NixOS/nixpkgs/commit/e03fc13fbae15480eebab1417ee69eea36012b46) alembic: 1.8.5 -> 1.8.6
* [`95fa09b7`](https://github.com/NixOS/nixpkgs/commit/95fa09b70adb606d8c23c9aa7540b8f1e81a6d70) python310Packages.torchsde: 0.2.4 -> 0.2.6
* [`865ac017`](https://github.com/NixOS/nixpkgs/commit/865ac01779549f329322d2af467ab9c0f01eb573) python3Packages.libnacl: 1.7.2 -> 2.1.0
* [`088ef51c`](https://github.com/NixOS/nixpkgs/commit/088ef51c9c9a62ddbcfba1dd33ae779437cbdb65) sfrotz: 2.52 -> 2.54
* [`388c7acd`](https://github.com/NixOS/nixpkgs/commit/388c7acd20362047809d3ae55407a75e6f7d3a33) OVMFFull: fix build on non-x86 platforms
* [`5662c6ba`](https://github.com/NixOS/nixpkgs/commit/5662c6bad8514b6948737136957ef715a1f52417) klayout: 0.28.11 -> 0.28.12
* [`9c1a0b21`](https://github.com/NixOS/nixpkgs/commit/9c1a0b21b090a245d8735527b380bec9c8aa72d7) maintainers: add esau79p
* [`b5052d64`](https://github.com/NixOS/nixpkgs/commit/b5052d6435ead233cd3bdb65141a557b898df744) aw-watcher-window-wayland: init at 0.1.0
* [`49fdb927`](https://github.com/NixOS/nixpkgs/commit/49fdb927f7cd0034e1a015ddb72fb38105205144) netpbm: 11.3.5 -> 11.4.2
* [`2a7ce841`](https://github.com/NixOS/nixpkgs/commit/2a7ce841257cda5b7a2751fb3b65f914fe1e31c9) python310Packages.weasyprint: 59.0 -> 60.1
* [`7b406592`](https://github.com/NixOS/nixpkgs/commit/7b40659214992d0ee1b8ec0772b7e6212d67f1d5) moarvm: 2023.08 -> 2023.09
* [`ec6fca3e`](https://github.com/NixOS/nixpkgs/commit/ec6fca3ed696ae1ab344e2577cb9913e230bf845) i2pd: 2.48.0 -> 2.49.0
* [`b7d9bb71`](https://github.com/NixOS/nixpkgs/commit/b7d9bb712455db7a1345d3a1b5e844aab571f22f) libcouchbase: 3.3.8 -> 3.3.9
* [`36091428`](https://github.com/NixOS/nixpkgs/commit/36091428190e329b85cc6f3900fa794496659437) praat: 6.3.16 -> 6.3.17
* [`8b2d0564`](https://github.com/NixOS/nixpkgs/commit/8b2d05645a9dfcdd0a4134adb064872528c3a07e) gqlgenc: 0.11.3 -> 0.15.1
* [`bfe71065`](https://github.com/NixOS/nixpkgs/commit/bfe71065068695c5326fb3ce402cbbbd60d9b46b) xorg.fonttosfnt: 1.2.2 -> 1.2.3
* [`f54d0ec3`](https://github.com/NixOS/nixpkgs/commit/f54d0ec3ae473eeab580d332a565e6170289cc54) python311Packages.py-serializable: 0.12.0 -> 0.13.0
* [`2a913e7b`](https://github.com/NixOS/nixpkgs/commit/2a913e7b5c4c8078b57b859dda844ba4ee86a632) tunnelx: 2023-07-nix -> 2023-09-29
* [`b4f9aca3`](https://github.com/NixOS/nixpkgs/commit/b4f9aca33616a6382c87acce65982ebff3073933) cryptomator: 1.9.4 -> 1.10.1
* [`a095a888`](https://github.com/NixOS/nixpkgs/commit/a095a888bdb9b14cddc8427e2e99050f04cac864) igraph: drop failing test on darwin
* [`f934c67a`](https://github.com/NixOS/nixpkgs/commit/f934c67aa8c72981c4bf27b692877d114c39f929) python310Packages.flask-babel: 3.1.0 -> 4.0.0
* [`6ffd0d3f`](https://github.com/NixOS/nixpkgs/commit/6ffd0d3ff3e77c3b1e101d73964e74b6facd9487) secp256k1: 0.3.2 -> 0.4.0
* [`2d4edcdb`](https://github.com/NixOS/nixpkgs/commit/2d4edcdb7fd7931328ba878ca022c3a2ec1bf41e) wvkbd: 0.12 -> 0.14.1
* [`aee6f2c2`](https://github.com/NixOS/nixpkgs/commit/aee6f2c25939a1aa092dc0c8506021b8bf8d8b30) mongodb-compass: 1.39.4 -> 1.40.2
* [`c4154583`](https://github.com/NixOS/nixpkgs/commit/c4154583798949b60e9b640e40f574feac515fd0) python310Packages.pyspark: 3.4.1 -> 3.5.0
* [`265abbe3`](https://github.com/NixOS/nixpkgs/commit/265abbe35f98f5d8b4173d17804505148b3d1308) brev-cli: 0.6.261 -> 0.6.262
* [`c3999477`](https://github.com/NixOS/nixpkgs/commit/c399947770d6181adf9106858f989cb3e2b22e8a) velero: 1.11.1 -> 1.12.0
* [`329bbe95`](https://github.com/NixOS/nixpkgs/commit/329bbe957b761df99b551eb44071bd5e514f98f3) coreth: 0.12.4 -> 0.12.5
* [`ef3151fc`](https://github.com/NixOS/nixpkgs/commit/ef3151fc1c1d63afe6af34a625fb7b527c8b3ed7) opcr-policy: 0.2.1 -> 0.2.4
* [`fa885bc0`](https://github.com/NixOS/nixpkgs/commit/fa885bc057eb84c7514ebfd2fdb396939f0e7129) gsocket: 1.4.40 -> 1.4.41
* [`7c9bf139`](https://github.com/NixOS/nixpkgs/commit/7c9bf139a211b1951320583c5bfaf745e9def523) elasticmq-server-bin: 1.4.3 -> 1.4.4
* [`8a706aec`](https://github.com/NixOS/nixpkgs/commit/8a706aec8445a6e11c76e61dfc28c5c102a80eec) mox: 0.0.6 -> 0.0.7
* [`cbb4d125`](https://github.com/NixOS/nixpkgs/commit/cbb4d125300e4f96ee2477cb827f62da05c0ecdc) plik: 1.3.7 -> 1.3.8
* [`b4531a95`](https://github.com/NixOS/nixpkgs/commit/b4531a95163cb1f9a36b180863f4c1d9d77a3fef) ibus-engines.anthy: 1.5.14 -> 1.5.15
* [`df3d59ca`](https://github.com/NixOS/nixpkgs/commit/df3d59ca78add2549690d942412c73f2e1b6f5e2) python310Packages.mpi4py: 3.1.4 -> 3.1.5
* [`6aa18105`](https://github.com/NixOS/nixpkgs/commit/6aa18105a84bd6eac42c94ebaf5c856321ba9a79) nco: 5.1.7 -> 5.1.8
* [`a90d7451`](https://github.com/NixOS/nixpkgs/commit/a90d7451c6d8db5c389598cd1b4d55ad9131131c) click: 0.6.2 -> 0.6.3
* [`ede5717d`](https://github.com/NixOS/nixpkgs/commit/ede5717d800eb91b8c3b856a1d5f700f9a4ada66) sweethome3d.application: 7.0.2 -> 7.2
* [`4bdf812b`](https://github.com/NixOS/nixpkgs/commit/4bdf812bc1ee70e7555593d936fded575dca6931) clarity-city: init at 1.0.0
* [`bf06bb0f`](https://github.com/NixOS/nixpkgs/commit/bf06bb0f8924be3e5c71d2009cf96381ad9c7990) spotify: use hash instead of sha512 in update script
* [`f05b197c`](https://github.com/NixOS/nixpkgs/commit/f05b197c2fb4e3011d8f79124c33456a45f6540d) python3Packages.huggingface-hub: 0.16.4 -> 0.17.3
* [`ecd89093`](https://github.com/NixOS/nixpkgs/commit/ecd89093e178e50ead57e3338f25e637dd29310b) nixos-rebuild: run activation inside systemd-run
* [`1e79cca6`](https://github.com/NixOS/nixpkgs/commit/1e79cca679380dd9fa05e76c11a22815cfcde773) release-notes: document nixos-rebuild changes
* [`50dd7641`](https://github.com/NixOS/nixpkgs/commit/50dd7641917ac88f153cf7311debe839c747f34f) join-desktop: drop
* [`8679b69d`](https://github.com/NixOS/nixpkgs/commit/8679b69dcd1f34ae9ae51bdbc65dad3ec91ef501) nixos/nano: include extra syntax highlight files when syntaxHighlight is true
* [`a5bc9ee4`](https://github.com/NixOS/nixpkgs/commit/a5bc9ee49ba381a9e98bb3921a92cefcfdba2c9b) nixos/nano: enable syntaxHighlight by default
* [`f9294b29`](https://github.com/NixOS/nixpkgs/commit/f9294b2952ee5d4c65d00aad04fb76ee3fef44db) joplin-desktop: add window decorations for wayland
* [`ff2868a4`](https://github.com/NixOS/nixpkgs/commit/ff2868a48071e4c3a1e9a6304f99700043204236) python310Packages.rcssmin: 1.1.1 -> 1.1.2
* [`21c4de68`](https://github.com/NixOS/nixpkgs/commit/21c4de68ca1a09fee23b0a6fb4c5f5d08d50436a) spaceship-prompt: 4.14.0 -> 4.14.1
* [`c49eefdf`](https://github.com/NixOS/nixpkgs/commit/c49eefdfe2216c13043c3b6ae507ed632fcf945b) shairport-sync: add xxd to the nativeBuildInputs
* [`c6d9d6e1`](https://github.com/NixOS/nixpkgs/commit/c6d9d6e16732baa9f1f2498f5e2784975d9cd9d4) python311Packages.rcssmin: clean-up
* [`0b4a67b0`](https://github.com/NixOS/nixpkgs/commit/0b4a67b071cfc1771eb7d332a69dcec0f529f5ac) vulkan-cts: 1.3.6.3 -> 1.3.7.0
* [`4c5af4f7`](https://github.com/NixOS/nixpkgs/commit/4c5af4f76f742cb5e4d95cdd89d743902969ce57) zed: 1.9.0 -> 1.10.0
* [`8814ada7`](https://github.com/NixOS/nixpkgs/commit/8814ada792591c9e0504c8f442bd6a7f8e1efc93) cargo-ndk: 3.3.0 -> 3.4.0
* [`9066e027`](https://github.com/NixOS/nixpkgs/commit/9066e027a077a8042d6f0e1cd13124f949be93bf) k8sgpt: 0.3.15 -> 0.3.17
* [`cf7f32a6`](https://github.com/NixOS/nixpkgs/commit/cf7f32a65e489b2892efd9524fafe03998182a98) vercel-pkg: use fetchYarnDeps
* [`3aeeea6d`](https://github.com/NixOS/nixpkgs/commit/3aeeea6d700fcf94839e4badf480e1407bddd8c7) fuc: 1.1.7 -> 1.1.8
* [`ba077857`](https://github.com/NixOS/nixpkgs/commit/ba077857b1cb62afefa17d7adcc53c287e331aa0) python311Packages.cirq-core: 1.1.0 -> 1.2.0
* [`3ebcff37`](https://github.com/NixOS/nixpkgs/commit/3ebcff37ed8d3e34301e3100ed86ed1207ece18a) ryujinx: 1.1.1012 -> 1.1.1044
* [`12562aa0`](https://github.com/NixOS/nixpkgs/commit/12562aa0b8ab52c78217bf6440fdbc0c8e9e84a3) ortp: 5.2.16 -> 5.2.109
* [`4b2a04de`](https://github.com/NixOS/nixpkgs/commit/4b2a04def6b411daca7a97708c7c140f8e269c05) libgpiod: 2.0.1 -> 2.0.2
* [`2a8f6ebd`](https://github.com/NixOS/nixpkgs/commit/2a8f6ebd6044c3161d553fdd648ccbb5f8d76e77) libxls: mark knownVulnerabilities CVE-2023-38851 - CVE-2023-38856
* [`0329cbc0`](https://github.com/NixOS/nixpkgs/commit/0329cbc02a3b28c56cd5804309b4ca0c7087f1ee) dart-sass: 1.68.0 -> 1.69.0
* [`499a40eb`](https://github.com/NixOS/nixpkgs/commit/499a40ebe5616ec4be714f209506936d8f6e4e49) linkerd_edge: 23.9.4 -> 23.10.1
* [`a13823f2`](https://github.com/NixOS/nixpkgs/commit/a13823f2c3f774641279e51e006eabd3fba27af9) inadyn: 2.11.0 -> 2.12.0
* [`c57e132c`](https://github.com/NixOS/nixpkgs/commit/c57e132ccfa869fabf6f1f45eab6303f19a9f3fd) react-native-debugger: 0.13.0 -> 0.14.0
* [`982e8657`](https://github.com/NixOS/nixpkgs/commit/982e8657eae2f0fbf70213d448505c9eea23cfe9) font-awesome: 6.1.1 -> 6.4.2
* [`746100a1`](https://github.com/NixOS/nixpkgs/commit/746100a122c038931fbc97cdf9ef36cef9bd015f) quassel: add ldap support for core
* [`3dc0f1e7`](https://github.com/NixOS/nixpkgs/commit/3dc0f1e7b7302de423653e5d18c7d0b6b1c8a082) blast-bin: 2.13.0 -> 2.14.1
* [`76fb9da4`](https://github.com/NixOS/nixpkgs/commit/76fb9da41fce405d87e5384e71855b5fbc06d45c) nixos/openssh: add support for authorized principals
* [`0df54e25`](https://github.com/NixOS/nixpkgs/commit/0df54e255bb40c6d1389b40d58c8b47c91be8e2d) forgejo-actions-runner: 2.4.0 -> 3.0.1
* [`c327d2b7`](https://github.com/NixOS/nixpkgs/commit/c327d2b7ac911fb7ec754bdc5c85c6a215f6b7ce) plasma5Packages.kopeninghours: init
* [`6ef9b308`](https://github.com/NixOS/nixpkgs/commit/6ef9b308ef1d0f9b8dbcd8ea9839945ee33794cf) plasma5Packages.kosmindoormap: init
* [`edd2e49f`](https://github.com/NixOS/nixpkgs/commit/edd2e49f9904e5c377d76bf74351e1d12e5b9016) quarto: added 'x86_64-darwin' 'aarch64-linux' 'aarch64-darwin' to platforms
* [`de570b1b`](https://github.com/NixOS/nixpkgs/commit/de570b1bb77617525ca0d5995e0d0c22dab15dc6) libquotient: propagate required libraries, split dev output, update meta.homepage
* [`423302ae`](https://github.com/NixOS/nixpkgs/commit/423302ae65f499a77a66151b6e2f4c2aebc89162) plasma5Packages.itinerary: init
* [`0722a104`](https://github.com/NixOS/nixpkgs/commit/0722a1041e2d8748fccfcc68c7cc5fbe5b207388) plasma5Packages.neochat: cleanup dependencies that are actually part of libquotient
* [`1931c374`](https://github.com/NixOS/nixpkgs/commit/1931c374de0d1f28b3ce905c61d8dff8194a6e56) maintainers: add npulidomateo
* [`366e5670`](https://github.com/NixOS/nixpkgs/commit/366e56703c4df40017d184ed006ccbb8261f894b) re-flex: 3.3.8 -> 3.4.1
* [`c1e96b94`](https://github.com/NixOS/nixpkgs/commit/c1e96b94e2782d48a49078bf77f291323152ac3f) darktable: fix build on darwin
* [`ce5371f7`](https://github.com/NixOS/nixpkgs/commit/ce5371f719e1a0bdc90a168df456572d0bda60ec) quarto: add even more platforms
* [`c7fc9de1`](https://github.com/NixOS/nixpkgs/commit/c7fc9de18b4a47bc057a3696e21725f1f430fcc7) quarto: fix passthru tests on darwin
* [`4182db56`](https://github.com/NixOS/nixpkgs/commit/4182db564df9c462540c3238697556673588b1c2) quarto: fix postInstall overrides
* [`a14617e7`](https://github.com/NixOS/nixpkgs/commit/a14617e7c0afe34ea8946cb082f6f466a709fe09) rabbitmq-server: 3.12.4 -> 3.12.6
* [`0776733a`](https://github.com/NixOS/nixpkgs/commit/0776733a1dece8ad1085432c0d5f6a5ae9f40091) prisma-engines: 5.2.0 -> 5.4.1
* [`8ddb2998`](https://github.com/NixOS/nixpkgs/commit/8ddb29984515e7e65a44ce4e84c58ab643122477) wallust: refactor derivation
* [`566d7348`](https://github.com/NixOS/nixpkgs/commit/566d7348ee28d4223a15bf8219e7d64b4afd792d) nodePackages.prisma: 5.2.0 -> 5.4.1
* [`d60c85fb`](https://github.com/NixOS/nixpkgs/commit/d60c85fb7588f4445a50bec744d449ede76001f0) blast-bin: add sourceProvenance to meta
* [`0e704957`](https://github.com/NixOS/nixpkgs/commit/0e70495721771ff2f16b2031c1d1f59ce9698f36) python311Packages.help2man: init at 0.0.9
* [`03c857c9`](https://github.com/NixOS/nixpkgs/commit/03c857c9530ee3b4e173844c889ad2ca4b6d9980) python311Packages.setuptools-generate: init at 0.0.6
* [`642bab4c`](https://github.com/NixOS/nixpkgs/commit/642bab4c87672afb1b2d1f64ec31b0b909e146be) libsForQt5.alkimia: 8.1.1 -> 8.1.2
* [`47f4cd99`](https://github.com/NixOS/nixpkgs/commit/47f4cd9933899cbce92867fd0b79b5c2b1d34bc0) vyper: 0.3.9 -> 0.3.10
* [`0ad1a333`](https://github.com/NixOS/nixpkgs/commit/0ad1a333f5d5d6d16ad0963a4422f7d3e0fa2092) nextcloud27: 27.1.1 -> 27.1.2
* [`efc5c80e`](https://github.com/NixOS/nixpkgs/commit/efc5c80e18def8a81f06e1da8bd584f3fa8a5ab8) nextcloud25: remove
* [`bbc7d496`](https://github.com/NixOS/nixpkgs/commit/bbc7d496667ff32b67071d30bf9b9402d29c6e39) nextcloud*Packages: update
* [`bc0c8dd4`](https://github.com/NixOS/nixpkgs/commit/bc0c8dd4a095e38a19e2b2d7af98be60240d6fc3) duplicacy: 3.1.0 -> 3.2.3
* [`4f5548b6`](https://github.com/NixOS/nixpkgs/commit/4f5548b6e0999c0089559300fe08920ff0b0cf9f) ymuse: 0.21 -> 0.22
* [`cca77286`](https://github.com/NixOS/nixpkgs/commit/cca7728632a8be602f43fd45b69026c5ad280ea2) ymuse: add meta.mainProgram and meta.platforms
* [`eac5f9f6`](https://github.com/NixOS/nixpkgs/commit/eac5f9f64639c16e3ce01a8173b33ae921959704) pdns: 4.8.2 -> 4.8.3
* [`4897be85`](https://github.com/NixOS/nixpkgs/commit/4897be85823f5de2a6828554573a131a0e278f7b) acme-sh: 3.0.6 -> 3.0.7
* [`088da23f`](https://github.com/NixOS/nixpkgs/commit/088da23f9ea4ed95da0f7842689774c0ab1837a3) nixos/test-instrumentation: fix unsetting of defaultGateway
* [`c11b788d`](https://github.com/NixOS/nixpkgs/commit/c11b788d1a6a2bed6187602a4cf2f3d1542098e7) nixos/network-interfaces-systemd: support defaultGateway.interface
* [`c3e90f56`](https://github.com/NixOS/nixpkgs/commit/c3e90f566715f717dc77a27f667b3372f40b9590) nixos/network-interfaces-systemd: require defaultGateway.interface
* [`44a67e19`](https://github.com/NixOS/nixpkgs/commit/44a67e1990c9aac25b3df40ddb6ee8015a9988d7) bloat: unstable-2023-09-24 -> unstable-2023-10-02
* [`91ddd9ee`](https://github.com/NixOS/nixpkgs/commit/91ddd9eeba367c8708213af42f6b1250d6164a81) haskellPackages.hledger-iadd: unmark broken
* [`70c8adce`](https://github.com/NixOS/nixpkgs/commit/70c8adce8d3b399d9e6e9b6528d3407588b35db6) kubo: 0.22.0 -> 0.23.0
* [`703a2717`](https://github.com/NixOS/nixpkgs/commit/703a27178bb9bf649b987b050dc8777d8709ea1e) calc: 2.14.3.5 -> 2.15.0.1
* [`3709afba`](https://github.com/NixOS/nixpkgs/commit/3709afba12b54cf30a338d441cff25912a55cb8d) calico-app-policy: 3.26.1 -> 3.26.3
* [`5c518e48`](https://github.com/NixOS/nixpkgs/commit/5c518e484fd2d07138396bcef4a3a5c9c7aa60f3) camunda-modeler: 5.15.1 -> 5.16.0
* [`d290c309`](https://github.com/NixOS/nixpkgs/commit/d290c309f40dff0e8e38f610ea20340cabac488e) nixos/network-interfaces-systemd: fix WakeOnLan
* [`f5f1751b`](https://github.com/NixOS/nixpkgs/commit/f5f1751b1ffcd936fc5964c3075943ee39621cf2) refactor: combine scripted and networkd WakeOnLan config
* [`5d5cc30b`](https://github.com/NixOS/nixpkgs/commit/5d5cc30bf3871706c2163cfbf8d56afe2d7af8cb) cargo-tauri: 1.3.0 -> 1.5.1
* [`d48011b7`](https://github.com/NixOS/nixpkgs/commit/d48011b75d564bd31a082a5924600c67b314c7ea) cargo-lambda: 0.18.1 -> 0.21.1
* [`bd116dc0`](https://github.com/NixOS/nixpkgs/commit/bd116dc04933b8c54937a9f8a1a11d0e2b76c00b) python311Packages.bip-utils: rename from bip_utils
* [`c80caa44`](https://github.com/NixOS/nixpkgs/commit/c80caa4429b894d4e5c54dbaa79930e35bab54c4) lexicon: use toPythonApplication of the python module
* [`cdcd9295`](https://github.com/NixOS/nixpkgs/commit/cdcd9295eb82db87c755f2e4128ee549ced07455) confluent-cli: 3.17.0 -> 3.37.0
* [`2788f1b0`](https://github.com/NixOS/nixpkgs/commit/2788f1b04e86a89e31cfc09aa46521e10378064d) ddccontrol-db: 20230911 -> 20231004
* [`7467afed`](https://github.com/NixOS/nixpkgs/commit/7467afede752a92cc9bb06b5005e82a27d02085e) dolt: 1.15.0 -> 1.18.1
* [`065af392`](https://github.com/NixOS/nixpkgs/commit/065af3929dfc9e977ac56fcf9c1a62e850ea1e0b) python311Packages.types-requests: 2.31.0.7 -> 2.31.0.8
* [`811af9cc`](https://github.com/NixOS/nixpkgs/commit/811af9cc92ef042cdcf9d080d21e765a95cb87fc) xmage: 1.4.42V6 -> 1.4.50V2
* [`e28b34ee`](https://github.com/NixOS/nixpkgs/commit/e28b34eecf0a8161a67498948ebb532327550f28) xmage: Convert to use finalAttrs for recursion
* [`9848d3df`](https://github.com/NixOS/nixpkgs/commit/9848d3dfc551659f0d7a47ab67ea23312b66b0b2) xmage: Format expression
* [`fc21de97`](https://github.com/NixOS/nixpkgs/commit/fc21de97f86744ab101995a664370f188a6f58fa) xmage: Use substring of version instead of hardcoding jar name
* [`e3638150`](https://github.com/NixOS/nixpkgs/commit/e3638150f27cdf6b8fa0cfeb695e7455c5d62fd5) gromacs: split outputs
* [`8ddd0105`](https://github.com/NixOS/nixpkgs/commit/8ddd01056fcf475a8b699f38a5def5eb44f9bd72) pikchr: unstable-2022-12-07 -> unstable-2023-08-30
* [`cd7babfc`](https://github.com/NixOS/nixpkgs/commit/cd7babfc8bd9c45bc336436a097f84ba36c90415) uhd: add passthru.updateScript
* [`4f03332c`](https://github.com/NixOS/nixpkgs/commit/4f03332c703142bfcc3fb4cc7efd6f5f3ecec45e) uhd: 4.4.0.0 -> 4.5.0.0
* [`8ff6850f`](https://github.com/NixOS/nixpkgs/commit/8ff6850f2564d26a91b30eb8f7993a7a2c3bf4bb) jetbrains: drop libstdc++.so.6 from LD_LIBRARY_PATH
* [`7a8b1426`](https://github.com/NixOS/nixpkgs/commit/7a8b142607999eb082a5fb9be5ec75d2cdedc50e) jetbrains: use -Djna.libary.path instead of LD_LIBRARY_PATH
* [`8158b662`](https://github.com/NixOS/nixpkgs/commit/8158b662c3f83b1a88feb86cd0eedda4833bed05) mdcat: 2.0.3 -> 2.0.4
* [`2e20fc3d`](https://github.com/NixOS/nixpkgs/commit/2e20fc3dbbe30e16518b3fb518d64dca023e12df) exodus: 23.5.22 -> 23.9.25
* [`3f936ff2`](https://github.com/NixOS/nixpkgs/commit/3f936ff2f558744da11d5643e34468ac2adbc687) xq-xml: 1.2.1 -> 1.2.2
* [`4b9de450`](https://github.com/NixOS/nixpkgs/commit/4b9de4504471e6d124c1fe56e6361447d0638966) cargo-component: unstable-2023-09-20 -> 0.2.0
* [`5c7a363f`](https://github.com/NixOS/nixpkgs/commit/5c7a363f9ccdcefc111aa5ad57abe478adf16e3f) openmpi: split outputs -> out, man
* [`50de82b1`](https://github.com/NixOS/nixpkgs/commit/50de82b10ead480bb94454bb7b20f0108fbd7212) openmpi: use getDev to get includes
* [`a56afaa1`](https://github.com/NixOS/nixpkgs/commit/a56afaa19e394aec99be2f98453b967c6d35aae2) openmpi: delete all libtool .la files
* [`37b69dd3`](https://github.com/NixOS/nixpkgs/commit/37b69dd34e6ffc5c7b13ac59fba95d8b4c367a03) mpich: split outputs -> out, doc, man
* [`3ba516e7`](https://github.com/NixOS/nixpkgs/commit/3ba516e75bb84cc643bf45c6e81cc8f6f62b5821) mvapich: split outputs -> out, doc, man
* [`ff542d5f`](https://github.com/NixOS/nixpkgs/commit/ff542d5f5360711d0055008c2ca88560e2a8b76e) libfabric: split outputs -> out, dev, man
* [`e5b27235`](https://github.com/NixOS/nixpkgs/commit/e5b27235e0c1ac60f1766e6654f717f2248df343) pmix: use getDev to get includes
* [`47c6341a`](https://github.com/NixOS/nixpkgs/commit/47c6341abbaa6699835f5ae78c1328e8d782eac4) pmix: remove libtool .la files
* [`71b60a7b`](https://github.com/NixOS/nixpkgs/commit/71b60a7bb79b75d9a87e87a57edfecb5b07b1875) ucc: split outputs -> out, dev
* [`a0a2fe7d`](https://github.com/NixOS/nixpkgs/commit/a0a2fe7d60dc14a13e5fa3426fd402517b64ed5e) ucx: split outputs -> out, doc, dev
* [`50ed96e6`](https://github.com/NixOS/nixpkgs/commit/50ed96e65cfb1fcc6f108e27528406d43a7ea75f) flacon: 11.2.0 -> 11.3.0
* [`45b1d202`](https://github.com/NixOS/nixpkgs/commit/45b1d202eff8fad701bba815cdfc30dea79b91f3) rstudio: fix server node patching
* [`fad0bf7d`](https://github.com/NixOS/nixpkgs/commit/fad0bf7d628bc193c1e06a06ebc49e162b6505ef) python3Packages.numpy: bump supported Python range
* [`80a67508`](https://github.com/NixOS/nixpkgs/commit/80a67508e5e50b9c16df9b98f2bbb521cea60351) python310Packages.ocrmypdf: 15.0.2 -> 15.1.0
* [`8c6f525d`](https://github.com/NixOS/nixpkgs/commit/8c6f525d12a2ac58ae5107452691ecaf1d2a0c25) maintainers: add gm6k
* [`bb2c03f0`](https://github.com/NixOS/nixpkgs/commit/bb2c03f0a185b5434923ed9384404588120e23ee) nixos/system-path: remove nano from defaultPackages description
* [`afb15c65`](https://github.com/NixOS/nixpkgs/commit/afb15c65131fe2912e8bc87e3e6c2a6028ae7bb0) nixos/manual: no DocBook for mkPackageOption
* [`169b1f39`](https://github.com/NixOS/nixpkgs/commit/169b1f39be29d4db38c875f74b936694c2d2112a) jfrog-cli: 2.48.0 -> 2.50.0
* [`cce0936c`](https://github.com/NixOS/nixpkgs/commit/cce0936ce6e594397a90467b05a61f05219a124e) jqp: 0.4.0 -> 0.5.0
* [`bc8d69cd`](https://github.com/NixOS/nixpkgs/commit/bc8d69cda8c19bd480415f170d5d078a7e4664bd) timoni: 0.14.1 -> 0.14.2
* [`21411716`](https://github.com/NixOS/nixpkgs/commit/21411716361eecbe408597578e33b9e02767be36) k3s_1_26: 1.26.6+k3s1 -> 1.26.9+k3s1
* [`fc75fe94`](https://github.com/NixOS/nixpkgs/commit/fc75fe94a92214cdb1101e699758aa612d9c658f) kestrel: 0.10.1 -> 0.11.0
* [`6af2ce35`](https://github.com/NixOS/nixpkgs/commit/6af2ce359094a2d89557261da7332737cc31c6f5) aether: remove (unmaintained upstream, sec issues)
* [`e69b1ce1`](https://github.com/NixOS/nixpkgs/commit/e69b1ce1b734e7e2739132917f04b25f6a6d8824) kubedb-cli: 0.35.0 -> 0.35.1
* [`8702ae01`](https://github.com/NixOS/nixpkgs/commit/8702ae01109216bddb9b05e3dae2fe6fb15ce117) nixos/nextcloud: drop enableBrokenCiphersForSSE
* [`ad57ad1f`](https://github.com/NixOS/nixpkgs/commit/ad57ad1ff5de0ce095d9627ce5ce70c318dd3881) nixos/nextcloud: update / clean up the nginx configuration
* [`9190214e`](https://github.com/NixOS/nixpkgs/commit/9190214efa57750bd8c3d508dc476ae12a32bd05) lesspipe: 2.08 -> 2.10
* [`de4782d1`](https://github.com/NixOS/nixpkgs/commit/de4782d134eb53f8187a3e5223d4d0fb5438c447) levant: 0.3.2 -> 0.3.3
* [`c297d40a`](https://github.com/NixOS/nixpkgs/commit/c297d40ad375ba17f10cf09346e711fd7f06d7f5) dune_3: 3.11.0 -> 3.11.1
* [`b6c652be`](https://github.com/NixOS/nixpkgs/commit/b6c652be5ccc27941351a809f03d841c1a9845ac) alfaview: 9.0.3 -> 9.2.0
* [`116ab287`](https://github.com/NixOS/nixpkgs/commit/116ab287c59d9861ecc1404488bff0219cba6d69) maintainers/fix-maintainers.pl: handle null github handles
* [`b6231435`](https://github.com/NixOS/nixpkgs/commit/b623143563badceb3fe59056f26bbab21de97783) maintainers/fix-maintainers.pl: error on unset GH_TOKEN
* [`2e722bdf`](https://github.com/NixOS/nixpkgs/commit/2e722bdfdbe6cef13d88f9c466f84be4122f0d13) maintainers: Fix github account names
* [`bcdfa188`](https://github.com/NixOS/nixpkgs/commit/bcdfa1884623c42ed83fe541e5a60b8ee652692c) jetbrains.rider: use autoPatchelf
* [`a6df5a77`](https://github.com/NixOS/nixpkgs/commit/a6df5a7719db86e88a5a141f016a25f8b9e043b9) prefetch-npm-deps: bump deps
* [`391a1245`](https://github.com/NixOS/nixpkgs/commit/391a1245b6d9b04abb8c42d9145593a15e4e2d56) nextcloud: stdenv -> stdenvNoCC
* [`5987f095`](https://github.com/NixOS/nixpkgs/commit/5987f095ef0ce9f6860569e31e768a29cc757fe1) furnace: Change updateScript
* [`691be085`](https://github.com/NixOS/nixpkgs/commit/691be085f9f99e60583c6e23046aa587df7d135c) butane: 0.18.0 -> 0.19.0
* [`7ca3be6b`](https://github.com/NixOS/nixpkgs/commit/7ca3be6b355c425a60d78603cb5f04896026605c) oha: 0.6.4 -> 0.6.5
* [`6be96dba`](https://github.com/NixOS/nixpkgs/commit/6be96dba0c5fc5f4cd29b1d163ace1f29103cc6e) dcgm: 3.1.8 -> 3.2.5
* [`4f381c3a`](https://github.com/NixOS/nixpkgs/commit/4f381c3af17565bd11842d5df51692f1249e7d55) dcgm: remove unused arguments
* [`a7b7ef9f`](https://github.com/NixOS/nixpkgs/commit/a7b7ef9feac1d0b02c01827df408184df84dcb9b) dcgm: add note about keeping dcgm and prometheus-dcgm-exporter in sync
* [`822bafc1`](https://github.com/NixOS/nixpkgs/commit/822bafc10ca25ab97ee1c73b20927cbf8366bad5) firefly-desktop: 2.1.5 -> 2.1.8
* [`c75ee6e3`](https://github.com/NixOS/nixpkgs/commit/c75ee6e356189b1490a1fa4e3a06ccb7d0446b8e) freeipa: 4.10.2 -> 4.11.0
* [`0dbe22d8`](https://github.com/NixOS/nixpkgs/commit/0dbe22d8cf53e5ecf806cf8fc951331bf76437bf) pot: 2.4.2 -> 2.6.2
* [`2ac93ee2`](https://github.com/NixOS/nixpkgs/commit/2ac93ee21b6b1edfd156ffc181839ee366a6021a) radarr: 4.7.5.7809 -> 5.0.3.8127
* [`a4e79d75`](https://github.com/NixOS/nixpkgs/commit/a4e79d756a056a608d498a030f81084b0a0f00c2) valeronoi: 0.1.9 -> 0.2.0
* [`cf8aa486`](https://github.com/NixOS/nixpkgs/commit/cf8aa48605d68997be93f69ce853d76449ff68cc) nixos/tests/kubo: various improvements
* [`5968bc1a`](https://github.com/NixOS/nixpkgs/commit/5968bc1abe84a6460121e7ab51e9b644f4cd3e15) gnome.evince: Fix cross
* [`5e246d96`](https://github.com/NixOS/nixpkgs/commit/5e246d96c4a05dfaf36b51f2be4f22f0385df97b) python311Packages.google-cloud-dataproc: 5.5.1 -> 5.6.0
* [`4539770a`](https://github.com/NixOS/nixpkgs/commit/4539770a466c35a2b3ce9db3bf3c674d2eb632fe) uptime-kuma: 1.23.2 -> 1.23.3
* [`56ea9649`](https://github.com/NixOS/nixpkgs/commit/56ea96492174381e9fb46b0b3ece759093a78bc9) karmor: 0.13.16 -> 0.14
* [`3b6389aa`](https://github.com/NixOS/nixpkgs/commit/3b6389aa2f49e87846760c8220387a2f4d27279f) nixos/release: don't block on firefox tests
* [`71c4ac9a`](https://github.com/NixOS/nixpkgs/commit/71c4ac9a8252dae795925c491e89389a34054264) calibre: 6.26.0 -> 6.28.1
* [`93569e8c`](https://github.com/NixOS/nixpkgs/commit/93569e8c5cd9355ed9dba7259c94a123e49f7c74) ronin: 2.0.4 -> 2.0.5
* [`d7e3b25d`](https://github.com/NixOS/nixpkgs/commit/d7e3b25dea27131def18db3b65930ec760e3c9a4) sonic-server: 1.4.0 -> 1.4.3
* [`37dfe014`](https://github.com/NixOS/nixpkgs/commit/37dfe0147f05f086d75eb40c09b02f51037f1868) sonic-server: add passthru.tests and passthru.updateScript
* [`c66b09f7`](https://github.com/NixOS/nixpkgs/commit/c66b09f77da62f5fe1dbbecdc4b1e230cc2d1de6) sonic-server: add anthonyroussel to maintainers
* [`be2d3622`](https://github.com/NixOS/nixpkgs/commit/be2d3622bbe95ef9de2425dd4b03be633cf678c6) kronosnet: 1.26 -> 1.28
* [`eef69c2e`](https://github.com/NixOS/nixpkgs/commit/eef69c2ee4d2deb7534b1c341c5e71c3102274f4) viceroy: 0.8.1 -> 0.9.1
* [`6a4034bb`](https://github.com/NixOS/nixpkgs/commit/6a4034bb9d93704f47df2d058746ce8c0ffa227e) frp: 0.51.3 -> 0.52.0
* [`7db98366`](https://github.com/NixOS/nixpkgs/commit/7db983665469498c44803020b521cf6b0bc6e506) wordpress6_1, wordpress6_2: drop
* [`917f9137`](https://github.com/NixOS/nixpkgs/commit/917f9137a7a6b4ab2926cd0188dad47f2fbee850) ferdium: add aarch64-linux
* [`df7dd3a9`](https://github.com/NixOS/nixpkgs/commit/df7dd3a91303b450ecc5cdfa51c3e1ec0485a67d) peazip: 9.9.0 → 9.4.0
* [`2f3a446c`](https://github.com/NixOS/nixpkgs/commit/2f3a446c5bbd45c0a97570f3306b1425ee8ea30f) php83: 8.3.0RC3 -> 8.3.0RC4
* [`71f562e0`](https://github.com/NixOS/nixpkgs/commit/71f562e0e85f1b3711f9a93aacd0f133fcba7978) infisical: 0.3.7 -> 0.14.2
* [`e6a97099`](https://github.com/NixOS/nixpkgs/commit/e6a97099d7f1bb69d5e32eeddfe61d2943cf6d9f) oxipng: 8.0.0 -> 9.0.0
* [`554e2412`](https://github.com/NixOS/nixpkgs/commit/554e2412e0b4a89f527786e67d568d9cf3842d80) prefetch-npm-deps: read url bodies within the retry loop
* [`0581acee`](https://github.com/NixOS/nixpkgs/commit/0581acee636c78731e7fa850613837feab991238) k0sctl: 0.15.5 -> 0.16.0
* [`3e876134`](https://github.com/NixOS/nixpkgs/commit/3e8761344600b19cf896787bb85ab2e2863c805d) github-runner: 2.309.0 -> 2.310.2
* [`2b367ecd`](https://github.com/NixOS/nixpkgs/commit/2b367ecd33cf77fa06b1c6cfa00cc675707c229a) lilypond-unstable: 2.25.8 -> 2.25.9
* [`329f4f7b`](https://github.com/NixOS/nixpkgs/commit/329f4f7bd9cd9b65d7e0416f9a71150d98e5a0d4) lobster: 2023.12 -> 2023.13
* [`37bf4c4d`](https://github.com/NixOS/nixpkgs/commit/37bf4c4dc8c2ff46aea515e29b1f07ccb5803477) python311Packages.zope-contenttype: rename from zope_contenttype
* [`c3cf8c3f`](https://github.com/NixOS/nixpkgs/commit/c3cf8c3f92a4e822500bdaa6caf109132450d05a) python311Packages.zope-contenttype: refactor
* [`678b644b`](https://github.com/NixOS/nixpkgs/commit/678b644bdc95ae84add9628e5e0fb1d9968310ea) python311Packages.zope-contenttype: 4.6 -> 5.1
* [`f4ef25cd`](https://github.com/NixOS/nixpkgs/commit/f4ef25cd61022c39f081b72b53a84c0279f9f5d4) lxgw-wenkai: 1.300 -> 1.311
* [`2a28e230`](https://github.com/NixOS/nixpkgs/commit/2a28e230babb2c3ff64059bc683a17829bb2656c) matrix-synapse-unwrapped: 1.93.0 -> 1.94.0
* [`c24956a9`](https://github.com/NixOS/nixpkgs/commit/c24956a978a6bffee1a47c7f2abecc46a155a3fc) pdfstudio2023: init at 2023.0.3
* [`e7470b17`](https://github.com/NixOS/nixpkgs/commit/e7470b17613d6cca44965e2df1420c390aa593de) mackerel-agent: 0.77.1 -> 0.78.0
* [`22db1d7c`](https://github.com/NixOS/nixpkgs/commit/22db1d7cad1832a9d7781a5631dba02bcae2e4ed) sfwbar: 1.0_beta11 -> 1.0_beta13
* [`3876a545`](https://github.com/NixOS/nixpkgs/commit/3876a545ed6eb9d7e0ef0b1940269971476528f7) makeInitrdNGTool: 0.1.0 -> 0.1.0
* [`6a927f93`](https://github.com/NixOS/nixpkgs/commit/6a927f93f1d9b1e35af775c09f24ca2f026040ae) marvin: 23.4.0 -> 23.12.0
* [`1a44a1cc`](https://github.com/NixOS/nixpkgs/commit/1a44a1ccd501c865e28dfbbdf03a5d20ad48cdcc) python311Packages.pysmartdl: rename from pySmartDL
* [`ba4578ec`](https://github.com/NixOS/nixpkgs/commit/ba4578ecd4bd73ae746b53feff3d03c042ef7c01) python311Packages.pysmartdl: refactor
* [`447f9d61`](https://github.com/NixOS/nixpkgs/commit/447f9d611da6a6ee5a54c75033684591bf25e101) maven: 3.9.4 -> 3.9.5
* [`37c77680`](https://github.com/NixOS/nixpkgs/commit/37c7768047edc6c6f5acb0bbe513d2ce31da2aa8) zfsUnstable: 2.2.0-rc4 -> 2.2.0-rc5
* [`91f528a7`](https://github.com/NixOS/nixpkgs/commit/91f528a7ecaebbefbd933cc97d56a288e8a6f50a) mediainfo: 23.07 -> 23.10
* [`d9a975bd`](https://github.com/NixOS/nixpkgs/commit/d9a975bdd70d2c85dc8d5d44ca7ca9c9324d1888) postgresqlPackages.pgvector: 0.5.0 -> 0.5.1
* [`b35d3bbe`](https://github.com/NixOS/nixpkgs/commit/b35d3bbe76df5d223a41b7ff9def788e5409e879) sops: 3.8.0 -> 3.8.1
* [`dc6ea0a4`](https://github.com/NixOS/nixpkgs/commit/dc6ea0a4f702aad1eb29a84231ec6026db3c1f9b) bazel-watcher: unpin go
* [`2d4aaaf7`](https://github.com/NixOS/nixpkgs/commit/2d4aaaf76bcfd80b64e1cf04183de6b67c31cb78) python311Packages.supervise-api: rename from supervise_api
* [`3f232237`](https://github.com/NixOS/nixpkgs/commit/3f232237fd7b45ec09a1dcc5dea8899a1b116bdb) python311Packages.supervise-api: refactor
* [`d5497ec3`](https://github.com/NixOS/nixpkgs/commit/d5497ec3b2698ed54367bd8159bf8712ab1c9d46) python310Packages.chex: 0.1.82 -> 0.1.83
* [`cb7fb86c`](https://github.com/NixOS/nixpkgs/commit/cb7fb86ce338c38ed3428034bdfcaebcc939b622) python310Packages.jaxopt: 0.5.5 -> 0.8.1
* [`ca65b160`](https://github.com/NixOS/nixpkgs/commit/ca65b160d23e62ec8f4b92088c8cab13bb3300da) micronaut: 4.1.1 -> 4.1.3
* [`be596a5a`](https://github.com/NixOS/nixpkgs/commit/be596a5aab0c485cf56da9956a72e305abe3e954) beeper: add update script
* [`69ad83d8`](https://github.com/NixOS/nixpkgs/commit/69ad83d8d6e7fd7cc546f15a1a5442b9a9f765ff) python311Packages.aioambient: 2023.08.0 -> 2023.10.1
* [`3a6c79cf`](https://github.com/NixOS/nixpkgs/commit/3a6c79cff6aa6f4c29af04b544ab367561f11346) nixos/x11: refactor XKB options into a single attrset
* [`1c07b382`](https://github.com/NixOS/nixpkgs/commit/1c07b3820682cb94fa05f68acdcd4bfa7e0f27d4) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.16.0 -> 0.17.0
* [`96f0cea1`](https://github.com/NixOS/nixpkgs/commit/96f0cea13421efa43f495b9c6374e3d58bd02d18) mmc-utils: unstable-2023-08-07 -> unstable-2023-10-10
* [`6cd6e42f`](https://github.com/NixOS/nixpkgs/commit/6cd6e42f1c9a5c24604abb086ec7f61aac4f509e) mockoon: 4.1.0 -> 5.0.0
* [`b1919587`](https://github.com/NixOS/nixpkgs/commit/b1919587180629929178e4156a0a780da17b034e) python311Packages.pyoutbreaksnearme: 2023.08.0 -> 2023.10.0
* [`a3b2f393`](https://github.com/NixOS/nixpkgs/commit/a3b2f393492fd07b71a504efd251a5690be7e062) python311Packages.pytile: 2023.08.0 -> 2023.10.0
* [`7f560763`](https://github.com/NixOS/nixpkgs/commit/7f560763b071f7add467b18825191f67cb29186d) monetdb: 11.47.5 -> 11.47.11
* [`3a751ede`](https://github.com/NixOS/nixpkgs/commit/3a751ede80117a9a6a440743d91d72bbac2edd87) mongocxx: 3.8.0 -> 3.8.1
* [`fe0c9571`](https://github.com/NixOS/nixpkgs/commit/fe0c95718c4e2b1d5607c385f8f4f32a70d99afb) monkeysAudio: 10.22 -> 10.24
* [`16b86be7`](https://github.com/NixOS/nixpkgs/commit/16b86be7d063409a5025cf96e5fa5e65d05f2719) python311Packages.google-cloud-dataproc: update changelog entry
* [`c0cb89a9`](https://github.com/NixOS/nixpkgs/commit/c0cb89a92198f4e184d8d098923fe9e30d4bc5dd) moon: 1.14.3 -> 1.15.0
* [`6b989a01`](https://github.com/NixOS/nixpkgs/commit/6b989a018268833aa10d3802e4929f77a982bde9) minetest-mapserver: init at 4.7.0
* [`0a31bb45`](https://github.com/NixOS/nixpkgs/commit/0a31bb4564dc6cf702abab10cafb49dd10701273) mullvad-vpn: 2023.4 -> 2023.5
* [`11b8ce5a`](https://github.com/NixOS/nixpkgs/commit/11b8ce5aa7cb46f940ca3ef8f1a215dea0efba1b) mympd: 12.0.2 -> 12.0.4
* [`438a71d4`](https://github.com/NixOS/nixpkgs/commit/438a71d461d167fedce8b4e9d6e68640ef339c71) nali: 0.7.3 -> 0.8.0
* [`9aa79c23`](https://github.com/NixOS/nixpkgs/commit/9aa79c238c66c8fffc4f5b2dfa2bdc65221622dc) advancecomp: 2.5 -> 2.6
* [`f66ff331`](https://github.com/NixOS/nixpkgs/commit/f66ff3317e80761c7da045a872305a6f785958c4) aliyun-cli: 3.0.181 -> 3.0.182
* [`f280b9c8`](https://github.com/NixOS/nixpkgs/commit/f280b9c8c12bd08a514f4594c2d6227e5abdcdcc) aliyun-cli: 3.0.182 -> 3.0.183
* [`0391a8b0`](https://github.com/NixOS/nixpkgs/commit/0391a8b0489973bc49a32cb4d3641667dedcf78a) rocmPackages.rpp: init at 5.7.0
* [`0b1d5a58`](https://github.com/NixOS/nixpkgs/commit/0b1d5a58e7348c05f29397cab05653c8d0294dc8) sabctools: 7.0.2 -> 7.1.2
* [`cb719dfa`](https://github.com/NixOS/nixpkgs/commit/cb719dfa72f36546313e80355cbf0516091abef1) nixos/tests/sabnzbd: add check for sabctools mismatch
* [`e7179c0a`](https://github.com/NixOS/nixpkgs/commit/e7179c0addee988ee626a6dfb856e52705a59be0) eccodes: 2.30.2 -> 2.32.0
* [`b14e89fd`](https://github.com/NixOS/nixpkgs/commit/b14e89fd73aa9616bbf6688883d3fc06e08bf40b) go-md2man: 2.0.2 -> 2.0.3
* [`9012f082`](https://github.com/NixOS/nixpkgs/commit/9012f082275ef70d0cce38cf87dd44ac5a275161) goodvibes: 0.7.6 -> 0.7.7
* [`7279e845`](https://github.com/NixOS/nixpkgs/commit/7279e8455f597933bbe6f8ebcfd7f231837e721c) ipinfo: 3.0.1 -> 3.1.2
* [`0af5408b`](https://github.com/NixOS/nixpkgs/commit/0af5408bb9eda32d6d132c56a01fb77f32a89e54) exploitdb: 2023-10-03 -> 2023-10-10
* [`9b2b056b`](https://github.com/NixOS/nixpkgs/commit/9b2b056b2794f5eafb6a29358bcff968c573ec1b) neocmakelsp: 0.6.5 -> 0.6.8
* [`56f01487`](https://github.com/NixOS/nixpkgs/commit/56f014878645fa0d46d4d7f32f94a3dcf824c36e) guile-lzlib: init at 0.0.2
* [`30ea1447`](https://github.com/NixOS/nixpkgs/commit/30ea14476a73f1383d3e612b3a312e5ab81520f6) netatalk: 3.1.15 -> 3.1.18
* [`8cd00fbe`](https://github.com/NixOS/nixpkgs/commit/8cd00fbe8a22fdeb157db863b97f5aea33a3d1d4) python311Packages.succulent: 0.2.3 -> 0.2.5
* [`dbc7104d`](https://github.com/NixOS/nixpkgs/commit/dbc7104de858c2b4be7d904c37a0c751ea1a798b) python311Packages.ihm: init at 0.41
* [`48201274`](https://github.com/NixOS/nixpkgs/commit/48201274b944caab6e3309486aa0f0548780180d) python311Packages.modelcif: init at 0.9
* [`20aad7f6`](https://github.com/NixOS/nixpkgs/commit/20aad7f6f9fe9575d7f1317d2757df319514b9e7) sing-box: 1.5.2 -> 1.5.3
* [`8426727e`](https://github.com/NixOS/nixpkgs/commit/8426727ec1278e119757a6e56e029d06ea07ab9f) appflowy: 0.3.2 -> 0.3.5
* [`c4c8c933`](https://github.com/NixOS/nixpkgs/commit/c4c8c9333cbfc004fe53e2601fe2343d4a4c0397) networkmanagerapplet: 1.32.0 -> 1.34.0
* [`fd1dc8a0`](https://github.com/NixOS/nixpkgs/commit/fd1dc8a0aab08dcb0acd8369265a805eafd85a50) nextdns: 1.40.1 -> 1.41.0
* [`817e2ca4`](https://github.com/NixOS/nixpkgs/commit/817e2ca434fa611d80172ce6ef80dbf332574e18) gnomeExtensions: Update for GNOME 45
* [`de8aa064`](https://github.com/NixOS/nixpkgs/commit/de8aa0640b5a90d2726403ce612ac5bc6c3e7992) python311Packages.pdbfixer: init at 1.9
* [`39ae78ab`](https://github.com/NixOS/nixpkgs/commit/39ae78abfdd597b6ddc82a897ac34ada2f1960b2) leptosfmt: 0.1.16 -> 0.1.17
* [`cf08ebd4`](https://github.com/NixOS/nixpkgs/commit/cf08ebd4e2c65d9a7c12d7c640306d2be462953f) erg: 0.6.21 -> 0.6.22
* [`834cf55c`](https://github.com/NixOS/nixpkgs/commit/834cf55cb84bba24bcda0ff3b147b9fc9e7aef4b) logseq: 0.9.18 -> 0.9.19
* [`8620e988`](https://github.com/NixOS/nixpkgs/commit/8620e988be7824273966a5e5dbf8eb38b92746c9) nmap-formatter: 2.1.2 -> 2.1.3
* [`c49efca7`](https://github.com/NixOS/nixpkgs/commit/c49efca702c8862cbb09b7f5eda02b2ed119b29f) nmrpflash: 0.9.20 -> 0.9.21
* [`fe46175b`](https://github.com/NixOS/nixpkgs/commit/fe46175bf29afc9d2ddf634281315fafc7dcb0f4) livebook: 0.10.0 -> 0.11.1
* [`fbda5a48`](https://github.com/NixOS/nixpkgs/commit/fbda5a48a7d422787731a4d4e0d1838869cf22ca) beeper: 3.71.16 -> 3.80.17
* [`8edda565`](https://github.com/NixOS/nixpkgs/commit/8edda56591bdfa7a30dfb7c6035b19f754e69169) consul-template: 0.33.0 -> 0.34.0
* [`a4054b49`](https://github.com/NixOS/nixpkgs/commit/a4054b491662855cf2a60a4bb18e70a68674dbef) sketchybar: 2.16.3 -> 2.17.0
* [`ac93f91a`](https://github.com/NixOS/nixpkgs/commit/ac93f91afed15548a4864378bdf30c4926140278) dolibarr: 18.0.1 -> 18.0.2
* [`94688709`](https://github.com/NixOS/nixpkgs/commit/94688709d9c1a25e98d6c87589117ec8c5109a00) granted: 0.17.1 -> 0.18.0
* [`a7977d39`](https://github.com/NixOS/nixpkgs/commit/a7977d393abddc04b2b2bcdf22d32e31000e3117) gvm-libs: 22.7.1 -> 22.7.2
* [`917f65f4`](https://github.com/NixOS/nixpkgs/commit/917f65f42ccae70589a0fe2e2750a7971dab8165) hubble: 0.12.0 -> 0.12.1
* [`f436b0ca`](https://github.com/NixOS/nixpkgs/commit/f436b0ca58779812dd16e9b3b840e30803688e79) lazydocker: 0.21.1 -> 0.23.0
* [`a3a74c2e`](https://github.com/NixOS/nixpkgs/commit/a3a74c2e8e4f515027eb6ae45eba087f9eb89a38) team-list.nix: add ocaml
* [`ccd7abe1`](https://github.com/NixOS/nixpkgs/commit/ccd7abe1baa9784eb06fc1c129c869e20105b49b) multimon-ng: 1.2.0 -> 1.3.0
* [`5713d5d5`](https://github.com/NixOS/nixpkgs/commit/5713d5d50e96db6fcc48b4bef3137ff80d1b54cf) martin: 0.9.0 -> 0.9.1
* [`85d301d8`](https://github.com/NixOS/nixpkgs/commit/85d301d8191c752b73c8977fca663684c906ab19) naabu: 2.1.8 -> 2.1.9
* [`e61cd68e`](https://github.com/NixOS/nixpkgs/commit/e61cd68e63d0802aa4aee58d6d15cfabf9477ffc) python311Packages.aliyun-python-sdk-sts: 3.1.1 -> 3.1.2
* [`b05ca81c`](https://github.com/NixOS/nixpkgs/commit/b05ca81c95e77748d554df3ba57cc9506b3a8f83) checkov: 2.5.6 -> 2.5.7
* [`a79ee4c2`](https://github.com/NixOS/nixpkgs/commit/a79ee4c26667fab94fa7d5ec977c9ea8951a7615) cargo-expand: 1.0.72 -> 1.0.73
* [`add36476`](https://github.com/NixOS/nixpkgs/commit/add36476f813de9c2a31c3512ae619a5d681749f) n98-magerun2: 7.1.0 -> 7.2.0
* [`d2445647`](https://github.com/NixOS/nixpkgs/commit/d2445647c6c45152dc70ad3530a36d0a893212b5) smbmap: 1.9.1 -> 1.9.2
* [`3a9934ff`](https://github.com/NixOS/nixpkgs/commit/3a9934ffec66e03c5a2cf17a7a52438dedddcfd8) python311Packages.zha-quirks: 0.0.104 -> 0.0.105
* [`ad9a6a40`](https://github.com/NixOS/nixpkgs/commit/ad9a6a40214d42930e86aab69aaff28ed2444a6a) python311Packages.sentry-sdk: 1.31.0 -> 1.32.0
* [`cf2c289c`](https://github.com/NixOS/nixpkgs/commit/cf2c289cbd5552c964a9817ff670e7d1219dc1ce) supersonic: add darwin support
* [`ab4c8ebf`](https://github.com/NixOS/nixpkgs/commit/ab4c8ebfcd0c0ca33e008cab35228795180312aa) python310Packages.blackjax: 0.9.6 -> 1.0.0
* [`c99a99ce`](https://github.com/NixOS/nixpkgs/commit/c99a99ceaefcbcf4e2ddb767925c77d43e06db92) python310Packages.bambi: 0.10.0 -> 0.12.0
* [`f548f734`](https://github.com/NixOS/nixpkgs/commit/f548f73410377233701caef391265c117685d110) photoprism: 230719-73fa7bbe8 -> 231011-63f708417
* [`1c52f7e6`](https://github.com/NixOS/nixpkgs/commit/1c52f7e6f12d719dcb7d1db9f9b5f386617ad882) python311Packages.aioqsw: 0.3.4 -> 0.3.5
* [`4bd5c723`](https://github.com/NixOS/nixpkgs/commit/4bd5c723ae2028963b51ed6962c4a8696dd22e33) python311Packages.archinfo: 9.2.71 -> 9.2.72
* [`3cc504d1`](https://github.com/NixOS/nixpkgs/commit/3cc504d1058017a2bbda953ab1589b84b909f1c1) python311Packages.ailment: 9.2.71 -> 9.2.72
* [`00945ffc`](https://github.com/NixOS/nixpkgs/commit/00945ffc90380cdbdd41f191ea9b39fd63067e44) python311Packages.pyvex: 9.2.71 -> 9.2.72
* [`3e15ff15`](https://github.com/NixOS/nixpkgs/commit/3e15ff15ccba4f58efb98d46698254f1adacbf10) python311Packages.claripy: 9.2.71 -> 9.2.72
* [`1c795b4d`](https://github.com/NixOS/nixpkgs/commit/1c795b4d26e40851dbd0a9f579b6adc2191d5171) python311Packages.angr: 9.2.71 -> 9.2.72
* [`2140b05e`](https://github.com/NixOS/nixpkgs/commit/2140b05e6758c629e8d81a36945ee7e52894c514) python311Packages.cle: 9.2.71 -> 9.2.72
* [`1f9626c9`](https://github.com/NixOS/nixpkgs/commit/1f9626c9da3dfe50e10e1c960c19864f390758f5) python311Packages.meshtastic: 2.2.9 -> 2.2.10
* [`6256a6d1`](https://github.com/NixOS/nixpkgs/commit/6256a6d1f04e0f2d1e112db58c8fdbd45f23b92d) python311Packages.in-n-out: 0.1.8 -> 0.1.9
* [`01cada7d`](https://github.com/NixOS/nixpkgs/commit/01cada7dc60efe33481f22dbe58762cc7fcc3384) rocmPackages.clr: Add OpenCL test
* [`386b2f2b`](https://github.com/NixOS/nixpkgs/commit/386b2f2ba60e109e7891ad080d9f816c7bc8efb2) brave: 1.58.137 -> 1.59.117
* [`a3e50a05`](https://github.com/NixOS/nixpkgs/commit/a3e50a05caabca9d6604dbb24d4006b77ca7e5aa) numix-icon-theme-circle: 23.09.11 -> 23.10.09
* [`2a81c6ed`](https://github.com/NixOS/nixpkgs/commit/2a81c6edbb0b0364f731fd0b2f3318cb5ba8da12) linuxPackages.nvidia_x11_vulkan_beta: 535.43.11 -> 535.43.13
* [`0a102793`](https://github.com/NixOS/nixpkgs/commit/0a10279342995a40fc4ad08a7f2a8250cc5ef4d7) lib.makeOverridable: fix functionArgs on returned function
* [`df8d91eb`](https://github.com/NixOS/nixpkgs/commit/df8d91eb3a96331358c2e552318e8fc5ba6cca46) numix-icon-theme-square: 23.09.11 -> 23.10.09
* [`8d584acc`](https://github.com/NixOS/nixpkgs/commit/8d584acc7ee85b0fa0e588d27c757b0e74a40293) guile: enable crypt on linux
* [`2749ff48`](https://github.com/NixOS/nixpkgs/commit/2749ff487daf5d67c49e8ca54d122e67a27c6c4b) mdcat: fix build on darwin
* [`d9cfb580`](https://github.com/NixOS/nixpkgs/commit/d9cfb5809451c835e7113489ff5751e57646b76f) oauth2c: 1.11.0 -> 1.12.0
* [`ad1f5709`](https://github.com/NixOS/nixpkgs/commit/ad1f57095f775995a53335523e24348d1184f836) searx: drop
* [`e793d184`](https://github.com/NixOS/nixpkgs/commit/e793d18455b876f8273e94f8de602966f6fd9c5a) nixos/searx: little makeover
* [`f156d0e6`](https://github.com/NixOS/nixpkgs/commit/f156d0e629b6f09837db29031abe69748c3eb039) electron_22-bin: 22.3.26 -> 22.3.27
* [`e23ca4bb`](https://github.com/NixOS/nixpkgs/commit/e23ca4bb96b255dcbec55cfd5156098c7ac61cdd) obs-studio-plugins.obs-move-transition: 2.9.4 -> 2.9.5
* [`e4435f8b`](https://github.com/NixOS/nixpkgs/commit/e4435f8b15c8f286e08defa07d44af7fa2c1a0ca) obs-studio-plugins.obs-vkcapture: 1.4.3 -> 1.4.4
* [`dcea2468`](https://github.com/NixOS/nixpkgs/commit/dcea24685754c1d2c1bdcb362a10880552cd56c2) linuxKernel.kernels.linux_lqx: 6.5.6-lqx1 -> 6.5.7-lqx1
* [`b4049114`](https://github.com/NixOS/nixpkgs/commit/b4049114ff20a7612f2bab4a9b01e162a8494bb8) flatpak: Fix fix-test-paths.patch
* [`b17560a4`](https://github.com/NixOS/nixpkgs/commit/b17560a4c18d623511047c2a65d05a85b5b3cf5d) caddy: 2.7.4 -> 2.7.5
* [`1a510fdf`](https://github.com/NixOS/nixpkgs/commit/1a510fdf52b30be0d4521104fa227871917160f3) ocamlPackages.mirage-crypto: 0.11.1 -> 0.11.2
* [`c98692db`](https://github.com/NixOS/nixpkgs/commit/c98692db99026fd809831d83ec43e34a83b8620a) mupdf_1_17: move to mupdf/1.17
* [`494167d4`](https://github.com/NixOS/nixpkgs/commit/494167d4581bf17ac486a4f2a97bbff637994155) caprine-bin: 2.58.3 -> 2.59.1
* [`21d520fb`](https://github.com/NixOS/nixpkgs/commit/21d520fbf202e84c80e32afc6b1377974335e4e4) tests.nixpkgs-check-by-name: Minor Nix refactor
* [`6710bc25`](https://github.com/NixOS/nixpkgs/commit/6710bc250a090c01da8659787e96aaea3df9ad32) tests.nixpkgs-check-by-name: Minor refactor
* [`26cec0db`](https://github.com/NixOS/nixpkgs/commit/26cec0dbe31c11fc8ccbf2fa32d503212a217916) tests.nixpkgs-check-by-name: Add custom argument test
* [`f394f738`](https://github.com/NixOS/nixpkgs/commit/f394f738faaee2a749eae7c507dccb1830dd440a) tests.nixpkgs-check-by-name: Improve an error message
* [`fcaa408d`](https://github.com/NixOS/nixpkgs/commit/fcaa408d005743b34aed8b7e2992ef885b4ce027) tests.nixpkgs-check-by-name: auto-calling differentiation
* [`23541bed`](https://github.com/NixOS/nixpkgs/commit/23541bed72c8385acddfc8e7ba0bd15d5a2c26af) tests.nixpkgs-check-by-name: Introduce --version
* [`d3bf6133`](https://github.com/NixOS/nixpkgs/commit/d3bf6133e826a6901c50d8524cb3fbbce038df28) tests.nixpkgs-check-by-name: Disallow empty all-packages.nix overrides
* [`84b616cc`](https://github.com/NixOS/nixpkgs/commit/84b616cc994d6c327a0425104af43126388018b6) python311Packages.bip-utils: enable tests
* [`2fa39d48`](https://github.com/NixOS/nixpkgs/commit/2fa39d48f5b9d02fc661edd0ff675cbd40e9b1ec) python311Packages.bip-utils: 2.7.0 -> 2.7.1
* [`b28b483a`](https://github.com/NixOS/nixpkgs/commit/b28b483ad362a1fa4d3519d425e6f6724220f44e) nickel: migrate to by-name
* [`8ebbe81b`](https://github.com/NixOS/nixpkgs/commit/8ebbe81b1738955a4c9f534952babddf653ba070) nls: migrate to by-name
* [`249fef3d`](https://github.com/NixOS/nixpkgs/commit/249fef3d848e45037eaf9fb2f3e8a8ef8652bfde) nls: delete Cargo.lock
* [`0ed137f6`](https://github.com/NixOS/nixpkgs/commit/0ed137f66508a44d8ce39aee8a7688399b481c3b) octavePackages.communications: 1.2.4 -> 1.2.6
* [`01deb5f0`](https://github.com/NixOS/nixpkgs/commit/01deb5f08581a03992d16c73dfddb42ad5813621) octavePackages.control: 3.5.2 -> 3.6.1
* [`993efa59`](https://github.com/NixOS/nixpkgs/commit/993efa596bdece03c8898ae444bf4ab87b4a42f8) tinygo: clean up Clang header path patch
* [`7c107e81`](https://github.com/NixOS/nixpkgs/commit/7c107e81d122b9ec77bfba141bc9c661e2673aad) octavePackages.general: 2.1.2 -> 2.1.3
* [`1ecda4be`](https://github.com/NixOS/nixpkgs/commit/1ecda4bec5379c3c6dc28541ffd41408aad89c10) python311Packages.distutils-extra: rename from distutils_extra
* [`04789c19`](https://github.com/NixOS/nixpkgs/commit/04789c1996da7de587d494332e4dcf93d9c9bfd9) python311Packages.ipython-genutils: rename from ipython_genutils
* [`5fec7350`](https://github.com/NixOS/nixpkgs/commit/5fec7350602401ab432bed1b0e20fd8541cd1ef2) octavePackages.sockets: 1.4.0 -> 1.4.1
* [`f3fabeca`](https://github.com/NixOS/nixpkgs/commit/f3fabeca1ef0736bca2d299fd9a1ada35a5ebf66) germinal: migrate to by-name
* [`ce3ff6bf`](https://github.com/NixOS/nixpkgs/commit/ce3ff6bf4a3228b406cfe019979799a4fb4113f1) kermit-terminal: update
* [`be48e33b`](https://github.com/NixOS/nixpkgs/commit/be48e33bc31e1354decb4013f8cdc87464c8a019) tilda: migrate to by-name
* [`96179893`](https://github.com/NixOS/nixpkgs/commit/96179893343901726eb96937460fa090ca5518ce) sound-of-sorting: update
* [`bde3f6a4`](https://github.com/NixOS/nixpkgs/commit/bde3f6a4b1013262ec089ff3f178e8784154ab19) havoc: migrate to by-name
* [`c68e9eca`](https://github.com/NixOS/nixpkgs/commit/c68e9ecaff866ffe01c415fb749a1d8b7cd3fff5) scimark: migrate to by-name
* [`b2425a56`](https://github.com/NixOS/nixpkgs/commit/b2425a56d9a6a6eaffc72f2f525f04d2141ee8e6) txr: migrate to by-name
* [`510ebb79`](https://github.com/NixOS/nixpkgs/commit/510ebb7964322c3a0317a9f037598b8206e4e984) pru: migrate to by-name
* [`e0844b31`](https://github.com/NixOS/nixpkgs/commit/e0844b318367792631999f0b739e7ae8c6691ffc) pyp: migrate to by-name
* [`282cc420`](https://github.com/NixOS/nixpkgs/commit/282cc4205cb5d624c33c60a86bc80c9c76be146a) robodoc: migrate to by-name
* [`c575a6b5`](https://github.com/NixOS/nixpkgs/commit/c575a6b5c250cd1af70d6c35896a77337c50f2e4) rs: migrate to by-name
* [`b841c225`](https://github.com/NixOS/nixpkgs/commit/b841c2253a8a87713252c671d509731400ee24bd) rst2html5: migrate to by-name
* [`01a3bf47`](https://github.com/NixOS/nixpkgs/commit/01a3bf4709fc336e70ff561d8d44578280be3973) robodoc: refactor
* [`0b89ccec`](https://github.com/NixOS/nixpkgs/commit/0b89ccec2edf9a35fd1361c944cc4a3019b600b6) uclibc-ng: migrate to by-name
* [`2b74160d`](https://github.com/NixOS/nixpkgs/commit/2b74160d8e5520465a6a81578d09659d65a0e4b2) uclibc-ng: refactor
* [`690f5d4a`](https://github.com/NixOS/nixpkgs/commit/690f5d4a10b1061518f3b61d09b87cbfbcb094b0) xscreensaver: migrate to by-name
* [`64cf2a1a`](https://github.com/NixOS/nixpkgs/commit/64cf2a1a5e882a28ca30a187a537287604dffd29) haunt: refactor
* [`ec63994c`](https://github.com/NixOS/nixpkgs/commit/ec63994cac1afebc457116a5a74954c32280c4b7) haunt: migrate to by-name
* [`2995ee4d`](https://github.com/NixOS/nixpkgs/commit/2995ee4d6309ee8d11daf8dedd632a4169e78cf7) dosbox-staging: migrate to by-name
* [`fcf47b67`](https://github.com/NixOS/nixpkgs/commit/fcf47b67409efa721486f8e64688987215fd837f) base16-shell-preview: migrate to by-name
* [`25fbe779`](https://github.com/NixOS/nixpkgs/commit/25fbe77939927fd9c7b64b4a0673bc5082440837) octavePackages.splines: 1.3.4 -> 1.3.5
* [`46d295f1`](https://github.com/NixOS/nixpkgs/commit/46d295f15cd526ac7d707d759923523fbe98bef9) nixos/gnu: remove
* [`22406377`](https://github.com/NixOS/nixpkgs/commit/224063778cad501556b62b36ecc90ee7c2bc31e2) octavePackages.statistics: 1.5.4 -> 1.6.0
* [`712c5943`](https://github.com/NixOS/nixpkgs/commit/712c5943f7d2766205885d1458825b9151a9fb4e) python311Packages.ipython-genutils: refactor
* [`42e1464c`](https://github.com/NixOS/nixpkgs/commit/42e1464c1a2597daa6ef1412b1531d83a600c4bd) tgpt: 2.0.2 -> 2.0.3
* [`2d386760`](https://github.com/NixOS/nixpkgs/commit/2d386760f73f26892c0dd9cacaeef0f11d99246b) git-mit: 5.12.157 -> 5.12.158
* [`a0d5762b`](https://github.com/NixOS/nixpkgs/commit/a0d5762b012ec283d6dc89a0adbda7f6bc7d2da1) octavePackages.stk: 2.8.0 -> 2.8.1
* [`07d258a5`](https://github.com/NixOS/nixpkgs/commit/07d258a505ac811435062db9bf9dd8893fce9db5) octavePackages.strings: 1.3.0 -> 1.3.1
* [`da9b5b54`](https://github.com/NixOS/nixpkgs/commit/da9b5b54558ca770d9e004f8b7917d8982e38da0) octavePackages.windows: 1.6.3 -> 1.6.4
* [`e20c1dc1`](https://github.com/NixOS/nixpkgs/commit/e20c1dc1b4b71094e53198e156be013ab030714e) octoprint: 1.9.2 -> 1.9.3
* [`4d198707`](https://github.com/NixOS/nixpkgs/commit/4d198707927e77066b061467f6501b0cfb9c2b8d) odpic: 5.0.0 -> 5.0.1
* [`ec5b4388`](https://github.com/NixOS/nixpkgs/commit/ec5b43883a118aec791a273d739048eaf8b88a2a) bat: migrate to by-name
* [`0c28a76a`](https://github.com/NixOS/nixpkgs/commit/0c28a76a269f2038446673f899bbef91c5ade891) oh-my-posh: 18.10.3 -> 18.11.0
* [`bbbf613e`](https://github.com/NixOS/nixpkgs/commit/bbbf613ed2441fc4a7ef7011be2b97c5624a3d3c) bat: 0.23.0 -> 0.24.0
* [`34c65fe8`](https://github.com/NixOS/nixpkgs/commit/34c65fe8df3ee0fadb18cff1777086c553b3e5eb) panicparse: missing package call in top-level
* [`92409f5c`](https://github.com/NixOS/nixpkgs/commit/92409f5c22f98a505753204ce044f7da4f0e0497) beeper: add mjm as maintainer
* [`6e022c37`](https://github.com/NixOS/nixpkgs/commit/6e022c37aa3558c0c956c8ddfa8dba68d286cfbe) onetun: 0.3.4 -> 0.3.5
* [`0609eddd`](https://github.com/NixOS/nixpkgs/commit/0609eddd64421b418cde397e62329fe46a235ffc) python311Packages.pyuv: fix build
* [`4d90959d`](https://github.com/NixOS/nixpkgs/commit/4d90959d49f086a1136469cd9cad294bc4c64093) terraform-ls: 0.32.1 -> 0.32.2
* [`1011a8c9`](https://github.com/NixOS/nixpkgs/commit/1011a8c946136760db79adb15eca5360027ff374) postgresqlPackages.timescaledb: 2.12.0 -> 2.12.1
* [`d23b1b86`](https://github.com/NixOS/nixpkgs/commit/d23b1b86973c6d1f8d4bf6df2748d1c0a5ac0a0c) openapi-generator-cli: 7.0.0 -> 7.0.1
* [`7d44850e`](https://github.com/NixOS/nixpkgs/commit/7d44850eed96a2c0fc3ac99d811406c489d8ffe1) nsxiv: migrate to by-name
* [`26e1af1a`](https://github.com/NixOS/nixpkgs/commit/26e1af1aa77696a60424420d01edb8f7635195db) nsxiv: improve
* [`acc76ae3`](https://github.com/NixOS/nixpkgs/commit/acc76ae3ec69b73111b7bad1b7cd5d88289163f7) nsxiv: 31 -> 32
* [`aef5f362`](https://github.com/NixOS/nixpkgs/commit/aef5f362f66667a9841292a97d05ac9d382c47f7) python311Packages.shap: 0.42.1 -> 0.43.0
* [`2b1258e4`](https://github.com/NixOS/nixpkgs/commit/2b1258e453017ff7d4a8e6cebc34df64272fc721) llvmPackages: add the removal of `extend` to release-notes
* [`861a30b8`](https://github.com/NixOS/nixpkgs/commit/861a30b80cc675627b02c3e22472b607dfbfe1aa) openspecfun: 0.5.5 -> 0.5.6
* [`d1a86a23`](https://github.com/NixOS/nixpkgs/commit/d1a86a2373e42a94c6a5a4c48f5f952d3bf6cc62) qownnotes: 23.10.0 -> 23.10.1
* [`63416505`](https://github.com/NixOS/nixpkgs/commit/634165056348e338561906ec64d598c93a61fb26) anytype: change src to github
* [`d258a1c1`](https://github.com/NixOS/nixpkgs/commit/d258a1c1f7c4ba7cab56c28bad96c10f58dd2e5d) immersed-vr: init at 9.6
* [`9e493bdf`](https://github.com/NixOS/nixpkgs/commit/9e493bdfc1c5b3c02333202df77ea6a548a0cea4) orchard: 0.13.1 -> 0.14.1
* [`f1c74998`](https://github.com/NixOS/nixpkgs/commit/f1c7499875cdd44636fa415667516a1b4ea78650) python311Packages.dllogger: init at 1.0.0
* [`e0becb4a`](https://github.com/NixOS/nixpkgs/commit/e0becb4aba2ee450f551b236509a22d762f68e9a) tradingview: init at 2.6.1
* [`3e9aecda`](https://github.com/NixOS/nixpkgs/commit/3e9aecda60d1b9fd802594054fcce785c68c4668) fortune-kind: 0.1.3 -> 0.1.4
* [`bb777015`](https://github.com/NixOS/nixpkgs/commit/bb777015c87b51b4ce26e2fc61cb833183a56d49) nixos/bandwhich: add missing capabilities
* [`12014e64`](https://github.com/NixOS/nixpkgs/commit/12014e64abdfcd8fa662de77edd8aa839fd005e6) picard: 2.9.2 -> 2.10
* [`eb0da9b1`](https://github.com/NixOS/nixpkgs/commit/eb0da9b1e32ac76f50c47327ada8f750b53786b4) python311Packages.elastic-apm: 6.18.0 -> 6.19.0
* [`5d41ee3b`](https://github.com/NixOS/nixpkgs/commit/5d41ee3bf74ed05c62346a3f20d2ae44e898f499) python311Packages.pyenphase: 1.11.4 -> 1.12.0
* [`e75a89c9`](https://github.com/NixOS/nixpkgs/commit/e75a89c9b36abc10dceae41996f63d04b1c35de7) python311Packages.socid-extractor: 0.0.25 -> 0.0.26
* [`fc23071a`](https://github.com/NixOS/nixpkgs/commit/fc23071ade8034c5b2a0acfc10280bb70fb6e487) python311Packages.teslajsonpy: 3.9.5 -> 3.9.6
* [`4d387960`](https://github.com/NixOS/nixpkgs/commit/4d38796041da3a4441323b54e38eee30284a2a1e) python311Packages.simplisafe-python: 2023.08.0 -> 2023.10.0
* [`29dd7cb6`](https://github.com/NixOS/nixpkgs/commit/29dd7cb6eb75b0be3dd4848a08cedfc012dc8df3) python311Packages.rich-click: 1.6.1 -> 1.7.0
* [`3458dc82`](https://github.com/NixOS/nixpkgs/commit/3458dc8223320db755cc43fd2cf3d65c5383b115) python311Packages.pymyq: 3.1.11 -> 3.1.13
* [`1e11e59f`](https://github.com/NixOS/nixpkgs/commit/1e11e59f838f7ac536db8e030496871a9a828b56) eza: 0.14.1 -> 0.14.2
* [`825cb4a9`](https://github.com/NixOS/nixpkgs/commit/825cb4a9e2a8e0ce47e8dec9d801fa12eab3a61d) qovery-cli: 0.72.0 -> 0.73.0
* [`487867ff`](https://github.com/NixOS/nixpkgs/commit/487867ffa519378e979870964f38b0eee3397c22) python311Packages.aioridwell: 2023.08.0 -> 2023.10.0
* [`c6ca4664`](https://github.com/NixOS/nixpkgs/commit/c6ca466438df86b2d30888a9a47cfe61a06321ea) partclone: 0.3.25 -> 0.3.27
* [`f3fdf2f8`](https://github.com/NixOS/nixpkgs/commit/f3fdf2f8531a0dcf90d63bdddf405f80fbdc98ba) python311Packages.aiowithings: init at 0.3.0
* [`b9cb3c33`](https://github.com/NixOS/nixpkgs/commit/b9cb3c33c43b603f10b4efb83a17a646dde5945f) pot: 2.6.2 -> 2.6.3
* [`7c2bcf14`](https://github.com/NixOS/nixpkgs/commit/7c2bcf14b504dd9022f60476a257ea3e346e649e) monero-{cli,gui}: 0.18.2.2 -> 0.18.3.1
* [`85e135d3`](https://github.com/NixOS/nixpkgs/commit/85e135d302be88a6d72fb277d709cb1ce7edc078) tree-sitter-grammars: add proto
* [`632c4140`](https://github.com/NixOS/nixpkgs/commit/632c4140e90583338bc00469faf32e768aeb84e0) tree-sitter: let nixpkgs-format reformat the buffer
* [`4de1baa6`](https://github.com/NixOS/nixpkgs/commit/4de1baa6cc310dff597ddb832a6026af0879bc23) phosh: 0.31.1 -> 0.32.0
* [`a03b1591`](https://github.com/NixOS/nixpkgs/commit/a03b1591598dbacb4efdf4062532d714a0bcbe0f) python311Packages.pyoutbreaksnearme: update disabled
* [`9e2ee4c8`](https://github.com/NixOS/nixpkgs/commit/9e2ee4c84610e0a3aa83f7ca7f8bc433d3baecba) babashka: use upstream version of Clojure tools
* [`7db47744`](https://github.com/NixOS/nixpkgs/commit/7db47744f53d37da0c03bd6059d3204d6213a454) buildGraalvmNativeImage: build with "-march=compatibility" by default
* [`2bb4672f`](https://github.com/NixOS/nixpkgs/commit/2bb4672f4d1ac0d753d799613e8d9dd9d9165d90) python311Packages.azure-storage-queue: 12.7.2 -> 12.7.3
* [`abab9809`](https://github.com/NixOS/nixpkgs/commit/abab9809183d1a8eeccee04d82aec1e13f878b25) python311Packages.azure-storage-file-share: 12.14.1 -> 12.14.2
* [`c20a6561`](https://github.com/NixOS/nixpkgs/commit/c20a65614b86e72f71ef2d2dfd9a5add0768ffa6) python311Packages.azure-servicebus: 7.11.2 -> 7.11.3
* [`76731f6f`](https://github.com/NixOS/nixpkgs/commit/76731f6f1ebbbe169671a2c3392f51be95d8bdc2) python311Packages.azure-mgmt-cosmosdb: 9.2.0 -> 9.3.0
* [`b32615f6`](https://github.com/NixOS/nixpkgs/commit/b32615f6d45d9a3de18bf9b42bb4c9b9fa513618) python311Packages.awscrt: 0.19.1 -> 0.19.2
* [`930c2a57`](https://github.com/NixOS/nixpkgs/commit/930c2a578f9a74a94b371eed6b50ca72afa0499f) bun: 1.0.4 -> 1.0.5
* [`5e01915e`](https://github.com/NixOS/nixpkgs/commit/5e01915ea9cd9d63d53644ad6beed31d4853ae85) php81Extensions.datadog_trace: 0.89.0 -> 0.92.2
* [`93263711`](https://github.com/NixOS/nixpkgs/commit/93263711f7476cd5af4ae28d316213eef0791f50) go-musicfox: 4.1.4 -> 4.2.1
* [`6ebe8cd1`](https://github.com/NixOS/nixpkgs/commit/6ebe8cd15053d4545eca5b82588b6318fcfb2f23) kdiff3: 1.10.5 -> 1.10.6
* [`1a794a3e`](https://github.com/NixOS/nixpkgs/commit/1a794a3e4b28c311a39449198a304a0dbed9cc00) nixos/mailman: store locks in ephemeral runtime directory
* [`96c3d0ed`](https://github.com/NixOS/nixpkgs/commit/96c3d0ed6394d2afc7f9385aad00bd54f4ef4da0) python311Packages.cle: update binaries for tests
* [`419e4922`](https://github.com/NixOS/nixpkgs/commit/419e4922aac949dc76584cd6479473639a9ca892) scriv: 1.3.1 -> 1.4.0
* [`bb3f82b1`](https://github.com/NixOS/nixpkgs/commit/bb3f82b1dd75b02d320bb2ae1f434cf59de1e61e) php81Extensions.snuffleupagus: 0.9.0 -> 0.10.0
* [`9a84d0ec`](https://github.com/NixOS/nixpkgs/commit/9a84d0ec60c09ae9cb46906435de701c8b4f8334) php81Packages.castor: 0.8.0 -> 0.9.1
* [`2cf8f6b5`](https://github.com/NixOS/nixpkgs/commit/2cf8f6b58a00fff32b9c71c598ef7d4264a53b53) headsetcontrol: add meta.mainProgram
* [`c8c9976c`](https://github.com/NixOS/nixpkgs/commit/c8c9976cb564d92ea0642238844f26e36deb5037) matrix-sliding-sync: 0.99.10 -> 0.99.11
* [`65c4ec59`](https://github.com/NixOS/nixpkgs/commit/65c4ec5964f77afca548cd865ff0c525ae88b978) maintainers: add YoshiRulz
* [`9b3bc22b`](https://github.com/NixOS/nixpkgs/commit/9b3bc22b2fa4a0daa83080e90886849cfb224140) php81Packages.php-cs-fixer: 3.28.0 -> 3.34.1
* [`3b1c0d6e`](https://github.com/NixOS/nixpkgs/commit/3b1c0d6ecc928d4f9fe0dbd3bfeb86de7c79aa36) fluent-bit: re-enable on darwin
* [`5338fc89`](https://github.com/NixOS/nixpkgs/commit/5338fc8906120dbadb65571df36a9bfa9114ba3f) python311Packages.cle: update disabled
* [`8fb2cff4`](https://github.com/NixOS/nixpkgs/commit/8fb2cff428ebe0d6d1cce69c439daf2448b4d364) python311Packages.angr: update disabled
* [`4776c5ba`](https://github.com/NixOS/nixpkgs/commit/4776c5baf57567bf35636057afc335712629f581) php81Packages.phpcs: 3.7.1 -> 3.7.2
* [`91568015`](https://github.com/NixOS/nixpkgs/commit/915680155f67068d1e5339ed15cc3001acb22f6c) limesctl: 3.2.1 -> 3.3.0
* [`50d78b0e`](https://github.com/NixOS/nixpkgs/commit/50d78b0ed6c2e04719f8f5d33d3b487e98f1f57c) php81Packages.phpmd: 2.13.0 -> 2.14.1
* [`77fb7cb5`](https://github.com/NixOS/nixpkgs/commit/77fb7cb5f848e42b7eba0897422af98dd0956c32) python311Packages.claripy: update disabled
* [`c92ab33f`](https://github.com/NixOS/nixpkgs/commit/c92ab33f231406c39f076a70c8aa4ab375b9e717) python311Packages.pyvex: update disabled
* [`3a02248e`](https://github.com/NixOS/nixpkgs/commit/3a02248e12d309d56cb846e327cd6429089ce5ab) python311Packages.hahomematic: 2023.10.7 -> 2023.10.8
* [`fce2579c`](https://github.com/NixOS/nixpkgs/commit/fce2579c3159f1ce4ea7c70cfd4f4446733d0fc2) bun: 1.0.5 -> 1.0.6
* [`252b6dc3`](https://github.com/NixOS/nixpkgs/commit/252b6dc39461b29f274ee48b604c20fabec22771) yutto: 2.0.0b28 -> 2.0.0b30
* [`86ac2bba`](https://github.com/NixOS/nixpkgs/commit/86ac2bba9bf2046da075664605e4320a4c5611fc) python311Packages.libcst: 1.0.1 -> 1.1.0
* [`8718efad`](https://github.com/NixOS/nixpkgs/commit/8718efadd1a62432aac9b0177b63a55e86511c7c) python311Packages.ailment: update disabled
* [`d0ed5d42`](https://github.com/NixOS/nixpkgs/commit/d0ed5d42c4d8a5a13d703afe4d1d137053d59323) python311Packages.libcst: ad changelog to meta
* [`4fa5f733`](https://github.com/NixOS/nixpkgs/commit/4fa5f7334a83dbfc8da2a0d5188d7703f8227222) rapidjson-unstable: init at unstable-2023-09-28
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
