### PR TITLE
niv nixpkgs: update 5a7b453b -> a3320403

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a7b453b37801e02561340653106ab2781b30165",
-        "sha256": "0llbjyibxy4kci2hhnrj7bwfmlgyqj8r7zw0wvxp7sgdf61xgq2s",
+        "rev": "a332040396d7e3c47883e9c115c1da485712805e",
+        "sha256": "063ncnfap6dvs341jap5mp6j87j4m236cgrgmg7zm822ss1h2nis",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5a7b453b37801e02561340653106ab2781b30165.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a332040396d7e3c47883e9c115c1da485712805e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5a7b453b...a3320403](https://github.com/nixos/nixpkgs/compare/5a7b453b37801e02561340653106ab2781b30165...a332040396d7e3c47883e9c115c1da485712805e)

* [`73f666a2`](https://github.com/NixOS/nixpkgs/commit/73f666a2044602d00c65a10d50a4906661155bba) nixos/modules/system/boot/stage-1.nix: add documentation for moved secrets in past system generations
* [`0f37581e`](https://github.com/NixOS/nixpkgs/commit/0f37581eab9258755adf6fef2c6b46c20add6fc3) nixos/libreswan: Use StateDirectory to setup ipsec/nss
* [`6eccad0f`](https://github.com/NixOS/nixpkgs/commit/6eccad0f4eaf76a939b3ce7a4198472bb12bd265) redfishtool: init at 1.1.8
* [`c952d995`](https://github.com/NixOS/nixpkgs/commit/c952d99534e11f238f2de73303f5d6017bd07a64) leanify: unstable-2022-12-04 -> unstable-2023-10-19
* [`3b1fa1b9`](https://github.com/NixOS/nixpkgs/commit/3b1fa1b9af8d69e597012d4b73b3c9b75a3fe879) sink-rotate: init at 1.0.4
* [`20531fbe`](https://github.com/NixOS/nixpkgs/commit/20531fbe4f8dc0a8422057c3c058ebac9cf02b8b) ipe: fix button images
* [`0163de08`](https://github.com/NixOS/nixpkgs/commit/0163de0826dd66203e39e6292d2540fd625edff1) meshoptimizer: unstable-2023-03-22 -> 0.20
* [`db3d599e`](https://github.com/NixOS/nixpkgs/commit/db3d599e7f5783c36f369623ed84b09b05691722) maintainers: add kud
* [`5254684a`](https://github.com/NixOS/nixpkgs/commit/5254684a0f4af15ba14caf6485dfb1f665f3faf8) nixos/docker: warn about changing storageDriver
* [`d08f8d0c`](https://github.com/NixOS/nixpkgs/commit/d08f8d0c9800165ba8a766cf798b0aa9b4089041) bat-extras: set pname to executable name
* [`1bcd510d`](https://github.com/NixOS/nixpkgs/commit/1bcd510dcc410f3f222e435384eda4f2c99a8de7) netproxrc: init at 1.1.0
* [`9b904a92`](https://github.com/NixOS/nixpkgs/commit/9b904a92a25aa86982e7f456c8d2ef6471c48015) brltty: 6.3 -> 6.6
* [`c2d1cd85`](https://github.com/NixOS/nixpkgs/commit/c2d1cd852fac14f9d05f86e5abeecaf32f8a78ad) nixos/brltty: Set isSystemUser for the brltty user
* [`ab1ad2b0`](https://github.com/NixOS/nixpkgs/commit/ab1ad2b066ad1d2a0edf1ded067fb451843418fa) nixosTests.sourcehut: remove unused VM image specifications
* [`3943aa57`](https://github.com/NixOS/nixpkgs/commit/3943aa57c0a1c346a15fae7b911a358c5da3364d) nixosTests.sourcehut: test user creation and OAuth token generation
* [`33c13e9e`](https://github.com/NixOS/nixpkgs/commit/33c13e9e4d1a6b5ff50fe33edbd0835ef254b236) nixosTests.sourcehut: listen on port 80, as well
* [`89278c98`](https://github.com/NixOS/nixpkgs/commit/89278c9846a88d51ec00b0b1f044070deb93a79f) nixosTests.sourcehut: run tests within a production environment
* [`8d135ac8`](https://github.com/NixOS/nixpkgs/commit/8d135ac86bbef7d4fab3b9000357697d1da73a29) python3.pkgs.meson: Use overridePythonAttrs
* [`8353fad1`](https://github.com/NixOS/nixpkgs/commit/8353fad13da8983b95c47426a355e044099cee91) nixos/dockerTools: fix includeStorePaths when enableFakechroot
* [`fece49bd`](https://github.com/NixOS/nixpkgs/commit/fece49bd62f4dc0636c0816a65733e260433035b) vte: allow to build without any gtk
* [`8cd995ce`](https://github.com/NixOS/nixpkgs/commit/8cd995ce1341e90e7433568d1c98d657276beceb) nixos/no-x-libs: add vte
* [`577bb277`](https://github.com/NixOS/nixpkgs/commit/577bb277aa3ccab68942424aca71cf44b03b39df) nixos/vte: use vte without any GUI dependencies
* [`effb6bd7`](https://github.com/NixOS/nixpkgs/commit/effb6bd756dfff8c88d635f346415cea6f4ddf96) nixosTests.sourcehut: configure Hut for direct API interaction
* [`7d7cc717`](https://github.com/NixOS/nixpkgs/commit/7d7cc717ebc36758c1e733b44a218d8426bf410b) nixosTests.sourcehut: test pushing Git repositories
* [`8f6a3420`](https://github.com/NixOS/nixpkgs/commit/8f6a342064eaa4ea1444058e186dcb661c0eecce) nixosTests.sourcehut: test repository download
* [`262cb39d`](https://github.com/NixOS/nixpkgs/commit/262cb39d4fc51471d4eeff339c9d107417fc09f8) nixosTests.sourcehut: add myself as maintainer
* [`6eb86e3c`](https://github.com/NixOS/nixpkgs/commit/6eb86e3c19312c4b585141848923d5594ab26e5e) nixosTests.sourcehut: refactor script to use subtests
* [`806369ad`](https://github.com/NixOS/nixpkgs/commit/806369ad445a2eeab8502079dc08c7fc8b1e4e58) dconf: enable feature parity for cross builds
* [`8114d5da`](https://github.com/NixOS/nixpkgs/commit/8114d5dabbf5f4f1e8c370b889d4f2986b63998b) argyllcms: support cross compilation
* [`2382d423`](https://github.com/NixOS/nixpkgs/commit/2382d423f427a2dc30ea6cee8b0b4c615c6f5cb3) nixosTests.sourcehut: factor-out node configuration
* [`195cbfc0`](https://github.com/NixOS/nixpkgs/commit/195cbfc0124ea3d5e4b6469cdd3efb42840d32eb) nixosTests.sourcehut: split tests belonging to different services
* [`8434df5e`](https://github.com/NixOS/nixpkgs/commit/8434df5efd9292190774211ae15995b26a290f2d) certificate-ripper: init at 2.2.0
* [`ce403bb5`](https://github.com/NixOS/nixpkgs/commit/ce403bb56de10b474d2b7d74f9ddcbae0e9fe3c9) measureme: 10.1.1 -> 11.0.0
* [`b04954bf`](https://github.com/NixOS/nixpkgs/commit/b04954bf143a2e5feb3937acd3a0886571d94d35) keepalived: disable net-snmp support when cross compiling
* [`147cc406`](https://github.com/NixOS/nixpkgs/commit/147cc4061eed12dc418ec753def00a1f9544fc23) nixos/sourcehut: ensure that the repos directory exists
* [`f912e13e`](https://github.com/NixOS/nixpkgs/commit/f912e13e7cc4664a692e40a92770a3a6b11b2af9) recode: 3.7.12 -> 3.7.14
* [`e1a9d1bf`](https://github.com/NixOS/nixpkgs/commit/e1a9d1bfcb7719704622e39a61161f5b85a46fb6) maintainers: add nu-nu-ko
* [`0c343ce1`](https://github.com/NixOS/nixpkgs/commit/0c343ce16e9f1fcc930b644a97025a48fed15afa) quark-goldleaf: init at 1.0.0
* [`56a43aab`](https://github.com/NixOS/nixpkgs/commit/56a43aaba8fa19cf63f53462f9fa357d4644f01c) nixos/quark-goldleaf: init
* [`73cb3367`](https://github.com/NixOS/nixpkgs/commit/73cb33678527ddc323c7fcef3d17ac85603e5b02) nixos/icewm: Update icewm start command
* [`37dcf6b8`](https://github.com/NixOS/nixpkgs/commit/37dcf6b80426035674faf694bc47a6a6cecaddcf) maintainers: add cdombroski
* [`1f9e86f3`](https://github.com/NixOS/nixpkgs/commit/1f9e86f31462b395d77151469a53543a94e46c36) nixosTests.docker-tools: Use both code paths in includeStorePath test
* [`2dfadd6d`](https://github.com/NixOS/nixpkgs/commit/2dfadd6d5fa9500c197ca5a2ba5ab06a5213e288) kas: 4.1 -> 4.2
* [`2188655d`](https://github.com/NixOS/nixpkgs/commit/2188655d64b4524e8ce1e1a9de09c0cc3ee2f161) measureme: 11.0.0 -> 11.0.1
* [`00679f46`](https://github.com/NixOS/nixpkgs/commit/00679f46fbd90c6e46412551c7739dcdeb7c8ba1) gitqlient: refactor to fetch submodules
* [`ee44cc4a`](https://github.com/NixOS/nixpkgs/commit/ee44cc4a139137fcc18908ba5b049b8a43caf38b) gitqlient: 1.5.0 -> 1.6.2
* [`09dc46b5`](https://github.com/NixOS/nixpkgs/commit/09dc46b5bd9da174e4d9b16d907b3574708c7cd6) dune3d: init at 0.9.3
* [`f6cee267`](https://github.com/NixOS/nixpkgs/commit/f6cee2673be09385e78c0301c8d1b05db528947a) linux: CONFIG_LED_TRIGGER_PHY=y
* [`6b6dd450`](https://github.com/NixOS/nixpkgs/commit/6b6dd4509e78de088873eeb24dd34888d7eb77d9) bat-extras: also set meta.mainProgram
* [`f29ce594`](https://github.com/NixOS/nixpkgs/commit/f29ce594568d9fa6fc2312eee5b530b7af48da74) maintainers: add nu-nu-ko
* [`2fbef4e3`](https://github.com/NixOS/nixpkgs/commit/2fbef4e3faf8d1478c76346ff71f7305cf75ec4b) rwpspread: init at 0.1.8
* [`d6d62910`](https://github.com/NixOS/nixpkgs/commit/d6d62910798a1924cdf19e13d4143be75c5a41c8) poppler: 23.11.0 -> 24.01.0
* [`3e8c66ac`](https://github.com/NixOS/nixpkgs/commit/3e8c66ac068f7d5836387f3a69ad6e2395a47ca7) nwg-panel: 0.9.20 -> 0.9.22
* [`f8ea90e3`](https://github.com/NixOS/nixpkgs/commit/f8ea90e36de1d25823f6b1f0c603ce0fb6701a6e) python3.pkgs.sphinxemoji: Fix missing propagated dependency on "setuptools"
* [`e7daaa70`](https://github.com/NixOS/nixpkgs/commit/e7daaa7001981d76ecc5c8ce67491f442d08c21b) bandwhich: add shell completions and man page
* [`8535f629`](https://github.com/NixOS/nixpkgs/commit/8535f629910b12778fa875e9e8a1c45d439e5d46) bandwhich: add `meta.changelog`
* [`51e17ae1`](https://github.com/NixOS/nixpkgs/commit/51e17ae1d21a35c77ffabc5cdd31fa9b4646333f) restinio: 0.6.19 -> 0.7.1, refactor, adopt
* [`4c707039`](https://github.com/NixOS/nixpkgs/commit/4c707039315ab2a276339f1ceb33dc1477f2d37f) nixos/ttyd: add writable option
* [`0d13d2a9`](https://github.com/NixOS/nixpkgs/commit/0d13d2a90f21947ddc20c13c4b0a70d88c354b16) nixos/ttyd: remove `with lib;`
* [`718f7177`](https://github.com/NixOS/nixpkgs/commit/718f7177c4ecd95fa69c7216f04143bf3f27bbd7) python311Packages.pytest-examples: don't propagate ruff
* [`796a49ec`](https://github.com/NixOS/nixpkgs/commit/796a49ec8d28370964d2aeda6e1feb573de9c145) unison-fsmonitor: init at 0.3.3
* [`85fe7c52`](https://github.com/NixOS/nixpkgs/commit/85fe7c5226ca94d635596bf62f3c8cda70bfb12f) dune3d: 0.9.3 -> 1.0.0
* [`5b64cf6f`](https://github.com/NixOS/nixpkgs/commit/5b64cf6fc67aa4602667edeba903f3480577d128) tests/slurm: use getDev for mpi test
* [`75e06d42`](https://github.com/NixOS/nixpkgs/commit/75e06d42700a7da5cf2e9eb016f17f4f91168b1f) boost: use getDev for mpi input
* [`61d8b53c`](https://github.com/NixOS/nixpkgs/commit/61d8b53c4181a2957b098f945fa5cd025b112295) libvdwxc: use getDev for mpi
* [`71035c19`](https://github.com/NixOS/nixpkgs/commit/71035c19eded5dcb9645d0d3943cec2aa3d605d4) python3Packages.mpi4py: remove unneeded mpicc definiton
* [`4a128778`](https://github.com/NixOS/nixpkgs/commit/4a12877882e4e6de227ca5af617502ef4ae01cfb) python3Packages: use getDev for mpi
* [`3600fc8d`](https://github.com/NixOS/nixpkgs/commit/3600fc8d47151ff6a66438529ffedbd2c4cfddab) python3Packages.gpaw: use getDev for mpi
* [`71f23d93`](https://github.com/NixOS/nixpkgs/commit/71f23d938d2f6f60c17e61a66399816d7837a618) scalapack: use getDev for mpi
* [`5bfb906f`](https://github.com/NixOS/nixpkgs/commit/5bfb906fc27b86a21872b522ff64963074336ee5) netcdf-mpi: use getDev for mpi
* [`2f44799d`](https://github.com/NixOS/nixpkgs/commit/2f44799d84e439781657d4de2a3dd0a794ec479e) hdf5: remove unneded path to mpi compiler
* [`989dd934`](https://github.com/NixOS/nixpkgs/commit/989dd934104eafba795fb2ebadfbab240aea7070) maintainers: add GPG key fingerprint for user kevincox
* [`ef302f8c`](https://github.com/NixOS/nixpkgs/commit/ef302f8c2aeb21afbe0ce3b45ac320b646fede7e) bazel: 7.0.0 -> 7.0.2
* [`861667c7`](https://github.com/NixOS/nixpkgs/commit/861667c75a62edd9a1311e72a9350210473e7bb1) maintainers: add lucasbergman
* [`9daafdfc`](https://github.com/NixOS/nixpkgs/commit/9daafdfcfbb404ba4238a885dc07e9752993e8c4) nvidia-container-toolkit: 1.9.0 -> 1.15.0-rc.3
* [`bae3aa33`](https://github.com/NixOS/nixpkgs/commit/bae3aa335cc81d8d2c1866a49b02551d3eee18c8) libsForQt5.rlottie-qml: init at 0-unstable-2021-05-03
* [`a52f790a`](https://github.com/NixOS/nixpkgs/commit/a52f790a4c980c60a877fdef581927a0b8c74c63) openmpi: use extra output for dev
* [`53402495`](https://github.com/NixOS/nixpkgs/commit/53402495f436ec2ed63db6e203da38fe0a717ff0) lomiri.lomiri-push-qml: init at 0-unstable-2022-09-15
* [`6aac7f88`](https://github.com/NixOS/nixpkgs/commit/6aac7f88054f5e5ba743f509faae0fefafd01b5e) python311Packages.papermill: fix build
* [`22b7b3d9`](https://github.com/NixOS/nixpkgs/commit/22b7b3d9c1e8d5bfce9e8b7f469c9f7bb660c0dd) python311Packages.papermill: enable tests
* [`87a0a83b`](https://github.com/NixOS/nixpkgs/commit/87a0a83b9710aeca552c90f7975814cc473880e2) python311Packages.papermill: add mainProgram
* [`a77f035e`](https://github.com/NixOS/nixpkgs/commit/a77f035ec8cb1448929fa4b0084bb4b3dc979cff) python311Packages.pydeck: fix build
* [`3aee7a7b`](https://github.com/NixOS/nixpkgs/commit/3aee7a7b80a59f95d662f57ad80e004a5b147fd9) cemu: Add patch to fix usage of internal glslang headers
* [`5af99f7f`](https://github.com/NixOS/nixpkgs/commit/5af99f7f38992ee5afa3991088b74eacc0fd8b2c) speed-dreams: 2.2.3 -> 2.3.0
* [`965352d1`](https://github.com/NixOS/nixpkgs/commit/965352d13d9258390a7cef4468bcd80b503177f0) pianoteq.standard-8: 8.1.1 -> 8.2.0
* [`9a76d7b7`](https://github.com/NixOS/nixpkgs/commit/9a76d7b75536d859b2e1f3a4608090767a250b8c) pianoteq.stage-trial: 8.1.1 -> 8.2.0
* [`f79d9cca`](https://github.com/NixOS/nixpkgs/commit/f79d9ccac2b8681dd4acd291d47f4cbbfa2f1fb4) pianoteq.standard-trial: 8.1.1 -> 8.2.0
* [`ac922d9f`](https://github.com/NixOS/nixpkgs/commit/ac922d9f9ab6c7bbc92f8fc6d1f733e5dd5bd7a3) yabai: 6.0.7 -> 6.0.9
* [`b7f29692`](https://github.com/NixOS/nixpkgs/commit/b7f29692c04d6a1581bf27753f414b80360e5a1d) nixos/hostapd: fix utf8Ssid setting not properly honored
* [`cb77c77f`](https://github.com/NixOS/nixpkgs/commit/cb77c77f5a769ecca179ff51dfb8329df0fb5496) libsForQt5.quickflux: init at 1.1-unstable-2020-11-10
* [`a8880f16`](https://github.com/NixOS/nixpkgs/commit/a8880f1647e6b8e83f1f9909bea17d4c0dbe8428) nixos/ttyd: add entrypoint option
* [`95a2ac0f`](https://github.com/NixOS/nixpkgs/commit/95a2ac0fd9938b30273148ae660eba72116727ac) microsoft-edge: Change update script to have consistent ordering of versions
* [`ccf92aad`](https://github.com/NixOS/nixpkgs/commit/ccf92aad9b5e7cf19953490035c6aee506d05104) nixos/jellyfin: add directory options
* [`42d8301e`](https://github.com/NixOS/nixpkgs/commit/42d8301efefe34650c3c08da96c823881b218525) jellyfin: add meta.mainProgram
* [`d7a4d45e`](https://github.com/NixOS/nixpkgs/commit/d7a4d45ece65b47ffb72c7b2d2b9469c321e8f7b) python311Packages.yasi: use buildPythonPackage, refactor
* [`ce11a6fb`](https://github.com/NixOS/nixpkgs/commit/ce11a6fb356d716ac5d8add14160c7ed49fbb756) fypp: move python application out of python-modules, refactor
* [`d1c4c31d`](https://github.com/NixOS/nixpkgs/commit/d1c4c31d2c6e4e6ca4e0114bc98fb72530924750) incus.ui: init at 0.5
* [`ee2c5cd8`](https://github.com/NixOS/nixpkgs/commit/ee2c5cd8106105911cbe8e84a33d00f73b41f551) tmux-xpanes: 4.1.4 -> 4.2.0
* [`bbf286d9`](https://github.com/NixOS/nixpkgs/commit/bbf286d98ef8831164683ed0601701d218455880) rocmPackages.clr: backport bf16 compilation fix
* [`39e2171c`](https://github.com/NixOS/nixpkgs/commit/39e2171c622aea216f94831c0bdbf82e96cedafc) python311Packages.diffusers: 0.25.1 -> 0.26.2
* [`04bf3bf6`](https://github.com/NixOS/nixpkgs/commit/04bf3bf69540219d18d6c15571dbaaff1b9ac553) go-judge: 1.8.0 -> 1.8.1
* [`e45311f1`](https://github.com/NixOS/nixpkgs/commit/e45311f14ae30d2bd74fb6293618792e16d71cff) keep-sorted: 0.3.0 -> 0.3.1
* [`a59c532c`](https://github.com/NixOS/nixpkgs/commit/a59c532c0a95e986dc962d38eef849614040b59e) moneydance: init at 2023.3_5064
* [`d3bca4cb`](https://github.com/NixOS/nixpkgs/commit/d3bca4cb5d79f22e8abc537cb0a8f9cfe746cd56) moneydance: add 'jvmFlags'
* [`23b89f91`](https://github.com/NixOS/nixpkgs/commit/23b89f915bd63ca9b469f280185daefaa9c3f7c7) sketchybar: 2.20.0 -> 2.20.1
* [`1c2a4b97`](https://github.com/NixOS/nixpkgs/commit/1c2a4b971eb0e683a85d1adcc97acd6f9b51e65b) srht-gen-oauth-tok: init at 0.1
* [`c335eb09`](https://github.com/NixOS/nixpkgs/commit/c335eb09fbce77a90868d997026974944941efe9) talosctl: 1.6.1 -> 1.6.4
* [`9bc0aed7`](https://github.com/NixOS/nixpkgs/commit/9bc0aed7cca9a1e6f4016c66fd6855ce61391402) golangci-lint: 1.55.2 -> 1.56.0
* [`25c1244c`](https://github.com/NixOS/nixpkgs/commit/25c1244cdebd0c288f300c362ed6bfd5983434d1) metals: 1.2.0 -> 1.2.1
* [`bf06413a`](https://github.com/NixOS/nixpkgs/commit/bf06413ada397f596c092a88f1573fed0435f133) aflplusplus: 4.09c -> 4.10c
* [`f47877ef`](https://github.com/NixOS/nixpkgs/commit/f47877efd0cc553a80d85a5c7a81c6214408b501) cargo-llvm-cov: 0.6.2 -> 0.6.3
* [`f6ee741a`](https://github.com/NixOS/nixpkgs/commit/f6ee741a1ebab2252063bf14dfe04fbbc9004d3d) cargo-llvm-cov: 0.6.3 -> 0.6.4
* [`4ee3ac37`](https://github.com/NixOS/nixpkgs/commit/4ee3ac37d1075b8527ac6d500df7e5387c9caf01) cargo-llvm-cov: 0.6.4 -> 0.6.5
* [`1f9cef93`](https://github.com/NixOS/nixpkgs/commit/1f9cef9379b58d641af7a0b6e26046ccef218047) python311Packages.python-engineio: 4.8.0 -> 4.9.0
* [`0ef61a4a`](https://github.com/NixOS/nixpkgs/commit/0ef61a4a2fcc69668a35d98e494f08fbf82e0efc) ani-cli: 4.7 -> 4.8
* [`b10b9598`](https://github.com/NixOS/nixpkgs/commit/b10b9598278efd76b7219e01eed6096d125790d8) bash-language-server: Add shellcheck to bin path
* [`fbb2c644`](https://github.com/NixOS/nixpkgs/commit/fbb2c6449cf319b84034343e57d3483efcb92396) qtcreator: 12.0.1 -> 12.0.2
* [`73201199`](https://github.com/NixOS/nixpkgs/commit/73201199902cc15e011f62c2eb7c19c960264812) ocf-resource-agents: fix build against `autoconf-2.72`
* [`22ffaa5c`](https://github.com/NixOS/nixpkgs/commit/22ffaa5c624f018d00a55196d7e197edb54a8e6c) python311Packages.python-socketio: 5.10.0 -> 5.11.1
* [`b3645ffc`](https://github.com/NixOS/nixpkgs/commit/b3645ffc0d2b26a40998a1b67df9410521437cb8) python311Packages.proton-vpn-session: 0.6.2-unstable-2023-10-24 -> 0.6.5
* [`75c65468`](https://github.com/NixOS/nixpkgs/commit/75c65468353220bacdf9b8e9c6bf68ce433e6665) python311Packages.proton-vpn-api-core: 0.20.1-unstable-2023-10-10 -> 0.20.3
* [`b89f0ff8`](https://github.com/NixOS/nixpkgs/commit/b89f0ff860967ffd9d1ba4c6322d162ced19a11a) python311Packages.proton-vpn-logger: 0.2.1-unstable-2023-05-10 -> 0.2.1
* [`964ba378`](https://github.com/NixOS/nixpkgs/commit/964ba3780424848602535315e8c125ced8d98e5e) geos_3_9: 3.9.2 -> 3.9.5
* [`8d32deb0`](https://github.com/NixOS/nixpkgs/commit/8d32deb0ee077ce35be5919077eca009d310eb20) python311Packages.proton-vpn-network-manager: 0.3.0-unstable-2023-09-05 -> 0.3.3
* [`2e255065`](https://github.com/NixOS/nixpkgs/commit/2e255065509f9bc8b6fd5b765242b5c1031bd2dc) python311Packages.proton-vpn-connection: 0.11.0-unstable-2023-09-05 -> 0.11.3
* [`47bcf4a4`](https://github.com/NixOS/nixpkgs/commit/47bcf4a4ddd7cde063ad3b8c6fcca15de254f951) protonvpn-gui: 4.1.0-unstable-2023-10-25 -> 4.1.10
* [`2ce33c60`](https://github.com/NixOS/nixpkgs/commit/2ce33c60cf74e50d118520fbe2407a7b73f98dec) lxd-container-image: set mode of configuration.nix
* [`7e0b9f76`](https://github.com/NixOS/nixpkgs/commit/7e0b9f767d79b89c4477a1cacb872d09d5878ada) homebank: 5.7.3 -> 5.7.4
* [`ea67eb20`](https://github.com/NixOS/nixpkgs/commit/ea67eb20789fc1ca2d937e0341bcf8702e90f276) pysolfc: 2.20.1 -> 2.21.0
* [`fb988d2f`](https://github.com/NixOS/nixpkgs/commit/fb988d2f7a085c849ef3cbdf16af3641c6896304) oil: rename to oil-python
* [`c627c0f5`](https://github.com/NixOS/nixpkgs/commit/c627c0f561795577e75438598745cac758f7fea1) oil: init at 0.20.0
* [`d339fffc`](https://github.com/NixOS/nixpkgs/commit/d339fffc7d514b53511ea528d3d6f770e5a79365) oil: add myself as maintainer
* [`83c9e4e9`](https://github.com/NixOS/nixpkgs/commit/83c9e4e910a5f839f22990bae9de10bddd9adc2f) rPackages.SuperGauss: add dependencies
* [`bca04fb3`](https://github.com/NixOS/nixpkgs/commit/bca04fb384f6c432ce09db9d8d8033d785fa4458) release-notes: add oil c++ note
* [`8fef22b0`](https://github.com/NixOS/nixpkgs/commit/8fef22b0e9066b17db9be0181db65bd50969e9ef) python312Packages.python-editor: 1.0.4 -> 1.0.4-unstable-2023-10-11
* [`f65ba8ea`](https://github.com/NixOS/nixpkgs/commit/f65ba8ea1463e0cc6f323a1814a59d09f30f62a8) brave: 1.62.156 -> 1.62.162
* [`6843e5da`](https://github.com/NixOS/nixpkgs/commit/6843e5da038062c6a19213240e750de4b7f8371c) mqttx: 1.9.8 -> 1.9.9
* [`2f47fb08`](https://github.com/NixOS/nixpkgs/commit/2f47fb0831dae9208d7f80b21688c6c7aa5496cd) rPackages.excursions: added dependency
* [`70a6efa8`](https://github.com/NixOS/nixpkgs/commit/70a6efa86d41ae78fd836fa3c90f96c41cc8167a) libtheora: ran nixpkgs-fmt
* [`0fcd5152`](https://github.com/NixOS/nixpkgs/commit/0fcd5152155a13c75680c77c6e952dc9a3d7c4ac) libtheora: add mingw support
* [`410d15e1`](https://github.com/NixOS/nixpkgs/commit/410d15e1568c6191d43fd726e61ddbc8c5af3cb0) linuxPackages_latest.perf: add `-O1` workaround for `gcc-13`
* [`ef913506`](https://github.com/NixOS/nixpkgs/commit/ef9135062b556e8b82d1641420f0dbba8fb4fe44) rPackages.CellBarcode: added dependency
* [`0f7d690e`](https://github.com/NixOS/nixpkgs/commit/0f7d690e48f70bebcd7a18365c512383310bc3b2) doc: consistently prefer and lead with cargoHash over cargSha256
* [`dfbb330b`](https://github.com/NixOS/nixpkgs/commit/dfbb330b7b0ecd8642112a46a395fb0f06f41982) ruffle: nightly-2023-04-10 -> nightly-2024-02-09
* [`907238ae`](https://github.com/NixOS/nixpkgs/commit/907238ae517879c7eade60cc3fb5824b088b643b) waf: remove vrthra from maintainers
* [`ce8b933d`](https://github.com/NixOS/nixpkgs/commit/ce8b933d769954ca5e51ed8321d77d1db88597cb) agg: fix darwin build
* [`a8a9062c`](https://github.com/NixOS/nixpkgs/commit/a8a9062cb8418eda3265f9415ecd51e4a997f62d) python312Packages.nlpcloud: 1.1.45 -> 1.1.46
* [`5db14cf8`](https://github.com/NixOS/nixpkgs/commit/5db14cf8998f45ada68681eb3c6742f26333b099) plumber: 2.5.2 -> 2.5.3
* [`61c4f91c`](https://github.com/NixOS/nixpkgs/commit/61c4f91c19e43a8cac382bc8af841e4ec4c01a0c) qt5.qtwebkit: fix build with GCC 13
* [`2ad2987a`](https://github.com/NixOS/nixpkgs/commit/2ad2987a9558ab913c42211fbd0fd78b612233f4) qt5.qtwebkit: apply libxml2 patch from upstream webkit
* [`76c91510`](https://github.com/NixOS/nixpkgs/commit/76c915102dd04ac8553f5f696b61331ba5081b95) python312Packages.oelint-parser: 3.1.0 -> 3.2.0
* [`3b31da53`](https://github.com/NixOS/nixpkgs/commit/3b31da53b9956cd5194825e06da22209a05cc3fc) x42-avldrums: 0.4.2 -> 0.7.2
* [`9f17995b`](https://github.com/NixOS/nixpkgs/commit/9f17995b41779ca94c7edb55f7ab6153c0300180) sfxr: fix segfault
* [`09a229f8`](https://github.com/NixOS/nixpkgs/commit/09a229f8e20ed3142f3cc9b0906083844bf23f19) maintainers: add DataHearth
* [`8bbff533`](https://github.com/NixOS/nixpkgs/commit/8bbff533a628a816d3b96c4be262396b1ba4fd18) vscode-extensions.aaron-bond.better-comments: init at 3.0.2
* [`f6954309`](https://github.com/NixOS/nixpkgs/commit/f6954309e8f0193ad5904cf787bbcfe47b63fa54) nixos/users-groups: warn on ambiguous password settings
* [`e0459db9`](https://github.com/NixOS/nixpkgs/commit/e0459db98563369531bf0cfc4ef1cab43141e638) speed-dream: add desktop item
* [`3c60f44d`](https://github.com/NixOS/nixpkgs/commit/3c60f44d330d74e33141db89b5eefb0d278daf71) python311Packages.stravalib: don't pin pydantic
* [`4de8afef`](https://github.com/NixOS/nixpkgs/commit/4de8afef2385940828e9652222b4171b512b6169) python311Packages.qcs-api-client: don't pin pydantic
* [`72d13f6f`](https://github.com/NixOS/nixpkgs/commit/72d13f6fdc5c51dc785155e8fec337289c5f7374) python311Packages.aioopenexchangerates: don't pin pydantic
* [`bac15ec6`](https://github.com/NixOS/nixpkgs/commit/bac15ec63085add6c6ebc1fe7d268ed5d53bb112) python3Packages.furo: 2023.9.10 -> 2024.1.29
* [`e6d6637b`](https://github.com/NixOS/nixpkgs/commit/e6d6637b1909243f24514b46ccaa2ae8c1276d5e) waybar: fix impure dependency on /bin/sh
* [`ee41311c`](https://github.com/NixOS/nixpkgs/commit/ee41311c6fa0519be8dcba68d30a593fd6848525) clifm: 1.16 -> 1.17
* [`d228250d`](https://github.com/NixOS/nixpkgs/commit/d228250dc817157c8dd375a02fe7d00e52625611) tilix: migrate to pkgs/by-name
* [`cac147d4`](https://github.com/NixOS/nixpkgs/commit/cac147d49c4f1e113383ca82e94af011ece1782b) tilix: adopt
* [`e03b63cd`](https://github.com/NixOS/nixpkgs/commit/e03b63cdaf4fc6655089116582bebfb8369ff581) tilix: modernize
* [`2b07edce`](https://github.com/NixOS/nixpkgs/commit/2b07edce45aebbcfedb678fbf3b4e9b5f3cd8476) signal-cli: 0.12.2 -> 0.12.8
* [`5980c1d8`](https://github.com/NixOS/nixpkgs/commit/5980c1d8556b6b0cad05fc57784d6a0037d9ebf0) tilix: 1.9.5 -> 1.9.6
* [`b531de72`](https://github.com/NixOS/nixpkgs/commit/b531de72bf787ff17c2b8eb4df75cfdf46dfd0c9) stp: fix the build against `gcc-13`
* [`af4faca2`](https://github.com/NixOS/nixpkgs/commit/af4faca291cd8f32da87ac1f2a1b82d2514253ed) discord-ptb: 0.0.66 -> 0.0.67
* [`71c2705c`](https://github.com/NixOS/nixpkgs/commit/71c2705c9bb19fb1e47dc36e6cb64c178b74f949) python311Packages.pycfmodel: don't pin pydantic
* [`a652c94e`](https://github.com/NixOS/nixpkgs/commit/a652c94ed97c5959aecc9dba718dfa5f8e5a2204) abracadabra: 2.3.5 -> 2.4.0
* [`df833dab`](https://github.com/NixOS/nixpkgs/commit/df833dab9cb1bbf03ac6921fe758473eaf2d6d71) cfripper: pin pydantic_1
* [`31ca7ca2`](https://github.com/NixOS/nixpkgs/commit/31ca7ca2418de76468018eca1c49f8387a5c99bc) istioctl: 1.20.2 -> 1.20.3
* [`9f89f93f`](https://github.com/NixOS/nixpkgs/commit/9f89f93f52878971273cce82d751e61140334006) invoiceplane: fix source hash
* [`ece3d186`](https://github.com/NixOS/nixpkgs/commit/ece3d186a5cdc5493b4eb6d2208aaaf32a7b57b2) imgui: 1.90.1 -> 1.90.2
* [`395f99b9`](https://github.com/NixOS/nixpkgs/commit/395f99b954cd600ba47b8f2eeb3381f2d7ed638a) findex: 0.7.1 -> 0.8.1
* [`90a5d1b9`](https://github.com/NixOS/nixpkgs/commit/90a5d1b931d48ce9764c541d06bc57848b2f7b9e) megahit: fir `gcc-13` build failure
* [`ac9c5347`](https://github.com/NixOS/nixpkgs/commit/ac9c53471dcc2fcdb1eaf8da0ab0d8721eeeb42b) xrestop: 0.5 -> 0.6
* [`899e7555`](https://github.com/NixOS/nixpkgs/commit/899e75551616b1c39a1dd3787612ad4d88684323) pcmanfm-qt: 1.4.0 -> 1.4.1
* [`6bcf3b89`](https://github.com/NixOS/nixpkgs/commit/6bcf3b890f49bb3b6c0ad1aeb2a8c4118c9a4bbc) python311Packages.torch: 2.1.2 -> 2.2.0
* [`e7a6102e`](https://github.com/NixOS/nixpkgs/commit/e7a6102e9220d0ea5f7b1ea7ddca0838f050d796) icon-library: 0.0.17 -> 0.0.18
* [`15eed1f7`](https://github.com/NixOS/nixpkgs/commit/15eed1f719ab63134e668fb4ec5900b82d3fc177) nextcloudPackages.integration_openai: init at 1.2.0, nextcloudPackages: update
* [`79d98568`](https://github.com/NixOS/nixpkgs/commit/79d98568c5dfddf745e29e95006829c4234d2e7a) arrpc: 3.2.0 -> 3.3.0
* [`8d165ba9`](https://github.com/NixOS/nixpkgs/commit/8d165ba9039c8ef55cf598aa1e65da1629fd2368) licenses: add mplus
* [`f8cec6e0`](https://github.com/NixOS/nixpkgs/commit/f8cec6e01d88e46aba0fb5f13e01f1b2edc033bf) treewide: use real mplus license
* [`6ab259ab`](https://github.com/NixOS/nixpkgs/commit/6ab259abe6ef75509aae434a8132aab0140b4ae8) dvtm-unstable: 2018-03-31 → unstable-2021-03-09
* [`1cd94ec0`](https://github.com/NixOS/nixpkgs/commit/1cd94ec0663bdbebc16b59ed3bf249c52c1a24ae) adbuco: patch to use XDG directory scheme by default
* [`4c5ada22`](https://github.com/NixOS/nixpkgs/commit/4c5ada2276ae311d210b4aa262be8b5a59f9f1a8) aduco: add patch to give exit code on dead session
* [`79ba445f`](https://github.com/NixOS/nixpkgs/commit/79ba445fd570ee4fee28003071afb80e49a0e603) abduco: add patch to report pixel sizes to child processes
* [`f0ccbfb3`](https://github.com/NixOS/nixpkgs/commit/f0ccbfb33109ac65d09792cc3df8b5be348c149a) abduco: add mirror, remove recursion
* [`f2e03957`](https://github.com/NixOS/nixpkgs/commit/f2e039573f112d1c5d7a8f0769fe1f0ed5e75a9d) natron: fix `gcc-13` build
* [`cf82d52a`](https://github.com/NixOS/nixpkgs/commit/cf82d52a23cd6dd70e4e0fb6603168443f5d691f) python311Packages.certbot: 2.7.4 -> 2.9.0
* [`37eeae68`](https://github.com/NixOS/nixpkgs/commit/37eeae6875e1164784bf7c453eb051392de1cdf5) nuraft: fix `gcc-13` build
* [`71915c86`](https://github.com/NixOS/nixpkgs/commit/71915c868db679a6d76e9de39c2e526ba6804a23) python311Packages.clarifai-grpc: 10.0.10 -> 10.1.3
* [`819cbc49`](https://github.com/NixOS/nixpkgs/commit/819cbc493784a6cc6556f9dfc04a8a820dab2dc2) afterglow-cursors-recolored: init at 0-unstable-2023-10-04
* [`bbe42235`](https://github.com/NixOS/nixpkgs/commit/bbe42235c8388053c93723e41b6c40db12ec317c) openmw-tes3mp: fix `raknet` depend build on `gcc-13`
* [`ebb01d76`](https://github.com/NixOS/nixpkgs/commit/ebb01d76dddd0df10460375cd7be3f1853f3efa4) openmw-tes3mp: fix `gcc-13` build
* [`53e0c3e9`](https://github.com/NixOS/nixpkgs/commit/53e0c3e9fa062bcdca6f2c922be67bd23eb20190) python311Packages.jaxlib-bin: 0.4.23 -> 0.4.24
* [`c3c69349`](https://github.com/NixOS/nixpkgs/commit/c3c693491ca0572da6b1a80e8ac164e4d74eff4d) winePackages.{unstable,staging}: 9.0 -> 9.1
* [`3d7e60be`](https://github.com/NixOS/nixpkgs/commit/3d7e60beb0224d40e86f4120e15302cdb0af94e9) woodpecker: use upstream naming for cli executable
* [`b491a952`](https://github.com/NixOS/nixpkgs/commit/b491a9522516a4d43f9f1aed542be96de1a74a0d) wifite2: 2.6.0 -> 2.7.0
* [`d87e3ab3`](https://github.com/NixOS/nixpkgs/commit/d87e3ab3a3724e71a7ef6b82e05691dd3e0f9f8c) Package migration to by-name
* [`65b289f6`](https://github.com/NixOS/nixpkgs/commit/65b289f68a2a677e9d675b849a10c19f3b188252) yosys: 0.37 -> 0.38
* [`721f5d80`](https://github.com/NixOS/nixpkgs/commit/721f5d8030e1eaa02b05ce20a0929793cd853821) ansible_2_15: 2.15.5 -> 2.15.9
* [`df84ec39`](https://github.com/NixOS/nixpkgs/commit/df84ec390f9ccf19c48bed1f789831b4373f9340) python311Packages.jaxlib: 0.4.23 -> 0.4.24
* [`68dd7531`](https://github.com/NixOS/nixpkgs/commit/68dd75315c31a8ebd089089455423354418668af) treewide: add system to "Unsupported system" throws
* [`c62f7c21`](https://github.com/NixOS/nixpkgs/commit/c62f7c21e997ec2adbd7dcc83b7cd2b704fe1c22) python311Packages.torch-bin: 2.1.2 -> 2.2.0
* [`1c0b570a`](https://github.com/NixOS/nixpkgs/commit/1c0b570a9ae57cfb94d65651ddbbafd1d30a6e33) python311Packages.torchaudio: 2.1.2 -> 2.2.0
* [`283343bd`](https://github.com/NixOS/nixpkgs/commit/283343bd2758ef091084a1d4e189ef07a484f126) python311Packages.torchaudio-bin: 2.1.2 -> 2.2.0
* [`ea277546`](https://github.com/NixOS/nixpkgs/commit/ea277546e277a09b7c48546e9cda8138aedca5af) python311Packages.torchvision: 0.16.2 -> 0.17.0
* [`fac77e6b`](https://github.com/NixOS/nixpkgs/commit/fac77e6b237fca2af8acd8222faae36f4c29f950) python311Packages.torchvision-bin: 0.16.2 -> 0.17.0
* [`adb9bde1`](https://github.com/NixOS/nixpkgs/commit/adb9bde1cc0f40e5ae1f8c5020e88ba8e30b0ef7) yabai: 6.0.9 -> 6.0.10
* [`873df446`](https://github.com/NixOS/nixpkgs/commit/873df4468f3e39409bfc8426b6c4f50e598d7ddd) renode-dts2repl: unstable-2024-02-02 -> unstable-2024-02-08
* [`0ffbb2a4`](https://github.com/NixOS/nixpkgs/commit/0ffbb2a4eee04856f0e9454205a7578f2bd29448) spooftooph: init at 0.5.2
* [`8121f355`](https://github.com/NixOS/nixpkgs/commit/8121f3559a98259a8e767dedf4eaf3939442c54d) treewide: add `mainProgram`
* [`3b2f55e8`](https://github.com/NixOS/nixpkgs/commit/3b2f55e89f8233333b191bb7b4c9d6448a4a2d74) xdg-desktop-portal: Use custom variable for finding portals
* [`fe40e990`](https://github.com/NixOS/nixpkgs/commit/fe40e99020f340c982e156e22ac531157174af5b) nixos/xdg/portal: Use systemPackage instead of buildEnv
* [`4da3fd28`](https://github.com/NixOS/nixpkgs/commit/4da3fd28201864ce753e5a75357859d8cb9c63b4) sonic-server: 1.4.3 -> 1.4.8
* [`0d1e594c`](https://github.com/NixOS/nixpkgs/commit/0d1e594cacb6745adfdc3d839ff4428d5eaa4a7b) moodle: 4.3.2 -> 4.3.3
* [`ba70c921`](https://github.com/NixOS/nixpkgs/commit/ba70c921d5e544df4c347d7224d8201416b0dbf1) freeciv: 3.0.9 -> 3.0.10
* [`5ea62d1e`](https://github.com/NixOS/nixpkgs/commit/5ea62d1e61462145aa78db0ce2bac612c207fca2) librime: 1.9.0 -> 1.10.0
* [`25a9f957`](https://github.com/NixOS/nixpkgs/commit/25a9f9572cefe3a2fb865385d1e4a63a0992aa24) nb: 7.10.3 -> 7.11.0
* [`a602c66f`](https://github.com/NixOS/nixpkgs/commit/a602c66f7e084f4432f190a3607cde781f8b119f) bitwig-studio: 5.0.11 -> 5.1.3
* [`76081bed`](https://github.com/NixOS/nixpkgs/commit/76081bed3a06aaa25dcf0fe355c9a79f2f7a593d) doc/qt: refresh
* [`282d32e7`](https://github.com/NixOS/nixpkgs/commit/282d32e76a4c2538cbedf332ce99fcac82b2b647) python311Packages.slowapi: 0.1.8 -> 0.1.9
* [`4fd75203`](https://github.com/NixOS/nixpkgs/commit/4fd75203126ea6a27b11fc7245415f76345f702d) corectrl: 1.3.9 -> 1.3.10
* [`7fd32911`](https://github.com/NixOS/nixpkgs/commit/7fd329110c82868520c1a9736317bec5ddf40b7e) python311Packages.slowapi: refactor
* [`8a7fcdca`](https://github.com/NixOS/nixpkgs/commit/8a7fcdca70d7c94f40ae4b72612bdb54cba74d16) python311Packages.aetcd: init at 1.0.0a4
* [`a59d5e30`](https://github.com/NixOS/nixpkgs/commit/a59d5e302874e2c3dc4e08693ae43635fd2f0157) svaba: fix `gcc-13` build failure
* [`9e463262`](https://github.com/NixOS/nixpkgs/commit/9e463262e9f1c7a39c5622e54cbcde286e507e0a) python311Packages.python-telegram-bot: 20.7 -> 20.8
* [`8188b29b`](https://github.com/NixOS/nixpkgs/commit/8188b29b886ea49c682de343796d9f223e583ca6) molecule: 6.0.3 -> 24.2.0
* [`a97504ef`](https://github.com/NixOS/nixpkgs/commit/a97504ef3acbba598576fa135e424d66763c74d2) pcloud: 1.14.3 -> 1.14.4
* [`a74b1732`](https://github.com/NixOS/nixpkgs/commit/a74b1732a70972459f56b190d7f1957ff656dd29) timeloop: fix `gcc-13` build failure
* [`9b09677d`](https://github.com/NixOS/nixpkgs/commit/9b09677d3e72cda96b3006bd11eee05cde030ec3) reaction: init at 1.3.0
* [`4f7b644d`](https://github.com/NixOS/nixpkgs/commit/4f7b644df537e92a9d748fc95623d043ec1e0bfc) arrow-cpp: disable a flaky test
* [`660b5902`](https://github.com/NixOS/nixpkgs/commit/660b5902d25069a3df7b301add468107c02a1d68) arrow-cpp: allow customizing aws-sdk-cpp.apis
* [`43f6f4e4`](https://github.com/NixOS/nixpkgs/commit/43f6f4e46f5e3bcf28239b4539a751070b8e5fe9) urbackup-client: enable parallel building
* [`4de07c15`](https://github.com/NixOS/nixpkgs/commit/4de07c15155fa4bd5859e7c34c702244c787ebfa) urbackup-client: fix `gcc-13` build failure
* [`fec3ca26`](https://github.com/NixOS/nixpkgs/commit/fec3ca261e2d7971c376d91dba984fce58cf5dae) arrow-cpp: add meta.pkgConfigModules
* [`18fb6bc8`](https://github.com/NixOS/nixpkgs/commit/18fb6bc8802c2dc6809592eb63b3976d1219d0ed) arrow-cpp: build with bzip2 support
* [`e0a428ff`](https://github.com/NixOS/nixpkgs/commit/e0a428ffd507346cf1d5e61c0610bcb3908a5242) vscode-extensions.charliermarsh.ruff: fix source hash
* [`77277dd0`](https://github.com/NixOS/nixpkgs/commit/77277dd0006503a15c90ee9fd06d5aa95c6ae3cd) torcs: add desktop item
* [`c17c1cc8`](https://github.com/NixOS/nixpkgs/commit/c17c1cc84b9ddb12557efb11faf90208609e075f) mongoc: 1.24.4 -> 1.25.4
* [`8965393f`](https://github.com/NixOS/nixpkgs/commit/8965393f1f2466acb893ecbda42298ec0c10784e) zrythm: fix `gcc-13` build failure
* [`961e0930`](https://github.com/NixOS/nixpkgs/commit/961e0930c3101dc9e262ebcc3ca17891234dc873) signalbackup-tools: 20240205 -> 20240210-1
* [`b18a422f`](https://github.com/NixOS/nixpkgs/commit/b18a422f41aab3daf8ff3966d43316cd28b7e64b) sysdig: 0.34.1 -> 0.35.1
* [`6f37738c`](https://github.com/NixOS/nixpkgs/commit/6f37738cf7ea61aa044b7ed98a6fc184067425b8) sysdig: remove unneeded tinydir (https://github.com/draios/sysdig/commit/838ffdeb05e9c747c25de7880f735b03e740741e)
* [`e6518988`](https://github.com/NixOS/nixpkgs/commit/e65189881746837a48f24fff46ee5a999d0da04f) python311Packages.starlette-wtf: fix build
* [`62c998c0`](https://github.com/NixOS/nixpkgs/commit/62c998c0bb92b8068b876bf60e0af349a9448b68) winePackages.{unstable,staging}: 9.1 -> 9.2
* [`2e2211a3`](https://github.com/NixOS/nixpkgs/commit/2e2211a386070c0b5b3cbb94fb7da83637cd12dd) wine: don't default mingwSupport to true outside stable release
* [`b2182b91`](https://github.com/NixOS/nixpkgs/commit/b2182b9130c18c8d8527b86e2e8a2cb749c115fa) wine: cleanup Wayland
* [`033b0dcb`](https://github.com/NixOS/nixpkgs/commit/033b0dcb7f4b26435f0924eb5acda8fe7d323ba6) whitesur-gtk-theme: add nordColor and darkerColor options
* [`997500c6`](https://github.com/NixOS/nixpkgs/commit/997500c6885ca83923cce49c91f7675515c3827b) maintainers: add _9R
* [`14f30e7b`](https://github.com/NixOS/nixpkgs/commit/14f30e7bfba12ab4908312469850a0b51b1bf928) raft-cowsql: 0.19.1 -> 0.22.0
* [`c9efac83`](https://github.com/NixOS/nixpkgs/commit/c9efac8374aad3a9bd15424075c24009388d6b3a) pmbootstrap 2.1.0 -> 2.2.0
* [`277a870c`](https://github.com/NixOS/nixpkgs/commit/277a870cf19dbbc37846528583f26007b55699ac) freefilesync: fix build with curl 8.6.0
* [`01a39263`](https://github.com/NixOS/nixpkgs/commit/01a39263ffc37b9d49f715de76b6248e93c2cb06) arrow-cpp: move to by-name
* [`830cfc27`](https://github.com/NixOS/nixpkgs/commit/830cfc27d99aed29f149b83e175e747105748d0d) tinyxml: apply patches for CVE-2023-34194 and CVE-2021-42260
* [`99a12fdb`](https://github.com/NixOS/nixpkgs/commit/99a12fdbb07c8d7711253bed31a97c329a229ebe) yabai: 6.0.10 -> 6.0.11
* [`5dfd5ecc`](https://github.com/NixOS/nixpkgs/commit/5dfd5ecc84d2925bba0eafddc4bcae44ec8ca5e2) flutter313: Fix aarch64-darwin
* [`db38aeee`](https://github.com/NixOS/nixpkgs/commit/db38aeee723be819360d1eb951c9f5988fdfb987) flutter316: Add aarch64-darwin hashes and fix meta.platforms
* [`ab168d1f`](https://github.com/NixOS/nixpkgs/commit/ab168d1f137db4978501cf592043a304b6c85fe0) flutter: Apply multiple Darwin aarch64 fixes
* [`9002bb2d`](https://github.com/NixOS/nixpkgs/commit/9002bb2df5d378fdbd06479dc296e9ebe1b6082f) python311Packages.thermopro-ble: 0.9.0 -> 0.10.0
* [`4c863e62`](https://github.com/NixOS/nixpkgs/commit/4c863e62e94b812306d6c9a126e3996405492d6a) plasma5Packages.itinerary: add missing dependency
* [`712a0c60`](https://github.com/NixOS/nixpkgs/commit/712a0c60a5cfe7c65ac329dbd9ecc24767497927) game-rs: 0.1.3 -> 0.2.0
* [`3ea21a4e`](https://github.com/NixOS/nixpkgs/commit/3ea21a4ea9a5d033dea3762f9dfcc6e4023e527e) wxmaxima: 24.02.0 -> 24.02.1
* [`e35d0cc0`](https://github.com/NixOS/nixpkgs/commit/e35d0cc0b52aba427b92c520b5f2c0c6b9670d5c) xpano: 0.17.0 -> 0.18.1
* [`57da038a`](https://github.com/NixOS/nixpkgs/commit/57da038a87c2c42d57003fc2451cdaffbe36b9f2) sispmctl: init at 4.11
* [`84f5833a`](https://github.com/NixOS/nixpkgs/commit/84f5833a9d9b5c693e449aa5a63be0d40b7886ef) presenterm: 0.6.0 -> 0.6.1
* [`e94f42a0`](https://github.com/NixOS/nixpkgs/commit/e94f42a0f355b4f9225edb57d756902c5cfb50be) yasashisa-gothic: init at 0-unstable-2014-03-13
* [`65a5c4b3`](https://github.com/NixOS/nixpkgs/commit/65a5c4b3c7dbeb37d82dc07cd987c4b05c8b4b13) python311Packages.vallox-websocket-api: 4.0.3 -> 4.1.0
* [`5e43c708`](https://github.com/NixOS/nixpkgs/commit/5e43c708676c9ca0cb5d4c848ee9f3057e94b815) nixos/tandoor-recipes: improve manage script
* [`2004c7b5`](https://github.com/NixOS/nixpkgs/commit/2004c7b5c464b9b1518e2e87b185c83838ab4c56) symfony-cli: 5.8.6 -> 5.8.8
* [`3ded64d1`](https://github.com/NixOS/nixpkgs/commit/3ded64d1d0638b9e164ebeee75b269a250cd906a) beeper: 3.94.20 -> 3.95.22
* [`89f5f4ab`](https://github.com/NixOS/nixpkgs/commit/89f5f4ab774f08bc5b677e7ad5687f477822b96a) kdiskmark: 3.0.0 -> 3.1.4
* [`d642e6fa`](https://github.com/NixOS/nixpkgs/commit/d642e6fad8d45b890f01eb72097ca59dc6d68a01) python311Packages.hahomematic: 2024.2.1 -> 2024.2.2
* [`dfd4e93a`](https://github.com/NixOS/nixpkgs/commit/dfd4e93ac5dbaa5b6332b53bf6a97d646180fc69) python311Packages.levenshtein: 0.24.0 -> 0.25.0
* [`f60049ee`](https://github.com/NixOS/nixpkgs/commit/f60049ee5de45bc6e27fd428f6bbf70c03639e28) cargo-show-asm: 0.2.29 -> 0.2.30
* [`e3ddd0d0`](https://github.com/NixOS/nixpkgs/commit/e3ddd0d0a78ce6a9e8911f61ed8251bc8973be77) squeekboard.meta.homepage: update
* [`e553e37a`](https://github.com/NixOS/nixpkgs/commit/e553e37abfb7e7fbd280c0b02d43ecd4331fe3c5) nixos/mysql: remove MySQL fixed 30 second timeout
* [`b445085c`](https://github.com/NixOS/nixpkgs/commit/b445085c22189a9807fbbdd260107e4b37226241) nixos/mysql: Use notify service type for MySQL >= 8.0
* [`eb9d064f`](https://github.com/NixOS/nixpkgs/commit/eb9d064fc67afa179369eef2bf5faf2184224e67) codeium: 1.6.30 -> 1.6.34
* [`a83c8342`](https://github.com/NixOS/nixpkgs/commit/a83c83422bd01d6cc9d0b588b9972619577d572a) python311Packages.argilla: 1.23.0 -> 1.24.0
* [`a9099d08`](https://github.com/NixOS/nixpkgs/commit/a9099d08eeec766e123dbf4150abc5545ebf1a79) python311Packages.anywidget: 0.9.0 -> 0.9.2
* [`de5d1e37`](https://github.com/NixOS/nixpkgs/commit/de5d1e37e7d1bdda75e7bc2c7347e464da6a5357) lychee: 0.14.2 -> 0.14.3
* [`ea4cd5c6`](https://github.com/NixOS/nixpkgs/commit/ea4cd5c63db9bed4e7ed7f3af89cc11cb75a5625) check-by-name: Update pinned tooling
* [`ca8f9489`](https://github.com/NixOS/nixpkgs/commit/ca8f948914d42cf01fea44fb4ba97bba5822ecab) python311Packages.appthreat-vulnerability-db: 5.6.1 -> 5.6.2
* [`0799b6de`](https://github.com/NixOS/nixpkgs/commit/0799b6de749b863c5a647a35d2a9a018860ba299) foundationdb: use msgpack-cxx instead of msgpack
* [`8750ab63`](https://github.com/NixOS/nixpkgs/commit/8750ab6320ae3240ec8508f021715c0b7fd612bf) python311Packages.meross-iot: 0.4.6.0 -> 0.4.6.2
* [`8b13b392`](https://github.com/NixOS/nixpkgs/commit/8b13b3923582375e2256e7c8f2aa03bae99f0f12) just: 1.23.0 -> 1.24.0
* [`736bd546`](https://github.com/NixOS/nixpkgs/commit/736bd54624f178b31ecb08930e01d79789eaed10) libgbinder: 1.1.35 -> 1.1.36
* [`62e2dedd`](https://github.com/NixOS/nixpkgs/commit/62e2dedd447aed85a89cfd14af6c95c983003883) python312Packages.fschat: 0.2.34 -> 0.2.36
* [`d73507aa`](https://github.com/NixOS/nixpkgs/commit/d73507aae635df37e68208ad508bcfc0b0bdd800) python312Packages.pytest-describe: 2.1.0 -> 2.2.0
* [`ebd05ed5`](https://github.com/NixOS/nixpkgs/commit/ebd05ed5241e53659fbfab0c9705f4d38485e7eb) cargo-chef: 0.1.62 -> 0.1.63
* [`a5b087ac`](https://github.com/NixOS/nixpkgs/commit/a5b087aca0da19c766fbcb75d355b63e2faf16e9) python312Packages.thermopro-ble: 0.9.0 -> 0.10.0
* [`ebf17582`](https://github.com/NixOS/nixpkgs/commit/ebf175827442142216254faaf3c3148f5551e59c) fq: 0.9.0 -> 0.10.0
* [`c7a38988`](https://github.com/NixOS/nixpkgs/commit/c7a389888d26351bc6a16ff0a64122a8fb2259dd) moq: 0.3.3 -> 0.3.4
* [`6a79a442`](https://github.com/NixOS/nixpkgs/commit/6a79a442b49967fd8ccae8eeb9f03a066d74eac4) imagemagick: 7.1.1-27 -> 7.1.1-28
* [`04bb48b1`](https://github.com/NixOS/nixpkgs/commit/04bb48b116ba34c330edba75f2acbe507d322971) gqlgenc: 0.18.1 -> 0.19.0
* [`2ca12634`](https://github.com/NixOS/nixpkgs/commit/2ca12634631314cc0622a943394670e1246e50b7) fastfetch: 2.7.1 -> 2.8.3
* [`bd1c70e1`](https://github.com/NixOS/nixpkgs/commit/bd1c70e1419210aef6cfcdc97bf91338c880efa4) fishPlugins.tide: 6.0.1 -> 6.1.1
* [`74bfa4e3`](https://github.com/NixOS/nixpkgs/commit/74bfa4e39e830c6d496d0088df6d57a5d3a26f37) python311Packages.stem: 1.8.2 -> 1.8.3-unstable-2024-02-11
* [`31ceb816`](https://github.com/NixOS/nixpkgs/commit/31ceb8166b2abedd53cf69e0154031dc47b885c3) diebahn: 2.1.0 -> 2.3.0
* [`d0183ef7`](https://github.com/NixOS/nixpkgs/commit/d0183ef771b8cf0b17b5df509567951747f692bf) Revert "python311Packages.asn1crypto: 1.5.1 -> 1.5.1-unstable-2023.11.03"
* [`0f451f6e`](https://github.com/NixOS/nixpkgs/commit/0f451f6e4a3c998e47c323a33d5f88dd5a532c74) python311Packages.asn1crypto: use pyproject = true
* [`cc2058e2`](https://github.com/NixOS/nixpkgs/commit/cc2058e2fc95c9d968e8cfacb933348c67ad6298) snapmaker-luban: 4.9.1 -> 4.10.2
* [`433837d5`](https://github.com/NixOS/nixpkgs/commit/433837d5ba350251df352f2abf569aa173708afa) python311Packages.asn1crypto: add dotlambda to maintainers
* [`d7f336c0`](https://github.com/NixOS/nixpkgs/commit/d7f336c0e43ed2410374ea0f618858f34ae9bf53) eigenlayer: 0.5.2 -> 0.6.1
* [`e17b1bff`](https://github.com/NixOS/nixpkgs/commit/e17b1bffd29c5466bca207fa762779b8ba4f2c87) supabase-cli: 1.142.2 -> 1.144.2
* [`71d1678f`](https://github.com/NixOS/nixpkgs/commit/71d1678f0a3351d3c6c9f21abced8a5cd42ba5e8) clash-geoip: 20240112 -> 20240212
* [`4f94d3a6`](https://github.com/NixOS/nixpkgs/commit/4f94d3a625a20746b12a482cd6a5198c9c208886) python311Packages.limits: add optional-dependencies
* [`08de1d9d`](https://github.com/NixOS/nixpkgs/commit/08de1d9de722db19204793c11e9cb7bf6746e46a) lomiri.content-hub: 1.1.0 -> 1.1.1
* [`5059a1ec`](https://github.com/NixOS/nixpkgs/commit/5059a1ec6879313dd34c716314b6213afa4fab9c) python311Packages.imageio: 2.33.1 -> 2.34.0
* [`0f7650ef`](https://github.com/NixOS/nixpkgs/commit/0f7650ef9c8e0117324cf8324fbe00255807de45) python311Packages.appthreat-vulnerability-db: 5.6.1 -> 5.6.2
* [`864ba40b`](https://github.com/NixOS/nixpkgs/commit/864ba40b393320423ddff1fbea8be20ebd32eb03) python311Packages.asyncwhois: 1.0.9 -> 1.1.0
* [`2548a200`](https://github.com/NixOS/nixpkgs/commit/2548a2004156d28466ba834604c05475e353c0d9) python311Packages.asyncwhois: refactor
* [`847f22d0`](https://github.com/NixOS/nixpkgs/commit/847f22d0c2997b16897b6dae8027e6c6f8400049) python311Packages.approvaltests: 10.3.0 -> 10.4.0
* [`2837198c`](https://github.com/NixOS/nixpkgs/commit/2837198c914f81e4e2a63c8f6076d769ab27eefa) python311Packages.xknxproject: 3.5.0 -> 3.6.0
* [`e2d1d6d2`](https://github.com/NixOS/nixpkgs/commit/e2d1d6d24c2609509ef0eb20298dbdfdb5d823cc) home-assistant: update component-packages
* [`7534a77b`](https://github.com/NixOS/nixpkgs/commit/7534a77bb6a1d8236acc94cd654d97952ba1e361) python311Packages.aioautomower: int at 2024.2.4
* [`27f0c20f`](https://github.com/NixOS/nixpkgs/commit/27f0c20fe5d85332dbe27bfc39f4395a040a477f) python311Packages.pyngrok: 7.1.1 -> 7.1.2
* [`45a31d17`](https://github.com/NixOS/nixpkgs/commit/45a31d17c97f07e449a32f35aa8b6c213afd89ae) ddev: 1.22.6 -> 1.22.7
* [`3c8d8cfc`](https://github.com/NixOS/nixpkgs/commit/3c8d8cfcfb96fc5895d6eafe1314d31d2576ce99) python312Packages.typeguard: refactor
* [`cf1efc01`](https://github.com/NixOS/nixpkgs/commit/cf1efc01d30593c4110e7b17b2ac3f17a4ed6c66) stalwart-mail: 0.5.2 -> 0.5.3
* [`8cac3257`](https://github.com/NixOS/nixpkgs/commit/8cac3257488262fb03a17a2a042b60c4543a1837) python311Packages.ariadne: adjust inputs
* [`494d8084`](https://github.com/NixOS/nixpkgs/commit/494d8084c0a35a29af43ae483c43a63664eec727) python311Packages.ariadne: 0.21.0 -> 0.22.0
* [`28623fb9`](https://github.com/NixOS/nixpkgs/commit/28623fb95e565cee9e571e74eaba460c4a9899d1) lomiri.content-hub: Add validatePkgConfig & meta.changelog, fix substituteInPlace warnings
* [`21c21e55`](https://github.com/NixOS/nixpkgs/commit/21c21e559ccd64d45dc140a0b644a35ca46a5129) vimPlugins.neocord: init at 2024-02-10 ([nixos/nixpkgs⁠#288120](https://togithub.com/nixos/nixpkgs/issues/288120))
* [`3af99022`](https://github.com/NixOS/nixpkgs/commit/3af990221c5605c219e2875c9ee8bb337087525b) linkerd_edge: 24.2.1 -> 24.2.2
* [`4439b1f1`](https://github.com/NixOS/nixpkgs/commit/4439b1f12086e89b0814864799d3ad19d3ad1078) chirp: unstable-2023-06-02 -> unstable-2024-02-08
* [`9e5d72b5`](https://github.com/NixOS/nixpkgs/commit/9e5d72b576f9172db6ffea1e57cc6e411fc397cc) python311Packages.shap: disable tests and reduce pythonImportsCheck
* [`bd6def34`](https://github.com/NixOS/nixpkgs/commit/bd6def34e2694e5eb4a8e2f26c6b75c152b4fe6f) neovimUtils.buildNeovimPlugin: use version from derivation if missing ([nixos/nixpkgs⁠#288251](https://togithub.com/nixos/nixpkgs/issues/288251))
* [`b670443f`](https://github.com/NixOS/nixpkgs/commit/b670443f42e537acbd28b5393cb5cef92ecd8ad1) nixos/hydra: use set-default in hydra-env wrapper package
* [`eac58d0e`](https://github.com/NixOS/nixpkgs/commit/eac58d0eebbc3e884890cafd609307da0cd08191) agdaPackages.cubical: 0.6 -> 0.7
* [`117a84da`](https://github.com/NixOS/nixpkgs/commit/117a84da4255ecc17bffbfc116ec80bc37efa696) golangci-lint: 1.56.0 -> 1.56.1
* [`af4f3c8c`](https://github.com/NixOS/nixpkgs/commit/af4f3c8cf698cf3a311f4cc66f1addb7b73e13df) golangci-lint: add meta.mainProgram
* [`8aab326d`](https://github.com/NixOS/nixpkgs/commit/8aab326d233f2e48a01401d0ba8b78606d376523) linux_testing: 6.8-rc3 -> 6.8-rc4
* [`9bf9e370`](https://github.com/NixOS/nixpkgs/commit/9bf9e3708e17e5c3b763b32e434e802acdfd4c1a) linux-rt_6_1: 6.1.75-rt23 -> 6.1.77-rt24
* [`caefd161`](https://github.com/NixOS/nixpkgs/commit/caefd1615b2232ea7c49fcc25fb42f6980f6cd82) molecule: add version test
* [`e5d0eda6`](https://github.com/NixOS/nixpkgs/commit/e5d0eda6d7b06613da9840f28204d0ad9d50375e) stgit: 2.4.3 -> 2.4.4
* [`e010085c`](https://github.com/NixOS/nixpkgs/commit/e010085c33cd6fdb166934021ce45b7261a1440e) python311Packages.textual-universal-directorytree: refactor
* [`19cee401`](https://github.com/NixOS/nixpkgs/commit/19cee401a2943ceed6b6b57420286a9a0454749f) python311Packages.textual-universal-directorytree: add patch for universal-pathlib
* [`4e5ae340`](https://github.com/NixOS/nixpkgs/commit/4e5ae340ae3606f07c373a42f2b05295b94eda7d) python311Packages.meross-iot: refactor
* [`31b9a9d1`](https://github.com/NixOS/nixpkgs/commit/31b9a9d18c4793ba327ebe80569a8b71c432c06a) opensnitch: 1.6.4 -> 1.6.5, opensnitch-ui: 1.6.4 -> 1.6.5.1
* [`1251bed4`](https://github.com/NixOS/nixpkgs/commit/1251bed414613f616ab37d6f8761f3e851e0abb0) phosh: 0.35.0 -> 0.36.0
* [`9a47ff9b`](https://github.com/NixOS/nixpkgs/commit/9a47ff9b6c505b336d1f9cad52aecf50cb7ac99b) python311Packages.home-assistant-chip-core: fix hash on aarch64
* [`a0bfe7bc`](https://github.com/NixOS/nixpkgs/commit/a0bfe7bcf5cd7795cdf6cb11e1bf5cc70b503d18) ols: nightly-2023-11-04 -> 0-unstable-2024-02-09
* [`d8c99b03`](https://github.com/NixOS/nixpkgs/commit/d8c99b0391a81c5b0a4f901fe370341baec37ff3) python3Packages.xformers: skip bulk updates
* [`c4122633`](https://github.com/NixOS/nixpkgs/commit/c4122633197c352d355f5d02c598238fddcd67f5) nixos/rustdesk-server: add extra args options for hbbr and hbbs
* [`1b9f9aae`](https://github.com/NixOS/nixpkgs/commit/1b9f9aae1a85b6d24ae090b6800282205d0f44d7) osu-lzer-bin: fix update-bin.sh script
* [`b6dd7c8c`](https://github.com/NixOS/nixpkgs/commit/b6dd7c8c7b8fd0bfcb88abf2fb81662a57b21fd3) osu-lazer: fix update.sh script
* [`dd5c1149`](https://github.com/NixOS/nixpkgs/commit/dd5c114933277f8aeb9bea478b14b237139aa293) scheme-manpages: unstable-2023-08-27 -> unstable-2024-02-11
* [`7a401d46`](https://github.com/NixOS/nixpkgs/commit/7a401d46b62bd5e640532cf11be75539d0108249) cloudflared: 2024.1.5 -> 2024.2.0
* [`019cdcae`](https://github.com/NixOS/nixpkgs/commit/019cdcaebe26806902068a54f99640569854b06b) tribler: deps pin pydantic_1
* [`a9df42c2`](https://github.com/NixOS/nixpkgs/commit/a9df42c202da74dcc463fbf9252f03ff26d25156) jetbrains-toolbox: 2.1.3.18901 -> 2.2.1.19765
* [`082bc519`](https://github.com/NixOS/nixpkgs/commit/082bc519287c5a88cd1d26f0a1db7b35aa8f55e7) werf: 1.2.288 -> 1.2.289
* [`5a8fb512`](https://github.com/NixOS/nixpkgs/commit/5a8fb512249df7cd73682e9e290080ad0e16a427) faraday-agent-dispatcher: 3.0.1 -> 3.2.1
* [`4b809a7a`](https://github.com/NixOS/nixpkgs/commit/4b809a7a61fe62c7ad1bdf640856f1ac69858dfc) linuxPackages.rtl8188eus: support kernel 6.7
* [`0e123540`](https://github.com/NixOS/nixpkgs/commit/0e123540e5870dff8f8a823d26f9d0abe14ac91b) paper-plane: Fix eval after gtk4 4.12.5 update
* [`511c9def`](https://github.com/NixOS/nixpkgs/commit/511c9def657b23d9b3ca8c61f1723ad10c1c4674) envio: init at 0.5.0
* [`65facc53`](https://github.com/NixOS/nixpkgs/commit/65facc534089814d07f331f4034655aa3bd33f7a) obs-studio-plugins.obs-teleport: 0.6.6 -> 0.7.0
* [`0953e704`](https://github.com/NixOS/nixpkgs/commit/0953e7043b6e189ff9222bcd3d68636df82adc52) python311Packages.types-pytz: 2023.4.0.20240130 -> 2024.1.0.20240203
* [`b17969fe`](https://github.com/NixOS/nixpkgs/commit/b17969fe5a4bb1974b5ea643722d0faa49fc1863) mdbook-pdf-outline: init at 0.1.4
* [`fda93f9f`](https://github.com/NixOS/nixpkgs/commit/fda93f9f11babd7673240f5bb332a92d1a98ee3d) liquidctl: fix test for pillow ≥ 10.2.0 ([nixos/nixpkgs⁠#288085](https://togithub.com/nixos/nixpkgs/issues/288085))
* [`b71a98af`](https://github.com/NixOS/nixpkgs/commit/b71a98af6c188d74da70d3b735c3bd045a90ce13) tree-sitter: 0.20.8 -> 0.20.9
* [`edd1c9b0`](https://github.com/NixOS/nixpkgs/commit/edd1c9b00ea482661b5a2834c6f0584da953a6b0) python311Packages.homeassistant-bring-api: init at 0.1.0
* [`1d5f9ae4`](https://github.com/NixOS/nixpkgs/commit/1d5f9ae48641dab528044a27113b4dc1343d97d9) rustdesk-flutter: unstable-2024-02-03 -> 1.2.3-unstable-2024-02-11
* [`bcf872cd`](https://github.com/NixOS/nixpkgs/commit/bcf872cd70fc95ae501696bde2e7f483cf463b7c) stlink: set darwin badPlatforms
* [`759e3093`](https://github.com/NixOS/nixpkgs/commit/759e30933935b65e39a2ae12d371356f016f36bd) glauth: 2.3.0 -> 2.3.1
* [`28bd8790`](https://github.com/NixOS/nixpkgs/commit/28bd8790ade0c8efaa85b022e5ab28ed66cf66ec) xdg-user-dirs: fix darwin builds
* [`2a560b65`](https://github.com/NixOS/nixpkgs/commit/2a560b654076211b1aaf03818240c5103edd3979) gitsign: 0.8.0 -> 0.8.1
* [`aa4405d6`](https://github.com/NixOS/nixpkgs/commit/aa4405d6ac65e018801dafaf66b124e16e736030) mpich: 4.1.2 -> 4.2.0
* [`e656d228`](https://github.com/NixOS/nixpkgs/commit/e656d2286aaccf5a3e58cd99f50e6ac768f32bb7) ardopc: init at unstable-2021-08-28
* [`afb68712`](https://github.com/NixOS/nixpkgs/commit/afb6871244622aab7bb27f592c738a65615f010c) abcmidi: 2024.01.04 -> 2024.02.11
* [`b8f16e4e`](https://github.com/NixOS/nixpkgs/commit/b8f16e4e339db000fc8137ea20572affb234d83a) netplan: fix path to generate executable
* [`47b708cb`](https://github.com/NixOS/nixpkgs/commit/47b708cb2b8186f94bdb93083d193f2824cdfe1e) birdwatcher: 2.2.4 -> 2.2.5
* [`ba97d1fb`](https://github.com/NixOS/nixpkgs/commit/ba97d1fb72b16ac0098351c47323474643f8fb78) alice-lg: 6.0.0 -> 6.1.0
* [`35b2e97c`](https://github.com/NixOS/nixpkgs/commit/35b2e97c996d8247dd144e53eab9cf1dfb119491) zfs-replicate: 3.2.6 -> 3.2.7
* [`8e930f41`](https://github.com/NixOS/nixpkgs/commit/8e930f416e5ecdab0dc3a02785f84480891afade) octodns-providers.bind: 0.0.5 -> 0.0.6
* [`662b7981`](https://github.com/NixOS/nixpkgs/commit/662b79811106b3d04f0bd01ef1474d0060ba9471) invidtui: 0.4.1 -> 0.4.2
* [`c6f4ab4b`](https://github.com/NixOS/nixpkgs/commit/c6f4ab4b5440d80bc55254fc1f6396ea7203ae44) roslyn-ls: init at 4.10.0-2.24102.11
* [`bb9b3d0d`](https://github.com/NixOS/nixpkgs/commit/bb9b3d0db567c94f05f8c69fc9777ad6eca845f2) trigger: add desktop item
* [`1fbd85e8`](https://github.com/NixOS/nixpkgs/commit/1fbd85e8889f488dca1065112420449e7ef45784) wireproxy: 1.0.6 -> 1.0.7
* [`afe7a6af`](https://github.com/NixOS/nixpkgs/commit/afe7a6afc9dbe7ea666a9dbf7a46b9826f1ff2c0) httpx: 1.3.9 -> 1.4.0
* [`ae5d5900`](https://github.com/NixOS/nixpkgs/commit/ae5d59001fe05f6a6badedecc518b761b1ceae63) python311Packages.securetar: 2023.12.0 -> 2024.2.0
* [`d4df0f2d`](https://github.com/NixOS/nixpkgs/commit/d4df0f2d2f49d29f5616145a1829383f259f9962) atmos: 1.57.0 -> 1.60.0
* [`a02a0823`](https://github.com/NixOS/nixpkgs/commit/a02a08237640169d6d30f6c106d0a94d07987a6e) libewf-legacy: fix pname
* [`162234a4`](https://github.com/NixOS/nixpkgs/commit/162234a4b63087d74774d2d965f1c8b997d0d176) pdfarranger: add libhandy
* [`9c5c1215`](https://github.com/NixOS/nixpkgs/commit/9c5c1215178ad701522faae2884711d0e663501d) tippecanoe: 2.42.0 -> 2.43.0
* [`e5e8d1ed`](https://github.com/NixOS/nixpkgs/commit/e5e8d1ed0b854b77a8dc94da270a38c717e455f5) speedtest-rs: 0.1.4 -> 0.1.5
* [`31fada65`](https://github.com/NixOS/nixpkgs/commit/31fada653bf0976e51cba33556438459f8bf1410) python312Packages.livereload: fix build by swapping nose with pytest
* [`51a7fd43`](https://github.com/NixOS/nixpkgs/commit/51a7fd43307dfa52abe329bad94fd03f7c84fdaa) flare-signal: 0.11.2 -> 0.12.0
* [`375e57e6`](https://github.com/NixOS/nixpkgs/commit/375e57e6ee0f59f9ce1f4bbe21a5de95a6ba4499) mtail: 3.0.0-rc53 -> 3.0.0-rc54
* [`ea5f5df1`](https://github.com/NixOS/nixpkgs/commit/ea5f5df1c79b5f5e23fd98df25937acf4a11e0bf) coqPackages.smtcoq: expand to more supported versions
* [`03f93e08`](https://github.com/NixOS/nixpkgs/commit/03f93e082f7d6f2e432837118382399e5ca6dd61) python3Packages.pynose: init at 1.4.8
* [`3ab52897`](https://github.com/NixOS/nixpkgs/commit/3ab52897b6cb23e69b86e6d23ef1d3b60b563f98) python312Packages.envs: fix build by switching to pynose
* [`b2902cf9`](https://github.com/NixOS/nixpkgs/commit/b2902cf903cde636eeadb882945cdabc6d61d434) python311Packages.editorconfig: 0.12.3 -> 0.12.4
* [`145c1947`](https://github.com/NixOS/nixpkgs/commit/145c194785f943e5dddde895fefc1690fc962869) python311Packages.edk2-pytool-library: 0.21.2 -> 0.21.3
* [`352a41f7`](https://github.com/NixOS/nixpkgs/commit/352a41f7ce0146a3aeac8bc71dba96a32e35ff62) python311Packages.essentials: init at 0.1.5
* [`9b4795a6`](https://github.com/NixOS/nixpkgs/commit/9b4795a6abea10f893feaa48788c036248b7c2eb) diffoscope: 254 -> 257
* [`081521b9`](https://github.com/NixOS/nixpkgs/commit/081521b972e063c8dd8ed01d3c16769f85608a9f) python312Packages.aiosqlite: drop aiounittest which isn't used since 0.18.0
* [`7782d26f`](https://github.com/NixOS/nixpkgs/commit/7782d26fb9aad17c5413146316b0a8503a865f5a) python311Packages.essentials-openapi: init at 1.0.9
* [`64cb577f`](https://github.com/NixOS/nixpkgs/commit/64cb577ff11cfb754ef7bf981ef7865e712687dc) python311Packages.neoteroi-mkdocs: init at 1.0.4
* [`597c5d2f`](https://github.com/NixOS/nixpkgs/commit/597c5d2f710be97b3d04a36036a703a2c18d1dbb) ext3grep: init at 0.10.2
* [`ff1f3ca6`](https://github.com/NixOS/nixpkgs/commit/ff1f3ca6fead45c26e5aa69b575dc8ec3d1b006c) pet: 0.6.0 -> 0.6.1
* [`bdc79efc`](https://github.com/NixOS/nixpkgs/commit/bdc79efc2b1e1eb4503589e6c362ccc9e10e9298) nixos/lxd/vm: fix network config
* [`cf68af85`](https://github.com/NixOS/nixpkgs/commit/cf68af8561b4624738f10158960ce2748fa75877) nixos/lxc/container: switch to networkd by default
* [`cad95ac9`](https://github.com/NixOS/nixpkgs/commit/cad95ac98ed8fb4367c5ab53b71d7b42e2d041c9) qcad: 3.29.3.1 -> 3.29.4.1
* [`1b71ae2a`](https://github.com/NixOS/nixpkgs/commit/1b71ae2afadc70ee65a4698c2104bd3a09a70a1a) offpunk: 2.1 -> 2.2
* [`f4d5a7ba`](https://github.com/NixOS/nixpkgs/commit/f4d5a7ba63d715df76ea0fb64f2dec516ea0af66) tmux-sessionizer: 0.3.2 -> 0.4.0-unstable-2024-02-06
* [`3a4365d4`](https://github.com/NixOS/nixpkgs/commit/3a4365d4ad04dec155bf938ca83eb0383bc6c4ea) heroic: 2.12.1 -> 2.13.0
* [`7451b490`](https://github.com/NixOS/nixpkgs/commit/7451b4903a7e87cbb2bb43c11f0401abd400bd03) python312Packages.pure-pcapy3: fix executing tests
* [`9fb56a06`](https://github.com/NixOS/nixpkgs/commit/9fb56a068dfaa8e45643f0909bca16f03935bc4a) python311Packages.torchmetrics: 1.3.0.post -> 1.3.1
* [`a8782abe`](https://github.com/NixOS/nixpkgs/commit/a8782abe6b936c66e6ef8d5c74cb101738945c9a) scripthaus: init at 0.5.1
* [`eb2be110`](https://github.com/NixOS/nixpkgs/commit/eb2be1102c5fda9670f72f1a99bceba26ad6aabd) python312Packages.aws-sam-translator: don't fail when pytest/pluggy, skip slow tests
* [`ba79b098`](https://github.com/NixOS/nixpkgs/commit/ba79b098ea439ec133cbeda2286f065252942e29) doc: use long-form docker commands, improve wording
* [`7e7357cb`](https://github.com/NixOS/nixpkgs/commit/7e7357cb287d95a24da0d0ecbb0fb232b7da7722) dsda-launcher: init at 1.3.1-hotfix
* [`267e5c7b`](https://github.com/NixOS/nixpkgs/commit/267e5c7b854d687307c6c6ec65783c4b27ff51fd) mystmd: 1.1.38 -> 1.1.40
* [`e4316fb2`](https://github.com/NixOS/nixpkgs/commit/e4316fb2558dee5f95e484195932fc3edeb0e9c8) gimme-aws-creds: 2.7.2 -> 2.8.0
* [`0fb4434d`](https://github.com/NixOS/nixpkgs/commit/0fb4434d0e90d6466866864149895b73b751fc97) menulibre: init at 2.2.3
* [`2e43a58d`](https://github.com/NixOS/nixpkgs/commit/2e43a58d5281526a5fc0c162c37436a9d4a99c6a) wit-bindgen: 0.16.0 -> 0.17.0
* [`23d741d8`](https://github.com/NixOS/nixpkgs/commit/23d741d8021e115c2e0f2ad5ab1d19cf4942ed43) linuxKernel.packages.linux_4_19.xpadneo: 0.9.5 -> 0.9.6
* [`a855b93c`](https://github.com/NixOS/nixpkgs/commit/a855b93c0c9955bf7ead57ab9356fa52848b591d) python311Packages.ocrmypdf: 16.0.4 -> 16.1.0
* [`927681e5`](https://github.com/NixOS/nixpkgs/commit/927681e58bc326175b9384ecc45a65bbb493610b) rwpspread: 0.1.8 -> 0.1.9
* [`2147bf75`](https://github.com/NixOS/nixpkgs/commit/2147bf756de23dc31f685f42733c5ad3769eb2e5) python311Packages.jc: 1.25.0 -> 1.25.1
* [`48153fcc`](https://github.com/NixOS/nixpkgs/commit/48153fccf589de646a447961fa8ab7328f7ca568) python312Packages.hahomematic: 2024.2.2 -> 2024.2.3
* [`bd98ec41`](https://github.com/NixOS/nixpkgs/commit/bd98ec419b61f5e25bb9888ebd869a4270e1cabb) rqlite: 8.19.0 -> 8.20.0
* [`f9d42f4f`](https://github.com/NixOS/nixpkgs/commit/f9d42f4f9604ba8d415fd7e47357d83fe0c5e5cf) ttyplot: move pkg-config to nativeBuildInputs
* [`b189a840`](https://github.com/NixOS/nixpkgs/commit/b189a840144f489b3a2521a943930b55fa8e604e) libui-ng: unstable-2023-12-19 -> unstable-2024-02-05
* [`e562fdc8`](https://github.com/NixOS/nixpkgs/commit/e562fdc82bc7ff24ca855224272cca5f859914ce) python311Packages.sphinx-book-theme: 1.1.0 -> 1.1.1
* [`1c5be10c`](https://github.com/NixOS/nixpkgs/commit/1c5be10c9c3bf3dcec58c4992a17a093f02c6732) terraform-ls: 0.32.6 -> 0.32.7
* [`bd8fcaea`](https://github.com/NixOS/nixpkgs/commit/bd8fcaea40d7ba5ed5ed4d3996781436a14269a2) ttyplot: add meta.platforms
* [`0976b724`](https://github.com/NixOS/nixpkgs/commit/0976b724de72a96ede48b6226cdaa67447a7508e) tmux: 3.3a -> 3.4
* [`e9c49cb5`](https://github.com/NixOS/nixpkgs/commit/e9c49cb5e1f2d5787ce27ef215c42165a7116aa2) libui-ng: add passthru.updateScript
* [`a1171e4d`](https://github.com/NixOS/nixpkgs/commit/a1171e4da0c2facaa15aec803e21abc259324693) xiu: init at 0.10.0
* [`c9c7d2c7`](https://github.com/NixOS/nixpkgs/commit/c9c7d2c7bb72ec35d9eb1cc32b2f248ee3dae6a2) reaper: 7.09 -> 7.11
* [`13dc069c`](https://github.com/NixOS/nixpkgs/commit/13dc069c6fdb891a91a6db09ba005b0937b5e8d6) checkpolicy: 3.5 -> 3.6
* [`c1984a92`](https://github.com/NixOS/nixpkgs/commit/c1984a920f1e34dad268451d18efb0a20b01b592) rcp: 0.5.0 -> 0.6.0
* [`8601deae`](https://github.com/NixOS/nixpkgs/commit/8601deaed1bfe5893016310fe7c25885d8f55106) cryptoverif: 2.07 → 2.08pl1
* [`46bb032a`](https://github.com/NixOS/nixpkgs/commit/46bb032a7ea1579af914ad9ecf68056a30f58909) python311Packages.niaarm: 0.3.6 -> 0.3.7
* [`b4aa3fab`](https://github.com/NixOS/nixpkgs/commit/b4aa3fab876491888ea335dc9c342d6cfbd0b995) maintainers: add DimitarNestorov
* [`46bdb36e`](https://github.com/NixOS/nixpkgs/commit/46bdb36ebba2a5d224c22c4e786df3f3fc25946d) yarn-berry: add DimitarNestorov to maintainers
* [`3492680c`](https://github.com/NixOS/nixpkgs/commit/3492680c7307336670aa778f4ff796459d4f24a6) yarn-berry: add update script
* [`cf6c61af`](https://github.com/NixOS/nixpkgs/commit/cf6c61af30adabc2a5a4ed1e6f18649e8aad9798) yarn-berry: 4.0.1 -> 4.1.0
* [`5d6f8f2f`](https://github.com/NixOS/nixpkgs/commit/5d6f8f2fc0f4c5601fa14b3c8a3a51fd6ff59a0b) starsector: 0.97a-RC8 -> 0.97a-RC9
* [`51aeaf7a`](https://github.com/NixOS/nixpkgs/commit/51aeaf7a61d7ae1b7b582c25ef35778ce223a2ad) ruby: replace rec {} with finalAttrs & make overriding possible
* [`cfcfbac7`](https://github.com/NixOS/nixpkgs/commit/cfcfbac7139dd4c0b988c3537a56b9b70bfc971a) python311Packages.qcodes: fix repo owner
* [`a54c8e2a`](https://github.com/NixOS/nixpkgs/commit/a54c8e2a04e91cea67d908977372c31aca80020a) python311Packages.qcodes: fix wheel version
* [`09ce60f8`](https://github.com/NixOS/nixpkgs/commit/09ce60f8a175dc7dd679d3b4718b291527cfc296) abseil-cpp-202206: 20220623.1 -> 20220623.2
* [`6a11b7a7`](https://github.com/NixOS/nixpkgs/commit/6a11b7a77777eeea5f6f7ce062cba5d458a92875) nixos/kubernetes: don't delete the apitoken after its created
* [`247ec3ea`](https://github.com/NixOS/nixpkgs/commit/247ec3ea92b9b93207d4f20ec65b2e7fc859a6b4) renode-unstable: 1.14.0+20240130git6e173a1bb -> 1.14.0+20240212git8eb88bb9c
* [`b63babd5`](https://github.com/NixOS/nixpkgs/commit/b63babd55d60a05dc191339e0f9e6feaa0785bc1) stp: fix build failure
* [`1d45b144`](https://github.com/NixOS/nixpkgs/commit/1d45b144611a65f25ae40b101badcd19061cadf0) alacritty: only depend on xdg-utils on Linux
* [`6fca7fea`](https://github.com/NixOS/nixpkgs/commit/6fca7fea2a36622390be171b684ac0bb7e5c6918) openvpn: 2.6.8 -> 2.6.9
* [`ba9a2517`](https://github.com/NixOS/nixpkgs/commit/ba9a2517fe4a9773a5a8d6e529cf31e0b476296d) bgpq4: 1.11 -> 1.12
* [`c60a7077`](https://github.com/NixOS/nixpkgs/commit/c60a707729e5766a85401e90ba5aec0b0f11603d) avrdudess: 2.16 -> 2.17
* [`bb3a527b`](https://github.com/NixOS/nixpkgs/commit/bb3a527b1be49e28307f2e7c2ee754d2542b23b8) _0xproto: 1.601 -> 1.602
* [`80680623`](https://github.com/NixOS/nixpkgs/commit/8068062320b51a91f5638c3d04312d3fb039bd2a) cargo-rdme: 1.4.2 -> 1.4.3
* [`72398088`](https://github.com/NixOS/nixpkgs/commit/72398088cfc04b069b45b7b172354c3dfed122cf) grpc_cli: 1.61.0 -> 1.61.1
* [`fb560346`](https://github.com/NixOS/nixpkgs/commit/fb5603461839dfbc1ae62e723e450b0c13417c77) xcbeautify: init at 1.4.0
* [`100c2c38`](https://github.com/NixOS/nixpkgs/commit/100c2c38a981aac431becbfec745218563acee5b) maintainers: add siddarthkay
* [`3bbdc26d`](https://github.com/NixOS/nixpkgs/commit/3bbdc26df2dc6eaeac472e675f3e647150bed06d) timeloop: unstable-2022-11-29 -> 3.0.3
* [`829297ba`](https://github.com/NixOS/nixpkgs/commit/829297baf5cb4270054c656694227a5c35d0b8e4) python311Packages.iminuit: 2.25.1 -> 2.25.2
* [`faa4329e`](https://github.com/NixOS/nixpkgs/commit/faa4329e6f84a3d6f702672ea4c25f3e0aa85314) satty: 0.8.3 -> 0.9.0
* [`9d01a9c8`](https://github.com/NixOS/nixpkgs/commit/9d01a9c802bdaf2fbc4aab8a859a264e49657c90) sqlboiler: 4.16.1 -> 4.16.2
* [`cb9e5222`](https://github.com/NixOS/nixpkgs/commit/cb9e52222d4fa03f1dc8afa1fb130bb12af0146e) tidal-hifi: 5.8.0 -> 5.9.0
* [`be412393`](https://github.com/NixOS/nixpkgs/commit/be4123939403982c4caffd3d3ba5451f74884547) glauth: drop obsolete `excludedPackages`
* [`ad9a891a`](https://github.com/NixOS/nixpkgs/commit/ad9a891acb3a8f83df59e1b963bc4e5dba4a8a9d) gnome.gnome-control-center: 45.2 → 45.3
* [`a68ed7d3`](https://github.com/NixOS/nixpkgs/commit/a68ed7d3ded8d0b95c2e23c74925362fc94c8d02) gnome.gnome-music: 45.0 → 45.1
* [`8027502e`](https://github.com/NixOS/nixpkgs/commit/8027502e1791d9c003807043f7842778eef5628b) gnome.gnome-shell: 45.3 → 45.4
* [`f0487f42`](https://github.com/NixOS/nixpkgs/commit/f0487f42e6b1d907a7ab67f16d11cdf91d687159) gnome.gnome-tweaks: 45.0 → 45.1
* [`f12ba361`](https://github.com/NixOS/nixpkgs/commit/f12ba3617cf276aef51dded9697e1d4b01a55849) gnome.mutter: 45.3 → 45.4
* [`5d07ac63`](https://github.com/NixOS/nixpkgs/commit/5d07ac63fb08195a1fbca9df83985bd52043f8a1) gnome.gnome-initial-setup: 45.0 → 45.4.1
* [`9a492fda`](https://github.com/NixOS/nixpkgs/commit/9a492fda467eca96ec72ee62bb37ab491304f248) libdex: Fix updateScript
* [`6b759628`](https://github.com/NixOS/nixpkgs/commit/6b759628f4cfc984dddbceecb66024dc3aa79290) rPackages.archive: added dependency
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
