### PR TITLE
niv home-manager: update 993fb02d -> db1878f0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "993fb02d20760067b8ee19c713d94cee07037759",
-        "sha256": "0gllbaljxp34ca7g4z6qkv11py8wvd11s27ky0lkfvx7vizvk9jk",
+        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
+        "sha256": "1qr1xsf4fsqmh8c7av984hvrc03y1y6s8nlxfp9zrzhlnh1v034m",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/993fb02d20760067b8ee19c713d94cee07037759.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/db1878f013b52ba5e4034db7c1b63e8d04173a86.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@993fb02d...db1878f0](https://github.com/nix-community/home-manager/compare/993fb02d20760067b8ee19c713d94cee07037759...db1878f013b52ba5e4034db7c1b63e8d04173a86)

* [`fff5204e`](https://github.com/nix-community/home-manager/commit/fff5204e5dbe8403d5ad1816c183f7b663d9fe1d) qt: fix basic usage when just `qt.enable = true` is set
* [`3de857fa`](https://github.com/nix-community/home-manager/commit/3de857fa7d996a60966cccb44fbfce8d3c4544d8) qt: fix `qt.platformTheme = "gtk3"`
* [`1aabb0a3`](https://github.com/nix-community/home-manager/commit/1aabb0a31b25ad83cfaa37c3fe29053417cd9a0f) picom: use getExe instead of hardcoded binary
* [`1bd1e864`](https://github.com/nix-community/home-manager/commit/1bd1e8646473235dfe76831812f8662b837cb184) ruff: add module
* [`134deb46`](https://github.com/nix-community/home-manager/commit/134deb46abd5d0889d913b8509413f6f38b0811e) bat: support boolean flags in config
* [`aeb2232d`](https://github.com/nix-community/home-manager/commit/aeb2232d7a32530d3448318790534d196bf9427a) home-manager: set stable release to 23.11
* [`e1f3b36a`](https://github.com/nix-community/home-manager/commit/e1f3b36ab01573fd35cae57d21f45d520433df61) home-manager: set unstable release to 24.05
* [`8cedd63e`](https://github.com/nix-community/home-manager/commit/8cedd63eede4c22deb192f1721dd67e7460e1ebe) fish: support flexible abbreviations
* [`a462e731`](https://github.com/nix-community/home-manager/commit/a462e7315deaa8194b0821f726709bb7e51a850c) yazi: update shell integrations and docs
* [`8340c0b4`](https://github.com/nix-community/home-manager/commit/8340c0b4d9986a91ca0ef746637839df99c43d3e) flake.lock: Update
* [`7c97c46d`](https://github.com/nix-community/home-manager/commit/7c97c46dc4f45f2a78df536a6ebe15252831b800) signaturepdf: add service
* [`db1878f0`](https://github.com/nix-community/home-manager/commit/db1878f013b52ba5e4034db7c1b63e8d04173a86) home-manager: add 24.05 as valid state version
