### PR TITLE
niv nixpkgs: update 65f4f042 -> 5ba94df4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "65f4f042f9a96a99afada17e1b6064f63da8aadc",
-        "sha256": "02aswz99hkjkkaj9wzbrbjisr1yzb61xdr66zws3xgdq2bzidd43",
+        "rev": "5ba94df425e26980b88e7f89e8d78cc33e6cf962",
+        "sha256": "158f175mjyxa56ys5wbfr68ykvkzdq7mh0c71vcmzsyzmp17b13b",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/65f4f042f9a96a99afada17e1b6064f63da8aadc.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5ba94df425e26980b88e7f89e8d78cc33e6cf962.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@65f4f042...5ba94df4](https://github.com/nixos/nixpkgs/compare/65f4f042f9a96a99afada17e1b6064f63da8aadc...5ba94df425e26980b88e7f89e8d78cc33e6cf962)

* [`b606e811`](https://github.com/NixOS/nixpkgs/commit/b606e811669a3f45d54740bb593d12058c3cbd4f) apng2gif: init at 1.8
* [`0c77de45`](https://github.com/NixOS/nixpkgs/commit/0c77de452ccc9ba5b4f170738fa23d8fe04cfa02) gif2apng: init at 1.9
* [`9f10ac64`](https://github.com/NixOS/nixpkgs/commit/9f10ac64ef840c41ab43dee6b3ffe07e788428ca) apngopt: init at 1.4
* [`db255951`](https://github.com/NixOS/nixpkgs/commit/db25595199c310fdee7d52066efedd2060a77874) mbidled: formatting
* [`0a8a7a7f`](https://github.com/NixOS/nixpkgs/commit/0a8a7a7f3f112ff6e46676ddefc55ffe5ee28b30) mbidled: unstable-2022-10-30 -> 2023-09-30
* [`108a6f18`](https://github.com/NixOS/nixpkgs/commit/108a6f181afc629d95c18543adc2a4c9d71a55f1) nixos/containers: check nixos-container names for underscores
* [`63a42a47`](https://github.com/NixOS/nixpkgs/commit/63a42a47de75e2b053743075bc9cce4b552e5b46) maintainers: add yannickulrich
* [`f92f8af4`](https://github.com/NixOS/nixpkgs/commit/f92f8af47fd049cca9ad8d67ed3547ce37d74542) vscode-extensions.catppuccin.catppuccin-vsc-icons: 0.12.0 -> 0.30.0
* [`bbafd350`](https://github.com/NixOS/nixpkgs/commit/bbafd350a44005f31ddff4c7e433353a5f3a9acf) readme: update method to show theme-based logo
* [`bfb8e800`](https://github.com/NixOS/nixpkgs/commit/bfb8e800ef3a6735c70446deae280c47d244df8f) vscode-extensions.foxundermoon.shell-format: 7.1.0 -> 7.2.5
* [`c1ead192`](https://github.com/NixOS/nixpkgs/commit/c1ead1926af300c686630e0f4afb4d11953f95eb) python311Packages.pytest-dependency: 0.5.1 -> 0.6.0
* [`0e74653e`](https://github.com/NixOS/nixpkgs/commit/0e74653e1a4180504c7b0c9488b5d4c2767d3e6f) wch-isp: 0.4.0 -> 0.4.1, move source to sr.ht
* [`b96305c9`](https://github.com/NixOS/nixpkgs/commit/b96305c92391ee709fec668ae3dd2934dda3a191) SDL2_mixer: 2.6.3 -> 2.8.0
* [`b8b53fdf`](https://github.com/NixOS/nixpkgs/commit/b8b53fdf37710b1c1b58b9a17e2649355dbee938) nixos/kernel: add hid_corsair to initrd modules
* [`63f7e0c1`](https://github.com/NixOS/nixpkgs/commit/63f7e0c1add75b6a991e722f6d5ea8257e2fcff3) SDL2_ttf: 2.20.2 -> 2.22.0
* [`fbf8ee8a`](https://github.com/NixOS/nixpkgs/commit/fbf8ee8a6a7563969ff663e10a2341f14e528766) msieve: 1.53 -> r1050
* [`0f51274e`](https://github.com/NixOS/nixpkgs/commit/0f51274e69d591eba28c3537fdba8edae075b888) python311Packages.black: 23.11.0 -> 24.1.1
* [`e071e1b9`](https://github.com/NixOS/nixpkgs/commit/e071e1b947ec26954a1cbbbfc001dec353d5c6fc) maintainers: add Guanran928
* [`8c55ddd3`](https://github.com/NixOS/nixpkgs/commit/8c55ddd36700723429c3a24b14661ac600b82ca6) resonance: init at 0-unstable-2023-06-06
* [`8533260f`](https://github.com/NixOS/nixpkgs/commit/8533260f17896b01a14e2da36e0244084c054a62) modemmanager: enable strictDeps
* [`26316368`](https://github.com/NixOS/nixpkgs/commit/26316368cbf79bebbd74094d2bdb3b2d96e73937) hedgedoc: fix executing any of the management clis, remove heroku bin
* [`e91a7b7a`](https://github.com/NixOS/nixpkgs/commit/e91a7b7a4e9513f4a2741b1a38c52fb81d4c9415) hedgedoc: move files to share/hedeodc in the package
* [`23998607`](https://github.com/NixOS/nixpkgs/commit/239986078b35942d022a72abb21214dc3fb33f64) jitsi-meet: 1.0.7762 -> 1.0.7790
* [`782e2d25`](https://github.com/NixOS/nixpkgs/commit/782e2d252dd9abc03f4ef765a9c35eed84476d6c) libselinux: remove use of LFS64 function
* [`d6ea5680`](https://github.com/NixOS/nixpkgs/commit/d6ea56801391c308de0185066b55b165c788a5fb) tinymembench: init at 0.4
* [`f9b69605`](https://github.com/NixOS/nixpkgs/commit/f9b6960581d2dd1b9b8bbf24fb268a6970191b85) kstars: 3.6.7 -> 3.6.9
* [`e70105cf`](https://github.com/NixOS/nixpkgs/commit/e70105cf8392dc7b792d8ffd73ac4c6e81e0f505) procmail: support cross compilation
* [`dddcbfae`](https://github.com/NixOS/nixpkgs/commit/dddcbfae8336d3d0da36c9e1d7fed745a0be2bc9) normaliz: init at version 3.10.1
* [`4d4d9063`](https://github.com/NixOS/nixpkgs/commit/4d4d90636eecb80e90d9486cda8d3fbfc8afcd2a) cosmic-settings: unstable-2024-01-09 -> 0-unstable-2024-02-15
* [`eb28e5e7`](https://github.com/NixOS/nixpkgs/commit/eb28e5e72ef912629ded3e265f7344ca21d115b9) stdenv: log build hooks as they run
* [`58a37380`](https://github.com/NixOS/nixpkgs/commit/58a373809a0399a64d8f5bc7ccc79d6c3c625447) nixos/systemd/initrd: follow init param symlinks
* [`191e258e`](https://github.com/NixOS/nixpkgs/commit/191e258e6cac29099eab124353e03210dd007254) nixos/boot: move name overwrite to pkgs.aggregateModules to option
* [`51f35952`](https://github.com/NixOS/nixpkgs/commit/51f359526f0a7c5992c4986ccc8dbbc3e8c5ce5a) stremio: split derivation arguments into multiple lines
* [`17875636`](https://github.com/NixOS/nixpkgs/commit/17875636a48c9a8bb199c6f03ddb5a2af20a6f62) maintainers: add elpdt852
* [`f3ea5cfa`](https://github.com/NixOS/nixpkgs/commit/f3ea5cfa6ec0a640735f4d6a0b5c91683c9bab25) nix-snapshotter: init at 0.2.0
* [`eaffd250`](https://github.com/NixOS/nixpkgs/commit/eaffd2500fb3ab7b073f3b3bf9e80deb9044b7a7) nethack: enable curses on darwin
* [`2776ca8d`](https://github.com/NixOS/nixpkgs/commit/2776ca8dcc102f7efb25315c086dd3fef732ae5c) cargo-auditable: 0.6.1 -> 0.6.2
* [`35f8b691`](https://github.com/NixOS/nixpkgs/commit/35f8b6919a63c2d415f825075bbe5535ca99bd05) vscode-extensions.vadimcn.vscode-lldb: Fix python scripts for adapter
* [`6c7e8088`](https://github.com/NixOS/nixpkgs/commit/6c7e80886c737da833acc9ca504faed0749e9f84) networkmanager: 1.44.2 → 1.46.0
* [`e1863b4f`](https://github.com/NixOS/nixpkgs/commit/e1863b4f797d15aef036b9f227f88580b60ef5b5) nixos/networkmanager: support stable-ssid for cloned MAC addresses
* [`ccce06eb`](https://github.com/NixOS/nixpkgs/commit/ccce06eb008423fa1a7fc8d540d9ad1766e95448) python3Packages.requests-gssapi: init at 1.2.3
* [`6c540376`](https://github.com/NixOS/nixpkgs/commit/6c540376d286c66452a1ce1a6869852a84dc14fd) python311Packages.pytest-httpserver: 1.0.8 -> 1.0.9
* [`6906fc1e`](https://github.com/NixOS/nixpkgs/commit/6906fc1ebc399fcb81b648209a08d368837f564a) python311Packages.pytest-httpserver: refactor
* [`c0d67ddf`](https://github.com/NixOS/nixpkgs/commit/c0d67ddff4dfd46d08a62cf730c04bda5b882481) nvtop: 3.0.2 -> 3.1.0
* [`101fce31`](https://github.com/NixOS/nixpkgs/commit/101fce31943bc1aff4c9fab0a608a1609a881f9a) srtp: 2.5.0 -> 2.6.0
* [`2d2ccff7`](https://github.com/NixOS/nixpkgs/commit/2d2ccff700f83588f1dc290f77e428fe85c90819) suwayomi-server: 0.7.0 -> 1.0.0
* [`2f460b3f`](https://github.com/NixOS/nixpkgs/commit/2f460b3f53867d1a4949cae7417203b1a457ea48) nixos/suwayomi-server: add option `settings.server.extensionRepos`
* [`3851be87`](https://github.com/NixOS/nixpkgs/commit/3851be87bcc486af2796ad42dc070eb20cb7cd7d) python3Packages:frozenlist2: init at 1.0.0
* [`87c22ad5`](https://github.com/NixOS/nixpkgs/commit/87c22ad506908f5653cd7fcf5629a2c9c750f15a) qpdf: 11.8.0 -> 11.9.0
* [`9aef0958`](https://github.com/NixOS/nixpkgs/commit/9aef09586ea26be9d2cf8bfa0564539ddcbe0129) prev: apply fixes from code review
* [`a34621a5`](https://github.com/NixOS/nixpkgs/commit/a34621a5bae13da358eb1082307c8d14f1fab864) git: 2.43.2 -> 2.44.0
* [`150cd0ab`](https://github.com/NixOS/nixpkgs/commit/150cd0ab619dae2da2fc7f8d8478000571e1717d) git: disable completion test all the time, as it is now failing even on x86-64_linux
* [`913a1d43`](https://github.com/NixOS/nixpkgs/commit/913a1d439ce5d066239403d9c6b27e34c221b94a) git: use easier string concatenation instead of inlining things
* [`22bb14bd`](https://github.com/NixOS/nixpkgs/commit/22bb14bd5de6eb3fe6d124016556b83ebfadce19) sane-backends: generate hwdb entries for epkowa scanners correctly
* [`c3bc720f`](https://github.com/NixOS/nixpkgs/commit/c3bc720fb7c7246daca4afaee3b160dc2ee03d63) ms-vscode-remote.remote-containers: 0.305.0 -> 0.347.0
* [`f854ac4b`](https://github.com/NixOS/nixpkgs/commit/f854ac4b41ba455ffcb02d5348e290a1d88a8a94) libunwind: 1.8.0 -> 1.8.1
* [`ff372db9`](https://github.com/NixOS/nixpkgs/commit/ff372db9b4e4eab33bf2c48a2d4ee8c644fe4f78) prev: per-review: reword comment regarding logging of implicit hooks
* [`db29803f`](https://github.com/NixOS/nixpkgs/commit/db29803fd8fbd08cec713e0dd7c191a965f1381d) libksba: 1.6.5 -> 1.6.6
* [`f44a9f89`](https://github.com/NixOS/nixpkgs/commit/f44a9f89a9eb96447fdeb971facfa8a162e8c847) npth: 1.6 -> 1.7
* [`ec87671b`](https://github.com/NixOS/nixpkgs/commit/ec87671bd192238bfc1f56c2afdeee820aa03f3d) nixos/plymouth: improving documentation of logo option
* [`6ef07201`](https://github.com/NixOS/nixpkgs/commit/6ef0720193235213a0df0e7375bd27e8c849cfb3) python311Packages.keyring: 24.3.0 -> 24.3.1
* [`d4c26061`](https://github.com/NixOS/nixpkgs/commit/d4c26061bd49f783c97df5c5b9942d1921ee60d5) libsForQt5.mauiPackages: fix typo
* [`779158c5`](https://github.com/NixOS/nixpkgs/commit/779158c5e32935a051917e15f7852976fbff2418) libsForQt5.mauiPackages: 3.0.2 -> 3.1.0
* [`28665e1e`](https://github.com/NixOS/nixpkgs/commit/28665e1e5e6b35c433578b22613a5d8e44a6d4ef) capslock: init at 0.1.1
* [`0dc95d4a`](https://github.com/NixOS/nixpkgs/commit/0dc95d4a887582de16a60d679d3ff0e7ac01deaf) memcached: 1.6.23 -> 1.6.24
* [`291f1d4b`](https://github.com/NixOS/nixpkgs/commit/291f1d4b7e059e2a80a45c1b305501c8335155d7) libipt: 2.1 -> 2.1.1
* [`160fdcf8`](https://github.com/NixOS/nixpkgs/commit/160fdcf85aea8c8877f47770804e7d0c5b017ec8) s2n-tls: 1.4.3 -> 1.4.5
* [`7ff4987d`](https://github.com/NixOS/nixpkgs/commit/7ff4987dafefac0551284ebc379a4f981953c637) cosmic-files: unstable-2024-01-12 -> 0-unstable-2024-02-28
* [`94e65456`](https://github.com/NixOS/nixpkgs/commit/94e65456eb991a3c3638c671cfd8d31a941981f2) cosmic-edit: 0-unstable-2024-01-19 -> 0-unstable-2024-02-28
* [`8b421de7`](https://github.com/NixOS/nixpkgs/commit/8b421de79c55265803fbd732ab453de90ce9f27f) cosmic-term: 0-unstable-2024-01-12 -> 0-unstable-2024-02-28
* [`87433fa0`](https://github.com/NixOS/nixpkgs/commit/87433fa05a6217c7066060de3bdeacff1a2d992a) pahole: 1.25 -> 1.26
* [`a9e9d60d`](https://github.com/NixOS/nixpkgs/commit/a9e9d60d946eb7b72ae1456cfb9a702f986e0847) ell: 0.62 -> 0.63
* [`3af48c85`](https://github.com/NixOS/nixpkgs/commit/3af48c85ed21d9cfdf54b6d8c62b4394b2de4837) libpsl: split outputs
* [`32c09ed0`](https://github.com/NixOS/nixpkgs/commit/32c09ed0c92a8361057a56c2b186553dbbbf88a8) vultr-cli: only generate shell completion when doing native compilation
* [`ccbbec1f`](https://github.com/NixOS/nixpkgs/commit/ccbbec1fb9deff1c78a66058023423ba78dcedab) re2: 2024-02-01 -> 2024-03-01
* [`d7a5c00b`](https://github.com/NixOS/nixpkgs/commit/d7a5c00b59bc763f26cf01f6864114a166acb410) wavpack: 5.6.0 -> 5.7.0
* [`0f0a1afe`](https://github.com/NixOS/nixpkgs/commit/0f0a1afe0a8602a67405ff2abb09ebf0ff426101) pixman: 0.43.2 -> 0.43.4
* [`aba28d51`](https://github.com/NixOS/nixpkgs/commit/aba28d51032fc7c1055e579cab280cc6b1a52492) xdg-utils: add perlPackages.FileMimeInfo to xdg-mime-prologue ([nixos/nixpkgs⁠#291692](https://togithub.com/nixos/nixpkgs/issues/291692))
* [`c88d5bd5`](https://github.com/NixOS/nixpkgs/commit/c88d5bd52915e6f847f84b21132e940fb2445bde) nghttp2: 1.59.0 -> 1.60.0
* [`6d72a791`](https://github.com/NixOS/nixpkgs/commit/6d72a791c06c29d223db2e005dab565d90067b59) autogen: patch out use of LFS64 functions
* [`52223518`](https://github.com/NixOS/nixpkgs/commit/52223518a0e72c082e3df83e7706e4c0c8898107) doxygen: unvendor spdlog
* [`ce852b43`](https://github.com/NixOS/nixpkgs/commit/ce852b43b0611897874a689cd0d534b7a6bf5594) giflib: 5.2.1 -> 5.2.2, apply patch for CVE-2021-40633
* [`fac842bb`](https://github.com/NixOS/nixpkgs/commit/fac842bb7abdb0ad0fb215f69a95c32ec9e9eea9) giflib: drop unused 4.1.nix
* [`92ed43bf`](https://github.com/NixOS/nixpkgs/commit/92ed43bf46b73c522bf9daf6767c3417e576148a) libjxl: fix build with `strictDeps = true;`
* [`13eea132`](https://github.com/NixOS/nixpkgs/commit/13eea132c082dfcc5080d50ef8724952934b6a47) libredirect: don't test LFS64 functions on musl
* [`9046690c`](https://github.com/NixOS/nixpkgs/commit/9046690c73d913972e510566f03fad33fbe7eaf1) hdf5: refactor to reduce downstream closure size
* [`598743ec`](https://github.com/NixOS/nixpkgs/commit/598743ec93acbe3674dd323526a119c495542ae8) libpng: 1.6.40 -> 1.6.42
* [`62b43397`](https://github.com/NixOS/nixpkgs/commit/62b433975f2d1ffa7cb4dab95f09f2ad56c0bbbc) spirv-llvm-translator: drop redundant `disable-warnings-if-gcc13`
* [`626bc9e6`](https://github.com/NixOS/nixpkgs/commit/626bc9e6ea15d23d7116b339a96a6168fec42811) boringssl: drop redundant `disable-warnings-if-gcc13`
* [`0712b9fe`](https://github.com/NixOS/nixpkgs/commit/0712b9fe0a0b23a19a24df0c8147dd50ba0a8d91) lzip: 1.24 -> 1.24.1
* [`944472c6`](https://github.com/NixOS/nixpkgs/commit/944472c645d0a6383015dc3c03605ad61ee02689) iwd: 2.14 → 2.15
* [`7374ffe8`](https://github.com/NixOS/nixpkgs/commit/7374ffe8f734d5bc288dfb960c8df57c1a4f53d4) emacs.pkgs.seq: stop shadowing it
* [`a9cfbfda`](https://github.com/NixOS/nixpkgs/commit/a9cfbfda7f3354200dba03a2f122a20f50784601) emacs.pkgs.seq: fix build
* [`75c7e616`](https://github.com/NixOS/nixpkgs/commit/75c7e616012c7e3fbb498a3f11a2083856abc033) nixos/oauth2_proxy_nginx: allow placing the login page itself under a separate domain
* [`710aa8d4`](https://github.com/NixOS/nixpkgs/commit/710aa8d4b56150d628c23ad1bb4ab8af92aa1026) at-spi2-core: 2.50.0 → 2.50.1
* [`894c8375`](https://github.com/NixOS/nixpkgs/commit/894c83756c39fa28bd65815193e0e5ef5030b832) python311Packages.ipython: 8.20.0 -> 8.22.1
* [`7de9dbd5`](https://github.com/NixOS/nixpkgs/commit/7de9dbd5d5126a594116cb62dfb7935536640b94) python3Packages.flask-security-too: 5.3.3 -> 5.4.1
* [`0c3c0fee`](https://github.com/NixOS/nixpkgs/commit/0c3c0fee1fabba70308f2318b13db1b36d9c1339) shadow: 4.14.5 -> 4.14.6
* [`ece21bf0`](https://github.com/NixOS/nixpkgs/commit/ece21bf002266a880b16ececb8a35c67058e8f19) ffmpeg_5: 5.1.3 -> 5.1.4
* [`19d6df88`](https://github.com/NixOS/nixpkgs/commit/19d6df886fa6b34470e7d32feb3b8717f8321599) ffmpeg: 6.1 -> 6.1.1
* [`1961b195`](https://github.com/NixOS/nixpkgs/commit/1961b19550f69680137e438b73dd5067266efec3) pipewire: Fix libdrm dependency
* [`1121d9db`](https://github.com/NixOS/nixpkgs/commit/1121d9dbb6747c6282f3b8082168aa6404790960) libopus: 1.4 -> 1.5.1
* [`3f801b7a`](https://github.com/NixOS/nixpkgs/commit/3f801b7a6589226ce8086908e61fefe22208b3df) libopus: use finalAttrs pattern
* [`3e648731`](https://github.com/NixOS/nixpkgs/commit/3e6487310ea0aa2be7a0b83bb7c83a6d6188bc9e) libopus: add pkg-config tester
* [`6d5c84fe`](https://github.com/NixOS/nixpkgs/commit/6d5c84fef68657f7187a0de3312db06459c8cb74) cargo-c: 0.9.24 -> 0.9.29
* [`a7c5d517`](https://github.com/NixOS/nixpkgs/commit/a7c5d5178ef02da322bdf6857095b635812b7afd) libopus: add passthru.updateScript
* [`b04b0d0e`](https://github.com/NixOS/nixpkgs/commit/b04b0d0ee04fde555e6681a6cd2153964c680464) perl: enableParallelBuilding when not crossCompiling
* [`3009ef39`](https://github.com/NixOS/nixpkgs/commit/3009ef39749c9d1870f3531dfe9dd1bda439af84) gn: drop redundant `disable-warnings-if-gcc13`
* [`cd00c693`](https://github.com/NixOS/nixpkgs/commit/cd00c693df51959c8ceb28c3feedd5a82d7992b1) python311Packages.django_4: 4.2.10 -> 4.2.11
* [`9b302a3b`](https://github.com/NixOS/nixpkgs/commit/9b302a3b9df848281536e4ece6fb9e6bf941bd15) python311Packages.sqlalchemy: 2.0.27 -> 2.0.28
* [`c0feba86`](https://github.com/NixOS/nixpkgs/commit/c0feba86fb90f56028dc11812d8aed9e068a2089) nixos/test-instrumentation: use full path to env
* [`9782a7ce`](https://github.com/NixOS/nixpkgs/commit/9782a7ce245fb6654d0db360a4e2c1f7a7dcf4a0) pcsclite: 2.0.1 -> 2.0.3
* [`c39fd61b`](https://github.com/NixOS/nixpkgs/commit/c39fd61be9f5c3aa3d8eb48d6a3a971fbe948bac) xorg.xauth: 1.1.2 -> 1.1.3
* [`db952cc1`](https://github.com/NixOS/nixpkgs/commit/db952cc105875528f3292aa0dc1497b82b44425b) maintainers: add rookeur
* [`62d119f5`](https://github.com/NixOS/nixpkgs/commit/62d119f5d618789a393de076fbf3a2a13b35b58a) vim: 9.1.0075 -> 9.1.0148
* [`2451fc96`](https://github.com/NixOS/nixpkgs/commit/2451fc96e710a2f7645703facab08b6b817711fb) 0.6.0 → 1.0b1 polonium.nix
* [`19827de6`](https://github.com/NixOS/nixpkgs/commit/19827de662d1ca2e2abf03adad6e86cfbc8b4f8c) update hashes for polonium 1.0b1
* [`5e98822f`](https://github.com/NixOS/nixpkgs/commit/5e98822fc7c1f3deff3145beb87599ef058c6870) maintainers: add fabianrig
* [`b5ff7ed5`](https://github.com/NixOS/nixpkgs/commit/b5ff7ed5aad90139a85cc992f6e151cb361389f4) maturin: 1.4.0 -> 1.5.0
* [`49a77003`](https://github.com/NixOS/nixpkgs/commit/49a77003ae1dfb3bafb4adeaf33b106fa4604dbf) hwdata: 0.379 -> 0.380
* [`fa5ec1f7`](https://github.com/NixOS/nixpkgs/commit/fa5ec1f70d0e4f96dd80d7dbe441a246eed559c0) pipewire: Remove dependency on tinycompress
* [`842db42c`](https://github.com/NixOS/nixpkgs/commit/842db42c45e522765f3223396c5976857043421f) pipewire: Enable ffmpeg support in tools when ffmpegSupport is enabled
* [`7b3431e7`](https://github.com/NixOS/nixpkgs/commit/7b3431e72ffa3e023a1802f5d3baf2e64ab67d1b) med: init at 3.10.1
* [`44dc371f`](https://github.com/NixOS/nixpkgs/commit/44dc371f12baa27677462273b8056842344bd3c9) appstream: build with compose support
* [`c0aefced`](https://github.com/NixOS/nixpkgs/commit/c0aefced56ec456fa83682fa7647e419dc373468) flatpak-builder: 1.2.3 -> 1.4.2
* [`3e745860`](https://github.com/NixOS/nixpkgs/commit/3e745860a40c5638567d77897b4d9cfb0fe1bb5d) python3Packages.pybind11: drop redundant `disable-warnings-if-gcc13`
* [`fcf59287`](https://github.com/NixOS/nixpkgs/commit/fcf592875713765c548702345020a6043ce52058) python3Packages.pycrypto: drop redundant `disable-warnings-if-gcc13`
* [`cdc6e3f3`](https://github.com/NixOS/nixpkgs/commit/cdc6e3f3b59d77027371a8c2c43e24b7ac0b9e80) uboot: 2023.07.02 -> 2024.01
* [`5b02c75a`](https://github.com/NixOS/nixpkgs/commit/5b02c75ac07a1ad525f1d7bfc305a4359d0f2917) go_1_21: 1.21.7 -> 1.21.8
* [`1c6325cb`](https://github.com/NixOS/nixpkgs/commit/1c6325cb744a70c88333275f6a60150b294282d5) authentik,authentik-outposts.ldap: 2023.10.7 -> 2024.2.2
* [`5ec74f48`](https://github.com/NixOS/nixpkgs/commit/5ec74f48ce026e0b3fda67376692aef8a12a021e) luarocks: 3.9.2 -> 3.10.0
* [`bfd8cef2`](https://github.com/NixOS/nixpkgs/commit/bfd8cef2828134fa9d0fca7707446bb1c73f42b6) olvid: init at 1.5.0
* [`c4eb1d6a`](https://github.com/NixOS/nixpkgs/commit/c4eb1d6a38894d9082a2217f7c58841df0ee74da) python3Packages.email-validator: 2.1.0 -> 2.1.1
* [`434c3c83`](https://github.com/NixOS/nixpkgs/commit/434c3c83deddda49eb345312690404083d51d2f6) rstudio: 2023.9.0+463 -> 2023.12.1+402
* [`74b1253a`](https://github.com/NixOS/nixpkgs/commit/74b1253a65f2e4fb0226228a4e68f53d81461963) SDL2: 2.30.0 -> 2.30.1
* [`a7765a73`](https://github.com/NixOS/nixpkgs/commit/a7765a73d4af88ab44c88c0ef4be3ea80bb786e4) libassuan: 2.5.6 -> 2.5.7
* [`d6b47c36`](https://github.com/NixOS/nixpkgs/commit/d6b47c36feae64b20250df20429f685c28388d65) python311Packages.cryptography: 42.0.2 -> 42.0.5
* [`92a6e0b5`](https://github.com/NixOS/nixpkgs/commit/92a6e0b5ef1ffec7a4c4da6106f6d895b2ec4b1c) python311Packages.httpx: 0.26.0 -> 0.27.0
* [`c0f3eda8`](https://github.com/NixOS/nixpkgs/commit/c0f3eda821f355349a40164a6ba203d8cc48da7e) python311Packages.httpx-auth: 0.21.0 -> 0.22.0
* [`d08d9c65`](https://github.com/NixOS/nixpkgs/commit/d08d9c65b6b05110ddb256900ca411eb881956aa) python311Packages.bcrypt: 4.1.1 -> 4.1.2
* [`ff9f6b8c`](https://github.com/NixOS/nixpkgs/commit/ff9f6b8c49bde62a593469152ffed7e690660801) python311Packages.pyopenssl: 23.3.0 -> 24.0.0
* [`50c3d5c5`](https://github.com/NixOS/nixpkgs/commit/50c3d5c5414fa15abeb1904b7f956e2b5c3bb8da) libassuan: update meta
* [`d85d4396`](https://github.com/NixOS/nixpkgs/commit/d85d4396e447088e7e09ce1ed1abed7af171d081) libassuan: add passthru.updateScript
* [`9c23a78b`](https://github.com/NixOS/nixpkgs/commit/9c23a78bd6d7b1490a0055fdbe438cdca3ee9bde) yubikey-touch-detector: 1.10.1 -> 1.11.0
* [`597e669b`](https://github.com/NixOS/nixpkgs/commit/597e669b94f89759fe8586568de57bf2096736ce) xorg.libXcursor: 1.2.1 -> 1.2.2
* [`3b6cf1e0`](https://github.com/NixOS/nixpkgs/commit/3b6cf1e0ce49468c9e571b15006d735e66f73a5d) libopenmpt: 0.7.3 -> 0.7.4
* [`e8994657`](https://github.com/NixOS/nixpkgs/commit/e8994657b46a505c0666775f7dfdab80c8a8bd3d) python312Packages.clickhouse-cityhash: fix build for python 3.12
* [`2dea768a`](https://github.com/NixOS/nixpkgs/commit/2dea768a21d625d1f23ac45c667809001cf62e23) nixseparatedebuginfod: 0.3.3 -> 0.3.4
* [`72013964`](https://github.com/NixOS/nixpkgs/commit/7201396492e8a4f3716153c1603ae3e884c79edc) llvm: stop running strip-preserve-atime.test
* [`9dd8b7a1`](https://github.com/NixOS/nixpkgs/commit/9dd8b7a1be7c75fbc54d76b539e18362b05e7beb) python312Packages.clickhouse-driver: add support for python 3.12
* [`1ce934ff`](https://github.com/NixOS/nixpkgs/commit/1ce934ff369d3ad4b9c454a2f745374a8e462678) emacs: add "withDbus" and "withSelinux" flags
* [`7517f8ed`](https://github.com/NixOS/nixpkgs/commit/7517f8edd06c02e2d773e2545f881eebc7de724f) glib: switch elfutils in for abandoned libelf
* [`f8e85512`](https://github.com/NixOS/nixpkgs/commit/f8e85512ed6b9647ac11cb6fa20c6cdf2c63ecd2) photonvision: init at 2024.2.3
* [`3609e216`](https://github.com/NixOS/nixpkgs/commit/3609e216a438192a6caf27f20f4c5124c91d83da) nixos/photonvision: init module
* [`ea710178`](https://github.com/NixOS/nixpkgs/commit/ea7101783c474ba072fa565e3ecc0e5c530ef61b) nixos/tests/photonvision: init
* [`9b7e02dd`](https://github.com/NixOS/nixpkgs/commit/9b7e02dd4b8ac50e568b076e9d3903c7a75808ac) nixos/dnsproxy: init module
* [`e035dab4`](https://github.com/NixOS/nixpkgs/commit/e035dab4fffc152878e73988272d099c3e6b13c1) doc: add services.dnsproxy to 24.05 release notes
* [`3fae0e20`](https://github.com/NixOS/nixpkgs/commit/3fae0e206d53551e09007099ad17831d00634496) dmenu-rs: 5.5.2 -> 5.5.3
* [`555aad70`](https://github.com/NixOS/nixpkgs/commit/555aad70c0fd79520ebd9d15d22bff27439b759f) nixos/joycond-cemuhook: fix missing module
* [`c50cf32d`](https://github.com/NixOS/nixpkgs/commit/c50cf32d821986998bd99472df263cc7e7ba9f4a) grpc: 1.62.0 -> 1.62.1
* [`85871c9d`](https://github.com/NixOS/nixpkgs/commit/85871c9dad25f62b76dbaa8f382ec4c8b7771cc2) python311Packages.grpcio: 1.62.0 -> 1.62.1
* [`5e70fe64`](https://github.com/NixOS/nixpkgs/commit/5e70fe64142b86c7f663ab40dc84b8a4832a93b0) python311Packages.grpcio-tools: 1.62.0 -> 1.62.1
* [`47c93314`](https://github.com/NixOS/nixpkgs/commit/47c9331476caa63ebb9d936cbc63160b1cd6f148) python311Packages.grpcio-status: 1.62.0 -> 1.62.1
* [`ab8f5854`](https://github.com/NixOS/nixpkgs/commit/ab8f5854e7816a201134e0e32adc941c82bd0a25) pkgsStatic.aws-c-cal: Fix dlopen assertion
* [`00d6265f`](https://github.com/NixOS/nixpkgs/commit/00d6265f186da2b0c788709d97b0d4613fa5a83f) flameshot: enable wayland clipboard
* [`11a38e6c`](https://github.com/NixOS/nixpkgs/commit/11a38e6cc597de46c55b42aac734e127148f9524) appium-inspector: init at 2024.3.1
* [`b5cc2890`](https://github.com/NixOS/nixpkgs/commit/b5cc28904946a749c6ad676bbd0c80a9d7c3b5be) roslyn-ls: 4.10.0-2.24102.11 -> 4.10.0-2.24124.2
* [`82ade585`](https://github.com/NixOS/nixpkgs/commit/82ade5850b8884c6ebe22786e5b7248a8154385e) appstream: 1.0.1 -> 1.0.2
* [`309c9076`](https://github.com/NixOS/nixpkgs/commit/309c90768c1cbe030c1c8c117187b5f4ce5b5fa6) cmus: 2.10.0 -> 2.10.0-unstable-2023-11-05
* [`9056b165`](https://github.com/NixOS/nixpkgs/commit/9056b165398e89dc989c1b900fe160d0eb76b622) sparrow: 1.8.1 -> 1.8.4
* [`6a43ed0f`](https://github.com/NixOS/nixpkgs/commit/6a43ed0f60edf9e1ced9822298c85718f2a16ccc) python311Packages.weasyprint: 61.1 -> 61.2
* [`67f2757e`](https://github.com/NixOS/nixpkgs/commit/67f2757e092c89aca744a761d4d54f1a15ea477d) iwd: 2.15 -> 2.16
* [`0d14dc5d`](https://github.com/NixOS/nixpkgs/commit/0d14dc5dd5a9cf3e4be31285ce75771567ef7ff9) vscode-extensions.smcpeak.default-keys-windows: init at 0.0.10
* [`9f50f521`](https://github.com/NixOS/nixpkgs/commit/9f50f521938528c4d89b9ac497e818f6153400f1) xapian: 1.4.24 -> 1.4.25
* [`a444ef31`](https://github.com/NixOS/nixpkgs/commit/a444ef3183d9a9a4d97d0820d83af0e8be9e1354) glslang: 14.0.0 -> 14.1.0
* [`bb9143e0`](https://github.com/NixOS/nixpkgs/commit/bb9143e01d74ffc5a47bfac4f16c59c776ac7187) exim: Add pgsql, sqlite, json, and srs support
* [`40365d01`](https://github.com/NixOS/nixpkgs/commit/40365d01451013824fa8538b9dc90c35d997acc1) unbound: 1.19.1 -> 1.19.2
* [`cfb85b75`](https://github.com/NixOS/nixpkgs/commit/cfb85b75c6999771ab72b0ad857685c7d2af21da) s2n-tls: 1.4.5 -> 1.4.6
* [`0d75f790`](https://github.com/NixOS/nixpkgs/commit/0d75f790cc14a69b0b6ee52a35dadbb3b992fa9a) disable-warnings-if-gcc13: drop unused `disable-warnings-if-gcc13` helper
* [`94ed0781`](https://github.com/NixOS/nixpkgs/commit/94ed0781e9f270a2d4a040f8e827f724cc54946f) go, buildGoModule, buildGoPackage: default to 1.22
* [`71b47cb8`](https://github.com/NixOS/nixpkgs/commit/71b47cb872ce162ca3fbfaaefb5a7d7e95ec3571) ffmpeg: apply binutils patch only to ffmpeg_4
* [`664b0607`](https://github.com/NixOS/nixpkgs/commit/664b060722d7ac80d6fd5d6cb360cc77020296dc) R: 4.3.2 -> 4.3.3
* [`3dd68b46`](https://github.com/NixOS/nixpkgs/commit/3dd68b46041f0216f50616314d033baf5c3273b6) udns: 0.4 -> 0.5
* [`2f3eab4a`](https://github.com/NixOS/nixpkgs/commit/2f3eab4aca732818548f2ec251c955edc5052529) python312Packages.pyscard: 2.0.7 -> 2.0.8
* [`cf1a3325`](https://github.com/NixOS/nixpkgs/commit/cf1a3325008cbb8a550d76a763760795cbebf4a1) Revert "stdenv: log build hooks as they run"
* [`60f5035d`](https://github.com/NixOS/nixpkgs/commit/60f5035dccf01ceeb9f182635109c98b3e2c3b26) python311Packages.django_4: remove patch, fix build
* [`6eabc6f9`](https://github.com/NixOS/nixpkgs/commit/6eabc6f9486d9d55dc6f4ccfc0366759edfed83f) python311Packages.types-setuptools: 69.1.0.20240308 -> 69.1.0.20240310
* [`55a28322`](https://github.com/NixOS/nixpkgs/commit/55a283228c07640685d7945d5a06a01e8afe7452) gradle: add package tests
* [`fa7a2643`](https://github.com/NixOS/nixpkgs/commit/fa7a264379b9f5f308f55bad8a4d8ea799d59dff) cpeditor: 6.11.2 -> 7.0.1
* [`ad9b6544`](https://github.com/NixOS/nixpkgs/commit/ad9b654485f1c920f6f960eda5eec7b51c63b806) pipewire: fix build without bluez support
* [`4f78d39e`](https://github.com/NixOS/nixpkgs/commit/4f78d39ea152e4697e0726fcab9e6c8a13a25769) extractpdfmark: init at 1.1.1
* [`c53bbe30`](https://github.com/NixOS/nixpkgs/commit/c53bbe30cd195e452c124473bee0cea050bea546) xz: 5.6.0 -> 5.6.1
* [`ad99b6bc`](https://github.com/NixOS/nixpkgs/commit/ad99b6bc95b8e6f5f92ae9d8fa3da8a4ace171a0) maintainers: add dmadisetti
* [`1f17d902`](https://github.com/NixOS/nixpkgs/commit/1f17d90284909800e8cd8ad24d646cb6b4f0f293) libadwaita: enable `separateDebugInfo`
* [`791d638f`](https://github.com/NixOS/nixpkgs/commit/791d638f3fe57c36d190b1fd1e399cfe21adf12d) maintainers: add akshayka
* [`a5f29938`](https://github.com/NixOS/nixpkgs/commit/a5f299386976202d1447fb1fe25b6006f94ab3d6) unixODBCDrivers.mariadb: cleanup
* [`111dd2ed`](https://github.com/NixOS/nixpkgs/commit/111dd2ed970469880a0c5a54fdb8eeccc0361ffb) openjdk16: make linux-only
* [`a6857b00`](https://github.com/NixOS/nixpkgs/commit/a6857b00fe466d887d615b33dd262584a066faac) nixos/mihomo: init
* [`a5d09a41`](https://github.com/NixOS/nixpkgs/commit/a5d09a41b021a593fe2d1318c038381d6f2295cf) nixos/mihomo: add release note
* [`84bbdc74`](https://github.com/NixOS/nixpkgs/commit/84bbdc744e8652367997f9c46907a2006e4e34b1) nixos/mihomo: add tests
* [`d7f68859`](https://github.com/NixOS/nixpkgs/commit/d7f68859379f632513c18852163da4547ddf25e4) nixVersions.nix_2_3: disable parallel checking
* [`ce789e7e`](https://github.com/NixOS/nixpkgs/commit/ce789e7e35e7cf72f5424f35d1b8b3ffcedd9226) llvmPackages_{12,13,14,15,16,17,git}.{libcxx,libcxxabi}: merge libcxxabi into libcxx ([nixos/nixpkgs⁠#292043](https://togithub.com/nixos/nixpkgs/issues/292043))
* [`d29146c1`](https://github.com/NixOS/nixpkgs/commit/d29146c1f85f68c5037c4fd6de9e7836fa3173d7) unbound: 1.19.2 pkg-config for protobuf-c
* [`4acba6cf`](https://github.com/NixOS/nixpkgs/commit/4acba6cff5c221f2bf24a55cf30852226cbe82b9) conway_polynomials: remove
* [`c1997f85`](https://github.com/NixOS/nixpkgs/commit/c1997f85ce75a94a03859e06ff58701986698aa8) python311Pacakges.conway-polynomials: init at 0.9
* [`0f7d9922`](https://github.com/NixOS/nixpkgs/commit/0f7d992272064fa69d9f24d18c043f116025ac74) flint3: propagate mpfr
* [`d57460f2`](https://github.com/NixOS/nixpkgs/commit/d57460f29d7cd53392a1e9b29dbeb6f75918c41b) fflas-ffpack, givaro, linbox: ensure march=native is not used
* [`294aaa85`](https://github.com/NixOS/nixpkgs/commit/294aaa85754968a5b917a90106cda04c5f428bfc) nauty: 2.7r4 -> 2.8.8
* [`2e1ebdb6`](https://github.com/NixOS/nixpkgs/commit/2e1ebdb6e0d98cadb1d2f1d053a2b2758ae4d550) singular: 4.3.2p2 -> 4.3.2p16
* [`a99657c1`](https://github.com/NixOS/nixpkgs/commit/a99657c1d46b99e7a4f72540833c370927552b63) dump_syms: 2.3.0 -> 2.3.1
* [`3000754f`](https://github.com/NixOS/nixpkgs/commit/3000754f50f02abf066727ef35789d1684789b45) opentelemetry-collector-contrib: 0.87.0 -> 0.96.0
* [`08b58d78`](https://github.com/NixOS/nixpkgs/commit/08b58d78541aee8dd6e203070012e871971aed19) opentelemetry-collector-contrib: disable check
* [`ff4e5d04`](https://github.com/NixOS/nixpkgs/commit/ff4e5d04deb8450b6c232c6dbc98e6232243e6e2) linuxkit: 1.0.1 -> 1.2.0
* [`b309d4fd`](https://github.com/NixOS/nixpkgs/commit/b309d4fdcc51a133bdce76b602e9f7489d2531a0) lua: actually fix longstanding bug in lua envHook causing relative module imports to stop working
* [`daf9f70d`](https://github.com/NixOS/nixpkgs/commit/daf9f70d56a7bf13ffa5b460dd0c9fdf75715c91) palp: 2.20 -> 2.21
* [`a589a264`](https://github.com/NixOS/nixpkgs/commit/a589a264beace089f31435d1ba05721c5b7b1c8f) directx-headers: 1.611.0 -> 1.613.0
* [`e801d182`](https://github.com/NixOS/nixpkgs/commit/e801d18240ec4b2b0f96d978f77eb3ed9a47600d) refind: add chewblacka to package maintainers
* [`90003640`](https://github.com/NixOS/nixpkgs/commit/90003640f05c9917ec565c033bcf4e6270c5f871) jasper: 4.2.1 -> 4.2.2
* [`d15ca5b8`](https://github.com/NixOS/nixpkgs/commit/d15ca5b8415167fe17f16872f1bb67bdde2a666d) curl-impersonate: switch to `gcc-13`, disable blanket `-Werror`
* [`c8a8550c`](https://github.com/NixOS/nixpkgs/commit/c8a8550c284f2dfeba02eb3d0930efc132727e46) Avoid top-level `with` in lib/tests/misc.nix
* [`44c49d2d`](https://github.com/NixOS/nixpkgs/commit/44c49d2d905c189d7cec5965d7daae8cdf85056f) libsmartcols: 2.36.1 -> 2.39.3
* [`99745dab`](https://github.com/NixOS/nixpkgs/commit/99745daba24ac432582d435723e4a7729a0ce56e) python312Packages.pytapo: 3.3.18 -> 3.3.19
* [`91ad4384`](https://github.com/NixOS/nixpkgs/commit/91ad438400dc322d9a8c14616252d66754d75480) lib/systems: remove more features from qemu-user
* [`5ea8b959`](https://github.com/NixOS/nixpkgs/commit/5ea8b9594ec555dcaf65e373999b1e093e6500ca) xml2rfc: 3.20.0 -> 3.20.1
* [`0e5569ba`](https://github.com/NixOS/nixpkgs/commit/0e5569bac76419dbe5d2c7af1f89213dae6635cc) python311Packages.build: 1.0.3 -> 1.1.1
* [`4c426366`](https://github.com/NixOS/nixpkgs/commit/4c42636632acceca3739bfad369b1ce380d58104) python311Packages.setuptools: 69.0.3 -> 69.1.1
* [`15b60d2b`](https://github.com/NixOS/nixpkgs/commit/15b60d2b028953a7fe5c419877bc2dd814eea624) python311Packages.poetry-core: 1.8.1 -> 1.9.0
* [`7005420d`](https://github.com/NixOS/nixpkgs/commit/7005420d7265b839931574b1f4166625dd9faab5) python311Packages.pip: 23.3.1 -> 24.0
* [`92c34d01`](https://github.com/NixOS/nixpkgs/commit/92c34d01035c9bca16ad8d5b6c2babdad24bb87a) python311Packages.pytest: 7.4.4 -> 8.0.2
* [`edc28f27`](https://github.com/NixOS/nixpkgs/commit/edc28f27bdae6b6ebf803b745be32576e0911860) python311Packages.hypothesis: 6.91.0 -> 6.98.17
* [`889ca732`](https://github.com/NixOS/nixpkgs/commit/889ca7324744bf2842bfa7aeef7bafe028dc2871) python312Packages.pytest-socket: 0.6.0 -> 0.7.0 ([nixos/nixpkgs⁠#291185](https://togithub.com/nixos/nixpkgs/issues/291185))
* [`340b176a`](https://github.com/NixOS/nixpkgs/commit/340b176a7fc98a1c8d146d17c7e005b1105c607b) python311Packages.cython_3: 3.0.7 -> 3.0.9 ([nixos/nixpkgs⁠#293823](https://togithub.com/nixos/nixpkgs/issues/293823))
* [`d20601a4`](https://github.com/NixOS/nixpkgs/commit/d20601a40dc8c8959d915ce19102ff261ece21ee) python311Packages.python-dateutil: 2.8.2 -> 2.9.0.post0
* [`fe5a3923`](https://github.com/NixOS/nixpkgs/commit/fe5a3923cdf31964970b7ab770553b294bd166e3) python311Packages.python-dateutil: normalize directory name
* [`5eb5bb94`](https://github.com/NixOS/nixpkgs/commit/5eb5bb9410893d076da7961d28fc0b8e2d286c69) python311Packages.cairosvg: normalize pname, switch to pyproject = true, add meta.changelog
* [`e71d1c92`](https://github.com/NixOS/nixpkgs/commit/e71d1c92e8eecebe4324530fbfe356180e3ae332) python311Packages.cairosvg: 2.7.0 -> 2.7.1
* [`04733f71`](https://github.com/NixOS/nixpkgs/commit/04733f719d9cd83c847d1afbe9a2d1d8a4acdc6e) python311Packages.beautifulsoup4: 4.12.2 -> 4.12.3
* [`147d7f9d`](https://github.com/NixOS/nixpkgs/commit/147d7f9df531de56b5c62ee0643b0de0506bb5a7) python311Packages.rpds-py: 0.10.6 -> 0.17.1
* [`9885fe73`](https://github.com/NixOS/nixpkgs/commit/9885fe7314e455566e0c2e757c268b0f37c5a87b) python311Packages.astroid: 3.0.2 -> 3.1.0
* [`e30c983e`](https://github.com/NixOS/nixpkgs/commit/e30c983e07fdd624fd33afcc455f186f094e9a55) pylint: 3.0.3 -> 3.1.0
* [`a944ef32`](https://github.com/NixOS/nixpkgs/commit/a944ef32a6d32f7ca8f2b60bc8200f13e778ca58) python311Packages.starlette: 0.35.1 -> 0.37.1
* [`d72a8444`](https://github.com/NixOS/nixpkgs/commit/d72a8444d5d94bbbf547f933c8f520a98b1d3fde) python311Packages.fastapi: 0.109.0 -> 0.110.0
* [`30ba78a3`](https://github.com/NixOS/nixpkgs/commit/30ba78a3237282f36c4ac07c45839fb24bb57753) python311Packages.sphinx: speed up tests with xdist
* [`da34dbdb`](https://github.com/NixOS/nixpkgs/commit/da34dbdb263785db8f8f752dbaf6c61fa108b777) python311Packages.pproxy: 2.3.7 -> 2.7.9
* [`e6df4d85`](https://github.com/NixOS/nixpkgs/commit/e6df4d85a0461b341e18b06654d4f0d17654b4f0) python3Packages.absl-py: 2.0.0 -> 2.1.0
* [`8e0a0f63`](https://github.com/NixOS/nixpkgs/commit/8e0a0f63226dd3e7095c7e32102f2b0e2f027513) python3Packages.accelerate: 0.26.1 -> 0.27.0
* [`db610e2b`](https://github.com/NixOS/nixpkgs/commit/db610e2bacc922002dbee0fd5d890531fdbe45f9) python3Packages.adlfs: 2023.10.0 -> 2024.2.0
* [`a1ed97c2`](https://github.com/NixOS/nixpkgs/commit/a1ed97c2febba603fc21300b4b2b4275105c2557) python311Packages.khanaa: init at 0.0.6
* [`b79eb9b0`](https://github.com/NixOS/nixpkgs/commit/b79eb9b093479c5ad49bf267b3c787d4c75301dc) libpng: 1.6.42 -> 1.6.43
* [`e27bcfed`](https://github.com/NixOS/nixpkgs/commit/e27bcfed1cc83863bde59068a0565a09955fbeb3) Avoid top-level `with` in pkgs/build-support/cc-wrapper/default.nix ([nixos/nixpkgs⁠#295213](https://togithub.com/nixos/nixpkgs/issues/295213))
* [`915f31d6`](https://github.com/NixOS/nixpkgs/commit/915f31d633ac53bdb76d3365e7f5b818c0864474) libgpg-error: 1.47 -> 1.48 ([nixos/nixpkgs⁠#292165](https://togithub.com/nixos/nixpkgs/issues/292165))
* [`980f694e`](https://github.com/NixOS/nixpkgs/commit/980f694ee1f123ca9c17a6af5ec663368ef689a8) ammonite: 2.5.3 -> 3.0.0-M1
* [`bd14553d`](https://github.com/NixOS/nixpkgs/commit/bd14553dea0a5f7b32f9647f4ca16ced7777f48e) catppuccin: bat ba4d168 -> 2bafe44
* [`d09fe10c`](https://github.com/NixOS/nixpkgs/commit/d09fe10c8d9f6f5dded4194566e47e28e46e1258) catppuccin: k9s 516f44d -> 590a762
* [`d5583568`](https://github.com/NixOS/nixpkgs/commit/d55835689224ec148caee7feb50b8804958f13ad) catppuccin: lazygit 0543c28 -> v2.0.0
* [`4b9a35cb`](https://github.com/NixOS/nixpkgs/commit/4b9a35cbd6c5207ff016d4a0989b63f03927ecf3) catppuccin: plymouth d4105cf -> 67759fb
* [`e1f76640`](https://github.com/NixOS/nixpkgs/commit/e1f76640a86df873650a517c06586bdc31161d3b) catppuccin: init thunderbird at d61882a
* [`226aa60f`](https://github.com/NixOS/nixpkgs/commit/226aa60ff843b066e6245d6c634ff4803fdb6462) python3Packages.aioaladdinconnect: 0.1.58 -> 0.2.0
* [`95888cf0`](https://github.com/NixOS/nixpkgs/commit/95888cf011ef51641ac023c6125f7b3db34ff810) python3Packages.aioautomower: 2024.2.10 -> 2024.3.0
* [`4017a0a8`](https://github.com/NixOS/nixpkgs/commit/4017a0a89e18c2f3e5f015d9ffc462ac911f5127) python3Packages.aiobotocore: 2.11.2 -> 2.12.1
* [`3db5296f`](https://github.com/NixOS/nixpkgs/commit/3db5296f855ef9acd295e630f8f4bc64f17a278e) python3Packages.aioelectricitymaps: 0.4.0 -> 1.0.0
* [`4963fa7f`](https://github.com/NixOS/nixpkgs/commit/4963fa7f590bb037eacbfb65efbd01983b3ea626) python3Packages.aioesphomeapi: 23.0.0 -> 23.1.0
* [`4a2260a4`](https://github.com/NixOS/nixpkgs/commit/4a2260a4b3ff0e12e8815b70ab94325a610ea715) python3Packages.aiosmtpd: 1.4.4.post2 -> 1.4.5
* [`6d53720f`](https://github.com/NixOS/nixpkgs/commit/6d53720f6d5a93f7c7e1c6e4afc2f5eb4b3a7c31) python3Packages.aiosql: 9.3 -> 10.1
* [`7af74ed4`](https://github.com/NixOS/nixpkgs/commit/7af74ed41ef5b6aa3343970ad32d8f38e54e35f2) python3Packages.alabaster: 0.7.13 -> 0.7.16
* [`c6712bc8`](https://github.com/NixOS/nixpkgs/commit/c6712bc8be57697b64f6d35b5dc15accf54aff64) python3Packages.albumentations: 1.4.0 -> 1.4.1
* [`ba44a74a`](https://github.com/NixOS/nixpkgs/commit/ba44a74a9f86a2f326803acdc8da5eef0cef8f1e) python3Packages.alembic: 1.13.0 -> 1.13.1
* [`2bedfee8`](https://github.com/NixOS/nixpkgs/commit/2bedfee8c5a57da7010fc38636af890f59d03508) python3Packages.amazon-ion: 0.11.3 -> 0.12.0
* [`76b11df7`](https://github.com/NixOS/nixpkgs/commit/76b11df7f5778c37cf76998b4ebd706fb22c2d8f) python3Packages.androguard: 3.4.0a1 -> 4.1.0
* [`e45dc345`](https://github.com/NixOS/nixpkgs/commit/e45dc3459908f7de49592133444b937d53ed0bb6) python3Packages.ansi2html: 1.8.0 -> 1.9.1
* [`cdaaff69`](https://github.com/NixOS/nixpkgs/commit/cdaaff69a907e7a10ad6d977f743fcb4474f9931) python3Packages.anthropic: 0.15.0 -> 0.19.1
* [`b695b624`](https://github.com/NixOS/nixpkgs/commit/b695b624893603a73623bdeecb06f4cb747813d8) python3Packages.anyconfig: 0.13.0 -> 0.14.0
* [`7df486b1`](https://github.com/NixOS/nixpkgs/commit/7df486b10149f71add577c07847932bc5dca9470) python3Packages.anyio: 4.2.0 -> 4.3.0
* [`e32e89b3`](https://github.com/NixOS/nixpkgs/commit/e32e89b3c73971615f6c010c87f02d8b5d43ecd3) python3Packages.apache-beam: 2.52.0 -> 2.54.0
* [`39a620b2`](https://github.com/NixOS/nixpkgs/commit/39a620b2685fd3fdd65d680a7284fe92b14cda25) python3Packages.apsw: 3.44.2.0 -> 3.45.1.0
* [`9e4766b7`](https://github.com/NixOS/nixpkgs/commit/9e4766b75bc6ef65580397bb40360e8475619b94) python3Packages.archspec: 0.2.2 -> 0.2.3
* [`efa5829c`](https://github.com/NixOS/nixpkgs/commit/efa5829c7ef722ebc544a62d2c93749aa235c5ef) python3Packages.argcomplete: 3.2.1 -> 3.2.2
* [`ea7ec541`](https://github.com/NixOS/nixpkgs/commit/ea7ec5414a049d72e9726264c2c4e655401fb4e1) python3Packages.argh: 0.30.4 -> 0.31.2
* [`6892a8cc`](https://github.com/NixOS/nixpkgs/commit/6892a8cc7676786a934e4e9d67e0dc4c8f3c9a4a) python3Packages.aria2p: 0.11.2 -> 0.12.0
* [`58b7395e`](https://github.com/NixOS/nixpkgs/commit/58b7395ea9a7f112b6579f0dffb28f39aa043aab) python3Packages.asdf-standard: 1.0.3 -> 1.1.1
* [`87ee234a`](https://github.com/NixOS/nixpkgs/commit/87ee234abfeb948f9ca7d07cd3268815e11fe232) python3Packages.astropy-iers-data: 0.2023.12.04.00.30.20 -> 0.2024.03.04.00.30.17
* [`cb7cc366`](https://github.com/NixOS/nixpkgs/commit/cb7cc366a6c32f61a20b5af803a1a1b9bec1d654) python3Packages.atlassian-python-api: 3.41.3 -> 3.41.11
* [`140dc71f`](https://github.com/NixOS/nixpkgs/commit/140dc71f0b8eb7401c3adcc4d8b2d7a6c8e9a7e7) python3Packages.attrs: 23.1.0 -> 23.2.0
* [`663f42f3`](https://github.com/NixOS/nixpkgs/commit/663f42f3851b5b3479a43845dbdeee99b250fcab) python3Packages.auth0-python: 4.7.0 -> 4.7.1
* [`52a98203`](https://github.com/NixOS/nixpkgs/commit/52a98203492d316f6aa000789b4ee935b3f7e693) python3Packages.aws-lambda-builders: 1.45.0 -> 1.47.0
* [`d1c47f41`](https://github.com/NixOS/nixpkgs/commit/d1c47f41ff1cd0b9f194d9087e6e00bf81e66906) python3Packages.awslambdaric: 2.0.8 -> 2.0.10
* [`5fbe6af7`](https://github.com/NixOS/nixpkgs/commit/5fbe6af7c7876c6c3cf036eb4907fd9d7747b655) python3Packages.aws-sam-translator: 1.82.0 -> 1.86.0
* [`715afac9`](https://github.com/NixOS/nixpkgs/commit/715afac975594fe815cd54dfde6dc60e657b642f) python3Packages.awswrangler: 3.5.2 -> 3.7.1
* [`ae343d19`](https://github.com/NixOS/nixpkgs/commit/ae343d19281806d2bff5d7d7fe854d4ae51559d1) python3Packages.aws-xray-sdk: 2.12.1 -> 2.13.0
* [`38a16040`](https://github.com/NixOS/nixpkgs/commit/38a1604032dad5d241921ea6e1af4ef3e33fb9ed) python3Packages.ax: 0.3.6 -> 0.3.7
* [`a5bc1146`](https://github.com/NixOS/nixpkgs/commit/a5bc11468459cd9c1f66b2044f0db26119d2c3e3) python3Packages.axisregistry: 0.4.5 -> 0.4.9
* [`e684ea56`](https://github.com/NixOS/nixpkgs/commit/e684ea5611d9a9ff697adba206c1c9bead3e7a98) python3Packages.azure-servicebus: 7.11.4 -> 7.12.0
* [`d25c22af`](https://github.com/NixOS/nixpkgs/commit/d25c22af2ec1c0a286321ee6e7009fb074fdbd28) python3Packages.azure-storage-blob: 12.19.0 -> 12.19.1
* [`0601a8b5`](https://github.com/NixOS/nixpkgs/commit/0601a8b517336978df69c05c348ff6ada719930b) python3Packages.b2sdk: 1.29.1 -> 1.32.0
* [`c3698af4`](https://github.com/NixOS/nixpkgs/commit/c3698af4099dacbb66d8e2ff6f3fea672600012c) python3Packages.bayespy: 0.5.28 -> 0.6.1
* [`a7124a9e`](https://github.com/NixOS/nixpkgs/commit/a7124a9e13f7084bb0f1800d049101b454ebb586) python3Packages.bentoml: 1.1.11 -> 1.2.5
* [`2a7cbee1`](https://github.com/NixOS/nixpkgs/commit/2a7cbee1831095c1724d003dc4f08a5fe459fde8) python3Packages.betamax: 0.8.1 -> 0.9.0
* [`403b896e`](https://github.com/NixOS/nixpkgs/commit/403b896eb3fbb193cae452721ab1b18e8f26b891) python3Packages.bids-validator: 1.14.0 -> 1.14.1
* [`7010ec9d`](https://github.com/NixOS/nixpkgs/commit/7010ec9d950ae81c0087c895d27452aa954990e1) python3Packages.bitarray: 2.8.5 -> 2.9.2
* [`5fe7e2bf`](https://github.com/NixOS/nixpkgs/commit/5fe7e2bff66da8067cfc86e42befa51879dc6ef2) python3Packages.black: 24.1.1 -> 24.2.0
* [`04f34380`](https://github.com/NixOS/nixpkgs/commit/04f34380f70e5e904ef387d10afb82ff4ca55624) python3Packages.blobfile: 2.0.2 -> 2.1.0
* [`8c9ebc51`](https://github.com/NixOS/nixpkgs/commit/8c9ebc5171aad1fb397f3bdf82b56338b295d36f) python3Packages.bluecurrent-api: 1.0.6 -> 1.2.1
* [`9ad0eec4`](https://github.com/NixOS/nixpkgs/commit/9ad0eec44de75bc07d7f1cb33533f931c1235f21) python3Packages.bork: 7.0.2 -> 8.0.0
* [`ca917a81`](https://github.com/NixOS/nixpkgs/commit/ca917a81e5f35d180b1a6b0726efcda6f745bc9b) python3Packages.botocore: 1.34.49 -> 1.34.58
* [`6ff8644c`](https://github.com/NixOS/nixpkgs/commit/6ff8644cdff4048a75220f8058c8a0bbaa8c476e) python3Packages.botorch: 0.9.5 -> 0.10.0
* [`ec19814c`](https://github.com/NixOS/nixpkgs/commit/ec19814cc05b1afa868fbded9586baae7e777815) python3Packages.broadbean: 0.11.0 -> 0.14.0
* [`a55c415d`](https://github.com/NixOS/nixpkgs/commit/a55c415d780db8e58c0174bc508cb79388e304b3) python3Packages.buildcatrust: 0.2.1 -> 0.3.0
* [`0223f66a`](https://github.com/NixOS/nixpkgs/commit/0223f66a943768881080752d6408e2022623a8e0) python3Packages.cachelib: 0.10.2 -> 0.12.0
* [`ba12c684`](https://github.com/NixOS/nixpkgs/commit/ba12c684c3681766271446d7329750c450d333d9) python3Packages.cantools: 39.4.4 -> 39.4.5
* [`b9368240`](https://github.com/NixOS/nixpkgs/commit/b9368240c954fe14fff94fd1a57af2e1fd7ed4e9) python3Packages.catppuccin: 1.3.2 -> 2.1.0
* [`ef298a57`](https://github.com/NixOS/nixpkgs/commit/ef298a57724953452440e409434c5fbd25aa74bf) python3Packages.celery-types: 0.20.0 -> 0.22.0
* [`46822d90`](https://github.com/NixOS/nixpkgs/commit/46822d90e8266ece0ef9b3d9b9b7f3ec059a08b9) python3Packages.cffsubr: 0.2.9.post1 -> 0.3.0
* [`2b7b03ee`](https://github.com/NixOS/nixpkgs/commit/2b7b03ee460f0edfaf06792845c005fd08a7f49c) python3Packages.cfn-lint: 0.84.0 -> 0.86.0
* [`2a227c11`](https://github.com/NixOS/nixpkgs/commit/2a227c112ba7927140d5c95c90afbfa2c359b912) python3Packages.clarifai: 10.1.0 -> 10.1.1
* [`5f217d31`](https://github.com/NixOS/nixpkgs/commit/5f217d31e74373d9cd8090c98ad9cdb08c376eaf) python3Packages.cleanlab: 2.5.0 -> 2.6.1
* [`411ab0f1`](https://github.com/NixOS/nixpkgs/commit/411ab0f15d33c8a07b7422e7b9dbd875841ff67a) python3Packages.cliff: 4.4.0 -> 4.6.0
* [`4e42259e`](https://github.com/NixOS/nixpkgs/commit/4e42259e951a1ea78be90c99052f20079228f66d) python3Packages.cmarkgfm: 2022.10.27 -> 2024.1.14
* [`e797faf0`](https://github.com/NixOS/nixpkgs/commit/e797faf00ff2fb6508e941051c68c7fa3df64ac4) python3Packages.coconut: 3.0.4 -> 3.1.0
* [`34eb55ef`](https://github.com/NixOS/nixpkgs/commit/34eb55ef32adacf113925474af0313c36fbe87f5) python3Packages.cogapp: 3.3.0 -> 3.4.1
* [`32725be2`](https://github.com/NixOS/nixpkgs/commit/32725be28250f57030e1dbba7460606b18c75f8d) python3Packages.coincurve: 18.0.0 -> 19.0.1
* [`a9d566dd`](https://github.com/NixOS/nixpkgs/commit/a9d566dd872cb5f7d79fdb947aeb8629f3f335b4) python3Packages.colorcet: 3.0.1 -> 3.1.0
* [`f184ef84`](https://github.com/NixOS/nixpkgs/commit/f184ef84b9d7b4c70d71c628b5d3d13b419a2b34) python3Packages.concurrent-log-handler: 0.9.24 -> 0.9.25
* [`c0db8e26`](https://github.com/NixOS/nixpkgs/commit/c0db8e2613fcd7254fe6d7234315dafd7839243d) python3Packages.configparser: 6.0.0 -> 6.0.1
* [`b65b02e5`](https://github.com/NixOS/nixpkgs/commit/b65b02e58f77c4f582309a58988114c12cb79c4a) python3Packages.cookiecutter: 2.5.0 -> 2.6.0
* [`67eddf58`](https://github.com/NixOS/nixpkgs/commit/67eddf589150bdc8638879044cdc7539e562774c) python3Packages.cornice: 6.0.1 -> 6.1.0
* [`7153176c`](https://github.com/NixOS/nixpkgs/commit/7153176cdee8262c64f6b964ab3496416b3ad7a2) python3Packages.coverage: 7.3.2 -> 7.4.3
* [`4588c976`](https://github.com/NixOS/nixpkgs/commit/4588c976ad9f21d2e25946e3e33532f6a7fbf18e) python3Packages.cryptoparser: 0.12.2 -> 0.12.3
* [`4516d3fe`](https://github.com/NixOS/nixpkgs/commit/4516d3fe45ee1ecf57980e0928b19ecb5bd1e275) python3Packages.cucumber-tag-expressions: 4.1.0 -> 6.1.0
* [`da7cdd85`](https://github.com/NixOS/nixpkgs/commit/da7cdd8544356c44fc2d694685d93ca25f499141) python3Packages.cupy: 12.3.0 -> 13.0.0
* [`ff50faad`](https://github.com/NixOS/nixpkgs/commit/ff50faadaab6ba17a70b32224f32e5e672303426) python3Packages.cytoolz: 0.12.2 -> 0.12.3
* [`78019bb9`](https://github.com/NixOS/nixpkgs/commit/78019bb9e72dcfb5f25da75dd558b34b71e567a2) python3Packages.dash: 2.15.0 -> 2.16.1
* [`6290009b`](https://github.com/NixOS/nixpkgs/commit/6290009bd6a5819b96016a8b238bd7d46df4737a) python3Packages.databricks-sql-connector: 3.0.3 -> 3.1.0
* [`a1dee898`](https://github.com/NixOS/nixpkgs/commit/a1dee89843e23fd1f10e375e9a5372d9b1b8b437) python3Packages.dataprep-ml: 0.0.21 -> 0.0.22
* [`0fd22706`](https://github.com/NixOS/nixpkgs/commit/0fd2270675b2fe546654a05b99c8ba03469911e7) python3Packages.datasets: 2.15.0 -> 2.18.0
* [`63155af4`](https://github.com/NixOS/nixpkgs/commit/63155af44bade56465b69493dcdd2a4e65921ffc) python3Packages.dbf: 0.99.3 -> 0.99.9
* [`4e77a666`](https://github.com/NixOS/nixpkgs/commit/4e77a666ea152d8e37a9d1c31e929e7690132390) python3Packages.ddt: 1.7.0 -> 1.7.2
* [`23d3bebb`](https://github.com/NixOS/nixpkgs/commit/23d3bebb63d743b08c4b197c3fda1658c29ed469) python3Packages.debtcollector: 2.5.0 -> 3.0.0
* [`12066737`](https://github.com/NixOS/nixpkgs/commit/120667371dfe6fffab46602f64252a95bce96c8c) python3Packages.debugpy: 1.8.0 -> 1.8.1
* [`285480bc`](https://github.com/NixOS/nixpkgs/commit/285480bc60009d4c5e0ebbb287941d5a26216140) python3Packages.deprecat: 2.1.1 -> 2.1.2
* [`c7d247a5`](https://github.com/NixOS/nixpkgs/commit/c7d247a5bb684403f5f97946d7d02725764e2c3c) python3Packages.dict2xml: 1.7.4 -> 1.7.5
* [`4b312fb3`](https://github.com/NixOS/nixpkgs/commit/4b312fb3b84a1c3d28f8bd657601365016d4fb55) python3Packages.dill: 0.3.7 -> 0.3.8
* [`2484707c`](https://github.com/NixOS/nixpkgs/commit/2484707cf4855bf80966993356c6a0629bcdd8b8) python3Packages.distlib: 0.3.7 -> 0.3.8
* [`96e59261`](https://github.com/NixOS/nixpkgs/commit/96e59261a29b2a9c09670a068d759cc0f7e335e1) python3Packages.distro: 1.8.0 -> 1.9.0
* [`f89c105d`](https://github.com/NixOS/nixpkgs/commit/f89c105d8a2f39f6a5e12acfcc8bcef92b40c36d) python3Packages.django-csp: 3.7 -> 3.8
* [`c0643ea7`](https://github.com/NixOS/nixpkgs/commit/c0643ea77a1605bd6eb4380460aec828606b5f9d) python3Packages.django-health-check: 3.17.0 -> 3.18.1
* [`a73d45aa`](https://github.com/NixOS/nixpkgs/commit/a73d45aae9d4962e6e71adc930c9f30cc30a4fdc) python3Packages.dm-sonnet: 2.0.0 -> 2.0.2
* [`7855a97f`](https://github.com/NixOS/nixpkgs/commit/7855a97f528d98cb45cac0abe3f787f9817039c0) python3Packages.docstring-to-markdown: 0.13 -> 0.15
* [`5bd5a2e5`](https://github.com/NixOS/nixpkgs/commit/5bd5a2e57bb66163be5888bb6fc88cb56ea82617) python3Packages.dploot: 2.2.5 -> 2.6.0
* [`f0d229d7`](https://github.com/NixOS/nixpkgs/commit/f0d229d7f3bf5966d53f1c2a694dc41666b45d18) python3Packages.drf-spectacular: 0.26.5 -> 0.27.1
* [`25d69788`](https://github.com/NixOS/nixpkgs/commit/25d6978876f9128192fc6c577b84b62fee051377) python3Packages.dsmr-parser: 1.3.1 -> 1.3.2
* [`36b0ec49`](https://github.com/NixOS/nixpkgs/commit/36b0ec493cfbf34fbc9998bc9845736f5f70aeb5) python3Packages.duckduckgo-search: 3.9.9 -> 5.0
* [`f5133f3f`](https://github.com/NixOS/nixpkgs/commit/f5133f3fc785ae1a3fa826bd63a479f923225cbc) python3Packages.dunamai: 1.19.0 -> 1.19.2
* [`71cc375c`](https://github.com/NixOS/nixpkgs/commit/71cc375c807bae1af3002ee0b3fe68f8a3213f45) python3Packages.dvc-azure: 3.0.1 -> 3.1.0
* [`ebb077d8`](https://github.com/NixOS/nixpkgs/commit/ebb077d820e623ce4309906baa868c767c7783a7) python3Packages.dvc-data: 3.9.0 -> 3.14.1
* [`be42f430`](https://github.com/NixOS/nixpkgs/commit/be42f4305a5ecce5bc1cdf7c70121bb31cd070e0) python3Packages.dvc: 3.43.1 -> 3.48.3
* [`75787430`](https://github.com/NixOS/nixpkgs/commit/75787430b76d9f3f3b7f908c62199c4895fde3ef) python3Packages.dvclive: 3.42.0 -> 3.44.0
* [`5634315a`](https://github.com/NixOS/nixpkgs/commit/5634315a01a042930aefa92461af214c5ea175f8) python3Packages.dvc-objects: 3.0.6 -> 5.1.0
* [`4ca52272`](https://github.com/NixOS/nixpkgs/commit/4ca522720fcaeebb093b33aa6442c31f71759e09) python3Packages.dvc-s3: 3.0.1 -> 3.1.0
* [`60ecf507`](https://github.com/NixOS/nixpkgs/commit/60ecf507aaa1baefe87e7df6c828c029870f0fe2) python3Packages.edalize: 0.5.1 -> 0.5.4
* [`948bd4de`](https://github.com/NixOS/nixpkgs/commit/948bd4dee5787530ef9a7bd1463377c63b0c5b33) python3Packages.editdistance: 0.6.2 -> 0.8.1
* [`aee1a432`](https://github.com/NixOS/nixpkgs/commit/aee1a432d97b16f896a2c3ddeb7af3d4db6fd5e4) python3Packages.elasticsearch: 8.11.0 -> 8.12.1
* [`1de1b9dd`](https://github.com/NixOS/nixpkgs/commit/1de1b9ddc420749d1ac46dacadedb774c0876c6e) python3Packages.elastic-transport: 8.10.0 -> 8.12.0
* [`9ad0e05d`](https://github.com/NixOS/nixpkgs/commit/9ad0e05d176df0e62afd5604d14471f292d46ee7) python3Packages.evdev: 1.6.1 -> 1.7.0
* [`b40bbba3`](https://github.com/NixOS/nixpkgs/commit/b40bbba35ecdd594838e7e06a1a30901a288f686) python3Packages.faker: 20.1.0 -> 24.0.0
* [`c653e471`](https://github.com/NixOS/nixpkgs/commit/c653e47121615a5060e35eaa0410d6c5f2e4e410) python3Packages.falcon: 3.1.1 -> 3.1.3
* [`dacc75de`](https://github.com/NixOS/nixpkgs/commit/dacc75de168a0a66f00d9bfb5d894891cdf39bd4) python3Packages.farm-haystack: 1.23.0 -> 1.25.0
* [`29eee3a2`](https://github.com/NixOS/nixpkgs/commit/29eee3a2c344d2bab0ac5d6528c9875839a71c11) python3Packages.fastavro: 1.9.0 -> 1.9.4
* [`ed03d3b0`](https://github.com/NixOS/nixpkgs/commit/ed03d3b059d4a7d8697cc556e67f33b5a1d1e1ea) python3Packages.fastembed: 0.1.2 -> 0.2.2
* [`e7221859`](https://github.com/NixOS/nixpkgs/commit/e7221859d5814201b4f1156665d2c668e25c003d) python3Packages.feedgen: 0.9.0 -> 1.0.0
* [`61fa5a23`](https://github.com/NixOS/nixpkgs/commit/61fa5a23750b145f870de57f0b9985de6b9deef5) python3Packages.flask-appbuilder: 4.3.10 -> 4.4.1
* [`5da6a016`](https://github.com/NixOS/nixpkgs/commit/5da6a0167e97af3be550cd0b01f6f9195070cb04) python3Packages.flask: 3.0.1 -> 3.0.2
* [`e2e2b3e8`](https://github.com/NixOS/nixpkgs/commit/e2e2b3e840e214d49ed5d36d76e48af4b21d7da8) python3Packages.flask-security-too: 5.3.3 -> 5.4.1
* [`1ff33641`](https://github.com/NixOS/nixpkgs/commit/1ff33641f9859caf97c3baa3cb4c893eb7047b2e) python3Packages.flask-session-captcha: 1.3.0 -> 1.4.0
* [`e703fcb3`](https://github.com/NixOS/nixpkgs/commit/e703fcb3ac22e4580badcbf72cb1425260fe27dd) python3Packages.flax: 0.7.5 -> 0.8.1
* [`8a064ad2`](https://github.com/NixOS/nixpkgs/commit/8a064ad2879c27670a8a04e0d640373928097f26) python3Packages.flet-core: 0.20.2 -> 0.21.1
* [`760fd49b`](https://github.com/NixOS/nixpkgs/commit/760fd49b10fd275a775bd0bdec357f44b2309ca5) python3Packages.flet: 0.20.2 -> 0.21.1
* [`eb3dc6d2`](https://github.com/NixOS/nixpkgs/commit/eb3dc6d20ab9efc166f7bd75546031995d668c09) python3Packages.flet-runtime: 0.20.2 -> 0.21.1
* [`ed5b3e83`](https://github.com/NixOS/nixpkgs/commit/ed5b3e839eb726d210a185f7639f3e085e65e9b1) python3Packages.fluent-logger: 0.10.0 -> 0.11.0
* [`95501fc2`](https://github.com/NixOS/nixpkgs/commit/95501fc23671daedab0ddb1d1e29bcd61570ba1e) python3Packages.folium: 0.15.1 -> 0.16.0
* [`f428d4f0`](https://github.com/NixOS/nixpkgs/commit/f428d4f0cc36b285f938c5737505314368e7eb64) python3Packages.fontbakery: 0.10.4 -> 0.11.2
* [`8103830c`](https://github.com/NixOS/nixpkgs/commit/8103830c97d6b010b974b9edf0c3947217a8263e) python3Packages.fontmake: 3.7.1 -> 3.8.1
* [`3592da95`](https://github.com/NixOS/nixpkgs/commit/3592da9567cf56c49e4c8cea358b9d992072765a) python3Packages.fonttools: 4.46.0 -> 4.49.0
* [`0309c136`](https://github.com/NixOS/nixpkgs/commit/0309c13632bb31f8110560458cb84d92f10ed1ad) python3Packages.formulae: 0.5.1 -> 0.5.3
* [`af57ca2c`](https://github.com/NixOS/nixpkgs/commit/af57ca2cb3925cc04228e97541f32c878941c6c8) python3Packages.fpdf2: 2.7.7 -> 2.7.8
* [`09cefb43`](https://github.com/NixOS/nixpkgs/commit/09cefb43b7c2923ac0b8a91cc4db9360c4d04b44) python3Packages.freezegun: 1.3.1 -> 1.4.0
* [`c8149d90`](https://github.com/NixOS/nixpkgs/commit/c8149d9020525d9da77b93fedc7b5bc329555ab3) python3Packages.future: 0.18.3 -> 1.0.0
* [`0bcdf70a`](https://github.com/NixOS/nixpkgs/commit/0bcdf70a1f543678335b8c325012512d46240f95) python3Packages.gaphas: 3.11.3 -> 4.0.0
* [`fb05f0cd`](https://github.com/NixOS/nixpkgs/commit/fb05f0cdf1ec05c21440e5996d6253d79c6e584b) python3Packages.gcovr: 6.0 -> 7.2
* [`a9fd30fd`](https://github.com/NixOS/nixpkgs/commit/a9fd30fd4ad9772bacc5ba99405b4efd1d45190d) python3Packages.gdown: 4.7.3 -> 5.1.0
* [`bd8e03b2`](https://github.com/NixOS/nixpkgs/commit/bd8e03b226ab86d01b0d042d07e7ec48d60e898b) python3Packages.geoip2: 4.7.0 -> 4.8.0
* [`3ea1a9d8`](https://github.com/NixOS/nixpkgs/commit/3ea1a9d807b4cc530f17b5702586edac1a3a3df5) python3Packages.gevent: 23.9.1 -> 24.2.1
* [`85663647`](https://github.com/NixOS/nixpkgs/commit/85663647fcc43e662c0cf4b5d6a0f9f4b62a0b1a) python3Packages.gflanguages: 0.5.13 -> 5.0.4
* [`164b89b2`](https://github.com/NixOS/nixpkgs/commit/164b89b2a21aff0ffcbfce05c19102dc9a198ca4) python3Packages.githubkit: 0.11.1 -> 0.11.2
* [`d257485a`](https://github.com/NixOS/nixpkgs/commit/d257485a718dd8f2a1a1bbe1d919ae07e0d20f79) python3Packages.gitpython: 3.1.40 -> 3.1.42
* [`1f9d8f1d`](https://github.com/NixOS/nixpkgs/commit/1f9d8f1df30de74903c7fffa61b087d44fe26287) python3Packages.glad2: 2.0.4 -> 2.0.5
* [`3f8f6909`](https://github.com/NixOS/nixpkgs/commit/3f8f690976443f3046bfdfe8be9963f892b0aec4) python3Packages.glean-parser: 11.0.1 -> 13.0.0
* [`6d70f71d`](https://github.com/NixOS/nixpkgs/commit/6d70f71d096c11861b988d9a349549e5ee2dd2b6) python3Packages.globus-sdk: 3.32.0 -> 3.39.0
* [`ce2b8659`](https://github.com/NixOS/nixpkgs/commit/ce2b86593aad976779fdfed26ce0d1017b920c4b) python3Packages.glyphsets: 0.6.11 -> 0.6.14
* [`a7de9ee8`](https://github.com/NixOS/nixpkgs/commit/a7de9ee8574d919f79eecb459910d2ae1361cec5) python3Packages.glyphslib: 6.6.0 -> 6.6.6
* [`8a190bc7`](https://github.com/NixOS/nixpkgs/commit/8a190bc759eec223806174724d7095f25d1ebd88) python3Packages.google-api-python-client: 2.120.0 -> 2.121.0
* [`57dcd914`](https://github.com/NixOS/nixpkgs/commit/57dcd914fa8f6864b5e0d174de64544cad6270bb) python3Packages.googleapis-common-protos: 1.61.0 -> 1.62.0
* [`6e50b589`](https://github.com/NixOS/nixpkgs/commit/6e50b589bafb45bbff7229830d1c878cc2da3aff) python3Packages.google-auth: 2.27.0 -> 2.28.1
* [`7ea21c05`](https://github.com/NixOS/nixpkgs/commit/7ea21c05a29b9e881e02388b34aae6685f1919d5) python3Packages.google-cloud-core: 2.3.3 -> 2.4.1
* [`7812f3d9`](https://github.com/NixOS/nixpkgs/commit/7812f3d924d1d37d4144cbcccfde33816c5a8d7e) python3Packages.google-cloud-iam: 2.12.2 -> 2.14.3
* [`4359ba12`](https://github.com/NixOS/nixpkgs/commit/4359ba12a498330418a544eac44b93c37c9fa5e6) python3Packages.google-cloud-kms: 2.21.2 -> 2.21.3
* [`81c48089`](https://github.com/NixOS/nixpkgs/commit/81c4808903cc3d25e3b97d07ef830802ed951e34) python3Packages.google-generativeai: 0.3.2 -> 0.4.0
* [`f3327cf1`](https://github.com/NixOS/nixpkgs/commit/f3327cf1063ddee77a0b27787e539abdb2de18a1) python3Packages.google-resumable-media: 2.6.0 -> 2.7.0
* [`375cfba4`](https://github.com/NixOS/nixpkgs/commit/375cfba4c750445a7ed83fef0d308eb8cc781e8c) python3Packages.gql: 3.4.1 -> 3.5.0
* [`9e0bfd7a`](https://github.com/NixOS/nixpkgs/commit/9e0bfd7a545c095ea4cf9f8fd48309e6cd0e99dd) python3Packages.gradio: 4.19.2 -> 4.20.1
* [`c1d044ca`](https://github.com/NixOS/nixpkgs/commit/c1d044ca6ca70d3574dcfba31ec50a050fab7cd8) python3Packages.graphtage: 0.3.0 -> 0.3.1
* [`d698f7ca`](https://github.com/NixOS/nixpkgs/commit/d698f7caf1049309b784add2d1244bb5ba606f82) python3Packages.green: 3.4.3 -> 4.0.1
* [`70b880f9`](https://github.com/NixOS/nixpkgs/commit/70b880f96755640cad1426ba44b8a66e1a7a6a1b) python3Packages.greenlet: 3.0.1 -> 3.0.3
* [`537322fb`](https://github.com/NixOS/nixpkgs/commit/537322fb4dd69ccd476eae8d1365308927a0e345) python3Packages.gspread: 5.12.4 -> 6.0.2
* [`3d449547`](https://github.com/NixOS/nixpkgs/commit/3d449547cc17f046966b68202d9f75fea5cb5fdf) python3Packages.gto: 1.6.2 -> 1.7.0
* [`00a73c5e`](https://github.com/NixOS/nixpkgs/commit/00a73c5e63161fcdf57e5202277fc98119249b3c) python3Packages.hacking: 6.0.1 -> 6.1.0
* [`e627985f`](https://github.com/NixOS/nixpkgs/commit/e627985f0bbeab6a78d3734afafaeb6e8237e9bc) python3Packages.hatch-fancy-pypi-readme: 23.1.0 -> 24.1.0
* [`0ba01cd7`](https://github.com/NixOS/nixpkgs/commit/0ba01cd7efa427b02636b030461c992b24eefc40) python3Packages.heudiconv: 1.0.1 -> 1.1.0
* [`3448b433`](https://github.com/NixOS/nixpkgs/commit/3448b4335f8f32a9082e411b98f7d4fc35a95643) python3Packages.hg-evolve: 11.1.1 -> 11.1.2
* [`556c8295`](https://github.com/NixOS/nixpkgs/commit/556c8295c14600d55f0cb9847ac56c29a4b4c866) python3Packages.hiredis: 2.3.0 -> 2.3.2
* [`aa834618`](https://github.com/NixOS/nixpkgs/commit/aa834618ccc499a37fc092d49a73d67963318963) python3Packages.hmmlearn: 0.3.0 -> 0.3.2
* [`6fd9a5e5`](https://github.com/NixOS/nixpkgs/commit/6fd9a5e56f324fb09451c4fa8b2e31e2e29c2b2b) python3Packages.homeassistant-bring-api: 0.1.0 -> 0.5.6
* [`8609858f`](https://github.com/NixOS/nixpkgs/commit/8609858fa1c83c5c847049e739f6fc57b4ea52cd) python3Packages.home-assistant-chip-clusters: 2024.2.1 -> 2024.2.2
* [`563bb5b8`](https://github.com/NixOS/nixpkgs/commit/563bb5b85e41b085163e0fd4a613092d59a7ddae) python3Packages.html2text: 2020.1.16 -> 2024.2.26
* [`e4ef8c5c`](https://github.com/NixOS/nixpkgs/commit/e4ef8c5cdc0db743d367cb2198b09aa0f89f1abf) python3Packages.httpbin: 0.10.1 -> 0.10.2
* [`8faf0480`](https://github.com/NixOS/nixpkgs/commit/8faf04805284aa08c7efb9e6a6c995e8ae699511) python3Packages.hupper: 1.12 -> 1.12.1
* [`428ade73`](https://github.com/NixOS/nixpkgs/commit/428ade739a8485ba782ccbf4a72f0cbea4397c40) python3Packages.hypothesmith: 0.3.1 -> 0.3.3
* [`24ee5ba6`](https://github.com/NixOS/nixpkgs/commit/24ee5ba6376f7de91a686385fee7aee8ae56c581) python3Packages.ifcopenshell: 231201 -> 240306
* [`74ab5aa3`](https://github.com/NixOS/nixpkgs/commit/74ab5aa3e73bb5864f511eb312fa363a807ae82b) python3Packages.importlib-metadata: 6.9.0 -> 7.0.2
* [`aeef6463`](https://github.com/NixOS/nixpkgs/commit/aeef6463dcf0cbb9c2bd679c07c36582595470e0) python3Packages.importlib-resources: 6.1.1 -> 6.1.3
* [`ba737081`](https://github.com/NixOS/nixpkgs/commit/ba7370811d4acd2e87b94724733c9834a67cdef4) Revert "directx-headers: 1.611.0 -> 1.613.0"
* [`ef046a1f`](https://github.com/NixOS/nixpkgs/commit/ef046a1fd424bffecf557d5e179319335bfcca65) python311Packages.xmod: init at 1.8.1
* [`1cb49d8e`](https://github.com/NixOS/nixpkgs/commit/1cb49d8e3accc9b8f8410e427c5e5a76f298d8fa) python311Packages.dek: init at 1.4.2
* [`e5978e16`](https://github.com/NixOS/nixpkgs/commit/e5978e16a106b6ed9076c991a5a8fad902a434a7) python311Packages.tdir: init at 1.8.2
* [`7f3a5574`](https://github.com/NixOS/nixpkgs/commit/7f3a55742c8ed1ac0cbb231c6870570e2a44926d) python311Packages.runs: init at 1.2.2
* [`5d188b1a`](https://github.com/NixOS/nixpkgs/commit/5d188b1a50024fb14e6ddc26f258c195d636277f) python311Packages.editor: init at 1.6.6
* [`aa2e2782`](https://github.com/NixOS/nixpkgs/commit/aa2e2782fbe26363c068c3b35d85944bb11e0eec) python3Packages.inquirer: 3.1.4 -> 3.2.4
* [`a0c15a81`](https://github.com/NixOS/nixpkgs/commit/a0c15a81b42b83b2a84fc6ad3765ecaee275d9d7) python3Packages.inscriptis: 2.3.2 -> 2.5.0
* [`4068daa3`](https://github.com/NixOS/nixpkgs/commit/4068daa3a7fb0ca4a02b7bb4938434866e534dbe) python3Packages.intellifire4py: 3.6.1 -> 4.1.9
* [`e5cb6b27`](https://github.com/NixOS/nixpkgs/commit/e5cb6b276fdb396ac7bb394a2174041236fcef3d) python3Packages.ipyparallel: 8.6.1 -> 8.7.0
* [`ab463314`](https://github.com/NixOS/nixpkgs/commit/ab4633145d67e1b2b803dd81747e455652efbf5c) python3Packages.ipython: 8.22.1 -> 8.22.2
* [`20e2ccf9`](https://github.com/NixOS/nixpkgs/commit/20e2ccf92097fd86750ce19c29edacab1af66d37) python3Packages.ipyvuetify: 1.9.0 -> 1.9.1
* [`470cd07b`](https://github.com/NixOS/nixpkgs/commit/470cd07bfa8cd495ec683c89aa5958dd5f440d2a) python3Packages.isort: 5.12.0 -> 5.13.2
* [`f75e015f`](https://github.com/NixOS/nixpkgs/commit/f75e015fce9d72be7b264b73fc1df8e0327afd7d) python3Packages.isosurfaces: 0.1.0 -> 0.1.2
* [`00f31957`](https://github.com/NixOS/nixpkgs/commit/00f3195776cb1cf1596d9e5d86af07c25d48af99) python3Packages.jaraco-classes: 3.3.0 -> 3.3.1
* [`64b4ded7`](https://github.com/NixOS/nixpkgs/commit/64b4ded7139f0ffd7277a35f31a4cce6983ff07e) python3Packages.jaraco-collections: 4.3.0 -> 5.0.0
* [`1754d3c2`](https://github.com/NixOS/nixpkgs/commit/1754d3c248c2602395c965d9667b4e671e16b1a8) python3Packages.jaraco-email: 3.1.0 -> 3.1.1
* [`df19cf34`](https://github.com/NixOS/nixpkgs/commit/df19cf34d9da12f3b46157815430b4b950a4f4c3) python3Packages.jaraco-net: 9.3.1 -> 10.2.0
* [`e1c0bda8`](https://github.com/NixOS/nixpkgs/commit/e1c0bda806ca984be8dd4aed81b9d752d5036f15) python3Packages.jax: 0.4.24 -> 0.4.25
* [`c1bddea5`](https://github.com/NixOS/nixpkgs/commit/c1bddea5029cb18b1322f9d5a9a8c28b97fe7bb0) python3Packages.jira: 3.5.2 -> 3.6.0
* [`a706acba`](https://github.com/NixOS/nixpkgs/commit/a706acbac07e43db0560c19360f7284262e843e2) python3Packages.jpylyzer: 2.1.0 -> 2.2.0
* [`ae056ae0`](https://github.com/NixOS/nixpkgs/commit/ae056ae0c74a06374025df601047d5784b31902f) python3Packages.jsonconversion: 0.2.13 -> 1.0.1
* [`d8c1f0d5`](https://github.com/NixOS/nixpkgs/commit/d8c1f0d5446eebb563f57f16379252c044ffcacd) python3Packages.jsonpickle: 3.0.2 -> 3.0.3
* [`675f5137`](https://github.com/NixOS/nixpkgs/commit/675f5137facc35743725b1410d1c775a5e093b19) python3Packages.jsonschema: 4.20.0 -> 4.21.1
* [`02ab08d5`](https://github.com/NixOS/nixpkgs/commit/02ab08d51a7de7f645573817cdc6c30e14d7f7e9) python3Packages.jsonschema-specifications: 2023.11.2 -> 2023.12.1
* [`b9283c32`](https://github.com/NixOS/nixpkgs/commit/b9283c323a3c8e22d1fc5b5d9a6b5b5ae76c9114) python3Packages.jupyter-collaboration: 2.0.2 -> 2.0.3
* [`8f42ff11`](https://github.com/NixOS/nixpkgs/commit/8f42ff119364fb37130d9093ea9a35f3700a3cd1) python3Packages.jupyterlab: 4.0.12 -> 4.1.4
* [`e4ba9099`](https://github.com/NixOS/nixpkgs/commit/e4ba90999d6c05e4b4b42f60b815b00f603ee384) python3Packages.jupyterlab-lsp: 5.0.3 -> 5.1.0
* [`d63f195d`](https://github.com/NixOS/nixpkgs/commit/d63f195d544d61ba50f5e62afcca20cd19666a74) python3Packages.jupyter-lsp: 2.2.3 -> 2.2.4
* [`a2540c55`](https://github.com/NixOS/nixpkgs/commit/a2540c55dee73040b370cf680189be09c3453f63) python3Packages.jupyter-server: 2.12.5 -> 2.13.0
* [`a75131f1`](https://github.com/NixOS/nixpkgs/commit/a75131f114cb02786fe9a8b41198e4aafb704b0b) python3Packages.kazoo: 2.9.0 -> 2.10.0
* [`f2947228`](https://github.com/NixOS/nixpkgs/commit/f294722875a82b4041312e4fc57d98e710c4af30) python3Packages.keras: 3.0.0 -> 3.0.5
* [`27b7a389`](https://github.com/NixOS/nixpkgs/commit/27b7a38948aa80340cf44195fbc682d6e8ca4403) python3Packages.keyring: 24.3.0 -> 24.3.1
* [`daa4a56a`](https://github.com/NixOS/nixpkgs/commit/daa4a56a3079913f25cb0f59aa8f71508f7ebe02) python3Packages.keystoneauth1: 5.4.0 -> 5.6.0
* [`dda15b82`](https://github.com/NixOS/nixpkgs/commit/dda15b82e3c34093e6c423c61fb86e59a47f4553) python3Packages.lark: 1.1.8 -> 1.1.9
* [`d8f0aba9`](https://github.com/NixOS/nixpkgs/commit/d8f0aba907368dd4550ebe952101524b81e9eb55) python3Packages.latexcodec: 2.0.1 -> 3.0.0
* [`d87d5b0e`](https://github.com/NixOS/nixpkgs/commit/d87d5b0ee83e1cddf354c4c510a106d6c472a46d) python3Packages.lazy-object-proxy: 1.9.0 -> 1.10.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
