### PR TITLE
niv home-manager: update 21b07830 -> a54e05bc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21b078306a2ab68748abf72650db313d646cf2ca",
-        "sha256": "0dv0xq65nbpdkgnpawdx9jsasz1w52n0f55z6iz9qpmm8gfqkkv5",
+        "rev": "a54e05bc12d88ff2df941d0dc1183cb5235fa438",
+        "sha256": "1rnksvzsplsy22cifngwnpdda074nkm5555217i1wfgqwscp36qd",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/21b078306a2ab68748abf72650db313d646cf2ca.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a54e05bc12d88ff2df941d0dc1183cb5235fa438.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@21b07830...a54e05bc](https://github.com/nix-community/home-manager/compare/21b078306a2ab68748abf72650db313d646cf2ca...a54e05bc12d88ff2df941d0dc1183cb5235fa438)

* [`157bf712`](https://github.com/nix-community/home-manager/commit/157bf71277c92dfc4691e5e1eb88db94043e3865) mpv: create doc output in tests
* [`354643e6`](https://github.com/nix-community/home-manager/commit/354643e6c1ce0762d498e5e676e7970922c89208) neomutt: fix tests
* [`7889bfb4`](https://github.com/nix-community/home-manager/commit/7889bfb4752b27c83c8ae9ca45f63b77fff7ef7b) home-manager: overrideable URLs in generated flake
* [`043ba285`](https://github.com/nix-community/home-manager/commit/043ba285c6dc20f36441d48525402bcb9743c498) tests: add basic integration tests
* [`07fd4117`](https://github.com/nix-community/home-manager/commit/07fd41171ff8f263a9e4a95e17a3db1ff8a000c9) home-manager: fix incorrect log message
* [`3d6791b3`](https://github.com/nix-community/home-manager/commit/3d6791b3897b526c82920a2ab5f61d71985b3cf8) home-manager: add Nix sanity check
* [`bb69e1d4`](https://github.com/nix-community/home-manager/commit/bb69e1d43ea052aa69d884ae751cb9d1999bd8b8) Update translation files
* [`f41f54fb`](https://github.com/nix-community/home-manager/commit/f41f54fb224fd47bd19f0786ebed282f241dc71f) Translate using Weblate (Czech)
* [`5aec43bc`](https://github.com/nix-community/home-manager/commit/5aec43bc0f647eba521c2fb82135f7c10e2ea500) Translate using Weblate (Turkish)
* [`7671ec19`](https://github.com/nix-community/home-manager/commit/7671ec1931daee86161c8da1115515447667545e) Translate using Weblate (Swedish)
* [`309465d2`](https://github.com/nix-community/home-manager/commit/309465d20993095a1c6ee2d7eda6ef3588f165ff) Translate using Weblate (Ukrainian)
* [`11edf9ca`](https://github.com/nix-community/home-manager/commit/11edf9cad78cce49d09436c8d725ae36b65671dc) flake.lock: Update
* [`738527f8`](https://github.com/nix-community/home-manager/commit/738527f866e7848fa9fcef174ee78ec262fd00e5) darwin: fonts: speed up font installation
* [`a54e05bc`](https://github.com/nix-community/home-manager/commit/a54e05bc12d88ff2df941d0dc1183cb5235fa438) tealdeer: module improvements
