### PR TITLE
niv nerd-icons.el: update ba03500e -> c6a4acf1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "ba03500eb5ac2dd5159b4efba9a1bd4b2ee4ef26",
-        "sha256": "1dgl7pd4zvwsjfqv1wkan2df7sl4i48398hnrjyvwdiqy5dnf4bd",
+        "rev": "c6a4acf19454b415cba1c43daf4bfca8fccdd9ba",
+        "sha256": "1pnlp54f0c2wgc65p932xyk71lyw361x17w71fnxgp72j1a3y6dz",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/ba03500eb5ac2dd5159b4efba9a1bd4b2ee4ef26.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/c6a4acf19454b415cba1c43daf4bfca8fccdd9ba.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@ba03500e...c6a4acf1](https://github.com/rainstormstudio/nerd-icons.el/compare/ba03500eb5ac2dd5159b4efba9a1bd4b2ee4ef26...c6a4acf19454b415cba1c43daf4bfca8fccdd9ba)

* [`46c51dd5`](https://github.com/rainstormstudio/nerd-icons.el/commit/46c51dd5030f672c26a29e6d3876876716b5cdbb) Only match the non-directory part of file name
* [`c6a4acf1`](https://github.com/rainstormstudio/nerd-icons.el/commit/c6a4acf19454b415cba1c43daf4bfca8fccdd9ba) Support new TeX major mode names provided by AUCTeX
