### PR TITLE
niv nixpkgs: update 7850f146 -> a7f1a3fd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7850f146305fd5ee52edf63b4404b60b21543a44",
-        "sha256": "1ywrn8y4hlhbifzy1cqv57r7km5k2rvaj087cy4zbiyg7cdya7vz",
+        "rev": "a7f1a3fd48e21086e4f74b46dd94f68664854920",
+        "sha256": "0wmrq67npfl91zbgq4ffff8w0v4715n28f6rl9f6ap7l59y9lx5q",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7850f146305fd5ee52edf63b4404b60b21543a44.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a7f1a3fd48e21086e4f74b46dd94f68664854920.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7850f146...a7f1a3fd](https://github.com/nixos/nixpkgs/compare/7850f146305fd5ee52edf63b4404b60b21543a44...a7f1a3fd48e21086e4f74b46dd94f68664854920)

* [`91a1291d`](https://github.com/NixOS/nixpkgs/commit/91a1291d2b767aab6d14ef8fb0d38b098da3ea6e) virtualbox: add pointer to related nix options
* [`35ee9a5b`](https://github.com/NixOS/nixpkgs/commit/35ee9a5b5bebeb068e496cec7ac7c2d909b69b34) libaal: 1.0.6 -> 1.0.7
* [`4ddb5778`](https://github.com/NixOS/nixpkgs/commit/4ddb5778a35f1babf779a13adbeabc89f972d605) libbpf: add some key reverse dependencies to passthru.tests
* [`caeb16f2`](https://github.com/NixOS/nixpkgs/commit/caeb16f2c35aae64f1c63783e45f4b8392234c35) srt: 1.5.2 -> 1.5.3
* [`33c7a78c`](https://github.com/NixOS/nixpkgs/commit/33c7a78ce79f61cb08bea2f46b03e0d5a5980ed6) router: 1.19.0 -> 1.30.1
* [`2128a2f3`](https://github.com/NixOS/nixpkgs/commit/2128a2f3fd739aae1a9534afb9d16d39b587aa57) libcamera: 0.0.5 -> 0.1.0
* [`34f8c1d7`](https://github.com/NixOS/nixpkgs/commit/34f8c1d7d7b5fa452c94964577e4c9d43032ecc4) rubberband: 3.1.0 -> 3.3.0
* [`b8f8c9b4`](https://github.com/NixOS/nixpkgs/commit/b8f8c9b4139977c197fb7c1c1a7a20a90b88661f) gnupg: revert defaults to openpgp in 2.4 branch
* [`27769500`](https://github.com/NixOS/nixpkgs/commit/27769500ea5430a42187651bd26185c19f5fde2c) m17n_lib: 1.8.2 -> 1.8.4
* [`4d71fcc0`](https://github.com/NixOS/nixpkgs/commit/4d71fcc01cfc3ff783d255618fa7699ee8b001bd) maintainers: add rgri
* [`84ef5ebe`](https://github.com/NixOS/nixpkgs/commit/84ef5ebe4d6ed2abec353c2905b26f3e245dfe25) gnupg: 2.4.1 -> 2.4.3
* [`b43b2684`](https://github.com/NixOS/nixpkgs/commit/b43b2684d659f4e2bc08fc82ef0538a4e4519b93) openvdb: 10.0.1 -> 11.0.0
* [`c1b98c18`](https://github.com/NixOS/nixpkgs/commit/c1b98c1879b181df11c2d263237b64d80f6d69f3) pam: 1.5.2 -> 1.5.3
* [`543e18bd`](https://github.com/NixOS/nixpkgs/commit/543e18bdd44a9eac5dcd50dd08a5254532b50fbc) icingaweb2: 2.11.4 -> 2.12.1
* [`ee736a3d`](https://github.com/NixOS/nixpkgs/commit/ee736a3dc985e9713ab97520f552c607249859b3) gd: disable fontconfig when built without Xorg
* [`bce0bd56`](https://github.com/NixOS/nixpkgs/commit/bce0bd56e80922990dd2e322476db6c73f6547a0) Add `patches` option to `buildExtension` of `gawkextlib`
* [`93c3fc7f`](https://github.com/NixOS/nixpkgs/commit/93c3fc7fe071893bbfed553f771ae22c1676319e) gawkextlib.haru: fix compilation errors due to typos fixed in `libharu`
* [`8d8f355b`](https://github.com/NixOS/nixpkgs/commit/8d8f355ba1ef8d3313ea09e08b4c1cb3d5ec08fe) groff: Update site.tmac to fix glyph usage errors
* [`200f8bc8`](https://github.com/NixOS/nixpkgs/commit/200f8bc8527ef8e10e8e72b46d78cc2c24841bd9) sonic-pi: 4.4.0 -> 4.5.0
* [`7be9f0f5`](https://github.com/NixOS/nixpkgs/commit/7be9f0f52630eec0bd9026ff0e0e31c8116ac7b2) curl: 8.4.0 -> 8.5.0
* [`f582ed98`](https://github.com/NixOS/nixpkgs/commit/f582ed985baa49c970a0b823567263cc08e6007c) argocd-vault-plugin: fix version output
* [`5e329241`](https://github.com/NixOS/nixpkgs/commit/5e329241e8b5c25e17e3a852323890d25cd271d9) light: support brightness control keys
* [`701410a9`](https://github.com/NixOS/nixpkgs/commit/701410a98791b01678c89c56a9d4fa2e1a01e6dc) catch2_3: 3.4.0 -> 3.5.0
* [`2fecacbe`](https://github.com/NixOS/nixpkgs/commit/2fecacbe0bbd69a6f9c5ad6d07c9793ba30d67e7) libplacebo: 5.264.1 -> 6.338.1
* [`e2c74eb9`](https://github.com/NixOS/nixpkgs/commit/e2c74eb96df03c2703f377d28233180c8294913f) libplacebo_5: init at 5.264.1
* [`3fb17d29`](https://github.com/NixOS/nixpkgs/commit/3fb17d290c93c66590b4af21e433b60af1851f82) vlc: use libplacebo_5
* [`f4e7e4a1`](https://github.com/NixOS/nixpkgs/commit/f4e7e4a19bb2ec8738caf0154ca2943776fca32b) ffmpeg_5: use libplacebo_5
* [`65e157dc`](https://github.com/NixOS/nixpkgs/commit/65e157dcd628fd862f04e3642e70fa04661200dc) eiwd: 2.8-1 -> 2.10-1
* [`1b2cc0d4`](https://github.com/NixOS/nixpkgs/commit/1b2cc0d457bafc74ad0d24f8d29134f8220b4f77) maptool: 1.13.2 -> 1.14.3
* [`e5586fef`](https://github.com/NixOS/nixpkgs/commit/e5586fef75ffb7a903dc3842fa29ccaeffa67dd0) evilwm: 1.1.1 -> 1.4.2
* [`9fa27075`](https://github.com/NixOS/nixpkgs/commit/9fa270750951d8de650357b01505c9a19be12c5e) glfw3: 3.3.8 -> 3.3.9
* [`0cdaebb1`](https://github.com/NixOS/nixpkgs/commit/0cdaebb1f1abe385c4a34d4d275e6e417cc8c3c2) icingaweb2-thirdparty: 0.12.0 -> 0.12.1
* [`303cd408`](https://github.com/NixOS/nixpkgs/commit/303cd408d7ab4d026122f2f2ece5be0bea10785f) icingaweb2-ipl: 0.13.0 -> 0.13.1
* [`5c3fbf08`](https://github.com/NixOS/nixpkgs/commit/5c3fbf08f967219dfa0a0e2e31097abd06dd51e4) apacheHttpdPackages.mod_wsgi3: 4.9.4 -> 5.0.0
* [`b378acd1`](https://github.com/NixOS/nixpkgs/commit/b378acd188e31866ee5173591e7dc16b541a0b4e) kubernetes-helmPlugins.helm-s3: 0.15.1 -> 0.16.0
* [`ae8175d7`](https://github.com/NixOS/nixpkgs/commit/ae8175d702227ef0c8cdc73467ece2690f1d42f3) lidarr: 1.4.5.3639 -> 2.0.7.3849
* [`53c6ef95`](https://github.com/NixOS/nixpkgs/commit/53c6ef9577a00d3563a6c6ba7d86b6aaed823ad4) gitkraken: devendor git
* [`066e25ae`](https://github.com/NixOS/nixpkgs/commit/066e25aed02d7dee703584c8044c4b67f2d805fc) dual-function-keys: 1.4.0 -> 1.5.0
* [`63eb622f`](https://github.com/NixOS/nixpkgs/commit/63eb622f72f6c274be35a69099340c59b7e44baf) lomiri.qqc2-suru-style: init at 0.20230206
* [`cec0f714`](https://github.com/NixOS/nixpkgs/commit/cec0f714ad188a540f296b8d298fca831c6bccec) python310Packages.django-hijack: 3.4.3 -> 3.4.5
* [`9c7c6476`](https://github.com/NixOS/nixpkgs/commit/9c7c647601fde64eaba094c062944e49fa98993d) python310Packages.django-simple-captcha: 0.5.20 -> 0.6.0
* [`241be60c`](https://github.com/NixOS/nixpkgs/commit/241be60c578cb7a1e84eff512867947495e0c6d7) python310Packages.google-cloud-bigquery-storage: 2.23.0 -> 2.24.0
* [`ccd64be2`](https://github.com/NixOS/nixpkgs/commit/ccd64be2901c8b37dd1b86fc2577163116070d48) python310Packages.google-cloud-resource-manager: 1.10.4 -> 1.11.0
* [`9113d55c`](https://github.com/NixOS/nixpkgs/commit/9113d55c9e4ea82e9ee0276c68a7982f073ac319) python310Packages.google-cloud-secret-manager: 2.16.4 -> 2.17.0
* [`c9b63b03`](https://github.com/NixOS/nixpkgs/commit/c9b63b03a1e664341c354744d0001901b596398c) libcap_ng: 0.8.3 -> 0.8.4
* [`0173fad4`](https://github.com/NixOS/nixpkgs/commit/0173fad4655b078e28f46676038ace61ce50e973) python310Packages.sphinxcontrib-confluencebuilder: 2.3.0 -> 2.4.0
* [`05aa6e45`](https://github.com/NixOS/nixpkgs/commit/05aa6e455aa47779a4589621cfdf6c9edab6b48e) python310Packages.yappi: 1.4.0 -> 1.6.0
* [`06170252`](https://github.com/NixOS/nixpkgs/commit/061702528519ad56dc5f9bfacaa6c8221de4f4a5) zulu: drop version from pname
* [`d55de311`](https://github.com/NixOS/nixpkgs/commit/d55de31158557df0dbc8c51d4d53bd6394beb09a) libraw: 0.21.1 -> 0.21.2
* [`80e66e3c`](https://github.com/NixOS/nixpkgs/commit/80e66e3c448264ad1447567e0b2dae2ada94fd8c) editline: pull `autoconf-2.72` fix pending upstream inclusion
* [`7a366773`](https://github.com/NixOS/nixpkgs/commit/7a366773e0f01899e622cc06a6acad927273d913) lapack-reference: 3.11 -> 3.12.0
* [`c9c1b4aa`](https://github.com/NixOS/nixpkgs/commit/c9c1b4aa6120cb4f7d6fe184aea4ec997374fb98) buildah-unwrapped: 1.33.2 -> 1.34.0
* [`0569a928`](https://github.com/NixOS/nixpkgs/commit/0569a9280356782250fdc45e07a2601a9429a438) doxygen: 1.9.8 -> 1.10.0
* [`a6edc678`](https://github.com/NixOS/nixpkgs/commit/a6edc678200d0320b770e9273ccd32b5859e5c24) convoy: remove
* [`72b7ebcd`](https://github.com/NixOS/nixpkgs/commit/72b7ebcdfcba7bd6194385493fb41d4b7bc59c17) rapidfuzz-cpp: 2.2.3 -> 3.0.0
* [`71be5a01`](https://github.com/NixOS/nixpkgs/commit/71be5a01183b959e1f0e97e8f6474bcb2f3599b9) python311Packages.rapidfuzz: 3.5.2 -> 3.6.0
* [`42fc5919`](https://github.com/NixOS/nixpkgs/commit/42fc5919f1b4544ef0c436cd7f14ff0af0e2ae3d) python311Packages.cython_3: 3.0.6 -> 3.0.7
* [`51d29a47`](https://github.com/NixOS/nixpkgs/commit/51d29a4759a278d7d9b7edac7764b2836b4e4a6e) nixosTests.nixops: Revert "tests.nixops: fix broken eval" to fix eval
* [`69d78abd`](https://github.com/NixOS/nixpkgs/commit/69d78abdb885134bc339a89faa038dde99412f34) pre-commit: fix pygrep hooks
* [`c761b32f`](https://github.com/NixOS/nixpkgs/commit/c761b32f7791ec3281c062cc6904273cf7c81e4e) swaylock-fancy: unstable-2023-11-21 -> unstable-2023-12-22
* [`891a6348`](https://github.com/NixOS/nixpkgs/commit/891a6348766ff17e4666b43aa94a28390467340e) buildGoModule: always set `-buildid=` as ldflag
* [`77d6ba8a`](https://github.com/NixOS/nixpkgs/commit/77d6ba8a4cf5a71bca40b76de3bc071e56399eb1) treewide: remove explicit `-buildid=`
* [`65d401f0`](https://github.com/NixOS/nixpkgs/commit/65d401f0b101a294dfd36ebcffa67375546ae586) ocamlPackages.containers: 3.12 -> 3.13.1
* [`6d432900`](https://github.com/NixOS/nixpkgs/commit/6d432900e2abba9817fc0588ac072f25dc331ec2) curl: add websocket support
* [`ea00c860`](https://github.com/NixOS/nixpkgs/commit/ea00c860cfe8546e6516a587d20befbf08645ec4) python311Packages.python-memcached: 1.59 -> 1.60
* [`925a03e1`](https://github.com/NixOS/nixpkgs/commit/925a03e1b36a709788d1897e90dcac2e9002f19d) python311Packages.pymemcache: add python-memcached test dependency
* [`b5162bfa`](https://github.com/NixOS/nixpkgs/commit/b5162bfa84e012181547a8dfc0ff12b27a20aec9) parsify: init at 2.0.1
* [`20812393`](https://github.com/NixOS/nixpkgs/commit/20812393c55b8daa6c63fc74b7a4eb5cdb08faeb) vym: 2.8.42 -> 2.9.0
* [`9671dc9a`](https://github.com/NixOS/nixpkgs/commit/9671dc9aea99ff7d0991f6735dde2b14bf2846af) vym: 2.9.0 -> 2.9.22
* [`4f1186ef`](https://github.com/NixOS/nixpkgs/commit/4f1186ef15c4530cbae297161d1565b5416bf4b2) vym: 2.9.22 -> 2.9.26
* [`b96fc128`](https://github.com/NixOS/nixpkgs/commit/b96fc12835d7dbf9c1bd9275eca036e80cff6b00) sonobuoy: add mainProgram, add changelog, fix description
* [`5b9fbcd1`](https://github.com/NixOS/nixpkgs/commit/5b9fbcd1b2ea338bdf332bbcc044719f49ea9f0b) sonobuoy: add custom update script
* [`c461d39b`](https://github.com/NixOS/nixpkgs/commit/c461d39b6d8c99413b6972c236c8326955c5079a) sonobuoy: add version test
* [`680fc7ee`](https://github.com/NixOS/nixpkgs/commit/680fc7eeed766ad3da6bb2803139c68528d65e38) netsurf.buildsystem: 1.9 -> 1.10
* [`d71152a4`](https://github.com/NixOS/nixpkgs/commit/d71152a44d0b02b19eed343e4bc304dae7a4524f) python311Packages.aioftp: 0.21.4 -> 0.22.2
* [`2cbbff53`](https://github.com/NixOS/nixpkgs/commit/2cbbff53e881d106915ca9dd564758a58e66fadc) tree-sitter-grammars: add templ
* [`09bd661b`](https://github.com/NixOS/nixpkgs/commit/09bd661b59aaf7ba5034fb0f80f0b720205e8719) zxing-cpp: 2.1.0 -> 2.2.1
* [`38d5ab18`](https://github.com/NixOS/nixpkgs/commit/38d5ab182bfa51f0c5297494fc5b2ab6668b537a) rav1e: 0.6.6 -> 0.7.0
* [`8f809e46`](https://github.com/NixOS/nixpkgs/commit/8f809e4630bfb2fa80499258b45ad428f0b29c71) nixops_unstable: fix `tests` eval with `allowAliases = false;`
* [`a280d7fc`](https://github.com/NixOS/nixpkgs/commit/a280d7fcfb642ecbbb16a42f87fd5a2be5f67dd8) cglm: 0.9.1 -> 0.9.2
* [`0ff6a0bd`](https://github.com/NixOS/nixpkgs/commit/0ff6a0bdaed9f6b6fc799f429a28f25519082b12) ffmpeg_6: make patch unconditional
* [`32339b66`](https://github.com/NixOS/nixpkgs/commit/32339b669b724ccc5a64791727ff1f4819eae763) rsync: fix missing ipv6 support
* [`ad89162c`](https://github.com/NixOS/nixpkgs/commit/ad89162ccf4102386de5c1be87d1a312e08583ac) python311Packages.python-memcached: 1.60 -> 1.61
* [`50711336`](https://github.com/NixOS/nixpkgs/commit/507113361f8c34b865c692dbea76d95bb626b6aa) fontconfig: 2.14.2 → 2.15.0
* [`5ae43986`](https://github.com/NixOS/nixpkgs/commit/5ae439867ea3afb115d6eade7271f1d5c4b3d5ac) libxmlb: 0.3.14 -> 0.3.15
* [`2a0f9cff`](https://github.com/NixOS/nixpkgs/commit/2a0f9cffe9a2965f0f5a712a85c5ee33d287f4bd) libewf-legacy: init at 20140814
* [`575db938`](https://github.com/NixOS/nixpkgs/commit/575db93887dc3fed90284dc2783ad35514995e93) picosnitch: 1.0.1 -> 1.0.3
* [`3a1b8034`](https://github.com/NixOS/nixpkgs/commit/3a1b8034c4fa8917997903443de000323272269f) lvm2: 2.03.22 -> 2.03.23
* [`291aa210`](https://github.com/NixOS/nixpkgs/commit/291aa2109e5cdceeba795eafbb9df5cacb4c9ed5) regripper: init at unstable-2023-07-23
* [`1d4109b8`](https://github.com/NixOS/nixpkgs/commit/1d4109b8588e010e10ee934a5bc0d533d45afedb) ablog: 0.11.4.post1 -> 0.11.6
* [`121750d8`](https://github.com/NixOS/nixpkgs/commit/121750d851e9e759b21007e19d826ff801b8efc7) aws-c-auth: 0.7.7 -> 0.7.10
* [`adaa47a6`](https://github.com/NixOS/nixpkgs/commit/adaa47a673d5c97c0ba0896678b964fa1f651f15) zsh-fzf-tab: add update script
* [`244d0515`](https://github.com/NixOS/nixpkgs/commit/244d0515f7e3ebf7ec5407c953d98c0bcd2b6c0a) python310Packages.spglib: 2.1.0 -> 2.2.0
* [`7a5da4fc`](https://github.com/NixOS/nixpkgs/commit/7a5da4fc0bc2b627eca98d7c1653e4fc6ac82758) pixman: enable parallel building
* [`07692e0f`](https://github.com/NixOS/nixpkgs/commit/07692e0f41b300f6e779f15dca876f0fe7a7f181) rrdtool: 1.7.2 -> 1.8.0
* [`e9affccd`](https://github.com/NixOS/nixpkgs/commit/e9affccd5dc411af25206238f5b44ba4444454f7) catch2_3: 3.5.0 -> 3.5.1
* [`3434366c`](https://github.com/NixOS/nixpkgs/commit/3434366c2de58cacab57095659ec482db318f2fb) super-productivity: 7.14.3 -> 7.17.2
* [`50bfc776`](https://github.com/NixOS/nixpkgs/commit/50bfc776d4e898528d46aa98ed29bb7e10fdc4bf) nvidia-x11.legacy_390: fix bug
* [`27e46a6f`](https://github.com/NixOS/nixpkgs/commit/27e46a6f43a8c3d06e37327253d955c74a2781ed) bluez: migrate to by-name
* [`3e06702e`](https://github.com/NixOS/nixpkgs/commit/3e06702eb49238f293e6f5742f48ef5ee1aac48c) iana-etc: 20230316 -> 20231227
* [`95a4f83d`](https://github.com/NixOS/nixpkgs/commit/95a4f83dbbddbba117736d1437d707a8f4c53802) bluez: refactor
* [`af69d4ac`](https://github.com/NixOS/nixpkgs/commit/af69d4ac9603f4ad0210613fe90baa6c17e3c721) bluez: 5.70 -> 5.71
* [`0d8901c0`](https://github.com/NixOS/nixpkgs/commit/0d8901c01fff0b208100854dd81f41844a69b859) libmbim: 1.28.4 -> 1.30.0
* [`f9f1dc58`](https://github.com/NixOS/nixpkgs/commit/f9f1dc58bd729fa61ebf842ee88e32562d51989c) libqmi: 1.32.4 -> 1.34.0
* [`cdca96d5`](https://github.com/NixOS/nixpkgs/commit/cdca96d5069ba474a9b55d1b5c2d6d32b3fda661) modemmanager: 1.20.6 -> 1.22.0
* [`b5eb6663`](https://github.com/NixOS/nixpkgs/commit/b5eb6663413b8ef5914db6f8ef0060f0e63e367b) folly: split outputs to reduce closure sizes
* [`ec4de101`](https://github.com/NixOS/nixpkgs/commit/ec4de10162ba6d3d649c5b83440f4c535fd060b9) bear: fix
* [`3637fa5b`](https://github.com/NixOS/nixpkgs/commit/3637fa5b79a6b55d0bdcdda101d00411aa16f804) bear: use ninja
* [`75a177b8`](https://github.com/NixOS/nixpkgs/commit/75a177b813627615b4fb98296bacbc5ebdaaac33) bear: remove broken on darwin
* [`503f0615`](https://github.com/NixOS/nixpkgs/commit/503f06151fb868a78bbd6303720813cf260ec4e8) meson: 1.3.0 -> 1.3.1
* [`4b1990d1`](https://github.com/NixOS/nixpkgs/commit/4b1990d18f8b6689243c039300f5f908589714df) vim: 9.0.2116 -> 9.1.0004
* [`188392f1`](https://github.com/NixOS/nixpkgs/commit/188392f19e0c72924c16f3d3a8481329cf0ff099) hwdata: 0.377-2 -> 0.378
* [`125e5265`](https://github.com/NixOS/nixpkgs/commit/125e526581d9a082ec0dacaba7ce752ecdc7ba5a) firewalld: 2.0.2 -> 2.1.0
* [`a31e6aa8`](https://github.com/NixOS/nixpkgs/commit/a31e6aa8ba276e650a96fe705241dd94d9667282) firewalld-gui: 2.0.2 -> 2.1.0
* [`b4ac0c8d`](https://github.com/NixOS/nixpkgs/commit/b4ac0c8d9863b80b5fa7086c7be30a975e0ff4fa) openexr: 2.5.8 -> 2.5.10 ([nixos/nixpkgs⁠#278994](https://togithub.com/nixos/nixpkgs/issues/278994))
* [`8ad3e398`](https://github.com/NixOS/nixpkgs/commit/8ad3e398b7270d7f36814bff1b72fdefca171fc8) pixman: 0.42.2 -> 0.43.0
* [`06289384`](https://github.com/NixOS/nixpkgs/commit/06289384cf531ca2936879574746d7dcff0ace82) python311Packages.pycurl: disable failing test
* [`699fa56e`](https://github.com/NixOS/nixpkgs/commit/699fa56eb0401fb5db69299685494794bb26ebfd) python3Packages.pycryptodome: 3.19.0 -> 3.19.1
* [`ab297f4e`](https://github.com/NixOS/nixpkgs/commit/ab297f4e293046bc17d67135e8f5c361312de54f) gtk-pipe-viewer: 0.4.8 -> 0.4.9
* [`9cb36140`](https://github.com/NixOS/nixpkgs/commit/9cb36140078d3f461bcc8267d10f8a4a3d9d85b8) gcc: prevent runtime references via __FILE__ but in a reversible manner
* [`b0c8d214`](https://github.com/NixOS/nixpkgs/commit/b0c8d214bb3cb9211e0ee7e26007dcb9cb893d11) python311Packages.pyrfc3339: rename from pyRFC3339
* [`942aa613`](https://github.com/NixOS/nixpkgs/commit/942aa6132784ebac3b55557dbd34541f7f7d5ec1) miniserve: 0.24.0 -> 0.25.0
* [`c09e1828`](https://github.com/NixOS/nixpkgs/commit/c09e1828a4a6a4b43bed6ae3a3b3444df0e69f1c) python311Packages.python-openzwave: rename from python_openzwave
* [`bfb2d0df`](https://github.com/NixOS/nixpkgs/commit/bfb2d0dfae7559542b99615e261b01eb6f85fa96) inetutils: 2.4 -> 2.5
* [`7f0d206f`](https://github.com/NixOS/nixpkgs/commit/7f0d206fceced603292e4a19d5a68386f6232121) parabolic: init at 2023.12.0
* [`3f4ed156`](https://github.com/NixOS/nixpkgs/commit/3f4ed1565b0fead4feaee6795aa60e78847cd1ed) gperftools: Add runtime perl dependency
* [`751a9553`](https://github.com/NixOS/nixpkgs/commit/751a9553243b4220c74894fe9cd867be5cf07103) imagemagick: 7.1.1-25 -> 7.1.1-26
* [`a219e438`](https://github.com/NixOS/nixpkgs/commit/a219e438d0d8cfed390fd9ff7b58c2130f0af09b) davinci-resolve: add street to fix build
* [`8372a1ab`](https://github.com/NixOS/nixpkgs/commit/8372a1ab4ffb8f62057534d1b5e33bd992e6ad30) vmware-horizon-client: 2306 -> 2309.1
* [`ff55b5d7`](https://github.com/NixOS/nixpkgs/commit/ff55b5d7e194f0cbd4c7200202934ffd4069e420) Update pkgs/development/libraries/libewf-legacy/default.nix
* [`18436b65`](https://github.com/NixOS/nixpkgs/commit/18436b6546500412fa03ec2e5aa3fecdcf7fa3a0) python311Packages.pikepdf: 8.9.0 -> 8.11.2
* [`cdd62b2f`](https://github.com/NixOS/nixpkgs/commit/cdd62b2f565ecbfc75237052c998421a01fd0fe7) python311Packages.ocrmypdf: 15.4.4 -> 16.0.4
* [`ca6da7a5`](https://github.com/NixOS/nixpkgs/commit/ca6da7a5571b77ac6e823f5fb90a87d91ea0610f) vim: delete commented code
* [`1332fa0d`](https://github.com/NixOS/nixpkgs/commit/1332fa0d74e3b403d8540640cb185203e5994ec4) go: 1.21.5 -> 1.21.6
* [`e05a981d`](https://github.com/NixOS/nixpkgs/commit/e05a981d057a66b0e5885ac496039ebd4d6ca70d) xxd: reduce closure size by splitting it into it's own output
* [`f683663d`](https://github.com/NixOS/nixpkgs/commit/f683663dd2c637593f0799ce4052e5a3ff413aa1) gocode: remove
* [`ff4dd0e5`](https://github.com/NixOS/nixpkgs/commit/ff4dd0e56292a45b34217b2f9a27d50e1d3ec5e1) vimPlugins.vim-go: remove gocode from binPath
* [`ec45311a`](https://github.com/NixOS/nixpkgs/commit/ec45311ab3edbca26848311dd8ddab5bf477c1ea) ycmd: remove gocode support
* [`adaab58a`](https://github.com/NixOS/nixpkgs/commit/adaab58ad0dcbdc1a31834c3255d7a692bdd9b54) vimPlugins.vim-go: add revive, cleanup todos
* [`df5728a4`](https://github.com/NixOS/nixpkgs/commit/df5728a4f4f5a365be96075a698d2b7013ee725f) nixos/filesystems: init sshfs
* [`8967ac72`](https://github.com/NixOS/nixpkgs/commit/8967ac726c70f1f04f56866cbe646df4cbf18d33) nixos/manual: update sshfs section
* [`78b38b91`](https://github.com/NixOS/nixpkgs/commit/78b38b91af1cf04064e180e8bc9beb10bd1f9fb4) bngblaster: 0.8.29 -> 0.8.34
* [`eac6fcaf`](https://github.com/NixOS/nixpkgs/commit/eac6fcaf257195f8e493ae7336fd15ade81397c9) gdcm: 3.0.22 -> 3.0.23
* [`803ba527`](https://github.com/NixOS/nixpkgs/commit/803ba5276526950f47a520323dd958aebf2b9d8a) libunwind: 1.6.2 -> 1.7.2
* [`402663dc`](https://github.com/NixOS/nixpkgs/commit/402663dc19c3961bf52063bb720c58087b567675) factorio: 1.1.100 -> 1.1.101
* [`221464d5`](https://github.com/NixOS/nixpkgs/commit/221464d5df7e0f5af986f4b873aed9fa2e886b10) python311Packages.jinja2: 3.1.2 -> 3.1.3
* [`0c56aff1`](https://github.com/NixOS/nixpkgs/commit/0c56aff1f27dd769f38866ebdcb7b7e0ee002eb3) python311Packages.jinja2: refactor
* [`5bd22370`](https://github.com/NixOS/nixpkgs/commit/5bd22370b9a3d55103fe2656522fbef4440f8e02) Reapply "python311Packages.sphinxcontrib-apidoc: don't propagate pbr"
* [`a0b4b85b`](https://github.com/NixOS/nixpkgs/commit/a0b4b85bfaf02e20837f23d2f9bc294101344583) llvm: Avoid cross compiling if the build platform can execute host binaries
* [`1e8bba4d`](https://github.com/NixOS/nixpkgs/commit/1e8bba4d5dadc087a8d53f131af2bb2505e663d8) libjxl: build with openexr 3 ([nixos/nixpkgs⁠#279947](https://togithub.com/nixos/nixpkgs/issues/279947))
* [`556394de`](https://github.com/NixOS/nixpkgs/commit/556394dec06937cae8d2440fd4b4188e8fcac021) mpg123: 1.32.3 -> 1.32.4
* [`98237a67`](https://github.com/NixOS/nixpkgs/commit/98237a67c733e5ed513d891907dd38b7e23c031f) mupdf-headless: init at 1.23.6
* [`20c11b36`](https://github.com/NixOS/nixpkgs/commit/20c11b364d4e6318ae58a5522e099f8c08f205fa) python311Packages.pikepdf: use mupdf-headless
* [`e062c9d9`](https://github.com/NixOS/nixpkgs/commit/e062c9d93c04f9734310b0e6b6abd05ecd40ffa6) python311Packages.img2pdf: use mupdf-headless
* [`674a5019`](https://github.com/NixOS/nixpkgs/commit/674a5019a494cf67c615ad250b0209ba15013375) desktopToDarwinBundle: use imagemagick_light
* [`e3613515`](https://github.com/NixOS/nixpkgs/commit/e3613515f13e680a7258c792b1bdb3ee9d6a5b30) mesa: 23.3.2 -> 23.3.3
* [`736b52dc`](https://github.com/NixOS/nixpkgs/commit/736b52dcc6211aab07f0ac807b7d3ab571e81775) quark-engine: 23.9.1 -> 23.12.1
* [`ba653c4d`](https://github.com/NixOS/nixpkgs/commit/ba653c4def9fc5851c9f85808052e2051463cc0b) libzip: backport patch for pkgconfig file
* [`a04b6ba9`](https://github.com/NixOS/nixpkgs/commit/a04b6ba924b3160457caf24021c58cf011795844) python310Packages.matplotlib: cleanup duplicate MPLSETUPCFG content
* [`0d9a06c9`](https://github.com/NixOS/nixpkgs/commit/0d9a06c96eec03d1ec02be02409636ade1f0fa14) python310Packages.matplotlib: remove oldest-supported-numpy
* [`e68cf14d`](https://github.com/NixOS/nixpkgs/commit/e68cf14d27fbebf87656762c02ab980b19d7796b) python310Packages.matplotlib: enable_lto explicitly
* [`eba8931d`](https://github.com/NixOS/nixpkgs/commit/eba8931d4c2cbe5b87c457a9e41eae8940ba62ee) python310Packages.matplotlib: comments fixes
* [`da0100be`](https://github.com/NixOS/nixpkgs/commit/da0100beaf6885dc0d68712927cbe18d818381c2) dbus: enable debug info
* [`d178ca8b`](https://github.com/NixOS/nixpkgs/commit/d178ca8b13ebc6bd971133c4df495d73a8cfe63a) libxslt: enable parallel building
* [`40a1952c`](https://github.com/NixOS/nixpkgs/commit/40a1952c78db2480b43b0c92482d16b8bc235c3e) rover: 0.14.0 -> 0.22.0
* [`08e61ec0`](https://github.com/NixOS/nixpkgs/commit/08e61ec0c320c10ede227766e4a3dc0fdcef7517) redis: 7.2.3 -> 7.2.4
* [`3ecaad0e`](https://github.com/NixOS/nixpkgs/commit/3ecaad0e0e9670eda92fa17ddb96f23fcd4159a7) nixos/networking/keepalived: do not emit `unicastPeers` when there are none
* [`fea57dc5`](https://github.com/NixOS/nixpkgs/commit/fea57dc5b57285d33918813d2f3695024d8fc9e8) nodejs_20: 20.10.0 -> 20.11.0
* [`18245979`](https://github.com/NixOS/nixpkgs/commit/182459799640e0ac73d2d98eceb779c585ad3192) pipewire: 1.0.0 -> 1.0.1
* [`eaba29aa`](https://github.com/NixOS/nixpkgs/commit/eaba29aaffb2dc063f90e418344f0fd0e35babc6) remove: rtthost
* [`b581ad2c`](https://github.com/NixOS/nixpkgs/commit/b581ad2cf1830772356b549f00886be4a42517c6) steamPackages.steam-runtime: 0.20220601.1 -> 0.20231127.68515
* [`c2cf4f3d`](https://github.com/NixOS/nixpkgs/commit/c2cf4f3d9e2889e5c3735914478ff73d178c73c0) rav1e: 0.7.0 -> 0.7.1
* [`2ec46240`](https://github.com/NixOS/nixpkgs/commit/2ec46240ae10398d789e163d4745e6d6d4a99398) llvmPackages_{15,16,17,git}.libcxx: fix darwin link flags ([nixos/nixpkgs⁠#278945](https://togithub.com/nixos/nixpkgs/issues/278945))
* [`6362ce27`](https://github.com/NixOS/nixpkgs/commit/6362ce27a81b9845c748ee8305979d8c50769e7e) mercurial: 6.6.1 -> 6.6.2
* [`8a5f6594`](https://github.com/NixOS/nixpkgs/commit/8a5f6594daa32af3686d13eb2efa5092598f9bbe) linux_latest: optionally build Linux 6.7 and onwards with rust support
* [`5fca7fea`](https://github.com/NixOS/nixpkgs/commit/5fca7feab9b1811348b6bb86fc0bbfa86a3acfea) rust-out-of-tree-module: init
* [`d1f33201`](https://github.com/NixOS/nixpkgs/commit/d1f33201effb2ce5b09e86bc15f787b909d40f99) nixos/tests/kernel-rust: init
* [`ec2016dd`](https://github.com/NixOS/nixpkgs/commit/ec2016dda402ded1261d2af0e29d02506b191eab) doc: explain how to enable Rust support in the Linux kernel
* [`f19268c4`](https://github.com/NixOS/nixpkgs/commit/f19268c4063d233bc837eb1ebce792dafdb91c2a) default-gcc-version: 12 -> 13 if !stdenv.isDarwin
* [`b384f046`](https://github.com/NixOS/nixpkgs/commit/b384f04673bf7c75ba628855d7b6c773e6d08024) gcc13: add patch for PR110280
* [`810cef75`](https://github.com/NixOS/nixpkgs/commit/810cef75ba11c147c99f72e6db6d2df90ad8f50d) llvmPackages_*.clangUseLLVM: add libunwind to lib search path
* [`d077cd86`](https://github.com/NixOS/nixpkgs/commit/d077cd8691af1957438a908e61ae271371c4d334) nixos/auto-upgrade: add system.autoUpgrade.fixedRandomDelay
* [`8ed53ddb`](https://github.com/NixOS/nixpkgs/commit/8ed53ddbb5b001f0a96d11ace1f3ef4ddc8d0bc9) ruby.rubygems: 3.5.3 -> 3.5.4
* [`ac174621`](https://github.com/NixOS/nixpkgs/commit/ac17462172cf2e1b3a1086903e16c03fccfdd60b) bundler: 2.5.3 -> 2.5.4
* [`2f66478f`](https://github.com/NixOS/nixpkgs/commit/2f66478faa833e951e377bb31ec2657944f00260) enchant: fix build with `strictDeps = true;`
* [`5dfb542d`](https://github.com/NixOS/nixpkgs/commit/5dfb542d0bb1eaf998ae84745c367b26ebe7cf5e) python311Packages.aioquic: 0.9.23 -> 0.9.25
* [`41cbdb1d`](https://github.com/NixOS/nixpkgs/commit/41cbdb1d705d1f3ca7da26f89d97cde3b1891e88) python311Packages.ansible: 9.0.1 -> 9.1.0
* [`4143d9ab`](https://github.com/NixOS/nixpkgs/commit/4143d9ab9bc6158257998e3c2936d1bc35c9db49) kde/frameworks: 5.113 -> 5.114
* [`ee851aa3`](https://github.com/NixOS/nixpkgs/commit/ee851aa31300dc98ca382aa9992e3098d850553d) python311Packages.azure-data-tables: 12.4.4 -> 12.5.0
* [`812b2931`](https://github.com/NixOS/nixpkgs/commit/812b29310bfdaa3d45e38a76a9fdb286431d2696) python3Packages.uamqp: add patch for CVE-2024-21646
* [`459e2889`](https://github.com/NixOS/nixpkgs/commit/459e2889615da6fc03b9869b611bfd4777cae28e) bear: disable tests
* [`c806c71c`](https://github.com/NixOS/nixpkgs/commit/c806c71ce050e29b5271b7734b0ebb0cda783f72) maturin: 1.3.0 -> 1.4.0
* [`63973dee`](https://github.com/NixOS/nixpkgs/commit/63973dee0a2fb79f68b53b2bdb4781a64f1b1b24) autoconf271, autoreconfHook271: hold back a version
* [`24f0289b`](https://github.com/NixOS/nixpkgs/commit/24f0289b18ed4e0b32b3e55ddbcf87d93692f278) python3Packages.awslambdaric: pin to `autoconf-2.71`
* [`7684034c`](https://github.com/NixOS/nixpkgs/commit/7684034cd99d49da0dbb90853c1c5df6f4a94aa8) firebird: pin to `autoconf-2.71`
* [`62abc91b`](https://github.com/NixOS/nixpkgs/commit/62abc91b9fa2bd651bb7bb0a7f7fecb9285130c0) autoconf: 2.71 -> 2.72
* [`bf6e2538`](https://github.com/NixOS/nixpkgs/commit/bf6e25382e5ecb9ba8732b062cc4fac8c7c4e8e6) python311Packages.pythran: 0.14.0 -> 0.15.0
* [`a786eee2`](https://github.com/NixOS/nixpkgs/commit/a786eee28474f306e9b0eb883f5631c187c7be0c) docker-machine-xhyve: remove
* [`936d081c`](https://github.com/NixOS/nixpkgs/commit/936d081c365ee30f1ed05a0645dae95d93719a97) docker-machine-kvm: remove
* [`0f5e83d4`](https://github.com/NixOS/nixpkgs/commit/0f5e83d4bb3257a19a28d3d3a3679ddfc2445af6) docker-machine: remove
* [`45091702`](https://github.com/NixOS/nixpkgs/commit/450917023fcd4a3009a91928753e74455d2413a8) go-musicfox: unpin go
* [`d8f54aa7`](https://github.com/NixOS/nixpkgs/commit/d8f54aa74aad9c708f579432a654aa520bae1900) k0sctl: unpin go
* [`93e09497`](https://github.com/NixOS/nixpkgs/commit/93e09497c4c87744e3f8c8790255407f81620e40) kubectl-klock: unpin go
* [`241b1e43`](https://github.com/NixOS/nixpkgs/commit/241b1e43e5eafc2bcfe07f46e84a47d6f3d83a97) timoni: unpin go
* [`c175894f`](https://github.com/NixOS/nixpkgs/commit/c175894f919714de8d4c3a3ac3d4a7dd103356e0) ktailctl: unpin go
* [`be71ae17`](https://github.com/NixOS/nixpkgs/commit/be71ae176e3538f626d065356e091454934ba84e) static-server: unpin go
* [`a5297dd3`](https://github.com/NixOS/nixpkgs/commit/a5297dd348f31e4434ebe3dc42e9492a95ea992f) uplosi: unpin go
* [`3779a7cc`](https://github.com/NixOS/nixpkgs/commit/3779a7cc0b938771e2dddaa2a8c1beb92de84290) zitadel: unpin go
* [`26603733`](https://github.com/NixOS/nixpkgs/commit/266037332c067bf3f44b81b8aeebe19d8525735f) risor: unpin go
* [`9d75411f`](https://github.com/NixOS/nixpkgs/commit/9d75411f78f61defe79ed669837696167a848fed) turso-cli: unpin go
* [`72de1442`](https://github.com/NixOS/nixpkgs/commit/72de14424083c43309bb54412896c2e3826e6428) juicity: unpin go
* [`1e65beb2`](https://github.com/NixOS/nixpkgs/commit/1e65beb2ab59e8318b25cdbb7b4b69b7852c4756) netdata-go-plugins: unpin go
* [`b879f328`](https://github.com/NixOS/nixpkgs/commit/b879f328b02e7d4fdcc7a6049e0750e74299639f) python311Packages.cron-descriptor: 1.2.35 -> 1.4
* [`e31a2f99`](https://github.com/NixOS/nixpkgs/commit/e31a2f99a604bbafd57877f427c2124937aa7795) python311Packages.fontparts: 0.11.0 -> 0.12.1
* [`d8ea99bd`](https://github.com/NixOS/nixpkgs/commit/d8ea99bd3572eda27b040c966dea7bce78766873) python311Packages.fuse: 1.0.5 -> 1.0.7
* [`386ec18e`](https://github.com/NixOS/nixpkgs/commit/386ec18e63042e4740dfa39bb57cfaee4d08585a) python311Packages.glean-parser: 10.0.3 -> 11.0.1
* [`a8a4e0e8`](https://github.com/NixOS/nixpkgs/commit/a8a4e0e83b48a1d93ce35c36362c6eced77d3dca) mpc-qt: reformat
* [`95f0a9ed`](https://github.com/NixOS/nixpkgs/commit/95f0a9ed4c5a7cb4581c9efa16a5097be72b212b) mpc-qt: add update script
* [`d024c5ca`](https://github.com/NixOS/nixpkgs/commit/d024c5ca0cb495c5a92d610c298677130629a984) code-server: remove unused playwright patch
* [`02bac9a1`](https://github.com/NixOS/nixpkgs/commit/02bac9a1a5d6742aa3d12174d8976d0b9d50bc6e) lxc: remove unreferenced db2x patch
* [`ac7903b5`](https://github.com/NixOS/nixpkgs/commit/ac7903b5c4c9356f05d61812aec838c065ab9b3e) ghc: remove unreferenced patches
* [`1db64f27`](https://github.com/NixOS/nixpkgs/commit/1db64f27b41e695392cf0cee375d7491a2c4fcc7) llvm: remove unreferenced patch
* [`8369a349`](https://github.com/NixOS/nixpkgs/commit/8369a3495d8bb2d9081dbb45fc1f1dcacd2e7cee) nitrokey-app2: 2.1.4 -> 2.1.5
* [`4edb91cc`](https://github.com/NixOS/nixpkgs/commit/4edb91cc2f59fa4795de48d47ef4f1c3f2951d7b) python3Packages.fonttools: remove interpolatable feature from tests
* [`15fe8361`](https://github.com/NixOS/nixpkgs/commit/15fe8361be36665b4e96e6df56567fe1f3f9d889) lttng-ust: 2.13.6 -> 2.13.7
* [`e07a2fab`](https://github.com/NixOS/nixpkgs/commit/e07a2fab7f065c3fa084027f07dcf8cafbd19394) stdenv: substituteStream: deprecate --replace in favor of --replace-{fail,warn,quiet}
* [`4c1b74ba`](https://github.com/NixOS/nixpkgs/commit/4c1b74bac7712f825e7682d39e8f010bbc50cd08) stdenv: substituteStream: escape echoed pattern in --replace mismatch warning
* [`4fef23e1`](https://github.com/NixOS/nixpkgs/commit/4fef23e1dc60341fda7799c5b6385eab08bd50d6) lune: 0.7.11 -> 0.8.0
* [`5cd9b0a6`](https://github.com/NixOS/nixpkgs/commit/5cd9b0a6ba85d41061779de6b11d0d079cda0804) redis: fix oom-score-adj test due to no permission
* [`3327390e`](https://github.com/NixOS/nixpkgs/commit/3327390efee9dee3b016ecabb0cb26dc52c8f59f) python311Packages.pytest-django: drop pytest-xdist
* [`ea74836d`](https://github.com/NixOS/nixpkgs/commit/ea74836d9a54861661f635431fee7f2c5a02243e) haredo: wrap program with a shell
* [`684e0d4b`](https://github.com/NixOS/nixpkgs/commit/684e0d4b773c296175ae444181eea00e81cc82bb) bufisk: init at 0.1.0
* [`fbc0c3ec`](https://github.com/NixOS/nixpkgs/commit/fbc0c3ec691206f7cb562e78f30cefb8eaebb163) btrfs-assistant: 1.8 -> 1.9
* [`ffe149b1`](https://github.com/NixOS/nixpkgs/commit/ffe149b1c41b1f3b75114fd0184674a38988489c) buildRubyGem: only use major minor in name ([nixos/nixpkgs⁠#229469](https://togithub.com/nixos/nixpkgs/issues/229469))
* [`2fbe2ecb`](https://github.com/NixOS/nixpkgs/commit/2fbe2ecb99900d01d6ae71004a6e14d36799ef4e) python311Packages.pyqtwebengine: 5.15.4 -> 5.15.6
* [`9de711cf`](https://github.com/NixOS/nixpkgs/commit/9de711cf62e9a5093b414cbbaca36747ce6f937a) makeFontsConf: add impureFontDirectories argument
* [`0a599528`](https://github.com/NixOS/nixpkgs/commit/0a599528c7d9f92f2803c105b1fa5ac06af235d8) pam: re-enable `pam_lastlog` module
* [`79ca6f5e`](https://github.com/NixOS/nixpkgs/commit/79ca6f5e306a80cbbb98cc8a2e0a057fa068c697) linuxPackages.rtl88x2bu: unstable-2023-09-24 -> unstable-2023-11-29
* [`9adf8388`](https://github.com/NixOS/nixpkgs/commit/9adf8388ba470a32f4991c99992cb274474ff7bd) qdirstat: 1.8.1 -> 1.9
* [`74385d58`](https://github.com/NixOS/nixpkgs/commit/74385d58d557f4ce8ece3ba1be870ed947e46fe2) libdrm: 2.4.119 -> 2.4.120
* [`1f3bcdf2`](https://github.com/NixOS/nixpkgs/commit/1f3bcdf27686e9d2c43a53cf3ba7cd0ee7978ff5) mysql-workbench: fix build, small refactor
* [`fdc78417`](https://github.com/NixOS/nixpkgs/commit/fdc784172978c251bdd6f600d9e2ebd585844249) python3Packages.sip: 6.8.0 -> 6.8.1
* [`c4be1f71`](https://github.com/NixOS/nixpkgs/commit/c4be1f71a512cbb4bd68ef8da99025023048f6d3) neovim-unwrapped: use finalAttrs
* [`cbb7b09b`](https://github.com/NixOS/nixpkgs/commit/cbb7b09bad82e5a7b8a1dce70948652da05276fc) neovim-unwrapped: enable structuredAttrs
* [`1291a81e`](https://github.com/NixOS/nixpkgs/commit/1291a81e4cfb1e511e58e7a978d42499a68a5edb) upscayl: 2.9.5 -> 2.9.8
* [`1de7b377`](https://github.com/NixOS/nixpkgs/commit/1de7b377f411b920b22f050b28ab67d0203b82c4) rl-2405: change note for bcachefs to be 'linuxPackages_latest'
* [`919c0546`](https://github.com/NixOS/nixpkgs/commit/919c05460b6711f5d8beb6c1e2fff91b0b831a56) nixos/stage-1.init.sh: fix IFS comment grammar
* [`d86395db`](https://github.com/NixOS/nixpkgs/commit/d86395db78fccd6c0d047ac987e05c3a9de2dcf7) nixos/stage-1.init.sh: only set 'IFS' in 'waitDevice' for bcachefs
* [`9dfa878a`](https://github.com/NixOS/nixpkgs/commit/9dfa878a20648152ef7851d3bf863a54fb52ffdd) nixos/bcachefs: clarify 'FIXME' comment on when to remove
* [`37615c68`](https://github.com/NixOS/nixpkgs/commit/37615c68b436106e27ea6f91242c39ec0f8d0082) kernel/common-config: add note on when to remove conditional and make default yes for bcachefs
* [`b1ce631c`](https://github.com/NixOS/nixpkgs/commit/b1ce631c29da99e29d4959b8e7e3e83ad91ef2e6) aliases: change 'linux(Packages)_testing_bcachefs' notes to use 'linux(Packages)_latest' or any kernel version at least 6.7
* [`6b8dc42e`](https://github.com/NixOS/nixpkgs/commit/6b8dc42ee1218515c17a8527e659368e58e7da39) bcachefs-tools: fixup for version 1.4.1
* [`c3316bcc`](https://github.com/NixOS/nixpkgs/commit/c3316bcce4ba7ead40a04b2c7aa9c6aeb33c4a03) nixos/bcachefs: add 'bcachefs-tools' to (udev/systemd).packages
* [`5a06c7fc`](https://github.com/NixOS/nixpkgs/commit/5a06c7fc22d66e3ba031ab42f1dae04a418f6cda) bcachefs-tools: add comment on when to enable build tests
* [`7abc6d26`](https://github.com/NixOS/nixpkgs/commit/7abc6d260be68d9e55b085a53138dfdceedc417a) nixos/doc: add missing anchor for Linux Rust
* [`1a9b407e`](https://github.com/NixOS/nixpkgs/commit/1a9b407e593cddb112ba772578dfc2298c8a4983) gnutls: 3.8.2 -> 3.8.3
* [`874c9183`](https://github.com/NixOS/nixpkgs/commit/874c91834c0be39e7e9dbb366d2a1d309a4f928c) linux: drop redundant bcachefs option hint
* [`ee701295`](https://github.com/NixOS/nixpkgs/commit/ee7012951002d6570e34e792497b29e40d75aba3) qt5, qt6: use versioned QML import paths in wrappers
* [`27f6a9ac`](https://github.com/NixOS/nixpkgs/commit/27f6a9ac7b99e9ed7c39da049d3ce1898346552f)  limesurvey: 6.1.2+230606 → 6.4.1+240108
* [`aa107844`](https://github.com/NixOS/nixpkgs/commit/aa1078442af22fde4aa70c72e97b09f78f878f04) readline: 8.2p7 -> 8.2p10
* [`b7420a77`](https://github.com/NixOS/nixpkgs/commit/b7420a771c4675a46f07b1333c04052a8068982a) qrencode: move test into passthru
* [`329de0f5`](https://github.com/NixOS/nixpkgs/commit/329de0f51e692cb6b226faad96915f1a7e071f2e) systemd: remove unused bindings
* [`748378a3`](https://github.com/NixOS/nixpkgs/commit/748378a3ec83bf64d130c4744d9fdbe3065f89bb) systemd: 254.6 -> 255.2
* [`8adacdd8`](https://github.com/NixOS/nixpkgs/commit/8adacdd880b32b3e0aa09e483b442b1a8227c521) kotatogram-desktop: fix tg_owt
* [`f8a0d67b`](https://github.com/NixOS/nixpkgs/commit/f8a0d67b2e579cc2bca9c968ebf3f26b8432f1ca) mpich: put pmix in build inputs.
* [`a20f3db9`](https://github.com/NixOS/nixpkgs/commit/a20f3db99526f44703fdf22518db0a524f5e0aea) slurm: fix to be able to work with pmix split outputs
* [`0a593340`](https://github.com/NixOS/nixpkgs/commit/0a5933400ea215833ef7e2564610b42e21ebfeb6) vulkan-volk: init at 1.3.275.0
* [`2a8f51fa`](https://github.com/NixOS/nixpkgs/commit/2a8f51face14173e235e097dfcc597825fc47218) glslang: 13.1.1 -> 14.0.0
* [`0dec9ac7`](https://github.com/NixOS/nixpkgs/commit/0dec9ac7772bb700af880f978c861bb967aa45f7) vulkan-headers: 1.3.268.0 -> 1.3.275.0
* [`ca785c26`](https://github.com/NixOS/nixpkgs/commit/ca785c26a93a5f071de28dfc74cac7c58b55d9f4) vulkan-loader: 1.3.268.0 -> 1.3.275.0
* [`7e0afaf5`](https://github.com/NixOS/nixpkgs/commit/7e0afaf597cdee90539014fdd27b7e4ac207fd4f) vulkan-validation-layers: 1.3.268.0 -> 1.3.275.0
* [`9346cae3`](https://github.com/NixOS/nixpkgs/commit/9346cae320191f052632f55f3fbdad965fa0c776) vulkan-tools: 1.3.268.0 -> 1.3.275.0
* [`0afd1dcf`](https://github.com/NixOS/nixpkgs/commit/0afd1dcf3e3ac1903d87634d80dc55f7b5f3de0c) vulkan-tools-lunarg: 1.3.268.0 -> 1.3.275.0
* [`5cb62285`](https://github.com/NixOS/nixpkgs/commit/5cb62285ca985e346740d7e5f2982d13b650a919) vulkan-extension-layer: 1.3.268.0 -> 1.3.275.0
* [`8023641f`](https://github.com/NixOS/nixpkgs/commit/8023641f15d1f1f739ffdfb7fa8fb66083ba628a) vulkan-utility-libraries: 1.3.268 -> 1.3.275.0
* [`b52d8522`](https://github.com/NixOS/nixpkgs/commit/b52d8522e53dd887e438f4d11bab610b0fbbc597) spirv-headers: 1.3.268.0 -> 1.3.275.0
* [`77037208`](https://github.com/NixOS/nixpkgs/commit/77037208859cbf320db3c72663d52695fe68c4c0) spirv-cross: 1.3.268.0 -> 1.3.275.0
* [`3eb5040f`](https://github.com/NixOS/nixpkgs/commit/3eb5040f0c7cfbdde36c04b3f807464e584f9967) spirv-tools: 1.3.268.0 -> 1.3.275.0
* [`94c2b6ca`](https://github.com/NixOS/nixpkgs/commit/94c2b6ca2fac598280271eb820d7e8935f4c0471) pacparser: 1.4.2 -> 1.4.3
* [`3590918e`](https://github.com/NixOS/nixpkgs/commit/3590918e9dee826e0592713859317dbbaf3fc7aa) sqlite-web: 0.3.6 -> 0.6.2
* [`4eda1f36`](https://github.com/NixOS/nixpkgs/commit/4eda1f36ba554f1d7b8609ab864ae35c979c3f98) ephemeralpg: update homepage
* [`e71a91d8`](https://github.com/NixOS/nixpkgs/commit/e71a91d8f35d17b710eef937cec6a3fe80c0e84f) maintainers: add medv
* [`1cf2d735`](https://github.com/NixOS/nixpkgs/commit/1cf2d7357c61b9c9ca5c92cb0e810571edee948a) gcc: fix c++ headers when same triplet cross compiling
* [`0c3d9f28`](https://github.com/NixOS/nixpkgs/commit/0c3d9f28c6220e97db0e741d554d7754e524b549) cc-wrapper: drop no-longer-necessary hack
* [`74231793`](https://github.com/NixOS/nixpkgs/commit/742317931e285035ffa43ba97de15949935f494c) lunar-client: cleaner packaging
* [`bc809761`](https://github.com/NixOS/nixpkgs/commit/bc809761f5d071de2a1364ac80631e3612021b03) lunar-client: 3.1.3 -> 3.2.1
* [`a97b743a`](https://github.com/NixOS/nixpkgs/commit/a97b743aac86453a01973bee7803af2e0ab661fc) fcitx5: 5.1.6 -> 5.1.7
* [`18ee07b0`](https://github.com/NixOS/nixpkgs/commit/18ee07b0ec1af1049c501135f6bae99f12be15c8) fcitx5-table-extra: 5.1.2 -> 5.1.3
* [`c56d3c66`](https://github.com/NixOS/nixpkgs/commit/c56d3c66fab1b3679601f076fa3a565a9ddad496) zsh-fzf-tab: sha256 to hash
* [`1e681535`](https://github.com/NixOS/nixpkgs/commit/1e681535010d89a9403306db2b117f7a2a47e518) mysql-shell: 8.0.35 -> 8.0.36
* [`59678658`](https://github.com/NixOS/nixpkgs/commit/59678658fa5a52990195880691a96c588c9be5d4) libime: 1.1.4 -> 1.1.5
* [`72a63781`](https://github.com/NixOS/nixpkgs/commit/72a63781f6e7d36022392a6d19a635f1315199c3) legit: 1.2.0 -> 1.2.0.post0
* [`14cf28cc`](https://github.com/NixOS/nixpkgs/commit/14cf28ccece3fcefcef51eabd3fac2974fd3ac38) cloudsmith-cli: 0.35.2 -> 1.1.1
* [`2d19c6e5`](https://github.com/NixOS/nixpkgs/commit/2d19c6e5d819bd6745acb49d39011ea3e85505bb) lune: add SystemConfiguration for Darwin
* [`94ea67ce`](https://github.com/NixOS/nixpkgs/commit/94ea67cef0739f5b409a6433f9965993b86a2aa9) k9s: 0.31.5 -> 0.31.6
* [`86963556`](https://github.com/NixOS/nixpkgs/commit/869635565236eee11380a508e1ada53d541be899) obs-studio: patch to fix libobs.po on arm64
* [`b9a93634`](https://github.com/NixOS/nixpkgs/commit/b9a936348588aefbf4462435ed2092d8a9e15928) istioctl: 1.20.1 -> 1.20.2
* [`dcb75ccb`](https://github.com/NixOS/nixpkgs/commit/dcb75ccb68ac910c8de65a0457035ad59d6c7c58) vengi-tools: 0.0.27 -> 0.0.28
* [`e12ddcf3`](https://github.com/NixOS/nixpkgs/commit/e12ddcf33e4818e2220f0ef769dc849db5f121a7) gphotos-sync: 3.1.2 -> 3.2.1
* [`02c71c28`](https://github.com/NixOS/nixpkgs/commit/02c71c2822a022d5ad27207e54881791ae3a90f4) twingate: 2023.250.97595 -> 2024.018.111182
* [`8e2d1382`](https://github.com/NixOS/nixpkgs/commit/8e2d1382115204a8896f296e69d602cefe805021) cargo-make: 0.37.5 -> 0.37.7
* [`1e0be8fb`](https://github.com/NixOS/nixpkgs/commit/1e0be8fbd7778f65093108e0b314933b096730be) pdfhummus: 4.6.2 -> 4.6.3
* [`147d7a0c`](https://github.com/NixOS/nixpkgs/commit/147d7a0c7a10306db2ebaaceee58d530f5711e39) xilinx-bootgen: xilinx_v2023.1 -> xilinx_v2023.2
* [`07e0e9d8`](https://github.com/NixOS/nixpkgs/commit/07e0e9d80cde229dd8481f4e35f7c9455491cf4f) bambu-studio: 01.08.02.56 -> 01.08.04.51
* [`0ed778e8`](https://github.com/NixOS/nixpkgs/commit/0ed778e82d49be505a115ca2bae61d9f20b32870) faustPhysicalModeling: 2.69.3 -> 2.70.3
* [`4b128008`](https://github.com/NixOS/nixpkgs/commit/4b128008c5d9fde881ce1b0a25e60ae0415a14d5) nixos/test-instrumentation: use file to set root password
* [`be2a4f37`](https://github.com/NixOS/nixpkgs/commit/be2a4f37af10d36cc02ab66fd955f07b2ed7d53e) nixos/dbus: explicitly set homeMode for dbus
* [`eec18457`](https://github.com/NixOS/nixpkgs/commit/eec1845744299b8be930029c58edde6d58957207) nixos/systemd-sysusers: init
* [`d4a8fe24`](https://github.com/NixOS/nixpkgs/commit/d4a8fe24c235f63a68b9aeaebeea8b00d6b9f9a7) nixos/systemd-sysusers: add manual section
* [`094f6cca`](https://github.com/NixOS/nixpkgs/commit/094f6cca9ab9dc1aa886be936b9e57f58a9457ab) nixos/systemd-sysusers: add release-note
* [`4bcec20f`](https://github.com/NixOS/nixpkgs/commit/4bcec20fa17c47cb4a9587ca247d6989ce6daf2b) move-mount-beneath: init at unstable-2023-11-26
* [`b250e162`](https://github.com/NixOS/nixpkgs/commit/b250e162d6683deffab11c965ac04f5eb9943c66) nixos/gamemode: add gamemode group
* [`f60836eb`](https://github.com/NixOS/nixpkgs/commit/f60836eb3a850de917985029feaea7338f6fcb8a) winePackages.stable: 8.0.2 -> 9.0
* [`352690d4`](https://github.com/NixOS/nixpkgs/commit/352690d43cf69e7feac7ec7e7aedb500dfe63648) winePackages.{unstable,staging}: 9.0-rc1 -> 9.0
* [`f5d71218`](https://github.com/NixOS/nixpkgs/commit/f5d71218d514db2d2551f5e1c1106d51e851a47b) winetricks: 20230212 -> 20240105
* [`6dff94ba`](https://github.com/NixOS/nixpkgs/commit/6dff94ba0485408c92a27d07a72f24e5722759d1) checkSSLCert: 2.78.0 -> 2.79.0
* [`5985d7e2`](https://github.com/NixOS/nixpkgs/commit/5985d7e2f6302c00381283c1f0928e8fc14d3069) pocketbase: 0.20.5 -> 0.20.7
* [`43dfca30`](https://github.com/NixOS/nixpkgs/commit/43dfca3054a273392b58681c1bd8ce222657e11b) maintainers: add mabster314
* [`55961341`](https://github.com/NixOS/nixpkgs/commit/55961341e39ec4e46b09eb2db491448f2c0105c3) kplex: init at 1.4
* [`91038667`](https://github.com/NixOS/nixpkgs/commit/9103866775b6c87558ced31f48cf3b3c86951156) lune: shorten disabled test comments
* [`1caeb1e8`](https://github.com/NixOS/nixpkgs/commit/1caeb1e80b92eab10933ff070e833e126cbc2f06) lune: ignore `.cargo/config.toml`
* [`12e44a4f`](https://github.com/NixOS/nixpkgs/commit/12e44a4f46a9e3f7f02adcd2771ea0237abd15cd) instawow: v3.1.0 -> 3.2.0
* [`6695a11e`](https://github.com/NixOS/nixpkgs/commit/6695a11e785fdc840d9a5d1b029f60542aba08bf) ruby.rubygems: 3.5.4 -> 3.5.5
* [`0a97ca4a`](https://github.com/NixOS/nixpkgs/commit/0a97ca4a0a04a3acd0bf10ebe5ca291fa6b43980) bundler: 2.5.4 -> 2.5.5
* [`30bed245`](https://github.com/NixOS/nixpkgs/commit/30bed2452c4cb3bda992170b123c102ed7bf327c) k9s: 0.31.6 -> 0.31.7
* [`a4370eba`](https://github.com/NixOS/nixpkgs/commit/a4370eba871e7f080f5906a778867b463172d914) antora: 3.1.5 -> 3.1.7
* [`0ccfce78`](https://github.com/NixOS/nixpkgs/commit/0ccfce78678126ec8d7d97742bc340cc3637d5ed) inetutils: set priority lower than util-linux
* [`e3995661`](https://github.com/NixOS/nixpkgs/commit/e3995661b1f157b5f55a5083ec28bb966dc9dfe7) spirv-llvm-translator: cherry-pick a patch to fix build with latest spirv-headers
* [`73119b45`](https://github.com/NixOS/nixpkgs/commit/73119b4570d422c203cf83a08eb0c1ebc4fa2d61) timeular: 6.6.5 -> 6.6.8
* [`fc5fa9a0`](https://github.com/NixOS/nixpkgs/commit/fc5fa9a09f92f74c2b14965784ca374b737f5f90) linux-router-without-wifi: 0.7.1 -> 0.7.3
* [`fd199bdc`](https://github.com/NixOS/nixpkgs/commit/fd199bdc5b31e916101c3cc2b42ea6a000e3142e) nixos/portunus: add seedSettings option
* [`b97e8edd`](https://github.com/NixOS/nixpkgs/commit/b97e8eddd837fccd6eb7dc0c9a50643b5c2cb504) apt: 2.7.8 -> 2.7.9
* [`f07a54ac`](https://github.com/NixOS/nixpkgs/commit/f07a54ac34d3ccc0e0cf3b7ed3a4d9391a8d7c6f) polypane: 17.0.0 -> 17.1.0
* [`e44cf032`](https://github.com/NixOS/nixpkgs/commit/e44cf032bc2c516e41a41cb58dbd6575bf85a221) qt5, qt6: fix QML path search order
* [`c8fe6248`](https://github.com/NixOS/nixpkgs/commit/c8fe62486c7c123a7fb36c13b146901b50b167ab) qq: 3.2.3-20201 -> 3.2.5-20979
* [`2fe4987c`](https://github.com/NixOS/nixpkgs/commit/2fe4987c280555857a4a1351a90418ca466f672b) qcad: 3.29.0.0 -> 3.29.2.0
* [`490556c6`](https://github.com/NixOS/nixpkgs/commit/490556c6a99f50ecfea4614f047864b7ba0036c8) duckscript: 0.9.2 -> 0.9.3
* [`da2bac16`](https://github.com/NixOS/nixpkgs/commit/da2bac1683a3f0f6a4f70d920d6e0e5611b8c4f7) systemdUkify: init
* [`985bafa5`](https://github.com/NixOS/nixpkgs/commit/985bafa5fc9e3ad846a54a68a71c06235c4aaaae) nixos/uki: init
* [`ed243190`](https://github.com/NixOS/nixpkgs/commit/ed2431905c1efe409d28ba89bc5cc337d538b27c) nixos/tests/appliance-repart-image: use UKIs
* [`5838eafe`](https://github.com/NixOS/nixpkgs/commit/5838eafe4cf4acef4af5bc5697b27fc4dfff64de) python311Packages.quaternion: 2022.4.4 -> 2023.0.2
* [`38f7be8b`](https://github.com/NixOS/nixpkgs/commit/38f7be8b49aef5a16cf62a3a2d12ae47d45b839a) wineWow64Packages.minimal: fix build
* [`775f27fd`](https://github.com/NixOS/nixpkgs/commit/775f27fdfeb90faaeb2588cde34aae5726dae15c) josm: 18907 → 18940
* [`381f5bdc`](https://github.com/NixOS/nixpkgs/commit/381f5bdc1f49a949bbc69398e85a88ae03525118) show-midi: 0.8.0 -> 0.9.0
* [`fdf411fb`](https://github.com/NixOS/nixpkgs/commit/fdf411fb36c721a4769a355a4330f23cb598632d) nixos/tigerbeetle: init module
* [`3f4aa472`](https://github.com/NixOS/nixpkgs/commit/3f4aa4721f1cbe137c6ac55b1d4446adc71e3746) python311Packages.rtree: 1.1.0 -> 1.2.0
* [`9a33f8ce`](https://github.com/NixOS/nixpkgs/commit/9a33f8ce5ba7329600b296996d944ec9ddaa7d38) cudaPackagesGoogle.cudnn_8_6: fix eval
* [`51723c2e`](https://github.com/NixOS/nixpkgs/commit/51723c2eac7ab16544bca076a89e3c3ac5ea1ed5) python311Packages.rtree: refactor
* [`5cf0f04f`](https://github.com/NixOS/nixpkgs/commit/5cf0f04f95f73888da861e0c1249dd9b581f30ab) cudaPackagesGoogle.cudnn_8_6: ensure present on all platforms
* [`c2e5e121`](https://github.com/NixOS/nixpkgs/commit/c2e5e121c44519193c84475b2d4c7371da2ede60) watchexec: 1.25.0 -> 1.25.1
* [`441d248d`](https://github.com/NixOS/nixpkgs/commit/441d248ded81ecfd44b55e09011825599d0d92f2) turbo: 1.10.16 -> 1.11.3
* [`40ae2763`](https://github.com/NixOS/nixpkgs/commit/40ae27632c8113f8037c9fedc6c899ab69c3082c) trytond: 7.0.2 -> 7.0.5
* [`9e0c900c`](https://github.com/NixOS/nixpkgs/commit/9e0c900ce9ab1c2c68a40b9a9591d43de9503c59) publii: 0.44.2 -> 0.44.4
* [`842c2de8`](https://github.com/NixOS/nixpkgs/commit/842c2de8016f90574841cf40846829206c491784) miniserve: add missing framework on darwin
* [`98490896`](https://github.com/NixOS/nixpkgs/commit/984908965607c5de2f304f8c1d6119849f675df2) elektroid: 2.5.2 -> 3.0
* [`2167a493`](https://github.com/NixOS/nixpkgs/commit/2167a493018790ab12a857503d2f5c6ae3b85188) linuxPackages.apfs: 0.3.6 -> 0.3.7
* [`35427ed4`](https://github.com/NixOS/nixpkgs/commit/35427ed41205e32566a312e04ffd74c6ab1f7b3c) linkerd_stable: 2.14.8 -> 2.14.9
* [`92c1df19`](https://github.com/NixOS/nixpkgs/commit/92c1df191bb5e17d0985beed64f94065233c2076) vscode-extensions.albymor.increment-selection: init at 0.2.0
* [`3843eeca`](https://github.com/NixOS/nixpkgs/commit/3843eeca37eec9f717949eb488be3b625ee07ade) vscode-extensions.bazelbuild.vscode-bazel: init at 0.7.0
* [`94e1a67d`](https://github.com/NixOS/nixpkgs/commit/94e1a67db13fd6c387bf3354553df5a1e55d3cdf) vscode-extensions.iliazeus.vscode-ansi: init at 1.1.6
* [`d1568030`](https://github.com/NixOS/nixpkgs/commit/d1568030f46f3d8a54ac9e495e0b58831076622b) vscode-extensions.jamesyang999.vscode-emacs-minimum: init at 1.1.1
* [`4fabb33b`](https://github.com/NixOS/nixpkgs/commit/4fabb33b3cf37c05d0bae4f58c61eddc21c3d86c) vscode-extensions.tim-koehler.helm-intellisense: init at 0.14.3
* [`8e489605`](https://github.com/NixOS/nixpkgs/commit/8e489605224d4cbd52d6cd3e24fca3cdcb31c766) vscode-extensions.twpayne.vscode-testscript: init at 0.0.4
* [`ebc29787`](https://github.com/NixOS/nixpkgs/commit/ebc297879d8f17ac5e89d0f0abf1736f706bfbaf) maintainers: add brpaz
* [`beccef0b`](https://github.com/NixOS/nixpkgs/commit/beccef0b4efedfbe10a3319090a109251c73a0fd) kubeseal: 0.24.5 -> 0.25.0
* [`1c7a0e34`](https://github.com/NixOS/nixpkgs/commit/1c7a0e3453f2429e63150e7b1a3834a437693451) gomarkdoc: init at 1.1.0
* [`fd872716`](https://github.com/NixOS/nixpkgs/commit/fd8727163d3b0bd77a274e201adf75a3c412d2d6) nixos/nix-gc: Drop with lib;
* [`23151743`](https://github.com/NixOS/nixpkgs/commit/23151743843ecc95ffdd87298df6121090c0b698) nixos/nix-gc: Add Type so systemctl waits properly
* [`e04524a9`](https://github.com/NixOS/nixpkgs/commit/e04524a931766d943e7ab1c13d763bcc913608d6) nixos/nix-gc: Use singleLineStr where possible
* [`c2299e79`](https://github.com/NixOS/nixpkgs/commit/c2299e790c6dff372c653392e8ae2082cb8142b8) python311Packages.openstacksdk: 2.0.0 -> 2.1.0
* [`d0d38247`](https://github.com/NixOS/nixpkgs/commit/d0d38247f01c2d0d6f4d8ab46401ead9a658de37) python3.pkgs.opentelemetry-api: 1.21.0 -> 1.22.0
* [`c913a0bc`](https://github.com/NixOS/nixpkgs/commit/c913a0bc0da401762630277afe845ff2cf8289a3) python3.pkgs.opentelemetry-instrumentation: 1.16.0 -> 0.43b0
* [`c91c1276`](https://github.com/NixOS/nixpkgs/commit/c91c1276ba311ae16407c153ca3808ecd6fa931c) python3.pkgs.opentelemetry-util-http: fix build
* [`f88ea9b9`](https://github.com/NixOS/nixpkgs/commit/f88ea9b9191df85e9f32ba57a5a497bdca191190) python3.pkgs.opentelemetry-instrumentation-flask: init at 0.43b0
* [`3b93cb34`](https://github.com/NixOS/nixpkgs/commit/3b93cb341979377845669d476d219e13fec1442e) zpaqfranz: 58.11 -> 59.1
* [`4e2bb19b`](https://github.com/NixOS/nixpkgs/commit/4e2bb19b7fec2b13be40124adb2697c86f3f58cf) reaper: 7.08 -> 7.09
* [`6852c70d`](https://github.com/NixOS/nixpkgs/commit/6852c70d137a9663077438dc43798a223cdf421c) cemu: 2.0-61 -> 2.0-65
* [`7e21e287`](https://github.com/NixOS/nixpkgs/commit/7e21e28768ecf865e4d1affb31e1150a3ea6af25) fluffychat: 1.14.1 -> 1.17.1
* [`faeaadb7`](https://github.com/NixOS/nixpkgs/commit/faeaadb739a13ef6adc5923d6b478125019cb495) lomiri.lomiri-thumbnailer: init at 3.0.2
* [`75597507`](https://github.com/NixOS/nixpkgs/commit/75597507ddbd686837fe5e5b5bfeb15beb970bbf) lomiri.qqc2-suru-style: Add meta.changelog
* [`b781682c`](https://github.com/NixOS/nixpkgs/commit/b781682c33d8fcbef1b470f4f0344d7f997f0130) lomiri.qtmir: init at 0.7.2-unstable-2024-01-08
* [`fc2fbe95`](https://github.com/NixOS/nixpkgs/commit/fc2fbe955454079c426e4e6ad17f16e1adcb72ed) tryton: 5.4.2 -> 7.0.5
* [`8b3edf41`](https://github.com/NixOS/nixpkgs/commit/8b3edf412a6e581380a9030c9574ac9a4a644fb4) faraday-cli: 2.1.9 -> 2.1.10
* [`dfc573e7`](https://github.com/NixOS/nixpkgs/commit/dfc573e79b77fb5ac9c48d8d17b3b232e263272f) python311Packages.agate-sql: 0.7.0 -> 0.7.2
* [`515b2d70`](https://github.com/NixOS/nixpkgs/commit/515b2d70bc4623c424e355d92f35382528c7b4b3) python312Packages.plaid-python: 18.3.0 -> 18.4.0
* [`c01fdbec`](https://github.com/NixOS/nixpkgs/commit/c01fdbec00c431e98b2369edd46677849db3ab1d) datadog-agent: 7.50.1 -> 7.50.3
* [`7aecbfc5`](https://github.com/NixOS/nixpkgs/commit/7aecbfc5816872179930697130a8b683a97680ac) ocamlPackages.containers: set minimal ocaml version
* [`d838162c`](https://github.com/NixOS/nixpkgs/commit/d838162cfbe8934cea730c165e2e47eda1849175) obs-studio: use fetchpatch to fix arm64 cmake
* [`b7dd776f`](https://github.com/NixOS/nixpkgs/commit/b7dd776f2610007cb96f59d8975597d70e08574d) ipxe: unstable-2023-07-19 -> unstable-2024-01-19
* [`c50512e9`](https://github.com/NixOS/nixpkgs/commit/c50512e90aeb0db7a5265603af160765bb23656f) circleci-cli: 0.1.29658 -> 0.1.29936
* [`6fc5258c`](https://github.com/NixOS/nixpkgs/commit/6fc5258c5c60fbb1128c902983068b6601f9a0b9) f3d: mark broken
* [`222e39ef`](https://github.com/NixOS/nixpkgs/commit/222e39efe5d605357dafac694b89ab771058ed2d) cnquery: 9.13.0 -> 9.14.0
* [`72906865`](https://github.com/NixOS/nixpkgs/commit/729068650f49f013361860529c1961cc0d8a0f12) entt: 3.12.2 -> 3.13.0
* [`cacbfe89`](https://github.com/NixOS/nixpkgs/commit/cacbfe899080f754b1aa2f79c2d0e0a9d91ec16a) vopono: 0.10.7 -> 0.10.8
* [`00f48620`](https://github.com/NixOS/nixpkgs/commit/00f48620ac28b2fc0bc080f8836dce385aa13bf4) winePackages.*: Enable wayland driver; wine-waylan
* [`555aac16`](https://github.com/NixOS/nixpkgs/commit/555aac16535f7ea1e23e90e55e9813da813c2305) devpi-client: 7.0.0 -> 7.0.2
* [`cc1c593b`](https://github.com/NixOS/nixpkgs/commit/cc1c593b1a8a83348459a77627f0cc53de0ec68c) meshcentral: 1.1.6 -> 1.1.19
* [`84b60551`](https://github.com/NixOS/nixpkgs/commit/84b60551ce0fc4dc76342c15078edac2bdff7572) carapace: 0.29.0 -> 0.29.1
* [`3fec4fd5`](https://github.com/NixOS/nixpkgs/commit/3fec4fd5dcf962f329b1163d644a96ea8e7e2f71) bilibili: 1.12.5-2 -> 1.13.0-2
* [`4fef90dc`](https://github.com/NixOS/nixpkgs/commit/4fef90dc12b8ff2b8162c0ba5c37a66c2f4e0be2) teamspeak5_client: 5.0.0-beta76 -> 5.0.0-beta77
* [`c56d24bb`](https://github.com/NixOS/nixpkgs/commit/c56d24bb4ca7c7e85873decdd59fc49425463173) lomiri.telephony-service: init at 0.5.2
* [`49211685`](https://github.com/NixOS/nixpkgs/commit/492116856761ed8d136f98a869b29fc975a7b957) ayatana-indicator-datetime: init at 23.10.0
* [`42f15297`](https://github.com/NixOS/nixpkgs/commit/42f15297066089241b694f0fb5913fef4e261ad0) ayatana-indicator-datetime: 23.10.0 -> 23.10.1
* [`b6ac6f11`](https://github.com/NixOS/nixpkgs/commit/b6ac6f110d9e5109a3ae0bd91c57d886e99ed04a) python311Packages.django-webpack-loader: 3.0.0 -> 3.0.1
* [`2d324fc2`](https://github.com/NixOS/nixpkgs/commit/2d324fc2426fd320dcd15326b830b50fc2949c55) nixos/archisteamfarm: don't use asf abbreviation for more clarity
* [`6d1d9127`](https://github.com/NixOS/nixpkgs/commit/6d1d912716d73aa497727802caba6ba6783e5c3a) nixos/archisteamfarm: drop with lib
* [`4d643055`](https://github.com/NixOS/nixpkgs/commit/4d643055abc061e6f6b8f85ac3e8b020cc863296) mgba: refactor
* [`0996eac9`](https://github.com/NixOS/nixpkgs/commit/0996eac93a397ca7e73da7d2e07419990c30e66f) spirit: unstable-2023-12-15 -> 0-unstable-2024-01-11
* [`613e86b7`](https://github.com/NixOS/nixpkgs/commit/613e86b7627e154b2ed844ba8a3a7345533aba46) starlark: unstable-2023-11-01 -> 0-unstable-2023-11-21
* [`4c1a14fe`](https://github.com/NixOS/nixpkgs/commit/4c1a14fe5c58ab4fe7e9b957a1ea2b4f670d2ece) mgba: 0.10.2 -> 0.10.3
* [`9838c39d`](https://github.com/NixOS/nixpkgs/commit/9838c39daca7487229811c8da6eb70d22255fbbe) mgba: unpin lua
* [`74e53c69`](https://github.com/NixOS/nixpkgs/commit/74e53c6981b1597b00fd77eedddb7aa89f87e69a) luau: 0.607 -> 0.609
* [`44480e03`](https://github.com/NixOS/nixpkgs/commit/44480e038917cc0e80ef2b20f23ef474c3e13139) gallery-dl: 1.26.6 -> 1.26.7
* [`06939057`](https://github.com/NixOS/nixpkgs/commit/06939057a493d00dd9715220d169e9510ea951bd) luau: add meta.mainProgram
* [`0aa5668b`](https://github.com/NixOS/nixpkgs/commit/0aa5668be44d3907bd8027e330c59273bcd1d697) resvg: 0.37.0 -> 0.38.0
* [`b9d0190c`](https://github.com/NixOS/nixpkgs/commit/b9d0190c543a8edcd95a1cbe7d91fc35b5de2bd0) nanovna-saver: 0.6.0 -> 0.6.3
* [`93ccb53d`](https://github.com/NixOS/nixpkgs/commit/93ccb53d87411544be45692fd8662f83982f4809) python311Packages.pomegranate: 1.0.0 -> 0.14.8
* [`c1cf4338`](https://github.com/NixOS/nixpkgs/commit/c1cf433881fad1266d834af704c107b90b3a4ee8) mopidy: 3.4.1 -> 3.4.2
* [`45335dbb`](https://github.com/NixOS/nixpkgs/commit/45335dbb49803f5dded31eba913f29108aaa5f1f) fanficfare: 4.29.0 -> 4.30.0
* [`ec37b23b`](https://github.com/NixOS/nixpkgs/commit/ec37b23b3294d5ba5d150e421f032b5ba7a7f5cd) python311Packages.rapidfuzz: 3.6.0 -> 3.6.1
* [`c18514d9`](https://github.com/NixOS/nixpkgs/commit/c18514d90082921904c7c1bbf652bf4146bcf2c9) moon: 1.19.0 -> 1.19.3
* [`19eb915f`](https://github.com/NixOS/nixpkgs/commit/19eb915fb8d6581d7161131b46da4472049ff8f9) linux_xanmod: 6.1.72 -> 6.1.74
* [`9c13e105`](https://github.com/NixOS/nixpkgs/commit/9c13e10574582c0f2e8f256751fb0c76fb6a2510) diffoscope: 253 -> 254
* [`f571fc09`](https://github.com/NixOS/nixpkgs/commit/f571fc09f10adb6dfc45ff2c67996538979c8c81) linux_xanmod_latest: 6.6.10 -> 6.6.13
* [`f6ebc9b4`](https://github.com/NixOS/nixpkgs/commit/f6ebc9b47890b5c23ed2d7445ea39f9181fc52af) fluent-bit: 2.2.1 -> 2.2.2
* [`148f46f3`](https://github.com/NixOS/nixpkgs/commit/148f46f3d00637b040d7787090245e960524d205) python311Packages.pyfaidx: 0.7.2.2 -> 0.8.1.1
* [`9981c3be`](https://github.com/NixOS/nixpkgs/commit/9981c3be25651c6f00b4130112dfc1392ee8307d) python312Packages.langsmith: 0.0.80 -> 0.0.83
* [`5dac1b23`](https://github.com/NixOS/nixpkgs/commit/5dac1b233c608c558921787af3a9dd8816838765) pomerium: 0.24.0 -> 0.25.0
* [`6c815377`](https://github.com/NixOS/nixpkgs/commit/6c815377c3b0a5a29f05adc54b41243737da8a20) ironbar: 0.13.0 -> 0.14.0
* [`d15b22eb`](https://github.com/NixOS/nixpkgs/commit/d15b22ebd535f6f54ae61f8e4f0da9bc841885f1) goldwarden: 0.2.9 -> 0.2.10
* [`29d9badd`](https://github.com/NixOS/nixpkgs/commit/29d9badd5101208da53f1cb25d0bc99f71fe84c7) ffmpeg: build with shaderc instead of glslang
* [`099029fa`](https://github.com/NixOS/nixpkgs/commit/099029fae624c17068a72172f5b09fe71eec4152) libplacebo_5, vulkan-volk: move to by-name
* [`bd2c570c`](https://github.com/NixOS/nixpkgs/commit/bd2c570c1c77510c828e7e6ab108045e30b2a986) ngtcp2-gnutls: 1.1.0 -> 1.2.0
* [`3b238ed6`](https://github.com/NixOS/nixpkgs/commit/3b238ed60ab203f7ad9490db7d216be0e06cc6dd) xsimd: Add doronbehar as maintainer
* [`6ae36a5a`](https://github.com/NixOS/nixpkgs/commit/6ae36a5a9f7165177a6c735f398d64738c039aef) python310Packages.meson-python: add doronbehar as maintainer
* [`d69f99aa`](https://github.com/NixOS/nixpkgs/commit/d69f99aaf866ed3b7fabd58740425c60f1d61a77) python310Packages.pythran: add doronbehar as maintainer
* [`a23ee294`](https://github.com/NixOS/nixpkgs/commit/a23ee294e595fecb44b084841a21b559c0fcea33) python311Packages.scipy: 1.11.4 -> 1.12.0
* [`8bd97ecc`](https://github.com/NixOS/nixpkgs/commit/8bd97eccd21fc0cdf1dc88710b6bbe4709d37b62) python311Packages.scipy: actually use pytestCheckHook
* [`83fc2070`](https://github.com/NixOS/nixpkgs/commit/83fc2070ecf18ff85d5560150bdb0ccb082a0d70) python311Packages.scipy: use --replace-fail in numpy dep substitution
* [`dce88117`](https://github.com/NixOS/nixpkgs/commit/dce88117e14afdb8462acbf83bd2d84cfbb1bcbc) python311Packages.crytic-compile: 0.3.5 -> 0.3.6
* [`f0116875`](https://github.com/NixOS/nixpkgs/commit/f0116875ede56582f26f063922395eb48519db8b) snac2: 2.44 -> 2.45
* [`db44fd6b`](https://github.com/NixOS/nixpkgs/commit/db44fd6b279a2f47b7863d4c30bdd7c3d74a54d2) zps: 1.2.9 -> 2.0.0
* [`1fe11598`](https://github.com/NixOS/nixpkgs/commit/1fe1159820c17b2005c009573034f8c3addf945d) php81Extensions.phalcon: 5.5.0 -> 5.6.0
* [`55db691b`](https://github.com/NixOS/nixpkgs/commit/55db691b5eb0e84afc2231f1a4c1027655394142) songrec: 0.3.3 -> 0.4.1
* [`23da6057`](https://github.com/NixOS/nixpkgs/commit/23da60579fef040fa4bacf41ca668d0edf53e1c0) tailspin: 2.4.0 -> 3.0.0
* [`1d27e278`](https://github.com/NixOS/nixpkgs/commit/1d27e278bdc103ec0a48fea5b3ddbe5bab7ca4b2) pass-git-helper: 1.2.0 -> 1.4.0
* [`a3ef982f`](https://github.com/NixOS/nixpkgs/commit/a3ef982fc5e3ce15c0b46e5c74220a991e2ce345) icinga2: 2.14.0 -> 2.14.2
* [`28f44879`](https://github.com/NixOS/nixpkgs/commit/28f44879c5203d54af14b6f77d614c75cc25926a) paperless-ngx: 2.3.3 -> 2.4.0
* [`ae6bedf7`](https://github.com/NixOS/nixpkgs/commit/ae6bedf7aab8b208b6b29a9d81cce55e4c7285d2) ckan: 1.34.2 -> 1.34.4
* [`f11c3d08`](https://github.com/NixOS/nixpkgs/commit/f11c3d08be7cf5a13e2ca8a525443c1d5a36621d) hurl: 4.1.0 -> 4.2.0
* [`d95bb316`](https://github.com/NixOS/nixpkgs/commit/d95bb316bddc6d558300fe9387fa7265ea6ff2e0) isa-l: 2.30.0 -> 2.31.0
* [`7342ecdb`](https://github.com/NixOS/nixpkgs/commit/7342ecdb313bdbc1ec058c1890da89086bab2b89) qtile: 0.23.0 -> 0.24.0
* [`6940744a`](https://github.com/NixOS/nixpkgs/commit/6940744a6f2e7e311064ad852f8797270518b9ae) vcpkg: 2023.12.12 -> 2024.01.12
* [`be3d12f8`](https://github.com/NixOS/nixpkgs/commit/be3d12f81009c8cdd0ca50a022a3bc1cf49ddb2f) video2midi: 0.4.6.5 -> 0.4.7.2
* [`edd47617`](https://github.com/NixOS/nixpkgs/commit/edd47617888c8080080d3bd1a3a6aa0832001dee) obs-studio-plugins.obs-composite-blur: init at 1.1.0
* [`a563b20a`](https://github.com/NixOS/nixpkgs/commit/a563b20aad7f7c41653355ce12a691ad23453550) perlPackages.ParseWin32Registry: init at 1.1
* [`82aed8e6`](https://github.com/NixOS/nixpkgs/commit/82aed8e6b53c707ace316e3bc386148eab0dbb6d) doitlive: 4.3.0 -> 5.0.0
* [`babc0626`](https://github.com/NixOS/nixpkgs/commit/babc062694905d1b9892ab5e5c0a6e3d22b32fe7) anilibria-winmaclinux: 1.2.12 -> 1.2.14
* [`3322ec64`](https://github.com/NixOS/nixpkgs/commit/3322ec64f613709b6a2bab0876e33d214846f3ae) python311Packages.pontos: 23.12.1 -> 24.1.2
* [`150ef131`](https://github.com/NixOS/nixpkgs/commit/150ef131938efea42f512250c054b4bba12b229b) unifi-protect-backup: 0.10.2 -> 0.10.3
* [`0613638e`](https://github.com/NixOS/nixpkgs/commit/0613638ecdda5ed65ec2b90ad4b34bdd1c16ba5c) backblaze2-b2: support alternative executable name
* [`42cc0d33`](https://github.com/NixOS/nixpkgs/commit/42cc0d3363c8d14d4b414b26d92290d8a3602e12) python312Packages.asterisk-mbox: fix build
* [`47e878f0`](https://github.com/NixOS/nixpkgs/commit/47e878f094c40f3337a7720a71eb9cea5029ab67) stormlib: migrate to by-name, rename from StormLib
* [`c448fd07`](https://github.com/NixOS/nixpkgs/commit/c448fd07c9b0b5bdce7efcd8290f83992fd78594) stormlib: fix build on darwin
* [`8c26170c`](https://github.com/NixOS/nixpkgs/commit/8c26170c9934acca5e81ca4a8f8660a6c7470e6e) oxker: 0.5.0 -> 0.6.0
* [`abb97f60`](https://github.com/NixOS/nixpkgs/commit/abb97f60228f4ffdd073cf5c16449e9e39a4bb94) ebtks: migrate to by-name, rename from EBTKS
* [`2fb5a908`](https://github.com/NixOS/nixpkgs/commit/2fb5a908e98973816c85cf3ee943c01578658b3c) pageedit: rename from PageEdit
* [`0131a451`](https://github.com/NixOS/nixpkgs/commit/0131a4517ef0ce6beff3b5049c5905dc88dd48e7) pageedit: fix build on x86_64-darwin
* [`c9f07e75`](https://github.com/NixOS/nixpkgs/commit/c9f07e75553fba13741fe538472ebe5a0a1b6582) sunvox: 2.1c -> 2.1.1c
* [`ad095f54`](https://github.com/NixOS/nixpkgs/commit/ad095f5411d050e84b306b5cd3ac22a65739d2af) kubecm: 0.26.0 -> 0.27.1
* [`b07ef31a`](https://github.com/NixOS/nixpkgs/commit/b07ef31a8bc1a27c9cb558907d7106cdaba52ad3) _9base: fix build on x86_64-darwin
* [`1dfbb1e1`](https://github.com/NixOS/nixpkgs/commit/1dfbb1e1f76acdb226cd55cd872148946bcc9454) ebtks: fix build on darwin
* [`49ee2abd`](https://github.com/NixOS/nixpkgs/commit/49ee2abdb821018ba3fd1ce7e335a231e44bd938) CoinMP: fix build with clang 16
* [`b91c6233`](https://github.com/NixOS/nixpkgs/commit/b91c6233489faa3c56c9b89a313c4bc50c24955f) python311Packages.msal: 1.25.0 -> 1.26.0
* [`bfec64e2`](https://github.com/NixOS/nixpkgs/commit/bfec64e2438f166e8fb9f00ce25cf35a2f6fca00) python311Packages.msal: refactor
* [`901f6006`](https://github.com/NixOS/nixpkgs/commit/901f60061821e5f751bb45094db45d052c9325ad) python311Packages.msal-extensions: 1.0.0 -> 1.1.0
* [`8f01ae98`](https://github.com/NixOS/nixpkgs/commit/8f01ae98b7d405c71176264c2acb6fe9b682f15c) python311Packages.python-gitlab: 4.2.0 -> 4.4.0
* [`cf0e5d92`](https://github.com/NixOS/nixpkgs/commit/cf0e5d92ea89eb5394b15ac71d650b1357690cac) Revert "CODEOWNERS: Watch the maintainers lists"
* [`acdd3a36`](https://github.com/NixOS/nixpkgs/commit/acdd3a362cb8840b0fc17cafa5b6d282377caa9f) python311Packages.msprime: 1.2.0 -> 1.3.0
* [`2e142e66`](https://github.com/NixOS/nixpkgs/commit/2e142e663d524e75bd8f606292a1dbd59345edd5) python311Packages.pybids: relax formulaic
* [`18d61d9c`](https://github.com/NixOS/nixpkgs/commit/18d61d9c2ee8ea0c3c990d5711543d13ff4f9580) python311Packages.qingping-ble: 0.9.0 -> 0.10.0
* [`469a52c9`](https://github.com/NixOS/nixpkgs/commit/469a52c941056ee69fbe01a5a66211132029e278) devspace: 6.3.8 -> 6.3.9
* [`18ee1f53`](https://github.com/NixOS/nixpkgs/commit/18ee1f53146e636c5bd27b823aa570b7139a7ab6) kaniko: 1.19.2 -> 1.20.0
* [`6af690aa`](https://github.com/NixOS/nixpkgs/commit/6af690aaf1189d6b860d2da77928ccf29171027f) opentelemetry-cpp: init at 1.13.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
