### PR TITLE
niv home-manager: update 8e5416b4 -> c067d57f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8e5416b478e465985eec274bc3a018024435c106",
-        "sha256": "1d3hs2i3k9ifl0as15irb94kq26s9vnl01srrpbz2c2193fjw0ld",
+        "rev": "c067d57fc4552835987fd7611c3a6741ee32ebd5",
+        "sha256": "0k8z4z8ybzybjw2j0l2gxj83k66sd3k571ni4qr0vyk88ahgrqf1",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/8e5416b478e465985eec274bc3a018024435c106.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c067d57fc4552835987fd7611c3a6741ee32ebd5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@8e5416b4...c067d57f](https://github.com/nix-community/home-manager/compare/8e5416b478e465985eec274bc3a018024435c106...c067d57fc4552835987fd7611c3a6741ee32ebd5)

* [`9bc7d84b`](https://github.com/nix-community/home-manager/commit/9bc7d84b8213255ecd5eb6299afdb77c36ece71d) zsh: made ZDOTDIR export to the shell ([nix-community/home-manager⁠#4619](https://togithub.com/nix-community/home-manager/issues/4619))
* [`fc2a8842`](https://github.com/nix-community/home-manager/commit/fc2a8842ea5106640eb89ec522dde9120df82d8a) k9s: add hotkey option ([nix-community/home-manager⁠#4617](https://togithub.com/nix-community/home-manager/issues/4617))
* [`a4218048`](https://github.com/nix-community/home-manager/commit/a421804890cd0581af03534886abae32a213c085) borgmatic: preparing upcoming borgmatic change
* [`48b0a302`](https://github.com/nix-community/home-manager/commit/48b0a30202516e25d9885525fbb200a045f23f26) granted: add module
* [`831b4fa3`](https://github.com/nix-community/home-manager/commit/831b4fa31749208e576050c563e9773aafd04941) clipmenu: set Environment to a list
* [`8765d4e3`](https://github.com/nix-community/home-manager/commit/8765d4e38aa0be53cdeee26f7386173e6c65618d) thefuck: add fish integration ([nix-community/home-manager⁠#4535](https://togithub.com/nix-community/home-manager/issues/4535))
* [`c067d57f`](https://github.com/nix-community/home-manager/commit/c067d57fc4552835987fd7611c3a6741ee32ebd5) swayr: add module ([nix-community/home-manager⁠#4322](https://togithub.com/nix-community/home-manager/issues/4322))
