### PR TITLE
niv devenv: update 263efe12 -> a7c4dd8f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "263efe1290b8481cd6d5d814b4655ce332b7f8b1",
-        "sha256": "08fbqdy9a1rq941gj8zk3zl1x88ngaa3yrkb186s6nz9s2c7f2ay",
+        "rev": "a7c4dd8f4eb1f98a6b8f04bf08364954e1e73e4f",
+        "sha256": "05fl4xngwph6lsvyb48ppcf24la66prflbsvbi5kay2lyyw61jrm",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/263efe1290b8481cd6d5d814b4655ce332b7f8b1.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/a7c4dd8f4eb1f98a6b8f04bf08364954e1e73e4f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@263efe12...a7c4dd8f](https://github.com/cachix/devenv/compare/263efe1290b8481cd6d5d814b4655ce332b7f8b1...a7c4dd8f4eb1f98a6b8f04bf08364954e1e73e4f)

* [`94f3b3db`](https://github.com/cachix/devenv/commit/94f3b3db7dabc4c5451d41c4c3d2412c60eabaec) ci: bump actions
