### PR TITLE
niv zsh-syntax-highlighting: update 143b25eb -> bb27265a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -240,10 +240,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "143b25eb98aa3227af63bd7f04413e1b3e7888ec",
-        "sha256": "1j8zjf4k0f78p4ihb5y1mml30ksakskb99q1fms0xabm9rr858ac",
+        "rev": "bb27265aeeb0a22fb77f1275118a5edba260ec47",
+        "sha256": "173a4mlydq9vs617wgsw1p06pflvgbnzrfhz4nf5pxmhfhljhgbc",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/143b25eb98aa3227af63bd7f04413e1b3e7888ec.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/bb27265aeeb0a22fb77f1275118a5edba260ec47.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@143b25eb...bb27265a](https://github.com/zsh-users/zsh-syntax-highlighting/compare/143b25eb98aa3227af63bd7f04413e1b3e7888ec...bb27265aeeb0a22fb77f1275118a5edba260ec47)

* [`65071902`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/65071902d306d543b2eecc6e954c6adaec9238a2) docs: add instructions to source .zshrc file after package install
* [`dd0cf649`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/dd0cf649d13e9bfdb86d6bf2c3df0131a0ab5df3) *: Use https in URLs
* [`1e82d8c8`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/1e82d8c83efa8b9fd0c7d1b9baffeb47d6cff960) changelog: Update through HEAD
* [`f8cd0b55`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/f8cd0b55b3d134cbc71360c94737528bca1a526f) docs: Replace zplug instructions with zinit
* [`0b5b3dcc`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/0b5b3dcc0c603c9e1b3ad9d59b3d923a4b2d2437) tests: parameter-to-global-alias: Use alias name less likely to clash
* [`e82e2d04`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/e82e2d042d55391e5c136c92ead4714db2d60b1a) main: precommand_options += ktrace
* [`d59ce0fb`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/d59ce0fbd014bd69b1eed21c029c0d51bf8d6a09) driver: Be resilient to KSH_ARRAYS being set in the calling scope
* [`71bd576a`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/71bd576af836517bda6dd574ef81176339144568)  CI += zsh 5.9
* [`bb27265a`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/bb27265aeeb0a22fb77f1275118a5edba260ec47) CI: Update action versions
