### PR TITLE
niv home-manager: update 017b12de -> 6665da45

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "017b12de5b899ef9b64e2c035ce257bfe95b8ae2",
-        "sha256": "1z57h7y22yza1z0p5sj3q26msw5my18x32jn1l3mj0ch6rk3xblp",
+        "rev": "6665da45dd03857a4ae600cf246435e6ae57407e",
+        "sha256": "13d51bqagwjmnddjc3lvqghclf9d224i77zcrmcip42kx9z2xxs4",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/017b12de5b899ef9b64e2c035ce257bfe95b8ae2.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/6665da45dd03857a4ae600cf246435e6ae57407e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@017b12de...6665da45](https://github.com/nix-community/home-manager/compare/017b12de5b899ef9b64e2c035ce257bfe95b8ae2...6665da45dd03857a4ae600cf246435e6ae57407e)

* [`a500de54`](https://github.com/nix-community/home-manager/commit/a500de54b2e3067201a40cefa5f210f719423ddf) eza: replace enableAliases with integration options
* [`49a266d2`](https://github.com/nix-community/home-manager/commit/49a266d2ca59df8a03249550e73a54626181b65d) hyprland: add option for per-input device configs
* [`dab2437c`](https://github.com/nix-community/home-manager/commit/dab2437ca0aa0b91bbb0ea72a9f10ee494833593) flake.lock: Update
* [`1b74e367`](https://github.com/nix-community/home-manager/commit/1b74e3679e90fe7ad142bb5f66610a0d92ac0165) docs: update home-manager-option-search URL
* [`31abb4f6`](https://github.com/nix-community/home-manager/commit/31abb4f6bc540dfa82562e81312cfdc77770f001) docs: fix broken link
* [`0906e8df`](https://github.com/nix-community/home-manager/commit/0906e8dfe7a4a530799681be4be8ac5b48fddc0b) eza: use `mkDefault` for aliases
* [`a82cdd28`](https://github.com/nix-community/home-manager/commit/a82cdd288e3570ac52cffe0abaf28fac7d967b68) offlineimap: disable starttls if tls is disabled
* [`383296ff`](https://github.com/nix-community/home-manager/commit/383296ffa45b539c28bf79ec2a272f652838ddd1) joplin-desktop: add module
* [`2f0db7d4`](https://github.com/nix-community/home-manager/commit/2f0db7d418e781354d8a3c50e611e3b1cd413087) joplin-desktop: fix maintainer field
* [`01e4a514`](https://github.com/nix-community/home-manager/commit/01e4a5143e92251272850a8e0fbb4518bd099087) gpg-agent: migrate to 'pinentryPackage'
* [`1ab3cec3`](https://github.com/nix-community/home-manager/commit/1ab3cec3a1bbb065b2d52b913d1431366028d5b5) rbw: simplify 'pinentry' type
* [`58771949`](https://github.com/nix-community/home-manager/commit/587719494ed18a184c98c4d55dde9469af4446bf) gpg-agent: fix broken variable reference
* [`bd9141ea`](https://github.com/nix-community/home-manager/commit/bd9141ea97d8ccd68b97aa2febfae44683881662) fusuma: add missing dependencies
* [`ec4096e9`](https://github.com/nix-community/home-manager/commit/ec4096e9000c0b3695c05576076449ad99e905e3) eza: fix typo in docs
* [`601c22f8`](https://github.com/nix-community/home-manager/commit/601c22f8af61b9a2e47001474c595c78771aa3b2) Translate using Weblate (Vietnamese)
* [`35536fc6`](https://github.com/nix-community/home-manager/commit/35536fc6d621a084b04a70a6478db2aebbe828ed) docs: update beets and description of overriding packages
* [`096d9c04`](https://github.com/nix-community/home-manager/commit/096d9c04b3e9438855aa65e24129b97a998bd3d9) qutebrowser: actually implement unbinding
* [`02954535`](https://github.com/nix-community/home-manager/commit/029545350c013721e12139c9102f1776ca8aa9bb) activitywatch: add module
* [`ca922258`](https://github.com/nix-community/home-manager/commit/ca922258e1682b435e632a5ca1910bbbed835345) senpai: switch to scfg format
* [`dc2f3812`](https://github.com/nix-community/home-manager/commit/dc2f3812b41f825ed466c24c4211160d75cb890c) nix-gc: add daily frequency option
* [`3ad5c12f`](https://github.com/nix-community/home-manager/commit/3ad5c12f3c9b36cb8185d3aef9adcab3f543660a) zsh: set autosuggestion color
* [`b004e47e`](https://github.com/nix-community/home-manager/commit/b004e47e03577e1226e2fe2f1e56d67a6aa8489d) zsh: correct link for syntax-highlighting styles
* [`c781b28a`](https://github.com/nix-community/home-manager/commit/c781b28add41b74423ab2e64496d4fc91192e13a) zsh: add patterns option to syntax-highlighting
* [`206f457f`](https://github.com/nix-community/home-manager/commit/206f457fffdb9a73596a4cb2211a471bd305243d) prezto: be caseSensitive by default
* [`7b3fca5a`](https://github.com/nix-community/home-manager/commit/7b3fca5adcf6c709874a8f2e0c364fe9c58db989) docs: minor fixes of guidelines
* [`865bef34`](https://github.com/nix-community/home-manager/commit/865bef34355d7ad22141f44460ecf7f759f0ff77) kime: fix configuration
* [`baf76594`](https://github.com/nix-community/home-manager/commit/baf7659448ffa6ab6870dba1ca681a4868c3068a) kime: remove documentation dependency on config
* [`93dcc3da`](https://github.com/nix-community/home-manager/commit/93dcc3daa9aa42698823305a79e0957089af652d) nix.gc: let systemd use any time config
* [`6665da45`](https://github.com/nix-community/home-manager/commit/6665da45dd03857a4ae600cf246435e6ae57407e) flake.lock: Update
