### PR TITLE
niv doomemacs: update 35dc1363 -> 286be1b2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "35dc13632b3177b9efedad212f2180f69e756853",
-        "sha256": "0ym6hrawygjmpc1mn2kg1b6rj13hcn7q23zvksppspgpvc59l7sf",
+        "rev": "286be1b2496a3ffa2280a16a41f56babebea93f0",
+        "sha256": "0mdaijxpzls0n6s0cj2ggxz3iivkx8qxc0qwlkhg1v8bxa3afsv0",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/35dc13632b3177b9efedad212f2180f69e756853.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/286be1b2496a3ffa2280a16a41f56babebea93f0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@35dc1363...286be1b2](https://github.com/doomemacs/doomemacs/compare/35dc13632b3177b9efedad212f2180f69e756853...286be1b2496a3ffa2280a16a41f56babebea93f0)

* [`b439300e`](https://github.com/doomemacs/doomemacs/commit/b439300e6a0c4ccc8473c25d4182d3cdb5d4f8d0) fix(everywhere): commandp error from C-c C-c
* [`179e300b`](https://github.com/doomemacs/doomemacs/commit/179e300bfdd55d6dc8b002a63481990a1e86b574) bump: visual-fill-column
* [`183ab389`](https://github.com/doomemacs/doomemacs/commit/183ab38926aa1506203ea9ea64f631d598f90b4a) bump: spell-fu
* [`2757a97a`](https://github.com/doomemacs/doomemacs/commit/2757a97a30e7c4a0c2a5d2de13f2214baf09b019) fix(org): don't change tab-width in org-mode
* [`2e123839`](https://github.com/doomemacs/doomemacs/commit/2e123839d12358895b37e190b1b8419666fb24e0) bump: :lang rust
* [`ff127805`](https://github.com/doomemacs/doomemacs/commit/ff127805d3b9f935076588e97d3e77d17afb6d97) bump: :tools magit
* [`b94d1481`](https://github.com/doomemacs/doomemacs/commit/b94d14811d069db1da891116b5ab4086359b67d3) bump: :tools lsp
* [`3dbdcb79`](https://github.com/doomemacs/doomemacs/commit/3dbdcb7947b8cfbc47d0790180de27ad0725a407) fix: define doom-font-error
* [`44bc88ec`](https://github.com/doomemacs/doomemacs/commit/44bc88ec3986d477c64c405ed9bbae2981fd8141) bump: code-review
* [`2324ff4b`](https://github.com/doomemacs/doomemacs/commit/2324ff4bb7e20fd0ed29a9ae05e4cd08ccc2c7f7) bump: :lang rust
* [`9f198978`](https://github.com/doomemacs/doomemacs/commit/9f198978f8a37d430175025b1c48418fd83bf268) fix(biblio): avoid 'oc-csl dependency cycle
* [`0fc32ed8`](https://github.com/doomemacs/doomemacs/commit/0fc32ed881e8b2fc8cd41c21c5f2977e160de06a) perf(biblio): do not load oc-natbib by default
* [`2b290159`](https://github.com/doomemacs/doomemacs/commit/2b2901593e00c999bded3fecd1b08192a1b821fe) refactor(biblio): tidy use-package usage
* [`c0311390`](https://github.com/doomemacs/doomemacs/commit/c03113906a6152ff232dc8c7c53513d97951a7fe) fix(dired): hide flycheck temp files
* [`5d77d317`](https://github.com/doomemacs/doomemacs/commit/5d77d317a37ed2d3211115763d34d4183c4c0d9f) fix(clojure): obsolete ref to cider-repl-print-length
* [`78b85b8a`](https://github.com/doomemacs/doomemacs/commit/78b85b8a72bd33ceda8071df37b3243907b633f1) fix(vertico): mapping for embark open in workspace
* [`645c856d`](https://github.com/doomemacs/doomemacs/commit/645c856de0cd9e0e419e22b7c00f3146009b55c5) fix(popup): allow killing popup buffers
* [`47dc59f3`](https://github.com/doomemacs/doomemacs/commit/47dc59f3b21fe150033c62974ba2642610bcd9ae) fix(nix): make doctor check against nix-nixfmt-bin
* [`bea81278`](https://github.com/doomemacs/doomemacs/commit/bea81278fd2ecb65db6a63dbcd6db2f52921ee41) bump: :checkers syntax
* [`d657be17`](https://github.com/doomemacs/doomemacs/commit/d657be1744a1481dc4646d0b62d5ee1d3e75d1d8) feat(vertico): completion highlights a la ivy
* [`7018cb45`](https://github.com/doomemacs/doomemacs/commit/7018cb45fbd4019214b4ee1a046ce94c4cb5e6ae) fix(vertico): disable minor mode highlight duly
* [`aad8ec18`](https://github.com/doomemacs/doomemacs/commit/aad8ec1895714f4fec6abfe444c9a69b4ee8f308) feat(java): java.el takes java-ts-mode into account
* [`79429ecc`](https://github.com/doomemacs/doomemacs/commit/79429ecc562893b77be257013f8150eb51005cc1) fix(nim): swap nimfmt with nimpretty
* [`d4434887`](https://github.com/doomemacs/doomemacs/commit/d4434887281f87be8a6aefdc50a7360df4571328) bump: :lang nim
* [`2bce9dbc`](https://github.com/doomemacs/doomemacs/commit/2bce9dbc1ad1e84641625a8d7d794f9644d58b21) fix: doom-incremental-first-idle-timer: type error when nil
* [`f1c1efe4`](https://github.com/doomemacs/doomemacs/commit/f1c1efe420afffdec8557dd7bf0e1782158bfc12) refactor(biblio): move 3rd party modes to use-package blocks
* [`3820ead9`](https://github.com/doomemacs/doomemacs/commit/3820ead9e3b029abb2e09289d4b875e25cdea332) tweak(markdown): disable wiki links & math highlights by default
* [`3b405c8d`](https://github.com/doomemacs/doomemacs/commit/3b405c8d8146553a1faad664e529c1ed0f841fa8) fix(lib): only use alpha-background on pgtk builds
* [`198fe82b`](https://github.com/doomemacs/doomemacs/commit/198fe82b6d4989b7fdffb810e97371c44fa4dbcb) feat(lib): backport find-sibling-file
* [`43870bf8`](https://github.com/doomemacs/doomemacs/commit/43870bf8318f6471c4ce5e14565c9f0a3fb6e368) fix(editorconfig): prevent changes to tab-width in org-mode
* [`41e81f67`](https://github.com/doomemacs/doomemacs/commit/41e81f67a73bb6d042c83a02f5c9ac3125306fd5) refactor(editorconfig): remove unused advice
* [`dec058fa`](https://github.com/doomemacs/doomemacs/commit/dec058fabb5ed188f712a90cfd987616ade3676a) fix(treemacs): treemacs-nerd-icons load order w/ +lsp
* [`6c1aa0fb`](https://github.com/doomemacs/doomemacs/commit/6c1aa0fb621a912a1a7eaed4f5db30a821d97327) bump: :tools editorconfig
* [`7f484f70`](https://github.com/doomemacs/doomemacs/commit/7f484f7010298d300d69fd0f70c5245e74949462) refactor: remove explain-pause-mode
* [`c6063de4`](https://github.com/doomemacs/doomemacs/commit/c6063de4399411e45a06e8ac14249b323419ae6c) nit: revise and reformat comments
* [`e27d9b35`](https://github.com/doomemacs/doomemacs/commit/e27d9b35d3a42e22951edcfbdaa63526f4b9c7b2) fix(popup): fix finding of major side window
* [`4be265ea`](https://github.com/doomemacs/doomemacs/commit/4be265ead73e587a9cc2e86f01e103728c5eaf20) fix: doom-incremental-first-idle-timer: type error when nil (part 2)
* [`61327bf7`](https://github.com/doomemacs/doomemacs/commit/61327bf77770d815d71ba84a872a2da3d8fd4a53) refactor(lib): use doom-region-{beginning,end}
* [`55917157`](https://github.com/doomemacs/doomemacs/commit/559171575e7685463ae6608b6c37caf7c234f89d) refactor(lib): doom-region-end: extract marker
* [`a0a1babc`](https://github.com/doomemacs/doomemacs/commit/a0a1babc0d24e34909fbe6801edbe8388a022b98) fix(cli): silence output from site-lisp
* [`1db96a1f`](https://github.com/doomemacs/doomemacs/commit/1db96a1fdb76a9ab245a298db701880eeba8fe7d) docs(web): correct type, mention JS comment hack, remove superfluous notice
* [`68682ac0`](https://github.com/doomemacs/doomemacs/commit/68682ac01269f2ba55b51f368901cf6735d7c24a) fix(ruby): ruby REPL w/ robe
* [`b3822557`](https://github.com/doomemacs/doomemacs/commit/b3822557044ba21c8823bc209ac584e922028916) release(modules): 24.03.0-dev
* [`a0344ffc`](https://github.com/doomemacs/doomemacs/commit/a0344ffc3ad7844075f6b0bc53c5130545d5a1d5) fix(mu4e): advice for new mu4e release
* [`f838c179`](https://github.com/doomemacs/doomemacs/commit/f838c1790d1946dff3cd275e053417964dd121c4) docs(default,mu4e,latex): fix repetition of `the` in docs
* [`90f90fb3`](https://github.com/doomemacs/doomemacs/commit/90f90fb34d36a029bcd69f203dd52887d13013a0) fix(treemacs): simplify lsp-treemacs load-order
* [`4af536cd`](https://github.com/doomemacs/doomemacs/commit/4af536cde23b1cae50049f24546765fbe944d1f1) fix(emacs-lisp): +emacs-lisp--module-at-point: wrong-number-of-arguments error
* [`5f858bb1`](https://github.com/doomemacs/doomemacs/commit/5f858bb142ccd1adb283d81cc6c703e872b36092) refactor(lsp): obsolete eglot-events-buffer-size
* [`5cc4056a`](https://github.com/doomemacs/doomemacs/commit/5cc4056abf30b0d9c5027b93a1022f8ee9e90f99) fix(format): +format-with-eglot-fn: eglot detection
* [`fec28a19`](https://github.com/doomemacs/doomemacs/commit/fec28a19e16cdd32364bf58e2c88699da514cb78) fix: save-place: don't move point more than once
* [`39db5de5`](https://github.com/doomemacs/doomemacs/commit/39db5de5709a0e4a3b1a88bfd58d7d0075b2d728) fix(org): only reveal point on save-place-after-find-file-hook
* [`0073c3d7`](https://github.com/doomemacs/doomemacs/commit/0073c3d70db750db94c53e67e725d11c73bff3f3) docs(twitter): add deprecation notice
* [`193475cd`](https://github.com/doomemacs/doomemacs/commit/193475cd644a5c7a441da1ec468d6d59c1436672) fix(lsp): s/eglot-events-buffer-size/eglot-events-buffer-config/
* [`5280fb28`](https://github.com/doomemacs/doomemacs/commit/5280fb2855eef82d65ae7cc5bc0ca52d06fcf2ca) fix(lsp): void-variable eglot-events-buffer-config
* [`c20c2aa3`](https://github.com/doomemacs/doomemacs/commit/c20c2aa36ed0be93beca3fc63eea2724f57af6a7) fix: tiny fonts in (daemon) GUI frames
* [`85ce8669`](https://github.com/doomemacs/doomemacs/commit/85ce866953c0446294a4201e4a2a362a7fa32b6c) feat(macos): osx-trash is only needed by emacs < 29
* [`6949451b`](https://github.com/doomemacs/doomemacs/commit/6949451b00eccbf03a6e070afafca85bec5daac5) module: add :completion corfu
* [`968a8975`](https://github.com/doomemacs/doomemacs/commit/968a8975308c772d0298021884758792eab641e8) feat(corfu): add snippets
* [`365a95de`](https://github.com/doomemacs/doomemacs/commit/365a95de76e14939b7296c636192319a675844cf) feat(corfu): more CAPFs and ergonomy changes
* [`0588b42b`](https://github.com/doomemacs/doomemacs/commit/0588b42b46265450128e438cef82f7906d8722e5) feat(corfu,vertico): use equal orderless config
* [`763464af`](https://github.com/doomemacs/doomemacs/commit/763464afdb9c46d5f60d4565c110d6d1a05fbf99) feat(corfu): general move-to-minibuffer impl
* [`4192c811`](https://github.com/doomemacs/doomemacs/commit/4192c811130c2c2e73eeb83a9f24a9ba40f8b02f) feat(corfu): make minibuffer completion optional
* [`bfb9aabe`](https://github.com/doomemacs/doomemacs/commit/bfb9aabe27fbb89f9e3f31b306c0bc2a103f15fd) feat(corfu): update minibuffer hints manually
* [`f9c02432`](https://github.com/doomemacs/doomemacs/commit/f9c0243211a4654347c7bb83daf5e80416739227) docs(corfu): add @⁠LemonBreezes as co-maintainer
* [`e8897421`](https://github.com/doomemacs/doomemacs/commit/e8897421b183cd5bc8a5b7c3dad52586d3120f22) fix(java): add lsp-treemacs
* [`b6e7bbbe`](https://github.com/doomemacs/doomemacs/commit/b6e7bbbe07494df7c78f9e733454a87fb9672bbb) fix(eval): overlay position
* [`5e7c7693`](https://github.com/doomemacs/doomemacs/commit/5e7c769315941f8af1507bf659c5607e4baae960) fix: ensure inhibit-* is reset on startup error
* [`1d9b1021`](https://github.com/doomemacs/doomemacs/commit/1d9b102181455710860bb7ddc07d86f1eb7f260c) fix: shut up site-lisp
* [`1d99d1f1`](https://github.com/doomemacs/doomemacs/commit/1d99d1f191ecfd5c03489c380b6e39497e7ab8d6) refactor: consolidate startup--load-user-init-file advice
* [`6b55c6ad`](https://github.com/doomemacs/doomemacs/commit/6b55c6adc6056d2337240ffcb403324fb739be05) refactor: inline doom--make-font-specs
* [`d553ebc9`](https://github.com/doomemacs/doomemacs/commit/d553ebc930d7d3d8a65740059250cfd4c037cc37) fix: invoke debugger for early-init.el-level errors
* [`550d6ecd`](https://github.com/doomemacs/doomemacs/commit/550d6ecd1984cc425ed89aa422ea0ce9119f8d27) bump: :tools magit
* [`9447e820`](https://github.com/doomemacs/doomemacs/commit/9447e820740edbc3f3ce9a296be934ca635e0131) bump: :completion vertico
* [`f7168930`](https://github.com/doomemacs/doomemacs/commit/f71689304e057eeefb0b9000c92518593c842e12) tweak: enable startup optimizations in debug mode
* [`875cd1ae`](https://github.com/doomemacs/doomemacs/commit/875cd1aef99ca19d4534b4fbbb6bc931e2e10440) fix(corfu): gate corfu-terminal config
* [`b52d2b2d`](https://github.com/doomemacs/doomemacs/commit/b52d2b2dd06a563e6f56aa2e36cb6e8c011b7061) fix(corfu): ispell: only complain once per session
* [`c9c221ca`](https://github.com/doomemacs/doomemacs/commit/c9c221ca5992aa98495a934fa6a85c98fdbefeb8) fix(corfu): wrong-type-argument characterp error
* [`7547cdac`](https://github.com/doomemacs/doomemacs/commit/7547cdac6d7da88bdee2abb9f9ddb2f7d10f7122) refactor(corfu): remove redundant setting
* [`c564c17a`](https://github.com/doomemacs/doomemacs/commit/c564c17a6ba83d2864fe532191eca4398794f996) fix(fold): reorder fold type checks
* [`0ea84d1c`](https://github.com/doomemacs/doomemacs/commit/0ea84d1c3bff76cdf8983bd033717631016fb31b) feat(vertico): add consult-yasnippet
* [`73f19acb`](https://github.com/doomemacs/doomemacs/commit/73f19acb66ff37d2ef1644516c0c983543ac2246) fix(julia): revise julia-snail settings
* [`d22fa5a6`](https://github.com/doomemacs/doomemacs/commit/d22fa5a67014f49c1e6b732bbde7737fe9e2f33f) fix(vertico): consult-dir: don't guess user from containers
* [`367b6711`](https://github.com/doomemacs/doomemacs/commit/367b6711343a483e2dbc181829d8ebe13cea68db) refactor(lsp): suffix advice & remove redundancy
* [`cd16150b`](https://github.com/doomemacs/doomemacs/commit/cd16150b8024808b394b6ac80eeac19751d81233) bump: :lang julia
* [`222dc470`](https://github.com/doomemacs/doomemacs/commit/222dc47060e7151b89a6e34e2b1237de42439589) feat(vertico): add orderless annotation filtering
* [`d3a00ba6`](https://github.com/doomemacs/doomemacs/commit/d3a00ba6af7357f00dd8a99b0a3f46ced766b170) nit(vertico): fix spelling in some docstrings
* [`2bdeabb0`](https://github.com/doomemacs/doomemacs/commit/2bdeabb0cf2b8a5bd4798a47da9b598ab46609e3) refactor(corfu): consolidate +orderless logic without vertico
* [`a8309146`](https://github.com/doomemacs/doomemacs/commit/a83091469b317812be2fe408f5edce665d018a7c) docs(corfu): debugging cape-dabbrev
* [`665d808d`](https://github.com/doomemacs/doomemacs/commit/665d808d09ecba0be1b2de3977950e579bb5daee) bump: :ui
* [`cb6e3f0e`](https://github.com/doomemacs/doomemacs/commit/cb6e3f0e89ac6e51155409566947af633744f466) fix(modeline,everywhere): adjust checker -> check
* [`76b45227`](https://github.com/doomemacs/doomemacs/commit/76b452278fcbe9f6087878568e56d4e5a6f5c677) fix(default): restore accidentally gated keybinds
* [`89e6b684`](https://github.com/doomemacs/doomemacs/commit/89e6b6849e5bee7fbf5e31f28ef4d4ae6b0ffc0b) fix(default): restore accidentally gated keybinds (part 2)
* [`bbadabda`](https://github.com/doomemacs/doomemacs/commit/bbadabda511027e515f02ccd7b70291ed03d8945) feat: allow setting evil states for leader keys
* [`50619219`](https://github.com/doomemacs/doomemacs/commit/506192199fa1332814aba2f09b9e052406c86e34) docs(docker): use after! & don't recommend use-package!
* [`18c88621`](https://github.com/doomemacs/doomemacs/commit/18c88621a422357b4bcce317808125f20320b432) refactor(vertico): don't use bind-key
* [`63c470bf`](https://github.com/doomemacs/doomemacs/commit/63c470bff32875098fa5a7f205e0b5eb08247686) refactor!(cli): remove compile and clean commands
* [`1fa8d3a4`](https://github.com/doomemacs/doomemacs/commit/1fa8d3a4b99275a1bad2aba8e9195c282b49b12d) fix(cli): retry on failure to clone packages (or abort)
* [`cff09198`](https://github.com/doomemacs/doomemacs/commit/cff091982e4197db48cd5749a9a0700d47aa9944) fix(cli): rewrite 'doom sync'; deprecate 'doom build'
* [`2591201a`](https://github.com/doomemacs/doomemacs/commit/2591201aa10ebaa611aeb1e9d35619723c70b541) refactor(cli): rename 'doom purge' -> 'doom gc'
* [`bfd21ede`](https://github.com/doomemacs/doomemacs/commit/bfd21edeeba0c30fe187aae79a735cfbd4928dae) nit: reformat core packages.el
* [`32ef0989`](https://github.com/doomemacs/doomemacs/commit/32ef0989abbf4407b3415554d2c4cdb00661f43e) fix(cli): appease byte-compiler wrt defcli-obsolete!
* [`77df11af`](https://github.com/doomemacs/doomemacs/commit/77df11af11b7ead75ddeca22ab8bd9cadc0191e4) refactor(cli): remove unused cli/help.el
* [`e24a583d`](https://github.com/doomemacs/doomemacs/commit/e24a583d5c0fc37df5319f9d690d2fe2989afd5b) tweak: move project-list-file to profile data dir
* [`1462f876`](https://github.com/doomemacs/doomemacs/commit/1462f8762314119009594314a4b8ef3ae9bf43b0) bump: :tools tree-sitter
* [`2df24d29`](https://github.com/doomemacs/doomemacs/commit/2df24d29f3923aa736692f9d986024dca3381b71) bump: :core
* [`8d50cd8b`](https://github.com/doomemacs/doomemacs/commit/8d50cd8bfb63e275949eb943fa9d1aad21a5332e) tweak(lib): print!: join (path ...) segments
* [`6d682eef`](https://github.com/doomemacs/doomemacs/commit/6d682eef8596b069aeaac9774711fdce48a7027f) fix(cli): void-function doom-packages-install error
* [`286be1b2`](https://github.com/doomemacs/doomemacs/commit/286be1b2496a3ffa2280a16a41f56babebea93f0) fix(cli): void-variable doom-profile-env-file-name error
