### PR TITLE
niv nerd-icons.el: update 58db45e0 -> 8095215a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "58db45e003e3c6283db54ace23e3594677ffd050",
-        "sha256": "19krrwfgiv1sd5p9xcd6gpfxvbmcjwa8skbllclic7nz17rcwjb5",
+        "rev": "8095215a503d8048739de8b4ea4066598edb8cbb",
+        "sha256": "1zwhslj2r63dmwgbv031b63rhhghf2nv8wb9zx31rdqh96g53s28",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/58db45e003e3c6283db54ace23e3594677ffd050.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/8095215a503d8048739de8b4ea4066598edb8cbb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@58db45e0...8095215a](https://github.com/rainstormstudio/nerd-icons.el/compare/58db45e003e3c6283db54ace23e3594677ffd050...8095215a503d8048739de8b4ea4066598edb8cbb)

* [`8095215a`](https://github.com/rainstormstudio/nerd-icons.el/commit/8095215a503d8048739de8b4ea4066598edb8cbb) Fix nerd icons charset range ([rainstormstudio/nerd-icons.el⁠#75](https://togithub.com/rainstormstudio/nerd-icons.el/issues/75))
