### PR TITLE
niv home-manager: update 51e44a13 -> 8c3b2a0c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "51e44a13acea71b36245e8bd8c7db53e0a3e61ee",
-        "sha256": "1a19f91vkpdi95l39fplrl3kfxmknkmbys4qi3fxibj751slm0y8",
+        "rev": "8c3b2a0cab64a464de9e41a470eecf1318ccff57",
+        "sha256": "06axgrabvg89j3qv0kh66p9z91p3q3myq690spgqh15j6xj4j9ri",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/51e44a13acea71b36245e8bd8c7db53e0a3e61ee.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/8c3b2a0cab64a464de9e41a470eecf1318ccff57.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@51e44a13...8c3b2a0c](https://github.com/nix-community/home-manager/compare/51e44a13acea71b36245e8bd8c7db53e0a3e61ee...8c3b2a0cab64a464de9e41a470eecf1318ccff57)

* [`e13aa9e2`](https://github.com/nix-community/home-manager/commit/e13aa9e287b3365473e5897e3667ea80a899cdfb) thunderbird: configure signature if set ([nix-community/home-manager⁠#4852](https://togithub.com/nix-community/home-manager/issues/4852))
* [`93e804e7`](https://github.com/nix-community/home-manager/commit/93e804e7f8a1eb88bde6117cd5046501e66aa4bd) docs: use alternative source of nmd
* [`7403ed49`](https://github.com/nix-community/home-manager/commit/7403ed49801e1a30ed0ffdec5b60c17f0cbf7bd5) home-manager: internalize uninstall
* [`0912d26b`](https://github.com/nix-community/home-manager/commit/0912d26b30332ae6a90e1b321ff88e80492127dd) gh: only run migration when required
* [`6217b735`](https://github.com/nix-community/home-manager/commit/6217b735988ef28fa07d9c4be92d06d5573defa3) listenbrainz-mpd: use sdnotify when possible
* [`f2942f33`](https://github.com/nix-community/home-manager/commit/f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8) Remove some formatting exceptions
* [`8ae3bfe2`](https://github.com/nix-community/home-manager/commit/8ae3bfe2bffe0b058b3158f83eaa53bf14ca347b) tests: use nmt from Nixpkgs
* [`846200eb`](https://github.com/nix-community/home-manager/commit/846200eb574faa2af808ed02e653c2b8ed51fd71) docs: use nmd from Nixpkgs
* [`b989db59`](https://github.com/nix-community/home-manager/commit/b989db5900df4bd1a786f8afd8063dae09d89a8c) home-manager: check profile exists in nixProfileRemove
* [`8c3b2a0c`](https://github.com/nix-community/home-manager/commit/8c3b2a0cab64a464de9e41a470eecf1318ccff57) flake: update release notes URL
