### PR TITLE
niv nixpkgs: update 3f21a22b -> d9de1239

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -93,9 +93,9 @@
         "sha256": "1c7pf6fp99y3gsn8pb73h1gwlz3ag2i0h5i8pl7i0f09p3ra9jr3",
         "type": "tarball",
         "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/0262a8c4fa41541438e489572bba8f0b4b689ae7.tar.gz",
-         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-     },
-     "niv": {
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",
         "homepage": "https://github.com/nmattia/niv",
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f21a22b5aafefa1845dec6f4a378a8f53d8681c",
-        "sha256": "15y8k3hazg91kscbmn7dy6m0q6zvmhlvvhg97gcl5kw87y0svzxk",
+        "rev": "d9de123937bc971bb232fc79d35a91f97beb2641",
+        "sha256": "03828lb6wz7v78q7r0k8fcrhw8x5yrll8s2kyg3myicljicnx3z0",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/3f21a22b5aafefa1845dec6f4a378a8f53d8681c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d9de123937bc971bb232fc79d35a91f97beb2641.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@3f21a22b...d9de1239](https://github.com/nixos/nixpkgs/compare/3f21a22b5aafefa1845dec6f4a378a8f53d8681c...d9de123937bc971bb232fc79d35a91f97beb2641)

* [`b109d934`](https://github.com/NixOS/nixpkgs/commit/b109d93442f2eae60afae90ce74ec8e3f763fdb5) taoup: 1.1.19 -> 1.21
* [`394763b5`](https://github.com/NixOS/nixpkgs/commit/394763b58355aac20f9fe2ba094cce716ef75faa) halide: 15.0.1 -> 16.0.0
* [`77486e6c`](https://github.com/NixOS/nixpkgs/commit/77486e6c93353cdabccb650bc257e270be0cddb1) halide: build against llvmPackages_16
* [`ed6e240d`](https://github.com/NixOS/nixpkgs/commit/ed6e240d32e6359be3947bdd8c852876e4464e4f) halide: disable float16 support on aarch16-linux
* [`b55f063c`](https://github.com/NixOS/nixpkgs/commit/b55f063caf98b12852f33d159d8fbb6b3dfc6646) halide: patch to remove dependency on Apple SDK
* [`c841f93d`](https://github.com/NixOS/nixpkgs/commit/c841f93dd98880f5a62c4995a3c9082f4478d2d6) halide: ::aligned_alloc is not available on x86_64-darwin
* [`7ccd4954`](https://github.com/NixOS/nixpkgs/commit/7ccd49546562fa11db090ec9d7bfc2b20fae6fbd) apptainer, singularity: drop obsolete LOCALSTATEDIR dirs
* [`ac776695`](https://github.com/NixOS/nixpkgs/commit/ac776695313a2da0ee99ba328da474f606a7a9d9) apptainer, singularity: make LOCALSTATEDIR internal by default
* [`bb4f1c41`](https://github.com/NixOS/nixpkgs/commit/bb4f1c410f3deb1afc1794c5cac54f8bc9e9c3e8) bazecor: init at 1.3.2
* [`98fae068`](https://github.com/NixOS/nixpkgs/commit/98fae06821b5a63d606988f70812152b9197967c) maintainers: add augustebaum
* [`db9a5fd2`](https://github.com/NixOS/nixpkgs/commit/db9a5fd280b086864550b348691868c12c838fb4) rasdaemon: 0.7.0 -> 0.8.0
* [`2c18352f`](https://github.com/NixOS/nixpkgs/commit/2c18352f1e7ec35480ab07b7e5b58e1326b522f2) inkscape-extensions.textext: init at 1.8.1
* [`8d900231`](https://github.com/NixOS/nixpkgs/commit/8d90023173c246daa0079a8682704e050c11b976) goredo: 1.31.0 -> 2.1.0
* [`9870f4d6`](https://github.com/NixOS/nixpkgs/commit/9870f4d6f5b50c55cfe77bd80b0588eb0d93903f) goredo: Move to pkgs/by-name
* [`49c417ae`](https://github.com/NixOS/nixpkgs/commit/49c417aedd8a6217f166d0f805e3056300b74798) maintainers: add lecoqjacob
* [`1ee5a5b6`](https://github.com/NixOS/nixpkgs/commit/1ee5a5b6ed5d1ea9226bf32fdd2af276ae475baa) nixos/sysctl: Enable Yama by default
* [`a3c9ae5a`](https://github.com/NixOS/nixpkgs/commit/a3c9ae5a681e24aef58d5207ecff41214bdea305) lxterminal: 0.3.2 -> 0.4.0
* [`b2192f0e`](https://github.com/NixOS/nixpkgs/commit/b2192f0e719c1d2e0a10288490bbd3c2070f847b) gns3-gui: fix running on Wayland
* [`5e251ed1`](https://github.com/NixOS/nixpkgs/commit/5e251ed1c685ea1eebed19d9cf5d9babbdcf058b) parsec-bin: 150_86e -> 150_90c
* [`4b04ebcd`](https://github.com/NixOS/nixpkgs/commit/4b04ebcdf9c1f356977ada1de780c0dcfc8b4225) colloid-kde: unstable-2022-07-13 -> unstable-2023-07-04
* [`e2334f95`](https://github.com/NixOS/nixpkgs/commit/e2334f95f7d4f828b2ff60f56a973c04211e7029) colloid-kde: install sddm theme
* [`01a3f1a1`](https://github.com/NixOS/nixpkgs/commit/01a3f1a169c45dbf9c2bb67c08e5fa329827e6a7) graphite-kde-theme: 2022-02-08 -> unstable-2023-10-25
* [`8fd86084`](https://github.com/NixOS/nixpkgs/commit/8fd860844114f7c380a25cdc7ef4500d62906d83) graphite-kde-theme: propagate sddm theme dependencies to user env
* [`6375c59c`](https://github.com/NixOS/nixpkgs/commit/6375c59c02bc492874d42ca016c1ad0c7ea537bf) graphite-kde-theme: add update script
* [`8b04b30e`](https://github.com/NixOS/nixpkgs/commit/8b04b30e747d1ca8e38fe72318b8955169955e31) sbcl: 2.3.9 -> 2.3.10
* [`8f55e6ca`](https://github.com/NixOS/nixpkgs/commit/8f55e6cae28dc17a94ee0661fa58b6f8690b42c4) lima-bin: 0.17.2 -> 0.18.0
* [`d10adb01`](https://github.com/NixOS/nixpkgs/commit/d10adb0177a5ee967dbcc7a345d27233c62b9ca6) searxng: unstable-2023-10-01 -> unstable-2023-10-31
* [`ead776d8`](https://github.com/NixOS/nixpkgs/commit/ead776d8a82bf3828150433410c43109b8152230) layan-kde: 2022-02-13 -> unstable-2023-09-30
* [`c689e840`](https://github.com/NixOS/nixpkgs/commit/c689e8404080c451f9495d75ce57dbdc428c717f) papirus-icon-theme: add update script
* [`d28775dd`](https://github.com/NixOS/nixpkgs/commit/d28775dde5684dd625a8ffdb89dbb10329154393) papirus-icon-theme: 20230901 -> 20231101
* [`e7621355`](https://github.com/NixOS/nixpkgs/commit/e7621355e79b25d3e45afc388efcce12002cc38d) qogir-kde: unstable-2022-07-08 -> unstable-2023-10-20
* [`9f7a6960`](https://github.com/NixOS/nixpkgs/commit/9f7a69608a7cebbcb03c055fbfa351d783658c99) libsForQt5.kdesu: add option to use sudo instead of su
* [`a1e212ba`](https://github.com/NixOS/nixpkgs/commit/a1e212ba0fb5190953e460c691c426774de56d3b) python311Packages.ciso8601: 2.3.0 -> 2.3.1
* [`76663292`](https://github.com/NixOS/nixpkgs/commit/7666329232ac5f6e2bf3b504569303f4329a06c5) marwaita-pop_os: add update script
* [`d1e23ba8`](https://github.com/NixOS/nixpkgs/commit/d1e23ba84ecc8b3f029ed20fcc062d8cac5d805a) marwaita-pop_os: 10.3 -> 17.0
* [`f54d9cdf`](https://github.com/NixOS/nixpkgs/commit/f54d9cdf127ddf4c2f03f21e7e82d3de8a3217a3) marwaita-ubuntu: add update script
* [`cf31acbf`](https://github.com/NixOS/nixpkgs/commit/cf31acbf1551369e645d8d864d44763e16a14cfb) marwaita-ubuntu: 1.7 -> 17.0
* [`85f988ba`](https://github.com/NixOS/nixpkgs/commit/85f988bae4c935e735ce6b8c055e8cd216a4d5a3) mojave-gtk-theme: 2023-06-13 -> 2023-08-04
* [`afbe68b2`](https://github.com/NixOS/nixpkgs/commit/afbe68b22266008973fde5f28b5dc371cf8c9e2e) numix-gtk-theme: add update script
* [`3cd6bd44`](https://github.com/NixOS/nixpkgs/commit/3cd6bd44573edd1bb083e0e23bcb088b6c1dc022) numix-gtk-theme: 2.6.7 -> unstable-2021-06-08
* [`f6370efd`](https://github.com/NixOS/nixpkgs/commit/f6370efdfbb57b08b5ee1b18a535dea1b2938c52) halide: disable fuzzing tests
* [`2edb7f2e`](https://github.com/NixOS/nixpkgs/commit/2edb7f2edbe1d843ffc706ed49b9bb9e6a6dad28) whitesur-kde: unstable-2023-08-15 -> unstable-2023-10-06
* [`2ff27bb7`](https://github.com/NixOS/nixpkgs/commit/2ff27bb7a11e59f850a520dedd9649b6ff1d2b03) whitesur-kde: propagate sddm theme dependencies to user env
* [`0cdbf88f`](https://github.com/NixOS/nixpkgs/commit/0cdbf88f83ae3efd218e6b081a283a02111e7e03) doc: Add lib.meta to the library functions ToC
* [`cf5f4206`](https://github.com/NixOS/nixpkgs/commit/cf5f42066fb537abe68fdbf26da2de58c86b7ebc) poetry: 1.6.1 -> 1.7.0
* [`655678ed`](https://github.com/NixOS/nixpkgs/commit/655678ed0aee7ccd88d8aa9d204cabef6659681d) poetryPlugins.poetry-plugin-export: 1.5.0 -> 1.6.0
* [`c75fed2f`](https://github.com/NixOS/nixpkgs/commit/c75fed2f17dfcab315beb9be110f3e3eda053dfe) parallel: 20230922 -> 20231022
* [`6d6e7afd`](https://github.com/NixOS/nixpkgs/commit/6d6e7afdc8c80e44b5dbfd50757439d9e3d91da2) kicad: 7.0.7 -> 7.0.8
* [`3580ff79`](https://github.com/NixOS/nixpkgs/commit/3580ff791fea0da169e2f23a53e57293fddc28d2) kicad: 7.0.8 -> 7.0.9
* [`eed6c133`](https://github.com/NixOS/nixpkgs/commit/eed6c1339d83998f546c9d0ed06032b433ea3842) python311Packages.ocrmypdf: 15.3.1 -> 15.4.0
* [`19af2853`](https://github.com/NixOS/nixpkgs/commit/19af28537bb59c849a666fce27e15d1f33fb03ee) nixos/btrbk: Support both Miller's sudo and sudo-rs
* [`f5803331`](https://github.com/NixOS/nixpkgs/commit/f5803331cff1674cb36f58a98fcfe750b8433b35) armagetronad: 0.2.9.1.0 -> 0.2.9.1.1 + passthrus for other versions
* [`690f0272`](https://github.com/NixOS/nixpkgs/commit/690f027251164629d30531e6fd660a9ef15f9ea1) nixos/ssm-agent: Handle sudo-rs too
* [`6f41e0b9`](https://github.com/NixOS/nixpkgs/commit/6f41e0b9aff319adc25ada9d41a5d8effae5ed79) armagetronad: reproducible build by setting version
* [`b66dea47`](https://github.com/NixOS/nixpkgs/commit/b66dea4711ab7dcb6352aae09e292bfa993015de) govulncheck: fix version information
* [`da893e4d`](https://github.com/NixOS/nixpkgs/commit/da893e4d17861e4a716d1d842ea141656e09a663) halide: use preCheck instead of overwriting checkPhase
* [`ae963d4c`](https://github.com/NixOS/nixpkgs/commit/ae963d4c93d0bfd057b43ddfaa5a1a308c3617ff) python3Packages.taskw: support relative paths in taskrc
* [`27bc4c66`](https://github.com/NixOS/nixpkgs/commit/27bc4c66e297b5a7bf2f010ffdddd9810dac30e9) cemu: 2.0-47 -> 2.0-59
* [`b18aa534`](https://github.com/NixOS/nixpkgs/commit/b18aa534bb1f3bc581befbb085074b5fa3de95bd) fable: 4.1.4 -> 4.5.0
* [`0dcfabb9`](https://github.com/NixOS/nixpkgs/commit/0dcfabb9e0b0f36b30e104198b490b903f69e2cd) fzf: fix perl detection
* [`20135add`](https://github.com/NixOS/nixpkgs/commit/20135addf0c43bbf2efd74104439df1b02479dd9) python3Packages.pykdl: use system pybind11
* [`1e0e27fb`](https://github.com/NixOS/nixpkgs/commit/1e0e27fbba0dc3f4693df1f11ba546404ecc9c52) feather: init at 2.5.2
* [`92ee7186`](https://github.com/NixOS/nixpkgs/commit/92ee71866ff18a811c46948a13c633ed638d2ae8) nixos/nat: fix nat-nftables
* [`3c83bfb2`](https://github.com/NixOS/nixpkgs/commit/3c83bfb2a88e3c7c24fff6c9232039b0a01488f1) haskellPackages: stackage LTS 21.16 -> LTS 21.19
* [`3d96c4e1`](https://github.com/NixOS/nixpkgs/commit/3d96c4e1f73a1545bf7c2dc0bbb9daf619475f1d) all-cabal-hashes: 2023-10-21T19:49:07Z -> 2023-11-10T11:27:19Z
* [`136a1508`](https://github.com/NixOS/nixpkgs/commit/136a1508497656863215563ec4b53ea42b978f3f) haskellPackages: regenerate package set based on current config
* [`b0d279d2`](https://github.com/NixOS/nixpkgs/commit/b0d279d2193732c5ce3d5414a707f871a70c47be) nixos/sonic-server: init
* [`0eeea808`](https://github.com/NixOS/nixpkgs/commit/0eeea808636d804e4022e6fa1661784f1a2b0074) nixosTests.sonic-server: init
* [`20b78e47`](https://github.com/NixOS/nixpkgs/commit/20b78e47f5ac09682747900ed35b0b36b324d8e7) sonic-server: add nixosTests.sonic-server to passthru.tests
* [`8b0f2aef`](https://github.com/NixOS/nixpkgs/commit/8b0f2aefa0021a9cce077b15e060ceb67c8d984a) haskellPackages.releaser: Unmark broken
* [`acb51580`](https://github.com/NixOS/nixpkgs/commit/acb51580ca06f9c487d3adcf25164bcb4b4617be) haskellPackages: Fixup ormolu minor version in overrides
* [`ea71c45d`](https://github.com/NixOS/nixpkgs/commit/ea71c45d76e781a728134af2888908587e3d2bdf) haskellPackages: Fixup pandoc minor version in overrides
* [`22cf6681`](https://github.com/NixOS/nixpkgs/commit/22cf6681f6977997d805720ea9d87a7fdfa9050a) haskellPackages: Fixup Cabal minor version in overrides
* [`b4d06896`](https://github.com/NixOS/nixpkgs/commit/b4d06896fb4260d99501a5aca9966a8ff1c7310f) haskellPackages: Fixup cabal-install-solver minor version in overrides
* [`c71bf5bc`](https://github.com/NixOS/nixpkgs/commit/c71bf5bc06ee9f0940b9425641fd81fe2c2bde16) haskellPackages: Fixup fourmolu minor version in overrides
* [`e9e6a2e4`](https://github.com/NixOS/nixpkgs/commit/e9e6a2e476f7ea475eaaa2e9428137d6fc83af9f) haskellPackages: regenerate package set based on current config
* [`d92b7a7f`](https://github.com/NixOS/nixpkgs/commit/d92b7a7f3741cadcc93557f1f2aab4f052b26c20) haskellPackages: Fixup crypton minor version in overrides
* [`743a7a59`](https://github.com/NixOS/nixpkgs/commit/743a7a597fa7d275f44e1f40420ca3d43df80de1) haskellPackages: Fixup hspec-core minor version in overrides
* [`4e2c97aa`](https://github.com/NixOS/nixpkgs/commit/4e2c97aa2b9ce8600e5b5f713da07562c804174d) haskellPackages: Fixup hspec-discover minor version in overrides
* [`030de47b`](https://github.com/NixOS/nixpkgs/commit/030de47bf7c338359b0bf078f231860aa9e9c584) haskellPackages: Fixup hspec-meta minor version in overrides
* [`99a02beb`](https://github.com/NixOS/nixpkgs/commit/99a02beb04adad4c0cc99ff6ad9c806d5fa53145) haskellPackages: Fixup hspec minor version in overrides
* [`5f76804b`](https://github.com/NixOS/nixpkgs/commit/5f76804b6e094a15a312b0fc8c8e30feda033822) haskellPackages: Fixup alex minor version in overrides
* [`816cb8c5`](https://github.com/NixOS/nixpkgs/commit/816cb8c50b8ccba83d7edde0511123a1d76c2fe4) goredo: 2.1.0 -> 2.2.0
* [`e2d95f5c`](https://github.com/NixOS/nixpkgs/commit/e2d95f5c2d50a471c0523ed457b4b7518708da1c) haskellPackages: regenerate package set based on current config
* [`c7b024e0`](https://github.com/NixOS/nixpkgs/commit/c7b024e05ef72a54d5ea81f2308a01ccb0c67563) haskell.packages.ghc810.text-metrics: jailbreak because of overly-strict bounds
* [`18cd3457`](https://github.com/NixOS/nixpkgs/commit/18cd34573b1ecd51124cff1a4690fc565d9109ed) haskell.packages.ghc88.text-metrics: jailbreak because of overly-strict bounds
* [`2a4b34a9`](https://github.com/NixOS/nixpkgs/commit/2a4b34a9d4c4c10d525afdd55e4a7587189ce1b9) haskell.packages.ghc96.some_1_0_6: update reference from some_1_0_5
* [`c717d863`](https://github.com/NixOS/nixpkgs/commit/c717d863e5a6a201e19e4049638505440911beaf) haskellPackages.ostree-pin: disable on darwin
* [`6947a267`](https://github.com/NixOS/nixpkgs/commit/6947a267ef2f8c7d73fe0b38c4b1388b049a14a5) haskellPackages.rsi-break: disable on darwin
* [`42a3a1f8`](https://github.com/NixOS/nixpkgs/commit/42a3a1f8fff18eaf6ff63d1a1946ff7426ae70ec) haskellPackages.vty-windows: disable on all platforms other than windows
* [`46175bc0`](https://github.com/NixOS/nixpkgs/commit/46175bc01df41531e33dbb2123f63b2ddc466650) haskell-language-server: Add toplevel jobs for all ghc versions
* [`80aced8d`](https://github.com/NixOS/nixpkgs/commit/80aced8d5cb1612e18f4d3d943810c654f1ba921) jazz2{,-content}: 2.1.0 -> 2.2.2, refactor
* [`588e73db`](https://github.com/NixOS/nixpkgs/commit/588e73db432c2b6a1932033232733da0078a5251) mpvScripts.buildLua: Only accept plain `scriptPath`, no glob etc.
* [`9c2b07c6`](https://github.com/NixOS/nixpkgs/commit/9c2b07c6d70f6d7cd0980e5e691483917bf467d3) mpvScripts.buildLua: Infer `scriptName` from `scriptPath` over `pname`
* [`44828070`](https://github.com/NixOS/nixpkgs/commit/44828070c33572fc24fa37129af5542d1d63a1c6) mpvScripts.quality-menu: Update following change in `buildLua`
* [`ad949a8d`](https://github.com/NixOS/nixpkgs/commit/ad949a8de8af5aa0625639290b13e22bb0b3e80b) mpvScripts.thumbnail: Update following change in `buildLua`
* [`fc596558`](https://github.com/NixOS/nixpkgs/commit/fc5965587a24b6eaf1e851292c5309955c3647fd) mpvScripts.mpvacious: Refactor with `buildLua` & upstream's `install` target
* [`f0d0f400`](https://github.com/NixOS/nixpkgs/commit/f0d0f400394668793b2bb7fb13a15711c90d8108) mpvScripts.mpvacious: 0.24 → 0.25
* [`a43f8ce9`](https://github.com/NixOS/nixpkgs/commit/a43f8ce903571709b3e9964b3c4c2a2d7b7797e6) changedetection-io: 0.45.3 -> 0.45.7.3
* [`05dabf68`](https://github.com/NixOS/nixpkgs/commit/05dabf68247a7a8d56b3a053be27e2b6722413ef) changedetection-io: add mikaelfangel as maintainer
* [`aa91a9df`](https://github.com/NixOS/nixpkgs/commit/aa91a9dfb7bcdcbd8bb8bd08ae8a905b9582c58d) goredo: 2.2.0 -> 2.3.0
* [`8514ac06`](https://github.com/NixOS/nixpkgs/commit/8514ac064923360ee87780c42e4b5017e7c2bb84) maintainers: add asbjornolling
* [`4fd012ba`](https://github.com/NixOS/nixpkgs/commit/4fd012bae7c5060dd44dc242d2c47adc454df613) tor-browser: add support for GPU acceleration
* [`039308e9`](https://github.com/NixOS/nixpkgs/commit/039308e97946cae07cb8ed361ad2e21bfbeb6975) mullvad-browser: add support for GPU acceleration
* [`d1235fca`](https://github.com/NixOS/nixpkgs/commit/d1235fcaecc88dfb68d29bb7818df9bdc84a56bd) haskellPackages.sensei: patch flaky test
* [`928a932b`](https://github.com/NixOS/nixpkgs/commit/928a932b313170caebda1215b1f27b11e579a722) Revert "haskell-language-server: Add toplevel jobs for all ghc versions"
* [`1a412719`](https://github.com/NixOS/nixpkgs/commit/1a4127190e2a7a0bcb37ae5a9dc4c78aabfa7047) haskell-language-server: Fix build
* [`6d0c672b`](https://github.com/NixOS/nixpkgs/commit/6d0c672b0578d6033592f9684aa70dcdbdace158) lxterminal: add pbsds as maintainer, remove velovix
* [`a0529d12`](https://github.com/NixOS/nixpkgs/commit/a0529d12379c9af7b14de7cf69b8657d8b13d844) libmicrohttpd_0_9_74: init at 0.9.74
* [`63509669`](https://github.com/NixOS/nixpkgs/commit/635096691eb96290fa415b28a57ec91383c767ae) taler: 0.9.2 -> 0.9.3
* [`437b2054`](https://github.com/NixOS/nixpkgs/commit/437b2054f4c1b16c246c0e42dd2acac13624d880) pass eval.nix as a file instead of expression
* [`a2d2fe44`](https://github.com/NixOS/nixpkgs/commit/a2d2fe440d51724473ba6b038196f42268c83982) tart: 2.0.0 -> 2.3.0
* [`e15afd6e`](https://github.com/NixOS/nixpkgs/commit/e15afd6e349e8755f951b92292760aaec7f7bbc9) haskellPackages.ghc96.fgl: update reference 5.8.1.1 -> 5.8.2.0
* [`290ec4fd`](https://github.com/NixOS/nixpkgs/commit/290ec4fd63387278fd2adfca9be8c4058da9ec7b) python311Packages.python-fedora: rename from python_fedora
* [`8c99b645`](https://github.com/NixOS/nixpkgs/commit/8c99b64556336b89c7bde7fabcd9cb4142c28f18) ctranslate2: withCUDA sets stdenv = gcc11Stdenv
* [`2cca81b2`](https://github.com/NixOS/nixpkgs/commit/2cca81b2adcc1541410e7e56756186fcb6a0c4e4) python311Packages.python-fedora: refactor
* [`c504b4d4`](https://github.com/NixOS/nixpkgs/commit/c504b4d46bd9fd268cda7febad354560b375826c) haskellPackages.ghc96.th-desugar: update reference 1.15 -> 1.16
* [`ad4c77e4`](https://github.com/NixOS/nixpkgs/commit/ad4c77e4fdfe7aa6c910b5f264a77a08cd3a6dd6) gex: 0.6.3. -> 0.6.4
* [`39fe1f1e`](https://github.com/NixOS/nixpkgs/commit/39fe1f1e54b16f0764657345a1047c8c021a3eb7) cloudlog: 2.5.0 -> 2.5.1
* [`2be3382a`](https://github.com/NixOS/nixpkgs/commit/2be3382a1df0d813a6c313f926b5917424a7ce47) fit-trackee: pin flask-sqlalchemy to 3.0.5
* [`e2f87ab3`](https://github.com/NixOS/nixpkgs/commit/e2f87ab3855762556297f0de4186e5c40958e0f0) touchosc: 1.2.4.180 -> 1.2.5.183
* [`0e169cf0`](https://github.com/NixOS/nixpkgs/commit/0e169cf0cc767c3c10284835f645198d89f83f51) itk: unvendor some of the dependencies
* [`dc16ee70`](https://github.com/NixOS/nixpkgs/commit/dc16ee70143744bd35e5ac7dba03bb729f19e5bd) gdcm: disable failing test on Aarch64
* [`d518566a`](https://github.com/NixOS/nixpkgs/commit/d518566a3076800978a2593c5f96cbf891983a26) mpvScripts.thumbfast: Refactor with `buildLua`
* [`9a360a73`](https://github.com/NixOS/nixpkgs/commit/9a360a73c083476000b9a8c7a5b367aedffaf919) mpvScripts.thumbfast: unstable-2023-06-06 → 2023-06-08
* [`ab23d42f`](https://github.com/NixOS/nixpkgs/commit/ab23d42fdf330603f5b65fdd761db8b7b42e773d) outline: 0.72.2 -> 0.73.1
* [`b48ec762`](https://github.com/NixOS/nixpkgs/commit/b48ec762e9d32be03454314333ee0344626a996e) petsc: 3.19.2 -> 3.19.4, fix tests, add more options
* [`6daf525c`](https://github.com/NixOS/nixpkgs/commit/6daf525c9d39174483384b618b962c53e9d21e78) quick-lint-js: support cross compiling
* [`843f1052`](https://github.com/NixOS/nixpkgs/commit/843f1052228ebf950d2c2151323880073519c66b) python3Packages.wagtail-localize: 1.6 -> 1.7
* [`23c92a19`](https://github.com/NixOS/nixpkgs/commit/23c92a19a342ce5203569e59997a66f0436c2968) wit-bindgen: 0.13.0 -> 0.14.0
* [`df75e9a4`](https://github.com/NixOS/nixpkgs/commit/df75e9a419988eeee9e6245cab1de18c2ba61fd5) python310Packages.uqbar: init at 0.7.0
* [`0f7de35e`](https://github.com/NixOS/nixpkgs/commit/0f7de35e2d7d44cc1000635762116b5d8da4854f) python310Packages.abjad: init at 3.19
* [`1b138461`](https://github.com/NixOS/nixpkgs/commit/1b1384618cbeaea924cdb421ed17e744bac4416c) maintainers: add 365tuwe
* [`0430dc41`](https://github.com/NixOS/nixpkgs/commit/0430dc415ed6c26a60b13540703a8f47bf8b523d) tera-cli: init at 0.2.5
* [`aa68c58a`](https://github.com/NixOS/nixpkgs/commit/aa68c58a9138c90444de1de12648ec7dc6db99eb) cargo-shuttle: 0.30.1 -> 0.33.0
* [`9756e476`](https://github.com/NixOS/nixpkgs/commit/9756e4769dba4039ef5c16b31fbe9fbfb396f2b8) oha: 0.6.5 -> 1.0.0
* [`cae15297`](https://github.com/NixOS/nixpkgs/commit/cae1529706068bcb607b028d0d2142a8a57ac90b) manix: 0.6.3 -> 0.7.1
* [`13a5e591`](https://github.com/NixOS/nixpkgs/commit/13a5e59195f556bd723578be22a3fd01d6766e0a) haskellPackages.kmonad: unbreak
* [`0f351078`](https://github.com/NixOS/nixpkgs/commit/0f3510781090e088ff4d2bcb4dbb2c5c173df6df) trilium-{desktop,server}: 0.60.4 -> 0.61.14
* [`7c2dc527`](https://github.com/NixOS/nixpkgs/commit/7c2dc527ec9b5f7fcfc0038519134c1ce9e68d60) audacity: 3.4.1 -> 3.4.2
* [`bdbadef2`](https://github.com/NixOS/nixpkgs/commit/bdbadef293acf4889fc1f796f2d8e528dc2597a9) audacity: switch to ffmpeg 6
* [`342b1ec9`](https://github.com/NixOS/nixpkgs/commit/342b1ec9752b08cf268455fdb08397ed18b2d8a8) navidrome: 0.49.3 -> 0.50.0
* [`2702f8c0`](https://github.com/NixOS/nixpkgs/commit/2702f8c0049181ef154d7eba551d4ab793af50b8) mystmd: 1.1.27 -> 1.1.29
* [`b95976f7`](https://github.com/NixOS/nixpkgs/commit/b95976f77c86c516f7136088b6f6423fffddef36) rubyPackages: gtk2 -> gtk3
* [`6d092421`](https://github.com/NixOS/nixpkgs/commit/6d092421973d12135be82bb6cfef15dc06423508) boundary: 0.14.1 -> 0.14.2
* [`789eccb0`](https://github.com/NixOS/nixpkgs/commit/789eccb0e7599aa0d6b144b4fe8583e7e7a7a69a) circus: pin to Python 3.10
* [`e621c4fe`](https://github.com/NixOS/nixpkgs/commit/e621c4fe602130f5ae4ffb093c00b49ae846b829) xtensor: switch to xsimd11
* [`2ab4e5cb`](https://github.com/NixOS/nixpkgs/commit/2ab4e5cb2542bde5806ed6faaaa809c765f706c9) xsimd10: remove
* [`2fd7fa6f`](https://github.com/NixOS/nixpkgs/commit/2fd7fa6fbe90e35225ada0d362992823bf656d18) haskell.compiler: link upstream issue for sphinx 7 patch
* [`d48d90ed`](https://github.com/NixOS/nixpkgs/commit/d48d90ed8aaa4ed16e6d0e2a27e06cd8746f359e) haskellPackages.ghc: 9.4.7 -> 9.4.8
* [`47a8cb60`](https://github.com/NixOS/nixpkgs/commit/47a8cb60570393664a205ee314fd6a3095581e02) haskell.compiler.integer-simple: construct using include list
* [`3af5377f`](https://github.com/NixOS/nixpkgs/commit/3af5377fa6dcd57c2bb2862a22dd98c93485d550) xtensor: remove a test failing on darwin
* [`3dce1fe2`](https://github.com/NixOS/nixpkgs/commit/3dce1fe21fe2f91ec91434b54dd57fc357c9e4a6) fwupd: 1.9.7 -> 1.9.8
* [`41c836ad`](https://github.com/NixOS/nixpkgs/commit/41c836ad8e09696da42deadc6e95bfb2b089d712) papirus-icon-theme: add withElementary optional argument
* [`8f69705d`](https://github.com/NixOS/nixpkgs/commit/8f69705dba34cc2f52b9a6d492f48a5d4134853a) audacity: prevent double wrapping
* [`ed34242a`](https://github.com/NixOS/nixpkgs/commit/ed34242a25afee198e6879b589a805f80dad5f25) bruno: 0.27.2 -> 1.1.1
* [`7f9abdcf`](https://github.com/NixOS/nixpkgs/commit/7f9abdcfcb7a44a9e8bbf954adeb6cce8e6800fe) nixos/nextcloud: fix docu of packages
* [`9f98f290`](https://github.com/NixOS/nixpkgs/commit/9f98f2904bb0b3fd80224c491440b6eb5ddcbed7) geoserver: fix startup script
* [`e6483fb7`](https://github.com/NixOS/nixpkgs/commit/e6483fb7e2d8df0feb6aa2d70d8c9e56254644b0) haskell.packages.ghc90.hspec-megaparsec: Fix build
* [`1f079b4f`](https://github.com/NixOS/nixpkgs/commit/1f079b4f44abd16ce13acc9bf497f4b20817a2b5) scryer-prolog: 0.9.2 -> 0.9.3
* [`0c8f03b8`](https://github.com/NixOS/nixpkgs/commit/0c8f03b8f0c3f425543aeb4ff2142945d916b96b) scryer-prolog: add wkral as a maintainer
* [`cdf75393`](https://github.com/NixOS/nixpkgs/commit/cdf7539341ae4cd9e6359d11554f95ec44357d94) docker-buildx: 0.11.2 -> 0.12.0
* [`e29677c5`](https://github.com/NixOS/nixpkgs/commit/e29677c5187b86d4d300f76574afc47e1991dc65) localsend: 1.11.1 -> 1.12.0, build from source
* [`2f41e7c6`](https://github.com/NixOS/nixpkgs/commit/2f41e7c6680b13dbcb4c5e2281b5e59863afcff2) python311Packages.pytaglib: 2.0.0 -> 2.1.0
* [`b42736ff`](https://github.com/NixOS/nixpkgs/commit/b42736ff9d04fe78699ae4ce4009f65da4ac1179) qt-video-wlr: 2020-08-03 -> 2023-07-22
* [`3d84496c`](https://github.com/NixOS/nixpkgs/commit/3d84496c930846948fb87bfc3dfce9997d5c713c) geoserver: add geospatial team to maintainers
* [`a0888000`](https://github.com/NixOS/nixpkgs/commit/a08880000dee157f618dc790ac3093e80cfc2b36) geoserver: add nixos test
* [`5a05ff45`](https://github.com/NixOS/nixpkgs/commit/5a05ff457951d47e925157521513bed21c18d3d1) python3Packages.pytest-order: 1.1.0 -> 1.2.0
* [`c0fd882c`](https://github.com/NixOS/nixpkgs/commit/c0fd882c3a382bf816ee18281932eb0941f5fb8a) cider: 1.6.1 -> 1.6.2
* [`4a91c1cf`](https://github.com/NixOS/nixpkgs/commit/4a91c1cf1a6391e35d22f429518d3c9160ecec65) python3Packages.furo: 2023.7.26 -> 2023.8.19
* [`be160f8f`](https://github.com/NixOS/nixpkgs/commit/be160f8f9a48989fe70356d0e03b75df8db193e3) python3Packages.furo: 2023.8.19 -> 2023.9.10
* [`d005b1ee`](https://github.com/NixOS/nixpkgs/commit/d005b1eec08a8187f11cd3fab9d0c76fa1324213) powershell: 7.3.9 -> 7.4.0
* [`fa9cdc83`](https://github.com/NixOS/nixpkgs/commit/fa9cdc83ab2a284aeaeebbeef89ec0d7eda17943) nixos/firewall: install nixos-firewall-tool for iptables by default
* [`de061611`](https://github.com/NixOS/nixpkgs/commit/de06161146c0f5e95ebf0a587df9b853eb684359) moon-buggy: add darwin compatibility
* [`849bbaed`](https://github.com/NixOS/nixpkgs/commit/849bbaedae4915dde1803083fe4a482cd3c1ab51) hyprshot: init at 1.2.3
* [`fa6d090b`](https://github.com/NixOS/nixpkgs/commit/fa6d090ba3bd3e2a8c453e8d34897b9fc5842850) datadog-agent: fix metric submission
* [`260586f1`](https://github.com/NixOS/nixpkgs/commit/260586f102d97e5d62e37afed4fc97fbd8c71300) bililiverecorder: 2.10.0 -> 2.10.1
* [`e9ca34f2`](https://github.com/NixOS/nixpkgs/commit/e9ca34f2125abce1f7282829129eaa1bfbb74e4c) abcmidi: 2023.09.13 -> 2023.11.17
* [`20e9267c`](https://github.com/NixOS/nixpkgs/commit/20e9267cbb4b145906380b918c08c7904c31fc6f) factorio: add dynamic server-settings loading
* [`f64eedb5`](https://github.com/NixOS/nixpkgs/commit/f64eedb5090c19ad18546a64f311d0106fe4037b) fheroes2: 1.0.9 -> 1.0.10
* [`ac3ddf46`](https://github.com/NixOS/nixpkgs/commit/ac3ddf46993c807b04f9b3ab941447f693ce4564) fioctl: 0.35 -> 0.38
* [`f88ba061`](https://github.com/NixOS/nixpkgs/commit/f88ba06143b7dc37dde56e55870a49267aeb26e2) hydra_unstable: 2023-10-20 -> 2023-11-17
* [`3f18b3cf`](https://github.com/NixOS/nixpkgs/commit/3f18b3cf10aef148350621eb065b9ef8a92390bb) pastebinit: fix deprecation warning and add darwin compatibility
* [`78c62132`](https://github.com/NixOS/nixpkgs/commit/78c62132ea1b39ca361f8f242953e10674805fa2) pantheon.granite7: 7.3.0 -> 7.4.0
* [`57788f74`](https://github.com/NixOS/nixpkgs/commit/57788f74b9a68b367e924264d4eb805f4c55ae96) gensio: 2.6.2 -> 2.7.7
* [`29fc9d1d`](https://github.com/NixOS/nixpkgs/commit/29fc9d1d8a5c08cb7e1ed737200d94d05eb315c7) python310Packages.glueviz: 1.14.1 -> 1.16.0
* [`d81ca2b4`](https://github.com/NixOS/nixpkgs/commit/d81ca2b405b195e8e40e015504f206a1b7c74e55) feh: Fix right-click buffer overflow crash
* [`22048dd6`](https://github.com/NixOS/nixpkgs/commit/22048dd6b59af2852b2c9991324e4cc5fd4f6367) minizip-ng: 4.0.2 -> 4.0.3
* [`ff903690`](https://github.com/NixOS/nixpkgs/commit/ff903690dc839872762bd4c19457d7919ab14d6f) prqlc: 0.10.0 -> 0.10.1
* [`a6cd4416`](https://github.com/NixOS/nixpkgs/commit/a6cd44164c4bff60beee410dd7136bcc4e0e07c5) lowdown: 1.0.2 -> 1.1.0
* [`e0f99ff2`](https://github.com/NixOS/nixpkgs/commit/e0f99ff238711aca22e77074de7f39783e45d227) hysteria: 2.2.0 -> 2.2.1
* [`601abf36`](https://github.com/NixOS/nixpkgs/commit/601abf3649447e137907b497490d91fb4a9be29c) python311Packages.apricot-select: init at 0.6.1
* [`2e1a0993`](https://github.com/NixOS/nixpkgs/commit/2e1a0993183796f2beb47d413da25742c865a4b7) changelog-d: init
* [`9009c53c`](https://github.com/NixOS/nixpkgs/commit/9009c53c9719a509920824e480731431bb3b4622) changelog-d: Use justStaticExecutables
* [`3ce9db80`](https://github.com/NixOS/nixpkgs/commit/3ce9db808b5bf6cf7e7c9c64d20c17620916c7e7) changelog-d: Move out tests.basic
* [`25df0e64`](https://github.com/NixOS/nixpkgs/commit/25df0e640974599c813e9bb3e8a9fba28f79bd12) changelog-d: Move out updateScript
* [`0ff56d50`](https://github.com/NixOS/nixpkgs/commit/0ff56d503a3177e21816d9864a215ee3da3d42ac) haskellPackages.changelog-d: Rename file
* [`eb8dafd2`](https://github.com/NixOS/nixpkgs/commit/eb8dafd288ccfffc18ff3b6fd41f01ef896e4039) changelog-d: Document tests and updateScript
* [`9f4a3df2`](https://github.com/NixOS/nixpkgs/commit/9f4a3df2e739c43e116a5f37eab86d7b211111da) changelog-d: Add shell completions
* [`44729300`](https://github.com/NixOS/nixpkgs/commit/44729300662727d30ff0a36f0637a7cecedf1bbf) rdma-core: 48.0 -> 49.0
* [`9eff21b3`](https://github.com/NixOS/nixpkgs/commit/9eff21b373b386bd4ac6038532dd23ee56ad59c8) snyk: 1.1207.0 -> 1.1248.0
* [`0e6cfd30`](https://github.com/NixOS/nixpkgs/commit/0e6cfd30a3a73f834ccd12c71a405133ca090809) haskellPackages: mark builds failing on hydra as broken
* [`9de97050`](https://github.com/NixOS/nixpkgs/commit/9de97050d175d66c9a2bc3e4b7b0104156af0b59) jabref: 5.10 -> 5.11
* [`a3dbce27`](https://github.com/NixOS/nixpkgs/commit/a3dbce27805e7453716a99a5f9c5b66eea1cd6b9) bun: 1.0.12 -> 1.0.13
* [`b6094308`](https://github.com/NixOS/nixpkgs/commit/b6094308ebbeb36495eb93c083c8a93e44d6985f) goss: 0.4.2 -> 0.4.4
* [`98a39fcd`](https://github.com/NixOS/nixpkgs/commit/98a39fcd619580d6102e6df9ea2701ca7726ff53) syft: 0.96.0 -> 0.97.1
* [`2ac09795`](https://github.com/NixOS/nixpkgs/commit/2ac0979531f2e0cafbb6faa310a75f43ed6e4202) keepass-diff: 1.1.3 -> 1.2.0
* [`2c2bc861`](https://github.com/NixOS/nixpkgs/commit/2c2bc861647c9b9524899b0695523553b06a27ff) Fix failing build of xkcdpass due to non-dt test
* [`0c82a228`](https://github.com/NixOS/nixpkgs/commit/0c82a2283860b290565eeb713ad468e7679fe7e1) calibre: 6.29.0 -> 7.0.0
* [`2ec633e8`](https://github.com/NixOS/nixpkgs/commit/2ec633e8ae25da628a9bfb06dc1344c452408875) Add pretty name for applied patch
* [`68e012e4`](https://github.com/NixOS/nixpkgs/commit/68e012e49a201e6890250cf0657ab71b29244c87) luabind_luajit: Fix build on all platforms
* [`f9c070ba`](https://github.com/NixOS/nixpkgs/commit/f9c070ba0b7e02b617bfa51cd0bfd1a8ba33fb22) halloy: 2023.4 -> 2023.5
* [`1375f28c`](https://github.com/NixOS/nixpkgs/commit/1375f28c0e96163f72017542cfa7f6ae9e7c3bcf) mcuboot-imgtool: fix pname
* [`8e4bc117`](https://github.com/NixOS/nixpkgs/commit/8e4bc117e37b5770ac6b8e676ef6ee384b3a57f8) python311Packages.datadog: mark broken
* [`aa31edd7`](https://github.com/NixOS/nixpkgs/commit/aa31edd7467c4141ea1b7f639eb367e196583c84) keedump: init at 0.1.0
* [`533df7ae`](https://github.com/NixOS/nixpkgs/commit/533df7ae7523a1e6dd2235a20e65abaa08e3938d) telegram-desktop: build on Darwin
* [`13f0af42`](https://github.com/NixOS/nixpkgs/commit/13f0af428ebce3411faa1eac184c3032ef423239) lib.fileset: Add overview section to reference docs
* [`deb32e08`](https://github.com/NixOS/nixpkgs/commit/deb32e08a2b57c536d4f5d4ff3abab3f49fe233e) opendrop: cleanup, add openssl to PATH
* [`4164b1c4`](https://github.com/NixOS/nixpkgs/commit/4164b1c47e5526278c02aeb49bc08d1a308be10e) lib.fileset: Re-order to match reference overview
* [`91978dff`](https://github.com/NixOS/nixpkgs/commit/91978dff82072cc21fb860ba996f14bcf09a77df) uiua: 0.2.0 -> 0.3.0
* [`b8686281`](https://github.com/NixOS/nixpkgs/commit/b8686281f85087067be905a4daa2bc0ad2e014cf) vscode-extensions.uiua-lang.uiua-vscode: 0.0.23 -> 0.0.24
* [`37e563cb`](https://github.com/NixOS/nixpkgs/commit/37e563cbc775b3e8934b37a3de3425aee735e3b4) nixVersions.2_3: 2.3.16 -> 2.3.17
* [`94a5cfaa`](https://github.com/NixOS/nixpkgs/commit/94a5cfaae6ef5df42bd131da04125a6480983023) nix_2_3: configure different maintainers
* [`0a58ab81`](https://github.com/NixOS/nixpkgs/commit/0a58ab81c2a54e587ba9eee30215cdf9606f91aa) rustic-rs: 0.5.4 -> 0.6.1
* [`e34c090c`](https://github.com/NixOS/nixpkgs/commit/e34c090c6d660ba4a7b8008547114601aa1af3b7) jenkins: 2.414.3 -> 2.426.1
* [`b56b0b28`](https://github.com/NixOS/nixpkgs/commit/b56b0b28a6f37388b922a42fc6c2b4172857a6e7) python311Packages.opensearch-py: 2.4.1 -> 2.4.2
* [`00111365`](https://github.com/NixOS/nixpkgs/commit/001113653e989531d7a701aaae4a19753a52be27) python3Packages.clvm-rs: 0.1.19 -> 0.3.0
* [`a43b7a77`](https://github.com/NixOS/nixpkgs/commit/a43b7a7751f7258893b9b4883d6af910c0641324) texlive.withPackages: convert tlDeps packages to attribute sets
* [`846cad76`](https://github.com/NixOS/nixpkgs/commit/846cad767ffd19f182b7108bca04d367ca7bc671) texlive.withPackages: pass package set to requiredTeXPackages instead of empty list
* [`631eca2e`](https://github.com/NixOS/nixpkgs/commit/631eca2e965325b4f006ae871421baa0b0074c79) texlive: document simpler way to build custom packages
* [`7377bba1`](https://github.com/NixOS/nixpkgs/commit/7377bba1c77b8d4f2f6b9957df34f354bf1da601) bazel_6: fix: make patched bash a native binary
* [`dd854492`](https://github.com/NixOS/nixpkgs/commit/dd854492117036e0c218d63ba3a5b2894cf7ce89) Update pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
* [`a7bbd704`](https://github.com/NixOS/nixpkgs/commit/a7bbd70413666119c13d56216457c352d8dad156) CODEOWNERS: Remove line for removed file
* [`055ba65f`](https://github.com/NixOS/nixpkgs/commit/055ba65fed8eac15b13ed68f70a7d506f9b2d291) lib: Take advantage of section descriptions
* [`941ea61e`](https://github.com/NixOS/nixpkgs/commit/941ea61ed03ee8059530d7ba50d74c257a10f587) rshim-user-space: 2.0.11 -> 2.0.12
* [`12c0a5ca`](https://github.com/NixOS/nixpkgs/commit/12c0a5cab96c3e9eb31d65bce3191ee012ba2462) libgpiod_1: restore 1.6.4 version
* [`37136d86`](https://github.com/NixOS/nixpkgs/commit/37136d86032b920a1dec03439eb046ab873c2310) rspamd: 3.7.3 -> 3.7.4
* [`20414d1a`](https://github.com/NixOS/nixpkgs/commit/20414d1a402e36c14e1dd4498e48e2e6153acecd) openocd: use libgpiod_1 instead of duplicated expressions
* [`ca81640a`](https://github.com/NixOS/nixpkgs/commit/ca81640aaf73ac4aa6250e1ff7532e8a9111479e) openocd-rp2040: use libgpiod_1 instead of duplicated expressions
* [`0d2085b1`](https://github.com/NixOS/nixpkgs/commit/0d2085b1626f9e6f313a4e63e822a08f3914a163) flashrom-stable: fix build due to incompatibility with libgpiod v2 API
* [`150db36b`](https://github.com/NixOS/nixpkgs/commit/150db36be14b040f734ec83d14f0c53566d1646b) wishlist: 0.14.0 -> 0.14.1
* [`0c35c624`](https://github.com/NixOS/nixpkgs/commit/0c35c6248337599311f66c4d041120e8718fcc15) jitsi-meet-prosody: 1.0.7531 -> 1.0.7629
* [`73908903`](https://github.com/NixOS/nixpkgs/commit/73908903ec13be6d9274bf94dadacf94ddc5e8f1) jitsi-meet: 1.0.7531 -> 1.0.7629
* [`841bd4d9`](https://github.com/NixOS/nixpkgs/commit/841bd4d99c51eea4722cbf4022f33ce5de673043) jitsi-videobridge: 2.3-44-g8983b11f -> 2.3-59-g5c48e421
* [`6794de08`](https://github.com/NixOS/nixpkgs/commit/6794de08f74a173086f6e918805156c23e057bfa) functional-linear-algebra: 0.4->0.4.1
* [`9efd78a3`](https://github.com/NixOS/nixpkgs/commit/9efd78a3a2f07b2ffde6ad62c29a2cff19a8865c) haskellPackages: add ghc-syntax-highlighter 0.0.10
* [`688fb101`](https://github.com/NixOS/nixpkgs/commit/688fb101e654869219ad51622e8cf84b6e9214c3) haskellPackages: regenerate package set based on current config
* [`024210d4`](https://github.com/NixOS/nixpkgs/commit/024210d44f7dc65a387e61f250b4192807294949) haskellPackages.ihaskell: unbreak
* [`13f7396f`](https://github.com/NixOS/nixpkgs/commit/13f7396fc18a30d269078b7b97bbfa19f0bfdb76) junicode: 2.200 -> 2.203
* [`d0782548`](https://github.com/NixOS/nixpkgs/commit/d07825480ab34e70b28ec7f441db46c32165bc8a) haskellPackages: mark ihaskell and dependencies unbroken
* [`4b375a4b`](https://github.com/NixOS/nixpkgs/commit/4b375a4b12e1582709419d5dce44288764145156) haskellPackages: regenerate package set based on current config
* [`d369fe24`](https://github.com/NixOS/nixpkgs/commit/d369fe2410c14d9531240c2ff666c6d32e82e18e) klipper: unstable-2023-10-21 -> unstable-2023-11-16
* [`b123dc76`](https://github.com/NixOS/nixpkgs/commit/b123dc763ca05fd67be7d01e7f7e8de232f6b808) vimPlugins: update on 2023-11-19
* [`951afedb`](https://github.com/NixOS/nixpkgs/commit/951afedbb62b6a71413cb44314827eca6a1f0f3a) vimPlugins.nvim-treesitter: update grammars
* [`b1a9b8d4`](https://github.com/NixOS/nixpkgs/commit/b1a9b8d47e2074391f95265d76f14680c2f3931f) commonsCompress: 1.24.0 -> 1.25.0
* [`4d0449ab`](https://github.com/NixOS/nixpkgs/commit/4d0449ab332b9a79b15da4d3f2762f65b224d656) discordo: unstable-2023-10-22 -> unstable-2023-11-14
* [`b4bbe73e`](https://github.com/NixOS/nixpkgs/commit/b4bbe73ed174d96c6eac32b788b62100252d3db5) zrok: 0.4.10 -> 0.4.15
* [`bdb599a3`](https://github.com/NixOS/nixpkgs/commit/bdb599a34c7258a44f6bc58aa52450ec81959659) zap: 2.13.0 -> 2.14.0
* [`52d05a38`](https://github.com/NixOS/nixpkgs/commit/52d05a3869ff24e19575dcb4835fcc0898ca3000) datadog-agent: 7.48.1 -> 7.49.0
* [`c155f439`](https://github.com/NixOS/nixpkgs/commit/c155f439382d85e10d3136ad8617ad6c14b37407) zarf: 0.30.0 -> 0.31.0
* [`f4f8e7c1`](https://github.com/NixOS/nixpkgs/commit/f4f8e7c13d3e3b33e9a43f1e1ff97d1697ec6240) circt: 1.58.0 -> 1.59.0
* [`eb5bf52c`](https://github.com/NixOS/nixpkgs/commit/eb5bf52c361be798d2794c5d080276867fe32556) kodiPackages.typing_extensions: 3.7.4.3 -> 4.7.1
* [`a530717b`](https://github.com/NixOS/nixpkgs/commit/a530717b86b220b646e4fb513759ea8b5c3d7070) kodiPackages.websocket: 0.58.0+matrix.2 -> 1.6.2
* [`31cc12bc`](https://github.com/NixOS/nixpkgs/commit/31cc12bc38bd6621252a256a2efcc92aa244121c) kraft: 0.6.6 -> 0.7.0
* [`71f9d1aa`](https://github.com/NixOS/nixpkgs/commit/71f9d1aab4fdca03d75c70ef87fd52feb7d21dee) kubedb-cli: 0.36.0 -> 0.37.0
* [`bc491200`](https://github.com/NixOS/nixpkgs/commit/bc491200033c72bffe2766c6f1ba9566428ab7eb) kubeseal: 0.24.2 -> 0.24.4
* [`5b84e5d7`](https://github.com/NixOS/nixpkgs/commit/5b84e5d78a2eff730a95313bee0a427825b1e5b2) kubeshark: 51.0.14 -> 51.0.27
* [`4800982f`](https://github.com/NixOS/nixpkgs/commit/4800982f99ee920c648672edb6fced33de2d9aea) hol_light: 2023-07-21 → 2023-11-03
* [`c60d7e0c`](https://github.com/NixOS/nixpkgs/commit/c60d7e0c77b281edd12ceab4f2f889ed67cfb836) ocamlPackages.camlp5: 8.00.05 → 8.02.1
* [`c6ae3f37`](https://github.com/NixOS/nixpkgs/commit/c6ae3f37a15eb4cf5de67294421e11bda283aaed) orpie: use default version of OCaml
* [`40003254`](https://github.com/NixOS/nixpkgs/commit/40003254a3d1557f91f1aa742293ee2e881ef900) kaldi: unstable-2023-10-13 -> unstable-2023-11-13
* [`a79b3a06`](https://github.com/NixOS/nixpkgs/commit/a79b3a0638e5b4526787b1843dbc2a95c33e0d7c) speedtest-go: 1.6.7 -> 1.6.9
* [`c5dbdb61`](https://github.com/NixOS/nixpkgs/commit/c5dbdb6182ee2b089ef060b76052adc6a3547680) nats-streaming-server: 0.25.5 -> 0.25.6
* [`4563bbad`](https://github.com/NixOS/nixpkgs/commit/4563bbadb91c6d7715feb499406c4f77a8b89c3d) gensio: fix build on darwin
* [`2f3dd454`](https://github.com/NixOS/nixpkgs/commit/2f3dd454f4e0aa4366ca1313d5c2ebe3f3a81fb4) lagrange: 1.17.3 -> 1.17.4
* [`3cc61163`](https://github.com/NixOS/nixpkgs/commit/3cc61163d12598f07e15a1ba418bae14fda52ae1) cargo-mommy: 0.2.0 -> 0.3.1
* [`537bedd1`](https://github.com/NixOS/nixpkgs/commit/537bedd19e26d88609ea9a72bf12161c651e6407) haskellPackages: mark builds failing on hydra as broken
* [`3be1aab8`](https://github.com/NixOS/nixpkgs/commit/3be1aab86f699fc2085a3b9da8dbf97092a99f78) centrifugo: init at 5.1.1
* [`728d6d91`](https://github.com/NixOS/nixpkgs/commit/728d6d9109f62677d4aff41aa9a070dc0adcbf7a) armadillo: 12.6.5 -> 12.6.6
* [`ae190884`](https://github.com/NixOS/nixpkgs/commit/ae1908845f453f2279e33c9b60b2ee47f979c6ca) gpu-screen-recorder: 1.0.0 -> unstable-2023.11.18
* [`cdff1a05`](https://github.com/NixOS/nixpkgs/commit/cdff1a05eeabbd0cbb8156cee99746ea8b0c995f) racket: fix build on darwin
* [`2c97a5ca`](https://github.com/NixOS/nixpkgs/commit/2c97a5caa739bf13ed8dc9fd62779b228846463e) maintainers: remove jfrankenau
* [`a27e78c9`](https://github.com/NixOS/nixpkgs/commit/a27e78c987961752f916c6b014c57a69669b379c) aide: 0.17.4 -> 0.18.6
* [`01c615fb`](https://github.com/NixOS/nixpkgs/commit/01c615fb2db939c1b89e4a00b6cfbbd45b7255e6) aide: add happysalada as maintainer
* [`181a9fe1`](https://github.com/NixOS/nixpkgs/commit/181a9fe1eaf18e8416bf62d505824d5d33d9e77c) easycrypt: fix runtest command
* [`b57ae8fe`](https://github.com/NixOS/nixpkgs/commit/b57ae8fe82cf48e41f967c11cd78cff9be5675ff) phpPackages.castor: 0.9.1 -> 0.10.0
* [`5fec0d8a`](https://github.com/NixOS/nixpkgs/commit/5fec0d8a357c69559c56c8dfdcc5b0a2ab29ef65) mailpit: 1.10.0 -> 1.10.1
* [`cbc2d7cb`](https://github.com/NixOS/nixpkgs/commit/cbc2d7cbfe96eecd6ab56247059749fec49a2f92) kubedock: init at 0.14.1
* [`79e743fe`](https://github.com/NixOS/nixpkgs/commit/79e743fe3bcc65a33380ce7040c1fce3a89e5f07) python311Packages.azure-eventhub: 5.11.4 -> 5.11.5
* [`d6f634c4`](https://github.com/NixOS/nixpkgs/commit/d6f634c42be3d3cdcb417e5e701427be108092b3) python311Packages.azure-mgmt-keyvault: 10.2.3 -> 10.3.0
* [`eb1d6dc5`](https://github.com/NixOS/nixpkgs/commit/eb1d6dc5e60b1279d5507250aca58b2ed6ea4fbd) python311Packages.azure-synapse-artifacts: 0.17.0 -> 0.18.0
* [`9cf60c4a`](https://github.com/NixOS/nixpkgs/commit/9cf60c4a56faeca2f22ff303f6f7a07d80f72f7a) python311Packages.bc-python-hcl2: 0.3.51 -> 0.4.1
* [`49ecc196`](https://github.com/NixOS/nixpkgs/commit/49ecc196862133ce9cba80546093fdb9ccda4e5a) python311Packages.cantools: 39.3.0 -> 39.4.0
* [`963372bb`](https://github.com/NixOS/nixpkgs/commit/963372bb1162951217d8aca9c3849e06f14d3202) legba: init at 0.6.0
* [`cc9e3666`](https://github.com/NixOS/nixpkgs/commit/cc9e3666916c9be95a8c201459b36adc0810b9f6) padre: init at 2.1.0
* [`2d706ffa`](https://github.com/NixOS/nixpkgs/commit/2d706ffaf334079b26f56f2be64f0184b4ede27d) multipass: fix broken fetch of git submodules in build
* [`5d6f4ec5`](https://github.com/NixOS/nixpkgs/commit/5d6f4ec5f073023790c01d25e3275e21a1b590b1) rl-2311: mention new texlive.withPackages and simpler custom TeX packages
* [`96e3dd4a`](https://github.com/NixOS/nixpkgs/commit/96e3dd4aa1de9011e9fff57eddb38517a85e71e8) osl: fix build, 1.12.13.0 -> 1.12.14.0
* [`a7543a03`](https://github.com/NixOS/nixpkgs/commit/a7543a03bbe4ea28584d4ae430bf78b3031e77cb) libation: init at 11.1.0
* [`c475ac32`](https://github.com/NixOS/nixpkgs/commit/c475ac3248877ce62bca18c659c7e9e2f9ee651e) chromium: add libglvnd to rpath
* [`2b896f47`](https://github.com/NixOS/nixpkgs/commit/2b896f4769f06165d22290a1f5c61ef987a33ba6) python3.pkgs.pybind11: remove unused input
* [`88a737ad`](https://github.com/NixOS/nixpkgs/commit/88a737ad9cc6a8343fe75b92d646a39f0c6fd922) pdm: 2.10.1 -> 2.10.3
* [`213e94a1`](https://github.com/NixOS/nixpkgs/commit/213e94a16e3aa52e7b98877a9a584db09d854ad9) checkov: 3.0.38 -> 3.0.40
* [`4b67d1a2`](https://github.com/NixOS/nixpkgs/commit/4b67d1a286c60c0906ec3e9c16486fefbcdd3f21) below: 0.6.3 -> 0.7.1
* [`b10f0e5f`](https://github.com/NixOS/nixpkgs/commit/b10f0e5faa3d78fa15c5773b63f15a597004fcb7) tailspin: 2.1.0 -> 2.2.0
* [`1d47cfbf`](https://github.com/NixOS/nixpkgs/commit/1d47cfbf65c57cfd03db57b48d7b1386a74a0286) mastodon: easier build patching
* [`7524d685`](https://github.com/NixOS/nixpkgs/commit/7524d6850a50c112f25e4aae609f308492ec49a6) libndtypes: add `dev` output
* [`7f40672e`](https://github.com/NixOS/nixpkgs/commit/7f40672e68c8325e6efe7e80ee9c212fcc36d105) python3Packages.ndtypes: add `dev` output
* [`d850d3be`](https://github.com/NixOS/nixpkgs/commit/d850d3bec484b80f5ce75188699c77f27e9922d1) rustic-rs: fix typo in `meta.changelog`
* [`0a6a7c83`](https://github.com/NixOS/nixpkgs/commit/0a6a7c83417c74c58e54b0e828ff6d6b21a39a5b) vector: Added upstream patch for Rust 1.73 fix
* [`49f367d4`](https://github.com/NixOS/nixpkgs/commit/49f367d412e01054407c55b19ffae51b8ad1dd38) alacritty-theme: unstable-2023-10-26 -> unstable-2023-11-07
* [`1dd8dd00`](https://github.com/NixOS/nixpkgs/commit/1dd8dd0019f920ca6673d514ecd35a6f92f86bb0) ibus-engines.m17n: 1.4.23 -> 1.4.24
* [`809f9260`](https://github.com/NixOS/nixpkgs/commit/809f926017796e7894271a530ac1cb9aa3401222) nixos/postgresql: fix mentioned settings in ensurePermissions warnings
* [`d87ee1ba`](https://github.com/NixOS/nixpkgs/commit/d87ee1bae0f6889ac473aba8d731c8ff361d544a) lib/maintainers: remove lheckemann from determinatesystems
* [`5bb41dca`](https://github.com/NixOS/nixpkgs/commit/5bb41dcaef6e48a93d79402b95c5bdd17d36957a) gcp-scanner: init at 1.3.0
* [`d5eddab5`](https://github.com/NixOS/nixpkgs/commit/d5eddab5b5a0d01c9c445043d370459ac0ff869f) elixir-ls: 0.17.3 -> 0.17.10
* [`80e1bce5`](https://github.com/NixOS/nixpkgs/commit/80e1bce562cc45903ac7912c28bd8200167f77bb) qt6.qtwayland: fix a crash issue with popup/submenus
* [`258e7ac0`](https://github.com/NixOS/nixpkgs/commit/258e7ac023d014882bda0850efdc2031035ee1e7) dua: 2.20.1 -> 2.20.2
* [`bb74ffd7`](https://github.com/NixOS/nixpkgs/commit/bb74ffd75616ffbd45df5ca81b66cb45bf5d9f29) go-sct: set meta.platforms
* [`7ce67836`](https://github.com/NixOS/nixpkgs/commit/7ce67836c3c3d1f1e5116dd5c7b0eb810b6425fc) mkl: fix hashes ([nixos/nixpkgs⁠#268693](https://togithub.com/nixos/nixpkgs/issues/268693))
* [`421a0d90`](https://github.com/NixOS/nixpkgs/commit/421a0d907b3a798599d0b5182cd69aca4e7c6ce3) linux_testing: 6.7-rc1 -> 6.7-rc2
* [`8bf55fee`](https://github.com/NixOS/nixpkgs/commit/8bf55fee357e4030208145e453fbcabbbfcebdfe) linux_6_6: 6.6.1 -> 6.6.2
* [`f1833b9d`](https://github.com/NixOS/nixpkgs/commit/f1833b9d4d45df710d7404ba06e6a6569d75fd79) linux_6_5: 6.5.11 -> 6.5.12
* [`b0e41f93`](https://github.com/NixOS/nixpkgs/commit/b0e41f935500ab018efcbbad4863105d3019edee) linux_6_1: 6.1.62 -> 6.1.63
* [`64de0b9c`](https://github.com/NixOS/nixpkgs/commit/64de0b9ca9c9a3f7610f97da0d67d9944abf88f3) linux_5_15: 5.15.138 -> 5.15.139
* [`94bb359c`](https://github.com/NixOS/nixpkgs/commit/94bb359cd82399eee3687d44fb49501a8e8e9a17) linux_5_10: 5.10.200 -> 5.10.201
* [`a7e86abf`](https://github.com/NixOS/nixpkgs/commit/a7e86abf01a4526efe2dc10099a1b881c6130c88) linux_5_4: 5.4.260 -> 5.4.261
* [`a08fcd0d`](https://github.com/NixOS/nixpkgs/commit/a08fcd0dac054e3e494a967b1871101351fdf673) linux_4_19: 4.19.298 -> 4.19.299
* [`c244dc12`](https://github.com/NixOS/nixpkgs/commit/c244dc12396218d6ae77b3ca13fe8a5f8eddf257) linux_4_14: 4.14.329 -> 4.14.330
* [`93040a29`](https://github.com/NixOS/nixpkgs/commit/93040a298ce94b6d2aba4b2902584805982526ff) vulkan-utility-libraries: 1.3.270 -> 1.3.268
* [`2efc126f`](https://github.com/NixOS/nixpkgs/commit/2efc126f85d580ad387866b8fc217a5b634a7a12) miniaudio: 0.11.18 -> 0.11.20
* [`248fceed`](https://github.com/NixOS/nixpkgs/commit/248fceed0e3430fb4a02a56dfba2413559f6e89f) mission-center: fix libGL.so not found
* [`8cf2ea85`](https://github.com/NixOS/nixpkgs/commit/8cf2ea853702f61373f22a9b0df53bdc7fa1d4a3) netmaker: change license to Apache
* [`8f36fa2c`](https://github.com/NixOS/nixpkgs/commit/8f36fa2c0f41d16678dd7af370ea1f9331a26682) celeste: 0.8.0 -> 0.8.1
* [`ab4c37fb`](https://github.com/NixOS/nixpkgs/commit/ab4c37fb7e2facbb99c1e6360bdd83ece746210d) igraph: 0.10.7 -> 0.10.8
* [`ab08d2f8`](https://github.com/NixOS/nixpkgs/commit/ab08d2f8d72951c35d793e09a6a0ec8bd5cf5657) python311Packages.igraph: 0.11.2 -> 0.11.3
* [`35132b62`](https://github.com/NixOS/nixpkgs/commit/35132b620c6b5296fdc2be9cc0d0ce9cc96a166e) mousai: 0.7.5 -> 0.7.6
* [`5ece469a`](https://github.com/NixOS/nixpkgs/commit/5ece469a8be8587da23dee4bd03b185a0830c68d) python311Packages.ibm-cloud-sdk-core: 3.17.2 -> 3.18.0
* [`05e7977f`](https://github.com/NixOS/nixpkgs/commit/05e7977fa99561374eb654159335be1e46b5ad0a) python311Packages.ibm-cloud-sdk-core: update disabled
* [`a8f38626`](https://github.com/NixOS/nixpkgs/commit/a8f3862611fd72b8096ef08f72190a274758c448) rapidfuzz-cpp: 2.1.1 -> 2.2.3
* [`e9861f19`](https://github.com/NixOS/nixpkgs/commit/e9861f19a7a9975fa7bc6a2b952df71221de4c6a) python311Packages.rapidfuzz: 3.4.0 -> 3.5.2
* [`d0816cb4`](https://github.com/NixOS/nixpkgs/commit/d0816cb45fcd91813d6312213d33388756ce8990) duperemove: 0.13 -> 0.14
* [`2eb9c21b`](https://github.com/NixOS/nixpkgs/commit/2eb9c21bad1fc31a53560982784286076614823c) python311Packages.latexify-py: 0.3.1 -> 0.4.1
* [`5527ad0b`](https://github.com/NixOS/nixpkgs/commit/5527ad0b164e2671ca2986ec81ec29ac24248120) python310Packages.python-on-whales: 0.66.0 -> 0.67.0
* [`a4752fe9`](https://github.com/NixOS/nixpkgs/commit/a4752fe92a917efc1e5a4f178950baebf48b8d9d) python311Packages.mdformat-frontmatter: 2.0.1 -> 2.0.8
* [`4bae64e4`](https://github.com/NixOS/nixpkgs/commit/4bae64e4203858fc4f10484aa9f8c60c39565d23) python311Packages.mdformat-frontmatter: add changelog to meta
* [`a1e8af43`](https://github.com/NixOS/nixpkgs/commit/a1e8af430e78e1fa05703708df31d03707f29840) python311Packages.mdformat-mkdocs: 1.0.4 -> 1.0.6
* [`6e4900ba`](https://github.com/NixOS/nixpkgs/commit/6e4900bae72232ad41d671ff4726ee966526c923) python311Packages.mitmproxy-macos: 0.3.11 -> 0.4.1
* [`58802b68`](https://github.com/NixOS/nixpkgs/commit/58802b68fe41ec2f5ddf6d0c6a109deb7a912aa6) typioca: 2.7.0 -> 2.8.0
* [`b770a059`](https://github.com/NixOS/nixpkgs/commit/b770a059ca3c844b29fb18d6347c23b4c2117c1b) python311Packages.mitmproxy-rs: 0.3.11 -> 0.4.1
* [`d86d781c`](https://github.com/NixOS/nixpkgs/commit/d86d781cb3db8861b58ec2821c80d797a596fd80) vesktop: add cacert to pnpmDeps derivation
* [`976c1712`](https://github.com/NixOS/nixpkgs/commit/976c17127bf3a644d03dd90c9790ec3edad800f1) cargo-codspeed: 2.3.2 -> 2.3.3
* [`d6ed0a19`](https://github.com/NixOS/nixpkgs/commit/d6ed0a1927f58b34c86a54d0c00b24cf90a71d6c) python311Packages.pex: 2.1.151 -> 2.1.153
* [`a43c1c10`](https://github.com/NixOS/nixpkgs/commit/a43c1c1090e332212cbbae5e6c633e1b03c28acb) wxformbuilder: unstable-2023-04-21 -> 4.0.0
* [`dc25d174`](https://github.com/NixOS/nixpkgs/commit/dc25d1744f59e438240867a5cfdd929cea256153) python311Packages.pikepdf: 8.4.0 -> 8.7.1
* [`98aae7c0`](https://github.com/NixOS/nixpkgs/commit/98aae7c031b8bb24d54cc4fe2ffda98e0bee2007) python311Packages.ocrmypdf: 15.4.0 -> 15.4.3
* [`91ac5b75`](https://github.com/NixOS/nixpkgs/commit/91ac5b759cba787a1291ccd13139425164eca438) experienced-pixel-dungeon: 2.15.3 -> 2.16
* [`beb50cde`](https://github.com/NixOS/nixpkgs/commit/beb50cdebe5fc9081f3fd106dc7bbc7dbd3951ca) python311Packages.pgspecial: 2.1.0 -> 2.1.1
* [`1ce7329f`](https://github.com/NixOS/nixpkgs/commit/1ce7329f6bbe7efcdf054977f20b36958be7bca5) xnee: fix build with clang 16
* [`370bfaa5`](https://github.com/NixOS/nixpkgs/commit/370bfaa5dd81e0031ae78324bfabb2c78f1ef95f) python311Packages.publicsuffixlist: 0.10.0.20231109 -> 0.10.0.20231120
* [`761fb4f1`](https://github.com/NixOS/nixpkgs/commit/761fb4f17346cf29a4d4c267c91ee4f695ffda8c) localsend: add meta.mainProgram
* [`7dbcb7eb`](https://github.com/NixOS/nixpkgs/commit/7dbcb7ebdb00638e3417382e00e5cb5de64e0861) gnustep.gui: fix build
* [`0c9c221a`](https://github.com/NixOS/nixpkgs/commit/0c9c221a06a1b989c9175fbb9c628a0136e82fec) python311Packages.mitmproxy: 10.1.1 -> 10.1.5
* [`868a61e7`](https://github.com/NixOS/nixpkgs/commit/868a61e7d468d8385d119956c07c76fcd8812a18) python311Packages.pykrakenapi: 0.3.1 -> 0.3.2
* [`98f1f6ea`](https://github.com/NixOS/nixpkgs/commit/98f1f6ea7b9c151d0849894f946eefa8924da53c) bfc: fix build on darwin
* [`307f1a28`](https://github.com/NixOS/nixpkgs/commit/307f1a287879a84880dbe3569db3400ba17b5e9b) firefox-unwrapped: 119.0.1 -> 120.0
* [`2fdbabab`](https://github.com/NixOS/nixpkgs/commit/2fdbababe10005da0096bde70cf84697d95e3637) teeworlds: add buildClient feature flag
* [`c08116fc`](https://github.com/NixOS/nixpkgs/commit/c08116fc3d14710d97b7a65996635cae46b807db) frawk: fix build on darwin
* [`c57f7397`](https://github.com/NixOS/nixpkgs/commit/c57f739753920e33b3bdde6d20824d6c1e342821) firefox-bin-unwrapped: 119.0.1 -> 120.0
* [`1156cd9e`](https://github.com/NixOS/nixpkgs/commit/1156cd9e9b57e2f5a11564c6cf64b86b01fae17a) msmtp: support not bringing in the additional scripts
* [`9c0e68d9`](https://github.com/NixOS/nixpkgs/commit/9c0e68d9a82216f1e4bcf3376aa05da0bde58ce7) ddnet: add buildClient feature flag
* [`f6169c3b`](https://github.com/NixOS/nixpkgs/commit/f6169c3bf310a3f4d7f6b4809bd0e5c08871be84) firefox-esr-115-unwrapped: 115.4.0esr -> 115.5.0esr
* [`9808815f`](https://github.com/NixOS/nixpkgs/commit/9808815f41cb5333d706776c1abf678b4d9570b2) xflr5: 6.47 -> 6.61
* [`389b1759`](https://github.com/NixOS/nixpkgs/commit/389b175993496cf32cbbc8700b97c08d792447b8) pkgs/top-level/release: drop nodejs 16 exception
* [`ecfe5a37`](https://github.com/NixOS/nixpkgs/commit/ecfe5a3784e748594b90332e5a9fe230b6847b6e) noice: add iogamaster as a maintainer
* [`3e39348b`](https://github.com/NixOS/nixpkgs/commit/3e39348bc6e314fa23e320e0a89eefe9c5d69548) rust-code-analysis: fix build on darwin
* [`c86f881b`](https://github.com/NixOS/nixpkgs/commit/c86f881b254aee656b8c1594f624041a1b01b378) floorp: 11.5.1 -> 11.6.0
* [`ab5cbf47`](https://github.com/NixOS/nixpkgs/commit/ab5cbf47a17e21084274c468a53f0217872307d6) floorp: enable WebRTC support
* [`b287551a`](https://github.com/NixOS/nixpkgs/commit/b287551a214ba3ba08d39b05725abc6be650cd7d) symbolicator: fix build on darwin
* [`dea17be3`](https://github.com/NixOS/nixpkgs/commit/dea17be39e52a82613b538141acbbcb70ae87020) topiary: fix build on darwin
* [`beb882e7`](https://github.com/NixOS/nixpkgs/commit/beb882e77aab1f22f187a4508da50fe09d8b69cd) cargo-modules: 0.10.2 -> 0.11.0
* [`d99faadf`](https://github.com/NixOS/nixpkgs/commit/d99faadfbd77b254a2d6e6dbd9051a77de55754f) sxiv: add h7x4 as maintainer
* [`f66b0ae2`](https://github.com/NixOS/nixpkgs/commit/f66b0ae2d8d8998e0fe659829ff10006c22035d1) python311Packages.strawberry-graphql: 0.214.0 -> 0.215.1
* [`609244d0`](https://github.com/NixOS/nixpkgs/commit/609244d0ce369ee0896f0f29904a5ac2c49c336f) python311Packages.twilio: 8.10.1 -> 8.10.2
* [`6c48ef9f`](https://github.com/NixOS/nixpkgs/commit/6c48ef9f912721bb936821f52a9766db9547ec99) python311Packages.twentemilieu: 2.0.0 -> 2.0.1
* [`1cc2c2f1`](https://github.com/NixOS/nixpkgs/commit/1cc2c2f13d7a548759a55f710fd0222da14c5403) lib.fileset.maybeMissing: init
* [`ca97497b`](https://github.com/NixOS/nixpkgs/commit/ca97497bfdd7adf39759f785845d60cefc165027) made EXPR_PATH point to local instead of store
* [`21c70852`](https://github.com/NixOS/nixpkgs/commit/21c70852a03f8941d655d43e4a2ec65c2e5e34ad) python311Packages.scikit-misc: replace ILP64 libs with LP64
* [`24268979`](https://github.com/NixOS/nixpkgs/commit/24268979b93fc596b52bc0fa72b5ad35d51cb258) python311Packages.dbt-semantic-interfaces: init at 0.2.2
* [`ceb8a731`](https://github.com/NixOS/nixpkgs/commit/ceb8a7315229cb5fd3c45924e15461400c809ca4) python311Packages.dbt-core: add dependancy dbt-semantic-interfaces
* [`d5308456`](https://github.com/NixOS/nixpkgs/commit/d5308456a65c1b4c14c33d6b2bdae5c6384285c3) python3Packages.adafruit-nrfutil: fix tests
* [`e3888fd7`](https://github.com/NixOS/nixpkgs/commit/e3888fd730167e9d58ec52bca185f1fe2a567681) claws-mail: 4.1.1 -> 4.2.0
* [`9855d35a`](https://github.com/NixOS/nixpkgs/commit/9855d35a01856ce12cabab0fb1a06d9d0de02342) codux: 15.13.0 -> 15.14.0
* [`0cfb3dd6`](https://github.com/NixOS/nixpkgs/commit/0cfb3dd635682a01dd4ad1dee0852fa80c4d40d2) python311Packages.python-opendata-transport: 0.3.0 -> 0.4.0
* [`e212445c`](https://github.com/NixOS/nixpkgs/commit/e212445cb760f63cd4085e8b836250f3ded90b45) python311Packages.python-opendata-transport: refactor
* [`c57a4343`](https://github.com/NixOS/nixpkgs/commit/c57a4343862ae0e95f77923bc5494a55bb7d8ee2) maintainers: remove the numtide team ([nixos/nixpkgs⁠#268684](https://togithub.com/nixos/nixpkgs/issues/268684))
* [`a92a94f5`](https://github.com/NixOS/nixpkgs/commit/a92a94f5675ddd856eb54bf0d6498766e45d4195) optipng: 0.7.7 -> 0.7.8
* [`5e4057d2`](https://github.com/NixOS/nixpkgs/commit/5e4057d2488a791545126bfddcfcddaa987173cd) python311Packages.notus-scanner: 22.6.0 -> 22.6.2
* [`6bef6ffa`](https://github.com/NixOS/nixpkgs/commit/6bef6ffaa416077eb2268de939520e23d21f6975) python311Packages.slack-sdk: 3.23.1 -> 3.24.0
* [`bfa945c7`](https://github.com/NixOS/nixpkgs/commit/bfa945c77942ef05f07f8315e39f28024546129b) python311Packages.tree-sitter: 0.20.2 -> 0.20.4
* [`7cc51706`](https://github.com/NixOS/nixpkgs/commit/7cc5170665f8d365abeb8b659140b432a211a6b6) python311Packages.reolink-aio: 0.7.15 -> 0.8.0
* [`290f89ff`](https://github.com/NixOS/nixpkgs/commit/290f89ffda8da3dc8f4f45b43088cfc80d71529e) python311Packages.identify: 2.5.31 -> 2.5.32
* [`2249f4de`](https://github.com/NixOS/nixpkgs/commit/2249f4de3466c9151cd3a33b024128e365925d14) ut: init at 2.0.0
* [`bd40a077`](https://github.com/NixOS/nixpkgs/commit/bd40a077080b958774a584ab633333249980649d) python311Packages.hahomematic: 2023.11.0 -> 2023.11.1
* [`a2d9f04b`](https://github.com/NixOS/nixpkgs/commit/a2d9f04b82747adf7d0cb48bb42d58c8e4aba6a8) python311Packages.easyenergy: 0.3.1 -> 1.0.0
* [`b026c669`](https://github.com/NixOS/nixpkgs/commit/b026c669394e1e21f9fc5feb9d067b5d0d6d14e2) python311Packages.energyzero: 0.5.0 -> 1.0.0
* [`a91d4613`](https://github.com/NixOS/nixpkgs/commit/a91d4613a64c84819c0f533383adf4a938958d52) lrzsz: fix clang -Werror on darwin
* [`d248a1e7`](https://github.com/NixOS/nixpkgs/commit/d248a1e7f7a3e839ec06cbb7776bcdb5fab67451) qutebrowser-qt5: replace qt5.qutebrowser
* [`4bd758c9`](https://github.com/NixOS/nixpkgs/commit/4bd758c9634eef2d58822b4aaa424051f613da0d) qutebrowser: use spliced qt6Packages
* [`2902f99c`](https://github.com/NixOS/nixpkgs/commit/2902f99c5734c0eebf265b4009dfccb5703aa9e1) llvmPackages: Dedupe `llvm_meta`
* [`5ac86a99`](https://github.com/NixOS/nixpkgs/commit/5ac86a99e7e1c3374c8a5bd28599026e5450ae06) llvmPackages: Dedupe releaseInfo
* [`e6751897`](https://github.com/NixOS/nixpkgs/commit/e6751897e0209add93b7ee9725e7479dea25c873) llvmPackages: Dedupe monorepoSrc
* [`c1e1a583`](https://github.com/NixOS/nixpkgs/commit/c1e1a583a02f1a7ee34b822a09ee2a5bae184396) llvmPackages_{13,14}: Use releaseInfo and monorepoSrc
* [`12b56aea`](https://github.com/NixOS/nixpkgs/commit/12b56aea48c519b4147a991ad4fedbf263d5a6b8) osl: fix build on darwin
* [`b59fd202`](https://github.com/NixOS/nixpkgs/commit/b59fd202d70faa17d0150bae3dd81d3461545a10) llvmPackages: Remove dead code
* [`9a7ff870`](https://github.com/NixOS/nixpkgs/commit/9a7ff8709b7db790f080af82526594e12de4f302) duperemove: fix hash
* [`c9da1f68`](https://github.com/NixOS/nixpkgs/commit/c9da1f6842cfcad04d7e0ab2a314b263efe4fb46) duperemove: add -Wno-error=format-security to CFLAGS
* [`3bcd5e8b`](https://github.com/NixOS/nixpkgs/commit/3bcd5e8b3bd280f2cae88506ab6dbf5f66822193) ogre: 14.1.0 -> 14.1.2
* [`042dce1f`](https://github.com/NixOS/nixpkgs/commit/042dce1f6815b11d1af84bbdc79789698479825f) zpool-auto-expand-partitions: 0.1.0 -> 0.1.1
* [`6d50b4ba`](https://github.com/NixOS/nixpkgs/commit/6d50b4ba87d53263521395a01f893ab148545597) pgbadger: fix build on darwin
* [`2e2fc891`](https://github.com/NixOS/nixpkgs/commit/2e2fc891488633cb1abc0310f6ab31264c6b0b39) joshuto: install shell completions
* [`e9622236`](https://github.com/NixOS/nixpkgs/commit/e962223660a35a1e9e0fdac1cc670b615278025b) joshuto: 0.9.5 -> 0.9.6
* [`c77bec3b`](https://github.com/NixOS/nixpkgs/commit/c77bec3bebd6c189a7b15eab0197055f12fa7002) esbuild: 0.19.6 -> 0.19.7
* [`a14bbc16`](https://github.com/NixOS/nixpkgs/commit/a14bbc1661ceff9c6a4f2d2e194cbd723002e7f4) esbuild: add myself to maintainers
* [`668965f9`](https://github.com/NixOS/nixpkgs/commit/668965f913b32f9dec8a3df19ecb150508cec5e5) python311Packages.psycopg: 3.1.12 -> 3.1.13
* [`9ec96384`](https://github.com/NixOS/nixpkgs/commit/9ec963841b0962d7b7376abebe533317e0740e39) doublecmd: 1.1.3 -> 1.1.5
* [`5f8f287c`](https://github.com/NixOS/nixpkgs/commit/5f8f287c1758e4212ddf014552a1e5def5587f08) nickel: fix build on darwin
* [`707b8aea`](https://github.com/NixOS/nixpkgs/commit/707b8aeae29478557c89b6c40aa24e16462e47b5) scarab: 2.1.0.0 -> 2.5.0.0
* [`a09acf29`](https://github.com/NixOS/nixpkgs/commit/a09acf2903eae8922fcef5e43612303273914e8b) discord-screenaudio: init at 1.9.2
* [`fa436286`](https://github.com/NixOS/nixpkgs/commit/fa436286e6704a99e37e17eef3987fb77c330f8f) python311Packages.redshift-connector: remove 'test' from pytest args; fix build
* [`a8e066ab`](https://github.com/NixOS/nixpkgs/commit/a8e066abd642485b0cbb670be8eda0f475bd35cb) python311Packages.awswrangler: add pyparsing module for checkPhase
* [`11b1b297`](https://github.com/NixOS/nixpkgs/commit/11b1b2972b69c9cda6005f5037e7f6b879a60358) git-credential-gopass: 1.15.8 -> 1.15.9
* [`2c06b55f`](https://github.com/NixOS/nixpkgs/commit/2c06b55f36941f13383095a851f8645d054e5dda) maintainers: add arthsmn
* [`51a01a7e`](https://github.com/NixOS/nixpkgs/commit/51a01a7e5515b469886c120e38db325c96694c2f) newsraft: init at 0.21
* [`2733adb9`](https://github.com/NixOS/nixpkgs/commit/2733adb99beb96d55e43ce3201f4cfd2161059cc) gopass-hibp: 1.15.8 -> 1.15.9
* [`1e347be5`](https://github.com/NixOS/nixpkgs/commit/1e347be5ecf0f3fb0d40981ac27b1bef6772d0ab) clipcat: 0.5.0 -> 0.5.1
* [`681e1e07`](https://github.com/NixOS/nixpkgs/commit/681e1e07bf6adbccfa002659a7b3dcea6787a279) rqbit: 2.2.2 -> 3.1.0
* [`7eeb6a28`](https://github.com/NixOS/nixpkgs/commit/7eeb6a2856ede52861747a062462dbe2a1793035) rqbit: 3.1.0 -> 3.2.0
* [`861c5926`](https://github.com/NixOS/nixpkgs/commit/861c59269ad7f33da7815e909c2d678b3b4b1343) unimatrix: init at unstable-2023-04-25
* [`83eaa6f5`](https://github.com/NixOS/nixpkgs/commit/83eaa6f557e300b1edb65f0599ca36e1f41187f9) whereami: fix build failure on darwin
* [`5b4b6f40`](https://github.com/NixOS/nixpkgs/commit/5b4b6f409ad522c88e880a8dd3ffbe7ca466a23f) maintainers: add maolonglong
* [`e7543c18`](https://github.com/NixOS/nixpkgs/commit/e7543c18c999e12640dad08f685d49a5fade333b) clamtk: wrap with wrapGAppsHook
* [`dd5a9960`](https://github.com/NixOS/nixpkgs/commit/dd5a9960f05fbfb5eb38944087b4862237973e27) gopass-jsonapi: 1.15.8 -> 1.15.9
* [`b006f66e`](https://github.com/NixOS/nixpkgs/commit/b006f66ee8025c2577ea33e35355ca548ae40eab) hex: 0.4.2 -> 0.5.0
* [`7ae0729a`](https://github.com/NixOS/nixpkgs/commit/7ae0729ae515ebccfb960ef7b95347c65fddde88) Encourage +1's for prioritisation
* [`71f5ffa8`](https://github.com/NixOS/nixpkgs/commit/71f5ffa84e539e420a35921bec2889d748c58cc7) python311Packages.mdtraj: init at 1.9.9
* [`036f0324`](https://github.com/NixOS/nixpkgs/commit/036f0324a4d00e4e8e96bb777c65c53f1bdd75eb) annapurna-sil: 1.204 → 2.000
* [`254486b5`](https://github.com/NixOS/nixpkgs/commit/254486b583c1836836d18f664e9d89d1646b4077) python311Packages.deap: fix build
* [`c5a90082`](https://github.com/NixOS/nixpkgs/commit/c5a900825e8b7cc14f4a34770d1efc8214a0800a) python311Packages.deap: add getpsyched as a maintainer
* [`8bcedcea`](https://github.com/NixOS/nixpkgs/commit/8bcedceaeaa7e918ed18b71ab5f22cdab505954c) kubeconform: 0.6.3 -> 0.6.4
* [`005cfbd7`](https://github.com/NixOS/nixpkgs/commit/005cfbd7a5bb15705896e258018820fb3b0363f0) leo-editor: 6.7.4 -> 6.7.5
* [`de58b0ea`](https://github.com/NixOS/nixpkgs/commit/de58b0eafe3e8c5ef510b0c6f426360989aa1e82) oksh: 7.3 -> 7.4
* [`ea8fa29a`](https://github.com/NixOS/nixpkgs/commit/ea8fa29ac107ae9ddf5bca428c43a2e4fb361bda) gosimports: init at 0.3.8
* [`8bba01f0`](https://github.com/NixOS/nixpkgs/commit/8bba01f0347f662dcf4f15d82bed86ea26c0ac4f) ast-grep: fix build with clang 12+
* [`0f4845f3`](https://github.com/NixOS/nixpkgs/commit/0f4845f3978434c63d1aa91cddc3443bfc20973f) hdf5_1_10: 1.10.9 -> 1.10.11
* [`2ac59be3`](https://github.com/NixOS/nixpkgs/commit/2ac59be3924ccfd8cd5dba37c432553be9adf364) at-spi2-core: 2.48.3 → 2.49.90
* [`b5487f38`](https://github.com/NixOS/nixpkgs/commit/b5487f38695aaacab3b5dbe84a0ff00e8ee3188e) baobab: 44.0 → 45.alpha
* [`44828aa0`](https://github.com/NixOS/nixpkgs/commit/44828aa078f053296f6e922c7631606036f4db88) epiphany: 44.6 → 45.beta
* [`52f2d69d`](https://github.com/NixOS/nixpkgs/commit/52f2d69df8bdef1319e9fb400c1ea8013d3d33c1) evolution: 3.48.4 → 3.49.2
* [`46dafdc8`](https://github.com/NixOS/nixpkgs/commit/46dafdc8324fb0b152195cd647eed2ca8489ad0a) evince: 44.3 → 45.alpha
* [`576e072b`](https://github.com/NixOS/nixpkgs/commit/576e072bc0b5c131f4c7f9be1eb56b5d0ea0478a) gjs: 1.76.2 → 1.77.1
* [`bce876b8`](https://github.com/NixOS/nixpkgs/commit/bce876b8cd2e4bba28af72bd9ce2de62ef284c2b) glib: 2.76.4 → 2.77.1
* [`e7fb1957`](https://github.com/NixOS/nixpkgs/commit/e7fb19575f6261adbc7dc4c5681424d4f0686ff3) gnome.adwaita-icon-theme: 44.0 → 45.beta
* [`11f6616d`](https://github.com/NixOS/nixpkgs/commit/11f6616d1129a2d4f064c3035fe17c7c8faa908c) glibmm_2_68: 2.76.0 → 2.77.0
* [`62ea5289`](https://github.com/NixOS/nixpkgs/commit/62ea5289932396585f1daffc3c0dda9e3c2594b4) gnome.eog: 44.3 → 45.alpha
* [`bcd5a66b`](https://github.com/NixOS/nixpkgs/commit/bcd5a66b1b14593a1f8252a39d31e297ce117eb1) gnome.gnome-applets: 3.46.0 → 3.49.1
* [`2bd3f072`](https://github.com/NixOS/nixpkgs/commit/2bd3f0722df6d650e9fd1cc8c103da9ea1dd8cd1) gnome.gnome-calculator: 44.0 → 45.beta
* [`2ab1530c`](https://github.com/NixOS/nixpkgs/commit/2ab1530c908d08ae712c352c2aa0934c4ece8ef0) gnome.gnome-backgrounds: 44.0 → 45.beta
* [`99473492`](https://github.com/NixOS/nixpkgs/commit/994734921a11510df6323de6b93b8d55416c8921) gnome.gnome-characters: 44.0 → 45.alpha
* [`a3306214`](https://github.com/NixOS/nixpkgs/commit/a3306214d74fc992f7f0e0d497189afc4b15a0fd) gnome.gnome-control-center: 44.3 → 45.alpha
* [`10470e55`](https://github.com/NixOS/nixpkgs/commit/10470e5523bd0a57889736ff1811cd641c9b2c25) gnome.gnome-font-viewer: 44.0 → 45.alpha
* [`3bdcdae6`](https://github.com/NixOS/nixpkgs/commit/3bdcdae69dbb0b9f66a53991ec636ef3ccbdbe8c) gnome.gnome-initial-setup: 44.0 → 45.beta
* [`b59752a0`](https://github.com/NixOS/nixpkgs/commit/b59752a065f38ad194dcb1557bff79272ee0da58) gnome.gnome-panel: 3.47.1 → 3.49.1
* [`a0d5afc7`](https://github.com/NixOS/nixpkgs/commit/a0d5afc75a181bd2f86f3643aa922592bbf080e2) gnome.gnome-remote-desktop: 44.2 → 45.alpha
* [`e3e0c346`](https://github.com/NixOS/nixpkgs/commit/e3e0c34673bce2d8ba8ddc552cf7221661e75ac9) gnome.gnome-settings-daemon: 44.1 → 45.alpha
* [`842b294c`](https://github.com/NixOS/nixpkgs/commit/842b294c390c71d2a589d6b74c891d1015f0ad21) gnome.gnome-shell: 44.5 → 45.alpha
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
