### PR TITLE
niv nixpkgs: update a3320403 -> cff84a20

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a332040396d7e3c47883e9c115c1da485712805e",
-        "sha256": "063ncnfap6dvs341jap5mp6j87j4m236cgrgmg7zm822ss1h2nis",
+        "rev": "cff84a2086451a31a552a672da95f132bd7c10af",
+        "sha256": "02dlvx2c8gwnzl6h5bha8zg5p1v0jqaiq5vd0lgy4darfcxxsnka",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a332040396d7e3c47883e9c115c1da485712805e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/cff84a2086451a31a552a672da95f132bd7c10af.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a3320403...cff84a20](https://github.com/nixos/nixpkgs/compare/a332040396d7e3c47883e9c115c1da485712805e...cff84a2086451a31a552a672da95f132bd7c10af)

* [`c47f2452`](https://github.com/NixOS/nixpkgs/commit/c47f2452530b9cdb58de578f1c44c37e8aa616f0) patch-shebangs: fix crash with shebang without trailing newline
* [`2bbbf414`](https://github.com/NixOS/nixpkgs/commit/2bbbf414fed6ab89cd971f5645da692dad6d9420) veracrypt: 1.25.9 -> 1.26.7
* [`122fd1d7`](https://github.com/NixOS/nixpkgs/commit/122fd1d71e6aeb6f7eba509556f8ad3898e67663) gocover-cobertura: init at 1.2.0
* [`ef8a8c13`](https://github.com/NixOS/nixpkgs/commit/ef8a8c13560c462f1ef30d969af488f149a4f353) python3Packages.dazl: init at 7.11.0
* [`cd8418e3`](https://github.com/NixOS/nixpkgs/commit/cd8418e3fde94d3c59a52fcdd83866d69b4f4d29) harfbuzz: 7.3.0 -> 8.3.0
* [`1b603789`](https://github.com/NixOS/nixpkgs/commit/1b60378913119c9a69a2fb927d482de31cd37777) raysession: 0.14.2 -> 0.14.3
* [`1cc54797`](https://github.com/NixOS/nixpkgs/commit/1cc547974e925ab61042c7caeb5e2b5a38224704) clipper2: 1.2.2 -> 1.3.0
* [`bd1c869e`](https://github.com/NixOS/nixpkgs/commit/bd1c869e2864a02c5dfde040b48e061611033a71) python311Packages.frozenlist: 1.4.0 -> 1.4.1
* [`db64f7f7`](https://github.com/NixOS/nixpkgs/commit/db64f7f7379858bfa3172a4fce108ef8a25df96d) lorri.service: remove ProtectHome, relax ProtectSystem
* [`9823f423`](https://github.com/NixOS/nixpkgs/commit/9823f42308711b53cbd1bc26fb6ebb0e19ce1ccb) temurin-bin: set sourceProvenance
* [`aa20d928`](https://github.com/NixOS/nixpkgs/commit/aa20d9281855a5adb57d481818bfab37cf872326) xterm: 388 -> 389
* [`7ec8335a`](https://github.com/NixOS/nixpkgs/commit/7ec8335a846d51cfdce7872b19c1037584f93f6d) python3Packages.orjson: specify the interpreter version to maturin
* [`9572f3b4`](https://github.com/NixOS/nixpkgs/commit/9572f3b4547da5b23a7ee51cf071d0ef8fa1fe43) python311Packages.pyflakes: 3.1.0 -> 3.2.0
* [`fa797ad1`](https://github.com/NixOS/nixpkgs/commit/fa797ad1b9e25a615d3981660ed878c426bf3074) python311Packages.flake8: 6.1.0 -> 7.0.0
* [`646976af`](https://github.com/NixOS/nixpkgs/commit/646976af2992dd100528390afef502e3bc981b5b) python311Packages.pytest-asyncio: 0.21.1 -> 0.23.3
* [`17aad7ce`](https://github.com/NixOS/nixpkgs/commit/17aad7ce46a73dd52416c727a11bcbd2e62fd1ce) python311Packages.astroid: 3.0.1 -> 3.0.2
* [`9700deb9`](https://github.com/NixOS/nixpkgs/commit/9700deb9529aae00cbdc803f630fba223de59de4) python3Packages.cffi: fix missing fn on old macos
* [`3817ed58`](https://github.com/NixOS/nixpkgs/commit/3817ed589dc8b310aea99cd1f4da57f6e0b02e27) maintainers: add rostan-t
* [`43553e91`](https://github.com/NixOS/nixpkgs/commit/43553e9192632e700e566958aa7b670b12a9b008) gssdp: fix build with `strictDeps = true;`
* [`2d9773b7`](https://github.com/NixOS/nixpkgs/commit/2d9773b7207dba3307f3fc8dcf63017d9212a9df) freeimage: mark with knownVulnerabilties
* [`03eabb40`](https://github.com/NixOS/nixpkgs/commit/03eabb40f6f91120b981506102828d61a01a3847) python3Packages.psycopg2: fix tests a little
* [`fed795df`](https://github.com/NixOS/nixpkgs/commit/fed795df7613533617a6154950ca5a4e08673db1) python3Packages.psycopg2cffi: run tests
* [`a2d839cc`](https://github.com/NixOS/nixpkgs/commit/a2d839ccabe8f1c4a86631780be15eb21532316e) maintainers: add binarycat
* [`4d37b4ff`](https://github.com/NixOS/nixpkgs/commit/4d37b4ffbfd6a7dd2acf32a7cedc09c941f8ac7f) python311Packages.google-cloud-testutils: 1.3.3 -> 1.4.0
* [`03f6cbe4`](https://github.com/NixOS/nixpkgs/commit/03f6cbe4c0e6311588d30a03014ab8e73b7019db) python311Packages.markdown: 3.5.1 -> 3.5.2
* [`44c752a5`](https://github.com/NixOS/nixpkgs/commit/44c752a58a62dce270c44e355c8aec2991dbd39b) deepin: don't install packages using freeimage by default
* [`b833c891`](https://github.com/NixOS/nixpkgs/commit/b833c891a3ca2cf16ae2c5926b94f728e73b2776) deepin.dtkgui: avoid use freeimage
* [`d04bb2d7`](https://github.com/NixOS/nixpkgs/commit/d04bb2d74f720f1ba1d78850e0300327be05d49f) python3Packages.refery: init at 2.1.0
* [`0dd95e32`](https://github.com/NixOS/nixpkgs/commit/0dd95e320dad6bad22d9c5bc0d16746af344cf64) oath-toolkit: 2.6.10 -> 2.6.11
* [`34d44e4c`](https://github.com/NixOS/nixpkgs/commit/34d44e4c8fe4ea740645931ce118187c2f6d13f9) emacsclient-commands: init at unstable-2023-09-22
* [`0934aaf9`](https://github.com/NixOS/nixpkgs/commit/0934aaf96f8dfb55b964008c00a2d035b7886adc) python311Packages.rangeparser: init at 0.1.3
* [`a8f65a17`](https://github.com/NixOS/nixpkgs/commit/a8f65a171d83ff3f683bcd5ee99cb1e7c2228dae) killerbee: init at 3.0.0-beta.2
* [`49308533`](https://github.com/NixOS/nixpkgs/commit/493085334e15a318164bab33b524f9b2509a0716) hspell: 1.1 -> 1.4
* [`43e56a88`](https://github.com/NixOS/nixpkgs/commit/43e56a88df43a7e884730beda1cd969edf26762a) libpaper: 1.1.28 -> 1.1.29
* [`25181b59`](https://github.com/NixOS/nixpkgs/commit/25181b596fb23a8d2cda1dac2ebe2d5943c80cef) thinkfan: Disable network access
* [`cee68718`](https://github.com/NixOS/nixpkgs/commit/cee68718db905fb78144cba5bd07d4822881cbb3) hddfancontrol: Disable network access
* [`e6f0d725`](https://github.com/NixOS/nixpkgs/commit/e6f0d7250dc6adb6b8e267ae217973c469ff1e55) darwin.Libsystem: add missing Darwin.apinotes
* [`8ffff1e6`](https://github.com/NixOS/nixpkgs/commit/8ffff1e699078926c0b41f2c5435b056c1146a23) buildFHSEnv: don't export `multiPaths` attribute
* [`380f19d1`](https://github.com/NixOS/nixpkgs/commit/380f19d11c4e9d8f5314491243a0e8128bf9d841) inih: 57 -> 58
* [`7a2f64c4`](https://github.com/NixOS/nixpkgs/commit/7a2f64c49144bad5239c59e9c1ad6feb679c4a3a) maintainers: add xgwq
* [`d1c8a07d`](https://github.com/NixOS/nixpkgs/commit/d1c8a07d3ff80376ba2055d77734d9a39abd90d2) mattermost-desktop 5.5.0 -> 5.6.0
* [`e0367745`](https://github.com/NixOS/nixpkgs/commit/e036774553209d2d5d2c7e232fa19e5187da072b) cringify: 0.1.1 -> 0.2.0
* [`494e53c2`](https://github.com/NixOS/nixpkgs/commit/494e53c2578f80e25ac95774402beb4ca137e17b) tree-sitter: 0.20.8 -> 0.20.9
* [`a3784fb4`](https://github.com/NixOS/nixpkgs/commit/a3784fb49791f0b8c5d377454189c13cb891181c) picard: set path for localedir build option
* [`9c234ddc`](https://github.com/NixOS/nixpkgs/commit/9c234ddcef6d0e1a63e3bba8ee0e3e9397063de4) libsass: 3.6.5 -> 3.6.6
* [`84b5bcae`](https://github.com/NixOS/nixpkgs/commit/84b5bcae2667942984b5e8ee3ae9b14f48f7d0a6) dockerTools: Add chown test
* [`9b793246`](https://github.com/NixOS/nixpkgs/commit/9b793246384ccbade633f60ea45b4ea70adb0017) imath: 3.1.9 -> 3.1.10
* [`e0d3d074`](https://github.com/NixOS/nixpkgs/commit/e0d3d074ab4e97c0d59674bec7facdff702e5d42) python310Packages.pygobject: don't propagate cairo dev dependencies
* [`eab86044`](https://github.com/NixOS/nixpkgs/commit/eab8604428876bbf4f9fba55b9bf87f0019b59ca) folly: 2023.02.27.00 -> 2024.01.22.00
* [`e70589fe`](https://github.com/NixOS/nixpkgs/commit/e70589fe0fe153017498c0f722fd6b448ce00b2a) folly: add some key reverse-dependencies to passthru.tests
* [`8d77fbd9`](https://github.com/NixOS/nixpkgs/commit/8d77fbd9b628491866fcf94e3521d7e473644aaf) chromaprint: build with ffmpeg_6
* [`997f4a1c`](https://github.com/NixOS/nixpkgs/commit/997f4a1c8694fe90dd3549788644e7a77d9118b6) karabiner-elements: 14.11.0 -> 14.13.0
* [`e542761b`](https://github.com/NixOS/nixpkgs/commit/e542761b88b7fd2cc85a99490297a10725a159cf) fizz: 2023.03.20.00 -> 2024.01.22.00
* [`aece3659`](https://github.com/NixOS/nixpkgs/commit/aece36597375ffbb6dcc2922e47d7c6789489b60) wangle: 2023.04.03.00 -> 2024.01.22.00
* [`72c1f53a`](https://github.com/NixOS/nixpkgs/commit/72c1f53acdd4ce86e17fe5675987199d5b40fe74) edencommon: 2023.03.06.00 -> 2024.01.22.00
* [`15e45bb7`](https://github.com/NixOS/nixpkgs/commit/15e45bb78c76bdbdcd6f76099d87a718644b788f) mvfst: init at 2024.01.22.00
* [`b03ce928`](https://github.com/NixOS/nixpkgs/commit/b03ce9285675d7bd05c9683f03d5d779182a4d68) fbthrift: 2023.03.20.00 -> 2024.01.22.00
* [`8face73d`](https://github.com/NixOS/nixpkgs/commit/8face73d62c4e559843b324b9fb644291e755425) fb303: 2023.06.12.00 -> 2024.01.22.00
* [`9d4282de`](https://github.com/NixOS/nixpkgs/commit/9d4282de104172baf6e5235525d86ddb7fdcb542) watchman: 2023.08.14.00 -> 2024.01.22.00
* [`8a82e6fa`](https://github.com/NixOS/nixpkgs/commit/8a82e6fade76e79c4d4f1a6430603e6fb776f3c4) libunwind: 1.7.2 -> 1.8.0
* [`89efa718`](https://github.com/NixOS/nixpkgs/commit/89efa7184d7baae1ad4f5096bb815dc1c1938503) lzip: 1.23 -> 1.24
* [`bb51848e`](https://github.com/NixOS/nixpkgs/commit/bb51848e23465846f5823d1bacbed808a4469fcd) linux_rpi3: fix build failure due to wrong Kconfig
* [`ab9684d1`](https://github.com/NixOS/nixpkgs/commit/ab9684d1dfbed0a562e1fe387368d3bca77e3a54) orc: 0.4.34 -> 0.4.36
* [`36261797`](https://github.com/NixOS/nixpkgs/commit/36261797813ddbb1785a83eb00d6465655429d70) rtl8821ce: unstable-2023-05-04 -> unstable-2024-01-20
* [`1733c6d5`](https://github.com/NixOS/nixpkgs/commit/1733c6d51ab08775262c42c20dcc0b18a203377a) alsa-ucm-conf: 1.2.10 -> 1.2.11
* [`e3bd3f94`](https://github.com/NixOS/nixpkgs/commit/e3bd3f9474c5533754c0de794cc2ca85e9d7c326) virtualbox: add symlink to localization files
* [`1f07009d`](https://github.com/NixOS/nixpkgs/commit/1f07009ddb49d225bad3f9c5e92cea8dba5a5efc) gnucap: 20210107 -> 20240130-dev
* [`af0add86`](https://github.com/NixOS/nixpkgs/commit/af0add86d4e9e837b04b7e2ce515acecfde6da5b) gnucap-modelgen-verilog: init at 20240130-dev
* [`f488b8e1`](https://github.com/NixOS/nixpkgs/commit/f488b8e1aeb694013af9f01d907966fb6322aa40) re2: 2023-11-01 -> 2024-02-01
* [`cbddc00e`](https://github.com/NixOS/nixpkgs/commit/cbddc00e2179c5f97f904ee06199e514d757f7af) c-ares: 1.19.1 -> 1.26.0
* [`da415550`](https://github.com/NixOS/nixpkgs/commit/da415550f0424e94972bac762f38ec2445f8fdf2) openh264: migrate to by-name
* [`472b03cf`](https://github.com/NixOS/nixpkgs/commit/472b03cf562796c59922572c0da783da6a9d880c) openh264: refactor
* [`9e742477`](https://github.com/NixOS/nixpkgs/commit/9e74247757893a79d95ac4039d83d507f83cdb66) python311Packages.flufl-lock: rename from flufl_lock
* [`7934203c`](https://github.com/NixOS/nixpkgs/commit/7934203c379c59dc7807164a15cf5c4584c0785e) python311Packages.flufl-lock: refactor
* [`13b149cd`](https://github.com/NixOS/nixpkgs/commit/13b149cdaa1303406bfd04b758015ee6b3226e65) python311Packages.flufl-bounce: rename from flufl_bounce
* [`000963e7`](https://github.com/NixOS/nixpkgs/commit/000963e7e40119b544d070fe39d20ad310411095) python311Packages.flufl-bounce: refactor
* [`97e79119`](https://github.com/NixOS/nixpkgs/commit/97e79119f2b95c36f50617d7c46fb055513d2b8c) python311Packages.flufl-i18n: rename from flufl_i18n
* [`4eea3ae9`](https://github.com/NixOS/nixpkgs/commit/4eea3ae9b0f72df1e4e229efbe7a703855742ce0) python311Packages.flufl-i18n: refactor
* [`1f09eb4d`](https://github.com/NixOS/nixpkgs/commit/1f09eb4d9e8d52d56ce3a77e14143af3efc4bdbb) electron_*-bin: fix libGL
* [`5de19bf7`](https://github.com/NixOS/nixpkgs/commit/5de19bf7097c942d021a035de776331978736aa5) pkgs/stdenv/linux: update x86_64-unknown-linux-musl bootstrap-files
* [`d10d3fe5`](https://github.com/NixOS/nixpkgs/commit/d10d3fe5d6dcaae5099e190f4de1a49355889f19) storeBackup: 3.5 -> 3.5.2, apply patch for CVE-2020-7040
* [`1e59729b`](https://github.com/NixOS/nixpkgs/commit/1e59729b4aadfb8f3d613170f0728b05cd463de1) ocamlPackages.oseq: 0.5 -> 0.5.1
* [`a21e1f2e`](https://github.com/NixOS/nixpkgs/commit/a21e1f2e9b50603e595500127ea806b113de2058) cavalier: move to by-name
* [`803a0617`](https://github.com/NixOS/nixpkgs/commit/803a0617a732d46aca4485f45c71c1c735e8d255) cakelisp: 0.1.0 -> 0.3.0-unstable-2023-12-18
* [`2f1b2150`](https://github.com/NixOS/nixpkgs/commit/2f1b2150ef0722f2280c6a475e581d287677bf96) SDL2: 2.28.5 -> 2.30.0
* [`55aed69b`](https://github.com/NixOS/nixpkgs/commit/55aed69b395ec1810009f4014ab9bec9eef58e5a) openh264: use meson
* [`18d7b029`](https://github.com/NixOS/nixpkgs/commit/18d7b02911e72ad84bbabcf1534c66889920a2ff) openh264: 2.4.0 -> 2.4.1
* [`6cb1c2d5`](https://github.com/NixOS/nixpkgs/commit/6cb1c2d5ac78d9af80606cadf351681d17f6979f) Use same major version of electron which mattermost-desktop uses itself; find electron binary via lib.getExe
* [`315ff3f2`](https://github.com/NixOS/nixpkgs/commit/315ff3f274799d6839e5d08e3c7412b337777266) Reapply "python311Packages.markupsafe: 2.1.3 -> 2.1.5" ([nixos/nixpkgs⁠#286070](https://togithub.com/nixos/nixpkgs/issues/286070))
* [`e7022a81`](https://github.com/NixOS/nixpkgs/commit/e7022a810a837abdcc733bfb87df9a12c712dea0) python311Packages.anyio: 4.1.0 -> 4.2.0
* [`c6eea93a`](https://github.com/NixOS/nixpkgs/commit/c6eea93ac534740d14101deec2e3a07a3edc6434) harfbuzz: remove unused args
* [`937e75be`](https://github.com/NixOS/nixpkgs/commit/937e75bef5d2357aefbad48bb142ffbdd4dacdac) harfbuzz: add flag to correctly install CMake files
* [`86e42fa8`](https://github.com/NixOS/nixpkgs/commit/86e42fa8651c9777f8533d42b74cd38e9e27ca5a) python311Packages.django-bootstrap4: 23.4 -> 24.1
* [`84bfd413`](https://github.com/NixOS/nixpkgs/commit/84bfd4138614dcaff2bce2f235d788007cf45bbf) python311Packages.pikepdf: 8.11.2 -> 8.12.0.post1
* [`daa047a5`](https://github.com/NixOS/nixpkgs/commit/daa047a5b0fb09037afa2fdf58fd013e7cdd31a4) python311Packages.multidict: 6.0.4 -> 6.0.5
* [`ea371537`](https://github.com/NixOS/nixpkgs/commit/ea371537655a80d1db6b97e0a77d8bcd2367bdb8) modemmanager: fix cross-compile: add python3 to nativeBuildInputs
* [`e456032a`](https://github.com/NixOS/nixpkgs/commit/e456032addae76701eb17e6c03fc515fd78ad74f) nixos/flake: put nixpkgs in NIX_PATH and system registry for flake configs
* [`54d6f5d7`](https://github.com/NixOS/nixpkgs/commit/54d6f5d76fb439cf50416679b65a7a85401daeb2) ruby: make C++ compiler overridable as well
* [`f6deefc8`](https://github.com/NixOS/nixpkgs/commit/f6deefc8956f27c546cb63a3768a2edb6e009b53) elpa-packages: updated 2024-02-04 (from overlay)
* [`46952099`](https://github.com/NixOS/nixpkgs/commit/4695209921f5a0cdf63f9fcdbc957ec57104fe4d) elpa-devel-packages: updated 2024-02-04 (from overlay)
* [`c864c54e`](https://github.com/NixOS/nixpkgs/commit/c864c54e9f4624b61a7a6de1887d95959b183453) melpa-packages: updated 2024-02-04 (from overlay)
* [`a97d0f2e`](https://github.com/NixOS/nixpkgs/commit/a97d0f2efeec5d48b0acf3e349a4fd33cb9ce261) nongnu-packages: updated 2024-02-04 (from overlay)
* [`2b43efb8`](https://github.com/NixOS/nixpkgs/commit/2b43efb8ae720fff9528d4bbafa06a7758dfa53f) libxml2: 2.12.4 → 2.12.5
* [`34239032`](https://github.com/NixOS/nixpkgs/commit/34239032617857582a5d8f24bb5bb45c373d6e0b) gtk3: 3.24.39 → 3.24.41
* [`ac193f06`](https://github.com/NixOS/nixpkgs/commit/ac193f068461eab2bac2e4c52f5fe73e08cf406e) gtk4: 4.12.4 → 4.12.5
* [`ee5c07b9`](https://github.com/NixOS/nixpkgs/commit/ee5c07b9e9d2a52837b340c6aefa11aca529560e) xorg.xkbcomp: 1.4.6 -> 1.4.7
* [`a729edad`](https://github.com/NixOS/nixpkgs/commit/a729edade899c37b6431c3718a21cdabb85b4a85) imlib2: 1.12.1 -> 1.12.2
* [`336faa6f`](https://github.com/NixOS/nixpkgs/commit/336faa6fda8c9f668fd3f6ed3c6f71fdb74205e8) mupdf: fix includedir in pkg-config file
* [`8dc0408d`](https://github.com/NixOS/nixpkgs/commit/8dc0408d2360232d618a50ad4a11eeb8399f7e30) Reapply [nixos/nixpkgs⁠#281577](https://togithub.com/nixos/nixpkgs/issues/281577): mpdecimal: 2.5.1 -> 4.0.0
* [`7cfa2e6f`](https://github.com/NixOS/nixpkgs/commit/7cfa2e6f77ebaec191a047e9e4505be00bb74f58) krb5: add support for building with LDAP database
* [`cb4f11ae`](https://github.com/NixOS/nixpkgs/commit/cb4f11ae7ad34f09d92a2db7e800db85184482ad) vim: 9.1.0004 -> 9.1.0075
* [`ddd68693`](https://github.com/NixOS/nixpkgs/commit/ddd686934d74178886524cedd1e1574c6513ed51) xorg.libXvMC: 1.0.13 -> 1.0.14
* [`5714c930`](https://github.com/NixOS/nixpkgs/commit/5714c930f2180d34e6b2cb70fc62cb79ab89be45) xorg.libxkbfile: 1.1.2 -> 1.1.3
* [`82acb37b`](https://github.com/NixOS/nixpkgs/commit/82acb37bdaa2cee61ba1a6cf2b49d4c654234d05) xorg.libXext: 1.3.5 -> 1.3.6
* [`cb4c41f9`](https://github.com/NixOS/nixpkgs/commit/cb4c41f93a85d7092f9dd846052a73043820e7d8) stdenv: fix `substituteStream --replace-quiet` deprecation warning
* [`370cd05f`](https://github.com/NixOS/nixpkgs/commit/370cd05f246d87cd8ebd4137e47b13334850293b) xdg-utils: rm unused dependency
* [`67d1d801`](https://github.com/NixOS/nixpkgs/commit/67d1d801b048c7200942e99606eb844e46d17329) kcachegrind: fix graphviz missing at runtime
* [`4ade524f`](https://github.com/NixOS/nixpkgs/commit/4ade524f21c0667af9c4b2ba8f4f7000f3565baa) shot-scraper: 1.3 -> 1.4
* [`8f9aa286`](https://github.com/NixOS/nixpkgs/commit/8f9aa2861a774ec4232b29c4428ffd8d2e7df937) mill: 0.11.6 -> 0.11.7
* [`ca54cd62`](https://github.com/NixOS/nixpkgs/commit/ca54cd621ead68244fc6aa1c55fde8c0d512f1c4) jasper: 4.1.2 -> 4.2.0
* [`a911614d`](https://github.com/NixOS/nixpkgs/commit/a911614d00ae9a767fb5effae90eb960c290f7b4) pdal: 2.6.2 -> 2.6.3
* [`7f8e2707`](https://github.com/NixOS/nixpkgs/commit/7f8e27078d93c1629a6afa155635c4bca8cc992a) xorg.xkeyboardconfig: 2.40 -> 2.41
* [`cee02923`](https://github.com/NixOS/nixpkgs/commit/cee02923964c10394850bb14626f104d1acd170e) libei: 1.2.0 -> 1.2.1
* [`bb6e8320`](https://github.com/NixOS/nixpkgs/commit/bb6e8320e5fac91f1443f51944a47b30bc1a538f) ffmpeg: compile with harfbuzz
* [`b55f39a8`](https://github.com/NixOS/nixpkgs/commit/b55f39a8b1f72d84923595ea4d8f14977adc8761) xdg-utils: 1.2.0 -> 1.2.1
* [`5ab2285f`](https://github.com/NixOS/nixpkgs/commit/5ab2285f3bc6a1fd2c55cd0a4019f67f6f827a17) python312Packages.pip: avoid pbr dependency through sphinxcontrib-apidoc
* [`824a0de5`](https://github.com/NixOS/nixpkgs/commit/824a0de5ffcfb7270075c449ab96703a2e6cd683) python312Packages.gpgme: fix build
* [`3c471856`](https://github.com/NixOS/nixpkgs/commit/3c471856fea5a35d6684bcc3cc5ee06bbb3451d3) flacon: add monkeysAudio codec to bin path
* [`02f9e778`](https://github.com/NixOS/nixpkgs/commit/02f9e7786865e4a150e7080a7c4e1ddaea641c87) tor: disabled tests on aarch32
* [`2963dff5`](https://github.com/NixOS/nixpkgs/commit/2963dff5712eb57fe7361c9b36747cb3088e15a4) clipit: set meta.mainProgram
* [`bba25c1d`](https://github.com/NixOS/nixpkgs/commit/bba25c1d922e0cc6a66148c43ac2142ac37bd560) pfetch-rs: 2.8.1 -> 2.9.0
* [`ae3fcc37`](https://github.com/NixOS/nixpkgs/commit/ae3fcc3702888cc48049a7c30b2b824f27810fff) hwdata: 0.378 -> 0.379
* [`17eb38c5`](https://github.com/NixOS/nixpkgs/commit/17eb38c58d88cfcf442bc4ac7c64a0aa6c12782c) libgit2: 1.7.1 -> 1.7.2
* [`dbc26859`](https://github.com/NixOS/nixpkgs/commit/dbc26859b607628a5a7551c4998cf0001ef8933c) libwacom: 2.9.0 -> 2.10.0
* [`49b3d040`](https://github.com/NixOS/nixpkgs/commit/49b3d040c5405a23f81e18b2d12730a0d2ba5eb8) mdbook: 0.4.36 -> 0.4.37
* [`89cb7dd9`](https://github.com/NixOS/nixpkgs/commit/89cb7dd94fa6f7b94261e194c48bf14793c8d346) aws-sam-cli: 1.103.0 -> 1.108.0
* [`1e4bf30c`](https://github.com/NixOS/nixpkgs/commit/1e4bf30cb89e37358500f95f9cbfc959e73c1ccd) go_1_21: 1.21.6 -> 1.21.7
* [`8751812a`](https://github.com/NixOS/nixpkgs/commit/8751812a3bc87bd5240245ef5b1dc22a97eece4f) python311: 3.11.7 -> 3.11.8
* [`a77a1222`](https://github.com/NixOS/nixpkgs/commit/a77a12229b31f3826c02fd7111cbb4da4a086809) changedetection-io: 0.45.9 -> 0.45.13
* [`39ef0c28`](https://github.com/NixOS/nixpkgs/commit/39ef0c2883ec0216597609e5fff3e5c901a68602) ell: 0.61 -> 0.62
* [`45fd6068`](https://github.com/NixOS/nixpkgs/commit/45fd60685fdae3907d36dbfdb5224e978a886150) python312: 3.12.1 -> 3.12.2
* [`eaf159f1`](https://github.com/NixOS/nixpkgs/commit/eaf159f1469f1d53a4bdbe21d7ad4d454ccd5115) python311Packages.python-dateutil: avoid DeprecationWarning on Python 3.12
* [`625f00d7`](https://github.com/NixOS/nixpkgs/commit/625f00d75328a73d36c7f21bc15921115b991e68) postgresql_12: 12.17 -> 12.18
* [`aa9a97dc`](https://github.com/NixOS/nixpkgs/commit/aa9a97dc17758d9bea4bc0a2db80ac099e53fef1) postgresql_13: 13.13 -> 13.14
* [`60a659a0`](https://github.com/NixOS/nixpkgs/commit/60a659a0c3fdbc1e78108046d50b060b080a4bad) postgresql_14: 14.10 -> 14.11
* [`2ad23c3f`](https://github.com/NixOS/nixpkgs/commit/2ad23c3f31409d01fd4fcc8afdd8b21dcd32de15) postgresql_15: 15.5 -> 15.6
* [`cbb254b9`](https://github.com/NixOS/nixpkgs/commit/cbb254b9f0db9572d3294c46c8b641e57df6adba) postgresql_16: 16.1 -> 16.2
* [`7ebc294d`](https://github.com/NixOS/nixpkgs/commit/7ebc294d950fbc6454416ca47cfb570592f60944) ruby.rubygems: 3.5.5 -> 3.5.6
* [`2526c594`](https://github.com/NixOS/nixpkgs/commit/2526c59458774d19f3faf290ad70ce6f6f01d24d) Revert "postgresql: Fix build with libxml2 2.12"
* [`167b1b6c`](https://github.com/NixOS/nixpkgs/commit/167b1b6c74334981e8b57428f1bac62c5d25a5de) libuv: 1.47.0 -> 1.48.0
* [`9edbd729`](https://github.com/NixOS/nixpkgs/commit/9edbd729da648793ef0d434a5abf464166ba9d1d) bundler: 2.5.5 -> 2.5.6
* [`f7a1d3b2`](https://github.com/NixOS/nixpkgs/commit/f7a1d3b2f60ad0aaf596244f8f1a68518b0199a6) llhttp: 9.1.3 -> 9.2.0
* [`d56c63c3`](https://github.com/NixOS/nixpkgs/commit/d56c63c3263ccebe43504e8c53d420cde840224f) onnxruntime: fix aarch64-darwin
* [`aeb939f8`](https://github.com/NixOS/nixpkgs/commit/aeb939f81f6581663594a3ecad177550e760f7b3) cmake: 3.27.9 -> 3.28.1
* [`a43d9cd6`](https://github.com/NixOS/nixpkgs/commit/a43d9cd69a2d02561217b56415edc95a9366a09e) nixos/prometheus-fastly-exporter: fix runtime environment
* [`d679c697`](https://github.com/NixOS/nixpkgs/commit/d679c69737ffc14b8d00339fa52ec45ae5fce9cb) prometheus-fastly-exporter: refactor
* [`b630c171`](https://github.com/NixOS/nixpkgs/commit/b630c17147a70c2d2d837b77ab3fef2c9bf380b6) libavif: 1.0.3 -> 1.0.4
* [`05b064b5`](https://github.com/NixOS/nixpkgs/commit/05b064b5de0f0de5b129517860f95778c12589e7) qctools: init at 1.3.1
* [`f69a5abf`](https://github.com/NixOS/nixpkgs/commit/f69a5abfd1a2b59eb6cb35d3f20f3aab363a9834) x42-gmsynth: 0.4.1 -> 0.6.0
* [`204c33e6`](https://github.com/NixOS/nixpkgs/commit/204c33e6e1ce5869e033b22a93e0912e4a7c9766) linux-rt_6_6: init at 6.6.15-rt22
* [`635e64ed`](https://github.com/NixOS/nixpkgs/commit/635e64ed17800f86dea79fc253f3926f1d05f389) apparmor: 3.1.6 -> 3.1.7
* [`7dcc6adc`](https://github.com/NixOS/nixpkgs/commit/7dcc6adc5d5c441ee4f85fa909efea2575da4b88) libselinux: 3.3 -> 3.6
* [`2288a1b9`](https://github.com/NixOS/nixpkgs/commit/2288a1b9b444981248a6bcef19993fa37175a86a) libuv: disable a problematic test
* [`d12a6c07`](https://github.com/NixOS/nixpkgs/commit/d12a6c07bf8c0988d7c78509014c7ed34a8e4ccb) foomatic-db: unstable-2023-09-02 -> unstable-2024-02-09
* [`4b8bdbc8`](https://github.com/NixOS/nixpkgs/commit/4b8bdbc8bd474753cb3fa2e739b4fbad0c89ba06) pkgsMusl.ffado: fix build
* [`cf07cc7f`](https://github.com/NixOS/nixpkgs/commit/cf07cc7f7fa903eee3a761c37913534ac69c4907) numactl: 2.0.16 -> 2.0.17
* [`47dc12e6`](https://github.com/NixOS/nixpkgs/commit/47dc12e62f91f0280ad221306def45c913cd7677) signal-desktop (aarch64): 6.44.0 -> 6.46.0
* [`b6e054d8`](https://github.com/NixOS/nixpkgs/commit/b6e054d84e5d051b897e2d377819f4c6db5b22c5) metasploit: 6.3.53 -> 6.3.54
* [`34773db5`](https://github.com/NixOS/nixpkgs/commit/34773db54631988465245b35eeecfa03c271bebb) tor: removed obsolete statement from doCheck expression
* [`002f3ecb`](https://github.com/NixOS/nixpkgs/commit/002f3ecbba6c99dc2877274ea5866d44cf5faa72) opensoundmeter: init at 1.3
* [`4f7333b0`](https://github.com/NixOS/nixpkgs/commit/4f7333b0aefc71f368cdfd32266dabc4be3a8c0d) python311Packages.orjson: 3.9.10 -> 3.9.13
* [`69835dcc`](https://github.com/NixOS/nixpkgs/commit/69835dccf0b7a4bcd51f7bc97f8d8fe61999cd1c) python311Packages.lxml: 4.9.4 -> 5.1.0
* [`917b3803`](https://github.com/NixOS/nixpkgs/commit/917b38036175a8530b40b3762dd85c0fc82ee149) git: 2.43.0 -> 2.43.1
* [`a5f9ace1`](https://github.com/NixOS/nixpkgs/commit/a5f9ace1e1f6819d78d0ae09062c7c58cc67a6b0) upscayl: 2.9.8 -> 2.9.9
* [`35f45b6c`](https://github.com/NixOS/nixpkgs/commit/35f45b6cb9206efe8bd9a2772ba4ec0e1fb202dc) numactl: 2.0.17 -> 2.0.18
* [`c2b25131`](https://github.com/NixOS/nixpkgs/commit/c2b2513131d0a9422f6088353872f4ed89fc21ca) super-productivity: 7.17.2 -> 8.0.0
* [`c42fbc79`](https://github.com/NixOS/nixpkgs/commit/c42fbc799ff386d8304b656f8cc0156ef7cee810) nanosaur: unstable-2021-12-03 -> 1.4.4-unstable-2023-05-21
* [`a79f4e52`](https://github.com/NixOS/nixpkgs/commit/a79f4e520e36174a6616ad92b99771c14732d065) resholve: oildev: disable libc tests unconditionally
* [`5e84b19d`](https://github.com/NixOS/nixpkgs/commit/5e84b19d911434d206bee21259afc60ce3527b00) yara: make patch unconditional
* [`98f1a7e4`](https://github.com/NixOS/nixpkgs/commit/98f1a7e4fb58204e36dd228a903dd5682c2a2143) python3Packages.numpy: disable test_dispatcher on x86_64 darwin
* [`bc5330c3`](https://github.com/NixOS/nixpkgs/commit/bc5330c3243df55d6231799676c3a4ac16a2f072) expat: 2.5.0 -> 2.6.0
* [`0436c773`](https://github.com/NixOS/nixpkgs/commit/0436c773c0bd9f7c1190f141c9ba7f25863d7ff6) gst_all_1.gstreamer: 1.22.8 -> 1.22.9
* [`3739b93a`](https://github.com/NixOS/nixpkgs/commit/3739b93af4a1270d954e439d5916237138e87943) gst_all_1.gst-plugins-base: 1.22.8 -> 1.22.9
* [`b0d9fc36`](https://github.com/NixOS/nixpkgs/commit/b0d9fc36ac41405c1bcb6d2fc787aff4db68c8b0) gst_all_1.gst-plugins-good: 1.22.8 -> 1.22.9
* [`046390b6`](https://github.com/NixOS/nixpkgs/commit/046390b62d272f3a0d20918fcb26d24049de7cdb) gst_all_1.gst-plugins-bad: 1.22.8 -> 1.22.9
* [`02e015aa`](https://github.com/NixOS/nixpkgs/commit/02e015aa9a43bafec525249f6f3febd2bce8683c) gst_all_1.gst-plugins-ugly: 1.22.8 -> 1.22.9
* [`e6617f5a`](https://github.com/NixOS/nixpkgs/commit/e6617f5a43f524f4a824b6b9bf8767c097380e72) gst_all_1.gst-libav: 1.22.8 -> 1.22.9
* [`2851f2a0`](https://github.com/NixOS/nixpkgs/commit/2851f2a08723065354cb3523747c6461b7d8981c) gst_all_1.gst-vaapi: 1.22.8 -> 1.22.9
* [`4f48afd8`](https://github.com/NixOS/nixpkgs/commit/4f48afd8efdc916a1a6c668f4daf923c2ac2e688) gst_all_1.gst-rstp-server: 1.22.8 -> 1.22.9
* [`cbcbdf3d`](https://github.com/NixOS/nixpkgs/commit/cbcbdf3db0141593d76c5206247dd156a87f9bdf) gst_all_1.gst-devtools: 1.22.8 -> 1.22.9
* [`22c5f5db`](https://github.com/NixOS/nixpkgs/commit/22c5f5db41afbb3c225f62ee2fd5a0218f734092) gst_all_1.gst-editing-services: 1.22.8 -> 1.22.9
* [`68d6e600`](https://github.com/NixOS/nixpkgs/commit/68d6e6001246b4fdc1827b9560fc653858e1c56d) python3Packages.gst-python: 1.22.7 -> 1.22.8
* [`59e7a498`](https://github.com/NixOS/nixpkgs/commit/59e7a49890cb128224c80c7f1dc02929f69cc4ff) python3Packages.python-multipart: 0.0.6 -> 0.0.7
* [`36d99540`](https://github.com/NixOS/nixpkgs/commit/36d99540b60e8e55c92a888d24dc7c949e20dd0b) python3Packages.python-multipart: add key reverse-dependencies to passthru.tests
* [`e89c8e55`](https://github.com/NixOS/nixpkgs/commit/e89c8e55bb81026fd4bd15856bfdf90adc992362) python3Packages.python-multipart: 0.0.7 -> 0.0.9
* [`37d6961f`](https://github.com/NixOS/nixpkgs/commit/37d6961f33897b0c1cfc1872c115b6e3aeb9c5ca) nixos/nextcloud: add regression test for not delivering code anymore
* [`1ac1e38a`](https://github.com/NixOS/nixpkgs/commit/1ac1e38a17f6b8f69f0787bd7eff8c5b8b23315c) synergy: fix x86_64-darwin build
* [`300c85ea`](https://github.com/NixOS/nixpkgs/commit/300c85eac50e3dc8ee73fd36bb9813f311bbb66a) dolphin-emu:  5.0-20347 -> 5.0-21088
* [`998cb4a0`](https://github.com/NixOS/nixpkgs/commit/998cb4a08ec8eb875f2f05c696fedf6f6cbc26b3) flood-for-transmission: 2024-01-24T16-52-06 -> 2024-02-10T19-10-27
* [`42ed9074`](https://github.com/NixOS/nixpkgs/commit/42ed907474a11c4383349fb850e9463bc1830f16) python311Packages.quil: init at 0.6.5
* [`51124dd2`](https://github.com/NixOS/nixpkgs/commit/51124dd283ed93556461b31b69db20ad3b73d4c0) python311Packages.qcs-sdk-python: init at 0.16.3
* [`4f48bcb1`](https://github.com/NixOS/nixpkgs/commit/4f48bcb15bff2aeefbcf15d92845b3c258f1df0f) python311Packages.pyquil: 4.2.0 -> 4.6.1
* [`c9328750`](https://github.com/NixOS/nixpkgs/commit/c9328750fa7c1a343b11727cf0bcf3509043048c) jogl: refactor
* [`ff9ecc86`](https://github.com/NixOS/nixpkgs/commit/ff9ecc868d2fa5f12a21eed7739aa6f5ca2b0816) readline63: drop
* [`397f77da`](https://github.com/NixOS/nixpkgs/commit/397f77dae00cfa435571c7e5c5b59deb430e38ab) gtest: 1.12.1 -> 1.14.0
* [`8a516b83`](https://github.com/NixOS/nixpkgs/commit/8a516b832451cd9993074f7f627a0fbb1d857a68) ysfx: init at 0-unstable-2022-07-31
* [`355ab764`](https://github.com/NixOS/nixpkgs/commit/355ab764b4b32e476eaf056009998408375f9961) stdenv: refactor of --replace-{quiet,warn,fail} logic
* [`981bcab4`](https://github.com/NixOS/nixpkgs/commit/981bcab43c1d401d83edf22ec4107b0fd76d060d) Reapply "libbsd: unstable-2023-04-29 -> 0.11.8"
* [`06901f31`](https://github.com/NixOS/nixpkgs/commit/06901f313d06849f86c50711aeac13b2917ee102) rust-bindgen-unwrapped: 0.69.2 -> 0.69.4
* [`948cc5d3`](https://github.com/NixOS/nixpkgs/commit/948cc5d3df8f6a7721429b1ca30b3fda34d25888) python311Packages.coinmetrics-api-client: 2024.1.17.17 -> 2024.2.6.16
* [`20a0a4dc`](https://github.com/NixOS/nixpkgs/commit/20a0a4dc7aaf487ff04db1668636e568772469cb) updatecli: 0.70.0 -> 0.72.0
* [`2a631931`](https://github.com/NixOS/nixpkgs/commit/2a631931eb38fa80f8f6943bb99fc2e6a3797bd2) zlint: 3.6.0 -> 3.6.1
* [`cb48b925`](https://github.com/NixOS/nixpkgs/commit/cb48b925c37acb76797106b5996b128b7209aa28) enchant: 2.6.5 -> 2.6.7
* [`aab04e7d`](https://github.com/NixOS/nixpkgs/commit/aab04e7db31c7f2a7229c6cf93ab1c7779ec5780) esdm: 1.0.0 -> 1.0.2
* [`0b8c8f6e`](https://github.com/NixOS/nixpkgs/commit/0b8c8f6ec4679886733bdc4adf644bcbeee9dbb2) libsecret: 0.21.2 -> 0.21.3
* [`af70ce2c`](https://github.com/NixOS/nixpkgs/commit/af70ce2c476e9de57172e6c95617e43e0df62266) buildcatrust: 0.1.3 -> 0.2.1
* [`d3d5b72c`](https://github.com/NixOS/nixpkgs/commit/d3d5b72c655a43daed891038fc3084a39860368c) nixos/sabnzbd: add openFirewall
* [`c49e6bf8`](https://github.com/NixOS/nixpkgs/commit/c49e6bf8b8e27877ef31fda183fcc599e2e05756) nixos/sabnzbd: use stateDirectory and mkIf-ify user/group creation
* [`19159a23`](https://github.com/NixOS/nixpkgs/commit/19159a234916d7169e15d267e6ee1c9462790319) nixos/security/ca: enable support for compatibility bundles
* [`7efe3b73`](https://github.com/NixOS/nixpkgs/commit/7efe3b73d0c2eec62f00b4b90612dbaa5c3b99c9) python311Packages.pyroute2: 0.7.11 -> 0.7.12
* [`04833c6b`](https://github.com/NixOS/nixpkgs/commit/04833c6bd87b38c1df97db992421fbddbe602e57) python311Packages.google-auth: 2.21.0 -> 2.27.0
* [`b7c377eb`](https://github.com/NixOS/nixpkgs/commit/b7c377eb94f09fe60bd805be06dd6490d38f285e) python311Packages.google-auth-oauthlib: 1.1.0 -> 1.2.0
* [`94e53e40`](https://github.com/NixOS/nixpkgs/commit/94e53e40f4d9d402a86d3f75f5c9fc0577429dcd) xorg.xprop: 1.2.6 -> 1.2.7
* [`6208d979`](https://github.com/NixOS/nixpkgs/commit/6208d979b17aeff825b2cb6ce91ee465305d66ef) xorg.xmore: 1.0.3 -> 1.0.4
* [`868e3ab4`](https://github.com/NixOS/nixpkgs/commit/868e3ab497f30883638a4fc0576dd2f7b3c8a776) xorg.makedepend: 1.0.8 -> 1.0.9
* [`2591a802`](https://github.com/NixOS/nixpkgs/commit/2591a802d5d83e4c85b7d7924b5c4450b71e15c9) xorg.xkbutils: 1.0.5 -> 1.0.6
* [`a6566657`](https://github.com/NixOS/nixpkgs/commit/a6566657e32aedc3520d1d69abbeaa617f2a4273) xorg.bitmap: 1.1.0 -> 1.1.1
* [`d8d6198b`](https://github.com/NixOS/nixpkgs/commit/d8d6198b713949086245c3a03046b576d77b2752) xorg.libpciaccess: 0.17 -> 0.18
* [`052c71c4`](https://github.com/NixOS/nixpkgs/commit/052c71c4181685aef0290652c4bbc21372a6e512) notify: 1.0.5 -> 1.0.6
* [`d36509a2`](https://github.com/NixOS/nixpkgs/commit/d36509a264265ca2e3ba8d5bb47d7838339b9a68) cmctl: 1.14.1 -> 1.14.2
* [`69c531d2`](https://github.com/NixOS/nixpkgs/commit/69c531d2865ee87648b35f62a02a28d7fc6b7e87) luarocks: 3.9.1 -> 3.9.2
* [`45be83cb`](https://github.com/NixOS/nixpkgs/commit/45be83cb546bf7b1e4b7ed8931d2e4a185fafaa2) vaultwarden.webvault: 2024.1.2 -> 2024.1.2b
* [`f1751443`](https://github.com/NixOS/nixpkgs/commit/f175144335fedc0235004768f087edc639baee39) btop: 1.3.0 -> 1.3.1
* [`561668b9`](https://github.com/NixOS/nixpkgs/commit/561668b9feb5d3e55b7c9ce58da2e319b1933052) chezmoi: 2.46.0 -> 2.46.1
* [`676219fc`](https://github.com/NixOS/nixpkgs/commit/676219fcd2172b83a87bcd05ca54e55b1000cf17) python311Packages.mkdocs-git-revision-date-localized-plugin: 1.2.2 -> 1.2.4
* [`2f765c46`](https://github.com/NixOS/nixpkgs/commit/2f765c46213ecfee94597ec7cd341d977c9213a0) openexr_3: 3.2.1 -> 3.2.2
* [`1f422e5d`](https://github.com/NixOS/nixpkgs/commit/1f422e5dd7d828f36791ff9c3012ee1d8ae74a79) python311Packages.pook: 1.1.1 -> 1.3.0
* [`54b97cbf`](https://github.com/NixOS/nixpkgs/commit/54b97cbffa71990a376d3834942a995253da2638) minesweep-rs: 6.0.52 -> 6.0.54
* [`6ef8838d`](https://github.com/NixOS/nixpkgs/commit/6ef8838dcf19a14c6afcd436e610105309bfe715) CONTRIBUTING.md: Sandboxing is enabled by default on Linux
* [`2651ddc7`](https://github.com/NixOS/nixpkgs/commit/2651ddc7b0788932df9da7416ccd1618d76c11fe) python/catch_conflicts: scan $out, not sys.path
* [`83fa0fc3`](https://github.com/NixOS/nixpkgs/commit/83fa0fc30d554d5d50715e41647d2e4401190dea) stone-kingdoms: 0.5.0 -> 0.6.0
* [`000b7bfd`](https://github.com/NixOS/nixpkgs/commit/000b7bfd47e07dc6b4d925b385ea974315233582) buildLuarocksPackage: ability to self reference extraConfig ([nixos/nixpkgs⁠#288253](https://togithub.com/nixos/nixpkgs/issues/288253))
* [`d3cb26fc`](https://github.com/NixOS/nixpkgs/commit/d3cb26fc5f66c6c364cbdb7eb29c4f16dcd05f66) home-assistant-custom-components.gpio: 0.0.2 -> 0.0.4
* [`214c40b2`](https://github.com/NixOS/nixpkgs/commit/214c40b24060e46ec283ee1a5cd71aa9e75d1dd0) codeql: 2.16.1 -> 2.16.2
* [`850ba549`](https://github.com/NixOS/nixpkgs/commit/850ba5495616040373c863109c26ebe4318e3948) python312Packages.sphinx: drop sphinxcontrib-apidoc
* [`b9706373`](https://github.com/NixOS/nixpkgs/commit/b97063732dfa16a23c5ee47b924d020e3be31599) python311Packages.python-openstackclient: add sphinxcontrib-apidoc to fix doc build
* [`e1c94f69`](https://github.com/NixOS/nixpkgs/commit/e1c94f69a45cda2939f6398a180c20303d52e11c) Revert "python312Packages.pip: avoid pbr dependency through sphinxcontrib-apidoc"
* [`9db042bf`](https://github.com/NixOS/nixpkgs/commit/9db042bf9e22b485f7071ba8093a78a67f8b2889) python311Packages.eventlet: fix tests on kernel 6.6+
* [`0a6ce8ec`](https://github.com/NixOS/nixpkgs/commit/0a6ce8ececfbd7afbca7ad72be7f8d520b88ef01) colord: revert "1.4.6 -> 1.4.7"
* [`ee8d56b3`](https://github.com/NixOS/nixpkgs/commit/ee8d56b332109d444ba436327bf54f86131ab0f7) bee-unstable: remove
* [`9817e910`](https://github.com/NixOS/nixpkgs/commit/9817e910a9bb6172422dab048cb5a59e17949c91) bee: refactor
* [`ff1896f6`](https://github.com/NixOS/nixpkgs/commit/ff1896f6ff0ad6637b17a9d4c87d9ba6391def9c) bee: 0.5.0 -> 1.18.2
* [`11eef97f`](https://github.com/NixOS/nixpkgs/commit/11eef97f3c8b65fa6d395f6095b30f0a709d4e5a) bee-clef: remove
* [`ce0a47cd`](https://github.com/NixOS/nixpkgs/commit/ce0a47cd2ce845d82fc85bae68c73101c73e31fb) maintainers: remove attila-lendvai
* [`fe0daba9`](https://github.com/NixOS/nixpkgs/commit/fe0daba939eb526f068085d94a907674b58e16c7) python311Packages.uvicorn: 0.24.0.post1 -> 0.27.1
* [`0ec317b5`](https://github.com/NixOS/nixpkgs/commit/0ec317b5f614b234935da08a0f87d93d8d02c852) graphviz: 9.0.0 -> 10.0.1
* [`d88514cb`](https://github.com/NixOS/nixpkgs/commit/d88514cb2be5defba98354b0341884949a1e8af3) graphviz: add more reverse-dependencies to passthru.tests
* [`fceccfb1`](https://github.com/NixOS/nixpkgs/commit/fceccfb14b50e0a749f7f2b8687c2a9a05184a4c) arxiv-latex-cleaner: 1.0.3 -> 1.0.4
* [`ec82aeb8`](https://github.com/NixOS/nixpkgs/commit/ec82aeb85098eb28a4c90673519f78a67a16c5e4) bacula: 13.0.3 -> 13.0.4
* [`2f369a69`](https://github.com/NixOS/nixpkgs/commit/2f369a69a01088f9ade7de7966c923d35912dda7) python312Packages.stanio: 0.4.0 -> 0.5.0
* [`0cbd114d`](https://github.com/NixOS/nixpkgs/commit/0cbd114d41b619aa611ab158528f551b14b8cd9c) pythonCatchConflictsHook: improve and add tests
* [`ffa81595`](https://github.com/NixOS/nixpkgs/commit/ffa815958e61aa978c715eb6e279c290617a6615) pythonCatchConflictsHook: make compatible to all python 3 versions
* [`a299915f`](https://github.com/NixOS/nixpkgs/commit/a299915fff009a44db79e093db1a3f68e4fea5c7) pythonCatchConflictsHook: improve docs
* [`8fd1819d`](https://github.com/NixOS/nixpkgs/commit/8fd1819d93e152761fea5bd878c42d801455119d) grpc: 1.61.0 -> 1.61.1
* [`58a94a92`](https://github.com/NixOS/nixpkgs/commit/58a94a9273b908e45e9915b40a0a2c4b4cc60d07) python311Packages.tensorboard: 2.15.1 -> 2.16.0
* [`6954e9a2`](https://github.com/NixOS/nixpkgs/commit/6954e9a29d8ee13a5cfec908b9eecd017c592db4) python311Packages.tensorboard: add meta.mainProgram
* [`74c4e935`](https://github.com/NixOS/nixpkgs/commit/74c4e93541826e901effddc07c1b9aab381e0444) pkgs/stdenv/linux: update x86_64-unknown-linux-gnu bootstrap-files
* [`96ce36b2`](https://github.com/NixOS/nixpkgs/commit/96ce36b286bee3a2fcd8b8eb9f4582c435593e5c) lockfile-progs: fix cross
* [`b3fc0611`](https://github.com/NixOS/nixpkgs/commit/b3fc061195c6e56429c14c7b664f0c38bea02a1e) yandex-browser-stable: 23.9.1.962-1 -> 24.1.1.917-1
* [`9aa6eef0`](https://github.com/NixOS/nixpkgs/commit/9aa6eef08c5a8c22a0066243ee4f28b24f83dff4) python311Packages.sentry-sdk: 1.40.3 -> 1.40.4
* [`0b97c767`](https://github.com/NixOS/nixpkgs/commit/0b97c767947c0da5cbf9866986c028b67b45d427) python311Packages.slack-sdk: 3.26.2 -> 3.27.0
* [`64574ee0`](https://github.com/NixOS/nixpkgs/commit/64574ee02fbaf09a42797f47ef475f92a8d22281) zrok: 0.4.23 -> 0.4.24
* [`734caaba`](https://github.com/NixOS/nixpkgs/commit/734caabaf0cdc9a63af7b03f0af5270f55e1fa39) python311Packages.linear-garage-door: init at 0.2.9
* [`ca317d9d`](https://github.com/NixOS/nixpkgs/commit/ca317d9ddd0a9285e16dd55c99d37c9d074c376a) home-assistant: update component-packages
* [`75c5c2a2`](https://github.com/NixOS/nixpkgs/commit/75c5c2a2ef4bfa7bfc849f44384c266e177e8cc2) python311Packages.sqlalchemy: 2.0.25 -> 2.0.27
* [`9c5646c1`](https://github.com/NixOS/nixpkgs/commit/9c5646c100a9aa1892448f0235e7f19a34f789c2) python311Packages.google-auth-oauthlib: set passthru.optional-dependencies
* [`11a19109`](https://github.com/NixOS/nixpkgs/commit/11a19109b687ea8f263870effe0513f2225771b1) stdenv: disregard xz exit status in order to fix subtle decompression issues
* [`3750594c`](https://github.com/NixOS/nixpkgs/commit/3750594cced45b63619db9f2e3f775e4a8e49965) python311Packages.pytz: 2023.3.post1 -> 2024.1
* [`062ee05a`](https://github.com/NixOS/nixpkgs/commit/062ee05a5784dfb8be2e7c951f4f5e3ea575b158) unbound: 1.19.0 -> 1.19.1
* [`b51ec220`](https://github.com/NixOS/nixpkgs/commit/b51ec220df4d04213929afd3e48dea5c1e60b16d) pre-commit: 3.6.0 -> 3.6.1
* [`1b96455b`](https://github.com/NixOS/nixpkgs/commit/1b96455bea2a7a4580921b227c15a2d2e7bc108a) ffmpeg_6: cherry-pick patch to fix VLC segfault
* [`ca5d04d6`](https://github.com/NixOS/nixpkgs/commit/ca5d04d64e82f05a29d5fbada7f8794b6e8b4214) dnsmasq: 2.89 -> 2.90
* [`604d1e25`](https://github.com/NixOS/nixpkgs/commit/604d1e2530cfc0d163d7bab9e8e1e6cf4409760c) python311Packages.oauthlib: refactor
* [`6634b866`](https://github.com/NixOS/nixpkgs/commit/6634b86601bb9b2180643c6c59ca099e5bdcf34c) nixos: Drop unused variable in systemd/initrd.nix
* [`ff7922f6`](https://github.com/NixOS/nixpkgs/commit/ff7922f604f937d81440fe040d0cba87c7b2ecaa) asn: 0.75.2 -> 0.75.3
* [`07e70c6a`](https://github.com/NixOS/nixpkgs/commit/07e70c6aa27d6f351bb5affafbc2ec6df065e0e4) pyenv: 2.3.35 -> 2.3.36
* [`2117ce1d`](https://github.com/NixOS/nixpkgs/commit/2117ce1daf428aea86469badcdc6cc16e8da6a8d) ugs: 2.1.4 -> 2.1.5
* [`dcd2582f`](https://github.com/NixOS/nixpkgs/commit/dcd2582f085be3bcd504dc1798dde7c0ab455324) mandelbulber: 2.31 -> 2.31-1
* [`bd65081a`](https://github.com/NixOS/nixpkgs/commit/bd65081a88bb491adf59e4668f49269f94a7a53d) sickgear: 3.30.9 -> 3.30.10
* [`387baf5c`](https://github.com/NixOS/nixpkgs/commit/387baf5c056e307b3808f7945cf9d420ba5f0029) glooctl: 1.16.3 -> 1.16.4
* [`c11dc420`](https://github.com/NixOS/nixpkgs/commit/c11dc420d811c6fcd3478562731397479d299558) rke: 1.5.3 -> 1.5.5
* [`66a94493`](https://github.com/NixOS/nixpkgs/commit/66a94493993cc9670230d1dcab3816a9de77c51f) python311Packages.slackclient: 3.26.2 -> 3.27.0
* [`1bee8a0b`](https://github.com/NixOS/nixpkgs/commit/1bee8a0b0ab9a0b99b9e83eacac544eb939a07fc) cmake: 3.28.1 -> 3.28.2
* [`5a5f0a81`](https://github.com/NixOS/nixpkgs/commit/5a5f0a814cb67695ec1536e38b139092d5e5ce4c) errands: init at 45.1.9
* [`34a0ebd0`](https://github.com/NixOS/nixpkgs/commit/34a0ebd030a322f757826ee2380fb22cdeddd137) openbabel-unstable: 3.1.1 -> unstable-06-12-23
* [`53a18967`](https://github.com/NixOS/nixpkgs/commit/53a18967a6310fa2a535547a3ab62e42cedb9810) avogadrolibs: 1.98.1 -> 1.99.0
* [`06a5108a`](https://github.com/NixOS/nixpkgs/commit/06a5108a6c02977802cabaa3243714648d6ddbfa) avogadro2: 1.98.1 -> 1.99.0
* [`3d4ea13c`](https://github.com/NixOS/nixpkgs/commit/3d4ea13cbe1ba36dffa6568a2c6d4c669b5c2670) luarocks: add luarocks-admin completion
* [`c8a261e8`](https://github.com/NixOS/nixpkgs/commit/c8a261e87041b716584b0b31fe777cd89f5910e9) molsketch: fix openbabel interface
* [`4cd9b469`](https://github.com/NixOS/nixpkgs/commit/4cd9b469f5dba68e061aecf505fb6549e554f146) python311Packages.aiodiscover: 1.6.0 -> 1.6.1
* [`f5b315ae`](https://github.com/NixOS/nixpkgs/commit/f5b315ae54f5b7f13519ae4275a5426661d028ee) molsketch: fix executable library dependencies to libmolsketch.so
* [`4b9f2819`](https://github.com/NixOS/nixpkgs/commit/4b9f2819eb658ecc3938291700e48979c0ee21f0) kf5: 5.114 -> 5.115
* [`3a9a99b1`](https://github.com/NixOS/nixpkgs/commit/3a9a99b1a0d3631f1f262cc983739c4026b751f0) liquibase: 4.25.1 -> 4.26.0
* [`54a75681`](https://github.com/NixOS/nixpkgs/commit/54a75681098d44939073838e2004127ab68974a0) qt5: refresh patches
* [`fe362520`](https://github.com/NixOS/nixpkgs/commit/fe36252019a7b21c951825f7028d4ef7b46c99a8) lib.modules.doRename: Add doc comments
* [`1cd71881`](https://github.com/NixOS/nixpkgs/commit/1cd71881f26f6b52b921933a4f09ffdf68db0716) nixos/systemd: Support notify-reload service Type
* [`7cdc04d3`](https://github.com/NixOS/nixpkgs/commit/7cdc04d35e666cb21e48a0d94e0fdf755d146b9f) mopidy-muse: 0.0.27 -> 0.0.30
* [`41cce513`](https://github.com/NixOS/nixpkgs/commit/41cce513ff13c7076d45f514cb9fbd65ffac7a5c) unix-privesc-check: init at 1.4
* [`dc25d29e`](https://github.com/NixOS/nixpkgs/commit/dc25d29e5f29e8b9cc17cdb5aa54ab119a1e3731) mozillavpn: 2.19.0 → 2.20.0
* [`088b2e8a`](https://github.com/NixOS/nixpkgs/commit/088b2e8a7de45f3b99f7c2c62d4665abfd1f82f4) lunar-client: 3.2.1 -> 3.2.3
* [`f69930e9`](https://github.com/NixOS/nixpkgs/commit/f69930e9436157b1e5b0ca404c580a5d06ce9df6) gjs: 1.78.3 -> 1.78.4
* [`9a75180f`](https://github.com/NixOS/nixpkgs/commit/9a75180f4f82b1d5e7e5bfcc29642fda85e68d60) yubico-piv-tool: 2.5.0 -> 2.5.1
* [`8de207d3`](https://github.com/NixOS/nixpkgs/commit/8de207d35c4c9f3643dbb0f097d80d001e5f6efb) libfive: unstable-2022-06-07 -> unstable-2024-02-14
* [`fb9c8c8a`](https://github.com/NixOS/nixpkgs/commit/fb9c8c8ad1944d8d5ac51cbfcf6cba1588dd3645) boringssl: 2023-09-27 -> 2024-02-15
* [`56fd54d5`](https://github.com/NixOS/nixpkgs/commit/56fd54d5fc150ce3beb00b84b713ad44f4761037) krane: 3.4.2 -> 3.5.0
* [`bab16f22`](https://github.com/NixOS/nixpkgs/commit/bab16f22592de9f466dab58074de949d88cc1f3e) mangohud: 0.7.0 -> 0.7.1
* [`77f0e391`](https://github.com/NixOS/nixpkgs/commit/77f0e39145af886245bfcd8db4c142ee7141fe82) c2ffi: unstable-2021-06-15 -> 0-unstable-2023-11-18
* [`ea4b0783`](https://github.com/NixOS/nixpkgs/commit/ea4b0783e940d4267af31a2105cc552fd5d51d6d) rehex: 0.60.1 -> 0.61.0
* [`d251dd63`](https://github.com/NixOS/nixpkgs/commit/d251dd638df479c9f2609a853439419d7bad29b7) iwd: 2.13 -> 2.14
* [`c21ebf7e`](https://github.com/NixOS/nixpkgs/commit/c21ebf7ed51f17339e3a202d134f30fe1811670c) memorymapping: remove disable-warnings-if-gcc13
* [`d6d6c8e4`](https://github.com/NixOS/nixpkgs/commit/d6d6c8e4c63e6cfab9e602694e9ef8f5440a283e) python311Packages.aiohue: 4.7.0 -> 4.7.1
* [`505bdf9a`](https://github.com/NixOS/nixpkgs/commit/505bdf9a662448dd7b347aa31276ecfa7811dbc9) python312Packages.ptyprocess: refactor
* [`ff516bb1`](https://github.com/NixOS/nixpkgs/commit/ff516bb178e3c3ba73f1043003979466540e757e) floorp: use `branding` parameter of `buildMozillaMach`
* [`c4635f96`](https://github.com/NixOS/nixpkgs/commit/c4635f966375e0d1445226dd40c01354a3f99222) python311Packages.google-cloud-compute: 1.15.0 -> 1.16.1
* [`040b45f9`](https://github.com/NixOS/nixpkgs/commit/040b45f979902e33216612ac0c3bf27cc979a452) wyoming-openwakeword: 1.8.1 -> 1.9.0
* [`257553e4`](https://github.com/NixOS/nixpkgs/commit/257553e4ed2257cf5be385ef9db33c07880d6444) mesa: 23.3.5 -> 24.0.1
* [`9c2b998a`](https://github.com/NixOS/nixpkgs/commit/9c2b998ab0081090ef5635034dce078d7f0390c0) home-assistant-custom-lovelace-modules.multiple-entity-row: init at 4.5.0
* [`c97b3c42`](https://github.com/NixOS/nixpkgs/commit/c97b3c42320053e6e6910d57639a2a0c0d255665) aws-c-compression: 0.2.17 -> 0.2.18
* [`2bcfbc13`](https://github.com/NixOS/nixpkgs/commit/2bcfbc136d3640b65d3feb7b84660d003a8dfdb6) python311Packages.openai: 1.11.0 -> 1.12.0
* [`60ecefd7`](https://github.com/NixOS/nixpkgs/commit/60ecefd7daf84d38231a600bcc48f4878817806c) python311Packages.click-default-group: 1.2.2 -> 1.2.4
* [`0475c565`](https://github.com/NixOS/nixpkgs/commit/0475c56500b83417a7bd4a5b5ade320ac81833eb) python311Packages.llm: 0.11.0 -> 0.13.1
* [`4939a683`](https://github.com/NixOS/nixpkgs/commit/4939a683ceeb35fcb8aa729eb17aabd5ae28effa) python311Packages.fastapi-sso: init at 0.11.0
* [`68aa8a1e`](https://github.com/NixOS/nixpkgs/commit/68aa8a1e11b36f71928506903a1113066d929abb) python311Packages.prisma: init at 0.12.0
* [`165a3b53`](https://github.com/NixOS/nixpkgs/commit/165a3b532331ed4f6b1b6d199f30164b8f3e8344) python311Packages.resend: init at 0.7.2
* [`77718891`](https://github.com/NixOS/nixpkgs/commit/777188914f6dee812dffefc33a44b38f0aef2a94) python311Packages.litellm: 1.23.0 -> 1.23.9
* [`e9e0a205`](https://github.com/NixOS/nixpkgs/commit/e9e0a20585c947e32db31ae77540e61b802c8208) python311Packages.langsmith: 0.0.83 -> 0.0.90
* [`4e799ea5`](https://github.com/NixOS/nixpkgs/commit/4e799ea564be48634879d536178033920ac80043) python311Packages.langchain-core: 0.1.16 -> 0.1.22
* [`3fbfedb4`](https://github.com/NixOS/nixpkgs/commit/3fbfedb4041fa4ed223ac58c3ef2746f39c89496) python311Packages.langchain-community: 0.0.16 -> 0.0.19
* [`d1b43382`](https://github.com/NixOS/nixpkgs/commit/d1b43382aa31be7d9000b020c35618975e3b890a) python311Packages.langchain: 0.1.1 -> 0.1.6
* [`5f905039`](https://github.com/NixOS/nixpkgs/commit/5f905039901731e856e0024b78019f90bf85f8e6) aws-checksums: 0.1.17 -> 0.1.18
* [`272a42e9`](https://github.com/NixOS/nixpkgs/commit/272a42e945f98c89db7a6d344885a6a60ae37984) python311Packages.google-cloud-storage: 2.13.0 -> 2.14.0
* [`67375d11`](https://github.com/NixOS/nixpkgs/commit/67375d11d48a18146c5c139f16ca82c47195cd41) aws-c-cal: 0.6.9 -> 0.6.10
* [`c5ac4e79`](https://github.com/NixOS/nixpkgs/commit/c5ac4e79a03ef62d9dc59974403d869b3c7a0273) fable: 4.11.0 -> 4.12.2
* [`88b862c2`](https://github.com/NixOS/nixpkgs/commit/88b862c2565c737dd7d5e147d81586b13f8b15f2) meson: 1.3.1 -> 1.3.2
* [`b3f483a5`](https://github.com/NixOS/nixpkgs/commit/b3f483a5c22134294727b253603a9f6441c638e8) pgbouncer: build with systemd support
* [`b89cd583`](https://github.com/NixOS/nixpkgs/commit/b89cd583aedd1d4dff6dc1b763d498ab05bb4941) nixos/pgbouncer: only depend on postgresql.service when enabled and use notify
* [`f6278d4f`](https://github.com/NixOS/nixpkgs/commit/f6278d4f6a85b1a512b266428c12adc9c8c26f2e) nixos/pgbouncer: fix openFirewall option
* [`d8b6ea05`](https://github.com/NixOS/nixpkgs/commit/d8b6ea0567243fd5e41f28ab48f0c599e2e38f8a) pmtiles: 1.14.1 -> 1.17.0
* [`b45c6072`](https://github.com/NixOS/nixpkgs/commit/b45c60727cdc6bfce048aeafcc2b803c2ec8d38a) cacert: 3.95 -> 3.98
* [`2e06e4d3`](https://github.com/NixOS/nixpkgs/commit/2e06e4d3dfdb75ac95e85d501b1c4368d0fdc298) nss_esr: 3.90.1 -> 3.90.2
* [`c74a4a55`](https://github.com/NixOS/nixpkgs/commit/c74a4a55b0831f073a7476b781ecc457b8e50455) python311Packages.skrl: 1.0.0 -> 1.1.0
* [`7aa7b440`](https://github.com/NixOS/nixpkgs/commit/7aa7b440f3666bc5310c1262f8226f238d331f00) kool: 3.0.0 -> 3.1.0
* [`f80f903a`](https://github.com/NixOS/nixpkgs/commit/f80f903aa22a2fbb4bc443e9d5464b16d0cac68a) mongodb-compass: 1.42.0 -> 1.42.1
* [`b8179041`](https://github.com/NixOS/nixpkgs/commit/b8179041eed66767a132c986bb522db0c9afdbfb) artem: 2.0.2 -> 2.0.6
* [`fdf77d10`](https://github.com/NixOS/nixpkgs/commit/fdf77d10cb0fc299fc9c4c81768bfe2cf62ce9d4) nixos/no-x-libs: build pipewire without vulkan support
* [`be902cb3`](https://github.com/NixOS/nixpkgs/commit/be902cb3651cc605623c30d4be1ddbc680d09f38) rPackages.Cyclops: fixed build
* [`252a17a9`](https://github.com/NixOS/nixpkgs/commit/252a17a97d285e57a5739a96524b895a38f12c1b) rPackages.LOMAR: added dependency
* [`4c1abf10`](https://github.com/NixOS/nixpkgs/commit/4c1abf10d9c94ca10630a4d2e7a47a5d8a2f7ade) rPackages.MAGEE: fixed build
* [`95623b60`](https://github.com/NixOS/nixpkgs/commit/95623b60be4dadd099abd2922899babbb31304c1) rPackages.highs: fix build
* [`6898582d`](https://github.com/NixOS/nixpkgs/commit/6898582da23cd186d9b4cefc37da7cd7c739b8d2) python311Packages.wcwidth: 0.2.12 -> 0.2.13
* [`1a169307`](https://github.com/NixOS/nixpkgs/commit/1a16930721f513720b1eb70b703e65c42426bc20) cmake: fix patch for darwin
* [`fbaf7446`](https://github.com/NixOS/nixpkgs/commit/fbaf7446ec8f9e2b39dd20840ab7d46bcc63e485) nixos/boot.uki: add tries option for automatic boot assessment
* [`b82a0549`](https://github.com/NixOS/nixpkgs/commit/b82a0549d092455de9e136a1bbe1799dbc5a03a7) python311Packages.argcomplete: 3.1.6 -> 3.2.1
* [`f40fcf45`](https://github.com/NixOS/nixpkgs/commit/f40fcf45170af3fdd83484f923af0db9a45605c4) vinegar: add regregrevert patch for wine 9.0 (stable)
* [`fd76859c`](https://github.com/NixOS/nixpkgs/commit/fd76859c8a2cb13342e556818bd0246c4fd25653) yutto: 2.0.0b33 -> 2.0.0b35
* [`2e4fb1a5`](https://github.com/NixOS/nixpkgs/commit/2e4fb1a50b7dbac41eeaef18d30423302260bee4) vinegar: added segregrevert.mypatch
* [`f5cba8e3`](https://github.com/NixOS/nixpkgs/commit/f5cba8e32019ad1785307747d912cf7e102d4f02) python3Packages.osc: Enable keyring support
* [`e603deaf`](https://github.com/NixOS/nixpkgs/commit/e603deafb8a56c1e92e7e307e0b7a0632d0857f1) maintainers: add raroh73
* [`140a69a1`](https://github.com/NixOS/nixpkgs/commit/140a69a184b9d1ff13d60049f7f12ed7543af460) k8sgpt: 0.3.26 -> 0.3.27
* [`e4bbd313`](https://github.com/NixOS/nixpkgs/commit/e4bbd31362607962e5d83dbac70fd7738c3330ca) kubetail: 1.6.18 -> 1.6.19
* [`82cb3d3c`](https://github.com/NixOS/nixpkgs/commit/82cb3d3ca11feb18d4686a1b585773f67b92def9) rPackages.vcfppR: fixed build
* [`93f6cd52`](https://github.com/NixOS/nixpkgs/commit/93f6cd522ae1fc7793d94ef21c4c3e5c5f4eb2d8) vinegar: switched Wine version to wine64Packages.staging, added
* [`829a6c33`](https://github.com/NixOS/nixpkgs/commit/829a6c33b6976b71aedbf6a5792322483d5cf5a6) crun: 1.14.1 -> 1.14.2
* [`6ab28e7f`](https://github.com/NixOS/nixpkgs/commit/6ab28e7f8559d7f5fdf59e5d5d8a8c9c9e18fca0) isomd5sum: 1.2.3 -> 1.2.4
* [`cc12ef85`](https://github.com/NixOS/nixpkgs/commit/cc12ef85673fe315074f2cac40d72a83abd3d844) unison-ucm: 0.5.15 -> 0.5.17
* [`d00cf3b9`](https://github.com/NixOS/nixpkgs/commit/d00cf3b9aa79164c31a89e6431511ca1905473d1) python311Packages.ledger-bitcoin: 0.2.2 -> 0.3.0
* [`2444fc7f`](https://github.com/NixOS/nixpkgs/commit/2444fc7fa51774674ae1c874d948f338dc5d97c1) snakemake: 8.4.4 -> 8.4.8
* [`a05fa3dc`](https://github.com/NixOS/nixpkgs/commit/a05fa3dc1be630d3c007faed731c4b027861a52e) maintainers: add abysssol
* [`828b4dc3`](https://github.com/NixOS/nixpkgs/commit/828b4dc30e4881480a793ad4821c30c7f98a1c80) ollama: 0.1.17 -> 0.1.24
* [`30a7446a`](https://github.com/NixOS/nixpkgs/commit/30a7446a159f3869d4e75f559e42f5f6cb3c6865) ollama: add support for gpu acceleration
* [`0e64c89e`](https://github.com/NixOS/nixpkgs/commit/0e64c89ef1432e683cd1f755863e6f139cdbb67d) alsa-ucm-conf: drop conflicting upstream patch
* [`7ed91d08`](https://github.com/NixOS/nixpkgs/commit/7ed91d089c96c57006bcc088bcd285dbcdaf5e3d) x265: mingw support bugfix
* [`4bf9291c`](https://github.com/NixOS/nixpkgs/commit/4bf9291caa8b68f3d4b7a3d870b3e397408be9c4) vscode-extensions.earthly.earthfile-syntax-highlighting: init at 0.0.16
* [`1efcf346`](https://github.com/NixOS/nixpkgs/commit/1efcf3467ef8be2bef1f233b24a53e4a7455ebc1) firefox-devedition-bin-unwrapped: update channel references
* [`3c706744`](https://github.com/NixOS/nixpkgs/commit/3c706744c6e4acbd17389edae5812674691c5a89) firefox-devedition-bin-unwrapped: 118.0b9 -> 123.0b9
* [`611c325e`](https://github.com/NixOS/nixpkgs/commit/611c325e51fcefaaa0252622b708eda72606e59c) firefox-beta-bin-unwrapped: 119.0b6 -> 123.0b9
* [`be41d7c8`](https://github.com/NixOS/nixpkgs/commit/be41d7c86b783e62ec4d6bbd6759ff46d38c608a) firefox-devedition-unwrapped: 121.0b9 -> 123.0b9
* [`91937c5e`](https://github.com/NixOS/nixpkgs/commit/91937c5e03439978963b6203173aa14bc84a1bba) firefox-beta-unwrapped: 121.0b9 -> 123.0b9
* [`6eb4d975`](https://github.com/NixOS/nixpkgs/commit/6eb4d975bb893d8915fa2f49c06b840fe8606fd2) python311Packages.torchio: 0.19.1 -> 0.19.5
* [`94206d77`](https://github.com/NixOS/nixpkgs/commit/94206d770c7ba90290cfeaf7df2b84e44307639d) ugrep: add meta.mainProgram
* [`7ff94904`](https://github.com/NixOS/nixpkgs/commit/7ff94904c520356b9e57650b87484ddeb4b0826b) ugrep: add version tester
* [`50f840e4`](https://github.com/NixOS/nixpkgs/commit/50f840e4f46ae5b95920ec72ef70f9d45e315291) k9s: 0.31.8 -> 0.31.9
* [`e1135aaf`](https://github.com/NixOS/nixpkgs/commit/e1135aaf4529414468a918ba0c262c08991f0bdd) shotwell: 0.32.4 → 0.32.6
* [`bfcd907a`](https://github.com/NixOS/nixpkgs/commit/bfcd907aa3fbec1a7da5e2a90595cd07455acac6) dolibarr: 18.0.5 -> 19.0.0
* [`c7378b2f`](https://github.com/NixOS/nixpkgs/commit/c7378b2f5019217576bc5dfe0f495e21e98a4a04) obs-studio-plugins.obs-vertical-canvas: 1.3.1 -> 1.4.0
* [`e15d47a9`](https://github.com/NixOS/nixpkgs/commit/e15d47a93c2a3beeaff5e235250fd98376622532) cpeditor: 6.11.1 -> 6.11.2
* [`0575895f`](https://github.com/NixOS/nixpkgs/commit/0575895f0b5ac96e4e72eee4312aad449d0a3042) gnome-builder: fix build by upstream patch
* [`6d28b263`](https://github.com/NixOS/nixpkgs/commit/6d28b263decf993108cd4917323bde000e4f7646) expat: fix tests flakiness in 2.6.0 version
* [`47abf033`](https://github.com/NixOS/nixpkgs/commit/47abf03340330b4748b68abc846067713e2e4ed6) cinnamon.cinnamon-control-center: fix tls support in online accounts
* [`982f791d`](https://github.com/NixOS/nixpkgs/commit/982f791d34a176c502632922a267f44a1f7fa822) discord-ptb: 0.0.67 -> 0.0.69
* [`4e980fe2`](https://github.com/NixOS/nixpkgs/commit/4e980fe26d4bee4e971733f12d8f83f053e8da5e) syft: 0.103.1 -> 0.105.0
* [`37a61de1`](https://github.com/NixOS/nixpkgs/commit/37a61de181e9a1c3fde9e250f0f91802793fc673) libmanette: 0.2.6 -> 0.2.7
* [`cee6d2ba`](https://github.com/NixOS/nixpkgs/commit/cee6d2ba3b47ee8e59e6eac1fa2769e5953c2aec) linux_xanmod: 6.1.76 -> 6.6.17
* [`65706932`](https://github.com/NixOS/nixpkgs/commit/65706932e752c4e6e188625fc8c06281ec1fd066) linux_xanmod_latest: 6.6.15 -> 6.7.5
* [`bc775ec0`](https://github.com/NixOS/nixpkgs/commit/bc775ec0dd25b06b867f336026010af47dcf02e7) cpython: allow full variant on all platformns where bluez is available
* [`4d70c229`](https://github.com/NixOS/nixpkgs/commit/4d70c229330e3b83b3cc5354a874edc9bea7f66c) python311Packages.botocore: 1.33.6 -> 1.34.21
* [`2f3336dc`](https://github.com/NixOS/nixpkgs/commit/2f3336dc1a7b39cdc1ade25ff369afb98b2d16a5) python311Packages.s3transfer: 0.8.2 -> 0.10.0
* [`092085c8`](https://github.com/NixOS/nixpkgs/commit/092085c8640c7a0de6d4a09809d641b59e7129cd) python311Packages.cfn-lint: 0.83.3 -> 0.84.0
* [`4f68e9b1`](https://github.com/NixOS/nixpkgs/commit/4f68e9b144adadf2e8537ec86b4d96788a61f849) python311Packages.aiobotocore: 2.8.0 -> 2.9.1
* [`af7e8e66`](https://github.com/NixOS/nixpkgs/commit/af7e8e66dd9501a6656d00a6bff0352ccc0f880e) python311Packages.boto3: 1.33.6 -> 1.34.21
* [`8edfb2c5`](https://github.com/NixOS/nixpkgs/commit/8edfb2c5c7f062fc433420ecfd81b7f2226b8579) awscli: 1.31.6 -> 1.32.21
* [`241f289f`](https://github.com/NixOS/nixpkgs/commit/241f289ff640057d0769e955a09d026b6c8bd92e) python311Packages.moto: 4.2.11 -> 4.2.13
* [`b92bc11e`](https://github.com/NixOS/nixpkgs/commit/b92bc11e8731212e1f305be52457da3fa84e8402) python311Packages.py-partiql-parser: 0.4.2 -> 0.5.0
* [`50e877ed`](https://github.com/NixOS/nixpkgs/commit/50e877ed8982f52de379ed76c3ab20850e1edff0) buildLuarocksPackage: accept structured luarocks config
* [`53909a65`](https://github.com/NixOS/nixpkgs/commit/53909a6527ea2603f56216f7b0366087897d3d4b) imgui: 1.90.2 -> 1.90.3
* [`0958f602`](https://github.com/NixOS/nixpkgs/commit/0958f602890efa6e166599b0927e8e375768ec29) deno: 1.40.2 -> 1.40.5
* [`fd464f05`](https://github.com/NixOS/nixpkgs/commit/fd464f0543b9b5370b1b3c165462e9f988d038bb) virtualisation/containers: add support for providing static CDI definitions
* [`ee578adf`](https://github.com/NixOS/nixpkgs/commit/ee578adfdc07f066168e75efb6e64c2dadcebb07) cloudlog: 2.6.3 -> 2.6.4
* [`5a7fbfb3`](https://github.com/NixOS/nixpkgs/commit/5a7fbfb3ce9428809f85c70c4563026b4edf7534) microsoft-gsl: apply nvcc patch for onnxruntime
* [`5902d04c`](https://github.com/NixOS/nixpkgs/commit/5902d04c3890bfc04eac1b3b3b3aac6e73a50b82) onnxruntime: add CUDA support
* [`a6e237a8`](https://github.com/NixOS/nixpkgs/commit/a6e237a86a4703e7c19e99357d781e3cabf288aa) modules/incus: add ui flag
* [`f1ed3953`](https://github.com/NixOS/nixpkgs/commit/f1ed39535e3838d8ba546eb3b0f93375be7355bc) nixosTests.incus: add ui test
* [`12d1a98a`](https://github.com/NixOS/nixpkgs/commit/12d1a98a6fcba8d3901a49b1acaa2ed83f59f05f) immersed-vr: 9.6 -> 9.10
* [`2e133643`](https://github.com/NixOS/nixpkgs/commit/2e13364360a9fa99fae738c9a845e8cb061860fc) kodiPackages.mediathekview: init at 1.0.9
* [`d08413cc`](https://github.com/NixOS/nixpkgs/commit/d08413cc170b8a848b38732ca0b9678c6894fff2) python311Packages.pex: 2.1.162 -> 2.2.1
* [`27496593`](https://github.com/NixOS/nixpkgs/commit/27496593727fc755213cddd7e5063e4a092eac93) python311Packages.primer3: 2.0.2 -> 2.0.3
* [`4b603ad9`](https://github.com/NixOS/nixpkgs/commit/4b603ad9cd26f71bd17d52c2f6923ce6ba163c63) dockerTools: configurable compression schema
* [`10bb09d3`](https://github.com/NixOS/nixpkgs/commit/10bb09d36cdb976a7d994e66733f510a4d6743ad) dim: init at unstable-2023-12-29
* [`d7ff5c62`](https://github.com/NixOS/nixpkgs/commit/d7ff5c623b349d1a0a3033817145be8d1fadcda1) git-ignore: 1.2.2 -> 1.3.1
* [`94908e26`](https://github.com/NixOS/nixpkgs/commit/94908e262b498600af4c6f7f046393254837c452) spacedrive: 0.1.4 -> 0.2.4
* [`dedb49d2`](https://github.com/NixOS/nixpkgs/commit/dedb49d2c1f40918406c8efc46f0f7f7e098691c) nwg-panel: 0.9.22 -> 0.9.23
* [`22f95879`](https://github.com/NixOS/nixpkgs/commit/22f95879b31bc40354653c86fc60ce495a10a562) nfdump: 1.7.3 -> 1.7.4
* [`deed69c5`](https://github.com/NixOS/nixpkgs/commit/deed69c590be6feb0d92f242b44f2618fcf3fd5e) pdm: install shell completion
* [`17495e7a`](https://github.com/NixOS/nixpkgs/commit/17495e7af7da3312920a397c352f494afefd94c8) devpod: 0.4.2 -> 0.5.2
* [`03fd0a84`](https://github.com/NixOS/nixpkgs/commit/03fd0a846d6c0c0f79539298afbc27752a893e2d) commitizen: 3.14.1 -> 3.15.0
* [`33fc7eac`](https://github.com/NixOS/nixpkgs/commit/33fc7eacc8c968513a370b7f31d7f731bcc2f7fe) schemacrawler: 16.21.1 -> 16.21.2
* [`c9c75da0`](https://github.com/NixOS/nixpkgs/commit/c9c75da0dd09917631ce5651b493bdfaa302f170) ligolo-ng: 0.5.1 -> 0.5.2
* [`f3691d4a`](https://github.com/NixOS/nixpkgs/commit/f3691d4aea0792eb4ec50d769e41f236fae06de3) sudo-font: 0.81 -> 1.0
* [`b61624e0`](https://github.com/NixOS/nixpkgs/commit/b61624e01a01ffd314bc92603bd6742a1967470d) crossplane-cli: 1.14.5 -> 1.15.0
* [`5a810307`](https://github.com/NixOS/nixpkgs/commit/5a810307b2ffab6120f1583d29a6ec449dea2dcd) vinegar: removed wine-loader-prefer-winedllpatch.patch
* [`9d1a1573`](https://github.com/NixOS/nixpkgs/commit/9d1a1573eb304e7a4375794e722cf3919e3c36d3) python311Packages.pandas: 2.1.3 -> 2.2.0
* [`8d976cbd`](https://github.com/NixOS/nixpkgs/commit/8d976cbde7f2f2ce58721bee3873832ffbf7a674) python312Packages.tqdm: ignore deprecationwarnings in tests
* [`6b8a561c`](https://github.com/NixOS/nixpkgs/commit/6b8a561c2dfba0882c330d69f211395c1281fb4e) python311Packages.numpy: 1.26.2 -> 1.26.4
* [`fd679ce2`](https://github.com/NixOS/nixpkgs/commit/fd679ce2c4afb4e26a578ca9e5246199c21285d5) python311Packages.llvmlite: 0.41.1 -> 0.42.0
* [`b3775924`](https://github.com/NixOS/nixpkgs/commit/b37759246b97b00d630ff1c7c8e7f4ec3e97894a) nb: 7.11.0 -> 7.12.1
* [`08e15487`](https://github.com/NixOS/nixpkgs/commit/08e1548791ee176cb654718d5136aa81b5a7596b) python311Packages.numba: 0.58.1 -> 0.59.0
* [`cf8e751c`](https://github.com/NixOS/nixpkgs/commit/cf8e751c2b9c2b072058c27a49fbf1d42dd4f9c2) brakeman: 6.1.1 -> 6.1.2
* [`bbcf1a58`](https://github.com/NixOS/nixpkgs/commit/bbcf1a58f9dacd5b61f5e026722db005b31dd4f1) untrunc-anthwlock: 2020.07.18 -> unstable-2021-11-21
* [`19831a29`](https://github.com/NixOS/nixpkgs/commit/19831a29ee9e1cf0df2fd74d9cff7ed2c79eaed0) brakeman: add meta.mainProgram
* [`38b1bad0`](https://github.com/NixOS/nixpkgs/commit/38b1bad0379f3b8aa1d1d25208ba94f2bf3c66ae) untrunc-anthwlock: add passthru.updateScript
* [`8ee3d762`](https://github.com/NixOS/nixpkgs/commit/8ee3d762fb9e2c4f027fc2d6f83d849d16f4aca5) plumber: build only main executable
* [`b9138b7c`](https://github.com/NixOS/nixpkgs/commit/b9138b7c072f55dcfd7b8c0747c3c4291bd0b28e) mk-python-derivation: Add dependencies & optional-dependencies arguments
* [`4d0cca46`](https://github.com/NixOS/nixpkgs/commit/4d0cca465476a1142c187198c9fe3fcd89aec6d1) mk-python-derivation: Add build-system argument
* [`7ba7e2dd`](https://github.com/NixOS/nixpkgs/commit/7ba7e2dd65fe4cf8a8288461162de1761a520004) python3.pkgs.requests: Use dependencies & optional-dependencies params
* [`07a221b4`](https://github.com/NixOS/nixpkgs/commit/07a221b41f63cd4ec023d48104b21533686c1cc3) python3.pkgs.pendulum: Use build-system & dependencies params
* [`32093435`](https://github.com/NixOS/nixpkgs/commit/32093435276d37ea9e19655f1e1c8f5d27dc3361) nixos/zope2: Remove module
* [`8cd20524`](https://github.com/NixOS/nixpkgs/commit/8cd205247188c2bedd1c3b0650dba606a776af24) moon: 1.20.1 -> 1.21.4
* [`8ec130e9`](https://github.com/NixOS/nixpkgs/commit/8ec130e9f5e36186f41a64ae389bcc187f2240e5) murex: 5.3.7000 -> 6.0.1000
* [`23bb3ddd`](https://github.com/NixOS/nixpkgs/commit/23bb3dddb14353fc5a269f155a5617faa200bb0b) doclifter: 2.20 -> 2.21
* [`801ffaaa`](https://github.com/NixOS/nixpkgs/commit/801ffaaa3690c0bc256c76b6eb8ef25e3c7cb2e2) bacnet-stack: 1.3.2 -> 1.3.3
* [`b06ebb2c`](https://github.com/NixOS/nixpkgs/commit/b06ebb2cf3afa6b82dba7f8acb37279b1f22eadb) ceph: fix cryptography override
* [`abd929bb`](https://github.com/NixOS/nixpkgs/commit/abd929bb058f8821d25ec2a835f8781c2b17f4ab) dart: 3.2.6 -> 3.3.0
* [`d4938791`](https://github.com/NixOS/nixpkgs/commit/d49387915cb94f85027d51a42ee46f7ee392aca7) megapixels: add Luflosi as maintainer
* [`5c8b72fd`](https://github.com/NixOS/nixpkgs/commit/5c8b72fd75ef6db82de00a1f6e53c84ba8ab9271) megapixels: migrate to by-name
* [`0494985d`](https://github.com/NixOS/nixpkgs/commit/0494985d0b98a3c903b1d671d4597d18badd2370) megapixels: cleanup
* [`8f92ea09`](https://github.com/NixOS/nixpkgs/commit/8f92ea094a2d8f0ee6bf0a5680e539070cb0b83a) megapixels: move to new upstream repo
* [`a74abfa1`](https://github.com/NixOS/nixpkgs/commit/a74abfa17d8164cae3d4ed0bed80ad69e86782a1) megapixels: 1.7.0 -> 1.8.0
* [`a575d59e`](https://github.com/NixOS/nixpkgs/commit/a575d59eaaeb5ef3e095eaebf71913225fb72feb) python311Packages.pyrainbird: 4.0.1 -> 4.0.2
* [`2c57e8e6`](https://github.com/NixOS/nixpkgs/commit/2c57e8e62dc84f41fe91a41833095f66ace30a22) python311Packages.pyrainbird: refactor
* [`73a1a40c`](https://github.com/NixOS/nixpkgs/commit/73a1a40c6eb657c85e399970644e5e7ec52a351e) python311Packages.ical: 6.1.1 -> 7.0.0
* [`35d99092`](https://github.com/NixOS/nixpkgs/commit/35d990920c846d05d6db33d8204e77561daa297b) qt5.qtbase: pick up a small security fix
* [`13c49b2f`](https://github.com/NixOS/nixpkgs/commit/13c49b2f442da8bef6ad762c25d0ad6f44abf97b) python3Packages.laces: init at 0.1.1
* [`02759ac1`](https://github.com/NixOS/nixpkgs/commit/02759ac1db4d517ba4e9e91314656e455d9c3a86) expr: 1.16.0 -> 1.16.1
* [`5e1a6504`](https://github.com/NixOS/nixpkgs/commit/5e1a6504e2bc38c17fe6ca5629b7e6b141349840) bip: drop blanket -Werror
* [`eb6bf91a`](https://github.com/NixOS/nixpkgs/commit/eb6bf91a172133e48eb83e602f30778a569541db) miniflux: 2.0.51 -> 2.1.0
* [`91412b09`](https://github.com/NixOS/nixpkgs/commit/91412b090b9de525fb71a281269b74463fbc02b2) python311Packages.pytest-asyncio: 0.23.3 -> 0.23.5
* [`2157a9ce`](https://github.com/NixOS/nixpkgs/commit/2157a9ce314be14a0787c08f74adb2960b8a7799) btcdeb: unstable-2022-04-03 -> 0.3.20-unstable-2024-02-06
* [`62e35e55`](https://github.com/NixOS/nixpkgs/commit/62e35e557c3ac0ddedb1492f759b38b49c14e117) typora: 1.8.9 -> 1.8.10
* [`65e2f7e7`](https://github.com/NixOS/nixpkgs/commit/65e2f7e7521d9df5a70413f0ff7d1a2fc007529d) thunderbird-bin: 115.6.0 -> 115.7.0
* [`73898d2b`](https://github.com/NixOS/nixpkgs/commit/73898d2b90fbebf9750d16ac89e342ebc1ddbefd) python311Packages.requirements-detector: relax astroid
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
