### PR TITLE
niv zsh-completions: update a0f027a1 -> 9e341f6a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -192,10 +192,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "a0f027a1de9272d22ce20465d660d7b611f30cf0",
-        "sha256": "158qa0ilkjvszdi847zg86rga7xj6pn3gmd1ncs4sanxgxc3w43k",
+        "rev": "9e341f6a202e83e2dc0a587f4970fa375de84d4e",
+        "sha256": "15y6sl1a9g7rwncdgh6l21h4gawbs0f64jczcfa3gnwgw0f84nqx",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/a0f027a1de9272d22ce20465d660d7b611f30cf0.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/9e341f6a202e83e2dc0a587f4970fa375de84d4e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@a0f027a1...9e341f6a](https://github.com/zsh-users/zsh-completions/compare/a0f027a1de9272d22ce20465d660d7b611f30cf0...9e341f6a202e83e2dc0a587f4970fa375de84d4e)

* [`d04e01fc`](https://github.com/zsh-users/zsh-completions/commit/d04e01fce362d18a7efdf9f1b14cd17780e7f28a) Add -DBUILD_SHARED_LIBS completion for cmake completions
