### PR TITLE
niv emacs-overlay: update bc072d9c -> 03b374a3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc072d9cca7c696b5167d352e20728515938f677",
-        "sha256": "1k91gf7vzsd5qxgcvrmpp7qx5vzdll03yg52dhwrpyqlshqw6pi0",
+        "rev": "03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9",
+        "sha256": "08650jk06yjhg2dwvngv455128ss859n268xa36mikapr5a4ka37",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/bc072d9cca7c696b5167d352e20728515938f677.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@bc072d9c...03b374a3](https://github.com/nix-community/emacs-overlay/compare/bc072d9cca7c696b5167d352e20728515938f677...03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9)

* [`825ce34a`](https://github.com/nix-community/emacs-overlay/commit/825ce34adf294e5f2b2de7e1606349cf07caa3f2) make extraEmacsPackages available when building init file
* [`46140cd6`](https://github.com/nix-community/emacs-overlay/commit/46140cd6aea038eb370d01095f12d5da4f656a43) Updated elpa
* [`19fac0e8`](https://github.com/nix-community/emacs-overlay/commit/19fac0e8e98cc770dc960094ff6be4f72f536e7d) Updated melpa
* [`f2d21ce0`](https://github.com/nix-community/emacs-overlay/commit/f2d21ce04546fe3120c1670f06e5f7598592ecd0) Updated emacs
* [`7130fb6c`](https://github.com/nix-community/emacs-overlay/commit/7130fb6cae4492784d282f005cfc3e43afc9ebb4) Updated emacs
* [`42f2c32d`](https://github.com/nix-community/emacs-overlay/commit/42f2c32d615b145ab47faeca4d9cfb48f7909052) Updated melpa
* [`fabe4b75`](https://github.com/nix-community/emacs-overlay/commit/fabe4b7550aaaf6e1fdc31cffe9164153a1e492c) Updated elpa
* [`488f22c2`](https://github.com/nix-community/emacs-overlay/commit/488f22c2eb3bc6a1cf0b4378afc7f331be67fc00) Updated melpa
* [`ad0b9834`](https://github.com/nix-community/emacs-overlay/commit/ad0b983479cb072cb0e97c9609c11d9e5aeced34) Updated emacs
* [`4e6805bd`](https://github.com/nix-community/emacs-overlay/commit/4e6805bd2930052e49344faf10f7e32f1bc2e34c) Updated flake inputs
* [`e7d08abf`](https://github.com/nix-community/emacs-overlay/commit/e7d08abf067abc211df72a0300bc24713105bad2) Updated nongnu
* [`3756fc6f`](https://github.com/nix-community/emacs-overlay/commit/3756fc6fdf12c19fa36bfd8cf912bf59a9de19b6) Updated elpa
* [`28256189`](https://github.com/nix-community/emacs-overlay/commit/282561890cbd396a3da4a494cd17f71d111f35bf) Updated melpa
* [`bdc43452`](https://github.com/nix-community/emacs-overlay/commit/bdc43452fa833f8ea0c78cb6e2bb67e4642e58ca) Updated emacs
* [`e4f17c81`](https://github.com/nix-community/emacs-overlay/commit/e4f17c81782040f23958ed74f1ab3a56b53df197) Updated emacs
* [`d82554b4`](https://github.com/nix-community/emacs-overlay/commit/d82554b44a986ca44c0c533b6f0c8109ffe69dec) Updated melpa
* [`a0a3bab9`](https://github.com/nix-community/emacs-overlay/commit/a0a3bab96eaa014edbf9868536f702fd57ac343e) Updated flake inputs
* [`2e1493b0`](https://github.com/nix-community/emacs-overlay/commit/2e1493b0e8b920d91a3d5c7382746dcd89ca2642) Updated elpa
* [`5cdd16c0`](https://github.com/nix-community/emacs-overlay/commit/5cdd16c04c0893ab07d28f6de20a3b7ec6f2f451) Updated melpa
* [`e33ffe03`](https://github.com/nix-community/emacs-overlay/commit/e33ffe039bf46a8d10d3e73e48dd7e298f0232e7) Updated emacs
* [`afa646fa`](https://github.com/nix-community/emacs-overlay/commit/afa646fadbdf62ce12a18d72c771bf3db60b0ba2) Updated elpa
* [`7759177b`](https://github.com/nix-community/emacs-overlay/commit/7759177bdc835391b892144af6488b6421946c34) Updated melpa
* [`501cc214`](https://github.com/nix-community/emacs-overlay/commit/501cc2145240ef9e2c4e466dd229350f3a50de4e) Updated emacs
* [`7f585f4a`](https://github.com/nix-community/emacs-overlay/commit/7f585f4ab4a726b3f6f73c2e5c267085bb0a13f2) Updated melpa
* [`164c11f0`](https://github.com/nix-community/emacs-overlay/commit/164c11f0ddbf47ed5a20272a35b8f24557eaabb1) Updated emacs
* [`16ca106d`](https://github.com/nix-community/emacs-overlay/commit/16ca106d2a6efab591b7489d1839b391f660b1b9) Updated flake inputs
* [`4eec5674`](https://github.com/nix-community/emacs-overlay/commit/4eec567404d4f12acd70674cbc3c319cf92fb43f) Updated elpa
* [`87dec8f9`](https://github.com/nix-community/emacs-overlay/commit/87dec8f92846c69fb17e4bddd66c160bd769cb38) Updated melpa
* [`41b0349b`](https://github.com/nix-community/emacs-overlay/commit/41b0349b7219d5128acbf66d753e921f283cf1b2) Updated emacs
* [`f2df9741`](https://github.com/nix-community/emacs-overlay/commit/f2df97415de3805c1daa3c14d30357e79943961e) Updated nongnu
* [`187befb5`](https://github.com/nix-community/emacs-overlay/commit/187befb50d43371b697cd6233e4caec3e18cd9f3) Updated elpa
* [`08ecda2d`](https://github.com/nix-community/emacs-overlay/commit/08ecda2df93d592fc6bf1ac7e9f5bc27ee876c11) Updated melpa
* [`0c9de266`](https://github.com/nix-community/emacs-overlay/commit/0c9de2665a034fbc19782514e32595412cb6a781) Updated emacs
* [`acdd825f`](https://github.com/nix-community/emacs-overlay/commit/acdd825fbf3127a8a12235c754ec5bd3d447c24d) Updated melpa
* [`f994dc5c`](https://github.com/nix-community/emacs-overlay/commit/f994dc5cd9323dc83968049348858ea7e683f424) Updated emacs
* [`77b373a3`](https://github.com/nix-community/emacs-overlay/commit/77b373a3930607022e7678ab30715763c24dfaa3) Updated flake inputs
* [`8a3ac745`](https://github.com/nix-community/emacs-overlay/commit/8a3ac745eefe247bdb0f3a33e35586d0d41a91f5) Updated elpa
* [`9b34fbdd`](https://github.com/nix-community/emacs-overlay/commit/9b34fbdd9556dcf635abdd543f71f1d245c8634c) Updated melpa
* [`6945b802`](https://github.com/nix-community/emacs-overlay/commit/6945b80223499bba37d46d9a0bc9ce85589df936) Updated emacs
* [`ac950010`](https://github.com/nix-community/emacs-overlay/commit/ac95001079db6ee5c1e05acf1c7fec33d1cf2f3a) Updated elpa
* [`f44c8471`](https://github.com/nix-community/emacs-overlay/commit/f44c8471e50df56af9229aa354f3061570dfab0a) Updated melpa
* [`72e11f21`](https://github.com/nix-community/emacs-overlay/commit/72e11f211bba2c57c5e646e35a95380fafd0341a) Updated emacs
* [`b7c67b5f`](https://github.com/nix-community/emacs-overlay/commit/b7c67b5f71db89ec27e1aa4413fbbcdf5bbfa451) Shut up obsolescence warning
* [`c748ebeb`](https://github.com/nix-community/emacs-overlay/commit/c748ebeb27022d6ece8d9bcda28755572f26dc5e) Updated melpa
* [`7de6a630`](https://github.com/nix-community/emacs-overlay/commit/7de6a630960f81ab2bf5a12ecdd5678ffaee9f5c) Updated emacs
* [`b814c602`](https://github.com/nix-community/emacs-overlay/commit/b814c6022b1658d29b0eacd4a1e797946ba2532a) Updated elpa
* [`6e6e5f78`](https://github.com/nix-community/emacs-overlay/commit/6e6e5f78c7e5edbf7091174a31b35446c3519098) Updated melpa
* [`5531296a`](https://github.com/nix-community/emacs-overlay/commit/5531296a4fd231dee0ad5bb252a47cbd0198b06d) Updated emacs
* [`68e08a9a`](https://github.com/nix-community/emacs-overlay/commit/68e08a9ac499542ef473bd5306345cf24a780f50) Updated nongnu
* [`ae6f9bc8`](https://github.com/nix-community/emacs-overlay/commit/ae6f9bc80ea20d24216b566aecfe8f3eb7b70363) Updated elpa
* [`fab6612e`](https://github.com/nix-community/emacs-overlay/commit/fab6612e70edd3d48993906a7e88c5216ce4c571) Updated melpa
* [`550f226f`](https://github.com/nix-community/emacs-overlay/commit/550f226f99b0e54179a76cf9500468e120def867) Updated emacs
* [`51d8c9b0`](https://github.com/nix-community/emacs-overlay/commit/51d8c9b0e14c73d3b52e3a5e894caff20337bc6a) Updated flake inputs
* [`11c8e196`](https://github.com/nix-community/emacs-overlay/commit/11c8e196c5130ce4f91f9f433ee5067001382df5) Updated melpa
* [`5106217a`](https://github.com/nix-community/emacs-overlay/commit/5106217a5b0652bcd8f24ebf955aed45d2e7c2ad) Updated emacs
* [`5d4ab701`](https://github.com/nix-community/emacs-overlay/commit/5d4ab701c80872226f8dcaf0b494816746cdb738) Updated elpa
* [`aa0155d1`](https://github.com/nix-community/emacs-overlay/commit/aa0155d148c316cc653476c83f3aac57afbde000) Updated melpa
* [`bda20050`](https://github.com/nix-community/emacs-overlay/commit/bda20050fde1908491e9b573430ebc4745cdea58) Updated emacs
* [`61b58a1c`](https://github.com/nix-community/emacs-overlay/commit/61b58a1cef89cf6b25fae43671ff33661ef1e6c3) Updated elpa
* [`1bb597ae`](https://github.com/nix-community/emacs-overlay/commit/1bb597ae016883152249651ceaaf85b1589d7ab4) Updated melpa
* [`552a5b1f`](https://github.com/nix-community/emacs-overlay/commit/552a5b1fbcde5557b2a011956fa36fdef056fdb7) Updated emacs
* [`0db31bf7`](https://github.com/nix-community/emacs-overlay/commit/0db31bf7477ac7c58157aa7d5d7674936b712f47) Updated melpa
* [`223c6e9b`](https://github.com/nix-community/emacs-overlay/commit/223c6e9be9ef430d3523ec9c996eb74cb329c42f) Updated emacs
* [`3c16647d`](https://github.com/nix-community/emacs-overlay/commit/3c16647dfd441883e733897e799fd450ebd7f2f3) Updated elpa
* [`6ce89b64`](https://github.com/nix-community/emacs-overlay/commit/6ce89b64f94a846b185e9ef1f063099e4e170c86) Updated melpa
* [`202c1eec`](https://github.com/nix-community/emacs-overlay/commit/202c1eec521b02ccad6e7bdf32476c0eddb54c2d) Updated emacs
* [`97017b23`](https://github.com/nix-community/emacs-overlay/commit/97017b23dad7fe36be291d0b99584ff9f67d9c34) Updated flake inputs
* [`97ebd2a2`](https://github.com/nix-community/emacs-overlay/commit/97ebd2a2bd3e4fc8ee09940822625654c949a391) Updated nongnu
* [`d28950bc`](https://github.com/nix-community/emacs-overlay/commit/d28950bce310568129d58b74639e73c7d3e73a78) Updated elpa
* [`b1b55ae0`](https://github.com/nix-community/emacs-overlay/commit/b1b55ae037f900793dcb74d87b18b6ba5d8c5d38) Updated melpa
* [`ccaf5772`](https://github.com/nix-community/emacs-overlay/commit/ccaf577227e5a64f95c03d66b6ac50879b4a3521) Updated emacs
* [`08d584a5`](https://github.com/nix-community/emacs-overlay/commit/08d584a52c965ad6cd592750e7e004a2bda0901a) Updated melpa
* [`4a34b655`](https://github.com/nix-community/emacs-overlay/commit/4a34b655ebc29a22f13b547c1fa3729f7dd42f94) Updated emacs
* [`fec6062d`](https://github.com/nix-community/emacs-overlay/commit/fec6062d065254ef7a6a288f63ed19c0fee6d6be) Updated elpa
* [`64a63365`](https://github.com/nix-community/emacs-overlay/commit/64a633659fab447f12c898a32c451f88b5c3c048) Updated melpa
* [`a225b7bb`](https://github.com/nix-community/emacs-overlay/commit/a225b7bbeab6a594a7f3859fef4c3f6898b1fd50) Updated emacs
* [`ae7f86b1`](https://github.com/nix-community/emacs-overlay/commit/ae7f86b13cab5b2e89f6d3e4c121471a59e7980e) Updated flake inputs
* [`2e98b222`](https://github.com/nix-community/emacs-overlay/commit/2e98b222342ad0cc9682d450988b498fb5309772) Updated elpa
* [`3ab30310`](https://github.com/nix-community/emacs-overlay/commit/3ab303101f287c1769f0a0dc4f7ec5473e61f94f) Updated melpa
* [`bc4a6ddc`](https://github.com/nix-community/emacs-overlay/commit/bc4a6ddc986782a49d3bf6cf6af27c6aeca7d8e9) Updated melpa
* [`eda89e24`](https://github.com/nix-community/emacs-overlay/commit/eda89e24ee4ceb6e4bfcd00dabb894d6301c36db) Updated emacs
* [`e73eddaa`](https://github.com/nix-community/emacs-overlay/commit/e73eddaaa5ffbdf35bda143a4068115a049f45a0) Updated melpa
* [`45e69044`](https://github.com/nix-community/emacs-overlay/commit/45e690448c8b0c3d3906bab65152f1c7e2e202a4) Updated emacs
* [`5c6b8429`](https://github.com/nix-community/emacs-overlay/commit/5c6b8429c02e6593ee2bab649b28225097893751) Updated elpa
* [`06528d90`](https://github.com/nix-community/emacs-overlay/commit/06528d90408b8c86f6d70ad2bb5e7f6fc86441ef) Updated melpa
* [`95acf329`](https://github.com/nix-community/emacs-overlay/commit/95acf3297bda934c1ec5260e18ffea39f05bbf3a) Updated emacs
* [`98d2b370`](https://github.com/nix-community/emacs-overlay/commit/98d2b3707652c8638046a7578f30924529965b90) Updated melpa
* [`22cce99b`](https://github.com/nix-community/emacs-overlay/commit/22cce99b0abb79c5d00583f6f82e823b2bdb131b) Updated emacs
* [`44600b1d`](https://github.com/nix-community/emacs-overlay/commit/44600b1d1af7e752cfff9981d3ee980d0bf979b5) Updated flake inputs
* [`b1ad7329`](https://github.com/nix-community/emacs-overlay/commit/b1ad7329314c03fddd5326344dab21ebdd65a775) Updated nongnu
* [`410471ee`](https://github.com/nix-community/emacs-overlay/commit/410471eea4a07ef88f2ff7be21d5cfae645beedb) Updated elpa
* [`6e3c4ba0`](https://github.com/nix-community/emacs-overlay/commit/6e3c4ba04fd2db2b3ef737071043c66755c92187) Updated melpa
* [`1e43a6cb`](https://github.com/nix-community/emacs-overlay/commit/1e43a6cba24ba1da009fd358ddde947c9df07afa) Updated emacs
* [`ad4a3a32`](https://github.com/nix-community/emacs-overlay/commit/ad4a3a3271d161eedf9e85f851be60b8a361bcf2) Updated melpa
* [`3c0112ec`](https://github.com/nix-community/emacs-overlay/commit/3c0112ec21770085a50d24a899d1644bb238cfef) Updated emacs
* [`d67fd9c9`](https://github.com/nix-community/emacs-overlay/commit/d67fd9c98f2694d771fb6b4f9390678683ccc064) Updated flake inputs
* [`9a84e691`](https://github.com/nix-community/emacs-overlay/commit/9a84e691ce4df35ba795b2bbb1945d3139f45a9e) Updated elpa
* [`d33b7a3d`](https://github.com/nix-community/emacs-overlay/commit/d33b7a3d9b9b12e4da69f5539845cf872cc0f8b3) Updated melpa
* [`6a029558`](https://github.com/nix-community/emacs-overlay/commit/6a029558e537f597a436ba36a7ffc28730ecb27e) Updated emacs
* [`7cdc51cc`](https://github.com/nix-community/emacs-overlay/commit/7cdc51cc725dbbf25173d0a5517448572cf041fe) Updated elpa
* [`6bf6a11f`](https://github.com/nix-community/emacs-overlay/commit/6bf6a11f29c04046a7a60795a90ac4932b70caba) Updated melpa
* [`f797cc93`](https://github.com/nix-community/emacs-overlay/commit/f797cc93d86b19e5e007f6df584a12ce6a3cc7e4) Updated emacs
* [`fc571589`](https://github.com/nix-community/emacs-overlay/commit/fc57158935b23b709de7d74e023084ce6332e86d) Updated melpa
* [`7e74ec81`](https://github.com/nix-community/emacs-overlay/commit/7e74ec81680fff91bf07330c0e23d1b4c7aeb6af) Updated emacs
* [`12f6e2ea`](https://github.com/nix-community/emacs-overlay/commit/12f6e2ea14f50b96ff1de2d0e4e5d809f014a924) Updated flake inputs
* [`e830065f`](https://github.com/nix-community/emacs-overlay/commit/e830065f1f726fe3d8fffe641939ad66b9237f89) Updated elpa
* [`dd946433`](https://github.com/nix-community/emacs-overlay/commit/dd946433ce801fab90088ceb499c2490ec97417c) Updated melpa
* [`78207864`](https://github.com/nix-community/emacs-overlay/commit/78207864349fb13b7ffd9445d2e0566376e3b738) Updated emacs
* [`5e48f3ea`](https://github.com/nix-community/emacs-overlay/commit/5e48f3eafb4cccf45c30047bb2f27b6a4a02b52f) Updated nongnu
* [`ab891678`](https://github.com/nix-community/emacs-overlay/commit/ab89167867bba167b6e6c4f545952a7f74410bb2) Updated elpa
* [`b33b514d`](https://github.com/nix-community/emacs-overlay/commit/b33b514df08dfc133f2ca5d43fcfbdb67f85fc1c) Updated melpa
* [`bf9f1098`](https://github.com/nix-community/emacs-overlay/commit/bf9f1098a348303e6eee96f02fc965531d86d984) Updated emacs
* [`be02660f`](https://github.com/nix-community/emacs-overlay/commit/be02660f6d6ab0a6add8652f6863d47157a5ae17) Updated flake inputs
* [`70266acb`](https://github.com/nix-community/emacs-overlay/commit/70266acb2bbfd9be21988aee89efab767d00913d) Updated melpa
* [`0f7f3b39`](https://github.com/nix-community/emacs-overlay/commit/0f7f3b39157419f3035a2dad39fbaf8a4ba0448d) Updated emacs
* [`376f5e10`](https://github.com/nix-community/emacs-overlay/commit/376f5e107de8e95d6decd185682c6deeef6ccbf5) Updated elpa
* [`6af2cc79`](https://github.com/nix-community/emacs-overlay/commit/6af2cc7983267b08387630f0da8eac3b55482bc5) Updated melpa
* [`1c9b038a`](https://github.com/nix-community/emacs-overlay/commit/1c9b038a329736e444cabffb0e473642458a9858) Updated emacs
* [`31b87a76`](https://github.com/nix-community/emacs-overlay/commit/31b87a760714d848938827be5d53d6bf79d2caaa) Updated elpa
* [`385de3ad`](https://github.com/nix-community/emacs-overlay/commit/385de3ad948bc01498b692a809f589a158bde91f) Updated melpa
* [`97d761e4`](https://github.com/nix-community/emacs-overlay/commit/97d761e40d1f82a982274fcdbef90c4316669052) Updated emacs
* [`b40877f8`](https://github.com/nix-community/emacs-overlay/commit/b40877f8ce5a3c4720e6d1e965bd65d9e9e1be3c) Updated flake inputs
* [`763c614a`](https://github.com/nix-community/emacs-overlay/commit/763c614a4cce4296941b44dece54390dd108b781) Updated emacs
* [`7e59721f`](https://github.com/nix-community/emacs-overlay/commit/7e59721f8aef4297683eae683c6883ca08957d0a) Updated nongnu
* [`b69808ce`](https://github.com/nix-community/emacs-overlay/commit/b69808ceea4367b7826d4045958d3e556365d3f4) Updated elpa
* [`e42410cb`](https://github.com/nix-community/emacs-overlay/commit/e42410cb62a21e0f39051ea76beaac7175ef8ede) Updated melpa
* [`9327b7e1`](https://github.com/nix-community/emacs-overlay/commit/9327b7e16a991c8a2efbad729ac28452d7c40bf0) Updated emacs
* [`8ceb0a35`](https://github.com/nix-community/emacs-overlay/commit/8ceb0a355b70a76ca3e4aad4584c7be55e0ad0e1) Updated nongnu
* [`fe8db2c0`](https://github.com/nix-community/emacs-overlay/commit/fe8db2c01aa9a1cf77a9bb9346081e21090b8890) Updated elpa
* [`645894d1`](https://github.com/nix-community/emacs-overlay/commit/645894d1da1ee1987d58149910440a3856d04f79) Updated melpa
* [`3ca8fd85`](https://github.com/nix-community/emacs-overlay/commit/3ca8fd85438bf9e717628f519044b56d54e56911) Updated emacs
* [`0e8b7913`](https://github.com/nix-community/emacs-overlay/commit/0e8b7913eb5577cec50e119c66fe1c647d440a31) Updated flake inputs
* [`8057607a`](https://github.com/nix-community/emacs-overlay/commit/8057607aec6360988e4a1951fedbfb4fe7552ddf) Updated melpa
* [`93c49f34`](https://github.com/nix-community/emacs-overlay/commit/93c49f3479f3abb5e0ed2c62387af0a83e5d59dc) Updated emacs
* [`f2566442`](https://github.com/nix-community/emacs-overlay/commit/f2566442d6ff7837f89dc962d0bce70c68a7d6a3) Updated flake inputs
* [`f9ac504d`](https://github.com/nix-community/emacs-overlay/commit/f9ac504d6dceac20600690ec40b2774ce98a6b7f) Updated elpa
* [`b234c1f8`](https://github.com/nix-community/emacs-overlay/commit/b234c1f87824418a6c6effcf3f9ad805221d1d5c) Updated melpa
* [`45b3e94d`](https://github.com/nix-community/emacs-overlay/commit/45b3e94dfd35aa81f150d293089ed8c28f602f5f) Updated emacs
* [`ccf25455`](https://github.com/nix-community/emacs-overlay/commit/ccf254555f8586272e1e50dc11eb9dc82ee51103) Updated flake inputs
* [`38e6edaa`](https://github.com/nix-community/emacs-overlay/commit/38e6edaa6d0aa316bd16042c76e5af93287b2512) Updated elpa
* [`872e3935`](https://github.com/nix-community/emacs-overlay/commit/872e3935226c183c84707fda203a08ce2358f2b9) Updated melpa
* [`512ec36b`](https://github.com/nix-community/emacs-overlay/commit/512ec36be62eaec6ddec1515a2a659029e35de30) Updated emacs
* [`a1245ef1`](https://github.com/nix-community/emacs-overlay/commit/a1245ef1bb10e332d1353312c058169407145cc7) Updated melpa
* [`1572bc00`](https://github.com/nix-community/emacs-overlay/commit/1572bc00e95555e6c4743957103d69c9ec08a336) Updated emacs
* [`609ba40f`](https://github.com/nix-community/emacs-overlay/commit/609ba40f7e228e70b102c14b084e63445decae0b) Updated elpa
* [`b0df43bf`](https://github.com/nix-community/emacs-overlay/commit/b0df43bf17931a6b870194770340d268fe7412c2) Updated melpa
* [`4887a3bf`](https://github.com/nix-community/emacs-overlay/commit/4887a3bf368f7ba9fe2640c23ce08646918d4414) Updated emacs
* [`c7090a11`](https://github.com/nix-community/emacs-overlay/commit/c7090a11f393071dcfd8a14ef5d803d30f477016) Updated nongnu
* [`33751916`](https://github.com/nix-community/emacs-overlay/commit/337519167c4ef503a9617a35e95322b10e756f6c) Updated elpa
* [`c3d788a4`](https://github.com/nix-community/emacs-overlay/commit/c3d788a49ce7f930194fa1b8e4afef65a34d6cf3) Updated melpa
* [`02231aec`](https://github.com/nix-community/emacs-overlay/commit/02231aec4f9f4d5bd6f8933036faf7b1df5f114f) Updated melpa
* [`462042a4`](https://github.com/nix-community/emacs-overlay/commit/462042a4c13a7f9ca6a2a6c46397945fc4444602) Updated emacs
* [`56546e3c`](https://github.com/nix-community/emacs-overlay/commit/56546e3cf5eabc382dd6a4b166d239b788e601f5) Updated flake inputs
* [`9454543c`](https://github.com/nix-community/emacs-overlay/commit/9454543c4d5e1bda8ee810e1c498031f08b16908) Updated elpa
* [`bbfdf3d5`](https://github.com/nix-community/emacs-overlay/commit/bbfdf3d5e9add63f15fa4444fb0fc61adbd11237) Updated melpa
* [`192e23af`](https://github.com/nix-community/emacs-overlay/commit/192e23af90504ef6514d9255f8ee006d47909e09) Updated emacs
* [`4afdb9d4`](https://github.com/nix-community/emacs-overlay/commit/4afdb9d4384f7e18faf385552899ad948f2601da) Updated elpa
* [`4d106338`](https://github.com/nix-community/emacs-overlay/commit/4d106338574dfb66e16ebb9b8a53b7693da2a787) Updated melpa
* [`69b18188`](https://github.com/nix-community/emacs-overlay/commit/69b181888ea72d7c8a769c1b1ff6c5cb49d084ed) Updated emacs
* [`9220b65f`](https://github.com/nix-community/emacs-overlay/commit/9220b65fb203554de784267c6a0a9a271888109c) Updated flake inputs
* [`e1d06e86`](https://github.com/nix-community/emacs-overlay/commit/e1d06e86d99e96d1588c291208490c8ee2c08a42) Updated melpa
* [`4337f34d`](https://github.com/nix-community/emacs-overlay/commit/4337f34dae4a0dc33539852a0e4a52d78605ac81) Updated emacs
* [`af022425`](https://github.com/nix-community/emacs-overlay/commit/af02242510319d4dcb895f4de83b74b461b9cbda) Updated elpa
* [`e3b3b271`](https://github.com/nix-community/emacs-overlay/commit/e3b3b271caf7a4664b51e1a25c16e5a69fe70036) Updated melpa
* [`6c7eca7e`](https://github.com/nix-community/emacs-overlay/commit/6c7eca7e41d5d47a0777b045a125a6f076b70c34) Updated emacs
* [`d2209311`](https://github.com/nix-community/emacs-overlay/commit/d2209311614dd33e16284e5d20ee602fb6fb44a2) Updated elpa
* [`5d4f6efc`](https://github.com/nix-community/emacs-overlay/commit/5d4f6efc7e8a34ba84eb7248fccf17bab25e1884) Updated melpa
* [`58625c8f`](https://github.com/nix-community/emacs-overlay/commit/58625c8f881f1d8dc996eb4cdef7327658912306) Updated melpa
* [`cc90958e`](https://github.com/nix-community/emacs-overlay/commit/cc90958e2418d9c9bd8cd0bfbc92ed37ce6c2195) Updated emacs
* [`3334b307`](https://github.com/nix-community/emacs-overlay/commit/3334b307419cd56f0c4451ab601e20845431946d) Updated flake inputs
* [`7d9b3079`](https://github.com/nix-community/emacs-overlay/commit/7d9b30798766d3f6cd7d099e51e21a65d537e71c) Updated elpa
* [`8f5a6a1f`](https://github.com/nix-community/emacs-overlay/commit/8f5a6a1f3e127fc8c0671f4abfce2d24ea2ea70c) Updated melpa
* [`a097d639`](https://github.com/nix-community/emacs-overlay/commit/a097d6392a1959ed28cdd1717b729437a1e7c4fe) Updated emacs
* [`a1434c43`](https://github.com/nix-community/emacs-overlay/commit/a1434c437d2c9eb4b638918cfb25729f42bf30b4) Updated flake inputs
* [`da95bd8d`](https://github.com/nix-community/emacs-overlay/commit/da95bd8d883d0e2a4bd5bdc7aad18a7cd2becb9f) Updated elpa
* [`5c1b7b8a`](https://github.com/nix-community/emacs-overlay/commit/5c1b7b8aafcb9e98a7244e5b2d1490844537045b) Updated melpa
* [`34775297`](https://github.com/nix-community/emacs-overlay/commit/347752976096227aed7d06226e1045b5f0112386) Updated emacs
* [`c83e29d6`](https://github.com/nix-community/emacs-overlay/commit/c83e29d619b19fea300c93cb506bbc99c6599b98) Updated melpa
* [`db8898a6`](https://github.com/nix-community/emacs-overlay/commit/db8898a6db80f8dc07056fd1f449f3a4b65c45f9) Updated nongnu
* [`6879e098`](https://github.com/nix-community/emacs-overlay/commit/6879e098c576b2e386fe84a464a5a4bad5bff41e) Updated elpa
* [`7b175193`](https://github.com/nix-community/emacs-overlay/commit/7b1751931dee4af2f8ca14c3958b45c2704ba4ee) Updated melpa
* [`eca18f04`](https://github.com/nix-community/emacs-overlay/commit/eca18f048a96d077a72881ced8949e1e8dcee4b5) Updated emacs
* [`0a5f33bc`](https://github.com/nix-community/emacs-overlay/commit/0a5f33bc21d5a2b594208da4d41cad7e19f29366) Updated nongnu
* [`46a27ccf`](https://github.com/nix-community/emacs-overlay/commit/46a27ccfdce3c14f8cc79250c6a27b5abc75832d) Updated elpa
* [`7523288d`](https://github.com/nix-community/emacs-overlay/commit/7523288d4a7691c719d168f74bf88404cded497f) Updated melpa
* [`965e4460`](https://github.com/nix-community/emacs-overlay/commit/965e446000282dda9bce8fc5fcf65a5ef038f396) Updated emacs
* [`cf4080f0`](https://github.com/nix-community/emacs-overlay/commit/cf4080f0f4e0e7eb3223b723b7617e34d6a1239c) Updated melpa
* [`39a63475`](https://github.com/nix-community/emacs-overlay/commit/39a63475945fea0d8b4e4aeb351f392c1c3beeab) Updated emacs
* [`acbcd811`](https://github.com/nix-community/emacs-overlay/commit/acbcd8110648411631b60b633b5d0c77bb61b20a) Updated flake inputs
* [`5bcb462a`](https://github.com/nix-community/emacs-overlay/commit/5bcb462ac3c818ca56389bf0c47346ee6b77cb6c) Updated elpa
* [`243457f5`](https://github.com/nix-community/emacs-overlay/commit/243457f5cf17fd1c3723889b474924afbe0789bf) Updated melpa
* [`0b46b54c`](https://github.com/nix-community/emacs-overlay/commit/0b46b54cbbf135a1e6924b0a7ca22dcfd98f0cc6) Updated emacs
* [`54d05956`](https://github.com/nix-community/emacs-overlay/commit/54d0595648c17dd7e782eef6242ccb2295a2a054) Updated elpa
* [`4735a15b`](https://github.com/nix-community/emacs-overlay/commit/4735a15b5329c87554a8d54873acddbc846e8753) Updated melpa
* [`6e1f5e6d`](https://github.com/nix-community/emacs-overlay/commit/6e1f5e6da33486d1f56d98f97949f961dd621479) Updated emacs
* [`1e5be0a6`](https://github.com/nix-community/emacs-overlay/commit/1e5be0a6a9e14ece938f8882f670eb44428db059) Updated melpa
* [`7f463b6a`](https://github.com/nix-community/emacs-overlay/commit/7f463b6ae783990b87a2821491df823f75f89f9c) Updated emacs
* [`9657a4d4`](https://github.com/nix-community/emacs-overlay/commit/9657a4d41b7efd275488613a3c408765b4d55e5b) Use --replace-warn instead of --replace in substituteInPlace
* [`dfe78231`](https://github.com/nix-community/emacs-overlay/commit/dfe78231595f36e4f25aee6a861feff5b077862a) Updated elpa
* [`ab74faf9`](https://github.com/nix-community/emacs-overlay/commit/ab74faf9e9930fa1785f8a6a0005cf2c17188d5c) Updated melpa
* [`ab98cf0c`](https://github.com/nix-community/emacs-overlay/commit/ab98cf0c6ddaf60cb1ef95e4e983695c7e8245e7) Updated emacs
* [`761171bc`](https://github.com/nix-community/emacs-overlay/commit/761171bc1702963573131b427893ed08de955463) Updated nongnu
* [`0a8c849a`](https://github.com/nix-community/emacs-overlay/commit/0a8c849ac931e30a752a151a6ac9b1f521e716f1) Updated elpa
* [`3b9569f7`](https://github.com/nix-community/emacs-overlay/commit/3b9569f7f88449ab2f4f016238232b90041fbac8) Updated melpa
* [`8bcb0f18`](https://github.com/nix-community/emacs-overlay/commit/8bcb0f18ef0e77012d8ade7cdb97e897774a179c) Updated emacs
* [`eab05784`](https://github.com/nix-community/emacs-overlay/commit/eab0578469312efc175332bc8ec405d6d7a765a0) Updated flake inputs
* [`8c960d16`](https://github.com/nix-community/emacs-overlay/commit/8c960d16f0397375d706757635a6b1c437d75fdb) Updated melpa
* [`841abef0`](https://github.com/nix-community/emacs-overlay/commit/841abef01afbd293aa80130bcbd811e4102d5770) Updated emacs
* [`fef9f0a6`](https://github.com/nix-community/emacs-overlay/commit/fef9f0a62e64b2d4342a69ec116627963f5eb8ae) Updated elpa
* [`53c07ac2`](https://github.com/nix-community/emacs-overlay/commit/53c07ac2da8d7afd90a2984241eeebfc6177b183) Updated melpa
* [`4e1e5405`](https://github.com/nix-community/emacs-overlay/commit/4e1e5405aa869da8bf98b2af7a99873586a01fbc) Updated emacs
* [`c22ec71c`](https://github.com/nix-community/emacs-overlay/commit/c22ec71c2ea3138f3979467c039f88846934c518) Updated flake inputs
* [`9384a2fe`](https://github.com/nix-community/emacs-overlay/commit/9384a2fe1256dd5827c46cceb81f8418da781aa7) Updated elpa
* [`69186537`](https://github.com/nix-community/emacs-overlay/commit/691865378410dab4c6ed7abdcd9658b4919d0adf) Updated melpa
* [`a34163ae`](https://github.com/nix-community/emacs-overlay/commit/a34163aecd2197823601eadeca2d4f0f2ef1eeb6) Updated emacs
* [`0a9f2206`](https://github.com/nix-community/emacs-overlay/commit/0a9f2206463dcf4f54d11d2edd98482e7154489d) Revert "Use --replace-warn instead of --replace in substituteInPlace"
* [`93582973`](https://github.com/nix-community/emacs-overlay/commit/93582973727a642498036486b8fc908dc89ac752) Updated melpa
* [`a793a085`](https://github.com/nix-community/emacs-overlay/commit/a793a0854929c608cf219792695fe45321a72782) Updated emacs
* [`c41feea3`](https://github.com/nix-community/emacs-overlay/commit/c41feea3fa9090592395720647822ffe5dc981bc) Updated flake inputs
* [`62a3839a`](https://github.com/nix-community/emacs-overlay/commit/62a3839a94055a0276b8828445ac29f97316bd9d) Updated nongnu
* [`acd01488`](https://github.com/nix-community/emacs-overlay/commit/acd01488bd5f491e28cc2051ac48ef220ec0d64d) Updated elpa
* [`92a5d3e7`](https://github.com/nix-community/emacs-overlay/commit/92a5d3e756ba99247a2dbe9d1d43e924318a4770) Updated melpa
* [`299398be`](https://github.com/nix-community/emacs-overlay/commit/299398be3c27d885cf17ff8310944b307a1449e9) Updated emacs
* [`c9356ad5`](https://github.com/nix-community/emacs-overlay/commit/c9356ad50ab78e0ac6eec0505cbdd3685427cee4) Updated elpa
* [`47070af1`](https://github.com/nix-community/emacs-overlay/commit/47070af18d262bd7a84f55c8e2b5108eae7d1de9) Updated melpa
* [`f42e044d`](https://github.com/nix-community/emacs-overlay/commit/f42e044d8eae9e0da1a00afa79d411765c757648) Updated emacs
* [`0a1a15af`](https://github.com/nix-community/emacs-overlay/commit/0a1a15afc03b1a48662ac62879b1918ec11289e2) Updated melpa
* [`42b8b4a5`](https://github.com/nix-community/emacs-overlay/commit/42b8b4a59edbd70550ebc96e95c9258dbdefd753) Updated emacs
* [`16b8c77f`](https://github.com/nix-community/emacs-overlay/commit/16b8c77f0c2f8ba9acdb1284b784aa0490e4d86e) Updated flake inputs
* [`fd78fc83`](https://github.com/nix-community/emacs-overlay/commit/fd78fc83959ee842d637871a046027ec4c69f194) Updated elpa
* [`8bd96b59`](https://github.com/nix-community/emacs-overlay/commit/8bd96b59c634cb8fd2cf7528a81be84d0779b0df) Updated melpa
* [`482ea123`](https://github.com/nix-community/emacs-overlay/commit/482ea12373e83482e9a37113908cb947980cf8aa) Updated emacs
* [`5f4a570f`](https://github.com/nix-community/emacs-overlay/commit/5f4a570f269fc26a704eccb796f5c59e4aaa96d3) Updated flake inputs
* [`a33b5055`](https://github.com/nix-community/emacs-overlay/commit/a33b5055039d7e575203ea63f9e194b141bf1231) Updated elpa
* [`255453a9`](https://github.com/nix-community/emacs-overlay/commit/255453a988380977c0df4eb2149434ee26151aaf) Updated melpa
* [`a31b5c4d`](https://github.com/nix-community/emacs-overlay/commit/a31b5c4d51ff2e400453aceea4b81a4a066eca79) Updated emacs
* [`091bfb2b`](https://github.com/nix-community/emacs-overlay/commit/091bfb2bf49d1c4aa31ff070ba17ed0cebca7f94) Updated melpa
* [`dc68b375`](https://github.com/nix-community/emacs-overlay/commit/dc68b375c2733198f642804a3cfacab5ede99761) Updated emacs
* [`17580f47`](https://github.com/nix-community/emacs-overlay/commit/17580f47433324e6e0a7a136103a3da9fd1c4749) Updated elpa
* [`fd86f754`](https://github.com/nix-community/emacs-overlay/commit/fd86f7540e1b446f3646906b7ee3cfdb4d8702d1) Updated emacs
* [`f6a1a96f`](https://github.com/nix-community/emacs-overlay/commit/f6a1a96f834d3d7936a768472d09006cc18d62d2) Updated melpa
* [`25081a86`](https://github.com/nix-community/emacs-overlay/commit/25081a866d8e2efeaa5407ee658051c140a63dd1) Updated nongnu
* [`fdc34eab`](https://github.com/nix-community/emacs-overlay/commit/fdc34eabbe59ffe5e935fcb53a40996fc4e46958) Updated elpa
* [`759e91c6`](https://github.com/nix-community/emacs-overlay/commit/759e91c65bad01974b7514a2905365bc04a115b4) Updated melpa
* [`2dee8f65`](https://github.com/nix-community/emacs-overlay/commit/2dee8f65405e0445d7178531e79a45b6fecfab92) Updated emacs
* [`c70c2e2a`](https://github.com/nix-community/emacs-overlay/commit/c70c2e2ac3b0b8f4f194cbd34115c65a033adefd) Updated melpa
* [`c94a9019`](https://github.com/nix-community/emacs-overlay/commit/c94a9019370b0d719621e1478d5bb317223ec15b) Updated emacs
* [`a00d13fb`](https://github.com/nix-community/emacs-overlay/commit/a00d13fb01ea97b39d558bda561955ccf4d0aaee) Updated nongnu
* [`3e9c83ab`](https://github.com/nix-community/emacs-overlay/commit/3e9c83abe98d2846f96a01afa313010a0f82e775) Updated elpa
* [`aa54c73c`](https://github.com/nix-community/emacs-overlay/commit/aa54c73cba1e6fed697f72c6d823df229116be41) Updated melpa
* [`cc3baade`](https://github.com/nix-community/emacs-overlay/commit/cc3baadef2a6e417cff991253f741b7726836649) Updated emacs
* [`fb25df62`](https://github.com/nix-community/emacs-overlay/commit/fb25df62dc98426dd4d97f871332ab579db70a02) Updated flake inputs
* [`d220ffb9`](https://github.com/nix-community/emacs-overlay/commit/d220ffb9f6ae2708cfd6179f7dd9d6502f220a39) Updated elpa
* [`84fdcde6`](https://github.com/nix-community/emacs-overlay/commit/84fdcde68b7b07761b69d5a416b66ed61dcfb23c) Updated melpa
* [`2dc1cb18`](https://github.com/nix-community/emacs-overlay/commit/2dc1cb1830ec2d802a74aa0338fe39fd082b4348) Updated melpa
* [`119523b8`](https://github.com/nix-community/emacs-overlay/commit/119523b8931aaad7648e1e42fe653f66a9b5ee21) Updated emacs
* [`4719c864`](https://github.com/nix-community/emacs-overlay/commit/4719c864b381b19dcacf7f720be3ee8a96a62da5) Updated flake inputs
* [`678a4feb`](https://github.com/nix-community/emacs-overlay/commit/678a4febfec7ae6900d54a2bab7db41a55aeacd6) Updated elpa
* [`0e8baab3`](https://github.com/nix-community/emacs-overlay/commit/0e8baab3c80e696600dfcc6a673c399a8c339e68) Updated melpa
* [`8c56baa0`](https://github.com/nix-community/emacs-overlay/commit/8c56baa0e5ba4bbf9947605a31672e2f4735b1a9) Updated emacs
* [`d80b2213`](https://github.com/nix-community/emacs-overlay/commit/d80b22132b8ea17707f87220b3518d9de200b599) Updated flake inputs
* [`c1da8cd5`](https://github.com/nix-community/emacs-overlay/commit/c1da8cd5719b0ef18fec8deea705cc77504f9217) Updated elpa
* [`7854b1de`](https://github.com/nix-community/emacs-overlay/commit/7854b1dee71f6bab443ed2b96c962f63cc409cdb) Updated melpa
* [`a9db0bff`](https://github.com/nix-community/emacs-overlay/commit/a9db0bffddf142648d9fc5be615dbc246d589296) Updated emacs
* [`f0b399a4`](https://github.com/nix-community/emacs-overlay/commit/f0b399a48ad970fbaabb0a171b103b066285054c) Updated flake inputs
* [`b0ff39b2`](https://github.com/nix-community/emacs-overlay/commit/b0ff39b2ecfd233a8117dd95dd1b1bfd926714ae) Updated melpa
* [`88cb60b6`](https://github.com/nix-community/emacs-overlay/commit/88cb60b6c44861e422302371c0761a89377cf2c7) Updated emacs
* [`24c73905`](https://github.com/nix-community/emacs-overlay/commit/24c73905454662533a7a4295787d6e241632bb01) Updated elpa
* [`187e5acf`](https://github.com/nix-community/emacs-overlay/commit/187e5acf9468f9403e7ce4d7876d682d4c347596) Updated melpa
* [`5e278b16`](https://github.com/nix-community/emacs-overlay/commit/5e278b16d982831f1b81669d26649454c1a37981) Updated emacs
* [`7cfc879c`](https://github.com/nix-community/emacs-overlay/commit/7cfc879c71a7903886fd4135a66495dd9cd365f0) Updated flake inputs
* [`001333f7`](https://github.com/nix-community/emacs-overlay/commit/001333f7e2fd7fbe5052bcabcf95adbe1275a29b) Updated nongnu
* [`03b374a3`](https://github.com/nix-community/emacs-overlay/commit/03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9) Updated elpa
