### PR TITLE
niv home-manager: update a54e05bc -> 1d085ea4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a54e05bc12d88ff2df941d0dc1183cb5235fa438",
-        "sha256": "1rnksvzsplsy22cifngwnpdda074nkm5555217i1wfgqwscp36qd",
+        "rev": "1d085ea4444d26aa52297758b333b449b2aa6fca",
+        "sha256": "0v2idasyxh8rsp4lkaph77ivc3ffwi8k2gk9h6rxvd5qxrfznb24",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a54e05bc12d88ff2df941d0dc1183cb5235fa438.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/1d085ea4444d26aa52297758b333b449b2aa6fca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a54e05bc...1d085ea4](https://github.com/nix-community/home-manager/compare/a54e05bc12d88ff2df941d0dc1183cb5235fa438...1d085ea4444d26aa52297758b333b449b2aa6fca)

* [`517601b3`](https://github.com/nix-community/home-manager/commit/517601b37c6d495274454f63c5a483c8e3ca6be1) jujutsu: remove shell completion
* [`3dda8e79`](https://github.com/nix-community/home-manager/commit/3dda8e795f12a4f67c287cef155939e1c5fbd0a3) river: add module
* [`0b69d574`](https://github.com/nix-community/home-manager/commit/0b69d574162cfa6eb7919d5614a48d0185550891) Translate using Weblate (Spanish)
* [`0e0e9669`](https://github.com/nix-community/home-manager/commit/0e0e9669547e45ea6cca2de4044c1a384fd0fe55) zsh: fix broken ZDOTDIR when path contains spaces
* [`4e6d25a5`](https://github.com/nix-community/home-manager/commit/4e6d25a51bb3035af7db54cc8f7fcac23e9467dc) lorri: systemd allow access to cache directories
* [`ae7a3b51`](https://github.com/nix-community/home-manager/commit/ae7a3b5137ca3522f2802b3183de8fe5287b13d2) hyprland: fix reloading
* [`4ee704cb`](https://github.com/nix-community/home-manager/commit/4ee704cb13a5a7645436f400b9acc89a67b9c08a) xscreensaver: add package option
* [`1d085ea4`](https://github.com/nix-community/home-manager/commit/1d085ea4444d26aa52297758b333b449b2aa6fca) yazi: update shell integrations ([nix-community/home-manager⁠#5048](https://togithub.com/nix-community/home-manager/issues/5048))
