### PR TITLE
niv doomemacs: update 98639850 -> 29b19412

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "986398504d09e585c7d1a8d73a6394024fe6f164",
-        "sha256": "16a7991h8ihmnshahadvzcm78g7y2gw4kfd496757mw5xqi71dxy",
+        "rev": "29b19412f6dcc36cf64a55c339f9a723fc0de3bc",
+        "sha256": "1nv3n8g5fgqsw4mfvlczw1svn8wd05i2f2hrqx9p4mi5m0g7qc5f",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/986398504d09e585c7d1a8d73a6394024fe6f164.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/29b19412f6dcc36cf64a55c339f9a723fc0de3bc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@98639850...29b19412](https://github.com/doomemacs/doomemacs/compare/986398504d09e585c7d1a8d73a6394024fe6f164...29b19412f6dcc36cf64a55c339f9a723fc0de3bc)

* [`c5f561b0`](https://github.com/doomemacs/doomemacs/commit/c5f561b0c54f9adab1a133ed91d2f9cbd50eeda0) bump: :core
* [`a180579d`](https://github.com/doomemacs/doomemacs/commit/a180579d6f1343dac87a5794c05641b20b8eef19) bump: :term eshell
* [`1bc5f441`](https://github.com/doomemacs/doomemacs/commit/1bc5f441f00a06e61087e59e94e8ce1642ffeea6) tweak: helpful-set-variable-function: use setq!
* [`574cd321`](https://github.com/doomemacs/doomemacs/commit/574cd321479ea66c0d1961da86a6969de06241a2) tweak(doom-quit): make quit message OS-sensitive
* [`edd95854`](https://github.com/doomemacs/doomemacs/commit/edd95854fd81f60a7132d830d07f4e4f22cbce89) fix: premature use of emoji fontset in <=28.1
* [`a00f0307`](https://github.com/doomemacs/doomemacs/commit/a00f03079ac0da2fe0af4193477d277132e3ae1e) bump: :app rss
* [`80f8b6b6`](https://github.com/doomemacs/doomemacs/commit/80f8b6b6802c38c3aa07bc4c428ca8fd7e9770dc) bump: :editor fold
* [`9be60fba`](https://github.com/doomemacs/doomemacs/commit/9be60fba435e41549d7e933293a25d9ede9a11c9) bump: :lang scala
* [`13fa55da`](https://github.com/doomemacs/doomemacs/commit/13fa55da8200e4482d5cb0d473762a3e08e21057) bump: :lang java
* [`c3b228fe`](https://github.com/doomemacs/doomemacs/commit/c3b228fedd050d8d028aa3d4ec2c439ab4a19bad) fix(treemacs): do not overwrite git mode when treemacs-python-executable is set
* [`31b2ad22`](https://github.com/doomemacs/doomemacs/commit/31b2ad22fbf09d99f6c1492274e48b2ffbbf5873) fix(org): call org-reveal in correct buffer
* [`cb3d0192`](https://github.com/doomemacs/doomemacs/commit/cb3d01920c83904a8af0805346c460d2f4f5a698) bump: :tools debugger lsp
* [`fba1d400`](https://github.com/doomemacs/doomemacs/commit/fba1d4005ee5c342cf1d974bc8700983a99f00e1) bump: :tools tree-sitter
* [`e4b1ed5a`](https://github.com/doomemacs/doomemacs/commit/e4b1ed5a6aefb81f75a75a59f78f4b62dd2613b5) refactor(eshell): eshell-prompt-regexp
* [`dc16fe10`](https://github.com/doomemacs/doomemacs/commit/dc16fe10e39f04ebb8e1bcf7f9befa19e9542fb6) feat(eshell): add imenu support
* [`6bea1f6a`](https://github.com/doomemacs/doomemacs/commit/6bea1f6a35d766dabb033b6eb461cc854df78297) perf(lsp): turn off eglot events buffer
* [`5100ab12`](https://github.com/doomemacs/doomemacs/commit/5100ab121d7b3d6bee6bf06773443fe3581be308) fix(upload): ssh-deploy-on-explicit-save: incorrect type
* [`e133da74`](https://github.com/doomemacs/doomemacs/commit/e133da7435eaa64ff8427fe4c60ad6cbf08298c8) docs(upload): append slash to ssh-deploy-root-local
* [`2a875d97`](https://github.com/doomemacs/doomemacs/commit/2a875d9727f4b3b69db57a38ae2833acdc98ad96) refactor(evil): remove lisp prefix-function embrace pair
* [`d9a5b326`](https://github.com/doomemacs/doomemacs/commit/d9a5b326b848f3b4fbbb24b6ef2d163da764f24c) docs: replace single -> double semicolons
* [`52be142e`](https://github.com/doomemacs/doomemacs/commit/52be142e5cda428620b892daeefd9102afb1919f) docs(rss): add a missing double quote in README
* [`7fb69fac`](https://github.com/doomemacs/doomemacs/commit/7fb69fac64672dbd002b6a7b35fea6845447615a) bump: :lang markdown
* [`7d5ceff5`](https://github.com/doomemacs/doomemacs/commit/7d5ceff5ec9683b975d5a60c1a287b804ab5a4c3) fix(plantuml): flycheck: executable support
* [`6a12331f`](https://github.com/doomemacs/doomemacs/commit/6a12331f8711e929c81b2546a726e5e3a0e692a1) docs(terraform): mention +lsp flag
* [`45f86d94`](https://github.com/doomemacs/doomemacs/commit/45f86d945944781890a83ae661abf95bd7879b2e) bump: :lang clojure
* [`fbf7e86b`](https://github.com/doomemacs/doomemacs/commit/fbf7e86b8e8372e460af5a283c05f8caf9cbd0c7) docs(clojure): clarify optional deps & add enrich-classpath note
* [`95e3491c`](https://github.com/doomemacs/doomemacs/commit/95e3491c3b65a753fab4612c01a1fc68acf0402d) bump: :completion company
* [`cdbf97b4`](https://github.com/doomemacs/doomemacs/commit/cdbf97b4e9f64e189010edb73e3cc4b24ff4185f) fix(format): align behaviour and documentation
* [`9b718f8a`](https://github.com/doomemacs/doomemacs/commit/9b718f8a5aff68dc63a6ece8d44db4ee77fcc511) docs(format): document +format-on-save-disabled-modes in README
* [`85d20f71`](https://github.com/doomemacs/doomemacs/commit/85d20f71ca45112af897931b20dac2cab2c89ebb) docs(format): fix name of doom-package
* [`9d8f657b`](https://github.com/doomemacs/doomemacs/commit/9d8f657b37f14a75eff6900bd9441c47083d5b01) refactor(format): describe what hook does
* [`9da33cf9`](https://github.com/doomemacs/doomemacs/commit/9da33cf9e7e853fb66781cf66f74d6986aba0e50) docs(format): describe interaction between +onsave and LSP
* [`c076b123`](https://github.com/doomemacs/doomemacs/commit/c076b1237f0b89a1c2ae95df8bda3c4a44e99450) docs(format): reasoning for using +format/buffer
* [`fbd00b6a`](https://github.com/doomemacs/doomemacs/commit/fbd00b6a08300b453c15410e693823078c9015af) fix(format): correct name of feature
* [`9c3d1951`](https://github.com/doomemacs/doomemacs/commit/9c3d1951e3d125b9dadd348f6c1c46f26c4a3a24) fix(swift): don't load lsp-sourcekit with eglot
* [`c2818bcf`](https://github.com/doomemacs/doomemacs/commit/c2818bcfaa5dc1a0139d1deff7d77bf42a08eede) fix(latex): avoid stealing focus after compilation
* [`9a1022ef`](https://github.com/doomemacs/doomemacs/commit/9a1022ef08d4d449e76341627325ff7756c4e178) bump: :editor format
* [`e5cbe36f`](https://github.com/doomemacs/doomemacs/commit/e5cbe36fd75ed6b833837f08f423a479bfa66f3d) bump: :tools tree-sitter
* [`f4e02a2d`](https://github.com/doomemacs/doomemacs/commit/f4e02a2d390ff411c05521c179732267b6543439) fix(org): don't call org-reveal in dead buffer
* [`87f6f7ab`](https://github.com/doomemacs/doomemacs/commit/87f6f7ab91089235a66d9076fa50a5fc4d37dfea) bump: :lang scheme
* [`f9c2397a`](https://github.com/doomemacs/doomemacs/commit/f9c2397a3cee34732b8279bba49af1e6f09eb113) fix: autoloads load order in profile bootstrap
* [`6ca6bf09`](https://github.com/doomemacs/doomemacs/commit/6ca6bf09355dac948118c341d5ecf2731b66b50f) bump: :lang haskell
* [`d55b078f`](https://github.com/doomemacs/doomemacs/commit/d55b078fa183cb2d44ad902e7d3760b1112b94b3) bump: :checkers
* [`88c59129`](https://github.com/doomemacs/doomemacs/commit/88c59129ec89afe8f38e3adb4676561fb5b41ccd) fix(lib): doom/bumpify-diff: skip non-package! forms
* [`fde4289f`](https://github.com/doomemacs/doomemacs/commit/fde4289f5ce2d5222b6cc81db5a6b6e6a5f71c31) bump: :completion company helm ivy
* [`29b19412`](https://github.com/doomemacs/doomemacs/commit/29b19412f6dcc36cf64a55c339f9a723fc0de3bc) dev: ignore .DS_Store at top level
