### PR TITLE
niv nixpkgs: update cff84a20 -> da097873

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cff84a2086451a31a552a672da95f132bd7c10af",
-        "sha256": "02dlvx2c8gwnzl6h5bha8zg5p1v0jqaiq5vd0lgy4darfcxxsnka",
+        "rev": "da0978737fb4f334408c72205dc2b88c3ec1f2a7",
+        "sha256": "00aszaw3yyx9l1rkzza80vwin3xmp67wlrv5dd13931wan06xws3",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/cff84a2086451a31a552a672da95f132bd7c10af.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/da0978737fb4f334408c72205dc2b88c3ec1f2a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@cff84a20...da097873](https://github.com/nixos/nixpkgs/compare/cff84a2086451a31a552a672da95f132bd7c10af...da0978737fb4f334408c72205dc2b88c3ec1f2a7)

* [`510e3f22`](https://github.com/NixOS/nixpkgs/commit/510e3f228fa1dc292c1f4420df78f39069fc9b70) maintainers: add yamashitax
* [`99a9b795`](https://github.com/NixOS/nixpkgs/commit/99a9b79591e125025f414ab88ad2ae71970f3900) maintainers: add yamashitax
* [`efc57086`](https://github.com/NixOS/nixpkgs/commit/efc57086fb0a32d67bcfd7a202e7ecba4da497f8) tableplus: init at 504
* [`f41a52de`](https://github.com/NixOS/nixpkgs/commit/f41a52de42eb4858827fa7937489310a22c816e2) sensible-side-buttons: init at 1.0.6
* [`da32d38b`](https://github.com/NixOS/nixpkgs/commit/da32d38b1c52ba6d324ae382ec9d852b7c9da0f0) nixos/mosquitto: fix ACL permissions
* [`46bf5858`](https://github.com/NixOS/nixpkgs/commit/46bf58589263259c1981e2de9baf69a3406c5fbc) nixos/plymouth: drop the X11 renderer in the initrd
* [`67dac365`](https://github.com/NixOS/nixpkgs/commit/67dac36589251928d401285866f402ea09297181) xclicker: init at 1.5.0
* [`48839cd0`](https://github.com/NixOS/nixpkgs/commit/48839cd0f1c367ff498f964d23178c8c944173bc) go-errorlint: init at 1.4.5
* [`4e5dcf8a`](https://github.com/NixOS/nixpkgs/commit/4e5dcf8a026beeb736adb9b3a9f4df2fd7385b92) openrazer: 3.6.1 -> 3.7.0
* [`d97875bc`](https://github.com/NixOS/nixpkgs/commit/d97875bc5f50389a931fa857691abba4127899b1) spotifywm: migrate to by-name
* [`8d7184f6`](https://github.com/NixOS/nixpkgs/commit/8d7184f6ae4fc1ee19a86724c98cf5a6dcd32d91) ipam: init at 0.3.0-1
* [`2e267112`](https://github.com/NixOS/nixpkgs/commit/2e2671126e2e1af4621e31c159f1a32b0ef8a903) lesspipe: validate and add script dependencies
* [`d8062309`](https://github.com/NixOS/nixpkgs/commit/d8062309ce63c8cebfd642caee9b2e1fd8977f76) flake-checker: init at 0.1.16
* [`a911b97d`](https://github.com/NixOS/nixpkgs/commit/a911b97ded6db70126a506e4dd9f9d89e8daf014) zathura-pdf-poppler: 0.3.1 -> 0.3.2
* [`2f6b060f`](https://github.com/NixOS/nixpkgs/commit/2f6b060f74551d8e96f7191de3066606489c5cc9) tweak(zathura): 0.5.2 -> 0.5.4
* [`2c86e532`](https://github.com/NixOS/nixpkgs/commit/2c86e5321c8dd8204860a7e3d078e439980debae) nixos/photoprism: allow writing to originalsPath, importPath and
* [`1e5f255c`](https://github.com/NixOS/nixpkgs/commit/1e5f255c115bd2bc63c76f9775cbc1fa1b8de655) photoprism: 231011-63f708417 -> 231128-f48ff16ef
* [`807e5439`](https://github.com/NixOS/nixpkgs/commit/807e5439aff3fd3cf18a90eb3c6847a1ae742de1) dynamodb-local: 2023-12-14 -> 2.2.1
* [`70e0c91f`](https://github.com/NixOS/nixpkgs/commit/70e0c91fd60a97bb0109e22caa7a670eaa062e46) sentry-cli: Enable shell completions
* [`71cbe0d1`](https://github.com/NixOS/nixpkgs/commit/71cbe0d18a1ce1eddb12049bceaca0e91407ad4c) factor: Fix withLibs wrapper
* [`d167743c`](https://github.com/NixOS/nixpkgs/commit/d167743c728545a4b63ac669e79eaefe3b0df623) nixos/kanidm: declare `online_backup` options
* [`f1a7704d`](https://github.com/NixOS/nixpkgs/commit/f1a7704d476dea87f0b5164a8e903695356d132e) python311Packages.yaspin: force colored output in termwiz, remove outdated postPatch
* [`88aa9235`](https://github.com/NixOS/nixpkgs/commit/88aa923563f2373390d836e735b19478bf4339f4) python311Packages.yaspin: speed up tests with xdist
* [`b55e7091`](https://github.com/NixOS/nixpkgs/commit/b55e709167ec244a4e771249a0db220a6fd660f2) python311Packages.termcolor: update meta
* [`eec2de86`](https://github.com/NixOS/nixpkgs/commit/eec2de86cf4d141de08667251e8551bdd4907b3b) python312Packages.overrides: 7.4.0 -> 7.6.0
* [`82dda993`](https://github.com/NixOS/nixpkgs/commit/82dda993c6c5db2cf4532c96d8e4be232e9a8bd3) python312Packages.overrides: refactor
* [`d1c5a663`](https://github.com/NixOS/nixpkgs/commit/d1c5a6631c33fc37f2f25dfbc0a2c7a4d495849f) redocly-cli: 1.5.0 -> 1.6.0
* [`67e2f837`](https://github.com/NixOS/nixpkgs/commit/67e2f837f460f0a56c2e02cdf73b65a13102c89a) tuleap-cli: 1.0.0 -> 1.1.0
* [`6ab5992b`](https://github.com/NixOS/nixpkgs/commit/6ab5992b6f7fd627d73bb1b9064a259346c7ca39) slade: 3.2.4 -> 3.2.5
* [`ec1754f8`](https://github.com/NixOS/nixpkgs/commit/ec1754f86b482f94671992852731b8eee34e5b6c) slade: fix GLib-GIO-ERROR
* [`17783e08`](https://github.com/NixOS/nixpkgs/commit/17783e08cd76e68051dbf4f838f93df4ebb590ff) slade: set GDK_BACKEND to x11
* [`c93716a0`](https://github.com/NixOS/nixpkgs/commit/c93716a025ccf695e982d93a8148279fb58d6c34) chrysalis: move to `pkgs/by-name`
* [`ee66b695`](https://github.com/NixOS/nixpkgs/commit/ee66b69564c67bc21fb6ef21504332c0aefe12cc) chrysalis: add eclairevoyant, nshalman to maintainers
* [`6d1da358`](https://github.com/NixOS/nixpkgs/commit/6d1da3580bb9ff1fe3624aee3d2629bd6446daed) chrysalis: set `passthru.updateScript`
* [`cd9b5900`](https://github.com/NixOS/nixpkgs/commit/cd9b5900bc7c84f0d854b32a723fdc108b2e6709) chrysalis: 0.13.2 -> 0.13.3
* [`2bc69ea0`](https://github.com/NixOS/nixpkgs/commit/2bc69ea034d5486ff687c00335ba2d020e7535d6) transfer-sh: init at 1.6.1
* [`01e674ba`](https://github.com/NixOS/nixpkgs/commit/01e674ba9038a1943d6227468501eef08735ead2) nixos/transfer-sh: init
* [`2e4d7b7a`](https://github.com/NixOS/nixpkgs/commit/2e4d7b7ad23ce9e95d828fe02d9ef5be3dd9e7be) nixosTests.transfer-sh: init
* [`77013c44`](https://github.com/NixOS/nixpkgs/commit/77013c442ec421f5bc11da0b7a6ebb9953cd1bf3) nixos/transfer-sh: add release note
* [`9d5d6bf1`](https://github.com/NixOS/nixpkgs/commit/9d5d6bf1022986677628b749e1906074bdc45372) lutris: add gstreamer and plugins to fhsenv
* [`1dc5eb13`](https://github.com/NixOS/nixpkgs/commit/1dc5eb13b0fe25ce66928869821997d8202d240d) nixos/armagetronad: add module with tests
* [`00ab950f`](https://github.com/NixOS/nixpkgs/commit/00ab950f70707f4e1759af557d0a0bea53d10e34) nixos/armagetronad: changelog
* [`133992eb`](https://github.com/NixOS/nixpkgs/commit/133992eb0daca368c82be43ed81e65931bf6e989) nixos/armagetronad: add tests for trunk
* [`19efe422`](https://github.com/NixOS/nixpkgs/commit/19efe422f074a95f78006d390f29faa0a71af489) cataclysm-dda: Patch cataclysm-dda and cataclysm-dda-git.
* [`0672c66c`](https://github.com/NixOS/nixpkgs/commit/0672c66c6a64d83127852fbd49265a203ce364e0) composefs: 1.0.2 -> 1.0.3
* [`59bd96c8`](https://github.com/NixOS/nixpkgs/commit/59bd96c8bff89f9699a5e88119e0cd6a24618c98) taschenrechner: 1.3.0 -> 1.4.0
* [`04b1af40`](https://github.com/NixOS/nixpkgs/commit/04b1af40a1820577a7e4e6c4441a2479d16aece9) kubebuilder: 3.13.0 -> 3.14.0
* [`4bfdc257`](https://github.com/NixOS/nixpkgs/commit/4bfdc257933624b767febbae56b91e6adc550e90) livekit-cli: 1.3.4 -> 1.4.0
* [`384c0cf6`](https://github.com/NixOS/nixpkgs/commit/384c0cf6c114db182c01eeeeddb0e9e4c1c04d6c) lima: 0.19.1 -> 0.20.1
* [`499e0d4d`](https://github.com/NixOS/nixpkgs/commit/499e0d4d3b325ac85375fdc6f090397b1acc2293) python311Packages.databricks-sql-connector: 3.0.2 -> 3.0.3
* [`15ffc7c2`](https://github.com/NixOS/nixpkgs/commit/15ffc7c27f93afdfed90d4a07777a9711d75accd) node-problem-detector: 0.8.14 -> 0.8.15
* [`3074b2c4`](https://github.com/NixOS/nixpkgs/commit/3074b2c4f9b798dedb896d2515b601a8da0d3e34) ludtwig: 0.8.0 -> 0.8.1
* [`c3a83ec5`](https://github.com/NixOS/nixpkgs/commit/c3a83ec52068dbef9c6c122b9a4aa2202ace9a8a) maintainers: add MalteJanz
* [`a393b26e`](https://github.com/NixOS/nixpkgs/commit/a393b26ec073a9f5d1a249a4cd29857d8d5bc3c4) kube-score: 1.17.0 -> 1.18.0
* [`b35ce4dd`](https://github.com/NixOS/nixpkgs/commit/b35ce4dd457baf0e8614b7e7ca535344ac2f179f) acorn: 0.10.0 -> 0.10.1
* [`51957cea`](https://github.com/NixOS/nixpkgs/commit/51957cea324b98cacaa411ac25f536d1ba75f7aa) surge-XT: 1.2.3 -> 1.3.1
* [`82d8119d`](https://github.com/NixOS/nixpkgs/commit/82d8119dcaa7f8ac0c110ad5773f255ebeca3328) rootlesskit: 1.1.1 -> 2.0.1
* [`f9f509a8`](https://github.com/NixOS/nixpkgs/commit/f9f509a8a5204e82f243cf36e50ab7c55ae859f6) python311Packages.cli-helpers: 2.3.0 -> 2.3.1
* [`ab7fc081`](https://github.com/NixOS/nixpkgs/commit/ab7fc081d7724c8978fac0ddfa73355c596c169d) evtest-qt: 0.2.0 -> 0.2.0-unstable-2023-09-13
* [`521dad6d`](https://github.com/NixOS/nixpkgs/commit/521dad6d26990b4164d3f279384845e6fb03f688) swayrbar: 0.3.7 -> 0.3.8
* [`f6015bee`](https://github.com/NixOS/nixpkgs/commit/f6015bee6ca55efeb86deec03214a64c2256306d) gmni: disable `fortify3` to fix `gcc-13` build
* [`f08e6826`](https://github.com/NixOS/nixpkgs/commit/f08e682641212522ee7c23676af0bd20e25dc9bd) maintainers: add frankp
* [`e0064454`](https://github.com/NixOS/nixpkgs/commit/e0064454203fdd45fe35b34c5921844514311c88) graphia: 3.2 -> 4.2
* [`27488b86`](https://github.com/NixOS/nixpkgs/commit/27488b861c50f9354bf07e7228164f30c2e6d660) lib.trivial: Remove unneeded polyfills
* [`31d23ba4`](https://github.com/NixOS/nixpkgs/commit/31d23ba418c16c2c5c81439182ac41dca6fd323d) lib.attrsets: Remove unneeded polyfills
* [`46fd25dd`](https://github.com/NixOS/nixpkgs/commit/46fd25dda92b6bcd1baafb0df806f4fc18305305) lib.lists: Remove unneeded polyfills
* [`f2c83770`](https://github.com/NixOS/nixpkgs/commit/f2c837700d25999cad451e9167d2823981669676) lib.strings: Remove unneeded polyfill
* [`886e85f4`](https://github.com/NixOS/nixpkgs/commit/886e85f4f4503e4a3f5f81996e5068b029918e92) lib.versions: Remove unneeded polyfill
* [`f6334637`](https://github.com/NixOS/nixpkgs/commit/f633463751ac6c389bbaa54c369652450ab7ba6f) docker_25: init at 25.0.3
* [`bec91993`](https://github.com/NixOS/nixpkgs/commit/bec91993b235b6deb9b86fd024f466bbb33581fc) intune-portal: 1.2312.35-jammy -> 1.2401.21-jammy
* [`7d8674cf`](https://github.com/NixOS/nixpkgs/commit/7d8674cfcd8400a59c77a74b5eb41c829e84c5c5) kaniko: 1.20.0 -> 1.20.1
* [`be1320f4`](https://github.com/NixOS/nixpkgs/commit/be1320f4285720b694ebb176b3d1c7d408de3b60) maintainers: add litchipi
* [`dc2e2dbd`](https://github.com/NixOS/nixpkgs/commit/dc2e2dbdc4cca96b0c6a0546e11d1bb01c35f49f) python3Packages.mmengine: disable failing tests
* [`f10331cf`](https://github.com/NixOS/nixpkgs/commit/f10331cf2e8ebe5125f7890769861545d91a6690) buildLinux: passthru by <pkg>.overrideAttrs instead of lib.extendDerivation
* [`c218341c`](https://github.com/NixOS/nixpkgs/commit/c218341c52e5847dde6abfeafb54219509364d55) ripes: 2.2.6 -> 2.2.6-unstable-2024-01-02
* [`cb9957f8`](https://github.com/NixOS/nixpkgs/commit/cb9957f8eb2ab61f9810b054bdd7eabd0db20836) suricata: 7.0.2 -> 7.0.3
* [`165b98a4`](https://github.com/NixOS/nixpkgs/commit/165b98a4975930eb2fa575d88d577a9d7646d226) python311Packages.pytraccar: 2.0.0 -> 2.1.0
* [`406b7a1a`](https://github.com/NixOS/nixpkgs/commit/406b7a1a3a3fccc55ab05e349fe3d4d71932015d) nest-cli: 10.2.1 -> 10.3.2
* [`eb092f16`](https://github.com/NixOS/nixpkgs/commit/eb092f16260678e025d89cf308c0e69b40ec8d39) surge-XT: better version info
* [`41d6cdf1`](https://github.com/NixOS/nixpkgs/commit/41d6cdf14681337f9a2d980ccab8d273cb0d3a18) kubectl-gadget: 0.24.0 -> 0.25.1
* [`f5ce53fc`](https://github.com/NixOS/nixpkgs/commit/f5ce53fc03aaf521360496d5011d4fbc38cda819) kubernetes-controller-tools: 0.13.0 -> 0.14.0, add meta.changelog
* [`3e72e7c0`](https://github.com/NixOS/nixpkgs/commit/3e72e7c01483666a4465abfeefbcd4c668c79865) pkgs.formats: negative type checking tests
* [`8b2d86b9`](https://github.com/NixOS/nixpkgs/commit/8b2d86b982c5d5c6f4c7402546d32b17eb6b07f8) pkgs.formats: toINIWithGlobalSection wrapper
* [`80e79ded`](https://github.com/NixOS/nixpkgs/commit/80e79ded15d1fc954de36e3e7c77725ea3fb3489) nixos/unbound: check validity of config file
* [`b5512e34`](https://github.com/NixOS/nixpkgs/commit/b5512e34a703ce5c7007efca8f9dd1645208c300) govc: 0.34.2 -> 0.35.0
* [`86f57930`](https://github.com/NixOS/nixpkgs/commit/86f579309dd1b31b352e6c7e2908e10aba592845) foomatic-db-engine: unstable-2022-05-03 -> unstable-2024-02-10
* [`926c00c9`](https://github.com/NixOS/nixpkgs/commit/926c00c9215846cb951a735d04761bf73b2b95bc) open-scq30: init at 1.10.6
* [`a72076da`](https://github.com/NixOS/nixpkgs/commit/a72076da44595d07a4e17a0247c13a77bb4ff79c) maintainers: add leonm1
* [`6d693554`](https://github.com/NixOS/nixpkgs/commit/6d6935549997ea39cf5fa534c75456409c175482) python-matter-server: link PAA certificates locally
* [`c0846f90`](https://github.com/NixOS/nixpkgs/commit/c0846f900a71e9bde3bf292882506cbb7cc97528) matter-server: add nixos service module
* [`2e4c0b9d`](https://github.com/NixOS/nixpkgs/commit/2e4c0b9dbca62f407808c54c24fdf5426679cb56) ipset: 7.19 -> 7.21
* [`4e949b80`](https://github.com/NixOS/nixpkgs/commit/4e949b80155c45de77ea8e0b4fb34fced07ced75) adwsteamgtk: init at 0.6.9
* [`92bcc840`](https://github.com/NixOS/nixpkgs/commit/92bcc84087d365b3c5fd9cdd557a8d7f093fe284) maintainers: add NIS
* [`ac04ecba`](https://github.com/NixOS/nixpkgs/commit/ac04ecbace9586d12250bef0052d95bce230b48b) wofi: 1.4 -> 1.4.1
* [`76ce5620`](https://github.com/NixOS/nixpkgs/commit/76ce5620c0d6e08d8c75d53c88c96da09e47b051) tshark: 4.2.2 -> 4.2.3
* [`21f77255`](https://github.com/NixOS/nixpkgs/commit/21f77255c17b90297813cffb9d99df0902b3fad6) bitmagnet: 0.6.2 -> 0.7.0
* [`0115f32c`](https://github.com/NixOS/nixpkgs/commit/0115f32cc87be5851a487364be011cccffd44218) maintainers: add vizid
* [`c726cc28`](https://github.com/NixOS/nixpkgs/commit/c726cc28c8b30ad95e4ca820cb68a4261d7709b5) vultr-cli: 2.22.0 -> 3.0.0
* [`0703a702`](https://github.com/NixOS/nixpkgs/commit/0703a70295c335490abe01f45fe68aee65118d7c) OVMF: Expose flag to require SMM with secure boot
* [`d68a84a5`](https://github.com/NixOS/nixpkgs/commit/d68a84a55a49e40108662a3f974be18e631eb790) OVMF: Use larger flash size with secure boot.
* [`4673ad72`](https://github.com/NixOS/nixpkgs/commit/4673ad725460b0539f3bbe94494cc013260d4015) OVMF: Enable building an NVRAM variables template with MSFT keys.
* [`9188bb51`](https://github.com/NixOS/nixpkgs/commit/9188bb5186c88b9e98da1de9420e53bf9d68180d) OVMF: Add test with secure boot enabled
* [`fb19dea0`](https://github.com/NixOS/nixpkgs/commit/fb19dea01f706276f5db1efca4ced9286a70b876) arianna: add missing runtime dependency
* [`cc0a2c1f`](https://github.com/NixOS/nixpkgs/commit/cc0a2c1fb954edc1a003f108c0e37cc74726dfb4) ctranslate2: 3.24.0 -> 4.0.0
* [`b2d119e3`](https://github.com/NixOS/nixpkgs/commit/b2d119e3946ae9edfa0508bc93d8b2b96fdfc29f) sentry-cli: 2.28.0 -> 2.28.6
* [`1293f046`](https://github.com/NixOS/nixpkgs/commit/1293f046b500a2cd60ddf195639fae6419163931) nixos/dhcpcd: optimize exitHook
* [`f6fc51dc`](https://github.com/NixOS/nixpkgs/commit/f6fc51dc9ffa06e8a6f939e7ab52392824cbd79b) OVMF: Clean up platform-specific code.
* [`88a1349d`](https://github.com/NixOS/nixpkgs/commit/88a1349dfe606be461057b553087eb6b787b4118) OVMF: Enable bundling the MS secure boot variables on aarch64.
* [`d1d55137`](https://github.com/NixOS/nixpkgs/commit/d1d551370f44bb1103bd5215cafce5446d5de23e) rPackages.zlib: fix build
* [`bbd65614`](https://github.com/NixOS/nixpkgs/commit/bbd656149ec355fb65613536acc3f16c8c5e6748) rPackages.vdiffr: fixed build
* [`8ff37e16`](https://github.com/NixOS/nixpkgs/commit/8ff37e160cc4f98108d66937e67fb23cf4682271) python3Packages.datafusion: 25.0.0 -> 35.0.0
* [`9c9de33f`](https://github.com/NixOS/nixpkgs/commit/9c9de33ff23253d192ced20e0d3ea3dc43c72631) gitoxide: Install shell completions.
* [`0824756d`](https://github.com/NixOS/nixpkgs/commit/0824756d056e91cf1c40523877449a698ad71b77) coolercontrol.*: init at 1.1.1
* [`a2e95831`](https://github.com/NixOS/nixpkgs/commit/a2e9583124e8ced26993d09cd8546508c7c6ebf5) maintainers: Add Erethon
* [`bf842f91`](https://github.com/NixOS/nixpkgs/commit/bf842f9162becde65c9447cf81c1672a80435e2a) calico-pod2daemon: 3.27.0 -> 3.27.2
* [`f8cf3dda`](https://github.com/NixOS/nixpkgs/commit/f8cf3dda82b48f8f2d008bd5ecbbab4b57bb4e7d) vivaldi: 6.5.3206.55 -> 6.5.3206.63
* [`ca242116`](https://github.com/NixOS/nixpkgs/commit/ca242116af937160979b86a475059757098f322c) loramon: init at 0.9.7
* [`e4ed48d6`](https://github.com/NixOS/nixpkgs/commit/e4ed48d695e5305b05ccb27491b55c83cdffc65d) c-graph: init at 2.0.1
* [`07624abd`](https://github.com/NixOS/nixpkgs/commit/07624abd9dd71df3367256bb2ceb5ccc3b8253a8) tortoisehg:6.2.2->6.6.3
* [`aa61dcde`](https://github.com/NixOS/nixpkgs/commit/aa61dcde0c14ae4485e95ec194249264d37ea62c) maintainers: nu-nu-ko fix email address & add matrix
* [`99bebcbf`](https://github.com/NixOS/nixpkgs/commit/99bebcbfa4df466c05b9114510eb6d9124ef59ca) nixos-rebuild: avoid --preserve-env
* [`7ade924a`](https://github.com/NixOS/nixpkgs/commit/7ade924af4a96e0632165b219f7e236712516282) openvswitch: 3.2.2 -> 3.3.0
* [`f8fba904`](https://github.com/NixOS/nixpkgs/commit/f8fba9040230fbcd77b43b96c8c687525f5519bf) python311Packages.boschshcpy: 0.2.90 -> 0.2.91
* [`7a045c9b`](https://github.com/NixOS/nixpkgs/commit/7a045c9bf5cc6d00767bb01d2dff70cb0d833399) rPackages.RcppCWB:fix build
* [`76595e49`](https://github.com/NixOS/nixpkgs/commit/76595e496e8cfc6f81dc1f45fbef35e758be2e37) rPackages.Rbwa: added dep
* [`2cea1dce`](https://github.com/NixOS/nixpkgs/commit/2cea1dce6d9782a735101117dca35909aeabde70) nixos/dockerTools: make buildImageWithNixDb reproducible
* [`f7858eac`](https://github.com/NixOS/nixpkgs/commit/f7858eaca7bc832f0dc4202476131f52647924a4) level-zero: 1.15.8 -> 1.16.0
* [`46dbad85`](https://github.com/NixOS/nixpkgs/commit/46dbad85d818aee27040e983fa7c15173724f111) level-zero: 1.16.0 -> 1.16.1
* [`bbad81f9`](https://github.com/NixOS/nixpkgs/commit/bbad81f93796ffaafa1f5478e8425616a2513b0f) nixos/prometheus-nut-exporter: use extraFlags, add nutVariables option
* [`5ed5232e`](https://github.com/NixOS/nixpkgs/commit/5ed5232e96246e7a8659b984f4f5687f2cc13a8b) intel-graphics-compiler: 1.0.15610.11 -> 1.0.15985.7
* [`8cdc94a9`](https://github.com/NixOS/nixpkgs/commit/8cdc94a92ee3b999446c14e10185233930db16f6) intel-compute-runtime: 23.48.27912.11 -> 24.05.28454.6, add meta.changelog
* [`c8ee33f2`](https://github.com/NixOS/nixpkgs/commit/c8ee33f26efea5e1aadc9dfb8283ca31fe72c67e) last: 1541 -> 1542
* [`1fa3ff53`](https://github.com/NixOS/nixpkgs/commit/1fa3ff53f0e132eb958fddd4378607a7058137db) bolt: 0.9.6 → 0.9.7
* [`7aaaf870`](https://github.com/NixOS/nixpkgs/commit/7aaaf87075fcdbd7c61709f780bd0bffe4847348) livekit: 1.5.2 -> 1.5.3
* [`14af7f5c`](https://github.com/NixOS/nixpkgs/commit/14af7f5cf98644e3fee3fb0771979706af6b1d2b) i3status-rust: 0.32.3 -> 0.33.0
* [`712ac796`](https://github.com/NixOS/nixpkgs/commit/712ac796e5be1c6bcafad54d46b7cdcd7fdc7bcb) tests.nixpkgs-check-by-name: Improve inherit detection
* [`1930ecaa`](https://github.com/NixOS/nixpkgs/commit/1930ecaa743ad13353ea88424daf2c62e5071ce1) nixos/k3s: add test for etcd backend
* [`10f2ace2`](https://github.com/NixOS/nixpkgs/commit/10f2ace2cb92c78c359af8b06e95e358abd58a9f) etcd: add k3s test
* [`6925ff91`](https://github.com/NixOS/nixpkgs/commit/6925ff914efeb0efcccef09a0785abf1769b701e) vikunja-api, vikunja-frontend: drop
* [`a61c8c9f`](https://github.com/NixOS/nixpkgs/commit/a61c8c9f5c19030102f62820db1ad037311702f7) tests.nixpkgs-check-by-name: Fix allowing non-path overrides
* [`24069b98`](https://github.com/NixOS/nixpkgs/commit/24069b982dcb3b64bb3de2fc3c7b3463f4b00723) tests.nixpkgs-check-by-name: Better error for non-syntactic callPackage
* [`27ad0b68`](https://github.com/NixOS/nixpkgs/commit/27ad0b68c4eee6c80a24f57f8d6b3d4cfba354fe) valent: unstable-2023-11-11 -> 0-unstable-2024-02-12
* [`1c90f168`](https://github.com/NixOS/nixpkgs/commit/1c90f168ecd2048a4df5a5998c1b9ee9c5fcd361) rednotebook: 2.31 -> 2.32
* [`7c8cd2a3`](https://github.com/NixOS/nixpkgs/commit/7c8cd2a34db45d07d66ed8c14d5def33360ec674) jasper: 4.2.0 -> 4.2.1
* [`9f51aec0`](https://github.com/NixOS/nixpkgs/commit/9f51aec09c6a72a84d9cd8f467d1c8bcc8fbf0ac) ludtwig: 0.8.1 -> 0.8.2
* [`7f9bb710`](https://github.com/NixOS/nixpkgs/commit/7f9bb7103a3a88a7d216cf2550077ce07900997c) vikunja: init at 0.23.0
* [`8817f080`](https://github.com/NixOS/nixpkgs/commit/8817f080cc87c78d2cfda682a49201a5fe0f2eb8) nixos/vikunja: adapt for vikunja 0.23.0
* [`47b7eb8f`](https://github.com/NixOS/nixpkgs/commit/47b7eb8fd946cd4b8a62fc518147491479b5b925) nixos/vikunja: remove setupNginx option
* [`c1e8f0b5`](https://github.com/NixOS/nixpkgs/commit/c1e8f0b5cb3a1a00de46158192c11d9217567aaa) dnf5: 5.1.12 -> 5.1.13
* [`5cdcdca9`](https://github.com/NixOS/nixpkgs/commit/5cdcdca9b906a53309a3f5fe3aa18a66aaf22a68) kratos: 1.0.0 -> 1.1.0
* [`9b89ddca`](https://github.com/NixOS/nixpkgs/commit/9b89ddcab78486dafae41e83205add23950c3f18) twitterBootstrap: 5.3.2 -> 5.3.3
* [`a0b82650`](https://github.com/NixOS/nixpkgs/commit/a0b82650a8859b47b5eccde0eafe4d5315fb608e) python311Packages.azure-eventhub: 5.11.5 -> 5.11.6
* [`2c41d0b8`](https://github.com/NixOS/nixpkgs/commit/2c41d0b8f41dbd913d861c8a4e8ddfd0e39515f4) python311Packages.graphviz: use graphviz-nox
* [`14980426`](https://github.com/NixOS/nixpkgs/commit/14980426d44dc3f6dcf5c4a8ae920be623d15dfe) python311Packages.ibis-framework: 7.1.0 -> 8.0.0
* [`e57214d5`](https://github.com/NixOS/nixpkgs/commit/e57214d5d30567f01e76cdda35c72283cba1376e) mako: add sh to runtime PATH to enable exec functionality
* [`3e5c0ea7`](https://github.com/NixOS/nixpkgs/commit/3e5c0ea7180f4ad37253a279b2a3c2fa26032bb2) gthumb: 3.12.4 -> 3.12.5
* [`16f04ef9`](https://github.com/NixOS/nixpkgs/commit/16f04ef974fd20582d5a3f38a548237af509c9f1) python311Packages.awesomeversion: refactor
* [`e445d27f`](https://github.com/NixOS/nixpkgs/commit/e445d27fb35dd4e4bf290ae51d70fdcb5923c626) python311Packages.aiomysensors: 0.3.11 -> 0.3.12
* [`0204be32`](https://github.com/NixOS/nixpkgs/commit/0204be321362b11a43daf87ea78078115285c75f) mopidy-muse: 0.0.30 -> 0.0.33
* [`96e208a6`](https://github.com/NixOS/nixpkgs/commit/96e208a60558f7a6acb7b51cff2ac6339ab28a23) nixos/tests/consul: enable unfree
* [`fe93ea4e`](https://github.com/NixOS/nixpkgs/commit/fe93ea4e8e83444f5258d0e593420aac71d0d177) nixos/podman: pass proxy variables to podman API
* [`60c29e79`](https://github.com/NixOS/nixpkgs/commit/60c29e7948eeefeb977af7e3ab5b254ce87015ce) shotcut: 24.01.31 -> 24.02.19
* [`ee28c27e`](https://github.com/NixOS/nixpkgs/commit/ee28c27e50ce543f8d81bdf29a61c2815a138aec) one-click-backup: init at 1.2.2.1
* [`38e0e9b2`](https://github.com/NixOS/nixpkgs/commit/38e0e9b27c2e43f18362781590ae10a508daa5a8) eww: unstable-2023-08-18 -> 0.5.0
* [`07cc28b7`](https://github.com/NixOS/nixpkgs/commit/07cc28b7bccfd887edc550eb10701a93506a363d) eww: deprecate eww-wayland package
* [`d79ca3c1`](https://github.com/NixOS/nixpkgs/commit/d79ca3c1bf1b709114b1a6baec26b5948ed22964) nordic: 2.2.0-unstable-2024-01-20 -> 2.2.0-unstable-2024-02-20
* [`a06ddc3b`](https://github.com/NixOS/nixpkgs/commit/a06ddc3baeada4af902dca1d25585103e712f3b2) clusterctl: 1.6.1 -> 1.6.2
* [`e3e2deea`](https://github.com/NixOS/nixpkgs/commit/e3e2deea55ca6e165ef00654619dd90080d9356a) kubefirst: 2.3.7 -> 2.3.8
* [`2b97d363`](https://github.com/NixOS/nixpkgs/commit/2b97d363cab83fb39e3e913b841f0bb68ee934ff) nixos/lxc/generator: remove sysctl error handling
* [`27a7336d`](https://github.com/NixOS/nixpkgs/commit/27a7336d09acb12ecce92fc7885339c865420ff3) python311Packages.oci: 2.121.1 -> 2.122.0
* [`4b5e21db`](https://github.com/NixOS/nixpkgs/commit/4b5e21db21c398966364d33c16cdc88f8ed34750) unixODBCDrivers.mariadb: 3.1.14 -> 3.1.20
* [`6f947173`](https://github.com/NixOS/nixpkgs/commit/6f947173fd1cdcff5e88fdd2aa00aeb626b8c1bf) indexed-bzip2: 1.5.0 -> 1.6.0
* [`07175da1`](https://github.com/NixOS/nixpkgs/commit/07175da12d71e4b7b1c7254d5718d38193d86ac0) _86Box: 4.0.1 -> 4.1
* [`b177e9f7`](https://github.com/NixOS/nixpkgs/commit/b177e9f700ddb6cb25904da809f2cd10f8f47660) python311Packages.pyexiftool: init at 0.5.6
* [`54bc1877`](https://github.com/NixOS/nixpkgs/commit/54bc187764cacb1abb7681bf938f62d8c67ec243) talosctl: 1.6.4 -> 1.6.5
* [`c4b0abea`](https://github.com/NixOS/nixpkgs/commit/c4b0abeac88fc9039f7b2e5292576bc9b946d642) linkerd_edge: 24.2.3 -> 24.2.4
* [`cf4a6f91`](https://github.com/NixOS/nixpkgs/commit/cf4a6f914c627545a1c99c369e2f1561f4baea5c) kde-rounded-corners: 0.6.0 -> 0.6.1
* [`8ea05606`](https://github.com/NixOS/nixpkgs/commit/8ea05606c9462b758c349d94a4b6a0e8c8261069) jacktrip: 1.10.1 -> 2.2.2
* [`daac6630`](https://github.com/NixOS/nixpkgs/commit/daac6630129fafea40af0c52f499069144add47d) johnny-reborn: move to xesf fork
* [`a53b07e2`](https://github.com/NixOS/nixpkgs/commit/a53b07e2523978518efc6ae161ef9ffba7933d6e) tests.nixpkgs-check-by-name: Improve error for wrong package file
* [`7258d472`](https://github.com/NixOS/nixpkgs/commit/7258d472bcd8886be8b1463bea6030d1afe93bbf) tests.nixpkgs-check-by-name: Improve non-syntactic callPackage error more
* [`75cdccd6`](https://github.com/NixOS/nixpkgs/commit/75cdccd6c4753efe4fa543a05e4d1741cfb63218) tests.nixpkgs-check-by-name: Improve more errors
* [`e53dda13`](https://github.com/NixOS/nixpkgs/commit/e53dda131a6ecd9dbf69b995c0d69005f6f16463) oh-my-posh: 19.8.3 -> 19.11.4
* [`db7562e8`](https://github.com/NixOS/nixpkgs/commit/db7562e886d07ab365e8c55c50cf93dd709121ab) tests.nixpkgs-check-by-name: Improve errors relating to the base branch
* [`f5e9b88a`](https://github.com/NixOS/nixpkgs/commit/f5e9b88af41e5c11b766fa9846d5f65b68fb2351) tests.nixpkgs-check-by-name: Evaluate base and main branch in parallel
* [`eb1f0144`](https://github.com/NixOS/nixpkgs/commit/eb1f01440af0f73fdc8e4e214a9a8b70358df971) tests.nixpkgs-check-by-name: More consistent errors
* [`1c4308c3`](https://github.com/NixOS/nixpkgs/commit/1c4308c35211e91bb97dedaaa1f0cba6e5b8322c) tests.nixpkgs-check-by-name: Better error for empty second arg
* [`ce271786`](https://github.com/NixOS/nixpkgs/commit/ce271786deaef526b9c99da85bf84ab4ff24a472) tests.nixpkgs-check-by-name: More spaces in errors
* [`d2fa5baf`](https://github.com/NixOS/nixpkgs/commit/d2fa5bafa9faff354c13c3117deb3025ca4a5795) tests.nixpkgs-check-by-name: Improve errors for new packages
* [`64da6178`](https://github.com/NixOS/nixpkgs/commit/64da6178bf10b92f57352d7d0cfca7eebbd527df) tests.nixpkgs-check-by-name: Fix internal docs
* [`c1373dd3`](https://github.com/NixOS/nixpkgs/commit/c1373dd3abaa278382a45b35b9bd42d38e963707) mealie: init at v1.2.0
* [`4ebf2b54`](https://github.com/NixOS/nixpkgs/commit/4ebf2b54b09589e35eccb1a565bfb124cb7d09ba) nixos/mealie: init module
* [`ba9431ed`](https://github.com/NixOS/nixpkgs/commit/ba9431edf8c436efebe139ebb7aa5182952078da) nixos/mealie: add to release notes 24.05
* [`aeb79caa`](https://github.com/NixOS/nixpkgs/commit/aeb79caaf67e8aa73ac7b4b0a477f38b4d0cab09) nixos/mealie: init tests
* [`2a131312`](https://github.com/NixOS/nixpkgs/commit/2a131312733e8724eac622cefc12669df1fb0d80) snyk: 1.1276.0 -> 1.1280.1
* [`85944a93`](https://github.com/NixOS/nixpkgs/commit/85944a937b8bcb8bc0e584415db8c644ae53eabd) xcb-util-cursor: 0.1.4 -> 0.1.5
* [`992582fd`](https://github.com/NixOS/nixpkgs/commit/992582fdf8c0104f3d36af2bc956842dab3cbad2) nixos/pipewire: Fix capitalization
* [`054bba56`](https://github.com/NixOS/nixpkgs/commit/054bba560af06ef9ba53c00e154be2ad3238f811) nixos/pipewire: add config packages option
* [`5bf2637b`](https://github.com/NixOS/nixpkgs/commit/5bf2637b489091b787944d9d60b4e04878ac1b89) nixos/wireplumber: add config packages option
* [`e722c561`](https://github.com/NixOS/nixpkgs/commit/e722c5616095cf5cacc25acfb76ebf165be25feb) nixos/wireplumber: add required lv2 plugins to service path
* [`475ee3a1`](https://github.com/NixOS/nixpkgs/commit/475ee3a18ec12ab3f53a78875918a38b5a04d340) lib/tests/test-with-nix.nix: init
* [`00e660b3`](https://github.com/NixOS/nixpkgs/commit/00e660b3dc95b18d30c42e5478912e80384d53b8) tuxedo-keyboard: 3.2.7 -> 3.2.14
* [`dcfebbf0`](https://github.com/NixOS/nixpkgs/commit/dcfebbf0be37569e2f08a5e94cf34484583e1f19) byobu: 5.133 -> 6.12
* [`38a30e16`](https://github.com/NixOS/nixpkgs/commit/38a30e160df3949cd7737c0b1585d3b7bcfe2529) byobu: migrate to by-name
* [`b16061a4`](https://github.com/NixOS/nixpkgs/commit/b16061a4709510636cc4aad797c37271f186c12e) clash-meta: 1.16.0 -> 1.18.1
* [`20eadafb`](https://github.com/NixOS/nixpkgs/commit/20eadafbf92af4f983c22745d82552d79c5ccd8b) lightningcss: 1.23.0 → 1.24.0
* [`c38af0cb`](https://github.com/NixOS/nixpkgs/commit/c38af0cb0ada52ff6b1d0875881e7726edfa4ab8) python311Packages.msal: 1.26.0 -> 1.27.0
* [`5d57df8a`](https://github.com/NixOS/nixpkgs/commit/5d57df8a804b46f9071778e918a2c43f942faf42) nixos/monado: init
* [`90031675`](https://github.com/NixOS/nixpkgs/commit/90031675224ca0a530e377d8e8b4927db36ca256) xr-hardware: init at unstable-2023-11-08
* [`ce36e73f`](https://github.com/NixOS/nixpkgs/commit/ce36e73fdba7264db7296fcac045e41601683a66) nixos/monado: link OpenXR runtimes
* [`2d2493b2`](https://github.com/NixOS/nixpkgs/commit/2d2493b23dc35f552e13f6022b0ec4b2a4cdc7b1) nixos/monado: add option to make Monado the default OpenXR runtime
* [`8fc2690b`](https://github.com/NixOS/nixpkgs/commit/8fc2690b73a3c0376f69c34a37dc716c5d6bd6bd) nixos/monado: add test
* [`0e585a63`](https://github.com/NixOS/nixpkgs/commit/0e585a63e2f2ae03d658d41ab99cd41c0b0de9c1) nixos/monado: make CAP_SYS_NICE wrapper configurable
* [`3f7e9bae`](https://github.com/NixOS/nixpkgs/commit/3f7e9baeebab425f44caa19de37f004724c9c0fc) nixos/monado: prevent Monado from restarting quickly
* [`bd1ab122`](https://github.com/NixOS/nixpkgs/commit/bd1ab1222fa0dfddc297ef76b85d69d80395b6f4) python3Packages.chainstream: init at 1.0.1
* [`8a7bd071`](https://github.com/NixOS/nixpkgs/commit/8a7bd071c80325951d4fc24652777a99d2d524d8) rpl: 1.10 -> 1.15.5
* [`afc0e001`](https://github.com/NixOS/nixpkgs/commit/afc0e00116da5d0f9a65cc14f3fc9785cb6e0208) rpl: Set myself as maintainer
* [`cfb5ebb1`](https://github.com/NixOS/nixpkgs/commit/cfb5ebb12ddedd8246b51da6882fb43ea6cf2a38) python311Packages.azure-core: 1.28.0 -> 1.30.0
* [`36d5ef97`](https://github.com/NixOS/nixpkgs/commit/36d5ef97b3edd7e7371b56aec0a99c603b18da81) python311Packages.azure-keyvault-certificates: 4.7.0 -> 4.8.0
* [`6e689fe2`](https://github.com/NixOS/nixpkgs/commit/6e689fe2b84b9ab684d7ccbc09635d80dc3e8d2b) python311Packages.azure-keyvault-secrets: 4.7.0 -> 4.8.0
* [`c108636f`](https://github.com/NixOS/nixpkgs/commit/c108636f51436f997912a2bc02d93098e89f27cc) python311Packages.azure-keyvault-administration: 4.3.0 -> 4.4.0
* [`47fe3b9a`](https://github.com/NixOS/nixpkgs/commit/47fe3b9ac92d4a5c51b54d4f8f76633b22d662bd) lucenepp: Build with C++14 instead of C++11.
* [`ad7ffca7`](https://github.com/NixOS/nixpkgs/commit/ad7ffca7563c23324b7b2652ed7a7340d9f4c368) maintainers: add RudiOnTheAir
* [`dd2251d2`](https://github.com/NixOS/nixpkgs/commit/dd2251d23ec77c2bec50eac6b3ab571fe9cd1008) cargo-tally: 1.0.38 -> 1.0.39
* [`4af152de`](https://github.com/NixOS/nixpkgs/commit/4af152de2db21ffc14d6be7224e15f9191083fb3) libgrapheme: init at 2.0.2
* [`1436b102`](https://github.com/NixOS/nixpkgs/commit/1436b102a8f6255afb349d1e7cbe344e9f07e3ab) telescope: 0.8.1 → 0.9
* [`62d5a059`](https://github.com/NixOS/nixpkgs/commit/62d5a05922e1d017a555a8c34a16502ac5a2122e) telescope: migrate to by-name
* [`cc0e4bb8`](https://github.com/NixOS/nixpkgs/commit/cc0e4bb80cc14590122a72e1493a0a85aec3a999) incus.unwrapped: 0.5.1 -> 0.6.0
* [`59ad2a08`](https://github.com/NixOS/nixpkgs/commit/59ad2a08fb909dcbf1e7f4cc27ddb87f51b6daa1) python311Packages.google-cloud-artifact-registry: 1.11.1 -> 1.11.2
* [`e63cd645`](https://github.com/NixOS/nixpkgs/commit/e63cd6450a2d601d4a05db34947d00196fde497d) python311Packages.google-cloud-artifact-registry: refactor
* [`a0680338`](https://github.com/NixOS/nixpkgs/commit/a06803387a4688de2cef3a23286e9e5d34e94390) libretro.beetle-pce-fast: unstable-2024-02-16 -> unstable-2024-02-23
* [`892afda4`](https://github.com/NixOS/nixpkgs/commit/892afda4fa260f0b3efcda49e0d844829036b29a) cargo-make: migrate to by-name
* [`ac6f4419`](https://github.com/NixOS/nixpkgs/commit/ac6f4419ebd5f71305f43a932bb4e5d9a371f152) cargo-make: 0.37.9 -> 0.37.10
* [`09565cc4`](https://github.com/NixOS/nixpkgs/commit/09565cc420f88d7c943a0b46db0b34bd90473df7) libretro.fbneo: unstable-2024-02-18 -> unstable-2024-02-22
* [`6a0ad369`](https://github.com/NixOS/nixpkgs/commit/6a0ad369f2cc36c9229f0c260c23e36206a278b9) nixos/incus: assert nftables is used when firewall is enabled
* [`d1d19f98`](https://github.com/NixOS/nixpkgs/commit/d1d19f98dcd116cf54f7b8442dc1e7c9f75785cc) ocamlPackages.mirage-fs: remove at 4.0.0
* [`f47c6f64`](https://github.com/NixOS/nixpkgs/commit/f47c6f64e2df697ab87087e7b3f4b59d52986b1f) ratarmount: 0.14.0 -> 0.14.1
* [`d3e9c310`](https://github.com/NixOS/nixpkgs/commit/d3e9c310ec0e69352cd0c0b357a355a776e34d9f) r2modman: 3.1.46 -> 3.1.47
* [`a4850157`](https://github.com/NixOS/nixpkgs/commit/a4850157eeae2e70e28e02158240fd062f16bc5f) nrr: 0.5.2 -> 0.8.0
* [`023bc57d`](https://github.com/NixOS/nixpkgs/commit/023bc57dcc9a464314da2740ef056a740726f6ef) llvmPackages_17.mlir: cleanup
* [`0eff4594`](https://github.com/NixOS/nixpkgs/commit/0eff4594e91d441e7ffb82a9e173af73bf793584) python311Packages.cohere: 4.47 -> 4.49
* [`d5decf6e`](https://github.com/NixOS/nixpkgs/commit/d5decf6e964b50425195ea8fd831931bb10b064f) virtualbox: add disable update patch
* [`788e889a`](https://github.com/NixOS/nixpkgs/commit/788e889aad2384a1c358c2ce47aa37a0ee80827d) wit-bindgen: migrate to by-name
* [`5c4f5063`](https://github.com/NixOS/nixpkgs/commit/5c4f5063150e617847f17f7a351d49b4d6cc0580) wit-bindgen: 0.17.0 -> 0.19.1
* [`f844dad6`](https://github.com/NixOS/nixpkgs/commit/f844dad6ee0a58a7aebf16fd7c02c1bb93b3f6b2) unison: 2.53.2 -> 2.53.4
* [`f7feb162`](https://github.com/NixOS/nixpkgs/commit/f7feb162fcaae3424229fda6902e94882a9140f1) surrealist: init at 1.11.5
* [`07084b7f`](https://github.com/NixOS/nixpkgs/commit/07084b7f8ef38354fce74847a607d2e636d785ec) linux_xanmod: 6.6.17 -> 6.6.18
* [`4d3cafba`](https://github.com/NixOS/nixpkgs/commit/4d3cafbabd211e309d6a146368980bcc2aea7a8e) linux_xanmod_latest: 6.7.5 -> 6.7.6
* [`25577e45`](https://github.com/NixOS/nixpkgs/commit/25577e45ec4869eb674dcf34af380c3daa786f65) python3Packages.cbor2: 5.5.1 -> 5.6.2
* [`2125493c`](https://github.com/NixOS/nixpkgs/commit/2125493cbbe4e8b66261dbfdd8d2aa789890f42d) backblaze-b2: Remove kevincox as maintainer
* [`d03847b8`](https://github.com/NixOS/nixpkgs/commit/d03847b891478eef7dd2fc5a1198146a8938e89e) pythonPackages.phx-class-registry: Assign backblaze-b2 maintainers as maintainers
* [`a786cc02`](https://github.com/NixOS/nixpkgs/commit/a786cc022728cb7a109d2806942941d53db48bce) nixos/systemd-boot: fix cross for lint check
* [`3494cee9`](https://github.com/NixOS/nixpkgs/commit/3494cee9ba30b1f11b3237d85a06c2b2297c9ef7) bemoji: 0.3.0 -> 0.4.0
* [`5b23a962`](https://github.com/NixOS/nixpkgs/commit/5b23a9624a2be23fc52e017efd2a2794ff5954b1) sn0int: migrate to by-name
* [`341ed52e`](https://github.com/NixOS/nixpkgs/commit/341ed52eee24dcd3601fa66101d2f029a78000b0) sn0int: install shell completions
* [`29a5680f`](https://github.com/NixOS/nixpkgs/commit/29a5680fda42c0fbd5757cd7ba3e0c941f3a46bf) stereotool: init at 10.21
* [`51cc4a3f`](https://github.com/NixOS/nixpkgs/commit/51cc4a3f4bd1ea31108c9f7fb442a4dfe414ce72) python312Packages.yalexs-ble: 2.4.1 -> 2.4.2
* [`1c5e101f`](https://github.com/NixOS/nixpkgs/commit/1c5e101ff55122ee1b8affa6b76099d8d7f7203d) zimlib: 8.2.0 -> 9.1.0
* [`4811d1dc`](https://github.com/NixOS/nixpkgs/commit/4811d1dc9a38cd1cff52798954f9b94c42088b5f) python311Packages.habluetooth: 2.4.0 -> 2.4.1
* [`d6e0a220`](https://github.com/NixOS/nixpkgs/commit/d6e0a2203305a9255619d79d91170d690cc8b62c) incus: fix broken custom storage volume
* [`132162cb`](https://github.com/NixOS/nixpkgs/commit/132162cb7ac45a060227613b030e0a4a476bb0a1) ptcollab: 0.6.4.7 -> 0.6.4.8
* [`7653b430`](https://github.com/NixOS/nixpkgs/commit/7653b430de3f698e516db351d0d58080a96bdf1e) squeezelite: 2.0.0.1465 -> 2.0.0.1468
* [`80cbd94d`](https://github.com/NixOS/nixpkgs/commit/80cbd94dfd7af7fdb2360f811f0eab639f509fca) csvlens: 0.6.0 -> 0.7.0
* [`039ee782`](https://github.com/NixOS/nixpkgs/commit/039ee782b072514a789db39866a0f81daefbb5c1) itch: 26.1.2 -> 26.1.3
* [`78eaf072`](https://github.com/NixOS/nixpkgs/commit/78eaf072dbc1d0acb8b05077f11ecb109893a2c9) itch: migrate to by-name
* [`a556e7b7`](https://github.com/NixOS/nixpkgs/commit/a556e7b759fe0c4a566dca022e8bb5e01f3c68cf) butler: migrate to by-name
* [`0c475bf3`](https://github.com/NixOS/nixpkgs/commit/0c475bf346822b9aeca366ebf801128ca38f8f46) vimPlugins: update on 2024-02-24
* [`98111032`](https://github.com/NixOS/nixpkgs/commit/98111032e3744bbcf94c27b3ab6b32b6c034423f) python311Packages.boto3: refactor
* [`81745f10`](https://github.com/NixOS/nixpkgs/commit/81745f10589aed961196cbc7b46899f11f37c44a) stellar-core: fix `gcc-13` build
* [`468c1880`](https://github.com/NixOS/nixpkgs/commit/468c188091675dfc714a68b8114fe9e0c86efaaf) vimPlugins: resolve github repository redirects
* [`509550d6`](https://github.com/NixOS/nixpkgs/commit/509550d66043ab52cf1df0d30c1d9b23cc84ef03) vimPlugins.nvim-treesitter: update grammars
* [`7b1a32ed`](https://github.com/NixOS/nixpkgs/commit/7b1a32ed15e0f28b0648f00d8aad1c27cc3160d5) ueberzugpp: 2.9.2 -> 2.9.3
* [`be840e52`](https://github.com/NixOS/nixpkgs/commit/be840e52ede33d07d3de8d62405ddf4023c1195b) ueberzugpp: move to pkgs/by-name
* [`34faa136`](https://github.com/NixOS/nixpkgs/commit/34faa136b5ce017694b192e269d598e9c9a020b1) rPackages.pathfindR: fix missing java
* [`7d0c8129`](https://github.com/NixOS/nixpkgs/commit/7d0c8129637823fc83e2b0aff9a4e945add51af9) nixos/systemd: merge unit options as lists when at least one value is a list
* [`97cb79a7`](https://github.com/NixOS/nixpkgs/commit/97cb79a70e02d041921e7f4550bc3def103a72fc) ansel: unstable-2024-01-05 -> unstable-2024-02-23
* [`74401322`](https://github.com/NixOS/nixpkgs/commit/744013228595ac1174a1fae196428ec9deb656c1) matomo: 4.16.0 -> 4.16.1
* [`90b4aafc`](https://github.com/NixOS/nixpkgs/commit/90b4aafc3466438ca9e3cb2cde748d4599514394) spring-boot-cli: 3.2.2 -> 3.2.3
* [`96032264`](https://github.com/NixOS/nixpkgs/commit/96032264a9e0410cc460053090a44641b430507c) python311Packages.cloudsmith-api: 2.0.9 -> 2.0.10
* [`6e503cb3`](https://github.com/NixOS/nixpkgs/commit/6e503cb3cb1acee5137a9af12aeffe035bd47103) microsoft-edge: 121.0.2277.128 -> 122.0.2365.52
* [`ca27a037`](https://github.com/NixOS/nixpkgs/commit/ca27a037078dfb73e9b6b20129d9c05b07bf0ec7) semgrep: 1.61.1 -> 1.62.0
* [`8833ca12`](https://github.com/NixOS/nixpkgs/commit/8833ca128d83b6e71898ba580d45ec36c63fc428) python311Packages.langsmith: 0.1.6 -> 0.1.8
* [`7095b0a3`](https://github.com/NixOS/nixpkgs/commit/7095b0a3953fcddb9602098cd63424f632fa3083) processing: help wrapper find libgl
* [`ba7c7a09`](https://github.com/NixOS/nixpkgs/commit/ba7c7a0969db20db48920be0e5393d7f5b812b5b) processing: preserve pre/post phase hooks
* [`7d10a86b`](https://github.com/NixOS/nixpkgs/commit/7d10a86bebda2dd005354b65c1a13a4d152d8a3d) vimPlugins.nvim-spectre: update vendored rust dependency's hash
* [`31d75ec2`](https://github.com/NixOS/nixpkgs/commit/31d75ec2539fd4652b9bebd6bac9f23a45eba5e9) pg_featureserv: install assets and configuration file
* [`d45f71ee`](https://github.com/NixOS/nixpkgs/commit/d45f71eea33df4a9ce70e5106a843328be38f13f) pg_tileserv: install assets and configuration file
* [`ba939531`](https://github.com/NixOS/nixpkgs/commit/ba939531ffdc3c6fa750fe72a41fb9e654573552) mise: 2024.2.16 -> 2024.2.18
* [`f43fb4c1`](https://github.com/NixOS/nixpkgs/commit/f43fb4c110836bcbbbb5e6265f0d05293b819d7d) build-support/php: set `COMPOSER_ROOT_VERSION` by default
* [`f4c31eb9`](https://github.com/NixOS/nixpkgs/commit/f4c31eb9c516d2df638fe82ffac2b2dffac2e00c) phpPackages.psalm: 5.15.1 -> 5.22.2
* [`5949927f`](https://github.com/NixOS/nixpkgs/commit/5949927f4d48b1fd6c27340029a50b861c99624c) phpPackages.php-parallel-lint: use sources and fix broken package
* [`920095e5`](https://github.com/NixOS/nixpkgs/commit/920095e5fe2dda82446c6614cc25bfb69bcc68eb) keycloak-scim-user-storage-api: 20230710 -> 20240214
* [`a7ebf1c6`](https://github.com/NixOS/nixpkgs/commit/a7ebf1c693bb5a00725bd8b1c67c62be18b58fea) scrutiny-collector: 0.7.2 -> 0.7.3
* [`2ca773f9`](https://github.com/NixOS/nixpkgs/commit/2ca773f986ad10591015ca49352500b8b1553922) scrutiny: 0.7.2 -> 0.7.3
* [`ba9add0e`](https://github.com/NixOS/nixpkgs/commit/ba9add0e57a2b8e512b1f8a9196e1702638cf727) lightdm-gtk-greeter: 2.0.8 -> 2.0.9
* [`503df1ef`](https://github.com/NixOS/nixpkgs/commit/503df1ef98e71271b3df2c6f4096573cef7490bd) himalaya: 1.0.0-beta.2 -> 1.0.0-beta.3
* [`2ddb5573`](https://github.com/NixOS/nixpkgs/commit/2ddb55732b107858fcc37bf7149a587e4ef3d401) linuxKernel.kernels.linux_zen: 6.7.5-zen1 -> 6.7.6-zen1
* [`0eedc765`](https://github.com/NixOS/nixpkgs/commit/0eedc765e28b7c71234dfa037e79827abbcbf645) squirreldisk: init at 0.3.4
* [`39a93d3c`](https://github.com/NixOS/nixpkgs/commit/39a93d3ca4763a9615d5ba19c6d6aa3971a3920a) minio: 2024-02-17T01-15-57Z -> 2024-02-24T17-11-14Z
* [`a799f841`](https://github.com/NixOS/nixpkgs/commit/a799f841be804fa23c18dbffed972973acb26106) rippled: fix `gcc-13` build failure
* [`6b9d8372`](https://github.com/NixOS/nixpkgs/commit/6b9d8372d96daed7c924a2ae4d75b09dfa452198) satellite: init at 0.4.2
* [`cb7307a8`](https://github.com/NixOS/nixpkgs/commit/cb7307a8ac6ba8ecacb30a1fc3266c6b2a5c0731) python311Packages.dirtyjson: init at 1.0.8
* [`0b5ab1be`](https://github.com/NixOS/nixpkgs/commit/0b5ab1be1ef7493ec35e7428174becbe076b50eb) python311Packages.nest-asyncio: refactor
* [`c2927347`](https://github.com/NixOS/nixpkgs/commit/c29273470bfc74b14854d90ed215626e0a259a9f) python311Packages.nest-asyncio: 1.5.6 -> 1.6.0
* [`51ecaa3f`](https://github.com/NixOS/nixpkgs/commit/51ecaa3f46a8c06f0cf87c92e9b2c3fd36d29f0c) python311Packages.llamaindex-py-client: init at 0.1.13
* [`2d67ca9d`](https://github.com/NixOS/nixpkgs/commit/2d67ca9db442f78c6ee54ed96d95281e2b6b285f) python311Packages.llama-index-core: init at 0.10.12
* [`81d853a5`](https://github.com/NixOS/nixpkgs/commit/81d853a5496c1c6b0904e7e43b29ea695b12f406) python311Packages.llama-parse: init at 0.3.4
* [`f983edcf`](https://github.com/NixOS/nixpkgs/commit/f983edcf38bb15efc15a160ef434a3fa666331f9) python311Packages.llama-index-readers-llama-parse: init at 0.10.12
* [`1ab2a118`](https://github.com/NixOS/nixpkgs/commit/1ab2a118544bf36952dbb14542d101f500181d49) python311Packages.llama-index-readers-file: init at 0.10.12
* [`9bf729af`](https://github.com/NixOS/nixpkgs/commit/9bf729afde9db73fd6ceb8d55bb4e2ffb7ba946a) python311Packages.llama-index-llms-openai: init at 0.10.12
* [`49734027`](https://github.com/NixOS/nixpkgs/commit/4973402708a4806a4e9424bda05ccbf6174bcfb6) python310Packages.fairseq: fix build; disable hydra
* [`27b830f6`](https://github.com/NixOS/nixpkgs/commit/27b830f645e8002edb745bea303217861b80c074) quarto: 1.3.450 -> 1.4.550
* [`1332bc40`](https://github.com/NixOS/nixpkgs/commit/1332bc4068b8c273dc92dfd06d931f26a69df8fd) python311Packages.llama-index-agent-openai: init at 0.10.12
* [`d2fb7e18`](https://github.com/NixOS/nixpkgs/commit/d2fb7e18ce7d862af3694409396195b0fd3d8d93) python311Packages.llama-index-program-openai: init at 0.10.12
* [`f691d8d4`](https://github.com/NixOS/nixpkgs/commit/f691d8d4a709324718cb4bbe01cff8cfd2bd0110) python311Packages.llama-index-multi-modal-llms-openai: init 0.10.12
* [`2c93b5fb`](https://github.com/NixOS/nixpkgs/commit/2c93b5fb8b61a0ab1a1806a12da1bf794eb2856a) aspellDicts: extend cp1252 workaround to all platforms
* [`b7db6503`](https://github.com/NixOS/nixpkgs/commit/b7db65036f991e665b870c577c1f30ea5816e25d) python311Packages.llama-index-embeddings-openai: init at 0.10.12
* [`855b66ba`](https://github.com/NixOS/nixpkgs/commit/855b66babf77d8ba23339f346dfa1e3d1432a682) python311Packages.awscrt: 0.20.3 -> 0.20.4
* [`d18dac4a`](https://github.com/NixOS/nixpkgs/commit/d18dac4a36d35c0a30451d718ac7ff29f3180b15) popeye: 0.11.3 -> 0.20.3
* [`32e29f26`](https://github.com/NixOS/nixpkgs/commit/32e29f2639c1a96b3026ee9ec6182408b67aa412) probe-rs: 0.22.0 -> 0.23.0
* [`99699f99`](https://github.com/NixOS/nixpkgs/commit/99699f99a51a9c8a8757d56fbff9cecf26ac252f) python3Packages.pymatgen: 2022.3.29 -> 2024.2.23
* [`8d0197fe`](https://github.com/NixOS/nixpkgs/commit/8d0197fe1e40da9365a3e2af51309feb52de0f6f) php-codesniffer: init at 3.7.2, phpcs: deprecated, phpcbf: deprecated
* [`7491aa43`](https://github.com/NixOS/nixpkgs/commit/7491aa43a777881766e02f32c0e42b263d0a2469) phpPackages.deployer: 6.8.0 -> 7.3.3
* [`d653d780`](https://github.com/NixOS/nixpkgs/commit/d653d7800fef3b6b43aa695bdb7382eebb9990d2) phpPackages.phan: use `buildComposerProject` builder
* [`b7f3d0df`](https://github.com/NixOS/nixpkgs/commit/b7f3d0df8fb5cc7994aa04ca7552dff6dcd98cf1) phpPackages.phing: 2.17.4 -> 3.0.0-rc6
* [`dae4e32f`](https://github.com/NixOS/nixpkgs/commit/dae4e32f4b046943e3913f9dde7bebbcc2b1821b) phpPackages.phive: use `buildComposerProject` builder
* [`68866194`](https://github.com/NixOS/nixpkgs/commit/68866194354da5cc7cf69914049c30b57c93f02b) phpPackages.php-cs-fixer: use `buildComposerProject` builder
* [`ee4ecc33`](https://github.com/NixOS/nixpkgs/commit/ee4ecc331b0b691500ec293959a88da9d5e2873a) phpPackages.phpmd: use `buildComposerProject` builder
* [`42be235e`](https://github.com/NixOS/nixpkgs/commit/42be235ec004c9fe3579ca9ef3ea29f47e92f673) n98-magerun: use `buildComposerProject` builder
* [`b453c845`](https://github.com/NixOS/nixpkgs/commit/b453c845f6fbf9053a046d44406d987bc1613c7e) n98-magerun2: use `buildComposerProject` builder
* [`7e3f284f`](https://github.com/NixOS/nixpkgs/commit/7e3f284f13d90495963017c4b9d333b7440256c1) drush: removed, standalone installation are no more supported
* [`6addd082`](https://github.com/NixOS/nixpkgs/commit/6addd0822026c2d1f406d8c9b5d0398c6ec382d9) phpExtensions.blackfire: remove obsolete `inherit`
* [`ddb92f07`](https://github.com/NixOS/nixpkgs/commit/ddb92f079f20a7d67c018ae3dd0a38fd1318753f) phpExtensions.relay: remove obsolete `inherit`
* [`afaaaef4`](https://github.com/NixOS/nixpkgs/commit/afaaaef418cd0411c96eeae3e85e15c3bdbce05a) flottbot: 0.13.0 -> 0.13.1
* [`36cd3b49`](https://github.com/NixOS/nixpkgs/commit/36cd3b49146ca08c7258541641006f81859a18d6) python311Packages.cachecontrol: 0.13.1 -> 0.14.0
* [`83e0914c`](https://github.com/NixOS/nixpkgs/commit/83e0914cfd930c640d0b498ac3e5cdd9a38665c8) python311Packages.cachecontrol: add dotlambda to maintainers
* [`4d360599`](https://github.com/NixOS/nixpkgs/commit/4d3605998f76152c3941fb23964c168ad6f0b62e) signalbackup-tools: 20240221 -> 20240225
* [`086388fc`](https://github.com/NixOS/nixpkgs/commit/086388fc15419bd9000378056a4369f63948ab1a) mattermost: 8.1.10 → 9.5.1
* [`91df784a`](https://github.com/NixOS/nixpkgs/commit/91df784a3f6673f3e44d8dc0acc7ab94da45f39b) mattermost: add passthru.updateScript
* [`c75dd8bf`](https://github.com/NixOS/nixpkgs/commit/c75dd8bff734836bee446f35265c1584acc3ca0b) ollama: 0.1.24 -> 0.1.26
* [`e3e58cdc`](https://github.com/NixOS/nixpkgs/commit/e3e58cdc76be8c4133f03d57258ea0154b2bd174) davinci-resolve: 18.6.4 -> 18.6.5
* [`90115aa3`](https://github.com/NixOS/nixpkgs/commit/90115aa3885fafee9699eb5e7168aca49912e531) squirreldisk: fix build for aarch64-linux
* [`2ed1ebcb`](https://github.com/NixOS/nixpkgs/commit/2ed1ebcb1cb62ac3df2fccc2262c36f6265cbd6b) bun: 1.0.28 -> 1.0.29
* [`ee5c4a98`](https://github.com/NixOS/nixpkgs/commit/ee5c4a9850bdd6767334c1afd996d42cc7610f87) librewolf-unwrapped: 122.0.1-2 -> 123.0-1
* [`2892afca`](https://github.com/NixOS/nixpkgs/commit/2892afcaebe414b36cd2586eb47e49c17487d4cb) python311Packages.floret: fix build by supplying <cstdint>
* [`e34df654`](https://github.com/NixOS/nixpkgs/commit/e34df65424774e1a66b8a534332bc2f2101871b1) wttrbar: 0.7.1 -> 0.8.0
* [`30982c16`](https://github.com/NixOS/nixpkgs/commit/30982c16ea5badfe8eab5c2269f717e09e71c02d) discordo: unstable-2024-02-21 -> unstable-2024-02-25
* [`3f37e3f0`](https://github.com/NixOS/nixpkgs/commit/3f37e3f041cf37b3dbdfd38cdb41da861d5813c2) qlcplus: fix `gcc-13` build (drop `-Werror`)
* [`d21d21ca`](https://github.com/NixOS/nixpkgs/commit/d21d21ca253413ad72e00998218b77b7cd925bbf) esphome: 2024.2.0 -> 2024.2.1
* [`a9466871`](https://github.com/NixOS/nixpkgs/commit/a946687141af3618ec9edf81d17b16546edf2d80) python311Packages.bottleneck: 1.3.7 -> 1.3.8
* [`682f958f`](https://github.com/NixOS/nixpkgs/commit/682f958f762d767670b1cdbc5a5f3f6a1d1de57a) vscode-extensions.equinusocio.vsc-material-theme: 33.8.0 -> 34.3.1
* [`a00e878c`](https://github.com/NixOS/nixpkgs/commit/a00e878cb349df2837f4c746f61aeb5ddf4905ca) vscode-extensions.equinusocio.vsc-material-theme: fix user-settings
* [`70e834c1`](https://github.com/NixOS/nixpkgs/commit/70e834c19b24957546e5e54c9ffbe33ace422d27) ollama: refactor
* [`b8d8c1f2`](https://github.com/NixOS/nixpkgs/commit/b8d8c1f207a8c80f7267920efa70db785e5d441e) nixos/ollama: add option for hardware acceleration
* [`59a24057`](https://github.com/NixOS/nixpkgs/commit/59a240579c40ab80d299e30bf84b24b2892095c7) ollama: test that rocm and cuda build successfully
* [`db56bb47`](https://github.com/NixOS/nixpkgs/commit/db56bb4785a24782ca764a8df41bf6010e7ad1ef) dolt: 1.32.6 -> 1.34.3
* [`3b0e6fce`](https://github.com/NixOS/nixpkgs/commit/3b0e6fce08a495e9a85858fe57217d8c94a9bdcf) fm-go: init at 0.16.0
* [`bc616640`](https://github.com/NixOS/nixpkgs/commit/bc61664025b59162719e23d110a82fec7efc7530) python311Packages.google-cloud-securitycenter: 1.26.1 -> 1.27.0
* [`043c2547`](https://github.com/NixOS/nixpkgs/commit/043c254721543939684fcc02d290f72858476475) gegl: 0.4.46 → 0.4.48
* [`4836d98c`](https://github.com/NixOS/nixpkgs/commit/4836d98cfd6a45e261515b1506d763970d60e985) python311Packages.azure-eventhub: refactor
* [`7b7cebb5`](https://github.com/NixOS/nixpkgs/commit/7b7cebb5650ede702116a0370c1265180f4ceed1) git-together: init at 0.1.0-alpha.26
* [`0600791f`](https://github.com/NixOS/nixpkgs/commit/0600791f3ef36e36d702984e275f114295714d58) maintainers: add sentientmonkey
* [`98802aa7`](https://github.com/NixOS/nixpkgs/commit/98802aa75a940f0670aa433664f17ccec33e6e0d) edbrowse: migrate to by-name
* [`7659f7b3`](https://github.com/NixOS/nixpkgs/commit/7659f7b35b1e0192cc321922d84d75301b215f89) edbrowse: refactor
* [`cac6cb1f`](https://github.com/NixOS/nixpkgs/commit/cac6cb1f1354668eb70b1078398feeaed92f87a7) zapzap: 5.2 -> 5.2.1
* [`8adf6e8c`](https://github.com/NixOS/nixpkgs/commit/8adf6e8c4fc2e72bb2c50335fcbe11a5fe65ee39) python311Packages.enamlx: 0.6.2 -> 0.6.4
* [`74cfb74b`](https://github.com/NixOS/nixpkgs/commit/74cfb74bb2d7c062294962093bb5727a3b556f9e) cmctl: 1.14.2 -> 1.14.3
* [`b660c6fd`](https://github.com/NixOS/nixpkgs/commit/b660c6fdb96fed8794f7430bca888e3cfa554aa9) cargo-audit: 0.19.0 -> 0.20.0
* [`dcee7e76`](https://github.com/NixOS/nixpkgs/commit/dcee7e76e91609f17cb16bccff8a3b50ba5df8cb) python312Packages.sphinxcontrib-apidoc: 0.4.0 -> 0.5.0
* [`2cab47a2`](https://github.com/NixOS/nixpkgs/commit/2cab47a26a4058fd8a5cc57b3204c712b6bbd0da) avalanchego: 1.10.19 -> 1.11.1
* [`5a56dbf2`](https://github.com/NixOS/nixpkgs/commit/5a56dbf2db07767a83fc020a84c205db8d418fc7) edbrowse: enable Unix ODBC support
* [`26c37fca`](https://github.com/NixOS/nixpkgs/commit/26c37fca28c97d0431b403f4d6ba2bbdc39c0b3c) whois: 5.5.20 -> 5.5.21
* [`5135272c`](https://github.com/NixOS/nixpkgs/commit/5135272cb67ed613216928341e5f398269c4ee08) live555: 2023.11.30 -> 2024.02.15
* [`524a9eca`](https://github.com/NixOS/nixpkgs/commit/524a9eca5e9b7feb47671f04c10ca296d66b71ca) live555: 2024.02.15 -> 2024.02.23
* [`00be2993`](https://github.com/NixOS/nixpkgs/commit/00be2993bb1ffd06ddb6da94beacdabf37bd1f11) imagemagick: 7.1.1-28 -> 7.1.1-29
* [`9ae5e2dc`](https://github.com/NixOS/nixpkgs/commit/9ae5e2dc3901a97f3302bb3adad69b0e52334608) switcheroo-control: fix build
* [`5e721403`](https://github.com/NixOS/nixpkgs/commit/5e721403ec713b20a3e7e4c17d7adeadb6f4cb95) packet-sd: fix chmod application order
* [`d70c353c`](https://github.com/NixOS/nixpkgs/commit/d70c353c1646a35fc5e586c06cd6d1b78f67e839) nixos/switcherooControl: add package option
* [`2e312bb4`](https://github.com/NixOS/nixpkgs/commit/2e312bb486c0cea58c2d428d8c374b6e0af7e167) python312Packages.urwid-readline: refactor
* [`97c12ac3`](https://github.com/NixOS/nixpkgs/commit/97c12ac3507e44be7ff763cef4db50bf8b30ce9a) python312Packages.urwid-readline: 0.13 -> 0.14
* [`6d5db91a`](https://github.com/NixOS/nixpkgs/commit/6d5db91a7f633661e454c50ec40cfb76acf90b10) wpsoffice{-cn}: 11.1.0.11711 -> 11.1.0.11719
* [`e4dd0692`](https://github.com/NixOS/nixpkgs/commit/e4dd06921f048a0cf389a6f15a69a6f3beb001e7) wlogout: 1.1.1 -> 1.2
* [`c7604322`](https://github.com/NixOS/nixpkgs/commit/c76043228eb33e0b737a4177e1b0b759c3d23705) lightgbm: 4.1.0 -> 4.3.0
* [`e4999e39`](https://github.com/NixOS/nixpkgs/commit/e4999e399377a32686a80cac56f65bf798237529) bitwarden: remove unused patch
* [`eec60b7f`](https://github.com/NixOS/nixpkgs/commit/eec60b7f3cdcbdd41baf90e9b7e3a9247709eae0) bitwarden: move to pkgs/by-name
* [`0187d7e4`](https://github.com/NixOS/nixpkgs/commit/0187d7e4f40ea2bc8c16f6826d5b4e99da534184) bitwarden-cli: move to pkgs/by-name
* [`4ff953a9`](https://github.com/NixOS/nixpkgs/commit/4ff953a95a63cf5baf3583c515dd387f1e189fb7) bitwarden-desktop: rename from bitwarden
* [`b491aad7`](https://github.com/NixOS/nixpkgs/commit/b491aad7b36bc58ae4e85f9b18ebaee7b80d0930) bitwarden-desktop: replace patch with upstream URL
* [`ffe913a3`](https://github.com/NixOS/nixpkgs/commit/ffe913a31a02126c94a7e72bd7a426524cd20ec7) atlas: 0.19.0 -> 0.19.1
* [`882c2a8c`](https://github.com/NixOS/nixpkgs/commit/882c2a8ce4d912c570a67054947ff23d358e6e0e) uv: 0.1.10 -> 0.1.11
* [`5c58d65e`](https://github.com/NixOS/nixpkgs/commit/5c58d65ef564890f0160b16e78b2d64c0fd52691) rqbit: 5.4.2 -> 5.5.0
* [`0aca8bdd`](https://github.com/NixOS/nixpkgs/commit/0aca8bdd4a5f10838fc5e96d24abb9eddf8706f4) maintainers: add MichaelCDormann
* [`dbff1bf4`](https://github.com/NixOS/nixpkgs/commit/dbff1bf4de1787051259db1aecf92b669fefb49b) legit-web: 0.2.1 -> 0.2.2
* [`e6a6af3b`](https://github.com/NixOS/nixpkgs/commit/e6a6af3bec35ccbdc6f459703608050a83c4a34c) xmrig: 6.21.0 -> 6.21.1
* [`9df84e4c`](https://github.com/NixOS/nixpkgs/commit/9df84e4c3d9d2efbd581bbd72a6f8ffbdf5754d4) python312Packages.systembridgeconnector: 4.0.1 -> 4.0.2
* [`1021e65f`](https://github.com/NixOS/nixpkgs/commit/1021e65f2575fb699779f3475c30941973b580e1) hcxtools: 6.3.2 -> 6.3.4
* [`03863969`](https://github.com/NixOS/nixpkgs/commit/03863969b717da4896652e05cc5c4c66afd18bef) rsgain: 3.4 -> 3.5
* [`eb5a11dd`](https://github.com/NixOS/nixpkgs/commit/eb5a11dd2910ebce53ee7a06eb96a4aa1a3154ac) hyprland-per-window-layout: 2.7 -> 2.8.1
* [`34c105aa`](https://github.com/NixOS/nixpkgs/commit/34c105aa3091ea3f79e4b4088f2087f8b856f122) supersonic-wayland: 0.9.0 -> 0.9.1
* [`84e65264`](https://github.com/NixOS/nixpkgs/commit/84e6526435d6044df40c884ddf36585123e6889e) whistle: 2.9.64 -> 2.9.65
* [`6bfbeaf6`](https://github.com/NixOS/nixpkgs/commit/6bfbeaf6aa460428a8d49c77c581886e41b57eaa) brev-cli: 0.6.273 -> 0.6.276
* [`c508803c`](https://github.com/NixOS/nixpkgs/commit/c508803c4d0d2bcec254890154f89d48c7651d1c) yq-go: 4.41.1 -> 4.42.1
* [`026674af`](https://github.com/NixOS/nixpkgs/commit/026674af7623435b9a2a6ffee67fe02a3b3f364f) ueberzugpp: 2.9.3 -> 2.9.4
* [`b872d25b`](https://github.com/NixOS/nixpkgs/commit/b872d25bf9b377ac951f06a3c0048e86c2da3f4b) signal-desktop-beta: 7.0.0-beta.1 -> 7.0.0-beta.2
* [`0fe033b2`](https://github.com/NixOS/nixpkgs/commit/0fe033b2327597ee8bdbdbc61059d144a0f25ea9) obs-studio-plugins.waveform: 1.7.0 -> 1.8.0
* [`14f52c51`](https://github.com/NixOS/nixpkgs/commit/14f52c51618229613efc88d3df384cb85ded9812) python311Packages.sapi-python-client: 0.7.1 -> 0.7.2
* [`bc97cf46`](https://github.com/NixOS/nixpkgs/commit/bc97cf467b38a3668fe96df3c70cb6a624ef4c1f) python311Packages.appthreat-vulnerability-db: 5.6.3 -> 5.6.4
* [`09a92121`](https://github.com/NixOS/nixpkgs/commit/09a92121c53efa0071f3a02456c4f7ef674c1102) python311Packages.yalexs: 1.11.2 -> 1.11.3
* [`eb74747f`](https://github.com/NixOS/nixpkgs/commit/eb74747f38d83f83aa6aace76e3f76a76194b081) nixos/pipewire: add LV2 plugins option
* [`0bd4cef2`](https://github.com/NixOS/nixpkgs/commit/0bd4cef20a4255800a36927e1d6f02a2c21c1633) python311Packages.yalexs: refactor
* [`f5bed206`](https://github.com/NixOS/nixpkgs/commit/f5bed20627a7bae2170c5cee0a50e05dbccb653c) beeper: 3.96.30 -> 3.97.44
* [`1d277ef7`](https://github.com/NixOS/nixpkgs/commit/1d277ef74125800f68abf2ae829e1e6693472346) git-releaser: 0.1.2 -> 0.1.3
* [`586f528d`](https://github.com/NixOS/nixpkgs/commit/586f528d1568ecbe74683878a931d726e2faf4ac) micropython: 1.22.1 -> 1.22.2
* [`51c9129b`](https://github.com/NixOS/nixpkgs/commit/51c9129bcf61f8c7341c575d095c4224f48bdc53) quaternion: 0.0.96-beta4 -> 0.0.96.1
* [`5af2b175`](https://github.com/NixOS/nixpkgs/commit/5af2b1756180a4d033d5691e6d0b309d1b27739d) wails: 2.7.1 -> 2.8.0
* [`14c955a7`](https://github.com/NixOS/nixpkgs/commit/14c955a77ee5adf5a45f6107afffd41b20fdaca2) vscode-extensions.uloco.theme-bluloco-light: init at 3.7.3
* [`53bb990c`](https://github.com/NixOS/nixpkgs/commit/53bb990cd02e921857d9c1fd6f6e6434f3758dbe) lomiri.lomiri-system-settings-unwrapped: init at 1.0.2
* [`429be394`](https://github.com/NixOS/nixpkgs/commit/429be39416b921a5af31eb76698956cfd9e95fba) lomiri.lomiri-system-settings-security-privacy: init at 1.0.2
* [`08ef9001`](https://github.com/NixOS/nixpkgs/commit/08ef9001677d64c88739cbeaa34879901e959ad4) lomiri.lomiri-system-settings: init at 1.0.2
* [`66129d5e`](https://github.com/NixOS/nixpkgs/commit/66129d5e24575468ad8feca2f035e33c7374e14a) tests/lomiri-system-settings: init
* [`a8bdc1dd`](https://github.com/NixOS/nixpkgs/commit/a8bdc1ddf68e7e7db7fb927259b66ddc4f1a6e63) gitea: 1.21.6 -> 1.21.7
* [`49179637`](https://github.com/NixOS/nixpkgs/commit/49179637b48023d68e6930d6af4869f11376bdb5) fuse-ext2: unstable-2020-07-12 -> 0.0.11
* [`1fd9f9fb`](https://github.com/NixOS/nixpkgs/commit/1fd9f9fbbb00b12c4863b1b55c0450c5d8253f3d) python311Packages.cloudpathlib: 0.17.0 -> 0.18.0
* [`b00c53e4`](https://github.com/NixOS/nixpkgs/commit/b00c53e4cae1ad821cc682497f4b047fd2e36e01) linux/hardened/patches/4.19: 4.19.306-hardened1 -> 4.19.307-hardened1
* [`ba1ea346`](https://github.com/NixOS/nixpkgs/commit/ba1ea346e08eef4aa90a81880a3b5dad36cae97c) linux/hardened/patches/5.10: 5.10.209-hardened1 -> 5.10.210-hardened1
* [`e04df474`](https://github.com/NixOS/nixpkgs/commit/e04df4742b02e10ae9fe95765b9646ad2b842d9e) linux/hardened/patches/5.15: 5.15.148-hardened1 -> 5.15.149-hardened1
* [`b833fc37`](https://github.com/NixOS/nixpkgs/commit/b833fc37a86d43f2439f5140c50dff8e7a7e75dc) linux/hardened/patches/5.4: 5.4.268-hardened1 -> 5.4.269-hardened1
* [`aff1004f`](https://github.com/NixOS/nixpkgs/commit/aff1004f12c81f4b4be9e119ef0c2bc8b28fa744) linux/hardened/patches/6.1: 6.1.78-hardened1 -> 6.1.79-hardened1
* [`5fcfd0a8`](https://github.com/NixOS/nixpkgs/commit/5fcfd0a8aec6324d2e8e68530561606ada441375) linux/hardened/patches/6.6: 6.6.17-hardened1 -> 6.6.18-hardened1
* [`8566d1b8`](https://github.com/NixOS/nixpkgs/commit/8566d1b8c6a6d862b7644c5ccf02d2d9fcd0435e) linux/hardened/patches/6.7: 6.7.5-hardened1 -> 6.7.6-hardened1
* [`d47dea2e`](https://github.com/NixOS/nixpkgs/commit/d47dea2ed2f116e6304b0f6dceadd1f95b4dcd8c) alacritty-theme: unstable-2024-02-11 -> unstable-2024-02-25
* [`b5468e9a`](https://github.com/NixOS/nixpkgs/commit/b5468e9ac3e667aee45e1d205620e1fd96b7c985) wiremock: 3.4.1 -> 3.4.2
* [`f51fe574`](https://github.com/NixOS/nixpkgs/commit/f51fe574acbc6f044b46da2ff40a6c35821723b3) fluent-icon-theme: 2023-06-07 -> 2024-02-25
* [`2b9f0438`](https://github.com/NixOS/nixpkgs/commit/2b9f0438230377995efb9a6efeec5f8572967643) zfs: update latestCompatibleLinuxPackages
* [`94cf4ea2`](https://github.com/NixOS/nixpkgs/commit/94cf4ea2ee3516607ff46f94bccd9b5a39c53b7a) searxng: unstable-2023-10-31 -> 0-unstable-2024-02-24 ([nixos/nixpkgs⁠#290962](https://togithub.com/nixos/nixpkgs/issues/290962))
* [`ff3ce791`](https://github.com/NixOS/nixpkgs/commit/ff3ce7917ca1c312fe47fa24188710a4db7a7764) python311Packages.ldfparser: 0.23.0 -> 0.24.0
* [`04abc678`](https://github.com/NixOS/nixpkgs/commit/04abc6788bf4ba3cd536c38a1483538a887da22d) libkiwix: 12.1.1 -> 13.1.0
* [`ce15c39c`](https://github.com/NixOS/nixpkgs/commit/ce15c39c7b3cc3c1fd49cedcee43310b2d893c95) python311Packages.oslo-db: 14.1.0 -> 15.0.0
* [`106c4ac6`](https://github.com/NixOS/nixpkgs/commit/106c4ac6aa6e325263b740fd30bdda3b430178ef) mongodb-4_4: 4.4.27 -> 4.4.28
* [`7e1aec7a`](https://github.com/NixOS/nixpkgs/commit/7e1aec7ad2b09ddd65e4e4d3ae27b000e81de18f) python311Packages.litellm: 1.26.8 -> 1.27.4
* [`f0fef1bf`](https://github.com/NixOS/nixpkgs/commit/f0fef1bf5bd366ad6b137aacbf6ea55900ca1004) wsjtx - docs: updated homepage ref
* [`46f6edbd`](https://github.com/NixOS/nixpkgs/commit/46f6edbd79ad46b4435c7fb1aa2a344d6530f63b) python311Packages.oslo-serialization: 5.3.0 -> 5.4.0
* [`4d63b277`](https://github.com/NixOS/nixpkgs/commit/4d63b2779f0b8ad397655b7e3aca530ec6bf7c13) fable: 4.12.2 -> 4.13.0
* [`f97e6cd0`](https://github.com/NixOS/nixpkgs/commit/f97e6cd0d01299575c08f1f4049898a66fa7252c) python311Packages.approvaltests: 10.4.0 -> 11.0.0
* [`6f1ce510`](https://github.com/NixOS/nixpkgs/commit/6f1ce51034f93ab9a2e113405c7748da42faa7ec) hyprshade: 3.0.2 -> 3.0.3
* [`6edee624`](https://github.com/NixOS/nixpkgs/commit/6edee624d05dc5b6fe938f35b90ff1359e047107) OVMF: Restore installation of OVMF.fd.
* [`950ac6fe`](https://github.com/NixOS/nixpkgs/commit/950ac6fe425d9020ccea2bbd93ae25269b547d86) rPackages.gifski: fixed build
* [`9690c76b`](https://github.com/NixOS/nixpkgs/commit/9690c76b4c1a48d394380ca31a9b71dc9334d263) python311Packages.sapi-python-client: 0.7.1 -> 0.7.2
* [`b3e58fae`](https://github.com/NixOS/nixpkgs/commit/b3e58fae720fb2bac13881d468d89077e4facfcf) python311Packages.xknxproject: 3.6.0 -> 3.7.0
* [`c786e63c`](https://github.com/NixOS/nixpkgs/commit/c786e63c704fb13cdfff7ac93285710baf76a603) doc: Fix typo resulting in broken link in manual
* [`4779b604`](https://github.com/NixOS/nixpkgs/commit/4779b60449eec7b38202ee971399e901e1eb96dd) python311Packages.xknx: 2.12.0 -> 2.12.1
* [`19d5c154`](https://github.com/NixOS/nixpkgs/commit/19d5c1544b546af519771c13c09a17280c122506) wttrbar: 0.8.0 -> 0.8.2
* [`f7b47a50`](https://github.com/NixOS/nixpkgs/commit/f7b47a50118c36f961d6516cbfb2de88fe63bb7a) prqlc: 0.11.1 -> 0.11.4
* [`578279f3`](https://github.com/NixOS/nixpkgs/commit/578279f34901571f8cb322381218d109e2c4fe23) ferium: 4.5.0 -> 4.5.2
* [`632f25be`](https://github.com/NixOS/nixpkgs/commit/632f25be6be21ea077bd94df90ff563bc3fd4428) tmuxPlugins.dracula: v2.2.0 -> v2.3.0
* [`e426a8f0`](https://github.com/NixOS/nixpkgs/commit/e426a8f09740106e2944be4c583894edcb04830c) lib: export attrsets.mergeAttrsList
* [`e320f924`](https://github.com/NixOS/nixpkgs/commit/e320f9245df0eace86c8f0e1c14dcb6b68e5f879) libvpl: patch to search `/run/opengl-drivers/lib/` for runtime implementations
* [`86145b95`](https://github.com/NixOS/nixpkgs/commit/86145b9573f98f671828d6f553c4a1229beefac9) python312Packages.myuplink: 0.4.1 -> 0.5.0
* [`354c8401`](https://github.com/NixOS/nixpkgs/commit/354c8401a456cac33a4f4e3a0d8abedb2364b3f5) rclone: update to fuse3
* [`e2db77a9`](https://github.com/NixOS/nixpkgs/commit/e2db77a986a5da16e664cc630376a03d4fae99fb) python311Packages.google-cloud-dataproc: 5.9.1 -> 5.9.2
* [`c91300cf`](https://github.com/NixOS/nixpkgs/commit/c91300cf577d1463d3becb22831cf310606c69b8) jasper: split outputs
* [`bba94d88`](https://github.com/NixOS/nixpkgs/commit/bba94d888559c7a6dd8741010f284afd18bb50f6) whitesur-gtk-theme: 2023-10-13 -> 2024-02-26
* [`8ee34a02`](https://github.com/NixOS/nixpkgs/commit/8ee34a02bc9716af7aa1a8e70bdf9612f876c36e) nix-your-shell: 1.4.0 -> 1.4.1
* [`4d6ea7fc`](https://github.com/NixOS/nixpkgs/commit/4d6ea7fc8a37dd87247b9b32d30e4c2050d5938f) onionshare: 2.6 -> 2.6.1
* [`8fb1a39e`](https://github.com/NixOS/nixpkgs/commit/8fb1a39e210e6325194e14167ce22abc1ab7346b) rust-analyzer-unwrapped: 2024-02-19 -> 2024-02-26
* [`cd2ec848`](https://github.com/NixOS/nixpkgs/commit/cd2ec848a90ffdbe716c8829e6c4f75406c5b1a3) kubernetes-helmPlugins.helm-unittest: 0.4.1 -> 0.4.2
* [`ace61596`](https://github.com/NixOS/nixpkgs/commit/ace615967148a3774537edada74fb19309b140bd) raspberrypi-eeprom: 2024.01.05-2712 -> 2024.02.16-271
* [`72f3c3e8`](https://github.com/NixOS/nixpkgs/commit/72f3c3e8e215923c6a4b4f85923faed4f4e7f3cf) rPackages.rmatio: fixed build
* [`9096ba15`](https://github.com/NixOS/nixpkgs/commit/9096ba15fa4a30a6eb3ff3dbdab1c46bf6a4722f) python311Packages.eigenpy: 3.3.0 -> 3.4.0
* [`cf110cad`](https://github.com/NixOS/nixpkgs/commit/cf110cadb9d14ba6b88578c6edb3b245f09537a4) kodiPackages.mediathekview: update script and dschrempf maintainer
* [`d49e40f8`](https://github.com/NixOS/nixpkgs/commit/d49e40f8f0945969eefc1ff5fded37d5370d4234) buildah-unwrapped: 1.34.0 -> 1.34.1
* [`e92e5ce3`](https://github.com/NixOS/nixpkgs/commit/e92e5ce3cc75ff04aeb839d6e4b0775e6cc2418a) sketchybar-app-font: 2.0.4 -> 2.0.5
* [`72def8da`](https://github.com/NixOS/nixpkgs/commit/72def8dad282f8e059a52ddd7bda814caf3b070c) {mfcj6510,mfcj470}dwcupswrapper: cleanup
* [`43847d7e`](https://github.com/NixOS/nixpkgs/commit/43847d7e8d53237765147de2eff94f886eafe31f) pyprland: 2.0.3 -> 2.0.4
* [`1cb3656c`](https://github.com/NixOS/nixpkgs/commit/1cb3656cf3f3fbbf1628f38652723d605a4299d4) jan: 0.4.6 -> 0.4.7
* [`542b6bf2`](https://github.com/NixOS/nixpkgs/commit/542b6bf2e82bf5468572af3cc112ac7a462a8950) composefs: inherit nixosTests
* [`6c0e4698`](https://github.com/NixOS/nixpkgs/commit/6c0e4698f09662f2f4359c82d2605f0de084f11c) linuxPackages.nvidiaPackages.production: 535.154.05 -> 550.54.14
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
