### PR TITLE
niv nerd-icons.el: update c6a4acf1 -> 58db45e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "c6a4acf19454b415cba1c43daf4bfca8fccdd9ba",
-        "sha256": "1pnlp54f0c2wgc65p932xyk71lyw361x17w71fnxgp72j1a3y6dz",
+        "rev": "58db45e003e3c6283db54ace23e3594677ffd050",
+        "sha256": "19krrwfgiv1sd5p9xcd6gpfxvbmcjwa8skbllclic7nz17rcwjb5",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/c6a4acf19454b415cba1c43daf4bfca8fccdd9ba.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/58db45e003e3c6283db54ace23e3594677ffd050.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@c6a4acf1...58db45e0](https://github.com/rainstormstudio/nerd-icons.el/compare/c6a4acf19454b415cba1c43daf4bfca8fccdd9ba...58db45e003e3c6283db54ace23e3594677ffd050)

* [`58db45e0`](https://github.com/rainstormstudio/nerd-icons.el/commit/58db45e003e3c6283db54ace23e3594677ffd050) fix [rainstormstudio/nerd-icons.el⁠#74](https://togithub.com/rainstormstudio/nerd-icons.el/issues/74): nerd-icons-icon-for-dir hangs on remote hosts
