### PR TITLE
niv home-manager: update 6e91c5df -> 51e44a13

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e91c5df192395753d8e6d55a0352109cb559790",
-        "sha256": "0mvy5v5h0gjysij8vrajx2z1z6gm2f3avvsf6w9zrfkarkfl41ja",
+        "rev": "51e44a13acea71b36245e8bd8c7db53e0a3e61ee",
+        "sha256": "1a19f91vkpdi95l39fplrl3kfxmknkmbys4qi3fxibj751slm0y8",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/6e91c5df192395753d8e6d55a0352109cb559790.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/51e44a13acea71b36245e8bd8c7db53e0a3e61ee.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@6e91c5df...51e44a13](https://github.com/nix-community/home-manager/compare/6e91c5df192395753d8e6d55a0352109cb559790...51e44a13acea71b36245e8bd8c7db53e0a3e61ee)

* [`4d8f9020`](https://github.com/nix-community/home-manager/commit/4d8f90205c6c90be2e81d94d0e5eedf71c1ba34e) zsh: fix zprof typo
* [`f772334b`](https://github.com/nix-community/home-manager/commit/f772334b357440e93e4c8f137d40b135720e3c83) flake.lock: Update
* [`992b38f2`](https://github.com/nix-community/home-manager/commit/992b38f29cd7e50d88a2ae069133750beda010a4) yazi: fix nushell integration
* [`fcbc70a7`](https://github.com/nix-community/home-manager/commit/fcbc70a7ee064f2b65dc1fac1717ca2a9813bbe6) xdg-portal: add new module
* [`c36cb65c`](https://github.com/nix-community/home-manager/commit/c36cb65c4a0ba17ab9262ab3c30920429348746c) xplr: support multiple plugins in cfg.plugins
* [`26b8adb3`](https://github.com/nix-community/home-manager/commit/26b8adb300e50efceb51fff6859a1a6ba1ade4f7) github: fix broken links
* [`294c13fa`](https://github.com/nix-community/home-manager/commit/294c13fa4b430b74733e66034ba12d6a11ef788e) home-manager: update --version to 24.05
* [`51e44a13`](https://github.com/nix-community/home-manager/commit/51e44a13acea71b36245e8bd8c7db53e0a3e61ee) Translate using Weblate (Czech)
