### PR TITLE
niv emacs-overlay: update 03b374a3 -> b7e580bd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9",
-        "sha256": "08650jk06yjhg2dwvngv455128ss859n268xa36mikapr5a4ka37",
+        "rev": "b7e580bd8e698b784a02a20071007930f993de99",
+        "sha256": "13msb0syy5189i70rjy2a7r2c9f05ns6y05sxy6ag08408ifsjq6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/b7e580bd8e698b784a02a20071007930f993de99.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@03b374a3...b7e580bd](https://github.com/nix-community/emacs-overlay/compare/03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9...b7e580bd8e698b784a02a20071007930f993de99)

* [`51d054fd`](https://github.com/nix-community/emacs-overlay/commit/51d054fd379c4bf1bc9df49c98db0a356ffc20f5) Updated melpa
* [`f46c7855`](https://github.com/nix-community/emacs-overlay/commit/f46c7855660fd07e03c4ce68f025b65f22ff95e2) Updated emacs
* [`d7155aaa`](https://github.com/nix-community/emacs-overlay/commit/d7155aaadc98b2c13874f78cc5e00f2dfefd7a6e) Updated melpa
* [`514217c9`](https://github.com/nix-community/emacs-overlay/commit/514217c91d0c914a2545a482e6c8bb051edcaa49) Updated flake inputs
* [`94bd2c06`](https://github.com/nix-community/emacs-overlay/commit/94bd2c06076fa392ccfcb88f63adf19b2482d5d9) Updated elpa
* [`c2af4557`](https://github.com/nix-community/emacs-overlay/commit/c2af45572b1a63acd56b23f135c5866ff19a7962) Updated melpa
* [`2b95246f`](https://github.com/nix-community/emacs-overlay/commit/2b95246fa59e3dd0627e308df545bbd4cc3ce22f) Updated emacs
* [`d909a8b4`](https://github.com/nix-community/emacs-overlay/commit/d909a8b4f5b332a8086ce2fbe7f30b91957c229b) Updated nongnu
* [`ba8ee81a`](https://github.com/nix-community/emacs-overlay/commit/ba8ee81a90e1019be55f950dffb4b75099691a3e) Updated elpa
* [`16fc59cc`](https://github.com/nix-community/emacs-overlay/commit/16fc59cc0a5882b60dbd7d5665363d743b3d95c1) Updated emacs
* [`89541209`](https://github.com/nix-community/emacs-overlay/commit/89541209151acb287bfb71659e738038521b0bcb) Updated emacs
* [`bab54c41`](https://github.com/nix-community/emacs-overlay/commit/bab54c414822538a2275bd32d546f87192ae1576) Updated flake inputs
* [`d8b62d7b`](https://github.com/nix-community/emacs-overlay/commit/d8b62d7bf5edf5d14ba03a904c9c9c4f3b719e81) Updated elpa
* [`bde7c369`](https://github.com/nix-community/emacs-overlay/commit/bde7c369f548e93febee51d1bc38ecbac644c308) Updated melpa
* [`1e6301ed`](https://github.com/nix-community/emacs-overlay/commit/1e6301ed0b30f7601ab4cf85cabc086385ce3618) Updated emacs
* [`bc61b276`](https://github.com/nix-community/emacs-overlay/commit/bc61b276a41a9f5bd1a4ff5ac7b7651cd76feb8c) Updated elpa
* [`0329a922`](https://github.com/nix-community/emacs-overlay/commit/0329a922bf16ccb1fa77205793f5b06aa82ce5aa) Updated melpa
* [`349cdc7e`](https://github.com/nix-community/emacs-overlay/commit/349cdc7ea8cbb285146a4ce42421ca15c956fb12) Updated emacs
* [`cb854888`](https://github.com/nix-community/emacs-overlay/commit/cb854888ea23851cc9b52094f67b5669ab335da4) Updated melpa
* [`38ae419b`](https://github.com/nix-community/emacs-overlay/commit/38ae419b3aa286f48b323adf97bb12738b1d7b1e) Updated emacs
* [`5e24cd86`](https://github.com/nix-community/emacs-overlay/commit/5e24cd86f616933e95467ff198b9101a8a7f8e65) Updated elpa
* [`973347e0`](https://github.com/nix-community/emacs-overlay/commit/973347e0c130fde703cfb631dcf9c81ece588c36) Updated melpa
* [`944910d3`](https://github.com/nix-community/emacs-overlay/commit/944910d3bf4ea98fbd7f0bfe95fe0f590b75bf83) Updated elpa
* [`6bd7020b`](https://github.com/nix-community/emacs-overlay/commit/6bd7020b3f194c67a517722c9e48ece36118581c) Updated melpa
* [`dcb6c5cc`](https://github.com/nix-community/emacs-overlay/commit/dcb6c5cc11efa3ab804960537242217cf335b230) Updated emacs
* [`2c532ba6`](https://github.com/nix-community/emacs-overlay/commit/2c532ba61d7313c62d30f3f9cbb71d5e377ab57c) Updated elpa
* [`57da8acf`](https://github.com/nix-community/emacs-overlay/commit/57da8acf16de0ec858445dabe43f523ad676335d) Updated melpa
* [`6cc67062`](https://github.com/nix-community/emacs-overlay/commit/6cc67062226eae7feb728b6bfe4246ebc801f028) Updated emacs
* [`6af908b1`](https://github.com/nix-community/emacs-overlay/commit/6af908b15dc06f1d8a804e7d0c874cc2d0323857) Updated melpa
* [`c9764e76`](https://github.com/nix-community/emacs-overlay/commit/c9764e76968428e466a9c4c5f11f48f510fb5c75) Updated emacs
* [`ca5a359a`](https://github.com/nix-community/emacs-overlay/commit/ca5a359a1303a14567b4c3aed43134412fbe4382) Updated flake inputs
* [`79d5576e`](https://github.com/nix-community/emacs-overlay/commit/79d5576efbed2e33eab26688fa0816a1872c8e01) Updated elpa
* [`f6880709`](https://github.com/nix-community/emacs-overlay/commit/f6880709cd55f7be74b6fe59eb7dcca4e0b68d94) Updated melpa
* [`ceb97396`](https://github.com/nix-community/emacs-overlay/commit/ceb9739648fff3dea0552003a9a4127191f50cd1) Updated emacs
* [`f25632fa`](https://github.com/nix-community/emacs-overlay/commit/f25632fa01090713d4f70ae345f2ddff0920d19c) Updated melpa
* [`5a24cf51`](https://github.com/nix-community/emacs-overlay/commit/5a24cf5100cd2584313119d0f4d413417fec949c) Updated emacs
* [`8ffe9469`](https://github.com/nix-community/emacs-overlay/commit/8ffe946962930f685577f4758979dc4e707d8262) Updated flake inputs
* [`730eef54`](https://github.com/nix-community/emacs-overlay/commit/730eef543fafa152aaff3c485f355492914fd02a) Updated elpa
* [`fb22d2ec`](https://github.com/nix-community/emacs-overlay/commit/fb22d2ecf6d4741221eba1950d5fb6b1702b9a26) Updated melpa
* [`c61a9a41`](https://github.com/nix-community/emacs-overlay/commit/c61a9a413d4423c2c08ed0fa740e9d124db316a3) Updated elpa
* [`efdcd87f`](https://github.com/nix-community/emacs-overlay/commit/efdcd87f425e4c37a7053b0466100bb0cba74889) Updated melpa
* [`9ae82c10`](https://github.com/nix-community/emacs-overlay/commit/9ae82c10a7065080516fb7665a143ff6f8a57136) Updated emacs
* [`abc67e1b`](https://github.com/nix-community/emacs-overlay/commit/abc67e1b6e96a8da4fed8c5bc6ab962cf05a3dec) Updated melpa
* [`984860d0`](https://github.com/nix-community/emacs-overlay/commit/984860d0f4f5c3a6d1d92d0ac3cd1c081408e138) Updated emacs
* [`3f549c3f`](https://github.com/nix-community/emacs-overlay/commit/3f549c3f5f9c4f764779fa161fbe5a245e6fb5c2) Updated elpa
* [`d6fc9ce4`](https://github.com/nix-community/emacs-overlay/commit/d6fc9ce426b1574182f0db5b395386920750a61b) Updated emacs
* [`8bac1264`](https://github.com/nix-community/emacs-overlay/commit/8bac12643777ddcade600de7752615867f7f518f) Updated melpa
* [`2f8aaed4`](https://github.com/nix-community/emacs-overlay/commit/2f8aaed4b9cf8b9337af27f887022285d6455cc8) Updated nongnu
* [`534e9e5c`](https://github.com/nix-community/emacs-overlay/commit/534e9e5cfacc2231cef91cd8bb566fc913f870e5) Updated elpa
* [`a1e4ce73`](https://github.com/nix-community/emacs-overlay/commit/a1e4ce731728a2caeb622945efc360641dde2eff) Updated melpa
* [`e720d1e4`](https://github.com/nix-community/emacs-overlay/commit/e720d1e442dbdd2ea55cddfe3e918ba2868f2c56) Updated emacs
* [`1a4c7993`](https://github.com/nix-community/emacs-overlay/commit/1a4c799379c9e34c1143e10e2379fc9bfaeed5b7) Updated flake inputs
* [`4cab03f2`](https://github.com/nix-community/emacs-overlay/commit/4cab03f2abf26865a6696e593b2cefe942c37216) Updated melpa
* [`35b810dc`](https://github.com/nix-community/emacs-overlay/commit/35b810dcbe9543e026f6a7095b955f7c9643b9b3) Updated emacs
* [`368f873d`](https://github.com/nix-community/emacs-overlay/commit/368f873d4066da95159c2095a847f6c36d74af83) Updated melpa
* [`50ac0adb`](https://github.com/nix-community/emacs-overlay/commit/50ac0adb684bcde50574db50f814960545620730) Updated emacs
* [`da023f67`](https://github.com/nix-community/emacs-overlay/commit/da023f67f164e5571faeac7feec565f211a1b27b) Updated elpa
* [`306bf8bb`](https://github.com/nix-community/emacs-overlay/commit/306bf8bbce411033bbef90fd29018b468cb988a3) Updated melpa
* [`6cd7ddb6`](https://github.com/nix-community/emacs-overlay/commit/6cd7ddb6c8a8ac4b2bfb35ca3261d3e689740c8e) Updated emacs
* [`5cc9aea5`](https://github.com/nix-community/emacs-overlay/commit/5cc9aea5965112e115907410eb7d0e578f269680) Updated elpa
* [`79a88091`](https://github.com/nix-community/emacs-overlay/commit/79a880910d54496696b71804aba9a8baeb7257e1) Updated elpa
* [`831c263f`](https://github.com/nix-community/emacs-overlay/commit/831c263fb23fb7f1319c594130a59fdea819ecc7) Updated melpa
* [`e32ea52f`](https://github.com/nix-community/emacs-overlay/commit/e32ea52fb7488de5a89f93dafe3050c30dab21fd) Updated emacs
* [`db47b248`](https://github.com/nix-community/emacs-overlay/commit/db47b2483942771a725cf10e7cd3b1ec562750b7) Updated flake inputs
* [`1e2aa1e2`](https://github.com/nix-community/emacs-overlay/commit/1e2aa1e26bc1a49b1ff4326e7b5193bcfb732129) Updated melpa
* [`aed9a9e5`](https://github.com/nix-community/emacs-overlay/commit/aed9a9e58391a498c2ed2b5bbd0b59ec3d862f6d) Updated emacs
* [`74be16c1`](https://github.com/nix-community/emacs-overlay/commit/74be16c1d2aaecc4e3cd19d323e89f528b492a57) Updated elpa
* [`0247f642`](https://github.com/nix-community/emacs-overlay/commit/0247f6426f346c7ffd575ed938ee835cea1b329e) Updated melpa
* [`4dd04421`](https://github.com/nix-community/emacs-overlay/commit/4dd04421a91873b26f5b4acc8b2c947cb91c7900) Updated emacs
* [`2b3c5813`](https://github.com/nix-community/emacs-overlay/commit/2b3c5813233795dff6c23fc56fbaa85fcf16b55a) Updated elpa
* [`f7c18159`](https://github.com/nix-community/emacs-overlay/commit/f7c18159c781e56a74d3352ef2865929fc122c61) Updated melpa
* [`a374fae4`](https://github.com/nix-community/emacs-overlay/commit/a374fae44c74b4347ec40dbf4fcbc5bd826b115d) Updated flake inputs
* [`18027002`](https://github.com/nix-community/emacs-overlay/commit/18027002ed3101066ae48b8ac497dd31b8d4329c) Updated melpa
* [`1cdd60ae`](https://github.com/nix-community/emacs-overlay/commit/1cdd60ae31faea0bc68251429f64589978415b4b) Updated emacs
* [`75b53fa5`](https://github.com/nix-community/emacs-overlay/commit/75b53fa59de9baac0f2506c27fb8f0fa4e840778) Updated flake inputs
* [`f8e768e5`](https://github.com/nix-community/emacs-overlay/commit/f8e768e5f64035f969537827191bd1983afd7635) Updated elpa
* [`95e75afe`](https://github.com/nix-community/emacs-overlay/commit/95e75afe4014460546943a683c33ad06af2b35e6) Updated melpa
* [`a230393b`](https://github.com/nix-community/emacs-overlay/commit/a230393bb7e2db667c63c3f5c279a6e26d8b1c5a) Updated emacs
* [`76ee24cf`](https://github.com/nix-community/emacs-overlay/commit/76ee24cfe3d9866cc55881a89d91d5f9403f9ee8) Updated nongnu
* [`b182b289`](https://github.com/nix-community/emacs-overlay/commit/b182b289866f512e2756444ce9f1877920d99bf1) Updated elpa
* [`95c9c9cc`](https://github.com/nix-community/emacs-overlay/commit/95c9c9cc198e6f579ab80f32c8c0e93a381c25b9) Updated melpa
* [`65f195e9`](https://github.com/nix-community/emacs-overlay/commit/65f195e937a170adac199b12eab303b8488bf38b) Updated emacs
* [`e60b2a8b`](https://github.com/nix-community/emacs-overlay/commit/e60b2a8b58cc767057fb5daf0d7d5fd305fe4999) Updated melpa
* [`b7ec159f`](https://github.com/nix-community/emacs-overlay/commit/b7ec159f704bf8b55accd190dc7d0e84182f9a45) Updated emacs
* [`38821439`](https://github.com/nix-community/emacs-overlay/commit/388214396e9868ecd648bce9ccfc4d6074e6aee5) Updated flake inputs
* [`5bd6ccde`](https://github.com/nix-community/emacs-overlay/commit/5bd6ccdea4d7f4672de5922c7eaf791adc928eed) Updated elpa
* [`f8ec23ab`](https://github.com/nix-community/emacs-overlay/commit/f8ec23ab79ad9f5c9d75eeca35f672ccf8b31c40) Updated melpa
* [`30fdb303`](https://github.com/nix-community/emacs-overlay/commit/30fdb303a64d5fcbbaf0609b75d3c9c783af7869) Updated emacs
* [`68478abb`](https://github.com/nix-community/emacs-overlay/commit/68478abbc2484dc059e797de119bebe46910aa32) Updated elpa
* [`7e07cbc3`](https://github.com/nix-community/emacs-overlay/commit/7e07cbc381897f0090e12cb9f442cedb10d94360) Updated melpa
* [`ef8c23de`](https://github.com/nix-community/emacs-overlay/commit/ef8c23deac5611eeebbb2292da740846ce3ded43) Updated flake inputs
* [`4f2b503c`](https://github.com/nix-community/emacs-overlay/commit/4f2b503c128466683e2beacf68310985d156d188) Updated melpa
* [`455c16ff`](https://github.com/nix-community/emacs-overlay/commit/455c16ffba92352443eb5f5f1a76fb8732fcb75b) Updated emacs
* [`cadc4a6d`](https://github.com/nix-community/emacs-overlay/commit/cadc4a6d3652b00376a39e9575b4e7992629f449) Updated elpa
* [`7746ff73`](https://github.com/nix-community/emacs-overlay/commit/7746ff739b6a31a7fcef7258ee50dc9450d0af53) Updated melpa
* [`383aeb1b`](https://github.com/nix-community/emacs-overlay/commit/383aeb1bf3e2fdf14e7b1b66a35123228d7a0edb) Updated emacs
* [`ca5deb0f`](https://github.com/nix-community/emacs-overlay/commit/ca5deb0fc98adf4dfcb9ca0dfdb6ca203ac7f95e) Updated elpa
* [`80f8e5e4`](https://github.com/nix-community/emacs-overlay/commit/80f8e5e418f5a20831f2f38478ec719f627f0673) Updated melpa
* [`69e03a14`](https://github.com/nix-community/emacs-overlay/commit/69e03a148e6c604aed3579d81989aabccbba4d67) Updated emacs
* [`cfb8d4a7`](https://github.com/nix-community/emacs-overlay/commit/cfb8d4a721073302d61539010ff04b91d5031689) Updated flake inputs
* [`9b66dbef`](https://github.com/nix-community/emacs-overlay/commit/9b66dbef5285b09ceebc337c76dc498e077c6a1f) Updated melpa
* [`c68aeff6`](https://github.com/nix-community/emacs-overlay/commit/c68aeff603f1b5c4cc7a57b876cf5e7101f2f21c) Updated emacs
* [`ad824e2d`](https://github.com/nix-community/emacs-overlay/commit/ad824e2db6498f90ac4b0ff0c17d1e8cb703e100) Updated flake inputs
* [`453a1468`](https://github.com/nix-community/emacs-overlay/commit/453a1468961b409ae7425dc693f1a1be3997735e) Updated elpa
* [`c53e8dc6`](https://github.com/nix-community/emacs-overlay/commit/c53e8dc6260294bcfb2298701ee512089365d912) Updated melpa
* [`70d8a682`](https://github.com/nix-community/emacs-overlay/commit/70d8a682934e97ef4a76630678ecf76ab9b08380) Updated emacs
* [`2587b8bc`](https://github.com/nix-community/emacs-overlay/commit/2587b8bcc1c54aa24452d2280364d10099109725) Updated nongnu
* [`ab8d51e7`](https://github.com/nix-community/emacs-overlay/commit/ab8d51e727e7b1caafb11dc378ec9c3ec417dc15) Updated elpa
* [`0e783a96`](https://github.com/nix-community/emacs-overlay/commit/0e783a9604517f65aa2032af98fee6539f5be1e5) Updated melpa
* [`2be142e8`](https://github.com/nix-community/emacs-overlay/commit/2be142e8ad86fd395ad4738e2aa66886592db930) Updated emacs
* [`eeab94f5`](https://github.com/nix-community/emacs-overlay/commit/eeab94f5941e95a272de6316e7bb8650bbb92570) Updated melpa
* [`33414e0b`](https://github.com/nix-community/emacs-overlay/commit/33414e0b88fe7408884b4542b86818397d9fe44c) Updated emacs
* [`5bad4af0`](https://github.com/nix-community/emacs-overlay/commit/5bad4af097f771c2329f4806a4828cac76dcb444) Updated elpa
* [`c00e6807`](https://github.com/nix-community/emacs-overlay/commit/c00e68074c8782f2e7befe496a7c5e0fbf9ce76b) Updated melpa
* [`c1b23815`](https://github.com/nix-community/emacs-overlay/commit/c1b23815c2e28419e9fadbd254c5bdd47cc6707d) Updated emacs
* [`c75e9d97`](https://github.com/nix-community/emacs-overlay/commit/c75e9d9702989e0dccdbdf9691ec393e1428099b) Updated flake inputs
* [`c37b349f`](https://github.com/nix-community/emacs-overlay/commit/c37b349fb9713102d8b2d13e720f269f4c45d864) Updated nongnu
* [`218be052`](https://github.com/nix-community/emacs-overlay/commit/218be052c69487035e61fea04287da0d17275199) Updated elpa
* [`a257259d`](https://github.com/nix-community/emacs-overlay/commit/a257259d041d08eaa52701a7d4f617d25656ea45) Updated melpa
* [`45dcc834`](https://github.com/nix-community/emacs-overlay/commit/45dcc83490fe6befb6c1fd5bacf9ded14cdf0554) Updated emacs
* [`96bcdc62`](https://github.com/nix-community/emacs-overlay/commit/96bcdc62af503632cfbf0fcd58fa1ae244947223) Updated melpa
* [`ee3a92b1`](https://github.com/nix-community/emacs-overlay/commit/ee3a92b17a377d2ac2bb8293638f7e87f74953ee) Updated emacs
* [`e32cd426`](https://github.com/nix-community/emacs-overlay/commit/e32cd426fb92d6328a94ce87de87a343ceaac2aa) Updated flake inputs
* [`7115e70b`](https://github.com/nix-community/emacs-overlay/commit/7115e70bb490c73a00b576b2a7040403e9460a09) Updated elpa
* [`553f68ee`](https://github.com/nix-community/emacs-overlay/commit/553f68ee98a5d36c188f563f4e0851adbc132eda) Updated melpa
* [`28c564cc`](https://github.com/nix-community/emacs-overlay/commit/28c564ccf915615c65c4c1334504f1535192dee2) Updated emacs
* [`af746c7a`](https://github.com/nix-community/emacs-overlay/commit/af746c7a293f90504c96f16dc821ca18038801db) Updated elpa
* [`35ae865e`](https://github.com/nix-community/emacs-overlay/commit/35ae865e6482b8446f2dc5edeb5ebac35c26b5cc) Updated melpa
* [`4d36a831`](https://github.com/nix-community/emacs-overlay/commit/4d36a8316894dbfc9af4364a1d869b9212f778eb) Updated emacs
* [`26b1d6e2`](https://github.com/nix-community/emacs-overlay/commit/26b1d6e259ed1774cad615a8f34832791e400ed5) Updated melpa
* [`0f1fd52b`](https://github.com/nix-community/emacs-overlay/commit/0f1fd52b4ea652c7e8d983ceefe3a298848d0c1a) Updated emacs
* [`3fbacadd`](https://github.com/nix-community/emacs-overlay/commit/3fbacaddcf3ba1055780517c817d4b0e3b99b47a) Updated nongnu
* [`e500adcc`](https://github.com/nix-community/emacs-overlay/commit/e500adcc051336f222f28b144bdea5e2a5384a0b) Updated elpa
* [`012c7047`](https://github.com/nix-community/emacs-overlay/commit/012c70470e2bc0430ecd878453fa01b070efd2a0) Updated melpa
* [`895a56e7`](https://github.com/nix-community/emacs-overlay/commit/895a56e7294c2e5be4f84aa8e1cbc9e53e91307e) Updated emacs
* [`04bb6d07`](https://github.com/nix-community/emacs-overlay/commit/04bb6d0707e8ace081979786c5e40401ea59da30) Updated elpa
* [`31aaa030`](https://github.com/nix-community/emacs-overlay/commit/31aaa0306208e29f9d83bd31e3cbe870d625b92d) Updated melpa
* [`a4e4766e`](https://github.com/nix-community/emacs-overlay/commit/a4e4766e170c7ab715ebadcd0e7cb87c54bddd8b) Updated melpa
* [`15f5f7d5`](https://github.com/nix-community/emacs-overlay/commit/15f5f7d5eb82b1d2e7a4f754b11480b91aea9e91) Updated emacs
* [`ae6b39da`](https://github.com/nix-community/emacs-overlay/commit/ae6b39daa8c758813f0671c23839483d9ff6e20b) Updated flake inputs
* [`d5956593`](https://github.com/nix-community/emacs-overlay/commit/d5956593e73501dd88a12412a4638fb48300a3c0) Updated nongnu
* [`d07b2d28`](https://github.com/nix-community/emacs-overlay/commit/d07b2d2813bac1dac913e8d2f58b9e5f735d855c) Updated elpa
* [`85535d7e`](https://github.com/nix-community/emacs-overlay/commit/85535d7e9e9e8ddc934dec61e80575a3f6b93c47) Updated melpa
* [`1e56dc4f`](https://github.com/nix-community/emacs-overlay/commit/1e56dc4fc532f35ac38368e48e1ed607586b5a02) Updated emacs
* [`c69f2e48`](https://github.com/nix-community/emacs-overlay/commit/c69f2e48abb2fd0958be8f44037c717d673e5f37) Updated elpa
* [`558bde4f`](https://github.com/nix-community/emacs-overlay/commit/558bde4f14b4d167520b3591b65f502b94589769) Updated melpa
* [`845e9cba`](https://github.com/nix-community/emacs-overlay/commit/845e9cbad448ab23a4c2a19705af2e1f380256b1) Updated emacs
* [`1eb94bb8`](https://github.com/nix-community/emacs-overlay/commit/1eb94bb894a203679187f9bfcf96a6adccbfb223) Updated flake inputs
* [`8505f267`](https://github.com/nix-community/emacs-overlay/commit/8505f2676daa4c5387df15472bf1baaf72af12f5) Updated melpa
* [`ddc0d1e4`](https://github.com/nix-community/emacs-overlay/commit/ddc0d1e406566b0389f4e7f25d4b6aa59f98114e) Updated emacs
* [`3cf84387`](https://github.com/nix-community/emacs-overlay/commit/3cf8438736eb28dcbcde868f71fdd31c19ea830d) Updated elpa
* [`561994a3`](https://github.com/nix-community/emacs-overlay/commit/561994a3c87ecfc8ddb1159c0153a15ce29deacd) Updated melpa
* [`f6166eec`](https://github.com/nix-community/emacs-overlay/commit/f6166eecac653b5ed815feacdf17aa2e797a0578) Updated emacs
* [`d7bb0442`](https://github.com/nix-community/emacs-overlay/commit/d7bb0442d385bd42a66257c5d6079972591172d8) Updated elpa
* [`4e137ce1`](https://github.com/nix-community/emacs-overlay/commit/4e137ce1885720e787775fcfe6560826470c032c) Updated melpa
* [`81b09b6b`](https://github.com/nix-community/emacs-overlay/commit/81b09b6bb82c0f62bf2d9755a680bf925c9de773) Updated melpa
* [`756bfe12`](https://github.com/nix-community/emacs-overlay/commit/756bfe12bd21a23d803025dc07c7493bd1948494) Updated emacs
* [`b46d002e`](https://github.com/nix-community/emacs-overlay/commit/b46d002e832944a78bfaf431c461187d11f2288c) Updated flake inputs
* [`2f9ef66d`](https://github.com/nix-community/emacs-overlay/commit/2f9ef66d7d1d55f1ce8deed9f8b7e9f4169760cb) Updated elpa
* [`de274dc5`](https://github.com/nix-community/emacs-overlay/commit/de274dc5d822bf93de2996ab40a98f314d123740) Updated melpa
* [`78da5146`](https://github.com/nix-community/emacs-overlay/commit/78da5146ec2bbffc5a31fe08be4bcaf2fd6eeea3) Updated emacs
* [`871ff869`](https://github.com/nix-community/emacs-overlay/commit/871ff869f459fb6115f66a830cfa5d5421ea9bbd) Updated nongnu
* [`22fa7038`](https://github.com/nix-community/emacs-overlay/commit/22fa70381601884c5859d21bf6b0fc9ba54c2845) Updated elpa
* [`cb90e34b`](https://github.com/nix-community/emacs-overlay/commit/cb90e34ba6dc4dbc277886e2302483aa32f5b557) Updated melpa
* [`88685372`](https://github.com/nix-community/emacs-overlay/commit/88685372ad906c0b12b541806a5fcdad9857681f) Updated emacs
* [`44817d1f`](https://github.com/nix-community/emacs-overlay/commit/44817d1f0a8150bafa1b5516d7896234ea867236) Updated flake inputs
* [`883f0161`](https://github.com/nix-community/emacs-overlay/commit/883f01615dd52d12aa2309c5d70fadc93153c81e) Updated melpa
* [`76b6a3e6`](https://github.com/nix-community/emacs-overlay/commit/76b6a3e62b790f56cb0707ce91bbe111c56cbcb7) Updated emacs
* [`e3379452`](https://github.com/nix-community/emacs-overlay/commit/e33794521c009a603063be601b9485bf76e22a04) Updated nongnu
* [`a665e7c3`](https://github.com/nix-community/emacs-overlay/commit/a665e7c30e6f86bc9cb7848f75d8fa856956df22) Updated elpa
* [`4a3172d9`](https://github.com/nix-community/emacs-overlay/commit/4a3172d9c3d385a9ef1e7e309c9afaf44a55b8c7) Updated melpa
* [`a9216f7a`](https://github.com/nix-community/emacs-overlay/commit/a9216f7a1ec216e36e31c7d2ed42de4df89d918a) Updated emacs
* [`8d22154b`](https://github.com/nix-community/emacs-overlay/commit/8d22154b02c319d07662f6eaab61da54f58778c6) Updated nongnu
* [`6dac2d37`](https://github.com/nix-community/emacs-overlay/commit/6dac2d374a457a1e117271a9b547c0628e1607bc) Updated elpa
* [`7270f36a`](https://github.com/nix-community/emacs-overlay/commit/7270f36aa2ef94fba91cc20abc1e70552669b4c9) Updated emacs
* [`3ceaaf96`](https://github.com/nix-community/emacs-overlay/commit/3ceaaf96fb4ee8f81cf5e381322d6d071950b55d) Updated melpa
* [`47805ddc`](https://github.com/nix-community/emacs-overlay/commit/47805ddcd1432713e7dd1191af54e585574c763b) Updated melpa
* [`db67dedb`](https://github.com/nix-community/emacs-overlay/commit/db67dedba21b1e119c7f835662e80934f0882c1e) Updated emacs
* [`4313d82e`](https://github.com/nix-community/emacs-overlay/commit/4313d82e2440ed3118a7eefd7e1ebd42ed9bed30) Updated flake inputs
* [`0eda17b4`](https://github.com/nix-community/emacs-overlay/commit/0eda17b4424345a0f3e26eaf966439a3f32a5dd6) Updated elpa
* [`9bcc2419`](https://github.com/nix-community/emacs-overlay/commit/9bcc24197b1ef9bcc336246c72aa0ae8e56d23ca) Updated melpa
* [`803135be`](https://github.com/nix-community/emacs-overlay/commit/803135bef04c3e58301ae422922e486223f526c0) Updated emacs
* [`aea1e8e4`](https://github.com/nix-community/emacs-overlay/commit/aea1e8e4ee210154ce4b3b2cf1d922577eb18adb) Updated elpa
* [`e6da5554`](https://github.com/nix-community/emacs-overlay/commit/e6da5554f4f7396f22499a8b87eb05b487e034c1) Updated melpa
* [`cad98a25`](https://github.com/nix-community/emacs-overlay/commit/cad98a253dc7b22fb12db42ccac3d04402e63dd0) Updated emacs
* [`b211a25f`](https://github.com/nix-community/emacs-overlay/commit/b211a25ffa4f6938243612b63c0d59e3d2ca0259) Updated melpa
* [`4dc3e8eb`](https://github.com/nix-community/emacs-overlay/commit/4dc3e8ebdfbe18cf0a1dcacac242ae3f3fb878b9) Updated emacs
* [`b6aff5c0`](https://github.com/nix-community/emacs-overlay/commit/b6aff5c0c41400f511b689f3896a3571e8f5b1f2) Updated flake inputs
* [`c0ccc0cc`](https://github.com/nix-community/emacs-overlay/commit/c0ccc0cc430b18b766c51942f16cd2d071fd9a90) Updated nongnu
* [`5a166e0a`](https://github.com/nix-community/emacs-overlay/commit/5a166e0a7a750ec08f18d61d627134d7a2948e28) Updated elpa
* [`3e0e49b0`](https://github.com/nix-community/emacs-overlay/commit/3e0e49b059f7f3aa66688c85b38f9ab2e8410da6) Updated melpa
* [`661ffb2c`](https://github.com/nix-community/emacs-overlay/commit/661ffb2c8fa3a7f8d032df474d035b33aa50a4b9) Updated emacs
* [`c97beff9`](https://github.com/nix-community/emacs-overlay/commit/c97beff978530311380ccd8698ede4c409e20a3f) Updated flake inputs
* [`a79977ec`](https://github.com/nix-community/emacs-overlay/commit/a79977ec536fa8d57ff193710131a2b662bcbc85) Updated elpa
* [`e3f8066b`](https://github.com/nix-community/emacs-overlay/commit/e3f8066b900c949dfb4b485be36d5704f9a112dc) Updated melpa
* [`75440e56`](https://github.com/nix-community/emacs-overlay/commit/75440e565fe138f169389e1a65cc21f7ec5f0a30) Updated emacs
* [`2ea50482`](https://github.com/nix-community/emacs-overlay/commit/2ea504825e8512a8ce2ffd43a7827ddac4ed3da0) Updated melpa
* [`5dc85425`](https://github.com/nix-community/emacs-overlay/commit/5dc85425ccc2513d6a843bf58ddd104b5689b6c6) Updated emacs
* [`b527a992`](https://github.com/nix-community/emacs-overlay/commit/b527a992efa2efc26c446c8b2c22b7e65dfc941d) Updated elpa
* [`a3e3e382`](https://github.com/nix-community/emacs-overlay/commit/a3e3e3826b7afd237956c4832cfe6806a1e7e2b5) Updated melpa
* [`2d56af52`](https://github.com/nix-community/emacs-overlay/commit/2d56af526e581cd6af4b28b508dbac970bf2f536) Updated emacs
* [`b3733b44`](https://github.com/nix-community/emacs-overlay/commit/b3733b44533e212435449583655ec06303f669ce) Updated flake inputs
* [`fb0b8273`](https://github.com/nix-community/emacs-overlay/commit/fb0b8273fdbb853c97dcfb9d0c02f3581a23d92a) Updated elpa
* [`80a28966`](https://github.com/nix-community/emacs-overlay/commit/80a289667716a29aef3f0f4ba6b5bfba118e2657) Updated melpa
* [`4ad65bb1`](https://github.com/nix-community/emacs-overlay/commit/4ad65bb18dc1b6e9bd62a9375986025ef9beb488) Updated emacs
* [`d3a94d43`](https://github.com/nix-community/emacs-overlay/commit/d3a94d43373ad928335853223470503d46cbf827) Updated melpa
* [`d6bbd32e`](https://github.com/nix-community/emacs-overlay/commit/d6bbd32eb3e0f167f312e1031c1beee452dc9174) Updated emacs
* [`422f326f`](https://github.com/nix-community/emacs-overlay/commit/422f326f7a2786d4454d2a942cac81fe0a835d43) Updated elpa
* [`50c3a1f7`](https://github.com/nix-community/emacs-overlay/commit/50c3a1f7ffc6b9e85e5b74c1a15fd7d5780dd817) Updated melpa
* [`cea4619a`](https://github.com/nix-community/emacs-overlay/commit/cea4619a3f9026cb4d805c81a70280c05ace512a) Updated emacs
* [`e4f201b6`](https://github.com/nix-community/emacs-overlay/commit/e4f201b647af64fd18aaf671fec0ceb8a71d1e0f) Updated nongnu
* [`40c879a7`](https://github.com/nix-community/emacs-overlay/commit/40c879a7212f4ff242fab34d3d604ce3856d1d55) Updated elpa
* [`3b51a532`](https://github.com/nix-community/emacs-overlay/commit/3b51a53286ab12124ddb7e22e037bad2aeb6dc0f) Updated melpa
* [`0bd7189c`](https://github.com/nix-community/emacs-overlay/commit/0bd7189c98161c469713f03a42fe599c53fcf98d) Updated melpa
* [`b0277cb5`](https://github.com/nix-community/emacs-overlay/commit/b0277cb505f1ab0e5ea4b1ed22128f31aaec294a) Updated emacs
* [`e9baa59a`](https://github.com/nix-community/emacs-overlay/commit/e9baa59a453ec4e833f708ce1e9b75ee525e9845) Updated elpa
* [`86bba67a`](https://github.com/nix-community/emacs-overlay/commit/86bba67a652c066cae1fb53ef0f23c96b721d2c4) Updated melpa
* [`b7e580bd`](https://github.com/nix-community/emacs-overlay/commit/b7e580bd8e698b784a02a20071007930f993de99) Updated emacs
