### PR TITLE
niv nixpkgs: update a7f1a3fd -> 629906e6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a7f1a3fd48e21086e4f74b46dd94f68664854920",
-        "sha256": "0wmrq67npfl91zbgq4ffff8w0v4715n28f6rl9f6ap7l59y9lx5q",
+        "rev": "629906e6a94b0cc022cbbfa6b85a6b9c960e624a",
+        "sha256": "0lq1c8dmrwfwlpwrchk79gh7cn5v4636zp0nn5vwijlbd0mf3jzj",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a7f1a3fd48e21086e4f74b46dd94f68664854920.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/629906e6a94b0cc022cbbfa6b85a6b9c960e624a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a7f1a3fd...629906e6](https://github.com/nixos/nixpkgs/compare/a7f1a3fd48e21086e4f74b46dd94f68664854920...629906e6a94b0cc022cbbfa6b85a6b9c960e624a)

* [`366496e2`](https://github.com/NixOS/nixpkgs/commit/366496e29e978ab41e9dc33e6192260d362cc099) beam-modules: Fix missing quotation marks
* [`ccaf5e5d`](https://github.com/NixOS/nixpkgs/commit/ccaf5e5d342697feacd5f040107bf8c12491ab76) seafile-server: 9.0.6 -> 10.0.1
* [`89e379ac`](https://github.com/NixOS/nixpkgs/commit/89e379ace2b962dcdc4fbc5fa2c91633b8fddcd2) seahub: 9.0.10 -> 10.0.1
* [`a312393f`](https://github.com/NixOS/nixpkgs/commit/a312393f1432d5b39a7215ef8d847c13c007ede3) nixos/seafile: support 9.0 to 10.0 migration
* [`e446bff2`](https://github.com/NixOS/nixpkgs/commit/e446bff28e8571fee066342569b1c21347bef6ec) fakechroot: apply patch to fix crash in __readlinkat_chk
* [`33ea6994`](https://github.com/NixOS/nixpkgs/commit/33ea6994924de53db5f5d54aabbac76bc72bc113) distrobox: 1.5.0.2 -> 1.6.0.1
* [`ac50a9b2`](https://github.com/NixOS/nixpkgs/commit/ac50a9b2d1bc92ec7a30bdb3a9692bafb8fc5df1) libbacktrace: unstable-2022-12-16 -> unstable-2023-11-30
* [`713713b6`](https://github.com/NixOS/nixpkgs/commit/713713b6f4d1874458c982c8069ecf3cde3c98dd) distrobox: update homepage
* [`38c2ef20`](https://github.com/NixOS/nixpkgs/commit/38c2ef20d53cece22c241ed0103f4a59e5648bd6) maintainers: add chito
* [`26ae57c0`](https://github.com/NixOS/nixpkgs/commit/26ae57c0161ce22f385896f2f1aced6cb0ede9fe) alsa-lib: provide wrapper for run-time access to plugins
* [`2523754f`](https://github.com/NixOS/nixpkgs/commit/2523754fb9058b5b3365db2386bb95afc85a9a65) brave: add gtk4
* [`b788592c`](https://github.com/NixOS/nixpkgs/commit/b788592ce55c65cccbb40bd20f582fab3da5d733) cargo-udeps: 0.1.43 -> 0.1.45
* [`067c1958`](https://github.com/NixOS/nixpkgs/commit/067c1958fa35b2b994944da7f4fe3fc7f326e418) protoc-gen-js: init at 3.21.2
* [`dd38622b`](https://github.com/NixOS/nixpkgs/commit/dd38622bab55b9eb96ecc26f0be5d38ee1b89fe0) zitadel: use local plugins for console protobuf generation
* [`c427b7a8`](https://github.com/NixOS/nixpkgs/commit/c427b7a82456779d703e9f5f048467b6fb6872e6) tecla: migrate to by-name hierarchy
* [`d5524221`](https://github.com/NixOS/nixpkgs/commit/d5524221a8a6dbee7d2719141772c055db2b2a45) tecla: refactor and adopt
* [`3799f9d6`](https://github.com/NixOS/nixpkgs/commit/3799f9d63a8a4c88f99dfb8fafe81cea253a8217) quick-lint-js: 2.19.0 -> 3.0.0
* [`ff893386`](https://github.com/NixOS/nixpkgs/commit/ff893386c55f8891db78f8caea23d25aef02280b) nixos/sane: add nixos test
* [`9abc7901`](https://github.com/NixOS/nixpkgs/commit/9abc79018cab8176643fbad06928b65760501cf7) nixos/kresd: fix port only regex
* [`c839d51f`](https://github.com/NixOS/nixpkgs/commit/c839d51fab7ac35d456a0232932c1b12a590e42e) syncthing: 1.27.1 -> 1.27.2
* [`5f6b7a35`](https://github.com/NixOS/nixpkgs/commit/5f6b7a35d636a4f89f0f7d913d3df9522541d23b) neo4j: 4.4.11 -> 5.9.0
* [`345f8000`](https://github.com/NixOS/nixpkgs/commit/345f8000dc49b9aa64931abb3f4a96e8f8c7cb76) maintainers: add minersebas
* [`0e15c844`](https://github.com/NixOS/nixpkgs/commit/0e15c844a9c2c4a2b315b7a7aac40c093663938c) agda: enable debug printing
* [`db876bc6`](https://github.com/NixOS/nixpkgs/commit/db876bc6f68057c6f9d0e5e46fe75992eed21d72) agdaPackages._1lab: disable debug printing
* [`c3061c36`](https://github.com/NixOS/nixpkgs/commit/c3061c36920e57f69ad326bc1a01428112724d44) sendme: init at 0.3.0
* [`a1936ce6`](https://github.com/NixOS/nixpkgs/commit/a1936ce687c4a23a74ed4a1aed24285357f963f0) packagekit: 1.2.5.1pre -> 1.2.8
* [`13f59f80`](https://github.com/NixOS/nixpkgs/commit/13f59f80b9359e14d9ed947c2bd21cb7a9548f23) packagekit: add nixos test to passthru.tests
* [`6ea80253`](https://github.com/NixOS/nixpkgs/commit/6ea8025302457f204f76b620921b8a35866b6738) dynamodb-local: Use JRE minimal
* [`d3332be3`](https://github.com/NixOS/nixpkgs/commit/d3332be38c681b9087511acfc4553816e33ebcad) tests.buildFHSEnv.liblzma: init
* [`92a0043e`](https://github.com/NixOS/nixpkgs/commit/92a0043ecfca662725666a0d29e574d6c3e60a2e) tests.buildFHSEnv.libtinfo: init
* [`ac0b9105`](https://github.com/NixOS/nixpkgs/commit/ac0b910598579a33bfd374580b8849fb89f3c063) rlottie: Switch to CMake
* [`8d51652b`](https://github.com/NixOS/nixpkgs/commit/8d51652b7db0f90f1c293a2b54a6effe1e3fa365) vvvvvv: 2.3.6 -> 2.4
* [`8916797d`](https://github.com/NixOS/nixpkgs/commit/8916797dcecca29019d5f572b933ae9c91d6fa23) maintainers: add peret
* [`566747a2`](https://github.com/NixOS/nixpkgs/commit/566747a27427114bc8bfb65df880f5b8b5193667) parallel-disk-usage: init at 0.9.0
* [`9c9e466d`](https://github.com/NixOS/nixpkgs/commit/9c9e466dc5deb8608fe4e35c6f3b08123ea5dc50) meerk40t: 0.8.1000 -> 0.9.3010
* [`4e6213cc`](https://github.com/NixOS/nixpkgs/commit/4e6213cc1235df8b4e39589e431ef4c8ffbf3c02) jitsi-meet-electron: 2022.10.1 -> 2023.11.3, build from source
* [`0d84bba9`](https://github.com/NixOS/nixpkgs/commit/0d84bba9912c2a4352b87769f3ec1efbde041422) python311Packages.robotframework: 6.1.1 -> 7.0
* [`01bc0e7c`](https://github.com/NixOS/nixpkgs/commit/01bc0e7caa07927fe06919fe172d65f248f5b0d3) qt6Packages.qwlroots: init at 0.1.0
* [`8fcbe295`](https://github.com/NixOS/nixpkgs/commit/8fcbe295ccf935bde92116b088a7999878d2b513) windows.mingw_w64: 10.0.0 -> 11.0.1
* [`fda4c4e2`](https://github.com/NixOS/nixpkgs/commit/fda4c4e2993a5c0f92fc516f6054f1bf85bd8dbc) bintools: disable relro/bindnow hardening on windows
* [`c704d7bb`](https://github.com/NixOS/nixpkgs/commit/c704d7bba3395460bfca33511a4a984a1cd2b4ca) maintainers: add liassica
* [`c75fa516`](https://github.com/NixOS/nixpkgs/commit/c75fa5168e662ef75cbf2302ce3ed61f3f39151d) maintainers: add emilioziniades
* [`d1c42ac3`](https://github.com/NixOS/nixpkgs/commit/d1c42ac35002abd3d751438a59f55cc5f6523f8b) optparse-bash: drop
* [`47cd2c62`](https://github.com/NixOS/nixpkgs/commit/47cd2c62f4707d1bbb37c2bf045ffdb4eecf3c83) add mainProgram to meta
* [`19f38ff3`](https://github.com/NixOS/nixpkgs/commit/19f38ff3d3dcd0a4e2896cb49bf99bf8ae3bb27a) nextcloud-client: drop git suffix from version number, remove unused cmake variable
* [`3755aefc`](https://github.com/NixOS/nixpkgs/commit/3755aefcb91129fcab9608f2864d2b77781ce685) distrobox: hardcode source repo name
* [`4504f46b`](https://github.com/NixOS/nixpkgs/commit/4504f46b9c22dbb3841e461da8b106094e6df2cb) zitadel: 2.40.3 -> 2.42.10
* [`a95da94f`](https://github.com/NixOS/nixpkgs/commit/a95da94f9aae7c543b538bbb991222465605159a) zitadel: use preBuild instead of overriding buildPhase
* [`bda32aac`](https://github.com/NixOS/nixpkgs/commit/bda32aac5c9f31e10c414c603cef3e5b558ec3d4) deepin.dtkcore: remove outdate patch
* [`7e27869a`](https://github.com/NixOS/nixpkgs/commit/7e27869a75e16cb919750ceb1e46d9525f3360b5) deepin: move distribution.info back to deepin-desktop-base
* [`04e1be76`](https://github.com/NixOS/nixpkgs/commit/04e1be760fea99579948d453ca557b4fefc9fbea) python311Packages.unearth: 0.12.1 -> 0.14.0
* [`1dacaf56`](https://github.com/NixOS/nixpkgs/commit/1dacaf5670a93bac331d8921760d7022b50e9734) mix2nix: 0.1.8 -> 0.1.9
* [`3b6e224d`](https://github.com/NixOS/nixpkgs/commit/3b6e224d123b2c3ab84b5e6fa5b056ee4c629c23) tests.buildFHSEnv.libtinfo: fix by using overriden ncurses
* [`d42c54bb`](https://github.com/NixOS/nixpkgs/commit/d42c54bbb73b5f8af767a9b58ac1885414705311) exegol: init at 4.3.1
* [`78a83b66`](https://github.com/NixOS/nixpkgs/commit/78a83b6645c7edbd30c72cd6334dd61f7d563053) maintainers: add _0b11stan
* [`500cd68b`](https://github.com/NixOS/nixpkgs/commit/500cd68bb15e06e216c887caf51e7e43fa960849) umr: unstable-2022-08-23 -> 1.0.8
* [`f5d30774`](https://github.com/NixOS/nixpkgs/commit/f5d30774ec9d24f74a979573333cb281a108db34) umr: use nix-update-script
* [`51d42151`](https://github.com/NixOS/nixpkgs/commit/51d42151e2676d637a188e1b1cad28ff13b87941) opencpn: 5.6.2 -> 5.8.4
* [`e027727e`](https://github.com/NixOS/nixpkgs/commit/e027727e757f495a7d6e9e5c670c4e2a7090bb41) ssl-proxy: unpin go
* [`d6b2103c`](https://github.com/NixOS/nixpkgs/commit/d6b2103c7a2aa56426abde91bdb9b7cb01a01b5c) gama: 2.27 -> 2.28
* [`5b0bd008`](https://github.com/NixOS/nixpkgs/commit/5b0bd008a4c2c3a6051df452f66cba8e29c69c6c) mpdecimal: 2.5.1 -> 4.0.0
* [`b28ae18d`](https://github.com/NixOS/nixpkgs/commit/b28ae18dd01e1284b8485811dea603bd39781441) sigal: 2.3 -> 2.4
* [`390f71d8`](https://github.com/NixOS/nixpkgs/commit/390f71d875a7ae70a1e1677708910d0e5e3f582c) ocamlPackages.ppx_deriving_yaml: 0.2.1 -> 0.2.2
* [`d62c6dea`](https://github.com/NixOS/nixpkgs/commit/d62c6deabdb91fa080bfbd97b5357be7b74de41e) docker_24: remove `LimitNOFILE=infinity` from `docker.service` unit
* [`4d582014`](https://github.com/NixOS/nixpkgs/commit/4d5820142510a66ad396cc043c29c086e6d80c58) omniorb: 4.3.1 -> 4.3.2
* [`bc380d82`](https://github.com/NixOS/nixpkgs/commit/bc380d82a06245860535c27d852fc7f0df0a5f40) bowtie2: 2.5.2 -> 2.5.3
* [`0da890c4`](https://github.com/NixOS/nixpkgs/commit/0da890c472f9ff1cea791a2ac6b2ceb4eec37125) fldigi: 4.2.03 -> 4.2.04
* [`819f41ab`](https://github.com/NixOS/nixpkgs/commit/819f41abefd82ccef60a5b941dfe704871314ce0) gsctl: unpin go
* [`680b0c2b`](https://github.com/NixOS/nixpkgs/commit/680b0c2b268a856f22a6005413af8ad19554bc3d) zfs-autobackup: 3.1.3 -> 3.2
* [`f8a9933b`](https://github.com/NixOS/nixpkgs/commit/f8a9933b814ff5971b2f1096144e872ef9782ad6) circom: 2.1.6 -> 2.1.8
* [`4e65c43b`](https://github.com/NixOS/nixpkgs/commit/4e65c43bc1f8150c37c87c5547d136755d51394d) kubernetes-helm: 3.13.3 -> 3.14.0
* [`a4faeae3`](https://github.com/NixOS/nixpkgs/commit/a4faeae31c23dfe81de03d00f07dd7769ea45809) g4music: 3.4-1 -> 3.5.1
* [`73cfe73f`](https://github.com/NixOS/nixpkgs/commit/73cfe73f78e204544e3849d9d029ef629ee23b61) frida-tools: 12.1.2 -> 12.3.0
* [`8298edd2`](https://github.com/NixOS/nixpkgs/commit/8298edd22f092f686a7c0afaa0f70be74a42d875) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.6.4 -> 1.6.5
* [`fc0c676c`](https://github.com/NixOS/nixpkgs/commit/fc0c676cac739e3eff8b81e349650fa17eb9c4c3) python311Packages.plyvel: 1.5.0 -> 1.5.1
* [`0eae86b7`](https://github.com/NixOS/nixpkgs/commit/0eae86b744f274a19f99d2ced5a0500153b1a0f0) discord: enable text-to-speech by default
* [`89c95c38`](https://github.com/NixOS/nixpkgs/commit/89c95c385ac65b838d253dccce522ff36925e45c) mdbook-i18n-helpers: 0.3.0 -> 0.3.2
* [`c751c1f9`](https://github.com/NixOS/nixpkgs/commit/c751c1f9a963f6608c429e555e6b8e3d18a0d67d) pyload-ng: add declarative user management patch
* [`0ccbca27`](https://github.com/NixOS/nixpkgs/commit/0ccbca2746300e182ed5b8a72753535556ff9f14) pyload-ng: add declarative configuration patch
* [`54c63ff6`](https://github.com/NixOS/nixpkgs/commit/54c63ff61370500b916ca9e6a3a89ef61049b3ed) eggnog-mapper: 2.1.10 -> 2.1.12
* [`8f03b6c9`](https://github.com/NixOS/nixpkgs/commit/8f03b6c9eb9f2d5916f671e2dd177f21179fc067) gigalixir: 1.6.0 -> 1.10.0
* [`504fc5b9`](https://github.com/NixOS/nixpkgs/commit/504fc5b9d53bd65d15d4feb4209485570c4e4621) mopidy-youtube: 3.6 -> 3.7
* [`a27ac00b`](https://github.com/NixOS/nixpkgs/commit/a27ac00bcc739f82b6813ae0e09b6cfdcf537335) python311Packages.http-ece: 1.1.0 -> 1.2.0
* [`fbdfde7c`](https://github.com/NixOS/nixpkgs/commit/fbdfde7c212f23cbdb608236144145059f823405) qt6Packages.kdsoap: 2.1.1 -> 2.2.0
* [`b104eff1`](https://github.com/NixOS/nixpkgs/commit/b104eff1877723d6b0a34aaad0a8ec62825887ef) tesseract: 5.3.3 -> 5.3.4
* [`7b067a28`](https://github.com/NixOS/nixpkgs/commit/7b067a28bf90e8b617eafbc639b51752a077820f) nodePackages.purescript-language-server: add mainProgram
* [`35c29c1d`](https://github.com/NixOS/nixpkgs/commit/35c29c1d68775d13bdcda3186a998388003438fc) nodePackages.purty: add mainProgram
* [`5cf58fce`](https://github.com/NixOS/nixpkgs/commit/5cf58fce746f4b40ca045be9073c155797138093) nodePackages.pulp: add mainProgram
* [`3bf0fc28`](https://github.com/NixOS/nixpkgs/commit/3bf0fc28812f5de72f99794097f49f242e692dba) nodePackages.pscid: add mainProgram
* [`825c82ed`](https://github.com/NixOS/nixpkgs/commit/825c82ed97b2191d58619ad2aa3ab8ae661344bb) spago: add mainProgram
* [`9eff9111`](https://github.com/NixOS/nixpkgs/commit/9eff911136ac9353b1dcdcfb7da50901350ac40b) dwarfs: 0.7.4 -> 0.7.5
* [`21606ab7`](https://github.com/NixOS/nixpkgs/commit/21606ab71e74d9b9c54b99eace7b3e9a6ab96813) crc: 2.30.0 -> 2.31.0
* [`a4b0c805`](https://github.com/NixOS/nixpkgs/commit/a4b0c8054a4eae5d759bf86d9493afb147b617a4) mopidy-iris: 3.64.0 -> 3.69.3
* [`348fe2dc`](https://github.com/NixOS/nixpkgs/commit/348fe2dccbf7ad93118d0cc25563910335623e0b) manuskript: 0.14.0 -> 0.16.1
* [`60f65181`](https://github.com/NixOS/nixpkgs/commit/60f651814e3337f670763985380250bdbb84409e) python311Packages.pysdl2: 0.9.15 -> 0.9.16
* [`144b776d`](https://github.com/NixOS/nixpkgs/commit/144b776d882d10e5585fc4da2d7984d31635b0e0) asdf-vm: 0.13.1 -> 0.14.0
* [`976cbecd`](https://github.com/NixOS/nixpkgs/commit/976cbecdbe6064ced14b9bc63d925fa9d98659c4) acorn: 0.9.2 -> 0.10.0
* [`b6c4b6cf`](https://github.com/NixOS/nixpkgs/commit/b6c4b6cf5d5a7754d1c861977976edb938e43fba) cel-go: 0.18.2 -> 0.19.0
* [`0c444cf2`](https://github.com/NixOS/nixpkgs/commit/0c444cf234277f3b9a2b1314552c0664368a0b81) python311Packages.pytelegrambotapi: 4.14.1 -> 4.15.2
* [`df469f77`](https://github.com/NixOS/nixpkgs/commit/df469f7720a875178a66768f83378a4f825a7d76) open-stage-control: 1.25.6 -> 1.25.7
* [`7609aa25`](https://github.com/NixOS/nixpkgs/commit/7609aa254f7bc47e609b1512c0971daeef1753be) python311Packages.tables: fix build
* [`80468464`](https://github.com/NixOS/nixpkgs/commit/80468464ba94d62404a9253d50512d311ede8e5a) rivalcfg: 4.10.0 -> 4.11.0
* [`3b9f5639`](https://github.com/NixOS/nixpkgs/commit/3b9f56393fd905b9e1aafe3c2e5f12fe9e87a5d6) python312Packages.libcloud: 3.7.0 -> 3.8.0
* [`f8445015`](https://github.com/NixOS/nixpkgs/commit/f84450155975f4bf927843b232a3423f452a6d23) kde-rounded-corners: 0.4.0 -> 0.6.0
* [`5c79f495`](https://github.com/NixOS/nixpkgs/commit/5c79f49590faf824bde35f9e058f1cbb16cf42b0) python311Packages.types-setuptools: 68.2.0.2 -> 69.0.0.20240115
* [`e5d8ef3f`](https://github.com/NixOS/nixpkgs/commit/e5d8ef3fa6a25094e82bb468bb89b995746edaf0) geist-font: init at 1.1.0
* [`7ae86ead`](https://github.com/NixOS/nixpkgs/commit/7ae86ead3755e995d282083ac805d1f18b8bb985) lazpaint: 7.2.2 -> 7.2.2-unstable-2024-01-20
* [`4d1f1601`](https://github.com/NixOS/nixpkgs/commit/4d1f160170fef83eae3a2fe08f06e55d5250e4d2) maintainers: add krloer
* [`7487b88f`](https://github.com/NixOS/nixpkgs/commit/7487b88f646cde3a27f8779b3fe1e7873def02da) renode-unstable: 1.14.0+20240106git1b3952c2c -> 1.14.0+20240119git1a0826937
* [`be3262ef`](https://github.com/NixOS/nixpkgs/commit/be3262efc2d995e5e07a949ef4c95bedb4dab3bf) luigi: 3.3.0 -> 3.5.0
* [`35b6aa21`](https://github.com/NixOS/nixpkgs/commit/35b6aa219baade0280844f7665c6fd309b58c710) prr: 0.14.0 -> 0.16.0
* [`ce517168`](https://github.com/NixOS/nixpkgs/commit/ce517168c8977c942594359bd4ddd4f4d5f39179) catch2_3: enable build for windows
* [`d2932553`](https://github.com/NixOS/nixpkgs/commit/d2932553d15eb0669535979f5dd2cd85061979e6) catch2: enable build for i686-windows
* [`6f0e7986`](https://github.com/NixOS/nixpkgs/commit/6f0e7986ed2f58d2fc59f518f3aa92de495a04d6) ebpf-verifier: re-pin to nixpkgs catch2_3 sources
* [`4fce85eb`](https://github.com/NixOS/nixpkgs/commit/4fce85eb9d111a842d6c30aa8c0e8eb0e63a7787) ossutil: 1.7.17 -> 1.7.18
* [`3ba0ddb7`](https://github.com/NixOS/nixpkgs/commit/3ba0ddb7cae48edb96d40ec4113ea1c04e39d673) quisk: 4.2.28 -> 4.2.29
* [`f35d0464`](https://github.com/NixOS/nixpkgs/commit/f35d046448c19c987a51b672823d8ba1e1412d2d) copier: 8.1.0 -> 9.1.0
* [`c8428208`](https://github.com/NixOS/nixpkgs/commit/c8428208cd899a7deb2598069cc4effb7b82d6c6) python311Packages.robotframework: refactor
* [`a538ed10`](https://github.com/NixOS/nixpkgs/commit/a538ed108f18e3d3348388d70dfce028d38a8174) gvproxy: 0.7.1 -> 0.7.2
* [`0a05841e`](https://github.com/NixOS/nixpkgs/commit/0a05841e6acf3b84141adeca6fb1a75b96f4666f) mandelbulber: 2.30 -> 2.31
* [`6ff429ca`](https://github.com/NixOS/nixpkgs/commit/6ff429ca57046dabc9ec3f2895959a30bb9a0bf9) questdb: 7.3.7 -> 7.3.9
* [`7d0fd7c1`](https://github.com/NixOS/nixpkgs/commit/7d0fd7c12a2085548f8df3d4ecc4c29c64474e24) switcheroo: init at 2.0.1
* [`bccea688`](https://github.com/NixOS/nixpkgs/commit/bccea6886ec79462369946b6050f30dfb21bc62e) cargo-binstall: 1.5.0 -> 1.6.1
* [`5d963adb`](https://github.com/NixOS/nixpkgs/commit/5d963adbcca7e7bb08414c3a77c0ee99c9609182) diffuse: 0.8.2 -> 0.9.0
* [`c8c83634`](https://github.com/NixOS/nixpkgs/commit/c8c8363417d1f4465318a4354c1f4b402e8b44be) python311Packages.openant: 1.2.1 -> 1.3.1
* [`dbf7e518`](https://github.com/NixOS/nixpkgs/commit/dbf7e51850eb9ccbfa782a17d25b3bf5a44aa818) shipwright: 7.1.1 -> 8.0.4, refactor
* [`002cd978`](https://github.com/NixOS/nixpkgs/commit/002cd978eeaf941d41ed04da219f307c6d639f74) goa: 3.14.4 -> 3.14.6
* [`a41d4226`](https://github.com/NixOS/nixpkgs/commit/a41d4226862818652e023626d67878d4cdd51997) waagent: 2.8.0.11 -> 2.9.1.1
* [`5c98c88b`](https://github.com/NixOS/nixpkgs/commit/5c98c88b38fc1ac06aad3ceee64937ef41a0aaf2) python311Packages.elasticsearch-dsl: 8.11.0 -> 8.12.0
* [`e10a2c89`](https://github.com/NixOS/nixpkgs/commit/e10a2c896c0ed8211ea81bf922383d62d8cffab1) pympress: 1.8.4 -> 1.8.5
* [`12f2c415`](https://github.com/NixOS/nixpkgs/commit/12f2c415e9bfdca28d13d6b782c7b1d5dbbe3879) carla: 2.5.7 -> 2.5.8
* [`4765bc88`](https://github.com/NixOS/nixpkgs/commit/4765bc88c6e5a2a70d5603edd3455e56ba83a507) bada-bib: 0.8.0 -> 0.8.1
* [`5edf1972`](https://github.com/NixOS/nixpkgs/commit/5edf19725d150e7ad7ef9d374339db68855759e1) cri-o-unwrapped: 1.29.0 -> 1.29.1
* [`5195b901`](https://github.com/NixOS/nixpkgs/commit/5195b9018c6ca692caf00bd375c61de2ded42c62) heisenbridge: 1.14.5 -> 1.14.6
* [`70b51d8d`](https://github.com/NixOS/nixpkgs/commit/70b51d8d17216ef6c4fdd073254899f1e8858bc9) postgresqlTestHook: add postgresqlExtraSettings variable
* [`2d6a88bc`](https://github.com/NixOS/nixpkgs/commit/2d6a88bc0ac46248c227d12d756c5dcd80695437) ghorg: 1.9.9 -> 1.9.10
* [`d7435d68`](https://github.com/NixOS/nixpkgs/commit/d7435d68399c8f1f16220386e1cb7f998b54a4cb) hyperrogue: 13.0 -> 13.0a
* [`bbcd3368`](https://github.com/NixOS/nixpkgs/commit/bbcd3368689198b737c8643c8be9786d88eb8d5d) vendir: 0.38.0 -> 0.39.0
* [`8a7d8ec6`](https://github.com/NixOS/nixpkgs/commit/8a7d8ec698703034e1d76798695240ca9bfe7bdf) figma-agent: 0.2.8 -> 0.3.2
* [`ea607df2`](https://github.com/NixOS/nixpkgs/commit/ea607df2e6668821abefeb60b925ad6c4f8a78ac) mbed-cli: 1.9.1 -> 1.10.5
* [`158f20ee`](https://github.com/NixOS/nixpkgs/commit/158f20ee86c38ffa0e65a460697bb98c58f448d3) bom: 0.5.1 -> 0.6.0
* [`feec8c5a`](https://github.com/NixOS/nixpkgs/commit/feec8c5a8c1aed86f6df7b59964c9834f0824aa5) bullshit: init at 0-unstable-2018-05-28
* [`2300b8e9`](https://github.com/NixOS/nixpkgs/commit/2300b8e9321d94bbe5774393350fa9621c332d17) junicode: 2.203 -> 2.206
* [`26b388b7`](https://github.com/NixOS/nixpkgs/commit/26b388b7492b4dcb2262612842fa11538bef7d3e) google-cloud-sql-proxy: 2.8.1 -> 2.8.2
* [`e9d1d734`](https://github.com/NixOS/nixpkgs/commit/e9d1d734494dfa2dddaac86275986c091c54c59f) maintainers: add siddharthdhakane
* [`7c95720f`](https://github.com/NixOS/nixpkgs/commit/7c95720fd6c72cee07f06f779ace83670a97273e) python311Packages.nameko: init at 2.4.1
* [`f42d4953`](https://github.com/NixOS/nixpkgs/commit/f42d4953ce4241a0d41eea5c199040703e0a664d) python311Packages.gocardless-pro: 1.50.0 -> 1.51.0
* [`1ff2b3e5`](https://github.com/NixOS/nixpkgs/commit/1ff2b3e5139963bbeab991b3b3ebac70eb54bc8f) argo: 3.5.2 -> 3.5.4
* [`4fb55447`](https://github.com/NixOS/nixpkgs/commit/4fb55447b118ad6cf33752e1dd43497f021cbc81) git-crecord: 20220324.0 -> 20230226.0
* [`39d635b4`](https://github.com/NixOS/nixpkgs/commit/39d635b40b758cc22736e08907fcca59b54e2341) pcsx2: 1.7.5474 -> 1.7.5497
* [`74328126`](https://github.com/NixOS/nixpkgs/commit/743281260c259c1b19dd70b8153a6ab850bb6e85) rbspy: 0.18.1 -> 0.19.0
* [`dedef734`](https://github.com/NixOS/nixpkgs/commit/dedef7343e3b5cacfc73d8dd85272a364ada639f) youplot: init at 0.4.5
* [`96154bbd`](https://github.com/NixOS/nixpkgs/commit/96154bbd2e2f223beb9e3a728f7c41df7075087f) python311Packages.python-arango: 7.8.1 -> 7.9.1
* [`db29e606`](https://github.com/NixOS/nixpkgs/commit/db29e6062adcd22654f31b965edb574f2ecaa6af) conan: 2.0.14 -> 2.0.17
* [`dff87abb`](https://github.com/NixOS/nixpkgs/commit/dff87abb002adc1796ff379358d61db50e884c8c) schemacrawler: 16.20.8 -> 16.21.1
* [`6abe83ba`](https://github.com/NixOS/nixpkgs/commit/6abe83ba89c3b9d7915486416036a2660856b679) litecli: 1.9.0 -> 1.10.0
* [`43b6df31`](https://github.com/NixOS/nixpkgs/commit/43b6df31e15ab17118782c59295364467a400827) container2wasm: 0.5.3 -> 0.6.2
* [`64739e1a`](https://github.com/NixOS/nixpkgs/commit/64739e1ab557a5f595dfa64e9532c7c8436ec9b9) xray: 1.8.6 -> 1.8.7
* [`2faf00d2`](https://github.com/NixOS/nixpkgs/commit/2faf00d2e017f87f65267495b390955167f4c927) fission: 1.20.0 -> 1.20.1
* [`f93b2661`](https://github.com/NixOS/nixpkgs/commit/f93b2661689757dbd1ab8b2ea8738371df80ef44) python311Packages.diff-cover: 8.0.1 -> 8.0.3
* [`37ae3c79`](https://github.com/NixOS/nixpkgs/commit/37ae3c7927c133f14a9549f2b92ce91df35a2d82) pandoc-include: 1.2.0 -> 1.2.1
* [`08068f49`](https://github.com/NixOS/nixpkgs/commit/08068f4945230e125fb65aaa6030a14839249d90) renode-dts2repl: unstable-2024-01-09 -> unstable-2024-01-20
* [`2865dd8c`](https://github.com/NixOS/nixpkgs/commit/2865dd8ca8cd632c972f606a65784e02bf3d3cd4) evcc: 0.123.8 -> 0.123.9
* [`f752df83`](https://github.com/NixOS/nixpkgs/commit/f752df831c9748fea139ad059314e9c0e556a2f0) wxsqlite3: 4.9.8 -> 4.9.9
* [`ba102c07`](https://github.com/NixOS/nixpkgs/commit/ba102c07f9ced3b917fc8cae1425dc0b2de30974) mysql_jdbc: 8.2.0 -> 8.3.0
* [`5f94cacf`](https://github.com/NixOS/nixpkgs/commit/5f94cacfda04fe753b24e3568b5fcca274e73602) nvpy: 2.2.0 -> 2.3.1
* [`bcf9a243`](https://github.com/NixOS/nixpkgs/commit/bcf9a24332a04ddcef154b792697320d40829820) handheld-daemon: init at 0.2.7
* [`52f22bfc`](https://github.com/NixOS/nixpkgs/commit/52f22bfc57dff00a93343e30a42e434b68062196) handheld-daemon: 0.27 -> 1.0.8
* [`f571033c`](https://github.com/NixOS/nixpkgs/commit/f571033ce013a416c744bd3d3ffc0fe525dbe3a9) handheld-daemon: use kebab-case instead of camelCase for service name
* [`2b1e5b44`](https://github.com/NixOS/nixpkgs/commit/2b1e5b447e7c89962cfec35e462910b988072def) kraft: 0.7.1 -> 0.7.3
* [`0dbcea42`](https://github.com/NixOS/nixpkgs/commit/0dbcea427572299a4bb8db111cc708f7c24e3483) melange: 0.5.5 -> 0.5.6
* [`8f80a44f`](https://github.com/NixOS/nixpkgs/commit/8f80a44f6f3c654b4ee9a3ada6001b8696f1eae3) cln: 1.3.6 -> 1.3.7
* [`97273f1a`](https://github.com/NixOS/nixpkgs/commit/97273f1a345ecbe8c69fe7609c539bd5012d8dc3) mkosi: 20.1 -> 20.2
* [`cc36b995`](https://github.com/NixOS/nixpkgs/commit/cc36b995f027838d6d73b968a007384bd82d4b91) clap: 1.1.10 -> 1.2.0
* [`0eaacdb1`](https://github.com/NixOS/nixpkgs/commit/0eaacdb15a5199b1ccd91cd63d20519f9896b765) nixpacks: 1.20.0 -> 1.21.0
* [`c841604f`](https://github.com/NixOS/nixpkgs/commit/c841604f00202c7e38ccc29f5eed42524bd32b12) jaq: 1.2.0 -> 1.3.0
* [`d0a2b5cc`](https://github.com/NixOS/nixpkgs/commit/d0a2b5cc8e0ca2d38e5da482e1fd7d02384b5d23) pgbackrest: 2.49 -> 2.50
* [`e059e54d`](https://github.com/NixOS/nixpkgs/commit/e059e54dd7d48afb9679e5b612ed288e448f618b) bobcat: refactor, migrate to by-name
* [`dbd66e11`](https://github.com/NixOS/nixpkgs/commit/dbd66e11cc09cc17d188ca6f62a8412f66d00907) simplex-chat-desktop: 5.4.2 -> 5.4.4
* [`4192e989`](https://github.com/NixOS/nixpkgs/commit/4192e98922baca3b390db3fc4d9533b5b22e5e3a) ofono: 2.2 -> 2.3
* [`19b3049c`](https://github.com/NixOS/nixpkgs/commit/19b3049c13c248965e41cfd6d21045a3f6a1c1f0) erg: 0.6.28 -> 0.6.29
* [`4069aa5a`](https://github.com/NixOS/nixpkgs/commit/4069aa5a1bea9aec9fff56635a1d77b5538b7941) spring-boot-cli: 3.2.1 -> 3.2.2
* [`ebf06389`](https://github.com/NixOS/nixpkgs/commit/ebf06389432aad9fffbb76143666428699ce4129) netexec: remove unnecessary package override
* [`cf50dc92`](https://github.com/NixOS/nixpkgs/commit/cf50dc9229080ae17bfefe5334dd21e3ebdb0548) python3Packages.dploot: init at 2.2.4
* [`9f13a17f`](https://github.com/NixOS/nixpkgs/commit/9f13a17f17886812c62d5418c323d0c3f1fea151) netexec: fix test by using pytestCheckHook
* [`29c1267f`](https://github.com/NixOS/nixpkgs/commit/29c1267fab998477c5d5719dce232381efe4b1d7) netexec: fix version format in custom impacket override
* [`ee64dd74`](https://github.com/NixOS/nixpkgs/commit/ee64dd74118c846c53eb528590105674848805bb) netexec: remove some declared dependencies
* [`7e421550`](https://github.com/NixOS/nixpkgs/commit/7e42155024183dfac8aa12ed48bebf97ad96bfc7) netexec: remove incorrectly included dependency from upstream
* [`78f2aada`](https://github.com/NixOS/nixpkgs/commit/78f2aadaec0350a1e8ea1ee02d67efe4bd822b5c) netexec: mark as broken in Darwin
* [`99b9a12a`](https://github.com/NixOS/nixpkgs/commit/99b9a12a156183cce9a22b48efc08bb8d53e95cf) netexec: 1.1.0 -> 1.1.0-unstable-2024-01-15
* [`ac50329e`](https://github.com/NixOS/nixpkgs/commit/ac50329e42a7fa86d410b1c18fecb11b99ea42ee) banana-cursor: move to the new by-name convention
* [`4109b0cc`](https://github.com/NixOS/nixpkgs/commit/4109b0ccd72ad8a421b8c8fdeadcccb49a3fcf9d) guestfs-tools: 1.50.1 -> 1.52.0
* [`1eaac579`](https://github.com/NixOS/nixpkgs/commit/1eaac5791b383754f65ac848c9eebe5e10996b46) banana-cursor: refactor to build from source and update meta
* [`46fa17c9`](https://github.com/NixOS/nixpkgs/commit/46fa17c90953d4854456d8faaf992f61918d9a6b) banana-cursor: add getpsyched as maintainer
* [`e880116f`](https://github.com/NixOS/nixpkgs/commit/e880116f34e57578dc9a252c6c2d4720513c37d7) corectrl: 1.3.8 -> 1.3.9
* [`46e5e576`](https://github.com/NixOS/nixpkgs/commit/46e5e576b83d261d4198c5a17ec48eedf8750c80) obsidian-export: init at 23.12.0
* [`70d0a6e5`](https://github.com/NixOS/nixpkgs/commit/70d0a6e54786994fb41f66796e20aff224028faa) nixos/pyload: init
* [`60518d6a`](https://github.com/NixOS/nixpkgs/commit/60518d6a5245bbd48b0d043549d6e22209474873) nixos/pyload: init test
* [`e837f462`](https://github.com/NixOS/nixpkgs/commit/e837f4623dae23f7fa03120ee52740fd45bee682) nixos/pyload: document new module
* [`a1c58f2a`](https://github.com/NixOS/nixpkgs/commit/a1c58f2a9761d4ea89fa4fef3ac438bd96f7f6d3) bmake: 20231210 -> 20240108
* [`f39009ec`](https://github.com/NixOS/nixpkgs/commit/f39009eccd14f587f29b627b5e753b9f86caca70) pyupgrade: 3.3.1 -> 3.15.0
* [`c35f6b46`](https://github.com/NixOS/nixpkgs/commit/c35f6b463a10f059acdb52a20bfb9f1f6c92bf40) xmlbird: 1.2.14 -> 1.2.15
* [`6c2c3940`](https://github.com/NixOS/nixpkgs/commit/6c2c3940263e872f96fdab6946e2251b55667acf) python312Packages.gsd: 3.2.0 -> 3.2.1
* [`41529f66`](https://github.com/NixOS/nixpkgs/commit/41529f66ed8e2c3261545e37310d025093022814) step-kms-plugin: 0.9.2 -> 0.10.0
* [`41f80e76`](https://github.com/NixOS/nixpkgs/commit/41f80e7617ab223e685a5f74fd895679d3df4cbc) mopidy-notify: 0.2.0 -> 0.2.1
* [`3bb98f9e`](https://github.com/NixOS/nixpkgs/commit/3bb98f9ecbb9bb02df2931e1979fbfb470b70cb4) ipopt: 3.14.13 -> 3.14.14
* [`68c71cfe`](https://github.com/NixOS/nixpkgs/commit/68c71cfe45db9a03b336f754b691e8aecad6a51d) maintainers: add nanotwerp
* [`4c8fa279`](https://github.com/NixOS/nixpkgs/commit/4c8fa279c402a8813d8b0084c359353445040ac1) phrase-cli: 2.19.3 -> 2.21.0
* [`3fb9eb76`](https://github.com/NixOS/nixpkgs/commit/3fb9eb76a308a388e05063ca0a480ab5161e83fc) sc-controller: 0.4.8.11 -> 0.4.8.13
* [`28762e23`](https://github.com/NixOS/nixpkgs/commit/28762e23a19cc336d61151ed9f2e09fc4d05e750) clap: add meta.pkgConfigModules and testers.hasPkgConfigModules
* [`c0820d4d`](https://github.com/NixOS/nixpkgs/commit/c0820d4dc529e2004ef9097082a0f87d0ca35001) python311Packages.pylxd: 2.3.1 -> 2.3.2
* [`fbad97cf`](https://github.com/NixOS/nixpkgs/commit/fbad97cf0c220a9429e6fadab97f041bcde851b7) qtractor: 0.9.25 -> 0.9.38
* [`137cb58c`](https://github.com/NixOS/nixpkgs/commit/137cb58cdb75e6fb305321c87d255fb6fcb05ff1) drogon: 1.9.1 -> 1.9.2
* [`390a681e`](https://github.com/NixOS/nixpkgs/commit/390a681eacc25fc1a3248a86c034800c51e23e31) eliot-tree: 19.0.1 -> 21.0.0
* [`b5b02297`](https://github.com/NixOS/nixpkgs/commit/b5b02297273d8c023a6303a8eae7ca9b146ee86d) mopidy-mopify: 1.6.1 -> 1.7.3
* [`c27879a6`](https://github.com/NixOS/nixpkgs/commit/c27879a68410f45aef3f753acc75f914bfc169ce) aseprite.skia: unpin icu58
* [`8260047c`](https://github.com/NixOS/nixpkgs/commit/8260047cc2b7f33cbaeefbebf637567c19e2cdd6) networkmanagerapplet: 1.34.0 -> 1.36.0
* [`2d46b9e8`](https://github.com/NixOS/nixpkgs/commit/2d46b9e876953cff8df5f2f694c84e70602d610f) mailcore2: fix build
* [`5784202c`](https://github.com/NixOS/nixpkgs/commit/5784202c32084b085320ac67a6c0c8c7c0881a97) python311Packages.azure-mgmt-containerservice: 28.0.0 -> 29.0.0
* [`b56ebe5b`](https://github.com/NixOS/nixpkgs/commit/b56ebe5bb3ddc552cbad48f9fa680102d812ada0) flink: 1.18.0 -> 1.18.1
* [`3c7b8382`](https://github.com/NixOS/nixpkgs/commit/3c7b83829e2058173b63c98ce60728035a8c516e) kamailio: 5.7.3 -> 5.7.4
* [`0eeb010f`](https://github.com/NixOS/nixpkgs/commit/0eeb010f57d39506cc8328b8a75d8d525ef9febb) libmysqlconnectorcpp: 8.2.0 -> 8.3.0
* [`2a471dae`](https://github.com/NixOS/nixpkgs/commit/2a471dae65470199f56ad3f481900a4859dc47a5) qjackctl: 0.9.12 -> 0.9.13
* [`8ce5c1a7`](https://github.com/NixOS/nixpkgs/commit/8ce5c1a7b65903f4b923c2d0bdd31d86b18d5619) amp: 0.6.2 -> 0.7.0
* [`72b7ca4e`](https://github.com/NixOS/nixpkgs/commit/72b7ca4e9511fa5ae16f002a466df43177ae0cad) bandit: 1.7.6 -> 1.7.7
* [`7aa8b48c`](https://github.com/NixOS/nixpkgs/commit/7aa8b48c2e9ebbb59c9d2f0bfdc0e5c8358a5a8a) jfrog-cli: 2.52.9 -> 2.52.10
* [`4bfc0c81`](https://github.com/NixOS/nixpkgs/commit/4bfc0c81cad0e3bd75b0b63ee85d3ffd0c1a472b) dos2unix: 7.5.1 -> 7.5.2
* [`1f72e377`](https://github.com/NixOS/nixpkgs/commit/1f72e3773f2ac94270b8ee3ad67636c0198fb75e) mdbook-pagetoc: 0.1.8 -> 0.1.9
* [`0d3f4391`](https://github.com/NixOS/nixpkgs/commit/0d3f439149605db034d9ede36dd40eb8eac77ada) libetpan: set meta.platforms
* [`fdb8b3b8`](https://github.com/NixOS/nixpkgs/commit/fdb8b3b8e2dad66dff1277ea7b530e6bfe1c0531) subxt: 0.33.0 -> 0.34.0
* [`c63b6c4d`](https://github.com/NixOS/nixpkgs/commit/c63b6c4d615b645d2cc2d20b73c689575f2a6551) python312Packages.moderngl: 5.9.0 -> 5.10.0
* [`ce7117cc`](https://github.com/NixOS/nixpkgs/commit/ce7117ccc055167bd2254328b659a80dbf28706c) mailcore2: fix build on darwin
* [`a9b5c3ce`](https://github.com/NixOS/nixpkgs/commit/a9b5c3ce90132e00fde003955f6aa9b2e6911556) maintainers: add dbrgn
* [`0f416970`](https://github.com/NixOS/nixpkgs/commit/0f4169703e0cd18ee81d65c11e33a211e3d06207) galerio: init at 1.2.0
* [`d5e6c5b1`](https://github.com/NixOS/nixpkgs/commit/d5e6c5b191969232cd5142b193115fcc6f30a89b) gfxreconstruct: 1.0.1 -> 1.0.2
* [`b1f8dd98`](https://github.com/NixOS/nixpkgs/commit/b1f8dd98900e640936c11eaa2ba077902669d0ea) vinegar: 1.6.0 -> 1.6.1
* [`25072f4a`](https://github.com/NixOS/nixpkgs/commit/25072f4a351b681a03b712ee7c3aab9e07c7224b) python312Packages.mkdocs-swagger-ui-tag: 0.6.7 -> 0.6.8
* [`7296553e`](https://github.com/NixOS/nixpkgs/commit/7296553e58a9af9b41e714037857b5260b85b8f4) exodus: 23.12.21 -> 24.1.15
* [`65a2508e`](https://github.com/NixOS/nixpkgs/commit/65a2508ee3588ef505b119e57348cdd60de4120b) python311Packages.redshift-connector: 2.0.917 -> 2.0.918
* [`f74b0fba`](https://github.com/NixOS/nixpkgs/commit/f74b0fba91ec3fdd2a72d6453ad38ceaf01b47c8) mozphab: 1.4.3 -> 1.5.1
* [`6b0a09c4`](https://github.com/NixOS/nixpkgs/commit/6b0a09c429b6ad67a0c1c06c5cb2552ee61620d8) way-displays: 1.9.0 -> 1.10.2
* [`0afc0c36`](https://github.com/NixOS/nixpkgs/commit/0afc0c36f340a7785d971d0ae533f7b3bc02abb4) spicedb-zed: 0.16.2 -> 0.16.4
* [`24514296`](https://github.com/NixOS/nixpkgs/commit/2451429628d675554abc3b10e9a537b135d19f4c) narsil: init at 1.3.0-49-gc042b573a
* [`59b24e89`](https://github.com/NixOS/nixpkgs/commit/59b24e896725632be10ea30258b3bd0e905ebdb9) plantuml-c4: unstable-2022-08-21 -> 2.8.0
* [`c9a1fcde`](https://github.com/NixOS/nixpkgs/commit/c9a1fcde03a2e3811ba7c6ae36ba6c698b873518) yj: add meta.mainProgram, move to by-name
* [`b1ba87dd`](https://github.com/NixOS/nixpkgs/commit/b1ba87dd5eb82719fd58fa084fe560fcce1b5eac) python311Packages.django-versatileimagefield: 3.0 -> 3.1
* [`710f3254`](https://github.com/NixOS/nixpkgs/commit/710f3254323006a48a43cc7fcb4db0901a9ee0bb) knxd: 0.14.59 → 0.14.60
* [`723ecdf6`](https://github.com/NixOS/nixpkgs/commit/723ecdf6d4ad8dec46315bd5d4157d2fe7071652) maintainers: add gpg fingerprint for ChaosAttractor
* [`48c78f89`](https://github.com/NixOS/nixpkgs/commit/48c78f89914e26505830e1dfe13d5b461946f509) nestopia-ue: migrate to by-name
* [`5c8c5664`](https://github.com/NixOS/nixpkgs/commit/5c8c5664e814513a3af5610492ea0693854667c1) unison-ucm: 0.5.13 -> 0.5.14
* [`3c9692d5`](https://github.com/NixOS/nixpkgs/commit/3c9692d5cd44724bc98cfe5f01757d3fb2816a30) nestopia-ue: 1.47 -> 1.52.0
* [`3a428de4`](https://github.com/NixOS/nixpkgs/commit/3a428de420cb56271b44ac4a56148a8a9609fb1d) python311Packages.nototools: 0.2.17 -> 0.2.19
* [`34250891`](https://github.com/NixOS/nixpkgs/commit/34250891220ec2a9f32f368432809db97eae09bf) uxn: unstable-2024-01-15 -> unstable-2024-01-21
* [`1cf39c1c`](https://github.com/NixOS/nixpkgs/commit/1cf39c1c73baeef055f32f7178342c692d668ebc) python311Packages.imbalanced-learn: 0.11.0 -> 0.12.0
* [`033b2fa8`](https://github.com/NixOS/nixpkgs/commit/033b2fa864d7166ade245c989cb047927d3ca12a) q: 0.15.1 -> 0.19.2
* [`09c1e949`](https://github.com/NixOS/nixpkgs/commit/09c1e9494b52cb707fbad12d3c0a6ce5ee2837cd) zoom-us: 5.17.1.1840 -> 5.17.5.2543
* [`70af019e`](https://github.com/NixOS/nixpkgs/commit/70af019e84f57abba1320be2088384dfc8371073) python311Packages.logilab-constraint: 0.8.0 -> 1.0
* [`e7e92742`](https://github.com/NixOS/nixpkgs/commit/e7e92742e5b31189d35fab99b43ab604b48e8afb) python311Packages.imbalanced-learn: refactor
* [`71f28c87`](https://github.com/NixOS/nixpkgs/commit/71f28c8795e762c0df414979fb8a64202c117cd9) crun: 1.13 -> 1.14
* [`05cfb1cb`](https://github.com/NixOS/nixpkgs/commit/05cfb1cb2f86e90d55d95a87fc1add901d1d5504) firebase-tools: 13.0.3 -> 13.1.0
* [`28969a9b`](https://github.com/NixOS/nixpkgs/commit/28969a9b81f8c22a3377799fd106e82399edeeff) vscode-extensions.dbaeumer.vscode-eslint: 2.4.2 -> 2.4.4
* [`61da1bf7`](https://github.com/NixOS/nixpkgs/commit/61da1bf730b0d5cf2495df65e08424d03299232d) notation: 1.0.1 -> 1.1.0
* [`b92d2bb7`](https://github.com/NixOS/nixpkgs/commit/b92d2bb77c6c4c5c237905bfb0e370c1947f978e) crowdsec: 1.5.5 -> 1.6.0
* [`937f8c57`](https://github.com/NixOS/nixpkgs/commit/937f8c57e4b1e13ea43eb94be2db561d8df6b6f8) python311Packages.pywebpush: 1.14.0 -> 1.14.1
* [`24ac8702`](https://github.com/NixOS/nixpkgs/commit/24ac870244647a983489ba3c3255a87552ffc0c5) aardvark-dns: 1.9.0 -> 1.10.0
* [`91bffc44`](https://github.com/NixOS/nixpkgs/commit/91bffc44e85d35b57e8957284f15b8d621394d4e) goodhosts: 1.1.1 -> 1.1.2
* [`e3f91884`](https://github.com/NixOS/nixpkgs/commit/e3f918841a2d6cbd1a8cd07691e09d38d22fa316) bookstack: 23.12.1 -> 23.12.2
* [`4a8ea134`](https://github.com/NixOS/nixpkgs/commit/4a8ea13452afefa44538c763bf60eef1c51fd561) wait4x: 2.13.0 -> 2.14.0
* [`91da7104`](https://github.com/NixOS/nixpkgs/commit/91da71041d23444191673466dbd3d42e2df13087) qv2ray: remove clang_8
* [`56504908`](https://github.com/NixOS/nixpkgs/commit/56504908440cf45db6d32f70eaec341c983e3d68) windows.crossThreadsStdenv: llvmPackages_8 -> llvmPackages
* [`7a0dc7c7`](https://github.com/NixOS/nixpkgs/commit/7a0dc7c7e87cd9bd3f3272a178660a495224ce46) treewide: drop LLVM8
* [`b170663a`](https://github.com/NixOS/nixpkgs/commit/b170663a3e1c4633cea3694a6a7cdc56b7074b22) pocketbase: 0.20.7 -> 0.21.1
* [`6d1e022e`](https://github.com/NixOS/nixpkgs/commit/6d1e022e7cbaa1079a2eef7f541d30d81b4e8e11) nixos/nautilus-open-any-terminal: init
* [`cb25cc7e`](https://github.com/NixOS/nixpkgs/commit/cb25cc7e66b4cf2073240be2e4cd2b684a56347e) singularity: 4.0.3 -> 4.1.0
* [`fdf23b92`](https://github.com/NixOS/nixpkgs/commit/fdf23b92ec4ed3a0b39ba8f0ec251e3cca66ed11) privoxy: fix socks4 and socks4a support under glibc's source fortification
* [`419dceda`](https://github.com/NixOS/nixpkgs/commit/419dceda001e66d037f5ba64704cc68e96d41d4a) dooit: 2.1.1 -> 2.2.0
* [`6f19bb8d`](https://github.com/NixOS/nixpkgs/commit/6f19bb8de4130c0dac48a33f404a0afda96559b1) wasmtime: 16.0.0 -> 17.0.0
* [`3aba7f08`](https://github.com/NixOS/nixpkgs/commit/3aba7f08ae7a3bf53c989cfaa232dcdf01e8fe52) kodi.packages.inputstream-ffmpegdirect: 20.5.0 -> unstable-20.5.0
* [`fcc93d6a`](https://github.com/NixOS/nixpkgs/commit/fcc93d6a442db00a0396097997047619848e2b74) bugdom: 1.3.3 -> 1.3.4
* [`206d26ad`](https://github.com/NixOS/nixpkgs/commit/206d26ad5d47702f815e98ea66c6db59cea50ac2) python3Packages.ziafont: fix ModuleNotFoundError: No module named 'setuptools'
* [`766bb714`](https://github.com/NixOS/nixpkgs/commit/766bb714719c6958ecc98dd806277f37c04b606e) python3Packages.ziafont: 0.6 -> 0.7
* [`faa8fa6c`](https://github.com/NixOS/nixpkgs/commit/faa8fa6cc055aac78f1057df6ab88800d8023e72) python3Packages.ziamath: fix ModuleNotFoundError: No module named 'setuptools'
* [`7a4a5c70`](https://github.com/NixOS/nixpkgs/commit/7a4a5c709c79167a0953807c24a320e14cb978a9) python3Packages.ziamath: 0.8.1 -> 0.9
* [`0bd988a4`](https://github.com/NixOS/nixpkgs/commit/0bd988a489051a0523bebfb3af51094e08ea0f83) python3Packages.schemdraw: fix ModuleNotFoundError: No module named 'setuptools'
* [`88189d0e`](https://github.com/NixOS/nixpkgs/commit/88189d0e878227122db7e8a04624fcbcf7a9bdd2) python3Packages.schemdraw: 0.17 -> 0.18
* [`edd52fec`](https://github.com/NixOS/nixpkgs/commit/edd52fece0cf6905f48cc9e0f2fc639ec3a9dd10) flannel: 0.24.0 -> 0.24.2
* [`be254acf`](https://github.com/NixOS/nixpkgs/commit/be254acf900475f53ef2198c593d134e8a4f0f4c) rpi-imager: 1.8.4 -> 1.8.5
* [`72d2419a`](https://github.com/NixOS/nixpkgs/commit/72d2419a4f75ba07dee64d1c6db4b16987182774) libsForQt5.maplibre-gl-native: fix build
* [`36b96b34`](https://github.com/NixOS/nixpkgs/commit/36b96b344d8447e23b92156410154af4e84a3dbc) dateutils: 0.4.10 -> 0.4.11
* [`096f6d6c`](https://github.com/NixOS/nixpkgs/commit/096f6d6c00a33a5565ffdee6094691eda0d6ab15) prometheus-openvpn-exporter: remove
* [`aaab9db5`](https://github.com/NixOS/nixpkgs/commit/aaab9db58cda0ba9c1405ba1e324fae5fc584092) highfive: 2.8.0 -> 2.9.0
* [`b0238d69`](https://github.com/NixOS/nixpkgs/commit/b0238d69c728b20da45da58fe101164a3584b550) sqlcl: 23.3.0.270.1251 -> 23.4.0.023.2321
* [`c26e72bb`](https://github.com/NixOS/nixpkgs/commit/c26e72bbef3c45193469b8575f9bbcb1beec5ef7) openrocket: init at 23.09
* [`7b9ca0f9`](https://github.com/NixOS/nixpkgs/commit/7b9ca0f9ec59224db0d17b4dd8d0407a2912c6f0) zinit: 3.12.1 -> 3.13.1
* [`26cdc416`](https://github.com/NixOS/nixpkgs/commit/26cdc416a4c3e5d698b24b475c38bd532d5f3c0c) magic-vlsi: 8.3.456 -> 8.3.459
* [`e6f96a70`](https://github.com/NixOS/nixpkgs/commit/e6f96a702dcf150a904d66e1b54f52c482f5a389) coreth: 0.12.7 -> 0.12.10
* [`4271d77b`](https://github.com/NixOS/nixpkgs/commit/4271d77bccf7c732cbbcd60ac3cb78956ffd9cf3) gbsplay: 0.0.94 -> 0.0.95
* [`80c7cef1`](https://github.com/NixOS/nixpkgs/commit/80c7cef1c70a3d2fe2dc98652a1b0d2639bfe58d) cargo-component: 0.6.0 -> 0.7.0
* [`2e66d0c1`](https://github.com/NixOS/nixpkgs/commit/2e66d0c1b4d04fcf7d6a606fb0cc7754a296088c) open-policy-agent: 0.60.0 -> 0.61.0
* [`cbcfc33c`](https://github.com/NixOS/nixpkgs/commit/cbcfc33c28ebbbc4680d1c8e5156421ed1253219) ff2mpv: 4.0.0 -> 5.0.1
* [`7e8613fb`](https://github.com/NixOS/nixpkgs/commit/7e8613fb4eae3b5c6db25936306cfc00c91779f0) zsh-powerlevel10k: 1.19.0 -> 1.20.0
* [`76611b61`](https://github.com/NixOS/nixpkgs/commit/76611b61260d9b1f2beaccdfaa30993dfecaa320) gitstatus: update libgit2 version
* [`a68fcf32`](https://github.com/NixOS/nixpkgs/commit/a68fcf325dd4f4a367edffcf825855aa4260656d) workcraft: 3.4.1 -> 3.4.2
* [`dbd8ac7c`](https://github.com/NixOS/nixpkgs/commit/dbd8ac7c8f83b31c907e5080ed8a79b990e10d96) python311Packages.dulwich: disable flaky test file on high cores
* [`cf01a563`](https://github.com/NixOS/nixpkgs/commit/cf01a563f44b6e8f080880b819bb3ca497a00606) uplosi: 0.1.2 -> 0.1.3
* [`29a3d47d`](https://github.com/NixOS/nixpkgs/commit/29a3d47d2e8f1daa9658688ac036df42f9c6189f) uplosi: add shell completion
* [`ec83597c`](https://github.com/NixOS/nixpkgs/commit/ec83597c63f3e26292c4b12fdcca42de14b3d901) signal-desktop: 6.44.0 -> 6.45.1
* [`21924e31`](https://github.com/NixOS/nixpkgs/commit/21924e31bbaf8ba68b3437aa61b2ac2ae88f869e) signal-desktop (aarch64): 6.42.0 -> 6.44.0
* [`24d4f214`](https://github.com/NixOS/nixpkgs/commit/24d4f214818c7092adeda8af9a0a43d6765db416) rshell: 0.0.31 -> 0.0.32
* [`916f15c4`](https://github.com/NixOS/nixpkgs/commit/916f15c469d75f9be730a8f427a2f4a6429846c6) gtimelog: convert to python application
* [`d111dade`](https://github.com/NixOS/nixpkgs/commit/d111dade74e3257aaeac0deefc8adcea22d2423f) gtimelog: unstable-2020-05-16 -> unstable-2023-10-05, cleanup
* [`2157862a`](https://github.com/NixOS/nixpkgs/commit/2157862aeab7d904d4f303669694a14857c1a510) gtimelog: install desktop entry
* [`ac881414`](https://github.com/NixOS/nixpkgs/commit/ac881414a6cda82b6b716bce5c84d08eab6ed5a2) yabai: 6.0.6 -> 6.0.7
* [`29d18e8f`](https://github.com/NixOS/nixpkgs/commit/29d18e8f6f78ff5782c097d019d082a978d90160) nixos/etcd: fixes etcd failing to start at boot and add openFirewall option
* [`cbe8e0c9`](https://github.com/NixOS/nixpkgs/commit/cbe8e0c9809aa50a4a9c389cab2879b3f8935c0f) nixos/etcd: fix etcd category from misc to databases
* [`4e316b85`](https://github.com/NixOS/nixpkgs/commit/4e316b85b86b1431ffcc49ab5e7a25c8d2fa1565) python3Packages.django-crispy-bootstrap5: init at 2023.10
* [`d061a3c1`](https://github.com/NixOS/nixpkgs/commit/d061a3c15449d72fa5219ed6e5379e3a0abc77b0) python311Packages.svgutils: init at 0.3.4
* [`43a00710`](https://github.com/NixOS/nixpkgs/commit/43a00710a5fc33db8bc713323aab1ecd98e5e077) python311Packages.nipreps-version: init at 1.0.4
* [`cdc7603f`](https://github.com/NixOS/nixpkgs/commit/cdc7603f70388aa126adcc69c05d3cc6ccb139d7) python311Packages.templateflow: init at 23.1.0
* [`7a483d6e`](https://github.com/NixOS/nixpkgs/commit/7a483d6e4f2625b01ed0fd9213401a061a4dbd85) python311Packages.niworkflows: init at 1.10.0
* [`177ec1bb`](https://github.com/NixOS/nixpkgs/commit/177ec1bbdd378c3d09330ba6b17db9990fa353dd) syslogng: 4.5.0 -> 4.6.0
* [`0d4ed021`](https://github.com/NixOS/nixpkgs/commit/0d4ed02177909a5a2b8717f0e0bb5871453a6e6b) md4c: migrate to by-name
* [`017d29b7`](https://github.com/NixOS/nixpkgs/commit/017d29b79d8e596e3e885430df1d55f488140001) hubble: 0.12.3 -> 0.13.0
* [`31d32f94`](https://github.com/NixOS/nixpkgs/commit/31d32f9467b9e2744bc7697b1b4478320a14c943) flyctl: 0.1.143 -> 0.1.146
* [`ddb2da8c`](https://github.com/NixOS/nixpkgs/commit/ddb2da8cc4b7b5cdb322f9ef3e1bb9b263b7320d) picard: 2.10 -> 2.11
* [`1860d8a1`](https://github.com/NixOS/nixpkgs/commit/1860d8a145db32ab911a8fe88a437e89aca54459) prusa-slicer: fix build on aarch64-darwin
* [`477ad870`](https://github.com/NixOS/nixpkgs/commit/477ad870d3c16a53370b4b53bb895469e01265bf) openvdb: fix build with tbb_2021_8 on x86_64_darwin
* [`a04f9a5e`](https://github.com/NixOS/nixpkgs/commit/a04f9a5e9e850dfe6cd1d1f601a470804f6e27e7) egglog: unstable-2023-09-12 -> 0-unstable-2024-01-26
* [`ac35f4b6`](https://github.com/NixOS/nixpkgs/commit/ac35f4b63f9b092d7a78a21a7dd743992c6e5150) lout: 3.42.2 -> 3.43
* [`b9f5bb60`](https://github.com/NixOS/nixpkgs/commit/b9f5bb6064f537adfc05ba5421e98d8f775e07c1) honk: 1.2.0 -> 1.2.1
* [`950d872c`](https://github.com/NixOS/nixpkgs/commit/950d872cf422eb747cb7e7fb15975c972620d3b2) python312Packages.social-auth-core: 4.5.1 -> 4.5.2
* [`b4e253b5`](https://github.com/NixOS/nixpkgs/commit/b4e253b5256bbbb7c4a62b638fdbc12294b0e80d) python312Packages.rich-rst: 1.1.7 -> 1.2.0
* [`a65d8608`](https://github.com/NixOS/nixpkgs/commit/a65d86085b733d4a708d1adfb085c5aa6ee94b92) clzip: 1.13 -> 1.14
* [`7838f3a6`](https://github.com/NixOS/nixpkgs/commit/7838f3a69c94e57616b3f6a1aa3b1d330d44336d) tauon: 7.7.0 -> 7.7.1
* [`2142c667`](https://github.com/NixOS/nixpkgs/commit/2142c667f6dd66371c14231682038e9c08e925de) libgig: 4.3.0 -> 4.4.0
* [`c3846222`](https://github.com/NixOS/nixpkgs/commit/c38462229028483211ed6a5179cdc1482b4f13a1) python311Packages.hyperscan: 0.6.0 -> 0.7.0
* [`b734b6c8`](https://github.com/NixOS/nixpkgs/commit/b734b6c87b2182522f9b24a6470d974717f45f26) python311Packages.pastescript: 3.3.0 -> 3.4.0
* [`54538174`](https://github.com/NixOS/nixpkgs/commit/545381743717551b57fd01d19299de663cd59ccc) ngtcp2: 1.1.0 -> 1.2.0
* [`e0e27d36`](https://github.com/NixOS/nixpkgs/commit/e0e27d36d908a60c2c986aaf8f965c6d47b4c866) besu: 23.10.3 -> 24.1.1
* [`ad1a9965`](https://github.com/NixOS/nixpkgs/commit/ad1a9965f4af785f2b9fb998014eec7ffcc668cc) md4c: refactor
* [`5b35a895`](https://github.com/NixOS/nixpkgs/commit/5b35a895b6bac4443da0e8721d81178cb353f95a) md4c: 0.4.8 -> 0.5.0
* [`4ced36cf`](https://github.com/NixOS/nixpkgs/commit/4ced36cf904de33a652b1016f54b3be21d0cc2e6) md4c: 0.5.0 -> 0.5.1
* [`a6d76f65`](https://github.com/NixOS/nixpkgs/commit/a6d76f65c446073cf47ffbfd30bfc36dba810a0a) avizo: 1.2.1 -> 1.3
* [`9eaf3bc8`](https://github.com/NixOS/nixpkgs/commit/9eaf3bc8d1d013961a62aaf055f22271a64567e4) dovecot_fts_xapian: 1.5.7 -> 1.5.8
* [`de5131ba`](https://github.com/NixOS/nixpkgs/commit/de5131ba71f1b4ba836e5307f760c4671d4f9c27) metal-cli: 0.19.0 -> 0.20.0
* [`f2acdb5b`](https://github.com/NixOS/nixpkgs/commit/f2acdb5b3493f93937e3fe1c5969f95426e5af5d) vncdo: 1.1.0 -> 1.2.0
* [`1eb10bd6`](https://github.com/NixOS/nixpkgs/commit/1eb10bd6bdebccee66a483c31422762bd9ea9eac) darwin.moltenvk: 1.2.4 -> 1.2.7
* [`32c502ed`](https://github.com/NixOS/nixpkgs/commit/32c502edfebdb2020a32a6e388b2b5e85352ef8a) python3Packages.stravalib: mark unbroken
* [`055453c1`](https://github.com/NixOS/nixpkgs/commit/055453c1fb5b2c50025d6609f5dc2ce544d5e197) tvm: 0.14.0 -> 0.15.0
* [`fb346a87`](https://github.com/NixOS/nixpkgs/commit/fb346a879191cf05f3b54bc8fc77859426dec7c1) nixos/tests/zfs: fix using wrong package
* [`b170717e`](https://github.com/NixOS/nixpkgs/commit/b170717e603c5715330670e1711fd6547bd9fdad) unifi-protect-backup: 0.10.3 -> 0.10.4
* [`07b9064e`](https://github.com/NixOS/nixpkgs/commit/07b9064e2bf09ea5841425e72dd501c9139280c3) kubecm: 0.27.1 -> 0.28.0
* [`c5565d4e`](https://github.com/NixOS/nixpkgs/commit/c5565d4e9fe13408d59640815abd5b84f692d77e) bonk: 0.3.2 -> 0.4.0
* [`55941ca5`](https://github.com/NixOS/nixpkgs/commit/55941ca51ea26ef02bd296270692bf316c11d22d) reptor: 0.8 -> 0.9
* [`7e7d3b9a`](https://github.com/NixOS/nixpkgs/commit/7e7d3b9a9dc1f9cde92d1ca8a0e9b94aeeb8ec47) discord: 0.0.40 -> 0.0.41
* [`5a4b4058`](https://github.com/NixOS/nixpkgs/commit/5a4b4058095ae8d690d16d129ff1f9752e400b04) discord-ptb: 0.0.64 -> 0.0.66
* [`a8e00a43`](https://github.com/NixOS/nixpkgs/commit/a8e00a43b48e5cccd12afa36ba27ffd5cc699726) discord-canary: 0.0.248 -> 0.0.257
* [`8526128f`](https://github.com/NixOS/nixpkgs/commit/8526128f43c94a3010c15ed0f9878f280bd94d64) discord-development: 0.0.8 -> 0.0.11
* [`a1bd9585`](https://github.com/NixOS/nixpkgs/commit/a1bd95850486c9c96181b4c86593b89a4f9ed982) discord: 0.0.291 -> 0.0.292
* [`2c1db09e`](https://github.com/NixOS/nixpkgs/commit/2c1db09e9706ef240b422a5949aca9504ddaddc3) discord-ptb: 0.0.94 -> 0.0.96
* [`cf5f65c9`](https://github.com/NixOS/nixpkgs/commit/cf5f65c931cdcaa8626116874cb0d16a57afbe36) discord-canary: 0.0.394 -> 0.0.401
* [`0c427ff7`](https://github.com/NixOS/nixpkgs/commit/0c427ff7c5df094ee9f69c4c2fc20186eb7a5a56) discord-development: 0.0.18 -> 0.0.27
* [`b32b6ec7`](https://github.com/NixOS/nixpkgs/commit/b32b6ec7a743b2f67b517c0c03cb186e06c3fc4c) maintainers: add gmacon
* [`093f6333`](https://github.com/NixOS/nixpkgs/commit/093f6333b6669589d85fa57f45751afa78bc786f) tarsnapper: 0.4 -> 0.5
* [`760c8880`](https://github.com/NixOS/nixpkgs/commit/760c8880b5a78441d5b49409aecb4d139981a80f) snicat: init at 0.0.1
* [`56d10daf`](https://github.com/NixOS/nixpkgs/commit/56d10daf59a5ef46792868162b0328f4f226a56d) ssdfs-utils: 4.37 -> 4.38
* [`f7ab4c99`](https://github.com/NixOS/nixpkgs/commit/f7ab4c9968d4eec52d2a8e5dbad84564c5404d6d) usbsdmux: 24.1 -> 24.1.1
* [`3a008093`](https://github.com/NixOS/nixpkgs/commit/3a00809390bc4b8b6ebc79e2d9ff029fd824aa46) nixos/prometheus-snmp-exporter: fix undefined logPrefix
* [`acc6248c`](https://github.com/NixOS/nixpkgs/commit/acc6248c52f53af020188d2650a5481f43ccfa55) python3Packages.autopep8: add meta.mainProgram
* [`d7612354`](https://github.com/NixOS/nixpkgs/commit/d76123547935660ba6d64a3e398374439a783f4d) mc: 4.8.30 -> 4.8.31
* [`f9eb284b`](https://github.com/NixOS/nixpkgs/commit/f9eb284ba7243a859a574ed76aa4fc2b8d5dae06) netbird: 0.25.4 -> 0.25.5
* [`b3179734`](https://github.com/NixOS/nixpkgs/commit/b317973497a8854aa9a8df96c8533db0eeae52da) python311Packages.b2sdk: 1.29.0 -> 1.29.1
* [`3783d2f7`](https://github.com/NixOS/nixpkgs/commit/3783d2f7b513bc7a3a27ce46217f208561ec8e08) aerospike: 4.2.0.4 -> 7.0.0.3
* [`0b3bbf00`](https://github.com/NixOS/nixpkgs/commit/0b3bbf00c0779ac017e28a0e6ab84361aba2ba4e) wmenu: 0.1.4 -> 0.1.6
* [`a32dac21`](https://github.com/NixOS/nixpkgs/commit/a32dac21465970e56dc5fa7df5db6a5ed112b0ca) python311Packages.types-docutils: 0.20.0.20240125 -> 0.20.0.20240126
* [`be005ab3`](https://github.com/NixOS/nixpkgs/commit/be005ab312b891be21b94534af141dd590665414) sqlite: `enableDeserialize` can be removed
* [`930062c2`](https://github.com/NixOS/nixpkgs/commit/930062c2c973fbc81cb38df93a81ec26c1a7ecf2) thanos: 0.33.0 -> 0.34.0
* [`250988e6`](https://github.com/NixOS/nixpkgs/commit/250988e658fe10534825fb3aa2e5405c8e57c676) home-assistant-custom-lovelace-modules.mini-graph-card: 0.11.0 -> 0.12.0
* [`ad65cff2`](https://github.com/NixOS/nixpkgs/commit/ad65cff2dee85d00c5af7cc575bc0a3eb0cbbc32) python311Packages.awswrangler: 3.5.1 -> 3.5.2
* [`0feb98ae`](https://github.com/NixOS/nixpkgs/commit/0feb98aeee9a52d4e8a524ac5ab2e6843772690c) vmware-horizon-client: 2309.1 -> 2312
* [`368ad197`](https://github.com/NixOS/nixpkgs/commit/368ad197512d95bce3ca884a01f9799b904d2138) sketchybar: 2.19.4 -> 2.20.0
* [`f9816616`](https://github.com/NixOS/nixpkgs/commit/f9816616428ff3247082580659c15eff5339495d) tailscale-nginx-auth: 1.58.0 -> 1.58.2
* [`e2e6e4ea`](https://github.com/NixOS/nixpkgs/commit/e2e6e4ea479e80b60e3dde7c0805aceaf61790cd) navidrome: 0.50.2 -> 0.51.0
* [`85e6e68b`](https://github.com/NixOS/nixpkgs/commit/85e6e68bc38007ca08366eae1df2b3217170ad84) home-assistant-custom-lovelace-modules.mini-media-player: 1.16.8 -> 1.16.9
* [`a2ddc20e`](https://github.com/NixOS/nixpkgs/commit/a2ddc20e100561d9831a01466f62b468243df6a1) alvr: init at 20.6.1
* [`1d3e2a92`](https://github.com/NixOS/nixpkgs/commit/1d3e2a92bc516a1ead80dafbd48a07fb935f684d) nixos/alvr: init module
* [`1be67c8f`](https://github.com/NixOS/nixpkgs/commit/1be67c8ff500934cbcdd8bd7fd622cc82c8e9c98) zsh-prezto: unstable-2024-01-18 -> unstable-2024-01-26
* [`92b98478`](https://github.com/NixOS/nixpkgs/commit/92b98478a830a7f7e6f65195aa1b2257798fe423) nixos/etc: fix type checking of build-composefs-dump.py
* [`4e139026`](https://github.com/NixOS/nixpkgs/commit/4e139026b506e2339c6ce224e2f7ad1e4bb4fa4b) nixos/repart: add option for configuring sector size
* [`0bf5f3be`](https://github.com/NixOS/nixpkgs/commit/0bf5f3be2512b2770bb8c4f45a7b7b1956909300) appliance-repart-image: fix OVMF not detecting disk
* [`57a288b6`](https://github.com/NixOS/nixpkgs/commit/57a288b6812cc1e5fc4f3dd92e70da62d7a52f0e) atkmm_2_36: 2.36.2 -> 2.36.3
* [`bb6a8f86`](https://github.com/NixOS/nixpkgs/commit/bb6a8f8625b982a934a3cae19c4df0ffa27475b5) kicad: 7.0.9 -> 7.0.10
* [`67d15b0c`](https://github.com/NixOS/nixpkgs/commit/67d15b0c094055134fa0cf8023b3bfd335f3b320) mysql-shell-innovation: 8.2.1 -> 8.3.0
* [`3ae5cf25`](https://github.com/NixOS/nixpkgs/commit/3ae5cf259c5e0b0b05ca1f0ed141becda36daefe) docker-compose: 2.24.0 -> 2.24.3
* [`3dcf3798`](https://github.com/NixOS/nixpkgs/commit/3dcf379831c9c00c19990b42c9bae91c85fa5e69) cloudlog: 2.6.2 -> 2.6.3
* [`11b4c5b0`](https://github.com/NixOS/nixpkgs/commit/11b4c5b070d3029319a0260e9bad0a83c6c3be4b) vulkan-tools: fix build on darwin
* [`ff9169be`](https://github.com/NixOS/nixpkgs/commit/ff9169be939a62d14decc09b6aabcab44054f68a) vkquake: fix build on darwin
* [`cab9c010`](https://github.com/NixOS/nixpkgs/commit/cab9c0100da53088518a73c1a1676efa0ad138d3) libplacebo: fix build on darwin
* [`88556f2f`](https://github.com/NixOS/nixpkgs/commit/88556f2f9dffa615db3b6c69a7ff2fdc588a16c0) microsoft-edge: 120.0.2210.144 -> 121.0.2277.83
* [`3c60abd1`](https://github.com/NixOS/nixpkgs/commit/3c60abd12322bf6bae9a8810c1ca814bcd3904aa) tigerbeetle: 0.14.175 -> 0.14.176
* [`2cc2d5c3`](https://github.com/NixOS/nixpkgs/commit/2cc2d5c3bbfdd53b422d2f68890d9b2d2facf8ff) opkg: 0.6.2 -> 0.6.3
* [`4edf2bce`](https://github.com/NixOS/nixpkgs/commit/4edf2bce3ccd9aa9ceff92ade8282739e2e3c4bd) bemenu: 0.6.16 -> 0.6.17
* [`86cdace6`](https://github.com/NixOS/nixpkgs/commit/86cdace604c7f9dc2ee15bd882bf270bb0bb1592) osmo-pcu: 1.3.1 -> 1.4.0
* [`eb557de5`](https://github.com/NixOS/nixpkgs/commit/eb557de5dd102ebd7c625cd1f41fcaa1c4d31ef4) python311Packages.unearth: drop support for python 3.7
* [`024b3865`](https://github.com/NixOS/nixpkgs/commit/024b38659bd749e2511eb007e037a98a20c1ce3d) python311Packages.databricks-sql-connector: 3.0.1 -> 3.0.2
* [`d050f04d`](https://github.com/NixOS/nixpkgs/commit/d050f04dc5ad2eccae099a1344fc589b8d8396e9) gama: fix build on aarch64-darwin
* [`833431ce`](https://github.com/NixOS/nixpkgs/commit/833431cef94db027721d0fa71114f0694924469e) songrec: 0.4.1 -> 0.4.2
* [`b223dc76`](https://github.com/NixOS/nixpkgs/commit/b223dc76ac71ee9b84afcf2237dcbb636c4ddeb4) readarr: 0.3.14.2358 -> 0.3.17.2409
* [`476dad39`](https://github.com/NixOS/nixpkgs/commit/476dad395a51595174ecbbbdf1d55607330003e1) stanc: 2.33.1 -> 2.34.0
* [`bd61856f`](https://github.com/NixOS/nixpkgs/commit/bd61856fb95096266f60d6e888993c1ff6bfce81) python311Packages.google-ai-generativelanguage: 0.4.0 -> 0.5.0
* [`f9c64885`](https://github.com/NixOS/nixpkgs/commit/f9c648858cb43cc3e1d2541fe677f398d4cadd50) meshcentral: fix update script
* [`d7d077c5`](https://github.com/NixOS/nixpkgs/commit/d7d077c5f55f91c54a72ce61d9fdb3725332a799) meshcentral: 1.1.19 -> 1.1.20
* [`d075c6f0`](https://github.com/NixOS/nixpkgs/commit/d075c6f0b1d8ac2e08b582f03731903defef8b32) gnuradio: disabledForGRafter -> disabled
* [`ab34bb73`](https://github.com/NixOS/nixpkgs/commit/ab34bb73484bcf7d639c07a4127eaba6ecba6c1d) gnuradioPackages: disabledForGRafter -> disabled
* [`581e13d0`](https://github.com/NixOS/nixpkgs/commit/581e13d0fb6747f8472ef3c6bb39192ccc864a09) namespace-cli: 0.0.328 -> 0.0.332
* [`da67f0ad`](https://github.com/NixOS/nixpkgs/commit/da67f0ad644911962cb90d2c4b15a9b807849361) komikku: 1.35.0 -> 1.36.0
* [`10381a23`](https://github.com/NixOS/nixpkgs/commit/10381a23df46e801c6f67396441b80339cfc4185) rke: 1.5.1 -> 1.5.3
* [`3ce24ee7`](https://github.com/NixOS/nixpkgs/commit/3ce24ee792c2e06399f434347bf39f39f68fc445) mise: 2024.1.24 -> 2024.1.30
* [`a9161ceb`](https://github.com/NixOS/nixpkgs/commit/a9161ceb5a3669ced280ce0805ad38470b5904b2) nixos/etc: remove leading slash from target paths in build-composefs-dump.py
* [`dff64f54`](https://github.com/NixOS/nixpkgs/commit/dff64f549e69a9fe83111628e0aae28654a1d6fc) nixos/x11: remove leading slash from environment.etc path
* [`740f07ae`](https://github.com/NixOS/nixpkgs/commit/740f07aee3f192708a74e83053fb58669e64850c) echidna: 2.2.1 -> 2.2.2
* [`37968485`](https://github.com/NixOS/nixpkgs/commit/3796848533ba4c51dcd9c0ddcd26a45c75f81504) lemminx: halve the closure size
* [`6b8fccf7`](https://github.com/NixOS/nixpkgs/commit/6b8fccf72ce501370b60d2eabb2e8cea6ff6b4ea) httplib: 0.14.3 -> 0.15.0
* [`d3cb53ff`](https://github.com/NixOS/nixpkgs/commit/d3cb53ff3c14bd17ceea717038fba035e1c98e83) kool: 2.2.0 -> 3.0.0
* [`39ba1b41`](https://github.com/NixOS/nixpkgs/commit/39ba1b4145516d98689f8ce60655e5679ecc0c1c) nixos/tests/zfs: improve naming
* [`5d798a06`](https://github.com/NixOS/nixpkgs/commit/5d798a06571b77d1d5af82b920751aa6951a6c21) nixos/tests/zfs: decouple makeZfsTest params from unstable vs. stable
* [`6261afcf`](https://github.com/NixOS/nixpkgs/commit/6261afcfd66b988212a4460b3617e2a1791b51d4) paper-clip: 4.0 -> 5.0
* [`e41b1efb`](https://github.com/NixOS/nixpkgs/commit/e41b1efb895d8e24531092378e46eac2e77ec177) tlsx: 1.1.5 -> 1.1.6
* [`5c8fbc5e`](https://github.com/NixOS/nixpkgs/commit/5c8fbc5e8d9d8ea8ef60f7b14ac5fcbdb833c513) python311Packages.awsipranges: init at 0.3.3
* [`91b25d13`](https://github.com/NixOS/nixpkgs/commit/91b25d13b99b596827ff642c2c1104b000938ea3) python311Packages.alive-progress: refactor
* [`cb8c8051`](https://github.com/NixOS/nixpkgs/commit/cb8c805187ab777851322e348aeeb72c7a47dc6d) python311Packages.alive-progress: 3.1.4 -> 3.1.5
* [`74548117`](https://github.com/NixOS/nixpkgs/commit/74548117cdca4a1f42bfdcbe3424b6ed84d3e541) nltk_data: add snowball_data
* [`b16d335a`](https://github.com/NixOS/nixpkgs/commit/b16d335ad49d39ec114d7396ab2fe13a8056752b) woodpecker-plugin-git: 2.4.0 -> 2.5.0
* [`da096af4`](https://github.com/NixOS/nixpkgs/commit/da096af4dbe545e1c6d6fecee86a849a33611fd3) tlsx: add ldflags
* [`2ef8836f`](https://github.com/NixOS/nixpkgs/commit/2ef8836fbe0146d93486b6f4c8087eae8ea8e544) nimlsp: 0.4.4 -> 0.4.6
* [`a9d7bbb1`](https://github.com/NixOS/nixpkgs/commit/a9d7bbb137571d0b5797c7a8b1fe8f40dd2ce5a6) ppsspp: refactor
* [`ed17c32c`](https://github.com/NixOS/nixpkgs/commit/ed17c32c97efb1487071a02ffce7a967c57f03d8) ppsspp: 1.16.1 -> 1.17
* [`51d444ef`](https://github.com/NixOS/nixpkgs/commit/51d444eff98308af526c3fe76969d308be4b8f6a) komga: 1.10.1 -> 1.10.3
* [`77f9c155`](https://github.com/NixOS/nixpkgs/commit/77f9c1555458be10b53b2354898c4993b1faa49f) prowler: init at 3.12.1
* [`753ca443`](https://github.com/NixOS/nixpkgs/commit/753ca44306fea3b2a0b6d7fd1cfc37ca84a5a56f) glslviewer: fix build with gcc 13
* [`39c00e24`](https://github.com/NixOS/nixpkgs/commit/39c00e2428bbbd3b03a64e0347395d29fab90057) thermald: 2.5.4 -> 2.5.6
* [`3c6e0b0d`](https://github.com/NixOS/nixpkgs/commit/3c6e0b0d3824746080feab6ef9cf65d76cfabd66) tev: fix build with gcc 13
* [`291b6a01`](https://github.com/NixOS/nixpkgs/commit/291b6a01c3156ec98f61d5b91eb2b83fe0a4f720) kubedog: 0.12.2 -> 0.12.3
* [`df379928`](https://github.com/NixOS/nixpkgs/commit/df379928f84734fe4cee237bc91ff31c5afa7be5) git-mit: 5.12.184 -> 5.12.186
* [`de6b5953`](https://github.com/NixOS/nixpkgs/commit/de6b59532ca3f8443570e79ced4bdc1537158458) fbjni: fix broken build due to missing `cstdint` include
* [`939db8e3`](https://github.com/NixOS/nixpkgs/commit/939db8e3379c857ae3fa6fd838c0696c5826043b) oam-tools: init at 0.1.2
* [`c09da460`](https://github.com/NixOS/nixpkgs/commit/c09da460e46046d3b9f4ec378995ffd21aa983ac) easyeasm: init at 1.0.6
* [`26897aa2`](https://github.com/NixOS/nixpkgs/commit/26897aa2537cff1815cf0d460e7528a88baee739) unciv: fix crash on startup
* [`db7b18f1`](https://github.com/NixOS/nixpkgs/commit/db7b18f15651c2b6127197fc7a88da8cedafbb07) datovka: 4.23.1 -> 4.23.4
* [`96e4f532`](https://github.com/NixOS/nixpkgs/commit/96e4f532f20ca53bb74abea24049ea74e5892798) mov-cli: refactor
* [`60132635`](https://github.com/NixOS/nixpkgs/commit/60132635d4584476212d38a8bff14a366dd8a591) mov-cli: migrate to by-name
* [`d861e6a9`](https://github.com/NixOS/nixpkgs/commit/d861e6a918711faa779a4575af4f061e4b8bdd53) mov-cli: 1.5.4 -> 1.5.6
* [`d378341e`](https://github.com/NixOS/nixpkgs/commit/d378341e283ea4ee3790965672348e9e87448db1) mov-cli: 1.5.6 -> 1.5.7
* [`ee8a5f63`](https://github.com/NixOS/nixpkgs/commit/ee8a5f63f5a997950fa59c63c605db232ba721cb) grizzly: 0.3.0 -> 0.3.1
* [`34ad6be1`](https://github.com/NixOS/nixpkgs/commit/34ad6be1cd23d17d79c93729dccee5541e0b004b) build-rust-crate: add missing CARGO_PKG env variables
* [`94e8e204`](https://github.com/NixOS/nixpkgs/commit/94e8e2045e1bd243f47671ea65d3845583a866ac) python311Packages.ytmusicapi: 1.5.0 -> 1.5.1
* [`da6d13ce`](https://github.com/NixOS/nixpkgs/commit/da6d13cea0023fc8501859ec38f16b036988f11d) graphite-cli: use buildNpmPackage
* [`3520bc21`](https://github.com/NixOS/nixpkgs/commit/3520bc218a78f786d14720d1e93bfcf8438fadc1) graphite-cli: 1.0.14 -> 1.1.2
* [`058d36f1`](https://github.com/NixOS/nixpkgs/commit/058d36f159333791bd22dff0fa0e70cc8b69c75b) net-cpp: 3.1.0 -> 3.1.1
* [`2f928063`](https://github.com/NixOS/nixpkgs/commit/2f9280632b911699f8bd3bf4c648204ee5a98fa2) persistent-cache-cpp: 1.0.6 -> 1.0.7
* [`fe21f2ce`](https://github.com/NixOS/nixpkgs/commit/fe21f2ceae7dab7356909f6a2ab5acdad6403488) lomiri.lomiri-schemas: 0.1.3 -> 0.1.4
* [`caad0176`](https://github.com/NixOS/nixpkgs/commit/caad017639e21c279eb6d9ed46e764608e69de8e) lomiri.hfd-service: 0.2.1 -> 0.2.2
* [`42ac243a`](https://github.com/NixOS/nixpkgs/commit/42ac243ab3d7c60534f0109dc5ae969e5bf8dfe7) lomiri.geonames: 0.3.0 -> 0.3.1
* [`0cfd256a`](https://github.com/NixOS/nixpkgs/commit/0cfd256a8150ebd938448784a78af9c6f1b1cc77) mongodb: mask Linux-only buildInputs on other platforms
* [`23f28ec0`](https://github.com/NixOS/nixpkgs/commit/23f28ec0a9d4b5c743df2a5a5ad2ab5088fbcbbe) wordnet: fix build on `clang-16`
* [`ac3e621e`](https://github.com/NixOS/nixpkgs/commit/ac3e621e7fc5501dd77dab6267de4a6a1a1b107e) deeptools: fix build
* [`6b47b111`](https://github.com/NixOS/nixpkgs/commit/6b47b1113fa23d77836594d71889ac9501bc4bb4) rdma-core: 49.1 -> 50.0
* [`bf755a20`](https://github.com/NixOS/nixpkgs/commit/bf755a20c6f71f5ee1fecaf98b3a019b34f96a59) jmol: 16.1.49 -> 16.1.51
* [`fd172356`](https://github.com/NixOS/nixpkgs/commit/fd172356959b5c8acca9d9ae62fe3e9335517e49) abseil-cpp_202401: init at 20240116.0
* [`c6944dff`](https://github.com/NixOS/nixpkgs/commit/c6944dffd3db5c3584e2d98d59cc74e4e71cd89c) portfolio: 0.67.1 -> 0.67.2
* [`a0d71869`](https://github.com/NixOS/nixpkgs/commit/a0d718692a373c4a1a9b8e6a3fd41445174a4dc8) mcaselector: 2.2.2 -> 2.3
* [`93234518`](https://github.com/NixOS/nixpkgs/commit/93234518828dfd10103cf4dc8e56724cbd468da4) edb: 1.3.0 -> 1.4.0
* [`b2b16180`](https://github.com/NixOS/nixpkgs/commit/b2b16180e20047f80e04dac3774b4f77fed78bd1) presenterm: 0.4.1 -> 0.5.0
* [`43695b8d`](https://github.com/NixOS/nixpkgs/commit/43695b8db40684570962a017de7241a256078eb9) pkgs/stdenv/darwin: move bootstrap files definitions to bootstrap-files/ directory
* [`bbabd9b6`](https://github.com/NixOS/nixpkgs/commit/bbabd9b6cbbc16841cb9d03949175ca0fd8548a0) obs-studio-plugins.obs-composite-blur: fix
* [`8dff0785`](https://github.com/NixOS/nixpkgs/commit/8dff0785cc6341eb8507c599e4900b74dc5eb745) docs/dart: Update unstable version example
* [`230eb916`](https://github.com/NixOS/nixpkgs/commit/230eb916d394f64c16e184a2398e0050bde8e3e6) budgie.budgie-session: init at 0.9.1
* [`a58775cf`](https://github.com/NixOS/nixpkgs/commit/a58775cfde259c2dc550b52a9805a4884c047c8f) gnome.gnome-session: Drop gnomeShellSupport option
* [`0d209c66`](https://github.com/NixOS/nixpkgs/commit/0d209c66415a8a751c8f6e34888729a2c13b64b8) nixos/budgie: Replace gnome-session with budgie-session
* [`cccf38f8`](https://github.com/NixOS/nixpkgs/commit/cccf38f8f85a87bc97a02d6b8511a3b7c872f4f2) gnmic: 0.35.0 -> 0.35.1
* [`9e67b430`](https://github.com/NixOS/nixpkgs/commit/9e67b4305cd96ce9d278b80a0c401700d87f7fdc) intel-compute-runtime: 23.43.27642.18 -> 23.48.27912.11
* [`348fc113`](https://github.com/NixOS/nixpkgs/commit/348fc113a21622069307d7f2ff2759b6154ae899) python311Packages.anthropic: 0.11.0 -> 0.12.0
* [`e0331ec3`](https://github.com/NixOS/nixpkgs/commit/e0331ec3e4861c3eb929c687eceab2db8526f656) terraform-compliance: 1.3.46 -> 1.3.47
* [`96101568`](https://github.com/NixOS/nixpkgs/commit/961015684e9924076248e1366f963a51f48164ec) uftrace: 0.15.1 -> 0.15.2
* [`0e7efe59`](https://github.com/NixOS/nixpkgs/commit/0e7efe59de3518ca0da1429b6ce8e859811f1da7) v2ray-domain-list-community: 20240105034708 -> 20240123112230
* [`4cecdd99`](https://github.com/NixOS/nixpkgs/commit/4cecdd99e5e2c1075f80425442c84c5b5c47d5e0) home-manager: unstable-2024-01-23 -> unstable-2024-01-28
* [`aa6d222e`](https://github.com/NixOS/nixpkgs/commit/aa6d222e64e20aa4b9be70efcabb29be5e5984fb) maintainers: add averagebit
* [`6e1cbcd3`](https://github.com/NixOS/nixpkgs/commit/6e1cbcd3c228eae9b7d4c94e425b685159295557) prometheus-knot-exporter: 3.3.3 -> 3.3.4
* [`c0079344`](https://github.com/NixOS/nixpkgs/commit/c0079344adae8a8eeb7ac8aae9247ce6001af9f5) python311Packages.approvaltests: 10.2.0 -> 10.3.0
* [`4dd4cdf0`](https://github.com/NixOS/nixpkgs/commit/4dd4cdf07a865f21b711e36ca35fb86edea1daff) python311Packages.robotframework-seleniumlibrary: fix tests
* [`93aa0025`](https://github.com/NixOS/nixpkgs/commit/93aa00253e724c803b1a3f413200ddc8042b4514) xfce.libxfce4windowing: init at 4.19.2
* [`1a7c8f44`](https://github.com/NixOS/nixpkgs/commit/1a7c8f44509b47006f3e21ea4b87f2189fba1dba) checkov: 3.1.70 -> 3.2.0
* [`773d09d9`](https://github.com/NixOS/nixpkgs/commit/773d09d9200df7a7724013aab6fb9b932b697631) python311Packages.nibabel: 5.1.0 -> 5.2.0
* [`50acbada`](https://github.com/NixOS/nixpkgs/commit/50acbada81e3b47cd495bee38884c5bf453c71c8) virt-viewer: add GStreamer in buildInputs
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
