### PR TITLE
niv zsh-completions: update e969ea6f -> ac96055f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "e969ea6f6e69771c238138583d637a6257809e0f",
-        "sha256": "1vadlv8sv602c5jf0pm4557k6a30ccy9nfpipj5fdw8vn80bn7vy",
+        "rev": "ac96055f0c4c2cad282d8c17a8e608899506573f",
+        "sha256": "0kbbcznhybgnxy6a2nviy42yi8g1ym150hwsvdivll7zjx2pbk4k",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/e969ea6f6e69771c238138583d637a6257809e0f.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/ac96055f0c4c2cad282d8c17a8e608899506573f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@e969ea6f...ac96055f](https://github.com/zsh-users/zsh-completions/compare/e969ea6f6e69771c238138583d637a6257809e0f...ac96055f0c4c2cad282d8c17a8e608899506573f)

* [`fd6ac7bd`](https://github.com/zsh-users/zsh-completions/commit/fd6ac7bd64378881fd3e4c376828d510c8aeb4ab) Add do-release-upgrade completion
* [`903b9b71`](https://github.com/zsh-users/zsh-completions/commit/903b9b713402aca1cdc38ee3c0f7929ce89cb1ea) Fix homebrew link
* [`bd6f7d8c`](https://github.com/zsh-users/zsh-completions/commit/bd6f7d8c5b4f5c49a2b592f7f190563584056573) Update node completion for version 21.0.0
* [`fee1c475`](https://github.com/zsh-users/zsh-completions/commit/fee1c475afdd037da5b9f2bc7175eef4885fb2bd) Add jest completion
