### PR TITLE
niv nixpkgs: update 6a251401 -> b12786c1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6a251401ea6a2ee5f6a19fd6e6c8504f9d41f520",
-        "sha256": "06za5zbcdrjxwv3579fgs8lw84nnx4ka56dpk9rh20p33j7pqb5s",
+        "rev": "b12786c187800110d3bdfa5e26e22b05250cc887",
+        "sha256": "1zplcsn8hi79ya6m6fxb0472lh6b62axkwpj9znrwa7ypdqhr8pn",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/6a251401ea6a2ee5f6a19fd6e6c8504f9d41f520.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/b12786c187800110d3bdfa5e26e22b05250cc887.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -156,11 +156,11 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unarchiver": {
-        "sha256": "071bj6rzchnamdz62ihf9j0n2dkmz5p1xs6z9bwq4ifbrxgrgci1",
+        "sha256": "049bzagrz07rs7c6x39awnrnq028vp334fxmdsigp9sc7l75a3b9",
         "type": "file",
         "url": "https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.dmg",
         "url_template": "https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.dmg",
-        "version": "4.3.5"
+        "version": "4.3.6"
     },
     "zsh-async": {
         "branch": "master",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@6a251401...b12786c1](https://github.com/nixos/nixpkgs/compare/6a251401ea6a2ee5f6a19fd6e6c8504f9d41f520...b12786c187800110d3bdfa5e26e22b05250cc887)

* [`595b703e`](https://github.com/NixOS/nixpkgs/commit/595b703e43124c3f3ad3d78b2ba5038fb73e3354) scalingo: init at 1.28.2
* [`3935158c`](https://github.com/NixOS/nixpkgs/commit/3935158cf3f43ac12d17ca889401875d15a764fc) Run tests when building
* [`851287a1`](https://github.com/NixOS/nixpkgs/commit/851287a149b70392a47fe02e8c1c1e198ff119ed) Fix DISABLE_UPDATE_CHECKER environment variable
* [`1be482b6`](https://github.com/NixOS/nixpkgs/commit/1be482b602a841cc5d2d94523fe96965225deb9f) python310Packages.syncer: 1.3.0 -> 2.0.3
* [`bb1795a9`](https://github.com/NixOS/nixpkgs/commit/bb1795a9ba2fab6757411567ea720faf4d1df091) Remove anchor from changelog URL
* [`d610e009`](https://github.com/NixOS/nixpkgs/commit/d610e0094ebe2907e40f84187537033215ef488f) scalingo: 1.28.2 -> 1.29.1
* [`404d6124`](https://github.com/NixOS/nixpkgs/commit/404d612423550ef0c07e095a169a17c3a74a13ab) jibri: 8.0-140-gccc7278 -> 8.0-145-g1a4bb8e
* [`b1292363`](https://github.com/NixOS/nixpkgs/commit/b12923631d6ace3a2f9e6fe05d34ec5211b67fd5) nixos/bacula: fix postgresql config and remove unneeded quotation marks
* [`77bc27cc`](https://github.com/NixOS/nixpkgs/commit/77bc27ccdb87b1a3400fc59f097f8218982a55ed) nixos/backups/restic: handle cases when both dynamicFileFrom and paths are set
* [`5a88a9b7`](https://github.com/NixOS/nixpkgs/commit/5a88a9b7267cd82770ed092d9572c7d05edd133c) pmbootstrap: 1.50.1->2.0.0
* [`6bb2cffa`](https://github.com/NixOS/nixpkgs/commit/6bb2cffa4c30855132a4a6b8d0e2acce1e844ce2) todoist-electron: 8.3.3 -> 8.6.0
* [`7ce5fa1a`](https://github.com/NixOS/nixpkgs/commit/7ce5fa1a82414b1b1cff16da0a781b87cdc5b168) nixos/nginx: add `application/javascript` to `compressMimeTypes`
* [`5ccc7d63`](https://github.com/NixOS/nixpkgs/commit/5ccc7d632b07f5b18e2e874dcdeb881a6948f2d9) nixos/boot/kernel: include nvme kmod by default
* [`721e1495`](https://github.com/NixOS/nixpkgs/commit/721e14956bbee18ecaba9159bef681cbd8b0e494) adi1090x-plymouth-themes: 2020-12-28 -> 1.0
* [`570afebd`](https://github.com/NixOS/nixpkgs/commit/570afebd1b47319e1349b927a21f4a178fcc14bf) jitsi-meet-prosody: 1.0.6943 -> 1.0.7531
* [`2abb1879`](https://github.com/NixOS/nixpkgs/commit/2abb18794aa3b72df9c8f4d2855811f2b8a186ba) opentelemetry-collector-contrib: 0.78.0 -> 0.85.0
* [`4c8b9a6e`](https://github.com/NixOS/nixpkgs/commit/4c8b9a6eab50f1e289c90a9385ebfc2df1af734c) jicofo: 1.0-1038 -> 1.0-1050
* [`1b959377`](https://github.com/NixOS/nixpkgs/commit/1b9593776766d18baa36e3b297f90e07ef454772) nginxModules.http_proxy_connect_module_v{24,25}: new modules for up to date nginx
* [`57393ed5`](https://github.com/NixOS/nixpkgs/commit/57393ed5dbde3ba39aee149bcaac4eb8ab6f13ef) pulumiPackages.pulumi-random: 4.8.2 -> 4.14.0
* [`bc5612c2`](https://github.com/NixOS/nixpkgs/commit/bc5612c202439f9d1f3c88913f83ddb96f978cbf) diffoscope: 248 -> 250
* [`86353a0c`](https://github.com/NixOS/nixpkgs/commit/86353a0c206d848ca59406d25d1be49738db40f9) tart: 1.6.0 -> 2.0.0
* [`c8a23dd8`](https://github.com/NixOS/nixpkgs/commit/c8a23dd80726d9e3683262378739b43f45581916) nginxModules.http_proxy_connect_module_v{18,19}: drop old broken modules
* [`055bf8cc`](https://github.com/NixOS/nixpkgs/commit/055bf8cc3eb8161443660e50155b9446e3691a9f) jitsi-videobridge: 2.2-69-gad606ca2 -> 2.3-44-g8983b11f
* [`865e14d5`](https://github.com/NixOS/nixpkgs/commit/865e14d5595a4ca23ee2e9234d7119ab282a9297) maintainers: added yunfachi
* [`b1fc3195`](https://github.com/NixOS/nixpkgs/commit/b1fc3195c10c072c32d1191e7276af329e0592c0) add Emscripten maintainers to CODEOWNERS
* [`dd54e58c`](https://github.com/NixOS/nixpkgs/commit/dd54e58c94943461ed0d32eff60fd52a42bf9148) emscripten docs: reword introduction
* [`b2f52652`](https://github.com/NixOS/nixpkgs/commit/b2f526526a53ba252a8a5860b70794c8e2044e89) emscripten docs: reformat examples to use admonition
* [`edf4036e`](https://github.com/NixOS/nixpkgs/commit/edf4036ece29f9a971c68a01fddaad554ad62e5a) tree-sitter-grammars: add wgsl
* [`ac108554`](https://github.com/NixOS/nixpkgs/commit/ac1085548ebacd98d648dba82a26a85ef4d2fbdc) blink: fix build
* [`ec508e4e`](https://github.com/NixOS/nixpkgs/commit/ec508e4e4327d050a868ca0c361b543f20a25962) kotlin-language-server: 1.3.5 -> 1.3.7
* [`6fa87aba`](https://github.com/NixOS/nixpkgs/commit/6fa87aba8af6ef47aa32782feeab7fdf7ea6811d) obs-studio: link libcef instead copy
* [`1572feeb`](https://github.com/NixOS/nixpkgs/commit/1572feeb89288d4d346931fddbad18dba2315c2c) fedifetcher: 5.0.1 -> 7.0.1
* [`6f1fe4a2`](https://github.com/NixOS/nixpkgs/commit/6f1fe4a256a111306604ad8a020670a0cfd7b815) sladeUnstable: unstable-2022-08-15 -> unstable-2023-09-30
* [`4e7d39d7`](https://github.com/NixOS/nixpkgs/commit/4e7d39d716025e9dc3d3af8155a09c875a8d66ca) clipman: Fix removed repository
* [`81601415`](https://github.com/NixOS/nixpkgs/commit/816014157e8f86a0d9ee4006c2b25e0cbe133565) confluent-cli, confluent-platform: add maintainer autophagy
* [`109c6a5f`](https://github.com/NixOS/nixpkgs/commit/109c6a5f5c13e16410a24a062f3c681d9cce341d) spdx-license-list-data: 3.21 -> 3.22
* [`6f1a7f8d`](https://github.com/NixOS/nixpkgs/commit/6f1a7f8dc82b7e59a0b236de0c72c334a674ce09) obs-studio: format comments
* [`a2a89453`](https://github.com/NixOS/nixpkgs/commit/a2a894536e29863fac63c176a3987666c36879c6) obs-studio: fix formatting
* [`e60282e1`](https://github.com/NixOS/nixpkgs/commit/e60282e1706081266172324ff39409d11e275689) graylog-3_3: drop, graylog-4_0: drop, graylog-4_3: drop
* [`a8896888`](https://github.com/NixOS/nixpkgs/commit/a8896888ba6cf2485536b61e9ca1ad6f87a33748) maintainers: add camelpunch
* [`cac8be84`](https://github.com/NixOS/nixpkgs/commit/cac8be8460ea225faf7d4050cd0f2a056f430de1) elektroid: init at 2.5.2
* [`8f511869`](https://github.com/NixOS/nixpkgs/commit/8f511869efa89bcafa605ebe87d8fbfb444fb18b) confluent-platform: 7.4.1 -> 7.5.0
* [`13364f12`](https://github.com/NixOS/nixpkgs/commit/13364f124a83832edc4abb259f03e5d264f70a68) cdemu: fix service setup
* [`b0b04e6b`](https://github.com/NixOS/nixpkgs/commit/b0b04e6bffbf9337fbdc462a588bfe8f658df09d) calc: fix substituteInPlace call
* [`0454d207`](https://github.com/NixOS/nixpkgs/commit/0454d2077b533e22fe00aea2110e69e993ba0f37) gwe: 0.15.5 -> 0.15.6
* [`8080f24c`](https://github.com/NixOS/nixpkgs/commit/8080f24c1b48c62544dba68666ce1ebc445ca6e0) keybase: 6.2.2 -> 6.2.3
* [`aa03eb72`](https://github.com/NixOS/nixpkgs/commit/aa03eb729fa84928e713e60bed9596a440492af3) imagemagick: 7.1.1-19 -> 7.1.1-20
* [`679f2b64`](https://github.com/NixOS/nixpkgs/commit/679f2b64e12bd27835091c89ae0b59279d516680) qutebrowser: add vulkan support
* [`b4214e1d`](https://github.com/NixOS/nixpkgs/commit/b4214e1db4a3d04e86e1bf8b791311073ba9b787) perlPackages.ImageMagick: 7.1.1-18 -> 7.1.1-20
* [`1945cb97`](https://github.com/NixOS/nixpkgs/commit/1945cb9740e8642aacf8163e1aa62f61d0cf6021) python310Packages.jupyterhub: add missing deps
* [`c957ca18`](https://github.com/NixOS/nixpkgs/commit/c957ca18cef708be6f1744573b4c06bd7b4934d5) miniupnpc: 2.2.4 -> 2.2.5
* [`5225f0b0`](https://github.com/NixOS/nixpkgs/commit/5225f0b0a7c4e76c7e50300a7608f8d9822d3626) libsForQt5.qtpbfimageplugin: 2.4 -> 2.5
* [`9537ce32`](https://github.com/NixOS/nixpkgs/commit/9537ce326e3555ed223a1dfe8f5453777f304b94) river-bnf: init at unstable-2023-10-10
* [`b0ed6703`](https://github.com/NixOS/nixpkgs/commit/b0ed6703f17e570b5db7602c3acfb4c07875bbcb) gromit-mpx: 1.4.3 -> 1.5.0
* [`b851674e`](https://github.com/NixOS/nixpkgs/commit/b851674e9fe1e62d57b327222bfd7a15cdce4f78) flrig: 2.0.03 -> 2.0.04
* [`a91bd0b4`](https://github.com/NixOS/nixpkgs/commit/a91bd0b468ae5bb51802ddb767ebcaf9954b605b) make-squashfs: add support for pseudoFiles, custom name, and disabling strip
* [`c2ff509e`](https://github.com/NixOS/nixpkgs/commit/c2ff509e66a2e4b3e2f1a24a20fa4340f34aba49) lxc-container: add squashfs image support and release output
* [`7f04544c`](https://github.com/NixOS/nixpkgs/commit/7f04544c2a6ca6b2cca873f1e1a61b3a86838084) nerdctl: 1.6.0 -> 1.6.1
* [`e51dee59`](https://github.com/NixOS/nixpkgs/commit/e51dee59de9457044c41ca7fcadd94f2a17bc57d) buildMozillaMach: allow distinct source and package versions
* [`e2e3f9d9`](https://github.com/NixOS/nixpkgs/commit/e2e3f9d95165677c549b51eb74420de450647c16) tilt: fix missing assets
* [`017f3cf5`](https://github.com/NixOS/nixpkgs/commit/017f3cf5b549c13054c65d9f95fafe38db91b893) pinniped: 0.26.0 -> 0.27.0
* [`3011f803`](https://github.com/NixOS/nixpkgs/commit/3011f803d19022b93767d62ce1c0925ac8153cca) pizarra: 1.7.4 -> 1.7.5
* [`2a08b191`](https://github.com/NixOS/nixpkgs/commit/2a08b19137543bb3aae77dc21ac0b3675c046366) platinum-searcher: 2.1.5 -> 2.2.0
* [`25d5d4fd`](https://github.com/NixOS/nixpkgs/commit/25d5d4fd89149d8634aa98850094be83173afdac) poedit: 3.3.2 -> 3.4
* [`5656b39a`](https://github.com/NixOS/nixpkgs/commit/5656b39a7c67634852932678c88a98ca3cb51bb2) fluidd: 1.25.3 -> 1.26.0
* [`9be29ccb`](https://github.com/NixOS/nixpkgs/commit/9be29ccbbe177aae1dced355643e404e02d47662) ghr: 0.16.0 -> 0.16.1
* [`907ec89b`](https://github.com/NixOS/nixpkgs/commit/907ec89bbe6dcde3276a5dbd8af56dd6de653d6e) libnats-c: 3.6.1 -> 3.7.0
* [`c8e9fe39`](https://github.com/NixOS/nixpkgs/commit/c8e9fe3984229bc9018ee62ff51c1e50f9ab0f64) lxgw-neoxihei: 1.105 -> 1.106
* [`f46a44c5`](https://github.com/NixOS/nixpkgs/commit/f46a44c54287af2c7cef9bd22841dcdc09c928ab) panicparse: 2.2.0 -> 2.3.1
* [`67a738ac`](https://github.com/NixOS/nixpkgs/commit/67a738ac97d2ed3ab3fb259814a2ccc860a903b2) polypane: 15.0.0 -> 15.0.1
* [`f151aeac`](https://github.com/NixOS/nixpkgs/commit/f151aeac50e1ded377cf65b3c42a5446c67d63e6) profile-sync-daemon: 6.48 -> 6.50
* [`f0f081a6`](https://github.com/NixOS/nixpkgs/commit/f0f081a621bf8f4c36617627f7942b5b1821dac8) prometheus-junos-czerwonk-exporter: 0.12.0 -> 0.12.2
* [`c4b961ae`](https://github.com/NixOS/nixpkgs/commit/c4b961aea37bd824dfa677cfeddc0afcc5285794) pulumictl: 0.0.44 -> 0.0.45
* [`cb5dda2c`](https://github.com/NixOS/nixpkgs/commit/cb5dda2c7097c484da5d1eaabc1b10f81bb8ec18) python310Packages.a2wsgi: 1.7.0 -> 1.8.0
* [`6b92b6d6`](https://github.com/NixOS/nixpkgs/commit/6b92b6d632cac92c04922082e33af16f2896e873) python310Packages.anytree: 2.9.0 -> 2.10.0
* [`242056cf`](https://github.com/NixOS/nixpkgs/commit/242056cfdd1f121d03be777c5313ac582107e7b4) python310Packages.asyncssh: 2.13.2 -> 2.14.0
* [`636e5646`](https://github.com/NixOS/nixpkgs/commit/636e5646a1a71703a739b545bf0959df02a1a34d) python310Packages.bincopy: 17.14.5 -> 19.1.0
* [`ac28bd0c`](https://github.com/NixOS/nixpkgs/commit/ac28bd0cb8dcf090765b09f2edb484619b37663c) eclint: 0.4.0 -> 0.5.0
* [`ace534bf`](https://github.com/NixOS/nixpkgs/commit/ace534bff6d3693c34292c8335e9df1b363ebfbf) libcmis: 0.5.2 -> 0.6.0
* [`4c89a5dd`](https://github.com/NixOS/nixpkgs/commit/4c89a5dd6014a059913e3cfb70f0785764de2849) ocm: 0.1.69 -> 0.1.70
* [`25381d09`](https://github.com/NixOS/nixpkgs/commit/25381d09c020011772efb0a0d6f47759e757b24a) janusgraph: 0.6.3 -> 0.6.4
* [`433a8736`](https://github.com/NixOS/nixpkgs/commit/433a8736ea9cc276e4ed2c2359f1ffa23156f671) python310Packages.localstack-ext: 2.2.0 -> 2.3.2
* [`80da54af`](https://github.com/NixOS/nixpkgs/commit/80da54afc13733eeae58982c16a1335978f59659) cowpatty: backport parallel build fix
* [`29aa3b34`](https://github.com/NixOS/nixpkgs/commit/29aa3b349c5b89148ce8a0e52baba48b950add39) python310Packages.pyjnius: 1.5.0 -> 1.6.0
* [`ecddcfca`](https://github.com/NixOS/nixpkgs/commit/ecddcfcafffada2a238182873ca776324c6b03d3) dyff: 1.5.8 -> 1.6.0
* [`e16e7f89`](https://github.com/NixOS/nixpkgs/commit/e16e7f894d31f3f9cf5ae82bcd6598601bddb18f) python310Packages.pyqt6-sip: 13.5.2 -> 13.6.0
* [`7622b070`](https://github.com/NixOS/nixpkgs/commit/7622b070b46c143999c4c34806d3c1c6c7ff8494) python310Packages.pyside2: 5.15.10 -> 5.15.11
* [`049f547e`](https://github.com/NixOS/nixpkgs/commit/049f547e9591e71632f9606183344727f04796b3) python310Packages.pysigma-backend-elasticsearch: 1.0.7 -> 1.0.9
* [`1e71b6c6`](https://github.com/NixOS/nixpkgs/commit/1e71b6c65adef816ad89526b7a98f5172540fdf9) python310Packages.pytapo: 3.2.14 -> 3.2.18
* [`13bc623e`](https://github.com/NixOS/nixpkgs/commit/13bc623eb950e17bf0c63e05cf9128fe8ac89ec4) python310Packages.pytesseract: 0.3.12 -> 0.3.13
* [`884f4735`](https://github.com/NixOS/nixpkgs/commit/884f473583591a1820ca9b1de5fb165a8ebe6bcc) python310Packages.pytest-pylint: 0.19.0 -> 0.21.0
* [`945337f0`](https://github.com/NixOS/nixpkgs/commit/945337f01fbb7512703ac89e97c3128735a7a14c) nxpmicro-mfgtools: pull upstream fix for gcc-13
* [`74a5f911`](https://github.com/NixOS/nixpkgs/commit/74a5f911a6fd3d6e67d6ffd440a96fe435e6d23b) python310Packages.pytorch-lightning: 2.0.9 -> 2.1.0
* [`b6d3ad0e`](https://github.com/NixOS/nixpkgs/commit/b6d3ad0eace5ada5dde1cc8cd826ef3e9513291e) python310Packages.traits: 6.4.2 -> 6.4.3
* [`f6ea5554`](https://github.com/NixOS/nixpkgs/commit/f6ea555427041d361e7f9e6e71ed20d46550e3e0) python310Packages.transmission-rpc: 7.0.1 -> 7.0.3
* [`b8dd439f`](https://github.com/NixOS/nixpkgs/commit/b8dd439fcba9c33c8f7c158373f9f7ebce3a5c0f) python310Packages.trytond: 6.8.4 -> 6.8.5
* [`47ed5cf6`](https://github.com/NixOS/nixpkgs/commit/47ed5cf6050df2d449869d4d08f8ee8021e8766c) ddccontrol: 0.6.3 -> 1.0.0
* [`ea669319`](https://github.com/NixOS/nixpkgs/commit/ea669319718f6b75a5ef35fd3521aee979468039) karate: 1.4.0 -> 1.4.1
* [`bce2a462`](https://github.com/NixOS/nixpkgs/commit/bce2a4625923159ad3e6052d945d08eb6b9eb5cb) figma-linux: mark vulnerable to CVE-2023-5217
* [`52c1a3f6`](https://github.com/NixOS/nixpkgs/commit/52c1a3f6801f4619595e248ea8fd4d79fac8cef8) hyprland: 0.30.0 -> 0.31.0
* [`7d01fc7f`](https://github.com/NixOS/nixpkgs/commit/7d01fc7f04fd01be2ead5665d30f1def9f103790) q: 0.12.0 -> 0.13.5
* [`48bb9de1`](https://github.com/NixOS/nixpkgs/commit/48bb9de10899a03bcd1c5d82912a3930ae7d1f53) qdrant: 1.5.1 -> 1.6.1
* [`8037207c`](https://github.com/NixOS/nixpkgs/commit/8037207c629aef6d3a26305256669a40d1d19223) questdb: 7.3.2 -> 7.3.3
* [`8da85630`](https://github.com/NixOS/nixpkgs/commit/8da856302cf6cc4f76af1b74ae8484e3f730c76f) nixos/shiori: add web root option
* [`355e5948`](https://github.com/NixOS/nixpkgs/commit/355e59481605cd803c384b733e34078538db126b) raxml: 8.2.12 -> 8.2.13
* [`597b9d6a`](https://github.com/NixOS/nixpkgs/commit/597b9d6a09c233867590cbf8de8dd7617e6e24a6) re-flex: 3.4.1 -> 3.5.0
* [`f7b2038d`](https://github.com/NixOS/nixpkgs/commit/f7b2038d2d69e133cc61778cd67fc5a6e727b40f) readarr: 0.3.6.2232 -> 0.3.8.2267
* [`79327a4a`](https://github.com/NixOS/nixpkgs/commit/79327a4ac5f642b66941a168062578d9d350a43b) regclient: 0.5.2 -> 0.5.3
* [`7e7cf31e`](https://github.com/NixOS/nixpkgs/commit/7e7cf31eac1d2d149c6157fd496b5dc997211249) glade: add darwin support
* [`6fcfa4fc`](https://github.com/NixOS/nixpkgs/commit/6fcfa4fc9840de4526bdd0d7a0ee493682a32b9d) bctoolbox: 5.2.98 -> 5.2.109
* [`bd11e0ff`](https://github.com/NixOS/nixpkgs/commit/bd11e0ffe3c1395dfa535aef98bf2a480019f7a1) genymotion: 3.5.0 -> 3.5.1
* [`2578871e`](https://github.com/NixOS/nixpkgs/commit/2578871eafacf50b452dc140c0dcf1bd29a90fe9) libxisf: 0.2.9 -> 0.2.10
* [`2dac4920`](https://github.com/NixOS/nixpkgs/commit/2dac4920c81fa4d6c0ec919c6e52c7d3e7eb1ac5) loksh: 7.3 -> 7.4
* [`e0fb6166`](https://github.com/NixOS/nixpkgs/commit/e0fb61667fa7d9d84d3c1d3dcb6adfe17ca730b4) memcached: 1.6.21 -> 1.6.22
* [`f6d6427c`](https://github.com/NixOS/nixpkgs/commit/f6d6427c68c50344bbf96ea9fb9534d8a58bcbc5) mozjpeg: 4.1.4 -> 4.1.5
* [`4404b068`](https://github.com/NixOS/nixpkgs/commit/4404b068b60c218f6ff5a872456098b062b64627) netclient: 0.21.0 -> 0.21.1
* [`d39b2427`](https://github.com/NixOS/nixpkgs/commit/d39b24272d1b1646aee2c6c46042efdbf5c623aa) libxisf: 0.2.9 -> 0.2.10
* [`5dab9d0f`](https://github.com/NixOS/nixpkgs/commit/5dab9d0ffce42f22bf69b8a8c048cf933f97b1f5) bitwarden: 2023.9.0 -> 2023.9.3
* [`1ab05aa5`](https://github.com/NixOS/nixpkgs/commit/1ab05aa5dfbf96a6ead9749b5ab98ed08a39d5e4) jellyfin-ffmpeg: 6.0-6 -> 6.0-7
* [`1fdacfff`](https://github.com/NixOS/nixpkgs/commit/1fdacfffa8ea13a0c27c0720bfb7a6d83060c216) maintainers: add msanft
* [`1d21f2e8`](https://github.com/NixOS/nixpkgs/commit/1d21f2e88dbde8892f49e416cd883d08a8e4d1e0) vscode-extensions.tsandall.opa: init at 0.12.2
* [`d9c88e76`](https://github.com/NixOS/nixpkgs/commit/d9c88e76399d7b8928774df6f0f9fec3c9ea62ac) python311Packages.oci: 2.112.4 -> 2.113.0
* [`ff40196e`](https://github.com/NixOS/nixpkgs/commit/ff40196e78e0e90e4d744501b7eba64ef49cb423) python311Packages.pydevccu: 0.1.6 -> 0.1.7
* [`d7d1894a`](https://github.com/NixOS/nixpkgs/commit/d7d1894a36eeff3d3bbb93f07902d8a589bfa1ce) nixos/home-assistant: use runCommandLocal for configuration.yaml
* [`0917aa46`](https://github.com/NixOS/nixpkgs/commit/0917aa4657eed29c30bb6098cfae5cc8e501f7ce) anilibria-winmaclinux: build with libvlc
* [`dea07297`](https://github.com/NixOS/nixpkgs/commit/dea0729772f44891abd92c3d5a2f5cb74cd037cd) qjackctl: 0.9.11 -> 0.9.12
* [`08e942a7`](https://github.com/NixOS/nixpkgs/commit/08e942a74daef2d49d5c2661a2fc8af8d99f7fcf) doctl: 1.99.0 -> 1.100.0
* [`60f62ab2`](https://github.com/NixOS/nixpkgs/commit/60f62ab2daf0fae296566c574b7b241ae13b5665) audible-cli: 0.2.4 -> 0.2.5
* [`baa70c2b`](https://github.com/NixOS/nixpkgs/commit/baa70c2ba3efda5826238b09a44a50f05a3eb2a0) libinput-gestures: 2.74 -> 2.76
* [`ab47bc4d`](https://github.com/NixOS/nixpkgs/commit/ab47bc4dd70b7efad3560a23738fc3eddcfc0eb4) audible-cli: refactor
* [`942620ba`](https://github.com/NixOS/nixpkgs/commit/942620ba9e1cea9513413b70b8af802c216dbaa2) maintainers: add taranarmo
* [`1916a0cb`](https://github.com/NixOS/nixpkgs/commit/1916a0cb9e97592ce22f6c3ca5e1febef1ca162b) syslogng: clean up build
* [`9fd3ea0f`](https://github.com/NixOS/nixpkgs/commit/9fd3ea0f76e7b20a5a2331eddaeffcfaf097c098) deeptools: 3.5.1 -> 3.5.4
* [`bc38370c`](https://github.com/NixOS/nixpkgs/commit/bc38370c81ebd327e5c5c6afad2312498169f245) rabbitmq-server: 3.12.6 -> 3.12.7
* [`bb699073`](https://github.com/NixOS/nixpkgs/commit/bb69907389a18ece02835774e29bb25904c86860) ugrep: 4.3.0 -> 4.3.1
* [`a3df1172`](https://github.com/NixOS/nixpkgs/commit/a3df11728ec5936c503bf981bcb299cb6ad9979f) libchamplain: add darwin support
* [`b4a77c9f`](https://github.com/NixOS/nixpkgs/commit/b4a77c9fad2265764a1fa68e28b4cac78fc215e0) grun: init at 0.9.3
* [`11f438d7`](https://github.com/NixOS/nixpkgs/commit/11f438d7f4ed42ab3a77589ea50020cd4895dab4) roswell: 22.12.14.113 -> 23.10.14.114
* [`3a766475`](https://github.com/NixOS/nixpkgs/commit/3a76647590fe64c4605e41099d1de13d84884672) rssguard: 4.5.0 -> 4.5.1
* [`51b85c18`](https://github.com/NixOS/nixpkgs/commit/51b85c180a3b626a98f8d5095aa1d2b3dc466121) rsyslog: 8.2308.0 -> 8.2310.0
* [`9a6b037f`](https://github.com/NixOS/nixpkgs/commit/9a6b037f08a77d62bd4a2c098794023d18e86c82) rtx: 2023.10.1 -> 2023.10.2
* [`aa07c55f`](https://github.com/NixOS/nixpkgs/commit/aa07c55f9f5f75e453b1953544f8d5fc90c69943) rune: 0.12.4 -> 0.13.1
* [`80697b6b`](https://github.com/NixOS/nixpkgs/commit/80697b6bfb570e18efc7741991a7dbd2bd64feab) sarasa-gothic: 0.42.1 -> 0.42.2
* [`19c94a2b`](https://github.com/NixOS/nixpkgs/commit/19c94a2b19f675a25533155c9f55e825c86aaaa3) abuild: 3.11.21 -> 3.12.0
* [`4c62744a`](https://github.com/NixOS/nixpkgs/commit/4c62744a6709d412eaa14887fab625fcc8fc11e5) egl-wayland: 1.1.12 -> 1.1.13
* [`29f976f6`](https://github.com/NixOS/nixpkgs/commit/29f976f69455cbc306c13286074111df2ecfaf4e) jruby: 9.4.3.0 -> 9.4.4.0
* [`8ee045a5`](https://github.com/NixOS/nixpkgs/commit/8ee045a5b147a16cb20c273ca269d52396614899) go-junit-report: 2.0.0 -> 2.1.0
* [`ab4b58a7`](https://github.com/NixOS/nixpkgs/commit/ab4b58a7f48053a20a23bc3366ba2b273e9790b7) notepad-next: 0.6.3 -> 0.6.4
* [`10856f48`](https://github.com/NixOS/nixpkgs/commit/10856f48d20659a32766545548f55fe872495046) moonlight-qt: 4.3.1 -> 5.0.0
* [`c22ef7b5`](https://github.com/NixOS/nixpkgs/commit/c22ef7b5bd37c98fa715b189f50f95dd58e36040) sdbus-cpp: 1.3.0 -> 1.4.0
* [`89e19b57`](https://github.com/NixOS/nixpkgs/commit/89e19b57da7e7c237ef1824615665637cb9f1584) crun: 1.9.2 -> 1.10
* [`13e62b22`](https://github.com/NixOS/nixpkgs/commit/13e62b222322fefdfc3412e484a6049b89e683dc) seafile-shared: 9.0.3 -> 9.0.4
* [`aca5e778`](https://github.com/NixOS/nixpkgs/commit/aca5e77875380a7528b9b2e716f9218e9097520d) release: block on `linux-builder.aarch64-darwin`
* [`7d335296`](https://github.com/NixOS/nixpkgs/commit/7d3352961a64a51521063c8ebea220e247eebcd5) python310Packages.jupyterlab: add meta.mainProgram
* [`71e4159f`](https://github.com/NixOS/nixpkgs/commit/71e4159f447a70403426ae3e10968c30314f5aff) oversteer: 0.7.2 -> 0.8.0
* [`d65e6602`](https://github.com/NixOS/nixpkgs/commit/d65e6602222c974264fc944916035fc2aee22157) oversteer: add changelog to meta
* [`c966ac69`](https://github.com/NixOS/nixpkgs/commit/c966ac6974c8c091a6e8ce944b64dd6543129c4c) oversteer: specify license
* [`9b3c1ffa`](https://github.com/NixOS/nixpkgs/commit/9b3c1ffa8c8daadb9ce157b9a774bc4cceddc3b9) skaffold: 2.7.1 -> 2.8.0
* [`ef66682d`](https://github.com/NixOS/nixpkgs/commit/ef66682d72316335dba3bc8af1ec833c940df2fb) youtube-music: add darwin support
* [`7f45cd96`](https://github.com/NixOS/nixpkgs/commit/7f45cd96e9a38e90fa8ef2ea3febff1b1f920cf4) nqptp: add adamcstephens as maintainer
* [`2ea5f968`](https://github.com/NixOS/nixpkgs/commit/2ea5f9683d360009bb63272af1dc16b26ba87e92) skypeforlinux: 8.105.0.208 -> 8.106.0.212
* [`68829e6b`](https://github.com/NixOS/nixpkgs/commit/68829e6b035e0cfba3e65f3ab2b73fc18de684f2) nqptp: 1.2.3 -> 1.2.4
* [`db70fd98`](https://github.com/NixOS/nixpkgs/commit/db70fd9812fa06932640b5d3930bfccffe4cbd52) rune: fix build on darwin
* [`dc042af9`](https://github.com/NixOS/nixpkgs/commit/dc042af9f18a606de977e82e48d8b16c0698215d) snappymail: 2.28.4 -> 2.29.1
* [`fef266a3`](https://github.com/NixOS/nixpkgs/commit/fef266a3219a9c29358648017509b487027e80ba) snd: 23.6 -> 23.8
* [`a077b7fa`](https://github.com/NixOS/nixpkgs/commit/a077b7fadb95813e3b72c10407974673a336c48e) openssh: add {Allow,Deny}{Users,Groups} settings
* [`47148453`](https://github.com/NixOS/nixpkgs/commit/4714845327dd4e972ee34cc4a8fa23c6b745e921) nixos/tests/openssh: add test for `AllowUsers`
* [`65c83c52`](https://github.com/NixOS/nixpkgs/commit/65c83c5228e42dcd3293376211f17ca77f5d723e) spicedb-zed: 0.14.0 -> 0.15.0
* [`bd1680ce`](https://github.com/NixOS/nixpkgs/commit/bd1680ce988fe97d2d31deea203dde2d5f8075ae) spire: 1.7.2 -> 1.8.2
* [`33c04d7d`](https://github.com/NixOS/nixpkgs/commit/33c04d7d2de02219316c9b4a71ff92456e3a56e7) spotify: 1.2.13.661.ga588f749 -> 1.2.22.982.g794acc0a
* [`53f624bc`](https://github.com/NixOS/nixpkgs/commit/53f624bc19dfdb61b1060de99e7c9015778ae931) sqldef: 0.16.7 -> 0.16.9
* [`865ff6ab`](https://github.com/NixOS/nixpkgs/commit/865ff6abf4f3d63af168f0b8e454221db35f5a3a) ssdfs-utils: 4.27 -> 4.35
* [`29c59267`](https://github.com/NixOS/nixpkgs/commit/29c592675639611cb3bd62288cb7c16c3e9e6d54) appflowy: 0.3.5 -> 0.3.6
* [`057adb6a`](https://github.com/NixOS/nixpkgs/commit/057adb6a1ac9bc7b6511a1e8633e405c2ce78e60) standardnotes: 3.173.4 -> 3.178.4
* [`30d20fbc`](https://github.com/NixOS/nixpkgs/commit/30d20fbc5b94344deac70212ee41c702e616e3ad) fantomas: init at 6.2.2
* [`e24d43a1`](https://github.com/NixOS/nixpkgs/commit/e24d43a18c99138b782fea2d00337e34539e360b) nixos/nvidia: partially revert [nixos/nixpkgs⁠#181674](https://togithub.com/nixos/nixpkgs/issues/181674)
* [`828d6846`](https://github.com/NixOS/nixpkgs/commit/828d6846a4f48c2e39851e53729ba24fc853c121) stunnel: 5.70 -> 5.71
* [`efc5d2c3`](https://github.com/NixOS/nixpkgs/commit/efc5d2c350d8f4f9c327584743da3a67cf203f68) sudo-font: 0.74 -> 0.77
* [`b9da7b77`](https://github.com/NixOS/nixpkgs/commit/b9da7b77e0b81de43cef9c41cf7252edcb2201cb) supabase-cli: 1.102.2 -> 1.107.0
* [`514ccd44`](https://github.com/NixOS/nixpkgs/commit/514ccd4402bea9f3410009db696ed29135fc1509) suricata: 7.0.0 -> 7.0.1
* [`ac8b1998`](https://github.com/NixOS/nixpkgs/commit/ac8b199862e3b061e689bf552fb7a75f9a283036) swagger-codegen: 2.4.31 -> 2.4.34
* [`e43ae440`](https://github.com/NixOS/nixpkgs/commit/e43ae4405bb996299ae67f15b8051a95f50632ca) swayrbar: 0.3.6 -> 0.3.7
* [`26314663`](https://github.com/NixOS/nixpkgs/commit/26314663256837f962d8b873b85a15edf152fd9b) system76-keyboard-configurator: 1.3.9 -> 1.3.10
* [`4fa46c1e`](https://github.com/NixOS/nixpkgs/commit/4fa46c1e9051c01c726da77e2f2d44fa4d6f8b51) talosctl: 1.5.3 -> 1.5.4
* [`a6c2d9af`](https://github.com/NixOS/nixpkgs/commit/a6c2d9af482ca99d3d1182f3c5db87180e3b78ec) ocamlPackages.sail: 0.15 → 0.16
* [`8170725e`](https://github.com/NixOS/nixpkgs/commit/8170725e405201d82b4ab5dced7556f8dfcf0820) python310Packages.a2wsgi: remove unused input
* [`3ce0f400`](https://github.com/NixOS/nixpkgs/commit/3ce0f400ca6cb88dca7413dce6030380494dafca) ansible-lint: 6.20.0 -> 6.21.1
* [`a190bf43`](https://github.com/NixOS/nixpkgs/commit/a190bf43b618e0bbc8cc5cd2310ae2a03f307190) mecab: expose mecab-ipadic in $out
* [`f0154409`](https://github.com/NixOS/nixpkgs/commit/f0154409a199152522818e70f23a75b49fcdff5d) nixos/nix-daemon: remove activationScript
* [`5c1fe73d`](https://github.com/NixOS/nixpkgs/commit/5c1fe73db9284938ae597591c3fe265ea08c215f) libsigcxx12: remove unused
* [`fe13bafe`](https://github.com/NixOS/nixpkgs/commit/fe13bafe88cf5386e15e5aa1a801d2f0b79be6ea) k40-whisperer: 0.62 -> 0.67
* [`deef8ff2`](https://github.com/NixOS/nixpkgs/commit/deef8ff2936e9db2845c68d4ebb2bce8281ff76c) python311Packages.tvdb-api: rename from tvdb_api
* [`b43269b8`](https://github.com/NixOS/nixpkgs/commit/b43269b8cd3ae4bcac7e78df5142cc5f06b86336) mpvScripts.thumbnail: 0.5.2 -> 0.5.3
* [`91100947`](https://github.com/NixOS/nixpkgs/commit/911009472a31f07c765be1056f1d875bef1c861c) ne: 3.3.2 -> 3.3.3
* [`e2b6ff83`](https://github.com/NixOS/nixpkgs/commit/e2b6ff83847e2acf1e16cced9ecd54329bff013e) nixos/akkoma: add services.akkoma.dist.extraFlags
* [`41c30ef9`](https://github.com/NixOS/nixpkgs/commit/41c30ef9a7d0635e4c0e82c451dba371f74ff3f9) nixpacks: 1.17.0 -> 1.18.0
* [`e34d4d20`](https://github.com/NixOS/nixpkgs/commit/e34d4d2001fad65879f3b8ab978cfe738e57a7f8) ooniprobe-cli: 3.18.1 -> 3.19.0
* [`496c3695`](https://github.com/NixOS/nixpkgs/commit/496c3695064b425c6af35dd6a1038fcb00504d4e) openturns: 1.21 -> 1.21.1
* [`e2e4463a`](https://github.com/NixOS/nixpkgs/commit/e2e4463a976d8e8c96a20b504322cf06673f4ba7) rpi-imager: 1.7.5 -> 1.8.1
* [`0c578d11`](https://github.com/NixOS/nixpkgs/commit/0c578d114661ac40f7a717925d8ada43371ed57a) rpi-imager: add passthru.tests.version
* [`24e4bc0e`](https://github.com/NixOS/nixpkgs/commit/24e4bc0eb3845a5b466d200b18d62042104f4952) rpi-imager: add meta.mainProgram
* [`ca55407e`](https://github.com/NixOS/nixpkgs/commit/ca55407e4275bd99ba8df1d8a9975bae54cf1651) adw-gtk3: 4.9 -> 5.1
* [`6ec8cad0`](https://github.com/NixOS/nixpkgs/commit/6ec8cad0725a85674aa0faadc686a665c470b5f7) akkoma: fix built-in captcha
* [`a8d5d2f2`](https://github.com/NixOS/nixpkgs/commit/a8d5d2f2075597f403c9d1af62ff7994fee49fc1) doc: generate documentation for lib.customisation
* [`6bcc63a1`](https://github.com/NixOS/nixpkgs/commit/6bcc63a1dc23885b97c9f8c5f4bf4aa8f07a48db) wttrbar: 0.4.0 -> 0.5.0
* [`e8d988c9`](https://github.com/NixOS/nixpkgs/commit/e8d988c99b9b8cb9acaf0e5d04a4d27866debbe9) dra-cla: unstable-2023-03-10 -> unstable-2023-10-10
* [`fc1031b2`](https://github.com/NixOS/nixpkgs/commit/fc1031b2d32c0301ce8a941c5646672c0d7dfdf0) nix-health: init at 0.2.3
* [`8e0b306c`](https://github.com/NixOS/nixpkgs/commit/8e0b306c82e44cb072d621375ac24d4370b8808e) flutter: fix version
* [`95cd49c3`](https://github.com/NixOS/nixpkgs/commit/95cd49c3b342a6f008976ebc3ec121da241f5631) webcord: lock ozone wayland behind NIXOS_OZONE_WL envvar
* [`cf002f1e`](https://github.com/NixOS/nixpkgs/commit/cf002f1eb46db5f137d102d83a3a3bb46f31bd7b) webcord: add self to maintainers
* [`a3a8bb09`](https://github.com/NixOS/nixpkgs/commit/a3a8bb09a80bb5000553fa436facbe74086a1275) raycast: 1.59.0 -> 1.60.1
* [`a4c90e09`](https://github.com/NixOS/nixpkgs/commit/a4c90e09f28b578d48cee150dceb3b94f5b9b554) gitkraken: 9.5.1 -> 9.9.2
* [`eca142d5`](https://github.com/NixOS/nixpkgs/commit/eca142d55576c269c4785a502b0e3e7d762dcfe4) turbo: fix -ldflags typo in go-turbo
* [`9573657e`](https://github.com/NixOS/nixpkgs/commit/9573657ebccce1e543f9afd772a32aa3ceed6c21) kind: fix -ldflags typo
* [`921e3c16`](https://github.com/NixOS/nixpkgs/commit/921e3c16cc3bf5d67dcd47a6615b322c98123f33) build-support/php: add colors in case of errors
* [`41dcc214`](https://github.com/NixOS/nixpkgs/commit/41dcc214e672b50b7f934d001e10d9ac34722483) terranix: 2.6.0 -> 2.7.0
* [`6ef329f8`](https://github.com/NixOS/nixpkgs/commit/6ef329f8b4f954aa39b5ba9e8a5aa506c95d98fa) wttrbar: 0.5.0 -> 0.5.1
* [`9407ed62`](https://github.com/NixOS/nixpkgs/commit/9407ed628de381dbf51d508081ea1564f32f2bff) nixos/tailscale: add openFirewall option
* [`19b35404`](https://github.com/NixOS/nixpkgs/commit/19b35404a2cd9df81618e26d9230ed1128e317b3) tesseract5: 5.3.2 -> 5.3.3
* [`d9dcbbdb`](https://github.com/NixOS/nixpkgs/commit/d9dcbbdb884a4669412409abe622760595a83c41) python311Packages.qds-sdk: rename from qds_sdk
* [`ccebea41`](https://github.com/NixOS/nixpkgs/commit/ccebea4132d69068ba5af60ff7a3d63a043531d5) python311Packages.qds-sdk: refactor
* [`f979c86b`](https://github.com/NixOS/nixpkgs/commit/f979c86ba3efaf388f6477114ea0751fbb0aee6a) timeular: 6.3.0 -> 6.5.0
* [`33277942`](https://github.com/NixOS/nixpkgs/commit/3327794230fb5342fda5991cd5028618dd62f065) _1password-gui: 8.10.18-19.BETA -> 8.10.20-1.BETA
* [`016bf951`](https://github.com/NixOS/nixpkgs/commit/016bf951e608183e1d8225624b89f08a334599a3) topicctl: 1.10.2 -> 1.11.0
* [`7ca950c4`](https://github.com/NixOS/nixpkgs/commit/7ca950c4742656c408294720c881f84851590cb0) touchosc: 1.2.1.171 -> 1.2.4.180
* [`8cc20316`](https://github.com/NixOS/nixpkgs/commit/8cc20316d03d6884c8814225138a14992b6ed2cc) adriconf: 2.5.1 -> 2.7.1
* [`c8e43485`](https://github.com/NixOS/nixpkgs/commit/c8e434857fab62303f396fb3b16b60a4b6a9c5e9) qdl: format
* [`e04a9339`](https://github.com/NixOS/nixpkgs/commit/e04a933900ecb8cedba9a7da4bfbd1cde859c12a) qdl: unstable 2021-05-06 -> 2023-04-11
* [`dbd4d678`](https://github.com/NixOS/nixpkgs/commit/dbd4d678f88e1d14c3d49ee8c2d5020808087e22) trinsic-cli: 1.11.0 -> 1.12.0
* [`840a42f5`](https://github.com/NixOS/nixpkgs/commit/840a42f5f850ac85b47431360bc53fe002c186bc) ttyd: 1.7.3 -> 1.7.4
* [`5885a545`](https://github.com/NixOS/nixpkgs/commit/5885a5453aa07c3991c274176050cc182bd5bec1) ttyplot: 1.4 -> 1.5
* [`d63f8fa2`](https://github.com/NixOS/nixpkgs/commit/d63f8fa271a6d6f7d553b8d850c78c21f1a13869) avro-c: 1.11.2 -> 1.11.3
* [`1121cec6`](https://github.com/NixOS/nixpkgs/commit/1121cec61595e1e825ef79e4517f6231fd827668) mediathekview: Set `mainProgram` to "mediathek"
* [`77d82189`](https://github.com/NixOS/nixpkgs/commit/77d82189b0328b039e58be6e7d700f915ff04811) fio: 3.35 -> 3.36
* [`e386c0c1`](https://github.com/NixOS/nixpkgs/commit/e386c0c15ffcbec2b2b0f7410add697bd3fb678f) gnunet-gtk: 0.19.0 -> 0.20.0
* [`24aca029`](https://github.com/NixOS/nixpkgs/commit/24aca029cb10e56aa8cf0fa50f0c381a6c3159ac) jetbrains-toolbox: 2.0.4.17212 -> 2.0.5.17700
* [`93b8f14a`](https://github.com/NixOS/nixpkgs/commit/93b8f14a2d36a17ebbd40f3f3907e43a01d44502) doc: lib.customization: add Type and Example tags
* [`0695d3e8`](https://github.com/NixOS/nixpkgs/commit/0695d3e8fe08dac78fc59354ae2f926915b0d6b6) lib.overrideDerivation: inter-link the documentation
* [`a2e97cff`](https://github.com/NixOS/nixpkgs/commit/a2e97cffbce1bb3bb2d1d1506e81f887a968705e) libdatachannel: 0.19.1 -> 0.19.2
* [`581f45b5`](https://github.com/NixOS/nixpkgs/commit/581f45b58b03e36441a82b521676d3d36cfbd55c) linuxKernel.packages.linux_4_19.akvcam: 1.2.2 -> 1.2.4
* [`46a7c4ca`](https://github.com/NixOS/nixpkgs/commit/46a7c4cade9d3ac19650341a5b9de31fd6bd83d8) build-support/php: add `composerStrictValidation` attribute
* [`354f2d23`](https://github.com/NixOS/nixpkgs/commit/354f2d23505ecb896e0b08325e7193416d81ed66) linuxKernel.packages.linux_5_15.r8125: 9.004.01 -> 9.011.01
* [`f2fb24e0`](https://github.com/NixOS/nixpkgs/commit/f2fb24e097b993a70eacbad482bc6f66c8acd1af) decker: init at 1.31
* [`e40c9776`](https://github.com/NixOS/nixpkgs/commit/e40c977696ba601d62a0d1f27f7284c14e9a0df6) gopls: use go 1.21 for build
* [`b3730275`](https://github.com/NixOS/nixpkgs/commit/b3730275397cc3efc3dcecea3bcaa8df88c2d93a) zfs-replicate: 1.2.3 -> 3.1.4
* [`22d19e95`](https://github.com/NixOS/nixpkgs/commit/22d19e954b55e0b42f56508cd3418cddee3266b0) complgen: 0.1.5 -> 0.1.6
* [`3b430d5a`](https://github.com/NixOS/nixpkgs/commit/3b430d5a97d27698b64fa01bee4bc04224d8b16d) zsh-abbr: 5.1.0 -> 5.2.0
* [`6ea912dc`](https://github.com/NixOS/nixpkgs/commit/6ea912dce280762defb0368875099221ff3a7c54) randomx: 1.1.10 -> 1.2.1
* [`1eb84fcf`](https://github.com/NixOS/nixpkgs/commit/1eb84fcf4d8a5c46d7135a63d9f6f64e93ab8678) tau-hydrogen: 1.0.11 -> 1.0.13
* [`ced1d0fd`](https://github.com/NixOS/nixpkgs/commit/ced1d0fd8d0773205b54a0f9acebf4a5479a41b3) mautrix-googlechat: unstable-2023-07-16 -> 0.5.1
* [`4893c369`](https://github.com/NixOS/nixpkgs/commit/4893c36948de428445b2ce9009239a8452240bdf) wttrbar: 0.5.1 -> 0.5.2
* [`69b6bce1`](https://github.com/NixOS/nixpkgs/commit/69b6bce15441929ca07fd96d4b9e92b083eeb1ff) toastify: 0.5.2 -> 0.5.4
* [`8f457241`](https://github.com/NixOS/nixpkgs/commit/8f4572417f8045d0c6fd0f1f30e22552ec0bd7ad) twitch-cli: 1.1.20 -> 1.1.21
* [`a744633b`](https://github.com/NixOS/nixpkgs/commit/a744633b66dfce3f606a8f95a29011979583b70d) linux_xanmod: 6.1.57 -> 6.1.58
* [`61419fe3`](https://github.com/NixOS/nixpkgs/commit/61419fe3a2a5f06a0d4bf3d99a739e6fae1f1e23) linux_xanmod_latest: 6.5.7 -> 6.5.8
* [`dd8a65bb`](https://github.com/NixOS/nixpkgs/commit/dd8a65bb797c23e339720408ac7c5069f2cd5e8e) space-station-14-launcher: 0.22.1 -> 0.24.0
* [`22325ce0`](https://github.com/NixOS/nixpkgs/commit/22325ce016eeb59be10ce964e106549ac95c1896) systemd-stage-1: Support for user shells
* [`ed7de2e6`](https://github.com/NixOS/nixpkgs/commit/ed7de2e611237f9592f48234c76da4c84552587e) ugs: 2.0.20 -> 2.0.21
* [`24e6c248`](https://github.com/NixOS/nixpkgs/commit/24e6c24825489aeb05b743f537f981544e66c9f6) ulauncher: 5.15.3 -> 5.15.4
* [`afe9745e`](https://github.com/NixOS/nixpkgs/commit/afe9745edb8f0643f0f889d64d561f3d4846f47e) systemd: properly wrap ukify by prefixing instead of overwriting PATH
* [`456a1b9a`](https://github.com/NixOS/nixpkgs/commit/456a1b9a9e11e933bdf2a4e023dfe1afbd3110dd) utf8proc: 2.8.0 -> 2.9.0
* [`17e227a8`](https://github.com/NixOS/nixpkgs/commit/17e227a87d1efef86d5cb7acf1040af84dca7f4f) unit: 1.31.0 -> 1.31.1
* [`4159393a`](https://github.com/NixOS/nixpkgs/commit/4159393adbde9ac7a2a727cd9da86f87d63d7a83) python311Packages.scooby: 0.7.4 -> 0.9.2
* [`45fcd52d`](https://github.com/NixOS/nixpkgs/commit/45fcd52d33782f3c3836ae1423ede853033a313f) upbound: 0.19.1 -> 0.21.0
* [`261caf29`](https://github.com/NixOS/nixpkgs/commit/261caf29f49d0c14d6896639be3b033aa305e977) ideviceinstaller: fix build
* [`4df45951`](https://github.com/NixOS/nixpkgs/commit/4df459513c415ec976427f9567e604fb21308d4d) perlPackages.ImageMagick: mark broken
* [`998ad4ce`](https://github.com/NixOS/nixpkgs/commit/998ad4ce0c018230cf745e0207cc3b58e8e6166e) tutanota-desktop: 3.118.8 -> 3.118.13
* [`e59b866c`](https://github.com/NixOS/nixpkgs/commit/e59b866c4eedd04f105aef2b908eb26c7ce01a99) drawio: unbreak on darwin
* [`d3935514`](https://github.com/NixOS/nixpkgs/commit/d3935514c330e42ec3d43272249631e1e35676f6) usbimager: 1.0.9 -> 1.0.10
* [`3cb477b7`](https://github.com/NixOS/nixpkgs/commit/3cb477b7ee822314ff8f81a2ba4a39671ad69c25) guile-gcrypt: set strictDeps
* [`506cb9e2`](https://github.com/NixOS/nixpkgs/commit/506cb9e268a080d30be19d6af77ca35773ce053e) guile-git: set strictDeps
* [`c109adc5`](https://github.com/NixOS/nixpkgs/commit/c109adc5bf3be38552cd803c7dcf7d0b94956035) guile-gnutls: set strictDeps
* [`ac37aede`](https://github.com/NixOS/nixpkgs/commit/ac37aede471acc6cd37a9274f625e92380402d81) guile-json: set strictDeps
* [`70d99074`](https://github.com/NixOS/nixpkgs/commit/70d990743ba2e6aa92cb99809c5d14653b7d8713) guile-lib: set strictDeps
* [`df4e8fb4`](https://github.com/NixOS/nixpkgs/commit/df4e8fb47a4c6701eb8c0e132b4dedf0e4472fd7) guile-sqlite3: set strictDeps
* [`be37bdac`](https://github.com/NixOS/nixpkgs/commit/be37bdacd401b2b0260cbf3e18525562c1909a5a) scheme-bytestructures: set strictDeps
* [`a9e00367`](https://github.com/NixOS/nixpkgs/commit/a9e00367e77d2c0b9b6f7daf9abd0fe136f3cc57) vassal: 3.7.0 -> 3.7.4
* [`902c21cc`](https://github.com/NixOS/nixpkgs/commit/902c21cca389af719b026ff713ecd1185ff10069) cidr-merger: init at 1.1.3
* [`e485b188`](https://github.com/NixOS/nixpkgs/commit/e485b1888d66ddb615deee3fb5c8d429c0668c07) vc: 1.4.3 -> 1.4.4
* [`75533a36`](https://github.com/NixOS/nixpkgs/commit/75533a36f98ac3b17cc52134ff86ed514c9a3e4a) svix-server: init at 1.13.0
* [`fa21ebc8`](https://github.com/NixOS/nixpkgs/commit/fa21ebc82575a4e5d9f8d3b44f46fbae94c06ea4) invidious: fix build with clang 16
* [`33750c35`](https://github.com/NixOS/nixpkgs/commit/33750c35958114be054a4abc8004df60edc24465) uiua: 0.0.20 -> 0.0.21
* [`d48146d7`](https://github.com/NixOS/nixpkgs/commit/d48146d75b5add726921cb1530ae9673f2576ec7) jruby: fix changelog
* [`d1889ea8`](https://github.com/NixOS/nixpkgs/commit/d1889ea88bc9c96854b123a4b60145b1b07881ed) lxd-unwrapped: 5.18 -> 5.19
* [`b5b9315a`](https://github.com/NixOS/nixpkgs/commit/b5b9315a6d42b8ffbfce5307bb6f3cb35e2958f6) paper-age: 1.1.4 -> 1.2.0
* [`9d57e6fc`](https://github.com/NixOS/nixpkgs/commit/9d57e6fceee42c84f3183911238f0a06334e7414) mystmd: init at 1.1.22
* [`ba13d73b`](https://github.com/NixOS/nixpkgs/commit/ba13d73b97408bc8954ef715a426e16933715b86) whistle: init at 2.9.58
* [`c253e5ec`](https://github.com/NixOS/nixpkgs/commit/c253e5eca749ae379206dae8ed391fe5cda260b6) jruby: add updateScript
* [`472d1b81`](https://github.com/NixOS/nixpkgs/commit/472d1b814c09cf75830c46326816ee76f0005b60) textsnatcher: init at 2.0.0
* [`cd3746a3`](https://github.com/NixOS/nixpkgs/commit/cd3746a3f98b31d9095b215e7d38c664446739f7) tradingview: fix directory structure
* [`219e2354`](https://github.com/NixOS/nixpkgs/commit/219e235433d51b682f8a34760aa6661f86609344) mpd: add soxr resampler support
* [`be4027e7`](https://github.com/NixOS/nixpkgs/commit/be4027e726fc9a64f69d7eea15272c411dbebc98) vscode-extensions.svelte.svelte-vscode: 107.4.3 -> 107.12.0
* [`6993265d`](https://github.com/NixOS/nixpkgs/commit/6993265d86399a5ef717993b6582a1d75377c56c) tab: 9.1 -> 9.2
* [`f80a8354`](https://github.com/NixOS/nixpkgs/commit/f80a8354fd5506e16af059d46ca9a9944b789cce) libcifpp: 5.2.1 -> 5.2.2
* [`30e00f04`](https://github.com/NixOS/nixpkgs/commit/30e00f04e3ee89159770d314180891fd6de7667f) dssp: 4.4.3 -> 4.4.4.1
* [`d8a520ab`](https://github.com/NixOS/nixpkgs/commit/d8a520abc7b2491a514a6473372018a59eee782b) python311Packages.anthropic: 0.3.13 -> 0.5.0
* [`204e07e2`](https://github.com/NixOS/nixpkgs/commit/204e07e24b2628e045aefed55f3eaf1b1fb63052) traefik: 2.10.4 -> 2.10.5
* [`a827b6aa`](https://github.com/NixOS/nixpkgs/commit/a827b6aa965c41aaedb85f8ac8e12215ca498625) kopia: 0.14.1 -> 0.15.0
* [`a37eccb3`](https://github.com/NixOS/nixpkgs/commit/a37eccb3fe66988aaaf4937ee82f49044733a2ea) trafficserver: 9.2.2 -> 9.2.3
* [`b269e685`](https://github.com/NixOS/nixpkgs/commit/b269e6853e233f5bd2365930860bfa53188cfebb) nixos-rebuild: fix --install-bootloader flag with systemd-run
* [`d57791c2`](https://github.com/NixOS/nixpkgs/commit/d57791c29f5447ae72ddc9f97d0cfdb8f9e4c459) python311Packages.aiowithings: 0.4.4 -> 1.0.0
* [`f32a622d`](https://github.com/NixOS/nixpkgs/commit/f32a622d3a3d55ce0c466bfd9c40649b6ee348cf) paperwork: 2.1.2 -> 2.2.0
* [`92a4b7e8`](https://github.com/NixOS/nixpkgs/commit/92a4b7e8eaef8d50db1f06c7c464a0538cfd5578) paperwork: 2.2.0 -> 2.2.1
* [`e07d5326`](https://github.com/NixOS/nixpkgs/commit/e07d5326fa0d54e057af2295321dcbf692979031) matrix-synapse: remove opentracing optional dependencies
* [`0288685a`](https://github.com/NixOS/nixpkgs/commit/0288685a4ddd1176f0dc0db99c9bb3ac24a7a752) nixos/matrix-synapse: remove opentracing options
* [`1fd6d612`](https://github.com/NixOS/nixpkgs/commit/1fd6d6120b6a682c4aeab0c0a27942a7c4d1627e) jetty: 12.0.1 -> 12.0.2
* [`1530a12d`](https://github.com/NixOS/nixpkgs/commit/1530a12dce08aab6125121d7b0ed4fc955609db9) uiua: 0.0.21 -> 0.0.22
* [`3be139fc`](https://github.com/NixOS/nixpkgs/commit/3be139fcb7a2bb6281da4e2ae7e4228f90282510) xdg-desktop-portal-hyprland: 1.1.0 -> 1.2.3
* [`c5304845`](https://github.com/NixOS/nixpkgs/commit/c530484520b664bec49d3ea8015cec5816c4bbef) nixpkgs-review: 2.10.2 -> 2.10.3
* [`25872524`](https://github.com/NixOS/nixpkgs/commit/25872524f0ed0e16c382754d8d10ddb44c23c50c) nixos/qemu-vm: add `virtualisation.tpm` for running TPM in QEMU infrastructure
* [`83b131bb`](https://github.com/NixOS/nixpkgs/commit/83b131bb55bde0511a17d3beb52145d778dd4105) nixos/tests: adopt newest TPM support in test infra
* [`60421a16`](https://github.com/NixOS/nixpkgs/commit/60421a1622ac05433afcf0179ff46f937e10096c) firefox: start killing all the per-extension options
* [`e6f5980d`](https://github.com/NixOS/nixpkgs/commit/e6f5980d87a28fda3e61e6c5916e72b509b623d6) nixos/tests/firefox: use the module
* [`8c40fbcb`](https://github.com/NixOS/nixpkgs/commit/8c40fbcb582be732781f45eb8ab872c7171c7b5c) pot: 2.6.3 -> 2.6.6
* [`1f99dffa`](https://github.com/NixOS/nixpkgs/commit/1f99dffae5a18bb70a15b07d68478d70c6eabdbe) python311Packages.torchmetrics: 1.1.2 -> 1.2.0
* [`af7889b4`](https://github.com/NixOS/nixpkgs/commit/af7889b4d93590259ff264b9e631793877bcb668) todoman: apply upstream patch
* [`6118c0b0`](https://github.com/NixOS/nixpkgs/commit/6118c0b0d04394041c148d1f7e91805946e87a52) litestream: 0.3.11 -> 0.3.12
* [`479480b3`](https://github.com/NixOS/nixpkgs/commit/479480b3a0a062fd10092354622751cdb6c2ce2f) kodi.packages.sendtokodi: init at 0.9.557
* [`68b60e44`](https://github.com/NixOS/nixpkgs/commit/68b60e44ed6aaf288b15c6e0ac9e648d51356445) xdp-tools: 1.4.0 -> 1.4.1
* [`a3faae47`](https://github.com/NixOS/nixpkgs/commit/a3faae470136ffcc77c1eeb179897a6921e093a2) ocamlPackages.brr: 0.0.4 → 0.0.6
* [`8bbeaa86`](https://github.com/NixOS/nixpkgs/commit/8bbeaa865f25c928f3a186219b03eb22363e6129) ocamlPackages.note: 0.0.2 → 0.0.3
* [`f4d631c3`](https://github.com/NixOS/nixpkgs/commit/f4d631c3d1d1102cedc8cb27c634aa5853ed1ecd) nixos/nginx: document implicit default port 80
* [`007d92d8`](https://github.com/NixOS/nixpkgs/commit/007d92d830b2ca82f518a3c1f69fbfea2db8f771) zfs: add armv7 to supported platforms
* [`3afb34d0`](https://github.com/NixOS/nixpkgs/commit/3afb34d09e0770d2fe86ab79ad930367a2466242) plantuml-server: 1.2023.10 -> 1.2023.12
* [`ccf080ee`](https://github.com/NixOS/nixpkgs/commit/ccf080ee055c620c6adc451c1b1b29a71ec0722a) amazon-ssm-agent: rename from ssm-agent
* [`33981053`](https://github.com/NixOS/nixpkgs/commit/33981053289592b9fccc1c491dd385d47be26b90) bitwarden: use copyDesktopItems
* [`049b4830`](https://github.com/NixOS/nixpkgs/commit/049b48307ddf3d49c025686575593f106cc60fa4) gitlab-runner: pin to Go 1.20
* [`72fdcbdc`](https://github.com/NixOS/nixpkgs/commit/72fdcbdccf2d7244073cf838adb14452271fb133) gitlab-runner: 16.4.0 -> 16.5.0
* [`34629526`](https://github.com/NixOS/nixpkgs/commit/34629526891534bf845231f4cfcd466f438b4420) nordic: unstable-2023-05-12 -> unstable-2023-10-17
* [`5fcb34ca`](https://github.com/NixOS/nixpkgs/commit/5fcb34ca05e3b0563ff87950df9940e0765f67c7) nordic: fix destination directory for sddm themes
* [`c16fc1ac`](https://github.com/NixOS/nixpkgs/commit/c16fc1ac32083c43f35cbdb1c7cfb00960833d6d) nordic: replace duplicates with symbolic links instead of hard links
* [`77313a5b`](https://github.com/NixOS/nixpkgs/commit/77313a5b05f7218646c9eb6fd89b8ecc37f1efc1) nordic: does not pass libsForqt5, but the individual needed packages
* [`ef1e7035`](https://github.com/NixOS/nixpkgs/commit/ef1e70356bf389f18d0a76ab552ffc151df5c062) nordic: propagate sddm qt dependencies to user env
* [`8b4b92ed`](https://github.com/NixOS/nixpkgs/commit/8b4b92edf9c1b06b88abb9126404c8814504c37c) nordic: qtgraphicaleffects is not needed
* [`9634e40f`](https://github.com/NixOS/nixpkgs/commit/9634e40fa1ea3a35a53bab3953098dabf5b5af40) nordic: move wallpapers to appropriate directory
* [`dc977b63`](https://github.com/NixOS/nixpkgs/commit/dc977b632f671a753807d219cce7dc18a3d1d978) nordic: install folder icons and cursors
* [`32433303`](https://github.com/NixOS/nixpkgs/commit/32433303fedb6dea4b8bc71caf0071bdf6a037d4) python311Packages.stem: enable on Python 3.11
* [`bf94e65e`](https://github.com/NixOS/nixpkgs/commit/bf94e65ed9e05e96c6eb7a3e95855729ad7d4e79) text-engine: fix build with clang 16
* [`28fd5df2`](https://github.com/NixOS/nixpkgs/commit/28fd5df299ade45d536e13b2fe10135e615205a4) trezord: build with go_1_20
* [`cae154a6`](https://github.com/NixOS/nixpkgs/commit/cae154a67eb8e0605464896ea53c87d5634020f1) nixos/systemd-tmpfiles: add settings option
* [`cbfabed8`](https://github.com/NixOS/nixpkgs/commit/cbfabed861001698b1adf3afed47ccdb93bcc046) rocmPackages.rocm-core: use tags for rocmUpdateScript
* [`ddada701`](https://github.com/NixOS/nixpkgs/commit/ddada701bc286d1d709b46815f928fed82e42260) python311Packages.s3fs: 2023.9.2 -> 2023.10.0
* [`816a8023`](https://github.com/NixOS/nixpkgs/commit/816a8023b49225743da788e1410f6c74b5776e91) rocmPackages.rocm-core: 5.7.0 -> 5.7.1
* [`ca9b6ed3`](https://github.com/NixOS/nixpkgs/commit/ca9b6ed32d93edece15db525f006941096e6e50b) gtk2: fix build with clang 16
* [`08f4fe20`](https://github.com/NixOS/nixpkgs/commit/08f4fe20874ea19c55849138fb3af734cb72a5a1) qemu-vm: stop the swtpm once qemu stops
* [`94ecc3da`](https://github.com/NixOS/nixpkgs/commit/94ecc3da74ce1595460f3657b0e00c708465a94c) piper-phonemize: 1.1.0 -> 2023.9.27-2
* [`20550edf`](https://github.com/NixOS/nixpkgs/commit/20550edf35252dd38d81a52301a60d05a48224a0) piper-tts: 1.2.0 -> 2023.9.27-1
* [`533a80b6`](https://github.com/NixOS/nixpkgs/commit/533a80b695989977e8701cf7bb665ba185e9ce80) ciscoPacketTracer: move to by-name
* [`fee54300`](https://github.com/NixOS/nixpkgs/commit/fee543007f9a601c22e03fcf8963151220c0fd7c) whatsapp-emoji-font: move to by-name
* [`9b971c24`](https://github.com/NixOS/nixpkgs/commit/9b971c24f959b3fb579b94c2e47f6e10dda24c1e) linux/hardened/patches/5.15: 5.15.135-hardened1 -> 5.15.136-hardened1
* [`f94d951d`](https://github.com/NixOS/nixpkgs/commit/f94d951d153f9e0c3bf5c92d297c45726d0fd161) linux/hardened/patches/6.1: 6.1.58-hardened1 -> 6.1.59-hardened1
* [`185d0d99`](https://github.com/NixOS/nixpkgs/commit/185d0d9900c0cff028bb0cf5b91f41d5e8a62fed) cockpit: move to by-name
* [`19bb8131`](https://github.com/NixOS/nixpkgs/commit/19bb81314176e2771f34e23a6204a51f1f82550d) go2rtc: 1.8.0 -> 1.8.1
* [`6284e392`](https://github.com/NixOS/nixpkgs/commit/6284e3921472aaca69bface1f8d4e7b0298af70d) python311Packages.django-markup: 1.7.2 -> 1.8.1
* [`9a71ac5b`](https://github.com/NixOS/nixpkgs/commit/9a71ac5ba963a7e2a98f2c8f24891b1bb7a1d588) python311Packages.django-mysql: 4.11.0 -> 4.12.0
* [`f281d55d`](https://github.com/NixOS/nixpkgs/commit/f281d55d877342f099ac31be2be63ab2d9b14ebb) Re-disable CGO apart from tests; version .87
* [`3282bddb`](https://github.com/NixOS/nixpkgs/commit/3282bddba586908294f4f2a15e79708f3ea1e07f) python311Packages.chacha20poly1305-reuseable: 0.4.2 -> 0.10.2
* [`bce303f8`](https://github.com/NixOS/nixpkgs/commit/bce303f80a4102558ddfb9541cb05da2eff75265) matrix-synapse.tools.synadm: 0.43.1 -> 0.44
* [`1642fd5f`](https://github.com/NixOS/nixpkgs/commit/1642fd5f029df3f02acc1a84fb6dde84a62fb9ba) python311Packages.rotary-embedding-torch: 0.3.2 -> 0.3.3
* [`20b62456`](https://github.com/NixOS/nixpkgs/commit/20b62456f0c85b206e59db5f16a7cd0016fa8262) lib/systems/parse.nix: add, use removeAbiSuffix
* [`06f8eb93`](https://github.com/NixOS/nixpkgs/commit/06f8eb9396f9093e2d66939c92dc73bb383b19a5) maintainers: add shivaraj-bh
* [`0425c4de`](https://github.com/NixOS/nixpkgs/commit/0425c4de6d1ebade3c082698a9d47b2f1b0080db) systemd-stage-1: bcachefs decryption
* [`5d306745`](https://github.com/NixOS/nixpkgs/commit/5d306745c7c7dfc5c210b146f66ad2396e2bf5cd) cargo-xwin: init at 0.14.8
* [`e836e568`](https://github.com/NixOS/nixpkgs/commit/e836e568e10984b3a326b1a03f8a2a6d82aa8741) zulu: default to zulu21
* [`871f4846`](https://github.com/NixOS/nixpkgs/commit/871f4846bd459a2ab376baaa6ea7d5aac7d9ce49) waybar-mpris: init at unstable-2022-01-27
* [`d466a347`](https://github.com/NixOS/nixpkgs/commit/d466a3471d2157d2006c9e11a6782054aba257a4) python3Packages.kivy: fix build on Darwin
* [`6f82462f`](https://github.com/NixOS/nixpkgs/commit/6f82462f39a618ca4d3901586d34c9fe6e79cf52) linux/hardened/patches/6.5: 6.5.7-hardened1 -> 6.5.8-hardened1
* [`523d3f14`](https://github.com/NixOS/nixpkgs/commit/523d3f143c6a361d5a5ceea39be100885c61ad54) invidious: fix build with GCC
* [`3635b263`](https://github.com/NixOS/nixpkgs/commit/3635b263cae64a9f917518828254ebd9a38e66fc) czkawka: add .desktop, icons and metainfo
* [`0e4b63f7`](https://github.com/NixOS/nixpkgs/commit/0e4b63f7132894594978d9bf12e604aeaec8ccea) Revert "nixos/systemd-boot: Avoid remote mypy executions"
* [`4ec81766`](https://github.com/NixOS/nixpkgs/commit/4ec81766c24419286ee41b39c04b502ecb770d4d) cockpit: 287 -> 303
* [`f28f6422`](https://github.com/NixOS/nixpkgs/commit/f28f64222941f3d7bbca6d43c7d022c8264e0c81) bruno: 0.17.0 -> 0.27.0
* [`a75d051b`](https://github.com/NixOS/nixpkgs/commit/a75d051be21c4af996978040e695d8cf038efc94) tailspin: 1.5.1 -> 1.6.0
* [`e0680e03`](https://github.com/NixOS/nixpkgs/commit/e0680e03d19395b447d0fe73876719e68fa63345) cockpit: simplify update script
* [`3742d941`](https://github.com/NixOS/nixpkgs/commit/3742d941f436136ca44827285c2d2b6220068f9f) python3Packages.qasync: 0.24.1 -> 0.26.1
* [`c3359081`](https://github.com/NixOS/nixpkgs/commit/c3359081f8ac61bfa78cc6e69227bb66429f824b) python3Packages.orange3: 3.36.0 -> 3.36.1
* [`1c52d103`](https://github.com/NixOS/nixpkgs/commit/1c52d10361bfaaedcc3b98f1a14fc957b9efb205) elpa-packages: updated 2023-10-22 (from overlay)
* [`1f5b0837`](https://github.com/NixOS/nixpkgs/commit/1f5b0837e308f04cabc8e164d1bdc4f956191e49) elpa-devel-packages: updated 2023-10-22 (from overlay)
* [`80c596fc`](https://github.com/NixOS/nixpkgs/commit/80c596fcf30ff02b791edd013950f162831263e0) melpa-packages: updated 2023-10-22 (from overlay)
* [`49daabdb`](https://github.com/NixOS/nixpkgs/commit/49daabdb77fa83527d7fb1a6f32b2dbb09cc35fb) nongnu-packages: updated 2023-10-22 (from overlay)
* [`53ff6688`](https://github.com/NixOS/nixpkgs/commit/53ff668819eb39bb2a247856be74a26906d53581) python3Packages.orange-canvas-core: 0.1.32 -> 0.1.33
* [`03eb6b98`](https://github.com/NixOS/nixpkgs/commit/03eb6b98803daa6365184c30fedb7d6334f2dff8) orange3: fix build
* [`070b5326`](https://github.com/NixOS/nixpkgs/commit/070b5326de4c9b6e7a27fadc03513527a76fa6d9) pdf2xml: drop
* [`b399739b`](https://github.com/NixOS/nixpkgs/commit/b399739bed7c8ddb30bff3b81975cdbeba58d126) viddy: 0.3.7 -> 0.4.0
* [`1f14d762`](https://github.com/NixOS/nixpkgs/commit/1f14d7626c8b4aa2827d3e9b0c32c33722189f25) zettlr: 2.3.0 -> 3.0.2
* [`96c294e7`](https://github.com/NixOS/nixpkgs/commit/96c294e7cacf7158b6f03e82d6f56f79e59c9595) python311Packages.stem: improve expression
* [`86a468b4`](https://github.com/NixOS/nixpkgs/commit/86a468b4735ee762cdcda372c3ee85e50e01280a) vintagestory: 1.18.12 -> 1.18.15
* [`86ae80d2`](https://github.com/NixOS/nixpkgs/commit/86ae80d22c75c02239df77ce37671ec20c6c3ba3) vivaldi: 6.2.3105.54 -> 6.2.3105.58
* [`233e5fd8`](https://github.com/NixOS/nixpkgs/commit/233e5fd81cb44be2d2b5ad26faff5cb0886f7d65) qutebrowser: 3.0.0 -> 3.0.2
* [`b5f04b80`](https://github.com/NixOS/nixpkgs/commit/b5f04b8059dae2f3329fd9801e5a8393285bca4c) cargo-nextest: 0.9.59 -> 0.9.61
* [`cddad20c`](https://github.com/NixOS/nixpkgs/commit/cddad20c11b09977dd31671debffc61d9ab86ee5) helmfile: 0.157.0 -> 0.158.0
* [`2f725bac`](https://github.com/NixOS/nixpkgs/commit/2f725bac328e814186433635cda9712cac9781b4) python311Packages.aioairzone-cloud: 0.2.7 -> 0.3.0
* [`c21a89cd`](https://github.com/NixOS/nixpkgs/commit/c21a89cd66a22a1010a24a0ec754e4a1b1ed4228) homepage-dashboard: 0.7.2 -> 0.7.4
* [`1994a865`](https://github.com/NixOS/nixpkgs/commit/1994a8651b0ecca5ac2dd0c8340e2b43c8aea551) ocamlPackages.carton: 0.6.0 → 0.7.0
* [`e1c765f9`](https://github.com/NixOS/nixpkgs/commit/e1c765f9d8121594108a1589cc6169d040b18258) godns: 3.0.1 -> 3.0.4
* [`931de276`](https://github.com/NixOS/nixpkgs/commit/931de27682fe969fdc2b6842fb0fcd52a1f37213) tempo: backport fix for crashes after Go 1.21 update
* [`ead3a414`](https://github.com/NixOS/nixpkgs/commit/ead3a41497124d1b6041b0355776ae70def6d9c9) python311Packages.pathy: 0.10.2 -> 0.10.3
* [`8b6acac9`](https://github.com/NixOS/nixpkgs/commit/8b6acac9de563ce3ebca39036c2eb8c8882b5ff5) floorp: init at 11.5.0
* [`d733b4e0`](https://github.com/NixOS/nixpkgs/commit/d733b4e072e3a367eceb6edb6253739fc8512619) Fix otelcol vendor hash
* [`6077496c`](https://github.com/NixOS/nixpkgs/commit/6077496cfd291ef062c487694faa8853a7ddf334) python310Packages.awkward-cpp: 22 -> 24
* [`6bdb8010`](https://github.com/NixOS/nixpkgs/commit/6bdb80100eb27b64060c4cae0e1602ac83834a8d) python310Packages.awkward: 2.3.1 -> 2.4.6
* [`53491174`](https://github.com/NixOS/nixpkgs/commit/534911741f908919e0103b2e51010a0f24dfc1c9) python310Packages.dask: 2023.8.0 -> 2023.10.0
* [`ab8a1d6e`](https://github.com/NixOS/nixpkgs/commit/ab8a1d6efc5028b45fa7c0fb64945720351d0d53) python310Packages.distributed: 2023.8.1 -> 2023.10.0
* [`af8a670c`](https://github.com/NixOS/nixpkgs/commit/af8a670c87a49576c29929cd25b77c4601a9e033) python310Packages.dask-awkward: 2023.8.1 -> 2023.10.0
* [`ed8ef58f`](https://github.com/NixOS/nixpkgs/commit/ed8ef58fd9c4a6c2eadd8c48e63fd0f5710a1194) python310Packages.dask-gateway-server: 2022.10.0 -> 2023.9.0
* [`366f7811`](https://github.com/NixOS/nixpkgs/commit/366f7811baf29849cdadd0cbe3d832e0dde89ced) python310Packages.uproot: 5.0.12 -> 5.1.2
* [`0c9d2b67`](https://github.com/NixOS/nixpkgs/commit/0c9d2b67b38b4dc48dbd1e9972ac5a8994569ec4) python310Packages.coffea: 2023.7.0.rc0 -> 2023.10.0.rc1
* [`d42436b1`](https://github.com/NixOS/nixpkgs/commit/d42436b175b8e1daa801381b2f39e19da1f87c5f) postgresqlPackages.pg_uuidv7: init at 1.3.0
* [`b9b49e5e`](https://github.com/NixOS/nixpkgs/commit/b9b49e5ee5ec34e8303c7d9affe83143f73fbb10) python310Packages.correctionlib: fix build
* [`9c61d0ff`](https://github.com/NixOS/nixpkgs/commit/9c61d0ff06d4e3da1f981e67713eefc34095f151) python311Packages.pyfibaro: 0.7.5 -> 0.7.6
* [`3bd3809d`](https://github.com/NixOS/nixpkgs/commit/3bd3809d0e5cb8ada73d0ee856b6ad9121cc907e) buildRustCrate: add isMips64n32 to badPlatforms
* [`4fc0e336`](https://github.com/NixOS/nixpkgs/commit/4fc0e3369810899279f0423699e2604e7088ff76) buildRustPackage: add isMips64n32 to badPlatforms
* [`249a3f6b`](https://github.com/NixOS/nixpkgs/commit/249a3f6bf3fc739cfcd40f73801e68763078adb8) python311Packages.pymunk: 6.5.1 -> 6.5.2
* [`7b9fa5f6`](https://github.com/NixOS/nixpkgs/commit/7b9fa5f6c36e91b3ea6b2e97c647a062af951c46) crate2nix: 0.10.0 -> 0.11.0
* [`69919a28`](https://github.com/NixOS/nixpkgs/commit/69919a28af1c181dc84523b100a8ed45d4071304) verilator: 5.012 -> 5.016
* [`4c597607`](https://github.com/NixOS/nixpkgs/commit/4c5976077891c9fe8a78adeaa83f0b0db77d1361) python311Packages.pywemo: 1.3.0 -> 1.3.1
* [`90b4574e`](https://github.com/NixOS/nixpkgs/commit/90b4574eafe92caddd634fe9e9a41a38c338a5b8) python311Packages.qbittorrent-api: 2023.9.53 -> 2023.10.54
* [`c8ae9117`](https://github.com/NixOS/nixpkgs/commit/c8ae9117bf2d47fdb5bff1c27b3b5b4e8ab14d1e) lzlib: fix cross
* [`3ceea278`](https://github.com/NixOS/nixpkgs/commit/3ceea2785ec8111283cece7085903876d6f2f396) evcxr: 0.15.1 -> 0.16.0
* [`cb39b1f3`](https://github.com/NixOS/nixpkgs/commit/cb39b1f3cd983f1ae36c6badedc49ada6fe3cb28) python311Packages.sphinx-tabs: 3.4.1 -> 3.4.4
* [`5bc9a594`](https://github.com/NixOS/nixpkgs/commit/5bc9a5944ef8fac0fd49dbcc9c3a9e95f42e9453) python311Packages.validobj: 1.0 -> 1.1
* [`ee0d2695`](https://github.com/NixOS/nixpkgs/commit/ee0d269562057bdeee36b0415db317313a4b49c0) proverif: 2.04 → 2.05
* [`c315a411`](https://github.com/NixOS/nixpkgs/commit/c315a4118a0cd9f62ecb194450f02adb555359d3) python311Packages.python-gvm: 23.10.0 -> 23.10.1
* [`14019b72`](https://github.com/NixOS/nixpkgs/commit/14019b7268883067e35bbdedcc84c8c297692f4f) sbt: 1.9.6 -> 1.9.7
* [`2f7e9723`](https://github.com/NixOS/nixpkgs/commit/2f7e972374bc999e13dc6c40fb7d4d313db21bf6) tellico: 3.5.1 -> 3.5.2
* [`c9fd3c63`](https://github.com/NixOS/nixpkgs/commit/c9fd3c63b228951eb21c769023dde9561f5ecf0a) unifont_upper: 15.1.02 -> 15.1.03
* [`358f8720`](https://github.com/NixOS/nixpkgs/commit/358f872017fe7adc587ba93e54b6798e831ef7e9) maintainers: add jakuzure
* [`59c14df1`](https://github.com/NixOS/nixpkgs/commit/59c14df1926fdd72604059067504a775560c6e4d) openmpi: 4.1.5 -> 4.1.6
* [`514a558d`](https://github.com/NixOS/nixpkgs/commit/514a558d64ab10271a773fff2d40008a30d5c05f) python310Packages.libknot: init at 3.3.2
* [`46b989f9`](https://github.com/NixOS/nixpkgs/commit/46b989f924f4d0f450ec1948b2de99293d563669) prometheus-knot-exporter: 2021-08-21 -> 3.3.2
* [`589ccfda`](https://github.com/NixOS/nixpkgs/commit/589ccfdac1ec6ae0e38f4f253f69be50c8713e1b) nixos/prometheus-exporters/knot: update for new exporter
* [`715afeb4`](https://github.com/NixOS/nixpkgs/commit/715afeb48ba1eb511548b85e6fa792d768fac44e) nixos/tests/prometheus-exporters/knot: update for new exporter version
* [`d4b380d6`](https://github.com/NixOS/nixpkgs/commit/d4b380d6a7efdb772c0fa31d4c3b4c15c3051c36) knot-dns: test exporter in passthru.tests
* [`b20261a2`](https://github.com/NixOS/nixpkgs/commit/b20261a2f29f9f6fb210b856c14c21cf9ebc801f) vtm: 0.9.9u -> 0.9.9w.1
* [`9593318c`](https://github.com/NixOS/nixpkgs/commit/9593318c0d89b6f6ba2147347ab7b5c14f189553) extremetuxracer: set meta.mainProgram
* [`6ae8e334`](https://github.com/NixOS/nixpkgs/commit/6ae8e33459cc9b720d68cbe472fd2c200215fb01) python311Packages.publicsuffixlist: 0.10.0.20231020 -> 0.10.0.20231022
* [`ccebc899`](https://github.com/NixOS/nixpkgs/commit/ccebc899547d6962a01fb07a98c863caec7d7486) nixos/tests: add nixos-rebuild-install-bootloader
* [`ab3ca40d`](https://github.com/NixOS/nixpkgs/commit/ab3ca40d2e2145ca342cb7725ad21bb14190a05d) nixos/release-combined: add nixos-rebuild-specialisations to release-combined
* [`65cb8b4e`](https://github.com/NixOS/nixpkgs/commit/65cb8b4e01c43d20b820e8c938f53a54f76cc3b1) nixos/tests: make nixos-rebuild tests x86_64-linux only
* [`a2471235`](https://github.com/NixOS/nixpkgs/commit/a2471235a8fbafcd6acabe128c45c55bccc65c54) perlPackages.LogfileRotate: init at 1.04
* [`758dd38b`](https://github.com/NixOS/nixpkgs/commit/758dd38b7c30298131a2ccdc35c01acebbd5648c) perlPackages.FileShareDirDist: init at 0.07
* [`0c7e2041`](https://github.com/NixOS/nixpkgs/commit/0c7e204138281a2f3e20f69daab3612b6796c5ab) perlPackages.MojoliciousPluginRenderFile: init at 0.12
* [`7264445b`](https://github.com/NixOS/nixpkgs/commit/7264445b895dfd5e156474a52485a7ebae3e9134) perlPackages.MojoliciousPluginTemplateToolkit: init at 0.006
* [`b6bc7bc0`](https://github.com/NixOS/nixpkgs/commit/b6bc7bc0a734e710c4c7498a3682fa4eb1f3d036) perlPackages.MinionBackendRedis: init at 0.003
* [`b5e36793`](https://github.com/NixOS/nixpkgs/commit/b5e3679394bc4006587f92491e07765090b104ab) perlPackages.NetDNSNative: init at 0.22
* [`01adead0`](https://github.com/NixOS/nixpkgs/commit/01adead0b4c3025654660b44fbe8da55ce094d85) perlPackages.ParallelLoops: init at 0.10
* [`9a4eb323`](https://github.com/NixOS/nixpkgs/commit/9a4eb3234a4e4fb3aa05858d62727f70f28eddbf) perlPackages.AlienFFI: init at 0.27
* [`92c4f2d4`](https://github.com/NixOS/nixpkgs/commit/92c4f2d4a94bb1002433fc7d8fa76ea0626f82c4) perlPackages.FFIPlatypus: init at 2.08
* [`0be11fef`](https://github.com/NixOS/nixpkgs/commit/0be11fef8eafa96ff647357a1813585866358e4b) perlPackages.Test2ToolsFFI: init at 0.06
* [`f4aaa984`](https://github.com/NixOS/nixpkgs/commit/f4aaa984f97b180513f85dcca27fad22a21ecf1f) perlPackages.Test2ToolsMemoryCycle: init at 0.01
* [`1bb779a8`](https://github.com/NixOS/nixpkgs/commit/1bb779a8d1ab1d179e4ccb98b3e8fd45f208e922) perlPackages.FFIPlatypusTypePtrObject: init at 0.03
* [`91c89878`](https://github.com/NixOS/nixpkgs/commit/91c898787ed1e278a1e68e3bdd6858fb6f7d919a) perlPackages.FFIPlatypusTypeEnum: init at 0.06
* [`3dec988a`](https://github.com/NixOS/nixpkgs/commit/3dec988ae7703eee769e057cdac2cb07be03fc32) perlPackages.FFIC: init at 0.15
* [`79838e5e`](https://github.com/NixOS/nixpkgs/commit/79838e5e7b2a50dec6cfe921f8f47b3ba38e42b9) perlPackages.FFICStat: init at 0.02
* [`77867843`](https://github.com/NixOS/nixpkgs/commit/77867843fbb2d6995d00f187f9f5311eaa89e84a) perlPackages.TestArchiveLibarchive: init at 0.02
* [`d12237ef`](https://github.com/NixOS/nixpkgs/commit/d12237ef2fc298191337088f086f47c8c4d66e64) perlPackages.ArchiveLibarchive: init at 0.08
* [`7003b5aa`](https://github.com/NixOS/nixpkgs/commit/7003b5aaa35574bda9030f63ea3de32d806e6dcc) perlPackages.ArchiveLibarchiveExtract: init at 0.03
* [`9bf12790`](https://github.com/NixOS/nixpkgs/commit/9bf12790113896378b438de4c15c305db3a3e1d7) perlPackages.ArchiveLibarchivePeek: init at 0.04
* [`5a3ef293`](https://github.com/NixOS/nixpkgs/commit/5a3ef293c48424dbccb52277a98dabcfb080f620) perlPackages.SysCpuAffinity: init at 1.12
* [`e9e06ffe`](https://github.com/NixOS/nixpkgs/commit/e9e06ffec6e682ff8b3e7ccb2bae5abe7be20fe5) gvm-tools: 23.9.0 -> 23.10.0
* [`87ea53f7`](https://github.com/NixOS/nixpkgs/commit/87ea53f7c9b1093cc5f74b282e5e6ef1710be5cb) lgogdownloader: 3.11 -> 3.12
* [`47ea99dd`](https://github.com/NixOS/nixpkgs/commit/47ea99dd5a56b14b8bc9c86e2909d9492eba65b7) armcord: remove unnecessary `splitString`
* [`40920ff1`](https://github.com/NixOS/nixpkgs/commit/40920ff12b330460167b597fdfbf80fecac91bcb) evcc: 0.120.3 -> 0.121.2
* [`100603f1`](https://github.com/NixOS/nixpkgs/commit/100603f1ad8dfbd09ac76db4456d692bb9375b11) nushellPlugins: update to nushell 0.86.0
* [`cee03e76`](https://github.com/NixOS/nixpkgs/commit/cee03e7670305dac6e28b815f01095adc4a62057) nushellPlugins.net: init at unstable-2023-09-27
* [`12a27740`](https://github.com/NixOS/nixpkgs/commit/12a2774096e81b39981023a7a6e1f405fc59fb75) nushellPlugins.regex: remove unused arg
* [`2201fa71`](https://github.com/NixOS/nixpkgs/commit/2201fa719978b02da5fab81c197c2002f1d081f4) nu_scripts: unstable-2023-10-07 -> unstable-2023-10-19
* [`f10674a4`](https://github.com/NixOS/nixpkgs/commit/f10674a42c75319027e57ffc609030b3d884128e) python311Packages.dj-rest-auth: fix tests
* [`483eaea5`](https://github.com/NixOS/nixpkgs/commit/483eaea5f28ff1c8e9813f40ed86c9c8992cc82e) python311Packages.adguardhome: 0.6.1 -> 0.6.2
* [`189c3c75`](https://github.com/NixOS/nixpkgs/commit/189c3c75fd5fb4594dba010c36065e8a3b985c02) sing-box: 1.5.3 -> 1.5.4
* [`c85bf013`](https://github.com/NixOS/nixpkgs/commit/c85bf0137df4d686cf080b05520800f92ee2a1d6) python311Packages.aioapns: 3.0 -> 3.1
* [`cfea4923`](https://github.com/NixOS/nixpkgs/commit/cfea4923c62373e861fbefb87d866a004a24c342) pgmoneta: 0.7.0 -> 0.7.1
* [`bd1fbd67`](https://github.com/NixOS/nixpkgs/commit/bd1fbd67f2eb1db6d353a3fa08ef7302d5692f78) sphinx-automodapi: fix import check, tests, use pyproject
* [`72ee8d9f`](https://github.com/NixOS/nixpkgs/commit/72ee8d9f12f91d84486944ea621257622ee47bfc) python3.pkgs.django-allauth-2fa: init at 0.11.1
* [`61a9e5e7`](https://github.com/NixOS/nixpkgs/commit/61a9e5e7c6c0f17018e0d2709c67d0cb68e8ead6) pipx: 1.2.0 -> 1.2.1
* [`7ffbdbaa`](https://github.com/NixOS/nixpkgs/commit/7ffbdbaa41070fb7dfafbdfaf7cf99736ba8410d) python311Packages.drf-spectacular: fix tests
* [`7570b91f`](https://github.com/NixOS/nixpkgs/commit/7570b91f6819d5017abf57a5eb9cb95c6095ff3e) hdf5: fix runtime error on darwin
* [`03938279`](https://github.com/NixOS/nixpkgs/commit/03938279300e131408db1dddfbeacd1df8c3de40) python3.pkgs.django-pwa: init at 1.1.0
* [`2f90fcb9`](https://github.com/NixOS/nixpkgs/commit/2f90fcb9734fe0cd7ce414c32bb157ceb9309701) neovim-qt-unwrapped: 0.2.17 -> 0.2.18
* [`f9656cc7`](https://github.com/NixOS/nixpkgs/commit/f9656cc72b93948a794cefcc4641296618833084) quake3-wrapper: Fix paths
* [`61658462`](https://github.com/NixOS/nixpkgs/commit/616584627a1a341ae7070db3f1c1fcd9a6980534) mullvad: 2023.3 -> 2023.5
* [`a3fcdd0c`](https://github.com/NixOS/nixpkgs/commit/a3fcdd0c3dd8f489946c2e0941e0ba7799d0f005) svd2rust: 0.30.1 -> 0.30.2
* [`a845a716`](https://github.com/NixOS/nixpkgs/commit/a845a7162cb493dcf9c743533c2dbaff3cea40a2) tf-summarize: 0.3.3 -> 0.3.6
* [`c9a11857`](https://github.com/NixOS/nixpkgs/commit/c9a118576512f722fedc85d0b207ffa7a52dbb83) xfce.xfce4-notifyd: 0.9.2 -> 0.9.3
* [`af557a58`](https://github.com/NixOS/nixpkgs/commit/af557a587bc65669154d30607affd0d416f2b938) typora: 1.7.5 -> 1.7.6
* [`f833d6f7`](https://github.com/NixOS/nixpkgs/commit/f833d6f755e8cfeff579b5d9ac3562207dc88fbf) python311Packages.fakeredis: 2.19.0 -> 2.20.0
* [`64754a98`](https://github.com/NixOS/nixpkgs/commit/64754a988e7b0615c2ea94aea4b5e251228466e8) python311Packages.google-cloud-trace: 1.11.2 -> 1.11.3
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
