### PR TITLE
niv zsh-completions: update 9e341f6a -> 9da7488c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -185,10 +185,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-completions",
-        "rev": "9e341f6a202e83e2dc0a587f4970fa375de84d4e",
-        "sha256": "15y6sl1a9g7rwncdgh6l21h4gawbs0f64jczcfa3gnwgw0f84nqx",
+        "rev": "9da7488c1152d786d237b45cbe5546eb90fc5f85",
+        "sha256": "1x0z9bmwg0blgjz9cfdvm45agphq5kklfk9vz2p5qcyfbx6db3cj",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-completions/archive/9e341f6a202e83e2dc0a587f4970fa375de84d4e.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-completions/archive/9da7488c1152d786d237b45cbe5546eb90fc5f85.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-completions:
Branch: master
Commits: [zsh-users/zsh-completions@9e341f6a...9da7488c](https://github.com/zsh-users/zsh-completions/compare/9e341f6a202e83e2dc0a587f4970fa375de84d4e...9da7488c1152d786d237b45cbe5546eb90fc5f85)

* [`e1243058`](https://github.com/zsh-users/zsh-completions/commit/e12430589cd4eae264d1d7497c3215c61e4fb116) Update node completion v21.2.0
* [`719d72d0`](https://github.com/zsh-users/zsh-completions/commit/719d72d025f89fff906ba359a9810c7045b08f0a) Update flutter and dart completion for flutter 3.16.0
