### PR TITLE
niv nixpkgs: update 589aab59 -> 191b2e79

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "589aab59f1e2d1916fd601603d79414b3ce9129c",
-        "sha256": "1jwyg80jf674kiyj6f2lai8xwjb46nia0vpjfmq84hh9r4336fp2",
+        "rev": "191b2e79a58fe7e6d622b7d14d1edf0752461d82",
+        "sha256": "16rcvwgca0ivrk3d6x80ln537jpb3vpg9s9nwk0ji4y72pg71dwd",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/589aab59f1e2d1916fd601603d79414b3ce9129c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/191b2e79a58fe7e6d622b7d14d1edf0752461d82.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@589aab59...191b2e79](https://github.com/nixos/nixpkgs/compare/589aab59f1e2d1916fd601603d79414b3ce9129c...191b2e79a58fe7e6d622b7d14d1edf0752461d82)

* [`a2f10d63`](https://github.com/NixOS/nixpkgs/commit/a2f10d636612a816eb4218baf8ece3cdcd828b68) beetsPackages.copyartifacts: unstable-2020-02-15 -> 0.1.5
* [`7c9a7925`](https://github.com/NixOS/nixpkgs/commit/7c9a7925b9674a05d0d4279eadf8123e615f8836) thermald: allow ignoring cpuid check
* [`2e6f50cf`](https://github.com/NixOS/nixpkgs/commit/2e6f50cf31e6108cdd6293af4bf0d251e109edcc) nixos/no-x-libs: add intel-vaapi-driver
* [`142d83f9`](https://github.com/NixOS/nixpkgs/commit/142d83f90e2903c92a78c8f4fa84a87fe37a0409) nixos/postfix: postalias should not use source file permissions
* [`0c50d6ec`](https://github.com/NixOS/nixpkgs/commit/0c50d6ec922c081dd65067e9af7c71ac5161ecd7) nginxModules.{lua,lua-upstream}: switch to luajit_openresty
* [`c172a8d4`](https://github.com/NixOS/nixpkgs/commit/c172a8d4adde101cecc078180b20ab86c5bfa52c) g4music: 3.3 -> 3.4-1
* [`47258b38`](https://github.com/NixOS/nixpkgs/commit/47258b38e3837b304987bc77a509b9ed3ee104b4) door-knocker: init at 0.4.1
* [`3743b24b`](https://github.com/NixOS/nixpkgs/commit/3743b24bf93ac75d94cdc2d0402d401ab4a6bb5e) vkdt: 0.6.0 -> 0.7.0
* [`ff61f2bb`](https://github.com/NixOS/nixpkgs/commit/ff61f2bb3ff587df1a81c54f0f1b31bce46eec01) gnome.gdm: Simplify DESTDIR hack
* [`8ef5fcf4`](https://github.com/NixOS/nixpkgs/commit/8ef5fcf4f5aa1a862a6787ea765e5bec8c5eb648) upower: Simplify DESTDIR hack
* [`646da4a9`](https://github.com/NixOS/nixpkgs/commit/646da4a9152697bd66e937265ef2c2a5cd402771) winhelpcgi: remove override libpng
* [`35248080`](https://github.com/NixOS/nixpkgs/commit/35248080ac286b31d0df8efd997e4dc1c751848a) ticktick: 1.0.80 -> 2.0.0
* [`75c4637f`](https://github.com/NixOS/nixpkgs/commit/75c4637ffb9165351f86ca1ee419b3b08aa7e622) contrast: 0.0.8 -> 0.0.10
* [`e5be54d1`](https://github.com/NixOS/nixpkgs/commit/e5be54d129670cd46863b9e657a6f8cecd7df6d2) cargo-public-api: 0.32.0 -> 0.33.0
* [`5cdd0b9a`](https://github.com/NixOS/nixpkgs/commit/5cdd0b9a38b8463d8210dbe092f6b5a7b1af8456) cargo-public-api: 0.33.0 -> 0.33.1
* [`1d19b2cb`](https://github.com/NixOS/nixpkgs/commit/1d19b2cb78d9a2d1bff3b9b1c2a9aa719c5cc376) openssl_3_2: init at 3.2.0
* [`9de58c34`](https://github.com/NixOS/nixpkgs/commit/9de58c34dc5a579598f7908a0504d11a355d5918) openssl_3_1: remove and explicitely state versioning
* [`28bb9781`](https://github.com/NixOS/nixpkgs/commit/28bb97817f2b8d0581dfcc513273e0dc04b6b0a1) nixos/swap: ensure correct ordering w.r.t. shutdown.target
* [`454f3cb5`](https://github.com/NixOS/nixpkgs/commit/454f3cb58d2ea69cfc2cda071c760e34aaa59813) nixos/apparmor: ensure correct ordering w.r.t. shutdown.target
* [`407ef672`](https://github.com/NixOS/nixpkgs/commit/407ef67228d2a1206e40a6978e5cb8a41ebb290f) nixos/auditd: ensure correct ordering w.r.t. shutdown.target
* [`d7ab46ed`](https://github.com/NixOS/nixpkgs/commit/d7ab46ed87ca8385e80ddff6138145baeacf033f) nixos/duosec: ensure correct ordering w.r.t. shutdown.target
* [`a7a5b2ec`](https://github.com/NixOS/nixpkgs/commit/a7a5b2eca1054166a60ac366d90da701e57b9138) nixos/suid-sgid-wrappers: ensure correct ordering w.r.t. shutdown.target
* [`5ab8a128`](https://github.com/NixOS/nixpkgs/commit/5ab8a128deb592b1c509b45e9a8b68442f9b262e) nixos/firewall-iptables: ensure correct ordering w.r.t. shutdown.target
* [`e4136ed6`](https://github.com/NixOS/nixpkgs/commit/e4136ed6dd7612043a62aea89eeb3c4f3ea549e5) nixos/growpart: ensure correct ordering w.r.t. shutdown.target
* [`0db4d5b3`](https://github.com/NixOS/nixpkgs/commit/0db4d5b3356d30519b6e51e76cf4872a7dffa3be) nixos/initrd-ssh: ensure correct ordering w.r.t. shutdown.target
* [`1f73c2a7`](https://github.com/NixOS/nixpkgs/commit/1f73c2a7b635442339505ac67a587b71c3748af7) nixos/initrd-secrets: ensure correct ordering w.r.t. shutdown.target
* [`9c505de9`](https://github.com/NixOS/nixpkgs/commit/9c505de9f4fddb0a13831682450445d9d59f0fd0) nixos/filesystems: ensure correct ordering w.r.t. shutdown.target
* [`d4f57da9`](https://github.com/NixOS/nixpkgs/commit/d4f57da9e85edc9d9fb00ce0b7f0906b78762659) nixos/bcachefs: ensure correct ordering w.r.t. shutdown.target
* [`e95b3d39`](https://github.com/NixOS/nixpkgs/commit/e95b3d3915161f7bfd03d04b755fd0bf744363a1) nixos/zfs: ensure correct ordering w.r.t. shutdown.target
* [`54064109`](https://github.com/NixOS/nixpkgs/commit/54064109fb09d69cba69e220b69a7f87d3515818) nixos/network-interfaces: ensure correct ordering w.r.t. shutdown.target
* [`07004b46`](https://github.com/NixOS/nixpkgs/commit/07004b46acc1c6de0bbe6f624aa8a724089bca03) nixos/lxd-agent: ensure correct ordering w.r.t. shutdown.target
* [`0a226a06`](https://github.com/NixOS/nixpkgs/commit/0a226a0639f07ce59087850a9036df1cf20e8aac) nixos/qemu: ensure correct ordering w.r.t. shutdown.target
* [`d8c9b26a`](https://github.com/NixOS/nixpkgs/commit/d8c9b26a16086d5e900a7c7a8577837860fc973f) nixos/tests/dhparams: ensure correct ordering w.r.t. shutdown.target
* [`88dc5ded`](https://github.com/NixOS/nixpkgs/commit/88dc5ded81a6ef0ab32920e78801ba1d68879863) nixos/tests/stunnel: ensure correct ordering w.r.t. shutdown.target
* [`6f809115`](https://github.com/NixOS/nixpkgs/commit/6f8091159ecec673fcafea1215ba190a86c99ebd) nixos/tests/systemd-initrd-networkd: ensure correct ordering w.r.t. shutdown.target
* [`25013e90`](https://github.com/NixOS/nixpkgs/commit/25013e907a4d8db63d624ca6977b41c3d0656f5b) ytmdl: 2023.07.27 -> 2023.11.26
* [`b4e8d24d`](https://github.com/NixOS/nixpkgs/commit/b4e8d24d24b94b73f20d56a06b20e1a92db01ad7) opendht: 2.5.5 -> 3.1.4
* [`1a3c37c9`](https://github.com/NixOS/nixpkgs/commit/1a3c37c91aa8e394dd33c8a5ecad3789f9dd9819) jami: 20230619.1 -> 20231201.0
* [`1a242ec2`](https://github.com/NixOS/nixpkgs/commit/1a242ec25d07c9e3b18e96dc0bdfb6c166beff26) darktile: 0.0.10 -> 0.0.11
* [`801ecec7`](https://github.com/NixOS/nixpkgs/commit/801ecec7851effd8dbfc881cc2f7e506b8058b1f) nixos/no-x-libs: add ghostscript
* [`c351a84e`](https://github.com/NixOS/nixpkgs/commit/c351a84eec83a57643e490c34cb8cb61e1341f53) nixos/tests/installer: test /boot on ZFS
* [`3e57c2e2`](https://github.com/NixOS/nixpkgs/commit/3e57c2e2ba954283f1ea0bde45e871410e42d111) gamemode: prefer finalAttrs over rec
* [`56669c8f`](https://github.com/NixOS/nixpkgs/commit/56669c8f5b3ce03381c23bd6682f3ce533167a4b) gamemode: fetch src from refs/tags
* [`f5375ec9`](https://github.com/NixOS/nixpkgs/commit/f5375ec98618347da6b036a5e06381ab7380db03) bitcoin: 25.1 -> 26.0
* [`cd034f47`](https://github.com/NixOS/nixpkgs/commit/cd034f4711f8b164352a773d5c99589a026c290a) gamemode: add mainProgram
* [`d209e990`](https://github.com/NixOS/nixpkgs/commit/d209e9900cd8cdefd7890b8bd04aa3ced8fb2279) gamemode: add updateScript
* [`c4cf8445`](https://github.com/NixOS/nixpkgs/commit/c4cf8445669782d32fde1e6cd1cd0d51b2f81fb0) nixos/tests/ft2-clone: cleanup
* [`e75decf4`](https://github.com/NixOS/nixpkgs/commit/e75decf46b045e79e80eed06301fa74ac15c583c) gnome.gpaste: Fix typelib path adjustment
* [`90c3e121`](https://github.com/NixOS/nixpkgs/commit/90c3e1212c91a74bae73567a43a83e0e56a5b669) hercules: 3.13 -> 4.6
* [`a9d02214`](https://github.com/NixOS/nixpkgs/commit/a9d02214b0991bd50aacd59c2e6758fb23af973a) pmbootstrap: 2.0.0 -> 2.1.0
* [`c9793c8a`](https://github.com/NixOS/nixpkgs/commit/c9793c8ae09afdf61f733d0aadc3404487632fc6) ipp-usb: 0.9.23 -> 0.9.24
* [`303c78a6`](https://github.com/NixOS/nixpkgs/commit/303c78a655ebcd54daa9e620d7fa8fdeebfaff99) freshrss: cleanup + runHook
* [`6290195a`](https://github.com/NixOS/nixpkgs/commit/6290195a26e1e7e0d13d51df3fb8baeba4152845) maintainers: add david-r-cox
* [`95375273`](https://github.com/NixOS/nixpkgs/commit/953752738923f68b041e0630b048c37ee9ffef8d) nixos/installation-device: remove warning about mdadm
* [`c57a4037`](https://github.com/NixOS/nixpkgs/commit/c57a4037f5d2a27de8ef9fde4006df7828a21d90) nixos/thanos: Changed query.replica-labels to a list parameter.
* [`bf8db64d`](https://github.com/NixOS/nixpkgs/commit/bf8db64ddb159a9867182a8e1bd61aff88fc6b57) lzsa: init at 1.4.1
* [`5f0c17ed`](https://github.com/NixOS/nixpkgs/commit/5f0c17edea433b360b76bb425d21f0157a8a61aa) x16: move from commanderx16
* [`fd6fc06e`](https://github.com/NixOS/nixpkgs/commit/fd6fc06eb9107c9dc6f80d0da3a4d4d19f7fd5a5) x16.rom: 44 -> 45
* [`61bd5e07`](https://github.com/NixOS/nixpkgs/commit/61bd5e07615fec93037ae254d41326ffcb082f3d) x16.emulator: 44 -> 45
* [`7d416c7e`](https://github.com/NixOS/nixpkgs/commit/7d416c7e15ff6204541c02ce1a9b884417c8abc7) x16.rom: 45 -> 46
* [`82529fe5`](https://github.com/NixOS/nixpkgs/commit/82529fe5ecaba9291163e80b7e71836a3d562169) x16.emulator: 45 -> 46
* [`572300c9`](https://github.com/NixOS/nixpkgs/commit/572300c97fd03daf74be77c73b7e61900dc3d670) vieb: 10.6.0 -> 11.0.0
* [`084df790`](https://github.com/NixOS/nixpkgs/commit/084df790dec9e31740a7747b9b9f39ac539bfa63) appdaemon: 4.2.1 -> 4.4.2
* [`ef92ea83`](https://github.com/NixOS/nixpkgs/commit/ef92ea831ecf13551db5c73a5973ba60e768c82c) cemu: 2.0-59 -> 2.0-61
* [`3bff45aa`](https://github.com/NixOS/nixpkgs/commit/3bff45aac60acab116d35195aa9f53390bf401a1) darktile: add aarch64-linux to badPlatforms
* [`2562649f`](https://github.com/NixOS/nixpkgs/commit/2562649f2b5dd4e4f20f02a63e4e401dccd8bfbe) cargo-typify: init at 0.0.14
* [`1e0120f8`](https://github.com/NixOS/nixpkgs/commit/1e0120f86385ffba40b07a9d8b45b648563cdd68) mpvScripts.mpv-playlistmanager: unstable-2023-08-09 → unstable-2023-11-28
* [`13c8727a`](https://github.com/NixOS/nixpkgs/commit/13c8727ad89482fb0d0bf02eb43e00c19dc6aa96) raspberrypi-eeprom: migrate to by-name
* [`7e8102be`](https://github.com/NixOS/nixpkgs/commit/7e8102be932defe23e6fde641bbd93729c667f83) raspberrypi-eeprom: cleanup
* [`9845925e`](https://github.com/NixOS/nixpkgs/commit/9845925e52bbace8658f39e5fb692960224b11b7) raspberrypi-eeprom: 2023.10.30-2712 -> 2023.12.06-2712
* [`a4dd202b`](https://github.com/NixOS/nixpkgs/commit/a4dd202be53cc59a43d46561f00ebc5203428a0a) mpvScripts.buildLua: don't remove `.lua` from `scriptName` when installing a directory
* [`ffd4482a`](https://github.com/NixOS/nixpkgs/commit/ffd4482a7dd54e66a4d14190c56db61edad3c9a9) mpvScripts.simple-mpv-webui: Drop superfluous `.lua` suffix in `scriptName`
* [`1c14a76c`](https://github.com/NixOS/nixpkgs/commit/1c14a76c0c2969bf279cf00853c067791bc80562) airwindows-lv2: 26.0 -> 26.2
* [`b2d6b306`](https://github.com/NixOS/nixpkgs/commit/b2d6b30648e2c51d869f085e819cbae950d6d19d) update oomd.nix
* [`679a417a`](https://github.com/NixOS/nixpkgs/commit/679a417a7a0c5df4a3206a19a0867adc0fa4099b) Declare removed option with `mkRemovedOptionModule`
* [`a70fb29f`](https://github.com/NixOS/nixpkgs/commit/a70fb29f4e8cae3b011981c79b2f9a793e753225) joplin-desktop: 2.12.18 -> 2.13.9
* [`9acfeb00`](https://github.com/NixOS/nixpkgs/commit/9acfeb00f1959e2cddac9638910bc66e8ddb9997) cargo-clone: 1.1.0 -> 1.2.1
* [`5e57448d`](https://github.com/NixOS/nixpkgs/commit/5e57448d4fc2d791beb183dd71798a033f72da42) systemd/oomd: add release note for the backward incompatibility
* [`9ba5deb8`](https://github.com/NixOS/nixpkgs/commit/9ba5deb8ec0dd1aeb9c0b7f22a09badde33886a6) faustPhysicalModeling: 2.68.1 -> 2.69.3
* [`9fc5ce8e`](https://github.com/NixOS/nixpkgs/commit/9fc5ce8ec5f75705ae36cfac7739360367d0df29) python311Packages.fhir-py: init at 1.4.2
* [`935e3291`](https://github.com/NixOS/nixpkgs/commit/935e329186b687e55549f8387967aecee1bc3940) freetds: 1.4.8 -> 1.4.10
* [`bc589174`](https://github.com/NixOS/nixpkgs/commit/bc58917492c1acdcaa0cb761e770b0780a4dde4a) gi-crystal: 0.19.0 -> 0.21.0
* [`2fa0b853`](https://github.com/NixOS/nixpkgs/commit/2fa0b8539e0140c9feb95e0ea4336599c04feaf1) git-town: 10.0.1 -> 11.1.0
* [`cd6ccb17`](https://github.com/NixOS/nixpkgs/commit/cd6ccb17370dcc227f773050c765dff7f219e7f1) Revert "kea: use separate runtime directories for each service"
* [`9f6a0545`](https://github.com/NixOS/nixpkgs/commit/9f6a0545174e6c3635e6b41349af0de22a8312cc) nixos/kea: preserve shared runtime directory
* [`e8201d7a`](https://github.com/NixOS/nixpkgs/commit/e8201d7a0c76c377b5215c6517cbe47c87c58752) jna: 5.13.0 -> 5.14.0
* [`b249a3cc`](https://github.com/NixOS/nixpkgs/commit/b249a3cc72a9f6467b5e61a3f234b7ed5d20205a) cargo-make: 0.37.4 -> 0.37.5
* [`ade9d358`](https://github.com/NixOS/nixpkgs/commit/ade9d3588e00731796593228c7a19ac5b5b8c249) libcifpp: 5.2.4 -> 6.0.0
* [`ccbc56db`](https://github.com/NixOS/nixpkgs/commit/ccbc56db1376800059daafb40389fe212743da43) vcluster: 0.17.0 -> 0.18.1
* [`418296e3`](https://github.com/NixOS/nixpkgs/commit/418296e34e61d4f5bd7492d5988b5ab9da0875a5) jj: init at 1.9.2
* [`c1f435ac`](https://github.com/NixOS/nixpkgs/commit/c1f435acb5b9a50b1c1192eadede43bae7f55738) renoise: 3.3.2 → 3.4.3
* [`186d8ebd`](https://github.com/NixOS/nixpkgs/commit/186d8ebd538315aea4e86549089a237cc78c25f4) maintainers: update uakci
* [`21c2941c`](https://github.com/NixOS/nixpkgs/commit/21c2941cf4704ee94d34db142e9cf21a63ace406) mockoon: 5.1.0 -> 6.0.1
* [`300ce37c`](https://github.com/NixOS/nixpkgs/commit/300ce37c0d294372b8c4ab129445b81554ca8a65) python311Packages.opensfm: unstable-2022-03-10 -> unstable-2023-12-09
* [`2e5276e6`](https://github.com/NixOS/nixpkgs/commit/2e5276e608d84311827a37c410110e5b1e3a00cf) python311Packages.opensfm: leave out the deprecated sphinx setuptools integration
* [`56066347`](https://github.com/NixOS/nixpkgs/commit/56066347c4561a3b261a59658f3b25daab68a063) python311Packages.opensfm: fix find_package(OpenCV) when opencv is built with cuda
* [`d6a94adf`](https://github.com/NixOS/nixpkgs/commit/d6a94adfc57e15c416846ec6e8367fc2c669c5ee) mox: 0.0.7 -> 0.0.8
* [`5e128184`](https://github.com/NixOS/nixpkgs/commit/5e1281845bb4a9618131d0b78eaeda3bd32a16b6) netmaker-full: 0.21.1 -> 0.21.2
* [`8222fa33`](https://github.com/NixOS/nixpkgs/commit/8222fa33b3388dc6d4cd4acd71d4ee17a1b56c78) hyprlandPlugins.hy3: init at 0.32.0
* [`b1364d16`](https://github.com/NixOS/nixpkgs/commit/b1364d161db96a194afa651d0030cf6aae0d9b24) package-project-cmake: 1.11.0 -> 1.11.1
* [`45e93e8d`](https://github.com/NixOS/nixpkgs/commit/45e93e8db0da8d84685b57da831aef409977c877) maintainers: add jankaifer
* [`792e0c21`](https://github.com/NixOS/nixpkgs/commit/792e0c2100a92b0a608fd402e1fa54548e370b60) podofo010: 0.10.2 -> 0.10.3
* [`8fe8a225`](https://github.com/NixOS/nixpkgs/commit/8fe8a22578c8591f5b8756439910e655da6c4615) nixos/munge: ask for network-online instead of network.target
* [`b29d689e`](https://github.com/NixOS/nixpkgs/commit/b29d689e3ad8f69703fb48ff68b5d0a7366ffb5c) nixos/munge: ask for the optional time-sync.target
* [`515a26d9`](https://github.com/NixOS/nixpkgs/commit/515a26d9972435834e2d8eaf1746b3a0bfc6c716) nixos/munge: run in foreground instead of using pidfile
* [`b27c3e82`](https://github.com/NixOS/nixpkgs/commit/b27c3e8252a3890224a168af167ecebc56298d5f) nixos/munge: restart "on-failure" (the default was "no")
* [`877de20d`](https://github.com/NixOS/nixpkgs/commit/877de20d9264218325340119980a19028a258147) jiten: cherry-pick test fix from upstream
* [`c45fb30b`](https://github.com/NixOS/nixpkgs/commit/c45fb30b2fc38c34df80e0517e49681e33db3015) python310Packages.aioguardian: 2023.11.0 -> 2023.12.0
* [`2148d300`](https://github.com/NixOS/nixpkgs/commit/2148d30045143b245cf1378c13f99f1006982874) python310Packages.django-filter: 23.4 -> 23.5
* [`2a747794`](https://github.com/NixOS/nixpkgs/commit/2a747794f4125affcf58244326764edbb955cb62) legba: 0.6.1 -> 0.7.1
* [`d5f7b820`](https://github.com/NixOS/nixpkgs/commit/d5f7b82092e276e67ca756a2df9e80fc9cb9ace2) maintainers: add br337
* [`29cf4af1`](https://github.com/NixOS/nixpkgs/commit/29cf4af1d58e2fb38840f60d51b930bea7a82cf6) spacedrive: add darwin
* [`f61302d5`](https://github.com/NixOS/nixpkgs/commit/f61302d5e3ff08eee47e595c5996ef61aac7b203) ferretdb: 1.16.0 -> 1.17.0
* [`e8130ad5`](https://github.com/NixOS/nixpkgs/commit/e8130ad55e361930e1d1d349f4f7db10307a5496) ferretdb: buildGo121Module -> buildGoModule
* [`47244908`](https://github.com/NixOS/nixpkgs/commit/4724490830d7703e54f2c124fd26d0b3c9889a1b) python310Packages.flet: 0.15.0 -> 0.17.0
* [`0775a7f4`](https://github.com/NixOS/nixpkgs/commit/0775a7f46029ef10a76ff57d84a5b2b49244bd7e) python310Packages.flet-core: 0.15.0 -> 0.17.0
* [`00225acf`](https://github.com/NixOS/nixpkgs/commit/00225acf818da04aa8c883280af99fca97f3985f) python310Packages.flet-runtime: 0.15.0 -> 0.17.0
* [`57358cd3`](https://github.com/NixOS/nixpkgs/commit/57358cd35aa9ac9c94040ad09c4f04a246a24e70) gitmoji-cli: install package.json
* [`0b087331`](https://github.com/NixOS/nixpkgs/commit/0b087331d123e315548a0d0dd83c0c5784e62040) gitmoji-cli: add version test
* [`b39cd260`](https://github.com/NixOS/nixpkgs/commit/b39cd260dd9c0be8e00dc52286e513c2478fba54) libck: cross-compilation fix
* [`d62b99af`](https://github.com/NixOS/nixpkgs/commit/d62b99afbb23934cff814bca1f38c50a2b1f8929) Revert "python3Packages.dynalite-devices: 0.1.48 -> 0.47"
* [`782978b7`](https://github.com/NixOS/nixpkgs/commit/782978b7fe13c7d66e0980d2d192de2527c55557) python311Packages.dynalite-panel: init at 0.0.4
* [`5517efe8`](https://github.com/NixOS/nixpkgs/commit/5517efe88531b804af960887b71de1c044484109) home-assistant: support dynalite component
* [`4af13554`](https://github.com/NixOS/nixpkgs/commit/4af13554542ef24b20acb3a023c3f7a34f845cff) sysbench: fix cross-compilation
* [`6fcb715f`](https://github.com/NixOS/nixpkgs/commit/6fcb715fa384ea917fda04ae47ec70be7ec904c3) cntr: 1.5.1 -> 1.5.2
* [`b297165e`](https://github.com/NixOS/nixpkgs/commit/b297165efde4b22f292fbc9ca39bd85eb471d1a7) cvc5: 1.0.8 -> 1.0.9
* [`31659d0b`](https://github.com/NixOS/nixpkgs/commit/31659d0b93547aa5cb2a818f450260f96bb55bb2) changedetection-io: 0.45.8.1 -> 0.45.9
* [`c37b5ac2`](https://github.com/NixOS/nixpkgs/commit/c37b5ac20740589a7e6b8bef9362fc9a4090c558) ssh-audit: 3.0.0 -> 3.1.0
* [`f2f89b35`](https://github.com/NixOS/nixpkgs/commit/f2f89b35058065fffcd5c6afd30606add4d37ba4) python310Packages.optimum: 1.14.1 -> 1.16.1
* [`d3e246f9`](https://github.com/NixOS/nixpkgs/commit/d3e246f9fa217545eb7dc957cc7bd0d820040d3c) nixos/guix: fix systemd socket unit
* [`1e211406`](https://github.com/NixOS/nixpkgs/commit/1e211406222fb92f1c7ffeee5cd98b03bf8fd660) ssb: remove
* [`74a4a70d`](https://github.com/NixOS/nixpkgs/commit/74a4a70d8e68957c4ab11545c8e81401153f3219) incus-unwrapped: 0.3.0 -> 0.4.0
* [`557bd745`](https://github.com/NixOS/nixpkgs/commit/557bd745bc6742e0f42700805c46c6d8233024ab) lxd-to-incus: 0.3.0 -> 0.4.0
* [`920f39c1`](https://github.com/NixOS/nixpkgs/commit/920f39c1c0fe7bf2df63bd8a1477c8d97ed36e84) lenovo-legion: fix desktop icons
* [`56e9ca19`](https://github.com/NixOS/nixpkgs/commit/56e9ca19b3f8f353c374c662fa909db86eea925c) lxcfs: 4.0.12 -> 5.0.4
* [`e028a52d`](https://github.com/NixOS/nixpkgs/commit/e028a52d6f26cc2b9aad598fd941717b1b2b125c) php81: 8.1.26 -> 8.1.27
* [`9d236a8a`](https://github.com/NixOS/nixpkgs/commit/9d236a8acee7227c25574b7bc8ee6c7f4cf50347) php82: 8.2.13 -> 8.2.14
* [`f6b24b3b`](https://github.com/NixOS/nixpkgs/commit/f6b24b3b68df2694baff0680da6b69c1f8443cbc) nlohmann_json_schema_validator: init at 2.3.0
* [`90493f94`](https://github.com/NixOS/nixpkgs/commit/90493f9411fd2205823bfe5aec3ee35d48cc55ca) python310Packages.regenmaschine: 2023.11.0 -> 2023.12.0
* [`28a0891d`](https://github.com/NixOS/nixpkgs/commit/28a0891db74cdd2f5ddc8829d88084609797a056)  clipqr: 1.1.0 -> 1.2.0
* [`91df2cb6`](https://github.com/NixOS/nixpkgs/commit/91df2cb6dc58a5c99e9e1c10dfe96eadfb92743b) livekit: 1.5.1 -> 1.5.2
* [`b706fece`](https://github.com/NixOS/nixpkgs/commit/b706fece012009a772b5f1720033df532a276360) tigerbeetle: init at 0.14.171
* [`317effb8`](https://github.com/NixOS/nixpkgs/commit/317effb80eace2d0192ca7637dfbda92bef2acb5) python310Packages.scmrepo: 1.5.0 -> 2.0.2
* [`f743f1db`](https://github.com/NixOS/nixpkgs/commit/f743f1dba967c308b24ede2d0a93b3b37b038d2e) python310Packages.simplisafe-python: 2023.10.0 -> 2023.12.0
* [`a7e7a9ae`](https://github.com/NixOS/nixpkgs/commit/a7e7a9ae1662710d6388609abafad1b7cccdaf71) hareThirdParty.hare-toml: init at 0.1.0
* [`ee3e7ac1`](https://github.com/NixOS/nixpkgs/commit/ee3e7ac1800f08c8cdab393be0c7428b8555f298) php83: 8.3.0 -> 8.3.1
* [`0438b1bb`](https://github.com/NixOS/nixpkgs/commit/0438b1bb65ca68f52b9eb9bb0e6a35e9613e30db) corrupter: init at 1.0
* [`03de4ec0`](https://github.com/NixOS/nixpkgs/commit/03de4ec04597fd47ddbb61962359bcef82b452a4) python310Packages.sqltrie: 0.9.0 -> 0.11.0
* [`c6c5bfbc`](https://github.com/NixOS/nixpkgs/commit/c6c5bfbcd6bf4fe98d2b7cf8163728f43e98f18d) python310Packages.svg2tikz: 2.1.0 -> 3.0.0
* [`60f5b2db`](https://github.com/NixOS/nixpkgs/commit/60f5b2dba43aec207dd0459783f3be5ef260bf64) python310Packages.temperusb: 1.6.0 -> 1.6.1
* [`10126c13`](https://github.com/NixOS/nixpkgs/commit/10126c13a44b9a42595cbdfd02485dabeecac072) python310Packages.types-ujson: 5.8.0.1 -> 5.9.0.0
* [`9eb4fc10`](https://github.com/NixOS/nixpkgs/commit/9eb4fc10ab9a1178e152c15ebaecafe26a0eccc5) git-quick-stats: 2.5.2 -> 2.5.3
* [`7d926d19`](https://github.com/NixOS/nixpkgs/commit/7d926d19d3d5259aa93e195c7018020e9e0c0b10) teams: Don't use root-level throw for unsupported platforms
* [`7f6b8976`](https://github.com/NixOS/nixpkgs/commit/7f6b89769ebed383ad5b6b3aea5da60aca3fbed3) gruvbox-plus-icons: Fix evaluation when allowAliases disabled
* [`12e32d6d`](https://github.com/NixOS/nixpkgs/commit/12e32d6dbba5e1b0a7c22c54a31ac684c0b3b4a5) dotnet-sdk: Don't add attributes when allowAliases disabled
* [`88142110`](https://github.com/NixOS/nixpkgs/commit/88142110d0750cc38841bcac0122de4f5e30e00d) wtk: Use meta.platforms to check for supported platform
* [`38ad4feb`](https://github.com/NixOS/nixpkgs/commit/38ad4feb1ea2817a4d88b99446a40a6a03e39ce3) gofumpt: Fix evaluation when allowAliases disabled
* [`1470c52c`](https://github.com/NixOS/nixpkgs/commit/1470c52c18d10107eb599e14ce61fc72140228b1) nextcloud25: Disable attributes when allowAliases disabled
* [`8bbbb78c`](https://github.com/NixOS/nixpkgs/commit/8bbbb78c9ad78dcbb506f673996f51e57ae39457) chia: Disable attributes if allowAliases disabled
* [`7c86ba50`](https://github.com/NixOS/nixpkgs/commit/7c86ba50c9bba39cd39adc5aacf9fac8b64f04bc) kdsingleapplication: 1.0.0 -> 1.1.0
* [`feb114f7`](https://github.com/NixOS/nixpkgs/commit/feb114f7f0f01295a99c108ed2d97cd0d152f41a) apacheHttpdPackages: Disable renamed/removed attributes when allowAliases disabled
* [`14b11885`](https://github.com/NixOS/nixpkgs/commit/14b118856b8a40493daf401a32de45f2e03fa8db) nix-repl: Disable attribute when allowAliases disabled
* [`21acf7c0`](https://github.com/NixOS/nixpkgs/commit/21acf7c055ab7750ea22b406a3ed07012f20baeb) freeswitch: 1.10.10 -> 1.10.11
* [`4a67cc2c`](https://github.com/NixOS/nixpkgs/commit/4a67cc2c36bd05516182f413da105299c03edc45) vscode-extensions.asvetliakov.vscode-neovim: 1.0.1 -> 1.5.0
* [`e5f58901`](https://github.com/NixOS/nixpkgs/commit/e5f58901b0e058c9f019798486c9f357daedaa3b) github-copilot-intellij-agent: 1.2.18.2908 -> 1.4.5.4049
* [`69899afa`](https://github.com/NixOS/nixpkgs/commit/69899afa52cf8bac0ba736347e50e8db3213e411) home-assistant-custom-lovelace-modules.mini-media-player: 1.16.6 -> 1.16.8
* [`2431c94d`](https://github.com/NixOS/nixpkgs/commit/2431c94db91de36dc464276a4f12b798c75bc946) evcc: 0.122.1 -> 0.123.0
* [`2b2c989c`](https://github.com/NixOS/nixpkgs/commit/2b2c989ce995dcd95b2def3cb7980ad6f8cf2b1a) python310Packages.virt-firmware: 23.10 -> 23.11
* [`7072750a`](https://github.com/NixOS/nixpkgs/commit/7072750af58e1c6fd94c1466762f7db9a49cf1ed) overskride: init at 0.5.6
* [`ff19ecca`](https://github.com/NixOS/nixpkgs/commit/ff19ecca713ecfeabbc53688582909dd9d96f33e) nixos/kanata: specify linux-dev as a list
* [`062e035c`](https://github.com/NixOS/nixpkgs/commit/062e035cc02350b74746fca85d686f828f0d2731) rqlite: 7.6.1 -> 8.13.2
* [`8f6fadd7`](https://github.com/NixOS/nixpkgs/commit/8f6fadd799f067148ac467a28a3722451b0267ea) glide-media-player: init at 0.6.1
* [`6fe2c0c9`](https://github.com/NixOS/nixpkgs/commit/6fe2c0c911e9fe2df25a9f58506b6db28ca172bb) rtx: 2023.12.18 -> 2023.12.35
* [`933b9510`](https://github.com/NixOS/nixpkgs/commit/933b95109bca233b7774357de80dbc0080bd891e) sameboy: 0.15.8 -> 0.16
* [`7b643730`](https://github.com/NixOS/nixpkgs/commit/7b6437303fa4022b10b7f1871903ac6c557432bb) scalingo: 1.29.1 -> 1.30.0
* [`aceb6713`](https://github.com/NixOS/nixpkgs/commit/aceb671300ddb6dc7f9baf7ab9e4b1dd761a4da6) glfw: add missing substitutions in wayland-minecraft edition
* [`2a3a04d2`](https://github.com/NixOS/nixpkgs/commit/2a3a04d22e2d8e99286cb6556464d5535c8f492f) mdk-sdk: init at 0.23.1
* [`0c90ac55`](https://github.com/NixOS/nixpkgs/commit/0c90ac55d14af608b00091f35fa22e62af6fb4fe) lomiri.hfd-service: Fix accountsservice interface linking
* [`7cd1467a`](https://github.com/NixOS/nixpkgs/commit/7cd1467a773782e350418d5948561470d58499ac) keymapp: init at 1.0.7
* [`2ed176b9`](https://github.com/NixOS/nixpkgs/commit/2ed176b99f80cf69c6c8ed80e65b814695563bbc) txtpbfmt: unstable-2023-03-28 -> unstable-2023-10-25
* [`31f611d2`](https://github.com/NixOS/nixpkgs/commit/31f611d22aa02e70988645c8856c10f490930eab) snappymail: 2.29.4 -> 2.31.0
* [`5802b1d0`](https://github.com/NixOS/nixpkgs/commit/5802b1d04df01eba1be34c6c580c553654a3a303) kubectx: 0.9.4 -> 0.9.5
* [`6f4d0b52`](https://github.com/NixOS/nixpkgs/commit/6f4d0b52611812854394cecfee8081823b105e5b) lib.types: Improve descriptions of composed types that have commas
* [`0894361f`](https://github.com/NixOS/nixpkgs/commit/0894361fa417e9f3055cfc4d9afcf00c5307310c) wordpressPackages.plugins.simple-mastodon-verification: init at 1.1.3
* [`1e09a54e`](https://github.com/NixOS/nixpkgs/commit/1e09a54e899b43fea266c45ea4b43f8dda01591e) pyprland: 1.6.0 -> 1.6.9
* [`1ab8b565`](https://github.com/NixOS/nixpkgs/commit/1ab8b565b5ed7337b8735656f7d92a57423b96f9) door-knocker: adopt
* [`8547ba30`](https://github.com/NixOS/nixpkgs/commit/8547ba30a26c8d3610939a143be2968dbe5d872c) door-knocker: 0.4.1 -> 0.4.2
* [`51e7c1d8`](https://github.com/NixOS/nixpkgs/commit/51e7c1d8f46a1bbe76dcecfd63f7713defa56768) spicedb: 1.26.0 -> 1.28.0
* [`9f62a2c0`](https://github.com/NixOS/nixpkgs/commit/9f62a2c0a0a79a896f3ba92581c05eb69418a9e7) fluxcd: 2.2.1 -> 2.2.2
* [`41ae0bfa`](https://github.com/NixOS/nixpkgs/commit/41ae0bfafe51bf5b48b0931ace3fb3d517b900f8) cagebreak: 2.2.1 -> 2.2.3
* [`d033bda2`](https://github.com/NixOS/nixpkgs/commit/d033bda2a5a593c48002eaa4d3dc258b3b98f0cd) django-mdeditor: init at 0.1.20
* [`2af0ee5b`](https://github.com/NixOS/nixpkgs/commit/2af0ee5b188844367714c4f62f1fef3bfabf06bf) ardour: 8.1 -> 8.2
* [`5037202b`](https://github.com/NixOS/nixpkgs/commit/5037202b688515d76e7d1149983438c4652315de) ipxe: Build snp.efi by default
* [`b6574f43`](https://github.com/NixOS/nixpkgs/commit/b6574f430d022bb0226f88d3e97b0b9ad3734cb9) python311Packages.aioskybell: 22.7.0 -> 23.12.0
* [`b9b3fe28`](https://github.com/NixOS/nixpkgs/commit/b9b3fe2818827950f5aa5c53da1ab54107c524ac) python311Packages.botocore-stubs: 1.34.2 -> 1.34.7
* [`fa5f38e1`](https://github.com/NixOS/nixpkgs/commit/fa5f38e14fb9bda49d179457812b0f0f97347dfd) python311Packages.hahomematic: 2023.11.4 -> 2023.12.4
* [`67d64071`](https://github.com/NixOS/nixpkgs/commit/67d640710092e0b0d9a6548873e67222344f0930) python311Packages.hachoir: 3.2.0 -> 3.3.0
* [`ee2d1ac6`](https://github.com/NixOS/nixpkgs/commit/ee2d1ac62bb1aac428d2cd7082f61e1924566216) trufflehog: 3.63.5 -> 3.63.7
* [`fa08b454`](https://github.com/NixOS/nixpkgs/commit/fa08b454a871887bf2021b0eb093c5138dbf045e) jazz2: 2.3.0 -> 2.4.0
* [`56e3155a`](https://github.com/NixOS/nixpkgs/commit/56e3155a0c9f59506b84c35a32ba5ddaf51482c9) python311Packages.botocore-stubs: 1.34.2 -> 1.34.7
* [`ff0f5bfb`](https://github.com/NixOS/nixpkgs/commit/ff0f5bfb902c7a75caa159028d884232f428146f) lomiri.history-service: init at 0.4
* [`0eaae22d`](https://github.com/NixOS/nixpkgs/commit/0eaae22d8440d03e8c8ab6714de674c94dc17236) lomiri.history-service: Fix pkg-config
* [`e8009e36`](https://github.com/NixOS/nixpkgs/commit/e8009e368821b08f7357ade698f264e4162b0fcd) lomiri.history-service: Fetch upstream-submitted patch
* [`220209b3`](https://github.com/NixOS/nixpkgs/commit/220209b3a9f65517652cc4e218f546be76b52e36) lomiri.history-service: Disable flaky test
* [`d7193bd0`](https://github.com/NixOS/nixpkgs/commit/d7193bd0f82ecfa3a98e402d0cd65aa4643d192b) lomiri.history-service: Fetch upstream-submitted patches, small cleanups
* [`54670895`](https://github.com/NixOS/nixpkgs/commit/54670895d39de400393807c0a710e8b2376221ff) drawterm: unstable-2023-09-03 -> unstable-2023-12-23
* [`f55dff34`](https://github.com/NixOS/nixpkgs/commit/f55dff344508dc1ec2b35bf826697cf480f1afe8) mypy-boto3: improve output
* [`e5ab70f4`](https://github.com/NixOS/nixpkgs/commit/e5ab70f4eea46d7580edfe8027797cb990e33312) vinegar: 1.5.9 -> 1.6.0
* [`83078b0c`](https://github.com/NixOS/nixpkgs/commit/83078b0c86cee197644a983deeedb5a08a6fb790) nwjs: 0.82.0 -> 0.83.0
* [`e70ceefa`](https://github.com/NixOS/nixpkgs/commit/e70ceefa64e5a6d05b6f911039261538d130d0aa) python310Packages.pyoutbreaksnearme: 2023.10.0 -> 2023.12.0
* [`953efa78`](https://github.com/NixOS/nixpkgs/commit/953efa78c8e35a4060866bb9983e3cab77250812) python311Packages.trimesh: 4.0.6 -> 4.0.8
* [`9343003c`](https://github.com/NixOS/nixpkgs/commit/9343003c0b7d9e7c3cd60fec6f096515917fe84b) postgresqlPackages.pg_repack: 1.4.8 -> 1.5.0
* [`0c27e026`](https://github.com/NixOS/nixpkgs/commit/0c27e026de6d0b92581745ebc92a2e0210ffeadf) mcfly: 0.8.1 -> 0.8.4
* [`42bb0d0d`](https://github.com/NixOS/nixpkgs/commit/42bb0d0d161b16d1a0c310f36339169634bb7a95) postgresqlPackages.pg_repack: add testers
* [`c16ffa0a`](https://github.com/NixOS/nixpkgs/commit/c16ffa0a125a6098c094fcb19d63c6c4512072d7) drawterm: add nixos tests
* [`9a2b7f1b`](https://github.com/NixOS/nixpkgs/commit/9a2b7f1b91a40d212f9e36aa730a59de4f4548a9) requestly: 1.5.13 -> 1.5.15
* [`5fc84cf3`](https://github.com/NixOS/nixpkgs/commit/5fc84cf30a9f978622aef53528795c9ef2ef42cd) k9s: 0.29.1 -> 0.30.0
* [`27377a09`](https://github.com/NixOS/nixpkgs/commit/27377a0989d14c4a5f4c9bcd9d64fd1523ba66c0) k9s: add changelog and mainProgram
* [`06ceba4f`](https://github.com/NixOS/nixpkgs/commit/06ceba4f5ba48e3b650748e800f6fd1fb52d7d2c) saga: 9.2.0 -> 9.3.0
* [`ec2daea6`](https://github.com/NixOS/nixpkgs/commit/ec2daea6e2c63b960b79e522176f62e2ab481341) stellarium: 23.3 -> 23.4
* [`87add9a0`](https://github.com/NixOS/nixpkgs/commit/87add9a0e542ee80577d8d16f68c28dc11c80196) snowflake: 2.8.0 -> 2.8.1
* [`4c638870`](https://github.com/NixOS/nixpkgs/commit/4c638870731167e36fc09d6e6fb40f01038c0498) supercronic: 0.2.27 -> 0.2.29
* [`6a16b6e2`](https://github.com/NixOS/nixpkgs/commit/6a16b6e2eb6b0de36747ad87974f4b124a07a52c) svdtools: 0.3.6 -> 0.3.8
* [`25e5dfd1`](https://github.com/NixOS/nixpkgs/commit/25e5dfd14258f2a74f7b358aa07eae2b3c5f7f4d) cachix-watch-store: allow to set a signing key
* [`c160b6f8`](https://github.com/NixOS/nixpkgs/commit/c160b6f8621de21aaf88fe93b65acef4f48b64f2) fheroes2: 1.0.10 -> 1.0.11
* [`e5a16fa9`](https://github.com/NixOS/nixpkgs/commit/e5a16fa98b4ae98b8137c92bdcad9b269a95c814) _0verkill: pin to autoconf-2.69
* [`d0cb2f3a`](https://github.com/NixOS/nixpkgs/commit/d0cb2f3ad59df3e788f0accc69cbf954933cc33a) tmux-sessionizer: add mrcjkb to maintainers
* [`7695b4a7`](https://github.com/NixOS/nixpkgs/commit/7695b4a79f8296c3e71427339f463f7c064381ef) tmux-sessionizer: 0.2.3 -> 0.3.0
* [`cbc34bb5`](https://github.com/NixOS/nixpkgs/commit/cbc34bb5812a9a43090c7ae2076264caa11c975d) tmux-sessionizer: replace `rec` with `let.. in`
* [`fea79f43`](https://github.com/NixOS/nixpkgs/commit/fea79f43d33645ebb180577979a173d2e1208a08) tmux-sessionizer: add passthru.tests.version
* [`f82870a9`](https://github.com/NixOS/nixpkgs/commit/f82870a99b420b772707d190c835742f0b8550b4) cinnamon.cinnamon-session: add patch for using login shell w/ wayland
* [`6698e960`](https://github.com/NixOS/nixpkgs/commit/6698e960266f333d31b284af154ea9ef456676a5) nixos/gpaste: also add to cinnamon session path - fixes [nixos/nixpkgs⁠#276028](https://togithub.com/nixos/nixpkgs/issues/276028)
* [`b07ca089`](https://github.com/NixOS/nixpkgs/commit/b07ca0897e89060aa73367bebe4ff0f078cd19f0) toml-f: 0.4.1 -> 0.4.2
* [`29e54d26`](https://github.com/NixOS/nixpkgs/commit/29e54d26206bc306b8c77da0161148fc7b785427) forgejo-actions-runner: 3.0.1 -> 3.3.0
* [`f41df75d`](https://github.com/NixOS/nixpkgs/commit/f41df75d8a7d4b32e4482bb9bcfd7112f0ae6206) sqlite3-to-mysql: 2.1.1 -> 2.1.6
* [`c8560218`](https://github.com/NixOS/nixpkgs/commit/c85602181e005ebfb6d46ce874e3925dd69e1734) bun: 1.0.18 -> 1.0.20
* [`7e70c084`](https://github.com/NixOS/nixpkgs/commit/7e70c084709574ad423159dcb461f8aede020d58) nixosTests.ssh-agent-auth: init
* [`9b881279`](https://github.com/NixOS/nixpkgs/commit/9b8812794b8c489ddb7756a7993affcef7fdd36f) nixosTests.ssh-agent-auth: Test both `sudo` and `sudo-rs`
* [`cefe8f06`](https://github.com/NixOS/nixpkgs/commit/cefe8f0668249d69834c7a429410b0ac3fe536c7) maintainers: add Nudelsalat
* [`e37552b8`](https://github.com/NixOS/nixpkgs/commit/e37552b8fa859f0ff499485bd643801c94137332) prometheus-ping-exporter: init at 1.1.0
* [`5d85f0ee`](https://github.com/NixOS/nixpkgs/commit/5d85f0eee8417f340424e20345e8ccb86929a73f) nixos/prometheus-ping-exporter: init
* [`f3fb9a91`](https://github.com/NixOS/nixpkgs/commit/f3fb9a9134efb8f1328fa78523c6bc75af649c7a) nixos/tests/prometheus-ping-exporter: init
* [`bb3def88`](https://github.com/NixOS/nixpkgs/commit/bb3def8849b2a064da22ac513ee712bd194c442d) frozen: Fix build on case-insensitive file systems
* [`28a5992e`](https://github.com/NixOS/nixpkgs/commit/28a5992e725caa7c7b210ee2f80d437bc27bd5da) uftp: 5.0.2 -> 5.0.3
* [`dec3a7df`](https://github.com/NixOS/nixpkgs/commit/dec3a7df827050c7627a2bac44d724ca5f60b6de) typioca: 2.8.0 -> 2.9.0
* [`a30b8e10`](https://github.com/NixOS/nixpkgs/commit/a30b8e10112766461a0359ed6606b1ad79de7c22) colloid-kde: make sddm a separate output
* [`d3397164`](https://github.com/NixOS/nixpkgs/commit/d3397164c5523115d8237bcf1e420a41dbeae647) ugs: 2.1.0 -> 2.1.4
* [`91b44573`](https://github.com/NixOS/nixpkgs/commit/91b445737aa226bafbbe167960aa456263779836) librewolf-unwrapped: 120.0.1-1 -> 121.0-1
* [`da08af64`](https://github.com/NixOS/nixpkgs/commit/da08af643a0bf16d3ad752a57286fc13f27a7f08) livebook: 0.11.3 -> 0.12.0
* [`1bbad9ad`](https://github.com/NixOS/nixpkgs/commit/1bbad9ad762aa499f1862943c9d81f2f4ad38884) url-parser: 1.0.6 -> 2.0.1
* [`167624ad`](https://github.com/NixOS/nixpkgs/commit/167624ad7e9d507d10c862f835f68870cdd23a69) lsp-plugins: 1.2.13 -> 1.2.14
* [`8326f423`](https://github.com/NixOS/nixpkgs/commit/8326f42345bebc328315a4b4edf7811c4864fb12) blas-reference: 3.11.0 -> 3.12.0
* [`6fc76141`](https://github.com/NixOS/nixpkgs/commit/6fc76141ae6d4f7b34d6af315263b3d03a9ed133) leptonica: 1.83.1 -> 1.84.0
* [`e6ce4a32`](https://github.com/NixOS/nixpkgs/commit/e6ce4a328699335ef223e09a17acb9aef65d2bad) ut: 2.0.0 -> 2.0.1
* [`7e573fef`](https://github.com/NixOS/nixpkgs/commit/7e573feffadf341bf92820dcc930d6ff245984a2) freshrss: 1.22.1 -> 1.23.0
* [`6b85a73b`](https://github.com/NixOS/nixpkgs/commit/6b85a73be918f630e9fcacb3d063961691ef5e27) rich-pixels: 2.1.1 -> 2.2.0
* [`2058c3a3`](https://github.com/NixOS/nixpkgs/commit/2058c3a373f047961549b3bd8531de5822139766) lammps: fix homepage and license
* [`68906a5f`](https://github.com/NixOS/nixpkgs/commit/68906a5fc5fa320213f4ed18dd615bef080e0608) aliases: fix typo
* [`60907d47`](https://github.com/NixOS/nixpkgs/commit/60907d4769dc7707ad08adbd0d93fc68ec66468b) just: 1.17.0 -> 1.18.1
* [`fc82acb9`](https://github.com/NixOS/nixpkgs/commit/fc82acb9ebe48fd1824a6b04617db570b19c3547) audiobookshelf: 2.6.0 -> 2.7.0
* [`dad9c990`](https://github.com/NixOS/nixpkgs/commit/dad9c990826e522976afca663de01ae75aa439ad) cudaPackages: replace the fhs paths in pkg-config files
* [`cfa07014`](https://github.com/NixOS/nixpkgs/commit/cfa07014b6af63298365329c8ffc2a132941d985) cudaPackages.cuda_cudart: patch cuda-XX.Y.pc
* [`6fc02c6c`](https://github.com/NixOS/nixpkgs/commit/6fc02c6c6f1c45eccc3fc2a450fcc2e1e85f4748) nixos/freshrss: fix test http-auth
* [`d82be4f9`](https://github.com/NixOS/nixpkgs/commit/d82be4f92f3bef59415367663e6dbcd110d5791a) timewarrior: 1.6.0 -> 1.7.0
* [`e46cb038`](https://github.com/NixOS/nixpkgs/commit/e46cb038b147fcfdef63262925f0153dffa54dc2) texstudio: 4.7.1 -> 4.7.2
* [`5d6136a5`](https://github.com/NixOS/nixpkgs/commit/5d6136a53eea91bcc7f32c83eb203d1b96494f52) cudaPackages: allow FHS references by default
* [`5044b022`](https://github.com/NixOS/nixpkgs/commit/5044b022f6b97d6c1a8484b1d73bb32c752b1a8e) vals: 0.30.0 -> 0.32.0
* [`2f38b15f`](https://github.com/NixOS/nixpkgs/commit/2f38b15f1612f9d961a747ba48e3b5dd25d731c5) flyctl: remove myself as maintainer
* [`c2383356`](https://github.com/NixOS/nixpkgs/commit/c238335625e6892cf0c012db1c5f07032d246957) waydroid: 1.4.1 -> 1.4.2
* [`5bf728a6`](https://github.com/NixOS/nixpkgs/commit/5bf728a6d494946b3a2027814ce96f8c86f76d97) vcmi: 1.4.0 -> 1.4.1
* [`2d75644e`](https://github.com/NixOS/nixpkgs/commit/2d75644e713f32a1caedb68ee6cd7b005ad710e0) vcpkg: 2023.10.19 -> 2023.12.12
* [`de78d939`](https://github.com/NixOS/nixpkgs/commit/de78d9392ed97ac1c03250c0466b06ff9a4b7a4d) vcpkg-tool: 2023-10-18 -> 2023-12-12
* [`76ee867f`](https://github.com/NixOS/nixpkgs/commit/76ee867f63f8357b9bdcd58618aed92b9b5a2d98) vendir: 0.37.0 -> 0.38.0
* [`121e5a6a`](https://github.com/NixOS/nixpkgs/commit/121e5a6a30a17d7ece2516b1512bfe15b7d6eb9e) vhdl-ls: 0.67.0 -> 0.77.0
* [`e90ec967`](https://github.com/NixOS/nixpkgs/commit/e90ec967f1608c79057e22722b8a736b6d78b197) vhs: 0.6.0 -> 0.7.1
* [`db9c52b2`](https://github.com/NixOS/nixpkgs/commit/db9c52b212047b2736bdae33b892a58367aa8a98) wander: 0.12.6 -> 0.14.1
* [`ed528caa`](https://github.com/NixOS/nixpkgs/commit/ed528caa132bea8ee4fa72a84a3d8b7b4ef95d92) backblaze-b2: add missing dependency setuptools
* [`5ab79e19`](https://github.com/NixOS/nixpkgs/commit/5ab79e192eeea36641574464e37b0f6b9eac5d14) backblaze-b2: add a version test
* [`765c5754`](https://github.com/NixOS/nixpkgs/commit/765c5754a9513300824a0c0591fb0c2b7a22714c) weaviate: 1.21.7 -> 1.23.0
* [`106c75f1`](https://github.com/NixOS/nixpkgs/commit/106c75f1bbcdae9abc6cf710a4f205ff0c8363e4) web-ext: 7.6.2 -> 7.9.0
* [`3c40377b`](https://github.com/NixOS/nixpkgs/commit/3c40377b98f844a3bfa3a8eab64a33b467067ab5) webanalyze: 0.3.9 -> 0.4.1
* [`51962449`](https://github.com/NixOS/nixpkgs/commit/51962449f1434273278994c4034d986ae8b00fb8) wgcf: 2.2.19 -> 2.2.20
* [`994b18cd`](https://github.com/NixOS/nixpkgs/commit/994b18cde11e2deba11f43d0e0a9221eaecba7f7) werf: 1.2.270 -> 1.2.275
* [`cf426817`](https://github.com/NixOS/nixpkgs/commit/cf4268174bd4a4229ae965104944084c5cd11a6d) where-is-my-sddm-theme: 1.5.1 -> 1.6.0
* [`213dcb7f`](https://github.com/NixOS/nixpkgs/commit/213dcb7fa12ea0c4d581548fde71ddfbcf0313cf) wiiload: 0.5.1 -> 0.5.3
* [`ad9f4cc5`](https://github.com/NixOS/nixpkgs/commit/ad9f4cc5ecdee3168d8f9eeb3f64e02df4b24abe) wofi-pass: 23.1.2 -> 23.1.4
* [`4999f97c`](https://github.com/NixOS/nixpkgs/commit/4999f97c9b88b9664d2d2b99652ab0a6d3ed3630) woodpecker-plugin-git: 2.2.0 -> 2.4.0
* [`0f4bd787`](https://github.com/NixOS/nixpkgs/commit/0f4bd7872cfcbdf4408dba731437f1a17820dffb) h3: add dev output
* [`7858f253`](https://github.com/NixOS/nixpkgs/commit/7858f253d60d2d0c6c0ffb25a7a49741553fcc3a) h3: use callPackages to make it overridable
* [`fd109717`](https://github.com/NixOS/nixpkgs/commit/fd109717f822c892567789934a866ec9ce93b37f) h3: do not expose static as argument
* [`01ff3717`](https://github.com/NixOS/nixpkgs/commit/01ff3717a29d730205d16f13be3ef05a7ea91559) ruby_3_3: 3.3.0-rc1 -> 3.3.0
* [`870cf99a`](https://github.com/NixOS/nixpkgs/commit/870cf99aec58d784bb71f8c86f8d94b9453856a6) rubyPackages: update
* [`97a6fa43`](https://github.com/NixOS/nixpkgs/commit/97a6fa437fed870c22e6910852c58375a341cde3) python311Packages.pglast: 5.6 -> 5.7
* [`fd0bc278`](https://github.com/NixOS/nixpkgs/commit/fd0bc2781abb69b9a483d4be5b8eb1ae63a26fdb) python311Packages.xhtml2pdf: 0.2.11 -> 0.2.13
* [`e7ab3d87`](https://github.com/NixOS/nixpkgs/commit/e7ab3d878c3ec321446d7d248cc56632e6792e1d) quickjs-ng: init at 0.3.0
* [`a5332c47`](https://github.com/NixOS/nixpkgs/commit/a5332c47f4ff2be8c6c839c1f595dfb289ff7fe7) postgresqlPackages.h3-pg: init at 4.1.3
* [`d5872fa7`](https://github.com/NixOS/nixpkgs/commit/d5872fa73bac530ac3531523aef55b0cbf0bf58a) python311Packages.borb: init at 2.1.20
* [`7fc99b0e`](https://github.com/NixOS/nixpkgs/commit/7fc99b0e79629a190174658ab7237633df8bdd87) libui-ng: init at unstable-2023-12-19
* [`b5f5d58b`](https://github.com/NixOS/nixpkgs/commit/b5f5d58b8fefcf22c73bacec8651768cd7ad27f2) h3: do not build filters by default
* [`f75d3dbf`](https://github.com/NixOS/nixpkgs/commit/f75d3dbffc9ea110a49f16e1515251fb962876d3) xemu: 0.7.117 -> 0.7.118
* [`5e727c91`](https://github.com/NixOS/nixpkgs/commit/5e727c91bda06e5ba421fa279ae3c687054ddb63) xercesc: 3.2.4 -> 3.2.5
* [`b45547a0`](https://github.com/NixOS/nixpkgs/commit/b45547a0a2b0e8064c445a50aaedc7f3b27e8ff7) nomad: fix licenses
* [`a53336ae`](https://github.com/NixOS/nixpkgs/commit/a53336ae53f6f8724880604edce172477caf8c7a) xsubfind3r: 0.4.0 -> 0.7.0
* [`d6ec7104`](https://github.com/NixOS/nixpkgs/commit/d6ec71046837691b15c96c34d07793aecae2b19a) xwaylandvideobridge: 0.3.0 -> 0.4.0
* [`72de499b`](https://github.com/NixOS/nixpkgs/commit/72de499b3895d738bb8365e9c4433256daa9a504) yor: 0.1.185 -> 0.1.187
* [`245fce8b`](https://github.com/NixOS/nixpkgs/commit/245fce8b6189badf9249050cb38f3b7c786f860b) ytt: 0.46.2 -> 0.46.3
* [`96d532b2`](https://github.com/NixOS/nixpkgs/commit/96d532b26299e44f2e4cfbe90924555b3eb31717) zchunk: 1.3.2 -> 1.4.0
* [`676ef2b4`](https://github.com/NixOS/nixpkgs/commit/676ef2b4b21cf98d9f0349c2763c7c016a5ae6e6) dart: fix fetchDartDeps
* [`02584ffe`](https://github.com/NixOS/nixpkgs/commit/02584ffe4c06680d7406e08505d7aca0a1cf8de3) zef: 0.21.1 -> 0.21.2
* [`2dfc0c9c`](https://github.com/NixOS/nixpkgs/commit/2dfc0c9c921fff11ef561626b83840d628086a97) zfp: 1.0.0 -> 1.0.1
* [`ad610b75`](https://github.com/NixOS/nixpkgs/commit/ad610b750aa466d9e00cd2fead6a3e232142e1ce) zint: 2.12.0 -> 2.13.0
* [`2cd1a5ef`](https://github.com/NixOS/nixpkgs/commit/2cd1a5ef3bd2d79b0c99a38ad0f81012f84a8864) python311Packages.cpufeature: add supported platforms
* [`b866b626`](https://github.com/NixOS/nixpkgs/commit/b866b626cce208ce9c57ba6bad381e61bb78feb6) python311Packages.aiohttp-zlib-ng: only depend on cpufeature where available
* [`e84f45fa`](https://github.com/NixOS/nixpkgs/commit/e84f45fae02d137879f7195f7860903e4a41e7ec) abcmidi: 2023.11.17 -> 2023.12.23
* [`4a9ba100`](https://github.com/NixOS/nixpkgs/commit/4a9ba100b44d6b63d1b73ae142a52a18914f91f6) abaddon: 0.1.13 -> 0.1.14
* [`556aeb33`](https://github.com/NixOS/nixpkgs/commit/556aeb33ab284b8eff4d456ba1f3aaaf34306ffc) python311Packages.google-generativeai: 0.2.2 -> 0.3.2
* [`a84b2cbe`](https://github.com/NixOS/nixpkgs/commit/a84b2cbe541c39c303ae3b05901ef422ce0c4d09) algolia-cli: 1.4.3 -> 1.5.0
* [`ed1a16e8`](https://github.com/NixOS/nixpkgs/commit/ed1a16e8869a2bf54b9f2bb3e7a7fd48cab7d197) munin: fix missing Date::Parse module error & make test fail w/o a fix
* [`186c2d34`](https://github.com/NixOS/nixpkgs/commit/186c2d34c65bc34e646a1af79eff9f195012fc8f) python311Packages.pyoutbreaksnearme: 2023.10.0 -> 2023.12.0
* [`d8441a73`](https://github.com/NixOS/nixpkgs/commit/d8441a73a5575be19fea7c6847c5c6d9471e9b36) python311Packages.pysml: 0.1.1 -> 0.1.2
* [`77b028c1`](https://github.com/NixOS/nixpkgs/commit/77b028c179c4e14cd7dfb1ac42c63887b8c4304d) amf-headers: 1.4.30 -> 1.4.32
* [`c609d663`](https://github.com/NixOS/nixpkgs/commit/c609d66376aac35fe600269b82adfe3f4c19d309) k9s: 0.30.0 -> 0.30.2
* [`4ecab957`](https://github.com/NixOS/nixpkgs/commit/4ecab957267c174d87d6d8dbf0fca47fa53a9eac) api-linter: 1.59.2 -> 1.60.0
* [`0e2f9be8`](https://github.com/NixOS/nixpkgs/commit/0e2f9be8dd5b31469d3e3cbf25471304f84c4400) arkade: 0.10.17 -> 0.10.20
* [`0c361983`](https://github.com/NixOS/nixpkgs/commit/0c3619835bcd2b8979c3393332e9ca427c1f57f6) nixos/freshrss: Stop running the updater service on system activation
* [`c3b7ccb6`](https://github.com/NixOS/nixpkgs/commit/c3b7ccb6f4fb3f6660631af2a9ac9a0127973582) ibus-libpinyin: 1.15.3 -> 1.15.6
* [`9f7ddbd2`](https://github.com/NixOS/nixpkgs/commit/9f7ddbd2981c3cd0e55838f2953e095b8a679d71) python310Packages.regenmaschine: update disabled
* [`93459c34`](https://github.com/NixOS/nixpkgs/commit/93459c34828b1fc8955ada064456e854e51256ee) python311Packages.aioguardian: update disabled
* [`03fc96c9`](https://github.com/NixOS/nixpkgs/commit/03fc96c98cb50310b5fd94056e5506bc5c14bc5c) ast-grep: 0.14.4 -> 0.15.1
* [`97f8df03`](https://github.com/NixOS/nixpkgs/commit/97f8df03dc07adc9e6f91bcbc2256d01af9e5bb3) assemblyscript: 0.27.9 -> 0.27.22
* [`5fa32011`](https://github.com/NixOS/nixpkgs/commit/5fa3201105aab14292243a88153d4f7f46a272ca) aws-iam-authenticator: 0.6.14 -> 0.6.16
* [`3465e1aa`](https://github.com/NixOS/nixpkgs/commit/3465e1aa80ba2833c7759fc793aaaa72e855aad9) balena-cli: 17.0.0 -> 17.4.9
* [`5a85f6a4`](https://github.com/NixOS/nixpkgs/commit/5a85f6a490ed0c09e618542da07be3934b97dcdc) baresip: 3.6.0 -> 3.7.0
* [`9f066b97`](https://github.com/NixOS/nixpkgs/commit/9f066b97ab0ac71ca81136444553be94bf600526) azure-storage-azcopy: 10.22.0 -> 10.22.1
* [`6838bf4f`](https://github.com/NixOS/nixpkgs/commit/6838bf4fead07067070c9394804cbc0200e5b9fb) bearer: 1.33.0 -> 1.33.1
* [`4c18de52`](https://github.com/NixOS/nixpkgs/commit/4c18de526b8b1c1d7411e6d6e14dd0a65f8ff348) kotlin{-native}: 1.9.20 -> 1.9.22
* [`7a9b7e9e`](https://github.com/NixOS/nixpkgs/commit/7a9b7e9eec44e725cb97a3d446f7a0bcb0ba7654) teams-for-linux: 1.3.22 -> 1.4.1
* [`f544c469`](https://github.com/NixOS/nixpkgs/commit/f544c46984b35e0120b2bee731d146278d340b17) libcec: enable the "Linux CEC Framework".
* [`ec50f136`](https://github.com/NixOS/nixpkgs/commit/ec50f136903de21feb3febeea9f10b22820b5240) usbmuxd2: unstable-2022-02-07 -> unstable-2023-12-12
* [`1a179d00`](https://github.com/NixOS/nixpkgs/commit/1a179d00ccb1bcf1b36f09d693d03cc8a1dc1430) neovide: 0.11.2 -> 0.12.0
* [`e5d049a3`](https://github.com/NixOS/nixpkgs/commit/e5d049a3e6622dfb29d8de66f0b5ca7570cd88a0) libsidplayfp: pull fix for `autoconf-2.72` pending upstream inclusion
* [`40b8d88d`](https://github.com/NixOS/nixpkgs/commit/40b8d88dd5fefa670d0b2efe5107bd1dbfb618ac) balena-cli: fix darwin build
* [`6ae26935`](https://github.com/NixOS/nixpkgs/commit/6ae269357f06bc08c054f05e09cf65a3e80678d9) buildkite-agent-metrics: 5.9.2 -> 5.9.3
* [`7954fc68`](https://github.com/NixOS/nixpkgs/commit/7954fc68cbc1710c62be71007483fdbbdfad1dac) opencv4: propagate real outputs in cxxdev even without cuda
* [`78d486bc`](https://github.com/NixOS/nixpkgs/commit/78d486bc1aba1a6b1cb87aa76ab25fc38edda2bd) hplip: add support for qtwayland
* [`c4b20bb4`](https://github.com/NixOS/nixpkgs/commit/c4b20bb40ea49f48da04a0b7878fe60756dfd48e) c2fmzq: 0.4.15 -> 0.4.16
* [`5654bf5b`](https://github.com/NixOS/nixpkgs/commit/5654bf5be30271f2caeadeaf6a7aa031764cb952) cargo-binstall: 1.4.6 -> 1.4.8
* [`70954d5b`](https://github.com/NixOS/nixpkgs/commit/70954d5b527cbae1a5c1b6437a41c7e345e05bbb) cargo-mutants: 23.12.0 -> 23.12.2
* [`d1ea7f19`](https://github.com/NixOS/nixpkgs/commit/d1ea7f192477e69b889c7f165dbd6e818af51f93) cargo-run-bin: 1.6.0 -> 1.6.1
* [`9db06dbb`](https://github.com/NixOS/nixpkgs/commit/9db06dbb85225f9dc6ee7a95cd4026f40b390080) cargo-swift: 0.4.0 -> 0.5.1
* [`3a546238`](https://github.com/NixOS/nixpkgs/commit/3a546238f47d8979aa3071d59d17b1305323c354) hplip: don't double wrap with qt env
* [`cbc10f8c`](https://github.com/NixOS/nixpkgs/commit/cbc10f8c7b2a191f8f987a09348d4358a8179354) cargo-xwin: 0.16.2 -> 0.16.3
* [`9aaea6c6`](https://github.com/NixOS/nixpkgs/commit/9aaea6c6bf89c150fd34bb0a2f53ee0240988518) cargo-tauri: 1.5.2 -> 1.5.4
* [`51f6fbef`](https://github.com/NixOS/nixpkgs/commit/51f6fbefdce3e71895144c13ec092434786517a5) sunshine: add meta.mainProgram
* [`22a2ee47`](https://github.com/NixOS/nixpkgs/commit/22a2ee4748f7a3dd32dff76a09668ebadbeef824) cdxgen: 6.0.14 -> 9.10.1
* [`6ea6cfd9`](https://github.com/NixOS/nixpkgs/commit/6ea6cfd99eacaa2ee159dd373b29693f5d090949) ceph-csi: 3.10.0 -> 3.10.1
* [`49db25dc`](https://github.com/NixOS/nixpkgs/commit/49db25dccbba28ff7e10089aa4e782b7fa9da7c9) rust: set sourceProvenance for bootstrap binary
* [`1810a8cf`](https://github.com/NixOS/nixpkgs/commit/1810a8cf9925cfe9d8793d6f3bfc671b3143cbe9) changie: 1.16.1 -> 1.17.0
* [`c0f720d3`](https://github.com/NixOS/nixpkgs/commit/c0f720d3b1e48e036770adeb65459ae427af50d2) cilium-cli: 0.15.17 -> 0.15.19
* [`1b807b60`](https://github.com/NixOS/nixpkgs/commit/1b807b609b37371a057646b8bfdd13c17449e2c7) goverview: install shell completion files
* [`a2ed961c`](https://github.com/NixOS/nixpkgs/commit/a2ed961c894c242fcffe27ad24cd27523dc5ec62) hugo: add missing `meta.mainProgram`
* [`a90c911b`](https://github.com/NixOS/nixpkgs/commit/a90c911ba67b972c299d5c08e0480bf8a012bcc0) Revert "gwyddion: mark as broken"
* [`fdc9cd95`](https://github.com/NixOS/nixpkgs/commit/fdc9cd958444a81860b9b72480554619d86e6fcf) containerlab: 0.48.1 -> 0.49.0
* [`d4de2594`](https://github.com/NixOS/nixpkgs/commit/d4de259403eb37211b00a477831f55e6902c0455) xfce.xfce4-docklike-plugin: 0.4.1 -> 0.4.2
* [`c704e306`](https://github.com/NixOS/nixpkgs/commit/c704e306090234f62e7d971f41e7d01bb6478d09) multirun: init at 1.1.3
* [`ecb4e1b5`](https://github.com/NixOS/nixpkgs/commit/ecb4e1b5d10a246326b4399826b1e80e746ab4c3) argocd: 2.9.1 -> 2.9.3
* [`a4544466`](https://github.com/NixOS/nixpkgs/commit/a4544466078e39d1f298416593a5c5f80afcbe48) cheat: 4.4.0 -> 4.4.2
* [`5c3cca0e`](https://github.com/NixOS/nixpkgs/commit/5c3cca0e2694e826ad32d5a978dd3a28dac0e711) anki: 23.10.1 -> 23.12
* [`80d9a1ea`](https://github.com/NixOS/nixpkgs/commit/80d9a1eae52555aeddf880609daef52d4d4acaad) libkrunfw: 3.11.0 -> 4.0.0
* [`0bafb36f`](https://github.com/NixOS/nixpkgs/commit/0bafb36f0eb98db89893b5a3d9a10d027de91bc2) libkrun: 1.5.1 -> 1.7.2
* [`f36a80e5`](https://github.com/NixOS/nixpkgs/commit/f36a80e54da29775c78d7eff0e628c2b4e34d1d7) cwiid: fix cross-compilation
* [`909b7cfa`](https://github.com/NixOS/nixpkgs/commit/909b7cfa7f8e1cf109b1c69c89c009262ceacf25) wttrbar: 0.6.0 -> 0.7.0
* [`ad729ac6`](https://github.com/NixOS/nixpkgs/commit/ad729ac62ec7517b0ebda1fe6d348ab79f6d83eb) devbox: 0.8.4 -> 0.8.5
* [`c0d1d6a2`](https://github.com/NixOS/nixpkgs/commit/c0d1d6a2935b1c4890723f3ce67d7f3d28f3c8a6) doomretro: 5.1.1 -> 5.1.3
* [`0f7b4aee`](https://github.com/NixOS/nixpkgs/commit/0f7b4aee1b08e1de308073ed39cc6a286a96c5cf) droidcam: 2.1.1 -> 2.1.2
* [`7b4fd056`](https://github.com/NixOS/nixpkgs/commit/7b4fd0568fc87f5212361357f42c5379e4624d87) maintainers: added new pgp key to anpin
* [`3e753058`](https://github.com/NixOS/nixpkgs/commit/3e7530585114f976dae7e93ec4e9eeae31289411) python311Packages.bravado-core: 6.1.0 -> 6.6.1
* [`2d7dc2b4`](https://github.com/NixOS/nixpkgs/commit/2d7dc2b4a9ea76aa9d6d2774737b88c9a318fd5b) python311Packages.geoalchemy2: 0.14.2 -> 0.14.3
* [`0c198710`](https://github.com/NixOS/nixpkgs/commit/0c1987100aeb36dc1bb5190200b2f5fe920a704b) python311Packages.remotezip: 0.12.1 -> 0.12.2
* [`6b48363b`](https://github.com/NixOS/nixpkgs/commit/6b48363b57f10147cc6f044d182ffa5a35754187) ledfx: 2.0.80 -> 2.0.86
* [`62266dbe`](https://github.com/NixOS/nixpkgs/commit/62266dbe341a9028d7b489972bbd39c28e8b3408) eask: 0.8.1 -> 0.9.1
* [`793994ba`](https://github.com/NixOS/nixpkgs/commit/793994bac1be3ecc7a54e239cee5a0d3a7fadde1) fwknop: pull fix for `autoconf-2.72` build pending upstream inclusion
* [`8966a102`](https://github.com/NixOS/nixpkgs/commit/8966a102909907d691b0c7a21bcf991580bfd596) cargo-workspaces: 0.2.44 -> 0.3.0
* [`4d8e7dfe`](https://github.com/NixOS/nixpkgs/commit/4d8e7dfe21c179fa03661927c79a3f4b79c79daf) cargo: fix description and homepage
* [`79f6fb1f`](https://github.com/NixOS/nixpkgs/commit/79f6fb1ff8a0376a51aacad3af4eacdd2b4d9633) flashprint: 5.8.1 -> 5.8.3
* [`e25b2d4e`](https://github.com/NixOS/nixpkgs/commit/e25b2d4e377b8db9ea2b2b86141cb588c5fab338) rustc: link to https homepage
* [`da490f0a`](https://github.com/NixOS/nixpkgs/commit/da490f0a167f06979c04ce14595d56785e766540) enlightenment.efl: 1.26.3 -> 1.27.0
* [`674019e9`](https://github.com/NixOS/nixpkgs/commit/674019e9ba09836797eafc222801bb8673fd3c12) enlightenment.enlightenment: 0.25.4 -> 0.26.0
* [`b59ddb30`](https://github.com/NixOS/nixpkgs/commit/b59ddb30f46babd5214fef8dcaef79e07e643a5b) pipewire: fix build without x11 support
* [`2e14d8ba`](https://github.com/NixOS/nixpkgs/commit/2e14d8ba72b07047d1dda0ed8161956fba34ee0a) nixos/no-x-libs: build qtbase without qt translation
* [`a5ac2d8d`](https://github.com/NixOS/nixpkgs/commit/a5ac2d8dc26c255541bd8cd2f67dcce5c55db274) kanata: mention breaking changes of v1.5.0
* [`0f993830`](https://github.com/NixOS/nixpkgs/commit/0f993830f5f191eecdaf2a2a5db63cbfa1b2952a) freedv: 1.9.5 -> 1.9.6
* [`52f8a4ca`](https://github.com/NixOS/nixpkgs/commit/52f8a4caad3e07466d9f882e214d273e261a477a) helmfile: 0.159.0 -> 0.160.0
* [`36d19bc3`](https://github.com/NixOS/nixpkgs/commit/36d19bc398634ba0d91f44f6b8b85bce27ba0ff9) kubecm: 0.25.0 -> 0.26.0
* [`51bbafd6`](https://github.com/NixOS/nixpkgs/commit/51bbafd6a7e1df7317d8df9d9d85d3bd6c482398) python311Packages.jaraco-logging: 3.2.0 -> 3.3.0
* [`e03340a3`](https://github.com/NixOS/nixpkgs/commit/e03340a3873201ba282966b5bc2626a01e6c5d4e) python311Packages.irc: 20.3.0 -> 20.3.1
* [`2dc30cae`](https://github.com/NixOS/nixpkgs/commit/2dc30cae79baac0848ca5d8228154479721f0c8f) libtraceevent: 1.7.3 -> 1.8.0
* [`afbd598e`](https://github.com/NixOS/nixpkgs/commit/afbd598e18aa97412edc67891207b55692e42dc2) frankenphp: 1.0.1 -> 1.0.2
* [`2100a51e`](https://github.com/NixOS/nixpkgs/commit/2100a51ebdcf1373105e76f4e6b0e56f1083e53c) phpExtensions.apcu: remove obsolete patch
* [`0ae9c343`](https://github.com/NixOS/nixpkgs/commit/0ae9c34391d79c14d33b7dc60ca95d34f3643e72) livebook: configurable package and extraPackages
* [`27eefe02`](https://github.com/NixOS/nixpkgs/commit/27eefe02e08eba3a0c57ef35e9298331475c6d27) python311Packages.mypy-boto3-*: 1.33.0 -> 1.34.0
* [`7da4af6d`](https://github.com/NixOS/nixpkgs/commit/7da4af6d7274e0c29b03ad1ad3622a65b4668ced) bacon: 2.13.0 -> 2.14.1
* [`e326909c`](https://github.com/NixOS/nixpkgs/commit/e326909cf3b43780228b36518b16301b0691513f) opencv4: extend the comment about cxxdev
* [`c7d08402`](https://github.com/NixOS/nixpkgs/commit/c7d08402867652debf2964a68922f711bd10d3f9) cudaPackages.cudart: stubs: add the libcuda.so.1 soname
* [`0d1e4efb`](https://github.com/NixOS/nixpkgs/commit/0d1e4efbde674b4c852ab4f5097763413c87bd8b) fbc: 1.10.0 -> 1.10.1
* [`79e0b12a`](https://github.com/NixOS/nixpkgs/commit/79e0b12a122d353ea4fb0d4601b99bfc048d7008) gyroflow: init at 1.5.4-2023-12-22
* [`76cd213e`](https://github.com/NixOS/nixpkgs/commit/76cd213e1eadfb172be69b1bfd25ca21e766c8a8) ligolo-ng: 0.4.4 -> 0.4.5
* [`3b509765`](https://github.com/NixOS/nixpkgs/commit/3b5097657e3cf73e4969491aabd6f3a3335cf1bb) ludusavi: 0.21.0 -> 0.22.0
* [`dd647021`](https://github.com/NixOS/nixpkgs/commit/dd647021251a01a02e5bfe1af8465eab4f5423fb) git-hound: 1.4 -> 1.7.2
* [`a61b910f`](https://github.com/NixOS/nixpkgs/commit/a61b910f3b8ac6db90145b2b93942ee37b06d94a) prometheus-consul-exporter: 0.9.0 -> 0.11.0
* [`d2fa06b6`](https://github.com/NixOS/nixpkgs/commit/d2fa06b609085385a43afc81251af98b7bab0434) python311Packages.mysqlclient: 2.2.0 -> 2.2.1
* [`b442b2a9`](https://github.com/NixOS/nixpkgs/commit/b442b2a9b54a4100dd564e370ebd3ad2f0d8e25c) telegram-desktop.tg_owt: unstable-2023-11-17 -> unstable-2023-12-21
* [`e34a5602`](https://github.com/NixOS/nixpkgs/commit/e34a56026c1032ec48170b82739c0770f5d638f6) telegram-desktop: 4.12.2 -> 4.13.1
* [`2293e040`](https://github.com/NixOS/nixpkgs/commit/2293e04065f706a7af08c50e0a30e72193c23c7d) python311Packages.simplisafe-python: refactor
* [`8cd60f25`](https://github.com/NixOS/nixpkgs/commit/8cd60f251eba14ef68b28d7a3fde3dd3d0d23a56) esphome: 2023.11.6 -> 2023.12.5
* [`3873eb4b`](https://github.com/NixOS/nixpkgs/commit/3873eb4bcd61d8835d4b9bc264e5ed6ecb8cea39) tor-browser: 13.0.6 -> 13.0.8
* [`9a4106e6`](https://github.com/NixOS/nixpkgs/commit/9a4106e62ca33c9f6b5c2906300a683a73da5ce6) mullvad-browser: 13.0.6 -> 13.0.7
* [`c21d0c38`](https://github.com/NixOS/nixpkgs/commit/c21d0c384484712202bb9f5a69858739f31742f5) anydesk: use desktopItems, move passthru before meta
* [`2f3dee34`](https://github.com/NixOS/nixpkgs/commit/2f3dee3492801fffd9f56c6abf5cb20c31091808) ignite-cli: init at 28.1.0
* [`593d5806`](https://github.com/NixOS/nixpkgs/commit/593d58068494fe0ea19367644c2cfe71979085c8) python311Packages.python-google-nest: 5.2.0 -> 5.2.1
* [`f0fb6f0a`](https://github.com/NixOS/nixpkgs/commit/f0fb6f0a2696dfb76d79a819bb42bec762fca8f2) doc: update mkBinaryCache section with admonitions and conventions
* [`03a26af7`](https://github.com/NixOS/nixpkgs/commit/03a26af731656deb7d4ea515e1f9fc8baa5a5f7f) speedtest-go: 1.6.9 -> 1.6.10
* [`90fa8361`](https://github.com/NixOS/nixpkgs/commit/90fa8361436f59618f1d75f5afc5987ae6fdd6fa) qjournalctl: 0.6.3 -> 0.6.4
* [`361628d8`](https://github.com/NixOS/nixpkgs/commit/361628d8f983b25faf3d71268dca37c5b5189ee8) sbctl: 0.12 -> 0.13
* [`c010cf1b`](https://github.com/NixOS/nixpkgs/commit/c010cf1bea6a66556b1df30d5d8c98537ba9a63f) sptk: 4.1 -> 4.2
* [`9d95ddfa`](https://github.com/NixOS/nixpkgs/commit/9d95ddfac4de893bf3b01d577e7622a4c5ef4a73) spleen: 2.0.1 -> 2.0.2
* [`a44afba8`](https://github.com/NixOS/nixpkgs/commit/a44afba8444dfa8642e4225accd36585d094001b) aliyun-cli: 3.0.189 -> 3.0.190
* [`4c5759ed`](https://github.com/NixOS/nixpkgs/commit/4c5759ed4a35483515c57a67c027e6d743c6be7a) wxmaxima: 23.11.0 -> 23.12.0
* [`9329efea`](https://github.com/NixOS/nixpkgs/commit/9329efeadc238dc9c169751403611481086f2d10) xdg-desktop-portal-hyprland: 1.2.5 -> 1.2.6
* [`12b40cf5`](https://github.com/NixOS/nixpkgs/commit/12b40cf56ca5d849f49ac8e7a4c7915a3b3922c3) fastfetch: 2.3.4 -> 2.4.0
* [`251c448e`](https://github.com/NixOS/nixpkgs/commit/251c448e7859d1ff36f2dc603ba94a2eaf12e733) eksctl: 0.165.0 -> 0.167.0
* [`5f396752`](https://github.com/NixOS/nixpkgs/commit/5f396752c0cb5ba84f2b194e3f3fa5bb595a74e8) tree-sitter-grammars.tree-sitter-nix: update grammar
* [`807ddcc0`](https://github.com/NixOS/nixpkgs/commit/807ddcc02c004ff230468f8d06bd2572a8850dd8) fastfetch: fix darwin x86
* [`8cc7f7c4`](https://github.com/NixOS/nixpkgs/commit/8cc7f7c44b2c799f646d495adba319c2f8854cf6) ergo: 5.0.16 -> 5.0.18
* [`cedbec08`](https://github.com/NixOS/nixpkgs/commit/cedbec08b50e6b8b6ab2ed85a1a005f08b91829d) fastcdr: 1.1.1 -> 2.1.2
* [`576c4f4a`](https://github.com/NixOS/nixpkgs/commit/576c4f4af5094340f6bbd1a74a54a5e28b6e916d) cudaPackages: eliminate exceptions
* [`cf214375`](https://github.com/NixOS/nixpkgs/commit/cf214375c9bc03f458dc6dad04990fd5774c6bb7) cudaPackages: manifest-builder: fake url/sha256 instead of exceptions
* [`b7ffddbc`](https://github.com/NixOS/nixpkgs/commit/b7ffddbce34c2bfb40048ba503080957ee312608) fingerprintx: 1.1.12 -> 1.1.13
* [`d552cc3b`](https://github.com/NixOS/nixpkgs/commit/d552cc3b6622cf7294f99953305df1664e9e8300) fioctl: 0.38 -> 0.40
* [`08041d34`](https://github.com/NixOS/nixpkgs/commit/08041d345eb1b33f26f325df7467ed10ef6df591) firebase-tools: 12.4.8 -> 13.0.2
* [`33f24ac8`](https://github.com/NixOS/nixpkgs/commit/33f24ac84ad42f222cb29a58b860ca0136e321e4) fits-cloudctl: 0.12.11 -> 0.12.12
* [`9b3a560a`](https://github.com/NixOS/nixpkgs/commit/9b3a560a8a255cc7d5b42e7499f90ef161b49061) flarectl: 0.83.0 -> 0.84.0
* [`760807bc`](https://github.com/NixOS/nixpkgs/commit/760807bc1e72ac669247623cb9f0847de84b6a40) flow: 0.224.0 -> 0.225.1
* [`91b7b94b`](https://github.com/NixOS/nixpkgs/commit/91b7b94bccbd67d335064fe6c25e14883124fd07) flyctl: 0.1.134 -> 0.1.135
* [`9b1f47a4`](https://github.com/NixOS/nixpkgs/commit/9b1f47a401f231fbc014b7394eaccd454a69d271) frp: 0.52.0 -> 0.53.2
* [`d8403f1f`](https://github.com/NixOS/nixpkgs/commit/d8403f1fe672b111498390d9b282e4a013ccb906) bento4: 1.6.0-640 -> 1.6.0-641
* [`a08466f3`](https://github.com/NixOS/nixpkgs/commit/a08466f3b30d6f4c53ac5a541e2d6f5d17799368) pacproxy: add meta.mainProgram, move to pkgs/by-name
* [`618d7fcf`](https://github.com/NixOS/nixpkgs/commit/618d7fcf2a4346b9b0e70a2162318a082dc7409f) lirc: fix cross-compilation
* [`8b9099ae`](https://github.com/NixOS/nixpkgs/commit/8b9099aed6613d0372a75652cc2b8da798d2764b) broot: 1.30.1 -> 1.30.2
* [`7215f205`](https://github.com/NixOS/nixpkgs/commit/7215f205cd6dd443a01b40cb14da04c57d930295) buttercup-desktop: 2.24.3 -> 2.24.4
* [`c4a88ae4`](https://github.com/NixOS/nixpkgs/commit/c4a88ae42420f87cebc06914fe45080cf350e65e) cadical: 1.9.1 -> 1.9.3
* [`af486ebc`](https://github.com/NixOS/nixpkgs/commit/af486ebc8b87aaa13ea8a843e4c62e7a77395b3e) dua: 2.23.0 -> 2.24.1
* [`40d0de07`](https://github.com/NixOS/nixpkgs/commit/40d0de07e18f3e20199767d775d1770865bd41c3) codux: 15.16.1 -> 15.16.2
* [`dd0652f2`](https://github.com/NixOS/nixpkgs/commit/dd0652f2d58bbe6e6757c67f5d424947fbc176e7) svtplay-dl: 4.28.1 -> 4.69
* [`f96d4b3e`](https://github.com/NixOS/nixpkgs/commit/f96d4b3eec23fe2b68431b317f25376ec935237a) git-mit: 5.12.180 -> 5.12.181
* [`20de361b`](https://github.com/NixOS/nixpkgs/commit/20de361bc4fa3a4c8bd17d9a7e8d78968593faf2) glooctl: 1.15.17 -> 1.15.18
* [`bfa30dc6`](https://github.com/NixOS/nixpkgs/commit/bfa30dc6e824521096d61bdb7c26cbc4d083fc25) python311Packages.pyenphase: 1.15.1 -> 1.15.2
* [`0d3c51e1`](https://github.com/NixOS/nixpkgs/commit/0d3c51e1f2714e381d6ae5ea9e7fab6c7d8c1132) python311Packages.pyatv: 0.14.4 -> 0.14.5
* [`529ccb0c`](https://github.com/NixOS/nixpkgs/commit/529ccb0c2f3dea7156485d2c3d4b2819b05c3c5a) python311Packages.python-roborock: 0.36.2 -> 0.38.0
* [`2d73c0b3`](https://github.com/NixOS/nixpkgs/commit/2d73c0b3b1e29b4991d9cdba8cf6040b511b8488) python311Packages.pyvicare: 2.29.0 -> 2.30.0
* [`f9fcccc4`](https://github.com/NixOS/nixpkgs/commit/f9fcccc40960eaaea221410cdf244692347274b7) python311Packages.pywerview: 0.5.2 -> 0.6
* [`ea3b769d`](https://github.com/NixOS/nixpkgs/commit/ea3b769d47538b79a7c30d336b95fb9de0cfee5a) python311Packages.pywerview: refactor
* [`31d6103d`](https://github.com/NixOS/nixpkgs/commit/31d6103d82a1a5ce413599f41febe716a243ef2d) python311Packages.scmrepo: 1.5.0 -> 2.0.2
* [`ca6dbf53`](https://github.com/NixOS/nixpkgs/commit/ca6dbf534a0dc3aee0409df3fff67a4921eb58d8) granted: 0.20.3 -> 0.20.5
* [`1bc797b6`](https://github.com/NixOS/nixpkgs/commit/1bc797b6cf816ae47581e19d741bfe832574ac90) python311Packages.sendgrid: 6.10.0 -> 6.11.0
* [`7ebd5b81`](https://github.com/NixOS/nixpkgs/commit/7ebd5b81b74e9f9ddb341473bb50059b4123f565) influxdb2-cli: remove unused buildGoPackage
* [`61b08e65`](https://github.com/NixOS/nixpkgs/commit/61b08e6536f06f99fe39789c0fcf9aa27253eda1) argo: remove unused buildGoPackage
* [`f4ad5cd1`](https://github.com/NixOS/nixpkgs/commit/f4ad5cd16c6eff28e1e69ddd09b531641c30add8) gotify-server: remove unused buildGoPackage
* [`86c73ad2`](https://github.com/NixOS/nixpkgs/commit/86c73ad2221c85ee39b26052a4a0dfde962d6ace) python311Packages.stdlibs: 2023.11.2 -> 2023.12.15
* [`678dffb6`](https://github.com/NixOS/nixpkgs/commit/678dffb6d8a0fbb83282d6d913c41c47e88ac967) python311Packages.types-awscrt: 0.19.18 -> 0.20.0
* [`d33f2cd4`](https://github.com/NixOS/nixpkgs/commit/d33f2cd4703abe97ea4c197f6c123152c208c9a5) ocamlPackages.poll: init at 0.3.1
* [`9fa84672`](https://github.com/NixOS/nixpkgs/commit/9fa84672bdb4520093e622cc77db98875e0c2508) python311Packages.whois: 0.99.27 -> 0.99.3
* [`b899e29b`](https://github.com/NixOS/nixpkgs/commit/b899e29b06210ea6fce52baf7c8f3a96e863a218) python311Packages.usb-devices: 0.4.1 -> 0.4.5
* [`2314f8df`](https://github.com/NixOS/nixpkgs/commit/2314f8dfe29af7d16f4204059a1da797a2afbae8) python311Packages.types-s3transfer: 0.8.2 -> 0.10.0
* [`9bbc992a`](https://github.com/NixOS/nixpkgs/commit/9bbc992a7b0f1b2d9b79f3bc3302339958558666) python311Packages.ttls: 1.8.1 -> 1.8.2
* [`181393b0`](https://github.com/NixOS/nixpkgs/commit/181393b02daa12f9c11946c54b1a93847766ba68) govendor: remove
* [`a3248182`](https://github.com/NixOS/nixpkgs/commit/a324818224fa385350fafc6fabf2d4b84d91cb95) gtop: 1.1.3 -> 1.1.5
* [`662f6cfd`](https://github.com/NixOS/nixpkgs/commit/662f6cfde25fb6f42089943b0137d25f82b36a6a) dep: remove
* [`4aa38869`](https://github.com/NixOS/nixpkgs/commit/4aa388695e8daba3fdb914442c0063d3800d0ccc) hcloud: 1.41.0 -> 1.41.1
* [`ae02e01a`](https://github.com/NixOS/nixpkgs/commit/ae02e01a6a202d06b03feef378de8f4e373c7f5f) glide: remove
* [`0b522b24`](https://github.com/NixOS/nixpkgs/commit/0b522b2429c27eeadd8e928d8e1eca274df62c90) nixos/pgadmin: add package option
* [`68c90094`](https://github.com/NixOS/nixpkgs/commit/68c90094fcf0161f65b500f6b6cf826887873e4b) hsd: 6.0.0 -> 6.1.1
* [`9c531999`](https://github.com/NixOS/nixpkgs/commit/9c531999c7ce9f34a297de5856e644fc642217f3) electron_28: 28.0.0 -> 28.1.0
* [`2ca04021`](https://github.com/NixOS/nixpkgs/commit/2ca040210d9bc5acbceab753c69d781da715f12d) electron_27: 27.1.3 -> 27.2.0
* [`62dbffc2`](https://github.com/NixOS/nixpkgs/commit/62dbffc2d7afc8f92bdbd861ddeb39e19fe39b2f) electron_26: 26.6.2 -> 26.6.3
* [`b8e27e66`](https://github.com/NixOS/nixpkgs/commit/b8e27e666d42eb2d307f84f0aa2e2a7779be1e81) htslib: 1.18 -> 1.19
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
