### PR TITLE
niv devenv: update 169d2cbc -> 5d99d9fb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "169d2cbce65977289f2e0e863a4e8f42f9ce98af",
-        "sha256": "0l5s3j16rfw2lk9gqf3hcqgfsds1axrcb3vqmzq3ar3q8kdz6x29",
+        "rev": "5d99d9fb18882d2b2ceeb09688c158e39b927394",
+        "sha256": "1ip483ha9n8rwhs7dgn754q9v999xdhj1cq11qhx2cbc8r381ii8",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/169d2cbce65977289f2e0e863a4e8f42f9ce98af.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/5d99d9fb18882d2b2ceeb09688c158e39b927394.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@169d2cbc...5d99d9fb](https://github.com/cachix/devenv/compare/169d2cbce65977289f2e0e863a4e8f42f9ce98af...5d99d9fb18882d2b2ceeb09688c158e39b927394)

* [`9dd1f740`](https://github.com/cachix/devenv/commit/9dd1f740183055f5dba7cd2668081ae7d64d5ee2) mongodb: added configure script and options to create a superuser on
* [`f8b5e098`](https://github.com/cachix/devenv/commit/f8b5e098bbcd082242f38407825b3773db6e1c71) mongodb: final touches for creating initial user.
* [`b79443d8`](https://github.com/cachix/devenv/commit/b79443d88ce411cfdccc45da14714f8955398650) Added mongosh to mongo service and added test for mongodb with initial
* [`30829df3`](https://github.com/cachix/devenv/commit/30829df30f7072a2b266f9e5b4aa71fa0427105e) generating examples should depend on successful build
* [`0d967cd7`](https://github.com/cachix/devenv/commit/0d967cd7a72f55137a7cb7f375017497acf3b7cf) unpin python 3.7 for cloudflare & fix build
* [`21d606c0`](https://github.com/cachix/devenv/commit/21d606c0926f2251b7fdc4d323819e7f1b40c75f) switch to nix ide with lsp support
* [`b4e98ae9`](https://github.com/cachix/devenv/commit/b4e98ae926cff2647a7ac9003cae68aadfe4280f) ci: name the reinstallation step
* [`b9c1704f`](https://github.com/cachix/devenv/commit/b9c1704f32974657070d209f6e5f332d6e2f60ce) Rewrite CLI in Python
* [`c81069c8`](https://github.com/cachix/devenv/commit/c81069c83ab242dd831e74a992c1d38d32b77d14) devenv inputs add <name> <url>
* [`cf9d1229`](https://github.com/cachix/devenv/commit/cf9d1229b814ac8d6aa2014a0ed9d6cd8d09e111) cli
* [`cfc0cb8e`](https://github.com/cachix/devenv/commit/cfc0cb8ea74c96b16297d740c4a6a7586cae6b8e) devenv print-dev-env --json
* [`d517bf08`](https://github.com/cachix/devenv/commit/d517bf084e6a53fbcd9c2b1e14ceed2cb9746de6) Nix 2.17 + patches
* [`1d37fdb0`](https://github.com/cachix/devenv/commit/1d37fdb0d13c36be996d68ee06bed5bde8f39083) shellcheck
* [`0fa6402c`](https://github.com/cachix/devenv/commit/0fa6402c19a3ba595aea913a86dd9592a49db7d6) Debug
* [`1cc2387c`](https://github.com/cachix/devenv/commit/1cc2387c2e2203c47d2edcf322888bb1d75b23f4) Disable macos-latest for now
* [`868f1b96`](https://github.com/cachix/devenv/commit/868f1b96eb9e3eaa4db40aa270fb3f8483188fb4) fix a few examples
* [`ce115efe`](https://github.com/cachix/devenv/commit/ce115efe24ba2317147f6b85e430e63bf0e62977) python: wrap to specify LD_LIBRARY_PATH
* [`bc7f048a`](https://github.com/cachix/devenv/commit/bc7f048a8f29dd701ea16d10004a90cd866e87f1) bump nix
* [`78d4f825`](https://github.com/cachix/devenv/commit/78d4f825f5362209ceefaa3d75979731ad01682b) python-poetry: debug LD_LIBRARY_PATH
* [`a70c6173`](https://github.com/cachix/devenv/commit/a70c6173038dc5c4c38434a50f7294398ca297f0) python: specify also DYLD_LIBRARY_PATH
* [`434e9155`](https://github.com/cachix/devenv/commit/434e9155ad63cab441a70778f3d39e4ef82926e2) Add languages.python.manylinux.enable, pass libraries to the interpreter.
* [`6c1194bb`](https://github.com/cachix/devenv/commit/6c1194bb0beff22f060fffa4f81a7a3b0afa64cb) if there's no cachix defined, ignore the error
* [`a4e43db1`](https://github.com/cachix/devenv/commit/a4e43db11670c9526f920f3e1f09653ffea7f500) bump nix
* [`58817926`](https://github.com/cachix/devenv/commit/588179263a34642dd1f58cd0370c03c02cc1fdb9) fix $ devenv shell ls -la
* [`5b6f6f23`](https://github.com/cachix/devenv/commit/5b6f6f2343b52efda09e5a53909b005c799cde3b) fix gc symlink
* [`506e189e`](https://github.com/cachix/devenv/commit/506e189e183bdd6f37517ee1ac0c415da7e787d5) allow passing through arguments from run_nix to run_command
* [`5ff197ac`](https://github.com/cachix/devenv/commit/5ff197ac57373a08ea93496dc52726fc81135e27) only log command errors when logging is enabled
* [`64f252fb`](https://github.com/cachix/devenv/commit/64f252fb8fe0feb73766bea56de680ac5098d4eb) disable stderr and logging for cachix evaluation
* [`369233d4`](https://github.com/cachix/devenv/commit/369233d471312597bc114214059944c828e0015b) add black pre-commit
* [`28fcf4a7`](https://github.com/cachix/devenv/commit/28fcf4a789612cff827bcbd0d0c1447f49a8b2ee) format python files using black
* [`5fa92100`](https://github.com/cachix/devenv/commit/5fa92100d075c04703adfa29adbad2083306272a) [FEAT] Conditionally link devenv profile
* [`a44199cd`](https://github.com/cachix/devenv/commit/a44199cd10d5eadbe31a71a13dc7d8d428010d87) containers: correctly pass no registry case
* [`123c00de`](https://github.com/cachix/devenv/commit/123c00dec045abdcc1e67a4243c832c1a4b8b872) devenv processes stop: print PID
* [`6408e959`](https://github.com/cachix/devenv/commit/6408e959b507d5f37e821a5b017fb0c15d9fafdb) normalize paths when root is /
* [`b25e8a00`](https://github.com/cachix/devenv/commit/b25e8a00d333ea5c4d03a3c1ff558d5791c49188) Recreate Python venv and run pip install less often
* [`fba13cfb`](https://github.com/cachix/devenv/commit/fba13cfbe53d10dc96879fbb327cc4be169d7ef3) Recreate Python venv and run pip install less often
* [`15d3a6fe`](https://github.com/cachix/devenv/commit/15d3a6fecf96fb2b32f5768fe49ad03b25d2dc30) container startup commands did not work due to quoting of args; we now also evaluate any shell variables in the startup command before executing it
* [`5af48b43`](https://github.com/cachix/devenv/commit/5af48b4369502ab9db6f871e86458e7cd0f1d7ad) examples/python-poetry: use python libraries instead of packages
* [`835ad1d0`](https://github.com/cachix/devenv/commit/835ad1d067145ea8e0b7b255e470f78cefb91cba) to allow 'devenv processes stop' to stop processes we need to exec the procfilescript
* [`eef3e486`](https://github.com/cachix/devenv/commit/eef3e4861a523a048ce743169a13dae056803b69) add a --keep-going flag and handle ctrl-C during test running more gracefully
* [`a6155c79`](https://github.com/cachix/devenv/commit/a6155c79ec24c748a3f250655802655b4d308178) until we get the env-venv nixpkgs stuff in a place we can use, we need to set LD_LIBRARY_PATH by hand
* [`8ca5e67e`](https://github.com/cachix/devenv/commit/8ca5e67ef256f1a7504a7f9278f34bce6f41b421) some packages are now unfree
* [`85acc1c8`](https://github.com/cachix/devenv/commit/85acc1c8767be7f6be3f73997f7a9242d110685e) some packages are now unfree
* [`90bb9f2f`](https://github.com/cachix/devenv/commit/90bb9f2f9eaf35d537cabbfa01e251593ff865b5) install rails via gem, add libyaml to make tests pass
* [`a0901d2e`](https://github.com/cachix/devenv/commit/a0901d2ea030502fd21bbecc34b6f5e2cd988414) add comment about env-venv
* [`1f05fd6a`](https://github.com/cachix/devenv/commit/1f05fd6af21ca420c592a5b70a675987a69828f8) comment
* [`9c24a04b`](https://github.com/cachix/devenv/commit/9c24a04bb85ea6c20a2255fc07954c1099816235) make python-native-libs test pass
* [`43443279`](https://github.com/cachix/devenv/commit/43443279950b9cf6e4098aa5b7257fde72efac23) put user-defined libs first on LD_LIBRARY_PATH
* [`7d14211b`](https://github.com/cachix/devenv/commit/7d14211bcd98a17ba2cab4a5400af297e5e9ddc2) add --exclude feature
* [`e7211866`](https://github.com/cachix/devenv/commit/e7211866357791f14d57e774584f5a8beee9ce1f) make tests pass
* [`c926f5a8`](https://github.com/cachix/devenv/commit/c926f5a829add6e2acffc139308297c7ad947462) try to make these tests pass but they do not
* [`62b52bc5`](https://github.com/cachix/devenv/commit/62b52bc5f8cb850d76020ace90417b6839ef4a72) make vault test pass in reality
* [`77185f33`](https://github.com/cachix/devenv/commit/77185f33687dd6b8e07d027973d4d02df965c69f) update poetry lock
* [`caf1a2ea`](https://github.com/cachix/devenv/commit/caf1a2ea564c31f2ee70bc67af56f77a2758848a) pre-commit run -a
* [`da4589b7`](https://github.com/cachix/devenv/commit/da4589b7b11962e71efb9e438d727cb63f81f744) mark phoenix as broken
* [`fb1c7e2d`](https://github.com/cachix/devenv/commit/fb1c7e2d9763cef3c6dc9c5fd869182e3489c065) print the command being run so we can run it by hand if it fails
* [`ac2e743b`](https://github.com/cachix/devenv/commit/ac2e743b492d0ad4fa11f6a0babd279d179fbf01)  allow builtins (like set and if) within container exec commands
* [`2fad7a80`](https://github.com/cachix/devenv/commit/2fad7a808da08737fdf66e705b7f065866624d62) Support allowBroken
* [`64f270df`](https://github.com/cachix/devenv/commit/64f270df002d6e78b7344fd544671a541e94600e) update nix to 2.21 (dev)
* [`748ff8b8`](https://github.com/cachix/devenv/commit/748ff8b895ce5cc6e537e6e15b7f124a7e1eb3d2) search: fix missing default
* [`9bd8d1a7`](https://github.com/cachix/devenv/commit/9bd8d1a7c78eb7cc158215f8cbe92437be5849f9) use self-hosted arm/linux
* [`3697204b`](https://github.com/cachix/devenv/commit/3697204b9d0188aa5063c95e9eb2d25b51b83208) fix cloudflare
* [`ff0400d5`](https://github.com/cachix/devenv/commit/ff0400d55d8141eb669aea380ca4c53624959d7a) bump nix
* [`f60f26e9`](https://github.com/cachix/devenv/commit/f60f26e9f57e6e84d402e4c6f3c01e8288566d33) .devenv.flake.nix -> .devenv/flake.nix
* [`461c9ef3`](https://github.com/cachix/devenv/commit/461c9ef3bbdf4bbb69898f6fe99047ecfea7b9a2) bump
* [`7de2eac3`](https://github.com/cachix/devenv/commit/7de2eac3728bf9ba8c02a57e4e060670d1805a99) bump
* [`05ec1516`](https://github.com/cachix/devenv/commit/05ec1516dbd356b97cfc2b02420fdfe49eb3b858) revert .devenv/flake.nix
* [`f7aa880d`](https://github.com/cachix/devenv/commit/f7aa880dad2c921d0609ac7a85345af026631030) unpin python 3.7 for cloudflare & fix build
* [`30c80455`](https://github.com/cachix/devenv/commit/30c804551307d8d94ba066cc115273b299d63c96) Rewrite CLI in Python
* [`f75c105b`](https://github.com/cachix/devenv/commit/f75c105b401be5c56065af8a325ba1f9917ccc8c) devenv inputs add <name> <url>
* [`be14084f`](https://github.com/cachix/devenv/commit/be14084f920afb7cdad78467a48b84516716d394) cli
* [`ced9ccff`](https://github.com/cachix/devenv/commit/ced9ccffe78eaebe2a3bca349f0d8fc40050db3c) Debug
* [`1f9f741e`](https://github.com/cachix/devenv/commit/1f9f741ea1f1631f387a878533927b2d58ba8983) Disable macos-latest for now
* [`226da372`](https://github.com/cachix/devenv/commit/226da3723741f62d1cbe8774bd71dfb69280532e) sync with upstream
* [`617acc62`](https://github.com/cachix/devenv/commit/617acc62260ddbd3f3ed84d3a808ff350f83f9d1) container devenv is now owned and procs started by a nonroot user
* [`0a2ddff2`](https://github.com/cachix/devenv/commit/0a2ddff2cbe462f7fca88e0c26e36e45ea862881) remove shadowed function
* [`94dc937f`](https://github.com/cachix/devenv/commit/94dc937ff398034aa7214f1997fe55d0fe4d15d7) format
* [`5ea46ef0`](https://github.com/cachix/devenv/commit/5ea46ef0f4508a5b22e45e08ff7024e8c1d89bf4) debug
* [`078554c4`](https://github.com/cachix/devenv/commit/078554c41c0f29c0475064e269c6e51dffbf05fe) fix ci?
* [`e0587373`](https://github.com/cachix/devenv/commit/e0587373db368899c018aea5c819f3941762728a) bump nix
* [`de506ee3`](https://github.com/cachix/devenv/commit/de506ee364da82244255120d3f8164ba60caa2d0) containers are only supported on linux
* [`46acff0a`](https://github.com/cachix/devenv/commit/46acff0a44db6a5627b01b7a3e457a838f4f5c57) don't rely on profiles on ci
* [`9b30c73f`](https://github.com/cachix/devenv/commit/9b30c73f5d4efbed55dfd024a696096e6370f52f) fix ci?
* [`baeadb30`](https://github.com/cachix/devenv/commit/baeadb3065f735bf8893dcd33a954ff0039817dc) Rewrite in Rust
* [`1f0bb149`](https://github.com/cachix/devenv/commit/1f0bb1490638c0d7c3b7bef2d6583cc712bd642f) fix ci
* [`7f39eef2`](https://github.com/cachix/devenv/commit/7f39eef26a6fc0b3ac6f2054345efe57fc5abe64) Introduce devenv-nixpkgs
* [`0565784c`](https://github.com/cachix/devenv/commit/0565784cef416a145e7c8312471f16c22acd2809) display process logs during testing
* [`bbbe0a33`](https://github.com/cachix/devenv/commit/bbbe0a333baa360bfddc0468d86a5993aa8a2b50) fix cli test
* [`02c48f66`](https://github.com/cachix/devenv/commit/02c48f660668be83bc3c0bac14692a2a5f4fc793) --cores defaults to 2, --max-jobs defaults to num_cpu/2
* [`6f91d5ad`](https://github.com/cachix/devenv/commit/6f91d5ada1b8c26953c9d25765d077a456788c26) fix dotenv test
* [`e91d7a4f`](https://github.com/cachix/devenv/commit/e91d7a4ff22a91f6e18000675ea1d11e9947e831) fix glibcLocales test on darwin
* [`d2f7f88c`](https://github.com/cachix/devenv/commit/d2f7f88c18c16e19f8c08f16cf4f800e2073cfa9) bump nix
* [`b9e31f31`](https://github.com/cachix/devenv/commit/b9e31f3132c54f55330f18bac50aee8da5476960) fix flakes eval
* [`2006015f`](https://github.com/cachix/devenv/commit/2006015f10e8443f4664ae810a2bfd3b81e0cb3d) skip tests for now
* [`051c6c49`](https://github.com/cachix/devenv/commit/051c6c49509f4f2f0350b12812d4e703b24cef86) fix direnv test
* [`688973c2`](https://github.com/cachix/devenv/commit/688973c234ad13ce48c2f9f1e740e312890016dc) fix example generation
* [`928228da`](https://github.com/cachix/devenv/commit/928228da39b3855d4a439624b33f566174a91bbd) ci: avoid building all over again
* [`2cd189bf`](https://github.com/cachix/devenv/commit/2cd189bf07cd625f0bc18920ffdc9453a3150710) remove dummy removal of tmpdir
* [`4c986e8e`](https://github.com/cachix/devenv/commit/4c986e8e3bd947f074ea9599157bca3e4a92ff93) docs: more devenv.yaml examples
* [`796c609c`](https://github.com/cachix/devenv/commit/796c609c10590e83a0d3eaa1640f71f8f1e9729b) examples/cockroachdb: supports only linux
* [`49a97ab9`](https://github.com/cachix/devenv/commit/49a97ab953da4101ae069fc9a6e2411a93686dc6) examples/python-venv: correctly use state dir
* [`2e043c03`](https://github.com/cachix/devenv/commit/2e043c03bd93d38b6e3e996617cf61380fb0f3b5) examples/simple-remote: use simple example as a base
* [`d8a8c122`](https://github.com/cachix/devenv/commit/d8a8c122679e98abc53d1c68f3344af5183cf24b) bump nix
* [`794116e3`](https://github.com/cachix/devenv/commit/794116e327e3dfe7e1edeaf6995e05c9babc8c26) fix flake/flake-parts templates
* [`dffe8c91`](https://github.com/cachix/devenv/commit/dffe8c917d7061ff8258371ab1d6ce5c63cf881c) fix github actions for tests
* [`3baecf32`](https://github.com/cachix/devenv/commit/3baecf32a721a8f9b509b3ca6465fbbf29ab05ef) try fix more examples
* [`fb7d9776`](https://github.com/cachix/devenv/commit/fb7d97762a7f09a7721ca11a37901ff88a62673b) examples: rubyonrails: use port 3000 instead of 5100
* [`055bc43d`](https://github.com/cachix/devenv/commit/055bc43d02e301fb8b10e41bb2e7711de859e862) examples: rubyonrails: force overwriting any files
* [`6ab8ee45`](https://github.com/cachix/devenv/commit/6ab8ee4545c8dc9bc48324c4724840f03344682e) postgres: support non-alphanumeric usernames
* [`74364ee1`](https://github.com/cachix/devenv/commit/74364ee1d08295a327a4aa3ad9082d00c0fbdb31) devenv: avoid rebuild when unrelated sources change
* [`c574ac17`](https://github.com/cachix/devenv/commit/c574ac17457e435b05275d63093c0cd6779c3813) fix a few more tests
* [`7ebf8ce4`](https://github.com/cachix/devenv/commit/7ebf8ce4229c32cc6a84a5a2c49b0ec1d5a38ad4) feat: add DEVENV_RUNTIME
* [`547d33a9`](https://github.com/cachix/devenv/commit/547d33a9b3308a38df2dd9eef165bf611d88e1e6) fix(postgres): don't crash with long working directory
* [`e1c2d72e`](https://github.com/cachix/devenv/commit/e1c2d72e62ad04ebdd7b675df5441274f3436d6c) doc: explain DEVENV_RUNTIME
* [`d9d8928b`](https://github.com/cachix/devenv/commit/d9d8928baa4a24077fd719286220d3b7c57e358a) more test fixes
* [`92fa4a70`](https://github.com/cachix/devenv/commit/92fa4a70d77d517c2127db260f854dee43debbb6) fix impure test
* [`1b788115`](https://github.com/cachix/devenv/commit/1b788115bc274ca943b79c317bfad02a25970202) make /tmp configurable
* [`cb94234d`](https://github.com/cachix/devenv/commit/cb94234d7188ac043828ac8a299f3c026588ac22) ruby: try with clean
* [`f0cfaf64`](https://github.com/cachix/devenv/commit/f0cfaf648175c7d1aa8308c7a5e806dbd5b0bdca) Remove permit-insecure test for now
* [`23404861`](https://github.com/cachix/devenv/commit/23404861b84299b2f532eb02e16d23b4bf5e74c3) disable standardml on aarch64
* [`9e459eb7`](https://github.com/cachix/devenv/commit/9e459eb788727da2e7c422ca4f242416d68536d4) add 1.0 blog post
* [`b5681ea9`](https://github.com/cachix/devenv/commit/b5681ea985f503ee352440dbd04af5b0b6af80b3) fix supported-languages example
* [`fe19d7f0`](https://github.com/cachix/devenv/commit/fe19d7f0ceab6b5d878745ae3e0521ace17ab20a) process-compose: set is_strict
* [`27f89238`](https://github.com/cachix/devenv/commit/27f89238a3c2a7cc716b0323f19686446df700c8) disable purescript on aarch64-linux
* [`cc76f0b8`](https://github.com/cachix/devenv/commit/cc76f0b89f240eb729741d8b3b03ee315e77b48d) always keep going
* [`2e9debcc`](https://github.com/cachix/devenv/commit/2e9debcceac77dbc50ca9c71433e1cf05e358732) docs: sync with pre-commit hooks
* [`a5bb0bda`](https://github.com/cachix/devenv/commit/a5bb0bda38e2be61223bf863127bf88703377a9e) docs: render strikethrough
* [`dea86890`](https://github.com/cachix/devenv/commit/dea8689069f25dc58b3f9de621609bfb6444b100) texlive: use str instead of string
* [`ccbd3062`](https://github.com/cachix/devenv/commit/ccbd3062eea01d580f6c90c1c8dbf4d771acac42) Make edit pass on 1.0 release post
* [`b80b1599`](https://github.com/cachix/devenv/commit/b80b15995046d97adda446da13e44bcfadcf1dc7) docs(phoenix): add example for elixir phoenix
* [`fef4366e`](https://github.com/cachix/devenv/commit/fef4366e50ffb477c198d28c3582e621f5bf95bc) Make more release-post tweaks
* [`68d3840c`](https://github.com/cachix/devenv/commit/68d3840c0dee9d4806fdaaf935eeb4dbf3c0b3fc) blog: edits
* [`ecaa6b2c`](https://github.com/cachix/devenv/commit/ecaa6b2c6f0fad4f2834595d8fa6d4ffe3d2f2b9) recommend experimental Nix installer
* [`24775a72`](https://github.com/cachix/devenv/commit/24775a72d2f1c188d43dd98617e514b311a17141) fix a bug in devenv init
* [`ba710af8`](https://github.com/cachix/devenv/commit/ba710af8d590902635d3909b1319559cb16457c9) docs(phoenix): remove interactive prompt from devenv shell init script
* [`08d8a345`](https://github.com/cachix/devenv/commit/08d8a3456e762f952e127ea3bd7cae1b7085d240) Make further tweaks to 1.0-release-post copy
* [`910e2b87`](https://github.com/cachix/devenv/commit/910e2b8778d65fc8729383151fcf1f655a66060c) DEVENV_RUNTIME: use XDG_RUNTIME_DIR or TMPDIR or /tmp
* [`d0c7023f`](https://github.com/cachix/devenv/commit/d0c7023f6b548f02f8b5c65fbf543ab643994c3b) fix [cachix/devenv⁠#694](https://togithub.com/cachix/devenv/issues/694)
* [`23e9cf0a`](https://github.com/cachix/devenv/commit/23e9cf0a9fc47469089c89a0553a6f3ef30f45f8) pre-commit: provide all packages that are used for the hooks
* [`129434ae`](https://github.com/cachix/devenv/commit/129434aeb89f918a1155df0ae22f3746b5fcfc60) blog clarify things
* [`3adfb7f8`](https://github.com/cachix/devenv/commit/3adfb7f8633e4d53b6e02c3f7c8fadd1625048b6) run flake tests
* [`f840b83c`](https://github.com/cachix/devenv/commit/f840b83c1cd865ae9bb868e4a77492c5465ce28c) integrate cachix
* [`883b0e48`](https://github.com/cachix/devenv/commit/883b0e4894541546b5d3988f79cb160e515de1ba) fix flake template
* [`c7f36c76`](https://github.com/cachix/devenv/commit/c7f36c76fc84ccd6807f60ee39996dbd50e0dcdf) don't fail on older devenv modules
* [`60cb6f70`](https://github.com/cachix/devenv/commit/60cb6f70fb782023b0ddecbd6946a707b809e74e) fix postgresql localhost healthcheck
* [`1bf66bfb`](https://github.com/cachix/devenv/commit/1bf66bfbad3f459a5fc626e66bfc50e36331fecd) garden
* [`3ccd354e`](https://github.com/cachix/devenv/commit/3ccd354eb75428b424c1333a25eb25ec208bd72b) fix tests
* [`b4be7681`](https://github.com/cachix/devenv/commit/b4be7681c9204cf4b0335e3458e56ebc4d8c1c2d) log to stderr
* [`2edb077b`](https://github.com/cachix/devenv/commit/2edb077b05483f2a9f6ce5c15bcdb81e455e7933) Fix flake-parts template
* [`b161b892`](https://github.com/cachix/devenv/commit/b161b892a9152c67349ca68911b6d1e93f91c417) Auto generate docs/reference/options.md
* [`91831ea4`](https://github.com/cachix/devenv/commit/91831ea42a079a8c0b5a32d6e0b7297ae151c75b) Touch up 1.0 release post
* [`56f4ea9d`](https://github.com/cachix/devenv/commit/56f4ea9d3f059be35e00b59030e9acad4e1f41a7) add redirects file
* [`60df0f37`](https://github.com/cachix/devenv/commit/60df0f37732b447e33d52eaa2b34fd681600c7f9) backward compatible devenv.tmpdir
* [`01faef8b`](https://github.com/cachix/devenv/commit/01faef8bbfe17e310139f29ca9db02d733344e9b) feat: Add fortran language support
* [`89fa20aa`](https://github.com/cachix/devenv/commit/89fa20aaf751e154f7a0c7fbcbd8491a13397778) fix [cachix/devenv⁠#1024](https://togithub.com/cachix/devenv/issues/1024)
* [`868cbd9a`](https://github.com/cachix/devenv/commit/868cbd9a0acb0c9e574cbe75fb83c58a71e1551a) support old Nix versions
* [`57e4a141`](https://github.com/cachix/devenv/commit/57e4a141480804674424c895d8c0dcd324750d2a) warn if Nix version is very old
* [`47363a71`](https://github.com/cachix/devenv/commit/47363a715ae95ad2118d642981604b9a3fa48428) processes: don't use state to track PID
* [`1268ba62`](https://github.com/cachix/devenv/commit/1268ba628c582ecfac53a16c191e9576c048db56) services/mysql: use empty config while mysql server bootstrapping, fixes [cachix/devenv⁠#1007](https://togithub.com/cachix/devenv/issues/1007)
* [`a7ba6766`](https://github.com/cachix/devenv/commit/a7ba6766c0cc351b8656c63560c6b19c3788455f) bump cargo
* [`b825433b`](https://github.com/cachix/devenv/commit/b825433bfb167dd1661beaf6de57a8c64f43f3bf) Add support for specifying Python root directory
* [`bed26522`](https://github.com/cachix/devenv/commit/bed26522794f32cb45ef99824ca3a09b81218e43) Add options for poetry install arguments
* [`ff40f021`](https://github.com/cachix/devenv/commit/ff40f0214551e3408d608f151a27310b4ddc5180) Refactoring of comments and option description
* [`99a2d15d`](https://github.com/cachix/devenv/commit/99a2d15d414307841a182cfe9d75d8ce67939b69) Remove trailing whitespace
* [`54425566`](https://github.com/cachix/devenv/commit/54425566cf077d7a7cc23ad8ae0057ffce44f34d) Add more options to poetry
* [`d2778e66`](https://github.com/cachix/devenv/commit/d2778e6608e2538118e3378aa4d67c7787fa93ae) Update python-poetry example
* [`d11cf576`](https://github.com/cachix/devenv/commit/d11cf576fa80d2644b165db62fd62dfb34da567f) Add example and tests for Python directory option
* [`2ff8144e`](https://github.com/cachix/devenv/commit/2ff8144eda7dee503abf1db9922d53d84f462535) Use `config.devenv.root` as default for Python project directory
* [`8c97d190`](https://github.com/cachix/devenv/commit/8c97d190eb80a5437c41b0ce748663d66db43574) Apply suggestions
* [`621af934`](https://github.com/cachix/devenv/commit/621af934963be5bdab230010435c058e6a06598c) Add integration with nixpkgs-terraform
* [`7eb5299e`](https://github.com/cachix/devenv/commit/7eb5299e29a9fbee18dbcb3832ac6d85c3863860) Edit unsupported error message
* [`7f321d10`](https://github.com/cachix/devenv/commit/7f321d1074eec09ae36387314357fd68eb0d1107) Add better error message
* [`f92fc5b8`](https://github.com/cachix/devenv/commit/f92fc5b8fda34d9b6e9d3fd871358c04bbe53fa4) Add tests for language.terraform
* [`e769623b`](https://github.com/cachix/devenv/commit/e769623b3e8f89fe6fdc8066bd97fc505a863855) Suggest updating the input in case of a missing version for languages.terraform.version
* [`cf065667`](https://github.com/cachix/devenv/commit/cf06566736d4ffdb69727901326d9835804a3477) Use getInput helper function for required inputs
* [`f89ff90c`](https://github.com/cachix/devenv/commit/f89ff90ca85bf86abe7eba3c89d5b8dbe7363eac) fix: .gitignore logic
* [`de536552`](https://github.com/cachix/devenv/commit/de536552f81404124e69020b44782fac222914a7) Remove nixpkgs input and use the default for examples/terraform
* [`467e9d96`](https://github.com/cachix/devenv/commit/467e9d96c4749c2200f695023101278314c47729) Auto generate docs/reference/options.md
* [`0f38dd9f`](https://github.com/cachix/devenv/commit/0f38dd9f487d54488b2010e0c039125ce3224099) Auto generate docs/reference/options.md
* [`5412a9e8`](https://github.com/cachix/devenv/commit/5412a9e89bf8df0eaad90cf18360b5f665f2ff19) Auto generate docs/reference/options.md
* [`06def05d`](https://github.com/cachix/devenv/commit/06def05d4f6a6a6cc874f2a78e1b3fdfdb017c8c) Auto generate examples/supported-languages/devenv.nix
* [`ff84855c`](https://github.com/cachix/devenv/commit/ff84855c686b3683aadd0935ef8c14755fe7b9fe) update roadmap
* [`5d547d4c`](https://github.com/cachix/devenv/commit/5d547d4cda9c72c2ba729dff7c38e31daa4fb5c0) instruct how to restart nix-daemon
* [`84ce563f`](https://github.com/cachix/devenv/commit/84ce563fcecbdee90b3c3550ab4f2fcd37b37def) mongodb example: don't start devenv manually
* [`4e446c65`](https://github.com/cachix/devenv/commit/4e446c65d2295d12d1503424aa352d28e7e32c7b) allow importing files from inputs
* [`37cb967b`](https://github.com/cachix/devenv/commit/37cb967bc4ad26a177ca3fc6552ecf70b9ed53d6) cleanup python directory
* [`1540fb33`](https://github.com/cachix/devenv/commit/1540fb33153fc1e9cb5c1d8fd75bf3770fd1e7ec) sigh
* [`43cbe4ce`](https://github.com/cachix/devenv/commit/43cbe4ced70004ab24b55732ee30c094de30b587) README: refresh
* [`59ccd569`](https://github.com/cachix/devenv/commit/59ccd56937eec5054ee92dc9e309af381639d4b7) typo
* [`e925dbe9`](https://github.com/cachix/devenv/commit/e925dbe97df726b44dd3dffa9e2a46473732981c) simple example: show enterTest
* [`113ee2a5`](https://github.com/cachix/devenv/commit/113ee2a5d706bcb744d34ccee362243a4fa32507) contributing: update
* [`93945f40`](https://github.com/cachix/devenv/commit/93945f4040fda832f6f55c4f197e5b069140de98) Auto generate docs/reference/options.md
* [`3d852ce6`](https://github.com/cachix/devenv/commit/3d852ce63fcbc9192f73a176a2cd189c5baeffad) Updated source_url in .envrc
* [`a55de912`](https://github.com/cachix/devenv/commit/a55de91224b13d490d10b7595a4b9911a0fe36f7) Minor typo/grammar fix
* [`fa136010`](https://github.com/cachix/devenv/commit/fa13601032e2bb4c2b6f647a8171239b870c250a) Enable nix language support
* [`325c7b1a`](https://github.com/cachix/devenv/commit/325c7b1aa07d4bcbb4aaae8e0cc0d40e18e48064) Fixed hash in .envrc
* [`1dd49eca`](https://github.com/cachix/devenv/commit/1dd49eca13bd8c0bec58e4dcc6aecbb19c998b81) Support dotenv comments
* [`226b720f`](https://github.com/cachix/devenv/commit/226b720f0f51789b9fd7d4711db7d79e0e402fc0) Update getting-started.md
* [`afa29528`](https://github.com/cachix/devenv/commit/afa29528a39f06545658593a5329ab6e79f13be3) now that devenv is in Nixpkgs, we simplify installation
* [`4cd98abe`](https://github.com/cachix/devenv/commit/4cd98abe9b509a1f69a7a5f78a831400a20d289f) typo
* [`f320890b`](https://github.com/cachix/devenv/commit/f320890b56839beecc303cb348f2158e2d1fe256) Update latest-version
* [`cd457e69`](https://github.com/cachix/devenv/commit/cd457e69241ea0374dd48f96c17addb976f7f5e6) Update mkdocs.yml
* [`a30343f3`](https://github.com/cachix/devenv/commit/a30343f36e7c097d9f78d3387753d06986fdaae3) Auto generate docs/reference/options.md
* [`e9c23b12`](https://github.com/cachix/devenv/commit/e9c23b1229598971a0a5612223079412dd04cfe6) Create $DEVENV_STATE when entering shell
* [`78213dba`](https://github.com/cachix/devenv/commit/78213dbaac468c715a021bbecc17ca30d4b39468) add tests for trusted store and debugging hook for when things go wrong
* [`a32447be`](https://github.com/cachix/devenv/commit/a32447bea188625abb2facfed2f5d513a20ac016) be explicit about containers not supported on macOS
* [`6e2c1ff3`](https://github.com/cachix/devenv/commit/6e2c1ff35009f72fb39a9477732abd635cca56d9) check for trusted user only if cachix is enabled
* [`06a7f0f1`](https://github.com/cachix/devenv/commit/06a7f0f1f7297aca56f6ac824f9e4df71dbb0814) container copy: fix 'Exec format error'
* [`47569d93`](https://github.com/cachix/devenv/commit/47569d938553debe95ddafc4633d6237b8c9b7a3) containers: try fixing skopeo command
* [`8e3fc16b`](https://github.com/cachix/devenv/commit/8e3fc16b5b29977839fe558c47ceaf453d37d47c) container: simplify docker-run
* [`9bd25295`](https://github.com/cachix/devenv/commit/9bd25295f4c2ff608b5bb0ad36684a2a0abc1b62) Fix weird errors on container run
* [`03aff16b`](https://github.com/cachix/devenv/commit/03aff16b304990c2fc542d640a0bbef619c18eb2) containers: default to local docker
* [`859585e9`](https://github.com/cachix/devenv/commit/859585e9105d0c413e1ed358a6bbdc6c1e7e4f64) Auto generate docs/reference/options.md
* [`103aa4cf`](https://github.com/cachix/devenv/commit/103aa4cf208eaeb4008a543b3740d2291ed1f9b9) devenv-run-tests: allow specifying input overrides
* [`ccda6a14`](https://github.com/cachix/devenv/commit/ccda6a147dc4c985d9996a6007bb9169b02b4549) Fix multiline shell example in docs
* [`9531e9a6`](https://github.com/cachix/devenv/commit/9531e9a65d6a709a8d443b29b9f97d4f6f6ed7bc) Fix typo in gc message
* [`1b37a0b4`](https://github.com/cachix/devenv/commit/1b37a0b4dd833863f31883d1311c90f27274e1bb) Fix [cachix/devenv⁠#1043](https://togithub.com/cachix/devenv/issues/1043)
* [`8aa42747`](https://github.com/cachix/devenv/commit/8aa4274786a7ca9492d306101d45d8e661352715) fix [cachix/devenv⁠#1051](https://togithub.com/cachix/devenv/issues/1051)
* [`72affdb7`](https://github.com/cachix/devenv/commit/72affdb7f6f16886d4fe471d2f6bbdae880d70d2) v1.0.2
* [`5d99d9fb`](https://github.com/cachix/devenv/commit/5d99d9fb18882d2b2ceeb09688c158e39b927394) Auto generate docs/reference/options.md
