### PR TITLE
niv devenv: update 91a572c9 -> bc4602a4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "91a572c9866b92294aec152b65fa06c4dad7816f",
-        "sha256": "1jjxl807vjissbrhxpvz9vy88f24d2jr6glwvagzn47ghxm1x6h5",
+        "rev": "bc4602a41c197edd5838c8a97da2ed0c1fc75d0e",
+        "sha256": "0fcs7mlwzp6rc2bm2lm5mlmmkp93n8vjiaissva109pb18y50a3j",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/91a572c9866b92294aec152b65fa06c4dad7816f.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/bc4602a41c197edd5838c8a97da2ed0c1fc75d0e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@91a572c9...bc4602a4](https://github.com/cachix/devenv/compare/91a572c9866b92294aec152b65fa06c4dad7816f...bc4602a41c197edd5838c8a97da2ed0c1fc75d0e)

* [`cfb0dfe8`](https://github.com/cachix/devenv/commit/cfb0dfe846b088ed87ba8c352930d27af6a8f164) add dynamodb-local service
* [`5bf61719`](https://github.com/cachix/devenv/commit/5bf61719e5b221f25ca1663490000e7ed58fdd24) Correct typo in option useDefaultsExtraFile
* [`5a30b9e5`](https://github.com/cachix/devenv/commit/5a30b9e5ac7c6167e61b1f4193d5130bb9f8defa) Auto generate docs/reference/options.md
* [`40b56738`](https://github.com/cachix/devenv/commit/40b567388381137a3c49acdff5f4b6946d645a5f) Auto generate docs/reference/options.md
* [`bc4602a4`](https://github.com/cachix/devenv/commit/bc4602a41c197edd5838c8a97da2ed0c1fc75d0e) elm: include elm-test
