### PR TITLE
niv niv: update d67c25f2 -> 6f6529db

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "d67c25f29716fd2087e71352783fcce194303a9a",
-        "sha256": "1813r42sz4pmv1syn38s281lmg2l7h779q4r33nn5azm7wy45yrh",
+        "rev": "6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5",
+        "sha256": "1qbyprn08917cszfm5syppi4r5p467qii4fzb2v1s0lrqqn0das4",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/d67c25f29716fd2087e71352783fcce194303a9a.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@d67c25f2...6f6529db](https://github.com/nmattia/niv/compare/d67c25f29716fd2087e71352783fcce194303a9a...6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5)

* [`6f6529db`](https://github.com/nmattia/niv/commit/6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5) Bump cachix/install-nix-action from 25 to 26 ([nmattia/niv⁠#395](https://togithub.com/nmattia/niv/issues/395))
