### PR TITLE
niv devenv: update fa9a708e -> 4eccee9a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "fa9a708e240c6174f9fc4c6eefbc6a89ce01c350",
-        "sha256": "0lk0w6nng98knd12ng77n1pg6iyp5hz52805kflcgisb3sw69yis",
+        "rev": "4eccee9a19ad9be42a7859211b456b281d704313",
+        "sha256": "1dq6ngwz33cminayxxd6gizhy4v4gr54i7f1ndfid79ffvp6kjsz",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/fa9a708e240c6174f9fc4c6eefbc6a89ce01c350.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/4eccee9a19ad9be42a7859211b456b281d704313.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@fa9a708e...4eccee9a](https://github.com/cachix/devenv/compare/fa9a708e240c6174f9fc4c6eefbc6a89ce01c350...4eccee9a19ad9be42a7859211b456b281d704313)

* [`674961d3`](https://github.com/cachix/devenv/commit/674961d302d37ade518e294a921671e953c59f2f) Add support for Vala
* [`209f16c5`](https://github.com/cachix/devenv/commit/209f16c520b42844dba50f5b722874eaccdecd20) Auto generate docs/reference/options.md
* [`f0319af4`](https://github.com/cachix/devenv/commit/f0319af4f966fb8bc25c6429f4f2e097e79116c2) Auto generate examples/supported-languages/devenv.nix
* [`0fb07521`](https://github.com/cachix/devenv/commit/0fb075217b628d29f32806226dd84a9a64953bd8) Add OpenTofu and use as default for aws-vault
* [`3cebaf80`](https://github.com/cachix/devenv/commit/3cebaf809c60569b84a46a6f2a1acf02acd0edf8) Auto generate docs/reference/options.md
* [`4eccee9a`](https://github.com/cachix/devenv/commit/4eccee9a19ad9be42a7859211b456b281d704313) Auto generate examples/supported-languages/devenv.nix
