### PR TITLE
niv nixpkgs: update baa913c9 -> 6a251401

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "baa913c9eb89ac65d5177731c5f9d42f981eb073",
-        "sha256": "0mqhf1p392a3jvq7fr6a09x26dq0my9gwgw8wq66xc9738pyrqjq",
+        "rev": "6a251401ea6a2ee5f6a19fd6e6c8504f9d41f520",
+        "sha256": "06za5zbcdrjxwv3579fgs8lw84nnx4ka56dpk9rh20p33j7pqb5s",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/baa913c9eb89ac65d5177731c5f9d42f981eb073.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6a251401ea6a2ee5f6a19fd6e6c8504f9d41f520.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@baa913c9...6a251401](https://github.com/nixos/nixpkgs/compare/baa913c9eb89ac65d5177731c5f9d42f981eb073...6a251401ea6a2ee5f6a19fd6e6c8504f9d41f520)

* [`2a6198fc`](https://github.com/NixOS/nixpkgs/commit/2a6198fc81b5392f56f33d5bc6a0239441211af4) out-of-tree: 2.0.4 > 2.1.1
* [`db1b253b`](https://github.com/NixOS/nixpkgs/commit/db1b253b3abf3c5a50492445883bdf0d5da143a7) mosquitto: use multiple outputs
* [`c05019d7`](https://github.com/NixOS/nixpkgs/commit/c05019d716e2d5aa6f6d05150672c413688b38e3) PULL_REQUEST_TEMPLATE.md: Update sandboxing check
* [`3310b016`](https://github.com/NixOS/nixpkgs/commit/3310b016fb261aa7d7623ff2cd84149cc01d7118) spicy-parser-generator: 1.7.0 -> 1.8.1
* [`06c0ac52`](https://github.com/NixOS/nixpkgs/commit/06c0ac52cc76e1f6ed91c18dc0f393d0839a10fc) ckb-next: 0.5.0 -> 0.6.0
* [`1fa68aa2`](https://github.com/NixOS/nixpkgs/commit/1fa68aa252c6a2c07ffc7a537b8f3d37df957c25) ruby-modules: add `suffix` and `gemType` in pathDerivation
* [`75340d54`](https://github.com/NixOS/nixpkgs/commit/75340d54b4d24961d8fe53fbcac9dfe762d0d4fc) haskell: Only report non-broken packages to Hackage
* [`30a24a3b`](https://github.com/NixOS/nixpkgs/commit/30a24a3bcdb7452ea8fe2d2d8d49fca569905333) Check pkg.meta.hydraPlatforms, not pkg.meta.broken
* [`28a081c7`](https://github.com/NixOS/nixpkgs/commit/28a081c7364a17a0f2a8b6554a7b06f1eab3bc4b) also inherit bantime
* [`8027d95f`](https://github.com/NixOS/nixpkgs/commit/8027d95ff01ba1a9dbc9f960a929ffe4e306d25c) xrootd: enable structured attributes
* [`9c80ef7f`](https://github.com/NixOS/nixpkgs/commit/9c80ef7f16acb29560154af94615768d16858559) xrootd: wrap executables with [DY]LD_LIBRARY_PATH
* [`bc744410`](https://github.com/NixOS/nixpkgs/commit/bc744410f5b6e406b2ac2cd0a000db6c88fdc2bd) xrootd.fetchxrd: remove duplicated wrapping
* [`4f318516`](https://github.com/NixOS/nixpkgs/commit/4f318516389444054791920017c5e3e29bfb2c1c) xrootd.fetchxrd: show progress bar with --verbose
* [`95f76d1d`](https://github.com/NixOS/nixpkgs/commit/95f76d1d100df7126ce202606745557710aa1c33) xrootd: opt out systemd where it breaks
* [`47c9ed07`](https://github.com/NixOS/nixpkgs/commit/47c9ed07dfeeb5963961fabf9e6332d3bf2a5bea) python3Packages.certifi: 2023.05.07 -> 2023.07.22
* [`86f362ce`](https://github.com/NixOS/nixpkgs/commit/86f362ce5b9d6606c6b6b832d864a47c45a05aaa) bioawk: init at unstable-2017-09-11
* [`040cf424`](https://github.com/NixOS/nixpkgs/commit/040cf4248dc1c6329cf08f73a46af13e140d4eb6) gcc: simplify expression by applying workarounds more broadly
* [`80198b83`](https://github.com/NixOS/nixpkgs/commit/80198b835b1fa20bab9b6a72d0e09c92e115d6e8) gcc: remove backticks-used-as-quotes (error prone)
* [`af319af2`](https://github.com/NixOS/nixpkgs/commit/af319af2254ce0dd303b03177875aaa52f25e265) gcc: unescapify backslash
* [`60d879e2`](https://github.com/NixOS/nixpkgs/commit/60d879e2571b55c8c86def5448594e4b20f2c5ff) doc manuals: add reference to nixos-render-docs
* [`4c3def1a`](https://github.com/NixOS/nixpkgs/commit/4c3def1ae8335362147fd096a1d14e2b35c89786) doc manuals: change reference link to nixos-render-docs
* [`98bd3171`](https://github.com/NixOS/nixpkgs/commit/98bd3171dc406f39cc32b6790a40926798835045) guile_2_2: fix build with clang 16 on x86_64-darwin
* [`f8382587`](https://github.com/NixOS/nixpkgs/commit/f8382587d9ac3857864204be8a3737e90f6f325b) guile_3_0: fix build with clang 16 on x86_64-darwin
* [`cdde96e7`](https://github.com/NixOS/nixpkgs/commit/cdde96e7583502b2ba9ef437a213a4178b126182) python3Packages.numpy: use pytestCheckHook & disable failing tests
* [`981754ab`](https://github.com/NixOS/nixpkgs/commit/981754aba87cb66ed37485632e39235e7f6fe381) nix-prefetch-git: fix make_deterministic_repo in submodules
* [`bad3edc0`](https://github.com/NixOS/nixpkgs/commit/bad3edc0c96029ed731898889d9dfb0560fcd0d9) python3Packages.ruamel-yaml-clib: fix build with clang 16
* [`e08ce498`](https://github.com/NixOS/nixpkgs/commit/e08ce498f03f12ae155b29a35c24adb26d4e8888) cc-wrapper: Account for NIX_LDFLAGS and NIX_CFLAGS_LINK in linkType
* [`01520e56`](https://github.com/NixOS/nixpkgs/commit/01520e5694b81fd4d181a40b06a26fcc031d0171) dbus: 1.14.8 -> 1.14.10
* [`8e25133a`](https://github.com/NixOS/nixpkgs/commit/8e25133afe16edd14c537a4fa6ab7c98715544bd) maintainers: add tsowell
* [`f0fcea2d`](https://github.com/NixOS/nixpkgs/commit/f0fcea2d55c6abfe3537f608bdcf789695b661d8) evsieve: init at 1.3.1
* [`87a35706`](https://github.com/NixOS/nixpkgs/commit/87a35706f8c81d2c6c217167da63abc2f59048e7) jemalloc: fix build with clang 16
* [`0823abd6`](https://github.com/NixOS/nixpkgs/commit/0823abd6406d8e92516eb0a1773f06603cebb07b) libdv: fix build with clang 16
* [`94423c09`](https://github.com/NixOS/nixpkgs/commit/94423c09106c028e04baf7d438d00440270dc143) vala: work around clang 16 function pointer errors
* [`eb3da7c4`](https://github.com/NixOS/nixpkgs/commit/eb3da7c49e97e098f61802957f7b4c1dbec952da) libdrm: 2.4.115 -> 2.4.116
* [`c45a7926`](https://github.com/NixOS/nixpkgs/commit/c45a792653d5273d3d99adafadd6df77577f1c94) ghostscript.tests.test-corpus-render: unstable-2022-12-01 -> unstable-2023-05-19
* [`38ac9a1f`](https://github.com/NixOS/nixpkgs/commit/38ac9a1f1032e5d5c62095e1e39b0c7bec49519e) iproute2: 6.4.0 -> 6.5.0
* [`bc07451d`](https://github.com/NixOS/nixpkgs/commit/bc07451d4f96c77355f7e7ebb7932666d094793d) nixos/dae: fix override existed config issue
* [`abb941f2`](https://github.com/NixOS/nixpkgs/commit/abb941f20b58942ea34829d860796d11a89a3dff) maintainers: add gray-heron
* [`1ff17519`](https://github.com/NixOS/nixpkgs/commit/1ff17519063edb36403242137aef497a52f7a8af) nixos/dae: use port type instead int
* [`48802990`](https://github.com/NixOS/nixpkgs/commit/488029904f1479417c677527ee73b1457b37c4a6) python3Packages.textparser: init at 0.24.0
* [`52de2390`](https://github.com/NixOS/nixpkgs/commit/52de239082e55f191b47ec2b959ec734432bb1bd) python3Packages.cantools: init at 38.0.2
* [`69e3784e`](https://github.com/NixOS/nixpkgs/commit/69e3784e03d2caa3d18348a9c41ca56da8e12a02) xorg.libpthreadstubs: 0.4 -> 0.5
* [`0cc33766`](https://github.com/NixOS/nixpkgs/commit/0cc3376650c09800ecc3eb7b7954b34cfc0938bd) xorg.xf86inputlibinput: 1.3.0 -> 1.4.0
* [`cd0e3964`](https://github.com/NixOS/nixpkgs/commit/cd0e3964e822921be35b7674b1b255fd632cc860) xorg.fontutil: 1.4.0 -> 1.4.1
* [`83714adf`](https://github.com/NixOS/nixpkgs/commit/83714adfd55ae7defa62907cbee82bc73a3f6a43) xorg.libxcb: 1.15 -> 1.16
* [`909ecad3`](https://github.com/NixOS/nixpkgs/commit/909ecad386251179b4404274a5a3a01a8de00732) xorg.xcbproto: 1.15.2 -> 1.16.0
* [`cbd4d659`](https://github.com/NixOS/nixpkgs/commit/cbd4d659e34c27cae5f48d7fdf6b2863f6492e6f) hdf5: switch to cmake build
* [`96d0f76c`](https://github.com/NixOS/nixpkgs/commit/96d0f76cd5f5fb331aa462a33f19ded41aa5f401) freetype: 2.13.1 -> 2.13.2
* [`85c6e70b`](https://github.com/NixOS/nixpkgs/commit/85c6e70b555fe892a049fa3d9dce000dc23a9562) libsodium: 1.0.18 -> 1.0.19
* [`7e1921a7`](https://github.com/NixOS/nixpkgs/commit/7e1921a7f3cf1602fb9b007950f7cf01698922ce) maintainers: Add soispha
* [`63ed3ecd`](https://github.com/NixOS/nixpkgs/commit/63ed3ecdaf325ce94e77e221d2ce84630f76cb5e) krb5: 1.20.1 -> 1.21.2
* [`1e3148d3`](https://github.com/NixOS/nixpkgs/commit/1e3148d3fe8b2864ca1fa6340f0701f1d424274a) tcl.tclPackageHook: Use makeBinaryWrapper
* [`b0c2a800`](https://github.com/NixOS/nixpkgs/commit/b0c2a800d67abf7c27d55b80d4f6c54e19a0b5d4) tcl.tclPackageHook: inherit maintainers and platforms
* [`aae53c8f`](https://github.com/NixOS/nixpkgs/commit/aae53c8f97b687c53c57ceb23ad45d31922ac361) qt5.qtModule,qt6.qtModule: deprecate qtInputs
* [`eb1266e7`](https://github.com/NixOS/nixpkgs/commit/eb1266e756fa2e41205d07f46c3ec2dafecb82c1) pulseaudio: expose config.h used in the build
* [`29d1e0cc`](https://github.com/NixOS/nixpkgs/commit/29d1e0ccbfc0ddf47cd7aa0107e6d0156ef2be9f) llvmPackages_16.llvm: skip googletest-timeout lit test
* [`23375e82`](https://github.com/NixOS/nixpkgs/commit/23375e823183abfcb4a6ba24b2487a2830a23313) llvmPackages_15.llvm: skip googletest-timeout lit test
* [`accafc0e`](https://github.com/NixOS/nixpkgs/commit/accafc0ed36ba6da401e1abc9595f633fc7d4401) cc-wrapper: add libcxxabi include flag for LLVM
* [`42f32926`](https://github.com/NixOS/nixpkgs/commit/42f329261698805c6367cc488105c6573f0e4cf5) tests.cc-wrapper.supported: add test for cxxabi header
* [`0259d84c`](https://github.com/NixOS/nixpkgs/commit/0259d84c22d5336201a576fed74d7bf10a58cdc4) kustomize_4: init at 4.5.7
* [`df8b425f`](https://github.com/NixOS/nixpkgs/commit/df8b425f8990cf8c6cd8a4477a70995bdd4fe2a4) makeBinaryWrapper: protect wildcards in flags
* [`99ccaa3d`](https://github.com/NixOS/nixpkgs/commit/99ccaa3d747f9af17e45881e5f7f98fc58d2644a) linux-kernel: Add HP drivers on 6.1+
* [`78b49e47`](https://github.com/NixOS/nixpkgs/commit/78b49e471c2ae86ec93cfe8589c2ceedcbec0303) python3.pkgs.pillow: 10.0.0 -> 10.0.1
* [`1e258e96`](https://github.com/NixOS/nixpkgs/commit/1e258e967ecf66686d515cff3f0b60cd748a060d) meson: 1.2.0 -> 1.2.1
* [`4d2b986d`](https://github.com/NixOS/nixpkgs/commit/4d2b986d7e0ccf006f780a431b84c0abb0ba5861) ghostscript: 10.01.2 -> 10.02.0
* [`4bda6aae`](https://github.com/NixOS/nixpkgs/commit/4bda6aaeb4dbfc275f1076d08e2be7e3418f1ad5) python310Packages.click: 8.1.6 -> 8.1.7
* [`9b610488`](https://github.com/NixOS/nixpkgs/commit/9b6104889a2edf4f92becadec3e82a338a3e2172) freetype: add changelog to meta
* [`b7e68243`](https://github.com/NixOS/nixpkgs/commit/b7e68243306833845cbf92e2ea1e0cf782481a51) openjdk: remove explicit flag to include ZGC
* [`b88fa28c`](https://github.com/NixOS/nixpkgs/commit/b88fa28cce63ab3693c81d6f7e602a9c24d79844) openjdk1{2,3,4,5,6,8}: quickfix, add images build
* [`e8d32b94`](https://github.com/NixOS/nixpkgs/commit/e8d32b940c4933b8dd6d26514567a7e17b6ece2a) graphviz: 8.1.0 -> 9.0.0
* [`226f3574`](https://github.com/NixOS/nixpkgs/commit/226f3574fbd590c7f35c7265f9cb27996070ce3b) openssl: 3.0.10 -> 3.0.11
* [`bcae9ce2`](https://github.com/NixOS/nixpkgs/commit/bcae9ce2cf99379d18ee27945152633fe6f077c3) networkmanager: 1.42.8 -> 1.44.0
* [`504954d2`](https://github.com/NixOS/nixpkgs/commit/504954d21ac6e844f67cd9f654858a1599fb946a) aws-c-sdkutils: 0.1.11 -> 0.1.12
* [`50bf74d6`](https://github.com/NixOS/nixpkgs/commit/50bf74d60886666a7180c13bc5893662701fd2d8) cups: 2.4.6 -> 2.4.7
* [`759ec111`](https://github.com/NixOS/nixpkgs/commit/759ec1113d0a1d6315b38bd83ec3562dacc08238) nixos/network-interfaces: stop wrapping ping with cap_net_raw
* [`a8ae77c1`](https://github.com/NixOS/nixpkgs/commit/a8ae77c1fbe9834c9a1e4d79203195c235b3ba8f) mesa: 23.1.7 -> 23.1.8
* [`1d50e695`](https://github.com/NixOS/nixpkgs/commit/1d50e695f33447906f4371ed27f2f45cf1946bc1) maintainers: add rtimush
* [`6800e5c1`](https://github.com/NixOS/nixpkgs/commit/6800e5c15135e37e366a071ebb1fa8c1c24689c8) kbd: 2.6.2 -> 2.6.3
* [`1008fa13`](https://github.com/NixOS/nixpkgs/commit/1008fa1354e3d99fa587d8ea4f67365be69071da) grc: add azahi as maintainer
* [`26f43f17`](https://github.com/NixOS/nixpkgs/commit/26f43f17e4b6f671ab395d510c41e10425ec037f) rustc: 1.72.0 -> 1.72.1
* [`5dfa639d`](https://github.com/NixOS/nixpkgs/commit/5dfa639d50260d6679db1b8cd6fa870d7b6ac042) hadoop: 3.3.5 -> 3.3.6, build container executor from source
* [`9be640a2`](https://github.com/NixOS/nixpkgs/commit/9be640a232166f14be4d38145970ffd63623c4d7) hadoop: support native libs on 3.2
* [`1cd3c804`](https://github.com/NixOS/nixpkgs/commit/1cd3c804bf4644fc168883c15b60baf596aba4fc) hadoop, nixos/hadoop: remove untarDir
* [`028231c0`](https://github.com/NixOS/nixpkgs/commit/028231c095f796e6c5960f40ca441d232318bbea) grc: add support for absolute store paths
* [`05b4d8e7`](https://github.com/NixOS/nixpkgs/commit/05b4d8e7f5372ca73e12be3b922ec019972e7ea2) libsoup{,_3}: enable `separateDebugInfo`
* [`8aa8cd68`](https://github.com/NixOS/nixpkgs/commit/8aa8cd68f4745eb92f003666bfd300f3e67cd9c1) unbound: backport fix for libunbound with nettle
* [`d2ec7eb4`](https://github.com/NixOS/nixpkgs/commit/d2ec7eb4edf02f441e91672556ced576eadd3954) scons: add AndersonTorres as maintainer
* [`c2996ef5`](https://github.com/NixOS/nixpkgs/commit/c2996ef5dde3d92943cc33794ed0837dd3834629) scons: shellcheck setupHook
* [`1608bde4`](https://github.com/NixOS/nixpkgs/commit/1608bde4283b5e5a0d0b61141b87ffd7c9c72d60) dmd: remove references to dmd-bootstrap
* [`b23e0812`](https://github.com/NixOS/nixpkgs/commit/b23e08124df73322d5e8000c013148e04cf22caa) glibc: 2.37-8 -> 2.37-39
* [`a74b3012`](https://github.com/NixOS/nixpkgs/commit/a74b3012678ab9640b2bc6062ac37fe6805c2f15) mysql-shell-innovation: init at 8.1.1
* [`ffa418a4`](https://github.com/NixOS/nixpkgs/commit/ffa418a4113e573878de1883527137784da7e937) indent: enable tests
* [`4e67f789`](https://github.com/NixOS/nixpkgs/commit/4e67f78941f5e512f6d082ee7665f00514f01a01) indent: 2.2.12 -> 2.2.13
* [`78453abb`](https://github.com/NixOS/nixpkgs/commit/78453abb1020048e54b74eaf18cbb711dba87a54) indent: add patches for CVE-2023-40305
* [`ef484333`](https://github.com/NixOS/nixpkgs/commit/ef4843339891c10edb550368ae77446441321f28) hadoop: add native libs support in all versions
* [`21fa56c1`](https://github.com/NixOS/nixpkgs/commit/21fa56c145258730be931cb870094b87997429cf) hadoop: fix eval on darwin
* [`e81936d5`](https://github.com/NixOS/nixpkgs/commit/e81936d59edde7c2e40980a59d1ccdf8bbebbaef) libarchive: 3.6.2 -> 3.7.2
* [`81e8caab`](https://github.com/NixOS/nixpkgs/commit/81e8caab85d911cde251d6615b0dced4cd0ffb11) pkgsi686Linux.libarchive: pull upstream fix for 32-bit systems
* [`e8615298`](https://github.com/NixOS/nixpkgs/commit/e86152986c6e6c563ced037c91403318d5a8b447) glibc: 2.37-39 -> 2.38-0
* [`d00a2208`](https://github.com/NixOS/nixpkgs/commit/d00a220853e808e2fcc9b951628645e779d56db6) direwolf: fix build w/ glibc-2.38
* [`5497c7ac`](https://github.com/NixOS/nixpkgs/commit/5497c7ac5df57e4c472a307f62e0072a3ca6c3a1) root: fix build w/ glibc-2.38
* [`774a808e`](https://github.com/NixOS/nixpkgs/commit/774a808ec9336326107de4096a07c22ed9c95a8e) kvmtool: fix build w/ glibc-2.38
* [`b6a5be45`](https://github.com/NixOS/nixpkgs/commit/b6a5be45845957d766997a9cf1b18fec2b0868f1) brickd: fix build w/ glibc-2.38
* [`a44542f7`](https://github.com/NixOS/nixpkgs/commit/a44542f7f6d6df5968cb4291a9372808a1034995) mamba: mark as broken
* [`25b89fa9`](https://github.com/NixOS/nixpkgs/commit/25b89fa9476a7b011ed6582d8e36d9a4fb4f8411) rset: mark as broken
* [`8c66a654`](https://github.com/NixOS/nixpkgs/commit/8c66a65495aa851bfb1d5e3869f109efedf3f0ab) rapidjson: skip a regressed test
* [`8348b18c`](https://github.com/NixOS/nixpkgs/commit/8348b18c096d60e5b5821157f7e8df781330fed4) glibc: 2.38-0 -> 2.38-23
* [`e86dbb20`](https://github.com/NixOS/nixpkgs/commit/e86dbb20f7a2dc7401a5a7a3db6da70ff3d0a951) nixos/rl-2311: mention glibc 2.37 -> 2.38 bump
* [`86749222`](https://github.com/NixOS/nixpkgs/commit/8674922276e2b9e717d1f6886ba660c620586175) buildRustPackage: support custom cargo profiles
* [`dd458977`](https://github.com/NixOS/nixpkgs/commit/dd458977a005ed068d8b2fe1664049b9092e2d22) nixos/pam: clean up rules
* [`0f9d719d`](https://github.com/NixOS/nixpkgs/commit/0f9d719d8ab58642d30aec627aa628efe44aa207) nixos/pam: split rule lists into individual rules
* [`661c4097`](https://github.com/NixOS/nixpkgs/commit/661c4097a116584ed36b9015d819706306017ee6) python311Packages.mkdocs-jupyter: 0.24.2 -> 0.24.5
* [`805576cd`](https://github.com/NixOS/nixpkgs/commit/805576cd9ba841be85066569c3bae7165402855c) python3Packages.argon2-cffi: remove unnecessary cffi dependencies
* [`b55e27cc`](https://github.com/NixOS/nixpkgs/commit/b55e27cc5c8f71e6f80a8011b36c8383a2087eca) python3Packages.argon2-cffi-bindings: use system libargon2
* [`cfce6560`](https://github.com/NixOS/nixpkgs/commit/cfce6560db86b1690477b8e769084ceab55c0d66) python3Packages.argon2-cffi: remove Python 2 dependencies
* [`10680532`](https://github.com/NixOS/nixpkgs/commit/1068053205f6fec8be64d5f45781f51977537fc1) python3Packages.argon2-cffi: 21.3.0 -> 23.1.0
* [`adf495d5`](https://github.com/NixOS/nixpkgs/commit/adf495d55f131c11ae0c31a52154138836332258) python3Packages.argon2-cffi: use pytestCheckHook
* [`03d751a6`](https://github.com/NixOS/nixpkgs/commit/03d751a63467414f836f4ec8f5397919cca657ff) systemd: Remove duplicate meson flag for sysusers
* [`c1df604e`](https://github.com/NixOS/nixpkgs/commit/c1df604e9fbae74f7aa7530ec13e14a85758be61) rust: add rust.envVars
* [`67a4f828`](https://github.com/NixOS/nixpkgs/commit/67a4f828b46cc6d58fe11c975304331ea1e63909) rust: hooks: fix cross compilation
* [`9a6eb994`](https://github.com/NixOS/nixpkgs/commit/9a6eb9943553ed282a0add226fb96cc810da8c37) libdovi: use rust.envVars for cargo-c
* [`6b4ae0eb`](https://github.com/NixOS/nixpkgs/commit/6b4ae0ebc89dd2462e2da1250de33bd8f281dfd5) libimagequant: use rust.envVars for cargo-c
* [`33c0b7f1`](https://github.com/NixOS/nixpkgs/commit/33c0b7f11c14a84c428aa725619c059c3b5e86f3) rav1e: use rust.envVars
* [`25088d49`](https://github.com/NixOS/nixpkgs/commit/25088d49601adce395b6f9defe63b06706f8136d) ffmpeg: ffmpeg_5 → ffmpeg_6
* [`a87f6a00`](https://github.com/NixOS/nixpkgs/commit/a87f6a0054ae73efb98dc0f46f29090ce1f46aef) freerdp: ffmpeg → ffmpeg_5
* [`2598cb64`](https://github.com/NixOS/nixpkgs/commit/2598cb64c13cccc1b380beeaf6b8bba0a472327a) go, buildGoModule, buildGoPackage: default to 1.21
* [`e0379772`](https://github.com/NixOS/nixpkgs/commit/e0379772393d14090d1b112a7340bfefe580b0c9) postgresql: default to v15 in 23.11
* [`2302594f`](https://github.com/NixOS/nixpkgs/commit/2302594fce58e9d12bf39d129cf2b42b9a859d17) ruby.rubygems: 3.4.19 -> 3.4.20
* [`5ba0c43b`](https://github.com/NixOS/nixpkgs/commit/5ba0c43b462317c3c152541d145733645384fccc) bundler: 2.4.19 -> 2.4.20
* [`0668ba30`](https://github.com/NixOS/nixpkgs/commit/0668ba303ad04673bf542e134c1a8740551d2c0c) libredwg: fix missing include with glibc-2.38
* [`e016224a`](https://github.com/NixOS/nixpkgs/commit/e016224a79188a353b1ba046205906da41cce8de) swiftPackages.Foundation: fix build w/ glibc-2.38
* [`d77e1384`](https://github.com/NixOS/nixpkgs/commit/d77e13848dd63155aab17d87a3d2c53deb935614) python3: 3.10 -> 3.11
* [`f23415e0`](https://github.com/NixOS/nixpkgs/commit/f23415e0397f72c116d0d685603ce6aee7a123bc) python311Packages.cepa: pull in patch to fix python 3.11 build
* [`dbdc0095`](https://github.com/NixOS/nixpkgs/commit/dbdc0095802278f807979884bd555a2ab7df8a1e) cpplint: patch so that tests pass on python 3.11
* [`31a7d7ba`](https://github.com/NixOS/nixpkgs/commit/31a7d7ba4cc389d4fda0fba97d9be2e1ae393ea7) python310Packages.recordlinkage: add missing build dependencies
* [`00ee658d`](https://github.com/NixOS/nixpkgs/commit/00ee658dfbcaac61a80a0b7ba1bb33d5b5caca44) portmod: 2.1.0 -> 2.6.2
* [`e96bf1e6`](https://github.com/NixOS/nixpkgs/commit/e96bf1e688b0acc55ba1865589699c090dfb3cd3) python310Packages.s3transfer: 0.6.1 -> 0.6.2
* [`6086908c`](https://github.com/NixOS/nixpkgs/commit/6086908c9896b9a49e81cdb20867de6cf2e2832c) python310: 3.10.12 -> 3.10.13
* [`836da003`](https://github.com/NixOS/nixpkgs/commit/836da00391f30f7c28af0e9363fdcd7f5578f16c) python311: 3.11.4 -> 3.11.5
* [`7aaa5ba9`](https://github.com/NixOS/nixpkgs/commit/7aaa5ba972c17dcc45e72dfddfe1238d5d6d2089) python310Packages.pytest-aiohttp: 1.0.4 -> 1.0.5
* [`06da4d82`](https://github.com/NixOS/nixpkgs/commit/06da4d82233610a2d9f30dbb214a741ac48c9b83) python311Packages.build: 0.10.0 -> 1.0.3
* [`a84e337f`](https://github.com/NixOS/nixpkgs/commit/a84e337f30b80411160b0ba58b519478629d5305) python311Packages.setuptools: 68.0.0 -> 68.2.2
* [`f90f651d`](https://github.com/NixOS/nixpkgs/commit/f90f651d0f3dcc97c721135433a17c990eae9670) python311Packages.build: fix tests
* [`a14239a0`](https://github.com/NixOS/nixpkgs/commit/a14239a0ee66b69de5043bd17596713c5b17d671) python311Packages.pdm-backend: 2.1.4 -> 2.1.6
* [`7cdcc74c`](https://github.com/NixOS/nixpkgs/commit/7cdcc74c70235db62a9f3ee255b2b1959ca9b1dc) python311Packages.poetry-core: 1.6.1 -> 1.7.0
* [`bbbb7858`](https://github.com/NixOS/nixpkgs/commit/bbbb7858e5114481300336bc080f27c904a7f8e9) python311Packages.pytest: 7.4.0 -> 7.4.2
* [`133c3edc`](https://github.com/NixOS/nixpkgs/commit/133c3edc11105f0d590f6eb3ebb7a12bbf791a4e) python311Packages.hypothesis: 6.68.2 -> 6.84.3
* [`42323c67`](https://github.com/NixOS/nixpkgs/commit/42323c673c9370451f6f1396d9cbe4b8b7c487eb) python3Packages.accelerate: 0.21.0 -> 0.23.0
* [`6597fe2a`](https://github.com/NixOS/nixpkgs/commit/6597fe2a5e0efc963a403eb339e85ee93b3c6bcc) python3Packages.adafruit-nrfutil: 0.5.3.post17 -> 1
* [`a38e5de1`](https://github.com/NixOS/nixpkgs/commit/a38e5de1b174a78200f484afbf0740ae10109021) python3Packages.aenum: 3.1.12 -> 3.1.15
* [`fae629ed`](https://github.com/NixOS/nixpkgs/commit/fae629edac597cd3261445e0b2e97a33335e6a4c) python3Packages.afdko: 3.9.3 -> 4.0.0
* [`3fef82ed`](https://github.com/NixOS/nixpkgs/commit/3fef82ed7d199cf9b0d5950ee5a48cb4b3560da8) python3Packages.aioairq: 0.2.4 -> 0.3.0
* [`1af7d839`](https://github.com/NixOS/nixpkgs/commit/1af7d8391e224db41233be09288d01530a09daf6) python3Packages.aiobotocore: 2.5.2 -> 2.6.0
* [`a26be73f`](https://github.com/NixOS/nixpkgs/commit/a26be73f1ff9ba54dd0161515717bd8c9e514360) python3Packages.aiofiles: 23.1.0 -> 23.2.1
* [`2586fb44`](https://github.com/NixOS/nixpkgs/commit/2586fb4407a05cf4b8ef51977c29fbbd6cbaf530) python3Packages.aiogram: 2.25.1 -> 3.0.0
* [`a63983ca`](https://github.com/NixOS/nixpkgs/commit/a63983ca633c5d7ec7170252e6c6e3e6dc1ac33d) python3Packages.aiohttp-socks: 0.8.1 -> 0.8.3
* [`c96bcebe`](https://github.com/NixOS/nixpkgs/commit/c96bcebeb72844836c4759011a2c9f8764581109) python3Packages.aiojobs: 1.1.0 -> 1.2.0
* [`6b55ec34`](https://github.com/NixOS/nixpkgs/commit/6b55ec34b72c47db75c2f43f84f3cdc4d54320ca) python3Packages.aiosql: 8.0 -> 9.0
* [`38549800`](https://github.com/NixOS/nixpkgs/commit/3854980058e66019b87ee9b63cfe2fc7919eb1d1) python3Packages.alembic: 1.9.4 -> 1.12.0
* [`4f168bc1`](https://github.com/NixOS/nixpkgs/commit/4f168bc16ca49f22ee2628a7f2fe4afdb278b3e3) python3Packages.allure-behave: 2.12.0 -> 2.13.2
* [`39eb3230`](https://github.com/NixOS/nixpkgs/commit/39eb3230fffff823bb8adab2967cdf8f510f8253) python3Packages.allure-pytest: 2.12.0 -> 2.13.2
* [`74ceb33d`](https://github.com/NixOS/nixpkgs/commit/74ceb33d268ba71b67950a667270ce7aeae934d6) python3Packages.allure-python-commons: 2.12.0 -> 2.13.2
* [`ac40f0c3`](https://github.com/NixOS/nixpkgs/commit/ac40f0c3c910e71a9275bbca30b30b25e5e9a945) python3Packages.allure-python-commons-test: 2.12.0 -> 2.13.2
* [`7ce74035`](https://github.com/NixOS/nixpkgs/commit/7ce7403597a034b6927ea14a27f56dd15b7eb20d) python3Packages.amazon-ion: 0.9.3 -> 0.10.0
* [`5697f685`](https://github.com/NixOS/nixpkgs/commit/5697f68514914fd5f1fe4f29497e37b4a698d1c3) python3Packages.amazon-kclpy: 2.1.1 -> 2.1.3
* [`78c366e9`](https://github.com/NixOS/nixpkgs/commit/78c366e9a54d2c3516e5b937c5df828fbbf6b34a) python3Packages.ansible: 8.3.0 -> 8.4.0
* [`0579d86d`](https://github.com/NixOS/nixpkgs/commit/0579d86ddb461790dbfc8d3dd0d402da6ba90909) python3Packages.anthropic: 0.3.11 -> 0.3.13
* [`9cd45c14`](https://github.com/NixOS/nixpkgs/commit/9cd45c14f23b4174f0160123473566d3b2c6017a) python3Packages.anyio: 3.7.1 -> 4.0.0
* [`3bab3cba`](https://github.com/NixOS/nixpkgs/commit/3bab3cbabc2f1bd3360d2008a1210752c9baf213) python3Packages.aocd: 1.3.2 -> 2.0.1
* [`8fac1e05`](https://github.com/NixOS/nixpkgs/commit/8fac1e059167c77914b1f11e8c36dabf097b9f18) python3Packages.apache-beam: 2.45.0 -> 2.50.0
* [`740d2fd2`](https://github.com/NixOS/nixpkgs/commit/740d2fd261bdaf163a09409dc38811fbfc1db72f) python3Packages.apsw: 3.42.0.0 -> 3.43.1.0
* [`48c31d85`](https://github.com/NixOS/nixpkgs/commit/48c31d859edc5ec0b0eb97fd175177f8272c1390) python3Packages.argostranslate: 1.8.0 -> 1.8.1
* [`00ba00e2`](https://github.com/NixOS/nixpkgs/commit/00ba00e21c81defdbf7c97ce3f82e7b515b0e399) python3Packages.argos-translate-files: 1.1.3 -> 1.1.4
* [`2d7f268e`](https://github.com/NixOS/nixpkgs/commit/2d7f268ece6caaaaab1cfee3dd0179296f5f3fa4) python3Packages.ariadne: 0.18.1 -> 0.20.1
* [`9c3b68bd`](https://github.com/NixOS/nixpkgs/commit/9c3b68bd3e08698cc2b0a03e1c118a53691f9d8b) python3Packages.array-record: 0.4.0 -> 0.4.1
* [`280cf2b5`](https://github.com/NixOS/nixpkgs/commit/280cf2b576b18cc6bcb954444a804b634ad45546) python3Packages.arviz: 0.15.1 -> 0.16.1
* [`f7c20eb5`](https://github.com/NixOS/nixpkgs/commit/f7c20eb5e1eb60ec8b9babe514698e599f60162d) python3Packages.asana: 3.2.1 -> 4.0.11
* [`9c901e3a`](https://github.com/NixOS/nixpkgs/commit/9c901e3a03338c372c388d3958abb623b9b0ba67) python3Packages.asf-search: 6.3.1 -> 6.6.3
* [`7c0162d5`](https://github.com/NixOS/nixpkgs/commit/7c0162d554fbed20d3ae10ac130d661d87d0bf4b) python3Packages.asttokens: 2.2.1 -> 2.4.0
* [`c99ccbfe`](https://github.com/NixOS/nixpkgs/commit/c99ccbfe741132ddc466299e81ae5c8b204f8b38) python3Packages.async-timeout: 4.0.2 -> 4.0.3
* [`4f0073c7`](https://github.com/NixOS/nixpkgs/commit/4f0073c770104d5453e4356eef02c682e46e03d7) python3Packages.atpublic: 3.1.1 -> 4.0
* [`9191b1d7`](https://github.com/NixOS/nixpkgs/commit/9191b1d7d6d5f29fcca4589c6d20bd16af980276) python3Packages.auth0-python: 4.4.0 -> 4.4.2
* [`8b1444a0`](https://github.com/NixOS/nixpkgs/commit/8b1444a07633efe0ec20526dc83be2dcb86ff232) python3Packages.autoflake: 2.0.1 -> 2.2.1
* [`b47b2e9f`](https://github.com/NixOS/nixpkgs/commit/b47b2e9fe93e07e77ef27726ece3db621a8e45a6) python3Packages.autopep8: 2.0.2 -> 2.0.4
* [`02ae9852`](https://github.com/NixOS/nixpkgs/commit/02ae98522c217d2c724ad1fa2b98de1530bccb01) python3Packages.awkward-cpp: 22 -> 23
* [`c4bb82dc`](https://github.com/NixOS/nixpkgs/commit/c4bb82dc19017cf69fb5b77dde3888a2d266e8de) python3Packages.awkward: 2.3.1 -> 2.4.2
* [`95db7cad`](https://github.com/NixOS/nixpkgs/commit/95db7cad8c3a1b18f47bc85ed449598f28fe4ae7) python3Packages.aws-adfs: 2.2.1 -> 2.8.2
* [`882b6ad8`](https://github.com/NixOS/nixpkgs/commit/882b6ad890ad15f0461db81ccc92493cfcb3c904) python3Packages.awslambdaric: 2.0.0 -> 2.0.7
* [`ce862017`](https://github.com/NixOS/nixpkgs/commit/ce8620175fc202fc482dca6c639acbeae25a0c59) python3Packages.awswrangler: 3.3.0 -> 3.4.0
* [`a6e22b4a`](https://github.com/NixOS/nixpkgs/commit/a6e22b4a4034080d94b3e4622c8d3ef411e76371) python3Packages.aws-xray-sdk: 2.11.0 -> 2.12.0
* [`b6c6d314`](https://github.com/NixOS/nixpkgs/commit/b6c6d314fc4c7d4dc1f447cad20dcc7b7b5cc107) python3Packages.azure-cosmos: 3.2.0 -> 4.5.1
* [`ef96a35c`](https://github.com/NixOS/nixpkgs/commit/ef96a35c44e85b1976c611bcbe0b4439a10f34ef) python3Packages.azure-mgmt-trafficmanager: 1.0.0 -> 1.1.0
* [`115aa7ab`](https://github.com/NixOS/nixpkgs/commit/115aa7ab7e390102d8c27d406d8c5bff6cbd4038) python3Packages.bambi: 0.10.0 -> 0.12.0
* [`9fc72e6a`](https://github.com/NixOS/nixpkgs/commit/9fc72e6a63d12166dabad952815e021e4159b284) python3Packages.bash_kernel: 0.9.0 -> 0.9.1
* [`994d3fa6`](https://github.com/NixOS/nixpkgs/commit/994d3fa6298bcd5c297251a35badc836a0a4f331) python3Packages.bbox: 0.9.2 -> 0.9.4
* [`cfbd3bde`](https://github.com/NixOS/nixpkgs/commit/cfbd3bdea7eead7c21add3b7508091f8e0d75d45) python3Packages.beartype: 0.14.0 -> 0.15.0
* [`732f6bbd`](https://github.com/NixOS/nixpkgs/commit/732f6bbda6df02044e9cf0be7162f962efee2619) python3Packages.bitcoinlib: 0.12.0 -> 0.12.2
* [`48e092e5`](https://github.com/NixOS/nixpkgs/commit/48e092e5a57599437fa50636ac52fe8fa81b9ed0) python3Packages.bitstring: 4.0.2 -> 4.1.2
* [`377fecd2`](https://github.com/NixOS/nixpkgs/commit/377fecd2ff36d4575738da2dbc0a87056ed9d78d) python3Packages.blinker: 1.5 -> 1.6.2
* [`b5e33a96`](https://github.com/NixOS/nixpkgs/commit/b5e33a962c4d97ad184437b54798b0d631c032fa) python3Packages.blinkpy: 0.21.0 -> 0.22.0
* [`2ab1bb9f`](https://github.com/NixOS/nixpkgs/commit/2ab1bb9fc4b18ef539f98b58b595b6cf401c178a) python3Packages.blosc2: 2.1.1 -> 2.2.7
* [`f2fae464`](https://github.com/NixOS/nixpkgs/commit/f2fae4647a88f2d1a6f7f1a95f45893d85086a01) python3Packages.botocore: 1.31.9 -> 1.31.48
* [`23884a5a`](https://github.com/NixOS/nixpkgs/commit/23884a5a7561f52b5cc876ab68faf7b3e3eb6f57) python3Packages.bottle: 0.12.24 -> 0.12.25
* [`92ed0b8c`](https://github.com/NixOS/nixpkgs/commit/92ed0b8c8b30f0b4907529c20cbc2183f3d109c7) python3Packages.bottombar: 1.0 -> 2.1
* [`d10b952b`](https://github.com/NixOS/nixpkgs/commit/d10b952be9184d61b7a90c664bdc409f013d9c2f) python3Packages.bqplot: 0.12.39 -> 0.12.40
* [`3c858588`](https://github.com/NixOS/nixpkgs/commit/3c858588b85c8a61cdfa1b4bd07818a8bdcd1bf9) python3Packages.bqscales: 0.3.1 -> 0.3.3
* [`ac85b308`](https://github.com/NixOS/nixpkgs/commit/ac85b30804e28c0e9f1a3cf2694c52c4a5b82944) python3Packages.breathe: 4.34.0 -> 4.35.0
* [`c31e6e83`](https://github.com/NixOS/nixpkgs/commit/c31e6e834fcdc40d9c4663145e4b9671d1e38e7c) python3Packages.brian2: 2.5.1 -> 2.5.4
* [`ae0f16a2`](https://github.com/NixOS/nixpkgs/commit/ae0f16a255811468b976e4525cfd189f5626f705) python3Packages.brotli: 1.0.9 -> 1.1.0
* [`61fd67c8`](https://github.com/NixOS/nixpkgs/commit/61fd67c8ec73c5532b5c2ef6b7537fd00b5fc125) python3Packages.bytewax: 0.16.2 -> 0.17.1
* [`64d92587`](https://github.com/NixOS/nixpkgs/commit/64d9258787066f4ab47b7f3f8856c30e692a77f2) python3Packages.castepxbin: 0.2.0 -> 0.3.0
* [`d039a285`](https://github.com/NixOS/nixpkgs/commit/d039a28561aaab04632b726acc246a2b67cc12ed) python3Packages.catppuccin: 1.1.1 -> 1.3.2
* [`8506b9ff`](https://github.com/NixOS/nixpkgs/commit/8506b9ff14baad868c2fa7ae9ed0c0a7c90d078d) python3Packages.cfn-lint: 0.79.6 -> 0.79.11
* [`c21422ec`](https://github.com/NixOS/nixpkgs/commit/c21422ec24566e6c41634006dd89b26fd082875d) python3Packages.chardet: 5.1.0 -> 5.2.0
* [`b144da36`](https://github.com/NixOS/nixpkgs/commit/b144da36411e00bcc7d3e314713fa01f0af5dade) python3Packages.charset-normalizer: 3.0.1 -> 3.2.0
* [`104a1e15`](https://github.com/NixOS/nixpkgs/commit/104a1e15abdbda86014205360d43ece9f375baf6) python3Packages.cheroot: 9.0.0 -> 10.0.0
* [`2912181c`](https://github.com/NixOS/nixpkgs/commit/2912181ccb8c75b2344ad38c702ef26ab6395239) python3Packages.chia-rs: 0.2.0 -> 0.2.10
* [`b1335210`](https://github.com/NixOS/nixpkgs/commit/b1335210272bcb7c695dc6cfdb08d61fa3fbec96) python3Packages.circuitbreaker: 1.4.0 -> 2.0.0
* [`8fad29c5`](https://github.com/NixOS/nixpkgs/commit/8fad29c518e0ef0533508d98c640307b1b5df330) python3Packages.cirq-core: 1.1.0 -> 1.2.0
* [`5a7dfd97`](https://github.com/NixOS/nixpkgs/commit/5a7dfd9776e8a05d40210f7a7f7254b42dd489e6) python3Packages.cleanlab: 2.4.0 -> 2.5.0
* [`66ae840e`](https://github.com/NixOS/nixpkgs/commit/66ae840e93e775f7e75e4bf3e7bb2f8394f3e43f) python3Packages.clickgen: 2.1.3 -> 2.1.8
* [`04da19ff`](https://github.com/NixOS/nixpkgs/commit/04da19ff3f7691a8a10976b53dc3afdca04a0e35) python3Packages.clickhouse-cli: 0.3.8 -> 0.3.9
* [`d08f71ff`](https://github.com/NixOS/nixpkgs/commit/d08f71ff52f0e96b0ea35700254d6204fb917b00) python3Packages.clickhouse-connect: 0.6.8 -> 0.6.11
* [`4477982d`](https://github.com/NixOS/nixpkgs/commit/4477982d1cb898c205cf0e855c0ead3646db7d2f) python3Packages.click-odoo-contrib: 1.16.1 -> 1.17.0
* [`c8356772`](https://github.com/NixOS/nixpkgs/commit/c8356772ea01fcb902fbf78a815a3cc6d47652ae) python3Packages.cliff: 4.2.0 -> 4.3.0
* [`f0a4cc45`](https://github.com/NixOS/nixpkgs/commit/f0a4cc453781189c3b8878606e12dfa20911e7cd) python3Packages.cohere: 4.21 -> 4.26.1
* [`98d6f425`](https://github.com/NixOS/nixpkgs/commit/98d6f425687d3e2c71eb2ffae1de9169f406e7db) python3Packages.coinmetrics-api-client: 2023.8.30.20 -> 2023.9.11.14
* [`ae63bf70`](https://github.com/NixOS/nixpkgs/commit/ae63bf704461c5ac07385841e5b79ae197357be7) python3Packages.colored: 1.4.4 -> 2.2.3
* [`8a340413`](https://github.com/NixOS/nixpkgs/commit/8a340413fd7337839e2d118dc7c9f280f42a1a1b) python3Packages.comm: 0.1.3 -> 0.1.4
* [`c1115ace`](https://github.com/NixOS/nixpkgs/commit/c1115acec604a8451bc0f45ca173f780e5cd9479) python3Packages.compreffor: 0.5.4 -> 0.5.5
* [`ce508b54`](https://github.com/NixOS/nixpkgs/commit/ce508b54291aab1c31b179bb19650431a5cb3bc5) python3Packages.configparser: 5.3.0 -> 6.0.0
* [`f0962123`](https://github.com/NixOS/nixpkgs/commit/f0962123a6bdf9529f00307f042ce2a3632d24ad) python3Packages.contourpy: 1.0.7 -> 1.1.0
* [`15af33b7`](https://github.com/NixOS/nixpkgs/commit/15af33b7428e2f7a390ffbd3ba280f3268e8512c) python3Packages.correctionlib: 2.2.2 -> 2.3.3
* [`a046621e`](https://github.com/NixOS/nixpkgs/commit/a046621efdfa8d11a5bc430a7106f1174f109056) python3Packages.coverage: 7.2.1 -> 7.3.1
* [`b18bd308`](https://github.com/NixOS/nixpkgs/commit/b18bd308a667c5afe3892de8ed413526907fbd3c) python3Packages.crate: 0.31.1 -> 0.33.0
* [`bdfd57d9`](https://github.com/NixOS/nixpkgs/commit/bdfd57d929251f0c6bb061b8d45e454a59793587) python3Packages.cronsim: 2.3 -> 2.5
* [`6be0873b`](https://github.com/NixOS/nixpkgs/commit/6be0873b6d46a6df0a3e780113f25046f788f08e) python3Packages.cryptolyzer: 0.8.4 -> 0.10.0
* [`6f14e9a7`](https://github.com/NixOS/nixpkgs/commit/6f14e9a7389048c48c4f02605fa3bbeca9b54201) python311Packages.cryptodatahub: init at 0.10.1
* [`2c6809e4`](https://github.com/NixOS/nixpkgs/commit/2c6809e48225c5c0a76ddbdb6271b86738a95150) python3Packages.cryptoparser: 0.8.4 -> 0.10.0
* [`290d253c`](https://github.com/NixOS/nixpkgs/commit/290d253caa49eb0bc3e2046ccbeb33fc2c48ee74) python3Packages.cvxopt: 1.3.0 -> 1.3.2
* [`b77342a8`](https://github.com/NixOS/nixpkgs/commit/b77342a8c31d4a551285139dfcbb345a465ab1bf) python3Packages.cx-freeze: 6.14.4 -> 6.15.7
* [`5623075f`](https://github.com/NixOS/nixpkgs/commit/5623075fea45294e0228b3a75ad2eb547627c4ed) python3Packages.cytoolz: 0.12.1 -> 0.12.2
* [`0d987586`](https://github.com/NixOS/nixpkgs/commit/0d987586d1dc4bd648c09cdbdcce1c65c460a560) python3Packages.dalle-mini: 0.1.4 -> 0.1.5
* [`9bfc6113`](https://github.com/NixOS/nixpkgs/commit/9bfc61135fa0807bd96091773c8ad072c5c038da) python3Packages.dash: 2.10.2 -> 2.13.0
* [`737963ab`](https://github.com/NixOS/nixpkgs/commit/737963ab6bd3059f121826766320e67e276aba11) python3Packages.dask-awkward: 2023.8.1 -> 2023.9.1
* [`f4baa962`](https://github.com/NixOS/nixpkgs/commit/f4baa962ef10f8ec9dcbe84f0b6b99403cbeb1ea) python3Packages.databases: 0.7.0 -> 0.8.0
* [`994619c7`](https://github.com/NixOS/nixpkgs/commit/994619c736a1fbd27e98a521c3961e9953fe815d) python3Packages.databricks-sql-connector: 2.4.0 -> 2.9.3
* [`54e51c49`](https://github.com/NixOS/nixpkgs/commit/54e51c49a31e75067d22eb31bf3aafbb73b4d244) python3Packages.dataset: 1.6.0 -> 1.6.2
* [`e75adaa1`](https://github.com/NixOS/nixpkgs/commit/e75adaa1cd760814afc3b467dd9e355a2157cf4e) python3Packages.datasets: 2.14.4 -> 2.14.5
* [`a079000a`](https://github.com/NixOS/nixpkgs/commit/a079000ab9154a9fbda443735cb0a697108a8cf7) python3Packages.datauri: 1.1.0 -> 2.0.0
* [`63d8d014`](https://github.com/NixOS/nixpkgs/commit/63d8d0141db0b9441075881cc367db83d7b5b18c) python3Packages.dbt-bigquery: 1.5.3 -> 1.6.4
* [`a99480f3`](https://github.com/NixOS/nixpkgs/commit/a99480f317815616a6a1a80aec43e6809b9c1744) python3Packages.dbt-core: 1.5.5 -> 1.6.2
* [`2b67c194`](https://github.com/NixOS/nixpkgs/commit/2b67c194355e90fbea627188766936be3a5438f1) python3Packages.dbt-redshift: 1.5.8 -> 1.6.1
* [`7eb0fcab`](https://github.com/NixOS/nixpkgs/commit/7eb0fcabb38ef4e51804ff676e0ba153ee27ddde) python3Packages.dbt-snowflake: 1.5.2 -> 1.6.2
* [`a9a61914`](https://github.com/NixOS/nixpkgs/commit/a9a61914c00f750f6f8ed6c419e6cc49ad3ed0f8) python3Packages.deal: 4.24.0 -> 4.24.2
* [`05cb8d74`](https://github.com/NixOS/nixpkgs/commit/05cb8d74a087729a63f5c060c7f387930d9a7e6f) python3Packages.deap: 1.3.3 -> 1.4.1
* [`7d207840`](https://github.com/NixOS/nixpkgs/commit/7d2078409a4b056fd3b16b65f02ff54d21e0cde0) python3Packages.debugpy: 1.6.7.post1 -> 1.8.0
* [`19ab95a2`](https://github.com/NixOS/nixpkgs/commit/19ab95a25207444d63647e1b6d4370bce15012a0) python3Packages.deepdiff: 6.3.0 -> 6.4.1
* [`03245646`](https://github.com/NixOS/nixpkgs/commit/032456462aca6f560d04865894690719377922ac) python3Packages.defcon: 0.10.2 -> 0.10.3
* [`df6d6c7f`](https://github.com/NixOS/nixpkgs/commit/df6d6c7fc9a23c2b3b774146f5c7453fe67fb54a) python3Packages.deprecated: 1.2.13 -> 1.2.14
* [`3e459355`](https://github.com/NixOS/nixpkgs/commit/3e45935566d358977e954eab3e6b077681e070ad) python3Packages.devtools: 0.11.0 -> 0.12.2
* [`0a53a81b`](https://github.com/NixOS/nixpkgs/commit/0a53a81bd007214f0163068284fe5024545c0af9) python3Packages.diff-match-patch: 20200713 -> 20230430
* [`abcfbd44`](https://github.com/NixOS/nixpkgs/commit/abcfbd44616e6ec00e8f7e7d8bf909cf1daf011d) python3Packages.dill: 0.3.6 -> 0.3.7
* [`3e57c65b`](https://github.com/NixOS/nixpkgs/commit/3e57c65bacbc5d2c34a9db414714bb9c270e43ce) python3Packages.dinghy: 1.2.0 -> 1.3.0
* [`6babcdba`](https://github.com/NixOS/nixpkgs/commit/6babcdba48c23f33fbd5297a6bb8d1062673627c) python3Packages.distlib: 0.3.6 -> 0.3.7
* [`d419e300`](https://github.com/NixOS/nixpkgs/commit/d419e300558ad684473fa22aff5179860515fc39) python3Packages.distrax: 0.1.3 -> 0.1.4
* [`d4a78112`](https://github.com/NixOS/nixpkgs/commit/d4a78112636208228793894bd9f9287425103a0b) python3Packages.django-anymail: 9.0 -> 10.1
* [`f86c2ccc`](https://github.com/NixOS/nixpkgs/commit/f86c2ccc4f9acb51b527f17326da6919d10c67a7) python3Packages.django-environ: 0.9.0 -> 0.11.2
* [`939aa839`](https://github.com/NixOS/nixpkgs/commit/939aa839778a317386fccb436509aae0fed022e4) python3Packages.django-extensions: 3.2.1 -> 3.2.3
* [`a676d938`](https://github.com/NixOS/nixpkgs/commit/a676d9380639cb5a4cf62df502a564f23e0a1f18) python3Packages.django-filter: 22.1 -> 23.2
* [`ff728fe8`](https://github.com/NixOS/nixpkgs/commit/ff728fe8b18d75055d30a6e81cebd3214ba4a7ed) python3Packages.django-hijack: 3.3.0 -> 3.4.1
* [`9636681b`](https://github.com/NixOS/nixpkgs/commit/9636681b9cee32b9fb475a8e184c7e60bf1ed819) python3Packages.django-import-export: 3.2.0 -> 3.3.1
* [`42dcc556`](https://github.com/NixOS/nixpkgs/commit/42dcc556e5f41f1ff8f9cf15b16d8180c3660c5f) python3Packages.django-redis: 5.2.0 -> 5.3.0
* [`acb5ad0b`](https://github.com/NixOS/nixpkgs/commit/acb5ad0b2e23057c32c962ee6ddf98144cca286f) python3Packages.django-storages: 1.13.2 -> 1.14
* [`d9384600`](https://github.com/NixOS/nixpkgs/commit/d9384600533279f5a1c8b1904fa95e391600f711) python3Packages.django-stubs: 4.2.3 -> 4.2.4
* [`e30d4eda`](https://github.com/NixOS/nixpkgs/commit/e30d4edaf04c618a563b8281c5a1f8e9234e2621) python3Packages.django-taggit: 3.1.0 -> 4.0.0
* [`b95727f3`](https://github.com/NixOS/nixpkgs/commit/b95727f367249b5283463734309401e7e2b2891f) python3Packages.dj-rest-auth: 4.0.1 -> 5.0.0
* [`1b3f4458`](https://github.com/NixOS/nixpkgs/commit/1b3f4458eefc3a275bd2de41d096caf782d91a1c) python3Packages.docformatter: 1.6.4 -> 1.7.5
* [`0b647074`](https://github.com/NixOS/nixpkgs/commit/0b6470747786aa0096d47a59d359632344f2f55a) python3Packages.docker: 6.0.1 -> 6.1.3
* [`adbb5737`](https://github.com/NixOS/nixpkgs/commit/adbb57375a63bfa57e6cc3100df6573d6a04fc4c) python3Packages.docopt-ng: 0.8.1 -> 0.9.0
* [`2b1ad993`](https://github.com/NixOS/nixpkgs/commit/2b1ad99374ed5af40dd3603b63b12ad11eb19af3) python3Packages.docutils: 0.19 -> 0.20.1
* [`7c198d9e`](https://github.com/NixOS/nixpkgs/commit/7c198d9e968a54e0f51102460294f9c809dec9a6) python3Packages.dogpile-cache: 1.2.0 -> 1.2.2
* [`942a15a2`](https://github.com/NixOS/nixpkgs/commit/942a15a274de315bc293b24666e87db6e23b9205) python3Packages.draftjs-exporter: 2.1.7 -> 5.0.0
* [`b249bad8`](https://github.com/NixOS/nixpkgs/commit/b249bad85a5746ccac8e63cb47df7f0edc70150a) python3Packages.duckdb-engine: 0.7.3 -> 0.9.2
* [`7e60aedc`](https://github.com/NixOS/nixpkgs/commit/7e60aedcca28eb44435c7237799bbcbf47076b23) python3Packages.duo-client: 4.7.1 -> 5.0.1
* [`e361bc26`](https://github.com/NixOS/nixpkgs/commit/e361bc26241cde96ead8a195e2502269543c2339) python3Packages.dynalite-devices: 0.1.48 -> 0.47
* [`c99859ce`](https://github.com/NixOS/nixpkgs/commit/c99859ce69aec9c22c39f83565d7b9faa18d9771) python3Packages.editables: 0.3 -> 0.5
* [`9b46e6be`](https://github.com/NixOS/nixpkgs/commit/9b46e6be71d71ac42b3b0b7aba74cf0fcfc49ed6) python3Packages.einops: 0.6.0 -> 0.6.1
* [`4705461a`](https://github.com/NixOS/nixpkgs/commit/4705461a9b4e225b4627c682a13c4da4dbbbb8f9) python3Packages.elasticsearch: 7.16.3 -> 8.9.0
* [`b63cb6f0`](https://github.com/NixOS/nixpkgs/commit/b63cb6f0187ae53cef239a4b2e9e1a5361da5545) python3Packages.elasticsearch-dsl: 7.4.0 -> 8.9.0
* [`ea0d007b`](https://github.com/NixOS/nixpkgs/commit/ea0d007b4a0b85a047af812111d84188f07c317d) python3Packages.email-validator: 1.3.1 -> 2.0.0
* [`9d211a8c`](https://github.com/NixOS/nixpkgs/commit/9d211a8cdbc6c98876dd34a292e710ae1b1680be) python3Packages.envisage: 6.1.0 -> 7.0.3
* [`72c4aa40`](https://github.com/NixOS/nixpkgs/commit/72c4aa40b7a6b60be95eed40ed00ed32df0daf9a) python3Packages.eradicate: 2.2.0 -> 2.3.0
* [`43fd8d29`](https://github.com/NixOS/nixpkgs/commit/43fd8d29f8c42e019cf11cf3e7a358f48b630577) python3Packages.execnet: 1.9.0 -> 2.0.2
* [`463a8396`](https://github.com/NixOS/nixpkgs/commit/463a8396ce09f688529447cd50ffac6953e96bf3) python3Packages.ezyrb: 1.3.0.post2305 -> 1.3.0.post2309
* [`299f3a88`](https://github.com/NixOS/nixpkgs/commit/299f3a889661dd26078ee9b007af2dd597785efb) python3Packages.faadelays: 0.0.7 -> 2023.8.0
* [`1733ac71`](https://github.com/NixOS/nixpkgs/commit/1733ac717b6d9ab5235aed2f2f345367223c123c) python3Packages.faker: 17.3.0 -> 19.6.1
* [`d4d5239e`](https://github.com/NixOS/nixpkgs/commit/d4d5239e1bf2486c7d80f256acb93a2db5fcc3b4) python3Packages.fastapi: 0.95.2 -> 0.103.1
* [`4b129dce`](https://github.com/NixOS/nixpkgs/commit/4b129dcef2a94a1e5a3f264681727dbccd76d00a) python3Packages.fastavro: 1.8.2 -> 1.8.3
* [`19d91b01`](https://github.com/NixOS/nixpkgs/commit/19d91b01ca45575f12ea6f9d258fbc84b2d760de) python3Packages.faster-whisper: 0.7.1 -> 0.8.0
* [`b9b9f0d5`](https://github.com/NixOS/nixpkgs/commit/b9b9f0d5f03c081e85a306f607571ec8519165d4) python3Packages.filelock: 3.12.2 -> 3.12.4
* [`44be9451`](https://github.com/NixOS/nixpkgs/commit/44be94515b9549eb67d4d0aefd25706318195b60) python3Packages.finvizfinance: 0.14.5 -> 0.14.6
* [`30373713`](https://github.com/NixOS/nixpkgs/commit/30373713b14dff1cd5fe1ff7f731878010a10403) python3Packages.flask-appbuilder: 4.3.1 -> 4.3.6
* [`c43b406b`](https://github.com/NixOS/nixpkgs/commit/c43b406bdd1ff1b5b2418ed19f193b079ffb6d08) python3Packages.flask: 2.2.5 -> 2.3.3
* [`c87f464e`](https://github.com/NixOS/nixpkgs/commit/c87f464efa105088160ebc17f0f71cb9d986a66f) python3Packages.flask-limiter: 3.3.1 -> 3.5.0
* [`d04ed91a`](https://github.com/NixOS/nixpkgs/commit/d04ed91a7dd49053457af3550c364db1293b04d1) python3Packages.flask-migrate: 4.0.4 -> 4.0.5
* [`30a98e35`](https://github.com/NixOS/nixpkgs/commit/30a98e35b2221796dd9544dfe8c09a7ba640f6be) python3Packages.flask-security-too: 5.1.2 -> 5.3.0
* [`e3c82268`](https://github.com/NixOS/nixpkgs/commit/e3c8226822304107b0d05243de79ec46e6bf1e16) python3Packages.flask-sqlalchemy: 3.0.3 -> 3.1.1
* [`2486099a`](https://github.com/NixOS/nixpkgs/commit/2486099a89ac379feaea9a4bc80bbfe337dddfc3) python3Packages.flax: 0.6.5 -> 0.7.4
* [`c1bcce3b`](https://github.com/NixOS/nixpkgs/commit/c1bcce3bacbfc6ec8e84476b30d5a66015fc4600) python3Packages.flet-core: 0.7.4 -> 0.10.1
* [`54acf881`](https://github.com/NixOS/nixpkgs/commit/54acf881fe49e73d29c9f320a520f15baa233732) python3Packages.flet: 0.7.4 -> 0.10.1
* [`a4d625fe`](https://github.com/NixOS/nixpkgs/commit/a4d625fe7c70f8b7224e952a6a5e0c1e1ff5a742) python3Packages.flow-record: 3.11 -> 3.12
* [`edbbbdec`](https://github.com/NixOS/nixpkgs/commit/edbbbdecbcd54e12f8b41180a1b4fac8e018b476) python3Packages.fontmake: 3.5.1 -> 3.7.1
* [`5f92ed96`](https://github.com/NixOS/nixpkgs/commit/5f92ed9650fb22ed99ed209ac6a48b67bb2ccbc3) python3Packages.fonttools: 4.38.0 -> 4.42.1
* [`db2078b1`](https://github.com/NixOS/nixpkgs/commit/db2078b108e7dd6fc45747963f251c1a9e4b883f) python3Packages.formulaic: 0.5.2 -> 0.6.4
* [`66b971f2`](https://github.com/NixOS/nixpkgs/commit/66b971f2a1c2e6dbedc516588fdf3a919470d4a0) python3Packages.frozenlist: 1.3.3 -> 1.4.0
* [`5fd1c736`](https://github.com/NixOS/nixpkgs/commit/5fd1c736ecad1e7fd00581b5e2bf358b828d8e8c) python3Packages.fugashi: 1.2.1 -> 1.3.0
* [`d8fd91aa`](https://github.com/NixOS/nixpkgs/commit/d8fd91aae0a3cd9d8541eb3cbc4492252bef309e) python3Packages.gentools: 1.1.0 -> 1.2.1
* [`6f8245d4`](https://github.com/NixOS/nixpkgs/commit/6f8245d4d9891db90277b313163f4a4502506c23) python3Packages.geoalchemy2: 0.13.3 -> 0.14.1
* [`660c096b`](https://github.com/NixOS/nixpkgs/commit/660c096b8c103fa4312b59ff17d322361ab3f738) python3Packages.gitpython: 3.1.33 -> 3.1.35
* [`4854d996`](https://github.com/NixOS/nixpkgs/commit/4854d996d16c5f81675f3ac947a0bf8c2e32d95c) python3Packages.glean-parser: 7.2.1 -> 9.0.0
* [`eea3c156`](https://github.com/NixOS/nixpkgs/commit/eea3c156c950b0e6b85701922932a05cab7c35fe) python3Packages.glfw: 2.5.9 -> 2.6.2
* [`bd1c416d`](https://github.com/NixOS/nixpkgs/commit/bd1c416dbb49eacd9da3779a26e456a6429d366d) python3Packages.google-api-python-client: 2.97.0 -> 2.99.0
* [`988637c2`](https://github.com/NixOS/nixpkgs/commit/988637c29ad06751087f4c8b9a54be9330c5b3d1) python3Packages.googleapis-common-protos: 1.58.0 -> 1.60.0
* [`364b9b8f`](https://github.com/NixOS/nixpkgs/commit/364b9b8fcc6f0606915d851533e51ba2403a0a52) python3Packages.google-auth-oauthlib: 1.0.0 -> 1.1.0
* [`7bf753ea`](https://github.com/NixOS/nixpkgs/commit/7bf753ea01f4c5f89ac3d6d04b5554de882d8357) python3Packages.gphoto2: 2.3.4 -> 2.5.0
* [`f184e773`](https://github.com/NixOS/nixpkgs/commit/f184e77321b5fbfc7865e485f159c565c7d6f0ad) python3Packages.gptcache: 0.1.37 -> 0.1.41
* [`f31870f6`](https://github.com/NixOS/nixpkgs/commit/f31870f64e65b8d7197b426f1f675d2a3ddc389e) python3Packages.gpustat: 1.1 -> 1.1.1
* [`b4bdb784`](https://github.com/NixOS/nixpkgs/commit/b4bdb7847e0cf152edbeb97e3e4d753264e16ca0) python3Packages.gradio: 3.43.1 -> 3.44.3
* [`198c03ec`](https://github.com/NixOS/nixpkgs/commit/198c03eca810a488f67cf7814f81c237cfb4b139) python3Packages.graspologic: 2.0.1 -> 3.2.0
* [`4c93a7eb`](https://github.com/NixOS/nixpkgs/commit/4c93a7eb8354b3d9bc7d334fb1da07b4a424cd83) python3Packages.grpcio-health-checking: 1.56.2 -> 1.58.0
* [`e4e910fc`](https://github.com/NixOS/nixpkgs/commit/e4e910fc9fa4f2cd2b0a1d4353e2b24d02129cfa) python3Packages.grpcio-status: 1.57.0 -> 1.58.0
* [`9043338f`](https://github.com/NixOS/nixpkgs/commit/9043338f9c5d5cd95d6b3c0844a7ff062f0de94e) python3Packages.grpcio-testing: 1.57.0 -> 1.58.0
* [`8a42a8f0`](https://github.com/NixOS/nixpkgs/commit/8a42a8f04dbb99b4b7aacac1ffb8d975ad31e1b9) python3Packages.grpcio-tools: 1.57.0 -> 1.58.0
* [`189036b1`](https://github.com/NixOS/nixpkgs/commit/189036b128001bb9f680adcb895ababa76b93aa7) python3Packages.gssapi: 1.8.2 -> 1.8.3
* [`4a015d4a`](https://github.com/NixOS/nixpkgs/commit/4a015d4ab9c89e7c808daf1002f7616378ff16e7) python3Packages.h5netcdf: 1.1.0 -> 1.2.0
* [`5105b6f0`](https://github.com/NixOS/nixpkgs/commit/5105b6f08e5e4e2bdf9526c7634ed6b4e8b9b24c) python3Packages.h5py: 3.8.0 -> 3.9.0
* [`c9aa0255`](https://github.com/NixOS/nixpkgs/commit/c9aa0255e66f6e534bd571c40cddbef68ed28a91) python3Packages.hacking: 5.0.0 -> 6.0.1
* [`298cb452`](https://github.com/NixOS/nixpkgs/commit/298cb4522f3c702919dd3613d3280e2c4a935b34) python3Packages.hatch-jupyter-builder: 0.8.2 -> 0.8.3
* [`4f29b6dd`](https://github.com/NixOS/nixpkgs/commit/4f29b6dd64d749d1de1630db822f077dc29ba7fe) python3Packages.hatch-nodejs-version: 0.3.1 -> 0.3.2
* [`ba22ff36`](https://github.com/NixOS/nixpkgs/commit/ba22ff366f1f7d24537bbe7e5a2679e2ecff36a4) python3Packages.hatch-requirements-txt: 0.3.0 -> 0.4.0
* [`154938c6`](https://github.com/NixOS/nixpkgs/commit/154938c6a5b83e46ea2510db2d17ed3f68de3ad8) python3Packages.hdbscan: 0.8.28 -> 0.8.33
* [`2505ae8a`](https://github.com/NixOS/nixpkgs/commit/2505ae8a42081f34537d602b8453e9420c82100f) python3Packages.hdf5plugin: 4.1.3 -> 4.2.0
* [`5d0ae485`](https://github.com/NixOS/nixpkgs/commit/5d0ae485dcb725f65890a5943a9315ba2c27161d) python3Packages.holidays: 0.29 -> 0.32
* [`986a7985`](https://github.com/NixOS/nixpkgs/commit/986a7985530e13ec2f4e37500e4d5a01ba36be29) python311Packages.flasgger: init at 0.9.5
* [`00575d3b`](https://github.com/NixOS/nixpkgs/commit/00575d3be2276e68902fff91eeae0fec3bc29d9b) python3Packages.httpbin: 0.7.0 -> 0.10.1
* [`878f1dac`](https://github.com/NixOS/nixpkgs/commit/878f1dac8d852b764f5a01454aa487ae6473f0d9) python3Packages.httpcore: 0.17.2 -> 0.18.0
* [`d5e357c0`](https://github.com/NixOS/nixpkgs/commit/d5e357c0ec555351d82641ec829aeedb58b740f2) python3Packages.httpx: 0.24.1 -> 0.25.0
* [`06b319c8`](https://github.com/NixOS/nixpkgs/commit/06b319c8f07c7c8f403c9188996c1b62745b2dbb) python3Packages.httpx-socks: 0.7.6 -> 0.7.8
* [`217c4c16`](https://github.com/NixOS/nixpkgs/commit/217c4c162f80195c1c86435ba354e449b3eee6c8) python3Packages.huggingface-hub: 0.16.4 -> 0.17.0
* [`525a7ff7`](https://github.com/NixOS/nixpkgs/commit/525a7ff7e7ee0b07930bf2a5ae7cbd20061b5d76) python3Packages.hupper: 1.11 -> 1.12
* [`b319a35b`](https://github.com/NixOS/nixpkgs/commit/b319a35bd8225832212fd47eb6a0a89f6281fc3e) python3Packages.hvac: 1.2.0 -> 1.2.1
* [`f6efff3b`](https://github.com/NixOS/nixpkgs/commit/f6efff3bab3c2eb5a329654d87d4efcfac3275e8) python3Packages.hypothesis-auto: 1.1.4 -> 1.1.5
* [`390d6e9c`](https://github.com/NixOS/nixpkgs/commit/390d6e9c4689c930a38d06cdadc87633fddf22d8) python3Packages.hyppo: 0.3.2 -> 0.4.0
* [`b9f2aa31`](https://github.com/NixOS/nixpkgs/commit/b9f2aa31ae111f656cea317717a9ffe4b4b5d313) python3Packages.ifcopenshell: 210410 -> 230915
* [`518b999a`](https://github.com/NixOS/nixpkgs/commit/518b999ae3f484d0043d1fc3b46c6095e3cd703d) python3Packages.image-go-nord: 0.1.5 -> 0.1.7
* [`2e0ebb17`](https://github.com/NixOS/nixpkgs/commit/2e0ebb17cab71d44d9c5f87ace1cfa478dc178fa) python3Packages.imageio: 2.28.1 -> 2.31.3
* [`a43bae5a`](https://github.com/NixOS/nixpkgs/commit/a43bae5ae44a52d77e476a86bd8f826a46b8803d) python3Packages.imageio-ffmpeg: 0.4.8 -> 0.4.9
* [`0b73de44`](https://github.com/NixOS/nixpkgs/commit/0b73de4439bb5271f4524c4f1ee92ff3bcae08c7) python3Packages.iminuit: 2.21.3 -> 2.24.0
* [`3c868352`](https://github.com/NixOS/nixpkgs/commit/3c86835248f537ff4cececc79df2346123d76645) python3Packages.importlib-resources: 5.12.0 -> 6.0.1
* [`e6fe97b9`](https://github.com/NixOS/nixpkgs/commit/e6fe97b972446d3d9ecf9ad905c8bdf5b58292fd) python3Packages.inflect: 6.0.4 -> 7.0.0
* [`62a975fb`](https://github.com/NixOS/nixpkgs/commit/62a975fb4915f8606fc6012d3549ec0afd256b69) python3Packages.ipykernel: 6.21.2 -> 6.25.2
* [`0408f7e5`](https://github.com/NixOS/nixpkgs/commit/0408f7e5ab6a22d7b63520d3a6dab5d4f1b2448c) python3Packages.ipython: 8.11.0 -> 8.15.0
* [`d41ef584`](https://github.com/NixOS/nixpkgs/commit/d41ef584108c61f0df8cb7af841ddb1026010fe5) python3Packages.ipywidgets: 8.0.6 -> 8.1.1
* [`fff4fd6c`](https://github.com/NixOS/nixpkgs/commit/fff4fd6ca8c06dc13a64851cc39760c9ce4f45c8) python3Packages.iso8601: 1.1.0 -> 2.0.0
* [`ac754926`](https://github.com/NixOS/nixpkgs/commit/ac7549262912fb7d2522c7408a0302e8c11ab41f) python3Packages.jaraco-classes: 3.1.1 -> 3.3.0
* [`21d90b6b`](https://github.com/NixOS/nixpkgs/commit/21d90b6be6754ac92242db6e18087b84f77574ff) python3Packages.jaraco-functools: 3.6.0 -> 3.9.0
* [`57becb34`](https://github.com/NixOS/nixpkgs/commit/57becb34f249ac5eacdca2eeb47fbabe1f8322d9) python3Packages.jaraco-itertools: 6.2.1 -> 6.4.1
* [`6265122b`](https://github.com/NixOS/nixpkgs/commit/6265122b3f31fad045ebc534befd3088bdce22c3) python3Packages.jaxopt: 0.5.5 -> 0.8
* [`4f842d36`](https://github.com/NixOS/nixpkgs/commit/4f842d36d25f8ac7f23d34b46e3371450cb1c02e) python3Packages.jedi-language-server: 0.40.0 -> 0.41.0
* [`f63e8f4c`](https://github.com/NixOS/nixpkgs/commit/f63e8f4ca9168511609a42b964e439f4e83b4ae7) python3Packages.jiwer: 3.0.2 -> 3.0.3
* [`618254d0`](https://github.com/NixOS/nixpkgs/commit/618254d0f6da5ea81be53a9f2ba10327a92d239d) python3Packages.jsonpickle: 3.0.1 -> 3.0.2
* [`d4d07bf4`](https://github.com/NixOS/nixpkgs/commit/d4d07bf40c54df322b0336120116a63d0c80cec5) python3Packages.jsonpointer: 2.3 -> 2.4
* [`ed4c01f0`](https://github.com/NixOS/nixpkgs/commit/ed4c01f01c7406e7f5f8e4c9788f44042d8ef9ec) python3Packages.jsonschema: 4.18.4 -> 4.19.0
* [`b9f6dfd2`](https://github.com/NixOS/nixpkgs/commit/b9f6dfd23c4cbff77071b36aaa17b75ec00e0c7c) python3Packages.jsonschema-spec: 0.2.3 -> 0.2.4
* [`8f36a246`](https://github.com/NixOS/nixpkgs/commit/8f36a246f8a072081cec9ac6b1acd8154dea9e7a) python3Packages.jupyter_client: 8.0.3 -> 8.3.1
* [`e57a600f`](https://github.com/NixOS/nixpkgs/commit/e57a600fc32e3305ffcc1d1b74d36c0d6114a3a5) python3Packages.jupyter-collaboration: 1.1.0 -> 1.2.0
* [`5a5b19de`](https://github.com/NixOS/nixpkgs/commit/5a5b19deeba87ee8f54eca7f4f89ef69e9e14eb3) python3Packages.jupyter-core: 5.2.0 -> 5.3.1
* [`b984e576`](https://github.com/NixOS/nixpkgs/commit/b984e5764f896443759c153121a000ee1811a3ae) python3Packages.jupyter-events: 0.6.3 -> 0.7.0
* [`1702e3e5`](https://github.com/NixOS/nixpkgs/commit/1702e3e5e354f292db825b76eae6779f7d038aee) python3Packages.jupyterlab: 4.0.3 -> 4.0.6
* [`bae333d8`](https://github.com/NixOS/nixpkgs/commit/bae333d8ad9e4a933b0649357065adf4a0b92488) python3Packages.jupyterlab-git: 0.41.0 -> 0.42.0
* [`0239f7b3`](https://github.com/NixOS/nixpkgs/commit/0239f7b3e34830e22cae3f68107cac235ec4c176) python3Packages.jupyterlab_server: 2.24.0 -> 2.25.0
* [`c47685b2`](https://github.com/NixOS/nixpkgs/commit/c47685b223977585e6e657c8156181341fbfb0fb) python3Packages.jupyterlab-widgets: 3.0.7 -> 3.0.9
* [`cd1b2049`](https://github.com/NixOS/nixpkgs/commit/cd1b2049e0bd97682bde4b7d27e0fea270d66928) python3Packages.justnimbus: 0.6.0 -> 0.7.2
* [`7f839183`](https://github.com/NixOS/nixpkgs/commit/7f83918396be90c9e6504735ad8dc081111d5163) python3Packages.kaggle: 1.5.13 -> 1.5.16
* [`ea62d5a2`](https://github.com/NixOS/nixpkgs/commit/ea62d5a2ff4412d1e38cb7632d363ecfcfc2f312) python3Packages.sapi-python-client: 0.5.0 -> 0.7.1
* [`18309a8c`](https://github.com/NixOS/nixpkgs/commit/18309a8c4189058e992978f0b3468830e8f6bcfe) python3Packages.keras: 2.11.0 -> 2.14.0
* [`e70d9773`](https://github.com/NixOS/nixpkgs/commit/e70d9773116a7c710562e2fcaa24ddcbdbd4c3e9) python3Packages.keystoneauth1: 5.1.2 -> 5.3.0
* [`63570fba`](https://github.com/NixOS/nixpkgs/commit/63570fbaaffcc427d706f9d6d4f3295547339f15) python3Packages.kiwisolver: 1.4.4 -> 1.4.5
* [`6d0ad263`](https://github.com/NixOS/nixpkgs/commit/6d0ad263ecabf5b50cb76d13600f7da39e0b7bfe) python3Packages.kubernetes: 26.1.0 -> 27.2.0
* [`6882f66a`](https://github.com/NixOS/nixpkgs/commit/6882f66aeec0cf74c052799d3c5f405130c3e754) python3Packages.labelbox: 3.38.0 -> 3.52.0
* [`e0cec355`](https://github.com/NixOS/nixpkgs/commit/e0cec3554dcf1c53410ad976753f9ed93fccef2e) python3Packages.labgrid: 0.4.1 -> 23.0.3
* [`38130532`](https://github.com/NixOS/nixpkgs/commit/3813053276429d143985bf1eb4c176f8ebeb39c9) python3Packages.langchain: 0.0.285 -> 0.0.291
* [`1723f25c`](https://github.com/NixOS/nixpkgs/commit/1723f25cdf1e9b0e45fee916783c33cef4f95752) python3Packages.langchainplus-sdk: 0.0.20 -> 0.0.21
* [`ad5c1e38`](https://github.com/NixOS/nixpkgs/commit/ad5c1e380252030bab308ca8e521ab4c9f901501) python3Packages.langsmith: 0.0.35 -> 0.0.37
* [`158da247`](https://github.com/NixOS/nixpkgs/commit/158da247b6ca5ea3e86903d56a6f56df57b3e2b1) python3Packages.lark: 1.1.5 -> 1.1.7
* [`bccd14d7`](https://github.com/NixOS/nixpkgs/commit/bccd14d7c855a1499f6ae198cbaf87ef47803db0) python3Packages.ledger-bitcoin: 0.2.1 -> 0.2.2
* [`338a12fa`](https://github.com/NixOS/nixpkgs/commit/338a12fa3afffd5d289a0671dd2c40e431a217fd) python3Packages.ledgercomm: 1.1.2 -> 1.2.0
* [`c19b8ff9`](https://github.com/NixOS/nixpkgs/commit/c19b8ff91f82e7b41f89c0bc72964176b75dbaa9) python3Packages.libarchive-c: 4.0 -> 5.0
* [`b5b1507a`](https://github.com/NixOS/nixpkgs/commit/b5b1507a027da8539cc4ac7c95ef33ef43c69abe) python3Packages.librosa: 0.10.0 -> 0.10.1
* [`8db51662`](https://github.com/NixOS/nixpkgs/commit/8db51662f206d99873fbc1d28d5461a0dd69417a) python3Packages.lightgbm: 3.3.5 -> 4.1.0
* [`2a3a78f6`](https://github.com/NixOS/nixpkgs/commit/2a3a78f699a6d70d1acf8a80d619d1b61bdf8697) python3Packages.limits: 3.5.0 -> 3.6.0
* [`5822c0e8`](https://github.com/NixOS/nixpkgs/commit/5822c0e87526643f7a1dd33439f04adc50b0337e) python3Packages.linear_operator: 0.5.1 -> 0.5.2
* [`88fbe414`](https://github.com/NixOS/nixpkgs/commit/88fbe4147214af6ad7dc77d640a5aac5aa4de50d) python3Packages.linkify-it-py: 2.0.0 -> 2.0.2
* [`c91cbeab`](https://github.com/NixOS/nixpkgs/commit/c91cbeab267ecdbed1b756f7c78807deeccd74a4) python3Packages.linode-api: 5.0.0 -> 5.7.2
* [`91a98133`](https://github.com/NixOS/nixpkgs/commit/91a98133db0acf6972a083453020ec7d076bc81a) python3Packages.lit: 15.0.6 -> 16.0.6
* [`ce37d02f`](https://github.com/NixOS/nixpkgs/commit/ce37d02ffad2a185f2e2217af7aeec032e605b88) python3Packages.localstack-ext: 1.4.0 -> 2.2.0
* [`3f02f386`](https://github.com/NixOS/nixpkgs/commit/3f02f3869c8f0e7116d8daf8112c161c389d849b) python3Packages.loguru: 0.7.0 -> 0.7.2
* [`5d4811f9`](https://github.com/NixOS/nixpkgs/commit/5d4811f9a3fb7b6c4bfca7549bbcb1de79d91642) python3Packages.m2r: 0.2.1 -> 0.3.1
* [`d944dc08`](https://github.com/NixOS/nixpkgs/commit/d944dc08fabae2dffd91314c445ef980bdc41ebf) python3Packages.magic-wormhole: 0.12.0 -> 0.13.0
* [`4fed536c`](https://github.com/NixOS/nixpkgs/commit/4fed536c96b7b214600b7eac5ae43c8878442eca) python3Packages.manifestoo-core: 0.11.0 -> 1.0
* [`d25392b3`](https://github.com/NixOS/nixpkgs/commit/d25392b33741c6e3f58514e186bb623725d64d43) python3Packages.markdown-it-py: 2.2.0 -> 3.0.0
* [`3d4b4445`](https://github.com/NixOS/nixpkgs/commit/3d4b44454ec7a9c3276142e1c193f432f4aeb059) python3Packages.mashumaro: 3.9.1 -> 3.10
* [`e5f1eb8a`](https://github.com/NixOS/nixpkgs/commit/e5f1eb8aa708a881108b44ceaf7da032b8ccbaaa) python3Packages.matplotlib: 3.7.2 -> 3.8.0
* [`93bfd75a`](https://github.com/NixOS/nixpkgs/commit/93bfd75a5fcbc3b4136ceb803015bf6f3ad4cf38) python3Packages.maya: 0.3.3 -> 0.6.1
* [`ba59279e`](https://github.com/NixOS/nixpkgs/commit/ba59279e00039daa9f623ffca62d8551a804a319) python3Packages.md2gemini: 1.9.0 -> 1.9.1
* [`6a4cbb9b`](https://github.com/NixOS/nixpkgs/commit/6a4cbb9ba7e161ac37947f753f21364db025cf56) python3Packages.mdit-py-plugins: 0.3.5 -> 0.4.0
* [`e755f15b`](https://github.com/NixOS/nixpkgs/commit/e755f15b5340fcf924b4b2efee7ad6dc45fb7660) python3Packages.mediapy: 1.1.8 -> 1.1.9
* [`1788ca7d`](https://github.com/NixOS/nixpkgs/commit/1788ca7d6474b236f153bf32b719a69fd1800d26) python3Packages.meep: 1.25.0 -> 1.27.0
* [`8c932a5f`](https://github.com/NixOS/nixpkgs/commit/8c932a5fbbf577149bd6705e482fd0782efa686e) python3Packages.meraki: 1.36.0 -> 1.37.2
* [`c325c5d1`](https://github.com/NixOS/nixpkgs/commit/c325c5d1d380a2142b256ad1ebdbb1ade3f1f770) python3Packages.mesa: 1.2.1 -> 2.1.1
* [`65713a2d`](https://github.com/NixOS/nixpkgs/commit/65713a2d6161c0a035b8be35485a364bdcdb7812) python3Packages.meson-python: 0.13.1 -> 0.14.0
* [`b7b97529`](https://github.com/NixOS/nixpkgs/commit/b7b97529d70aa6b86120eac5d0935852b8e8b9f6) python3Packages.mido: 1.2.10 -> 1.3.0
* [`1e12502e`](https://github.com/NixOS/nixpkgs/commit/1e12502e2bf6ee35977b30c4e10e9c837c359ce1) python3Packages.mistletoe: 1.0.1 -> 1.2.1
* [`85091129`](https://github.com/NixOS/nixpkgs/commit/85091129cc9c3fdb5f55febad74121fec1c48fa8) python3Packages.mizani: 0.9.2 -> 0.10.0
* [`c8897c2b`](https://github.com/NixOS/nixpkgs/commit/c8897c2bfb3aaeab96ef1db12d28c004373619f5) python3Packages.mkdocs: 1.4.2 -> 1.5.2
* [`643c7448`](https://github.com/NixOS/nixpkgs/commit/643c7448eac02c139a4fd7cbda614b2ff657c830) python3Packages.mkdocs-material: 9.1.13 -> 9.3.1
* [`418d300e`](https://github.com/NixOS/nixpkgs/commit/418d300e74d6f1727f74caf03aa4cadde1375206) python3Packages.mkdocs-mermaid2-plugin: 1.0.8 -> 1.1.0
* [`806c547e`](https://github.com/NixOS/nixpkgs/commit/806c547e2048714c3107462282e6955cb9d7fab1) python3Packages.mkdocs-swagger-ui-tag: 0.6.4 -> 0.6.5
* [`6bb6b3b0`](https://github.com/NixOS/nixpkgs/commit/6bb6b3b0ad1d8908dc531190f8880a68f465e196) python3Packages.mkdocstrings: 0.21.2 -> 0.23.0
* [`0da7c212`](https://github.com/NixOS/nixpkgs/commit/0da7c21243b6d0b4aabe0203057b9309ed4130dd) python3Packages.mlflow: 2.5.0 -> 2.7.0
* [`c3709af8`](https://github.com/NixOS/nixpkgs/commit/c3709af8d22390e36203fcc9ec94396051478b3a) python3Packages.mlxtend: 0.21.0 -> 0.22.0
* [`49baf384`](https://github.com/NixOS/nixpkgs/commit/49baf38467bccf20d534ffe821cfd4b0ad117a52) python3Packages.mmcv: 2.0.0 -> 2.0.1
* [`fb6ac480`](https://github.com/NixOS/nixpkgs/commit/fb6ac4804821d30d38629324f9be1e5e3575480f) python3Packages.mne-python: 1.3.1 -> 1.5.1
* [`33b265d1`](https://github.com/NixOS/nixpkgs/commit/33b265d122d0df7f58c1caf2dc7087e51007b040) python3Packages.mocket: 3.11.0 -> 3.11.1
* [`37caca92`](https://github.com/NixOS/nixpkgs/commit/37caca92daf15150ab108f6fd2e26fe3035f1004) python3Packages.mongoengine: 0.26.0 -> 0.27.0
* [`f8f9c657`](https://github.com/NixOS/nixpkgs/commit/f8f9c657e095da9380c4ce9fbc8cdd8cfba0253f) python3Packages.monty: 2023.4.10 -> 2023.9.5
* [`a77006e1`](https://github.com/NixOS/nixpkgs/commit/a77006e1357b72ef3dd746e2c50402df582b9d82) python3Packages.more-itertools: 9.1.0 -> 10.1.0
* [`8eed4800`](https://github.com/NixOS/nixpkgs/commit/8eed4800ca48d1b03756f489de0d4ffbc36c1fca) python3Packages.moto: 4.1.3 -> 4.2.2
* [`12843fd9`](https://github.com/NixOS/nixpkgs/commit/12843fd99d69676e043ecfce440975d8a3e85fb3) python3Packages.motor: 3.1.1 -> 3.3.1
* [`464ca602`](https://github.com/NixOS/nixpkgs/commit/464ca602e26f3c0a28c54ac40894e6619effcc27) python3Packages.msal: 1.23.0 -> 1.24.0
* [`afb24c28`](https://github.com/NixOS/nixpkgs/commit/afb24c280450474257291d009e11e820237a1447) python3Packages.multipledispatch: 0.6.0 -> 1.0.0
* [`7d530cdf`](https://github.com/NixOS/nixpkgs/commit/7d530cdf0e4bc1a3bc7b7d392d1aedea2c3abcbd) python3Packages.multiprocess: 0.70.14 -> 0.70.15
* [`eb5e5f7b`](https://github.com/NixOS/nixpkgs/commit/eb5e5f7b993a02eaf5e08b6aa969a7040ac7a206) python3Packages.munch: 2.5.0 -> 4.0.0
* [`56495815`](https://github.com/NixOS/nixpkgs/commit/56495815ddbc2dff509eaa376c53e0818924161a) python3Packages.mysqlclient: 2.1.1 -> 2.2.0
* [`103f6d45`](https://github.com/NixOS/nixpkgs/commit/103f6d45c28bf56f98f89bbf9078d7c92322957a) python3Packages.myst-docutils: 1.0.0 -> 2.0.0
* [`d7cb2e00`](https://github.com/NixOS/nixpkgs/commit/d7cb2e0029a391dc86205337e66a7098d4c2fd6d) python3Packages.myst-parser: 1.0.0 -> 2.0.0
* [`2e9d6714`](https://github.com/NixOS/nixpkgs/commit/2e9d671497ef5e2f8cac6d78a1f0f6c93fc1dfbc) python3Packages.napalm: 3.4.1 -> 4.1.0
* [`f1f45b93`](https://github.com/NixOS/nixpkgs/commit/f1f45b9324c37b3da24b171410584cf17e38f887) python3Packages.napari-npe2: 0.7.0 -> 0.7.2
* [`2344fcf4`](https://github.com/NixOS/nixpkgs/commit/2344fcf4237908535e3c5bbcaa26ecda1a9bc16b) python3Packages.nbclient: 0.7.2 -> 0.8.0
* [`5c69a5af`](https://github.com/NixOS/nixpkgs/commit/5c69a5af18c79590391574e31978196d4e681fa5) python3Packages.nbconvert: 7.7.3 -> 7.8.0
* [`71dd0754`](https://github.com/NixOS/nixpkgs/commit/71dd07545349ddc55e98cbb8c09d4552bb8cad45) python3Packages.nbformat: 5.9.1 -> 5.9.2
* [`1cf1e177`](https://github.com/NixOS/nixpkgs/commit/1cf1e17786d7b57cf885380f266a1888e8edbb43) python3Packages.netmiko: 4.1.2 -> 4.2.0
* [`8940eebc`](https://github.com/NixOS/nixpkgs/commit/8940eebc57c072baa2ddb4376ca8f39b89af4567) python3Packages.networkx: 3.0 -> 3.1
* [`d802c42f`](https://github.com/NixOS/nixpkgs/commit/d802c42feb494570a1673b39b798a1be6ccef58d) python3Packages.nilearn: 0.10.0 -> 0.10.1
* [`293e81de`](https://github.com/NixOS/nixpkgs/commit/293e81dedf047c1eab4e8eb963cbbbb1e66f947f) python3Packages.nose2: 0.12.0 -> 0.13.0
* [`699260c8`](https://github.com/NixOS/nixpkgs/commit/699260c8d92bb243ff338f286dd7e164d03a72a7) python3Packages.notebook: 7.0.2 -> 7.0.3
* [`150e5c52`](https://github.com/NixOS/nixpkgs/commit/150e5c522149654cbda416634e743fea69625a50) python3Packages.notebook-shim: 0.2.2 -> 0.2.3
* [`4bc8bd1d`](https://github.com/NixOS/nixpkgs/commit/4bc8bd1da7c1f19fb3abcad8b1901d479c1c48ac) python3Packages.ntc-templates: 3.2.0 -> 3.5.0
* [`53686257`](https://github.com/NixOS/nixpkgs/commit/53686257b4362713dcc14d2edeb852422c573c8e) python3Packages.numexpr: 2.8.4 -> 2.8.6
* [`24b1da5b`](https://github.com/NixOS/nixpkgs/commit/24b1da5b5e5fe37a071df8e89af89197679f0404) python3Packages.numpy: 1.25.1 -> 1.25.2
* [`2f2e86b2`](https://github.com/NixOS/nixpkgs/commit/2f2e86b28018b00f9d4450c5e8585a23c3cd6189) python3Packages.nutils: 7.3 -> 8.3
* [`aa3b6af7`](https://github.com/NixOS/nixpkgs/commit/aa3b6af7bc48df3d046cbf9dc92a48dcad4d8c89) python3Packages.okta: 2.9.2 -> 2.9.3
* [`68162454`](https://github.com/NixOS/nixpkgs/commit/6816245472c4fc259d9739e8765469eefe639067) python3Packages.onnxconverter-common: 1.13.0 -> 1.14.0
* [`4e6b2c6e`](https://github.com/NixOS/nixpkgs/commit/4e6b2c6e7c01d5f0a5f3c63d4ca86f4f620f966f) python3Packages.openaiauth: 2.0.0 -> 3.0.0
* [`d367eb41`](https://github.com/NixOS/nixpkgs/commit/d367eb411a6c11b4b0c38c12aa7421f1501a2874) python3Packages.openapi-core: 0.18.0 -> 0.18.1
* [`1b267740`](https://github.com/NixOS/nixpkgs/commit/1b267740058aa7173c8eaa1bc662c67dc0a07b5a) python3Packages.openllm-core: 0.2.27 -> 0.3.4
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
