### PR TITLE
niv home-manager: update ac721691 -> defbb9c5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ac7216918cd65f3824ba7817dea8f22e61221eaf",
-        "sha256": "110m66gdxhidamz0y5i5ijpv4lx2p8iwfhiwajpwf2vginn74jn7",
+        "rev": "defbb9c5857e157703e8fc7cf3c2ceb01cb95883",
+        "sha256": "1jv49087s87sjfa0fxbjcvcmjsqsv7rm3lif8hrx7mz2b3cls670",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/ac7216918cd65f3824ba7817dea8f22e61221eaf.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/defbb9c5857e157703e8fc7cf3c2ceb01cb95883.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@ac721691...defbb9c5](https://github.com/nix-community/home-manager/compare/ac7216918cd65f3824ba7817dea8f22e61221eaf...defbb9c5857e157703e8fc7cf3c2ceb01cb95883)

* [`80ac72bf`](https://github.com/nix-community/home-manager/commit/80ac72bf03afc0177b30fdbe386b9f747bfea910) docs: render without deprecated optionsDocBook
* [`728423e6`](https://github.com/nix-community/home-manager/commit/728423e6f46b862af34ed93c2440469aca6a69f2) docs: add home-manager manpage
* [`0dcb7676`](https://github.com/nix-community/home-manager/commit/0dcb767676ec46602247fd89e423124075eeff96) docs: add htmlOpenTool to manual
* [`f48a0062`](https://github.com/nix-community/home-manager/commit/f48a0062dfe9bbf42050b557a0a5de0f4706ac75) docs: update paths to make manual tests pass
* [`e4d29039`](https://github.com/nix-community/home-manager/commit/e4d290396c116c75ae0b17aa49613d9bc4493936) docs: update manual to refer to 23.11
* [`8dae2041`](https://github.com/nix-community/home-manager/commit/8dae2041eff0a59abe640b62da922aa4aa6f4483) docs: use nixos-render-docs
* [`2098c6fe`](https://github.com/nix-community/home-manager/commit/2098c6fe915b6f393a311d6b9a920c2b4c268b5d) docs: no justification in home-manager manpage
* [`32063973`](https://github.com/nix-community/home-manager/commit/32063973cc041c1a902d688765cdf83ad0c47179) docs: fix note blocks
* [`b5a47bd7`](https://github.com/nix-community/home-manager/commit/b5a47bd700f275dbede0b9a15b40d0dd599472c2) docs: this is the `home-manager` manual
* [`be801227`](https://github.com/nix-community/home-manager/commit/be801227317673cff6bd818a99898758d76d0dac) docs: include 3rd-party part
* [`5c2ef524`](https://github.com/nix-community/home-manager/commit/5c2ef5243d9c72b7804343c7e901f182f541120a) docs: extend home-configuration.nix header
* [`67b797a3`](https://github.com/nix-community/home-manager/commit/67b797a37723a7c059e8c366819ffe968456a713) docs: update nmd version
* [`eff22a27`](https://github.com/nix-community/home-manager/commit/eff22a27e293809ea40ce004d6982ee6a099a1e0) docs: replace `console` language with `shell`
* [`b006bf1d`](https://github.com/nix-community/home-manager/commit/b006bf1d7456912fbf886f197320468b0f7a850c) docs: render DESCRIPTION and OPTIONS headings
* [`0a710464`](https://github.com/nix-community/home-manager/commit/0a710464932ae65238f583e69f887fea6bd72c0e) docs: fix syntax highlighting
* [`613dbb35`](https://github.com/nix-community/home-manager/commit/613dbb35dbc142fd5cadca847f8677e64a502bfa) docs: rename generated manual to `index.xhtml`
* [`f10eb1b3`](https://github.com/nix-community/home-manager/commit/f10eb1b3ee8e5ee2891b34b6c9f12567f73f9693) docs: apply nixfmt
* [`efa36e89`](https://github.com/nix-community/home-manager/commit/efa36e896951bec8d96e38ea40a22c010bd1bd8f) Translate using Weblate (Czech)
* [`fa91c109`](https://github.com/nix-community/home-manager/commit/fa91c109b0dd12e680dd29010e262884f7b26186) docs: use relative paths to static resources
* [`e6b7303b`](https://github.com/nix-community/home-manager/commit/e6b7303bd149723c57ca23f5a9428482d6b07306) docs: fix broken links in README
* [`093777ee`](https://github.com/nix-community/home-manager/commit/093777ee4ab07d70be46e8edb492865e12a865e0) caffeine: remove ProtectHome service option
* [`9a00befa`](https://github.com/nix-community/home-manager/commit/9a00befa13126e318fa4b895adeb84d383c9ab3f) ci: bump cachix/cachix-action from 12 to 13
* [`defbb9c5`](https://github.com/nix-community/home-manager/commit/defbb9c5857e157703e8fc7cf3c2ceb01cb95883) hyprland: add option sourceFirst
