### PR TITLE
niv home-manager: update 8c3b2a0c -> 2d47379a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8c3b2a0cab64a464de9e41a470eecf1318ccff57",
-        "sha256": "06axgrabvg89j3qv0kh66p9z91p3q3myq690spgqh15j6xj4j9ri",
+        "rev": "2d47379ad591bcb14ca95a90b6964b8305f6c913",
+        "sha256": "1n3fmpy33ws04fgdjaczi3z4s19aipf82dy2zfga7m3j55pj32k4",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/8c3b2a0cab64a464de9e41a470eecf1318ccff57.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/2d47379ad591bcb14ca95a90b6964b8305f6c913.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@8c3b2a0c...2d47379a](https://github.com/nix-community/home-manager/compare/8c3b2a0cab64a464de9e41a470eecf1318ccff57...2d47379ad591bcb14ca95a90b6964b8305f6c913)

* [`fa152fd7`](https://github.com/nix-community/home-manager/commit/fa152fd745b816dcfc751962f2e20c8669aed8f1) xsession: allow xplugd to restart on failure
* [`bf4b576f`](https://github.com/nix-community/home-manager/commit/bf4b576f84e1ce54ec886836bae7695738aa5a6c) firefox: restore compatibility for extraPolicies
* [`37d6eece`](https://github.com/nix-community/home-manager/commit/37d6eeceee464adc03585404eebd68765b3c8615) flake.lock: Update
* [`16cefa78`](https://github.com/nix-community/home-manager/commit/16cefa78cc801911ebd4ff1faddc6280ab3c9228) flake.lock: Update
* [`646c243e`](https://github.com/nix-community/home-manager/commit/646c243e6f8426b37e45cbd6263f607fe046808a) flake.lock: Update
* [`9fed3282`](https://github.com/nix-community/home-manager/commit/9fed3282e9d5fdc106001a20a84d4e3d8c86dd13) gradle: re-add britter as maintainer
* [`62856932`](https://github.com/nix-community/home-manager/commit/62856932af0c75c5be7a5ba23441e16a305423b3) gradle: Don't enable programs.java
* [`d9c86968`](https://github.com/nix-community/home-manager/commit/d9c869681db7171a1ffb6f88489e4a5170fd0fb5) sway: include cursor environment variables
* [`b84191db`](https://github.com/nix-community/home-manager/commit/b84191db127c16a92cbdf7f7b9969d58bb456699) gh: add github gist to default credential hosts
* [`d6185e83`](https://github.com/nix-community/home-manager/commit/d6185e83d864a4a73d5e6655ab7410c074c0657c) docs, tests: revert to fetchTarball for nmd and nmt
* [`2064348e`](https://github.com/nix-community/home-manager/commit/2064348e555b6aa963da6372a8f14e6acb80a176) hyprland: do not override existing plugins settings in config
* [`ce4b88c4`](https://github.com/nix-community/home-manager/commit/ce4b88c465d928f4f8b75d0920f1788d5b65ca94) mcfly: add mcfly-fzf integration
* [`9b378afa`](https://github.com/nix-community/home-manager/commit/9b378afae72cb07471e19aefc30e8e05ef2d7a61) hyprland: change plugins settings generation
* [`928f2528`](https://github.com/nix-community/home-manager/commit/928f2528f9ee952ba0a47bbb1ece8d93ed66e784) mise: add module
* [`0021558d`](https://github.com/nix-community/home-manager/commit/0021558dba313b6f494cd16362dcd4071f407535) mise: fix test
* [`020399c2`](https://github.com/nix-community/home-manager/commit/020399c287afa853136b8089c315e238bf4b161d) k9s: v0.29/v0.30 compatibility
* [`4af6720f`](https://github.com/nix-community/home-manager/commit/4af6720fff6cdc6188ccd4533365a202f6adeccc) k9s: fix unnecessary test dependency
* [`2d47379a`](https://github.com/nix-community/home-manager/commit/2d47379ad591bcb14ca95a90b6964b8305f6c913) flake.lock: Update
