### PR TITLE
niv devenv: update 405a4c6a -> 7354096f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "405a4c6a3fecfd2a7fb37cc13f4e760658e522e6",
-        "sha256": "07ipw3ndlabi5851lrlhh7afij16r9hpld1gqabhpg44hdfz9d9i",
+        "rev": "7354096fc026f79645fdac73e9aeea71a09412c3",
+        "sha256": "178b7azh3yh2d7d20y4f7bn791zvl7kgpmq50xaclhq795ddh20s",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/405a4c6a3fecfd2a7fb37cc13f4e760658e522e6.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/7354096fc026f79645fdac73e9aeea71a09412c3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@405a4c6a...7354096f](https://github.com/cachix/devenv/compare/405a4c6a3fecfd2a7fb37cc13f4e760658e522e6...7354096fc026f79645fdac73e9aeea71a09412c3)

* [`b28e680a`](https://github.com/cachix/devenv/commit/b28e680af121c7fb449364e863acc6251ebe0771) templates/simple: fix typo in .envrc
