### PR TITLE
niv powerlevel10k: update b9a2d846 -> d70eedb3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "b9a2d846efff427fd13b7e95d83a5761666329ac",
-        "sha256": "0ddqigmgxx5j2i7vhpspqbcw4m86r783ja1aglzssnlwic35qria",
+        "rev": "d70eedb345a9cc54b4f3e9ae09b0dbbb4edc9a39",
+        "sha256": "1sc7r3ny471hndbv466slbshj3fn7sbdmsdv9349q1asc83hxyw0",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/b9a2d846efff427fd13b7e95d83a5761666329ac.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/d70eedb345a9cc54b4f3e9ae09b0dbbb4edc9a39.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@b9a2d846...d70eedb3](https://github.com/romkatv/powerlevel10k/compare/b9a2d846efff427fd13b7e95d83a5761666329ac...d70eedb345a9cc54b4f3e9ae09b0dbbb4edc9a39)

* [`47b0187a`](https://github.com/romkatv/powerlevel10k/commit/47b0187a675afed6b49007fe1915b2c0fe94b7bc) docs: add a note about `p10k reload` ([romkatv/powerlevel10k⁠#2006](https://togithub.com/romkatv/powerlevel10k/issues/2006))
* [`44f754d7`](https://github.com/romkatv/powerlevel10k/commit/44f754d711c108dbbbfc2e0612961cd44afb71ea) use "rm" instead of "unlink" to delete old config file
* [`36cce9a0`](https://github.com/romkatv/powerlevel10k/commit/36cce9a088c8cd7d7b1a3adccc74cf2a130c51e0) wizard: replace rm with zf_rm ([romkatv/powerlevel10k⁠#2504](https://togithub.com/romkatv/powerlevel10k/issues/2504))
* [`dec88165`](https://github.com/romkatv/powerlevel10k/commit/dec881651ccbd90f7f68b2a2012cf4870741d0dd) Squashed 'gitstatus/' changes from 38d35b959..215063d47
