### PR TITLE
niv nerd-icons.el: update 3af4d38c -> d53c5a1e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "3af4d38c1119567b20ef9020f70de163d0d58c37",
-        "sha256": "1g8lain6k0w5kzzb612mb2s6f62bi3lfdyh2anzd4f1vw2jwkfk8",
+        "rev": "d53c5a1e0e8837735310d9ebff53d072a947872a",
+        "sha256": "0rvs0fdaq46d1p09ln77lyvng4g18za8npy32a0vjdmbl97rcm1c",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/3af4d38c1119567b20ef9020f70de163d0d58c37.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/d53c5a1e0e8837735310d9ebff53d072a947872a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@3af4d38c...d53c5a1e](https://github.com/rainstormstudio/nerd-icons.el/compare/3af4d38c1119567b20ef9020f70de163d0d58c37...d53c5a1e0e8837735310d9ebff53d072a947872a)

* [`8a39f736`](https://github.com/rainstormstudio/nerd-icons.el/commit/8a39f736e44ec0928803f64fe0c9657ac24e71ca) docs: customize icons
* [`64648202`](https://github.com/rainstormstudio/nerd-icons.el/commit/6464820214f2edbe8070ea2d109f02531847546d) add .iso support (disk icon)
* [`007d818f`](https://github.com/rainstormstudio/nerd-icons.el/commit/007d818f726a8dba75fc520207bb035ad9c46610) fix mdi-icon disc
* [`d53c5a1e`](https://github.com/rainstormstudio/nerd-icons.el/commit/d53c5a1e0e8837735310d9ebff53d072a947872a) fix typo
