### PR TITLE
niv emacs-overlay: update cc3249d5 -> 1b8163de

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cc3249d5b0eb6600f253a1f7be45343ffcc4b89e",
-        "sha256": "1l5rjgvifrnkzxd81xrzh2mphh66x41899hjm95qr8bfisyz7w9j",
+        "rev": "1b8163de282e43d005b28e768fd156d417d441d9",
+        "sha256": "0wfpd0n6q5cjd6jszdz7jsmdh3rvirkp8qsv1c21cc67pki82vgh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/cc3249d5b0eb6600f253a1f7be45343ffcc4b89e.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/1b8163de282e43d005b28e768fd156d417d441d9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@cc3249d5...1b8163de](https://github.com/nix-community/emacs-overlay/compare/cc3249d5b0eb6600f253a1f7be45343ffcc4b89e...1b8163de282e43d005b28e768fd156d417d441d9)

* [`bca74373`](https://github.com/nix-community/emacs-overlay/commit/bca743739225ab481214631ff0e5b0b020842688) Updated repos/elpa
* [`dc3cdc57`](https://github.com/nix-community/emacs-overlay/commit/dc3cdc570c3edaa326ea4cdd6a4dac02fbcc6243) Updated repos/emacs
* [`f6ec5012`](https://github.com/nix-community/emacs-overlay/commit/f6ec501280f5d4b2fa7a12635c62271e9dfe3a36) Updated repos/melpa
* [`d180616e`](https://github.com/nix-community/emacs-overlay/commit/d180616e5912ba02c96bc5bce8c5eac15cf1a661) Updated repos/nongnu
* [`83475bfb`](https://github.com/nix-community/emacs-overlay/commit/83475bfbd96f6af2c33fc37add37a1112fe52e67) Updated repos/emacs
* [`ed7548e5`](https://github.com/nix-community/emacs-overlay/commit/ed7548e554d9649d37e821f178c3f01f6f566072) Updated repos/melpa
* [`886cc758`](https://github.com/nix-community/emacs-overlay/commit/886cc7587d9c1113c5e17e0415dc1543cd51d4df) Updated flake inputs
* [`40870a5f`](https://github.com/nix-community/emacs-overlay/commit/40870a5f35fda3e501f895dde1b01df57757c77f) Updated repos/elpa
* [`f03559d1`](https://github.com/nix-community/emacs-overlay/commit/f03559d12e9b9ead9e242c88239782c19e682ea4) Updated repos/emacs
* [`2e5f6063`](https://github.com/nix-community/emacs-overlay/commit/2e5f60632355d27bbe73bf1aecab1775303233cd) Updated repos/melpa
* [`8f8b4a41`](https://github.com/nix-community/emacs-overlay/commit/8f8b4a41ca2c32a8d20bfb7298af35618cef47ba) Updated repos/elpa
* [`c7079b66`](https://github.com/nix-community/emacs-overlay/commit/c7079b66c30dfef0f3dd5a428dae497618d1eff1) Updated repos/emacs
* [`6b4f2d7b`](https://github.com/nix-community/emacs-overlay/commit/6b4f2d7b574ccbabb8bd4964650a82482a08d3fa) Updated repos/melpa
* [`d1a8d64f`](https://github.com/nix-community/emacs-overlay/commit/d1a8d64f28fd7ad9a6c84917cd99ddf7fdb6ed80) Updated flake inputs
* [`ef923b59`](https://github.com/nix-community/emacs-overlay/commit/ef923b59e35f8d4328d9e6bdbbdd580eb9dcecdc) Updated repos/emacs
* [`80c0d258`](https://github.com/nix-community/emacs-overlay/commit/80c0d258d4cef4463a9d7076c1d279dae2170386) Updated repos/melpa
* [`271cf1c4`](https://github.com/nix-community/emacs-overlay/commit/271cf1c48c036ca3a40335b0ed3b04d8d44d3824) Updated repos/nongnu
* [`86062b35`](https://github.com/nix-community/emacs-overlay/commit/86062b359377ebe6ebdbb7b652f7b941fee8eafd) Updated repos/elpa
* [`038664e8`](https://github.com/nix-community/emacs-overlay/commit/038664e868e43afb4aa1fe72728ec98dcad111ae) Updated repos/emacs
* [`fca46666`](https://github.com/nix-community/emacs-overlay/commit/fca46666f2b796c7ed2edae8718089c878997344) Updated repos/melpa
* [`38303caa`](https://github.com/nix-community/emacs-overlay/commit/38303caa82d09dec1880ffd0bc2d51432a3bd6d9) Updated repos/elpa
* [`0be586eb`](https://github.com/nix-community/emacs-overlay/commit/0be586eb41a0500ef989790f5862fab71e7151bb) Updated repos/emacs
* [`13838a84`](https://github.com/nix-community/emacs-overlay/commit/13838a843bdd49b928919c6e7835327c1a1b275e) Updated repos/melpa
* [`8f964138`](https://github.com/nix-community/emacs-overlay/commit/8f964138749616526f0d2792e05e06aa5d509741) Updated repos/nongnu
* [`ae8e816e`](https://github.com/nix-community/emacs-overlay/commit/ae8e816eda343dfcce11adb7428e61c2870506eb) Updated flake inputs
* [`27a7f669`](https://github.com/nix-community/emacs-overlay/commit/27a7f6697d55dd859c1dea8193fc3ca15c3bb280) Updated repos/emacs
* [`32c56bb4`](https://github.com/nix-community/emacs-overlay/commit/32c56bb4b8020d2f73e887dc37b1afcbd2eb24cc) Updated repos/melpa
* [`99fb18c4`](https://github.com/nix-community/emacs-overlay/commit/99fb18c4f0b7abdcd2d93c98c94e6d3d745ee283) Updated repos/nongnu
* [`1aa829e3`](https://github.com/nix-community/emacs-overlay/commit/1aa829e37e5c1fc6d30ce07741e41dd68a7b4287) Updated repos/elpa
* [`65704d67`](https://github.com/nix-community/emacs-overlay/commit/65704d670841bd5ebcea1f32e5e6cb2c0df46f07) Updated repos/emacs
* [`c1ecbd6e`](https://github.com/nix-community/emacs-overlay/commit/c1ecbd6ee4b45991444b511a22f88af2b920aee1) Updated repos/melpa
* [`6b1b2aec`](https://github.com/nix-community/emacs-overlay/commit/6b1b2aec5740bfd9975667c1dc18c7a0c9731e64) Updated flake inputs
* [`f7e314a0`](https://github.com/nix-community/emacs-overlay/commit/f7e314a02983cd3da607543cd4f8d3d06bc1b414) Updated repos/elpa
* [`c4b40176`](https://github.com/nix-community/emacs-overlay/commit/c4b40176fdb653c2fd9e4fcff9df5e3c6063cc73) Updated repos/emacs
* [`cabc363c`](https://github.com/nix-community/emacs-overlay/commit/cabc363cbd1892dffdcc4cfc7090d080fe8957fb) Updated repos/melpa
* [`4728a809`](https://github.com/nix-community/emacs-overlay/commit/4728a80913ec511fef8f1777da37c31733f515c2) Updated repos/nongnu
* [`285aa518`](https://github.com/nix-community/emacs-overlay/commit/285aa51899fc52761535aa920f7fe9e57b5a0437) Updated repos/emacs
* [`8e42a346`](https://github.com/nix-community/emacs-overlay/commit/8e42a3463ac1a25a9948e965e2fefc570fadd702) Updated repos/melpa
* [`e66f1300`](https://github.com/nix-community/emacs-overlay/commit/e66f1300bcc02c943089ca84ba55a76e7aca5af5) Updated repos/elpa
* [`add0f018`](https://github.com/nix-community/emacs-overlay/commit/add0f01838515035c8329191740af6ef9b6045fe) Updated repos/emacs
* [`4658536e`](https://github.com/nix-community/emacs-overlay/commit/4658536e67d119a2a529e1df715d3f9ceb74223e) Updated repos/melpa
* [`497d3b4b`](https://github.com/nix-community/emacs-overlay/commit/497d3b4bf5db0d58fc4ba9723f7c872f784e72b7) Updated repos/elpa
* [`dd3c0ed4`](https://github.com/nix-community/emacs-overlay/commit/dd3c0ed4939c5bf5033b9f5da6852204877a8a30) Updated repos/emacs
* [`31ad6282`](https://github.com/nix-community/emacs-overlay/commit/31ad62827c81f9a6f34af2dc4ada0655f6b08cb0) Updated repos/melpa
* [`fb53121f`](https://github.com/nix-community/emacs-overlay/commit/fb53121fdc7721cedc43082e7bd3329c557b5f79) Updated flake inputs
* [`f863630b`](https://github.com/nix-community/emacs-overlay/commit/f863630b3a81b865330798c489b80f21bee33a91) Updated repos/emacs
* [`fd47dc60`](https://github.com/nix-community/emacs-overlay/commit/fd47dc60f7d4ec23ce097573b41f14b996181242) Updated repos/melpa
* [`06b231d9`](https://github.com/nix-community/emacs-overlay/commit/06b231d93f89edad1e209097827cf6287a9ad55a) Updated flake inputs
* [`808f3d03`](https://github.com/nix-community/emacs-overlay/commit/808f3d03a6e393605833ce9a8482619c3be73718) Updated repos/elpa
* [`9616eb6d`](https://github.com/nix-community/emacs-overlay/commit/9616eb6d4c50064068159bbc29d6a7ddef53ac80) Updated repos/emacs
* [`9086be91`](https://github.com/nix-community/emacs-overlay/commit/9086be91a915ad3e5cce2d8ae6d2abc3c5ecdf47) Updated repos/melpa
* [`652005f7`](https://github.com/nix-community/emacs-overlay/commit/652005f73d248e91bba4ec7d1164175668ba10fd) Updated repos/elpa
* [`4f8cd3e3`](https://github.com/nix-community/emacs-overlay/commit/4f8cd3e375b5433db24fd6756fea92f5a17d488a) Updated repos/emacs
* [`cd7727e9`](https://github.com/nix-community/emacs-overlay/commit/cd7727e9a8d4ff98659880b5121a8438fc53d8cd) Updated repos/melpa
* [`5ce24eed`](https://github.com/nix-community/emacs-overlay/commit/5ce24eed757d854bb290a0a0499053226fec1fc8) Updated repos/nongnu
* [`5d65aad4`](https://github.com/nix-community/emacs-overlay/commit/5d65aad4ff2124f00cf68d154f1c85a14d62850f) Updated repos/emacs
* [`66979186`](https://github.com/nix-community/emacs-overlay/commit/66979186afc45c8bfcc54dc2788b1a1679bb10d3) Updated repos/elpa
* [`a9375fdc`](https://github.com/nix-community/emacs-overlay/commit/a9375fdc81c04aa20f197c195720de179360b4f5) Updated repos/melpa
* [`aeb0d24a`](https://github.com/nix-community/emacs-overlay/commit/aeb0d24a0ab32efd4e0f46c4d58091630e0e71d5) Updated repos/elpa
* [`3c9b8daf`](https://github.com/nix-community/emacs-overlay/commit/3c9b8daf760a0c803c55f287b98576cf725a47bc) Updated repos/emacs
* [`babeb3ae`](https://github.com/nix-community/emacs-overlay/commit/babeb3ae6fa3af3ca3adadc306bc353c8d9fccc5) Updated repos/melpa
* [`f0bd17d9`](https://github.com/nix-community/emacs-overlay/commit/f0bd17d91055f9d9b55e6bf7b51835ad63c52e5c) Updated repos/melpa
* [`9f6fe2c8`](https://github.com/nix-community/emacs-overlay/commit/9f6fe2c8d5b0800e4beeda0854c4b16c9580a2d9) Updated flake inputs
* [`a15257b6`](https://github.com/nix-community/emacs-overlay/commit/a15257b6603b0d40aa6b4c37b1f90792b44af4e7) Updated repos/elpa
* [`36318fc2`](https://github.com/nix-community/emacs-overlay/commit/36318fc21b60dd9f4f40928af3ff5e5f52bac83c) Updated repos/emacs
* [`4f81073c`](https://github.com/nix-community/emacs-overlay/commit/4f81073c44bfa46c97cdd739345e6dc05494c69a) Updated repos/melpa
* [`96f8613e`](https://github.com/nix-community/emacs-overlay/commit/96f8613e5e5ff1ae9fdd9a691233e5784c658827) Updated repos/elpa
* [`f5a09ade`](https://github.com/nix-community/emacs-overlay/commit/f5a09ade2e3a111288c2dd54f3f86813a87daa6e) Updated repos/melpa
* [`b3e43b61`](https://github.com/nix-community/emacs-overlay/commit/b3e43b61c5ffa8fd51ef0d2746f57f8183610ffd) Updated repos/nongnu
* [`1760a51c`](https://github.com/nix-community/emacs-overlay/commit/1760a51c56aacd6a34e098657c799e73dd2665c4) Updated repos/emacs
* [`dc09405b`](https://github.com/nix-community/emacs-overlay/commit/dc09405b5f031852d3e930b1fa91e973b5206ef8) Updated repos/melpa
* [`f839163e`](https://github.com/nix-community/emacs-overlay/commit/f839163e8e7c04f5489d5b4dccba28b3ff95652c) Updated repos/elpa
* [`9918a6e2`](https://github.com/nix-community/emacs-overlay/commit/9918a6e2674a1cc95d5e41097f1ada84f2fc611d) Updated repos/emacs
* [`905fa765`](https://github.com/nix-community/emacs-overlay/commit/905fa7654037fc22b5d96f88bea5e4aab4c1f007) Updated repos/melpa
* [`1588e483`](https://github.com/nix-community/emacs-overlay/commit/1588e483bb22ff36a0235fc4bb8ce3fea3999f81) Updated repos/elpa
* [`a791cc56`](https://github.com/nix-community/emacs-overlay/commit/a791cc561a2fe5a1c13a0b102a06bfbab4bb121f) Updated repos/emacs
* [`db5f62b4`](https://github.com/nix-community/emacs-overlay/commit/db5f62b4e53ec885fd7777a61f872b3a7bdf269d) Updated repos/emacs
* [`68bc2c77`](https://github.com/nix-community/emacs-overlay/commit/68bc2c77ec96d2e5cb1e9953e8b8ea864aaf1c79) Updated repos/emacs
* [`1a47948b`](https://github.com/nix-community/emacs-overlay/commit/1a47948bbbe3eea50deaabf5f260d3b2a233aaa5) Updated repos/melpa
* [`89ba3af7`](https://github.com/nix-community/emacs-overlay/commit/89ba3af71159e8e078aeaf2ee84c50314bf663c4) Updated repos/elpa
* [`e1a2dbb3`](https://github.com/nix-community/emacs-overlay/commit/e1a2dbb36f1aced2ef19f76fd2baccf626758ba9) Updated repos/emacs
* [`c5096406`](https://github.com/nix-community/emacs-overlay/commit/c5096406b8513c224447d3f99554064c12ac8c32) Updated repos/melpa
* [`8b0bd6d0`](https://github.com/nix-community/emacs-overlay/commit/8b0bd6d04e48e1b2431b8143a16db93ef53ff08a) Updated repos/nongnu
* [`f0585f48`](https://github.com/nix-community/emacs-overlay/commit/f0585f48d11b1f9962496369ed8d081121ecba8f) Updated repos/emacs
* [`f9c303fc`](https://github.com/nix-community/emacs-overlay/commit/f9c303fcf115b77cfd285f8f2f83efb072c04c69) Updated repos/melpa
* [`5449f26d`](https://github.com/nix-community/emacs-overlay/commit/5449f26ddb7efb807d92fe76c600902f857035f4) Updated repos/elpa
* [`e8d2afbc`](https://github.com/nix-community/emacs-overlay/commit/e8d2afbcf27ea0748fd20c46c171eaf20cfdb6bf) Updated repos/emacs
* [`2dc0beb6`](https://github.com/nix-community/emacs-overlay/commit/2dc0beb6d0f3d19c577faab69b6338fb5a1ce17e) Updated repos/melpa
* [`b6a20bc2`](https://github.com/nix-community/emacs-overlay/commit/b6a20bc29328bccb1a706d5c326026a1f9d67b64) Updated repos/elpa
* [`64713415`](https://github.com/nix-community/emacs-overlay/commit/64713415368a53970d79c1dd5dc909a84433b7cc) Updated repos/emacs
* [`d8505e66`](https://github.com/nix-community/emacs-overlay/commit/d8505e66a5955db4690f40e9aecf17b35fa8da8d) Updated repos/melpa
* [`83bc5d5b`](https://github.com/nix-community/emacs-overlay/commit/83bc5d5bbb6dd272222aa94ebe96cc0430256b99) Updated repos/nongnu
* [`9300cab7`](https://github.com/nix-community/emacs-overlay/commit/9300cab78679876a48e29095a13316e6e0115d4f) Updated repos/emacs
* [`0012b376`](https://github.com/nix-community/emacs-overlay/commit/0012b3768be7411000ba6d18b4f2571315564760) Updated repos/melpa
* [`34876f50`](https://github.com/nix-community/emacs-overlay/commit/34876f50e54e98ab5afaff2e54bb27e9b9418962) Updated repos/elpa
* [`28fe385e`](https://github.com/nix-community/emacs-overlay/commit/28fe385ec804b86f584ed0c13915298f1b02120b) Updated repos/emacs
* [`8c8cfde9`](https://github.com/nix-community/emacs-overlay/commit/8c8cfde9fd9fd4c51bb7bd26391151b70af1d1d0) Updated repos/melpa
* [`c5f0c468`](https://github.com/nix-community/emacs-overlay/commit/c5f0c468f8e92246473c1eabe997ad1c41fb6a1a) Updated repos/nongnu
* [`e1b33c57`](https://github.com/nix-community/emacs-overlay/commit/e1b33c574d27c6de6612fe0b073043c8d1f8d362) Updated repos/elpa
* [`a50f51b0`](https://github.com/nix-community/emacs-overlay/commit/a50f51b0f729a640296fbda65bd5a78c7c06541b) Updated repos/emacs
* [`9c34acf8`](https://github.com/nix-community/emacs-overlay/commit/9c34acf849fb9781b22045d2a6d9acf6add631e1) Updated repos/melpa
* [`edf63e4a`](https://github.com/nix-community/emacs-overlay/commit/edf63e4ac22d6afc9e0513047c216504d3754e2d) Updated repos/nongnu
* [`c6a6721b`](https://github.com/nix-community/emacs-overlay/commit/c6a6721b733d8cccadba920af5acc682ec1e2cdb) Updated repos/emacs
* [`57400456`](https://github.com/nix-community/emacs-overlay/commit/574004568151819a92d44728614334e91a16c2c3) Updated repos/melpa
* [`a2aab00b`](https://github.com/nix-community/emacs-overlay/commit/a2aab00bfc49d6a43d4c10eb0dcd9633885ff8f6) Updated flake inputs
* [`27c1ae56`](https://github.com/nix-community/emacs-overlay/commit/27c1ae56554f4ea2e32aaddfe61ff24be57d34d6) Updated repos/elpa
* [`ab04a4ff`](https://github.com/nix-community/emacs-overlay/commit/ab04a4ff4a3648349b99cbb793ff5e12f5567c53) Updated repos/emacs
* [`a27b3c79`](https://github.com/nix-community/emacs-overlay/commit/a27b3c79d0eb23a47fb16c569c05e51d4f5aa76a) Updated repos/melpa
* [`87219c66`](https://github.com/nix-community/emacs-overlay/commit/87219c6667c12e5f4442d27c073b9c56dbf0c95e) Updated repos/nongnu
* [`c9d7a0f4`](https://github.com/nix-community/emacs-overlay/commit/c9d7a0f4575b6fa14e69660a0c3558611588d58b) Updated repos/elpa
* [`b138783c`](https://github.com/nix-community/emacs-overlay/commit/b138783ca8ff6491102722a7736e45a4f349713c) Updated repos/emacs
* [`cc2ef318`](https://github.com/nix-community/emacs-overlay/commit/cc2ef3184e5489cdb29aa1d7eeb1922de919d113) Updated repos/melpa
* [`fe55f8be`](https://github.com/nix-community/emacs-overlay/commit/fe55f8be14c4537f42b037051e9f5cb7ffcad246) Updated repos/nongnu
* [`e385e6bb`](https://github.com/nix-community/emacs-overlay/commit/e385e6bbcf25fbe136c6bdd85415486c86b8e1b4) Updated repos/emacs
* [`e71b61bf`](https://github.com/nix-community/emacs-overlay/commit/e71b61bfab4cbe8895935d54d5ea6635725f48db) Updated repos/melpa
* [`4ed08388`](https://github.com/nix-community/emacs-overlay/commit/4ed083888eac6202ec4887b02577cc168352d10f) Updated repos/nongnu
* [`9b07f5fb`](https://github.com/nix-community/emacs-overlay/commit/9b07f5fb18b7a5eb8da3c7f57c6c34dd242bd33e) Updated repos/elpa
* [`438e0a00`](https://github.com/nix-community/emacs-overlay/commit/438e0a009ad538ed7e16d4e5d60792101c1b2498) Updated repos/emacs
* [`df15eee2`](https://github.com/nix-community/emacs-overlay/commit/df15eee224e887ad80534d27f25d25adaaae4512) Updated repos/melpa
* [`e477b6ee`](https://github.com/nix-community/emacs-overlay/commit/e477b6ee6df9f2753baf9a5af8ba38de8143ed5b) Updated repos/elpa
* [`31536776`](https://github.com/nix-community/emacs-overlay/commit/31536776b83b783973c0e9f5e1ef8835ebc4a0e0) Updated repos/emacs
* [`0cac00bb`](https://github.com/nix-community/emacs-overlay/commit/0cac00bb83505d021348645f85818eb735ce737c) Updated repos/melpa
* [`2fe12926`](https://github.com/nix-community/emacs-overlay/commit/2fe12926dbe9b091fc7b01d33f8c7e0c3280a812) Updated repos/nongnu
* [`13913608`](https://github.com/nix-community/emacs-overlay/commit/139136085644c0bc39aba22f7c27d1e4ff98d664) Updated repos/emacs
* [`1d4ed29d`](https://github.com/nix-community/emacs-overlay/commit/1d4ed29d4d9d076210485697c325f8d6914d908f) Updated repos/melpa
* [`6eddd8a0`](https://github.com/nix-community/emacs-overlay/commit/6eddd8a050a7bcb950e8c906e876379f130a5182) Updated flake inputs
* [`5ca896a4`](https://github.com/nix-community/emacs-overlay/commit/5ca896a4f9ae416df9924ea429d5d78bc4b0da66) Updated repos/elpa
* [`d8fa70aa`](https://github.com/nix-community/emacs-overlay/commit/d8fa70aacc3e2300a80c6652621ac3401d2872c1) Updated repos/emacs
* [`c9f770c8`](https://github.com/nix-community/emacs-overlay/commit/c9f770c87c701375f28af95679af355d6c61f1ce) Updated repos/melpa
* [`9fd5bd89`](https://github.com/nix-community/emacs-overlay/commit/9fd5bd899afc98efb29beb181fd6351f93f9091b) Updated repos/elpa
* [`f62fb6b8`](https://github.com/nix-community/emacs-overlay/commit/f62fb6b84d64106c1d2224a744c33d9462655556) Updated repos/melpa
* [`dea7e901`](https://github.com/nix-community/emacs-overlay/commit/dea7e901113b914ee742f446f459b7c082db2e70) Updated repos/emacs
* [`accc684e`](https://github.com/nix-community/emacs-overlay/commit/accc684eb6fceac1b504fc6bec7298263dae3f86) Updated repos/melpa
* [`4bd146ea`](https://github.com/nix-community/emacs-overlay/commit/4bd146eaf6f124248d4e17499a0552e321128606) Updated flake inputs
* [`c31a5f2a`](https://github.com/nix-community/emacs-overlay/commit/c31a5f2a131b06d703841aeaf652f5d83f2ba34a) Updated repos/elpa
* [`81b4a3b4`](https://github.com/nix-community/emacs-overlay/commit/81b4a3b457be5409d85dd404ddc312d0b4e2baeb) Updated repos/emacs
* [`5356ef4e`](https://github.com/nix-community/emacs-overlay/commit/5356ef4e43d7829c5ac9e2a19ecaec24da9c8c63) Updated repos/melpa
* [`6391a4dd`](https://github.com/nix-community/emacs-overlay/commit/6391a4dd8c1a269dc84829c20abf7389cb90717b) Updated repos/elpa
* [`2349c8b8`](https://github.com/nix-community/emacs-overlay/commit/2349c8b85056fd1a64a5a7038e0391a944f6e25b) Updated repos/emacs
* [`ce7bfa6c`](https://github.com/nix-community/emacs-overlay/commit/ce7bfa6c89c1ea73a57983c5f17b41f919085826) Updated repos/melpa
* [`4dfcfe37`](https://github.com/nix-community/emacs-overlay/commit/4dfcfe37911921337dbe66ca0dac24c393f6beee) Updated repos/nongnu
* [`8bc596fb`](https://github.com/nix-community/emacs-overlay/commit/8bc596fb2d0723b9bc53468faaa38b23cb8b1949) Updated repos/emacs
* [`cd979f7d`](https://github.com/nix-community/emacs-overlay/commit/cd979f7df596efe5f2c832a9309da59df07edba8) Updated repos/melpa
* [`e211eb49`](https://github.com/nix-community/emacs-overlay/commit/e211eb490496327b1af04a1466d457964a089df9) Updated repos/elpa
* [`5b38149b`](https://github.com/nix-community/emacs-overlay/commit/5b38149b09cd069163666ce106df0b6445ad579e) Updated repos/emacs
* [`94a0f967`](https://github.com/nix-community/emacs-overlay/commit/94a0f967876bbb4b42292026d2c776cade605589) Updated repos/melpa
* [`aa60bde0`](https://github.com/nix-community/emacs-overlay/commit/aa60bde03afeaffa88c92d09d5d93a5e88938b52) Updated flake inputs
* [`aff8c63e`](https://github.com/nix-community/emacs-overlay/commit/aff8c63e9377c97dd8642997914f87422e90a4c6) Updated repos/elpa
* [`47e326ed`](https://github.com/nix-community/emacs-overlay/commit/47e326ed0f913e12ff7e06a8b51578a89ca6ae44) Updated repos/emacs
* [`4b4cdad6`](https://github.com/nix-community/emacs-overlay/commit/4b4cdad6d7ca394d228b104177cf9ee6e977d45e) Updated repos/melpa
* [`cc0ff3db`](https://github.com/nix-community/emacs-overlay/commit/cc0ff3db579aa280610a5400c0d9a389281d093e) Updated repos/nongnu
* [`64026aa4`](https://github.com/nix-community/emacs-overlay/commit/64026aa44893fa270730471a9dff263e3795c1ea) Updated flake inputs
* [`6548dfc7`](https://github.com/nix-community/emacs-overlay/commit/6548dfc7daa4057fd345ae5ed8801ad0bc2b96e6) Updated repos/emacs
* [`80f73d68`](https://github.com/nix-community/emacs-overlay/commit/80f73d6844f13f9be025d96cab116126349339f8) Updated repos/melpa
* [`cf174f60`](https://github.com/nix-community/emacs-overlay/commit/cf174f60fed1b0782065969469907b3783222791) Updated repos/elpa
* [`dc657642`](https://github.com/nix-community/emacs-overlay/commit/dc6576424d581145d8f9601974f39a979a1a4e7b) Updated repos/melpa
* [`bf1df2c2`](https://github.com/nix-community/emacs-overlay/commit/bf1df2c2f61d240286086c713b9b161a41a02dad) Updated repos/elpa
* [`c8fca3f6`](https://github.com/nix-community/emacs-overlay/commit/c8fca3f6aea811a21964939963acaecb2f86b4c4) Updated repos/emacs
* [`afe0c253`](https://github.com/nix-community/emacs-overlay/commit/afe0c2530f88b7a42f6a02fa5ac511892dab13b3) Updated repos/melpa
* [`e7fc10e8`](https://github.com/nix-community/emacs-overlay/commit/e7fc10e85984b4e14f371caf91a5e59819a5f4aa) Updated repos/emacs
* [`a163b433`](https://github.com/nix-community/emacs-overlay/commit/a163b43334a82ef433d8e11c1be767afd3ac0226) Updated repos/melpa
* [`0edca3f2`](https://github.com/nix-community/emacs-overlay/commit/0edca3f2a716b1be1dc79e414a1e95ec6117b581) Updated flake inputs
* [`d681346e`](https://github.com/nix-community/emacs-overlay/commit/d681346e2bd1d20758ac7df7bb0fba29c869255a) Updated repos/elpa
* [`bd163cbb`](https://github.com/nix-community/emacs-overlay/commit/bd163cbb21aa5e72b08960f28d2f18eb45c42542) Updated repos/emacs
* [`4465b41e`](https://github.com/nix-community/emacs-overlay/commit/4465b41e8fa9d24520c5dac921d47f7015e4eea4) Updated repos/melpa
* [`f6bd5b51`](https://github.com/nix-community/emacs-overlay/commit/f6bd5b516e016b4dec94bdf72ace884771a561e3) Updated repos/nongnu
* [`c9fb0127`](https://github.com/nix-community/emacs-overlay/commit/c9fb0127acb2f5e3e2ee994ed2af2e224106d260) Updated repos/elpa
* [`9fd6de0d`](https://github.com/nix-community/emacs-overlay/commit/9fd6de0d4213bf3a27ffb6936d700cc8b0e8a801) Updated repos/emacs
* [`a45554ee`](https://github.com/nix-community/emacs-overlay/commit/a45554eee3f64ac9fa109527972b4819ca6a4d30) Updated repos/melpa
* [`25ec9844`](https://github.com/nix-community/emacs-overlay/commit/25ec984429d5935a4755041357141983f13d0815) Updated repos/nongnu
* [`593c05f5`](https://github.com/nix-community/emacs-overlay/commit/593c05f54a5980915d439990c551c5546ff7d44a) Updated repos/emacs
* [`92d18002`](https://github.com/nix-community/emacs-overlay/commit/92d180024e1bc6c96af2cd71da752b7706b47857) Updated repos/melpa
* [`21c9b484`](https://github.com/nix-community/emacs-overlay/commit/21c9b484ed1bdd23ed4a4631b35e449e06cc801a) Updated flake inputs
* [`082589e3`](https://github.com/nix-community/emacs-overlay/commit/082589e33e0df473749140a012ed2c8d4f3eda41) Updated repos/elpa
* [`937984e1`](https://github.com/nix-community/emacs-overlay/commit/937984e1f3d6c9f962975309069ceeae05e81571) Updated repos/emacs
* [`861a8a63`](https://github.com/nix-community/emacs-overlay/commit/861a8a638959672f1dfe694a18a536a842e6cf84) Updated repos/melpa
* [`6379ddd2`](https://github.com/nix-community/emacs-overlay/commit/6379ddd2b71bdbbf2f905f7c45f9d7210e5dc7cb) Updated flake inputs
* [`040d5918`](https://github.com/nix-community/emacs-overlay/commit/040d59181718758b3e6eccbc296752b4773c070c) Updated repos/elpa
* [`d87a188b`](https://github.com/nix-community/emacs-overlay/commit/d87a188b26262db0e9b5299d77265a315ecef026) Updated repos/emacs
* [`7733a8f0`](https://github.com/nix-community/emacs-overlay/commit/7733a8f0d3aca4be0c95145ff9a36ecc01538395) Updated repos/melpa
* [`f575a6d1`](https://github.com/nix-community/emacs-overlay/commit/f575a6d16e0404e32fb30021e3e2a758c47372b7) Updated flake inputs
* [`a70fd6e9`](https://github.com/nix-community/emacs-overlay/commit/a70fd6e93de6f0d0bca3c02f9cc1acbaa914254e) Updated repos/melpa
* [`8292591d`](https://github.com/nix-community/emacs-overlay/commit/8292591d3162fa481a46a41ed393fa252635a3cb) Updated repos/elpa
* [`28c02064`](https://github.com/nix-community/emacs-overlay/commit/28c02064560b89926b01bea9c3ea5cdda562afa6) Updated repos/emacs
* [`21926f29`](https://github.com/nix-community/emacs-overlay/commit/21926f291e61451d93c5f51b155f6f6507748c49) Updated repos/melpa
* [`3df19fb0`](https://github.com/nix-community/emacs-overlay/commit/3df19fb06c4e76dcb5e4074506b69a30a76df434) Updated repos/elpa
* [`d5277bfe`](https://github.com/nix-community/emacs-overlay/commit/d5277bfee08f3bb41377695e370a1bd810a63cbe) Updated repos/emacs
* [`9e60cd75`](https://github.com/nix-community/emacs-overlay/commit/9e60cd75324d794cc59b66003ccadbb83729967e) Updated repos/melpa
* [`2735b538`](https://github.com/nix-community/emacs-overlay/commit/2735b53860344f8a83bba3c550c363d77697717c) Updated repos/emacs
* [`3fa87242`](https://github.com/nix-community/emacs-overlay/commit/3fa8724200bc0329d2d7ca3becf623dbed61431b) Updated repos/melpa
* [`cb8a0a23`](https://github.com/nix-community/emacs-overlay/commit/cb8a0a230c396bbce39e8c987bdc8564d99ff57c) Updated repos/elpa
* [`f289f869`](https://github.com/nix-community/emacs-overlay/commit/f289f869efe4e3f732071cc30c6370b334ab1a50) Updated repos/emacs
* [`b2f0ca4a`](https://github.com/nix-community/emacs-overlay/commit/b2f0ca4a3a73528460ec8b1e2178e3fe478235e2) Updated repos/melpa
* [`3417e220`](https://github.com/nix-community/emacs-overlay/commit/3417e220e04211bb58e3aa3864f92c909229b945) Updated repos/elpa
* [`5acfcf9e`](https://github.com/nix-community/emacs-overlay/commit/5acfcf9ee1b725773890aebbab8059920e4ee483) Updated repos/melpa
* [`908226aa`](https://github.com/nix-community/emacs-overlay/commit/908226aa3ed86ccb9bb45b146a1991ea89f52dbb) Updated repos/nongnu
* [`aa3f9624`](https://github.com/nix-community/emacs-overlay/commit/aa3f9624307c54b3a9d613a65f23a366cfd3ca1d) Updated repos/emacs
* [`00fe9cdc`](https://github.com/nix-community/emacs-overlay/commit/00fe9cdc30398cb126f104a8bebbfaf3b2344ccb) Updated repos/melpa
* [`a22b1c3d`](https://github.com/nix-community/emacs-overlay/commit/a22b1c3d775b1a050f589914c22b25b584c58979) Updated repos/elpa
* [`5385f8d8`](https://github.com/nix-community/emacs-overlay/commit/5385f8d83fe3a55e513e76643b5d570f4d30e7b6) Updated repos/emacs
* [`7fc25b0a`](https://github.com/nix-community/emacs-overlay/commit/7fc25b0a6adf43e1ba62864cdf180c7011065f69) Updated repos/melpa
* [`9fc2e308`](https://github.com/nix-community/emacs-overlay/commit/9fc2e308b7892d8a04008d681233225cfd4e4f65) Updated repos/nongnu
* [`a94c0d43`](https://github.com/nix-community/emacs-overlay/commit/a94c0d43748d2830aed62bfe11e3a302f0fc56f6) Updated flake inputs
* [`2043e43f`](https://github.com/nix-community/emacs-overlay/commit/2043e43fcb47f0e263488d5ccc66b07dc57940a5) Updated repos/elpa
* [`4ddb760e`](https://github.com/nix-community/emacs-overlay/commit/4ddb760e705fb711641381105bd50b94b5395e17) Updated repos/emacs
* [`7d58a5b0`](https://github.com/nix-community/emacs-overlay/commit/7d58a5b06d126ef3bfac51a17f359201374a7490) Updated repos/melpa
* [`391eb599`](https://github.com/nix-community/emacs-overlay/commit/391eb59948708ee2d3ea6e12ad5a880f61b679f4) Updated repos/emacs
* [`b60a4a64`](https://github.com/nix-community/emacs-overlay/commit/b60a4a64a9659c58aa5e28724e4a9dae7872a546) Updated repos/melpa
* [`ab2f15a1`](https://github.com/nix-community/emacs-overlay/commit/ab2f15a1cdcb2d5490714062ce28dbe0f9ba56ea) Update README.org
* [`7b005fd9`](https://github.com/nix-community/emacs-overlay/commit/7b005fd943883e2c49328bd697680f462b8e9aa3) Updated repos/elpa
* [`673f7368`](https://github.com/nix-community/emacs-overlay/commit/673f736848f8e286c0e4efa39d290ce125725f9c) Updated repos/emacs
* [`3515d563`](https://github.com/nix-community/emacs-overlay/commit/3515d5633e2e52e30466c674a02233500add2965) Updated repos/melpa
* [`95e53f0f`](https://github.com/nix-community/emacs-overlay/commit/95e53f0f4b8227d57cb121c2bdf81c6aa9165ad6) Updated repos/nongnu
* [`e3c7a4f3`](https://github.com/nix-community/emacs-overlay/commit/e3c7a4f33728880fe9b35d9e2984ea7594dc996d) Updated flake inputs
* [`e722bacb`](https://github.com/nix-community/emacs-overlay/commit/e722bacb7f4a72d22000b3580c731bd928b82952) Updated repos/elpa
* [`196217c9`](https://github.com/nix-community/emacs-overlay/commit/196217c959824d2fb46bec1f3a40770574b914d5) Updated repos/emacs
* [`22c99a85`](https://github.com/nix-community/emacs-overlay/commit/22c99a85d9188d7eaea0f8db050240f35c65eca7) Updated repos/melpa
* [`cc8840b8`](https://github.com/nix-community/emacs-overlay/commit/cc8840b8c004b94164b38d003581cba25bb44c99) Updated repos/nongnu
* [`f45d71a4`](https://github.com/nix-community/emacs-overlay/commit/f45d71a43b8e62821787d1540be5c1c5e148f633) Updated repos/emacs
* [`312d910d`](https://github.com/nix-community/emacs-overlay/commit/312d910d5c8e738ed280ebcc7535d6cbc1c44f16) Updated repos/melpa
* [`cc49b5aa`](https://github.com/nix-community/emacs-overlay/commit/cc49b5aa6d48df28920893e3c84cf24cec632b7a) Updated repos/elpa
* [`782a3303`](https://github.com/nix-community/emacs-overlay/commit/782a33039695862aecbab3b24439204dacf047f8) Updated repos/emacs
* [`a424ad5c`](https://github.com/nix-community/emacs-overlay/commit/a424ad5cf8aadc89bf7c3dac2584fa003be833a5) Updated repos/melpa
* [`d419c32b`](https://github.com/nix-community/emacs-overlay/commit/d419c32b00f86aa2bdf56ad8e1f4516b796539b9) Updated repos/nongnu
* [`c966a4b1`](https://github.com/nix-community/emacs-overlay/commit/c966a4b1819da5be0dbd9a9b37a45af2a11cb039) Updated repos/elpa
* [`66914e86`](https://github.com/nix-community/emacs-overlay/commit/66914e8616678b47426b43557d167ec47324b6ec) Updated repos/emacs
* [`f7360e45`](https://github.com/nix-community/emacs-overlay/commit/f7360e4587f3bd2974e76028748bb3bdbad204c4) Updated repos/melpa
* [`873e9d01`](https://github.com/nix-community/emacs-overlay/commit/873e9d018737305ecc1c2c9195f7e5ffa2a86873) Updated repos/nongnu
* [`421c04cf`](https://github.com/nix-community/emacs-overlay/commit/421c04cf6b136010d947dfde1c0ba2f24888cb7d) Updated repos/emacs
* [`309f6092`](https://github.com/nix-community/emacs-overlay/commit/309f6092a689e3b402a32a589bb5a6ead9abe528) Updated repos/melpa
* [`5e9d681b`](https://github.com/nix-community/emacs-overlay/commit/5e9d681b6e5d1b28aa9e6f63af25d95bdcd072cf) Updated flake inputs
* [`acbc9c3b`](https://github.com/nix-community/emacs-overlay/commit/acbc9c3b2f1babf2e2ad8bd090f88cb3a6b7204f) Updated repos/elpa
* [`3119a254`](https://github.com/nix-community/emacs-overlay/commit/3119a25433fbbdcd459e4b95d2b9a3d00f5914cc) Updated repos/nongnu
* [`6ef4c47e`](https://github.com/nix-community/emacs-overlay/commit/6ef4c47e8aa6f2e83249e85b81adff48adea7ce6) Updated flake inputs
* [`c74c8e1f`](https://github.com/nix-community/emacs-overlay/commit/c74c8e1ff4452759a8c46599cb8c704e0444db2e) Updated repos/elpa
* [`42bbaab9`](https://github.com/nix-community/emacs-overlay/commit/42bbaab936bfb1f5c7a332eb41b19580f686ad85) Updated repos/emacs
* [`0c42825c`](https://github.com/nix-community/emacs-overlay/commit/0c42825cc6084148895c853c3824687337ace4c8) Updated repos/melpa
* [`eca0a5db`](https://github.com/nix-community/emacs-overlay/commit/eca0a5db94fc129bccc66c36c944b45ac78198b7) Updated repos/nongnu
* [`783005da`](https://github.com/nix-community/emacs-overlay/commit/783005dadd5fd10a1237b64659ff3dde88a4dc38) Updated repos/emacs
* [`88dc6d60`](https://github.com/nix-community/emacs-overlay/commit/88dc6d6095da5b9436c69c47b44558230fa4fee7) Updated repos/melpa
* [`4448eae1`](https://github.com/nix-community/emacs-overlay/commit/4448eae1e86582f4c8fa14fd6866b95a7a269853) Updated repos/elpa
* [`c651f509`](https://github.com/nix-community/emacs-overlay/commit/c651f5094b14ec1475c6504bec1c4da2d6d58e39) Updated repos/emacs
* [`8ca0b1e7`](https://github.com/nix-community/emacs-overlay/commit/8ca0b1e7f427edf5e4b54485500aa8620aa8288c) Updated repos/melpa
* [`10aa8610`](https://github.com/nix-community/emacs-overlay/commit/10aa8610c73002d869b67eb261c609201dd24757) Updated repos/nongnu
* [`12af9b0c`](https://github.com/nix-community/emacs-overlay/commit/12af9b0c63590db14aa2ec9a9022edff58173cf8) Updated repos/elpa
* [`38d5883a`](https://github.com/nix-community/emacs-overlay/commit/38d5883a401207c889c8e993519908048b88170f) Updated repos/emacs
* [`14bfb2ab`](https://github.com/nix-community/emacs-overlay/commit/14bfb2ab205d5040420b4daf90a69f9e169fdb2a) Updated repos/melpa
* [`b624204e`](https://github.com/nix-community/emacs-overlay/commit/b624204e3066a662fea1a6860f5fabef4630275e) Updated flake inputs
* [`199d39af`](https://github.com/nix-community/emacs-overlay/commit/199d39af661ae5a8b28d7da71319eee61d61d6a2) Updated repos/emacs
* [`2527e136`](https://github.com/nix-community/emacs-overlay/commit/2527e1367b92eea59652378b88108b162484e7d1) Updated repos/melpa
* [`d3129804`](https://github.com/nix-community/emacs-overlay/commit/d3129804485f1bb11c9d13d44388948743079bed) Updated repos/elpa
* [`7fad827e`](https://github.com/nix-community/emacs-overlay/commit/7fad827ecbb2789760562b2c9112f2abe60efea2) Updated repos/emacs
* [`ff495a31`](https://github.com/nix-community/emacs-overlay/commit/ff495a3172537a9a5d05fadd0699daf5deb48dc0) Updated repos/melpa
* [`d1a64036`](https://github.com/nix-community/emacs-overlay/commit/d1a64036ea1761e094e0baa019176071350494ac) Updated repos/elpa
* [`edc2d972`](https://github.com/nix-community/emacs-overlay/commit/edc2d972c21aaf62cd0220727fe7716bf2ff045d) Updated repos/emacs
* [`3dbc3235`](https://github.com/nix-community/emacs-overlay/commit/3dbc3235fb7a7fd48d9c164bac12a3f1cf4b68c8) Updated repos/melpa
* [`87af8a9f`](https://github.com/nix-community/emacs-overlay/commit/87af8a9faf5cfbbd25795d9fe7574808bef46870) Updated repos/nongnu
* [`a8c4f67e`](https://github.com/nix-community/emacs-overlay/commit/a8c4f67ed6a0d1cc4b4c29fb520a95f4032fd67a) Updated flake inputs
* [`4c85f50c`](https://github.com/nix-community/emacs-overlay/commit/4c85f50cbc21792b0922848cff0ab8de6b95573e) Updated repos/melpa
* [`77a49fa6`](https://github.com/nix-community/emacs-overlay/commit/77a49fa6ee1e63b43ff755c58775b1ff72bda4fc) Updated repos/elpa
* [`f9e492d4`](https://github.com/nix-community/emacs-overlay/commit/f9e492d455d655f3853f424ae55e504c663318b6) Updated repos/melpa
* [`61c8cf26`](https://github.com/nix-community/emacs-overlay/commit/61c8cf26da93bf7574c64c7eebd241d4b160e091) Updated repos/elpa
* [`784d9301`](https://github.com/nix-community/emacs-overlay/commit/784d9301071b98c581b5be0096929408b35558bc) Updated repos/melpa
* [`e81dd4bf`](https://github.com/nix-community/emacs-overlay/commit/e81dd4bf787abe60101b867f84abb414599afa37) Updated repos/nongnu
* [`c9af8570`](https://github.com/nix-community/emacs-overlay/commit/c9af857061186f215f7052b7c85553e28eac948d) Updated flake inputs
* [`644bbbd9`](https://github.com/nix-community/emacs-overlay/commit/644bbbd9491ee2329df1aeeef18c86ef788034a5) Updated repos/emacs
* [`f59e99c3`](https://github.com/nix-community/emacs-overlay/commit/f59e99c3973f99a9338bdb03876b9072400589aa) Updated repos/melpa
* [`0fe3cdd7`](https://github.com/nix-community/emacs-overlay/commit/0fe3cdd7a3711e79d52bdf44d8081af1ab24b141) Updated repos/elpa
* [`9e1f9e55`](https://github.com/nix-community/emacs-overlay/commit/9e1f9e5515a4d99699fdf956e1ac7edf2e4d3b72) Updated repos/emacs
* [`b7e97741`](https://github.com/nix-community/emacs-overlay/commit/b7e9774116a69ea997a4c4789f9dde30d11325b0) Updated repos/melpa
* [`ffe08c51`](https://github.com/nix-community/emacs-overlay/commit/ffe08c51b289d92ee8d82f13dd069a54b8bdf3f1) Updated repos/nongnu
* [`26649a0d`](https://github.com/nix-community/emacs-overlay/commit/26649a0d3fbfe92b0b00e8cb46d50c6937e0ec7f) Updated repos/elpa
* [`b9ab22d5`](https://github.com/nix-community/emacs-overlay/commit/b9ab22d55dc3737d77db13de79260ee0adda5d4f) Updated repos/emacs
* [`62af4a0a`](https://github.com/nix-community/emacs-overlay/commit/62af4a0abcc6ab9734504c3e0b50f30deb989af1) Updated repos/melpa
* [`da71fb8e`](https://github.com/nix-community/emacs-overlay/commit/da71fb8eea8f0b3be18ea25f17e2d28dd6ee4139) Updated repos/nongnu
* [`913e44a1`](https://github.com/nix-community/emacs-overlay/commit/913e44a13636fd111139ee683a6741ccb4c28672) Updated repos/melpa
* [`cfb162b4`](https://github.com/nix-community/emacs-overlay/commit/cfb162b4ee59399c2433d339d0e5789ead3b2690) Updated repos/elpa
* [`9fd67695`](https://github.com/nix-community/emacs-overlay/commit/9fd67695e4a5e49d0861724613361b99480ff688) Updated repos/emacs
* [`1b8163de`](https://github.com/nix-community/emacs-overlay/commit/1b8163de282e43d005b28e768fd156d417d441d9) Updated repos/melpa
