### PR TITLE
niv nixpkgs: update eb5caed9 -> 8423b2df

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb5caed9e18e2a91ec891597766eddffce5670bb",
-        "sha256": "0z87ip2qv1lh88smdxvkiabdmm4kdvd3afb5fbxv2kj8fbbmwx5j",
+        "rev": "8423b2dff7b10463eb97f9242bd62a1ff8d2ee3e",
+        "sha256": "1qx9zq73hbrihlf2m4daw2ad4j8rjn3jbpn2y9fzmxnr40lic2hl",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/eb5caed9e18e2a91ec891597766eddffce5670bb.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8423b2dff7b10463eb97f9242bd62a1ff8d2ee3e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@eb5caed9...8423b2df](https://github.com/nixos/nixpkgs/compare/eb5caed9e18e2a91ec891597766eddffce5670bb...8423b2dff7b10463eb97f9242bd62a1ff8d2ee3e)

* [`a7242250`](https://github.com/NixOS/nixpkgs/commit/a724225019ff3eea82694bff8b5867e716a45880) python310Packages.dynd: Fix broken build
* [`421d6da3`](https://github.com/NixOS/nixpkgs/commit/421d6da3e1781e1d65eaaa211caca2a46d61da98) python39Packages.jupyter-client: Fix build for Python 3.9
* [`b38f2821`](https://github.com/NixOS/nixpkgs/commit/b38f2821720add570f5bcdeba0ffa469e16963eb) ejabberd: Add awk to ejabberdctl path
* [`9b3ff483`](https://github.com/NixOS/nixpkgs/commit/9b3ff4831bef9c3c1d96d0faa1724c7614371041) {birdtray,isgx,mycrypto,osu-lazer,stretchly,tree-sitter}: remove oxalica as maintainer
* [`4c03c879`](https://github.com/NixOS/nixpkgs/commit/4c03c879ca24cd3df40cc5111ac45de758de32cf) lomiri.lomiri-schemas: init at 0.1.3
* [`a53a73c7`](https://github.com/NixOS/nixpkgs/commit/a53a73c74f0c835e0c19ab4582d3f96c1b376789) nixos/smartd: Fix mail recipient field
* [`c634dae2`](https://github.com/NixOS/nixpkgs/commit/c634dae2798046a6d27734e708c83909b359eb59) pandoc: use library's version
* [`98673433`](https://github.com/NixOS/nixpkgs/commit/9867343397ddb05de9d7cb75f312f83cfbc29152) maintainers: add javimerino
* [`9288bd04`](https://github.com/NixOS/nixpkgs/commit/9288bd04336367eefcdb3dcbeaf75d38374a9f96) guilt: init at 0.37-rc1
* [`70aa345b`](https://github.com/NixOS/nixpkgs/commit/70aa345bec1135ea9524cd893aea1f6e3dd82387) doc/python: use python3Packages instead of python3.pkgs
* [`c0da39e7`](https://github.com/NixOS/nixpkgs/commit/c0da39e7bb6d4f326c5ed07e76883c57dfe3fad4) maintainers: add rayslash
* [`ebec07fd`](https://github.com/NixOS/nixpkgs/commit/ebec07fd244410736b00990fa3609f6a9c3bfdef) nixos/tests/openssh: wait for sshd(.socket) units, add timeout=30
* [`abedeabd`](https://github.com/NixOS/nixpkgs/commit/abedeabde442d96767d080e8dbd91b690b189834) burpsuite: 2023.7.2 -> 2023.9.4
* [`311d0941`](https://github.com/NixOS/nixpkgs/commit/311d09417f35d517925c09f646bce0cf0447540c) burpsuite: Add support for professional edition
* [`b9b6de15`](https://github.com/NixOS/nixpkgs/commit/b9b6de1573cea25a7302fd82f98f8d6e1b4313e2) burpsuite: 2023.9.4 -> 2023.10.1.1
* [`152086d8`](https://github.com/NixOS/nixpkgs/commit/152086d88c6d2e78f800ce153d78b61c7f3ba5ea) burpsuite: name cleanup now that buildFHSEnv works with pname and version
* [`3aec2103`](https://github.com/NixOS/nixpkgs/commit/3aec2103ad3c0e3cc8735ebc9342428c597ac982) openafs: Patch for Linux kernels 6.5 and 6.6
* [`082a03e1`](https://github.com/NixOS/nixpkgs/commit/082a03e152664089552d3d83b033bd1d5a451d2f) haskell.compiler.ghc*Binary: fix globbing
* [`d0914cd5`](https://github.com/NixOS/nixpkgs/commit/d0914cd5305eec9788db51e560186965800558c9) kemai: support wayland --no-g
* [`01085991`](https://github.com/NixOS/nixpkgs/commit/010859918f45f2b2820a78370ae32571838ac06d) kemai: set mainProgram
* [`9d66d3c7`](https://github.com/NixOS/nixpkgs/commit/9d66d3c7f87e10c83d74b7f3d6b541360e04cb22) rshim-user-space: add bfb-install
* [`3b97883f`](https://github.com/NixOS/nixpkgs/commit/3b97883fd16fd6f8eadd8eafa3c1976a25192bac) openraPackages.engines.release: 20230225 -> 20231010
* [`90c31a3d`](https://github.com/NixOS/nixpkgs/commit/90c31a3d12ee5292ad20d3e382d0f2e310b5c756) wavebox: 10.114.26-2 -> 10.117.18-2
* [`35c9d66a`](https://github.com/NixOS/nixpkgs/commit/35c9d66a0341f5d984cf592ed4ec5a30a45e8982) wavebox: add update script
* [`a393a302`](https://github.com/NixOS/nixpkgs/commit/a393a30239bc0663fe7f64959d8394e429ad7742) wavebox: 10.117.18-2 -> 10.117.21-2
* [`5fc826a9`](https://github.com/NixOS/nixpkgs/commit/5fc826a9cc043e7714e1f82e4abb28334517e866) wavebox: use proper API endpoint in update
* [`93d7c04d`](https://github.com/NixOS/nixpkgs/commit/93d7c04dac8af7cc0b2b28cc0de7a00cb11bbafb) wavebox: 10.117.21-2 -> 10.118.5-2
* [`c0efb925`](https://github.com/NixOS/nixpkgs/commit/c0efb92592c15f3402b06e0748b497f4648536d9) aldente: 1.22.2 -> 1.22.3
* [`689f4496`](https://github.com/NixOS/nixpkgs/commit/689f4496b8800c3bd1625566b743e8a609f45635) homebank: 5.6.6 -> 5.7.1
* [`5a137cf6`](https://github.com/NixOS/nixpkgs/commit/5a137cf6070a132be840562b68cdda8734ad2841) nixos/hardware: use mkEnableOption
* [`d73c4902`](https://github.com/NixOS/nixpkgs/commit/d73c49026a37079a61307386864e71d84205a983) haskellPackages: stackage LTS 21.14 -> LTS 21.16
* [`e5997282`](https://github.com/NixOS/nixpkgs/commit/e5997282a390870f80174fbb18ea39aeafb3984c) all-cabal-hashes: 2023-10-04T18:27:12Z -> 2023-10-21T19:49:07Z
* [`13fea7f2`](https://github.com/NixOS/nixpkgs/commit/13fea7f2add742b9b969fc7fe32f01f28684b3b5) haskellPackages: regenerate package set based on current config
* [`61d5040e`](https://github.com/NixOS/nixpkgs/commit/61d5040ef113029678055d05e3d6b90cd97169ef) nixos-rebuild: Drop incorrectly implemented short args for build/target host
* [`a5e30e71`](https://github.com/NixOS/nixpkgs/commit/a5e30e71b683e649e8e2f145c500bd2abf77b388) nixos-rebuild: Locally own the nixos-rebuild completion
* [`5e760735`](https://github.com/NixOS/nixpkgs/commit/5e7607353937233b0d2c18a14b5a1cea5a7d69a0) nix-bash-completions: Drop nixos-rebuild completion
* [`b779210e`](https://github.com/NixOS/nixpkgs/commit/b779210e3a07b5edaf0f8bc46f86477ea1c91da0) haskellPackages.Cabal-syntax: Update overrides
* [`a1e8ef46`](https://github.com/NixOS/nixpkgs/commit/a1e8ef46c6e9657f48fbe5f0e0f738fb28fae65a) haskellPackages: Eval fixes
* [`7bec1b95`](https://github.com/NixOS/nixpkgs/commit/7bec1b95d185405824272cb3ecd2d73501a8d2b2) haskellPackages.cabal-plan-bounds: Unbreak on 9.6, add nomeata as maintainer
* [`4a47fc93`](https://github.com/NixOS/nixpkgs/commit/4a47fc9395f2dc6577a2f637debc1518236592c6) haskellPackages.vector: remove redundant patch
* [`5ea11408`](https://github.com/NixOS/nixpkgs/commit/5ea114083c0362f8d58f967fccb7e4916f02cf06) haskell.packages.ghc96.tls: fix missing LLVM tools on aarch64
* [`30e4f23f`](https://github.com/NixOS/nixpkgs/commit/30e4f23f8daec8cb2e71a31b55c883653756a5be) kismet: 2022-08 -> 2023-07
* [`caf1c4ef`](https://github.com/NixOS/nixpkgs/commit/caf1c4efda9aac9b6b8437d4c8c89c927dcaebee) haskellPackages: more eval fixes
* [`484135d0`](https://github.com/NixOS/nixpkgs/commit/484135d06c6b4743b0982fee2d2133283340daa5) cairo-lang: 2.2.0 -> 2.3.0
* [`03b2c6ce`](https://github.com/NixOS/nixpkgs/commit/03b2c6cec8709ca45fdbf248b7890a4a4c7380c3) lunar-client: migrate to by-name
* [`53946680`](https://github.com/NixOS/nixpkgs/commit/539466804b46ba5b2c861f39c2a04f19ac435c2a) lunar-client: add updateScript
* [`f136588b`](https://github.com/NixOS/nixpkgs/commit/f136588bfb03ce325e406c49c71ae1fe1f81302a) picosnitch: 0.14.0 -> 1.0.1
* [`af63e7a1`](https://github.com/NixOS/nixpkgs/commit/af63e7a15daf283b4ce634006b3767f9c0eb0c58) rPackages: CRAN and BioC update
* [`7dcf64d6`](https://github.com/NixOS/nixpkgs/commit/7dcf64d662145bc72816ff0e72ecd7086ffd0daf) material-design-icons: 7.2.96 -> 7.3.67
* [`9f7335d4`](https://github.com/NixOS/nixpkgs/commit/9f7335d44912c5af97e7dc01caba7c6340442f82) nixos/hostapd: document that legacy example should have optional MFP
* [`9e7c877d`](https://github.com/NixOS/nixpkgs/commit/9e7c877de75835018551bbd3029ac4d83f3e31cc) nixos/hostapd: remove managementFrameProtection
* [`97ba4fac`](https://github.com/NixOS/nixpkgs/commit/97ba4facba98267a6dd53bc0cfa4b1fc563ae2e2) haskell-language-server: fix eval
* [`6c2b227d`](https://github.com/NixOS/nixpkgs/commit/6c2b227d34a6d926d8519b9f56565e2f27622956) agdaPackages.*: support literate Typst files
* [`e8bf86a5`](https://github.com/NixOS/nixpkgs/commit/e8bf86a523b9f656345f4fb882d39365782a9f43) agdaPackages.standard-library: 1.7.2 -> 1.7.3
* [`ae86b088`](https://github.com/NixOS/nixpkgs/commit/ae86b088694959e3092f6009f80ce80972f74f7d) agdaPackages.agda-categories: 0.1.7.1a -> 0.1.7.2
* [`170a9778`](https://github.com/NixOS/nixpkgs/commit/170a9778b4267285115903b6b0320f120b7df4c7) agdaPackages._1lab: unstable-2023-03-07 -> unstable-2023-10-11
* [`8b59b95f`](https://github.com/NixOS/nixpkgs/commit/8b59b95f25c3d6a10908cf129ffc1020007b0de3) agdaPackages.{agda-prelude,functional-linear-algebra}: mark as broken
* [`57eea055`](https://github.com/NixOS/nixpkgs/commit/57eea055839f7caa7b9b55c6d4112ba0bfa71ae9) agdaPackages.cubical: 0.5 -> 0.6
* [`5e0fcae2`](https://github.com/NixOS/nixpkgs/commit/5e0fcae262d8465a820c45b6565ecef3173b1013) aravis: 0.8.28 -> 0.8.30
* [`4b653bda`](https://github.com/NixOS/nixpkgs/commit/4b653bdacf5db1ec183969921f685abc00e2d46e) futhark: mark not broken, add athas as maintainer
* [`1df76857`](https://github.com/NixOS/nixpkgs/commit/1df768573bc2459eb89f5ffdf7edc5bbf8cb042c) agdaPackages.agda-prelude: unstable-2022-01-14 -> unstable-2023-10-04
* [`9e2743f8`](https://github.com/NixOS/nixpkgs/commit/9e2743f883d3bb8810f08b7de10c7a0e91b94032) mir: 2.14.1 -> 2.15.0
* [`89aefe0b`](https://github.com/NixOS/nixpkgs/commit/89aefe0bfacd1d54469fcf650b87a095cd24ff78) mir: Fetch patch to fix build
* [`b0a0f985`](https://github.com/NixOS/nixpkgs/commit/b0a0f9856dfdc2348520e4b152ec77e5e7a44858) rPackages.httpuv: fix build
* [`d8098cb1`](https://github.com/NixOS/nixpkgs/commit/d8098cb1b65c162cf954567343d4c0440290852b) tokyo-night-gtk: unstable-2023-01-17 -> unstable-2023-05-30
* [`aae20a0f`](https://github.com/NixOS/nixpkgs/commit/aae20a0f4329a2270a0da18e956ab4eadb7763ad) lib2geom: 1.2.2 → 1.3
* [`e7eb9f5e`](https://github.com/NixOS/nixpkgs/commit/e7eb9f5e0ffbfaab6a998093a446404de39f5497) python3.pkgs.inkex: inherit source from Inkscape
* [`89138016`](https://github.com/NixOS/nixpkgs/commit/8913801669a9411a4427b4c1cb9126b9cedb9b36) inkscape: inherit filelock dependency from cachecontrol
* [`99ab0ebe`](https://github.com/NixOS/nixpkgs/commit/99ab0ebeabff4f694eb7179cce7cd1f9da772060) inkscape: 1.2.2 → 1.3
* [`6a024aab`](https://github.com/NixOS/nixpkgs/commit/6a024aab010208995419a9ca69513a7a191bd0ca) reversal-icon-theme: init at unstable-2023-05-13
* [`3dd6060a`](https://github.com/NixOS/nixpkgs/commit/3dd6060ab5e73af6ade9715dc89a541485a6a5fa) raylib: support macOS
* [`0dd2112a`](https://github.com/NixOS/nixpkgs/commit/0dd2112aa6faad8c5fec6c6d7dce767d5aa7a4fe) qemu-utils: Rework as an emulatorless qemu build
* [`310e449b`](https://github.com/NixOS/nixpkgs/commit/310e449b04202e5cf80cdddfb680d6743fd012fa) qemu: Build qemu-utils on ofborg
* [`ecbdec62`](https://github.com/NixOS/nixpkgs/commit/ecbdec62a3031deb4d05ce6b33a944de443cae13) spidermonkey_91: add patch to allow building with python311
* [`f32c2fd3`](https://github.com/NixOS/nixpkgs/commit/f32c2fd32c180b12b004543d5c7956cec8071a3e) rockyou: iniat at unstable-2023-05-12
* [`614e7213`](https://github.com/NixOS/nixpkgs/commit/614e7213777c2844d46dcb246231430da4e01013) seclists: init at 2023.02
* [`9b0f5a34`](https://github.com/NixOS/nixpkgs/commit/9b0f5a34dd072dbf5ecbfca4d5e865826cf81985) nmap: add wordlist
* [`d34574a6`](https://github.com/NixOS/nixpkgs/commit/d34574a6fc2940bef831d62401ca5c90da1f646a) wfuzz: add wordlist output
* [`5897ae60`](https://github.com/NixOS/nixpkgs/commit/5897ae609173dde287cf4eb91a4e0dee93ed0c92) wordlists: init at 2023-10-10
* [`42ba9eb2`](https://github.com/NixOS/nixpkgs/commit/42ba9eb2140e793bcc8f4faeaedc2e0b6405e852) cracklib: change wordlists prameter to lists for compatiblity with wordlists package
* [`fe7d4944`](https://github.com/NixOS/nixpkgs/commit/fe7d494468a8df2432d1c1ff4f1824dfc9af71cf) haskellPackages.mpi-hs*: respect pkgs.mpi and make tests pass
* [`704aa729`](https://github.com/NixOS/nixpkgs/commit/704aa729f16da77894b98d8fa780732b50d52c66) haskell.packages.ghc96: Fix ghc-lib(-parser) eval
* [`be603676`](https://github.com/NixOS/nixpkgs/commit/be603676d827216d01c2263355332730db6f712d) haskell.packages.ghc96: Fix base-compat-batteries eval
* [`7a0d89ed`](https://github.com/NixOS/nixpkgs/commit/7a0d89ed56f58c3abed892a2f763c4dfb44cf1e4) haskell.packages.ghc96.haskell-language-server: Fix eval
* [`a3267d99`](https://github.com/NixOS/nixpkgs/commit/a3267d9949db6aa07555bf3d63ca1c385ad7c169) mongodb-5_0: 5.0.21 -> 5.0.22
* [`5c52701a`](https://github.com/NixOS/nixpkgs/commit/5c52701a0a934881325b468832b953954b5892ee) mongodb_6-0: 6.0.10 -> 6.0.11
* [`44dc3d47`](https://github.com/NixOS/nixpkgs/commit/44dc3d47d454909f09248b8a0dd0336498fe74f0) flycast: 2.1 -> 2.2
* [`f9ee2b7b`](https://github.com/NixOS/nixpkgs/commit/f9ee2b7bf836552b6b8b558f7c428197966b26c4) mergerfs: 2.37.1 -> 2.38.0
* [`7d517bfb`](https://github.com/NixOS/nixpkgs/commit/7d517bfb76d71fa662228f99fae536f86d602b38) netdata: add systemd-journal plugin
* [`40ba1f1f`](https://github.com/NixOS/nixpkgs/commit/40ba1f1f7289936cca0773b9424886f6d9079d77) mariadb-connector-java: init at 3.2.0
* [`27dfebc7`](https://github.com/NixOS/nixpkgs/commit/27dfebc7f80c2c4fc798a5771b629f679bff3810) pandoc: remove GHC & haskell deps from closure, 5.2G => 250M
* [`e2a6ef55`](https://github.com/NixOS/nixpkgs/commit/e2a6ef5564833c9dd1fcde438bb69fba87581d1c) todoist-electron: 8.6.0 -> 8.9.3
* [`d9cc8495`](https://github.com/NixOS/nixpkgs/commit/d9cc84954de4ea676e32cbc6ae2a7c129616ff89) git-brunch: mark unbroken
* [`2238cc1e`](https://github.com/NixOS/nixpkgs/commit/2238cc1ed9c0a61507167444799f516dda46af3d) haskellPackages.dhall-lsp-server: Apply patch relaxing lens bound
* [`918d088a`](https://github.com/NixOS/nixpkgs/commit/918d088a656aa1b392f43e0a907cb6612b350984) floorp: 11.5.0 -> 11.5.1
* [`4f2eaf6a`](https://github.com/NixOS/nixpkgs/commit/4f2eaf6a5ffb1e3c712ab6f8de80e2e5eef54c62) bazecor: init at 1.3.6
* [`e143a933`](https://github.com/NixOS/nixpkgs/commit/e143a933f67eeaadc6aeaf56740bcf040f89b31f) check-meta.nix: Fix flake note
* [`2348f572`](https://github.com/NixOS/nixpkgs/commit/2348f5726edbd3e51c8f8dfe9787eaaf9e7ea136) gotify-desktop: 1.3.1 -> 1.3.2
* [`fb83fbd4`](https://github.com/NixOS/nixpkgs/commit/fb83fbd42eaa6c7400aa08e377d494f23c4cb717) libdatachannel: fix include path in cmake files
* [`235d8a1c`](https://github.com/NixOS/nixpkgs/commit/235d8a1cab2cc828eb5e1eb5c9c0b3849e6d2c08) libdatachannel: 0.19.2 -> 0.19.3
* [`d10118ab`](https://github.com/NixOS/nixpkgs/commit/d10118ab7d1cd53b77a6ed043e13e915a424cfa9) mcuboot-imgtool: init at 1.10.0
* [`206d2042`](https://github.com/NixOS/nixpkgs/commit/206d20426cb2959aab8cc3cfc8e62aa68bc7b52f) lib.strings: add `replicate`
* [`e5440111`](https://github.com/NixOS/nixpkgs/commit/e5440111301c432989471f96df0ed4416cf7185a) trurl: 0.8 -> 0.9
* [`a249a761`](https://github.com/NixOS/nixpkgs/commit/a249a761734074e549348501c860a41d63d24c46) nuget: allow aarch64-linux and darwin builds
* [`e75c485f`](https://github.com/NixOS/nixpkgs/commit/e75c485fd374ae920daad7b8de5233a8f9c2239a) doc: fix dockerTools nix-prefetch-docker example
* [`351fcfc8`](https://github.com/NixOS/nixpkgs/commit/351fcfc8f58db9097a807a8b6c9c29f0e514d703) python310Packages.stytra: opencv3 -> opencv4
* [`55015a2b`](https://github.com/NixOS/nixpkgs/commit/55015a2b73fafae9eb2110322c52fab2b05b48f2) python310Packages.bpycv: opencv3 -> opencv4
* [`2e252eac`](https://github.com/NixOS/nixpkgs/commit/2e252eacd1b92319dab835f5bf15a63bc2538b8e) python310Packages.imagecorruptions: opencv3 -> opencv4
* [`85a54135`](https://github.com/NixOS/nixpkgs/commit/85a54135de9bcc48019a777971049d3f4b2c63b0) python310Packages.imutils: opencv3 -> opencv4
* [`79273222`](https://github.com/NixOS/nixpkgs/commit/79273222521bcba8621a5a023589cfb34c95c805) python310Packages.camelot: opencv3 -> opencv4
* [`f3f65986`](https://github.com/NixOS/nixpkgs/commit/f3f6598682539ab70db602067ab06f412d94f27d) python310Packages.imantics: opencv3 -> opencv4; enable tests
* [`8a726d9d`](https://github.com/NixOS/nixpkgs/commit/8a726d9df69641b12784e9cc8ba37f0d4934b478) python310Packages.easyocr: opencv3 -> opencv4
* [`74e7f103`](https://github.com/NixOS/nixpkgs/commit/74e7f1035a2505efa74198bfe6197f4f65517f27) python310Packages.moviepy: remove optional opencv3 dependency
* [`409f9573`](https://github.com/NixOS/nixpkgs/commit/409f95731e3653c08118c5985b7a29b0da886a46) shellcheck-minimal: init
* [`054f6706`](https://github.com/NixOS/nixpkgs/commit/054f67065e41950264f972bad2ab90645386f224) haskellPackages.changelog-d: init
* [`01d1c835`](https://github.com/NixOS/nixpkgs/commit/01d1c835ff18101e8a602e3e7028716c1a445cbd) shogun: opencv3 -> opencv4
* [`8c856417`](https://github.com/NixOS/nixpkgs/commit/8c856417c049c5753eb8ec15b11fdfb749e6e0f5) python310Packages.opencv3: remove
* [`662c0011`](https://github.com/NixOS/nixpkgs/commit/662c0011576e46b2b35c398b655e970afc3f4195) haskellPackages.changelog-d: Add basic test
* [`04352278`](https://github.com/NixOS/nixpkgs/commit/043522789b997c51b9eb2de84add68896f917860) nixos/services/netdata: add systemd-journald plugin as a privileged wrapper
* [`f7fa553d`](https://github.com/NixOS/nixpkgs/commit/f7fa553d6ac6722647f17eb0167a76a96318987b) kismet: disable coconut support
* [`15f640cc`](https://github.com/NixOS/nixpkgs/commit/15f640cc9eff7bba35b92d519e1d00b758cfa211) simde: init at 0.7.6
* [`a9d6c649`](https://github.com/NixOS/nixpkgs/commit/a9d6c649ddd6ef260894f8ed4a90c0c26e8a2a24) haskellPackages: regenerate package set based on current config
* [`234797a1`](https://github.com/NixOS/nixpkgs/commit/234797a1421c94aea89bbfe95418b1827c2e49b8) use meson to build and install
* [`5a537c30`](https://github.com/NixOS/nixpkgs/commit/5a537c306ae1b178216d98005df10187af645822) expand platforms
* [`a1a2af36`](https://github.com/NixOS/nixpkgs/commit/a1a2af3655d4a75e3b8544ae3a546be1d8e24bf5) remove period from description
* [`6ef93940`](https://github.com/NixOS/nixpkgs/commit/6ef9394016d9be6235e93d744a538546a66ad49d) maintainers: add whiteley
* [`861b1c6b`](https://github.com/NixOS/nixpkgs/commit/861b1c6beacf9c5fb2d84bcee36e1d5cb714251d) python311Packages.sentry-sdk: 1.32.0 -> 1.33.1
* [`42b516f9`](https://github.com/NixOS/nixpkgs/commit/42b516f9e9c51271e65a79ac42332d96c82163bf) python311Packages.cyclonedx-python-lib: 4.2.3 -> 5.1.0
* [`0da52d67`](https://github.com/NixOS/nixpkgs/commit/0da52d67ac267ee604de9f5a52d1530e73aca3ce) checkov: 2.5.15 -> 3.0.15
* [`704361f6`](https://github.com/NixOS/nixpkgs/commit/704361f688b94a96d802c9318d237442977df863) yersinia: 0.8.2 -> unstable-2022-11-20 unmark broken aarch64-linux
* [`3c7be359`](https://github.com/NixOS/nixpkgs/commit/3c7be3591399c6f19e50fb3d9d688648ada2eb65) R: 4.3.1 -> 4.3.2
* [`b4084e4b`](https://github.com/NixOS/nixpkgs/commit/b4084e4b44772ccd9f895335b71465dc24f5dcf2) cloudflared: 2023.8.2 -> 2023.10.0
* [`035ce8b1`](https://github.com/NixOS/nixpkgs/commit/035ce8b122e856aaabd32364b174fdb8f07287cc) netdata: 1.43.0 -> 1.43.2
* [`f872c3a6`](https://github.com/NixOS/nixpkgs/commit/f872c3a648b7b27d814fee01199e890412878e81) netdata: update go.d.plugin 0.56.3 -> 0.56.4
* [`41b534b4`](https://github.com/NixOS/nixpkgs/commit/41b534b40ff8ef3a79720b4e7a8b1e04bfa1c20b) python311Packages.bandcamp-api: 0.2.2 -> 0.2.3
* [`5bfec27b`](https://github.com/NixOS/nixpkgs/commit/5bfec27bdb89708d550bc5561c1863e19789610b) deck: 1.27.1 -> 1.28.0
* [`23483be5`](https://github.com/NixOS/nixpkgs/commit/23483be539de2fc2bbc22ad3ce5d94074630131d) gcc-arm-embedded-13: init at 13.2.rel1
* [`3c381e85`](https://github.com/NixOS/nixpkgs/commit/3c381e85c73b53819a13871a1f67b62c4ed0e9da) anki-bin: 2.1.66 -> 23.10
* [`4585ec28`](https://github.com/NixOS/nixpkgs/commit/4585ec287825b6a34296fa192c67ea77d5536467) kotlin-native: 1.9.10 -> 1.9.20
* [`c783a977`](https://github.com/NixOS/nixpkgs/commit/c783a977dc97caa1fce53aff038fbf0b8b6a68f7) last: 1471 -> 1499
* [`8d7b487b`](https://github.com/NixOS/nixpkgs/commit/8d7b487bae4a971cca7f84727f5fb2897f123425) virtualbox: 7.0.10 -> 7.0.12
* [`8b1325bc`](https://github.com/NixOS/nixpkgs/commit/8b1325bc4695ac02165e715b6d629f279ebad8d5) maintainers: add nasageek
* [`536401e9`](https://github.com/NixOS/nixpkgs/commit/536401e90aa3c74d2f0226f4e55a005dc8f9eac3) nixos/restic: fix [nixos/nixpkgs⁠#264696](https://togithub.com/nixos/nixpkgs/issues/264696) and add a regression test
* [`f495f235`](https://github.com/NixOS/nixpkgs/commit/f495f235540757b21deeb702e9305dcbc5439889) qgis: 3.32.3 -> 3.34.0
* [`01768412`](https://github.com/NixOS/nixpkgs/commit/01768412a223856e9345f89aa5cf9d3798628a5d) godot_4: 4.1.1 -> 4.1.3-stable
* [`f754973d`](https://github.com/NixOS/nixpkgs/commit/f754973d145da2e9b5c43e4dda38721a0aaf3145) haskell hydra-report: bump timeout for all requests to Hydra
* [`919bcbef`](https://github.com/NixOS/nixpkgs/commit/919bcbef8ad90151a31ed43daf5a50f76573e9eb) mongodb-compass: 1.40.2 -> 1.40.4
* [`34eba92a`](https://github.com/NixOS/nixpkgs/commit/34eba92a09b6b9533c73cdcfe1b3db226301617e) nats-server: 2.10.2 -> 2.10.4
* [`b2fccae8`](https://github.com/NixOS/nixpkgs/commit/b2fccae80913400dc6b63aa37c27a5c96243fcad) zwave-js: module init, zwave-js-server: init at 1.33.0
* [`00138c96`](https://github.com/NixOS/nixpkgs/commit/00138c96aa59254709ae99d9558a8380a320b730) python311Packages.objax: disable tests to fix build
* [`e9ced3dc`](https://github.com/NixOS/nixpkgs/commit/e9ced3dc12367a9edf17ac58e5c03f1397cc280f) aws-sso-cli: 1.14.0 -> 1.14.2
* [`8c4cf09f`](https://github.com/NixOS/nixpkgs/commit/8c4cf09fa49ddf3896d1af72151f31bfe53d3ade) kluctl: 2.20.8 -> 2.22.1
* [`1646eec3`](https://github.com/NixOS/nixpkgs/commit/1646eec3be1687c500b45d7886b9f82008f4f279) python3Packages.zcbor: init at 0.7.0
* [`758e0ef5`](https://github.com/NixOS/nixpkgs/commit/758e0ef541aa3fbe8dd07572d0f047496cbc08c9) nominatim: fix issues with package
* [`e6eac90f`](https://github.com/NixOS/nixpkgs/commit/e6eac90f894d9f7dfa963b5fb138ea28e9e68298) gammastep: fix systemd unit directory
* [`31806129`](https://github.com/NixOS/nixpkgs/commit/31806129f67d79395638be04e8b68e28befccc44) redshift: set meta.mainProgram
* [`5fa84309`](https://github.com/NixOS/nixpkgs/commit/5fa84309f580d91bf9416aa6d52d0978a28a8cf4) gammastep: set meta.mainProgram
* [`6a1aee06`](https://github.com/NixOS/nixpkgs/commit/6a1aee0690e46e8cdb025eab1175c741dfea3c05) gammastep: add eclairevoyant to maintainers
* [`8b5c86c5`](https://github.com/NixOS/nixpkgs/commit/8b5c86c569c72d226a573a71965771a19f137992) python311Packages.google-cloud-container: 2.32.0 -> 2.33.0
* [`e201be6c`](https://github.com/NixOS/nixpkgs/commit/e201be6cc46dab79b67c6dca5271275bb37e78e5) python311Packages.google-cloud-dlp: 3.12.3 -> 3.13.0
* [`c3589160`](https://github.com/NixOS/nixpkgs/commit/c3589160ae99b3d02f332e8c1f9dca8a5ace34d7) python311Packages.google-cloud-securitycenter: 1.23.3 -> 1.24.0
* [`f391265c`](https://github.com/NixOS/nixpkgs/commit/f391265c5cf1cd3115f5a4d5ea90fc8cd0f579f9) hubble: 0.12.1 -> 0.12.2
* [`6660475d`](https://github.com/NixOS/nixpkgs/commit/6660475dea29309327ee3b2e6824ec0011589017) oh-my-posh: 18.11.0 -> 18.22.0
* [`cf0bb8de`](https://github.com/NixOS/nixpkgs/commit/cf0bb8dea864d389dcaf1a5505d2b06ad4c40ac5) oh: 0.8.1 -> 0.8.3
* [`1b70c55e`](https://github.com/NixOS/nixpkgs/commit/1b70c55e67fced2eb78ef18625dbc1a9abc0e882) onlyoffice-documentserver: 7.4.1 -> 7.5.0
* [`a6dfad13`](https://github.com/NixOS/nixpkgs/commit/a6dfad13f4db51c44e237c1888a694f376bb0f30) haskellPackages.cabal2nix-unstable: bump to latest commit
* [`9cbe3360`](https://github.com/NixOS/nixpkgs/commit/9cbe3360fbbb57e54d922fec7e5a80f9453a91d6) haskellPackages: regenerate package set based on current config
* [`8a8ec371`](https://github.com/NixOS/nixpkgs/commit/8a8ec371fe6bd092d180e12a0112a37448b4cb30) haskellPackages.gi-graphene: mark unbroken
* [`632a837c`](https://github.com/NixOS/nixpkgs/commit/632a837cef5a8ce3667696f871874cbc8f1070d7) opengrok: 1.12.15 -> 1.12.21
* [`650e5169`](https://github.com/NixOS/nixpkgs/commit/650e5169319788e2a06468585c59aaf1a355166f) kanidm: 1.1.0-beta.13 -> 1.1.0-rc.15
* [`e392fe93`](https://github.com/NixOS/nixpkgs/commit/e392fe93bc5c1ecd6012dcff558992f7c39de6da) p2pool: 3.7 -> 3.8
* [`c53a8f64`](https://github.com/NixOS/nixpkgs/commit/c53a8f6431ee0de3c893be8ed7b9dc0172938bc8) pachyderm: 2.7.2 -> 2.7.6
* [`2fc42077`](https://github.com/NixOS/nixpkgs/commit/2fc42077cc349c4c5c013d98970476abbc33df8b) photoflare: 1.6.12 -> 1.6.13
* [`a82f6e8a`](https://github.com/NixOS/nixpkgs/commit/a82f6e8abb35dc7cac5791337d229f968cab7c25) mathjax-node-cli: use buildNpmPackage
* [`83df023f`](https://github.com/NixOS/nixpkgs/commit/83df023f3b1d8b20d9162b24e3ab8fd986ec8bec) fcitx5-configtool: 5.1.1 -> 5.1.2
* [`1edc113c`](https://github.com/NixOS/nixpkgs/commit/1edc113c871babfbdb4b5dc89317f954c76bb123) fcitx5-hangul: 5.1.0 -> 5.1.1
* [`889833cf`](https://github.com/NixOS/nixpkgs/commit/889833cf06d76b9cbb55d1a7a171fe00650117f8) cosmic-settings: wrap program with cosmic-icons
* [`3fd47fc9`](https://github.com/NixOS/nixpkgs/commit/3fd47fc9770a58caeb34f8d6fef9408b2459bdd4) feishin: 0.4.1 -> 0.5.1
* [`34cd800d`](https://github.com/NixOS/nixpkgs/commit/34cd800dde36a04be83444f43d1158e88a930c55) kubebuilder: 3.12.0 -> 3.13.0
* [`5e300392`](https://github.com/NixOS/nixpkgs/commit/5e30039235470289bad73826db24f2d43bcfc460) wiremock: migrate to by-name
* [`f24ea671`](https://github.com/NixOS/nixpkgs/commit/f24ea67184330c8269bb1b39f47fe070967ad668) wiremock: add anthonyroussel to maintainers
* [`384f17bf`](https://github.com/NixOS/nixpkgs/commit/384f17bfad3fd9cd7e410b371f8739ee67d31371) wiremock: add meta.{changelog,mainProgram}
* [`c4d3c3cc`](https://github.com/NixOS/nixpkgs/commit/c4d3c3cc1a4fc86e816b27433711fed76e04e5d4) wiremock: 2.35.0 -> 3.2.0
* [`1f15c08d`](https://github.com/NixOS/nixpkgs/commit/1f15c08dc995e1bf0e4687b484c69a13c11a5b6e) wiremock: add passthru.updateScript
* [`09cc8b21`](https://github.com/NixOS/nixpkgs/commit/09cc8b216e97a4ec0ff982856ffd3d1edc12f9db) python311Packages.lazr-config: rename from lazr_config
* [`d2922cc7`](https://github.com/NixOS/nixpkgs/commit/d2922cc787be40f453570d8213d8e727db7982de) media-downloader: 3.4.0 -> 4.0.0
* [`99e6bb85`](https://github.com/NixOS/nixpkgs/commit/99e6bb855320407b90e344e66eae221b36e5809b) moonlight-embedded: 2.6.1 -> 2.6.2
* [`c6ce4bc0`](https://github.com/NixOS/nixpkgs/commit/c6ce4bc05172e47b36b5c4a4e410834f9c91b904) plexRaw: 1.32.6.7557-1cf77d501 -> 1.32.7.7621-871adbd44
* [`5d0f3d60`](https://github.com/NixOS/nixpkgs/commit/5d0f3d602595cb23f1e0901049b298926534df7e) python311Packages.lazr-config: refactor
* [`375e6a3c`](https://github.com/NixOS/nixpkgs/commit/375e6a3c1dd6611fd5ea221d3a600ee8ae52db5b) python311Packages.lazr-config: 2.2.3 -> 3.0
* [`067e014f`](https://github.com/NixOS/nixpkgs/commit/067e014f772c9bb486ba43dc0626001207304af3) python311Packages.lazr-delegates: rename from lazr_delegates
* [`c8396e38`](https://github.com/NixOS/nixpkgs/commit/c8396e38c10d9a01bbe600bc64da4593f6071bfb) python311Packages.lazr-delegates: refactor
* [`62ea8683`](https://github.com/NixOS/nixpkgs/commit/62ea868312bac1f6cc01a9996bc35bb658bea879) python311Packages.lazr-delegates: 2.0.4 -> 2.1.0
* [`33cf3363`](https://github.com/NixOS/nixpkgs/commit/33cf33634eb5030563a5c1a7308d66884888f0a7) ugrep: 4.3.1 -> 4.3.2
* [`d06c5237`](https://github.com/NixOS/nixpkgs/commit/d06c52373af97865f670f3c06c1d744be145f959) clickhouse-backup: 2.4.1 -> 2.4.2
* [`f9665bb1`](https://github.com/NixOS/nixpkgs/commit/f9665bb173b81515ad2f421e5482a091af8b8bc8) python311Packages.pymaging_png: remove
* [`069e1ee0`](https://github.com/NixOS/nixpkgs/commit/069e1ee048316d310310f3b673b4b51484d02f7a) python311Packages.pymaging: remove
* [`775d998c`](https://github.com/NixOS/nixpkgs/commit/775d998c9a6a3fd7d1d5482be91e986521babd14) palemoon-bin: 32.4.1 -> 32.5.0
* [`c3b9db38`](https://github.com/NixOS/nixpkgs/commit/c3b9db387be6463aec6af669d7268443a0f0c0ba) python311Packages.restructuredtext-lint: rename from restructuredtext_lint
* [`b46372d7`](https://github.com/NixOS/nixpkgs/commit/b46372d72575986011ec6be11779d12df4c4ee88) python311Packages.restructuredtext-lint: refactor
* [`a0ab0c88`](https://github.com/NixOS/nixpkgs/commit/a0ab0c8878a5f8079a1ca95b124a651e599bbd06) lunatask: 1.7.7 -> 1.7.8
* [`c5e4273f`](https://github.com/NixOS/nixpkgs/commit/c5e4273f6064a702693015c403afeffb2adea685) kubectl-cnpg: 1.20.2 -> 1.21.0
* [`79621bf8`](https://github.com/NixOS/nixpkgs/commit/79621bf80400134843c7303bb8953554e748057b) praat: 6.3.17 -> 6.3.20
* [`c1a28a4e`](https://github.com/NixOS/nixpkgs/commit/c1a28a4ea29b62aa524be9534ba6d4db6da34b7a) prometheus-sql-exporter: 0.4.7 -> 0.5.2
* [`a1b6d519`](https://github.com/NixOS/nixpkgs/commit/a1b6d51957639df4b0e15458cd0106c43aa1f6d3) pwsafe: 1.17.0 -> 1.18.0
* [`2eb15c29`](https://github.com/NixOS/nixpkgs/commit/2eb15c2926060439a24940f07b385f9210816fc5) python311Packages.canals: 0.8.1 -> 0.9.0
* [`64a4d3b4`](https://github.com/NixOS/nixpkgs/commit/64a4d3b4bbe2cfe05d174c8b3b0595dc3f9b98ab) python310Packages.adjusttext: 0.8.0 -> 0.8.1
* [`dab4aa83`](https://github.com/NixOS/nixpkgs/commit/dab4aa836625c9c75212170f241b5f82d7aee1bb) zitadel: 2.37.2 -> 2.40.3
* [`8973ad96`](https://github.com/NixOS/nixpkgs/commit/8973ad968cfd16a8fabdf28450ce856e6a7edf04) python311Packages.torrent-parser: rename from torrent_parser
* [`8e7947fa`](https://github.com/NixOS/nixpkgs/commit/8e7947fa0604dedddc4a2d38837f3b4c47310b3f) python311Packages.torrent-parser: refactor
* [`a434c9f3`](https://github.com/NixOS/nixpkgs/commit/a434c9f37e6517791ff21cd2716d87ad78c7204c) pinegrow: 7.05.2 -> 7.8
* [`fbc5e23e`](https://github.com/NixOS/nixpkgs/commit/fbc5e23ebd2f5717c36bd07c5217f72d752198de) sqlite3-to-mysql: 2.0.3 -> 2.1.1
* [`451b3946`](https://github.com/NixOS/nixpkgs/commit/451b394679a41a3985dc9234df022ec96ae22f98) python3Packages.reorder-python-imports: 3.11.0 -> 3.12.0
* [`29b25573`](https://github.com/NixOS/nixpkgs/commit/29b2557347b7dfbe2b19e6c4eae57cb4872ae156) gomplate: force build with go 1.20
* [`4e33273a`](https://github.com/NixOS/nixpkgs/commit/4e33273a8499382be875cbeedfbb46b31e64f373) python3Packages.ducc0: 0.31.0 -> 0.32.0
* [`bb866971`](https://github.com/NixOS/nixpkgs/commit/bb8669712e7e4d1899e26230a0ec878b088379ab) grails: 6.0.0 -> 6.1.0
* [`772d3f60`](https://github.com/NixOS/nixpkgs/commit/772d3f609fe7bcd296c176fce6dc97067201c1ae) intel-cmt-cat: 23.08 -> 23.11
* [`575af233`](https://github.com/NixOS/nixpkgs/commit/575af2335424da9c9c21d709855ccf79c35b6451) llama-cpp: 1469 -> 1483
* [`51a383c1`](https://github.com/NixOS/nixpkgs/commit/51a383c15fe38be49f686be760db2f8b9b8cb929) meld: avoid -dev paths in runtime closure
* [`daa5214d`](https://github.com/NixOS/nixpkgs/commit/daa5214d97a0f25a980cfac634511ebc67712830) python311Packages.stytra: mark broken
* [`421b4946`](https://github.com/NixOS/nixpkgs/commit/421b4946ab55532db395490a7658ed1262cbc61f) mdhtml: 0.2.2 -> 0.3.0
* [`13b121be`](https://github.com/NixOS/nixpkgs/commit/13b121bee9ba03f88ee5f85ee18f97234d793b3e) sharedown: mark broken
* [`044e50b3`](https://github.com/NixOS/nixpkgs/commit/044e50b331310361b26829e2f5bb8b787d1c7aeb) lamdera: 1.2.0 -> 1.2.1
* [`2513ca1d`](https://github.com/NixOS/nixpkgs/commit/2513ca1dbc3127fd66252d396308921e73f1725c) heroic: add unzip to FHS env
* [`388c14ed`](https://github.com/NixOS/nixpkgs/commit/388c14edc589b5d7152a2ceedcd26d6a8977baf4) texlive.combined.scheme-bookpub: init
* [`80cd75f4`](https://github.com/NixOS/nixpkgs/commit/80cd75f4cb07ab7b48e750b783be8eee721445f3) texlive: export schemes at top level
* [`ae7102b8`](https://github.com/NixOS/nixpkgs/commit/ae7102b8d7f0f2e5c75f5e9197d737d7ff917996) texlive: do not recurse into attrs
* [`e999c6d9`](https://github.com/NixOS/nixpkgs/commit/e999c6d9dd35d8022ed36c8a953573a562f69436) routedns: 0.1.20 -> 0.1.51
* [`029da501`](https://github.com/NixOS/nixpkgs/commit/029da501017ebd0c3902ec8fc8758b20e81788a1) nile: 1.0.0 -> unstable-2023-10-03
* [`e9a9a606`](https://github.com/NixOS/nixpkgs/commit/e9a9a60690c116e71b8df68dcda27f3043a9cd47) heroic: 2.9.2 -> 2.10.0
* [`f2c37523`](https://github.com/NixOS/nixpkgs/commit/f2c37523ee07ae36c2d1b49b1541686f0766baea) vopono: 0.10.6 -> 0.10.7
* [`b6b7733e`](https://github.com/NixOS/nixpkgs/commit/b6b7733e4ac0a4f3b3e0a88a70b41d2442f1e770) uwsgi: 2.0.22 -> 2.0.23
* [`02ba6a40`](https://github.com/NixOS/nixpkgs/commit/02ba6a40405cfd089d1e4705cf3add969ee3bfbf) evcc: 0.121.5 -> 0.122.0
* [`9518abf6`](https://github.com/NixOS/nixpkgs/commit/9518abf6ce56fc3c1890e568e5c10b37cd0527af) portfolio: 0.65.4 -> 0.65.5
* [`1817b5bd`](https://github.com/NixOS/nixpkgs/commit/1817b5bdb0f429ee8353217f257456059490dac7) zotero: 6.0.27 -> 6.0.30
* [`58d3a7b8`](https://github.com/NixOS/nixpkgs/commit/58d3a7b8708155dd753d72b3a8b8d17f0c8600cf) ovftool: 4.5.0 -> 4.6.2 (4.6.0 on i686-linux)
* [`aeb94983`](https://github.com/NixOS/nixpkgs/commit/aeb9498351cf33088970b1a25440b2c2748bb3ce) mattermost: 8.1.3 -> 8.1.4
* [`4f2a7929`](https://github.com/NixOS/nixpkgs/commit/4f2a79293fdccf59627977478cce23b62c7cb7f6) devpod: init at 0.4.1
* [`c93f9133`](https://github.com/NixOS/nixpkgs/commit/c93f913379cf6e8862bd1533f654b2cf6347264a) ocenaudio: 3.13.1 -> 3.13.2
* [`3b9f1951`](https://github.com/NixOS/nixpkgs/commit/3b9f19513234c5ceac06f671ba4cf04292ab3b16) ocserv: 1.2.1 -> 1.2.2
* [`b1900ad6`](https://github.com/NixOS/nixpkgs/commit/b1900ad682ce6bad8def4349988ade77a2d37d3f) omniorb: 4.3.0 -> 4.3.1
* [`42baf8f1`](https://github.com/NixOS/nixpkgs/commit/42baf8f175a84f9536aa152c910cbe22c01f006a) python311Packages.accelerate: fix build when torch.distributed is disabled
* [`8ca87f4d`](https://github.com/NixOS/nixpkgs/commit/8ca87f4d76d8090bb8152ef706eff2a9faea188b) polypane: 15.0.1 -> 16.0.0
* [`6e880e55`](https://github.com/NixOS/nixpkgs/commit/6e880e55b012712512a10694602643400c35cd91) publii: 0.43.0 -> 0.43.1
* [`45718e9f`](https://github.com/NixOS/nixpkgs/commit/45718e9f7476e2803871539c38e2c9e13e6fdd4d) libmt32emu: 2.7.0 -> 2.7.1
* [`f85d61ac`](https://github.com/NixOS/nixpkgs/commit/f85d61ac5398883005ab54d2af6621dffd148349) python310Packages.cobs: 1.2.0 -> 1.2.1
* [`2434ed12`](https://github.com/NixOS/nixpkgs/commit/2434ed121a8bb656a2fa16920993833bd82c51e9) python311Packages.multi-key-dict: rename from multi_key_dict
* [`0bd996ce`](https://github.com/NixOS/nixpkgs/commit/0bd996ce96a2696da9f8c4c9da7690bacad8031e) python311Packages.multi-key-dict: refactor
* [`e1dd90b1`](https://github.com/NixOS/nixpkgs/commit/e1dd90b1b3d267854ff183a51d38af42d6bb6842) python310Packages.coinmetrics-api-client: 2023.9.29.14 -> 2023.10.30.13
* [`6e500a73`](https://github.com/NixOS/nixpkgs/commit/6e500a732055490865b8525c9984d3b6ed40d8cb) carapace: 0.28.2 -> 0.28.3
* [`5dc90ed9`](https://github.com/NixOS/nixpkgs/commit/5dc90ed9327bc2f1f3a668c24bf6a866561d3621) gitoxide: 0.30.0 -> 0.31.1
* [`54ea3c51`](https://github.com/NixOS/nixpkgs/commit/54ea3c518b55b79ad7e893cb40c0c4278151c606) picotool: add udev rules
* [`f623bbbf`](https://github.com/NixOS/nixpkgs/commit/f623bbbf8a6405f3667757d1bf41c43f09e84138) qgis-ltr: 3.28.11 -> 3.28.12
* [`cb65afe1`](https://github.com/NixOS/nixpkgs/commit/cb65afe1cbdcfe7baa5cb333530e299d5a4d00e6) cargo-leptos: 0.2.0 -> 0.2.1
* [`b4bba87c`](https://github.com/NixOS/nixpkgs/commit/b4bba87c4b25dcab6495a5ee02b793d98bad0324) jrnl: 4.0.1 -> 4.1
* [`463bd286`](https://github.com/NixOS/nixpkgs/commit/463bd286278a4873f7e97ee57ce44d2c2dd5a4e2) jrnl: add version test
* [`9a5095a5`](https://github.com/NixOS/nixpkgs/commit/9a5095a537c98b7c46584800c6f7ee141f9bbf78) tests.texlive: replace texlive.combine with texlive.withPackages
* [`13cb90b5`](https://github.com/NixOS/nixpkgs/commit/13cb90b5be39b6939dbb01cc6666b0f5c9daa577) tests.texlive: use texlive.pkgs.PKGNAME attribute set instead of texlive.PKGNAME.pkgs list
* [`8f944be4`](https://github.com/NixOS/nixpkgs/commit/8f944be4119326dfda3636b68dfb1417495750aa) gnu-cobol: replace texlive.combined.scheme-basic with texliveBasic
* [`fb565527`](https://github.com/NixOS/nixpkgs/commit/fb565527899452f6dfb81a7936f408d24a43feb2) pari: replace texlive.combined.scheme-basic with texliveBasic
* [`8d9f66a2`](https://github.com/NixOS/nixpkgs/commit/8d9f66a2eec2725067131c8fa6ed6fd0622b200c) pidginPackages: replace texlive.combined.scheme-basic with texliveBasic
* [`e5075bb6`](https://github.com/NixOS/nixpkgs/commit/e5075bb665751dece8fec7b71e74bf9d8a6c4c9b) sagetex: replace texlive.combined.scheme-basic with texliveBasic
* [`1c96a6d3`](https://github.com/NixOS/nixpkgs/commit/1c96a6d381a2379da280c1bb575f5a37ff125374) scapy: replace texlive.combined.scheme-basic with texliveBasic
* [`9ae3cdf7`](https://github.com/NixOS/nixpkgs/commit/9ae3cdf7e77088c25f9ecaf59a22e90695bb703d) blahtexml: replace texlive.combined.scheme-full with texliveFull
* [`1429e5b5`](https://github.com/NixOS/nixpkgs/commit/1429e5b57ee023b5e62463932c12c9c3e70f9873) bluespec: replace texlive.combined.scheme-full with texliveFull
* [`8bae94d5`](https://github.com/NixOS/nixpkgs/commit/8bae94d587102fd6c7ec4d73ac5910cba3779703) advi: replace texlive.combined.scheme-medium with texliveMedium
* [`422c63c2`](https://github.com/NixOS/nixpkgs/commit/422c63c2a477c4c2ff6be65d27f6c3df2c2d5cb9) asl: replace texlive.combined.scheme-medium with texliveMedium
* [`e132b36d`](https://github.com/NixOS/nixpkgs/commit/e132b36dcee39b00cf7005fbc7c65496657fa509) apostrophe: replace texlive.combined.scheme-medium with texliveMedium
* [`4d77ab5c`](https://github.com/NixOS/nixpkgs/commit/4d77ab5cb57ef029c1fcb55eac5aeae3ee6be74e) avrdude: replace texlive.combined.scheme-medium with texliveMedium
* [`7a945b38`](https://github.com/NixOS/nixpkgs/commit/7a945b3874c2e28ce934ef33a18b6cab33362f8b) linuxdoc-tools: replace texlive.combined.scheme-medium with texliveMedium
* [`0ef5f56c`](https://github.com/NixOS/nixpkgs/commit/0ef5f56c469f23a3b9b5bfcf41d109c9f26d29bf) ne: replace texlive.combined.scheme-medium with texliveMedium
* [`8c19beda`](https://github.com/NixOS/nixpkgs/commit/8c19bedab1a592c4f9f9e61462d03ff2df0aebc3) ns-3: replace texlive.combined.scheme-medium with texliveMedium
* [`30990380`](https://github.com/NixOS/nixpkgs/commit/309903802adf7742884aeb3ce6ec1b49c6c72bb1) nuweb: replace texlive.combined.scheme-medium with texliveMedium
* [`2a0440c2`](https://github.com/NixOS/nixpkgs/commit/2a0440c2a40338e7f6e223093dd40acc27f77353) rPackages: replace texlive.combined.scheme-medium with texliveMedium
* [`803eae4c`](https://github.com/NixOS/nixpkgs/commit/803eae4c8310b4eed6fb44cfe9982fa5b8f4b4a9) zettlr: replace texlive.combined.scheme-medium with texliveMedium
* [`d589dcc0`](https://github.com/NixOS/nixpkgs/commit/d589dcc0e9a581536f80fe6a44d73c27e69bb507) openmolcas: replace texlive.combined.scheme-minimal with texliveMinimal
* [`dc348b84`](https://github.com/NixOS/nixpkgs/commit/dc348b84451f5c97df8ac8de50b403f43d676ff2) cddblib: replace texlive.combined.scheme-small with texliveSmall
* [`aecbfc41`](https://github.com/NixOS/nixpkgs/commit/aecbfc41401950bcf24b3203ffe4d3e24ccc1dae) enblend-enfuse: replace texlive.combine with texliveSmall
* [`37726ded`](https://github.com/NixOS/nixpkgs/commit/37726ded83c3a35fe5ccc195df29ebf52d868917) giac: replace texlive.combined.scheme-small with texliveSmall
* [`48e9feab`](https://github.com/NixOS/nixpkgs/commit/48e9feabca1d82cf66665d3c865222395a637ffd) gnuplot: replace texlive.combine with texliveSmall
* [`909531d2`](https://github.com/NixOS/nixpkgs/commit/909531d25524082b7be5dac4d18a0dcc59f080c7) ipe: replace texlive.combine with texliveSmall
* [`9a2865f1`](https://github.com/NixOS/nixpkgs/commit/9a2865f10e911eec8800855c51c66a48e933cc89) python3Packages.pypandoc: replace texlive.combined.scheme-small with texliveSmall
* [`1fd98825`](https://github.com/NixOS/nixpkgs/commit/1fd9882538b909581ae991c34e412f3f1dcab12f) ragel: replace texlive.combined.scheme-small with texliveSmall
* [`eb6eef10`](https://github.com/NixOS/nixpkgs/commit/eb6eef1073c1468921a3f835f6293896ecc99940) singular: replace texlive.combined.scheme-small with texliveSmall
* [`5b6a5f89`](https://github.com/NixOS/nixpkgs/commit/5b6a5f89438aab3edf1b9734cb3807f678d16c49) skribilo: replace texlive.combined.scheme-small with texliveSmall
* [`cdc9dba2`](https://github.com/NixOS/nixpkgs/commit/cdc9dba2bcc1d4a54aa37e3a8b3d37a00cef9777) texmacs: replace texlive.combined.scheme-small with texliveSmall
* [`eadb394f`](https://github.com/NixOS/nixpkgs/commit/eadb394f32f4460f9c0494061c0370d4ca4c9725) pandoc-drawio-filter: replace texlive.combined.scheme-tetex with texliveTeTeX
* [`00ab8f1f`](https://github.com/NixOS/nixpkgs/commit/00ab8f1f588996619cd279047cca683358cfa238) therion: replace texlive.combined.scheme-tetex with texliveTeTeX
* [`f72a3122`](https://github.com/NixOS/nixpkgs/commit/f72a312206a102585c86b5f9dffc0339a76fd3e8) dblatex: replace texlive.combine with texliveBasic.withPackages
* [`8ada8e2b`](https://github.com/NixOS/nixpkgs/commit/8ada8e2b257048e115dd8516188caff7042bbdd4) dwarf-fortress: replace texlive.combine with texliveBasic.withPackages
* [`41f4b456`](https://github.com/NixOS/nixpkgs/commit/41f4b45604a8506e8c518061612cbfcb1210d231) pari: replace texlive.combine with texliveBasic.withPackages
* [`9f4a0a42`](https://github.com/NixOS/nixpkgs/commit/9f4a0a421f130aba0e232fde4f1e3df9be16e457) rivet: replace texlive.combine with texliveBasic.withPackages
* [`9b4d056e`](https://github.com/NixOS/nixpkgs/commit/9b4d056ec5133da7a14500ede0f6fb8f39ad727e) xyce: replace texlive.combine with texliveMedium.withPackages
* [`ce4a4e65`](https://github.com/NixOS/nixpkgs/commit/ce4a4e651e020d9fe58b4c59cc09bef86d268bdd) graphite-gtk-theme: fix wallpapers
* [`95802a1d`](https://github.com/NixOS/nixpkgs/commit/95802a1d9e6188a6a800a8d008849706f9ed5260) vdrPlugins.nopacity: 1.1.14 -> 1.1.16
* [`c624a438`](https://github.com/NixOS/nixpkgs/commit/c624a4380e78cceb9c2e05b3dadfd5e7ddeba03f) vdrPlugings.softhddevice: 1.12.1 -> 1.12.5
* [`c1ea1e71`](https://github.com/NixOS/nixpkgs/commit/c1ea1e7178c83ee80b039441d485401a22b88196) vdrPlugins.markad: 3.3.5 -> 3.3.6
* [`92501d7b`](https://github.com/NixOS/nixpkgs/commit/92501d7bedc0c9fd17e71d228118aad542f71d54) catdvi: replace texlive.combine with texliveInfraOnly.withPackages
* [`9d3d2373`](https://github.com/NixOS/nixpkgs/commit/9d3d2373a9c710cac1a3e191d51a0a53078358a5) manim: replace texlive.combine with texliveInfraOnly.withPackages
* [`5fcdb283`](https://github.com/NixOS/nixpkgs/commit/5fcdb283198755f57a67678573cc61e3b11aa4d7) asciidoc: replace texlive.combine with texliveMinimal.withPackages
* [`25708f8e`](https://github.com/NixOS/nixpkgs/commit/25708f8e5a386a0fd0ff2418541bcbf0983296f4) asymptote: replace texlive.combine with texliveSmall.withPackages
* [`6bc7fe6c`](https://github.com/NixOS/nixpkgs/commit/6bc7fe6c113183151cf7f8837574af302331ce39) dot2tex: replace texlive.combine with texliveSmall.withPackages
* [`f6a496b3`](https://github.com/NixOS/nixpkgs/commit/f6a496b3de7cb1d33dfd76fd042dee942c15396f) lilypond: replace texlive.combine with texliveSmall.withPackages
* [`2fa4ebdb`](https://github.com/NixOS/nixpkgs/commit/2fa4ebdbc1cc5b792b8fa08b690cb81247fef14e) mitscheme: replace texlive.combine with texliveSmall.withPackages
* [`2e4e6991`](https://github.com/NixOS/nixpkgs/commit/2e4e6991ace81f35fee9b309c7aa8db90c3a7db9) paperwork: replace texlive.combine with texliveSmall.withPackages
* [`32be1224`](https://github.com/NixOS/nixpkgs/commit/32be122447f5d9732972265bd97fdfa58a520406) python3Packages.sphinxcontrib-tikz: replace texlive.combine with texliveSmall.withPackages
* [`69899e59`](https://github.com/NixOS/nixpkgs/commit/69899e59a27ae83dcc3b3c813a307c159c08ef5e) R: replace texlive.combine with texliveSmall.withPackages
* [`6a7c8f0d`](https://github.com/NixOS/nixpkgs/commit/6a7c8f0d330d8fcc6946955a42d999c8a28c7cfd) rocmPackages.migraphx: replace texlive.combine with texliveSmall.withPackages
* [`8801b6e5`](https://github.com/NixOS/nixpkgs/commit/8801b6e5c0e6f83edfad439e754f6ead62913f2b) rocmPackages.miopen: replace texlive.combine with texliveSmall.withPackages
* [`fc2a6b86`](https://github.com/NixOS/nixpkgs/commit/fc2a6b8606535dee5aad4160acda488be686c725) rocmPackages.miopengemm: replace texlive.combine with texliveSmall.withPackages
* [`ffb91229`](https://github.com/NixOS/nixpkgs/commit/ffb9122972ba046b508ac14cf7fea31f8fa79f0a) rocmPackages.rdc: replace texlive.combine with texliveSmall.withPackages
* [`818d9f0b`](https://github.com/NixOS/nixpkgs/commit/818d9f0baca951b57294f945af67465175167b06) rocmPackages.rocdbgapi: replace texlive.combine with texliveSmall.withPackages
* [`4fbe6527`](https://github.com/NixOS/nixpkgs/commit/4fbe6527ac5604c5f0ad90ba569f27d0c5418103) pandoc-acro: replace texlive.combine with texliveTeTeX.withPackages
* [`f5edeac4`](https://github.com/NixOS/nixpkgs/commit/f5edeac421435433eb651ae520ae0b9994c2d07b) tests.texlive.fixedHashes: ignore .tex attribute sets that are not derivations
* [`669c6323`](https://github.com/NixOS/nixpkgs/commit/669c6323653157d625a3f573611089bc2ff1576a) get_iplayer: 3.33 -> 3.34
* [`0d6c05b1`](https://github.com/NixOS/nixpkgs/commit/0d6c05b175b3ef647f2f8a9da21f4ad2aea81ed8) python311Packages.radish-bdd: 0.17.0 -> 0.17.1
* [`3a2389bf`](https://github.com/NixOS/nixpkgs/commit/3a2389bf79bceb4ae17c07381e0c73474d9f9c88) top-level/mpvScripts: import → callPackage
* [`a899b23b`](https://github.com/NixOS/nixpkgs/commit/a899b23bd3e4f6bd6f6d762dd2260952f1d72b9d) mpvScripts: refactor around `buildLua` helper
* [`54d25073`](https://github.com/NixOS/nixpkgs/commit/54d250735ad3e99b870ec24a198d73dc18b44315) mpvScripts.{blacklistExtensions, seekTo}: makeOverridable & refactor
* [`7b792b0b`](https://github.com/NixOS/nixpkgs/commit/7b792b0bcffb77795001dc0840d090e21a609a6b) mpvScripts.buildLua: Run {pre, post}install hooks
* [`0ee702c4`](https://github.com/NixOS/nixpkgs/commit/0ee702c43936f4fb169b53916b3f3251ffcc5441) haskellPackages.sdl2-gfx: work around sdl2 pkg-config issue
* [`73c05bde`](https://github.com/NixOS/nixpkgs/commit/73c05bde44613703e901c835132dadec3efe38b4) harfbuzz: record provided pkg-config modules in meta
* [`d32cb372`](https://github.com/NixOS/nixpkgs/commit/d32cb37277093e405e93e3cd69807a3a07873e80) sdl2: record provided pkg-config modules in meta
* [`e3235021`](https://github.com/NixOS/nixpkgs/commit/e3235021ec0999f11112d86084a15ca7df4bf29e) SDL2_gfx: record provided pkg-config modules in meta
* [`4c56be2a`](https://github.com/NixOS/nixpkgs/commit/4c56be2a7e100a5afe2c4b859740be96f5d5ea62) SDL2_ttf: record provided pkg-config modules in meta
* [`c31f0065`](https://github.com/NixOS/nixpkgs/commit/c31f00657042dcb85e45777be4f3701032a4f2f5) haskellPackages.sdl2-ttf: work around sdl2 pkg-config issue
* [`46570625`](https://github.com/NixOS/nixpkgs/commit/465706255f1d32e15f8feba2a28e6d4ab5d9fe8b) grpc: explicitly use the build platform for `grpc_cpp_plugin`
* [`b4217d47`](https://github.com/NixOS/nixpkgs/commit/b4217d476a21617bd0fb80931fa90281af7588b3) mopidy-spotify: add updateScript
* [`b0ab1eba`](https://github.com/NixOS/nixpkgs/commit/b0ab1eba3d0c6c5182554e82ad0490d4f927bd8f) mopidy-spotify: unstable-2023-04-21 -> unstable-2023-11-01
* [`9348a545`](https://github.com/NixOS/nixpkgs/commit/9348a545f5518637b0e89150970db1ddb82fc205) wasmedge: 0.13.4 -> 0.13.5
* [`2e60191c`](https://github.com/NixOS/nixpkgs/commit/2e60191ca9a622070c0258a6762db50cbd157420) gdal: 3.7.2 -> 3.7.3
* [`3b65f33c`](https://github.com/NixOS/nixpkgs/commit/3b65f33cb465124700f27e6fc4e34df42ea5634e) open-english-wordnet: init at 2022
* [`281f03a6`](https://github.com/NixOS/nixpkgs/commit/281f03a6db70779c86b5de0550b1a56577b47011) open-english-wordnet: Fix merge.py
* [`ad929515`](https://github.com/NixOS/nixpkgs/commit/ad9295157901e218f9e27b0cb14a9cb791d139d4) nixos/sudo: Don't include empty sections
* [`96ef6f25`](https://github.com/NixOS/nixpkgs/commit/96ef6f252f6236a6cb0a814a417dea762c923c74) iterm2: 3.4.21 → 3.4.22
* [`10f86523`](https://github.com/NixOS/nixpkgs/commit/10f86523a2223e0f7c9fc71b95d0a7b00e69b663) uiua: 0.0.25 -> 0.1.0
* [`fa40d645`](https://github.com/NixOS/nixpkgs/commit/fa40d6457ab7ccf5bd65f620df82413a1de58dc3) nix-prefetch-git: download submodules with --progress
* [`41c429a5`](https://github.com/NixOS/nixpkgs/commit/41c429a5609bbaf643107925774e79359435a565) git-codereview: 1.7.0 -> 1.8.0
* [`9aee9b16`](https://github.com/NixOS/nixpkgs/commit/9aee9b163eae96d44134c1851cc0bdf021bfb477) nixos/akkoma: Do not warn under sudo-rs
* [`d53d9040`](https://github.com/NixOS/nixpkgs/commit/d53d90401d3d0497bba7def7e9d975d7438433cf) iosevka: 27.3.2 -> 27.3.4
* [`dc6c5010`](https://github.com/NixOS/nixpkgs/commit/dc6c5010cb3ca54c141288c637ebd89dd8aabd49) texlab: 5.10.1 -> 5.11.0
* [`74b8e888`](https://github.com/NixOS/nixpkgs/commit/74b8e888a66e29a139e097125cff2d268dc5d9a5) python310Packages.django-crispy-forms: 2.0 -> 2.1
* [`a6a80ca9`](https://github.com/NixOS/nixpkgs/commit/a6a80ca903f6470876395496c80ed6c39b0f0bd3) python311Packages.latexify-py: 0.2.0 -> 0.3.1
* [`180845e8`](https://github.com/NixOS/nixpkgs/commit/180845e861dba88cd7ba50ca3bc5c10acc21b3a0) python310Packages.django-ipware: 5.0.0 -> 5.0.2
* [`326904b1`](https://github.com/NixOS/nixpkgs/commit/326904b12883d033755940f02248b36053abbcf2) nixos/google-compute-config: Add sudo-rs rules
* [`9259a8d2`](https://github.com/NixOS/nixpkgs/commit/9259a8d2792df63129ccbc2a239049b72af06379) nixos/google_oslogin: Handle sudo-rs too
* [`b840084e`](https://github.com/NixOS/nixpkgs/commit/b840084e5889e440e41786f29bf736364914b97d) gut: 0.2.10 -> 0.3.0
* [`466e5b6f`](https://github.com/NixOS/nixpkgs/commit/466e5b6f306951375d85e0b3a9abcb2b51b2826f) nixos-firewall-tool: init at 0.0.1
* [`b44a0a50`](https://github.com/NixOS/nixpkgs/commit/b44a0a505916125b04b859fb92a085065d684e20) microsoft-edge: 118.0.2088.76 -> 119.0.2151.44
* [`f4e70e2c`](https://github.com/NixOS/nixpkgs/commit/f4e70e2c210fcd7dc613f7b1cdae9dd0b2870199) btrfs-progs: 6.5.3 -> 6.6.1
* [`1e27ed32`](https://github.com/NixOS/nixpkgs/commit/1e27ed3283e694230f1ffcafc8c16f8e34b14c87) python310Packages.djangorestframework-dataclasses: 1.3.0 -> 1.3.1
* [`c40ef720`](https://github.com/NixOS/nixpkgs/commit/c40ef72059c98667001326f3a5c82d84ff2a7a52) polybar: 3.6.3 -> 3.7.0
* [`34cf3b71`](https://github.com/NixOS/nixpkgs/commit/34cf3b7147b8810470e9b23434e323b1afd69626) maintainers: quantenzitrone github account rename
* [`c53a7c6c`](https://github.com/NixOS/nixpkgs/commit/c53a7c6c0422d8d76b84bd0697697e97988c68d5) python311Packages.pygls: 1.1.1 -> 1.1.2
* [`ab1da439`](https://github.com/NixOS/nixpkgs/commit/ab1da43942868d28b5655d520177801a8f3191e4) llm-ls: init at 0.4.0
* [`8dd92c2f`](https://github.com/NixOS/nixpkgs/commit/8dd92c2f2af86935945ae2cdf2d5c27ea9a7ece3) python310Packages.duckduckgo-search: 3.8.5 -> 3.9.4
* [`12cc200d`](https://github.com/NixOS/nixpkgs/commit/12cc200d4383e8ca1b3e7f5c66edcbaedbd2739d) python311Packages.img2pdf: fix evaluation on darwin
* [`f5db0239`](https://github.com/NixOS/nixpkgs/commit/f5db02399ad8f660f0e9c080758d6c78635ffc67) lune: 0.7.4 -> 0.7.11
* [`d3847db2`](https://github.com/NixOS/nixpkgs/commit/d3847db254c7bcaf88151eab2f116dee7b6e3c12) python310Packages.dvclive: 3.1.0 -> 3.2.0
* [`bc2d5988`](https://github.com/NixOS/nixpkgs/commit/bc2d5988780f02c26daea44016df56a1dc4fb8e2) treewide: change pythonForBuild to pythonOnBuildForHost
* [`bd80b073`](https://github.com/NixOS/nixpkgs/commit/bd80b073ca2a711e381418fe1847d5dda99ee293) python310Packages.easydict: 1.10 -> 1.11
* [`d41a5aca`](https://github.com/NixOS/nixpkgs/commit/d41a5acab479352f6d85a099b72b64b404297f02) python310Packages.einops: 0.6.1 -> 0.7.0
* [`4e5e1578`](https://github.com/NixOS/nixpkgs/commit/4e5e1578fe2f3fbfae45cea85782ef25db14df43) qutebrowser: add meta attributes
* [`2c6991d1`](https://github.com/NixOS/nixpkgs/commit/2c6991d11948fccf536d56cfd915899e53808d37) qutebrowser: cleanup
* [`efd2139d`](https://github.com/NixOS/nixpkgs/commit/efd2139d1e29677c309d3d49869f5cea1be6ba22) terragrunt: 0.53.0 -> 0.53.2
* [`7b486182`](https://github.com/NixOS/nixpkgs/commit/7b486182f98a8e9233e521133fba11a9fa8c0271) python310Packages.ezyrb: 1.3.0.post2309 -> 1.3.0.post2311
* [`e503660f`](https://github.com/NixOS/nixpkgs/commit/e503660f305ae62b60f89d178b6d25d270dff190) python310Packages.faster-whisper: 0.8.0 -> 0.9.0
* [`21a2b2a3`](https://github.com/NixOS/nixpkgs/commit/21a2b2a3a4c6271f9922264993bdbef1fd58a1a6) python310Packages.fasttext-predict: 0.9.2.1 -> 0.9.2.2
* [`68971c9c`](https://github.com/NixOS/nixpkgs/commit/68971c9c826538fde418ad1bf3ed605d5b7306e3) python310Packages.finvizfinance: 0.14.6 -> 0.14.7
* [`6fceda32`](https://github.com/NixOS/nixpkgs/commit/6fceda323811308a9a9caae0439e3b412868122f) twilio-cli: 5.15.0 -> 5.16.1
* [`be7a9def`](https://github.com/NixOS/nixpkgs/commit/be7a9def101478a029a41bd9ec89fe11b4210855) python310Packages.flask-paginate: 2023.10.8 -> 2023.10.24
* [`2e5986a5`](https://github.com/NixOS/nixpkgs/commit/2e5986a5e5c897b778b29c5dbe73529d66ca7501) age: skip flaky plugin test
* [`ac7eb40b`](https://github.com/NixOS/nixpkgs/commit/ac7eb40b3273c49070192cbe11db7d3b866a53b6) python310Packages.glcontext: 2.4.0 -> 2.5.0
* [`f6489b77`](https://github.com/NixOS/nixpkgs/commit/f6489b77dbc9160926c73875570990b83a7ed880) pretendard: 1.3.8 -> 1.3.9
* [`8f68c2d1`](https://github.com/NixOS/nixpkgs/commit/8f68c2d142d65388f5252cd0266c7aa60096902f) geph.{cli,gui}: 4.7.8 -> 4.10.1
* [`b3f34128`](https://github.com/NixOS/nixpkgs/commit/b3f341285692fa0dbd8e6566204ab31c8e2300a8) python310Packages.globus-sdk: 3.29.0 -> 3.31.0
* [`0a04df53`](https://github.com/NixOS/nixpkgs/commit/0a04df5301cb9092a12b72158db18a98fac14c9d) python310Packages.gocardless-pro: 1.47.0 -> 1.48.0
* [`c240d63c`](https://github.com/NixOS/nixpkgs/commit/c240d63ceda632c22ea6787ab771f4e798c22a54) heroic: fix infinite loop when starting some games
* [`127a0140`](https://github.com/NixOS/nixpkgs/commit/127a01401bcb39b4a906feedb186116d71e7b1d9) legendary-gl: 0.20.33 -> unstable-2023-10-14
* [`f901e1e6`](https://github.com/NixOS/nixpkgs/commit/f901e1e6d8ebc14d21770380e4ed4e71d69221f1) python311Packages.alexapy: 1.27.7 -> 1.27.8
* [`f9c8e76f`](https://github.com/NixOS/nixpkgs/commit/f9c8e76f6352cce44371c47ba52caf3d407fcfe0) python311Packages.boschshcpy: 0.2.73 -> 0.2.75
* [`6e24c2a4`](https://github.com/NixOS/nixpkgs/commit/6e24c2a4e85a11a19f98168c147cc6a06afb5b5f) python311Packages.dvclive: 3.1.0 -> 3.2.0
* [`3dcd4909`](https://github.com/NixOS/nixpkgs/commit/3dcd49096a9fd016edb36d914dc29d5ec47c0473) python311Packages.aiocomelit: 0.3.0 -> 0.3.1
* [`bf6b60a5`](https://github.com/NixOS/nixpkgs/commit/bf6b60a5da8dd72bef72cd61cdd791adc7cf781c) python311Packages.amqp: 5.1.1 -> 5.2.0
* [`82672ae0`](https://github.com/NixOS/nixpkgs/commit/82672ae0d5d3f3ca300554a3c69c9a1d31b71b02) python311Packages.amqp: add changelog to meta
* [`e277b265`](https://github.com/NixOS/nixpkgs/commit/e277b2651ed15638d460efda5ff902fdfbf539be) python311Packages.amqp: update disabled
* [`df984012`](https://github.com/NixOS/nixpkgs/commit/df984012e14689b41a758d1e6d4ed46618005ae3) python311Packages.blinkpy: 0.22.2 -> 0.22.3
* [`8aa7363f`](https://github.com/NixOS/nixpkgs/commit/8aa7363f3a0ab5044ea9c4bb31936eba54f8cce2) python311Packages.evohome-async: 0.4.3 -> 0.4.4
* [`8c931598`](https://github.com/NixOS/nixpkgs/commit/8c931598f1f7643129b340b011349ac1148f58c6) python311Packages.meshtastic: 2.2.11 -> 2.2.12
* [`05a969ac`](https://github.com/NixOS/nixpkgs/commit/05a969ac9867b4bcd0288d0c671bb96d6d48363c) python311Packages.lsassy: 3.1.8 -> 3.1.9
* [`132dadc9`](https://github.com/NixOS/nixpkgs/commit/132dadc9f5eb78df3123f6530fa60eca67e8cdec) python311Packages.rns: 0.6.5 -> 0.6.6
* [`d836219c`](https://github.com/NixOS/nixpkgs/commit/d836219cf80566344afafdebf5bc85e1ffddbb57) python311Packages.publicsuffixlist: 0.10.0.20231104 -> 0.10.0.20231105
* [`ad9ec542`](https://github.com/NixOS/nixpkgs/commit/ad9ec542d93124abf02a323e89c5f00ef62a6ded) python311Packages.plugwise: 0.34.4 -> 0.34.5
* [`c14537f6`](https://github.com/NixOS/nixpkgs/commit/c14537f6b34e67eeef6c707ed4fa4740ceb140c3) python311Packages.pyoverkiz: 1.12.1 -> 1.12.2
* [`f984eede`](https://github.com/NixOS/nixpkgs/commit/f984eede065441dd460ae8af6eb4969d20b71d2e) python311Packages.pycep-parser: 0.4.1 -> 0.4.2
* [`cbec227f`](https://github.com/NixOS/nixpkgs/commit/cbec227fed3c816b66d2eb09e1fe2337f804403f) python311Packages.pysml: 0.1.0 -> 0.1.1
* [`4854a493`](https://github.com/NixOS/nixpkgs/commit/4854a49301ddb6d232c5f785e94a2177104f4309) python311Packages.tplink-omada-client: 1.3.5 -> 1.3.6
* [`758ebe76`](https://github.com/NixOS/nixpkgs/commit/758ebe76e27a04a29cc189957665650095aecad2) python311Packages.tldextract: 5.0.1 -> 5.1.0
* [`ffe3a853`](https://github.com/NixOS/nixpkgs/commit/ffe3a8533b377af3dc58dad84557919c277d66c7) pb: 0.1.0 -> 0.2.0
* [`daeffe3a`](https://github.com/NixOS/nixpkgs/commit/daeffe3a43a4803adf3989d8b5fe8f5366d53c7b) python310Packages.fschat: 0.2.30 -> 0.2.32
* [`338af8db`](https://github.com/NixOS/nixpkgs/commit/338af8dbeb6aa5681aa1a0ebb798d154265aa08d) python311Packages.skodaconnect: 1.3.7 -> 1.3.8
* [`7e1ea962`](https://github.com/NixOS/nixpkgs/commit/7e1ea9625b157aec14c5abe8d83d097ff4188206) vaultwarden: 1.29.2 -> 1.30.0
* [`e2898bc4`](https://github.com/NixOS/nixpkgs/commit/e2898bc40dbdabb2c673edcde8dccbf3f14d03d6) vaultwarden.webvault: 2023.7.1 -> 2023.10.0
* [`d0488cd8`](https://github.com/NixOS/nixpkgs/commit/d0488cd805b4152b84bdb7436553032f269093e9) python310Packages.gptcache: 0.1.41 -> 0.1.42
* [`b19deb31`](https://github.com/NixOS/nixpkgs/commit/b19deb31c377b9b6e67296bfdf946a439f4019ff) autokey: 0.95.10 -> 0.96.0
* [`49f44489`](https://github.com/NixOS/nixpkgs/commit/49f444897b1d53e7a0408449773f66f830532a61) syncoid: disable PrivateUsers in systemd unit
* [`45b43c95`](https://github.com/NixOS/nixpkgs/commit/45b43c95ae6f92289c9d0d11629ad08a166d468e) python310Packages.greeneye-monitor: 5.0 -> 5.0.1
* [`cac8c76f`](https://github.com/NixOS/nixpkgs/commit/cac8c76f21fccba39376504e18c23f7e18fd8419) lua-rtoml: init 0.2
* [`271b097d`](https://github.com/NixOS/nixpkgs/commit/271b097d249399613fd9a3edfa6eb69e9db43023) rshim-user-space: make bfb-install optional
* [`307ef68a`](https://github.com/NixOS/nixpkgs/commit/307ef68a01a6c2cc6ab932ef765a2909743130a3) mkpasswd: fix build with clang
* [`99f10b4c`](https://github.com/NixOS/nixpkgs/commit/99f10b4ceb4c09f892db68abb8576b52a8c9a6aa) sxhkd: refactor
* [`fd8a8c91`](https://github.com/NixOS/nixpkgs/commit/fd8a8c9160438e002bf471fe2be3411559836060) haskellPackages.ema(-note): Drop maintainership
* [`75dadb2d`](https://github.com/NixOS/nixpkgs/commit/75dadb2dfe1837aef23d2830636674c272d2019a) xosview: migrate to by-name
* [`b9b47db2`](https://github.com/NixOS/nixpkgs/commit/b9b47db21a6858cba7e0525e789a267f13377a7c) xosview: set meta.mainProgram
* [`235bc12b`](https://github.com/NixOS/nixpkgs/commit/235bc12b4f4c88d7c472ad5f052499bee9a00826) xosview: split man output
* [`bbb40f17`](https://github.com/NixOS/nixpkgs/commit/bbb40f1705905ce0abaff24a721e0b44a7bae550) xosview2: migrate to by-name
* [`512cd289`](https://github.com/NixOS/nixpkgs/commit/512cd28980d819e77dbebbe93a5ea22d45971434) xosview2: set meta.mainProgram
* [`16a0d2d4`](https://github.com/NixOS/nixpkgs/commit/16a0d2d4ad922af0fbf72b7264761b56fbfe16e4) xosview2: 2.3.2 -> 2.3.3
* [`7ce9c220`](https://github.com/NixOS/nixpkgs/commit/7ce9c2203d5552b1aa7d56930eb85af06447e3d4) python311Packages.gphoto2: fix setuptools.__version__ build breakage
* [`0b5afd03`](https://github.com/NixOS/nixpkgs/commit/0b5afd03e225a491b0bd76f65000eb686bf294e2) librime: set darwin as support platforms
* [`3e053ee6`](https://github.com/NixOS/nixpkgs/commit/3e053ee6fa7a710ce214d0166be8937df70a559f) python311Packages.jaxopt: 0.8.1 -> 0.8.2
* [`7da6b95c`](https://github.com/NixOS/nixpkgs/commit/7da6b95c27baeb1815cefd1b21fd4cf24baa742d) python310Packages.gspread: 5.11.3 -> 5.12.0
* [`6e1795e1`](https://github.com/NixOS/nixpkgs/commit/6e1795e145f785337ef01d99941fa32d6d40adff) docker-machine-hyperkit: disable on aarch64-darwin
* [`ae5cb919`](https://github.com/NixOS/nixpkgs/commit/ae5cb919f50ca93d9ecdb6b92d67627fecc2ccad) nixos/testing/nodes: Do allow aliases
* [`0c0ddef8`](https://github.com/NixOS/nixpkgs/commit/0c0ddef8dd810888fa4b9167d4ee33b31958508d) python310Packages.hg-evolve: 11.0.2 -> 11.1.0
* [`89fd59c1`](https://github.com/NixOS/nixpkgs/commit/89fd59c12a39fc06ccd54fe04c8ba4c1fa076146) nixos/vagrant-guest: Set `security.sudo-rs.wheelNeedsPassword` too
* [`521a48a7`](https://github.com/NixOS/nixpkgs/commit/521a48a71e8cf72a1366a58319100841b6988653) python310Packages.holoviews: 1.17.1 -> 1.18.0
* [`c5b219ec`](https://github.com/NixOS/nixpkgs/commit/c5b219ec902db9fd069f7f0d6ac7dd864d5d9c47) inkscape: fix runtime error on darwin
* [`2bd1ea64`](https://github.com/NixOS/nixpkgs/commit/2bd1ea64e9cc491213597384b84a5776f68d82b8) python310Packages.httpx-socks: 0.7.8 -> 0.8.0
* [`39795945`](https://github.com/NixOS/nixpkgs/commit/397959453fad26bef2c5b2e7f5761dd23d8784a7) python310Packages.grpcio-reflection: 1.59.0 -> 1.59.2
* [`a29cae70`](https://github.com/NixOS/nixpkgs/commit/a29cae7046d725a77dc2611dfaf2c69fe103f609) python310Packages.grpcio-channelz: 1.59.0 -> 1.59.2
* [`8ab2f095`](https://github.com/NixOS/nixpkgs/commit/8ab2f09522d5aefabf1100b3f59a3bde628cb2b4) nixos/qemu-vm: fix infinite recursion
* [`2e05b5ed`](https://github.com/NixOS/nixpkgs/commit/2e05b5ed7847449296a840f05690ab650351aa58) python310Packages.ignite: 0.4.12 -> 0.4.13
* [`a2333cfa`](https://github.com/NixOS/nixpkgs/commit/a2333cfafbe611eca0118605e35f262f84652128) python310Packages.intellifire4py: 3.1.29 -> 3.1.30
* [`ce6043e5`](https://github.com/NixOS/nixpkgs/commit/ce6043e5f87c6ff3615a92848a80f0959f3db3a6) sing-box: 1.6.0 -> 1.6.1
* [`d9105c28`](https://github.com/NixOS/nixpkgs/commit/d9105c28c8ca979fc1e55ba2f30511cbc36efa5a) nixos/stage-1: create initramfs /lib at build time
* [`87e58fd5`](https://github.com/NixOS/nixpkgs/commit/87e58fd593870eab91022b91c9535632730d7eb6) clamtk: init at 6.16
* [`efff81c0`](https://github.com/NixOS/nixpkgs/commit/efff81c0a1d1ef92ca00094a33b4d0d428e51c3e) neatvnc: 0.7.0 -> 0.7.1
* [`c762d1d7`](https://github.com/NixOS/nixpkgs/commit/c762d1d727168ad970d5c8accb32e00a91d6017d) wayvnc: 0.7.1 -> 0.7.2
* [`509320f0`](https://github.com/NixOS/nixpkgs/commit/509320f015df5fcd4f07e35b68d6799bce031f50) python311Packages.lru-dict: 1.2.0 -> 1.3.0
* [`2ec6f635`](https://github.com/NixOS/nixpkgs/commit/2ec6f635344b634beb6b58137a78df83ab18f95e) haskell.compiler.ghcHEAD: 9.7.20230527 -> 9.9.20231014
* [`24541d3a`](https://github.com/NixOS/nixpkgs/commit/24541d3ab37ee8346de9d8e3f5931e7d1aa74dd0) nvidia-vaapi-driver: 0.0.10 -> 0.0.11
* [`b21b9612`](https://github.com/NixOS/nixpkgs/commit/b21b961274baaf44c19f9705d8bc34f4b168f5ae) amazon-ssm-agent: skip time dependent/flaky test
* [`66ebe121`](https://github.com/NixOS/nixpkgs/commit/66ebe1216377e98b13fc2cc7624bc42d221224fd) python310Packages.jc: 1.23.5 -> 1.23.6
* [`16ff967a`](https://github.com/NixOS/nixpkgs/commit/16ff967abfa4fa20fb9befca81080e2a8d5ec3a3) python310Packages.jug: 2.3.0 -> 2.3.1
* [`a1977eeb`](https://github.com/NixOS/nixpkgs/commit/a1977eebaad503e564db3b3f28d0810a2eee466f) home-assistant: backport litterrobot tests fix
* [`015739d7`](https://github.com/NixOS/nixpkgs/commit/015739d7bffa7da4e923978040a2f7cba6af3270) google-cloud-sdk: 446.0.1 -> 452.0.1 ([nixos/nixpkgs⁠#264589](https://togithub.com/nixos/nixpkgs/issues/264589))
* [`f3ef03d8`](https://github.com/NixOS/nixpkgs/commit/f3ef03d89739e1edb9dde65b0d4a3a19f80c31a3) lsp-plugins: 1.2.12 -> 1.2.13
* [`ad388534`](https://github.com/NixOS/nixpkgs/commit/ad38853459b9e62bffe9af2f326dc5a2933a1666) rsync: fix regression with _FORTIFY_SOURCE=2
* [`6af34413`](https://github.com/NixOS/nixpkgs/commit/6af34413eab157cbd44fa1aed61b59c79bcde609) python311Packages.rchitect: 0.4.2 -> 0.4.4
* [`05c6e556`](https://github.com/NixOS/nixpkgs/commit/05c6e556634ed8f8e58b9b8f067b84a93c659de4) python311Packages.radian: 0.6.7 -> 0.6.8
* [`83bf3ed8`](https://github.com/NixOS/nixpkgs/commit/83bf3ed892ca3d97cacd5bf41b67a185622ad971) trust-dns: 0.23.0 -> 0.24.0
* [`48b56a7d`](https://github.com/NixOS/nixpkgs/commit/48b56a7dd627e8e454c16965863ddf73fffaed58) python310Packages.langsmith: 0.0.53 -> 0.0.57
* [`3f269391`](https://github.com/NixOS/nixpkgs/commit/3f269391c51a180210918994d8e92cb954671273) vlang: 2023.42 -> 2023.44
* [`b2616f0e`](https://github.com/NixOS/nixpkgs/commit/b2616f0e67917fea16cec019c82120d6b03d3515) maintainers: add delta231
* [`9b7de1e6`](https://github.com/NixOS/nixpkgs/commit/9b7de1e6423738985d92b69742a421fd370c2304) vlang: add delta231 as maintainer
* [`eef4e9fb`](https://github.com/NixOS/nixpkgs/commit/eef4e9fb8196989d9ebe96ab1accda1f36d5d6c1) Revert "rsync: fix regression with _FORTIFY_SOURCE=2" ([nixos/nixpkgs⁠#265876](https://togithub.com/nixos/nixpkgs/issues/265876))
* [`1e0bc237`](https://github.com/NixOS/nixpkgs/commit/1e0bc23756226a1a681d2e2db8f3ee1a2e746bd8) piper-phonemize: 2023.9.27-2 -> 2023.11.6-1
* [`6e99e2f4`](https://github.com/NixOS/nixpkgs/commit/6e99e2f4ce22a7c146da47b7b425aad73d740f15) piper-tts: 2023.9.27-1 -> 2023.11.6-1
* [`3f8dbecd`](https://github.com/NixOS/nixpkgs/commit/3f8dbecdd0f2627e0fd1a04ed16efc2e5cc981c7) fishPlugins.fzf-fish: 10.0 -> 10.1
* [`d4c81f85`](https://github.com/NixOS/nixpkgs/commit/d4c81f85cbba852a0daff05973034e80ee190fc8) vaultwarden: fix update-script
* [`4f9009f5`](https://github.com/NixOS/nixpkgs/commit/4f9009f51a4a4685b234568d8912bb7fa816f628) python310Packages.mandown: 1.5.0 -> 1.6.0
* [`c40690db`](https://github.com/NixOS/nixpkgs/commit/c40690dbe0d7f541f89672ad7d62f02c3ecc537e) tippecanoe: 2.19.0 → 2.35.0
* [`9dec7a00`](https://github.com/NixOS/nixpkgs/commit/9dec7a00ad892d14ce2256285c33b00a4ffb34d7) nixos/gnome/at-spi2-core: fix disabling a11y in all contexts
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
