### PR TITLE
niv powerlevel10k: update ce7c2423 -> 8e2a22d8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "ce7c242337c6e1002c0af64d43b8c8904007055b",
-        "sha256": "1wmsf4ki07k2ad5k6hgal2llc556lh8rwjyh3k1g22gp4fjmnvld",
+        "rev": "8e2a22d80ba9f5fd6c784f66dc52c21385eb2642",
+        "sha256": "18qvp4y7d8vmz3aqh6a48534v80pd0fvkd48ghz7xa7zc5q2pvrp",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/ce7c242337c6e1002c0af64d43b8c8904007055b.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/8e2a22d80ba9f5fd6c784f66dc52c21385eb2642.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@ce7c2423...8e2a22d8](https://github.com/romkatv/powerlevel10k/compare/ce7c242337c6e1002c0af64d43b8c8904007055b...8e2a22d80ba9f5fd6c784f66dc52c21385eb2642)

* [`5bba4b84`](https://github.com/romkatv/powerlevel10k/commit/5bba4b849b04da665d9776930f47371ebb9974a4) skip batteries with "Unknown" status ([romkatv/powerlevel10k⁠#2562](https://togithub.com/romkatv/powerlevel10k/issues/2562))
* [`1aa91f00`](https://github.com/romkatv/powerlevel10k/commit/1aa91f0069bcfbdb82ebdded74eb1730ad0674e1) add icon for yazi level
* [`eb8f96f8`](https://github.com/romkatv/powerlevel10k/commit/eb8f96f8080cbab3786425a24b7ad64695a59e91) add prompt segment for yazi levels
* [`67cedd3e`](https://github.com/romkatv/powerlevel10k/commit/67cedd3edcd54aa8edf392d72d9b637fa01eec9f) add visual expansion to wizard
* [`665257d0`](https://github.com/romkatv/powerlevel10k/commit/665257d05925bf399741126fd457d471a41e7ccd) add themes support
* [`f880e187`](https://github.com/romkatv/powerlevel10k/commit/f880e18769409ffe407b725c6004c5a8e849408d) update readme
* [`8e2a22d8`](https://github.com/romkatv/powerlevel10k/commit/8e2a22d80ba9f5fd6c784f66dc52c21385eb2642) cleanup and bump version ([romkatv/powerlevel10k⁠#2572](https://togithub.com/romkatv/powerlevel10k/issues/2572))
