### PR TITLE
niv powerlevel10k: update 862440ae -> 43061673

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "862440ae112603c8e2d202f6edb94eeaa1509120",
-        "sha256": "18zsm01s70yi1m5y162l09lw02nxpf6rxklldxqcmb2sd5kgk7c8",
+        "rev": "430616734aa06ff3def48cb511fb43db7466a64e",
+        "sha256": "0sgv25vgn78gpwdwmqi2kjd3qdbiyc6jmawiw7zxw3a1wvh0xfgf",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/862440ae112603c8e2d202f6edb94eeaa1509120.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/430616734aa06ff3def48cb511fb43db7466a64e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@862440ae...43061673](https://github.com/romkatv/powerlevel10k/compare/862440ae112603c8e2d202f6edb94eeaa1509120...430616734aa06ff3def48cb511fb43db7466a64e)

* [`c7fa7d67`](https://github.com/romkatv/powerlevel10k/commit/c7fa7d6748cf6935ff7aeaa4d0d76a1ed2bfb852) make rust_version segment compatible with the new rustup toolchain file ([romkatv/powerlevel10k⁠#2413](https://togithub.com/romkatv/powerlevel10k/issues/2413))
* [`43061673`](https://github.com/romkatv/powerlevel10k/commit/430616734aa06ff3def48cb511fb43db7466a64e) make terraform_version compatible with tfenv ([romkatv/powerlevel10k⁠#2049](https://togithub.com/romkatv/powerlevel10k/issues/2049))
