### PR TITLE
niv niv: update 290965ab -> d67c25f2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "290965abaa02be33b601032d850c588a6bafb1a5",
-        "sha256": "1f75kd0s7ch882camvsp0shkbx0vs0hshn184il0fi6i7k4xs5hy",
+        "rev": "d67c25f29716fd2087e71352783fcce194303a9a",
+        "sha256": "1813r42sz4pmv1syn38s281lmg2l7h779q4r33nn5azm7wy45yrh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/290965abaa02be33b601032d850c588a6bafb1a5.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/d67c25f29716fd2087e71352783fcce194303a9a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@290965ab...d67c25f2](https://github.com/nmattia/niv/compare/290965abaa02be33b601032d850c588a6bafb1a5...d67c25f29716fd2087e71352783fcce194303a9a)

* [`67b245a3`](https://github.com/nmattia/niv/commit/67b245a3566f212e9109f4575bbe539008fc4ba1) Remove Unnecessary Uses of `rec` ([nmattia/niv⁠#390](https://togithub.com/nmattia/niv/issues/390))
* [`51216db2`](https://github.com/nmattia/niv/commit/51216db28d64567177a973ae28d92c6ce8c10ee6) Update cpp example ([nmattia/niv⁠#394](https://togithub.com/nmattia/niv/issues/394))
* [`d67c25f2`](https://github.com/nmattia/niv/commit/d67c25f29716fd2087e71352783fcce194303a9a) Update FAQ to explain submodules ([nmattia/niv⁠#393](https://togithub.com/nmattia/niv/issues/393))
