### PR TITLE
niv devenv: update a7c4dd8f -> 895e8403

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "a7c4dd8f4eb1f98a6b8f04bf08364954e1e73e4f",
-        "sha256": "05fl4xngwph6lsvyb48ppcf24la66prflbsvbi5kay2lyyw61jrm",
+        "rev": "895e8403410c3ec14d1e8cae94e88b4e7e2e8c2f",
+        "sha256": "1p2v94j3b5fy9wa09s91n47xwsqymfcd48av4b5m5cjpilnzkv0z",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/a7c4dd8f4eb1f98a6b8f04bf08364954e1e73e4f.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/895e8403410c3ec14d1e8cae94e88b4e7e2e8c2f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@a7c4dd8f...895e8403](https://github.com/cachix/devenv/compare/a7c4dd8f4eb1f98a6b8f04bf08364954e1e73e4f...895e8403410c3ec14d1e8cae94e88b4e7e2e8c2f)

* [`f236d4a6`](https://github.com/cachix/devenv/commit/f236d4a692aee087147e81a760bbe2767f534f19) Add defaultMimeTypes to Nginx
* [`9215a209`](https://github.com/cachix/devenv/commit/9215a20921df928b1ff8de201ea08196108cdb72) handle multiple dotenv files
* [`22a57079`](https://github.com/cachix/devenv/commit/22a57079f394157a1413b94f3c3bd0b37660ae34) bump version
* [`6f21a9df`](https://github.com/cachix/devenv/commit/6f21a9df9f949dc17f8dd93100a309259cc82c42) update dotenv filenames tests
* [`103bb429`](https://github.com/cachix/devenv/commit/103bb42908b6571c9485af0c578a59fe18a1d49f) update dotenv doc
* [`6578f387`](https://github.com/cachix/devenv/commit/6578f387783b81de9db74bfe199566d024d62948) Auto generate docs/reference/options.md
* [`84c0c64e`](https://github.com/cachix/devenv/commit/84c0c64e1fcdcbb9dc09b78c73f395322a1a5759) keep only filename instead of filenames in dotenv
* [`68f7e62e`](https://github.com/cachix/devenv/commit/68f7e62e48e02ad7f739f6af7632bc023588e6f1) Auto generate docs/reference/options.md
* [`a13d46c4`](https://github.com/cachix/devenv/commit/a13d46c4308561e2d6f8e79f81f5c30da4585d2c) fix dotenv test
* [`9926ec8b`](https://github.com/cachix/devenv/commit/9926ec8bb60482e09138025509ff7999a85150de) remove lock file
* [`9790569b`](https://github.com/cachix/devenv/commit/9790569bbacf0b52a9ef0d72c857da0b4c4c3a39) print message for now found files
* [`52670341`](https://github.com/cachix/devenv/commit/526703418c416f10da13fdbb8a1b5d37c1810e3b) fix dotenv example
* [`70ed5367`](https://github.com/cachix/devenv/commit/70ed5367ca03d6d1af8bec54db081b51627407e6) fix: redis startup on WSL2
* [`0794e175`](https://github.com/cachix/devenv/commit/0794e17528c2fb202c7c24a735f62d6653cea16f) Add description to script
* [`e2a808af`](https://github.com/cachix/devenv/commit/e2a808af5b8a7f2cb0ec0ab0801dc8b12eb5a2a7) Auto generate docs/reference/options.md
* [`b2100972`](https://github.com/cachix/devenv/commit/b21009725ead1989db5ba40e438131a460429713) Auto generate docs/reference/options.md
* [`81143e41`](https://github.com/cachix/devenv/commit/81143e41a718e2e63dd8147267648a2b62379a76) Auto generate docs/reference/options.md
* [`e7164710`](https://github.com/cachix/devenv/commit/e716471050be8fc55e193dcf92d82d4587bc38a9) de-bump latest-version
* [`5ad1498d`](https://github.com/cachix/devenv/commit/5ad1498d926a229af1a9f5c0575c0135cae33c22) Auto generate docs/reference/options.md
* [`8e85d3cb`](https://github.com/cachix/devenv/commit/8e85d3cb673d8797248eba531a78c97d29c22465) Remove examples/varnish/devenv.lock
* [`dcc42aa7`](https://github.com/cachix/devenv/commit/dcc42aa7faf887b8982da4154a015855ce993855) Add devenv.lock to .gitignore in examples/ directory
* [`ca864685`](https://github.com/cachix/devenv/commit/ca864685aa74518ce8034ee52d1c2ae542563892) elasticmq: init
* [`895e8403`](https://github.com/cachix/devenv/commit/895e8403410c3ec14d1e8cae94e88b4e7e2e8c2f) Auto generate docs/reference/options.md
