### PR TITLE
niv niv: update 9341b102 -> 723f0eeb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "9341b1027da2c2f95f8e808a3cb4b403e0a62c77",
-        "sha256": "1l996s518iv7bcfzzhxlsn35ahbslpbvhl3ds1zpnama7la23y9b",
+        "rev": "723f0eeb969a730db3c30f977c2b66b9dce9fe4a",
+        "sha256": "0016l7230gd2kdh0g2w573r9a2krqb7x4ifcjhhsn4h1bwap7qr0",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9341b1027da2c2f95f8e808a3cb4b403e0a62c77.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/723f0eeb969a730db3c30f977c2b66b9dce9fe4a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-zsh-completions": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@9341b102...723f0eeb](https://github.com/nmattia/niv/compare/9341b1027da2c2f95f8e808a3cb4b403e0a62c77...723f0eeb969a730db3c30f977c2b66b9dce9fe4a)

* [`723f0eeb`](https://github.com/nmattia/niv/commit/723f0eeb969a730db3c30f977c2b66b9dce9fe4a) updated readme from release-21.05 to nixos-unstable ([nmattia/niv⁠#378](https://togithub.com/nmattia/niv/issues/378))
