### PR TITLE
niv home-manager: update 1d085ea4 -> 23ff9821

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d085ea4444d26aa52297758b333b449b2aa6fca",
-        "sha256": "0v2idasyxh8rsp4lkaph77ivc3ffwi8k2gk9h6rxvd5qxrfznb24",
+        "rev": "23ff9821bcaec12981e32049e8687f25f11e5ef3",
+        "sha256": "1xnpif3nsi9s4dxxcakax7xjw6pjyc6k79hw2s01jg1nww7plpw4",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1d085ea4444d26aa52297758b333b449b2aa6fca.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/23ff9821bcaec12981e32049e8687f25f11e5ef3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1d085ea4...23ff9821](https://github.com/nix-community/home-manager/compare/1d085ea4444d26aa52297758b333b449b2aa6fca...23ff9821bcaec12981e32049e8687f25f11e5ef3)

* [`ecfffe36`](https://github.com/nix-community/home-manager/commit/ecfffe363102f2c95bed6576465504c6a57bf8fe) river: fix systemd activation ([nix-community/home-manager⁠#5055](https://togithub.com/nix-community/home-manager/issues/5055))
* [`2f336776`](https://github.com/nix-community/home-manager/commit/2f3367769a93b226c467551315e9e270c3f78b15) Translate using Weblate (Portuguese (Brazil))
* [`0992b38e`](https://github.com/nix-community/home-manager/commit/0992b38e5e1f3fba5cf7d386a20a39ce8ea6ee3f) tests: add mkStubPackage in Nixpkgs overlay
* [`4de84265`](https://github.com/nix-community/home-manager/commit/4de84265d7ec7634a69ba75028696d74de9a44a7) fcitx5: fix tests
* [`d579633f`](https://github.com/nix-community/home-manager/commit/d579633ff9915a8f4058d5c439281097e92380a8) khal: fix contact integration ([nix-community/home-manager⁠#4836](https://togithub.com/nix-community/home-manager/issues/4836))
* [`23ff9821`](https://github.com/nix-community/home-manager/commit/23ff9821bcaec12981e32049e8687f25f11e5ef3) ci: bump DeterminateSystems/update-flake-lock from 20 to 21
