### PR TITLE
niv nixpkgs: update 191b2e79 -> 1bf1c7a2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "191b2e79a58fe7e6d622b7d14d1edf0752461d82",
-        "sha256": "16rcvwgca0ivrk3d6x80ln537jpb3vpg9s9nwk0ji4y72pg71dwd",
+        "rev": "1bf1c7a244e63f4e550815ea3432fb83c5f69b8a",
+        "sha256": "0xkjz0yag7363hxwqrhl0va1zkii7710m8rwmcqprp3vx7wfj2in",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/191b2e79a58fe7e6d622b7d14d1edf0752461d82.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/1bf1c7a244e63f4e550815ea3432fb83c5f69b8a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@191b2e79...1bf1c7a2](https://github.com/nixos/nixpkgs/compare/191b2e79a58fe7e6d622b7d14d1edf0752461d82...1bf1c7a244e63f4e550815ea3432fb83c5f69b8a)

* [`7d32fe6d`](https://github.com/NixOS/nixpkgs/commit/7d32fe6dbee7c88c47bd707a769c05686643e255) ethash: 0.8.0 -> 1.0.1
* [`0d8594ef`](https://github.com/NixOS/nixpkgs/commit/0d8594ef0dea6a07e03c8b37f0d71ea3490ac991) bazel-watcher: 0.21.2 -> 0.23.1
* [`a9867af6`](https://github.com/NixOS/nixpkgs/commit/a9867af6b4fd13fbc5ae6c7bdc43b2d6b4b32630) build2.bootstrap: 0.15.0 -> 0.16.0
* [`7477d92e`](https://github.com/NixOS/nixpkgs/commit/7477d92e934a3adf957ef4a4b7d55bc3d50672af) emulsion: 9.0 -> 10.4
* [`cc4bb3d6`](https://github.com/NixOS/nixpkgs/commit/cc4bb3d6728d249f4450e3587644c8203465685a) prismlauncher: add withWaylandGLFW override
* [`915431fb`](https://github.com/NixOS/nixpkgs/commit/915431fb2d5680e5d66083a83ffb8da353626594) prismlauncher: add comments explaining new args
* [`2f96e409`](https://github.com/NixOS/nixpkgs/commit/2f96e4094365b8e67100afd29cb6c88452d47fea) graphicsmagick: 1.3.39 -> 1.3.42
* [`823474f5`](https://github.com/NixOS/nixpkgs/commit/823474f53ec0e56c3a3eafef649294dc04d2ecc0) psqlodbc: 13.02.0000 -> 16.00.0000
* [`8be05482`](https://github.com/NixOS/nixpkgs/commit/8be05482df410454a2e59d456ddc643f4a3bd261) prismlauncher: move shellWrapper to let block
* [`9175b939`](https://github.com/NixOS/nixpkgs/commit/9175b939c1d382685ed6f04dda0a66c6d1e6810f) prismlauncher: give interm. package accurate name
* [`b5f6f06c`](https://github.com/NixOS/nixpkgs/commit/b5f6f06c99f64d9702e97df5d81559359ad68e0e) nixos/release: drop i686-linux support
* [`86573a63`](https://github.com/NixOS/nixpkgs/commit/86573a638951c123df7f2e1aa495823d6203ed66) pkcrack: init at 1.2.2
* [`f876c6c0`](https://github.com/NixOS/nixpkgs/commit/f876c6c0047c255aa6cbadcb4e9e283fabe6bb3d) opendmarc: 1.3.3 -> 1.4.2
* [`88ef13e3`](https://github.com/NixOS/nixpkgs/commit/88ef13e3d811cd69abfb65e7bc9e4eb6a2798aa6) perlPackages.FileFcntlLock: init at 0.22
* [`08c66763`](https://github.com/NixOS/nixpkgs/commit/08c667636a095e7c1ae3b96a97fdfc6f17490875) maccy: init at 0.28.0
* [`0e074516`](https://github.com/NixOS/nixpkgs/commit/0e074516831b078a2cce6ab6ab3e66ebf1776f81) galene: 0.7.2 -> 0.8
* [`3938d5b1`](https://github.com/NixOS/nixpkgs/commit/3938d5b1de4c1b82c4126086d8ae57c2cc0face7) bip: 0.8.9 -> 0.9.3
* [`821a54b1`](https://github.com/NixOS/nixpkgs/commit/821a54b1fa93239ddf6d0efb2b31870d0e75b99e) mkbootimage: init at 2.3-unstable-2022-05-26
* [`6c6f790f`](https://github.com/NixOS/nixpkgs/commit/6c6f790f33e9e06e8f702d19792809968fcc4788) universal-android-debloater: init at 0.6.1
* [`1a3aa094`](https://github.com/NixOS/nixpkgs/commit/1a3aa094263e532f3b4d8670ddc7907a81c98266) python310Packages.phonopy: 2.20.0 -> 2.21.0
* [`5d2035aa`](https://github.com/NixOS/nixpkgs/commit/5d2035aa6edacc7255e9359ba5886fb218691eea) haskellPackages: stackage LTS 21.21 -> LTS 21.23
* [`a87e99f7`](https://github.com/NixOS/nixpkgs/commit/a87e99f7775b2fbfca86ad025599cbddc72a79d5) all-cabal-hashes: 2023-11-20T05:37:18Z -> 2023-12-04T17:35:08Z
* [`1bd63713`](https://github.com/NixOS/nixpkgs/commit/1bd6371376766bcd72fdff63887f6e5aa89c92d2) haskellPackages: regenerate package set based on current config
* [`1a1a8d25`](https://github.com/NixOS/nixpkgs/commit/1a1a8d2559b28d99086947934f33c137fd81c816) maintainers/scripts/merge-and-open-pr: fix error handling
* [`221b8aae`](https://github.com/NixOS/nixpkgs/commit/221b8aae16b27da0bde126e4b80bf5be703274af) haskellPackages: fix eval
* [`8772aa52`](https://github.com/NixOS/nixpkgs/commit/8772aa52b6fa40c73463bdd269f73325f37cb567) Revert "treewide: add bcachefsLinuxTesting and bcachefsLinuxTesting tests"
* [`10207ea9`](https://github.com/NixOS/nixpkgs/commit/10207ea9198edb55d8feb4cd491c2f2fbb5c3984) linux_testing_bcachefs: fully deprecate in favor of 'linux_testing'
* [`b86edef0`](https://github.com/NixOS/nixpkgs/commit/b86edef087c3596a08d8a8c6d82f8d5fb2043c9a) rl-2405: Note that 'linux_testing_bcachefs' is now fully deprecated and removed
* [`3f826bf8`](https://github.com/NixOS/nixpkgs/commit/3f826bf8e8f9b856fdcf704a6589851e8ad0c4a3) bcachefs-tools: 1.3.3 -> 1.3.5
* [`9598daf3`](https://github.com/NixOS/nixpkgs/commit/9598daf31aec96e4a987e2e03d68cf55ce575d0a) linux/common-config: add default bcachefs options
* [`ffed3c45`](https://github.com/NixOS/nixpkgs/commit/ffed3c458620cd3fb2d2a3ef4aaea97ff7cbea10) gremlin-console: 3.7.0 -> 3.7.1
* [`b8ffb445`](https://github.com/NixOS/nixpkgs/commit/b8ffb4453b5848c48249a110434d8d4d57cde6d9) kdbg: 3.0.1 -> 3.1.0
* [`62f9d808`](https://github.com/NixOS/nixpkgs/commit/62f9d8085d7639d08d58491f1c715d893a65d0fd) liblouis: 3.27.0 -> 3.28.0
* [`5e01074f`](https://github.com/NixOS/nixpkgs/commit/5e01074fbc056f5851190342d9bdc2bcf741fb8b) stm32cubemx: 6.9.2 -> 6.10.0
* [`7869770b`](https://github.com/NixOS/nixpkgs/commit/7869770b2381022736d03ce2a694dae81bde7a5e) rustdesk-server: 1.1.8 -> 1.1.9
* [`aa1ab6c8`](https://github.com/NixOS/nixpkgs/commit/aa1ab6c835a0f45d97fe8024b3ab3e6dbf6f4789) haskellPackages: fix eval some more
* [`88545ace`](https://github.com/NixOS/nixpkgs/commit/88545acef7881913cb4f966b2ed0c768faa7e711) haskellPackages: regenerate package set based on current config
* [`dc68acff`](https://github.com/NixOS/nixpkgs/commit/dc68acff616973e9e39b1990cb28d2cb9046ca2b) gretl: 2023b -> 2023c
* [`bf3fb8a2`](https://github.com/NixOS/nixpkgs/commit/bf3fb8a2550cc09b20cbdcc7cd73e8daca20f219) build-support/fetchpijul: Add cacert dependency and set impureEnvVars
* [`b9c45ec6`](https://github.com/NixOS/nixpkgs/commit/b9c45ec6b8f037756198e1c04588f3f4f689ce3e) build-support/fetchpijul: Enable strictDeps
* [`75cbf2f0`](https://github.com/NixOS/nixpkgs/commit/75cbf2f031338c8930bee795f5ef7a8bfabeab95) napi-rs-cli: 2.12.0 -> 2.16.5
* [`e900e763`](https://github.com/NixOS/nixpkgs/commit/e900e76327a5bfb776dcbddb98c4f1d46491a953) renderdoc: 1.29 -> 1.30
* [`0ae13741`](https://github.com/NixOS/nixpkgs/commit/0ae13741a89dc1af46a6915f0c76dddd51645ff6) agdaPackages._1lab: unstable-2023-10-11 -> unstable-2023-12-04
* [`0a686c36`](https://github.com/NixOS/nixpkgs/commit/0a686c36f166d0cd26994e31b1a451940fe79391) haskellPackages.hnix: remove obsolete patch and overrides
* [`1b23d469`](https://github.com/NixOS/nixpkgs/commit/1b23d469fa8b5bbe2c0c348f9fbf02dc4581a3b4) ser2net: 4.5.1 -> 4.6.0
* [`95374567`](https://github.com/NixOS/nixpkgs/commit/9537456726a36f45351cff630f167e1d2e76798b) shellhub-agent: 0.13.4 -> 0.13.6
* [`544e3db2`](https://github.com/NixOS/nixpkgs/commit/544e3db250b752bb590f518909a9dd9144126778) napi-rs-cli: 2.16.5 -> 2.17.0
* [`4f69429a`](https://github.com/NixOS/nixpkgs/commit/4f69429ab17b2789ad3a7716ae759b38fa5b4242) kokkos: 4.1.00 -> 4.2.00
* [`d2d5fb2a`](https://github.com/NixOS/nixpkgs/commit/d2d5fb2a87430ba9b0dcb39fa2fb1f0addb509c6) vimPlugins.vim-clap: 0.47 -> 0.49
* [`8a6c6d48`](https://github.com/NixOS/nixpkgs/commit/8a6c6d48becf9be2231f50c5d0d54308863dbb0a) uxplay: 1.66 -> 1.67
* [`80cc2994`](https://github.com/NixOS/nixpkgs/commit/80cc2994aeb043d7f44e2860b91d739e6ca7b674) vkd3d: 1.9 -> 1.10
* [`adbfc040`](https://github.com/NixOS/nixpkgs/commit/adbfc04098d022e6deb66fa59336d04b1a4fb3d7) grpc_cli: 1.59.2 -> 1.60.0
* [`07b1f271`](https://github.com/NixOS/nixpkgs/commit/07b1f2711ba63704f9f24e95f2b768f6e207f8e2) klipper-estimator: 3.5.0 -> 3.6.0
* [`af15b33d`](https://github.com/NixOS/nixpkgs/commit/af15b33dceebd0964de00833417ae3ec5915c997) swagger-codegen3: 3.0.50 -> 3.0.51
* [`b11a6912`](https://github.com/NixOS/nixpkgs/commit/b11a691235b7ee401434384bf2dffb9e2afacb5f) haskell.packages.ghc810.http-types: disable checks
* [`4e4b31df`](https://github.com/NixOS/nixpkgs/commit/4e4b31df114b5ffe1a9cc41a54855ec603e5e96a) haskell.packages.ghc90.http-types: disable checks
* [`c7fc09f6`](https://github.com/NixOS/nixpkgs/commit/c7fc09f68192e30f5f0c60bcd19c763c43079248) qgroundcontrol: 4.2.9 -> 4.3.0
* [`2af11c95`](https://github.com/NixOS/nixpkgs/commit/2af11c95df9d02027f43a7e5319d9886c971d870) weave-gitops: 0.35.0 -> 0.38.0
* [`0eb5a95d`](https://github.com/NixOS/nixpkgs/commit/0eb5a95d268eaf1f064b0f6445c8dd8085f37ad5) checkstyle: 10.12.5 -> 10.12.6
* [`d3fcf59b`](https://github.com/NixOS/nixpkgs/commit/d3fcf59b678b58cb667e17174f91e63701670479) haskellPackages.scat: unbreak
* [`67bb4284`](https://github.com/NixOS/nixpkgs/commit/67bb428465ceb3b32f33363bbfda66effb381cae) haskellPackages.selda: unbreak
* [`d65c4445`](https://github.com/NixOS/nixpkgs/commit/d65c4445a9842de6759719b131227293df1b5549) Add hardware.sane.backends-package option.
* [`50d4435a`](https://github.com/NixOS/nixpkgs/commit/50d4435a37a7ce438928b4ba2b41b12bcdca8e8f) zsh-prezto: unstable-2023-11-08 -> unstable-2023-11-30
* [`dc0fd26a`](https://github.com/NixOS/nixpkgs/commit/dc0fd26a1f6cd59a21002fe3c070a252d14d43b7) haskellPackages.hnix-store-core: move older to extraPackages
* [`a042857c`](https://github.com/NixOS/nixpkgs/commit/a042857c78eae9eca028964b68a4b6aa612ccf6c) haskellPackages.scat, haskellPackages.selda: drop hydraPlatforms = lib.platforms.none
* [`9d6713fe`](https://github.com/NixOS/nixpkgs/commit/9d6713fe82896e1ee83fa0d73d3afd598254ed2a) haskellPackages.cachix_1_3_3: remove
* [`69502d6d`](https://github.com/NixOS/nixpkgs/commit/69502d6d93726d2a758d388c4b75d2bea918d4ef) coursier: 2.1.7 -> 2.1.8
* [`8d76f5ce`](https://github.com/NixOS/nixpkgs/commit/8d76f5ce4d152e24e2790afefd71146614ef84dc) bcachefs-tools: 1.3.3 -> 1.3.5
* [`78018ef6`](https://github.com/NixOS/nixpkgs/commit/78018ef67e20c0fb142ad044258949ee59c52371) cmus: fix feature detection on darwin
* [`a514d8c1`](https://github.com/NixOS/nixpkgs/commit/a514d8c148e78d0d222689bdae55d242e0ff454e) systemd-stage-1: allow non-existent /lib/firmware
* [`1b0e9a9a`](https://github.com/NixOS/nixpkgs/commit/1b0e9a9afea0ffbe539e53c76891735d52cef0d9) mailutils: set sysconfdir to /etc
* [`e4a16eaf`](https://github.com/NixOS/nixpkgs/commit/e4a16eafc9bd86854fa83d3e2470c8ab5b88d7f7) cljfmt: 0.11.2 -> 0.12.0
* [`66ea46be`](https://github.com/NixOS/nixpkgs/commit/66ea46be076e4ea891d2c647b53701c12dae46ea) haskellPackages.rapid: remove broken flag
* [`38baa1f3`](https://github.com/NixOS/nixpkgs/commit/38baa1f3af43f967824b1b3ecfadf94717dfe2e1) agdaPackages.standard-library: 1.7.3 -> 2.0
* [`b3b5d76b`](https://github.com/NixOS/nixpkgs/commit/b3b5d76be332d79c1b077a3b25cbdf9661daee37) mpvScripts.buildLua: Expose `meta.position`
* [`2403dae1`](https://github.com/NixOS/nixpkgs/commit/2403dae1fa3125eba4bf3e8e770ae6c066cabb3c) mpvScripts.chapterskip: Add `updateScript`
* [`0f604eff`](https://github.com/NixOS/nixpkgs/commit/0f604eff4ad93ba4351ad75839f8f9c92a3ac016) mpvScripts.mpv-webm: Fix `updateScript`
* [`41099908`](https://github.com/NixOS/nixpkgs/commit/4109990857cfa65d03c9cec9622508257e8fc45a) mpvScripts.convert: Add `updateScript`
* [`4c968b42`](https://github.com/NixOS/nixpkgs/commit/4c968b42042c059d4eaaab02234fd5a90b570a2e) mpvScripts.cutter: Add `updateScript`
* [`b0a5637c`](https://github.com/NixOS/nixpkgs/commit/b0a5637c9e6e5b11d07dddb8d3e223f90e65e817) mpvScripts.inhibit-gnome: Add `updateScript`
* [`66a1cca9`](https://github.com/NixOS/nixpkgs/commit/66a1cca95284d8651ee9edf6cb9c0fd9340f6837) mpvScripts.mpris: Add `updateScript`
* [`160de305`](https://github.com/NixOS/nixpkgs/commit/160de305f5fc2e1f3fc19f7e790aedb7bd5e3ef2) mpvScripts.mpv-playlistmanager: Add `updateScript`
* [`8ada2200`](https://github.com/NixOS/nixpkgs/commit/8ada2200634781e5ad914f5448130b7a2a0b6283) mpvScripts.mpvacious: Add `updateScript`
* [`19da46d6`](https://github.com/NixOS/nixpkgs/commit/19da46d6ee6df863047d802b4291c50b8d8d0cd1) mpvScripts.quality-menu: Add `updateScript`
* [`0a30568c`](https://github.com/NixOS/nixpkgs/commit/0a30568c20cf0e7e24cdd9cdeaae6ae6d1bc78df) mpvScripts.simple-mpv-ui: Add `updateScript`
* [`76767f51`](https://github.com/NixOS/nixpkgs/commit/76767f5188ed01c8c6f7bc4b6ec3f7c56f2f747b) mpvScripts.thumbfast: Add `updateScript`
* [`d89554dc`](https://github.com/NixOS/nixpkgs/commit/d89554dc42a86d30c39041a1c06c4e326dd6a547) mpvScripts.thumbnail: Add `updateScript`
* [`0eb7e6ab`](https://github.com/NixOS/nixpkgs/commit/0eb7e6abcf125fa567a827752af928e9574f8ce8) mpvScripts.uosc: Add `updateScript`
* [`56d6e161`](https://github.com/NixOS/nixpkgs/commit/56d6e1614f775709199cadb3e3e132d4f6133558) mpvScripts.visualizer: Add `updateScript`
* [`40ef9f3b`](https://github.com/NixOS/nixpkgs/commit/40ef9f3b76adb6dc431148c341ce0b43551996e8) mpvScripts.vr-reversal: Add `updateScript`
* [`255dbfdb`](https://github.com/NixOS/nixpkgs/commit/255dbfdbe219d9197440743c5e94a7e99d4dad5d) mpvScripts.webtorrent-mpv-hook: Add `updateScript`
* [`6abfd41f`](https://github.com/NixOS/nixpkgs/commit/6abfd41fd1a4df1a042e1205b750526b7c612936) mpvScripts.sponsorblock-minimal: Add `updateScript`
* [`7ac0108f`](https://github.com/NixOS/nixpkgs/commit/7ac0108ffa944bf9e6ddbb20c5b7929ba0df2baa) haskell.packages.ghc98.haskell-language-server: Enable job
* [`54fc9f63`](https://github.com/NixOS/nixpkgs/commit/54fc9f63561a5522161600bdbe392b67a698ce59) haskell.packages.ghc9{6,8}: work around aarch64-darwin output cycles
* [`0a89a654`](https://github.com/NixOS/nixpkgs/commit/0a89a654a9162927de7e62d67e8dea5e190869fe) argo: 3.5.1 -> 3.5.2
* [`ddf2fa89`](https://github.com/NixOS/nixpkgs/commit/ddf2fa899aed56089c62e38c7898df0ccb05f221) haskellPackages.PortMidi: fix ALSA plugins load path
* [`ab382f47`](https://github.com/NixOS/nixpkgs/commit/ab382f47ef1ba99449bf6e07a31108e22871fa63) davinci-resolve: Remove address
* [`0d31c8b2`](https://github.com/NixOS/nixpkgs/commit/0d31c8b213c09d073fe8dfb3b5797e2c54fa933d) celestia: 1.6.3 -> 1.6.4
* [`8cc99ed5`](https://github.com/NixOS/nixpkgs/commit/8cc99ed5952c7bce8142bc18c757a8e11c57d9b8) bazel_7: start by copying bazel_6
* [`78dd0baf`](https://github.com/NixOS/nixpkgs/commit/78dd0bafa69c5df3643c0a0d076710281808fc02) bazel_7: init at 7.0.0-pre.20230917.3
* [`e0a1a73c`](https://github.com/NixOS/nixpkgs/commit/e0a1a73c4157e99ecdea6ca419d55aa3c37cf292) bazel_7: Simplify callBazelTest
* [`03f458b3`](https://github.com/NixOS/nixpkgs/commit/03f458b351e77aa57ec2478dfff2e091ede0acd6) bazel_7: restrict USER hack to darwin
* [`d1f60e01`](https://github.com/NixOS/nixpkgs/commit/d1f60e013bc9af231f66a013c2a467ffc9b3c123) bazel_7: split tests for clarity
* [`9b820d98`](https://github.com/NixOS/nixpkgs/commit/9b820d98a6c3de681c3deeaec83ca6f9b0341521) bazel_7: refactor and comment
* [`30cbfd47`](https://github.com/NixOS/nixpkgs/commit/30cbfd470de5879ce99e19d052b082d767418ea7) bazel_7: More refactors
* [`022befe8`](https://github.com/NixOS/nixpkgs/commit/022befe8ae00f679ee3cd991338b8acf50f9bb76) Get bazel building on all major platforms, with tests
* [`b09a7423`](https://github.com/NixOS/nixpkgs/commit/b09a742323adeb4083adbc8cdc808c956fc00090) bazel_7: Filter bzlmod dependencies by name predicate
* [`7051773c`](https://github.com/NixOS/nixpkgs/commit/7051773ca8280026a4fcee357fcaa72c4eaa28b0) bazel_7: Separate test deps (without binaries)
* [`229bce10`](https://github.com/NixOS/nixpkgs/commit/229bce1095a9563455e82d9f84241b18b2e5cf06) bazel_7: Cleanup patchPhase
* [`be69c186`](https://github.com/NixOS/nixpkgs/commit/be69c186cc672b1639004359eee94a048d10adf3) Rework repository_cache, lockfile generation, and protobuf tests as a whole
* [`622804ab`](https://github.com/NixOS/nixpkgs/commit/622804ab5d0ae449bea1dfca1e8ca3e37e671821) Add 7.0.0rc2, but some patches need an update
* [`05ecc09b`](https://github.com/NixOS/nixpkgs/commit/05ecc09b571aa5b048db33457856de837065a78d) Bump to 7.0.0rc2
* [`5151e14e`](https://github.com/NixOS/nixpkgs/commit/5151e14e2c01bc5098213c33dbd5d83f7b5d1c80) bazel_7: cleanup changes made to common tests
* [`90bfff13`](https://github.com/NixOS/nixpkgs/commit/90bfff13965d4577c43672ad04e1f96ce6bb3c60) bazel_7: cleanup changes made to common patches
* [`058102dd`](https://github.com/NixOS/nixpkgs/commit/058102dd42a16c42209707743df65dc1a4ec88e3) bazel_7: cleanup protobuf tests
* [`a4cf97e4`](https://github.com/NixOS/nixpkgs/commit/a4cf97e4156929c657987a7dfe2a1febebb0201c) bazel_7: cleanup unused files
* [`0c136866`](https://github.com/NixOS/nixpkgs/commit/0c136866975dad66cf9cc6ef796b54311a063fa6) bazel_7: rename protobuf test lockfile
* [`7dd831ba`](https://github.com/NixOS/nixpkgs/commit/7dd831bac7bf341efcd7914851ba8f0189e42d25) bazel_7: rename protobuf test lockfile, part 2
* [`207fb754`](https://github.com/NixOS/nixpkgs/commit/207fb75488d1321d96ff13ab919d37f5ec63e15a) bazel_7: darwin (sandbox) fixes
* [`4d54ca89`](https://github.com/NixOS/nixpkgs/commit/4d54ca897b34cc8870f20ad73f52bcfc0b340451) bazel_7: 7.0.0rc2 -> 7.0.0rc7
* [`306e8eaf`](https://github.com/NixOS/nixpkgs/commit/306e8eaf537440f3d28f32720b27f6288627125b) bazel_7: fix darwin compilation with CLang 16 & recent nixpkgs/master
* [`2a92a230`](https://github.com/NixOS/nixpkgs/commit/2a92a2304a7adc7d92064bc26ddef87bfb29429b) bazel_7: 7.0.0rc7 -> 7.0.0
* [`f8eaea18`](https://github.com/NixOS/nixpkgs/commit/f8eaea18b0f630e6f060d509fb166f1e923eca78) bazel_7: address most review comments
* [`5fc2602a`](https://github.com/NixOS/nixpkgs/commit/5fc2602a32e7de399443f8128451880a01af9e88) bazel_7: restore xcode_locator patch from no-arc patch
* [`6d93cdd5`](https://github.com/NixOS/nixpkgs/commit/6d93cdd566ac2d809458bae328ed5b08dd7ba91b) bazel_7: restore xcode_locator no-arc fix, still needed
* [`3b9a0d15`](https://github.com/NixOS/nixpkgs/commit/3b9a0d15276afb583467a532c6f5c64e80b5c6fa) complgen: 0.1.7 -> 0.1.8
* [`0d222a35`](https://github.com/NixOS/nixpkgs/commit/0d222a358002f6ab8c3c277eb46ed12ed33cfe40) bazel_7: re-enable arc in xcode_locator command
* [`b8d931a9`](https://github.com/NixOS/nixpkgs/commit/b8d931a91a5cf5ff0b991718b7a8a3ce0932d3b5) deck: 1.28.0 -> 1.29.2
* [`a9babd90`](https://github.com/NixOS/nixpkgs/commit/a9babd90f6b50318a406c79c022fdfc9fe2aba65) detekt: 1.23.3 -> 1.23.4
* [`a73ae4bf`](https://github.com/NixOS/nixpkgs/commit/a73ae4bf9fdf3eadcba76109b76bc5746182dbfb) nixos/guix: add Guix home support
* [`a30a2c9f`](https://github.com/NixOS/nixpkgs/commit/a30a2c9f403f53a56049f99360262055063a6988) bazel_7: fix cpp-test with bzlmod, for linux
* [`459e800b`](https://github.com/NixOS/nixpkgs/commit/459e800b0475d6804808798f67a5f58e3294a6e4) bazel_7: fix protobuf test on darwin
* [`8d95c6b8`](https://github.com/NixOS/nixpkgs/commit/8d95c6b8fa65a6cf6609e8ce961fa5a4a1b2f697) eclib: 20230424 -> 20231212
* [`3ab2c86f`](https://github.com/NixOS/nixpkgs/commit/3ab2c86f2c18e3033f960040db3346052e657f97) ent-go: 0.12.3 -> 0.12.5
* [`43b6f6d3`](https://github.com/NixOS/nixpkgs/commit/43b6f6d3c6c058ebc6e07268fc7d830f22d187cf) haskell.lib.compose.triggerRebuild: don't discard old postUnpack
* [`72758409`](https://github.com/NixOS/nixpkgs/commit/727584094927a24d314e782ae3dcee737b35221a) haskellPackages.cachix: workaround cache corruption on aarch64-linux
* [`217b470a`](https://github.com/NixOS/nixpkgs/commit/217b470a600d44a96ab91528cf8d32236671fe67) erlfmt: 1.2.0 -> 1.3.0
* [`4bdd9c1a`](https://github.com/NixOS/nixpkgs/commit/4bdd9c1ac7c29f09729d6c009e5bf47c329a3ea8) faudio: 23.11 -> 23.12
* [`51911c05`](https://github.com/NixOS/nixpkgs/commit/51911c05b3a31ec1198e36dae9168916be09a0bd) fontfor: 0.3.1 -> 0.4.1
* [`9d73fb68`](https://github.com/NixOS/nixpkgs/commit/9d73fb68cc16b9094c62de48952f30507a504f94) fuc: 1.1.9 -> 1.1.10
* [`562b64b9`](https://github.com/NixOS/nixpkgs/commit/562b64b9084749ef2ec4ef49f96baaea485cea51) frugal: 3.17.5 -> 3.17.6
* [`6505bdde`](https://github.com/NixOS/nixpkgs/commit/6505bdde29ddce76d1e870e6edd97584679ac4d3) ballerina: 2201.8.3 -> 2201.8.4
* [`db3548dc`](https://github.com/NixOS/nixpkgs/commit/db3548dcb2659e1294e61849cf37a4e50afc1dff) bambu-studio: 01.08.01.57 -> 01.08.02.56
* [`67fc0e51`](https://github.com/NixOS/nixpkgs/commit/67fc0e51da63363007fd9e0aab330b1fa3fe057e) biome: 1.4.0 -> 1.4.1
* [`5902643e`](https://github.com/NixOS/nixpkgs/commit/5902643e53f2fc0fdbabfc72431ed8cea991e519) datovka: 4.22.1 -> 4.23.1
* [`0c909de8`](https://github.com/NixOS/nixpkgs/commit/0c909de8e6aba87755f39f919b4f8edad18e5a5d) fwts: 23.07.00 -> 23.11.00
* [`ad8750a9`](https://github.com/NixOS/nixpkgs/commit/ad8750a98689c1cce1423db993d56290a56c7af1) glab: 1.35.0 -> 1.36.0
* [`548be517`](https://github.com/NixOS/nixpkgs/commit/548be5179919d0d49d24b6ecff99f03034880acd) goa: 3.13.2 -> 3.14.1
* [`d1cf538f`](https://github.com/NixOS/nixpkgs/commit/d1cf538f316f0cb18919398b4f50867de9194b5f) maintainers: add honnip
* [`3dee9902`](https://github.com/NixOS/nixpkgs/commit/3dee99022280e87a3e2490ccda6b413132c7a93b) grafana-dash-n-grab: 0.5.0 -> 0.5.1
* [`81371719`](https://github.com/NixOS/nixpkgs/commit/813717191fab0eb5727948f8bf1d7a257b859953) hayagriva: 0.5.0 -> 0.5.1
* [`f9480bd3`](https://github.com/NixOS/nixpkgs/commit/f9480bd35d7610bc352a2b7a06c60a8fb9e854dd) heimer: 4.2.0 -> 4.3.0
* [`8e16d73d`](https://github.com/NixOS/nixpkgs/commit/8e16d73dab42254b43e56373e1177941d453e647) helio-workstation: 3.11 -> 3.12
* [`37dc0d7c`](https://github.com/NixOS/nixpkgs/commit/37dc0d7cadf2c0d68b03b33fbff3d831fd295157) ibus-engines.m17n: 1.4.24 -> 1.4.27
* [`cda02a74`](https://github.com/NixOS/nixpkgs/commit/cda02a740a69397dbf2ae606f45c537b81a1211d) interactsh: 1.1.7 -> 1.1.8
* [`4eee2245`](https://github.com/NixOS/nixpkgs/commit/4eee2245481b2e18342810a98c75414efabbbe66) jbang: 0.111.0 -> 0.114.0
* [`8b737613`](https://github.com/NixOS/nixpkgs/commit/8b7376138db6c681ef3b6ec0afed10861246bc1e) jumppad: 0.5.53 -> 0.5.59
* [`083c34e3`](https://github.com/NixOS/nixpkgs/commit/083c34e30c265b231927985c0e79349a517c97fc) kak-lsp: 15.0.0 -> 15.0.1
* [`fb4f693d`](https://github.com/NixOS/nixpkgs/commit/fb4f693d5c7e142ddd3e32218065e29bb1a5a090) kconf: 1.12.0 -> 2.0.0
* [`b4245787`](https://github.com/NixOS/nixpkgs/commit/b4245787b08c495e8fa4bf1979d016097503cdd2) kio-fuse: 5.0.1 -> 5.1.0
* [`32428445`](https://github.com/NixOS/nixpkgs/commit/32428445a5088b881e821b4d31e722614847bec2) kraft: 0.7.0 -> 0.7.1
* [`2d77fcb1`](https://github.com/NixOS/nixpkgs/commit/2d77fcb17dd94adfd1cb9180de2f8aaee3af12f7) krill: 0.14.2 -> 0.14.4
* [`cadb0122`](https://github.com/NixOS/nixpkgs/commit/cadb0122ad8aa904fbd8e08b423fb338ae257c73) calicoctl: 3.26.4 -> 3.27.0
* [`5c1a9b12`](https://github.com/NixOS/nixpkgs/commit/5c1a9b12a7574be45433f43e29ceff39773d4e29) dnsdist: 1.8.2 -> 1.8.3
* [`7080623b`](https://github.com/NixOS/nixpkgs/commit/7080623b9430535ce2181f4509e2ae64797e7dbf) kubectl-gadget: 0.22.0 -> 0.23.1
* [`97049308`](https://github.com/NixOS/nixpkgs/commit/9704930820c25807b2d66517bf441f0e75937a47) kubernetes-polaris: 8.5.2 -> 8.5.3
* [`d1303fe5`](https://github.com/NixOS/nixpkgs/commit/d1303fe5a282fadb6b51f64bce5778c715a5b510) kubeseal: 0.24.4 -> 0.24.5
* [`9ae70cc5`](https://github.com/NixOS/nixpkgs/commit/9ae70cc57e6428328f1cb191a190f8b78715fafd) kuma: 2.4.3 -> 2.5.1
* [`826cca41`](https://github.com/NixOS/nixpkgs/commit/826cca412f60d81d5468ed5b57f993b645abab39) lbreakouthd: 1.1.4 -> 1.1.5
* [`364fd55a`](https://github.com/NixOS/nixpkgs/commit/364fd55a8b16be9b94314792529d479ef093431c) dool: 1.3.0 -> 1.3.1
* [`ee1febfa`](https://github.com/NixOS/nixpkgs/commit/ee1febfa0bc1366e874ac4c832a870dbab41281e) libsemanage: 3.5 -> 3.6
* [`34a8c3de`](https://github.com/NixOS/nixpkgs/commit/34a8c3dec5213079a905fc86d01b946de1c94c56) chiaki4dec: 1.4.1 -> 1.5.1
* [`79141497`](https://github.com/NixOS/nixpkgs/commit/791414974b4c50117eafbe83c1507627a0629a42) maven: 3.9.5 -> 3.9.6
* [`0fc36421`](https://github.com/NixOS/nixpkgs/commit/0fc364211d7bd79500336ac3df7bdbce5a883a38) maskromtool: 2023-09-13 -> 2023-12-07
* [`d359074c`](https://github.com/NixOS/nixpkgs/commit/d359074c85811175639a828218fdff9e1ae4250c) miller: 6.9.0 -> 6.10.0
* [`bf41850b`](https://github.com/NixOS/nixpkgs/commit/bf41850bc21b091ada1346c4a1f1e90fcabac70d) minimacy: 1.1.2 -> 1.2.0
* [`49b2c113`](https://github.com/NixOS/nixpkgs/commit/49b2c113cc54c70c1e34c163f8e081f6c75b0c95) minizinc: 2.8.0 -> 2.8.2
* [`930e3e5b`](https://github.com/NixOS/nixpkgs/commit/930e3e5be6ee955ba77bc77409644696208888ab) chromium: use llvm 17
* [`c1685afe`](https://github.com/NixOS/nixpkgs/commit/c1685afe509a3a6d8a53f243945b30335fe90044) commonsBcel: 6.7.0 -> 6.8.0
* [`c9de9069`](https://github.com/NixOS/nixpkgs/commit/c9de9069ea08d4a4b4e36a197a2d9cf8edfb26f0) aws-adfs: 2.9.0 -> 2.10.0
* [`05ed5e81`](https://github.com/NixOS/nixpkgs/commit/05ed5e8165c345e9ea36b1d565446407ca8e229c) invoiceplane: 1.6.0 -> 1.6.1
* [`91006633`](https://github.com/NixOS/nixpkgs/commit/910066333438e0d4a03a3208a50b8c8b4c0cd43f) opengrok: 1.12.23 -> 1.13.0
* [`8059adfb`](https://github.com/NixOS/nixpkgs/commit/8059adfb7b5ed8ea61546fb9e8b21484dfc09714) osv-scanner: 1.4.3 -> 1.5.0
* [`10d2bc48`](https://github.com/NixOS/nixpkgs/commit/10d2bc48679c2643e83080a5bf55734e71e48912) pachyderm: 2.8.1 -> 2.8.2
* [`cecf6fad`](https://github.com/NixOS/nixpkgs/commit/cecf6fad1ee8639155a1caee56437b8e42ddd609) passff-host: 1.2.3 -> 1.2.4
* [`737c5323`](https://github.com/NixOS/nixpkgs/commit/737c53238490d4221aac56e81a64813ce3246a9d) packer: 1.9.5 -> 1.10.0
* [`4fa6dc6a`](https://github.com/NixOS/nixpkgs/commit/4fa6dc6a4d6a1e8200a845acf3870f90c53c7325) peg: 0.1.19 -> 0.1.20
* [`2421ba70`](https://github.com/NixOS/nixpkgs/commit/2421ba701367cc64607acf82ee4d51b8b36aee55) pgpool: 4.4.5 -> 4.5.0
* [`dbacc08f`](https://github.com/NixOS/nixpkgs/commit/dbacc08f0a704c75b5440af295ebb8a7b9ccce96) libomemo-c: init at 0.5.0
* [`795f9216`](https://github.com/NixOS/nixpkgs/commit/795f9216ce47f4f24ca532ede7f33002a2763661) qxmpp: add withOmemo
* [`cc6798be`](https://github.com/NixOS/nixpkgs/commit/cc6798be1520082ae0526f5469681287510f1b6e) kaidan: 0.8.0 -> 0.9.1
* [`41035cdf`](https://github.com/NixOS/nixpkgs/commit/41035cdfeb1e3e2f68b61772a02887046fcf231d) bluemail: 1.131.4-1795 -> 1.136.21-1884
* [`6745b492`](https://github.com/NixOS/nixpkgs/commit/6745b4928fd4d0999bea3739123c376fe8b48790) pinniped: 0.27.0 -> 0.28.0
* [`e3b1b686`](https://github.com/NixOS/nixpkgs/commit/e3b1b686d6a786a66311a74b5426d324108d56ab) polypane: 16.0.0 -> 17.0.0
* [`ad6a2900`](https://github.com/NixOS/nixpkgs/commit/ad6a29000268ccc6f6eadda0eed28067a54faf40) porsmo: 0.2.0 -> 0.3.0
* [`c94cf423`](https://github.com/NixOS/nixpkgs/commit/c94cf423ae59e919a1ff64f7af3953a1bb98a186) prometheus-mongodb-exporter: 0.39.0 -> 0.40.0
* [`c2e9041e`](https://github.com/NixOS/nixpkgs/commit/c2e9041e80e747a332f4233acc6d69034d3410b0) microsoft-edge: 119.0.2151.72 -> 120.0.2210.77
* [`f958b7de`](https://github.com/NixOS/nixpkgs/commit/f958b7de9abc04a7a9ba2377ad7c4d3f7a9e9db4) pyrosimple: 2.12.0 -> 2.12.1
* [`d4525414`](https://github.com/NixOS/nixpkgs/commit/d45254140743bc0dded8c35177063868004c99da) python310Packages.aiokafka: 0.8.1 -> 0.10.0
* [`20905d33`](https://github.com/NixOS/nixpkgs/commit/20905d33b1daec724608ce3376b85b5e831646ac) python310Packages.bc-python-hcl2: 0.4.1 -> 0.4.2
* [`bf5e9ce7`](https://github.com/NixOS/nixpkgs/commit/bf5e9ce7d9a7d1409bc39f26b61417743e9f7ff7) python310Packages.bugsnag: 4.6.0 -> 4.6.1
* [`f35225d3`](https://github.com/NixOS/nixpkgs/commit/f35225d3d648e1d0b3e5d36e035d542934826e64) bazel_7: backport bazel_6 bash fixes for remote execution
* [`1795976a`](https://github.com/NixOS/nixpkgs/commit/1795976a325d1fdfee9004440cccb580ea6eaae9) bazel_7: Unse runJDK for runtime
* [`756e2f48`](https://github.com/NixOS/nixpkgs/commit/756e2f4838240f0afbdb28c929f00c966350cbf3) python310Packages.cupy: 12.2.0 -> 12.3.0
* [`69fbd8d0`](https://github.com/NixOS/nixpkgs/commit/69fbd8d01ee124fa0a17cb705372f56d2b7246e6) haskell.packages.ghc98: Add system-cxx-std-lib attribute to fix eval
* [`b0578103`](https://github.com/NixOS/nixpkgs/commit/b0578103e738a63d3ec3008d392d38ff9fc35e59) python310Packages.cx-freeze: 6.15.11 -> 6.15.12
* [`c992b3aa`](https://github.com/NixOS/nixpkgs/commit/c992b3aa92dddc13c44a0f1afcd29c33cd8422f7) python310Packages.dbt-redshift: 1.7.0 -> 1.7.1
* [`85af2227`](https://github.com/NixOS/nixpkgs/commit/85af22275d8f0852af1e31c02a0300f7a2abd7d7) python310Packages.dbt-semantic-interfaces: 0.2.2 -> 0.4.1
* [`eaa9b995`](https://github.com/NixOS/nixpkgs/commit/eaa9b995025e3b14dd359c039f68c8af3fca3d75) fixup! bazel_7: backport bazel_6 bash fixes for remote execution
* [`2a4700c4`](https://github.com/NixOS/nixpkgs/commit/2a4700c48be3c6b58e06fc31a78924fe643a6bae) bazel_7: Add regression test for empty lockfiles
* [`bfbc35e0`](https://github.com/NixOS/nixpkgs/commit/bfbc35e0d03599e8f23f9e10959cf31f8606c3f1) fixup! bazel_7: backport bazel_6 bash fixes for remote execution
* [`a092e4c7`](https://github.com/NixOS/nixpkgs/commit/a092e4c7be399ccad81a7df9aa2facde027db385) vit: 2.2.0 -> 2.3.2
* [`a66dd462`](https://github.com/NixOS/nixpkgs/commit/a66dd462a826c9248ed25f5a93a2376d39375d81) feat(workstyle,dconf,rnix-lsp,marksman,macchanger,restic): add meta.mainProgram
* [`a067fcce`](https://github.com/NixOS/nixpkgs/commit/a067fcceadbc5d9dcc97d684e7641dba933c2165) commonsLang: 3.13.0 -> 3.14.0
* [`9f773af3`](https://github.com/NixOS/nixpkgs/commit/9f773af306f83afb9ee8988c538094b7f448d54b) imgcat: 2.5.2 -> 2.6.0
* [`1a933830`](https://github.com/NixOS/nixpkgs/commit/1a93383024e77ba5da00dcb15a61ddf49cd7577a) python310Packages.cx-freeze: update postPatch section
* [`07c30835`](https://github.com/NixOS/nixpkgs/commit/07c30835e14367d32c24ba3c39793fba46aac1d8) haskellPackages: update dhall and related packages
* [`cd7ea422`](https://github.com/NixOS/nixpkgs/commit/cd7ea4221b4537ed51ce57bdc84a059b9b71d73a) python310Packages.eccodes: 2.32.1 -> 2.33.0
* [`71554176`](https://github.com/NixOS/nixpkgs/commit/71554176c52d986fd02bac7980bb3b75b5d3d24c) python310Packages.dbt-core: 1.6.2 -> 1.7.4
* [`6ceee903`](https://github.com/NixOS/nixpkgs/commit/6ceee903e3d02ea0721ee0f42aef71a5f320606b) python310Packages.dbt-semantic-interfaces: 0.4.1 -> 0.4.2
* [`6ac9b874`](https://github.com/NixOS/nixpkgs/commit/6ac9b874e678ae5601f2b9fd62cece837f9f8682) annotator: init at 1.2.1
* [`477e7d6b`](https://github.com/NixOS/nixpkgs/commit/477e7d6b60e817661632ff3a8aaf2e39c4cceadc) chromium: drop inactive maintainers
* [`ff1380cb`](https://github.com/NixOS/nixpkgs/commit/ff1380cb3a936bc84d04059ca842af957f3ab513) CODEOWNERS: init chromium
* [`5a098d2c`](https://github.com/NixOS/nixpkgs/commit/5a098d2cb6db1815c62f76fdf6a159c121f3225a) haskellPackages.hopengpg-tools: Unmark broken
* [`2e1b1d11`](https://github.com/NixOS/nixpkgs/commit/2e1b1d11d9bc0993f153976c81edad74a9029809) emscripten: 3.1.50 -> 3.1.51
* [`ba20f7d5`](https://github.com/NixOS/nixpkgs/commit/ba20f7d5876d7286ba466aa4461c0e0cd76ed958) appflowy: add desktop icon
* [`2f4e02cf`](https://github.com/NixOS/nixpkgs/commit/2f4e02cfd338e7222b0944dc7c0f829b4c65ef46) python310Packages.guessit: 3.7.1 -> 3.8.0
* [`761476f1`](https://github.com/NixOS/nixpkgs/commit/761476f10e89fe0de5b714917fb5cb5e4a8ab87a) read-it-later: init at 0.5.0
* [`04ae918f`](https://github.com/NixOS/nixpkgs/commit/04ae918fb585b98dba903de1dea0785f67c9b0d8) i2p: 2.3.0 -> 2.4.0
* [`e40cad49`](https://github.com/NixOS/nixpkgs/commit/e40cad49c4340ede3f01f548a1c1c9d43ca53549) flannel: 0.23.0 -> 0.24.0
* [`21acd3b7`](https://github.com/NixOS/nixpkgs/commit/21acd3b7875379b642ae075b8c122f3c0bbe24cf) haskell.packages.*.{terminfo,xhtml}: allow builds on Hydra for cross
* [`bd167334`](https://github.com/NixOS/nixpkgs/commit/bd16733467dee0b515fc0c0f8a56b9d548fc132c) release-haskell.nix: add missing ghc948 jobs
* [`3d2fdba8`](https://github.com/NixOS/nixpkgs/commit/3d2fdba896fd532fc7d6a4b13e3e5c10873c8af2) pkgsCross.*.haskell.packages.ghc96.terminfo: fix evaluation
* [`8b4558e2`](https://github.com/NixOS/nixpkgs/commit/8b4558e28b14572b9544d93b3fc6c3a1241c94bf) release-haskell.nix: bump pkgsStatic testing from ghc928 to ghc948
* [`ce5cbc44`](https://github.com/NixOS/nixpkgs/commit/ce5cbc446589d0d94629c56be31a52e3a63bd182) haskell.packages.{ghc96,ghc98}: disable haddock for cross
* [`04feff05`](https://github.com/NixOS/nixpkgs/commit/04feff05630de355b5a1931e5862c6d18e65f5ae) odpic: 5.0.1 -> 5.1.0
* [`9db17e1f`](https://github.com/NixOS/nixpkgs/commit/9db17e1fe07532287bdd5cdbaf0e619299d5645f) pacemaker: 2.1.6 -> 2.1.7
* [`9067af4f`](https://github.com/NixOS/nixpkgs/commit/9067af4fb42166ebb2c06ec1cc9f044c83f4ce94) haskell.compiler: drop all ghcs without an stackage LTS snapshot
* [`e896d283`](https://github.com/NixOS/nixpkgs/commit/e896d283ee3c3402e2ce7e4d95da1d0e9740cdac) pdsh: 2.34 -> 2.35
* [`a3c19972`](https://github.com/NixOS/nixpkgs/commit/a3c199721561d0bfb03c72ee9b5d2120bd46ea1e) nixos/firefox: disable updates when policies when programs.firefox.policies is defined
* [`7998143a`](https://github.com/NixOS/nixpkgs/commit/7998143a43ae0ab51eed75e92851446daddc7966) haskell.compiler: also build manual for cross-compilers
* [`b7ece537`](https://github.com/NixOS/nixpkgs/commit/b7ece537bb396412f9980b4fba62d6d13014cc6d) nixos/guix: fix conditional linking of profiles
* [`3b51d3ea`](https://github.com/NixOS/nixpkgs/commit/3b51d3ea335eadde2d190092bf26efdc6ebc46e8) python310Packages.logilab-common: 1.11.0 -> 2.0.0
* [`9570c2a2`](https://github.com/NixOS/nixpkgs/commit/9570c2a2f31cea20efe53edd14f42436df0999bd) python310Packages.logilab-constraint: 0.6.2 -> 0.7.1
* [`65009b06`](https://github.com/NixOS/nixpkgs/commit/65009b0607236d96605736b6c6b5456544d7e22e) chiaki4deck: add psn-account-id script to output
* [`045b4f72`](https://github.com/NixOS/nixpkgs/commit/045b4f7276e36826a9030abe2bed85d8c65d2a19) nixseparatedebuginfod: init at 0.3.2
* [`0b311f43`](https://github.com/NixOS/nixpkgs/commit/0b311f4328f63b77096e3e4e87a4dbe191ad29e8) libnvme: 1.6 -> 1.7.1
* [`17d6a386`](https://github.com/NixOS/nixpkgs/commit/17d6a38665e5fc9ed3c1cd54f9b8dce9cff1bd86) nvme-cli: 2.6 -> 2.7
* [`840971dd`](https://github.com/NixOS/nixpkgs/commit/840971dd0b1d0b7838c3ddb43da4408773de374a) go-migrate: 4.16.2 -> 4.17.0
* [`74ba4334`](https://github.com/NixOS/nixpkgs/commit/74ba433414093fde23c5e46a6712d5af61cc6914) kics: 1.7.11 -> 1.7.12
* [`6c8b42cc`](https://github.com/NixOS/nixpkgs/commit/6c8b42cc9464cfacf93305714a510888609fd869) modem-manager-gui: use `finalAttrs` pattern
* [`eff4440d`](https://github.com/NixOS/nixpkgs/commit/eff4440d59de63e8c774ad7f01961ed1baec4f3a) modem-manager-gui: swapped `sha256` -> `hash`
* [`8c844e69`](https://github.com/NixOS/nixpkgs/commit/8c844e6964bbbd98fc03d4585be1fe277ff3817b) modem-manager-gui: fixed revision download
* [`5d81c1fa`](https://github.com/NixOS/nixpkgs/commit/5d81c1faa84b84618715de87be071631b9635707) bind: 9.18.20 -> 9.18.21
* [`a5961670`](https://github.com/NixOS/nixpkgs/commit/a596167020d731658d02ac71743fdb78ac8dbe91) xyce: 7.7.0 -> 7.8.0
* [`9b2d4d2f`](https://github.com/NixOS/nixpkgs/commit/9b2d4d2faa875d91f76d77a9193ff7a840f263e7) snakemake-interface-common: init at 1.15.0
* [`91902787`](https://github.com/NixOS/nixpkgs/commit/919027873867dfe443e0813c16e0f4ac8c7a538a) snakemake-interface-executor-plugins: init at 8.1.3
* [`39ee2523`](https://github.com/NixOS/nixpkgs/commit/39ee2523bf5f5364e4482b8018f39e41bc5eafcc) snakemake-interface-storage-plugins: init at 3.0.0
* [`7a20ed69`](https://github.com/NixOS/nixpkgs/commit/7a20ed69c0b69d6059f5257dd89f74ac98af7738) snakemake-executor-plugin-cluster-generic: init at 1.0.7
* [`7ff81781`](https://github.com/NixOS/nixpkgs/commit/7ff81781f2db594e5f1dedd6467b9be4ecfc2de2) snakemake: 7.32.4 -> 8.0.1
* [`5a8c65e1`](https://github.com/NixOS/nixpkgs/commit/5a8c65e118c36697efb1fcec3093d915dd68a8ff) rustPlatform.importCargoLock: fix workspace_root detection
* [`6afc8c26`](https://github.com/NixOS/nixpkgs/commit/6afc8c26753f5b8219fe97d6a0c7f65af08102e8) lldb_14: fix broken bindings again
* [`31e9d5b1`](https://github.com/NixOS/nixpkgs/commit/31e9d5b15abbb947b8e562e5665d3e73b053b3de) asciidoctorj: 2.5.10 -> 2.5.11
* [`a8464acc`](https://github.com/NixOS/nixpkgs/commit/a8464accca62c00b3dc6ea69e6a206577c98b78f) darktable: 4.4.2 -> 4.6.0
* [`1545ace6`](https://github.com/NixOS/nixpkgs/commit/1545ace6349b38177e82c5d04f0e1038faf52361) mpd: 0.23.14 -> 0.23.15
* [`3c452161`](https://github.com/NixOS/nixpkgs/commit/3c452161193c93a7f4dadd10fe964acbe5a9d750) clickgen: 2.1.9 -> 2.2.0
* [`189be7da`](https://github.com/NixOS/nixpkgs/commit/189be7da7e1e0e18eb5484ca5af8110a25ad4ef4) mermaid-filter: 1.4.6 -> 1.4.7
* [`9ae3e2e2`](https://github.com/NixOS/nixpkgs/commit/9ae3e2e2457f34f5f8dd37c0a92ade2b3029f38b) python310Packages.python-lsp-black: 1.3.0 -> 2.0.0
* [`a6e59fff`](https://github.com/NixOS/nixpkgs/commit/a6e59fff33ebb2556633db4ef17150f848dfdbbd) haskellPackages.warp: enable tests and fix eval error
* [`659d9f62`](https://github.com/NixOS/nixpkgs/commit/659d9f626dc3c3f90f2906564b8f129680cdd629) python310Packages.qtawesome: 1.2.3 -> 1.3.0
* [`b8c84438`](https://github.com/NixOS/nixpkgs/commit/b8c844388038c1ab24cf61fc26cf7751f206101d) python310Packages.quantities: 0.14.1 -> 0.15.0
* [`abda3d04`](https://github.com/NixOS/nixpkgs/commit/abda3d04e4f7591a9651a22022f94d58c5aa6b91) python310Packages.r2pipe: 1.8.2 -> 1.8.4
* [`04a4f1f8`](https://github.com/NixOS/nixpkgs/commit/04a4f1f8a5e1fb3040912f1b3c6e05020d2542c7) git-annex: bump hash
* [`af6bb9cd`](https://github.com/NixOS/nixpkgs/commit/af6bb9cd99318cdee995f0d66646efba1ec4e9c1) python310Packages.semaphore-bot: 0.16.0 -> 0.17.0
* [`a3187b02`](https://github.com/NixOS/nixpkgs/commit/a3187b0235090ee58f7b9317172107e203872e1b) python310Packages.skl2onnx: 1.15.0 -> 1.16.0
* [`66fde3cb`](https://github.com/NixOS/nixpkgs/commit/66fde3cbe030105aee427e5daa27a5f77a90ee75) python310Packages.snowflake-connector-python: 3.5.0 -> 3.6.0
* [`501f5f28`](https://github.com/NixOS/nixpkgs/commit/501f5f28b9b57e6eec705f1c42932dc5961c568a) python310Packages.python-lsp-black: refactor
* [`5c573fdd`](https://github.com/NixOS/nixpkgs/commit/5c573fdd60804b060117112974296ec9e960b614) python310Packages.stanza: 1.6.1 -> 1.7.0
* [`228c2083`](https://github.com/NixOS/nixpkgs/commit/228c2083694b0fcad91efa6484963d1295e99829) python310Packages.stripe: 7.7.0 -> 7.10.0
* [`2d6fdbc7`](https://github.com/NixOS/nixpkgs/commit/2d6fdbc76488fb21fc22e653966cb8f6d24f4132) python310Packages.thinc: 8.2.1 -> 8.2.2
* [`9e49f37e`](https://github.com/NixOS/nixpkgs/commit/9e49f37e6c34517b6cab30b69e5c55051eefe3e7) python310Packages.trainer: 0.0.32 -> 0.0.36
* [`eb84f264`](https://github.com/NixOS/nixpkgs/commit/eb84f26482f7dd6054233cf48ff6beb215686748) delly: 1.1.8 -> 1.2.6
* [`3cad12f6`](https://github.com/NixOS/nixpkgs/commit/3cad12f665f6b9afb18ea0e96ca3652fc6a98077) fluent-bit: 2.2.0 -> 2.2.1
* [`e942ceb6`](https://github.com/NixOS/nixpkgs/commit/e942ceb6906b30869fc975bb900bd6955784358d) leptosfmt: 0.1.17 -> 0.1.18
* [`c81e8857`](https://github.com/NixOS/nixpkgs/commit/c81e8857f03c0237b869a9e1f804c241064f1d6b) openapi-generator-cli: 7.1.0 -> 7.2.0
* [`0b936e0c`](https://github.com/NixOS/nixpkgs/commit/0b936e0c5b96f84213da7798f787344db7751a3b) protoc-gen-go: 1.31.0 -> 1.32.0
* [`13fb6b70`](https://github.com/NixOS/nixpkgs/commit/13fb6b70df91d1655935257b862dccf820757820) python310Packages.vertica-python: 1.3.7 -> 1.3.8
* [`c41ccd9e`](https://github.com/NixOS/nixpkgs/commit/c41ccd9ea58fbd42f94b210fffdd6133da49070b) nvidia-texture-tools: refactor
* [`96e6782e`](https://github.com/NixOS/nixpkgs/commit/96e6782e874deb25afddb6f92ba2e6e9ab60f09c) nvidia-texture-tools: migrate to by-name
* [`5915032d`](https://github.com/NixOS/nixpkgs/commit/5915032da4954f2d32035a3c1063fd8d961c2b2c) python310Packages.weasyprint: 60.1 -> 60.2
* [`c1a504fb`](https://github.com/NixOS/nixpkgs/commit/c1a504fbdb0fbee5d6f3fb3a73830b30d818e287) soci: fix darwin build
* [`df7d405e`](https://github.com/NixOS/nixpkgs/commit/df7d405e0d22e7880579d5734f44b9cdcbb05914) python310Packages.xml2rfc: 3.18.2 -> 3.19.0
* [`34031ce8`](https://github.com/NixOS/nixpkgs/commit/34031ce8f5b6ebd03447c2515243789d8a1fde17) qdrant: 1.6.1 -> 1.7.3
* [`aaba03dc`](https://github.com/NixOS/nixpkgs/commit/aaba03dc411d7ac1258c520619461430a6940f45) rabbitmq-server: 3.12.8 -> 3.12.11
* [`1f3487ff`](https://github.com/NixOS/nixpkgs/commit/1f3487ffbdb27b198db2c045292a642552de3906) rauc: 1.10.1 -> 1.11
* [`116a281c`](https://github.com/NixOS/nixpkgs/commit/116a281c137bd1fcdbea5c5d71f63357664ba61e) reaper: 7.06 -> 7.07
* [`06756b12`](https://github.com/NixOS/nixpkgs/commit/06756b129bc759fea8d3efda7d2e93504f2588a8) reveal-md: 5.5.1 -> 5.5.2
* [`945e1105`](https://github.com/NixOS/nixpkgs/commit/945e1105ef42f409dd2303198dd74e168875bd95) rke: 1.4.11 -> 1.5.1
* [`219d8874`](https://github.com/NixOS/nixpkgs/commit/219d8874ba45be82807a8ab8d73b68eecda2d8d4) runme: 2.0.5 -> 2.0.6
* [`32641332`](https://github.com/NixOS/nixpkgs/commit/32641332e96bca52efe9f6f5a7d1c0d57f54290c) schemacrawler: 16.20.5 -> 16.20.7
* [`4b323b9a`](https://github.com/NixOS/nixpkgs/commit/4b323b9a28b5e46dc695e4726d61ae060dfbc53b) sdrangel: 7.17.1 -> 7.17.2
* [`027f7996`](https://github.com/NixOS/nixpkgs/commit/027f79960cb24e472ade5b656ec39d1d5639b948) semodule-utils: 3.5 -> 3.6
* [`4ac3c725`](https://github.com/NixOS/nixpkgs/commit/4ac3c725bc4780f1810687db7c111bd5144b5ac5) sentry-cli: 2.21.2 -> 2.23.1
* [`4c50cbdd`](https://github.com/NixOS/nixpkgs/commit/4c50cbdd40b41e2286831ae7199da920bdfaf143) shaarli: 0.12.2 -> 0.13.0
* [`b211a4f7`](https://github.com/NixOS/nixpkgs/commit/b211a4f74d712717a95e8aacf27e4bf367726e5c) shards: 0.17.3 -> 0.17.4
* [`53d74984`](https://github.com/NixOS/nixpkgs/commit/53d74984fc3ce2dd4a27b18ca4771510120af40a) shell_gpt: 0.9.4 -> 1.0.1
* [`b0e580bf`](https://github.com/NixOS/nixpkgs/commit/b0e580bfc4ec59a093d8772b35ac8094bfa5a102) signal-desktop: 6.42.0 -> 6.42.1
* [`be81ec42`](https://github.com/NixOS/nixpkgs/commit/be81ec42202e34a6d1217f467868d05f4e7925b0) snabb: 2023.06 -> 2023.10
* [`50fab0ba`](https://github.com/NixOS/nixpkgs/commit/50fab0ba43d4312e7a824fc3b5cb30c161bb3032) soft-serve: 0.7.3 -> 0.7.4
* [`359e45e0`](https://github.com/NixOS/nixpkgs/commit/359e45e03d04b325345c9dea778a8a7ff0bee205) snyk: 1.1248.0 -> 1.1266.0
* [`890fd1b4`](https://github.com/NixOS/nixpkgs/commit/890fd1b438ef235e8e1abd957914bb8f3abf4efd) sogo: 5.9.0 -> 5.9.1
* [`5b7ab695`](https://github.com/NixOS/nixpkgs/commit/5b7ab69570996025ad5b52500398556994ac3803) sov: 0.93 -> 0.94
* [`769b8d7e`](https://github.com/NixOS/nixpkgs/commit/769b8d7efc518a509cb7dddad7557ee6baa1dd55) monitoring-plugins: 2.3.0 -> 2.3.5
* [`65182e9a`](https://github.com/NixOS/nixpkgs/commit/65182e9a232d9627e754e87e39a5db170dbb0fa7) spicedb-zed: 0.15.0 -> 0.15.2
* [`db4a437e`](https://github.com/NixOS/nixpkgs/commit/db4a437ef308ee1c695db9232df539a0c332bf53) ssdfs-utils: 4.35 -> 4.37
* [`7b1c735a`](https://github.com/NixOS/nixpkgs/commit/7b1c735aaa999a263e048d243407515033ede291) ssh-to-pgp: 1.1.0 -> 1.1.2
* [`2f1fdb5b`](https://github.com/NixOS/nixpkgs/commit/2f1fdb5bb7cc212e266d797e8f941381c6ed2e36) ssm-session-manager-plugin: 1.2.497.0 -> 1.2.536.0
* [`f7d9499f`](https://github.com/NixOS/nixpkgs/commit/f7d9499f5466ca84096863358eb84e3aa8b6fe71) steampipe: 0.21.1 -> 0.21.2
* [`e4ef1c87`](https://github.com/NixOS/nixpkgs/commit/e4ef1c87cc55d1318990056be5646a7ac9731df6) labwc: 0.6.6 -> 0.7.0
* [`5496357b`](https://github.com/NixOS/nixpkgs/commit/5496357ba4b05b66625fc41b900e7f5ee4839548) stress-ng: 0.17.02 -> 0.17.03
* [`237a4e05`](https://github.com/NixOS/nixpkgs/commit/237a4e056b637bd615605a91e2347925e33d2fc9) strongswan: 5.9.12 -> 5.9.13
* [`a1dae0c1`](https://github.com/NixOS/nixpkgs/commit/a1dae0c1157b3742fc8c3a50ea2ee4f0f76bee85) subxt: 0.31.0 -> 0.33.0
* [`bb8baee0`](https://github.com/NixOS/nixpkgs/commit/bb8baee03039239f3644fcf924642e7983c83e58) sudo-font: 0.77 -> 0.80
* [`058a469e`](https://github.com/NixOS/nixpkgs/commit/058a469e80833ecd51fb3c6f77344f92a789b16e) sundials: 6.6.1 -> 6.7.0
* [`bd067eab`](https://github.com/NixOS/nixpkgs/commit/bd067eabe53ea0a1a030a8cc50a618b4f6cb9654) enyo-launcher: 2.0.5 -> 2.0.6
* [`d5a6a6c7`](https://github.com/NixOS/nixpkgs/commit/d5a6a6c73701fcd041fa73f2b7abdbd7e7000647) genymotion: 3.5.1 -> 3.6.0
* [`4c395aa8`](https://github.com/NixOS/nixpkgs/commit/4c395aa8e3a01333b7250ddf1b02bcaed05388bd) agdaPackages.functional-linear-algebra: 0.4.1 -> 0.5.0
* [`63574be9`](https://github.com/NixOS/nixpkgs/commit/63574be95cfa08065f8d8a43c416e7da78cb3dc9) ghidra: 10.4 -> 11.0
* [`bc2205c9`](https://github.com/NixOS/nixpkgs/commit/bc2205c9e51129da88e9e57105b420123507ba90) rethinkdb: 2.4.3 -> 2.4.4
* [`2fbcfd12`](https://github.com/NixOS/nixpkgs/commit/2fbcfd125e30c9a9c6b0d4e4328d7afecf4a8493) rsyslog: 8.2310.0 -> 8.2312.0
* [`f6db7849`](https://github.com/NixOS/nixpkgs/commit/f6db7849a79bbb6b4d5fb5d8a6242b6d07dbed8c) skypeforlinux: 8.108.0.205 -> 8.110.76.107
* [`26c2ed1c`](https://github.com/NixOS/nixpkgs/commit/26c2ed1c95f3967de6c3c217b8b13a31b187b16e) nixos/tailscale: fix after and wants
* [`f886a0cb`](https://github.com/NixOS/nixpkgs/commit/f886a0cb6b5a2cad1dbf5273920a5b097f2bbe97) symengine: 0.11.1 -> 0.11.2
* [`c61b5dd5`](https://github.com/NixOS/nixpkgs/commit/c61b5dd5b01615f85f269f7c9dab28277498ea0d) syncthing: 1.26.1 -> 1.27.1
* [`49ca66cb`](https://github.com/NixOS/nixpkgs/commit/49ca66cb576c47dddc0053b5601141dc6035f6f5) syncthing-discovery: 1.26.1 -> 1.27.1
* [`17c234b9`](https://github.com/NixOS/nixpkgs/commit/17c234b96c2de3519ecbce7bd5e3213e75da9c27) tempo: 2.3.0 -> 2.3.1
* [`2fc02c08`](https://github.com/NixOS/nixpkgs/commit/2fc02c0831e07ad464f9a304dfc147be3f0f21eb) slurm: 23.02.7.1 -> 23.11.0.1
* [`db1a65b4`](https://github.com/NixOS/nixpkgs/commit/db1a65b4ef0fd20997acc4b266d15167d5c059a0) timeular: 6.6.0 -> 6.6.5
* [`861d7a7f`](https://github.com/NixOS/nixpkgs/commit/861d7a7f34b7b9c9552f78ca5622bfa4b9d1bde4) topicctl: 1.11.0 -> 1.12.0
* [`09986411`](https://github.com/NixOS/nixpkgs/commit/0998641159f86503713812d847d42e7300908990) slurm-spank-stunnel: add patch for slurm-23.11
* [`d272adb1`](https://github.com/NixOS/nixpkgs/commit/d272adb1b89b0eb1caa81a7f8a01ba6d35deee3f) slurm-spank-x11: add patch for slurm-23.11
* [`5c023641`](https://github.com/NixOS/nixpkgs/commit/5c023641e966a26614604c1df92910b46b9fa2a2) slurm-spank-stunnel: use getDev
* [`8df32609`](https://github.com/NixOS/nixpkgs/commit/8df326098bacf6f1c4e10be48f959a7d0d6657dd) slurm-spank-x11: use getDev
* [`cd8d1e47`](https://github.com/NixOS/nixpkgs/commit/cd8d1e473fdf5b61279518d5eb23c5c33cf26d6b) trinsic-cli: 1.12.0 -> 1.13.0
* [`b6e3827d`](https://github.com/NixOS/nixpkgs/commit/b6e3827d1f07f4bdf1ad5151b884ef2f24eaec2d) trunk: 0.18.0 -> 0.18.3
* [`3a8a9f60`](https://github.com/NixOS/nixpkgs/commit/3a8a9f60fbdd497f106822c7e5915b5f686d0992) tui-journal: 0.5.1 -> 0.6.0
* [`a2fcf95c`](https://github.com/NixOS/nixpkgs/commit/a2fcf95c2db63d53852f1afc5eb0b2b8c93f0d9c) turtle-build: 0.4.7 -> 0.4.8
* [`1c32f80b`](https://github.com/NixOS/nixpkgs/commit/1c32f80b883e1b566ccd4dd8e4d8210ce3a09811) slurm: use getDev
* [`ce94dee4`](https://github.com/NixOS/nixpkgs/commit/ce94dee42884831c78d655ac99bcedb98c1088de) twitch-cli: 1.1.21 -> 1.1.22
* [`f4bab691`](https://github.com/NixOS/nixpkgs/commit/f4bab69135ff404554d00f1e5b0520f4bcac0d82) parallel: 20231122 -> 20231222
* [`55bfe3a9`](https://github.com/NixOS/nixpkgs/commit/55bfe3a9a91e9f0f6d910cf0c154e4553fbf3ce4) gfold: 4.4.0 -> 4.4.1
* [`9d7a314a`](https://github.com/NixOS/nixpkgs/commit/9d7a314a3b5fd445a159a015233b54e93146f657) python311Packages.pytest-qt: 4.2.0 -> 4.3.1
* [`8811ed98`](https://github.com/NixOS/nixpkgs/commit/8811ed9838f695a3f981acb4c58340e6a1ed7efc) publii: 0.44.1 -> 0.44.2
* [`2d99466b`](https://github.com/NixOS/nixpkgs/commit/2d99466bcf568fd322ec03af67a14f41904c1789) ultrastardx: 2023.11.0 -> 2023.12.0
* [`cf88e0be`](https://github.com/NixOS/nixpkgs/commit/cf88e0bef25084874601c50d4d30e55afa599a7a) unpoller: 2.9.2 -> 2.9.5
* [`4190e432`](https://github.com/NixOS/nixpkgs/commit/4190e4322bba2ccf2dcde76ad8c5d054bd298cea) uptime-kuma: 1.23.7 -> 1.23.10
* [`e4b593b3`](https://github.com/NixOS/nixpkgs/commit/e4b593b386fbb7e3e902e0db675018c7c97034c9) regclient: 0.5.5 -> 0.5.6
* [`33f3e3f9`](https://github.com/NixOS/nixpkgs/commit/33f3e3f9d758b70d232eb8a0185bfa5affc90d1d) utf8cpp: 4.0.3 -> 4.0.4
* [`f2e94c25`](https://github.com/NixOS/nixpkgs/commit/f2e94c25e54cfe4b2dbfaf2b051a63f5c667dfe8) valeronoi: 0.2.0 -> 0.2.1
* [`f9fd996e`](https://github.com/NixOS/nixpkgs/commit/f9fd996e280c1234906b60d446fd14f2956148bc) valijson: 1.0.1 -> 1.0.2
* [`b04ea3d1`](https://github.com/NixOS/nixpkgs/commit/b04ea3d1f372f2c15dc55f49e4b1ee61f832d0cf) vassal: 3.7.5 -> 3.7.6
* [`4dca06e7`](https://github.com/NixOS/nixpkgs/commit/4dca06e708172a7f8da1f65c2b7c5c4d8228f6d2) vault: 1.14.8 -> 1.15.4
* [`ea8ce3d4`](https://github.com/NixOS/nixpkgs/commit/ea8ce3d403edb13a5b90109cdc767f2529b0c0e1) vcg: 2022.02 -> 2023.12
* [`d0a4cc81`](https://github.com/NixOS/nixpkgs/commit/d0a4cc818cbf6b3df68d0058c950a0c84c8d455b) victoriametrics: 1.93.7 -> 1.96.0
* [`0b1884bf`](https://github.com/NixOS/nixpkgs/commit/0b1884bfbf21b35cda226fe6ecc00b0057a2abca) vitess: 17.0.3 -> 18.0.2
* [`45379b7f`](https://github.com/NixOS/nixpkgs/commit/45379b7fd5b0f5a0502b00001d09d3945541a12e) vmagent: 1.93.6 -> 1.96.0
* [`a3f1d604`](https://github.com/NixOS/nixpkgs/commit/a3f1d604fa416efbafea1ee311f55f3f36e40345) wasabiwallet: 2.0.4 -> 2.0.5
* [`789a05e8`](https://github.com/NixOS/nixpkgs/commit/789a05e8e43c358290978d0e857e02ce12ebb6f7) wazero: 1.5.0 -> 1.6.0
* [`4501d7cd`](https://github.com/NixOS/nixpkgs/commit/4501d7cd726d9be449499091d1e2fe1f85a4a161) wcslib: 8.1 -> 8.2.2
* [`35a0a657`](https://github.com/NixOS/nixpkgs/commit/35a0a6578671d6633e1acc6d57807333487c7c96) wit-bindgen: 0.14.0 -> 0.16.0
* [`cb97f8a6`](https://github.com/NixOS/nixpkgs/commit/cb97f8a696dedcb018fa0fddaafc49e2eb968274) wxsqlite3: 4.9.6 -> 4.9.8
* [`038d0025`](https://github.com/NixOS/nixpkgs/commit/038d0025b7499d21de59a145c883a85ad8e278d0) xc: 0.6.0 -> 0.7.0
* [`dada0b27`](https://github.com/NixOS/nixpkgs/commit/dada0b27f41c4a5ab055b5c2c6df6d3e36a5d6b4) xcp: 0.12.1 -> 0.16.0
* [`966546ec`](https://github.com/NixOS/nixpkgs/commit/966546ec3757dc0a6bccc7265f6a8947f5ebcd43) xtl: 0.7.5 -> 0.7.7
* [`d4b1547a`](https://github.com/NixOS/nixpkgs/commit/d4b1547ad925447acc4ff17e68857016305fa19c) yoshimi: 2.3.1 -> 2.3.1.3
* [`785dfe25`](https://github.com/NixOS/nixpkgs/commit/785dfe253cbfaa678654a63dd0a86fb76ef6018a) youki: 0.3.0 -> 0.3.1
* [`51cd4182`](https://github.com/NixOS/nixpkgs/commit/51cd418220c1d5783dcc66a4bbbac49816117048) zarf: 0.31.0 -> 0.32.0
* [`d7fde7c4`](https://github.com/NixOS/nixpkgs/commit/d7fde7c4d0800681f6f29fe6bbce65dcde85f563) zed: 1.11.0 -> 1.12.0
* [`c6548ac0`](https://github.com/NixOS/nixpkgs/commit/c6548ac0a58da56f09aecd9b0f74520162e507c0) zwave-js-server: 1.33.0 -> 1.34.0
* [`deea0644`](https://github.com/NixOS/nixpkgs/commit/deea0644ac98665bbf910fdd47f9a2cbb1112baf) aspectj: 1.9.20.1 -> 1.9.21
* [`0b927023`](https://github.com/NixOS/nixpkgs/commit/0b927023711a020faae86c1f728c0230864482d7) asterisk: 20.5.1 -> 20.5.2
* [`b4231790`](https://github.com/NixOS/nixpkgs/commit/b42317907737990d36dc72bdbec1043409e25f4b) bazel-gazelle: 0.33.0 -> 0.35.0
* [`d87f2aac`](https://github.com/NixOS/nixpkgs/commit/d87f2aac2dde3906a00d7e239347c536e05ea3c5) brev-cli: 0.6.264 -> 0.6.267
* [`f40210f7`](https://github.com/NixOS/nixpkgs/commit/f40210f7053584e55d10239eda0a4bf275d81bdf) chezmoi: 2.41.0 -> 2.42.3
* [`8ea530aa`](https://github.com/NixOS/nixpkgs/commit/8ea530aa97ae9ff8a80e7e2908c38fc4c27b5246) circleci-cli: 0.1.29314 -> 0.1.29658
* [`ace8acc5`](https://github.com/NixOS/nixpkgs/commit/ace8acc5cb4fc5514c7b65d90c6ea54e77c56b37) clickhouse-backup: 2.4.2 -> 2.4.14
* [`c7dd2275`](https://github.com/NixOS/nixpkgs/commit/c7dd2275a694a2fc9e1870fde963322821fc620c) codeql: 2.15.4 -> 2.15.5
* [`25719b53`](https://github.com/NixOS/nixpkgs/commit/25719b53c02258948671ce417f307a6dd86da44d) ctlptl: 0.8.24 -> 0.8.25
* [`da9fac84`](https://github.com/NixOS/nixpkgs/commit/da9fac8430c145c1ffcad3b3c0be2d3fe8365e51) antora: 3.1.3 -> 3.1.5
* [`6e1a491d`](https://github.com/NixOS/nixpkgs/commit/6e1a491d5e5f62c0752f90a38ebd803cb0b7aae5) darklua: 0.11.1 -> 0.12.1
* [`d98fe218`](https://github.com/NixOS/nixpkgs/commit/d98fe2184dc30bed92263959607718844b4f3325) ckan: 1.33.2 -> 1.34.2
* [`3e74698d`](https://github.com/NixOS/nixpkgs/commit/3e74698d4d976d9517ee695841894b38dc5bb5da) datadog-agent: 7.49.0 -> 7.50.1
* [`8635fec0`](https://github.com/NixOS/nixpkgs/commit/8635fec0b70937d2ed4a5f4b2c1f9142654597c5) dbmate: 2.8.0 -> 2.10.0
* [`8a9191ad`](https://github.com/NixOS/nixpkgs/commit/8a9191adafa6ffd14febd3fd983e8b703e34ad97) dl-librescore: 0.34.47 -> 0.34.59
* [`f7ef8905`](https://github.com/NixOS/nixpkgs/commit/f7ef8905abb5a84f8b44e29afb5c8d75243bc6ec) doctl: 1.100.0 -> 1.102.0
* [`c99f48ee`](https://github.com/NixOS/nixpkgs/commit/c99f48ee939a15a5628889ae84b4963a561fb0c4) ecs-agent: 1.78.1 -> 1.79.2
* [`64b6b5e7`](https://github.com/NixOS/nixpkgs/commit/64b6b5e787d48f8c235ccb71a097f6de5dd2461d) nixos/portunus: make sure the cookies are only send over https if it is enabled
* [`b088f987`](https://github.com/NixOS/nixpkgs/commit/b088f9871eeb97adb6d0ff530548b86d7ab44b77) libsoup: Remove passthru.propagatedUserEnvPackages
* [`4a5f2bd6`](https://github.com/NixOS/nixpkgs/commit/4a5f2bd6e88c1bc3e16c0c2a19c9d5e65b3a1830) stdenv/check-meta: Use bespoke type checking
* [`e6880da8`](https://github.com/NixOS/nixpkgs/commit/e6880da84a9ef4aa44f2e3ce45c42201e8f1c57d) elasticmq-server-bin: 1.5.2 -> 1.5.4
* [`40d6ff6f`](https://github.com/NixOS/nixpkgs/commit/40d6ff6f7415f1eca9abba96ed6fa3ce397dab23) exodus: 23.12.7 -> 23.12.21
* [`fa00a800`](https://github.com/NixOS/nixpkgs/commit/fa00a8000b933f4a09a4045f4eba95e20ff30b5f) goimports-reviser: 3.6.0 -> 3.6.2
* [`1ca391eb`](https://github.com/NixOS/nixpkgs/commit/1ca391eb9462f5d9b61f19d196879c19693ddfdb) govc: 0.33.1 -> 0.34.1
* [`76b9ec18`](https://github.com/NixOS/nixpkgs/commit/76b9ec188d0c634a85e5f0a25095cab83eab9569) libint: 2.7.2 -> 2.8.1
* [`a9ff8e71`](https://github.com/NixOS/nixpkgs/commit/a9ff8e71a880962896ca650210a22275d08eee8d) jql: 7.0.7 -> 7.1.2
* [`3d1386ef`](https://github.com/NixOS/nixpkgs/commit/3d1386ef5b6d592ca29e542a3d4f26f8f0ff7b3a) komga: 1.8.3 -> 1.9.2
* [`d8f0a788`](https://github.com/NixOS/nixpkgs/commit/d8f0a7886b365ac676deb0683189731fbd9dec57) jetbrains-toolbox: 2.1.1.18388 -> 2.1.3.18901
* [`3081228c`](https://github.com/NixOS/nixpkgs/commit/3081228cc4a2e345880cba80ff11544a466b1285) dart: Use Nix instead of Pub
* [`f8fb1ee8`](https://github.com/NixOS/nixpkgs/commit/f8fb1ee85be55cc4a4a9cc4a49340742c4032f04) dart-sass-embedded: Use buildDartApplication
* [`6552dc5c`](https://github.com/NixOS/nixpkgs/commit/6552dc5c90e8beb32b5af9bcf9ec69f677d2d42f) dart-sass-embedded: Drop
* [`34ce9c64`](https://github.com/NixOS/nixpkgs/commit/34ce9c64c9c123afb16def28966858fe41b955c4) pub2nix.readPubspecLock: Include entire source in package derivations
* [`7c7cb950`](https://github.com/NixOS/nixpkgs/commit/7c7cb9508540480f2bfb2f72406f45d7d737077a) dart: Update documentation for pub2nix
* [`4f623fa0`](https://github.com/NixOS/nixpkgs/commit/4f623fa0a101f6e8818e81f699b434f3cda95421) buildDartApplication: Refactor autoDepsList logic
* [`4eb35ef7`](https://github.com/NixOS/nixpkgs/commit/4eb35ef7115d9b358de4cf746c3477ab08836d28) buildDartApplication: Link the package_config.json in a separate derivation
* [`7e043f5f`](https://github.com/NixOS/nixpkgs/commit/7e043f5f28da0813c0317deb5478475abb8a6156) buildDartApplication: Accept additional package_config.json setup commands
* [`af6e82b4`](https://github.com/NixOS/nixpkgs/commit/af6e82b47a76d6d14ba71c03537c6d034c85b647) flutter.buildFlutterApplication: Use extraPackageConfigSetup
* [`7c9b7547`](https://github.com/NixOS/nixpkgs/commit/7c9b7547846189255b2f37eb604be2d2fd2000f8) buildDartApplication: Document nix-shell usage
* [`dbc05b2c`](https://github.com/NixOS/nixpkgs/commit/dbc05b2c8097ab94af390d3e475a3caf44e4149f) dart: Add headings to nix-shell documentation sections
* [`bea71b1f`](https://github.com/NixOS/nixpkgs/commit/bea71b1fe3d1dce1ebb5f772bc2e8736478aa27c) pub2nix.readPubspecLock: Add `packagePath` convenience attribute
* [`92809a1c`](https://github.com/NixOS/nixpkgs/commit/92809a1cc5fb50d706a01ff232128ca9421f4584) buildDartApplication: Document running build tools
* [`d41348a6`](https://github.com/NixOS/nixpkgs/commit/d41348a68a130b5358740e394f50d7fb5fc69838) dartHooks.dartConfigHook: Add packageRun utility
* [`65d2cc04`](https://github.com/NixOS/nixpkgs/commit/65d2cc04a31ce77e949b90d5745f607e6ee26151) dartHooks.dartConfigHook: Simplify packageRun function
* [`4e4c4c2a`](https://github.com/NixOS/nixpkgs/commit/4e4c4c2ad00e36754b3abadd086e2ec3fdcd2884) buildDartApplication: Use overrides for dev dependencies as well
* [`9f3ae29e`](https://github.com/NixOS/nixpkgs/commit/9f3ae29eca3f8dfda4b6066083813562dbf61220) dart: ffigen: Add package override
* [`18d9cd0c`](https://github.com/NixOS/nixpkgs/commit/18d9cd0c50461d03b213c2c97cfac04508f70dd2) pub2nix.readPubspecLock: Add package versions to passthru
* [`48bf6da9`](https://github.com/NixOS/nixpkgs/commit/48bf6da95540a48ad920643d3c4c43045e748a91) buildDartApplication: Declare dependency sources as build inputs
* [`53a3485b`](https://github.com/NixOS/nixpkgs/commit/53a3485bfcb16e84fdc9222639856d499f7d07ed) flutter.buildFlutterApplication: Remove unneeded nativeBuildInputs
* [`f057034d`](https://github.com/NixOS/nixpkgs/commit/f057034d6a7fc4739e6c1a66b7ced248170296f4) flutter.buildFlutterApplication: Don't assume jq and yq are available in extraPackageConfigSetup
* [`8494ee61`](https://github.com/NixOS/nixpkgs/commit/8494ee610bf249bc691b7257d54495ee2f7bdc54) flutter.buildFlutterApplication: Add pkg-config to nativeBuildInputs
* [`1ae96d07`](https://github.com/NixOS/nixpkgs/commit/1ae96d070420e87b8c23ccd60990eb4a061d62f4) buildDartApplication: Move package sources to nativeBuildInputs
* [`cf55bc73`](https://github.com/NixOS/nixpkgs/commit/cf55bc7300560f63f4e76521dbd163a00b060769) buildDartApplication: Generate LD_LIBRARY_PATH at build time
* [`d31efc29`](https://github.com/NixOS/nixpkgs/commit/d31efc291a7d97c46dedc7aa3b6a348bcff67859) k3s_1_29: init at 1.29.0
* [`2bd3e5d7`](https://github.com/NixOS/nixpkgs/commit/2bd3e5d779f31c751cf2f23e98fc4dbe74f4328c) buildDartApplication: Use package source builders and setup hooks instead of package overrides
* [`23952fb6`](https://github.com/NixOS/nixpkgs/commit/23952fb64184b44d1c884dd592b6a19381413bf2) buildDartApplication: Remove depsListFile
* [`81a99463`](https://github.com/NixOS/nixpkgs/commit/81a99463d8b2047083fea88534ae9b7f27355835) buildDartApplication: Pass `customSourceBuilders` through to pub2nix
* [`32e3ea18`](https://github.com/NixOS/nixpkgs/commit/32e3ea18d572250c397694dca1d3158493637357) buildDartApplication: Document customSourceBuilders
* [`fc733120`](https://github.com/NixOS/nixpkgs/commit/fc7331203efd82932b3a4f43f1add77d4a3baf59) ferdium: 6.6.0 -> 6.7.0
* [`11cd7aa7`](https://github.com/NixOS/nixpkgs/commit/11cd7aa7d6315780253da131e22f609450fcb7ac) ferdium: fix and simplify update script
* [`2f3c5f0f`](https://github.com/NixOS/nixpkgs/commit/2f3c5f0f69807c19e295809c126799fb0a0b5f3d) lima: 0.18.0 -> 0.19.1
* [`e827619c`](https://github.com/NixOS/nixpkgs/commit/e827619c11b393430c388062bcc96c8c6a80bfcc) buildDartApplication: remove unused pubGetScript and generatePubspecLock
* [`b0a2d432`](https://github.com/NixOS/nixpkgs/commit/b0a2d432da49753a6edde30feb597474a9557aef) buildDartApplication: fix note about fixed-output derivation
* [`65b0c270`](https://github.com/NixOS/nixpkgs/commit/65b0c270c2c5b74c37855090678f94a8ca4de116) pub2nix: Add disclaimer why not to use fetchTarball
* [`5a5db928`](https://github.com/NixOS/nixpkgs/commit/5a5db92870a31076ad2e611ecae9159d490b5d69) buildDartApplication: remove customSourceBuilders from baseDerivation
* [`b1f51e96`](https://github.com/NixOS/nixpkgs/commit/b1f51e965af62ca37a89b4533e9a996a590bba3e) python311Packages.jpype1: 1.4.1 -> 1.5.0
* [`e8cfe721`](https://github.com/NixOS/nixpkgs/commit/e8cfe721c7c872b73bb20e944744d20b49be4f38) zola: 0.17.2 -> 0.18.0
* [`5692c3bc`](https://github.com/NixOS/nixpkgs/commit/5692c3bc501ffe00c1e9a4ef92ad7b014f351fdf) agdaPackages.agda-categories: 0.1.7.2 -> 0.2.0
* [`9a00eb12`](https://github.com/NixOS/nixpkgs/commit/9a00eb12503d9e5eac895c2eae16006f8f0b625f) haskellPackages.gi-vte: fix by adding missing gi-cairo dep
* [`37117904`](https://github.com/NixOS/nixpkgs/commit/3711790416b5c793e4498e2040b1b690fc00e18e) ns-usbloader: 7.0 -> 7.1
* [`c48feabc`](https://github.com/NixOS/nixpkgs/commit/c48feabc0381650ab0ba7b574adda14bc1682c58) melange: 0.5.1 -> 0.5.5
* [`7ec8f6c1`](https://github.com/NixOS/nixpkgs/commit/7ec8f6c17d0a16b9c662c1800e1b2553eddacc49) metabase: 0.47.8 -> 0.48.1
* [`6378efc7`](https://github.com/NixOS/nixpkgs/commit/6378efc7d6eaaa32e47f8f5ec798eceb255de5ae) metal-cli: 0.17.0 -> 0.19.0
* [`1b40a07e`](https://github.com/NixOS/nixpkgs/commit/1b40a07ee0086ffd194745cd9d8a8875d964c979) micronaut: 4.1.6 -> 4.2.2
* [`2e1b3d05`](https://github.com/NixOS/nixpkgs/commit/2e1b3d05f0d104524ea0b4a398ce710333ebd37d) iperf: 3.15 -> 3.16
* [`c213f60b`](https://github.com/NixOS/nixpkgs/commit/c213f60b57e2402d9bce6feebea011f87eb168ef) nsq: 1.2.1 -> 1.3.0
* [`e20c3d38`](https://github.com/NixOS/nixpkgs/commit/e20c3d388c57c3faa23e4aecc5d7f418e24c257a) nexttrace: 1.2.6 -> 1.2.8
* [`534fb0ba`](https://github.com/NixOS/nixpkgs/commit/534fb0bad5d47707d1697bbd39cda6964e0551b6) openai: 1.6.0 -> 1.6.1
* [`0d02683f`](https://github.com/NixOS/nixpkgs/commit/0d02683fc740f21ba8496364bf8fc6bd76aa4279) optifine: 1.20.1_HD_U_I5 -> 1.20.1_HD_U_I6
* [`0f751d00`](https://github.com/NixOS/nixpkgs/commit/0f751d00cce47dd1455188d5ff38ef17e06d3489) oranda: 0.5.0 -> 0.6.1
* [`ca89b111`](https://github.com/NixOS/nixpkgs/commit/ca89b111a551efb722f3906a4ebb55bf15caa6c8) agdaPackages.agdarsec: mark as broken
* [`798437ac`](https://github.com/NixOS/nixpkgs/commit/798437ac6b0662fabd84ccf5907d5004dedb0c15) promptfoo: 0.28.0 -> 0.33.2
* [`03c1cfda`](https://github.com/NixOS/nixpkgs/commit/03c1cfda4ab0bffcbf6083ace40befdfbad9b447) protoc-gen-connect-go: 1.12.0 -> 1.14.0
* [`8d211c80`](https://github.com/NixOS/nixpkgs/commit/8d211c80fc37e83beb3d38ee025d12d53a5018df) copilot-el: init at d4fa14cea818e041b4a536c5052cf6d28c7223d7
* [`920334ca`](https://github.com/NixOS/nixpkgs/commit/920334caf49397795281f3d662ab0f12042337e5) python310Packages.apispec: 6.3.0 -> 6.3.1
* [`37836f9a`](https://github.com/NixOS/nixpkgs/commit/37836f9ac77ec0757afba871c3d553ecc43290cd) python310Packages.awacs: 2.4.0 -> 2.4.1
* [`00e1faf8`](https://github.com/NixOS/nixpkgs/commit/00e1faf8cd58327d8915efed3024aa0333db6f43) python310Packages.azure-mgmt-cosmosdb: 9.3.0 -> 9.4.0
* [`7ec927ac`](https://github.com/NixOS/nixpkgs/commit/7ec927ac70ab6350bbdf9d2b592cab6eb26db5dd) python310Packages.basemap: 1.3.8 -> 1.3.9
* [`c3f21e3d`](https://github.com/NixOS/nixpkgs/commit/c3f21e3dd6db82afc9262d1f6095cb0be06beca2) python3.pkgs.django-modeltranslation: init at 0.18.11
* [`234a820e`](https://github.com/NixOS/nixpkgs/commit/234a820e0038efa22cee26a16cc825c20d5af756) python310Packages.dtw-python: 1.3.0 -> 1.3.1
* [`d895ac36`](https://github.com/NixOS/nixpkgs/commit/d895ac366c9732d4c3633fbbb4cd5c82686da210) ddns-go: 5.6.7 -> 5.7.0
* [`70168ca8`](https://github.com/NixOS/nixpkgs/commit/70168ca8684c149d9e909c10d8df5402b8f34fe1) google-java-format: 1.19.0 -> 1.19.1
* [`140eaf50`](https://github.com/NixOS/nixpkgs/commit/140eaf504b2df016d4e12261f3452be60bdfc829) i2pd: 2.49.0 -> 2.50.1
* [`9ce833e2`](https://github.com/NixOS/nixpkgs/commit/9ce833e2bcff32bb0f8c767762ad38a7c02e6bbe) echidna: fix broken build
* [`c3acc30f`](https://github.com/NixOS/nixpkgs/commit/c3acc30f7cca56512bf6f1352b4d12b71f6dbb6b) python310Packages.gtts: 2.4.0 -> 2.5.0
* [`feadff00`](https://github.com/NixOS/nixpkgs/commit/feadff003ea9902443ed763fab8b82653180b055) cvc5: 1.0.9 -> 1.1.0
* [`f12c3bc3`](https://github.com/NixOS/nixpkgs/commit/f12c3bc3d9f6de5529c0472d6b63cf56d69b98d5) python310Packages.jwcrypto: 1.5.0 -> 1.5.1
* [`01e1f06d`](https://github.com/NixOS/nixpkgs/commit/01e1f06d2346184e08ef8efed02ea97f2a5304d1) python310Packages.lightning-utilities: 0.10.0 -> 0.10.1
* [`d5bc89ee`](https://github.com/NixOS/nixpkgs/commit/d5bc89ee0806ce80302fd84c05a8da156adb4684) python310Packages.manifestoo-core: 1.3 -> 1.4
* [`cff5eb91`](https://github.com/NixOS/nixpkgs/commit/cff5eb918d09799431b2974160e8a1250b2453be) flowblade: 2.12 -> 2.12.0.2
* [`20647e84`](https://github.com/NixOS/nixpkgs/commit/20647e846d12a25d71d25fff47dc5ddfb85d35b5) groonga: 13.0.9 -> 13.1.0
* [`f038ea19`](https://github.com/NixOS/nixpkgs/commit/f038ea19d19e69cb6acf8e2b25ff4dcffb16c027) libngspice: 41 -> 42
* [`eae45fb6`](https://github.com/NixOS/nixpkgs/commit/eae45fb66909744a6d4c7c289f68940c7a0cb7e4) nb: 7.9.0 -> 7.9.1
* [`125d399f`](https://github.com/NixOS/nixpkgs/commit/125d399f79beda82d67b51b3f0d14f7c792a8894) ocserv: 1.2.2 -> 1.2.3
* [`23d5ea7b`](https://github.com/NixOS/nixpkgs/commit/23d5ea7b02004310c891585c241645064a9e519f) riemann: 0.3.10 -> 0.3.11
* [`c777f0bf`](https://github.com/NixOS/nixpkgs/commit/c777f0bfa71e4c6f1ff5cea2b8ede3d523dd550e) tulip: 5.7.2 -> 5.7.3
* [`86e62126`](https://github.com/NixOS/nixpkgs/commit/86e62126b3b3a374faf0ddc2e2bb9e5ba8b240bb) minetest-mapserver: 4.7.0 -> 4.8.0
* [`af026a99`](https://github.com/NixOS/nixpkgs/commit/af026a99cdbe98790041e07fecfd1559121b0f49) premid: 2.3.2 -> 2.3.4
* [`d19e1547`](https://github.com/NixOS/nixpkgs/commit/d19e15474a46a1381a222069c738f7fe2bf74f62) hyperrogue: 12.1z -> 13.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
