### PR TITLE
niv home-manager: update 6665da45 -> 1c2c5e4c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6665da45dd03857a4ae600cf246435e6ae57407e",
-        "sha256": "13d51bqagwjmnddjc3lvqghclf9d224i77zcrmcip42kx9z2xxs4",
+        "rev": "1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb",
+        "sha256": "0sjnfw4ia5m0yvpr4y4d7frizvs6si3w2xy931z5xmxszy2rm4sq",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/6665da45dd03857a4ae600cf246435e6ae57407e.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@6665da45...1c2c5e4c](https://github.com/nix-community/home-manager/compare/6665da45dd03857a4ae600cf246435e6ae57407e...1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb)

* [`02246443`](https://github.com/nix-community/home-manager/commit/022464438a85450abb23d93b91aa82e0addd71fb) Translate using Weblate (Korean)
* [`3583fea7`](https://github.com/nix-community/home-manager/commit/3583fea7866834f70960a374cb0f4a6d1ffd0fc0) flake.lock: Update
* [`1c2acec9`](https://github.com/nix-community/home-manager/commit/1c2acec99933f9835cc7ad47e35303de92d923a4) xdg-portal: align with NixOS module
* [`19b87b9a`](https://github.com/nix-community/home-manager/commit/19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1) vdirsyncer: add urlCommand and userNameCommand options
* [`1c2c5e4c`](https://github.com/nix-community/home-manager/commit/1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb) home-manager: fix nix-build option `-q`
