### PR TITLE
niv powerlevel10k: update 0cc19ac2 -> 3fe8706d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0cc19ac2ede35fd8accff590fa71df580dc7e109",
-        "sha256": "173735r9x2v0hhzr96pc4a4n0jnwjx73rxz57b1j24m38kl5c57q",
+        "rev": "3fe8706d248e330c9902baaf3399ab8d7d8f60ee",
+        "sha256": "1n3bcy7yz9x2igy0hyshxpw7r2jwr1lcnlmy5hdsdbmwycwc13kc",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0cc19ac2ede35fd8accff590fa71df580dc7e109.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/3fe8706d248e330c9902baaf3399ab8d7d8f60ee.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@0cc19ac2...3fe8706d](https://github.com/romkatv/powerlevel10k/compare/0cc19ac2ede35fd8accff590fa71df580dc7e109...3fe8706d248e330c9902baaf3399ab8d7d8f60ee)

* [`d39e4268`](https://github.com/romkatv/powerlevel10k/commit/d39e4268355f7a10f7758982db2a59e485d2659a) docs: mention sessions in the font instructions for MobaXterm ([romkatv/powerlevel10k⁠#2599](https://togithub.com/romkatv/powerlevel10k/issues/2599))
* [`0fdca5b1`](https://github.com/romkatv/powerlevel10k/commit/0fdca5b1e606cc9ab083d2f41262fa10adcbfb21) always offer the flat heads option in the wizard ([romkatv/powerlevel10k⁠#2600](https://togithub.com/romkatv/powerlevel10k/issues/2600))
* [`6836bfe2`](https://github.com/romkatv/powerlevel10k/commit/6836bfe2da51bf32472b67df062347cfc4b1952e) fix heads in the wizard ([romkatv/powerlevel10k⁠#2605](https://togithub.com/romkatv/powerlevel10k/issues/2605))
* [`07a971d3`](https://github.com/romkatv/powerlevel10k/commit/07a971d310821fd50ef91281543ff8fa446bd76c) remove `DISABLE_UPDATE_PROMPT=true` from instant prompt
* [`93d074a8`](https://github.com/romkatv/powerlevel10k/commit/93d074a82bcf5ac3dfe50b53b483381b8e330e01) add p10k-deactivate-instant-prompt
* [`a3f7dabc`](https://github.com/romkatv/powerlevel10k/commit/a3f7dabcae10f30f9cac402a4c4265c70be16846) cleanup
* [`50794fab`](https://github.com/romkatv/powerlevel10k/commit/50794faba46cc695ec6dc168793db08a50ea811b) Revert "add p10k-deactivate-instant-prompt"
* [`55c8f74c`](https://github.com/romkatv/powerlevel10k/commit/55c8f74c386b2cf54d3ca914cd451e22342e8d8a) Revert "remove `DISABLE_UPDATE_PROMPT=true` from instant prompt"
* [`a7f13e42`](https://github.com/romkatv/powerlevel10k/commit/a7f13e420e8bc929dcd7f1dc719f7b632fd5356c) bump version
* [`45627c52`](https://github.com/romkatv/powerlevel10k/commit/45627c528b4e3d8949a1e5c72ee3fe7cac516d8d) Squashed 'gitstatus/' changes from 215063d4..62177e89
