### PR TITLE
niv home-manager: update 2d47379a -> d634c3ab

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d47379ad591bcb14ca95a90b6964b8305f6c913",
-        "sha256": "1n3fmpy33ws04fgdjaczi3z4s19aipf82dy2zfga7m3j55pj32k4",
+        "rev": "d634c3abafa454551f2083b054cd95c3f287be61",
+        "sha256": "0mxrylbycywi8qh6zb1il5yfb5apbjsd7avhvfpavclkjaz80awb",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/2d47379ad591bcb14ca95a90b6964b8305f6c913.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d634c3abafa454551f2083b054cd95c3f287be61.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@2d47379a...d634c3ab](https://github.com/nix-community/home-manager/compare/2d47379ad591bcb14ca95a90b6964b8305f6c913...d634c3abafa454551f2083b054cd95c3f287be61)

* [`3d0dc78e`](https://github.com/nix-community/home-manager/commit/3d0dc78e80031731240c979d87eed8e090d35439) bemenu: allow floats in settings
* [`3df2a80f`](https://github.com/nix-community/home-manager/commit/3df2a80f3f85f91ea06e5e91071fa74ba92e5084) zoxide: fix nushell 0.89 deprecation
* [`6b28ab2d`](https://github.com/nix-community/home-manager/commit/6b28ab2d798c1c84e24053d95f4ee1dd9d81e2fb) tealdeer: add cache update activation script
* [`42567290`](https://github.com/nix-community/home-manager/commit/425672900691a16a897fc47b4d5c3013d2a822a0) treewide: deprecate `DRY_RUN_CMD` and `DRY_RUN_NULL`
* [`190c6f46`](https://github.com/nix-community/home-manager/commit/190c6f46090a62ad025828bd8e16799d8fcdab1e) home-manager: avoid running empty `nix profile remove`
* [`e8481103`](https://github.com/nix-community/home-manager/commit/e84811035d7c8ec79ed6c687a97e19e2a22123c1) treewide: deprecate `VERBOSE_ECHO`
* [`6359d40f`](https://github.com/nix-community/home-manager/commit/6359d40f6ec0b72a38e02b333f343c3d4929ec10) firefox: implement native messaging hosts
* [`70688f19`](https://github.com/nix-community/home-manager/commit/70688f195a294a09d31d6bfe339bb090d443e949) keepassx: remove module
* [`03958aff`](https://github.com/nix-community/home-manager/commit/03958aff4415a5278d0ea462db370e9d770e904e) firefox: add default containers
* [`c82e52b0`](https://github.com/nix-community/home-manager/commit/c82e52b0d96eb9f1c8334add871dce8e837d043b) flake.lock: Update
* [`c7ce343d`](https://github.com/nix-community/home-manager/commit/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15) home-manager: add extendModules attribute
* [`690764d2`](https://github.com/nix-community/home-manager/commit/690764d2dcfccf01ddfc9f19220c88182339f40f) firefox: Reimplement FF native messaging
* [`b2f56952`](https://github.com/nix-community/home-manager/commit/b2f56952074cb46e93902ecaabfb04dd93733434) network-manager-applet: add XDG data directory
* [`e5f2a059`](https://github.com/nix-community/home-manager/commit/e5f2a0590a9387e17e6433b280e45d14f82683b4) flake.lock: Update ([nix-community/home-manager⁠#4964](https://togithub.com/nix-community/home-manager/issues/4964))
* [`7a461c70`](https://github.com/nix-community/home-manager/commit/7a461c70ed20e7e4a2af1710fdfb89ec70473e47) firefox: fix darwin NativeMessagingHostsPath
* [`ebba24a6`](https://github.com/nix-community/home-manager/commit/ebba24a6fefa3d749291be7192ef817736a10bd1) wob: add module
* [`4d54c29b`](https://github.com/nix-community/home-manager/commit/4d54c29bce71f8c261513e0662cc573d30f3e33e) home-manager: remove the export of `run`
* [`d634c3ab`](https://github.com/nix-community/home-manager/commit/d634c3abafa454551f2083b054cd95c3f287be61) tealdeer: add option to toggle update on activation
