### PR TITLE
niv doomemacs: update 844a82c4 -> 98639850

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "844a82c4a0cacbb5a1aa558c88675ba1a9ee80a3",
-        "sha256": "06g9rn12xdynbfx1gv7p82i50l64apm6gfypjih24kcz6fairw2r",
+        "rev": "986398504d09e585c7d1a8d73a6394024fe6f164",
+        "sha256": "16a7991h8ihmnshahadvzcm78g7y2gw4kfd496757mw5xqi71dxy",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/844a82c4a0cacbb5a1aa558c88675ba1a9ee80a3.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/986398504d09e585c7d1a8d73a6394024fe6f164.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@844a82c4...98639850](https://github.com/doomemacs/doomemacs/compare/844a82c4a0cacbb5a1aa558c88675ba1a9ee80a3...986398504d09e585c7d1a8d73a6394024fe6f164)

* [`8eebab4f`](https://github.com/doomemacs/doomemacs/commit/8eebab4f9762e93d44cfee6264e7dbaa9f2e9a03) fix(ocaml): add dune-project to ocaml projectile root files
* [`2497d58e`](https://github.com/doomemacs/doomemacs/commit/2497d58e9a8da7387334dd6168459bcbaa77793d) fix(vertico): ensure recentf-mode for consult-buffer
* [`1e1e6150`](https://github.com/doomemacs/doomemacs/commit/1e1e6150d82a2c51be721c551cb85b8d0409cc24) fix(data): correct XML closing tag insertion
* [`f5be3ec1`](https://github.com/doomemacs/doomemacs/commit/f5be3ec1e58ca4702079004a045bf945889423bd) fix: use ansi-color-compilation-filter on emacs28+
* [`da99d39e`](https://github.com/doomemacs/doomemacs/commit/da99d39e4daed6db855556e297e4f8f83d93a1f3) docs(nix): mention +lsp flag 
* [`1a2789c9`](https://github.com/doomemacs/doomemacs/commit/1a2789c9229f6a6bd4c9001667f3134ec8b8247b) fix(workspaces): check before loading tab configuration
* [`bd9aef92`](https://github.com/doomemacs/doomemacs/commit/bd9aef928c6b32c368173f69458e8797841eeea3) fix(rust): make cargo popups consistent
* [`10567b6c`](https://github.com/doomemacs/doomemacs/commit/10567b6cec47e24a6f124aa94a4e4d20367aa3d1) nit(mu4e): :height parameter was already the default value
* [`9f922065`](https://github.com/doomemacs/doomemacs/commit/9f922065baeff5e5686da4f687481334426a94e1) refactor(mu4e): prepare `+mu4e-normalised-icon' for extra padding
* [`b40e435f`](https://github.com/doomemacs/doomemacs/commit/b40e435f539fdac0c9f4dfe70fbda26a70f30da2) feat(mu4e): add space-right argument to `+mu4e-normalised-icon'
* [`feec9368`](https://github.com/doomemacs/doomemacs/commit/feec9368e2dc8a425d1d388a451595343cef5b80) feat(mu4e): set consistent icons for `mu4e-modeline-*' variables
* [`ce8c2af0`](https://github.com/doomemacs/doomemacs/commit/ce8c2af08c9d528fa38a2b29e6ee185c3494a1c8) fix(mu4e): set popup rules for mu4e
* [`5df41be0`](https://github.com/doomemacs/doomemacs/commit/5df41be02b0de41d45d4c6d0e25148e40fdb4a22) nit(mu4e): remove underline for blank space
* [`c4bb95e0`](https://github.com/doomemacs/doomemacs/commit/c4bb95e073c3cd8bc9e0a115bbc31d7d3023e788) fix(popup): change evil function to call following upstream rename
* [`5e6430e9`](https://github.com/doomemacs/doomemacs/commit/5e6430e9e6e642fc12913cc6b10e599317a2bb7a) fix: assign Nerd Fonts directly to Unicode PUAs
* [`317cea5e`](https://github.com/doomemacs/doomemacs/commit/317cea5eefda4c4fa9dde036985ffd7887dad792) fix: assign emoji fallbacks directly to emoji script
* [`1cc7b040`](https://github.com/doomemacs/doomemacs/commit/1cc7b040598a1cc6c1d76e9747cf10f5147cca52) docs: clarify doom-unicode-font default
* [`4499ce7b`](https://github.com/doomemacs/doomemacs/commit/4499ce7b0a0137766387289000d45d253e6e1ee2) refactor: doom-unicode-font -> doom-symbol-font
* [`37affa5c`](https://github.com/doomemacs/doomemacs/commit/37affa5cff40c61ca68a6f544e6daa10377f3abe) feat: add doom-emoji-font
* [`7abed4db`](https://github.com/doomemacs/doomemacs/commit/7abed4dbf1619ff581bf24dc72822c625b9983fc) fix: fall back to emoji font for symbols
* [`b42882c5`](https://github.com/doomemacs/doomemacs/commit/b42882c54520e783beb7fa0784a9657c5a2625fe) refactor: make fallback font families constant
* [`98639850`](https://github.com/doomemacs/doomemacs/commit/986398504d09e585c7d1a8d73a6394024fe6f164) refactor: defvar -> defcustom
