### PR TITLE
niv devenv: update 86f476f7 -> af34c270

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "86f476f7edb86159fd20764489ab4e4df6edb4b6",
-        "sha256": "0kx8bhsf72vkmla41zkhk8f7nbf2pggx2d45cqd4g18isk49pr4z",
+        "rev": "af34c270e708675c02831c5a4d6d1d3d6efb0854",
+        "sha256": "16agyhnfbsczq3by4r6kcpk5da6b00vig59wqg8sv7v5flkys55c",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/86f476f7edb86159fd20764489ab4e4df6edb4b6.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/af34c270e708675c02831c5a4d6d1d3d6efb0854.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@86f476f7...af34c270](https://github.com/cachix/devenv/compare/86f476f7edb86159fd20764489ab4e4df6edb4b6...af34c270e708675c02831c5a4d6d1d3d6efb0854)

* [`e8fd5d43`](https://github.com/cachix/devenv/commit/e8fd5d4389104e73a79a13708d4f9e36d984e10b) fix: adds support for multiple IP configurations for one hostname in `hostctl.nix`
* [`d5fd391b`](https://github.com/cachix/devenv/commit/d5fd391bbe4d9aea78b6971fec04436c9acf8544) chore: adds examples on `examples/mkcert/devenv.nix`
* [`853bb50b`](https://github.com/cachix/devenv/commit/853bb50b8f7ba0830ec9265ae604fb87de43bddf) fix: fixed formatting issues
* [`2c0eb6ed`](https://github.com/cachix/devenv/commit/2c0eb6ed8641f16eb577a1168e0df95dbe0679c7) Auto generate docs/reference/options.md
* [`0b29893a`](https://github.com/cachix/devenv/commit/0b29893ac9010831d82e9f0cb5ea1a0dcae3f86b) doc: using-with-flakes should also expose config
* [`af34c270`](https://github.com/cachix/devenv/commit/af34c270e708675c02831c5a4d6d1d3d6efb0854) Auto generate docs/reference/options.md
