### PR TITLE
niv devenv: update 0e68853b -> 91a572c9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0e68853bb27981a4ffd7a7225b59ed84f7180fc7",
-        "sha256": "151gd36r0s7ilalssiyg7v840k7nhi315hnb0cwvkg5dfnigqypl",
+        "rev": "91a572c9866b92294aec152b65fa06c4dad7816f",
+        "sha256": "1jjxl807vjissbrhxpvz9vy88f24d2jr6glwvagzn47ghxm1x6h5",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/0e68853bb27981a4ffd7a7225b59ed84f7180fc7.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/91a572c9866b92294aec152b65fa06c4dad7816f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@0e68853b...91a572c9](https://github.com/cachix/devenv/compare/0e68853bb27981a4ffd7a7225b59ed84f7180fc7...91a572c9866b92294aec152b65fa06c4dad7816f)

* [`4d85d01b`](https://github.com/cachix/devenv/commit/4d85d01b6f7c11357187a526297748a6496de8ea) Add an option to toggle defautls-extra-file for mysql cli commands
* [`24d92f4d`](https://github.com/cachix/devenv/commit/24d92f4dc741b6723926e19783e0b66bedfb97bd) javascript: support bun
* [`d4f2849d`](https://github.com/cachix/devenv/commit/d4f2849dd4883715858789fe538a067b59951530) Auto generate docs/reference/options.md
* [`91a572c9`](https://github.com/cachix/devenv/commit/91a572c9866b92294aec152b65fa06c4dad7816f) Auto generate docs/reference/options.md
