### PR TITLE
niv emacs-overlay: update 1b8163de -> 75d58280

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1b8163de282e43d005b28e768fd156d417d441d9",
-        "sha256": "0wfpd0n6q5cjd6jszdz7jsmdh3rvirkp8qsv1c21cc67pki82vgh",
+        "rev": "75d582804c561bb16f726916096ee22272d156cc",
+        "sha256": "19y0yvljjhm3cf0n7dyzpfmqbl901d5xngivgma4ypyxy46d57vw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/1b8163de282e43d005b28e768fd156d417d441d9.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/75d582804c561bb16f726916096ee22272d156cc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@1b8163de...75d58280](https://github.com/nix-community/emacs-overlay/compare/1b8163de282e43d005b28e768fd156d417d441d9...75d582804c561bb16f726916096ee22272d156cc)

* [`0e3354d2`](https://github.com/nix-community/emacs-overlay/commit/0e3354d28739e65339fe0ad8c31a5d638f420168) Updated repos/elpa
* [`9bbd47c3`](https://github.com/nix-community/emacs-overlay/commit/9bbd47c38f3525817ff2733e4cf6e7ea3ff1b5b8) Updated repos/emacs
* [`19a1e4de`](https://github.com/nix-community/emacs-overlay/commit/19a1e4de1ebe4c0ffd4436a395b2b6fbef2a6773) Updated repos/melpa
* [`f7753ffa`](https://github.com/nix-community/emacs-overlay/commit/f7753ffa160ec5e2960357290267bc7b7171e6d9) Updated repos/nongnu
* [`a5f0ee16`](https://github.com/nix-community/emacs-overlay/commit/a5f0ee16ab1c9cb38b4a855d70961b75427a5161) Updated flake inputs
* [`e46350d4`](https://github.com/nix-community/emacs-overlay/commit/e46350d4cf8bc8a41dc18b75979b6c6129a1304e) Updated repos/emacs
* [`ead33b53`](https://github.com/nix-community/emacs-overlay/commit/ead33b53bddac6d9e4e01d1e80e6dc1d8d30d2a3) Updated repos/melpa
* [`e3751b87`](https://github.com/nix-community/emacs-overlay/commit/e3751b876974295bf3dd93a31c5ac554ff6ddb2b) Updated repos/elpa
* [`2038bd98`](https://github.com/nix-community/emacs-overlay/commit/2038bd988f6947699561832f81f4250ad37462a6) Updated repos/emacs
* [`d6f9a741`](https://github.com/nix-community/emacs-overlay/commit/d6f9a7414ece512046f84b1ece1ba9538cbd1ea2) Updated repos/melpa
* [`8dc16b0f`](https://github.com/nix-community/emacs-overlay/commit/8dc16b0f0edfb3560497724dfe8d214d5b251c65) Updated flake inputs
* [`c0952561`](https://github.com/nix-community/emacs-overlay/commit/c0952561b32efddbff65efcc4ab5f31df932b8b0) Updated repos/elpa
* [`eee7ae9d`](https://github.com/nix-community/emacs-overlay/commit/eee7ae9d0f4bfea569c0af9973fa089395e2daea) Updated repos/melpa
* [`8baf9759`](https://github.com/nix-community/emacs-overlay/commit/8baf97591f1df81ce5ef7305a66a4bb0404009bd) Updated repos/nongnu
* [`13b5aff9`](https://github.com/nix-community/emacs-overlay/commit/13b5aff9fe02d0338729b4de0dd0d795578aa778) Updated repos/emacs
* [`590e9947`](https://github.com/nix-community/emacs-overlay/commit/590e99479d5f34c57781252f5ac3f956e4c0d237) Updated repos/melpa
* [`9168578d`](https://github.com/nix-community/emacs-overlay/commit/9168578dade9b93ec70b3563ac023b9b2c3fc3f1) Updated repos/elpa
* [`eb4bf0e2`](https://github.com/nix-community/emacs-overlay/commit/eb4bf0e26c40eadb6add3fad57a43c2d892d7b8c) Updated repos/emacs
* [`bf63d14c`](https://github.com/nix-community/emacs-overlay/commit/bf63d14c647476891713198bbb7ffef48b523ad6) Updated repos/melpa
* [`2cad7552`](https://github.com/nix-community/emacs-overlay/commit/2cad7552433397581b0f3c8218c7c111b1896587) Updated repos/nongnu
* [`3a995e18`](https://github.com/nix-community/emacs-overlay/commit/3a995e180635a363358de231d2c5d533fa4c55ca) Updated repos/elpa
* [`eaf7ae54`](https://github.com/nix-community/emacs-overlay/commit/eaf7ae54eec482b10896d50b8b916898bcdf4cd9) Updated repos/emacs
* [`58e2efaf`](https://github.com/nix-community/emacs-overlay/commit/58e2efaf6e4d79332378b15c50277495c1198988) Updated repos/melpa
* [`c5359301`](https://github.com/nix-community/emacs-overlay/commit/c5359301a75608fec3fe2f112de053d32d79a0ea) Updated repos/emacs
* [`b9765a41`](https://github.com/nix-community/emacs-overlay/commit/b9765a4102f23b014d17d71aa0283d8e047477f6) Updated repos/melpa
* [`7235502b`](https://github.com/nix-community/emacs-overlay/commit/7235502b7fd057fac31ccf2638011f249d8ccaef) Updated repos/elpa
* [`abec2ee6`](https://github.com/nix-community/emacs-overlay/commit/abec2ee68af6f81cd2d51a880b2a46f87bc584f3) Updated repos/emacs
* [`41aca908`](https://github.com/nix-community/emacs-overlay/commit/41aca908ef62507056270f2b6f7109cfe2f94995) Updated repos/melpa
* [`b633dc11`](https://github.com/nix-community/emacs-overlay/commit/b633dc1183ad4f2e1eaaec541d655920e3b1f1da) Updated repos/nongnu
* [`ccf7377e`](https://github.com/nix-community/emacs-overlay/commit/ccf7377ec09257db9923f91b63ecbb4c591fedc1) Updated flake inputs
* [`78c8eb7c`](https://github.com/nix-community/emacs-overlay/commit/78c8eb7ccd4f4a3b94ec673b0ee39b11f714f0ed) Updated repos/elpa
* [`fe38fd7c`](https://github.com/nix-community/emacs-overlay/commit/fe38fd7c9db1dc1714af85db2dd228071a195a92) Updated repos/emacs
* [`ef6075df`](https://github.com/nix-community/emacs-overlay/commit/ef6075df726c868b83d36426d889ddcdc64d7111) Updated repos/melpa
* [`068abb54`](https://github.com/nix-community/emacs-overlay/commit/068abb549359f2330f37a1d0f21f09fb638ac6d4) Updated repos/nongnu
* [`036ee470`](https://github.com/nix-community/emacs-overlay/commit/036ee470a39b01dd6332fedd9d63c81322c48f15) Updated repos/emacs
* [`1ff54718`](https://github.com/nix-community/emacs-overlay/commit/1ff5471880b6e48f63ec5fa668486ab1268c2b22) Updated repos/melpa
* [`8f37332e`](https://github.com/nix-community/emacs-overlay/commit/8f37332eb73475bfd9bee266a039e267cba9a185) Updated flake inputs
* [`9eedbdf7`](https://github.com/nix-community/emacs-overlay/commit/9eedbdf7ec172a6e8b8b32edf48c9e1ea9da43ba) Updated repos/elpa
* [`6243303e`](https://github.com/nix-community/emacs-overlay/commit/6243303ef440aab59c659496ac24b3c84a85833f) Updated repos/emacs
* [`a8e5dc30`](https://github.com/nix-community/emacs-overlay/commit/a8e5dc30e5a4ea9e765b34140a3d5457163d39f6) Updated repos/melpa
* [`dc744ac6`](https://github.com/nix-community/emacs-overlay/commit/dc744ac6f2083258415507daa492937d14d44b55) Updated repos/nongnu
* [`1840d8de`](https://github.com/nix-community/emacs-overlay/commit/1840d8de3947998fcc3c0277cb58ec2046cbad73) Updated repos/elpa
* [`658049b8`](https://github.com/nix-community/emacs-overlay/commit/658049b88f2f9b336658a9518069906e48147673) Updated repos/emacs
* [`629fdea1`](https://github.com/nix-community/emacs-overlay/commit/629fdea1a72f81c528ce88ffea7a9214c07b4cd1) Updated repos/melpa
* [`4c177e0f`](https://github.com/nix-community/emacs-overlay/commit/4c177e0f890cb081e7ce1ae12649bbc93f727dd7) Updated repos/nongnu
* [`5bc76d2e`](https://github.com/nix-community/emacs-overlay/commit/5bc76d2e18a8592d49e1539e7eb79a95a3f2ce1c) Updated repos/melpa
* [`41dcdafd`](https://github.com/nix-community/emacs-overlay/commit/41dcdafdb7a0a0989a6236090a5dafb2306341a8) Updated repos/elpa
* [`43c76035`](https://github.com/nix-community/emacs-overlay/commit/43c76035dcf5d71e0ad333a574ae607b0cfdf15d) Updated repos/emacs
* [`45cc8ec0`](https://github.com/nix-community/emacs-overlay/commit/45cc8ec0b95b46baa65adad88e6ea0037fb8c8f8) Updated repos/melpa
* [`7d69a058`](https://github.com/nix-community/emacs-overlay/commit/7d69a05897fd2bf53db2004f90975eacedc1f717) Updated repos/elpa
* [`9854704d`](https://github.com/nix-community/emacs-overlay/commit/9854704dff6dc39d8d3d106da9e4c149ea7dd5a4) Updated repos/emacs
* [`384abdc7`](https://github.com/nix-community/emacs-overlay/commit/384abdc7504cb95d3df0ea1f72f01f1b5b2b039f) Updated repos/melpa
* [`6d41130f`](https://github.com/nix-community/emacs-overlay/commit/6d41130ffc00158f8c86a913c96d3d98463a7c90) Updated repos/emacs
* [`ff627044`](https://github.com/nix-community/emacs-overlay/commit/ff6270444ab7e1ab6fac3464d173b03aa8cb7a75) Updated repos/melpa
* [`06c4ff77`](https://github.com/nix-community/emacs-overlay/commit/06c4ff77a025f5f14756edca62181460f51a81bf) Updated flake inputs
* [`36401611`](https://github.com/nix-community/emacs-overlay/commit/36401611ddff3ed053837dc8d4630b566d081574) Updated repos/elpa
* [`7d353e91`](https://github.com/nix-community/emacs-overlay/commit/7d353e914a05e4f06ed0bf6d4efb03e827ce23db) Updated repos/emacs
* [`0a9317a7`](https://github.com/nix-community/emacs-overlay/commit/0a9317a71ebb8407a46834b55eaa3ce84eb27a46) Updated repos/melpa
* [`38b96a83`](https://github.com/nix-community/emacs-overlay/commit/38b96a83c36cce95b2ef6ac975cb921fad970222) Updated flake inputs
* [`0f474ee4`](https://github.com/nix-community/emacs-overlay/commit/0f474ee4328b9c5af40bb16cde751cc9c151bc2d) Updated repos/elpa
* [`f8a62137`](https://github.com/nix-community/emacs-overlay/commit/f8a6213710016bdb0d9edab5129c7069ffcc3a08) Updated repos/emacs
* [`3bad6461`](https://github.com/nix-community/emacs-overlay/commit/3bad646173201de59d462f1825c5f5116cafa36f) Updated repos/melpa
* [`348e66ff`](https://github.com/nix-community/emacs-overlay/commit/348e66ffa3eeea21a62fc25d13e625dbfc8ac899) Updated repos/emacs
* [`7a2b06b1`](https://github.com/nix-community/emacs-overlay/commit/7a2b06b15c0497ebb75a059dfabadc1d707dd6d0) Updated repos/melpa
* [`431cf541`](https://github.com/nix-community/emacs-overlay/commit/431cf541ab443c366d47d87ca387ecdff098a170) Updated repos/elpa
* [`481128e0`](https://github.com/nix-community/emacs-overlay/commit/481128e0e763ea1bdfd7b2f1fb54b2c32ae7fe65) Updated repos/emacs
* [`433f8ba3`](https://github.com/nix-community/emacs-overlay/commit/433f8ba396eb78f6e3ac80d0be76083e0fcb4640) Updated repos/melpa
* [`b6fa0a73`](https://github.com/nix-community/emacs-overlay/commit/b6fa0a7314fbcca7257770e1064bfef44d9d7293) Updated repos/nongnu
* [`9f6f0e77`](https://github.com/nix-community/emacs-overlay/commit/9f6f0e77688d72a5314041b048e4efa7f1b8f224) Updated repos/elpa
* [`ecb8fcd4`](https://github.com/nix-community/emacs-overlay/commit/ecb8fcd4dc2c9bc63e33d28a0543b5dc7fd69ea7) Updated repos/emacs
* [`45ed406c`](https://github.com/nix-community/emacs-overlay/commit/45ed406ced5d2d1483aed1e0e844dcfa8ba9e0b1) Updated repos/melpa
* [`170e8603`](https://github.com/nix-community/emacs-overlay/commit/170e86030361a09053abe3ca36b0fefa1292a13e) Updated repos/nongnu
* [`d9cd5f09`](https://github.com/nix-community/emacs-overlay/commit/d9cd5f09f121ae0e2673f5ca8f4ece7a320fa659) Updated repos/emacs
* [`ea9cd7c2`](https://github.com/nix-community/emacs-overlay/commit/ea9cd7c22194345e4db85e334b8ff40cc384c536) Updated repos/melpa
* [`74ca1d8a`](https://github.com/nix-community/emacs-overlay/commit/74ca1d8abcbd3296d11f54c20db8c17f91007262) Updated repos/elpa
* [`ef7d33ab`](https://github.com/nix-community/emacs-overlay/commit/ef7d33ab570feb00414e00a13990bf4e1cdf334c) Updated repos/emacs
* [`7087b02d`](https://github.com/nix-community/emacs-overlay/commit/7087b02d82d945bef0936b7d7781a520cd6e55e5) Updated repos/melpa
* [`c4bd6164`](https://github.com/nix-community/emacs-overlay/commit/c4bd61649b43078a4946b08d9a66c419a52d3380) Updated flake inputs
* [`c53ad5f8`](https://github.com/nix-community/emacs-overlay/commit/c53ad5f833eace3644c895457b78fb5a7475ea02) Updated repos/elpa
* [`a1417924`](https://github.com/nix-community/emacs-overlay/commit/a1417924d2fdfc3c5a8b5113cb42e4b2d9308710) Updated repos/emacs
* [`8f9af3a1`](https://github.com/nix-community/emacs-overlay/commit/8f9af3a191e8d5ebf884e7f39ccabbc383213058) Updated repos/melpa
* [`533b3984`](https://github.com/nix-community/emacs-overlay/commit/533b39841271451714d1a269622a720b176a82b3) Updated repos/emacs
* [`9e85d89e`](https://github.com/nix-community/emacs-overlay/commit/9e85d89e1938256adc3e1886e5c03319c0d94630) Updated repos/melpa
* [`acfdbe09`](https://github.com/nix-community/emacs-overlay/commit/acfdbe097cc7bf9f7412345a6ec54eb3582c2867) Updated repos/elpa
* [`530c6a6b`](https://github.com/nix-community/emacs-overlay/commit/530c6a6b7b78c00aac4e6c91f7c440566366873e) Updated repos/emacs
* [`5fd742dc`](https://github.com/nix-community/emacs-overlay/commit/5fd742dc7aa5e5642461b0def2afac00da9103f6) Updated repos/melpa
* [`0c7b9e24`](https://github.com/nix-community/emacs-overlay/commit/0c7b9e24eb801bb37870ce579d84b0f06ff8f5d6) Updated repos/nongnu
* [`9117ee18`](https://github.com/nix-community/emacs-overlay/commit/9117ee18977127784735f7604358dd154d9e0af7) Updated repos/elpa
* [`82c5d6db`](https://github.com/nix-community/emacs-overlay/commit/82c5d6dbbbf0c99eccfd36d48a8e1e64f9faf399) Updated repos/emacs
* [`f789abe5`](https://github.com/nix-community/emacs-overlay/commit/f789abe560f5f0fbff08d8fec9244a3a576af2c6) Updated repos/melpa
* [`956b70d6`](https://github.com/nix-community/emacs-overlay/commit/956b70d64d5ff36c53242cd335fe8274c0cfa2e7) Updated repos/nongnu
* [`817e0731`](https://github.com/nix-community/emacs-overlay/commit/817e0731e1c326bfc279d75531357789f6b7d5dc) Updated repos/melpa
* [`857d0d51`](https://github.com/nix-community/emacs-overlay/commit/857d0d518bfcd3b3e1c561f25be9c6075d48cd0b) Updated flake inputs
* [`da181c88`](https://github.com/nix-community/emacs-overlay/commit/da181c8824e7c220e5e7f1c6f6e3b473f58cd89e) Updated repos/elpa
* [`fa3cc21d`](https://github.com/nix-community/emacs-overlay/commit/fa3cc21d6f25e556b5eae7219fd3ed7406ad20d1) Updated repos/emacs
* [`0d9122dd`](https://github.com/nix-community/emacs-overlay/commit/0d9122ddb0e9677458d5cfaa81810b5f05399b00) Updated repos/melpa
* [`d947dcdc`](https://github.com/nix-community/emacs-overlay/commit/d947dcdc615bf6d776597fa8e9726620690dc9ed) Updated repos/elpa
* [`007ca6bf`](https://github.com/nix-community/emacs-overlay/commit/007ca6bf56c63dbe2546a39b10a5e9d42ae48f52) Updated repos/emacs
* [`c9ef46c1`](https://github.com/nix-community/emacs-overlay/commit/c9ef46c1eb4fa852e76cdcc57a14d24b8e3bc141) Updated repos/melpa
* [`61c35019`](https://github.com/nix-community/emacs-overlay/commit/61c35019e3080f199aae18b978c06ffdc4153e32) Updated repos/nongnu
* [`a57e6b7b`](https://github.com/nix-community/emacs-overlay/commit/a57e6b7bc4e2906503d89755c9fbfab536c46e88) Updated repos/emacs
* [`5075b8df`](https://github.com/nix-community/emacs-overlay/commit/5075b8df3d8d4d28e73e921acb46a2cf7f34ad28) Updated repos/melpa
* [`27171bad`](https://github.com/nix-community/emacs-overlay/commit/27171bad183b4791319c7b1253794e11fd5718ec) Updated flake inputs
* [`bdb723bd`](https://github.com/nix-community/emacs-overlay/commit/bdb723bde52828879ef73fcba1097a8a26532e7d) Updated repos/elpa
* [`5be1f7f9`](https://github.com/nix-community/emacs-overlay/commit/5be1f7f9d0c327557a246599a7af345b123c9491) Updated repos/melpa
* [`d335aa71`](https://github.com/nix-community/emacs-overlay/commit/d335aa7178443668e97a8b906cad0e1da6402687) Updated repos/elpa
* [`84f8ab02`](https://github.com/nix-community/emacs-overlay/commit/84f8ab0290cefe329974ed9a57cb947494fdcd10) Updated repos/emacs
* [`e4dd7bd3`](https://github.com/nix-community/emacs-overlay/commit/e4dd7bd3566a43bdec8e3d5cc239ef0a86046c59) Updated repos/melpa
* [`edfe7ad2`](https://github.com/nix-community/emacs-overlay/commit/edfe7ad2a87fad08c9c8ae6f65e0ecf5e824e601) Updated repos/nongnu
* [`456374df`](https://github.com/nix-community/emacs-overlay/commit/456374df242902ba4a749260f218d0e4fa646bc7) Updated repos/melpa
* [`bf07a8a5`](https://github.com/nix-community/emacs-overlay/commit/bf07a8a5c05e4323b4d5628968bc76bb7face009) Updated repos/elpa
* [`47798c4a`](https://github.com/nix-community/emacs-overlay/commit/47798c4ab07d5f055bb2625010cf6d8e3f384923) Updated repos/melpa
* [`e27b8ee6`](https://github.com/nix-community/emacs-overlay/commit/e27b8ee6ec4a7886b7f1960736dc1c97f607146f) repos: fix tests
* [`e7f1d35a`](https://github.com/nix-community/emacs-overlay/commit/e7f1d35ad19df15a8facab256d75617c7b022086) .github: Execute updates in a matrix
* [`541a166c`](https://github.com/nix-community/emacs-overlay/commit/541a166cfb1fa8f2c1ea397e1a1f8cb3989e3f3b) .github: Remove flake input update from repo update matrix
* [`9893e2a6`](https://github.com/nix-community/emacs-overlay/commit/9893e2a61442d7bbe8a46755c62385ff0bcd9cd5) Updated flake inputs
* [`8ff52408`](https://github.com/nix-community/emacs-overlay/commit/8ff5240882365441f5fe54d2f89104bb23b6160c) update: fixup repos for git diff
* [`b7b1eb0a`](https://github.com/nix-community/emacs-overlay/commit/b7b1eb0a0a09728f9a4762b217028039635f38db) Revert "repos: fix tests"
* [`b99616e7`](https://github.com/nix-community/emacs-overlay/commit/b99616e7c7e16b1ae002cc5e59554bf5982a3710) update: fixup repos
* [`1b650fad`](https://github.com/nix-community/emacs-overlay/commit/1b650fad0b5f88c337b733640887be737e98bf04) Updated nongnu
* [`5e0a5419`](https://github.com/nix-community/emacs-overlay/commit/5e0a54199dc27917676036c5ae5f57c24d16b651) Updated elpa
* [`4e6ae198`](https://github.com/nix-community/emacs-overlay/commit/4e6ae19845aa817da2180dfc6255493e48766bc3) repos/emacs: Only instantiate derivations on update, dont build
* [`3ef6bde7`](https://github.com/nix-community/emacs-overlay/commit/3ef6bde7aa16dbae70c9c9010801abf0d785b1d2) repos/emacs: And also remove no-out-link
* [`561c5343`](https://github.com/nix-community/emacs-overlay/commit/561c5343ce83d4b37c7c29d8d989884a8e584113) Updated emacs
* [`20e3f5a3`](https://github.com/nix-community/emacs-overlay/commit/20e3f5a3c65d2d3a5adda15359c429958b41f73e) Updated emacs
* [`1d5a4b9d`](https://github.com/nix-community/emacs-overlay/commit/1d5a4b9d76843020600c204620440d919249d0fb) Update bytecomp-revert.patch
* [`9e5d9f80`](https://github.com/nix-community/emacs-overlay/commit/9e5d9f807ad49485bcbfddbb6672e72891bae079) fixup! Update bytecomp-revert.patch
* [`c0ef7074`](https://github.com/nix-community/emacs-overlay/commit/c0ef7074c168adcb5f4038d9848eaedaeb5a27bc) Temporarily disable "emacs" update
* [`f0ae3cf0`](https://github.com/nix-community/emacs-overlay/commit/f0ae3cf0dd629934f66b83c05269ea3b5685ebf7) Revert "Updated emacs"
* [`53918e94`](https://github.com/nix-community/emacs-overlay/commit/53918e94a1f0ea236f96a4e566c0544a0174593c) Revert "Updated emacs"
* [`dbd5468d`](https://github.com/nix-community/emacs-overlay/commit/dbd5468d4387c66a94e07170d1373ab76dcc9ab3) Revert "fixup! Update bytecomp-revert.patch"
* [`0dfd7c9b`](https://github.com/nix-community/emacs-overlay/commit/0dfd7c9bdd4323a805781e0bdf6bcae7251742a3) Revert "Update bytecomp-revert.patch"
* [`1683e36d`](https://github.com/nix-community/emacs-overlay/commit/1683e36d107e35e1786126fa64cfbe41e8b4e572) Updated nongnu
* [`d1755a1b`](https://github.com/nix-community/emacs-overlay/commit/d1755a1bc7482123a229cef72b526944f6085891) Updated elpa
* [`bfe818bd`](https://github.com/nix-community/emacs-overlay/commit/bfe818bd2936828a3669df3afb21707b09d99cd9) Updated flake inputs
* [`28c6b621`](https://github.com/nix-community/emacs-overlay/commit/28c6b6217ef2b5346ad4fb08365cdb6e116e521a) Updated elpa
* [`a7464ad5`](https://github.com/nix-community/emacs-overlay/commit/a7464ad5b068547d0a86048e544283e3261ce756) Updated elpa
* [`8f17c8c7`](https://github.com/nix-community/emacs-overlay/commit/8f17c8c7d793cde1b0b58a26c754690cbd683004) Updated flake inputs
* [`7340210b`](https://github.com/nix-community/emacs-overlay/commit/7340210bf9a1af035e2456fd4a5acc930fc45872) Updated nongnu
* [`1c1dd489`](https://github.com/nix-community/emacs-overlay/commit/1c1dd489e1c6c6a895a1648b540b9c4ee8cd0aa6) Updated elpa
* [`d69ed241`](https://github.com/nix-community/emacs-overlay/commit/d69ed24198fbb8fc49deb92c727d1efc662b700f) Updated nongnu
* [`9147a422`](https://github.com/nix-community/emacs-overlay/commit/9147a4227e3db2c461dac05f9e0e7c586f852fb9) Updated elpa
* [`cf14f3f6`](https://github.com/nix-community/emacs-overlay/commit/cf14f3f673227631fda56daf01d87e983da76efb) Updated elpa
* [`c84fbd9b`](https://github.com/nix-community/emacs-overlay/commit/c84fbd9be553628e6295efb1cdb8c9d261e5bdff) Updated elpa
* [`995ac3a4`](https://github.com/nix-community/emacs-overlay/commit/995ac3a4535431f4236df0e7e0b1c0f669cdb02d) Updated flake inputs
* [`d72b6439`](https://github.com/nix-community/emacs-overlay/commit/d72b6439873ce66a1183d1b28e00a173e8a63ed7) Updated elpa
* [`5cd18705`](https://github.com/nix-community/emacs-overlay/commit/5cd18705d47b49e35f760a83fdc33dc6e1e3f757) Updated elpa
* [`12a5452d`](https://github.com/nix-community/emacs-overlay/commit/12a5452d0edc6cb0e11391c069aef5538ebed31c) Update nixpkgs-stable to 23.11
* [`71ccac2c`](https://github.com/nix-community/emacs-overlay/commit/71ccac2c15e3cef22b64de400df51132dbd45fd7) Update github action version
* [`5205fb0c`](https://github.com/nix-community/emacs-overlay/commit/5205fb0c0ac5dfdb3f468b7581cd4fd4e289a4d9) Updated elpa
* [`ceea404c`](https://github.com/nix-community/emacs-overlay/commit/ceea404cfe880edf745928fe93d7c39172dfce10) Updated flake inputs
* [`a99d70ad`](https://github.com/nix-community/emacs-overlay/commit/a99d70addcc094dfb2c93d74073850c11c0b5a7f) Updated elpa
* [`86bc6834`](https://github.com/nix-community/emacs-overlay/commit/86bc6834b2e1adffca92c6faf0431c1a453cb73f) Updated nongnu
* [`e9e995a2`](https://github.com/nix-community/emacs-overlay/commit/e9e995a2f582217b7c4efe38415fafbbc06274d2) Updated elpa
* [`285a626f`](https://github.com/nix-community/emacs-overlay/commit/285a626fe34c40d6f3e3f63f69f4ceb0cfc29e80) Updated elpa
* [`abc8913c`](https://github.com/nix-community/emacs-overlay/commit/abc8913c8eb39cca83df7a878195f284af88e3ee) Updated flake inputs
* [`dbf41b39`](https://github.com/nix-community/emacs-overlay/commit/dbf41b3900117bb836118f7d3144bae6878a1c5e) Updated elpa
* [`fae6a53b`](https://github.com/nix-community/emacs-overlay/commit/fae6a53b30177995da0262a1b539898c48071f4b) Updated elpa
* [`3aa0c5fc`](https://github.com/nix-community/emacs-overlay/commit/3aa0c5fc7e1960258e5894fab855b8d7dc7809bb) Updated flake inputs
* [`e8ccf1b1`](https://github.com/nix-community/emacs-overlay/commit/e8ccf1b1586e022c8d5ac8667ae78c475f328061) Updated nongnu
* [`3eaaeef7`](https://github.com/nix-community/emacs-overlay/commit/3eaaeef710b852dc55ef09b85cc438ca8c7f58b8) Updated elpa
* [`75d58280`](https://github.com/nix-community/emacs-overlay/commit/75d582804c561bb16f726916096ee22272d156cc) Updated elpa
