### PR TITLE
niv home-manager: update defbb9c5 -> e8aaced7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "defbb9c5857e157703e8fc7cf3c2ceb01cb95883",
-        "sha256": "1jv49087s87sjfa0fxbjcvcmjsqsv7rm3lif8hrx7mz2b3cls670",
+        "rev": "e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798",
+        "sha256": "0myryi7fjcdl9ncmff6mn1kc3f8skvs3f6a5sghb1mglc0py8s70",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/defbb9c5857e157703e8fc7cf3c2ceb01cb95883.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@defbb9c5...e8aaced7](https://github.com/nix-community/home-manager/compare/defbb9c5857e157703e8fc7cf3c2ceb01cb95883...e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798)

* [`c7b84ad0`](https://github.com/nix-community/home-manager/commit/c7b84ad0e82b9551c49881c61fa74abd58190709) Translate using Weblate (Russian)
* [`700002cb`](https://github.com/nix-community/home-manager/commit/700002cbaea52c159682ea733461e025bd687ee8) Translate using Weblate (Russian)
* [`bb202f19`](https://github.com/nix-community/home-manager/commit/bb202f194b67ccbef75e55077fd5153fe0fe2198) Translate using Weblate (Catalan)
* [`b61fae90`](https://github.com/nix-community/home-manager/commit/b61fae90bada652f816b47b1181c8c3d0208bcbc) Translate using Weblate (Russian)
* [`d33e0e74`](https://github.com/nix-community/home-manager/commit/d33e0e7442353c444b62b9b11fb6b84c87903144) Translate using Weblate (Russian)
* [`5be24c74`](https://github.com/nix-community/home-manager/commit/5be24c74d966bfb8fce8fad1ee222affc0e76ebc) Translate using Weblate (Russian)
* [`dd5aef0a`](https://github.com/nix-community/home-manager/commit/dd5aef0a794907d581140f181167997f071b48e3) Translate using Weblate (Russian)
* [`b3c4e98a`](https://github.com/nix-community/home-manager/commit/b3c4e98aec170c04268451db00d7dbe2dad2f4a5) Translate using Weblate (Portuguese)
* [`01a66e31`](https://github.com/nix-community/home-manager/commit/01a66e313f9386cbde1ed597aeb5c3a08661e2d9) msmtp: add configurable package
* [`0e7cd646`](https://github.com/nix-community/home-manager/commit/0e7cd646743249c6f4f257e8cfacf73ccf19e0b9) docs: fix nix-darwin module configuration example
* [`d9297efd`](https://github.com/nix-community/home-manager/commit/d9297efd3a1c3ebb9027dc68f9da0ac002ae94db) awscli: only write config files when not empty
* [`7a69b3e7`](https://github.com/nix-community/home-manager/commit/7a69b3e738a587915a374994e05e8e10f1216721) ssh: add addKeysToAgent option
* [`5e9d1fe1`](https://github.com/nix-community/home-manager/commit/5e9d1fe19f2d17cdfeb3b7e5e668f763e430cd28) flake.lock: Update
* [`7a88cded`](https://github.com/nix-community/home-manager/commit/7a88cdedbda35f808ed2f329a7a811e0511870f9) hyprland: improve config reload
* [`be97e96d`](https://github.com/nix-community/home-manager/commit/be97e96dab93e766b7ed57cf5529a49eb765fad3) flake: add packages for tests
* [`0e2e443f`](https://github.com/nix-community/home-manager/commit/0e2e443ff24f9d75925e91b89d1da44b863734af) hyprland: mark plugin setting as important
* [`abdc82d9`](https://github.com/nix-community/home-manager/commit/abdc82d930521448e47574b8ca1a0a450e861cca) yazi: pass additional args to ya alias
* [`6fc71dc5`](https://github.com/nix-community/home-manager/commit/6fc71dc563c78f999386a55b1892c05039199e8f) docs: add release-notes as appendix
* [`6c82b1c9`](https://github.com/nix-community/home-manager/commit/6c82b1c9ce4dfb882cf53d1b9a09f01fbc9b0ba1) docs: use .xhtml for appendices
* [`07754e93`](https://github.com/nix-community/home-manager/commit/07754e935a5e6f07f73e43c214f4f24f8ef82117) docs: add considerate as maintainer
* [`5b339866`](https://github.com/nix-community/home-manager/commit/5b3398668b2b7f41607cf77fc9f1cb6402716882) fish: Fix babelization of hm-session-vars
* [`e9b9ecef`](https://github.com/nix-community/home-manager/commit/e9b9ecef4295a835ab073814f100498716b05a96) gtk: fix GTK 4 theme being ignored
* [`59c15ebe`](https://github.com/nix-community/home-manager/commit/59c15ebe3df602432cff8454a4918465dd05c9d9) docs: fix link texts in release notes
* [`c22b41f0`](https://github.com/nix-community/home-manager/commit/c22b41f006d4c66d183d1e8baaca4b8f48062979) docs: fix broken link text
* [`a2e592cc`](https://github.com/nix-community/home-manager/commit/a2e592cc49850f32b59d0ab2a66ae0871f525c65) home-manager: improve nix profile detection
* [`e4dba0bd`](https://github.com/nix-community/home-manager/commit/e4dba0bd01956170667458be7b45f68170a63651) docs: set the manual version to "24.05 (unstable)"
* [`e8aaced7`](https://github.com/nix-community/home-manager/commit/e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798) home-manager: sort list packages output
