### PR TITLE
niv home-manager: update f99eace7 -> 21b07830

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f99eace7c167b8a6a0871849493b1c613d0f1b80",
-        "sha256": "1xfls81znzrjz021wd404hvdb7r9wfh8pvls6cpa3q2hmc5qghnh",
+        "rev": "21b078306a2ab68748abf72650db313d646cf2ca",
+        "sha256": "0dv0xq65nbpdkgnpawdx9jsasz1w52n0f55z6iz9qpmm8gfqkkv5",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f99eace7c167b8a6a0871849493b1c613d0f1b80.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/21b078306a2ab68748abf72650db313d646cf2ca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f99eace7...21b07830](https://github.com/nix-community/home-manager/compare/f99eace7c167b8a6a0871849493b1c613d0f1b80...21b078306a2ab68748abf72650db313d646cf2ca)

* [`5b9156fa`](https://github.com/nix-community/home-manager/commit/5b9156fa9a8b8beba917b8f9adbfd27bf63e16af) zellij: use full executable path
* [`4c0357ff`](https://github.com/nix-community/home-manager/commit/4c0357ff874f8250fcae621d5626aba1c7161710) sway: fix workspace 10 missing from default config ([nix-community/home-manager⁠#4636](https://togithub.com/nix-community/home-manager/issues/4636))
* [`fb0196ad`](https://github.com/nix-community/home-manager/commit/fb0196ad9d18554e035de27d4f2a906ba050b407) imapnotify: enable STARTTLS if enabled in email account config ([nix-community/home-manager⁠#5013](https://togithub.com/nix-community/home-manager/issues/5013))
* [`d1d6ca9b`](https://github.com/nix-community/home-manager/commit/d1d6ca9b6552fc93032b76661c83061f1cd4e6e8) flake.lock: Update
* [`bfd0ae29`](https://github.com/nix-community/home-manager/commit/bfd0ae29a86eff4603098683b516c67e22184511) emacs: use `overrideScope` instead of `overrideScope'`
* [`a09cfdba`](https://github.com/nix-community/home-manager/commit/a09cfdbaf11c821340cff24d9ad1c264708ee12e) neomutt: Initial IMAP support ([nix-community/home-manager⁠#4597](https://togithub.com/nix-community/home-manager/issues/4597))
* [`21b07830`](https://github.com/nix-community/home-manager/commit/21b078306a2ab68748abf72650db313d646cf2ca) flake.lock: Update
