### PR TITLE
niv nixpkgs: update b12786c1 -> eb5caed9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12786c187800110d3bdfa5e26e22b05250cc887",
-        "sha256": "1zplcsn8hi79ya6m6fxb0472lh6b62axkwpj9znrwa7ypdqhr8pn",
+        "rev": "eb5caed9e18e2a91ec891597766eddffce5670bb",
+        "sha256": "0z87ip2qv1lh88smdxvkiabdmm4kdvd3afb5fbxv2kj8fbbmwx5j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/b12786c187800110d3bdfa5e26e22b05250cc887.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/eb5caed9e18e2a91ec891597766eddffce5670bb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@b12786c1...eb5caed9](https://github.com/nixos/nixpkgs/compare/b12786c187800110d3bdfa5e26e22b05250cc887...eb5caed9e18e2a91ec891597766eddffce5670bb)

* [`6406751e`](https://github.com/NixOS/nixpkgs/commit/6406751e1c5c774c5389d3bc3de6535bf3356175) build-rust-crate: point rustc to the correct linker
* [`317b01bb`](https://github.com/NixOS/nixpkgs/commit/317b01bbd75166da9af25bc6262cecdf010e9376) python310Packages.sybil: 4.0.1 -> 5.0.0
* [`b33b32fc`](https://github.com/NixOS/nixpkgs/commit/b33b32fc2808a0be9480d83d45630ebf61c27efe) chromium: late-bind xdg-utils if broken
* [`b7fd0226`](https://github.com/NixOS/nixpkgs/commit/b7fd022677881ef364859c1c1a54552a470c1f0a) nixos/oci-containers: make systemd service pre-start extensible
* [`ca743c97`](https://github.com/NixOS/nixpkgs/commit/ca743c970bd8e5348284174e17bd5b4a114f063f) box64: Fetch patch to fix SDL1 support regression
* [`1b572d52`](https://github.com/NixOS/nixpkgs/commit/1b572d52b73b1c51cd78e47cc12c80696128faae) box64: Migrate to finalAttrs pattern
* [`d5de36d1`](https://github.com/NixOS/nixpkgs/commit/d5de36d1b18f6f554d0a78289593509bc149cb9d) box64: Refactor cmakeFlags, only check if executable, add meta.mainProgram
* [`d8fea65d`](https://github.com/NixOS/nixpkgs/commit/d8fea65d0202aecbcfc35a6e21a4088908418723) box64: Enable build & dynarec on more platforms
* [`4d1c96e5`](https://github.com/NixOS/nixpkgs/commit/4d1c96e59b6f46a9538fa49f586049850f1f4110) libcaption: init at 0.7
* [`049871af`](https://github.com/NixOS/nixpkgs/commit/049871afaf583f984d1440f64620757c6ad87c8d) obs-studio-plugins.obs-replay-source: init at 1.6.12
* [`00a8e143`](https://github.com/NixOS/nixpkgs/commit/00a8e1434232ddfe8a3b98732c1cdd8d8700dec6) shattered-pixel-dungeon: split generic builder
* [`0ef6049b`](https://github.com/NixOS/nixpkgs/commit/0ef6049bce1dcfcf5f3661c8875e2647885f31da) rkpd2: init at 1.0.0
* [`0524993d`](https://github.com/NixOS/nixpkgs/commit/0524993d8aa29071cfa6f39c1d10550c5d92de82) rat-king-adventure: init at 1.5.2a
* [`04a8a092`](https://github.com/NixOS/nixpkgs/commit/04a8a092492932faca3c92973bb203a7b5f91d7f) riemann_c_client: Optional TLS support & other changes
* [`28b41a60`](https://github.com/NixOS/nixpkgs/commit/28b41a601f59ff0546328ec54c5c10176c77f368) python3Packages.ray: 2.6.1 -> 2.7.0
* [`b9495de1`](https://github.com/NixOS/nixpkgs/commit/b9495de12eb949fd9d0ca3ebb9c9b862f2f6f786) kernel/common-config: arm: configure alignment traps
* [`62657db3`](https://github.com/NixOS/nixpkgs/commit/62657db38614020b4acb7b7de18e4cefceb91060) texlive.combine: only derivations under .packages
* [`a4ea714c`](https://github.com/NixOS/nixpkgs/commit/a4ea714c80a2ea9a0da383ac7e2ef6b5b026ef67) texlive.tlpdb.nix: detect presence of info pages
* [`3b441a23`](https://github.com/NixOS/nixpkgs/commit/3b441a2399f4bcc9c44dc003bb2d3ebfdbb5cac1) maintainers: add argrat
* [`7ea6d0a7`](https://github.com/NixOS/nixpkgs/commit/7ea6d0a7190642e52ea452fbecca8936e198a4c4) postgresqlPackages.pg_embedding: init at 0.3.6
* [`e0c25ec2`](https://github.com/NixOS/nixpkgs/commit/e0c25ec2bd95f5d89e2ecce5343c445544cdf098) ocamlPackages.ocamlformat: 0.26.0 → 0.26.1
* [`1bef913e`](https://github.com/NixOS/nixpkgs/commit/1bef913e8ca6e63aa8f92a6b2f78420db4b3203f) ocamlPackages.ocamlformat-rpc-lib: 0.26.0 → 0.26.1
* [`32a2a085`](https://github.com/NixOS/nixpkgs/commit/32a2a0852c37606f963868baa1276ed28f73c047) Link version for ocamlformat{,-lib,-rpc-lib}
* [`918618ee`](https://github.com/NixOS/nixpkgs/commit/918618ee66b3f1b0a1f4e89be4a9821a947c1199) lunarml: unstable-2023-09-21 → 0.0.20230924
* [`59ed5f7c`](https://github.com/NixOS/nixpkgs/commit/59ed5f7c5c8609b0fdffd5ccde59965738adefb3) peertube: 5.1.0 -> 5.2.1
* [`41b8c8b2`](https://github.com/NixOS/nixpkgs/commit/41b8c8b23b6e25e86b01ea3b7006fb076ed8c6a5) peertube: update nginx configuration
* [`5d7723dd`](https://github.com/NixOS/nixpkgs/commit/5d7723dd5ba1ee02595f03554acc139b627b3834) nixos/switch-to-configuration: Lock the switch
* [`3782b3b5`](https://github.com/NixOS/nixpkgs/commit/3782b3b5d954c660abc3cad1d799edc033b61691) nixos/virtualisation: add hostname option to oci-containers.
* [`024951bf`](https://github.com/NixOS/nixpkgs/commit/024951bf243040835ef9bc9bca125ab61088e787) kernelPackages.nct6687d: init at unstable-2023-09-22
* [`48ed9466`](https://github.com/NixOS/nixpkgs/commit/48ed94664e9f8307e569a44ab3bd8e569b493bd6) android-tools: 34.0.1 -> 34.0.4
* [`23422982`](https://github.com/NixOS/nixpkgs/commit/2342298229c864082f38580ae7a5b54525095f5d) openssh: enable ldns
* [`333a351b`](https://github.com/NixOS/nixpkgs/commit/333a351b288a708b258b251a7535f4ac2ddf16f8) texlive.buildTeXLivePackage: switch to fake multi-output derivations for TeX Live packages
* [`361364ab`](https://github.com/NixOS/nixpkgs/commit/361364aba0bb0796ff4e17265beab04868a3d745) tests.texlive.binaries: use new texlive package source
* [`988124cf`](https://github.com/NixOS/nixpkgs/commit/988124cf206384e4ef826987d8a1158cc27ec1c2) tests.texlive.shebangs: use new texlive package source
* [`5f45cca0`](https://github.com/NixOS/nixpkgs/commit/5f45cca0b92aef9777a8be0a4476bf3f4e065d25) texlive.bin.pygmentex: use new texlive package source
* [`471ab010`](https://github.com/NixOS/nixpkgs/commit/471ab010da1005e5b73e3aea3e60988668821be9) texlive.bin.xpdfopen: use new texlive package source
* [`e910132c`](https://github.com/NixOS/nixpkgs/commit/e910132c4fb09c47b734f2c6d7ec93bc94d9dac0) iwona: use new texlive package source
* [`5d3d8b92`](https://github.com/NixOS/nixpkgs/commit/5d3d8b92fd1696141fc798c06c98defc73139122) biber: use new texlive package source
* [`3bdd2407`](https://github.com/NixOS/nixpkgs/commit/3bdd2407fb20eb8c35a45ecc2c68a79cdb8f266c) biber-ms: use new texlive package source
* [`33c6d50f`](https://github.com/NixOS/nixpkgs/commit/33c6d50f08d3517143396eb97df31057afab1e1c) mftrace: use new tex package structure
* [`9824aa47`](https://github.com/NixOS/nixpkgs/commit/9824aa47a55987365fe6f3f90c6bba5cde6b401b) sagetex: use new tex package structure
* [`a06e0753`](https://github.com/NixOS/nixpkgs/commit/a06e07539eb22de353a615ac50d6ad0f5db1239b) texlive: document new texlive.pkgs attribute
* [`7731bbbc`](https://github.com/NixOS/nixpkgs/commit/7731bbbc79f52624f3059df588ae909674718790) opencv4WithoutCuda: init at opencv4.version
* [`69e182e6`](https://github.com/NixOS/nixpkgs/commit/69e182e6f1b0db8da8c39b004c7e358a50d5387a) sdrangel: opencv3 -> opencv4
* [`8969c706`](https://github.com/NixOS/nixpkgs/commit/8969c706d25fcc4789c47d7011fa93e062d911e1) mxnet: opencv3 -> opencv4
* [`2a2ba3dc`](https://github.com/NixOS/nixpkgs/commit/2a2ba3dc3f08090e12cee4c11ba4a558a46a5fff) caffeWithCuda: mark broken
* [`935338d1`](https://github.com/NixOS/nixpkgs/commit/935338d123b4f183820c134edb058e5d022d6e8b) caffe: opencv3 -> opencv4
* [`5a1de75e`](https://github.com/NixOS/nixpkgs/commit/5a1de75eb021bc7c9aa190b3bab193dfa41c0bc8) opencv3WithoutCuda: remove
* [`33941871`](https://github.com/NixOS/nixpkgs/commit/339418713e3ee42263d0e3639d0c6a6a092f2307) gmic-qt: remove apparently unused opencv3 dependency
* [`2fbd1b97`](https://github.com/NixOS/nixpkgs/commit/2fbd1b97f1364a1064e68c179ad472551ccdad80) video2midi: opencv3 -> opencv4
* [`381e03e0`](https://github.com/NixOS/nixpkgs/commit/381e03e03a1fc4b83c2a94d83898f4a3dd6abf8c) waifu2x-converter-cpp: opencv3 -> opencv4
* [`52d5403b`](https://github.com/NixOS/nixpkgs/commit/52d5403bee68fd0ce2b41a493cc632ef6c2106ed) parallel: add gawk to wrapper path
* [`924e7e61`](https://github.com/NixOS/nixpkgs/commit/924e7e61288a9230159acc95873a75b713638706) keepass: 2.54 -> 2.55
* [`e4f1b6e1`](https://github.com/NixOS/nixpkgs/commit/e4f1b6e15f0ccc9dff67681fbcfb3ec4c296d277) python310Packages.gtts: 2.3.2 -> 2.4.0
* [`d7ee02de`](https://github.com/NixOS/nixpkgs/commit/d7ee02def5cbd8ebdddf354d7f88f045f9f7afde) python310Packages.opencensus-ext-azure: 1.1.9 -> 1.1.11
* [`ccb0f871`](https://github.com/NixOS/nixpkgs/commit/ccb0f8712921956eb8345dc0d20a694c0bd4cff4) prosody: use default network, remove libevent, config deprecated
* [`548e4550`](https://github.com/NixOS/nixpkgs/commit/548e4550a0b46d74558b3cf77db486a41b0bcb4c) vieb: 10.3.0 -> 10.4.0
* [`b992e7a7`](https://github.com/NixOS/nixpkgs/commit/b992e7a7310721a224d589ee9869173e97bb2256) minecraft-server: 1.20.1 -> 1.20.2
* [`d7c49ca7`](https://github.com/NixOS/nixpkgs/commit/d7c49ca7152768114a9359b729557f77b8343545) lib.getExe': check arguments
* [`d2161d06`](https://github.com/NixOS/nixpkgs/commit/d2161d06321770f37fd86bfa15296dd8de0196a0) lib/tests: add tests for getExe' and getExe
* [`6143b417`](https://github.com/NixOS/nixpkgs/commit/6143b4172be76426a7ec05f111fcb876da7054bd) python311Packages.questionary: unstable-2022-07-27 -> 2.0.1
* [`44c59cb2`](https://github.com/NixOS/nixpkgs/commit/44c59cb218cbf955fe194c4cdb1f994e8ebce2d6) python311Packages.questionary: add changelog to meta
* [`7c846eb3`](https://github.com/NixOS/nixpkgs/commit/7c846eb3ca367dbd1995c0b71f106d2861367038) python311Packages.pilkit: unstable-2022-02-17 -> 3.0
* [`8113dbcf`](https://github.com/NixOS/nixpkgs/commit/8113dbcf2e2544236cba28d359cb32b809dd0a59) python311Packages.pilkit: change the license to BSD3
* [`9e8674d8`](https://github.com/NixOS/nixpkgs/commit/9e8674d8e97a64284924c08fab4550f479156470) composefs: 1.0.0 -> 1.0.1
* [`8ea9f40f`](https://github.com/NixOS/nixpkgs/commit/8ea9f40f74b83e0f47f1c2897ea240b435d6faaa) nng: 1.6.0-prerelease update for rPackages.nanonext
* [`30967f8b`](https://github.com/NixOS/nixpkgs/commit/30967f8be970b245dd656f3a5fbf8dc793e52e34) heroic: add libunwind to FHS env
* [`123e1408`](https://github.com/NixOS/nixpkgs/commit/123e1408930435ba7553ce16cce367cd492261bc) steam: add libunwind to FHS env
* [`464e69ef`](https://github.com/NixOS/nixpkgs/commit/464e69ef243a9846111bac8ba4b7e962c133fdaf) dropbox: 111.3.447 -> 185.4.6054
* [`3439e8c1`](https://github.com/NixOS/nixpkgs/commit/3439e8c114c6ab90e9040d10bd42dcb6b7e60109) dropbox-cli: 2020.03.04 -> 2023.09.06
* [`fa7406f5`](https://github.com/NixOS/nixpkgs/commit/fa7406f51fc948c8ca871a276b67078a7b9bc48c) dropbox-cli: add meta.mainProgram
* [`d9ee3bc9`](https://github.com/NixOS/nixpkgs/commit/d9ee3bc94f1987ab095d819a6ef64a9db496d8c8) yaml-cpp: 0.7.0 -> 0.8.0
* [`e4e2245d`](https://github.com/NixOS/nixpkgs/commit/e4e2245d352af4c8f37b2975998fe06adf6f27e1) poetryPlugins.poetry-plugin-up: 0.4.0 -> 0.7.0
* [`7b4e8f91`](https://github.com/NixOS/nixpkgs/commit/7b4e8f91da954ab741df634f440f57699bd84a57) dante: fix build with clang 16
* [`98a16180`](https://github.com/NixOS/nixpkgs/commit/98a1618021b39524ee93ab685de4107c19bff092) mosquitto: 2.0.17 -> 2.0.18
* [`facbafb0`](https://github.com/NixOS/nixpkgs/commit/facbafb04b0a8b64b108c770958151759578f69d) mosquitto: add nixos test into passthru.tests
* [`741025d9`](https://github.com/NixOS/nixpkgs/commit/741025d9b11c7c5fabb05d8a03a9be43f204cf31) python3Packages.flask-security-too: fix build
* [`72e5e4ea`](https://github.com/NixOS/nixpkgs/commit/72e5e4ea54e73326fdf788181c0dccafe164b3cf) kakounePlugins: updated the 10-22-2023
* [`7620b617`](https://github.com/NixOS/nixpkgs/commit/7620b617e59c9d78119fa67081ce72efd9bc1b40) texlive: implement __overrideTeXConfig and withPackage
* [`673605c4`](https://github.com/NixOS/nixpkgs/commit/673605c4e4223b68709dc8603675c0e651c93c3a) linux: allow to omit the common-config.nix
* [`4b89da79`](https://github.com/NixOS/nixpkgs/commit/4b89da79806d46f1533871436fcfec991eb4561c) qgroundcontrol: 4.2.8 -> 4.2.9
* [`2ce46f4f`](https://github.com/NixOS/nixpkgs/commit/2ce46f4fc0f23085421d43e2ff26c33fe9d35568) crystal: fix build with newer versions of clang
* [`14f2ba71`](https://github.com/NixOS/nixpkgs/commit/14f2ba715dc95b85716dabbf192327d7a031522f) minimal-bootstrap.bash{,_2_05}: Normalize the NIX_BUILD_CORES variable
* [`4f62cc03`](https://github.com/NixOS/nixpkgs/commit/4f62cc0388847299d25e8b21bd5021ee6f745fd6) minimal-bootstrap.*: improve parallelisation using newer bash version
* [`d3234553`](https://github.com/NixOS/nixpkgs/commit/d3234553aa9713592215308bd4bd898c0e46f24e) nixosTests.nginx-sandbox: remove broken test and move the sandboxing test to the openresty test
* [`9aaa5a41`](https://github.com/NixOS/nixpkgs/commit/9aaa5a411e789450147889118c84ab74bbecda15) vimPlugins.vim-clap: 0.45 -> 0.46
* [`ed5caab7`](https://github.com/NixOS/nixpkgs/commit/ed5caab7e015f919ceddd5ddfdc0366ebea29caf) vitess: 17.0.2 -> 17.0.3
* [`3a81a607`](https://github.com/NixOS/nixpkgs/commit/3a81a607ab03d955e390ebc53f7496a526d34c57) vmagent: 1.93.5 -> 1.93.6
* [`03c40199`](https://github.com/NixOS/nixpkgs/commit/03c40199a6a1fe084aa66b09785cba80686e52d4) vokoscreen-ng: 3.7.0 -> 3.8.0
* [`3a5035e3`](https://github.com/NixOS/nixpkgs/commit/3a5035e3bef47c95413b9cf543b46c06c9ac54e2) vttest: 20230201 -> 20230924
* [`220e1c3f`](https://github.com/NixOS/nixpkgs/commit/220e1c3f3fd7fbbb9987de283b6fe33e6ae937f7) vulkan-utility-libraries: 1.3.261 -> 1.3.269
* [`21005263`](https://github.com/NixOS/nixpkgs/commit/21005263f5123f5312cecfb64c37e3fe24c621e8) wallabag: 2.6.6 -> 2.6.7
* [`fd969671`](https://github.com/NixOS/nixpkgs/commit/fd9696710dc37fc076b36b186e45cdec1c9cdbd4) weaviate: 1.21.1 -> 1.21.7
* [`5633e623`](https://github.com/NixOS/nixpkgs/commit/5633e62305842db0a5317e54760785609d31cc5e) wfa2-lib: 2.3.3 -> 2.3.4
* [`c485709e`](https://github.com/NixOS/nixpkgs/commit/c485709e2a64d24feb3999a198d52b3556077826) wipefreespace: 2.5 -> 2.6
* [`5e1dad5e`](https://github.com/NixOS/nixpkgs/commit/5e1dad5e6c56ebb5be1b2a920aaf1eb2c51138f8) wxsqlite3: 4.9.4 -> 4.9.6
* [`37f8f668`](https://github.com/NixOS/nixpkgs/commit/37f8f6681c761a5788b633f1da8f1f8a940bfabc) tests.nixpkgs-check-by-name: Intermediate error type refactoring prep
* [`ed56d74c`](https://github.com/NixOS/nixpkgs/commit/ed56d74c089d6b058a28eaf4a5ef04b190ed3651) tests.nixpkgs-check-by-name: Intermediate path reference errors
* [`a755aa7d`](https://github.com/NixOS/nixpkgs/commit/a755aa7d0251e4282ebdfdd33cbb00382b9a004c) tests.nixpkgs-check-by-name: Intermediate SearchPath error
* [`96f6a350`](https://github.com/NixOS/nixpkgs/commit/96f6a350fa74e995dbbf750b17cad2d6cbb3186e) tests.nixpkgs-check-by-name: Intermediate PathInterpolation error
* [`9a3abc43`](https://github.com/NixOS/nixpkgs/commit/9a3abc4383da1a430525902b87db02ddcfc279ee) tests.nixpkgs-check-by-name: Intermediate CouldNotParseNix error
* [`4897b63a`](https://github.com/NixOS/nixpkgs/commit/4897b63ae67d6f56a0d9a7f0db421467ebe8828b) tests.nixpkgs-check-by-name: Intermediate Symlink errors
* [`9a0ef886`](https://github.com/NixOS/nixpkgs/commit/9a0ef886236eefb13ea84422c5c8ba7865ccf6f8) tests.nixpkgs-check-by-name: Intermediate NonDerivation error
* [`b688da81`](https://github.com/NixOS/nixpkgs/commit/b688da8189f69a760d140400f3f19bd188754b57) tests.nixpkgs-check-by-name: Intermediate WrongCallPackage error
* [`4f17b936`](https://github.com/NixOS/nixpkgs/commit/4f17b9367d7535fc5308557b92e1b306662b3d3d) tests.nixpkgs-check-by-name: Intermediate UndefinedAttr error
* [`e3979d14`](https://github.com/NixOS/nixpkgs/commit/e3979d14cda13b4a6cb15ebccf6052cc67c0db4c) tests.nixpkgs-check-by-name: Intermediate PackageNixDir error
* [`64f5eb61`](https://github.com/NixOS/nixpkgs/commit/64f5eb616e673babd2b54cc07394b04b22242493) tests.nixpkgs-check-by-name: Intermediate PackageNixNonExistent error
* [`b011d53b`](https://github.com/NixOS/nixpkgs/commit/b011d53bda903f70d884ca42a43b65db9b430901) tests.nixpkgs-check-by-name: Intermediate IncorrectShard error
* [`e7d9cc96`](https://github.com/NixOS/nixpkgs/commit/e7d9cc96ed0f8edeb52a2dbeefdcf00e4aedf8ee) tests.nixpkgs-check-by-name: Intermediate InvalidPackageName error
* [`935f8226`](https://github.com/NixOS/nixpkgs/commit/935f82267a84a69a7aa66b2b849fc57f15d24685) tests.nixpkgs-check-by-name: Intermediate CaseSensitiveDuplicate error
* [`143e267a`](https://github.com/NixOS/nixpkgs/commit/143e267ad24e7872ed8adede446d2a9f95e4c409) tests.nixpkgs-check-by-name: Intermediate PackageNonDir error
* [`b7ace019`](https://github.com/NixOS/nixpkgs/commit/b7ace0198cfc971a887358bdc8871c6f5c31cfb4) tests.nixpkgs-check-by-name: Intermediate InvalidShardName error
* [`571eaed1`](https://github.com/NixOS/nixpkgs/commit/571eaed155dced7e29b4e2c6c40f63b0ce521a99) tests.nixpkgs-check-by-name: Intermediate ShardNonDir error
* [`bb89ca72`](https://github.com/NixOS/nixpkgs/commit/bb89ca72dfd79d88f7e3de2460c96a0255ebac11) tests.nixpkgs-check-by-name: Refactor
* [`83b88750`](https://github.com/NixOS/nixpkgs/commit/83b887504c9a4aaa4e25f89bbf3dc19074fba29e) tests.nixpkgs-check-by-name: Support for combining check results
* [`0475238e`](https://github.com/NixOS/nixpkgs/commit/0475238ec08c5b903eac37a13efd1b6f4b9617a3) tests.nixpkgs-check-by-name: Make structural check a global function
* [`d65f3ddb`](https://github.com/NixOS/nixpkgs/commit/d65f3ddb890570dea21df41e386d0f6401c9ec3a) tests.nixpkgs-check-by-name: Make reference check part of structural check
* [`e58bc754`](https://github.com/NixOS/nixpkgs/commit/e58bc75444d5d722a995cf350b0d6c298aeb3808) tests.nixpkgs-check-by-name: Remove Nixpkgs struct
* [`3d604407`](https://github.com/NixOS/nixpkgs/commit/3d60440799721601b04ff39e83374aa684a5300b) tests.nixpkgs-check-by-name: Remove error writer
* [`eac0b690`](https://github.com/NixOS/nixpkgs/commit/eac0b69063c0706d3a0bc956a1efc04745c14594) tests.nixpkgs-check-by-name: Redesign and document check_result functions
* [`8be41ace`](https://github.com/NixOS/nixpkgs/commit/8be41ace99f26479ba1d5a7a0c413e0885113158) tests.nixpkgs-check-by-name: Separate file for all problems
* [`03c58ad1`](https://github.com/NixOS/nixpkgs/commit/03c58ad1d687e8928b2b59f8dc44fb2c4c43300f) tests.nixpkgs-check-by-name: Minor doc updates
* [`dd4c5590`](https://github.com/NixOS/nixpkgs/commit/dd4c55900665400ab0fc71df23a0735b8ee37a59) xastir: 2.1.8 -> 2.2.0
* [`10da5e8a`](https://github.com/NixOS/nixpkgs/commit/10da5e8a47bce52d8f3b6602e126bf7ab851d047) xlockmore: 5.72 -> 5.73
* [`78583ba0`](https://github.com/NixOS/nixpkgs/commit/78583ba088869664fca68de5fdb119b7670f1f97) xmlbird: 1.2.12 -> 1.2.14
* [`9c446d39`](https://github.com/NixOS/nixpkgs/commit/9c446d3911e7c4b6633b9428577345b95964f430) yoshimi: 2.3.0.3 -> 2.3.1
* [`0f3bf1c2`](https://github.com/NixOS/nixpkgs/commit/0f3bf1c22690730838fa2528725de19f95a23f9b) linode-cli: add techknowlogick to maintainers
* [`6ff4f2c2`](https://github.com/NixOS/nixpkgs/commit/6ff4f2c2569f0a3280081b7d6da421a8baa23b51) yubihsm-shell: 2.4.0 -> 2.4.1
* [`40b779ef`](https://github.com/NixOS/nixpkgs/commit/40b779efdc366235fa8af6d9f28af8e440b50e43) pyenv: 2.3.28 -> 2.3.31
* [`60a0ada1`](https://github.com/NixOS/nixpkgs/commit/60a0ada1f844a8ffefa81b7de9ba34214c710a4c) zef: 0.19.1 -> 0.20.0
* [`622b059a`](https://github.com/NixOS/nixpkgs/commit/622b059af98bd4e0701131da054eafeffa9c7dae) maintainers: add Cryolitia
* [`46804529`](https://github.com/NixOS/nixpkgs/commit/4680452994068fb0f9b699d515a02e0253e0019f) zrok: 0.4.6 -> 0.4.10
* [`1f4552da`](https://github.com/NixOS/nixpkgs/commit/1f4552da2261def9665210e9ca2c769b32f4571b) albert: 0.22.13 -> 0.22.14
* [`beb33584`](https://github.com/NixOS/nixpkgs/commit/beb33584013f49d198152ad8ae8797bb6fa0266f) gsound: enable introspection/vala when cross compiled
* [`07bd6950`](https://github.com/NixOS/nixpkgs/commit/07bd6950264963127bbe6962868fcb30cad01abe) aespipe: 2.4f -> 2.4g
* [`ce6f5b78`](https://github.com/NixOS/nixpkgs/commit/ce6f5b781e3a06ce6042187cac7c8e36acf11e7c) fim: 0.6 -> 0.7
* [`169f2703`](https://github.com/NixOS/nixpkgs/commit/169f2703864c27cb6403d7d554d34c8f93376f9f) go-camo: 2.4.4 -> 2.4.5
* [`1d3bc272`](https://github.com/NixOS/nixpkgs/commit/1d3bc272bc31389c06ae1670d7577cab760ffd25) calibre-web: 0.6.20 -> 0.6.21
* [`293bfdc0`](https://github.com/NixOS/nixpkgs/commit/293bfdc031a1eaa5cc571000977df14b6d8237c8) gspell: enable vala for cross compilation
* [`64ff415f`](https://github.com/NixOS/nixpkgs/commit/64ff415f67ddc09ca6d3d2d09d091edc90ed82c0) python311Packages.nunavut: 2.1.1 -> 2.3.0
* [`5d0c92ba`](https://github.com/NixOS/nixpkgs/commit/5d0c92ba3d257e9c927ba9049cc2ca40b777c759) crowdsec: 1.5.4 -> 1.5.5
* [`82e708c1`](https://github.com/NixOS/nixpkgs/commit/82e708c19230f77fbb5ea01157fc1226e72119de) tests.nixpkgs-check-by-name: Custom Validation type and improvements
* [`77539696`](https://github.com/NixOS/nixpkgs/commit/7753969628f2d229d2e9fc40a904d5f08dece09b) tests.nixpkgs-check-by-name: Remove PackageContext helper
* [`952bb841`](https://github.com/NixOS/nixpkgs/commit/952bb841aeadb56ab106eb62cdd128f446a47db0) Revert "nixos/sway: add enableRealtime option"
* [`3cc6ad19`](https://github.com/NixOS/nixpkgs/commit/3cc6ad19d7bbb5e57dd8eb5a10a5441278705029) benthos: 4.19.0 -> 4.22.0
* [`951430c3`](https://github.com/NixOS/nixpkgs/commit/951430c3abb5ed4ebb72184634423dbbee11b407) codeql: 2.14.6 -> 2.15.1
* [`0a431bfe`](https://github.com/NixOS/nixpkgs/commit/0a431bfe3b3ce2e1d5ce68ce981ea3f03463b863) coreth: 0.12.5 -> 0.12.6
* [`909df816`](https://github.com/NixOS/nixpkgs/commit/909df81605bfc746bf431acfa2f7e8a83f0f5b41) gvfs: support cross compilation
* [`3d3f4c0c`](https://github.com/NixOS/nixpkgs/commit/3d3f4c0cb8d5bf1b5919d42cadf721ef58abdaf3) coin-utils: 2.11.9 -> 2.11.10
* [`e32757ad`](https://github.com/NixOS/nixpkgs/commit/e32757ad3aebd7a8cede506a1b7ead6e7bfb16fc) opkg: 0.6.1 -> 0.6.2
* [`7ade1a4b`](https://github.com/NixOS/nixpkgs/commit/7ade1a4b3a5eab11a2f6ef51cd0ba54dd2c11230) celeste: 0.7.0 -> 0.8.0
* [`02349bcc`](https://github.com/NixOS/nixpkgs/commit/02349bcc6969c05276272d34aeb566586ce8bc6f) otpclient: 3.1.9 -> 3.2.0
* [`ca7dccc8`](https://github.com/NixOS/nixpkgs/commit/ca7dccc8a9968c442329d4668aebce00110bb376) displaylink: Add aarch64 support
* [`54813343`](https://github.com/NixOS/nixpkgs/commit/54813343795c8e7c9198abb055f2e303eb497be3) brave: 1.59.120 -> 1.59.124
* [`33d6002c`](https://github.com/NixOS/nixpkgs/commit/33d6002c507c07f204c630e6ba876a45c651b477) fishPlugins.bobthefish: unstable-2022-08-02 -> unstable-2023-06-16
* [`ef34e71d`](https://github.com/NixOS/nixpkgs/commit/ef34e71d89c299e7078fe45a5f0be0b522a4a8b1) zsnes: fix build against zlib-1.3
* [`962db360`](https://github.com/NixOS/nixpkgs/commit/962db36057db0a3e75bdec4e5b864f786cdc1237) _9pfs: fix cross compilation
* [`97bfad5e`](https://github.com/NixOS/nixpkgs/commit/97bfad5e156d2e91eccb4ad621a3b50329e3c0d2) duperemove: fix cross compilation
* [`b8f93f04`](https://github.com/NixOS/nixpkgs/commit/b8f93f048d43c98b0648d327009080e3ca0938d9) sov: fix cross compilation
* [`7227cb1d`](https://github.com/NixOS/nixpkgs/commit/7227cb1d734a2a3ce19a7ce94d5541e03ed1582c) lib.fileset: Fix shellcheck warnings in tests
* [`88f736f8`](https://github.com/NixOS/nixpkgs/commit/88f736f871452cf064689b4098bc92bfb5aef070) lib.fileset.toSource: Test with unknown file type
* [`8a9d735e`](https://github.com/NixOS/nixpkgs/commit/8a9d735e425f53a019315eb3685fd0e3acaf876b) fcitx5-material-color: init at 0.2.1
* [`29e19d0a`](https://github.com/NixOS/nixpkgs/commit/29e19d0aba1fd580d5e7569a5391c6566c6a283b) fcitx5-nord: init at unstable-2021-07-27
* [`63b47bba`](https://github.com/NixOS/nixpkgs/commit/63b47bba5ec5a2358806a89306aaba0abea7b3f2) docker-compose: 2.21.0 -> 2.23.0
* [`48355100`](https://github.com/NixOS/nixpkgs/commit/483551007890fade4eb2ec2fa1a69f173ff09c9e) lean-language-server: init at 3.4.0
* [`15e17917`](https://github.com/NixOS/nixpkgs/commit/15e17917fc0f47af221cbcb6b3fcb5afb84d5cca) nixos/grafana-image-renderer: use Grafana's http_addr rather than localhost
* [`1194ff06`](https://github.com/NixOS/nixpkgs/commit/1194ff06b0d94851b20b724281963c544754177e) python311Packages.azure-mgmt-netapp: 10.1.0 -> 11.0.0
* [`08f81afb`](https://github.com/NixOS/nixpkgs/commit/08f81afb5de677c2b311fb2d669481ff97295ff4) govc: 0.32.0 -> 0.33.0
* [`31790f5d`](https://github.com/NixOS/nixpkgs/commit/31790f5d1926d8799f052ed3f00f45df4c02fe96) level-zero: 1.14.0 -> 1.15.1
* [`42782fdf`](https://github.com/NixOS/nixpkgs/commit/42782fdf6a9dc7e0dd11f9d97deec4a3340034d4) python311Packages.azure-mgmt-containerregistry: 10.1.0 -> 10.2.0
* [`3a4ae2b4`](https://github.com/NixOS/nixpkgs/commit/3a4ae2b42a45f2f9749853df313ebb7827b0dd5d) spring-boot-cli: 2.3.2 -> 3.1.5
* [`30b28ece`](https://github.com/NixOS/nixpkgs/commit/30b28ece73888d434c79009ddd9f09ed2f60cc49) spring-boot-cli: add passthru.{updateScript,tests.version}
* [`cd585ee7`](https://github.com/NixOS/nixpkgs/commit/cd585ee70d0071f677c7380dc7fad0de8967adee) spring-boot-cli: add meta.mainProgram
* [`764c1c2a`](https://github.com/NixOS/nixpkgs/commit/764c1c2a46a7045fce332fb71f4e6a419758d692) upx: 4.1.0 -> 4.2.0
* [`4e6f9775`](https://github.com/NixOS/nixpkgs/commit/4e6f9775819f236538570ff52a769511ee42a794) asm-lsp: init at v0.4.2
* [`fc5f9cae`](https://github.com/NixOS/nixpkgs/commit/fc5f9cae21630873bad9595fd444d66c6ee34dbd) atuin: 16.0.0 -> 17.0.0
* [`6e15779f`](https://github.com/NixOS/nixpkgs/commit/6e15779fda5c92bc77425abcf3532a86b5f813b1) nixos/sudo: fix `security.sudo.package`
* [`ad2838c3`](https://github.com/NixOS/nixpkgs/commit/ad2838c30fe0eab6564345257e098c9ea9692823) ergo: 5.0.14 -> 5.0.15
* [`c0d6bc38`](https://github.com/NixOS/nixpkgs/commit/c0d6bc38744ce416d9c8d249fd0da881b47aa3e8) bruno: 0.27.0 -> 0.27.2
* [`1252a65d`](https://github.com/NixOS/nixpkgs/commit/1252a65d4e19b094db92baf06609073bbf76fbc4) dendrite: 0.13.3 -> 0.13.4
* [`c57c3733`](https://github.com/NixOS/nixpkgs/commit/c57c3733cbc5ed7c045d881338226bbc82000378) frugal: 3.17.2 -> 3.17.5
* [`09f77899`](https://github.com/NixOS/nixpkgs/commit/09f7789948ae6e73f294870e44b6fe21f42d08b2) zfstools: fix missing zpool in PATH
* [`ef561a5c`](https://github.com/NixOS/nixpkgs/commit/ef561a5c31814a734786223a7d0634ef80da1391) crun: 1.10 -> 1.11
* [`59ebe39f`](https://github.com/NixOS/nixpkgs/commit/59ebe39f7bddce448a2cc3e4fdf25038e0e46a03) wakapi: 2.9.1 -> 2.9.2
* [`444622b7`](https://github.com/NixOS/nixpkgs/commit/444622b7424e8ddd1465cea93fdb143fc4c6ac25) bacnet-stack: 1.0.0 -> 1.3.1
* [`ba934a88`](https://github.com/NixOS/nixpkgs/commit/ba934a880749ea5bb8b608d83c19338789f67a85) clamav: 1.2.0 -> 1.2.1
* [`160cafb4`](https://github.com/NixOS/nixpkgs/commit/160cafb40318df3686794747169267274884f213) clp: 1.17.8 -> 1.17.9
* [`132d985b`](https://github.com/NixOS/nixpkgs/commit/132d985be99b0c572edc5840afb83f39afafe8f2) flat-remix-gnome: 20230606 -> 20231026
* [`220ce1ff`](https://github.com/NixOS/nixpkgs/commit/220ce1ff3188bbefbeec22964cc0edec387b0319) maintainers: add sysedwinistrator
* [`22d77f34`](https://github.com/NixOS/nixpkgs/commit/22d77f348c5fce337f8ccd0665988a6284618db0) jq-lsp: init at 2023-10-27
* [`5f1c8b99`](https://github.com/NixOS/nixpkgs/commit/5f1c8b99f828abc921278471fc303b4bb008c204) flink: 1.17.1 -> 1.18.0
* [`bdbfa943`](https://github.com/NixOS/nixpkgs/commit/bdbfa94378e9066eb1a894f8e28808591455d3dc) gfxreconstruct: 1.0.0 -> 1.0.1
* [`8dc9931b`](https://github.com/NixOS/nixpkgs/commit/8dc9931bdebff4d94d15e96b71aaf63c2a499bd0) graphene: disable broken NEON support on armv7l-linux
* [`c15e1f61`](https://github.com/NixOS/nixpkgs/commit/c15e1f61b005d2606b16efa8e36bdf3f96f6e09a) ssh-audit: add test of audited configuration
* [`63ef0339`](https://github.com/NixOS/nixpkgs/commit/63ef0339923bb33aba54301d83ad7f047ee9a2f8) nixos/paperless: set PAPERLESS_SECRET_KEY
* [`a9066322`](https://github.com/NixOS/nixpkgs/commit/a9066322451ff6ec4cbdc81db6b6cb3b244b604f) systemd-stage-1: No longer experimental
* [`e3fcbde5`](https://github.com/NixOS/nixpkgs/commit/e3fcbde55c7404b1c9904c3b897b206b5c2eec63) streamlink: 6.2.1 -> 6.3.1
* [`11c48276`](https://github.com/NixOS/nixpkgs/commit/11c482767a6849fdfdd09ca095bc180cc52ae286) nordic: make sddm a separate output
* [`c61bf670`](https://github.com/NixOS/nixpkgs/commit/c61bf67001a96024bc6758626f47e87011647cb5) linkerd_stable: 2.14.1 -> 2.14.2
* [`929c72ad`](https://github.com/NixOS/nixpkgs/commit/929c72ad0088f5e1e5d27aaa611e5c992a1aee1b) poco: 1.12.4 -> 1.12.5
* [`379286f0`](https://github.com/NixOS/nixpkgs/commit/379286f07eac082fddbec76084898e181f3a35e2) osi: 0.108.8 -> 0.108.9
* [`b2783d69`](https://github.com/NixOS/nixpkgs/commit/b2783d6996cd06e443129cd39f9d619397528942) prqlc: 0.9.5 -> 0.10.0
* [`9478c533`](https://github.com/NixOS/nixpkgs/commit/9478c533e56d61a088aada4015e0070ddc8389b7) python310Packages.eccodes: 2.32.0 -> 2.32.1
* [`15287929`](https://github.com/NixOS/nixpkgs/commit/15287929d3400e1b7af713e30ff287a2dc56aa22) mystmd: 1.1.22 -> 1.1.23
* [`b59a05ec`](https://github.com/NixOS/nixpkgs/commit/b59a05ec897ca282e6b6fcbeb25320d98d053308) mystmd: add version tester
* [`5866b3f8`](https://github.com/NixOS/nixpkgs/commit/5866b3f8bf4f5060089acaa954c5ad3977051ae7) python311Packages.nunavut: update disabled python version
* [`5fd29e19`](https://github.com/NixOS/nixpkgs/commit/5fd29e195830038ae04dd0a2895213209e330621) python311Packages.streamlit: 1.27.2 -> 1.28.0
* [`9c143ca6`](https://github.com/NixOS/nixpkgs/commit/9c143ca68aa95c927289aa9a1b123f2e74e631b7) wl-mirror: 0.13.2 -> 0.14.2
* [`0404987a`](https://github.com/NixOS/nixpkgs/commit/0404987a9b6998ed167aed9bc48b6c5c6b530ed3) microsoft-edge: 118.0.2088.46 -> 118.0.2088.76
* [`84411916`](https://github.com/NixOS/nixpkgs/commit/84411916549ac36633415ea62de31fd9540ebbd6) infisical: 0.14.2 -> 0.14.3
* [`82d6672c`](https://github.com/NixOS/nixpkgs/commit/82d6672cc9620a6758cb7100a38070b91adb20f5) go-ios: 1.0.117 -> 1.0.120
* [`ec6bb917`](https://github.com/NixOS/nixpkgs/commit/ec6bb917d2abf80450435a490f9c6ed8f648117d) birdfont: 2.33.1 -> 2.33.3
* [`30a04f13`](https://github.com/NixOS/nixpkgs/commit/30a04f134941de8af07757bd94f856cc288c653b) fishnet: 2.5.1 -> 2.7.1
* [`2e9c6d32`](https://github.com/NixOS/nixpkgs/commit/2e9c6d3225076ef559a3f154d77fc1f67bbe28ac) obs-studio-plugins.obs-pipewire-audio-capture: 1.1.1 -> 1.1.2
* [`6fcf7c42`](https://github.com/NixOS/nixpkgs/commit/6fcf7c4254e57ccac5be4c8a03d80d3b1a7d9f00) pgcli: 3.5.0 -> 4.0.0
* [`94e7c46c`](https://github.com/NixOS/nixpkgs/commit/94e7c46cab611d6dad3832b97178f419359d5c0e) prometheus-postgres-exporter: 0.14.0 -> 0.15.0
* [`180831dd`](https://github.com/NixOS/nixpkgs/commit/180831dd4670963628a3790a985dec2591cd4c44) experienced-pixel-dungeon: init at 2.15.3
* [`ebc47211`](https://github.com/NixOS/nixpkgs/commit/ebc472116ee184ad786c746b4931858f99599090) summoning-pixel-dungeon: init at 1.2.5
* [`32c51ff1`](https://github.com/NixOS/nixpkgs/commit/32c51ff1df1ea89bbb6cefcf0e7584ac114431dc) shorter-pixel-dungeon: init at 1.2.0
* [`20f7101e`](https://github.com/NixOS/nixpkgs/commit/20f7101e79104cf6a139177f7f1caa181e676b04) brand new derivation
* [`b553f3a1`](https://github.com/NixOS/nixpkgs/commit/b553f3a109eac0b79c34dac04637a4d944c9be2d) pgadmin4: fix build due to Flask update
* [`16d0952b`](https://github.com/NixOS/nixpkgs/commit/16d0952b67256806ba00f7448697500f403c8bac) cargo-make: 0.37.2 -> 0.37.3
* [`206b76c9`](https://github.com/NixOS/nixpkgs/commit/206b76c931f69bb14606c2363a43a90119f2300f) add note
* [`1fd87b65`](https://github.com/NixOS/nixpkgs/commit/1fd87b651da5dc40aa75d29d483b93706625b956) nextcloud26: 26.0.7 -> 26.0.8
* [`8edd2e85`](https://github.com/NixOS/nixpkgs/commit/8edd2e856c17964fc776ace20d5742c23034cd25) nextcloud27: 27.1.2 -> 27.1.3
* [`ecc02253`](https://github.com/NixOS/nixpkgs/commit/ecc02253d3850f44c0b6b160396edda87eda1dc7) nextcloud26Packages: regen
* [`91239bc4`](https://github.com/NixOS/nixpkgs/commit/91239bc459a8a182305a43885f602183adafdba9) nextcloud27Packages: regen
* [`ec800e6a`](https://github.com/NixOS/nixpkgs/commit/ec800e6a05f537828ae53397cbab47eedd72ca82) goeland: 0.15.0 -> 0.16.0
* [`dc034b03`](https://github.com/NixOS/nixpkgs/commit/dc034b033f8bb337c68dab0cbc1dda42b0ff7ff4) rspamd: 3.7.2 -> 3.7.3
* [`5579da56`](https://github.com/NixOS/nixpkgs/commit/5579da56eeee2f2862d134b34793b57de4530288) hyperrogue: 12.1q -> 12.1x
* [`88e296d3`](https://github.com/NixOS/nixpkgs/commit/88e296d3b48faf41d2ea8d38eb95321a24db9622) mssql_jdbc: 12.4.1 -> 12.4.2
* [`76008c01`](https://github.com/NixOS/nixpkgs/commit/76008c01dc328dae6ea5ffab4a6bfbc67302820f) vcsi: 7.0.13 -> 7.0.16
* [`c3a57194`](https://github.com/NixOS/nixpkgs/commit/c3a57194282506295398036a4abd504bd4d19527) linux_xanmod: 6.1.58 -> 6.1.60
* [`c3bf00cd`](https://github.com/NixOS/nixpkgs/commit/c3bf00cd574e5856a29fae15b1b4eacf1d3e397a) linux_xanmod_latest: 6.5.8 -> 6.5.9
* [`0711d3d6`](https://github.com/NixOS/nixpkgs/commit/0711d3d69bcce0f7f94aeb740716bf9d6bcab507) xmrig: add meta.mainProgram
* [`72205983`](https://github.com/NixOS/nixpkgs/commit/72205983aac053e1a21d0332c87fe4da9afdcc0b) maintainers: update fugi
* [`94bd41f1`](https://github.com/NixOS/nixpkgs/commit/94bd41f14fb3fec64c45f6a6b23540a430b112cc) agdsn-zsh-config: 0.7.1 -> 0.8.0
* [`e9ddec59`](https://github.com/NixOS/nixpkgs/commit/e9ddec5936f9f8b432668ab99fb1743f3c7e1fd3) ferdium: 6.5.2 -> 6.6.0
* [`f632ca57`](https://github.com/NixOS/nixpkgs/commit/f632ca576f03186f839dfbf59a79f2e60031e14e) librewolf-unwrapped: 118.0.1-1 -> 119.0-5
* [`e8b07ec6`](https://github.com/NixOS/nixpkgs/commit/e8b07ec65b5bab6e419308d39baf061738e0daa4) gotrue-supabase: 2.99.0 -> 2.105.0
* [`a935849c`](https://github.com/NixOS/nixpkgs/commit/a935849c3252db2b20fc307df3af99b3170add9c) gpodder: 3.11.3 -> 3.11.4
* [`b6e1d7dd`](https://github.com/NixOS/nixpkgs/commit/b6e1d7ddd072fc935715f9ecba50f2b0aa6a1ea6) hurl: 4.0.0 -> 4.1.0
* [`da07e52f`](https://github.com/NixOS/nixpkgs/commit/da07e52ffa908dcfc77535b49bf2c08eed2af2cd) hydrus: 544 -> 549
* [`3010b187`](https://github.com/NixOS/nixpkgs/commit/3010b1873b8795a4c95625118b96caac8fb8434f) hydrus: clean up checkPhase and doc output
* [`e2a7dd9c`](https://github.com/NixOS/nixpkgs/commit/e2a7dd9c5ff54d17200e965aa4a7261ac169e05e) gthumb: 3.12.3 -> 3.12.4
* [`436118d6`](https://github.com/NixOS/nixpkgs/commit/436118d6d74e28e6fd477499f0e1d80a3854c38b) iotop-c: 1.24 -> 1.25
* [`d250b905`](https://github.com/NixOS/nixpkgs/commit/d250b90560bcb73ddc54bbd6db2829ead5ee4bf2) jfrog-cli: 2.50.0 -> 2.50.4
* [`78542d34`](https://github.com/NixOS/nixpkgs/commit/78542d3491352d62f4176fdacb9738c645fd6bc7) jitsi-meet: 1.0.7322 -> 1.0.7531
* [`de825bb3`](https://github.com/NixOS/nixpkgs/commit/de825bb3ba6514ade9be42518637b2b078b00cf0) k8sgpt: 0.3.17 -> 0.3.19
* [`1315bbd7`](https://github.com/NixOS/nixpkgs/commit/1315bbd7140a7ce983b76e91ee2ebbd0f0e94374) kics: 1.7.8 -> 1.7.10
* [`3e0b166f`](https://github.com/NixOS/nixpkgs/commit/3e0b166f50c4bbb0fd4d56c8ae76cb5a68fd6982) klipper: unstable-2023-09-10 -> unstable-2023-10-21
* [`8c57a615`](https://github.com/NixOS/nixpkgs/commit/8c57a61589d70c8c4ad2858ac7c82169f74ddf34) kubedb-cli: 0.35.1 -> 0.36.0
* [`f9dc1525`](https://github.com/NixOS/nixpkgs/commit/f9dc1525724801d335252db549214339502dd598) kubevpn: 2.0.0 -> 2.0.1
* [`fd3e4ee4`](https://github.com/NixOS/nixpkgs/commit/fd3e4ee4a019dc1908e4e55a5702ef073b1497c0) kustomize-sops: 4.2.3 -> 4.2.5
* [`10c309cb`](https://github.com/NixOS/nixpkgs/commit/10c309cb82e0eea4b0bf7392cee49416bda366bc) libdnf: 0.71.0 -> 0.72.0
* [`6d5efcd9`](https://github.com/NixOS/nixpkgs/commit/6d5efcd981d995eef3994f0f9a665a23274400f2) alfaview: 9.2.0 -> 9.4.0
* [`e2cd5f72`](https://github.com/NixOS/nixpkgs/commit/e2cd5f722e9984fc7d34e00a2b45953e6975159c) argo: 3.4.11 -> 3.5.0
* [`ed8dfa9a`](https://github.com/NixOS/nixpkgs/commit/ed8dfa9a56d5fdf781fdaa9dd40541c697765069) armadillo: 12.6.4 -> 12.6.5
* [`b9143de7`](https://github.com/NixOS/nixpkgs/commit/b9143de7f9f4e2235d2219b7e647cc3208927439) cardinal: 23.09 -> 23.10
* [`eb424144`](https://github.com/NixOS/nixpkgs/commit/eb42414431d5f61ec18f779e5d2eaaeff7ebfafb) python311Packages.withings-sync: init at 4.2.1
* [`8314e5ba`](https://github.com/NixOS/nixpkgs/commit/8314e5baa6dc32641b38773118a834f228ff4b85) python311Packages.garminconnect: 0.2.8 -> 0.2.9
* [`247a6e56`](https://github.com/NixOS/nixpkgs/commit/247a6e56a172ece543d0924c3b695ae41cf3aa68) python311Packages.google-cloud-translate: 3.12.0 -> 3.12.1
* [`9ea4504f`](https://github.com/NixOS/nixpkgs/commit/9ea4504f6b746d40690f76ef1997fa7ddd8eec20) python311Packages.google-cloud-vision: 3.4.4 -> 3.4.5
* [`17983c80`](https://github.com/NixOS/nixpkgs/commit/17983c800bc08a5093ec0932f244031c117d90bc) atuin: 17.0.0 -> 17.0.1
* [`8eb8c788`](https://github.com/NixOS/nixpkgs/commit/8eb8c7883ba232d974fcc3533a90e5c8d17e3bb3) ballerina: 2201.8.1 -> 2201.8.2
* [`1b6153a0`](https://github.com/NixOS/nixpkgs/commit/1b6153a04e49ad9134ba7472f9716e919a82796d) python311Packages.cohere: 4.26.1 -> 4.32
* [`ddae1c58`](https://github.com/NixOS/nixpkgs/commit/ddae1c58ad38b8a3258a66b65df5a57da1066c52) besu: 23.7.3 -> 23.10.0
* [`a112662b`](https://github.com/NixOS/nixpkgs/commit/a112662b80e0400c4bf3913dbc9e66edd6d6328b) sozu: 0.15.6 -> 0.15.13
* [`036c5cb9`](https://github.com/NixOS/nixpkgs/commit/036c5cb9ded6aceebee1fc507223a01603dd9310) doc: update r-b issue template
* [`b19edaec`](https://github.com/NixOS/nixpkgs/commit/b19edaec41ea588f14e4c24157a7ccfcc10d5f34) python311Packages.sqlite-migrate: init at version 0.1a2
* [`9840fd8c`](https://github.com/NixOS/nixpkgs/commit/9840fd8c12c1b74de4dacc4722ebf0fd62c029ad) schismtracker: 20230906 -> 20231029
* [`d30bd8a8`](https://github.com/NixOS/nixpkgs/commit/d30bd8a8cc0e11b873367dc37e24af7755a357a2) k3s: build with go_1_20
* [`ee422628`](https://github.com/NixOS/nixpkgs/commit/ee42262830ecf480ede731d7567ef9d046a9c911) cargo-insta: 1.32.0 -> 1.33.0
* [`30ebba75`](https://github.com/NixOS/nixpkgs/commit/30ebba7599051d8a2d8a1b9c28878e98ff0a1875) cargo-modules: 0.9.4 -> 0.10.2
* [`2cb8f62d`](https://github.com/NixOS/nixpkgs/commit/2cb8f62d5249bae83be664ed261278a0d6b869fe) chezmoi: 2.40.0 -> 2.40.3
* [`d87d8483`](https://github.com/NixOS/nixpkgs/commit/d87d84833b761d5b9c2b7e082d6ed9c2b4f1c0d1) drogon: 1.8.7 -> 1.9.0
* [`54b3c061`](https://github.com/NixOS/nixpkgs/commit/54b3c061cb98b0449ca30a087dc1ceea0133be6a) maintainers: add jl178
* [`55d04ca0`](https://github.com/NixOS/nixpkgs/commit/55d04ca0df7485ec681f95236b8c9c758e436729) python311Packages.hap-python: 4.9.0 -> 4.9.1
* [`d44205d7`](https://github.com/NixOS/nixpkgs/commit/d44205d74dd6df3fe2e6963abc1ef7be363610c4) python311Packages.msal: 1.24.0 -> 1.24.1
* [`06e9e4bc`](https://github.com/NixOS/nixpkgs/commit/06e9e4bc0ae551abc83611dc5ebf39270a61ae81) git-extras: 7.0.0 -> 7.1.0
* [`287e151e`](https://github.com/NixOS/nixpkgs/commit/287e151ee1a0385dcf0de42ba37595e1b1e1dd89) git-cliff: 1.3.1 -> 1.4.0
* [`2b9f28d0`](https://github.com/NixOS/nixpkgs/commit/2b9f28d01babe3307b99394797ef547679c331fe) python311Packages.objsize: 0.6.1 -> 0.7.0
* [`1f7cab48`](https://github.com/NixOS/nixpkgs/commit/1f7cab48749a5a0891ae7511727bcbe9e2bde0eb) python311Packages.ocrmypdf: 15.2.0 -> 15.3.1
* [`c2ac35cf`](https://github.com/NixOS/nixpkgs/commit/c2ac35cf624de17e03fb74fe24cb82daa33caf5a) ddcutil: 1.4.2 -> 2.0.0
* [`8622d204`](https://github.com/NixOS/nixpkgs/commit/8622d20439815a28fad3b9c678358b5bacf94c9b) pipecontrol: 0.2.10 -> 0.2.11
* [`c39560a9`](https://github.com/NixOS/nixpkgs/commit/c39560a9d26267bc838771b9dc96d599cdebad0d) podofo010: 0.10.1 -> 0.10.2
* [`d5a991ba`](https://github.com/NixOS/nixpkgs/commit/d5a991ba83518f50a1dc383311d6989aa4b438f9) ddcui: 0.3.0 ->  0.4.2
* [`357bd136`](https://github.com/NixOS/nixpkgs/commit/357bd13608fe8dc65e1224057e9fafaeccc9262c) carapace: 0.28.0 -> 0.28.2
* [`4b4cc103`](https://github.com/NixOS/nixpkgs/commit/4b4cc103b772cbfd6f3f4ff993059a99a6188745) python311Packages.pysignalclirestapi: 0.3.18 -> 0.3.21
* [`2540af16`](https://github.com/NixOS/nixpkgs/commit/2540af169e2e37568802be8adda3512f722af9de) mitmproxy: 9.0.1 -> 10.1.1
* [`5628aeb5`](https://github.com/NixOS/nixpkgs/commit/5628aeb5b08e2857df4ceb506b682836a0269d39) kea: allow kea to cross-compile
* [`00b64d0c`](https://github.com/NixOS/nixpkgs/commit/00b64d0c49c5a694ca5778891205f4d82dffd42b) vapoursynth: R64 -> R65
* [`f327c74c`](https://github.com/NixOS/nixpkgs/commit/f327c74c3022953fa75676b65891a46d446a8012) riemann: 0.3.8 -> 0.3.9
* [`09689ad1`](https://github.com/NixOS/nixpkgs/commit/09689ad135f25e0e20c566bbddf25113953f57f2) python3Packages.prawcore: disable tests requiring network
* [`596d2611`](https://github.com/NixOS/nixpkgs/commit/596d26111c23269e12757aa75d8b381b2eadcce2) python3Packages.praw: disable tests requiring network
* [`79a2e28f`](https://github.com/NixOS/nixpkgs/commit/79a2e28f115740256522179816a31e670e0676cb) visidata: 2.11 -> 2.11.1
* [`a771cbe7`](https://github.com/NixOS/nixpkgs/commit/a771cbe75e0122bb8bd2da5156ff6837b2fa2872) python311Packages.peaqevcore: 19.5.10 -> 19.5.12
* [`0dc31283`](https://github.com/NixOS/nixpkgs/commit/0dc31283c339db3a4fd7a9653bd688fde56ad345) sdrangel: 7.16.0 -> 7.17.0
* [`0469c8e3`](https://github.com/NixOS/nixpkgs/commit/0469c8e35d483bb1d6d381d0d2124f4e42660cd0) odoo: 16.0.20230722 -> 16.0.20231024
* [`a313a406`](https://github.com/NixOS/nixpkgs/commit/a313a406cdab47c9938df5b20ab6d8f88c5a4ceb) xsubfind3r: 0.3.0 -> 0.4.0
* [`16936f43`](https://github.com/NixOS/nixpkgs/commit/16936f4313f19d269c12494ef15ea9bb19bb7d61) spicetify-cli: 2.25.1 -> 2.25.2
* [`bc724326`](https://github.com/NixOS/nixpkgs/commit/bc724326058677f99efc6385c57a8b19ef57dd9f) python311Packages.prophet: 1.1.4 -> 1.1.5
* [`fc4478d4`](https://github.com/NixOS/nixpkgs/commit/fc4478d4ae6e66cb3501f7348dace2f1f569e89a) salt: 3006.3 -> 3006.4
* [`f8e8e037`](https://github.com/NixOS/nixpkgs/commit/f8e8e037acc51699bf43cfc47f1e1f8f254efca8) hyprpicker: set mainProgram
* [`eda430b8`](https://github.com/NixOS/nixpkgs/commit/eda430b89e86a882992f8f5e9dc28fa0f64d6d19) kubeclarity: 2.21.1 -> 2.22.0
* [`ab20fb6a`](https://github.com/NixOS/nixpkgs/commit/ab20fb6a905db61ea4085a1502e83055ff9ff577) maintainer: add giomf
* [`2da3bd29`](https://github.com/NixOS/nixpkgs/commit/2da3bd29f79d425edd4ece6891079a03646b0c26) codux: 15.10.0 -> 15.13.0
* [`e27d402e`](https://github.com/NixOS/nixpkgs/commit/e27d402ea4d8129cf5466bd49f3792358baa4f16) lutris: 0.5.13 -> 0.5.14
* [`4544b852`](https://github.com/NixOS/nixpkgs/commit/4544b8527313ce5bc86324f768994ee2d3a6f462) maintainers: add adriangl
* [`8569ee55`](https://github.com/NixOS/nixpkgs/commit/8569ee55f7ce7112c814ace32965442bc508d3f6) waylock: 0.6.2 -> 0.6.3
* [`4f971ebf`](https://github.com/NixOS/nixpkgs/commit/4f971ebf3ca68a419995fba30363a8f328bf9fba) nixos/wyoming/faster-whisper: pass device config to executable
* [`f3fabe24`](https://github.com/NixOS/nixpkgs/commit/f3fabe24f9c3fe20283b0dcff8b5fb9441586de2) audiobookshelf: 2.4.4 -> 2.5.0
* [`479138ac`](https://github.com/NixOS/nixpkgs/commit/479138acc513e9d770d3e10ab45d778392017358) ctranslate2: add CUDA/cuDNN support
* [`1152e785`](https://github.com/NixOS/nixpkgs/commit/1152e785222f616929a181380d9e04f80c2299c6) cie-middleware-linux: 1.4.4.0 -> 1.5.0
* [`433fe023`](https://github.com/NixOS/nixpkgs/commit/433fe023817d45abcda828c48f27512c212d398f) escrotum: add ffmpeg-full to PATH of wrapper
* [`96ac708b`](https://github.com/NixOS/nixpkgs/commit/96ac708b24922904571962b4113e4040a68d496b) dar: 2.7.10 -> 2.7.13
* [`a0cf0dfa`](https://github.com/NixOS/nixpkgs/commit/a0cf0dfae15d47abcc1f73208ec361989282f2f1) der-ascii: 0.1.0 -> 0.3.0
* [`caa33d11`](https://github.com/NixOS/nixpkgs/commit/caa33d11696ed3f2e7816b07b3c19ee1feccfe52) hyprdim: 2.2.1 -> 2.2.2
* [`e8221c96`](https://github.com/NixOS/nixpkgs/commit/e8221c96c6dc7541ce69c2af4e07068482a5c3d4) scala-cli: 1.0.4 -> 1.0.5
* [`4d03298c`](https://github.com/NixOS/nixpkgs/commit/4d03298c6fe372e0110dd509cb74fdde1f30522e) dnsdist: 1.8.1 -> 1.8.2
* [`9b975558`](https://github.com/NixOS/nixpkgs/commit/9b97555888a52e3d670a67af62844f994934721e) dprint: 0.41.0 -> 0.42.5
* [`c543abd7`](https://github.com/NixOS/nixpkgs/commit/c543abd7235e5cb6eb7b011ae8deb0222f0b1a27) python3Packages.libusb1: 3.0.0 -> 3.1.0
* [`89f912e2`](https://github.com/NixOS/nixpkgs/commit/89f912e2e2a76eace1395835ce861ad75595615d) exodus: 23.9.25 -> 23.10.24
* [`c0782f8e`](https://github.com/NixOS/nixpkgs/commit/c0782f8e9c837e9f4da1b2e60a9af1d8b2dd32d6) mysql-shell: 8.0.34 -> 8.0.35
* [`919951b1`](https://github.com/NixOS/nixpkgs/commit/919951b1e53db2fbe8611e106d6d78c254d16bde) mysql-shell-innovation: 8.1.1 -> 8.2.0
* [`2ffd8991`](https://github.com/NixOS/nixpkgs/commit/2ffd899107b83d04999cb1cca19e0e14d28c3742) flashprint: 5.8.0 -> 5.8.1
* [`0a32ab67`](https://github.com/NixOS/nixpkgs/commit/0a32ab67b32255af0096a38c557a946d7d90cd07) deepin.dde-daemon: fix build with ddcutil 2
* [`b45ec9b1`](https://github.com/NixOS/nixpkgs/commit/b45ec9b195c0abebfad558b56e9a08ccbd70a965) libhugetlbfs: make meta.badPlatforms flat
* [`d761372b`](https://github.com/NixOS/nixpkgs/commit/d761372b5cf1bc52ebad1b333339c3921d0b00f3) mailpit: 1.7.1 -> 1.9.9
* [`50b063ba`](https://github.com/NixOS/nixpkgs/commit/50b063baaafe7f4e6d1f5c01afc2e46430ffd636) zuo: unstable-2023-01-02 -> unstable-2023-10-17
* [`22c60114`](https://github.com/NixOS/nixpkgs/commit/22c601148eb296a0d19e285d6a46e0b404f22834) chezmoi: 2.40.3 -> 2.40.4
* [`58da932d`](https://github.com/NixOS/nixpkgs/commit/58da932d40f4e387f1125c5e66ebd57cf3608c67) python311Packages.scrapy: fix build
* [`1c247c31`](https://github.com/NixOS/nixpkgs/commit/1c247c31d4814f539520360cc2263b5138fa213e) mailpit: add meta.mainProgram
* [`e9d089bb`](https://github.com/NixOS/nixpkgs/commit/e9d089bba06041d094c61165f282d85fd15be31b) zuo: add updateScript
* [`3928b00f`](https://github.com/NixOS/nixpkgs/commit/3928b00f1973ad0c6f8c71c43f176b9ac003af7e) python311Packages.pydata-sphinx-theme: 0.14.2 -> 0.14.3
* [`39042ada`](https://github.com/NixOS/nixpkgs/commit/39042adae35cff4594c884ce225250dcfe590d34) lean4: 4.1.0 -> 4.2.0
* [`25b84471`](https://github.com/NixOS/nixpkgs/commit/25b84471338a5c5c26397e007204864e34cedde0) luau: 0.600 -> 0.601
* [`3c46bb45`](https://github.com/NixOS/nixpkgs/commit/3c46bb4528b125956e36d66d9ead5fc422450616) iredis: 1.13.2 -> 1.14.0
* [`16bd046e`](https://github.com/NixOS/nixpkgs/commit/16bd046e51447fcd2bbeb667d91f2edb47630957) intel-one-mono: 1.2.1 -> 1.3.0
* [`99835e7d`](https://github.com/NixOS/nixpkgs/commit/99835e7d6b212c7eb682ee4b026bcac68fbcc601) c0: unstable-2022-10-25 -> unstable-2023-09-05
* [`20b2d942`](https://github.com/NixOS/nixpkgs/commit/20b2d94235fd3319653b48741eaa54b8a9137b41) fstar: 2023.04.25 -> 2023.09.03
* [`759242ae`](https://github.com/NixOS/nixpkgs/commit/759242aed9f89aeaa32ec43d9d12028ba8c8d230) parson: 1.5.2 -> 1.5.3
* [`4e9938a4`](https://github.com/NixOS/nixpkgs/commit/4e9938a45f25e117fea26a137eb26ea0cf85c88a) gqrx: 2.17.2 -> 2.17.3
* [`def8bfe0`](https://github.com/NixOS/nixpkgs/commit/def8bfe0c7595fd24a4a44c2c1f08aac973d30a6) hebbot: set meta.mainProgram
* [`4d32327b`](https://github.com/NixOS/nixpkgs/commit/4d32327bb04299bd7596cf98266e926656494b14) gimoji: set meta.mainProgram
* [`fa1b02a5`](https://github.com/NixOS/nixpkgs/commit/fa1b02a52fb35ccd37072d635081cef02acc07d0) grpcurl: 1.8.8 -> 1.8.9
* [`d5965022`](https://github.com/NixOS/nixpkgs/commit/d5965022f2ecfa26149ae18e28e5b546c4f004df) python311Packages.nuitka: default to lto off for darwin
* [`e0c77885`](https://github.com/NixOS/nixpkgs/commit/e0c778859ce4dd897aa5e2230ad963dd8bb7aac8) buildbot: fix twisted version requirement & missing pkg_resources
* [`79cb5653`](https://github.com/NixOS/nixpkgs/commit/79cb565399168fa1136efa80579cecbcf2e5c5d8) python311Packages.img2pdf: 0.4.4 -> 0.5.0
* [`14e7480d`](https://github.com/NixOS/nixpkgs/commit/14e7480dd52916cf68c0872ef1c9c21388e26ab9) python311Packages.pgvector: 0.2.2 -> 0.2.3
* [`8c7d5159`](https://github.com/NixOS/nixpkgs/commit/8c7d51592f5464adcb6183a5597f7bf8afcf6c8d) python311Packages.peewee: 3.16.3 -> 3.17.0
* [`99bc0b5a`](https://github.com/NixOS/nixpkgs/commit/99bc0b5a9a6fe6a4584a6df1a8fbf5b1059409e6) seaweedfs: 3.55 -> 3.58
* [`9909fe5a`](https://github.com/NixOS/nixpkgs/commit/9909fe5a1c0fdb249e54b270ab6bad7d9d2a0fca) python311Packages.qcodes-loop: remove patch
* [`9c8d9a7a`](https://github.com/NixOS/nixpkgs/commit/9c8d9a7af3ae0f2e4abc0851d5938e0c7847a781) python311Packages.publicsuffixlist: 0.10.0.20231026 -> 0.10.0.20231030
* [`0532c141`](https://github.com/NixOS/nixpkgs/commit/0532c14154f0e4989546516adfac3099dce9fe2a) python311Packages.publicsuffixlist: switch to pyproject
* [`419eba9a`](https://github.com/NixOS/nixpkgs/commit/419eba9ab1a86c5fb01cee802ee47120c8efa78f) linux_6_6: init at 6.6
* [`6ea7f7bc`](https://github.com/NixOS/nixpkgs/commit/6ea7f7bc7f9ecdb80b542a75db9748ea13e9175c) python311Packages.unearth: 0.11.2 -> 0.12.1
* [`1689fed5`](https://github.com/NixOS/nixpkgs/commit/1689fed51fe68d88e6bf93001753ce720d7328de) pdm: 2.9.3 -> 2.10.0
* [`be33098c`](https://github.com/NixOS/nixpkgs/commit/be33098cfffff918ac527888058436ee193b6cd6) linux/common-config: enable new security features for 6.6
* [`25fbde2a`](https://github.com/NixOS/nixpkgs/commit/25fbde2ad051c356db231594cc4c672cbfed396b) civo: 1.0.67 -> 1.0.68
* [`ed449a1f`](https://github.com/NixOS/nixpkgs/commit/ed449a1f058053e5926e29033f868129730b229b) pr-tracker: fetchurl -> fetchzip
* [`423b31f1`](https://github.com/NixOS/nixpkgs/commit/423b31f1b24ec8d82baec9a5bb969da892010e6d) pr-tracker: 1.2.0 -> 1.3.0
* [`c871ce0f`](https://github.com/NixOS/nixpkgs/commit/c871ce0f51bcc77e033d85204ca77efcb167d356) bazel_6: Fix `pythonBinPath` and `pythonBinPathWithNixHacks` tests
* [`c08e458e`](https://github.com/NixOS/nixpkgs/commit/c08e458e7f2ff57c28684e659c958695ecb84672) guitarix: fix build
* [`ed759c8b`](https://github.com/NixOS/nixpkgs/commit/ed759c8bd872a139069a6bbd5b5447c01a727f0b) microsoft-edge: added overwriteable command line args
* [`16c2c081`](https://github.com/NixOS/nixpkgs/commit/16c2c0819ba54a7c1d7c8efb2663d33890149752) lux: 0.19.0 -> 0.21.0
* [`1aa5e4f8`](https://github.com/NixOS/nixpkgs/commit/1aa5e4f866eccc3aaea160885d29d85a7d046537) ddns-go: 5.6.3 -> 5.6.4
* [`5f3e09f4`](https://github.com/NixOS/nixpkgs/commit/5f3e09f413c14d12e11ab06c30a923f81e04d97a) fulcio: 1.4.1 -> 1.4.3
* [`1220a4d4`](https://github.com/NixOS/nixpkgs/commit/1220a4d4dd1a4590780a5e1c18d1333a121be366) postgresql_11: remove
* [`71ece62f`](https://github.com/NixOS/nixpkgs/commit/71ece62fd4fb14f652128ebfbc9a68305ec9bce3) glom: provide bin dir of postgresql
* [`f68143e8`](https://github.com/NixOS/nixpkgs/commit/f68143e8cdcc6df87d609710736e0b5d226cb645) todoman: 4.3.2 -> 4.4.0
* [`caf70776`](https://github.com/NixOS/nixpkgs/commit/caf70776a2b500e0e010519b1ebf136d81df130e) qmplay2: 23.08.22 -> 23.10.22
* [`6d8ef00e`](https://github.com/NixOS/nixpkgs/commit/6d8ef00edc74772feebb743b2adf3d2106d62e0c) cf-terraforming: 0.14.0 -> 0.15.0
* [`7b0a2b8d`](https://github.com/NixOS/nixpkgs/commit/7b0a2b8d874928fb56782fb35efb8745995b90c3) brogue-ce: 1.12 -> 1.13
* [`cca22054`](https://github.com/NixOS/nixpkgs/commit/cca22054c073694e4ca49ca6471be8326d43316b) systemd-stage-1: Add assertions for unsupported options.
* [`c412b385`](https://github.com/NixOS/nixpkgs/commit/c412b3851c10e431959e144af15ec2fba403068a) mus: 0.1.0 -> 0.2.0
* [`eea75686`](https://github.com/NixOS/nixpkgs/commit/eea756868f85192635046fc2214590bd4e81bdee) build(deps): bump korthout/backport-action from 1.3.1 to 2.0.0
* [`8272db15`](https://github.com/NixOS/nixpkgs/commit/8272db154d3b2738ddb216896f4fb733220da2dc) isso: fix tests
* [`b20c401b`](https://github.com/NixOS/nixpkgs/commit/b20c401bc5f110e67b9fb3ed842bc40c7062cac3) airlift: init at 0.3.0
* [`441a4c04`](https://github.com/NixOS/nixpkgs/commit/441a4c04da8f4fbe8fc33f5a9a1c621c51e7dd4a) pgweb: 0.14.1 -> 0.14.2
* [`0f6cc801`](https://github.com/NixOS/nixpkgs/commit/0f6cc8018c7b7f9244f06ad8072ab017808ad0c2) lib.fileset.toSource: Improve error for unknown file types
* [`47c81d32`](https://github.com/NixOS/nixpkgs/commit/47c81d3286bd027d5b55fa581f9502eff4ea8822) lib.fileset.toSource: Optimise unknown file type error
* [`50df7f97`](https://github.com/NixOS/nixpkgs/commit/50df7f977548c296e475ad37c1d44afcdc9f8e26) lib.fileset.difference: init
* [`d900a4fb`](https://github.com/NixOS/nixpkgs/commit/d900a4fbdc57b0fce7d7308a0aa3e1fa0aa65684) joker: 1.3.0 -> 1.3.1
* [`310d0195`](https://github.com/NixOS/nixpkgs/commit/310d0195270a1757c91764355f0c26a440cfebca) esphome: 2023.10.3 -> 2023.10.4
* [`fcc44e9a`](https://github.com/NixOS/nixpkgs/commit/fcc44e9aeae563b9beea171ef47d1a11dd117d12) llvmPackages_12.openmp,llvmPackages_13.openmp: fix cross
* [`57853e57`](https://github.com/NixOS/nixpkgs/commit/57853e57b8b3c2bbbdafe568b9fd28aaa92d71e5) sing-box: 1.5.4 -> 1.5.5
* [`7950c700`](https://github.com/NixOS/nixpkgs/commit/7950c700e89662ea6ba2d09f6b78ac20b6fde5ab) python3Packages.notmuch2: add missing runtime dependency cffi
* [`eacd6b5a`](https://github.com/NixOS/nixpkgs/commit/eacd6b5ab888f24a7a9fb17b662fa44b2e9714a9) nomino: 1.3.2 -> 1.3.3
* [`204ee865`](https://github.com/NixOS/nixpkgs/commit/204ee865754f5f3bb7316653f79c25ed63a78eed) nixosTests.xfce: Check if any coredumps are found
* [`31d029e2`](https://github.com/NixOS/nixpkgs/commit/31d029e21e9142e68d421d0c05b8ddf2246ee7ce) circup: 1.2.3 -> 1.4.0
* [`47e870bb`](https://github.com/NixOS/nixpkgs/commit/47e870bb0377efbe9cb6a7bb6a962a79d26f8ba8) ldeep: 1.0.42 -> 1.0.43
* [`6d82eb77`](https://github.com/NixOS/nixpkgs/commit/6d82eb775360156ecca1e7c8872f9bfa80939d2a) postgresqlPackages: remove compat with postgresql_11
* [`8387ca22`](https://github.com/NixOS/nixpkgs/commit/8387ca22d16b8e5f7a66e30708f8a265d9349c5c) python311Packages.plugwise: 0.33.2 -> 0.34.4
* [`eacaedfa`](https://github.com/NixOS/nixpkgs/commit/eacaedfaa649aafbaa6ef7905d3eca0e9dc8f171) python311Packages.python-kasa: 0.5.3 -> 0.5.4
* [`9e0f6eb3`](https://github.com/NixOS/nixpkgs/commit/9e0f6eb369ed124edbafe18f6316f535816bc2b9) python311Packages.python-roborock: 0.35.0 -> 0.35.3
* [`eae9ff7d`](https://github.com/NixOS/nixpkgs/commit/eae9ff7dc69eb79ea004a5f9fa49953a3d148fd9) python311Packages.scmrepo: 1.4.0 -> 1.4.1
* [`945cdad4`](https://github.com/NixOS/nixpkgs/commit/945cdad4ee2fd3987c7214c2cbaf8483e1c94a02) postgresql: remove pipelinedb extension
* [`7578c597`](https://github.com/NixOS/nixpkgs/commit/7578c597fa551cec1561ae6afdde3f49ce3e9739) python311Packages.langsmith: 0.0.49 -> 0.0.53
* [`9d89f7ce`](https://github.com/NixOS/nixpkgs/commit/9d89f7ceef377d9c0294386873e138012c0b1ae7) python311Packages.langchain: 0.0.320 -> 0.0.325
* [`279cecf6`](https://github.com/NixOS/nixpkgs/commit/279cecf6b748294be69fa1f38627f146252afb9e) nixos/postgresql: remove postgresql_11-backup-all test
* [`0d00863e`](https://github.com/NixOS/nixpkgs/commit/0d00863e3cebc25ac227bddac00fc747317a4b5a) python311Packages.langchain: clean up dependencies
* [`97c8df0f`](https://github.com/NixOS/nixpkgs/commit/97c8df0fbce5aa10ddfb1076966827b32b89190e) ripgrep-all: 0.9.6 -> 1.0.0-alpha.5
* [`16b7da22`](https://github.com/NixOS/nixpkgs/commit/16b7da228a6dd504db883c712688da83f9976646) broot: 1.26.1 -> 1.27.0
* [`c114a76e`](https://github.com/NixOS/nixpkgs/commit/c114a76e93fad77a4601f56dff5cfcf5b88e2a45) python311Packages.openapi-schema-pydantic: remove
* [`88c8c03b`](https://github.com/NixOS/nixpkgs/commit/88c8c03b1b0bc37b6e6e22259ffaec7c21d434bf) python311Packages.pycfmodel: 0.20.3 -> 0.21.0
* [`a7ded185`](https://github.com/NixOS/nixpkgs/commit/a7ded1859c0ec8a77d11c0154284b025f9b30417) odoo: update dependencies
* [`d63cd3a7`](https://github.com/NixOS/nixpkgs/commit/d63cd3a7dd9777f2db2ca6f88c71379314b9839a) python311Packages.subarulink: 0.7.7 -> 0.7.8
* [`cfbc8b5d`](https://github.com/NixOS/nixpkgs/commit/cfbc8b5d0a031e1051757cb7d7efe5eefad69c96) mastodon: fix rev
* [`b827052e`](https://github.com/NixOS/nixpkgs/commit/b827052e1d92836278bc2115eab0e2d337a45093) circom: init at 2.1.6
* [`0d34502f`](https://github.com/NixOS/nixpkgs/commit/0d34502fe3c62ae1d61a11f573ea637c4d537170) nixos/wyoming/openwakeword: relax model selection
* [`220628ea`](https://github.com/NixOS/nixpkgs/commit/220628eafe6bfe478d2432edaa82b6cb5eb388b6) cargo-semver-checks: 0.24.1 -> 0.24.2
* [`81914ea5`](https://github.com/NixOS/nixpkgs/commit/81914ea5844ea09d3d01250090a0513d0b45aa43) python3Packages.torch: check in patch for PyTorch PR 108847
* [`52bd1c63`](https://github.com/NixOS/nixpkgs/commit/52bd1c63e57db51229597f0be9aab9382ae8d2e0) gatekeeper: 3.13.2 -> 3.13.3
* [`1da93776`](https://github.com/NixOS/nixpkgs/commit/1da9377680c49e711d0b1c5cc2d714aff116b615) minify: 2.20.0 -> 2.20.1
* [`db6fb9e9`](https://github.com/NixOS/nixpkgs/commit/db6fb9e9d34e6484674c06d6c569ac342d2dcdcf) v2ray-domain-list-community: 20231015073627 -> 20231030084219
* [`fc497260`](https://github.com/NixOS/nixpkgs/commit/fc49726007729bec58beadbd98dc538b37188f73) python311Packages.pyschlage: 2023.9.1 -> 2023.10.0
* [`90250f8e`](https://github.com/NixOS/nixpkgs/commit/90250f8e2a50b83ea2a56c1433d84babef3825d2) python311Packages.aemet-opendata: 0.4.5 -> 0.4.6
* [`d89a6f9e`](https://github.com/NixOS/nixpkgs/commit/d89a6f9ef3beb6ae55d9e8c593bd842a317748a6) python311Packages.androidtv: 0.0.72 -> 0.0.73
* [`bf489907`](https://github.com/NixOS/nixpkgs/commit/bf4899073b457bce250edd95a42f03797505a635) python311Packages.opower: 0.0.37 -> 0.0.38
* [`fa874ac9`](https://github.com/NixOS/nixpkgs/commit/fa874ac90ad95eaa3dc6e91c16b8b67ba6e91d90) python311Packages.geniushub-client: 0.7.0 -> 0.7.1
* [`48e6ac6d`](https://github.com/NixOS/nixpkgs/commit/48e6ac6d4fccb3dbce456229f78500ffe7e36d4b) wyoming-openwakeword: 1.5.1 -> 1.8.1
* [`753b33c6`](https://github.com/NixOS/nixpkgs/commit/753b33c620fa97de5af74f4cee450b3a08c6a404) prometheus-systemd-exporter: 0.5.0 → 0.6.0
* [`f6642aaf`](https://github.com/NixOS/nixpkgs/commit/f6642aaf8b64bf6f74483938928f70452a3d79bc) perlPackages.ProcDaemon: init at 0.23
* [`3c7dd692`](https://github.com/NixOS/nixpkgs/commit/3c7dd692d3f6eb59042d922ac3f093a2b5e50cd4) perlPackages.ProcPIDFile: init at 1.29
* [`b4d5e89f`](https://github.com/NixOS/nixpkgs/commit/b4d5e89f9e2484b93f2b5f522203423d6af59712) perlPackages.ParseEDID: init at 1.0.7
* [`db05c276`](https://github.com/NixOS/nixpkgs/commit/db05c27629a01abf6249cacbb01e10d9d1edee90) perlPackages.NetCUPS: init at 0.64
* [`47d3ce69`](https://github.com/NixOS/nixpkgs/commit/47d3ce69dc74012708636ea6dbc84d2c429a9c80) perlPackages.MacSysProfile: init at 0.05
* [`c4dab4b2`](https://github.com/NixOS/nixpkgs/commit/c4dab4b230907dfc2f2f4df51d66037318588032) perlPackages.XMLEntities: init at 1.0002
* [`f35eefd3`](https://github.com/NixOS/nixpkgs/commit/f35eefd3d603ca5dd65a55ddf323af48fbb947db) perlPackages.MacPropertyList: init at 1.504
* [`5954b622`](https://github.com/NixOS/nixpkgs/commit/5954b622091ba75b90e9de221e45beeb3e417422) ocsinventory-agent: init at 2.10.1
* [`e4582806`](https://github.com/NixOS/nixpkgs/commit/e458280606907749759bcb323c09ba652045b3ef) nixos/wyoming/openwakeword: update for 1.8.1
* [`c1ae82f4`](https://github.com/NixOS/nixpkgs/commit/c1ae82f448b10b278dc77e02518775175b463a27) nixos/systemd: fix make unit failed when unit too large
* [`2c08ccb3`](https://github.com/NixOS/nixpkgs/commit/2c08ccb3f4a7cb4ecdcdc448201d07cd7110c12e) vencord: 1.6.0 -> 1.6.1
* [`89a32d28`](https://github.com/NixOS/nixpkgs/commit/89a32d286797b7158cb2e642a259456c643e0b17) tempo: 2.2.3 -> 2.3.0
* [`e600cdf7`](https://github.com/NixOS/nixpkgs/commit/e600cdf7b0c288c6087a329ac2415931eaba8e70) libutp_3_4: unstable-2023-08-04 -> unstable-2023-10-16
* [`d9b8f117`](https://github.com/NixOS/nixpkgs/commit/d9b8f117c6be4d6f660f5ba6b690845f2e74af8b) python311Packages.mpris-server: init at 0.4.2
* [`14ff056b`](https://github.com/NixOS/nixpkgs/commit/14ff056b465b4591bd636d940cbca521acd710b3) monophony: init at 2.3.1
* [`af99f7c7`](https://github.com/NixOS/nixpkgs/commit/af99f7c79682cde7bc9f2cf6704949b0700a32e5) chickenPackages.chickenEggs.sdl-base: fix build on linux
* [`8008b576`](https://github.com/NixOS/nixpkgs/commit/8008b57675c9ffc72b6f53100362a13e7a0b49db) chickenPackages.chickenEggs.taglib: fix build
* [`f1f005dc`](https://github.com/NixOS/nixpkgs/commit/f1f005dca2add65704555fb714ae9c614f945172) add user "wamirez" to maintainer-list.nix
* [`4766ca06`](https://github.com/NixOS/nixpkgs/commit/4766ca0615cbfccef7e9ac36ab107322a87a5a97) restic: 0.16.1 -> 0.16.2
* [`21cb9b71`](https://github.com/NixOS/nixpkgs/commit/21cb9b713093e2ed4973997e79a229bc0d30d64f) linux-firmware: 20230919 -> 20231030
* [`f473e10b`](https://github.com/NixOS/nixpkgs/commit/f473e10b0d9d38a72abd376da9a7201d8b6c0eb3) oxlint: 0.0.14 -> 0.0.15
* [`e4bb5ab6`](https://github.com/NixOS/nixpkgs/commit/e4bb5ab6dce5d797696170d102ad5f510fe13236) python3Packages.junit2html: init at 30.1.3
* [`cf355290`](https://github.com/NixOS/nixpkgs/commit/cf3552902af2491d9612d4b8213a3065f287420b) git-mit: 5.12.167 -> 5.12.169
* [`3ed8e8db`](https://github.com/NixOS/nixpkgs/commit/3ed8e8db18e7af9a0d5768a39ef39404c6f18366) changie: 1.15.0 -> 1.15.1
* [`26d50f98`](https://github.com/NixOS/nixpkgs/commit/26d50f986008ad8df57f0e0fcb408febac094446) freetube: fix build, use latest electron
* [`0952c197`](https://github.com/NixOS/nixpkgs/commit/0952c19751dd472d157a7d6ededff5c7885e3a9b) smplayer: 23.6.0 -> 23.6.0.10170
* [`1638e2ad`](https://github.com/NixOS/nixpkgs/commit/1638e2adee953690a2347a875b53e6657a371265) jasper: migrate to by-name
* [`49c916fc`](https://github.com/NixOS/nixpkgs/commit/49c916fc34fee1383d39bd09ee51a0c428e3f7fc) jasper: 2.0.32 -> 3.0.0
* [`4cfe0bce`](https://github.com/NixOS/nixpkgs/commit/4cfe0bcee39b2692318102a49b60fe5c20229b18) jasper: 3.0.0 -> 4.0.0
* [`c90192b9`](https://github.com/NixOS/nixpkgs/commit/c90192b9ee8d49a68d18f1775d85f55e6a8fcedd) pyspread: migrate to by-name
* [`247c509f`](https://github.com/NixOS/nixpkgs/commit/247c509f1bb64f706333c96b5c4e5f4c0b4f5aab) pyspread: 2.0.2 -> 2.2.2
* [`d183f303`](https://github.com/NixOS/nixpkgs/commit/d183f303480cb3f08f2bb455a32de1ede403ec17) fclones: 0.33.1 -> 0.34.0
* [`3b8a1a7a`](https://github.com/NixOS/nixpkgs/commit/3b8a1a7a70b528c6dd31b160fd7ad3b32d983dbf) hd-idle: 1.20 -> 1.21
* [`8ad03e1d`](https://github.com/NixOS/nixpkgs/commit/8ad03e1df986841e91d9cb08f9817b86bda79d12) python311Packages.home-assistant-chip-core: update aarch64-linux hash
* [`d074b63c`](https://github.com/NixOS/nixpkgs/commit/d074b63cb017fd6175d535af2569db6153808e6a) numbat: init at 1.6.3
* [`398758b8`](https://github.com/NixOS/nixpkgs/commit/398758b86b506192aafe93b6d44d9af6c853d6ea) meritous: migrate to by-name
* [`469419ac`](https://github.com/NixOS/nixpkgs/commit/469419accf3b68e2d51c463fb4085c61476f4ecd) meritous: 1.4 -> 1.5
* [`8afd7447`](https://github.com/NixOS/nixpkgs/commit/8afd7447ee04a418b0812bc3c81b7708bca40c04) meritous: add meta.{changelog,mainProgram}
* [`baae0f8e`](https://github.com/NixOS/nixpkgs/commit/baae0f8e0f2bdccff302590985496498d7d9982e) tailscale: 1.50.1 -> 1.52.0
* [`d20cb844`](https://github.com/NixOS/nixpkgs/commit/d20cb844a7bb8701ce8700bf950781e19ebd382c) limesctl: 3.3.0 -> 3.3.1
* [`d3db35f6`](https://github.com/NixOS/nixpkgs/commit/d3db35f684db741b162dc7fc4ce12d97296cef01) stage-2: don't write to /dev/kmsg if missing
* [`d90e0d6b`](https://github.com/NixOS/nixpkgs/commit/d90e0d6be3fd2882eaca05a678e494cc535da97a) scraper: 0.18.0 -> 0.18.1
* [`33094aea`](https://github.com/NixOS/nixpkgs/commit/33094aea3e007f79558fdd3cd157d9d216205e07) erg: 0.6.23 -> 0.6.24
* [`390a2965`](https://github.com/NixOS/nixpkgs/commit/390a2965da31baf366685728dd60eca4b6944ee5) mysql80: 8.0.34 -> 8.0.35
* [`a9a8e764`](https://github.com/NixOS/nixpkgs/commit/a9a8e764c4584e492809484e70550c2ad2b0cab9) rsonpath: 0.8.3 -> 0.8.4
* [`17d5421f`](https://github.com/NixOS/nixpkgs/commit/17d5421f04702ac2d96d03f8fa7cb759d2b4d53d) vimPlugins.vim-clap: fix build on darwin
* [`4eeff46b`](https://github.com/NixOS/nixpkgs/commit/4eeff46bbb70fb37c85f2d9d22a66b63aa918a97) freetube: add test
* [`3530242d`](https://github.com/NixOS/nixpkgs/commit/3530242d18b3d4a3e557287b203b4bb07c312f49) boxxy: 0.8.1 -> 0.8.3
* [`936f24ed`](https://github.com/NixOS/nixpkgs/commit/936f24ed009fa043db972c45d4695eaf65224a56) Revert "lean-language-server: init at 3.4.0"
* [`50d42883`](https://github.com/NixOS/nixpkgs/commit/50d4288307d27bad3193dc28f82ca91f8f4b20c3) yggdrasil: 0.4.7 -> 0.5.1
* [`2dfea1c1`](https://github.com/NixOS/nixpkgs/commit/2dfea1c1b7813ba547a4818f0dc08e7f6005b064) libre: 2.9.0 -> 3.6.0
* [`3b6f331a`](https://github.com/NixOS/nixpkgs/commit/3b6f331a2faa64752242d6d2178b6a60c81df429) baresip: 2.9.0 -> 3.6.0
* [`d3e9f4ec`](https://github.com/NixOS/nixpkgs/commit/d3e9f4ecd61597423f5ad3840f4e5dcf1db30c55) uiua: 0.0.23 -> 0.0.25
* [`95f583d6`](https://github.com/NixOS/nixpkgs/commit/95f583d6d728280246985bcc552dae403d62a677) vscode-extensions.uiua-lang.uiua-vscode: 0.0.21 -> 0.0.22
* [`6252f792`](https://github.com/NixOS/nixpkgs/commit/6252f792d250dd957291ddddebd6c774a04647de) uiua368: update description
* [`0067b13b`](https://github.com/NixOS/nixpkgs/commit/0067b13bfa95a610e0ecf1b9b3e976dfd21a6d37) hyprnome: 0.1.0 -> 0.2.0
* [`9156ee26`](https://github.com/NixOS/nixpkgs/commit/9156ee26cf2f3ba429c0428706fd3714a8a74c53) localstack: 2.3.0 -> 2.3.2
* [`ea3ca0b1`](https://github.com/NixOS/nixpkgs/commit/ea3ca0b1e3a9e9a4be4bbb313fc0343c50d3c90c) nixos/image: fix documentation build
* [`6fa4f267`](https://github.com/NixOS/nixpkgs/commit/6fa4f267d369ef18db3f563abb45b7e3bb21ff2b) wyoming-piper: 1.3.2 -> 1.4.0
* [`e3647a17`](https://github.com/NixOS/nixpkgs/commit/e3647a1769fff52e1bbde66bf3eeb837a246742a) nixos/wyoming/openwakeword: fix typo in attribute name
* [`dd69fced`](https://github.com/NixOS/nixpkgs/commit/dd69fcedb9e199c2b24e4ac423290cf34276af58) python311Packages.pydbus: fix typo and use pep517 builder
* [`ddda371f`](https://github.com/NixOS/nixpkgs/commit/ddda371f595946a639bf53d7e827b43bb7b144e4) python311Packages.home-assistant-chip-core: 2023.10.1 -> 2023.10.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
