### PR TITLE
niv devenv: update 4eccee9a -> 6c0bad00

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "4eccee9a19ad9be42a7859211b456b281d704313",
-        "sha256": "1dq6ngwz33cminayxxd6gizhy4v4gr54i7f1ndfid79ffvp6kjsz",
+        "rev": "6c0bad0045f1e1802f769f7890f6a59504825f4d",
+        "sha256": "0wv22hrcidiydx33nrhp1cv8jz0c29njy4vp880gwkvgh1vcwd0a",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/4eccee9a19ad9be42a7859211b456b281d704313.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/6c0bad0045f1e1802f769f7890f6a59504825f4d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@4eccee9a...6c0bad00](https://github.com/cachix/devenv/compare/4eccee9a19ad9be42a7859211b456b281d704313...6c0bad0045f1e1802f769f7890f6a59504825f4d)

* [`71809bca`](https://github.com/cachix/devenv/commit/71809bca1921dcc2c72e3749891ec91ed0fb78c4) services/mysql: properly use wrappers during setup
* [`c7a819f2`](https://github.com/cachix/devenv/commit/c7a819f2773678bd11c7eb13e6fb5603979eac9e) Revert "javascript: support bun"
* [`48933218`](https://github.com/cachix/devenv/commit/48933218f6d7c8536e00c7bc17f9cf239a389a3e) Auto generate docs/reference/options.md
* [`739fef95`](https://github.com/cachix/devenv/commit/739fef952f77c3691d09b860ebc75687720725e9) build devcontainer image on release tag
* [`acc01d3e`](https://github.com/cachix/devenv/commit/acc01d3eac2c858887f44df96c8121b70d3b03cc) docs: formatting
* [`db45f9a2`](https://github.com/cachix/devenv/commit/db45f9a2f0e45d8070c28698b1376ea52b456660) Add support for specifying JavaScript root directory
* [`10797db4`](https://github.com/cachix/devenv/commit/10797db44dc0b473bd0065d73986629e36bc5657) Use nodejs-slim package by default
* [`b0f7f912`](https://github.com/cachix/devenv/commit/b0f7f912d42764fd96e8b6d43fab6bf30d183cc0) Add alternative JavaScript runtimes
* [`10b8abd4`](https://github.com/cachix/devenv/commit/10b8abd4e215dfa5d213b525f124fc43915e704a) Add/update examples for alternative JavaScript runtimes
* [`caf51456`](https://github.com/cachix/devenv/commit/caf51456f6fb35a9ff809425c0ddff9a8d9396bd) Auto generate docs/reference/options.md
* [`12124efa`](https://github.com/cachix/devenv/commit/12124efa908e8deeeabc05d9ade4033ee40bc75e) fix: replace "CREATE USER" with "CREATE ROLE"
* [`be7e8358`](https://github.com/cachix/devenv/commit/be7e8358c1d871021e3d24acc67e2beb41830e10) Auto generate docs/reference/options.md
* [`7cc37ced`](https://github.com/cachix/devenv/commit/7cc37ced84c0538cf81a50c4444d2c311a8d8fc0) chore(deps): bump cachix/install-nix-action from 25 to 26
