### PR TITLE
niv powerlevel10k: update ab6a863e -> 307bce24

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "ab6a863e231b1d85c89e152165719bfe826bc449",
-        "sha256": "10gjy1x1s4gcb2b5kj7xl3lixn465m6rdrzn24mi7vimk9p6kmzk",
+        "rev": "307bce24d19fa09d971a0d33c39f3c9fda82924e",
+        "sha256": "0qw9vw9vdv9y66jf5amck3kyc1qd1c5czpahgym3pbh3bbgkhw3k",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/ab6a863e231b1d85c89e152165719bfe826bc449.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/307bce24d19fa09d971a0d33c39f3c9fda82924e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@ab6a863e...307bce24](https://github.com/romkatv/powerlevel10k/compare/ab6a863e231b1d85c89e152165719bfe826bc449...307bce24d19fa09d971a0d33c39f3c9fda82924e)

* [`a6fa4e43`](https://github.com/romkatv/powerlevel10k/commit/a6fa4e43049715141df7390964b97b618421338c) faq: [oh-my-zsh] theme 'powerlevel10k/powerlevel10k' not found
* [`bd0fa8a0`](https://github.com/romkatv/powerlevel10k/commit/bd0fa8a08f62a6e49f8a2ef47f5103fa840d2198) docs: fix a link
* [`35833ea1`](https://github.com/romkatv/powerlevel10k/commit/35833ea15f14b71dbcebc7e54c104d8d56ca5268) docs: document per_directory_history segment ([romkatv/powerlevel10k⁠#2384](https://togithub.com/romkatv/powerlevel10k/issues/2384))
* [`307bce24`](https://github.com/romkatv/powerlevel10k/commit/307bce24d19fa09d971a0d33c39f3c9fda82924e) docs: fix a link to zsh-theme-powerlevel10k archlinux package
