### PR TITLE
niv nerd-icons.el: update 0262a8c4 -> 1dc133b7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "0262a8c4fa41541438e489572bba8f0b4b689ae7",
-        "sha256": "1c7pf6fp99y3gsn8pb73h1gwlz3ag2i0h5i8pl7i0f09p3ra9jr3",
+        "rev": "1dc133b7cd5d6b08090a4b8fd1cf5433bab65be5",
+        "sha256": "0f3rdsy4iwxv2p422p2aa687zn2qlcw84dail7smb1rdh6gz89v9",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/0262a8c4fa41541438e489572bba8f0b4b689ae7.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/1dc133b7cd5d6b08090a4b8fd1cf5433bab65be5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@0262a8c4...1dc133b7](https://github.com/rainstormstudio/nerd-icons.el/compare/0262a8c4fa41541438e489572bba8f0b4b689ae7...1dc133b7cd5d6b08090a4b8fd1cf5433bab65be5)

* [`95281e35`](https://github.com/rainstormstudio/nerd-icons.el/commit/95281e35d9402d6b235811cae6d4a8988499c570) update README & screenshots
* [`f4802270`](https://github.com/rainstormstudio/nerd-icons.el/commit/f480227003918b50eedbd7f9ce5a518a0ea63d62) use `nf-seti-git` for git extension icons
* [`a506b43d`](https://github.com/rainstormstudio/nerd-icons.el/commit/a506b43dc241ee07c28ce815068277084afbf09c) fix nf-seti-git
* [`cfda588d`](https://github.com/rainstormstudio/nerd-icons.el/commit/cfda588dc1e865a8a121b9071f3720fd4937492b) feat: add lisp icons
* [`5f79a832`](https://github.com/rainstormstudio/nerd-icons.el/commit/5f79a8321a1848fd16d9a976953486a118164f38) update to Nerd Fonts 3.1.0
* [`e109d09b`](https://github.com/rainstormstudio/nerd-icons.el/commit/e109d09b95706bb93c821b1229ca09cf00195690) use common lisp icons
* [`1dc133b7`](https://github.com/rainstormstudio/nerd-icons.el/commit/1dc133b7cd5d6b08090a4b8fd1cf5433bab65be5) add docs for python script and use safer  requests.get
