### PR TITLE
niv nixpkgs: update 338c49e0 -> a3670679

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "338c49e0c453b0525c47c0597c7e4e2797714676",
-        "sha256": "05m3ypqggqpmm6higldcxbi0gq15fvxa0kjnlvcnl6c32jy7755r",
+        "rev": "a3670679058c06e817358782f82aa0edff8df39d",
+        "sha256": "11bx9bvzygf03ggmmawcisi5cnjqyrgvk1cs824b8sfx7dz0x4bz",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/338c49e0c453b0525c47c0597c7e4e2797714676.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a3670679058c06e817358782f82aa0edff8df39d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@338c49e0...a3670679](https://github.com/nixos/nixpkgs/compare/338c49e0c453b0525c47c0597c7e4e2797714676...a3670679058c06e817358782f82aa0edff8df39d)

* [`06edf256`](https://github.com/NixOS/nixpkgs/commit/06edf256858f3947a129814b342c5a264323bf7f) bintools-wrapper: Set ZERO_AR_DATE and re-enable LC_UUID on Darwin
* [`30b2770a`](https://github.com/NixOS/nixpkgs/commit/30b2770a5405477e4142140dc2f4510ebb54c147) xdg-utils: allow xdg-open access to mimeopen
* [`e8a0ae4d`](https://github.com/NixOS/nixpkgs/commit/e8a0ae4ddbe298d1b4ba2f6f7ef8839d9ed4e884) revanced-cli: init at 2.22.0
* [`1718e247`](https://github.com/NixOS/nixpkgs/commit/1718e247eb5d1dcbe9dd9caf0399a4f3e0c03d1f) keyd: 2.4.2 -> 2.4.3
* [`6591d332`](https://github.com/NixOS/nixpkgs/commit/6591d332f93422e388ef6337f6b362b4ff8d0724) nixos/keyd: Allow service to call nice syscall
* [`8562dc92`](https://github.com/NixOS/nixpkgs/commit/8562dc924d89825ed829ea3f086896871d96fd3c) nixos/prometheus: add remote{Read, Write}.headers options
* [`86f22aa5`](https://github.com/NixOS/nixpkgs/commit/86f22aa56a7bc7c65be35026b63ff8a0a45fc727) opencl-headers: use cmake build
* [`2d08d206`](https://github.com/NixOS/nixpkgs/commit/2d08d206829ac8268606004a449156ae33ed6415) translatelocally: 2023-08-25 -> 2023-09-20
* [`f2c86115`](https://github.com/NixOS/nixpkgs/commit/f2c86115094c6af189b42b0d760526be143976d8) ffsubsync: init at 0.4.25
* [`b352bcba`](https://github.com/NixOS/nixpkgs/commit/b352bcbaceb16c5e1d8e9f249174550f3b51a3f9) shipwright: 7.0.2 -> 7.1.1
* [`a218879f`](https://github.com/NixOS/nixpkgs/commit/a218879f39d4e5be7f9522a11de9ad12f580b3c9) french-numbers: init at 1.2.0
* [`671020de`](https://github.com/NixOS/nixpkgs/commit/671020de387e8a7d2d5cf2a91ab6c88e4a10ad2f) vimPlugins.nfnl: init at 2023-09-08
* [`605c428a`](https://github.com/NixOS/nixpkgs/commit/605c428a4865f3b7feddaab856d60b1a3bba74e1) libsigcxx, libsigcxx30: add "dev" output
* [`b6ce112e`](https://github.com/NixOS/nixpkgs/commit/b6ce112e9d3e19665e3196eabab862f48e4cfa2c) qpdf: 11.6.1 -> 11.6.3
* [`76b707c4`](https://github.com/NixOS/nixpkgs/commit/76b707c42262feb84c26f855a4d2e88f1d35e340) oauth2ms: init at 2021-07-09
* [`8505127b`](https://github.com/NixOS/nixpkgs/commit/8505127bf04d8d9a92264af0858a37828ad0d23d) muse: 4.1.0 -> 4.2.1
* [`6767e9d5`](https://github.com/NixOS/nixpkgs/commit/6767e9d5a02f7a3d5835cefc8a3900da892b9ccb) sord: 0.16.14 -> 0.16.16
* [`0a9b7f2e`](https://github.com/NixOS/nixpkgs/commit/0a9b7f2e945f0cae67eec8689ff3f3fc82be0cdb) lilv: 0.24.20 -> 0.24.22
* [`f79d2b75`](https://github.com/NixOS/nixpkgs/commit/f79d2b757009dfe968320e60a3467b4c5b27fe81) linuxHeaders: 6.5 -> 6.6
* [`7ec92e7e`](https://github.com/NixOS/nixpkgs/commit/7ec92e7ee6e3238b376c31ef2e228f015265d98a) xz: 5.4.4 -> 5.4.5
* [`5672d3d8`](https://github.com/NixOS/nixpkgs/commit/5672d3d8b835b510a72b4280c97e8db0765ebef4) nixos/quicktun: clean up module
* [`78f663bc`](https://github.com/NixOS/nixpkgs/commit/78f663bc0b6d4e24401164f07113533f119d2fa7) nixos/quicktun: add test
* [`1a409a92`](https://github.com/NixOS/nixpkgs/commit/1a409a92aaf5b223dae7447c20daf174faf17dd7) quicktun: add h7x4 as maintainer
* [`0acd1c03`](https://github.com/NixOS/nixpkgs/commit/0acd1c038fe790343996cf59b9f76b805967b77f) prometheus-xmpp-alerts: 0.5.6 → 0.5.8
* [`ca73360b`](https://github.com/NixOS/nixpkgs/commit/ca73360bb710b9975d63e07058e565c828dfdebf) net-snmp: drop build-only references from the closure
* [`74abf2b6`](https://github.com/NixOS/nixpkgs/commit/74abf2b6d91d1b0f20e29b40160cae68f7f89d9a) libnsl: add "dev" output
* [`76f315ab`](https://github.com/NixOS/nixpkgs/commit/76f315abd20b6ab04c1f6cae35aeedd12ae50a4a) python311Packages.sphinx-autodoc-typehints: 1.24.0 -> 1.24.1
* [`10aac3e8`](https://github.com/NixOS/nixpkgs/commit/10aac3e8db782ca81e184e206bbddfe91f333321) tzdata: copy `leap-seconds.list` to `$out/share/zoneinfo`
* [`c0762004`](https://github.com/NixOS/nixpkgs/commit/c07620044c7e709bb743853fd6e22f15059b2cad) libuv: 1.46.0 -> 1.47.0
* [`a7e4d18a`](https://github.com/NixOS/nixpkgs/commit/a7e4d18a05497c21c790c57b5534b70d11845aad) libuv: remove unneeded Darwin dependencies
* [`df8bba79`](https://github.com/NixOS/nixpkgs/commit/df8bba7926ec29ac00c5b8dd3195e2c0b7d2e150) libuv: add pkg-config tester
* [`216a4088`](https://github.com/NixOS/nixpkgs/commit/216a408812ce0d7a13f379312162e848297e4fa0) mercurial: 6.5.2 -> 6.5.3
* [`cb6f270b`](https://github.com/NixOS/nixpkgs/commit/cb6f270be221dc966c945178c72692ba1545ad3c) pyqt6: 6.5.2 -> 6.6.0
* [`4c1f0232`](https://github.com/NixOS/nixpkgs/commit/4c1f02326840aa91ac8d44b5f5b6d1818ad0fe92) gnome2.libIDL: fix cross
* [`2ab7a11d`](https://github.com/NixOS/nixpkgs/commit/2ab7a11dd8bd91c6325a46c45a57851ed9d1b260) python3.pkgs.pytest-regressions: align dependencies with upstream
* [`38a32f41`](https://github.com/NixOS/nixpkgs/commit/38a32f41de8945dba1f4b32ec0ddf2c94c322e88) gnome2.ORBit2: fix cross
* [`ebb42ada`](https://github.com/NixOS/nixpkgs/commit/ebb42ada24c4641d6a2efc8d8fd7aa5baf96710a) unbound: 1.18.0 -> 1.19.0
* [`139b44ee`](https://github.com/NixOS/nixpkgs/commit/139b44eed3b490d370a6a594a74071fb1fea5fad) gnome2.GConf: enable strictDeps
* [`9165c8ad`](https://github.com/NixOS/nixpkgs/commit/9165c8adad90eaef5db49f2f6766a64e76dfce0d) gnome2.libglade: fix cross
* [`75705240`](https://github.com/NixOS/nixpkgs/commit/757052408f6d9a1f03d3ed105ac7fa6701a04f1c) libgnome-keyring: fix cross
* [`946178a1`](https://github.com/NixOS/nixpkgs/commit/946178a15194bb711441fbf31df385b918f56fca) gnome2.libgnomecanvas: fix cross
* [`eb3b5d33`](https://github.com/NixOS/nixpkgs/commit/eb3b5d33aad8a9dfb63a6eebf36005dd1e6ed419) xsimd: 11.1.0 -> 11.2.0
* [`4d7c82ab`](https://github.com/NixOS/nixpkgs/commit/4d7c82abab83072e3991ebbaffc121e151a5711d) nuspell: 5.1.3 -> 5.1.4
* [`14bd32cb`](https://github.com/NixOS/nixpkgs/commit/14bd32cbf1ae99bbf63a8dc34ddd9f562309b4a3) SDL2: 2.28.4 -> 2.28.5
* [`406de7fd`](https://github.com/NixOS/nixpkgs/commit/406de7fdc30979f745f6a0747d16985a5cd811c5) libass: enable CoreText backend on darwin
* [`2377882c`](https://github.com/NixOS/nixpkgs/commit/2377882c2e24cf1dacc8361339c36e3a2b62924d) faad2: 2.10.1 -> 2.11.0
* [`29d5a48f`](https://github.com/NixOS/nixpkgs/commit/29d5a48fd05ef0a9a68c845367870d343f206d13) desktop-file-utils: 0.26 -> 0.27
* [`233ca3d9`](https://github.com/NixOS/nixpkgs/commit/233ca3d9ac6e3035d82881602e842a730628ef3c) buildFHSenv: fixup /etc permissions
* [`57cd9252`](https://github.com/NixOS/nixpkgs/commit/57cd9252da85b88fa0f71b9e2279e05eb6baabcb) python311Packages.snack: 0.52.23 -> 0.52.24
* [`51c81e65`](https://github.com/NixOS/nixpkgs/commit/51c81e6530016e83f8dcf6bf8a05d924205204af) python311Packages.snack: add changelog to meta
* [`61f957f8`](https://github.com/NixOS/nixpkgs/commit/61f957f87617d6a7c14a815346fc2a91b4ed0ce6) nixos/unbound: Fix deprecation warnings
* [`5d608cc9`](https://github.com/NixOS/nixpkgs/commit/5d608cc92538e61d6eb4c3e2e5ef9b9425f9a038) darwin.apple_sdk_11_0.frameworks.CoreVideo: switch to sed
* [`16d8035b`](https://github.com/NixOS/nixpkgs/commit/16d8035b62cfaac8b12daee0d35700569b7776df) doxygen_gui: 1.9.7 -> 1.9.8
* [`57955932`](https://github.com/NixOS/nixpkgs/commit/57955932f26997beb78529a5de3df422c11022c6) libfido2: 1.13.0 -> 1.14.0
* [`8f0842b0`](https://github.com/NixOS/nixpkgs/commit/8f0842b0ca7274521cf0c2783d29c481c3a9dad5) libglvnd: enable 64-bit file APIs
* [`e1f858ec`](https://github.com/NixOS/nixpkgs/commit/e1f858ec13091a729a60d9ccf63a47af9d9ded7e) faad2: 2.11.0 -> 2.11.1
* [`61987573`](https://github.com/NixOS/nixpkgs/commit/619875730985b3e366f1bf88d97fd4205a1a95e3) sratom: 0.6.14 -> 0.6.16
* [`b103e1e3`](https://github.com/NixOS/nixpkgs/commit/b103e1e3d7fc1a967b347af017c110fb9ea7a69b) gst-plugins-good: add openssl dependency
* [`590745a7`](https://github.com/NixOS/nixpkgs/commit/590745a7b60f3140d82073ed893daa252ac6230e) cmake: 3.27.7 -> 3.27.8
* [`86522720`](https://github.com/NixOS/nixpkgs/commit/8652272012b546b3f20bc533573f4d6458353dd4) pipewire: 0.3.84 -> 0.3.85
* [`f4b83396`](https://github.com/NixOS/nixpkgs/commit/f4b833961b646fcdfa3246f3b5e9da3db967bf50) systemd: 254.3 -> 254.6
* [`ff08829f`](https://github.com/NixOS/nixpkgs/commit/ff08829fddcd2d388e90f75f72ea40420d67871e) p11-kit: 0.25.0 -> 0.25.3
* [`427782c4`](https://github.com/NixOS/nixpkgs/commit/427782c4c42324fa0bd4e8b1f0a6101e6b766555) libusb1: Fix mingw build
* [`a2681568`](https://github.com/NixOS/nixpkgs/commit/a268156842f37ab10e146d8b9a1ce019784feff4) shared-mime-info: 2.3 -> 2.4
* [`392fbc90`](https://github.com/NixOS/nixpkgs/commit/392fbc90a86a696810a853e9eedf2fd7e2dafcdf) nixos/lib/test-driver: make wait_for_unit ask for ActiveState only
* [`3b4b8055`](https://github.com/NixOS/nixpkgs/commit/3b4b805561f11699c3597564ef34077e1e2ef719) stdenv: consistent phases header
* [`bfb4b03e`](https://github.com/NixOS/nixpkgs/commit/bfb4b03edafe661d02a5f3ba3eb04abeac6728b6) grpc: 1.59.1 -> 1.59.3
* [`478d6e7a`](https://github.com/NixOS/nixpkgs/commit/478d6e7ac39654ec2ca5a0e8ef2d73948f0fe846) python311Packages.grpcio: use PyPi tarball
* [`46629f6e`](https://github.com/NixOS/nixpkgs/commit/46629f6e50f896913c4c286ef3d14351fec92023) python311Packages.grpcio-tools: 1.59.0 -> 1.59.3
* [`cc97da26`](https://github.com/NixOS/nixpkgs/commit/cc97da26167adb9c45f8757399dc245b16e600db) python311Packages.grpcio-status: 1.59.0 -> 1.59.3
* [`6abc77ca`](https://github.com/NixOS/nixpkgs/commit/6abc77ca5ceef471ecdf94afe58e62b2466bfe4a) maintainers: add vonixxx
* [`e9ca6038`](https://github.com/NixOS/nixpkgs/commit/e9ca6038eb5f4398fc57feb4084b7df4afaa6d7d) rustc,cargo: 1.73.0 -> 1.74.0
* [`b852b4fa`](https://github.com/NixOS/nixpkgs/commit/b852b4fa5a0fd8049e946a5d185755a6b3d4b6ae) autoPatchelfHook: fix arguments parsing
* [`85bd9e90`](https://github.com/NixOS/nixpkgs/commit/85bd9e9040cf610c97556b8e2b05fdb60d375e03) Revert "Revert "firefox-bin: remove workaround""
* [`71d9dab8`](https://github.com/NixOS/nixpkgs/commit/71d9dab8f0870f2609182299d260676320398883) starship: change logic that sets STARSHIP_CONFIG so that it won't override a user-provided config
* [`e9596668`](https://github.com/NixOS/nixpkgs/commit/e9596668d6ff62b409db99a0d17edd6149eaf447) blink: Fix static compilation
* [`48096e8e`](https://github.com/NixOS/nixpkgs/commit/48096e8e5c5a543ab51d78064e03f2b0ef2c233b) libavif: 1.0.1 -> 1.0.2
* [`d9edfa75`](https://github.com/NixOS/nixpkgs/commit/d9edfa75a975ef2aa712da501e62f9ef2621af8a) libksba: 1.6.4 -> 1.6.5
* [`9375cf20`](https://github.com/NixOS/nixpkgs/commit/9375cf20083c296b6db94f8534b3372c21f0cb69) fetchgitlab: make args more similar to fetchgithub
* [`a838881c`](https://github.com/NixOS/nixpkgs/commit/a838881cdacef7685b95f0c9088c6ed14228dc1f) fetchgitlab: add option for sparse checkout
* [`cf00f9c2`](https://github.com/NixOS/nixpkgs/commit/cf00f9c2ea24f80f1ecea7d9fdd5c5a11e12f997) fetchgitlab: add option to force fetchgit
* [`69b2aa71`](https://github.com/NixOS/nixpkgs/commit/69b2aa71ab3c9bf18d56997a5dd5bee5db4b9102) cmake: Fix feature check
* [`565d7dce`](https://github.com/NixOS/nixpkgs/commit/565d7dce03152c39aa0a29ead4789567348c4f7f) dvdauthor: 0.7.1 -> 0.7.2
* [`2707f679`](https://github.com/NixOS/nixpkgs/commit/2707f6791a51fa4e20fa1ae7a8202d884b8d2369) gnutls: 3.8.1 -> 3.8.2
* [`507cf994`](https://github.com/NixOS/nixpkgs/commit/507cf9942594a50a3314c74a327bb5aef34f7ace) bogofilter: 1.2.4 -> 1.2.5
* [`796079b2`](https://github.com/NixOS/nixpkgs/commit/796079b2987b6910bd6f89e07c03da2196c3b706) vim: 9.0.2048 -> 9.0.2116
* [`667296fb`](https://github.com/NixOS/nixpkgs/commit/667296fbfc7ea8ce5c5754a1fcc131133de589a1) libspectre: 0.2.7 -> 0.2.12
* [`c2c20bb2`](https://github.com/NixOS/nixpkgs/commit/c2c20bb22a0d45b486ce31f93e2f6098d86628bc) coreutils: 9.3 -> 9.4 ([nixos/nixpkgs⁠#264215](https://togithub.com/nixos/nixpkgs/issues/264215))
* [`4104fe93`](https://github.com/NixOS/nixpkgs/commit/4104fe93c076af4f208362b7c9cd1b9a9f9386e1) python3Packages.numpy: remove reference to build Python
* [`bad887d9`](https://github.com/NixOS/nixpkgs/commit/bad887d92620c8b1673bd0f7e8d966ae0e642664) python3Packages.numpy: fix cross compilation
* [`07ca66a0`](https://github.com/NixOS/nixpkgs/commit/07ca66a0976aec31462861c7eb281574b4c5fcba) atlauncher: 3.4.34.2 -> 3.4.35.3
* [`515ce669`](https://github.com/NixOS/nixpkgs/commit/515ce669bcd98d25d0be99e8f6687f1913f057fc) nixos/postgresql: point doc link to current like all others
* [`4df141fe`](https://github.com/NixOS/nixpkgs/commit/4df141fe3ffc5169146366ed99df93f22ad9a31c) ghostscript: 10.02.0 -> 10.02.1
* [`5afd7864`](https://github.com/NixOS/nixpkgs/commit/5afd78645bb04b31796204718d35b6c30b664414) libaom: 3.7.0 -> 3.7.1
* [`0e06e6f4`](https://github.com/NixOS/nixpkgs/commit/0e06e6f4f87be5ccbe30bce91bd9f8fe165ef293) nss_latest: 3.94 -> 3.95
* [`a1c24a75`](https://github.com/NixOS/nixpkgs/commit/a1c24a7517effb013d892b7b1a44112bb5d68f9f) zotero_7: init at 7.0.0-beta
* [`363dc695`](https://github.com/NixOS/nixpkgs/commit/363dc695f6bd0765dfb3fdc2fdc5f04522e58cc4) pngtoico: use up-to-date libpng
* [`0e7469d1`](https://github.com/NixOS/nixpkgs/commit/0e7469d16ee2e2e494bca516ac25a2d4f68970d5) sng: use up-to-date libpng
* [`49ad896d`](https://github.com/NixOS/nixpkgs/commit/49ad896d600dab169ac202145a218dcd08010cee) voxelands: use up-to-date libpng
* [`9e8a41f1`](https://github.com/NixOS/nixpkgs/commit/9e8a41f187336cce5533def8a825871c46f6c2cc) readline: 8.2p1 -> 8.2p7
* [`e874a50b`](https://github.com/NixOS/nixpkgs/commit/e874a50b42201ac2a389d587f4e32adbb3eb3e73) libdrm: 2.4.117 -> 2.4.118
* [`a6de9da2`](https://github.com/NixOS/nixpkgs/commit/a6de9da2a51bf7044b4bca6daa5d6891fa34b2d4) libde265: 1.0.12 -> 1.0.14
* [`d8b17789`](https://github.com/NixOS/nixpkgs/commit/d8b1778995c661d88aba7e6f1f910e26775aa6b6) cacert: 3.92 -> 3.95
* [`96fb9249`](https://github.com/NixOS/nixpkgs/commit/96fb9249cdcaf2d71a84921dbc6eb126a01f91ae) zotero_7: swapping maintainer from i077 to atila
* [`ed84add1`](https://github.com/NixOS/nixpkgs/commit/ed84add1578efca6af4a586c6f2add1a0cea102b) nixos/starship: add comment describing why this uses a hardcoded path
* [`0a4140bc`](https://github.com/NixOS/nixpkgs/commit/0a4140bcc83813b1b20a8e8f85d2441ae88bb871) bash: 5.2p15 -> 5.2p21
* [`fea610bb`](https://github.com/NixOS/nixpkgs/commit/fea610bb94c5590c89fed7926000c062c0ff6411) python3Packages.pulp: add cbc solver
* [`de5c1c2f`](https://github.com/NixOS/nixpkgs/commit/de5c1c2f79a98f5b450fd0a7b5564bc767046c68) libffi: backport fix for implicit function declarations in libffi
* [`c7c8da03`](https://github.com/NixOS/nixpkgs/commit/c7c8da035d8cc5c5cf0c12d76dedf25d6520f2d5) nftables: fix python module lookup for libnftables
* [`966e7af1`](https://github.com/NixOS/nixpkgs/commit/966e7af193c8c5c0c3df1a9e0b0deab8b7bc0585) http-parser: Build on windows
* [`2ba28085`](https://github.com/NixOS/nixpkgs/commit/2ba280859c9612236fb7cb6f37d726d3009d6fc5) libgit2: Fix build on Windows
* [`6073e62b`](https://github.com/NixOS/nixpkgs/commit/6073e62bb540fe29ea476d274efeb56de9e998c4) mupdf: 1.23.5 -> 1.23.6
* [`73ff1fc6`](https://github.com/NixOS/nixpkgs/commit/73ff1fc601308d78b45759bc632aa69d2603f562) avahi: apply patch for CVE-2023-38473
* [`618c7304`](https://github.com/NixOS/nixpkgs/commit/618c7304c0cffe1db707be30737416193076845e) openh264: 2.3.1 -> 2.4.0
* [`ca68d6a2`](https://github.com/NixOS/nixpkgs/commit/ca68d6a2a7ec86574379c7ae9825021c51ca5d41) libsodium: 1.0.18 -> 1.0.19, drop -Ofast flag
* [`b3d32f53`](https://github.com/NixOS/nixpkgs/commit/b3d32f5302441366631e37d0ce5ea4950727d02e) gst_all_1.gstreamer: 1.22.6 -> 1.22.7
* [`3b8197a2`](https://github.com/NixOS/nixpkgs/commit/3b8197a2b7e90f7dd47e44d15799fab334e5886a) gst_all_1.gst-plugins-base: 1.22.6 -> 1.22.7
* [`4ae96968`](https://github.com/NixOS/nixpkgs/commit/4ae96968a21c4ba2845287c1c39d15cb7c4afe0d) gst_all_1.gst-plugins-good: 1.22.6 -> 1.22.7
* [`fbbd5fca`](https://github.com/NixOS/nixpkgs/commit/fbbd5fca7ad2a75a0a2c50eb8f6c4c3db9d220ff) gst_all_1.gst-plugins-bad: 1.22.6 -> 1.22.7
* [`0628efe7`](https://github.com/NixOS/nixpkgs/commit/0628efe77e91d3af9f2cd00113b464d596307afc) gst_all_1.gst-plugins-ugly: 1.22.6 -> 1.22.7
* [`27044230`](https://github.com/NixOS/nixpkgs/commit/2704423053c9ad83a9bf29d8931ce51588a6bb7d) gst_all_1.gst-libav: 1.22.6 -> 1.22.7
* [`db986621`](https://github.com/NixOS/nixpkgs/commit/db986621b5c296a2f878c8f40eeba136f289e044) gst_all_1.gst-vaapi: 1.22.6 -> 1.22.7
* [`f8929124`](https://github.com/NixOS/nixpkgs/commit/f8929124db7553efddb262affbecb1c9fe3f5b43) gst_all_1.gst-devtools: 1.22.6 -> 1.22.7
* [`6858aabf`](https://github.com/NixOS/nixpkgs/commit/6858aabf62db21e5f7f24a753da815e37a8acfa3) gst_all_1.gst-rtsp-server: 1.22.6 -> 1.22.7
* [`94f7fa95`](https://github.com/NixOS/nixpkgs/commit/94f7fa9544a25b11bbc40120c92c8f92ffbfa979) gst_all_1.gst-editing-services: 1.22.6 -> 1.22.7
* [`0e55a04e`](https://github.com/NixOS/nixpkgs/commit/0e55a04e65b0814b15f65a1807d8a0bc310848d2) python311Packages.gst-python: 1.22.6 -> 1.22.7
* [`28396091`](https://github.com/NixOS/nixpkgs/commit/283960913a1eff83bfa8ad578cf4754f94bf4227) zeromq: fix paths in pkg-config file
* [`e6800155`](https://github.com/NixOS/nixpkgs/commit/e68001550de99fac8336e2c230dcd7e0157777ed) stdenv: run patchShebangs on the configure script when it's a file
* [`20591326`](https://github.com/NixOS/nixpkgs/commit/20591326aaff590f5051a17f2b50ade7636d908f) treewide: remove unnecessary patching of configure script
* [`d35bb8a5`](https://github.com/NixOS/nixpkgs/commit/d35bb8a52731f8693cf062d5452bebd3e334d20e) m17n_db: 1.8.2 -> 1.8.5
* [`f3ee548e`](https://github.com/NixOS/nixpkgs/commit/f3ee548e96fae8919ab8ca0944e08fa64f6314d3) roc-toolkit: 0.2.5 -> 0.3.0
* [`32c52236`](https://github.com/NixOS/nixpkgs/commit/32c52236b2d84280395e2115191ed8411a93a049) pipewire: 0.3.85 -> 1.0.0
* [`faf7b4ac`](https://github.com/NixOS/nixpkgs/commit/faf7b4acbf050beb7927d51199abeb0c31afc5ad) python3Packages.gevent: 22.10.2 -> 23.9.1
* [`38b85cb4`](https://github.com/NixOS/nixpkgs/commit/38b85cb4449a90f66cee5339064a6a3fee709302) avahi: apply patch for CVE-2023-38469
* [`f65b41f1`](https://github.com/NixOS/nixpkgs/commit/f65b41f13dc33338d287d9d8637d63fd2ae6978b) avahi: apply patch for CVE-2023-38470
* [`fb22f402`](https://github.com/NixOS/nixpkgs/commit/fb22f402f47148b2f42d4767615abb367c1b7cfd) avahi: apply patch for CVE-2023-38471
* [`e89c9025`](https://github.com/NixOS/nixpkgs/commit/e89c902564486dfe87f409b9b1ea727e45a7dbd0) avahi: apply patch for CVE-2023-38472
* [`cb202d19`](https://github.com/NixOS/nixpkgs/commit/cb202d19e436356413b29f6454ec95493b30fbb9) libedit: manually define __STDC_ISO_10646__ to fix the build issue against musl
* [`22c8c101`](https://github.com/NixOS/nixpkgs/commit/22c8c101cc103b07c311522d944bc88e167ea36d) python3Packages.gevent: add some key reverse-dependencies to passthru.tests
* [`afb4fdd9`](https://github.com/NixOS/nixpkgs/commit/afb4fdd94c7c64856dc283d520e6b4f876d1007a) ploticus: remove override libpng
* [`47b2da5c`](https://github.com/NixOS/nixpkgs/commit/47b2da5c196ce8611ec179f476dc19b2bd851890) extremetuxracer: remove override libpng
* [`f25aaf9b`](https://github.com/NixOS/nixpkgs/commit/f25aaf9b44b153b805154cababc6807d42a8a3fa) python311Packages.trove-classifiers: 2023.8.7 -> 2023.11.22
* [`308b0c8c`](https://github.com/NixOS/nixpkgs/commit/308b0c8ce674dc11ae65ffc9fecce2af785b8ac8) python311Packages.cryptography: 41.0.3 -> 41.0.5
* [`0eef5bf2`](https://github.com/NixOS/nixpkgs/commit/0eef5bf2ba66ba995f478299b8b01e865a22edfb) python311Packages.cryptography-vectors: 41.0.3 -> 41.0.5
* [`a0dd067c`](https://github.com/NixOS/nixpkgs/commit/a0dd067cb3602cf46cb70eb51b4a2efa30128c01) kseexpr: init at 4.0.4.0
* [`8dd11c5f`](https://github.com/NixOS/nixpkgs/commit/8dd11c5f193394159d88e52fbadab6d8930c8a4f) lager: init at 0.1.0
* [`3542ebb7`](https://github.com/NixOS/nixpkgs/commit/3542ebb79df4b261a2723187fa3f032594e43600) zug: init at 0.1.0
* [`03652db9`](https://github.com/NixOS/nixpkgs/commit/03652db90bf4de615c3011d36136a27818019ae3) nixos/river: add xdg.portal.config
* [`1cd7dcdb`](https://github.com/NixOS/nixpkgs/commit/1cd7dcdbd0dbec9e9978c00c64a587e7bffd0495) python3Packages.click-aliases: 1.0.3 -> 1.0.4
* [`49570cd0`](https://github.com/NixOS/nixpkgs/commit/49570cd067c72c37497a8d0c00b8cbe05eaa95f8) nghttp3: 1.0.0 -> 1.1.0
* [`09470cf6`](https://github.com/NixOS/nixpkgs/commit/09470cf630f708bd8e97c3cbb7613699cae3b864) samba: 4.19.2 -> 4.19.3
* [`c3e8fafc`](https://github.com/NixOS/nixpkgs/commit/c3e8fafcc05b097754ddec60c0c6997f95837d9a) ngtcp2: 1.0.0 -> 1.1.0
* [`a38e092e`](https://github.com/NixOS/nixpkgs/commit/a38e092e21bca27cd24f1c17aab5198e9322f3e6) navidrome: fix cross-compilation
* [`f81ea4a5`](https://github.com/NixOS/nixpkgs/commit/f81ea4a5e6ee213addcb05a2fde901131f1aca5c) glslang: fix build on riscv
* [`8efe6a71`](https://github.com/NixOS/nixpkgs/commit/8efe6a71cb0de07361290b7c53936478095f03b8) nixos/vdirsyncer: fix config.statusPath option
* [`e30be982`](https://github.com/NixOS/nixpkgs/commit/e30be98231b26fd9277532d53803646716ed2d78) dns-root-data: update B.root-servers.net addresses
* [`536fe796`](https://github.com/NixOS/nixpkgs/commit/536fe796af179c662b4d12c7c474ae0da57a5717) intiface-central: init at 2.5.3
* [`3f05c9a8`](https://github.com/NixOS/nixpkgs/commit/3f05c9a8f8f078b6d026f4c0e73ed9ee7b02950f) nodejs_18: 18.18.2 -> 18.19.0
* [`83cb8288`](https://github.com/NixOS/nixpkgs/commit/83cb8288766cc8ef5b5d9b73e9a91032b31b2c45) oh-my-zsh: 2023-06-26 -> 2023-11-29
* [`95a5f141`](https://github.com/NixOS/nixpkgs/commit/95a5f1411645416240a59b75a04ee70997fc6bcc) nixos/plasma5: Dont add samba a second time to `environment.systemPackages`
* [`ea8f862a`](https://github.com/NixOS/nixpkgs/commit/ea8f862acf5a5cdc678f2b97c7579a810c0c15f6) mkosi: drop patches backported to systemd 254.6
* [`a18b35ae`](https://github.com/NixOS/nixpkgs/commit/a18b35ae5bba71286ecde1bf7abe157106fc69ab) perl536: 5.36.1 -> 5.36.3
* [`8aac6da1`](https://github.com/NixOS/nixpkgs/commit/8aac6da1c3df78bd6b53fd6811c7ceb82e2a912d) perl538: 5.38.0 -> 5.38.2
* [`9d619cb7`](https://github.com/NixOS/nixpkgs/commit/9d619cb756cdf8839cca7fb450081ab318af3f88) grpc: 1.59.3 -> 1.60.0
* [`ffa8947f`](https://github.com/NixOS/nixpkgs/commit/ffa8947f4aecee1a7ceb55578159f57f3046f9fc) opam: fix build on darwin
* [`fa58b67d`](https://github.com/NixOS/nixpkgs/commit/fa58b67d7ac3db8b1ba27c4a4bf531f5d6935ec1) http-parser: Delete unused patch
* [`33f464b6`](https://github.com/NixOS/nixpkgs/commit/33f464b661f939689aa56af6b6e27b504c5afb93) http_parser: fix copying outputs for static build
* [`e0f242ae`](https://github.com/NixOS/nixpkgs/commit/e0f242aefeacce990f7c18113ac24ed5da56d93a) python311Packages.cryptography: 41.0.5 -> 41.0.7
* [`4358d06d`](https://github.com/NixOS/nixpkgs/commit/4358d06d99b6443e94ee5883a8b7625fc68bef30) python311Packages.cryptography-vectors: 41.0.5 -> 41.0.7
* [`8b51cdd3`](https://github.com/NixOS/nixpkgs/commit/8b51cdd3bea18e806e3ed63add8e19292dfc84ec) rustc: add a compiler wrapper
* [`8929ba83`](https://github.com/NixOS/nixpkgs/commit/8929ba838fa34da64f1490a4f47209d20c9346be) rustc: use the wrapper for fastCross sysroot
* [`52a13b81`](https://github.com/NixOS/nixpkgs/commit/52a13b8125c47617e47902351e6d6d47e675c3a7) separateDebugInfo: use NIX_RUSTFLAGS
* [`68aaaec7`](https://github.com/NixOS/nixpkgs/commit/68aaaec7d2844cf16706b71b80d433f1b426e733) gcc12, gcc13: fix typos in comments around __FILE__ patch
* [`96257050`](https://github.com/NixOS/nixpkgs/commit/962570502025732acf10f2101ae94cb882eca61e) perl.perl-cross: 1.5 -> 84db4c71
* [`9d25b89a`](https://github.com/NixOS/nixpkgs/commit/9d25b89a2a137aa8e5d84faaec5e24791a08bcaa) maintainers: add zedseven
* [`f5060bb7`](https://github.com/NixOS/nixpkgs/commit/f5060bb7ee0c8a33763e1c26f8ca9e1d975168e9) nom: 2.0.5 -> 2.1.0
* [`7a40fdc2`](https://github.com/NixOS/nixpkgs/commit/7a40fdc288e69ba94947c1c4ec29c0f24e461eef) krita: 5.1.5 -> 5.2.0
* [`9b9df554`](https://github.com/NixOS/nixpkgs/commit/9b9df554a2f655ac9b7dc1963ed0726e1952c537) vimPlugins.nvim-ts-rainbow: deprecate
* [`249a6de7`](https://github.com/NixOS/nixpkgs/commit/249a6de70328745500616204209551612bece7e5) graphite2: fix cross-compilation
* [`cd6ff2f7`](https://github.com/NixOS/nixpkgs/commit/cd6ff2f7cee49f132d125bd1e79fe4693eb2599b) man-db: 2.11.2 -> 2.12.0
* [`c8cdc399`](https://github.com/NixOS/nixpkgs/commit/c8cdc3999e773edcdae8a24f396704e23c11c143) libgcrypt: 1.10.2 -> 1.10.3
* [`3adb26e8`](https://github.com/NixOS/nixpkgs/commit/3adb26e89899d668a2d24d89a28ef804bc85c90c) libxslt: 1.1.38 -> 1.1.39
* [`1f279037`](https://github.com/NixOS/nixpkgs/commit/1f27903774d0b5c96fd8e1bef5b57929038c2ea5) iwd: backport fix for ell-0.61 (add rtnetlink.h inclusion)
* [`9fe8c004`](https://github.com/NixOS/nixpkgs/commit/9fe8c004ad5bcf36f1479854ac0893f81e680784) ell: 0.59 -> 0.61
* [`8177c2e8`](https://github.com/NixOS/nixpkgs/commit/8177c2e81f825b6d73532e0844eb8720d6c7b58b) iwd: 2.8 -> 2.10
* [`01494384`](https://github.com/NixOS/nixpkgs/commit/014943848a796c0c2bf0615be0ee1009ff685cd8) zix: apply upstream fix for fdatasync() on darwin
* [`3602b74f`](https://github.com/NixOS/nixpkgs/commit/3602b74fad0592c3e41a126ae0b083f9a05422a5) zix: enable tests
* [`5f3a2d68`](https://github.com/NixOS/nixpkgs/commit/5f3a2d687ef2b9b04184062f899a881851b07747) shadow: 4.14.1 -> 4.14.2
* [`235e16e9`](https://github.com/NixOS/nixpkgs/commit/235e16e90f0fd324615eb290c4a2448df1c9ceab) nlohmann_json: 3.11.2 -> 3.11.3
* [`d738269f`](https://github.com/NixOS/nixpkgs/commit/d738269f281167e70956433ce20326d203a48b4f) libkrb5: 1.20.2 -> 1.21.2
* [`0027d68c`](https://github.com/NixOS/nixpkgs/commit/0027d68ced4b1700b5db0ada2ae878bcaca86e88) openblas: 0.3.24 -> 0.3.25
* [`c4b3cc03`](https://github.com/NixOS/nixpkgs/commit/c4b3cc031e051233d7dfa6f124db215d0fb31224) nodejs: default to nodejs_20
* [`6864df8a`](https://github.com/NixOS/nixpkgs/commit/6864df8a826078955482d8df01e3163f4018441b) libass: put the release note into 24.05
* [`0ee8802f`](https://github.com/NixOS/nixpkgs/commit/0ee8802f859ff6d0e690618d0b172b209a845a47) ocamlPackages.merlin: 4.12 → 4.13
* [`7cb40bcd`](https://github.com/NixOS/nixpkgs/commit/7cb40bcdcc813097a36ad65781f8adfb68e9a5fe) ocamlPackages.merlin: Drop unused source hashes
* [`b8138aa5`](https://github.com/NixOS/nixpkgs/commit/b8138aa59ecb734ca07d2f790fd7e7066fd709ec) unison-ucm: M5g -> M5j
* [`abe69649`](https://github.com/NixOS/nixpkgs/commit/abe69649526224d9dcd95260f0ee519f9f74baec) emacsPackages.lspce: unstable-2023-10-30 -> unstable-2023-12-01
* [`e3c52566`](https://github.com/NixOS/nixpkgs/commit/e3c52566dbe401ed66205d0d59ac3db6a6b24b30) pest-ide-tools: fix package not building on Darwin
* [`66f8bb33`](https://github.com/NixOS/nixpkgs/commit/66f8bb337ade76dbe6e0ddf2e62593046753ac90) shotcut: 21.09.20 -> 23.11.29
* [`d3ceb22d`](https://github.com/NixOS/nixpkgs/commit/d3ceb22d663e1775194c7946f2cf781e9353085f) mlt: fix jackrack support
* [`ec80591e`](https://github.com/NixOS/nixpkgs/commit/ec80591e9467ae784934f30fb43d1d464121d73b) libkrb5: fix build on darwin: add `kerberos` and `xpc` to propagated build inputs
* [`c583ee74`](https://github.com/NixOS/nixpkgs/commit/c583ee748a91b1da9ef36e8da5e565b7f114703f) bluez: cherry-pick upstream fix for devices not pairing sometimes
* [`94a3c175`](https://github.com/NixOS/nixpkgs/commit/94a3c175826801407a66f4f992407755fdebf83d) lib.systems.elaborate: add libDir attribute
* [`bf6f0d3c`](https://github.com/NixOS/nixpkgs/commit/bf6f0d3cf4e1ed8c146b4e028b80be26383f5036) nixos/ldso: init module
* [`57f06683`](https://github.com/NixOS/nixpkgs/commit/57f0668383abd4a8116d9edd032146e55eb7b483) xsimd: refresh musl and darwin patches
* [`3fb3016a`](https://github.com/NixOS/nixpkgs/commit/3fb3016a0bd5e80a5cca2c9084729eff2311ebd3) ibus-engines.bamboo: 0.7.8 -> 0.8.2-rc18
* [`5d7e9d25`](https://github.com/NixOS/nixpkgs/commit/5d7e9d25ac15513b5cfe2f42d5a84cceba713fe7) borgbackup: 1.2.6 -> 1.2.7
* [`b5ac5c96`](https://github.com/NixOS/nixpkgs/commit/b5ac5c9612f2c21661c2f4ad536762754a5c8756) libsForQt5.mauiPackages: 3.0.1 -> 3.0.2
* [`89ef7b76`](https://github.com/NixOS/nixpkgs/commit/89ef7b76f3be2540cbb3d99a20c99029d481a613) nixos-rebuild: passthru accept-flake-config
* [`2ab00e47`](https://github.com/NixOS/nixpkgs/commit/2ab00e471f7b408e8716c5ed8de11b5ed63ffab5) dnscontrol: 4.6.2 -> 4.6.3
* [`a8bb784e`](https://github.com/NixOS/nixpkgs/commit/a8bb784e6d41d5f16e082d537500ce7b6cb7bb23) vadimcn.vscode-lldb.adapter: fix passthru adapter
* [`0d84d187`](https://github.com/NixOS/nixpkgs/commit/0d84d1878037ee12ddd66f2faaf54da89702fb30) dsdcc: 1.9.4 -> 1.9.5
* [`1530d9b6`](https://github.com/NixOS/nixpkgs/commit/1530d9b60dd30ac38a0a906239e4aef6c9d1f634) fasm: 1.73.31 -> 1.73.32
* [`7e11e9ae`](https://github.com/NixOS/nixpkgs/commit/7e11e9ae3ec8fb83b2a96430e088abb107096375) pachyderm: 2.7.6 -> 2.8.1
* [`3a6b8cd8`](https://github.com/NixOS/nixpkgs/commit/3a6b8cd838c7e3e124c3672a367a3314af919b9a) guile_3_0: remove inactive maintainers
* [`f8fda473`](https://github.com/NixOS/nixpkgs/commit/f8fda4730fe9d7567784540b26a054d64d70567d) geos: 3.11.2 -> 3.12.1
* [`d52e7fea`](https://github.com/NixOS/nixpkgs/commit/d52e7fea87498f4eb82a988d09780c4a4e02eafc) arti: 1.1.10 -> 1.1.11
* [`08fa5394`](https://github.com/NixOS/nixpkgs/commit/08fa5394e3a7a9a06358bd3dbdfe918ce554c4b6) freetype: ran nixpkgs-fmt
* [`62acfe8a`](https://github.com/NixOS/nixpkgs/commit/62acfe8ae2a8fe2df612cce8f12d4b9d64a7f04e) okteto: 2.22.3 -> 2.23.0
* [`1f13eabc`](https://github.com/NixOS/nixpkgs/commit/1f13eabcd6f5b00fe9de9575ac52c66a0e887ce6) go: 1.21.4 -> 1.21.5
* [`10f62d34`](https://github.com/NixOS/nixpkgs/commit/10f62d348bea474cf95abdb91457ab497e664a6f) go_1_20: 1.20.11 -> 1.20.12
* [`75c2a9de`](https://github.com/NixOS/nixpkgs/commit/75c2a9deebc306e3afc3cd1ffd054fe070ec9a1d) altair: 5.2.6 -> 5.2.13
* [`2e38c42c`](https://github.com/NixOS/nixpkgs/commit/2e38c42cbb60da4446e82b13dafe393fab031c8c) vlang: weekly.2023.44 -> 0.4.3
* [`f59d1cf6`](https://github.com/NixOS/nixpkgs/commit/f59d1cf6d6494900826bf80fa6dd7547d51e75d3) build-support/php: prevent the creation of symlinks of `bin` ending with `.bat`
* [`d2232269`](https://github.com/NixOS/nixpkgs/commit/d2232269ed9a61ce80b96b26ad104f82292fd973) mosdepth: 0.3.5 -> 0.3.6
* [`1b2bab09`](https://github.com/NixOS/nixpkgs/commit/1b2bab090cf0a4bb8eefec62bf382263bbecf122) geos: keep version 3.11 of package
* [`8a9d435c`](https://github.com/NixOS/nixpkgs/commit/8a9d435c4a49c48aeeb233e8f1b93f604c01c19a) python3Packages.pygeos: use GEOS 3.11
* [`1c8e6e66`](https://github.com/NixOS/nixpkgs/commit/1c8e6e66934fc9ecc77cf2508771c0abe900d67b) trivy: 0.47.0 -> 0.48.0
* [`853e859a`](https://github.com/NixOS/nixpkgs/commit/853e859ac8b77fc15a2f6efcaa1fd17047c528de) vault-bin: 1.15.3 -> 1.15.4
* [`7cf8d687`](https://github.com/NixOS/nixpkgs/commit/7cf8d6878561e8b2e4b1186f79f1c0e66963bdac) vault: 1.14.7 -> 1.14.8
* [`d2d22158`](https://github.com/NixOS/nixpkgs/commit/d2d22158a2931e490a71002b826cec1134a85423) androidStudioPackages.stable: 2022.3.1.20 -> 2023.1.1.26
* [`18437fb3`](https://github.com/NixOS/nixpkgs/commit/18437fb33d2002cdf0423fa4dff0169d0f327bf7) python3Packages.shapely: keep version 1.8
* [`6e5571b0`](https://github.com/NixOS/nixpkgs/commit/6e5571b09b69b12063bd5db71824aed1c52b3118) rqbit: 3.2.0 -> 4.0.1
* [`b04aa8e7`](https://github.com/NixOS/nixpkgs/commit/b04aa8e72e752713af6944aefa9d74c6f7b1dedd) himitsu: 0.4 -> 0.5
* [`f39eb362`](https://github.com/NixOS/nixpkgs/commit/f39eb36250a7bd11bacc3454d9378f5bcdf683cf) nixos/snapraid: remove from top-level
* [`9a07607d`](https://github.com/NixOS/nixpkgs/commit/9a07607d713f3fdfe52c4275101d1bb59eb6e0ef) kikit: use shapely 1.8
* [`4dcf815a`](https://github.com/NixOS/nixpkgs/commit/4dcf815a7e442bbd12eb3fd278e5f870e0c4427a) hipchat: remove
* [`5c3dd9a5`](https://github.com/NixOS/nixpkgs/commit/5c3dd9a59e0ac4eb072177b20ad134600effdd74) nebula: 1.7.2 -> 1.8.0
* [`73f47900`](https://github.com/NixOS/nixpkgs/commit/73f47900fa9ed8ede153fdafbda166ea3c228f9d) maintainers: add euraka-cpu
* [`c975ff60`](https://github.com/NixOS/nixpkgs/commit/c975ff60fc00336c64509e93b2b7e6b0b8af860a) geos: rename geos39 to geos_3_9
* [`0d883c3c`](https://github.com/NixOS/nixpkgs/commit/0d883c3cea84a796499780d91930e7ca9633d387) geos: rename geos311 to geos_3_11
* [`8b5d46f1`](https://github.com/NixOS/nixpkgs/commit/8b5d46f1ce15b75312c17b999a47fdd351a3b0a9) python3Packages.shapely: rename shapely18 to shapely_1_8
* [`e5d396da`](https://github.com/NixOS/nixpkgs/commit/e5d396dad7ad7ed53cdf4b8b1f41536abbb8377c) lima-bin: 0.18.0 -> 0.19.0
* [`f11fd28a`](https://github.com/NixOS/nixpkgs/commit/f11fd28ab4672700e004ebec03127506d1c41047) rtx: 2023.11.2 -> 2023.12.18
* [`983effd8`](https://github.com/NixOS/nixpkgs/commit/983effd86a873e5fc4a370829e9f27ad52b2e552) gruvbox-plus-icon-pack: init at unstable-2023-11-07
* [`0b28ef1c`](https://github.com/NixOS/nixpkgs/commit/0b28ef1c387851ef731c3f310b6705cdec0b37f5) sgt-puzzles: 20231025.35f7965 -> 20231120.08365fb
* [`d375d45f`](https://github.com/NixOS/nixpkgs/commit/d375d45f033c164133f60993aed89965f32859e2) k6: 0.47.0 -> 0.48.0
* [`cea7115f`](https://github.com/NixOS/nixpkgs/commit/cea7115f2753c6f93dccb0517c4837b97779ece2) freetype: Add mingw32 hostPlatform build support
* [`ef545093`](https://github.com/NixOS/nixpkgs/commit/ef5450930394ab3bb73354df807d8cd77b48e4e0) k9s: 0.28.2 -> 0.29.0
* [`5b07f4c8`](https://github.com/NixOS/nixpkgs/commit/5b07f4c86159336f13a2a12db567defdabb62fd0) k9s: 0.29.0 -> 0.29.1
* [`43b086d5`](https://github.com/NixOS/nixpkgs/commit/43b086d53492c3fdcbc6128132d5e88fa7f71576) bluez: apply patch for CVE-2023-45866
* [`a5b8caa3`](https://github.com/NixOS/nixpkgs/commit/a5b8caa346ba946749136c9896b40d25266958f0) cudatoolkit: Replace vendored Qt plugins with symlinks
* [`afbbb2c5`](https://github.com/NixOS/nixpkgs/commit/afbbb2c528e4782214fdfed50b17bccddcf9003b) paperless-ngx: 2.0.1 -> 2.1.0
* [`0a7702e8`](https://github.com/NixOS/nixpkgs/commit/0a7702e8a5e5503fd1742d851ae214004ed1bf70) maintainers: add ajaxbits
* [`d7665fd1`](https://github.com/NixOS/nixpkgs/commit/d7665fd14defbd047ddb9879c2f320ff2fee8c97) tdlib: 1.8.21 -> 1.8.22
* [`236bcc73`](https://github.com/NixOS/nixpkgs/commit/236bcc73154eca6a64039ffc7314c3fe620852d7) nbd: format with nixpkgs-fmt
* [`268b1444`](https://github.com/NixOS/nixpkgs/commit/268b144407ffcbd8e584364fe269a36b1a6de963) nbd: add nickcao to maintainers
* [`8c124f6e`](https://github.com/NixOS/nixpkgs/commit/8c124f6e1e9b0ef4ccec68e371a84b537984d1bd) nbd: add missing libnl dependency
* [`52f1d9b0`](https://github.com/NixOS/nixpkgs/commit/52f1d9b03ae38126e7f648634fcad35897f464ed) nbd: set sysconfdir to /etc
* [`d12f11bb`](https://github.com/NixOS/nixpkgs/commit/d12f11bbb1b9b49b5deb8447062ce03eb36ccbfa) nbd: drop ad-hoc copying of readme, the manpages already cover everything
* [`697c460c`](https://github.com/NixOS/nixpkgs/commit/697c460ce4dd09f15e9c99801125c7ea2cffb543) nsd: 4.7.0 -> 4.8.0
* [`2275ffd7`](https://github.com/NixOS/nixpkgs/commit/2275ffd75d61ec5312ce20fe0233d4dac7dd9de6) subnetcalc: 2.4.22 -> 2.4.23
* [`4cc50ccb`](https://github.com/NixOS/nixpkgs/commit/4cc50ccb6ec851ab14711a8a858a37e7863ac9ff) deepin.deepin-icon-theme: 2023.04.03 -> 2023.11.28
* [`da05a5f9`](https://github.com/NixOS/nixpkgs/commit/da05a5f95b470fb7c3453ff594f4216846916899) apktool: 2.9.0 -> 2.9.1
* [`99df6a7a`](https://github.com/NixOS/nixpkgs/commit/99df6a7a5474b80edc5cf7f6a377964889d8c2fe) cargo-cyclonedx: 0.3.8 -> 0.4.1
* [`adadeffe`](https://github.com/NixOS/nixpkgs/commit/adadeffea9192691f1068afa9759f75ecc1b5b8b) utf8cpp: 3.2.5 -> 4.0.3
* [`b0cb8660`](https://github.com/NixOS/nixpkgs/commit/b0cb8660121f57ec0cd4c63a6a5179b90e3c337c) saml2aws: 2.36.12 -> 2.36.13
* [`9f9f0356`](https://github.com/NixOS/nixpkgs/commit/9f9f0356bc193839cb70be4ec3e91d2bf8250b2b) openai-triton-llvm: 14.0.6-f28c006a5895 -> 17.0.0-c5dede880d17
* [`cb64fcc7`](https://github.com/NixOS/nixpkgs/commit/cb64fcc78730879189ab78dc9f792c238361799f) emilua: 0.4.3 -> 0.5.1
* [`d5341eed`](https://github.com/NixOS/nixpkgs/commit/d5341eed0d99b84d2c3c65220e536da0af027a5f) gtree: 1.10.3 -> 1.10.4
* [`72235721`](https://github.com/NixOS/nixpkgs/commit/722357216e30d49b4f682bc697725b75d0857103) apktool: add changelog to meta
* [`435b0778`](https://github.com/NixOS/nixpkgs/commit/435b0778e223c4b312f4f10b97dc723ff3cddac6) paperless-ngx: 2.1.0 -> 2.1.1
* [`403e3dbc`](https://github.com/NixOS/nixpkgs/commit/403e3dbcbd3186733d0db2a6485821fa5510c739) smartgithg: 22.1.5 -> 23.1.1
* [`3cf13345`](https://github.com/NixOS/nixpkgs/commit/3cf1334510de69a4c2ceb360b57fa6c9821c6c22) mdhtml: 0.3.1 -> 1.0
* [`177363f8`](https://github.com/NixOS/nixpkgs/commit/177363f8ff0c612fafac3405e12b75a9abe6f38b) questdb: 7.3.4 -> 7.3.7
* [`0f0a6634`](https://github.com/NixOS/nixpkgs/commit/0f0a6634a0e2e17a38d4c468d9e0ba27af4be916) regbot: 0.5.4 -> 0.5.5
* [`3b2e32b5`](https://github.com/NixOS/nixpkgs/commit/3b2e32b5117e3da6fa3de1c8b67f9bf6660095b7) opensubdiv: use cuda_nvcc only if cudaSupport
* [`458d7055`](https://github.com/NixOS/nixpkgs/commit/458d70557d7ba3f476764641748a8ef8f7d0aff6) emacs: set 29 as default version
* [`d28abe1c`](https://github.com/NixOS/nixpkgs/commit/d28abe1cc627d21707c9ae7b74822638e7fc1a78) iroh: 0.5.1 -> 0.11.0
* [`72bd4bbb`](https://github.com/NixOS/nixpkgs/commit/72bd4bbb58f6867a00af2a0ddaae2d601c1ee2c7) lib.attrsets.longestValidPathPrefix: init
* [`6b021471`](https://github.com/NixOS/nixpkgs/commit/6b0214711c9c518ed6a504c3489c342c2cff3ab0) asitop: 0.0.23 -> 0.0.24
* [`7d993b95`](https://github.com/NixOS/nixpkgs/commit/7d993b9521aa8a229648a1c33e730df8b630670f) lib.attrsets.hasAttrByPath: Document law and laziness, and test it
* [`aa62e4d7`](https://github.com/NixOS/nixpkgs/commit/aa62e4d76378606b6ef0e4234ed327b964aa2e58) cargo-mutants: 23.11.2 -> 23.12.0
* [`057a7ef3`](https://github.com/NixOS/nixpkgs/commit/057a7ef32482e1bb6f1f7232aaaf905e96cd048b) libbitcoin{,client,explorer,network,protocol}: 3.5.0 -> 3.8.0
* [`c1ffcb40`](https://github.com/NixOS/nixpkgs/commit/c1ffcb40904a48fe74f44ccad4230cd35bc00836) androidStudioPackages.canary: 2023.2.1.14 -> 2023.2.1.17
* [`2b25625c`](https://github.com/NixOS/nixpkgs/commit/2b25625c1f6072b5c5b571486c4cf45b56799297) python3Packages.openai-triton: 2.0.0 -> 2.1.0
* [`81059927`](https://github.com/NixOS/nixpkgs/commit/810599277409a7d564c159983f3bb4a51aed1ea3) cudaPackages.cudatoolkit: propagate the hook to nativeBuildInputs correctly
* [`7c97d5f5`](https://github.com/NixOS/nixpkgs/commit/7c97d5f5c441cce6ad717a85676eec7c7ff1b27e) suitesparse: migrate to redist cuda
* [`3658f481`](https://github.com/NixOS/nixpkgs/commit/3658f481cb6f2e8f65f1f0fe117972bedadd0cbf) sqldef: 0.16.10 -> 0.16.13
* [`e730fe9b`](https://github.com/NixOS/nixpkgs/commit/e730fe9bf6b7c290583f61477e05eebfc88e32fc) janus-gateway: 1.2.0 -> 1.2.1
* [`8118b7cc`](https://github.com/NixOS/nixpkgs/commit/8118b7cc36801877da403b1c2d957ea8c42fa341) prometheus: 2.48.0 -> 2.48.1
* [`ebd96e0c`](https://github.com/NixOS/nixpkgs/commit/ebd96e0c7d4040eb480874532dcfc96ea9410763) broot: 1.29.0 -> 1.30.0
* [`b99682e3`](https://github.com/NixOS/nixpkgs/commit/b99682e31bbecec31019fb762755ee7c656de339) pcsctools: add passthru.updateScript
* [`4fbc0cc5`](https://github.com/NixOS/nixpkgs/commit/4fbc0cc53b5c268b305f1da7fe6aee461c3c0f5c) pcsctools: 1.6.2 -> 1.7.0
* [`81f4e3c7`](https://github.com/NixOS/nixpkgs/commit/81f4e3c78459351cb150019b6cbdb819967028ea) containerd: 1.7.9 -> 1.7.11
* [`f6956884`](https://github.com/NixOS/nixpkgs/commit/f6956884974b621b9e02df8d259e57d2ac5c78f2) fix
* [`9a618e43`](https://github.com/NixOS/nixpkgs/commit/9a618e439f9d9036236bd14c85e5a74204799267) pcsctools: add passthru.tests.version
* [`30008fd7`](https://github.com/NixOS/nixpkgs/commit/30008fd748ea919310cc02818da4523046bc6d83) pcsctools: add meta.{changelog,mainProgram}
* [`ea03092e`](https://github.com/NixOS/nixpkgs/commit/ea03092e128ea0ffc2fee178f671aa8acfed5630) pcsctools: add anthonyroussel to maintainers
* [`5b070095`](https://github.com/NixOS/nixpkgs/commit/5b0700954643a8164e3c316ebba1de3d09a3f9a9) pcsc-tools: init from pcsctools
* [`848b539f`](https://github.com/NixOS/nixpkgs/commit/848b539f97a91650bed4c07f28c25aa56bd68dc6) pcsc-tools: enable darwin build
* [`06c4c391`](https://github.com/NixOS/nixpkgs/commit/06c4c391813aa656da77cace4d46a6e258b51269) spglib: 2.1.0 -> 2.2.0
* [`652e9e49`](https://github.com/NixOS/nixpkgs/commit/652e9e4956ad9b6be2f4f0865a1755a3062b44ac) maintainers: add nicolas-goudry
* [`84bb50ca`](https://github.com/NixOS/nixpkgs/commit/84bb50caec7b7c59e6a40bac7ab78a673c999419) gitkraken: 9.9.2 -> 9.10.0
* [`70cc2908`](https://github.com/NixOS/nixpkgs/commit/70cc290842c6488479218911ced40f6e8ad941a7) python311Packages.google-ai-generativelanguage: 0.3.4 -> 0.3.5
* [`2010a2f7`](https://github.com/NixOS/nixpkgs/commit/2010a2f7e2faa689137d4418188037ffce38b46d) calc: 2.15.0.1 -> 2.15.0.2
* [`039f73f1`](https://github.com/NixOS/nixpkgs/commit/039f73f134546e59ec6f1b56b4aff5b81d889f64) flake: fix `lib.trivial.version` when used from a flake
* [`bb7921d1`](https://github.com/NixOS/nixpkgs/commit/bb7921d1d6a0df8ebdc36b8ee745fe704b93b846) flake: also provide proper version info for lib's flake
* [`130935a3`](https://github.com/NixOS/nixpkgs/commit/130935a3e33387e32837384aada2cf3739e10926) typos: 1.16.23 -> 1.16.24
* [`f4d95eae`](https://github.com/NixOS/nixpkgs/commit/f4d95eae1e505f111b1e54ebefb9de8c6e3d5c2f) minecraft-server: 1.20.2 -> 1.20.4
* [`12e26f3c`](https://github.com/NixOS/nixpkgs/commit/12e26f3cfc522b5c5681c4feb817598066079b33) jetbrains: 2022.3 -> 2023.3 EAP
* [`73dbdc27`](https://github.com/NixOS/nixpkgs/commit/73dbdc270797c9846aec04c584cd79e12a256c60) jetbrains.plugins: update
* [`897087ec`](https://github.com/NixOS/nixpkgs/commit/897087ecc2b74171f8f697020c188e2c882f4dbd) jetbrains: 2023.2.3 -> 2023.3 EAP
* [`8dfa8a91`](https://github.com/NixOS/nixpkgs/commit/8dfa8a9147fe9833f6ea48ea42b57b176842ef76) jetbrains.plugins: update
* [`f7528df7`](https://github.com/NixOS/nixpkgs/commit/f7528df7c568fb7d1c7313886621e2a74d060a08) jetbrains: 2023.2.2 -> 2023.3 EAP
* [`571066d3`](https://github.com/NixOS/nixpkgs/commit/571066d3f7ec3bd98d8a892083fc33b312fe74a6) jetbrains.plugins: update
* [`5d664972`](https://github.com/NixOS/nixpkgs/commit/5d66497260d67c0392c0e6c9a09c6fe8ac10d43a) memtree: unstable-2023-11-04 → 2023-11-22
* [`1b46ab02`](https://github.com/NixOS/nixpkgs/commit/1b46ab02fd39ffcf3316b2e9fbc46948e3b6a903) memtree: Replace custom `checkPhase` with `pytestCheckHook`
* [`4c3cb337`](https://github.com/NixOS/nixpkgs/commit/4c3cb337881549b2b4464b7c1bb0827d61bd2789) memtree: Add missing `mainProgram` metadata
* [`b323b1da`](https://github.com/NixOS/nixpkgs/commit/b323b1da57054cbf16e9bf71a0aed84559da9594) davix: 0.8.4 -> 0.8.5
* [`8b217a82`](https://github.com/NixOS/nixpkgs/commit/8b217a82a25d34c4306271bc0cf301caeae32ba7) vcmi: 1.3.2 -> 1.4.0
* [`7811b310`](https://github.com/NixOS/nixpkgs/commit/7811b310b6cdbf5bcd204892a55c7e393c940f72) swayimg: move to by-name
* [`b978927d`](https://github.com/NixOS/nixpkgs/commit/b978927dcd6d3bc39be572d5ea5003cb6c6066ab) vtm: 0.9.16 -> 0.9.27
* [`31f22390`](https://github.com/NixOS/nixpkgs/commit/31f223904d9aa30f0c052b301557775243a03278) swayimg: 1.11 -> 1.12
* [`ba94c68e`](https://github.com/NixOS/nixpkgs/commit/ba94c68eb0fe7660e0c4d6109e1afc832737b772) swayimg: add version tester
* [`c8efe731`](https://github.com/NixOS/nixpkgs/commit/c8efe731654340e9ce4a2a42e6cf6500aedd53ad) lomiri.mediascanner2: init at 0.115
* [`ca556191`](https://github.com/NixOS/nixpkgs/commit/ca556191757470ccb68697eb89cace55a4558f2d) lomiri.trust-store: init at unstable-2023-10-17
* [`cdc6ed5c`](https://github.com/NixOS/nixpkgs/commit/cdc6ed5c2669bfd7d419091677f0cdb4cb6b097d) mpvScripts.cutter: simplify with `buildLua`
* [`89e75ee8`](https://github.com/NixOS/nixpkgs/commit/89e75ee87a5bdf4f25669f2fdc697f56d5410b9b) mpvScripts.cutter: unstable-2021-02-03 → 2023-11-09
* [`0ce537f0`](https://github.com/NixOS/nixpkgs/commit/0ce537f0fa692638db4f3deeeb670fb0b85b2223) fzf: reduce closure size by just quieten perl instead of providing glibcLocales
* [`6e4f1294`](https://github.com/NixOS/nixpkgs/commit/6e4f129474a33f2ff0458e05b955643f9dc290f4) rocketchat-desktop: 3.9.10 -> 3.9.11
* [`282d9fd9`](https://github.com/NixOS/nixpkgs/commit/282d9fd9ea3867a87fdcaaf3ace95d03bff64562) webtorrent-mpv-hook: 1.3.3 → 1.4.1
* [`dc8feaa9`](https://github.com/NixOS/nixpkgs/commit/dc8feaa9b5f98c40ac1ce0b2e73170281effe915) geogram: 1.8.3 -> 1.8.6
* [`ab2df828`](https://github.com/NixOS/nixpkgs/commit/ab2df8282fc5a565726b936f236e8bbbf3703807) mpvScripts.thumbfast: unstable-2023-06-04 → 2023-12-08
* [`de5adfc2`](https://github.com/NixOS/nixpkgs/commit/de5adfc28509f3f383af56c045611af1fd220330) qutebrowser: 3.0.2 -> 3.1.0
* [`41fe0777`](https://github.com/NixOS/nixpkgs/commit/41fe0777299eb131745747323241b2085569184b) mpvScripts.thumbfast: bring `mpv` in `PATH` instead of patching its path in
* [`a351c9b5`](https://github.com/NixOS/nixpkgs/commit/a351c9b530bd7bd385c4f0e89606e09f46f50829) nixos/wpa_supplicant: Ensure the generated config isn't world-readable
* [`cd79e7c0`](https://github.com/NixOS/nixpkgs/commit/cd79e7c075ebf0191df542897f46c21587182762) mpvScripts.visualizer: unstable-2021-07-10 → 2023-08-13
* [`8bf840c3`](https://github.com/NixOS/nixpkgs/commit/8bf840c35847ec94d57be8b5349f14b4e4aa92be) mpvScripts.visualizer: simplify with `buildLua`
* [`59adfe40`](https://github.com/NixOS/nixpkgs/commit/59adfe40d229176970af951a545cac567d9e1653) upx: add update script
* [`f6895492`](https://github.com/NixOS/nixpkgs/commit/f68954929762454e8feb0fc8e39598e5306de936) upx: 4.2.0 -> 4.2.1
* [`4a8c4be3`](https://github.com/NixOS/nixpkgs/commit/4a8c4be3983322557da6a3b9e588c3b3825b0fe9) turbovnc: 3.0.3 -> 3.1
* [`7e150fb8`](https://github.com/NixOS/nixpkgs/commit/7e150fb88741fbfff9c270ebc259f75cfecda41a) colima: 0.6.5 -> 0.6.6
* [`d3d9c1c6`](https://github.com/NixOS/nixpkgs/commit/d3d9c1c6b1710d6418eee324fa5023f08909e685) winePackages.{unstable,staging}: 8.20 -> 9.0-rc1
* [`73877a6f`](https://github.com/NixOS/nixpkgs/commit/73877a6f3459d2ff756074a470dae38a782442d5) jshon: fix build on aarch64-darwin
* [`2ba03035`](https://github.com/NixOS/nixpkgs/commit/2ba030352fcf58482a40717e04c0306ecee14f90) cargo-nextest: 0.9.63 -> 0.9.64
* [`d7605f18`](https://github.com/NixOS/nixpkgs/commit/d7605f18a97b30416a202a6905df237f37fc7eeb) nixos.shibboleth-sp: remove jammerful from meta.maintainers
* [`faf405f1`](https://github.com/NixOS/nixpkgs/commit/faf405f1144047daac734d228172281249b6b8cf) log4shib: remove jammerful from meta.maintainers
* [`6019cc97`](https://github.com/NixOS/nixpkgs/commit/6019cc9756b777d03bd5618e19062e7134a28a85) opensaml-cpp: remove jammerful from meta.maintainers
* [`32058230`](https://github.com/NixOS/nixpkgs/commit/320582300cce46ddafbacff49491da112c41e98a) shibboleth-sp: remove jammerful from meta.maintainers
* [`21a7f613`](https://github.com/NixOS/nixpkgs/commit/21a7f6131edd9d22044185436eeadf3ca060b85c) xml-tooling-c: remove jammerful from meta.maintainers
* [`be36b62b`](https://github.com/NixOS/nixpkgs/commit/be36b62bea5592b30355319192b28faaad86a2ab) gerrit: remove jammerful from meta.maintainers
* [`c933413f`](https://github.com/NixOS/nixpkgs/commit/c933413f2f4766e09ded216430d1e66ae892a4f6) maintainers: remove jammerful
* [`8f7b83c5`](https://github.com/NixOS/nixpkgs/commit/8f7b83c569e5834722ae1d613ac747a4fb5b582b) endlines: init at 1.9.2
* [`5bb8d4a7`](https://github.com/NixOS/nixpkgs/commit/5bb8d4a70e8672b9e21b99c1ed7d334be0b4ac70) tor-browser: use copyDesktopItems
* [`ad836af7`](https://github.com/NixOS/nixpkgs/commit/ad836af7f9d1a4200407dca16d6dfc802f4a19f8) tor-browser: use system install & simplify wrapper
* [`ad7d50a0`](https://github.com/NixOS/nixpkgs/commit/ad7d50a02f0cb532ffbc3c9b03ffa4f46f8be423) etcd_3_5: 3.5.10 -> 3.5.11
* [`f64eee41`](https://github.com/NixOS/nixpkgs/commit/f64eee41df7772429a2987b03a7c3c911d6f0368) pre-commit: 3.3.3 -> 3.6.0
* [`27bbec3c`](https://github.com/NixOS/nixpkgs/commit/27bbec3c0c7d9b0b0e6a80afae5ececc1801b8fb) moodle: 4.3 -> 4.3.1
* [`4b663a94`](https://github.com/NixOS/nixpkgs/commit/4b663a941782b815d9bc4482b7f1111aeffb3959) python311Packages.dulwich: 0.21.6 -> 0.21.7
* [`f6628888`](https://github.com/NixOS/nixpkgs/commit/f6628888779ec37029f9d4408f217ff594dd50ab) python311Packages.youtokentome: init at 1.0.6
* [`d6255094`](https://github.com/NixOS/nixpkgs/commit/d6255094450deac00b023c089728400f3bff764c) python311Packages.nvdlib: init at 0.7.6
* [`1ee8c8c4`](https://github.com/NixOS/nixpkgs/commit/1ee8c8c4613321f9ea0dd09fbafabe83134dbf4d) python311Packages.avidtools: init 0.1.1.2
* [`c15f4180`](https://github.com/NixOS/nixpkgs/commit/c15f418082b065d32791be9086468b0e8b8840e9) postgresql12JitPackages.plpgsql_check: 2.6.2 -> 2.7.0
* [`2b30f061`](https://github.com/NixOS/nixpkgs/commit/2b30f061b362eb681712fc35a2032117757c9665) xray: 1.8.4 -> 1.8.6
* [`659c0084`](https://github.com/NixOS/nixpkgs/commit/659c0084940aede2c9d90c6cf16735b3bf9690ee) prometheus-zfs-exporter: Added ldflags to add version label to
* [`22046dd4`](https://github.com/NixOS/nixpkgs/commit/22046dd4ede8b04b622fd4e77c7cfdc7567a001a) xfce.xfce4-docklike-plugin: init at 0.4.1
* [`b18e4eaa`](https://github.com/NixOS/nixpkgs/commit/b18e4eaa2a541713ab8834304296d2547b657077) zef: 0.21.0 -> 0.21.1
* [`1df4bba1`](https://github.com/NixOS/nixpkgs/commit/1df4bba1f1319465d4f43e05729a0f38db60e359) python311Packages.pymc: 5.10.0 -> 5.10.1
* [`55536179`](https://github.com/NixOS/nixpkgs/commit/55536179506be429a15432de9b83906d87dfc2af) python311Packages.pytensor: 2.18.1 -> 2.18.2
* [`78f5ed05`](https://github.com/NixOS/nixpkgs/commit/78f5ed053aba713ea2fc1226ec8193d298c221fc) lib/trivial: drop `rec` in favor of `lib` fixpoint
* [`ede5720a`](https://github.com/NixOS/nixpkgs/commit/ede5720a0dde969cf83dd7cbbe54ad8c5ff7a97b) flake/version overlay: review fixes
* [`cb289a92`](https://github.com/NixOS/nixpkgs/commit/cb289a9256254d00e147521388093468eaf202cb) flake: be backwards-compatible for `--impure`
* [`b96ba988`](https://github.com/NixOS/nixpkgs/commit/b96ba988d670ddb0e26ede4e3482624f4158a649) flake: drop libVersionInfoOverlay
* [`780e8ab5`](https://github.com/NixOS/nixpkgs/commit/780e8ab5a8731cc282ea215b1bf5dcffe597d2a5) rare: 1.10.3 -> 1.10.7
* [`e1260f80`](https://github.com/NixOS/nixpkgs/commit/e1260f8064bd237f531b82d8e3c9822e32a3866c) metasploit: 6.3.45 -> 6.3.46
* [`1b2394e2`](https://github.com/NixOS/nixpkgs/commit/1b2394e223e08d206d1d6ad0e8cf066df005ea83) python311Packages.yargy: rename from yagry
* [`68e29c7c`](https://github.com/NixOS/nixpkgs/commit/68e29c7cca5969ec21581c6728ccc2725704c120) zrok: 0.4.15 -> 0.4.18
* [`c2685f11`](https://github.com/NixOS/nixpkgs/commit/c2685f11a1dbed95e6bbd130936abd30267bbf32) tandoor-recipes: Fix URL import
* [`0833abbd`](https://github.com/NixOS/nixpkgs/commit/0833abbd49b9f2abc7675a1e6c17a3ae251d8eb4) libdynd: remove stdenv override
* [`c4198e32`](https://github.com/NixOS/nixpkgs/commit/c4198e3251cbfa6fe57cffe1e6215f66a429ceb5) python311Packages.dynd: mark as broken
* [`16a11b6b`](https://github.com/NixOS/nixpkgs/commit/16a11b6be33fbd4dd474c00ec5790b03ea9efc9d) swfmill: add darwin support
* [`7c1035d2`](https://github.com/NixOS/nixpkgs/commit/7c1035d290622a28369124faadeefaf160640235) quickjs: 2021-03-27 -> 2023-12-09
* [`91dc77ad`](https://github.com/NixOS/nixpkgs/commit/91dc77adaa237d2c93fa415b574a2b84a7e349b3) jetbrains.jdk: fix docs
* [`7e25c398`](https://github.com/NixOS/nixpkgs/commit/7e25c398095f7d620bdf64b65d4492bc248b5005) php81Extensions.opcache: fix compile on zts build
* [`a9221188`](https://github.com/NixOS/nixpkgs/commit/a92211886b1987a8a70791f3f6f37e56857b104c) strelka: fix build on gcc-12
* [`70ada52c`](https://github.com/NixOS/nixpkgs/commit/70ada52c57f8951f0cf8d82945effb6ba9f689fc) vivictpp: 0.3.1 -> 1.0.0
* [`143e44f5`](https://github.com/NixOS/nixpkgs/commit/143e44f5760982bdfddc78a24f007c91282fb4fe) metasploit: fix update script
* [`dc522329`](https://github.com/NixOS/nixpkgs/commit/dc522329ea630b328d6f8ed2149f149c17914e2c) rio: 0.0.29 -> 0.0.30
* [`7bc4955a`](https://github.com/NixOS/nixpkgs/commit/7bc4955aaa5bcb4faa4bc81403dc8492480aa6ca) upx: use finalAttrs
* [`3ca45e2b`](https://github.com/NixOS/nixpkgs/commit/3ca45e2bbb1dfcece5222c5cb7a7642542ec49cb) upx: add version test
* [`5a64fb27`](https://github.com/NixOS/nixpkgs/commit/5a64fb279993d632a4866c16e26aa14e5769d903) nixos/acme: add syntax highlighting to code blocks
* [`e377a77e`](https://github.com/NixOS/nixpkgs/commit/e377a77e8d795a199b01d7cb080efd09b059177a) colima: 0.6.6 -> 0.6.7
* [`a4c3ba0b`](https://github.com/NixOS/nixpkgs/commit/a4c3ba0b67183bb0b0a1dd12506ca0840446829b) pocketbase: 0.19.4 -> 0.20.0
* [`9692c0f8`](https://github.com/NixOS/nixpkgs/commit/9692c0f88a7b68f9a7631d0e88c51a5866f4f0b6) gnomeExtensions: update
* [`e75d394a`](https://github.com/NixOS/nixpkgs/commit/e75d394a65f0b4074e7608aeca636f18b9088793) contacts: drop xcbuild6Hook
* [`36df21cb`](https://github.com/NixOS/nixpkgs/commit/36df21cb967e0af90f7ed39fdd44abeabd61ebc6) xcbuild6Hook, xcodebuild6: drop
* [`f2e3aba1`](https://github.com/NixOS/nixpkgs/commit/f2e3aba1e477517c4d3b87f98baae51c06cf3c61) spicetify-cli: migrate to by-name
* [`8374ab21`](https://github.com/NixOS/nixpkgs/commit/8374ab2113c7522766acf5ab1af9d8c6824c06d4) spicetify-cli: 2.27.2 -> 2.28.1
* [`39899cea`](https://github.com/NixOS/nixpkgs/commit/39899cea55fac53be1f77693a2048de69122f586) maintainers: add tirimia
* [`ac30f5f4`](https://github.com/NixOS/nixpkgs/commit/ac30f5f4d6e044daacd0ae6f891bd2bb63ff6167) jigdo: 0.7.3 -> 0.8.2, refactor
* [`07f5f75d`](https://github.com/NixOS/nixpkgs/commit/07f5f75da675408023db689d5a39fe4a578c79e8) flwrap: remove stdenv override
* [`52587231`](https://github.com/NixOS/nixpkgs/commit/525872310821d6f5e99915097912f1ed58bec324) atuin: 17.0.1 -> 17.1.0
* [`ea483cfa`](https://github.com/NixOS/nixpkgs/commit/ea483cfa42dd5a8d7c67b35a26920c09e533657f) drumgizmo: fix build with gcc 13
* [`3ba69a0e`](https://github.com/NixOS/nixpkgs/commit/3ba69a0eed98e4869fa79aacc40d34607d697429) wl-gammarelay-rs: init at 0.3.2
* [`dd5012e1`](https://github.com/NixOS/nixpkgs/commit/dd5012e1669ff94dbcbb44ba6a1ee721c7533ad9) xqilla: fix build with gcc 11+
* [`6bf97b30`](https://github.com/NixOS/nixpkgs/commit/6bf97b30505737257072a330a42575003ac77276) vinegar: 1.5.8 -> 1.5.9
* [`70e59937`](https://github.com/NixOS/nixpkgs/commit/70e59937439f7347c06816774c00598e600c24af) non: fix build with gcc 11+
* [`f2dc1883`](https://github.com/NixOS/nixpkgs/commit/f2dc18834be35908a3cbc8af5c2e97e1d2d53c99) podman: 4.7.2 -> 4.8.1
* [`6cf771c1`](https://github.com/NixOS/nixpkgs/commit/6cf771c18174bf00ee229ff6de28a1b9a6d0650c) frankenphp: fix loading php extensions and custom config
* [`659c541a`](https://github.com/NixOS/nixpkgs/commit/659c541a069320622c3394b2cb5aec26315d38b0) cxxtools: 2.2.1 -> 3.0
* [`7b88d5d3`](https://github.com/NixOS/nixpkgs/commit/7b88d5d3888893784bc74f60b2bf378243fcd896) tntnet: 2.2.1 -> 3.0
* [`6c643560`](https://github.com/NixOS/nixpkgs/commit/6c6435606a8b7b937a2036aa51e2e68418e254a1) tntdb: 1.3 -> 1.4
* [`75c13bf6`](https://github.com/NixOS/nixpkgs/commit/75c13bf6aac049d5fec26c07c28389a72c25a30b) wasm-bindgen-cli: remove myself as a maintainer
* [`0566f3f1`](https://github.com/NixOS/nixpkgs/commit/0566f3f1a1a14d2a32d0ac4274034375fbd33866) mold: remove myself as a maintainer
* [`a83d30ff`](https://github.com/NixOS/nixpkgs/commit/a83d30ff4db69823f86a23cf8afa6f5852079f43) cxxtools: hardcode TZDIR
* [`839a7115`](https://github.com/NixOS/nixpkgs/commit/839a711508711b082dc0b1527ecc6faf7d49a7a7) bencode: remove stdenv override
* [`9585dfd3`](https://github.com/NixOS/nixpkgs/commit/9585dfd3bbe3663a7e778a8892388b726a07fe8a) opendbx: remove stdenv override
* [`17c1cc55`](https://github.com/NixOS/nixpkgs/commit/17c1cc555b34a3dccb6abfe845bb654b48491731) loki: remove stdenv override
* [`f1f87973`](https://github.com/NixOS/nixpkgs/commit/f1f879734fea3b8d41747221d964486df3279b80) ericw-tools: fix build with gcc 11+
* [`133fc77d`](https://github.com/NixOS/nixpkgs/commit/133fc77d70a88f920dc72fb721b422169c870983) cromfs: fix build with gcc 11+
* [`0fdc7bc6`](https://github.com/NixOS/nixpkgs/commit/0fdc7bc6b5d3cba6eadc1ba562a2efef535411dc) quickemu: 4.9.1 -> 4.9.2
* [`4ef4032e`](https://github.com/NixOS/nixpkgs/commit/4ef4032e6dd2964da529add016c0b2b4e3338336) squid: 5.9 -> 6.6
* [`f66cb202`](https://github.com/NixOS/nixpkgs/commit/f66cb20232b52bc40cb7b5d1e97f3e40b09181a3) web-ext: Include only production dependencies in build
* [`c8c2ae63`](https://github.com/NixOS/nixpkgs/commit/c8c2ae638aa2e723a2b3517c4390d3c46d671ee8) lib.pipe: Avoid creating scopes
* [`5793c49b`](https://github.com/NixOS/nixpkgs/commit/5793c49b0dbfce4cd7691f6cd849ae76bc97f5c5) vale: 2.29.7 -> 2.30.0
* [`c275e75b`](https://github.com/NixOS/nixpkgs/commit/c275e75b198ee621cbfcc7224d5e36ef903b3f8e) dmd: 2.105.2 -> 2.106.0
* [`ad647985`](https://github.com/NixOS/nixpkgs/commit/ad647985cf40f0970dac341f5677afafa96edeea) lib.toHexString: Statically compute hexDigits attrset
* [`a128a3f2`](https://github.com/NixOS/nixpkgs/commit/a128a3f234afb3d0a1d67b8b36e93cc629d0186d) lib.isConvertibleToString: Statically compute types list
* [`2d478748`](https://github.com/NixOS/nixpkgs/commit/2d478748209f7dfb932eeabdd2378af012f08457) lib.cmakeOptionType: Statically compute types list
* [`fcab3fbd`](https://github.com/NixOS/nixpkgs/commit/fcab3fbd7127eaf5c09028be1693ae7098fb50ef) circt: Add shared libs and split llvm
* [`930b7d74`](https://github.com/NixOS/nixpkgs/commit/930b7d743f401d8868348dc266d13c956fdecf56) poretools: mark as broken
* [`c37d28c2`](https://github.com/NixOS/nixpkgs/commit/c37d28c293a822bc1120e2391ff200651ea1d2d7) dtools: 2.105.2 -> 2.106.0
* [`7de3ca12`](https://github.com/NixOS/nixpkgs/commit/7de3ca1228b8808481f86262f19dd44aefa1c907) azure-static-sites-client: 1.0.024941 -> 1.0.025241
* [`bc9e74ff`](https://github.com/NixOS/nixpkgs/commit/bc9e74ff4045750db927267257cc337889f17ce1) gcli: 2.0.0 -> 2.1.0
* [`e97b3e41`](https://github.com/NixOS/nixpkgs/commit/e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d) ocamlPackages.conduit: 6.2.0 → 6.2.1
* [`a6ed8696`](https://github.com/NixOS/nixpkgs/commit/a6ed8696c8705f4a064a6f0d2f58d88d1d662a26) genact: 1.2.2 -> 1.3.0
* [`0cd6e601`](https://github.com/NixOS/nixpkgs/commit/0cd6e601a6412d28d36df8d2322151c286d0ced6) kalign: 3.3.5 -> 3.4.0
* [`e1d78ab7`](https://github.com/NixOS/nixpkgs/commit/e1d78ab772743ab4177e0331d7cc5269260281a8) kor: 0.3.0 -> 0.3.2
* [`020354d1`](https://github.com/NixOS/nixpkgs/commit/020354d1ee9501c9200e42cf658da5970b07621e) python311Packages.imageio: 2.33.0 -> 2.33.1
* [`cc9b8fd7`](https://github.com/NixOS/nixpkgs/commit/cc9b8fd70e37ce2a7314d29428c81d23a9e9395c) vimPlugins.harpoon: track correct branch (master)
* [`42d91a3a`](https://github.com/NixOS/nixpkgs/commit/42d91a3a06c8907da1e2f4cf6df69c5adcad659e) vimPlugins.harpoon2: init at 2023-12-11
* [`55071f35`](https://github.com/NixOS/nixpkgs/commit/55071f351d32d5dd29a0ca46db6e8fcf75577f6e) vimPlugins: update on 2023-12-11
* [`93da378e`](https://github.com/NixOS/nixpkgs/commit/93da378e4de05b80d7fe6b1f7ff5531aaf4755d5) vimPlugins.nvim-treesitter: update grammars
* [`1c09cb43`](https://github.com/NixOS/nixpkgs/commit/1c09cb43cea8bee1fd8c4d629fab80f6582f2eeb) nixos/avahi: rename remaining config options
* [`f20753f6`](https://github.com/NixOS/nixpkgs/commit/f20753f6d61f67330bfa0aac3d29fe88d7a6204b) passmark-performancetest: init at 11.0.1002
* [`08c8caf9`](https://github.com/NixOS/nixpkgs/commit/08c8caf96f4a04b39deb78e0e20ed18ea3359f2d) clojure: 1.11.1.1413 -> 1.11.1.1429
* [`3891a318`](https://github.com/NixOS/nixpkgs/commit/3891a3183e4f70ed7f4b7fcf6c44ea038682729f) cmctl: 1.13.2 -> 1.13.3
* [`3fc9b986`](https://github.com/NixOS/nixpkgs/commit/3fc9b9866512166a3f648344fd1a5ce732e7bc9a) maintainers/teams: Add frlan to team flyingcircus ([nixos/nixpkgs⁠#273495](https://togithub.com/nixos/nixpkgs/issues/273495))
* [`d2f88656`](https://github.com/NixOS/nixpkgs/commit/d2f88656bd36bf06ed501a170502d2f02c5aa0f6) homepage-dashboard: 0.8.2 -> 0.8.3
* [`39bd27fd`](https://github.com/NixOS/nixpkgs/commit/39bd27fd2e71dbcf87efdb675500496fa3cd2633) python311Packages.jupyterlab: 4.0.6 -> 4.0.9
* [`de4942fc`](https://github.com/NixOS/nixpkgs/commit/de4942fcf0360455510904a48bf2127769c139df) leftwm: add `meta.mainProgram`
* [`96de580f`](https://github.com/NixOS/nixpkgs/commit/96de580f10f89e6f5774abebc1128094e9796a5a) cockpit: 305 -> 306
* [`931fe055`](https://github.com/NixOS/nixpkgs/commit/931fe055f48d053993f071e7a150fb2d5610220c) keycloak: 23.0.0 -> 23.0.1
* [`beec1faf`](https://github.com/NixOS/nixpkgs/commit/beec1fafb2b207130f657b9719805888762ead34) commitizen: 3.12.0 -> 3.13.0
* [`108b8264`](https://github.com/NixOS/nixpkgs/commit/108b82645e4d89aa45f48b9d48c21a6b91e46b8a) python3Packages.grafanalib: init at 0.7.0
* [`f8a4c1e8`](https://github.com/NixOS/nixpkgs/commit/f8a4c1e888c71bda3b970c9beffd284bf94e526f) nix-direnv: migrate to by-name
* [`69d61d5a`](https://github.com/NixOS/nixpkgs/commit/69d61d5ab0500d9ee52881ebacfb8c8f268ca0d8) nix-direnv: 2.5.1 -> 3.0.0
* [`9feea720`](https://github.com/NixOS/nixpkgs/commit/9feea720c5b0dd3ce9aeb4f805fa14a2fd2eb8d8) checkov: 3.1.27 -> 3.1.31
* [`a9d2f909`](https://github.com/NixOS/nixpkgs/commit/a9d2f909ec2d20cc8f681b597d90a11b7a13c14f) python311Packages.asyauth: 0.0.16 -> 0.0.18
* [`9146a4aa`](https://github.com/NixOS/nixpkgs/commit/9146a4aaf66a556ff91c6e2c7c0f1f406c06e0e0) python311Packages.minikerberos: 0.4.3 -> 0.4.4
* [`773d00bc`](https://github.com/NixOS/nixpkgs/commit/773d00bcb5535917522800e6d1251643ace69460) python311Packages.msldap: 0.5.7 -> 0.5.9
* [`9d899c07`](https://github.com/NixOS/nixpkgs/commit/9d899c0743a142ade38b713ad3234c4d65e722bc) python311Packages.setupmeta: 3.5.2 -> 3.6.0
* [`ec14b74f`](https://github.com/NixOS/nixpkgs/commit/ec14b74f3577761bff820f8491428c45b043d117) python311Packages.ical: 6.1.0 -> 6.1.1
* [`0863f6d2`](https://github.com/NixOS/nixpkgs/commit/0863f6d2da0be5e8d7e3fb316ef58cdfe145220b) nixos/stub-ld: init module
* [`7c3de90b`](https://github.com/NixOS/nixpkgs/commit/7c3de90b5fab67bf9c50bf578c82b0d59375ce03) sigma-cli: 0.7.10 -> 0.7.11
* [`e915c124`](https://github.com/NixOS/nixpkgs/commit/e915c124273fd11d0bfb0e59bb7fea0be3e9fae0) python311Packages.hatasmota: 0.7.3 -> 0.8.0
* [`a95164a6`](https://github.com/NixOS/nixpkgs/commit/a95164a69ff9dcc5abe6bec0accfddeb8bb7611f) python311Packages.hatasmota: refactor
* [`3b13bd5c`](https://github.com/NixOS/nixpkgs/commit/3b13bd5c841fc77b92d2c627001414f839d57514) stdenv: Avoid some list allocations in check-meta when checking licenses
* [`9a0a097a`](https://github.com/NixOS/nixpkgs/commit/9a0a097a9408733526a236de32b706e7706d0195) stdenv: Avoid allocating intermediate attrset when checking meta validity
* [`14655c8d`](https://github.com/NixOS/nixpkgs/commit/14655c8d9ae95c07b5878f22431d5bcbe923054e) binaryen: fix build with Node 20
* [`3b235f07`](https://github.com/NixOS/nixpkgs/commit/3b235f07359a2fe5bf2bf005ede25ecab8f19f87) akkoma-frontends.admin-fe: build with Node 18
* [`d3edf81c`](https://github.com/NixOS/nixpkgs/commit/d3edf81c96c91fdc2b96d4277db135bba638740f) python311Packages.zeroconf: 0.128.0 -> 0.128.4
* [`1053f306`](https://github.com/NixOS/nixpkgs/commit/1053f306894a4c0e591bc65a082f31647f885b1e) linux_testing: 6.7-rc4 -> 6.7-rc5
* [`b52a1136`](https://github.com/NixOS/nixpkgs/commit/b52a1136c3ec28131eeb2fa1673c81e8d6cd5410) linux_6_6: 6.6.5 -> 6.6.6
* [`082f3bcf`](https://github.com/NixOS/nixpkgs/commit/082f3bcfb725d6ed1c5a5740348f5258991bdc30) linux_6_1: 6.1.66 -> 6.1.67
* [`4d0a013f`](https://github.com/NixOS/nixpkgs/commit/4d0a013fde9720a165f236e46995eaba3fc1cec0) homepage-dashboard: mark as broken for darwin
* [`17f6e20d`](https://github.com/NixOS/nixpkgs/commit/17f6e20dc45384710129888f4aefc27b0d315106) signal-desktop: refactor to make nix-update work
* [`6ff039d2`](https://github.com/NixOS/nixpkgs/commit/6ff039d24c4c33a0cacba4b5bd2396d87ed7c3d5) xdg-terminal-exec: init at unstable-2023-12-08
* [`cdc24ab4`](https://github.com/NixOS/nixpkgs/commit/cdc24ab40989d45fab2779d9df243aba5f3cfe3c) nixos/networking-interfaces: fix rootless ping
* [`3ce2a25e`](https://github.com/NixOS/nixpkgs/commit/3ce2a25e504a72e727e6bdf845655344e55ee4a6) strelka: add aarch64-linux support
* [`9e7e41c4`](https://github.com/NixOS/nixpkgs/commit/9e7e41c43d6ba72feadeca221af48a968d016068) systemd: fix path to stubs in ukify
* [`bc98e1c4`](https://github.com/NixOS/nixpkgs/commit/bc98e1c4577cd71a13dd08abf75df905b0057647) python3Packages.unix-ar: init at 0.2.1
* [`0a25fb88`](https://github.com/NixOS/nixpkgs/commit/0a25fb88804101493c5c83be51201d17edaaab48) librealsense: 2.45.0 -> 2.54.2
* [`34cbd933`](https://github.com/NixOS/nixpkgs/commit/34cbd933a7414c93748351d096855600e89bb67a) openclonk: unbreak
* [`cbc8f416`](https://github.com/NixOS/nixpkgs/commit/cbc8f4164be75158f8a9472505e36ee2cf572a52) nixos/pulseaudio: don't create config file or enable avahi when pulse is disabled
* [`68221c35`](https://github.com/NixOS/nixpkgs/commit/68221c35ff10c0e3f61074d97b02dc4b32164ad4) ceph: use absolute binary paths instead of relative paths
* [`4d418165`](https://github.com/NixOS/nixpkgs/commit/4d4181652bcefee456400714c8bdae1a131a4710) uri: fix build on darwin
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
