### PR TITLE
niv home-manager: update 3c1d8758 -> 78125bc6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d",
-        "sha256": "15lbabsqc5h5aj32gjzi9l4n9jmy7z9laby1i9k17z73726fjgv0",
+        "rev": "78125bc681d12364cb65524eaa887354134053d0",
+        "sha256": "0qrhsq5hbybcsd467hw02vx7q470kvk5mmmi6w7xbphgy9ykyawc",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/78125bc681d12364cb65524eaa887354134053d0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@3c1d8758...78125bc6](https://github.com/nix-community/home-manager/compare/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d...78125bc681d12364cb65524eaa887354134053d0)

* [`6dfbdc97`](https://github.com/nix-community/home-manager/commit/6dfbdc977e059f30376e23f70f67d9726d5c91b8) unison: add package option
* [`6bba6478`](https://github.com/nix-community/home-manager/commit/6bba64781e4b7c1f91a733583defbd3e46b49408) password-store-sync: remove module
* [`a4a72ffd`](https://github.com/nix-community/home-manager/commit/a4a72ffd76f2c974601e7adff356e5c277e08077) flake.lock: Update
* [`9a2ce656`](https://github.com/nix-community/home-manager/commit/9a2ce6569752bb00b86c075ade7ffd47242f3827) zsh: generalize zsh-history-substring-search
* [`d4a5076e`](https://github.com/nix-community/home-manager/commit/d4a5076ea8c2c063c45e0165f9f75f69ef583e20) borgmatic: improve support for version 1.8.0
* [`3b67ae3f`](https://github.com/nix-community/home-manager/commit/3b67ae3f665379c06999641f99d94dba75b53876) services.cliphist: add module ([nix-community/home-manager⁠#4445](https://togithub.com/nix-community/home-manager/issues/4445))
* [`f033205b`](https://github.com/nix-community/home-manager/commit/f033205b251439bda16fd9071b163b6eacb4fdf6) firefox: extract an overlay common to all tests
* [`78125bc6`](https://github.com/nix-community/home-manager/commit/78125bc681d12364cb65524eaa887354134053d0) firefox: add test for duplicate profile id assertion
