### PR TITLE
niv home-manager: update 80679ea5 -> 6e91c5df

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80679ea5074ab7190c4cce478c600057cfb5edae",
-        "sha256": "0cyp0hvscb1jdm5yc94nblhf9dgx6yqyw7qrvy2jxd8ird3ajg02",
+        "rev": "6e91c5df192395753d8e6d55a0352109cb559790",
+        "sha256": "0mvy5v5h0gjysij8vrajx2z1z6gm2f3avvsf6w9zrfkarkfl41ja",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/80679ea5074ab7190c4cce478c600057cfb5edae.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/6e91c5df192395753d8e6d55a0352109cb559790.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@80679ea5...6e91c5df](https://github.com/nix-community/home-manager/compare/80679ea5074ab7190c4cce478c600057cfb5edae...6e91c5df192395753d8e6d55a0352109cb559790)

* [`d1d95084`](https://github.com/nix-community/home-manager/commit/d1d950841d230490f308f5fcf8c0d4f2bd3f24a7) gh: include version in settings
* [`2939d490`](https://github.com/nix-community/home-manager/commit/2939d490366251d9ed5a0bd938275c590a1d6fa6) gh: test for existence of hosts file
* [`45854459`](https://github.com/nix-community/home-manager/commit/458544594ba7f0333cf5718045ee7a8eaf5de433) gpg-agent: don't set a default for pinentry
* [`0f11c140`](https://github.com/nix-community/home-manager/commit/0f11c140657cc1d78febec4d6aca3836422600d2) osmscout-server: add module
* [`c24c2985`](https://github.com/nix-community/home-manager/commit/c24c298562fe41b39909f632c5a7151bbf6b4628) zsh.prezto: fix path in example for 'pmoduleDirs'
* [`6e2afa5c`](https://github.com/nix-community/home-manager/commit/6e2afa5c3b8bb17bdc7c1a5be896aed177449f59) sftpman: add module
* [`f8a4a5c1`](https://github.com/nix-community/home-manager/commit/f8a4a5c18f4fee53ac3016a52a97df2aaeede65b) gh: idempotently consider existing symlinks
* [`ba6b7501`](https://github.com/nix-community/home-manager/commit/ba6b75011b44e85b1b755b6c423f85d0817645f7) alacritty: make compatible with alacritty 0.13
* [`30f9cdd6`](https://github.com/nix-community/home-manager/commit/30f9cdd69d1486a3d5cddaaabef7288d8ed389ee) oh-my-posh: fix test under Darwin
* [`77c698fa`](https://github.com/nix-community/home-manager/commit/77c698fa4b3081b6019ad77d1bfedf06dbbde0db) zsh: add support for zproof
* [`df7f29a2`](https://github.com/nix-community/home-manager/commit/df7f29a231a483c88cbd00608db99634f854a8e1) zoxide: fix use with recent Nushell
* [`c48ae40d`](https://github.com/nix-community/home-manager/commit/c48ae40dbbb9193b4766c020bca116e127455ab9) Translate using Weblate (German)
* [`2aff324c`](https://github.com/nix-community/home-manager/commit/2aff324cf65f5f98f89d878c056b779466b17db8) bemenu: add module
* [`2e8634c2`](https://github.com/nix-community/home-manager/commit/2e8634c252890cb38c60ab996af04926537cbc27) flake.lock: Update
* [`b7ef79bc`](https://github.com/nix-community/home-manager/commit/b7ef79bcf47c002bd6ae81a52bd3f233297edbde) Translate using Weblate (Ukrainian)
* [`f06edaf1`](https://github.com/nix-community/home-manager/commit/f06edaf18b119da7bb301eebbf87971bbb9fb162) lorri: unbreak due to too tight sandboxing
* [`6e91c5df`](https://github.com/nix-community/home-manager/commit/6e91c5df192395753d8e6d55a0352109cb559790) i3blocks: added configuration module
