### PR TITLE
niv powerlevel10k: update 8e2a22d8 -> b973805f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "8e2a22d80ba9f5fd6c784f66dc52c21385eb2642",
-        "sha256": "18qvp4y7d8vmz3aqh6a48534v80pd0fvkd48ghz7xa7zc5q2pvrp",
+        "rev": "b973805f019cb9a4ecb1ccdf8879d89eb2b1b111",
+        "sha256": "1jbc7dfaykixy91xcyxczhslbwgpb6ijby3xwg13ch4zjpmagci2",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/8e2a22d80ba9f5fd6c784f66dc52c21385eb2642.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/b973805f019cb9a4ecb1ccdf8879d89eb2b1b111.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@8e2a22d8...b973805f](https://github.com/romkatv/powerlevel10k/compare/8e2a22d80ba9f5fd6c784f66dc52c21385eb2642...b973805f019cb9a4ecb1ccdf8879d89eb2b1b111)

* [`17cd9e35`](https://github.com/romkatv/powerlevel10k/commit/17cd9e354a283edeb657d340e1bbc0a30de5f967) when looking for .fvm/flutter_sdk, require that the last segment is a symlink rather than .fvm ([romkatv/powerlevel10k⁠#2573](https://togithub.com/romkatv/powerlevel10k/issues/2573))
* [`9e3418d3`](https://github.com/romkatv/powerlevel10k/commit/9e3418d319b1700c768b5c3c94c73ec70351ab09) Detect rpi os based on apt source
* [`12e0592a`](https://github.com/romkatv/powerlevel10k/commit/12e0592ac8f1d017b2dc7183b7720d98d8e41ed4) Still keep debian
* [`bfbc65e6`](https://github.com/romkatv/powerlevel10k/commit/bfbc65e63d071220dfbdb708bbde859ac7c64184) whitespace
* [`31d99b69`](https://github.com/romkatv/powerlevel10k/commit/31d99b694c97107a3db5ee4a8c33ab1308bff107) Fix in wizard.zsh
* [`bb16e366`](https://github.com/romkatv/powerlevel10k/commit/bb16e366c3f7d68f73fa9129f3593524ff6420ac) Undelete ubuntu. I shouldn't code this tired.
* [`b973805f`](https://github.com/romkatv/powerlevel10k/commit/b973805f019cb9a4ecb1ccdf8879d89eb2b1b111) cleanup and bump version ([romkatv/powerlevel10k⁠#2576](https://togithub.com/romkatv/powerlevel10k/issues/2576))
