### PR TITLE
niv devenv: update 75dfa5e6 -> aa237a7b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "75dfa5e6c5caac2098a6d46c711e5307e4557e2c",
-        "sha256": "12a1y4ri70mbifn176j93pp53jrqj4d7b1fvzxl0iwl7yzm2k34q",
+        "rev": "aa237a7b5605b4f58714762d1f56627dfb1b3dfa",
+        "sha256": "1rmaf8iwxv8sh7j9nbzv7dcpvmmy77ks5ssfw4pncldgl7nqlgiv",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/75dfa5e6c5caac2098a6d46c711e5307e4557e2c.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/aa237a7b5605b4f58714762d1f56627dfb1b3dfa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@75dfa5e6...aa237a7b](https://github.com/cachix/devenv/compare/75dfa5e6c5caac2098a6d46c711e5307e4557e2c...aa237a7b5605b4f58714762d1f56627dfb1b3dfa)

* [`df1d649b`](https://github.com/cachix/devenv/commit/df1d649b7b7d565b3a59852af7fc9e241d8af059) Add delta support
* [`ff37923d`](https://github.com/cachix/devenv/commit/ff37923d4ba9e220b9826594e83fc29e1a4f4338) Auto generate docs/reference/options.md
* [`4a4b6388`](https://github.com/cachix/devenv/commit/4a4b63881dbd62b4e615e86cc60fffdea9e84248) Add Default for $RUBYLIB and $GEM_PATH
