### PR TITLE
niv doomemacs: update 29b19412 -> 03d692f1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "29b19412f6dcc36cf64a55c339f9a723fc0de3bc",
-        "sha256": "1nv3n8g5fgqsw4mfvlczw1svn8wd05i2f2hrqx9p4mi5m0g7qc5f",
+        "rev": "03d692f129633e3bf0bd100d91b3ebf3f77db6d1",
+        "sha256": "0p6f481237ddiib8lxvl5qndyfhz9ribxwzz6ns0n6lkzzlh7m1x",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/29b19412f6dcc36cf64a55c339f9a723fc0de3bc.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/03d692f129633e3bf0bd100d91b3ebf3f77db6d1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@29b19412...03d692f1](https://github.com/doomemacs/doomemacs/compare/29b19412f6dcc36cf64a55c339f9a723fc0de3bc...03d692f129633e3bf0bd100d91b3ebf3f77db6d1)

* [`a89d4b7d`](https://github.com/doomemacs/doomemacs/commit/a89d4b7df556bb8b309d1c23e0b60404e750f156) tweak(default): add binding for undo-tree
* [`c7ddbe04`](https://github.com/doomemacs/doomemacs/commit/c7ddbe049f2d4f36f808b9113f5ca80a5892e54f) fix(swift): set-eglot-client!: extra argument
* [`f8274f20`](https://github.com/doomemacs/doomemacs/commit/f8274f208c3f60a9407a8d432be137748d97134d) bump: :lang org
* [`0d8479ae`](https://github.com/doomemacs/doomemacs/commit/0d8479ae9bc736a0cb2465eab16dae7c449d84de) tweak: emit feedback when started in daemon mode
* [`b1d8d1cd`](https://github.com/doomemacs/doomemacs/commit/b1d8d1cd9f4a2245329330cd92c04cf8f9e41472) nit: reformatting, comment, and markup revision
* [`5b9da18b`](https://github.com/doomemacs/doomemacs/commit/5b9da18bc10cff72026e63552cd5241a806d676d) fix(csharp): enable lsp in csharp-tree-sitter-mode
* [`36d18d6d`](https://github.com/doomemacs/doomemacs/commit/36d18d6da59f3b5acd5fa36e9a24724bd7c03f11) fix(cc): enable lsp in cuda-mode
* [`4d072ce8`](https://github.com/doomemacs/doomemacs/commit/4d072ce888577b023774460f6036abefcd0a1fa6) release(modules): 23.12.0-dev
* [`abd29569`](https://github.com/doomemacs/doomemacs/commit/abd29569a6b78515599c2133fcb06da3e06bee14) bump: :lang nim
* [`f6851d56`](https://github.com/doomemacs/doomemacs/commit/f6851d56ef6baa5e7de8a1b2adea8c7a80f8f0fe) fix(org): correct face for doom-user links
* [`03d692f1`](https://github.com/doomemacs/doomemacs/commit/03d692f129633e3bf0bd100d91b3ebf3f77db6d1) fix(vertico): embark open in new workspace action
