### PR TITLE
niv powerlevel10k: update 43061673 -> 174ce9bf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -137,10 +137,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "430616734aa06ff3def48cb511fb43db7466a64e",
-        "sha256": "0sgv25vgn78gpwdwmqi2kjd3qdbiyc6jmawiw7zxw3a1wvh0xfgf",
+        "rev": "174ce9bf0166c657404a21f4dc9608da935f7325",
+        "sha256": "1vgy8g4b9nkhijqlr9cffigxa5rwdp7fldxa2s5p36yr5xcymyyx",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/430616734aa06ff3def48cb511fb43db7466a64e.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/174ce9bf0166c657404a21f4dc9608da935f7325.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@43061673...174ce9bf](https://github.com/romkatv/powerlevel10k/compare/430616734aa06ff3def48cb511fb43db7466a64e...174ce9bf0166c657404a21f4dc9608da935f7325)

* [`18f0bec1`](https://github.com/romkatv/powerlevel10k/commit/18f0bec1bbdcd595a6cc8155dc09c44acee06d32) use newer icons for azure and azure devops ([romkatv/powerlevel10k⁠#2472](https://togithub.com/romkatv/powerlevel10k/issues/2472))
* [`174ce9bf`](https://github.com/romkatv/powerlevel10k/commit/174ce9bf0166c657404a21f4dc9608da935f7325) recognize azure devops git remote HTTPS URLs ([romkatv/powerlevel10k⁠#2472](https://togithub.com/romkatv/powerlevel10k/issues/2472))
