### PR TITLE
niv zsh-completions: update ac96055f -> a0f027a1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "ac96055f0c4c2cad282d8c17a8e608899506573f",
-        "sha256": "0kbbcznhybgnxy6a2nviy42yi8g1ym150hwsvdivll7zjx2pbk4k",
+        "rev": "a0f027a1de9272d22ce20465d660d7b611f30cf0",
+        "sha256": "158qa0ilkjvszdi847zg86rga7xj6pn3gmd1ncs4sanxgxc3w43k",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/ac96055f0c4c2cad282d8c17a8e608899506573f.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/a0f027a1de9272d22ce20465d660d7b611f30cf0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@ac96055f...a0f027a1](https://github.com/zsh-users/zsh-completions/compare/ac96055f0c4c2cad282d8c17a8e608899506573f...a0f027a1de9272d22ce20465d660d7b611f30cf0)

* [`e097ee8b`](https://github.com/zsh-users/zsh-completions/commit/e097ee8b0c633f2bd11247b88a955a8ec3c4d7f6) Update node.js for version 21.1.0
