### PR TITLE
niv home-manager: update 78125bc6 -> f540f30f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78125bc681d12364cb65524eaa887354134053d0",
-        "sha256": "0qrhsq5hbybcsd467hw02vx7q470kvk5mmmi6w7xbphgy9ykyawc",
+        "rev": "f540f30f1f3c76b68922550dcf5f78f42732fd37",
+        "sha256": "15i1wczgbknh1dm8kf2d7rncaaa01gj47s4bsg8aip2hv2l3r99g",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/78125bc681d12364cb65524eaa887354134053d0.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f540f30f1f3c76b68922550dcf5f78f42732fd37.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@78125bc6...f540f30f](https://github.com/nix-community/home-manager/compare/78125bc681d12364cb65524eaa887354134053d0...f540f30f1f3c76b68922550dcf5f78f42732fd37)

* [`f6bb5c29`](https://github.com/nix-community/home-manager/commit/f6bb5c297372719a6ea1c369b2b1a1aa10580452) docs: add stateVersion to the NixOS/nix-darwin example
* [`132f9851`](https://github.com/nix-community/home-manager/commit/132f9851858986d78db0b08157256384bbc5738c) home-manager: add .editorconfig
* [`b25161c6`](https://github.com/nix-community/home-manager/commit/b25161c6a2c3b7cabb9cfdc70c35007c8ecb7241) darkman: add module
* [`7a46e6cb`](https://github.com/nix-community/home-manager/commit/7a46e6cb3ca02a478bdafc53c0ac89da6efc050c) im/fcitx5: fix missing plugins on Qt6 ([nix-community/home-manager⁠#4468](https://togithub.com/nix-community/home-manager/issues/4468))
* [`b3acf1dc`](https://github.com/nix-community/home-manager/commit/b3acf1dc78b38a2fe03b287fead44d7ad25ac7c5) flake.lock: Update
* [`3e1f8df4`](https://github.com/nix-community/home-manager/commit/3e1f8df4f0036124e18a37ad227d3c97ba29d214) thefuck: add instant mode option
* [`05649393`](https://github.com/nix-community/home-manager/commit/05649393ac1f34980a5cf6a6e89de77626c9182b) recoll: update option descriptions
* [`cffc9938`](https://github.com/nix-community/home-manager/commit/cffc9938c71ef5f80df032ff67f9f643f979579e) fzf: fix fish integration
* [`84fa81c7`](https://github.com/nix-community/home-manager/commit/84fa81c7acb018c3c5a504dcefbc28a182c933c2) fzf: add mkOrder for fish like we do for other shells
* [`54c1ca74`](https://github.com/nix-community/home-manager/commit/54c1ca74d949aa900f9723cef8408ddc32352a05) flake.lock: Update
* [`3433206e`](https://github.com/nix-community/home-manager/commit/3433206e51766b4164dad368a81325efbf343fbe) qutebrowser: add greasemonkey userscript option
* [`92bf9c25`](https://github.com/nix-community/home-manager/commit/92bf9c2585a1a3105d34becb2ed41ae5022d292c) Translate using Weblate (Turkish)
* [`a969307e`](https://github.com/nix-community/home-manager/commit/a969307eb96651c73cacbc38157144cd023eb78c) Translate using Weblate (Lithuanian)
* [`c5c1ea85`](https://github.com/nix-community/home-manager/commit/c5c1ea85181d2bb44e46e8a944a8a3f56ad88f19) Translate using Weblate (Portuguese)
* [`ae631b0b`](https://github.com/nix-community/home-manager/commit/ae631b0b20f06f7d239d160723d228891ddb2fe0) docs: fix option name
* [`4c0bcf5d`](https://github.com/nix-community/home-manager/commit/4c0bcf5dff03c48c4b047c9ab304c74b2bcdcdeb) exa: add aliases to nushell
* [`81ab1462`](https://github.com/nix-community/home-manager/commit/81ab14626273ca38cba947d9a989c9d72b5e7593) readme: major cleanup
* [`219d268a`](https://github.com/nix-community/home-manager/commit/219d268a69512ff520fe8da1739ac22d95d52355) aerc: fix config paths on darwin
* [`f540f30f`](https://github.com/nix-community/home-manager/commit/f540f30f1f3c76b68922550dcf5f78f42732fd37) cbatticon: Add support for batteryId
