### PR TITLE
niv home-manager: update 28072118 -> 993fb02d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "280721186ab75a76537713ec310306f0eba3e407",
-        "sha256": "0qf13vx8nr3c97id0gsmhxdf3kcnfyhc18lfk96qwbwb7lnz0d73",
+        "rev": "993fb02d20760067b8ee19c713d94cee07037759",
+        "sha256": "0gllbaljxp34ca7g4z6qkv11py8wvd11s27ky0lkfvx7vizvk9jk",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/280721186ab75a76537713ec310306f0eba3e407.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/993fb02d20760067b8ee19c713d94cee07037759.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@28072118...993fb02d](https://github.com/nix-community/home-manager/compare/280721186ab75a76537713ec310306f0eba3e407...993fb02d20760067b8ee19c713d94cee07037759)

* [`b4ea37c6`](https://github.com/nix-community/home-manager/commit/b4ea37c633d809eaa1b998f72d9d86c1a6a558cb) qt: remove remaining Qt 4 support
* [`5744ebf3`](https://github.com/nix-community/home-manager/commit/5744ebf3593ed95516e47d1895b7f19f57de7eb4) qt: export QT_PLUGIN_PATH/QML2_IMPORT_PATH
* [`4b2d3b03`](https://github.com/nix-community/home-manager/commit/4b2d3b03becc184f2d1485e109c6a55f94d5f886) qt: remove top-level `with lib`
* [`3452e14e`](https://github.com/nix-community/home-manager/commit/3452e14ec729e0582a5fb120c14ed5c6d7fb64d3) qt: workaround issue when i18n.inputMethod.enabled = 'fcitx5'
* [`4ba652d8`](https://github.com/nix-community/home-manager/commit/4ba652d8a8a02348790100ffec69c8787aca9fe9) qt: add style mappings for Qt 6
* [`541d32d8`](https://github.com/nix-community/home-manager/commit/541d32d8b868753b0a627d542182cba9216325d9) qt: add support for platformTheme lxqt
* [`bc53e4c2`](https://github.com/nix-community/home-manager/commit/bc53e4c240ea71d2f4b271d95c262369ab7adc7c) qt: add qgnomeplatform-qt6 when platformTheme is set to gnome
* [`eaee696b`](https://github.com/nix-community/home-manager/commit/eaee696b6e77b8ec848fe6c49c9bc0fdfadafb3a) qt: simplify style.name mappings
* [`55eee5bd`](https://github.com/nix-community/home-manager/commit/55eee5bd67fee341e86a457646bd4b78c5a77d26) qt: use sessionVariablesExtra to export QT_PLUGIN_PATH/QML2_IMPORT_PATH
* [`1e80a0b3`](https://github.com/nix-community/home-manager/commit/1e80a0b3d8ef2a9ffc0399b32edcd588ac396fa6) qt: allow usage without setting platformTheme
* [`1160454c`](https://github.com/nix-community/home-manager/commit/1160454c791fa777ce59373fca86c25ad075265a) qt: support gtk3 platform theme
* [`ab1459a1`](https://github.com/nix-community/home-manager/commit/ab1459a1fb646c40419c732d05ec0bf2416d4506) openstackclient: add module ([nix-community/home-manager⁠#4530](https://togithub.com/nix-community/home-manager/issues/4530))
* [`f6c1a4f2`](https://github.com/nix-community/home-manager/commit/f6c1a4f23b99543270c1319500d3eefcd731586d) Translate using Weblate (Italian)
* [`18ce0de4`](https://github.com/nix-community/home-manager/commit/18ce0de460a6f291926fd4ca03f2df9b0a291c6f) Translate using Weblate (Turkish)
* [`c1a03312`](https://github.com/nix-community/home-manager/commit/c1a033122df8a3c74fda3780c83a104a7d60873c) Translate using Weblate (French)
* [`3feeb771`](https://github.com/nix-community/home-manager/commit/3feeb7715584fd45ed1389cec8fb15f6930e8dab) firefox: add support for specifying policies ([nix-community/home-manager⁠#4626](https://togithub.com/nix-community/home-manager/issues/4626))
* [`ecd0a800`](https://github.com/nix-community/home-manager/commit/ecd0a800f716b80a6eac58a7ac34d6d33e6fa5ee) Translate using Weblate (French)
* [`6fd3a5b7`](https://github.com/nix-community/home-manager/commit/6fd3a5b728e71922945a388501886922bef11eaf) flake.lock: Update
* [`7af96988`](https://github.com/nix-community/home-manager/commit/7af969886b0792be6d1d2c13404052e6393a8eb3) home-manager: improve comment in example configuration
* [`993fb02d`](https://github.com/nix-community/home-manager/commit/993fb02d20760067b8ee19c713d94cee07037759) zsh: allow enabling syntax highlighters ([nix-community/home-manager⁠#4360](https://togithub.com/nix-community/home-manager/issues/4360))
