### PR TITLE
niv powerlevel10k: update cda24b72 -> ab6a863e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "cda24b72b790b0bec54a6090ab85a0f23caea8b6",
-        "sha256": "0f6ikhwda2g1arbz8fawqb996w6kfzhfzg6vlgx34qdnc1zhxgl9",
+        "rev": "ab6a863e231b1d85c89e152165719bfe826bc449",
+        "sha256": "10gjy1x1s4gcb2b5kj7xl3lixn465m6rdrzn24mi7vimk9p6kmzk",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/cda24b72b790b0bec54a6090ab85a0f23caea8b6.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/ab6a863e231b1d85c89e152165719bfe826bc449.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@cda24b72...ab6a863e](https://github.com/romkatv/powerlevel10k/compare/cda24b72b790b0bec54a6090ab85a0f23caea8b6...ab6a863e231b1d85c89e152165719bfe826bc449)

* [`9be438f8`](https://github.com/romkatv/powerlevel10k/commit/9be438f8625139d58877ef00a5d414c809608672) add foot font instructions
* [`c180a5e0`](https://github.com/romkatv/powerlevel10k/commit/c180a5e040d078eab501a71dc455a8eadc43fd44) font: fix foot instructions ([romkatv/powerlevel10k⁠#2536](https://togithub.com/romkatv/powerlevel10k/issues/2536))
* [`4d7925c9`](https://github.com/romkatv/powerlevel10k/commit/4d7925c983c923e83f3f87ab6da5a279d6a8173c) Add parsing of pyvenv.cfg
* [`30ba16ec`](https://github.com/romkatv/powerlevel10k/commit/30ba16ecd84cde5ef8b7eaef407d26f909371f3a) font: update alacritty instructions ([romkatv/powerlevel10k⁠#2539](https://togithub.com/romkatv/powerlevel10k/issues/2539))
* [`8fefef22`](https://github.com/romkatv/powerlevel10k/commit/8fefef228571c08ce8074d42304adec3b0876819) rewrite the handling of custom prompt in virtualenv ([romkatv/powerlevel10k⁠#2540](https://togithub.com/romkatv/powerlevel10k/issues/2540))
* [`ab6a863e`](https://github.com/romkatv/powerlevel10k/commit/ab6a863e231b1d85c89e152165719bfe826bc449) docs: mention truecolor
