### PR TITLE
niv zsh-history-substring-search: update 400e58a8 -> 19b88766

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -228,10 +228,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-history-substring-search",
-        "rev": "400e58a87f72ecec14f783fbd29bc6be4ff1641c",
-        "sha256": "0vjw4s0h4sams1a1jg9jx92d6hd2swq4z908nbmmm2qnz212y88r",
+        "rev": "19b887667a155befeb5850f0af46a45cc5311ae2",
+        "sha256": "19whab3ac1j6qryayxs056a5b7clbcanw7k1mb8w4dqh2i7g5zms",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/400e58a87f72ecec14f783fbd29bc6be4ff1641c.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/19b887667a155befeb5850f0af46a45cc5311ae2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for zsh-history-substring-search:
Branch: master
Commits: [zsh-users/zsh-history-substring-search@400e58a8...19b88766](https://github.com/zsh-users/zsh-history-substring-search/compare/400e58a87f72ecec14f783fbd29bc6be4ff1641c...19b887667a155befeb5850f0af46a45cc5311ae2)

* [`da5f0673`](https://github.com/zsh-users/zsh-history-substring-search/commit/da5f0673b9a464c702f042a8a18d8ce2d08ac6e8) fix search match highlight with latest z-sy-h
* [`3bbc5a8c`](https://github.com/zsh-users/zsh-history-substring-search/commit/3bbc5a8cfa26f238d16609a6f1fab3e40c74bf8c) replace sourcing method with `exec zsh`
* [`591ca332`](https://github.com/zsh-users/zsh-history-substring-search/commit/591ca3326adfad8b444ea52dc1337d936b79a0c7) chore: update readme
* [`2e28e232`](https://github.com/zsh-users/zsh-history-substring-search/commit/2e28e23261b661bbcbadf21022098f17fb73a466) fix: line wrap
* [`19b88766`](https://github.com/zsh-users/zsh-history-substring-search/commit/19b887667a155befeb5850f0af46a45cc5311ae2) Use brew to determine prefix
