### PR TITLE
niv home-manager: update d634c3ab -> f99eace7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d634c3abafa454551f2083b054cd95c3f287be61",
-        "sha256": "0mxrylbycywi8qh6zb1il5yfb5apbjsd7avhvfpavclkjaz80awb",
+        "rev": "f99eace7c167b8a6a0871849493b1c613d0f1b80",
+        "sha256": "1xfls81znzrjz021wd404hvdb7r9wfh8pvls6cpa3q2hmc5qghnh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d634c3abafa454551f2083b054cd95c3f287be61.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f99eace7c167b8a6a0871849493b1c613d0f1b80.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d634c3ab...f99eace7](https://github.com/nix-community/home-manager/compare/d634c3abafa454551f2083b054cd95c3f287be61...f99eace7c167b8a6a0871849493b1c613d0f1b80)

* [`2db6a2a4`](https://github.com/nix-community/home-manager/commit/2db6a2a42930ffff0ffd690dec3f2c0b6f4fe66d) docs: add style sheets and `scrubDerivations`
* [`4d53427b`](https://github.com/nix-community/home-manager/commit/4d53427bce7bf3d17e699252fd84dc7468afc46e) xfconf: fix config loading
* [`880d9bc2`](https://github.com/nix-community/home-manager/commit/880d9bc2110f7cae59698f715b8ca42cdc53670c) nix: fix generation of nix.conf for nix >= 2.20
* [`1ca21064`](https://github.com/nix-community/home-manager/commit/1ca210648a6ca9b957efde5da957f3de6b1f0c45) tests: reduce closure sizes
* [`230836bb`](https://github.com/nix-community/home-manager/commit/230836bb7ca318aec7bad8442954da611d06a172) hyprland: fix hyprctl crash
* [`9291f28f`](https://github.com/nix-community/home-manager/commit/9291f28f93a818e4496a6f71f6c77f59108d4d46) Translate using Weblate (Turkish)
* [`4ab01785`](https://github.com/nix-community/home-manager/commit/4ab01785b85aac4dd0f0414f7c0ca4c007e64054) flake.lock: Update
* [`f80df90c`](https://github.com/nix-community/home-manager/commit/f80df90c105d081a49d123c34a57ead9dac615b9) fish: implement shellInitLast (after others)
* [`1683c507`](https://github.com/nix-community/home-manager/commit/1683c507c2c58a502294330de940e2b4b51bdf75) vdirsyncer: create postHook script when non-empty
* [`4740f2cc`](https://github.com/nix-community/home-manager/commit/4740f2ccda184e9cc509d7a82b26d7271e0c79d9) kitty: always export `KITTY_SHELL_INTEGRATION`
* [`a28b12d7`](https://github.com/nix-community/home-manager/commit/a28b12d7412324aa22a5f9df8909672dec33613e) vscode: add openvscode-server
* [`afcedcf2`](https://github.com/nix-community/home-manager/commit/afcedcf2c8e424d0465e823cf833eb3adebe1db7) mcfly: add interfaceView option
* [`274bd470`](https://github.com/nix-community/home-manager/commit/274bd470a544647d90d7491037fdf8af61b7d8d0) nix-gc: add service
* [`3c6f2dd5`](https://github.com/nix-community/home-manager/commit/3c6f2dd59cb8c0b06ed1fe01f297e75bbaec3003) himalaya: adjust module for v1.0.0-beta
* [`b319781e`](https://github.com/nix-community/home-manager/commit/b319781e304c668da0ef144b1b4ee48977d4877d) home-manager: Check VISUAL before EDITOR for editor
* [`13dbf262`](https://github.com/nix-community/home-manager/commit/13dbf2623d6465d5c4db54ce8a5a630dce79c3e9) swayosd: update executable
* [`7b4ea8d8`](https://github.com/nix-community/home-manager/commit/7b4ea8d82fdeaa71ab942a8a8f6f8add8afdfad0) arrpc: add module
* [`f65dcd6c`](https://github.com/nix-community/home-manager/commit/f65dcd6c15db0fc2045d56ef8fdf4a03aa52e81f) neomutt: fix crypt_use_gpgme in newer versions
* [`f99eace7`](https://github.com/nix-community/home-manager/commit/f99eace7c167b8a6a0871849493b1c613d0f1b80) jetbrains-remote: add module
