### PR TITLE
niv nerd-icons.el: update 1dc133b7 -> dd309491

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "1dc133b7cd5d6b08090a4b8fd1cf5433bab65be5",
-        "sha256": "0f3rdsy4iwxv2p422p2aa687zn2qlcw84dail7smb1rdh6gz89v9",
+        "rev": "dd3094918fe69312d53bf927d20eaccbe941c6a8",
+        "sha256": "1fikkqm8gbwwsvas00mvqfaddgdakrddf4dk6jccv87bg54zjahg",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/1dc133b7cd5d6b08090a4b8fd1cf5433bab65be5.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/dd3094918fe69312d53bf927d20eaccbe941c6a8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@1dc133b7...dd309491](https://github.com/rainstormstudio/nerd-icons.el/compare/1dc133b7cd5d6b08090a4b8fd1cf5433bab65be5...dd3094918fe69312d53bf927d20eaccbe941c6a8)

* [`aa0affc8`](https://github.com/rainstormstudio/nerd-icons.el/commit/aa0affc8918661b42cd09922ec2281451671b9ef) update common lisp icons and scheme icons.
* [`dd309491`](https://github.com/rainstormstudio/nerd-icons.el/commit/dd3094918fe69312d53bf927d20eaccbe941c6a8) fix lisp icon
