### PR TITLE
niv nixpkgs: update da097873 -> c41ece23

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -254,8 +254,8 @@ let
     fira-code
     font-awesome
     # (iosevka.override { privateBuildPlan = { family = "Iosevka Term"; design = [ "term" "ss08" ]; }; set = "term-ss08"; })
-    (iosevka-bin.override { variant = "sgr-iosevka-term-ss08"; })
-    (iosevka-bin.override { variant = "etoile"; })
+    (iosevka-bin.override { variant = "SGr-IosevkaTermSS08"; })
+    (iosevka-bin.override { variant = "Etoile"; })
     powerline-fonts
     powerline-symbols
     source-code-pro

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da0978737fb4f334408c72205dc2b88c3ec1f2a7",
-        "sha256": "00aszaw3yyx9l1rkzza80vwin3xmp67wlrv5dd13931wan06xws3",
+        "rev": "c41ece2391fdc2351e839a9d9bb9cc561480ddea",
+        "sha256": "0sh7ps4v334434w128a1z8p2ayrzqbp3hv2968l7f7fq4iwj9xfb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/da0978737fb4f334408c72205dc2b88c3ec1f2a7.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c41ece2391fdc2351e839a9d9bb9cc561480ddea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@da097873...c41ece23](https://github.com/nixos/nixpkgs/compare/da0978737fb4f334408c72205dc2b88c3ec1f2a7...c41ece2391fdc2351e839a9d9bb9cc561480ddea)

* [`ac78e8d2`](https://github.com/NixOS/nixpkgs/commit/ac78e8d26490906f9e0a5f275c56370fdb9d7c2f) octavePackages.signal: 1.4.3 -> 1.4.5
* [`75560978`](https://github.com/NixOS/nixpkgs/commit/755609786bd91c66de88673922c5be79f1e68830) liberfa: 2.0.0 -> 2.0.1
* [`fba9fda7`](https://github.com/NixOS/nixpkgs/commit/fba9fda7397faf230adc9224035fffac6bd71c00) nixos/tests/privoxy: Verify socks support
* [`c5a6e915`](https://github.com/NixOS/nixpkgs/commit/c5a6e915eca670dc7bae27661888b398213c003c) python311Packages.bc-detect-secrets: 1.4.30 -> 1.5.1
* [`0a454655`](https://github.com/NixOS/nixpkgs/commit/0a45465507d3ce0ab8948f1e9892fafc6441e06b) default jdk: 19 -> 21
* [`e4b8d803`](https://github.com/NixOS/nixpkgs/commit/e4b8d803b657035e7bd484e5a79bc8896996feea) junicode: 2.203 -> 2.204
* [`3e53f2b5`](https://github.com/NixOS/nixpkgs/commit/3e53f2b569c3463d314311c4c96947f0a1b9f8b9) lib/licenses: add xskat
* [`a1646919`](https://github.com/NixOS/nixpkgs/commit/a16469199953d74aa4a832eded584ed98eaef72a) xskat: change license to xskat
* [`d4a13075`](https://github.com/NixOS/nixpkgs/commit/d4a13075248705dab85a7218ccde8cbd4817e4b2) lib/licenses: add xinetd
* [`00aad0ec`](https://github.com/NixOS/nixpkgs/commit/00aad0ecd98f6bab86cd4a791083a19d60c7112c) xinetd: change license to xinetd
* [`a302ae8a`](https://github.com/NixOS/nixpkgs/commit/a302ae8adc0a9f89e5ade805e980e32b0de41eae) lib/licenses: add smlnj
* [`052fc661`](https://github.com/NixOS/nixpkgs/commit/052fc6613b77a5dd24240a16756c3a25adcf1efa) xfontsel: change license to x11, smlnj and mit
* [`03d654be`](https://github.com/NixOS/nixpkgs/commit/03d654beb03ee8d293785629f31bc50f113c0bca) welkin: change license to bsd3
* [`186ff75f`](https://github.com/NixOS/nixpkgs/commit/186ff75feed99ec1b9d6b4a97465ff99cb8140a9) vue: change license to ecl20
* [`00ed9a34`](https://github.com/NixOS/nixpkgs/commit/00ed9a344cb48ceeb56e0a1fcdebcfd0cca6564d) virtual-ans: chnage license to unfreeRedistibutable
* [`4cbf461f`](https://github.com/NixOS/nixpkgs/commit/4cbf461ffd3f493ce4e6b0f0c663df087c385c4a) vdrsymbols: change license to bitstreamVera and publicDomain
* [`346182c3`](https://github.com/NixOS/nixpkgs/commit/346182c334e4f9169cc262ac79c798b895002fe0) ubuntu-font-family: change license to ufl
* [`f465c29e`](https://github.com/NixOS/nixpkgs/commit/f465c29e045b32d8821f4d7b834f025db2f27c84) gst_all_1.gst-plugins-good: dlopen libsoup_3 with an absolute path
* [`95f9761f`](https://github.com/NixOS/nixpkgs/commit/95f9761fd96a64fd82ea6feb57b9cf190a636a50) lib/license: add dtoa
* [`ad306fc1`](https://github.com/NixOS/nixpkgs/commit/ad306fc1c89cd397c26aba7978a7eed77e515c2c) u9fs: change license to dtoa
* [`4711e886`](https://github.com/NixOS/nixpkgs/commit/4711e8868124ad860cea902b8ab6e3223e78a9e5) tty-clock: change license to bsd3
* [`3b388c96`](https://github.com/NixOS/nixpkgs/commit/3b388c963bff85c26a0b3d3c15f6685a9e3cf5b9) tinyxml: change license to zlib
* [`88c08be8`](https://github.com/NixOS/nixpkgs/commit/88c08be88ffd6266451c3a547122aa55f31a2576) taskopen: change license to gpl2Plus
* [`1f014124`](https://github.com/NixOS/nixpkgs/commit/1f014124f6cb768b2a68459ef71f71b5f907e309) conky: support cross compilation
* [`8252af0d`](https://github.com/NixOS/nixpkgs/commit/8252af0d74757042a8e1df773521a63c3ca69903) conky: enable Wayland support
* [`ac80e19d`](https://github.com/NixOS/nixpkgs/commit/ac80e19d8c1a117d653173ebd87aff9b150639b5) conky: remove upstreamed patch
* [`77288bdd`](https://github.com/NixOS/nixpkgs/commit/77288bdd80fdabb808e5ac603d9566eb382207a3) mypy: 1.5.1 -> 1.8.0
* [`732f1c1f`](https://github.com/NixOS/nixpkgs/commit/732f1c1f52a6fd1278091d6cf840bdb981069a73) proxysql: unpin libmicrohttpd
* [`4cdc2935`](https://github.com/NixOS/nixpkgs/commit/4cdc2935734651cf7585ca521a256ff97070fb07) libmicrohttpd: bump default 0.9.71 -> 0.9.74
* [`3dc65e9b`](https://github.com/NixOS/nixpkgs/commit/3dc65e9b2027466877097fcd8258048b88dcd6ec) taler: unpin libmicrohttpd
* [`b1419c93`](https://github.com/NixOS/nixpkgs/commit/b1419c93dafef777dc8bf2c6a7661614e39700c0) libjson-rpc-cpp: unpin libmicrohttpd
* [`05ee64b2`](https://github.com/NixOS/nixpkgs/commit/05ee64b27b0542965cb8b77a16498de7948a716a) libmicrohttpd: 0.9.74 -> 0.9.77
* [`2b9af270`](https://github.com/NixOS/nixpkgs/commit/2b9af27096395874bf66df2f6dc8cd0813bf745e) junicode: 2.204 -> 2.205
* [`0593d3b9`](https://github.com/NixOS/nixpkgs/commit/0593d3b9970083c4945b691a0afaf38496261bbe) kanagawa-gtk-theme: init at unstable-2023-07-03
* [`b2429f86`](https://github.com/NixOS/nixpkgs/commit/b2429f864b07ac8a2d238fb7316d1178cfe91de5) junicode: 2.205 -> 2.206
* [`de0a5c6a`](https://github.com/NixOS/nixpkgs/commit/de0a5c6a6bf2d0c4180bb95ae91be9f06eb28a1d) nixos/syncoid: add missing ZFS mount permission
* [`0d867b74`](https://github.com/NixOS/nixpkgs/commit/0d867b74bc64b8ef4f84943479f0b35e258e9d6b) vscode-extensions.ms-vscode.cpptools: aarch64 support
* [`64d85415`](https://github.com/NixOS/nixpkgs/commit/64d85415ee8ffcecdbd9ee97ab94e4641d46631b) nodejs: remove references to build dependencies
* [`6b70d2ca`](https://github.com/NixOS/nixpkgs/commit/6b70d2cafaee3c3202a777e9b7e9c24e8ebcda36) outline: use nodejs 20
* [`68500c37`](https://github.com/NixOS/nixpkgs/commit/68500c37a31b65a37bed7b7297fd51e1b2ddf194) ffmpeg: enable vulkan in small variant
* [`5ea2d3f8`](https://github.com/NixOS/nixpkgs/commit/5ea2d3f8b7e86a7ce7e20386377ec56fe1ea7b8e) python311Packages.patsy: 0.5.4 -> 0.5.6
* [`30fb6fa2`](https://github.com/NixOS/nixpkgs/commit/30fb6fa20a52a8db4d9e176d97c535358d44a67d) sqlcipher: 4.5.5 -> 4.5.6
* [`71793305`](https://github.com/NixOS/nixpkgs/commit/717933051c9cf8b8f862e743b7e9f75fca32991b) python312Packages.pyaml: 23.9.7 -> 23.12.0
* [`016a4360`](https://github.com/NixOS/nixpkgs/commit/016a436059667c68a886639fa6b77e27e9a2bd85) libyang: move to by-name; 2.1.128 -> 2.1.148
* [`921e21cf`](https://github.com/NixOS/nixpkgs/commit/921e21cf79f8dd299b0cdc77c34dab0640013cef) python311Packages.kubernetes: 28.1.0 -> 29.0.0
* [`58963330`](https://github.com/NixOS/nixpkgs/commit/5896333012c8c88da49b1b062280e5fa95a4ad54) spdlog: 1.12.0 -> 1.13.0
* [`cdd95bd3`](https://github.com/NixOS/nixpkgs/commit/cdd95bd39ce3ed3efc71698aa0adaf2160b4b3d6) nixos/nebula: default to port 0 for hosts other than lighthouse/relay
* [`bcc41ee9`](https://github.com/NixOS/nixpkgs/commit/bcc41ee917d22677923a5f3cafb26e22740d4bbe) uclibc: 1.0.44 -> 1.0.45
* [`11f0b99f`](https://github.com/NixOS/nixpkgs/commit/11f0b99fbb56eb3569e08b1b6f83c8f35fefed3e) mapproxy: 1.15.1 -> 2.0.2
* [`83edba3e`](https://github.com/NixOS/nixpkgs/commit/83edba3eb94d1182d37d08b0867e6f3ff2efbd47) python311Packages.podman: 4.8.2 -> 4.9.0
* [`67bfaf3d`](https://github.com/NixOS/nixpkgs/commit/67bfaf3d03df0a03aa3cf8722962c393e63f3713) doc: add note in Partitioning and formatting section
* [`b04217c0`](https://github.com/NixOS/nixpkgs/commit/b04217c07acc957fc292ab3d87eaedf472eedcd4) avahi: remove unused perl dependency
* [`55354746`](https://github.com/NixOS/nixpkgs/commit/553547465b9ed2868fc921845ed75bb22ed48fa2) python311Packages.bokeh: 3.3.3 -> 3.3.4
* [`0d13278b`](https://github.com/NixOS/nixpkgs/commit/0d13278ba64ddd244f25b7ee0d9daee2ce6a2925) vorta: 0.8.12 -> 0.9.1
* [`946c025a`](https://github.com/NixOS/nixpkgs/commit/946c025a5c11f5467260fc4de988975f134451a0) lego: 4.14.2 -> 4.15.0
* [`2356d90e`](https://github.com/NixOS/nixpkgs/commit/2356d90e39880756834d0d1dbbbace61e85fbead) mdevctl: 1.2.0 -> 1.3.0
* [`24255b19`](https://github.com/NixOS/nixpkgs/commit/24255b1985cd8a19b460b188b6c86ba528c01e1c) renderdoc: 1.30 -> 1.31
* [`5ca4b3b4`](https://github.com/NixOS/nixpkgs/commit/5ca4b3b443ca8eccbc8bac004a25e1e89cdf79d3) python311Packages.nilearn: 0.10.2 -> 0.10.3
* [`512e74fa`](https://github.com/NixOS/nixpkgs/commit/512e74fa8a1830c9895f85899b73d263e7827afb) nifi: 1.24.0 -> 1.25.0
* [`f2d559d5`](https://github.com/NixOS/nixpkgs/commit/f2d559d5630383c33f0054d581775fad3799f4c2) python311Packages.tsfresh: 0.20.1 -> 0.20.2
* [`c6d34d2e`](https://github.com/NixOS/nixpkgs/commit/c6d34d2ef31683d5e25c2ca826ed52d130a73bda) python311Packages.ppft: 1.7.6.7 -> 1.7.6.8
* [`4a523a72`](https://github.com/NixOS/nixpkgs/commit/4a523a72bd79b053734811e8530e25a96061d5e8) python311Packages.py3status: 3.55 -> 3.56
* [`a0dc93ec`](https://github.com/NixOS/nixpkgs/commit/a0dc93ec12b275935d464dacd3e6c8d40cc87991) s-tui: 1.1.4 -> 1.1.6
* [`7839bd4a`](https://github.com/NixOS/nixpkgs/commit/7839bd4abede9918935821e29c9367e82d824dd8) python311Packages.meshio: 5.3.4 -> 5.3.5
* [`5e0c7900`](https://github.com/NixOS/nixpkgs/commit/5e0c79009351e7645463e9cec717e2d2d7321d83) python311Packages.dash: 2.14.2 -> 2.15.0
* [`9ce5d4b4`](https://github.com/NixOS/nixpkgs/commit/9ce5d4b45e727bfbc745e49f9d3f36018d34384b) ytfzf: 2.6.1 -> 2.6.2
* [`528fde34`](https://github.com/NixOS/nixpkgs/commit/528fde34d45eeaef34bba2e6ee19f2a8e0579121) fetchmail: 6.4.37 -> 6.4.38
* [`60c52cdb`](https://github.com/NixOS/nixpkgs/commit/60c52cdb356c9ff0c4db5fa4b728477e68b6af16) diamond: 2.1.8 -> 2.1.9
* [`7fad8387`](https://github.com/NixOS/nixpkgs/commit/7fad8387e2ac1dfd3c43de9125a9bb59049c21fb) himitsu: 0.5 -> 0.6
* [`5c752e52`](https://github.com/NixOS/nixpkgs/commit/5c752e524021c9206f24fe6afc0343a52c72f20d) libnabo: 1.0.7 -> 1.1.0
* [`2cb56854`](https://github.com/NixOS/nixpkgs/commit/2cb56854584f760d457fab3d9f31702227d104fa) minizinc: 2.8.2 -> 2.8.3
* [`229974e0`](https://github.com/NixOS/nixpkgs/commit/229974e0e057373342a6599f8c75ee0f42926eac) pyrosimple: 2.12.1 -> 2.13.0
* [`dc10e2fc`](https://github.com/NixOS/nixpkgs/commit/dc10e2fcf4bb8555d2da179e596877f615ffd078) edid-decode: unstable-2022-12-14 -> unstable-2024-01-29
* [`83f8bd49`](https://github.com/NixOS/nixpkgs/commit/83f8bd4914865e4adba5fb0b63cc7b7cd40017ca) python311Packages.python-utils: 3.8.1 -> 3.8.2
* [`9a2cea90`](https://github.com/NixOS/nixpkgs/commit/9a2cea90faa8264ff4c9b80ef59dfc7616418220) python311Packages.numexpr: 2.8.7 -> 2.9.0
* [`d0ff9405`](https://github.com/NixOS/nixpkgs/commit/d0ff94057bce62c133c73318690ac4a1a860498c) python311Packages.dash: remove ansi2html from deps
* [`654f0f9d`](https://github.com/NixOS/nixpkgs/commit/654f0f9da644c141d6404781118237f68ba81306) tevent: 0.16.0 -> 0.16.1
* [`079edf52`](https://github.com/NixOS/nixpkgs/commit/079edf524df960cfd954e3b92e5b45e9c2d2f3c8) python312Packages.py-dmidecode: 0.1.2 -> 0.1.3
* [`a2e0285c`](https://github.com/NixOS/nixpkgs/commit/a2e0285cde305610cdaa96053961fd7a5f5e1912) libmediainfo: 23.11 -> 24.01
* [`0ff47e0e`](https://github.com/NixOS/nixpkgs/commit/0ff47e0eb1684204156d86e837ccb61690437f2d) stress-ng: 0.17.04 -> 0.17.05
* [`ba0eb24e`](https://github.com/NixOS/nixpkgs/commit/ba0eb24e27e91880030f759014600f8f3d2913a3) ghq: 1.4.2 -> 1.5.0
* [`99924315`](https://github.com/NixOS/nixpkgs/commit/999243158a0b86197ebbb5f930781563c44105e2) python311Packages.fastai: 2.7.13 -> 2.7.14
* [`6452b530`](https://github.com/NixOS/nixpkgs/commit/6452b5304c8c9aac38eeb232731f21ea33568431) python311Packages.dataclasses-json: 0.6.3 -> 0.6.4
* [`e7a2d8aa`](https://github.com/NixOS/nixpkgs/commit/e7a2d8aa18770a1ac2a2073a563ee298e7e7d90a) prometheus-restic-exporter: 1.4.0 -> 1.5.0
* [`de306fb3`](https://github.com/NixOS/nixpkgs/commit/de306fb3d64f5086fbf63fec1d104f7187512b0d) nixos/prometheus-restic-exporter: Use LoadCredential for password file
* [`8fb55db9`](https://github.com/NixOS/nixpkgs/commit/8fb55db962b66048c95fee0bf2dd1a79877574a7) runelite: 2.6.12 -> 2.6.13
* [`40128466`](https://github.com/NixOS/nixpkgs/commit/401284660925a278c7ed55908839180e9db12f86) python311Packages.xattr: 1.0.0 -> 1.1.0
* [`be41f86a`](https://github.com/NixOS/nixpkgs/commit/be41f86a80f9d6e5910ce153057560cb672a2b83) gcc: amend __FILE__ mangling patch to only affect `-fmacro-prefix-map=`
* [`ad28f28a`](https://github.com/NixOS/nixpkgs/commit/ad28f28a91a6e917bd479ec7d4d7886904db939d) python311Packages.xattr: refactor
* [`dc5b5a07`](https://github.com/NixOS/nixpkgs/commit/dc5b5a078bd10053cba75c3bc7e80c4b261a865d) python311Packages.django-treebeard: 4.7 -> 4.7.1
* [`d047b68a`](https://github.com/NixOS/nixpkgs/commit/d047b68ab2f93642b22521a0013a2e1629003d5a) cava: 0.10.0 -> 0.10.1
* [`595ba44d`](https://github.com/NixOS/nixpkgs/commit/595ba44d03698e833ba930cf04ce6c12165b45e6) acme-client: 1.3.2 -> 1.3.3
* [`1ec233ab`](https://github.com/NixOS/nixpkgs/commit/1ec233abe3ecb983bb83868c14d0ee7a033f96f1) rascal: 0.28.2 -> 0.33.8
* [`4ee0db61`](https://github.com/NixOS/nixpkgs/commit/4ee0db6137552b13dcd82b79d1d020fbf95bbb8b) easyeffects: 7.1.3 -> 7.1.4
* [`3a9f95f5`](https://github.com/NixOS/nixpkgs/commit/3a9f95f5bc1a9e2f3c1d5ef6c1abc073b014fdb0) swayimg: 2.0 -> 2.1
* [`8ae8de37`](https://github.com/NixOS/nixpkgs/commit/8ae8de37be6d0ad6c811f377738670de983074dd) snd: 24.0 -> 24.1
* [`a650532f`](https://github.com/NixOS/nixpkgs/commit/a650532fdbb1bb9220680782c57d79d24a7fe7c2) jose: 11 -> 12
* [`4cf6bc00`](https://github.com/NixOS/nixpkgs/commit/4cf6bc0080e442145c4796f68445c7d755c3243b) commonsBcel: 6.8.0 -> 6.8.1
* [`84c8bb51`](https://github.com/NixOS/nixpkgs/commit/84c8bb51c09fa78d846212fc7de51e976c9a75c9) python311Packages.django-debug-toolbar: 4.2 -> 4.3
* [`462a6d5c`](https://github.com/NixOS/nixpkgs/commit/462a6d5caaa02d1403da2de8f8815a771b454055) pioneer: 20220203 -> 20240203
* [`b13e32f1`](https://github.com/NixOS/nixpkgs/commit/b13e32f1f86d0f3768ec4b4c223e152b52ee0d5b) lyx: 2.3.6.1 -> 2.3.7-1
* [`529eb034`](https://github.com/NixOS/nixpkgs/commit/529eb034b10df5a2cc84ea94a719186d175612e4) python311Packages.grpcio-testing: 1.60.0 -> 1.60.1
* [`5a2f3cd7`](https://github.com/NixOS/nixpkgs/commit/5a2f3cd7b2b20aeedca4b1efc42c550eadf266e3) gensio: 2.8.2 -> 2.8.3
* [`b3cf3d89`](https://github.com/NixOS/nixpkgs/commit/b3cf3d89404d86c32318af8c0c159c81b3f50967) mediainfo: 23.11 -> 24.01.1
* [`17b380dd`](https://github.com/NixOS/nixpkgs/commit/17b380ddf755269cf2622c51aae5d7700ed6e64a) media-downloader: 4.2.0 -> 4.3.1
* [`d6a186c0`](https://github.com/NixOS/nixpkgs/commit/d6a186c0ec0e938c6bc7569f48ed45332018cc43) kode-mono: 1.205 -> 1.206
* [`04e86a6c`](https://github.com/NixOS/nixpkgs/commit/04e86a6c18e3e774ba53ac39fb3c2b6b6972be98) mpvScripts.mpvacious: 0.25 -> 0.26
* [`27a2693d`](https://github.com/NixOS/nixpkgs/commit/27a2693d87ade1e7c18315b74ae8086db999a383) python312Packages.rpy2: 3.5.14 -> 3.5.15
* [`5770fc70`](https://github.com/NixOS/nixpkgs/commit/5770fc7007fd7cf4604de417203a78cb28d72e72) tgpt: move to `pkgs/by-name`
* [`c55223e3`](https://github.com/NixOS/nixpkgs/commit/c55223e31425952af7005fe1e2378ae799c861dc) tgpt: set `passthru.updateScript`
* [`1e517999`](https://github.com/NixOS/nixpkgs/commit/1e5179996c3ba3599050514a616c2d583332873d) pulldown-cmark: 0.9.6 -> 0.10.0
* [`af8375bb`](https://github.com/NixOS/nixpkgs/commit/af8375bb3b61588b2bfb6ea3438c7efa71a95115) fits-cloudctl: 0.12.13 -> 0.12.16
* [`ec2d71a4`](https://github.com/NixOS/nixpkgs/commit/ec2d71a40f085253ce0b93c9b9a480d0022184f4) python312Packages.mysqlclient: 2.2.1 -> 2.2.3
* [`c8fb7e02`](https://github.com/NixOS/nixpkgs/commit/c8fb7e02dbf5477a6c834eeaa519816475897c8b) nwg-drawer: 0.4.3 -> 0.4.5
* [`2b600a72`](https://github.com/NixOS/nixpkgs/commit/2b600a72fc83cc97b0ed92f13c78c42c53552591) keepass: 2.55 -> 2.56
* [`32c68916`](https://github.com/NixOS/nixpkgs/commit/32c689167bdc8615244566e82f9ff13db48ce20f) span-lite: 0.10.3 -> 0.11.0
* [`972297f0`](https://github.com/NixOS/nixpkgs/commit/972297f0c50817588a5db4f7b2a6202deec26f04) nextdns: 1.41.0 -> 1.42.0
* [`b69ffeb3`](https://github.com/NixOS/nixpkgs/commit/b69ffeb3a27b44c811f2c2f744f616c049142901) apparmor-utils: fix aa-remove-unknown read check
* [`401f68c7`](https://github.com/NixOS/nixpkgs/commit/401f68c74ce3dfc2ddff6461fa85fff2462d0d06) gbsplay: 0.0.95 -> 0.0.96
* [`70181a6e`](https://github.com/NixOS/nixpkgs/commit/70181a6ea9608218387a3c3cce9c9df4a66047c0) qtractor: 0.9.38 -> 0.9.39
* [`76951b6f`](https://github.com/NixOS/nixpkgs/commit/76951b6fb1f8f4ccd8cd14d030646f1f6819db68) quick-lint-js: 3.0.0 -> 3.1.0
* [`9341515f`](https://github.com/NixOS/nixpkgs/commit/9341515f65a1c77a9425dfa91f9aa3ecd348d8b5) elasticsearch-curator: 8.0.8 -> 8.0.10
* [`c2fb2d03`](https://github.com/NixOS/nixpkgs/commit/c2fb2d03259dc1ad8b9d9c61a3a6168a0c79b51f) maintainers: add gwg313
* [`b7ba4e26`](https://github.com/NixOS/nixpkgs/commit/b7ba4e2692a845f7a2f0407ce359c963de0aa4d1) bozohttpd: 20220517 -> 20240126
* [`47c41495`](https://github.com/NixOS/nixpkgs/commit/47c4149589821a7e7b4f591084b2f6bc2b8fb5d3) python312Packages.types-pillow: 10.1.0.20240106 -> 10.2.0.20240206
* [`f2709f67`](https://github.com/NixOS/nixpkgs/commit/f2709f67a7fceb657634f0c05b9fe40388a7dd7c) linuxsampler: 2.2.0 -> 2.3.0
* [`f7a8f767`](https://github.com/NixOS/nixpkgs/commit/f7a8f767c3368c58b53f083925ecd6d22359588f) libgsf: 1.14.51 -> 1.14.52
* [`94a6ba90`](https://github.com/NixOS/nixpkgs/commit/94a6ba908e87e3243ccc3810c790e998e7d6de9b) elf2uf2-rs: 1.3.8 -> 2.0.0
* [`86be3551`](https://github.com/NixOS/nixpkgs/commit/86be355171f43c1744bc15724fb718961e869b90) rhvoice: 1.8.0 -> 1.14.0
* [`a06508ad`](https://github.com/NixOS/nixpkgs/commit/a06508ad68a1c5a13f27656fc48777dbcf86c94b) slibGuile: 3b7 -> 3c1
* [`1ed84a2a`](https://github.com/NixOS/nixpkgs/commit/1ed84a2a0ccd8e1954a998cd13c21a77f0a0f99e) python312Packages.troposphere: 4.5.3 -> 4.6.0
* [`880adcba`](https://github.com/NixOS/nixpkgs/commit/880adcbadce91e640849030aa11e9837fddd55b9) libfilezilla: 0.45.0 -> 0.46.0
* [`16ad5826`](https://github.com/NixOS/nixpkgs/commit/16ad58266e9e4cb300880000aea066525fc77c5e) owntracks-recorder: 0.9.6 -> 0.9.7
* [`35e16bd9`](https://github.com/NixOS/nixpkgs/commit/35e16bd907627b41b212e33a809aff85b81229bf) ocf-resource-agents: fix `pos` attribute to define source location
* [`23aabacf`](https://github.com/NixOS/nixpkgs/commit/23aabacf15381de560c30b716311c858f4d0d8a9) sqlite-web: 0.6.2 -> 0.6.3
* [`4ebe4721`](https://github.com/NixOS/nixpkgs/commit/4ebe4721a6220a6f6365787089e2149589b9de27) ocf-resource-agents: expose it's inputs as attributes
* [`1414c92a`](https://github.com/NixOS/nixpkgs/commit/1414c92a0b544f8f0d58753d10723ad21bb0b3bd) contour: 0.4.2.6429 -> 0.4.3.6442
* [`8f42ee75`](https://github.com/NixOS/nixpkgs/commit/8f42ee751238c6b8fdd227df330bcc47b5853fae) ffmpeg: backport binutils-2.41 fix
* [`ce68b899`](https://github.com/NixOS/nixpkgs/commit/ce68b8998fe4fa834c41c8866875cdd2c9d1d10a) kodi: backport binutils-2.41 fix for bundled ffmpeg
* [`cce58ee2`](https://github.com/NixOS/nixpkgs/commit/cce58ee24d525e24126c06d8cbe31458aabf6359) mythtv: backport binutils-2.41 fix for bundled ffmpeg
* [`fa4285b1`](https://github.com/NixOS/nixpkgs/commit/fa4285b1ad0309777f906ada00bac9bc5219ed67) avidemux: backport binutils-2.41 fix for bundled ffmpeg
* [`d0f26a4a`](https://github.com/NixOS/nixpkgs/commit/d0f26a4af195bf03b7e1a8fac387555ec7c80020) binutils: 2.40 -> 2.41
* [`ad0265fa`](https://github.com/NixOS/nixpkgs/commit/ad0265faff06fb8522c52e7bfe3d6614687765d7) python311Packages.greynoise: 2.0.1 -> 2.1.0
* [`1c644705`](https://github.com/NixOS/nixpkgs/commit/1c644705a165e3ba6a95ed7e24dff9347e9ef4cf) python311Packages.s3fs: 2023.12.2 -> 2024.2.0
* [`7d962a94`](https://github.com/NixOS/nixpkgs/commit/7d962a94e42e1b033afd5e1d51023bd431f1e83d) python311Packages.btrees: 5.1 -> 5.2
* [`93af9701`](https://github.com/NixOS/nixpkgs/commit/93af9701dd3b298e6bd1b6aaff4e86611e57e88c) eccodes: 2.33.0 -> 2.34.0
* [`b1085e9a`](https://github.com/NixOS/nixpkgs/commit/b1085e9a089689150e8f1d5d1186e8ba58a1ff37) python312Packages.pytest-qt: 4.3.1 -> 4.4.0
* [`e787d04b`](https://github.com/NixOS/nixpkgs/commit/e787d04bd62e554098f0d44ccf9929e1d470cb5f) pdfsam-basic: 5.2.0 -> 5.2.2
* [`b60b5a62`](https://github.com/NixOS/nixpkgs/commit/b60b5a62720e4e2d2822566413860e3d16ae8cb9) nwg-hello: 0.1.6 -> 0.1.7
* [`4cab83a2`](https://github.com/NixOS/nixpkgs/commit/4cab83a2a58f69fe61ac7ae0c05cee0da6ae83c8) revive: 1.3.6 -> 1.3.7
* [`8b21717c`](https://github.com/NixOS/nixpkgs/commit/8b21717c1cf2d35a097c90072ab298b2d96a6360) gimx: fix build against `gcc-13`
* [`f9a74741`](https://github.com/NixOS/nixpkgs/commit/f9a747419075dd90f875d07ef437bbb9d81846bb) python311Packages.slixmpp: 1.8.4 -> 1.8.5
* [`9a8752ce`](https://github.com/NixOS/nixpkgs/commit/9a8752ceff59a0ea9df0d32f7d16b27cd1744eaf) python311Packages.dploot: 2.2.4 -> 2.2.5
* [`3afb3460`](https://github.com/NixOS/nixpkgs/commit/3afb3460447c62021749515a26b6b483e3246048) python311Packages.pyramid-jinja2: 2.10 -> 2.10.1
* [`0bc1ec86`](https://github.com/NixOS/nixpkgs/commit/0bc1ec86a795308f8d502817d1daf42cd8b606fd) consul-alerts: add meta.mainProgram
* [`2cec2e3c`](https://github.com/NixOS/nixpkgs/commit/2cec2e3caf404912939a06768b5674f3d7e56a1b) ipxe: unstable-2024-01-19 -> unstable-2024-02-08
* [`d8219178`](https://github.com/NixOS/nixpkgs/commit/d8219178dade75f349f87a43829ec99c4a1d56d3) python311Packages.deepl: 1.16.1 -> 1.17.0
* [`cc150006`](https://github.com/NixOS/nixpkgs/commit/cc1500069088cb180bb3a70ca49c2cdc2e188f4e) cryptominisat: 5.11.15 -> 5.11.21
* [`3476bb3e`](https://github.com/NixOS/nixpkgs/commit/3476bb3e7f5cb2abea24799deaf5b06cf6ab4105) spdx-license-list-data: 3.22 -> 3.23
* [`02e02025`](https://github.com/NixOS/nixpkgs/commit/02e020255d330e5140ebb6f3e24ae9be59359c5b) ceph-csi: 3.10.1 -> 3.10.2
* [`933cd7dd`](https://github.com/NixOS/nixpkgs/commit/933cd7ddce15fff457548b51165b8bc91b88c945) goaccess: 1.8.1 -> 1.9.1
* [`c8a31b73`](https://github.com/NixOS/nixpkgs/commit/c8a31b73821a0cfe2df73718f78d5771e3833a00) camunda-modeler: 5.19.0 -> 5.20.0
* [`94f6b130`](https://github.com/NixOS/nixpkgs/commit/94f6b130d06ea099789f1cb0aa4567b3e3fa924b) kernel-hardening-checker: init at 0.6.6
* [`3f949f96`](https://github.com/NixOS/nixpkgs/commit/3f949f962811653fae0df1484bc7edb8a20d2e66) clblast: 1.6.1 -> 1.6.2
* [`c1b17e74`](https://github.com/NixOS/nixpkgs/commit/c1b17e74d7e4bdfbfa6ff2ac2664589a1ae9d690) libjwt: 1.16.0 -> 1.17.0
* [`fad1dfd7`](https://github.com/NixOS/nixpkgs/commit/fad1dfd7b21075047a117a12d6a5b4d483302af8) alfaview: 9.8.1 -> 9.8.2
* [`5ca14e22`](https://github.com/NixOS/nixpkgs/commit/5ca14e22c6673701224986dd34662b99d9aee08a) igv: 2.17.1 -> 2.17.2
* [`ae2e4eaa`](https://github.com/NixOS/nixpkgs/commit/ae2e4eaa32aea6725777c43b0d0012a173f4a112) drogon: 1.9.2 -> 1.9.3
* [`2945ec09`](https://github.com/NixOS/nixpkgs/commit/2945ec09345aba6df94bc8e1637ff59b62b7f6c1) lxgw-wenkai: 1.315 -> 1.320
* [`0d1a9d72`](https://github.com/NixOS/nixpkgs/commit/0d1a9d72be4faf6c0cff4e364d750a0848e826e4) libmbd: 0.12.7 -> 0.12.8
* [`4970328d`](https://github.com/NixOS/nixpkgs/commit/4970328d9c1de1d24df2c5cc91df693dd2e752e7) maintainers: add sascha8a
* [`53d1bb94`](https://github.com/NixOS/nixpkgs/commit/53d1bb94a5da90eb3dc200a1c95b6fd320db09f0) pgadmin4: 8.2 -> 8.3
* [`7ad2ea76`](https://github.com/NixOS/nixpkgs/commit/7ad2ea762ecf9f8762b51ea7df66a834322eb826) ckbcomp: 1.224 -> 1.226
* [`d444ffff`](https://github.com/NixOS/nixpkgs/commit/d444ffff4912071e33bbe47956c89fae059b4c2f) rose-pine-cursor: init at 1.1.0
* [`3efdb8d6`](https://github.com/NixOS/nixpkgs/commit/3efdb8d6faaaf908036584b55b5a6db88ccbd1ac) purescript: 0.15.14 -> 0.15.15
* [`7a86bbde`](https://github.com/NixOS/nixpkgs/commit/7a86bbde701ae9364379fed57930b5e7eb994bb8) kraft: 0.7.3 -> 0.7.5
* [`1deb2fe0`](https://github.com/NixOS/nixpkgs/commit/1deb2fe09e66a3259578a7489e3e068c2ad576bd) datovka: 4.23.4 -> 4.23.6
* [`93d4c4b4`](https://github.com/NixOS/nixpkgs/commit/93d4c4b42cf410dc996e7d333dbcfc62117ac2d5) dyff: 1.6.0 -> 1.7.1
* [`9a733b06`](https://github.com/NixOS/nixpkgs/commit/9a733b06be7d65bf92da5a7d8c32be8272606404) amazon-ssm-agent: 3.2.2222.0 -> 3.3.40.0
* [`b88eb394`](https://github.com/NixOS/nixpkgs/commit/b88eb39405dfbd9adbbcbc6cc0a7fadc79db00fb) python311Packages.bx-python: 0.10.0 -> 0.11.0
* [`0294fd56`](https://github.com/NixOS/nixpkgs/commit/0294fd5661b72dd09316aa4ad4ece2471c0205f0) conftest: 0.48.0 -> 0.49.1
* [`966ac980`](https://github.com/NixOS/nixpkgs/commit/966ac9809cc04835da02d29559984488e4507941) coursier: 2.1.8 -> 2.1.9
* [`d4709721`](https://github.com/NixOS/nixpkgs/commit/d4709721176c3e7c50b0161a5ea30fbe86db354e) pulseaudio: 16.1 -> 17.0
* [`bdec5e64`](https://github.com/NixOS/nixpkgs/commit/bdec5e64cf41e50b35eb48aae663551961ff8f37) python312Packages.habanero: 1.2.3 -> 1.2.6
* [`8fdc2416`](https://github.com/NixOS/nixpkgs/commit/8fdc24168ab5e859a70ca7704f397ab4e268d5da) openloco: 23.02 -> 24.01.1
* [`efec1b5c`](https://github.com/NixOS/nixpkgs/commit/efec1b5c14c247d351e680c3e57d21658c7cf5eb) python311Packages.bx-python: update disabled
* [`179fee08`](https://github.com/NixOS/nixpkgs/commit/179fee08738e934995dae7771ec81be9f2c6023c) digikam: move to `by-name`
* [`1b7a9bdf`](https://github.com/NixOS/nixpkgs/commit/1b7a9bdf98d8aee06a453649c5f07ec4f2b5e1e8) digikam: 8.1.0 -> 8.2.0
* [`4068b77f`](https://github.com/NixOS/nixpkgs/commit/4068b77f5b1d24b58fc6babb05dbd516835ce66f) htmldoc: 1.9.17 -> 1.9.18
* [`5f04929f`](https://github.com/NixOS/nixpkgs/commit/5f04929fda728c346c4db9c3c7e3fc038039ad7e) insomnia: 2023.5.8 -> 8.6.1
* [`4f6b60f4`](https://github.com/NixOS/nixpkgs/commit/4f6b60f44de9e2ff3f1f85d799cbb20cd4dec2db) gosec: 2.18.2 -> 2.19.0
* [`88371646`](https://github.com/NixOS/nixpkgs/commit/88371646552299df2eadb6d8b4f8170e51f866d6) clj-kondo: 2023.12.15 -> 2024.02.12
* [`8d7dfcdc`](https://github.com/NixOS/nixpkgs/commit/8d7dfcdc171c5e936bd15b73b156008843664d32) python311Packages.unicode-rbnf: 1.0.0 -> 1.1.0
* [`52924b8f`](https://github.com/NixOS/nixpkgs/commit/52924b8f33a6a6daf508955e7674e3a6675fa835) sq: 0.46.1 -> 0.47.4
* [`8fbaa394`](https://github.com/NixOS/nixpkgs/commit/8fbaa394ac2ca1af99f7ac0d5ae260beb452912d) networkmanager-l2tp: 1.20.10 -> 1.20.12
* [`d363f526`](https://github.com/NixOS/nixpkgs/commit/d363f526259bb22416d885e244c89061515d0b23) nixos/postgresql: drop ensurePermissions option
* [`8f28deae`](https://github.com/NixOS/nixpkgs/commit/8f28deae45cc3e481382cac1ff1a329bc226f49c) jellyfin-ffmpeg: 6.0.1-2 -> 6.0.1-3
* [`c58bb51c`](https://github.com/NixOS/nixpkgs/commit/c58bb51c7ff5056330174972244edd1fa9b91c1b) python312Packages.pydantic-core: 2.14.5 -> 2.14.6
* [`bab8bac2`](https://github.com/NixOS/nixpkgs/commit/bab8bac2f635313fca73f94a2172756e94a29195) python312Packages.pydantic: 2.5.2 -> 2.5.3
* [`5d334a8f`](https://github.com/NixOS/nixpkgs/commit/5d334a8fa9ea4992498e09bd0ea1114627031d97) cubiomes-viewer: 3.4.2 -> 4.0.1
* [`e7535fb4`](https://github.com/NixOS/nixpkgs/commit/e7535fb488bff3ea93b2d80bf7a380e0044a0099) python312Packages.mdformat-admon: 1.0.2 -> 2.0.0
* [`836f87a3`](https://github.com/NixOS/nixpkgs/commit/836f87a33ef741379a3e9d831f2940b61ac1ed78) python311Packages.flask-limiter: 3.5.0 -> 3.5.1
* [`85ccc0ee`](https://github.com/NixOS/nixpkgs/commit/85ccc0ee99f31175291f1333a2fdc92e08d762c5) python311Packages.aiohttp-client-cache: 0.10.0 -> 0.11.0
* [`32c51e13`](https://github.com/NixOS/nixpkgs/commit/32c51e13988c0ee53921f5fa3d12d9a43f3ed1d7) libremidi: 4.2.4 -> 4.4.0
* [`5706b7e8`](https://github.com/NixOS/nixpkgs/commit/5706b7e8fcde2bedd3db962b63a27fac7a759f6c) python311Packages.django-model-utils: 4.3.1 -> 4.4.0
* [`7e0fd60a`](https://github.com/NixOS/nixpkgs/commit/7e0fd60a149458650f378414548e9db0316eeddd) dbmate: 2.11.0 -> 2.12.0
* [`f1fba949`](https://github.com/NixOS/nixpkgs/commit/f1fba94949abd24b26b7b7ae30c261b70e8f5e9a) abseil-cpp: 20240116.0 -> 20240116.1
* [`50072421`](https://github.com/NixOS/nixpkgs/commit/500724213ac0c4d9fd0b483c7c794ee51d673ed1) python311Packages.cx-freeze: 6.15.13 -> 6.15.15
* [`ee7519ae`](https://github.com/NixOS/nixpkgs/commit/ee7519ae1fe2c1e673fcdcd0a7285e0513dd505f) puredata: 0.54-0 -> 0.54-1
* [`7047d0db`](https://github.com/NixOS/nixpkgs/commit/7047d0dbf873f5c9e5e08227e12a52f4edd24351) libedit: migrate to by-name hierarchy
* [`305bb109`](https://github.com/NixOS/nixpkgs/commit/305bb109a8d98e43aa0bfb3edd2b78f8b9906935) libedit: refactor and adopt
* [`f54875f9`](https://github.com/NixOS/nixpkgs/commit/f54875f90e7e32922e1be4599feacdd31cc8833f) resholve: partially fix cross-compilation
* [`4e8a98c5`](https://github.com/NixOS/nixpkgs/commit/4e8a98c5352d641146011890de66a6a90ef1329d) python311Packages.celery: disable failing test
* [`fbbe8d07`](https://github.com/NixOS/nixpkgs/commit/fbbe8d07084807cbb004075fe95bb7a7e57b7425) poppler: 24.01.0 -> 24.02.0
* [`be68ea0f`](https://github.com/NixOS/nixpkgs/commit/be68ea0fe82c55bec33144180d99f08b662d5166) xlockmore: 5.74 -> 5.75
* [`4cb28926`](https://github.com/NixOS/nixpkgs/commit/4cb2892699743ff4a1a19fe5937659c26a8f4cd0) oauth2-proxy: 7.5.1 -> 7.6.0
* [`05137505`](https://github.com/NixOS/nixpkgs/commit/05137505f701e9d99bc8793e43b9c2975bfb159b) python311Packages.unidecode: 1.3.6 -> 1.3.8
* [`aa479abe`](https://github.com/NixOS/nixpkgs/commit/aa479abea2118e16f398d58105f116dea0ca1b86) ddcui: 0.4.2 -> 0.5.4
* [`47845c94`](https://github.com/NixOS/nixpkgs/commit/47845c94add899ec9d8fe98b13c60eeaac248e3d) zef: 0.21.2 -> 0.21.4
* [`aa23c20d`](https://github.com/NixOS/nixpkgs/commit/aa23c20d4d654b44458df2fb8e61953d85d9441c) python311Packages.sv-ttk: 2.5.5 -> 2.6.0
* [`06193f2f`](https://github.com/NixOS/nixpkgs/commit/06193f2f45111faaba5718fa8aea2b5535032d84) python312Packages.social-auth-core: 4.5.2 -> 4.5.3
* [`63894130`](https://github.com/NixOS/nixpkgs/commit/63894130bc5e2b4250d836095a10c8d517744408) python311Packages.python-vipaccess: 0.14.1 -> 0.14.2
* [`3c2b7251`](https://github.com/NixOS/nixpkgs/commit/3c2b7251470150cbdcae48ff2b0d616ec76464e3) xvidcore: run nixpkgs-fmt
* [`a354fe4b`](https://github.com/NixOS/nixpkgs/commit/a354fe4b2f7b78ad2291beb8cfd1ea210511607a) xvidcore: add mingw support
* [`8e4a4e54`](https://github.com/NixOS/nixpkgs/commit/8e4a4e54f82e3267c79708eaf7feecd4eddb21e7) shadow: 4.14.3 -> 4.14.5
* [`3f89316a`](https://github.com/NixOS/nixpkgs/commit/3f89316af000885845d34c9a6776d8344af6a4c9) ffmpeg: work around libvulkan.so not being NEEDED
* [`701fdc64`](https://github.com/NixOS/nixpkgs/commit/701fdc64c7bb71985eceff80e80b5bb19c1c8490) nqp: 2023.08 -> 2024.01
* [`a302588c`](https://github.com/NixOS/nixpkgs/commit/a302588c3956735b728db84e230e5203827e4826) rakudo: 2023.08 -> 2024.01
* [`26735b28`](https://github.com/NixOS/nixpkgs/commit/26735b28eabaee12821544933b167d8c513ac195) dav1d: 1.3.0 -> 1.4.0
* [`2d8effb0`](https://github.com/NixOS/nixpkgs/commit/2d8effb0fc5d0abd1ccad3e857239ba92f860b46) lidarr: 2.0.7.3849 -> 2.1.7.4030
* [`a0f80e96`](https://github.com/NixOS/nixpkgs/commit/a0f80e965c98ae248c7c92e68a82de0d7d53e478) pkgs/stdenv/linux/make-bootstrap-tools-cross.nix: allow entries for to-be uplaoded targets
* [`051ebee8`](https://github.com/NixOS/nixpkgs/commit/051ebee8c9ed01507824869c7b2534eb6125bb8c) nixos/tests/miniflux: move common test script into function for less repetition
* [`e85014c1`](https://github.com/NixOS/nixpkgs/commit/e85014c155104b612e28223300d447957a155a22) python311Packages.holoviews: 1.18.1 -> 1.18.3
* [`53e78999`](https://github.com/NixOS/nixpkgs/commit/53e789997843bbff37ec6ae04159300d42b1fd2a) subnetcalc: 2.4.23 -> 2.5.1
* [`96474d88`](https://github.com/NixOS/nixpkgs/commit/96474d8808f3f32b2dcb8f202b235bc4814b7c03) frugal: 3.17.6 -> 3.17.8
* [`e9db8c4c`](https://github.com/NixOS/nixpkgs/commit/e9db8c4c77271ec3766f6a7b22e66c2e63bc87c3) clingcon: 5.2.0 -> 5.2.1
* [`963348a9`](https://github.com/NixOS/nixpkgs/commit/963348a9c280caa6b8e27200aeb4f67694805949) cctz: 2.3 -> 2.4
* [`19a3dabd`](https://github.com/NixOS/nixpkgs/commit/19a3dabd047e29760520028c381ac506b3de3ba1) python311Packages.virt-firmware: 24.1.1 -> 24.2
* [`9acf9f0a`](https://github.com/NixOS/nixpkgs/commit/9acf9f0a191dc19d0754da2f57e684db8ecb57d6) confluent-platform: 7.5.0 -> 7.6.0
* [`1c102628`](https://github.com/NixOS/nixpkgs/commit/1c102628bc6039df4809e7b7495c99526c82d886) trytond: 7.0.5 -> 7.0.7
* [`8fb720a7`](https://github.com/NixOS/nixpkgs/commit/8fb720a710613d197c1fd684a449aa5aa5c58106) ed: 1.20 -> 1.20.1
* [`68dced8d`](https://github.com/NixOS/nixpkgs/commit/68dced8dc74e918deffe15a1b431be9fec8d3270) iosevka: 27.3.5 -> 28.1.0
* [`21ccf0e6`](https://github.com/NixOS/nixpkgs/commit/21ccf0e6269ab816924fc623dc26b4c97cee7c9a) iosevka-bin: 27.3.5 -> 28.1.0
* [`6422f343`](https://github.com/NixOS/nixpkgs/commit/6422f3435d9a392da347139385c7c672fd02f81b) ibus-engines.m17n: 1.4.27 -> 1.4.28
* [`e42524f7`](https://github.com/NixOS/nixpkgs/commit/e42524f702e017754691fb1cb90fe42cf8788b0e) python311Packages.plux: 1.4.0 -> 1.5.0
* [`9ea46f3b`](https://github.com/NixOS/nixpkgs/commit/9ea46f3b12a04e0bd118b431fa3010e541592318) python312Packages.jsbeautifier: 1.14.11 -> 1.15.1
* [`38c3c8cb`](https://github.com/NixOS/nixpkgs/commit/38c3c8cb79c6e3703b277baafdffe770bb8e13ee) pcre2: 10.42 -> 10.43
* [`edba60c4`](https://github.com/NixOS/nixpkgs/commit/edba60c44a7e897ae71dc6bef4b16024be153a76) python311Packages.pyipv8: 2.12.0 -> 2.13.0
* [`826b2f30`](https://github.com/NixOS/nixpkgs/commit/826b2f305d265ca5b03e4c84eb70c90b9ba48d83) python311Packages.chart-studio: 5.18.0 -> 5.19.0
* [`5b891c00`](https://github.com/NixOS/nixpkgs/commit/5b891c00f4d019afd6330806fc9fd28430f8427c) python311Packages.etils: 1.6.0 -> 1.7.0
* [`7d06db3b`](https://github.com/NixOS/nixpkgs/commit/7d06db3b8c022d169c0d37276aab9cee27bbc873) yacreader: 9.13.1 -> 9.14.2
* [`cf4a87c3`](https://github.com/NixOS/nixpkgs/commit/cf4a87c39cca71e25dea15beb3c3b3a5c41cf152) eiwd: 2.10-1 -> 2.14-1
* [`f95591df`](https://github.com/NixOS/nixpkgs/commit/f95591df2c33a60aa91df1ee28e4f4dfd91f2609) grafana-dash-n-grab: 0.5.1 -> 0.5.2
* [`949e1be1`](https://github.com/NixOS/nixpkgs/commit/949e1be104548adf37b8d60cb86ecd003085b74d) google-java-format: 1.19.2 -> 1.20.0
* [`2d09024e`](https://github.com/NixOS/nixpkgs/commit/2d09024e5fbe7cf30ebd0912612413038a941f68) undefined-medium: 1.1 -> 1.2
* [`90f257d9`](https://github.com/NixOS/nixpkgs/commit/90f257d961039f74987b703a033c9a2aa36de3a9) zimfw: 1.12.1 -> 1.13.0
* [`968dd26b`](https://github.com/NixOS/nixpkgs/commit/968dd26b44667071fbd9851f8b1e7e8b9982499e) python311Packages.dvclive: 3.41.1 -> 3.42.0
* [`f898523e`](https://github.com/NixOS/nixpkgs/commit/f898523ea4eb1c44a0612c2be1de9de30886acc2) python311Packages.dvc-studio-client: 0.18.0 -> 0.20.0
* [`2183b128`](https://github.com/NixOS/nixpkgs/commit/2183b128cc8fe5abd70e18d98c820fbcf5c2a215) espflash: add installShellCompletion
* [`79e9d4ca`](https://github.com/NixOS/nixpkgs/commit/79e9d4ca4e3cd20821745cd8c51f6b87acd33b17) orca-slicer: 1.9.0 -> 1.9.1
* [`b7899c6f`](https://github.com/NixOS/nixpkgs/commit/b7899c6ff833bbc2f31d61f40d7aabe77d63a59f) cdogs-sdl: 1.5.0 -> 2.0.0
* [`32f56d72`](https://github.com/NixOS/nixpkgs/commit/32f56d72667797a5adc555fd1e7c413072dae155) nixos/nebula: fix port resolution for firewall rules
* [`7e98a86a`](https://github.com/NixOS/nixpkgs/commit/7e98a86a2e1ba455d8c85cc9fd6b22753ca0983f) python311Packages.sqlmodel: 0.0.14 -> 0.0.16
* [`e7a1d116`](https://github.com/NixOS/nixpkgs/commit/e7a1d116305e071343ee890822702f6813279e67) scdoc: 1.11.2-unstable-2023-03-08 -> 1.11.3
* [`b87b7491`](https://github.com/NixOS/nixpkgs/commit/b87b7491f120ca2fd0293bf6cc796b729a4461d3) ncspot: add an updateScript
* [`66a5316e`](https://github.com/NixOS/nixpkgs/commit/66a5316eeede064cd526d994683fc37fc8b7f023) ncspot: add a simple test
* [`35ced865`](https://github.com/NixOS/nixpkgs/commit/35ced865ae79bc06a6b311ce5c03d21586158bd8) ncspot: install a desktop file
* [`978bb765`](https://github.com/NixOS/nixpkgs/commit/978bb765826145a718292b7f4d2753d98a4c33a7) ncspot: add liff as a maintainer
* [`2b436231`](https://github.com/NixOS/nixpkgs/commit/2b436231e88759eeac6dab7f30bae2e8c7330752) goa: 3.14.6 -> 3.15.0
* [`0303f073`](https://github.com/NixOS/nixpkgs/commit/0303f073dcbd4fb49ba73609eb30745f09d4f908) openxr-loader: 1.0.33 -> 1.0.34
* [`47b9e8c2`](https://github.com/NixOS/nixpkgs/commit/47b9e8c2e8a166528c905a0f8e7ab99a346ba3a0) libcbor: 0.10.2 -> 0.11.0
* [`8c9b74f3`](https://github.com/NixOS/nixpkgs/commit/8c9b74f324e77c883b456d95cd83a49e82c6fb34) python311Packages.basemap: 1.4.0 -> 1.4.1
* [`ccea76c7`](https://github.com/NixOS/nixpkgs/commit/ccea76c72d9ee1befe6f658989f321395d113f62) dtc: set meta.mainProgram
* [`2424c8db`](https://github.com/NixOS/nixpkgs/commit/2424c8db9dd95d8a301aeb20e1d237c0cc6e637a) buildUBoot: specify absolute path of dtc, fix building u-boot 2023.10+
* [`ad8f3a89`](https://github.com/NixOS/nixpkgs/commit/ad8f3a891f9e50931351bca421b621fae746a8fa) htb-toolkit: add platforms metadata
* [`ca998ba0`](https://github.com/NixOS/nixpkgs/commit/ca998ba079863ca82882a57455f99a44626b3559) youtube-music: 3.1.0 -> 3.2.2, little cleanup
* [`dd35ea3c`](https://github.com/NixOS/nixpkgs/commit/dd35ea3c844fd4468386e7e20b823b4860f181c3) yara: 4.4.0 -> 4.5.0
* [`4e61655e`](https://github.com/NixOS/nixpkgs/commit/4e61655eba6b9cf871ee289232e9a4122c883c28) rPackages.poisbinom: added dep
* [`cc5deb28`](https://github.com/NixOS/nixpkgs/commit/cc5deb282e3c25a9b1ca54bee591c58b696334fd) rPackages.bioacoustics: added deps to fix build
* [`bd37cac4`](https://github.com/NixOS/nixpkgs/commit/bd37cac455dd3f6b8d2ee48244de3d58ae31da97) rPackages.GeneralizedWendland: added deps to fix build
* [`9d2e415a`](https://github.com/NixOS/nixpkgs/commit/9d2e415a04db0fc2e8a3cc35088dbc646f533b58) mpg123: 1.32.4 -> 1.32.5
* [`cee2b321`](https://github.com/NixOS/nixpkgs/commit/cee2b321f6c7ac891f0bc362ca783dffe31be5e0) rPackages.TDA: fixed build
* [`b9214ecf`](https://github.com/NixOS/nixpkgs/commit/b9214ecf65ab9b89667a1a234715bd43d30d4acd) rPackages.SemiCompRisks: fixed build
* [`015cd156`](https://github.com/NixOS/nixpkgs/commit/015cd15645dd7b5ea785f5222e8c877b0cf3e6b3) libffi: 3.4.4 -> 3.4.6
* [`9c52c605`](https://github.com/NixOS/nixpkgs/commit/9c52c605731df999725c0a9b92cec16663dfbe2c) youtube-music: 3.2.2 -> 3.3.1
* [`1c747bd5`](https://github.com/NixOS/nixpkgs/commit/1c747bd5a912f792970465da9ff3c089bcfa29fc) openlibm: 0.8.1 -> 0.8.2
* [`a192e7a7`](https://github.com/NixOS/nixpkgs/commit/a192e7a71260501082fbf8e9b5908130a5e7202d) python311Packages.nbdime: fix build
* [`572f4f51`](https://github.com/NixOS/nixpkgs/commit/572f4f511a96f7524921a0c7e9d1e2a21fa4c1e4) python311Packages.pytest-notebook: init at 0.10.0
* [`da8ee36d`](https://github.com/NixOS/nixpkgs/commit/da8ee36d3675f5947e4baf697898e373aa4bb1a7) python311Packages.pyocd-pemicro: init at 1.1.5
* [`1a97d1a2`](https://github.com/NixOS/nixpkgs/commit/1a97d1a23111b1e87b505020338d11604b486d03) python311Packages.dnspython: 2.4.2 -> 2.6.1
* [`62b6a963`](https://github.com/NixOS/nixpkgs/commit/62b6a96351f40cf5276248df337246d320b58e57) libheif: 1.15.2 -> 1.17.6
* [`902d2dc5`](https://github.com/NixOS/nixpkgs/commit/902d2dc5d78d01ed322737d4dd2fd0d7d38d15b2) python3Packages.pillow-heif: 0.14.0 -> 0.15.0
* [`84cd983e`](https://github.com/NixOS/nixpkgs/commit/84cd983e2136991313080480216413288b5398e3) wl-screenrec: unstable-2023-09-17 -> 0.1.3
* [`6c923b2b`](https://github.com/NixOS/nixpkgs/commit/6c923b2bad18de8459e7df56b787310700437bc0) python311Packages.spsdk: 2.0.1 -> 2.1.0
* [`7813d94b`](https://github.com/NixOS/nixpkgs/commit/7813d94b0b7314544098e32fa75c74501dabb58b) vttest: 20231230 -> 20240218
* [`fecf59f0`](https://github.com/NixOS/nixpkgs/commit/fecf59f0933514493f97c48173f139b49f2748e2) libtorrent-rasterbar: 2.0.9 -> 2.0.10
* [`c01b0279`](https://github.com/NixOS/nixpkgs/commit/c01b0279330c3d5ebf717c9983172695d371a04c) cimg: 3.3.3 -> 3.3.4
* [`7dec18da`](https://github.com/NixOS/nixpkgs/commit/7dec18dad1522ff9d81f2dd363d92121cc55d129) samba: 4.19.4 -> 4.19.5
* [`625133aa`](https://github.com/NixOS/nixpkgs/commit/625133aa2eac00b061666af295b9af6d8dc4e68f) sentencepiece: 0.1.99 -> 0.2.0
* [`a9de206e`](https://github.com/NixOS/nixpkgs/commit/a9de206ed4883520cbbb39ac7e3a8afad443f913) cmake: 3.28.2 -> 3.28.3
* [`fd06200a`](https://github.com/NixOS/nixpkgs/commit/fd06200ae6c98924e274f21cc2c91f36ac8932f8) far2l: 2.5.3 -> 2.6.0
* [`7022a2eb`](https://github.com/NixOS/nixpkgs/commit/7022a2eba32b7eac2cbf3ea895a9a8d01e6e2b12) openttd-ttf: init at 0.5
* [`5c736ea8`](https://github.com/NixOS/nixpkgs/commit/5c736ea810c70e0e56ffe79011c79ce1e06eecd2) genact: 1.3.0 -> 1.4.2
* [`4dad448b`](https://github.com/NixOS/nixpkgs/commit/4dad448bfb205f2904aaf941b21b2dcc10387fae) python311Packages.service-identity: 23.1.0 -> 24.1.0
* [`909dc5ab`](https://github.com/NixOS/nixpkgs/commit/909dc5abf1c2f9c26a73059d47af63c219fb6671) python311Packages.autoflake: 2.2.1 -> 2.3.0
* [`a048b5ca`](https://github.com/NixOS/nixpkgs/commit/a048b5ca638cd7776705dd2edfdd69bba0bb2ffc) prometheus-artifactory-exporter: 1.13.2 -> 1.14.0
* [`517228f1`](https://github.com/NixOS/nixpkgs/commit/517228f1e74c7ee3580f72869da9e6da4e2e78e6) moonlight-embedded: 2.6.2 -> 2.7.0
* [`6a5ff7be`](https://github.com/NixOS/nixpkgs/commit/6a5ff7be4398a0c822008e52e3ef8faf3338bb1a) rocketchat-desktop: 3.9.11 -> 3.9.14
* [`733ea48f`](https://github.com/NixOS/nixpkgs/commit/733ea48fdaef2a9ebe9c963920cda21d5e30d9a8) python311Packages.pytweening: 1.0.7 -> 1.2.0
* [`7ed82bda`](https://github.com/NixOS/nixpkgs/commit/7ed82bda3a2325557db97bb238bc2ae97fd80c7a) python311Packages.torch-audiomentations: 0.11.0 -> 0.11.1
* [`3b42fd24`](https://github.com/NixOS/nixpkgs/commit/3b42fd246acccce9735febd2ac443720e580f9df) python312Packages.textual-dev: 1.4.0 -> 1.5.1
* [`7652097e`](https://github.com/NixOS/nixpkgs/commit/7652097e275713ec80748e9337cbee586c37d9d6) xterm: 389 -> 390
* [`c23dc48a`](https://github.com/NixOS/nixpkgs/commit/c23dc48a6998412b1bf4d2f175a2672f590a9fbc) squirrel-sql: 4.6.0 -> 4.7.1
* [`607a7c79`](https://github.com/NixOS/nixpkgs/commit/607a7c79aa9a16e05aeae3d3a4e3653564480818) pynitrokey: pin cryptography
* [`9e37aaff`](https://github.com/NixOS/nixpkgs/commit/9e37aaffb633b77bc1b75241a1f0eee9be01b78e) nitrokey-app2: pin cryptography
* [`96f1273f`](https://github.com/NixOS/nixpkgs/commit/96f1273f750421d6563784942515016f63fb9ef4) protoc-gen-connect-go: 1.14.0 -> 1.15.0
* [`be0bcfb9`](https://github.com/NixOS/nixpkgs/commit/be0bcfb984c4a248524b6c0d85f030695ec98df9) python311Packages.pyro-ppl: 1.8.6 -> 1.9.0
* [`ce3e06f8`](https://github.com/NixOS/nixpkgs/commit/ce3e06f8cc7b45187b50c75ffe893698f34633cc) grpc: 1.61.1 -> 1.62.0
* [`20791bca`](https://github.com/NixOS/nixpkgs/commit/20791bcac58fcce641affa53fb014218020ee312) python311Packages.grpcio: 1.60.1 -> 1.62.0
* [`1d96b00f`](https://github.com/NixOS/nixpkgs/commit/1d96b00f601685896f9f08e1d6a79f60dbc0b960) python311Packages.grpcio-health-checking: 1.60.1 -> 1.62.0
* [`efd3a376`](https://github.com/NixOS/nixpkgs/commit/efd3a376b5a0cba55c99d1f02ae742bcfee4a877) python311Packages.grpcio-testing: 1.60.1 -> 1.62.0
* [`79fbf170`](https://github.com/NixOS/nixpkgs/commit/79fbf170fdb35af9052b82f3e3f78fc1ed49a689) python311Packages.grpcio-status: 1.60.1 -> 1.62.0
* [`f142043f`](https://github.com/NixOS/nixpkgs/commit/f142043f50200ea22fc600d14bcd4e9778ec8443) python311Packages.grpcio-tools: 1.60.1 -> 1.62.0
* [`235abcae`](https://github.com/NixOS/nixpkgs/commit/235abcaee7ece21bd352baa1ec6f1550593d718b) python311Packages.grpcio-channelz: 1.60.1 -> 1.62.0
* [`ce2a8dc6`](https://github.com/NixOS/nixpkgs/commit/ce2a8dc6696a1166427b48babd9124fcf48cff83) bluez: Remove recursivePthLoader from Python wrapper
* [`23e833be`](https://github.com/NixOS/nixpkgs/commit/23e833be7543c0880c05d900918557eac9152c71) fluidd: 1.27.1 -> 1.28.1
* [`bf1a92c0`](https://github.com/NixOS/nixpkgs/commit/bf1a92c099d4d1ce6b5c7be89a4838b213aaf26f) exodus: 24.1.15 -> 24.2.12
* [`2420888e`](https://github.com/NixOS/nixpkgs/commit/2420888e820ba4fe2f4df3af4b4093f5c91612c4) libgig: 4.4.0 -> 4.4.1
* [`144f2872`](https://github.com/NixOS/nixpkgs/commit/144f28723c253f0a479ea92211d1ccc97cbc0fe0) readarr: 0.3.17.2409 -> 0.3.19.2437
* [`9128751c`](https://github.com/NixOS/nixpkgs/commit/9128751cbd5cb883d5890ec859c611b996077ed9) python311Packages.pyro-ppl: refactor
* [`d6863708`](https://github.com/NixOS/nixpkgs/commit/d68637083ff04002b02f6585f02aef5b2bab06c5) opentelemetry-collector: 0.93.0 -> 0.95.0
* [`b43afaea`](https://github.com/NixOS/nixpkgs/commit/b43afaeab11929b17f0f5de5365bfa6e2432a81c) python312Packages.pyomo: 6.7.0 -> 6.7.1
* [`acde7b0d`](https://github.com/NixOS/nixpkgs/commit/acde7b0dbafaefaa285e805b9f10150f1b3ea363) gcompris: 3.3 -> 4.0
* [`61e5079c`](https://github.com/NixOS/nixpkgs/commit/61e5079c983a347b80bc2b6211e13b0bb4388614) mercurial: 6.6.2 -> 6.6.3
* [`03a4c739`](https://github.com/NixOS/nixpkgs/commit/03a4c73920dd35e2e5be21b27e5ded26d70fb054) git: 2.43.1 -> 2.43.2
* [`90aaea8d`](https://github.com/NixOS/nixpkgs/commit/90aaea8dfb3731c7b97b0f0d5d280124b5dc2f59) lua*: support relative modules even when there are system modules
* [`96d56311`](https://github.com/NixOS/nixpkgs/commit/96d56311bcf455990c83b556800f73d8f8fca285) hishtory: 0.267 -> 0.277
* [`2a9407f3`](https://github.com/NixOS/nixpkgs/commit/2a9407f30df7cf62244439aeacc529a8c82ea849) holochain-launcher: 0.11.0 -> 0.11.5
* [`119a6327`](https://github.com/NixOS/nixpkgs/commit/119a63272ca2f9a4bf9358e121bca365a54f29bd) sqlcmd: 1.5.0 -> 1.6.0
* [`cd3487f6`](https://github.com/NixOS/nixpkgs/commit/cd3487f624afeb16738def4450eba97f985253a7) pachyderm: 2.8.4 -> 2.9.0
* [`111835a5`](https://github.com/NixOS/nixpkgs/commit/111835a500edbe3f17976f24fa3af7ea441360f9) sdrangel: 7.18.0 -> 7.18.1
* [`0afb0280`](https://github.com/NixOS/nixpkgs/commit/0afb028097674794590ed50fab8adefeb3f00070) yoshimi: 2.3.1.3 -> 2.3.2
* [`ec629d85`](https://github.com/NixOS/nixpkgs/commit/ec629d858fd93d4b0398b9a8f99d34d344174235) besu: 24.1.1 -> 24.1.2
* [`30120631`](https://github.com/NixOS/nixpkgs/commit/30120631aa269718e1cb45f3a026b0106fe3e7d3) python311Packages.xmlschema: 3.0.1 -> 3.0.2
* [`debe2901`](https://github.com/NixOS/nixpkgs/commit/debe29016091766a77dc1d80eadfbd19f19d2518) python311Packages.xmlschema: refactor
* [`dc680869`](https://github.com/NixOS/nixpkgs/commit/dc680869d848acfd9c8c247b99f226a3c32104eb) python311Packages.chispa: 0.9.4 -> 0.10.0
* [`62579be8`](https://github.com/NixOS/nixpkgs/commit/62579be8a36ea446b45c9d4bb7097f4dd3fe213a) python311Packages.debian-inspector: 31.0.0 -> 31.1.0
* [`c6cc244b`](https://github.com/NixOS/nixpkgs/commit/c6cc244b1e9eb64eef5bbe78a09ae2beeb8c3e4b) bash_unit: 2.1.0 -> 2.2.0
* [`3ae56d4c`](https://github.com/NixOS/nixpkgs/commit/3ae56d4cf65f77eb3a128c68439d9e349e67bf02) arduino-ide: 2.2.1 -> 2.3.2
* [`52eace11`](https://github.com/NixOS/nixpkgs/commit/52eace11d2ea1fb7863cb06756b6a45c01303bcd) lsd2dsl: migrate to by-name
* [`dfc25f4e`](https://github.com/NixOS/nixpkgs/commit/dfc25f4e049ae65152cab9642037ce0585a0fd17) lsd2dsl: 0.5.4 → 0.6.0
* [`b668dcd8`](https://github.com/NixOS/nixpkgs/commit/b668dcd8de523584955bff9b6f402b642983a174) eclipse-mat: 1.14.0.20230315 -> 1.15.0.20231206
* [`514ed92e`](https://github.com/NixOS/nixpkgs/commit/514ed92ea24263b018fc83f9c21b20c637171c39) mssql_jdbc: 12.4.2 -> 12.6.1
* [`1a7498c3`](https://github.com/NixOS/nixpkgs/commit/1a7498c3afc02baf43c3c82e98626367cf89978a) tmuxinator: 3.0.5 -> 3.1.2
* [`5428c69d`](https://github.com/NixOS/nixpkgs/commit/5428c69de9153d2ea079b22d4244cd365bbe8489) polypane: 17.1.0 -> 18.0.0
* [`1698ab22`](https://github.com/NixOS/nixpkgs/commit/1698ab22202db0b9432e829a551ea678cf76057b) open-stage-control: 1.25.7 -> 1.26.1
* [`a9bb4d1c`](https://github.com/NixOS/nixpkgs/commit/a9bb4d1c6759e12bbdee5abe7c112001de1f9453) sosreport: 4.6.1 -> 4.7.0
* [`a3f49e09`](https://github.com/NixOS/nixpkgs/commit/a3f49e09c483b6be505027b1134ea0ed3f48bd07) python3Packages.telepath: 0.3 -> 0.3.1
* [`593000b7`](https://github.com/NixOS/nixpkgs/commit/593000b7d1e21cd84c7ecd965a64916b0982b202) squashfuse: 0.5.0 -> 0.5.2
* [`d251d9d2`](https://github.com/NixOS/nixpkgs/commit/d251d9d2765fc86314c87cf114e9afedae609d49) python312Packages.types-setuptools: 69.1.0.20240215 -> 69.1.0.20240217
* [`dd24bffa`](https://github.com/NixOS/nixpkgs/commit/dd24bffaeaa4222b9b4db285d08ada122ec29e2d) python311Packages.types-setuptools: 69.1.0.20240217 -> 69.1.0.20240223
* [`cac7e060`](https://github.com/NixOS/nixpkgs/commit/cac7e060ef1092cc6a07b109719845b4e59653b4) rapidjson-unstable: Remove C++11 mode.
* [`9e87044d`](https://github.com/NixOS/nixpkgs/commit/9e87044ded431997bfacc5f53a15591b51e7526e) python311Packages.django-simple-history: 3.4.0 -> 3.5.0
* [`719105a4`](https://github.com/NixOS/nixpkgs/commit/719105a413159be56ded21ad49084d24bc982c26) nv-codec-headers-versions: init
* [`a85f33d2`](https://github.com/NixOS/nixpkgs/commit/a85f33d2b24c987486779a8bbf2052705cab7cc5) Revert "python312Packages.pbr: mark as broken"
* [`738881c8`](https://github.com/NixOS/nixpkgs/commit/738881c8d2d628d43168295d861cf17b53c7068c) ocamlPackages.dscheck: 0.2.0 -> 0.4.0
* [`21e27095`](https://github.com/NixOS/nixpkgs/commit/21e27095c889c3a962ead5277c6f3fdfbf7120b0) ripgrep-all: add missing dependency
* [`baa2d56d`](https://github.com/NixOS/nixpkgs/commit/baa2d56de5e7b84825d5a43e4def208606bc3819) python311Packages.plac: 1.4.0 -> 1.4.3
* [`cb3d4091`](https://github.com/NixOS/nixpkgs/commit/cb3d40911de27e954d6c56eaf32bce35164e5509) ballerina: 2201.8.4 -> 2201.8.5
* [`47a5d2d0`](https://github.com/NixOS/nixpkgs/commit/47a5d2d0b58e8938023c24523eababf7421fbd31) pidgin: 2.14.12 -> 2.14.13
* [`67d804b3`](https://github.com/NixOS/nixpkgs/commit/67d804b373a192cd837043dd24256b78a971ba7e) steampipe: 0.21.7 -> 0.21.8
* [`60b11bfa`](https://github.com/NixOS/nixpkgs/commit/60b11bfabf562e4772a26b38a39199a62f260a9f) python311Packages.trackpy: 0.6.1 -> 0.6.2
* [`66322929`](https://github.com/NixOS/nixpkgs/commit/663229295a957e56c964641160ab201953eeb62b) python311Packages.pikepdf: 8.12.0.post1 -> 8.13.0
* [`63279fb2`](https://github.com/NixOS/nixpkgs/commit/63279fb2b0cfdf6a9f2d12bd4ac45975ab9a7a07) protontricks: 1.11.0 -> 1.11.1
* [`906d3ed7`](https://github.com/NixOS/nixpkgs/commit/906d3ed70fce3b482348ad22c50bd997172fdb50) python311Packages.svg-py: 1.4.2 -> 1.4.3
* [`a33b9f25`](https://github.com/NixOS/nixpkgs/commit/a33b9f25ddd9a1efe5d8eef8d3200f169f3b0db9) popeye: install shell completion
* [`555dd6cb`](https://github.com/NixOS/nixpkgs/commit/555dd6cbe7a084f55bee36c02e025336c6b6a555) hackrf: 2023.01.1 -> 2024.02.1
* [`d82e12a4`](https://github.com/NixOS/nixpkgs/commit/d82e12a42f83853162d32f835cdd26bdb5c8cec6) c-ares: 1.26.0 -> 1.27.0
* [`5153865c`](https://github.com/NixOS/nixpkgs/commit/5153865c6d8422fe6ca502abf493c6dc546d87f3) python312Pacakges.django: fix tests
* [`dba0deb0`](https://github.com/NixOS/nixpkgs/commit/dba0deb0f88234eebf08ae8be663b5ffdf4393a5) python312Packages.enocean: switch to pynose
* [`cb8b6ded`](https://github.com/NixOS/nixpkgs/commit/cb8b6dedc40deff5212c5ea15aadaa3ae15febc5) python312Packages.habitipy: switch to pynose
* [`ee5173a4`](https://github.com/NixOS/nixpkgs/commit/ee5173a41741437e823281a45e16382a6bdc1457) python312Packages.http-ece: refactor, switch tests to pynose
* [`de503339`](https://github.com/NixOS/nixpkgs/commit/de5033393e676787e9efddcea78dcd88d2b5949a) python311Packages.influxdb: switch to pynose, disable and fix failing tests
* [`60fb5aa1`](https://github.com/NixOS/nixpkgs/commit/60fb5aa15765b1989d0fcd69dfa4e88702904c06) python312Packages.lark: disable tests
* [`a827b9d4`](https://github.com/NixOS/nixpkgs/commit/a827b9d4f0001f74a05f4da675268fe7d6667380) python312Packages.py-vapid: switch to pynose, remove linters from checkInputs
* [`11574c0b`](https://github.com/NixOS/nixpkgs/commit/11574c0b9000e079ddb5e4fc3fc4fa8a7a919bdc) python312Packages.smmap: disable tests
* [`34a99206`](https://github.com/NixOS/nixpkgs/commit/34a99206e24693ebb4d8f272a0b4449ce691a01d) python312Packages.statsd: disable tests, remove old patching
* [`24d4e25f`](https://github.com/NixOS/nixpkgs/commit/24d4e25fa3c974b7331f6f4b239ada8ca2cc4572) python312Packages.uncertainties: disable tests
* [`1d170e2a`](https://github.com/NixOS/nixpkgs/commit/1d170e2aecb6b8871a939261e9efdf5f51336880) python312Packages.uvcclient: switch to pynose, fix test
* [`27acc537`](https://github.com/NixOS/nixpkgs/commit/27acc53725c10bcb9f21e1bbed422e2408d70c7d) python312Packages.youless-api: switch to pynose
* [`6987e8ce`](https://github.com/NixOS/nixpkgs/commit/6987e8ce91490000e5b92df64ff70a1753190ad3) python312Packages.lomond: disable failing test
* [`3ed18f4b`](https://github.com/NixOS/nixpkgs/commit/3ed18f4b1086330d71e094f904987cff525b6530) python311Packages.aiocoap: pep517 build, optionals
* [`bccff637`](https://github.com/NixOS/nixpkgs/commit/bccff637fd887f4404dcd1f088bfd0be404e3bc7) python312Packages.aiocoap: disable failing tests
* [`05281dca`](https://github.com/NixOS/nixpkgs/commit/05281dca417628761c3462feb2fb0903e0568890) python312Packages.snitun: pep517 build, disable failing tests
* [`adcdfe29`](https://github.com/NixOS/nixpkgs/commit/adcdfe29bfa710c326552d8c568fdb7a23c82709) python311Packages.xknx: fix pytest-asyncio 0.22 compat
* [`8086e8fd`](https://github.com/NixOS/nixpkgs/commit/8086e8fd083ad421153ced310cb418d39e2097a5) python312Packages.airly: disable tests
* [`4d3ee799`](https://github.com/NixOS/nixpkgs/commit/4d3ee79969896e3c8afc6c7d05000323f3b2f74b) python312Packages.twilio: disable tests
* [`e48f6ee2`](https://github.com/NixOS/nixpkgs/commit/e48f6ee25928e5b88f64299b508e512ea4e1272e) python312Packages.yalexs: disable tests
* [`5bba46ed`](https://github.com/NixOS/nixpkgs/commit/5bba46edf73a44010205856ca4f39424794713fb) python312Packages.pushbullet-py: disable failing tests
* [`2f77f5cc`](https://github.com/NixOS/nixpkgs/commit/2f77f5cc86a6ed5a714bbb34aba4c82341a9367a) python311Packages.gpiozero: 2.0 -> 2.0.1
* [`f96fa785`](https://github.com/NixOS/nixpkgs/commit/f96fa7854c53e92662390feb9795ffc5aee4c9ce) python312Packages.lingua: replace SafeConfigParser with ConfigParser
* [`7d619af5`](https://github.com/NixOS/nixpkgs/commit/7d619af56350f28b97a02eaa83d5a9974e81949e) python311Packages.minio: 7.2.0 -> 7.2.4
* [`7ac9a1ec`](https://github.com/NixOS/nixpkgs/commit/7ac9a1ec6128c324b1c2cc7ba6c5cd68df7ee8aa) python312Packages.alarmdecoder: fix py3.12 compat
* [`872ae70f`](https://github.com/NixOS/nixpkgs/commit/872ae70f87acf6aad78a4e266693930a802b6557) python312Packages.fitbit: fix py3.12 compat
* [`8c9e9cfd`](https://github.com/NixOS/nixpkgs/commit/8c9e9cfdb0f4fa69784b9105f99cd790adcbd799) python312Packages.pyicloud: disable failing test
* [`ea191d77`](https://github.com/NixOS/nixpkgs/commit/ea191d7790f80f90fb813389906397426a7d3b9a) python311Packages.odp-amsterdam: relax pytz constraint
* [`854eab23`](https://github.com/NixOS/nixpkgs/commit/854eab2389c2b292012830ac1126537c160f7285) python312Packages.pysqueebox: disable failing test
* [`210e3452`](https://github.com/NixOS/nixpkgs/commit/210e3452a52e567c4404350ad2e52159c6ef26c7) python311Packages.pydiscovergy: relax pytz constraint
* [`81b96f96`](https://github.com/NixOS/nixpkgs/commit/81b96f96906cfd0128f7a0d891034c542fa01b32) python312Packages.bidict: 0.22.1 -> 0.23.1
* [`89656f0c`](https://github.com/NixOS/nixpkgs/commit/89656f0c5300ee47298808eb0279dc3f08e53a90) python312Packages.django_5: fix tests
* [`a56f7e23`](https://github.com/NixOS/nixpkgs/commit/a56f7e234b4b613826a9dd03c63eacac8d85a2fb) wpa_supplicant: enable 802.11s mesh networking
* [`663e3ab5`](https://github.com/NixOS/nixpkgs/commit/663e3ab54eeac726d2cf62e03bdff7f021f637fc) linuxKernel.packages.linux_5_10_hardened.akvcam: 1.2.4 -> 1.2.5
* [`5517a52e`](https://github.com/NixOS/nixpkgs/commit/5517a52e30c15942593d2fd9de9b20107a4420ba) linuxKernel.packages.linux_6_7_hardened.r8125: 9.011.01 -> 9.012.03
* [`b404aa98`](https://github.com/NixOS/nixpkgs/commit/b404aa9828c6f3c1c8a98ed5e8853d9b79b0231b) Revert "python311Packages.smartypants: avoid rebuild"
* [`0d053d7c`](https://github.com/NixOS/nixpkgs/commit/0d053d7ca63519b5ba35e9607f353c95275c5376) python312Packages.pyvo: 1.5 -> 1.5.1
* [`7d96b43f`](https://github.com/NixOS/nixpkgs/commit/7d96b43f5f2c45d5a482ce292d6e3a803ac115b0) vscode-extensions.contextmapper.context-mapper-vscode-extension: 6.7.0 -> 6.11.0
* [`bc57f200`](https://github.com/NixOS/nixpkgs/commit/bc57f200b5018b556f9f0dde6c68b501125da9aa) ocamlPackages.curly: 0.2.0 -> 0.3.0
* [`6af7d927`](https://github.com/NixOS/nixpkgs/commit/6af7d9276d1e04b6155c08d8c39e372f4314a0d6) ocamlPackages.domain-local-timeout: 0.1.0 -> 1.0.1
* [`e029cffd`](https://github.com/NixOS/nixpkgs/commit/e029cffd29cb19b83521b4cc358eab438cc6ae39) fmt: 10.1.1 -> 10.2.1
* [`8213444c`](https://github.com/NixOS/nixpkgs/commit/8213444c63728f9876c2520a00b7c32e9540b581) ocamlPackages.qcheck-multicoretests-util: 0.2 -> 0.3
* [`ff69cc4a`](https://github.com/NixOS/nixpkgs/commit/ff69cc4aacdb2b06d2c77c1a96d3f389afcc684d) ocamlPackages.linenoise: 1.4.0 -> 1.5
* [`4a91b3e7`](https://github.com/NixOS/nixpkgs/commit/4a91b3e798c7fb9faa8613e4180d39ac3db42266) cc-wrapper: add trivialautovarinit hardening flag support
* [`5ddeaeb1`](https://github.com/NixOS/nixpkgs/commit/5ddeaeb1feef96f49833a0a927d4fe4434a42409) llvmPackages_*.llvm: disable trivialautovarinit hardening flag
* [`ccf0e19d`](https://github.com/NixOS/nixpkgs/commit/ccf0e19d55beea941c4b4274e6a6f5ae26aaec2d) catch2_3: disable trivialautovarinit hardening flag
* [`2b673eef`](https://github.com/NixOS/nixpkgs/commit/2b673eef6fe3c7844563d92099d7a1ac2c0e65b1) gnutls: disable trivialautovarinit hardening flag
* [`f63d2dfb`](https://github.com/NixOS/nixpkgs/commit/f63d2dfb562ea05507c1e3cf1bc498762dd4d656) libnetfilter_conntrack: disable trivialautovarinit hardening flag
* [`4123c6c9`](https://github.com/NixOS/nixpkgs/commit/4123c6c93f5349072bedf91b8ee4dd2a9a368986) lttng-ust: disable trivialautovarinit hardening flag
* [`12970b96`](https://github.com/NixOS/nixpkgs/commit/12970b96ed55cf36a0d3f8cb49b7ea621077f43d) systemd: disable trivialautovarinit hardening flag
* [`1cae11c0`](https://github.com/NixOS/nixpkgs/commit/1cae11c0fc716d0a2ae83b6916e90fa538714308) coreutils: disable trivialautovarinit hardening flag
* [`e195f08a`](https://github.com/NixOS/nixpkgs/commit/e195f08a888ced893272a239fce36fb2b7b75a60) elpa-packages: updated 2024-02-24 (from overlay)
* [`bb3b286f`](https://github.com/NixOS/nixpkgs/commit/bb3b286f3ccf1d4a0a4acadd9815d49bea9f3cee) elpa-devel-packages: updated 2024-02-24 (from overlay)
* [`2d8d2256`](https://github.com/NixOS/nixpkgs/commit/2d8d2256d8d8951a21e1e83e112027822b3da2df) melpa-packages: updated 2024-02-24 (from overlay)
* [`7db5963d`](https://github.com/NixOS/nixpkgs/commit/7db5963dffd1370ae905f18cab59a46433c5820a) nongnu-packages: updated 2024-02-24 (from overlay)
* [`7a834428`](https://github.com/NixOS/nixpkgs/commit/7a83442851a0c09a07851f4f9cc88fe4d8f73ea5) wesnoth: 1.16.9 -> 1.16.11
* [`81ca2cb9`](https://github.com/NixOS/nixpkgs/commit/81ca2cb993a26c654f635e97f3787284a6754805) ocamlPackages.ocaml-version: 3.6.2 -> 3.6.4
* [`fcfa6742`](https://github.com/NixOS/nixpkgs/commit/fcfa674276662e21af7c60f27adb0dfbd136dcca) weechatScripts.wee-slack: 2.10.1 -> 2.10.2
* [`fbf3520f`](https://github.com/NixOS/nixpkgs/commit/fbf3520fe74b527263ad6fca3f3dcdafa0fb614f) ocamlPackages.lua-ml: 0.9.1 -> 0.9.2
* [`b9cd71f1`](https://github.com/NixOS/nixpkgs/commit/b9cd71f1602c65053c1b81ca8be4aead2845306f) kubernetes-helmPlugins.helm-git: 0.10.0 -> 0.15.1
* [`b2378d42`](https://github.com/NixOS/nixpkgs/commit/b2378d4262aac26d3c3a1f33ca8132e2f8a145d0) ocamlPackages.tar: 2.5.1 -> 2.6.0
* [`4708908d`](https://github.com/NixOS/nixpkgs/commit/4708908d820d7785b220f55d73da69c6986943fb) keyutils: split man pages into its own output
* [`a25dbb0c`](https://github.com/NixOS/nixpkgs/commit/a25dbb0cf7da9ab7afdc179944f8ac91fa7169d9) ocamlPackages.iso8601: 0.2.4 -> 0.2.5
* [`5f870a1c`](https://github.com/NixOS/nixpkgs/commit/5f870a1c4dcb6dff024a316890bcd000e2991e21) python311Packages.pygmo: 2.19.5 -> 2.19.6
* [`5c7c19cc`](https://github.com/NixOS/nixpkgs/commit/5c7c19cc7ef416b2f4a154263c6d04a50bbac86c) xz: 5.4.6 -> 5.6.0
* [`17cd479a`](https://github.com/NixOS/nixpkgs/commit/17cd479aeeb1437582895b2873d86a497e9166e3) am2rlauncher: init at 2.3.0
* [`1d184f7a`](https://github.com/NixOS/nixpkgs/commit/1d184f7a85efb9cb5e999630f8263dfb90b5fa54) python3Packages.osc-diagram: init at unstable-2023-08-07
* [`acc72a20`](https://github.com/NixOS/nixpkgs/commit/acc72a20109399f266db0b61b3e9f5c82214b9a8) python311Packages.xml2rfc: 3.19.1 -> 3.20.0
* [`b7230e67`](https://github.com/NixOS/nixpkgs/commit/b7230e67df46c1ec73d7b9b782249a8382450d24) s2geometry: Build with C++14 instead of C++11.
* [`772f3f22`](https://github.com/NixOS/nixpkgs/commit/772f3f226210e325493f034b6a6ba8293541d56e) python311Packages.aiocomelit: 0.8.3 -> 0.9.0
* [`cb07207e`](https://github.com/NixOS/nixpkgs/commit/cb07207e0cf397d0ba8897ef82ded1083501ada9) git-machete: 3.22.0 -> 3.23.2
* [`02ad1f94`](https://github.com/NixOS/nixpkgs/commit/02ad1f9442e76307dbf8e6f8854d648c83aef06f) brlaser: v6 -> 6-unstable-2023-02-30
* [`bf967efd`](https://github.com/NixOS/nixpkgs/commit/bf967efdd7eb8b0aaf79d1fbbb81598b824ec264) python312Packages.glfw: 2.6.5 -> 2.7.0
* [`3519ab4c`](https://github.com/NixOS/nixpkgs/commit/3519ab4c1c73cde2a2dfdfca4561e62aa66683a5) python311Packages.dogpile-cache: 1.3.0 -> 1.3.2
* [`cfb2a3f7`](https://github.com/NixOS/nixpkgs/commit/cfb2a3f730d5bd9f5118c85bba84eca005d69bd0) dcnnt: 0.9.2 -> 0.10.0
* [`1fe4d18a`](https://github.com/NixOS/nixpkgs/commit/1fe4d18a662ad0c73b1e3942e9bd531b3c7b7951) alienarena: 7.71.2 -> 7.71.6
* [`e8d9e0ee`](https://github.com/NixOS/nixpkgs/commit/e8d9e0ee877dfeb84f7472cf51d79cca4f43b907) python312Packages.sanic-testing: 23.6.0 -> 23.12.0
* [`e5d73251`](https://github.com/NixOS/nixpkgs/commit/e5d73251660f231dd15a14993d4042d9dc082c78) pythonCatchConflictsHook: avoid infinite recursion
* [`b1bccc25`](https://github.com/NixOS/nixpkgs/commit/b1bccc25ec523b1d4f6508ccb750b91bc07bb473) pythonCatchConflictsHook: test cyclic dependency
* [`609fa7d2`](https://github.com/NixOS/nixpkgs/commit/609fa7d249cbeb6082747807a31a69e85e8dd983) metabase: 0.48.4 -> 0.48.7
* [`1ffc8cfb`](https://github.com/NixOS/nixpkgs/commit/1ffc8cfb2ff6800ed93fa9aa2587392882a06a54) ibus-engines.typing-booster-unwrapped: 2.25.1 -> 2.25.3
* [`e3d55936`](https://github.com/NixOS/nixpkgs/commit/e3d559361abd947fd05ee89e45c13b29e2e3dff0) github-release: use buildGoModule
* [`1eb53d1b`](https://github.com/NixOS/nixpkgs/commit/1eb53d1bba2dfae9021e0b352c3f1ff6956b490c) python312Packages.yfinance: 0.2.36 -> 0.2.37
* [`a67d8d68`](https://github.com/NixOS/nixpkgs/commit/a67d8d68bb24175d6e2e00a4af27d6b89c42cca7) s3fs: 1.93 -> 1.94
* [`946aada6`](https://github.com/NixOS/nixpkgs/commit/946aada6f8ea9af68df642577c82850390a7ad01) giada: 0.26.1 -> 1.0.0
* [`c474f84b`](https://github.com/NixOS/nixpkgs/commit/c474f84b5609d49883d8ada8316622735b7c1155) decent-sampler: 1.9.4 -> 1.10.0
* [`bb0def8f`](https://github.com/NixOS/nixpkgs/commit/bb0def8f6da0394e0615b0f8ccb846f752cdaf00) promptfoo: 0.39.1 -> 0.43.1
* [`6b6fc594`](https://github.com/NixOS/nixpkgs/commit/6b6fc5949897a06841cf873ea203747e48dba2a4) decent-sampler: added vst plugins
* [`c7639264`](https://github.com/NixOS/nixpkgs/commit/c7639264630ef87794e03dfb720ed7531e506b27) ptouch-driver: init at 1.7.0
* [`42ac5798`](https://github.com/NixOS/nixpkgs/commit/42ac57986eb3a4113aa390fe199e6131a1eddfbb) ddsmt: init at 2.0.3
* [`c26c7286`](https://github.com/NixOS/nixpkgs/commit/c26c72864f1342f1e5b5bf921bc98e8c46c9db33) python311Packages.django-crispy-bootstrap5: 2023.10 -> 2024.2
* [`0997b57e`](https://github.com/NixOS/nixpkgs/commit/0997b57e759c5bb58538d978dda0726c1aac1eda) libsecret: 0.21.3 -> 0.21.4
* [`b69b3b67`](https://github.com/NixOS/nixpkgs/commit/b69b3b679062182e9c88e9a6d75a4cf932daa7ae) python311Packages.bayespy: 0.5.26 -> 0.5.28
* [`8277cec0`](https://github.com/NixOS/nixpkgs/commit/8277cec0e3c370dde56863f7556fdf74a13c4c55) phosh-mobile-settings: 0.35.1 -> 0.36.0
* [`466073eb`](https://github.com/NixOS/nixpkgs/commit/466073ebd409c034f367acac44858b5329c2c22c) ricochet: remove, outdated
* [`f07b890d`](https://github.com/NixOS/nixpkgs/commit/f07b890d21afe363e3be7acc8b85dabd1b98240d) ain: 1.3.0 -> 1.4.0
* [`fa1ab31b`](https://github.com/NixOS/nixpkgs/commit/fa1ab31bf1d93792fa6a31757c634c2ac5e10eb7) gitoxide: 0.33.0 -> 0.34.0
* [`a8a2cc30`](https://github.com/NixOS/nixpkgs/commit/a8a2cc301b69685cbece828bbad470b24808c182) verilator: 5.020 -> 5.022
* [`64c61ee3`](https://github.com/NixOS/nixpkgs/commit/64c61ee30ae85105b7320f64d1cd8f5bfc3cdf9f) commonsIo: 2.11.0 -> 2.15.1
* [`9f1dcd5f`](https://github.com/NixOS/nixpkgs/commit/9f1dcd5f766c9d1aa07b5a83fc4b70bef1993ac7) aichat: 0.12.0 -> 0.13.0
* [`7a46881f`](https://github.com/NixOS/nixpkgs/commit/7a46881fa4a22aa0a12ff6814d34cbef2e3cc1fc) python312Packages.qbittorrent-api: 2024.1.58 -> 2024.2.59
* [`6d56d4cd`](https://github.com/NixOS/nixpkgs/commit/6d56d4cdaf0b6b0e7bb0e8347b2065c2b3f35fef) ocamlPackages.reason: 3.10.0 -> 3.11.0
* [`0d8e3846`](https://github.com/NixOS/nixpkgs/commit/0d8e3846928125f7f60a0d191de604180476b0c2) python312Packages.pyspark: 3.5.0 -> 3.5.1
* [`3ea3d7fb`](https://github.com/NixOS/nixpkgs/commit/3ea3d7fb1ecf14293bca29acb6132d7df305999b) cargo-mutants: 24.2.0 -> 24.2.1
* [`6f68ffee`](https://github.com/NixOS/nixpkgs/commit/6f68ffeec31edc9b825ad10eebeedc461d738a2d) wimlib: 1.14.3 -> 1.14.4
* [`c8cddb44`](https://github.com/NixOS/nixpkgs/commit/c8cddb44f5a7d248c3b18f4f6511a1a646ed4cbe) fanbox-dl: 0.18.2 -> 0.19.2
* [`69e3b586`](https://github.com/NixOS/nixpkgs/commit/69e3b586a2268b6b56e573330a1ab02efa8379f6) python311Packages.cf-xarray: 0.8.8 -> 0.9.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
