### PR TITLE
niv doomemacs: update ff33ec8f -> 35dc1363

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ff33ec8f7a89d168ca533612e2562883c89e029f",
-        "sha256": "093linm3d9rp529s462lihdf3jy4zn299sgla1v1hr3wr55v6898",
+        "rev": "35dc13632b3177b9efedad212f2180f69e756853",
+        "sha256": "0ym6hrawygjmpc1mn2kg1b6rj13hcn7q23zvksppspgpvc59l7sf",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/ff33ec8f7a89d168ca533612e2562883c89e029f.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/35dc13632b3177b9efedad212f2180f69e756853.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@ff33ec8f...35dc1363](https://github.com/doomemacs/doomemacs/compare/ff33ec8f7a89d168ca533612e2562883c89e029f...35dc13632b3177b9efedad212f2180f69e756853)

* [`2e67ad18`](https://github.com/doomemacs/doomemacs/commit/2e67ad18e926935107b899be61b7b16b03250906) feat(emacs-lisp): no doc warnings with flymake
* [`e9763514`](https://github.com/doomemacs/doomemacs/commit/e9763514241583be864cbc2caaa6f6dee8c9907e) feat(emacs-lisp): add reduced-flymake-byte-compile
* [`c37f314f`](https://github.com/doomemacs/doomemacs/commit/c37f314f14b71034328193397af2b44136fae276) fix(syntax): s/connetion/connection
* [`b50b2c46`](https://github.com/doomemacs/doomemacs/commit/b50b2c464004452d348e364865863b2c4fe542d8) refactor(syntax): separate out implementations
* [`a7b810a9`](https://github.com/doomemacs/doomemacs/commit/a7b810a93f05e4966d3dcce207c7c2ce77bd4039) fix(emacs-lisp): lexical argument, error popup
* [`1ddd74b0`](https://github.com/doomemacs/doomemacs/commit/1ddd74b003cf6b803c15a64a1e97bb754f042497) bump: :email wanderlust
* [`916c97bd`](https://github.com/doomemacs/doomemacs/commit/916c97bdf1add1f964ca630848bd2c5e544e21de) tweak(wanderlust): switch to alerting
* [`dbbd1f2b`](https://github.com/doomemacs/doomemacs/commit/dbbd1f2b01010c5f784241d066ccf586167b099c) tweak(wanderlust): don't show DKIM, ARC and similar signatures
* [`e09838e0`](https://github.com/doomemacs/doomemacs/commit/e09838e01ae42b1043b6e5f7262e0a91270d173f) fix(wanderlust): avoid `File name too long...`
* [`ebcb383c`](https://github.com/doomemacs/doomemacs/commit/ebcb383c99008a25e1c4f1cb3ea2b80c645d2be6) tweak(wanderlust): do not truncate long subjects or mail lines
* [`a20ca0cc`](https://github.com/doomemacs/doomemacs/commit/a20ca0cc0a316881546bd6aaa0fe636ae0459ab4) fix(wanderlust): enforce `wl-message-id-domain` only on automatic gmail config
* [`a461a1f6`](https://github.com/doomemacs/doomemacs/commit/a461a1f62c625dcbaaa6ccb141ac945063f32b23) tweak(wanderlust): add +xface flag
* [`302b72d9`](https://github.com/doomemacs/doomemacs/commit/302b72d9ed0e90186d9c79730ee9b9927947495c) tweak(wanderlust): sane forward tag
* [`2c15e4e6`](https://github.com/doomemacs/doomemacs/commit/2c15e4e6fc2f8edb95ca0344364877b20a6483db) fix(evil): obsolete `evil-command-window` advice
* [`d509d8be`](https://github.com/doomemacs/doomemacs/commit/d509d8bea1ad27ab9b7e9ddca329f494686b336e) fix(file-templates): invalid function call
* [`66666859`](https://github.com/doomemacs/doomemacs/commit/66666859939a7a438c075ce7a3e49ea160417ec8) fix(emacs-lisp): add elisp flymake load path advice
* [`d1d0a7e2`](https://github.com/doomemacs/doomemacs/commit/d1d0a7e258c7cf33e3037d8e37506c03063bd059) fix(eshell): remove fish executable advice
* [`0290663c`](https://github.com/doomemacs/doomemacs/commit/0290663cf32dd2f6cbfff3ac22b2ff6843f1539f) fix(emacs-lisp): void-variable flycheck-disabled-checkers error
* [`82b6bd31`](https://github.com/doomemacs/doomemacs/commit/82b6bd31590d05307cdb1a9608ee0eadb3e375ca) docs(ivy): mention lowered `ivy-sort-max-size`
* [`d03ac051`](https://github.com/doomemacs/doomemacs/commit/d03ac051bfcb62f14ded89af413f220028698ee0) fix(coq): inhibit indent detection
* [`180ffd3f`](https://github.com/doomemacs/doomemacs/commit/180ffd3fa8243579e10a3e42efb6b678e6b0a2ac) release(modules): 24.02.0-dev
* [`ffd2654a`](https://github.com/doomemacs/doomemacs/commit/ffd2654aa3166f767ed2eafebfc9cae34d75f454) fix(emacs-lisp): non-package-mode: only enable in elisp buffers
* [`d38787ed`](https://github.com/doomemacs/doomemacs/commit/d38787edf48f4c08bdf7ea8b3b54fcbc268f13b5) bump: :lang emacs-lisp
* [`659f7bfc`](https://github.com/doomemacs/doomemacs/commit/659f7bfc71d4d321728a5b8d68c5d2cd218d3dcb) refactor!: deprecate IS-* OS constants
* [`fc6934c2`](https://github.com/doomemacs/doomemacs/commit/fc6934c24073f07c7caecba65bf303479ef036c7) refactor: introduce doom-module-load-path
* [`77ea4013`](https://github.com/doomemacs/doomemacs/commit/77ea4013dd1a13253a712e593265e8164c144fee) refactor: doom-module: conform variables to conventions
* [`3bea4f66`](https://github.com/doomemacs/doomemacs/commit/3bea4f66a8443ef8a0525bd3b180b0c650dccdb8) refactor(emacs-lisp): elisp-demos: reorganize Doom demos
* [`4c89262a`](https://github.com/doomemacs/doomemacs/commit/4c89262a6b51d391f6e57f510d30845b06aca42b) nit(emacs-lisp): reformat/revise comments
* [`66d70c38`](https://github.com/doomemacs/doomemacs/commit/66d70c38a6c567ca06c26de46a68500b9f6e29fc) docs: bump supported Emacs version to 29.2
* [`b4f39e53`](https://github.com/doomemacs/doomemacs/commit/b4f39e53698eaeb43a4277a057db91e418b0c590) nit: doom-modules: reformat & declare obsolete variables defs
* [`51dcb4dc`](https://github.com/doomemacs/doomemacs/commit/51dcb4dc997aca2d754d2df9b81e40ba1ae3f029) nit: fix s/make/bake typo
* [`7654262c`](https://github.com/doomemacs/doomemacs/commit/7654262cdca57e6cddcf1d5c6acb9381ddbd3bc6) tweak(lib): doom-info: show $EMACS/$EMACSDIR
* [`e0c9ef6a`](https://github.com/doomemacs/doomemacs/commit/e0c9ef6ad681548d27943f0a1b98cd790b347e16) bump: :lang ocaml
* [`be48f358`](https://github.com/doomemacs/doomemacs/commit/be48f3588b26aa92d7c0b9b8da30f8443a3857c3) bump: :lang org
* [`615a77fa`](https://github.com/doomemacs/doomemacs/commit/615a77fafcd5ca85c117cc7c91ea4f9a23c3739c) bump: :config
* [`210a5d41`](https://github.com/doomemacs/doomemacs/commit/210a5d416209d4f4a0866786935775c66d3e8a23) bump: :ui
* [`b070a801`](https://github.com/doomemacs/doomemacs/commit/b070a801ed3d95e896cf87044223d24dfb0a7b19) bump: :tools collab
* [`1a05e2fa`](https://github.com/doomemacs/doomemacs/commit/1a05e2fa6429adf3e4c0efbfda8fdee9e9279600) bump: :tools
* [`53998a02`](https://github.com/doomemacs/doomemacs/commit/53998a024965ddb328e9deea38c1e4089a1e5bb2) module: remove :tools gist
* [`151b67ba`](https://github.com/doomemacs/doomemacs/commit/151b67baf27bc17e2cfaf47253f66f7ffd43c5df) bump: :editor evil
* [`e701522d`](https://github.com/doomemacs/doomemacs/commit/e701522d680b54299d43f03bd0d8d00c19bfe28a) bump: :editor
* [`2f7d8f41`](https://github.com/doomemacs/doomemacs/commit/2f7d8f41e1ceeb38bec25113e1c50e6245be9c67) feat(lookup): add Kagi
* [`2ace9023`](https://github.com/doomemacs/doomemacs/commit/2ace90233cd6cc93fd82777b42e85ee4fe8e2bba) feat(org): add Kagi custom link type
* [`343c3a82`](https://github.com/doomemacs/doomemacs/commit/343c3a82b06a666da34a885a81a0c525529887fa) refactor: s/doom-modules-dirs/doom-module-load-path/
* [`f14e7907`](https://github.com/doomemacs/doomemacs/commit/f14e7907f63bfade786d930dcbe452069cab7587) fix: doom-module-locate-paths: remove file-name-sans-extension call
* [`ce6ea7d8`](https://github.com/doomemacs/doomemacs/commit/ce6ea7d85f35813dca9202e29346faed98bbfb53) bump: :lang
* [`75ff47ae`](https://github.com/doomemacs/doomemacs/commit/75ff47aef03e65cb419c926a77e48635a25c9f5c) bump: :app
* [`4cb06578`](https://github.com/doomemacs/doomemacs/commit/4cb06578fc8341cefe8793b3f370cd22e88ce37f) bump: :completion
* [`792c41f6`](https://github.com/doomemacs/doomemacs/commit/792c41f638907e2515956d29c6aaf1f65ec39747) bump: :email mu4e notmuch
* [`e242ac95`](https://github.com/doomemacs/doomemacs/commit/e242ac9548487ae50857ec1b169a20d946019816) bump: :emacs
* [`83f5c4f8`](https://github.com/doomemacs/doomemacs/commit/83f5c4f81844364733f09a545807585161036e91) bump: :input
* [`36385091`](https://github.com/doomemacs/doomemacs/commit/36385091e89206dda7a8453cd90345fdba5442b2) bump: :os tty
* [`7afc21a6`](https://github.com/doomemacs/doomemacs/commit/7afc21a65262cd52b1a35bd2ee8e5d0321a6fbe9) fix(magit): remove lazy emacsqlite build hack
* [`d124c7d1`](https://github.com/doomemacs/doomemacs/commit/d124c7d19c5910ee4b66d2a41ac2fdfe93ed5bd5) bump: code-review
* [`bd6a382b`](https://github.com/doomemacs/doomemacs/commit/bd6a382b1804e8193932f68ac6a95a6aca0beaa1) fix(dired): void-variable dired-omit-files error
* [`ba09e432`](https://github.com/doomemacs/doomemacs/commit/ba09e4323ad629ca0ef86e58f43fab976f88b8c4) bump: :core
* [`3dbbd8b6`](https://github.com/doomemacs/doomemacs/commit/3dbbd8b68d99d04f0020e5fdb0dd2a7fb841a045) feat(common-lisp): introduce `sly-overlay`
* [`eb4e8960`](https://github.com/doomemacs/doomemacs/commit/eb4e8960af0570bac997cb3c70cb39a7d9b16a24) refactor: remove all-the-icons
* [`fe186403`](https://github.com/doomemacs/doomemacs/commit/fe18640376b1bbbb4e084305abbeee41f137eaa7) fix: --profile switch in noninteractive sessions
* [`5c3b8203`](https://github.com/doomemacs/doomemacs/commit/5c3b8203350c2e9685754494cff90a14a056a3c9) fix: void-variable doom-modules-load-path error
* [`f55131f7`](https://github.com/doomemacs/doomemacs/commit/f55131f7458545903a2f9e9899d38e4363f35ec6) fix: early-init: expand string-remove-suffix
* [`2fb0bf98`](https://github.com/doomemacs/doomemacs/commit/2fb0bf98ae75836aed2473dce28f0dc21a1c0f1d) nit: early-init: revise comments
* [`a5ff292c`](https://github.com/doomemacs/doomemacs/commit/a5ff292cbd294f58b1b77e1e43e14f81f695b6e4) fix(emacs-lisp): 'defining as dynamic an already lexical var' error
* [`a2484538`](https://github.com/doomemacs/doomemacs/commit/a2484538b48237636a70e5b4ccd358a4fb03c13c) bump: :tools magit :emacs vc
* [`90dae259`](https://github.com/doomemacs/doomemacs/commit/90dae2594042ac73ea7e38fb044917e153e9ebeb) fix(cli): ensure $EMACSDIR/lisp/cli is in $DOOMPATH
* [`5ef7075f`](https://github.com/doomemacs/doomemacs/commit/5ef7075f9645a784657606f34e1129c6f6f607d2) nit(popup): mention post-command-select-window for 30.x+
* [`15339e46`](https://github.com/doomemacs/doomemacs/commit/15339e4671c2dfb06c8289e1ae6860e701a408b2) fix(lib): doom-project-find-file: cl-no-applicable-method project-root
* [`1b0af3bf`](https://github.com/doomemacs/doomemacs/commit/1b0af3bfc747d9ef4973af0b5698b1c71cff86f5) fix(lib): doom-project-find-file: remove +vertico/consult-fd-or-find
* [`4db34776`](https://github.com/doomemacs/doomemacs/commit/4db347769e1254e55365e3e8be41410c548f90b8) fix(file-templates): unknown directive error from __license-lgpl3
* [`b655f6aa`](https://github.com/doomemacs/doomemacs/commit/b655f6aa1f55c385f8821ffc29d950ec2b68a9b1) docs(fortran): show how to customize fprettier
* [`30a7f2d4`](https://github.com/doomemacs/doomemacs/commit/30a7f2d436b50645614b7734bacb104cf155437d) fix(lib): doom/sudo-find-file: expand given path
* [`d6db0312`](https://github.com/doomemacs/doomemacs/commit/d6db0312fdf8c3a69d1aac243808b824ec9491e7) tweak(org): honor default command when archiving
* [`52355c61`](https://github.com/doomemacs/doomemacs/commit/52355c6131fdddea578bf3de737a46c60852a127) fix(org): initialize eldoc in org-mode buffers
* [`3986ee6c`](https://github.com/doomemacs/doomemacs/commit/3986ee6c2b1b2629a12733017d675c9ac94a84ba) fix: exclude indent detection in derived modes
* [`fe776f8d`](https://github.com/doomemacs/doomemacs/commit/fe776f8d84027759482c59bcb360b8eaef756864) fix(vertico): use remote fd in tramp buffers
* [`77105188`](https://github.com/doomemacs/doomemacs/commit/771051886912f934cdbc21a22abdc7c173c9f170) bump: :email wanderlust
* [`86516511`](https://github.com/doomemacs/doomemacs/commit/8651651125f8009b669f0297c63683968a8f014e) tweak(wanderlust): don't show DomainKey-Signature
* [`20de3d0f`](https://github.com/doomemacs/doomemacs/commit/20de3d0f29c1f4924611bfd72d39aae4fa51e3eb) refactor(format): introduce +format-functions
* [`e9ea3cc5`](https://github.com/doomemacs/doomemacs/commit/e9ea3cc5913cb0a996158a3cc855fe94c15a2b7d) feat(format): add eglot support
* [`9ba6d719`](https://github.com/doomemacs/doomemacs/commit/9ba6d7191ccb964584f0e392606ff6e5ccaa73db) refactor(format): improve lsp/eglot formatter dispatchers
* [`3acb75cb`](https://github.com/doomemacs/doomemacs/commit/3acb75cb166fcd947c7f87510377fc0fec4d458e) bump: :lang dart
* [`7984cd8e`](https://github.com/doomemacs/doomemacs/commit/7984cd8e0fee24738fe911365738f2fe634854bb) tweak(cli): use fancier string-dist suggestion alg
* [`8d4d8315`](https://github.com/doomemacs/doomemacs/commit/8d4d831565ca492572796612c7f23e588a37c7cf) dev: update license year
* [`1e8fd091`](https://github.com/doomemacs/doomemacs/commit/1e8fd0912009988ad101d3ead47c23b8e091699f) fix(format): +format-in-org-src-blocks-fn
* [`5c7149da`](https://github.com/doomemacs/doomemacs/commit/5c7149da670fa76f4422dee2e8b432a2af9189bc) docs(format): +format-in-org-src-blocks-fn: add docstring
* [`cce9438d`](https://github.com/doomemacs/doomemacs/commit/cce9438d9f7f28bb5ca3e05cf7c1202dff586956) fix(default): +evil module flag typo
* [`f0ad1616`](https://github.com/doomemacs/doomemacs/commit/f0ad161643c05842ca41bcb5daadcf7a7db98983) fix(org): list checkbox toggle on RET
* [`7a377348`](https://github.com/doomemacs/doomemacs/commit/7a3773484be37f389119513f5f77b0c32d984d3b) fix(doom): remove neotree icon config
* [`98d753e1`](https://github.com/doomemacs/doomemacs/commit/98d753e1036f76551ccaa61f5c810782cda3b48a) fix: blank frame on can't-find-font error during startup
* [`35dc1363`](https://github.com/doomemacs/doomemacs/commit/35dc13632b3177b9efedad212f2180f69e756853) bump: :lang rust
