### PR TITLE
niv nixpkgs: update d9de1239 -> 72061433

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d9de123937bc971bb232fc79d35a91f97beb2641",
-        "sha256": "03828lb6wz7v78q7r0k8fcrhw8x5yrll8s2kyg3myicljicnx3z0",
+        "rev": "72061433dd3711fe9a06b177323e4ffd4a81847a",
+        "sha256": "0advvnbsrbvvz1m2zhkigkmq00ib0kq7a7qkrh5i33vkczdq7pjd",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d9de123937bc971bb232fc79d35a91f97beb2641.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/72061433dd3711fe9a06b177323e4ffd4a81847a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d9de1239...72061433](https://github.com/nixos/nixpkgs/compare/d9de123937bc971bb232fc79d35a91f97beb2641...72061433dd3711fe9a06b177323e4ffd4a81847a)

* [`06d89dac`](https://github.com/NixOS/nixpkgs/commit/06d89dac2045b6d42c5eb2d907afd92df826467a) goperf: init at unstable-2022-09-20
* [`53cc9ddf`](https://github.com/NixOS/nixpkgs/commit/53cc9ddff1812ddcca28b5d9f0359f756284fa43) saxon-he: 9.9.0.1 -> 11.5
* [`4229a103`](https://github.com/NixOS/nixpkgs/commit/4229a103bd118db2ac837cbe9dba578771c8947b) libpqxx: 7.7.0 → 7.7.5
* [`46b3a493`](https://github.com/NixOS/nixpkgs/commit/46b3a4935dc3496e1b3d0636e87588057c46ee0e) rotp: init at 1.04
* [`3fe9c960`](https://github.com/NixOS/nixpkgs/commit/3fe9c960ef64c14745513f0ba8cd16bd560babda) hyprpicker: switch to wlroots_0_16
* [`6ba3ff14`](https://github.com/NixOS/nixpkgs/commit/6ba3ff14bc6af961a01d70155ed1cdd352c58f22) watchexec: 1.22.2 -> 1.23.0
* [`89d92033`](https://github.com/NixOS/nixpkgs/commit/89d92033ce24f28136b0bcef6ec963cd5145e8ca) maintainers: add redxtech
* [`13e6a040`](https://github.com/NixOS/nixpkgs/commit/13e6a040c040af720542a3dd6285fdbcbc262880) vimix-cursor-theme: init at 2020-02-24
* [`be26791c`](https://github.com/NixOS/nixpkgs/commit/be26791c5bf1386e599f40b628b18b9e2e64f866) vrc-get: 1.1.3 -> 1.3.0
* [`8539bc90`](https://github.com/NixOS/nixpkgs/commit/8539bc905505b36ac5eda7eeedc6095e6473bc3c) maintainers: add stnley
* [`ba532691`](https://github.com/NixOS/nixpkgs/commit/ba532691a73766d2ee3cab78cdccafabfcda7061) emmet-language-server: init at 2.2.0
* [`9218434c`](https://github.com/NixOS/nixpkgs/commit/9218434c94ff5d5d23607e00428c94a475681801) qmenumodel: init at 0.9.1
* [`8838eb98`](https://github.com/NixOS/nixpkgs/commit/8838eb98b55f27fdf1470ed43ba8ae7feee89b4d) qmenumodel: 0.9.1 -> 0.9.2
* [`46b1742f`](https://github.com/NixOS/nixpkgs/commit/46b1742febfea021b949d3dc02567dd7a5896abe) unl0kr: init
* [`e22bc793`](https://github.com/NixOS/nixpkgs/commit/e22bc793baffca5054122e20b19856c93365f6a3) properties-cpp: 0.0.1 -> 0.0.3
* [`920cbea4`](https://github.com/NixOS/nixpkgs/commit/920cbea46cffae0273f7135071f3d62abf5804e1) icingaweb2-thirdparty: 0.11.0 -> 0.12.0
* [`0f8084ba`](https://github.com/NixOS/nixpkgs/commit/0f8084ba6bc3d11c2a42744b59fe430a3e2bc127) nixos/doc: add documentation on using FIDO2 tokens in systemd stage1
* [`f1137c4d`](https://github.com/NixOS/nixpkgs/commit/f1137c4db54e42d986c87bcc1f354002fdde620e) open62541: 1.3.7 -> 1.3.8
* [`2c8e24a2`](https://github.com/NixOS/nixpkgs/commit/2c8e24a2144a99f2ae75bef8725ed393bded225e) segger-ozone: 3.28e -> 3.30b
* [`46b2ddd5`](https://github.com/NixOS/nixpkgs/commit/46b2ddd5940a6df98e04fe513f10c0ee31600515) segger-ozone: refactor with autoPatchelfHook, support i686-linux
* [`c7fc4e04`](https://github.com/NixOS/nixpkgs/commit/c7fc4e04aaf142a728cd2b69eb18fc5ae03610c5) {libsForQt5.qzxing,qt6Packages.qzxing}: init at 3.3.0
* [`0c22987c`](https://github.com/NixOS/nixpkgs/commit/0c22987cbd48192892b63a3c72d5f13495b26a70) net-cpp: init at 3.1.0
* [`ad1a442f`](https://github.com/NixOS/nixpkgs/commit/ad1a442fbdf07f574f88165fe04ae1d1b0dbbbf7) libcue: 2.2.1 -> 2.3.0
* [`69e24a57`](https://github.com/NixOS/nixpkgs/commit/69e24a579c9a03e7c802323c78959a1560845bc3) nixos/module: add boot.initrd.unl0kr
* [`c5512988`](https://github.com/NixOS/nixpkgs/commit/c5512988b125e38fdf1edbd82302335ded797924) nixos/tests: init systemd-initrd-luks-unl0kr
* [`04fab8b9`](https://github.com/NixOS/nixpkgs/commit/04fab8b9eed529430d362131deaa2c2d9f82dc1b) dlib: build with fftw, blas and webp
* [`0ddd921e`](https://github.com/NixOS/nixpkgs/commit/0ddd921ebd0c3045382e0539c328d3ebf0bb4e5a) vagrant: 2.3.4 -> 2.3.7
* [`1b9c8b2d`](https://github.com/NixOS/nixpkgs/commit/1b9c8b2d0f11131e5373de65d5abcafe7838f8f3) vagrant: libvirt-provider: 0.8.2 -> 0.12.2
* [`40e2a9f9`](https://github.com/NixOS/nixpkgs/commit/40e2a9f945108f42b80198bb67739c1a422abc9e) qdigidoc: 4.2.12 -> 4.4.0
* [`0cb07e0d`](https://github.com/NixOS/nixpkgs/commit/0cb07e0d469303f989acf9d4263f567a5a91eb45) chiaki4deck: 1.4.0 -> 1.4.1
* [`76460f7e`](https://github.com/NixOS/nixpkgs/commit/76460f7e73dd7b54ad52546475c38e5e66cd08e3) libxmlb: 0.3.10 -> 0.3.14
* [`86498a74`](https://github.com/NixOS/nixpkgs/commit/86498a74a769ab07f865f02c641e80fc47e7458b) passExtensions.pass-file: init at 1.0.0
* [`fa4581f1`](https://github.com/NixOS/nixpkgs/commit/fa4581f1efbc6315ab111f5c7ab3022c237f5a44) ayatana-indicator-messages: init at 23.10.0
* [`b18f8aa7`](https://github.com/NixOS/nixpkgs/commit/b18f8aa7040ead350d5da0b0ee07c2d596d6ebd3) eclipses.eclipse-dsl: Init at 2023-09
* [`aba2b6d3`](https://github.com/NixOS/nixpkgs/commit/aba2b6d387dcbe2f8e06de7140442a8459220b34) nixos/ayatana-indicators: init module
* [`84605b10`](https://github.com/NixOS/nixpkgs/commit/84605b10088d734ce7ec049acd69e7a78abe535a) nixos/tests: Add ayatana-indicators test
* [`4aac5539`](https://github.com/NixOS/nixpkgs/commit/4aac5539d0ea8e4a7ef830ee748a1cc78b519bf6) lomiri.biometryd: init at 0.3.0
* [`50c613d9`](https://github.com/NixOS/nixpkgs/commit/50c613d926675d1b4aaff04c4d18a102f573e449) micro: 2.0.12 -> 2.0.13
* [`81a45239`](https://github.com/NixOS/nixpkgs/commit/81a45239fa616ad5a610b4c89514ee3ed315538a) gnuplot: 5.4.9 -> 5.4.10
* [`d47bb326`](https://github.com/NixOS/nixpkgs/commit/d47bb3261f54f5285b0f0714cd4f3f7452f89017) nixos/i3: add updateSessionEnvironment option
* [`52c5c3fc`](https://github.com/NixOS/nixpkgs/commit/52c5c3fc78877e1b66467b5ff1848d0b459a2cc8) raysession: 0.13.1 -> 0.14.2
* [`23c7af2d`](https://github.com/NixOS/nixpkgs/commit/23c7af2d23729cb87dc5e5b6b615c0d5ac0532d9) maintainers: add tc-kaluza
* [`60fa50c0`](https://github.com/NixOS/nixpkgs/commit/60fa50c058fc5939aa549a4daa50b9d0d9ee2899) insulator2: init at 2.12.2
* [`8ba16234`](https://github.com/NixOS/nixpkgs/commit/8ba16234145791a1bf2f05fcbd1b5f7cbd13b29c) xdg-desktop-portal-wlr: add bash to program wrapper
* [`258d76f5`](https://github.com/NixOS/nixpkgs/commit/258d76f551a81c9b9fd5256966c718a6d62b9e6c) systemd: add withLogTrace option
* [`2e458caa`](https://github.com/NixOS/nixpkgs/commit/2e458caa6852868dbb1c7542e1f7f37c773efd34) yder: 1.4.19 -> 1.4.20
* [`020476ee`](https://github.com/NixOS/nixpkgs/commit/020476ee9d8898e99454fba526310fe71d341399) abbaye-des-morts: 2.0.1 -> 2.0.2
* [`327f772e`](https://github.com/NixOS/nixpkgs/commit/327f772eef3d7ae031fe4d17d9006420b2d38e8f) gpuvis: 20211204 -> 0.1
* [`87ff8913`](https://github.com/NixOS/nixpkgs/commit/87ff8913bf53dbb2205cadc22d1cc076c146bc97) eclipses.plugins.ivyde{,rv}: Replace SHA-1 hashes with SHA256 in SRI format
* [`3418c7c1`](https://github.com/NixOS/nixpkgs/commit/3418c7c1e719658cab509347ad4995ef0e67998c) jetbrains: Append Python to PATH rather than prepend
* [`a9b63a45`](https://github.com/NixOS/nixpkgs/commit/a9b63a457e93d8dd03b7c4d3840bf38c97ddb4cf) libosinfo: 1.10.0 -> 1.11.0
* [`673be3ee`](https://github.com/NixOS/nixpkgs/commit/673be3eed6e919d9079614ec2141f1d06d36a30e) flarectl: init at 0.80.0
* [`e0741dfd`](https://github.com/NixOS/nixpkgs/commit/e0741dfda450b6fc046d9273ae0d1f012f57894a) libblockdev: 3.0.3 -> 3.0.4
* [`ea702e25`](https://github.com/NixOS/nixpkgs/commit/ea702e25db5be8a3f529f7d3a5aea7688b3e9a85) greetd.gtkgreet: 0.7 -> 0.8
* [`c04d238f`](https://github.com/NixOS/nixpkgs/commit/c04d238f443b8c984ad20d8a344ca2b5c5ba0a17) inspectrum: 0.2.3 -> 0.3.1
* [`749d5f3b`](https://github.com/NixOS/nixpkgs/commit/749d5f3b0f59b016be17da3009276d5f2f886931) fend: add `meta.changelog`
* [`1617eeca`](https://github.com/NixOS/nixpkgs/commit/1617eeca678b9b1a2e52e3474ee4b624b5efa12f) fend: add package tests
* [`7318e9dc`](https://github.com/NixOS/nixpkgs/commit/7318e9dcfeb8363f75ff2b3d7e2b7527c0d53492) litefs: 0.5.4 -> 0.5.8
* [`89f5e438`](https://github.com/NixOS/nixpkgs/commit/89f5e438515fd30c080b65903928e4ef44088471) melange: 0.4.0 -> 0.5.1
* [`ae2c5f6e`](https://github.com/NixOS/nixpkgs/commit/ae2c5f6e15312622b298a107dfc38412f8b98979) consul: 1.16.1 -> 1.16.3
* [`094eb77f`](https://github.com/NixOS/nixpkgs/commit/094eb77f323e1e33bd09378edb2207a902ff5a7b) opam-publish: 2.2.0 -> 2.3.0
* [`330d2db1`](https://github.com/NixOS/nixpkgs/commit/330d2db19fa25fad7e3d9b5066b5fd82cd66bbe3) grafana: skip two more flaky tests
* [`e32eb681`](https://github.com/NixOS/nixpkgs/commit/e32eb6818377a7d3ed2d0815418e6cb8427819e7) realesrgan-ncnn-vulkan: 0.1.3.2 -> 0.2.0
* [`9768b51d`](https://github.com/NixOS/nixpkgs/commit/9768b51de67b06962cea89f11f4452f0368a5bd6) intel-compute-runtime: 23.30.26918.20 -> 23.35.27191.9
* [`7a363cef`](https://github.com/NixOS/nixpkgs/commit/7a363cef5fde13b484019ef342dbdd91c30b3200) nixos/dolibarr: add package option
* [`17ab7088`](https://github.com/NixOS/nixpkgs/commit/17ab7088afa0db7168e245ab878f437265e354a2) languagetool: 6.2 -> 6.3
* [`83584fa4`](https://github.com/NixOS/nixpkgs/commit/83584fa417c4bb0f014a3383829c342a6305c419) libaec: 1.1.1 -> 1.1.2
* [`3f81d2c5`](https://github.com/NixOS/nixpkgs/commit/3f81d2c5c59d6a8524ef7c207c920d76b4e34238) moarvm: 2023.09 -> 2023.10
* [`0f0e603e`](https://github.com/NixOS/nixpkgs/commit/0f0e603ed434ddceb4bffc0f6e7c534e8128b79f) mockoon: 5.0.0 -> 5.1.0
* [`901dcdf4`](https://github.com/NixOS/nixpkgs/commit/901dcdf4dffd7c6e30a435ff75a508be9a8797c6) kallisto: 0.50.0 -> 0.50.1
* [`bd8ff6d2`](https://github.com/NixOS/nixpkgs/commit/bd8ff6d2fdf67c616aa8f1ebc2713fe1e7fa2d93) octavePackages.instrument-control: 0.8.0 -> 0.9.1
* [`a810762b`](https://github.com/NixOS/nixpkgs/commit/a810762be27afd35ea7b3ab92e0aa0eacfb9d868) octavePackages.ltfat: 2.5.0 -> 2.6.0
* [`b9d1da32`](https://github.com/NixOS/nixpkgs/commit/b9d1da32525e493c7005178fdd6ac9ac44b8b499) goaccess: 1.8 -> 1.8.1
* [`bed356c1`](https://github.com/NixOS/nixpkgs/commit/bed356c15a48b855abffabf76f82797cd60c238c) highfive: 2.7.1 -> 2.8.0
* [`8909df85`](https://github.com/NixOS/nixpkgs/commit/8909df85e787a23e9562ac73565a43fa877f25f6) tvm: 0.13.0 -> 0.14.0
* [`50abe806`](https://github.com/NixOS/nixpkgs/commit/50abe8063c4028961b45799ee651ed21a7207847) sov: add passthru.updateScript
* [`043723bc`](https://github.com/NixOS/nixpkgs/commit/043723bc0c0e1fa0e871b9a2c756bcd7540c928b) sov: 0.92b -> 0.93
* [`287a8597`](https://github.com/NixOS/nixpkgs/commit/287a8597d0a22bf33a8e7c9633da08a4fbff2a10) twitch-tui: 2.5.1 -> 2.6.0
* [`8a06588e`](https://github.com/NixOS/nixpkgs/commit/8a06588ed46c1fcae97881d154106ebea1a9d76c) otel-desktop-viewer: init at 0.1.4
* [`df5285c7`](https://github.com/NixOS/nixpkgs/commit/df5285c79c034350121e65d9bc6c579d7e933b8c) salut: init at unstable-2022-12-17
* [`cac1f957`](https://github.com/NixOS/nixpkgs/commit/cac1f9575a16329c33eb0b3f87d69e7afb9a8ba8) buttercup-desktop: 2.20.3 -> 2.21.0
* [`6f28ce98`](https://github.com/NixOS/nixpkgs/commit/6f28ce985605031e0d772fe7f4f4710bb92c07ad) nixos/x2goserver: Work with both Miller's sudo and sudo-rs
* [`96405d41`](https://github.com/NixOS/nixpkgs/commit/96405d41ced8e64b5c3cc96a50300b52172950e2) janusgraph: 0.6.4 -> 1.0.0
* [`7bdc9489`](https://github.com/NixOS/nixpkgs/commit/7bdc9489de91dc3515e88759d42854293a06075d) tradingview: 2.6.1 -> 2.6.3
* [`c2df7ce3`](https://github.com/NixOS/nixpkgs/commit/c2df7ce3f7eedbabfe6e57cf4ad04658e4532819) libmysqlconnectorcpp: 8.1.0 -> 8.2.0
* [`7e8337af`](https://github.com/NixOS/nixpkgs/commit/7e8337af460e2e92e903f3548295509fcde937ba) ultrastardx: 2023.9.0 -> 2023.11.0
* [`58cf8505`](https://github.com/NixOS/nixpkgs/commit/58cf8505ce73d10175d4bbe03818eaf318bb7718) athens: init at 0.12.1
* [`9c5825bd`](https://github.com/NixOS/nixpkgs/commit/9c5825bd27f5684aed9d31ad31727c12dd982211) nixos/athens: init at 0.12.1
* [`e5ecd94d`](https://github.com/NixOS/nixpkgs/commit/e5ecd94df801fc17fe4db24a5b1e7ac4ea8d3219) nxpmicro-mfgtools: 1.5.125 -> 1.5.139
* [`5084d572`](https://github.com/NixOS/nixpkgs/commit/5084d57230b07d5101d3f2d72ee339e9e9d43914) deadbeef: 1.9.5 -> 1.9.6
* [`8f0fc5a2`](https://github.com/NixOS/nixpkgs/commit/8f0fc5a2eb4d6941b6b8dda4ac047d9e6c45cc14) sumo: 1.18.0 -> 1.19.0
* [`4d9f4c07`](https://github.com/NixOS/nixpkgs/commit/4d9f4c07cb9500ffd949547f6a64ac1b618e38be) pam-honeycreds: init at 1.9
* [`05a86408`](https://github.com/NixOS/nixpkgs/commit/05a8640892d82265583c71123dfd6bf3a81d95ae) remmina: 1.4.31 -> 1.4.33
* [`51dc84e1`](https://github.com/NixOS/nixpkgs/commit/51dc84e112894640b176614e03f6a965d7d9a6cb) flamp: 2.2.09 -> 2.2.10
* [`ed05e999`](https://github.com/NixOS/nixpkgs/commit/ed05e9994bfd38b336f1133895bd568fa82ad997) minikube: 1.31.2 -> 1.32.0
* [`29159a75`](https://github.com/NixOS/nixpkgs/commit/29159a75049857609d0700310cadd4bbd294f29f) dirb: link wordlists to `$out/share/wordlists`
* [`8e78c0eb`](https://github.com/NixOS/nixpkgs/commit/8e78c0ebac6017e6b06986ad0741d10b926e492c) monado: unstable-2023-08-22 -> unstable-2023-11-09
* [`6d170103`](https://github.com/NixOS/nixpkgs/commit/6d1701030cca2cef276b606d1bed800371eee6d9) schemacrawler: 16.20.4 -> 16.20.5
* [`47b7aae9`](https://github.com/NixOS/nixpkgs/commit/47b7aae9d00cacacf7242cdae24fe26574280c22) maintainer: add noodlez1232
* [`28db09a3`](https://github.com/NixOS/nixpkgs/commit/28db09a338cc43633135011b3371b6be87556a21) obs-studio-plugins.obs-move-transition: 2.9.5 -> 2.9.6
* [`6a83941f`](https://github.com/NixOS/nixpkgs/commit/6a83941f494a3521fb753248f54bbb6ef7d89e65) bindfs: 1.17.4 -> 1.17.5
* [`9d68ff32`](https://github.com/NixOS/nixpkgs/commit/9d68ff32d7d4428adde249eb3db45c904fa78d1f) gifgen: init at 1.2.0
* [`f683a749`](https://github.com/NixOS/nixpkgs/commit/f683a749fb6f2d149af2b888794b46d72acee389) obs-studio-plugins.obs-transition-table: 0.2.6 -> 0.2.7
* [`98e26121`](https://github.com/NixOS/nixpkgs/commit/98e261211b4362e321e5ccdf1179056c775be62d) opensnitch: 1.6.3 -> 1.6.4
* [`2c816df7`](https://github.com/NixOS/nixpkgs/commit/2c816df73285f93ab42de590e529d87490c715a8) emojify: init at 2.2.0
* [`a7b54e11`](https://github.com/NixOS/nixpkgs/commit/a7b54e113649e8f38d8e4efe72739efe228b532e) seqkit: 2.5.1 -> 2.6.0
* [`b81f1255`](https://github.com/NixOS/nixpkgs/commit/b81f1255eb67f584400ab2e0f8c4c759964e73cb) slsa-verifier: 2.4.0 -> 2.4.1
* [`4c338ac0`](https://github.com/NixOS/nixpkgs/commit/4c338ac082d182a9abdec55fce26ddb77ca4c850) uftp: 5.0.1 -> 5.0.2
* [`7fbd91bf`](https://github.com/NixOS/nixpkgs/commit/7fbd91bfa633868e56ba080cec1e16596b0e9aab) zed: 1.10.0 -> 1.11.0
* [`69765bd7`](https://github.com/NixOS/nixpkgs/commit/69765bd743924a72c68d246201bc072bd5de9bbc) libdatovka: 0.4.0 -> 0.5.0
* [`ae5fe741`](https://github.com/NixOS/nixpkgs/commit/ae5fe741ba9acade281a9185139e3922811c9696) nixos/roundcube: Ignore newline at end of password file
* [`f1047f61`](https://github.com/NixOS/nixpkgs/commit/f1047f611df1754555bd98d6f90cac7f02c5f24f) joycond-cemuhook: init at unstable-2023-08-09
* [`cea373ca`](https://github.com/NixOS/nixpkgs/commit/cea373ca564e82c6c5d5615b245d1f5e7ff087bb) keymapper: 2.7.2 -> 3.0.0
* [`a88bfcc3`](https://github.com/NixOS/nixpkgs/commit/a88bfcc380c57001a5bd47d4c0f3a14b248788a0) freeciv: 3.0.8 -> 3.0.9
* [`4ad5678a`](https://github.com/NixOS/nixpkgs/commit/4ad5678a8e92b6d993f03a39070ab463084ba5d7) sftpgo: 2.5.4 -> 2.5.5
* [`3c0a4162`](https://github.com/NixOS/nixpkgs/commit/3c0a41629668bb3eff8564a86fb8f5f3b39a011a) cimg: 3.3.1 -> 3.3.2
* [`6a23a1df`](https://github.com/NixOS/nixpkgs/commit/6a23a1df293e108511713634bc2eccb7f659dbbb) gmic-qt: 3.3.1 -> 3.3.2
* [`e029a619`](https://github.com/NixOS/nixpkgs/commit/e029a61976a6e0034f7a44c5dd476ebc506c74ee) juju: 3.2.3 -> 3.3.0
* [`cd49f637`](https://github.com/NixOS/nixpkgs/commit/cd49f6378c53e3815dd87ed6bca1dccc6981f4c0) python311Packages.zope-configuration: rename frome zope_configuration
* [`e5317b93`](https://github.com/NixOS/nixpkgs/commit/e5317b9352594a61f0070f797f17974852e0cff7) python311Packages.zope-configuration: refactor
* [`98b74e8a`](https://github.com/NixOS/nixpkgs/commit/98b74e8ae768e0e8d5df13966b591a225aeaacda) python311Packages.zope-configuration: 4.4.1 -> 5.0
* [`6f0e72c9`](https://github.com/NixOS/nixpkgs/commit/6f0e72c9cab6d21c68cdf1dd23762a406b9aa616) python311Packages.zope-testing: rename from zope_testing
* [`15e9135d`](https://github.com/NixOS/nixpkgs/commit/15e9135dd7ca912ee014344af13da1e7711cfe57) python311Packages.zope-testing: refactor
* [`2414cc4e`](https://github.com/NixOS/nixpkgs/commit/2414cc4edc5b355979708d5cd76527b4071cb8d7) argocd-vault-plugin: 1.16.1 -> 1.17.0
* [`5ccea07f`](https://github.com/NixOS/nixpkgs/commit/5ccea07f6982adf10cdfc1c2cb0ccec9c696815f) ibus-engines.table: 1.17.3 -> 1.17.4
* [`09edf1dd`](https://github.com/NixOS/nixpkgs/commit/09edf1dd841301c4b7cb18ad40859a2885d79df8) irqbalance: 1.9.2 -> 1.9.3
* [`e4346914`](https://github.com/NixOS/nixpkgs/commit/e4346914e19f1ffc1b26a8eac09b245f92a513e0) glfw: fix build for Python bindings
* [`ffe530bc`](https://github.com/NixOS/nixpkgs/commit/ffe530bc21a27c3c52d7c9ec178b6271ae36c41c) q: 0.13.5 -> 0.15.1
* [`e5b328b4`](https://github.com/NixOS/nixpkgs/commit/e5b328b4c4d28e8bf67d0588b8f73002d026715e) questdb: 7.3.3 -> 7.3.4
* [`290bc1fb`](https://github.com/NixOS/nixpkgs/commit/290bc1fbe0855cbc82efa17bf9382f428512910f) mujoco: 2.3.7 -> 3.0.0, add Python bindings
* [`9d698d53`](https://github.com/NixOS/nixpkgs/commit/9d698d53620502d498c049f83571df588e81acee) maintainers: add trespaul
* [`59973029`](https://github.com/NixOS/nixpkgs/commit/5997302957c6757e24344f970e4770ddda911176) re-flex: 3.5.0 -> 3.5.1
* [`0b5abe8d`](https://github.com/NixOS/nixpkgs/commit/0b5abe8d41f66a71ac2b56fe035caf96150a281c) recyclarr: 6.0.1 -> 6.0.2
* [`4e0ee6bd`](https://github.com/NixOS/nixpkgs/commit/4e0ee6bdbdadf356ce951434d8527f8c7d7c89ca) regbot: 0.5.3 -> 0.5.4
* [`da06ef01`](https://github.com/NixOS/nixpkgs/commit/da06ef01cea96d977bcfa2a94d09b13a998f88f2) bzrtp: 5.2.98 -> 5.2.111
* [`9868bc5e`](https://github.com/NixOS/nixpkgs/commit/9868bc5e2e4745a310e145781b9822fad56be5ed) opensnitch-ui: 1.6.2 -> 1.6.4
* [`2b2c6f4c`](https://github.com/NixOS/nixpkgs/commit/2b2c6f4c287c6107acb9b7b0c2b00dd53bf27b44) kent: enable patches if needed.
* [`18c6fd5a`](https://github.com/NixOS/nixpkgs/commit/18c6fd5a200ae7319fd6bb0de73e15d7759fb410) leatherman: 1.12.10 -> 1.12.11
* [`2d18c4c7`](https://github.com/NixOS/nixpkgs/commit/2d18c4c72f69748c0a003c4318afe9689a5ce171) libzim: 8.2.1 -> 9.0.0
* [`91899b11`](https://github.com/NixOS/nixpkgs/commit/91899b1109f176e0edc8979ce453447aa1c66f67) kubeone: 1.7.0 -> 1.7.1
* [`1687add9`](https://github.com/NixOS/nixpkgs/commit/1687add93b97e6863702dd0b60344943cdea5785) rabbitmq-server: 3.12.7 -> 3.12.8
* [`5890c348`](https://github.com/NixOS/nixpkgs/commit/5890c348661b73df954baa74dc57d2c936f9ad34) rssguard: 4.5.1 -> 4.5.3
* [`5aad7201`](https://github.com/NixOS/nixpkgs/commit/5aad720177230290632e8327eab529dc94792cf2) transgui: unstable-2022-02-02 -> unstable-2023-10-19
* [`7a8a2192`](https://github.com/NixOS/nixpkgs/commit/7a8a219298f19423a419c2f18be6dd29bce29256) sarasa-gothic: 0.42.2 -> 0.42.6
* [`59878f63`](https://github.com/NixOS/nixpkgs/commit/59878f63cac103b28bb8fec293798f4efd18e816) python311Packages.black: 23.9.1 -> 23.11.0
* [`215951e4`](https://github.com/NixOS/nixpkgs/commit/215951e4c816f7cd142625df2b6ab3149e39ea14) check-meta: Improve performance
* [`0527676b`](https://github.com/NixOS/nixpkgs/commit/0527676bd9b2505603208c412198016575228255) check-meta: don't use with
* [`de49c241`](https://github.com/NixOS/nixpkgs/commit/de49c2415c716bb598d5ff536082842c4c6745c0) lomiri.biometryd: Fetch submitted changes from upstream
* [`eedc4827`](https://github.com/NixOS/nixpkgs/commit/eedc482721f8e7802428c686c3cc9930249b9e8a) spire: 1.8.2 -> 1.8.3
* [`64171a25`](https://github.com/NixOS/nixpkgs/commit/64171a258cc30c0596dddcf8ddfed53a323c1330) racket,racket-minimal: 8.10 -> 8.11
* [`48f99e93`](https://github.com/NixOS/nixpkgs/commit/48f99e939274469e44306b667e257866455df377) suricata: 7.0.1 -> 7.0.2
* [`cda66fe2`](https://github.com/NixOS/nixpkgs/commit/cda66fe22f09071e55c70f0f92c058a908eb215b) abaddon: 0.1.12 -> 0.1.13
* [`3881f6f8`](https://github.com/NixOS/nixpkgs/commit/3881f6f864fcd788efc7402bd8149ac5d07e6882) sourcehut.pastesrht: add myself as maintainer
* [`5476b490`](https://github.com/NixOS/nixpkgs/commit/5476b490d4c47655ee6345a120b663fa5351ee07) nixos/sourcehut: compile and integrate paste.sr.ht API component
* [`3ac1c95c`](https://github.com/NixOS/nixpkgs/commit/3ac1c95cfa84b3b31880935f69a612da246b1025) maven: improve buildMavenPackage offline mode
* [`efc6520b`](https://github.com/NixOS/nixpkgs/commit/efc6520b6847074420ae5d98abb76928e30221fe) tar2ext4: 0.11.1 -> 0.11.4
* [`249c6d04`](https://github.com/NixOS/nixpkgs/commit/249c6d04b1f35dbdd516fcafbc312d935d4d1a6f) check-meta: don't use rec
* [`bbd02eb3`](https://github.com/NixOS/nixpkgs/commit/bbd02eb30ea935810e018019004b350e031891c1) maintainers: add n00b00s
* [`06c136e2`](https://github.com/NixOS/nixpkgs/commit/06c136e24b867b199989dd745b2a94e19e2cf113) python3.pkgs.gcodepy: init at 0.1.1
* [`f291a75f`](https://github.com/NixOS/nixpkgs/commit/f291a75fdad21c487730f604f0a248f72c3cbac4) immudb: 1.5.0 -> 1.9DOM.0
* [`efd4c89c`](https://github.com/NixOS/nixpkgs/commit/efd4c89c137aa7c588885c14f5e6e60ead4879a2) maintainers: add ayes-web
* [`a1df20a5`](https://github.com/NixOS/nixpkgs/commit/a1df20a561b2b9ba7efed6485e8b20627b82b847) bats.libraries.bats-file: 0.3.0 -> 0.4.0
* [`d84b211f`](https://github.com/NixOS/nixpkgs/commit/d84b211fea38cb5f1e6fcfd6d34ab3bd29a14a79) sourcehut.pastesrht: 0.15.1 -> 0.15.2
* [`5ff0206f`](https://github.com/NixOS/nixpkgs/commit/5ff0206f183077f416714ab213f9a047a1b2150d) treesheets: unstable-2023-09-15 -> unstable-2023-11-13
* [`2cbc3b25`](https://github.com/NixOS/nixpkgs/commit/2cbc3b251abc648e488b943d198541866f0d7cc2) vault-bin: 1.15.0 -> 1.15.2
* [`6202a400`](https://github.com/NixOS/nixpkgs/commit/6202a4001c686db8081d2246324c5cd1d6603913) dotnet-sdk: 6.0.416 -> 6.0.417
* [`67fd9867`](https://github.com/NixOS/nixpkgs/commit/67fd986747e574c664928087153302fc8d77482f) dotnet-sdk_7: 7.0.403 -> 7.0.404
* [`1670aac5`](https://github.com/NixOS/nixpkgs/commit/1670aac55054460697f21dc9bdeba32eadcd422f) vivaldi: 6.2.3105.58 -> 6.4.3160.42
* [`5ed7ebe4`](https://github.com/NixOS/nixpkgs/commit/5ed7ebe4849ad0128b32510a9fde6e8526b999e8) python3Packages.gekko: init at 1.0.6
* [`21c4107d`](https://github.com/NixOS/nixpkgs/commit/21c4107d3e498b48c56eeaf0868f8e9fcb5c06f7) gromacs: add the plumed patches
* [`07ed6685`](https://github.com/NixOS/nixpkgs/commit/07ed6685dc8b4ccdae86fc301e16c395999a260f) prisma-engines: 5.4.1 -> 5.6.0
* [`17881833`](https://github.com/NixOS/nixpkgs/commit/178818331eddcbcc1b032fa6314f7d04be199c2e) nodePackages.prisma: 5.4.1 -> 5.6.0
* [`c14085ee`](https://github.com/NixOS/nixpkgs/commit/c14085ee5380057a9f44e536b5498b759414d02f) keepass: move to by-name, remove dependency on buildDotnetPackage
* [`75389217`](https://github.com/NixOS/nixpkgs/commit/7538921747fe331b50c2d5890cc3c07a7e1f065a) dotnet-sdk_8: 8.0.100-rc.2.23502.2 -> 8.0.100
* [`aa7e324b`](https://github.com/NixOS/nixpkgs/commit/aa7e324b9168c1b2e15698d6e53d22f4f98634f1) dotnet-sdk_8: fix smoke test
* [`2b0ca5c6`](https://github.com/NixOS/nixpkgs/commit/2b0ca5c6e9bce803b3aefe1665208193738699d2) maintainers: add lamarios
* [`742948c5`](https://github.com/NixOS/nixpkgs/commit/742948c5e5d04a47fe4fb0d15ce064e8e5e3a254) xlockmore: 5.73 -> 5.74
* [`3a50fc50`](https://github.com/NixOS/nixpkgs/commit/3a50fc50f90ac18a8d5fc1268e9fc308d3e54324) yubihsm-shell: 2.4.1 -> 2.4.2
* [`b8ff55a0`](https://github.com/NixOS/nixpkgs/commit/b8ff55a04517df153278d419d910f8ae804332a5) prometheus: 2.47.2 -> 2.48.0
* [`ae071152`](https://github.com/NixOS/nixpkgs/commit/ae071152fbdb29805e548b77bd171d6f8d3cd57b) wireshark: refactor
* [`63e64c41`](https://github.com/NixOS/nixpkgs/commit/63e64c4159401c54c3da27bb6fa78ae63bf517b8) kak-lsp: 14.2.0 -> 15.0.0
* [`dd6fa9c2`](https://github.com/NixOS/nixpkgs/commit/dd6fa9c2e691ead3b729a064d816c375be2a0c1f) mujoco: 3.0.0 -> 3.0.1
* [`df50c25a`](https://github.com/NixOS/nixpkgs/commit/df50c25a910ae846cc8c33384736b859c165ea0b) pagefind: 1.0.3 -> 1.0.4
* [`b8698e31`](https://github.com/NixOS/nixpkgs/commit/b8698e3189c5bef890d02cc326cac5b75dbbc160) davinci-resolve: 18.5.1 -> 18.6
* [`8e2b31fe`](https://github.com/NixOS/nixpkgs/commit/8e2b31fedb1ad028db7b11df8236f581e1b76b2e) davinci-resolve: passthru underlying drv
* [`7b93c209`](https://github.com/NixOS/nixpkgs/commit/7b93c209effcc5525bfd879ae24f0196ccfd42b5) davinci-resolve: fail fast if filename is incorrect
* [`fe45cd37`](https://github.com/NixOS/nixpkgs/commit/fe45cd375a4b70fe761b188b77d81c4aabd85296) davinci-resolve: add studioVariant
* [`5cfab80f`](https://github.com/NixOS/nixpkgs/commit/5cfab80f9af2828c5e4e84a35ab574d363167351) davinci-resolve: dynamically get downloadid
* [`c63eb5c2`](https://github.com/NixOS/nixpkgs/commit/c63eb5c260bbc101e833f7a3a9ef1df72010bdc3) davinci-resolve: fix missing version in meta
* [`b01f295e`](https://github.com/NixOS/nixpkgs/commit/b01f295eb2a74216e162a5a2834e377c524aff8a) davinci-resolve: 18.6 -> 18.6.2
* [`304b1bd6`](https://github.com/NixOS/nixpkgs/commit/304b1bd679990e76922162011137b8bd8588305d) davinci-resolve: 18.6.2 -> 18.6.3
* [`c1d3d8cf`](https://github.com/NixOS/nixpkgs/commit/c1d3d8cfc9869f1ac7ecd7745404aa640b97ccdc) antidote: 1.9.2 -> 1.9.3
* [`9479c062`](https://github.com/NixOS/nixpkgs/commit/9479c06213ab2f9751aedc279ea1e83b0ff04de2) wireshark: 4.0.10 -> 4.2.0
* [`cf865b06`](https://github.com/NixOS/nixpkgs/commit/cf865b06e51625e660e8effb4b2540dfa8cc802f) delve: 1.21.0 -> 1.21.2
* [`c0495a8f`](https://github.com/NixOS/nixpkgs/commit/c0495a8f3fab834f7958d8e5c93e32782effba12) CHOWTapeModel: 2.10.0 -> 2.11.4
* [`7aaa7649`](https://github.com/NixOS/nixpkgs/commit/7aaa764930c8873cf818d7d2d7222079cdcdc16b) ludtwig: init at 0.8.0
* [`63d18064`](https://github.com/NixOS/nixpkgs/commit/63d18064db85ed5ca804970eadbda49ddab4f6d9) doomretro: 5.0.4 -> 5.0.7
* [`322c3882`](https://github.com/NixOS/nixpkgs/commit/322c3882aa0dec91b0cb59bad569419c0ace160a) vieb: 10.4.0 -> 10.6.0
* [`78e015a7`](https://github.com/NixOS/nixpkgs/commit/78e015a782960ddb246f8760c1361c20e221f203) simplotask: 1.11.5 → 1.12.0
* [`8f2ec8ab`](https://github.com/NixOS/nixpkgs/commit/8f2ec8ab2bf87b487cf51aae7664132deceda692) bind: 9.18.19 -> 9.18.20
* [`97ddf8d9`](https://github.com/NixOS/nixpkgs/commit/97ddf8d9419e2f6d3e0eb86b199ed46aebf493d7) sov: move to by-name
* [`1298459e`](https://github.com/NixOS/nixpkgs/commit/1298459eda3936dfc698d5461dc3011fc1ee8a66) gomplate: 3.11.5 -> 3.11.6
* [`3b954b88`](https://github.com/NixOS/nixpkgs/commit/3b954b886f124d771212205a141da05091d5ed7e) log4cplus: 2.1.0 -> 2.1.1
* [`f30ebbd3`](https://github.com/NixOS/nixpkgs/commit/f30ebbd394f5b9bf6f50d8f979ba3bafa2c581d4) blobfuse: 2.1.0 -> 2.1.2
* [`a569d58a`](https://github.com/NixOS/nixpkgs/commit/a569d58a920d2ca8d04996889c36fedb5041cf77) python3Packages.manuf: use embedded `manuf` data
* [`fb62887f`](https://github.com/NixOS/nixpkgs/commit/fb62887f0377d3fe3fb81ef1fc4fddde63e5db97) xcp: 0.12.0 -> 0.12.1
* [`90479ad3`](https://github.com/NixOS/nixpkgs/commit/90479ad3fad1a84aec21c02bc487b3355f98d6dc) python311Packages.yamllint: 1.32.0 -> 1.33.0
* [`c5e3e874`](https://github.com/NixOS/nixpkgs/commit/c5e3e874282778b57450fe9152f30bd22fab1f6e) compactor: add a space after `Type` in `check-response-opt.sh`
* [`53bf0b21`](https://github.com/NixOS/nixpkgs/commit/53bf0b2154d764f40f9d464e035d91b0f2af7b4c) coreboot-toolchain: 4.21 -> 4.22
* [`36633ed0`](https://github.com/NixOS/nixpkgs/commit/36633ed087d79312c5303cd09d688c759ab9ecfa) maintainers: add fmhoeger
* [`693025db`](https://github.com/NixOS/nixpkgs/commit/693025dbcfeae372380e98455cac355436d926b1) fh: 0.1.7 -> 0.1.8
* [`259028e8`](https://github.com/NixOS/nixpkgs/commit/259028e829b57a452350324fc04cf6904ef8cc40) goffice: 0.10.55 -> 0.10.56
* [`bb3d86a2`](https://github.com/NixOS/nixpkgs/commit/bb3d86a20ced96097cc460dc995f32b362b3abac) python311Packages.flask-sock: init at 0.7.0
* [`f1361c50`](https://github.com/NixOS/nixpkgs/commit/f1361c508956058c5c7de49604cca4769bb45a49) davinci-resolve: fix runtime error
* [`13569030`](https://github.com/NixOS/nixpkgs/commit/135690307d28b6fecf7d756f98afbf1db770150a) input-remapper: 1.5.0 -> 2.0.1
* [`6ec04a90`](https://github.com/NixOS/nixpkgs/commit/6ec04a904c6a570700ba3b5a7163a59c99baf639) iosevka-bin: 27.3.1 -> 27.3.5
* [`66b29137`](https://github.com/NixOS/nixpkgs/commit/66b29137978dcca809ffdfba8d9d7d7f7f6a114b) darwin.linux-builder: Disable evaluation
* [`64b587e3`](https://github.com/NixOS/nixpkgs/commit/64b587e3e22dc078cd4c73d2d8f5331d8321ae65) nixos/system.disableInstallerTools: Do define options without effect
* [`f3e9d7f8`](https://github.com/NixOS/nixpkgs/commit/f3e9d7f84bfc569b5bf85c43d1b25d8770b0d7b4) darwin.linux-builder: Disable installer tools
* [`92ec26ce`](https://github.com/NixOS/nixpkgs/commit/92ec26ce8d59d6856fb4f5ee4d1b74c654ca6eda) cvs: fix CFLAGS only on darwin
* [`26b585aa`](https://github.com/NixOS/nixpkgs/commit/26b585aa7b1291580fd2152f5c1295731ced6b9a) netbsd.sys: make compiler and linker warnings non-fatal
* [`32ec1255`](https://github.com/NixOS/nixpkgs/commit/32ec12551fba06ca890566bf85b1e3d569fe49a7) netbsd.sys: patch nocombreloc linker flag
* [`6edf1185`](https://github.com/NixOS/nixpkgs/commit/6edf1185e8ce8987e03ec115a3a29db3d92c2ae7) clerk: unstable-2023-01-14 -> unstable-2023-10-07
* [`5c898bec`](https://github.com/NixOS/nixpkgs/commit/5c898bec57e89cd4ceaf8d18140773fdba2447c8) nixos/redis: loosen systemd address family restrictions
* [`c6a43042`](https://github.com/NixOS/nixpkgs/commit/c6a430429776cf591042557a4a117b485d55ebb2) inter: 3.19 -> 4.0
* [`6f795d50`](https://github.com/NixOS/nixpkgs/commit/6f795d50c7de9c383800c3c7729ce8e720e5d70f) i3-auto-layout: 0.2 -> unstable 2022-05-29
* [`e982f082`](https://github.com/NixOS/nixpkgs/commit/e982f0829aaf1cb71ad2fa2ca9d9ef60967a73cf) argo: 3.5.0 -> 3.5.1
* [`b03f48be`](https://github.com/NixOS/nixpkgs/commit/b03f48beaf1479795f55143b15f52aacbcb38d92) python311Packages.azure-identity: 1.14.0 -> 1.15.0
* [`7b5f99cb`](https://github.com/NixOS/nixpkgs/commit/7b5f99cbac85d3a29d35cdef58cf476d5a9852b2) tree-sitter-grammars: add uiua
* [`f4ec121e`](https://github.com/NixOS/nixpkgs/commit/f4ec121e10bfa9804c3104a8b052a21480f3a2f1) homebank: 5.7.1 -> 5.7.2
* [`1601c4d0`](https://github.com/NixOS/nixpkgs/commit/1601c4d05266f4acc4cd5fbfe8ac9246d6e76cb7) mnemosyne: 2.7.2 → 2.10.1
* [`8f8cd9d9`](https://github.com/NixOS/nixpkgs/commit/8f8cd9d9d7ddc759786604010da0c9e8f58ada3a) matio: 1.5.23 -> 1.5.26
* [`778f5353`](https://github.com/NixOS/nixpkgs/commit/778f5353045c4e0356f68240cde75eedfb65235f) badlion-client: init at 3.15.0
* [`8f82d696`](https://github.com/NixOS/nixpkgs/commit/8f82d69669538b587b541cd0114f0f298d5c7309) libcap: Fix static build setting LIBCSTATIC=yes
* [`66627f27`](https://github.com/NixOS/nixpkgs/commit/66627f271e9c963d0db0706f2e3a429ebc423c16) super-tiny-icons: unstable-2023-05-22 -> unstable-2023-11-06
* [`3a4be8aa`](https://github.com/NixOS/nixpkgs/commit/3a4be8aa4b6232c8393c2eb1f7d217b3d39317c5) moarvm: fix build failure on x86_64-darwin
* [`658a6a9b`](https://github.com/NixOS/nixpkgs/commit/658a6a9b9119206fd4c1a0d4db7b3e67d09cf024) ctlptl: 0.8.22 -> 0.8.24
* [`412543dd`](https://github.com/NixOS/nixpkgs/commit/412543ddd83f4ee235ee32772afc19483aaf83ab) nixos/libvirtd: add support for nss modules
* [`d3c5f52c`](https://github.com/NixOS/nixpkgs/commit/d3c5f52c3d9a95a08176e522320e9b781528feee) cocoapods: 1.13.0 -> 1.14.3
* [`eafa92c5`](https://github.com/NixOS/nixpkgs/commit/eafa92c5f75598d7b54310c6a91b04c4854ba92d) libfabric: 1.19.0 -> 1.20.0
* [`4d3c9e00`](https://github.com/NixOS/nixpkgs/commit/4d3c9e00cbcda1b6180e6f92dbf7c75334ddeb06) go2rtc: 1.8.2 -> 1.8.4
* [`da1facff`](https://github.com/NixOS/nixpkgs/commit/da1facff638c224b67434598037a54fc30378f5d) python311Packages.django_5: 5.0b1 -> 5.0rc1
* [`764053bc`](https://github.com/NixOS/nixpkgs/commit/764053bc02134c8bc2a936f33b6313f2c67ed518) python311Packages.txtorcon: 23.5.0 -> 23.11.0
* [`46859402`](https://github.com/NixOS/nixpkgs/commit/4685940219ead5e9905394eb2746a2e707c0ae9d) catppuccin: add grub theme
* [`395b7cc3`](https://github.com/NixOS/nixpkgs/commit/395b7cc35b0f43d03a64190423b13f623304df81) python311Packages.torch: choose magma at the expression level
* [`64346426`](https://github.com/NixOS/nixpkgs/commit/643464269f674d3bd9062f55c2f47e193348283d) python311Packages.torch: fix typo in the cuda&&rocm error message
* [`1e33c881`](https://github.com/NixOS/nixpkgs/commit/1e33c8819f402536bc765a6246fe8b5dfae0afb7) magma: respect the global isStatic
* [`9dd800dc`](https://github.com/NixOS/nixpkgs/commit/9dd800dc899da4f683b901609bb2bd307029beec) svlint: 0.9.0 -> 0.9.1
* [`ae2f8408`](https://github.com/NixOS/nixpkgs/commit/ae2f8408d2091117c90cbcdb12426b230ffc7bbe) zinit: 3.12.0 -> 3.12.1
* [`d15ca5f7`](https://github.com/NixOS/nixpkgs/commit/d15ca5f785b542d7ae9f4d2bf53e1d120d8030a6) k3s: 1.27.6 -> 1.27.7
* [`341cc37b`](https://github.com/NixOS/nixpkgs/commit/341cc37b91ef58563292dc8f1aa0a1d286d90006) k3s_1_28: init at 1.28.3
* [`110e47b4`](https://github.com/NixOS/nixpkgs/commit/110e47b44975244fc0bd876876bb307eccdbe4bb) wxmaxima: 23.10.0 -> 23.11.0
* [`cc4bd303`](https://github.com/NixOS/nixpkgs/commit/cc4bd303877c3eb2db186ca214712f54dbe69bae) perlPackages.BioBigfile: init at 1.07
* [`75fc8ae0`](https://github.com/NixOS/nixpkgs/commit/75fc8ae0f4380d790d71ba76da932b333b2a49f8) perlPackages.BioBigFile: Addressing reviewer change
* [`64282d46`](https://github.com/NixOS/nixpkgs/commit/64282d466bc02218e88d2fa25bf7349c4cc7d715) librewolf-unwrapped: 119.0.1-1 -> 120.0-1
* [`cb111d05`](https://github.com/NixOS/nixpkgs/commit/cb111d05c790d453fb00d2aea3e2148ba5cc73b7) dprint: 0.42.5 -> 0.43.0
* [`950887fc`](https://github.com/NixOS/nixpkgs/commit/950887fc2ab298cc1f65e0bafe4285fdcd74c8a9) geph: add cacert to provide certificates during fetches
* [`801b22a1`](https://github.com/NixOS/nixpkgs/commit/801b22a15181c2a14c2c6b2280c7c931c8134f4a) libwebsockets: 4.3.2 -> 4.3.3
* [`161b691b`](https://github.com/NixOS/nixpkgs/commit/161b691b11d66886b3b12e82e13d42d7e4d032e7) flowtime: 3.1 -> 6.1
* [`e8e83ee1`](https://github.com/NixOS/nixpkgs/commit/e8e83ee1a8e546a14a1e6eaee8e40cb94b93cd27) peg: 0.1.18 -> 0.1.19
* [`2f143de8`](https://github.com/NixOS/nixpkgs/commit/2f143de8fdfdbec45282deb129e6cf420731a374) phd2: 2.6.11 -> 2.6.12
* [`de04f54d`](https://github.com/NixOS/nixpkgs/commit/de04f54d51332a96ae0e0ef096324ef4a85a6772) mill: 0.11.5 -> 0.11.6
* [`c034d14c`](https://github.com/NixOS/nixpkgs/commit/c034d14c4163964be3f35003cad46e0fb4aa8ae6) fetchfossil: support SRI hashes
* [`e3013991`](https://github.com/NixOS/nixpkgs/commit/e30139915866616b40f0662d540e815dadf7942b) cloudfoundry-cli: 8.7.4 -> 8.7.5
* [`3dcd819c`](https://github.com/NixOS/nixpkgs/commit/3dcd819caa03c848a9a06964857e12e4b789239e) minimal-bootstrap.mes: 0.24.2 -> 0.25
* [`fe2c39b7`](https://github.com/NixOS/nixpkgs/commit/fe2c39b7e9d9068febbe2369d7372e609cc54cb2) jetbrains-toolbox: 2.1.0.18144 -> 2.1.1.18388
* [`f409967b`](https://github.com/NixOS/nixpkgs/commit/f409967b04a01079ee5da102b4220a5e0450559f) linuxPackages.nvidia_x11: 545.29.02 -> 545.29.06
* [`796b4926`](https://github.com/NixOS/nixpkgs/commit/796b4926bbdea841eaab82239fe7f7e93daf75dd) mkosi: 18 -> 19
* [`28a41e21`](https://github.com/NixOS/nixpkgs/commit/28a41e21cbdf2077f5b2058eef72bc6392e3c50c) mkosi: cleanup wrapping
* [`3f5b64f3`](https://github.com/NixOS/nixpkgs/commit/3f5b64f3c751a02e920c5b296811b0dffbcf2d9a) mkosi: add man page
* [`fdb0b82f`](https://github.com/NixOS/nixpkgs/commit/fdb0b82f5c5501814edbb59acdfef478a9a66ab7) mkosi: add importsCheck
* [`f272f575`](https://github.com/NixOS/nixpkgs/commit/f272f575abdba0769e02e014f24931ca18a6645f) python3Packages.{shiboken6,pyside6}: 6.5.2 -> 6.6.0
* [`1808d7c2`](https://github.com/NixOS/nixpkgs/commit/1808d7c2823880f50820aec652e49aa997662e29) highlight: 4.7 -> 4.10
* [`e699137b`](https://github.com/NixOS/nixpkgs/commit/e699137b1f55dfa2599f06c75893fa0ae2655a53) civo: 1.0.68 -> 1.0.69
* [`3a46f755`](https://github.com/NixOS/nixpkgs/commit/3a46f755ff10dafd7ec9a4622abb3a1d7b63fd2e) lib3270: init at 5.4
* [`7a1cd06b`](https://github.com/NixOS/nixpkgs/commit/7a1cd06b4d44020001d0746317e5bae8dca97a5f) ctranslate2: 3.21.0 -> 3.22.0
* [`04c89196`](https://github.com/NixOS/nixpkgs/commit/04c89196bbd28a027714026648943d14b983d076) archi: add automatic updates
* [`99fdbbf0`](https://github.com/NixOS/nixpkgs/commit/99fdbbf06d43acd2f9e637353689f9343afd1f72) amdgpu_top: 0.1.11 -> 0.3.1
* [`5cbd87db`](https://github.com/NixOS/nixpkgs/commit/5cbd87db772a85f56c7967fb3a4372c9f3840146) initool: 0.14.0 -> 0.14.1
* [`e926b13c`](https://github.com/NixOS/nixpkgs/commit/e926b13cd7608f6f5a4f4cf60608c1e0360e596b) pwninit: Add elfutils as dependency
* [`9ca36cdb`](https://github.com/NixOS/nixpkgs/commit/9ca36cdb3268890d414d6c6ea78a42de14ae1d50) dtkcommon: 5.6.9 -> 5.6.17
* [`b86462e7`](https://github.com/NixOS/nixpkgs/commit/b86462e7b995d7657947eee7616199107baebc96) dtkcore: 5.6.10 -> 5.6.17
* [`7408427d`](https://github.com/NixOS/nixpkgs/commit/7408427db9e90668c7752b647d6a936f736869a7) dtkgui: 5.6.10 -> 5.6.17
* [`a9c372f1`](https://github.com/NixOS/nixpkgs/commit/a9c372f122b8ed8fda902f645bcb9360fa0d6178) dtkwidget: 5.6.10 -> 5.6.17
* [`18a0f195`](https://github.com/NixOS/nixpkgs/commit/18a0f195607fec34f28aee6eb61743a8d86882e0) dtkdeclarative: init at 5.6.17
* [`f761418e`](https://github.com/NixOS/nixpkgs/commit/f761418ee88e9779c2475483378c81710fc59eac) qt5integration: 5.6.6 -> 5.6.17
* [`b13b1c40`](https://github.com/NixOS/nixpkgs/commit/b13b1c40781b618e1bdb8c20e176686f2c939634) dwayland: 5.24.3-deepin.1.4 -> 5.25.0
* [`5a095678`](https://github.com/NixOS/nixpkgs/commit/5a095678cd90c579dc9a6ba33389952745ee39ff) qt5platform-plugins: 5.6.9 -> 5.6.16
* [`7fd2c325`](https://github.com/NixOS/nixpkgs/commit/7fd2c32551868d39f251c5460fc50d0c71815405) dde-qt-dbus-factory: 5.5.22 -> 6.0.0
* [`050ce364`](https://github.com/NixOS/nixpkgs/commit/050ce364eac1433c892196bb51f747bee4fa74be) deepin-pdfium: 1.0.1 -> 1.0.2
* [`1d57bf42`](https://github.com/NixOS/nixpkgs/commit/1d57bf425c5135a99854d842ccac491b2d78bac7) util-dfm: 1.2.12 -> 1.2.16
* [`e59bf738`](https://github.com/NixOS/nixpkgs/commit/e59bf738804d26bc7530c02c70773e885d3b9bef) image-editor: 1.0.32 -> 1.0.35
* [`95267d43`](https://github.com/NixOS/nixpkgs/commit/95267d43726a43a24446a2ed3ff27bb3df46193c) deepin-kwin: 5.24.3-deepin.1.9 -> 5.25.11
* [`bb1134e6`](https://github.com/NixOS/nixpkgs/commit/bb1134e6d019cc22d3df4c76df088edd6fb09b55) dde-kwin: remove
* [`e6736d01`](https://github.com/NixOS/nixpkgs/commit/e6736d013c8da2d64587ffca8cc3592bb5ee238d) deepin-pw-check: 5.1.18 -> 6.0.2
* [`86f28dc4`](https://github.com/NixOS/nixpkgs/commit/86f28dc401fdfc82e0098f88a61bf3dbecf79468) dde-api: 5.5.32 -> 6.0.7
* [`24e1b0d3`](https://github.com/NixOS/nixpkgs/commit/24e1b0d39d347fc4a94e98be2410949ca67e4443) deepin-desktop-schemas: 5.10.11 -> 6.0.5
* [`6045b360`](https://github.com/NixOS/nixpkgs/commit/6045b360fa1d3b120e0b9a7517560655cc9fc947) startdde: 5.10.1 -> 6.0.10
* [`8e91f7c7`](https://github.com/NixOS/nixpkgs/commit/8e91f7c70d8ac339fda384f0bf029b02ca171700) dde-daemon: 5.14.122 -> 6.0.22
* [`c1b774de`](https://github.com/NixOS/nixpkgs/commit/c1b774deac43e00e56615268867f8f5815395c89) dde-account-faces: 1.0.12.1 -> 1.0.15
* [`756c6ce6`](https://github.com/NixOS/nixpkgs/commit/756c6ce67eeb1cc0a864af1ccd7c943027fb5ce0) deepin-wallpapers: 1.7.10 -> 1.7.16
* [`9824e03f`](https://github.com/NixOS/nixpkgs/commit/9824e03f5e4bf83e7be89b8b8b213253a39bd762) deepin-desktop-theme: init at 1.0.8
* [`f21a5f64`](https://github.com/NixOS/nixpkgs/commit/f21a5f646fcec6c238959d36896f7dc68900b7d5) dde-file-manager: 6.0.23 -> 6.0.31
* [`fdc46fb8`](https://github.com/NixOS/nixpkgs/commit/fdc46fb8ec7356b0b0f8bf3f868dedf9d04746ee) dde-dock: 5.5.81 -> 6.0.22
* [`16c60c99`](https://github.com/NixOS/nixpkgs/commit/16c60c99403c073fff288d1b833b119739b106de) dde-clipboard: 5.4.25 -> 6.0.7
* [`d67833e6`](https://github.com/NixOS/nixpkgs/commit/d67833e63ade1ace575c48defa00d1069455a9ef) dde-control-center: 5.6.3 -> 6.0.28
* [`5730c12e`](https://github.com/NixOS/nixpkgs/commit/5730c12eda85cd7b77b0642627561a38e7c8d566) dde-app-services: 0.0.20 -> 1.0.23
* [`f4d6cca7`](https://github.com/NixOS/nixpkgs/commit/f4d6cca76cf6e856e30db5e74a40986a5c483401) dde-polkit-agent: 5.5.22 -> 6.0.5
* [`9e079d77`](https://github.com/NixOS/nixpkgs/commit/9e079d770adf0e806d6fb67f791031b5936a8938) dde-session-shell: 5.6.4 -> 6.0.10
* [`7613b21f`](https://github.com/NixOS/nixpkgs/commit/7613b21f12a08712517fd8ac7efe5a762bc57b91) dde-session-ui: 5.6.2 -> 6.0.10
* [`5cf7c0bc`](https://github.com/NixOS/nixpkgs/commit/5cf7c0bc9b21679b032e1bc3ea62660e35fd2165) dde-network-core: 1.1.8 -> 2.0.15
* [`a1f93e27`](https://github.com/NixOS/nixpkgs/commit/a1f93e275cf41a381769e9ef602b28bcc21dac66) dde-widgets: init at 6.0.14
* [`42393f9b`](https://github.com/NixOS/nixpkgs/commit/42393f9b099e8edd92de4fb759e7f201eeb73633) dde-calendar: 5.10.1 -> 5.11.0
* [`416ffd68`](https://github.com/NixOS/nixpkgs/commit/416ffd68263d07b9c67774a239ef64c0835da7ef) dpa-ext-gnomekeyring: 5.0.11 -> 6.0.1
* [`b9ce06ae`](https://github.com/NixOS/nixpkgs/commit/b9ce06ae062644bbb69dd2a3eff9f2408beee58f) dde-launchpad: init at 0.0.2
* [`f80750ff`](https://github.com/NixOS/nixpkgs/commit/f80750ffc3a7e9c5f2fca18e1036415b5f6c14aa) deepin-service-manager: init at 1.0.3
* [`c5b44804`](https://github.com/NixOS/nixpkgs/commit/c5b448043578bfd4541865616eee2869ba418ddc) dde-session: init at 1.1.9
* [`fe69e321`](https://github.com/NixOS/nixpkgs/commit/fe69e321da8079e8cf52e5f8649a97408988a339) dde-appearance: init at 1.1.6
* [`9b426102`](https://github.com/NixOS/nixpkgs/commit/9b426102171870753677a46393d5855fa85f14ba) deepin-picker: 5.0.28 -> 6.0.0
* [`3f1eb313`](https://github.com/NixOS/nixpkgs/commit/3f1eb313e002b11b3fb4779664c7cf28b910f89c) dde-application-manager: init at 1.0.19
* [`aa4d16aa`](https://github.com/NixOS/nixpkgs/commit/aa4d16aa25b29eba35a29d642d28961ae761f328) deepin-voice-note: 5.11.1 -> 6.0.13
* [`eed4e169`](https://github.com/NixOS/nixpkgs/commit/eed4e1692cad4fa0f9a906e48d844fc7310e29f7) deepin-music: 6.2.31 -> 7.0.3
* [`35ae005d`](https://github.com/NixOS/nixpkgs/commit/35ae005d22f2e62beecdf34d4f070a58a4c980ed) deepin-album: 5.10.9 -> 6.0.2
* [`540b8c45`](https://github.com/NixOS/nixpkgs/commit/540b8c4577fb44a70858572c83a73c03c6457fde) deepin-movie-reborn: 5.10.28 -> 6.0.5
* [`7ed1e608`](https://github.com/NixOS/nixpkgs/commit/7ed1e6085fb8b766517e7625b26c4174fb0b7edb) deepin-ocr-plugin-manager: init at unstable-2023-07-10
* [`eb4b8252`](https://github.com/NixOS/nixpkgs/commit/eb4b8252786706e8699915eb3d17a35ff94b3a9f) deepin-image-viewer: 5.9.13 -> 6.0.2
* [`8641d28c`](https://github.com/NixOS/nixpkgs/commit/8641d28c8af58260fa41e07a70693d1441674f9b) deepin-screensaver: 5.0.16 -> 5.0.18
* [`0ec84863`](https://github.com/NixOS/nixpkgs/commit/0ec84863a05da17e38ce1dacc54f0724faa460bb) aliases: add dde-kwin
* [`245ae0f6`](https://github.com/NixOS/nixpkgs/commit/245ae0f64fed828f6bdee195325e3da6c27e8587) services.deepin.app-services: add systemd service
* [`12fba794`](https://github.com/NixOS/nixpkgs/commit/12fba794916e9bd22be7e19e283f2315b55f1ade) deepin: add v23 packages
* [`1c056a5b`](https://github.com/NixOS/nixpkgs/commit/1c056a5b64027483e7e337270fd6cacf6a449cc9) deepin-system-monitor: 5.9.33 -> 6.0.8
* [`0dbcf0c1`](https://github.com/NixOS/nixpkgs/commit/0dbcf0c1fa7734ffb7a2ce2153e6e99ee3c861d9) dde-gsettings-schemas: remove outdata packages
* [`62ae1155`](https://github.com/NixOS/nixpkgs/commit/62ae11556ef23a9c12ae6ecaf55cb87b407b603c) deepin-screen-recorder: 5.12.1 -> unstable-2023-07-10
* [`7ba64f4c`](https://github.com/NixOS/nixpkgs/commit/7ba64f4cd4448bec684fac3c753e3db7e8b52bba) deepin-camera: 6.0.2 -> unstable-2023-09-26
* [`b9aa8546`](https://github.com/NixOS/nixpkgs/commit/b9aa85464414d9bba2555ddfc9688f3f1eeec2cc) deepin: don't wait dde-wm-chooser in v23
* [`c7312655`](https://github.com/NixOS/nixpkgs/commit/c7312655f1fdf67ea7d51590649ac43c213d0bbc) dde-gsettings-schemas: add gsettings-desktop-schemas
* [`004c4690`](https://github.com/NixOS/nixpkgs/commit/004c46908d55292b04ea7ae02b6966f69b1b9cae) deepin-compressor: fix build for new dtk
* [`e40e4975`](https://github.com/NixOS/nixpkgs/commit/e40e4975455c604812b59d18c82a291f911fd0b9) deepin-reader: 6.0.2 -> 6.0.5
* [`268ad2a6`](https://github.com/NixOS/nixpkgs/commit/268ad2a62c22aafe29635dc8951896103e9a1b4f) deepin-clone: mark as broken
* [`142e1406`](https://github.com/NixOS/nixpkgs/commit/142e1406017b15a50b003ab9e73e0857be565f19) deepin-screen-recorder: use a substituteInPlace candidate to patch
* [`3a056b3f`](https://github.com/NixOS/nixpkgs/commit/3a056b3ff98d8c2826ec674ec4c81d8ddaa61b4c) dde-gsettings-schemas: Bring closer to GNOME
* [`6db5b06f`](https://github.com/NixOS/nixpkgs/commit/6db5b06f027fae8e6d964fddb104bc97af0e3f23) capnproto: 1.0.1 -> 1.0.1.1
* [`02f6d506`](https://github.com/NixOS/nixpkgs/commit/02f6d506c14bb2dd1f47153e422abb0648dd8b06) kodiPackages.osmc-skin: 18.0.0 -> 20.1.0
* [`b90209f3`](https://github.com/NixOS/nixpkgs/commit/b90209f3ded1954c364b4dd22ffa34c7f0478d0c) llpp: remove unneeded configurePhase
* [`e531c995`](https://github.com/NixOS/nixpkgs/commit/e531c99505df9b97b096ef75e4c5d2afa954875b) llpp: fix license
* [`04b42d0e`](https://github.com/NixOS/nixpkgs/commit/04b42d0e68561c0c7ef56367c975eb78324d2869) llpp: update homepage
* [`3a2c9f34`](https://github.com/NixOS/nixpkgs/commit/3a2c9f34999f2a4c5a020e0401cf9c30aec76e3a) llpp: remove unused inputs
* [`fe5d1fb7`](https://github.com/NixOS/nixpkgs/commit/fe5d1fb7065a7a88560b7b333db10b05ec3205cf) dde-launcher: remove
* [`1d5d7bb1`](https://github.com/NixOS/nixpkgs/commit/1d5d7bb18ba37498ab9f83c26cb793edc7ce103d) gloox: 1.0.27 -> 1.0.28
* [`090493d4`](https://github.com/NixOS/nixpkgs/commit/090493d4cda6564f452950279e11ac06ce3b6778) nordzy-icon-theme: 1.8.5 -> 1.8.6
* [`36b81e27`](https://github.com/NixOS/nixpkgs/commit/36b81e27041377c9a47d8b1d18cfa00d9a4a87fe) gnome-secrets: 7.2 -> 8.0
* [`44c1b100`](https://github.com/NixOS/nixpkgs/commit/44c1b1007ed291c2c6f4445f7660ee00c3566ad0) dde-launchpad: 0.0.2 -> 0.2.1
* [`21fed88e`](https://github.com/NixOS/nixpkgs/commit/21fed88e1cf2dfd9b44682aea702b22f46072178) deepin(go-package): use `vendorHash` instead of `vendorSha256`
* [`196a660c`](https://github.com/NixOS/nixpkgs/commit/196a660c6c882727954d979f9dcd9629eea56ed7) libutp_3_4: unstable-2023-10-16 -> unstable-2023-11-14
* [`eee4e5a6`](https://github.com/NixOS/nixpkgs/commit/eee4e5a64f307daf18e65ad3f98a9ad9ccacfd73) lilypond-unstable: 2.25.9 -> 2.25.10
* [`9a579e14`](https://github.com/NixOS/nixpkgs/commit/9a579e14dd7536bf4cf554c065615810defd72d8) gscan2pdf: fix build failures
* [`fe3094b0`](https://github.com/NixOS/nixpkgs/commit/fe3094b0dcc167494891090d49f367c59ea4c6e9) gscan2pdf: re-add previously removed test
* [`1e270492`](https://github.com/NixOS/nixpkgs/commit/1e2704927aeb052ede5cedde4b6eb20d424af5d2) gscan2pdf: add patch to remove warnings during test
* [`d54a7a60`](https://github.com/NixOS/nixpkgs/commit/d54a7a6019d30ecee3cbd363a99297b7f2bd00d7) gscan2pdf: patch from upstream with utf8 filenames
* [`770c9bb5`](https://github.com/NixOS/nixpkgs/commit/770c9bb52e41e2e508de9d0f38fc5a364d8616c9) setzer: 61 -> 62
* [`8c15911d`](https://github.com/NixOS/nixpkgs/commit/8c15911d79664ac9122adb738138b265bb3d9f78) makeInitrdNGTool: 0.1.0 -> 0.1.0
* [`4bae1b32`](https://github.com/NixOS/nixpkgs/commit/4bae1b3222690f59b6ed582fafe3a0f871add39d) treewide: use lib.warnIf instead of improvised alternatives
* [`826ee3f6`](https://github.com/NixOS/nixpkgs/commit/826ee3f67dcf0cec13b5f7b5ab4c9dfb7147ffc1) java-service-wrapper: build with latest jdk
* [`5cc0c69b`](https://github.com/NixOS/nixpkgs/commit/5cc0c69b1df838ea5c1abbb453ffc147d70fe909) libv3270: init at 5.4
* [`7f1ea97c`](https://github.com/NixOS/nixpkgs/commit/7f1ea97cf4e1082e52eea2be1ef6ca67d3aa2b25) pw3270: init at 5.4
* [`1aafac5c`](https://github.com/NixOS/nixpkgs/commit/1aafac5ceb5ce7b2a6f981c510da5ec5c7e21449) ddclient: 3.11.1 -> 3.11.2
* [`5449b274`](https://github.com/NixOS/nixpkgs/commit/5449b274d47bf93f5147d43c8ff812c260c1edf0) brill: init at 4.000.073
* [`031a2c01`](https://github.com/NixOS/nixpkgs/commit/031a2c01aa77a6504db2374c82d5b90369882294) maintainers: add gernotfeichter
* [`b88b9a47`](https://github.com/NixOS/nixpkgs/commit/b88b9a4700174359f2623f7e195ba372a68cd60b) python3Packages.pytest-testinfra: 9.0.0 -> 10.0.0
* [`08bdd67b`](https://github.com/NixOS/nixpkgs/commit/08bdd67bed3d675f39171c1d8f8bd0bb9598db96) figlet: link to unistd on all platforms; restore warnings
* [`69d4f038`](https://github.com/NixOS/nixpkgs/commit/69d4f03872eb1c9db884912bfa00463f86676486) fsautocomplete: sdk_6_0 -> sdk_7_0
* [`aeb3ad9d`](https://github.com/NixOS/nixpkgs/commit/aeb3ad9dbdd102c14eebddd60e72783752e385e5) micronaut: 4.1.3 -> 4.1.6
* [`ccc07db8`](https://github.com/NixOS/nixpkgs/commit/ccc07db88c04071072d94501f15684cbb5575d4b) oclgrind: use LLVM 12.
* [`2fd8e336`](https://github.com/NixOS/nixpkgs/commit/2fd8e3361591e34697948411d8ab303302e93d7b) nextcloud26: 26.0.8 -> 26.0.9
* [`2070d4b5`](https://github.com/NixOS/nixpkgs/commit/2070d4b56584d6a0c453da6964b6f5c45c54b6fe) nextcloud27: 27.1.3 -> 27.1.4
* [`8da1d68e`](https://github.com/NixOS/nixpkgs/commit/8da1d68e33ac99be880f95ba4f24e9d75f7d21f8) nextcloud26Packages: regen
* [`b0f478b8`](https://github.com/NixOS/nixpkgs/commit/b0f478b86138bf0003c126da67ddec9fed080b4f) nextcloud27Packages: regen
* [`ba656ad8`](https://github.com/NixOS/nixpkgs/commit/ba656ad84ebb89cad244d23bc61002ceff332b15) prefetch-npm-deps: bump deps
* [`81ed58b0`](https://github.com/NixOS/nixpkgs/commit/81ed58b0fef21985242dea442e398b3bb81c9d67) prefetch-npm-deps: make cargo happy
* [`daec4bf7`](https://github.com/NixOS/nixpkgs/commit/daec4bf7347a779d5d4a25524e056987c46ea519) prefetch-npm-deps: instrument some logging
* [`77571a84`](https://github.com/NixOS/nixpkgs/commit/77571a847f4c6c744a2541b493b2b7e9751a13ce) prefetch-npm-deps: use default value when lockfile has no deps
* [`09081aa8`](https://github.com/NixOS/nixpkgs/commit/09081aa859322fa382c1f106d989b5b4b3b37e74) fetchNpmDeps: add test case where empty default lockfile packages is needed
* [`f02bf9bc`](https://github.com/NixOS/nixpkgs/commit/f02bf9bcc56d5099964affd5b6259a25d4d33789) mujs: 1.3.3 -> 1.3.4
* [`96a1dd0f`](https://github.com/NixOS/nixpkgs/commit/96a1dd0fa705294f4774b289b393de0c217a6af7) python3Packages.frozendict: 2.3.8 -> 2.3.9
* [`d81e1ac8`](https://github.com/NixOS/nixpkgs/commit/d81e1ac8ae899d7fb1ffd90886a5d612da7ffa48) cfs-zen-tweaks: 1.2.0 -> 1.3.0
* [`335893e5`](https://github.com/NixOS/nixpkgs/commit/335893e573cf9fda889eb1803d78cb3e65fca79b) navidrome: 0.50.0 -> 0.50.1
* [`9151e537`](https://github.com/NixOS/nixpkgs/commit/9151e53703dc9b62e85c011887071d9d391bac36) dippi: 4.0.2 -> 4.0.6
* [`59be2186`](https://github.com/NixOS/nixpkgs/commit/59be218688362f19214e0c143446693c38e258c3) neocmakelsp: 0.6.8 -> 0.6.11
* [`c1afc17f`](https://github.com/NixOS/nixpkgs/commit/c1afc17f954817fbc483ddb387cdd33d69529a78) olm: 3.2.15 -> 3.2.16
* [`160e2f62`](https://github.com/NixOS/nixpkgs/commit/160e2f620e9fa92ce325135e708e9b11385bb842) bazecor: 1.3.6 -> 1.3.8
* [`c53afd46`](https://github.com/NixOS/nixpkgs/commit/c53afd4687e877496b6b4565459412b45ecb71c5) polkadot: 1.3.0 -> 1.4.0
* [`9b5cfd41`](https://github.com/NixOS/nixpkgs/commit/9b5cfd41d86b1bbc8c9b7406760154b4832ebb76) samba: fix samba-tool
* [`be3c6be0`](https://github.com/NixOS/nixpkgs/commit/be3c6be08ef277422a1461cc3fcb8b0f4866293e) regex-cli: 0.1.1 -> 0.2.0
* [`5b44443d`](https://github.com/NixOS/nixpkgs/commit/5b44443d4b01b22b3246e7ad939f3e4faae5319a) valent: unstable-2023-08-26 -> unstable-2023-11-11
* [`719a0bdd`](https://github.com/NixOS/nixpkgs/commit/719a0bdd9ad0a437ba9c6d0df01ec8074008ea54) syslogng: 4.4.0 -> 4.5.0
* [`f32f9e80`](https://github.com/NixOS/nixpkgs/commit/f32f9e80464b1f641822b3ac763b2dfd34a7b608) zs: init at 0.4.1
* [`b3e84ac8`](https://github.com/NixOS/nixpkgs/commit/b3e84ac8dddfea20a1d9f12b11bd5e344eaa87cc) hostapd: enable macsec
* [`8d0da14d`](https://github.com/NixOS/nixpkgs/commit/8d0da14dbbdbd8aa917dce4515635c934eb75316) keycloak: 22.0.5 -> 23.0.0
* [`0847a05a`](https://github.com/NixOS/nixpkgs/commit/0847a05a3fe0f08e957dfd006521425402ec7e1f) tuba: 0.4.1 -> 0.5.0
* [`2d60e17c`](https://github.com/NixOS/nixpkgs/commit/2d60e17c28ae9c83189d83d8296ddb9675a1be21) pianotrans: add missing resampy dependency
* [`4c87c27f`](https://github.com/NixOS/nixpkgs/commit/4c87c27f5a977abcf9500e9a23860b5b23f0917a) monitoring-plugins: fix path to ping in check_ping
* [`48ad37bc`](https://github.com/NixOS/nixpkgs/commit/48ad37bcd477675b0dbadcadc26afebe050e2d50) tdlib: 1.8.19 -> 1.8.21
* [`76bfb735`](https://github.com/NixOS/nixpkgs/commit/76bfb735286b0fa4d6ada23f919276d73766260f) groonga: 12.0.7 -> 13.0.9
* [`25599afd`](https://github.com/NixOS/nixpkgs/commit/25599afd79c86f798c5599b446f64e76dee749df) leaf: init at 0.1.0
* [`68b95da5`](https://github.com/NixOS/nixpkgs/commit/68b95da59bec73918993d20cc17a76b0e2dceabe) nerdfonts: 3.0.2 -> 3.1.0
* [`334cf939`](https://github.com/NixOS/nixpkgs/commit/334cf93916bb1ec4d52831809c02b6e81c341068) poetry: 1.7.0 -> 1.7.1
* [`5427e0b5`](https://github.com/NixOS/nixpkgs/commit/5427e0b5b33dce61c730864a52371b4270ddc38c) poetryPlugins.poetry-plugin-up: 0.7.0 -> 0.7.1
* [`41434a07`](https://github.com/NixOS/nixpkgs/commit/41434a07ffa4ecf14b35205bdc97aa7873972b8d) fldigi: 4.2.00 -> 4.2.03
* [`dd181268`](https://github.com/NixOS/nixpkgs/commit/dd181268f840e7609e25a7ceff8f21119b9b0519) obs-studio-plugins.obs-vertical-canvas: 1.2.5 -> 1.3.0
* [`51e8bd8a`](https://github.com/NixOS/nixpkgs/commit/51e8bd8a47257563ec8ec4966674ab4322aa8405) wxGTK32: fix console crash
* [`2b87cdd1`](https://github.com/NixOS/nixpkgs/commit/2b87cdd1179ec73a3dd66a1d8e26bbed9d415521) alp: init at 1.1.17
* [`02ad7154`](https://github.com/NixOS/nixpkgs/commit/02ad715448b76c414d9d8a9851601c4e9f0168b6) sway-new-workspace: init at 0.1.5
* [`aa5506c7`](https://github.com/NixOS/nixpkgs/commit/aa5506c7aae414f86a6c3537263166ebea979bf3) bloaty: 1.1 -> 1.1-unstable-2023-11-06
* [`c20eff42`](https://github.com/NixOS/nixpkgs/commit/c20eff42cfbc5d0c83135dc35020467760c77739) bloaty: devendor git submodules
* [`ecddf906`](https://github.com/NixOS/nixpkgs/commit/ecddf906dc52161749cdafa5c9605c0812bd7019) teck-udev-rules: correct meta.license attribute
* [`7694dd1f`](https://github.com/NixOS/nixpkgs/commit/7694dd1fc0548c70d4bd2fbc334126416b44b539) uni: 2.5.1 -> 2.6.0
* [`6bcb7fad`](https://github.com/NixOS/nixpkgs/commit/6bcb7fade49e4ab3de4b538853810020abe4decb) kakoune: fix compiling with clang for macOS
* [`4df8dcc5`](https://github.com/NixOS/nixpkgs/commit/4df8dcc5813d35315286bbe78826d552506b84a0) python3Packages.importlab: 0.7 → 0.8.1
* [`2049b08b`](https://github.com/NixOS/nixpkgs/commit/2049b08b3b9f1e4252c59fba728437068f7fe776) tectonic: fixed compilation issue
* [`4915a2e7`](https://github.com/NixOS/nixpkgs/commit/4915a2e7821a29dd68dcdfe8de4ab16653acd69b) kernel: enable support for MT798X
* [`94e1bc18`](https://github.com/NixOS/nixpkgs/commit/94e1bc18ff1a1f8777823b1ab11af4a32f1f1080) vscode-extensions.arrterian.nix-env-selector: 1.0.9 -> 1.0.10
* [`b6877b60`](https://github.com/NixOS/nixpkgs/commit/b6877b6051d8107899d74d34fc57adc196e12ff3) metasploit: 6.3.43 -> 6.3.44
* [`4eed370a`](https://github.com/NixOS/nixpkgs/commit/4eed370ae9177d43f2e67c8c23993584882044d1) linux-pam: fix cross-compilation from darwin
* [`3d9a0c1e`](https://github.com/NixOS/nixpkgs/commit/3d9a0c1e432985b52dea3c612c86b9c9fa0bec5a) betula: init at 1.1.0
* [`b9d8cfbf`](https://github.com/NixOS/nixpkgs/commit/b9d8cfbff0d990972dd625231fbbd683b63808f8) alsa-scarlett-gui: unstable-2022-08-11 -> 0.3.2
* [`40fb3ac0`](https://github.com/NixOS/nixpkgs/commit/40fb3ac069f0d865e411c3650a3cb52f45cf5676) gcli: init at 2.0.0
* [`f20a95a8`](https://github.com/NixOS/nixpkgs/commit/f20a95a86a9c03be71445ae1788f68b8c8139c16) build-support/release: deprecate phases
* [`8a31407d`](https://github.com/NixOS/nixpkgs/commit/8a31407d7c55e8956ff55e69ea0cd97d782334f5) phpunit: 10.4.1 -> 10.4.2
* [`fa41730b`](https://github.com/NixOS/nixpkgs/commit/fa41730b86df51d45465ef36d5dda8a5a898fbb5) nixos/switch-to-configuration: remove explicit tmpfiles invocation
* [`856eb81d`](https://github.com/NixOS/nixpkgs/commit/856eb81d1f9d60c82567f3ed73f3bd637b28e6b8) llvmPackages_{7,8,9}.{llvm-polly,libllvm-polly}: fix build with clang 16
* [`cc2d0f04`](https://github.com/NixOS/nixpkgs/commit/cc2d0f04db141124215b199b67b0f6008a64d86f) llvmPackages_6.lldb: fix build on x86_64-darwin
* [`2804d70d`](https://github.com/NixOS/nixpkgs/commit/2804d70d6d314674d4574e9f01b1cc4b16b6f638) cyme: 1.5.2 -> 1.6.0
* [`79e3ab84`](https://github.com/NixOS/nixpkgs/commit/79e3ab84dd10e448b06f2af7a5b322c03932a9d9) nixos/tests/nextcloud: fix with-declarative-redis-and-secrets test
* [`1b5617e2`](https://github.com/NixOS/nixpkgs/commit/1b5617e25bc7b4f2390898e895792be5f0e68c6e) nixos/libvirtd: add netcat and support
* [`896439cd`](https://github.com/NixOS/nixpkgs/commit/896439cdcbb27d3e51287b51956d64edf88ee9f8) aws-sam-cli: add anthonyroussel to maintainers
* [`565ebb62`](https://github.com/NixOS/nixpkgs/commit/565ebb629fa79075b214e941d2139aaa5d156272) aws-sam-cli: add meta.mainProgram
* [`b48ed3ed`](https://github.com/NixOS/nixpkgs/commit/b48ed3ed61fc718d3f616e78ced97f6975521349) aws-sam-cli: fix upstream url
* [`f096c10d`](https://github.com/NixOS/nixpkgs/commit/f096c10d7f5f976106255d4c95c7a96d35db5e23) aws-sam-cli: add passthru.updateScript and passthru.tests
* [`d97b3743`](https://github.com/NixOS/nixpkgs/commit/d97b37430f8f0262f97f674eb357551b399c2003) python310Packages.tensorflow-bin: 2.13.0 -> 2.15.0
* [`00fdaa01`](https://github.com/NixOS/nixpkgs/commit/00fdaa0116e2a76da2f9d4ba5cc105e3de3a5912) android-udev-rules: 20231104 -> 20231124
* [`c4e5aac4`](https://github.com/NixOS/nixpkgs/commit/c4e5aac4e5aa6b89931f0f957a165ae0a314d641) shavee: 0.5.1 -> 0.7.3
* [`7a399b75`](https://github.com/NixOS/nixpkgs/commit/7a399b7503374820cc9d95a3ce36a4cb80689c7b) monkeysAudio: 10.26 -> 10.28
* [`1cdbfb73`](https://github.com/NixOS/nixpkgs/commit/1cdbfb73348a5fbe8efb1d49b23b130a676dba1e) python311Packages.cvxopt: use LP64 blas on darwin; fix build
* [`7246ec5b`](https://github.com/NixOS/nixpkgs/commit/7246ec5b0d2c79c28b66b48f5dce877710af6899) python311Packages.astropy-healpix: upstream patch to fix darwin build
* [`337359c9`](https://github.com/NixOS/nixpkgs/commit/337359c939d9ce3bd6c1d1a75af6ca75aec46a82) esbuild: 0.19.7 -> 0.19.8
* [`5c771366`](https://github.com/NixOS/nixpkgs/commit/5c77136629795251e98001932a37fbfb8db246df) python311Packages.anthropic: 0.5.0 -> 0.7.4
* [`54c8998b`](https://github.com/NixOS/nixpkgs/commit/54c8998ba18d253786b1fd56a712c92693151b4c) treewide: /lib/libexec -> /libexec
* [`b1649f85`](https://github.com/NixOS/nixpkgs/commit/b1649f854a40e3a838b0ff712f4b9f049e9dd50f) allegro5: 5.2.8.0 -> 5.2.9.0
* [`f2ba4634`](https://github.com/NixOS/nixpkgs/commit/f2ba463443d75241ff0f0843459abcf19fb8200a) python311Packages.aws-sam-translator: 1.78.0 -> 1.81.0
* [`13da2e94`](https://github.com/NixOS/nixpkgs/commit/13da2e946399b570144a4f9b3e45688664b0600e) nixos/emacs: Remove absolute paths from documentation
* [`b1475566`](https://github.com/NixOS/nixpkgs/commit/b1475566ff48625d5552029f0485c20b588a0c82) nitrokey-app: specify license
* [`03e44c93`](https://github.com/NixOS/nixpkgs/commit/03e44c932bbe94bb68410be4c60ebf3cca132a2d) nitrokey-app: add changelog to meta
* [`0d896422`](https://github.com/NixOS/nixpkgs/commit/0d8964226923bbc85574a6a748a4a488a93f01b4) nitrokey-app: format with nixpkgs-fmt
* [`3761771d`](https://github.com/NixOS/nixpkgs/commit/3761771d8718a6975eec63732704d2cf1c8aa0b5) phpExtensions.relay: 0.6.3 -> 0.6.8
* [`f7d2a5b1`](https://github.com/NixOS/nixpkgs/commit/f7d2a5b1235f98d7cc187a391de923740ce138b6) vesktop: add desktop item categories
* [`f3530d0d`](https://github.com/NixOS/nixpkgs/commit/f3530d0ddb6fc100f318e80906a79747ade52800) postgresql12JitPackages.pgrouting: 3.5.1 -> 3.6.0
* [`bf92006f`](https://github.com/NixOS/nixpkgs/commit/bf92006f47ad996ab1261a9408ec7d14e432f61a) postgresqlPackages.pgrouting: fix build darwin
* [`b59ed689`](https://github.com/NixOS/nixpkgs/commit/b59ed689c4bd5bc8394734def7edff7ef602ed7d) gnomeExtensions.arcmenu: 44 -> 52
* [`522a4348`](https://github.com/NixOS/nixpkgs/commit/522a4348d89f08c20696f2137521a5b049604026) python311Packages.rapidgzip: 0.10.3 -> 0.10.4
* [`7beab0f4`](https://github.com/NixOS/nixpkgs/commit/7beab0f407b735bb9a9be2c753ab2946a81cccdf) otus-lisp: move to by-name structure
* [`a73f29dd`](https://github.com/NixOS/nixpkgs/commit/a73f29ddcfcfd6cdf63774d4f6456d9e117fb05b) otus-lisp: 2.4 -> 2.5
* [`3f857b57`](https://github.com/NixOS/nixpkgs/commit/3f857b574c56f84a80b72f62a4a7a229ac6cb6cc) srsran: 23.04.1 -> 23.11
* [`b4ebded2`](https://github.com/NixOS/nixpkgs/commit/b4ebded26a536cc6a9bee54f31c989646d9d826f) python311Packages.rapidgzip: add changelog to meta
* [`b83ebefb`](https://github.com/NixOS/nixpkgs/commit/b83ebefbb5ad62d6f6bc372dd8168b94b0c6f894) hyprpaper: 0.4.0 -> 0.5.0
* [`444195a4`](https://github.com/NixOS/nixpkgs/commit/444195a47eaa06d7e9f4d663f5dd3d218ed54baa) hare: refactor `harePackages` into `hareThirdParty`
* [`6f0c0f24`](https://github.com/NixOS/nixpkgs/commit/6f0c0f24e3ac8d1142be684ccd860a89eb6ca7fd) fnott: set `meta.mainProgram`
* [`9fe386e2`](https://github.com/NixOS/nixpkgs/commit/9fe386e214b2c030f711f3632316f5a1c51f3073) fnott: remove `with lib;`
* [`11d6013a`](https://github.com/NixOS/nixpkgs/commit/11d6013a2fcd8b48e0a7104141eb94431459c4ea) fnott: set `passthru.updateScript`
* [`54da1811`](https://github.com/NixOS/nixpkgs/commit/54da1811a0d07928a278c81c194ae00387a0ace2) fnott: enable `strictDeps`
* [`097d123c`](https://github.com/NixOS/nixpkgs/commit/097d123c29b4d420b31cf84274f576117cff4285) fnott: move to `pkgs/by-name`
* [`a1a4f9bb`](https://github.com/NixOS/nixpkgs/commit/a1a4f9bbaa8ea0f362095b50f1002a196f0f0e69) python311Packages.edk2-pytool-library: 0.19.5 -> 0.19.6
* [`0ac7d194`](https://github.com/NixOS/nixpkgs/commit/0ac7d19428fb716d99c6511c58c18cfa1b975a34) v2ray-domain-list-community: 20231121082246 -> 20231122065640
* [`0a091fcc`](https://github.com/NixOS/nixpkgs/commit/0a091fccccde0d481063e972ec0af5f4b7a2e700) haskellPackages.hidapi: fix darwin build
* [`6df99202`](https://github.com/NixOS/nixpkgs/commit/6df9920261314153f159c965780a497f925e622e) gdlauncher: 3.1.44 -> 3.1.45
* [`b9b8024d`](https://github.com/NixOS/nixpkgs/commit/b9b8024dd059eda5d403230f9e345e6be1c56e66) snd: 23.8 -> 23.9
* [`cc522281`](https://github.com/NixOS/nixpkgs/commit/cc522281d2673b5cf8fc9dc0636c34f05235098a) pot: 2.6.6 -> 2.7.0
* [`acc2979e`](https://github.com/NixOS/nixpkgs/commit/acc2979ea32b43b96ec45f49ec67a01e57110476) ravedude: add updateScript
* [`9eab5170`](https://github.com/NixOS/nixpkgs/commit/9eab5170f31c000d997d4163c4248d4664ca9401) ravedude: add mainProgram
* [`52ef1ef0`](https://github.com/NixOS/nixpkgs/commit/52ef1ef0cc538f8f77ea6f4649491061071d81c5) ravedude: add simple version test
* [`58d04b3a`](https://github.com/NixOS/nixpkgs/commit/58d04b3a4b1108326353a29375b1be1dbe0d2a10) ravedude: 0.1.5 -> 0.1.6
* [`d2779b11`](https://github.com/NixOS/nixpkgs/commit/d2779b1194c012e249deac858ee79033266b820a) checkSSLCert: 2.76.0 -> 2.77.0
* [`df44acd7`](https://github.com/NixOS/nixpkgs/commit/df44acd7aae287caa0ca085fd36f14d1bda75ca2) citrix_workspace: 23.07.0 -> 23.09.0
* [`0d220827`](https://github.com/NixOS/nixpkgs/commit/0d220827ac37547654418b9e1880e225521ee562) liberasurecode: ignore strict prototypes on clang; fix darwin
* [`4cd6f5a8`](https://github.com/NixOS/nixpkgs/commit/4cd6f5a826e22c0e87919fc56dec8f83e3aa9533) libLAS: apply upstream patch to fix compile error
* [`7cacb030`](https://github.com/NixOS/nixpkgs/commit/7cacb030def5af71894297787a4a98e9cf91ae3e) linux-rt_latest: remove patch that doesn't apply
* [`9670ddc5`](https://github.com/NixOS/nixpkgs/commit/9670ddc54389828b70447860821ed6521124bdd1) zfs: default disable zfs_dmu_offset_next_sync to avoid data corruption
* [`baf85423`](https://github.com/NixOS/nixpkgs/commit/baf854234261a3002457cdd2a1b8b78908c5c625) opengrok: 1.12.21 -> 1.12.23
* [`09a4aa0e`](https://github.com/NixOS/nixpkgs/commit/09a4aa0e519a7e0eab98e664b4f16f85a28e9eed) bisq-desktop: 1.9.12 -> 1.9.14
* [`8e6e709c`](https://github.com/NixOS/nixpkgs/commit/8e6e709ca1fcdb1d3a75b117c90cce769cd6b65a) kapacitor: fix build of embedded `libflux` dependency with current rust
* [`7fe9dab7`](https://github.com/NixOS/nixpkgs/commit/7fe9dab7d1a438e6899972a639974906886a1451) owncast: 0.1.1 -> 0.1.2
* [`68482a8f`](https://github.com/NixOS/nixpkgs/commit/68482a8f99b1b21988beea3cc0cfe060f6adabdd) openimageio: 2.4.15.0 -> 2.5.5.0
* [`eb6d53c5`](https://github.com/NixOS/nixpkgs/commit/eb6d53c504407c878ae238b90a393eb23bc32b90) jo: add meta.mainProgram
* [`6d2727dd`](https://github.com/NixOS/nixpkgs/commit/6d2727dd4d2bab207a8e9865151d713b5545dc1c) nhentai: fix pdf generation
* [`8880f027`](https://github.com/NixOS/nixpkgs/commit/8880f0272f7cc69d7f70a6d28a294af105094bff) nhentai: set `meta.mainProgram`
* [`4562f4fc`](https://github.com/NixOS/nixpkgs/commit/4562f4fcfef120b667d62bebe7449940ef16d4a0) nhentai: remove `with lib;`
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
