### PR TITLE
niv devenv: update 525d60c4 -> 263efe12

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "525d60c44de848a6b2dd468f6efddff078eb2af2",
-        "sha256": "0n4q4njl20zh9a1vw12x7ywrcx7s58ja9zih4yhnsi1bxlaa96rs",
+        "rev": "263efe1290b8481cd6d5d814b4655ce332b7f8b1",
+        "sha256": "08fbqdy9a1rq941gj8zk3zl1x88ngaa3yrkb186s6nz9s2c7f2ay",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/525d60c44de848a6b2dd468f6efddff078eb2af2.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/263efe1290b8481cd6d5d814b4655ce332b7f8b1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@525d60c4...263efe12](https://github.com/cachix/devenv/compare/525d60c44de848a6b2dd468f6efddff078eb2af2...263efe1290b8481cd6d5d814b4655ce332b7f8b1)

* [`ddee67a6`](https://github.com/cachix/devenv/commit/ddee67a6c7f3fafc6d0b029a39802af1ec3dffe8) Add `containers.<name>.maxLayers` option
* [`442f9636`](https://github.com/cachix/devenv/commit/442f963624dbd2e77d021a5f329093e44712592c) Fix literalExpression call
* [`38302f4b`](https://github.com/cachix/devenv/commit/38302f4b9ff45915151848b719c5c4127946c1b8) Auto generate docs/reference/options.md
* [`9fceda49`](https://github.com/cachix/devenv/commit/9fceda49328b160c448038d5b28200d123eb0995) Pin releases on cachix
