### PR TITLE
niv zsh-syntax-highlighting: update bb27265a -> dcc99a86

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -209,10 +209,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "bb27265aeeb0a22fb77f1275118a5edba260ec47",
-        "sha256": "173a4mlydq9vs617wgsw1p06pflvgbnzrfhz4nf5pxmhfhljhgbc",
+        "rev": "dcc99a86497491dfe41fb8b0d5f506033546a8c0",
+        "sha256": "184xwc6wc55jppn4h357pdxkkilqh6cpfn2cpawgahdrrdgwpf3k",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/bb27265aeeb0a22fb77f1275118a5edba260ec47.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/dcc99a86497491dfe41fb8b0d5f506033546a8c0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@bb27265a...dcc99a86](https://github.com/zsh-users/zsh-syntax-highlighting/compare/bb27265aeeb0a22fb77f1275118a5edba260ec47...dcc99a86497491dfe41fb8b0d5f506033546a8c0)

* [`9bb3db7f`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/9bb3db7fd2715e07804b23a78e0eed797e137610) driver: Use stable zsh release in is-at-least calls
* [`db085e46`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/db085e4661f6aafd24e5acb5b2e17e4dd5dddf3e) Tag version 0.8.0.
* [`dcc99a86`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/dcc99a86497491dfe41fb8b0d5f506033546a8c0) Post-release version number bump.
