### PR TITLE
niv devenv: update ad0ae333 -> 0e68853b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "ad0ae333b210e31237e1fc4a7ddab71a01785add",
-        "sha256": "1r6j2rxbicmd85bl2idpgpk7rrr5i283vh3cc23vxw9dxnnkwvkp",
+        "rev": "0e68853bb27981a4ffd7a7225b59ed84f7180fc7",
+        "sha256": "151gd36r0s7ilalssiyg7v840k7nhi315hnb0cwvkg5dfnigqypl",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/ad0ae333b210e31237e1fc4a7ddab71a01785add.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/0e68853bb27981a4ffd7a7225b59ed84f7180fc7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@ad0ae333...0e68853b](https://github.com/cachix/devenv/compare/ad0ae333b210e31237e1fc4a7ddab71a01785add...0e68853bb27981a4ffd7a7225b59ed84f7180fc7)

* [`e4019e17`](https://github.com/cachix/devenv/commit/e4019e17e9818cc3f107cef515d23d255e43e29a) doc: fix github actions snippet
* [`c90a1925`](https://github.com/cachix/devenv/commit/c90a19256de1c5cda890afb1c589c759ec66f51d) Allow nodeName to be configured
* [`60cdb73b`](https://github.com/cachix/devenv/commit/60cdb73b9e9f2ebf1969cf4615a4f0d054fdbc10) Formatting
* [`9479b999`](https://github.com/cachix/devenv/commit/9479b999d9b96e46ce5dd31a72994df3efcf0d54) Adds rabbitmq test script
* [`0e68853b`](https://github.com/cachix/devenv/commit/0e68853bb27981a4ffd7a7225b59ed84f7180fc7) Auto generate docs/reference/options.md
