### PR TITLE
niv devenv: update 5d99d9fb -> 93875897

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "5d99d9fb18882d2b2ceeb09688c158e39b927394",
-        "sha256": "1ip483ha9n8rwhs7dgn754q9v999xdhj1cq11qhx2cbc8r381ii8",
+        "rev": "93875897c86651f19b242ac8b71fbd977b877f6d",
+        "sha256": "0fdaqhxmpj3j6v4ibn0kn5rcnhr4hj0qn4a4w0daj8i73y7nds66",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/5d99d9fb18882d2b2ceeb09688c158e39b927394.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/93875897c86651f19b242ac8b71fbd977b877f6d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@5d99d9fb...93875897](https://github.com/cachix/devenv/compare/5d99d9fb18882d2b2ceeb09688c158e39b927394...93875897c86651f19b242ac8b71fbd977b877f6d)

* [`77123c3b`](https://github.com/cachix/devenv/commit/77123c3b69df87dbe98e3b74c5138ba578404039) package.nix: 1.0.2
* [`302bafac`](https://github.com/cachix/devenv/commit/302bafac875d8620c5b8063ceb6c116d8037208c) add release notes
* [`93875897`](https://github.com/cachix/devenv/commit/93875897c86651f19b242ac8b71fbd977b877f6d) bump nixpkgs rev for 1.0.2
