### PR TITLE
niv devenv: update 895e8403 -> e681a99f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "895e8403410c3ec14d1e8cae94e88b4e7e2e8c2f",
-        "sha256": "1p2v94j3b5fy9wa09s91n47xwsqymfcd48av4b5m5cjpilnzkv0z",
+        "rev": "e681a99ffe2d2882f413a5d771129223c838ddce",
+        "sha256": "1z6sns17716kciq92vpixhv46fgsc7mwa8i70iqp8lfn13r7whwq",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/895e8403410c3ec14d1e8cae94e88b4e7e2e8c2f.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/e681a99ffe2d2882f413a5d771129223c838ddce.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@895e8403...e681a99f](https://github.com/cachix/devenv/compare/895e8403410c3ec14d1e8cae94e88b4e7e2e8c2f...e681a99ffe2d2882f413a5d771129223c838ddce)

* [`4c371154`](https://github.com/cachix/devenv/commit/4c371154063fd5e0ec7ada0825adc961f0bce30a) caddy: use mainProgram for binary
* [`0212984c`](https://github.com/cachix/devenv/commit/0212984c4b2628e66d95d9b40724f266be3923aa) fix: shell check error in mailpit
* [`598e55f1`](https://github.com/cachix/devenv/commit/598e55f174187c080dc8dc28df92b75e79610131) feat: Add a default overlay
* [`9aebf5c9`](https://github.com/cachix/devenv/commit/9aebf5c907aef84b1b2156d23209e1ce1eff64c1) unify all test scripts
* [`863f2509`](https://github.com/cachix/devenv/commit/863f2509b7863b4cae79b6ad67c38ba432d9f790) fix for bitrot in flake template; devenv up requires processes.run.exec
* [`81c73ae6`](https://github.com/cachix/devenv/commit/81c73ae6de3b4b9e1ba8c7de7ffb8c3c5b1a2871) use self-hosted arm/linux
* [`e681a99f`](https://github.com/cachix/devenv/commit/e681a99ffe2d2882f413a5d771129223c838ddce) Auto generate examples/supported-languages/devenv.nix
