### PR TITLE
niv zsh-history-substring-search: update 19b88766 -> 8dd05bfc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -197,10 +197,10 @@
         "homepage": "",
         "owner": "zsh-users",
         "repo": "zsh-history-substring-search",
-        "rev": "19b887667a155befeb5850f0af46a45cc5311ae2",
-        "sha256": "19whab3ac1j6qryayxs056a5b7clbcanw7k1mb8w4dqh2i7g5zms",
+        "rev": "8dd05bfcc12b0cd1ee9ea64be725b3d9f713cf64",
+        "sha256": "142mp8r8xw0mhfjqrmdcnyz0nw24ryfpcgi7hkii9ba2pn6sx2w6",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/19b887667a155befeb5850f0af46a45cc5311ae2.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-history-substring-search/archive/8dd05bfcc12b0cd1ee9ea64be725b3d9f713cf64.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for zsh-history-substring-search:
Branch: master
Commits: [zsh-users/zsh-history-substring-search@19b88766...8dd05bfc](https://github.com/zsh-users/zsh-history-substring-search/compare/19b887667a155befeb5850f0af46a45cc5311ae2...8dd05bfcc12b0cd1ee9ea64be725b3d9f713cf64)

* [`a7e6d94b`](https://github.com/zsh-users/zsh-history-substring-search/commit/a7e6d94ba5e1ef8afa31840682f69deffdd1310c) updated readme to include Zinit instructions
* [`8f5d8a5a`](https://github.com/zsh-users/zsh-history-substring-search/commit/8f5d8a5aa9942da7b2a764c7fa79e0f36ba802f7) Add Fig as an installation method to the README ([zsh-users/zsh-history-substring-search⁠#133](https://togithub.com/zsh-users/zsh-history-substring-search/issues/133))
* [`8dd05bfc`](https://github.com/zsh-users/zsh-history-substring-search/commit/8dd05bfcc12b0cd1ee9ea64be725b3d9f713cf64) Update README.md
