### PR TITLE
niv devenv: update e681a99f -> 405a4c6a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e681a99ffe2d2882f413a5d771129223c838ddce",
-        "sha256": "1z6sns17716kciq92vpixhv46fgsc7mwa8i70iqp8lfn13r7whwq",
+        "rev": "405a4c6a3fecfd2a7fb37cc13f4e760658e522e6",
+        "sha256": "07ipw3ndlabi5851lrlhh7afij16r9hpld1gqabhpg44hdfz9d9i",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/e681a99ffe2d2882f413a5d771129223c838ddce.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/405a4c6a3fecfd2a7fb37cc13f4e760658e522e6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@e681a99f...405a4c6a](https://github.com/cachix/devenv/compare/e681a99ffe2d2882f413a5d771129223c838ddce...405a4c6a3fecfd2a7fb37cc13f4e760658e522e6)

* [`0f96aa45`](https://github.com/cachix/devenv/commit/0f96aa4590ccc496acd3bb39a1e1b1dc53400037) Add influxdb module
* [`dad24416`](https://github.com/cachix/devenv/commit/dad24416b1ca61a5551db0de863b047765ac0454) Add settings for InfluxDB
* [`a3770ae3`](https://github.com/cachix/devenv/commit/a3770ae3e111eac4252f941078fa1eb549ccf8ac) Remove lock, rename settings to config
* [`d4b9af65`](https://github.com/cachix/devenv/commit/d4b9af65992f802023a623c9bfabc6f528304080) Increase wait time for instance start
* [`405a4c6a`](https://github.com/cachix/devenv/commit/405a4c6a3fecfd2a7fb37cc13f4e760658e522e6) Auto generate docs/reference/options.md
