### PR TITLE
niv home-manager: update c067d57f -> 28072118

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c067d57fc4552835987fd7611c3a6741ee32ebd5",
-        "sha256": "0k8z4z8ybzybjw2j0l2gxj83k66sd3k571ni4qr0vyk88ahgrqf1",
+        "rev": "280721186ab75a76537713ec310306f0eba3e407",
+        "sha256": "0qf13vx8nr3c97id0gsmhxdf3kcnfyhc18lfk96qwbwb7lnz0d73",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c067d57fc4552835987fd7611c3a6741ee32ebd5.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/280721186ab75a76537713ec310306f0eba3e407.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c067d57f...28072118](https://github.com/nix-community/home-manager/compare/c067d57fc4552835987fd7611c3a6741ee32ebd5...280721186ab75a76537713ec310306f0eba3e407)

* [`76e7c05f`](https://github.com/nix-community/home-manager/commit/76e7c05f7d3d5ffac219450af824043da52af1cc) home-cursor: fix typo in XDG data directory link
* [`6a844446`](https://github.com/nix-community/home-manager/commit/6a8444467c83c961e2f5ff64fb4f422e303c98d3) systemd: add settings option ([nix-community/home-manager⁠#4276](https://togithub.com/nix-community/home-manager/issues/4276))
* [`858fe2f0`](https://github.com/nix-community/home-manager/commit/858fe2f09a4149a8ec5494a501324a8b97e2e51c) firefox: refactor duplicate profile ID detection
* [`54586daa`](https://github.com/nix-community/home-manager/commit/54586daa59e4d46968fbec498b31bf992e557e43) firefox: add container support
* [`47226ec7`](https://github.com/nix-community/home-manager/commit/47226ec7e791d8080a63c170ab50bf27539117cf) emacs: Remove obsolete socket file workaround
* [`f5182ffc`](https://github.com/nix-community/home-manager/commit/f5182ffc4211860348fc7c78e0ba3a9d36f13aeb) emacs: Fix socket activation
* [`e27be9db`](https://github.com/nix-community/home-manager/commit/e27be9db7b4ae5791f53d241b3661353c51a9677) systemd: avoid creating an empty user.conf
* [`691cbcc0`](https://github.com/nix-community/home-manager/commit/691cbcc03af6ad1b5384c0e0e0b5f2298f58c5ce) k9s: add aliases, plugins, views
* [`d78f6693`](https://github.com/nix-community/home-manager/commit/d78f6693ee382ee3b94bf48f2b0d0034ce2d902b) firefox: add finalPackage read-only option
* [`fad880ea`](https://github.com/nix-community/home-manager/commit/fad880ea934808072cd224152854d4257034bd24) firefox: minor documentation fix
* [`50e582b9`](https://github.com/nix-community/home-manager/commit/50e582b9f91e409ffd2e134017445d376659b32e) swayidle: always restart systemd unit on failure
* [`28072118`](https://github.com/nix-community/home-manager/commit/280721186ab75a76537713ec310306f0eba3e407) firefox: support setting a separate default search engine in private browsing ([nix-community/home-manager⁠#4114](https://togithub.com/nix-community/home-manager/issues/4114))
