### PR TITLE
niv home-manager: update f540f30f -> 8e5416b4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f540f30f1f3c76b68922550dcf5f78f42732fd37",
-        "sha256": "15i1wczgbknh1dm8kf2d7rncaaa01gj47s4bsg8aip2hv2l3r99g",
+        "rev": "8e5416b478e465985eec274bc3a018024435c106",
+        "sha256": "1d3hs2i3k9ifl0as15irb94kq26s9vnl01srrpbz2c2193fjw0ld",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f540f30f1f3c76b68922550dcf5f78f42732fd37.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/8e5416b478e465985eec274bc3a018024435c106.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f540f30f...8e5416b4](https://github.com/nix-community/home-manager/compare/f540f30f1f3c76b68922550dcf5f78f42732fd37...8e5416b478e465985eec274bc3a018024435c106)

* [`6045b68e`](https://github.com/nix-community/home-manager/commit/6045b68ee725167ed0487f0fb88123202ba61923) cava: add module
* [`14b54157`](https://github.com/nix-community/home-manager/commit/14b54157201fd574b0fa1b3ce7394c9d3a87fbc1) sxhkd: set scope OOMPolicy to continue
* [`9d0f799c`](https://github.com/nix-community/home-manager/commit/9d0f799c669833677df31306149d763dbff00e6f) helix: add extraPackages option
* [`09587fbb`](https://github.com/nix-community/home-manager/commit/09587fbbc6a669f7725613e044c2577dc5d43ab5) hyprland: add tray.target
* [`1369d2ce`](https://github.com/nix-community/home-manager/commit/1369d2cefb6f128c30e42fabcdebbacc07e18b3f) aerc: fix config paths on darwin
* [`f92a54fe`](https://github.com/nix-community/home-manager/commit/f92a54fef4eacdbe86b0a2054054dd58b0e2a2a4) wezterm: remove automatic config reload call
* [`8e5416b4`](https://github.com/nix-community/home-manager/commit/8e5416b478e465985eec274bc3a018024435c106) services.swayidle: change target to generic session ([nix-community/home-manager⁠#3913](https://togithub.com/nix-community/home-manager/issues/3913))
