### PR TITLE
niv nixpkgs: update 8423b2df -> 3f21a22b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8423b2dff7b10463eb97f9242bd62a1ff8d2ee3e",
-        "sha256": "1qx9zq73hbrihlf2m4daw2ad4j8rjn3jbpn2y9fzmxnr40lic2hl",
+        "rev": "3f21a22b5aafefa1845dec6f4a378a8f53d8681c",
+        "sha256": "15y8k3hazg91kscbmn7dy6m0q6zvmhlvvhg97gcl5kw87y0svzxk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/8423b2dff7b10463eb97f9242bd62a1ff8d2ee3e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/3f21a22b5aafefa1845dec6f4a378a8f53d8681c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@8423b2df...3f21a22b](https://github.com/nixos/nixpkgs/compare/8423b2dff7b10463eb97f9242bd62a1ff8d2ee3e...3f21a22b5aafefa1845dec6f4a378a8f53d8681c)

* [`abbf2508`](https://github.com/NixOS/nixpkgs/commit/abbf25081d596e5fa46d6fe6db6bd1af1963de3e) joomscan: init at unstable-2021-06-08
* [`214d3739`](https://github.com/NixOS/nixpkgs/commit/214d37395e66c2d3395ce06ecc702b1beafc2eda) timidity: fix config location
* [`02c88887`](https://github.com/NixOS/nixpkgs/commit/02c8888784f54704d9b6896e944144044db3f91a) added myself as a maintainer
* [`317a5d65`](https://github.com/NixOS/nixpkgs/commit/317a5d653f390317706c0cbf0527c107862c8186) tesseract5: update dependencies
* [`8224ddea`](https://github.com/NixOS/nixpkgs/commit/8224ddeae18dce3dae92ccc0daaa082f8085b4bc) nixos/jitsi-meet: updated prosody config
* [`2465ddb8`](https://github.com/NixOS/nixpkgs/commit/2465ddb85b90d1f06e888dcc3473aeaae13cbd5f) jitsi-excalidraw: init at x17
* [`84ab09c3`](https://github.com/NixOS/nixpkgs/commit/84ab09c3b12ce4691b8ab5a2c48b8a8801f1d72a) nixos/jitsi-meet: support Excalidraw whiteboard
* [`1f438f85`](https://github.com/NixOS/nixpkgs/commit/1f438f858fea2cb895c337ff22e5d9c199e31176) nixos/jitsi-meet: support secure domain setup
* [`47a130b0`](https://github.com/NixOS/nixpkgs/commit/47a130b0858702e8d3215e3545078cdf1dbff182) linux.configfile: remove unused kernelTarget attr
* [`468f5b68`](https://github.com/NixOS/nixpkgs/commit/468f5b689061e1e8ca54d882a3330d4ba225f295) linuxManualConfig: fix inaccurate FIXME comment
* [`549c83e4`](https://github.com/NixOS/nixpkgs/commit/549c83e491e411dc0a6b2146daf6634f9fde417d) maintainers: add marcovergueira
* [`b4c4f471`](https://github.com/NixOS/nixpkgs/commit/b4c4f471a6d8bb0689e0310f0418bdd3ff489ee9) dcp375cw{lpr,-cupswrapper}: init at 1.1.3
* [`8f07186b`](https://github.com/NixOS/nixpkgs/commit/8f07186bb340ba23e120806953ee9005fa5fe032) nixos/parsedmarc: fix validation for smtp
* [`601e2035`](https://github.com/NixOS/nixpkgs/commit/601e20354eef924e99f6d0bdebcca94ac4fbc2e7) nixos/pixiecore: fix port 4011 from tcp to udp
* [`d0c42dfa`](https://github.com/NixOS/nixpkgs/commit/d0c42dfaa7db23fdc1b62b3632ef464c968bb11c) pam: bind Linux-PAM locales from pam-specific folder (upstream patch)
* [`9fdf395c`](https://github.com/NixOS/nixpkgs/commit/9fdf395cc74f67644509424922815b238645fa16) makeStaticBinaries: Set -DCMAKE_SKIP_INSTALL_RPATH
* [`14b8b406`](https://github.com/NixOS/nixpkgs/commit/14b8b406d913d4091f2632b13e256204e3ab6deb) Xaw3d: 1.6.3 -> 1.6.5
* [`cb05cb7c`](https://github.com/NixOS/nixpkgs/commit/cb05cb7cb90c69c9437058144dcc25f0eac2a2b0) python310Packages.pikepdf: 8.3.0 -> 8.4.0
* [`9ced81cf`](https://github.com/NixOS/nixpkgs/commit/9ced81cfbd5cd2fbab74a7368a09bcc924ce6353) glibc: use libutil.a when libutil.so.1 is unavailable
* [`9b2ca17a`](https://github.com/NixOS/nixpkgs/commit/9b2ca17abcd2374bc684539a180aa75f8a063dd0) npmHooks.npmInstallHook: avoid script output in npm pack command
* [`9b0f869d`](https://github.com/NixOS/nixpkgs/commit/9b0f869de891663c913b7c85b9e56fd67cdbdd1d) kega-fusion: add missing libGL dependency
* [`9d79ac11`](https://github.com/NixOS/nixpkgs/commit/9d79ac1125ea7cbe1819d2545b68da18a18c237e) python3Packages.pyopenssl: fix `postPatch`
* [`8ce75029`](https://github.com/NixOS/nixpkgs/commit/8ce75029303da343311e6204aeb3456986ab2e87) libglvnd: 1.6.0 -> 1.7.0
* [`17398e4f`](https://github.com/NixOS/nixpkgs/commit/17398e4ff31415b0cefb3273325ed08bddec5a68) systemd: suggest using `--runtime` on `systemctl edit`
* [`6ca008dd`](https://github.com/NixOS/nixpkgs/commit/6ca008ddd56adf171cfdff15dd049e460db198ce) libopenmpt: 0.7.2 -> 0.7.3
* [`6cb233d7`](https://github.com/NixOS/nixpkgs/commit/6cb233d707877d1a4fad5624a28cafa9db8640d4) spicetify-cli: add default CustomApps, Extensions, Themes
* [`a08a688b`](https://github.com/NixOS/nixpkgs/commit/a08a688b37257f6a6d657da2443f8d569271f388) libpfm: Fix windows build
* [`90b1bbbb`](https://github.com/NixOS/nixpkgs/commit/90b1bbbbac8def5c78e1f640a8eb5594547aeda8) python310Packages.pluggy: 1.2.0 -> 1.3.0
* [`f8f4cb2b`](https://github.com/NixOS/nixpkgs/commit/f8f4cb2b2665c9bc6aecb143f96c49034df46299) linux_xanmod: remove explicit pstate flag
* [`5cd89013`](https://github.com/NixOS/nixpkgs/commit/5cd89013b60fb433324d8e0a823ef10a8c45de10) linux_xanmod: remove explicit FUTEX flags
* [`04f543f9`](https://github.com/NixOS/nixpkgs/commit/04f543f913aa82d710def9af06572e34b30b1e4b) linux_xanmod: don't enable FQ_PIE
* [`1400b6e9`](https://github.com/NixOS/nixpkgs/commit/1400b6e9ece28ae97362f85188362b942e70dc32) linux_xanmod: add note about xanmod-specific kconfig flags
* [`45c01771`](https://github.com/NixOS/nixpkgs/commit/45c01771fb4644601bb21b5da82856500e468a3f) linux/common-config: enable FSCACHE_STATS
* [`c7b27743`](https://github.com/NixOS/nixpkgs/commit/c7b277439df34919ef24eae1335f689d03dec4ba) python310Packages.flask-cors: 3.0.10 -> 4.0.0
* [`2b49d460`](https://github.com/NixOS/nixpkgs/commit/2b49d460baaf931b3491e1d00a457036644f6877) libdeflate: 1.18 -> 1.19
* [`f1159b8c`](https://github.com/NixOS/nixpkgs/commit/f1159b8c5841e2ea31bad7e78c2df10732c7add2) python311Packages.pycyphal: init at 1.15.2
* [`7b13a350`](https://github.com/NixOS/nixpkgs/commit/7b13a350aa11dac70b962db34e3ddd2e110d2e6a) python311Packages.pyuavcan: add deprecation warning
* [`128512d5`](https://github.com/NixOS/nixpkgs/commit/128512d54bf689da895b20c26058a2e1577b10d6) python311Packages.pycyphal: init at 1.15.2
* [`0f465f79`](https://github.com/NixOS/nixpkgs/commit/0f465f79819cf1726a9cd0e60496cedf4559e858) yakut: init at 0.13.0
* [`bcbdb800`](https://github.com/NixOS/nixpkgs/commit/bcbdb800cf7659d6ff36ac114121a056fe8c9656) llvmPackages: 11 -> 16 on Darwin
* [`9ed7bfe4`](https://github.com/NixOS/nixpkgs/commit/9ed7bfe46bf193e55a6fd8ae89dfe54b4dca2c18) llvmPackages: 11 -> 16 on Linux
* [`ebf3de48`](https://github.com/NixOS/nixpkgs/commit/ebf3de48cbd26aa53941153539de38697782bce9) webrtc-audio-processing_1: add `dev` output
* [`216eea11`](https://github.com/NixOS/nixpkgs/commit/216eea110163a7b2eb1700f5bb331661b785d78e) imlib2: 1.12.0 -> 1.12.1
* [`5a881224`](https://github.com/NixOS/nixpkgs/commit/5a881224c5cd34deb1f2f8e24140866e66b310fc) openssl_3_1: init at 3.1.1
* [`1d17df8f`](https://github.com/NixOS/nixpkgs/commit/1d17df8f2d025f934083059186df0f8e83a0bc2e) alsa-ucm-conf: 1.2.9 -> 1.2.10
* [`1bd767f5`](https://github.com/NixOS/nixpkgs/commit/1bd767f56b3bd666721f0f1ae90328406dcfee37) openssl: use hash, add thillux as maintainer
* [`9cf9b9d8`](https://github.com/NixOS/nixpkgs/commit/9cf9b9d897faa0ad9322a764c823cd5f2126ec63) openssl_3_1: 3.1.1 -> 3.1.2
* [`f5449675`](https://github.com/NixOS/nixpkgs/commit/f5449675faa50feee5365ff9e24f7cedb1ce8be1) openssl_3_1: 3.1.2 -> 3.1.3
* [`998e6973`](https://github.com/NixOS/nixpkgs/commit/998e697358b21e82d79950d7454a5e4d642a3833) openfec: 1.4.2 -> 1.4.2.9
* [`d4758c3f`](https://github.com/NixOS/nixpkgs/commit/d4758c3f27804693ebb6ddce2e9f6624b3371b08) libvterm-neovim: 0.3.2 -> 0.3.3
* [`6715b097`](https://github.com/NixOS/nixpkgs/commit/6715b097e6b1a6649141877af7d0b60f12468ad1) libwacom: 2.7.0 -> 2.8.0
* [`69a84207`](https://github.com/NixOS/nixpkgs/commit/69a8420777252dee75d7463b4e1cc94f8bb8f2b3) openblas: 0.3.21 -> 0.3.24
* [`45fa4a88`](https://github.com/NixOS/nixpkgs/commit/45fa4a8863da155eff19971eb0c51bfaf99ef400) nodejs: use system ca certificate store
* [`e00f77c7`](https://github.com/NixOS/nixpkgs/commit/e00f77c7b83b420a42add5f16ae83fb5122300f0) fluidsynth: 2.3.3 -> 2.3.4
* [`69c24679`](https://github.com/NixOS/nixpkgs/commit/69c24679d695d06e22a544cbed3bd10feff63c5a) libffi: remove --disable-exec-static-tramp flag
* [`55e0f80e`](https://github.com/NixOS/nixpkgs/commit/55e0f80e372f2bb45b87035c7a4ac16b0ba40e14) game-music-emu: disable UBSAN
* [`2e45dd5b`](https://github.com/NixOS/nixpkgs/commit/2e45dd5b0d32c6adff4a8408c8d985ba3ae5ae47) game-music-emu: add zlib dependency
* [`4c6fd59f`](https://github.com/NixOS/nixpkgs/commit/4c6fd59fcd6a3c5235ed4f946313329cefbed818) cc-wrapper: ensure NIX_HARDENING_ENABLE fortify3 implies fortify too
* [`7d810bf8`](https://github.com/NixOS/nixpkgs/commit/7d810bf8a43a3f10a476e7475861fab00e160ff8) neovim: enable structured attributes
* [`61b61a20`](https://github.com/NixOS/nixpkgs/commit/61b61a20fc6ea7e478488d0014e38bda833f7080) neovim.tests.nvim_autowrap: remove warning
* [`6783b22c`](https://github.com/NixOS/nixpkgs/commit/6783b22c9e888af4c0b5250be52865aa481f0c9f) rustc: support clang-based stdenv
* [`c9900619`](https://github.com/NixOS/nixpkgs/commit/c99006196213485409bce27b211094cd77491add) jbig2dec: 0.19 -> 0.20
* [`10cb2bd4`](https://github.com/NixOS/nixpkgs/commit/10cb2bd443b6ef50a1b9c5f5ef1e6db7d93cde62) autoPatchelfHook: add `patchelfFlags` option
* [`28939022`](https://github.com/NixOS/nixpkgs/commit/2893902201e2cb2cebaaf3a8da61622675f20887) firefox-bin: remove workaround
* [`8318df5b`](https://github.com/NixOS/nixpkgs/commit/8318df5b630579a910fd2fd3ae46bdfec37d1ef4) buildDotnetModule: fix running fetch-deps with no nugetDeps defined.
* [`f1cc116e`](https://github.com/NixOS/nixpkgs/commit/f1cc116e3db5cff8b92ec30ec5283de966e22066) buildDotnetModule: make docs more clear on how to generate nugetDeps for the first time
* [`48f25989`](https://github.com/NixOS/nixpkgs/commit/48f25989c32ee63eb19f9fa7fc68c09ce9a8aef8) python3Packages.sphinxHook: Avoid propagating sphinx
* [`ff9db6e3`](https://github.com/NixOS/nixpkgs/commit/ff9db6e3ecc7e603bfa9b196993e8e2da6eaf3b8) openblas: drop loongarch64 patch
* [`7a27e224`](https://github.com/NixOS/nixpkgs/commit/7a27e224ca121711ca0d5b2d9af5f98100393b78) libglvnd: static library is unsupported
* [`4d71dbe4`](https://github.com/NixOS/nixpkgs/commit/4d71dbe492b3654c8e6745b2ff520f91969722f6) openexr_3: 3.2.0 -> 3.2.1
* [`edd561ab`](https://github.com/NixOS/nixpkgs/commit/edd561abce79cdd090e8ed414238bc397d1a38d8) python311: 3.11.5 -> 3.11.6
* [`fad90186`](https://github.com/NixOS/nixpkgs/commit/fad90186f922aa862ef5929e05dd24d50d49ec1f) linuxHeaders: revert accidental `struct sockaddr_ll` size change
* [`6d01ee43`](https://github.com/NixOS/nixpkgs/commit/6d01ee4328c6a55c56d4ff639489064f8a8c79cd) luaPackages.mpack: 1.0.9 -> 1.0.10
* [`efdba2d7`](https://github.com/NixOS/nixpkgs/commit/efdba2d7be656c63bdfce7319b1b62332098cb46) xorg.libX11: 1.8.6 -> 1.8.7
* [`6a935b14`](https://github.com/NixOS/nixpkgs/commit/6a935b14c1a5866e502cccf3af7d3473e4ef9a7e) xorg.libXpm: 3.5.16 -> 3.5.17
* [`968607c8`](https://github.com/NixOS/nixpkgs/commit/968607c81278a7b9abd773f13d07f267e03d24e4) bcachefs-tools: remove unnecessary dependency on valgrind
* [`f278e60b`](https://github.com/NixOS/nixpkgs/commit/f278e60b5cbe9d353904674448a60abd56de112b) bcachefs-tools: reintroduce format-security error.
* [`e10bb108`](https://github.com/NixOS/nixpkgs/commit/e10bb1082a5aba0d9b9e298336df68bbae6dfc7d) bcachefs: enable ftrace for upstream bug reports
* [`6c1a24a6`](https://github.com/NixOS/nixpkgs/commit/6c1a24a6eaf0df82c06f2e5925dbf09fcf3d59c3) bcachefs: Add YellowOnion as maintainer
* [`d6bf8b47`](https://github.com/NixOS/nixpkgs/commit/d6bf8b47ece5ed435cc0e66725fc7afe0ee1550b) bcachefs: 2023-06-28 -> 2023-09-29
* [`1048867f`](https://github.com/NixOS/nixpkgs/commit/1048867fe06f9473a51a7d33e95aaf5b0fefc0cc) bcachefs: fix version not showing correctly
* [`98b8e0de`](https://github.com/NixOS/nixpkgs/commit/98b8e0dee980244fc632178866b04888387ed166) bcachefs: revert using json to hold bcachefs commits/hashes
* [`5660d0f7`](https://github.com/NixOS/nixpkgs/commit/5660d0f73b788104c9e8b8fc6992671d9dc8ec5f) SDL2: 2.28.3 -> 2.28.4
* [`7646ffb8`](https://github.com/NixOS/nixpkgs/commit/7646ffb8bde3fd14ce823aea38bfd2c26d6aec26) systemd: fix RuntimeError issue when building for armv7l and riscv64
* [`caa3d9d7`](https://github.com/NixOS/nixpkgs/commit/caa3d9d75d10e04acca17826624243cfaf922abb) glibc: 2.38-23 -> 2.38-27
* [`334f853e`](https://github.com/NixOS/nixpkgs/commit/334f853e6862d961c0654a8f4eb381497d81f678) python311Packages.boto3: 1.28.9 -> 1.28.57
* [`3ef2a7c6`](https://github.com/NixOS/nixpkgs/commit/3ef2a7c67050361d81a3cd3cdfc6282fefcb350b) python311Packages.botocore: 1.31.48 -> 1.31.57
* [`851fcadd`](https://github.com/NixOS/nixpkgs/commit/851fcadd85a72423c10045d4ff65bf46b26fbe78) python311Packages.s3transfer: 0.6.2 -> 0.7.0
* [`f759198a`](https://github.com/NixOS/nixpkgs/commit/f759198a3bfe8ed34e73de48d154c9cc97b126da) awscli: 1.29.9 -> 1.29.57
* [`c3688d9b`](https://github.com/NixOS/nixpkgs/commit/c3688d9bb6b3ff2e43c4384bb06221af01e0b39e) awscli: add anthonyroussel to maintainers
* [`4a5241e7`](https://github.com/NixOS/nixpkgs/commit/4a5241e7522493cb13011fb3a27a9b6d4228a229) awscli: add passthru.tests.version, passthru.updateScript
* [`53c5f084`](https://github.com/NixOS/nixpkgs/commit/53c5f084151264701e6332f1606bb892bf9c3574) stdenv: refactor `.attrs.sh` detection
* [`8bc5104a`](https://github.com/NixOS/nixpkgs/commit/8bc5104a6e6a6acf09f9d7ddf1c6a9293efb405a) treewide: refactor `.attrs.sh` detection
* [`c8f5c30c`](https://github.com/NixOS/nixpkgs/commit/c8f5c30c37e60d2c96c525d9df0917f852e7f5ad) pkgs/build-support: refactor drvs using `__structuredAttrs = true`
* [`53717676`](https://github.com/NixOS/nixpkgs/commit/537176760c8fab063ba1389d83b7b2da3857ee99) gcc12, gcc13: always mangle __FILE__ into invalid store path
* [`cfbbd0b3`](https://github.com/NixOS/nixpkgs/commit/cfbbd0b36e4d031b83b8392c4d34bf5fce00016b) jellyseerr: 1.4.1 -> 1.7.0
* [`912c6056`](https://github.com/NixOS/nixpkgs/commit/912c60564334a81af7cfd4a38f9eed44d7770fa9) mesa: don't depend on build python
* [`13a4690d`](https://github.com/NixOS/nixpkgs/commit/13a4690d0d9f140eeb2d253184b5271d3010469e) cc-wrapper: Use MacOS compatible mktemp command
* [`b1367e99`](https://github.com/NixOS/nixpkgs/commit/b1367e992ad341a7fcbe2ea9a63e6bed01c59f3f) mpg123: 1.31.3 -> 1.32.3
* [`4f2bb1cc`](https://github.com/NixOS/nixpkgs/commit/4f2bb1ccb30ca873ce6ac9273997c3ac228f50fa) audiofile: fix build with clang 16
* [`c0ade641`](https://github.com/NixOS/nixpkgs/commit/c0ade641884aa2fc6bcaf7a2a09aa2de3311c090) libiscsi: fix build on clang 16
* [`6470afff`](https://github.com/NixOS/nixpkgs/commit/6470affffe52fb278c447ce13f1d4a13116d44eb) qt5.full: remove qtwebkit
* [`bdbf7062`](https://github.com/NixOS/nixpkgs/commit/bdbf70625a6f642b678d81b75a1467bafea163e5) qt5: 5.15.10 -> 5.15.11
* [`469b6eae`](https://github.com/NixOS/nixpkgs/commit/469b6eae8a9a9ec6b85a3147ddb3ec659c267b50) pipewire: 0.3.80 -> 0.3.81
* [`5d1e268a`](https://github.com/NixOS/nixpkgs/commit/5d1e268aec3cbea1847c1bc551ef8578398e3ae0) grpc: Work around clang limitations
* [`60ee8647`](https://github.com/NixOS/nixpkgs/commit/60ee8647e1b258cae0f0060981a248eb75c8f35f) s2n-tls: 1.3.50 -> 1.3.54
* [`6765f082`](https://github.com/NixOS/nixpkgs/commit/6765f08294a1e3b82fb7d5281c2d4e65e65c9e5a) xkeyboard_config: 2.39 -> 2.40
* [`bd54c236`](https://github.com/NixOS/nixpkgs/commit/bd54c2369ccbd710ae7a0cb879d6a3207ba2b0f4) dnsmasq: enable nftset support
* [`fc7cadb5`](https://github.com/NixOS/nixpkgs/commit/fc7cadb57a30ca96453f606588147887cba96d0b) shadow: 4.14.0 -> 4.14.1
* [`922c5300`](https://github.com/NixOS/nixpkgs/commit/922c530087f04e5f076addf274628e0bd5d4d4da) transmission_4: fix web UI path in AppArmor rules
* [`71ab0b6c`](https://github.com/NixOS/nixpkgs/commit/71ab0b6c1c94fdc5d702bbe401bbf841f0d2257b) transmission_4: add option to allow additional paths in AppArmor rules
* [`f9c6b6f4`](https://github.com/NixOS/nixpkgs/commit/f9c6b6f43af34da1419d4d0c0d3da43b237ec7a4) xorg.libXrandr: 1.5.3 -> 1.5.4
* [`69308fb3`](https://github.com/NixOS/nixpkgs/commit/69308fb32f6fcd98d92b4b0e9063d1d66d466e50) shared-mime-info: 2.2 -> 2.3
* [`0278da4d`](https://github.com/NixOS/nixpkgs/commit/0278da4d36872304136b01e17047a365b7712c40) bluez: 5.66 -> 5.70
* [`c5b7e4bd`](https://github.com/NixOS/nixpkgs/commit/c5b7e4bdd69436ef01addafcf3ede7e4d9d4bdad) networkmanager: 1.44.0 -> 1.44.2
* [`d669dfbb`](https://github.com/NixOS/nixpkgs/commit/d669dfbb0d48353d703a076bfe8c801a64f731fc) hwdata: 0.374 -> 0.375
* [`10f35ff0`](https://github.com/NixOS/nixpkgs/commit/10f35ff05df1f3c1f1c2a04f8dcb525950f70e8a) meson.setupHook: prefer meson commands over ninja
* [`42298883`](https://github.com/NixOS/nixpkgs/commit/422988830438de3c381ed1b527993069b6a2c235) paulstretch: make patch urls reproducible
* [`fde06111`](https://github.com/NixOS/nixpkgs/commit/fde061116af7916e3c56fffcbc467d1cddfa8550) autotrace: make patch urls reproducible
* [`1fb57652`](https://github.com/NixOS/nixpkgs/commit/1fb576525324d6a11f302fda9b6a84bd2fdb102e) volnoti: make patch urls reproducible
* [`17ed52d5`](https://github.com/NixOS/nixpkgs/commit/17ed52d535e5536c0b3530ed4b9fd6fecefc19c2) neomutt: make patch urls reproducible
* [`2376191f`](https://github.com/NixOS/nixpkgs/commit/2376191fc9aa06170326a7bfadc6f0d894e95738) freenet: make patch urls reproducible
* [`7cc9e7c2`](https://github.com/NixOS/nixpkgs/commit/7cc9e7c28ecef3021462ae77b58f9640ff66f476) vampire: make patch urls reproducible
* [`eef61049`](https://github.com/NixOS/nixpkgs/commit/eef610491743bcbcbf2cff58ac1a7b7b3dcd12e8) hub: make patch urls reproducible
* [`789d8bab`](https://github.com/NixOS/nixpkgs/commit/789d8bab2f2d2fe99df97b3fc02df863ed4c6454) kodi: make patch urls reproducible
* [`7f21a996`](https://github.com/NixOS/nixpkgs/commit/7f21a99614f5d2891d89b2de4f1e4e3bcf5136a8) libcbor: move headers out to "dev" output
* [`92c96af1`](https://github.com/NixOS/nixpkgs/commit/92c96af1f1af20c734c52799f4778f29c25c2f52) meson: 1.2.1 -> 1.2.2
* [`9622ba47`](https://github.com/NixOS/nixpkgs/commit/9622ba47e9c86933302d4e039bcfbb97c4b0e9ec) mjpegtools: fix build with clang 16
* [`68d0dfd0`](https://github.com/NixOS/nixpkgs/commit/68d0dfd07b54692bc3172d12fe153671f69ff946) expect: fix build with clang 16
* [`c11cb00a`](https://github.com/NixOS/nixpkgs/commit/c11cb00a1e86d63b4d6599fe774e22b1c02f10c9) rustc: 1.72.1 -> 1.73.0
* [`11aa79c4`](https://github.com/NixOS/nixpkgs/commit/11aa79c4c0f3f999c869101b99f72ad4dfe02d66) python310Packages.cython_3: 3.0.2 -> 3.0.3
* [`e5309904`](https://github.com/NixOS/nixpkgs/commit/e530990460b38a22aa2ed9ce3d7367b07ff036f6) rapidfuzz-cpp: 2.0.0 -> 2.1.1
* [`122bab65`](https://github.com/NixOS/nixpkgs/commit/122bab654c08486928fbe36752181c8bc27315da) python310Packages.rapidfuzz: 3.3.1 -> 3.4.0
* [`8793a0b5`](https://github.com/NixOS/nixpkgs/commit/8793a0b570760b07d289cbecae16f7f5e8aa951c) binaryen: 114 -> 116
* [`509feb2e`](https://github.com/NixOS/nixpkgs/commit/509feb2e9b0127a8b4dd3229001dddbdd1fbafea) llvmPackages_16.lld: backport table-base patch
* [`9d12e677`](https://github.com/NixOS/nixpkgs/commit/9d12e6771c37d977ed064ec48feee926d8680fce) emscripten: 3.1.45 -> 3.1.47
* [`d887ff6f`](https://github.com/NixOS/nixpkgs/commit/d887ff6f61d79f2bc6afd31a8f3328bfefc76d8f) indent: Use depsBuildBuild instead of pkgsBuildBuild
* [`a98b5844`](https://github.com/NixOS/nixpkgs/commit/a98b58442cee1afe26238090b75eb3750152b484) chayang: Use depsBuildBuild instead of pkgsBuildBuild
* [`7f262b68`](https://github.com/NixOS/nixpkgs/commit/7f262b6859d906516cb480b790f52c5ea23e5162) emscripten: ensure node_modules are available
* [`a590bf11`](https://github.com/NixOS/nixpkgs/commit/a590bf11d1d87c58fdcbf024e389f54a9e25e97c) libva: 2.19.0 -> 2.20.0
* [`72729d32`](https://github.com/NixOS/nixpkgs/commit/72729d323f3bfa859e7012a9cb3bcf6d4bbe3dc0) neovim: run hooks for build phase
* [`b8056984`](https://github.com/NixOS/nixpkgs/commit/b80569845a1b6c8447df07ea4376c54e310e3b6c) maturin: 1.2.3 -> 1.3.0
* [`15366eb5`](https://github.com/NixOS/nixpkgs/commit/15366eb57dfc1d89fd718c156df7773180af6ac5) zeromq: 4.3.4 -> 4.3.5
* [`e3127089`](https://github.com/NixOS/nixpkgs/commit/e3127089c2b83698dc473ab015d7a6075f1b6125) libuv: add patch to disable io_uring on selected kernels
* [`27e869c6`](https://github.com/NixOS/nixpkgs/commit/27e869c60b9bc60d1b0465d23a1944d516d05aab) libuv: add marsam to maintainers
* [`35503309`](https://github.com/NixOS/nixpkgs/commit/35503309a8acc35d27d12b7c389c9c601bf70747) sqlite: 3.43.1 -> 3.43.2
* [`e73ab477`](https://github.com/NixOS/nixpkgs/commit/e73ab47781dcfacde8cb473f29266c848e2651bd) python3Packages.protobuf3: use dedicated package definition
* [`d453b6e6`](https://github.com/NixOS/nixpkgs/commit/d453b6e67a3d76e48e6f89cbd90b6861d782ac2a) protobuf_21: init at 21.12, protobuf_23: init at 23.4, protobuf_24: init at 24.3
* [`ee14e5df`](https://github.com/NixOS/nixpkgs/commit/ee14e5df159199e807a5a3ddaebff0366b5aae84) python3Packages.protobuf: use pkgs.protobuf_24
* [`80aaa46d`](https://github.com/NixOS/nixpkgs/commit/80aaa46d4c7d6f121a4fb9879a8e41c536186c8a) protobuf: use new package definition only
* [`fd70154f`](https://github.com/NixOS/nixpkgs/commit/fd70154fca3ffda11d56926e54f9cf3d35b94a77) DarwinTools: fix Darwin cross-compilation
* [`54fa4b20`](https://github.com/NixOS/nixpkgs/commit/54fa4b20984a8218b8d72a2e0703d7c67fe94fd3) iptables: 1.8.9 -> 1.8.10
* [`54c2dacf`](https://github.com/NixOS/nixpkgs/commit/54c2dacff4141d0f0977b5717e4537b4258b49f2) openutau: clarify license situation with worldline again
* [`edb0b85e`](https://github.com/NixOS/nixpkgs/commit/edb0b85e627cfa9663730dafdc1721641a0378af) kmod: 30 -> 31
* [`c0dfbebe`](https://github.com/NixOS/nixpkgs/commit/c0dfbebe1650aafa1d882fc51ce72b0a7023f9dc) ell: 0.58 -> 0.59
* [`3608deaf`](https://github.com/NixOS/nixpkgs/commit/3608deaf08d5dbcef329d527f75b2f4d8bd7db0f) pipewire: 0.3.81 -> 0.3.82
* [`b5f97b03`](https://github.com/NixOS/nixpkgs/commit/b5f97b03a312d72bc19da535a504f25db481139e) maintainers: add mrtnvgr
* [`2e09a00f`](https://github.com/NixOS/nixpkgs/commit/2e09a00fbee8d1578c76ca062c787e5eaea74745) libnsl: 2.0.0 -> 2.0.1
* [`beb14644`](https://github.com/NixOS/nixpkgs/commit/beb14644b7ed3e499d53d363fb51002ff2483c10) darwin.apple_sdk: use bootstrap fetchurl
* [`df14e86d`](https://github.com/NixOS/nixpkgs/commit/df14e86d9cd11b3c6122aa34a41f5af9ec617009) stdenv.darwin: fix infinite recursion after curl update
* [`84cf8e00`](https://github.com/NixOS/nixpkgs/commit/84cf8e007fce3fa2bcb2935c7de29e1df1c8846e) curl: build with system frameworks
* [`7d6ed061`](https://github.com/NixOS/nixpkgs/commit/7d6ed061ca769a2572bcef5d0490402c0832b373) lttng-ust: 2.13.1 -> 2.13.6
* [`dc4f98c0`](https://github.com/NixOS/nixpkgs/commit/dc4f98c0952b1f621e2262b62448482fbaeacde2) lilv: 0.24.12 -> 0.24.20
* [`9641d946`](https://github.com/NixOS/nixpkgs/commit/9641d94660ff77b970276ab6d1937861cf966f40) libimagequant: 4.2.1 -> 4.2.2
* [`4ea88062`](https://github.com/NixOS/nixpkgs/commit/4ea88062449196bc49aadf965bbf5fee36ef0b6a) opencore-amr: 0.1.5 -> 0.1.6
* [`4756a3b9`](https://github.com/NixOS/nixpkgs/commit/4756a3b968d8aeac5e43bf2bb99f005e079d476e) ibm-sw-tpm2: backport openssl-3.1 support
* [`a4e2dd0f`](https://github.com/NixOS/nixpkgs/commit/a4e2dd0f72c32e6036e8f7c52e172cc4b6d1c5a2) check: fix compilation on cross-compiled musl ([nixos/nixpkgs⁠#260675](https://togithub.com/nixos/nixpkgs/issues/260675))
* [`8804ed64`](https://github.com/NixOS/nixpkgs/commit/8804ed642ea9e4a90a5901814d05cefeeaadd041) libical: 3.0.16 -> 3.0.17
* [`663e8fd7`](https://github.com/NixOS/nixpkgs/commit/663e8fd7140abcc47c2ccc5542d023181d20110b) libical: add changelog to meta
* [`a248348d`](https://github.com/NixOS/nixpkgs/commit/a248348d2f490b2b1b664ce6185d0bd294258a78) oniguruma: 6.9.8 -> 6.9.9
* [`8a8899ae`](https://github.com/NixOS/nixpkgs/commit/8a8899aebec0485f5d8f24692c80bd4fa0086e19) python3Packages.imgtool: init at 1.10.0
* [`920bc7a2`](https://github.com/NixOS/nixpkgs/commit/920bc7a2fd6b87fd41414aaf508521e0ede4c60c) xvfb-run: only set fontconfig if not specified
* [`73cd37ce`](https://github.com/NixOS/nixpkgs/commit/73cd37cec957de7756ce8b6f7f506581ad8825ec) protobuf: 24.3 -> 24.4
* [`089edc0d`](https://github.com/NixOS/nixpkgs/commit/089edc0d49d35ce510c4f242934c34882895fa92) python311Packages.uvloop: 0.17.0 -> 0.18.0
* [`ad09f9cd`](https://github.com/NixOS/nixpkgs/commit/ad09f9cd36d32f94cd7cc87d2b11ec3d38e1d04a) mysql-shell-innovation: fix eval
* [`a92c0217`](https://github.com/NixOS/nixpkgs/commit/a92c0217476f93cb0d1429c921772baadda956f9) python311Packages.urllib3: 2.0.5 -> 2.0.6
* [`0b1d0df8`](https://github.com/NixOS/nixpkgs/commit/0b1d0df88f08d6fed706bcd099009426db98c9a2) linux/kernels-org.json: remove 6.4
* [`d016404c`](https://github.com/NixOS/nixpkgs/commit/d016404ccd291838794c6e6c1e9ac6779cc5fa9f) buildDotnetModule: parse version before passing it to dotnet
* [`3154cd1c`](https://github.com/NixOS/nixpkgs/commit/3154cd1c7fda4b25fde0b6da24295dc4a26a7d42) arrpc: make patch urls reproducible
* [`b48a8bb5`](https://github.com/NixOS/nixpkgs/commit/b48a8bb529d409ff08873fa6753317faa4aa5db0) ghc-9.6.x: make patch urls reproducible
* [`85d8c838`](https://github.com/NixOS/nixpkgs/commit/85d8c838acf3f9441e65b4354a66e999b531e3d9) openjpeg: make patch urls reproducible
* [`f08a223d`](https://github.com/NixOS/nixpkgs/commit/f08a223dbb159efa36525a6a0a5bdb2fd274f125) python3Packages.markdown-macros: make patch urls reproducible
* [`0e0c2b82`](https://github.com/NixOS/nixpkgs/commit/0e0c2b8201c98b94934e535ccd36b2c6f897ebed) python3Packages.pympler: make patch urls reproducible
* [`09d21f29`](https://github.com/NixOS/nixpkgs/commit/09d21f296ae6bfbd20babd588b647ecd93cc53f8) python3Packages.rocket-errbot: make patch urls reproducible
* [`92120c79`](https://github.com/NixOS/nixpkgs/commit/92120c7906ad7321d8bdf3f65addc249bc3b925c) python3Packages.sqlalchemy-migrate: make patch urls reproducible
* [`20190215`](https://github.com/NixOS/nixpkgs/commit/20190215b0c97cbd7014fa2dda8d72d5f0acad73) python3Packages.udatetime: make patch urls reproducible, update hash
* [`291a2e80`](https://github.com/NixOS/nixpkgs/commit/291a2e809b85e209e817d1d60dafebb62d89695c) orthorobot: make patch urls reproducible
* [`1a7901f8`](https://github.com/NixOS/nixpkgs/commit/1a7901f8f84afe6ae8205fbf7b829d09803ecf26) numatop: make patch urls reproducible
* [`4c841565`](https://github.com/NixOS/nixpkgs/commit/4c841565f9be019862bdc1112c263b154c25b5b9) pam_p11: make patch urls reproducible
* [`f5989166`](https://github.com/NixOS/nixpkgs/commit/f5989166821273be8fb439536c9095ed7cec21bf) sacd: make patch urls reproducible
* [`04d60bdc`](https://github.com/NixOS/nixpkgs/commit/04d60bdc53e3afe9f840b055a6811fb238e85674) ciel: make patch urls reproducible
* [`b9e8f5a2`](https://github.com/NixOS/nixpkgs/commit/b9e8f5a206b8b8c11c06f250725256f7de962b27) certmgr: make patch urls reproducible
* [`6dc62c08`](https://github.com/NixOS/nixpkgs/commit/6dc62c08737037872ee1563f17125290eb6e696a) python311Packages.simplejson: 3.19.1 -> 3.19.2
* [`4e1e2314`](https://github.com/NixOS/nixpkgs/commit/4e1e231400e7164db42a3465156224e79f449b92) libtirpc: 1.3.3 -> 1.3.4
* [`37d4ad90`](https://github.com/NixOS/nixpkgs/commit/37d4ad90042f29f1dd88d231d3af4c5425b67163) libtiff: clarify the need for headers.patch
* [`bfa73725`](https://github.com/NixOS/nixpkgs/commit/bfa7372576dda9e851ef0d2b4b6ce2167be7a65e) libtiff: clarify the need for rename-version.patch
* [`0a74a54a`](https://github.com/NixOS/nixpkgs/commit/0a74a54ac2600656cd0b640d5ea1c8efb5c35d68) libtiff: 4.5.1 -> 4.6.0
* [`dfd9ed93`](https://github.com/NixOS/nixpkgs/commit/dfd9ed939b25e143fa111a654853588c1f7f3880) libmysofa: 1.3.1 -> 1.3.2
* [`25ec5c23`](https://github.com/NixOS/nixpkgs/commit/25ec5c2344a9b64616701f57e5da216c33d7765f) ghidra: 10.3.3 -> 10.4
* [`9e2dec78`](https://github.com/NixOS/nixpkgs/commit/9e2dec78c0dde2bde4ab1a30e53ba5464edfd98c) vim: 9.0.1897 -> 9.0.2048
* [`57c28503`](https://github.com/NixOS/nixpkgs/commit/57c2850386b4d59f018bd6272d7d1532f4eedbba) qt5: update to latest upstream patchset
* [`7a0d0802`](https://github.com/NixOS/nixpkgs/commit/7a0d08029866bef6dcc39d11d68ea6c52e12643d) python3.pkgs.buildPython*: allow overriding of the stdenv
* [`04f489ca`](https://github.com/NixOS/nixpkgs/commit/04f489ca6032d1fbaa4ce4aaaf125e3cb4c4e107) python3Packages.pybind11: work around clang check
* [`0dfb5e77`](https://github.com/NixOS/nixpkgs/commit/0dfb5e77f13443d9677337d5bb93f9f58adfa30b) libaom: 3.6.1 -> 3.7.0
* [`cf1128c1`](https://github.com/NixOS/nixpkgs/commit/cf1128c17a8a94bea4c12487a865a8e231d931e7) nodejs: clang 16 compatibility for x86_64-darwin
* [`3ad67b4e`](https://github.com/NixOS/nixpkgs/commit/3ad67b4e12eebbb23ab2632d44c74662709e02a5) nodejs_14: work around building with clang 16
* [`3cb5c118`](https://github.com/NixOS/nixpkgs/commit/3cb5c1189fcbe3706fd3cab7fdf4ea52053f7e7d) nodejs_16: work around building with clang 16
* [`ea71bb55`](https://github.com/NixOS/nixpkgs/commit/ea71bb5508f4e1a290d6d4fd4e6606fbc1d6edb4) kde/frameworks: 5.110 -> 5.111
* [`249e31af`](https://github.com/NixOS/nixpkgs/commit/249e31affe3dfb7f5211fb05c50b947104e16a69) pipewire: 0.3.82 -> 0.3.83
* [`ff44e8ab`](https://github.com/NixOS/nixpkgs/commit/ff44e8ab072deaaa234525dd42010cfa5c536de7) pipewire: simplify outputs drastically
* [`347f401c`](https://github.com/NixOS/nixpkgs/commit/347f401c24ab4892eba94c3a3df3bd569af92214) ruby.rubygems: 3.4.20 -> 3.4.21
* [`dfd0a283`](https://github.com/NixOS/nixpkgs/commit/dfd0a2834a24ecb2ed46b62f6908b2e857e4fa27) bundler: 2.4.20 -> 2.4.21
* [`30e8b8e1`](https://github.com/NixOS/nixpkgs/commit/30e8b8e18dc89923720681a794301baee44b555e) nixos/pipewire: simplify pw-pulse disabling
* [`b3da3948`](https://github.com/NixOS/nixpkgs/commit/b3da3948316871b54cf4c32533a06b990f49b87e) percona-server_8_0: avoid use of `protobuf3_21` alias
* [`631742c8`](https://github.com/NixOS/nixpkgs/commit/631742c8dccc6dc67fe7f6d8a6c35d878268a3b4) python311Packages.psycopg2: fix cross
* [`e73b7f8d`](https://github.com/NixOS/nixpkgs/commit/e73b7f8d63d2f940ab8110001942b5491d07fd28) bzip2: Add `enableStatic`. See [nixos/nixpkgs⁠#61575](https://togithub.com/nixos/nixpkgs/issues/61575)
* [`ef4c88d1`](https://github.com/NixOS/nixpkgs/commit/ef4c88d1f67efe6a36b40119ebf11ff134f40724) zstd: Add `enableStatic`. See [nixos/nixpkgs⁠#61575](https://togithub.com/nixos/nixpkgs/issues/61575)
* [`b8bdfe57`](https://github.com/NixOS/nixpkgs/commit/b8bdfe5752216aeb97d787ff81e8dc5bf3330f7f) celluloid: add libGL build input
* [`287e4618`](https://github.com/NixOS/nixpkgs/commit/287e4618a150e3c453104e3ae4767fdbeb16a988) clapper: add libGL build input
* [`48f289e3`](https://github.com/NixOS/nixpkgs/commit/48f289e3e38bcc0eeecdf3c9eeffbe79bd5cce7d) cogl: force linking against libGL if used
* [`11364434`](https://github.com/NixOS/nixpkgs/commit/1136443434c69aa0544353ddbf8fc9c5146ae9ed) fbida: Add missing libGL
* [`265d25a4`](https://github.com/NixOS/nixpkgs/commit/265d25a4fca6bf96a6efe3e627544c4502ce2349) fcitx5: Add missing expat and xcbutil
* [`43df859d`](https://github.com/NixOS/nixpkgs/commit/43df859d0158e4f076dc610aec91cdeb27706875) gst_all_1.gst-plugins-good: Add missing libGL
* [`c4e8f607`](https://github.com/NixOS/nixpkgs/commit/c4e8f6072b0d9bcaeab546563733042956df760c) gwyddion: add libGL build input
* [`de928d3f`](https://github.com/NixOS/nixpkgs/commit/de928d3fd7c36d49a7b9ef59f38055ceb8928e19) hyprland: add libGL build input
* [`53b55017`](https://github.com/NixOS/nixpkgs/commit/53b550170d368d32dbd67f4a952468dd7c4137ac) hyprpaper: Add missing libGL
* [`9c3a7f2a`](https://github.com/NixOS/nixpkgs/commit/9c3a7f2ae8206a76dfbfb40fe0f8ef2657af1401) hyprpicker: Add missing libGL
* [`3f59b0a6`](https://github.com/NixOS/nixpkgs/commit/3f59b0a61bbf1a15e42d8efeb96d93973fa6df52) i3lock: add xcbutil build input
* [`b5acdd6f`](https://github.com/NixOS/nixpkgs/commit/b5acdd6fa0d7cd8179daa5a4640496de46fe2050) i3lock-blur: add libGL build input
* [`69eeadcc`](https://github.com/NixOS/nixpkgs/commit/69eeadcce6057ecd06fce6f055672ceed44d2661) i3lock-color: add xcbutil build input
* [`c0ca4954`](https://github.com/NixOS/nixpkgs/commit/c0ca495400b26ea1b363d06635ff727cf879d5fe) industrializer: add libGL build input
* [`6308a174`](https://github.com/NixOS/nixpkgs/commit/6308a174648fffc7eb895c064d17d19af115b500) jay: add libGL build input
* [`66a4fbe5`](https://github.com/NixOS/nixpkgs/commit/66a4fbe50a22a6ff5c493212fe16d4daaf2949e2) kapitonov-plugins-pack: add xcbutil build input
* [`3cd0eaf6`](https://github.com/NixOS/nixpkgs/commit/3cd0eaf6860ee5749e7bf18a42c8e0ec3656339c) mission-center: Add missing libGL
* [`a1887ed5`](https://github.com/NixOS/nixpkgs/commit/a1887ed5396d7bb3993f0271a3ccf935c216dfe2) rubyPackages.cairo-gobject: add expat build input
* [`c1ac6569`](https://github.com/NixOS/nixpkgs/commit/c1ac656934fd404042872a9d00a2dfc69ed222b8) squeak: add libGL build input
* [`442b2e8c`](https://github.com/NixOS/nixpkgs/commit/442b2e8c35970521a1a1160b46967e67b4618362) stone-phaser: Add missing libGL
* [`8d5b9fc7`](https://github.com/NixOS/nixpkgs/commit/8d5b9fc7c362f8d7f70ee73258a0b463e05e4abd) string-machine: Add missing libGL
* [`cb414381`](https://github.com/NixOS/nixpkgs/commit/cb414381c07379677aaf7f04d72d204a09933413) sway: add libGL build input
* [`6bdb478d`](https://github.com/NixOS/nixpkgs/commit/6bdb478d737f49bfd756faa4593fc274281426c5) wayfire: add libGL build input
* [`beb014d4`](https://github.com/NixOS/nixpkgs/commit/beb014d4ea0c2a489e4fa1bc87d6a1b3eecb3777) weston: Add missing libGL
* [`215518fb`](https://github.com/NixOS/nixpkgs/commit/215518fbc0aafa522f4170851a446348811e3221) wmfocus: add expat build input
* [`77d52cd3`](https://github.com/NixOS/nixpkgs/commit/77d52cd3f179ee99a4873f16c9fd018e90463451) wxSVG: add expat build input
* [`2c0a4f46`](https://github.com/NixOS/nixpkgs/commit/2c0a4f46b95cdd7403ff35f9c5a2a4805fc051f2) cairo: 1.16.0 -> 1.18.0
* [`38451d36`](https://github.com/NixOS/nixpkgs/commit/38451d363b0a58ade469a3bf24824472f0b5cc96) s2n-tls: 1.3.54 -> 1.3.55
* [`ab29d08c`](https://github.com/NixOS/nixpkgs/commit/ab29d08c1319b6f90485970eddd97ed00e3ccb48) python311Packages.sqlalchemy: 2.0.21 -> 2.0.22
* [`31ebe7b4`](https://github.com/NixOS/nixpkgs/commit/31ebe7b4598145f4009873be59d88d4fcbe952a1) doc: fix heading levels of Meson hook documentation
* [`1974a253`](https://github.com/NixOS/nixpkgs/commit/1974a253012c399839dea2ebce8fa88e1157ce4a) darwin.Libm: add missing function declarations
* [`32f301db`](https://github.com/NixOS/nixpkgs/commit/32f301db268853b9f0449b08c6809d369541d6d2) Revert "ruby: fix build with clang 16"
* [`9f8ad2a3`](https://github.com/NixOS/nixpkgs/commit/9f8ad2a32ab91165b19f365db05ece6a0bcc50f0) Revert "guile_2_2: fix build with clang 16 on x86_64-darwin"
* [`4b0d1daf`](https://github.com/NixOS/nixpkgs/commit/4b0d1daf5197d217b2d01ba795b69b1de387811a) Revert "guile_3_0: fix build with clang 16 on x86_64-darwin"
* [`e47c4fd6`](https://github.com/NixOS/nixpkgs/commit/e47c4fd6990eee200c48baa5f00212499070c9a4) python310Packages.pillow: 10.0.1 -> 10.1.0
* [`96fe81f1`](https://github.com/NixOS/nixpkgs/commit/96fe81f17ce8db2ca53533fb0a79374790552e71) linux: remove hack for old kernels
* [`eb180ea0`](https://github.com/NixOS/nixpkgs/commit/eb180ea033453b6d6fd4122fea1aa35c5b8fca21) python310Packages.aiohttp: 3.8.5 -> 3.8.6
* [`e3646a73`](https://github.com/NixOS/nixpkgs/commit/e3646a73230646acd32b09d66ae969f8092ac1ca) home-assistant: pin aiohttp to 3.8.5
* [`52a1b0c0`](https://github.com/NixOS/nixpkgs/commit/52a1b0c07797b84016f01fde93ee7879434be7aa) linuxManualConfig: always depend on ubootTools
* [`9429b569`](https://github.com/NixOS/nixpkgs/commit/9429b5692a0cf09f28d30e29ff80c7c6c915f717) luaPackages: update csv files
* [`e8dbe285`](https://github.com/NixOS/nixpkgs/commit/e8dbe285c5be25e33e93bb6b0e5f05a11508c793) luaPackages.readline: moved out from the generated set
* [`d83aab96`](https://github.com/NixOS/nixpkgs/commit/d83aab96a0fc9c8fcc8187966e2e939c25d8ec53) luarocks-nix: unstable-2023-02-26 -> unstable-2023-09-08
* [`12776aa7`](https://github.com/NixOS/nixpkgs/commit/12776aa73661c9a7ad65ad2f6fbdd13d0463daab) update-luarocks-package: update script
* [`cc32e0f4`](https://github.com/NixOS/nixpkgs/commit/cc32e0f45cec4e04927f3db1fcf2d7d6e2021030) luaPackages: update
* [`9a48adc3`](https://github.com/NixOS/nixpkgs/commit/9a48adc3196236b38772cb217160012a7aa04c27) mark lua-resty-session as broken
* [`db9d831c`](https://github.com/NixOS/nixpkgs/commit/db9d831c0b427c763469f9efc46fc847edf22ca6) luaPackages.lua-ff-zlib: init
* [`8b7a6ef5`](https://github.com/NixOS/nixpkgs/commit/8b7a6ef57e6d8ef969d1de4cdd42d777c8d4ad29) luaPackages.cyrussasl: remove because broken/old
* [`7acb6b6b`](https://github.com/NixOS/nixpkgs/commit/7acb6b6b76d06960f0e119f7c29cdcb9c86ab229) openrussian-cli: mark as broken
* [`fa760534`](https://github.com/NixOS/nixpkgs/commit/fa76053442d2af3dba6783da0709b986b3032cd2) nelua: unstable-2023-01-21 -> unstable-2023-09-16
* [`08535145`](https://github.com/NixOS/nixpkgs/commit/08535145485e136bf115fea821a626ac40230488) luaPackages: updated the 10-22-2023
* [`282d9cd2`](https://github.com/NixOS/nixpkgs/commit/282d9cd278480206964640c73cab2621e77300d7) minizip: apply patch for CVE-2023-45853
* [`dd4f12ef`](https://github.com/NixOS/nixpkgs/commit/dd4f12ef27f088642725f6cc254515642a27ba32) fuse3: 3.11.0 -> 3.16.1
* [`dec8dd47`](https://github.com/NixOS/nixpkgs/commit/dec8dd47cfaa5a036c222752dacc122df79fb75e) fuse3: 3.16.1 -> 3.16.2
* [`57909959`](https://github.com/NixOS/nixpkgs/commit/57909959384ea7b6d7f2d5732ddfdcce92f146b7) nixos/doc: document backward incompatibility of fuse3 bump to 3.16.2
* [`2a4dcd98`](https://github.com/NixOS/nixpkgs/commit/2a4dcd98ca5935894a0fc119621cdb43128c298b) aalib: fix build with clang 16
* [`d474c87a`](https://github.com/NixOS/nixpkgs/commit/d474c87aff678090f108a23f0b3e521ae0d4e034) gnu-config: 2023-07-31 -> 2023-09-19
* [`34c88b12`](https://github.com/NixOS/nixpkgs/commit/34c88b1293608b1d0b029082e555c8b577fbbaa9) libshout: fix build with clang 16
* [`36eff4f4`](https://github.com/NixOS/nixpkgs/commit/36eff4f43199433fdeba4d098f7799d1bb81d576) meson: introduce mesonInstallTags
* [`79f60450`](https://github.com/NixOS/nixpkgs/commit/79f60450063eb3a2270cca8066c353fc3c0facf7) systemd: allow building only the libraries
* [`856d0075`](https://github.com/NixOS/nixpkgs/commit/856d0075a7c352d363b221bfdf3adce0daff247e) systemd: use systemdLibs for packages that need udev
* [`dd97082f`](https://github.com/NixOS/nixpkgs/commit/dd97082f16096cc46e3c42247a193a31dc0a333a) pcsclite: depend on systemd libraries only
* [`294b1ff6`](https://github.com/NixOS/nixpkgs/commit/294b1ff629f84132f11ef887af92a5ca5db8b8c8) apr-util: find correct BDB when using clang 16
* [`c7b7b36a`](https://github.com/NixOS/nixpkgs/commit/c7b7b36af0d73e8865a38da484de3d585f6b317f) which: fix meta
* [`efa1fb94`](https://github.com/NixOS/nixpkgs/commit/efa1fb9403a916950d11b801b708f84a4a56f3e7) which: use SRI hash
* [`e55269bc`](https://github.com/NixOS/nixpkgs/commit/e55269bcdd1c7a89074cde3ff63ffbc30dfe6790) perlPackages.AlgorithmCheckDigits: 1.3.5 -> 1.3.6
* [`cff706c5`](https://github.com/NixOS/nixpkgs/commit/cff706c533bffbbc075bce81ceb3847e0556042e) perlPackages.AlienBaseModuleBuild: 1.15 -> 1.17
* [`89ec8e20`](https://github.com/NixOS/nixpkgs/commit/89ec8e200f767869d34838fe3fed4c8c2c6cab48) perlPackages.AlienBuild: 2.37 -> 2.80
* [`914cbf6b`](https://github.com/NixOS/nixpkgs/commit/914cbf6b1850933c0b7c33b6935828adeab3a5a9) perlPackages.AlienLibxml2: 0.17 -> 0.19
* [`17b973b4`](https://github.com/NixOS/nixpkgs/commit/17b973b4acf815029505c3e301628fd338298135) perlPackages.Alienm4: 0.19 -> 0.21
* [`5af506c6`](https://github.com/NixOS/nixpkgs/commit/5af506c6c37d6a0df1e70c99eb38d4375c1e7bba) perlPackages.ApacheAuthCookie: 3.30 -> 3.31
* [`24b83dfa`](https://github.com/NixOS/nixpkgs/commit/24b83dfa7f13319047e7a2590b280fe76212ca12) perlPackages.ApacheTest: 1.42 -> 1.43
* [`87c9ee75`](https://github.com/NixOS/nixpkgs/commit/87c9ee75ce36ef0b8d2afa2c1aee4c6f7deaedf8) perlPackages.AppCLI: 0.50 -> 0.52
* [`0426aa5d`](https://github.com/NixOS/nixpkgs/commit/0426aa5d0fd490b7b372fa3edb09ff3d09209ad3) perlPackages.AppCmd: 0.331 -> 0.336
* [`cbb4ab34`](https://github.com/NixOS/nixpkgs/commit/cbb4ab347074409023447be3f8469d9f0650871d) perlPackages.AppMusicChordPro: 6.010 -> 6.030
* [`4753bfeb`](https://github.com/NixOS/nixpkgs/commit/4753bfebe586974debab67426323a4a47f2093d4) perlPackages.AppPackager: 1.430.1 -> 1.440
* [`0c5994e6`](https://github.com/NixOS/nixpkgs/commit/0c5994e62313a2e3042c6631805ad1abba30dabd) perlPackages.AppSqitch: 1.3.1 -> 1.4.0
* [`9a19b8a6`](https://github.com/NixOS/nixpkgs/commit/9a19b8a6ce9cd1f331ecf844e5f62f950707fab3) perlPackages.Appcpanminus: 1.7045 -> 1.7047
* [`9e01d3bc`](https://github.com/NixOS/nixpkgs/commit/9e01d3bc16d096bb5d03c1c687e3458f442f32ba) perlPackages.Appcpm: 0.997011 -> 0.997014
* [`6527d935`](https://github.com/NixOS/nixpkgs/commit/6527d935a9b942da165bd051b3c127cbf4664f4c) perlPackages.Applify: 0.22 -> 0.23
* [`e4f101db`](https://github.com/NixOS/nixpkgs/commit/e4f101db905e715da9f97959951bd0b796fb8d01) perlPackages.Appperlbrew: 0.89 -> 0.98
* [`e76509b9`](https://github.com/NixOS/nixpkgs/commit/e76509b94f66f4dfb9abcef2e78f4d9e9f4656f8) perlPackages.ArchiveExtract: 0.86 -> 0.88
* [`e407187c`](https://github.com/NixOS/nixpkgs/commit/e407187c4db9a96a4999dcde32b0157fd637e260) perlPackages.ArchiveTar: 2.38 -> 3.02
* [`eaf361e4`](https://github.com/NixOS/nixpkgs/commit/eaf361e49a705ea7a11ecca90dd2df93671b30b6) perlPackages.ArrayCompare: 3.0.7 -> 3.0.8
* [`4979da27`](https://github.com/NixOS/nixpkgs/commit/4979da274070d062f9cf534969e66ab32e67dd3a) perlPackages.AstroFITSHeader: 3.07 -> 3.09
* [`5c93b716`](https://github.com/NixOS/nixpkgs/commit/5c93b7160098d9385fd2a092dcf478269a19f06f) perlPackages.AuthenSASL: 2.16 -> 2.1700
* [`b8d7cf0f`](https://github.com/NixOS/nixpkgs/commit/b8d7cf0ff979e8bd31f5f77cf251416ae58c6154) perlPackages.BCOW: 0.004 -> 0.007
* [`296b6632`](https://github.com/NixOS/nixpkgs/commit/296b66320295357a32ae7885f892ddf3f3904977) perlPackages.BHooksEndOfScope: 0.24 -> 0.26
* [`55932f5b`](https://github.com/NixOS/nixpkgs/commit/55932f5b9661a4f8304b45c5a05bf0797ea8d981) perlPackages.BusinessISBN: 3.005 -> 3.008
* [`35dae683`](https://github.com/NixOS/nixpkgs/commit/35dae68308c050a857017387f528bb84404a4c0e) perlPackages.BusinessISBNData: 20191107 -> 20231006.001
* [`17e9366f`](https://github.com/NixOS/nixpkgs/commit/17e9366ff51e04cfd1af23cff42434a0adf12f36) perlPackages.BusinessISMN: 1.201 -> 1.203
* [`885d7f2e`](https://github.com/NixOS/nixpkgs/commit/885d7f2e1f6531e95034b74c577d20dc27b7d65a) perlPackages.BusinessISSN: 1.004 -> 1.005
* [`2d743342`](https://github.com/NixOS/nixpkgs/commit/2d7433429c217d697b66f66106cb05893030adb4) perlPackages.CGI: 4.51 -> 4.59
* [`f4a06940`](https://github.com/NixOS/nixpkgs/commit/f4a069402dcbed31e6f25230467d9afb59929061) perlPackages.CGICompile: 0.25 -> 0.26
* [`8aa70c9b`](https://github.com/NixOS/nixpkgs/commit/8aa70c9bd87187219cb3e86df995bf57bc9d1dc4) perlPackages.CGIFast: 2.15 -> 2.16
* [`735cbd7a`](https://github.com/NixOS/nixpkgs/commit/735cbd7abfb2c76381e963655327bdc8fe151326) perlPackages.CGISimple: 1.25 -> 1.280
* [`d446003d`](https://github.com/NixOS/nixpkgs/commit/d446003d5f4084307cb43aff60a647d8d8a98bc4) perlPackages.CHI: 0.60 -> 0.61
* [`74d800b5`](https://github.com/NixOS/nixpkgs/commit/74d800b560b1a7179ccc8704f5aa48ccda988389) perlPackages.CLASS: 1.00 -> 1.1.8
* [`6d5ce95b`](https://github.com/NixOS/nixpkgs/commit/6d5ce95b912f8c72fcbc04ec80b514b775835ef2) perlPackages.CLIHelpers: 1.8 -> 2.0
* [`38a781e7`](https://github.com/NixOS/nixpkgs/commit/38a781e79d14d2e65d2ba9be582bf3dcaf879389) perlPackages.CPAN: 2.29 -> 2.36
* [`60b1ec21`](https://github.com/NixOS/nixpkgs/commit/60b1ec21c1b8a04c3181f59db742f3b1add4d8b8) perlPackages.CPAN02PackagesSearch: 0.001 -> 0.100
* [`ac0906bf`](https://github.com/NixOS/nixpkgs/commit/ac0906bf8cb5a0a745da87963598f64358472eac) perlPackages.CPANAudit: 20230309.004 -> 20230826.001
* [`40fff2b7`](https://github.com/NixOS/nixpkgs/commit/40fff2b7f7bd824c130275dee3ab1ce4e935be8b) perlPackages.CPANMetaCheck: 0.014 -> 0.018
* [`93cc89fb`](https://github.com/NixOS/nixpkgs/commit/93cc89fbca7321982037b8bcf3cf10374280aefc) perlPackages.CPANMini: 1.111016 -> 1.111017
* [`50c5f298`](https://github.com/NixOS/nixpkgs/commit/50c5f298fb3a688341c84fab00bc2bb914fce0de) perlPackages.CPANPLUS: 0.9908 -> 0.9914
* [`dea63aed`](https://github.com/NixOS/nixpkgs/commit/dea63aed3a8ebf6f29bc23f0ef6f884fa48aac23) perlPackages.CPANPerlReleases: 5.20201120 -> 5.20230920
* [`6cf512f8`](https://github.com/NixOS/nixpkgs/commit/6cf512f8cd7bf30c2615e31bbbd1941579e800f4) perlPackages.CPANUploader: 0.103015 -> 0.103018
* [`9587bb00`](https://github.com/NixOS/nixpkgs/commit/9587bb001a3380e56fd124697b237be6cf3ca8c0) perlPackages.CSSMinifierXS: 0.09 -> 0.13
* [`f10f50dd`](https://github.com/NixOS/nixpkgs/commit/f10f50dddb19b220eb73c8633471290b2fb019a1) perlPackages.CacheFastMmap: 1.54 -> 1.57
* [`492a3f83`](https://github.com/NixOS/nixpkgs/commit/492a3f839f6062d28de71f12701c3a6e3c3c6036) perlPackages.CacheMemcachedFast: 0.26 -> 0.28
* [`3b35f583`](https://github.com/NixOS/nixpkgs/commit/3b35f583d24f89edb905f59baae18bd4ff6b6cd2) perlPackages.Cairo: 1.108 -> 1.109
* [`de95e3f2`](https://github.com/NixOS/nixpkgs/commit/de95e3f254c6b22c3d8ed511ec5486ce8fb3d676) perlPackages.CarpAssert: 0.21 -> 0.22
* [`6296d52c`](https://github.com/NixOS/nixpkgs/commit/6296d52c4937d653dbc81b8dc48f936dba72cf1e) perlPackages.CarpAssertMore: 1.24 -> 2.3.0
* [`c9e844cf`](https://github.com/NixOS/nixpkgs/commit/c9e844cf8a9f1b03adea58de36ae648c1f945977) perlPackages.Carton: 1.0.34 -> 1.0.35
* [`251ec4d3`](https://github.com/NixOS/nixpkgs/commit/251ec4d3a19d50783fc96a1fe04de3332e35a434) perlPackages.CatalystAuthenticationStoreLDAP: 1.016 -> 1.017
* [`d3b948e2`](https://github.com/NixOS/nixpkgs/commit/d3b948e2388a3a12099bcda2174732f19eae6e24) perlPackages.CatalystModelDBICSchema: 0.65 -> 0.66
* [`786100d4`](https://github.com/NixOS/nixpkgs/commit/786100d4445c053a629c1814295193e27da8d87f) perlPackages.CatalystPluginSession: 0.41 -> 0.43
* [`300d46f5`](https://github.com/NixOS/nixpkgs/commit/300d46f5e681f3f422bedcd46f3e86ad4656d10f) perlPackages.CatalystPluginStaticSimple: 0.36 -> 0.37
* [`b1b29c19`](https://github.com/NixOS/nixpkgs/commit/b1b29c19447eb7ef985d4e45f32c0cbbed914179) perlPackages.CatalystRuntime: 5.90128 -> 5.90131
* [`7c91a417`](https://github.com/NixOS/nixpkgs/commit/7c91a41799203cdf95422a056f1872f2c6fa8694) perlPackages.CatalystViewCSV: 1.7 -> 1.8
* [`ce4e4d5f`](https://github.com/NixOS/nixpkgs/commit/ce4e4d5f853fe362c5eb8293006e8f9ced2527f4) perlPackages.CatalystViewTT: 0.45 -> 0.46
* [`c1659ab4`](https://github.com/NixOS/nixpkgs/commit/c1659ab4299cf7c07862f45e8a91bfe9ad3e1960) perlPackages.Catmandu: 1.2013 -> 1.2020
* [`dc9e5410`](https://github.com/NixOS/nixpkgs/commit/dc9e54104d15d034d1f82f775cb6d3c2cb715c73) perlPackages.Chart: 2.4.10 -> 2.403.9
* [`79f311ce`](https://github.com/NixOS/nixpkgs/commit/79f311ce8f7090c0b4adfc7c1a05746f3e59d07b) perlPackages.ClassDataInheritable: 0.08 -> 0.09
* [`c18b8e5b`](https://github.com/NixOS/nixpkgs/commit/c18b8e5b494e7e3b72e98fac0b61effee73be727) perlPackages.ClassMethodModifiers: 2.13 -> 2.15
* [`c014bc82`](https://github.com/NixOS/nixpkgs/commit/c014bc82a5d3184dc40474b46e0de37d48b93b91) perlPackages.ClassObservable: 1.04 -> 2.004
* [`adc88529`](https://github.com/NixOS/nixpkgs/commit/adc88529ccccc7ef13dd32e67f8c6ee17ba3f2f0) perlPackages.Clipboard: 0.26 -> 0.28
* [`30a6c2ca`](https://github.com/NixOS/nixpkgs/commit/30a6c2caed1af8e9255c5644893d6db588c20a9e) perlPackages.Clone: 0.45 -> 0.46
* [`a3fcf21b`](https://github.com/NixOS/nixpkgs/commit/a3fcf21b8ee32643999f85fed2801b80b478ccb5) perlPackages.CodeTidyAll: 0.78 -> 0.83
* [`ab7138e7`](https://github.com/NixOS/nixpkgs/commit/ab7138e78c7a979e98be9e9f974f67bb3c552aca) perlPackages.CompressRawBzip2: 2.101 -> 2.206
* [`b53711c0`](https://github.com/NixOS/nixpkgs/commit/b53711c0e6efd4d431bb551d3c25ef4b080bfbbe) perlPackages.CompressRawLzma: 2.101 -> 2.206
* [`2f48565b`](https://github.com/NixOS/nixpkgs/commit/2f48565bf75f39b883c20ab58434e134662fbac3) perlPackages.CompressRawZlib: 2.103 -> 2.206
* [`df5589d3`](https://github.com/NixOS/nixpkgs/commit/df5589d3c494e82475e5c7856dc0f6b8aa579125) perlPackages.ConfigAny: 0.32 -> 0.33
* [`9aa10ef8`](https://github.com/NixOS/nixpkgs/commit/9aa10ef8b09e96c81b57e9e435c08c36a442ab86) perlPackages.ConfigAutoConf: 0.319 -> 0.320
* [`6d1adae0`](https://github.com/NixOS/nixpkgs/commit/6d1adae09ab91096afd6c7faa45f2198d69a46ad) perlPackages.ConfigGeneral: 2.63 -> 2.65
* [`054dd2d8`](https://github.com/NixOS/nixpkgs/commit/054dd2d8a6092935e3610280db66a16b9deaa461) perlPackages.ConfigINI: 0.025 -> 0.029
* [`39501059`](https://github.com/NixOS/nixpkgs/commit/395010597e56bcf7886e919208d80047bbb0deea) perlPackages.ConfigMVP: 2.200011 -> 2.200013
* [`d77b84e0`](https://github.com/NixOS/nixpkgs/commit/d77b84e00a2528fc7f2d04a225972d18246b0ea3) perlPackages.ConfigMVPReaderINI: 2.101463 -> 2.101465
* [`62bbecdf`](https://github.com/NixOS/nixpkgs/commit/62bbecdf4f7c8959ffa1818d42ad120515ce87d7) perlPackages.ConfigTiny: 2.24 -> 2.29
* [`7fa6b6d4`](https://github.com/NixOS/nixpkgs/commit/7fa6b6d432f17551d1ad53ca82d3cca280e1dee5) perlPackages.Connector: 1.47 -> 1.53
* [`032ea57f`](https://github.com/NixOS/nixpkgs/commit/032ea57f9d6336da6fa104363071cc01dd94563e) perlPackages.ConvertASN1: 0.33 -> 0.34
* [`6fd197e0`](https://github.com/NixOS/nixpkgs/commit/6fd197e0b3e2558b82b89984fb7ad2d785f75f9f) perlPackages.ConvertColor: 0.11 -> 0.17
* [`eebdfbf4`](https://github.com/NixOS/nixpkgs/commit/eebdfbf401f73a9e1697fc72db4fb8d68a07a64c) perlPackages.CpanelJSONXS: 4.36 -> 4.37
* [`f8008f84`](https://github.com/NixOS/nixpkgs/commit/f8008f845c76df003ab472e9aafc090a9b17582a) perlPackages.CryptArgon2: 0.010 -> 0.019
* [`0961351f`](https://github.com/NixOS/nixpkgs/commit/0961351ff5830b35d412f6ac0be37c3cef4d5e75) perlPackages.CryptCurve25519: 0.06 -> 0.07
* [`3c49991b`](https://github.com/NixOS/nixpkgs/commit/3c49991b6a76dbdb96b90822f1eb8c076eee6576) perlPackages.CryptEd25519: 1.04 -> 1.05
* [`12e76f10`](https://github.com/NixOS/nixpkgs/commit/12e76f10640af65b93583dcc9a82f4039d4c9f8d) perlPackages.CryptFormat: 0.10 -> 0.12
* [`eec38738`](https://github.com/NixOS/nixpkgs/commit/eec387388ffccf8116950d6ef770c818a5a00176) perlPackages.CryptJWT: 0.029 -> 0.035
* [`7df322f0`](https://github.com/NixOS/nixpkgs/commit/7df322f043cb5c99166d4d5212805b214c1fa83a) perlPackages.CryptOpenSSLAES: 0.02 -> 0.15
* [`da17a73f`](https://github.com/NixOS/nixpkgs/commit/da17a73fedbc249777d0d5213b225c6ef7b5c59e) perlPackages.CryptOpenSSLX509: 1.914 -> 1.915
* [`a84274e5`](https://github.com/NixOS/nixpkgs/commit/a84274e5dcfeab6e9c43a19573c65f8e8b438865) perlPackages.CryptPKCS10: 2.001 -> 2.005
* [`216b512c`](https://github.com/NixOS/nixpkgs/commit/216b512c856d9731f981fb74f71c67b429e0f227) perlPackages.CryptPassphraseArgon2: 0.003 -> 0.009
* [`ecaa5dcb`](https://github.com/NixOS/nixpkgs/commit/ecaa5dcb96a36b5bb868d5263c12cbafb54bc23c) perlPackages.CryptPasswdMD5: 1.40 -> 1.42
* [`cd592993`](https://github.com/NixOS/nixpkgs/commit/cd5929935b9d779f8b66c3d20759d11434035c6f) perlPackages.CryptPerl: 0.34 -> 0.38
* [`9835778a`](https://github.com/NixOS/nixpkgs/commit/9835778adeacb7af4b54f6b3011b6090e2981fc9) perlPackages.CryptRandPasswd: 0.06 -> 0.07
* [`a62da32a`](https://github.com/NixOS/nixpkgs/commit/a62da32a1f10829df0ce33ebf936ccbcfe763b3b) perlPackages.CryptRandom: 1.52 -> 1.54
* [`5aba99c9`](https://github.com/NixOS/nixpkgs/commit/5aba99c9852f1be1d6c493502c4a0a92c4a92d90) perlPackages.CryptRijndael: 1.15 -> 1.16
* [`e784068f`](https://github.com/NixOS/nixpkgs/commit/e784068f9953486093aab4ba8b3d0c3244d5de56) perlPackages.CryptURandom: 0.36 -> 0.39
* [`108585c2`](https://github.com/NixOS/nixpkgs/commit/108585c2585fa0dbb1bae67ac55158307ee96c9b) perlPackages.CryptX: 0.078 -> 0.080
* [`8117916d`](https://github.com/NixOS/nixpkgs/commit/8117916d983c0f226359b8b3a505cd2a8986819e) perlPackages.CryptX509: 0.53 -> 0.55
* [`98f04ae6`](https://github.com/NixOS/nixpkgs/commit/98f04ae6fd5b1bfb34430e2f62b634ccb8bc0f14) perlPackages.Curses: 1.37 -> 1.44
* [`6faec9d6`](https://github.com/NixOS/nixpkgs/commit/6faec9d6d4431e9434e0cf75c7860ae195fe1a8e) perlPackages.DBDCSV: 0.56 -> 0.60
* [`bf63be90`](https://github.com/NixOS/nixpkgs/commit/bf63be907b7a0d3293aef45ab631964bd1b767d9) perlPackages.DBDMariaDB: 1.22 -> 1.23
* [`4213fa46`](https://github.com/NixOS/nixpkgs/commit/4213fa4614fbe7ae648b32e183e37cdd9005d2d3) perlPackages.DBDMock: 1.58 -> 1.59
* [`d66f274f`](https://github.com/NixOS/nixpkgs/commit/d66f274fc0e3fb645bc510c5def41f3a9a258a8b) perlPackages.DBDOracle: 1.80 -> 1.83
* [`5988d92f`](https://github.com/NixOS/nixpkgs/commit/5988d92f6f23ae25854046a75ff06ef945fdfc44) perlPackages.DBDPg: 3.14.2 -> 3.17.0
* [`1eb85ec0`](https://github.com/NixOS/nixpkgs/commit/1eb85ec0980ab99e1e0d53b9aa47b67ece5af781) perlPackages.DBDSQLite: 1.70 -> 1.74
* [`daadb437`](https://github.com/NixOS/nixpkgs/commit/daadb437a075fd67b71679bd9be40e8ea1996c1a) perlPackages.DBDsybase: 1.16 -> 1.23
* [`08b742fc`](https://github.com/NixOS/nixpkgs/commit/08b742fc0d4fc422530d7ae0873d55c6fdc1fc37) perlPackages.DBFile: 1.855 -> 1.859
* [`1df3413e`](https://github.com/NixOS/nixpkgs/commit/1df3413e72c3c1fd3fcac603870b40815ffb99a2) perlPackages.DBIxClassSchemaLoader: 0.07049 -> 0.07051
* [`bbaa9b68`](https://github.com/NixOS/nixpkgs/commit/bbaa9b688f302f12506779c6983bef027b616607) perlPackages.DBIxConnector: 0.56 -> 0.59
* [`c0ecb0fa`](https://github.com/NixOS/nixpkgs/commit/c0ecb0fa6688c334e92d8137be9085483fc34f3a) perlPackages.DBIxDBSchema: 0.45 -> 0.47
* [`c5b63ff0`](https://github.com/NixOS/nixpkgs/commit/c5b63ff08fc9d43a976485f030ce62d320a0dc56) perlPackages.DBMDeep: 2.0016 -> 2.0017
* [`6987dd3a`](https://github.com/NixOS/nixpkgs/commit/6987dd3a7ee2f82c6bd7dd7f6d0890120d64b59d) perlPackages.DataCompare: 1.27 -> 1.29
* [`addffb73`](https://github.com/NixOS/nixpkgs/commit/addffb73ab34aa8ab3a8beb94971f67a4cda3141) perlPackages.DataDump: 1.23 -> 1.25
* [`42fe16aa`](https://github.com/NixOS/nixpkgs/commit/42fe16aa5088d387267bf2dfa24f032812447f25) perlPackages.DataGUID: 0.049 -> 0.051
* [`90a21ad7`](https://github.com/NixOS/nixpkgs/commit/90a21ad715fb0a15aa11da95b609ab691b95b98e) perlPackages.DataHexDump: 0.02 -> 0.04
* [`ff165697`](https://github.com/NixOS/nixpkgs/commit/ff165697c08c8ae9fb6eca6f23859309b307aec2) perlPackages.DataMessagePack: 1.01 -> 1.02
* [`750d7e6d`](https://github.com/NixOS/nixpkgs/commit/750d7e6d2267921055dacc0a886585418c3236d7) perlPackages.DataOptList: 0.110 -> 0.114
* [`fcc2c1d7`](https://github.com/NixOS/nixpkgs/commit/fcc2c1d74f970ecf7644c6c6453ce8d5d8817d4a) perlPackages.DataPrinter: 0.40 -> 1.001001
* [`4504a48b`](https://github.com/NixOS/nixpkgs/commit/4504a48bddfec46f46d3c7ed8b857d3403967df7) perlPackages.DataSection: 0.200007 -> 0.200008
* [`aebefd0a`](https://github.com/NixOS/nixpkgs/commit/aebefd0a150be13cd2c39cc9d0ed22021d8baa36) perlPackages.DataULID: 1.0.0 -> 1.2.1
* [`d092fb7d`](https://github.com/NixOS/nixpkgs/commit/d092fb7d4340439689841c7d034149b085b80a3d) perlPackages.DataUtil: 0.66 -> 0.67
* [`ceb78aaf`](https://github.com/NixOS/nixpkgs/commit/ceb78aaff1be52299ff6217dcdec0850b12a40be) perlPackages.DataValidateDomain: 0.14 -> 0.15
* [`f481f206`](https://github.com/NixOS/nixpkgs/commit/f481f20677fe2468bf72fd24af4df31e31c76c05) perlPackages.DataValidateIP: 0.27 -> 0.31
* [`20d877c0`](https://github.com/NixOS/nixpkgs/commit/20d877c015e2ef00adf22cd021f03d1bc6c95f07) perlPackages.DataVisitor: 0.31 -> 0.32
* [`ef50e8a5`](https://github.com/NixOS/nixpkgs/commit/ef50e8a5b226ac4ef227715fba9f8f1415edbca0) perlPackages.DateManip: 6.83 -> 6.92
* [`26949c16`](https://github.com/NixOS/nixpkgs/commit/26949c161f605301210cf447934c95e2d8ee2a26) perlPackages.DateTime: 1.54 -> 1.59
* [`1105155a`](https://github.com/NixOS/nixpkgs/commit/1105155acc174a5e3e4321771c008f63d9d0f97f) perlPackages.DateTimeCalendarJulian: 0.102 -> 0.107
* [`c6f06f6d`](https://github.com/NixOS/nixpkgs/commit/c6f06f6dda72d806a581f8584b1a02d485640c26) perlPackages.DateTimeFormatFlexible: 0.32 -> 0.34
* [`d0722f10`](https://github.com/NixOS/nixpkgs/commit/d0722f106fed4cbf7983447cd0a3412a2f4ee47a) perlPackages.DateTimeFormatISO8601: 0.15 -> 0.16
* [`ecaca2f6`](https://github.com/NixOS/nixpkgs/commit/ecaca2f61fd69b285e151f853f670094b0582ba9) perlPackages.DateTimeFormatMySQL: 0.06 -> 0.08
* [`16e0a312`](https://github.com/NixOS/nixpkgs/commit/16e0a3126b791328193494a190f50d087bdb4ac7) perlPackages.DateTimeFormatNatural: 1.11 -> 1.18
* [`391ce84e`](https://github.com/NixOS/nixpkgs/commit/391ce84e750d2940f87b5367a94a4574b74fcd29) perlPackages.DateTimeFormatPg: 0.16013 -> 0.16014
* [`080775d2`](https://github.com/NixOS/nixpkgs/commit/080775d278ed738e3f5b486b9c8a7ceddc59d912) perlPackages.DateTimeFormatStrptime: 1.77 -> 1.79
* [`c1e3942e`](https://github.com/NixOS/nixpkgs/commit/c1e3942e58d08df1bd37bc31068dda9912783861) perlPackages.DateTimeFormatW3CDTF: 0.07 -> 0.08
* [`4cc40deb`](https://github.com/NixOS/nixpkgs/commit/4cc40deb7c047acaa1a6ed8b838ae486275b2d54) perlPackages.DateTimeLocale: 1.28 -> 1.39
* [`5daed003`](https://github.com/NixOS/nixpkgs/commit/5daed0030cbca655a7d133a7f5a98207fcbb14e3) perlPackages.DateTimeTimeZone: 2.44 -> 2.60
* [`4bf03c24`](https://github.com/NixOS/nixpkgs/commit/4bf03c247d0b5e7c29282d6c973ca07fcdea61c5) perlPackages.DateTimeXEasy: 0.089 -> 0.091
* [`bed2c956`](https://github.com/NixOS/nixpkgs/commit/bed2c95623a998f9bcb98967412e81868ac68ec5) perlPackages.DevelCamelcadedb: 2021.2 -> 2023.1
* [`d02b427d`](https://github.com/NixOS/nixpkgs/commit/d02b427de4aeef5024a7dfdf99c3e27e70b7362f) perlPackages.DevelCheckOS: 1.85 -> 1.96
* [`42e4219b`](https://github.com/NixOS/nixpkgs/commit/42e4219ba1aa7adbfa30e4d9da59947e291fe746) perlPackages.DevelChecklib: 1.14 -> 1.16
* [`e26f0003`](https://github.com/NixOS/nixpkgs/commit/e26f00039d1f7f11ac3320733284543c762fb3c5) perlPackages.DevelHide: 0.0013 -> 0.0015
* [`7de5dd4c`](https://github.com/NixOS/nixpkgs/commit/7de5dd4cca9b780988eefc49994e6d950b78cfc6) perlPackages.DevelOverloadInfo: 0.005 -> 0.007
* [`340b4f22`](https://github.com/NixOS/nixpkgs/commit/340b4f22e4752b4bc92bfa5ca8075adfded63254) perlPackages.DevelPPPort: 3.62 -> 3.68
* [`8c2c93e5`](https://github.com/NixOS/nixpkgs/commit/8c2c93e5463ecf5fe0fe881a950b66a59b5355bc) perlPackages.DigestCRC: 0.22.2 -> 0.24
* [`dcfe7eda`](https://github.com/NixOS/nixpkgs/commit/dcfe7eda2202a59b0126dd4ccc88c86cf4adff2c) perlPackages.DigestHMAC: 1.03 -> 1.04
* [`af241fa9`](https://github.com/NixOS/nixpkgs/commit/af241fa9898f92150c9351647b259d73e5b964cd) perlPackages.DigestSHA3: 1.04 -> 1.05
* [`21a8e37a`](https://github.com/NixOS/nixpkgs/commit/21a8e37a258e7a34369d4b6c8c3024cf22e14fd1) perlPackages.DistZilla: 6.017 -> 6.030
* [`df32ae56`](https://github.com/NixOS/nixpkgs/commit/df32ae567121dd3c1351f21ce2aca9786dd33cce) perlPackages.DistZillaPluginPodWeaver: 4.008 -> 4.010
* [`097b745c`](https://github.com/NixOS/nixpkgs/commit/097b745cf2864741d34eba51d4d964ab4da18513) perlPackages.DistZillaPluginTestDistManifest: 2.000005 -> 2.000006
* [`814463a7`](https://github.com/NixOS/nixpkgs/commit/814463a78289be6e5b57f8a75341dd5488ac279d) perlPackages.DistZillaPluginTestPortability: 2.001000 -> 2.001001
* [`87c4a9e6`](https://github.com/NixOS/nixpkgs/commit/87c4a9e6e4ab58adb209f3c672ba719a8e8acde1) perlPackages.DistZillaPluginTestUnusedVars: 2.000007 -> 2.001001
* [`e2c07921`](https://github.com/NixOS/nixpkgs/commit/e2c07921fbb881d9cbb7f4eb15f9206e601fd22d) perlPackages.Dumbbench: 0.111 -> 0.503
* [`85534450`](https://github.com/NixOS/nixpkgs/commit/855344503e649c67cd4d635fa38df7649fea2f40) perlPackages.EV: 4.33 -> 4.34
* [`680b9443`](https://github.com/NixOS/nixpkgs/commit/680b9443ab20f201ae36f043a5cf5873f692ce5c) perlPackages.EmailAbstract: 3.008 -> 3.010
* [`79b27321`](https://github.com/NixOS/nixpkgs/commit/79b273214aa73422bfe7b43c420b9b907d55c1b0) perlPackages.EmailAddress: 1.912 -> 1.913
* [`69e957f6`](https://github.com/NixOS/nixpkgs/commit/69e957f6656ac2cae28c7752c77983bcfce64c32) perlPackages.EmailAddressXS: 1.04 -> 1.05
* [`7bcedf6b`](https://github.com/NixOS/nixpkgs/commit/7bcedf6bfb7a0c1df4f415b0389102b47a16f94b) perlPackages.EmailDateFormat: 1.005 -> 1.008
* [`ea2cc2a2`](https://github.com/NixOS/nixpkgs/commit/ea2cc2a24705d789130a625b1ab929aa73f1ac03) perlPackages.EmailMIME: 1.949 -> 1.953
* [`cdf10d18`](https://github.com/NixOS/nixpkgs/commit/cdf10d18eae770fd2dbf45a45f4cd417c7cf9f54) perlPackages.EmailMIMEContentType: 1.024 -> 1.028
* [`e0d1ecc0`](https://github.com/NixOS/nixpkgs/commit/e0d1ecc0cd85b02a1cc37685e6e15c9a1efa12d6) perlPackages.EmailMIMEEncodings: 1.315 -> 1.317
* [`ba3f5309`](https://github.com/NixOS/nixpkgs/commit/ba3f5309d2436690b4d50911832569120e00c6bc) perlPackages.EmailMessageID: 1.406 -> 1.408
* [`d39c08e1`](https://github.com/NixOS/nixpkgs/commit/d39c08e1e7a9f39c0909a273438f651098f9d6d5) perlPackages.EmailOutlookMessage: 0.920 -> 0.921
* [`15a3c834`](https://github.com/NixOS/nixpkgs/commit/15a3c834724594a1c76b7778e6b2a9ae65e1c80d) perlPackages.EmailSender: 1.300035 -> 2.600
* [`da4024b0`](https://github.com/NixOS/nixpkgs/commit/da4024b0c0fd7cef4b6e5fd4e6d68d10214c9d24) perlPackages.EmailSimple: 2.216 -> 2.218
* [`8c8e9cfb`](https://github.com/NixOS/nixpkgs/commit/8c8e9cfbbe261724930086d0d5639af652df5cde) perlPackages.EmailStuffer: 0.018 -> 0.020
* [`6cdb1552`](https://github.com/NixOS/nixpkgs/commit/6cdb1552def6638838c9e7bf30e633d9fad14476) perlPackages.EmailValid: 1.202 -> 1.203
* [`e95c83d9`](https://github.com/NixOS/nixpkgs/commit/e95c83d924ab99bf6784ab246a430083a47194a2) perlPackages.ExcelWriterXLSX: 1.09 -> 1.11
* [`c6d5965e`](https://github.com/NixOS/nixpkgs/commit/c6d5965ef46cf0aed5d2d7c03f57e3436268f42b) perlPackages.ExceptionClass: 1.44 -> 1.45
* [`88b60f22`](https://github.com/NixOS/nixpkgs/commit/88b60f22c32cc50a5933c722ef96d2d5e92e5489) perlPackages.ExporterLite: 0.08 -> 0.09
* [`8839d5a3`](https://github.com/NixOS/nixpkgs/commit/8839d5a34d2914bbbf304704e15a3fb2b28b6fc3) perlPackages.ExporterTiny: 1.002002 -> 1.006002
* [`913cfba8`](https://github.com/NixOS/nixpkgs/commit/913cfba84f2ceccea6f4150df784102dcfca7a82) perlPackages.ExtUtilsCppGuess: 0.21 -> 0.26
* [`a7d1c20e`](https://github.com/NixOS/nixpkgs/commit/a7d1c20ed621cfcc6282ddeb790b32a1b56f3120) perlPackages.ExtUtilsDepends: 0.8000 -> 0.8001
* [`bd98a2bd`](https://github.com/NixOS/nixpkgs/commit/bd98a2bdef34a188e3cde1cc2d3c2bce5320c3f6) perlPackages.ExtUtilsF77: 1.24 -> 1.26
* [`58db7413`](https://github.com/NixOS/nixpkgs/commit/58db7413b899bdc10b8b839bac5aa7772832b004) perlPackages.ExtUtilsInstall: 2.18 -> 2.22
* [`7b51c38c`](https://github.com/NixOS/nixpkgs/commit/7b51c38c05f8aaec574570843d5dbdf48aefd49b) perlPackages.ExtUtilsMakeMaker: 7.62 -> 7.70
* [`68957bf4`](https://github.com/NixOS/nixpkgs/commit/68957bf4f8092cf78140bc8bb8ea8f235c58bee6) perlPackages.FCGI: 0.79 -> 0.82
* [`d4899f09`](https://github.com/NixOS/nixpkgs/commit/d4899f096df289b1add15696c1a66863a2e13cb4) perlPackages.FFICheckLib: 0.27 -> 0.31
* [`723a7294`](https://github.com/NixOS/nixpkgs/commit/723a7294cb2561b929a38099ba732ff377556034) perlPackages.FileCopyRecursiveReduced: 0.006 -> 0.007
* [`e146d83e`](https://github.com/NixOS/nixpkgs/commit/e146d83eaca832f33adb6f0f0d62aa07444f8f99) perlPackages.FileFindObject: 0.3.5 -> 0.3.8
* [`c1dbdf32`](https://github.com/NixOS/nixpkgs/commit/c1dbdf3206f2d4c00c2b09e32e98491363870a9d) perlPackages.FileFindObjectRule: 0.0312 -> 0.0313
* [`a7d9f926`](https://github.com/NixOS/nixpkgs/commit/a7d9f926e01655f370ab98254e7985e3948882bd) perlPackages.FileFindRulePerl: 1.15 -> 1.16
* [`d5693bd8`](https://github.com/NixOS/nixpkgs/commit/d5693bd8d34bfedd93db05ad100611e6521b9c75) perlPackages.FileListing: 6.14 -> 6.16
* [`407ba9b9`](https://github.com/NixOS/nixpkgs/commit/407ba9b9c07789e01e651c89b03b8ba4be856700) perlPackages.FileMap: 0.67 -> 0.71
* [`797d9caf`](https://github.com/NixOS/nixpkgs/commit/797d9caf827f790263eff745f40b03635f319118) perlPackages.FileMimeInfo: 0.30 -> 0.33
* [`527e2f47`](https://github.com/NixOS/nixpkgs/commit/527e2f47b544b8be872e250965b04f7835378fbc) perlPackages.FileRemove: 1.60 -> 1.61
* [`d058d94c`](https://github.com/NixOS/nixpkgs/commit/d058d94c81a41a7abbb47c433038ac9142803199) perlPackages.FileShare: 0.25 -> 0.27
* [`a0a49203`](https://github.com/NixOS/nixpkgs/commit/a0a49203a535b67999f313002fdff64f81859cff) perlPackages.FileShareDirInstall: 0.13 -> 0.14
* [`9e59782e`](https://github.com/NixOS/nixpkgs/commit/9e59782eb7697b8bfbb94dd0448521419e33d569) perlPackages.FileSlurper: 0.012 -> 0.014
* [`ced31452`](https://github.com/NixOS/nixpkgs/commit/ced31452590657a65702b772d33a31633430089f) perlPackages.FileTouch: 0.11 -> 0.12
* [`cb61eb18`](https://github.com/NixOS/nixpkgs/commit/cb61eb18d789798de2e620fdad537c8707e4f699) perlPackages.FileWhich: 1.23 -> 1.27
* [`2514eb1a`](https://github.com/NixOS/nixpkgs/commit/2514eb1aeacc56af1e7386a98840ceb89eda0d11) perlPackages.Filechdir: 0.1010 -> 0.1011
* [`7008295d`](https://github.com/NixOS/nixpkgs/commit/7008295df45f497d916c91588b8728600fbd4444) perlPackages.Filter: 1.60 -> 1.64
* [`a3ef6c8a`](https://github.com/NixOS/nixpkgs/commit/a3ef6c8ada32525a0e8ffe654484b8d6162998e3) perlPackages.FunctionParameters: 2.001003 -> 2.002004
* [`a7c9e248`](https://github.com/NixOS/nixpkgs/commit/a7c9e248403ddb5913a8ad8514fb93370c7f5fd8) perlPackages.Furl: 3.13 -> 3.14
* [`08bf8912`](https://github.com/NixOS/nixpkgs/commit/08bf8912b1d33eae49251074329f2c5bd1e453b0) perlPackages.FutureIO: 0.11 -> 0.14
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
