### PR TITLE
niv nixpkgs: update c41ece23 -> 65f4f042

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c41ece2391fdc2351e839a9d9bb9cc561480ddea",
-        "sha256": "0sh7ps4v334434w128a1z8p2ayrzqbp3hv2968l7f7fq4iwj9xfb",
+        "rev": "65f4f042f9a96a99afada17e1b6064f63da8aadc",
+        "sha256": "02aswz99hkjkkaj9wzbrbjisr1yzb61xdr66zws3xgdq2bzidd43",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c41ece2391fdc2351e839a9d9bb9cc561480ddea.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/65f4f042f9a96a99afada17e1b6064f63da8aadc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c41ece23...65f4f042](https://github.com/nixos/nixpkgs/compare/c41ece2391fdc2351e839a9d9bb9cc561480ddea...65f4f042f9a96a99afada17e1b6064f63da8aadc)

* [`23df0d63`](https://github.com/NixOS/nixpkgs/commit/23df0d63ee81c0e0f1710f67c994aa5ae85d9e6b) opentoonz: Fix after rpath change
* [`d3d67e08`](https://github.com/NixOS/nixpkgs/commit/d3d67e08db3385566b2f292da9dbe5b3e1828815) opentoonz: 1.5.0 -> 1.6.0
* [`1ac99a16`](https://github.com/NixOS/nixpkgs/commit/1ac99a163a04e97e2be5a083b0998e5486958467) opentoonz: 1.6.0 -> 1.7.1
* [`db56a553`](https://github.com/NixOS/nixpkgs/commit/db56a5530cb833104e4b3052b90869890ad3fbdd) toxiproxy: 2.5.0 -> 2.6.0
* [`e9162b92`](https://github.com/NixOS/nixpkgs/commit/e9162b92502a3bdd8031ee901491cf6345237da6) gitignore: remove redundant /result entry
* [`12afc8f1`](https://github.com/NixOS/nixpkgs/commit/12afc8f19ee09147e6592fa23c3bde7aecc90042) xp-pen-deco-01-v2-driver: 3.2.3.230215-1 -> 3.4.9-231023
* [`8d06988a`](https://github.com/NixOS/nixpkgs/commit/8d06988a1a76f17d7f9df9a81c3a32f04550990e) tautulli: 2.13.2 -> 2.13.4
* [`cd3a15fd`](https://github.com/NixOS/nixpkgs/commit/cd3a15fdd67051b0f53915d0bbde26c6d6ede206) maintainers: add eownerdead
* [`06408189`](https://github.com/NixOS/nixpkgs/commit/06408189a3c83fc952eb4a04b4b3b2aa37d838d5) pdpmake: init at 1.4.1
* [`020ef480`](https://github.com/NixOS/nixpkgs/commit/020ef480768822300f4c9fbf22762117b8e280d6) haskell.compiler.ghc981: allow bootstrapping with GHC 9.6.*
* [`edebca76`](https://github.com/NixOS/nixpkgs/commit/edebca765c17d551b9634c02f6a02f1b122e0ba0) haskell.compiler.ghc963Binary: init at 9.6.3
* [`55339fdf`](https://github.com/NixOS/nixpkgs/commit/55339fdfb88ac9100076457c00c7fcd606494526) all-cabal-hashes: 2023-12-17T16:07:47Z -> 2024-01-07T11:23:32Z
* [`854b5340`](https://github.com/NixOS/nixpkgs/commit/854b5340529bef34fe98b8ed91eff95ee5bf03fd) haskellPackages: stackage LTS 21.25 -> LTS 22.4
* [`61355bb9`](https://github.com/NixOS/nixpkgs/commit/61355bb9d4f29ab7bb5cfa5e30ad2eb2b04837a3) haskellPackages: regenerate package set based on current config
* [`d9b750c2`](https://github.com/NixOS/nixpkgs/commit/d9b750c286127f6a7085af0d62321e8a07c3c6a8) haskellPackages.ghc: 9.4.8 -> 9.6.3
* [`bd7b3021`](https://github.com/NixOS/nixpkgs/commit/bd7b302130a472d2e160feb3d2e6bf4a46080254) haskellPackages: fix eval with GHC 9.6 and Stackage LTS 22
* [`5707d014`](https://github.com/NixOS/nixpkgs/commit/5707d014d4018ec7c3c7c3d89d78d1c88b07b910) Revert "pandoc: use library's version"
* [`50a5a126`](https://github.com/NixOS/nixpkgs/commit/50a5a1263b3fc8f675e2e8c81e3189b5e585ff84) haskellPackages.http-api-data: allow hspec 2.11.*
* [`9a237d0c`](https://github.com/NixOS/nixpkgs/commit/9a237d0c03dc9257c9ad760c2d57ee513de38d3b) pandoc: fix eval
* [`636f5f7a`](https://github.com/NixOS/nixpkgs/commit/636f5f7a438572f69d26befd4b7da01f7639cdfc) haskellPackages.configurator-pg: remove jailbreak
* [`8d15aa4a`](https://github.com/NixOS/nixpkgs/commit/8d15aa4ac67065e845961631b68a7d36c1ca142d) haskellPackages.postgrest: update comment
* [`185f85e2`](https://github.com/NixOS/nixpkgs/commit/185f85e2029afd55489c885a37329c0255ba5518) haskellPackages.hasql-pool: remove redundant override
* [`789cd14a`](https://github.com/NixOS/nixpkgs/commit/789cd14ab9236e822a23e32970ce724ac0c655fa) haskellPackages.{fuzzyset_0_2_4,swagger2}: jailbreak for hspec
* [`73eca9a2`](https://github.com/NixOS/nixpkgs/commit/73eca9a20f1543103dc2c6a7632fc377c9d84dad) haskellPackages.hspec-api: unmark as broken
* [`06427a92`](https://github.com/NixOS/nixpkgs/commit/06427a924188249b00d803d0e508f7030fd6b382) haskellPackages.monad-bayes: fix eval
* [`6d58e1bf`](https://github.com/NixOS/nixpkgs/commit/6d58e1bf6479ce66da79b94a896b5383367f7481) haskellPackages.ShellCheck: fix failing test
* [`3f513445`](https://github.com/NixOS/nixpkgs/commit/3f51344505eb7336eaf4bc49c539c5bd5b8842e3) haskellPackages.tasty-discover: allow hspec 2.11.*
* [`e006e61a`](https://github.com/NixOS/nixpkgs/commit/e006e61ab89196524e9dbefc51cad7c437d3ead8) haskell.packages.*.optparse-applicative: fix infinite recursion
* [`960bbb99`](https://github.com/NixOS/nixpkgs/commit/960bbb9963243d952d8620aa579ff74be2472e89) haskell.packages.ghc94.haskell-language-server: fix eval
* [`002e2059`](https://github.com/NixOS/nixpkgs/commit/002e2059cac75b50c533d6b1dc2454f33c8ed7e9) haskell.packages.ghc{810,90,92}.cabal-install: fix eval
* [`c83116b4`](https://github.com/NixOS/nixpkgs/commit/c83116b474156f1e2ef07ef569fd46581688ffb8) haskell.packages.ghc98: fix evaluation errors
* [`a2dd913a`](https://github.com/NixOS/nixpkgs/commit/a2dd913a78eba74c799fe2ce6f278a5e6ad0822b) haskell.packages.*.indexed-traversable: provide compat lib if needed
* [`816fd1b9`](https://github.com/NixOS/nixpkgs/commit/816fd1b9b03630eada3e0580712930f6bc656b91) hck: add meta.mainProgram
* [`834ad25a`](https://github.com/NixOS/nixpkgs/commit/834ad25a8f41ba8da6475c159d6d58ba62b2b2f6) lf: add meta.mainProgram
* [`250ed20d`](https://github.com/NixOS/nixpkgs/commit/250ed20d7213fc059ed9fb7eed6179c31627d47b) xdragon: add meta.mainProgram
* [`75c78d07`](https://github.com/NixOS/nixpkgs/commit/75c78d07154aba53b8da2ca6bbb63c83e079b1bc) xfce4-terminal: add meta.mainProgram
* [`8dafcd5d`](https://github.com/NixOS/nixpkgs/commit/8dafcd5dab1009cfb957097511ed1630c82fe5c3) haskellPackages.{djinn,mueval}: fix build
* [`dd8abb91`](https://github.com/NixOS/nixpkgs/commit/dd8abb912117202ddf9c1e288a421d2f330e6273) pkgsStatic.haskellPackages: use haskell.packages.ghc94
* [`c1ac4da3`](https://github.com/NixOS/nixpkgs/commit/c1ac4da312d1d2b2e15300f009b6c617ab55750e) haskellPackages.lzma-conduit: lift overly strict bounds
* [`bd583b61`](https://github.com/NixOS/nixpkgs/commit/bd583b6169c956e1b4504fa840ae9b3fcc9ed938) haskellPackages.vty-unix: remove broken flag
* [`f805a394`](https://github.com/NixOS/nixpkgs/commit/f805a394487072d8ce1ed2d530c7519a895abd3a) pkgsStatic.haskell.packages.ghc96.ghc: mark broken
* [`8ecc123c`](https://github.com/NixOS/nixpkgs/commit/8ecc123cf0d206dffdf79c3c06cdc9460b987557) haskell.packages.*.{these,OneTuple}: provide compat pkg where needed
* [`8ce5cd43`](https://github.com/NixOS/nixpkgs/commit/8ce5cd43da0edeaeaf3b41f1936907cc49cc0ff5) haskellPackages.repa: apply build fixes for ghc >= 9.4
* [`146350db`](https://github.com/NixOS/nixpkgs/commit/146350db3ff112c487ca11431ea3b70603ecf7c0) haskell.packages.ghc98: jailbreak deps of hip with too strict bounds
* [`4c27ef07`](https://github.com/NixOS/nixpkgs/commit/4c27ef073812cca25178bc5d6e467a92229355ce) haskellPackages.hip: allow more simplifier ticks for GHC >= 9.6
* [`c6d6fc10`](https://github.com/NixOS/nixpkgs/commit/c6d6fc10eea700e6cc4d0f88017b2b8a84ea0d2a) bench: allow optparse-applicative >= 0.18
* [`42cf316c`](https://github.com/NixOS/nixpkgs/commit/42cf316cee8e2c6a0778e76b177eecbeffb8a41d) haskellPackages.filepath-bytestring: disable equivalency test suite
* [`b8e146ac`](https://github.com/NixOS/nixpkgs/commit/b8e146ac790b50aaa642892f3bcaaedf6b9d1283) haskellPackages.glib-stopgap: mark as broken
* [`80c10db7`](https://github.com/NixOS/nixpkgs/commit/80c10db7bc1a9198e3ca692144099174a56185e8) haskell.compiler.ghc963Binary: only install_name_tool mach-o exes
* [`3cab1ed4`](https://github.com/NixOS/nixpkgs/commit/3cab1ed4499aa12a008fef15395ff23b11ce5c4c) gitit: patch for Stackage LTS 22
* [`3a808c92`](https://github.com/NixOS/nixpkgs/commit/3a808c92f8c01f940425cfa41556d4e39f994d5c) haskellPackages.hiedb: 0.4.4.0 -> 0.5.0.0
* [`a05474be`](https://github.com/NixOS/nixpkgs/commit/a05474beda438ce451e124c6a55b922c4b21a4fb) haskell.packages.*.OneTuple: provide base-orphans where necessary
* [`1ef945a9`](https://github.com/NixOS/nixpkgs/commit/1ef945a916f6bd25d80d57602dfbeb8bb8514d81) haskell.packages.ghc94.generically: provide missing base-orphans
* [`c312cd21`](https://github.com/NixOS/nixpkgs/commit/c312cd21f623826adf523ad5e6cc176efa209928) haskell.packages.*.base-compat-batteries: provide extra compat deps
* [`33f6aca9`](https://github.com/NixOS/nixpkgs/commit/33f6aca9aedcb4a3d762bb29d8f935ec6f1c24d7) Don't jailbreak servant on GHC 9.4
* [`49c1247b`](https://github.com/NixOS/nixpkgs/commit/49c1247b0e548b5b92bf5c83014c1efdc8534688) darcs: build using GHC 9.4
* [`c2a3a06e`](https://github.com/NixOS/nixpkgs/commit/c2a3a06e0fbce8fac7238cf97448ff91aab4df23) darcs: simplify flag override
* [`429c0aea`](https://github.com/NixOS/nixpkgs/commit/429c0aea4b38f935bc674ef920dc4ed29578ae4b) haskell.packages.ghc98.hourglass: disable broken test suite
* [`afb843b8`](https://github.com/NixOS/nixpkgs/commit/afb843b80f9be2b27374bb131283e68bff532136) maintainers/scripts/haskell: ignore self-dependencies
* [`18456d10`](https://github.com/NixOS/nixpkgs/commit/18456d10ef0a568229cd5c6d6ae78ec09693c3e4) maintainers/scripts/haskell: optimise `calculateReverseDependencies`
* [`513a7873`](https://github.com/NixOS/nixpkgs/commit/513a7873d0fafa391b6cd13ae388f7a52a418fae) haskellPackages.cubical: mark broken
* [`de33d9cc`](https://github.com/NixOS/nixpkgs/commit/de33d9ccece9367601143f77ce2a691a86804596) haskellPackages: regenerate package set based on current config
* [`03a44807`](https://github.com/NixOS/nixpkgs/commit/03a44807b40dccc8081a3e03f07292aaefa7a745) unblock proto-lens-protoc
* [`b2ccdee1`](https://github.com/NixOS/nixpkgs/commit/b2ccdee12406b216609174e7d9ac7ec3bc907241) regenerate haskell packages
* [`65b9499b`](https://github.com/NixOS/nixpkgs/commit/65b9499b84bde1af8c256cec92950668cf97aca9) haskellPackages.tar-conduit: temporarily pin to 0.4.1 to fix correctness bug
* [`9cc4b19e`](https://github.com/NixOS/nixpkgs/commit/9cc4b19ee67ccf6a7137d2570fc788f8cad8382b) tests.haskell.shellFor: change from using linear to cereal
* [`2721b450`](https://github.com/NixOS/nixpkgs/commit/2721b450146183d0e53279a9386b4c4a4896353a) haskellPackages.brick: disable tests
* [`c4a42ee0`](https://github.com/NixOS/nixpkgs/commit/c4a42ee0293432a951f80387953c2fdca34da273) haskellPackages.hnix: allow free 5.2
* [`83387128`](https://github.com/NixOS/nixpkgs/commit/83387128d7a9fe25d79173dd9c5f59b2e3d48f99) haskellPackages.crypton-connection: remove obsolete override
* [`12981b81`](https://github.com/NixOS/nixpkgs/commit/12981b81a8e0b22166a2874a3eacfb45eb2630be) haskellPackages.postgresql-simple: Enable check
* [`0dd36ea5`](https://github.com/NixOS/nixpkgs/commit/0dd36ea5c38c7b7a9c9943f23d5e45352b435d12) haskellPackages.users-postgresql-simple: Enable check
* [`488534ae`](https://github.com/NixOS/nixpkgs/commit/488534ae5e6286c6b364d59708d1d09115482e44) haskellPackages.postgresql-simple-migration: Enable check
* [`83c6ef3b`](https://github.com/NixOS/nixpkgs/commit/83c6ef3b9c75a50456309d5e1361c86311e43d69) haskellPackages.extensions: jailbreak
* [`1f1ff084`](https://github.com/NixOS/nixpkgs/commit/1f1ff08418c67aca69a298eab338809564fc0432) all-cabal-hashes: 2024-01-07T11:23:32Z -> 2024-01-15T09:56:31Z
* [`d2aae771`](https://github.com/NixOS/nixpkgs/commit/d2aae771680026e27db8740e9e15450aae85ce9a) haskellPackages: regenerate package set based on current config
* [`a8c5755f`](https://github.com/NixOS/nixpkgs/commit/a8c5755f373b5d182ad0555300fc7e5b91bae23c) haskellPackages.hiedb: remove obsolete override
* [`17af309f`](https://github.com/NixOS/nixpkgs/commit/17af309f17d12d3baeac81ccbb1089f94aef9d57) haskellPackages.hoogle: use safe 0.3.20
* [`0db3a34b`](https://github.com/NixOS/nixpkgs/commit/0db3a34bfdda2d229363b565d7960e35b90f2678) haskellPackages.pandoc-crossref: remove obsolete pin
* [`b3f76d0e`](https://github.com/NixOS/nixpkgs/commit/b3f76d0ef6cf89c005a64881060216b1a5c7ea77) haskell-language-server: fix build with hiedb 0.5
* [`4ddf5a65`](https://github.com/NixOS/nixpkgs/commit/4ddf5a650f6cc161be022cd395129a40f28e02b6) haskell-language-server: bump default GHC version to 9.6
* [`224a341c`](https://github.com/NixOS/nixpkgs/commit/224a341c21bf3cbb628c9bc13e40f11523161851) haskellPackages.irc-{conduit,client}: use crypton-connection
* [`fa2376a0`](https://github.com/NixOS/nixpkgs/commit/fa2376a0b903227770320f0edf1313e3fc4e878f) haskellPackages.tcod-haskell: mark as only supported on linux
* [`bc98a9a4`](https://github.com/NixOS/nixpkgs/commit/bc98a9a450ad9aa1499b3a0cac5fb580fd5f6fd6) bv-little builds
* [`c0a8edd2`](https://github.com/NixOS/nixpkgs/commit/c0a8edd289aa8de78bc5d27a725f5ef34c71383f) haskell.packages.ghc96: Remove unnecessary jailbreaks
* [`376561d9`](https://github.com/NixOS/nixpkgs/commit/376561d96f0c504347f97701adce8b797c4b8b76) haskellPackages.{haskintex,profiteur}: unmark broken
* [`bbf7b3af`](https://github.com/NixOS/nixpkgs/commit/bbf7b3af60a6b98df3ba625a845a7bf8d1932a58) matterhorn: 50200.19.0 -> unstable-2024-01-11
* [`76a41943`](https://github.com/NixOS/nixpkgs/commit/76a419433f08424fc4abc3536d1b0d4cb78a128e) haskellPackages.utf8-light: allow hspec 2.11
* [`bb0e433d`](https://github.com/NixOS/nixpkgs/commit/bb0e433d0116ba71b9a4ae0f8ff3ffcf26784cb1) haskell.packages.ghc96.mmark: work around codegen issue on aarch64
* [`e1be0b03`](https://github.com/NixOS/nixpkgs/commit/e1be0b03bdc635143ffda27247587fd83cf4355f) release-haskell.nix: hoogle and hlint work with GHC 9.6.3
* [`31858b75`](https://github.com/NixOS/nixpkgs/commit/31858b7516bcf4d0166df973680120b934e05dbf) release-haskell.nix: express weeder test range via exclusion
* [`4ab40214`](https://github.com/NixOS/nixpkgs/commit/4ab4021420c5e67b536bd480d9a9ba9872da4efc) git-annex: manually install man pages
* [`20e38d06`](https://github.com/NixOS/nixpkgs/commit/20e38d06e86f269e9496a56417b22f1fd7fdedb9) haskellPackages.openapi3: Unmark broken
* [`b3213201`](https://github.com/NixOS/nixpkgs/commit/b3213201ae4fe5ceaa708b10fbb4740e86a3fa1d) haskellPackages: regenerate package set based on current config
* [`0d818adf`](https://github.com/NixOS/nixpkgs/commit/0d818adfdf3322ab152641e4298f8bcad04bbc73) elmPackages.elm: fix compilation with stackage LTS 22.4
* [`b53d8e6c`](https://github.com/NixOS/nixpkgs/commit/b53d8e6cdb122b40c1666629da1f7fac0f72a7ec) haskell.compiler.ghc964: init at 9.6.4
* [`778125d9`](https://github.com/NixOS/nixpkgs/commit/778125d9b0fe871482d1a155e2847bfaadcba15b) all-cabal-hashes: 2024-01-15T09:56:31Z -> 2024-01-18T12:46:00Z
* [`ea3a560b`](https://github.com/NixOS/nixpkgs/commit/ea3a560ba6fe1328b829acd8e6c8bbcdb74be4c1) haskellPackages.general-allocate: remove broken flag
* [`3702ba16`](https://github.com/NixOS/nixpkgs/commit/3702ba16ba92d2093bbe0428f23d7384168f373d) naproche: unstable-2023-07-11 -> unstable-2024-01-18
* [`2ae5dc04`](https://github.com/NixOS/nixpkgs/commit/2ae5dc04722b94ec9f170524ed2b511bc1b5f654) haskellPackages.cabal-plan: jailbreak
* [`5f48a7d0`](https://github.com/NixOS/nixpkgs/commit/5f48a7d0f1591554f601667b3cdc3681cc78cfec) haskellPackages.arbtt: Drop already-applied patch
* [`c7c93d47`](https://github.com/NixOS/nixpkgs/commit/c7c93d47ac77bd3c911467aba632ba2d77a9570d) haskellPackages.espial: Remove no longer needed patch
* [`05abc0d3`](https://github.com/NixOS/nixpkgs/commit/05abc0d3ef015cdd64ba0f70dcda8a6ac0ed1fa3) haskellPackages.svgcairo: Set revision to null
* [`8210984d`](https://github.com/NixOS/nixpkgs/commit/8210984dfce3cdf83f9d14aa9af31902e2650a53) haskellPackages: hie-bios 0.12.1 -> 0.13.1, implicit-hie 0.1.2.7 -> 0.1.4.0
* [`2f8dcca4`](https://github.com/NixOS/nixpkgs/commit/2f8dcca4a9ae7abcb05bc10c9001e01e180fe233) haskellPackages.ghc: 9.6.3 -> 9.6.4
* [`029662af`](https://github.com/NixOS/nixpkgs/commit/029662af3ede7411770b0315e9b63622d9d893bc) haskellPackages: stackage LTS 22.4 -> LTS 22.7
* [`fb8fd479`](https://github.com/NixOS/nixpkgs/commit/fb8fd479d5375615f2d65bb98152dda35ba88998) all-cabal-hashes: 2024-01-18T12:46:00Z -> 2024-01-22T13:31:17Z
* [`b2dcc590`](https://github.com/NixOS/nixpkgs/commit/b2dcc590a7ab6235cb9c9201add64424355217c2) haskellPackages: regenerate package set based on current config
* [`e2d3798b`](https://github.com/NixOS/nixpkgs/commit/e2d3798b2f64dc098634d16468429b439bb26365) haskellPackages: fix eval
* [`b6811e30`](https://github.com/NixOS/nixpkgs/commit/b6811e306488216a309fce41dcbbaac1495989b2) haskellPackages.unleash-client-haskell: jailbreak
* [`a7ad5b99`](https://github.com/NixOS/nixpkgs/commit/a7ad5b99b1ae3446d422578b07c60bdc18159e95) haskellPackages.hercules-ci-optparse-applicative: 0.16.1.0 -> 0.18.1.0
* [`e6507a8f`](https://github.com/NixOS/nixpkgs/commit/e6507a8ff6924c0e1158abb6f9b3eb73509caae5) haskellPackages.unicode-data: disable tests
* [`033f2764`](https://github.com/NixOS/nixpkgs/commit/033f27646e0ae19cc9f4fa788adedb0afc24cf80) python3Packages.databricks-connect: 11.3.6 -> 11.3.26
* [`1deacca2`](https://github.com/NixOS/nixpkgs/commit/1deacca27e1c4fe24ca86e66fa531507e273f819) haskellPackages.tree-diff: disable tests
* [`b568b8df`](https://github.com/NixOS/nixpkgs/commit/b568b8df52eb2151b0c6da3605a5134726480cdb) haskellPackages.niv: add patches
* [`ffd987ee`](https://github.com/NixOS/nixpkgs/commit/ffd987eef91f81bea001e4b45601d05122258dda) haskellPackages.apecs-physics: remove broken flag
* [`e0801b2b`](https://github.com/NixOS/nixpkgs/commit/e0801b2b7e45cf36ad3aa0dcd3d96125c4f890d6) haskellPackages.lens-family-th: drop doJailbreak
* [`f1030af6`](https://github.com/NixOS/nixpkgs/commit/f1030af6eb4a78b390126d792a74681e228cb460) haskellPackages: Cleanup overrides for older ghc versions
* [`c5526821`](https://github.com/NixOS/nixpkgs/commit/c55268218e73b30d48676178768e078ff9ff8907) haskell-language-server: Fix build
* [`a4af1f8d`](https://github.com/NixOS/nixpkgs/commit/a4af1f8d3579c89f63f4df18cf1519b737e6c63c) haskellPackages: regenerate package set based on current config
* [`541965b5`](https://github.com/NixOS/nixpkgs/commit/541965b5ba81464b44e358805bc0b4677ed20380) haskellPackaages.heist: Not broken
* [`545bd859`](https://github.com/NixOS/nixpkgs/commit/545bd8594dfdcd1e3c5e88539f79cf1bb3343ebf) nix-output-monitor: 2.1.1 -> 2.1.2
* [`57b7a9f1`](https://github.com/NixOS/nixpkgs/commit/57b7a9f1a6448583b1cf68c7bc29e1d9b9d70f84) haskellPackages.paths: Drop maralorn as maintainer
* [`43231111`](https://github.com/NixOS/nixpkgs/commit/43231111d21305349a717a53c8f9dfae094e26ed) haskellPackages.specup add maintainer
* [`725488cb`](https://github.com/NixOS/nixpkgs/commit/725488cb7a5e285967e3f2890a9e5bb4be24561d) haskellPackages.reflex-dom: remove obsolete jailbreak
* [`298e5fdd`](https://github.com/NixOS/nixpkgs/commit/298e5fddd308a84571066e773299e2dd1abd87d9) build(deps): bump korthout/backport-action from 2.1.1 to 2.4.1
* [`7d3e9df6`](https://github.com/NixOS/nixpkgs/commit/7d3e9df619d1f20618b6f8cda9cf7065eed9efb8) haskellPackages: stackage LTS 22.7 -> LTS 22.8
* [`aa075b53`](https://github.com/NixOS/nixpkgs/commit/aa075b53a78f774871502f3f513f6eedf295cf06) all-cabal-hashes: 2024-01-22T13:31:17Z -> 2024-01-31T17:44:31Z
* [`5e9a1bf8`](https://github.com/NixOS/nixpkgs/commit/5e9a1bf8728c35887fcb4fa2ebaf710b1051c0f6) haskellPackages: regenerate package set based on current config
* [`c3d97636`](https://github.com/NixOS/nixpkgs/commit/c3d97636e0e0f22650c0cb02dd2cb8a185a53dd5) go-swag: 1.8.12 -> 1.16.3
* [`08c24595`](https://github.com/NixOS/nixpkgs/commit/08c24595c6fbcc12aab39cbd709c29b80e33e36e) lighthouse: 4.5.0 -> 4.6.0
* [`f90f6e6f`](https://github.com/NixOS/nixpkgs/commit/f90f6e6f93916a3f4e929188d0a614dd9eb80d92) specup: init
* [`05a3a508`](https://github.com/NixOS/nixpkgs/commit/05a3a5084c1d9ca6b0692a7fc375fd768de14ffe) haskellPackages.ascii: Apply patches to ascii dependencies
* [`b9cae330`](https://github.com/NixOS/nixpkgs/commit/b9cae33009fc80c32f151fbe768b69e718cf2a57) haskellPackages.cabal2nix-unstable: 2024-01-04 -> 2024-02-05
* [`68ee161b`](https://github.com/NixOS/nixpkgs/commit/68ee161b90277af87552cb93adc536f1c46fb039) haskell.packages.ghc94.ghc-exactprint: pin to 1.6.1.3
* [`b9341ddc`](https://github.com/NixOS/nixpkgs/commit/b9341ddc6fa0071fab0b6243a36852b0159dee8b) haskell.packages.ghc94.hw-fingertree: don't check
* [`38842666`](https://github.com/NixOS/nixpkgs/commit/388426667a52c66f289a46a334f7ad65dca3b588) haskellPackages.nix-serve-ng: apply patch
* [`d4c2507d`](https://github.com/NixOS/nixpkgs/commit/d4c2507dfe31f0d5c2b3455cff0f226805c1b5b2) magma: remove unused callPackage argument
* [`be7e7209`](https://github.com/NixOS/nixpkgs/commit/be7e7209885cfb7a6016afea29de44730e85776c) magma: switch to cudaOlder and cudaAtLeast
* [`9d4ac337`](https://github.com/NixOS/nixpkgs/commit/9d4ac33716fc1f3f3626dcd3b0f0bfe771fdbc16) magma: switch to strings.cmake* functions
* [`0974463f`](https://github.com/NixOS/nixpkgs/commit/0974463f47d3eacbe14aa7109155a4192ecb378a) magma: specify Fortran name mangling scheme
* [`2898a9c4`](https://github.com/NixOS/nixpkgs/commit/2898a9c4d747d3e6b27d37424e46e57e45470f40) magma: CUDA setup hook handles setting CC/CXX
* [`16209df1`](https://github.com/NixOS/nixpkgs/commit/16209df1650a4aae7411d53f97cf8ea0f3fb6ac2) haskellPackages.postgresql-libpq: Use pkg-config instead of pg_config to find libpq
* [`7d25d060`](https://github.com/NixOS/nixpkgs/commit/7d25d060eb2830be96d114311821753821378de0) haskellPackages.package-version: Not broken
* [`eb56edbc`](https://github.com/NixOS/nixpkgs/commit/eb56edbce050a9b7e74d38a68e125783ad05571c) haskellPackages.mkDerivation: remove version checks for unsupported GHC
* [`9d57ec90`](https://github.com/NixOS/nixpkgs/commit/9d57ec90d67eedff67fcee07acb83e18c94f8d25) haskellPackages.mkDerivation: remove some empty lines and default arguments
* [`0e182841`](https://github.com/NixOS/nixpkgs/commit/0e182841322f67cef7e03a9b266759d426a9ba4c) haskellPackages.mkDerivation: pass -split-sections when cross-compiling
* [`a2083c74`](https://github.com/NixOS/nixpkgs/commit/a2083c748faa18d883aca5ebb7aaacd6da1c461d) haskellPackages.mkDerivation: refactor to use enableFeature for stripping
* [`28fc434e`](https://github.com/NixOS/nixpkgs/commit/28fc434ed4e3c07ff26b19b712992fa0f6b32414) haskellPackages.hal: Not broken
* [`4327d0ae`](https://github.com/NixOS/nixpkgs/commit/4327d0aead1cbb282c9bc242e13ca9c33704a107) magma: add test output for GPU testing
* [`c02c6dd5`](https://github.com/NixOS/nixpkgs/commit/c02c6dd53d44daafaa9de3f32fcde64de2cc1ec1) hermitcli: init at 0.28.2
* [`33eb2e8a`](https://github.com/NixOS/nixpkgs/commit/33eb2e8a9c60d08b7ef3d77422007105ae3a10de) phpExtensions.ioncube-loader: init at 13.0.2
* [`b877cf77`](https://github.com/NixOS/nixpkgs/commit/b877cf77e1f2236026fdc82c68af8a3c88e3573a) Update pkgs/by-name/he/hermitcli/package.nix
* [`5ae2fba1`](https://github.com/NixOS/nixpkgs/commit/5ae2fba1b126071801d17a5ae14e952b08832177) haskellPackages.gi-gtk_4: Build fixes
* [`d06425d7`](https://github.com/NixOS/nixpkgs/commit/d06425d779cb4b23fc3b9d8e97a3dc5b27dea2d2) haskellPackages.gi-adwaita: Build fixes
* [`081f32d2`](https://github.com/NixOS/nixpkgs/commit/081f32d2ae355f7d946d81235954a03e02120ef9) haskellPackages: regenerate package set based on current config
* [`7f500eb9`](https://github.com/NixOS/nixpkgs/commit/7f500eb92df04aea14c7ee04740037661c16b260) specup: Add to release-haskell tests
* [`74742416`](https://github.com/NixOS/nixpkgs/commit/747424168cd2231153560290a14b19d5d1b047bb) haskell-modules: add revision argument to callHackageDirect
* [`2ef368a3`](https://github.com/NixOS/nixpkgs/commit/2ef368a3d7bb2822ff1be3f38497d19948b7de94) all-cabal-hashes: 2024-01-31T17:44:31Z -> 2024-02-12T23:23:22Z
* [`86db6149`](https://github.com/NixOS/nixpkgs/commit/86db6149e4beaa90106c9320c0ef31752aad28ad) haskellPackages.mattermost-api: Remove all overrides
* [`45efe09c`](https://github.com/NixOS/nixpkgs/commit/45efe09c2dcd404864f7a664528a6e4ed35879a4) haskellPackages.matterhorn: Remove redundant overrides
* [`bc242d50`](https://github.com/NixOS/nixpkgs/commit/bc242d50b4ed74acf0263621d5c49e3f183ceda5) haskellPackages.matterhorn: 50200.19.0 -> 90000.0.0
* [`145ce21e`](https://github.com/NixOS/nixpkgs/commit/145ce21eb5b23c4a9887831cc17c61e5116ef7a8) haskellPackages: Clean up brick extra-packages entries
* [`1309fb0e`](https://github.com/NixOS/nixpkgs/commit/1309fb0e37969447f454332ea53cf066c6ad7854) haskellPackages: regenerate package set based on current config
* [`9b74bc0a`](https://github.com/NixOS/nixpkgs/commit/9b74bc0a266e17dda38253ecd3721525fce7fcc1) hci: runc -> crun
* [`1e0bfec0`](https://github.com/NixOS/nixpkgs/commit/1e0bfec0a710ead9c235c1f234dca2d976030e1f) hercules-ci-agent: runc -> crun
* [`f4bce3c8`](https://github.com/NixOS/nixpkgs/commit/f4bce3c8177a0b545944cc0b41115ebc997465fc) haskellPackages.xmonad-contrib: drop obsolete patch
* [`195392f7`](https://github.com/NixOS/nixpkgs/commit/195392f7cf4384c166e1b08ba85f1f3116363bfe) cocoapods: 1.15.1 -> 1.15.2
* [`980d1086`](https://github.com/NixOS/nixpkgs/commit/980d1086ccd9c7c30c5c199503c5fa6d8505a131) haskell.compiler: determine native-bignum GHCs via excludes
* [`149fb601`](https://github.com/NixOS/nixpkgs/commit/149fb601dd1546587934c74724ff7fb700c75380) nixos/tinyproxy: add quotes around the filter path
* [`b97f8558`](https://github.com/NixOS/nixpkgs/commit/b97f8558875443dbad3fb4109b7450b1171df759) linuxPackages.rr-zen_workaround: 2020-09-22 -> 2023-11-23
* [`0d872ff5`](https://github.com/NixOS/nixpkgs/commit/0d872ff580a131ec5084e27a622c450e85d126c4) Fix makeself header path
* [`65c7cdc3`](https://github.com/NixOS/nixpkgs/commit/65c7cdc3a77c59881cb0f7c39dbce5c8ca950df3) haskellPackages.containers-unicode-symbols: unbreak
* [`37491e71`](https://github.com/NixOS/nixpkgs/commit/37491e71bad13d318bdd536f359e1d40de302e48) haskellPackages.numerals-base: unbreak
* [`a91725da`](https://github.com/NixOS/nixpkgs/commit/a91725da5573382816ad0fba6a45af85045535e0) haskellPackages: regenerate package set based on current config
* [`3c99de33`](https://github.com/NixOS/nixpkgs/commit/3c99de339049b1d5250df9ac03857fcc7e05eb42) inlyne: 0.3.2 -> 0.4.0
* [`36d3a292`](https://github.com/NixOS/nixpkgs/commit/36d3a292653e20c08526e0d462978f4ff7bdacbc) haskell.packages.ghc96: jailbreak break
* [`e1516fb3`](https://github.com/NixOS/nixpkgs/commit/e1516fb380b5c3765dd4f2bb382a5de397722a6d) grass: remove obsolete proj-datumgrid dependency
* [`876ec104`](https://github.com/NixOS/nixpkgs/commit/876ec10472faf4da965673dcf42730bcd1fcfdd6) libtins: Forcibly compile with C++14.
* [`5068ae6e`](https://github.com/NixOS/nixpkgs/commit/5068ae6e15cdc0af9359969f9d22dec89b4ae9e1) ch9344: 1.9 -> 2.0
* [`27450315`](https://github.com/NixOS/nixpkgs/commit/27450315a615c8cbb25638eb5263e1db8dd38c07) xmonad: update to version 0.18.0 in ghc-9.8.x package set to fix the build
* [`638a3c85`](https://github.com/NixOS/nixpkgs/commit/638a3c85f4ecc42a4fc3b8c12dfb51b403455fa7) libmpd: patch ghc-9.8.x version of the build to support text-2.1.x
* [`858108a1`](https://github.com/NixOS/nixpkgs/commit/858108a105094e63d6d7a35ec4ea93090f7f2a45) hlint: update to version 3.8 in ghc-9.8.x package set to fix the build
* [`58ea1557`](https://github.com/NixOS/nixpkgs/commit/58ea15575b8943fd80611aabb8259dfed7b44b49) bsb-http-chunked: disable tests in ghc-9.8.x package set to fix the build
* [`ef321a0e`](https://github.com/NixOS/nixpkgs/commit/ef321a0ed68ccc8b0babaca977303ff5528e8fa5) papermc: provide multiple versions
* [`27567240`](https://github.com/NixOS/nixpkgs/commit/27567240ea94c99ad8d0f117a888f364971f24a1) ghc: add new compiler version 9.8.2
* [`df284fa4`](https://github.com/NixOS/nixpkgs/commit/df284fa43c9365e1e03b08cda09b5e3ff83e2cfc) haskellPackages: avoid re-enabling previously disabled tests
* [`72e03b91`](https://github.com/NixOS/nixpkgs/commit/72e03b91eaa7b2e631e6f642efdb538a5bcb29fa) haskellPackages: add dontCheckIf helper
* [`f4f56c7a`](https://github.com/NixOS/nixpkgs/commit/f4f56c7af274170b68f93a9b0561f674a07b5add) haskell.compiler: no dynamic way without enableShared/enableProfiledLibs
* [`2d02d0d4`](https://github.com/NixOS/nixpkgs/commit/2d02d0d463358f591657d8b9904f4adfe9c69d2f) haskell.compiler.ghc982: fix bootstrap with GHC 9.6
* [`46cdbff4`](https://github.com/NixOS/nixpkgs/commit/46cdbff42bbb6a1494417f44c1355e59ed155d32) haskell.packages.ghc98.ghc: 9.8.1 -> 9.8.2
* [`a71dda05`](https://github.com/NixOS/nixpkgs/commit/a71dda05b3a5964438e3c9927c139fc50c58e7ef) koka: patch for stackage 22 deps
* [`6cd74777`](https://github.com/NixOS/nixpkgs/commit/6cd7477733aa5eeb9742ac4ccea3c53c4b6f5020) nixos/hydra: add option for starman workers
* [`81b28210`](https://github.com/NixOS/nixpkgs/commit/81b282109e4b16045d75c89d7727fe46df77dfba) libei: fix cross compilation
* [`0bb731d7`](https://github.com/NixOS/nixpkgs/commit/0bb731d7b6a7f83557ee8beef05cfab7145411f3) haskellPackages.haskell-language-server: Correct dependency versions
* [`0374457c`](https://github.com/NixOS/nixpkgs/commit/0374457c361a58f74b2f845f7e2f4406800b84e7) haskellPackages: regenerate package set based on current config
* [`51e91568`](https://github.com/NixOS/nixpkgs/commit/51e91568e305831263561be491893addf5a86d00) rshim-user-space: 2.0.12 -> 2.0.20
* [`9a38f36b`](https://github.com/NixOS/nixpkgs/commit/9a38f36b7e478e6009a885d1407e28feb56fa501) haskellPackages.dhall-lsp-server: use latest revision from git
* [`ef24420f`](https://github.com/NixOS/nixpkgs/commit/ef24420fdd80a65e3b5dc964b1601f74f29e2c0c) haskellPackages: regenerate package set based on current config
* [`cac215e2`](https://github.com/NixOS/nixpkgs/commit/cac215e232ea99a5f4697bdfca413ebb5587867c) cockpit: 311 -> 312
* [`bfd91000`](https://github.com/NixOS/nixpkgs/commit/bfd910008fef76f74519e0ab6fcfa7371abf109f) haskell.packages.ghc98.hiedb: dontCheck
* [`45f5989a`](https://github.com/NixOS/nixpkgs/commit/45f5989acdfa4e42f24f1fc0f8d86d1088e52e7a) sonarr: 4.0.1.929 -> 4.0.2.1183
* [`c014c04d`](https://github.com/NixOS/nixpkgs/commit/c014c04d4a7cb701c658f02bc848a8875c85f80a) haskellPackages.feed: allow base-compat-0.13
* [`de8942e1`](https://github.com/NixOS/nixpkgs/commit/de8942e125c5b5a5c849f866d4675bee729d1f7b) dockerTools: set NIX_SSL_CERT_FILE in image
* [`27f854e7`](https://github.com/NixOS/nixpkgs/commit/27f854e7e5952c631024f95ebeb4d572f491ca06) rPackages.xslt: fix build
* [`38ee05a3`](https://github.com/NixOS/nixpkgs/commit/38ee05a3c79cb96a8ebb953ed7b2a6448129a881) usbredir: 0.13.0 -> 0.14.0
* [`10fc05bf`](https://github.com/NixOS/nixpkgs/commit/10fc05bfc1bb3713f37b730987d0a4c539b166c7) nixos/matrix-synapse: allow synapse to write to directories of unix socket paths
* [`502f34f3`](https://github.com/NixOS/nixpkgs/commit/502f34f3e09ccf06443b0a1de269a584fb424693) nixos/komga: rfcfmt, rm mdDoc & toplvl with lib
* [`01317be8`](https://github.com/NixOS/nixpkgs/commit/01317be8d084b958528d2a5d0944c7a70b674a05) maintainers: add osnyx & ma27 to team flyingcircus
* [`eea6943f`](https://github.com/NixOS/nixpkgs/commit/eea6943f7fd8f19cd9de1eb0f5853d112953fec3) discordchatexporter-cli: move to by-name
* [`36f94399`](https://github.com/NixOS/nixpkgs/commit/36f943996c6cd8f08433b1fc754273ff6d98bd28) discordchatexporter-cli: 2.41.2 -> 2.42.8
* [`ad2f55dc`](https://github.com/NixOS/nixpkgs/commit/ad2f55dc4e95f2740c9543b98ef341a0c21cb6fc) nixos/bacula: Add support for TLS
* [`2af073f7`](https://github.com/NixOS/nixpkgs/commit/2af073f716056bbf0d1997edd002807cc4def83e) nixos/bacula: refactor option generation
* [`487a5e9b`](https://github.com/NixOS/nixpkgs/commit/487a5e9b52c1ef233b93a8ce6b58d46aa306115c) kore: unpin openssl_1_1
* [`b18bcf3a`](https://github.com/NixOS/nixpkgs/commit/b18bcf3a048f711bcb30857beee136c238f598fc) nixos/komga: add systemd service hardening
* [`636584b3`](https://github.com/NixOS/nixpkgs/commit/636584b3ff55e7d2e6e80fef43e5e4644c1d09ef) nixos/komga: use lib.getExe
* [`de7dc98e`](https://github.com/NixOS/nixpkgs/commit/de7dc98e0f748597e06544b5d1744053a0a535c1) haskellPackages.reflex-ghci: jailbreak to fix build
* [`ada45da7`](https://github.com/NixOS/nixpkgs/commit/ada45da783259f228a6fc16c8d39d362549df618) haskellPackages: regenerate package set based on current config
* [`5c063245`](https://github.com/NixOS/nixpkgs/commit/5c063245d4f54883c811c50455a2a9dae8d10e1b) haskellPackages.ema: More jailbreaks to fix the build
* [`5ee8407c`](https://github.com/NixOS/nixpkgs/commit/5ee8407c8251566e073b4e0c4878c54d227a96c9) docker_20_10: remove
* [`d26becd0`](https://github.com/NixOS/nixpkgs/commit/d26becd0acba29cc3112e61a59073906e75b5759) haskellPackages.emanote: Fix build with jailbreaks and patch
* [`97dc5559`](https://github.com/NixOS/nixpkgs/commit/97dc55595774320001d5a9482761fc3b261f6875) haskellPackages: regenerate package set based on current config
* [`10de88c2`](https://github.com/NixOS/nixpkgs/commit/10de88c2b4814ca30b6fb6ab8e751ad57b0bd0e3) hdrop: 0.4.4 -> 0.5.0
* [`34f62e6c`](https://github.com/NixOS/nixpkgs/commit/34f62e6cf8ff68558f2ab8689d319949d288c93d) photoqt: 4.2 -> 4.3
* [`b2d75283`](https://github.com/NixOS/nixpkgs/commit/b2d7528345501097c8e73eaf6eaed703c274ebbb) payme: init at 1.2.0
* [`cc04ae58`](https://github.com/NixOS/nixpkgs/commit/cc04ae587859f24ea08548c7447c759162fb0c08) nixos/amazon-ec2-amis: Add NixOS 23.11
* [`2735157b`](https://github.com/NixOS/nixpkgs/commit/2735157bd91b2caeca304ab43ac28b8682f2bfd0) maintainer-list: add kuznetsss
* [`64a1723a`](https://github.com/NixOS/nixpkgs/commit/64a1723a33020a4fc115cc107239b4eb24330bc2) ultrastardx: 2024.1.0 -> 2024.3.0
* [`ca2c7e00`](https://github.com/NixOS/nixpkgs/commit/ca2c7e00e8f486a80542e3e9d89dd71d85b140ba) miniupnpd: 2.3.4 -> 2.3.5
* [`ee7b08e5`](https://github.com/NixOS/nixpkgs/commit/ee7b08e50acb5724ef20698f100342c2566f68ca) tableplus: 504 -> 538
* [`5c792c8d`](https://github.com/NixOS/nixpkgs/commit/5c792c8dabc8dd940b1b69ec69423f4a6aa78414) musescore: Remove 'broken' for aarch64-linux.
* [`8c43108d`](https://github.com/NixOS/nixpkgs/commit/8c43108d4449a27b5bbc5f8b695b08d3d0b33a4e) doomretro: 5.2.1 -> 5.3
* [`308691f3`](https://github.com/NixOS/nixpkgs/commit/308691f3fe23cc4ac9385d66701016794a132eeb) haskellPackages.semaphore-compat: removed from `broken.yaml`, build fixed
* [`a83f50c7`](https://github.com/NixOS/nixpkgs/commit/a83f50c7203322dfd31c09d967ed8e2ab4afa511) scrcpy: 2.3.1 -> 2.4
* [`4b85fd4b`](https://github.com/NixOS/nixpkgs/commit/4b85fd4b12106707e49d0f31d74d36b196eeccdd) twingate: 2024.018.111147 -> 2024.63.115392
* [`507266bd`](https://github.com/NixOS/nixpkgs/commit/507266bd8db8108423b0026e2c7aac30609b68c1) haskellPackages.reflex-gi-gtk: Fix the build
* [`af70a90e`](https://github.com/NixOS/nixpkgs/commit/af70a90e8e3db7e24d2c870bb143b46ebe280e7b) haskellPackages: regenerate package set based on current config
* [`d6f8a918`](https://github.com/NixOS/nixpkgs/commit/d6f8a918b182dd3edb1da08d53d55f7c2cd38665) haskellPackages: regenerate package set based on current config
* [`5b274d5f`](https://github.com/NixOS/nixpkgs/commit/5b274d5f017ba4d610e495a6fae8a193966e9d25) nixos/nix: add workaround for 9487
* [`4d3910b4`](https://github.com/NixOS/nixpkgs/commit/4d3910b48038067a9a3c9c8586b83de325680089) gnustep: replace custom builder with hooks
* [`29b9c32b`](https://github.com/NixOS/nixpkgs/commit/29b9c32b4cdb91b48d23b00fc9777ffd2ff0a3b8) psmisc: 23.6 -> 23.7
* [`2d2836f0`](https://github.com/NixOS/nixpkgs/commit/2d2836f0603ed9598e59688d0effb0cf7a2fccb7) prometheus-smartctl-exporter: 0.11.0 -> 0.12.0
* [`3b8496a4`](https://github.com/NixOS/nixpkgs/commit/3b8496a49faf0bf37f9b682af6977de09daa644f) xfe: 1.46 -> 1.46.1
* [`c295ef8f`](https://github.com/NixOS/nixpkgs/commit/c295ef8fb1082c94d7a67248ec613bf25c5456a7) citrix-workspace: Add opencv 4.7.0 compatibility soname's
* [`b15ded3d`](https://github.com/NixOS/nixpkgs/commit/b15ded3d29ebe8648f057a11a818e498b29ae743) pithos: 1.6.1 -> 1.6.2
* [`ce130e27`](https://github.com/NixOS/nixpkgs/commit/ce130e272f320599992e3c70b24b7b3b693c590d) mailspring: support aarch64-darwin
* [`7aa9c29c`](https://github.com/NixOS/nixpkgs/commit/7aa9c29cb6ca7d78ff491879743a7357f72ef548) mailspring: use replace-fail with substituteInPlace
* [`6d7c2551`](https://github.com/NixOS/nixpkgs/commit/6d7c25513879d21ce18a9a042f93792e6fb70a88) kminion: init at 2.2.6
* [`6766d433`](https://github.com/NixOS/nixpkgs/commit/6766d4335e01148cd994256c644442d1daab91ad) kminion: add meta.updateScript
* [`bc19782e`](https://github.com/NixOS/nixpkgs/commit/bc19782e3f918bd05a3afe10a6e3a1357350711b) lact: 0.5.0 -> 0.5.3
* [`6ed0cca1`](https://github.com/NixOS/nixpkgs/commit/6ed0cca1b99aa3176e7bc24537ec305e53ca7ccc) tboot: 1.11.1 -> 1.11.2
* [`d3bc8092`](https://github.com/NixOS/nixpkgs/commit/d3bc8092063b7c03fe480957e13a474557357fbc) python3Packages.shapely: 2.0.2 -> 2.0.3
* [`fdc2bb0e`](https://github.com/NixOS/nixpkgs/commit/fdc2bb0e982d28cb73cc4f46b08251e7a9e14198) python3Packages.shapely: alphabetical ordering of parameters
* [`726dff81`](https://github.com/NixOS/nixpkgs/commit/726dff81a0900096caded1d32620e4ab03b5c0d5) gtk-pipe-viewer: 0.4.9 -> 0.5.0
* [`fd329403`](https://github.com/NixOS/nixpkgs/commit/fd329403dca0e508856fc1ef8c2d7f6443a41fdd) python311Packages.py-scrypt: 0.8.20 -> 0.8.24
* [`0892a22d`](https://github.com/NixOS/nixpkgs/commit/0892a22d92bb883865ade3a599a51e447f172991) gitit: drop upstreamed patches
* [`dece59d0`](https://github.com/NixOS/nixpkgs/commit/dece59d0df8ff748de80bae437d5ea78c7584a7f) haskell.packages.ghc{94,96}.weeder: lift optparse-applicative bound
* [`fe92ebba`](https://github.com/NixOS/nixpkgs/commit/fe92ebbaa8314dd735e601586bb61acd993ac165) haskellPackages.taffybar: add patch for newer scotty versions
* [`51a22900`](https://github.com/NixOS/nixpkgs/commit/51a22900610b3ba34ee976e56a5ce31954d1adf1) haskellPackages.fclabels: disable broken test suite
* [`6d08d61a`](https://github.com/NixOS/nixpkgs/commit/6d08d61a655c2f0d5a6ebdac7f2a7fbedb1b1c03) liblouis: 3.28.0 -> 3.29.0
* [`5f2e6243`](https://github.com/NixOS/nixpkgs/commit/5f2e6243fba18cd8d548c85dbb13c8cabe364e2a) koka: build with lsp-2.4.0.0
* [`4a843da6`](https://github.com/NixOS/nixpkgs/commit/4a843da662c40ef9fc9ecdf5b69057fe407a5acb) dnscontrol: fix version reporting (again)
* [`a1ca1b10`](https://github.com/NixOS/nixpkgs/commit/a1ca1b10ab18687dd2f3eca1bff2afb4c5cb25bb) dnscontrol: add version test to `passthru.tests`
* [`05ba7a6c`](https://github.com/NixOS/nixpkgs/commit/05ba7a6c72296533f10298de8c0e8f2463b29b58) kubectl-gadget: 0.25.1 -> 0.26.0
* [`96eeaa30`](https://github.com/NixOS/nixpkgs/commit/96eeaa30e99c2c0786299efeef978f168324b464) tar2ext4: 0.11.4 -> 0.12.0
* [`1d85557b`](https://github.com/NixOS/nixpkgs/commit/1d85557b5025a67d94d31c3c0508253c26b90f07) snapTools: remove
* [`ffb34be6`](https://github.com/NixOS/nixpkgs/commit/ffb34be67d93ad895aced8afd378b2604c007997) syncthing: 1.27.2 -> 1.27.4
* [`95747101`](https://github.com/NixOS/nixpkgs/commit/957471018a18ec187e52acd4ef16d41fff035ef0) rivalcfg: 4.11.0 -> 4.12.0
* [`3e98d578`](https://github.com/NixOS/nixpkgs/commit/3e98d578958677398ad4434211875519de17f3e9) nixos/doc: Add 24.05 release notes for AMIs
* [`eec9f853`](https://github.com/NixOS/nixpkgs/commit/eec9f8535b065480975980266ce89a85f6af1cbd) atmos: 1.64.3 -> 1.65.0
* [`a225b4b8`](https://github.com/NixOS/nixpkgs/commit/a225b4b8e2aadae9c0312e0023c38eb3dac080bc) devpi-server: 6.9.2 -> 6.10.0
* [`9f6b151d`](https://github.com/NixOS/nixpkgs/commit/9f6b151ddf88a3a2267aee2bc39c738f87415169) gnomeExtensions: auto-update
* [`d2882117`](https://github.com/NixOS/nixpkgs/commit/d28821170a36755baecfd349445e4c217a950427) polkadot: 1.7.0 -> 1.8.0
* [`dd8b2665`](https://github.com/NixOS/nixpkgs/commit/dd8b266521cec9d01fec1cd6b0c648f53427dd10) unpoller: 2.9.5 -> 2.10.0
* [`1d3263dc`](https://github.com/NixOS/nixpkgs/commit/1d3263dc98df283112747f40e85e2fdf59209147) yaegi: 0.15.1 -> 0.16.0
* [`a402b1c5`](https://github.com/NixOS/nixpkgs/commit/a402b1c53d62c46fc403a2f4b8d70340bf9378d7) git-agecrypt: init at unstable-2023-07-14
* [`37c7abc9`](https://github.com/NixOS/nixpkgs/commit/37c7abc96cc63cc63f3bd73aaffe4183d59f0079) jackass: init at v0.2.3
* [`c5eaf0ed`](https://github.com/NixOS/nixpkgs/commit/c5eaf0ed83f9865133ecbbba3c29a75250fd4a61) bambu-studio: Fix build
* [`6473b3f6`](https://github.com/NixOS/nixpkgs/commit/6473b3f6b70079acd434ffee931c3e33943dfcf1) getdp: 3.5.0 -> 3.6.0
* [`bca104b0`](https://github.com/NixOS/nixpkgs/commit/bca104b0e57f59f293fc924e60d1adc4105f0ad6) java-service-wrapper: 3.5.54 -> 3.5.56
* [`c9f3cc6a`](https://github.com/NixOS/nixpkgs/commit/c9f3cc6a29286e480560109dd55b566b2c2d173b) cfssl: 1.6.4 -> 1.6.5
* [`de914786`](https://github.com/NixOS/nixpkgs/commit/de914786bf90eb173ab99323e9831236064e882e) tessen: 2.2.1 -> 2.2.3
* [`3950337c`](https://github.com/NixOS/nixpkgs/commit/3950337cb954e9e36ab8b030d022dfa82ebe5c4a) ciao: 1.22.0-m7 -> 1.23.0-m1
* [`ec758e1f`](https://github.com/NixOS/nixpkgs/commit/ec758e1f6fb3dbc812f40cb1be4e23d5c9853bcd) check-by-name: Update pinned tooling
* [`1937f785`](https://github.com/NixOS/nixpkgs/commit/1937f7859fc4b3ff3e807bf3dd998b875985f843) sysdig: 0.35.1 -> 0.35.3
* [`f753e58e`](https://github.com/NixOS/nixpkgs/commit/f753e58e6ec33dc93e8e319c03bad049d9b5a5b4) nixos/networkd: allow RoutingPolicyRule port ranges
* [`a2c86c86`](https://github.com/NixOS/nixpkgs/commit/a2c86c862fbac18a213a182936ba54a97bf9069c) maintainers: add savedra1
* [`a4c22942`](https://github.com/NixOS/nixpkgs/commit/a4c22942fbb432bfd1d60b1ea8196206e7fba684) singularity: 4.1.1 -> 4.1.2
* [`a0a73144`](https://github.com/NixOS/nixpkgs/commit/a0a7314433259ec007fb3b4d5cff6427e1bac8d9) idris2Packages.buildIdris: propagate idris libraries
* [`58f66305`](https://github.com/NixOS/nixpkgs/commit/58f663052a4917a7ad39fe14cc4bc0b0d9586078) haskellPackages.ghc-lib*: drop unused versions
* [`37e3d628`](https://github.com/NixOS/nixpkgs/commit/37e3d62849712ac04b7a02216b22f047d8a451ab) kana: init at 1.4
* [`91ae595f`](https://github.com/NixOS/nixpkgs/commit/91ae595ff875ae0106e5d375acbc809daaf03115) youtrack: 2023.3.24329 -> 2024.1.25893
* [`5d79313c`](https://github.com/NixOS/nixpkgs/commit/5d79313cc735fdbd8d9ca4cc9a9402e04ac2a5d5) json-fortran: 8.3.0 -> 8.4.0
* [`56aeedf4`](https://github.com/NixOS/nixpkgs/commit/56aeedf456e676d46af2595c3f66de9cf95f2cdd) sunshine: use cuda compatible libstdc++ when building with cuda support
* [`38260f87`](https://github.com/NixOS/nixpkgs/commit/38260f877c0a30199eb6667ad656436b430e895a) proxmark3: fix build failure on x86_64-darwin
* [`29423a5d`](https://github.com/NixOS/nixpkgs/commit/29423a5d70aa1fd952da03252d7fe68dd34f0596) proxmark3: add gd optional dependency
* [`38261d95`](https://github.com/NixOS/nixpkgs/commit/38261d955670cfebe1653700af56a6a6cabdfd12) nixos/hoogle: add extraOptions
* [`ca5b14fa`](https://github.com/NixOS/nixpkgs/commit/ca5b14fa8dc5e6512a2e8eab06c01636dd48290c) djot-js: 0.2.3 -> 0.3.1
* [`e61656f5`](https://github.com/NixOS/nixpkgs/commit/e61656f55bacc244cb06755c3922ffa53eaf0391) re-flex: 4.0.1 -> 4.1.0
* [`7e0ba2d7`](https://github.com/NixOS/nixpkgs/commit/7e0ba2d755efc54eba2da3c72ffb344f03ed80aa) haskellPackages.ghcide-test-utils: unbreak
* [`1f15b451`](https://github.com/NixOS/nixpkgs/commit/1f15b451272c8bd4dc890fd7a722b6055ab7408b) bun: 1.0.29 -> 1.0.30
* [`bc3f515b`](https://github.com/NixOS/nixpkgs/commit/bc3f515b512cbd16c238c0408f71b4339e5fbef4) grafana: 10.3.3 -> 10.3.4
* [`9ab85400`](https://github.com/NixOS/nixpkgs/commit/9ab85400252f0d4fcbf82bad5d04f0a423e21007) kotlin{-native}: 1.9.22 -> 1.9.23
* [`af07c5dd`](https://github.com/NixOS/nixpkgs/commit/af07c5dd1ec6f73c79397fbb8e129b57acc430a7) diesel-cli: remove dependency on mariadb server
* [`72e550db`](https://github.com/NixOS/nixpkgs/commit/72e550dbcc437cef869a0c9bcaf79485b73b9e1e) rustPlatform: fix `override` on hooks
* [`ed9afea0`](https://github.com/NixOS/nixpkgs/commit/ed9afea01260da46a169105421489f24e26ce96e) gridcoin-research: 5.4.5.0 -> 5.4.6.0-hotfix-1
* [`0c666ea7`](https://github.com/NixOS/nixpkgs/commit/0c666ea7807d333fb20f2cafdd89ab71874999b5) Revert "haskellPackages.openapi3: hotfix"
* [`cb0cca86`](https://github.com/NixOS/nixpkgs/commit/cb0cca86cdddf56319bda318184393fc575a09ec) Revert "haskellPackages.hercules-ci-*: update"
* [`2ca352c5`](https://github.com/NixOS/nixpkgs/commit/2ca352c59214ea765ddb79c35d6cf2c2ffde97d3) cloudlog: 2.6.5 -> 2.6.6
* [`6cc231f5`](https://github.com/NixOS/nixpkgs/commit/6cc231f5e326e3713cf47e7eb46a95215c683f83) mmc-utils: unstable-2023-10-10 -> unstable-2024-03-07
* [`b78c76fb`](https://github.com/NixOS/nixpkgs/commit/b78c76fbad6762911e8707ade1155e7f22ac04ad) jfsw: 20211225 -> 20240303
* [`c0651987`](https://github.com/NixOS/nixpkgs/commit/c06519879b5aa5a565afb1b04a3291bf33ac8c2e) glab: 1.36.0 -> 1.37.0
* [`05c721c6`](https://github.com/NixOS/nixpkgs/commit/05c721c665bffa4006f5b0eb2a5366f4fc304dd2) wt: 4.10.0 -> 4.10.4
* [`5a83e4a2`](https://github.com/NixOS/nixpkgs/commit/5a83e4a22c342ac013a0303f2c2dce28b920a548) fastfetch: 2.8.7 -> 2.8.8
* [`5b233fd6`](https://github.com/NixOS/nixpkgs/commit/5b233fd6aed6c39f0d37855d7bc4d8a807b36f8c) discord-canary: 0.0.285 -> 0.0.294
* [`ba751420`](https://github.com/NixOS/nixpkgs/commit/ba751420e2d287a7d10005818ddf4e7aa7253e28) kminion: 2.2.6 -> 2.2.7
* [`0825add7`](https://github.com/NixOS/nixpkgs/commit/0825add7bd8beec313e0ea3a57c97f40b32cc839) ocamlPackages.eliom: 10.1.2 → 10.3.1
* [`9a14560b`](https://github.com/NixOS/nixpkgs/commit/9a14560bd964dd9b9d14d5bb8a0185594c1603db) dovecot_fts_xapian: 1.7.4 -> 1.7.6
* [`dc158268`](https://github.com/NixOS/nixpkgs/commit/dc158268f7bedccea096098a2fe020362e564f51) nixos/amazon-image: Enable Amazon SSM Agent by default
* [`98334403`](https://github.com/NixOS/nixpkgs/commit/98334403342b3fc948f6f3cb5805ceaf88f4f526) maintainers: add Sanskarzz
* [`a53c538e`](https://github.com/NixOS/nixpkgs/commit/a53c538ea8104b809b74935063efaffa65a6fbdd) kyverno-chainsaw: init at 0.1.7
* [`9e570d09`](https://github.com/NixOS/nixpkgs/commit/9e570d09eb38fee56645ffbfb27dcce34c2e158a) clipse: init at 0.0.6
* [`49653ab9`](https://github.com/NixOS/nixpkgs/commit/49653ab9dd63d30d1d80caba68c3c0a86e36328b) aerospike: 7.0.0.4 -> 7.0.0.5
* [`fbad683c`](https://github.com/NixOS/nixpkgs/commit/fbad683c26cd7723eb8ad8c7fd50ae73338794b1) rune: 0.13.1 -> 0.13.2
* [`0cf64325`](https://github.com/NixOS/nixpkgs/commit/0cf64325cff9acff376e77e4cd37dd51c390fe54) conftest: 0.49.1 -> 0.50.0
* [`7f8c5d43`](https://github.com/NixOS/nixpkgs/commit/7f8c5d43d6727403dfb249e2f19c3d5859f189ee) discordo: unstable-2024-03-03 -> unstable-2024-03-07
* [`44bfd526`](https://github.com/NixOS/nixpkgs/commit/44bfd5263843016da33758ec3eef15e987ba728b) media-downloader: 4.3.1 -> 4.4.0
* [`67c1193f`](https://github.com/NixOS/nixpkgs/commit/67c1193fab6649cc788641411a64e34ca6ab3672) nixos/unbound: disable checkconf when remote-control is used
* [`1d2030ab`](https://github.com/NixOS/nixpkgs/commit/1d2030ab5b42af6341b4b78750257f00e11f9044) dolt: 1.35.0 -> 1.35.1
* [`b25ebe53`](https://github.com/NixOS/nixpkgs/commit/b25ebe535b738f6bfab5f03fdb42fdc70b996efa) rootlesskit: 2.0.1 -> 2.0.2
* [`631b5f64`](https://github.com/NixOS/nixpkgs/commit/631b5f64fcde4b0df6667c46d919d6fed493cf03) flannel: 0.24.2 -> 0.24.3
* [`645c0b4b`](https://github.com/NixOS/nixpkgs/commit/645c0b4b6694c83af5812da21790b1e87a0f29f3) phosh-mobile-settings: 0.36.0 -> 0.37.0
* [`2c08f884`](https://github.com/NixOS/nixpkgs/commit/2c08f884092a0c3679a4007bc27a595e23dd2119) python311Packages.systembridgeconnector: fix version in wheel
* [`9f384078`](https://github.com/NixOS/nixpkgs/commit/9f3840785bed83234dd27b293ad30b38e4aece29) pyp: refactor
* [`5211205c`](https://github.com/NixOS/nixpkgs/commit/5211205ca9a44c3eff29c940d4238bd87aa733fc) pyp: remove restriction on 3.10
* [`d6599f77`](https://github.com/NixOS/nixpkgs/commit/d6599f77f65c65cfb4dac3dd8eec52f21bd4e6ce) pyp: update expression according to new guidelines
* [`cd975261`](https://github.com/NixOS/nixpkgs/commit/cd975261c7594517908b1c39d39a9197baf3b28d) pyp: migrate it to by-name hierarchy
* [`72d1792f`](https://github.com/NixOS/nixpkgs/commit/72d1792fe5ea694a21035e299b2d852e645c4fdc) mediainfo-gui: 23.11 -> 24.01.1
* [`57e0eafb`](https://github.com/NixOS/nixpkgs/commit/57e0eafb5e7b50392d0356b87a2e62b6bb7f1910) libspelling: 0.2.0 -> 0.2.1
* [`5d00ebc6`](https://github.com/NixOS/nixpkgs/commit/5d00ebc6b4d0a1ff07396fc902a88c29ef5685d9) xf86_input_wacom: 1.2.0 -> 1.2.1
* [`62a7cc55`](https://github.com/NixOS/nixpkgs/commit/62a7cc559f1bad91f951903760d03eae52182655) nixfmt-rfc-style: apply serokell/nixfmt[nixos/nixpkgs⁠#133](https://togithub.com/nixos/nixpkgs/issues/133)
* [`a7cdb7f2`](https://github.com/NixOS/nixpkgs/commit/a7cdb7f2b12c6f14facdef2cd9a10efd1f407918) Avoid `with lib;` at the top level in pkgs/top-level/release-lib.nix
* [`11bf7021`](https://github.com/NixOS/nixpkgs/commit/11bf7021af1224bdde92453ff4490aa9d2aa5f28) Avoid `with lib;` at the top level in pkgs/top-level/unixtools.nix
* [`f5f26f0b`](https://github.com/NixOS/nixpkgs/commit/f5f26f0bbc1d344e2849a267349d30c7e0ae2c1a) Avoid `with lib;` at the top level in pkgs/top-level/release-python.nix
* [`f23c28ca`](https://github.com/NixOS/nixpkgs/commit/f23c28ca41f7b2e4843e5b4ba1d6f2fb9ea2f105) Avoid `with lib;` at the top level in pkgs/top-level/release-cuda.nix
* [`5aa9130a`](https://github.com/NixOS/nixpkgs/commit/5aa9130a69c047ae21a729666e929f4274f76411) Avoid `with lib;` at the top level in pkgs/top-level/octave-packages.nix
* [`fec9460e`](https://github.com/NixOS/nixpkgs/commit/fec9460e07d797a6d77e6aaf89d5ee4bc8545299) Avoid `with lib;` at the top level in pkgs/top-level/kodi-packages.nix
* [`8a034c52`](https://github.com/NixOS/nixpkgs/commit/8a034c526ef48e395727c825041fe328e98416f8) Avoid `with lib;` at the top level in pkgs/top-level/config.nix
* [`5a64a05c`](https://github.com/NixOS/nixpkgs/commit/5a64a05c666cc0fbabd4205c4382a47181d5af6d) Avoid top-level `with ...;` in pkgs/top-level/release-r.nix
* [`210c9eda`](https://github.com/NixOS/nixpkgs/commit/210c9eda8a5e6d1c06afaa66fa8b6214c74947f6) Avoid top-level `with ...;` in pkgs/top-level/release-small.nix
* [`30ad4435`](https://github.com/NixOS/nixpkgs/commit/30ad44351913257ad2cb9a19ccae358e1909d9bc) Avoid top-level `with ...;` in pkgs/top-level/release-cross.nix
* [`93710be2`](https://github.com/NixOS/nixpkgs/commit/93710be289b7926a8cca3917306bf8937b2596ef) Avoid top-level `with ...;` in pkgs/top-level/release.nix
* [`dbf0a30c`](https://github.com/NixOS/nixpkgs/commit/dbf0a30c0e627f2eea8a5c25f89f0d24d7279b5c) Avoid `rec` and correct indentation in `pkgs/top-level/kodi-packages.nix`
* [`91b3db13`](https://github.com/NixOS/nixpkgs/commit/91b3db13093b1aecdba07041eb44b7103c235d94) treewide: fix sourceRoot for fetchgit-based src
* [`a0991778`](https://github.com/NixOS/nixpkgs/commit/a0991778a5380593cfa6057faa5b17885ae7fa69) clojure: 1.11.1.1435 -> 1.11.2.1446
* [`cb7c67bf`](https://github.com/NixOS/nixpkgs/commit/cb7c67bfc8c28ea29d7b81d9b3e017892fbcf8d0) isolate: 1.10.1 -> 2.0
* [`93049f92`](https://github.com/NixOS/nixpkgs/commit/93049f92ff6a1e5386420376536f238bf8cc8121) pupdate: 3.2.1 -> 3.8.0
* [`fc3a9934`](https://github.com/NixOS/nixpkgs/commit/fc3a993440a18b7b66e7652e4502c417c8ecfa2e) zotero: 6.0.30 -> 6.0.35
* [`52afd5d2`](https://github.com/NixOS/nixpkgs/commit/52afd5d25f30c6ab0a4c25597a391619656eba8a) diffoscope: 259 -> 260
* [`b6403710`](https://github.com/NixOS/nixpkgs/commit/b6403710df19244480866612437f434601491311) xonsh: set dontWrapPythonPrograms
* [`4747d9fd`](https://github.com/NixOS/nixpkgs/commit/4747d9fddcd08152a15edc729fcf4698dcbcf1d1) xonsh: 0.14.4 -> 0.15.1
* [`23af5dd0`](https://github.com/NixOS/nixpkgs/commit/23af5dd096c92ec56efdb8a6300b0d96d5602b34) schismtracker: 20240129 -> 20240308
* [`fb611d3f`](https://github.com/NixOS/nixpkgs/commit/fb611d3f5ad92b26f446497fe52c6d6081b710c7) sesh: 0.12.0 -> 0.15.0
* [`83627032`](https://github.com/NixOS/nixpkgs/commit/836270328fdb61f3d6e362028044a7f1fd2ab5f9) jigmo: init at 20230816
* [`83b66d99`](https://github.com/NixOS/nixpkgs/commit/83b66d995ff8546c3bf9e6244472b76ecc1a2bee) pocketbase: 0.22.2 -> 0.22.3
* [`4981f014`](https://github.com/NixOS/nixpkgs/commit/4981f01489c3eae3429f53617a8ca125b7e22f7d) naev: 0.11.3 -> 0.11.4
* [`3fafcf06`](https://github.com/NixOS/nixpkgs/commit/3fafcf0683f662f4197598533979f12e6cd0a3c4) reproxy: 1.0.0 → 1.1.1
* [`0ac49e81`](https://github.com/NixOS/nixpkgs/commit/0ac49e81be86cff7e061409570a3f3bb5f196d23) reproxy: migrate to by-name
* [`04e6aee1`](https://github.com/NixOS/nixpkgs/commit/04e6aee11d477e9485f37ee90a91410273f34eec) google-cloud-sdk: 452.0.1 -> 467.0.0
* [`a1896739`](https://github.com/NixOS/nixpkgs/commit/a1896739f6c7beced9d6a99b3e7aae8570eb4179) postgresql.pkgs: remove broken conditions for legacy versions
* [`a69f3706`](https://github.com/NixOS/nixpkgs/commit/a69f3706c7361b51ad3a991bdf689ff64751ae74) postgresql_12.pkgs.pg_repack: fix build
* [`f58132cb`](https://github.com/NixOS/nixpkgs/commit/f58132cb157d226b024418c0643994f2d31f2800) postgresql.pkgs.repmgr: fix build on linux
* [`5a57e16d`](https://github.com/NixOS/nixpkgs/commit/5a57e16d64748330ed7722ecb07d22f93ed967b2) postgresql.pkgs.pg_auto_failover: fix build on linux
* [`81c32a6b`](https://github.com/NixOS/nixpkgs/commit/81c32a6b3337d961a27bb9ac92f175b31e209d28) postgresql.pkgs.plv8: 3.1.5 -> 3.1.10
* [`135a3edf`](https://github.com/NixOS/nixpkgs/commit/135a3edf34da8badaf9a04304bfd831a957dd581) jacktrip: 2.2.2 -> 2.2.3
* [`838e48a8`](https://github.com/NixOS/nixpkgs/commit/838e48a89bd5f66b1ae956cfd62b6dceceb8d96a) rPackages.rDEA: fixed build
* [`0b1ab854`](https://github.com/NixOS/nixpkgs/commit/0b1ab8545eb74dc5b0dfc927309cccc834689b6a) python311Packages.sentry-sdk: 1.40.6 -> 1.41.0
* [`a312b411`](https://github.com/NixOS/nixpkgs/commit/a312b41117930031b659bdf12c4f3f4120952656) deeptools: 3.5.4 -> 3.5.5
* [`9aabf7a4`](https://github.com/NixOS/nixpkgs/commit/9aabf7a485eb5bd0e831457147441381cbf102cf) frugal: 3.17.8 -> 3.17.9
* [`b861b89b`](https://github.com/NixOS/nixpkgs/commit/b861b89ba1bd48c0718dcd3317e1aeca5a7f47fc) mitmproxy: 10.2.3 -> 10.2.4
* [`f72b809d`](https://github.com/NixOS/nixpkgs/commit/f72b809df5c05774a21177395e94b71be8f9e88d) rnix-lsp: remove package
* [`d47280b5`](https://github.com/NixOS/nixpkgs/commit/d47280b54b28b2b932df83d22d2b88bae39a71bc) tf-summarize: 0.3.7 -> 0.3.8
* [`5f6cea4c`](https://github.com/NixOS/nixpkgs/commit/5f6cea4c872a81f9ca84f5b88d23a42bac50ebf8) dmarc-report-converter: 0.6.5 -> 0.7.0
* [`e37e316b`](https://github.com/NixOS/nixpkgs/commit/e37e316bc22c9168ae8ae4e86aa7ae2c60e5850e) rPackages.opencv: fix build
* [`a36afbdd`](https://github.com/NixOS/nixpkgs/commit/a36afbdd06cba206287c4d985650ad91d391c68e) ruff: 0.3.1 -> 0.3.2
* [`5760460e`](https://github.com/NixOS/nixpkgs/commit/5760460e246b9d67355ccbafafdd75e8f05402b9) minizincide: 2.8.2 -> 2.8.3
* [`131439ff`](https://github.com/NixOS/nixpkgs/commit/131439ff2e6ef054cac603c1e52737111c0559c2) python311Packages.google-cloud-asset: 3.24.3 -> 3.25.0
* [`33df4307`](https://github.com/NixOS/nixpkgs/commit/33df4307c0dd834d965966607ec2185aa56d35f5) python311Packages.google-cloud-websecurityscanner: 1.14.2 -> 1.14.3
* [`870f58ff`](https://github.com/NixOS/nixpkgs/commit/870f58ffa94d8dd44246351aec220c77399ed4f8) python3Packages.gpuctypes: init at unstable-2023-11-26
* [`b7bcf94a`](https://github.com/NixOS/nixpkgs/commit/b7bcf94a708ce799a8586ce6255f80a27615731c) python311Packages.gpuctypes: add gpu tests
* [`24833cd1`](https://github.com/NixOS/nixpkgs/commit/24833cd162babe2c4d50b910d439d714fa8897d2) python3Packages.tinygrad: init at 0.8.0
* [`e6f565c8`](https://github.com/NixOS/nixpkgs/commit/e6f565c80d155ae2fb049962a06fb37e9c69c98b) miriway: unstable-2024-02-14 -> unstable-2024-03-06
* [`cdc62d93`](https://github.com/NixOS/nixpkgs/commit/cdc62d93a5713951da41cef441312625281adfec) magic-enum: 0.8.5 -> 0.9.5
* [`2c79eeeb`](https://github.com/NixOS/nixpkgs/commit/2c79eeeb830d8b1bef216adc0e14b5b811afe1c7) heroic: apply upstream adtraction fallback
* [`8082302c`](https://github.com/NixOS/nixpkgs/commit/8082302cfa19f9546c60d6d42fdbd19bd34f3009) idris2Packages.idris2Lsp: Add metadata to derivation
* [`caaf070e`](https://github.com/NixOS/nixpkgs/commit/caaf070e773a14cf214a789afa1a11d8b0a22f8a) python312Packages.pytest-examples: fix add patches due failing tests
* [`e5901147`](https://github.com/NixOS/nixpkgs/commit/e590114712b0e3674524696bd5dbf67f7464f927) gotosocial: 0.13.3 -> 0.14.1
* [`75c085f6`](https://github.com/NixOS/nixpkgs/commit/75c085f6c22aac3d29a279f908b08be51b61a174) dotnet: strip native symbols from runtime
* [`4abba468`](https://github.com/NixOS/nixpkgs/commit/4abba468680a8f9d7ad10b41140f11d7d90bfde1) fluffychat: 1.17.1 -> 1.18.0
* [`ec96063d`](https://github.com/NixOS/nixpkgs/commit/ec96063dce17cc8495e6596b8e496f483e65c256) nicotine-plus: migrate to gtk4
* [`9e119fe3`](https://github.com/NixOS/nixpkgs/commit/9e119fe382c098b89d57b687baff77bb0c006bb3) nicotine-plus: move to pkgs/by-name
* [`665a8341`](https://github.com/NixOS/nixpkgs/commit/665a8341d277550dfa47fb8557dda8bf14d7e3b3) stress-ng: 0.17.05 -> 0.17.06
* [`5751d5f7`](https://github.com/NixOS/nixpkgs/commit/5751d5f71743d1961e426a98fad1ea6dc1cca95f) abracadabra: 2.4.0 -> 2.5.0
* [`0ba56d8e`](https://github.com/NixOS/nixpkgs/commit/0ba56d8e1713d574f18da5c53b7241eb1d96b2b3) bililiverecorder: 2.10.1 -> 2.11.0
* [`03f97e69`](https://github.com/NixOS/nixpkgs/commit/03f97e690f23ce52729afab6ae266bd45ebc9bfc) jbang: 0.114.0 -> 0.115.0
* [`bc5f8a80`](https://github.com/NixOS/nixpkgs/commit/bc5f8a8059742b4c778362469adad2d703690744) mox: 0.0.9 -> 0.0.10
* [`10b5c199`](https://github.com/NixOS/nixpkgs/commit/10b5c19984f56375e58e9a6843d6762961e1c61f) igir: 2.5.0 -> 2.5.2
* [`f3db387b`](https://github.com/NixOS/nixpkgs/commit/f3db387b97b11f945a05f5068e998721372bd8c2) fsuae: prepare for by-name migration
* [`91856c93`](https://github.com/NixOS/nixpkgs/commit/91856c93b381f3998738b7ca9468fc473e77cf50) fsuae-launcher: prepare for by-name migration
* [`c2ad2cde`](https://github.com/NixOS/nixpkgs/commit/c2ad2cde3a2ae9831374801970fc07497c334529) fsuae: migrate to by-name
* [`f67c4bbc`](https://github.com/NixOS/nixpkgs/commit/f67c4bbccf1b4bac1d1b26e2812442cbc40f2f59) fsuae-launcher: migrate to by-name
* [`773de59c`](https://github.com/NixOS/nixpkgs/commit/773de59c1b602822af1e6ed750481cdcb896b6ac) fsuae-launcher: 3.1.68 -> 3.1.70
* [`a6d61a96`](https://github.com/NixOS/nixpkgs/commit/a6d61a96676d1b4ca2ba9edcb8c8dda4b4662fbd) bcache-tools: 1.0.7 -> 1.0.8
* [`9f7c981b`](https://github.com/NixOS/nixpkgs/commit/9f7c981becdaf5db54b43a2ac22a70feee0162c8) kikit: 1.4.0 -> 1.5.0
* [`7de0429c`](https://github.com/NixOS/nixpkgs/commit/7de0429c2511d507cffe0df99e12a66e43cae020) scsh: 0.7pre -> 0.7-unstable-2024-03-09
* [`571a9f40`](https://github.com/NixOS/nixpkgs/commit/571a9f40b8586dbc0a6417ccd3c9d9bd13f69e23) uv: 0.1.16 -> 0.1.17
* [`1dc508f7`](https://github.com/NixOS/nixpkgs/commit/1dc508f72cc6515f0f78f221e8682c0ed8899c6d) yt-dlp: 2023.12.30 -> 2024.3.10
* [`707cbe03`](https://github.com/NixOS/nixpkgs/commit/707cbe03d1b9f46412f1ba51bf7c95b153874243) scsh: add passthru.updateScript
* [`d807f03f`](https://github.com/NixOS/nixpkgs/commit/d807f03f74e6bd24d5baf2f7396e2b9329747459) quick-lint-js: 3.1.0 -> 3.2.0
* [`af7c614e`](https://github.com/NixOS/nixpkgs/commit/af7c614e5a05dd0e459b451be2b5c6a722bae58f) ferdium: 6.7.0 -> 6.7.1
* [`e7695eec`](https://github.com/NixOS/nixpkgs/commit/e7695eec30df1de649b824c94dc40877b5a199a7) toot: 0.41.1 -> 0.42.0
* [`2c968160`](https://github.com/NixOS/nixpkgs/commit/2c96816018036396d1f8befaed8303a715678eb8) rPackages.gpg: fixed build
* [`45468495`](https://github.com/NixOS/nixpkgs/commit/45468495560c4d49bde405b0bd2cfc7a67d0ec2f) rPackages.stpphawkes: fixed build
* [`ea5e24eb`](https://github.com/NixOS/nixpkgs/commit/ea5e24ebd106e3bd9661bd92691ee33f718b2973) python311Packages.types-psutil: 5.9.5.17 -> 5.9.5.20240205
* [`12f779bc`](https://github.com/NixOS/nixpkgs/commit/12f779bcd52b7d862937d815a65c3ed3e917db52) maintainers/scripts/bootstrap-files: Add powerpc64 to CROSS_TARGETS
* [`5ec7dcd7`](https://github.com/NixOS/nixpkgs/commit/5ec7dcd7c55dfd23f7b38c2f28e48034148fefdf) pkgs/stdenv/linux: init powerpc64-unknown-linux-gnuabielfv2 bootstrap-files
* [`e6bc4928`](https://github.com/NixOS/nixpkgs/commit/e6bc4928bc0b4764ef848333a9132fb8ee1eeb4d) haskellPackages.ghc-debug-brick: Fix build
* [`6814bef1`](https://github.com/NixOS/nixpkgs/commit/6814bef1edd88dc31eea863320fffc2cd00738c5) gimpPlugins.gap: 2.6.0 -> 2.6.0-unstable-2023-05-20
* [`d6516b3a`](https://github.com/NixOS/nixpkgs/commit/d6516b3ac9d25acf3dc53ba0c5d626f94c55c7a3) haskellPackages.graphql-client: Disable tests
* [`7928bc1a`](https://github.com/NixOS/nixpkgs/commit/7928bc1aa67f2dc11c8dd35cac5b13569f7b1fe3) python312Packages.pypinyin: 0.50.0 -> 0.51.0
* [`13d10cc6`](https://github.com/NixOS/nixpkgs/commit/13d10cc6e302e7d5800c6a08c1728b14c3801e26) Drop support for iCalendar
* [`2058a095`](https://github.com/NixOS/nixpkgs/commit/2058a09590653c6cff3470046cc343a1236fe28c) antimicrox: 3.3.4 -> 3.4.0
* [`c57c612b`](https://github.com/NixOS/nixpkgs/commit/c57c612ba0857dd9e58a64f9a32124f75e0e4893) evilwm: 1.4.2 -> 1.4.3
* [`84269dc0`](https://github.com/NixOS/nixpkgs/commit/84269dc031052cb3a0ca0c5b43b68bf49a840d4e) haskellPackages.threadscope: Fix build
* [`5be59e2a`](https://github.com/NixOS/nixpkgs/commit/5be59e2a5f6a700114d8f503a2db7efbdd86e52a) python312Packages.grpcio-testing: 1.62.0 -> 1.62.1
* [`a7016c10`](https://github.com/NixOS/nixpkgs/commit/a7016c1016f6a157d28a690c185483fedb0967ce) tuya-device-sharing-sdk: init at 0.2.0
* [`bde386aa`](https://github.com/NixOS/nixpkgs/commit/bde386aa1e44583cf9167c0edbddb69915854a88) home-assistant: typo
* [`3ffe0ebd`](https://github.com/NixOS/nixpkgs/commit/3ffe0ebddd402ab6ad20b982cdb603a447cba124) home-assistant: update component-packages
* [`87a4f132`](https://github.com/NixOS/nixpkgs/commit/87a4f1321fd8519860b065f824eed97b4b44b18e) dnf4: 4.18.2 -> 4.19.0
* [`7c467f63`](https://github.com/NixOS/nixpkgs/commit/7c467f63632a1e68e780a27cabd7f6d617306767) python312Packages.aiopvpc: 4.2.2 -> 4.3.0
* [`4150fc1b`](https://github.com/NixOS/nixpkgs/commit/4150fc1b4b5cf4f07e2a7ff0840436bb5db253a6) gtkcord4: migrate to pkgs/by-name
* [`aa4a658b`](https://github.com/NixOS/nixpkgs/commit/aa4a658bbac768bbb2cdc20574205ee307ec821e) rPackages.apsimx: fixed build
* [`a69527ff`](https://github.com/NixOS/nixpkgs/commit/a69527ffec035b48b6f9bcdef93c742a6a8b6b30) python311Packages.dissect-executable: 1.4 -> 1.5
* [`1f739a60`](https://github.com/NixOS/nixpkgs/commit/1f739a607bdae80b7c89bf618fbe07c108cfaa1d) steampipe: 0.21.8 -> 0.22.0
* [`e662ea95`](https://github.com/NixOS/nixpkgs/commit/e662ea95f50aa8aebc13b2172a9ea171a0453d24) v2ray-domain-list-community: 20240221053250 -> 20240310062737
* [`5096e9a7`](https://github.com/NixOS/nixpkgs/commit/5096e9a78474181331f2374acb43e0e692d1c422) hyprlandPlugins.hy3: unstable-2024-02-23 -> 0.36.0
* [`c235d913`](https://github.com/NixOS/nixpkgs/commit/c235d9139d8d566c67a010401e75a86fc3e7c8ea) rPackages.unrtf: fix build error
* [`cc13881d`](https://github.com/NixOS/nixpkgs/commit/cc13881d2e241ac35959b8a99c191ff3022d6fff) granted: 0.21.0 -> 0.21.1
* [`aeda0de9`](https://github.com/NixOS/nixpkgs/commit/aeda0de97acda27ff77e692ee3700dac05bc47e7) popeye: 0.20.5 -> 0.21.0
* [`cdebbedd`](https://github.com/NixOS/nixpkgs/commit/cdebbedd64ce5207f65be2f30ede15a290c3a45c) python311Packages.persim: 0.3.2 -> 0.3.5
* [`672e2c01`](https://github.com/NixOS/nixpkgs/commit/672e2c013f384f575636946b4d59a98fcc6dd353) scli: 0.7.3 -> 0.7.4
* [`6eee9d1c`](https://github.com/NixOS/nixpkgs/commit/6eee9d1c552ab1700e91b1e6c59775e75441b9a3) dissent: 0.0.19 -> 0.0.21; renamed from gtkcord4
* [`6a3f6d0b`](https://github.com/NixOS/nixpkgs/commit/6a3f6d0b65dff9d332d1f51d1a889dbca79097fd) python312Packages.pyqt6-webengine: normalize folder and pname
* [`2c5bf8a1`](https://github.com/NixOS/nixpkgs/commit/2c5bf8a1097eca05eee980b4ffd7ebe5515b8f4c) zrok: 0.4.24 -> 0.4.26
* [`fa7b1f5e`](https://github.com/NixOS/nixpkgs/commit/fa7b1f5eb8b9fda2dd2544f4341b346913a54303) kube-router: 2.0.1 -> 2.1.0
* [`88d82e85`](https://github.com/NixOS/nixpkgs/commit/88d82e8587266c2f773054f0cfd7e14a85c26f83) kube-router: unpin Go version
* [`64022a29`](https://github.com/NixOS/nixpkgs/commit/64022a296caffc55d1b13d27414aa2783bdf8bad) terser: 5.28.1 -> 5.29.1
* [`f7ed1663`](https://github.com/NixOS/nixpkgs/commit/f7ed1663f3ee34178872c35c3a0f1521ea13258e) sbcl: assert coreCompression -> !purgeNixReferences
* [`bbf6991a`](https://github.com/NixOS/nixpkgs/commit/bbf6991aa5fded31c4050331f557ebc559d6b13e) folio: init at 24.05
* [`2383e873`](https://github.com/NixOS/nixpkgs/commit/2383e873f915088bb53a79576b1d555cc558f0de) python312Packages.ipy: normalize pname and folder
* [`6b592238`](https://github.com/NixOS/nixpkgs/commit/6b592238cdb1b6341b95d95cb45f1f26f3a62077) moon: 1.22.4 -> 1.22.6
* [`574ccc12`](https://github.com/NixOS/nixpkgs/commit/574ccc1256059141f2931f6e5bf112a8c04d8d88) python312Packages.pyqt6-charts: normalize pname
* [`c9893686`](https://github.com/NixOS/nixpkgs/commit/c98936865da51654138466b3b9e195bf060dcb29) gitu: init at 0.5.4
* [`434e4065`](https://github.com/NixOS/nixpkgs/commit/434e4065af7f8439c6af7ca7a2a08ba04488acac) python311Packages.dissect-executable: refactor
* [`2f8f308c`](https://github.com/NixOS/nixpkgs/commit/2f8f308c950679873d1bbe7aacaf5072e2af2d78) python312Packages.aiopvpc: refactor
* [`2f219223`](https://github.com/NixOS/nixpkgs/commit/2f2192235a3a1e617a2578127cae147aeb37b3d8) python312Packages.imread: normalize pname
* [`cec84c2f`](https://github.com/NixOS/nixpkgs/commit/cec84c2febbdc25b03c0bf0e1a2ac6335490c99e) python311Packages.universal-pathlib: 0.1.4 -> 0.2.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
