### PR TITLE
niv powerlevel10k: update d804048e -> cda24b72

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "d804048efc46b8b248693fa3a7bfc9f863bb1254",
-        "sha256": "0q7sachpvxaki983q8p7dkjbx6igab3g00vy3yfjb4yzxxz8dhb1",
+        "rev": "cda24b72b790b0bec54a6090ab85a0f23caea8b6",
+        "sha256": "0f6ikhwda2g1arbz8fawqb996w6kfzhfzg6vlgx34qdnc1zhxgl9",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/d804048efc46b8b248693fa3a7bfc9f863bb1254.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/cda24b72b790b0bec54a6090ab85a0f23caea8b6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@d804048e...cda24b72](https://github.com/romkatv/powerlevel10k/compare/d804048efc46b8b248693fa3a7bfc9f863bb1254...cda24b72b790b0bec54a6090ab85a0f23caea8b6)

* [`651033c3`](https://github.com/romkatv/powerlevel10k/commit/651033c3df5465b56f40f019a78dac1ef9807a57) work around a bug in laravel that results in colorized output ([romkatv/powerlevel10k⁠#2534](https://togithub.com/romkatv/powerlevel10k/issues/2534))
* [`f5d5abfe`](https://github.com/romkatv/powerlevel10k/commit/f5d5abfe1f89e5ea0d6f7cde6f3d9cd4b7c89d14) fix a silly bug introduced in the last commit ([romkatv/powerlevel10k⁠#2534](https://togithub.com/romkatv/powerlevel10k/issues/2534))
* [`cda24b72`](https://github.com/romkatv/powerlevel10k/commit/cda24b72b790b0bec54a6090ab85a0f23caea8b6) bump version
