### PR TITLE
niv nixpkgs: update 72061433 -> 338c49e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "72061433dd3711fe9a06b177323e4ffd4a81847a",
-        "sha256": "0advvnbsrbvvz1m2zhkigkmq00ib0kq7a7qkrh5i33vkczdq7pjd",
+        "rev": "338c49e0c453b0525c47c0597c7e4e2797714676",
+        "sha256": "05m3ypqggqpmm6higldcxbi0gq15fvxa0kjnlvcnl6c32jy7755r",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/72061433dd3711fe9a06b177323e4ffd4a81847a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/338c49e0c453b0525c47c0597c7e4e2797714676.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@72061433...338c49e0](https://github.com/nixos/nixpkgs/compare/72061433dd3711fe9a06b177323e4ffd4a81847a...338c49e0c453b0525c47c0597c7e4e2797714676)

* [`e1370b78`](https://github.com/NixOS/nixpkgs/commit/e1370b78792505fa6a276a29a8e2a0b7d69756a3) sss-cli: init at 0.1.1
* [`2b984b10`](https://github.com/NixOS/nixpkgs/commit/2b984b10fa0ca11021138acf7f380922b1dafc93) g2o: 20230223 -> 20230806
* [`0ba4d72c`](https://github.com/NixOS/nixpkgs/commit/0ba4d72c554405ac693c472e23cff1d28d352dc1) g2o: split outputs
* [`78fd6b41`](https://github.com/NixOS/nixpkgs/commit/78fd6b41368e404f87b504f85e5c1f2c494bc9b5) rtabmap: add patches to fix build with g2o 20230806
* [`429be0eb`](https://github.com/NixOS/nixpkgs/commit/429be0eb30691c483efbee6d8b06816035022c3e) houdini: fix missing quotation marks in wrappers
* [`fe0ccd50`](https://github.com/NixOS/nixpkgs/commit/fe0ccd505aa237b44c755cf2c85ee7b4c96d199a) houdini: expose husk, mantra binaries
* [`cab849df`](https://github.com/NixOS/nixpkgs/commit/cab849dffd7d9c3a5ee993fdd9464b9f1bd53ec6) python3Packages.mediafire-dl: init at 2023-09-07
* [`803403d9`](https://github.com/NixOS/nixpkgs/commit/803403d9fb586892357f116d59f20b6292d12149) mozillavpn: 2.16.1 → 2.17.1
* [`b910a66c`](https://github.com/NixOS/nixpkgs/commit/b910a66c610e6ab69c647d8d256ddc85924e0c7f) naproche: 2022-10-24 -> unstable-2023-07-11
* [`e011daa1`](https://github.com/NixOS/nixpkgs/commit/e011daa1f9b4918ffd56c3d4b950e425a0aac436) isabelle: 2022 -> 2023
* [`7dd0a639`](https://github.com/NixOS/nixpkgs/commit/7dd0a639cbd4b3a3f8cf160a6eb372c98ad43b0f) igir: init at 2.0.6
* [`f373e638`](https://github.com/NixOS/nixpkgs/commit/f373e638dedf05e503301ef3c9015a9a05bfb24d) tevent: 0.15.0 -> 0.16.0
* [`60199f1d`](https://github.com/NixOS/nixpkgs/commit/60199f1d26630af16a0305057ebeba3362c594af) spark: init 3.5.0, 3.4.0->3.4.1, 3.3.2->3.3.3
* [`fc7aceed`](https://github.com/NixOS/nixpkgs/commit/fc7aceed429a24e3efc49b82691f5fac596f59e9) spark: use finalAttrs
* [`392bc542`](https://github.com/NixOS/nixpkgs/commit/392bc5422573ffce67a5ac924bc6494398150edb) spark: add passthru test
* [`ca6c662a`](https://github.com/NixOS/nixpkgs/commit/ca6c662a6745859bed2a785879509fef84a627e5) python311Packages.cheetah3: 3.3.2 -> 3.3.3
* [`f41a7c57`](https://github.com/NixOS/nixpkgs/commit/f41a7c57faf42eacb4b6363f95061ac9ab7f3c51) ocamlPackages.fix: 20220121 -> 20230505
* [`1d182037`](https://github.com/NixOS/nixpkgs/commit/1d182037be34c894dded0565e64da762a72c8759) cryptominisat: 5.11.14 -> 5.11.15
* [`e766e537`](https://github.com/NixOS/nixpkgs/commit/e766e537551bd9045359abce070e9d555e86e410) cryptopp: 8.8.0 -> 8.9.0
* [`bad03d8c`](https://github.com/NixOS/nixpkgs/commit/bad03d8cb8ff56e54503fe2a2128a04b1813df5a) Disable global cache for emscripten
* [`ba1c2cb7`](https://github.com/NixOS/nixpkgs/commit/ba1c2cb708824a1e1cccf16e38dcf1a46ed0acf7) rdkafka: 2.2.0 -> 2.3.0
* [`c2a3f9b0`](https://github.com/NixOS/nixpkgs/commit/c2a3f9b0282e2c02fe124c763f5f4c35ad80d77d) ocamlPackages.ocaml-version: 3.6.1 -> 3.6.2
* [`d768bf69`](https://github.com/NixOS/nixpkgs/commit/d768bf69a1ee47c8483273b9373763f88d434eb3) maptool: extract application JARs from package
* [`4305607b`](https://github.com/NixOS/nixpkgs/commit/4305607bb83cf08c96dbe43d47bbc3003122471a) openshift: 4.13.0 -> 4.14.0
* [`84de6c28`](https://github.com/NixOS/nixpkgs/commit/84de6c2816f43ff10e3df3cb45bfb0c7a503bbf1) cargo-swift: init at 0.4.0
* [`50379840`](https://github.com/NixOS/nixpkgs/commit/50379840d5e457e913f538e9e6d1b5b8b59b2b13) mozillavpn: 2.17.1 → 2.18.0
* [`78f4873a`](https://github.com/NixOS/nixpkgs/commit/78f4873a4fff0696d5c9666ae99a429c70c8c39b) cldr-annotations: 43.0 -> 44.0
* [`ef9732e1`](https://github.com/NixOS/nixpkgs/commit/ef9732e11f242a17b5b1a7e58397006a3c8f77d9) spark: remove untarDir
* [`a6ddad64`](https://github.com/NixOS/nixpkgs/commit/a6ddad641da57aa4985777185324245c5bea11be) spark: remove 3.2.4
* [`fefde6c1`](https://github.com/NixOS/nixpkgs/commit/fefde6c13541500dcd85c56f3900d757808a5d06) spark: remove with; to avoid ambiguity
* [`c7b3c167`](https://github.com/NixOS/nixpkgs/commit/c7b3c167662cf3f554585fcfa62e2d031ce86947) python310Packages.datashader: 0.15.2 -> 0.16.0
* [`effd00b7`](https://github.com/NixOS/nixpkgs/commit/effd00b7bc0108fc996e890c80a798a312a10a28) python311Packages.python-vlc: 3.0.18122 -> 3.0.20123
* [`e926f861`](https://github.com/NixOS/nixpkgs/commit/e926f861eeb5ccc06c26edf9f169753274261c9a) python310Packages.django-stubs: 4.2.4 -> 4.2.6
* [`7e1b6541`](https://github.com/NixOS/nixpkgs/commit/7e1b6541a0884fc870cab18607548e3eb11d0e76) python310Packages.django-stubs-ext: 4.2.2 -> 4.2.5
* [`94aac108`](https://github.com/NixOS/nixpkgs/commit/94aac108c6a7c26a0101cddd9104bd057484a36e) python310Packages.django-taggit: 4.0.0 -> 5.0.1
* [`b9886753`](https://github.com/NixOS/nixpkgs/commit/b9886753ca2d1b7017bfdef4aa32f13f0a21485c) python310Packages.etils: 1.5.1 -> 1.5.2
* [`1725fad5`](https://github.com/NixOS/nixpkgs/commit/1725fad5a7b1d4000be8b104739e20e2377f9324) python310Packages.flask-mailman: 0.3.0 -> 1.0.0
* [`fca2f165`](https://github.com/NixOS/nixpkgs/commit/fca2f165a61ed1dd0976d8910ac4cf1b80dbc6cb) python310Packages.glean-parser: 9.0.0 -> 10.0.3
* [`e34b3d01`](https://github.com/NixOS/nixpkgs/commit/e34b3d0157fd7390e8391f04a35d3901cbf24ce6) python310Packages.google-cloud-dataproc: 5.6.0 -> 5.7.0
* [`3de73417`](https://github.com/NixOS/nixpkgs/commit/3de73417124ca358b3253468eceb8c6b0d7c74ee) python310Packages.hvac: 1.2.1 -> 2.0.0
* [`c70a7f9f`](https://github.com/NixOS/nixpkgs/commit/c70a7f9fe95bd6eed4933113e7e9a20c9a1bcf8a) nwjs: 0.54.1 -> 0.82.0
* [`3fdf3742`](https://github.com/NixOS/nixpkgs/commit/3fdf3742bacab4cdd69e583606a92f7f7a8986d9) nwjs: format file
* [`52c29960`](https://github.com/NixOS/nixpkgs/commit/52c2996076cbf3ef8209024c23b983f9d85903ea) nwjs: go all in with autoPatchelfHook
* [`ab8d3140`](https://github.com/NixOS/nixpkgs/commit/ab8d3140fb4f90d8ff9bae8c7507da8551bec25a) nwjs: change maintainer to mikaelfangel
* [`6ef12a0c`](https://github.com/NixOS/nixpkgs/commit/6ef12a0ca50b3761029686f149ffac099eb8ff8d) python311Packages.emborg: 1.37 -> 1.38
* [`d3fe3372`](https://github.com/NixOS/nixpkgs/commit/d3fe3372669808cb49b53925657fe759480e4655) zsh-vi-mode: 0.10.0 -> 0.11.0
* [`dbff1f0b`](https://github.com/NixOS/nixpkgs/commit/dbff1f0b64f97c8769828baf2adc696f6e838556) python310Packages.hvac: update disabled python version
* [`c4032274`](https://github.com/NixOS/nixpkgs/commit/c4032274ea5f11fad7b83fef6a195ffbdcfa1bbf) python310Packages.google-cloud-dataproc: update homepage
* [`cdb25467`](https://github.com/NixOS/nixpkgs/commit/cdb2546783793fb1b47ac66ce4405906a9672610) drone-scp: init at 1.6.11
* [`76184f68`](https://github.com/NixOS/nixpkgs/commit/76184f68b8d7c71cc8a805e38c16301c985ba12f) scriv: 1.4.0 -> 1.5.0
* [`07a85a35`](https://github.com/NixOS/nixpkgs/commit/07a85a353f512aac9397165a691204aca9ebd241) cbor-diag: 0.8.4 -> 0.8.7
* [`ed704c81`](https://github.com/NixOS/nixpkgs/commit/ed704c819e539a2333b7b18384391be69305b733) mobilecoin-wallet: 1.5.0 -> 1.8.0
* [`ff7bd7ab`](https://github.com/NixOS/nixpkgs/commit/ff7bd7ab1f2732af99eea59e999939df62a026b6) python311Packages.r2pipe: 1.8.0 -> 1.8.2
* [`d92a11f5`](https://github.com/NixOS/nixpkgs/commit/d92a11f5509be937ef8ca4cb5551f7878cc838ce) cgl: init at 0.60.8
* [`ef3e2dff`](https://github.com/NixOS/nixpkgs/commit/ef3e2dff0baf163fa770ba61dc731b4923ec4c05) vscode-extensions.ms-toolsai.jupyter: patch to avoid writing to read-only store
* [`a222ff94`](https://github.com/NixOS/nixpkgs/commit/a222ff94ba1baf295400442e53eb946662905e58) libdnf: add cppunit, reenable tests
* [`7aa1e441`](https://github.com/NixOS/nixpkgs/commit/7aa1e441a5a0b451ab0ac9bbfbb563062676c2a5) maintainers: add ekimber
* [`857b1051`](https://github.com/NixOS/nixpkgs/commit/857b105115c07bcda8ea680981e65ddd48705990) mev-boost: init at 1.6
* [`1007489f`](https://github.com/NixOS/nixpkgs/commit/1007489fe663b437d915f09e1333b39cfa82b036) python310Packages.siobrultech-protocols: 0.12.0 -> 0.13.0
* [`00aa82e8`](https://github.com/NixOS/nixpkgs/commit/00aa82e892ab031ad80a56b86dca95727bb1bab2) python310Packages.social-auth-core: 4.4.2 -> 4.5.0
* [`71dd9c3d`](https://github.com/NixOS/nixpkgs/commit/71dd9c3d538195abdcdaf6b1afdcf72193dcaf0a) nixos/nextcloud: missing ocm-dir applys also from 26.0.8 onward
* [`7cd84e21`](https://github.com/NixOS/nixpkgs/commit/7cd84e2123570bfce1d54c5a847391ff489ccbe6) python310Packages.tracerite: 1.1.0 -> 1.1.1
* [`b2879b78`](https://github.com/NixOS/nixpkgs/commit/b2879b78cc8953252b1ec9edfb9652e55ce23eff) thedesk: remove original binary from package
* [`7366ba22`](https://github.com/NixOS/nixpkgs/commit/7366ba22a2eb9fc4e19424eddaf69706d7e19f68) vscode-extensions.kddejong.vscode-cfn-lint: 0.21.0 -> 0.25.1
* [`79283256`](https://github.com/NixOS/nixpkgs/commit/79283256c9cbcd3fb7b30ebbef7a4800cd02ba14) python310Packages.wtf-peewee: 3.0.4 -> 3.0.5
* [`63be9fe0`](https://github.com/NixOS/nixpkgs/commit/63be9fe0559ec04882deffae2ca8e0f8f93763e8) apacheAnt_1_9: remove
* [`e3997ff7`](https://github.com/NixOS/nixpkgs/commit/e3997ff7995701532e70886c3bd84c7c353c9258)  python310Packages.social-auth-core: add cahngelog to meta
* [`cca2e7b2`](https://github.com/NixOS/nixpkgs/commit/cca2e7b21b98bca181c75a7acd6b5a81f9b0636e) python310Packages.tracerite: add changelog to meta
* [`4c9d5c3b`](https://github.com/NixOS/nixpkgs/commit/4c9d5c3b2ccd176a135380de7a947a1d6e5463bd) python310Packages.tracerite: disable on unsupported Python releases
* [`c9c6fc6f`](https://github.com/NixOS/nixpkgs/commit/c9c6fc6fecf463a313ebfad915a69dcd54db8439) hping: fix cross
* [`afb583d4`](https://github.com/NixOS/nixpkgs/commit/afb583d4a70501d3e7abe405186c8b45794291fe) python311Packages.tree-sitter: 0.20.2 -> 0.20.4
* [`3c8108f9`](https://github.com/NixOS/nixpkgs/commit/3c8108f93d24289aa3dd8472e124b6771702b790) python311Packages.tree-sitter: add changelog to meta
* [`07d473bc`](https://github.com/NixOS/nixpkgs/commit/07d473bc3abb22b2492426f1a0e4d5c399b3cdda) acorn: 0.8.0 -> 0.9.2
* [`a25fabad`](https://github.com/NixOS/nixpkgs/commit/a25fabad9ebb4b4a6ef038a4a072b61c69a97ee7) jruby: 9.4.4.0 -> 9.4.5.0
* [`da18e482`](https://github.com/NixOS/nixpkgs/commit/da18e482dc7da664ff22c90d419b829bd5ed7644) sqlcl: 23.2.0.178.1027 -> 23.3.0.270.1251
* [`c57eadcf`](https://github.com/NixOS/nixpkgs/commit/c57eadcfe157e0309b40a356233b57b0848f17a8) symengine: 0.10.1 -> 0.11.1
* [`81aaf98b`](https://github.com/NixOS/nixpkgs/commit/81aaf98bca4b0f11171add6a151fbb1be4b35673) spicedb: 1.25.0 -> 1.26.0
* [`6227e97c`](https://github.com/NixOS/nixpkgs/commit/6227e97c55a5910861f5cf5057307a73f240ecf5) aaaaxy: 1.4.72 -> 1.4.101
* [`4b0b3413`](https://github.com/NixOS/nixpkgs/commit/4b0b3413b48d303bfd5714c7161cb3a574bee38f) nixos/keycloak: Allow setting hostname-url
* [`af75c89f`](https://github.com/NixOS/nixpkgs/commit/af75c89f483ef07b598e47006e5859cf8835f35f) python3Packages.bdffont: init at 0.0.14
* [`09640dba`](https://github.com/NixOS/nixpkgs/commit/09640dbaeb7c4535bf6aaaadbc6c3e1a5365c5bd) python3Packages.character-encoding-utils: init at 0.0.6
* [`e64bc6f3`](https://github.com/NixOS/nixpkgs/commit/e64bc6f37f72fd12fa14aa667a6c1436caeab36b) python3Packages.unidata-blocks: init at 0.0.6
* [`ca98c930`](https://github.com/NixOS/nixpkgs/commit/ca98c93050b20d92248cb49efebeee54420b39da) python3Packages.pixel-font-builder: init at 0.0.10
* [`a0520c44`](https://github.com/NixOS/nixpkgs/commit/a0520c4483c6b9bd3d115fd05500c9d0e2b977ec) ark-pixel-font: init at 2023.08.15
* [`6893d192`](https://github.com/NixOS/nixpkgs/commit/6893d1929ef162d564a241195ced487362f5b362) python3Packages.bdffont: 0.0.14 -> 0.0.15
* [`d14d14ab`](https://github.com/NixOS/nixpkgs/commit/d14d14abbb0e2bbf1067adb1de085f1ba3875497) python3Packages.unidata-blocks: 0.0.6 -> 0.0.8
* [`84e51c52`](https://github.com/NixOS/nixpkgs/commit/84e51c525d6a39c8d4047a387391faf4c901ee1a) nixos/plasma5: enable dconf by default
* [`b4fe2ede`](https://github.com/NixOS/nixpkgs/commit/b4fe2eded13a41f055a93dc1dbd51b6da90b1645) elasticmq-server-bin: 1.4.5 -> 1.5.0
* [`d1f48434`](https://github.com/NixOS/nixpkgs/commit/d1f48434fc05644fae3667a035ed328bbccdd320) dart: 3.1.3 -> 3.2.0
* [`f27994f8`](https://github.com/NixOS/nixpkgs/commit/f27994f87aed6ec38bbc762970243052bcdeb6dc) minizinc: 2.7.6 -> 2.8.0
* [`07121532`](https://github.com/NixOS/nixpkgs/commit/0712153200f489ca1a66184e63e18fd42883276d) wob: 0.14.2 -> 0.15.1
* [`3e4e76e6`](https://github.com/NixOS/nixpkgs/commit/3e4e76e6769bab6fa7f1f6f9d63967147e701ac8) greetd: create cache dir for tuigreet
* [`5e8069cc`](https://github.com/NixOS/nixpkgs/commit/5e8069cc83c5e6e05a5037872da6fb72b1a71e50) maintainers: add eymeric
* [`e12bd4fd`](https://github.com/NixOS/nixpkgs/commit/e12bd4fd54f6ad7ab166d3f1c1d2d9300852777b) haskellPackages: stackage LTS 21.19 -> LTS 21.21
* [`479cffe9`](https://github.com/NixOS/nixpkgs/commit/479cffe9cd853eb71e91b81ac8d01445f29d8ce5) all-cabal-hashes: 2023-11-10T11:27:19Z -> 2023-11-20T05:37:18Z
* [`d35fd4d8`](https://github.com/NixOS/nixpkgs/commit/d35fd4d84ea26bf6de6d647225120665add39488) haskellPackages: regenerate package set based on current config
* [`d3291b33`](https://github.com/NixOS/nixpkgs/commit/d3291b33c3c3506f72a82637594a699ec4352105) haskellPackages: hnix-store-core-0.6.1.0 -> hnix-store-core-0.7.0.0
* [`3ed29a3e`](https://github.com/NixOS/nixpkgs/commit/3ed29a3e852af1cf9c37a66eff574548e828627f) haskellPackages: regenerate transitive broken packages
* [`d984a65c`](https://github.com/NixOS/nixpkgs/commit/d984a65c4d0e34e8312d82ffa576fa69386aae66) haskellPackages.hiedb: remove redundant patch
* [`5dcd7819`](https://github.com/NixOS/nixpkgs/commit/5dcd7819f7803e0bddcb482507cbd7e9b98cf2e3) haskellPackages: regenerate package set based on current config
* [`97f4fac2`](https://github.com/NixOS/nixpkgs/commit/97f4fac2ed5508bb9b5af47e9e711d1efeb49532) nix-template-rpm: remove
* [`c5425534`](https://github.com/NixOS/nixpkgs/commit/c54255349152e18e113d22f49efe8626312a7971) exodus: 23.10.24 -> 23.11.6
* [`3428de97`](https://github.com/NixOS/nixpkgs/commit/3428de976f463894d7bb3232317a71a9c9e3074c) git-annex-remote-rclone: 0.7 -> 0.8
* [`d1b3251d`](https://github.com/NixOS/nixpkgs/commit/d1b3251d47c1617f88b03e9ba74a75506a0692a5) python311Packages.picobox: 3.0.0 -> 4.0.0
* [`2af613b5`](https://github.com/NixOS/nixpkgs/commit/2af613b58c9401fd7b4d270a46f22a755990fd43) haskell.compiler.ghc*: set abs paths for cctools bintools w/ hadrian
* [`72570670`](https://github.com/NixOS/nixpkgs/commit/72570670c09ef827af6498da657fd6fea3b546cc) ton: 2023.06 -> 2023.10
* [`e696fea2`](https://github.com/NixOS/nixpkgs/commit/e696fea2af0a51d5eb2c327d8142cda53e2f39f4) maintainers.davidarmstronglewis: update github to oceanlewis
* [`9dfdbccf`](https://github.com/NixOS/nixpkgs/commit/9dfdbccf1dc5cee103aca0595bb3fbc6c759255b) maintainers.milran: update github to wattmto
* [`8c34d8fb`](https://github.com/NixOS/nixpkgs/commit/8c34d8fb7b96913b0dc737e4628f35aab7cc1fc4) maintainers.revol-xut: update github to tanneberger
* [`39622e70`](https://github.com/NixOS/nixpkgs/commit/39622e701d86081a986101868effde0649502957) maintainers.SamirTalwar: fix githubId typo
* [`d04c014f`](https://github.com/NixOS/nixpkgs/commit/d04c014f8a0eed943cffdfc933ca757c172f21e5) strongswan: 5.9.11 -> 5.9.12
* [`03058077`](https://github.com/NixOS/nixpkgs/commit/030580776a8e95c0871b5c6acd00c77b1d9fc545) haskell.compiler.ghcHEAD: 9.9.20231014 -> 9.9.20231121
* [`1ccaf0c1`](https://github.com/NixOS/nixpkgs/commit/1ccaf0c1471adc88c2eade131f30ef21a2feaeda) haskell.packages.ghc88.doctest: skip test requiring newer base
* [`2e07f636`](https://github.com/NixOS/nixpkgs/commit/2e07f636f202524409815eaa1e3250033b4e82c0) gnustep.gui: 0.29.0 -> 0.30.0
* [`5de49797`](https://github.com/NixOS/nixpkgs/commit/5de49797c464a6e35f333fbdfbab60123c7c81ae) cf-terraforming: 0.15.0 -> 0.16.1
* [`5f2e034f`](https://github.com/NixOS/nixpkgs/commit/5f2e034f106bf89dc687af118fe366fb7eb7a7d9) zammad: remove yarn steps from update script
* [`67f69d2a`](https://github.com/NixOS/nixpkgs/commit/67f69d2abad2f64eae28c48071c9bd159ce28c96) vendir: 0.35.2 -> 0.37.0
* [`e2a8855e`](https://github.com/NixOS/nixpkgs/commit/e2a8855e674930aa4a1b6c408bb4cfe81a9b64e3) minio: 2023-09-20T22-49-55Z -> 2023-11-01T18-37-25Z
* [`715df037`](https://github.com/NixOS/nixpkgs/commit/715df03700a94e60587ff8df7a722e76c5817a4d) minio-client: 2023-09-07T22-48-55Z -> 2023-10-30T18-43-32Z
* [`f56b5200`](https://github.com/NixOS/nixpkgs/commit/f56b520024cf2f8b9717bf0da192d0ddfa722554) git-town: 9.0.1 -> 10.0.1
* [`38232bc5`](https://github.com/NixOS/nixpkgs/commit/38232bc5288375fb46099cf0665bf8d736e948c4) ocamlPackages.inotify: 2.4.1 -> 2.5
* [`6f33a6ad`](https://github.com/NixOS/nixpkgs/commit/6f33a6ad1f02d7efcdb5fe5aa2437a0aec24a111) ballerina: 2201.8.2 -> 2201.8.3
* [`ac607cf5`](https://github.com/NixOS/nixpkgs/commit/ac607cf537f76149c376f4f4bc9dd80b16e3747e) uhdm: 1.77 -> 1.80
* [`f0de09a2`](https://github.com/NixOS/nixpkgs/commit/f0de09a2f46fa9b734d841fa756ef2f61499cfee) docker-compose: 2.23.1 -> 2.23.3
* [`80fdffb4`](https://github.com/NixOS/nixpkgs/commit/80fdffb416bb82aabeb02293bbe31739257e1832) armTrustedFirmwareTools: 2.9.0 -> 2.10.0
* [`e3695de8`](https://github.com/NixOS/nixpkgs/commit/e3695de873a9dffea44632fe17cc4cc8fa1bb9ab) ocamlPackages.iter: 1.7 -> 1.8
* [`d4955c5e`](https://github.com/NixOS/nixpkgs/commit/d4955c5e58077ac73d6db3b54be1226490fb4e86) tpm2-tools: 5.5 -> 5.6
* [`8c87a98c`](https://github.com/NixOS/nixpkgs/commit/8c87a98ce1e8850faee64a0a540acff233b66bd2) buildHomeAssistantComponent: fix install with patches applied
* [`e3cb5270`](https://github.com/NixOS/nixpkgs/commit/e3cb52705252ad0f07eae44c73aedf8972ea717f) qlog: make it build on mac
* [`f69c63a6`](https://github.com/NixOS/nixpkgs/commit/f69c63a6b855e4c241124835744adc4857d1f1f0) gtkcord4: 0.0.12 -> 0.0.16-1
* [`b65d18e2`](https://github.com/NixOS/nixpkgs/commit/b65d18e21ca94418df3994f447a25d267ad008a2) gtkcord4: fix description and add mainProgram
* [`2ca79e7f`](https://github.com/NixOS/nixpkgs/commit/2ca79e7f9d14ebc34495affc576eccd4f17aa5e2) nixos/ejabberd: ensure erlang cookie is made
* [`b7d2cf6c`](https://github.com/NixOS/nixpkgs/commit/b7d2cf6c9efb5708c57df88380272458c074bc6b) freetds: 1.4.6 -> 1.4.7
* [`d939175c`](https://github.com/NixOS/nixpkgs/commit/d939175ce07bebadd3e2e29a0077c0e7e60416fe) pythonPackages.cirq-core: fix build on aarch64
* [`1de8ec33`](https://github.com/NixOS/nixpkgs/commit/1de8ec33c5f8432525f3f60ee97d78accda29c9e) python3Packages.cirq-core: fix build on aarch64
* [`748ccc92`](https://github.com/NixOS/nixpkgs/commit/748ccc92a6f72c99258ce5b5bf464e79c6244710) libsForQt5.bismuth: Fix generated JS
* [`d7890eda`](https://github.com/NixOS/nixpkgs/commit/d7890eda288c53bb68fa4b0ace3763405c0fbc90) stepmania: use diff-friendly formatting
* [`5a81ef63`](https://github.com/NixOS/nixpkgs/commit/5a81ef6335f19d67a21c0b96a1b8d5922e80b644) stepmania: use SRI hash
* [`4e08f168`](https://github.com/NixOS/nixpkgs/commit/4e08f168930fe3f5e186c6118e1ce3ce1928ea1f) nixos/networkd: fix manpage for `WireGuardPeer` config
* [`d5260c55`](https://github.com/NixOS/nixpkgs/commit/d5260c5544b9dfbe35392d7b4e03ee57d7205628) nixos/transmission: correct typo on systemd StateDirectory
* [`6d2c0458`](https://github.com/NixOS/nixpkgs/commit/6d2c0458b8982619d53b8aa092697d7184cb676b) nexttrace: 1.2.3.1 -> 1.2.6
* [`677c50a1`](https://github.com/NixOS/nixpkgs/commit/677c50a1a5ff4e1f6e46e0cbac732dbf102cf9b9) freetds: 1.4.7 -> 1.4.8
* [`17aefe8c`](https://github.com/NixOS/nixpkgs/commit/17aefe8cc8f08d4453be99d544099eae0f589af5) python311Packages.cloudflare: 2.12.4 -> 2.14.2
* [`482bf1a0`](https://github.com/NixOS/nixpkgs/commit/482bf1a03636d1388faa626fb5484a2a816fb2a5) floorp: 11.6.0 -> 11.6.1
* [`7ef523cd`](https://github.com/NixOS/nixpkgs/commit/7ef523cdd7ceb2f94286dd6ddb54d7edbb3e2199) sparrow: 1.7.9 -> 1.8.1
* [`e26e222a`](https://github.com/NixOS/nixpkgs/commit/e26e222a5054aec0473254434e6416f538dc231d) stepmania: 5.1.0-b2 -> 5.1.0-b2-unstable-2022-11-14
* [`6c241dc0`](https://github.com/NixOS/nixpkgs/commit/6c241dc0f08e302bf0de833879d0fb5fcfd7b63c) stepmania: add h7x4 as maintainer
* [`86b4c217`](https://github.com/NixOS/nixpkgs/commit/86b4c2178310d57b411e65ac1cb27e67a95654e9) stepmania: install desktop entry and icons
* [`63d7b9f9`](https://github.com/NixOS/nixpkgs/commit/63d7b9f96c1ca168f56fa34b1328d0c6c1e21dad) cvs-fast-export: 1.61 -> 1.62
* [`507f1dde`](https://github.com/NixOS/nixpkgs/commit/507f1dde5722eb89c5a90a1a98c698c697c04e60) python311Packages.zulip: 0.8.2 -> 0.9.0
* [`c035dd96`](https://github.com/NixOS/nixpkgs/commit/c035dd9665a7c744d1b8e4e28566a07c4f2d43f3) pe-bear: 0.6.5.2 -> 0.6.6
* [`57d2dd65`](https://github.com/NixOS/nixpkgs/commit/57d2dd657f84f988faf9bf7bf7ea74eb4ceccf9f) python311Packages.moderngl: 5.8.2 -> 5.9.0
* [`d7a3b288`](https://github.com/NixOS/nixpkgs/commit/d7a3b288417388e0b478a1192bd2e2b35d8d746c) python311Packages.xattr: 0.10.1 -> 1.0.0
* [`b25918f6`](https://github.com/NixOS/nixpkgs/commit/b25918f6fd9d5a439d58ea598924fa2037902fac) human-readable: init at 1.3.4
* [`8856d14f`](https://github.com/NixOS/nixpkgs/commit/8856d14f0c672ade3b9f00cd7bb52c6d7e428bec) pyipv8: init at 2.12.0
* [`4df5e824`](https://github.com/NixOS/nixpkgs/commit/4df5e8249dce54ea8e2eaafbe78f086bc740852d) python311Packages.robotframework-pythonlibcore: 4.2.0 -> 4.3.0
* [`f313c64b`](https://github.com/NixOS/nixpkgs/commit/f313c64b6aa4005b362c6c41f2fc281f82467b91) python310Packages.asf-search: 6.6.3 -> 6.7.1
* [`fbd57b43`](https://github.com/NixOS/nixpkgs/commit/fbd57b4324786ec8db39d7ce60e0adbc065df87e) tribler: 7.11.0 -> 7.13.0
* [`9cb08989`](https://github.com/NixOS/nixpkgs/commit/9cb089895c7239b3b910857247aae27c2dbe7b18) kmscon: set strictDeps, fix cross compilation
* [`aa3928fa`](https://github.com/NixOS/nixpkgs/commit/aa3928fad42dc370979f7d897b1a887c58f7526f) samba: fix cross compilation
* [`11f5f3bf`](https://github.com/NixOS/nixpkgs/commit/11f5f3bf13666ff52f4f43f804133a71e756c427) aseprite: 1.2.40 -> 1.3
* [`99de7700`](https://github.com/NixOS/nixpkgs/commit/99de770041385799f0de0bbf3d35a857cd365723) spatialite_gui: add geospatial team to maintainers
* [`a7118622`](https://github.com/NixOS/nixpkgs/commit/a7118622e267309d290ebff46cc19e632797ec8e) gti: 1.8.0 -> 1.9.1
* [`3f05b485`](https://github.com/NixOS/nixpkgs/commit/3f05b485684f95b2d2528eb6fd1b18f85fee1849) spring-boot-cli: 3.1.5 -> 3.2.0
* [`df0ebc03`](https://github.com/NixOS/nixpkgs/commit/df0ebc03b85c3a13f0fa347ed685154bc25bd50c) libbacktrace: disable tests on musl
* [`47e8afb4`](https://github.com/NixOS/nixpkgs/commit/47e8afb4b2679c836044d999ee09be136e2e9c96) mpvpaper: 1.3 -> 1.4
* [`564b8682`](https://github.com/NixOS/nixpkgs/commit/564b868205255fa21ba030098cd2273080ed8dd8) emacsPackages.emacspeak: 56.0 -> 58.0
* [`0089263c`](https://github.com/NixOS/nixpkgs/commit/0089263c11be11d0e2bb464de13587a12ecb3671) praat: 6.3.20 -> 6.4
* [`02dd7c7b`](https://github.com/NixOS/nixpkgs/commit/02dd7c7bb36cfd930eaf7124e560013074ccf01e) prefetch-npm-deps: add support for npm alias schema in version spec
* [`281c5694`](https://github.com/NixOS/nixpkgs/commit/281c5694e0f4c9f71ea9d4c7cfc63522fc1aa8ff) pgbackrest: 2.48 -> 2.49
* [`64502c3e`](https://github.com/NixOS/nixpkgs/commit/64502c3e091692b4cecbfdf7936d402c2ab67dcb) serverless: use buildNpmPackage
* [`3a41b138`](https://github.com/NixOS/nixpkgs/commit/3a41b138c0783ff5afac1ce8538ad9139da3899e) diffoci: 0.1.2 -> 0.1.4
* [`b48183f5`](https://github.com/NixOS/nixpkgs/commit/b48183f5c9650eaa31fafa18c0d6c3a0c19220d9) doppler: 3.66.3 -> 3.66.5
* [`70ecf339`](https://github.com/NixOS/nixpkgs/commit/70ecf3398d245006986fb4d90876f5b1726c10a9) bazarr: 1.3.1 -> 1.4.0
* [`220c693e`](https://github.com/NixOS/nixpkgs/commit/220c693e6fa0ba3c8611a2349843d67c5f907879) xeus: 3.1.3 -> 3.1.4
* [`c828d263`](https://github.com/NixOS/nixpkgs/commit/c828d263fdbb090a36ba782142d5b6e26d653445) mozillavpn: 2.18.0 → 2.18.1
* [`da82a56a`](https://github.com/NixOS/nixpkgs/commit/da82a56ae50712279f57c451cdde37c544c57fe2) wordpress: default to wordpress6_4
* [`110e5c27`](https://github.com/NixOS/nixpkgs/commit/110e5c27bfbd8f9deceebd6e4930733503bca216) parallel: 20231022 -> 20231122
* [`cee0693d`](https://github.com/NixOS/nixpkgs/commit/cee0693dc0c2664b368eb730f040cead90b40cf3) emacs: set 29 as default version
* [`96bc9478`](https://github.com/NixOS/nixpkgs/commit/96bc94784d55a5ebdf630193d4a349ff1bdf7e19) emacs: remove 28
* [`5a169a41`](https://github.com/NixOS/nixpkgs/commit/5a169a41ffa11015bc8c4178bb9559a0ce99d490) flowblade: 2.10.0.4 -> 2.12
* [`016d7891`](https://github.com/NixOS/nixpkgs/commit/016d7891e95afb5d3e4d2eb59f7e701c2edd1e97) {libqalculate, qalculate-gtk, qalculate-qt}: 4.8.1 -> 4.9.0
* [`90a5c36a`](https://github.com/NixOS/nixpkgs/commit/90a5c36a854f6965115a6f6a6c1b6bf122dccb20) {libqalculate, qalculate-gtk}: change sha256 attribute to hash
* [`1d56e790`](https://github.com/NixOS/nixpkgs/commit/1d56e7909d692b4a8cd52d8d503391e63f279c7a) trivial-builders/test/references-test.sh: lint with ShellCheck
* [`183f8746`](https://github.com/NixOS/nixpkgs/commit/183f87466de7ee1a590e5ead855f53465a72b5e2) maintainsers: add lukas-heiligenbrunner
* [`beae87d5`](https://github.com/NixOS/nixpkgs/commit/beae87d564c4d1843a92a3a011ab3d1042b61a52) appimage-run: add libthai
* [`834d7b76`](https://github.com/NixOS/nixpkgs/commit/834d7b76489ad06a4b6efdb818022d3e0c17d820) trilium-{desktop,server}: 0.62.2 -> 0.62.3
* [`211b645d`](https://github.com/NixOS/nixpkgs/commit/211b645d47d18a3bd307c6057a16490381fb4657) libsForQt5.libopenshot-audio: refactor
* [`eeed1845`](https://github.com/NixOS/nixpkgs/commit/eeed18452e2cfff071fdc69686bbe0ef3dfd39c8) libsForQt5.libopenshot-audio: migrate to libraries
* [`f65b9438`](https://github.com/NixOS/nixpkgs/commit/f65b9438ffb8aa63bb85dcfbde764ea9f23cd50b) libsForQt5.libopenshot: refactor
* [`047d0f2c`](https://github.com/NixOS/nixpkgs/commit/047d0f2c4cf6e36efa4757ddb626a0f0fea4176b) libsForQt5.libopenshot: migrate to libraries
* [`355e6317`](https://github.com/NixOS/nixpkgs/commit/355e6317ba0a1d879c0b89641a2ceebc80a44548) openshot-qt: 3.0.0 -> 3.1.1
* [`dc23ea8c`](https://github.com/NixOS/nixpkgs/commit/dc23ea8ce1c07573291974e9798de00165f128ff) grafx2: fixup desktop file
* [`518f6550`](https://github.com/NixOS/nixpkgs/commit/518f6550420bdecb0d5632ac33cb618d75a9d6e7) python310Packages.dbt-redshift: 1.6.1 -> 1.7.0
* [`917144a8`](https://github.com/NixOS/nixpkgs/commit/917144a854144e54edf38ae06286990f90304a8d) spade: init at 0.5.0
* [`ad5e7447`](https://github.com/NixOS/nixpkgs/commit/ad5e744714640aad36eda89e6b6026c397b4ace5) treewide: finalAttrs.doCheck -> finalAttrs.finalPackage.doCheck
* [`9d5d8af1`](https://github.com/NixOS/nixpkgs/commit/9d5d8af186d1fe453b88b90ac738ba345663e364) zsa-udev-rules: unstable-2022-10-26 -> unstable-2023-11-30
* [`efca3c03`](https://github.com/NixOS/nixpkgs/commit/efca3c0329531a2bdba8a018dff91434257112a3) nixos/teeworlds: reduce closure size
* [`7e5167cb`](https://github.com/NixOS/nixpkgs/commit/7e5167cbbd315315b88b5343cfb9390251b2d485) heroic: 2.10.0 -> 2.11.0
* [`c4b5c76c`](https://github.com/NixOS/nixpkgs/commit/c4b5c76c0d5e54633e4b9467a5a83edb4d2924cd) python310Packages.django-reversion: 5.0.6 -> 5.0.8
* [`9186a4d6`](https://github.com/NixOS/nixpkgs/commit/9186a4d61a40840434e4865999f033cf165c96ee) rl-2311: Minor ToC change
* [`f8550330`](https://github.com/NixOS/nixpkgs/commit/f8550330a092fb5036ea7b9271d88a9126caaf63) rl-2311: Use stable references
* [`13dd600b`](https://github.com/NixOS/nixpkgs/commit/13dd600bf6a4a17ba2f1c4d9cebefb3755444417) python310Packages.duckduckgo-search: 3.9.4 -> 3.9.9
* [`f41aba37`](https://github.com/NixOS/nixpkgs/commit/f41aba37396530c3fca935343069bf29b4564df3) treewide: remove unreferenced patch files
* [`d1e8cfa9`](https://github.com/NixOS/nixpkgs/commit/d1e8cfa97782a508550aed1a4c5d116547d91708) ofono: 2.1 -> 2.2
* [`5f4a3262`](https://github.com/NixOS/nixpkgs/commit/5f4a326244e68adcf1ad27b1eb9a8b3dd15f2423) maintainers: add ninjafb
* [`2d0f4a7e`](https://github.com/NixOS/nixpkgs/commit/2d0f4a7ec19082248094eb04a35c93c94b1d35d5) nixos/nix.nix: Support new Nix 2.20 command syntax
* [`6e44fea7`](https://github.com/NixOS/nixpkgs/commit/6e44fea7961a0403fe2f445dd0cc356373c21280) trippy: 0.8.0 -> 0.9.0
* [`709cd5ed`](https://github.com/NixOS/nixpkgs/commit/709cd5ed8fbc25361f985a51fa342aa848461d29) ytree: 2.05 -> 2.06
* [`2c26073e`](https://github.com/NixOS/nixpkgs/commit/2c26073eaef4bdd14fd263f8f1d8c136b9156155) lanraragi: remove dependency version patch
* [`bb595d0a`](https://github.com/NixOS/nixpkgs/commit/bb595d0a8a9058e4140e7cc11254a13197f2f543) ytree: use finalAttrs desin pattern
* [`e6ab988b`](https://github.com/NixOS/nixpkgs/commit/e6ab988be0c19258652dca0c81c6964725bba324) ytree: migrate to by-name
* [`367e3397`](https://github.com/NixOS/nixpkgs/commit/367e3397a1f88978f44d604224b8c316902c4e92) cocogitto: 5.6.0 -> 6.0.1
* [`1730d667`](https://github.com/NixOS/nixpkgs/commit/1730d667adc78e1f1c4c1f3e70429280d53d5c07) aws-iam-authenticator: 0.6.12 -> 0.6.13
* [`fff45742`](https://github.com/NixOS/nixpkgs/commit/fff45742a172059c559daaf2aeab331a664d5fbe) libmediainfo: 23.10 -> 23.11
* [`8062ed4b`](https://github.com/NixOS/nixpkgs/commit/8062ed4beff02f4e0e18f067a62e743a9e3b948f) mediainfo: 23.10 -> 23.11
* [`f69a2325`](https://github.com/NixOS/nixpkgs/commit/f69a2325c77f184f2ac9855d1ee02926ec1a4355) pkcs11helper: 1.29.0 -> 1.30.0
* [`c117e7b9`](https://github.com/NixOS/nixpkgs/commit/c117e7b919f0ec623a974791575b1751390ac1df) python311Packages.evohome-async: 0.4.11 -> 0.4.12
* [`ed03ef95`](https://github.com/NixOS/nixpkgs/commit/ed03ef9581aec66515be7d57aa002dacac9bcd48) resources: init at 1.2.1
* [`da2543fe`](https://github.com/NixOS/nixpkgs/commit/da2543fef450bb53fabfd26c403a23fd9293ef31) oxigraph: 0.3.20 -> 0.3.21
* [`eecc2530`](https://github.com/NixOS/nixpkgs/commit/eecc2530d9853a84ae55507b5db22bc40a164723) python3Packages.lcd-i2c: init at 0.2.3
* [`4a15b6bd`](https://github.com/NixOS/nixpkgs/commit/4a15b6bd301364b9e2e7cb23fc5f56a05e3036ca) remmina: enable wayland
* [`442c67f9`](https://github.com/NixOS/nixpkgs/commit/442c67f96e09b7aca0849fd7c09a66c40d896a80) timeular: fix hash
* [`b125bb55`](https://github.com/NixOS/nixpkgs/commit/b125bb5583cf0bd7f8d638ab95253776648bfdc4) python311Packages.pyhanko-certvalidator: 0.23.0 -> 0.26.2
* [`1d11692d`](https://github.com/NixOS/nixpkgs/commit/1d11692de2ec046482a6453c24659a2e8af07a2c) python311Packages.pyhanko: 0.20.0 -> 0.21.0
* [`35992ca5`](https://github.com/NixOS/nixpkgs/commit/35992ca5c5468f45fb1bfa691328305ff230b000) usbview: 2.0 -> 3.1
* [`6259a32b`](https://github.com/NixOS/nixpkgs/commit/6259a32b452d693bb5d1892b0d18a93e2d9c876d) usbview: add mainProgram
* [`684fa5f4`](https://github.com/NixOS/nixpkgs/commit/684fa5f4613eedd68620ac825f320e7c03826339) usbview: add h7x4 as maintainer
* [`efdec260`](https://github.com/NixOS/nixpkgs/commit/efdec26090fe6c61327b67d933e39d694da36bc2) treewide: install missing desktopItems
* [`cbc7f381`](https://github.com/NixOS/nixpkgs/commit/cbc7f3810e042d20d378461226054ffebdffc3ea) python311Packages.pyroute2: 0.7.9 -> 0.7.10
* [`f9123510`](https://github.com/NixOS/nixpkgs/commit/f9123510dbe9a2168d8140697ae7e931498dfd6e) kubernetes: don't always open flannel fw ports
* [`bbf1b29b`](https://github.com/NixOS/nixpkgs/commit/bbf1b29bcd5e6cc423f7f09ca517e33de4c3f0b4) droidcam: 2.0.0 -> 2.1.0
* [`0b95fc14`](https://github.com/NixOS/nixpkgs/commit/0b95fc140e0281b38e722824153e118318fc2291) fastmod: 0.4.3 -> 0.4.4
* [`96012ae1`](https://github.com/NixOS/nixpkgs/commit/96012ae1052638373b08bd9d8b0251e93c9bd570) hypnotix: 3.7 -> 4.0
* [`cf1efebe`](https://github.com/NixOS/nixpkgs/commit/cf1efebe8ca685e46a11af1d39c5e923dcfa59ce) linuxPackages.nvidia_x11_vulkan_beta: 535.43.16 -> 535.43.19
* [`274f21f1`](https://github.com/NixOS/nixpkgs/commit/274f21f1f49cc10e5ee52e37b497362f62674cb2) mate.mate-panel: 1.26.3 -> 1.26.4
* [`461255ec`](https://github.com/NixOS/nixpkgs/commit/461255ec058e1880a395bc5158d46e4fd092bb92) python3Packages.webdataset: init at 0.2.79
* [`c1885ddd`](https://github.com/NixOS/nixpkgs/commit/c1885ddd44d4be67c123ce06448d55781501f596) collision: 3.5.0 -> 3.6.0
* [`8a61aa5d`](https://github.com/NixOS/nixpkgs/commit/8a61aa5d37e8025b42ad8843fb7a54214ce2e587) libdeltachat: 1.131.7 -> 1.131.9
* [`5dda2abb`](https://github.com/NixOS/nixpkgs/commit/5dda2abb3f3395c57ca7a626fb092646f6b7ba64) deltachat-desktop: 1.42.1 -> 1.42.2
* [`7b5608e5`](https://github.com/NixOS/nixpkgs/commit/7b5608e5bd7d5197e76f568e54dc3596cfbead3d) maintainers: add Schweber
* [`6660f639`](https://github.com/NixOS/nixpkgs/commit/6660f639da24b925e88600be69372d6fdc812308) mlterm: fix build on darwin/clang_16
* [`6710510c`](https://github.com/NixOS/nixpkgs/commit/6710510c22791692163097d51cec2217e4070d1f) media-downloader: 4.0.0 -> 4.1.0
* [`ef1f6ebd`](https://github.com/NixOS/nixpkgs/commit/ef1f6ebd43ae30205f28a3749aff80bf59d6e3a5) oil: 0.18.0 -> 0.19.0
* [`a3377f1a`](https://github.com/NixOS/nixpkgs/commit/a3377f1ad89d7dad30184b985f5c6a9cddd3ef8c) python310Packages.galois: 0.3.6 -> 0.3.7
* [`0f53cb1b`](https://github.com/NixOS/nixpkgs/commit/0f53cb1b56aab625862eaf379de94fdfb5ef1035) python310Packages.globus-sdk: 3.31.0 -> 3.32.0
* [`573be650`](https://github.com/NixOS/nixpkgs/commit/573be65092f275fcc1f60bb5c79ad1e2ec27b659) python310Packages.glom: 23.3.0 -> 23.5.0
* [`2ddebe76`](https://github.com/NixOS/nixpkgs/commit/2ddebe76c28bd9611b1b8a1c86006888fce04348) python310Packages.gocardless-pro: 1.48.0 -> 1.49.0
* [`7b339bdc`](https://github.com/NixOS/nixpkgs/commit/7b339bdcbe35de32823c57a1e0b034730df63742) python310Packages.google-cloud-asset: 3.20.0 -> 3.20.1
* [`019ef8f3`](https://github.com/NixOS/nixpkgs/commit/019ef8f3cc08db6c03a56970e6f96bd2ed295885) python310Packages.google-cloud-bigquery-storage: 2.22.0 -> 2.23.0
* [`409d6b19`](https://github.com/NixOS/nixpkgs/commit/409d6b1941ff32d2a00ff88f4ee2271b3a54884b) python310Packages.google-cloud-container: 2.33.0 -> 2.35.0
* [`663dbfb8`](https://github.com/NixOS/nixpkgs/commit/663dbfb82d631c8fcc4b6c46a4db3760a99e1c36) nixos/home-assistant: fix custom lovelace module loading
* [`4913d175`](https://github.com/NixOS/nixpkgs/commit/4913d1753f493450df07f2cc954c041c0d7b8c5a) home-assistant-custom-lovelace-modules.light-entity-card: init at 6.1.0
* [`77b73675`](https://github.com/NixOS/nixpkgs/commit/77b73675647ac03bff94068ddfa1136dbb614a67) grype: 0.69.1 -> 0.73.4
* [`55b53ee5`](https://github.com/NixOS/nixpkgs/commit/55b53ee558f3c54f5c9ca494d1996365dd585580) lomiri.lomiri-settings-components: init at 1.0.1
* [`aa89dd7c`](https://github.com/NixOS/nixpkgs/commit/aa89dd7c6d6c9f3611c435ebed550e88166bfda6) lomiri.lomiri-settings-components: 1.0.1 -> 1.1.0
* [`10b8b720`](https://github.com/NixOS/nixpkgs/commit/10b8b720f1706dc3c418f0c21052d68b07f2d50e) proxmox-backup-client: 3.0.1 -> 3.1.2
* [`dce34a5b`](https://github.com/NixOS/nixpkgs/commit/dce34a5be43f6b246ea83175f6cf158d62cfe2bb) proxmox-backup-client: reformat input-list to usual style
* [`ca662816`](https://github.com/NixOS/nixpkgs/commit/ca662816b92f27dc44814d8c430a08b7845da586) lomiri.u1db-qt: init at 0.1.7
* [`6d92d973`](https://github.com/NixOS/nixpkgs/commit/6d92d97372e38fbc0a02a8134ee4be195a27496d) python310Packages.google-cloud-securitycenter: 1.24.0 -> 1.24.1
* [`09002e9d`](https://github.com/NixOS/nixpkgs/commit/09002e9d23eaa33f7cbcd2107e1a9a334154ef3e) nixos/ups: various fixes & clean up
* [`c1793ff6`](https://github.com/NixOS/nixpkgs/commit/c1793ff6236474b9e534c0dbd9805a5037871b3a) nixos/ups: add {users,upsmon,upsd} config options
* [`76c77fa3`](https://github.com/NixOS/nixpkgs/commit/76c77fa3df80998e0538213311894a52a39d8d86) notmuch: 0.38.1 -> 0.38.2
* [`51b3ed8b`](https://github.com/NixOS/nixpkgs/commit/51b3ed8b16e5c4feb99a0e7b75b907729422e9b5) python310Packages.hg-git: 1.0.2 -> 1.0.3
* [`6e760de7`](https://github.com/NixOS/nixpkgs/commit/6e760de78e7a4bb8bec101e233aeef08f776f113) python310Packages.holoviews: 1.18.0 -> 1.18.1
* [`1abaa4ce`](https://github.com/NixOS/nixpkgs/commit/1abaa4cea1e6bed2e61e8870aaff8990ffea91c3) python311Packages.picobox: refactor
* [`c391b7d4`](https://github.com/NixOS/nixpkgs/commit/c391b7d46cd93df29d35c3a16f7c8ecd92c6a93f) xdg-desktop-portal-xapp: 1.0.3 -> 1.0.4
* [`f4df7ea9`](https://github.com/NixOS/nixpkgs/commit/f4df7ea9887a2f8919d280a5a8769375d6908f43) matlab-language-server: init at 1.1.6
* [`388554bc`](https://github.com/NixOS/nixpkgs/commit/388554bc12d2c4569c2ee9eeae8a624c7984fbe6) deepgit: 4.3.1 -> 4.4
* [`46190c26`](https://github.com/NixOS/nixpkgs/commit/46190c26586ddfcc05a2ed64d9426fced68bb7b2) scaleway-cli: 2.24.0 -> 2.25.0
* [`4ed2fdd3`](https://github.com/NixOS/nixpkgs/commit/4ed2fdd34b4cccbf71f8089b6d4c5c043e16f89b) haskell-language-server: fix build with lsp 2.3
* [`cb7ba3fd`](https://github.com/NixOS/nixpkgs/commit/cb7ba3fde402d65584b888ea354bdaf29bb856b9) gnomeExtensions: autoupdate
* [`5f1da6e0`](https://github.com/NixOS/nixpkgs/commit/5f1da6e04566d45c8f8d05d938e619c93e53a4c3) scripts/haskell/hydra-report: use inline emoji
* [`8667baf1`](https://github.com/NixOS/nixpkgs/commit/8667baf161e3f705f56c1bdd9cc48f187a3627a6) nixos/redmine: Fix database assertions
* [`1e5e9a95`](https://github.com/NixOS/nixpkgs/commit/1e5e9a9503c6d4a5d84c0f0a09d9028328bf0c80) Adding dbus (secret manager) and app indicator
* [`77bde146`](https://github.com/NixOS/nixpkgs/commit/77bde146f4f80174e078ba565625a45c9d934da3) python310Packages.i-pi: 2.4.0 -> 2.6.1
* [`1bc79073`](https://github.com/NixOS/nixpkgs/commit/1bc79073dd462e32465dbb02deeb1d48ad3957c9) xfce.mkXfcederivation: Fix ofborg maintainer ping
* [`64b67b14`](https://github.com/NixOS/nixpkgs/commit/64b67b14a63959218d44677a3a26a9e97bf4100a) python310Packages.subliminal: mark as broken
* [`79567db9`](https://github.com/NixOS/nixpkgs/commit/79567db9149d508c99f03b83b7fed6d32faaa971) pjsip: fix build on clang/darwin
* [`d873210f`](https://github.com/NixOS/nixpkgs/commit/d873210f1eb182d4dea8e116d291f8d58600ee16) pjsip: 2.13.1 -> 2.14
* [`7da500d7`](https://github.com/NixOS/nixpkgs/commit/7da500d7cbcc6fbb02e021041395039a6b808e0c) php: add flags for static build and zend engine tweaks
* [`21e686ea`](https://github.com/NixOS/nixpkgs/commit/21e686eaec7d5527fa5ee22ca2d18a3ba23b106f) frankenphp: add darwin support
* [`93a0b21b`](https://github.com/NixOS/nixpkgs/commit/93a0b21b821255926c2b3fa93398d7171b0943a0) Adding dbus (secret manager) and app indicator
* [`edbc1427`](https://github.com/NixOS/nixpkgs/commit/edbc14275838c7d018d2a55a54df40e8ea3189b0) python310Packages.inquirer: 3.1.3 -> 3.1.4
* [`5568a104`](https://github.com/NixOS/nixpkgs/commit/5568a1043c570f02be9522d0f5aa1acfb6a5156d) python310Packages.intellifire4py: 3.1.30 -> 3.5.0
* [`1ccdf7c3`](https://github.com/NixOS/nixpkgs/commit/1ccdf7c36905a785ba4451973928801cf0a02789) fusuma: 3.1.0 -> 3.3.1
* [`f17155ae`](https://github.com/NixOS/nixpkgs/commit/f17155ae1348c8dacd90ee6a8426ee18407ea36a) video-trimmer: use ffmpeg-headless, to reduce closure
* [`ba0dc5b5`](https://github.com/NixOS/nixpkgs/commit/ba0dc5b5d3007816cd0f5b9520d8bbb15365fd93) python311Packages.example-robot-data: 4.0.8 -> 4.0.9
* [`7697f2ef`](https://github.com/NixOS/nixpkgs/commit/7697f2ef7f17a22747e1b9e4dc16120a173ed483) spark: 3.4.1->3.4.2
* [`550b95e2`](https://github.com/NixOS/nixpkgs/commit/550b95e22c148071bf155573f9ced0bf96e2d408) bup: Fix build on Darwin with LLVM 16
* [`193f6e7f`](https://github.com/NixOS/nixpkgs/commit/193f6e7fd279dbafd764c0886a6ee952e5b1316e) python310Packages.jplephem: 2.20 -> 2.21
* [`2f96d436`](https://github.com/NixOS/nixpkgs/commit/2f96d436cef9ad44198f7dfb7cd2ab83445bfc0c) istioctl: 1.18.2 -> 1.20.0
* [`ae4d17ab`](https://github.com/NixOS/nixpkgs/commit/ae4d17ab6e363f46eaadb0881780b8b5ffb8019f) python3Packages.python-mapnik: disable more failing tests
* [`73b4f7b9`](https://github.com/NixOS/nixpkgs/commit/73b4f7b939d0153e7c5d65314afe225a4d862532) jetbrains.jdk: 17.0.7-b829.16 -> 17.0.8-b1000.8
* [`17bc746f`](https://github.com/NixOS/nixpkgs/commit/17bc746f1f992e6f8043f152e9b3d094c8f18236) jetbrains.jdk-no-jcef: init at 17.0.8-b1000.8
* [`3b53d2b1`](https://github.com/NixOS/nixpkgs/commit/3b53d2b1378e9c9a6aea1b9137f51bc69bc45184) jetbrains.*: overhaul, add source builds for pycharm and idea
* [`f6e48acf`](https://github.com/NixOS/nixpkgs/commit/f6e48acfa21ba34298e976c327939567135e1acc) gcc8: support avr cross compilation on aarch64-darwin
* [`7bb88994`](https://github.com/NixOS/nixpkgs/commit/7bb88994c146189d3caac37b049ab518ced4350f) libfmvoice: init at 0.0.0-unstable-2023-05-21
* [`0a152135`](https://github.com/NixOS/nixpkgs/commit/0a152135e37830a8d50475951d693a4660fea65a) vgm2x: init at 0.0.0-unstable-2023-05-10
* [`e64a3937`](https://github.com/NixOS/nixpkgs/commit/e64a39372f7e455d8ec861a0c9eaeed81835402c) fmtoy: unstable-2022-12-23 -> 0.0.0-unstable-2023-05-21
* [`a585f940`](https://github.com/NixOS/nixpkgs/commit/a585f9402c16e16019b5e4b872085cdbe24bae41) fmtoy: Move to pkgs/by-name
* [`08038ebd`](https://github.com/NixOS/nixpkgs/commit/08038ebd545060a813554d70e1b893412d80cf89) vgm2x: 0.0.0-unstable-2023-05-10 -> 0.0.0-unstable-2023-08-27
* [`a9ffe197`](https://github.com/NixOS/nixpkgs/commit/a9ffe1975c063568059a15e863fad7a019cfa8d0) hyfetch: 1.4.10 -> 1.4.11
* [`869dfeb6`](https://github.com/NixOS/nixpkgs/commit/869dfeb6f255a3b1d08d88073ce5d0a99ca8b6f4) python310Packages.jsbeautifier: 1.14.9 -> 1.14.11
* [`89590d2a`](https://github.com/NixOS/nixpkgs/commit/89590d2a02628d29d87e64443a9c5374ffb26daf) python311Packages.psycopg: 3.1.13 -> 3.1.14
* [`612e91db`](https://github.com/NixOS/nixpkgs/commit/612e91db9a81abb53884990025979f7011af6b0c) haruna: use `ffmpeg-headless` over `ffmpeg-full`
* [`ead3e80d`](https://github.com/NixOS/nixpkgs/commit/ead3e80dd1eebf5215befbc83a50f140ca6a4c4b) python310Packages.labelbox: 3.56.0 -> 3.57.0
* [`ec44c740`](https://github.com/NixOS/nixpkgs/commit/ec44c740ca262a3055a0c076d59db96f9a227e8c) python310Packages.labgrid: 23.0.3 -> 23.0.4
* [`0ebea895`](https://github.com/NixOS/nixpkgs/commit/0ebea895518328b58d169c27860433d5594f4823) qt6.qtmultimedia: Enable Spatial Audio (Quick3D)
* [`ed972a40`](https://github.com/NixOS/nixpkgs/commit/ed972a40b2f3f8b2185f6ecfc7cad859e4d9550a) router: add CVE-2023-45812 to knownVulnerabilities
* [`91b8e472`](https://github.com/NixOS/nixpkgs/commit/91b8e472a5b7661bcc2f930a1abe14881f335a73) qt6.qtmultimedia: Compile ffmpeg multimedia plugin
* [`d3de574b`](https://github.com/NixOS/nixpkgs/commit/d3de574b8ccc0e98b4490197265f60b03b36c0e9) qt6.qtmultimedia: Compile hardware-accelerated VAAPI
* [`7e886531`](https://github.com/NixOS/nixpkgs/commit/7e886531a2b9be8ca3fd43bde8e82cbae9b9e4a0) qt6.qtmultimedia: Fix failure to load libva.so
* [`1d17fa36`](https://github.com/NixOS/nixpkgs/commit/1d17fa361b0fe462ecdc67b623e6b68578bf4c18) vimPlugins.wtf-nvim: init at 2023-11-11
* [`393847dd`](https://github.com/NixOS/nixpkgs/commit/393847ddf81675da96fe76b037a03ee2fa170853) vimPlugins: update on 2023-12-03
* [`de1aca9b`](https://github.com/NixOS/nixpkgs/commit/de1aca9bcf597856fbe22babff3481646195fdb7) vimPlugins.nvim-treesitter: update grammars
* [`7a553c4d`](https://github.com/NixOS/nixpkgs/commit/7a553c4d2962266fae443c3c17d134e9279d819e) python310Packages.langsmith: 0.0.63 -> 0.0.69
* [`8397b95d`](https://github.com/NixOS/nixpkgs/commit/8397b95db8ef6a6510de3ed2842f6b9dba39f057) nix-doc: 0.6.2 -> 0.6.4
* [`5286ff07`](https://github.com/NixOS/nixpkgs/commit/5286ff070a0631800f328ce77172d7b185d59866) grafana: 10.2.0 -> 10.2.2
* [`294645a0`](https://github.com/NixOS/nixpkgs/commit/294645a07a96e2135a3ff43cee7a8585665c8c65) python310Packages.latexify-py: 0.4.1 -> 0.4.2
* [`2cd2b63f`](https://github.com/NixOS/nixpkgs/commit/2cd2b63f8397fcb4a34080790ae793c8b2f0bfce) git-town: fix passthru tests
* [`db4ce465`](https://github.com/NixOS/nixpkgs/commit/db4ce465edd23222973fff494b0cc3a522d7a3dc) handlr-regex: migrate to pkgs/by-name
* [`740b9853`](https://github.com/NixOS/nixpkgs/commit/740b9853a6f4d57decea5099cdb65f3601ac5fdb) lomiri.lomiri-app-launch: init at 0.1.8
* [`5bf787f8`](https://github.com/NixOS/nixpkgs/commit/5bf787f8c21c0502e7874abd4cc84ca656a11a1a) pat: 0.15.0 -> 0.15.1
* [`cbf69c83`](https://github.com/NixOS/nixpkgs/commit/cbf69c83d3b2bdc5eca341aa9e44e0406794af81) nixos/mastodon: clarify the need to set streamingProcesses
* [`e673ae14`](https://github.com/NixOS/nixpkgs/commit/e673ae14059391e00cf2a55cb6611948502c7730) fcitx5-bamboo: init at 1.0.4
* [`bbf87577`](https://github.com/NixOS/nixpkgs/commit/bbf875773f5e84913154cf3555dfc5b9e621a294) zsh-vi-mode: set platforms
* [`931de380`](https://github.com/NixOS/nixpkgs/commit/931de380e145386b34fd75dd36eee5f61eadd3ad) olive-editor: fix build by pinning openimageio to 2.4.15.0
* [`e8d71f69`](https://github.com/NixOS/nixpkgs/commit/e8d71f6901f728999168b8fbffbed319dff5c27f) handlr-regex: 0.8.5 -> 0.9.0
* [`df6a845b`](https://github.com/NixOS/nixpkgs/commit/df6a845b71064dfdde801a0962e1dac76258fa51) aws-workspaces: 4.6.0 include missing xcbutil dependency
* [`69d4020b`](https://github.com/NixOS/nixpkgs/commit/69d4020bbbf061029f80f5956ee5a5064c25d64a) polyml: move definition of `src` attribute to standard location
* [`3e320a2a`](https://github.com/NixOS/nixpkgs/commit/3e320a2ada9e43ddd32094c3806b3666d9994a3a) polyml: enable tests
* [`0108269b`](https://github.com/NixOS/nixpkgs/commit/0108269b3882c72e60fa4d24b4ab3d586b8ef8e0) python311Packages.html2image: init at 2.0.4.3
* [`5f69f0ed`](https://github.com/NixOS/nixpkgs/commit/5f69f0ed2eb1751e24e0cb7f4100bd973dd2db69) python311Packages.openai: 0.28.1 -> 1.3.7
* [`9e71df9f`](https://github.com/NixOS/nixpkgs/commit/9e71df9f5ef28c3868430b50c9e532b34a719751) python311Packages.litellm: 0.11.1 -> 1.7.11
* [`214197d7`](https://github.com/NixOS/nixpkgs/commit/214197d7e2f8f441c28304916ddba95f7344f80e) python310Packages.logbook: 1.6.0 -> 1.7.0.post0
* [`3768e103`](https://github.com/NixOS/nixpkgs/commit/3768e103ef9786850fb2fdca268f387c03c962f4) pynitrokey: 0.4.42 -> 0.4.43
* [`1105fa7e`](https://github.com/NixOS/nixpkgs/commit/1105fa7e134a5baa7ad416ac56797e9aab8e9f21) monophony: 2.3.1 -> 2.4.0
* [`673c8d72`](https://github.com/NixOS/nixpkgs/commit/673c8d72ca29bc6a3d69008e4ca76947f4b5827a) sshx: split components, unstable-2023-11-04 -> unstable-2023-11-23
* [`54557f8b`](https://github.com/NixOS/nixpkgs/commit/54557f8bfa59351354524053d4787ce2ee5c4f90) sshx-server: add web ui
* [`34deb05e`](https://github.com/NixOS/nixpkgs/commit/34deb05e5599997d5685387e4f44376915f1e561) nixos/buildbot: fix worker package
* [`e270b7be`](https://github.com/NixOS/nixpkgs/commit/e270b7beff7c137a8aa0d34867e960febd2a346c) php: use a versioned url for install-pear-nozlib.phar
* [`3f916c8d`](https://github.com/NixOS/nixpkgs/commit/3f916c8d59ab7d8e4c9b9cc107f4711064a7b3cf) starsector: added missing build input
* [`f88ba5ea`](https://github.com/NixOS/nixpkgs/commit/f88ba5ea192736529d7b2a1ab1490624953c38f2) ocamlPackages.gluten: 0.3.0 → 0.5.0
* [`f9972484`](https://github.com/NixOS/nixpkgs/commit/f997248425ec535993a905f0ad676593103e5182) ocamlPackages.gluten-eio: init at 0.5.0
* [`e76d8d1a`](https://github.com/NixOS/nixpkgs/commit/e76d8d1a326fcbdde58241d4e6d1c9716823c460) python310Packages.meep: 1.27.0 -> 1.28.0
* [`4e5d8476`](https://github.com/NixOS/nixpkgs/commit/4e5d847614831d79759cdcbfa83b4b5e7f6f1870) python310Packages.mkdocs-swagger-ui-tag: 0.6.6 -> 0.6.7
* [`515f0d1b`](https://github.com/NixOS/nixpkgs/commit/515f0d1b59abaa8194c75544eb0d8859915a3edd) python310Packages.mkdocstrings: 0.23.0 -> 0.24.0
* [`608e8f6e`](https://github.com/NixOS/nixpkgs/commit/608e8f6e87c385545bf353e069d0e8ea8db00d65) python310Packages.millheater: 0.11.6 -> 0.11.7
* [`eefffd00`](https://github.com/NixOS/nixpkgs/commit/eefffd003a2c2cac2206e48ea9801bfa5ccee74b) python310Packages.mkdocstrings: refactor
* [`e4c124c5`](https://github.com/NixOS/nixpkgs/commit/e4c124c5a1741478ba8279951869beec642dfa17) treewide: replace `inherit (libsForQt5)` with `libsForQt5.callPackage` where possible
* [`fc8fa7c2`](https://github.com/NixOS/nixpkgs/commit/fc8fa7c26bd4033979de1eddf01fbc8e061121b2) treewide: remove unused qmake and cmake
* [`c8b52e55`](https://github.com/NixOS/nixpkgs/commit/c8b52e55f76f9d75bccc20e9beb33f96af994f0d) kor: initial at 0.3.0
* [`9a9459f2`](https://github.com/NixOS/nixpkgs/commit/9a9459f211f1ee8b114f50d0d307ea46f490e585) python310Packages.netapp-ontap: 9.13.1.0 -> 9.14.1.0
* [`75e326dc`](https://github.com/NixOS/nixpkgs/commit/75e326dcb79c6980bba267508a32ff9e7e5b0e45) proj: 9.3.0 -> 9.3.1
* [`c817976d`](https://github.com/NixOS/nixpkgs/commit/c817976de50d26c5c6593af6dc234ada9245d1f0) pulumi-bin: 3.94.0 -> 3.95.0
* [`a358f634`](https://github.com/NixOS/nixpkgs/commit/a358f6347aae695c52c39f9f54799c67daa855b2) python310Packages.numpy-stl: 3.0.1 -> 3.1.1
* [`451238c2`](https://github.com/NixOS/nixpkgs/commit/451238c21663fd523bf8301fc32a5c8c300b68b6) python311Packages.syncedlyrics: 0.6.1 -> 0.7.0
* [`1f3e5702`](https://github.com/NixOS/nixpkgs/commit/1f3e570272d9aa504808fe9c418b36a80f7d4085) python311Packages.syncedlyrics: refactor
* [`043094ee`](https://github.com/NixOS/nixpkgs/commit/043094ee053e5f0e5b0a7c5517fb32c8c002bacd) gdal: disable test failing with PROJ 9.3.1
* [`bab591bb`](https://github.com/NixOS/nixpkgs/commit/bab591bb0b39cd2b4138d8b8b00d99b3f5f4f5ff) python310Packages.oci: 2.113.0 -> 2.117.0
* [`406772bf`](https://github.com/NixOS/nixpkgs/commit/406772bf9953775aa19ddadb6abde5681a1d916e) python310Packages.oauthenticator: 16.2.0 -> 16.2.1
* [`00accfe5`](https://github.com/NixOS/nixpkgs/commit/00accfe5651cdd279e9b705f592e387c5fc4e129) vscode-extensions.davidanson.vscode-markdownlint: 0.52.0 -> 0.53.0
* [`14ef2bb6`](https://github.com/NixOS/nixpkgs/commit/14ef2bb6aec19753e4111a70ac7ac8c9d800cbe9) wrangler: Fix broken workerd on linux
* [`f729a8e6`](https://github.com/NixOS/nixpkgs/commit/f729a8e68c9e722946127f8d75aa27eda65f79d8) fastgron: 0.6.5 -> 0.7.0
* [`43029b50`](https://github.com/NixOS/nixpkgs/commit/43029b506fcf3dc2a346c9ac3003e8ab93348f77) weechat-unwrapped: 4.1.1 -> 4.1.2
* [`7fba22e3`](https://github.com/NixOS/nixpkgs/commit/7fba22e321209e45d14264da6d169d614d26fbd7) linuxKernel.kernels.linux_zen: 6.6.3-zen1 -> 6.6.4-zen1
* [`3d00512f`](https://github.com/NixOS/nixpkgs/commit/3d00512fce24402f2d6a3580d1d4238dda7f2139) linuxKernel.kernels.linux_lqx: 6.6.3-lqx1 -> 6.6.4-lqx1
* [`26bb95da`](https://github.com/NixOS/nixpkgs/commit/26bb95dae986aa902d4596287a3a9b37328f7b4b) python311Packages.azure-identity: fix propogatedBuildImports and darwin
* [`66ec462b`](https://github.com/NixOS/nixpkgs/commit/66ec462bfd4d294323db26ed2b1c49a245e79ece) python310Packages.oelint-parser: 2.11.6 -> 2.12.0
* [`f509382c`](https://github.com/NixOS/nixpkgs/commit/f509382c11ed445b52f249efa6e2fe66d1b56fa7) node-red_service: correct package to nodePackages.node-red
* [`a449e06d`](https://github.com/NixOS/nixpkgs/commit/a449e06d5fb1aa174ff5e6f7c429d2f02e1b5548) rustc-wasm32: fix build
* [`c64d6957`](https://github.com/NixOS/nixpkgs/commit/c64d69574ac1c00be11d77c72003560c1b522267) python3.pkgs.ariadne: remove opentracing dependency ([nixos/nixpkgs⁠#271999](https://togithub.com/nixos/nixpkgs/issues/271999))
* [`a8f317f6`](https://github.com/NixOS/nixpkgs/commit/a8f317f6dccbc6c21719510fdebf0f3638626217) fwupd: 1.9.9 -> 1.9.10
* [`e6656031`](https://github.com/NixOS/nixpkgs/commit/e6656031649fb46d4cd0b5dcca4620be5dfe1c83) perl-debug-adapter: init at 1.0.5
* [`53c3732f`](https://github.com/NixOS/nixpkgs/commit/53c3732fa4cc7f48ccc5b69a45eb7a37d629572a) python310Packages.opencensus-ext-azure: 1.1.11 -> 1.1.12
* [`dea51af6`](https://github.com/NixOS/nixpkgs/commit/dea51af6ec537b0efa22d63391118b9d6eb5962a) bruno: 1.3.0 -> 1.3.1
* [`223f3907`](https://github.com/NixOS/nixpkgs/commit/223f39072360441f9dd9642fc8ff55b34fa17f44) cinnamon.bulky: 3.0 -> 3.1
* [`24cc57ad`](https://github.com/NixOS/nixpkgs/commit/24cc57ad9047ae1fbcc9b5c2a709d632c0669e3c) cinnamon.cinnamon-translations: 6.0.0 -> 6.0.1
* [`02315392`](https://github.com/NixOS/nixpkgs/commit/02315392b77aa8877e1094d4bb7c82c8d5fa88ee) cinnamon.folder-color-switcher: 1.5.9 -> 1.6.0
* [`89aef20d`](https://github.com/NixOS/nixpkgs/commit/89aef20db3231b3ca9dbc020a2d2a5541e5ce53b) cinnamon.pix: 3.2.0 -> 3.2.1
* [`370581e4`](https://github.com/NixOS/nixpkgs/commit/370581e4c9303640c448ad1fb675044147088dd2) cinnamon.xapp: 2.8.0 -> 2.8.1
* [`72a1775c`](https://github.com/NixOS/nixpkgs/commit/72a1775c273ef93bfe013ac79b535283edcc032c) cinnamon.xreader: 3.8.3 -> 3.8.4
* [`f8c95bdc`](https://github.com/NixOS/nixpkgs/commit/f8c95bdc6eb72aae54c9d4b049c95fa451ecaf3d) cinnamon.xviewer: 3.4.2 -> 3.4.3
* [`a50e21b2`](https://github.com/NixOS/nixpkgs/commit/a50e21b2398292ed22747f6347e8dc95c5b7ba01) lightdm-slick-greeter: 2.0.0 -> 2.0.1
* [`75d83252`](https://github.com/NixOS/nixpkgs/commit/75d832528d0fb2b3a6b4ea2f50e7ff3814936dde) xed-editor: 3.4.3 -> 3.4.4
* [`4cbd7d15`](https://github.com/NixOS/nixpkgs/commit/4cbd7d153ecb9be6ec1aaa4a0688dbeedd0bb8f0) sing-box: 1.7.1 -> 1.7.2
* [`d612c3fc`](https://github.com/NixOS/nixpkgs/commit/d612c3fc827e8cbb3098c8f3cd069ee8ac09b2af) satty: 0.7.0 -> 0.8.0
* [`023cd82d`](https://github.com/NixOS/nixpkgs/commit/023cd82d0402e74886696699f9b681e9dc7194f0) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.17.5 -> 0.17.10
* [`c98f07b4`](https://github.com/NixOS/nixpkgs/commit/c98f07b42223774b8be0b521750a1ec717bd9bf0) compass: use bundlerEnv
* [`8e653122`](https://github.com/NixOS/nixpkgs/commit/8e65312288be643faa0a75a0b80995b565a1b494) pls: 5.4.0 -> 0.0.1-beta.2
* [`6ab8c1f6`](https://github.com/NixOS/nixpkgs/commit/6ab8c1f6b3144d176af6ca6d0db23eb2674d843f) guile: Fix posix_spawn use on Darwin, Hurd, and other platforms
* [`c77b10b4`](https://github.com/NixOS/nixpkgs/commit/c77b10b41ba82f1913944bae1504a4120c4efdd6) hydra_unstable: 2023-12-01 -> 2023-12-04
* [`08419410`](https://github.com/NixOS/nixpkgs/commit/084194100c0d39ecfd4b4fb9d21551ceccab9c1b) rure: update Cargo.lock
* [`e9269d82`](https://github.com/NixOS/nixpkgs/commit/e9269d82f7842c0c3050c402ee98ebfdc20524bb) python311Packages.torchaudio: fix build when cudaSupport is enabled
* [`ecdbabb2`](https://github.com/NixOS/nixpkgs/commit/ecdbabb2a30afb075664caf0bf2b568ffd7acd88) python310Packages.particle: 0.23.0 -> 0.23.1
* [`ac3ce007`](https://github.com/NixOS/nixpkgs/commit/ac3ce007c77dff5793eec96b0c3e415d06babc49) vault: 1.14.4 -> 1.14.7
* [`425c2c4c`](https://github.com/NixOS/nixpkgs/commit/425c2c4cf7b17da6c7686ac3c73aaeac4fbc80b7) maintainers/team-list: init lxc team
* [`6765aac1`](https://github.com/NixOS/nixpkgs/commit/6765aac1542f5339b85a3720ffc90a5093e7151b) treewide/lxc: set lxc team as maintainer
* [`d626de5a`](https://github.com/NixOS/nixpkgs/commit/d626de5a59f75205dcf9131e19c58dd2976cafe5) lxcfs: remove with lib
* [`ccb7b8e3`](https://github.com/NixOS/nixpkgs/commit/ccb7b8e3095adb7096596df6f03eb57a542aec58) nixos/lxcfs: remove with lib
* [`27064dd7`](https://github.com/NixOS/nixpkgs/commit/27064dd722bb233ed13d23cfd4e062cf09be9f08) nixos/lxc: remove with lib
* [`f8160d88`](https://github.com/NixOS/nixpkgs/commit/f8160d8856f3f385a060b6324ed62a125b9833d2) lxc: remove with lib
* [`98ff28fa`](https://github.com/NixOS/nixpkgs/commit/98ff28fa7997a31a0a544f9aee04b998827c7d2f) python310Packages.peaqevcore: 19.5.20 -> 19.5.21
* [`9b6b9349`](https://github.com/NixOS/nixpkgs/commit/9b6b934949a02ef19868f76df0f5dbcef67a8278) nixos/clevis: guard zfs code behind config.clevis.boot.initrd.enable
* [`c7c4982b`](https://github.com/NixOS/nixpkgs/commit/c7c4982bff474195749fe24629ff7ae79772b8e9) prettypst: init at unstable-2023-11-27
* [`4803b4b5`](https://github.com/NixOS/nixpkgs/commit/4803b4b51775e6d89f2846a852a837c986b4e1af) openems: unstable-2020-02-15 -> v0.0.36
* [`85aa2d80`](https://github.com/NixOS/nixpkgs/commit/85aa2d80defe7c7d7fec62a59aab158937fd4e2f) vault-bin: fix license as 1.15 and later is unfree bsl11
* [`28608b04`](https://github.com/NixOS/nixpkgs/commit/28608b04486f5c9218ba6b74f347456253ea9f4f) nixos/clevis: skip filesystem with null devices
* [`a267c5b9`](https://github.com/NixOS/nixpkgs/commit/a267c5b907e75fb81302dbda1ee8d38d050f150a) vault-bin: 1.15.2 -> 1.15.3
* [`83a989d4`](https://github.com/NixOS/nixpkgs/commit/83a989d4af7b2f34d11da1a893f4d98c7624b347) openmm: 8.0.0 -> 8.1.0
* [`9a8efb40`](https://github.com/NixOS/nixpkgs/commit/9a8efb40fc2afd38f306fccc370e012af71f679e) checkov: 3.1.20 -> 3.1.21
* [`3a43a0c7`](https://github.com/NixOS/nixpkgs/commit/3a43a0c77c810d3a957e377a320b0855ee8c2cbe) python311Packages.opower: 0.0.39 -> 0.0.40
* [`b3379839`](https://github.com/NixOS/nixpkgs/commit/b33798399623ceca802f2b71a075dbb246c03fc3) wannier90: init at 3.1.0
* [`36fbaa0d`](https://github.com/NixOS/nixpkgs/commit/36fbaa0de4ba40984daae894f1ab3ce5d8c9f76e) libmbd: init at 0.12.7
* [`50fc2bfb`](https://github.com/NixOS/nixpkgs/commit/50fc2bfb8bbb28356d39f891eec31ea1a31db633) quantum-espresso: 6.6 -> 7.2
* [`71336eeb`](https://github.com/NixOS/nixpkgs/commit/71336eebdd01a4de556736b2b9644d5067045410) setzer: 62 -> 63
* [`a2679772`](https://github.com/NixOS/nixpkgs/commit/a2679772153393457710d581ecfb5029d9e75745) typst: 0.9.0 -> 0.10.0
* [`6444a095`](https://github.com/NixOS/nixpkgs/commit/6444a0957bd825e454382d5e7211865afe8ab534) mpvScripts.buildLua: Generate the correct `scriptName` for directories
* [`3bb1ff16`](https://github.com/NixOS/nixpkgs/commit/3bb1ff16f83f2265094769bdc88d7c740a62a1f0) python310Packages.piccolo-theme: 0.18.0 -> 0.19.0
* [`10ac7f01`](https://github.com/NixOS/nixpkgs/commit/10ac7f01aba9d5ca28553fa7eb707f6b35998f82) python311Packages.evohome-async: add mainProgram
* [`418ec136`](https://github.com/NixOS/nixpkgs/commit/418ec13660fecfb437d0f361c2a36b79deb42027) python311Packages.evohome-async: 0.4.12 -> 0.4.13
* [`2252b262`](https://github.com/NixOS/nixpkgs/commit/2252b26260f64ab7d21bddd3b6d1ceb2564c30c2) python3Packages.jaxlib-bin: move asserts to broken to avoid breaking eval
* [`ccdb9285`](https://github.com/NixOS/nixpkgs/commit/ccdb9285bcc4d122771c69251a32dd13ab034f61) python311Packages.bluetooth-data-tools: 1.15.0 -> 1.17.0
* [`385e6d0a`](https://github.com/NixOS/nixpkgs/commit/385e6d0a14b40a92f869bebcbab913713a049be6) python311Packages.habluetooth: init at 0.5.1
* [`ce2dcc6d`](https://github.com/NixOS/nixpkgs/commit/ce2dcc6dcb6bdbb6c1be5799ac14aa4874a8739c) mpvScripts.buildLua: Handle explicitly-recursive attrsets
* [`492f6628`](https://github.com/NixOS/nixpkgs/commit/492f662817bfd1191b409fb7ee09cf6af847361b) mpvScripts.uosc: refactor with `buildLua`
* [`cf861f91`](https://github.com/NixOS/nixpkgs/commit/cf861f91752b0d2a81e96f22dee187eccf740f0c) mpvScripts.uosc: 4.7.0 → 5.1.1
* [`ebef0c31`](https://github.com/NixOS/nixpkgs/commit/ebef0c31074009f49a7d2e900deff099137ed0fd) cudaPackages.nccl-tests: support building with CUDA < 11.4 with cudatoolkit
* [`0e8c66d7`](https://github.com/NixOS/nixpkgs/commit/0e8c66d7c1a663803c0c5aa13298a7f20aaee0e9) python310Packages.plaid-python: 18.0.0 -> 18.2.0
* [`4e40a200`](https://github.com/NixOS/nixpkgs/commit/4e40a200f55a2160fadbfbe37901fe9c65b7c737) haskellPackages: mark builds failing on hydra as broken
* [`5ac7bc51`](https://github.com/NixOS/nixpkgs/commit/5ac7bc5197516267524bfc740456f700867745fb) ncurses: gate postFixup related to unicode support (closes [nixos/nixpkgs⁠#271716](https://togithub.com/nixos/nixpkgs/issues/271716))
* [`0f248f30`](https://github.com/NixOS/nixpkgs/commit/0f248f30536c2a1e9d3dbbd78e56538b37ef3955) python310Packages.podman: 4.8.0 -> 4.8.0.post1
* [`3ac584ce`](https://github.com/NixOS/nixpkgs/commit/3ac584ced04c3580cd3a7c3cbdb175eaba4bf22d) x264: Add mingw32 hostPlatform support
* [`87724c94`](https://github.com/NixOS/nixpkgs/commit/87724c94c3950a50c66661c7132254ee13f7370f) mastodon: 4.2.1 -> 4.2.2
* [`46f14d30`](https://github.com/NixOS/nixpkgs/commit/46f14d30aa6a57dfdc008901b2d58c54365a0290) haskell.compiler.ghc884: remove at 8.8.4
* [`01052abf`](https://github.com/NixOS/nixpkgs/commit/01052abf25a9458f7a43a08974dfdb65329923ac) cone: unstable-2021-07-25 -> unstable-2022-12-12
* [`ae29d067`](https://github.com/NixOS/nixpkgs/commit/ae29d067ffef9693dcd5b1b9c4c4eafca2f87ac9) llvmPackages_7: remove at 7.1.0
* [`ea7faf9d`](https://github.com/NixOS/nixpkgs/commit/ea7faf9d9e2add046b819aab954932121a508633) haskell.compiler.ghc865Binary: clean up unused aarch64-linux src
* [`bd151aad`](https://github.com/NixOS/nixpkgs/commit/bd151aad5bceba29d3c78f4df848ef9fabe55939) haskell.compiler.ghc865Binary: correct useLLVM condition
* [`274c1f09`](https://github.com/NixOS/nixpkgs/commit/274c1f0970e715ba4793fcd68b666af03a79a83e) haskell.compiler.ghc865Binary: don't pass llvmPackages_6
* [`bb5dbaa4`](https://github.com/NixOS/nixpkgs/commit/bb5dbaa4fa0cb3d9ca93372291b57f9844bd71cf) maude: remove clang version special casing
* [`8c59811e`](https://github.com/NixOS/nixpkgs/commit/8c59811e4eabfc15896aea584dfb58f9bd227cf5) root5: broken with clang
* [`5bf016e1`](https://github.com/NixOS/nixpkgs/commit/5bf016e1e98accfd62c5bbd5a6dea3049af72595) python3Packages.torch: enable cuDNN & NCCL only if available
* [`d23df73a`](https://github.com/NixOS/nixpkgs/commit/d23df73a07a8cb8a3b8fb0630a8a861a2afc74b6) ctranslate2: enable cuDNN only if it is available
* [`31607456`](https://github.com/NixOS/nixpkgs/commit/31607456eeb8eff28603e0ee56493b0ac166fec1) python3Packages.tensorflow: move asserts to broken to avoid breaking eval
* [`61468b5f`](https://github.com/NixOS/nixpkgs/commit/61468b5f11e6fd91ae1936742b2f5910208023c9) python310Packages.policyuniverse: 1.5.1.20230817 -> 1.5.1.20231109
* [`5b43e781`](https://github.com/NixOS/nixpkgs/commit/5b43e78193b35919df3cf845c06030b241eebf97) buildDotnetModule: fix rare error when evaluation of version fails
* [`d2800c58`](https://github.com/NixOS/nixpkgs/commit/d2800c585b0b69c7f531860331b2a9223065e8a9) cudaPackages.nccl: support building with CUDA < 11.4 with cudatoolkit
* [`5bda2ec6`](https://github.com/NixOS/nixpkgs/commit/5bda2ec626a4107f8adc3a7e58c16c0594c40d2c) cudaPackagesGoogle: init, a package-set for jax and tf
* [`3ee37e43`](https://github.com/NixOS/nixpkgs/commit/3ee37e4356ef08d0a4b872e76031983288e40a80) tensorrt: dont break eval for unrelated packages
* [`e5b174be`](https://github.com/NixOS/nixpkgs/commit/e5b174bedb0af5f8da2be151f241b6d0174f6bfb) opensubdiv: drop the cudatoolkit.run file, and respect cudaFlags
* [`23813841`](https://github.com/NixOS/nixpkgs/commit/238138417344ba277e80ed451ce5f80f47dd86f2) blender: drop cudatoolkit.runfile
* [`5c2a368f`](https://github.com/NixOS/nixpkgs/commit/5c2a368f87f0f3b0585255aaa5a2d1547da4c29c) catboost: downgrade to cudaPackages_11 because of unsupported architectures (compute_35)
* [`361d7da3`](https://github.com/NixOS/nixpkgs/commit/361d7da37f7bb945a026cb15dcb5ec548bf87e95) ctranslate2: fix the cuda 12 build
* [`6c632020`](https://github.com/NixOS/nixpkgs/commit/6c63202052bb23151ca77b613357c790c5542e42) cudaPackages.cuda_nvcc: fix (getExe cuda_nvcc)
* [`0dc161b2`](https://github.com/NixOS/nixpkgs/commit/0dc161b2f806aa3d9dd7bee4f3dbb5289bc98eeb) cudaPackages_12.cutensor: init and fix
* [`ee108108`](https://github.com/NixOS/nixpkgs/commit/ee108108fcbe21999ecc1f36ac730c15376dc824) python3Packages.cupy: fix (use older cutensor)
* [`58819d63`](https://github.com/NixOS/nixpkgs/commit/58819d631edc8ffa5658ef025e1b1c04903cc43f) ucx: fix the cudaPackages_12 variant; drop the cudatoolkit runfile dependency
* [`31f1b517`](https://github.com/NixOS/nixpkgs/commit/31f1b517cdea429dc7a6c212ca650ea184c75a93) gromacs: drop cudatoolkit.run
* [`0c4b1fcf`](https://github.com/NixOS/nixpkgs/commit/0c4b1fcfba531c8f33b416583053df2582a6843e) openvino: opencvConfig.cmake attempts to find_package(CUDA)
* [`9cc210a7`](https://github.com/NixOS/nixpkgs/commit/9cc210a7839f4e2aeb13bcadc96981daf8bc6501) nvidia-thrust: rm as deprecated
* [`3e37f3c9`](https://github.com/NixOS/nixpkgs/commit/3e37f3c9836da7cf6dd2c3d66a442cd8c74113b3) ucc: drop the cudatoolkit runfile
* [`0f047c23`](https://github.com/NixOS/nixpkgs/commit/0f047c2372f2ebfaf67fad4aaacc131f5d879583) ucc: respect cudaFlags
* [`4c6d2b81`](https://github.com/NixOS/nixpkgs/commit/4c6d2b81cf4dd94398a6fc5b3727c685b439f4b3) openmpi: drop the cudatoolkit runfile
* [`9d729f26`](https://github.com/NixOS/nixpkgs/commit/9d729f260d023569a20c4339776e6b442a9f588c) python311Packages.torchWithCuda: drop cuda_cudart.static at runtime
* [`a54ae775`](https://github.com/NixOS/nixpkgs/commit/a54ae775396a717ce9c66a5bf4f5ebe1f5575c4e) catppuccin: add qt5ct
* [`8998288f`](https://github.com/NixOS/nixpkgs/commit/8998288f7bf25c8dedac09a563523f25a47e32ea) luaPackages.fzy: init at 1.0-1
* [`d4f0515e`](https://github.com/NixOS/nixpkgs/commit/d4f0515e07679841c8b6edab19c2ed8d698fde32) logseq: 0.9.20 -> 0.10.0
* [`d7632d8a`](https://github.com/NixOS/nixpkgs/commit/d7632d8a73a2ff0cb4371580590de069d0e57fa3) csxcad: unstable-2022-05-18 -> v0.6.3
* [`3081bc2f`](https://github.com/NixOS/nixpkgs/commit/3081bc2fc2ce2d21434461e3435887875f0acf28) python3Packages.python-csxcad: unstable-2020-02-18 -> v0.6.3
* [`1ee4fe34`](https://github.com/NixOS/nixpkgs/commit/1ee4fe34965bfa4bbe2dc7cea228579c712f7468) python3Packages.python-openems: unstable-2020-02-18 -> v0.0.36
* [`d4241e8f`](https://github.com/NixOS/nixpkgs/commit/d4241e8fbbceb70475a2b135296816aab46dcca1) python310Packages.pydal: 20230521.1 -> 20231114.3
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
