### PR TITLE
niv nixpkgs: update 87b9bf8e -> 7850f146

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "87b9bf8ea4bf9f961376e44a2c9d5ea9a5cf9207",
-        "sha256": "1w799agy5kgscrq10cvvsni37za9s058zhyplcz4469vdd78f1pn",
+        "rev": "7850f146305fd5ee52edf63b4404b60b21543a44",
+        "sha256": "1ywrn8y4hlhbifzy1cqv57r7km5k2rvaj087cy4zbiyg7cdya7vz",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/87b9bf8ea4bf9f961376e44a2c9d5ea9a5cf9207.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/7850f146305fd5ee52edf63b4404b60b21543a44.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@87b9bf8e...7850f146](https://github.com/nixos/nixpkgs/compare/87b9bf8ea4bf9f961376e44a2c9d5ea9a5cf9207...7850f146305fd5ee52edf63b4404b60b21543a44)

* [`0ba01717`](https://github.com/NixOS/nixpkgs/commit/0ba017171d5129b8acf431a1ee40b4e31dff3fb1) doc: fix outdated /var/lib/container from pre-2205
* [`49e24fc8`](https://github.com/NixOS/nixpkgs/commit/49e24fc872e61fa30624b5be605ec2e912344dc6) Mention qt-specific callPackage variants in docs
* [`a06b7a48`](https://github.com/NixOS/nixpkgs/commit/a06b7a48f0db58748e6efdfc816d89618557bfe7) maintainers: add michaelBrunner
* [`3a42fb90`](https://github.com/NixOS/nixpkgs/commit/3a42fb90176dc7a6efb8e462ad5f8be9fbced733) zd1211: only copy firmware files according to readme, update license
* [`86b0dfb6`](https://github.com/NixOS/nixpkgs/commit/86b0dfb6d6e692114576c34910858830fd532862) maintainers: add edswordsmith
* [`effe62a7`](https://github.com/NixOS/nixpkgs/commit/effe62a77a83624c429658d757a607fc15e9a195) _0xproto: init at 1.300
* [`28cfd573`](https://github.com/NixOS/nixpkgs/commit/28cfd573deebeb3a681e344366c4395c5f414131) ham: unstable-2022-10-26 -> unstable-2023-10-06
* [`c9b4e19f`](https://github.com/NixOS/nixpkgs/commit/c9b4e19fa7a24aa525beea2ecfd3f6341ce99ded) blackbox-terminal: support sixel
* [`caec251e`](https://github.com/NixOS/nixpkgs/commit/caec251ee4ab15ad954bd9da464457d59ca7c4c1) blackbox-terminal: add linsui as maintainer
* [`9593d338`](https://github.com/NixOS/nixpkgs/commit/9593d338a0561779fdd90028ce7fc438081a7a45) mbedtls: 3.5.0 -> 3.5.1, mbedtls_2: 2.28.5 -> 2.28.6
* [`ac827a6f`](https://github.com/NixOS/nixpkgs/commit/ac827a6f855b58feb4f5b6ea073acf83b3348339) nixos/samba: make securityType an enum
* [`ba12e9a8`](https://github.com/NixOS/nixpkgs/commit/ba12e9a8f236fb74c81220895c8c92a633a7a5e0) sha2wordlist: init at unstable-2023-02-20
* [`0a620163`](https://github.com/NixOS/nixpkgs/commit/0a620163b972e2d06dd81c7491cc9534708724ec) nixos/firebird: fix coerce error
* [`ebafcea7`](https://github.com/NixOS/nixpkgs/commit/ebafcea7668304d9d51eeeadace4e0c971048403) sqlite-vss: init at 0.1.2
* [`4e456706`](https://github.com/NixOS/nixpkgs/commit/4e45670630a2afd11a5523ba3cbf35e23d6d7b0b) fanficfare: 4.25.0 -> 4.29.0
* [`84685518`](https://github.com/NixOS/nixpkgs/commit/84685518f81e5255731e2a60a61a5c1880f69a8e) cosmic-icons: add unstableGitUpdater
* [`5f2651eb`](https://github.com/NixOS/nixpkgs/commit/5f2651eb3f227724f0b48bf689e0196d6912175f) maintainers: add gigahawk
* [`17771d61`](https://github.com/NixOS/nixpkgs/commit/17771d614417f9fe460bff44530ab73a6457b9b0) xstow: 1.1.0 -> 1.1.1
* [`3ec28ca0`](https://github.com/NixOS/nixpkgs/commit/3ec28ca05dac5dab5dad0fcfbd60f6c98a1e637a) add libnotify
* [`a21c63e0`](https://github.com/NixOS/nixpkgs/commit/a21c63e0254dca58e03a4bb6bfda217aefe54017) maintainers: add zoriya
* [`2d79d996`](https://github.com/NixOS/nixpkgs/commit/2d79d99612071b24176aa9a7426b4e702f59602c) xstow: unmark as broken on darwin
* [`0906f092`](https://github.com/NixOS/nixpkgs/commit/0906f092402a1636f225a83ad0590a9401664c99) libvibrant: init at 2100c09
* [`2d5fcca2`](https://github.com/NixOS/nixpkgs/commit/2d5fcca24d1b2a559fb977b0706c5dfa29ce56a5) vibrantLinux: init at 2.1.10
* [`de12dd74`](https://github.com/NixOS/nixpkgs/commit/de12dd74d20baa343ad631e6089de8777cbbced1) nixos/sshServe: use bash as default shell for nix-ssh user
* [`c1678c25`](https://github.com/NixOS/nixpkgs/commit/c1678c25679f3803509c66ae9870bea7d13aea84) doc: mkYarnPackage/mkYarnModules should use offlineCache to prevent IFD
* [`136ad2c9`](https://github.com/NixOS/nixpkgs/commit/136ad2c98f1c7a5520dce223345b91f57fa380d9) kickstart: init at 0.4.0
* [`329abb1a`](https://github.com/NixOS/nixpkgs/commit/329abb1a5dde2a4b28025e835697c981904bee06) houdini: 19.5.569 -> 20.0.506
* [`f757546d`](https://github.com/NixOS/nixpkgs/commit/f757546d0fbd88e37026ab526573c1099e9afa2e) xserver service: xkbvalidate: Respect `xkb.dir`. Fixes [nixos/nixpkgs⁠#31138](https://togithub.com/nixos/nixpkgs/issues/31138).
* [`5ba1e86b`](https://github.com/NixOS/nixpkgs/commit/5ba1e86bb097515f1fc22270a60716beb6ea1109) tests.writers.simple.fsharp: Add missing dependency
* [`921ee60d`](https://github.com/NixOS/nixpkgs/commit/921ee60d2cce0e8497f59b3ca212c6530b78bb1f) nixos/ssh: pass XAUTHORITY to ssh-askpass
* [`1f611587`](https://github.com/NixOS/nixpkgs/commit/1f61158764f7af206179fc3b6014fa4a4253614b) autocorrect: 2.8.5 -> 2.9.0
* [`b968413d`](https://github.com/NixOS/nixpkgs/commit/b968413db939b577c6708f9ace904b83a425d059) cloud-init: 23.3.3 -> 23.4
* [`039ec280`](https://github.com/NixOS/nixpkgs/commit/039ec28011f3e6386b757e19615521fe56960e01) cloud-init: update nixos support patch
* [`409782d0`](https://github.com/NixOS/nixpkgs/commit/409782d025cca6ae0f7cd26a17480f979942ceee) nixos/cloud-init: fail test faster
* [`068372ee`](https://github.com/NixOS/nixpkgs/commit/068372ee6f0146af5e7e01aa10252dbd85fdf826) heimdal: 7.8.0 -> 7.8.0-unstable-2023-11-29
* [`8a8f1d4e`](https://github.com/NixOS/nixpkgs/commit/8a8f1d4e8be8331ecb691ab936584fe1d716b9a8) atlauncher: 3.4.35.3 -> 3.4.35.4
* [`3a3ca849`](https://github.com/NixOS/nixpkgs/commit/3a3ca849c893f7f6a831511cb020ec0d038fdfc8) atlauncher: move package into by-name
* [`706e6caa`](https://github.com/NixOS/nixpkgs/commit/706e6caa521da8e3002747154a2ee7c7d78caa2f) obs-studio-plugins.advanced-scene-switcher: 1.24.0 -> 1.24.2
* [`05e00f63`](https://github.com/NixOS/nixpkgs/commit/05e00f63f7c6500f4ab4d43e4d785b9215c3c236) matrix-authentication-service: init at 0.7.0
* [`8da05bc3`](https://github.com/NixOS/nixpkgs/commit/8da05bc3bdfcaa50c4716baec1a007d11ff58a23) libsForQt5.qtkeychain: 0.14.1 -> 0.14.2
* [`95fbdb37`](https://github.com/NixOS/nixpkgs/commit/95fbdb370c174904d4abbd2f8ac694545f0e2d68) espflash: init at 2.1.0
* [`abb0c243`](https://github.com/NixOS/nixpkgs/commit/abb0c2434750b268f09c0f21076c4fa10d30b224) python310Packages.google-cloud-runtimeconfig: 0.33.3 -> 0.34.0
* [`b4d847ed`](https://github.com/NixOS/nixpkgs/commit/b4d847ed27ed10e19de6984e35faaaff8eda555c) bonsai: init at 1.0.2
* [`44e54cf3`](https://github.com/NixOS/nixpkgs/commit/44e54cf37cb4af643ba37bd146217647874383d9) python3Packages.pdoc-pyo3-sample-library: init at 1.0.11
* [`43f1e317`](https://github.com/NixOS/nixpkgs/commit/43f1e317aaf8ff4ea2b3cd3a7e1807d4ac765d42) python3Packages.pdoc: 14.1.0 -> 14.2.0
* [`a6765026`](https://github.com/NixOS/nixpkgs/commit/a67650269a036a3a6ae17be1c5e5fb85e736db57) paralus-cli: init at 0.1.4
* [`d3a7f457`](https://github.com/NixOS/nixpkgs/commit/d3a7f4571657c559e8da50945dc71f592633e916) doc: update buildRustPackage documentation
* [`5cdbbaa0`](https://github.com/NixOS/nixpkgs/commit/5cdbbaa029dd1715a82b00d77fb5e6c0795fd449) redocly-cli: silence update messages
* [`1473ac22`](https://github.com/NixOS/nixpkgs/commit/1473ac2228d1f1541f3508aa0121dc1598122fe0) Revert "pinentry: drop gtk2"
* [`d8854a4f`](https://github.com/NixOS/nixpkgs/commit/d8854a4fafeaa1281d39117cda51599b6c5ecbf8) secp256k1: 0.4.0 -> 0.4.1
* [`410543a9`](https://github.com/NixOS/nixpkgs/commit/410543a974cbdefe8f6f5d572f1999f7430bd112) betterbird: 115.4.2-bb17 -> 115.6.0-bb21
* [`27add5ac`](https://github.com/NixOS/nixpkgs/commit/27add5ac6fff2092379fffac350bac854d5114bc) grmon: init at 0.1
* [`bbf189ed`](https://github.com/NixOS/nixpkgs/commit/bbf189ed4c24a2dea14a49ac2f5ea9a934145c4f) radarr: 5.1.3 -> 5.2.6
* [`a35d1012`](https://github.com/NixOS/nixpkgs/commit/a35d1012dd6d258c14582f44ff3e9d11f053ab6a) liboqs: Fix build error
* [`4d56321d`](https://github.com/NixOS/nixpkgs/commit/4d56321d1f5f2ac29e3f6cfe438694a580468002) tradingview: 2.6.3 -> 2.7.2
* [`dcf42714`](https://github.com/NixOS/nixpkgs/commit/dcf427140d8a7dda674899dc01132c8a289bbf74) ttfb: 1.7.0 -> 1.10.0
* [`36111f0a`](https://github.com/NixOS/nixpkgs/commit/36111f0a0f5f8c821c96f8ab5b2dc66445e27856) esphome: install shell completion
* [`b88dcaca`](https://github.com/NixOS/nixpkgs/commit/b88dcacafdae994a8be1504dd5493488682fa13d) nix: point `nix edit` and `ofborf` at the original `version` attribute
* [`b2f5fd52`](https://github.com/NixOS/nixpkgs/commit/b2f5fd526644948a0d8c544a54e31b371edd9c3c) khronos-ocl-icd-loader: 2022.01.04 -> 2023.12.14
* [`9ce7ca30`](https://github.com/NixOS/nixpkgs/commit/9ce7ca3096259bd2a36439a2aed588bebb85167d) libdwarf: 0.4.2 -> 0.9.0
* [`a9c78d1d`](https://github.com/NixOS/nixpkgs/commit/a9c78d1d0cb9d417498cfd3be005dcbff1f9868b) libdwarf: Enable dumping of zstd compressed sections
* [`6fcd9c7e`](https://github.com/NixOS/nixpkgs/commit/6fcd9c7e933d12f0295653174dd64aeb2ed5b60d) beets: fix broken aarch64 build due to missing plugin test
* [`8f9a0b24`](https://github.com/NixOS/nixpkgs/commit/8f9a0b242e20bebb43871c58c8007c917d91f962) box64: 0.2.4 -> 0.2.6
* [`75610d64`](https://github.com/NixOS/nixpkgs/commit/75610d64527cd346a2f5402a281490f6125c8b56) oculante: 0.7.7 -> 0.8.6
* [`eebc6154`](https://github.com/NixOS/nixpkgs/commit/eebc61541381310753f2dfc83e87e9b892cb5002) wlcs: 1.6.1 -> 1.7.0
* [`e7aa3531`](https://github.com/NixOS/nixpkgs/commit/e7aa35317e436522d804ec309d39cf0130cb2130) apacheHttpdPackages.subversion: 1.14.2 -> 1.14.3
* [`f4cdad8a`](https://github.com/NixOS/nixpkgs/commit/f4cdad8aabe3ca7a73ed4929a529b7d2e6e63566) doc: improve documentation for trivial text writing functions
* [`d87e452c`](https://github.com/NixOS/nixpkgs/commit/d87e452c512f2ddcfd91153df4a4a1d3ed70c61f) xarchiver: 0.5.4.21 -> 0.5.4.22
* [`3b74d878`](https://github.com/NixOS/nixpkgs/commit/3b74d8781fc67bb3490bc15ba2b58230e2567be9) nixos/roundcube: update nginx configuration
* [`7ead602f`](https://github.com/NixOS/nixpkgs/commit/7ead602f9376f3de9e1de23c4c00a0122612f7c7) nixos/roundcube: add configureNginx option
* [`5e1a456a`](https://github.com/NixOS/nixpkgs/commit/5e1a456a8dbf3cb3f68b2063ba388bcd00947b93) spring-boot-cli: 3.2.0 -> 3.2.1
* [`5897b365`](https://github.com/NixOS/nixpkgs/commit/5897b36528399c53aa4d8aafd57e7356c9120565) disk-filltest: migrate to by-name
* [`2aca1fc8`](https://github.com/NixOS/nixpkgs/commit/2aca1fc81d8e85c9d5a7136edd4afb66eed42aad) disk-filltest: adopt
* [`d76236da`](https://github.com/NixOS/nixpkgs/commit/d76236da522f95e8728151a54b7371b77b7dbdb3) gtklp: migrate to by-name
* [`61031595`](https://github.com/NixOS/nixpkgs/commit/61031595bdf49cbb7b95b5e5bbe73f3561127659) gtklp: adopt
* [`ca389f7a`](https://github.com/NixOS/nixpkgs/commit/ca389f7ae12edc103d7e164115e9138e2f77c42d) ssh-askpass-fullscreen: migrate to by-name
* [`7d8e65b9`](https://github.com/NixOS/nixpkgs/commit/7d8e65b9b2f0fb1eed5f873390b6923e6ed45151) ssh-askpass-fullscreen: adopt
* [`7f9b9936`](https://github.com/NixOS/nixpkgs/commit/7f9b9936881f25c67aad7cf45948928ac72fc72d) maintainers: remove caadar
* [`bdbd8f70`](https://github.com/NixOS/nixpkgs/commit/bdbd8f703b920cde4e7e8c88d6fcc745073049ab) fix sample value for option services.wordpress.sites.<name>.languages
* [`e3be1786`](https://github.com/NixOS/nixpkgs/commit/e3be1786626f61a66bff2c4388a815374a8909fa) swagger-codegen: 2.4.34 -> 2.4.38
* [`a9906762`](https://github.com/NixOS/nixpkgs/commit/a9906762a0389f37faa37aa46886448924167d79) xrdp: 0.9.23.1 -> 0.9.24
* [`9e65510c`](https://github.com/NixOS/nixpkgs/commit/9e65510cc4354e8491efecfb9dc4be410d162b55) thanos: 0.32.5 -> 0.33.0
* [`fd86d940`](https://github.com/NixOS/nixpkgs/commit/fd86d9400fd63aa95ec0432b972d0a00a9381372) vips: 8.15.0 -> 8.15.1
* [`f56e01f1`](https://github.com/NixOS/nixpkgs/commit/f56e01f1af29df2113c312c8cfa2596dcb44e3a4) zrok: 0.4.18 -> 0.4.20
* [`d58b352b`](https://github.com/NixOS/nixpkgs/commit/d58b352bdc2ab1f359e4887a73e06fc38e94b442) flrig: 2.0.04 -> 2.0.05
* [`66bce6f2`](https://github.com/NixOS/nixpkgs/commit/66bce6f2a0265540476c932c75579d0cab290bac) sudo: 1.9.15p4 -> 1.9.15p5
* [`e891cb76`](https://github.com/NixOS/nixpkgs/commit/e891cb762a8ee5e6429efc2d81ec8c0b9f42f811) python311Packages.python-sql: 1.4.2 -> 1.4.3
* [`214608c8`](https://github.com/NixOS/nixpkgs/commit/214608c8a5c68aef141a4ef38558022d57f617da) worker: 4.12.1 -> 5.0.0
* [`be797d6f`](https://github.com/NixOS/nixpkgs/commit/be797d6f58393f32f24d108b6cbaf78d8d34b926) fac: 2.0.0 -> unstable-2023-12-29
* [`2fda1c96`](https://github.com/NixOS/nixpkgs/commit/2fda1c969d6fd3dd6c6ab616b17f7f0d4d211ca7) show-midi: init at 0.8.0
* [`639ea320`](https://github.com/NixOS/nixpkgs/commit/639ea32054290c9b270c05dad2ecfe1afd063b0a) mbuffer: 20230301 -> 20231216
* [`cce77540`](https://github.com/NixOS/nixpkgs/commit/cce77540a7332cd1f81df390efc86af23ec4b6b4) maintainers: add patwid
* [`e773e43b`](https://github.com/NixOS/nixpkgs/commit/e773e43b4cfa3433bd39f4d16a0d62f9b77bcb6a) mdk-sdk: 0.23.1 -> 0.24.0
* [`491e1b3f`](https://github.com/NixOS/nixpkgs/commit/491e1b3fd99535f5db8ae552cb4d5a6d2ad322b7) tinyssh: 20230101 -> 20240101
* [`cd7dc1e2`](https://github.com/NixOS/nixpkgs/commit/cd7dc1e241298728c929fb86f2bb27ede5df878b) liquibase: 4.24.0 -> 4.25.1
* [`850d3c7b`](https://github.com/NixOS/nixpkgs/commit/850d3c7b933ea6b4b86b480930024237225954e0) functionalplus: 0.2.20-p0 -> 0.2.22
* [`4e2cc76a`](https://github.com/NixOS/nixpkgs/commit/4e2cc76adaef51156bf50e96cbf6e107afe5c4a8) persistent-cache-cpp: Fetch patch for leveldb dependency propagation
* [`d8f20e7c`](https://github.com/NixOS/nixpkgs/commit/d8f20e7c7bb922d695876cc8040c8515167c8989) besu: 23.10.2 -> 23.10.3
* [`a5077c24`](https://github.com/NixOS/nixpkgs/commit/a5077c24aa2eedd57ea2cc5d354506c519a16e09) cvs-fast-export: 1.62 -> 1.63
* [`f370a127`](https://github.com/NixOS/nixpkgs/commit/f370a127ae8bbdce69e06a3dc70e9a10d5b4f563) log4cxx: 1.1.0 -> 1.2.0
* [`8314af15`](https://github.com/NixOS/nixpkgs/commit/8314af158f26563abf1f3ff4b95812afe8521a37) nixos/network-interfaces: fix implicit dependency on underlying device
* [`1f3f621c`](https://github.com/NixOS/nixpkgs/commit/1f3f621c5d473f8480e86f4a8814e3150fe276dd) python311Packages.pybase64: 1.3.1 -> 1.3.2
* [`225bfa37`](https://github.com/NixOS/nixpkgs/commit/225bfa37ab9d79db8d8c0dffbcfcfc0620b930be) snd: 23.9 -> 24.0
* [`5fb3301d`](https://github.com/NixOS/nixpkgs/commit/5fb3301dad4ff5c41342d7c961bd4590e343e332) mkNugetSource: Remove meta.licenses attribute
* [`d6e5ae98`](https://github.com/NixOS/nixpkgs/commit/d6e5ae986c5f936ae97320a6409583bf433ba663) matrix-hookshot: 4.7.0 -> 5.1.2
* [`c637680b`](https://github.com/NixOS/nixpkgs/commit/c637680b5d5ab844db4d9e5c13da8056aa47ac3f) lomiri.lomiri-indicator-network: init at 1.0.0
* [`8a6daacd`](https://github.com/NixOS/nixpkgs/commit/8a6daacde1b9c2e7d80d62f4dc6df11e9cb642e0) lomiri.lomiri-indicator-network: 1.0.0 -> 1.0.1
* [`e7b537ab`](https://github.com/NixOS/nixpkgs/commit/e7b537ab95bf3505a38b222f009bdbb0a5f03e3f) media-downloader: 4.1.0 -> 4.2.0
* [`928d6608`](https://github.com/NixOS/nixpkgs/commit/928d66083e5bae2f4d2ef622a2d53b3ac8760297) mkNugetSource: Allow passing arbitrary stdenv.mkDerivation attrs
* [`9fbf82d9`](https://github.com/NixOS/nixpkgs/commit/9fbf82d9cb48d7dab89611139c51816d599dbe2d) systemd-lib: add Install WantedBy section to make units similar to upstream ones
* [`adbb2033`](https://github.com/NixOS/nixpkgs/commit/adbb20330e6323654e964f5af11d9a39f993c97b) bootstrap-studio: 6.5.1 -> 6.6.0
* [`48596390`](https://github.com/NixOS/nixpkgs/commit/4859639097b2f082c1bccb31b062b2bee3aefb16) weechatScripts.weechat-notify-send: 0.9 -> 0.10
* [`afc2f0f7`](https://github.com/NixOS/nixpkgs/commit/afc2f0f7bcd067b75e9c849ab978a741f8a9038b) postgresqlPackages.postgis: build minimal gdal version
* [`c342f61a`](https://github.com/NixOS/nixpkgs/commit/c342f61a3b0d3bb6574688d8a261bb6bcd4446b0) arduino-cli: 0.34.2 -> 0.35.0
* [`1b25a006`](https://github.com/NixOS/nixpkgs/commit/1b25a006dc5f8a551e30d7d72475060bbb9626ea) ndi: 5.5.2 -> 5.6.0
* [`a602fd26`](https://github.com/NixOS/nixpkgs/commit/a602fd26c1b3f1e3e24702956ae326481e840ab4) python310Packages.podman: 4.8.1 -> 4.8.2
* [`f6e6a6d8`](https://github.com/NixOS/nixpkgs/commit/f6e6a6d80e96ee1da4a79b0e9578612831b5cc3c) doc: replace pcre with pcre2 in example script
* [`c8144bb5`](https://github.com/NixOS/nixpkgs/commit/c8144bb5975693f385b11078421377f7bfca1fd8) cloud-init: 23.3 -> 23.4.1
* [`d6baaf1c`](https://github.com/NixOS/nixpkgs/commit/d6baaf1c42b41d5a43ff196bdbe10cf5864f87be) nixos/cloud-init: fix DHCP race condition
* [`0f5af6f6`](https://github.com/NixOS/nixpkgs/commit/0f5af6f6b7f67265520b42a351f5f445a383cf43) ory: init at 0.2.2
* [`984f5cb7`](https://github.com/NixOS/nixpkgs/commit/984f5cb71dc4285531452a32162677f83cec2a4b) atlauncher: add meta.sourceProvenance
* [`eb97e9f9`](https://github.com/NixOS/nixpkgs/commit/eb97e9f924943c968545b64e3df77a73fc62b917) atlauncher: make binary name static
* [`7e45990c`](https://github.com/NixOS/nixpkgs/commit/7e45990c06adc32b7aaf196b36b20001c5f8ce42) nixos/sshd: fix socket activated ports when using ListenAddress
* [`7a34d93a`](https://github.com/NixOS/nixpkgs/commit/7a34d93acc15bca348497797949c86b761eae3ed) python310Packages.pyctr: 0.7.1 -> 0.7.3
* [`6d772e93`](https://github.com/NixOS/nixpkgs/commit/6d772e930a7741ce9fbd87ae598dd92f6b0d261d) python310Packages.pycuda: 2023.1 -> 2024.1
* [`96068363`](https://github.com/NixOS/nixpkgs/commit/960683630f74b059d972009900d68c470235ce60) mqttx: init at 1.9.8
* [`321fbe2a`](https://github.com/NixOS/nixpkgs/commit/321fbe2ae89176bfad887c64fed7e212e3f6cfb3) sameboy: 0.16 -> 0.16.1
* [`d4bbe4ee`](https://github.com/NixOS/nixpkgs/commit/d4bbe4eed54827cb1ea8cfc63fda1cbd07235f91) schemacrawler: 16.20.7 -> 16.20.8
* [`25a0bb58`](https://github.com/NixOS/nixpkgs/commit/25a0bb5863e27d75e3be1e37a372a924073e5558) telepresence2: 2.15.1 -> 2.17.0
* [`ea9e098b`](https://github.com/NixOS/nixpkgs/commit/ea9e098b7e9805271ee1129ed5382093c6d57ff7) ultrastardx: 2023.12.0 -> 2024.1.0
* [`916feb4a`](https://github.com/NixOS/nixpkgs/commit/916feb4a3dfcff643d77377cbf7e19175032c16e) leptonica: 1.84.0 -> 1.84.1
* [`1b100349`](https://github.com/NixOS/nixpkgs/commit/1b100349549e3a7c121008f04f0f2033e24b6ea0) utf8cpp: 4.0.3 -> 4.0.5
* [`0600edc4`](https://github.com/NixOS/nixpkgs/commit/0600edc49773a5cfb90f55a67d51c02707e328ed) debianutils: 5.15 -> 5.16
* [`ee887b1a`](https://github.com/NixOS/nixpkgs/commit/ee887b1a8ae443ab1944e8af08abed6452413ca7) gwyddion: 2.64 -> 2.65
* [`08d8359e`](https://github.com/NixOS/nixpkgs/commit/08d8359e39c0d713752f9292f03920257d7a0506) miniupnpc: 2.2.5 -> 2.2.6
* [`ff54529c`](https://github.com/NixOS/nixpkgs/commit/ff54529c314acf4feb8083f1f6b8f585ff33bc42) miniupnpd: 2.3.3 -> 2.3.4
* [`af1666dc`](https://github.com/NixOS/nixpkgs/commit/af1666dc2ea5050e625f6e6528e4480be1dfd405) swaks: 20201014.0 -> 20240103.0
* [`dd993260`](https://github.com/NixOS/nixpkgs/commit/dd99326063ff4c68990610d710b04c2045f1c224) openxr-loader: 1.0.32 -> 1.0.33
* [`1dad7f68`](https://github.com/NixOS/nixpkgs/commit/1dad7f68219c6097d9897fef26287796ad66c2f2) nixos/repart: add loop module to initrd
* [`27f24b33`](https://github.com/NixOS/nixpkgs/commit/27f24b330493039de280635e777098196bf3407a) python311Packages.logilab-constraint: 0.7.1 -> 0.8.0
* [`0d9fa804`](https://github.com/NixOS/nixpkgs/commit/0d9fa804c1e002c373ef5f7f0b5c13f22c394193) glooctl: 1.15.18 -> 1.15.19
* [`929ac617`](https://github.com/NixOS/nixpkgs/commit/929ac617313014eb34344ceb97d696f8320ff4c0) maintainers: add lavafroth
* [`f8c2dafb`](https://github.com/NixOS/nixpkgs/commit/f8c2dafb53091ac2b89d56834f279c2d99f51d35) libmpdclient: 2.20 -> 2.21
* [`09efe009`](https://github.com/NixOS/nixpkgs/commit/09efe009d0d1282558ffc536b3e9587101460211) libmpdclient: migrate to by-name
* [`ba8a8def`](https://github.com/NixOS/nixpkgs/commit/ba8a8def3f602fd10d3cbc779d755682fe9bdecf) libmpdclient: cleanup
* [`7f542aa8`](https://github.com/NixOS/nixpkgs/commit/7f542aa896c1e51967203ef05a69f30b70ed5576) libmpdclient: 2.21 -> 2.22
* [`7f167083`](https://github.com/NixOS/nixpkgs/commit/7f167083de849811cd12d44ec37cbed4bb94f173) unison-ucm: 0.5.12 -> 0.5.13
* [`a4f9304b`](https://github.com/NixOS/nixpkgs/commit/a4f9304bc158b0ee7ffaa183a8655e32cb49b517) vivaldi: 6.5.3206.48 -> 6.5.3206.50
* [`df68e79b`](https://github.com/NixOS/nixpkgs/commit/df68e79bcf0aa7ee141bfc0aa4395c3cddef91f1) starsector: add missing runtime dependency xrandr
* [`ceb58ead`](https://github.com/NixOS/nixpkgs/commit/ceb58ead72110d2d06336d51a155719542dfd8e3) xml-tooling-c: 3.0.4 -> 3.2.4
* [`f2e62b74`](https://github.com/NixOS/nixpkgs/commit/f2e62b74e159e52f5519953e9b7cb5233c68f675) bacnet-stack: 1.3.1 -> 1.3.2
* [`2b46e6cb`](https://github.com/NixOS/nixpkgs/commit/2b46e6cbc7f4c73f6178b8f9f16a0f0417452046) xfe: 1.45 -> 1.46
* [`d05a864d`](https://github.com/NixOS/nixpkgs/commit/d05a864db230e7b7442e4ea42506988bcf8ce01d) avrdudess: 2.14 -> 2.15
* [`cfc399c3`](https://github.com/NixOS/nixpkgs/commit/cfc399c3994015e4ef8a1e8a3842026d150ff1ff) praat: 6.4.01 -> 6.4.03
* [`b057e48b`](https://github.com/NixOS/nixpkgs/commit/b057e48b2a90422e5e0054b90dbbef11529d024d) mlx42: 2.3.2 -> 2.3.3
* [`50d0eb6c`](https://github.com/NixOS/nixpkgs/commit/50d0eb6c9f5cf3020bae9deddd873f89dc779ee2) nixos-rebuild: add lib to repl to make debugging even easier
* [`31cb1b07`](https://github.com/NixOS/nixpkgs/commit/31cb1b07c9fa28a678c27b72a70c8757d9f939b0) bulloak: 0.5.4 -> 0.6.1
* [`92a401fb`](https://github.com/NixOS/nixpkgs/commit/92a401fb19086b2ffdd55741c5c67be533173719) cddl: 0.8.9 -> 0.10.3
* [`f1c0d04d`](https://github.com/NixOS/nixpkgs/commit/f1c0d04d804e3c0243bce39d02b14ddf29f2ff0f) cddl: add amesgen as maintainer
* [`24e77d6a`](https://github.com/NixOS/nixpkgs/commit/24e77d6afa38010664003acca9ae9f34492d1658) blocky: 0.22 -> 0.23
* [`2208511a`](https://github.com/NixOS/nixpkgs/commit/2208511ab5f3be7758ea445cb84ef9ac141592e6) s3scanner: init at 3.0.4
* [`b0c4d13f`](https://github.com/NixOS/nixpkgs/commit/b0c4d13f4e6bfab349ac832d73504436e2e02a12) gtkcord4: 0.0.16-1 -> 0.0.17
* [`66a1f470`](https://github.com/NixOS/nixpkgs/commit/66a1f4700fec7731e1ef980bf3b08b94d2900204) sudo-font: 0.80 -> 0.81
* [`d70f541f`](https://github.com/NixOS/nixpkgs/commit/d70f541fcb517bba69f2a5fedd6e7aa35b9fce5d) grizzly: 0.2.0 -> 0.3.0
* [`12d74fb0`](https://github.com/NixOS/nixpkgs/commit/12d74fb0615d0c958dc39585c469ca627e60e886) hilbish: 2.1.2 -> 2.2.1
* [`0e6e068f`](https://github.com/NixOS/nixpkgs/commit/0e6e068f89d4398b730d7123044200b52d426237) jackett: 0.21.1468 -> 0.21.1510
* [`c7ef5c0b`](https://github.com/NixOS/nixpkgs/commit/c7ef5c0bf48f1868b5579a8622b28eaf747308f9) libcint: 5.4.0 -> 6.1.0
* [`3eed54d1`](https://github.com/NixOS/nixpkgs/commit/3eed54d14c4b369b2efd86c13fe689c749ebe0a6) python311Packages.retry-decorator: rename from retry_decorator
* [`0827a3b2`](https://github.com/NixOS/nixpkgs/commit/0827a3b2e933ceec176403c0c19bf96c04461d17) autocorrect: add missing frameworks on darwin
* [`dbe38b28`](https://github.com/NixOS/nixpkgs/commit/dbe38b2877f935728db4a1aa6e475750c4cb4fbc) libcint: fix tests on darwin, set platforms
* [`7d8120a7`](https://github.com/NixOS/nixpkgs/commit/7d8120a72eef91609c066db1067d377e20bf7ae3) dolphin-emu: 5.0-19870 -> 5.0-20347
* [`c7b66c71`](https://github.com/NixOS/nixpkgs/commit/c7b66c7165a627b2c6e82fe6664f34bf0583eff0) fira-math: init at 0.3.4
* [`bb1d7fe0`](https://github.com/NixOS/nixpkgs/commit/bb1d7fe0c34b961910141fbc71b122939b1e6a9a) yabai: 6.0.4 -> 6.0.5
* [`8816df47`](https://github.com/NixOS/nixpkgs/commit/8816df475a970b16305d09b33aac9f7839b96f43) p2pool: 3.9 -> 3.10
* [`e3878fa0`](https://github.com/NixOS/nixpkgs/commit/e3878fa07b2e3edb6b1fe600db3b9bc3fdfc77f6) ldc: 1.35.0 -> 1.36.0
* [`263a28fd`](https://github.com/NixOS/nixpkgs/commit/263a28fd7bf34b63f900d68b214dc280c0c9f179) ldc: update to LLVM 17
* [`7e5d75af`](https://github.com/NixOS/nixpkgs/commit/7e5d75aff4ac4dd4195d31e98aea4e2b22407d97) grsync: Add wrapGAppsHook
* [`8930c796`](https://github.com/NixOS/nixpkgs/commit/8930c7968f28d7a5ca55e37560f9c1a2dc1fad81) chkservice: remove
* [`7303752a`](https://github.com/NixOS/nixpkgs/commit/7303752a899cd71f227e75cc2e23c896aa89a909) alpine-make-vm-image: 0.12.0 -> 0.13.0
* [`392f406b`](https://github.com/NixOS/nixpkgs/commit/392f406b79539721be6e34fd9523aeb49ebe2a0f) maintainers: add appsforartists
* [`98ed8c23`](https://github.com/NixOS/nixpkgs/commit/98ed8c2346b72db4e9780f122d81e64058a92c4a) inconsolata: 2.001 -> 3.001
* [`e138af57`](https://github.com/NixOS/nixpkgs/commit/e138af57877d37345ed17b7ce83861823d069c08) sniffglue: 0.15.0 -> 0.16.0
* [`4537d82f`](https://github.com/NixOS/nixpkgs/commit/4537d82fc030791db9de83dec5123689659446a7) dorion: 3.1.1 -> 4.0.0
* [`66047aa1`](https://github.com/NixOS/nixpkgs/commit/66047aa1b9fd1e25b9391718e95df15264ee4765) jfrog-cli: 2.52.8 -> 2.52.9
* [`1918b607`](https://github.com/NixOS/nixpkgs/commit/1918b607953f1fe33230027bc9f99f3a73672fdd) luaPackages.image-nvim: correct magick dependency
* [`186cbf36`](https://github.com/NixOS/nixpkgs/commit/186cbf36e1af0ddb3a47b42de54b47336a111abb) pocket-updater-utility: 2.42.0 -> 2.43.0
* [`71d7145a`](https://github.com/NixOS/nixpkgs/commit/71d7145a4b2b47b4312f22ce41846ec1e18c3c0c) mint: 0.15.3 -> 0.19.0
* [`0f9f5f48`](https://github.com/NixOS/nixpkgs/commit/0f9f5f484f4029c2db3a52e570a2f4df224614d6) yabai: 6.0.5 -> 6.0.6
* [`dc334c2a`](https://github.com/NixOS/nixpkgs/commit/dc334c2a8cfa255ba2f46fadc1659992d499d346) python310Packages.boxx: 0.10.12 -> 0.10.13
* [`38c0769f`](https://github.com/NixOS/nixpkgs/commit/38c0769f8d15be0c94019cb032e9301391e3f045) python310Packages.colorful: 0.5.5 -> 0.5.6
* [`e5a95fa6`](https://github.com/NixOS/nixpkgs/commit/e5a95fa6399691dffccf40fb156591ad5985801a) go-minimock: 3.1.3 -> 3.3.6
* [`bf5e589e`](https://github.com/NixOS/nixpkgs/commit/bf5e589e3058c453e1cd55e26b97cfddf65fd1ed) flare-signal: 0.11.1 -> 0.11.2
* [`aa1a1457`](https://github.com/NixOS/nixpkgs/commit/aa1a145744d462654c7965bb36c0ccdd0f6d1294) python310Packages.google-cloud-asset: 3.22.0 -> 3.23.0
* [`54c0ef42`](https://github.com/NixOS/nixpkgs/commit/54c0ef42528497d522da809797ea9e1a88242ffa) python310Packages.google-cloud-texttospeech: 2.15.0 -> 2.15.1
* [`f30d03a7`](https://github.com/NixOS/nixpkgs/commit/f30d03a7061152bbb2ef7864d3ba3af4312e5356) python310Packages.hvac: 2.0.0 -> 2.1.0
* [`a8293a49`](https://github.com/NixOS/nixpkgs/commit/a8293a49cf9dddbde5750af29ebd34a287edb13e) clifm: 1.15 -> 1.16
* [`0a32b0c8`](https://github.com/NixOS/nixpkgs/commit/0a32b0c8164546d837c6ea8cff213a810b6510d1) chafa: 1.12.5 -> 1.14.0
* [`fadeddc6`](https://github.com/NixOS/nixpkgs/commit/fadeddc6db24e8681f3e0232800ad79552987926) fortran-fpm: 0.9.0 -> 0.10.0
* [`5a3b55ba`](https://github.com/NixOS/nixpkgs/commit/5a3b55ba70d8115abea1db74b4876161186b0311) maintainers: add theaninova
* [`cf61ba0b`](https://github.com/NixOS/nixpkgs/commit/cf61ba0b57e9bd966da1d414ee35fd11265fe743) caf: 0.19.4 -> 0.19.5
* [`9b942592`](https://github.com/NixOS/nixpkgs/commit/9b94259208cac33dfc546361427959e5d2c709f7) tuleap-cli: init at 1.0.0
* [`d83b3ae5`](https://github.com/NixOS/nixpkgs/commit/d83b3ae5a6f25476c74570de07554cb4524cb822) kubevpn: 2.2.0 -> 2.2.1
* [`d3763eeb`](https://github.com/NixOS/nixpkgs/commit/d3763eeb08d2ecb1115c8ff00bddf8c801bd929a) libhdhomerun: 20220303 -> 20231214
* [`8f6f6b4e`](https://github.com/NixOS/nixpkgs/commit/8f6f6b4eac40e7d248f575399ab93e1a0211b4dc) c-for-go: init at `a1822f0`
* [`b6839c45`](https://github.com/NixOS/nixpkgs/commit/b6839c45e5fee0d9e480a29845f70dc11617156a) magic-vlsi: 8.3.454 -> 8.3.456
* [`556e05b1`](https://github.com/NixOS/nixpkgs/commit/556e05b1f81a1e5848f495ede9a3dcadd851adcf) metabase: 0.48.1 -> 0.48.2
* [`8e0a0d3a`](https://github.com/NixOS/nixpkgs/commit/8e0a0d3a184ce2d77d84c85d8183638ec1f3b25e) mockoon: 6.0.1 -> 6.1.0
* [`6fe79120`](https://github.com/NixOS/nixpkgs/commit/6fe79120ccce9db0d51a9f67af67ea55013ada02) npm-check-updates: 16.14.0 -> 16.14.12
* [`9d5b4872`](https://github.com/NixOS/nixpkgs/commit/9d5b48721d619c43308c9474642b2c757426a005) emacs/titaniumenv: Drop broken files
* [`ce51556e`](https://github.com/NixOS/nixpkgs/commit/ce51556e2b38daaf49034dc29ecf2b2682da5688) gotraceui: 0.3.0 -> 0.4.0
* [`54e606bd`](https://github.com/NixOS/nixpkgs/commit/54e606bda04d292787745c5047f32572d5cfecfc) openai-whisper-cpp: 1.5.2 -> 1.5.4
* [`b9eee53d`](https://github.com/NixOS/nixpkgs/commit/b9eee53d1ce940e764ab8fc1210aaf10666d8b2e) mdevctl: 1.2.0 -> 1.3.0
* [`c1a73c10`](https://github.com/NixOS/nixpkgs/commit/c1a73c1082d96feb1f80f9857538499c253a9a3c) netop: init at 0.1.4
* [`98d05349`](https://github.com/NixOS/nixpkgs/commit/98d0534987054f78855d3f241e9edb3942b3ec01) clifm: 1.15 -> 1.16
* [`9c701484`](https://github.com/NixOS/nixpkgs/commit/9c7014841661dff7b882b78516bf97e099dfa8f2) linuxPackages.apfs: 0.3.5 -> 0.3.6
* [`41fb6ea8`](https://github.com/NixOS/nixpkgs/commit/41fb6ea81bb844406e031a06e0a932eaf21f0294) rPackages: CRAN and BioC update
* [`6dfec6a2`](https://github.com/NixOS/nixpkgs/commit/6dfec6a2d5fc0977cbb706d0462709be622a37f8) geoipupdate: 6.0.0 -> 6.1.0
* [`a7c30eb7`](https://github.com/NixOS/nixpkgs/commit/a7c30eb7cec5c1dbea57de7f7a2a1e32fc3e38ce) python310Packages.pycaption: 2.2.0 -> 2.2.1
* [`6962ac40`](https://github.com/NixOS/nixpkgs/commit/6962ac40c68e9eb829930332dba7458c4f92a7e6) revive: 1.3.5 -> 1.3.6
* [`f7a17577`](https://github.com/NixOS/nixpkgs/commit/f7a175776eeb7dda707d88d7ae7b0621727a4543) ci: Check if all nix files are parseable
* [`f9ffd43c`](https://github.com/NixOS/nixpkgs/commit/f9ffd43cd39432c38895e7978f65ce149ed9c73e) git-quick-stats: 2.5.3 -> 2.5.4
* [`79c16847`](https://github.com/NixOS/nixpkgs/commit/79c168475f1ee9e1d092187b27476129b50f42ec) glamoroustoolkit: use system libgit2
* [`1608e01a`](https://github.com/NixOS/nixpkgs/commit/1608e01ab4092cf9519bc826a0f71475c9cfd06e) python311Packages.pycaption: refactor
* [`a6a12e00`](https://github.com/NixOS/nixpkgs/commit/a6a12e000d496e5cb154f7b5c3b9a2f3acb97898) python310Packages.strawberry-graphql: 0.215.1 -> 0.217.1
* [`81e01976`](https://github.com/NixOS/nixpkgs/commit/81e01976d383bf474ab43b8248753138fc442c40) flirc: 3.24.3 -> 3.27.10
* [`69fc71a8`](https://github.com/NixOS/nixpkgs/commit/69fc71a82c0e3acba5045666b48cdaf5adc8d4c3) tests.nixpkgs-check-by-name: Basic info for non-by-name attributes
* [`57afdc54`](https://github.com/NixOS/nixpkgs/commit/57afdc545bdc9894754c51265ab993da556915e4) tests.nixpkgs-check-by-name: Enforce pkgs/by-name for new packages
* [`cbff0283`](https://github.com/NixOS/nixpkgs/commit/cbff02834f3c0a1daa3502566fcf19433f9ca214) tests.nixpkgs-check-by-name: Sort the eval validation results
* [`d659d5f8`](https://github.com/NixOS/nixpkgs/commit/d659d5f8acb06ada213dac7c7d87ac20cba15c22) tests.nixpkgs-check-by-name: Use real lib for tests
* [`be26d748`](https://github.com/NixOS/nixpkgs/commit/be26d74840eb86f7e7dfb11dce0f5d329e775257) tests.nixpkgs-check-by-name: Add test for alternate callPackage's
* [`0751c7f1`](https://github.com/NixOS/nixpkgs/commit/0751c7f1d3bfdfeb79d8ba4f4f479eba24009dc3) transifex-client: remove as deprecated
* [`628e3e29`](https://github.com/NixOS/nixpkgs/commit/628e3e2921e41e95b5e21ad86832e200039ff7f1) python3Packages.pdoc: fix darwin
* [`a6937af2`](https://github.com/NixOS/nixpkgs/commit/a6937af2a9a6725147fc4c6d7f96be8cffec4fdd) tz: 0.6.3 -> 0.7.0
* [`50656be0`](https://github.com/NixOS/nixpkgs/commit/50656be095258080366a9238cbfa4b134ab52117) python311Packages.nose-warnings-filters: rename from nose_warnings_filters
* [`dc1bb8ca`](https://github.com/NixOS/nixpkgs/commit/dc1bb8caba2863b75aab0f48db2a16a9e2429a37) flutter: Add version json file
* [`579e0132`](https://github.com/NixOS/nixpkgs/commit/579e01329e83a2bd44762be64b3862e1f8dfd8b7) flutter: Rename platform to flutterPlatform
* [`da6757fd`](https://github.com/NixOS/nixpkgs/commit/da6757fd9d0deff3fe5ead896834c3e3e70d8d66) flutter: Make fetch-artifects.nix independent from the host's platform
* [`ed823ace`](https://github.com/NixOS/nixpkgs/commit/ed823acee218f7659b6504bb42f4743580cd6f51) atmos: 1.16.0 -> 1.53.0
* [`c3f75e05`](https://github.com/NixOS/nixpkgs/commit/c3f75e05e02cfa44182aa00c5931b99afa88eaa2) python310Packages.webargs: 8.3.0 -> 8.4.0
* [`e23b2a10`](https://github.com/NixOS/nixpkgs/commit/e23b2a10e45eb0e0a56616e1ae331159c4cdfb07) python310Packages.wheezy-captcha: 3.0.2 -> 3.2.0
* [`e7f07ce6`](https://github.com/NixOS/nixpkgs/commit/e7f07ce6e5f05db8b10d84d23e3cfca726dc215e) flamp: 2.2.10 -> 2.2.11
* [`b85fb278`](https://github.com/NixOS/nixpkgs/commit/b85fb278cd7bbfd23c4e44a6c5984237c09d906b) libsForQt5.kdsoap: 2.1.1 -> 2.2.0
* [`e133b24d`](https://github.com/NixOS/nixpkgs/commit/e133b24ddf11f8173dd02c5632e917e115dc2363) memcached: 1.6.22 -> 1.6.23
* [`212ff04a`](https://github.com/NixOS/nixpkgs/commit/212ff04ac0bd01457b954c67919e2c251597e65e) starsector: add rafaelrc to maintainers
* [`9473398e`](https://github.com/NixOS/nixpkgs/commit/9473398eec642783bee86f831e33cebc13edd21d) openturns: 1.21.2 -> 1.22
* [`2202d5c9`](https://github.com/NixOS/nixpkgs/commit/2202d5c90955c302d45587cbd68e7a5eb24c0c50) primesieve: 11.1 -> 11.2
* [`719f0582`](https://github.com/NixOS/nixpkgs/commit/719f058246c9cc8e70791243b525047d2a589a3f) ustreamer: 5.45 -> 5.48
* [`6dd81b5c`](https://github.com/NixOS/nixpkgs/commit/6dd81b5c75146567f504d2b656cd9090d2f81925) alfaview: 9.7.0 -> 9.8.1
* [`6f2685e4`](https://github.com/NixOS/nixpkgs/commit/6f2685e4d9902e6a1d55fadd58698ccc04c8cf9c) nanoflann: 1.5.3 -> 1.5.4
* [`3e3dceda`](https://github.com/NixOS/nixpkgs/commit/3e3dcedae8ddbddd88a2aff70edf27b222437252) python311Packages.openai: 1.6.1 -> 1.7.1
* [`d177e2ef`](https://github.com/NixOS/nixpkgs/commit/d177e2ef06fd8550117c5ddc0964a5d8feccc417) nixos/sysupdate: fix example text
* [`4db309fb`](https://github.com/NixOS/nixpkgs/commit/4db309fbea46fd99aa9d520b83e582323bfe1bf7) vaultwarden.webvault: 2023.12.0 -> 2024.1.0
* [`de477f92`](https://github.com/NixOS/nixpkgs/commit/de477f92b18435cd9a556970ece0fe05576ea2a1) inform6: 6.41-r10 -> 6.41-r11
* [`398d0498`](https://github.com/NixOS/nixpkgs/commit/398d04989e65c124dacb3b4b748042ea860eb554) readability-extractor: 0.0.10 -> 0.0.11
* [`30773079`](https://github.com/NixOS/nixpkgs/commit/30773079f5c6acbbae9775c423a9f55843be4ef2) python310Packages.yark: 1.2.9 -> 1.2.10
* [`a6fb345f`](https://github.com/NixOS/nixpkgs/commit/a6fb345fbfbaffd34d9b3d2c5bd4ab5618f4705a) python310Packages.zconfig: 3.6.1 -> 4.0
* [`6a9e3f4d`](https://github.com/NixOS/nixpkgs/commit/6a9e3f4d550a12e500f2ab91a529bdca679b0b44) libusbp: init at 1.3.0
* [`90cdd717`](https://github.com/NixOS/nixpkgs/commit/90cdd717e3085ba564b81f2350b9cd83f55ad479) dotnet-sdk_6: 6.0.417 -> 6.0.418
* [`50e760ea`](https://github.com/NixOS/nixpkgs/commit/50e760ea3ab6a405a50e354cae15d192ff24919a) dotnet-sdk_7: 7.0.404 -> 7.0.405
* [`b7d74162`](https://github.com/NixOS/nixpkgs/commit/b7d741627846373e979882c8ce719e8e32621964) dotnet-sdk_8: 8.0.100 -> 8.0.101
* [`3ec033f4`](https://github.com/NixOS/nixpkgs/commit/3ec033f4e729a4027677ee54a43f0c8fa403a0dc) ArchiSteamFarm: Make compatible with .NET 8.0.1
* [`bda77a3b`](https://github.com/NixOS/nixpkgs/commit/bda77a3bd5f2602bcbbf43b5bbb7b5b3248c155e) fsautocomplete: Update framework deps
* [`3a0626d7`](https://github.com/NixOS/nixpkgs/commit/3a0626d7fc083188a4805f3749b937df1c4e212b) naps2: Update framework deps
* [`0d50a327`](https://github.com/NixOS/nixpkgs/commit/0d50a327adc31b77a131abaa98cdd3a9c6ec50f2) omnisharp-roslyn: Update framework deps
* [`8b7ef255`](https://github.com/NixOS/nixpkgs/commit/8b7ef2554a92b5f80923e4a693b4b96fa5ecc2ba) readarr: 0.3.14.2348 -> 0.3.14.2358
* [`436ade14`](https://github.com/NixOS/nixpkgs/commit/436ade14bb5b715d5679376ebaa5e2fc10fcf817) imgui: 1.90 -> 1.90.1
* [`08c00a0f`](https://github.com/NixOS/nixpkgs/commit/08c00a0fb0dc1f508dee3edda8e6edbede078961) elastic: 0.1.3 → 0.1.4
* [`09623aa1`](https://github.com/NixOS/nixpkgs/commit/09623aa182864bcf8cb17bf0b60f2be0f9647ad3) wike: 2.0.1 → 2.1.0
* [`d8cdaedc`](https://github.com/NixOS/nixpkgs/commit/d8cdaedc42ac25aa442833ea9eb36be6af2a8789) fragments: 2.1.0 → 2.1.1
* [`6beed540`](https://github.com/NixOS/nixpkgs/commit/6beed5405fdbf0c230e4d00d5b7e9cb4914778df) trillian: 1.5.3 -> 1.6.0
* [`6815a007`](https://github.com/NixOS/nixpkgs/commit/6815a0077d291a35a2f7c3eb715ece3da7035419) nix-cl: provide the original pname as an attribute
* [`a38eab06`](https://github.com/NixOS/nixpkgs/commit/a38eab0660321e96f635770dbfe026000d09d9bf) reaper: 7.07 -> 7.08
* [`5a022850`](https://github.com/NixOS/nixpkgs/commit/5a0228509a68046e3c51b87dd55f0b12847a5d48) evcc: 0.123.7 -> 0.123.8
* [`4cdca414`](https://github.com/NixOS/nixpkgs/commit/4cdca4149552b5b114f7e709d88021c0c07e22c4) rednotebook: 2.29.3 -> 2.31
* [`5b4ad739`](https://github.com/NixOS/nixpkgs/commit/5b4ad73974f05474065607f00652093aadaf802e) mpich: enable pmix support
* [`4108296b`](https://github.com/NixOS/nixpkgs/commit/4108296b53f9622929b975266e118d63d671631f) mpich: drop unrecognized option --enable-sharedlib
* [`6cccc07a`](https://github.com/NixOS/nixpkgs/commit/6cccc07ab7ff4d71a30c61575b8e67011f8e3aa2) mpich: do not disable gforker by default
* [`94761489`](https://github.com/NixOS/nixpkgs/commit/947614897ecf2d726f76c3fc5933ab64bbdb5419) mpich: extend the warning about pmix
* [`48025cb2`](https://github.com/NixOS/nixpkgs/commit/48025cb2cfb190482fcb548f49e0bcd8d8bd69d3) mpich-pmix: init
* [`a850790a`](https://github.com/NixOS/nixpkgs/commit/a850790a260ddffb9c37fdfac2a2daae88ad0118) retext: 8.0.0 -> 8.0.1
* [`8191bad7`](https://github.com/NixOS/nixpkgs/commit/8191bad70b44b8a6a2a55e78061c173fd3347538) rivalcfg: 4.8.0 -> 4.10.0
* [`1c015b3d`](https://github.com/NixOS/nixpkgs/commit/1c015b3d100abb22f50dda78ca8d2552386d6b85) rmview: 3.1.2 -> 3.1.3
* [`9bf0a829`](https://github.com/NixOS/nixpkgs/commit/9bf0a82912112f4102387ef5247d89c2544c49a0) mpich: handle empty withPm correctly
* [`da486271`](https://github.com/NixOS/nixpkgs/commit/da48627167790070b51146ef73788b1a6c54c32a) postgresqlPackages.pg_partman: 5.0.0 -> 5.0.1
* [`31cdc427`](https://github.com/NixOS/nixpkgs/commit/31cdc42751645300cf81101e864be6e34bc3428a) rake: 13.0.6 -> 13.1.0
* [`36436ec4`](https://github.com/NixOS/nixpkgs/commit/36436ec47f716995fe17abc1db1f8cdb37e4c9d1) ante: 2022-08-22 -> 2023-12-18
* [`9716216a`](https://github.com/NixOS/nixpkgs/commit/9716216a1fb623e31d3666d91dedaca038f570ad) freeipa: 4.11.0 -> 4.11.1
* [`f9b38e08`](https://github.com/NixOS/nixpkgs/commit/f9b38e08f679e76f2008a21d50f591167efb8b76) python311Packages.pyaudio: 0.2.13 -> 0.2.14
* [`94d83cc9`](https://github.com/NixOS/nixpkgs/commit/94d83cc9bdccefbc2d8a2ee469f2b6f198cc4b4a) python311Packages.pysigma-backend-elasticsearch: 1.0.9 -> 1.0.10
* [`cde2c092`](https://github.com/NixOS/nixpkgs/commit/cde2c09219d0c6d22a35efac7d1ff23baf0ddd01) ocamlPackages.uucd: 15.0.0 → 15.1.0
* [`4c010291`](https://github.com/NixOS/nixpkgs/commit/4c010291d1bf9fbe37252f564a4a3de18fb7e948) rqlite: 8.13.2 -> 8.16.3
* [`2c3349cc`](https://github.com/NixOS/nixpkgs/commit/2c3349ccfa078c6653d9b899da5584b85e66a361) mountpoint-s3: init at 1.3.2
* [`4f198178`](https://github.com/NixOS/nixpkgs/commit/4f198178bfd527b81b03578db2b2eea8173b7226) runme: 2.0.7 -> 2.2.0
* [`91becdb6`](https://github.com/NixOS/nixpkgs/commit/91becdb6bdc5353fbcec014b58776fcbd4bb8789) s3cmd: 2.3.0 -> 2.4.0
* [`d9e6014a`](https://github.com/NixOS/nixpkgs/commit/d9e6014ac8912fac216506c7ebcd91dcceb8136a) sacad: 2.4.0 -> 2.7.5
* [`c097f4c8`](https://github.com/NixOS/nixpkgs/commit/c097f4c8855b4ad360376a9990d53eef411b0812) salt: 3006.4 -> 3006.5
* [`fff8a317`](https://github.com/NixOS/nixpkgs/commit/fff8a317703894f4edb4673a08493f4a35cddc6b) sasutils: 0.4.0 -> 0.5.0
* [`7cfbd0e9`](https://github.com/NixOS/nixpkgs/commit/7cfbd0e9d23931ba4c724573503588730450f64c) python311Packages.pysigma-backend-elasticsearch: refactor
* [`6acd292e`](https://github.com/NixOS/nixpkgs/commit/6acd292ea9a754f6522e669cb39e44b0a7814947) python311Packages.zconfig: refactor
* [`4d7c57eb`](https://github.com/NixOS/nixpkgs/commit/4d7c57eb5a30b212da77fcc7e50301b2f9300d9a) python311Packages.zconfig: migrate to pytestCheckHook
* [`f60e8bcf`](https://github.com/NixOS/nixpkgs/commit/f60e8bcfaff8c41b7fbfba3f42b7363c1178f10b) python311Packages.yark: refactor
* [`a622538c`](https://github.com/NixOS/nixpkgs/commit/a622538ce29798f76664ece8b8b5a4c8d818a7b4) powersupply: init at 0.9.0
* [`154ad83d`](https://github.com/NixOS/nixpkgs/commit/154ad83dcdb7ff1126470e64d48e775b4864a662) haproxy: 2.9.1 -> 2.9.2
* [`3998af67`](https://github.com/NixOS/nixpkgs/commit/3998af67d6c6c87a54a626961035ea834a271b77) snyk: 1.1266.0 -> 1.1269.0
* [`1502179a`](https://github.com/NixOS/nixpkgs/commit/1502179ab54ea7d719a087ee89933a7b3fa1aa7e) sosreport: 4.4 -> 4.6.1
* [`da331231`](https://github.com/NixOS/nixpkgs/commit/da33123120274610ded6af3191bc17540255c31c) spotify-cli-linux: 1.6.0 -> 1.8.2
* [`bf81e824`](https://github.com/NixOS/nixpkgs/commit/bf81e824ed92253b55aa0669dab012b0c03bad4b) maintainers: add diogotcorreia
* [`ae6e632d`](https://github.com/NixOS/nixpkgs/commit/ae6e632dcf9122b9509bfb3eae381ff4ea1e731a) treewide: update meta.description to fit the guidelines
* [`41c3d2d9`](https://github.com/NixOS/nixpkgs/commit/41c3d2d96cebd7d623a2d2d6b951c2f26c34d0d1) update arguments to definition lists as per docs team meeeting / @⁠danielsidhion
* [`2d36a09d`](https://github.com/NixOS/nixpkgs/commit/2d36a09d8bb5274b89bb080da5a10e0f954aa443) psst: unstable-2023-05-13 -> unstable-2024-01-12
* [`5b698dff`](https://github.com/NixOS/nixpkgs/commit/5b698dffbb70f742639f120835f735d47c44ef79) kode-mono: 1.201 -> 1.202
* [`999e5c92`](https://github.com/NixOS/nixpkgs/commit/999e5c920d8c8ff4b286e600a228ff7e5dfc78df) rmfakecloud: remove unused input
* [`131945d1`](https://github.com/NixOS/nixpkgs/commit/131945d1954c034e8e0457a62a068a15e9423738) rmfakecloud: 0.0.13.2 -> 0.0.17
* [`1e9fc75c`](https://github.com/NixOS/nixpkgs/commit/1e9fc75c6ee179872a0a9e0560fa638425a06fc7) whitespace cleanup
* [`0f103a3c`](https://github.com/NixOS/nixpkgs/commit/0f103a3ccccdca7d85eb662a66c5c8133a730132) triton: 7.16.0 -> 7.17.0
* [`7b498ca7`](https://github.com/NixOS/nixpkgs/commit/7b498ca7df66945226074b5e30ac9eecdf518af8) tartube: 2.4.221 -> 2.5.0
* [`4c84c9c1`](https://github.com/NixOS/nixpkgs/commit/4c84c9c1c36cb0daa2eaa04b3f5c415fac1cac57) nixos/mail/listmonk: fix hardening directives
* [`c28c56f3`](https://github.com/NixOS/nixpkgs/commit/c28c56f3790762920f3c9849b05a69fc8b9848f6) fetchzip: allow dropping unzip
* [`71a024e1`](https://github.com/NixOS/nixpkgs/commit/71a024e1f6e0d2263b5249d65b92ef5c14010a79) fetchFromGitHub: drop unzip
* [`27b277b6`](https://github.com/NixOS/nixpkgs/commit/27b277b63c2c8ab5a0e40e88216f1061a80183d0) tests.cuda: inherit the ready cudaPackages_XX.cuda-samples
* [`875e43df`](https://github.com/NixOS/nixpkgs/commit/875e43dfd70a3e58573d94d44e4c931d464ae76a) cudaPackages.cuda{,-library}-samples: move to cuda-modules/
* [`18b114d8`](https://github.com/NixOS/nixpkgs/commit/18b114d8bf40e26c86e3d2eadc4df1e5e3fcfb0d) cudaPackages_11_4.saxpy: clean(er) eval error
* [`e7f5fc51`](https://github.com/NixOS/nixpkgs/commit/e7f5fc51be81954b0d219a541698e700d9989349) python311Packages.python-gvm: 23.12.0 -> 24.1.0
* [`90787dbe`](https://github.com/NixOS/nixpkgs/commit/90787dbe89db86f661ff0b2b71a752518fa014de) nixos/nextcloud: set up base directories & override.config.php with tmpfiles
* [`6f9ac4bc`](https://github.com/NixOS/nixpkgs/commit/6f9ac4bc0a00f2ef7028678128f965ec1edffeb4) gef: 2023.08 -> 2024.01
* [`6199fe11`](https://github.com/NixOS/nixpkgs/commit/6199fe11a6b98144569b08f280bfdf75e011f1b1) hydrogen: 1.2.2 -> 1.2.3
* [`9a56e7c0`](https://github.com/NixOS/nixpkgs/commit/9a56e7c084daefa591bca5b681f65e4992cee441) fritz-exporter: init at 2.3.1
* [`f5b7da46`](https://github.com/NixOS/nixpkgs/commit/f5b7da46a2c8d5785f29740f96c9ea7943f142ab) morewaita-icon-theme: 43.2 -> 45
* [`1d7100a0`](https://github.com/NixOS/nixpkgs/commit/1d7100a082dffe49d94f1afe26be484cd07e3c6f) zeroad: fix build with new gcc and libxml
* [`51dfaf63`](https://github.com/NixOS/nixpkgs/commit/51dfaf639a9365f327e1ffd153a237178999fb82) nixos/zfs: fix getKeyLocations when listsnaps=on
* [`80d4e7a9`](https://github.com/NixOS/nixpkgs/commit/80d4e7a9d7df98a33e1dfeb7602710409a88097e) powershell: 7.4.0 -> 7.4.1
* [`629b8f63`](https://github.com/NixOS/nixpkgs/commit/629b8f635430c4290a64e9a36e9865763b0f5030) containerd: 1.7.11 -> 1.7.12
* [`32638686`](https://github.com/NixOS/nixpkgs/commit/32638686d1913cc867cb8ab4ab0115e312c65113) Apply @⁠bzm3r suggestions from code review
* [`25b2c3a0`](https://github.com/NixOS/nixpkgs/commit/25b2c3a0cc480ee4f01c82df717f26f984a490d4) incorporate the spirit of change proposed by @⁠DanielSidhion at https://github.com/NixOS/nixpkgs/pull/277534#discussion_r1450778530
* [`7aa84efb`](https://github.com/NixOS/nixpkgs/commit/7aa84efba2600d1c2446c2dee95cf8d36ba437bc) incorporate the suggestion at https://github.com/NixOS/nixpkgs/pull/277534/files#r1450959283
* [`9dd6f844`](https://github.com/NixOS/nixpkgs/commit/9dd6f8446d99b990f931ff508c89395f669f10ef) icloudpd: init at 1.17.3
* [`56108dd5`](https://github.com/NixOS/nixpkgs/commit/56108dd5ab70b012c7ffd885b84bb44a7367e4f0) not realized; produced
* [`39227d5c`](https://github.com/NixOS/nixpkgs/commit/39227d5ce39c9004972ca3b15e89268ceaeca7db) describing the composiion of the store path elements is not really that useful
* [`b0f54230`](https://github.com/NixOS/nixpkgs/commit/b0f542304df44f97abe8c497dce917c53d7cd972) add to example
* [`1ba2c408`](https://github.com/NixOS/nixpkgs/commit/1ba2c40826ab64c6a3a6e41a88728861d05622e4) tflint-plugins.tflint-ruleset-google: 0.24.0 -> 0.26.0
* [`1c1ca562`](https://github.com/NixOS/nixpkgs/commit/1c1ca56266b1c10ec764af2578203732b83097d9) pgadmin: 8.1 -> 8.2
* [`c2eb9919`](https://github.com/NixOS/nixpkgs/commit/c2eb9919f7d87909f64786528a0f1e4ac3463da7) python3Packages.webauthn: 1.11.1 -> 2.0.0
* [`6e3e1403`](https://github.com/NixOS/nixpkgs/commit/6e3e1403f1ade925bba5d93a36d1a7c703c83ec2) python311Packages.sentry-sdk: 1.39.0 -> 1.39.2
* [`250f6d5b`](https://github.com/NixOS/nixpkgs/commit/250f6d5bbd5195e27c0746a4b426d381381933ad) pmtiles: init at 1.12.0
* [`4dd06373`](https://github.com/NixOS/nixpkgs/commit/4dd063739978c149b15a974b557115bcceba3470) python311Packages.kombu: 5.3.4 -> 5.3.5
* [`03e575b0`](https://github.com/NixOS/nixpkgs/commit/03e575b0bb7d57cb31cc7346e3d2964d2e1f38aa) pulseaudio-module-xrdp: init at 0.7
* [`f0f94e78`](https://github.com/NixOS/nixpkgs/commit/f0f94e782353c369dc77b1dfd4c1af9704fc70e8) pkgsMusl.bun: mark broken for musl
* [`fb74449a`](https://github.com/NixOS/nixpkgs/commit/fb74449aeaefe38fd7e7bb64d79ca0a30a065ec7) passdetective: init at 1.0.7
* [`ff579039`](https://github.com/NixOS/nixpkgs/commit/ff579039ee1b1d87103caa457fbdcbd14324ac11) xrdp: reformat the derivation for the changes
* [`4e412d09`](https://github.com/NixOS/nixpkgs/commit/4e412d091c194f9090e54fe49946e0797f450200) xrdp: enable a few more features
* [`4a45704d`](https://github.com/NixOS/nixpkgs/commit/4a45704d344ba3df41ec3de0885dcbfee027af07) xrdp: add myself as mainntainer
* [`44ae5fe2`](https://github.com/NixOS/nixpkgs/commit/44ae5fe2113cd0c279e84d6806a03f3f3797a2b6) nixos/xrdp: add audio.enable option
* [`cf26222c`](https://github.com/NixOS/nixpkgs/commit/cf26222cc8a04db6ee2714271e09d448fea74fdd) nixos/tests: add xrdp-with-audio-pulseaudio
* [`7530777b`](https://github.com/NixOS/nixpkgs/commit/7530777b72ba12d9636a633fb782d32782493877) advanced-scene-switcher: remove `paveloom` from maintainers
* [`d255738d`](https://github.com/NixOS/nixpkgs/commit/d255738da5e75aa6e6a05bc6364df55429c83ebd) anki: remove `paveloom` from maintainers
* [`3a29950a`](https://github.com/NixOS/nixpkgs/commit/3a29950a95440ba92603922103b673ae5eea949e) blueprint-compiler: remove `paveloom` from maintainers
* [`92b80d64`](https://github.com/NixOS/nixpkgs/commit/92b80d64883da5dd178a0f513eeb62a41dc4a713) codon: remove `paveloom` from maintainers
* [`76e3feb9`](https://github.com/NixOS/nixpkgs/commit/76e3feb9f1814b229e079910df4dbbe2cac644bf) gut: remove `paveloom` from maintainers
* [`8c2e8070`](https://github.com/NixOS/nixpkgs/commit/8c2e8070f3ab3a15c5339038b614e30d7b57a7b8) identity: remove `paveloom` from maintainers
* [`ffa9ae28`](https://github.com/NixOS/nixpkgs/commit/ffa9ae28418b95dd65411e1a2b8c56708c769368) libremidi: remove `paveloom` from maintainers
* [`4828a8f1`](https://github.com/NixOS/nixpkgs/commit/4828a8f149a3bf889ef2a9cf85d2d87d6fe3a375) mecab: remove `paveloom` from maintainers
* [`e1fd2c62`](https://github.com/NixOS/nixpkgs/commit/e1fd2c62ba21e7ca5bbd0dc64af5957975000ce5) obs-teleport: remove `paveloom` from maintainers
* [`24641d42`](https://github.com/NixOS/nixpkgs/commit/24641d4209bebf2c75f30e05a51d5c576947ae2f) picard: remove `paveloom` from maintainers
* [`3a4ede4d`](https://github.com/NixOS/nixpkgs/commit/3a4ede4dc7bdca756244e7a660d81e1af0bbe328) python3Packages.darkdetect: remove `paveloom` from maintainers
* [`0dd46625`](https://github.com/NixOS/nixpkgs/commit/0dd46625572f84e7cf7c44cabff249e661f1b665) python3Packages.mobi: remove `paveloom` from maintainers
* [`e55e13e9`](https://github.com/NixOS/nixpkgs/commit/e55e13e98c22047f7bdc3c77a78d9a7b26fa1e0a) python3Packages.readmdict: remove `paveloom` from maintainers
* [`3d3b1a76`](https://github.com/NixOS/nixpkgs/commit/3d3b1a7684bb6b88cb75c1771446290154ea29e9) python3Packages.sentence-splitter: remove `paveloom` from maintainers
* [`1b058603`](https://github.com/NixOS/nixpkgs/commit/1b058603b969fe4f9f2be74509b201b377d8cee9) python3Packages.simplemma: remove `paveloom` from maintainers
* [`cb570cf8`](https://github.com/NixOS/nixpkgs/commit/cb570cf85eb30c9633fb8f2a0df68b032dfdf380) python3Packages.slpp: remove `paveloom` from maintainers
* [`105c7458`](https://github.com/NixOS/nixpkgs/commit/105c74585102e5a232bf80b8bc918aee02323146) qbittorrent: remove `paveloom` from maintainers
* [`4b53474e`](https://github.com/NixOS/nixpkgs/commit/4b53474e6cbde27532fc5db9633e29f80690b0b0) quodlibet: remove `paveloom` from maintainers
* [`200c3208`](https://github.com/NixOS/nixpkgs/commit/200c3208337d97b5044dac0e715c970f33609011) subtitleedit: remove `paveloom` from maintainers
* [`9942154f`](https://github.com/NixOS/nixpkgs/commit/9942154f3e6bcc8c696e4b1cfc0691c69c1c6689) wireshark: remove `paveloom` from maintainers
* [`7063e1fc`](https://github.com/NixOS/nixpkgs/commit/7063e1fcd021ced81fdb988a71f9166cf2ca7874) python311Packages.biopython: 1.82 -> 1.83
* [`18bb8a07`](https://github.com/NixOS/nixpkgs/commit/18bb8a070536b35fcd3e87b9296c46bf2ffeec81) python3Packages.pure-protobuf: 3.0.0 -> 2.3.0
* [`83bf1923`](https://github.com/NixOS/nixpkgs/commit/83bf19239f7969c461219130c65ab50ce4fa4604) python311Packages.bokeh: 3.3.2 -> 3.3.3
* [`ef9fddc0`](https://github.com/NixOS/nixpkgs/commit/ef9fddc0e7aff2503a878e9eb8133960f0f36530) python311Packages.boltztrap2: 22.12.1 -> 24.1.1
* [`894f4b73`](https://github.com/NixOS/nixpkgs/commit/894f4b73c0455282d8b9c42048d7c095830c4f1e) linux_xanmod: 6.1.70 -> 6.1.72
* [`1c6483b6`](https://github.com/NixOS/nixpkgs/commit/1c6483b6a6482224471a9c1277a8291e7873375d) linux_xanmod_latest: 6.6.9 -> 6.6.10
* [`d92b5376`](https://github.com/NixOS/nixpkgs/commit/d92b5376526cee94f3b6be90a6e7a149ca7b3b9c) wamr: 1.3.0 -> 1.3.1
* [`66f7db11`](https://github.com/NixOS/nixpkgs/commit/66f7db11a1707f1520f53afc00a9716ca4314b57) gnome-network-displays: remove apparently unneeded patch
* [`ef47f32b`](https://github.com/NixOS/nixpkgs/commit/ef47f32b6f6040753ba8a31677ad0e92376b9f8d) monolith: 2.7.0 -> 2.8.0
* [`65507ade`](https://github.com/NixOS/nixpkgs/commit/65507adef6725a7484ad2bfae70eb31657be7a3a) bruno: fix darwin builds
* [`6d993906`](https://github.com/NixOS/nixpkgs/commit/6d9939065dd6c62c1acb164edb34e7f99561a123) bruno: fix arm64 linux builds
* [`c71fa4be`](https://github.com/NixOS/nixpkgs/commit/c71fa4be0ca5f8d43b2630fa314f266dbc0cffac) heimdal: clean up package
* [`fe2a639a`](https://github.com/NixOS/nixpkgs/commit/fe2a639aa74baff686663831b72e5b89f3595825) heimdal: add h7x4 as maintainer
* [`08c9ea86`](https://github.com/NixOS/nixpkgs/commit/08c9ea8606792b3b26b9e36c11a5227ad841304f) modprobed-db: init at 2.46
* [`9a9c192d`](https://github.com/NixOS/nixpkgs/commit/9a9c192d743b691f0d7a98736aa1d6a5a1fa7e8d) ansible: 2.15.5 -> 2.16.2
* [`5ea284d4`](https://github.com/NixOS/nixpkgs/commit/5ea284d4f402aea4e9a1cbc6fb735d7bb98c8d4d) ansible_2_13: remove
* [`722d7cdb`](https://github.com/NixOS/nixpkgs/commit/722d7cdbb42712097b7f186c7f1a62935985f6b0) python311Packages.pytest-ansible: 4.1.1 -> 24.1.1
* [`fbfaf31f`](https://github.com/NixOS/nixpkgs/commit/fbfaf31f9b6be11440a285bc526388175aa7afcc) chezmoi: 2.42.3 -> 2.45.0
* [`5b9de10b`](https://github.com/NixOS/nixpkgs/commit/5b9de10b9e440b82a9a682a844e3d1abf93f76fb) python311Packages.biopython: enable tests and refactor
* [`c0c2562b`](https://github.com/NixOS/nixpkgs/commit/c0c2562b2e2d6a545d00956c7fb440c5b3b0e642) python311Packages.django-ninja: 1.0.1 -> 1.1.0
* [`61b09ebd`](https://github.com/NixOS/nixpkgs/commit/61b09ebd36d9a1dfb85b85665ad21b51d87e6c71) apacheHttpdPackages.mod_auth_mellon: 0.18.1 -> 0.19.0
* [`aa616516`](https://github.com/NixOS/nixpkgs/commit/aa6165163223245f7fe970efcd4f8d5a462dcd99) datefudge: 1.24 -> 1.25
* [`2e144895`](https://github.com/NixOS/nixpkgs/commit/2e1448950f1f579e6e8f81ee1ac0579f412801ee) python311Packages.clarabel: init at v0.6.0.post1
* [`652754ac`](https://github.com/NixOS/nixpkgs/commit/652754ac37567781be911d9dbb091337bb96d42d) python311Packages.cvxpy: add clarabel dependency
* [`ee18b58c`](https://github.com/NixOS/nixpkgs/commit/ee18b58cf4916c5e0a0f80396114ee8786a9f1bb) pub2nix: Fix language version regex on Darwin
* [`5a0bebf0`](https://github.com/NixOS/nixpkgs/commit/5a0bebf0fd577eec40b560053d8aa7f28ff72227) rmg: init at 0.5.4
* [`f9da8ba7`](https://github.com/NixOS/nixpkgs/commit/f9da8ba711ddb818df58d298daa8d07fae41b1dc) python311Packages.dogpile-cache: 1.2.2 -> 1.3.0
* [`e3f00a4e`](https://github.com/NixOS/nixpkgs/commit/e3f00a4e056407c7b6d7b82e48bb83052450922e) python311Packages.langchain-core: init at 0.1.10
* [`bc4f1f5d`](https://github.com/NixOS/nixpkgs/commit/bc4f1f5d2fa634cc97f26dd7270357eef91929f2) python311Packages.langchain-community: init at 0.0.12
* [`0684a7f8`](https://github.com/NixOS/nixpkgs/commit/0684a7f8d032b48123db699f2c096f1a9436069d) python311Packages.langsmith: 0.0.75 -> 0.0.80
* [`ba1518e6`](https://github.com/NixOS/nixpkgs/commit/ba1518e683fb22bd68736bfd28e3a831f1ae63db) python311Packages.langchain: 0.0.344 -> 0.1.0
* [`8c65bdc3`](https://github.com/NixOS/nixpkgs/commit/8c65bdc334264c53cf1b8853d17c8817b304d594) doc: add section about mkShellNoCC
* [`b87f8c38`](https://github.com/NixOS/nixpkgs/commit/b87f8c382efe5487a3b325a5b0871ff2304d48e4) python311Packages.flask-caching: 2.0.2 -> 2.1.0
* [`4f4dad19`](https://github.com/NixOS/nixpkgs/commit/4f4dad19466adbb475f89ff64a16bec8a280534a) fim-rs: init at 0.4.10
* [`3c8c55fb`](https://github.com/NixOS/nixpkgs/commit/3c8c55fb83298d317ab782b2f972d3bbd5c32cba) diffsitter: 0.8.1 -> 0.8.2
* [`a7f98b83`](https://github.com/NixOS/nixpkgs/commit/a7f98b836966cff672c900de99aec12f78f182b3) python311Packages.pyisemail: init at 2.0.1
* [`cf3f392a`](https://github.com/NixOS/nixpkgs/commit/cf3f392abec5e0e41fb33991c3db9fd5d00a47af) packj: init at 0.15-beta
* [`a4c451fd`](https://github.com/NixOS/nixpkgs/commit/a4c451fd3757a0920bc8d4f41b8979609c2ff2a8) nixos/kubo: cleanup
* [`afb57ff0`](https://github.com/NixOS/nixpkgs/commit/afb57ff041463ed5586b2d350afa4fedf96c85e1) elasticsearch: 7.17.10 -> 7.17.16
* [`d84ff40a`](https://github.com/NixOS/nixpkgs/commit/d84ff40a2d93ca873dd1c23fe3f79b56bc9e754f) python311Packages.google-cloud-datacatalog: 3.17.0 -> 3.17.2
* [`9b67dc75`](https://github.com/NixOS/nixpkgs/commit/9b67dc7566653ec7f4c6e35155ef9184a4f39a98) python311Packages.google-cloud-bigquery: 3.13.0 -> 3.16.0
* [`64c9e855`](https://github.com/NixOS/nixpkgs/commit/64c9e8551c7c8764772d0d9015ea03a2573d2953) python311Packages.gocardless-pro: 1.49.0 -> 1.50.0
* [`163bdda8`](https://github.com/NixOS/nixpkgs/commit/163bdda8fcca1bd69e47375ae05e5a9a04684bb0) pixi: init at 0.11.1
* [`5e13517a`](https://github.com/NixOS/nixpkgs/commit/5e13517a9ccca918d8b6de0bda509e261e2db8d8) nom: add maintainer nadir-ishiguro
* [`4cf5b993`](https://github.com/NixOS/nixpkgs/commit/4cf5b993ba046b1587ae7ac552ba990a62c9f9b0) python311Packages.pyqt5-multimedia: rename from pyqt5_with_qtmultimedia
* [`c30db09f`](https://github.com/NixOS/nixpkgs/commit/c30db09f018a50a25809abc3412824270eb069d6) audio-sharing: init at 0.2.2
* [`ffdcec2d`](https://github.com/NixOS/nixpkgs/commit/ffdcec2d94622d842f340a98ff5d3564e3c52ce1) nixos/tests/incus: add lxd-to-incus migration test
* [`0348f74f`](https://github.com/NixOS/nixpkgs/commit/0348f74f6afa6d823281587ba2766f2642af5277) python311Packages.hg-git: 1.0.3 -> 1.1.0
* [`9db85f27`](https://github.com/NixOS/nixpkgs/commit/9db85f27193e0e8db02a880e0cf00f017c5d16ba) sfizz: fix compilation with gcc 13
* [`529c8626`](https://github.com/NixOS/nixpkgs/commit/529c8626618a6bbc1d7891b0337ae93646fd02de) maintainers: add mattpolzin
* [`20760fd9`](https://github.com/NixOS/nixpkgs/commit/20760fd970c33c997fec682485fc70ab6fe91a8f) catppuccin-qt5ct: init at 2023-03-21
* [`6bacad52`](https://github.com/NixOS/nixpkgs/commit/6bacad5239cef944e39b69c9e9f62d94a2efbaa8) maintainers: add clr-cera
* [`7a4e19b9`](https://github.com/NixOS/nixpkgs/commit/7a4e19b91bfaddce99b22c2b8163cbc7e403d738) python311Packages.iterative-telemetry: 0.0.7 -> 0.0.8
* [`9246733a`](https://github.com/NixOS/nixpkgs/commit/9246733a3a5aefc9aab8aece35910429a320c702) guitarix: gcc13 fixes with upstream patch
* [`8fb19edb`](https://github.com/NixOS/nixpkgs/commit/8fb19edbdf8367960e6890ecb7880427c4ab62c7) sidequest: set dontUnpack
* [`2e7ed085`](https://github.com/NixOS/nixpkgs/commit/2e7ed08541b21a26e2e929a230b278b5eb15b39d) libayatana-common: Enable Lomiri features
* [`1fdb3bb1`](https://github.com/NixOS/nixpkgs/commit/1fdb3bb1c1f78329cd93ee972f8e7f0bc3f771fc) pololu-tic: init at 1.8.1
* [`84ac7df0`](https://github.com/NixOS/nixpkgs/commit/84ac7df0a4ece1880769facba66f1a31d525ddae) pinentry-bemenu: add 'meta.mainProgram'
* [`1a76b6cc`](https://github.com/NixOS/nixpkgs/commit/1a76b6cc783c01157372e31fbb768a767e5f7580) pinentry-rofi: add 'meta.mainProgram'
* [`67608598`](https://github.com/NixOS/nixpkgs/commit/67608598c99e943a747067ae987a4728eaefefa5) python311Packages.aiosql: 9.1 -> 9.2
* [`ec836290`](https://github.com/NixOS/nixpkgs/commit/ec836290b03ac2eef0e083720a6186894c89ffeb) pinentry_mac: add 'meta.mainProgram'
* [`5c44c87c`](https://github.com/NixOS/nixpkgs/commit/5c44c87c8d269ad970a1b8ea8c09e17ec28ddb0d) python3Packages.wandb: fix build
* [`9e817011`](https://github.com/NixOS/nixpkgs/commit/9e817011deed363d92ad3f21e9604a6501011ced) plymouth: 23.360.11 -> 24.004.60
* [`25f6d695`](https://github.com/NixOS/nixpkgs/commit/25f6d6952b3f6d2e39dff626895bf4036fc782d7) ogre: drop freeimage
* [`63cad099`](https://github.com/NixOS/nixpkgs/commit/63cad0998f0b72be28096b19068611d17ab72834) python311Packages.ledgercomm: 1.2.0 -> 1.2.1
* [`cf1dfaa3`](https://github.com/NixOS/nixpkgs/commit/cf1dfaa32a0201cc14801ebb93b5ef865d42522a) catppuccin: add starship theme
* [`0744b437`](https://github.com/NixOS/nixpkgs/commit/0744b437d39c13614c1254a27f5dff074d924e53) python311Packages.locationsharinglib: 5.0.2 -> 5.0.3
* [`7d2c5bf4`](https://github.com/NixOS/nixpkgs/commit/7d2c5bf495a113fac493cad733f5bf89e1915b35) python311Packages.logging-journald: 0.6.5 -> 0.6.7
* [`c607932d`](https://github.com/NixOS/nixpkgs/commit/c607932d27f54592db0f5da51ce1c042677e2bb8) librewolf-unwrapped: 121.0-1 -> 121.0.1-1
* [`3d9d2ce4`](https://github.com/NixOS/nixpkgs/commit/3d9d2ce4a25fdb60eaf3ec580c7572a9a2d02b38) nixseparatedebuginfod: 0.3.2 -> 0.3.3
* [`083770a4`](https://github.com/NixOS/nixpkgs/commit/083770a4baf1a6fdb21aab8b2546afcd43d60c6b) brscan5: 1.2.9-0 -> 1.3.0-0
* [`6605c0da`](https://github.com/NixOS/nixpkgs/commit/6605c0dad80d6399176706cde1893179e058320e) openxray: 1144-december-2021-rc1 -> 1747-january-2023-rc3
* [`1fb2556e`](https://github.com/NixOS/nixpkgs/commit/1fb2556e994c3e549deea0330a2f72373d190a05) openxray: 1747-january-2023-rc3 -> 2088-august-2023-rc1
* [`60c8b2e2`](https://github.com/NixOS/nixpkgs/commit/60c8b2e2339e25add195e0cdcc4989f5208726bf) openxray: Enable on Darwin
* [`f853628a`](https://github.com/NixOS/nixpkgs/commit/f853628ae5569d40879d77880026935347930a4b) openxray: 2088-august-2023-rc1 -> 2188-november-2023-rc1, add passthru.updateScript
* [`47c63826`](https://github.com/NixOS/nixpkgs/commit/47c638264b9e7564853cf1998128b3b2eb63013b) openxray: Simplify wrapping
* [`61b28ab5`](https://github.com/NixOS/nixpkgs/commit/61b28ab54f41d1c6ff68a96341badfeddd9e4fe2) yubikey-manager-qt: fix build by upgrading to yubikey-manager 5 from 4
* [`672a1381`](https://github.com/NixOS/nixpkgs/commit/672a13811cc2ac096cc09734d921128cc0f497e0) stuntrally: drop freeimage
* [`362aba4b`](https://github.com/NixOS/nixpkgs/commit/362aba4b17a3e4ae04c50af4a2ae98a11d81bae6) openxray: Drop freeimage
* [`1093eb01`](https://github.com/NixOS/nixpkgs/commit/1093eb017638269a34073817863931ebc52606ae) python312Packages.strct: unbreak with upstreamed patch, properly set version
* [`15683782`](https://github.com/NixOS/nixpkgs/commit/156837824fc1d6c8d9a6e9857aab9a5b4e0cb46f) python312Packages.birch: unbreak with upstreamed patch, properly set version
* [`d7b283c3`](https://github.com/NixOS/nixpkgs/commit/d7b283c3573a6bd687c424cb48c1f84a0fd0107d) python311Packages.mkdocs-macros: 0.7.0 -> 1.0.5
* [`e635b837`](https://github.com/NixOS/nixpkgs/commit/e635b83747623b733e08b3806499e0f0880ef090) python311Packages.mmh3: 4.0.1 -> 4.1.0
* [`40cd3bcc`](https://github.com/NixOS/nixpkgs/commit/40cd3bcc06d8a9118c26ab905a7d52d672283942) lxqt.obconf-qt: 0.16.3 -> 0.16.4
* [`3e924be8`](https://github.com/NixOS/nixpkgs/commit/3e924be8a85a134df4fa5169adfb871f54473865) tmuxp: 1.29.0 -> 1.34.0
* [`21a031c3`](https://github.com/NixOS/nixpkgs/commit/21a031c3d9a3efd4fda4775271cd2a48868c6242) k0sctl: 0.17.3 -> 0.17.4
* [`4620431c`](https://github.com/NixOS/nixpkgs/commit/4620431ce5050b2657acd4bd30686c0f986b6b67) shaderc: 2022.4 -> 2023.8
* [`cac10ee0`](https://github.com/NixOS/nixpkgs/commit/cac10ee05182c5298764a4e623da0a1be8f92f55) tmuxp: add myself as co-maintainer
* [`3a2f6713`](https://github.com/NixOS/nixpkgs/commit/3a2f67135424c281f8de4ab2025119ae9f7701e9) nh: fix darwin build
* [`8111d4ca`](https://github.com/NixOS/nixpkgs/commit/8111d4ca8e5c0973bd8e4a2b9ed176b9896cc648) python3Packages.pyopengl: fix substituteInPlace
* [`f5f3a3ff`](https://github.com/NixOS/nixpkgs/commit/f5f3a3fff1c70258d3c26814e9968a518b02df4c) python311Packages.pyatem: 0.9.0 -> 0.10.0
* [`fa25fe24`](https://github.com/NixOS/nixpkgs/commit/fa25fe24b35a2f1b1e4d9828c7d6f7ef61daab54) openswitcher: 0.9.1 -> 0.10.0
* [`5e104185`](https://github.com/NixOS/nixpkgs/commit/5e104185a9fac56ece41a400f8f4bbf46fcf84db) python311Packages.mpd2: 3.1.0 -> 3.1.1
* [`06cbb08c`](https://github.com/NixOS/nixpkgs/commit/06cbb08c1fc1c84dd7c54f92afb725df3b18fa54) python311Packages.ics: refactor
* [`9ecb8b53`](https://github.com/NixOS/nixpkgs/commit/9ecb8b53f9bccd67c75d4bd36df64fc07c1ad66e) brook: 20230606 -> 20240214
* [`4c18ac61`](https://github.com/NixOS/nixpkgs/commit/4c18ac6185f383a6916a97a9b0865d3df46d6778) librealsense: unbreak on gcc13
* [`8fc50f53`](https://github.com/NixOS/nixpkgs/commit/8fc50f53a3204f494850d1253be59aa72e6ceeae) csvlens: 0.5.1 -> 0.6.0
* [`c35f2b06`](https://github.com/NixOS/nixpkgs/commit/c35f2b069fc59711f2900794c9584b68b2178db6) calcure: refactor
* [`775a326d`](https://github.com/NixOS/nixpkgs/commit/775a326df087d2dac2ca3ec0cc87438c6c3d0092) emacs-lsp-booster: 0.1.1 -> 0.2.0
* [`0bd03de4`](https://github.com/NixOS/nixpkgs/commit/0bd03de4276809c6f0b23421dd9cbe282a81df7f) zircolite: init at 2.9.9
* [`fd5b4df7`](https://github.com/NixOS/nixpkgs/commit/fd5b4df78d8fe80bc52a93af1158f55aa7da641b) pokeget-rs: 1.4.0 -> 1.4.2
* [`05a21a18`](https://github.com/NixOS/nixpkgs/commit/05a21a1870bdf0b2f6ced6ecd3b7f088e345c77a) python311Packages.python-crontab: disable failing test
* [`af146f47`](https://github.com/NixOS/nixpkgs/commit/af146f47b310b695053dd850b5dd7cf638272ade) osu-lazer-bin: 2023.113.0 -> 2023.114.0
* [`7ff48c20`](https://github.com/NixOS/nixpkgs/commit/7ff48c20eeba8944b8c2f8ce614501144ba82f6a) osu-lazer: 2024.113.0 -> 2023.114.0
* [`8e934650`](https://github.com/NixOS/nixpkgs/commit/8e934650ce9ab7b0276fb1bbf4c72d85f2ab4d92) nixos: Expose lib attribute on configuration for repl
* [`8be52599`](https://github.com/NixOS/nixpkgs/commit/8be52599b7074027d7614eab8f4eb8d29b8f72ab) nixos-rebuild: Prefer the module lib when available
* [`b73ceb1c`](https://github.com/NixOS/nixpkgs/commit/b73ceb1ca70cc108305ca7af3dda7ce3bc7b4358) flutter: Make it possible to override `operatingSystem` internally
* [`5e99fd33`](https://github.com/NixOS/nixpkgs/commit/5e99fd3304c5338df87996e42434dcf03dcc6e14) flutter: Move to a structure more fitting for multiple versions
* [`5113efa6`](https://github.com/NixOS/nixpkgs/commit/5113efa6a55be2bfe4abb257852e2157d1e7d51c) obs-studio: fix build with alsa/pulseaudio/pipewire support disabled
* [`02327600`](https://github.com/NixOS/nixpkgs/commit/02327600e33b5cecec9db6a7c4e047bfbee9640b) obs-studio: add eclairevoyant to maintainers
* [`ff67c91c`](https://github.com/NixOS/nixpkgs/commit/ff67c91cf88a721a3e9a5ddf75b74c404b8fec0f) freerdp: use latest ffmpeg
* [`dba2ca51`](https://github.com/NixOS/nixpkgs/commit/dba2ca516cdee94989272238a877b9e8edff8cad) python311Packages.oslo-context: 5.1.1 -> 5.3.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
