### PR TITLE
niv niv: update 6bd7cd68 -> b0ad17bc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "6bd7cd686220bf3db0e212481faf9578e8c8ff0f",
-        "sha256": "15claxlj6y15db67qc7kb4vzyn6sv7r13z4q502vq7a4z2488z94",
+        "rev": "b0ad17bce706449304b20fa1b81f7f6f0220f804",
+        "sha256": "0hcjqhxirbpcs3xjrydylv5yca8k8zd3a3rzsjdkzsj57jpr6hp0",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/6bd7cd686220bf3db0e212481faf9578e8c8ff0f.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/b0ad17bce706449304b20fa1b81f7f6f0220f804.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@6bd7cd68...b0ad17bc](https://github.com/nmattia/niv/compare/6bd7cd686220bf3db0e212481faf9578e8c8ff0f...b0ad17bce706449304b20fa1b81f7f6f0220f804)

* [`a77f96a4`](https://github.com/nmattia/niv/commit/a77f96a496b83a48d958d3b80b33f11931f6083a) Bump cachix/install-nix-action from 24 to 25 ([nmattia/niv⁠#386](https://togithub.com/nmattia/niv/issues/386))
* [`b0ad17bc`](https://github.com/nmattia/niv/commit/b0ad17bce706449304b20fa1b81f7f6f0220f804) Bump cachix/cachix-action from 13 to 14 ([nmattia/niv⁠#387](https://togithub.com/nmattia/niv/issues/387))
