### PR TITLE
niv emacs-overlay: update a8239b33 -> cc3249d5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a8239b33859352caabc400e051c649481f4a02b2",
-        "sha256": "12avqrj96b634g1m73y6ayin2cr8q5vw6ml0r81iv8ws6g2h6py7",
+        "rev": "cc3249d5b0eb6600f253a1f7be45343ffcc4b89e",
+        "sha256": "1l5rjgvifrnkzxd81xrzh2mphh66x41899hjm95qr8bfisyz7w9j",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/a8239b33859352caabc400e051c649481f4a02b2.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/cc3249d5b0eb6600f253a1f7be45343ffcc4b89e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@a8239b33...cc3249d5](https://github.com/nix-community/emacs-overlay/compare/a8239b33859352caabc400e051c649481f4a02b2...cc3249d5b0eb6600f253a1f7be45343ffcc4b89e)

* [`59c639a9`](https://github.com/nix-community/emacs-overlay/commit/59c639a964b9cd9b00dca16cec0a5bb2ee26dcf7) Updated repos/elpa
* [`3da47d84`](https://github.com/nix-community/emacs-overlay/commit/3da47d846ea672a2e7a3c8a9e538618fdd19b9f7) Updated repos/emacs
* [`35cd314b`](https://github.com/nix-community/emacs-overlay/commit/35cd314b91697767a763df184ef4e94400a96b86) Updated repos/melpa
* [`8153d977`](https://github.com/nix-community/emacs-overlay/commit/8153d977806a632fe03acee3764cce5a8ed12cd8) Updated repos/nongnu
* [`b54ed5aa`](https://github.com/nix-community/emacs-overlay/commit/b54ed5aa66cc7c4635a7614c6328c25106e6c21b) Updated flake inputs
* [`f2236bf5`](https://github.com/nix-community/emacs-overlay/commit/f2236bf572eee26ca93fe164eed298ad53d61126) Updated repos/emacs
* [`5f14ec7a`](https://github.com/nix-community/emacs-overlay/commit/5f14ec7a4977810a06f8eacb0169374fb4e282e9) Updated repos/melpa
* [`0f5d0409`](https://github.com/nix-community/emacs-overlay/commit/0f5d040994de82f841b7439b833b7b4e72fc34a7) Updated flake inputs
* [`ca517642`](https://github.com/nix-community/emacs-overlay/commit/ca5176423287022792ad6f6786c4ed398ad27126) Updated repos/elpa
* [`3d75bfc1`](https://github.com/nix-community/emacs-overlay/commit/3d75bfc1e3b4c392d4a3d27e2285b7aee128493d) Updated repos/emacs
* [`7b82fa15`](https://github.com/nix-community/emacs-overlay/commit/7b82fa153cc9f8961e1f9b3ef28f2a1dd423706d) Updated repos/melpa
* [`02a8a841`](https://github.com/nix-community/emacs-overlay/commit/02a8a8417837a9198bd008ed6b5016c0c83452e3) Updated repos/elpa
* [`fa9806ca`](https://github.com/nix-community/emacs-overlay/commit/fa9806caeeb75411ad9a1640d4c6b5b2698abca7) Updated repos/emacs
* [`26f0a46f`](https://github.com/nix-community/emacs-overlay/commit/26f0a46fa1840073d942353c29ef634a4d5db146) Updated repos/melpa
* [`9f78ee90`](https://github.com/nix-community/emacs-overlay/commit/9f78ee906eb5034ed79c90d22dfd5680f27d7136) Updated repos/emacs
* [`f7181b8a`](https://github.com/nix-community/emacs-overlay/commit/f7181b8a48e4087826dfc1eeea51521a638bbc8e) Updated repos/melpa
* [`c231089a`](https://github.com/nix-community/emacs-overlay/commit/c231089aff799637747034d067fc4459753aa717) Updated repos/nongnu
* [`2e4925af`](https://github.com/nix-community/emacs-overlay/commit/2e4925af108af1e7d0903ed2d199341897a1ca6b) Updated repos/elpa
* [`20703168`](https://github.com/nix-community/emacs-overlay/commit/20703168b6bcafacef5bf87962d81e00be7a4a15) Updated repos/melpa
* [`0dee9a72`](https://github.com/nix-community/emacs-overlay/commit/0dee9a72e827a826937a249ac1abf212e1d2d6d7) Updated repos/elpa
* [`563b70a5`](https://github.com/nix-community/emacs-overlay/commit/563b70a53de0172fc239b8efe136909deff63b21) Updated repos/emacs
* [`9519fc6b`](https://github.com/nix-community/emacs-overlay/commit/9519fc6bbeed69a3f94e9989fe27feb9425ecadc) Updated repos/melpa
* [`205b18fc`](https://github.com/nix-community/emacs-overlay/commit/205b18fcd20edad37e79c8598f6a799b70a6d4a3) Updated repos/nongnu
* [`8c635c17`](https://github.com/nix-community/emacs-overlay/commit/8c635c17a58475fc040e5e667611a562b2d852aa) Updated repos/emacs
* [`a202ec0d`](https://github.com/nix-community/emacs-overlay/commit/a202ec0db49962241a811481ba15ac7e98ebad04) Updated repos/melpa
* [`09babb5c`](https://github.com/nix-community/emacs-overlay/commit/09babb5c45cfbb1580319f1786f9288172dc1f57) Updated repos/elpa
* [`a46a8e95`](https://github.com/nix-community/emacs-overlay/commit/a46a8e95edc4bd84f37feff0cdb52e65fdcc12a7) Updated repos/emacs
* [`d88c1d26`](https://github.com/nix-community/emacs-overlay/commit/d88c1d26a6874ab9ef657753e170bbcee7506ce1) Updated repos/melpa
* [`ae7bf9cb`](https://github.com/nix-community/emacs-overlay/commit/ae7bf9cb51d89d4ebdadeedacb505ec2452957c9) Updated flake inputs
* [`61b9351c`](https://github.com/nix-community/emacs-overlay/commit/61b9351cbccfe5381124189d84a680047b45f5d0) Updated repos/elpa
* [`7e50eac2`](https://github.com/nix-community/emacs-overlay/commit/7e50eac2420a044e5dd81c214c9ceaca332a75e7) Updated repos/emacs
* [`f2cbadb9`](https://github.com/nix-community/emacs-overlay/commit/f2cbadb9c68d0562f15961ee79e9152c4e4ede4f) Updated repos/melpa
* [`412726c6`](https://github.com/nix-community/emacs-overlay/commit/412726c6afe83d316116883d0e67411c7b92f2cd) Updated repos/nongnu
* [`b5cd865d`](https://github.com/nix-community/emacs-overlay/commit/b5cd865dfced7090920e9fcf4504def79769c687) Updated flake inputs
* [`1b859076`](https://github.com/nix-community/emacs-overlay/commit/1b859076f98c7ba304a5af76e6724117f99366f7) Updated repos/emacs
* [`61ba9eca`](https://github.com/nix-community/emacs-overlay/commit/61ba9eca21db0a7e8a6471d11f3f6f74b79a70ba) Updated repos/melpa
* [`58658cd3`](https://github.com/nix-community/emacs-overlay/commit/58658cd3561df53984a7059330744302bfa72d22) Updated repos/elpa
* [`75661d12`](https://github.com/nix-community/emacs-overlay/commit/75661d121061e9605faf797288c7607182c6b9f3) Updated repos/emacs
* [`d1a4d78b`](https://github.com/nix-community/emacs-overlay/commit/d1a4d78b072580fa4a627b667cec417aea995f15) Updated repos/melpa
* [`5d3420b5`](https://github.com/nix-community/emacs-overlay/commit/5d3420b52d31bec234b128ac422aef0328a60cf4) Updated repos/elpa
* [`4f989f47`](https://github.com/nix-community/emacs-overlay/commit/4f989f47a2ebfdb7f14058880f09e87da837587b) Updated repos/emacs
* [`73c7af80`](https://github.com/nix-community/emacs-overlay/commit/73c7af80973a82e17a598076f098847e1f41e95c) Updated repos/melpa
* [`7dc7aec2`](https://github.com/nix-community/emacs-overlay/commit/7dc7aec2339f0e4d200bcd13b309cc14ec59bd2b) Updated flake inputs
* [`1546b25d`](https://github.com/nix-community/emacs-overlay/commit/1546b25de198b62919855da6c6c4f0061abba5dc) Updated repos/emacs
* [`5eba7d96`](https://github.com/nix-community/emacs-overlay/commit/5eba7d96a70b1aad7918b07a4f6563362a8255b7) Updated repos/melpa
* [`16d6c700`](https://github.com/nix-community/emacs-overlay/commit/16d6c70044fc735d863f2181e0e63a7f1fac5db1) Updated repos/elpa
* [`06671e10`](https://github.com/nix-community/emacs-overlay/commit/06671e1036d2e51cc0a2a7de43affef851246439) Updated repos/emacs
* [`804c3f5e`](https://github.com/nix-community/emacs-overlay/commit/804c3f5ecc955fd7fa2e70be2f2937b5a2c05f26) Updated repos/melpa
* [`2a7fb653`](https://github.com/nix-community/emacs-overlay/commit/2a7fb653cc84efc62bfd460709fcf6c1ab8752f9) Updated repos/elpa
* [`21521dc7`](https://github.com/nix-community/emacs-overlay/commit/21521dc7d053e232dd6efd2d219a4225241a500a) Updated repos/emacs
* [`d800f754`](https://github.com/nix-community/emacs-overlay/commit/d800f754cd0717a45052f9feef10b7357f5b0a14) Updated repos/melpa
* [`bff45ef9`](https://github.com/nix-community/emacs-overlay/commit/bff45ef9a6e5bb1e8c5cb08ecf4bc9f8823be7c7) Updated repos/nongnu
* [`b3bcc646`](https://github.com/nix-community/emacs-overlay/commit/b3bcc6462565999f840a3eed7db528d768ba55c4) Updated repos/emacs
* [`d281e212`](https://github.com/nix-community/emacs-overlay/commit/d281e212b96ccacf6d768b14f21ac392f55d36ef) Updated repos/melpa
* [`2308be43`](https://github.com/nix-community/emacs-overlay/commit/2308be4351ab8a152248a48baebf22649c83a487) Updated repos/nongnu
* [`27265eca`](https://github.com/nix-community/emacs-overlay/commit/27265eca82bc54d39e15d665ae871a6be6008f15) Updated repos/elpa
* [`843e213a`](https://github.com/nix-community/emacs-overlay/commit/843e213a54b0e21a6cff48453ed06bd6133ff9c6) Updated repos/emacs
* [`54087a1b`](https://github.com/nix-community/emacs-overlay/commit/54087a1b3a7ef51d0968bbfa7a700d2848ffae9c) Updated repos/melpa
* [`f8804319`](https://github.com/nix-community/emacs-overlay/commit/f8804319371a4a5eb2e1d211da5ce25f70c7d932) Updated flake inputs
* [`8f8a0690`](https://github.com/nix-community/emacs-overlay/commit/8f8a0690bd203e7418ebf20456acb8893a96661b) Updated repos/elpa
* [`4c0652ca`](https://github.com/nix-community/emacs-overlay/commit/4c0652caa2d9f958b4b7a243b8339936dafb4a43) Updated repos/emacs
* [`0de859c1`](https://github.com/nix-community/emacs-overlay/commit/0de859c1a3cf76a4750d2e1252b124de588f1607) Updated repos/melpa
* [`e47ab91a`](https://github.com/nix-community/emacs-overlay/commit/e47ab91a68eb9f5f283cea02bfbcb186332d496a) Updated repos/emacs
* [`01ec8b0a`](https://github.com/nix-community/emacs-overlay/commit/01ec8b0aa9297d8668c475a60b942ae79303c462) Updated repos/melpa
* [`dad180d7`](https://github.com/nix-community/emacs-overlay/commit/dad180d78df8942ca14116b42525cc510b0ddf8d) Updated repos/nongnu
* [`cd2751d7`](https://github.com/nix-community/emacs-overlay/commit/cd2751d7cd750f6fa8233bfffc1e3a472cba3167) Updated repos/elpa
* [`bf9c7c8f`](https://github.com/nix-community/emacs-overlay/commit/bf9c7c8fd7951982c3df20335eac205b971b86c8) Updated repos/emacs
* [`e8cbdc1b`](https://github.com/nix-community/emacs-overlay/commit/e8cbdc1b2799fdaa6a4967ca65b4320853b35672) Updated repos/melpa
* [`fd9abdf5`](https://github.com/nix-community/emacs-overlay/commit/fd9abdf529d2eae96f62d665c795d0806262f117) Updated flake inputs
* [`75739329`](https://github.com/nix-community/emacs-overlay/commit/75739329e524fe4cb1cbab10f52541c8ea9241a7) Updated repos/elpa
* [`11317e83`](https://github.com/nix-community/emacs-overlay/commit/11317e83c74dcc4b08065e50f266de3dfa37440c) Updated repos/emacs
* [`82456a79`](https://github.com/nix-community/emacs-overlay/commit/82456a7911d6c945538faf9c3939502cbea0c4a7) Updated repos/melpa
* [`3f942773`](https://github.com/nix-community/emacs-overlay/commit/3f942773192735d987ab517ceaae2a0479d4e601) Updated repos/nongnu
* [`01a70684`](https://github.com/nix-community/emacs-overlay/commit/01a70684f761ce069ca29185fea6e1e2d4b6b99f) Updated flake inputs
* [`7b990e2f`](https://github.com/nix-community/emacs-overlay/commit/7b990e2f1e4644d8a0a868380389c58f90868299) Updated repos/emacs
* [`809579eb`](https://github.com/nix-community/emacs-overlay/commit/809579ebfa30e1f557dab8fef3ab848f1f7a4312) Updated repos/melpa
* [`c7ac54dd`](https://github.com/nix-community/emacs-overlay/commit/c7ac54dd8409046d50d17c11d4fa29a782b37804) Updated repos/nongnu
* [`c2654b32`](https://github.com/nix-community/emacs-overlay/commit/c2654b32856c586c8f4b6dd1d60359291f90b73d) Updated repos/elpa
* [`99adec38`](https://github.com/nix-community/emacs-overlay/commit/99adec381af79c58314bde4545cb08346406d4b7) Updated repos/melpa
* [`d761233e`](https://github.com/nix-community/emacs-overlay/commit/d761233edac5c05d2ed785d345cde51d8d052491) Updated repos/elpa
* [`2cb0bd49`](https://github.com/nix-community/emacs-overlay/commit/2cb0bd49ed9507478281ab0955df00302c0af5c6) Updated repos/emacs
* [`9a644118`](https://github.com/nix-community/emacs-overlay/commit/9a64411895ed66edf61b8b6a4d30271565a471d2) Updated repos/melpa
* [`b383ed4c`](https://github.com/nix-community/emacs-overlay/commit/b383ed4c8436167c24289af1d034ef76130f2bfc) Updated repos/nongnu
* [`7bdac242`](https://github.com/nix-community/emacs-overlay/commit/7bdac242d7b8359da8aa494c8b36e3236c81d2c5) Updated repos/emacs
* [`bdbe672d`](https://github.com/nix-community/emacs-overlay/commit/bdbe672d553baaf44aa6b5b97b3515fa307558a3) Updated repos/melpa
* [`8cbc4395`](https://github.com/nix-community/emacs-overlay/commit/8cbc4395c5eb0deb2ae37c43c1f2b4a3fc387598) Updated repos/elpa
* [`3e5397cf`](https://github.com/nix-community/emacs-overlay/commit/3e5397cf6e91582f37186842b2f561246d590c00) Updated repos/emacs
* [`460e804f`](https://github.com/nix-community/emacs-overlay/commit/460e804ff3575ceaa3db71d9f1c1afa4de33e0e1) Updated repos/melpa
* [`76b6b84a`](https://github.com/nix-community/emacs-overlay/commit/76b6b84a22df906734471bacc52d38969ba2eb8f) Updated repos/elpa
* [`09420cad`](https://github.com/nix-community/emacs-overlay/commit/09420cad26cb84d0e935303898fdf7473c7a3b0f) Updated repos/emacs
* [`080201e6`](https://github.com/nix-community/emacs-overlay/commit/080201e6625c3783d370acdf78a2b9e6f2d8eaec) Updated repos/melpa
* [`c9995f7c`](https://github.com/nix-community/emacs-overlay/commit/c9995f7cd865c9d3b1dc27cf25999fd2f9e10ef7) Updated repos/nongnu
* [`1c755624`](https://github.com/nix-community/emacs-overlay/commit/1c755624c21271ccac9e6039506a31472674b31a) Updated repos/emacs
* [`85b061ae`](https://github.com/nix-community/emacs-overlay/commit/85b061aefa29e54da20356aaab9abe6a2cb824d7) Updated repos/melpa
* [`4ae79826`](https://github.com/nix-community/emacs-overlay/commit/4ae7982669b68a7b1dcc40753530b5d5a63f72e1) Updated repos/elpa
* [`302084dd`](https://github.com/nix-community/emacs-overlay/commit/302084ddd0bb81f51633d32148710da14a6d82d8) Updated repos/emacs
* [`f5a40daa`](https://github.com/nix-community/emacs-overlay/commit/f5a40daaee5ccbea1675a7a4e47a84ce919e769f) Updated repos/melpa
* [`dca77684`](https://github.com/nix-community/emacs-overlay/commit/dca776848490f315cfa4e6f0c44b7206929043ff) Updated flake inputs
* [`3e06da38`](https://github.com/nix-community/emacs-overlay/commit/3e06da389d8aa4c0aaa11d5b72f63568b3b7d48d) Updated repos/elpa
* [`3f80bd5f`](https://github.com/nix-community/emacs-overlay/commit/3f80bd5f0173b6252c9784b6268ffa3587cd7ebb) Updated repos/emacs
* [`8330eb06`](https://github.com/nix-community/emacs-overlay/commit/8330eb06dc9f115afa70cf9c514505571f100120) Updated repos/melpa
* [`bfc5d3e3`](https://github.com/nix-community/emacs-overlay/commit/bfc5d3e3517818755933a73cc736920e06092996) Updated repos/melpa
* [`9246f949`](https://github.com/nix-community/emacs-overlay/commit/9246f9495f7a7cab27972b28eabcc6104d4675f5) Updated repos/elpa
* [`ea18d7b0`](https://github.com/nix-community/emacs-overlay/commit/ea18d7b097a2fcbd03ef5d7f858fa9e0c45de6fb) Updated repos/emacs
* [`c6b64ca1`](https://github.com/nix-community/emacs-overlay/commit/c6b64ca167953829cc318920f7e254d751d08295) Updated repos/melpa
* [`3f386997`](https://github.com/nix-community/emacs-overlay/commit/3f3869978d932178b1a7c74d1140f583fbce780e) Updated flake inputs
* [`81011518`](https://github.com/nix-community/emacs-overlay/commit/810115184d16b4c787659f86c0d4fbb86bd34a37) Updated repos/elpa
* [`e86c4bfc`](https://github.com/nix-community/emacs-overlay/commit/e86c4bfc8df3d51b888b48f90b2a44d54ad4f882) Updated repos/emacs
* [`77229726`](https://github.com/nix-community/emacs-overlay/commit/7722972664332248a4240cd40f6e55994ef1ddfa) Updated repos/melpa
* [`b86758ad`](https://github.com/nix-community/emacs-overlay/commit/b86758ad99b97f7c983c52078e3cfe1477adf9a0) Updated repos/melpa
* [`8fcffefa`](https://github.com/nix-community/emacs-overlay/commit/8fcffefa594c0772446afa98a78dc2bcb50ba3b4) Updated repos/elpa
* [`89d6658e`](https://github.com/nix-community/emacs-overlay/commit/89d6658ed709fa3506d0dc0776ea6e5534af66bb) Updated repos/emacs
* [`bd5c5e9a`](https://github.com/nix-community/emacs-overlay/commit/bd5c5e9a9b460a275df97c7226f573cd88cb27ef) Updated repos/melpa
* [`800454ab`](https://github.com/nix-community/emacs-overlay/commit/800454ab6b35eb622592f5ccdb7425391c9c046f) Updated repos/elpa
* [`609b9e74`](https://github.com/nix-community/emacs-overlay/commit/609b9e7454201865c97cab177e0ffc2c589dad9d) Updated repos/emacs
* [`cf54306a`](https://github.com/nix-community/emacs-overlay/commit/cf54306a663c6103b37001599ee9b094ff7810ca) Updated repos/melpa
* [`88770e2e`](https://github.com/nix-community/emacs-overlay/commit/88770e2e1dc7ad3920acb8011529121bbea9ce32) Updated repos/nongnu
* [`16b6a946`](https://github.com/nix-community/emacs-overlay/commit/16b6a946f5311680f6739a3160fa8e874e2f1341) Updated repos/emacs
* [`2cbc820d`](https://github.com/nix-community/emacs-overlay/commit/2cbc820d1a06d284a48f521fc66c4072ea071fbc) Updated repos/melpa
* [`9364ba0a`](https://github.com/nix-community/emacs-overlay/commit/9364ba0aef0a32331f4f6c1dd4d0f3488b1431e3) Updated flake inputs
* [`db7f4ccd`](https://github.com/nix-community/emacs-overlay/commit/db7f4ccd23fbcf5b102114d90d2f79f1769dcc99) Updated repos/elpa
* [`b6b23de1`](https://github.com/nix-community/emacs-overlay/commit/b6b23de1802a3ac435c9b8c7cc79bcb505085b2c) Updated repos/emacs
* [`e3280b27`](https://github.com/nix-community/emacs-overlay/commit/e3280b2745253e6e312bb4ee1aab68feb71b34ff) Updated repos/melpa
* [`19f86eb0`](https://github.com/nix-community/emacs-overlay/commit/19f86eb0df14744f711d13ff484d69a5174a59b3) Updated repos/elpa
* [`e9fd8456`](https://github.com/nix-community/emacs-overlay/commit/e9fd84562259ba5bd07c57c7766789ca6ae1e513) Updated repos/emacs
* [`c1d54371`](https://github.com/nix-community/emacs-overlay/commit/c1d5437118f4a64aa404681c4e89095539083378) Updated repos/melpa
* [`0c2b75ce`](https://github.com/nix-community/emacs-overlay/commit/0c2b75cef024e0756ba80b5411289d87584ecf43) Updated repos/nongnu
* [`22cbeae9`](https://github.com/nix-community/emacs-overlay/commit/22cbeae9599ef284f44fccda64b304ee2e6c4075) Updated repos/emacs
* [`24ebfe98`](https://github.com/nix-community/emacs-overlay/commit/24ebfe981a2d04e4d2d998f338854c07f38b7191) Updated repos/melpa
* [`fa2c99af`](https://github.com/nix-community/emacs-overlay/commit/fa2c99af244d425c43ef768cec348c995a98a1a5) Updated repos/nongnu
* [`ba47e17e`](https://github.com/nix-community/emacs-overlay/commit/ba47e17ea69555dbf2e3e32e5cc78273468c5be0) Updated repos/elpa
* [`1c04ae0f`](https://github.com/nix-community/emacs-overlay/commit/1c04ae0fa14e3c4e6f6bdbd597d40e48d0ec8db8) Updated repos/emacs
* [`e7b748e9`](https://github.com/nix-community/emacs-overlay/commit/e7b748e9a98d6fb4864fa61f809ae1e5f60bffbb) Updated repos/melpa
* [`8072e138`](https://github.com/nix-community/emacs-overlay/commit/8072e1387e967b3ee08f6b6687c97807c552e8f2) Updated repos/elpa
* [`3e0b8c25`](https://github.com/nix-community/emacs-overlay/commit/3e0b8c25548dc7ba1fd9f479f25e7caa39a29976) Updated repos/melpa
* [`3598717d`](https://github.com/nix-community/emacs-overlay/commit/3598717dc0d3c80ba0438f5161537ed7ddbcb96c) Updated repos/emacs
* [`a6b92160`](https://github.com/nix-community/emacs-overlay/commit/a6b92160f12d1caa2c67d7785ec312df4cbefe29) Updated repos/melpa
* [`5a93a5da`](https://github.com/nix-community/emacs-overlay/commit/5a93a5dad00a9028b8e54a40208f878c4aaf5a1c) Updated repos/nongnu
* [`785c7a1c`](https://github.com/nix-community/emacs-overlay/commit/785c7a1c0676aa69572af549fead549fdfb987d6) Updated flake inputs
* [`2825f0a0`](https://github.com/nix-community/emacs-overlay/commit/2825f0a04b1540093e81ad54ac97ef695dea4f2a) Updated repos/elpa
* [`eb0c4081`](https://github.com/nix-community/emacs-overlay/commit/eb0c4081511f882211c8c4f334cfe22249607733) Updated repos/emacs
* [`2350e5c3`](https://github.com/nix-community/emacs-overlay/commit/2350e5c3843d7fd47018e4491ad061facb39e4de) Updated repos/melpa
* [`856029b7`](https://github.com/nix-community/emacs-overlay/commit/856029b7ef712eaa801a1eacb8f1a7bf9fa50d97) Updated repos/elpa
* [`37d80624`](https://github.com/nix-community/emacs-overlay/commit/37d80624de5630aa4787fffe489b6191b819a010) Updated repos/emacs
* [`b2a33ede`](https://github.com/nix-community/emacs-overlay/commit/b2a33ede1b5ba9c3d8b79f8d42dec4adde89649e) Updated repos/nongnu
* [`b12ee158`](https://github.com/nix-community/emacs-overlay/commit/b12ee15832319a700aa9e47bc84295ba7b63910e) Updated repos/emacs
* [`67acc54c`](https://github.com/nix-community/emacs-overlay/commit/67acc54cceef38a92ba132e121659fef97698184) Updated repos/melpa
* [`ed4a8e8d`](https://github.com/nix-community/emacs-overlay/commit/ed4a8e8d0b339a847f6d0878955efdf91293559c) Updated repos/elpa
* [`35d46b0c`](https://github.com/nix-community/emacs-overlay/commit/35d46b0cb203c534ddbd1293a573468031000596) Updated repos/emacs
* [`681f8bcd`](https://github.com/nix-community/emacs-overlay/commit/681f8bcd84e4f857c51071dc4feb511a4e119337) Updated repos/elpa
* [`7c3c0570`](https://github.com/nix-community/emacs-overlay/commit/7c3c0570c5d2787a5ad53cbacb26e0d344ac901c) Updated repos/emacs
* [`fcd7cd12`](https://github.com/nix-community/emacs-overlay/commit/fcd7cd126e3f624eecb9ea845e9a17ab6079bfd8) Updated repos/melpa
* [`799b1cef`](https://github.com/nix-community/emacs-overlay/commit/799b1cef8453dd4700e454f161de4e8299880708) Updated repos/nongnu
* [`c4804b8f`](https://github.com/nix-community/emacs-overlay/commit/c4804b8f1cf82bbe90436dcfb4ab113d9a9dbed2) Updated repos/melpa
* [`d9f0639f`](https://github.com/nix-community/emacs-overlay/commit/d9f0639f8c99c3219ed34d096ea9ec7d0d8b8a17) Updated repos/elpa
* [`f00aaf68`](https://github.com/nix-community/emacs-overlay/commit/f00aaf685cb1a8558956129f6b58e78c7510fb9a) Updated repos/emacs
* [`8e36d1e4`](https://github.com/nix-community/emacs-overlay/commit/8e36d1e403c464e855de36c52ff23096951dfbc0) Updated repos/melpa
* [`26b9fe03`](https://github.com/nix-community/emacs-overlay/commit/26b9fe030bab5bb54b4cdb75b0c1d09dc9f0cda5) Updated flake inputs
* [`cd0db5c9`](https://github.com/nix-community/emacs-overlay/commit/cd0db5c9600cae17d0770feb23f2ba1baf9df63b) Updated repos/elpa
* [`7d313613`](https://github.com/nix-community/emacs-overlay/commit/7d3136134a78ddb301bee827c8696abff1ab7118) Updated repos/emacs
* [`a1cbe4d4`](https://github.com/nix-community/emacs-overlay/commit/a1cbe4d435c005b1023ede665e64533c2677db84) Updated repos/emacs
* [`82b81829`](https://github.com/nix-community/emacs-overlay/commit/82b81829dd689bbc397ead6615c1f1f212acb80d) Updated repos/melpa
* [`c37c526b`](https://github.com/nix-community/emacs-overlay/commit/c37c526b64adfd5d3659e3dae70b688707328c4b) Updated repos/elpa
* [`548e7944`](https://github.com/nix-community/emacs-overlay/commit/548e7944fe6ad2ab143b59e5095e781d10b3a08a) Updated repos/emacs
* [`bee2c073`](https://github.com/nix-community/emacs-overlay/commit/bee2c0732237f68c906a46a9133200830b4bae76) Updated repos/melpa
* [`6e4ec71b`](https://github.com/nix-community/emacs-overlay/commit/6e4ec71bc68456b8c8fb7bdb2adabe64af840711) Updated flake inputs
* [`4699f9df`](https://github.com/nix-community/emacs-overlay/commit/4699f9dfe760cc45d5eccd1da531e6b4b79adb6d) Updated repos/elpa
* [`5a35c5ff`](https://github.com/nix-community/emacs-overlay/commit/5a35c5ffa5a7f17cc373ab9f0847795b137fc0b5) Updated repos/emacs
* [`4e780ff6`](https://github.com/nix-community/emacs-overlay/commit/4e780ff685236158ecec68bed60a489bc8a14416) Updated repos/melpa
* [`fe40ad6c`](https://github.com/nix-community/emacs-overlay/commit/fe40ad6ce08ce1ec49f8e0ff3d95a35b92aa48c8) Updated repos/nongnu
* [`6f6fe482`](https://github.com/nix-community/emacs-overlay/commit/6f6fe48285fec1e4076e381df4f3f7e9a9186fd7) Updated repos/melpa
* [`2e57d25c`](https://github.com/nix-community/emacs-overlay/commit/2e57d25ca0727155acd795d857f37932c457dbf7) Updated repos/nongnu
* [`5e0353b0`](https://github.com/nix-community/emacs-overlay/commit/5e0353b0048e8e5af9b93f47bf914c0f3fefabff) Updated repos/elpa
* [`8bc94376`](https://github.com/nix-community/emacs-overlay/commit/8bc94376be2ab9290c3275f18a29cc47c7889c4f) Updated repos/melpa
* [`33285979`](https://github.com/nix-community/emacs-overlay/commit/33285979d6a295fc1c278dbaaa29ec1370288dd0) Updated flake inputs
* [`e999d857`](https://github.com/nix-community/emacs-overlay/commit/e999d857f879942fb0fe5a25967e9eb8959edeb4) Updated repos/elpa
* [`7e236c96`](https://github.com/nix-community/emacs-overlay/commit/7e236c963a46bc712971f9f6ff78f4ea50b64c0f) Updated repos/emacs
* [`2263a42b`](https://github.com/nix-community/emacs-overlay/commit/2263a42b31d89c691239083c0e9694f66e20b548) Updated repos/emacs
* [`4a09e468`](https://github.com/nix-community/emacs-overlay/commit/4a09e468458ee95f18c162e69f3d667686fee02a) Updated repos/melpa
* [`56a45c50`](https://github.com/nix-community/emacs-overlay/commit/56a45c50c4e93a0b0ef5575ea081fe051e6fc052) Updated repos/elpa
* [`a2150bf8`](https://github.com/nix-community/emacs-overlay/commit/a2150bf803352e9a557115e24c3e6748ced6b5e4) Updated repos/emacs
* [`01daeb68`](https://github.com/nix-community/emacs-overlay/commit/01daeb686193d90372c2f141792245f5e3aa6bf6) Updated repos/melpa
* [`f4864948`](https://github.com/nix-community/emacs-overlay/commit/f48649481f67d1e0fe7346d90c663581818a912a) Updated flake inputs
* [`d12ec7de`](https://github.com/nix-community/emacs-overlay/commit/d12ec7dec93bfddc617f3d846f7188fcb89ae15b) Updated repos/elpa
* [`205e4d04`](https://github.com/nix-community/emacs-overlay/commit/205e4d04d38a66a0787b838a0ccb46317726df59) Updated repos/emacs
* [`d24d6419`](https://github.com/nix-community/emacs-overlay/commit/d24d6419a28b760cfb442f0227ab8d8797abe84f) Updated repos/melpa
* [`e58f332c`](https://github.com/nix-community/emacs-overlay/commit/e58f332cc035aaaf82c9c9f8e07b3e21ac977d77) Updated repos/nongnu
* [`21b2740b`](https://github.com/nix-community/emacs-overlay/commit/21b2740b4ddf5c772d97d79dafddef3e7c30aead) Updated flake inputs
* [`4ef658a5`](https://github.com/nix-community/emacs-overlay/commit/4ef658a5331019c33673cac27361304df28025fa) Updated repos/melpa
* [`bca51db1`](https://github.com/nix-community/emacs-overlay/commit/bca51db1c86cb6064ae6c422e5a3a83668fab53c) Updated repos/elpa
* [`237a4118`](https://github.com/nix-community/emacs-overlay/commit/237a41188ad3efaae99ecf439e5099d1c9e7f7b9) Updated repos/emacs
* [`b2362dcf`](https://github.com/nix-community/emacs-overlay/commit/b2362dcffd0c6e196c147df44a6c1aeca13418c8) Updated repos/melpa
* [`02f899c5`](https://github.com/nix-community/emacs-overlay/commit/02f899c5fd6b5a5f386fc56300f62bbb2d28c6f7) Updated repos/elpa
* [`2754c3af`](https://github.com/nix-community/emacs-overlay/commit/2754c3afef1af870f60971b63bb5ae06a27372f7) Updated repos/emacs
* [`48db4475`](https://github.com/nix-community/emacs-overlay/commit/48db44758a697a781c8e2c3f74671df8f7b0e8e1) Updated repos/melpa
* [`0e0d24a1`](https://github.com/nix-community/emacs-overlay/commit/0e0d24a13321cd93af7f2a10a61fe71f6d81448b) Updated repos/emacs
* [`3c904d76`](https://github.com/nix-community/emacs-overlay/commit/3c904d7645c60421843e4aca9089283c480d1e3a) Updated flake inputs
* [`860be88c`](https://github.com/nix-community/emacs-overlay/commit/860be88c0afc7d78d5e662736ab138be34c6be12) Updated repos/elpa
* [`33158cb7`](https://github.com/nix-community/emacs-overlay/commit/33158cb7e77ccae9fecfbc343ef05310151945b2) Updated repos/emacs
* [`c596975b`](https://github.com/nix-community/emacs-overlay/commit/c596975b3348b3b06c198ccd49c5e43a69e1fd2e) Updated repos/elpa
* [`72c8b9f3`](https://github.com/nix-community/emacs-overlay/commit/72c8b9f3d2f4a6789ce1193eb9202f294f4b75c9) Updated repos/emacs
* [`c7f41766`](https://github.com/nix-community/emacs-overlay/commit/c7f417665786766e56d773f4d5ba4e6bc4998744) Updated repos/melpa
* [`ead48f55`](https://github.com/nix-community/emacs-overlay/commit/ead48f55a6da3757b939b4c40456e300bb76f16a) Updated repos/emacs
* [`c91f08c9`](https://github.com/nix-community/emacs-overlay/commit/c91f08c9226cab44bd6ba915f8d527c48eed2851) Updated repos/melpa
* [`09794089`](https://github.com/nix-community/emacs-overlay/commit/097940897bba5a8df9f566f317945211b92a45c6) Updated repos/nongnu
* [`3637c279`](https://github.com/nix-community/emacs-overlay/commit/3637c2791d7b16c8568998a70d3af5bf54c08047) Updated repos/elpa
* [`7fe510de`](https://github.com/nix-community/emacs-overlay/commit/7fe510de8909d248df2d32d758303a325b3738f9) Updated repos/emacs
* [`2dd5c9ed`](https://github.com/nix-community/emacs-overlay/commit/2dd5c9ed3b051828571a468932887ad4eb4bad92) Updated repos/elpa
* [`e890385f`](https://github.com/nix-community/emacs-overlay/commit/e890385f6ca9093916ed2124c7fc921b2a4121fa) Updated repos/emacs
* [`45761790`](https://github.com/nix-community/emacs-overlay/commit/45761790c882313970a6880fde9ce208a7b04c2e) Updated repos/emacs
* [`d8198c1a`](https://github.com/nix-community/emacs-overlay/commit/d8198c1a7176ae4079557bfc1f6b90159ffabb8a) Updated repos/nongnu
* [`deed8c8c`](https://github.com/nix-community/emacs-overlay/commit/deed8c8c38181c2b0da51858224505f97a87ac85) Updated repos/elpa
* [`7fe9fac2`](https://github.com/nix-community/emacs-overlay/commit/7fe9fac2a61c2e476bbb586f20ab4872072e2868) Updated repos/emacs
* [`20d9e9e3`](https://github.com/nix-community/emacs-overlay/commit/20d9e9e36843d7baf4f8528b9c71d81ed691eac7) Updated repos/elpa
* [`f31f0519`](https://github.com/nix-community/emacs-overlay/commit/f31f0519dd30d99e03690583dc95fd517737f179) Updated repos/emacs
* [`2731e691`](https://github.com/nix-community/emacs-overlay/commit/2731e6914d19927bb0767f5b7ea89a01f1b1968d) Updated repos/nongnu
* [`7186cb7a`](https://github.com/nix-community/emacs-overlay/commit/7186cb7a20f6a34f5d1cbc82cf9181aab4342a54) Updated repos/emacs
* [`56c53da5`](https://github.com/nix-community/emacs-overlay/commit/56c53da59719a22d16492ffd1494ba427dc2374c) Updated flake inputs
* [`4c11a382`](https://github.com/nix-community/emacs-overlay/commit/4c11a382257599b25ca1c077cbba9d87baf006e8) Updated repos/elpa
* [`c8754202`](https://github.com/nix-community/emacs-overlay/commit/c875420205f936ec0df3a009dca1e6a27808927a) Updated repos/emacs
* [`5bf36bac`](https://github.com/nix-community/emacs-overlay/commit/5bf36bac3904c4138ffc2eb85523d2ffb60ef010) Updated repos/melpa
* [`55d5447d`](https://github.com/nix-community/emacs-overlay/commit/55d5447daffff63db04495bbf9d06c5dde894c12) Updated flake inputs
* [`f45b8da7`](https://github.com/nix-community/emacs-overlay/commit/f45b8da7645a176174fbd47ea9a29053be37bc5a) Updated repos/elpa
* [`f03d1b7b`](https://github.com/nix-community/emacs-overlay/commit/f03d1b7b58df777a18dec85fb7b2868b562d35ef) Updated repos/emacs
* [`93d8aab7`](https://github.com/nix-community/emacs-overlay/commit/93d8aab7c650884586df44458ff9ab5901be4dd2) Updated repos/melpa
* [`2a5b681a`](https://github.com/nix-community/emacs-overlay/commit/2a5b681a554bc4afdf840201b4f51a09ab23e9b8) Updated repos/nongnu
* [`a4b9c9d6`](https://github.com/nix-community/emacs-overlay/commit/a4b9c9d6121b7ea03e11d98e98e226fda68ff946) Updated flake inputs
* [`bd7432a6`](https://github.com/nix-community/emacs-overlay/commit/bd7432a6da29d334f634e22b368621e269a8e6b5) Updated repos/emacs
* [`52539f93`](https://github.com/nix-community/emacs-overlay/commit/52539f937d2ffe62392aede3b37965582659a298) Updated repos/elpa
* [`723d8ec0`](https://github.com/nix-community/emacs-overlay/commit/723d8ec014852d74bc04769c5b47446d5eee5a1d) Updated repos/emacs
* [`3e173560`](https://github.com/nix-community/emacs-overlay/commit/3e173560c72e4b22dd7dd8b7117b42130979fdf3) Updated flake inputs
* [`c49397ba`](https://github.com/nix-community/emacs-overlay/commit/c49397ba080188f64321bdf1c7650861a9587ca4) Updated repos/elpa
* [`8b102cba`](https://github.com/nix-community/emacs-overlay/commit/8b102cbad079bcbd98c746a84c44d4ec5b23a0c7) Updated repos/emacs
* [`ad989770`](https://github.com/nix-community/emacs-overlay/commit/ad98977084414cf12564f5cc45b8f9aef217aafa) Updated repos/melpa
* [`72a4241f`](https://github.com/nix-community/emacs-overlay/commit/72a4241f1b63ba150a8691517036d10015302a6d) Updated repos/emacs
* [`88a6b098`](https://github.com/nix-community/emacs-overlay/commit/88a6b098a9e77718eebd801b650695765e54136a) Updated repos/melpa
* [`5c51c0c6`](https://github.com/nix-community/emacs-overlay/commit/5c51c0c662020d4f69c954416c7966814748eee9) Updated repos/elpa
* [`b06cb636`](https://github.com/nix-community/emacs-overlay/commit/b06cb63603a599e42483d5541c9c107122be0c0e) Updated repos/emacs
* [`7e6cc3c9`](https://github.com/nix-community/emacs-overlay/commit/7e6cc3c97847651f7c3035274430daaeed94e153) Updated repos/melpa
* [`93e0cb0f`](https://github.com/nix-community/emacs-overlay/commit/93e0cb0f55da1862372c70859ddef9c93cd143fc) Updated flake inputs
* [`7efa7726`](https://github.com/nix-community/emacs-overlay/commit/7efa7726f1bb11c69839cb5d7712cf101f0e9fd7) Updated repos/elpa
* [`75c826ce`](https://github.com/nix-community/emacs-overlay/commit/75c826ceb5898607333b7030b41060b2030e3e75) Updated repos/emacs
* [`4136a5c0`](https://github.com/nix-community/emacs-overlay/commit/4136a5c099d27ba91ec431639e9348eae57094b9) Updated repos/emacs
* [`e70494fc`](https://github.com/nix-community/emacs-overlay/commit/e70494fcb4466020552ee39b1d39f7910dee27f0) Updated repos/melpa
* [`b6189be5`](https://github.com/nix-community/emacs-overlay/commit/b6189be517dd256fbb01021a2351272857a6288b) Updated repos/elpa
* [`28af8e36`](https://github.com/nix-community/emacs-overlay/commit/28af8e36fd9b6b668ffa3e164d76ac470456bea8) Updated repos/emacs
* [`45659cab`](https://github.com/nix-community/emacs-overlay/commit/45659cab8b875d266146821df333ea443b935212) Updated repos/melpa
* [`6eebbb0b`](https://github.com/nix-community/emacs-overlay/commit/6eebbb0bd08f21c389c68be03f2a4b8e98e82da8) Updated repos/elpa
* [`0a2e2159`](https://github.com/nix-community/emacs-overlay/commit/0a2e21596ab0b303c6d7b6657e8a966d8bb72e9c) Updated repos/emacs
* [`d194712b`](https://github.com/nix-community/emacs-overlay/commit/d194712b55853051456bc47f39facc39d03cbc40) Updated repos/melpa
* [`8e8e318e`](https://github.com/nix-community/emacs-overlay/commit/8e8e318e0e896a490564481d4310f903ae54cdac) Updated repos/emacs
* [`12ae810b`](https://github.com/nix-community/emacs-overlay/commit/12ae810bf81432484baf86610a848cb9479f29e8) Updated repos/melpa
* [`230c038d`](https://github.com/nix-community/emacs-overlay/commit/230c038d6cbb15f44bfa7371f4dac44c82f63a9e) Updated flake inputs
* [`b6754758`](https://github.com/nix-community/emacs-overlay/commit/b675475841c35ae1b3684d65665cd835bf89efcc) Updated repos/emacs
* [`2b203b7f`](https://github.com/nix-community/emacs-overlay/commit/2b203b7f03b4494235afe7667dde4d65d231202d) Updated repos/melpa
* [`2dec052c`](https://github.com/nix-community/emacs-overlay/commit/2dec052c6dd34e80bdb5733955891c8b74a91329) Updated repos/elpa
* [`244859eb`](https://github.com/nix-community/emacs-overlay/commit/244859ebc7c524fc223cf7d10838cd573e815f08) Updated repos/emacs
* [`74962565`](https://github.com/nix-community/emacs-overlay/commit/74962565868a528ea92f4fc1ae79feef55bda8d2) Updated repos/melpa
* [`a0ba952a`](https://github.com/nix-community/emacs-overlay/commit/a0ba952a747d0bd4ba53a050ee9ef3f8f15af994) Updated repos/nongnu
* [`b9d2a391`](https://github.com/nix-community/emacs-overlay/commit/b9d2a391c3ec265e8ddfaf6c8542e386ba6a5edc) Updated repos/emacs
* [`9716242d`](https://github.com/nix-community/emacs-overlay/commit/9716242daed6b500616e0d2378a06f5eba53ca2b) Updated repos/melpa
* [`d23c399c`](https://github.com/nix-community/emacs-overlay/commit/d23c399c5bee87780e713b4c56152dead5b0ebdb) Updated repos/elpa
* [`edd1db81`](https://github.com/nix-community/emacs-overlay/commit/edd1db81a528627587fde38231411f97c6807a60) Updated repos/emacs
* [`238d4cd5`](https://github.com/nix-community/emacs-overlay/commit/238d4cd5adee2a5dd893e27f0cf7e5af856d576e) Updated repos/melpa
* [`cdd8610d`](https://github.com/nix-community/emacs-overlay/commit/cdd8610dc89433e7648067847270273f74951b45) Updated flake inputs
* [`01d1e79b`](https://github.com/nix-community/emacs-overlay/commit/01d1e79b05736977a013b7efd69afb4504d707dc) Updated repos/elpa
* [`c791f97f`](https://github.com/nix-community/emacs-overlay/commit/c791f97fb1ff0abc57347a15ba18371da9861bef) Updated repos/emacs
* [`269ac5a3`](https://github.com/nix-community/emacs-overlay/commit/269ac5a3bbd2f0f4d2e0912f219f973441271bd4) Updated repos/melpa
* [`c151c851`](https://github.com/nix-community/emacs-overlay/commit/c151c85112f55859e138c83c754b69fb4a69510b) Updated flake inputs
* [`25d375fe`](https://github.com/nix-community/emacs-overlay/commit/25d375fea6325da22ea1cea07db1d010f5e17a32) Updated repos/elpa
* [`7b50d324`](https://github.com/nix-community/emacs-overlay/commit/7b50d3245f7561378c28678390a15ffcf10c555a) Updated repos/emacs
* [`cc3249d5`](https://github.com/nix-community/emacs-overlay/commit/cc3249d5b0eb6600f253a1f7be45343ffcc4b89e) Updated repos/melpa
