### PR TITLE
niv doomemacs: update 03d692f1 -> ff33ec8f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "03d692f129633e3bf0bd100d91b3ebf3f77db6d1",
-        "sha256": "0p6f481237ddiib8lxvl5qndyfhz9ribxwzz6ns0n6lkzzlh7m1x",
+        "rev": "ff33ec8f7a89d168ca533612e2562883c89e029f",
+        "sha256": "093linm3d9rp529s462lihdf3jy4zn299sgla1v1hr3wr55v6898",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/03d692f129633e3bf0bd100d91b3ebf3f77db6d1.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/ff33ec8f7a89d168ca533612e2562883c89e029f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@03d692f1...ff33ec8f](https://github.com/doomemacs/doomemacs/compare/03d692f129633e3bf0bd100d91b3ebf3f77db6d1...ff33ec8f7a89d168ca533612e2562883c89e029f)

* [`19482ee5`](https://github.com/doomemacs/doomemacs/commit/19482ee5823b426969574a4cc45302b9257efd04) feat(latex): allow fill-paragraph in description
* [`1ee42940`](https://github.com/doomemacs/doomemacs/commit/1ee429406bc24055d18ab0dfaee5f29b8fbc301d) fix(org): restart org-mode before indirect buffer
* [`2b54b573`](https://github.com/doomemacs/doomemacs/commit/2b54b5732c8b01c70a543db970b32b9a91602deb) docs(lib): improve docs of doom-file-read/-write
* [`efe8d476`](https://github.com/doomemacs/doomemacs/commit/efe8d476bcca6c0ef64ee0538c32b1a3f4733c25) fix(lib): use unibyte in binary temp buffers
* [`fcf63d61`](https://github.com/doomemacs/doomemacs/commit/fcf63d615a1cb3837e051f24d76fe2630bf714fd) tweak(lib): write elisp in escaped form to files
* [`dca4e4a8`](https://github.com/doomemacs/doomemacs/commit/dca4e4a8ed41e0a025d41500297d6fa662d8e22b) fix(popup): find internal major side windows
* [`41289cfe`](https://github.com/doomemacs/doomemacs/commit/41289cfef6fcf785a0b789d0dd6c8fdeff9acb09) fix(lib): doom/bumpify-diff: respect structure of given list
* [`68d59f72`](https://github.com/doomemacs/doomemacs/commit/68d59f726d1d8b40cb0069b43edfff1fedbd37db) bump: :term eshell
* [`819f3f11`](https://github.com/doomemacs/doomemacs/commit/819f3f11ccb8f8185dbeb48afd8988a5f0ba6214) bump: :ui doom
* [`c1516edd`](https://github.com/doomemacs/doomemacs/commit/c1516edd66b2cd108f07f1be9ef08db8d9dde2a8) bump: :lang common-lisp
* [`28539824`](https://github.com/doomemacs/doomemacs/commit/2853982447926f561d448ac5f1f15ce2bef836dd) feat(common-lisp): use `sly-asdf`
* [`56b6169a`](https://github.com/doomemacs/doomemacs/commit/56b6169ae739fb67a33746cc5863030b3e4fc6d3) fix(default): read correct manpath on MacOS
* [`8352562b`](https://github.com/doomemacs/doomemacs/commit/8352562b2cff2258075f2349e0695b86fd4e6359) fix(lib): appease byte-compiler-sama
* [`be900213`](https://github.com/doomemacs/doomemacs/commit/be900213300254d384fd55a77a782a7cfe8f346c) fix(cli): ensure local file/dir permissions
* [`f1e77e66`](https://github.com/doomemacs/doomemacs/commit/f1e77e66924d0f32878941e3fdeed8494873d5a1) feat(lib): doom-file-write: separate :mode for directories
* [`a5ffbd85`](https://github.com/doomemacs/doomemacs/commit/a5ffbd85502634a8b291216b589cb936e539bf85) fix: ensure top-level file-name-handler-alist is affected
* [`fcd95a09`](https://github.com/doomemacs/doomemacs/commit/fcd95a09d02b5dc3655c011d76547de454f6c420) nit: minor comment revision, reformatting, & internal refactor
* [`6edb9dfc`](https://github.com/doomemacs/doomemacs/commit/6edb9dfc773028a9de4015aeae8c75418c264d20) tweak(indent-guides): default to bitmap in GUI
* [`ae451ff7`](https://github.com/doomemacs/doomemacs/commit/ae451ff754b975d27de05a114095c815c644d295) docs(vertico): mention `:args` option in docstring
* [`acb5af17`](https://github.com/doomemacs/doomemacs/commit/acb5af177b0a57ca4b05d00d5055d109198e2984) fix(vertico): don't shell-quote consult-ripgrep-args
* [`6275ed7e`](https://github.com/doomemacs/doomemacs/commit/6275ed7e8f67d4633ee83c80336603ee48fff772) bump: :ui modeline
* [`f9137b40`](https://github.com/doomemacs/doomemacs/commit/f9137b40e73ab9054d5500da2759d45e48dc4aa9) docs(idris): add doctor.el
* [`d87c181a`](https://github.com/doomemacs/doomemacs/commit/d87c181aea740a5a628d5689c4e5d034ec640656) fix(upload): ssh-deploy-on-explicit-save = 1
* [`9bfc0ee0`](https://github.com/doomemacs/doomemacs/commit/9bfc0ee0293913d9ede8b1b1eee454cdaa306634) bump: :completion vertico
* [`60e22fd2`](https://github.com/doomemacs/doomemacs/commit/60e22fd2eb614876039db75eb4d2958092a43e2d) refactor(vertico): use consult-fd
* [`7803ea2e`](https://github.com/doomemacs/doomemacs/commit/7803ea2e739438f20b388c6a50ed9b68bccc4843) fix(vertico): consult-project(-root->)-function
* [`cb62ec09`](https://github.com/doomemacs/doomemacs/commit/cb62ec0905afff50d99f8030201a637c5bc3a407) tweak(vertico): use fd’s smart case
* [`25a89491`](https://github.com/doomemacs/doomemacs/commit/25a89491a384a48c2dee56b76fdcb69e9ebdbf2a) nit(vertico): remove default --regex option for fd
* [`76f309ce`](https://github.com/doomemacs/doomemacs/commit/76f309ceb5f223e21638afe9f831fb348f810e99) tweak(vertico): show entire path for fd results
* [`190a3704`](https://github.com/doomemacs/doomemacs/commit/190a37043c772e9652df9f33b694e019df58d5ec) bump: :completion vertico
* [`1584f8a6`](https://github.com/doomemacs/doomemacs/commit/1584f8a61ea064e1fff41609882c20dbde2e975d) fix(vertico): use consult-fd only with new enough fd
* [`828445db`](https://github.com/doomemacs/doomemacs/commit/828445dbfb66355fd1e2f3e244ccc45bc078b722) bump: :completion vertico
* [`38527910`](https://github.com/doomemacs/doomemacs/commit/3852791066a7a3557aa56990b9302e8ed37e5e3f) bump: :tools debugger lsp
* [`46567088`](https://github.com/doomemacs/doomemacs/commit/46567088079a084319b90cc337e47ab34c5f2dd8) bump: :lang python
* [`ff33ec8f`](https://github.com/doomemacs/doomemacs/commit/ff33ec8f7a89d168ca533612e2562883c89e029f) bump: :lang swift
