### PR TITLE
niv devenv: update aa237a7b -> ad0ae333

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "aa237a7b5605b4f58714762d1f56627dfb1b3dfa",
-        "sha256": "1rmaf8iwxv8sh7j9nbzv7dcpvmmy77ks5ssfw4pncldgl7nqlgiv",
+        "rev": "ad0ae333b210e31237e1fc4a7ddab71a01785add",
+        "sha256": "1r6j2rxbicmd85bl2idpgpk7rrr5i283vh3cc23vxw9dxnnkwvkp",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/aa237a7b5605b4f58714762d1f56627dfb1b3dfa.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/ad0ae333b210e31237e1fc4a7ddab71a01785add.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@aa237a7b...ad0ae333](https://github.com/cachix/devenv/compare/aa237a7b5605b4f58714762d1f56627dfb1b3dfa...ad0ae333b210e31237e1fc4a7ddab71a01785add)

* [`b0a0ce2d`](https://github.com/cachix/devenv/commit/b0a0ce2da7e67daff6a0a48f6adf879592be6e17) feat: add support for running a different nix language server
* [`0b3995d8`](https://github.com/cachix/devenv/commit/0b3995d8c80c8f69cb8b5f4a311ae06bad6281ae) feat: this looks better
* [`f153d19f`](https://github.com/cachix/devenv/commit/f153d19f421cde13084d1d357e0ea81d5828674f) fix: do not use ++ here
* [`ad0ae333`](https://github.com/cachix/devenv/commit/ad0ae333b210e31237e1fc4a7ddab71a01785add) Auto generate docs/reference/options.md
