### PR TITLE
niv nerd-icons.el: update dd309491 -> b29ef760

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "dd3094918fe69312d53bf927d20eaccbe941c6a8",
-        "sha256": "1fikkqm8gbwwsvas00mvqfaddgdakrddf4dk6jccv87bg54zjahg",
+        "rev": "b29ef760e92f36f47720f6c58435854129ee7163",
+        "sha256": "1nc1cvyrnwwd4s975sfgdyyv4yxnlv6i7npn1dd070ibfi09v1wa",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/dd3094918fe69312d53bf927d20eaccbe941c6a8.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/b29ef760e92f36f47720f6c58435854129ee7163.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@dd309491...b29ef760](https://github.com/rainstormstudio/nerd-icons.el/compare/dd3094918fe69312d53bf927d20eaccbe941c6a8...b29ef760e92f36f47720f6c58435854129ee7163)

* [`b29ef760`](https://github.com/rainstormstudio/nerd-icons.el/commit/b29ef760e92f36f47720f6c58435854129ee7163) update to Nerd Font 3.1.1
