### PR TITLE
niv devenv: update bc4602a4 -> fa9a708e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "bc4602a41c197edd5838c8a97da2ed0c1fc75d0e",
-        "sha256": "0fcs7mlwzp6rc2bm2lm5mlmmkp93n8vjiaissva109pb18y50a3j",
+        "rev": "fa9a708e240c6174f9fc4c6eefbc6a89ce01c350",
+        "sha256": "0lk0w6nng98knd12ng77n1pg6iyp5hz52805kflcgisb3sw69yis",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/bc4602a41c197edd5838c8a97da2ed0c1fc75d0e.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/fa9a708e240c6174f9fc4c6eefbc6a89ce01c350.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@bc4602a4...fa9a708e](https://github.com/cachix/devenv/compare/bc4602a41c197edd5838c8a97da2ed0c1fc75d0e...fa9a708e240c6174f9fc4c6eefbc6a89ce01c350)

* [`eada611e`](https://github.com/cachix/devenv/commit/eada611e281688e35637552e5da4e8b9d11fbb0e) terraform: Dynamic `aws-vault` wrapper
* [`2d970e0c`](https://github.com/cachix/devenv/commit/2d970e0c5e143b0e19aa35c883bbb0ebf3df7a35) Update option description
* [`0b44971a`](https://github.com/cachix/devenv/commit/0b44971aceacca37329a2c6a9a0806db404fec9c) Reorder packages
* [`2d46c1b6`](https://github.com/cachix/devenv/commit/2d46c1b63edebbcb30061914b00de25bed31ad65) Pass arguments to aws-vault exec
* [`bef2adab`](https://github.com/cachix/devenv/commit/bef2adabf3d2ee4a7ad5250dd5e6ec92821a3117) feat: Implement aws-vault integration
* [`0652cd3e`](https://github.com/cachix/devenv/commit/0652cd3eec9b3dbc1ce50e7e8d2cfcb8d7158e01) Add basic example
* [`4d57dca9`](https://github.com/cachix/devenv/commit/4d57dca9b3f2af8547baea09079d58f34c7b4a9e) Update profile description
* [`4fb45637`](https://github.com/cachix/devenv/commit/4fb4563736735d830cbdcc5abc3f385b9fb26b11) Update example
* [`51195857`](https://github.com/cachix/devenv/commit/5119585774912d42406eaefe06c19a168157266f) Add awscli2WrapperEnable option
* [`a98a9e1a`](https://github.com/cachix/devenv/commit/a98a9e1a788d8b65dfa6449b3810045d6a551ab6) Update aws-vault example
* [`74dc714e`](https://github.com/cachix/devenv/commit/74dc714e3adde601734144734d2cb14d2594abef) Refactor wrapper options as submodules
* [`c9fca671`](https://github.com/cachix/devenv/commit/c9fca6714ebc53ba4dc7972d4f20c668f80d2bb0) Update example
* [`5344a70f`](https://github.com/cachix/devenv/commit/5344a70fad7ea75c662043a8c45e341656ef3908) Rename option from awscli2Wrapper to awscliWrapper
* [`655764eb`](https://github.com/cachix/devenv/commit/655764ebc974849f22464b60e5efb636a80372b3) Fix: flag conversion was wrong
* [`f5d594f7`](https://github.com/cachix/devenv/commit/f5d594f79022f4468fae9d04418cb607890a9347) Auto generate docs/reference/options.md
