### PR TITLE
niv devenv: update af34c270 -> 14fdefc0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "af34c270e708675c02831c5a4d6d1d3d6efb0854",
-        "sha256": "16agyhnfbsczq3by4r6kcpk5da6b00vig59wqg8sv7v5flkys55c",
+        "rev": "14fdefc0bb80c3d6f3a18a491e33429b4064c371",
+        "sha256": "0iiiwsp7g4f136kj3agmxrpdmi773s0w0aknzx0apr22w352pza6",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/af34c270e708675c02831c5a4d6d1d3d6efb0854.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/14fdefc0bb80c3d6f3a18a491e33429b4064c371.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@af34c270...14fdefc0](https://github.com/cachix/devenv/compare/af34c270e708675c02831c5a4d6d1d3d6efb0854...14fdefc0bb80c3d6f3a18a491e33429b4064c371)

* [`835ef7bb`](https://github.com/cachix/devenv/commit/835ef7bb8fd6794a9daf71c9de0ba80ba48e5261) Update services.md
* [`28c6c507`](https://github.com/cachix/devenv/commit/28c6c507e2594c3c880e64d8991875e0efea5f1f) feat(langs): add Idris language
* [`628ce468`](https://github.com/cachix/devenv/commit/628ce468e1081d866e46aa8e6b2d0aa79a17d563) Auto generate docs/reference/options.md
* [`80e740c7`](https://github.com/cachix/devenv/commit/80e740c7eb91b3d1c82013ec0ba4bfbc9a83734a) Auto generate examples/supported-languages/devenv.nix
