### PR TITLE
niv nixpkgs: update a3670679 -> 589aab59

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3670679058c06e817358782f82aa0edff8df39d",
-        "sha256": "11bx9bvzygf03ggmmawcisi5cnjqyrgvk1cs824b8sfx7dz0x4bz",
+        "rev": "589aab59f1e2d1916fd601603d79414b3ce9129c",
+        "sha256": "1jwyg80jf674kiyj6f2lai8xwjb46nia0vpjfmq84hh9r4336fp2",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a3670679058c06e817358782f82aa0edff8df39d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/589aab59f1e2d1916fd601603d79414b3ce9129c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a3670679...589aab59](https://github.com/nixos/nixpkgs/compare/a3670679058c06e817358782f82aa0edff8df39d...589aab59f1e2d1916fd601603d79414b3ce9129c)

* [`cce7ae91`](https://github.com/NixOS/nixpkgs/commit/cce7ae91050ceaad9b8e02762920f1f05b457080) sqlboiler: init at 4.14.2
* [`7eff362c`](https://github.com/NixOS/nixpkgs/commit/7eff362ca4c87dd120a7e0bb23ced8525193a518) nixos/ssh: inline askPassword
* [`dd1b3b07`](https://github.com/NixOS/nixpkgs/commit/dd1b3b077af7250742b710d53f983e271bff0b5b) nixos/postfix: add systemd hardening directives
* [`73f6ce62`](https://github.com/NixOS/nixpkgs/commit/73f6ce62ec98ebae1eb08df039886c041b780b85) persistent-cache-cpp: init at 1.0.5
* [`b89bf6f9`](https://github.com/NixOS/nixpkgs/commit/b89bf6f9f201868b405ef86ef22beed81b1a7bb0) persistent-cache-cpp: Add patch to fix on Darwin
* [`3ddfc867`](https://github.com/NixOS/nixpkgs/commit/3ddfc8671c4a16ec095eb4fa7017631b30afc747) persistent-cache-cpp: Propagate leveldb
* [`eb221a89`](https://github.com/NixOS/nixpkgs/commit/eb221a898f6ff927ea48dc4d4ea2445fb5713c79) nixos/lxd-agent: prevent restarting on change
* [`cf8a4723`](https://github.com/NixOS/nixpkgs/commit/cf8a4723bcc84fefa8a2dd7ced63c180125b2843) nixos: test programs.npm.npmrc setting
* [`e2fb2e80`](https://github.com/NixOS/nixpkgs/commit/e2fb2e8087637a482eb222a81a0af642b357334a) sudachidict: init at 20230927
* [`fa555271`](https://github.com/NixOS/nixpkgs/commit/fa555271ab6c44c0fda9fdf6de0acdfcfef4a28f) sudachi-rs: init at 0.6.7
* [`4fcc2ea1`](https://github.com/NixOS/nixpkgs/commit/4fcc2ea1c061a013a6ca360e962189cf188df833) python311Packages.sudachidict-core: init at 20230927
* [`7d2e1543`](https://github.com/NixOS/nixpkgs/commit/7d2e1543a3f89a46c7b10e279035c5c90c14d283) python311Packages.sudachipy: init at 0.6.7
* [`3e37922c`](https://github.com/NixOS/nixpkgs/commit/3e37922c72e618ef8e4848e3bc4dda2006b75578) authelia: fix update script
* [`e3a7f716`](https://github.com/NixOS/nixpkgs/commit/e3a7f716c230dfff5f5deb9c454ddd4f4621eb79) nixos/sway: refactoring of `package` option
* [`dd77a799`](https://github.com/NixOS/nixpkgs/commit/dd77a799f813dfb7a49aba2aacfbfb69d79b92b3) nixos/transmission: /run/host must be writable, fixes [nixos/nixpkgs⁠#258793](https://togithub.com/nixos/nixpkgs/issues/258793)
* [`accbc67b`](https://github.com/NixOS/nixpkgs/commit/accbc67b046c4391d6bb6340044b79fb15f34020) nixos/transmission: use mkDefault on PrivateMounts and PrivateUsers
* [`62acc4ea`](https://github.com/NixOS/nixpkgs/commit/62acc4ea903b7c77f0599cc2c50e361dc2d6fc62) faust: 2.59.6 -> 2.69.3
* [`a626abc1`](https://github.com/NixOS/nixpkgs/commit/a626abc1321baa9576cc0f6c44333eb7989d8b62) azure-functions-core-tools: build from source
* [`f217e475`](https://github.com/NixOS/nixpkgs/commit/f217e47591376a4da59e0d8a1377489a51e06ad2) azure-functions-core-tools: 4.0.5348 -> 4.0.5390
* [`38fc00eb`](https://github.com/NixOS/nixpkgs/commit/38fc00ebb2445c7837116b6c21d86681213df3d3) azure-functions-core-tools: 4.0.5390 -> 4.0.5413
* [`9180c571`](https://github.com/NixOS/nixpkgs/commit/9180c5714341293a3fbcae409c3ba8af9e28cedd) azure-functions-core-tools: 4.0.5413 -> 4.0.5441
* [`6fedcb4f`](https://github.com/NixOS/nixpkgs/commit/6fedcb4fe157db380d63227d8a9f34b69ee12d62) azure-functions-core-tools: 4.0.5441 -> 4.0.5455
* [`220d6c53`](https://github.com/NixOS/nixpkgs/commit/220d6c532c236f8af2ec37a86548d965c8255336) maintainers: add jpts
* [`9f3a78c8`](https://github.com/NixOS/nixpkgs/commit/9f3a78c8f21864acc1ff23e960063b317a229dfc) python3Packages.cherrypy-cors: init at 1.7.0
* [`0fec76de`](https://github.com/NixOS/nixpkgs/commit/0fec76de98b22bd45fc63595a2d558f0560dc292) anytype: 0.35.25-beta -> 0.36.0
* [`236bdb03`](https://github.com/NixOS/nixpkgs/commit/236bdb034addda9dd9b45f222379e03966cf2d6c) maintainers: add dblsaiko
* [`46c18ddf`](https://github.com/NixOS/nixpkgs/commit/46c18ddf65ab1e8302229accc8bfa601f5e7b543) pgadmin: migrate to prefetch-yarn-deps
* [`918c0666`](https://github.com/NixOS/nixpkgs/commit/918c0666abe7263f8ae3cbe59cdf55a607aa62f9) pgadmin4: 7.7 -> 7.8
* [`5beb818e`](https://github.com/NixOS/nixpkgs/commit/5beb818e319da0d81c5a04ec6e680a420cb9fd54) pgadmin: 7.8 -> 8.0
* [`b297cddb`](https://github.com/NixOS/nixpkgs/commit/b297cddb057560a34b7aa6e5f68aaf252d58dc2f) trivy: add shell completions
* [`37b5f213`](https://github.com/NixOS/nixpkgs/commit/37b5f213a1327e03de429deb5afd8bad60cb5908) ledger: migrate to by-name
* [`f19a64e7`](https://github.com/NixOS/nixpkgs/commit/f19a64e770f5276516179e88097006508d19d06a) aqbanking: drop gtk2
* [`7b6580db`](https://github.com/NixOS/nixpkgs/commit/7b6580dba42d2ec15e8b2b90fb2f1da93bd0d398) maintainers/teams: init and add helsinki-systems
* [`fb9e48c6`](https://github.com/NixOS/nixpkgs/commit/fb9e48c6b907b6524a39898bfc5d1c7d0d63fdd4) doc: clarify stdenv phase flag attributes
* [`0db5959b`](https://github.com/NixOS/nixpkgs/commit/0db5959bd714fdff40f2b34fb75d026448341f14) nixos/gns3-server: init
* [`7cfb9417`](https://github.com/NixOS/nixpkgs/commit/7cfb9417751c0531d3b28835517c1535fa918b2b) nixosTests.gns3-server: init
* [`6c19bd66`](https://github.com/NixOS/nixpkgs/commit/6c19bd6631327933501f5d00f2d23557428dc05c) nginxModules.zstd: 0.1.0 -> 0.1.1
* [`a1975fdf`](https://github.com/NixOS/nixpkgs/commit/a1975fdf659c395ca5a759b3a894edd6945df9d8) twitter-color-emoji: 14.1.2 -> 15.0.2
* [`4084ee0c`](https://github.com/NixOS/nixpkgs/commit/4084ee0cd55e41b6d78ea578f03ef3471a261731) make-initrd-ng: fix reproducibility problems
* [`395fc064`](https://github.com/NixOS/nixpkgs/commit/395fc06431dd2d89f2a2718867266df249463598) lib: Add contribution guidelines
* [`a9922f4d`](https://github.com/NixOS/nixpkgs/commit/a9922f4dc1da848c24bcc07ec8a9c491cde81c8f) livekit: init at 1.5.1
* [`16157297`](https://github.com/NixOS/nixpkgs/commit/161572971b70adbc72b894457bb99127d2409c86) matrix-hookshot: 4.5.1 -> 4.6.0
* [`8ea80a3f`](https://github.com/NixOS/nixpkgs/commit/8ea80a3f11e48e800666b5599cc4b63728c01ad0) matrix-hookshot: 4.6.0 -> 4.7.0
* [`1fb02dec`](https://github.com/NixOS/nixpkgs/commit/1fb02dec01083202cf95c51e08d18a19a52f26b6) python3Packages.aiosql: 9.0 → 9.1
* [`5b434a46`](https://github.com/NixOS/nixpkgs/commit/5b434a46c30b27e3856043ee0d025ea7627f5686) python310Packages.wagtail: 5.1.3 -> 5.2.2
* [`6b5b325d`](https://github.com/NixOS/nixpkgs/commit/6b5b325d929955a64fcf4c2c3960f11924d0befd) netpbm: 11.4.4 -> 11.4.5
* [`3f4e3a86`](https://github.com/NixOS/nixpkgs/commit/3f4e3a862f20370d36a59a9534788099225d3484) Checkpointedbuilds: add derivation override functions
* [`8beb5624`](https://github.com/NixOS/nixpkgs/commit/8beb56244d6baf34bc5fbf010e79243fe59b6394) checkpointedBuilds: add usage example based on virtualbox
* [`1cd6b7fd`](https://github.com/NixOS/nixpkgs/commit/1cd6b7fdc37cdc7a4a31c87aa31e4ebf5ed930c8) checkpointedBuilds: rename buildOut to checkpointedBuildArtifacts
* [`17e88c28`](https://github.com/NixOS/nixpkgs/commit/17e88c2890068e944c61dbaf7493ae12417b8944) checkpointedBuild: add checkpointed build test based on pkgs hello
* [`cd6c65fe`](https://github.com/NixOS/nixpkgs/commit/cd6c65fe2d96e8342f85f8467dee9b76618a144d) checkpointedBuild: consider removing files and make buildartifacts the only output of the prepare step
* [`c8afee88`](https://github.com/NixOS/nixpkgs/commit/c8afee88bf346c80f79d036e34ca2d232b037792) checkpointedBuild: fix tests for checkpointedBuild functions
* [`fc2e3fac`](https://github.com/NixOS/nixpkgs/commit/fc2e3fac619288868c4e0b019a8c561ea6885777) doc: add section about checkpointed build
* [`c85d18ff`](https://github.com/NixOS/nixpkgs/commit/c85d18ff91710698f696cf964132967f9fc4bb5b) checkpointedBuilds: allow dotglob and remove debugging leftover
* [`ddfddf4b`](https://github.com/NixOS/nixpkgs/commit/ddfddf4b719134ac0acd04595372ca1bde4d0879) checkpointedBuilds: add comments in the code
* [`6db96122`](https://github.com/NixOS/nixpkgs/commit/6db96122047fe7bdc1d58e201c9d161c0c479aba) rename: incremental -> checkpointed builds
* [`0ab2262b`](https://github.com/NixOS/nixpkgs/commit/0ab2262bdd601a2997d7f6067eadc767391f7298) checkpointBuild: fix whitespaces in documentation
* [`342c7949`](https://github.com/NixOS/nixpkgs/commit/342c7949e93c2b730ed9d6c244351391b3fe3412) transmission_4: 4.0.4 -> 4.0.5
* [`c67b995a`](https://github.com/NixOS/nixpkgs/commit/c67b995a88998fb3b0117504d74bf3b286f157e3) ns-usbloader: fix dependencies for gtk file picker
* [`8938a19d`](https://github.com/NixOS/nixpkgs/commit/8938a19d67000d52fd6ceff25a1524077f0bdea1) kustomize: 5.2.1 -> 5.3.0
* [`bf9b01b3`](https://github.com/NixOS/nixpkgs/commit/bf9b01b302c13c9d692d4579150f721a99365ee6) parsec-bin: vulkan renderer dependency
* [`47a15d56`](https://github.com/NixOS/nixpkgs/commit/47a15d56c8a707ca58a4d2630832b2b70ddabfdf) sonobuoy: 0.56.14 -> 0.56.17
* [`a201da67`](https://github.com/NixOS/nixpkgs/commit/a201da67d3d9f0e3c7323a055abb273045c919f7) sonobuoy: 0.56.17 -> 0.57.1
* [`dcf32315`](https://github.com/NixOS/nixpkgs/commit/dcf32315636b838593133ceeac17d68ae56dad68) cairo-lang: 2.3.0 -> 2.4.0
* [`14727507`](https://github.com/NixOS/nixpkgs/commit/147275079aefc3ce66b656d694e8b29255ef5971) tektoncd-cli: 0.32.2 -> 0.33.0
* [`cdbb25cf`](https://github.com/NixOS/nixpkgs/commit/cdbb25cf40e64b01fe07b5847d0be1376dcfe29e) tutanota-desktop: 3.118.27 -> 3.119.3
* [`dd5bcbfb`](https://github.com/NixOS/nixpkgs/commit/dd5bcbfb998d39f38619b51e0c7ff999c9013f1c) maintainers: add pabloaul
* [`cac5a123`](https://github.com/NixOS/nixpkgs/commit/cac5a123257c790a00d0e84ae97aad3a11fcc613) parsec-bin: add pabloaul to maintainers
* [`2166416e`](https://github.com/NixOS/nixpkgs/commit/2166416e4e19831ce158aa23bd4ccce2dfbd5524) parsec-bin: use ffmpeg_5
* [`2da5fe61`](https://github.com/NixOS/nixpkgs/commit/2da5fe614fc80ba9b15472d41570e44555747ab0) parsec-bin: 150_90c -> 150_91a
* [`435076cc`](https://github.com/NixOS/nixpkgs/commit/435076cc1ca6e6e5aa8e6bf5cd18f35202daf2df) mpv: use correct nv-codec-headers version
* [`17eed148`](https://github.com/NixOS/nixpkgs/commit/17eed148280397aee0bec181bf14220fc39fb8f3) python3Packages.django-modelcluster: 6.0 -> 6.1
* [`4a219c8a`](https://github.com/NixOS/nixpkgs/commit/4a219c8aebf8275118981db856355f88aaa84bca) nut: patch nutshutdown to set a default for NUT_CONFPATH
* [`7d995675`](https://github.com/NixOS/nixpkgs/commit/7d9956755e5a31d4718c949fabe786caf538fc50) nut: fix systemd unit patching
* [`fc004b09`](https://github.com/NixOS/nixpkgs/commit/fc004b09e5fbe0affdf4cf7c12cc856dcf214849) nixos/ups: install udev rules for nut
* [`cae4cbf4`](https://github.com/NixOS/nixpkgs/commit/cae4cbf42fffc328c47c48334a60bafe5eb5781f) r2modman: update electron version
* [`a989353e`](https://github.com/NixOS/nixpkgs/commit/a989353ef236a9b16f4aa27653d3c89a53168726) nixos/tests/systemd-boot: change garbage-collect-entry test name
* [`91cae38e`](https://github.com/NixOS/nixpkgs/commit/91cae38e4520812edd48620b2cd158dd3fa1cdca) tracebox: fix build with gcc 11+
* [`0a7681ba`](https://github.com/NixOS/nixpkgs/commit/0a7681ba34c47ae217366b726578c9a550f6eb39) halftone: 0.3.1 -> 0.5.0
* [`ada5e110`](https://github.com/NixOS/nixpkgs/commit/ada5e11049aad6908824f45a4537e6792f2d1c37) r2modman: use lib.getExe instead of hard-coded path
* [`af559e0e`](https://github.com/NixOS/nixpkgs/commit/af559e0e3ce002b2005009e933af97c5a9fb11d2) r2modman: specify meta.mainProgram
* [`f0d62e89`](https://github.com/NixOS/nixpkgs/commit/f0d62e899b3c6a9e81ffab6332a1de388305f8fc) seabios: 1.16.2 -> 1.16.3
* [`799c6a1f`](https://github.com/NixOS/nixpkgs/commit/799c6a1fc734cb2f330c5116bf50db1e57abeb65) seabios: refactor
* [`87a5d76d`](https://github.com/NixOS/nixpkgs/commit/87a5d76ddd6e4ddb1ca084aa6d3a0b3163f6156e) seabios: mark Darwin as a bad platform
* [`76a0cbc7`](https://github.com/NixOS/nixpkgs/commit/76a0cbc7fdb995558dbbc0bf0d21828876a1e7be) seabios: migrate to by-name
* [`ba3dcb9d`](https://github.com/NixOS/nixpkgs/commit/ba3dcb9dc5151f5b8e47592e71e1cd1e8be06083) xen_4_15: fixup seabios location
* [`d5c17b3c`](https://github.com/NixOS/nixpkgs/commit/d5c17b3c47b708ff78cd5737072f155dd2a80e10) ovmf: fixup seabios location
* [`af00309d`](https://github.com/NixOS/nixpkgs/commit/af00309d20ad2e3c9b6e736d3e45fe8b5246c540) rocksndiamonds: 4.1.1.0 -> 4.3.8.0
* [`5551291f`](https://github.com/NixOS/nixpkgs/commit/5551291f546c3302534d27d2a51ea5fcf5b6a457) linphone: 5.0.16 -> 5.1.2
* [`c76ffa04`](https://github.com/NixOS/nixpkgs/commit/c76ffa0463d45654ea2967456a185d7c913a0b4a) linphone: fix install with cmake
* [`66c38ab0`](https://github.com/NixOS/nixpkgs/commit/66c38ab0c04a8f4d5534badd8ac4d55bd27cdf6b) python310Packages.glueviz: 1.16.0 -> 1.17.1
* [`1416e0d4`](https://github.com/NixOS/nixpkgs/commit/1416e0d41535d9a7af072045f3a5a54137cafc61) ryujinx: 1.1.1053 -> 1.1.1100
* [`0678d2ea`](https://github.com/NixOS/nixpkgs/commit/0678d2eaa0e9a9dd1fd4151ed019630ba273699f) nixpkgs-hammering: unstable-2023-03-09 -> unstable-2023-11-06
* [`09650c6b`](https://github.com/NixOS/nixpkgs/commit/09650c6ba599594f3969614607db0d7f5cf438ff) jibri: 8.0-145-g1a4bb8e -> 8.0-160-g5af7dd7
* [`54c98c60`](https://github.com/NixOS/nixpkgs/commit/54c98c60eea6518d47dafab48ed673c22169ab32) jicofo: 1.0-1050 -> 1.0-1057
* [`c6e29c24`](https://github.com/NixOS/nixpkgs/commit/c6e29c24111865c74fcadaee69ba186edb619a71) jitsi-meet: 1.0.7629 -> 1.0.7658
* [`3cb53ae5`](https://github.com/NixOS/nixpkgs/commit/3cb53ae5d9e094d47008f1569da0d278ad2d9403) jitsi-meet-prosody: 1.0.7629 -> 1.0.7658
* [`a62e2401`](https://github.com/NixOS/nixpkgs/commit/a62e240148948f095b533d33a70e4629636c8538) jitsi-videobridge: 2.3-59-g5c48e421 -> 2.3-61-g814bffd6
* [`0244f870`](https://github.com/NixOS/nixpkgs/commit/0244f8703c3c8edcebda449448100610e56e2240) k3s: 1.27.7+k3s2 -> 1.27.8+k3s2
* [`f61980db`](https://github.com/NixOS/nixpkgs/commit/f61980dbf91d43e969157bc34186f912024f62cf) doc: fix typo in checkpoint build section
* [`bfb2b984`](https://github.com/NixOS/nixpkgs/commit/bfb2b98441e4663e781b0fed5d1c85e27f3c7eb6) cri-tools: 1.28.0 -> 1.29.0
* [`0d6d654f`](https://github.com/NixOS/nixpkgs/commit/0d6d654f3683e58495c04c10d13319df52a59034) doc: checkpointBuild: fix wording
* [`a3e0a52d`](https://github.com/NixOS/nixpkgs/commit/a3e0a52de43d929493b6639e83cb701f197c2643) checkpointBuilds: add hooks for checkpoint builds
* [`15c2c682`](https://github.com/NixOS/nixpkgs/commit/15c2c6827bac0a023556177ea7ba5646efe43742) checkpointBuild: doc remove textual description in favor of an integrated example
* [`48a47a63`](https://github.com/NixOS/nixpkgs/commit/48a47a63596200a62eb633e08d534a3420f426ce) parlatype: 3.1 -> 4.0
* [`0e27b4d3`](https://github.com/NixOS/nixpkgs/commit/0e27b4d33fb3e373f0ff2fd957d4784591d35874) redocly-cli: fix build-docs command
* [`13a1d191`](https://github.com/NixOS/nixpkgs/commit/13a1d1919e72b739d848fdbfcb058922e1c7f686) texmacs: build as bundle on darwin
* [`fe98636e`](https://github.com/NixOS/nixpkgs/commit/fe98636ee4382518d1ad49598916130594059f19) devspace: 6.3.5 -> 6.3.7
* [`78405803`](https://github.com/NixOS/nixpkgs/commit/7840580348900362759fe26d71142bf006f1908a) python311Packages.sentry-sdk: 1.37.1 -> 1.39.0
* [`f1ea01f9`](https://github.com/NixOS/nixpkgs/commit/f1ea01f944d8c4c3533aa99f9b9884ee175385ab) rPackages.tesseract: fix build
* [`b75cc1d3`](https://github.com/NixOS/nixpkgs/commit/b75cc1d316d2934bf56307f245574928b778249d) alfaview: 9.5.0 -> 9.7.0
* [`09fb5164`](https://github.com/NixOS/nixpkgs/commit/09fb5164a191d62488c23b2257130bb9d11ecaa6) arkade: 0.10.15 -> 0.10.17
* [`7aa133e3`](https://github.com/NixOS/nixpkgs/commit/7aa133e3ca804e6115862f9813b22c766c28c790) asn: 0.75 -> 0.75.2
* [`90f63461`](https://github.com/NixOS/nixpkgs/commit/90f634616291f83981cd76d4701022c895a05572) aseprite: 1.3 -> 1.3.2
* [`8b2150bd`](https://github.com/NixOS/nixpkgs/commit/8b2150bdd14758f7f8b47e0a3a1b03513dcd0bc4) aws-lambda-rie: 1.12 -> 1.15
* [`bb215123`](https://github.com/NixOS/nixpkgs/commit/bb215123da331a977f921de9bba82a5d7f33fa8f) bcftools: 1.18 -> 1.19
* [`0d6c4e0b`](https://github.com/NixOS/nixpkgs/commit/0d6c4e0b314d7a9297d56fcc3348b6613d110b9a) boogie: 3.0.6 -> 3.0.9
* [`747933a9`](https://github.com/NixOS/nixpkgs/commit/747933a933961d5a614be0974cd983364cb67892) boundary: 0.14.2 -> 0.14.3
* [`5ebb78d9`](https://github.com/NixOS/nixpkgs/commit/5ebb78d9522ce232286ae0518a1020b8e099e7e1) doc: checkpointBuild: fix wording
* [`97fccdce`](https://github.com/NixOS/nixpkgs/commit/97fccdce1e19f2a07ab21a82ec8084d1c430b046) c2fmzq: 0.4.9 -> 0.4.15
* [`a3c72d13`](https://github.com/NixOS/nixpkgs/commit/a3c72d132a6921e2744f1c9bca051d77af2f1367) moar: 1.18.5 -> 1.18.6
* [`66c58274`](https://github.com/NixOS/nixpkgs/commit/66c58274f430c7cb3474826f381a066c768fad58) tldr: 1.6.0 -> 1.6.1
* [`a529d6f9`](https://github.com/NixOS/nixpkgs/commit/a529d6f911c3e73a88955a75bf683ebd9f0a5923) vencord: 1.6.4 -> 1.6.5
* [`423bb23f`](https://github.com/NixOS/nixpkgs/commit/423bb23f0ca0d2b3c0e555762e0b47b0473b68c1) changie: 1.16.0 -> 1.16.1
* [`e1bd4d15`](https://github.com/NixOS/nixpkgs/commit/e1bd4d15e8275f14814a50d8c6fa5a3e670e9b03) xorg.xorgserver: 21.1.9 -> 21.1.10
* [`dad002c3`](https://github.com/NixOS/nixpkgs/commit/dad002c322a8a4a697791d6c238d06b518b1c563) unison-ucm: M5j -> 0.5.11
* [`f4c3a1a8`](https://github.com/NixOS/nixpkgs/commit/f4c3a1a8b32aa97e71390ce56718c9fa9f63b120) cilium-cli: 0.15.12 -> 0.15.17
* [`59619586`](https://github.com/NixOS/nixpkgs/commit/59619586ca262f747c9400e11568379f6654128c) open-stage-control: pin to nodejs_18 for now
* [`e1967c92`](https://github.com/NixOS/nixpkgs/commit/e1967c9212dfd94c33dee37b986c14c695efc31a) livekit-cli: init at 1.3.4
* [`53cf178f`](https://github.com/NixOS/nixpkgs/commit/53cf178f5db161f620d15e9b2e749196507f7fea) krane: 3.3.0 -> 3.4.0
* [`ea2de833`](https://github.com/NixOS/nixpkgs/commit/ea2de833561dd874c47726b79348383f6d06a145) krane: add changelog
* [`50e01f04`](https://github.com/NixOS/nixpkgs/commit/50e01f040243dc9c70a248f221dee1e439072ef2) QuadProgpp: 4b6bd65 -> unstable-2023-01-20, refactor
* [`3e92c6f5`](https://github.com/NixOS/nixpkgs/commit/3e92c6f562aa84ce0ca43326aacf9d13af67cf51) doomretro: 5.0.7 -> 5.1.1
* [`a20f9282`](https://github.com/NixOS/nixpkgs/commit/a20f928204c12c22bb02a3f60e79e4d8a50a9c7e) metals: 1.1.0 -> 1.2.0
* [`c0c8f0f1`](https://github.com/NixOS/nixpkgs/commit/c0c8f0f1a24f074af6fbe0e6acc5727b7b98f489) tmuxPlugins.urlview: switch to extract_url
* [`facb7a38`](https://github.com/NixOS/nixpkgs/commit/facb7a38b3a0a7f276f8a7f7902cb126b51e87f4) urlview: remove
* [`6dacbccd`](https://github.com/NixOS/nixpkgs/commit/6dacbccdc5a6be71f59981a81d67fb7e4f7dfc9d) istioctl: 1.20.0 -> 1.20.1
* [`2c34e78f`](https://github.com/NixOS/nixpkgs/commit/2c34e78fdc6ab8e54720c7779d9b910ef7681885) revanced-cli: 2.2.0 -> 4.3.0
* [`22333c61`](https://github.com/NixOS/nixpkgs/commit/22333c615d0c4b6d473f16d348a577b484ba66be) mkvtoolnix: use utf8cpp from nixpkgs
* [`3e1dba86`](https://github.com/NixOS/nixpkgs/commit/3e1dba866f8346b38bc236483b1d80cee352be3d) wlroots_0_17: init at 0.17.0
* [`88f84ef1`](https://github.com/NixOS/nixpkgs/commit/88f84ef1b208106030711ec4848bfa632ebd96c9) tinywl: inherit wlroots's patches
* [`01800a5a`](https://github.com/NixOS/nixpkgs/commit/01800a5ad15c7c9de1ab9823a411f0b017714f50) wlroots: 0.16.2 -> 0.17.0
* [`e5ffde60`](https://github.com/NixOS/nixpkgs/commit/e5ffde60d57ad667b93216055c5085ec60cee2e9) wlroots-hyprland: remove unnecessary overrideAttrs
* [`3ed88c57`](https://github.com/NixOS/nixpkgs/commit/3ed88c578cfd25a3661c75931a16005063da3c46) dwl: 0.4 -> 0.5
* [`fbb468d3`](https://github.com/NixOS/nixpkgs/commit/fbb468d36937fe4dcc558ee089b233f4f8b44eb6) waybox: 0.2.0 -> 0.2.2
* [`55037435`](https://github.com/NixOS/nixpkgs/commit/55037435f8ba1dd1392d094495457542fb74d787) wio: unstable-2023-05-28 -> unstable-2023-11-23
* [`74cff0aa`](https://github.com/NixOS/nixpkgs/commit/74cff0aa8d4bcd631877fa1c25d79db726c1c9b6) wlroots-hyprland: version should be 0.18.0-dev
* [`318a5c60`](https://github.com/NixOS/nixpkgs/commit/318a5c604c1bba8ee1cc7be86eac2b319c3ef0f5) fvwm3: 1.0.8 -> 1.0.9
* [`c618d890`](https://github.com/NixOS/nixpkgs/commit/c618d890bc9008aabff97d8b7882efd28c9fa237) gatk: 4.4.0.0 -> 4.5.0.0
* [`36bf6afd`](https://github.com/NixOS/nixpkgs/commit/36bf6afd42e755bf51ce9678ce2710e1b1d68f99) julia.withPackages: init on supported Julias (1.6, 1.8, 1.9)
* [`c8f0d302`](https://github.com/NixOS/nixpkgs/commit/c8f0d302c1a8cd893bb7a6e11f9176b54127239a) julia: add documentation to manual + release note
* [`c93e8f3e`](https://github.com/NixOS/nixpkgs/commit/c93e8f3e628eb71456b10b628c50ec561f01b8fd) doublecmd: 1.1.5 -> 1.1.7
* [`fcdea383`](https://github.com/NixOS/nixpkgs/commit/fcdea38355b817b86101b9bb6f717858bc96b4eb) chromium: never use libpng-apng patch
* [`418d39f8`](https://github.com/NixOS/nixpkgs/commit/418d39f81ae800512e52bce47e6d9d8ca46354b9) exodus: 23.11.6 -> 23.12.7
* [`bd588f23`](https://github.com/NixOS/nixpkgs/commit/bd588f23b4ce367fba13cd90153b51a6980612c2) gerrit: 3.8.3 -> 3.9.1
* [`97174c44`](https://github.com/NixOS/nixpkgs/commit/97174c444b4a066c9760b291f811a2dfc3807fd8) ocamlPackages.git: 3.13.0 → 3.14.0
* [`a3520e38`](https://github.com/NixOS/nixpkgs/commit/a3520e38bbbb2edf689c22a222db9b5d4c69eb83) frankenphp: fix collision with php package
* [`6e4d90f0`](https://github.com/NixOS/nixpkgs/commit/6e4d90f0b0351e9fd7510c2bb627b8bc2cfb5152) nvidia_x11.dc_535: 535.129.03
* [`b122013b`](https://github.com/NixOS/nixpkgs/commit/b122013b2373776f4d232692a7e9bf6cb5a832d1) go-mockery: 2.36.0 -> 2.38.0
* [`57846d0c`](https://github.com/NixOS/nixpkgs/commit/57846d0cae80c2015a4b493b3fe2a09f49b61669) nixos/resolved: Allow upstream fallback override
* [`c3256929`](https://github.com/NixOS/nixpkgs/commit/c3256929e9bc84eaae4137c91b55c57998238c88) nixos/resolved: changelog for fallbackDns changes
* [`2b9666c0`](https://github.com/NixOS/nixpkgs/commit/2b9666c0168472d76ea9954a7f90ee00425c3858) google-cloud-sql-proxy: 2.7.2 -> 2.8.1
* [`bb74ebb7`](https://github.com/NixOS/nixpkgs/commit/bb74ebb72bb621a03313107f1d32401493b3c438) playwright-driver: fix browser download on darwin
* [`70c8ee0c`](https://github.com/NixOS/nixpkgs/commit/70c8ee0c9292450cd7263f1fbdea63f6909073e9) vscode: 1.84.2 -> 1.85.1
* [`2e3c2705`](https://github.com/NixOS/nixpkgs/commit/2e3c2705b98351bc95d01d42ab535f3dc230c593) Remove "-s" and "-w" from the ldflags example
* [`13c72b69`](https://github.com/NixOS/nixpkgs/commit/13c72b69d0a46fdbbbb8bbc43ee0c86d37e87df7) hubble: 0.12.2 -> 0.12.3
* [`d4dc2b34`](https://github.com/NixOS/nixpkgs/commit/d4dc2b347d9300f75f50ec281aaea1fe9d8325d5) hyprland-per-window-layout: 2.3.1 -> 2.4
* [`9e1d149f`](https://github.com/NixOS/nixpkgs/commit/9e1d149f0582ac8d5ac96f6c44e9cf5db3e4c422) dafny: 4.3.0 -> 4.4.0
* [`45c4fb24`](https://github.com/NixOS/nixpkgs/commit/45c4fb240acfab31be940b8d1c1f4d7ffdb10c81) nixos/kubo: convert two settings to RFC42-style settings
* [`c3f58974`](https://github.com/NixOS/nixpkgs/commit/c3f5897467aad6ce33f602296d085acce06ff2e5) jotta-cli: 0.15.93226 -> 0.15.98319
* [`97827754`](https://github.com/NixOS/nixpkgs/commit/978277544a813a42fe333b032d5051399676305a) jwx: 2.0.16 -> 2.0.18
* [`cb0a9875`](https://github.com/NixOS/nixpkgs/commit/cb0a987569f3f701e51cd842342cb738dcafac23) kail: 0.17.0 -> 0.17.1
* [`586eef94`](https://github.com/NixOS/nixpkgs/commit/586eef94b8328a441a545dd2c1f30c89b85a99f8) kapp: 0.59.1 -> 0.59.2
* [`e714a966`](https://github.com/NixOS/nixpkgs/commit/e714a966338f787a5eda9b3d5566e45a8bc5f08a) kubergrunt: 0.13.0 -> 0.13.1
* [`5c6786bc`](https://github.com/NixOS/nixpkgs/commit/5c6786bc3bba7c9780f9ed5f46f76ff2a0012f67) kubeswitch: 0.8.0 -> 0.8.1
* [`782c576d`](https://github.com/NixOS/nixpkgs/commit/782c576dde5571acb03cd969f5385e7fc54c1ddb) kubevpn: 2.0.1 -> 2.1.3
* [`bebc9fc5`](https://github.com/NixOS/nixpkgs/commit/bebc9fc5dba2cb778eaf6488ae9237627214ad14) lammps-mpi: 2Aug2023_update1 -> 2Aug2023_update2
* [`dedf5959`](https://github.com/NixOS/nixpkgs/commit/dedf5959a57fd3913a49165d4f9f5329fb7db282) aflplusplus: 4.08c -> 4.09c
* [`632bdcd0`](https://github.com/NixOS/nixpkgs/commit/632bdcd0a0d0be0d17eee5d681fca9c26f89bcf3) python311Packages.soco: 0.29.1 -> 0.30.0
* [`9c0f59ad`](https://github.com/NixOS/nixpkgs/commit/9c0f59adc112491ae4cadda52709724d6189315b) libvirt: 9.9.0 -> 9.10.0
* [`efecc40c`](https://github.com/NixOS/nixpkgs/commit/efecc40c7f6d08da37042321f69f62eb0d6f0dd4) linkerd: 2.14.5 -> 2.14.6
* [`71e70e3a`](https://github.com/NixOS/nixpkgs/commit/71e70e3aad8f0238ebe2bdaa72a7355cd0823aaf) lilypond-unstable: 2.25.10 -> 2.25.11
* [`7a4db40a`](https://github.com/NixOS/nixpkgs/commit/7a4db40a47939292cc7d05a853b02ad0194f05f5) linkerd_edge: 23.11.4 -> 23.12.2
* [`e5f5f16f`](https://github.com/NixOS/nixpkgs/commit/e5f5f16f4b47f2fecc22e90b0de3240652cb8067) magic-vlsi: 8.3.449 -> 8.3.453
* [`98de3299`](https://github.com/NixOS/nixpkgs/commit/98de32993972890f91abcb629009da6293af6c3d) prusa-slicer: 2.7.0->2.7.1
* [`d2ffb249`](https://github.com/NixOS/nixpkgs/commit/d2ffb2494854a4e85c9f83d806a4c20fbbe01bc4) makeInitrdNGTool: 0.1.0 -> 0.1.0
* [`3abaf0af`](https://github.com/NixOS/nixpkgs/commit/3abaf0af063668d4a887591dcdf9a57cbe86102d) aliases: convert `urlview` throw to a oneliner
* [`50de886c`](https://github.com/NixOS/nixpkgs/commit/50de886ca96bdac9182612bb289af32ed0db22e7) lomiri.lomiri-ui-extras: init at 0.6.2
* [`5f33404b`](https://github.com/NixOS/nixpkgs/commit/5f33404b95017bf1f01bee885ca86ed1464a5da2) step-ca: 0.25.0 -> 0.25.2
* [`41005dab`](https://github.com/NixOS/nixpkgs/commit/41005dab72d29b07e64f801fe8890e4f22de6b9d) mediainfo-gui: 23.10 -> 23.11
* [`541f4b98`](https://github.com/NixOS/nixpkgs/commit/541f4b98aab856d7e11d5e7bccda5913ef1e9904) mediamtx: 1.3.0 -> 1.4.0
* [`1af62510`](https://github.com/NixOS/nixpkgs/commit/1af62510139d477b653ce3cfbe0d9f4a6b1386a6) mediastreamer: 5.2.109 -> 5.2.111
* [`9f44477a`](https://github.com/NixOS/nixpkgs/commit/9f44477aa252a9675c39a03c7d824b648344ad4e) fzf-make: 0.11.0 -> 0.12.0
* [`84f25e21`](https://github.com/NixOS/nixpkgs/commit/84f25e21d620b0bda9ca82b9bfb5d19223ddaa14) mediawriter: 5.0.8 -> 5.0.9
* [`f3259681`](https://github.com/NixOS/nixpkgs/commit/f32596813d55bd190988813ff76755c4b4eeb759) mermerd: 0.9.0 -> 0.10.0
* [`dfa0eb52`](https://github.com/NixOS/nixpkgs/commit/dfa0eb52866b822e7e60c1fad3b8b685d5740efa) messer-slim: 4.0.1 -> 4.1
* [`b4a9d7cd`](https://github.com/NixOS/nixpkgs/commit/b4a9d7cda615f8f856751c6aa55fd30e7c61722b) moonraker: unstable-2023-08-03 -> unstable-2023-12-16
* [`0b1dbca5`](https://github.com/NixOS/nixpkgs/commit/0b1dbca50f472d837e6f3c4d6d65664ca61fafb6) loupe: 45.2 → 45.3
* [`6d031527`](https://github.com/NixOS/nixpkgs/commit/6d031527a039e93861138ff9c6b56e500364afc9) vte: 0.74.1 → 0.74.2
* [`a91476ef`](https://github.com/NixOS/nixpkgs/commit/a91476ef8c619fe01a6c5f40b7281a4dc59bed88) python311Packages.equinox: fix build by fetching upstream patch
* [`0e5da742`](https://github.com/NixOS/nixpkgs/commit/0e5da7422f0c8d2ec4825ffda05f9c560f162358) python311Packages.jaxtyping: 0.2.23 -> 0.2.25
* [`c3e74ffd`](https://github.com/NixOS/nixpkgs/commit/c3e74ffd28f2568baf3ec2053a0b727891963931) mkvtoolnix: 80.0 -> 81.0
* [`8d80e51b`](https://github.com/NixOS/nixpkgs/commit/8d80e51b6ead790234283a1dacb3e1dfe11cfa5a) streamlink: 6.4.2 -> 6.5.0
* [`199dda40`](https://github.com/NixOS/nixpkgs/commit/199dda40ae24cf410c93d2e0b37613d8c34d48b0) opencl-headers: 2023.02.06 -> 2023.12.14
* [`55a7977b`](https://github.com/NixOS/nixpkgs/commit/55a7977b4c10e8a3bf9e12deb16ca57d906256ca) opencl-headers: add reverse dependencies to passthru.tests
* [`fc768649`](https://github.com/NixOS/nixpkgs/commit/fc7686495f4b075cbb0e8821103c4f3a7411f8d4) squawk: 0.24.2 -> 0.26.0
* [`3572dd8d`](https://github.com/NixOS/nixpkgs/commit/3572dd8dc64664cf9f3a80d807b1d76886dbfc8d) opencl-headers: add pkg-config tester
* [`dccabec1`](https://github.com/NixOS/nixpkgs/commit/dccabec197c24080a7650e7731acce19ae32aaf9) namespace-cli: 0.0.307 -> 0.0.322
* [`33879dfb`](https://github.com/NixOS/nixpkgs/commit/33879dfbe6d44f06173da37eadb007e18af321d5) netclient: 0.21.1 -> 0.21.2
* [`8796286f`](https://github.com/NixOS/nixpkgs/commit/8796286f357b532ca46e13ba9cc5e261a7a69f3c) netassert: 2.0.2 -> 2.0.3
* [`14903148`](https://github.com/NixOS/nixpkgs/commit/14903148690cad36bcbb0ad3f0b6d0419df0feca) nix-eval-jobs: 2.19.0 -> 2.19.2
* [`47ed4540`](https://github.com/NixOS/nixpkgs/commit/47ed4540eb9bd383f136d0a870f2d452725a0873) oauth2c: 1.12.2 -> 1.12.3
* [`ea210cb8`](https://github.com/NixOS/nixpkgs/commit/ea210cb88ed95113b53dcc034252f8f41773383b) cargo-llvm-cov: 0.5.37 -> 0.5.38
* [`5b046fa5`](https://github.com/NixOS/nixpkgs/commit/5b046fa5d96e7f4606e247bc13eb011a741a152d) python311Packages.ruff-lsp: 0.0.47 -> 0.0.48
* [`95c00e36`](https://github.com/NixOS/nixpkgs/commit/95c00e3624d62b095dbfa55b0fab579ec9434b8f) ocamlPackages.yojson: 2.1.1 -> 2.1.2
* [`c4da1f41`](https://github.com/NixOS/nixpkgs/commit/c4da1f410c7969b80a23195f2cba509fc847f961) cargo-llvm-cov: 0.5.38 -> 0.5.39
* [`bb1ab299`](https://github.com/NixOS/nixpkgs/commit/bb1ab2997f9cb8b0579833d2e0df7fb141cd0aec) trufflehog: 3.63.1 -> 3.63.2
* [`1078b943`](https://github.com/NixOS/nixpkgs/commit/1078b943f04951bfb39f504f8c847f808397afdb) trufflehog: 3.63.2 -> 3.63.4
* [`24b51ca5`](https://github.com/NixOS/nixpkgs/commit/24b51ca50a343127c7ed396c83c24f093337444c) octavePackages.ocl: 1.2.1 -> 1.2.2
* [`3f1692a1`](https://github.com/NixOS/nixpkgs/commit/3f1692a172abe7996244695d4773b71b2c8fbc72) oelint-adv: 3.26.4 -> 3.26.5
* [`b4ba3117`](https://github.com/NixOS/nixpkgs/commit/b4ba3117559b3424f0db292cd4d52a13494557b1) okteto: 2.23.0 -> 2.23.1
* [`2e46cf39`](https://github.com/NixOS/nixpkgs/commit/2e46cf395733f48b5f6c41e4039dffc4f98ec474) onlyoffice-documentserver: 7.5.0 -> 7.5.1
* [`cfc1c6e7`](https://github.com/NixOS/nixpkgs/commit/cfc1c6e7a940fe42598c3de343acab1e78793586) ooniprobe-cli: 3.19.1 -> 3.20.0
* [`ab307062`](https://github.com/NixOS/nixpkgs/commit/ab3070626afa4748a4595cc67f80ef096d72829b) opcr-policy: 0.2.4 -> 0.2.8
* [`d2a58d52`](https://github.com/NixOS/nixpkgs/commit/d2a58d52e7dbce020b9e6e4ce087b776de6bff4e) openai: 1.3.7 -> 1.5.0
* [`d884cb11`](https://github.com/NixOS/nixpkgs/commit/d884cb11aba1365279f9cc6d4a66698611503750) rocm-docs-core: add note to move to 'rocmPackages_common' later
* [`1f3ddf0a`](https://github.com/NixOS/nixpkgs/commit/1f3ddf0a271ca0d3863785ca010379f3f5ec351c) rocmPackages_5: mark broken if at least version '6.0.0'
* [`998b97dc`](https://github.com/NixOS/nixpkgs/commit/998b97dcce5b41bb71792dd2197357bab309201d) nix-eval-jobs: 2.19.2 -> 2.19.3
* [`48a5a0fe`](https://github.com/NixOS/nixpkgs/commit/48a5a0fe538ad02dcf039fb91b28082679b68dc0) ouch: 0.5.0 -> 0.5.1
* [`965254f8`](https://github.com/NixOS/nixpkgs/commit/965254f8d3b06dc42a2a6e88230286b44ff99b5b) webcord: 4.5.2 -> 4.6.0
* [`00cb53de`](https://github.com/NixOS/nixpkgs/commit/00cb53de4fa2ba9fcdb52f504943d6ec8ebe5ce5) nginx: fix nginx binary pathname
* [`8d578326`](https://github.com/NixOS/nixpkgs/commit/8d578326dbe94709d7801a750a6c57abc3eaaee7) cinnamon.nemo-extensions: 6.0.0 -> 6.0.1
* [`3b322aed`](https://github.com/NixOS/nixpkgs/commit/3b322aed7a7f2b29103160f92d5bafb25afbcd74) cinnamon.folder-color-switcher: 1.6.0 -> 1.6.1
* [`20f70b29`](https://github.com/NixOS/nixpkgs/commit/20f70b29f7d71354e48e8a721fed76ec672058b4) pcm: 202307 -> 202311
* [`3c9696e2`](https://github.com/NixOS/nixpkgs/commit/3c9696e255426f318f406baf26d44a4789b6ffbe) epson-escpr2: use rpm & cpio instead of busybox
* [`1b41925d`](https://github.com/NixOS/nixpkgs/commit/1b41925db034243a2fb6a955e058825674f9b1cd) epson-escpr2: 1.1.49 -> 1.2.9
* [`cf6d8952`](https://github.com/NixOS/nixpkgs/commit/cf6d89525ff7c1b19c119eb9f73f18ad4f3c0c0e) nixos/zed: use global sendmail if configured
* [`bfbebb41`](https://github.com/NixOS/nixpkgs/commit/bfbebb4158f6ed1675d7435ca05cc420342a3f6d) php81Extensions.datadog_trace: 0.94.0 -> 0.95.0
* [`400c5a62`](https://github.com/NixOS/nixpkgs/commit/400c5a622a46982058455bd2177aa20ddc18ba88) php81Extensions.maxminddb: 1.11.0 -> 1.11.1
* [`7394781d`](https://github.com/NixOS/nixpkgs/commit/7394781ddeedbf137ff280ae807aa6a5f407ac7a) aldente: 1.24 -> 1.24.1
* [`34ced515`](https://github.com/NixOS/nixpkgs/commit/34ced5157c2206daddfccb2d8662da0600214ca6) shotcut: 23.11.29 -> 23.12.15
* [`ca56a090`](https://github.com/NixOS/nixpkgs/commit/ca56a0908f5b19ff925e387506ec301edd343264) php81Extensions.mongodb: 1.16.2 -> 1.17.1
* [`0225a786`](https://github.com/NixOS/nixpkgs/commit/0225a786e5c53c87d24616ce75e1213140df86ae) nixos/networkd: allow IPv6LinkLocalAddressGenerationMode in networkConfig
* [`07e34cfd`](https://github.com/NixOS/nixpkgs/commit/07e34cfddbdc6804654c26a2493f4e7e13ea6b5d) miniflux: 2.0.50 -> 2.0.51
* [`233526c0`](https://github.com/NixOS/nixpkgs/commit/233526c09af3f10f29e1951574e46a11a2625d2c) miniflux: add emilylange as maintainer
* [`4a7faeaf`](https://github.com/NixOS/nixpkgs/commit/4a7faeaff38e1a5036a77dcbebd14d09dcf3cd5d) nixos/invidious: remove obsolete database maintenance service
* [`460e34b2`](https://github.com/NixOS/nixpkgs/commit/460e34b273592fb6b4fa7e57d65c02c82895d03a) nixos/tests/invidious: move postgres-tcp into second machine and fix tests
* [`45bd4b11`](https://github.com/NixOS/nixpkgs/commit/45bd4b1159bb29d4a60c1d811f24b3487acbcab6) nixos/invidious: add option to run more invidious instances
* [`65e8f8a6`](https://github.com/NixOS/nixpkgs/commit/65e8f8a69790c61ff862ccc6de977644566f8456) nixos/tests/invidious: add test for scaled invidious
* [`d41706ba`](https://github.com/NixOS/nixpkgs/commit/d41706bae27673db9e307e6165eb47d75ee74ce6) nixos/invidious: bind to 127.0.0.1 instead of 0.0.0.0 if nginx is used
* [`5e320dba`](https://github.com/NixOS/nixpkgs/commit/5e320dba222b5bd67f80289818ec7f361b04b112) http3-ytproxy: init at unstable-2022-07-03
* [`ac5c1886`](https://github.com/NixOS/nixpkgs/commit/ac5c1886fd9fe49748d7ab80accc4c847481df14) nixos/invidious: add option to configure http3-ytproxy for invidious
* [`24e561fa`](https://github.com/NixOS/nixpkgs/commit/24e561fabca19b9cee1fef98e793b712901b8482) nixos/invidious: change default database user to invidious
* [`a681ff90`](https://github.com/NixOS/nixpkgs/commit/a681ff90b7cee38da2eebfb96dd9c48ee1807cc1) miniflux: remove `buildGoModule` pin, replace `let in` with `rec`
* [`bc940be7`](https://github.com/NixOS/nixpkgs/commit/bc940be7c3f50bafd03db65ed127527ebc216393) php81Extensions.openswoole: 22.0.0 -> 22.1.2
* [`417ad7b0`](https://github.com/NixOS/nixpkgs/commit/417ad7b0345aefec76f9760797fabe24174b0eab) php81Packages.php-cs-fixer: 3.40.0 -> 3.41.1
* [`6fce82a1`](https://github.com/NixOS/nixpkgs/commit/6fce82a10eaaeee9fd32209eed30d2463131854b) php81Packages.phpmd: 2.14.1 -> 2.15.0
* [`292c74c7`](https://github.com/NixOS/nixpkgs/commit/292c74c7a92efe45cfdfc091fb48d8c575346a95) nixos/nextcloud: set correct MIME type for .mjs files
* [`96937447`](https://github.com/NixOS/nixpkgs/commit/96937447e73f0034993df01dc37d04313f408a1d) bc-ur: init at 0.3.0
* [`0fa9ae6b`](https://github.com/NixOS/nixpkgs/commit/0fa9ae6b544ccb9fbc4613c05f7ba27471397080) feather: 2.5.2 -> 2.6.1
* [`86efccfa`](https://github.com/NixOS/nixpkgs/commit/86efccfa45b058d51c429105dc2108e2ad1da005) angie: init at 1.4.0
* [`c580ebee`](https://github.com/NixOS/nixpkgs/commit/c580ebee409e5bfad058c4c39dad5535fcbbee5a) angie-console-light: init at 1.1.1
* [`b79f1854`](https://github.com/NixOS/nixpkgs/commit/b79f1854093a172684321bf1ce8bf26781694362) nixos/tests/nginx-http3: add angie package in testing
* [`362a2e61`](https://github.com/NixOS/nixpkgs/commit/362a2e618c143d139f1c0058f7b45b4c626ee493) nixos/tests: add test api in angie package
* [`be58446c`](https://github.com/NixOS/nixpkgs/commit/be58446c794c7baec615387c7324404af4a0a9dc) nvitop: 1.3.1 -> 1.3.2
* [`bf74ecda`](https://github.com/NixOS/nixpkgs/commit/bf74ecda4285f75985ba6c0a2f9ac6ad79b1b512) pgadmin: 8.0 -> 8.1
* [`a78bd227`](https://github.com/NixOS/nixpkgs/commit/a78bd2277ea469d18c72c9dd8b27acfbd47b3c5a) phrase-cli: 2.15.0 -> 2.19.0
* [`ae3140f6`](https://github.com/NixOS/nixpkgs/commit/ae3140f6fdb6012469dfda842f5b1a225c03902e) pgadmin: cleanup
* [`8bf02ebc`](https://github.com/NixOS/nixpkgs/commit/8bf02ebc9b40539066d093dfe9bf8923479be616) zapzap: fix double wrapping, install icon in correct directory
* [`cc4b2b36`](https://github.com/NixOS/nixpkgs/commit/cc4b2b36df2209252233147350c7c8d36ab099e5) plantuml-server: 1.2023.12 -> 1.2023.13
* [`7a8c37d7`](https://github.com/NixOS/nixpkgs/commit/7a8c37d77e980caa2e519edb46c78e78815032a7) rye: 0.15.2 -> 0.16.0
* [`975a327d`](https://github.com/NixOS/nixpkgs/commit/975a327d4af0a3164b0a6ea23a1657ddc65bba0e) pocket-updater-utility: 2.37.0 -> 2.38.1
* [`50bf72a2`](https://github.com/NixOS/nixpkgs/commit/50bf72a24901303d6f1f31b15e4509af3ee4adda) unicorn: fix build on riscv
* [`20992f16`](https://github.com/NixOS/nixpkgs/commit/20992f16402b6de54a4e7a9b064e2b8de30bcf36) pocketbase: 0.20.0 -> 0.20.1
* [`12f105ce`](https://github.com/NixOS/nixpkgs/commit/12f105ce2562e01470c80ca13695172f836c6c40) sassc: set meta.mainProgram
* [`94a71e66`](https://github.com/NixOS/nixpkgs/commit/94a71e666077d8619f0a3e43cd42fc16fbe5915b) btrfs-progs: user build's python for man pages generation, not host's
* [`e476dfaa`](https://github.com/NixOS/nixpkgs/commit/e476dfaab3561ed663f43db81394c04107eeb182) snippetexpander: init at 1.0.1
* [`70085247`](https://github.com/NixOS/nixpkgs/commit/7008524735942a6296f1d18f1b52c4082c24b275) postgresql12JitPackages.pg_uuidv7: 1.4.0 -> 1.4.1
* [`ff3fd860`](https://github.com/NixOS/nixpkgs/commit/ff3fd8603916b7ff4b580bf57df07161daa7d469) postgresql12JitPackages.tds_fdw: unstable-2023-09-28 -> unstable-2023-12-04
* [`a9e9acff`](https://github.com/NixOS/nixpkgs/commit/a9e9acff4f561c9d75f05b93c621a6d7f75f35ba) lomiri.lomiri-notifications: init at 1.3.0
* [`ee4c8f50`](https://github.com/NixOS/nixpkgs/commit/ee4c8f509ac3abddfbe5da8a5c27ee0384d43cfe) act: 0.2.55 -> 0.2.56
* [`17411073`](https://github.com/NixOS/nixpkgs/commit/17411073a84160104bb516fc5aebb8bcb5bf0f94) vaultwarden.webvault: 2023.10.0 -> 2023.12.0
* [`1999136c`](https://github.com/NixOS/nixpkgs/commit/1999136cee48a10e87328be78bfbeb8d5bbdcf3a) python311Packages.eigenpy: 3.1.4 -> 3.2.0
* [`f9a71d8c`](https://github.com/NixOS/nixpkgs/commit/f9a71d8cf33db22a81fe2d182188dce55f7da76a) process-compose: 0.77.4 -> 0.77.6
* [`f87188ab`](https://github.com/NixOS/nixpkgs/commit/f87188abaf14f24bd0a23f5ef473d468a53f7a90) cmdstan: refactor
* [`8db5a1a6`](https://github.com/NixOS/nixpkgs/commit/8db5a1a6b911cf32e95cdb351a6aeab1812fc7b6) pcl: fix configurePhase with withCuda=true
* [`6618ac8b`](https://github.com/NixOS/nixpkgs/commit/6618ac8b543fecfbc35cd0c8116e0fbdfb9ca2e0) prometheus-domain-exporter: 1.21.1 -> 1.22.0
* [`d2006e25`](https://github.com/NixOS/nixpkgs/commit/d2006e25fd53c06853a752426da3ae1b69edb906) bruno: 1.4.0 -> 1.5.0
* [`44b90312`](https://github.com/NixOS/nixpkgs/commit/44b9031298a7f28541d2f00a00604011e0b2ae3a) prometheus-gitlab-ci-pipelines-exporter: 0.5.5 -> 0.5.6
* [`8cb04468`](https://github.com/NixOS/nixpkgs/commit/8cb044684fcaa1296049ad5e60026ee7f38bc3d1) prometheus-graphite-exporter: 0.14.0 -> 0.15.0
* [`8c58a7cb`](https://github.com/NixOS/nixpkgs/commit/8c58a7cb4be05edcce761074ca2f111b39771322) nixos/luksroot: add final newline to /etc/crypttab
* [`5079ef29`](https://github.com/NixOS/nixpkgs/commit/5079ef293082fd890601c05e602e1420a7555032) persistent-cache-cpp: 1.0.5 -> 1.0.6
* [`1f4a878c`](https://github.com/NixOS/nixpkgs/commit/1f4a878c1944e01abd219b138a539e4567412c2e) prometheus-influxdb-exporter: 0.11.4 -> 0.11.5
* [`07130e98`](https://github.com/NixOS/nixpkgs/commit/07130e98563c9467969815060b7f7891a4922ff3) persistent-cache-cpp: Fetch upstream-submitted patches
* [`fa80274f`](https://github.com/NixOS/nixpkgs/commit/fa80274f38d473ba34aeefb696e4da34df765f79) trunk: fix build on darwin
* [`80a04171`](https://github.com/NixOS/nixpkgs/commit/80a04171d5f6011292f1eb83146716058ca1f1ad) maintainers: add endle
* [`958adeed`](https://github.com/NixOS/nixpkgs/commit/958adeedd3bed39f3faa7b9262a249d3cff658d6) prometheus-nginx-exporter: 0.11.0 -> 1.0.0
* [`9578e89e`](https://github.com/NixOS/nixpkgs/commit/9578e89eef096bd619488d224a4b22c4d1cded17) prometheus-nut-exporter: 3.0.0 -> 3.1.1
* [`9e46efb8`](https://github.com/NixOS/nixpkgs/commit/9e46efb828420a9735bd945bc43086020338bdb1) deepin.deepin-desktop-base: 2022.11.15-deepin -> 2023.09.05
* [`620c89f5`](https://github.com/NixOS/nixpkgs/commit/620c89f58e707b4c562cae3c9e5eb83b86302988) prometheus-statsd-exporter: 0.25.0 -> 0.26.0
* [`ffa6079c`](https://github.com/NixOS/nixpkgs/commit/ffa6079cb03df796478e4e7030d3af5368ae781f) add libGL
* [`61fbaa4d`](https://github.com/NixOS/nixpkgs/commit/61fbaa4dbdf3ebd29b16efa894be45004c8e8801) dolibarr: 18.0.3 -> 18.0.4
* [`63f6c1d3`](https://github.com/NixOS/nixpkgs/commit/63f6c1d3f9dc3df015926c396d51b6b73a3e712d) goeland: 0.16.0 -> 0.17.0
* [`21b6bf51`](https://github.com/NixOS/nixpkgs/commit/21b6bf5150062413c5965f2048a094e1899014fa) Revert "packages-config.nix: ignore haskellPackages.hs-mesos"
* [`e1c9282d`](https://github.com/NixOS/nixpkgs/commit/e1c9282d161c7cee44c46a120f19db87079ba2f9) deepin.deepin-voice-note: 6.0.13 -> 6.0.15
* [`330eb2de`](https://github.com/NixOS/nixpkgs/commit/330eb2ded430e9032cdd0b8c3a3d38e1d42427a8) pithos: 1.6.0 -> 1.6.1
* [`3e056716`](https://github.com/NixOS/nixpkgs/commit/3e0567164961757ca50a7078e97b47aa24b5c469) jc: 1.23.6 -> 1.24.0
* [`710e9e06`](https://github.com/NixOS/nixpkgs/commit/710e9e066cbeaf68ab5ad970b9b25652318cae41) nsz: 4.5.0 -> 4.6.0
* [`4d1be9e3`](https://github.com/NixOS/nixpkgs/commit/4d1be9e3953d30c20f7b5b40b5d80784d0dd9a99) lunarml: 0.0.20231113 -> 0.1.0
* [`4f352d93`](https://github.com/NixOS/nixpkgs/commit/4f352d93119983a1fc6e55590ed6ffa22e451d9d) nuclei: 3.1.1 -> 3.1.2
* [`f6282232`](https://github.com/NixOS/nixpkgs/commit/f6282232de5d0c869889c5f7016f02db04b3336b) python311Packages.dvc-http: 2.30.2 -> 2.32.0
* [`8ee808a7`](https://github.com/NixOS/nixpkgs/commit/8ee808a74259f960ef88ad7d34310ceb9f24baf0) python311Packages.minidump: 0.0.22 -> 0.0.23
* [`52645772`](https://github.com/NixOS/nixpkgs/commit/526457722c5462deab0a85eac739493e54b55e94) praat: 6.4 -> 6.4.01
* [`9c75a2d2`](https://github.com/NixOS/nixpkgs/commit/9c75a2d29b780c8ac0bf90b6119f602ef512cd9e) python310Packages.adafruit-io: 2.7.0 -> 2.7.1
* [`9291f159`](https://github.com/NixOS/nixpkgs/commit/9291f1591febdcbf34134acaa7e845e620d02c8f) python310Packages.adafruit-platformdetect: 3.56.0 -> 3.57.0
* [`1ede548b`](https://github.com/NixOS/nixpkgs/commit/1ede548b027748858593e288636c89671e9de502) python310Packages.aioambient: 2023.10.1 -> 2023.12.0
* [`39e4eb6c`](https://github.com/NixOS/nixpkgs/commit/39e4eb6cca3c2856d1c9c7579c9473a0acaa726b) ocamlPackages.telemetry: init at 0.0.1
* [`0e4a4b71`](https://github.com/NixOS/nixpkgs/commit/0e4a4b715b0deb5b50ccc702c16cf1ebc90c2d57) ocamlPackages.riot: 0.0.2 → 0.0.5
* [`e7323a5b`](https://github.com/NixOS/nixpkgs/commit/e7323a5be5ab57e8810f62c1329fc17c52e2accb) python310Packages.aiocomelit: 0.6.2 -> 0.7.0
* [`762b82d8`](https://github.com/NixOS/nixpkgs/commit/762b82d8c5f174315fd33afe31e3c626fd84b958) python310Packages.aioconsole: 0.6.2 -> 0.7.0
* [`99de747e`](https://github.com/NixOS/nixpkgs/commit/99de747e114427ccc5b31740a6f35bb59f52c2b0) python311Packages.polars: 0.19.12 -> 0.20.0
* [`97dbea90`](https://github.com/NixOS/nixpkgs/commit/97dbea90865930041e2d6b3ee753f98181b4e18a) python310Packages.aiooss2: 0.2.7 -> 0.2.8
* [`36c8c253`](https://github.com/NixOS/nixpkgs/commit/36c8c2530d3534a7810cf64cf25ccac856698c51) python310Packages.aiolyric: 1.1.0 -> 1.1.1
* [`aa3cd9c9`](https://github.com/NixOS/nixpkgs/commit/aa3cd9c9552880a7ce9e456631218b5e97a45a44) nixos/tests/gitlab: download even more RAM
* [`c8e2b03b`](https://github.com/NixOS/nixpkgs/commit/c8e2b03b5ea06b1809fed725ac71b302f92b2956) path-of-building.data: 2.37.0 -> 2.38.0
* [`965236f4`](https://github.com/NixOS/nixpkgs/commit/965236f4c0083e575afe576962ed61a3967564eb) ft2-clone: 1.73 -> 1.74
* [`84421478`](https://github.com/NixOS/nixpkgs/commit/84421478e83744513e168f23951d50f58623ce1c) python310Packages.aioridwell: 2023.10.0 -> 2023.12.0
* [`afa523cf`](https://github.com/NixOS/nixpkgs/commit/afa523cfbe29fd80bd5a2f37e93f013c4c8fa164) python310Packages.aiorecollect: 2023.11.0 -> 2023.12.0
* [`87eee26d`](https://github.com/NixOS/nixpkgs/commit/87eee26dfeae6e265d8e4ee316ef66d426067159) python310Packages.aiortm: 0.8.6 -> 0.8.7
* [`fcd0ecfa`](https://github.com/NixOS/nixpkgs/commit/fcd0ecfa5d78c069fd98a13ad504a516854b880b) nix-eval-jobs: 2.19.3 -> 2.19.4
* [`a087861e`](https://github.com/NixOS/nixpkgs/commit/a087861ed819ee738c8ea68304dcc933c7b4eb65) python310Packages.aiovodafone: 0.4.3 -> 0.5.1
* [`f094289e`](https://github.com/NixOS/nixpkgs/commit/f094289e005efeb17070abc96d671855937b7257) symfony-cli: 5.7.5 -> 5.7.6
* [`7f6d7e2d`](https://github.com/NixOS/nixpkgs/commit/7f6d7e2dfa9e73fa5ee1980537fa04d9f6f8e8b1) python310Packages.anywidget: 0.7.1 -> 0.8.0
* [`bb8de8a5`](https://github.com/NixOS/nixpkgs/commit/bb8de8a5dd6a9cad64fdf719557abcb1604c5326) python310Packages.approvaltests: 10.1.0 -> 10.2.0
* [`eb6ef047`](https://github.com/NixOS/nixpkgs/commit/eb6ef047e9fb7f4a4ad8475e4a8990c4fb3f21ab) python310Packages.appthreat-vulnerability-db: 5.5.4 -> 5.5.6
* [`8a034b12`](https://github.com/NixOS/nixpkgs/commit/8a034b122750f8a3ea986dd97e8898b0bd805d5e) nnpdf: 4.0.6 -> 4.0.7
* [`2710a8e0`](https://github.com/NixOS/nixpkgs/commit/2710a8e084e592a231d05184a4577839cdec6258) python310Packages.asf-search: 6.7.1 -> 6.7.2
* [`82b945c0`](https://github.com/NixOS/nixpkgs/commit/82b945c0e380ab6920f4db7e74660e6a49a0207d) python310Packages.apycula: 0.9.1 -> 0.10.0
* [`1a5f1c6a`](https://github.com/NixOS/nixpkgs/commit/1a5f1c6a217cbc9adb2e90f8b21db35c4b6ea750) python310Packages.argilla: 1.19.0 -> 1.20.0
* [`2e1347c9`](https://github.com/NixOS/nixpkgs/commit/2e1347c9a7aa77b0972d00e5694ef2734a821394) python310Packages.asana: 4.0.11 -> 5.0.3
* [`3cf84a57`](https://github.com/NixOS/nixpkgs/commit/3cf84a5706eee907338ac5578d889dc1d025a68b) mailpit: 1.11.0 -> 1.11.1
* [`33ccd943`](https://github.com/NixOS/nixpkgs/commit/33ccd9438ce6f32a809f84dd0f1f63c349e7a356) python310Packages.asyncsleepiq: 1.3.7 -> 1.4.0
* [`44909a18`](https://github.com/NixOS/nixpkgs/commit/44909a1816cc9ee1b0fa8bdd184b16fc82f76e49) python310Packages.auth0-python: 4.6.1 -> 4.7.0
* [`6aefc850`](https://github.com/NixOS/nixpkgs/commit/6aefc8503f17395fcdc57abf20922d8c6009ce82) python310Packages.authcaptureproxy: 1.3.0 -> 1.3.2
* [`f1c70b44`](https://github.com/NixOS/nixpkgs/commit/f1c70b448cf467b8a86cca32c635ad14b07e6f5b) prr: init at 0.11.0
* [`29d99b1a`](https://github.com/NixOS/nixpkgs/commit/29d99b1a6eef724d32ece21d56cb4adf2924d326) waagent: nixpkgs-fmt
* [`beff92b8`](https://github.com/NixOS/nixpkgs/commit/beff92b86faa946f1413e9fb419eacca51c76317) waagent: use buildPythonApplication
* [`76254a64`](https://github.com/NixOS/nixpkgs/commit/76254a64b941574e76c18d2e3d70090a023ec1af) waagent: fix description in meta
* [`f9991e9d`](https://github.com/NixOS/nixpkgs/commit/f9991e9de0014bc7e15394ef312fdf3d3112abd6) waagent: fixes
* [`276939e0`](https://github.com/NixOS/nixpkgs/commit/276939e0a1a218a8541c6c36a675e166c7131845) nixos/waagent: move runtime dependencies to systemd service
* [`f1c8d070`](https://github.com/NixOS/nixpkgs/commit/f1c8d0709be6c9d510d4cafcdb2ad481f398c461) nixos/waagent: provide waagent udev rules in initrd
* [`85e0f8e5`](https://github.com/NixOS/nixpkgs/commit/85e0f8e59da3a518f789c4bb43e0c7b6219d25b5) ibus: fix skipping key release events[1] in Wine
* [`e2d75f43`](https://github.com/NixOS/nixpkgs/commit/e2d75f43bf829cd3165dcf9606a590bc904efa8d) python310Packages.aws-lambda-builders: 1.43.0 -> 1.44.0
* [`aef183b8`](https://github.com/NixOS/nixpkgs/commit/aef183b8ae0163a23f057d6679666bf144768c93) python310Packages.azure-mgmt-network: 25.1.0 -> 25.2.0
* [`a2157e62`](https://github.com/NixOS/nixpkgs/commit/a2157e6284e625b31243a6385cfd959411a7b6ca) python310Packages.azure-mgmt-compute: 30.3.0 -> 30.4.0
* [`8529c05a`](https://github.com/NixOS/nixpkgs/commit/8529c05a2338da2e22525e93fcf18ac65b47b36a) python310Packages.boto3-stubs: 1.29.7 -> 1.34.2
* [`1776cc26`](https://github.com/NixOS/nixpkgs/commit/1776cc26a20dc680b055e26cc7a6b7ae4e6821e4) python310Packages.botocore-stubs: 1.33.8 -> 1.34.2
* [`6421e181`](https://github.com/NixOS/nixpkgs/commit/6421e18125c03863f76dbeb26689008cd1521f63) mmtf-cpp: 1.0.0 -> 1.1.0
* [`da1f5eab`](https://github.com/NixOS/nixpkgs/commit/da1f5eab0f6014d30fcaf0ab8eaf6b2fe88a8b15) molequeue: cmake fixes
* [`817612c1`](https://github.com/NixOS/nixpkgs/commit/817612c13a0da4b3925a0d6776cb1dfb15ed4fdd) avogadrolibs: 1.97.0 -> 1.98.1
* [`1d2d308e`](https://github.com/NixOS/nixpkgs/commit/1d2d308e2e25d5a5c38a2b44d4d2d4fe83416a0a) avogadro2: 1.97.0 -> 1.98.1
* [`f4ae825d`](https://github.com/NixOS/nixpkgs/commit/f4ae825dc2038af9892cca32a6bdc9473b2228d8) lightdm-slick-greeter: 2.0.1 -> 2.0.2
* [`8372ba53`](https://github.com/NixOS/nixpkgs/commit/8372ba53e80eb4965e36dc3884d3cc30b2d64f51) broot: 1.30.0 -> 1.30.1
* [`c75a348b`](https://github.com/NixOS/nixpkgs/commit/c75a348b43f69dfb5f6d50597a672ee1f2b67734) python310Packages.censys: 2.2.9 -> 2.2.10
* [`bd1f27b9`](https://github.com/NixOS/nixpkgs/commit/bd1f27b9b3a614b1227ba444c81070aebf836c66) indilib: 2.0.3 -> 2.0.5
* [`cdb27134`](https://github.com/NixOS/nixpkgs/commit/cdb271343f0c7443a5dd8aa8cbd2878f3aaae08b) python310Packages.aiovodafone: refactor
* [`5b31bfe1`](https://github.com/NixOS/nixpkgs/commit/5b31bfe1da7194266139c3da433f202b81e3ac9e) indi-firmware: 2.0.3 -> 2.0.5
* [`dfe67681`](https://github.com/NixOS/nixpkgs/commit/dfe67681d9299aca1174a5a4828cc446a02cfdda) python310Packages.adafruit-platformdetect: refactor
* [`8a61def1`](https://github.com/NixOS/nixpkgs/commit/8a61def159502f5d5d0e351bbd43fc20010122ae) indi-full: 2.0.3 -> 2.0.5
* [`6430b7a1`](https://github.com/NixOS/nixpkgs/commit/6430b7a181ddbe4774da00b30df9cf35d37ada30) nixos/prometheus-sabnzbd-exporter: use LoadCredential for apiKeyFile
* [`ae8dc824`](https://github.com/NixOS/nixpkgs/commit/ae8dc8248110973e15a16fdf179f34b05889b5b7) python311Packages.aioambient: refactor
* [`b9e4b87e`](https://github.com/NixOS/nixpkgs/commit/b9e4b87e32206c597e5043a9d8edd8ce1c7fec25) cinnamon.xreader: 3.8.4 -> 4.0.0
* [`9e11ec57`](https://github.com/NixOS/nixpkgs/commit/9e11ec57b9957ba37a38a293ac34fc3891657f8e) python310Packages.clarifai: 9.10.4 -> 9.11.0
* [`8f0649c7`](https://github.com/NixOS/nixpkgs/commit/8f0649c7ae8c555b8034eed3e41889380d953f6d) python310Packages.clarifai-grpc: 9.10.6 -> 9.11.2
* [`9bf1b596`](https://github.com/NixOS/nixpkgs/commit/9bf1b596d6ac72af6a4785fea8dff272eb7b7f50) python310Packages.clickhouse-connect: 0.6.21 -> 0.6.23
* [`73f58904`](https://github.com/NixOS/nixpkgs/commit/73f58904034cecc77f429ee8aa0baa59f1d49466) python310Packages.confight: 1.3.1 -> 2.0
* [`fd439a46`](https://github.com/NixOS/nixpkgs/commit/fd439a461855108ca3d6e4399732c88739f4d51c) zsh-powerlevel10k: make imports more diff friendly
* [`8e0593cc`](https://github.com/NixOS/nixpkgs/commit/8e0593ccf348a835335ed644af69160e6c16ca90) zsh-powerlevel10k: avoid importing `pkgs`
* [`f54152d2`](https://github.com/NixOS/nixpkgs/commit/f54152d2a509df6f6e4c9852baf25113f857c086) python311Packages.censys: refactor
* [`a0f94525`](https://github.com/NixOS/nixpkgs/commit/a0f94525b0c387c9e311031873b3d4d33ab5d204) julia docs: one line per sentence
* [`f0d3f016`](https://github.com/NixOS/nixpkgs/commit/f0d3f016970f1f3f4e41bf883222e11439c7f25f) qt6Packages.qxlsx: 1.4.6 -> 1.4.7
* [`8de14f52`](https://github.com/NixOS/nixpkgs/commit/8de14f527765f885635e15524181dd2d97a620b4) python310Packages.crc: 5.0.0 -> 6.0.0
* [`635bd604`](https://github.com/NixOS/nixpkgs/commit/635bd604b6cc51f7e1be8f864e0ae0a2b068da49) python310Packages.cryptolyzer: 0.12.0 -> 0.12.1
* [`3998c003`](https://github.com/NixOS/nixpkgs/commit/3998c00333767542639d3d9ca0586847d9181aea) python310Packages.cryptoparser: 0.12.0 -> 0.12.1
* [`442e1ea3`](https://github.com/NixOS/nixpkgs/commit/442e1ea3990c7371f256cfcab66d8039f5539e76) python311Packages.aioconsole: refactor
* [`59302f4a`](https://github.com/NixOS/nixpkgs/commit/59302f4a91eb5dc408587a911dac56fc3354fb41) python311Packages.auth0-python: update disabled
* [`b00586cb`](https://github.com/NixOS/nixpkgs/commit/b00586cb2611a9fad32eb1e716dda41e3e4ae586) rocmPackages_5: GitHub repo owner has generally changed to 'ROCm'
* [`252aec46`](https://github.com/NixOS/nixpkgs/commit/252aec463279f4131c256bd9fde12296ec6d2e83) rocmPackages_5: update script: error if version > 5
* [`ba111791`](https://github.com/NixOS/nixpkgs/commit/ba11179111c821c87a6458fe87efb4ba2fc8e0e3) witness: 0.1.14 -> 0.2.0
* [`f12915c4`](https://github.com/NixOS/nixpkgs/commit/f12915c4e0c143774d3139d6accb7a66df252fb9) waagent: fix re-execution
* [`1791eeb7`](https://github.com/NixOS/nixpkgs/commit/1791eeb7bd782b49b33998fa9152710f4117ffc2) cgal: default to version 5
* [`b9704019`](https://github.com/NixOS/nixpkgs/commit/b9704019c99bfa358712debe86d91d3fe58d442d) cgal_4: 4.14.2 → 4.14.3
* [`b69c7344`](https://github.com/NixOS/nixpkgs/commit/b69c73444956b5386a5b029f0cf6b5ff1112b9cf) gitlab-runner: 16.6.0 -> 16.6.1 ([nixos/nixpkgs⁠#274415](https://togithub.com/nixos/nixpkgs/issues/274415))
* [`51f5b7df`](https://github.com/NixOS/nixpkgs/commit/51f5b7df9723b09c1fbab48846bacb793a2a45c4) syn2mas: init at 0.7.0
* [`57c4009c`](https://github.com/NixOS/nixpkgs/commit/57c4009cfdb03dd1fb426af4fa8046e2563a6469) python310Packages.dataprep-ml: 0.0.20 -> 0.0.21
* [`7e6bc497`](https://github.com/NixOS/nixpkgs/commit/7e6bc49753eb0d24f23796e5fae4a424f1aec0fa) python311Packages.anova-wifi: init at 0.10.3
* [`551d7c03`](https://github.com/NixOS/nixpkgs/commit/551d7c03299f224e4cfe03babac2455b8dd9a95a) home-assistant: update component packages
* [`969f3a45`](https://github.com/NixOS/nixpkgs/commit/969f3a45ab54efafa307ce9714f47e3e194cc3cf) python311Packages.icalevents: init at 0.1.27
* [`c0268a7b`](https://github.com/NixOS/nixpkgs/commit/c0268a7b9aefc14ab28558d07741059c644f0866) home-assistant-custom-components.waste_collection_schedule: init at 1.44.0
* [`432b9bd6`](https://github.com/NixOS/nixpkgs/commit/432b9bd6208071be5035efa7e275f906f252861c) nixos/firmware: Omit removed rtl8723-bs package
* [`7a1b958d`](https://github.com/NixOS/nixpkgs/commit/7a1b958d069fb54ed017920578be599ee417520e) python311Packages.opower: 0.0.41 -> 0.1.0
* [`c7cb02a4`](https://github.com/NixOS/nixpkgs/commit/c7cb02a4359fb58dc03b66897b24b8fa8d11dc75) python311Packages.motionblinds: 0.6.18 -> 0.6.19
* [`b2ea24e5`](https://github.com/NixOS/nixpkgs/commit/b2ea24e59c0007dd065b808e36d4fc1ae4ccfb8e) python311Packages.blinkpy: 0.22.3 -> 0.22.4
* [`b774d4b3`](https://github.com/NixOS/nixpkgs/commit/b774d4b3735965279d8a9f23ab6ab5ae90af1f92) python311Packages.reolink-aio: 0.8.2 -> 0.8.4
* [`3128cd73`](https://github.com/NixOS/nixpkgs/commit/3128cd737c7f7558a90f6c1b622fa58bd7540ab2) python311Packages.pyasuswrt: 0.1.20 -> 0.1.21
* [`246e1de3`](https://github.com/NixOS/nixpkgs/commit/246e1de302454d98646285098ce044b1a4d1bf95) python311Packages.bleak-esphome: 0.3.0 -> 0.4.0
* [`40f39e81`](https://github.com/NixOS/nixpkgs/commit/40f39e8117c83dea7ebab68e121d4f31528bb293) python311Packages.bluetooth-adapters: 0.16.1 -> 0.16.2
* [`48c5f854`](https://github.com/NixOS/nixpkgs/commit/48c5f85442c450b5e7bffaa511c0f256ffe418c9) python3Packages.brother-ql: apply patch for Pillow>=10.0
* [`7d565226`](https://github.com/NixOS/nixpkgs/commit/7d565226df0b818af851c810ecf46f4dc39dd900) openssh: 9.5p1 -> 9.6p1
* [`aaae1b52`](https://github.com/NixOS/nixpkgs/commit/aaae1b52a3c2f20e53025228a893f1303f81ced1) ktls-utils: init at 0.10
* [`accee511`](https://github.com/NixOS/nixpkgs/commit/accee5111df54b921cf3a1a48ca2d80e2eb9a61d) musescore: 4.1.1 -> 4.2.0
* [`2ada2933`](https://github.com/NixOS/nixpkgs/commit/2ada2933862487956e111d4163f8551300d8037a) syncthingtray: add xdg-utils to PATH
* [`0ea45cd1`](https://github.com/NixOS/nixpkgs/commit/0ea45cd17b9454344e86473a1743d1239360d628) gcfflasher: 4.0.3-beta -> 4.3.0-beta
* [`8ea50098`](https://github.com/NixOS/nixpkgs/commit/8ea5009875e9901b56a2cfbb97ba0514c4a6c0d8) gcfflasher: set platforms
* [`15a64317`](https://github.com/NixOS/nixpkgs/commit/15a643171de00bfcfba1d061e4ca62b1d2c4d15b) xwayland-run: init at 0.0.2
* [`2592a670`](https://github.com/NixOS/nixpkgs/commit/2592a6704ef820f60b2c7c41037e508a9d14a252) python311Packages.cached-ipaddress: init at 0.3.0
* [`bdd67c91`](https://github.com/NixOS/nixpkgs/commit/bdd67c91f25dfa977152fd9c15dfe9c0b9a68aef) python311Packages.aiodiscover: 1.5.1 -> 1.6.0
* [`63c77c23`](https://github.com/NixOS/nixpkgs/commit/63c77c2361cd1cb27a8566b1dffa2a626fc79a08) python311Packages.qingping-ble: 0.8.2 -> 0.9.0
* [`a18f2d40`](https://github.com/NixOS/nixpkgs/commit/a18f2d4085e48ed84233aabe3c7ab54b0efd7a96) python310Packages.dissect: 3.10 -> 3.11
* [`1eb75826`](https://github.com/NixOS/nixpkgs/commit/1eb75826beb297ffc9800c2673ae3f9a7b8555bb) obs-studio: remove self as maintainer
* [`501585ea`](https://github.com/NixOS/nixpkgs/commit/501585eac1b1de29a2747490d722d02f0951c0f6) obs-studio-plugins.wlrobs: remove self as maintainer
* [`e2a49d95`](https://github.com/NixOS/nixpkgs/commit/e2a49d958215321048bd0dac8efbae07417cb626) python310Packages.dissect-esedb: 3.9 -> 3.10
* [`67a7f7d2`](https://github.com/NixOS/nixpkgs/commit/67a7f7d2e73557befb2a480f614e09b52eabfe81) shellhub-agent: 0.13.4 -> 0.13.6
* [`27582799`](https://github.com/NixOS/nixpkgs/commit/27582799515ded5ad7cf9255de32cae0ef452f24) python310Packages.dissect-extfs: 3.6 -> 3.7
* [`39c3f5fe`](https://github.com/NixOS/nixpkgs/commit/39c3f5fe38844ff7521741967fcb5706084931b1) osu-lazer-bin: 2023.1130.0 -> 2023.1218.1
* [`10380ec4`](https://github.com/NixOS/nixpkgs/commit/10380ec4b06a4c2ef179a78942d72ca3becd04b9) osu-lazer: 2023.1026.0 -> 2023.1218.1
* [`5ca627ad`](https://github.com/NixOS/nixpkgs/commit/5ca627ad2b43c104d6d9960106bf918fe93ae3ca) python311Packages.dissect-util: 3.12 -> 3.13
* [`994fc1f9`](https://github.com/NixOS/nixpkgs/commit/994fc1f931869d8c01096ee5099141c6f87c04ef) python311Packages.dissect-target: 3.13 -> 3.14
* [`3e4e8411`](https://github.com/NixOS/nixpkgs/commit/3e4e8411244ca4e3969ab71deeff33330634b53a) python311Packages.acquire: 3.10 -> 3.11
* [`b1a96bbb`](https://github.com/NixOS/nixpkgs/commit/b1a96bbbf22c2e375080773a366f6e9dbf7cd3ba) doc: Add test for broken links in `manpage-urls.json`
* [`a687d6ab`](https://github.com/NixOS/nixpkgs/commit/a687d6ab7e962403d4b5ec8d3d6bc7cc79849d08) doc/manpage-urls.json: Fix link to gnunet's manual
* [`ba387f0a`](https://github.com/NixOS/nixpkgs/commit/ba387f0a5be2a11366b046c6e28f9ce4bd348f58) workflows/manual-nixpkgs: Run the manual's tests
* [`ae2527e1`](https://github.com/NixOS/nixpkgs/commit/ae2527e1e2c9136f6df8221f9851d89a12d9eb17) nss_latest: 3.96 -> 3.96.1
* [`0bac154c`](https://github.com/NixOS/nixpkgs/commit/0bac154c969c7f65434e8106db513f1cc2a5a400) sqlboiler: refactor
* [`38e912ea`](https://github.com/NixOS/nixpkgs/commit/38e912eaa3890122be2c1354772d1791e53ea8dc) doc/tests/manpage-urls.py: Add type annotations
* [`ea960719`](https://github.com/NixOS/nixpkgs/commit/ea960719b48c581b2061de7e34cdf8646c2c9248) signald: Add xargs and sed dependencies to wrapper
* [`4a49de9d`](https://github.com/NixOS/nixpkgs/commit/4a49de9da680ee8b826b679f6599dcc368f85aed) python310Packages.django-import-export: 3.3.3 -> 3.3.4
* [`c9df5dba`](https://github.com/NixOS/nixpkgs/commit/c9df5dbaec08a3167838321c596621f47f0dd564) python310Packages.django-ipware: 6.0.1 -> 6.0.3
* [`6ca6d3cb`](https://github.com/NixOS/nixpkgs/commit/6ca6d3cb984dcd1d5fee085cd5dc1f6695037a63) regex2json: init at 0.11.0
* [`c597e026`](https://github.com/NixOS/nixpkgs/commit/c597e026873894d69e3661d4a335f7321c8841e7) protoc-gen-rust-grpc: init at 0.8.3
* [`640831bf`](https://github.com/NixOS/nixpkgs/commit/640831bf79564a52b1b7108af1221621642a1dc9) python310Packages.django-rq: 2.9.0 -> 2.10.1
* [`9ee8211c`](https://github.com/NixOS/nixpkgs/commit/9ee8211ce30ddd5b738bf6ef3bd1b05b6ebec209) python310Packages.django-rest-registration: 0.8.2 -> 0.8.3
* [`edb8b799`](https://github.com/NixOS/nixpkgs/commit/edb8b7994c383d3754cbb03b2bdb6016026e19cc) pinentry: drop gtk2
* [`e222fc58`](https://github.com/NixOS/nixpkgs/commit/e222fc5802585b06c96469e2d481eb01546fa242) plasma5Packages.breeze-gtk: drop gtk2
* [`b76ebfc6`](https://github.com/NixOS/nixpkgs/commit/b76ebfc6ccb7b76beeebc580355f9cb210c71206) plasma5Packages.kde-gtk-config: build without gtk2
* [`2b122abc`](https://github.com/NixOS/nixpkgs/commit/2b122abc406018898e143985d5fe92dc20f4dee9) ibus: build without gtk2
* [`1ebb7d7b`](https://github.com/NixOS/nixpkgs/commit/1ebb7d7bba2953a4223956cfb5f068b0095f84a7) nixos/gitea: add hmacKey support
* [`fc4e60a5`](https://github.com/NixOS/nixpkgs/commit/fc4e60a5214a22be6086c25cc601bfedf4da6cb8) vulkan-tools-lunarg: add qt5
* [`dfb1eeb6`](https://github.com/NixOS/nixpkgs/commit/dfb1eeb6203f1f5717bad06cba0c5feed74f0b52) python310Packages.botorch: 0.9.4 -> 0.9.5
* [`09aa95a7`](https://github.com/NixOS/nixpkgs/commit/09aa95a74efc9b018307a3a5160a61121d0849fc) python310Packages.djangoql: 0.17.1 -> 0.18.0
* [`16ddc355`](https://github.com/NixOS/nixpkgs/commit/16ddc355d39f5a2f67d4105e101154bdfb3fba5e) python310Packages.djangorestframework-simplejwt: 5.3.0 -> 5.3.1
* [`b25b7d9e`](https://github.com/NixOS/nixpkgs/commit/b25b7d9e40d1cc24b7b79ad728d5fcb0a38fdf3e) lomiri.lomiri-download-manager: init at 0.1.2
* [`cea1ae36`](https://github.com/NixOS/nixpkgs/commit/cea1ae3633c1cffba0a43e2ca057d03afff9ac0d) argos: unstable-20230404 → unstable-2023-09-26
* [`5a9e975e`](https://github.com/NixOS/nixpkgs/commit/5a9e975e3ef6e84e9cea5231b6b97a70112af43e) python310Packages.dockerspawner: 12.1.0 -> 13.0.0
* [`dba7b7f4`](https://github.com/NixOS/nixpkgs/commit/dba7b7f4bfe2c7d7e379293f33c0c7978b836e4a) lilypond-with-fonts: fix build of some fonts
* [`213eabf5`](https://github.com/NixOS/nixpkgs/commit/213eabf52c5d9db2fe759ca96bdedb7a322d9930) lilypond-with-fonts: fix font's permissions
* [`517916e9`](https://github.com/NixOS/nixpkgs/commit/517916e94f7d588929db327634a027fd9c99c851) vsmtp: drop as upstream has gone
* [`dc58efc6`](https://github.com/NixOS/nixpkgs/commit/dc58efc69cc430dc5bf08cf5b69fdfdd763e343c) gnomeExtensions.system-monitor-next: Patch to fix runtime errors
* [`4b1ee3e6`](https://github.com/NixOS/nixpkgs/commit/4b1ee3e616190461004dbe50fd26014506eaf85e) gnomeExtensions.system-monitor: Remove in favor of system-monitor-next
* [`d3ee0135`](https://github.com/NixOS/nixpkgs/commit/d3ee01357620a3b0d7eec68a2622ccbcfda8869f) lilypod-with-fonts: add missing fonts' directory
* [`74f2e495`](https://github.com/NixOS/nixpkgs/commit/74f2e495436983b9b3d8c9a94a638bb411cfb245) lib.fileset.fetchGit: Refactoring
* [`1bb85ca0`](https://github.com/NixOS/nixpkgs/commit/1bb85ca0d483ea7c3fbbcba7d12ce57d57c70e90) mpvScripts: Add test validating `scriptName`
* [`f4e390dc`](https://github.com/NixOS/nixpkgs/commit/f4e390dc8a336cb32bdc9e8bba7cb3b195e9b237) mpvScripts: Test that dir-packaged scripts contain exactly one `main.*`
* [`ad95e298`](https://github.com/NixOS/nixpkgs/commit/ad95e2989d252a15dd8a3af78ba3f92f9221e8be) mpvScripts.mpvacious: Fix `scriptName`
* [`14f0b7d7`](https://github.com/NixOS/nixpkgs/commit/14f0b7d7444aa6e1ffd589787b409173b7660fc8) mpvScripts.simple-mpv-webui: Fix `scriptName`
* [`94e3fd7a`](https://github.com/NixOS/nixpkgs/commit/94e3fd7aac9080078868f99e0ce1a6abea5a0a5c) python310Packages.dvc-data: 2.24.0 -> 3.0.1
* [`21c14e70`](https://github.com/NixOS/nixpkgs/commit/21c14e7095229a27f8ac4d403350467542794aa9) mpvScripts.{blacklistExtensions, seekTo}: Add (hacky) `updateScript`
* [`19a8f086`](https://github.com/NixOS/nixpkgs/commit/19a8f0868aa93ce18150bad16b3c6a482659695b) python310Packages.dvc-studio-client: 0.17.0 -> 0.18.0
* [`941397c1`](https://github.com/NixOS/nixpkgs/commit/941397c1b1414dd8c9ce3181df873281f771c16a) mpvScripts.{blacklistExtensions, seekTo}: unstable-2022-10-02 → 2023-12-18
* [`adce32e0`](https://github.com/NixOS/nixpkgs/commit/adce32e028ecedb3fda532ced186510ed5e14a8e) pcl: rename withCuda to cudaSupport
* [`9c90a963`](https://github.com/NixOS/nixpkgs/commit/9c90a963a079074af92a11335d8b4924a93da9e2) pcl: fix build on darwin
* [`24770ef3`](https://github.com/NixOS/nixpkgs/commit/24770ef35f74380a49938975a8f5410e7aea7ca8) python310Packages.dvclive: 3.3.1 -> 3.4.1
* [`e4a8fef4`](https://github.com/NixOS/nixpkgs/commit/e4a8fef4ab57588c36cb974a1b3717409bef2314) python310Packages.edk2-pytool-library: 0.19.6 -> 0.19.8
* [`3c553dbb`](https://github.com/NixOS/nixpkgs/commit/3c553dbb434bce2ecd7e418ecc07197f1b35c631) python310Packages.elasticsearch8: 8.11.0 -> 8.11.1
* [`18c3ca7d`](https://github.com/NixOS/nixpkgs/commit/18c3ca7dccd208461376f4a9faeff2ff2ef5d9d6) python310Packages.etils: 1.5.2 -> 1.6.0
* [`432aa817`](https://github.com/NixOS/nixpkgs/commit/432aa817203416d969d18285114da356237aa6f8) vscodium: 1.85.0.23343 -> 1.85.1.23348
* [`49ad5417`](https://github.com/NixOS/nixpkgs/commit/49ad5417489185ab32ed409f815001a1c6ba5033) python310Packages.faraday-plugins: 1.14.0 -> 1.15.0
* [`8b522701`](https://github.com/NixOS/nixpkgs/commit/8b52270180c947ed2d2cf5c1f3815f52670927a0) python310Packages.farm-haystack: 1.22.1 -> 1.23.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
