### PR TITLE
niv devenv: update 7354096f -> 75dfa5e6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "7354096fc026f79645fdac73e9aeea71a09412c3",
-        "sha256": "178b7azh3yh2d7d20y4f7bn791zvl7kgpmq50xaclhq795ddh20s",
+        "rev": "75dfa5e6c5caac2098a6d46c711e5307e4557e2c",
+        "sha256": "12a1y4ri70mbifn176j93pp53jrqj4d7b1fvzxl0iwl7yzm2k34q",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/7354096fc026f79645fdac73e9aeea71a09412c3.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/75dfa5e6c5caac2098a6d46c711e5307e4557e2c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@7354096f...75dfa5e6](https://github.com/cachix/devenv/compare/7354096fc026f79645fdac73e9aeea71a09412c3...75dfa5e6c5caac2098a6d46c711e5307e4557e2c)

* [`aa7ceea8`](https://github.com/cachix/devenv/commit/aa7ceea82d8ee857e9e18ec7b9e806aeec28c42b) Add PhpStorm plugin to documentation
* [`f226e21f`](https://github.com/cachix/devenv/commit/f226e21f32f00793c6ea6c6a7e50236d62371826) Fix my name in docs
* [`6c677cd9`](https://github.com/cachix/devenv/commit/6c677cd93beb202d083a2a302bf6ffd8e2ca65de) Update pre-commit-hooks
* [`18ef9849`](https://github.com/cachix/devenv/commit/18ef9849d1ecac7a9a7920eb4f2e4adcf67a8c3a) Auto generate docs/reference/options.md
* [`4305afc6`](https://github.com/cachix/devenv/commit/4305afc61d041e84d94ef0cc07e22cedecaf5bcd) Add ocaml's findlib
* [`47d2490e`](https://github.com/cachix/devenv/commit/47d2490e71cb28fbaec3fd43b81ac0292f3d4526) chore(deps): bump cachix/install-nix-action from 24 to 25
* [`17c182e6`](https://github.com/cachix/devenv/commit/17c182e60027dd8f2f492db8fe73d67bd064518e) chore(deps): bump cachix/cachix-action from 13 to 14
