### PR TITLE
niv powerlevel10k: update 307bce24 -> ce7c2423

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "307bce24d19fa09d971a0d33c39f3c9fda82924e",
-        "sha256": "0qw9vw9vdv9y66jf5amck3kyc1qd1c5czpahgym3pbh3bbgkhw3k",
+        "rev": "ce7c242337c6e1002c0af64d43b8c8904007055b",
+        "sha256": "1wmsf4ki07k2ad5k6hgal2llc556lh8rwjyh3k1g22gp4fjmnvld",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/307bce24d19fa09d971a0d33c39f3c9fda82924e.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/ce7c242337c6e1002c0af64d43b8c8904007055b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@307bce24...ce7c2423](https://github.com/romkatv/powerlevel10k/compare/307bce24d19fa09d971a0d33c39f3c9fda82924e...ce7c242337c6e1002c0af64d43b8c8904007055b)

* [`6f4520cc`](https://github.com/romkatv/powerlevel10k/commit/6f4520cc13cd203fef81ecc7f095cd45c7960766) add neon support
* [`adc238fa`](https://github.com/romkatv/powerlevel10k/commit/adc238fa1d188d075e8803ea85dcca44d2deff4f) neon support
* [`62341054`](https://github.com/romkatv/powerlevel10k/commit/62341054d8aa40ade03fc55bdbc95b9ff2d8d2b6) set the default value of LINUX_NEON_ICON to a glyph that exists in the recommended font ([romkatv/powerlevel10k⁠#2553](https://togithub.com/romkatv/powerlevel10k/issues/2553))
* [`34ee1c6b`](https://github.com/romkatv/powerlevel10k/commit/34ee1c6bbb6b8e2372c4937d9ea7afa1855957de) fix: use correct sourcehut repository url ([romkatv/powerlevel10k⁠#2556](https://togithub.com/romkatv/powerlevel10k/issues/2556))
* [`ce7c2423`](https://github.com/romkatv/powerlevel10k/commit/ce7c242337c6e1002c0af64d43b8c8904007055b) bump versions
