### PR TITLE
niv zsh-completions: update 2c1e9af1 -> e969ea6f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "2c1e9af19562bfb74a9167122c460bd22e39c06d",
-        "sha256": "00bz7lsvnpzsfkmm2qb69jjgnnx2n1xcdqlyj6xwzibcy5wmv43w",
+        "rev": "e969ea6f6e69771c238138583d637a6257809e0f",
+        "sha256": "1vadlv8sv602c5jf0pm4557k6a30ccy9nfpipj5fdw8vn80bn7vy",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/2c1e9af19562bfb74a9167122c460bd22e39c06d.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/e969ea6f6e69771c238138583d637a6257809e0f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@2c1e9af1...e969ea6f](https://github.com/zsh-users/zsh-completions/compare/2c1e9af19562bfb74a9167122c460bd22e39c06d...e969ea6f6e69771c238138583d637a6257809e0f)

* [`1f930686`](https://github.com/zsh-users/zsh-completions/commit/1f930686273db3e902fa26723e1fc7ba6878846e) Add basic completions for shallow-backup
* [`9a59a719`](https://github.com/zsh-users/zsh-completions/commit/9a59a71911bcca1cccb72b6f0f7c7142160f83d8) Update src/_shallow-backup
* [`8fed2d1e`](https://github.com/zsh-users/zsh-completions/commit/8fed2d1e839f7b97ec613ccdf42e243ebd19e79d) Update src/_shallow-backup
* [`9d358ae3`](https://github.com/zsh-users/zsh-completions/commit/9d358ae351324ab5f003998b80cdaece0da31be4) Update src/_shallow-backup
* [`1e80d3c1`](https://github.com/zsh-users/zsh-completions/commit/1e80d3c1bf0cf7caa740b9af14c87e0eaff52ba4) Update src/_shallow-backup
* [`660b7e49`](https://github.com/zsh-users/zsh-completions/commit/660b7e4963daef546d6c81202eedf1eee5766e25) Update src/_shallow-backup
