### PR TITLE
niv nixpkgs: update 1bf1c7a2 -> 87b9bf8e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1bf1c7a244e63f4e550815ea3432fb83c5f69b8a",
-        "sha256": "0xkjz0yag7363hxwqrhl0va1zkii7710m8rwmcqprp3vx7wfj2in",
+        "rev": "87b9bf8ea4bf9f961376e44a2c9d5ea9a5cf9207",
+        "sha256": "1w799agy5kgscrq10cvvsni37za9s058zhyplcz4469vdd78f1pn",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/1bf1c7a244e63f4e550815ea3432fb83c5f69b8a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/87b9bf8ea4bf9f961376e44a2c9d5ea9a5cf9207.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@1bf1c7a2...87b9bf8e](https://github.com/nixos/nixpkgs/compare/1bf1c7a244e63f4e550815ea3432fb83c5f69b8a...87b9bf8ea4bf9f961376e44a2c9d5ea9a5cf9207)

* [`b8060bf7`](https://github.com/NixOS/nixpkgs/commit/b8060bf715f6e2505d10d48b96c231fc94fb08dc) notmuch-bower: Add runtime dependencies
* [`c0bc18bf`](https://github.com/NixOS/nixpkgs/commit/c0bc18bf2f76a4e1f6e748e06e4faa4c9a232eed) lua: split manual into separate output
* [`072c252f`](https://github.com/NixOS/nixpkgs/commit/072c252f925ffa665053f3c151f888b16404ca98) libgcrypt: Correct known vulnerability
* [`496a143d`](https://github.com/NixOS/nixpkgs/commit/496a143d847070dbda8d4233759401f841c5e4ce) Update pkgs/development/interpreters/lua-5/interpreter.nix
* [`c2805bdd`](https://github.com/NixOS/nixpkgs/commit/c2805bddc16492a516e2bc0c875adf1217d67164) freeplane: 1.9.14 -> 1.11.4
* [`8585568d`](https://github.com/NixOS/nixpkgs/commit/8585568d7d9f895b928d297f2df7b0d73c069d7c) lib.fixedPoints.extends: Improve documentation
* [`327f1c2d`](https://github.com/NixOS/nixpkgs/commit/327f1c2d09fec31ae38665911bd6383c10498dad) lib.fixedPoints.extends: Add type and examples
* [`149a793c`](https://github.com/NixOS/nixpkgs/commit/149a793c07e07965c8941658e59056d11a010668) lib.fixedPoints.extends: Refactor implementation and document arguments
* [`20e1dd2d`](https://github.com/NixOS/nixpkgs/commit/20e1dd2d1e29c8a771fe0f73ce8c13cc952265fb) buildDotnetModule: actually use installPath
* [`36514501`](https://github.com/NixOS/nixpkgs/commit/36514501c7004ae8a2c6d79cc5c93178747d7ee5) python310Packages.pillow: clean up darwin-only patch
* [`8b8ecfa4`](https://github.com/NixOS/nixpkgs/commit/8b8ecfa4451bef30f51d6c1db46c441d8e945e9a) graph-cli: fix runtime crash
* [`f4dab6c2`](https://github.com/NixOS/nixpkgs/commit/f4dab6c2b71603b734105daa8bddfcd12b654f8e) doxygen: 1.9.7 -> 1.9.8
* [`5ae8ce81`](https://github.com/NixOS/nixpkgs/commit/5ae8ce81fa9a921d400aea2ff30305b1e6c16968) cubicsdr: fix for liquid-dsp v1.50
* [`7bfaf94b`](https://github.com/NixOS/nixpkgs/commit/7bfaf94b1ee4ce08c8d7c8773122e7ae26a084d0) miniupnpd-nftables: init at 2.3.3
* [`e5f20af1`](https://github.com/NixOS/nixpkgs/commit/e5f20af132e27f28fadff93d5535034d5e5348ed) graph-cli: 0.1.18 -> 0.1.19
* [`13c278cb`](https://github.com/NixOS/nixpkgs/commit/13c278cb1cd8503f5ab9a550315a75a0001bc247) lib.fixedPoints.extends: Doc improvements
* [`c5346971`](https://github.com/NixOS/nixpkgs/commit/c534697174be56be7cb026fbdaf9ec973a090a7b) dhcpcd: 9.4.1 -> 10.0.2
* [`0fb82b30`](https://github.com/NixOS/nixpkgs/commit/0fb82b30ea0743776854511c22f99139c33d7d68) smartmontools: build without update-smart-drivedb
* [`3c2efe61`](https://github.com/NixOS/nixpkgs/commit/3c2efe61dc6a6919e667bf70616da7819352431f) docs/installation-usb: add more flags to dd
* [`30d1e55e`](https://github.com/NixOS/nixpkgs/commit/30d1e55e257ec68c55c87c5b446ceea8fc1fb038) make-single-disk-zfs-image: make memSize configurable
* [`eac98ed5`](https://github.com/NixOS/nixpkgs/commit/eac98ed50efe959941340505aedb0020f4fad896) openstack-image-zfs: add 'ramMB' option to configure build VM memory
* [`80627bfe`](https://github.com/NixOS/nixpkgs/commit/80627bfe8ff3a42161597bea24a257e78ff94b94) stdenv: enable multithreading for `xz` decompression
* [`1dc2fd4b`](https://github.com/NixOS/nixpkgs/commit/1dc2fd4bdd71ac988dce79a31e023658f04c5f1d) nixos/usbStorage: update device flag
* [`0c0e1a46`](https://github.com/NixOS/nixpkgs/commit/0c0e1a46650af7cf77febf1b55c40aa210c05b53) iproute2: 6.5.0 -> 6.6.0
* [`ecdd5e63`](https://github.com/NixOS/nixpkgs/commit/ecdd5e63c272b9c5136324fdbe43c932d12b4494) maintainers: add proglottis
* [`68ca8f19`](https://github.com/NixOS/nixpkgs/commit/68ca8f197a68b0c32c58a808453fb3dd33012460) fileinfo: init at unstable-2022-09-16
* [`f4c51495`](https://github.com/NixOS/nixpkgs/commit/f4c51495b73809304062bac1ee487297a707a4c0) jbig2dec: fix cross
* [`82d922a9`](https://github.com/NixOS/nixpkgs/commit/82d922a96660d988727f0f28a6b3844829c0a024) python311Packages.werkzeug: 2.3.7 -> 2.3.8
* [`ca5de5d9`](https://github.com/NixOS/nixpkgs/commit/ca5de5d9a3001ffe60d4a3c5e6e657405724a243) spirv-llvm-translator: 14.0.0 -> 14.0.0+unstable-2023-06-22
* [`0530d6bd`](https://github.com/NixOS/nixpkgs/commit/0530d6bd0498e6f554cc9070a163ac9aec5819c8) doc: add explanatory code comment
* [`3fbf12bd`](https://github.com/NixOS/nixpkgs/commit/3fbf12bd525a51d395bbf516b6e4808e84588c9a) mono: use strictDeps
* [`ef0b88ac`](https://github.com/NixOS/nixpkgs/commit/ef0b88ac3cff25c25d5a472c250961a907bd5660) pngquant: 2.17.0 -> 3.0.3
* [`38d4a0e7`](https://github.com/NixOS/nixpkgs/commit/38d4a0e7d8fd80877dfb869aba628cf3af025b80) kmod-debian-aliases: 22-1.1 -> 30+20230601-2
* [`ce6dfe84`](https://github.com/NixOS/nixpkgs/commit/ce6dfe84f3dd7fc77301f5ef52bf4fbc8cdeb6d0) kmod-blacklist-ubuntu: 28-1ubuntu4 -> 30+20230519-1ubuntu3
* [`4ddb0b4b`](https://github.com/NixOS/nixpkgs/commit/4ddb0b4b677fd55acab809b2559a722f5b33a517) polkit: remove rsync build dependency
* [`4fac6af7`](https://github.com/NixOS/nixpkgs/commit/4fac6af7603987b1966d9ed72bc3facf32d1d555) gumbo: 0.10.1 -> 0.12.1
* [`56aa31d0`](https://github.com/NixOS/nixpkgs/commit/56aa31d0b48e14021c16d05731238674983fe1fc) swiftpm: force-unwrap file handles in `swift-tools-support-core`
* [`647e9c86`](https://github.com/NixOS/nixpkgs/commit/647e9c86687479311e86b887f8faf2dc16684087) swift-driver: force-unwrap file handles in `swift-tools-support-core`
* [`2b816ea9`](https://github.com/NixOS/nixpkgs/commit/2b816ea9b9065328de6b5cddac98af4fe6fc2dcd) cudaPackages.fabricmanager: deprecate phases
* [`18951ce7`](https://github.com/NixOS/nixpkgs/commit/18951ce703172c79e9624277b21d6103b450557f) vala: look for files in `targetOffset`
* [`0e0f557a`](https://github.com/NixOS/nixpkgs/commit/0e0f557a20ac6164e67c0688ddefaa9bad433c80) hotdoc: fix clang header finding with llvm 16
* [`ea61bb80`](https://github.com/NixOS/nixpkgs/commit/ea61bb8011fe04867ea5e90a72e4be880129a840) libbpf: 1.2.2 -> 1.3.0
* [`3b73ab96`](https://github.com/NixOS/nixpkgs/commit/3b73ab96a727dccf1a05bc9fd9a8e39f1311ad37) nixos/plasma5: use plasma5Packages everywhere for clarity
* [`3621446c`](https://github.com/NixOS/nixpkgs/commit/3621446cc036cca6a2107453a93e68401a9d26eb) Add blinry to maintainers
* [`08e87f1a`](https://github.com/NixOS/nixpkgs/commit/08e87f1a6c963ed693b6d519173b8cf3dbfa498a) identity: refactor
* [`1db7be4d`](https://github.com/NixOS/nixpkgs/commit/1db7be4d61f2816192d96e361b8008c12eb51ec8) identity: 0.5.0 -> 0.6.0
* [`010a6250`](https://github.com/NixOS/nixpkgs/commit/010a6250db54a2efb74d7db846379eae0878de09) nixos/pgadmin: add passwordLength setting
* [`d1c585a7`](https://github.com/NixOS/nixpkgs/commit/d1c585a7908737ea6cb8755c54693bdea13194f6) php81.extensions.sqlite3, php82.extensions.sqlite3: backport sqlite-3.44.0 fix
* [`5c014ce1`](https://github.com/NixOS/nixpkgs/commit/5c014ce103edc986c4f42f020f20c5980b22068a) sqlite, sqlite-analyzer: 3.43.2 -> 3.44.2
* [`6cce4ef8`](https://github.com/NixOS/nixpkgs/commit/6cce4ef8791ad9df77394986170528f7a39ebb08) gpgme: 1.23.0 -> 1.23.2
* [`128f0f8a`](https://github.com/NixOS/nixpkgs/commit/128f0f8ade7dbadea8e108cb7adb4aee5fb1408d) mdbook: 0.4.35 -> 0.4.36
* [`0a352c67`](https://github.com/NixOS/nixpkgs/commit/0a352c677ce5fd9f4ea3c89cc7492c2037c62da6) klog-time-tracker: init at 6.2
* [`0f0b89fc`](https://github.com/NixOS/nixpkgs/commit/0f0b89fc7bcea595d006f8323f40bb75c8a230af) x264: fix runtime crash due to llvm-strip args
* [`75766880`](https://github.com/NixOS/nixpkgs/commit/7576688040b1116f1ec351f09f3b049c74ca4e7c) cpio: pull upstream fix for clang-16
* [`8ef81629`](https://github.com/NixOS/nixpkgs/commit/8ef81629e9838ff4b6f94d691f4072ca67ece128) libelf: unconditionally apply autoreconfHook
* [`fbc7955d`](https://github.com/NixOS/nixpkgs/commit/fbc7955d726169ae9a12c337ef0519a69dcf8edb) libimobiledevice: pull upstream fix for `clang-16` support
* [`b9dbec02`](https://github.com/NixOS/nixpkgs/commit/b9dbec027921b9b8fbf993a4b905af809763058c) rust-bindgen-unwrapped: 0.66.1 -> 0.69.1
* [`033c0517`](https://github.com/NixOS/nixpkgs/commit/033c05174755b00b6ef86f79d14f4f0f9d5d4626) libgcrypt: set enableParallelBuilding=true
* [`c75b7209`](https://github.com/NixOS/nixpkgs/commit/c75b720939a02e4d0c8fa4e381bfec2f6c81dea9) libgcrypt: set enableParallelChecking=true
* [`0a437bc5`](https://github.com/NixOS/nixpkgs/commit/0a437bc535100721ad0b94084e6ad9e0d7af31fc) aws-c-auth: 0.7.6 -> 0.7.7
* [`44a821e9`](https://github.com/NixOS/nixpkgs/commit/44a821e9e6bf0923db57b7eb4dcca7698835b4b9) aws-c-common: 0.9.9 -> 0.9.10
* [`1951d2f9`](https://github.com/NixOS/nixpkgs/commit/1951d2f98b99fbaa3f3b1f494de4bceb214ef136) aws-c-event-stream: 0.3.1 -> 0.3.2
* [`294f7280`](https://github.com/NixOS/nixpkgs/commit/294f728064d12135c8179baf91c1f0573a565d4c) aws-c-http: 0.7.11 -> 0.7.14
* [`30a16c34`](https://github.com/NixOS/nixpkgs/commit/30a16c34c7ce3c3169864396c354fa9ddddd748d) aws-c-mqtt: 0.9.9 -> 0.9.10
* [`b521d9ca`](https://github.com/NixOS/nixpkgs/commit/b521d9caa2fc13272b23650e21e05639731f3df3) aws-c-s3: 0.3.23 -> 0.4.0
* [`a6940976`](https://github.com/NixOS/nixpkgs/commit/a6940976126540c0adf088a2b2d531b6f336a8d4) aws-c-io: 0.13.35 -> 0.13.36
* [`651abe35`](https://github.com/NixOS/nixpkgs/commit/651abe355f4dd073e3b707e54684eec6d5b63c7d) aws-crt-cpp: 0.24.6 -> 0.24.7
* [`93674ab5`](https://github.com/NixOS/nixpkgs/commit/93674ab521fe03e2a2fbc8179ce47f67b7ad6a59) aws-c-cal: 0.6.0 -> 0.6.9
* [`6cc5be4d`](https://github.com/NixOS/nixpkgs/commit/6cc5be4dd022df60e892a41667f2ed8730fed610) aws-sdk-cpp: 1.11.200 -> 1.11.207
* [`2cb60909`](https://github.com/NixOS/nixpkgs/commit/2cb609096de83e07c5eb6f5075105b11119afe6d) aws-sdk-cpp: add nix and arrow-cpp to tests
* [`de9a34d3`](https://github.com/NixOS/nixpkgs/commit/de9a34d3f1d00d5b6416a09f8aefb73dcb3b5f9c) aws-sdk-cpp: add 'tests.cmake-find-package'
* [`87ebba17`](https://github.com/NixOS/nixpkgs/commit/87ebba1750ba09413507a28d8a827d17c1da0e1e) libde265: 1.0.12 -> 1.0.14
* [`c8770488`](https://github.com/NixOS/nixpkgs/commit/c87704885719b21fa9d62c6e5676f3e1da269b44) libde265: use cmake build system
* [`ef9e9081`](https://github.com/NixOS/nixpkgs/commit/ef9e9081840a7798a39025bd6e664d73db754e87) gi-docgen: 2023.1 -> 2023.3
* [`325920e1`](https://github.com/NixOS/nixpkgs/commit/325920e11edfd67ebe62da1287fccbba86c5060e) gtk4: 4.12.3 → 4.12.4
* [`2730bc7f`](https://github.com/NixOS/nixpkgs/commit/2730bc7f8df767a13dfeb63ca5293f03c5b89fe9) shadow: backport `clang-16` build fix
* [`41fe9efd`](https://github.com/NixOS/nixpkgs/commit/41fe9efd4fa531a26afcac95cb959b88659d2afa) git: 2.42.0 -> 2.43.0
* [`9ba72f15`](https://github.com/NixOS/nixpkgs/commit/9ba72f15d1b43a205942746e19271e41a7db21d3) luaPackages.plenary-nvim: add code to run tests
* [`09d4abf0`](https://github.com/NixOS/nixpkgs/commit/09d4abf0ca18632a629c1a757333e2a18f49b5eb) fetchurl/mirrors: add cdn.download.kde.org as default KDE mirror
* [`e9eb9f97`](https://github.com/NixOS/nixpkgs/commit/e9eb9f97f3f363d1f73250aff9b7c0fa64c04a61) kdsoap: add Qt6 support
* [`8cf720ba`](https://github.com/NixOS/nixpkgs/commit/8cf720ba33e5f022774adf0e181d4af12357ddad) qca: rename from qca-qt5, add Qt6 support
* [`194dd385`](https://github.com/NixOS/nixpkgs/commit/194dd385329d2385871914542796f1c1ac91d946) packagekit-qt: add Qt6 support
* [`5d563af1`](https://github.com/NixOS/nixpkgs/commit/5d563af1ec505516ab1f7f901d0119ee0d131dda) futuresql: add Qt6 support
* [`f350f30b`](https://github.com/NixOS/nixpkgs/commit/f350f30bf78a6dd8a8ced3d30c72979ded47a657) kquickimageedit: add Qt6 support
* [`e027c8d3`](https://github.com/NixOS/nixpkgs/commit/e027c8d36e622cf2cfc62c5f1f90d112a399800a) libqaccessibilityclient: add Qt6 support
* [`a5901c45`](https://github.com/NixOS/nixpkgs/commit/a5901c45f0369111bce272cf9067eaded48016b1) qcoro: add Qt6 support
* [`d0de2628`](https://github.com/NixOS/nixpkgs/commit/d0de262839bdfe0cf62c7f3be3cac76300f61054) mlt: add Qt6 support
* [`a2a83fc4`](https://github.com/NixOS/nixpkgs/commit/a2a83fc41a7064b84aad656d0b15e4a346fb84df) qgpgme: add Qt6 support
* [`4e616054`](https://github.com/NixOS/nixpkgs/commit/4e616054f59170070d0086e1315bf97028cc4412) libquotient: add Qt6 support
* [`0e54559d`](https://github.com/NixOS/nixpkgs/commit/0e54559d137b5ff63519a39ecbe8bbfbbcda4df1) qtutilities: add Qt6 support
* [`ae3e7a0a`](https://github.com/NixOS/nixpkgs/commit/ae3e7a0a482b195af4db6c75fbc74df893cf53a5) qtforkawesome: add Qt6 support
* [`4093257b`](https://github.com/NixOS/nixpkgs/commit/4093257b3a5d8c1ff988bdfb7263e58070117181) plasma-wayland-protocols: 1.10.0 -> 1.11.1
* [`2bd9d62b`](https://github.com/NixOS/nixpkgs/commit/2bd9d62bfedd80da9307fa2c409e1111a6869921) maintainers: add uartman
* [`3c5e88f5`](https://github.com/NixOS/nixpkgs/commit/3c5e88f539969670634cc48fea63c5633a2d7769) gjs: 1.78.0 -> 1.78.1
* [`8f001560`](https://github.com/NixOS/nixpkgs/commit/8f001560cf09d959671a29080f59fd440ac6df1a) meson: 1.2.3 -> 1.3.0
* [`713e7bb2`](https://github.com/NixOS/nixpkgs/commit/713e7bb27be15293c65a386b18d46231dcc879d3) nv-codec-headers-12: 12.0.16.0 -> 12.1.14.0
* [`ebd5a516`](https://github.com/NixOS/nixpkgs/commit/ebd5a51661ca98a205acac2e7fdbdb8f3a5cf4a9) ffmpeg: substitute sha256sum with hash
* [`319a37eb`](https://github.com/NixOS/nixpkgs/commit/319a37ebf52035d024806cf025407ec8656d8209) ffmpeg: sort external libraries
* [`a18a8b5c`](https://github.com/NixOS/nixpkgs/commit/a18a8b5c7ba930e3982e212a9fc0c422a155f206) gdb: 13.2 -> 14.1
* [`6c6a5062`](https://github.com/NixOS/nixpkgs/commit/6c6a5062b7016f0c9262c25858183e4a0d96f78d) ffmpeg: add arthsmn as a maintainer
* [`3a9d9480`](https://github.com/NixOS/nixpkgs/commit/3a9d9480cecb1102d86a941e67838ffe2ea72b92) ffmpeg: 6.0 -> 6.1
* [`b96d3a4f`](https://github.com/NixOS/nixpkgs/commit/b96d3a4f6c96d375dce7a020e908911013a499ab) jellyfin-ffmpeg: 6.0-7 -> 6.0.1-1
* [`10ea6439`](https://github.com/NixOS/nixpkgs/commit/10ea6439961e0d1090e9d818451806221d502976) mpd: fix build with ffmpeg 6.1
* [`41d6390f`](https://github.com/NixOS/nixpkgs/commit/41d6390f917dded4952337ea4abeb007d3930d7c)  wl-screenrec: fix build by setting ffmpeg to version 5
* [`180fad87`](https://github.com/NixOS/nixpkgs/commit/180fad87322929dcef29cd3b1890b5218ec944a6) gifski: fix build by setting ffmpeg to version 5
* [`d70de064`](https://github.com/NixOS/nixpkgs/commit/d70de0641d58e50889befa84afaf222ad51c570d) lcms: 2.15 -> 2.16
* [`7fcbd1d0`](https://github.com/NixOS/nixpkgs/commit/7fcbd1d046c93239a5a7081c5c58de6d55c8bbc7) libao: backport upstream patch for `clang-16` support
* [`5de4edd3`](https://github.com/NixOS/nixpkgs/commit/5de4edd389e6536aeb754d4342914b7cbaca444a) mariadb-connector-c: switch links over to github
* [`4f92bea3`](https://github.com/NixOS/nixpkgs/commit/4f92bea34a6d31cd5eca1175a11b8f9fb93de53e) systemd: enable debug info
* [`d2ec10f4`](https://github.com/NixOS/nixpkgs/commit/d2ec10f49a4d27cd05cbb8795dafbf7491abda22) Update pkgs/development/libraries/libao/default.nix
* [`96027ca2`](https://github.com/NixOS/nixpkgs/commit/96027ca2d7a16699ece15df6f6144ac747160d63) gdb: add `xz` to buildInputs to enable `lzma` support
* [`989723ec`](https://github.com/NixOS/nixpkgs/commit/989723ecf240a4f5a1b8dd3d61fe8a2d48cfda7a) rustc-wasm32: merge into rustc
* [`02f7cdc1`](https://github.com/NixOS/nixpkgs/commit/02f7cdc1e450ce92d0069a5c021c7d0407372cd7) util-linux: 2.39.2 -> 2.39.3
* [`93ebe44a`](https://github.com/NixOS/nixpkgs/commit/93ebe44ac34a3d3c36dd790780076255fd895c19) rocmPackages_5: pin stdenv to GCC 12
* [`660b0bd0`](https://github.com/NixOS/nixpkgs/commit/660b0bd012886485b593c33c3fe41ab46aae611d) fsverity-utils: update repo url
* [`fb4a93a9`](https://github.com/NixOS/nixpkgs/commit/fb4a93a913e9bf7f46b73aacd8a4986354170c7f) treewide: fetchgit -> fetchzip (git.kernel.org)
* [`6e34087a`](https://github.com/NixOS/nixpkgs/commit/6e34087a32dae15a93cd38e1e820c6204f8099ac) tuna: patchPhase -> postPatch
* [`178dca3d`](https://github.com/NixOS/nixpkgs/commit/178dca3d9b8e20040a101ba8dbbd92661b696cec) libseccomp: 2.5.4 -> 2.5.5
* [`40141ac8`](https://github.com/NixOS/nixpkgs/commit/40141ac8e06a133a5d66e26dd85f3afc7a2a26ec) libavif: 1.0.2 -> 1.0.3
* [`c8e61256`](https://github.com/NixOS/nixpkgs/commit/c8e61256e6f6831bf5621d4b9ea74567063ec745) nixos/influxdb: restart on failure
* [`37784412`](https://github.com/NixOS/nixpkgs/commit/37784412276ad1af3719a6fe15de0b05374a5447) buildcatrust: use pep517 builder
* [`6201454d`](https://github.com/NixOS/nixpkgs/commit/6201454d9549efead1b1b3939383696211c9a371) python3.pkgs.jinja2: build offline documentation in separate derivation
* [`2abb06f0`](https://github.com/NixOS/nixpkgs/commit/2abb06f012baf909569da3b72c67ef1225931c5a) disable-warnings-if-gcc13: init
* [`08c69bab`](https://github.com/NixOS/nixpkgs/commit/08c69babcc3a969bc343e1d63386102f15bb88bc) pycrypto: disable-warnings-if-gcc13
* [`211e2cc0`](https://github.com/NixOS/nixpkgs/commit/211e2cc03672c806af88227910e0d991b256f918) efivar: disable-warnings-if-gcc13
* [`c8cadde6`](https://github.com/NixOS/nixpkgs/commit/c8cadde6999b25e0fd1aac2a7abf450c97fbe277) btop: disable-warnings-if-gcc13
* [`71301132`](https://github.com/NixOS/nixpkgs/commit/71301132cb0d174676936efae5ede2568e8db27a) claws-mail: disable-warnings-if-gcc13
* [`6f948e92`](https://github.com/NixOS/nixpkgs/commit/6f948e92909add2a1026d0b1b41784a5309817cc) tesseract: disable-warnings-if-gcc13
* [`929e6d36`](https://github.com/NixOS/nixpkgs/commit/929e6d3620a857438cb20032bb3346b0bb7e635a) nixVersions: disable-warnings-if-gcc13
* [`8df1400e`](https://github.com/NixOS/nixpkgs/commit/8df1400e1d2ad4ceb19ab1af4b8de04fa469a865) libgcc: pass --disable-plugins
* [`01daef22`](https://github.com/NixOS/nixpkgs/commit/01daef2253d85e7ad370efb93e07bddc623d3778) pybind: disable-warnings-if-gcc13
* [`6de0b4ce`](https://github.com/NixOS/nixpkgs/commit/6de0b4ce3f0ef1aa8a298a7af0bef36b02e2f8c5) gn: apply disable-warnings-if-gcc13
* [`e2b669a1`](https://github.com/NixOS/nixpkgs/commit/e2b669a1378ee2ba4f609060d173d9056f014a70) blueprint: disable tests (time out)
* [`646116bf`](https://github.com/NixOS/nixpkgs/commit/646116bf6efdf4582d7dd883be0d902086fddff4) curaengine: disable warnings if gcc13
* [`ddc68c6d`](https://github.com/NixOS/nixpkgs/commit/ddc68c6d10f3bb11f549cc44422cc58b73175323) kodi-inputstream-ffmpeg-direct: disable warnings if gcc13
* [`3b96fe0c`](https://github.com/NixOS/nixpkgs/commit/3b96fe0c7a4d1baa4594343fce8fb4dce8d55590) libe57format: disable warnings if gcc13
* [`41e258d6`](https://github.com/NixOS/nixpkgs/commit/41e258d69f55afdfabb840df639776dc60bf221f) python-qt: add disable-warnings-if-gcc13
* [`e8da5f10`](https://github.com/NixOS/nixpkgs/commit/e8da5f109a14be06d2ea0d168573db80d8a302cc) zeroc-ice: add disable-warnings-if-gcc13
* [`72e1872a`](https://github.com/NixOS/nixpkgs/commit/72e1872aa6e0046f4eea58444dfd1df61cad531c) google-cloud-cpp: add disable-warnings-if-gcc13
* [`1f0cd24e`](https://github.com/NixOS/nixpkgs/commit/1f0cd24e42f55bf036345b32c13b3732927748e4) curl-impersonate: pin-to-gcc12-if-gcc13
* [`0740825f`](https://github.com/NixOS/nixpkgs/commit/0740825ff3d0160f13c3ac9347dfc5c1f08e8d09) osrm-backend: disable-warnings-if-gcc13
* [`cb7a725b`](https://github.com/NixOS/nixpkgs/commit/cb7a725b24bfabfe50e3183a77fd29b176f4ec04) proj: disable-warnings-if-gcc13
* [`bcc99835`](https://github.com/NixOS/nixpkgs/commit/bcc998350b833974c0731eab10e0a5f135721961) gmsh: disable-warnings-if-gcc13
* [`edca7298`](https://github.com/NixOS/nixpkgs/commit/edca72981b98c2d91986f091674265c9e67f4d5c) intel-media-sdk: disable-warnings-if-gcc13
* [`624674c2`](https://github.com/NixOS/nixpkgs/commit/624674c2733ff2fdb9921c0c0b242eb78773a532) waylandpp: disable-warnings-if-gcc13
* [`aef849eb`](https://github.com/NixOS/nixpkgs/commit/aef849eb678fb6c71498fd45aea2767b8015ad7d) gnuradio: disable-warnings-if-gcc13
* [`3b55335a`](https://github.com/NixOS/nixpkgs/commit/3b55335a6ba23a8f7f26214295b5585f8c770c77) boringssl: disable-warnings-if-gcc13
* [`01eeda19`](https://github.com/NixOS/nixpkgs/commit/01eeda19fc976bd20624c58a3654ba112046c381) rippled: disable-warnings-if-gcc13
* [`a05fdec0`](https://github.com/NixOS/nixpkgs/commit/a05fdec038427b5d94e4b16231421a2c64d72a39) litecoin: disable-warnings-if-gcc13
* [`6b49c3a5`](https://github.com/NixOS/nixpkgs/commit/6b49c3a5f6d84739e58587acf3fd3dd8e15f73a0) pcsx2: disable-warnings-if-gcc13
* [`362ef255`](https://github.com/NixOS/nixpkgs/commit/362ef25565b192944a72a2e48615204c309ed761) python3Packages.ecos: disable-warnings-if-gcc13
* [`e490f829`](https://github.com/NixOS/nixpkgs/commit/e490f829f424b00f95e7b02bdad96c608af29a2f) opencollada: disable-warnings-if-gcc13
* [`5fd588a2`](https://github.com/NixOS/nixpkgs/commit/5fd588a2826511a9c53dde13efbc4e84f8eb13d6) reproc: disable-warnings-if-gcc13
* [`c6414567`](https://github.com/NixOS/nixpkgs/commit/c641456714cb62d461da8d54b991a581e2d615a4) memorymapping: disable-warnings-if-gcc13
* [`24c0a68e`](https://github.com/NixOS/nixpkgs/commit/24c0a68e39fef69cd3d52169d9d38fb9cad1ff0b) python3Packages.fasttext: disable-warnings-if-gcc13
* [`ae85fc22`](https://github.com/NixOS/nixpkgs/commit/ae85fc224e1cd460c50e2a107e053bbe9d9a8748) gmsh: disable-warnings-if-gcc13
* [`0d9b2ee1`](https://github.com/NixOS/nixpkgs/commit/0d9b2ee196777f7203c2ee74e8fdb48d092d23f7) usbguard: disable-warnings-if-gcc13
* [`863ffdd1`](https://github.com/NixOS/nixpkgs/commit/863ffdd1cf56e2914426e4e3db1102fe60294251) python3Packages.gmsh: typo fix
* [`f8ae5d47`](https://github.com/NixOS/nixpkgs/commit/f8ae5d476b88bb9ce1b42ca9b795f6bb93f87d02) virtualbox: disable-warnings-if-gcc13
* [`4b31530a`](https://github.com/NixOS/nixpkgs/commit/4b31530a1432c96d0e2f57ff2e2dffe9d3a95914) openmw.tes3mp: disable-warnings-if-gcc13
* [`5c964287`](https://github.com/NixOS/nixpkgs/commit/5c964287288ae617dadc3cf7ef87a1e0c96bf3b8) python-qt: hit it in the head with a hammer
* [`87c56200`](https://github.com/NixOS/nixpkgs/commit/87c56200c8a8aff0575c1e9ac2f3b6230136520f) vertcoind: disable-warnings-if-gcc13
* [`c1f5a91a`](https://github.com/NixOS/nixpkgs/commit/c1f5a91a90aab5860a20e8e4bf2819aa156c5eb3) wownero: disable-warnings-if-gcc13
* [`5cfedeb5`](https://github.com/NixOS/nixpkgs/commit/5cfedeb5579a0086cdbe55d199cd2ba33dc7fa55) litecoind: disable-warnings-if-gcc13
* [`4889f6aa`](https://github.com/NixOS/nixpkgs/commit/4889f6aa4a55f202b135f767f01fd42ae63bd538) pin-to-gcc12-if-gcc13: init
* [`695fe131`](https://github.com/NixOS/nixpkgs/commit/695fe131c264a3cc244c9b07c71335f07bb92452) llvm: use gcc12Stdenv for llvmPackages<=14
* [`cc938b33`](https://github.com/NixOS/nixpkgs/commit/cc938b33066bb676b080357a030eef0bdc5377e8) nix_2_3: pin-to-gcc12-if-gcc13
* [`37e818dd`](https://github.com/NixOS/nixpkgs/commit/37e818dd13b06e2e67de3eeb80cbee021a634525) btor2tools: pin-to-gcc12-if-gcc13
* [`7687cd1a`](https://github.com/NixOS/nixpkgs/commit/7687cd1aa3cc7123c3e5a422b2e09159b42068a0) bazel: pin-to-gcc12-if-gcc13
* [`aeec2ff8`](https://github.com/NixOS/nixpkgs/commit/aeec2ff86fc165d918ddf2ff47686d16080bfb0c) binaryen: pin-to-gcc12-if-gcc13
* [`079cc88a`](https://github.com/NixOS/nixpkgs/commit/079cc88a0c8f6e5043694f90dc3b77314781a33a) bobcat: pin-to-gcc12-if-gcc13
* [`d35d9854`](https://github.com/NixOS/nixpkgs/commit/d35d9854a3ee7c803c0dc1b33f66e45229dd3cc7) spike: pin-to-gcc12-if-gcc13
* [`d1a45de9`](https://github.com/NixOS/nixpkgs/commit/d1a45de91c315c6265a40662428cee62b4f8f274) sdrpp: pin-to-gcc12-if-gcc13
* [`bd06d968`](https://github.com/NixOS/nixpkgs/commit/bd06d96893ae7ffc22e8653e33d035241994255b) rocksdb: pin-to-gcc12-if-gcc13
* [`adfd6245`](https://github.com/NixOS/nixpkgs/commit/adfd624596e6b581f2b22f1826a5cb68bcfed01c) crossguid: pin-to-gcc12-if-gcc13
* [`4032e8a1`](https://github.com/NixOS/nixpkgs/commit/4032e8a14c55a00351a0495f63c86b94e931c289) libfilezilla: pin-to-gcc12-if-gcc13
* [`b9d90fc3`](https://github.com/NixOS/nixpkgs/commit/b9d90fc37898b64fedcff8cd5de9c50b9cfea38f) bees: pin-to-gcc12-if-gcc13
* [`ac04da88`](https://github.com/NixOS/nixpkgs/commit/ac04da88e073dd4cd1a7f3b1c194c5ae0beb599f) waylandpp: pin-to-gcc12-if-gcc13
* [`a0283a7c`](https://github.com/NixOS/nixpkgs/commit/a0283a7cda940f9e52ce76c3b661bb4f12083b0b) envoy: pin-to-gcc12-if-gcc13
* [`ee2a1d4f`](https://github.com/NixOS/nixpkgs/commit/ee2a1d4ffd37799a14e4f7172804ed9cae5622f2) v8: pin-to-gcc12-if-gcc13
* [`cbe33813`](https://github.com/NixOS/nixpkgs/commit/cbe338135a0283bb7eb22c09629191ca7825fbd6) openjfx: pin-to-gcc12-if-gcc13
* [`9e2ac728`](https://github.com/NixOS/nixpkgs/commit/9e2ac72837c8b66f7e0d6e5be644d1266cbd873d) qgrep: pin-to-gcc12-if-gcc13
* [`b1e3c7ac`](https://github.com/NixOS/nixpkgs/commit/b1e3c7ac87880f037fe21b111ab09221279dcfb2) texlive: pin-to-gcc12-if-gcc13
* [`c984d488`](https://github.com/NixOS/nixpkgs/commit/c984d48816386c226748add9d5bd0f2513f6aade) spirv-llvm-translator: disable-warnings-if-gcc13
* [`b334ff1e`](https://github.com/NixOS/nixpkgs/commit/b334ff1e612714cd32caebc0177713ccb6612c78) rocmPackages_5.llvm: use gcc12Stdenv if stdenv.cc.cc.isGNU>=13
* [`59048500`](https://github.com/NixOS/nixpkgs/commit/59048500b27505ef81b13bc0716a2822be616b4e) default-gcc-version: 12 -> 13
* [`f431d7dd`](https://github.com/NixOS/nixpkgs/commit/f431d7ddab38764cb573d340951a090ddcb48de5) binaryen: backport fix for nodejs 20
* [`1a1ab806`](https://github.com/NixOS/nixpkgs/commit/1a1ab8064493870ce3a614bc9a1cb8d49074c503) plasma-wayland-protocols: 1.11.1 -> 1.12.0
* [`9f2af79c`](https://github.com/NixOS/nixpkgs/commit/9f2af79c824ef230964c7b13f80c778df5ddf7e1) libubox: unstable-2023-11-03 -> unstable-2023-11-28
* [`f3b40524`](https://github.com/NixOS/nixpkgs/commit/f3b40524a13b7225a115958b01550724cf366f97) ubus: unstable-2023-11-14 -> unstable-2023-11-28
* [`f54c943f`](https://github.com/NixOS/nixpkgs/commit/f54c943f10644f68b43531bf715ac60513173f9c) ustream-ssl: unstable-2023-02-25 -> unstable-2023-11-11
* [`b91ec197`](https://github.com/NixOS/nixpkgs/commit/b91ec1976c39a53715ed7ee6d2a894da1697fd03) netifd: unstable-2021-04-03 -> unstable-2023-11-27
* [`2c5b11db`](https://github.com/NixOS/nixpkgs/commit/2c5b11db23a63c0563bf6ff8e50eec224e4dcc34) uqmi: unstable-2019-06-27 -> unstable-2023-10-30
* [`1f98a828`](https://github.com/NixOS/nixpkgs/commit/1f98a82849e1b367ef2149f82b66e4a76c015373) libnl: 3.7.0 -> 3.8.0
* [`019b212f`](https://github.com/NixOS/nixpkgs/commit/019b212fe79d3ea65ab6853e577a4658fa87c8b1) ucode: init at 0.0.20231102
* [`74247007`](https://github.com/NixOS/nixpkgs/commit/7424700747a01298a8838cf19ee3bba6275d5c9c) udebug: init at unstable-2023-11-28
* [`e405324e`](https://github.com/NixOS/nixpkgs/commit/e405324e8941cd45f310e403bcd4871655dec796) enchant: 2.6.2 -> 2.6.3
* [`11ba8b69`](https://github.com/NixOS/nixpkgs/commit/11ba8b69a2ec3bd21f9c7520ae2ab18c1c98d750) libaom: 3.7.1 -> 3.8.0
* [`cbda7b45`](https://github.com/NixOS/nixpkgs/commit/cbda7b451e355f4dcaf3391a697a95cb30b6c719) mercurial: 6.5.3 -> 6.6.1
* [`e182281c`](https://github.com/NixOS/nixpkgs/commit/e182281c206d210a7ba13ad54b677775985e339d) pcsclite: add passthru.updateScript
* [`5d04db14`](https://github.com/NixOS/nixpkgs/commit/5d04db1493e1fcc95ebf564a16f97def6374795e) pcsclite: add anthonyroussel to maintainers
* [`9ac67155`](https://github.com/NixOS/nixpkgs/commit/9ac6715549ce35ce0170a4dbf9965e477f5878b4) pcsclite: 1.9.5 -> 2.0.1
* [`4988c9de`](https://github.com/NixOS/nixpkgs/commit/4988c9de461646b7f8cf7de5fb2be2fc22c5429c) pcsclite: switch to fetchFromGitlab
* [`c2206922`](https://github.com/NixOS/nixpkgs/commit/c22069226be743893403c1eb994fca48dce98de0) pcsclite: add passthru.tests.version
* [`56603eb6`](https://github.com/NixOS/nixpkgs/commit/56603eb6ae5af788797d184383473579d5d72ab2) pcsclite: add meta.{changelog,mainProgram}
* [`6fe9a866`](https://github.com/NixOS/nixpkgs/commit/6fe9a866d91219a496a9bb9115bbc27711c88173) mesa: use upstreamed patches for macOS fixes
* [`88f50101`](https://github.com/NixOS/nixpkgs/commit/88f50101ac4b6e019123b107b3e028ab81df6527) nixos/zfs: check pool state with -d, like import
* [`1a489735`](https://github.com/NixOS/nixpkgs/commit/1a489735585c2f8b43e0e49ee3e05905a5dea5bb) luaPackages.fidget-nvim: init at 1.0.0
* [`fe379762`](https://github.com/NixOS/nixpkgs/commit/fe379762a2c030cf9076283701a2dc87497b5222) luaPackages: update on 2023-12-07
* [`d5b50b71`](https://github.com/NixOS/nixpkgs/commit/d5b50b71a65eef026b88278d248d6b941d5e3b45) luaPackages: fix lua_cliargs and toml-edit after update
* [`df40110e`](https://github.com/NixOS/nixpkgs/commit/df40110ea77c48544b79564ac3cf3fc646a7cb3c) luaPackages: unpin compat53
* [`8245a918`](https://github.com/NixOS/nixpkgs/commit/8245a9189050d076d0bbfdb33a0bbeeb86a0f497) luaPackages: pin luuid to 20120509-2
* [`11498aed`](https://github.com/NixOS/nixpkgs/commit/11498aed21cfdc45e93d8243e6458d8883d45214) mupdf: fix bin libmupdf.dylib loading on darwin
* [`efe2d987`](https://github.com/NixOS/nixpkgs/commit/efe2d9878dc8461b052f0b34992657fe28d262b9) directx-headers: 1.610.2 -> 1.611.0
* [`b3b09c5e`](https://github.com/NixOS/nixpkgs/commit/b3b09c5eb29d1f1fcd6899e2d43252dde4e356a0) nixos/nullmailer: be flexible about time related types
* [`d7ea9fe3`](https://github.com/NixOS/nixpkgs/commit/d7ea9fe393dc71eb5c5ffc106e0671515e851f20) nixos/miniflux: allow ints in config
* [`22b52d9c`](https://github.com/NixOS/nixpkgs/commit/22b52d9c975b323cc6a1f51598269b7357cb02fb) Revert "systemd: enable debug info"
* [`8837ce7d`](https://github.com/NixOS/nixpkgs/commit/8837ce7d664b11c9ffe002b46640625e50000bc8) ipu6-drivers: unstable-2023-08-28 -> unstable-2023-11-15
* [`bfca0a84`](https://github.com/NixOS/nixpkgs/commit/bfca0a849ea31e1076b47672458b7b208a1f18cb) ipu6-camera-bin: unstable-2023-02-08 -> unstable-2023-10-26
* [`6835a72a`](https://github.com/NixOS/nixpkgs/commit/6835a72af649f4b0720cc005d458ddf7234b9630) ipu6-camera-hal and icamerasrc updates
* [`5448caf9`](https://github.com/NixOS/nixpkgs/commit/5448caf9476e5e1675bbc12eb438834ec00f6ea0) scons_3_1_2: use github instead of sourceforge direct link
* [`2d13423f`](https://github.com/NixOS/nixpkgs/commit/2d13423feb195aa787332f79759d72591aa54b93) scons_4_1_0: use github instead of sourceforge direct link
* [`70b907a4`](https://github.com/NixOS/nixpkgs/commit/70b907a49601af69b909b72d2d9c53697e4fbf9d) scons_4_5_2: use github instead of sourceforge direct link
* [`f9a1ba69`](https://github.com/NixOS/nixpkgs/commit/f9a1ba6987b55de1ab9836af799028ade39168e5) systemd: add GnuTLS when remote is enabled
* [`ad586e6b`](https://github.com/NixOS/nixpkgs/commit/ad586e6bebef46d3a2e61751b5e028dd261556b3) formats.systemd: init INI-style systemd config file format
* [`9ab63e1a`](https://github.com/NixOS/nixpkgs/commit/9ab63e1ad59d1ed65c561e6b6a38a68e4d69e051) nixos/journald-gateway: init
* [`6410e72f`](https://github.com/NixOS/nixpkgs/commit/6410e72fd241bb481249a69f724502a5f9b62f74) nixos/journald-remote: init
* [`2fb8bd4b`](https://github.com/NixOS/nixpkgs/commit/2fb8bd4baf22958e963e615e79441f4bc446aede) nixos/journald-upload: init
* [`b484343c`](https://github.com/NixOS/nixpkgs/commit/b484343cbc7f5726bdc0d03f340cd9d36476e927) release-notes: mention new journald remote-related new services
* [`302c329a`](https://github.com/NixOS/nixpkgs/commit/302c329ab562e15ef57fd9daf5a304b9dee2f7da) nixos/tests/journal-gateway: init
* [`dadb93b4`](https://github.com/NixOS/nixpkgs/commit/dadb93b425cda51ab81f5838f6de63c5bfcc7f54) nixos/tests/journal-upload: init
* [`7112490c`](https://github.com/NixOS/nixpkgs/commit/7112490cb70e9195c135aff53c56b31e3d644719) systemd: add journal tests to passthru.tests
* [`9bfe785f`](https://github.com/NixOS/nixpkgs/commit/9bfe785f741a78dae5c9511fd7920c3d70b402ea) maintainers: add crschnick
* [`5b38e9fe`](https://github.com/NixOS/nixpkgs/commit/5b38e9fe131035393856b428e87ed03c079b64df) xpipe: init at 1.7.3
* [`eecfbe39`](https://github.com/NixOS/nixpkgs/commit/eecfbe397a82d53bdfbe6527556d5ff3e0a10c30) nixos/(tests/)journald-(remote|upload|gateway): add raitobezarius as a maintainer
* [`1a5bd697`](https://github.com/NixOS/nixpkgs/commit/1a5bd697adecf27385b69352485baa52a6e02fe9) mkDerivation, bintools-wrapper: move defaultHardeningFlags determination to bintools-wrapper
* [`dc2247a3`](https://github.com/NixOS/nixpkgs/commit/dc2247a3b56ba1bfef5bb48499eb0d36ad2e9ff3) stdenvAdapters: add withDefaultHardeningFlags
* [`d7bcf97d`](https://github.com/NixOS/nixpkgs/commit/d7bcf97d774ade58ab33836aa421ea3dca27bf86) got: 0.94 -> 0.95, cleanup
* [`90ee1601`](https://github.com/NixOS/nixpkgs/commit/90ee16016ccf826fcfc80201f306b6621906f9d6) ibm-sw-tpm2: add Darwin support
* [`87a5f1a2`](https://github.com/NixOS/nixpkgs/commit/87a5f1a2e663db79db079f91638fae98e22f92d7) wails: 2.6.0 -> 2.7.1
* [`904e7ce0`](https://github.com/NixOS/nixpkgs/commit/904e7ce05b2366b960a7412354e31f8f9af227ab) pypy: add option to change optimization level, update homepage, cleanup
* [`6a58aac6`](https://github.com/NixOS/nixpkgs/commit/6a58aac66886cd834381192abb7f7cd918cf537e) pkgsStatic.cyrus_sasl: fix build
* [`d896ef6c`](https://github.com/NixOS/nixpkgs/commit/d896ef6c803c706821fcdc103aa093767a7cab63) nss_esr: 3.90 -> 3.90.1
* [`d8c9c776`](https://github.com/NixOS/nixpkgs/commit/d8c9c776b52a7827a7160b3dcc6aadd6bb1a1d51) libsecret: 0.21.1 -> 0.21.2
* [`2f583fdd`](https://github.com/NixOS/nixpkgs/commit/2f583fdd0567fdd3fbadf1b31b530a372f5ee1d8) hwdata: 0.376 -> 0.377-2
* [`85f62516`](https://github.com/NixOS/nixpkgs/commit/85f625165c8ae94b61d81776d4f635c724c153bf) poetry: compose packageOverrides if already defined for python interpreter
* [`0da01763`](https://github.com/NixOS/nixpkgs/commit/0da017634639700c0a0e46bfd84cbc1a5005beba) v4l2loopback: unstable-2023-02-19 -> unstable-2023-11-23
* [`1381007a`](https://github.com/NixOS/nixpkgs/commit/1381007a828e52f932d8542c1fb4d9bd4727625a) ipu6-drivers: unstable-2023-11-15 -> unstable-2023-11-24
* [`25659148`](https://github.com/NixOS/nixpkgs/commit/25659148ef4200e0c53a189dd89898602f95bb26) ivsc-driver: unstable-2023-03-10 -> unstable-2023-11-09
* [`ad8dfeab`](https://github.com/NixOS/nixpkgs/commit/ad8dfeabe7bf852ea938592bcd2fad76db1f92ee) ivsc-firmware: unstable-2022-11-02 -> unstable-2023-08-11
* [`fc2013e3`](https://github.com/NixOS/nixpkgs/commit/fc2013e3ebe0e4f2c3ff87159b7784216d26c6b7) ipu6-camera-bins: rename from ipu6-camera-bin
* [`a541b15f`](https://github.com/NixOS/nixpkgs/commit/a541b15ffe27e2b31af2642f8cf2cad4aeca461f) ipu6-camera-bins: remove unnecessary post-fixup steps
* [`ae5f61ea`](https://github.com/NixOS/nixpkgs/commit/ae5f61ea9eab9699847a1ce9f433a2ce34dc63fa) ipu6-camera-hal: remove unnecessary post-fixup and cmake flag
* [`74f7417e`](https://github.com/NixOS/nixpkgs/commit/74f7417eacd20713ec67582c26718d5d3943eebc) ipu6-camera-hal: patch libs to find platform-specific ipu6-camera-bins
* [`5adf1a2f`](https://github.com/NixOS/nixpkgs/commit/5adf1a2f48e793c310978880a4b861da1ba6891e) icamerasrc: remove unnecessary rec
* [`85169ed6`](https://github.com/NixOS/nixpkgs/commit/85169ed61cb1a7bca075084e3ebe3cb96e359205) nixos/ipu6: add support for ipu6epmtl
* [`7a32e1f8`](https://github.com/NixOS/nixpkgs/commit/7a32e1f807971e665ea4f8be123f8ac901b74454) gebaar-libinput: fix build with gcc 11+
* [`4c105a18`](https://github.com/NixOS/nixpkgs/commit/4c105a18caa4f0d71776bc7ce7e50d4f92dc4a18) s2n-tls: 1.3.56 -> 1.4.0
* [`a1749deb`](https://github.com/NixOS/nixpkgs/commit/a1749debdbecd07125d6b01abd753279da100322) gnome-extension-manager: 0.4.2 -> 0.4.3
* [`bf98ebb8`](https://github.com/NixOS/nixpkgs/commit/bf98ebb80bcbe10fadda204233687e54f153e467) gnome-extension-manager: update dependency list
* [`5841f51f`](https://github.com/NixOS/nixpkgs/commit/5841f51f88b71070e39433b0c6a07d59b35ec0b9) postgresql: add pam support on linux
* [`50ce6586`](https://github.com/NixOS/nixpkgs/commit/50ce658660bbe7c008f8a5ad41c1bc12a941a254) svt-av1: 1.7.0 -> 1.8.0
* [`6db6c6df`](https://github.com/NixOS/nixpkgs/commit/6db6c6df7b29062f980150435cf357efee22d13b) llvmPackages_*: update name for LLVMgold patch for clang >= 11
* [`3e8355df`](https://github.com/NixOS/nixpkgs/commit/3e8355df84c7352c908bfbe3ac0231c9d6ea24a2) llvmPackages_{16,17,git}: reenable LLVMgold plugin
* [`e665b892`](https://github.com/NixOS/nixpkgs/commit/e665b892b3c79ee8bf1063df6dd80f593aac5389) antidote: 1.9.3 -> 1.9.4
* [`a2f773b3`](https://github.com/NixOS/nixpkgs/commit/a2f773b358b9716147a68abe7262340bcdf862c4) bcc: 0.28.0 -> 0.29.1
* [`7bd712b1`](https://github.com/NixOS/nixpkgs/commit/7bd712b1de14a699651f1d7f8a953ef5627ca67d) xmlcopyeditor: fix build with libxml2 2.12
* [`f89cce2e`](https://github.com/NixOS/nixpkgs/commit/f89cce2e02bf64297f211dc8a4549f54bc5ed024) gnome-extension-manager: add Meson options
* [`0d883c6e`](https://github.com/NixOS/nixpkgs/commit/0d883c6e248d2482d74e68bafcef454f5eadb566) gnome-extension-manager: add meta.mainProgram
* [`1ff13b86`](https://github.com/NixOS/nixpkgs/commit/1ff13b86c8bc77c72d1fafd717d739941f46a247) fasthenry: init at 3.0.1
* [`8e900345`](https://github.com/NixOS/nixpkgs/commit/8e9003456f916a0562125baf2ce53d24f2a73900) jq: 1.7 -> 1.7.1
* [`271a204c`](https://github.com/NixOS/nixpkgs/commit/271a204ced19f1db030ed40b6b0f22844ec345b2) json-c: 0.16 -> 0.17
* [`59169c5d`](https://github.com/NixOS/nixpkgs/commit/59169c5dc342c8a8a660bf1ed5854da0966bb74c) xsimd: 11.2.0 -> 12.1.1
* [`abd1d7f9`](https://github.com/NixOS/nixpkgs/commit/abd1d7f93319df76c6fee7aee7ecd39ec6136d62) mesa: 23.1.7 -> 23.3.1, bump patches
* [`4f9b3a7e`](https://github.com/NixOS/nixpkgs/commit/4f9b3a7ec30f0a00d904f57084978df84ac43587) mesa: use default llvmPackages
* [`9faad7fb`](https://github.com/NixOS/nixpkgs/commit/9faad7fb0b2a3a20aa0632573e78af02ff928f29) auto-patchelf: add support for __structuredAttrs
* [`45901c42`](https://github.com/NixOS/nixpkgs/commit/45901c42fc91c1d1d46a811b9578b4d92da98135) auto-patchelf: improve deprecation check by searching all elements
* [`3d39b856`](https://github.com/NixOS/nixpkgs/commit/3d39b8561d1cd8d2af029b868f08db6dceec526a) libwacom: 2.8.0 -> 2.9.0
* [`ad98277a`](https://github.com/NixOS/nixpkgs/commit/ad98277a948005906d49c8234b5ff18bf8bc2b06) libwacom: correct license
* [`3e54fa94`](https://github.com/NixOS/nixpkgs/commit/3e54fa949cdcd4d69ecb99267c29c8aeb70a30d6) hedgewars: hold SDL2_image back on 2.6 branch
* [`90be38f7`](https://github.com/NixOS/nixpkgs/commit/90be38f71b22b838a87426b71e0282f50436c832) libjodycode: init at 3.1
* [`e35bf8ef`](https://github.com/NixOS/nixpkgs/commit/e35bf8efa0778e6fa928dc4d0da9104907f20848) jdupes: 1.21.0 -> 1.27.3
* [`8c377491`](https://github.com/NixOS/nixpkgs/commit/8c37749143e442258de68bfaa32d8976f8ffd87d) jdupes.meta.maintainers: remove romildo
* [`3fd02dbe`](https://github.com/NixOS/nixpkgs/commit/3fd02dbe809e913e4b8e047b6c5dbed8db319255) fission: 1.19.0 -> 1.20.0
* [`ad7141ef`](https://github.com/NixOS/nixpkgs/commit/ad7141efd07eff2acf24cf7586b0ed5f7ff9c6b5) mesa: backport patches to fix build on Darwin and 32-bit platforms
* [`237c0484`](https://github.com/NixOS/nixpkgs/commit/237c0484fe86d147654e54c1a264fad6d578c5c9) nix-web: 0.1.0 -> 0.2.0
* [`7b971ce7`](https://github.com/NixOS/nixpkgs/commit/7b971ce7d12291ee25f85f2ad3be5f3d6adcf521) nix-web: Build on platforms.unix, depend on OpenSSL if not on Darwin
* [`217f8078`](https://github.com/NixOS/nixpkgs/commit/217f80780d83e3c392412e4d93b6e3d87a8c1e1a) kde/frameworks: 5.112 -> 5.113
* [`38d918c0`](https://github.com/NixOS/nixpkgs/commit/38d918c0fe7b659070fd5818ab3e361807aca28b) libsass: add patch for CVE-2022-26592, CVE-2022-43357 & CVE-2022-43358
* [`32854236`](https://github.com/NixOS/nixpkgs/commit/328542368f1a39b1725a4af0e1b348770ee23b5f) libsass: add some key reverse-dependencies to passthru.tests
* [`49a64c97`](https://github.com/NixOS/nixpkgs/commit/49a64c97c0d904446a4bf9478f7157ae056c50cb) libxml2: 2.11.5 → 2.12.3
* [`350d4c7d`](https://github.com/NixOS/nixpkgs/commit/350d4c7d1d96fcab1fbc3f70101bbdaf102d6182) glib: fix pkg-config tests
* [`95d453d5`](https://github.com/NixOS/nixpkgs/commit/95d453d59cd6726b6324b65be31f622cbe126f3b) glib: 2.78.1 → 2.78.3
* [`4071c294`](https://github.com/NixOS/nixpkgs/commit/4071c294ac96b0b9abce50c9574ce45378e44ba1) nixos/lxd: convert cfg.package to mkPackageOption
* [`e19bed44`](https://github.com/NixOS/nixpkgs/commit/e19bed44b290fbb9ef605aabb3da77af80a3624f) numactl: drop libatomic workaround for riscv
* [`dbc36629`](https://github.com/NixOS/nixpkgs/commit/dbc366296d8450ccddba6d29486679f4ef3ca868) cargo,rustc: 1.74.0 -> 1.74.1
* [`c77ba710`](https://github.com/NixOS/nixpkgs/commit/c77ba710fefc02b4aacd007815efba0b2edf5fc9) mariadb: drop libatomic workaround for riscv
* [`f197cb43`](https://github.com/NixOS/nixpkgs/commit/f197cb435d307f747df8551dc753e1b468519866) zstd: drop libatomic workaround for riscv
* [`9eaa23ac`](https://github.com/NixOS/nixpkgs/commit/9eaa23ac72bc10ef21f0a0a86b335cf6d990ac13) glslang: drop libatomic workaround for riscv
* [`dbb7b67b`](https://github.com/NixOS/nixpkgs/commit/dbb7b67b569cf5149ca38347b6457806cfdb7c76) aws-sdk-cpp: drop libatomic workaround for riscv
* [`8b2757a1`](https://github.com/NixOS/nixpkgs/commit/8b2757a19198c76836b3ba8df664431951b9c60a) cmake: drop libatomic workaround for riscv
* [`945e8a25`](https://github.com/NixOS/nixpkgs/commit/945e8a25905b6915fde365d8c6ce2830f26a6816) libjxl: drop libatomic workaround for riscv
* [`908cac75`](https://github.com/NixOS/nixpkgs/commit/908cac752a39953ee517f86fda4aae7a076b091a) python3Packages.tokenizers: pack test assets in linkFarm
* [`98b66ac6`](https://github.com/NixOS/nixpkgs/commit/98b66ac6c7ac1a48d3efaafde663befaae82d15b) libvmaf: 2.3.1 -> 3.0.0
* [`f1f12bc3`](https://github.com/NixOS/nixpkgs/commit/f1f12bc39a1b69ec0e89e6dc7945f473e569da6b) kas: init at 4.1
* [`3d69cf4b`](https://github.com/NixOS/nixpkgs/commit/3d69cf4bdda871fc03033a2fddd4a601bf097b5a) jbig2dec: fix cross-compilation
* [`beea4df6`](https://github.com/NixOS/nixpkgs/commit/beea4df6c80424cbdf305fbec139028670cfeb12) librsvg: 2.57.0 -> 2.57.1
* [`038a9683`](https://github.com/NixOS/nixpkgs/commit/038a96835b20a7a74223c65c955611390bb4cc94) python3.pkgs.beautifulsoup4: Fix build with libxml2 2.12
* [`17d12f1b`](https://github.com/NixOS/nixpkgs/commit/17d12f1bc1df0e0988d3ef08394f6b4f0eb780f1) sharutils: Fix static build on macOS
* [`21714bc0`](https://github.com/NixOS/nixpkgs/commit/21714bc071d192f02277ecb0ca9e0f2740c42582) unittest-cpp: fix 'Version:' field in .pc file
* [`6557e130`](https://github.com/NixOS/nixpkgs/commit/6557e130ae796b35cca9bc183a6db94d1f7ae7b2) libssh: 0.10.5 -> 0.10.6
* [`2e223c78`](https://github.com/NixOS/nixpkgs/commit/2e223c782a8fcf954b6e35a63815d17a779c91a5) procps: enable 8bit support, thereby fix [nixos/nixpkgs⁠#275220](https://togithub.com/nixos/nixpkgs/issues/275220)
* [`093c5949`](https://github.com/NixOS/nixpkgs/commit/093c5949e5cbafcd4464b30c881717e1a177e94d) fanbox-dl: init at 0.17.0
* [`76f87e44`](https://github.com/NixOS/nixpkgs/commit/76f87e44ea6cdbccfebdf21088ef6d7c08906160) listenbrainz-mpd: 2.3.1 -> 2.3.2
* [`be85c770`](https://github.com/NixOS/nixpkgs/commit/be85c770766938c9ba107fc9f763748c109e1854) plugdata: init at 0.8.0
* [`ca8a6d8c`](https://github.com/NixOS/nixpkgs/commit/ca8a6d8c19ed6534c6e4b088e2348c261cc2bc33) wrapRustcWith: allow --sysroot to be overridden
* [`1ee9f3c8`](https://github.com/NixOS/nixpkgs/commit/1ee9f3c87c12262520c9aa6a1b4ff5f056dad652) Revert "rust-hypervisor-firmware: fix build ([nixos/nixpkgs⁠#257345](https://togithub.com/nixos/nixpkgs/issues/257345))"
* [`fabbe931`](https://github.com/NixOS/nixpkgs/commit/fabbe931ab45651edc154693c7b06cc8ce171e28) pdal: enable unit tests
* [`2b0bf78d`](https://github.com/NixOS/nixpkgs/commit/2b0bf78df61b2b05feb05f364fad1ab519645713) nixos/snmpd: init
* [`afdbb7a9`](https://github.com/NixOS/nixpkgs/commit/afdbb7a9c0c6f9ec2013c4729bc4fad318b2702c) nixos/snmpd: add nixos test
* [`427268d1`](https://github.com/NixOS/nixpkgs/commit/427268d17e11b5de4d715b4d2f162716f771be23) maintainers: add vncsb
* [`aed25dc7`](https://github.com/NixOS/nixpkgs/commit/aed25dc7da77b6c69bac7ba0624818a933db4f81) bloodhound-py: 1.6.1 > 1.7.1 + refactor
* [`368dd7d0`](https://github.com/NixOS/nixpkgs/commit/368dd7d0b22cce316f7ee2d878faf6707d4eecff) boxed-cpp: init at 1.1.0
* [`bf0cf6f2`](https://github.com/NixOS/nixpkgs/commit/bf0cf6f215eb30d6f00c0c50c948e28234b80b6c) libunicode: 0.3.0 -> 0.4.0
* [`fa7f4072`](https://github.com/NixOS/nixpkgs/commit/fa7f4072d24cf8a56aef48436059255eea76bf49) contour: 0.3.12.262 -> 0.4.0.6245
* [`07520a61`](https://github.com/NixOS/nixpkgs/commit/07520a61c5938ce0f892a657d6d590938dddaba9) netexec: init at 1.1.0
* [`0af190cd`](https://github.com/NixOS/nixpkgs/commit/0af190cd57538d91a2b3a198af3ed8ed398c79b0) electron: add missing `meta.mainProgram`
* [`60082467`](https://github.com/NixOS/nixpkgs/commit/6008246790d4b3eb27c02d3a9b9424b91f55a8b4) systemd: disable NSCD when DNSSEC validation is disabled in timesyncd
* [`a648bdee`](https://github.com/NixOS/nixpkgs/commit/a648bdeede3883aeb2d9ecda43ad0f2455879abe) python311Packages.packaging: 23.1 -> 23.2
* [`8f3162f8`](https://github.com/NixOS/nixpkgs/commit/8f3162f83fcccf26bf50c55ff960fd2dee5264b2) python3.pkgs.pythonRuntimeDepsCheckHook: init
* [`0c0f77f0`](https://github.com/NixOS/nixpkgs/commit/0c0f77f0191be2a252d42616b3d6da9becd6f568) python311Packages.sphinxcontrib-*: disable runtime deps check
* [`ed0b7d3e`](https://github.com/NixOS/nixpkgs/commit/ed0b7d3e9c65911146a9b90a44fe9d17c23ea0a2) python39Packages.build: drop dependency on importlib-metadata
* [`f31e6ef8`](https://github.com/NixOS/nixpkgs/commit/f31e6ef87a8afacb62edec7af3f3c00eb4486c77) python311Packages.paginate: init at 0.5.6
* [`98512358`](https://github.com/NixOS/nixpkgs/commit/9851235821385de33a50b788bd4321e70e72b203) python311Packages.mkdocs-minify-plugin: rename from mkdocs-minify
* [`8a301b77`](https://github.com/NixOS/nixpkgs/commit/8a301b77011490a452b8010b56a2b602394c9349) python311Packages.mkdos-material: 9.3.1 -> 9.4.14
* [`c3b3c463`](https://github.com/NixOS/nixpkgs/commit/c3b3c463b2d3e6c6f485b631112b2b332529fefb) python311Packages.sqlalchemy: drop egg_info build tag
* [`a91bcf87`](https://github.com/NixOS/nixpkgs/commit/a91bcf877bb08704e305f2572c3d2650a3b734a9) python311Packages.packaging: refactor and adopt
* [`a1c41295`](https://github.com/NixOS/nixpkgs/commit/a1c4129514c4d977021c5551c532806e0de30dd7) python311Packages.cachetools: 5.3.0 -> 5.3.2
* [`30a8eeb2`](https://github.com/NixOS/nixpkgs/commit/30a8eeb2511e12d321d185047ece5714e3f45c90) python311Packages.httpbin: fix build, refactor
* [`726629ec`](https://github.com/NixOS/nixpkgs/commit/726629eca68a958b53c5c4fdfe07faa7963966f7) python311Packages.questinary: relax prompt-toolkit constraint
* [`0bf566dc`](https://github.com/NixOS/nixpkgs/commit/0bf566dcc8d947ffff30c4e0511493138210eb21) python311Packages.sphinx-prompt: relax dependency constraints
* [`7db4bc88`](https://github.com/NixOS/nixpkgs/commit/7db4bc88ac97894eba76dcba521c9a72653049ac) python311Packages.readchar: fix version, use pep517 builder
* [`ca6ecf0c`](https://github.com/NixOS/nixpkgs/commit/ca6ecf0c669b633a31edc015b477bd877ce20960) python311Packages.miauth: fix build
* [`59f02031`](https://github.com/NixOS/nixpkgs/commit/59f02031e95b4b840651990dcb27b3fc79d43766) python311Packages.typing-extensions: 4.7.1 -> 4.8.0
* [`e9babd93`](https://github.com/NixOS/nixpkgs/commit/e9babd935d5440ceaec06b1d6fd6ba0f34dfe503) home-assistant: relax lru-dict constraint, clean up
* [`b1d113c0`](https://github.com/NixOS/nixpkgs/commit/b1d113c0eb1592ee30187fc7107c54468a38df5f) wyoming-piper: relax wyoming constraint
* [`c48d94c5`](https://github.com/NixOS/nixpkgs/commit/c48d94c573baeb81226e99bf6ff08b429bde4be6) python311Packages.python-osc: fix build, enable tests
* [`b8fbb294`](https://github.com/NixOS/nixpkgs/commit/b8fbb2942dc042a79bd775cd68495dfababa0b62) python311Packages.trove-classifiers: 2023.8.7 -> 2023.11.29
* [`bce7bb08`](https://github.com/NixOS/nixpkgs/commit/bce7bb08f8fe9d9164c4566cc78961bc0baf0ecb) python311Packages.mkdocs: 1.5.2 -> 1.5.3
* [`4bdb2120`](https://github.com/NixOS/nixpkgs/commit/4bdb2120acc36d6ad99079635d1a41661d5dd0f3) python311Packages.mkdocs-material-extensions: 1.1.1 -> 1.3.1
* [`5bd94e68`](https://github.com/NixOS/nixpkgs/commit/5bd94e6862ad47ce994a844877b6f4c3f3845043) python311Packages.click: disable failing test
* [`9e89f0fa`](https://github.com/NixOS/nixpkgs/commit/9e89f0fad50f8577e70920092f8ec31c8254d159) python311Packages.pydantic: disable strict docs building
* [`c87fe643`](https://github.com/NixOS/nixpkgs/commit/c87fe643e7bf1567af2aeefe3f81fe5e6c6ca3b3) python311Packages.pysml: propagate aiohttp
* [`be5b79be`](https://github.com/NixOS/nixpkgs/commit/be5b79beae52accdabe1e0680dbcbf6477972dea) homeassistant-satellite: relax aiohttp constraint
* [`2addce9d`](https://github.com/NixOS/nixpkgs/commit/2addce9d0b8583151db224f9b4036c9c37050d4a) python311Packages.playwright: relax pyee constraint
* [`9ec3a75d`](https://github.com/NixOS/nixpkgs/commit/9ec3a75daab3a95382ccbfac2f75686aa86ce9f2) python311Packages.mitmproxy: use -mitmproxy forks of dependencies
* [`a32f0741`](https://github.com/NixOS/nixpkgs/commit/a32f0741b539360eb255675c247822253a8d316e) pinnwand: relax docutils constraint
* [`735551d0`](https://github.com/NixOS/nixpkgs/commit/735551d0a325cd8904d2f8512978541f8d01f2fe) pysentation: relax click and rich constraints
* [`46e7e7b1`](https://github.com/NixOS/nixpkgs/commit/46e7e7b1b0fb55ea9830d35d357ab53ecdd224a0) python311Packages.aiormq: 6.7.7 -> 6.7.6
* [`dd3502a3`](https://github.com/NixOS/nixpkgs/commit/dd3502a32a1b76e2428b398b0c4d04cf63fa6130) python311Packages.auth0-python: 4.6.0 -> 4.6.1
* [`50321c95`](https://github.com/NixOS/nixpkgs/commit/50321c955aeb3e5a2754432a0fd35435fb448d7e) airlift: drop dependency on argparse
* [`29504f76`](https://github.com/NixOS/nixpkgs/commit/29504f7693db6e7a2fea95e6171512928264db67) python311Packages.bork: relax dependency constraints
* [`1609acb3`](https://github.com/NixOS/nixpkgs/commit/1609acb3e221a50f390fee708f9df2bbd6b5f86a) python311Packages.clickhouse-cli: relax sqlparse constraint
* [`fe9ca43b`](https://github.com/NixOS/nixpkgs/commit/fe9ca43b32caa343d2895c4247043646b3c479cf) python311Packages.distributed: relax dask constraint
* [`18eeca26`](https://github.com/NixOS/nixpkgs/commit/18eeca26f17c40db25b82c75754f8820088a666e) python311Packages.jupyter-book: update relaxed deps
* [`f272c42d`](https://github.com/NixOS/nixpkgs/commit/f272c42ddb03418e18465ebc775fa1b8b86de335) websecprobe: 0.0.10 -> 0.0.11
* [`3c001233`](https://github.com/NixOS/nixpkgs/commit/3c001233fdd363a7c55ec57cadf1a6794b4ff41d) python311Packages.rnginline: relax docopt-ng constraint
* [`89d6208e`](https://github.com/NixOS/nixpkgs/commit/89d6208e634e21bfa1860420010623f7b62e766f) python311Packages.thelogrus: relax pyaml constraint
* [`47c4d249`](https://github.com/NixOS/nixpkgs/commit/47c4d24989d40bbf7eaf0a08b53a83d8f083c432) python311Packages.sphinx-mdinclude: mark broken
* [`cd798668`](https://github.com/NixOS/nixpkgs/commit/cd798668685b950150a3f6c86891df1fc46c1722) python311Packages.pysuez: propagate regex, remove datetime dependency
* [`2541f38d`](https://github.com/NixOS/nixpkgs/commit/2541f38d9521b5139d1a25fc31d3f7362fa2164d) python311Packages.pysolcast: propagate anyconfig
* [`bb958df5`](https://github.com/NixOS/nixpkgs/commit/bb958df5e0ef886f08c7722b7c1e9d1ecbeec4c2) python311Packages.pyfaidx: propagate importlib-metadata
* [`cbf90bfe`](https://github.com/NixOS/nixpkgs/commit/cbf90bfeb1b12a0a70f85d1390919dbc03cc28b7) python311Packages.lsprotocol: 2023.0.0b1 -> 2023.0.0
* [`ac154f60`](https://github.com/NixOS/nixpkgs/commit/ac154f6003ad2ed1e4472498ffdcd21fc9b7d735) python311Packages.fastapi: 0.103.1 -> 0.104.1
* [`65738f89`](https://github.com/NixOS/nixpkgs/commit/65738f8959f048058083ccf6bbf7dcb5169d218e) python311Packages.pomegranate: update propagated dependencies
* [`ab55124a`](https://github.com/NixOS/nixpkgs/commit/ab55124ae8aa8ad07af8008eec867c424493afbc) python311Packages.barectf: relax various dependency constraints
* [`75ea9f54`](https://github.com/NixOS/nixpkgs/commit/75ea9f544376db3032d9d7c1eb27ed888a9a96e4) python311Packages.aiowatttime: 2023.08.0 -> 2023.10.0
* [`f00f929a`](https://github.com/NixOS/nixpkgs/commit/f00f929ac2938a9c766da2ff794d9ccc8d731610) python311Packages.uqbar: drop black dependency
* [`ceffebc6`](https://github.com/NixOS/nixpkgs/commit/ceffebc69c6f000acc89805ae2f5cb6a04f69ffc) python311Packages.requirements-detector: fix build
* [`8fbd41a7`](https://github.com/NixOS/nixpkgs/commit/8fbd41a744998cb0c6098b7b6db82869f1b654f0) python311Packages.pyarr: fix build
* [`b884735c`](https://github.com/NixOS/nixpkgs/commit/b884735cb97f0e5acf7a7c0c351acc979628e1fa) python311Packages.plyfile: 1.0.2 -> 1.0.2
* [`af2cfab4`](https://github.com/NixOS/nixpkgs/commit/af2cfab40cf2b7fec5909808aaddfc9723783723) python311Packages.yarl: 1.9.2 -> 1.9.3
* [`6be64b26`](https://github.com/NixOS/nixpkgs/commit/6be64b269c1953058e93f3d4cced5dce6c3c28e5) python311Packages.time-machine: 2.12.0 -> 2.13.0
* [`6faeba40`](https://github.com/NixOS/nixpkgs/commit/6faeba40e784f037b7cd9ce05279a07dbea03be6) python311Packages.aiohttp: 3.8.6 -> 3.9.0
* [`ae323dc9`](https://github.com/NixOS/nixpkgs/commit/ae323dc9f52dee832f046b98fb1c588981780ecc) python310Packages.aiohttp: unvendor llhttp
* [`1f45a5fe`](https://github.com/NixOS/nixpkgs/commit/1f45a5fe78c8c920c4650c0c592629943c36f086) python311Packages.aiohttp: 3.9.0 -> 3.9.1
* [`c8537968`](https://github.com/NixOS/nixpkgs/commit/c8537968c787cff0407ba07dcb8ebc9e70abb897) python311Packages.aioresponses: 0.7.4 -> 0.7.6
* [`7bc8a6b0`](https://github.com/NixOS/nixpkgs/commit/7bc8a6b0bc2d21accce3c68822f1783ceb6ed02b) python311Packages.httpcore: 0.18.0 -> 1.0.2
* [`fef98474`](https://github.com/NixOS/nixpkgs/commit/fef98474ee8b54eedc5064c71c53af45593e9ec2) python311Packages.idna: 3.4 -> 3.6
* [`7c52a3d9`](https://github.com/NixOS/nixpkgs/commit/7c52a3d97dbf09a6946955f89f3d1b673495a742) python311Packages.certifi: 2023.07.22 -> 2023.11.17
* [`6aa973e1`](https://github.com/NixOS/nixpkgs/commit/6aa973e1c825656ec0706d9aeb53e3f9e119464e) python312Packages.eventlet: disable tests
* [`977e62dc`](https://github.com/NixOS/nixpkgs/commit/977e62dc909a49841968531ff186814456c8b184) python311Packages.httpx: 0.25.0 -> 0.25.2
* [`0da50dbd`](https://github.com/NixOS/nixpkgs/commit/0da50dbd3351eea30d6d34b75348768360f73351) home-assistant: relax httpx, yarl constraints
* [`78c27b37`](https://github.com/NixOS/nixpkgs/commit/78c27b37571b76e71a62d5b8cb4accc4922544cf) python311Packages.apricot-select: move nose to check deps
* [`d2bd23cd`](https://github.com/NixOS/nixpkgs/commit/d2bd23cdf0510890e55c4d70f1f07dd555d040ac) python312Packages.pyrfc3339: disable tests
* [`67d45947`](https://github.com/NixOS/nixpkgs/commit/67d45947297a2f92364200c65503151957189734) python311Packages.babel: 2.12.1 -> 2.14.0
* [`2ca4b56f`](https://github.com/NixOS/nixpkgs/commit/2ca4b56f559706f956a392c0df030926e01083cc) python311Packages.itsdangerous: ignore deprecation warnings
* [`c249d27c`](https://github.com/NixOS/nixpkgs/commit/c249d27c7c221cc3b4f98f872210f45761d38f5d) python311Packages.testtools: 2.6.0 -> 2.7.1
* [`01d0a575`](https://github.com/NixOS/nixpkgs/commit/01d0a5751fc6567c483a734c0c20b6124be2a25f) python312Packages.curio: fix build
* [`23aee670`](https://github.com/NixOS/nixpkgs/commit/23aee6701a2c70f080b01b659fcc833692ff3ff6) python312Packages.paginate: disable failing tests
* [`7737ca94`](https://github.com/NixOS/nixpkgs/commit/7737ca94b8faf850874c5ae232da4d716e52608c) python312Packages.pytest-trio: drop dependency on async-generator
* [`46e78187`](https://github.com/NixOS/nixpkgs/commit/46e781875688d9eccda27421af20147032e13802) python311Packages.setuptools: 68.2.2 -> 69.0.2
* [`c7630445`](https://github.com/NixOS/nixpkgs/commit/c763044555b90720e5138eba0cdfe11e677bb71b) python311Packages.cython: use pep517 builder
* [`ce4eec79`](https://github.com/NixOS/nixpkgs/commit/ce4eec791f3ca981ad1779ef157874d56efe5bc0) python311Packages.hatch-vcs: 0.3.0 -> 0.4.0
* [`bd7f8434`](https://github.com/NixOS/nixpkgs/commit/bd7f8434f376fe0aa15a8cee2587293921fb9934) python311Packages.cython_3: 3.0.3 -> 3.0.6
* [`9a81b8e7`](https://github.com/NixOS/nixpkgs/commit/9a81b8e7eb32bfb9d0febbd96ec54c8504d19d0e) python311Packages.filelock: 3.12.4 -> 3.13.1
* [`da763cf1`](https://github.com/NixOS/nixpkgs/commit/da763cf18959bf9faa01b07bff3f7b7f0ed5e59e) python311Packages.poetry-core: 1.7.0 -> 1.8.1
* [`bd5c0975`](https://github.com/NixOS/nixpkgs/commit/bd5c09754f101c161db538744c46170d7735fde0) python311Packages.pip: 23.2.1 -> 23.3.1
* [`b3061380`](https://github.com/NixOS/nixpkgs/commit/b30613803ceefc92fa1d87a7879be334f3b54183) python311Packages.pytest-mock: 3.11.1 -> 3.12.0
* [`4dd353cb`](https://github.com/NixOS/nixpkgs/commit/4dd353cbb4f2f80fb724bcb9804c49784edb388e) python311Packages.pdm-backend: 2.1.6 -> 2.1.7
* [`32579c2c`](https://github.com/NixOS/nixpkgs/commit/32579c2c2dd6d9575d0a54ca196e48d73e77cab8) python311Packages.hypothesis: 6.84.3 -> 6.91.0
* [`effe4935`](https://github.com/NixOS/nixpkgs/commit/effe4935a112a55ec27e463440c93ba73fa958c8) python311Packages.exceptiongroup: 1.1.2 -> 1.2.0
* [`1ed4386e`](https://github.com/NixOS/nixpkgs/commit/1ed4386ee3efc2d03a383677e54199a4e5b8852b) python311Packages.urllib3: 2.0.7 -> 2.1.0
* [`0d2fb4e0`](https://github.com/NixOS/nixpkgs/commit/0d2fb4e0e5c76d56cca8503a274f1e87df9854f0) python311Packages.pytest-xdist: 3.3.1 -> 3.5.0
* [`6108e5bd`](https://github.com/NixOS/nixpkgs/commit/6108e5bd7a7239c48f099a0ca936170c2de29a9e) python3Packages.setuptools-scm: 7.1.0 -> 8.0.4
* [`4c1f2493`](https://github.com/NixOS/nixpkgs/commit/4c1f249333bce383f24ee41ab8aa12da970872cd) setuptools-scm: add setup hook for version and sources inclusion
* [`4729b781`](https://github.com/NixOS/nixpkgs/commit/4729b781a8145e36939cc1a9e1f055214d30ceff) python311Packages.scipy: 1.11.3 -> 1.11.4
* [`03ed4664`](https://github.com/NixOS/nixpkgs/commit/03ed4664424b83f3a058fbf50258a40dd7685876) python311Packages.trio: 0.22.2 -> 0.23.1
* [`83c96fdb`](https://github.com/NixOS/nixpkgs/commit/83c96fdbca0c20d248615f13b11417cec7aa241f) python311Packages.anyio: 4.0.0 -> 4.1.0
* [`049599bb`](https://github.com/NixOS/nixpkgs/commit/049599bbc6aba383d7ea7ffe3209ff9ccace568f) python311Packages.dirty-equals: 0.7.0 -> 0.7.1
* [`c2c64d88`](https://github.com/NixOS/nixpkgs/commit/c2c64d8895dd9d6dc8729930444c7649ba1f55dc) python3Packages.bcrypt: remove dependency on cffi
* [`05167dd5`](https://github.com/NixOS/nixpkgs/commit/05167dd5c36083c0153ba962fa42af5c4351916a) python310Packages: stop recursing into attrset
* [`a09c0e7f`](https://github.com/NixOS/nixpkgs/commit/a09c0e7ff448c2c7988ddebeb09c965481ff87fa) python312Packages: recurse into attrset
* [`ec8fd85a`](https://github.com/NixOS/nixpkgs/commit/ec8fd85aeb7ce91e77e6d16d172245c72981a91f) python311Packages.tank-utiliy: don't depend on urllib3[secure] extra
* [`2155a449`](https://github.com/NixOS/nixpkgs/commit/2155a449cced1cbe8cf1c617d9dd961b0ccf78b1) python311Packages.pydantic-core: 2.6.3 -> 2.14.5
* [`ffb2e65e`](https://github.com/NixOS/nixpkgs/commit/ffb2e65e054b989c55a83f79af0ed4b912e22e14) python311Packages.pydantic: 1.10.12 -> 2.3.0
* [`a1afcb22`](https://github.com/NixOS/nixpkgs/commit/a1afcb22069de15288fc520cba814b3d9cc66d2e) python311Packages.pydantic-settings: 2.0.3 -> 2.1.0
* [`4c0f60d1`](https://github.com/NixOS/nixpkgs/commit/4c0f60d1d859e0bc8ff4b2d979cc992db4d23ef7) python311Packages.pydantic_1: init at 1.10.3
* [`4bb12a81`](https://github.com/NixOS/nixpkgs/commit/4bb12a81334fa0c79b99cdc1243be463dd8c2bf3) python311Packages.versioningit: 2.2.0 -> 2.2.1
* [`ea1fafe2`](https://github.com/NixOS/nixpkgs/commit/ea1fafe29860d47f81ea0e826654d30424a5fa8a) python311Packages.fastapi: add optional-dependencies for pydantic 2
* [`0dbf0725`](https://github.com/NixOS/nixpkgs/commit/0dbf072559f1cceff24da4cb9e24611a5d52965e) python311Packages.kanidm: 0.0.3 -> 0.0.3-unstable-2023-08-23
* [`b63a9460`](https://github.com/NixOS/nixpkgs/commit/b63a94603b42dfde7632fe5277287c707d58d57e) python311Packages.django-ninja: 0.22.2 -> 1.0.1
* [`f6bb6ce8`](https://github.com/NixOS/nixpkgs/commit/f6bb6ce8607ef1d8c415a1df426d404e5a078a4b) python311Packages.pythonfinder: 2.0.5 -> 2.0.6
* [`8cf8a150`](https://github.com/NixOS/nixpkgs/commit/8cf8a15095c97c2eff1eca7afb3165c1b2046f57) python311Packages.pyaussiebb: 0.0.18 -> 0.1.1
* [`0970c7a6`](https://github.com/NixOS/nixpkgs/commit/0970c7a6649701f87727fbdf455ed1a458755708) python311Packages.demetriek: apply a pydantic>=2 compatible patch
* [`871063c4`](https://github.com/NixOS/nixpkgs/commit/871063c458e35ad18835dd4788eecbddf996b588) python311Packages.demetriek: fix darwin sandbox build
* [`1b66d629`](https://github.com/NixOS/nixpkgs/commit/1b66d62955686ba4386d8e6e50c1e47bba458cf5) python311Packages.fastapi-mail: 1.3.1 -> 1.4.1
* [`011f3aee`](https://github.com/NixOS/nixpkgs/commit/011f3aee67283226eb2550066b0286852efb1fa0) python311Pacakges.napari-npe2: 0.7.2 -> 0.7.2-unstable-2023-10-20
* [`31a29e67`](https://github.com/NixOS/nixpkgs/commit/31a29e674684217da0aa364c52593aa4579912db) python311Packages.rstcheck-core: 1.0.3 -> 1.2.0
* [`9d7a13bc`](https://github.com/NixOS/nixpkgs/commit/9d7a13bcac1cef49656bec427d4e97408e18a78a) python311Packages.strawberry-graphql: fix test with pydantic>=2
* [`c8a16406`](https://github.com/NixOS/nixpkgs/commit/c8a16406498640cbef0a0d40a8e031b71f3e69d5) python311Packages.strawberry-graphql: fix darwin sandbox build
* [`26eed3b8`](https://github.com/NixOS/nixpkgs/commit/26eed3b8efe5542cb72431ae40433bf3009cdb24) python311Packages.xbox-webapi: 2.0.11 -> 2.1.0
* [`66f22766`](https://github.com/NixOS/nixpkgs/commit/66f2276627d3f64480e62d614529582a189d98d0) cloudflare-dyndns: pin pydantic_1
* [`98210e11`](https://github.com/NixOS/nixpkgs/commit/98210e1151c130459f76d85106856c58723707ca) flare-floss: pin pydantic_1
* [`d3a52695`](https://github.com/NixOS/nixpkgs/commit/d3a52695af1d95017b0c69443cb6e2ee8b90b4b6) khoj: 0.3.0 -> 1.0.1
* [`884a6324`](https://github.com/NixOS/nixpkgs/commit/884a6324e20bfd2e5d7141f4ce5f39d65976f7b6) octoprint: pin pydantic_1
* [`2a2b137e`](https://github.com/NixOS/nixpkgs/commit/2a2b137e325b14d0d97763d953f388bb15ecffcf) remote-exec: pin pydantic_1
* [`2a930da0`](https://github.com/NixOS/nixpkgs/commit/2a930da0f494182ba83510ea274bb735537c2e16) stacs: pin pydantic_1
* [`da45c80e`](https://github.com/NixOS/nixpkgs/commit/da45c80e1fb6e8a158a0478c424dd2763070364c) python311Packages.aiopurpleair: apply patch for pydantic>=2
* [`6bb203b6`](https://github.com/NixOS/nixpkgs/commit/6bb203b63a829c3dca0be63520f33817ba822528) python311Packages.aionotion: apply patch for pydantic>=2
* [`c83e9289`](https://github.com/NixOS/nixpkgs/commit/c83e9289207b1bef11093b70e2a45ba0f1e90cfc) python311Packages.aionotion: add meta.changelog
* [`f2aa6731`](https://github.com/NixOS/nixpkgs/commit/f2aa67314e95c83aaae3d3dbc216cda1bd24886c) frigate: pin pydantic_1
* [`0aabea0b`](https://github.com/NixOS/nixpkgs/commit/0aabea0ba1b5bd409e67080e494e5d8ae0915269) home-assistant: pin pydantic_1
* [`0a12d134`](https://github.com/NixOS/nixpkgs/commit/0a12d134596da8804eae53d185f777fc00bc9088) home-assistant: pin versioningit at 2.2.0
* [`5fa3852b`](https://github.com/NixOS/nixpkgs/commit/5fa3852b945e931f21b4e38beb30f3323b7e2e5b) treewide: marke as broken due to incompatibility with pydantic>=2
* [`fe3fca2b`](https://github.com/NixOS/nixpkgs/commit/fe3fca2b92cca58c0ea118c2b8e4b99afc9c46d2) python311Packages.pikepdf: 8.4.0 -> 8.7.1
* [`32a6949d`](https://github.com/NixOS/nixpkgs/commit/32a6949d54134bdda5ed279c914fbc6f79fdc84d) python311Packages.ocrmypdf: 15.4.0 -> 15.4.4
* [`8056f925`](https://github.com/NixOS/nixpkgs/commit/8056f9250ce8b7f9bdf0ccdc6c7a6808ae8f1be9) treewide: remove redundant SETUPTOOLS_SCM_PRETEND_VERSION usage
* [`63ab0ccf`](https://github.com/NixOS/nixpkgs/commit/63ab0ccf209c01c800f033c4f08ef28863f0274d) python311Packages.markdown: 3.4.4 -> 3.5.1
* [`9e69d3ef`](https://github.com/NixOS/nixpkgs/commit/9e69d3ef1d69cbab9858ce7d32ecc82e96545fd6) python311Packages.jsonschema-path: init at 0.3.2
* [`0cb71bbf`](https://github.com/NixOS/nixpkgs/commit/0cb71bbfd22a6a511a1ed4131f10f3ea7e5ba33e) python311Packages.openapi-spec-validator: 0.6.0 -> 0.7.1
* [`cb483040`](https://github.com/NixOS/nixpkgs/commit/cb48304000a6b2b29cb8763e76c6e93a26e5002b) python311Packages.openapi-core: 0.18.1 -> 0.18.2
* [`11c2b05b`](https://github.com/NixOS/nixpkgs/commit/11c2b05ba6e1de7a2940ab11bf4cc798e73b826a) nbqa: 1.7.0 -> 1.7.1
* [`2a5df407`](https://github.com/NixOS/nixpkgs/commit/2a5df407e6fb1c68f09e32513fb24e901b6c1439) python311Packages.astroid: 2.15.6 -> 3.0.1
* [`7e6d1c03`](https://github.com/NixOS/nixpkgs/commit/7e6d1c030a394609652e556822273f0fae3315eb) pylint: 2.17.5 -> 3.0.1
* [`01f6a679`](https://github.com/NixOS/nixpkgs/commit/01f6a6799e959b231eaaf609c2725ab11dd6636f) python311Packages.astroid: set GaetanLepage as maintainer
* [`613e6adc`](https://github.com/NixOS/nixpkgs/commit/613e6adc87b68ba9e9cc8e87e5fdc198182b7b15) python3Packages.absl-py: 1.4.0 -> 2.0.0
* [`9715a906`](https://github.com/NixOS/nixpkgs/commit/9715a9061abce116b8e16de48a9086513be2b16a) python3Packages.accelerate: 0.24.1 -> 0.25.0
* [`321e2c55`](https://github.com/NixOS/nixpkgs/commit/321e2c5588c1f8d81764139cc587e286182f54c0) python3Packages.aiobotocore: 2.6.0 -> 2.8.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
