### PR TITLE
niv zsh-syntax-highlighting: update dcc99a86 -> e0165eaa

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -209,10 +209,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "dcc99a86497491dfe41fb8b0d5f506033546a8c0",
-        "sha256": "184xwc6wc55jppn4h357pdxkkilqh6cpfn2cpawgahdrrdgwpf3k",
+        "rev": "e0165eaa730dd0fa321a6a6de74f092fe87630b0",
+        "sha256": "016adxfxk29akcmkhn9v11sar0plmfcnp4hfn3w03457wqvvddg2",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/dcc99a86497491dfe41fb8b0d5f506033546a8c0.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/e0165eaa730dd0fa321a6a6de74f092fe87630b0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@dcc99a86...e0165eaa](https://github.com/zsh-users/zsh-syntax-highlighting/compare/dcc99a86497491dfe41fb8b0d5f506033546a8c0...e0165eaa730dd0fa321a6a6de74f092fe87630b0)

* [`e0165eaa`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/e0165eaa730dd0fa321a6a6de74f092fe87630b0) main: Refactor __is_redirection
