### PR TITLE
niv niv: update 7b76374b -> 6bd7cd68

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "7b76374b2b44152bfbf41fcb60162c2ce9182e7a",
-        "sha256": "1ql11hzgxdahj9x0b20b70izcmayb22rinrg82kgp5z19bvpsgrp",
+        "rev": "6bd7cd686220bf3db0e212481faf9578e8c8ff0f",
+        "sha256": "15claxlj6y15db67qc7kb4vzyn6sv7r13z4q502vq7a4z2488z94",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/7b76374b2b44152bfbf41fcb60162c2ce9182e7a.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/6bd7cd686220bf3db0e212481faf9578e8c8ff0f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@7b76374b...6bd7cd68](https://github.com/nmattia/niv/compare/7b76374b2b44152bfbf41fcb60162c2ce9182e7a...6bd7cd686220bf3db0e212481faf9578e8c8ff0f)

* [`1d8e2e4d`](https://github.com/nmattia/niv/commit/1d8e2e4d43c5743795e9eac8b8a080397a0903e8) Bump cachix/cachix-action from 12 to 13 ([nmattia/niv⁠#382](https://togithub.com/nmattia/niv/issues/382))
* [`6bd7cd68`](https://github.com/nmattia/niv/commit/6bd7cd686220bf3db0e212481faf9578e8c8ff0f) Bump cachix/install-nix-action from 23 to 24 ([nmattia/niv⁠#383](https://togithub.com/nmattia/niv/issues/383))
