### PR TITLE
niv devenv: update 14fdefc0 -> 525d60c4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "14fdefc0bb80c3d6f3a18a491e33429b4064c371",
-        "sha256": "0iiiwsp7g4f136kj3agmxrpdmi773s0w0aknzx0apr22w352pza6",
+        "rev": "525d60c44de848a6b2dd468f6efddff078eb2af2",
+        "sha256": "0n4q4njl20zh9a1vw12x7ywrcx7s58ja9zih4yhnsi1bxlaa96rs",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/14fdefc0bb80c3d6f3a18a491e33429b4064c371.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/525d60c44de848a6b2dd468f6efddff078eb2af2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@14fdefc0...525d60c4](https://github.com/cachix/devenv/compare/14fdefc0bb80c3d6f3a18a491e33429b4064c371...525d60c44de848a6b2dd468f6efddff078eb2af2)

* [`f139c76d`](https://github.com/cachix/devenv/commit/f139c76d7aea21addff625f3d94dcc9869482a7c) Let containers be compatible with libnvidia-container
* [`3ff67be1`](https://github.com/cachix/devenv/commit/3ff67be13b877517e6ee59fd02270d3a97050927) flake: add devenv-up as a package
* [`c5178dbc`](https://github.com/cachix/devenv/commit/c5178dbccdd7d8b9da3133d924028275e8c9c778) template: add .gitignore
* [`59f3c1ec`](https://github.com/cachix/devenv/commit/59f3c1ecd6847c815cdc035ab06a08c331bc0b92) template: add .envrc to all templates
* [`0c41b864`](https://github.com/cachix/devenv/commit/0c41b86406e910a75fbde28f81ec7f6fda74f7e1) Auto generate docs/reference/options.md
