### PR TITLE
niv home-manager: update db1878f0 -> ac721691

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
-        "sha256": "1qr1xsf4fsqmh8c7av984hvrc03y1y6s8nlxfp9zrzhlnh1v034m",
+        "rev": "ac7216918cd65f3824ba7817dea8f22e61221eaf",
+        "sha256": "110m66gdxhidamz0y5i5ijpv4lx2p8iwfhiwajpwf2vginn74jn7",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/db1878f013b52ba5e4034db7c1b63e8d04173a86.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/ac7216918cd65f3824ba7817dea8f22e61221eaf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@db1878f0...ac721691](https://github.com/nix-community/home-manager/compare/db1878f013b52ba5e4034db7c1b63e8d04173a86...ac7216918cd65f3824ba7817dea8f22e61221eaf)

* [`2a604e61`](https://github.com/nix-community/home-manager/commit/2a604e614f974af7e4f9296f1560ce275d2e3786) Translate using Weblate (Portuguese (Brazil))
* [`3d154dab`](https://github.com/nix-community/home-manager/commit/3d154dab14aef8fcf510e291030cecc53b02985a) Translate using Weblate (Russian)
* [`ef908825`](https://github.com/nix-community/home-manager/commit/ef9088253c120d9b4dc26c5e41dd6c3c781ee9f0) Translate using Weblate (Russian)
* [`9e869829`](https://github.com/nix-community/home-manager/commit/9e869829c263d611e3ece814ff2b826463833238) swayidle: daemonize swaylock in example configuration
* [`4a8545f5`](https://github.com/nix-community/home-manager/commit/4a8545f5e737a6338814a4676dc8e18c7f43fc57) swayidle: add systemd suspend to example
* [`0d401071`](https://github.com/nix-community/home-manager/commit/0d4010711922388c80a115d62cdb7ba04c2ed738) flake.lock: Update
* [`ce67b37c`](https://github.com/nix-community/home-manager/commit/ce67b37cabbdaef7bfd614130b182f61867f4c42) Translate using Weblate (Russian)
* [`efe28e24`](https://github.com/nix-community/home-manager/commit/efe28e24f36b4852a3df2c6a518941208e095b04) Translate using Weblate (Italian)
* [`e504e8d0`](https://github.com/nix-community/home-manager/commit/e504e8d01f950776c3a3160ba38c5957a1b89e66) Translate using Weblate (Dutch)
* [`948703f3`](https://github.com/nix-community/home-manager/commit/948703f3e71f1332a0cb535ebaf5cb14946e3724) broot: Add nushell integration ([nix-community/home-manager⁠#4714](https://togithub.com/nix-community/home-manager/issues/4714))
* [`ac721691`](https://github.com/nix-community/home-manager/commit/ac7216918cd65f3824ba7817dea8f22e61221eaf) firefox: fix folders not showing in toolbar
