### PR TITLE
niv powerlevel10k: update 174ce9bf -> b9a2d846

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "174ce9bf0166c657404a21f4dc9608da935f7325",
-        "sha256": "1vgy8g4b9nkhijqlr9cffigxa5rwdp7fldxa2s5p36yr5xcymyyx",
+        "rev": "b9a2d846efff427fd13b7e95d83a5761666329ac",
+        "sha256": "0ddqigmgxx5j2i7vhpspqbcw4m86r783ja1aglzssnlwic35qria",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/174ce9bf0166c657404a21f4dc9608da935f7325.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/b9a2d846efff427fd13b7e95d83a5761666329ac.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@174ce9bf...b9a2d846](https://github.com/romkatv/powerlevel10k/compare/174ce9bf0166c657404a21f4dc9608da935f7325...b9a2d846efff427fd13b7e95d83a5761666329ac)

* [`92bee796`](https://github.com/romkatv/powerlevel10k/commit/92bee796428eac486c8766e7fc7c2a2e4b712dfd) Add icons for VCS_GIT usage
* [`47d5397b`](https://github.com/romkatv/powerlevel10k/commit/47d5397baa7473db2b4d8f9c59cef8fa51c78376) Add various remote git server instances
* [`211c9034`](https://github.com/romkatv/powerlevel10k/commit/211c90343f51884ed1655de4284ebe12342db9d8) wizard: recognize `source -- ~.p10k.zsh` in .zshrc
* [`096a731d`](https://github.com/romkatv/powerlevel10k/commit/096a731db3947caa69f350243f5f2ea0ce2da47e) define usable defaults for VCS_*_ICON ([romkatv/powerlevel10k⁠#2493](https://togithub.com/romkatv/powerlevel10k/issues/2493))
* [`c39e5304`](https://github.com/romkatv/powerlevel10k/commit/c39e5304a13760804ee41cce52c4b49946baa2e7) add VCS_GIT_GITEA_ICON and VCS_GIT_SOURCEHUT_ICON ([romkatv/powerlevel10k⁠#2493](https://togithub.com/romkatv/powerlevel10k/issues/2493))
* [`9547f228`](https://github.com/romkatv/powerlevel10k/commit/9547f228224e73b4b34c365e1937f096b06da830) s/VCS_GIT_ARCH_ICON/VCS_GIT_ARCHLINUX_ICON/ ([romkatv/powerlevel10k⁠#2493](https://togithub.com/romkatv/powerlevel10k/issues/2493))
* [`7fd76370`](https://github.com/romkatv/powerlevel10k/commit/7fd76370f53f87f956c811766a452c83ced4014b) be a lot more strict when matching the remote git URL ([romkatv/powerlevel10k⁠#2493](https://togithub.com/romkatv/powerlevel10k/issues/2493))
* [`b9a2d846`](https://github.com/romkatv/powerlevel10k/commit/b9a2d846efff427fd13b7e95d83a5761666329ac) docs: clarify that powerlevel10k does not install new commands ([romkatv/powerlevel10k⁠#2498](https://togithub.com/romkatv/powerlevel10k/issues/2498))
