### PR TITLE
niv home-manager: update e8aaced7 -> 80679ea5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798",
-        "sha256": "0myryi7fjcdl9ncmff6mn1kc3f8skvs3f6a5sghb1mglc0py8s70",
+        "rev": "80679ea5074ab7190c4cce478c600057cfb5edae",
+        "sha256": "0cyp0hvscb1jdm5yc94nblhf9dgx6yqyw7qrvy2jxd8ird3ajg02",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/80679ea5074ab7190c4cce478c600057cfb5edae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e8aaced7...80679ea5](https://github.com/nix-community/home-manager/compare/e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798...80679ea5074ab7190c4cce478c600057cfb5edae)

* [`ebeeef94`](https://github.com/nix-community/home-manager/commit/ebeeef94ab0cba72ca3b3a89b98658dcc1296c11) docs: fix typo in nix-flakes.md
* [`efc177c1`](https://github.com/nix-community/home-manager/commit/efc177c15f2a8bb063aeb250fe3c7c21e1de265e) sapling: add module
* [`433120e4`](https://github.com/nix-community/home-manager/commit/433120e47d016c9960dd9c2b1821e97d223a6a39) gradle: add module
* [`c8c6a527`](https://github.com/nix-community/home-manager/commit/c8c6a52702a81ba01b905b2b3aa64f06d246f905) sway: fix failing tests
* [`4f258945`](https://github.com/nix-community/home-manager/commit/4f258945de476b54471b07645013f6aa6c8219bb) thefuck: fix test case
* [`0360475e`](https://github.com/nix-community/home-manager/commit/0360475ee0fc870bc450874da5b5d7b2a85a091b) gradle: temporarily comment out the maintainer entry
* [`8f38f1a2`](https://github.com/nix-community/home-manager/commit/8f38f1a231547a9d9bc9f0233eb9c92cfb89f025) docs: fix broken home-manager options link
* [`67c4c05c`](https://github.com/nix-community/home-manager/commit/67c4c05c29d2bd72cef7376c38351cb30af4d708) direnv: Apply nushell env transformations
* [`bc52cdd5`](https://github.com/nix-community/home-manager/commit/bc52cdd5795e60850e860b5ccce7e8b9537d86f9) direnv: Use ${getExe pkg} instead of ${pkg}/bin/pkg
* [`3bfaacf4`](https://github.com/nix-community/home-manager/commit/3bfaacf46133c037bb356193bd2f1765d9dc82c1) direnv: Make lines shorter
* [`b897544a`](https://github.com/nix-community/home-manager/commit/b897544a798d487044d7356ff4cf6d4748ac231a) direnv: Fix nushell integration ENV_CONVERSIONS
* [`8b797c8e`](https://github.com/nix-community/home-manager/commit/8b797c8eea1eba7dfb47f6964103e6e0d134255f) fish: escape abbr expansions once again
* [`19a78437`](https://github.com/nix-community/home-manager/commit/19a784373439032363daeba0a991e5e59bbad178) zoxide: use interactive shell init for Fish
* [`fb5ac0c8`](https://github.com/nix-community/home-manager/commit/fb5ac0c870a1b3ffea70e02ab1720d991ce812ae) nix-index: use interactive shell init for Fish
* [`07c322a7`](https://github.com/nix-community/home-manager/commit/07c322a7cff03267fd881adae1afe63367c5d608) aerc-accounts: support for maildirpp ([nix-community/home-manager⁠#4653](https://togithub.com/nix-community/home-manager/issues/4653))
* [`7184dfe6`](https://github.com/nix-community/home-manager/commit/7184dfe663ec35629802ed2a739147989173422a) firefox: update docs example for nativeMessagingHosts
* [`de913414`](https://github.com/nix-community/home-manager/commit/de9134144b456104953c2533debb27a02787891f) unison: better retry/restart reporting failures
* [`a2523ea0`](https://github.com/nix-community/home-manager/commit/a2523ea0343b056ba240abbac90ab5f116a7aa7b) gpg-agent: add nushell integration
* [`16fcb967`](https://github.com/nix-community/home-manager/commit/16fcb9674a71220313f91446e0c259bce5c20f0f) home-environment: fix incompatible profile error
* [`d5a917ba`](https://github.com/nix-community/home-manager/commit/d5a917bab40daf4e5f82cd27162b8a6656d3beab) Translate using Weblate (French)
* [`015a36e9`](https://github.com/nix-community/home-manager/commit/015a36e9c737d97356eb1627d4d7c7bd84976b85) oh-my-posh: enable nushell integration
* [`80679ea5`](https://github.com/nix-community/home-manager/commit/80679ea5074ab7190c4cce478c600057cfb5edae) flake.lock: Update
