### PR TITLE
niv emacs-overlay: update 75d58280 -> bc072d9c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "75d582804c561bb16f726916096ee22272d156cc",
-        "sha256": "19y0yvljjhm3cf0n7dyzpfmqbl901d5xngivgma4ypyxy46d57vw",
+        "rev": "bc072d9cca7c696b5167d352e20728515938f677",
+        "sha256": "1k91gf7vzsd5qxgcvrmpp7qx5vzdll03yg52dhwrpyqlshqw6pi0",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/75d582804c561bb16f726916096ee22272d156cc.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/bc072d9cca7c696b5167d352e20728515938f677.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@75d58280...bc072d9c](https://github.com/nix-community/emacs-overlay/compare/75d582804c561bb16f726916096ee22272d156cc...bc072d9cca7c696b5167d352e20728515938f677)

* [`3750376a`](https://github.com/nix-community/emacs-overlay/commit/3750376a60b55eb5f2b62d7e89b34cde0c4f048e) Updated flake inputs
* [`e62cd63f`](https://github.com/nix-community/emacs-overlay/commit/e62cd63fa83d4dd9a81fe3695aa255e1d1d2ddbe) Updated nongnu
* [`7fd5b5b7`](https://github.com/nix-community/emacs-overlay/commit/7fd5b5b760ea726aa4c7670be7d93623936f9bf3) Updated elpa
* [`4778b6a4`](https://github.com/nix-community/emacs-overlay/commit/4778b6a4e51b4784b31d57ee5a291d8b6d5d4635) Updated flake inputs
* [`575fcd2d`](https://github.com/nix-community/emacs-overlay/commit/575fcd2ddb0e7c40611ba68d4a977e0cdc729669) Updated elpa
* [`3fe6a192`](https://github.com/nix-community/emacs-overlay/commit/3fe6a192ba6247fad6e7abfd90b43b5f7ae47864) Revert "Temporarily disable "emacs" update"
* [`a72d83f6`](https://github.com/nix-community/emacs-overlay/commit/a72d83f69cd87fc3cb490636b3afab0cb2353a67) Updated nongnu
* [`3b8c5f64`](https://github.com/nix-community/emacs-overlay/commit/3b8c5f64c9772497f9e817a69cfe50382f011bc5) Updated elpa
* [`e3fb072d`](https://github.com/nix-community/emacs-overlay/commit/e3fb072d0225fee400a7d0f8106dd555f950a6bd) Updated emacs
* [`fed34a0e`](https://github.com/nix-community/emacs-overlay/commit/fed34a0eef8e579e006806e5b8df427d5519b7f4) Revert "Revert "Update bytecomp-revert.patch""
* [`c4a8dedd`](https://github.com/nix-community/emacs-overlay/commit/c4a8dedd3f96f3ebe57edb627bb9150fcb4f12bc) Revert "Revert "fixup! Update bytecomp-revert.patch""
* [`3d54e9e2`](https://github.com/nix-community/emacs-overlay/commit/3d54e9e2478562d784f2a01e61c8f1c0b9c91748) Revert "Revert "Revert "fixup! Update bytecomp-revert.patch"""
* [`a8b69407`](https://github.com/nix-community/emacs-overlay/commit/a8b694071f2159f2f0e6c08cbe5bb18abb6fad40) Revert "Revert "Revert "Update bytecomp-revert.patch"""
* [`8fec7971`](https://github.com/nix-community/emacs-overlay/commit/8fec797146cc0d2b309b2017feae0ae3d39db78c) Revert "Updated emacs"
* [`b61ae954`](https://github.com/nix-community/emacs-overlay/commit/b61ae954d6ccb73f9d650c107e5eef594861d7ee) Revert "Merge pull request [nix-community/emacs-overlay⁠#378](https://togithub.com/nix-community/emacs-overlay/issues/378) from Vonfry/revert/disable-emacs"
* [`ac761af6`](https://github.com/nix-community/emacs-overlay/commit/ac761af646d27dade521104de298dd4a7032c508) Updated elpa
* [`3d2bac98`](https://github.com/nix-community/emacs-overlay/commit/3d2bac987331c70ff44594ad5b2e298a5572c529) Reset GIT_PAGER
* [`f1d372c3`](https://github.com/nix-community/emacs-overlay/commit/f1d372c3cc8c5524c6f0c937a5629365203c351b) Updated elpa
* [`037752e5`](https://github.com/nix-community/emacs-overlay/commit/037752e56a049798a44a9a07dec53617bdba5bc0) Updated melpa
* [`1f1b99ff`](https://github.com/nix-community/emacs-overlay/commit/1f1b99ff99e4603e9ecbd218f1611c50c32baf53) Updated flake inputs
* [`2cb3fceb`](https://github.com/nix-community/emacs-overlay/commit/2cb3fceb716d51d798a2efe63926e56b502ecc0b) Updated elpa
* [`80065986`](https://github.com/nix-community/emacs-overlay/commit/80065986c87ca583b979ad83ddb62a7d70d24a45) Updated melpa
* [`c4e45eff`](https://github.com/nix-community/emacs-overlay/commit/c4e45eff568029ef3309817cb4610f04be604353) Updated melpa
* [`46787d20`](https://github.com/nix-community/emacs-overlay/commit/46787d2076b8a828425daffb81e64acdbb8fa2b8) Updated flake inputs
* [`fb0d8b86`](https://github.com/nix-community/emacs-overlay/commit/fb0d8b86460a2eaba3bea2dcae5346a24aab0822) Updated nongnu
* [`5872f588`](https://github.com/nix-community/emacs-overlay/commit/5872f588832d7db88fa8471b87878e4a409718ed) Updated elpa
* [`9206a7ac`](https://github.com/nix-community/emacs-overlay/commit/9206a7acdc0dd951d5d229b09405c7c6205bcef4) Updated melpa
* [`fb4a5d51`](https://github.com/nix-community/emacs-overlay/commit/fb4a5d5160bb70801603b46e4a1bc4623c945694) Updated flake inputs
* [`94b6e684`](https://github.com/nix-community/emacs-overlay/commit/94b6e68490568844771f136728d551af61c3f0bb) Updated elpa
* [`80810571`](https://github.com/nix-community/emacs-overlay/commit/80810571751109b3d71213763c7197f1128b7898) Updated melpa
* [`6a88aa2f`](https://github.com/nix-community/emacs-overlay/commit/6a88aa2f7cd8e96ca5abc9433c7aea997a4f794e) Updated melpa
* [`b6d2d8bd`](https://github.com/nix-community/emacs-overlay/commit/b6d2d8bde643a02e3bc74ecd15a534c31ea328c1) Updated elpa
* [`5e4e57b1`](https://github.com/nix-community/emacs-overlay/commit/5e4e57b1e3aecf7318550156aebd6605c00e1eb7) Updated melpa
* [`4b77b102`](https://github.com/nix-community/emacs-overlay/commit/4b77b102b4dfef209af4875478dabcde03e4dea5) Updated elpa
* [`0bb376d4`](https://github.com/nix-community/emacs-overlay/commit/0bb376d47272738f7c720f03f1098b96ad3ea0f6) Updated melpa
* [`85ac1bf8`](https://github.com/nix-community/emacs-overlay/commit/85ac1bf8543d2e179d7748f3788d58b06eacc758) Updated melpa
* [`4a17d22f`](https://github.com/nix-community/emacs-overlay/commit/4a17d22f425279621da0e9a3060031e5769ede0e) Updated flake inputs
* [`96a2809f`](https://github.com/nix-community/emacs-overlay/commit/96a2809fba7398dec610a5367c219d03dde07bf9) Updated elpa
* [`3ada6ddb`](https://github.com/nix-community/emacs-overlay/commit/3ada6ddb60f9313cb2ac977106605e09c857ffec) Updated melpa
* [`fd1709ea`](https://github.com/nix-community/emacs-overlay/commit/fd1709ea259d3b2d02ef4f7b5f33886d93313305) Updated elpa
* [`f769dc27`](https://github.com/nix-community/emacs-overlay/commit/f769dc272f7645f0ec7c50ca79490cef15123e25) Updated melpa
* [`3bfd4b27`](https://github.com/nix-community/emacs-overlay/commit/3bfd4b274002a4dbbead2d61c93437c5458fed84) Updated melpa
* [`581db622`](https://github.com/nix-community/emacs-overlay/commit/581db622349edd9c3b1110999fd942e1d3271728) Updated elpa
* [`8966ec83`](https://github.com/nix-community/emacs-overlay/commit/8966ec83cb59493c07a06c12d25f0d7439abfe5e) Updated melpa
* [`475d3b2d`](https://github.com/nix-community/emacs-overlay/commit/475d3b2df3e517d96b60bfa08bf7dfe226b51d5e) Updated elpa
* [`2e23449b`](https://github.com/nix-community/emacs-overlay/commit/2e23449b445bbe200c9bd8e880662747ef99e4ae) Updated melpa
* [`0ed4fcf5`](https://github.com/nix-community/emacs-overlay/commit/0ed4fcf55a8d866cfc0f4dcfc37158634da8d251) Updated flake inputs
* [`3a855a7a`](https://github.com/nix-community/emacs-overlay/commit/3a855a7a6f5f092ef81b45416c84f794b076f7ed) Updated melpa
* [`aa5b925d`](https://github.com/nix-community/emacs-overlay/commit/aa5b925d130417c34a20dc90e50c9812a70f7d9e) Updated nongnu
* [`6ca69191`](https://github.com/nix-community/emacs-overlay/commit/6ca691917cbb7a260a58168544d757b915d901ec) Updated elpa
* [`e765064d`](https://github.com/nix-community/emacs-overlay/commit/e765064de63acb093a8ecb4483dd76860f4d9c70) Updated melpa
* [`ab8a9be4`](https://github.com/nix-community/emacs-overlay/commit/ab8a9be49670ca7e8a208de44bfc848ee480560a) Updated elpa
* [`bb6e486a`](https://github.com/nix-community/emacs-overlay/commit/bb6e486a9fcb96868b15741ff4ee446cc731db43) Updated melpa
* [`223007e4`](https://github.com/nix-community/emacs-overlay/commit/223007e4c62a86896fc662af5f9fd21a11cdb41b) Updated melpa
* [`b5387363`](https://github.com/nix-community/emacs-overlay/commit/b538736308576dcf3665e784ecd83c6d249efcb0) Updated elpa
* [`5126615a`](https://github.com/nix-community/emacs-overlay/commit/5126615a62f93c7b2311eb9180e420e460ed8515) Updated melpa
* [`2e9e4ff1`](https://github.com/nix-community/emacs-overlay/commit/2e9e4ff10f436778688759f440917228373b2e82) Updated elpa
* [`58305b28`](https://github.com/nix-community/emacs-overlay/commit/58305b28029922b981f333229500e9ff34896c72) Updated melpa
* [`dbcecbaa`](https://github.com/nix-community/emacs-overlay/commit/dbcecbaa6f0e7b59851c395a23dad531efe4b17d) Updated flake inputs
* [`4118d09e`](https://github.com/nix-community/emacs-overlay/commit/4118d09e3b6613425c4d48f4aa4b2ed944e5b801) Updated melpa
* [`96b3adef`](https://github.com/nix-community/emacs-overlay/commit/96b3adefc7df872692b6263a50431662e4426cd6) Updated flake inputs
* [`15237ecc`](https://github.com/nix-community/emacs-overlay/commit/15237ecc6c37985dcb55574d6df249d333f0dff7) Updated elpa
* [`e5d3e66b`](https://github.com/nix-community/emacs-overlay/commit/e5d3e66bb146b77a9c978533dfb6028b9248f2fa) Updated melpa
* [`6f6f6689`](https://github.com/nix-community/emacs-overlay/commit/6f6f66894593df01cc015a74087a27998792c293) Updated flake inputs
* [`4f711094`](https://github.com/nix-community/emacs-overlay/commit/4f7110943cbceeda940b4253e3e22373725dd114) Updated elpa
* [`9b35a20a`](https://github.com/nix-community/emacs-overlay/commit/9b35a20ab70da97fd1266ce816dd4104f89c88b9) Updated melpa
* [`2dc2fe68`](https://github.com/nix-community/emacs-overlay/commit/2dc2fe681e05c9bf79755ef605c6a100a510361f) Updated melpa
* [`aa348140`](https://github.com/nix-community/emacs-overlay/commit/aa3481405e2bcb7f5c7c20c72198fcf0f96057a6) Updated elpa
* [`4b0b67c3`](https://github.com/nix-community/emacs-overlay/commit/4b0b67c374297a8dd880fbfc13eddf495197b308) Updated melpa
* [`b1042ceb`](https://github.com/nix-community/emacs-overlay/commit/b1042cebf0e7cf4a8a805c590f67dcd0c398c0fd) Updated nongnu
* [`c19de550`](https://github.com/nix-community/emacs-overlay/commit/c19de550027db6d9d1ba85b63b4cb78fdf73ee00) Updated elpa
* [`905528b5`](https://github.com/nix-community/emacs-overlay/commit/905528b5c9c5eac4c82c86493aec69f85ea1c050) Updated melpa
* [`fcd7c360`](https://github.com/nix-community/emacs-overlay/commit/fcd7c360c3f73ec91da70155df6d9a413e4bd128) Updated melpa
* [`9a5b785e`](https://github.com/nix-community/emacs-overlay/commit/9a5b785e55d35fcbbb50c5098cc78917c1a924d4) Updated elpa
* [`7931d882`](https://github.com/nix-community/emacs-overlay/commit/7931d882cdb5ce330571f583e989117fdfa808f1) Updated melpa
* [`f7a9453d`](https://github.com/nix-community/emacs-overlay/commit/f7a9453dc2173a9cf64fd59ae7a11d9c0aa8ac8b) Updated nongnu
* [`3ad4e810`](https://github.com/nix-community/emacs-overlay/commit/3ad4e8104948385481e9d1cc37405818f46d9ab4) Updated elpa
* [`9e423719`](https://github.com/nix-community/emacs-overlay/commit/9e423719e0c85a4624813489080636f4d696fa3e) Updated melpa
* [`8363635c`](https://github.com/nix-community/emacs-overlay/commit/8363635cc3d70d8869e3ead707eb01e03a203f78) Updated melpa
* [`c11eac23`](https://github.com/nix-community/emacs-overlay/commit/c11eac23245ed3571df6eef40831422a3d49ad18) Updated elpa
* [`53b4803d`](https://github.com/nix-community/emacs-overlay/commit/53b4803d6cb623b5b4e3540af99e1b356bbc7f30) Updated melpa
* [`7d39cb04`](https://github.com/nix-community/emacs-overlay/commit/7d39cb04455e9f6335409f30aff5b4fd058357bb) Updated elpa
* [`37f90a02`](https://github.com/nix-community/emacs-overlay/commit/37f90a0217cea4a976895240059bb45a904b84e4) Updated melpa
* [`8a3a40fd`](https://github.com/nix-community/emacs-overlay/commit/8a3a40fdad4a0fa56f98bf0b53db631a9367680b) Updated melpa
* [`c0376182`](https://github.com/nix-community/emacs-overlay/commit/c0376182b057f1aa71c34075320f3e3309466d8a) Updated flake inputs
* [`adf6870c`](https://github.com/nix-community/emacs-overlay/commit/adf6870cdaf54d033ba7e5954090734c52156480) Updated elpa
* [`9fa1fdb2`](https://github.com/nix-community/emacs-overlay/commit/9fa1fdb259360c2d7b45bb3f4003a83b5f9f809e) Updated melpa
* [`9a132afd`](https://github.com/nix-community/emacs-overlay/commit/9a132afd3eb09b2d64b32823019774b73775620c) Updated elpa
* [`6bd9fd95`](https://github.com/nix-community/emacs-overlay/commit/6bd9fd951f5306ff81c01c38bc0e5773947aa349) Updated melpa
* [`b36b61e6`](https://github.com/nix-community/emacs-overlay/commit/b36b61e6161891b596271b017f5774f9441b516b) Updated melpa
* [`4247dbb7`](https://github.com/nix-community/emacs-overlay/commit/4247dbb7670026b1fab04ffe1f7f9a5b4703ad4e) Updated flake inputs
* [`386dd8a7`](https://github.com/nix-community/emacs-overlay/commit/386dd8a72c1f67f1d2cf7ef298a207b616954723) Updated nongnu
* [`5de811b8`](https://github.com/nix-community/emacs-overlay/commit/5de811b8eb256adc08733ced7271fc89f7a40278) Updated elpa
* [`d28ef513`](https://github.com/nix-community/emacs-overlay/commit/d28ef513693ace9f18ffb90948169bfa3c61f6af) Updated melpa
* [`3b9c536c`](https://github.com/nix-community/emacs-overlay/commit/3b9c536c66615b8f03ea73c605501eb2bec33e3e) Updated elpa
* [`c114295b`](https://github.com/nix-community/emacs-overlay/commit/c114295bcec0eb9f036e0d893e09e1bffdf3e84e) Updated melpa
* [`bd632887`](https://github.com/nix-community/emacs-overlay/commit/bd632887992dea09e08244c2f7c632c3590ab9dc) Updated flake inputs
* [`3efb3670`](https://github.com/nix-community/emacs-overlay/commit/3efb36706c4c97569002e13d4072640f00a0b14e) Updated melpa
* [`bb990abe`](https://github.com/nix-community/emacs-overlay/commit/bb990abe0aec2f288bbd547b872d95c70fa5b2eb) Updated elpa
* [`0272f041`](https://github.com/nix-community/emacs-overlay/commit/0272f04189d187055b300c77178cce855382cc55) Updated melpa
* [`9ad02597`](https://github.com/nix-community/emacs-overlay/commit/9ad0259722fd75ed4402d5e8cf1393ddf94a4928) Updated flake inputs
* [`d2a68273`](https://github.com/nix-community/emacs-overlay/commit/d2a68273c0a309d78c6e654602bf5c087f401d61) Updated elpa
* [`ed25d979`](https://github.com/nix-community/emacs-overlay/commit/ed25d9799f2251666a0e8749a15f4301ebf37a1b) Updated melpa
* [`7e2ecc36`](https://github.com/nix-community/emacs-overlay/commit/7e2ecc3654c3daa74a1f72826cac9b8fd13a7f06) Updated melpa
* [`5ae3690b`](https://github.com/nix-community/emacs-overlay/commit/5ae3690b9a643950743bc5890f778b31a5d76c00) Updated elpa
* [`70164fbf`](https://github.com/nix-community/emacs-overlay/commit/70164fbf83cdcd4d3772db6193a5b402716271e5) Updated melpa
* [`686f6c59`](https://github.com/nix-community/emacs-overlay/commit/686f6c59c4db2ff550f48ff9b767d6d53e8ca0cd) Updated elpa
* [`9aaefc4e`](https://github.com/nix-community/emacs-overlay/commit/9aaefc4e713561e39a642e2a645777528b40fbdb) Updated melpa
* [`39f23b18`](https://github.com/nix-community/emacs-overlay/commit/39f23b184ca4b191fbef420ba3f6f63a0895d68b) Updated melpa
* [`4baba64e`](https://github.com/nix-community/emacs-overlay/commit/4baba64e8088c2cdbde661d6697d1fff3ba59f6d) Manually update emacs-unstable for 29.2 release
* [`10ebdcc9`](https://github.com/nix-community/emacs-overlay/commit/10ebdcc9777f3accf780ff2a66da3052445a05b6) Updated flake inputs
* [`4e2567af`](https://github.com/nix-community/emacs-overlay/commit/4e2567af3a540d4c9e5512b3f70589b9d7ec181b) Updated elpa
* [`68ce1f4f`](https://github.com/nix-community/emacs-overlay/commit/68ce1f4f6c8d1c0fc9ee3d9febac9fd62e527647) Updated melpa
* [`eeb8da16`](https://github.com/nix-community/emacs-overlay/commit/eeb8da168b6882e54d66b960a2ee9490663b6a7d) Updated flake inputs
* [`eaf998b4`](https://github.com/nix-community/emacs-overlay/commit/eaf998b4ab1397000afeeced036fcb55e61750dd) Updated elpa
* [`397f91d9`](https://github.com/nix-community/emacs-overlay/commit/397f91d98f2bd0d81ce54b15ad6bf457a8dc536a) Updated melpa
* [`dc3dafe4`](https://github.com/nix-community/emacs-overlay/commit/dc3dafe421095791e2dacf2b03e1686365160d35) Updated melpa
* [`ad687a09`](https://github.com/nix-community/emacs-overlay/commit/ad687a09864a19b45a00d02ee8cebd13760113ef) Updated elpa
* [`e812fbf7`](https://github.com/nix-community/emacs-overlay/commit/e812fbf7ec5c1e9fa44fb74a3f456cdf68fb7a4f) Updated melpa
* [`fd002eb7`](https://github.com/nix-community/emacs-overlay/commit/fd002eb789e61b5c213c531f0e5973d98c0a2688) Updated flake inputs
* [`2876e264`](https://github.com/nix-community/emacs-overlay/commit/2876e264544034fa2f8ac06faec09b87a9a6c916) Updated elpa
* [`fcc7bd71`](https://github.com/nix-community/emacs-overlay/commit/fcc7bd71eadb8041dab9e97c237ae12873be627a) Updated melpa
* [`fd04cba8`](https://github.com/nix-community/emacs-overlay/commit/fd04cba897ffc741d08eceee8cb4d4058177eb5d) Updated melpa
* [`90dfac9d`](https://github.com/nix-community/emacs-overlay/commit/90dfac9d46c86246b7fac16c689b5e5492bf9b2c) Revert "Temporarily disable "emacs" update"
* [`ceacea3b`](https://github.com/nix-community/emacs-overlay/commit/ceacea3bc70890c816cd616ec2a7af5ff93d6f4c) Revert "Revert "Revert "Revert "Update bytecomp-revert.patch""""
* [`7744578a`](https://github.com/nix-community/emacs-overlay/commit/7744578ae998127cef9002949f84778e6775a2c8) Revert "Revert "Revert "Revert "fixup! Update bytecomp-revert.patch""""
* [`2db8934d`](https://github.com/nix-community/emacs-overlay/commit/2db8934d6ec0a50effad0cf4dfbcdd496d0d2fdc) Update emacs
* [`e574b56c`](https://github.com/nix-community/emacs-overlay/commit/e574b56c87d7894f1cb14dacf38ff5c4a5082431) elisp: Tangle org-mode files when used with defaultInitFile
* [`d3944caa`](https://github.com/nix-community/emacs-overlay/commit/d3944caa140aa7ee67b0238ec3a19a910e4a4050) Updated emacs
* [`c4615217`](https://github.com/nix-community/emacs-overlay/commit/c4615217bce56ec45cff6be1a91bba17ac4b4de0) Updated flake inputs
* [`446a8bee`](https://github.com/nix-community/emacs-overlay/commit/446a8bee5f191ec899ba7eb33c507a3187146d2a) Updated nongnu
* [`19aeab9b`](https://github.com/nix-community/emacs-overlay/commit/19aeab9b06a80467836db74d673421027f29bf3f) Updated emacs
* [`eb1e63bf`](https://github.com/nix-community/emacs-overlay/commit/eb1e63bfb52352f35edc63d39b70ad4a186e132c) Updated elpa
* [`340aa2c0`](https://github.com/nix-community/emacs-overlay/commit/340aa2c0aa86961ed4cc818885e245660d6bc611) Updated melpa
* [`2595ca99`](https://github.com/nix-community/emacs-overlay/commit/2595ca99db800f3be0759aae85d0cf44a231732c) Updated emacs
* [`79e0d240`](https://github.com/nix-community/emacs-overlay/commit/79e0d24045abb888a0c1e039c5c8c7349162bc28) Updated melpa
* [`3135b0f4`](https://github.com/nix-community/emacs-overlay/commit/3135b0f49fab65ff105d0a6f6eeceae184b335cb) Updated elpa
* [`cfc3478a`](https://github.com/nix-community/emacs-overlay/commit/cfc3478a947fd0296e9d834269bb77f9814d9de3) Updated flake inputs
* [`8f9a6e38`](https://github.com/nix-community/emacs-overlay/commit/8f9a6e38cb3c57dad69656722474f38dd301d898) Updated emacs
* [`7ead5922`](https://github.com/nix-community/emacs-overlay/commit/7ead5922cd7e28b488040ae600ab079578220b3e) Updated elpa
* [`ee992c3b`](https://github.com/nix-community/emacs-overlay/commit/ee992c3b9fac56c40e79c958e5241250feccd336) Updated melpa
* [`48fa5dcf`](https://github.com/nix-community/emacs-overlay/commit/48fa5dcf1a3b3d412aad5fb54440d01c357c5265) Updated emacs
* [`83731bc2`](https://github.com/nix-community/emacs-overlay/commit/83731bc2f68f485e843534da607f374f75b4f0bd) Updated melpa
* [`7906c257`](https://github.com/nix-community/emacs-overlay/commit/7906c2578426d2f0dfc42d4a585896f38f5f8731) Updated flake inputs
* [`207d3343`](https://github.com/nix-community/emacs-overlay/commit/207d3343f36c098cefab8c920a67309e436b3243) Updated elpa
* [`90b1750b`](https://github.com/nix-community/emacs-overlay/commit/90b1750b38194c49eb99a9074b6fc7f24956fd4b) Updated emacs
* [`6474bb55`](https://github.com/nix-community/emacs-overlay/commit/6474bb55cdc31790ce7911a501689b3099985c09) Updated melpa
* [`f2304fe5`](https://github.com/nix-community/emacs-overlay/commit/f2304fe5b19fd1554a977eaf905cd82bd6186f0e) Updated nongnu
* [`d87c4688`](https://github.com/nix-community/emacs-overlay/commit/d87c4688208b04e4c1d49090ce19a46eb6031209) Updated emacs
* [`e58b822a`](https://github.com/nix-community/emacs-overlay/commit/e58b822a7c3de3e2445982da0630eb5dbd58e72d) Updated elpa
* [`7f898abe`](https://github.com/nix-community/emacs-overlay/commit/7f898abe4a56b56b9f5b13dec1af0132b1950642) Updated melpa
* [`0ba82576`](https://github.com/nix-community/emacs-overlay/commit/0ba825768579730f1db48b74245e9948df3875db) Updated emacs
* [`e2953343`](https://github.com/nix-community/emacs-overlay/commit/e2953343aa80377bb1f486f46ef5553b5570753e) Updated melpa
* [`667d22e0`](https://github.com/nix-community/emacs-overlay/commit/667d22e0dd361093efa024dfe30fd1b3334676b3) Updated flake inputs
* [`cfbcb6f4`](https://github.com/nix-community/emacs-overlay/commit/cfbcb6f4cdf4a206bc3bf51abb6b5c7f27700932) Updated emacs
* [`1060b97c`](https://github.com/nix-community/emacs-overlay/commit/1060b97c199bf5abff50bf09c7983250e749d884) Updated elpa
* [`b47e82db`](https://github.com/nix-community/emacs-overlay/commit/b47e82dbcfdfa4b6ce844565707b51fde1b58988) Updated melpa
* [`d6772c6c`](https://github.com/nix-community/emacs-overlay/commit/d6772c6c105d28dcd1f7763aa507b9cdddee249c) Try removing the bytecomp-revert.patch
* [`ea1f9f60`](https://github.com/nix-community/emacs-overlay/commit/ea1f9f60b6530698e2340c7798229355500bbfb2) Revert "Try removing the bytecomp-revert.patch"
* [`0c3c8702`](https://github.com/nix-community/emacs-overlay/commit/0c3c87020fcca200978143698e85d5846a47bb2c) Updated emacs
* [`71b38b13`](https://github.com/nix-community/emacs-overlay/commit/71b38b1324939cd53b0b3c31d4a82aec238ae1af) Updated elpa
* [`24b4024a`](https://github.com/nix-community/emacs-overlay/commit/24b4024af8327b64067d97dd9d98e635ffd9beca) Updated melpa
* [`3cdb6ec1`](https://github.com/nix-community/emacs-overlay/commit/3cdb6ec1b4c537b72395f9f09f5a573f80315166) Updated emacs
* [`46d30fde`](https://github.com/nix-community/emacs-overlay/commit/46d30fdef02008e5f1856d4039a0b48d20a3bca6) Updated melpa
* [`0d6e23e8`](https://github.com/nix-community/emacs-overlay/commit/0d6e23e87da95a64b1f4aa871bddd1640708c767) Updated emacs
* [`e3b7bb7f`](https://github.com/nix-community/emacs-overlay/commit/e3b7bb7fffddec090d20fc805aa9717a550b7d5a) Updated elpa
* [`697e5806`](https://github.com/nix-community/emacs-overlay/commit/697e580696334fa0d85276b98f484e03fa88dc83) Updated melpa
* [`fca275c0`](https://github.com/nix-community/emacs-overlay/commit/fca275c0dad55e519073df9552ccb34dd1fc08fc) Updated nongnu
* [`5b427ea1`](https://github.com/nix-community/emacs-overlay/commit/5b427ea16e8c0e9510d1afcd98bb1e7f51ef8f07) Updated emacs
* [`fdd86a5e`](https://github.com/nix-community/emacs-overlay/commit/fdd86a5eb908203d3bac9f694960508a8182b601) Updated elpa
* [`cefc21a7`](https://github.com/nix-community/emacs-overlay/commit/cefc21a743a96cf996c4f09e141317e74e7ae794) Updated melpa
* [`dd5d758f`](https://github.com/nix-community/emacs-overlay/commit/dd5d758f69dd1ae6d0399763aa73ca34974ce9e3) Updated emacs
* [`f551c97d`](https://github.com/nix-community/emacs-overlay/commit/f551c97d8bb48bd7fe95bc6819f64e8aada4d76e) Revert "repos/emacs: And also remove no-out-link"
* [`1da43661`](https://github.com/nix-community/emacs-overlay/commit/1da43661dec36a276fbae4c4c78f79c3a084328d) Revert "repos/emacs: Only instantiate derivations on update, dont build"
* [`b141adfd`](https://github.com/nix-community/emacs-overlay/commit/b141adfd12559af3a9fb73f9ba6a70703e4abc25) Updated flake inputs
* [`ac7a6bb9`](https://github.com/nix-community/emacs-overlay/commit/ac7a6bb962205862337d8034b04c98d6059f604d) Updated elpa
* [`f955f653`](https://github.com/nix-community/emacs-overlay/commit/f955f65318caf28da81fe80f5437c6446dbfa7a3) Updated emacs
* [`fc034627`](https://github.com/nix-community/emacs-overlay/commit/fc0346276e0e2a5abd5bbb9535d96f4ba4d4482c) Updated elpa
* [`a05080ae`](https://github.com/nix-community/emacs-overlay/commit/a05080ae009d2725536f028bc1ac47aedd2344b0) Updated melpa
* [`6d9de841`](https://github.com/nix-community/emacs-overlay/commit/6d9de8417bab707a31f75a9c7a633e581c387385) Updated emacs
* [`babae500`](https://github.com/nix-community/emacs-overlay/commit/babae500c2bca610eb38e17a1ef1bf0f70beb29e) Updated emacs
* [`fe9774e2`](https://github.com/nix-community/emacs-overlay/commit/fe9774e2308a9efbfb83c1f1c0b69d9db3581649) Updated elpa
* [`89ef4839`](https://github.com/nix-community/emacs-overlay/commit/89ef483952c2f5d1a4d8e52be846a6c20fd6be64) Updated emacs
* [`77ab1e5b`](https://github.com/nix-community/emacs-overlay/commit/77ab1e5b58f46c48b78e47bcd3d727459740cb57) Updated flake inputs
* [`27805cce`](https://github.com/nix-community/emacs-overlay/commit/27805ccec0cd57b4dd2e6768f9df769d3e62ca77) Updated elpa
* [`e0252ec4`](https://github.com/nix-community/emacs-overlay/commit/e0252ec480bc1e09b95f0fd044921972dfca45aa) Updated emacs
* [`44a03f57`](https://github.com/nix-community/emacs-overlay/commit/44a03f57c31e3fb4323410988389278a4f2f7999) Updated emacs
* [`f33d4946`](https://github.com/nix-community/emacs-overlay/commit/f33d4946fa34a82e9c0580ab95813445b6659da3) Updated elpa
* [`d8b97372`](https://github.com/nix-community/emacs-overlay/commit/d8b97372ee6f5024ef715da603e40a62cc1f9703) Updated emacs
* [`d423c8ca`](https://github.com/nix-community/emacs-overlay/commit/d423c8ca41a06c35a733d408c17f733ab8327f0a) Updated elpa
* [`d6d5dd09`](https://github.com/nix-community/emacs-overlay/commit/d6d5dd09b6533a30e3b312f0f225bd3475733f23) Updated emacs
* [`a26ccf07`](https://github.com/nix-community/emacs-overlay/commit/a26ccf07b81aa26a4e7ee4c58f4a0f9d919e642a) Updated emacs
* [`7c2ab8b3`](https://github.com/nix-community/emacs-overlay/commit/7c2ab8b3dc60b7f2d0d492472d0b6f1444712a21) Updated nongnu
* [`eff17f93`](https://github.com/nix-community/emacs-overlay/commit/eff17f93e92eaa9ff77c79c1783d36267ce88450) Updated elpa
* [`87bfbcd2`](https://github.com/nix-community/emacs-overlay/commit/87bfbcd248f3f17040db47b2cc8542033b12d051) Updated emacs
* [`7428bf63`](https://github.com/nix-community/emacs-overlay/commit/7428bf63084f80df50a57903ce020dfac0b50128) Updated flake inputs
* [`bceb8269`](https://github.com/nix-community/emacs-overlay/commit/bceb8269cbe8ed5b80c46dc43c8f5f6b785cbb84) Updated elpa
* [`89b15dc9`](https://github.com/nix-community/emacs-overlay/commit/89b15dc964cd67eeedbeee4d68c5716211cfa0d8) Updated melpa
* [`380a2b90`](https://github.com/nix-community/emacs-overlay/commit/380a2b909774bc47385dfa9556f28f243ea87c71) Updated emacs
* [`bc9d133f`](https://github.com/nix-community/emacs-overlay/commit/bc9d133ffbbcd1e3fe0ed78016deb1345912890b) Updated flake inputs
* [`b22256e6`](https://github.com/nix-community/emacs-overlay/commit/b22256e6623d78a850143a4f381a3175432b7388) Updated nongnu
* [`a9a8e422`](https://github.com/nix-community/emacs-overlay/commit/a9a8e422dffc94c697fb2f5495fbc83b6c64de59) Updated elpa
* [`9f6d6ca6`](https://github.com/nix-community/emacs-overlay/commit/9f6d6ca61c8cf8cc39c2436d538a39d64720f4f7) Updated melpa
* [`bf073f54`](https://github.com/nix-community/emacs-overlay/commit/bf073f540fd96d1c5f3faf56a7f4664c8bb49ede) Updated emacs
* [`248e2664`](https://github.com/nix-community/emacs-overlay/commit/248e26643010de9f5dd61d4c4d592b72c6f2d16f) Updated nongnu
* [`de3f66c6`](https://github.com/nix-community/emacs-overlay/commit/de3f66c6abccf36c44a642b4dfa48d6326d0292e) Updated elpa
* [`b7295450`](https://github.com/nix-community/emacs-overlay/commit/b7295450764fe32f3e478e31c4121bf05a6bc8a5) Updated melpa
* [`392cb00f`](https://github.com/nix-community/emacs-overlay/commit/392cb00f9e019b9ec1ef4eb530ac0cfb2ddd32e3) Updated emacs
* [`852652c2`](https://github.com/nix-community/emacs-overlay/commit/852652c248f0448153dec4e1882ba04f6d02ac74) Fix geiser hash
* [`276530c6`](https://github.com/nix-community/emacs-overlay/commit/276530c68ca828bf33d2af230f73fe8a49778209) Updated melpa
* [`4224d726`](https://github.com/nix-community/emacs-overlay/commit/4224d7269955e4cab294384f7ba8daed73810946) Updated emacs
* [`00418d6b`](https://github.com/nix-community/emacs-overlay/commit/00418d6b797f9cf85245cd014a6df4617961bcfe) Updated elpa
* [`630458ac`](https://github.com/nix-community/emacs-overlay/commit/630458acbc94c79af0c4eb26dd9ac26532e31d5a) Updated melpa
* [`eb3071f9`](https://github.com/nix-community/emacs-overlay/commit/eb3071f959d2c4bd6eccd2176d43f33ccfbfb3b1) Updated emacs
* [`d34f17e6`](https://github.com/nix-community/emacs-overlay/commit/d34f17e62858894d8dbfd75c238dec79e5c0c62f) Updated flake inputs
* [`c1d91c19`](https://github.com/nix-community/emacs-overlay/commit/c1d91c199c6408abd286e7f65a89e3c246ece16d) Updated elpa
* [`4f8c4bbe`](https://github.com/nix-community/emacs-overlay/commit/4f8c4bbe1684ec4c6799454b89c66a439cb79433) Updated melpa
* [`6ed1948d`](https://github.com/nix-community/emacs-overlay/commit/6ed1948db6bf8b21ba2d25b3e2d9a45c0176b166) Updated emacs
* [`45ee2dda`](https://github.com/nix-community/emacs-overlay/commit/45ee2dda7788c6f6adab331b904495f1fd95ae7e) Updated flake inputs
* [`33e73c7e`](https://github.com/nix-community/emacs-overlay/commit/33e73c7e349b88ca393b5613c2b230cb82154eac) Updated melpa
* [`2d69eefb`](https://github.com/nix-community/emacs-overlay/commit/2d69eefbcadbac97bda477477cd53c0ef815f436) Updated emacs
* [`8db120f2`](https://github.com/nix-community/emacs-overlay/commit/8db120f2369ed54f570dcc146b244559468a2f6e) Updated elpa
* [`512b3890`](https://github.com/nix-community/emacs-overlay/commit/512b3890a5bc20a6d9996dfdda4ca2276194eba8) Updated melpa
* [`ca826bd6`](https://github.com/nix-community/emacs-overlay/commit/ca826bd6f5311300e47847adca289e580376d8ff) Updated emacs
* [`bc072d9c`](https://github.com/nix-community/emacs-overlay/commit/bc072d9cca7c696b5167d352e20728515938f677) Updated nongnu
