### PR TITLE
niv nixpkgs: update 629906e6 -> 5a7b453b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "629906e6a94b0cc022cbbfa6b85a6b9c960e624a",
-        "sha256": "0lq1c8dmrwfwlpwrchk79gh7cn5v4636zp0nn5vwijlbd0mf3jzj",
+        "rev": "5a7b453b37801e02561340653106ab2781b30165",
+        "sha256": "0llbjyibxy4kci2hhnrj7bwfmlgyqj8r7zw0wvxp7sgdf61xgq2s",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/629906e6a94b0cc022cbbfa6b85a6b9c960e624a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5a7b453b37801e02561340653106ab2781b30165.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@629906e6...5a7b453b](https://github.com/nixos/nixpkgs/compare/629906e6a94b0cc022cbbfa6b85a6b9c960e624a...5a7b453b37801e02561340653106ab2781b30165)

* [`50c6120a`](https://github.com/NixOS/nixpkgs/commit/50c6120a3e14a15b507f07237d4748c6ebacbba5) buildUBoot: supports Python scripts with their own environment
* [`32104c2f`](https://github.com/NixOS/nixpkgs/commit/32104c2fec1299dcd2e1253dfcfc1894b1096469) ubootTools: add `efivar.py` as a tool
* [`fed5af2d`](https://github.com/NixOS/nixpkgs/commit/fed5af2d157c56fc79baa24287e8eaf1ce4798db) nixos/systemd: update rateLimitBurst documentaion.
* [`57dbf4c0`](https://github.com/NixOS/nixpkgs/commit/57dbf4c082e00be0c27412b72080b99b09101d88) nixos/tt-rss: supply --force-yes to update-schema
* [`0c8f023b`](https://github.com/NixOS/nixpkgs/commit/0c8f023b9dd582d38b38fe350c53c7aeb9212e23) dav1d: 1.2.1 -> 1.3.0
* [`dc0f09a4`](https://github.com/NixOS/nixpkgs/commit/dc0f09a49f590b825e93bfd9e0ea94b4b5701fc4) zip: fix buffer overflow on Unicode path names
* [`cbf59c98`](https://github.com/NixOS/nixpkgs/commit/cbf59c98a8b8565f345cbe3a00485324bcf513cd) libipt: 2.0.6 -> 2.1
* [`6ed6953e`](https://github.com/NixOS/nixpkgs/commit/6ed6953e22ec8648f566c9a459e84e5b90a71806) nixos/oci-containers: stop container using backend
* [`a748f5ce`](https://github.com/NixOS/nixpkgs/commit/a748f5ceee4ca962712144cb58b0eaef2703c461) rl_json: init at 0.14
* [`f7f4acca`](https://github.com/NixOS/nixpkgs/commit/f7f4accacb472cca4eb9dc8f60a218fd6e65d91a) boehmgc: 8.2.2 -> 8.2.4
* [`b2d0641e`](https://github.com/NixOS/nixpkgs/commit/b2d0641e340334994ffc1cc455ab8d82a5ffb13d) nix: rebase boehmgc-coroutine-sp-fallback.patch
* [`759a7cc5`](https://github.com/NixOS/nixpkgs/commit/759a7cc50e170a1137bb172559b961fa657ecb8a) buildMozillaMach: passthru requireSigning/allowAddonSideload
* [`491072e7`](https://github.com/NixOS/nixpkgs/commit/491072e797f6d28960f182d45125f1f93b9522ce) buildMozillaMach: allow overriding requireSigning/allowAddonSideload
* [`791b761c`](https://github.com/NixOS/nixpkgs/commit/791b761c6181525b897e6f0f6f6e80d3fe462eca) cmake: 3.27.8 -> 3.27.9
* [`687f42d6`](https://github.com/NixOS/nixpkgs/commit/687f42d64bb894d41aef996db7d8bf6d356d8ff9) unicode-character-database: do not include env-vars
* [`7fbc26ac`](https://github.com/NixOS/nixpkgs/commit/7fbc26ac84f9045241052ac7b675f2f821fe8bc5) libsForQt515.audiotube: depend on kpurpose
* [`f341406d`](https://github.com/NixOS/nixpkgs/commit/f341406ddc2a077de0b8e7d3a5ff68cedbd84cad) kbd: 2.6.3 -> 2.6.4
* [`969511fb`](https://github.com/NixOS/nixpkgs/commit/969511fba74e62e0fc01719ce848b265eb6642ac) tmuxPlugins.tmux-thumbs: 0.7.1 -> 0.8.0
* [`77536ba6`](https://github.com/NixOS/nixpkgs/commit/77536ba66a2033df2f3c561f753268002698a791) libsepol: 3.5 -> 3.6
* [`c8de15eb`](https://github.com/NixOS/nixpkgs/commit/c8de15eb07efc1d79cbf940ed69d70d9a269d9ba) maintainers: add Gliczy
* [`59539b9b`](https://github.com/NixOS/nixpkgs/commit/59539b9bc5a4a91e6778505a8901f56c6ad841e1) tsm-client: 8.1.20.0 -> 8.1.21.0
* [`9c870ac7`](https://github.com/NixOS/nixpkgs/commit/9c870ac78f6157260ba1f96f9ce077ce84478532) nixos/kubernetes: fix pki's mkSpec function
* [`953f3577`](https://github.com/NixOS/nixpkgs/commit/953f35778af53c85862d4ed2cb0bec49851c7e83) fdk_aac: 2.0.2 -> 2.0.3
* [`92605d21`](https://github.com/NixOS/nixpkgs/commit/92605d2155a8eda40f781dd65733a09957ea9b69) alsa-ucm-conf: apply patch to fix SplitPCM: Device argument may not be set
* [`572a7c01`](https://github.com/NixOS/nixpkgs/commit/572a7c01fb4c12b88f6dda33d1ffbca8b3b8a88f) exempi: 2.6.4 -> 2.6.5
* [`e6d5d5d4`](https://github.com/NixOS/nixpkgs/commit/e6d5d5d44f03cfd3ca37a9a9a12a6fe6a30b14a5) pcsclite: disable building pcsc-wirecheck{,-gen} when cross compiling
* [`3ca69672`](https://github.com/NixOS/nixpkgs/commit/3ca696729b25b9adc71040237bcacf0125d156d1) cloudflared: fixed missing configuration options
* [`52a0f4a7`](https://github.com/NixOS/nixpkgs/commit/52a0f4a7acc0f6445d501c6519d6357b7513419c) fcitx5-openbangla-keyboard: fix runtime crash
* [`068d0c8a`](https://github.com/NixOS/nixpkgs/commit/068d0c8a43cb9bf50d56bdb00d0aa7813417a518) boinctui: init at 2.7.1
* [`6f4daaaf`](https://github.com/NixOS/nixpkgs/commit/6f4daaafe58ce280cba781498279b5a22bf38623) ataripp: migrate to by-name
* [`e5338a2b`](https://github.com/NixOS/nixpkgs/commit/e5338a2b7db2b0f8938e5d7634bf55d0aa2f8845) ataripp: cleanup
* [`006a2b5e`](https://github.com/NixOS/nixpkgs/commit/006a2b5e92041ec31feeb2abd49079e2a17d956f) atari800: migrate to by-name
* [`704823fe`](https://github.com/NixOS/nixpkgs/commit/704823fe3c9ec66bb058161fd76cfcd4ce87ccca) atari800: cleanup
* [`8c4161f8`](https://github.com/NixOS/nixpkgs/commit/8c4161f86d32c8443c8cb38f8885d605cbe61b37) atari800: 5.0.0 -> 5.1.0
* [`e9a8b6e4`](https://github.com/NixOS/nixpkgs/commit/e9a8b6e46577d11e2e4570b99d1ff7b95012217c) update-melpa: use cl-lib instead of cl
* [`db45ed38`](https://github.com/NixOS/nixpkgs/commit/db45ed38013b04a706847abc56203fdad901c5c9) nixosTests.kernel-generic: fix the eval
* [`a9323a37`](https://github.com/NixOS/nixpkgs/commit/a9323a371bf69b640fd3034a546535b16774bb52) p11-kit: fix builds on single-user systems
* [`18ee3115`](https://github.com/NixOS/nixpkgs/commit/18ee31152a86519ecf045c9bf4580a0b5c8ac245) c-blosc: 1.21.1 -> 1.21.5
* [`09a08620`](https://github.com/NixOS/nixpkgs/commit/09a086209247c1b813f04dd31d96dd357bd7efea) python311Packages.pillow-jpls: init at 1.3.2
* [`2e2097cb`](https://github.com/NixOS/nixpkgs/commit/2e2097cb96680da1351b36c4eff76de274c32242) update-melpa: use url lib to parse HTTP instead of custom code
* [`87e591d6`](https://github.com/NixOS/nixpkgs/commit/87e591d63b5964ae5dd725fbcdeaf0c650eeb356) python311Packages.highdicom: init at 0.22.0
* [`6e533207`](https://github.com/NixOS/nixpkgs/commit/6e533207335eac36a932123ab39760e06198ac69) go-critic: init at 0.11.0
* [`87a298de`](https://github.com/NixOS/nixpkgs/commit/87a298deee7eed5a859ebff64df0c8da6c0075ab) fitsverify: init at 4.22
* [`75afd4c0`](https://github.com/NixOS/nixpkgs/commit/75afd4c0beae2fc6cf94ebd56ee9a5e17836ba36) maintainers add remexre
* [`c1162ca5`](https://github.com/NixOS/nixpkgs/commit/c1162ca5608df8cb4841e132302cab61f5ed2d41) davinci-resolve-studio: Automatically create license dir
* [`faaff6e3`](https://github.com/NixOS/nixpkgs/commit/faaff6e3665ae07fc73abf0c76071f5275044874) maintainers: add jokatzke
* [`47563275`](https://github.com/NixOS/nixpkgs/commit/47563275a17776056e6c198efd377f2b90d8c8a3) space-station-14-launcher: 0.24.0 -> 0.25.1
* [`f24dc640`](https://github.com/NixOS/nixpkgs/commit/f24dc6400176c841e4b0748a1825d57e49be19ac) linenoise: 1.0.10 -> 1.0-34-g93b2db9
* [`b2007d12`](https://github.com/NixOS/nixpkgs/commit/b2007d128e2f63d38d6585cfeec6989d7920b925) cmd-wrapped: init at 0.1.1
* [`4819e2bf`](https://github.com/NixOS/nixpkgs/commit/4819e2bfe059a5320ef858dc3abb68c9df99d020) c-blosc: avoid vendored lz4, zlib & zstd, enable tests
* [`b5dfa01e`](https://github.com/NixOS/nixpkgs/commit/b5dfa01e6781cf907109567d5ca994a80e0be02f) degate: init at 2.0.0
* [`612b3227`](https://github.com/NixOS/nixpkgs/commit/612b3227d3612b0ae78d014caef0eba1fdef7ce7) enchant: 2.6.3 -> 2.6.5
* [`3ae0f901`](https://github.com/NixOS/nixpkgs/commit/3ae0f9017f3dada94ae36942ad169fa59e315c3b) libedit: 20221030-3.1 -> 20230828-3.1
* [`88d193f8`](https://github.com/NixOS/nixpkgs/commit/88d193f8f5aa06531282ff6a7a4198662cd2f856) iproute2: 6.6.0 -> 6.7.0
* [`3b5f59a0`](https://github.com/NixOS/nixpkgs/commit/3b5f59a08e7b1a8a8e99771726fa04046e19f058) octoprint.plugins.printtimegenius: 2.2.8 -> 2.3.1
* [`9e7bee8b`](https://github.com/NixOS/nixpkgs/commit/9e7bee8bb553a78f36b9e2b1ca88a66e638cc611) halftone: 0.5.0 -> 0.6.0
* [`5a94735b`](https://github.com/NixOS/nixpkgs/commit/5a94735bb4c7bba4ddce4bab3e0892a77a522ca2) halftone: add meta.mainProgram and meta.platforms
* [`205ccaef`](https://github.com/NixOS/nixpkgs/commit/205ccaef1d141f0c6ce4cc317dc23a8f7befcfac) qpdf: 11.6.3 -> 11.8.0
* [`62d6083d`](https://github.com/NixOS/nixpkgs/commit/62d6083d3cd4ee629da58b4225349c21c9099999) python311Packages.trove-classifiers: 2023.11.29 -> 2024.1.8
* [`678eee38`](https://github.com/NixOS/nixpkgs/commit/678eee38f3edeba6ddb13b02cf0c62608a9c0549) boatswain: 0.3.0 → 0.4.0
* [`6899a742`](https://github.com/NixOS/nixpkgs/commit/6899a742755959f6ad50055b5ee3f5393a09632d) maintainers: add croissong
* [`a3dd9749`](https://github.com/NixOS/nixpkgs/commit/a3dd9749f9cbe70543e2e2b1c172d225233070eb) updatecli: init at 0.70.0
* [`b027bb03`](https://github.com/NixOS/nixpkgs/commit/b027bb0374d489badcb61b2c6b8459aac43bf5df) rclip: 1.7.6 -> 1.7.24
* [`5ae7a93f`](https://github.com/NixOS/nixpkgs/commit/5ae7a93f626a37f4320a4a789096c6dd3569ff96) attr: 2.5.1 -> 2.5.2
* [`813f5d7b`](https://github.com/NixOS/nixpkgs/commit/813f5d7bbb4c09b997bf67ac0a0697e4d22e3fc0) isocodes: 4.15.0 -> 4.16.0
* [`70d94329`](https://github.com/NixOS/nixpkgs/commit/70d943295c92e98af02a809053d295a69a72719f) rubyPackages.msgpack: drop nonexistent dependency on msgpack
* [`d8150733`](https://github.com/NixOS/nixpkgs/commit/d815073393b24c345a16f3784f97989f998600e9) libidn: 1.41 -> 1.42
* [`5aaf2ce7`](https://github.com/NixOS/nixpkgs/commit/5aaf2ce7e59f6a0cae48459d29f773f305381875) libsForQt5.qca: 2.3.7 -> 2.3.8
* [`95123f35`](https://github.com/NixOS/nixpkgs/commit/95123f35896a54f51693e41921b7aa9b03a641b0) nginxModules.echo: add version to support nix-update
* [`7b74c252`](https://github.com/NixOS/nixpkgs/commit/7b74c252dfacecb0b2edb4e4495bb21a5df9c896) nginxModules.lua: add version to support nix-update
* [`f462bea3`](https://github.com/NixOS/nixpkgs/commit/f462bea34eb7b82f7c4a21e66bb62264fd51304c) nginxModules.echo: 0.62 -> 0.63
* [`d8a53ce4`](https://github.com/NixOS/nixpkgs/commit/d8a53ce4285fc38a5daa140e16937b413904e13b) nginxModules.lua: 0.10.22 -> 0.10.26
* [`2e051a49`](https://github.com/NixOS/nixpkgs/commit/2e051a49b48b284abf038eecf74251d5538e20a9) libpsl: 0.21.2 -> 0.21.5
* [`32cacb91`](https://github.com/NixOS/nixpkgs/commit/32cacb910002b59442fdd10bf5a5de3d8e326071) cpio: 2.14 -> 2.15
* [`bbf8e405`](https://github.com/NixOS/nixpkgs/commit/bbf8e405bd569deb94619c6a61e3bb735df91531) catch2_3: 3.5.1 -> 3.5.2
* [`97e613d5`](https://github.com/NixOS/nixpkgs/commit/97e613d5ccb5a2a040f73ec9046f822444b516c1) xorg.imake: 1.0.9 -> 1.0.10
* [`ce18df9f`](https://github.com/NixOS/nixpkgs/commit/ce18df9f95f2f4786a9ea4a7ed67e49d4ecfaec9) python310Packages.mitmproxy-rs: fix platforms
* [`10496208`](https://github.com/NixOS/nixpkgs/commit/104962081f5ee294f50d2e7d7c65dd92e4741c37) python3Packages.mitmproxy-wireguard: drop
* [`9296199d`](https://github.com/NixOS/nixpkgs/commit/9296199d02167661ae9ebc86d89ca70fe32a02af) sqlite, sqlite-analyzer: 3.44.2 -> 3.45.0
* [`6c28096c`](https://github.com/NixOS/nixpkgs/commit/6c28096c16e7a8c8add40b1f12dbd97f87c87767) shadow: 4.14.2 -> 4.14.3
* [`4181c1f5`](https://github.com/NixOS/nixpkgs/commit/4181c1f58775ee90277569f4f636e6cabe91d828) bash: 5.2p21 -> 5.2p26
* [`43f2bb13`](https://github.com/NixOS/nixpkgs/commit/43f2bb13b225287422b8da5edd8b51a3007ff095) libdecor: 0.1.1 → 0.2.2
* [`bfe565b3`](https://github.com/NixOS/nixpkgs/commit/bfe565b38722e3e26356d00c9da8a7a24b1a1e2e) libmaxminddb: 1.7.1 -> 1.9.1
* [`bc08997f`](https://github.com/NixOS/nixpkgs/commit/bc08997f00d1262b5a1cf2808d6cb046c4d0c4cb) dhcpcd: 10.0.3 -> 10.0.6
* [`159b810b`](https://github.com/NixOS/nixpkgs/commit/159b810bead4af2e04145d8a63168cab0d40538b) libcamera: 0.1.0 → 0.2.0
* [`184c7127`](https://github.com/NixOS/nixpkgs/commit/184c7127eadc6b4febac64dca030637e7b0ab28c) wimlib: 1.13.6 -> 1.14.3
* [`c58d060c`](https://github.com/NixOS/nixpkgs/commit/c58d060c232c5affcc8fa9fde5f0f88ac660be76) emacs: 29.1 -> 29.2
* [`3ae83d1f`](https://github.com/NixOS/nixpkgs/commit/3ae83d1fadf35b1c57541627400612c4fb892249) python3Packages.scipy: add patch to fix build with openblas 0.3.26
* [`4adfb15a`](https://github.com/NixOS/nixpkgs/commit/4adfb15a20051c7bd075b9d03a8227211422977f) openblas: 0.3.25 -> 0.3.26
* [`fdc01914`](https://github.com/NixOS/nixpkgs/commit/fdc01914573cab5d476e4cc3dd4df1fcf13b8403) pipewire: Added upstream patch for libcamera 0.2.0 changes.
* [`e6b3cd9d`](https://github.com/NixOS/nixpkgs/commit/e6b3cd9d23fa0078d73f1c5dc3b3e533e832b26c) python311Packages.ansible-core: generate missing man pages
* [`234a9042`](https://github.com/NixOS/nixpkgs/commit/234a90427a2707de5b73b4a28be51a2f8d3e5740) gjs: 1.78.1 -> 1.78.3
* [`bc73401b`](https://github.com/NixOS/nixpkgs/commit/bc73401bf642f80465900c38090dae5618cd5be1) pam: 1.5.3 -> 1.6.0
* [`2193026e`](https://github.com/NixOS/nixpkgs/commit/2193026e9fe9189a04a585e217a272e44ef93bca) efivar: pull `gcc-13` fix pending upstream inclusion
* [`59fe6971`](https://github.com/NixOS/nixpkgs/commit/59fe697100e0bc5046c20c314c2d5689831b4b30) libaom: 3.8.0 -> 3.8.1
* [`b6933c94`](https://github.com/NixOS/nixpkgs/commit/b6933c94d807f1a7b7876090c660da925a48012f) db60: 6.0.20 -> 6.0.30
* [`0520a001`](https://github.com/NixOS/nixpkgs/commit/0520a00194b98b05d9dd5c3f61c784982db9ae9d) db62: 6.2.23 -> 6.2.32
* [`147e5c50`](https://github.com/NixOS/nixpkgs/commit/147e5c5026cd9e77fa456fcead3e5486969e263f) iputils: 20231222 -> 20240117
* [`ce9db269`](https://github.com/NixOS/nixpkgs/commit/ce9db269a63518296030dbf2a0cb0f729686552e) linuxHeaders: 6.6 -> 6.7
* [`a8f8d262`](https://github.com/NixOS/nixpkgs/commit/a8f8d262582eec4ee8c6a6e76d70116c5b51a7ff) release-notes: add note on new ability to set defaultHardeningFlags
* [`40868719`](https://github.com/NixOS/nixpkgs/commit/40868719b0ff142d0df5fba0f2ec7f370e072048) cc-wrapper: add zerocallusedregs hardening flag
* [`851f20e1`](https://github.com/NixOS/nixpkgs/commit/851f20e12826cf368d2df9f7137061b8108636d0) libxml2: 2.12.3-unstable-2023-12-14 → 2.12.4
* [`e35a2e2f`](https://github.com/NixOS/nixpkgs/commit/e35a2e2fe339efdeb9493fc6e4b29f39992afe0c) python3Packages.pillow: 10.1.0 -> 10.2.0
* [`aa776b2f`](https://github.com/NixOS/nixpkgs/commit/aa776b2f66cf1a02110ca907d0f6831164806b29) libbsd: unstable-2023-04-29 -> 0.11.8
* [`108dfbc2`](https://github.com/NixOS/nixpkgs/commit/108dfbc2c4a8aeb07cca8c0ee7aafa684995e1b3) libcbor: unstable-2023-01-29 -> 0.10.2
* [`cf938b42`](https://github.com/NixOS/nixpkgs/commit/cf938b42d02e9a150d9b077b8a83b009d5808716) libwpd: 0.10.0 -> 0.10.3
* [`39d481d3`](https://github.com/NixOS/nixpkgs/commit/39d481d3b015d6fa2f0945c4c77a01aeeabd6458) libwpg: 0.3.3 -> 0.3.4
* [`c943bf8a`](https://github.com/NixOS/nixpkgs/commit/c943bf8a2ef60e9cdb7662816d214ac4797b3993) publicsuffix-list: unstable-2023-02-16 -> 0-unstable-2024-01-07
* [`9f074f99`](https://github.com/NixOS/nixpkgs/commit/9f074f996e1fc5f09faeeab8f15af889676dbe7f) matrix-synapse-plugins.matrix-synapse-s3-storage-provider: 1.2.1 -> 1.3.0
* [`e79c1338`](https://github.com/NixOS/nixpkgs/commit/e79c13385843382aa2256898f80b44030889f9a5) add pkgsExtraHardening package set
* [`506ec38e`](https://github.com/NixOS/nixpkgs/commit/506ec38e7f2292790dba1b34b5def792ad2de5e8) cc-wrapper, clang: use new mechanism to selectively unsupport zerocallusedregs
* [`6ed157d9`](https://github.com/NixOS/nixpkgs/commit/6ed157d9b95901ea59e59c0f8e1ae154e3eca2b9) bluez: 5.71 -> 5.72
* [`79393a0b`](https://github.com/NixOS/nixpkgs/commit/79393a0b8651641d2aa2a1d5234045eba6d53020) apfsprogs: migrate to by-name
* [`e0af35e1`](https://github.com/NixOS/nixpkgs/commit/e0af35e11410df340828c9e7044c4bfd87ce8ba3) apfsprogs: enable `strictDeps`
* [`573a0dc7`](https://github.com/NixOS/nixpkgs/commit/573a0dc7fccd03ae53c4744424991b7190061061) apfsprogs: unstable-2023-06-06 -> unstable-2023-11-30
* [`db2e18be`](https://github.com/NixOS/nixpkgs/commit/db2e18bec8b659c24aefbf4c245b36978c5e97f3) ed: 1.19 -> 1.20
* [`d05d881c`](https://github.com/NixOS/nixpkgs/commit/d05d881cbe2d1cff586e800ee14d619bec0c265c) blink: 1.0.0 -> 1.1.0
* [`6ab22c11`](https://github.com/NixOS/nixpkgs/commit/6ab22c116897f8dc5f074ee95625293af2af5ac5) nghttp2: 1.57.0 -> 1.59.0
* [`8b019cb9`](https://github.com/NixOS/nixpkgs/commit/8b019cb963231315e5ad84e19a81fe3e8dcdf31d) vimPlugins.vim-clap: 0.49 -> 0.50
* [`a1438ae6`](https://github.com/NixOS/nixpkgs/commit/a1438ae600fbc8befcd590072c0f90e6a1b6771f) libuv: work around test breaks on macOS < 10.15
* [`b20a26be`](https://github.com/NixOS/nixpkgs/commit/b20a26be5b463cf3452f47d81eee210c5e2889c9) python311Packages.afdko: 4.0.0+unstable-2023-11-07 -> 4.0.1
* [`9e218d49`](https://github.com/NixOS/nixpkgs/commit/9e218d49f008957cb15b0cd48875ee5b164835af) azure-cli: 2.55.0 -> 2.56.0
* [`83bc0039`](https://github.com/NixOS/nixpkgs/commit/83bc00391abbe7e830613cce03272fba995f7eca) gh2md: 2.0.0 -> 2.3.1
* [`95331c15`](https://github.com/NixOS/nixpkgs/commit/95331c15ee1e2bcb4e92dd7b43b6f7fdc6a3425f) bluez: fix build by adding pygments
* [`24e043c6`](https://github.com/NixOS/nixpkgs/commit/24e043c62b7b8c56516b83baba7d9ac3d74b5715) python3Packages.h5io: init at 0.2.1
* [`2a6418ee`](https://github.com/NixOS/nixpkgs/commit/2a6418ee03f9533f9492d9cd48053703e6e14f32) python3Packages.pytest-harvest: init at 1.10.4
* [`ccad08f7`](https://github.com/NixOS/nixpkgs/commit/ccad08f75e0d7d94131e22cd1e63a706ac02915b) python3Packages.pymatreader: init at 0.0.31
* [`3f00b40f`](https://github.com/NixOS/nixpkgs/commit/3f00b40fff0e6de822196dd926d8efca430b490b) androidenv: don't include emulator when includeEmulator is false
* [`77d29a6d`](https://github.com/NixOS/nixpkgs/commit/77d29a6dfc12f0ef3f7f0115c3b85a9b998be7ec) rust-bindgen-unwrapped: 0.69.1 -> 0.69.2
* [`a6efe42f`](https://github.com/NixOS/nixpkgs/commit/a6efe42fe09100bbffd3a00ad1b61d464e4a7e25) python3Packages.mne-python: 1.6.0 -> 1.6.1
* [`9f56eed7`](https://github.com/NixOS/nixpkgs/commit/9f56eed7b7f778ad930b3549483b663402665013) python3Packages.mne-python: add myself (mbalatsko) as maintainer
* [`96a3f017`](https://github.com/NixOS/nixpkgs/commit/96a3f01792ec16408c07c770ebcd170773b5b97b) python311Packages.sphinx-tabs: 3.4.4 -> 3.4.5
* [`3bf7b153`](https://github.com/NixOS/nixpkgs/commit/3bf7b1536dde66b3d3de84f9e4cb5549a35642b1) libimagequant: 4.2.2 -> 4.3.0
* [`521965dd`](https://github.com/NixOS/nixpkgs/commit/521965dd914a2b119afd8c6747a81a207771dc89) libimagequant: add pkg-config tester
* [`d5300aa7`](https://github.com/NixOS/nixpkgs/commit/d5300aa760a62f77705d9f939e9a26c7f0317218) jabref: 5.11 -> 5.12
* [`496556a2`](https://github.com/NixOS/nixpkgs/commit/496556a2a8370706314a04c593cb40a41fb817af) libinput: 1.24.0 -> 1.25.0
* [`4a5606d3`](https://github.com/NixOS/nixpkgs/commit/4a5606d31f1dfab7d55064eb12478e7217b46630) cmake: enable debug info
* [`43736227`](https://github.com/NixOS/nixpkgs/commit/4373622765a3fb8f91ea671c4bcabe70af6fa0e2) raspberrypi-eeprom: 2023.12.06-2712 -> 2024.01.05-2712
* [`afdbbdce`](https://github.com/NixOS/nixpkgs/commit/afdbbdcebf7cde8a7710a5f9dd9ad4c7b6d9ba5a) python311Packages.pymdown-extensions: 10.5 -> 10.7
* [`d2095d1d`](https://github.com/NixOS/nixpkgs/commit/d2095d1d6744ce7d95b00347034114bdb5b87e64) crawl: 0.29.0 -> 0.31.0
* [`a32aa987`](https://github.com/NixOS/nixpkgs/commit/a32aa987d2b04f3d7eb432ed8d11062ccc5bdc88) libvpx: 1.13.1 -> 1.14.0
* [`2812d120`](https://github.com/NixOS/nixpkgs/commit/2812d1202f4208438a6679d2dcecf8ec325aa74d) systemd: add meta.longDescription
* [`1a3a5407`](https://github.com/NixOS/nixpkgs/commit/1a3a5407a0565bd845c0c9f5280133aef8a818a3) systemd: update licensing info
* [`92dfeb7b`](https://github.com/NixOS/nixpkgs/commit/92dfeb7b3dab820ae307c56c216d175c69ee93cd) systemd: rewrite comments
* [`67643f8e`](https://github.com/NixOS/nixpkgs/commit/67643f8ec84bef1482204709073e417c9f07eb87) systemd: break too long lines of Nix code
* [`4eab8d9e`](https://github.com/NixOS/nixpkgs/commit/4eab8d9e1f6e23939174addf55552f6b9a6ab1ed) git-blame-ignore-revs: add two systemd cosmetic modifications
* [`15a8cd49`](https://github.com/NixOS/nixpkgs/commit/15a8cd49df44daa617e663524c4d4d5ad8011636) libjxl: 0.8.2 -> 0.9.1, libaom: remove butteraugli support
* [`08fb5feb`](https://github.com/NixOS/nixpkgs/commit/08fb5feb87acf300a06a896912e77250ce4aa252) lilv: 0.24.22 -> 0.24.24
* [`58762560`](https://github.com/NixOS/nixpkgs/commit/58762560bc3e8843bdfcada1b04ebcd019c5529e) umockdev: enable strictDeps
* [`ded8c868`](https://github.com/NixOS/nixpkgs/commit/ded8c868f68826a8e04c9935e0abe9aa3f9b6507) umockev: hardcode udevadm
* [`95061a19`](https://github.com/NixOS/nixpkgs/commit/95061a19206278a0ae6eb798a950c901113ea0eb) python311Packages.cf-xarray: 0.8.7 -> 0.8.8
* [`b5db527b`](https://github.com/NixOS/nixpkgs/commit/b5db527bd6369c716b969522400c7783884bff9a) python311Packages.pluggy: 1.3.0 -> 1.4.0
* [`5c5f9bf2`](https://github.com/NixOS/nixpkgs/commit/5c5f9bf221661b0de5e53806a34ed4a36fbc0523) zlib: 1.3 -> 1.3.1
* [`897760f5`](https://github.com/NixOS/nixpkgs/commit/897760f5bb873f439121f6561545be402795518d) mesa: 23.3.3 -> 23.3.4
* [`ee7bd568`](https://github.com/NixOS/nixpkgs/commit/ee7bd5684eae9acbfb9498548ccb89b913ee645a) openai-whisper-cpp: fix cuda build
* [`c71060d9`](https://github.com/NixOS/nixpkgs/commit/c71060d91f8d244bea176504179110c04462b96a) librewolf-unwrapped: repository moved to Codeberg
* [`56a3b62f`](https://github.com/NixOS/nixpkgs/commit/56a3b62fe15c8cf62a21fdc8fe2ce6660a7852ed) cryptsetup: 2.6.1 -> 2.7.0
* [`06cd3d57`](https://github.com/NixOS/nixpkgs/commit/06cd3d57a72b08672171091ce5516e9024d4e782) s2n-tls: 1.4.1 -> 1.4.2
* [`71c6265b`](https://github.com/NixOS/nixpkgs/commit/71c6265be02691f4ba1926202d9b2e6391a2cd47) python3Packages.sip: add qgis and qgis-ltr to passthru.tests
* [`2136bc77`](https://github.com/NixOS/nixpkgs/commit/2136bc77182e8d7b842c77dbbfbf2055c87fbfe1) lsof: 4.98.0 -> 4.99.3
* [`d96e8482`](https://github.com/NixOS/nixpkgs/commit/d96e8482331eaebc87139eb5453e2a21d0ec0153) anbox: fix build
* [`370afc7c`](https://github.com/NixOS/nixpkgs/commit/370afc7cced5e775055d694b8244dc8f3d801a44) gdal: add java bindings
* [`e130791a`](https://github.com/NixOS/nixpkgs/commit/e130791ad6e13934efeb8e70b71b16bfc2cdcd1e) gdal: apply `nixpkgs-fmt`
* [`b1985fcf`](https://github.com/NixOS/nixpkgs/commit/b1985fcf475e9066acd12a67b10a72891ceb14f5) grip-search: fix build with GCC 13
* [`d4e775bd`](https://github.com/NixOS/nixpkgs/commit/d4e775bd1a2f30a7e9a5873ad908591c6c31c982) makeInitrdNGTool: 0.1.0 -> 0.1.0
* [`f419df05`](https://github.com/NixOS/nixpkgs/commit/f419df05df66ab4fb53320e7fca5b0cab277c82e) wayland-protocols: 1.32 -> 1.33
* [`0df59332`](https://github.com/NixOS/nixpkgs/commit/0df59332a51c3643580b0fb3f3c5c7d7e0e2b27f) frei0r: 2.3.1 -> 2.3.2
* [`5cadfbeb`](https://github.com/NixOS/nixpkgs/commit/5cadfbeb385e08e5b6018ba6ce7f0dbfc0cb57eb) lutris: 0.5.14 -> 0.5.16
* [`756efb58`](https://github.com/NixOS/nixpkgs/commit/756efb587c51ab73911a293295e27cf85f4a4ee6) python311Packages.werkzeug: 2.3.7 -> 3.0.1
* [`a24d9a6a`](https://github.com/NixOS/nixpkgs/commit/a24d9a6a54fbba232db7f654beff8e3150d5f5ff) python311Packages.flask: 2.3.3 -> 3.0.1
* [`138f345f`](https://github.com/NixOS/nixpkgs/commit/138f345fdafcf94952f55b0663d678d3fed4c019) python311Packages.quart: 0.18.4 -> 0.19.4
* [`df144419`](https://github.com/NixOS/nixpkgs/commit/df144419002c8c4fba918692541f2f4465ee8448) python311Packages.json-logging: test quart integration
* [`e5d3d385`](https://github.com/NixOS/nixpkgs/commit/e5d3d385319d2bc8fd07c2e6a4a05bf9e5fc1ed4) python311Packages.sentry-sdk: add quart optional
* [`ac2b358b`](https://github.com/NixOS/nixpkgs/commit/ac2b358b7d0d100ad9ab94f3434b2fa743ae9845) python311Packages.httpbin: backport flask 3.0 support
* [`d2c9ee56`](https://github.com/NixOS/nixpkgs/commit/d2c9ee5630e7fcb4db7e7c0fdd4c597b63f507ae) python311Packages.flask-basicauth: drop
* [`569fb193`](https://github.com/NixOS/nixpkgs/commit/569fb1934476dbc2206b0ceb8bcd86f0b39b42dd) python311Packages.flask-sessionstore: drop
* [`22e69038`](https://github.com/NixOS/nixpkgs/commit/22e69038a60c7255f1ce4ad304464a7531c8e43a) python311Packages.flask-session-captcha: fix build with flask 3.0
* [`68c9550f`](https://github.com/NixOS/nixpkgs/commit/68c9550fc7632b36854709898015d2ab6e285593) python311Packages.flask-autoindex: drop
* [`2cee7f37`](https://github.com/NixOS/nixpkgs/commit/2cee7f3747437664630dbb3b90693365084f7322) python311Packages.flask-api: fix flask 3.0 compat, enable tests
* [`53137014`](https://github.com/NixOS/nixpkgs/commit/53137014dbc506de4aac84ea47e3cbd2489143a4) python311Packages.flask-restful: fix tests
* [`8592e8e5`](https://github.com/NixOS/nixpkgs/commit/8592e8e5540801bc9bd208c0419e3984ae34611b) python311Packages.flask-gravatar: fix flask 3.0 compat
* [`a6dec248`](https://github.com/NixOS/nixpkgs/commit/a6dec248157c977bd6b9650de88ca900c99609b0) python311Packages.ipython: 8.18.1 -> 8.20.0
* [`e5fb80d3`](https://github.com/NixOS/nixpkgs/commit/e5fb80d393373ea5732ddc7987002b39db877a72) libwpe: 1.14.1 -> 1.14.2
* [`4027133a`](https://github.com/NixOS/nixpkgs/commit/4027133ab0faf27bead55da1af4df790030fa9a0) python311Packages.lightgbm: 4.2.0 -> 4.3.0
* [`31ab028e`](https://github.com/NixOS/nixpkgs/commit/31ab028e34f9a11556e45c80e829182243aef369) at-spi2-core: enable debug info
* [`b9e78cd4`](https://github.com/NixOS/nixpkgs/commit/b9e78cd4a0fd869c426c537ff6dc0941ad433658) rl-2405: highlight cryptsetup upgrade
* [`0a81bc8c`](https://github.com/NixOS/nixpkgs/commit/0a81bc8cd2c8483937d0e641ac78e67930cf579c) starsector: fix the icon symlink
* [`a1f829ca`](https://github.com/NixOS/nixpkgs/commit/a1f829cad75112fdfcafe981ea5b18ff2cfc156f) xz: 5.4.5 -> 5.4.6
* [`9e733405`](https://github.com/NixOS/nixpkgs/commit/9e7334055ada28c8731b3eb47c46b850a7c31e8e) pgadmin4: remove flask-babelex
* [`c65c8255`](https://github.com/NixOS/nixpkgs/commit/c65c8255a1964aee7702c30a2ee23fd35a8b38aa) glib: 2.78.3 → 2.78.4
* [`635e753d`](https://github.com/NixOS/nixpkgs/commit/635e753d7fafa56fe519251fb63b7accb8295a27) python311Packages.snowflake-connector-python: 3.6.0 -> 3.7.0
* [`4c9b5cb3`](https://github.com/NixOS/nixpkgs/commit/4c9b5cb310f4896f016f34083662ee665a0ef8ea) nixos/rabbitmq: prefer 'install' over 'mkdir/chmod/chown'
* [`b3d48a4f`](https://github.com/NixOS/nixpkgs/commit/b3d48a4f32ac55594f7da60514e13aa417dafe26) crossfire-server: fix build due to missing `cstdint` include
* [`ba787a42`](https://github.com/NixOS/nixpkgs/commit/ba787a42f9ee11c50a3c3ca175e06d16740539fc) python311Packages.param: 2.0.1 -> 2.0.2
* [`6394e99d`](https://github.com/NixOS/nixpkgs/commit/6394e99db9fbb277cb2d977ee7b3e2eb763a11c9) mailutils: 3.16 -> 3.17
* [`e8d29165`](https://github.com/NixOS/nixpkgs/commit/e8d2916513a7cff6690f0057e857cbb167726351) ffmpeg: make some build options configurable
* [`07456685`](https://github.com/NixOS/nixpkgs/commit/074566850e991865b60ce1810f10899570a3ffd6) ffmpeg: move libdc1394 and libraw1394 to the right option
* [`975e3170`](https://github.com/NixOS/nixpkgs/commit/975e3170f9bbb7f353b1630e828c40822a3f040a) python311Packages.django-maintenance-mode: 0.19.0 -> 0.21.1
* [`cba74f01`](https://github.com/NixOS/nixpkgs/commit/cba74f016edc758d3657f715f7c4486e5e346c21) libplacebo: 6.338.1 -> 6.338.2
* [`6c1f8181`](https://github.com/NixOS/nixpkgs/commit/6c1f8181b823359fea74a4a06bee13c8bd41845d) libidn2: 2.3.4 -> 2.3.7
* [`ae25ed6e`](https://github.com/NixOS/nixpkgs/commit/ae25ed6e53f1c3c7ccb0e61710b7a3d1cc14da17) libei: 1.1.0 -> 1.2.0
* [`75041793`](https://github.com/NixOS/nixpkgs/commit/7504179397e11841dae9879dfe419ca1e21c4af6) dhcpcd: change files after patching
* [`1af95a24`](https://github.com/NixOS/nixpkgs/commit/1af95a24c11402f46f8ab055a3fb14458f65bd70) nixos/dhcpcd: link dhcpcd.conf to /etc/ to fix dhcpcd -k
* [`42b05f1c`](https://github.com/NixOS/nixpkgs/commit/42b05f1c6df89609d6bcb9bf505cb35a96c273ae) wrapRustc: handle --sysroot=
* [`8dddca5e`](https://github.com/NixOS/nixpkgs/commit/8dddca5e75e01790e411926053840aa9e6a378bd) python311Packages.malduck: 4.3.2 -> 4.4.0
* [`08d7dab2`](https://github.com/NixOS/nixpkgs/commit/08d7dab2bed188732ac7275661290a48d72e3f95) python311Packages.python-memcached: 1.61 -> 1.62
* [`a197159d`](https://github.com/NixOS/nixpkgs/commit/a197159d9081f513d94c3788c7474dcaae6a468b) asterisk: 20.5.2 -> 20.6.0
* [`e3761602`](https://github.com/NixOS/nixpkgs/commit/e3761602e2b3f951305b77cf38a7ab57fe46de6b) python311Packages.python-memcached: run tests
* [`3627df98`](https://github.com/NixOS/nixpkgs/commit/3627df98c19a25f5c29498182ce5da8f8eaadb51) rabbitvcs: mark as broken
* [`d08b1a27`](https://github.com/NixOS/nixpkgs/commit/d08b1a27b64091af7e575b22a6d092aabd050f64) dbus_cplusplus: make patches unconditional
* [`eb1ae3c3`](https://github.com/NixOS/nixpkgs/commit/eb1ae3c3e1ecf52352d9c9bb076d87494024200f) ocserv: 1.2.3 -> 1.2.4
* [`235a2de2`](https://github.com/NixOS/nixpkgs/commit/235a2de244de0b1c762d7a778c479d9224a93b90) ckbcomp: 1.223 -> 1.224
* [`2fce9d00`](https://github.com/NixOS/nixpkgs/commit/2fce9d00fe0e546702d6f37be429f266f8fe0db7) gwe: 0.15.6 -> 0.15.7
* [`56c07582`](https://github.com/NixOS/nixpkgs/commit/56c0758286cb5ddf8a79f33a45ffac7fe00a0941) kafkactl: 3.5.1 -> 4.0.0
* [`4662dcef`](https://github.com/NixOS/nixpkgs/commit/4662dcefb137319748ed436212354fac8cad7fb0) python311Packages.panel: 1.3.4 -> 1.3.8
* [`349c2d76`](https://github.com/NixOS/nixpkgs/commit/349c2d76c538676549e15895f6b99464a6815d6d) webrtc-audio-processing_1: fix build on musl ([nixos/nixpkgs⁠#284471](https://togithub.com/nixos/nixpkgs/issues/284471))
* [`b78ba9bc`](https://github.com/NixOS/nixpkgs/commit/b78ba9bc68b003288d56bab62693ea28e2cdfd76) lib.types.unique: Check inner type deeply
* [`7f1305d3`](https://github.com/NixOS/nixpkgs/commit/7f1305d3d2666813654c14e0b7bb97d65d5602e0) python311Packages.hatchling: 1.21.0 -> 1.21.1
* [`ce8999ae`](https://github.com/NixOS/nixpkgs/commit/ce8999ae596f55ca66eda709ba245849a02a4800) python311Packages.scikit-rf: 0.30.0 -> 0.31.0
* [`46dae33d`](https://github.com/NixOS/nixpkgs/commit/46dae33dd966e5260b7f022594871ec3597c4a34) pkgs/stdenv/linux: update i686-unknown-linux-gnu bootstrap-files
* [`3da096a5`](https://github.com/NixOS/nixpkgs/commit/3da096a5c3d70f4497d525ef478f588011052962) pcsclite: move binaries, polkit, systemd files to out, move libraries to lib
* [`38b2b0f6`](https://github.com/NixOS/nixpkgs/commit/38b2b0f6b5363c690333f4a80f481d56c3ca0c36) global-platform-pro: fix path pcsclite libs
* [`cea7de1d`](https://github.com/NixOS/nixpkgs/commit/cea7de1d0fb130e2ca307491ab8a9d0a922e80c4) python311Packages.sqlalchemy: 2.0.21 -> 2.0.25
* [`45ec7e6f`](https://github.com/NixOS/nixpkgs/commit/45ec7e6f80b0e3417cab470219e7babe3f389897) python311Packages.sqlalchemy-utils: fix sqlalchemy 2.0.22+ compat
* [`46983110`](https://github.com/NixOS/nixpkgs/commit/469831105f111160d08636bd9dd9fac73244e607) breeze-hacked-cursor-theme: init at unstable-2024-1-28
* [`42854430`](https://github.com/NixOS/nixpkgs/commit/4285443034fbe390d6c327a46b32fa7cee87f164) maintainers: add donteatoreo
* [`1be73c76`](https://github.com/NixOS/nixpkgs/commit/1be73c7684bca8f87d5385bada689f5fd53c5c4a) python311Packages.awscrt: 0.19.19 -> 0.20.3
* [`96f7b821`](https://github.com/NixOS/nixpkgs/commit/96f7b8213bd9f6aebc4a54815195de827a05b561) python311Packages.psutil: 5.9.6 -> 5.9.8
* [`7579a5ec`](https://github.com/NixOS/nixpkgs/commit/7579a5ecbd486f2f3f0ee56acb0a037573ce35d2) awscli2: unpin awscrt
* [`c094770e`](https://github.com/NixOS/nixpkgs/commit/c094770e6d71cadf6f8b7f8c2ac481e173cde2a9) python311Packages.pdm-backend: 2.1.7 -> 2.1.8
* [`f2e95cfc`](https://github.com/NixOS/nixpkgs/commit/f2e95cfc72929819ddeb7f9e4e228e27f3716ec2) mopidy-ytmusic: 0.3.8 -> 0.3.9
* [`87497e5b`](https://github.com/NixOS/nixpkgs/commit/87497e5b048ef0c65b85f1593cb5427c3618201f) frescobaldi: 3.2 -> 3.3.0
* [`b5f03338`](https://github.com/NixOS/nixpkgs/commit/b5f03338002038494b079fb6b149e196ce2faa12) python311Packages.colorlog: 6.8.0 -> 6.8.2
* [`28077c7e`](https://github.com/NixOS/nixpkgs/commit/28077c7e24732423d9951e438927b67b56c98cab) turbo: refactor to remove golang code
* [`b5319f60`](https://github.com/NixOS/nixpkgs/commit/b5319f606e4db9ac896900abe8bc5cf3b3cd4d84) gofumpt: 0.5.0 -> 0.6.0
* [`e6c2cf34`](https://github.com/NixOS/nixpkgs/commit/e6c2cf34ff5abb37a25f7208687b355b68e38156) gofumpt: move to by-name
* [`6e56cbff`](https://github.com/NixOS/nixpkgs/commit/6e56cbffebf5e510150c23d2f3ff5eb0361f6d46) pkgsStatic.graphene: fix build
* [`cac14e82`](https://github.com/NixOS/nixpkgs/commit/cac14e82fcd67706cbe0492d2b81d76e200c3cd3) vscode-extensions.shopify.ruby-lsp: Init at 0.5.8
* [`0960bc0e`](https://github.com/NixOS/nixpkgs/commit/0960bc0e1d93934edfc4994c611277b2bdd8886b) python311Packages.pathos: 0.3.1 -> 0.3.2
* [`4d9df398`](https://github.com/NixOS/nixpkgs/commit/4d9df398307b5de9ddd8e989374b4d45a2c63e58) csharprepl: init at 0.6.6
* [`9d8e55f6`](https://github.com/NixOS/nixpkgs/commit/9d8e55f6f4af104286d53435d92833d45f22b741) netpbm: 11.5.1 -> 11.5.2
* [`e8678f4f`](https://github.com/NixOS/nixpkgs/commit/e8678f4fb3ac6071b0d383b8997146ba2b0ee932) abseil-cpp: 202301 -> 202401
* [`b42437fd`](https://github.com/NixOS/nixpkgs/commit/b42437fd010c561ea90df63c88eb78d5a186947e) [staging] gnupg 2.4.3 -> 2.4.4
* [`c086ed06`](https://github.com/NixOS/nixpkgs/commit/c086ed06132477ef6089a2f41eb1f1c97b22ce02) llvmPackages_17: unbreak on x86_64-darwin
* [`301ae036`](https://github.com/NixOS/nixpkgs/commit/301ae03634cc859488a54d16edd86443092d03d9) libpsl: disable testing with valgrind
* [`1b6580c6`](https://github.com/NixOS/nixpkgs/commit/1b6580c627fc5c240680d94c199e88956c063bc8) maintainers: add raspher
* [`996b4ebc`](https://github.com/NixOS/nixpkgs/commit/996b4ebc08e567e51af2116d8aa86c4069256fe6) curl: build with public suffix list support
* [`f957c305`](https://github.com/NixOS/nixpkgs/commit/f957c3051cf70ab4054e7345d03e33027da05429) python311Packages.mashumaro: 3.11 -> 3.12
* [`bdb4a037`](https://github.com/NixOS/nixpkgs/commit/bdb4a037270cd3a8e1c817183716efad66ab9420) peergos: init at 0.14.1
* [`a44c757b`](https://github.com/NixOS/nixpkgs/commit/a44c757bb740c5faaf0e328afd1c6bc1c666b024) manix: 0.7.1 -> 0.8.0
* [`2b4a1a1d`](https://github.com/NixOS/nixpkgs/commit/2b4a1a1d4f9db1b7007966d6205645acc5f7e57b) doc/option-types: Definitions are not declared
* [`4d8a6757`](https://github.com/NixOS/nixpkgs/commit/4d8a6757232e060448fb6b1440de82dbbf5e9bbf) python311Packages.aiohttp: 3.9.1 -> 3.9.3
* [`c7c64a8c`](https://github.com/NixOS/nixpkgs/commit/c7c64a8c72d7c209aa301a946fa9938af2f430de) darwin.apple_sdk_11_0.stdenv: set darwinSdkVersion on all platforms
* [`9a1126f9`](https://github.com/NixOS/nixpkgs/commit/9a1126f9bc402691f8f079545c943f4d74800d71) treewide: move darwinSdkVersion to hostPlatform
* [`c5184317`](https://github.com/NixOS/nixpkgs/commit/c51843178a38dde439eb95bc8b8604e462c68f18) python311Packages.azure-mgmt-datafactory: 4.0.0 -> 5.0.0
* [`1a48d83d`](https://github.com/NixOS/nixpkgs/commit/1a48d83d1d5289cf01122e306412b550b4cc86eb) angband: add meta.platforms, use finalAttrs pattern
* [`f4788891`](https://github.com/NixOS/nixpkgs/commit/f47888918fd30e76ae72ccdb8197292e23d7c818) maintainers: add struan
* [`fad5dae7`](https://github.com/NixOS/nixpkgs/commit/fad5dae748b7416cfb72e707940cbcdb9775998b) python311Packages.hvplot: 0.9.1 -> 0.9.2
* [`eb142d94`](https://github.com/NixOS/nixpkgs/commit/eb142d948d9907d20ba87670b6a11227c50ffe5f) xdg-desktop-portal-wlr: 0.7.0 -> 0.7.1
* [`b925d4bb`](https://github.com/NixOS/nixpkgs/commit/b925d4bbc06f2fc3244a7d75b2902679b80d7a5c) ttyplot: 1.6.1 -> 1.6.2
* [`2dcb1d7b`](https://github.com/NixOS/nixpkgs/commit/2dcb1d7b9f42b59b27fb3f32372fafbc866053a3) python312Packages.gtts: 2.5.0 -> 2.5.1
* [`8131ae42`](https://github.com/NixOS/nixpkgs/commit/8131ae42937591d121f76aa0cdf9ad3b9d0b27f7) tdb: 1.4.9 -> 1.4.10
* [`21e7387a`](https://github.com/NixOS/nixpkgs/commit/21e7387ac93c3dcce6ce6e5a10b9087fb393cc9a) altair: 6.1.0 -> 6.2.0
* [`0c367bef`](https://github.com/NixOS/nixpkgs/commit/0c367bef7459f408239df97759384ee5c25ce23d) lmdb: 0.9.31 -> 0.9.32
* [`ef4d6d0b`](https://github.com/NixOS/nixpkgs/commit/ef4d6d0bc867191394fbd215ed23e0055ce76cc8) velero: 1.12.3 -> 1.13.0
* [`85dae148`](https://github.com/NixOS/nixpkgs/commit/85dae1482b4427bc750a736c2a0820120f5fea2a) uacme: 1.7.4 -> 1.7.5
* [`8ac6e314`](https://github.com/NixOS/nixpkgs/commit/8ac6e314e96583e162584694a59c538b27699605) lmdb: add .meta.changelog
* [`bf6c634c`](https://github.com/NixOS/nixpkgs/commit/bf6c634c162580d2765ca52127d654a6a040cace) ntbtls: 0.3.1 -> 0.3.2
* [`00b56f7c`](https://github.com/NixOS/nixpkgs/commit/00b56f7c0280785813b03786578da6d06e6ef4e8) python312Packages.pox: 0.3.3 -> 0.3.4
* [`042e3115`](https://github.com/NixOS/nixpkgs/commit/042e31156f66a351a4ff05f57e52ad8f0fb7364c) python312Packages.oci: 2.118.0 -> 2.120.0
* [`9ec31683`](https://github.com/NixOS/nixpkgs/commit/9ec316831f68bdb51691e37b3861dcbe006ad797) libcamera-qcam: init
* [`d6ee9686`](https://github.com/NixOS/nixpkgs/commit/d6ee968663f3c206f1edf45a4ab5b76bc2f518ee) libcamera: move to pkgs/by-name
* [`48dc1dba`](https://github.com/NixOS/nixpkgs/commit/48dc1dba06b1fdf5376d71a6cfe55cdbc4f118aa) openblas: update URLs, upstream repo was moved
* [`498be9f2`](https://github.com/NixOS/nixpkgs/commit/498be9f21656ad704b89d650336349325b69a33a) jellyfin-ffmpeg: 6.0.1-1 -> 6.0.1-2
* [`55b7a72d`](https://github.com/NixOS/nixpkgs/commit/55b7a72d78137f5d3dada85ac21ad6611cc59824) qcad: 3.29.2.0 -> 3.29.3.1
* [`8a707a12`](https://github.com/NixOS/nixpkgs/commit/8a707a1221df4cbf65e48f999f7b693afde420e8) vaultwarden.webvault: 2024.1.1b -> 2024.1.2
* [`3451d89d`](https://github.com/NixOS/nixpkgs/commit/3451d89dfeea9336f192b51b0372076beed040ca) confy: 0.7.0 -> 0.7.1
* [`4d70b049`](https://github.com/NixOS/nixpkgs/commit/4d70b0490892e7be85fbf17830534dd43cc9d59e) datefudge: 1.25 -> 1.26
* [`52b6b905`](https://github.com/NixOS/nixpkgs/commit/52b6b9051abbd7c28c227da1e8e490b5016dc95a) elektroid: 3.0 -> 3.0.1
* [`ccaad56e`](https://github.com/NixOS/nixpkgs/commit/ccaad56e4b7d3fb3c7b461ef3d43045992b54e5f) openssl_3: 3.0.12 -> 3.0.13
* [`2d9a5944`](https://github.com/NixOS/nixpkgs/commit/2d9a5944ef48afefcac19a3297c62b5393431343) openssl_3_2: 3.2.0 -> 3.2.1
* [`fffe54bd`](https://github.com/NixOS/nixpkgs/commit/fffe54bddcc2bb0cf1ec78ca93da21d151ef1a9e) libgit2: Enable tests
* [`de022038`](https://github.com/NixOS/nixpkgs/commit/de0220384c4271e231d0d7f7a731aed05cbda6bf) libgit2: Enable multiple outputs
* [`9bf562b1`](https://github.com/NixOS/nixpkgs/commit/9bf562b11125814694df4562d4ff401527125d76) COPYING: 2023 -> 2024
* [`0648d5b5`](https://github.com/NixOS/nixpkgs/commit/0648d5b544db929000cf19501d121e690c066792) pixman: 0.43.0 -> 0.43.2
* [`efc7c1f5`](https://github.com/NixOS/nixpkgs/commit/efc7c1f5e8e56d75e2edd1ba67194ac14ca4799c) openldap: 2.6.6 -> 2.6.7
* [`d0fd0aa4`](https://github.com/NixOS/nixpkgs/commit/d0fd0aa42e12dc389c2f9488c397140ffec9fc4d) openldap: don't use openssl_legacy anymore
* [`0e6d5f04`](https://github.com/NixOS/nixpkgs/commit/0e6d5f0483eaa997acd64d792bf25c34294bfd14) fastcdr: fix build issue due to doxygen warnings
* [`b9a91cf2`](https://github.com/NixOS/nixpkgs/commit/b9a91cf25d236de630b766d6a7e1df361f7df6c0) python311Packages.types-pytz: 2023.3.1.1 -> 2023.4.0.20240130
* [`d2c59048`](https://github.com/NixOS/nixpkgs/commit/d2c59048d1e21fc0354b80a9a841b0493eb584c3) python311Packages.types-pytz: refactor
* [`2ff295a0`](https://github.com/NixOS/nixpkgs/commit/2ff295a0a93f213e472ffb0fd8d518cb4cdbe9ae) python311Packages.sentry-sdk: 1.39.2 -> 1.40.0
* [`ed892915`](https://github.com/NixOS/nixpkgs/commit/ed892915b8a7cf156d49c07ac1ef36321981d722) tests.nixpkgs-check-by-name: LineIndex functionality, semantics, tests
* [`42387a98`](https://github.com/NixOS/nixpkgs/commit/42387a98a83f8f91f96b40f5b23fe4435b2b878b) sqlite, sqlite-analyzer: 3.45.0 -> 2.45.1
* [`da01901c`](https://github.com/NixOS/nixpkgs/commit/da01901c0c8bacea04938f059261f9317ab14de3) ruff: 0.1.13 -> 0.1.15
* [`f9272aa0`](https://github.com/NixOS/nixpkgs/commit/f9272aa06046b2bddc5f1ad0fd401dcccdb605d4) ffado: 2.4.7 -> 2.4.8
* [`0bcb0522`](https://github.com/NixOS/nixpkgs/commit/0bcb05228423463ff80ad1419111ff4df31b9ee4) tests.nixpkgs-check-by-name: Syntactic callPackage detection
* [`db435ae5`](https://github.com/NixOS/nixpkgs/commit/db435ae516e548b278c156cc5e015017bb8495f6) tests.nixpkgs-check-by-name: Re-use nixFileCache more
* [`46da6c5c`](https://github.com/NixOS/nixpkgs/commit/46da6c5c1f8daee0be796f27f1307b39e45fb5cf) tests.nixpkgs-check-by-name: Format
* [`7d1f0a4c`](https://github.com/NixOS/nixpkgs/commit/7d1f0a4cd4ac9b224ace12222107882d869adce0) tests.nixpkgs-check-by-name: Allow new package variants
* [`9f0215d1`](https://github.com/NixOS/nixpkgs/commit/9f0215d1896f1d8b2e35195a4b653ff1dff06349) pkgsMusl.pam: fix build
* [`ccff7495`](https://github.com/NixOS/nixpkgs/commit/ccff74953242cf66ac72bc6268148d4421586aba) nixos/boot.uki: allow partial overrides of default UKI settings
* [`85ab4f8d`](https://github.com/NixOS/nixpkgs/commit/85ab4f8d499923ba7b449e84017eff767bca380e) gperftools: 2.10 -> 2.15
* [`439cbb37`](https://github.com/NixOS/nixpkgs/commit/439cbb3721b06db26935e62aac190cbbdf481fd8) home-assistant-custom-components.localtuya: init at 5.2.1
* [`d12dffd9`](https://github.com/NixOS/nixpkgs/commit/d12dffd9801fbf97bf5ac0c3a657a837a0019753) xmage: Add abueide as maintainer
* [`80c279fc`](https://github.com/NixOS/nixpkgs/commit/80c279fc0c12818ec64d6ac31398d4f9da186f7b) xmage: 1.4.50V2 -> 1.4.51-dev_2024-01-30_19-35
* [`20da7932`](https://github.com/NixOS/nixpkgs/commit/20da7932d70a7dd438acf0af4ffd0cc48ca49914) boundary: 0.14.3 -> 0.15.0
* [`3e79150f`](https://github.com/NixOS/nixpkgs/commit/3e79150fc453990225b311a349a938da7b0b6722) libmodsecurity: 3.0.11 -> 3.0.12
* [`715ac7cb`](https://github.com/NixOS/nixpkgs/commit/715ac7cbd51b21978ac546f30ac22d86cd2d8de8) tinycompress: 1.2.8 -> 1.2.11
* [`f00ea27c`](https://github.com/NixOS/nixpkgs/commit/f00ea27c41789cd7d26fa64cc40c60967bd20a6d) openttd-jgrpp: 0.56.2 -> 0.57.0
* [`ffa28e91`](https://github.com/NixOS/nixpkgs/commit/ffa28e91a7dfbe9bec33cf8d3ef388823664cee6) fermyon-spin: 2.1.0 -> 2.2.0
* [`5196cfab`](https://github.com/NixOS/nixpkgs/commit/5196cfabda9253c4f02948c4bbbff80911cf1af7) ocamlPackages.lablgtk3: 3.1.3 → 3.1.4
* [`16e5d894`](https://github.com/NixOS/nixpkgs/commit/16e5d894040dd53752a86bb4431058c8de693600) ocamlPackages.lablgtk3-rsvg2: init at 3.1.4
* [`6e20857d`](https://github.com/NixOS/nixpkgs/commit/6e20857de620fe16e5892492a1ef731917bf3a11) osv-scanner: 1.6.1 -> 1.6.2
* [`9c751995`](https://github.com/NixOS/nixpkgs/commit/9c7519950b4e7d14a2dd76393d05577116fb552d) srm-cuarzo: 0.4.0-1 -> 0.5.0-1
* [`9ddbe0c7`](https://github.com/NixOS/nixpkgs/commit/9ddbe0c7e4774439077a68b4b3def480da903f68) python311Packages.ansible: 9.1.0 -> 9.2.0
* [`6ae8eb18`](https://github.com/NixOS/nixpkgs/commit/6ae8eb187d72c6dee6014063481f50a1b8d17557) python311Packages.ansible-core: 2.16.2 -> 2.16.3
* [`63b90c56`](https://github.com/NixOS/nixpkgs/commit/63b90c560347817fef17591179daaae495401c36) pipewire: 1.0.1 -> 1.0.2, big cleanup
* [`284ed7b9`](https://github.com/NixOS/nixpkgs/commit/284ed7b9144f06ead7746013d52ed8705ef4a2f3) tuxclocker: 1.4.0 -> 1.5.0
* [`6a6529ac`](https://github.com/NixOS/nixpkgs/commit/6a6529ace1f564668ed7546fe032e2418e4b3f0f) nix-bash-completions: fix improper escaping
* [`d4f49567`](https://github.com/NixOS/nixpkgs/commit/d4f4956702bb93948654a7fb9183900fb9a1ac40) curl: 8.5.0 -> 8.6.0
* [`ec3c1112`](https://github.com/NixOS/nixpkgs/commit/ec3c1112e22680c660157dd047f34cf24c69f14a) amber: 2022-04-21 -> 2023-09-02
* [`50866dc2`](https://github.com/NixOS/nixpkgs/commit/50866dc20fb85063f1d4e103b11530092c490d03) nixos/sysupdate: allow lists in sysupdate config
* [`514bfa66`](https://github.com/NixOS/nixpkgs/commit/514bfa6674600e08c321b9efdab807a14835c4ff) nixos/sysupdate: fix systemd-sysupdate test
* [`84a4712b`](https://github.com/NixOS/nixpkgs/commit/84a4712bcb567905aeecf7afc009848fdc457ea4) lib/tests/packages-from-directory: make sure all .nix files parse
* [`8cf33c2d`](https://github.com/NixOS/nixpkgs/commit/8cf33c2dd1f3564187c063787109c000cb011f69) flutter: remove path interpolation
* [`6dc3672c`](https://github.com/NixOS/nixpkgs/commit/6dc3672c15b6022112b6e511605f0da45c8a8965) flutter/update: add .in extensions to Nix expression template files
* [`488b4c9f`](https://github.com/NixOS/nixpkgs/commit/488b4c9fa1cdd283a7d6a1afe82bb7f6d1135c61) flutter/update: provide fake hashes of the proper length
* [`da5ef4eb`](https://github.com/NixOS/nixpkgs/commit/da5ef4eb6a1bdf3e9ad22c4683b103d5b4ff9574) python311Packages.pydantic-settings: remove ruff dependency
* [`9e543e33`](https://github.com/NixOS/nixpkgs/commit/9e543e3353af49f85f47e50cf569460b54407feb) s2n-tls: 1.4.2 -> 1.4.3
* [`fc6c92fa`](https://github.com/NixOS/nixpkgs/commit/fc6c92faf36907f8d43034a3d5335aa41c571c84) nixos/nftables: remove default systemd dependencies
* [`c840191d`](https://github.com/NixOS/nixpkgs/commit/c840191df517291d24c2752de427e5c81798ebad) acl: 2.3.1 -> 2.3.2
* [`cfb8f44c`](https://github.com/NixOS/nixpkgs/commit/cfb8f44c8c364ffc1d7d4d6ffc4b493720acf53c) ffmpeg: update license flags
* [`7f8349fd`](https://github.com/NixOS/nixpkgs/commit/7f8349fd48d8b996646017d5770aab6b13684529) glibc: 2.38-27 -> 2.38-44 and patch for glibc possible memory corruption in qsort()
* [`db05de2c`](https://github.com/NixOS/nixpkgs/commit/db05de2c35d51d480ed1b87e8ee7db31018bda37) alsa-lib: 1.2.9 -> 1.2.11
* [`82b99fdd`](https://github.com/NixOS/nixpkgs/commit/82b99fddde03a8d40ed9d8bcdae4164bfd4492d0) shotcut: 24.01.13 -> 24.01.31
* [`5fa88aef`](https://github.com/NixOS/nixpkgs/commit/5fa88aef09bf3fb2d3432e5f9d0c8f01814c9159) mongodb-compass: 1.41.0 -> 1.42.0
* [`b839f65f`](https://github.com/NixOS/nixpkgs/commit/b839f65fcee186a0434104b7ac14875a95dc6326) libre: 3.8.0 -> 3.9.0
* [`29bc0559`](https://github.com/NixOS/nixpkgs/commit/29bc0559e6119bafaa7f55c59a30cb0c08c1a950) go_1_19: drop
* [`14e14094`](https://github.com/NixOS/nixpkgs/commit/14e1409469ab86fb0921ea80cb9adddb5e9367b7) postgresqlPackages.pg_squeeze: init at 1.5.2
* [`71378349`](https://github.com/NixOS/nixpkgs/commit/71378349f4a349ae9708aec6c2c54c163ab52d33) libusb1: 1.0.26 -> 1.0.27
* [`1852a38f`](https://github.com/NixOS/nixpkgs/commit/1852a38f7701c7961aebd2210ec20aa44f673475) mdk-sdk: 0.24.0 -> 0.25.0
* [`d5fd2638`](https://github.com/NixOS/nixpkgs/commit/d5fd2638269a1e140f2c30d1f3535e755183ccfb) segger-jlink: init at 794a
* [`c2f2509a`](https://github.com/NixOS/nixpkgs/commit/c2f2509a7591da15d5159ca6b6d52efa950c0f88) nrfconnect: init at 4.3.0
* [`9058bc4e`](https://github.com/NixOS/nixpkgs/commit/9058bc4e8f118f83f877c34a4c59f87bbf295d2d) nrf-command-line-tools: init at 10.23.2
* [`0445c390`](https://github.com/NixOS/nixpkgs/commit/0445c39047e7c994a452b023040064210e14dadf) doc: update environment helpers in dockerTools docs, add fakeNss section
* [`e447b153`](https://github.com/NixOS/nixpkgs/commit/e447b1533e92be340607459b97e99cf393078479) glibc: enable `cet` only on `x86_64` (skip `x86_32`)
* [`e6b37d5a`](https://github.com/NixOS/nixpkgs/commit/e6b37d5a61dd9e0e4780eaa36b42000257a38233) curl: disable fetchpatch passthru test on darwin
* [`9592b073`](https://github.com/NixOS/nixpkgs/commit/9592b073bc4f4a5db1dbaf664aae16df07d44a79) nwg-hello: init at 0.1.6
* [`5c3d1019`](https://github.com/NixOS/nixpkgs/commit/5c3d10192a49d6c89ccb209d4659ee0e2ff51f29) wiki-js: 2.5.300 -> 2.5.301
* [`d0846f14`](https://github.com/NixOS/nixpkgs/commit/d0846f147639690f9217a9b1357439ff485b6632) targetcli: 2.1.57 -> 2.1.58
* [`ab499084`](https://github.com/NixOS/nixpkgs/commit/ab4990844c1cf60177b273b00f3356c6a6739ddf) telegram-desktop: 4.14.9 -> 4.14.12
* [`e81e82cd`](https://github.com/NixOS/nixpkgs/commit/e81e82cdccfc40966f4905aafb5f2d19cdc0f4c0) tzdata: 2023d -> 2024a
* [`17a860e8`](https://github.com/NixOS/nixpkgs/commit/17a860e8dc94d0a455d7d819f3f912c17d681c6a) tzdata: misc changes and reformats
* [`6c8f89fa`](https://github.com/NixOS/nixpkgs/commit/6c8f89faa9d1dbcae853a218c783fbe06d447507) tzdata: enable (most) checks
* [`8318842f`](https://github.com/NixOS/nixpkgs/commit/8318842f1f46418c5e4c0ae70aeeed9b4989519a) libjpeg_turbo: 2.1.5.1 -> 3.0.2
* [`b0b80e15`](https://github.com/NixOS/nixpkgs/commit/b0b80e15d19e69944d19dd83e1751400300c054a) suitesparse: Fix OpenMP build with clang. See [nixos/nixpkgs⁠#79818](https://togithub.com/nixos/nixpkgs/issues/79818)
* [`64fe3481`](https://github.com/NixOS/nixpkgs/commit/64fe3481230a2e0788df4556b1b9ee9025b9f483) openblas: Fix OpenMP build with clang. See [nixos/nixpkgs⁠#79818](https://togithub.com/nixos/nixpkgs/issues/79818)
* [`9541564b`](https://github.com/NixOS/nixpkgs/commit/9541564b3bdfddfd150222f426817339b6a5028a) python311Packages.google-cloud-vision: 3.5.0 -> 3.6.0
* [`8800e9dc`](https://github.com/NixOS/nixpkgs/commit/8800e9dc4ecc49ec3dbc3f463f17f4bbbbd1411c) moar: 1.23.0 -> 1.23.4
* [`17005cee`](https://github.com/NixOS/nixpkgs/commit/17005cee029b21ac6615bcc1365278000489ad94) webp-pixbuf-thumbnailer: 0.2.2 -> 0.2.6
* [`c9a40240`](https://github.com/NixOS/nixpkgs/commit/c9a40240f06a16d216f7a8d6069d53dd331c81d4) grpc: 1.60.0 -> 1.61.0
* [`0fa5a852`](https://github.com/NixOS/nixpkgs/commit/0fa5a852b48175275122966465d5cf817e64e859) python311Packages.grpcio: 1.60.0 -> 1.60.1
* [`559446a6`](https://github.com/NixOS/nixpkgs/commit/559446a69107963ff078f3889fdbc3798b6968d5) python311Packages.grpcio-tools: 1.60.0 -> 1.60.1
* [`1df016d6`](https://github.com/NixOS/nixpkgs/commit/1df016d6999f2373789ec293002558d1aa74eda5) python311Packages.grpcio-status: 1.60.0 -> 1.60.1
* [`2c0e503c`](https://github.com/NixOS/nixpkgs/commit/2c0e503c4cb095e3678d682492949cc29b50178f) python311Packages.grpcio-channelz: 1.60.0 -> 1.60.1
* [`1dc3c590`](https://github.com/NixOS/nixpkgs/commit/1dc3c590290a082a914116780b165d673e825fb4) python311Packages.grpcio-health-checking: 1.60.0 -> 1.60.1
* [`6187ac43`](https://github.com/NixOS/nixpkgs/commit/6187ac4319ad0f206fd62eb6adef337bad62e4c4) python311Packages.grpcio-testing: 1.60.0 -> 1.60.1
* [`4cf92787`](https://github.com/NixOS/nixpkgs/commit/4cf92787c80aa627979ccc89047f2146d2a2704c) maintainers: add devplayer0
* [`6cc7f7b9`](https://github.com/NixOS/nixpkgs/commit/6cc7f7b9b1a1739ab964443386e9cca1ab79052f) python3Packages.qemu: init at 0.6.1.0a1
* [`29c76650`](https://github.com/NixOS/nixpkgs/commit/29c7665003cdcfe3319c969a9846f594dfeae550) lib.modules.doRename: Add condition parameter
* [`ddbfc50d`](https://github.com/NixOS/nixpkgs/commit/ddbfc50d8f539cbaeb5222e151168ba5d4681548) python3Packages.qemu: add maintainer davhau
* [`9c4a6579`](https://github.com/NixOS/nixpkgs/commit/9c4a65790a0001872ccf6787471818a9fe5c72a3) qemu-python-utils: init at "0.6.1.0a1"
* [`b1328ab6`](https://github.com/NixOS/nixpkgs/commit/b1328ab69bccca2678f6ceec8aadac4d146f891b) ffmpeg: sort features
* [`1b22bac1`](https://github.com/NixOS/nixpkgs/commit/1b22bac1745e831e7a3abc805b78b4a99facaa34) ffmpeg: rename withLibplacebo to withPlacebo
* [`1cb111b4`](https://github.com/NixOS/nixpkgs/commit/1cb111b48902f74765eb6354332dbd83a4a175bc) ffmpeg: move version specific options to enableFeature
* [`48b20da0`](https://github.com/NixOS/nixpkgs/commit/48b20da0fbc133dd43e5ee7d48f7eaab24f3548f) ffmpeg: turn libflite into option
* [`f28414a6`](https://github.com/NixOS/nixpkgs/commit/f28414a6d1da3ab10851791f56521df4639d3c15) ffmpeg: move chromaprint from jellyfin version into regular version
* [`11749a4e`](https://github.com/NixOS/nixpkgs/commit/11749a4e25e609832eaad35da94a0467469627d1) python3Packages.qemu: fix shadowed qemu; improve expression
* [`c04cc133`](https://github.com/NixOS/nixpkgs/commit/c04cc1332157496b69f552546de53495a928224c) linuxPackages.openafs: Patch for Linux kernel 6.7
* [`d508f812`](https://github.com/NixOS/nixpkgs/commit/d508f8120e1a1f2f405fe81fd7c7d13b49faffca) python311Packages.kiss-headers: fix format to pyproject
* [`b22414ea`](https://github.com/NixOS/nixpkgs/commit/b22414ea35c2dfcd5e07c1b8c0de2709fdc12291) cpython: unpin legacy openssl
* [`f2f4cf05`](https://github.com/NixOS/nixpkgs/commit/f2f4cf0515fcbfe584efa3de116c38cdb4f1b6be) cpython: resolve substituteStream --replace deprecation
* [`97625d03`](https://github.com/NixOS/nixpkgs/commit/97625d0307db3db59b09f4122717cdaed7adc926) cpython: prune patches and configure flags
* [`2d6fa6f3`](https://github.com/NixOS/nixpkgs/commit/2d6fa6f35d8a880eb37349f103db7e87742c7292) cpython: refactor & clean up
* [`9b516e42`](https://github.com/NixOS/nixpkgs/commit/9b516e4288f09374e1426e4ec0a606169db1d52b) cpython: build with our own libmpdecimal
* [`c819f1ae`](https://github.com/NixOS/nixpkgs/commit/c819f1aef8afdce200d1f38283e0f10d489bfcaa) ffmpeg: add jopejoe1 as maintainer
* [`37d0a576`](https://github.com/NixOS/nixpkgs/commit/37d0a5768447e6453c7fd9ada36c7ed0228b5c36) wordpressPackages: add license information
* [`3695cacf`](https://github.com/NixOS/nixpkgs/commit/3695cacfc5e8b3c3df9611a9ab174f12db6c03c7) cronutils: init at 1.10
* [`7c852861`](https://github.com/NixOS/nixpkgs/commit/7c8528613db9c21afeaa5be27730005fda7795f5) python311Packages.geopandas: 0.14.2 -> 0.14.3
* [`b0e8cc52`](https://github.com/NixOS/nixpkgs/commit/b0e8cc5276d3a4dce4676e5144b7750db02cd4d5) k9s: fix broken completion scripts on aarch64-darwin
* [`0f0a6c57`](https://github.com/NixOS/nixpkgs/commit/0f0a6c5706a7be9881da4df92c9c5a86ed5a14ce) nix: drop warning disabling on `gcc-13`
* [`457e32ec`](https://github.com/NixOS/nixpkgs/commit/457e32ecef99f0ca220dd4dede97f8180e0a3ab9) python311Packages.cryptography: 41.0.7 -> 42.0.2
* [`70bf8a38`](https://github.com/NixOS/nixpkgs/commit/70bf8a38a71604a78104ce1a898af3facbb4adf4) pg_tileserv: 1.0.10 → 1.0.11
* [`014e1f6e`](https://github.com/NixOS/nixpkgs/commit/014e1f6ecc23950e35ae4b9097e27286ecacbc10) incus: move unwrapped to incus dir
* [`42742010`](https://github.com/NixOS/nixpkgs/commit/42742010df39e2bcfe413f2bd83be5770e41fb62) incus: reformat with nixfmt-rfc-style
* [`cf372500`](https://github.com/NixOS/nixpkgs/commit/cf372500be7a9068c431b7f68da2c31a6c3f60ea) incus: add support for multiple releases
* [`a55e16ad`](https://github.com/NixOS/nixpkgs/commit/a55e16ad8d215cf96b5415bccd418b61b99936ab) incus: add statically compiled client
* [`5f087b32`](https://github.com/NixOS/nixpkgs/commit/5f087b3221142436513d2941392d09d5e8a922c5) incus: lxd-to-incus is now part of main package
* [`41962099`](https://github.com/NixOS/nixpkgs/commit/419620998d8d4e101ff9545520448179751c23a8) python311Packages.pytest: 7.4.3 -> 7.4.4
* [`d4bb178c`](https://github.com/NixOS/nixpkgs/commit/d4bb178c916d59b4ef6186aa1d5062c379dae89f) libjpeg_turbo: add mingw support
* [`8bec9ba8`](https://github.com/NixOS/nixpkgs/commit/8bec9ba8b60b07edbd25db096bb5bf14526bf8bd) fanficfare: 4.30.0 -> 4.31.0
* [`3ae57dc6`](https://github.com/NixOS/nixpkgs/commit/3ae57dc64de3a43da1ad3bcf9c4086b1288e4cf3) pipewire: 1.0.2 -> 1.0.3
* [`42a8cabe`](https://github.com/NixOS/nixpkgs/commit/42a8cabeeb8a8270203a5d831c529f4258632dc5) onlyoffice-bin_latest: 7.5.1 -> 8.0.0
* [`859ee774`](https://github.com/NixOS/nixpkgs/commit/859ee774e1c302583321a9403798fde76dd8bf8d) displaylink: use `finalAttrs` pattern
* [`1551a2e3`](https://github.com/NixOS/nixpkgs/commit/1551a2e3e2b179620b959092ea8dc4642f035fa8) displaylink: add missing phase hooks
* [`cacc44a5`](https://github.com/NixOS/nixpkgs/commit/cacc44a576eafdf70001377d465fb52e776b0dff) displaylink: switch to `makeBinaryWrapper`
* [`a4e9c088`](https://github.com/NixOS/nixpkgs/commit/a4e9c088701dc31cd8223a06329a1c76ddcaabaa) displaylink: sort `meta` attributes and add `meta.mainProgram`
* [`25b075df`](https://github.com/NixOS/nixpkgs/commit/25b075dffd70dc7da9aff90c38267b807093da6a) evdi: use `finalAttrs` pattern
* [`7ae4984c`](https://github.com/NixOS/nixpkgs/commit/7ae4984c3091b26f5fa956d459a120273217bd9d) evdi: add missing phase hooks
* [`93d5d8dc`](https://github.com/NixOS/nixpkgs/commit/93d5d8dcde92127adecf3b46f01e158ed3d9bc70) evdi: sort `meta` attributes
* [`12490c71`](https://github.com/NixOS/nixpkgs/commit/12490c715146458a288cf48a8bb6035df22d4464) evdi: update code style
* [`45581ad4`](https://github.com/NixOS/nixpkgs/commit/45581ad4b458878c871ed5038d5e36cf49e005bd) libjpeg_turbo: fix cross to compatible platforms
* [`6269f311`](https://github.com/NixOS/nixpkgs/commit/6269f3116b5ad289bd09ac06b2769bb22d34b982) lzip: add mingw support
* [`e81e4db0`](https://github.com/NixOS/nixpkgs/commit/e81e4db07b0e5cd9b95b935dee7623aabb21ac79) cockroachdb-bin: 23.1.7 -> 23.1.14
* [`d39d1b7a`](https://github.com/NixOS/nixpkgs/commit/d39d1b7a0b268200bf07ffaf1eca3676f39b5c85) python311Packages.pygltflib: init at 1.16.1
* [`c5b2dd9e`](https://github.com/NixOS/nixpkgs/commit/c5b2dd9e8d2ef88fe7bb0491b2ec6c9278d1a647) foonathan-memory: init at 0.7-3
* [`68cf8846`](https://github.com/NixOS/nixpkgs/commit/68cf88462eec6c7c8a38001a899854251c56381f) python311Packages.setuptools: 69.0.2 -> 69.0.3
* [`273b448b`](https://github.com/NixOS/nixpkgs/commit/273b448b6a3fe0961b939bea8f2c4e202e489448) incus: fix update script
* [`6f5ac580`](https://github.com/NixOS/nixpkgs/commit/6f5ac5808c3497c38c969fce266dea38c2871181) mesa: 23.3.4 -> 23.3.5
* [`52355ccd`](https://github.com/NixOS/nixpkgs/commit/52355ccd6cd5d8283ca0624fc1f3961b5f75f1c5) signal-desktop: 6.45.1 -> 6.46.0
* [`4c25ff02`](https://github.com/NixOS/nixpkgs/commit/4c25ff02e2727f81430bf69e1790f0dc60a815c8) linux_xanmod: 6.1.74 -> 6.1.76
* [`d0a99254`](https://github.com/NixOS/nixpkgs/commit/d0a99254bf66b5dd2dbdc98d399c7ea80d9ad0f1) build-fhs-user-env: add compatibility for pipewire alsa emulation
* [`e83e8317`](https://github.com/NixOS/nixpkgs/commit/e83e8317cf7f90b2120745a3a6099e9c334b616b) parabolic: fix mainProgram
* [`17e5d0df`](https://github.com/NixOS/nixpkgs/commit/17e5d0dfedb682409abf0381fade7ec1b336eb92) linux_xanmod_latest: 6.6.13 -> 6.6.15
* [`f3fab8ac`](https://github.com/NixOS/nixpkgs/commit/f3fab8ac983e8f25293ef44abce52ceeb3e9c428) mesa: don't fail if $dev/lib/pkgconfig/dri.pc doesn't exist
* [`ffadbb67`](https://github.com/NixOS/nixpkgs/commit/ffadbb6788b40d9bf84074ecabbf05de8be1daf8) kubernetes: prefer 'install' over 'mkdir/chmod/chown'
* [`b7b6c49c`](https://github.com/NixOS/nixpkgs/commit/b7b6c49cad5c55d38db442d6ddb9677f2d5b1e0a) python311Packages.pymc: fix homepage
* [`88244b5f`](https://github.com/NixOS/nixpkgs/commit/88244b5f75261283681e7486e2b7883973291321) mesa: remove disk cache key override
* [`bad435e1`](https://github.com/NixOS/nixpkgs/commit/bad435e1580628ffeece1265ade74a05e38b88d2) ff2mpv: 5.0.1 -> 5.1.0
* [`9ec3d895`](https://github.com/NixOS/nixpkgs/commit/9ec3d89500e732a1daa6072e8883048d4b25e0a0) tlmi-auth: improve overridability
* [`52d2e90d`](https://github.com/NixOS/nixpkgs/commit/52d2e90d45930a1bbb68a288e563b17306ad3846) tlmi-auth: enable cross-compliation by correctly classifying dependencies
* [`c313242f`](https://github.com/NixOS/nixpkgs/commit/c313242fe83e4fa6d28b7cfd6f980a8e24573670) micro: fixed clipboard issue
* [`6ce91e12`](https://github.com/NixOS/nixpkgs/commit/6ce91e12df5357ec6f8dbee06a6a8cc5905ac86f) jackett: 0.21.1658 -> 0.21.1672
* [`493a19f1`](https://github.com/NixOS/nixpkgs/commit/493a19f131c987c2eeddf5b0db7daf3dfecef8d9) python311Packages.httpx: 0.25.2 -> 0.26.0
* [`605d1948`](https://github.com/NixOS/nixpkgs/commit/605d194842463d2ac6b654b7ecfec59c0e1071b8) pkgsMusl.umockdev: fix build
* [`e6854b29`](https://github.com/NixOS/nixpkgs/commit/e6854b295bfa9c6d8fc43fede650d87154a3fcc8) nixos/github-runners: only override pkg if it has a `nodeRuntimes` arg
* [`995c69c0`](https://github.com/NixOS/nixpkgs/commit/995c69c03631f72fe99571c54e4f9009ee8cd80f) csharpier: 0.27.0 -> 0.27.2
* [`841b7fc7`](https://github.com/NixOS/nixpkgs/commit/841b7fc727756cf5606b5f1154a57355b3e74f84) python311Packages.starlette: 0.32.0.post1 -> 0.35.1
* [`cd23ee40`](https://github.com/NixOS/nixpkgs/commit/cd23ee40b551221240c1389f2e454eb4b2808484) python311Packages.fastapi: 0.104.1 -> 0.109.0
* [`295ffd29`](https://github.com/NixOS/nixpkgs/commit/295ffd29996e1beb31014565164cf6a4b62b90bc) python311Packges.starlette: test fastapi in passthru.tests
* [`63220cb7`](https://github.com/NixOS/nixpkgs/commit/63220cb7265b6b7b532863b2d9eccc2b22f278fd) maintainers: add katrinafyi
* [`aa3873ac`](https://github.com/NixOS/nixpkgs/commit/aa3873aca109e114209e0d5530486f46725347c3) python311Packages.markupsafe: 2.1.3 -> 2.1.5
* [`6d8c6eb3`](https://github.com/NixOS/nixpkgs/commit/6d8c6eb3cdea7abfb89d8ce49b3f75b2895dbe0e) python311Packages.markupsafe: test reverse dependencies in passthru
* [`b88eaf5d`](https://github.com/NixOS/nixpkgs/commit/b88eaf5d62b6098afeb4e8c49f8e8dfe43d8e245) nixos/nautilus-open-any-terminal: add to module-list.nix
* [`bcb6afc7`](https://github.com/NixOS/nixpkgs/commit/bcb6afc76e742aaa6642e216125b04da408e3a88) Revert "python311Packages.markupsafe: 2.1.3 -> 2.1.5" ([nixos/nixpkgs⁠#286070](https://togithub.com/nixos/nixpkgs/issues/286070))
* [`cbbc4c6e`](https://github.com/NixOS/nixpkgs/commit/cbbc4c6eab0227aabbe1aef8e7b60bb069f010ee) microsoft-edge: 121.0.2277.83 -> 121.0.2277.98
* [`cd18eaeb`](https://github.com/NixOS/nixpkgs/commit/cd18eaebc4d99b5499eb2e5e5965135c3fdbf870) cardboard: mark broken (`gcc-13` build failure)
* [`c0b2aec0`](https://github.com/NixOS/nixpkgs/commit/c0b2aec02f44e8b3320cd190052f075be909f55f) k3s_1_28: 1.28.5+k3s1 -> 1.28.6+k3s1
* [`8322031a`](https://github.com/NixOS/nixpkgs/commit/8322031abc1afd3b94dd2b37914ee7c06a08fbd6) python311Packages.google-ai-generativelanguage: 0.5.0 -> 0.5.1
* [`d3312786`](https://github.com/NixOS/nixpkgs/commit/d33127863ecda07ddd292d9bad7f8717f69430a0) lib: make deprecation warnings consistent
* [`ff68866e`](https://github.com/NixOS/nixpkgs/commit/ff68866e7d7c3722461a25cea7bb9a5e8a810fc4) python311Packages.asf-search: 6.7.3 -> 7.0.4
* [`45027f5d`](https://github.com/NixOS/nixpkgs/commit/45027f5dd8510ee1f81bd50c6955b418107f3dbd) python311Packages.xarray-dataclasses: init at 1.7.0
* [`c04efae3`](https://github.com/NixOS/nixpkgs/commit/c04efae3921bca777d0dad0b67530fbfd8914d5c) python311Packages.spatial-image: init at 1.0.0
* [`b087e3d1`](https://github.com/NixOS/nixpkgs/commit/b087e3d16cae38d202a6543fb23e307b7009357e) maintainers: add flandweber
* [`e917d374`](https://github.com/NixOS/nixpkgs/commit/e917d374107d85d09833c216716e29fce0f5fd63) python311Packages.explorerscript: 0.1.4 -> 0.1.5
* [`a27e9573`](https://github.com/NixOS/nixpkgs/commit/a27e95737f07873a9f1972d229d6243c435db140) python311Packages.skytemple-rust: 1.6.1 -> 1.6.3
* [`1a91ac4d`](https://github.com/NixOS/nixpkgs/commit/1a91ac4da819919f1f2bd08e104b3dc75fdca013) python311Packages.skytemple-files: 1.6.1 -> 1.6.3
* [`9a90fb62`](https://github.com/NixOS/nixpkgs/commit/9a90fb622888d5b44c608906d486c458e2628d8f) python311Packages.skytemple-dtef: 1.6.0 -> 1.6.1
* [`f8802bf1`](https://github.com/NixOS/nixpkgs/commit/f8802bf10d5576d1c293899b575fa797e5b41660) python311Packages.skytemple-ssb-debugger: 1.6.1 -> 1.6.2
* [`e2eab5db`](https://github.com/NixOS/nixpkgs/commit/e2eab5dbd8b39c9cc554a1dd26b57e97a9f644ba) lomiri.lomiri-app-launch: Fix flakiness
* [`293607ea`](https://github.com/NixOS/nixpkgs/commit/293607eaf9e2e87af72fe875ab8f4ecd29c9e38e) cilium-cli: 0.15.21 -> 0.15.22
* [`03cf8016`](https://github.com/NixOS/nixpkgs/commit/03cf80164ac2742c7ff4f0c49c20a0ea658fb560) maintainers: add gangaram
* [`85da7aca`](https://github.com/NixOS/nixpkgs/commit/85da7aca82afba4156c6edfa9f6a6cc36b28aacf) np: init at 0.11.0
* [`ea9149bb`](https://github.com/NixOS/nixpkgs/commit/ea9149bb36f12e389bbb57be6e3dc10848685276) nmap-parse: init at 0-unstable-2022-09-26
* [`a7053c69`](https://github.com/NixOS/nixpkgs/commit/a7053c695ddcf99800d589774b9dc08c184c4dc2) maintainers: add Ligthiago
* [`1fb9ffec`](https://github.com/NixOS/nixpkgs/commit/1fb9ffecd44731c2268d45f01c4731a40c622571) qt6Packages.wayqt: init at 0.2.0
* [`ece0a74a`](https://github.com/NixOS/nixpkgs/commit/ece0a74ac2de714108ecd80533077795b4b0ec82) python311Packages.google-cloud-os-config: 1.16.0 -> 1.17.0
* [`f56f725f`](https://github.com/NixOS/nixpkgs/commit/f56f725f8c15710680b2b09e07289724b2580849) rage: 0.9.2 -> 0.10.0
* [`2a9e0d51`](https://github.com/NixOS/nixpkgs/commit/2a9e0d51195e69c7bcdd7bbf13703ae2c27c483e) rage: migrate to by-name
* [`64496116`](https://github.com/NixOS/nixpkgs/commit/64496116d472c54e4c5047579e00b5f1758721ee) python311Packages.google-cloud-securitycenter: 1.25.0 -> 1.26.0
* [`1acef57f`](https://github.com/NixOS/nixpkgs/commit/1acef57f423e7a141bfcd2ba8ff06ec3650d4f0f) dua: 2.26.0 -> 2.28.0
* [`6c994d39`](https://github.com/NixOS/nixpkgs/commit/6c994d39d273ff30c0a12a5460d0581706008744) cmctl: 1.13.3 -> 1.14.1
* [`95500ec6`](https://github.com/NixOS/nixpkgs/commit/95500ec6ab3a4ae976a1b5d18ba8dfe297480e9e) vbam: 2.1.8 -> 2.1.9
* [`cee13123`](https://github.com/NixOS/nixpkgs/commit/cee13123c01af4538ee85a683f52794b8e0b5bd6) xdg-utils: unstable-2022-11-06 -> 1.2.0, resholve
* [`07d74035`](https://github.com/NixOS/nixpkgs/commit/07d74035fa2f6959933ddbf0bc7d84e11b320aa3) wxmaxima: 23.12.0 -> 24.02.0
* [`c771030c`](https://github.com/NixOS/nixpkgs/commit/c771030c085581a1de19219bc945026b36d2aeff) bazarr: 1.4.0 -> 1.4.1
* [`33ed01ea`](https://github.com/NixOS/nixpkgs/commit/33ed01ea05d8d79770a5fa9453c6bbae6b7c1ffc) python311Packages.osqp: disable failing unit tests
* [`965fc232`](https://github.com/NixOS/nixpkgs/commit/965fc2329412d7b08074811d099d5d1a1707694f) brook: unpin go1.20
* [`8f46594a`](https://github.com/NixOS/nixpkgs/commit/8f46594af294311350ac25812cbe72c69924e72d) juicefs: 1.1.1 -> 1.1.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
